### PR TITLE
fix(cloud): pre-seed managed agent eliza.json before container start (fixes local_inference)

### DIFF
--- a/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
@@ -1242,6 +1242,39 @@ export class DockerSandboxProvider implements SandboxProvider {
       const containerId = extractDockerCreateContainerId(
         await ssh.exec(dockerCreateCmd, DOCKER_CMD_TIMEOUT_MS),
       );
+
+      // Pre-seed the cloud runtime config on the HOST side of the
+      // `${volumePath}/eliza:/root/.eliza` mount BEFORE starting the container,
+      // so the agent's loadElizaConfig() at early boot already sees
+      // deploymentTarget/serviceRouting. The post-start `docker exec` write
+      // below otherwise races the agent's config read (~0.6s post-start vs the
+      // ~0.2s boot-time read), leaving cloud agents stuck on runtime=local →
+      // local_inference (#8434/#9887). Best-effort; the post-start write below
+      // stays as a fallback (and overwrites with identical content).
+      try {
+        if (allEnv.ELIZAOS_CLOUD_BASE_URL) {
+          const preSeed = Buffer.from(
+            JSON.stringify(buildManagedElizaRuntimeConfig(allEnv)),
+            "utf-8",
+          ).toString("base64");
+          await ssh.exec(
+            `mkdir -p ${shellQuote(`${volumePath}/eliza`)} && printf %s ${shellQuote(
+              preSeed,
+            )} | base64 -d > ${shellQuote(`${volumePath}/eliza/eliza.json`)}`,
+            DOCKER_CMD_TIMEOUT_MS,
+          );
+          logger.info(
+            `[docker-sandbox] Pre-seeded eliza.json on host volume for ${containerName}`,
+          );
+        }
+      } catch (preSeedErr) {
+        logger.warn(
+          `[docker-sandbox] Failed to pre-seed eliza.json (post-start write will retry): ${
+            preSeedErr instanceof Error ? preSeedErr.message : String(preSeedErr)
+          }`,
+        );
+      }
+
       await ssh.exec(`docker start ${shellQuote(containerName)}`, DOCKER_CMD_TIMEOUT_MS);
       logger.info(
         `[docker-sandbox] Container created on ${nodeId}: ${containerId} (${containerName})`,

--- a/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
@@ -1263,9 +1263,7 @@ export class DockerSandboxProvider implements SandboxProvider {
             )} | base64 -d > ${shellQuote(`${volumePath}/eliza/eliza.json`)}`,
             DOCKER_CMD_TIMEOUT_MS,
           );
-          logger.info(
-            `[docker-sandbox] Pre-seeded eliza.json on host volume for ${containerName}`,
-          );
+          logger.info(`[docker-sandbox] Pre-seeded eliza.json on host volume for ${containerName}`);
         }
       } catch (preSeedErr) {
         logger.warn(


### PR DESCRIPTION
## Problem
Every dedicated-agent chat returns `{"text":"Sorry, I'm having a provider issue","failureKind":"local_inference"}`. Root-caused live (#9887): the managed runtime config (carrying #9891/#9892's `deploymentTarget:{runtime:"cloud"}` + `serviceRouting`) is written to `/root/.eliza/eliza.json` via `docker exec` **after** `docker start`. The agent's `loadElizaConfig()` runs in early boot **before** that ~0.6s-post-start write, so `resolveElizaCloudTopology` resolves `runtime=local` and `plugin-local-inference` serves TEXT (which then errors → `local_inference`).

Timestamps from a live prod agent: container start `16:39:34.351`, `eliza.json` written `16:39:34.958` (0.6s later) — the config lands after the agent has already resolved topology.

## Fix
Pre-seed the same `buildManagedElizaRuntimeConfig(allEnv)` onto the **host** side of the `${volumePath}/eliza:/root/.eliza` mount **before** `docker start`, so it's present at first boot. Additive — the post-start `docker exec` write stays as a fallback (idempotent overwrite).

## Verification
Will attach: fresh-agent boot log flipping `Cloud config: inference=false, runtime=local` → `inference=true, runtime=cloud`, and a real cloud chat reply. Refs #8434, #9887.