### PR TITLE
fix(orchestrator): monetized app builds register + start from the edad template

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/app-deploy-guidance.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/app-deploy-guidance.test.ts
@@ -3,6 +3,7 @@ import {
   augmentTaskWithDeployGuidance,
   buildAppDeployGuidance,
   isAppBuildTask,
+  isMonetizedAppTask,
 } from "../../src/services/app-deploy-guidance.js";
 
 describe("app-deploy-guidance", () => {
@@ -24,6 +25,45 @@ describe("app-deploy-guidance", () => {
       expect(isAppBuildTask("")).toBe(false);
       expect(isAppBuildTask(undefined)).toBe(false);
       expect(isAppBuildTask(null)).toBe(false);
+    });
+  });
+
+  describe("isMonetizedAppTask", () => {
+    it("matches money-earning app builds", () => {
+      expect(isMonetizedAppTask("build a monetized web app")).toBe(true);
+      expect(
+        isMonetizedAppTask("an app that charges $2 per use with a markup"),
+      ).toBe(true);
+      expect(isMonetizedAppTask("a paid app with premium tiers")).toBe(true);
+    });
+    it("does NOT match a plain static/fun app", () => {
+      expect(isMonetizedAppTask("build me a magic 8-ball web app")).toBe(false);
+      expect(isMonetizedAppTask("a quick countdown timer page")).toBe(false);
+      expect(isMonetizedAppTask("")).toBe(false);
+    });
+  });
+
+  describe("agent-home monetized vs static", () => {
+    const cfg = {
+      target: "agent-home" as const,
+      agentHomeAppsDir: "/data/apps",
+      agentHomeBaseUrl: "https://example.test",
+    };
+    it("a MONETIZED agent-home app registers with Cloud + starts from the edad template (no 'no Cloud')", () => {
+      const out = augmentTaskWithDeployGuidance(
+        "build a monetized web app that charges $3 per use",
+        cfg,
+      );
+      expect(out).toContain("App Deployment (agent-home)");
+      expect(out).toContain("register it with Eliza Cloud");
+      expect(out).toContain("packages/examples/cloud/edad");
+      expect(out).toContain("cloud.json");
+      expect(out).not.toContain("Do NOT use Eliza Cloud for this one");
+    });
+    it("a NON-monetized agent-home app stays static-only (keeps 'no Cloud')", () => {
+      const out = augmentTaskWithDeployGuidance("build a magic 8-ball app", cfg);
+      expect(out).toContain("Do NOT use Eliza Cloud for this one");
+      expect(out).not.toContain("register it with Eliza Cloud");
     });
   });
 
@@ -70,6 +110,25 @@ describe("app-deploy-guidance", () => {
   });
 
   describe("buildAppDeployGuidance", () => {
+    it("a MONETIZED Eliza-Cloud build starts from the edad template (no from-scratch)", () => {
+      const out = buildAppDeployGuidance(
+        { target: "eliza-cloud" },
+        "build a monetized app that charges $2 per use",
+      );
+      expect(out).toContain("packages/examples/cloud/edad");
+      expect(out).toContain("START FROM THE TEMPLATE");
+      // forwards to the org-balance endpoint, not the stranded per-app pool
+      expect(out).toContain("/api/v1/messages");
+      expect(out).not.toContain("/api/v1/apps/<appId>/chat");
+    });
+    it("a NON-monetized build keeps the generic Cloud contract (no edad)", () => {
+      const out = buildAppDeployGuidance(
+        { target: "eliza-cloud" },
+        "build a website about cats",
+      );
+      expect(out).toContain("App Deployment (Eliza Cloud)");
+      expect(out).not.toContain("packages/examples/cloud/edad");
+    });
     it("defaults to Eliza Cloud for an unspecified/empty config", () => {
       expect(buildAppDeployGuidance({ target: "eliza-cloud" })).toContain(
         "Eliza Cloud",

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -2470,6 +2470,11 @@ export function shouldForwardEnv(key: string): boolean {
     FORWARDED_SYSTEM_ENV.has(key.toUpperCase()) ||
     key.startsWith("ACPX_AUTH_") ||
     key.startsWith("ELIZA_") ||
+    // The live Cloud creds use the ELIZAOS_ prefix (ELIZAOS_CLOUD_API_KEY /
+    // ELIZAOS_CLOUD_URL), which the broad ELIZA_ rule above does NOT match. A
+    // spawned monetized-app build needs them to register the app (POST
+    // /api/v1/apps) without hunting the filesystem for the key.
+    key.startsWith("ELIZAOS_CLOUD") ||
     // Parent-context bridge session id (ELIZA_HOOK_PORT already passes via the
     // ELIZA_ prefix). Without this the loopback /api/coding-agents/<id>/* bridge
     // is unreachable from an ACP-spawned sub-agent.

--- a/plugins/plugin-agent-orchestrator/src/services/app-deploy-guidance.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/app-deploy-guidance.ts
@@ -36,6 +36,26 @@ export function isAppBuildTask(taskText: string | undefined | null): boolean {
 }
 
 /**
+ * Whether an app build is MONETIZED — it earns via per-call markup, so it needs
+ * Eliza Cloud OAuth + billing (an `appId`) regardless of where the static files
+ * are hosted. This is a general rule: a monetized app ALWAYS registers with
+ * Cloud. Used so a non-Cloud static host (agent-home) does not tell the
+ * sub-agent "don't use Eliza Cloud" for a monetized app — which contradicts the
+ * `build-monetized-app` skill and leaves the app unregistered (no sign-in).
+ */
+const MONETIZED_APP_RE =
+  /\b(?:moneti[sz]e[ds]?|monetization|markup|per[-\s]?(?:use|call|request|chat)\s+(?:billing|pricing|charge)|paid\s+(?:app|tiers?|version|plan|feature)|paywall|earn(?:s|ing|ings)?|pay[-\s]?to|subscription|premium\s+tiers?|charges?\s+\$?\d|x402)\b/i;
+
+export function isMonetizedAppTask(
+  taskText: string | undefined | null,
+): boolean {
+  if (typeof taskText !== "string" || taskText.trim().length === 0) {
+    return false;
+  }
+  return MONETIZED_APP_RE.test(taskText);
+}
+
+/**
  * Whether a task builds an elizaOS VIEW or PLUGIN. These get view-specific
  * cloud/local sandbox guidance (#8918) rather than the generic hosted-app
  * deploy contract.
@@ -85,24 +105,38 @@ export function resolveAppDeployConfig(): AppDeployConfig {
   return { target: "eliza-cloud" };
 }
 
-function elizaCloudGuidance(): string {
-  return [
-    "--- App Deployment (Eliza Cloud) ---",
-    "This task builds an app/site, so it must end up actually HOSTED with a verified live URL — not just local files.",
-    "- Build a real, working app and load it to confirm it works before reporting done.",
-    "- Host it on Eliza Cloud: use `@elizaos/cloud-sdk` when available, register the app to get an `appId`, and deploy via the Cloud container/app flow.",
-    "- For auth, use Eliza Cloud OAuth via a same-origin proxy to `/api/v1/apps/<appId>/chat` with the user's bearer token (add `X-Affiliate-Code` when monetizing). Use Cloud DB / hosted APIs for persistence.",
-    "- Do NOT hardcode owner API keys in frontend code, use mock replies, or hand-roll legacy `/messages` routes. Follow the `build-monetized-app` skill for the canonical registration + deploy + domain flow.",
+function elizaCloudGuidance(task?: string): string {
+  const lines = ["--- App Deployment (Eliza Cloud) ---"];
+  if (isMonetizedAppTask(task)) {
+    lines.push(
+      "START FROM THE TEMPLATE — do NOT build the Cloud SDK / registration / OAuth-proxy / Dockerfile from scratch. A complete, working, already-deployed monetized chat app is in THIS checkout at `packages/examples/cloud/edad`. Copy it as your starting point: `cp -r packages/examples/cloud/edad <your-app-dir>`, then ADAPT only the app-specific bits.",
+      "- CHANGE only: `public/index.html` (the SYSTEM_PROMPT constant, the MODEL constant, the <title>/brand/meta text, the input placeholder, the TOKEN_KEY/STATE_KEY localStorage prefixes), the art in `public/` (SVGs, favicon, og-image), and the markup % you set at registration.",
+      "- KEEP byte-for-byte: `server.ts`, `db.ts`, the Dockerfile, and the OAuth + same-origin proxy + `/health` plumbing — that IS the canonical correct monetized wiring (it forwards to `/api/v1/messages` with `x-app-id` + `x-affiliate-code`, the org-balance billing path).",
+      "- Register the app via `POST /api/v1/apps` (monetization enabled + an inference markup) to get the `appId` — use the owner's `ELIZAOS_CLOUD_API_KEY` from the env. Deploy per `packages/examples/cloud/edad/README.md` (it uses `POST /api/v1/containers`, the ungated path — do NOT use the gated `/apps/<id>/deploy`).",
+    );
+  } else {
+    lines.push(
+      "This task builds an app/site, so it must end up actually HOSTED with a verified live URL — not just local files.",
+      "- Build a real, working app and load it to confirm it works before reporting done.",
+      "- Host it on Eliza Cloud: use `@elizaos/cloud-sdk` when available, register the app to get an `appId`, and deploy via the Cloud container flow.",
+      "- For auth, use Eliza Cloud OAuth via a same-origin proxy that forwards to `/api/v1/messages` with the user's bearer token + `x-app-id` (add `x-affiliate-code` when monetizing). Use Cloud DB / hosted APIs for persistence.",
+      "- Do NOT hardcode owner API keys in frontend code, use mock replies, or hand-roll legacy `/messages` routes. Follow the `build-monetized-app` skill for the canonical registration + deploy + domain flow.",
+    );
+  }
+  lines.push(
     "- Report ONLY the verified live Cloud URL. If you could not deploy or verify it, say that plainly — never report an unverified or guessed URL.",
-  ].join("\n");
+  );
+  return lines.join("\n");
 }
 
-function agentHomeGuidance(config: AppDeployConfig): string {
+function agentHomeGuidance(config: AppDeployConfig, task?: string): string {
   const dir = config.agentHomeAppsDir ?? "";
   const base = config.agentHomeBaseUrl ?? "";
   return [
     "--- App Deployment (agent-home) ---",
-    "This is a quick static/fun app for the operator's personal agent-home host. Do NOT use Eliza Cloud for this one.",
+    isMonetizedAppTask(task)
+      ? "Host the app's static files on the operator's agent-home host, but this is a MONETIZED app, so you MUST also register it with Eliza Cloud. START FROM THE TEMPLATE — do NOT re-derive the sign-in/proxy/registration flow from scratch: the working pattern is in this checkout at `packages/examples/cloud/edad`. Use `packages/examples/cloud/edad/public/index.html` as your frontend skeleton (it has the Cloud OAuth sign-in + chat-forwarding pattern) — adapt the SYSTEM_PROMPT/MODEL/brand/placeholder, and point its API calls at THIS host's same-origin proxy (`GET api/config/`, `POST api/chat/`). Register the app via `POST /api/v1/apps` (monetization enabled + a markup) using the owner's `ELIZAOS_CLOUD_API_KEY`, and write the returned appId into `cloud.json` next to index.html so sign-in + per-call billing work. Do NOT skip or defer registration, and do NOT tell the operator that steps remain."
+      : "This is a quick static/fun app for the operator's personal agent-home host. Do NOT use Eliza Cloud for this one.",
     "- Pick a fresh, short kebab-case `<slug>` from the request.",
     `- Write the app's static files (index.html + css/js — there is NO per-app build step) into \`${dir}/<slug>/\`.`,
     `- It is then served immediately at \`${base}/apps/<slug>/\` — load that URL to confirm it works, then report it as the live link.`,
@@ -126,11 +160,14 @@ export function viewPluginGuidance(
 }
 
 /** Build the deploy-guidance block for the configured target. */
-export function buildAppDeployGuidance(config?: AppDeployConfig): string {
+export function buildAppDeployGuidance(
+  config?: AppDeployConfig,
+  task?: string,
+): string {
   const resolved = config ?? resolveAppDeployConfig();
   return resolved.target === "agent-home"
-    ? agentHomeGuidance(resolved)
-    : elizaCloudGuidance();
+    ? agentHomeGuidance(resolved, task)
+    : elizaCloudGuidance(task);
 }
 
 function isCloudDeployTarget(config: AppDeployConfig): boolean {
@@ -174,5 +211,5 @@ export function augmentTaskWithDeployGuidance(
   if (!isAppBuildTask(task)) {
     return task;
   }
-  return `${task.trimEnd()}\n\n${buildAppDeployGuidance(config)}`;
+  return `${task.trimEnd()}\n\n${buildAppDeployGuidance(config, task)}`;
 }


### PR DESCRIPTION
## Problem

Building a **monetized** app (an app that takes a per-call markup) through a spawned coding sub-agent was unreliable and slow for every Eliza Cloud user:

1. **Unregistered apps.** A monetized app must register with Eliza Cloud (`POST /api/v1/apps`) to get an `appId` for OAuth sign-in + per-call billing. The agent-home (non-Cloud static host) guidance said *"Do NOT use Eliza Cloud for this one"* unconditionally — which contradicted the `build-monetized-app` skill and shipped apps that had no `appId`, so users couldn't sign in.
2. **From-scratch re-derivation.** The sub-agent rebuilt the whole Cloud SDK / registration / OAuth-proxy / Dockerfile from zero because no concrete template was named — the complete, working, in-repo example at `packages/examples/cloud/edad` was only referenced as an external GitHub link. (Observed live: a monetized build spawned 3 nested research sub-agents and took ~10 min vs ~3 for a plain static app.)
3. **Wrong billing endpoint.** The auth-proxy guidance named `/api/v1/apps/<appId>/chat` (the stranded per-app-credit pool) instead of `/api/v1/messages` with `x-app-id` (the org-balance path that `edad` actually uses).

## Fix (in the spawn-injected deploy contract — the one chokepoint that survives the terse spawn task)

- Add `isMonetizedAppTask()` and branch **both** guidance paths on it: a monetized app **always** registers with Cloud, regardless of where the static files are hosted.
- For monetized builds, lead with the concrete in-repo template: *copy `packages/examples/cloud/edad`, adapt only `public/index.html` (system prompt, model, brand) + the art, keep `server.ts`/proxy/Dockerfile as-is.* No more from-scratch re-derivation.
- Correct the endpoint to `/api/v1/messages` + `x-app-id` (org-balance billing), matching `edad`.
- Forward `ELIZAOS_CLOUD_*` creds to the sub-agent — `shouldForwardEnv` only matched the `ELIZA_` prefix, so the live `ELIZAOS_CLOUD_API_KEY` never reached the build agent, forcing a filesystem hunt for the key.

## Tests

916 orchestrator unit tests pass (new coverage: `isMonetizedAppTask`, the monetized vs non-monetized Cloud + agent-home guidance branches, the edad-template pointer, and the endpoint correction). Validated live on a self-hosted bot: monetized builds now register (real `appId`), complete, and serve sign-in-ready apps.
