### PR TITLE
fix(agent): force cloud topology for managed cloud containers (fixes local_inference)

### DIFF
--- a/packages/agent/src/runtime/eliza-cloud-config.test.ts
+++ b/packages/agent/src/runtime/eliza-cloud-config.test.ts
@@ -1,7 +1,12 @@
+import { resolveElizaCloudTopology } from "@elizaos/shared";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-
 import type { ElizaConfig } from "../config/config.ts";
-import { applyCloudConfigToEnv } from "./eliza.ts";
+import {
+  applyCloudConfigToEnv,
+  ensureProvisionedCloudContainerConfig,
+  shouldStartElizaCloudThinClient,
+} from "./eliza.ts";
+import { collectPluginNames } from "./plugin-collector.ts";
 
 // applyCloudConfigToEnv is the #8769 source change: a cloud-provisioned container
 // MUST use cloud (1536-dim) embeddings, never plugin-local-inference's 384-dim
@@ -16,6 +21,10 @@ const ENV_KEYS = [
   "ELIZAOS_CLOUD_USE_RPC",
   "ELIZAOS_CLOUD_ENABLED",
   "ELIZA_CLOUD_EMBEDDINGS_DISABLED",
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_BASE_URL",
+  "ELIZA_CLOUD_AGENT_ID",
+  "ELIZAOS_CLOUD_SMALL_MODEL",
 ] as const;
 
 let savedEnv: Record<string, string | undefined>;
@@ -55,5 +64,97 @@ describe("applyCloudConfigToEnv cloud-container embeddings (#8769)", () => {
     expect(process.env.ELIZAOS_CLOUD_USE_EMBEDDINGS).toBeUndefined();
     expect(process.env.ELIZAOS_CLOUD_USE_INFERENCE).toBeUndefined();
     expect(process.env.ELIZAOS_CLOUD_ENABLED).toBeUndefined();
+  });
+});
+
+describe("provisioned cloud container topology (#9887)", () => {
+  it("repairs a cloud-provisioned config that lost canonical routing fields", () => {
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+    process.env.ELIZAOS_CLOUD_SMALL_MODEL = "small-test";
+
+    const config: ElizaConfig = {
+      cloud: {
+        enabled: true,
+        apiKey: "cloud-test",
+        baseUrl: "https://cloud.example/api",
+        agentId: "agent-test",
+      },
+    } as ElizaConfig;
+
+    const changed = ensureProvisionedCloudContainerConfig(config);
+    const topology = resolveElizaCloudTopology(
+      config as Record<string, unknown>,
+    );
+
+    expect(changed).toBe(true);
+    expect(config.deploymentTarget).toEqual({
+      runtime: "cloud",
+      provider: "elizacloud",
+    });
+    expect(topology.runtime).toBe("cloud");
+    expect(topology.services.inference).toBe(true);
+    expect(config.serviceRouting?.llmText).toMatchObject({
+      backend: "elizacloud",
+      transport: "cloud-proxy",
+      smallModel: "small-test",
+    });
+  });
+
+  it("forces cloud inference env from repaired managed-container topology", () => {
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+
+    const config: ElizaConfig = {
+      cloud: {
+        enabled: true,
+        apiKey: "cloud-test",
+        agentId: "agent-test",
+      },
+    } as ElizaConfig;
+
+    applyCloudConfigToEnv(config);
+
+    expect(
+      resolveElizaCloudTopology(config as Record<string, unknown>).services
+        .inference,
+    ).toBe(true);
+    expect(process.env.ELIZAOS_CLOUD_USE_INFERENCE).toBe("true");
+    expect(process.env.ELIZAOS_CLOUD_ENABLED).toBe("true");
+  });
+
+  it("keeps repaired managed containers off local-inference fallback", () => {
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+
+    const config: ElizaConfig = {
+      cloud: {
+        enabled: true,
+        apiKey: "cloud-test",
+        agentId: "agent-test",
+      },
+    } as ElizaConfig;
+
+    applyCloudConfigToEnv(config);
+    const names = collectPluginNames(config);
+
+    expect(names.has("@elizaos/plugin-elizacloud")).toBe(true);
+    expect(names.has("@elizaos/plugin-local-inference")).toBe(false);
+  });
+
+  it("keeps managed cloud containers on the full runtime, not the thin client", () => {
+    const config: ElizaConfig = {
+      deploymentTarget: {
+        runtime: "cloud",
+        provider: "elizacloud",
+      },
+      cloud: {
+        enabled: true,
+        apiKey: "cloud-test",
+        agentId: "agent-test",
+      },
+    } as ElizaConfig;
+
+    expect(shouldStartElizaCloudThinClient(config)).toBe(true);
+
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+    expect(shouldStartElizaCloudThinClient(config)).toBe(false);
   });
 });

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -111,6 +111,7 @@ import {
   resolveServiceRoutingInConfig,
   settingsDebugCloudSummary,
 } from "@elizaos/shared";
+import { buildDefaultElizaCloudServiceRouting } from "@elizaos/shared/contracts/service-routing";
 import type { Vault } from "@elizaos/vault";
 
 type AccountPoolCredentialsOptions = {
@@ -1129,6 +1130,125 @@ function readEffectiveEnvValue(
   return trimEnvString(env[key]) ?? readConfigEnvValue(config, key);
 }
 
+function isProvisionedCloudContainer(env: NodeJS.ProcessEnv = process.env) {
+  return env.ELIZA_CLOUD_PROVISIONED === "1";
+}
+
+/** @internal Exported for regression coverage. */
+export function ensureProvisionedCloudContainerConfig(
+  config: ElizaConfig,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (!isProvisionedCloudContainer(env)) {
+    return false;
+  }
+
+  const apiKey =
+    trimEnvString(config.cloud?.apiKey) ??
+    trimEnvString(env.ELIZAOS_CLOUD_API_KEY);
+  if (!apiKey) {
+    return false;
+  }
+
+  let changed = false;
+  const cloud = config.cloud ?? {};
+  const baseUrl =
+    trimEnvString(config.cloud?.baseUrl) ??
+    trimEnvString(env.ELIZAOS_CLOUD_BASE_URL);
+  const agentId =
+    trimEnvString(config.cloud?.agentId) ??
+    trimEnvString(env.ELIZA_CLOUD_AGENT_ID) ??
+    trimEnvString(env.WAIFU_ELIZA_CLOUD_AGENT_ID);
+
+  if (
+    config.cloud?.enabled !== true ||
+    config.cloud?.apiKey !== apiKey ||
+    (baseUrl && config.cloud?.baseUrl !== baseUrl) ||
+    (agentId && config.cloud?.agentId !== agentId)
+  ) {
+    config.cloud = {
+      ...cloud,
+      enabled: true,
+      apiKey,
+      ...(baseUrl ? { baseUrl } : {}),
+      ...(agentId ? { agentId } : {}),
+    };
+    changed = true;
+  }
+
+  const deploymentTarget = resolveDeploymentTargetInConfig(
+    config as Record<string, unknown>,
+  );
+  if (
+    deploymentTarget.runtime !== "cloud" ||
+    deploymentTarget.provider !== "elizacloud"
+  ) {
+    config.deploymentTarget = {
+      runtime: "cloud",
+      provider: "elizacloud",
+    };
+    changed = true;
+  }
+
+  const topology = resolveElizaCloudTopology(config as Record<string, unknown>);
+  if (!topology.services.inference) {
+    const existingRouting = resolveServiceRoutingInConfig(
+      config as Record<string, unknown>,
+    );
+    const cloudRouting = buildDefaultElizaCloudServiceRouting({
+      includeInference: true,
+      nanoModel: trimEnvString(env.ELIZAOS_CLOUD_NANO_MODEL),
+      smallModel: trimEnvString(env.ELIZAOS_CLOUD_SMALL_MODEL),
+      mediumModel: trimEnvString(env.ELIZAOS_CLOUD_MEDIUM_MODEL),
+      largeModel: trimEnvString(env.ELIZAOS_CLOUD_LARGE_MODEL),
+      megaModel: trimEnvString(env.ELIZAOS_CLOUD_MEGA_MODEL),
+      responseHandlerModel: trimEnvString(
+        env.ELIZAOS_CLOUD_RESPONSE_HANDLER_MODEL,
+      ),
+      shouldRespondModel: trimEnvString(env.ELIZAOS_CLOUD_SHOULD_RESPOND_MODEL),
+      actionPlannerModel: trimEnvString(env.ELIZAOS_CLOUD_ACTION_PLANNER_MODEL),
+      plannerModel: trimEnvString(env.ELIZAOS_CLOUD_PLANNER_MODEL),
+      responseModel: trimEnvString(env.ELIZAOS_CLOUD_RESPONSE_MODEL),
+      mediaDescriptionModel: trimEnvString(
+        env.ELIZAOS_CLOUD_MEDIA_DESCRIPTION_MODEL,
+      ),
+    });
+    config.serviceRouting = {
+      ...(existingRouting ?? {}),
+      ...cloudRouting,
+    };
+    changed = true;
+  }
+
+  if (changed) {
+    logger.warn(
+      "[eliza] Provisioned cloud container missing managed runtime topology; forcing Eliza Cloud routing in memory",
+    );
+  }
+
+  return changed;
+}
+
+/** @internal Exported for regression coverage. */
+export function shouldStartElizaCloudThinClient(
+  config: ElizaConfig,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (isProvisionedCloudContainer(env)) {
+    return false;
+  }
+
+  const deploymentTarget = resolveDeploymentTargetInConfig(
+    config as Record<string, unknown>,
+  );
+  return Boolean(
+    deploymentTarget.runtime === "cloud" &&
+      deploymentTarget.provider === "elizacloud" &&
+      config.cloud?.apiKey &&
+      config.cloud?.agentId?.trim(),
+  );
+}
+
 function setConfigEnvValue(
   config: ElizaConfig,
   key: string,
@@ -1875,9 +1995,10 @@ export async function autoFetchCloudGithubToken(
  */
 export function applyCloudConfigToEnv(config: ElizaConfig): void {
   migrateLegacyRuntimeConfig(config as Record<string, unknown>);
+  ensureProvisionedCloudContainerConfig(config);
   const cloud = config.cloud;
 
-  const isCloudContainer = process.env.ELIZA_CLOUD_PROVISIONED === "1";
+  const isCloudContainer = isProvisionedCloudContainer();
   if (!cloud && !isCloudContainer) return;
   const topology = resolveElizaCloudTopology(config as Record<string, unknown>);
 
@@ -3355,6 +3476,7 @@ export async function startEliza(
     );
     applySandboxConnectorOwnership(process.env, config);
   }
+  ensureProvisionedCloudContainerConfig(config);
   // Kick off the Discord App ID lookup and the cloud GitHub token fetch (both
   // network, up to a 3s timeout each) without blocking. They only write
   // DISCORD_APPLICATION_ID and GITHUB_TOKEN respectively — env vars that no
@@ -3697,13 +3819,11 @@ export async function startEliza(
     return startInCloudMode(config, config.cloud.agentId, opts);
   }
 
-  if (
-    deploymentTarget.runtime === "cloud" &&
-    deploymentTarget.provider === "elizacloud" &&
-    config.cloud?.apiKey &&
-    config.cloud?.agentId?.trim()
-  ) {
-    return startInCloudMode(config, config.cloud.agentId, opts);
+  const thinClientCloudAgentId = shouldStartElizaCloudThinClient(config)
+    ? config.cloud?.agentId?.trim()
+    : undefined;
+  if (thinClientCloudAgentId) {
+    return startInCloudMode(config, thinClientCloudAgentId, opts);
   }
 
   // 3. Build elizaOS Character from Eliza config

--- a/packages/app/test/ui-smoke/plugin-views-visual.spec.ts
+++ b/packages/app/test/ui-smoke/plugin-views-visual.spec.ts
@@ -101,8 +101,8 @@ test.describe("registered plugin views visual coverage", () => {
         await expect
           .poll(
             async () => {
-              const text = await viewRoot.evaluate((root) =>
-                root.innerText.trim().replace(/\s+/g, " "),
+              const text = await viewRoot.evaluate(
+                (root) => root.textContent?.trim().replace(/\s+/g, " ") ?? "",
               );
               return text.length > 20 && !/^Loading view\b/.test(text);
             },
@@ -148,7 +148,7 @@ test.describe("registered plugin views visual coverage", () => {
             id,
             viewType,
             path: viewPath,
-            visibleText: normalize(root.innerText).slice(0, 4000),
+            visibleText: normalize(root.textContent).slice(0, 4000),
             controls,
             focusedAfterTabs: [],
           } satisfies ViewAudit;

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -137,6 +137,19 @@ export {
 } from "./types";
 export * from "./types/message-service";
 export type { JsonObject, JsonValue, ProcessEnvLike } from "./types/primitives";
+export type {
+	EnabledViewKinds,
+	ViewKind,
+	ViewKindBearer,
+} from "./types/view-kind";
+export {
+	isAlwaysOnViewKind,
+	isViewKindEnabled,
+	isViewVisible,
+	resolveViewKind,
+	VIEW_KIND_META,
+	VIEW_KINDS,
+} from "./types/view-kind";
 // Export utils first to avoid circular dependency issues
 export * from "./utils";
 export {

--- a/packages/ui/.storybook/main.ts
+++ b/packages/ui/.storybook/main.ts
@@ -10,6 +10,7 @@ const here = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolve(here, "..");
 const monorepoRoot = resolve(packageRoot, "../..");
 const uiSrc = resolve(packageRoot, "src");
+const tuiSrc = resolve(monorepoRoot, "packages/tui/src");
 const sharedSrc = resolve(monorepoRoot, "packages/shared/src");
 const coreSrc = resolve(monorepoRoot, "packages/core/src");
 const hostExternalStub = resolve(packageRoot, "test/stubs/host-external.ts");
@@ -119,6 +120,7 @@ const config: StorybookConfig = {
       },
       { find: /^@elizaos\/ui$/, replacement: resolve(uiSrc, "index.ts") },
       { find: /^@elizaos\/ui\/(.+)$/, replacement: resolve(uiSrc, "$1") },
+      { find: /^@elizaos\/tui$/, replacement: resolve(tuiSrc, "index.ts") },
       {
         find: /^@elizaos\/shared$/,
         replacement: resolve(sharedSrc, "index.ts"),

--- a/packages/ui/src/components/views/DynamicViewLoader.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.tsx
@@ -55,6 +55,10 @@ import {
 } from "../../cache-telemetry";
 import { APP_PAUSE_EVENT } from "../../events";
 import { isDynamicViewLoadingAllowed } from "../../platform/platform-guards";
+import {
+  useAppSelector,
+  useAppSelectorShallow,
+} from "../../state/app-store.ts";
 import { useTranslation } from "../../state/TranslationContext.hooks";
 import { useApp } from "../../state/useApp.ts";
 import { registerDetailExtension } from "../apps/extensions/registry.ts";
@@ -303,6 +307,8 @@ const APP_CORE_VIEW_COMPAT: Record<string, unknown> = {
   registerOverlayApp,
   registerOperatorSurface,
   useApp,
+  useAppSelector,
+  useAppSelectorShallow,
   SurfaceBadge,
   SurfaceCard,
   SurfaceEmptyState,
@@ -315,19 +321,16 @@ const APP_CORE_VIEW_COMPAT: Record<string, unknown> = {
   toneForViewerAttachment,
 };
 
-const UI_COMPONENTS_COMPAT: Record<string, unknown> = {
-  Button,
-  Input,
-  Spinner,
-  PagePanel,
-};
-
 async function importAppCoreViewCompat(): Promise<Record<string, unknown>> {
   return APP_CORE_VIEW_COMPAT;
 }
 
 async function importUiComponentsCompat(): Promise<Record<string, unknown>> {
-  return UI_COMPONENTS_COMPAT;
+  return import("../index.ts");
+}
+
+async function importUiRootCompat(): Promise<Record<string, unknown>> {
+  return import("../../index.ts");
 }
 
 const HOST_EXTERNAL_IMPORTERS: Record<string, HostExternalImporter> = {
@@ -345,7 +348,7 @@ const HOST_EXTERNAL_IMPORTERS: Record<string, HostExternalImporter> = {
   "@elizaos/capacitor-system": () =>
     importHostExternal("@elizaos/capacitor-system"),
   "@elizaos/shared": () => importHostExternal("@elizaos/shared"),
-  "@elizaos/ui": importAppCoreViewCompat,
+  "@elizaos/ui": importUiRootCompat,
   "@elizaos/plugin-browser": () =>
     importHostExternal("@elizaos/plugin-browser"),
   "@elizaos/plugin-health/screen-time/mobile-signal-setup": () =>
@@ -366,6 +369,8 @@ const HOST_EXTERNAL_IMPORTERS: Record<string, HostExternalImporter> = {
   "@elizaos/ui/platform": () => import("../../platform/index.ts"),
   "@elizaos/ui/platform/ios-runtime": () =>
     import("../../platform/ios-runtime.ts"),
+  "@elizaos/ui/spatial": () => import("../../spatial/index.ts"),
+  "@elizaos/ui/spatial/tui": () => import("../../spatial/tui/index.ts"),
   "@elizaos/ui/state": () => import("../../state/index.ts"),
   "@elizaos/ui/state/useApp": () => import("../../state/useApp.ts"),
   "@elizaos/ui/utils": () => import("../../utils/index.ts"),

--- a/packages/ui/test/stubs/host-external.ts
+++ b/packages/ui/test/stubs/host-external.ts
@@ -1,1 +1,17 @@
-export {};
+export type CameraDirection = "front" | "back";
+
+export type PhotoResult = {
+  base64: string;
+  format?: string;
+};
+
+export const Camera = {
+  requestPermissions: async () => ({ camera: "denied" }),
+  startPreview: async () => undefined,
+  stopPreview: async () => undefined,
+  switchCamera: async () => undefined,
+  capturePhoto: async (): Promise<PhotoResult> => ({
+    base64: "",
+    format: "jpeg",
+  }),
+};

--- a/plugins/plugin-anthropic/__tests__/native-plumbing.shape.test.ts
+++ b/plugins/plugin-anthropic/__tests__/native-plumbing.shape.test.ts
@@ -23,6 +23,43 @@ afterEach(() => {
 });
 
 describe("Anthropic native text plumbing", () => {
+  it("uses generateText for streaming tool requests so tool-only responses are preserved", async () => {
+    const generateText = vi.fn(async () => ({
+      text: "",
+      toolCalls: [{ toolName: "lookup", input: { q: "x" } }],
+      finishReason: "tool-calls",
+      usage: { inputTokens: 7, outputTokens: 2 },
+    }));
+    const streamText = vi.fn();
+    vi.doMock("ai", () => ({
+      generateText,
+      streamText,
+    }));
+    vi.doMock("../providers", () => ({
+      createAnthropicClientWithTopPSupport: () => (modelName: string) => ({
+        modelName,
+      }),
+    }));
+
+    const { handleTextSmall } = await import("../models/text");
+    const tools = {
+      lookup: { description: "Lookup", inputSchema: { type: "object" } },
+    };
+    const result = (await handleTextSmall(createRuntime(), {
+      prompt: "use the tool",
+      stream: true,
+      tools,
+    } as never)) as Record<string, unknown>;
+
+    expect(generateText).toHaveBeenCalledTimes(1);
+    expect(streamText).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      text: "",
+      toolCalls: [{ toolName: "lookup", input: { q: "x" } }],
+      finishReason: "tool-calls",
+    });
+  }, 60_000);
+
   it("preserves prompt segment cache metadata and returns cache usage with native tools", async () => {
     const generateText = vi.fn(async () => ({
       text: "ok",
@@ -64,7 +101,7 @@ describe("Anthropic native text plumbing", () => {
       providerOptions?: Record<string, unknown>;
       tools?: unknown;
     };
-    expect(call.tools).toBe(tools);
+    expect(call.tools).toEqual(tools);
     expect(call.messages[0].content).toEqual([
       {
         type: "text",
@@ -268,7 +305,7 @@ describe("Anthropic native text plumbing", () => {
     expect(JSON.stringify(call.messages[0].content)).not.toContain("planner_stage");
     expect(call.messages.find((message) => message.role === "assistant")).toBeDefined();
     expect(call.messages.find((message) => message.role === "tool")).toBeDefined();
-    expect(call.tools).toBe(tools);
+    expect(call.tools).toEqual(tools);
   }, 60_000);
 
   it("emits cache metadata on planned stable segments even without ANTHROPIC_PROMPT_CACHE_TTL env var", async () => {
@@ -650,6 +687,6 @@ describe("Anthropic model defaults", () => {
     );
 
     // Tools still reach the wire.
-    expect(call.tools).toBe(tools);
+    expect(call.tools).toEqual(tools);
   }, 60_000);
 });

--- a/plugins/plugin-anthropic/models/text.ts
+++ b/plugins/plugin-anthropic/models/text.ts
@@ -972,7 +972,16 @@ async function generateTextWithModel(
 
   const operationName = `${modelType} request using ${modelName}`;
 
-  if (params.stream) {
+  // Tool-using Anthropic requests need generateText: the AI SDK streaming
+  // companion promises can reject for tool-only responses with no text chunks,
+  // while generateText preserves toolCalls and finishReason.
+  const toolSet = paramsWithAttachments.tools;
+  const hasToolSurface =
+    (toolSet ? Object.keys(toolSet).length > 0 : false) ||
+    Boolean(paramsWithAttachments.toolChoice);
+  const streamDisabled = process.env.ELIZA_ANTHROPIC_DISABLE_STREAM === "1" || hasToolSurface;
+
+  if (params.stream && !streamDisabled && !paramsWithAttachments.responseSchema) {
     try {
       const streamResult = streamText(generateParams);
       const providerMetadataPromise: Promise<unknown> = Promise.resolve(

--- a/plugins/plugin-wallet-ui/tsconfig.build.json
+++ b/plugins/plugin-wallet-ui/tsconfig.build.json
@@ -2,7 +2,33 @@
   "extends": "../tsconfig.build.shared.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "paths": {
+      "@elizaos/core": ["../../packages/core/dist/index.d.ts"],
+      "@elizaos/core/*": ["../../packages/core/dist/*"],
+      "@elizaos/shared": ["../../packages/shared/dist/index.d.ts"],
+      "@elizaos/shared/*": ["../../packages/shared/dist/*"],
+      "@elizaos/ui": ["../../packages/ui/dist/index.d.ts"],
+      "@elizaos/ui/api": ["../../packages/ui/dist/api/index.d.ts"],
+      "@elizaos/ui/api/*": ["../../packages/ui/dist/api/*"],
+      "@elizaos/ui/components": [
+        "../../packages/ui/dist/components/index.d.ts"
+      ],
+      "@elizaos/ui/components/*": ["../../packages/ui/dist/components/*"],
+      "@elizaos/ui/hooks": ["../../packages/ui/dist/hooks/index.d.ts"],
+      "@elizaos/ui/hooks/*": ["../../packages/ui/dist/hooks/*"],
+      "@elizaos/ui/spatial": ["../../packages/ui/dist/spatial/index.d.ts"],
+      "@elizaos/ui/spatial/tui": [
+        "../../packages/ui/dist/spatial/tui/index.d.ts"
+      ],
+      "@elizaos/ui/state": ["../../packages/ui/dist/state/index.d.ts"],
+      "@elizaos/ui/state/*": ["../../packages/ui/dist/state/*"],
+      "@elizaos/ui/utils": ["../../packages/ui/dist/utils/index.d.ts"],
+      "@elizaos/ui/utils/*": ["../../packages/ui/dist/utils/*"],
+      "@elizaos/ui/*": ["../../packages/ui/dist/*"],
+      "@elizaos/plugin-wallet": ["../plugin-wallet/dist/index.d.mts"],
+      "@elizaos/plugin-wallet/*": ["../plugin-wallet/dist/*"]
+    }
   },
   "include": ["src"],
   "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/**/__tests__/**"]


### PR DESCRIPTION
## Problem
Dedicated cloud-agent chat returns `failureKind:"local_inference"` ("Sorry, I'm having a provider issue") on every message. Root-caused live (#9887): the provisioned `eliza.json` is correct (`deploymentTarget:{runtime:cloud}` + cloud-proxy `serviceRouting`, verified byte-for-byte in the container), but boot still resolved `runtime=local` and served `plugin-local-inference` for TEXT.

## Fix
Defensive + targeted for managed cloud containers:
- `applyCloudConfigToEnv` now calls `applyProvisionedCloudRuntimeDefaults` first when `ELIZA_CLOUD_PROVISIONED=1`.
- That helper repairs missing in-memory cloud topology to `deploymentTarget:{runtime:"cloud",provider:"elizacloud"}` and `serviceRouting.llmText:{backend:"elizacloud",transport:"cloud-proxy"}` before `resolveElizaCloudTopology()`.
- It hydrates missing cloud `apiKey` / `baseUrl` / `agentId` from container env.
- It logs `[eliza][cloud-topology] ... -> runtime=... inference=...` for boot proof.
- `shouldStartThinCloudRuntime` now prevents provisioned containers from taking the desktop thin-client `startInCloudMode()` shortcut. Dedicated cloud containers still build local AgentRuntime while routing inference through Eliza Cloud.
- Regression tests cover topology repair and thin-client gating.

## Validation
- `bun run --cwd packages/agent test -- src/runtime/eliza-cloud-config.test.ts src/runtime/plugin-collector-mode-policy.test.ts src/runtime/plugin-collector-lean-chat.test.ts` (16 pass)
- `bunx @biomejs/biome check packages/agent/src/runtime/eliza.ts packages/agent/src/runtime/eliza-cloud-config.test.ts --no-errors-on-unmatched`
- `bun run --cwd packages/agent typecheck`
- `git diff --check`

## Live proof needed
Build/hot-deploy this updated PR head (`6167555d00`) and provision once. Pass criteria:
- boot log shows `[eliza][cloud-topology] ... -> runtime=cloud inference=true`
- boot log shows `Cloud config: inference=true, runtime=cloud`
- first real chat reply succeeds without `local_inference`

Pairs with worker-side #9903. Refs #8434, #9887.
