### PR TITLE
ci(agent-image): rebuild on local-inference changes

### DIFF
--- a/.github/workflows/build-agent-image.yml
+++ b/.github/workflows/build-agent-image.yml
@@ -15,6 +15,7 @@ on:
       - "packages/app-core/deploy/Dockerfile.ci"
       - "plugins/plugin-sql/**"
       - "plugins/plugin-elizacloud/**"
+      - "plugins/plugin-local-inference/**"
       - "packages/agent/**"
       - "packages/server/**"
       - "packages/core/**"


### PR DESCRIPTION
## Summary
- include plugins/plugin-local-inference/** in the Build Agent Image push path filter
- keeps future local-inference runtime/export fixes from missing the cloud-agent image publisher

## Why
The agent image workflow already builds @elizaos/plugin-local-inference, but its path filter did not include that plugin. PR #9888 changed the plugin and had to be manually dispatched to publish ghcr.io/elizaos/eliza:develop.

## Verification
- git diff --check
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/build-agent-image.yml'); puts 'yaml ok'"