### PR TITLE
fix(local-inference): ship route subpath export

### DIFF
--- a/plugins/plugin-local-inference/build.ts
+++ b/plugins/plugin-local-inference/build.ts
@@ -47,6 +47,7 @@ const result = await Bun.build({
 	// (oven-sh/bun#12734).
 	entrypoints: [
 		"./src/index.ts",
+		"./src/local-inference-routes.ts",
 		"./src/runtime/index.ts",
 		"./src/routes/index.ts",
 		"./src/services/index.ts",
@@ -72,6 +73,7 @@ console.log("📝 Generating TypeScript declarations...");
 // Override rootDir to src so declarations land directly in dist/ rather than nested under the monorepo rootDir
 await $`tsc --emitDeclarationOnly --declaration --declarationDir dist --rootDir src --noCheck --skipLibCheck -p tsconfig.json`.quiet();
 
+await import(new URL("./dist/local-inference-routes.js", import.meta.url).href);
 await import(new URL("./dist/voice-workbench.js", import.meta.url).href);
 
 console.log(

--- a/plugins/plugin-local-inference/package.json
+++ b/plugins/plugin-local-inference/package.json
@@ -46,6 +46,16 @@
 			"import": "./dist/routes/index.js",
 			"default": "./dist/routes/index.js"
 		},
+		"./local-inference-routes": {
+			"types": "./src/local-inference-routes.ts",
+			"eliza-source": {
+				"types": "./src/local-inference-routes.ts",
+				"import": "./src/local-inference-routes.ts",
+				"default": "./src/local-inference-routes.ts"
+			},
+			"import": "./dist/local-inference-routes.js",
+			"default": "./dist/local-inference-routes.js"
+		},
 		"./services": {
 			"types": "./src/services/index.ts",
 			"eliza-source": {


### PR DESCRIPTION
## Summary
- add `src/local-inference-routes.ts` as a Bun build entrypoint so `dist/local-inference-routes.js` is emitted
- add an explicit `./local-inference-routes` package export matching the agent runtime import
- add a build-time import guard so this missing exported JS file fails during plugin build instead of in provisioned cloud agent containers

## Why
A live provisioned cloud agent (`316438e9`) was failing API startup with:

```
Cannot find module '/app/packages/agent/node_modules/@elizaos/plugin-local-inference/dist/local-inference-routes.js'
```

The container had `ELIZA_CLOUD_PROVISIONED=1`, an Eliza Cloud API key, and cloud model pins present, but the package only shipped `dist/local-inference-routes.d.ts`; the JS file was missing. The agent imports `@elizaos/plugin-local-inference/local-inference-routes` from `packages/agent/src/api/server.ts` and `health-routes.ts`, so the package needs to emit that runtime subpath.

## Verification
- `bun run --cwd plugins/plugin-local-inference build`
- `node -e "import('@elizaos/plugin-local-inference/local-inference-routes').then(m=>console.log(Object.keys(m).filter(k=>k.includes('LocalInference')).sort().join('\\n')))"`
- `bun run --cwd plugins/plugin-local-inference test src/local-inference-routes.test.ts`
- `bun run --cwd plugins/plugin-local-inference typecheck`

Related: #9887
