### PR TITLE
fix(agent): preserve cloud topology in provisioned containers

### DIFF
--- a/packages/agent/src/runtime/eliza-cloud-config.test.ts
+++ b/packages/agent/src/runtime/eliza-cloud-config.test.ts
@@ -1,7 +1,11 @@
+import { resolveElizaCloudTopology } from "@elizaos/shared";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-
 import type { ElizaConfig } from "../config/config.ts";
-import { applyCloudConfigToEnv } from "./eliza.ts";
+import {
+  applyCloudConfigToEnv,
+  applyProvisionedCloudRuntimeDefaults,
+  shouldStartThinCloudRuntime,
+} from "./eliza.ts";
 
 // applyCloudConfigToEnv is the #8769 source change: a cloud-provisioned container
 // MUST use cloud (1536-dim) embeddings, never plugin-local-inference's 384-dim
@@ -16,6 +20,9 @@ const ENV_KEYS = [
   "ELIZAOS_CLOUD_USE_RPC",
   "ELIZAOS_CLOUD_ENABLED",
   "ELIZA_CLOUD_EMBEDDINGS_DISABLED",
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_BASE_URL",
+  "ELIZA_CLOUD_AGENT_ID",
 ] as const;
 
 let savedEnv: Record<string, string | undefined>;
@@ -45,6 +52,46 @@ describe("applyCloudConfigToEnv cloud-container embeddings (#8769)", () => {
     expect(process.env.ELIZA_CLOUD_EMBEDDINGS_DISABLED).toBeUndefined();
     // Cloud inference is likewise forced on for a provisioned container.
     expect(process.env.ELIZAOS_CLOUD_USE_INFERENCE).toBe("true");
+  });
+
+  it("repairs provisioned cloud topology when the in-memory config lost canonical routing", () => {
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+    process.env.ELIZAOS_CLOUD_API_KEY = "cloud-key";
+    process.env.ELIZAOS_CLOUD_BASE_URL = "https://api.elizacloud.ai/api/v1";
+    process.env.ELIZA_CLOUD_AGENT_ID = "agent-123";
+    const config = {
+      cloud: { enabled: true },
+    } as ElizaConfig;
+
+    applyProvisionedCloudRuntimeDefaults(config);
+
+    expect(config.cloud?.apiKey).toBe("cloud-key");
+    expect(config.cloud?.agentId).toBe("agent-123");
+    expect(config.deploymentTarget).toEqual({
+      runtime: "cloud",
+      provider: "elizacloud",
+    });
+    expect(config.serviceRouting?.llmText).toMatchObject({
+      backend: "elizacloud",
+      transport: "cloud-proxy",
+    });
+    const topology = resolveElizaCloudTopology(
+      config as Record<string, unknown>,
+    );
+    expect(topology.runtime).toBe("cloud");
+    expect(topology.services.inference).toBe(true);
+  });
+
+  it("uses thin cloud runtime only outside provisioned cloud containers", () => {
+    const config = {
+      deploymentTarget: { runtime: "cloud", provider: "elizacloud" },
+      cloud: { enabled: true, apiKey: "cloud-key", agentId: "agent-123" },
+    } as ElizaConfig;
+
+    expect(shouldStartThinCloudRuntime(config)).toBe(true);
+
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+    expect(shouldStartThinCloudRuntime(config)).toBe(false);
   });
 
   it("is a no-op when neither cloud config nor ELIZA_CLOUD_PROVISIONED is present", () => {

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -99,6 +99,8 @@ import {
   type UUID,
 } from "@elizaos/core";
 import {
+  buildDefaultElizaCloudServiceRouting,
+  buildElizaCloudServiceRoute,
   DEFAULT_ELIZA_CLOUD_TEXT_MODEL,
   formatError,
   isElizaSettingsDebugEnabled,
@@ -1874,10 +1876,11 @@ export async function autoFetchCloudGithubToken(
  * ElizaCloud plugin can discover settings at startup.
  */
 export function applyCloudConfigToEnv(config: ElizaConfig): void {
+  applyProvisionedCloudRuntimeDefaults(config);
   migrateLegacyRuntimeConfig(config as Record<string, unknown>);
   const cloud = config.cloud;
 
-  const isCloudContainer = process.env.ELIZA_CLOUD_PROVISIONED === "1";
+  const isCloudContainer = isProvisionedCloudContainer();
   if (!cloud && !isCloudContainer) return;
   const topology = resolveElizaCloudTopology(config as Record<string, unknown>);
 
@@ -2058,6 +2061,95 @@ export function applyCloudConfigToEnv(config: ElizaConfig): void {
   } else {
     delete process.env.ELIZA_CLOUD_RPC_DISABLED;
   }
+}
+
+function isProvisionedCloudContainer(): boolean {
+  return process.env.ELIZA_CLOUD_PROVISIONED === "1";
+}
+
+function buildCloudRouteFromEnv() {
+  return buildElizaCloudServiceRoute({
+    nanoModel: process.env.ELIZAOS_CLOUD_NANO_MODEL,
+    smallModel: process.env.ELIZAOS_CLOUD_SMALL_MODEL,
+    mediumModel: process.env.ELIZAOS_CLOUD_MEDIUM_MODEL,
+    largeModel: process.env.ELIZAOS_CLOUD_LARGE_MODEL,
+    megaModel: process.env.ELIZAOS_CLOUD_MEGA_MODEL,
+    responseHandlerModel: process.env.ELIZAOS_CLOUD_RESPONSE_HANDLER_MODEL,
+    shouldRespondModel: process.env.ELIZAOS_CLOUD_SHOULD_RESPOND_MODEL,
+    actionPlannerModel: process.env.ELIZAOS_CLOUD_ACTION_PLANNER_MODEL,
+    plannerModel: process.env.ELIZAOS_CLOUD_PLANNER_MODEL,
+    responseModel: process.env.ELIZAOS_CLOUD_RESPONSE_MODEL,
+    mediaDescriptionModel: process.env.ELIZAOS_CLOUD_MEDIA_DESCRIPTION_MODEL,
+  });
+}
+
+export function applyProvisionedCloudRuntimeDefaults(
+  config: ElizaConfig,
+): void {
+  if (!isProvisionedCloudContainer()) return;
+
+  const root = config as Record<string, unknown>;
+  migrateLegacyRuntimeConfig(root);
+
+  const cloud = config.cloud ?? {};
+  const apiKey =
+    cloud.apiKey?.trim() || process.env.ELIZAOS_CLOUD_API_KEY?.trim();
+  const baseUrl =
+    cloud.baseUrl?.trim() || process.env.ELIZAOS_CLOUD_BASE_URL?.trim();
+  const agentId =
+    cloud.agentId?.trim() ||
+    process.env.ELIZA_CLOUD_AGENT_ID?.trim() ||
+    process.env.WAIFU_ELIZA_CLOUD_AGENT_ID?.trim();
+
+  if (apiKey || baseUrl || agentId) {
+    config.cloud = {
+      ...cloud,
+      enabled: cloud.enabled ?? Boolean(apiKey),
+      ...(apiKey ? { apiKey } : {}),
+      ...(baseUrl ? { baseUrl } : {}),
+      ...(agentId ? { agentId } : {}),
+    };
+  }
+
+  const deploymentTarget = resolveDeploymentTargetInConfig(root);
+  if (
+    deploymentTarget.runtime !== "cloud" ||
+    deploymentTarget.provider !== "elizacloud"
+  ) {
+    root.deploymentTarget = { runtime: "cloud", provider: "elizacloud" };
+  }
+
+  const serviceRouting = resolveServiceRoutingInConfig(root) ?? {};
+  const llmText = serviceRouting.llmText;
+  const hasCloudTextRoute =
+    llmText?.transport === "cloud-proxy" && llmText.backend === "elizacloud";
+  const baseRouting = {
+    ...serviceRouting,
+    ...(hasCloudTextRoute ? {} : { llmText: buildCloudRouteFromEnv() }),
+  };
+  root.serviceRouting = buildDefaultElizaCloudServiceRouting({
+    base: baseRouting,
+    includeInference: true,
+  });
+
+  const topology = resolveElizaCloudTopology(root);
+  logger.info(
+    `[eliza] Provisioned cloud topology: runtime=${topology.runtime}, inference=${topology.services.inference}, hasApiKey=${Boolean(config.cloud?.apiKey || process.env.ELIZAOS_CLOUD_API_KEY)}`,
+  );
+}
+
+export function shouldStartThinCloudRuntime(config: ElizaConfig): boolean {
+  if (isProvisionedCloudContainer()) return false;
+
+  const deploymentTarget = resolveDeploymentTargetInConfig(
+    config as Record<string, unknown>,
+  );
+  return Boolean(
+    deploymentTarget.runtime === "cloud" &&
+      deploymentTarget.provider === "elizacloud" &&
+      config.cloud?.apiKey &&
+      config.cloud.agentId?.trim(),
+  );
 }
 
 /**
@@ -3697,13 +3789,11 @@ export async function startEliza(
     return startInCloudMode(config, config.cloud.agentId, opts);
   }
 
-  if (
-    deploymentTarget.runtime === "cloud" &&
-    deploymentTarget.provider === "elizacloud" &&
-    config.cloud?.apiKey &&
-    config.cloud?.agentId?.trim()
-  ) {
-    return startInCloudMode(config, config.cloud.agentId, opts);
+  if (shouldStartThinCloudRuntime(config)) {
+    const cloudAgentId = config.cloud?.agentId?.trim();
+    if (cloudAgentId) {
+      return startInCloudMode(config, cloudAgentId, opts);
+    }
   }
 
   // 3. Build elizaOS Character from Eliza config


### PR DESCRIPTION
## Summary
- force provisioned cloud containers (`ELIZA_CLOUD_PROVISIONED=1`) to canonical Eliza Cloud topology at boot when the in-memory config has lost `deploymentTarget` / `serviceRouting`
- hydrate missing cloud api/baseUrl/agentId fields from container env before topology resolution
- prevent provisioned containers from taking the desktop thin-client `startInCloudMode` shortcut; dedicated containers must still build a local AgentRuntime while routing inference through Eliza Cloud
- add regression coverage for topology repair and thin-client gating

## Why
Phone-agent verified the live container file is correct, but boot still logs `Cloud config: inference=false, runtime=local, hasApiKey=true, isCloudContainer=true`. This patch makes the cloud-container boot path resilient to that exact in-memory config loss and avoids the next misroute once `deploymentTarget.runtime=cloud` is restored.

Refs #9887, #8434.

## Validation
- `bun run --cwd packages/agent test -- src/runtime/eliza-cloud-config.test.ts src/runtime/plugin-collector-mode-policy.test.ts src/runtime/plugin-collector-lean-chat.test.ts` (16 pass)
- `bunx @biomejs/biome check packages/agent/src/runtime/eliza.ts packages/agent/src/runtime/eliza-cloud-config.test.ts --no-errors-on-unmatched`
- `bun run --cwd packages/agent typecheck`
- `git diff --check`
