### PR TITLE
fix(cloud): port #9882 app-auth/authorize StewardProvider fix to main (prod sign-in crash)

### DIFF
--- a/packages/ui/src/cloud/public-pages/pages/app-auth/app-authorize-page.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/app-auth/app-authorize-page.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// --- collaborator doubles ---
+
+// The real StewardAuthProvider lazy-loads the heavy `@stwd/*` runtime and reads
+// router/location context. Stub it with a marker wrapper so we can assert the
+// authorize content is mounted INSIDE it (the #9881 fix: useAuth() needs the
+// Steward provider as an ancestor on this public route).
+vi.mock("../../../shell/StewardProvider", () => ({
+  StewardAuthProvider: ({ children }: { children: ReactNode }) => (
+    <div data-testid="steward-auth-provider">{children}</div>
+  ),
+}));
+
+vi.mock("../../../../cloud-ui/components/auth/authorize-content", () => ({
+  AuthorizeContent: () => <div data-testid="authorize-content" />,
+}));
+
+vi.mock("../../../shell/CloudI18nProvider", () => ({
+  useCloudT: () => (_key: string, opts?: { defaultValue?: string }) =>
+    opts?.defaultValue ?? _key,
+}));
+
+vi.mock("../../lib/use-page-title", () => ({ usePageTitle: () => {} }));
+
+import AppAuthAuthorizePage from "./app-authorize-page";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("AppAuthAuthorizePage", () => {
+  it("mounts AuthorizeContent inside StewardAuthProvider so useAuth() resolves on the public route (#9881)", () => {
+    render(<AppAuthAuthorizePage />);
+
+    const provider = screen.getByTestId("steward-auth-provider");
+    const content = screen.getByTestId("authorize-content");
+    expect(provider).toBeTruthy();
+    expect(content).toBeTruthy();
+    // The provider must be an ancestor of the authorize content, otherwise
+    // `useAuth()` throws "must be used within a <StewardProvider>".
+    expect(provider.contains(content)).toBe(true);
+  });
+});

--- a/packages/ui/src/cloud/public-pages/pages/app-auth/app-authorize-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/app-auth/app-authorize-page.tsx
@@ -2,11 +2,21 @@
  * Third-party app OAuth-authorize page (public). Reuses the cloud-ui
  * `AuthorizeContent` component (the shared authorize UI). Ported from
  * `@elizaos/cloud-frontend/src/pages/app-auth/authorize/page.tsx`.
+ *
+ * `AuthorizeContent` calls `useAuth()` / renders `<StewardLogin>` from
+ * `@stwd/react`, both of which require an ancestor Steward `<StewardProvider>`.
+ * As a `public: true` route this page renders WITHOUT the per-route Steward
+ * wrapper (see `CloudRouteElement`), so it must mount the shell's
+ * `StewardAuthProvider` itself — otherwise `useAuth()` throws "must be used
+ * within a <StewardProvider>" and all monetized-app sign-in is blocked (#9881).
+ * `StewardAuthProvider` already lists `/app-auth` in its runtime route patterns,
+ * so it mounts the Steward runtime even for an unauthenticated visitor.
  */
 
 import { Suspense } from "react";
 import { AuthorizeContent } from "../../../../cloud-ui/components/auth/authorize-content";
 import { useCloudT } from "../../../shell/CloudI18nProvider";
+import { StewardAuthProvider } from "../../../shell/StewardProvider";
 import { usePageTitle } from "../../lib/use-page-title";
 
 export default function AppAuthAuthorizePage() {
@@ -17,8 +27,10 @@ export default function AppAuthAuthorizePage() {
     }),
   );
   return (
-    <Suspense fallback={null}>
-      <AuthorizeContent />
-    </Suspense>
+    <StewardAuthProvider>
+      <Suspense fallback={null}>
+        <AuthorizeContent />
+      </Suspense>
+    </StewardAuthProvider>
   );
 }


### PR DESCRIPTION
## Why
`elizacloud.ai/app-auth/authorize` (third-party monetized-app sign-in, e.g. `nubilio.org/apps/*`) crashes in **production** with:
```
Error: useAuth must be used within a <StewardProvider> with an `auth` prop.
  at AuthorizeContent (authorize-content…js)
```
This is #9881. The fix (#9882) wraps `<AuthorizeContent>` in `<StewardAuthProvider>` (which whitelists `/app-auth` in its runtime route patterns so `useAuth()` resolves). **#9882 merged to `develop` only — it was never ported to `main`.** Prod (`elizacloud.ai` console = `packages/app`) deploys from `main`, so live users still hit the crash (prod build `623f7290`, 2026-06-27, predates the fix).

## What
Clean cherry-pick of #9882 (`d771e1c9c0`) onto `main`. Verified main already exports `StewardAuthProvider` and lists `/^\/app-auth(?:\/|$)/` in `STEWARD_RUNTIME_ROUTE_PATTERNS`, so this is a 2-line wrap + the existing unit test. No divergence, no behavior change beyond mounting the provider.

## Verification
- Identical to the develop commit that passed Cloud Tests.
- Unit test `app-authorize-page.test.tsx` asserts the authorize UI renders without the `useAuth` throw.
- After merge → push-to-main deploys the `eliza-cloud` Pages project → prod `/app-auth/authorize` resolves.

Refs #9881, #9882. Tracking #8434.