### PR TITLE
perf(cloud-api): instrument chat-completions pre-forward TTFT (#9899)

### DIFF
--- a/packages/cloud-api/v1/chat/completions/route.ts
+++ b/packages/cloud-api/v1/chat/completions/route.ts
@@ -740,6 +740,12 @@ export async function handleChatCompletionsPOST(
   try {
     // 1. Authenticate
     const { user, apiKey } = await requireAuthOrApiKeyWithOrg(req);
+    // Pre-forward latency instrumentation (#9899): measured TTFT through this
+    // route is ~6.5s while cerebras-direct is ~0.24s — 100% of the overhead is
+    // pre-forward work, not the model. These marks split it (auth vs the
+    // rate-limit/app/catalog/moderation reads vs the reserve write) so the next
+    // fix targets the real cross-region-Railway hotspot instead of guessing.
+    const tAuth = Date.now();
 
     // 1b. Per-org tier rate limit
     if (user.organization_id && !options.skipOrgRateLimit) {
@@ -896,6 +902,7 @@ export async function handleChatCompletionsPOST(
       effectiveMaxTokens ?? request.max_tokens ?? 500;
     const affiliateCode = req.headers.get("X-Affiliate-Code");
 
+    const tBeforeReserve = Date.now();
     let reservation: CreditReservation;
     let appCreditsInfo:
       | { appId: string; estimatedBaseCost: number; app: typeof monetizedApp }
@@ -981,6 +988,7 @@ export async function handleChatCompletionsPOST(
     }
 
     settleReservation = createCreditReservationSettler(reservation);
+    const tAfterReserve = Date.now();
 
     // 7. Convert messages for AI SDK
     const systemMessage = request.messages.find((m) => m.role === "system");
@@ -998,6 +1006,20 @@ export async function handleChatCompletionsPOST(
       streaming: request.stream,
       estimatedInputTokens,
       webSearchEnabled: webSearchActive,
+    });
+
+    // Pre-forward latency breakdown (#9899). authMs = auth+org DB lookup;
+    // midReadsMs = rate-limit + app + reasoning-catalog + moderation (these run
+    // serially and are independent → the parallelization candidate); reserveMs =
+    // the credit-reservation DB write; totalMs = everything before the model
+    // call. Compare against cerebras-direct ~0.24s to see how much of TTFT is us.
+    logger.info("[Chat Completions][preforward]", {
+      model,
+      authMs: tAuth - startTime,
+      midReadsMs: tBeforeReserve - tAuth,
+      reserveMs: tAfterReserve - tBeforeReserve,
+      totalMs: Date.now() - startTime,
+      stream: request.stream === true,
     });
 
     // 8. Handle streaming vs non-streaming


### PR DESCRIPTION
## Why
Dedicated-agent chat feels slow (~6–9s). I root-caused it live (#9899): measured TTFT through `api.elizacloud.ai` = **6.8–7.4s** vs **cerebras-direct = 0.24s** for the same model (`gpt-oss-120b`), and generation streams fast on both. **100% of the overhead is cloud-api pre-forward TTFT** — and `getLanguageModel` already routes these models cerebras-direct, so it is *not* BitRouter/reasoning/model/pipeline.

## What
One `[Chat Completions][preforward]` log line before the model forward, splitting the serial pre-forward chain:
- `authMs` — `requireAuthOrApiKeyWithOrg` (auth + org DB lookup)
- `midReadsMs` — rate-limit + app lookup + reasoning-catalog + moderation (independent reads; the parallelization candidate)
- `reserveMs` — the credit-reservation DB write
- `totalMs` — everything before the model call

Purely additive: 3 `Date.now()` marks + one `logger.info`. **No control-flow, no billing change** (post-response billing is already deferred via `waitUntil`).

## Why instrument before fixing
The fix candidates (parallelize the mid-reads, skip catalog for cerebras-native, edge-cache auth) each target a different step. Rather than refactor a billing-critical hot path on a guess, this lands the measurement first so the follow-up is minimal and targeted. Follow-up fix PR will reference the numbers this surfaces.

Refs #9899, #8434.