### PR TITLE
fix(orchestrator): LLM-generated in-voice spawn ack (supersedes #9885)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/progress-cadence.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/progress-cadence.test.ts
@@ -33,6 +33,7 @@
 import {
   _resetBuildVariantForTests,
   isLocalCodeExecutionAllowed,
+  ModelType,
 } from "@elizaos/core";
 import {
   afterEach,
@@ -175,6 +176,11 @@ async function buildHookedRuntime(
 
   const runtime = {
     agentId: "agent-0000-0000-0000-000000000000",
+    character: {
+      name: "TestBot",
+      bio: ["a concise, helpful test assistant"],
+      style: { chat: ["casual", "terse"] },
+    },
     logger,
     getSetting: () => undefined,
     getService: (type: string) => services.get(type) ?? null,
@@ -346,13 +352,26 @@ describe("emitProgress routing ladder + cadence", () => {
     const rt = await buildHookedRuntime([{ source: SOURCE, capabilities: [] }]);
     seedSession(rt, "s-ack", "ack-task");
 
+    // The spawn ack is the model's own one-line acknowledgement (in-voice,
+    // in-language) — not a hardcoded literal. The mocked model returns a fixed
+    // line; the posted ack is that line, sanitized.
+    rt.useModel.mockResolvedValueOnce("On it — starting now.");
+
     // First non-terminal event triggers the single spawn ACK (delayMs is forced
     // to 0 for ack mode, so it posts immediately).
     await fire(rt, "s-ack", "ready");
     expect(rt.sendMessageToTarget).toHaveBeenCalledTimes(1);
     expect(
       (rt.sendMessageToTarget.mock.calls[0][1] as { text: string }).text,
-    ).toBe("working on it now.");
+    ).toBe("On it — starting now.");
+    // The ack is generated with the small text model.
+    expect(rt.useModel).toHaveBeenCalledWith(
+      ModelType.TEXT_SMALL,
+      expect.objectContaining({
+        system: expect.stringContaining("TestBot"),
+        prompt: expect.any(String),
+      }),
+    );
 
     // Subsequent events (narration, tools) must NOT add more acks.
     await fire(rt, "s-ack", "message", { text: "still working" });
@@ -361,6 +380,55 @@ describe("emitProgress routing ladder + cadence", () => {
     });
     await vi.advanceTimersByTimeAsync(5_000);
     expect(rt.sendMessageToTarget).toHaveBeenCalledTimes(1);
+
+    await rt.dispose();
+  });
+
+  it("ack mode feeds the task text to the model so it can match the user's language", async () => {
+    process.env.ACPX_PROGRESS_MODE = "ack";
+    const rt = await buildHookedRuntime([{ source: SOURCE, capabilities: [] }]);
+    // initialTask carries the real user request — the language signal handed to
+    // the model (here: French). The model itself is mocked, but we assert the
+    // request reached it so the in-language behavior is wired.
+    rt.sessions.set("s-fr", {
+      status: "running",
+      metadata: {
+        source: SOURCE,
+        roomId: ROOM,
+        label: "build-site",
+        initialTask: "construis-moi un site vitrine en français",
+      },
+    });
+    rt.useModel.mockResolvedValueOnce("C'est parti.");
+
+    await fire(rt, "s-fr", "ready");
+    expect(rt.sendMessageToTarget).toHaveBeenCalledTimes(1);
+    expect(
+      (rt.sendMessageToTarget.mock.calls[0][1] as { text: string }).text,
+    ).toBe("C'est parti.");
+    const [, params] = rt.useModel.mock.calls[0] as [
+      unknown,
+      { prompt: string },
+    ];
+    expect(params.prompt).toContain(
+      "construis-moi un site vitrine en français",
+    );
+
+    await rt.dispose();
+  });
+
+  it("ack mode falls back to a short literal when the model call fails", async () => {
+    process.env.ACPX_PROGRESS_MODE = "ack";
+    const rt = await buildHookedRuntime([{ source: SOURCE, capabilities: [] }]);
+    seedSession(rt, "s-ack-fail", "ack-task");
+    rt.useModel.mockRejectedValueOnce(new Error("no model registered"));
+
+    await fire(rt, "s-ack-fail", "ready");
+    // Never silence: the ack still posts exactly once, using the fallback.
+    expect(rt.sendMessageToTarget).toHaveBeenCalledTimes(1);
+    expect(
+      (rt.sendMessageToTarget.mock.calls[0][1] as { text: string }).text,
+    ).toBe("On it.");
 
     await rt.dispose();
   });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/spawn-ack.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/spawn-ack.test.ts
@@ -1,0 +1,146 @@
+/**
+ * spawn-ack.test.ts
+ *
+ * Unit coverage for the pure pieces of the LLM-generated "ack"-mode spawn
+ * acknowledgement (plugins/plugin-agent-orchestrator/src/index.ts). The single
+ * `useModel` call that produces the line is impure and covered through the
+ * progress-hook harness (progress-cadence.test.ts); the prompt construction and
+ * output sanitization are pure and tested directly here.
+ *
+ * The whole point of this surface is that there is NO hardcoded ack phrase, no
+ * i18n table, and no scraped personality: the model writes the line in the
+ * character's voice and the user's language. These tests pin the two seams that
+ * make that safe — the prompt carries the character + task, and the model's
+ * output is reduced to one clean line (with a literal fallback only when the
+ * model produces nothing usable).
+ */
+
+import type { Character } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  buildSpawnAckSystemPrompt,
+  buildSpawnAckUserPrompt,
+  SPAWN_ACK_FALLBACK,
+  sanitizeSpawnAck,
+} from "../../src/index.js";
+
+describe("buildSpawnAckSystemPrompt", () => {
+  it("carries the character name, voice, and the one-line + same-language rules", () => {
+    const character: Character = {
+      name: "Milady",
+      bio: ["a terse, dry on-chain assistant"],
+      adjectives: ["dry", "precise"],
+      style: { chat: ["casual"], all: ["concise"] },
+    };
+    const prompt = buildSpawnAckSystemPrompt(character);
+    expect(prompt).toContain("You are Milady.");
+    expect(prompt).toContain("a terse, dry on-chain assistant");
+    // Voice traits are surfaced from the configured character, never hardcoded.
+    expect(prompt).toContain("dry");
+    expect(prompt).toContain("precise");
+    // Hard constraints that keep the output to one short in-language line.
+    expect(prompt.toLowerCase()).toContain("one");
+    expect(prompt.toLowerCase()).toContain("same language");
+    expect(prompt.toLowerCase()).toContain("no emoji");
+  });
+
+  it("degrades gracefully for an empty character (no name, no bio, no style)", () => {
+    const prompt = buildSpawnAckSystemPrompt({});
+    expect(prompt).toContain("You are the assistant.");
+    expect(prompt.toLowerCase()).toContain("same language");
+    // No dangling "Voice:" header when there are no traits to list.
+    expect(prompt).not.toContain("Voice:");
+  });
+
+  it("dedupes overlapping traits and bounds the voice descriptor list", () => {
+    const character: Character = {
+      name: "Bot",
+      adjectives: ["calm", "calm", "warm"],
+      style: { chat: ["warm", "friendly"], all: ["friendly"] },
+    };
+    const prompt = buildSpawnAckSystemPrompt(character);
+    // "warm"/"friendly" appear once each in the joined voice list despite the
+    // duplication across adjectives + style.chat + style.all.
+    const voiceLine = prompt.slice(prompt.indexOf("Voice:"));
+    expect(voiceLine.match(/warm/g)?.length).toBe(1);
+    expect(voiceLine.match(/friendly/g)?.length).toBe(1);
+  });
+});
+
+describe("buildSpawnAckUserPrompt", () => {
+  it("embeds the task verbatim as the language signal", () => {
+    const prompt = buildSpawnAckUserPrompt("déploie le site sur Cloudflare");
+    expect(prompt).toContain("déploie le site sur Cloudflare");
+    expect(prompt).toContain("acknowledgement");
+  });
+
+  it("supplies a neutral placeholder when the task is blank", () => {
+    const prompt = buildSpawnAckUserPrompt("   ");
+    expect(prompt).toContain("the task they just gave you");
+  });
+
+  it("clips an overlong task so the prompt stays bounded", () => {
+    const long = "x".repeat(1000);
+    const prompt = buildSpawnAckUserPrompt(long);
+    expect(prompt).toContain("…");
+    expect(prompt.length).toBeLessThan(500);
+  });
+});
+
+describe("sanitizeSpawnAck", () => {
+  it("returns a clean one-liner unchanged", () => {
+    expect(sanitizeSpawnAck("On it — starting now.")).toBe(
+      "On it — starting now.",
+    );
+  });
+
+  it("keeps only the first non-empty line", () => {
+    expect(sanitizeSpawnAck("\n\nOkay, getting into it.\nblah blah")).toBe(
+      "Okay, getting into it.",
+    );
+  });
+
+  it("strips a leading emoji and list/quote markers", () => {
+    expect(sanitizeSpawnAck("🚀 On it.")).toBe("On it.");
+    expect(sanitizeSpawnAck("- On it.")).toBe("On it.");
+    expect(sanitizeSpawnAck("> On it.")).toBe("On it.");
+  });
+
+  it("strips a single pair of surrounding quotes (straight, smart, backtick)", () => {
+    expect(sanitizeSpawnAck('"On it."')).toBe("On it.");
+    expect(sanitizeSpawnAck("'On it.'")).toBe("On it.");
+    expect(sanitizeSpawnAck("“On it.”")).toBe("On it.");
+    expect(sanitizeSpawnAck("`On it.`")).toBe("On it.");
+  });
+
+  it("collapses internal whitespace", () => {
+    expect(sanitizeSpawnAck("On    it    now.")).toBe("On it now.");
+  });
+
+  it("preserves non-English output untouched (no language assumptions)", () => {
+    expect(sanitizeSpawnAck("C'est parti, je m'y mets.")).toBe(
+      "C'est parti, je m'y mets.",
+    );
+    expect(sanitizeSpawnAck("了解、今すぐ取りかかります。")).toBe(
+      "了解、今すぐ取りかかります。",
+    );
+  });
+
+  it("clips an over-long line and marks the truncation", () => {
+    const out = sanitizeSpawnAck("word ".repeat(60));
+    expect(out.length).toBeLessThanOrEqual(120);
+    expect(out.endsWith("…")).toBe(true);
+  });
+
+  it("returns empty (caller falls back) for empty / whitespace-only input", () => {
+    expect(sanitizeSpawnAck("")).toBe("");
+    expect(sanitizeSpawnAck("   \n  ")).toBe("");
+  });
+});
+
+describe("SPAWN_ACK_FALLBACK", () => {
+  it("is a short, neutral, non-empty literal", () => {
+    expect(SPAWN_ACK_FALLBACK.trim().length).toBeGreaterThan(0);
+    expect(SPAWN_ACK_FALLBACK.length).toBeLessThanOrEqual(24);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/index.ts
+++ b/plugins/plugin-agent-orchestrator/src/index.ts
@@ -9,6 +9,7 @@
  */
 
 import type {
+  Character,
   IAgentRuntime,
   Memory,
   Plugin,
@@ -577,7 +578,7 @@ export function compactProgressText(text: string): string {
 /**
  * Decide whether the planner already acknowledged a spawn turn, so the
  * orchestrator's spawn ACK can be suppressed (avoiding two back-to-back acks:
- * planner "On it." + orchestrator "working on it now."). True iff the planner
+ * the planner's "On it." plus the orchestrator's own spawn ack). True iff the planner
  * sent a user-facing message to the room within the spawn turn — i.e. at/after
  * the session's createdAt minus a small lookback (REPLY and the TASKS spawn
  * action run in the same turn, in either order). A planner reply older than
@@ -607,6 +608,119 @@ export function sanitizePlannerText(text: string): string {
   return cleaned.length > 0
     ? `${cleaned} ${SELF_HEAL_REPLACEMENT}`
     : SELF_HEAL_REPLACEMENT;
+}
+
+// ── LLM-generated spawn acknowledgement ──────────────────────────────────────
+// In "ack" mode the orchestrator posts ONE short line when it kicks off a coding
+// sub-agent. A single hardcoded literal ("working on it now.") read identically
+// robotic on every spawn, was always English regardless of the user's language,
+// and never matched the agent's character voice. Instead, the small text model
+// writes the line: it speaks in the configured character's own voice (no
+// hardcoded personality, no scraping `style.chat`) and in the user's language
+// (no i18n table), and natural sampling removes the verbatim repeat. This is the
+// same approach the LLM progress heartbeat already uses to write its status line
+// in the narration's language. The pure helpers below build the prompts and
+// sanitize the output (unit-tested); the single `useModel` call in the progress
+// hook is the only impure part, and it falls back to SPAWN_ACK_FALLBACK so the
+// ack can never become silence.
+
+// Minimal degraded fallback, used ONLY when the model call fails or returns
+// nothing usable — never the primary path. Kept short and neutral on purpose.
+export const SPAWN_ACK_FALLBACK = "On it.";
+
+// Longest acknowledgement we keep. An ack is a one-liner; anything longer is the
+// model over-answering, so it gets clipped.
+const SPAWN_ACK_MAX_CHARS = 120;
+
+/**
+ * System prompt for spawn-ack generation. Carries the character's own voice —
+ * derived from the configured character, never hardcoded — plus the hard
+ * constraints that keep the output to a single short in-language line. Pure +
+ * deterministic so it is unit-tested directly.
+ */
+export function buildSpawnAckSystemPrompt(character: Character): string {
+  const name = (character.name ?? "").trim() || "the assistant";
+  const voiceParts: string[] = [];
+  const bio = (character.bio ?? []).map((b) => b.trim()).filter(Boolean);
+  if (bio.length > 0) voiceParts.push(bio.slice(0, 3).join(" "));
+  const traits = [
+    ...(character.adjectives ?? []),
+    ...(character.style?.chat ?? []),
+    ...(character.style?.all ?? []),
+  ]
+    .map((t) => t.trim())
+    .filter(Boolean);
+  if (traits.length > 0) {
+    voiceParts.push(`Voice: ${[...new Set(traits)].slice(0, 8).join(", ")}.`);
+  }
+  return [
+    `You are ${name}.`,
+    voiceParts.join(" ").trim(),
+    "You have just kicked off a background task the user asked for.",
+    "Reply with exactly ONE short, natural line, in your own voice, confirming you're on it.",
+    "Write it in the same language the user used.",
+    "No quotes, no emoji, no markdown, no preamble — just the line. Keep it under 12 words.",
+  ]
+    .filter((part) => part.length > 0)
+    .join(" ");
+}
+
+/**
+ * User-turn prompt for spawn-ack generation: the task being started. The task
+ * text doubles as the language signal — the model replies in whatever language
+ * it is written in (same mechanism as the heartbeat summarizer). Pure.
+ */
+export function buildSpawnAckUserPrompt(task: string): string {
+  const trimmed = task.trim();
+  const what = trimmed.length > 0 ? trimmed : "the task they just gave you";
+  const clipped = what.length > 400 ? `${what.slice(0, 397)}…` : what;
+  return `The task you're starting:\n${clipped}\n\nYour one-line acknowledgement:`;
+}
+
+/**
+ * Clean a model-produced ack into a single plain line: first non-empty line,
+ * surrounding quotes / emoji / list markers stripped, whitespace collapsed,
+ * length capped. Returns "" when nothing usable remains (the caller then falls
+ * back to SPAWN_ACK_FALLBACK). Pure + deterministic.
+ */
+export function sanitizeSpawnAck(raw: string): string {
+  if (!raw) return "";
+  const firstLine =
+    raw
+      .replace(/\r\n/g, "\n")
+      .split("\n")
+      .map((line) => line.trim())
+      .find((line) => line.length > 0) ?? "";
+  if (!firstLine) return "";
+  let cleaned = firstLine
+    .replace(PROGRESS_EMOJI_PREFIX_REGEX, "")
+    .replace(/^[>*\-•\s]+/, "")
+    .trim();
+  // Strip a single pair of surrounding quotes (straight, smart, or backtick).
+  const quotePairs: ReadonlyArray<readonly [string, string]> = [
+    ['"', '"'],
+    ["'", "'"],
+    ["“", "”"],
+    ["‘", "’"],
+    ["`", "`"],
+  ];
+  for (const [open, close] of quotePairs) {
+    if (
+      cleaned.length >= open.length + close.length &&
+      cleaned.startsWith(open) &&
+      cleaned.endsWith(close)
+    ) {
+      cleaned = cleaned
+        .slice(open.length, cleaned.length - close.length)
+        .trim();
+      break;
+    }
+  }
+  cleaned = cleaned.replace(/\s{2,}/g, " ").trim();
+  if (!cleaned) return "";
+  return cleaned.length > SPAWN_ACK_MAX_CHARS
+    ? `${cleaned.slice(0, SPAWN_ACK_MAX_CHARS - 1).trimEnd()}…`
+    : cleaned;
 }
 
 function stripToolTranscripts(raw: string): string {
@@ -828,8 +942,8 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
   // Last "ack"-mode spawn ACK time per ROOM (`${source}::${roomId}`). One user
   // turn frequently fans out into several sub-agent sessions — a re-spawn, or a
   // multi-file build that spawns more than once — and ackedSessions is per
-  // SESSION, so each would post its own "working on it now." (the duplicate-ack
-  // nubs saw). Suppressing a sibling session's ACK when the room already acked
+  // SESSION, so each would post its own spawn ack (the duplicate-ack nubs saw).
+  // Suppressing a sibling session's ACK when the room already acked
   // within this window collapses one turn to a single ACK; a genuinely new
   // request after the window still gets its own.
   const roomAckAt = new Map<string, number>();
@@ -1071,6 +1185,38 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
     lastHeartbeatSummary.delete(sessionId);
   };
 
+  // Generate the one-line "ack"-mode spawn acknowledgement via the small text
+  // model — in the character's own voice and the user's language (see
+  // buildSpawnAckSystemPrompt). The task text (the language signal) is read from
+  // the session's `initialTask` metadata, falling back to the label. Best-effort:
+  // any failure (no model registered, a throw, empty output) collapses to a short
+  // literal, so the ack is never silence and never blocks the spawn.
+  const generateSpawnAck = async (
+    sessionId: string,
+    label: string,
+  ): Promise<string> => {
+    try {
+      const session = await acp.getSession(sessionId).catch(() => null);
+      const meta = (session?.metadata ?? {}) as Record<string, unknown>;
+      const task =
+        typeof meta.initialTask === "string" && meta.initialTask.trim()
+          ? meta.initialTask
+          : label;
+      const raw = await runtime.useModel(ModelType.TEXT_SMALL, {
+        system: buildSpawnAckSystemPrompt(runtime.character),
+        prompt: buildSpawnAckUserPrompt(task),
+        maxTokens: 32,
+        temperature: 0.7,
+      });
+      return (
+        sanitizeSpawnAck(typeof raw === "string" ? raw : "") ||
+        SPAWN_ACK_FALLBACK
+      );
+    } catch {
+      return SPAWN_ACK_FALLBACK;
+    }
+  };
+
   // Generic capability probe — multi-integration aware. The orchestrator
   // routes UX through whichever surface the target connector supports,
   // falling back gracefully when a capability is missing (e.g. Twitter/X
@@ -1262,15 +1408,16 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
         await emitProgress(sessionId, target, rawText, sessionLabel);
         return;
       }
-      const initialText = state
+      // The "ack"-mode spawn line is generated by the model AFTER the
+      // synchronous claim below (so the claim stays atomic), so leave it empty
+      // here and fill it once this event has exclusively claimed the first post.
+      const isAckFirstPost = !state && progressPolicy.mode === "ack";
+      let initialText = state
         ? displayText
         : progressPolicy.mode === "threaded"
           ? `🚀 [${sessionLabel}] running`
           : progressPolicy.mode === "ack"
-            ? // "ack" mode posts ONE clean spawn ACK (never the raw sub-agent
-              // narration) and never edits it afterward — the completion
-              // synthesis is the separate final message. Plain text, no emoji.
-              "working on it now."
+            ? ""
             : displayText;
       // Claim the first post synchronously before the await. A second progress
       // event for the same session that arrives while this send is in flight
@@ -1281,9 +1428,9 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
         if (firstPostInFlight.has(sessionId)) return;
         // ack mode posts exactly one ACK per ROOM per window — a sibling
         // sub-agent session spawned by the SAME user turn must not post a second
-        // "working on it now.". Checked synchronously before the claim/await so
-        // a concurrent sibling bails here. (Per-session suppression below still
-        // guards the heartbeat / narration re-entry for this one session.)
+        // ack. Checked synchronously before the claim/await so a concurrent
+        // sibling bails here. (Per-session suppression below still guards the
+        // heartbeat / narration re-entry for this one session.)
         if (progressPolicy.mode === "ack") {
           const roomAckKey = `${target.source}::${target.roomId}`;
           const now = Date.now();
@@ -1314,6 +1461,14 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
             if (oldest !== undefined) ackedSessions.delete(oldest);
           }
         }
+      }
+      // "ack" mode posts ONE clean spawn ACK (never the raw sub-agent narration)
+      // and never edits it afterward — the completion synthesis is the separate
+      // final message. The line is the model's own in-voice, in-language
+      // acknowledgement. Generated here, AFTER the claim above, so the dedup
+      // stays synchronous and the model latency sits outside the claim window.
+      if (isAckFirstPost) {
+        initialText = await generateSpawnAck(sessionId, sessionLabel);
       }
       const sent = await runtime.sendMessageToTarget(
         target,
@@ -1579,8 +1734,8 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
         // same user request, spawned under a fresh sessionId minutes later. The
         // per-session ackedSessions/firstPostInFlight guards never see it, and the
         // per-room ack dedup window (60s) has long expired — so without this gate
-        // each retry posts another "working on it now." (the triple-ack users
-        // reported). The original user-requested session has no
+        // each retry posts another spawn ack (the triple-ack users reported).
+        // The original user-requested session has no
         // buildVerifyRetryCount, so it still acks exactly once.
         const isVerifyRetrySpawn =
           typeof meta.buildVerifyRetryCount === "number" &&
@@ -1597,8 +1752,8 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
         ) {
           // Dedupe against the planner's own acknowledgment. The planner often
           // replies "On it." in the same turn it spawns the task; posting a
-          // second orchestrator ACK ("working on it now.") right after is the
-          // back-to-back double-ack users complained about. If a user-facing
+          // second orchestrator ACK right after is the back-to-back double-ack
+          // users complained about. If a user-facing
           // (non-internal) message hit this room within the spawn turn — i.e.
           // at/after createdAt minus a small lookback — the planner already
           // acked: claim the marker (so trailing events + heartbeat stay


### PR DESCRIPTION
Supersedes #9885 (the spawn-ack half). Different approach, same goal: kill the robotic spawn ack — but without hardcoding phrasing, an i18n table, or any personality logic.

## Problem

In `ack` progress mode the orchestrator posts ONE short line when it kicks off a coding sub-agent. On `develop` that line is a single hardcoded literal — `"working on it now."`:

- identical on every spawn (reads robotic),
- always English regardless of the user's language,
- never in the agent's character voice.

#9885 replaces the literal with a rotated pool of ~6 neutral English phrases + per-room anti-repeat. That fixes the verbatim repeat, but the phrasing is still hardcoded, still English-only (localizing needs an i18n table), and still deliberately voice-neutral. It also has to carry rotation bookkeeping (`buildAckPhrases` / `pickNextAck` / `lastAckByRoom`).

## Fix — let the agent write the line

Ask the model. This is exactly what the orchestrator's existing LLM progress **heartbeat** already does — it writes its status line in the narration's language. The spawn ack was the one remaining hardcoded English literal on that surface.

`generateSpawnAck` calls `useModel(TEXT_SMALL, …)` with:
- a **system** prompt carrying the character's own voice — derived from the *configured* `character` (name + bio + adjectives + style), never hardcoded. (#9885 correctly avoided scraping `character.style.chat` because it once surfaced a literal `"casual"` as an ack; handing the character to the model instead of string-scraping it is the clean way to get voice.)
- a **user** prompt carrying the task text, which doubles as the **language signal** — the model replies in whatever language the request was written in.

Natural sampling gives the variation that #9885's rotation logic had to engineer by hand, so the anti-repeat bookkeeping is gone.

### What this removes vs #9885
- ❌ hardcoded ack phrases → ✅ model writes them, in voice
- ❌ English-only / would need i18n → ✅ in the user's language for free
- ❌ rotation + per-room last-phrase tracking → ✅ natural sampling

### Safety / behavior preserved
- **Never silence, never blocks the spawn.** Any failure (no model registered, a throw, empty/garbage output) collapses to a short literal fallback (`SPAWN_ACK_FALLBACK = "On it."`).
- **Concurrency-safe.** The model call happens *after* the synchronous first-post claim, so the per-session (`ackedSessions` / `firstPostInFlight`) and per-room (`roomAckAt`) dedup stay atomic — a concurrent sibling still bails before any `await` — and the model latency sits outside the claim window.
- **All existing ack guards unchanged:** per-session, per-room 60s window, verify-retry suppression, and planner-already-acked dedup.
- Pure seams (`buildSpawnAckSystemPrompt`, `buildSpawnAckUserPrompt`, `sanitizeSpawnAck`) are unit-tested; the single `useModel` call is the only impure part.

## Tests

**916 orchestrator unit tests green** (`bun run --cwd plugins/plugin-agent-orchestrator vitest run __tests__/unit/`).

- New `spawn-ack.test.ts` (pure helpers): prompt construction carries character + task + the one-line/same-language rules; sanitization handles first-line-only, emoji/list/quote stripping, whitespace collapse, length clip, **non-English passthrough** (French + Japanese), and empty→fallback.
- Updated `progress-cadence.test.ts` ack-mode cases: the posted ack is the model's own line (called with `ModelType.TEXT_SMALL` + a system mentioning the character); the **task text reaches the model** so the in-language behavior is wired (French `initialTask` asserted in the prompt); and a model failure **falls back to a literal** while still posting exactly one ack.
- Typecheck clean; Biome clean.

## Note on #9885 Part B

#9885 also adds an honest **sub-agent failure relay** (`subAgentFailureResponseEvaluator`) for terminal failures that previously landed as silence. That's an orthogonal, good fix and is intentionally **not** included here so this PR stays focused on the ack. It can land separately — and, by the same principle as this PR, its user-facing line should ideally be voiced by the agent rather than a hardcoded English template.