### PR TITLE
fix(ci): repair cloud test gate after #9917 reorg (was silently false-green)

### DIFF
--- a/packages/scripts/test-cloud-run.mjs
+++ b/packages/scripts/test-cloud-run.mjs
@@ -6,7 +6,7 @@
 // `$OLDPWD` semantics.
 
 import { spawnSync } from "node:child_process";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -27,13 +27,45 @@ const env = {
   SKIP_SERVER_CHECK: "true",
 };
 
-const cloudSharedSrc = path.join(repoRoot, "packages", "cloud-shared", "src");
-const cloudApiTests = path.join(repoRoot, "packages", "cloud-api", "__tests__");
+// NOTE: keep in sync with the package layout. The #9917 reorg moved these from
+// packages/cloud-shared -> packages/cloud/shared and packages/cloud-api ->
+// packages/cloud/api; the stale paths made `bun test` target nonexistent dirs,
+// so the cloud unit suite (incl. the IAC inference hot-path tests) silently ran
+// nothing = false-green gate.
+const cloudSharedSrc = path.join(
+  repoRoot,
+  "packages",
+  "cloud",
+  "shared",
+  "src",
+);
+const cloudApiTests = path.join(
+  repoRoot,
+  "packages",
+  "cloud",
+  "api",
+  "__tests__",
+);
 // cloud-tests.yml already triggers on `packages/scripts/cloud/**`, but nothing
 // here ran those tests — the daemon/admin guards (e.g. the provisioning-worker
 // env-reconcile regression test for #8756) silently never executed. Include the
 // directory so the path trigger actually exercises them.
 const cloudScriptsTests = path.join(repoRoot, "packages", "scripts", "cloud");
+
+// Fail loud if a test root is missing. `bun test <nonexistent-dir>` exits 0 with
+// no tests run, so a stale path (e.g. after a package move) turns this gate into
+// a silent false-green instead of a failure. Guard against that recurring.
+const testRoots = { cloudSharedSrc, cloudApiTests, cloudScriptsTests };
+const missing = Object.entries(testRoots)
+  .filter(([, dir]) => !existsSync(dir))
+  .map(([name, dir]) => `${name} -> ${dir}`);
+if (missing.length > 0) {
+  console.error(
+    `[test:cloud] test root(s) not found — the gate would silently run no tests:\n  ${missing.join("\n  ")}\n` +
+      "Update packages/scripts/test-cloud-run.mjs to match the current package layout.",
+  );
+  process.exit(1);
+}
 
 const result = spawnSync(
   "bun",


### PR DESCRIPTION
## The bug (live, not flag-gated)

The #9917 package reorg moved `packages/cloud-shared` → `packages/cloud/shared` and `packages/cloud-api` → `packages/cloud/api`, but `packages/scripts/test-cloud-run.mjs` (the `test:cloud` gate behind `cloud-tests.yml` + `windows-ci.yml`) still pointed `bun test` at the **old, now-deleted** paths.

`bun test <nonexistent-dir>` exits **0** with no tests run — so the gate went **silently false-green**. **214 cloud-shared test files stopped running in CI**, including the brand-new IAC inference hot-path suites from #9899 (`inference-auth-context`, `inference-billing-fast-path`, `admin-moderation-iac`).

## Fix

- Repoint `cloudSharedSrc` / `cloudApiTests` at the new `packages/cloud/{shared,api}` layout.
- Add a **fail-loud `existsSync` guard** on all test roots, so a future package move breaks the gate loudly instead of silently passing.

## Verification

| check | result |
|---|---|
| corrected roots resolve to real dirs | ✅ all 3 exist |
| `.test.ts` discoverable under corrected `cloud/shared/src` | **214** (was 0) |
| IAC suites present under corrected path | ✅ |
| guard flags the OLD paths as missing | ✅ |
| biome | ✅ clean |

Surfaced by an adversarial review of #9917 (the same review also found a flag-gated billing-sweep KV-pagination bug + some peripheral reorg-stale script paths — reported to @lalalune separately). Refs #8434.