### PR TITLE
chore(cloud-api): enable INFERENCE_HOT_PATH_CACHE on STAGING to measure cold-auth win (#9899)

### DIFF
--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -318,7 +318,7 @@ REDIS_RATE_LIMITING = "false"
 # single cache read; INFERENCE_OPTIMISTIC_BILLING enables Tier-2 off-path
 # billing (durable backstop). SAFE_BALANCE_THRESHOLD (USD) left empty -> +Inf ->
 # every org takes the safe synchronous-reserve path even if optimistic is on.
-INFERENCE_HOT_PATH_CACHE = "false"
+INFERENCE_HOT_PATH_CACHE = "true"
 INFERENCE_OPTIMISTIC_BILLING = "false"
 SAFE_BALANCE_THRESHOLD = ""
 FORCE_REDIS_EVENTS = "false"


### PR DESCRIPTION
## What
One-line, **staging-only**: flips `INFERENCE_HOT_PATH_CACHE` `false → true` under `[env.staging.vars]` in `packages/cloud/api/wrangler.toml`. **Default + production stay `false`** — the prod cutover remains @lalalune's gated call.

## Why
Shaw's IAC #9899 hot-path cache (collapses auth+moderation to one KV read, ~3–5s cold-auth → ~42ms warm) is built + merged but OFF on every env, so prod chat is still the slow path (~11–13s measured). To justify the prod flip we need a real before/after on a safe env.

**Staging is KV-ready** — `[env.staging.kv_namespaces] binding="CACHE_KV"`, `CACHE_ENABLED=true`, `CACHE_BACKEND=auto` — so the fast path actually exercises (not fail-open). And it **fails-open to slow_path** if the cache is ever unavailable (`inference-auth-context.ts:92`), so this is safe even if KV hiccups. Zero real users on staging. Instant revert = flip back.

## After merge
`develop` auto-deploys `eliza-cloud-api-staging`. I'll measure auth/TTFT delta on `api-staging.elizacloud.ai` and post the before/after to #8434 so @lalalune has the data for the prod cutover decision.

@lalalune this is in your IAC rollout lane — merge if you're ready to measure staging, or close it if you want to sequence differently. Not touching prod or your billing flags (`INFERENCE_OPTIMISTIC_BILLING` / `SAFE_BALANCE_THRESHOLD` untouched).