### PR TITLE
fix(cloud): port #9539 — pricing-catalog 404 must not 500 inference (LIVE prod bug)

### DIFF
--- a/packages/cloud-shared/src/lib/services/ai-pricing/providers/gateway.test.ts
+++ b/packages/cloud-shared/src/lib/services/ai-pricing/providers/gateway.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, mock, test } from "bun:test";
+
+const loggerWarnCalls: unknown[] = [];
+
+mock.module("../../../utils/logger", () => ({
+  logger: {
+    warn: (...args: unknown[]) => {
+      loggerWarnCalls.push(args);
+    },
+  },
+}));
+
+mock.module("./cerebras", () => ({
+  fetchCerebrasPublicCatalogEntries: async () => {
+    throw new Error("cerebras catalog 404");
+  },
+}));
+
+describe("pricing provider gateway", () => {
+  test("degrades external catalog failures instead of throwing", async () => {
+    const { fetchEntriesForSource } = await import("./gateway");
+
+    await expect(fetchEntriesForSource("cerebras")).resolves.toEqual([]);
+    expect(loggerWarnCalls).toHaveLength(1);
+    expect(loggerWarnCalls[0]).toEqual([
+      "[AI Pricing] external catalog fetch failed; using cached/seed pricing",
+      { source: "cerebras", error: "cerebras catalog 404" },
+    ]);
+  });
+});

--- a/packages/cloud-shared/src/lib/services/ai-pricing/providers/gateway.ts
+++ b/packages/cloud-shared/src/lib/services/ai-pricing/providers/gateway.ts
@@ -1,3 +1,4 @@
+import { logger } from "../../../utils/logger";
 import type { PreparedPricingEntry, PriceLookupSource } from "../types";
 import { fetchAtlasCloudCatalogEntries } from "./atlascloud";
 import { fetchBitRouterCatalogEntries } from "./bitrouter";
@@ -7,7 +8,7 @@ import { fetchFalCatalogEntries } from "./fal";
 import { fetchSunoEntries } from "./suno";
 import { fetchVastSnapshotEntries } from "./vast";
 
-export async function fetchEntriesForSource(
+async function dispatchEntriesForSource(
   source: PriceLookupSource,
 ): Promise<PreparedPricingEntry[]> {
   switch (source) {
@@ -34,5 +35,24 @@ export async function fetchEntriesForSource(
       return [];
     default:
       return [];
+  }
+}
+
+export async function fetchEntriesForSource(
+  source: PriceLookupSource,
+): Promise<PreparedPricingEntry[]> {
+  // External pricing-catalog fetches are best-effort METADATA. A provider
+  // outage — e.g. Cerebras retiring its public `/public/v1/models?format=openrouter`
+  // endpoint (now 404) — must degrade pricing, never propagate and 500 the
+  // inference path that prices a completion. Fall back to no fresh entries;
+  // cached/seed pricing still applies.
+  try {
+    return await dispatchEntriesForSource(source);
+  } catch (error) {
+    logger.warn("[AI Pricing] external catalog fetch failed; using cached/seed pricing", {
+      source,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return [];
   }
 }


### PR DESCRIPTION
## Live prod bug
`POST https://api.elizacloud.ai/api/v1/chat/completions` is **500-ing in prod right now**:
```
{"error":{"message":"Request failed for https://api.cerebras.ai/public/v1/models?format=openrouter: 404","type":"api_error"}}
```
Cerebras retired its public `/public/v1/models?format=openrouter` endpoint (now 404). The pricing path (`fetchEntriesForSource` → cerebras provider) **throws on that 404 instead of degrading**, propagating up and 500-ing the inference call on the cold-cache path. Verified live against a real agent key.

## Root cause: main-vs-develop parity gap (3rd one)
The fix — **#9539 (`9dade2bedd`)** — has been on `develop` since 2026-06-25 but was **never ported to `main`**, and prod deploys from main. Same class as the app-auth crash (#9882→#9898) and the orchestrator build break (#9895): fix on develop, prod on main stays broken.

## Fix
Clean cherry-pick of #9539. `fetchEntriesForSource` wraps `dispatchEntriesForSource` in try/catch → returns `[]` + warns on any external-catalog failure (external pricing is best-effort metadata; cached/seed pricing still applies). `fetchCerebrasPublicCatalogEntries` is reached ONLY through this path, so it's fully covered.

## Verification
- Repro: live prod 500 with the exact cerebras-404 message (above).
- After merge + deploy: chat/completions degrades gracefully (uses cached/seed pricing) instead of 500-ing.
- I'll re-curl prod to confirm 200 once the Worker redeploys.

Refs #9539, #8434.