### PR TITLE
fix(build): capture root tsconfigs in turbo globalDependencies (cache correctness) (#9626)

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,9 @@
     "package.json",
     "bun.lock",
     "bunfig.toml",
-    "turbo.json"
+    "turbo.json",
+    "tsconfig.json",
+    "tsconfig.base.json"
   ],
   "tasks": {
     "build": {


### PR DESCRIPTION
## What

A Turbo **cache-correctness** fix for #9626: the repo-root TypeScript configs are build inputs for every package, but neither `globalDependencies` nor any task input captured them — so editing a root compiler option replayed **stale cached** `build`/`typecheck`/`lint`/`.d.ts` output across all packages.

- Root `tsconfig.json` (target ES2022, `declaration`, `declarationMap`, `paths`) is extended by **31** package `tsconfig.json` / `tsconfig.declarations.json` files that drive each package's `.d.ts` emit (e.g. `packages/core/tsconfig.declarations.json` → `tsc --project` for the d.ts step).
- `tsconfig.base.json` (ES2024/NodeNext) is extended by `packages/{skills,app,tui}` build/typecheck configs.
- The generic `build` task input `"tsconfig.json"` is **package-relative** (matches `packages/<pkg>/tsconfig.json`, not the root), and neither root path appears anywhere in `turbo.json`.

This is the same class of shared-input cache bug already fixed for `build.config.ts` (#9654) and the shared tsup/vite configs (#9717). `globalDependencies` only **widens** invalidation, so it can never produce stale output or break a build.

## Verification (real `turbo run build --dry-run`, `@elizaos/core#build` hash)

| | touch root `tsconfig.json` → hash |
|---|---|
| **before fix** (current `globalDependencies`) | `3086b8f3…` → `3086b8f3…` — **unchanged** (stale cache, the bug) |
| **after fix** (root tsconfigs added) | `fd9f280d…` → `12d98a43…` — **changes** (cache correctly busted) |

Diff is two lines added to `globalDependencies`.

**UI walkthrough N/A** — build-cache config; verified via the turbo dry-run hash A/B above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)