### PR TITLE
fix(cloud): hotfix managed runtime routing import

### DIFF
--- a/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
@@ -8,7 +8,7 @@
  * Reference: eliza-cloud/backend/services/container-orchestrator.ts
  */
 
-import { buildDefaultElizaCloudServiceRouting } from "@elizaos/shared";
+import { buildDefaultElizaCloudServiceRouting } from "@elizaos/shared/contracts/service-routing";
 import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
 import { dockerNodesRepository } from "../../db/repositories/docker-nodes";
 import type { DockerNode } from "../../db/schemas/docker-nodes";


### PR DESCRIPTION
## Summary

- fix the managed runtime config hotfix import path for CI
- import `buildDefaultElizaCloudServiceRouting` from its concrete shared contracts subpath instead of the root `@elizaos/shared` barrel

## Why

#9892 merged the managed cloud runtime config fix, but `Cloud Tests / lint-and-types` failed because CI resolves `@elizaos/shared` through the built root `dist/index.d.ts`, which does not expose `buildDefaultElizaCloudServiceRouting`. The symbol is exported by `@elizaos/shared/contracts/service-routing`, so this keeps the runtime fix and makes cloud typecheck resolve the API correctly.

## Validation

- `git diff --check`
- `bunx @biomejs/biome check packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts`
- `bun run --cwd packages/cloud-shared typecheck`
- `bun run --cwd packages/cloud-api typecheck`
- `bun run verify:cloud` advanced past the prior `cloud-shared`/`cloud-api` failure and then failed locally in `cloud-frontend` due missing frontend deps in this checkout (`react-router-dom`, `lucide-react`, etc.), unrelated to this import.
