### PR TITLE
chore(cloud): enable INFERENCE_HOT_PATH_CACHE in STAGING only (measure the #9899 latency win)

### DIFF
--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -318,7 +318,7 @@ REDIS_RATE_LIMITING = "false"
 # single cache read; INFERENCE_OPTIMISTIC_BILLING enables Tier-2 off-path
 # billing (durable backstop). SAFE_BALANCE_THRESHOLD (USD) left empty -> +Inf ->
 # every org takes the safe synchronous-reserve path even if optimistic is on.
-INFERENCE_HOT_PATH_CACHE = "false"
+INFERENCE_HOT_PATH_CACHE = "true"
 INFERENCE_OPTIMISTIC_BILLING = "false"
 SAFE_BALANCE_THRESHOLD = ""
 FORCE_REDIS_EVENTS = "false"


### PR DESCRIPTION
Flips the inference hot-path cache ON in **staging only** to get a real latency measurement of shaw's #9899 fix (prod is still slow-path; fix is merged but flag-OFF everywhere).

- **Staging only** — prod + default untouched (prod cutover stays @lalalune's call)
- **Billing flag stays OFF** (Tier-2 has an open KV-sweep bug, #9928)
- **Fails open** to the authoritative slow path if KV is unavailable; flag-OFF/ON verified byte-identical by review
- **Reversible** by reverting one line

@lalalune — you own the rollout sequencing, so I'm not merging this unilaterally while you're active; it's a ready-to-go artifact + I'll measure staging latency the moment it's enabled (by you or on your go). Refs #8434.