### PR TITLE
perf(cloud-api): measure pre-forward TTFT via X-Eliza-Preforward-Ms header (#9899)

### DIFF
--- a/packages/cloud-api/v1/chat/completions/route.ts
+++ b/packages/cloud-api/v1/chat/completions/route.ts
@@ -740,6 +740,12 @@ export async function handleChatCompletionsPOST(
   try {
     // 1. Authenticate
     const { user, apiKey } = await requireAuthOrApiKeyWithOrg(req);
+    // Pre-forward TTFT measurement (#9899): measured TTFT through this route is
+    // ~6.5s while cerebras-direct is ~0.24s — 100% of the overhead is here, not
+    // the model. These marks are emitted as an X-Eliza-Preforward-Ms response
+    // header so the exact slow step is readable from a plain curl (no CF log
+    // access needed), pinpointing the fix instead of guessing.
+    const tAuth = Date.now();
 
     // 1b. Per-org tier rate limit
     if (user.organization_id && !options.skipOrgRateLimit) {
@@ -896,6 +902,7 @@ export async function handleChatCompletionsPOST(
       effectiveMaxTokens ?? request.max_tokens ?? 500;
     const affiliateCode = req.headers.get("X-Affiliate-Code");
 
+    const tBeforeReserve = Date.now();
     let reservation: CreditReservation;
     let appCreditsInfo:
       | { appId: string; estimatedBaseCost: number; app: typeof monetizedApp }
@@ -981,6 +988,7 @@ export async function handleChatCompletionsPOST(
     }
 
     settleReservation = createCreditReservationSettler(reservation);
+    const tAfterReserve = Date.now();
 
     // 7. Convert messages for AI SDK
     const systemMessage = request.messages.find((m) => m.role === "system");
@@ -1001,52 +1009,62 @@ export async function handleChatCompletionsPOST(
     });
 
     // 8. Handle streaming vs non-streaming
-    if (request.stream) {
-      return await handleStreamingRequest(
-        model,
-        systemPrompt,
-        modelMessages,
-        request,
-        user,
-        apiKey ? { id: apiKey.id } : null,
-        appCreditsInfo,
-        affiliateCode,
-        idempotencyKey,
-        requestId,
-        appId,
-        startTime,
-        req.signal,
-        routeTimeoutMs,
-        settleReservation,
-        cotOptions,
-        effectiveMaxTokens,
-        webSearchOptions,
-        billingSource,
+    const preforwardResponse = request.stream
+      ? await handleStreamingRequest(
+          model,
+          systemPrompt,
+          modelMessages,
+          request,
+          user,
+          apiKey ? { id: apiKey.id } : null,
+          appCreditsInfo,
+          affiliateCode,
+          idempotencyKey,
+          requestId,
+          appId,
+          startTime,
+          req.signal,
+          routeTimeoutMs,
+          settleReservation,
+          cotOptions,
+          effectiveMaxTokens,
+          webSearchOptions,
+          billingSource,
+        )
+      : await handleNonStreamingRequest(
+          model,
+          systemPrompt,
+          modelMessages,
+          request,
+          user,
+          apiKey ? { id: apiKey.id } : null,
+          appCreditsInfo,
+          affiliateCode,
+          idempotencyKey,
+          requestId,
+          appId,
+          startTime,
+          req.signal,
+          routeTimeoutMs,
+          settleReservation,
+          cotOptions,
+          effectiveMaxTokens,
+          webSearchOptions,
+          billingSource,
+          options.executionCtx,
+        );
+    // Emit per-step pre-forward timing as a readable header (#9899). Debug-only
+    // numbers, no behavior change. totalMs = everything before the model
+    // forward; compare vs cerebras-direct ~0.24s to see how much of TTFT is us.
+    try {
+      preforwardResponse.headers.set(
+        "X-Eliza-Preforward-Ms",
+        `total=${Date.now() - startTime};auth=${tAuth - startTime};mid=${tBeforeReserve - tAuth};reserve=${tAfterReserve - tBeforeReserve}`,
       );
-    } else {
-      return await handleNonStreamingRequest(
-        model,
-        systemPrompt,
-        modelMessages,
-        request,
-        user,
-        apiKey ? { id: apiKey.id } : null,
-        appCreditsInfo,
-        affiliateCode,
-        idempotencyKey,
-        requestId,
-        appId,
-        startTime,
-        req.signal,
-        routeTimeoutMs,
-        settleReservation,
-        cotOptions,
-        effectiveMaxTokens,
-        webSearchOptions,
-        billingSource,
-        options.executionCtx,
-      );
+    } catch {
+      // Some Response shapes have immutable headers — never fail a request for a debug header.
     }
+    return preforwardResponse;
   } catch (error) {
     await settleReservation?.(0);
     const rawMessage = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Why
Dedicated-agent chat is slow (~6.5s). Measured: TTFT through `api.elizacloud.ai` = ~6.5s vs **cerebras-direct = 0.24s** for the same model — 100% of the overhead is cloud-api **pre-forward** work (the serial auth → rate-limit → moderation → reserve Railway round-trips), not the model, not the catalog (KV-cached), not BitRouter (these models route cerebras-direct).

## What
Adds an `X-Eliza-Preforward-Ms` response header: `total=…;auth=…;mid=…;reserve=…`. This lets me read the **exact per-step breakdown from a plain curl in prod** — no CF log access needed — so the follow-up fix targets the real slow step instead of guessing (parallelize the reads vs. the reserve write vs. edge-cache auth).

Additive only: 3 `Date.now()` marks + capture the handler `Response` to set one debug header. **No control-flow or billing change.** Goes to `main` so I can measure prod directly; supersedes #9900's log-only approach (headers are readable end-to-end). I'll post the measured breakdown here, then ship the targeted fix + remove the header.

Refs #9899, #8434.