### PR TITLE
fix(local-inference): hotfix stable agent image route export

### DIFF
--- a/.github/workflows/build-agent-image.yml
+++ b/.github/workflows/build-agent-image.yml
@@ -15,6 +15,7 @@ on:
       - "packages/app-core/deploy/Dockerfile.ci"
       - "plugins/plugin-sql/**"
       - "plugins/plugin-elizacloud/**"
+      - "plugins/plugin-local-inference/**"
       - "packages/agent/**"
       - "packages/server/**"
       - "packages/core/**"

--- a/plugins/plugin-local-inference/build.ts
+++ b/plugins/plugin-local-inference/build.ts
@@ -30,6 +30,7 @@ const result = await Bun.build({
 	// (oven-sh/bun#12734).
 	entrypoints: [
 		"./src/index.ts",
+		"./src/local-inference-routes.ts",
 		"./src/runtime/index.ts",
 		"./src/routes/index.ts",
 		"./src/services/index.ts",
@@ -55,6 +56,7 @@ console.log("📝 Generating TypeScript declarations...");
 // Override rootDir to src so declarations land directly in dist/ rather than nested under the monorepo rootDir
 await $`tsc --emitDeclarationOnly --declaration --declarationDir dist --rootDir src --noCheck --skipLibCheck -p tsconfig.json`.quiet();
 
+await import(new URL("./dist/local-inference-routes.js", import.meta.url).href);
 await import(new URL("./dist/voice-workbench.js", import.meta.url).href);
 
 console.log(

--- a/plugins/plugin-local-inference/package.json
+++ b/plugins/plugin-local-inference/package.json
@@ -46,6 +46,16 @@
 			"import": "./dist/routes/index.js",
 			"default": "./dist/routes/index.js"
 		},
+		"./local-inference-routes": {
+			"types": "./src/local-inference-routes.ts",
+			"eliza-source": {
+				"types": "./src/local-inference-routes.ts",
+				"import": "./src/local-inference-routes.ts",
+				"default": "./src/local-inference-routes.ts"
+			},
+			"import": "./dist/local-inference-routes.js",
+			"default": "./dist/local-inference-routes.js"
+		},
 		"./services": {
 			"types": "./src/services/index.ts",
 			"eliza-source": {


### PR DESCRIPTION
## Summary
- cherry-pick #9888 onto `main` so the stable cloud-agent image ships `@elizaos/plugin-local-inference/local-inference-routes`
- cherry-pick #9889 onto `main` so future local-inference changes trigger `Build Agent Image`

## Why
Production managed-agent defaults resolve to `ghcr.io/elizaos/eliza:stable` unless ops overrides `ELIZA_AGENT_IMAGE` / `CONTAINERS_DEFAULT_IMAGE`. The runtime fix is already merged to `develop`, but production stable needs the same minimal fix on `main` to rebuild/publish the `:stable` image.

## Validation
- `git diff --check origin/main..HEAD`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/build-agent-image.yml'); puts 'yaml ok'"`
- `bun run --cwd plugins/plugin-local-inference build`
- `bun run --cwd plugins/plugin-local-inference test src/local-inference-routes.test.ts`
- `bun run --cwd plugins/plugin-local-inference typecheck`
- `bun -e "import('@elizaos/plugin-local-inference/local-inference-routes').then(m=>console.log(Object.keys(m).filter(k=>k.includes('LocalInference')).sort().join('\\n')))"`

Note: the equivalent Node import on current `main` hits an existing `@elizaos/registry` export issue (`./first-party/curated-app-definitions.json`) outside this hotfix path; Bun import and plugin build/tests/typecheck pass.
