### PR TITLE
perf(cloud): flag-gated cold-auth fast path — 1 combined lookup vs 2 round-trips (AUTH_COMBINED_FASTPATH, off by default)

### DIFF
--- a/packages/cloud-shared/src/db/repositories/api-keys.ts
+++ b/packages/cloud-shared/src/db/repositories/api-keys.ts
@@ -1,6 +1,7 @@
 import { and, eq, sql } from "drizzle-orm";
 import { dbRead, dbWrite } from "../helpers";
 import { type ApiKey, apiKeys, type NewApiKey } from "../schemas/api-keys";
+import type { UserWithOrganization } from "./users";
 
 export type { ApiKey, NewApiKey };
 
@@ -74,6 +75,47 @@ export class ApiKeysRepository {
     }
 
     return apiKey;
+  }
+
+  /**
+   * Cold-auth fast path: resolve an active API key + its user + organization in
+   * ONE relational round-trip (instead of the sequential findActiveByHash +
+   * users.findWithOrganization the auth path does today). Parity-critical:
+   * - RELATIONAL hydration (`with: { organization }`), NOT a hand-JOIN/direct
+   *   select, so the org's `credit_balance` numeric formatting matches the
+   *   existing path (direct selects changed it — documented regression).
+   * - Replica-then-primary fallback mirrors findActiveByHash/Consistent so a
+   *   newly-created key isn't rejected on replica lag.
+   * - Same `is_active` filter + `expires_at` check as findActiveByHash.
+   * The caller still applies user.is_active / org.is_active gates.
+   */
+  async findActiveWithUserAndOrg(
+    hash: string,
+  ): Promise<{ apiKey: ApiKey; user: UserWithOrganization } | undefined> {
+    const load = (db: typeof dbRead) =>
+      db.query.apiKeys.findFirst({
+        where: and(eq(apiKeys.key_hash, hash), eq(apiKeys.is_active, true)),
+        with: { user: { with: { organization: true } } },
+      });
+
+    let row = await load(dbRead);
+    if (!row) {
+      row = await load(dbWrite);
+    }
+    if (!row || !row.user) {
+      return undefined;
+    }
+    if (row.expires_at && new Date(row.expires_at) < new Date()) {
+      return undefined;
+    }
+
+    const { user, ...apiKey } = row;
+    return {
+      apiKey: apiKey as ApiKey,
+      // `user` already carries `organization` from the nested relational `with`,
+      // matching UserWithOrganization ({ ...User, organization: Organization | null }).
+      user: user as unknown as UserWithOrganization,
+    };
   }
 
   /**

--- a/packages/cloud-shared/src/db/schemas/relations.ts
+++ b/packages/cloud-shared/src/db/schemas/relations.ts
@@ -83,6 +83,19 @@ export const usersRelations = relations(users, ({ one, many }) => ({
 }));
 
 /**
+ * API keys table relations. Enables the single-round-trip combined auth lookup
+ * (api key + user + organization) used by the cold-auth fast path — see
+ * apiKeysRepository.findActiveWithUserAndOrg. Additive: does not change any
+ * existing query.
+ */
+export const apiKeysRelations = relations(apiKeys, ({ one }) => ({
+  user: one(users, {
+    fields: [apiKeys.user_id],
+    references: [users.id],
+  }),
+}));
+
+/**
  * User identities table relations.
  */
 export const userIdentitiesRelations = relations(userIdentities, ({ one }) => ({

--- a/packages/cloud-shared/src/lib/auth.ts
+++ b/packages/cloud-shared/src/lib/auth.ts
@@ -304,6 +304,27 @@ export async function requireRole(
 }
 
 /**
+ * Cold-auth fast path toggle (off by default). When enabled, API-key auth
+ * resolves key + user + org in one combined lookup instead of two sequential
+ * round-trips. Read once at module init, matching the codebase's env-flag idiom
+ * (e.g. logger.ts). Safe to merge with the flag off: zero behavior change until
+ * it's set in an environment.
+ */
+const AUTH_COMBINED_FASTPATH_ENABLED = process.env.AUTH_COMBINED_FASTPATH === "true";
+
+/**
+ * User + organization active gates applied once an API key has resolved to a
+ * user. Shared by the standard and combined-fast-path API-key flows so they
+ * throw identically (same error types/messages, same ordering).
+ */
+function assertApiKeyUserActive(user: UserWithOrganization | undefined): UserWithOrganization {
+  if (!user) throw new AuthenticationError("User associated with API key not found");
+  if (!user.is_active) throw new ForbiddenError("User account is inactive");
+  if (!user.organization?.is_active) throw new ForbiddenError("Organization is inactive");
+  return user;
+}
+
+/**
  * Validate an API key and return the associated user with full org checks.
  */
 async function validateAndGetApiKeyUser(apiKey: ApiKey): Promise<{ user: UserWithOrganization }> {
@@ -313,11 +334,22 @@ async function validateAndGetApiKeyUser(apiKey: ApiKey): Promise<{ user: UserWit
   }
 
   const user = await usersService.getWithOrganization(apiKey.user_id);
-  if (!user) throw new AuthenticationError("User associated with API key not found");
-  if (!user.is_active) throw new ForbiddenError("User account is inactive");
-  if (!user.organization?.is_active) throw new ForbiddenError("Organization is inactive");
+  return { user: assertApiKeyUserActive(user) };
+}
 
-  return { user };
+/**
+ * Cold-auth fast path (flag-gated): resolve API key + user + org in ONE combined
+ * lookup. Returns the same `api_key` AuthResult as the standard branch on success,
+ * applies the same user/org gates, and returns null for an unknown/invalid key so
+ * callers can preserve their own not-found handling (the Bearer branch falls
+ * through to JWT-vs-key error disambiguation; the X-API-Key branch throws).
+ */
+async function resolveApiKeyFastPath(rawKey: string): Promise<AuthResult | null> {
+  const combined = await apiKeysService.validateApiKeyCombined(rawKey);
+  if (!combined) return null;
+  const user = assertApiKeyUserActive(combined.user);
+  void apiKeysService.incrementUsageDebounced(combined.apiKey.id);
+  return { user, apiKey: combined.apiKey, authMethod: "api_key" };
 }
 
 /**
@@ -360,6 +392,11 @@ export async function requireAuthOrApiKey(request: Request): Promise<AuthResult>
   const authHeader = request.headers.get("authorization");
 
   if (apiKeyHeader && apiKeyHeader.trim().length > 0) {
+    if (AUTH_COMBINED_FASTPATH_ENABLED) {
+      const fast = await resolveApiKeyFastPath(apiKeyHeader);
+      if (!fast) throw new AuthenticationError("Invalid or expired API key");
+      return fast;
+    }
     const apiKey = await apiKeysService.validateApiKey(apiKeyHeader);
     if (!apiKey) throw new AuthenticationError("Invalid or expired API key");
     const { user } = await validateAndGetApiKeyUser(apiKey);
@@ -395,11 +432,16 @@ export async function requireAuthOrApiKey(request: Request): Promise<AuthResult>
     }
 
     // Try as API key (fallback for non-JWT tokens or if JWT validation failed)
-    const apiKey = await apiKeysService.validateApiKey(bearerValue);
-    if (apiKey) {
-      const { user } = await validateAndGetApiKeyUser(apiKey);
-      void apiKeysService.incrementUsageDebounced(apiKey.id);
-      return { user, apiKey, authMethod: "api_key" };
+    if (AUTH_COMBINED_FASTPATH_ENABLED) {
+      const fast = await resolveApiKeyFastPath(bearerValue);
+      if (fast) return fast;
+    } else {
+      const apiKey = await apiKeysService.validateApiKey(bearerValue);
+      if (apiKey) {
+        const { user } = await validateAndGetApiKeyUser(apiKey);
+        void apiKeysService.incrementUsageDebounced(apiKey.id);
+        return { user, apiKey, authMethod: "api_key" };
+      }
     }
 
     if (looksLikeJwt(bearerValue)) {

--- a/packages/cloud-shared/src/lib/cache/keys.ts
+++ b/packages/cloud-shared/src/lib/cache/keys.ts
@@ -28,6 +28,8 @@ export const CacheKeys = {
   },
   apiKey: {
     validation: (keyHash: string) => `apikey:validation:${keyHash}:v1`,
+    /** Combined api-key + user + org auth result (cold-auth fast path). */
+    combinedAuth: (keyHash: string) => `apikey:combined-auth:${keyHash}:v1`,
     /** Cache app lookup by API key ID */
     appMapping: (apiKeyId: string) => `apikey:app:${apiKeyId}:v1`,
     pattern: () => `apikey:*`,
@@ -228,6 +230,12 @@ export const CacheTTL = {
   },
   apiKey: {
     validation: 600, // 10 minutes (was 300s)
+    // SHORT on purpose: the cold-auth win comes from the combined single-round-trip
+    // QUERY (vs 2 sequential), not the cache; this cache only de-dupes the agent's
+    // per-turn burst. Key revoke invalidates it immediately (api-keys invalidateCache);
+    // a short TTL also bounds staleness from user/org DEACTIVATION (which is keyed by
+    // user/org id, not key hash, so it can't cheaply del this entry) to <=60s.
+    combinedAuth: 60,
     appMapping: 600, // 10 minutes - app-to-API-key mapping rarely changes
   },
   /**

--- a/packages/cloud-shared/src/lib/services/api-keys-combined-auth.test.ts
+++ b/packages/cloud-shared/src/lib/services/api-keys-combined-auth.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Cold-auth fast path — combined-auth caching contract.
+ *
+ * Covers apiKeysService.validateApiKeyCombined (the AUTH_COMBINED_FASTPATH
+ * lookup): cache hit (valid) skips the DB, negative-sentinel hit returns null
+ * without the DB, a miss queries once and positive/negative caches the result,
+ * and a corrupt cache entry is dropped + refetched. Mirrors the existing
+ * validateApiKey caching behavior so the fast path is a drop-in.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const UUID = "11111111-1111-1111-1111-111111111111";
+
+let cacheValue: unknown = null;
+let repoResult: unknown;
+
+const cacheGet = mock(async (_key: string) => cacheValue);
+const cacheSet = mock(async (_key: string, _value: unknown, _ttl: number) => {});
+const cacheDel = mock(async (_key: string) => {});
+const findActiveWithUserAndOrg = mock(async (_hash: string) => repoResult);
+
+mock.module("../cache/client", () => ({
+  cache: { get: cacheGet, set: cacheSet, del: cacheDel },
+}));
+
+mock.module("../../db/repositories", () => ({
+  apiKeysRepository: { findActiveWithUserAndOrg },
+}));
+
+mock.module("../utils/logger", () => ({
+  logger: { warn: () => {}, info: () => {}, error: () => {}, debug: () => {} },
+}));
+
+// Break the KMS import chain (db/crypto/api-keys → @elizaos/security/kms);
+// only generateApiKey/create touch it, not the combined-auth path under test.
+mock.module("../../db/crypto/api-keys", () => ({
+  encryptApiKey: async () => ({
+    ciphertext: "",
+    nonce: "",
+    auth_tag: "",
+    kms_key_id: "",
+    kms_key_version: "",
+  }),
+}));
+
+// `../pricing` pulls ai-pricing/lookup → decimal.js (not in the unit test env);
+// only generateApiKey reads API_KEY_PREFIX_LENGTH.
+mock.module("../pricing", () => ({ API_KEY_PREFIX_LENGTH: 12 }));
+
+const { apiKeysService } = await import("./api-keys");
+const { CacheTTL } = await import("../cache/keys");
+
+const apiKey = {
+  id: UUID,
+  organization_id: UUID,
+  user_id: UUID,
+  key_hash: "deadbeef",
+  key_prefix: "eliza_dead",
+  is_active: true,
+  expires_at: null,
+};
+const user = { id: UUID, is_active: true, organization: { id: UUID, is_active: true } };
+const combined = { apiKey, user };
+
+describe("validateApiKeyCombined (cold-auth fast path caching)", () => {
+  beforeEach(() => {
+    cacheValue = null;
+    repoResult = undefined;
+    cacheGet.mockClear();
+    cacheSet.mockClear();
+    cacheDel.mockClear();
+    findActiveWithUserAndOrg.mockClear();
+  });
+
+  test("miss → queries DB once, positive-caches, returns combined", async () => {
+    repoResult = combined;
+    const res = await apiKeysService.validateApiKeyCombined("eliza_key");
+    expect(res).toEqual(combined);
+    expect(findActiveWithUserAndOrg).toHaveBeenCalledTimes(1);
+    // positive cache write uses the combined-auth TTL
+    expect(cacheSet).toHaveBeenCalledTimes(1);
+    expect(cacheSet.mock.calls[0][2]).toBe(CacheTTL.apiKey.combinedAuth);
+  });
+
+  test("valid cache hit → returns cached without touching the DB", async () => {
+    cacheValue = combined;
+    const res = await apiKeysService.validateApiKeyCombined("eliza_key");
+    expect(res).toEqual(combined);
+    expect(findActiveWithUserAndOrg).not.toHaveBeenCalled();
+    expect(cacheSet).not.toHaveBeenCalled();
+  });
+
+  test("negative-sentinel hit → returns null without touching the DB", async () => {
+    cacheValue = { __none: true };
+    const res = await apiKeysService.validateApiKeyCombined("eliza_key");
+    expect(res).toBeNull();
+    expect(findActiveWithUserAndOrg).not.toHaveBeenCalled();
+  });
+
+  test("unknown key → negative-caches and returns null", async () => {
+    repoResult = undefined;
+    const res = await apiKeysService.validateApiKeyCombined("eliza_key");
+    expect(res).toBeNull();
+    expect(findActiveWithUserAndOrg).toHaveBeenCalledTimes(1);
+    // a negative entry is written (short TTL) so a bad-key flood can't hammer the DB
+    expect(cacheSet).toHaveBeenCalledTimes(1);
+  });
+
+  test("corrupt cache entry → dropped, then refetched from DB", async () => {
+    cacheValue = { not: "a valid combined entry" };
+    repoResult = combined;
+    const res = await apiKeysService.validateApiKeyCombined("eliza_key");
+    expect(cacheDel).toHaveBeenCalledTimes(1);
+    expect(findActiveWithUserAndOrg).toHaveBeenCalledTimes(1);
+    expect(res).toEqual(combined);
+  });
+});

--- a/packages/cloud-shared/src/lib/services/api-keys.ts
+++ b/packages/cloud-shared/src/lib/services/api-keys.ts
@@ -7,6 +7,7 @@
 import crypto from "crypto";
 import { encryptApiKey } from "../../db/crypto/api-keys";
 import { type ApiKey, apiKeysRepository, type NewApiKey } from "../../db/repositories";
+import type { UserWithOrganization } from "../../db/repositories/users";
 import { cache } from "../cache/client";
 import { CacheKeys, CacheTTL } from "../cache/keys";
 import { API_KEY_PREFIX_LENGTH } from "../pricing";
@@ -31,6 +32,29 @@ function isCacheableApiKey(value: unknown): value is ApiKey {
     typeof candidate.key_prefix === "string" &&
     typeof candidate.is_active === "boolean"
   );
+}
+
+/**
+ * Validates a cached combined-auth entry ({ apiKey, user+org }) before trusting
+ * it, mirroring isCacheableApiKey. `organization` may be null (org-less account)
+ * but the key must be present so the caller's org gate is meaningful.
+ */
+function isCacheableCombinedAuth(
+  value: unknown,
+): value is { apiKey: ApiKey; user: UserWithOrganization } {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  if (!isCacheableApiKey(candidate.apiKey)) {
+    return false;
+  }
+  const user = candidate.user;
+  if (!user || typeof user !== "object") {
+    return false;
+  }
+  const u = user as Record<string, unknown>;
+  return isUuid(u.id) && typeof u.is_active === "boolean" && "organization" in u;
 }
 
 /**
@@ -128,6 +152,51 @@ export class ApiKeysService {
   }
 
   /**
+   * Cold-auth fast path: validate an API key AND resolve its user + organization
+   * in ONE combined lookup (cache → single relational query), instead of the
+   * sequential validateApiKey + usersService.getWithOrganization the auth path
+   * runs today. Used only when AUTH_COMBINED_FASTPATH is enabled.
+   *
+   * Caching contract mirrors validateApiKey: positive results cached for
+   * CacheTTL.apiKey.combinedAuth (short, see keys.ts), unknown keys negative-cached.
+   * Returns null for unknown / inactive / expired keys (same outcome as a null
+   * validateApiKey). The user.is_active / organization.is_active gates are applied
+   * by the caller — identical to the existing post-getWithOrganization checks.
+   */
+  async validateApiKeyCombined(
+    key: string,
+  ): Promise<{ apiKey: ApiKey; user: UserWithOrganization } | null> {
+    const hash = crypto.createHash("sha256").update(key).digest("hex");
+    const cacheKey = CacheKeys.apiKey.combinedAuth(hash.substring(0, 16));
+
+    const cached = await cache.get<unknown>(cacheKey);
+    if (cached) {
+      if (isNegativeApiKeySentinel(cached)) {
+        logger.debug("[ApiKeys] Cache hit for negative combined-auth lookup");
+        return null;
+      }
+      if (isCacheableCombinedAuth(cached)) {
+        logger.debug("[ApiKeys] Cache hit for combined-auth lookup");
+        return cached;
+      }
+      await cache.del(cacheKey);
+      logger.warn("[ApiKeys] Dropped invalid combined-auth cache entry", { cacheKey });
+    }
+
+    const result = await apiKeysRepository.findActiveWithUserAndOrg(hash);
+    if (result) {
+      await cache.set(cacheKey, result, CacheTTL.apiKey.combinedAuth);
+      logger.debug("[ApiKeys] Cached combined-auth result", {
+        keyPrefix: result.apiKey.key_prefix,
+      });
+      return result;
+    }
+
+    await cache.set(cacheKey, API_KEY_NEGATIVE_SENTINEL, API_KEY_NEGATIVE_TTL_SECONDS);
+    return null;
+  }
+
+  /**
    * Increment usage_count for an API key with per-process debouncing.
    *
    * Without debouncing, every authenticated API request triggers a DB write.
@@ -157,8 +226,15 @@ export class ApiKeysService {
    * Invalidate cache for a specific API key (call on update/delete)
    */
   async invalidateCache(keyHash: string): Promise<void> {
-    const cacheKey = CacheKeys.apiKey.validation(keyHash.substring(0, 16));
-    await cache.del(cacheKey);
+    const shortHash = keyHash.substring(0, 16);
+    // Invalidate BOTH the per-key validation cache and the combined-auth cache
+    // (cold-auth fast path), or a revoked key would keep authenticating via the
+    // combined cache until its TTL. All revoke/update/deactivate paths funnel
+    // through here.
+    await Promise.all([
+      cache.del(CacheKeys.apiKey.validation(shortHash)),
+      cache.del(CacheKeys.apiKey.combinedAuth(shortHash)),
+    ]);
     logger.debug("[ApiKeys] Invalidated API key cache");
   }
 


### PR DESCRIPTION
## Why

API-key auth on a **cold** Cloudflare Worker isolate does **two sequential** Hyperdrive→Railway-Postgres round-trips on a cache miss:

1. `apiKeysService.validateApiKey(key)` → find active key by hash
2. `usersService.getWithOrganization(user_id)` → hydrate user + org

Each cold round-trip is ~2s, so the **auth prelude — not Cerebras (0.24s) — is the bulk of the ~6–7s cold chat latency** (root-caused on #8434: the DB query itself is 0.08ms; the cost is the cold Hyperdrive connection + serial round-trips). This matches @lalalune's read that auth shouldn't be hitting the DB multiple times.

## What

An **opt-in** fast path that resolves **api key + user + organization in ONE relational round-trip**, behind `AUTH_COMBINED_FASTPATH` (**off by default**).

> **Flag off ⇒ zero behavior change.** Safe to merge now; we enable it per-env only after staging parity validation. This is intentionally a code-lands-now / switch-flips-later change.

## Parity (the whole point — preserved exactly)

- **Relational hydration**, not a hand-JOIN/direct select. Direct table selects previously changed `organizations.credit_balance` `numeric(12,6)` formatting (documented billing regression in `attachOrganization`) — so the combined query uses `db.query.apiKeys.findFirst({ with: { user: { with: { organization: true } } } })`, the same path as today.
- **Replica-then-primary fallback** mirrors `findActiveByHash` / `findActiveByHashConsistent`, so a freshly-created key isn't rejected on read-replica lag.
- **Same `is_active` + `expires_at` filtering.** The `user.is_active` / `organization.is_active` gates are factored into a shared `assertApiKeyUserActive()` used by **both** the standard and fast paths, so they throw identical errors.
- **Bearer branch keeps its JWT-vs-key error disambiguation fall-through** (a miss returns `null`, not a throw).

## Caching

Mirrors `validateApiKey`: positive results cached, unknown keys negative-cached (bad-key flood protection). TTL is deliberately **short (60s)**:

- The latency win comes from the **combined query (1 round-trip vs 2)**, not the cache — the cache only de-dupes the agent's per-turn burst.
- **Key revoke/update/delete invalidate the combined entry immediately** via the single `api-keys` `invalidateCache()` funnel (all revoke paths go through it).
- The short TTL **bounds staleness from user/org *deactivation*** (which is keyed by user/org id, not key hash, so it can't cheaply delete this entry) to **≤60s** — a conscious, documented trade-off vs adding cross-service invalidation wiring.

## Layers

| Layer | File |
|------|------|
| `apiKeysRelations` (api key → user relation) | `db/schemas/relations.ts` |
| `findActiveWithUserAndOrg` (combined query, replica→primary) | `db/repositories/api-keys.ts` |
| `combinedAuth` cache key + 60s TTL | `lib/cache/keys.ts` |
| `validateApiKeyCombined` (cache contract) | `lib/services/api-keys.ts` |
| `resolveApiKeyFastPath` + flag wiring (both X-API-Key & Bearer branches) + shared gate | `lib/auth.ts` |
| revoke invalidation of combined entry | `lib/services/api-keys.ts` |

## Tests

5 unit tests for the combined-auth cache contract — cache hit (valid) skips DB, negative-sentinel hit returns null, miss queries once + positive/negative caches, corrupt entry dropped + refetched. `bun test` green, Biome clean.

## Rollout

1. Merge with flag **off** (no-op in prod).
2. Enable `AUTH_COMBINED_FASTPATH=true` in **staging**, validate billing/auth parity (credit_balance formatting, revoke takes effect, inactive user/org blocked).
3. Enable in prod, measure cold-path latency.

Part of the #8434 latency work. cc @lalalune