### PR TITLE
fix(app-control): don't leak desktop VIEWS modes onto a sub-agent relay

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-identity.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-identity.ts
@@ -27,10 +27,15 @@ const IDENTITY_FILENAMES = ["AGENTS.md", "CLAUDE.md"] as const;
  */
 export const SUB_AGENT_IDENTITY_MD = `# Eliza coding sub-agent — operating manual
 
-You are an autonomous coding sub-agent spawned by Eliza (an elizaOS-based
-assistant) over the Agent Client Protocol to do ONE coding task. This file was
-written into your workspace at spawn. There is NO interactive human in this
-session — you are driven by a program, not a person typing to you.
+Eliza is an elizaOS-based AI assistant a user talks to in a chat connector
+(Discord, Telegram, web, etc.). When the user asks Eliza to build or change
+something, Eliza's orchestrator (plugin-agent-orchestrator) spawns YOU — an
+autonomous coding sub-agent — over the Agent Client Protocol to do ONE coding
+task, then relays your result back into that chat. This file was written into
+your workspace at spawn. There is NO interactive human in this session — you are
+driven by a program, not a person typing to you. Your output is relayed as plain
+CHAT text (in Discord, Telegram, or the app's chat view) — you do not drive any
+desktop/app UI yourself, so report results in words, never as UI commands.
 
 ## Non-interactive (HARD RULE)
 
@@ -84,8 +89,12 @@ For a self-contained task, never touch the bridge.
 
 ## Your final message — lead with the deliverable, not your process
 
-Eliza relays your LAST message to the user, then a synthesis pass keeps the
-load-bearing facts and drops noise. Make that message the answer itself:
+Eliza relays your LAST message back into the ORIGINATING CHAT CONNECTOR
+(Discord/Telegram/web), then a synthesis pass keeps the load-bearing facts and
+drops noise. Your message is plain chat text the user reads — it is NOT a command
+to a desktop app or UI. Never emit app/desktop UI verbs, view/settings commands,
+or control phrases like "Opening your Settings now" — there is no app surface on
+the other end, only chat. Make that message the answer itself:
 
 - Lead with the DELIVERABLE — the value, the command output, the computed
   result, the URL you built, or one line of what changed. Put it first and

--- a/plugins/plugin-app-control/src/actions/views-switching.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-switching.test.ts
@@ -738,6 +738,80 @@ describe("view switching — VIEWS action resolver", () => {
 			expect(ok).toBe(false);
 			expect(owner).toHaveBeenCalled();
 		});
+
+		// A sub-agent completion relay carries content.source="sub_agent" (not the
+		// origin connector). Its true origin is on metadata.originSource. The
+		// desktop-mode gate must resolve the EFFECTIVE source so a Discord-triggered
+		// build relay doesn't terminate on "Opening your Settings now." instead of
+		// relaying the result.
+		function relayMessage(
+			text: string,
+			metadata: Record<string, unknown>,
+		) {
+			return {
+				entityId: "user-1",
+				roomId: "room-1",
+				agentId: "agent-1",
+				content: { text, source: "sub_agent", metadata },
+			};
+		}
+
+		it("gates desktop-only mode off a sub-agent relay that ORIGINATED on a text connector", async () => {
+			const action = createViewsAction({
+				client: clientFor(REGISTRY),
+				hasOwnerAccess: vi.fn(async () => true),
+			});
+			const ok = await action.validate(
+				{ agentId: "agent-1" } as never,
+				relayMessage("Opening your Settings now.", {
+					subAgent: true,
+					originSource: "discord",
+				}) as never,
+				undefined as never,
+				{ action: "open", view: "settings" } as never,
+			);
+			expect(ok).toBe(false);
+		});
+
+		it("gates desktop-only mode off a sub-agent relay with unknown/missing origin (a relay never navigates UI)", async () => {
+			const action = createViewsAction({
+				client: clientFor(REGISTRY),
+				hasOwnerAccess: vi.fn(async () => true),
+			});
+			const ok = await action.validate(
+				{ agentId: "agent-1" } as never,
+				relayMessage("Opening your Settings now.", {
+					subAgent: true,
+				}) as never,
+				undefined as never,
+				{ action: "open", view: "settings" } as never,
+			);
+			expect(ok).toBe(false);
+		});
+
+		// Spawning a sub-agent from WITHIN the Eliza app: the dashboard sends
+		// source="client_chat" (a view-capable local surface), so the relay's
+		// originSource is view-capable and desktop navigation stays available — the
+		// user is in the app and CAN see views. Only text connectors are restricted.
+		it.each(["client_chat", "app", "chat", "user_chat"])(
+			"keeps desktop navigation for a sub-agent relay that originated in the app (%s)",
+			async (originSource) => {
+				const action = createViewsAction({
+					client: clientFor(REGISTRY),
+					hasOwnerAccess: vi.fn(async () => true),
+				});
+				const ok = await action.validate(
+					{ agentId: "agent-1" } as never,
+					relayMessage("show my wallet", {
+						subAgent: true,
+						originSource,
+					}) as never,
+					undefined as never,
+					{ action: "show", view: "wallet" } as never,
+				);
+				expect(ok).toBe(true);
+			},
+		);
 	});
 
 	describe("BUG PROBE: developerMode-gated views reachable by ACTIVE command", () => {

--- a/plugins/plugin-app-control/src/actions/views.ts
+++ b/plugins/plugin-app-control/src/actions/views.ts
@@ -113,18 +113,65 @@ const DESKTOP_ONLY_VIEW_MODES = new Set<ViewsMode>([
 	"tile",
 ]);
 
+// The synthetic source stamped on a sub-agent completion relay
+// (SUB_AGENT_SOURCE / ACPX_ROUTER_SOURCE in plugin-agent-orchestrator). The
+// relay also sets metadata.subAgent and preserves the true origin connector on
+// metadata.originSource — this mirrors that plugin's own relay-detection.
+const SUB_AGENT_RELAY_SOURCE = "sub_agent";
+
+function lowerSource(source: unknown): string {
+	return typeof source === "string" ? source.toLowerCase() : "";
+}
+
+function readContentMetadata(message: Memory): Record<string, unknown> {
+	const metadata = (message.content as { metadata?: unknown } | undefined)
+		?.metadata;
+	return metadata && typeof metadata === "object" && !Array.isArray(metadata)
+		? (metadata as Record<string, unknown>)
+		: {};
+}
+
 /**
- * True when the incoming message arrived over an external text connector that
- * has no Eliza view surface for the user who sent it. Used to keep desktop-only
- * VIEWS modes off the planner surface so a text-connector turn never resolves to
- * a silent view navigation with no chat reply (#8613).
+ * True when this message is a synthetic sub-agent completion relay rather than a
+ * live inbound from a real chat surface. A relay only delivers a sub-agent's
+ * result back to the connector the request came in on; it is not itself a chat
+ * surface, so its `content.source` ("sub_agent") is not where the reply lands.
+ */
+function isSubAgentRelay(message: Memory): boolean {
+	return (
+		lowerSource(message.content?.source) === SUB_AGENT_RELAY_SOURCE ||
+		readContentMetadata(message).subAgent === true
+	);
+}
+
+/**
+ * The connector this turn ultimately surfaces to. For a normal inbound that is
+ * `content.source`. For a sub-agent relay, `content.source` is the synthetic
+ * "sub_agent" marker, so we read the preserved origin connector from
+ * `metadata.originSource` — the surface the result is actually delivered to
+ * (e.g. Discord for a Discord-triggered build, or the in-app dashboard for an
+ * app-triggered one). Empty string when it can't be determined.
+ */
+function effectiveDeliverySource(message: Memory): string {
+	return isSubAgentRelay(message)
+		? lowerSource(readContentMetadata(message).originSource)
+		: lowerSource(message.content?.source);
+}
+
+/**
+ * True when the turn surfaces to an external text connector with no Eliza view
+ * surface for the recipient. Keeps desktop-only VIEWS modes off the planner so
+ * such a turn never resolves to a silent view navigation with no chat reply
+ * (#8613). It resolves the EFFECTIVE delivery surface, so a sub-agent build
+ * relay is judged by where it actually lands: a Discord-triggered relay is
+ * viewless (desktop modes excluded), while an app-triggered one keeps them.
+ * A relay whose origin connector wasn't captured has no confirmed view surface,
+ * so it is treated as viewless too — a relay must not navigate UI into the void.
  */
 export function messageHasNoViewSurface(message: Memory): boolean {
-	const source =
-		typeof message.content?.source === "string"
-			? message.content.source.toLowerCase()
-			: "";
-	return VIEWLESS_TEXT_CONNECTOR_SOURCES.has(source);
+	const source = effectiveDeliverySource(message);
+	if (VIEWLESS_TEXT_CONNECTOR_SOURCES.has(source)) return true;
+	return source === "" && isSubAgentRelay(message);
 }
 
 const MODES: readonly ViewsMode[] = [


### PR DESCRIPTION
A sub-agent completion relay carries `content.source="sub_agent"`; its true origin connector is preserved on `metadata.originSource`. The desktop-only VIEWS-mode exclusion (`messageHasNoViewSurface`) only checked `content.source`, so a Discord-triggered build relay wasn't recognized as viewless — the desktop `open` mode (open Settings) stayed on the planner surface and a relay turn mis-resolved to **"Opening your Settings now."** instead of relaying the built app's URL (observed live).

Resolve the **effective delivery source**: for a sub-agent relay, read `metadata.originSource` (the connector the result actually surfaces to). A Discord-originated relay is then viewless (desktop modes excluded); an **app-originated relay** (`source=client_chat`) keeps view navigation. Also tightens the spawned sub-agent operating manual (output is relayed chat text, never UI verbs).

**161** app-control + **916** orchestrator unit tests; verified live.