### PR TITLE
fix: stabilize dedicated cloud handoff and agent task acks

### DIFF
--- a/packages/app/scripts/verify-chunk-safety.mjs
+++ b/packages/app/scripts/verify-chunk-safety.mjs
@@ -121,7 +121,7 @@ if (process.env.ELIZA_WEB_ABSOLUTE_BASE === "1") {
       "\nThe web SPA base regressed to relative. Depth-2+ routes (/auth/cli-login,\n" +
         "/app-auth/authorize, /payment/:id) would resolve assets to /<route>/assets/…,\n" +
         "which the SPA fallback serves as text/html → the bundle never boots → blank\n" +
-        'page. Keep `base` absolute for the web build (vite.config.ts:\n' +
+        "page. Keep `base` absolute for the web build (vite.config.ts:\n" +
         '`process.env.ELIZA_WEB_ABSOLUTE_BASE === "1" ? "/" : "./"`). Do NOT deploy.',
     );
     process.exit(1);

--- a/packages/cloud-api/auth/create-anonymous-session/route.test.ts
+++ b/packages/cloud-api/auth/create-anonymous-session/route.test.ts
@@ -15,7 +15,10 @@ mock.module("@/lib/services/anonymous-session-creator", () => ({
 const store = new Map<string, { count: number; expireAt: number }>();
 const fakeRedis = {
   async incr(key: string) {
-    const entry = store.get(key) ?? { count: 0, expireAt: Date.now() + 300_000 };
+    const entry = store.get(key) ?? {
+      count: 0,
+      expireAt: Date.now() + 300_000,
+    };
     entry.count += 1;
     store.set(key, entry);
     return entry.count;

--- a/packages/cloud-api/mcp/route.ts
+++ b/packages/cloud-api/mcp/route.ts
@@ -100,17 +100,20 @@ async function handleJsonRpc(c: AppContext, message: unknown) {
   }
 }
 
-app.get("/", (c) =>
-  getPlatformUpstream(c)
-    ? forwardMcpUpstreamRequest(c.req.raw, getPlatformUpstream(c)!)
-    : c.json({
-        success: true,
-        name: "eliza-cloud-platform",
-        protocol: "mcp",
-        transport: "streamable-http",
-        tools: listPlatformCloudMcpTools().map((tool) => tool.name),
-      }),
-);
+app.get("/", async (c) => {
+  const upstream = getPlatformUpstream(c);
+  if (upstream) {
+    return forwardMcpUpstreamRequest(c.req.raw, upstream);
+  }
+
+  return c.json({
+    success: true,
+    name: "eliza-cloud-platform",
+    protocol: "mcp",
+    transport: "streamable-http",
+    tools: listPlatformCloudMcpTools().map((tool) => tool.name),
+  });
+});
 
 app.post("/", async (c) => {
   const upstream = getPlatformUpstream(c);
@@ -132,7 +135,7 @@ app.post("/", async (c) => {
   return c.json(Array.isArray(body) ? results : results[0]);
 });
 
-app.all("*", (c) => {
+app.all("*", async (c) => {
   const upstream = getPlatformUpstream(c);
   if (upstream) return forwardMcpUpstreamRequest(c.req.raw, upstream);
   return c.json(

--- a/packages/cloud-api/v1/coding-containers/route.test.ts
+++ b/packages/cloud-api/v1/coding-containers/route.test.ts
@@ -154,7 +154,9 @@ describe("coding containers route", () => {
 
     // ghcr.io/dexploarer/* is in the default allowlist, so this passes the
     // allowlist gate but fails the digest-pin gate (mutable :latest).
-    const response = await postCodingContainer("ghcr.io/dexploarer/bnancy:latest");
+    const response = await postCodingContainer(
+      "ghcr.io/dexploarer/bnancy:latest",
+    );
 
     expect(response.status).toBe(403);
     expect(await response.json()).toEqual(

--- a/packages/cloud-api/v1/coding-containers/route.ts
+++ b/packages/cloud-api/v1/coding-containers/route.ts
@@ -179,7 +179,12 @@ async function createCodingContainer(
   // When armed, an allowed image must also be pinned to a full sha256 digest
   // so the registry cannot swap the bytes behind a mutable tag after the
   // allowlist check passes. Default OFF (opt-in via env).
-  if (imageRequiresDigestPin(payload.image, containersEnv.requireDigestPinnedImages())) {
+  if (
+    imageRequiresDigestPin(
+      payload.image,
+      containersEnv.requireDigestPinnedImages(),
+    )
+  ) {
     logger.warn("[CodingContainers API] image rejected: digest pin required", {
       orgId: user.organization_id,
       image: payload.image,

--- a/packages/cloud-api/v1/containers/route.ts
+++ b/packages/cloud-api/v1/containers/route.ts
@@ -271,7 +271,12 @@ app.post("/", async (c) => {
 
     // SECURITY (opt-in): when the digest-pin gate is armed, reject mutable
     // refs so an allowed repo cannot swap bytes behind a tag after this check.
-    if (imageRequiresDigestPin(body.image, containersEnv.requireDigestPinnedImages())) {
+    if (
+      imageRequiresDigestPin(
+        body.image,
+        containersEnv.requireDigestPinnedImages(),
+      )
+    ) {
       logger.warn("[Containers API] image rejected: digest pin required", {
         organizationId: user.organization_id,
         image: body.image,

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs-delete-enqueue.test.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs-delete-enqueue.test.ts
@@ -15,6 +15,7 @@
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import type { SQL } from "drizzle-orm";
 import { PgDialect } from "drizzle-orm/pg-core";
+import * as realOutboundUrl from "../security/outbound-url";
 
 // ---- captured query state ----
 let capturedSelectWhere: SQL | undefined;
@@ -89,9 +90,14 @@ mock.module("../../db/helpers", () => ({
   writeTransaction: (fn: (t: typeof tx) => Promise<unknown>) => transaction(fn),
 }));
 
-// Avoid the real outbound-URL guard and job hydration/insert-prep pulling in DB.
+// Stub the outbound-URL guard the enqueue path calls so it can't reach out over
+// the network, but keep the module's full export surface intact — `safe-fetch`
+// (pulled in transitively) statically imports `isForbiddenIpAddress`,
+// `normalizeHostname`, and `resolveSafeOutboundTarget`, and a partial mock would
+// break that link with "Export named 'isForbiddenIpAddress' not found".
 mock.module("../security/outbound-url", () => ({
-  assertSafeOutboundUrl: mock(async (u: string) => u),
+  ...realOutboundUrl,
+  assertSafeOutboundUrl: mock(async (u: string) => new URL(u)),
 }));
 
 // hydrateJob / prepareJobInsertData reach into object-storage offloading; stub

--- a/packages/core/src/__tests__/messages-format.test.ts
+++ b/packages/core/src/__tests__/messages-format.test.ts
@@ -43,6 +43,50 @@ describe("formatMessages", () => {
 		);
 	});
 
+	it("preserves the full reacted-to message text in context (#9874)", () => {
+		// A reaction memory's `text` truncates the reacted-to content to a short
+		// stub; the untruncated original lives in `reactedMessageText`. Context
+		// formatting must surface the full statement so the planner does not
+		// back-rationalize a truncated fragment into a phantom task.
+		const full =
+			"can you pull the Q3 revenue numbers and compare them against Q2 for me";
+		const rendered = formatMessages({
+			messages: [
+				{
+					id: "00000000-0000-0000-0000-000000000021" as UUID,
+					entityId: "00000000-0000-0000-0000-000000000002" as UUID,
+					roomId,
+					createdAt: 1765381653000,
+					content: {
+						text: `*Added 👍 to: "${full.slice(0, 50)}…"*`,
+						reactedMessageText: full,
+					},
+				} as Memory,
+			],
+			entities: [],
+		});
+
+		expect(rendered).toContain(full);
+		expect(rendered).toContain("reacted-to message in full");
+	});
+
+	it("omits the reacted-to context line when no reactedMessageText is set", () => {
+		const rendered = formatMessages({
+			messages: [
+				{
+					id: "00000000-0000-0000-0000-000000000022" as UUID,
+					entityId: "00000000-0000-0000-0000-000000000002" as UUID,
+					roomId,
+					createdAt: 1765381653000,
+					content: { text: "just a normal message" },
+				} as Memory,
+			],
+			entities: [],
+		});
+
+		expect(rendered).not.toContain("reacted-to message in full");
+	});
+
 	it("advertises a stored-content read when readable text is stored", () => {
 		const rendered = formatMessages({
 			messages: [

--- a/packages/core/src/runtime/__tests__/addressed-to.test.ts
+++ b/packages/core/src/runtime/__tests__/addressed-to.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Entity, IAgentRuntime, Memory, UUID } from "../../types/index.ts";
+import { addresseeIsNonOwnerBot } from "../addressed-to.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000aa" as UUID;
+const BOT_B = "00000000-0000-0000-0000-0000000000bb" as UUID;
+const HUMAN_X = "00000000-0000-0000-0000-0000000000cc" as UUID;
+const ROOM_ID = "00000000-0000-0000-0000-000000000001" as UUID;
+const SENDER_ID = "00000000-0000-0000-0000-0000000000dd" as UUID;
+
+function makeRuntime(overrides: Partial<IAgentRuntime> = {}): IAgentRuntime {
+	return {
+		agentId: AGENT_ID,
+		character: { name: "MyAgent" },
+		getAgent: vi.fn(async () => null),
+		getEntitiesForRoom: vi.fn(async () => [] as Entity[]),
+		...overrides,
+	} as unknown as IAgentRuntime;
+}
+
+function makeMessage(
+	contentMetadata?: Record<string, unknown>,
+	topLevelMetadata?: Record<string, unknown>,
+): Memory {
+	return {
+		id: "00000000-0000-0000-0000-0000000000ee" as UUID,
+		entityId: SENDER_ID,
+		roomId: ROOM_ID,
+		content: {
+			text: "do the thing",
+			...(contentMetadata ? { metadata: contentMetadata } : {}),
+		},
+		...(topLevelMetadata ? { metadata: topLevelMetadata } : {}),
+	} as Memory;
+}
+
+describe("addresseeIsNonOwnerBot (#9874 item 1)", () => {
+	it("returns false when there are no explicit addressees", async () => {
+		expect(
+			await addresseeIsNonOwnerBot({
+				runtime: makeRuntime(),
+				message: makeMessage(),
+				addressedTo: [],
+			}),
+		).toBe(false);
+	});
+
+	it("returns false when addressed to this agent by name (case/@-insensitive)", async () => {
+		expect(
+			await addresseeIsNonOwnerBot({
+				runtime: makeRuntime(),
+				message: makeMessage({ fromBot: true }),
+				addressedTo: ["@myagent"],
+			}),
+		).toBe(false);
+	});
+
+	it("returns false when addressed to this agent by id", async () => {
+		expect(
+			await addresseeIsNonOwnerBot({
+				runtime: makeRuntime(),
+				message: makeMessage({ fromBot: true }),
+				addressedTo: [AGENT_ID],
+			}),
+		).toBe(false);
+	});
+
+	it("returns true when a bot addresses someone other than us (sender fromBot)", async () => {
+		expect(
+			await addresseeIsNonOwnerBot({
+				runtime: makeRuntime(),
+				message: makeMessage({ fromBot: true }),
+				addressedTo: ["SomeOtherBot"],
+			}),
+		).toBe(true);
+	});
+
+	it("also accepts legacy top-level fromBot metadata", async () => {
+		expect(
+			await addresseeIsNonOwnerBot({
+				runtime: makeRuntime(),
+				message: makeMessage(undefined, { fromBot: true }),
+				addressedTo: ["SomeOtherBot"],
+			}),
+		).toBe(true);
+	});
+
+	it("returns true when an addressee resolves to a registered agent (no fromBot)", async () => {
+		const getAgent = vi.fn(async (id: UUID) =>
+			id === BOT_B ? ({ id: BOT_B } as unknown) : null,
+		);
+		expect(
+			await addresseeIsNonOwnerBot({
+				runtime: makeRuntime({ getAgent } as Partial<IAgentRuntime>),
+				message: makeMessage(),
+				addressedTo: [BOT_B],
+			}),
+		).toBe(true);
+	});
+
+	it("returns false when the addressee is a human (not a registered agent, not fromBot)", async () => {
+		expect(
+			await addresseeIsNonOwnerBot({
+				runtime: makeRuntime(),
+				message: makeMessage(),
+				addressedTo: [HUMAN_X],
+			}),
+		).toBe(false);
+	});
+
+	it("returns false when an addressed name cannot be resolved and the sender is not a bot", async () => {
+		expect(
+			await addresseeIsNonOwnerBot({
+				runtime: makeRuntime(),
+				message: makeMessage(),
+				addressedTo: ["@ghost"],
+			}),
+		).toBe(false);
+	});
+
+	it("returns false when a BOT addresses us by a platform-handle ALIAS (not character.name)", async () => {
+		// Regression: the agent's room entity carries platform-handle aliases
+		// (e.g. samantha_ai_bot) that are not character.name. A bot addressing us
+		// by such an alias must be recognized as addressed-to-us and NOT have its
+		// tool request suppressed — the self-by-resolution check runs before the
+		// fromBot short-circuit.
+		const runtime = makeRuntime({
+			getEntitiesForRoom: vi.fn(async () => [
+				{ id: AGENT_ID, names: ["samantha_ai_bot", "Samantha"] },
+			]),
+		} as unknown as Partial<IAgentRuntime>);
+		expect(
+			await addresseeIsNonOwnerBot({
+				runtime,
+				message: makeMessage({ fromBot: true }),
+				addressedTo: ["@samantha_ai_bot"],
+			}),
+		).toBe(false);
+	});
+});

--- a/packages/core/src/runtime/__tests__/message-handler.test.ts
+++ b/packages/core/src/runtime/__tests__/message-handler.test.ts
@@ -100,6 +100,64 @@ describe("v5 message handler routing", () => {
 		}
 	});
 
+	it("suppresses the simple→requiresTool promotion for bot-to-bot crosstalk (#9874)", () => {
+		// The inbound is addressed to another bot, not us; the caller resolved
+		// that and passes suppressToolPromotion. requiresTool would normally
+		// promote a simple-only turn to planning against general — here it must
+		// stay on the simple reply so we do not fabricate a phantom tool task.
+		const output = {
+			processMessage: "RESPOND" as const,
+			thought: "Overheard crosstalk.",
+			plan: {
+				contexts: ["simple"],
+				requiresTool: true,
+				reply: "got it",
+			},
+		};
+
+		const promoted = routeMessageHandlerOutput(output);
+		expect(promoted.type).toBe("planning_needed");
+
+		const suppressed = routeMessageHandlerOutput(output, {
+			suppressToolPromotion: true,
+		});
+		expect(suppressed.type).toBe("final_reply");
+		if (suppressed.type === "final_reply") {
+			expect(suppressed.reply).toBe("got it");
+		}
+	});
+
+	it("suppression also blocks the candidateActions promotion, but leaves explicit non-simple planning intact (#9874)", () => {
+		const candidatePromotion = {
+			processMessage: "RESPOND" as const,
+			thought: "candidate hint.",
+			plan: {
+				contexts: ["simple"],
+				requiresTool: true,
+				candidateActions: ["BASH"],
+				reply: "on it",
+			},
+		};
+		expect(
+			routeMessageHandlerOutput(candidatePromotion, {
+				suppressToolPromotion: true,
+			}).type,
+		).toBe("final_reply");
+
+		// Suppression only blocks the simple-path promotion; a turn that already
+		// selected a real non-simple context still plans against it.
+		const explicitPlanning = {
+			processMessage: "RESPOND" as const,
+			thought: "real context.",
+			plan: { contexts: ["general"], requiresTool: true },
+		};
+		expect(
+			routeMessageHandlerOutput(explicitPlanning, {
+				suppressToolPromotion: true,
+			}).type,
+		).toBe("planning_needed");
+	});
+
 	it("keeps simple route for explicit non-tool candidate hints", () => {
 		const output = {
 			processMessage: "RESPOND" as const,

--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -763,6 +763,192 @@ describe("v5 planner loop skeleton", () => {
 		expect(runtime.useModel).toHaveBeenCalledTimes(2);
 	});
 
+	it("captures a SAFE native-text refusal at required-tool exhaustion instead of a generic apology (#9874)", async () => {
+		// Companion to the guard above. When Stage 1 forced requiresTool but no
+		// exposed tool can satisfy the request, a native-mode model emits an
+		// honest refusal as `text` with no REPLY call / explicit messageToUser.
+		// That text is a genuine user-facing reply (not a pre-tool thought), so it
+		// must reach the user — gated through the user-safe refusal check — rather
+		// than throwing into the caller's generic "something went wrong".
+		const runtime = {
+			useModel: vi.fn(async () => ({
+				text: "I'm not able to search the chat history directly from here.",
+				toolCalls: [],
+			})),
+			logger: { warn: vi.fn() },
+		};
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			tools: [{ name: "LOOKUP", description: "Lookup current status." }],
+			requireNonTerminalToolCall: true,
+			config: { maxRequiredToolMisses: 1 },
+			executeToolCall: vi.fn(),
+			evaluate: vi.fn(),
+		});
+
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toBe(
+			"I'm not able to search the chat history directly from here.",
+		);
+		// maxRequiredToolMisses=1: the 2nd miss exhausts the cap and returns the
+		// captured native refusal.
+		expect(runtime.useModel).toHaveBeenCalledTimes(2);
+	});
+
+	it("never surfaces a leaked tool-call as a native refusal at exhaustion (#9874)", async () => {
+		// Negative control: native text that is a reasoning/leak must be rejected
+		// by the user-safe gate, so the loop throws rather than leaking it.
+		const runtime = {
+			useModel: vi.fn(async () => ({
+				text: "I need to call SEARCH_MESSAGES to find that.",
+				toolCalls: [],
+			})),
+			logger: { warn: vi.fn() },
+		};
+
+		await expect(
+			runPlannerLoop({
+				runtime,
+				context: { id: "ctx" },
+				tools: [{ name: "LOOKUP", description: "Lookup current status." }],
+				requireNonTerminalToolCall: true,
+				config: { maxRequiredToolMisses: 1 },
+				executeToolCall: vi.fn(),
+				evaluate: vi.fn(),
+			}),
+		).rejects.toMatchObject({
+			name: "TrajectoryLimitExceeded",
+			kind: "required_tool_misses",
+		});
+		expect(runtime.useModel).toHaveBeenCalledTimes(2);
+	});
+
+	it.each([
+		"Let me check the database for that information.",
+		"Let me pull up your recent messages.",
+		"I'm reviewing the conversation history to answer.",
+		"I'll look that up and get back to you.",
+		"Pulling up the info now, one sec.",
+	])("never surfaces native intent-narration as a refusal: %s (#9874)", async (text) => {
+		// Regression: a native pre-tool/intent-narration text carries no leak
+		// markup and no "thinking through" marker, so a denylist would let it
+		// through and the agent would falsely claim it is doing work it never
+		// did. The positive-allowlist gate (must read as an inability) rejects
+		// it → the loop throws → caller emits the generic apology, never the
+		// phantom action claim.
+		const runtime = {
+			useModel: vi.fn(async () => ({ text, toolCalls: [] })),
+			logger: { warn: vi.fn() },
+		};
+
+		await expect(
+			runPlannerLoop({
+				runtime,
+				context: { id: "ctx" },
+				tools: [{ name: "LOOKUP", description: "Lookup current status." }],
+				requireNonTerminalToolCall: true,
+				config: { maxRequiredToolMisses: 1 },
+				executeToolCall: vi.fn(),
+				evaluate: vi.fn(),
+			}),
+		).rejects.toMatchObject({
+			name: "TrajectoryLimitExceeded",
+			kind: "required_tool_misses",
+		});
+	});
+
+	it("does not surface explicit messageToUser intent-narration at required-tool exhaustion (#9874)", async () => {
+		const runtime = {
+			useModel: vi.fn(async () =>
+				JSON.stringify({
+					messageToUser: "Let me check the database for that information.",
+					toolCalls: [],
+				}),
+			),
+			logger: { warn: vi.fn() },
+		};
+
+		await expect(
+			runPlannerLoop({
+				runtime,
+				context: { id: "ctx" },
+				tools: [{ name: "LOOKUP", description: "Lookup current status." }],
+				requireNonTerminalToolCall: true,
+				config: { maxRequiredToolMisses: 1 },
+				executeToolCall: vi.fn(),
+				evaluate: vi.fn(),
+			}),
+		).rejects.toMatchObject({
+			name: "TrajectoryLimitExceeded",
+			kind: "required_tool_misses",
+		});
+		expect(runtime.useModel).toHaveBeenCalledTimes(2);
+	});
+
+	it("does not surface terminal REPLY intent-narration at required-tool exhaustion (#9874)", async () => {
+		const runtime = {
+			useModel: vi.fn(async () => ({
+				text: "",
+				toolCalls: [
+					{
+						id: "reply-1",
+						name: "REPLY",
+						arguments: {
+							text: "Let me check the database for that information.",
+						},
+					},
+				],
+			})),
+			logger: { warn: vi.fn() },
+		};
+
+		await expect(
+			runPlannerLoop({
+				runtime,
+				context: { id: "ctx" },
+				tools: [{ name: "LOOKUP", description: "Lookup current status." }],
+				requireNonTerminalToolCall: true,
+				config: { maxRequiredToolMisses: 1 },
+				executeToolCall: vi.fn(),
+				evaluate: vi.fn(),
+			}),
+		).rejects.toMatchObject({
+			name: "TrajectoryLimitExceeded",
+			kind: "required_tool_misses",
+		});
+		expect(runtime.useModel).toHaveBeenCalledTimes(2);
+	});
+
+	it("surfaces an explicit honest refusal at required-tool exhaustion (#9874)", async () => {
+		const runtime = {
+			useModel: vi.fn(async () =>
+				JSON.stringify({
+					messageToUser: "That capability is not available this turn.",
+					toolCalls: [],
+				}),
+			),
+			logger: { warn: vi.fn() },
+		};
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			tools: [{ name: "LOOKUP", description: "Lookup current status." }],
+			requireNonTerminalToolCall: true,
+			config: { maxRequiredToolMisses: 1 },
+			executeToolCall: vi.fn(),
+			evaluate: vi.fn(),
+		});
+
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toBe(
+			"That capability is not available this turn.",
+		);
+		expect(runtime.useModel).toHaveBeenCalledTimes(2);
+	});
+
 	it("retries planner calls to tools that are not exposed this turn", async () => {
 		const runtime = {
 			useModel: vi

--- a/packages/core/src/runtime/addressed-to.ts
+++ b/packages/core/src/runtime/addressed-to.ts
@@ -115,7 +115,100 @@ interface ResolveTargetsArgs {
 	addressedTo: readonly string[];
 }
 
-async function resolveAddressedTargets(
+/**
+ * Detects bot-to-bot crosstalk: the inbound message is directed at another
+ * participant that is NOT this agent, in a context where the agent is merely
+ * overhearing. Used to suppress the simple→requiresTool promotion so the agent
+ * does not fabricate a tool task from crosstalk it was not asked to act on
+ * (#9874 item 1).
+ *
+ * Returns true only when ALL hold:
+ *  - the message carries explicit `addressedTo` targets,
+ *  - none of them is this agent (by name or id) — i.e. it is not addressed to us,
+ *  - it is bot crosstalk: the SENDER is a bot (`fromBot` on either supported
+ *    message metadata shape), OR a resolved addressee is itself a registered
+ *    agent (`getAgent`).
+ *
+ * A human owner addressed by name is never a registered agent and never carries
+ * `fromBot`, so owner-directed talk does not trip this. Fails SAFE (returns
+ * false) whenever it cannot positively confirm crosstalk — suppression is the
+ * conservative action and is only taken on a clear signal.
+ */
+export async function addresseeIsNonOwnerBot(
+	args: ApplyAddressedToArgs,
+): Promise<boolean> {
+	const { runtime, message, addressedTo } = args;
+	if (!addressedTo || addressedTo.length === 0) {
+		return false;
+	}
+
+	const normalize = (value: string) =>
+		value.trim().toLowerCase().replace(/^@/, "");
+	const self = new Set<string>();
+	const selfId = runtime.agentId;
+	if (selfId) self.add(selfId.toLowerCase());
+	const selfName = runtime.character?.name;
+	if (selfName) self.add(normalize(selfName));
+
+	const cleaned = addressedTo
+		.map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+		.filter((entry) => entry.length > 0);
+	if (cleaned.length === 0) {
+		return false;
+	}
+
+	// Addressed to us by literal name/id → handle normally, never suppress.
+	if (cleaned.some((entry) => self.has(normalize(entry)))) {
+		return false;
+	}
+
+	// Resolve names→ids against the room. This also maps the agent's OWN entity
+	// aliases (platform handles like @samantha_ai_bot that connectors store on the
+	// agent's entity) to selfId, so a turn addressed to us by an alias is NOT
+	// mistaken for crosstalk — even when the sender is a bot. We must do this
+	// BEFORE the fromBot short-circuit, otherwise an owner-run relay bot
+	// addressing us by our handle would have its legitimate request suppressed.
+	const targets = await resolveAddressedTargets({
+		runtime,
+		message,
+		addressedTo,
+	});
+	if (selfId && targets.some((id) => id === selfId)) {
+		return false;
+	}
+
+	// A bot talking to someone other than us is crosstalk we are overhearing.
+	const contentMetadata =
+		message.content?.metadata &&
+		typeof message.content.metadata === "object" &&
+		!Array.isArray(message.content.metadata)
+			? (message.content.metadata as Record<string, unknown>)
+			: undefined;
+	const topLevelMetadata =
+		message.metadata &&
+		typeof message.metadata === "object" &&
+		!Array.isArray(message.metadata)
+			? (message.metadata as Record<string, unknown>)
+			: undefined;
+	const senderIsBot =
+		contentMetadata?.fromBot === true || topLevelMetadata?.fromBot === true;
+	if (senderIsBot) {
+		return true;
+	}
+
+	// Otherwise confirm at least one addressee resolves to a registered agent.
+	for (const targetId of targets) {
+		if (targetId === selfId) {
+			continue;
+		}
+		if (await runtime.getAgent(targetId)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+export async function resolveAddressedTargets(
 	args: ResolveTargetsArgs,
 ): Promise<UUID[]> {
 	const { runtime, message, addressedTo } = args;

--- a/packages/core/src/runtime/message-handler.ts
+++ b/packages/core/src/runtime/message-handler.ts
@@ -194,6 +194,7 @@ function parseExtract(raw: unknown): MessageHandlerExtract | undefined {
 
 export function routeMessageHandlerOutput(
 	output: V5MessageHandlerOutput,
+	options?: { suppressToolPromotion?: boolean },
 ): MessageHandlerRoute {
 	const processMessage = output.processMessage;
 	if (processMessage === "IGNORE") {
@@ -234,10 +235,15 @@ export function routeMessageHandlerOutput(
 	// routing layer.
 	const candidateActionsRequestPlanning =
 		hasCandidateActions && output.plan.requiresTool !== false;
-	if (
+	// #9874 item 1: when the caller has identified this turn as bot-to-bot
+	// crosstalk addressed to a non-owner bot, do NOT promote a simple-path turn
+	// into forced tool planning. The agent is overhearing talk it was not asked
+	// to act on; forcing a tool fabricates a phantom task (the false-ack seed).
+	// The Stage-1 simple reply still ships via the final_reply branch below.
+	const promotionRequested =
 		(requiresTool || candidateActionsRequestPlanning) &&
-		nonSimpleContexts.length === 0
-	) {
+		nonSimpleContexts.length === 0;
+	if (promotionRequested && !options?.suppressToolPromotion) {
 		return {
 			type: "planning_needed",
 			output,

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -245,9 +245,17 @@ export async function runPlannerLoop(
 					requireNonTerminalToolCall &&
 					!hasExecutedNonTerminalTool(trajectory)
 				) {
-					const refusalCandidate = getNonEmptyString(
-						lastPlannerExplicitMessageToUser,
-					);
+					// Prefer the planner's EXPLICIT messageToUser refusal. When the
+					// model emitted only native free text (no explicit field, no REPLY
+					// call), fall back to that text ONLY if it survives the user-safe
+					// refusal gate — which rejects reasoning/leak/fabrication AND
+					// pre-tool deliberation — so an honest native-mode refusal reaches
+					// the user instead of the caller's generic apology, without ever
+					// surfacing a pre-tool thought (#9874 item 3; guarded by the "does
+					// not capture native text fallback" test).
+					const refusalCandidate =
+						userSafeRefusalCandidate(lastPlannerExplicitMessageToUser) ??
+						userSafeRefusalCandidate(plannerOutput.messageToUser);
 					if (refusalCandidate) lastTerminalRefusalText = refusalCandidate;
 					requiredToolMisses++;
 					if (
@@ -361,9 +369,11 @@ export async function runPlannerLoop(
 					requireNonTerminalToolCall &&
 					!hasExecutedNonTerminalTool(trajectory)
 				) {
-					const refusalCandidate = terminalMessageFromToolCalls(
-						plannerOutput.toolCalls,
-						plannerOutput.messageToUser,
+					const refusalCandidate = userSafeRefusalCandidate(
+						terminalMessageFromToolCalls(
+							plannerOutput.toolCalls,
+							plannerOutput.messageToUser,
+						),
 					);
 					if (refusalCandidate) lastTerminalRefusalText = refusalCandidate;
 					requiredToolMisses++;
@@ -2834,6 +2844,75 @@ function isUnsafeUserVisibleText(value: string | undefined): boolean {
 		/\b(?:MESSAGE\s+action|action=(?:draft_reply|respond|send_draft|triage|list_inbox))\b/i,
 		/\{\s*"parameters"\s*:/i,
 	].some((pattern) => pattern.test(text));
+}
+
+// Detects planner free-text that NARRATES the model's own deliberation / tool
+// selection rather than addressing the user — a pre-tool "thought". Kept as a
+// belt-and-braces reject alongside the positive allowlist below.
+function looksLikePreToolThought(value: string): boolean {
+	const text = value.trim();
+	if (!text) return false;
+	return [
+		/\bthink(?:ing)?\s+through\b/i,
+		/\btool\s+choice\b/i,
+		/\b(?:after|before|once)\s+(?:thinking|considering|deciding|choosing|reviewing|figuring)\b/i,
+		/\blet me (?:think|consider|figure|decide|choose)\b/i,
+		/\bI(?:'ll| will| should| need to| am going to| plan to)\s+(?:think|consider|figure|decide|choose)\b/i,
+	].some((pattern) => pattern.test(text));
+}
+
+// Positive markers that a native free-text is a genuine inability/refusal — the
+// ONLY shape we surface from an ambiguous native `text` field. An allowlist (not
+// a denylist of known-bad phrasings) is what makes this safe: intent-narration
+// like "Let me check the database" or "I'm reviewing the history" carries no
+// inability marker, so it is never surfaced and a pre-tool thought can't reach
+// the user as a fake "refusal" (#9874 item 3).
+const REFUSAL_MARKERS = [
+	/\b(?:can(?:'|no)?t|cannot)\b/i,
+	/\b(?:un)?able to\b/i,
+	/\bdon'?t (?:have|see)\b/i,
+	/\bno (?:access|way|ability|matching|such|suitable)\b/i,
+	/\bnot (?:available|possible|supported|something I can|wired|connected|set up)\b/i,
+	/\bisn'?t (?:available|possible|supported|something I can)\b/i,
+	/\bthere(?:'s| is| are) (?:no|nothing)\b/i,
+];
+
+// In-flight / imminent action narration — the confabulation shape ("Let me look
+// that up", "I'm pulling up your messages", "please hold"). Rejected even when a
+// refusal marker co-occurs, because once this iteration ends no further tool
+// work happens, so any "I'm doing X now" is a false promise.
+const IN_FLIGHT_ACTION_CLAIM = [
+	/\blet me\b/i,
+	/\bI(?:'ll| will| am going to|'m going to|'m gonna| am gonna)\b/i,
+	/\bI'?m\s+(?:checking|fetching|searching|looking|pulling|reviewing|gathering|working|getting|grabbing|loading|digging|querying)\b/i,
+	/\b(?:one|just a)\s+(?:sec|second|moment|min|minute)\b/i,
+	/\bplease (?:hold|wait)\b/i,
+	/\b(?:be right back|brb|hang on)\b/i,
+];
+
+// Gate for surfacing native planner free-text as a forced-tool-exhaustion
+// refusal (#9874 item 3). Returns the sanitized message ONLY when it POSITIVELY
+// reads as an inability statement (REFUSAL_MARKERS) and carries no leaked
+// tool-call/reasoning markup (isUnsafeUserVisibleText), no deliberation
+// (looksLikePreToolThought), and no in-flight action claim (IN_FLIGHT). When the
+// text is ambiguous (e.g. a bare native "Let me check…" thought) it returns
+// undefined and the caller falls back to its generic apology — the safe
+// direction. Stricter than userSafeFinalMessage's candidate check, which runs on
+// text already known to be user-directed.
+function userSafeRefusalCandidate(
+	message: string | undefined,
+): string | undefined {
+	const candidate = sanitizePlannerMessage(message);
+	if (!candidate) return undefined;
+	if (!REFUSAL_MARKERS.some((pattern) => pattern.test(candidate))) {
+		return undefined;
+	}
+	if (isUnsafeUserVisibleText(candidate)) return undefined;
+	if (looksLikePreToolThought(candidate)) return undefined;
+	if (IN_FLIGHT_ACTION_CLAIM.some((pattern) => pattern.test(candidate))) {
+		return undefined;
+	}
+	return candidate;
 }
 
 function preferRecommendedToolCall(

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -41,7 +41,10 @@ import {
 import { retrieveActions } from "../runtime/action-retrieval";
 import { resolveActionRolePolicyRole } from "../runtime/action-role-policy";
 import { tierActionResults } from "../runtime/action-tiering";
-import { applyAddressedTo } from "../runtime/addressed-to";
+import {
+	addresseeIsNonOwnerBot,
+	applyAddressedTo,
+} from "../runtime/addressed-to";
 import { normalizeTopics } from "../runtime/builtin-field-evaluators";
 import {
 	filterByContextGate,
@@ -5922,7 +5925,30 @@ export async function runV5MessageRuntimeStage1(args: {
 			messageHandler.plan.contexts,
 			availableContexts,
 		);
-		const route = routeMessageHandlerOutput(messageHandler);
+		// #9874 item 1: suppress the simple→requiresTool promotion when this turn
+		// is bot-to-bot crosstalk addressed to a non-owner bot — the agent is
+		// overhearing, not being asked to act, so forcing a tool fabricates a
+		// phantom task. Cheap-gated: only resolve addressees when a promotion could
+		// actually fire (requiresTool / candidateActions) and the message carries
+		// explicit addressees.
+		const mayPromoteToTool =
+			messageHandler.plan.requiresTool === true ||
+			(messageHandler.plan.candidateActions?.length ?? 0) > 0;
+		// Fail SAFE on any resolution error (DB hiccup in getEntitiesForRoom /
+		// getAgent): a transient failure must NOT convert a normal turn into the
+		// generic failure reply — it just means "don't suppress", matching the
+		// conservative contract and the fire-and-forget addressee handling above.
+		const suppressToolPromotion =
+			mayPromoteToTool && addressedTo.length > 0
+				? await addresseeIsNonOwnerBot({
+						runtime: args.runtime,
+						message: args.message,
+						addressedTo,
+					}).catch(() => false)
+				: false;
+		const route = routeMessageHandlerOutput(messageHandler, {
+			suppressToolPromotion,
+		});
 		if (route.type === "ignored" || route.type === "stopped") {
 			return {
 				kind: "terminal",

--- a/packages/core/src/types/primitives.ts
+++ b/packages/core/src/types/primitives.ts
@@ -114,6 +114,15 @@ export interface Content {
 	/** UUID of parent message if this is a reply/thread */
 	inReplyTo?: UUID;
 
+	/**
+	 * Full, untruncated text of the message THIS message reacted to. Connectors
+	 * that record an emoji reaction as a short display stub in `text` (e.g.
+	 * `*Added 👍 to: "first 50 chars…"*`) set this so context-building can feed
+	 * the planner the complete reacted-to statement instead of a truncated
+	 * fragment it would otherwise back-rationalize into a phantom task (#9874).
+	 */
+	reactedMessageText?: string;
+
 	/** Array of media attachments */
 	attachments?: Media[];
 

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -499,6 +499,7 @@ export const formatMessages = ({
 		}
 
 		const messageText = (message.content as Content).text;
+		const reactedMessageText = (message.content as Content).reactedMessageText;
 		const messageActions = (message.content as Content).actions;
 		const messageThought = (message.content as Content).thought;
 		const foundEntity = entityById.get(message.entityId);
@@ -562,6 +563,13 @@ export const formatMessages = ({
 		const textString = messageText
 			? `${timestampString} ${formattedName}: ${messageText}`
 			: null;
+		// A reaction message's `text` is a short stub that truncates the reacted-to
+		// content; surface the full original so the planner reads the complete
+		// statement and does not back-rationalize a truncated fragment (#9874).
+		const reactedContextString =
+			typeof reactedMessageText === "string" && reactedMessageText.trim()
+				? `(reacted-to message in full: "${reactedMessageText.trim()}")`
+				: null;
 		const actionString =
 			messageActions && messageActions.length > 0
 				? `${
@@ -571,6 +579,7 @@ export const formatMessages = ({
 
 		const messageString = [
 			textString,
+			reactedContextString,
 			thoughtString,
 			actionString,
 			attachmentString,

--- a/packages/shared/src/config/boot-config-store.ts
+++ b/packages/shared/src/config/boot-config-store.ts
@@ -61,6 +61,8 @@ export interface AppBootConfig {
   cloudApiBase?: string;
   vrmAssets?: BundledVrmAsset[];
   firstRunStyles?: unknown[];
+  /** Default-on shared cloud tier; false is the dedicated-direct kill-switch. */
+  preferSharedCloudTier?: boolean;
   characterCatalog?: CharacterCatalogData;
   envAliases?: readonly (readonly [string, string])[];
   clientMiddleware?: ClientMiddleware;
@@ -70,6 +72,7 @@ export interface AppBootConfig {
 export const DEFAULT_BOOT_CONFIG: AppBootConfig = {
   branding: {},
   cloudApiBase: "https://elizacloud.ai",
+  preferSharedCloudTier: true,
 };
 
 const BOOT_CONFIG_STORE_KEY = Symbol.for("elizaos.app.boot-config");

--- a/packages/ui/src/cloud/connectors/discord-gateway-connection.tsx
+++ b/packages/ui/src/cloud/connectors/discord-gateway-connection.tsx
@@ -75,7 +75,9 @@ function normalizeCharacters(
   });
 }
 
-async function fetchRuntimeCharacters(signal?: AbortSignal): Promise<Character[]> {
+async function fetchRuntimeCharacters(
+  signal?: AbortSignal,
+): Promise<Character[]> {
   const data = await api<{ agents?: Array<{ id?: unknown; name?: unknown }> }>(
     "/api/agents",
     { signal, skipAuth: true },

--- a/packages/ui/src/components/settings/settings-sections.ts
+++ b/packages/ui/src/components/settings/settings-sections.ts
@@ -20,6 +20,10 @@ import {
   Webhook,
 } from "lucide-react";
 import type { ComponentType } from "react";
+import {
+  CLOUD_SETTINGS_GROUP_ID,
+  registerSettingsGroup,
+} from "../../cloud/settings/cloud-settings-group";
 import { ReleaseCenterView } from "../pages/ReleaseCenterView";
 import { AdvancedSection } from "./AdvancedSection";
 import { AppearanceSettingsSection } from "./AppearanceSettingsSection";
@@ -36,10 +40,6 @@ import { RemotePluginHostSection } from "./RemotePluginHostSection";
 import { RuntimeSettingsSection } from "./RuntimeSettingsSection";
 import { SecretsManagerSection } from "./SecretsManagerSection";
 import { SecuritySettingsSection } from "./SecuritySettingsSection";
-import {
-  CLOUD_SETTINGS_GROUP_ID,
-  registerSettingsGroup,
-} from "../../cloud/settings/cloud-settings-group";
 import {
   SETTINGS_GROUP_LABEL,
   SETTINGS_GROUP_ORDER,

--- a/packages/ui/src/config/boot-config-store.test.ts
+++ b/packages/ui/src/config/boot-config-store.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_BOOT_CONFIG } from "./boot-config-store";
+
+describe("DEFAULT_BOOT_CONFIG", () => {
+  it("defaults preferSharedCloudTier on so handoff is the default create path", () => {
+    expect(DEFAULT_BOOT_CONFIG.preferSharedCloudTier).toBe(true);
+  });
+
+  it("keeps preferSharedCloudTier overridable as a kill-switch", () => {
+    const killSwitched = {
+      ...DEFAULT_BOOT_CONFIG,
+      preferSharedCloudTier: false,
+    };
+
+    expect(killSwitched.preferSharedCloudTier).toBe(false);
+  });
+});

--- a/packages/ui/src/config/boot-config-store.ts
+++ b/packages/ui/src/config/boot-config-store.ts
@@ -298,13 +298,9 @@ export interface AppBootConfig {
     naturalLanguage?: boolean;
   };
   /**
-   * Phase-0 cloud tier flip (MVP). When true, the first-run cloud-create path
-   * requests a SHARED (container-free, in-Worker) agent so the user chats
-   * instantly with no provisioning wait, instead of the default DEDICATED
-   * always-on container. Off by default: the seamless shared→dedicated handoff
-   * is not built yet, so making everyone shared would strand them there — this
-   * flag is for the instant-shared demo only. When false the create request is
-   * byte-identical to the dedicated path (sends `alwaysOn: true`).
+   * Prefer the instant shared cloud tier during first-run, then hand off to a
+   * dedicated agent in the background. Default on; set false as a kill-switch to
+   * return first-run cloud creation to the dedicated-direct path.
    */
   preferSharedCloudTier?: boolean;
   /** Character catalog data — replaces cross-package import of catalog.json. */
@@ -325,6 +321,7 @@ export interface AppBootConfig {
 export const DEFAULT_BOOT_CONFIG: AppBootConfig = {
   branding: {},
   cloudApiBase: "https://elizacloud.ai",
+  preferSharedCloudTier: true,
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/ui/src/first-run/use-first-run-controller.test.tsx
+++ b/packages/ui/src/first-run/use-first-run-controller.test.tsx
@@ -2,6 +2,11 @@
 
 import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  CLOUD_HANDOFF_PHASE_EVENT,
+  type CloudHandoffPhaseDetail,
+  dispatchCloudHandoffRetry,
+} from "../events";
 
 type ActiveServerArgs = {
   kind: "cloud";
@@ -17,10 +22,26 @@ type ActiveServerRecord = {
   accessToken?: string;
 };
 
+type CloudCompatAgentCreateResult = {
+  success: boolean;
+  data: {
+    agentId: string;
+    agentName: string;
+    jobId: string;
+    status: string;
+    nodeId: string | null;
+    message: string;
+  };
+};
+
+type CreateCloudCompatAgent = (opts?: {
+  [key: string]: unknown;
+}) => Promise<CloudCompatAgentCreateResult>;
+
 const mocks = vi.hoisted(() => ({
   cloudAuthenticated: false,
-  // Phase-1 shared-tier flag (boot-config). Default off → byte-identical to
-  // pre-Phase-1; the create-both test flips it on to exercise the handoff arm.
+  // Phase-1 shared-tier flag (boot-config). Most tests hold it off to exercise
+  // the kill-switch; shared-handoff tests flip it on explicitly.
   preferSharedCloudTier: false,
   addAgentProfile: vi.fn(() => ({
     id: "profile-shared-1",
@@ -98,7 +119,7 @@ const mocks = vi.hoisted(() => ({
   // Phase-1 create-both: when the shared-tier flag is on, the controller
   // provisions a SEPARATE dedicated agent (a plain create, no preferSharedTier)
   // as the handoff target.
-  createCloudCompatAgent: vi.fn(async () => ({
+  createCloudCompatAgent: vi.fn<CreateCloudCompatAgent>(async () => ({
     success: true as const,
     data: {
       agentId: "dedicated-1",
@@ -267,12 +288,27 @@ vi.mock("./voice-readiness", () => ({
 
 import { useFirstRunController } from "./use-first-run-controller";
 
+async function flushHandoffPromises(): Promise<void> {
+  for (let i = 0; i < 6; i++) await Promise.resolve();
+}
+
 describe("useFirstRunController cloud first-run", () => {
   beforeEach(() => {
     localStorage.clear();
     mocks.cloudAuthenticated = false;
     mocks.preferSharedCloudTier = false;
-    mocks.createCloudCompatAgent.mockClear();
+    mocks.createCloudCompatAgent.mockReset();
+    mocks.createCloudCompatAgent.mockImplementation(async () => ({
+      success: true as const,
+      data: {
+        agentId: "dedicated-1",
+        agentName: "Demo Agent",
+        jobId: "",
+        status: "provisioning",
+        nodeId: null,
+        message: "Agent created",
+      },
+    }));
     mocks.addAgentProfile.mockClear();
     mocks.completeFirstRun.mockClear();
     // mockReset (not mockClear): individual tests install custom
@@ -321,7 +357,16 @@ describe("useFirstRunController cloud first-run", () => {
       bridgeUrl: null,
       created: true,
     }));
-    mocks.startCloudAgentHandoff.mockClear();
+    mocks.startCloudAgentHandoff.mockReset();
+    mocks.startCloudAgentHandoff.mockImplementation(
+      async (_args: {
+        onSwitch: (containerBase: string) => void;
+        [key: string]: unknown;
+      }) => ({
+        status: "switched-empty" as const,
+        imported: 0,
+      }),
+    );
     mocks.removeAgentProfile.mockClear();
     mocks.deleteSharedBridgeAgent.mockClear();
     mocks.silentlyRepointToDedicated.mockClear();
@@ -347,6 +392,7 @@ describe("useFirstRunController cloud first-run", () => {
 
     await act(async () => {
       await result.current.finishRuntime();
+      await flushHandoffPromises();
     });
 
     expect(mocks.handleCloudLogin).toHaveBeenCalledTimes(1);
@@ -419,12 +465,65 @@ describe("useFirstRunController cloud first-run", () => {
     expect(handoffArgs?.dedicatedAgentId).not.toBe(handoffArgs?.agentId);
   });
 
+  it("surfaces dedicated create failure as a retryable handoff failure", async () => {
+    mocks.preferSharedCloudTier = true;
+    mocks.createCloudCompatAgent.mockResolvedValueOnce({
+      success: false,
+      data: {
+        agentId: "",
+        agentName: "Demo Agent",
+        jobId: "",
+        status: "error",
+        nodeId: null,
+        message: "out of credits",
+      },
+    });
+    const phases: CloudHandoffPhaseDetail[] = [];
+    const onPhase = (event: Event) => {
+      phases.push((event as CustomEvent<CloudHandoffPhaseDetail>).detail);
+    };
+    window.addEventListener(CLOUD_HANDOFF_PHASE_EVENT, onPhase);
+    const { result } = renderHook(() => useFirstRunController());
+
+    try {
+      await act(async () => {
+        await result.current.finishRuntime();
+        await flushHandoffPromises();
+      });
+
+      expect(mocks.completeFirstRun).toHaveBeenCalledWith("chat", {
+        launchCompanionOverlay: true,
+      });
+      expect(mocks.startCloudAgentHandoff).not.toHaveBeenCalled();
+      expect(phases).toContainEqual({
+        agentId: "agent-1",
+        phase: "migrating",
+      });
+      expect(phases).toContainEqual({
+        agentId: "agent-1",
+        phase: "failed",
+        error: "out of credits",
+      });
+
+      await act(async () => {
+        dispatchCloudHandoffRetry({ agentId: "agent-1" });
+        await flushHandoffPromises();
+      });
+
+      expect(mocks.createCloudCompatAgent).toHaveBeenCalledTimes(2);
+      expect(mocks.startCloudAgentHandoff).toHaveBeenCalledTimes(1);
+    } finally {
+      window.removeEventListener(CLOUD_HANDOFF_PHASE_EVENT, onPhase);
+    }
+  });
+
   it("PR3: the handoff onSwitch re-points SILENTLY (no switchAgentProfile, no draft wipe, no shell flash)", async () => {
     mocks.preferSharedCloudTier = true;
     const { result } = renderHook(() => useFirstRunController());
 
     await act(async () => {
       await result.current.finishRuntime();
+      await flushHandoffPromises();
     });
 
     // Grab the onSwitch the controller armed the supervisor with, and fire it
@@ -460,9 +559,7 @@ describe("useFirstRunController cloud first-run", () => {
 
     await act(async () => {
       await result.current.finishRuntime();
-      // Let runCloudAgentHandoff's start().then(onSwitchSucceeded) settle.
-      await Promise.resolve();
-      await Promise.resolve();
+      await flushHandoffPromises();
     });
 
     expect(mocks.removeAgentProfile).toHaveBeenCalledTimes(1);
@@ -535,9 +632,9 @@ describe("useFirstRunController cloud first-run", () => {
   });
 
   it("flag OFF: a created shared agent neither provisions a dedicated agent nor arms the handoff", async () => {
-    // Phase-1 is gated on the boot-config flag. With it OFF (the default), even
+    // Phase-1 is gated on the boot-config flag. With it OFF (kill-switch), even
     // a shared-base create stays byte-identical to pre-Phase-1: no second
-    // (dedicated) create, no handoff. The demo turns the flag on.
+    // (dedicated) create, no handoff.
     mocks.preferSharedCloudTier = false;
     mocks.selectOrProvisionCloudAgent.mockResolvedValue({
       agentId: "agent-1",

--- a/packages/ui/src/first-run/use-first-run-controller.ts
+++ b/packages/ui/src/first-run/use-first-run-controller.ts
@@ -772,9 +772,8 @@ export function useFirstRunController(): FirstRunController {
         bio,
         ...(opts.preferAgentId ? { preferAgentId: opts.preferAgentId } : {}),
         ...(opts.forceCreate ? { forceCreate: true } : {}),
-        // Phase-0 MVP: when the boot-config flag is on, request a SHARED
-        // (instant, container-free) agent on create instead of a dedicated
-        // always-on container. Default off → unchanged dedicated behavior.
+        // Default-on shared tier: request an instant container-free bridge on
+        // create, unless the boot config kill-switch returns to dedicated-direct.
         ...(getBootConfig().preferSharedCloudTier
           ? { preferSharedTier: true }
           : {}),
@@ -826,8 +825,9 @@ export function useFirstRunController(): FirstRunController {
       // supervisor to poll IT, copy the conversation across, and switch over
       // once it's running. Without that separate dedicated target the supervisor
       // would poll the shared agent forever and time out (the reconciliation's
-      // "the branch fires but never resolves"). Best-effort: on failure the user
-      // stays on the (working) shared adapter.
+      // "the branch fires but never resolves"). Dedicated creation is inside the
+      // retryable handoff thunk so create failures surface as `failed` and the
+      // banner's Retry button re-runs the whole create→handoff path.
       //
       // Flag OFF → `preferSharedTier` was never sent, so `selectedAgent` is the
       // dedicated agent itself (not a shared base) and this branch is skipped:
@@ -838,12 +838,12 @@ export function useFirstRunController(): FirstRunController {
         isDirectCloudSharedAgentBase(cloudAgentApiBase)
       ) {
         const sharedAgentId = selectedAgent.agentId;
-        // Provision the dedicated agent ONCE, here, so a handoff retry re-arms
-        // the supervisor against the same dedicated id instead of minting a new
-        // dedicated agent each time. A plain create (no `preferSharedTier`)
-        // yields the DEDICATED always-on container — the migration target.
-        const dedicated = await client
-          .createCloudCompatAgent({
+        const cloudApiBase =
+          getBootConfig().cloudApiBase || "https://www.elizacloud.ai";
+        const createDedicatedHandoffTarget = async (): Promise<string> => {
+          // A plain create (no `preferSharedTier`) yields the DEDICATED
+          // always-on container — the migration target.
+          const dedicated = await client.createCloudCompatAgent({
             agentName: name,
             ...(bio.length ? { agentConfig: { bio } } : {}),
             // Bypass the backend reuse guard: the org already has a non-terminal
@@ -852,79 +852,79 @@ export function useFirstRunController(): FirstRunController {
             // the handoff probe then polls the shared base (which never grows a
             // dedicated container) and times out, so the switch never fires.
             forceCreate: true,
-          })
-          .catch(() => null);
-        const dedicatedAgentId =
-          dedicated?.success && dedicated.data.agentId
-            ? dedicated.data.agentId
-            : null;
-        if (dedicatedAgentId) {
-          // Surface the handoff lifecycle (migrating → switched | timed-out |
-          // failed) as typed phase events instead of swapping silently, and
-          // keep a `timed-out`/`failed` retryable rather than a silent permanent
-          // fallback. The supervisor's import is idempotent, so a retry just
-          // re-runs the same call against the same dedicated agent.
-          const cloudApiBase =
-            getBootConfig().cloudApiBase || "https://www.elizacloud.ai";
-          runCloudAgentHandoff(
-            sharedAgentId,
-            () =>
-              client.startCloudAgentHandoff({
-                // Source: the shared agent the user is chatting on right now.
-                agentId: sharedAgentId,
-                sharedApiBase: cloudAgentApiBase,
-                // The shared adapter keeps one canonical conversation per agent id.
-                conversationId: sharedAgentId,
-                // Target: the separate dedicated agent we just kicked off. The
-                // supervisor polls THIS record for its container base.
-                dedicatedAgentId,
+          });
+          if (dedicated.success && dedicated.data.agentId) {
+            return dedicated.data.agentId;
+          }
+          throw new Error(
+            dedicated.success
+              ? "Dedicated agent creation returned no agent id."
+              : (dedicated.data.message ?? "Dedicated agent creation failed."),
+          );
+        };
+        // Surface the handoff lifecycle (migrating → switched | timed-out |
+        // failed) as typed phase events instead of swapping silently, and keep a
+        // `timed-out`/`failed` retryable rather than a silent permanent fallback.
+        runCloudAgentHandoff(
+          sharedAgentId,
+          async () => {
+            const dedicatedAgentId = await createDedicatedHandoffTarget();
+            return await client.startCloudAgentHandoff({
+              // Source: the shared agent the user is chatting on right now.
+              agentId: sharedAgentId,
+              sharedApiBase: cloudAgentApiBase,
+              // The shared adapter keeps one canonical conversation per agent id.
+              conversationId: sharedAgentId,
+              // Target: the separate dedicated agent we just kicked off. The
+              // supervisor polls THIS record for its container base.
+              dedicatedAgentId,
+              cloudApiBase,
+              authToken,
+              // The invisible switch (PR3). switchAgentProfile() would
+              // clearAllChatDrafts() (wiping the composer) and dispatch
+              // SWITCH_AGENT (re-entering the coordinator → full-screen
+              // <StartupScreen/> + dropped WS). The handoff instead re-points
+              // SILENTLY in place: persist the dedicated profile, seamlessly
+              // swap the API/WS base (no visible disconnect), keep the same
+              // conversation id mounted, and DON'T touch drafts or the
+              // coordinator. The transcript was already copied to the dedicated
+              // agent, so the chat surface stays live throughout the swap.
+              onSwitch: (containerBase) => {
+                silentlyRepointToDedicated({
+                  containerBase,
+                  authToken,
+                  dedicatedAgentId,
+                });
+              },
+            });
+          },
+          // Gated on switch-SUCCESS (`switched`/`switched-empty`): only once
+          // the user is on the dedicated and the transcript was copied is the
+          // transient shared bridge safe to delete. On `timed-out`/`failed`
+          // this never runs, so the user keeps the working shared bridge (and
+          // their conversation). Fire-and-forget: a failed delete just leaks a
+          // shared row — never blocks the (already switched) user.
+          () => {
+            // Drop the now-dead shared profile from the local registry. The
+            // switch already activated the dedicated profile (silent-repoint's
+            // addAgentProfile), so removing the shared one by its captured id
+            // can't touch the active dedicated profile — it just stops the
+            // orphaned `cloud:<sharedId>` row from lingering in the picker.
+            removeAgentProfile(sharedAgentProfile.id);
+            void client
+              .deleteSharedBridgeAgent(sharedAgentId, {
                 cloudApiBase,
                 authToken,
-                // The invisible switch (PR3). switchAgentProfile() would
-                // clearAllChatDrafts() (wiping the composer) and dispatch
-                // SWITCH_AGENT (re-entering the coordinator → full-screen
-                // <StartupScreen/> + dropped WS). The handoff instead re-points
-                // SILENTLY in place: persist the dedicated profile, seamlessly
-                // swap the API/WS base (no visible disconnect), keep the same
-                // conversation id mounted, and DON'T touch drafts or the
-                // coordinator. The transcript was already copied to the dedicated
-                // agent, so the chat surface stays live throughout the swap.
-                onSwitch: (containerBase) => {
-                  silentlyRepointToDedicated({
-                    containerBase,
-                    authToken,
-                    dedicatedAgentId,
-                  });
-                },
-              }),
-            // Gated on switch-SUCCESS (`switched`/`switched-empty`): only once
-            // the user is on the dedicated and the transcript was copied is the
-            // transient shared bridge safe to delete. On `timed-out`/`failed`
-            // this never runs, so the user keeps the working shared bridge (and
-            // their conversation). Fire-and-forget: a failed delete just leaks a
-            // shared row — never blocks the (already switched) user.
-            () => {
-              // Drop the now-dead shared profile from the local registry. The
-              // switch already activated the dedicated profile (silent-repoint's
-              // addAgentProfile), so removing the shared one by its captured id
-              // can't touch the active dedicated profile — it just stops the
-              // orphaned `cloud:<sharedId>` row from lingering in the picker.
-              removeAgentProfile(sharedAgentProfile.id);
-              void client
-                .deleteSharedBridgeAgent(sharedAgentId, {
-                  cloudApiBase,
-                  authToken,
-                })
-                .then((res) => {
-                  if (!res.success) {
-                    console.warn(
-                      `[useFirstRunController] shared bridge delete failed (leaked row ${sharedAgentId}): ${res.error ?? "unknown"}`,
-                    );
-                  }
-                });
-            },
-          );
-        }
+              })
+              .then((res) => {
+                if (!res.success) {
+                  console.warn(
+                    `[useFirstRunController] shared bridge delete failed (leaked row ${sharedAgentId}): ${res.error ?? "unknown"}`,
+                  );
+                }
+              });
+          },
+        );
       }
     },
     [completeFirstRun, uiLanguage],

--- a/packages/ui/src/state/useFirstRunCallbacks.ts
+++ b/packages/ui/src/state/useFirstRunCallbacks.ts
@@ -674,11 +674,10 @@ export function useFirstRunCallbacks(deps: FirstRunCallbacksDeps) {
             name: firstRunName,
             bio: style?.bio ?? ["An autonomous AI agent."],
             ...(preferAgentId ? { preferAgentId } : {}),
-            // Phase-0 MVP: boot-config flag → request a SHARED (instant,
-            // container-free) agent on create. Default off → dedicated, unchanged.
-            ...(getBootConfig().preferSharedCloudTier
-              ? { preferSharedTier: true }
-              : {}),
+            // This legacy callback path does not own the shared→dedicated
+            // handoff supervisor; keep it dedicated-direct even when
+            // preferSharedCloudTier is default-on. The controller path owns the
+            // shared bridge and background handoff.
             onProgress: () => {},
           });
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/progress-cadence.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/progress-cadence.test.ts
@@ -33,6 +33,7 @@
 import {
   _resetBuildVariantForTests,
   isLocalCodeExecutionAllowed,
+  ModelType,
 } from "@elizaos/core";
 import {
   afterEach,
@@ -47,9 +48,37 @@ import { createAgentOrchestratorPlugin } from "../../src/index.js";
 import { AcpService } from "../../src/services/acp-service.js";
 
 type SessionHandler = (sessionId: string, event: string, data: unknown) => void;
+type TimerApiWithAsyncDrain = typeof vi & {
+  runAllTimersAsync?: () => Promise<void>;
+  advanceTimersByTimeAsync?: (ms: number) => Promise<void>;
+};
 
 const ROOM = "11111111-2222-3333-4444-555555555555" as const;
 const SOURCE = "discord";
+
+async function drainHookRegistrationTimers(): Promise<void> {
+  const timerApi = vi as TimerApiWithAsyncDrain;
+  if (typeof timerApi.runAllTimersAsync === "function") {
+    await timerApi.runAllTimersAsync();
+    return;
+  }
+  vi.runAllTimers();
+  for (let i = 0; i < 10; i++) {
+    await Promise.resolve();
+  }
+}
+
+async function advanceTimersByTime(ms: number): Promise<void> {
+  const timerApi = vi as TimerApiWithAsyncDrain;
+  if (typeof timerApi.advanceTimersByTimeAsync === "function") {
+    await timerApi.advanceTimersByTimeAsync(ms);
+    return;
+  }
+  vi.advanceTimersByTime(ms);
+  for (let i = 0; i < 10; i++) {
+    await Promise.resolve();
+  }
+}
 
 // Env keys the progress policy + gating read. Saved/restored per test so modes
 // don't leak between cases and the plugin always registers in code-exec mode.
@@ -175,6 +204,11 @@ async function buildHookedRuntime(
 
   const runtime = {
     agentId: "agent-0000-0000-0000-000000000000",
+    character: {
+      name: "TestBot",
+      bio: ["a concise, helpful test assistant"],
+      style: { chat: ["casual", "terse"] },
+    },
     logger,
     getSetting: () => undefined,
     getService: (type: string) => services.get(type) ?? null,
@@ -202,9 +236,11 @@ async function buildHookedRuntime(
 
   await plugin.init?.({}, runtime);
   // init() schedules the hook registration on a setTimeout(0) macrotask whose
-  // body awaits getServiceLoadPromise; runAllTimersAsync drains the timer AND
-  // the awaited microtasks so the hook subscribes before we return.
-  await vi.runAllTimersAsync();
+  // body awaits getServiceLoadPromise; drain the timer AND the awaited
+  // microtasks so the hook subscribes before we return. Bun's direct test
+  // runner does not expose Vitest's runAllTimersAsync, so the helper falls back
+  // to a bounded microtask drain.
+  await drainHookRegistrationTimers();
 
   if (sessionHandlers.length === 0) {
     throw new Error(
@@ -246,7 +282,7 @@ function seedSession(
 /**
  * Fire one session event and let the hook's async body settle. The hook handler
  * is fire-and-forget async with a chain of plain awaits (getSession → emitProgress
- * → sendMessageToTarget). advanceTimersByTimeAsync drains pending timers AND the
+ * → sendMessageToTarget). advanceTimersByTime drains pending timers AND the
  * awaited microtasks between them; a few extra microtask turns flush the rest.
  */
 async function fire(
@@ -256,7 +292,7 @@ async function fire(
   data: unknown = {},
 ): Promise<void> {
   rt.emit(sessionId, event, data);
-  await vi.advanceTimersByTimeAsync(0);
+  await advanceTimersByTime(0);
   for (let i = 0; i < 8; i++) await Promise.resolve();
 }
 
@@ -300,11 +336,11 @@ describe("emitProgress routing ladder + cadence", () => {
 
     // After the 1.5s silence-flush window, flushMessageBuffer calls emitProgress
     // — but the 15s delayMs debounce holds the first post back.
-    await vi.advanceTimersByTimeAsync(1_600);
+    await advanceTimersByTime(1_600);
     expect(rt.sendMessageToTarget).not.toHaveBeenCalled();
 
     // Crossing delayMs releases exactly one buffered post.
-    await vi.advanceTimersByTimeAsync(15_000);
+    await advanceTimersByTime(15_000);
     expect(rt.sendMessageToTarget).toHaveBeenCalledTimes(1);
 
     const [, content] = rt.sendMessageToTarget.mock.calls[0];
@@ -331,7 +367,7 @@ describe("emitProgress routing ladder + cadence", () => {
       toolCall: { id: "t1", kind: "edit", rawInput: { file_path: "/a/b.ts" } },
     });
     // Drain the silence-flush + any heartbeat windows.
-    await vi.advanceTimersByTimeAsync(60_000);
+    await advanceTimersByTime(60_000);
 
     expect(rt.sendMessageToTarget).not.toHaveBeenCalled();
     expect(rt.editMessageOnTarget).not.toHaveBeenCalled();
@@ -346,21 +382,106 @@ describe("emitProgress routing ladder + cadence", () => {
     const rt = await buildHookedRuntime([{ source: SOURCE, capabilities: [] }]);
     seedSession(rt, "s-ack", "ack-task");
 
+    // The spawn ack is the model's own one-line acknowledgement (in-voice,
+    // in-language) — not a hardcoded literal. The mocked model returns a fixed
+    // line; the posted ack is that line, sanitized.
+    rt.useModel.mockResolvedValueOnce("On it — starting now.");
+
     // First non-terminal event triggers the single spawn ACK (delayMs is forced
     // to 0 for ack mode, so it posts immediately).
     await fire(rt, "s-ack", "ready");
     expect(rt.sendMessageToTarget).toHaveBeenCalledTimes(1);
     expect(
       (rt.sendMessageToTarget.mock.calls[0][1] as { text: string }).text,
-    ).toBe("working on it now.");
+    ).toBe("On it — starting now.");
+    // The ack is generated with the small text model.
+    expect(rt.useModel).toHaveBeenCalledWith(
+      ModelType.TEXT_SMALL,
+      expect.objectContaining({
+        system: expect.stringContaining("TestBot"),
+        prompt: expect.any(String),
+      }),
+    );
 
     // Subsequent events (narration, tools) must NOT add more acks.
     await fire(rt, "s-ack", "message", { text: "still working" });
     await fire(rt, "s-ack", "tool_running", {
       toolCall: { id: "t1", kind: "read", rawInput: { file_path: "/x.ts" } },
     });
-    await vi.advanceTimersByTimeAsync(5_000);
+    await advanceTimersByTime(5_000);
     expect(rt.sendMessageToTarget).toHaveBeenCalledTimes(1);
+
+    await rt.dispose();
+  });
+
+  it("ack mode feeds the task text to the model so it can match the user's language", async () => {
+    process.env.ACPX_PROGRESS_MODE = "ack";
+    const rt = await buildHookedRuntime([{ source: SOURCE, capabilities: [] }]);
+    // initialTask carries the real user request — the language signal handed to
+    // the model (here: French). The model itself is mocked, but we assert the
+    // request reached it so the in-language behavior is wired.
+    rt.sessions.set("s-fr", {
+      status: "running",
+      metadata: {
+        source: SOURCE,
+        roomId: ROOM,
+        label: "build-site",
+        initialTask: "construis-moi un site vitrine en français",
+      },
+    });
+    rt.useModel.mockResolvedValueOnce("C'est parti.");
+
+    await fire(rt, "s-fr", "ready");
+    expect(rt.sendMessageToTarget).toHaveBeenCalledTimes(1);
+    expect(
+      (rt.sendMessageToTarget.mock.calls[0][1] as { text: string }).text,
+    ).toBe("C'est parti.");
+    const [, params] = rt.useModel.mock.calls[0] as [
+      unknown,
+      { prompt: string },
+    ];
+    expect(params.prompt).toContain(
+      "construis-moi un site vitrine en français",
+    );
+
+    await rt.dispose();
+  });
+
+  it("ack mode falls back to a short literal when the model call fails", async () => {
+    process.env.ACPX_PROGRESS_MODE = "ack";
+    const rt = await buildHookedRuntime([{ source: SOURCE, capabilities: [] }]);
+    seedSession(rt, "s-ack-fail", "ack-task");
+    rt.useModel.mockRejectedValueOnce(new Error("no model registered"));
+
+    await fire(rt, "s-ack-fail", "ready");
+    // Never silence: the ack still posts exactly once, using the fallback.
+    expect(rt.sendMessageToTarget).toHaveBeenCalledTimes(1);
+    expect(
+      (rt.sendMessageToTarget.mock.calls[0][1] as { text: string }).text,
+    ).toBe("On it.");
+
+    await rt.dispose();
+  });
+
+  it("ack mode suppresses a delayed model ack after a terminal event", async () => {
+    process.env.ACPX_PROGRESS_MODE = "ack";
+    const rt = await buildHookedRuntime([{ source: SOURCE, capabilities: [] }]);
+    seedSession(rt, "s-late-ack", "ack-task");
+
+    let resolveAck!: (value: string) => void;
+    const pendingAck = new Promise<string>((resolve) => {
+      resolveAck = resolve;
+    });
+    rt.useModel.mockReturnValueOnce(pendingAck);
+
+    await fire(rt, "s-late-ack", "ready");
+    expect(rt.sendMessageToTarget).not.toHaveBeenCalled();
+
+    await fire(rt, "s-late-ack", "task_complete", { response: "done" });
+    resolveAck("On it late.");
+    for (let i = 0; i < 8; i++) await Promise.resolve();
+
+    expect(rt.sendMessageToTarget).not.toHaveBeenCalled();
 
     await rt.dispose();
   });
@@ -409,7 +530,7 @@ describe("emitProgress routing ladder + cadence", () => {
     // the only thing standing between the retry and a second "working on it now."
     // ack is the `isVerifyRetrySpawn` gate in registerProgressHook. Advance well
     // past the room-dedup window so this asserts the guard, not the room-dedup.
-    await vi.advanceTimersByTimeAsync(120_000);
+    await advanceTimersByTime(120_000);
     rt.sessions.set("s-retry", {
       status: "running",
       metadata: {
@@ -444,7 +565,7 @@ describe("emitProgress routing ladder + cadence", () => {
     // under the same label, past the room-dedup window. The label cache — now
     // populated because the first send returned a platformId — reuses the cached
     // main message and skips the network send entirely.
-    await vi.advanceTimersByTimeAsync(120_000);
+    await advanceTimersByTime(120_000);
     rt.sessions.set("s-respawn", {
       status: "running",
       metadata: { source: SOURCE, roomId: ROOM, label: "build-site" },
@@ -479,7 +600,7 @@ describe("emitProgress routing ladder + cadence", () => {
     await fire(rt, "s-thread", "message", {
       text: "Implementing the feature.",
     });
-    await vi.advanceTimersByTimeAsync(1_600); // silence-flush window
+    await advanceTimersByTime(1_600); // silence-flush window
     for (let i = 0; i < 8; i++) await Promise.resolve();
     expect(rt.sendMessageToTarget).toHaveBeenCalledTimes(1);
     const spawnText = (
@@ -492,7 +613,7 @@ describe("emitProgress routing ladder + cadence", () => {
     // More narration → routes into the SAME thread: no second main-channel send,
     // no second thread creation.
     await fire(rt, "s-thread", "message", { text: "Wiring it up." });
-    await vi.advanceTimersByTimeAsync(1_600);
+    await advanceTimersByTime(1_600);
     for (let i = 0; i < 8; i++) await Promise.resolve();
     expect(rt.createThreadOnTarget).toHaveBeenCalledTimes(1);
     expect(rt.sendMessageToTarget).toHaveBeenCalledTimes(1);
@@ -518,7 +639,7 @@ describe("emitProgress routing ladder + cadence", () => {
 
     // Advance past two slow heartbeat ticks. With empty output AND empty tool
     // history the tick returns before calling useModel or emitting anything.
-    await vi.advanceTimersByTimeAsync(65_000);
+    await advanceTimersByTime(65_000);
 
     expect(rt.useModel).not.toHaveBeenCalled();
     expect(rt.sendMessageToTarget).not.toHaveBeenCalled();
@@ -545,14 +666,14 @@ describe("emitProgress routing ladder + cadence", () => {
     rt.editMessageOnTarget.mockClear();
 
     // First fast tick (~10s): the LLM summary posts once.
-    await vi.advanceTimersByTimeAsync(10_500);
+    await advanceTimersByTime(10_500);
     const postsAfterFirst =
       rt.sendMessageToTarget.mock.calls.length +
       rt.editMessageOnTarget.mock.calls.length;
     expect(postsAfterFirst).toBe(1);
 
     // Two more ticks producing the identical summary → no additional posts.
-    await vi.advanceTimersByTimeAsync(25_000);
+    await advanceTimersByTime(25_000);
     const postsAfterMore =
       rt.sendMessageToTarget.mock.calls.length +
       rt.editMessageOnTarget.mock.calls.length;

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/spawn-ack.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/spawn-ack.test.ts
@@ -1,0 +1,146 @@
+/**
+ * spawn-ack.test.ts
+ *
+ * Unit coverage for the pure pieces of the LLM-generated "ack"-mode spawn
+ * acknowledgement (plugins/plugin-agent-orchestrator/src/index.ts). The single
+ * `useModel` call that produces the line is impure and covered through the
+ * progress-hook harness (progress-cadence.test.ts); the prompt construction and
+ * output sanitization are pure and tested directly here.
+ *
+ * The whole point of this surface is that there is NO hardcoded ack phrase, no
+ * i18n table, and no scraped personality: the model writes the line in the
+ * character's voice and the user's language. These tests pin the two seams that
+ * make that safe — the prompt carries the character + task, and the model's
+ * output is reduced to one clean line (with a literal fallback only when the
+ * model produces nothing usable).
+ */
+
+import type { Character } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  buildSpawnAckSystemPrompt,
+  buildSpawnAckUserPrompt,
+  SPAWN_ACK_FALLBACK,
+  sanitizeSpawnAck,
+} from "../../src/index.js";
+
+describe("buildSpawnAckSystemPrompt", () => {
+  it("carries the character name, voice, and the one-line + same-language rules", () => {
+    const character: Character = {
+      name: "Milady",
+      bio: ["a terse, dry on-chain assistant"],
+      adjectives: ["dry", "precise"],
+      style: { chat: ["casual"], all: ["concise"] },
+    };
+    const prompt = buildSpawnAckSystemPrompt(character);
+    expect(prompt).toContain("You are Milady.");
+    expect(prompt).toContain("a terse, dry on-chain assistant");
+    // Voice traits are surfaced from the configured character, never hardcoded.
+    expect(prompt).toContain("dry");
+    expect(prompt).toContain("precise");
+    // Hard constraints that keep the output to one short in-language line.
+    expect(prompt.toLowerCase()).toContain("one");
+    expect(prompt.toLowerCase()).toContain("same language");
+    expect(prompt.toLowerCase()).toContain("no emoji");
+  });
+
+  it("degrades gracefully for an empty character (no name, no bio, no style)", () => {
+    const prompt = buildSpawnAckSystemPrompt({});
+    expect(prompt).toContain("You are the assistant.");
+    expect(prompt.toLowerCase()).toContain("same language");
+    // No dangling "Voice:" header when there are no traits to list.
+    expect(prompt).not.toContain("Voice:");
+  });
+
+  it("dedupes overlapping traits and bounds the voice descriptor list", () => {
+    const character: Character = {
+      name: "Bot",
+      adjectives: ["calm", "calm", "warm"],
+      style: { chat: ["warm", "friendly"], all: ["friendly"] },
+    };
+    const prompt = buildSpawnAckSystemPrompt(character);
+    // "warm"/"friendly" appear once each in the joined voice list despite the
+    // duplication across adjectives + style.chat + style.all.
+    const voiceLine = prompt.slice(prompt.indexOf("Voice:"));
+    expect(voiceLine.match(/warm/g)?.length).toBe(1);
+    expect(voiceLine.match(/friendly/g)?.length).toBe(1);
+  });
+});
+
+describe("buildSpawnAckUserPrompt", () => {
+  it("embeds the task verbatim as the language signal", () => {
+    const prompt = buildSpawnAckUserPrompt("déploie le site sur Cloudflare");
+    expect(prompt).toContain("déploie le site sur Cloudflare");
+    expect(prompt).toContain("acknowledgement");
+  });
+
+  it("supplies a neutral placeholder when the task is blank", () => {
+    const prompt = buildSpawnAckUserPrompt("   ");
+    expect(prompt).toContain("the task they just gave you");
+  });
+
+  it("clips an overlong task so the prompt stays bounded", () => {
+    const long = "x".repeat(1000);
+    const prompt = buildSpawnAckUserPrompt(long);
+    expect(prompt).toContain("…");
+    expect(prompt.length).toBeLessThan(500);
+  });
+});
+
+describe("sanitizeSpawnAck", () => {
+  it("returns a clean one-liner unchanged", () => {
+    expect(sanitizeSpawnAck("On it — starting now.")).toBe(
+      "On it — starting now.",
+    );
+  });
+
+  it("keeps only the first non-empty line", () => {
+    expect(sanitizeSpawnAck("\n\nOkay, getting into it.\nblah blah")).toBe(
+      "Okay, getting into it.",
+    );
+  });
+
+  it("strips a leading emoji and list/quote markers", () => {
+    expect(sanitizeSpawnAck("🚀 On it.")).toBe("On it.");
+    expect(sanitizeSpawnAck("- On it.")).toBe("On it.");
+    expect(sanitizeSpawnAck("> On it.")).toBe("On it.");
+  });
+
+  it("strips a single pair of surrounding quotes (straight, smart, backtick)", () => {
+    expect(sanitizeSpawnAck('"On it."')).toBe("On it.");
+    expect(sanitizeSpawnAck("'On it.'")).toBe("On it.");
+    expect(sanitizeSpawnAck("“On it.”")).toBe("On it.");
+    expect(sanitizeSpawnAck("`On it.`")).toBe("On it.");
+  });
+
+  it("collapses internal whitespace", () => {
+    expect(sanitizeSpawnAck("On    it    now.")).toBe("On it now.");
+  });
+
+  it("preserves non-English output untouched (no language assumptions)", () => {
+    expect(sanitizeSpawnAck("C'est parti, je m'y mets.")).toBe(
+      "C'est parti, je m'y mets.",
+    );
+    expect(sanitizeSpawnAck("了解、今すぐ取りかかります。")).toBe(
+      "了解、今すぐ取りかかります。",
+    );
+  });
+
+  it("clips an over-long line and marks the truncation", () => {
+    const out = sanitizeSpawnAck("word ".repeat(60));
+    expect(out.length).toBeLessThanOrEqual(120);
+    expect(out.endsWith("…")).toBe(true);
+  });
+
+  it("returns empty (caller falls back) for empty / whitespace-only input", () => {
+    expect(sanitizeSpawnAck("")).toBe("");
+    expect(sanitizeSpawnAck("   \n  ")).toBe("");
+  });
+});
+
+describe("SPAWN_ACK_FALLBACK", () => {
+  it("is a short, neutral, non-empty literal", () => {
+    expect(SPAWN_ACK_FALLBACK.trim().length).toBeGreaterThan(0);
+    expect(SPAWN_ACK_FALLBACK.length).toBeLessThanOrEqual(24);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-failure-evaluator.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-failure-evaluator.test.ts
@@ -1,0 +1,143 @@
+import type {
+  Memory,
+  MessageHandlerResult,
+  ResponseHandlerEvaluatorContext,
+} from "@elizaos/core";
+import { SIMPLE_CONTEXT_ID } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { subAgentFailureResponseEvaluator } from "../../src/evaluators/sub-agent-failure.js";
+
+function makeContext(overrides: {
+  text?: string;
+  source?: string;
+  metadata?: Record<string, unknown>;
+  messageHandler?: Partial<MessageHandlerResult>;
+}): ResponseHandlerEvaluatorContext {
+  const messageHandler: MessageHandlerResult = {
+    processMessage: "RESPOND",
+    thought: "",
+    plan: {
+      contexts: ["general"],
+      reply: "",
+      requiresTool: true,
+      ...overrides.messageHandler?.plan,
+    },
+    ...overrides.messageHandler,
+  };
+  const message = {
+    id: "00000000-0000-0000-0000-000000000001",
+    entityId: "00000000-0000-0000-0000-000000000002",
+    agentId: "00000000-0000-0000-0000-000000000003",
+    roomId: "00000000-0000-0000-0000-000000000004",
+    content: {
+      text:
+        overrides.text ??
+        "[sub-agent: text-my-ex (claude) — error]\nACP session failed: registration request timed out.",
+      source: overrides.source ?? "sub_agent",
+      metadata: {
+        subAgent: true,
+        subAgentEvent: "error",
+        subAgentLabel: "text-my-ex",
+        ...overrides.metadata,
+      },
+    },
+  } as Memory;
+  return {
+    runtime: {} as never,
+    message,
+    state: {} as never,
+    messageHandler,
+    availableContexts: [{ id: SIMPLE_CONTEXT_ID, description: "simple" }],
+  };
+}
+
+describe("subAgentFailureResponseEvaluator", () => {
+  it("relays one honest failure message on a terminal error synthetic (no silence)", () => {
+    const context = makeContext({});
+    expect(subAgentFailureResponseEvaluator.shouldRun(context)).toBe(true);
+    const result = subAgentFailureResponseEvaluator.evaluate(context);
+    expect(result.reply).toBe(
+      `Couldn't finish the "text-my-ex" task — ACP session failed: registration request timed out. Want me to retry?`,
+    );
+    expect(result.requiresTool).toBe(false);
+    expect(result.setContexts).toEqual([SIMPLE_CONTEXT_ID]);
+    expect(result.clearCandidateActions).toBe(true);
+    expect(result.clearParentActionHints).toBe(true);
+  });
+
+  it("also fires for state_lost_exhausted and round_trip_cap_exceeded", () => {
+    for (const subAgentEvent of [
+      "state_lost_exhausted",
+      "round_trip_cap_exceeded",
+    ]) {
+      const context = makeContext({ metadata: { subAgentEvent } });
+      expect(subAgentFailureResponseEvaluator.shouldRun(context)).toBe(true);
+    }
+  });
+
+  it("does NOT fire for task_complete (that is the completion evaluator's job)", () => {
+    const context = makeContext({
+      metadata: { subAgentEvent: "task_complete" },
+    });
+    expect(subAgentFailureResponseEvaluator.shouldRun(context)).toBe(false);
+  });
+
+  it("does NOT fire for non sub-agent messages", () => {
+    const context = makeContext({
+      source: "discord",
+      metadata: { subAgent: false },
+    });
+    expect(subAgentFailureResponseEvaluator.shouldRun(context)).toBe(false);
+  });
+
+  it("defers to the planner when it is taking a concrete follow-up action", () => {
+    const context = makeContext({
+      messageHandler: {
+        plan: {
+          contexts: ["general"],
+          reply: "",
+          requiresTool: true,
+          candidateActions: ["TASKS_SEND_TO_AGENT"],
+        },
+      } as Partial<MessageHandlerResult>,
+    });
+    expect(subAgentFailureResponseEvaluator.shouldRun(context)).toBe(false);
+  });
+
+  it.each([
+    ["candidate TASKS", { candidateActions: ["TASKS"] }],
+    [
+      "candidate TASKS_SPAWN_AGENT",
+      { candidateActions: ["TASKS_SPAWN_AGENT"] },
+    ],
+    ["parent TASKS", { parentActionHints: ["TASKS"] }],
+  ])("ignores stale generic task hints: %s", (_label, plan) => {
+    const context = makeContext({
+      messageHandler: {
+        plan: {
+          contexts: ["general"],
+          reply: "",
+          requiresTool: true,
+          ...plan,
+        },
+      } as Partial<MessageHandlerResult>,
+    });
+    expect(subAgentFailureResponseEvaluator.shouldRun(context)).toBe(true);
+  });
+
+  it("does NOT fire when the turn is already STOP", () => {
+    const context = makeContext({
+      messageHandler: { processMessage: "STOP" },
+    });
+    expect(subAgentFailureResponseEvaluator.shouldRun(context)).toBe(false);
+  });
+
+  it("uses a generic subject and omits the reason for label-less, noise-only narration", () => {
+    const context = makeContext({
+      text: "[internal-code-9931]",
+      metadata: { subAgentLabel: undefined },
+    });
+    const result = subAgentFailureResponseEvaluator.evaluate(context);
+    expect(result.reply).toBe("Couldn't finish that task. Want me to retry?");
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/__tests__/sandbox-gating.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/sandbox-gating.test.ts
@@ -88,6 +88,24 @@ describe("agent-orchestrator sandbox gating", () => {
     expect(actions[0]?.name).toBe("TASKS");
   });
 
+  it("registers completion and failure response evaluators under supported direct builds", {
+    timeout: SLOW,
+  }, async () => {
+    process.env.ELIZA_BUILD_VARIANT = "direct";
+    process.env.ELIZA_PLATFORM = "desktop";
+    _resetBuildVariantForTests();
+
+    const agentOrchestratorPlugin = createAgentOrchestratorPlugin();
+    expect(
+      (agentOrchestratorPlugin.responseHandlerEvaluators ?? []).map(
+        (evaluator) => evaluator.name,
+      ),
+    ).toEqual([
+      "agent-orchestrator.sub-agent-completion",
+      "agent-orchestrator.sub-agent-failure",
+    ]);
+  });
+
   it("registers only a TASKS unsupported stub on Android without a staged shell", {
     timeout: SLOW,
   }, async () => {

--- a/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-failure.ts
+++ b/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-failure.ts
@@ -1,0 +1,163 @@
+import {
+  type Memory,
+  type MessageHandlerResult,
+  type ResponseHandlerEvaluator,
+  SIMPLE_CONTEXT_ID,
+} from "@elizaos/core";
+
+const SUB_AGENT_SOURCE = "sub_agent";
+
+// Terminal failure events the SubAgentRouter stamps onto a synthetic inbound
+// when a coding sub-agent dies WITHOUT delivering: a hard ACP error, an
+// exhausted state-recovery budget, or a force-stopped ping-pong loop. Unlike
+// `task_complete`, none of these had a response-handler evaluator, so the
+// planner saw the error synthetic and frequently produced no reply — the user
+// was left staring at the spawn ack with no outcome ("working on it" → silence).
+const TERMINAL_FAILURE_EVENTS = new Set([
+  "error",
+  "state_lost_exhausted",
+  "round_trip_cap_exceeded",
+]);
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function contentRecord(message: Memory): Record<string, unknown> | undefined {
+  return asRecord(message.content);
+}
+
+function metadataRecord(message: Memory): Record<string, unknown> | undefined {
+  return asRecord(contentRecord(message)?.metadata);
+}
+
+function textOf(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function hasStrings(value: unknown): boolean {
+  return (
+    Array.isArray(value) && value.some((entry) => textOf(entry).length > 0)
+  );
+}
+
+function normalizedActionHints(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry) => textOf(entry).toUpperCase())
+    .filter((entry) => entry.length > 0);
+}
+
+function hasOnlyStaleFailureHints(value: unknown): boolean {
+  const hints = normalizedActionHints(value);
+  return (
+    hints.length > 0 &&
+    hints.every(
+      (hint) =>
+        hint === "TASKS" ||
+        hint === "ATTACHMENT" ||
+        hint === "SPAWN_AGENT" ||
+        hint === "TASKS_CREATE" ||
+        hint === "TASKS_CREATE_TASK" ||
+        hint === "TASKS_SPAWN_AGENT" ||
+        hint === "TASKS_SPAWN_TASK_AGENT",
+    )
+  );
+}
+
+function isTerminalSubAgentFailure(message: Memory): boolean {
+  const content = contentRecord(message);
+  const metadata = metadataRecord(message);
+  if (!content || !metadata) return false;
+  const source = textOf(content.source).toLowerCase();
+  if (source !== SUB_AGENT_SOURCE && metadata.subAgent !== true) return false;
+  return TERMINAL_FAILURE_EVENTS.has(textOf(metadata.subAgentEvent));
+}
+
+// Trim the router's error narration to a single short, user-readable clause:
+// drop leading label/emoji/quote annotations and skip bare internal codes.
+function shortReason(body: string): string {
+  const firstLine = body
+    .replace(/\r\n/g, "\n")
+    .split("\n")
+    .map((line) =>
+      line
+        .replace(/^[\s>*•-]+/, "")
+        .replace(/^\[[^\]]*\]\s*/, "")
+        .trim(),
+    )
+    .find((line) => line.length > 0 && /\s/.test(line));
+  if (!firstLine) return "";
+  // First sentence only, with trailing sentence punctuation stripped so the
+  // reply template's own period doesn't double up ("timed out.. Want me…").
+  const clause = firstLine
+    .split(/(?<=[.!?])\s/)[0]
+    .replace(/[.!?]+$/, "")
+    .trim();
+  return clause.length > 160 ? `${clause.slice(0, 157)}…` : clause;
+}
+
+function buildFailureReply(label: string, reason: string): string {
+  const what = label ? `the "${label}" task` : "that task";
+  const because = reason ? ` — ${reason}` : "";
+  return `Couldn't finish ${what}${because}. Want me to retry?`;
+}
+
+function respondIfNeeded(messageHandler: MessageHandlerResult) {
+  return messageHandler.processMessage === "RESPOND"
+    ? {}
+    : { processMessage: "RESPOND" as const };
+}
+
+/**
+ * Response-handler evaluator that guarantees a sub-agent terminal FAILURE never
+ * lands as silence. The completion evaluator (`sub-agent-completion`) routes
+ * `task_complete`; this is its failure-side twin for the `error` /
+ * `state_lost_exhausted` / `round_trip_cap_exceeded` synthetics the router
+ * emits but nothing handled. When the planner is taking a concrete follow-up of
+ * its own (feeding the still-running session input, or a real next step) we
+ * defer to it; otherwise we relay one honest line so the user gets an outcome
+ * instead of a dangling spawn ack.
+ */
+export const subAgentFailureResponseEvaluator: ResponseHandlerEvaluator = {
+  name: "agent-orchestrator.sub-agent-failure",
+  description:
+    "Routes terminal sub-agent failure synthetics (error / state-lost / round-trip-cap) to one honest user-facing message instead of silence.",
+  priority: 10,
+  shouldRun: ({ message, messageHandler }) => {
+    if (!isTerminalSubAgentFailure(message)) return false;
+    if (messageHandler.processMessage === "STOP") return false;
+    // If the planner is taking a concrete follow-up action of its own, let it
+    // own the turn rather than overriding with a generic failure line.
+    const hasConcreteCandidateAction =
+      hasStrings(messageHandler.plan.candidateActions) &&
+      !hasOnlyStaleFailureHints(messageHandler.plan.candidateActions);
+    const hasConcreteParentHint =
+      hasStrings(messageHandler.plan.parentActionHints) &&
+      !hasOnlyStaleFailureHints(messageHandler.plan.parentActionHints);
+    if (hasConcreteCandidateAction || hasConcreteParentHint) {
+      return false;
+    }
+    return true;
+  },
+  evaluate: ({ message, messageHandler }) => {
+    const metadata = metadataRecord(message) ?? {};
+    const label = textOf(metadata.subAgentLabel);
+    const reason = shortReason(textOf(contentRecord(message)?.text));
+    return {
+      ...respondIfNeeded(messageHandler),
+      requiresTool: false,
+      setContexts: [SIMPLE_CONTEXT_ID],
+      clearCandidateActions: true,
+      clearParentActionHints: true,
+      reply: buildFailureReply(label, reason),
+      debug: [
+        `sub-agent terminal failure (${textOf(
+          metadata.subAgentEvent,
+        )}); relaying one honest failure message instead of leaving the spawn ack dangling`,
+      ],
+    };
+  },
+};

--- a/plugins/plugin-agent-orchestrator/src/index.ts
+++ b/plugins/plugin-agent-orchestrator/src/index.ts
@@ -9,6 +9,7 @@
  */
 
 import type {
+  Character,
   IAgentRuntime,
   Memory,
   Plugin,
@@ -39,6 +40,7 @@ import {
 } from "./actions/sandbox-stub.js";
 import { tasksAction } from "./actions/tasks.js";
 import { subAgentCompletionResponseEvaluator } from "./evaluators/sub-agent-completion.js";
+import { subAgentFailureResponseEvaluator } from "./evaluators/sub-agent-failure.js";
 import { codingAgentExamplesProvider } from "./providers/action-examples.js";
 import { activeSubAgentsProvider } from "./providers/active-sub-agents.js";
 import { activeWorkspaceContextProvider } from "./providers/active-workspace-context.js";
@@ -218,7 +220,7 @@ export function createAgentOrchestratorPlugin(): Plugin {
     actions: orchestratorActions,
     providers: orchestratorProviders,
     responseHandlerEvaluators: codeExecutionAllowed
-      ? [subAgentCompletionResponseEvaluator]
+      ? [subAgentCompletionResponseEvaluator, subAgentFailureResponseEvaluator]
       : [],
     // Eager-start the orchestrator's services. They're declared in `services:`
     // above and registered by elizaOS, but service registration is lazy — the
@@ -577,7 +579,7 @@ export function compactProgressText(text: string): string {
 /**
  * Decide whether the planner already acknowledged a spawn turn, so the
  * orchestrator's spawn ACK can be suppressed (avoiding two back-to-back acks:
- * planner "On it." + orchestrator "working on it now."). True iff the planner
+ * the planner's "On it." plus the orchestrator's own spawn ack). True iff the planner
  * sent a user-facing message to the room within the spawn turn — i.e. at/after
  * the session's createdAt minus a small lookback (REPLY and the TASKS spawn
  * action run in the same turn, in either order). A planner reply older than
@@ -607,6 +609,131 @@ export function sanitizePlannerText(text: string): string {
   return cleaned.length > 0
     ? `${cleaned} ${SELF_HEAL_REPLACEMENT}`
     : SELF_HEAL_REPLACEMENT;
+}
+
+// ── LLM-generated spawn acknowledgement ──────────────────────────────────────
+// In "ack" mode the orchestrator posts ONE short line when it kicks off a coding
+// sub-agent. A single hardcoded literal ("working on it now.") read identically
+// robotic on every spawn, was always English regardless of the user's language,
+// and never matched the agent's character voice. Instead, the small text model
+// writes the line: it speaks in the configured character's own voice (no
+// hardcoded personality, no scraping `style.chat`) and in the user's language
+// (no i18n table), and natural sampling removes the verbatim repeat. This is the
+// same approach the LLM progress heartbeat already uses to write its status line
+// in the narration's language. The pure helpers below build the prompts and
+// sanitize the output (unit-tested); the single `useModel` call in the progress
+// hook is the only impure part, and it falls back to SPAWN_ACK_FALLBACK so the
+// ack can never become silence.
+
+// Minimal degraded fallback, used ONLY when the model call fails or returns
+// nothing usable — never the primary path. Kept short and neutral on purpose.
+export const SPAWN_ACK_FALLBACK = "On it.";
+
+// Longest acknowledgement we keep. An ack is a one-liner; anything longer is the
+// model over-answering, so it gets clipped.
+const SPAWN_ACK_MAX_CHARS = 120;
+const SPAWN_ACK_TIMEOUT_MS = 750;
+
+function withSpawnAckTimeout<T>(promise: Promise<T>, fallback: T): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<T>((resolve) => {
+    timer = setTimeout(() => resolve(fallback), SPAWN_ACK_TIMEOUT_MS);
+    (timer as { unref?: () => void }).unref?.();
+  });
+  return Promise.race([promise.catch(() => fallback), timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
+/**
+ * System prompt for spawn-ack generation. Carries the character's own voice —
+ * derived from the configured character, never hardcoded — plus the hard
+ * constraints that keep the output to a single short in-language line. Pure +
+ * deterministic so it is unit-tested directly.
+ */
+export function buildSpawnAckSystemPrompt(character: Character): string {
+  const name = (character.name ?? "").trim() || "the assistant";
+  const voiceParts: string[] = [];
+  const bio = (character.bio ?? []).map((b) => b.trim()).filter(Boolean);
+  if (bio.length > 0) voiceParts.push(bio.slice(0, 3).join(" "));
+  const traits = [
+    ...(character.adjectives ?? []),
+    ...(character.style?.chat ?? []),
+    ...(character.style?.all ?? []),
+  ]
+    .map((t) => t.trim())
+    .filter(Boolean);
+  if (traits.length > 0) {
+    voiceParts.push(`Voice: ${[...new Set(traits)].slice(0, 8).join(", ")}.`);
+  }
+  return [
+    `You are ${name}.`,
+    voiceParts.join(" ").trim(),
+    "You have just kicked off a background task the user asked for.",
+    "Reply with exactly ONE short, natural line, in your own voice, confirming you're on it.",
+    "Write it in the same language the user used.",
+    "No quotes, no emoji, no markdown, no preamble — just the line. Keep it under 12 words.",
+  ]
+    .filter((part) => part.length > 0)
+    .join(" ");
+}
+
+/**
+ * User-turn prompt for spawn-ack generation: the task being started. The task
+ * text doubles as the language signal — the model replies in whatever language
+ * it is written in (same mechanism as the heartbeat summarizer). Pure.
+ */
+export function buildSpawnAckUserPrompt(task: string): string {
+  const trimmed = task.trim();
+  const what = trimmed.length > 0 ? trimmed : "the task they just gave you";
+  const clipped = what.length > 400 ? `${what.slice(0, 397)}…` : what;
+  return `The task you're starting:\n${clipped}\n\nYour one-line acknowledgement:`;
+}
+
+/**
+ * Clean a model-produced ack into a single plain line: first non-empty line,
+ * surrounding quotes / emoji / list markers stripped, whitespace collapsed,
+ * length capped. Returns "" when nothing usable remains (the caller then falls
+ * back to SPAWN_ACK_FALLBACK). Pure + deterministic.
+ */
+export function sanitizeSpawnAck(raw: string): string {
+  if (!raw) return "";
+  const firstLine =
+    raw
+      .replace(/\r\n/g, "\n")
+      .split("\n")
+      .map((line) => line.trim())
+      .find((line) => line.length > 0) ?? "";
+  if (!firstLine) return "";
+  let cleaned = firstLine
+    .replace(PROGRESS_EMOJI_PREFIX_REGEX, "")
+    .replace(/^[>*\-•\s]+/, "")
+    .trim();
+  // Strip a single pair of surrounding quotes (straight, smart, or backtick).
+  const quotePairs: ReadonlyArray<readonly [string, string]> = [
+    ['"', '"'],
+    ["'", "'"],
+    ["“", "”"],
+    ["‘", "’"],
+    ["`", "`"],
+  ];
+  for (const [open, close] of quotePairs) {
+    if (
+      cleaned.length >= open.length + close.length &&
+      cleaned.startsWith(open) &&
+      cleaned.endsWith(close)
+    ) {
+      cleaned = cleaned
+        .slice(open.length, cleaned.length - close.length)
+        .trim();
+      break;
+    }
+  }
+  cleaned = cleaned.replace(/\s{2,}/g, " ").trim();
+  if (!cleaned) return "";
+  return cleaned.length > SPAWN_ACK_MAX_CHARS
+    ? `${cleaned.slice(0, SPAWN_ACK_MAX_CHARS - 1).trimEnd()}…`
+    : cleaned;
 }
 
 function stripToolTranscripts(raw: string): string {
@@ -825,11 +952,22 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
   // heartbeat re-run the first-post path and post a SECOND ack. Keying ack
   // suppression on this set instead makes it exactly one ack per session.
   const ackedSessions = new Set<string>();
+  // Terminal events can arrive while the model is still writing the first ack.
+  // Once terminal is observed, a late ack must be suppressed; otherwise the user
+  // can see "On it" after completion/failure. Bounded like ackedSessions.
+  const terminalSessions = new Set<string>();
+  const markSessionTerminal = (sessionId: string): void => {
+    terminalSessions.add(sessionId);
+    if (terminalSessions.size > 512) {
+      const oldest = terminalSessions.values().next().value;
+      if (oldest !== undefined) terminalSessions.delete(oldest);
+    }
+  };
   // Last "ack"-mode spawn ACK time per ROOM (`${source}::${roomId}`). One user
   // turn frequently fans out into several sub-agent sessions — a re-spawn, or a
   // multi-file build that spawns more than once — and ackedSessions is per
-  // SESSION, so each would post its own "working on it now." (the duplicate-ack
-  // nubs saw). Suppressing a sibling session's ACK when the room already acked
+  // SESSION, so each would post its own spawn ack (the duplicate-ack nubs saw).
+  // Suppressing a sibling session's ACK when the room already acked
   // within this window collapses one turn to a single ACK; a genuinely new
   // request after the window still gets its own.
   const roomAckAt = new Map<string, number>();
@@ -1071,6 +1209,43 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
     lastHeartbeatSummary.delete(sessionId);
   };
 
+  // Generate the one-line "ack"-mode spawn acknowledgement via the small text
+  // model — in the character's own voice and the user's language (see
+  // buildSpawnAckSystemPrompt). The task text (the language signal) is read from
+  // the session's `initialTask` metadata, falling back to the label. Best-effort:
+  // any failure (no model registered, a throw, empty output) collapses to a short
+  // literal, so the ack is never silence and never blocks the spawn.
+  const generateSpawnAck = async (
+    sessionId: string,
+    label: string,
+  ): Promise<string> => {
+    try {
+      const session = await acp.getSession(sessionId).catch(() => null);
+      const meta = (session?.metadata ?? {}) as Record<string, unknown>;
+      const task =
+        typeof meta.initialTask === "string" && meta.initialTask.trim()
+          ? meta.initialTask
+          : label;
+      return await withSpawnAckTimeout(
+        runtime
+          .useModel(ModelType.TEXT_SMALL, {
+            system: buildSpawnAckSystemPrompt(runtime.character),
+            prompt: buildSpawnAckUserPrompt(task),
+            maxTokens: 32,
+            temperature: 0.7,
+          })
+          .then(
+            (raw) =>
+              sanitizeSpawnAck(typeof raw === "string" ? raw : "") ||
+              SPAWN_ACK_FALLBACK,
+          ),
+        SPAWN_ACK_FALLBACK,
+      );
+    } catch {
+      return SPAWN_ACK_FALLBACK;
+    }
+  };
+
   // Generic capability probe — multi-integration aware. The orchestrator
   // routes UX through whichever surface the target connector supports,
   // falling back gracefully when a capability is missing (e.g. Twitter/X
@@ -1236,6 +1411,7 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
         target.roomId,
         sessionLabel,
       );
+      if (!state && terminalSessions.has(sessionId)) return;
       // Reuse the existing 🚀 main message for this label when it exists —
       // respawn / rate-limit retry / follow-up should NOT post a duplicate
       // "🚀 [label] running" line. Bind state to the cached message id and
@@ -1262,15 +1438,16 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
         await emitProgress(sessionId, target, rawText, sessionLabel);
         return;
       }
-      const initialText = state
+      // The "ack"-mode spawn line is generated by the model AFTER the
+      // synchronous claim below (so the claim stays atomic), so leave it empty
+      // here and fill it once this event has exclusively claimed the first post.
+      const isAckFirstPost = !state && progressPolicy.mode === "ack";
+      let initialText = state
         ? displayText
         : progressPolicy.mode === "threaded"
           ? `🚀 [${sessionLabel}] running`
           : progressPolicy.mode === "ack"
-            ? // "ack" mode posts ONE clean spawn ACK (never the raw sub-agent
-              // narration) and never edits it afterward — the completion
-              // synthesis is the separate final message. Plain text, no emoji.
-              "working on it now."
+            ? ""
             : displayText;
       // Claim the first post synchronously before the await. A second progress
       // event for the same session that arrives while this send is in flight
@@ -1281,9 +1458,9 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
         if (firstPostInFlight.has(sessionId)) return;
         // ack mode posts exactly one ACK per ROOM per window — a sibling
         // sub-agent session spawned by the SAME user turn must not post a second
-        // "working on it now.". Checked synchronously before the claim/await so
-        // a concurrent sibling bails here. (Per-session suppression below still
-        // guards the heartbeat / narration re-entry for this one session.)
+        // ack. Checked synchronously before the claim/await so a concurrent
+        // sibling bails here. (Per-session suppression below still guards the
+        // heartbeat / narration re-entry for this one session.)
         if (progressPolicy.mode === "ack") {
           const roomAckKey = `${target.source}::${target.roomId}`;
           const now = Date.now();
@@ -1313,6 +1490,18 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
             const oldest = ackedSessions.values().next().value;
             if (oldest !== undefined) ackedSessions.delete(oldest);
           }
+        }
+      }
+      // "ack" mode posts ONE clean spawn ACK (never the raw sub-agent narration)
+      // and never edits it afterward — the completion synthesis is the separate
+      // final message. The line is the model's own in-voice, in-language
+      // acknowledgement. Generated here, AFTER the claim above, so the dedup
+      // stays synchronous and the model latency sits outside the claim window.
+      if (isAckFirstPost) {
+        initialText = await generateSpawnAck(sessionId, sessionLabel);
+        if (terminalSessions.has(sessionId)) {
+          firstPostInFlight.delete(sessionId);
+          return;
         }
       }
       const sent = await runtime.sendMessageToTarget(
@@ -1489,7 +1678,9 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
     }
     // No reaction support and no edit: post a terminal failure message so
     // the user knows the sub-agent ended on a non-success state.
-    if (!state.canEdit) {
+    const suppressFailurePost =
+      progressPolicy.mode === "ack" || progressPolicy.mode === "silent";
+    if (!state.canEdit && !suppressFailurePost) {
       try {
         await runtime.sendMessageToTarget(
           target,
@@ -1564,6 +1755,14 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
           typeof meta.label === "string" && meta.label.trim().length > 0
             ? meta.label
             : `sub-agent ${sessionId.slice(0, 8)}`;
+        const isTerminalEvent =
+          evName === "stopped" ||
+          evName === "error" ||
+          evName === "task_complete" ||
+          evName === "cancelled";
+        if (isTerminalEvent) {
+          markSessionTerminal(sessionId);
+        }
         // "ack" mode: post the single clean spawn ACK on the FIRST event of any
         // kind, not just narration. The ack used to ride on the first
         // message-buffer flush, which only fires after a narration silence gap
@@ -1579,8 +1778,8 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
         // same user request, spawned under a fresh sessionId minutes later. The
         // per-session ackedSessions/firstPostInFlight guards never see it, and the
         // per-room ack dedup window (60s) has long expired — so without this gate
-        // each retry posts another "working on it now." (the triple-ack users
-        // reported). The original user-requested session has no
+        // each retry posts another spawn ack (the triple-ack users reported).
+        // The original user-requested session has no
         // buildVerifyRetryCount, so it still acks exactly once.
         const isVerifyRetrySpawn =
           typeof meta.buildVerifyRetryCount === "number" &&
@@ -1588,6 +1787,7 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
         if (
           progressPolicy.mode === "ack" &&
           !ackedSessions.has(sessionId) &&
+          !terminalSessions.has(sessionId) &&
           !isVerifyRetrySpawn &&
           evName !== "task_complete" &&
           evName !== "turn_complete" &&
@@ -1597,8 +1797,8 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
         ) {
           // Dedupe against the planner's own acknowledgment. The planner often
           // replies "On it." in the same turn it spawns the task; posting a
-          // second orchestrator ACK ("working on it now.") right after is the
-          // back-to-back double-ack users complained about. If a user-facing
+          // second orchestrator ACK right after is the back-to-back double-ack
+          // users complained about. If a user-facing
           // (non-internal) message hit this room within the spawn turn — i.e.
           // at/after createdAt minus a small lookback — the planner already
           // acked: claim the marker (so trailing events + heartbeat stay
@@ -1628,17 +1828,7 @@ function registerProgressHook(runtime: IAgentRuntime): () => void {
         // edit messages in place, slow (30s) when each tick is a new post.
         if (evName === "ready" || evName === "tool_running") {
           startHeartbeat(sessionId, label, source, roomId);
-        } else if (
-          evName === "stopped" ||
-          evName === "error" ||
-          evName === "task_complete" ||
-          // `cancelled` is also a terminal event emitted by acp-service when a
-          // session is cancelled mid-flight (cancelSession or active.cancelled
-          // exit path). Without including it here, the heartbeat keeps polling
-          // and per-session map entries (toolHistory, progressBySession,
-          // lastPostByKey) leak for the life of the runtime.
-          evName === "cancelled"
-        ) {
+        } else if (isTerminalEvent) {
           // Mark the main-channel spawn message with the terminal outcome via
           // reaction + (when supported) inline summary edit, BEFORE the
           // progressBySession entry is cleared below. This is the user-facing
@@ -1923,6 +2113,7 @@ export {
   handleCodingAgentRoutes,
 } from "./api/routes.js";
 export { subAgentCompletionResponseEvaluator } from "./evaluators/sub-agent-completion.js";
+export { subAgentFailureResponseEvaluator } from "./evaluators/sub-agent-failure.js";
 // Providers
 export { activeSubAgentsProvider } from "./providers/active-sub-agents.js";
 export {

--- a/plugins/plugin-discord/discord-reactions.ts
+++ b/plugins/plugin-discord/discord-reactions.ts
@@ -183,6 +183,11 @@ export async function handleReaction(
 				source: "discord",
 				inReplyTo,
 				channelType,
+				// `text` above truncates the reacted-to message to a 50-char display
+				// stub; preserve the full original so context-building feeds the
+				// planner the complete statement, not a fragment it back-rationalizes
+				// into a phantom task (#9874 item 2).
+				...(messageContent ? { reactedMessageText: messageContent } : {}),
 			},
 			metadata: {
 				accountId,

--- a/plugins/plugin-facewear/src/index.ts
+++ b/plugins/plugin-facewear/src/index.ts
@@ -182,10 +182,10 @@ export { displayFacewearTextAction as displaySmartglassesTextAction } from "./ac
 export { facewearControlAction as smartglassesControlAction } from "./actions/facewear-control.ts";
 export { facewearStatusAction as smartglassesStatusAction } from "./actions/facewear-status.ts";
 export { facewearMicrophoneAction as smartglassesMicrophoneAction } from "./actions/microphone.ts";
-// Tri-modal view wrappers — the gui/xr/tui surfaces for the two own views. The
-// manifest declares these as the `componentExport` (bundle) + navTab targets.
-export { FacewearView } from "./components/FacewearView.tsx";
-export { SmartglassesPanelView } from "./components/SmartglassesPanelView.tsx";
+// NOTE: the React view wrappers (FacewearView / SmartglassesPanelView) are NOT
+// re-exported here — that drags React/@elizaos/ui into the Node agent bundle and
+// fails plugin load. The app loads them via the browser entry (src/register.ts)
+// + the Vite view bundle (componentExport from dist/views/bundle.js).
 export type {
   FacewearDeviceProfile,
   FacewearDeviceType,

--- a/plugins/plugin-feed/src/index.ts
+++ b/plugins/plugin-feed/src/index.ts
@@ -60,4 +60,7 @@ if (typeof window === "undefined") {
 export default feedPlugin;
 export * from "./routes.js";
 export * from "./ui/feed-data.js";
-export * from "./ui/index.js";
+// NOTE: the UI surface (./ui/index — FeedOperatorSurface + registerOperatorSurface)
+// is intentionally NOT re-exported here. The Node agent imports this entry to
+// register the plugin's views; pulling React/UI in breaks that bundle. The app
+// loads the UI via the dedicated browser entry (src/ui/index.ts) + view bundle.

--- a/plugins/plugin-local-inference/src/routes/voice-models-routes.ts
+++ b/plugins/plugin-local-inference/src/routes/voice-models-routes.ts
@@ -61,6 +61,7 @@ import {
 	type VoiceModelVersion,
 } from "@elizaos/shared";
 import { evaluateRuntimePolicy } from "../services/network-policy";
+import { stageWakeWordModel } from "../services/voice/wake-word-staging";
 import {
 	downloadVoiceModel,
 	VoiceModelDownloadError,
@@ -499,28 +500,53 @@ export async function handleVoiceModelsRoutes(
 			);
 			return true;
 		}
-		// First asset only; this endpoint handles one published voice archive per request.
 		if (status.latestKnown.ggufAssets.length === 0) {
 			sendJsonError(res, `no assets published for ${id}`, 409);
 			return true;
 		}
 		const controller = new AbortController();
 		try {
-			const result = await getDownloader()({
-				version: status.latestKnown,
-				bundleVoiceDir: bundleVoiceDir(),
-				stagingDir: voiceStagingDir(),
-				assetIndex: 0,
-				networkPolicy,
-				signal: controller.signal,
-			});
+			// Download EVERY published asset for this version. Multi-asset models
+			// (e.g. `wakeword` ships melspec + embedding + classifier) were only
+			// fetching asset 0 before, leaving the model unusable (#9880).
+			const results: Array<{
+				finalPath: string;
+				sha256: string;
+				sizeBytes: number;
+			}> = [];
+			for (
+				let assetIndex = 0;
+				assetIndex < status.latestKnown.ggufAssets.length;
+				assetIndex++
+			) {
+				results.push(
+					await getDownloader()({
+						version: status.latestKnown,
+						bundleVoiceDir: bundleVoiceDir(),
+						stagingDir: voiceStagingDir(),
+						assetIndex,
+						networkPolicy,
+						signal: controller.signal,
+					}),
+				);
+			}
+			// Stage the wake-word head into the loader's `wake/<head>.<kind>.gguf`
+			// layout — the downloader's flat `models/voice/` names are not where
+			// the runtime resolves the standalone three-GGUF head (#9880).
+			const staged = await stageWakeWordModel(
+				status.latestKnown,
+				bundleVoiceDir(),
+			);
 			sendJson(res, {
 				ok: true,
 				id,
 				version: status.latestKnown.version,
-				finalPath: result.finalPath,
-				sha256: result.sha256,
-				sizeBytes: result.sizeBytes,
+				// `finalPath` keeps its single-asset shape for back-compat.
+				finalPath: results[0]?.finalPath,
+				finalPaths: results.map((r) => r.finalPath),
+				stagedPaths: staged,
+				sha256: results[0]?.sha256,
+				sizeBytes: results.reduce((n, r) => n + r.sizeBytes, 0),
 			});
 		} catch (err) {
 			if (err instanceof VoiceModelDownloadError) {

--- a/plugins/plugin-local-inference/src/services/voice/wake-word-staging.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/wake-word-staging.test.ts
@@ -1,0 +1,79 @@
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { latestVoiceModelVersion } from "@elizaos/shared/local-inference";
+import { describe, expect, it } from "vitest";
+import {
+	downloadedAssetName,
+	planWakeWordStaging,
+	stageWakeWordModel,
+} from "./wake-word-staging";
+
+describe("wake-word staging plan (#9880)", () => {
+	const wake = latestVoiceModelVersion("wakeword");
+
+	it("maps each downloaded GGUF onto the loader's wake/<head>.<kind>.gguf layout", () => {
+		if (!wake) throw new Error("wakeword version missing");
+		const plan = planWakeWordStaging(
+			wake,
+			"/state/models/voice",
+			"/state/local-inference/wake",
+		);
+		expect(plan).toHaveLength(3);
+
+		// The downloaded name is version-prefixed; the destination is the canonical
+		// basename the runtime resolves.
+		const byDest = Object.fromEntries(plan.map((c) => [c.to, c.from]));
+		expect(byDest["/state/local-inference/wake/hey-eliza.melspec.gguf"]).toBe(
+			"/state/models/voice/wakeword-0.3.0-hey-eliza.melspec.gguf",
+		);
+		expect(byDest["/state/local-inference/wake/hey-eliza.embedding.gguf"]).toBe(
+			"/state/models/voice/wakeword-0.3.0-hey-eliza.embedding.gguf",
+		);
+		expect(
+			byDest["/state/local-inference/wake/hey-eliza.classifier.gguf"],
+		).toBe("/state/models/voice/wakeword-0.3.0-hey-eliza.classifier.gguf");
+	});
+
+	it("returns no copies for a non-wakeword model", () => {
+		const vad = latestVoiceModelVersion("vad");
+		if (!vad) throw new Error("vad version missing");
+		expect(planWakeWordStaging(vad, "/x", "/y")).toEqual([]);
+	});
+
+	it("stageWakeWordModel copies the downloaded GGUFs into the wake dir", async () => {
+		if (!wake) throw new Error("wakeword version missing");
+		const root = await mkdtemp(path.join(tmpdir(), "wake-stage-"));
+		const bundleVoiceDir = path.join(root, "models", "voice");
+		const wakeDir = path.join(root, "local-inference", "wake");
+		await mkdir(bundleVoiceDir, { recursive: true });
+		// Lay down the downloaded (version-prefixed) files the downloader writes.
+		for (const asset of wake.ggufAssets) {
+			await writeFile(
+				path.join(bundleVoiceDir, downloadedAssetName(wake, asset.filename)),
+				"GGUF",
+			);
+		}
+
+		const staged = await stageWakeWordModel(wake, bundleVoiceDir, wakeDir);
+
+		expect(staged.sort()).toEqual(
+			[
+				path.join(wakeDir, "hey-eliza.classifier.gguf"),
+				path.join(wakeDir, "hey-eliza.embedding.gguf"),
+				path.join(wakeDir, "hey-eliza.melspec.gguf"),
+			].sort(),
+		);
+		for (const p of staged) expect(existsSync(p)).toBe(true);
+	});
+
+	it("downloadedAssetName prefixes id + version", () => {
+		expect(
+			downloadedAssetName(
+				{ id: "wakeword", version: "0.3.0" },
+				"voice/wakeword/hey-eliza.melspec.gguf",
+			),
+		).toBe("wakeword-0.3.0-hey-eliza.melspec.gguf");
+	});
+});

--- a/plugins/plugin-local-inference/src/services/voice/wake-word-staging.ts
+++ b/plugins/plugin-local-inference/src/services/voice/wake-word-staging.ts
@@ -1,0 +1,82 @@
+/**
+ * Wake-word model staging (issue #9880).
+ *
+ * The voice-model auto-updater downloads each GGUF into the flat bundle voice
+ * dir (`<state-dir>/models/voice/`) under a version-prefixed name, e.g.
+ * `wakeword-0.3.0-hey-eliza.melspec.gguf`. The wake-word runtime, however,
+ * resolves the standalone three-GGUF head from `<bundleRoot>/wake/` or
+ * `<state-dir>/local-inference/wake/` under the canonical `<head>.<kind>.gguf`
+ * names (see `resolveWakeWordStandalonePaths` in `wake-word.ts`).
+ *
+ * Those two locations + naming schemes don't match, so a freshly-downloaded
+ * wake model was never found by the loader. This module bridges the two: it maps
+ * a downloaded `wakeword` version onto the loader's expected layout and stages
+ * (copies) the files into place. Pure planning is separated from the I/O so the
+ * filename mapping is unit-testable without a filesystem.
+ */
+
+import { copyFile, mkdir } from "node:fs/promises";
+import path from "node:path";
+import type { VoiceModelVersion } from "@elizaos/shared/local-inference";
+import { localInferenceRoot } from "../paths";
+import { OPENWAKEWORD_DIR_REL_PATH } from "./wake-word";
+
+/** The loader's wake directory: `<state-dir>/local-inference/wake`. */
+export function wakeStagingDir(): string {
+	return path.join(localInferenceRoot(), OPENWAKEWORD_DIR_REL_PATH);
+}
+
+/** The downloader's final name for an asset: `<id>-<version>-<basename>`. */
+export function downloadedAssetName(
+	version: Pick<VoiceModelVersion, "id" | "version">,
+	assetFilename: string,
+): string {
+	return `${version.id}-${version.version}-${path.basename(assetFilename)}`;
+}
+
+export interface WakeStageCopy {
+	/** Absolute source path in the bundle voice dir. */
+	from: string;
+	/** Absolute destination path in the wake dir (`<head>.<kind>.gguf`). */
+	to: string;
+}
+
+/**
+ * Plan the copies that put a downloaded `wakeword` version where the runtime
+ * loader resolves it. Returns `[]` for any non-wakeword id (nothing to stage).
+ * The destination name is the asset's basename (already `<head>.<kind>.gguf`,
+ * e.g. `hey-eliza.melspec.gguf`).
+ */
+export function planWakeWordStaging(
+	version: VoiceModelVersion,
+	bundleVoiceDir: string,
+	wakeDir: string = wakeStagingDir(),
+): WakeStageCopy[] {
+	if (version.id !== "wakeword") return [];
+	return version.ggufAssets.map((asset) => {
+		const base = path.basename(asset.filename);
+		return {
+			from: path.join(bundleVoiceDir, downloadedAssetName(version, base)),
+			to: path.join(wakeDir, base),
+		};
+	});
+}
+
+/**
+ * Execute the staging plan: copy each downloaded wake GGUF into the loader's
+ * wake dir under its canonical name. No-op for non-wakeword versions. Returns
+ * the destination paths it wrote.
+ */
+export async function stageWakeWordModel(
+	version: VoiceModelVersion,
+	bundleVoiceDir: string,
+	wakeDir: string = wakeStagingDir(),
+): Promise<string[]> {
+	const plan = planWakeWordStaging(version, bundleVoiceDir, wakeDir);
+	if (plan.length === 0) return [];
+	await mkdir(wakeDir, { recursive: true });
+	for (const copy of plan) {
+		await copyFile(copy.from, copy.to);
+	}
+	return plan.map((c) => c.to);
+}

--- a/plugins/plugin-shell/tsconfig.build.json
+++ b/plugins/plugin-shell/tsconfig.build.json
@@ -2,6 +2,11 @@
   "extends": "./tsconfig.json",
   "exclude": ["node_modules", "dist", "**/*.test.ts", "__tests__", "build.ts"],
   "compilerOptions": {
-    "types": ["node", "bun-types"]
+    "rootDir": ".",
+    "types": ["node", "bun-types"],
+    "paths": {
+      "@elizaos/shared": ["../../packages/shared/dist/index.d.ts"],
+      "@elizaos/shared/*": ["../../packages/shared/dist/*"]
+    }
   }
 }

--- a/plugins/plugin-shell/tsconfig.json
+++ b/plugins/plugin-shell/tsconfig.json
@@ -7,7 +7,7 @@
     "declarationMap": true,
     "sourceMap": true,
     "outDir": "./dist",
-    "rootDir": ".",
+    "rootDir": "../..",
     "strict": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
@@ -16,13 +16,14 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "allowImportingTsExtensions": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,
     "types": ["node", "bun-types"],
     "paths": {
-      "@elizaos/shared": ["../../packages/shared/dist/index.d.ts"],
-      "@elizaos/shared/*": ["../../packages/shared/dist/*"]
+      "@elizaos/shared": ["../../packages/shared/src/index.ts"],
+      "@elizaos/shared/*": ["../../packages/shared/src/*"]
     }
   },
   "include": ["./**/*"],

--- a/plugins/plugin-trajectory-logger/src/index.ts
+++ b/plugins/plugin-trajectory-logger/src/index.ts
@@ -3,9 +3,10 @@
  *
  * The Plugin object (runtime contract — view declarations) lives in `./plugin`,
  * free of UI imports, so the agent can register the plugin's views without
- * pulling the React trajectory surface into the Node process. This barrel
- * re-exports it alongside the UI and SDK surface for browser/view-bundle and
- * direct consumers.
+ * pulling the React trajectory surface into the Node process. The UI surface (`./register` + `./ui`)
+ * is intentionally NOT re-exported here — that pulls React into the agent
+ * bundle and fails plugin load. The app loads the UI via the browser entry
+ * (`src/ui.ts`) and the Vite view bundle.
  */
 
 export type {
@@ -15,11 +16,3 @@ export type {
 export type { PhaseName, PhaseStatus, PhaseSummary } from "./phases";
 export { PHASES, summarizePhases } from "./phases";
 export { default, trajectoryLoggerPlugin } from "./plugin.js";
-export * from "./register";
-export {
-  registerTrajectoryLoggerApp,
-  TRAJECTORY_LOGGER_APP_NAME,
-  TrajectoryLoggerAppView,
-  TrajectoryLoggerView,
-  trajectoryLoggerApp,
-} from "./ui";


### PR DESCRIPTION
Closes #9887.

## Summary
- Suppress simple-to-tool promotion for bot-to-bot crosstalk and preserve full reacted-to message text in context.
- Generate one clean orchestrator spawn ack via the small text model and relay terminal sub-agent failures instead of leaving users with a dangling ack.
- Default first-run shared cloud creation on, move dedicated target creation into the retryable handoff path, and keep the legacy callback dedicated-direct.
- Clear repo verification blockers in cloud-api typing/formatting, cloud-shared outbound-url test mocking, and plugin-shell shared type resolution.

## Evidence
- Synced: `git fetch origin && git rebase origin/develop` (branch was up to date), then `bun install`.
- `bun run verify` passed: 529/529 Turbo tasks, build/typecheck audits, turbo build-deps audit, and 30 dist-path consumer configs.
- Root build passed with daemon-disabled read-only cache mode: `timeout 900 node packages/scripts/run-turbo.mjs run build --concurrency=8 --no-daemon --no-cache --summarize=false --output-logs=new-only --log-order=stream && bun run check:view-bundles` (237/237 build tasks; view-bundle guard OK).
- Focused tests passed:
  - `bun test packages/core/src/runtime/__tests__/addressed-to.test.ts packages/core/src/runtime/__tests__/message-handler.test.ts packages/core/src/runtime/__tests__/planner-loop.test.ts packages/core/src/__tests__/messages-format.test.ts` (88 pass)
  - `bun test plugins/plugin-agent-orchestrator/__tests__/unit/progress-cadence.test.ts plugins/plugin-agent-orchestrator/__tests__/unit/spawn-ack.test.ts plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-failure-evaluator.test.ts plugins/plugin-agent-orchestrator/src/__tests__/sandbox-gating.test.ts` (47 pass)
  - `bun run --cwd packages/ui test -- src/config/boot-config-store.test.ts src/first-run/use-first-run-controller.test.tsx` (23 pass)
  - `bun test packages/cloud-shared/src/lib/services/provisioning-jobs-delete-enqueue.test.ts` (7 pass)
- `git diff --check origin/develop...HEAD` passed.

## Evidence N/A
- Real-LLM trajectory: not run in this workspace; no live model scenario/credentials were available during this pass.
- Screenshot/video/audio evidence: not applicable to this code-path and verification cleanup pass; no visual layout, media, voice, STT, or TTS behavior was changed.
