### PR TITLE
fix(cloud-api): refund credit reservation on streaming provider error (money bug)

### DIFF
--- a/packages/cloud-api/v1/chat/completions/route.ts
+++ b/packages/cloud-api/v1/chat/completions/route.ts
@@ -1247,6 +1247,22 @@ async function handleStreamingRequest(
         model,
       });
     },
+    // A provider error during streaming (e.g. the cerebras 429/5xx the
+    // fail-fast path surfaces) fires onError — NOT onFinish or onAbort. Without
+    // this, the upfront credit reservation is never reconciled and the user is
+    // billed for zero output. Mirrors the non-streaming error path's
+    // settleReservation(0). The settler is idempotent (first-call-wins), so a
+    // later onFinish/onAbort cannot double-refund.
+    onError: async ({ error }: { error: unknown }) => {
+      await settleReservation(0);
+      logger.error(
+        "[Chat Completions] Stream provider error — reservation refunded",
+        {
+          model,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
+    },
   } as Parameters<typeof streamText>[0]);
 
   // Convert to OpenAI-compatible SSE stream

--- a/packages/cloud-api/v1/messages/route.ts
+++ b/packages/cloud-api/v1/messages/route.ts
@@ -980,6 +980,21 @@ async function handleStream(
         estimatedInputTokens,
       });
     },
+    // A provider error during streaming (e.g. cerebras 429/5xx) fires onError —
+    // NOT onFinish or onAbort. Without this the upfront credit reservation is
+    // never reconciled and the user is billed for zero output. Mirrors the
+    // non-streaming error path's settleReservation(0); the settler is
+    // idempotent (first-call-wins) so this cannot double-refund.
+    onError: async ({ error }: { error: unknown }) => {
+      await settleReservation(0);
+      logger.error(
+        "[Messages API] Stream provider error — reservation refunded",
+        {
+          model,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
+    },
   });
 
   const encoder = new TextEncoder();


### PR DESCRIPTION
## The bug (real money)
Streaming `/v1/chat/completions` and `/v1/messages` reserve credits **upfront** (`reserveCredits`) and only refund through the settler. The settler was wired to `streamText`'s `onFinish` (success) and `onAbort` (client abort) — but **not `onError`**.

In `ai@6`, a provider error mid/at-start of stream (e.g. the cerebras 429/5xx that `withRateLimitFailFast` surfaces) fires **`onError`**, not `onFinish`/`onAbort`. The stream-consumer `catch` only calls `controller.error()` and never settles, and the outer `try/catch` can't run because the `200` + SSE `Response` was already returned. **Net: a streaming request whose provider errors leaves the upfront reservation un-refunded → the user is billed for zero output.**

## Fix
Add `onError: () => settleReservation(0)` to **both** streaming handlers — mirroring what the non-streaming handlers already do on error (they call `settleReservation(0)` in their `catch`). 

`createCreditReservationSettler` is **idempotent** (memoizes `settlePromise`, first-call-wins — verified in `credit-reservation.ts`), so a later `onFinish`/`onAbort` cannot double-refund.

## Evidence
- Asymmetry: non-streaming settles on error (route.ts `catch` → `settleReservation(0)`), streaming had `onFinish`+`onAbort` only — no `onError`.
- Idempotency confirmed in `createCreditReservationSettler`.
- `ai@6` `onError` is the standard streamText error callback.

Found by the cloud launch-readiness audit (adversarially verified). A dedicated streaming-error integration test is a recommended follow-up — the route's test harness doesn't currently mock streamText lifecycle callbacks. Refs #8434.

## Cost tradeoff (deliberate — do not "optimize" into charging users for failures)
- **Start errors (common cerebras 429):** cerebras generated nothing → it does not bill us → clean (nobody pays).
- **Mid-stream errors (partial tokens, then 5xx/drop):** cerebras may bill us for tokens already generated, and we refund the user fully → we absorb that small partial cost. Accepted: `onError` has no usage data (partial billing impossible), it matches the non-streaming + `onAbort` paths, and charging users for failed/partial responses is wrong UX. Small + intermittent.
