### PR TITLE
fix(training): remove dead refs to deleted MTP-drafter distillation scripts (#9580)

### DIFF
--- a/packages/training/docs/training/eliza1-smallest-finetunes.md
+++ b/packages/training/docs/training/eliza1-smallest-finetunes.md
@@ -58,16 +58,15 @@ active release gate; the live audit rejects legacy-only evidence.
 
 ## MTP Drafter
 
-Distill the smallest drafter only after the 2B target model is fixed:
+The in-repo drafter distiller and validator (`scripts/distill_mtp_drafter.py`,
+`scripts/mtp/validate_drafter.py`) were removed. Release-grade from-scratch
+drafter distillation is H100/H200-gated and done out of band; it is not required
+for a release-shaped bundle.
 
-```bash
-bash scripts/mtp/jobs/distill_mtp_2b.sh
-python scripts/mtp/validate_drafter.py \
-  --tier 2b \
-  --target-gguf bundles/2b/text/eliza-1-2b-256k.gguf \
-  --drafter-gguf bundles/2b/mtp/drafter-2b.gguf \
-  --report-out bundles/2b/mtp/validation-real.json
-```
+The supported, no-train path converts the published Gemma-4 MTP drafter to the
+`mtp-draft` GGUF arch and A/B-validates it against the target, then stages it at
+`bundles/2b/mtp/drafter-2b.gguf`. Full runbook:
+`plugins/plugin-local-inference/docs/gemma4-mtp-drafter-conversion.md`.
 
 Publish only if the MTP acceptance gate improves or preserves latency
 without regressing correctness.

--- a/packages/training/scripts/kokoro/__tests__/conftest.py
+++ b/packages/training/scripts/kokoro/__tests__/conftest.py
@@ -8,9 +8,8 @@ peft, librosa, onnx). They rely on:
   - `numpy` for the voice-bin shape check.
 
 Each test runs the script's `main()` function directly with argv, asserting
-file outputs. This matches the convention in
-`packages/training/scripts/test_distill_mtp_drafter.py` — drive a CLI by
-its own main() so coverage tracks the real entry point.
+file outputs — drive a CLI by its own `main()` so coverage tracks the real
+entry point.
 """
 
 from __future__ import annotations

--- a/packages/training/scripts/manifest/release_process_guard.py
+++ b/packages/training/scripts/manifest/release_process_guard.py
@@ -17,7 +17,6 @@ BLOCKED_PATTERNS: tuple[str, ...] = (
     "eliza1_eval_suite",
     "benchmark/server.ts",
     "benchmarks.realm.cli",
-    "validate_drafter.py",
     "mtp_drafter_runtime_smoke",
     "elizaos_webshop",
     "elizaos_terminal_bench",

--- a/packages/training/scripts/manifest/stage_local_eliza1_bundle.py
+++ b/packages/training/scripts/manifest/stage_local_eliza1_bundle.py
@@ -379,7 +379,7 @@ _GGUF_DRAFTER_TARGET_CHECKPOINT_KEY: Final[str] = (
 
 def _read_drafter_target_checkpoint_sha256(drafter_path: Path) -> str | None:
     """Read the target text-checkpoint sha256 the drafter was distilled
-    against, recorded as a GGUF metadata string by ``distill_mtp_drafter.py``.
+    against, recorded as a GGUF metadata string by the drafter producer.
 
     Returns ``None`` for local stand-in drafters (source-converted GGUFs
     have no such key). The publish path treats a missing key as a hard
@@ -527,8 +527,9 @@ def _write_target_meta(
                 "finalElizaWeights": False,
                 "architecture": None,
                 "architectureSource": (
-                    "not validated; run scripts/mtp/validate_drafter.py "
-                    "against the final target and drafter GGUFs before publish"
+                    "not validated; validate the target/drafter GGUF pair out "
+                    "of band before publish (see plugins/plugin-local-inference/"
+                    "docs/gemma4-mtp-drafter-conversion.md)"
                 ),
                 # sha256 of the text checkpoint this drafter was distilled
                 # against, copied from the drafter GGUF's
@@ -543,7 +544,8 @@ def _write_target_meta(
                         "key": "tokenizer.ggml.*",
                         "blockingReason": (
                             "target/drafter tokenizer metadata has not been "
-                            "validated by scripts/mtp/validate_drafter.py"
+                            "validated out of band (see plugins/plugin-local-"
+                            "inference/docs/gemma4-mtp-drafter-conversion.md)"
                         ),
                     }
                 ],

--- a/packages/training/scripts/manifest/stage_real_eliza1_bundle.py
+++ b/packages/training/scripts/manifest/stage_real_eliza1_bundle.py
@@ -539,8 +539,9 @@ def _write_target_meta(
                 "finalElizaWeights": True,
                 "architecture": None,
                 "architectureSource": (
-                    "not validated; run scripts/mtp/validate_drafter.py "
-                    "against the final target and drafter GGUFs before publish"
+                    "not validated; validate the target/drafter GGUF pair out "
+                    "of band before publish (see plugins/plugin-local-inference/"
+                    "docs/gemma4-mtp-drafter-conversion.md)"
                 ),
                 "targetCheckpointSha256": drafter_target_sha,
                 "matchesTargetCheckpoint": drafter_matches,
@@ -552,7 +553,8 @@ def _write_target_meta(
                         "key": "tokenizer.ggml.*",
                         "blockingReason": (
                             "target/drafter tokenizer metadata has not been "
-                            "validated by scripts/mtp/validate_drafter.py"
+                            "validated out of band (see plugins/plugin-local-"
+                            "inference/docs/gemma4-mtp-drafter-conversion.md)"
                         ),
                     }
                 ],

--- a/packages/training/scripts/run_pipeline.py
+++ b/packages/training/scripts/run_pipeline.py
@@ -365,10 +365,13 @@ def main() -> int:
                     help="Skip the Eliza-1 GGUF bundle stage.")
     ap.set_defaults(eliza1_bundle=None)  # None ⇒ auto (on iff the fork is found)
     ap.add_argument("--mtp-drafter", action="store_true",
-                    help="Also distill a MTP speculative-decode drafter for "
-                         "this tier (distill_mtp_drafter.py). Needs a GPU for "
-                         "a real run; uses --synthetic-smoke when --eval-mode "
-                         "smoke so the pipeline still validates on CPU.")
+                    help="REMOVED — passing this now hard-errors. In-repo MTP "
+                         "drafter distillation (scripts/distill_mtp_drafter.py) "
+                         "was deleted; release-grade distillation is H100/H200-"
+                         "gated and done out of band. Produce the drafter via "
+                         "the no-train convert + A/B runbook (plugins/plugin-"
+                         "local-inference/docs/gemma4-mtp-drafter-conversion.md) "
+                         "and stage it into the bundle's mtp/ dir.")
     ap.add_argument("--skip-throughput-bench", action="store_true",
                     help="Skip stage 6c (llama-bench tokens/sec on the produced "
                          "GGUFs — prefill + generation t/s, CUDA build if "
@@ -378,6 +381,17 @@ def main() -> int:
 
     if args.publish and not args.bundle_dir:
         raise SystemExit("--publish requires --bundle-dir")
+
+    if args.mtp_drafter:
+        raise SystemExit(
+            "--mtp-drafter is no longer supported: the in-repo drafter "
+            "distillation script (scripts/distill_mtp_drafter.py) was removed. "
+            "Release-grade MTP drafter distillation is H100/H200-gated and done "
+            "out of band. For the supported no-train path, convert the published "
+            "Gemma-4 MTP drafter and A/B it per "
+            "plugins/plugin-local-inference/docs/gemma4-mtp-drafter-conversion.md, "
+            "then stage the resulting drafter GGUF into the bundle's mtp/ dir."
+        )
 
     entry = registry_get(args.registry_key)
     if (
@@ -684,10 +698,12 @@ def main() -> int:
 
     # ───────────── stage 6b: Eliza-1-typed GGUF bundle ─────────────────
     # PolarQuant 4-bit weights packed via the fork's Q4_POLAR GGML type +
-    # QJL1_256 K-cache & TBQ V-cache JSON sidecars + eliza1_manifest.json,
-    # optionally paired with a MTP drafter. optimize_for_eliza1.py is the
-    # canonical orchestrator (it re-runs polarquant→qjl→turboquant idempotently
-    # and then converts via the fork) — run_pipeline just delegates to it.
+    # QJL1_256 K-cache & TBQ V-cache JSON sidecars + eliza1_manifest.json.
+    # The MTP drafter is produced out of band (no-train convert + A/B per
+    # plugins/plugin-local-inference/docs/gemma4-mtp-drafter-conversion.md) and
+    # staged into the bundle's mtp/ dir, not by this stage. optimize_for_eliza1.py
+    # is the canonical orchestrator (it re-runs polarquant→qjl→turboquant
+    # idempotently and then converts via the fork) — run_pipeline delegates to it.
     fork_dir = _resolve_eliza1_llama_cpp()
     want_bundle = args.eliza1_bundle if args.eliza1_bundle is not None else (fork_dir is not None)
     if want_bundle and not args.skip_quantize:
@@ -702,23 +718,6 @@ def main() -> int:
             summary["stages"]["eliza1_bundle"] = {"skipped": "no checkpoint"}
         else:
             opt_dir = ckpt_dir / "eliza1-optimized"
-            drafter_gguf: Path | None = None
-            if args.mtp_drafter:
-                mtp_dir = ckpt_dir / "mtp"
-                d_cmd = [
-                    "uv", "run", "--extra", "train", "python",
-                    "scripts/distill_mtp_drafter.py",
-                    "--tier", tier_id,
-                    "--target-checkpoint", str(finetuned_model),
-                    "--dataset", str(train_file),
-                    "--out-dir", str(mtp_dir),
-                ]
-                if args.eval_mode == "smoke":
-                    d_cmd.append("--synthetic-smoke")
-                rc = run(d_cmd, cwd=ROOT)
-                summary["stages"]["mtp_drafter"] = {"exit": rc, "output": str(mtp_dir)}
-                cand = mtp_dir / f"drafter-{tier_id}.gguf"
-                drafter_gguf = cand if cand.exists() else None
             o_cmd = [
                 "uv", "run", "--extra", "train", "python",
                 "scripts/optimize_for_eliza1.py",
@@ -729,8 +728,6 @@ def main() -> int:
                 "--calibration-samples", "128",
                 "--llama-cpp-dir", str(fork_dir),
             ]
-            if drafter_gguf is not None:
-                o_cmd += ["--drafter-repo", str(drafter_gguf)]
             if args.publish and getattr(entry, "eliza_repo_id", None):
                 o_cmd += ["--hf-repo", entry.eliza_repo_id]
             rc = run(o_cmd, cwd=ROOT)

--- a/packages/training/scripts/train_nebius.sh
+++ b/packages/training/scripts/train_nebius.sh
@@ -474,109 +474,26 @@ fetch() {
   rsync -avhz --info=progress2 "$target:$REMOTE_TRAIN_DIR/reports/" "$ROOT/reports/" || true
 }
 
-# --- MTP drafter distillation (distill_mtp_drafter.py) ----------------
-# Env knobs (defaults frugal — a small KD job, not a full pipeline):
-#   MTP_TIER              tier the drafter ships for. Active tiers (per
-#                            distill_mtp_drafter.py::ACTIVE_TIERS): 2b,
-#                            4b, 9b, 27b, 27b-256k. Default: 2b.
-#   MTP_TARGET_CHECKPOINT remote path (relative to $REMOTE_TRAIN_DIR) to the
-#                            SFT'd target text HF checkpoint directory. The
-#                            distiller loads the target via
-#                            AutoModelForCausalLM.from_pretrained(<this>).
-#                            Required for a real run.
-#   MTP_TARGET_GGUF       (optional) remote path to the final shipped target
-#                            text GGUF; its sha256 is stamped into the drafter
-#                            GGUF metadata (`mtp-draft.target_checkpoint_sha256`).
-#                            Strongly recommended — without it the script falls
-#                            back to hashing model.safetensors[.index.json].
-#   MTP_TARGET_MODEL_ID   (optional) canonical Eliza-1 target model id.
-#                            Defaults to the tier's entry in
-#                            distill_mtp_drafter.py::DEFAULT_TARGET_MODEL
-#                            (e.g. elizaos/eliza-1/bundles/2b for tier=2b).
-#   MTP_STUDENT_BASE      HF id of the student base. Defaults to
-#                            google/gemma-4-E2B-Base (the Eliza-1 mandated
-#                            student for every active tier — keep this aligned
-#                            with model_registry.py::MTP_DRAFTER_BASE).
-#   MTP_DATASET           distillation corpus (default $TRAIN_FILE).
-#   MTP_EPOCHS / MTP_BATCH / MTP_GRAD_ACCUM / MTP_MAX_SEQ_LEN
-#                            default 1 / 8 / 4 / 2048.
-#   MTP_MAX_SAMPLES       cap examples (default 0 = all; set e.g. 20000 for
-#                            a short budget-bounded run).
-#   MTP_OUT_DIR           remote+local out dir name (default
-#                            out/mtp-drafter-${MTP_TIER}).
+# --- MTP drafter distillation (REMOVED) -------------------------------
+# The in-repo drafter distiller (scripts/distill_mtp_drafter.py) was deleted.
+# Release-grade MTP drafter distillation is H100/H200-gated and now done out of
+# band, not driven from this script. The supported no-train path converts the
+# published Gemma-4 MTP drafter to the mtp-draft GGUF arch and A/B-validates it
+# per plugins/plugin-local-inference/docs/gemma4-mtp-drafter-conversion.md, then
+# stages the result at bundles/<tier>/mtp/drafter-<tier>.gguf.
 run_distill_remote() {
-  local target; target="$(ssh_target)"
-  local tier="${MTP_TIER:-2b}"
-  local target_ckpt="${MTP_TARGET_CHECKPOINT:-}"
-  local target_gguf="${MTP_TARGET_GGUF:-}"
-  local target_model_id="${MTP_TARGET_MODEL_ID:-}"
-  local student_base="${MTP_STUDENT_BASE:-google/gemma-4-E2B-Base}"
-  local ds="${MTP_DATASET:-$TRAIN_FILE}"
-  local epochs="${MTP_EPOCHS:-1}" batch="${MTP_BATCH:-8}" ga="${MTP_GRAD_ACCUM:-4}"
-  local msl="${MTP_MAX_SEQ_LEN:-2048}" maxn="${MTP_MAX_SAMPLES:-0}"
-  local out_dir="${MTP_OUT_DIR:-out/mtp-drafter-${tier}}"
-  local hf_tok="${HUGGING_FACE_HUB_TOKEN:-${HF_TOKEN:-}}"
-  local log="$REMOTE_TRAIN_DIR/distill_${RUN_NAME}.log"
+  cat >&2 <<'MSG'
+[train_nebius][distill] ERROR: in-repo MTP drafter distillation was removed.
+scripts/distill_mtp_drafter.py no longer exists, so there is nothing to run on
+the remote box. Release-grade MTP drafter distillation is H100/H200-gated and
+done out of band.
 
-  if [ -z "$target_ckpt" ]; then
-    echo "[train_nebius][distill] ERROR: MTP_TARGET_CHECKPOINT is required (remote path to the SFT'd target text HF checkpoint, e.g. checkpoints/eliza-1-2b-apollo-.../final)" >&2
-    return 2
-  fi
-  local target_gguf_arg=""
-  [ -n "$target_gguf" ] && target_gguf_arg="--target-gguf $target_gguf"
-  local target_model_id_arg=""
-  [ -n "$target_model_id" ] && target_model_id_arg="--target-model-id $target_model_id"
-
-  echo "[train_nebius][distill] tier=$tier target_ckpt=$target_ckpt target_gguf=${target_gguf:-(none)} student_base=$student_base dataset=$ds epochs=$epochs batch=$batch ga=$ga seq=$msl max_samples=$maxn"
-  ssh -o StrictHostKeyChecking=no "$target" "cat > $REMOTE_TRAIN_DIR/.run_distill.sh" <<EOF
-#!/usr/bin/env bash
-set -euo pipefail
-cd $REMOTE_TRAIN_DIR
-export PATH=\$HOME/.local/bin:\$PATH
-export CUDA_VISIBLE_DEVICES=0
-export HF_HOME=/opt/hf-cache
-sudo mkdir -p \$HF_HOME && sudo chown -R \$USER \$HF_HOME || true
-${hf_tok:+export HUGGING_FACE_HUB_TOKEN='$hf_tok'; export HF_TOKEN='$hf_tok'}
-uv sync --extra train
-# Gemma 4 (gemma4 arch) needs transformers >= 4.57.0.dev0; the train
-# extra pins >=4.46. Upgrade in-venv (matches the local box's 5.7.0).
-uv pip install --python .venv/bin/python -U 'transformers>=4.57.0' 'accelerate>=1.1.0'
-# Same cu130-driver problem as run_remote(): the Nebius cuda12.8 image ships a
-# 570.x driver; the cu130-pinned torch can't see CUDA. Swap to cu128.
-.venv/bin/python -c 'import torch,sys; sys.exit(0 if torch.cuda.is_available() else 1)' 2>/dev/null || {
-  echo "[remote][distill] torch cannot see CUDA — swapping to torch 2.11.0+cu128"
-  uv pip uninstall --python .venv/bin/python torch torchvision triton 2>/dev/null || true
-  cu13pkgs="\$(uv pip list --python .venv/bin/python 2>/dev/null | awk '/^nvidia-[a-z0-9-]+ /{print \$1}')"
-  [ -n "\$cu13pkgs" ] && uv pip uninstall --python .venv/bin/python \$cu13pkgs 2>/dev/null || true
-  uv pip install --python .venv/bin/python 'torch==2.11.0' --index-url https://download.pytorch.org/whl/cu128
-  uv pip install --python .venv/bin/python --reinstall nvidia-cusparselt-cu12
-  .venv/bin/python -c 'import torch; assert torch.cuda.is_available(); print("[remote][distill] torch", torch.__version__, "cuda OK on", torch.cuda.get_device_name(0))'
-}
-export UV_NO_SYNC=1 UV_FROZEN=1
-.venv/bin/python scripts/distill_mtp_drafter.py \\
-  --tier $tier \\
-  --target-checkpoint $target_ckpt $target_gguf_arg $target_model_id_arg \\
-  --student-base $student_base \\
-  --dataset $ds --out-dir $out_dir \\
-  --epochs $epochs --batch-size $batch --grad-accum $ga --max-seq-len $msl --max-samples $maxn
-echo DISTILL_DONE_OK
-EOF
-  # Same PIPESTATUS[0] fix as run_remote — `$?` of a tee pipeline is tee's rc.
-  ssh -o StrictHostKeyChecking=no "$target" "chmod +x $REMOTE_TRAIN_DIR/.run_distill.sh; tmux kill-session -t elizadistill 2>/dev/null || true; tmux new-session -d -s elizadistill \"bash $REMOTE_TRAIN_DIR/.run_distill.sh 2>&1 | tee $log; echo DISTILL_EXIT=\\\${PIPESTATUS[0]} >> $log\""
-  echo "[train_nebius][distill] launched under tmux 'elizadistill' — log: $log"
-  local i=0
-  while true; do
-    sleep 60; i=$((i+1))
-    local tail_out; tail_out="$(ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 "$target" "tail -n 3 $log 2>/dev/null" 2>/dev/null || echo '(ssh hiccup)')"
-    echo "[train_nebius][distill] +$((i))m | $(echo "$tail_out" | tr '\n' ' ' | tr '\r' ' ' | tail -c 220)"
-    if ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 "$target" "grep -q 'DISTILL_EXIT=' $log 2>/dev/null"; then
-      local rc; rc="$(ssh -o StrictHostKeyChecking=no "$target" "grep 'DISTILL_EXIT=' $log | tail -1 | sed 's/.*=//'" 2>/dev/null || echo '?')"
-      echo "[train_nebius][distill] finished (DISTILL_EXIT=$rc)"
-      [ "$rc" = "0" ] || return 1
-      break
-    fi
-    if [ "$i" -gt 240 ]; then echo "[train_nebius][distill] ERROR: still running after 4h — bailing (VM left up; ssh in or run teardown)"; return 1; fi
-  done
+Supported no-train path (no GPU box needed): convert the published Gemma-4 MTP
+drafter to the mtp-draft GGUF arch and A/B-validate it, per
+  plugins/plugin-local-inference/docs/gemma4-mtp-drafter-conversion.md
+then stage the result at bundles/<tier>/mtp/drafter-<tier>.gguf.
+MSG
+  return 2
 }
 
 fetch_distill() {


### PR DESCRIPTION
## What

Removes the dead references to the **deleted** MTP-drafter training scripts (`distill_mtp_drafter.py`, `distill_dflash_drafter.py`, `mtp/validate_drafter.py`) across the training pipeline. Closes the one crisp doable-here item flagged in #9580.

These scripts are gone on `develop`, but the pipeline still referenced them — two of those were **real runtime failures**:
- `run_pipeline.py --mtp-drafter` invoked `scripts/distill_mtp_drafter.py` at stage 6b.
- `train_nebius.sh`'s `run_distill_remote()` ssh'd to a GPU box and ran the same missing script.
- The manifest stagers + a doc told users to run the deleted `mtp/validate_drafter.py`.

## Changes (7 files, −150/+65)

| File | Change |
|---|---|
| `run_pipeline.py` | `--mtp-drafter` now **hard-errors at parse time** with an accurate message → the supported no-train convert + A/B runbook; removed the dead stage-6b distill block (behavior-preserving — a drafter-less bundle was already the outcome whenever `--mtp-drafter` was absent). |
| `train_nebius.sh` | `run_distill_remote()` hard-errors instead of running the deleted script; dropped the dead env-knob comment header (−121 lines). |
| `manifest/stage_{local,real}_eliza1_bundle.py` | Reword manifest strings to "validated out of band / see the runbook". `releaseState`/validation logic untouched. |
| `manifest/release_process_guard.py` | Drop the unreachable `"validate_drafter.py"` denylist entry (a deleted script can never be a running process; all live patterns retained). |
| `docs/.../eliza1-smallest-finetunes.md`, `kokoro/__tests__/conftest.py` | Point at the supported convert path / drop the deleted-test comment. |

No new feature, no silent fallback — failures are loud and actionable per the native-inference `AGENTS.md` "hard error, no defensive code" convention.

## Verification

```
python3 -m py_compile run_pipeline.py manifest/stage_*.py manifest/release_process_guard.py  → OK
bash -n train_nebius.sh                                                                       → OK
pytest scripts/manifest/{stage_local,stage_real,release_process_guard,release_verification_queue} + kokoro/__tests__
                                                                                              → 74 passed, 0 failed
grep for the 3 deleted script names                                                           → only the new "removed, use X" messages remain
```

(Pre-existing unrelated failures in `test_audit_hf_eliza1_release.py` — `audit_hf_eliza1_release.py` untouched — are on `develop` already.)

**Evidence:** UI/screens **N/A** (training-script cleanup, no UI surface). Real-LLM trajectory **N/A** (no agent/model code path). Verification = the test/compile output above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)