### PR TITLE
chore(training): drop dead distill plumbing + fix stale docstring (#9580 / #9921 follow-up)

### DIFF
--- a/packages/training/scripts/run_pipeline.py
+++ b/packages/training/scripts/run_pipeline.py
@@ -12,8 +12,9 @@ Stages (skippable individually; see flags):
   6. Quantized benchmark                          → benchmarks/<run>/<q>/
   6b. Eliza-1-typed GGUF bundle (--eliza1-bundle,  → checkpoints/<run>/eliza1-optimized/
       auto-on if the elizaOS/llama.cpp fork is       (Q4_POLAR GGUF + qjl_config.json +
-      found): optimize_for_eliza1.py +                turboquant.json + eliza1_manifest.json),
-      optional MTP drafter (--mtp-drafter)     checkpoints/<run>/mtp/drafter-<tier>.gguf
+      found): optimize_for_eliza1.py +                turboquant.json + eliza1_manifest.json).
+      (The MTP drafter is staged out of band — --mtp-drafter is removed and
+      hard-errors; see gemma4-mtp-drafter-conversion.md for the convert + A/B path.)
   6c. Throughput bench (llama-bench on the GGUFs)  → checkpoints/<run>/evals/throughput.json
       — prefill + gen tokens/sec, CUDA build if       (best -fa 1 -b 2048 -ngl 99 on GPU)
       available; --skip-throughput-bench to skip

--- a/packages/training/scripts/train_nebius.sh
+++ b/packages/training/scripts/train_nebius.sh
@@ -523,34 +523,6 @@ teardown() {
   fi
 }
 
-sync_distill_dataset() {
-  # The distiller needs (a) the corpus file (MTP_DATASET / TRAIN_FILE) and
-  # (b) the SFT'd target HF checkpoint directory (MTP_TARGET_CHECKPOINT).
-  # Optionally (c) the final shipped target GGUF (MTP_TARGET_GGUF) so the
-  # drafter can stamp the exact checkpoint hash.
-  local target; target="$(ssh_target)"
-  local ds="${MTP_DATASET:-$TRAIN_FILE}"
-  local d; d="$(dirname "$ds")"
-  ssh -o StrictHostKeyChecking=no "$target" "mkdir -p $REMOTE_TRAIN_DIR/$d"
-  echo "[train_nebius][sync] sending distillation corpus $ds"
-  rsync -avhz --partial --info=progress2 "$ROOT/$ds" "$target:$REMOTE_TRAIN_DIR/$ds"
-
-  local target_ckpt="${MTP_TARGET_CHECKPOINT:-}"
-  if [ -n "$target_ckpt" ]; then
-    local ckpt_dir; ckpt_dir="$(dirname "$target_ckpt")"
-    ssh -o StrictHostKeyChecking=no "$target" "mkdir -p $REMOTE_TRAIN_DIR/$ckpt_dir"
-    echo "[train_nebius][sync] sending target HF checkpoint $target_ckpt (this is the SFT'd text model — multi-GB)"
-    rsync -avhz --partial --info=progress2 "$ROOT/$target_ckpt/" "$target:$REMOTE_TRAIN_DIR/$target_ckpt/"
-  fi
-  local target_gguf="${MTP_TARGET_GGUF:-}"
-  if [ -n "$target_gguf" ]; then
-    local gguf_dir; gguf_dir="$(dirname "$target_gguf")"
-    ssh -o StrictHostKeyChecking=no "$target" "mkdir -p $REMOTE_TRAIN_DIR/$gguf_dir"
-    echo "[train_nebius][sync] sending target GGUF $target_gguf"
-    rsync -avhz --partial --info=progress2 "$ROOT/$target_gguf" "$target:$REMOTE_TRAIN_DIR/$target_gguf"
-  fi
-}
-
 case "$cmd" in
   smoke) smoke ;;
   provision) provision ;;
@@ -575,16 +547,12 @@ case "$cmd" in
     fetch
     ;;
   distill-full)
-    # Provision → sync training tree → sync the one corpus → distill → fetch
-    # the drafter → teardown. Frugal: a single H200 for ~1-3 GPU-h on a small
-    # KD job. Set MTP_MAX_SAMPLES for a short budget-bounded pass.
-    # Same fetch-then-teardown pattern as `full` — see v4 incident note above.
-    trap 'echo "[train_nebius] distill-full: ensuring fetch + teardown on exit"; fetch_distill || true; teardown || true' EXIT
-    provision
-    sync_tree
-    sync_distill_dataset
+    # The remote MTP-drafter distillation path was removed (the in-repo
+    # distiller scripts are gone; release-grade distillation is H100/H200-gated
+    # and done out of band — produce the drafter via the no-train convert + A/B
+    # runbook instead). run_distill_remote hard-errors, so fail fast HERE before
+    # provisioning a VM / rsyncing the tree (avoids a wasteful spin-up + teardown).
     run_distill_remote
-    fetch_distill
     ;;
   help|*) sed -n '1,80p' "$0" ;;
 esac


### PR DESCRIPTION
## What

Follow-up to the merged #9921, from an adversarial re-review of that change.

1. **`train_nebius.sh` — fail fast before provisioning.** `run_distill_remote()` was made to hard-error in #9921 (the in-repo distiller is gone), but the `distill-full` command still ran `provision` → `sync_tree` → `sync_distill_dataset` (spinning up an H200 + rsyncing multi-GB) **before** reaching that hard-error, then tore the VM down — wasteful cloud spend on a dead path. `distill-full` now calls `run_distill_remote` first, so it errors with the actionable message *before* any VM is provisioned. The now-orphaned `sync_distill_dataset()` helper (only caller was `distill-full`) is removed per the dead-code mandate. **−39/+8 lines.**

2. **`run_pipeline.py` — stale docstring.** The module flow comment still listed `optional MTP drafter (--mtp-drafter) → …mtp/drafter-<tier>.gguf` as a live stage; `--mtp-drafter` was removed and hard-errors in #9921. Reworded to point at the out-of-band convert + A/B path.

## Verification

```
bash -n packages/training/scripts/train_nebius.sh   → OK
python3 -m py_compile packages/training/scripts/run_pipeline.py → OK
grep sync_distill_dataset train_nebius.sh           → 0 refs (fully removed)
```

No behavior change for any working path — `distill-full` already errored on the missing remote script; it now errors sooner and cheaper.

**UI N/A** — training CLI dead-code cleanup; verified via the compile checks above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)