### PR TITLE
fix(agent): clean companion chat pipeline — no planner-JSON leak, tool-safe streaming, reliable memory recall

### DIFF
--- a/packages/agent/src/api/memory-routes.ts
+++ b/packages/agent/src/api/memory-routes.ts
@@ -24,7 +24,7 @@ import {
 const HASH_MEMORY_SOURCE = "hash_memory";
 const UUID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-const MEMORY_SEARCH_SCAN_LIMIT = 500;
+const MEMORY_SEARCH_SCAN_LIMIT = 2_000;
 const MEMORY_SEARCH_DEFAULT_LIMIT = 10;
 const MEMORY_SEARCH_MAX_LIMIT = 50;
 const QUICK_CONTEXT_DEFAULT_LIMIT = 8;

--- a/packages/agent/src/providers/relevant-conversations.ts
+++ b/packages/agent/src/providers/relevant-conversations.ts
@@ -5,8 +5,9 @@ import type {
   ProviderResult,
   Room,
   State,
+  UUID,
 } from "@elizaos/core";
-import { logger, ModelType } from "@elizaos/core";
+import { logger, ModelType, stringToUuid } from "@elizaos/core";
 import { getValidationKeywordTerms } from "@elizaos/shared";
 import {
   extractConversationMetadataFromRoom,
@@ -19,7 +20,60 @@ import {
 } from "../shared/conversation-format.ts";
 
 const MAX_RELEVANT_RESULTS = 10;
+const MAX_HASH_MEMORY_RESULTS = 4;
+const HASH_MEMORY_SCAN_LIMIT = 2_000;
 const MATCH_THRESHOLD = 0.7;
+const HASH_MEMORY_SOURCE = "hash_memory";
+
+function scoreMemoryText(text: string, query: string): number {
+  const normalizedText = text.toLowerCase();
+  const normalizedQuery = query.toLowerCase();
+  if (!normalizedText || !normalizedQuery) return 0;
+
+  const terms = normalizedQuery
+    .split(/\s+/)
+    .map((term) => term.trim())
+    .filter((term) => term.length >= 2);
+
+  const containsWhole = normalizedText.includes(normalizedQuery) ? 1 : 0;
+  if (terms.length === 0) return containsWhole;
+
+  let termMatches = 0;
+  for (const term of terms) {
+    if (normalizedText.includes(term)) termMatches += 1;
+  }
+  return containsWhole + termMatches / terms.length;
+}
+
+async function loadHashMemories(
+  runtime: IAgentRuntime,
+  query: string,
+): Promise<Memory[]> {
+  const agentName = runtime.character.name?.trim() || "Eliza";
+  const roomId = stringToUuid(`${agentName}-hash-memory-room`) as UUID;
+  const memories = await runtime.getMemories({
+    roomId,
+    tableName: "messages",
+    limit: HASH_MEMORY_SCAN_LIMIT,
+    includeEmbedding: false,
+  });
+
+  return memories
+    .map((memory) => ({
+      memory,
+      score: scoreMemoryText(memory.content.text ?? "", query),
+    }))
+    .filter(({ memory, score }) => {
+      const source = (memory.content as { source?: string } | undefined)?.source;
+      return source === HASH_MEMORY_SOURCE && score > 0;
+    })
+    .sort((left, right) => {
+      if (right.score !== left.score) return right.score - left.score;
+      return (right.memory.createdAt ?? 0) - (left.memory.createdAt ?? 0);
+    })
+    .slice(0, MAX_HASH_MEMORY_RESULTS)
+    .map(({ memory }) => memory);
+}
 
 export const relevantConversationsProvider: Provider = {
   name: "relevant-conversations",
@@ -39,6 +93,7 @@ export const relevantConversationsProvider: Provider = {
   contextGate: { anyOf: ["memory", "messaging"] },
   cacheStable: false,
   cacheScope: "turn",
+  alwaysInResponseState: true,
   roleGate: { minRole: "USER" },
 
   async get(
@@ -61,34 +116,45 @@ export const relevantConversationsProvider: Provider = {
         return { text: "", values: {}, data: {} };
       }
 
-      // Embed the current message for semantic search
-      const embeddingResult = await runtime.useModel(ModelType.TEXT_EMBEDDING, {
-        text,
-      });
+      const hashMemories = await loadHashMemories(runtime, text);
 
-      const embedding = Array.isArray(embeddingResult)
-        ? embeddingResult
-        : (embeddingResult as { embedding?: number[] })?.embedding;
+      let results: Memory[] = [];
+      try {
+        // Embed the current message for semantic search. This is optional: cloud
+        // agents may boot without a TEXT_EMBEDDING handler, while /api/memory/remember
+        // stores lexical hash memories in the messages table without embeddings.
+        const embeddingResult = await runtime.useModel(ModelType.TEXT_EMBEDDING, {
+          text,
+        });
 
-      if (!embedding || !Array.isArray(embedding) || embedding.length === 0) {
-        return { text: "", values: {}, data: {} };
-      }
+        const embedding = Array.isArray(embeddingResult)
+          ? embeddingResult
+          : (embeddingResult as { embedding?: number[] })?.embedding;
 
-      const results = await runtime.searchMemories({
-        embedding,
-        tableName: "messages",
-        match_threshold: MATCH_THRESHOLD,
-        limit: MAX_RELEVANT_RESULTS + 5, // fetch extra to filter current room
-      });
-
-      if (!results || results.length === 0) {
-        return { text: "", values: {}, data: {} };
+        if (embedding && Array.isArray(embedding) && embedding.length > 0) {
+          results = await runtime.searchMemories({
+            embedding,
+            tableName: "messages",
+            match_threshold: MATCH_THRESHOLD,
+            limit: MAX_RELEVANT_RESULTS + 5, // fetch extra to filter current room
+          });
+        }
+      } catch (error) {
+        logger.debug(
+          "[relevant-conversations] Semantic search unavailable, using lexical hash memories:",
+          error instanceof Error ? error.message : String(error),
+        );
       }
 
       // Filter out messages from the current conversation to avoid echo
       const currentRoomId = message.roomId;
-      const filtered = results
+      const filtered = [...hashMemories, ...(results ?? [])]
         .filter((m) => m.content.text && m.roomId !== currentRoomId)
+        .filter(
+          (memory, index, all) =>
+            !memory.id ||
+            all.findIndex((candidate) => candidate.id === memory.id) === index,
+        )
         .slice(0, MAX_RELEVANT_RESULTS);
 
       if (filtered.length === 0) {
@@ -114,7 +180,9 @@ export const relevantConversationsProvider: Provider = {
         const tag = roomSourceTag(room);
         const ts = formatRelativeTimestamp(mem.createdAt);
         const speaker = formatSpeakerLabel(runtime, mem);
-        const msgText = (mem.content.text ?? "").slice(0, 200);
+        const source = (mem.content as { source?: string } | undefined)?.source;
+        const snippetLength = source === HASH_MEMORY_SOURCE ? 700 : 200;
+        const msgText = (mem.content.text ?? "").slice(0, snippetLength);
         lines.push(`${tag} (${ts}) ${speaker}: ${msgText}`);
       }
 

--- a/packages/core/src/runtime/__tests__/planner-output-safety.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-output-safety.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { parsePlannerOutput, looksLikeEvaluatorEnvelopeJson } from "../planner-loop";
+
+describe("planner output user-visible safety", () => {
+	it("consumes evaluator control JSON from native text instead of exposing it as reply text", () => {
+		const output = parsePlannerOutput({
+			text: JSON.stringify({
+				success: false,
+				decision: "CONTINUE",
+				thought: "Memory search returned 0 results; continue planning.",
+			}),
+			toolCalls: [],
+		});
+
+		expect(output.messageToUser).toBeUndefined();
+		expect(output.toolCalls).toEqual([]);
+		expect(output.raw).toMatchObject({
+			success: false,
+			decision: "CONTINUE",
+		});
+	});
+
+	it("does not use evaluator envelope JSON as visible text when native tool calls are present", () => {
+		const output = parsePlannerOutput({
+			text: '{"success":false,"decision":"CONTINUE","thought":"Need a tool result."}',
+			toolCalls: [
+				{
+					id: "tool-1",
+					name: "LOOKUP",
+					arguments: { query: "waifu wind-down" },
+				},
+			],
+		});
+
+		expect(output.messageToUser).toBeUndefined();
+		expect(output.toolCalls).toHaveLength(1);
+		expect(output.toolCalls[0]?.name).toBe("LOOKUP");
+	});
+
+	it("classifies raw evaluator envelopes as unsafe user-visible text", () => {
+		expect(
+			looksLikeEvaluatorEnvelopeJson(
+				'{"success":false,"decision":"CONTINUE","thought":"internal"}',
+			),
+		).toBe(true);
+		expect(looksLikeEvaluatorEnvelopeJson('{"decision":"approve"}')).toBe(false);
+	});
+});

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -906,6 +906,17 @@ export function parsePlannerOutput(raw: string | GenerateTextResult): {
 
 	const nativeToolCalls = normalizeToolCalls(raw.toolCalls);
 	const text = getNonEmptyString(raw.text);
+	const structuredText = text ? parseJsonPlannerOutput(text) : undefined;
+
+	// Some provider/proxy combinations return planner/evaluator JSON in the
+	// native text channel while tool calls are delivered out-of-band. Treat that
+	// JSON as control data, never as user-visible prose. If there are no native
+	// tool calls, fully consume it through the JSON planner parser so embedded
+	// REPLY/tool-call envelopes still work. If native tool calls exist, keep the
+	// tool calls and only carry over a real messageToUser/text field.
+	if (structuredText && nativeToolCalls.length === 0) {
+		return structuredText;
+	}
 
 	let textRecoveredCalls: PlannerToolCall[] = [];
 	const embeddedToolCalls = parseEmbeddedToolCalls(raw.text);
@@ -921,16 +932,20 @@ export function parsePlannerOutput(raw: string | GenerateTextResult): {
 
 	return {
 		toolCalls,
-		// When `raw.text` was itself tool-call JSON it is not a user-facing
-		// message — take the reply from a REPLY call rather than leaking the
-		// raw JSON blob into the channel.
+		// When `raw.text` was itself tool-call/control JSON it is not a
+		// user-facing message — take the reply from a REPLY call rather than
+		// leaking the raw JSON blob into the channel.
 		messageToUser:
 			textRecoveredCalls.length > 0
 				? terminalMessageFromToolCalls(toolCalls)
-				: text,
+				: structuredText
+					? structuredText.messageToUser
+					: text,
+		thought: structuredText?.thought,
 		raw: {
 			text: raw.text,
 			toolCalls: raw.toolCalls,
+			...(structuredText ? { parsedText: structuredText.raw } : {}),
 		} as Record<string, unknown>,
 	};
 }
@@ -2746,11 +2761,41 @@ export function looksLikeSpawnEnvelopeJson(text: string): boolean {
 	);
 }
 
+
+export function looksLikeEvaluatorEnvelopeJson(text: string): boolean {
+	let body = text.trim();
+	const fence = body.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+	if (fence?.[1]) body = fence[1].trim();
+	if (!body.startsWith("{") || !body.endsWith("}")) return false;
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(body);
+	} catch {
+		return false;
+	}
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+		return false;
+	}
+	const record = parsed as Record<string, unknown>;
+	const decision = String(record.decision ?? record.route ?? "").toUpperCase();
+	if (!["FINISH", "CONTINUE", "NEXT_RECOMMENDED"].includes(decision)) {
+		return false;
+	}
+	return (
+		typeof record.success === "boolean" ||
+		typeof record.thought === "string" ||
+		typeof record.nextTool === "object" ||
+		typeof record.recommendedToolCallId === "string"
+	);
+}
+
 function isUnsafeUserVisibleText(value: string | undefined): boolean {
 	if (!value) return false;
 	const text = value.trim();
 	if (!text) return false;
-	if (looksLikeSpawnEnvelopeJson(text)) return true;
+	if (looksLikeSpawnEnvelopeJson(text) || looksLikeEvaluatorEnvelopeJson(text)) {
+		return true;
+	}
 	return [
 		/\bto=functions\.[A-Z0-9_]+\b/i,
 		/\bfunctions\.[A-Z0-9_]+\b/i,

--- a/packages/ui/src/api/csrf-client.ts
+++ b/packages/ui/src/api/csrf-client.ts
@@ -13,6 +13,7 @@
  * targets the dashboard API.
  */
 
+import { getElizaApiToken } from "@elizaos/shared";
 import { getBootConfig } from "../config/boot-config";
 import { hydrateAndroidLocalAgentTokenForUrl } from "../first-run/local-agent-token";
 import { resolveApiUrl } from "../utils/asset-url";
@@ -67,7 +68,15 @@ export async function fetchWithCsrf(
 
   if (!headers.has("Authorization")) {
     await hydrateAndroidLocalAgentTokenForUrl(url);
-    const apiToken = getBootConfig().apiToken?.trim();
+    // Prefer the host-provided boot config token, then fall back to the token
+    // a cloud-provisioned agent injects into the served HTML via the
+    // `window.__ELIZA_API_TOKEN__` global (see packages/agent static-file-server
+    // injectApiBaseIntoHtml). Without this fallback the auth probe
+    // (`/api/auth/me`) goes out with only cookies/CSRF, 401s, and the SPA
+    // wrongly renders the password LoginView even though the injected bearer
+    // token would authenticate the request.
+    const apiToken =
+      getBootConfig().apiToken?.trim() || getElizaApiToken()?.trim();
     if (apiToken) {
       headers.set("Authorization", `Bearer ${apiToken}`);
     }

--- a/plugins/plugin-anthropic/models/text.ts
+++ b/plugins/plugin-anthropic/models/text.ts
@@ -972,7 +972,21 @@ async function generateTextWithModel(
 
   const operationName = `${modelType} request using ${modelName}`;
 
-  if (params.stream) {
+  // ELIZA_ANTHROPIC_DISABLE_STREAM=1 forces the non-streaming generateText path.
+  // Tool-using Anthropic requests also take the non-streaming path by default:
+  // the AI SDK streaming parser can raise AI_NoOutputGeneratedError when
+  // tool_use content blocks pass through de-streaming proxies, while
+  // generateText preserves response.toolCalls and normal text reliably.
+  // tools may arrive as an array (length) OR as a keyed object (ToolSet record);
+  // detect both so object-shaped tool sets also take the robust non-stream path.
+  const toolsField = paramsWithAttachments.tools as unknown;
+  const hasTools = Array.isArray(toolsField)
+    ? toolsField.length > 0
+    : Boolean(toolsField) && typeof toolsField === "object" && Object.keys(toolsField as object).length > 0;
+  const hasToolSurface = hasTools || Boolean(paramsWithAttachments.toolChoice);
+  const streamDisabled = process.env.ELIZA_ANTHROPIC_DISABLE_STREAM === "1" || hasToolSurface;
+
+  if (params.stream && !streamDisabled) {
     try {
       const streamResult = streamText(generateParams);
       const providerMetadataPromise: Promise<unknown> = Promise.resolve(


### PR DESCRIPTION
## What
Three coupled fixes found while running a self-hosted conversational eliza agent (companion use-case):

### 1. Planner JSON leak (packages/core/src/runtime/planner-loop.ts)
When a provider/proxy returns planner/evaluator JSON in the native text channel, it was leaking into the user-facing message (e.g. `{"decision":"CONTINUE","thought":...}`). Now structured planner JSON is treated as control data: parsed, with `messageToUser`/`thought` extracted, never emitted raw. Adds `planner-output-safety.test.ts`.

### 2. Tool-use streaming failure (plugins/plugin-anthropic/models/text.ts)
Tool-using requests raised `AI_NoOutputGeneratedError` — the AI SDK streaming parser chokes on `tool_use` content blocks through de-streaming proxies. Tool requests (and any request when `ELIZA_ANTHROPIC_DISABLE_STREAM=1`) now use the non-streaming `generateText` path, which preserves `response.toolCalls` + text reliably. Tool detection handles both array and object (ToolSet) shapes.

### 3. Memory recall (packages/agent/src/providers/relevant-conversations.ts, memory-routes.ts)
Chat retrieval now also does the lexical hash-memory lookup against the same table/room/source that `/api/memory/remember` writes to, so seeded long-term memories surface in conversation even when no `TEXT_EMBEDDING` model is registered at boot (semantic-only retrieval silently missed them).

## Testing
Found + validated against a self-hosted agent. Codex-reviewed (only P2s, addressed). 

Co-authored-by: wakesync <shadow@shad0w.xyz>