### PR TITLE
fix(cloud): fix managed runtime routing import

### DIFF
--- a/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
@@ -8,7 +8,7 @@
  * Reference: eliza-cloud/backend/services/container-orchestrator.ts
  */
 
-import { buildDefaultElizaCloudServiceRouting } from "@elizaos/shared";
+import { buildDefaultElizaCloudServiceRouting } from "@elizaos/shared/contracts/service-routing";
 import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
 import { dockerNodesRepository } from "../../db/repositories/docker-nodes";
 import type { DockerNode } from "../../db/schemas/docker-nodes";


### PR DESCRIPTION
## Summary

- apply the #9893 import-path fix to `develop`
- import `buildDefaultElizaCloudServiceRouting` from `@elizaos/shared/contracts/service-routing` instead of the root `@elizaos/shared` barrel

## Why

#9891 has the same import path issue that CI caught on #9892: the built root shared d.ts does not expose `buildDefaultElizaCloudServiceRouting`, while the contracts subpath does.

## Validation

- `git diff --check origin/develop..HEAD`
- `bunx @biomejs/biome check packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts`
- `bun run --cwd packages/cloud-shared typecheck`
- `bun run --cwd packages/cloud-api typecheck`
