### PR TITLE
feat(handoff): make the seamless shared→dedicated handoff the default (flip preferSharedCloudTier on; keep the flag as a kill-switch)

### DIFF
--- a/packages/shared/src/config/boot-config-store.ts
+++ b/packages/shared/src/config/boot-config-store.ts
@@ -70,6 +70,10 @@ export interface AppBootConfig {
 export const DEFAULT_BOOT_CONFIG: AppBootConfig = {
   branding: {},
   cloudApiBase: "https://elizacloud.ai",
+  // Seamless shared→dedicated handoff is the default create path. Kept as a
+  // kill-switch: a deployment can set this false to fall back to the
+  // dedicated-direct create (no handoff). Mirrors the ui-package store.
+  preferSharedCloudTier: true,
 };
 
 const BOOT_CONFIG_STORE_KEY = Symbol.for("elizaos.app.boot-config");

--- a/packages/ui/src/config/boot-config-store.test.ts
+++ b/packages/ui/src/config/boot-config-store.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_BOOT_CONFIG } from "./boot-config-store";
+
+describe("DEFAULT_BOOT_CONFIG", () => {
+  // The seamless shared→dedicated handoff is the default create path: a fresh
+  // first-run gets the instant shared bridge plus a background dedicated agent
+  // it silently re-points to. Flipping this default ON is what makes the handoff
+  // the normal "create an agent" behavior.
+  it("defaults preferSharedCloudTier ON so the handoff is the default create path", () => {
+    expect(DEFAULT_BOOT_CONFIG.preferSharedCloudTier).toBe(true);
+  });
+
+  // Kill-switch: the flag is still a real, overridable field. A deployment can
+  // set it false to fall back to the dedicated-direct create with no handoff,
+  // so the OFF branch must stay reachable.
+  it("keeps preferSharedCloudTier overridable as a kill-switch", () => {
+    const killSwitched = {
+      ...DEFAULT_BOOT_CONFIG,
+      preferSharedCloudTier: false,
+    };
+    expect(killSwitched.preferSharedCloudTier).toBe(false);
+  });
+});

--- a/packages/ui/src/config/boot-config-store.ts
+++ b/packages/ui/src/config/boot-config-store.ts
@@ -298,13 +298,16 @@ export interface AppBootConfig {
     naturalLanguage?: boolean;
   };
   /**
-   * Phase-0 cloud tier flip (MVP). When true, the first-run cloud-create path
-   * requests a SHARED (container-free, in-Worker) agent so the user chats
-   * instantly with no provisioning wait, instead of the default DEDICATED
-   * always-on container. Off by default: the seamless shared→dedicated handoff
-   * is not built yet, so making everyone shared would strand them there — this
-   * flag is for the instant-shared demo only. When false the create request is
-   * byte-identical to the dedicated path (sends `alwaysOn: true`).
+   * Seamless shared→dedicated handoff — the default create path. When true (the
+   * default), first-run cloud-create requests a SHARED (container-free, in-Worker)
+   * agent so the user chats instantly with no provisioning wait, then provisions a
+   * DEDICATED always-on container in the background and silently re-points to it
+   * once it's running. This is the normal "create an agent" behavior under the
+   * locked model: every agent is dedicated, the shared runtime is just the invisible
+   * instant bridge. Kept as a kill-switch — a deployment can set this `false` to fall
+   * back to the byte-identical dedicated-direct create (sends `alwaysOn: true`, no
+   * handoff). Only a freshly-created shared base arms the handoff, so picked/existing
+   * agents are unaffected either way.
    */
   preferSharedCloudTier?: boolean;
   /** Character catalog data — replaces cross-package import of catalog.json. */
@@ -325,6 +328,10 @@ export interface AppBootConfig {
 export const DEFAULT_BOOT_CONFIG: AppBootConfig = {
   branding: {},
   cloudApiBase: "https://elizacloud.ai",
+  // Seamless shared→dedicated handoff is the default create path. Kept as a
+  // kill-switch: a deployment can set this false to fall back to the
+  // dedicated-direct create (no handoff).
+  preferSharedCloudTier: true,
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Make the seamless shared→dedicated handoff the **DEFAULT** agent-creation behavior — flip `preferSharedCloudTier` on in `DEFAULT_BOOT_CONFIG`.

## Why
The full handoff is merged (create → instant shared bridge → invisible swap → dedicated → delete shared). Per the model (every agent is dedicated; the shared runtime is an invisible instant bridge), this IS the intended normal behavior. The flag was the incremental-rollout scaffold; now the feature is complete, so it becomes the default.

## What
- `preferSharedCloudTier: true` in `DEFAULT_BOOT_CONFIG` (both the `ui` store and the `shared` store — they share the same `Symbol.for("elizaos.app.boot-config")` global slot, so both are flipped for consistency).
- **The flag stays as a one-line kill-switch** — a deployment can set it `false` to fully revert to the dedicated-direct create. The OFF branch + its test are untouched. (Full flag removal = a follow-up after live soak.)

## Safety
- The handoff gate is unchanged (`preferSharedCloudTier && selectedAgent.created && isDirectCloudSharedAgentBase`), so picked/existing agents are unaffected — only a **freshly-created shared base** arms the handoff.
- Kill-switch still tested (the flag-OFF path remains covered).
- **35/35 tests** (2 new boot-config + 33 existing first-run/chat-send).

## ⚠️ Gates before this is launch-safe (operational, NOT code — see `.claude/plans/handoff-make-default.md`)
1. **Verify the full swap LIVE** — one `create-both → dedicated running → import → switch → delete` cycle watched in `eliza-cloud-api-prod` logs. **Never done yet.**
2. **Warm pool ON** (`WARM_POOL_ENABLED=true` + sizing) — else every signup = a cold ~90s–11min dedicated provision. UX is fine (the user's on the instant shared bridge meanwhile), but it's a fleet/launch-spike concern.
3. **Orphan-shared reaper cron** — a timed-out/failed handoff currently leaks a shared `agent_sandboxes` + `shared_runtime_history` row.

Merging this flips behavior for **all** users (one dedicated Hetzner container per signup). Recommend merging **after (1)**, or keeping it demo-build-only until then. The kill-switch makes it instantly reversible either way.
