### PR TITLE
fix(cloud): negative-cache failed AI-pricing catalog fetch — stop per-request cerebras-404 re-fetch (prod latency)

### DIFF
--- a/packages/cloud-shared/src/lib/services/ai-pricing/cache.test.ts
+++ b/packages/cloud-shared/src/lib/services/ai-pricing/cache.test.ts
@@ -1,0 +1,41 @@
+/**
+ * getCachedExternalEntries negative-caching: a failing external-catalog fetch
+ * (e.g. Cerebras retiring its public catalog → permanent 404) must NOT be
+ * re-run on every hot-path pricing lookup. Regression guard for the prod
+ * latency issue where the failing fetch ran 2x per chat request.
+ */
+import { expect, test } from "bun:test";
+import { getCachedExternalEntries } from "./cache";
+import type { PreparedPricingEntry } from "./types";
+
+test("negative-caches a failing loader — subsequent lookups skip the re-fetch", async () => {
+  let calls = 0;
+  const loader = async (): Promise<PreparedPricingEntry[]> => {
+    calls++;
+    throw new Error("upstream 404");
+  };
+
+  // First call: the failure propagates so the caller degrades to seed/cached
+  // pricing (unchanged behavior); the loader is invoked exactly once.
+  await expect(getCachedExternalEntries("test:neg", loader)).rejects.toThrow("upstream 404");
+  expect(calls).toBe(1);
+
+  // Subsequent call within the negative TTL: returns the cached empty result
+  // WITHOUT re-invoking the (slow, failing) loader.
+  const second = await getCachedExternalEntries("test:neg", loader);
+  expect(second).toEqual([]);
+  expect(calls).toBe(1);
+});
+
+test("caches a successful loader result — loader runs once", async () => {
+  let calls = 0;
+  const entry = { model: "m", provider: "p" } as unknown as PreparedPricingEntry;
+  const loader = async (): Promise<PreparedPricingEntry[]> => {
+    calls++;
+    return [entry];
+  };
+
+  expect(await getCachedExternalEntries("test:pos", loader)).toEqual([entry]);
+  expect(await getCachedExternalEntries("test:pos", loader)).toEqual([entry]);
+  expect(calls).toBe(1);
+});

--- a/packages/cloud-shared/src/lib/services/ai-pricing/cache.ts
+++ b/packages/cloud-shared/src/lib/services/ai-pricing/cache.ts
@@ -1,4 +1,9 @@
-import { EXTERNAL_CACHE_TTL_MS, type ExternalCacheValue, type PreparedPricingEntry } from "./types";
+import {
+  EXTERNAL_CACHE_TTL_MS,
+  type ExternalCacheValue,
+  NEGATIVE_EXTERNAL_CACHE_TTL_MS,
+  type PreparedPricingEntry,
+} from "./types";
 
 const externalCatalogCache = new Map<string, ExternalCacheValue>();
 
@@ -23,7 +28,22 @@ export async function getCachedExternalEntries(
   // Evict expired entries before adding new ones to prevent unbounded growth
   evictExpiredCacheEntries();
 
-  const entries = await loader();
+  let entries: PreparedPricingEntry[];
+  try {
+    entries = await loader();
+  } catch (error) {
+    // Negative-cache the failure (shorter TTL) so a dead/erroring upstream — e.g.
+    // Cerebras retiring its public catalog endpoint (permanent 404) — is NOT
+    // re-fetched on every hot-path pricing lookup. The first failure per TTL
+    // still propagates so the caller logs + degrades to seed/cached pricing
+    // exactly as today; subsequent lookups hit this cached empty result and
+    // skip the (variably slow) network round-trip entirely.
+    externalCatalogCache.set(cacheKey, {
+      entries: [],
+      expiresAt: Date.now() + NEGATIVE_EXTERNAL_CACHE_TTL_MS,
+    });
+    throw error;
+  }
   externalCatalogCache.set(cacheKey, {
     entries,
     expiresAt: Date.now() + EXTERNAL_CACHE_TTL_MS,

--- a/packages/cloud-shared/src/lib/services/ai-pricing/types.ts
+++ b/packages/cloud-shared/src/lib/services/ai-pricing/types.ts
@@ -85,4 +85,14 @@ export type CandidatePreparedPricingEntry = {
 
 export const EXTERNAL_CACHE_TTL_MS = 15 * 60 * 1000;
 
+/**
+ * Shorter TTL used to NEGATIVE-cache a failed external-catalog fetch. Without it,
+ * a permanently-failing upstream (e.g. Cerebras retiring its public
+ * `/public/v1/models?format=openrouter` catalog → 404) is re-fetched on EVERY
+ * hot-path pricing lookup (measured 2x per chat request in prod), adding the
+ * failing fetch's variable latency to every turn. 5 min lets a recovered
+ * upstream be picked up again reasonably soon.
+ */
+export const NEGATIVE_EXTERNAL_CACHE_TTL_MS = 5 * 60 * 1000;
+
 export const BITROUTER_MODELS_URL = "https://api.bitrouter.ai/v1/models?output_modalities=all";


### PR DESCRIPTION
Port to main of #9914 (develop). **Found by tailing prod:** every `/v1/chat/completions` re-fetches the retired Cerebras public catalog (now 404) **2× per request** because `getCachedExternalEntries` only caches successful results — a throwing loader propagates without caching, so the dead endpoint is re-hit on every hot-path pricing lookup (variably slow, 0.6–12s). Fix negative-caches the failure (5-min TTL); first failure still degrades to seed pricing as today, subsequent lookups skip the round-trip. 2 unit tests. Will re-tail prod after deploy to confirm the warnings stop. Refs #9899, #8434.