### PR TITLE
fix(cloud): write managed runtime routing config

### DIFF
--- a/packages/cloud-shared/src/lib/services/__tests__/docker-sandbox-headscale-route.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/docker-sandbox-headscale-route.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { resolveElizaCloudTopology } from "@elizaos/shared";
 import {
+  buildManagedElizaRuntimeConfig,
   DockerSandboxProvider,
   headscaleVpnEnabled,
   requiresHeadscaleRoute,
@@ -155,6 +157,36 @@ describe("resolveDockerSandboxImage", () => {
     expect(resolveDockerSandboxImage(undefined, "ghcr.io/elizaos/eliza:stable")).toBe(
       "ghcr.io/elizaos/eliza:stable",
     );
+  });
+});
+
+describe("buildManagedElizaRuntimeConfig", () => {
+  test("writes canonical cloud runtime + inference routing for managed containers", () => {
+    const config = buildManagedElizaRuntimeConfig({
+      ELIZAOS_CLOUD_API_KEY: "agent-api-key",
+      ELIZAOS_CLOUD_BASE_URL: "https://api.elizacloud.ai/api/v1",
+      ELIZAOS_CLOUD_SMALL_MODEL: "gpt-oss-120b",
+      ELIZAOS_CLOUD_LARGE_MODEL: "zai-glm-4.7",
+      ELIZA_CLOUD_AGENT_ID: "cloud-agent-1",
+    });
+
+    const topology = resolveElizaCloudTopology(config);
+
+    expect(config).toMatchObject({
+      deploymentTarget: { runtime: "cloud", provider: "elizacloud" },
+      linkedAccounts: {
+        elizacloud: { status: "linked", source: "api-key" },
+      },
+      cloud: {
+        enabled: true,
+        apiKey: "agent-api-key",
+        baseUrl: "https://api.elizacloud.ai/api/v1",
+        agentId: "cloud-agent-1",
+      },
+    });
+    expect(topology.runtime).toBe("cloud");
+    expect(topology.services.inference).toBe(true);
+    expect(topology.shouldLoadPlugin).toBe(true);
   });
 });
 

--- a/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
@@ -8,6 +8,7 @@
  * Reference: eliza-cloud/backend/services/container-orchestrator.ts
  */
 
+import { buildDefaultElizaCloudServiceRouting } from "@elizaos/shared";
 import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
 import { dockerNodesRepository } from "../../db/repositories/docker-nodes";
 import type { DockerNode } from "../../db/schemas/docker-nodes";
@@ -130,6 +131,48 @@ export function resolveDockerSandboxImage(
   operatorOverride = DOCKER_IMAGE_OVERRIDE,
 ): string {
   return dockerImage || operatorOverride || "ghcr.io/elizaos/eliza:latest";
+}
+
+export function buildManagedElizaRuntimeConfig(
+  allEnv: Record<string, string | undefined>,
+): Record<string, unknown> {
+  const apiKey = allEnv.ELIZAOS_CLOUD_API_KEY || "";
+  const agentId = allEnv.ELIZA_CLOUD_AGENT_ID || allEnv.WAIFU_ELIZA_CLOUD_AGENT_ID;
+
+  return {
+    logging: { level: "info" },
+    deploymentTarget: { runtime: "cloud", provider: "elizacloud" },
+    ...(apiKey
+      ? {
+          linkedAccounts: {
+            elizacloud: {
+              status: "linked",
+              source: "api-key",
+            },
+          },
+        }
+      : {}),
+    serviceRouting: buildDefaultElizaCloudServiceRouting({
+      includeInference: true,
+      nanoModel: allEnv.ELIZAOS_CLOUD_NANO_MODEL,
+      smallModel: allEnv.ELIZAOS_CLOUD_SMALL_MODEL,
+      mediumModel: allEnv.ELIZAOS_CLOUD_MEDIUM_MODEL,
+      largeModel: allEnv.ELIZAOS_CLOUD_LARGE_MODEL,
+      megaModel: allEnv.ELIZAOS_CLOUD_MEGA_MODEL,
+      responseHandlerModel: allEnv.ELIZAOS_CLOUD_RESPONSE_HANDLER_MODEL,
+      shouldRespondModel: allEnv.ELIZAOS_CLOUD_SHOULD_RESPOND_MODEL,
+      actionPlannerModel: allEnv.ELIZAOS_CLOUD_ACTION_PLANNER_MODEL,
+      plannerModel: allEnv.ELIZAOS_CLOUD_PLANNER_MODEL,
+      responseModel: allEnv.ELIZAOS_CLOUD_RESPONSE_MODEL,
+      mediaDescriptionModel: allEnv.ELIZAOS_CLOUD_MEDIA_DESCRIPTION_MODEL,
+    }),
+    cloud: {
+      enabled: Boolean(apiKey),
+      apiKey,
+      baseUrl: allEnv.ELIZAOS_CLOUD_BASE_URL || "",
+      ...(agentId ? { agentId } : {}),
+    },
+  };
 }
 
 function trimTrailingSlash(value: string): string {
@@ -1278,14 +1321,7 @@ export class DockerSandboxProvider implements SandboxProvider {
               "https://api-staging.elizacloud.ai/api/v1 for staging, https://api.elizacloud.ai/api/v1 for prod).",
           );
         }
-        const elizaConfig = JSON.stringify({
-          logging: { level: "info" },
-          cloud: {
-            enabled: Boolean(allEnv.ELIZAOS_CLOUD_API_KEY),
-            apiKey: allEnv.ELIZAOS_CLOUD_API_KEY || "",
-            baseUrl: allEnv.ELIZAOS_CLOUD_BASE_URL,
-          },
-        });
+        const elizaConfig = JSON.stringify(buildManagedElizaRuntimeConfig(allEnv));
         // Base64-encode the JSON before passing it through the shell so an
         // apiKey/baseUrl containing single quotes can't break out of the
         // outer sh -c quoting or inject commands on the remote host.


### PR DESCRIPTION
## Summary

- write canonical `deploymentTarget` and `serviceRouting` into managed Docker agents' `/root/.eliza/eliza.json`
- keep the existing cloud credential/base URL payload, including agent id
- add a regression test that resolves the generated config through `resolveElizaCloudTopology()` and asserts `runtime=cloud` plus `services.inference=true`

## Why

The live cloud agent investigation showed managed containers had cloud env (`ELIZA_CLOUD_PROVISIONED=1`, `ELIZAOS_CLOUD_ENABLED=true`, API key/model env), but the runtime topology log could still say `inference=false, runtime=local`. The Docker provider only persisted the legacy `cloud` block into `eliza.json`; topology is decided by canonical first-run config (`deploymentTarget` + `serviceRouting`).

This makes newly provisioned managed agents explicit cloud runtimes with cloud-proxy inference routing, matching the env and avoiding local-inference fallback ambiguity.

## Validation

- `bunx @biomejs/biome check packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts packages/cloud-shared/src/lib/services/__tests__/docker-sandbox-headscale-route.test.ts`
- `bun run --cwd packages/cloud-shared typecheck`
- `bun test packages/cloud-shared/src/lib/services/__tests__/docker-sandbox-headscale-route.test.ts -t buildManagedElizaRuntimeConfig` printed the new test as passing, then the existing provider test module kept the Bun process open; stopped after capturing the pass output.

## Follow-up

After merge/deploy, provision a fresh cloud agent and confirm startup logs show `Cloud config: inference=true, runtime=cloud` and chat no longer falls back to `local_inference`.
