### PR TITLE
fix(core): reconcile EMBEDDING_DIMENSION / EMBEDDING_DIMENSIONS to prevent silent memory breakage

### DIFF
--- a/packages/core/src/__tests__/provisioning.test.ts
+++ b/packages/core/src/__tests__/provisioning.test.ts
@@ -21,15 +21,18 @@ import type { IAgentRuntime } from "../types/runtime";
 function makeRuntime(opts: {
 	hasModel: boolean;
 	embeddingDimension?: string | number;
+	embeddingDimensions?: string | number;
 }): { runtime: IAgentRuntime; ensureDim: ReturnType<typeof vi.fn> } {
 	const ensureDim = vi.fn(async () => true);
 	const runtime = createMockRuntime({
 		agentId: "00000000-0000-0000-0000-000000000001",
 		adapter: { ensureEmbeddingDimension: ensureDim },
 		getModel: vi.fn(() => (opts.hasModel ? async () => [] : undefined)),
-		getSetting: vi.fn((key: string) =>
-			key === "EMBEDDING_DIMENSION" ? opts.embeddingDimension : undefined,
-		),
+		getSetting: vi.fn((key: string) => {
+			if (key === "EMBEDDING_DIMENSION") return opts.embeddingDimension;
+			if (key === "EMBEDDING_DIMENSIONS") return opts.embeddingDimensions;
+			return undefined;
+		}),
 	});
 	return { runtime, ensureDim };
 }
@@ -79,5 +82,37 @@ describe("ensureEmbeddingDimension (core/provisioning.ts daemon-composition prob
 		});
 		await ensureEmbeddingDimension(runtime);
 		expect(ensureDim).toHaveBeenCalledWith(768);
+	});
+
+	it("falls back to EMBEDDING_DIMENSIONS (plural) when EMBEDDING_DIMENSION is unset", async () => {
+		const { runtime, ensureDim } = makeRuntime({
+			hasModel: true,
+			embeddingDimensions: "1536",
+		});
+		await ensureEmbeddingDimension(runtime);
+		expect(ensureDim).toHaveBeenCalledWith(1536);
+	});
+
+	it("prefers the explicit singular EMBEDDING_DIMENSION when the two conflict (and logs a conflict warning)", async () => {
+		const { runtime, ensureDim } = makeRuntime({
+			hasModel: true,
+			embeddingDimension: "384",
+			embeddingDimensions: "1536",
+		});
+		await ensureEmbeddingDimension(runtime);
+		// the explicit singular provisioning setting wins for the DB column; the
+		// operator-facing conflict warning is emitted as a side-effect (visible in
+		// the logger output) so a 384-vs-1536 mismatch can't silently break memory.
+		expect(ensureDim).toHaveBeenCalledWith(384);
+	});
+
+	it("uses the agreed value when singular and plural match", async () => {
+		const { runtime, ensureDim } = makeRuntime({
+			hasModel: true,
+			embeddingDimension: "1536",
+			embeddingDimensions: "1536",
+		});
+		await ensureEmbeddingDimension(runtime);
+		expect(ensureDim).toHaveBeenCalledWith(1536);
 	});
 });

--- a/packages/core/src/provisioning.ts
+++ b/packages/core/src/provisioning.ts
@@ -191,17 +191,42 @@ export async function ensureEmbeddingDimension(
 		return;
 	}
 
-	const raw = runtime.getSetting("EMBEDDING_DIMENSION");
-	const dimension =
-		typeof raw === "number"
-			? raw
-			: typeof raw === "string"
-				? parseInt(raw, 10)
+	// The DB vector-column dimension MUST match the runtime embedder's output
+	// dimension. `EMBEDDING_DIMENSION` (singular) is this provisioning setting;
+	// `EMBEDDING_DIMENSIONS` (plural) is what the runtime embedder (e.g.
+	// @elizaos/plugin-embeddings) uses. They are easily confused, and when they
+	// silently diverge the embedder writes N-dim vectors into an M-dim column —
+	// storage/search breaks and "no facts available" results. Accept both
+	// spellings (singular wins as the explicit provisioning setting), and warn
+	// loudly when both are set to conflicting values.
+	const parseDim = (value: unknown): number =>
+		typeof value === "number"
+			? value
+			: typeof value === "string"
+				? parseInt(value, 10)
 				: NaN;
+	const singular = parseDim(runtime.getSetting("EMBEDDING_DIMENSION"));
+	const plural = parseDim(runtime.getSetting("EMBEDDING_DIMENSIONS"));
+	if (
+		Number.isFinite(singular) &&
+		singular > 0 &&
+		Number.isFinite(plural) &&
+		plural > 0 &&
+		singular !== plural
+	) {
+		logger.warn(
+			{ src: "provisioning", agentId: runtime.agentId, singular, plural },
+			`EMBEDDING_DIMENSION (${singular}) and EMBEDDING_DIMENSIONS (${plural}) conflict — ` +
+				`the DB vector column and the runtime embedder must agree, or memory storage/search will break. ` +
+				`Using EMBEDDING_DIMENSION=${singular}; set both to the same value (e.g. 1536 for OpenAI text-embedding-3-small, 384 for gte-small).`,
+		);
+	}
+	const dimension =
+		Number.isFinite(singular) && singular > 0 ? singular : plural;
 	if (!Number.isFinite(dimension) || dimension <= 0) {
 		logger.debug(
 			{ src: "provisioning", agentId: runtime.agentId },
-			"EMBEDDING_DIMENSION not set or invalid, skipping (set it in character settings to avoid LLM detection)",
+			"EMBEDDING_DIMENSION / EMBEDDING_DIMENSIONS not set or invalid, skipping (set it in character settings to avoid LLM detection)",
 		);
 		return;
 	}


### PR DESCRIPTION
The DB vector-column dimension (provisioning, `EMBEDDING_DIMENSION` singular) must match the runtime embedder's output dimension (e.g. `@elizaos/plugin-embeddings`, `EMBEDDING_DIMENSIONS` plural). These two settings are easily confused, and when they silently diverge the embedder writes N-dim vectors into an M-dim column — **fact/memory storage and semantic search break, surfacing as "no facts available"** even though facts are being extracted.

Observed live on a self-hosted bot: a 384-dim DB column (from `EMBEDDING_DIMENSION=384`) vs a 1536-dim OpenAI embedder (from `EMBEDDING_DIMENSIONS=1536`) → memory recall returned nothing. After reconciling to a consistent 1536, the bot stored + recalled 10/10 test facts.

`ensureEmbeddingDimension` now accepts both spellings (explicit singular wins) and logs a loud, actionable warning naming both values when they conflict, so the mismatch can't pass silently. **8/8** provisioning tests.