### PR TITLE
docs(cli-inference): correct the ACTION_PLANNER registration claim

### DIFF
--- a/plugins/plugin-cli-inference/AGENTS.md
+++ b/plugins/plugin-cli-inference/AGENTS.md
@@ -29,8 +29,23 @@ No actions, providers, evaluators, or routes. Model handlers only, and **only th
 | `TEXT_LARGE` | `claude --print` or `codex exec` |
 | `TEXT_MEGA` | "" |
 | `RESPONSE_HANDLER` | "" |
+| `ACTION_PLANNER` | "" — **only when `ELIZA_PLANNER_NATIVE_TOOLS=0`** (text-planner mode) |
 
-`TEXT_SMALL` / `TEXT_NANO` / `TEXT_MEDIUM` and `ACTION_PLANNER` are intentionally **not** registered (the planner needs GBNF / native-tool enforcement the CLI cannot honor).
+`TEXT_SMALL` / `TEXT_NANO` / `TEXT_MEDIUM` are intentionally **not** registered (high-frequency triage tiers fall through to the cheap provider).
+
+`ACTION_PLANNER` is **conditional**: in the default native-tools mode
+(`ELIZA_PLANNER_NATIVE_TOOLS=1`) it is **not** registered, because that planner
+needs GBNF / native-tool grammar the free-text CLI cannot honor — so the planner
+stays on a grammar-honoring provider while the CLI still serves the user-facing
+reply (`RESPONSE_HANDLER`) and large generations (`TEXT_LARGE`). In **text-planner
+mode** (`ELIZA_PLANNER_NATIVE_TOOLS=0`) the CLI **does** register and serve
+`ACTION_PLANNER`: the grammar-heavy planner prompt is rewritten into a clean
+"pick ONE action, emit `{action, params}` JSON" routing prompt (see
+`clean-routing-planner.ts`, proven live with `claude --print --model
+claude-opus-4-8`). This is how the **whole brain** (chat + planner + coding) can
+run on a single Claude Max subscription **TOS-clean**, no API key, no stealth.
+Note: the per-turn `claude` subprocess makes the text-planner path slower than a
+direct-API provider (~tens of seconds for a planner turn).
 
 ## Layout
 

--- a/plugins/plugin-cli-inference/CLAUDE.md
+++ b/plugins/plugin-cli-inference/CLAUDE.md
@@ -29,8 +29,23 @@ No actions, providers, evaluators, or routes. Model handlers only, and **only th
 | `TEXT_LARGE` | `claude --print` or `codex exec` |
 | `TEXT_MEGA` | "" |
 | `RESPONSE_HANDLER` | "" |
+| `ACTION_PLANNER` | "" — **only when `ELIZA_PLANNER_NATIVE_TOOLS=0`** (text-planner mode) |
 
-`TEXT_SMALL` / `TEXT_NANO` / `TEXT_MEDIUM` and `ACTION_PLANNER` are intentionally **not** registered (the planner needs GBNF / native-tool enforcement the CLI cannot honor).
+`TEXT_SMALL` / `TEXT_NANO` / `TEXT_MEDIUM` are intentionally **not** registered (high-frequency triage tiers fall through to the cheap provider).
+
+`ACTION_PLANNER` is **conditional**: in the default native-tools mode
+(`ELIZA_PLANNER_NATIVE_TOOLS=1`) it is **not** registered, because that planner
+needs GBNF / native-tool grammar the free-text CLI cannot honor — so the planner
+stays on a grammar-honoring provider while the CLI still serves the user-facing
+reply (`RESPONSE_HANDLER`) and large generations (`TEXT_LARGE`). In **text-planner
+mode** (`ELIZA_PLANNER_NATIVE_TOOLS=0`) the CLI **does** register and serve
+`ACTION_PLANNER`: the grammar-heavy planner prompt is rewritten into a clean
+"pick ONE action, emit `{action, params}` JSON" routing prompt (see
+`clean-routing-planner.ts`, proven live with `claude --print --model
+claude-opus-4-8`). This is how the **whole brain** (chat + planner + coding) can
+run on a single Claude Max subscription **TOS-clean**, no API key, no stealth.
+Note: the per-turn `claude` subprocess makes the text-planner path slower than a
+direct-API provider (~tens of seconds for a planner turn).
 
 ## Layout
 


### PR DESCRIPTION
The `plugin-cli-inference` CLAUDE.md/AGENTS.md stated `ACTION_PLANNER` is never registered, but the plugin **does** register and serve it in text-planner mode (`ELIZA_PLANNER_NATIVE_TOOLS=0`) — it rewrites the grammar-heavy planner prompt into a clean `{action,params}` routing prompt (`clean-routing-planner.ts`). Clarifies that the whole brain can run on a single Claude Max subscription TOS-clean via `claude --print` (no API key, no stealth), and notes the per-turn subprocess latency tradeoff (the text-planner path is slower than a direct-API provider — measured ~25-68s/turn live, since the planner cold-spawns a process per model call). Pure doc fix; no code change.