### PR TITLE
fix(ui): simplify cloud auth completion

### DIFF
--- a/packages/app/public/_headers
+++ b/packages/app/public/_headers
@@ -32,6 +32,11 @@
 /assets/*
   Cache-Control: public, max-age=31536000, immutable
 
-# OAuth/popup callback pages need a relaxed COOP so window.closed works.
+# OAuth/popup callback pages need a relaxed COOP so popup status remains
+# observable when a browser path is script-opened. OS-opened tabs still must not
+# render dead close controls.
 /app-auth/*
+  Cross-Origin-Opener-Policy: same-origin-allow-popups
+
+/auth/*
   Cross-Origin-Opener-Policy: same-origin-allow-popups

--- a/packages/ui/src/cloud/public-pages/pages/auth/auth-success-page.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/auth-success-page.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const searchParamsRef = vi.hoisted(() => ({
+  current: new URLSearchParams("platform=github"),
+}));
+
+vi.mock("react-router-dom", () => ({
+  useSearchParams: () => [searchParamsRef.current, vi.fn()],
+}));
+
+vi.mock("../../../shell/CloudI18nProvider", () => ({
+  useCloudT:
+    () =>
+    (
+      _key: string,
+      opts?: { defaultValue?: string; platform?: string },
+    ): string =>
+      (opts?.defaultValue ?? _key).replace(
+        "{{platform}}",
+        opts?.platform ?? "",
+      ),
+}));
+
+vi.mock("../../lib/use-page-title", () => ({ usePageTitle: () => {} }));
+
+import AuthSuccessPage from "./auth-success-page";
+
+describe("AuthSuccessPage", () => {
+  beforeEach(() => {
+    searchParamsRef.current = new URLSearchParams("platform=github");
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("shows the connected platform and routes back to Cloud without trying to close the tab", () => {
+    const closeSpy = vi.spyOn(window, "close").mockImplementation(() => {});
+
+    render(<AuthSuccessPage />);
+
+    expect(screen.getByText("GitHub Connected")).toBeTruthy();
+    expect(
+      screen.getByText("Your GitHub account has been connected successfully."),
+    ).toBeTruthy();
+    expect(screen.queryByText(/say/i)).toBeNull();
+    expect(screen.queryByText("You can close this window.")).toBeNull();
+    expect(
+      screen
+        .getByRole("link", { name: "Open Eliza Cloud" })
+        .getAttribute("href"),
+    ).toBe("/dashboard");
+    expect(closeSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/cloud/public-pages/pages/auth/auth-success-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/auth-success-page.tsx
@@ -1,14 +1,16 @@
 /**
  * OAuth/connector auth-success callback page (public). Shows a connection-
- * successful card and auto-closes the popup. Ported from
+ * successful card and routes the user back into Cloud. Ported from
  * `@elizaos/cloud-frontend/src/pages/auth/success/page.tsx`.
  */
 
-import { CheckCircle, MessageCircle } from "lucide-react";
-import { useEffect, useState } from "react";
+import { CheckCircle } from "lucide-react";
 import { useSearchParams } from "react-router-dom";
+import { Button } from "../../../../components/primitives";
 import { useCloudT } from "../../../shell/CloudI18nProvider";
 import { usePageTitle } from "../../lib/use-page-title";
+
+const CLOUD_DASHBOARD_PATH = "/dashboard";
 
 const platformNames: Record<string, string> = {
   google: "Google",
@@ -26,7 +28,6 @@ function capitalize(str: string): string {
 
 export default function AuthSuccessPage() {
   const t = useCloudT();
-  const [canClose, setCanClose] = useState(false);
   const [searchParams] = useSearchParams();
 
   usePageTitle(
@@ -45,19 +46,6 @@ export default function AuthSuccessPage() {
   const platformDisplay = platform
     ? platformNames[platform.toLowerCase()] || capitalize(platform)
     : null;
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      try {
-        window.close();
-      } catch {
-        setCanClose(true);
-      }
-      setCanClose(true);
-    }, 2000);
-
-    return () => clearTimeout(timer);
-  }, []);
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-black p-4">
@@ -92,30 +80,13 @@ export default function AuthSuccessPage() {
             </p>
           </div>
 
-          <div className="w-full p-4 bg-white/[0.04] border border-white/14">
-            <div className="flex items-center gap-3 text-left">
-              <MessageCircle className="h-5 w-5 text-neutral-400 flex-shrink-0" />
-              <p className="text-sm text-neutral-300">
-                {t("cloud.authSuccess.returnPrefix", {
-                  defaultValue: "Return to your chat and say",
-                })}{" "}
-                <span className="text-white font-medium">
-                  {t("cloud.authSuccess.doneWord", { defaultValue: '"done"' })}
-                </span>{" "}
-                {t("cloud.authSuccess.returnSuffix", {
-                  defaultValue: "to verify the connection.",
-                })}
-              </p>
-            </div>
-          </div>
-
-          {canClose && (
-            <p className="text-xs text-neutral-600">
-              {t("cloud.authSuccess.canClose", {
-                defaultValue: "You can close this window.",
+          <a href={CLOUD_DASHBOARD_PATH} className="w-full">
+            <Button className="w-full h-11 bg-[var(--brand-orange)] hover:bg-[#e54f00] text-white">
+              {t("cloud.authSuccess.openCloud", {
+                defaultValue: "Open Eliza Cloud",
               })}
-            </p>
-          )}
+            </Button>
+          </a>
         </div>
       </div>
     </div>

--- a/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.test.tsx
@@ -120,7 +120,7 @@ describe("CliLoginPage", () => {
     expect(link.getAttribute("href")).toBe(SIGN_IN_HREF);
   });
 
-  it("completes the session when authenticated: POSTs /complete, notifies the opener, shows success, never redirects", async () => {
+  it("completes the session when authenticated: POSTs /complete, notifies the opener, and lands in Cloud", async () => {
     sessionAuthRef.current = {
       ready: true,
       authenticated: true,
@@ -151,11 +151,16 @@ describe("CliLoginPage", () => {
       { type: "eliza-cloud-auth-complete", sessionId: "sess-1" },
       "*",
     );
-    expect(screen.getByText("ek_live_abc")).toBeTruthy();
-    expect(navigateMock).not.toHaveBeenCalled();
+    expect(screen.getByText("Opening your dashboard...")).toBeTruthy();
+    expect(screen.queryByText("API Key Details")).toBeNull();
+    expect(screen.queryByText("ek_live_abc")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Close Window" })).toBeNull();
+    expect(navigateMock).toHaveBeenCalledWith("/dashboard", {
+      replace: true,
+    });
   });
 
-  it("renders the error panel when the session id is missing — no POST, no redirect", async () => {
+  it("renders the error panel when the session id is missing — no POST, no redirect, no dead close button", async () => {
     searchParamsRef.current = new URLSearchParams("");
 
     render(<CliLoginPage />);
@@ -165,6 +170,12 @@ describe("CliLoginPage", () => {
     ).toBeTruthy();
     expect(apiFetchMock).not.toHaveBeenCalled();
     expect(navigateMock).not.toHaveBeenCalled();
+    expect(screen.queryByRole("button", { name: "Close Window" })).toBeNull();
+    expect(
+      screen
+        .getByRole("link", { name: "Open Eliza Cloud" })
+        .getAttribute("href"),
+    ).toBe("/dashboard");
   });
 
   it("surfaces a completion failure as the error panel", async () => {
@@ -184,6 +195,7 @@ describe("CliLoginPage", () => {
       expect(screen.getByText("Authentication Error")).toBeTruthy(),
     );
     expect(screen.getByText("boom")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Close Window" })).toBeNull();
   });
 
   it("clears the stale Steward session on a 401 during completion", async () => {

--- a/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.tsx
@@ -37,6 +37,8 @@ type PageState =
 
 type PanelTone = "accent" | "danger" | "success";
 
+const CLOUD_DASHBOARD_PATH = "/dashboard";
+
 const PANEL_TONE_CLASSES: Record<
   PanelTone,
   { container: string; icon: string }
@@ -74,12 +76,6 @@ function getPageState({
   if (!ready) return { status: "initializing" };
   if (!authenticated) return { status: "waiting_auth" };
   return { status: "loading" };
-}
-
-function getUserEmail(user: unknown): string | undefined {
-  if (!user || typeof user !== "object" || !("email" in user)) return undefined;
-  const { email } = user as { email?: unknown };
-  return typeof email === "string" ? email : undefined;
 }
 
 function CliLoginPanel({
@@ -126,7 +122,7 @@ function CliLoginPanel({
 
 export default function CliLoginPage() {
   const t = useCloudT();
-  const { authenticated, ready, user } = useSessionAuth();
+  const { authenticated, ready } = useSessionAuth();
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const sessionId = searchParams.get("session");
@@ -203,6 +199,11 @@ export default function CliLoginPage() {
     };
   }, [authenticated, ready, sessionId, t]);
 
+  useEffect(() => {
+    if (completion.status !== "success") return;
+    navigate(CLOUD_DASHBOARD_PATH, { replace: true });
+  }, [completion.status, navigate]);
+
   const pageState = getPageState({
     authenticated,
     completion,
@@ -213,7 +214,6 @@ export default function CliLoginPage() {
   const returnToQuery = searchParams.toString();
   const returnTo = `/auth/cli-login${returnToQuery ? `?${returnToQuery}` : ""}`;
   const signInHref = `/login?returnTo=${encodeURIComponent(returnTo)}`;
-  const userEmail = getUserEmail(user);
 
   // No "CLI Authentication" interstitial: when the user isn't signed in yet,
   // forward straight to the Steward login. `returnTo` brings the browser back
@@ -278,15 +278,16 @@ export default function CliLoginPage() {
                 </Button>
               </a>
             ) : null}
-            <Button
-              onClick={() => window.close()}
-              variant="outline"
-              className="w-full mt-2 border-white/14 hover:bg-white/10"
-            >
-              {t("cloud.cliLogin.closeWindow", {
-                defaultValue: "Close Window",
-              })}
-            </Button>
+            <a href={CLOUD_DASHBOARD_PATH} className="w-full">
+              <Button
+                variant="outline"
+                className="w-full mt-2 border-white/14 hover:bg-white/10"
+              >
+                {t("cloud.cliLogin.openCloud", {
+                  defaultValue: "Open Eliza Cloud",
+                })}
+              </Button>
+            </a>
           </>
         }
         description={pageState.errorMessage}
@@ -376,17 +377,16 @@ export default function CliLoginPage() {
     return (
       <CliLoginPanel
         actions={
-          <Button
-            onClick={() => window.close()}
-            variant="outline"
-            className="w-full border-white/14 hover:bg-white/10"
-          >
-            {t("cloud.cliLogin.closeWindow", { defaultValue: "Close Window" })}
-          </Button>
+          <a href={CLOUD_DASHBOARD_PATH} className="w-full">
+            <Button className="w-full h-11 bg-[var(--brand-orange)] hover:bg-[#e54f00] text-white">
+              {t("cloud.cliLogin.openCloud", {
+                defaultValue: "Open Eliza Cloud",
+              })}
+            </Button>
+          </a>
         }
         description={t("cloud.cliLogin.successDescription", {
-          defaultValue:
-            "You're signed in. Your credentials were sent to the app or CLI you started from.",
+          defaultValue: "You're signed in. Redirecting you to Eliza Cloud.",
         })}
         icon={CheckCircle2}
         title={t("cloud.cliLogin.authComplete", {
@@ -394,42 +394,11 @@ export default function CliLoginPage() {
         })}
         tone="success"
       >
-        <div className="w-full bg-black/40 border border-white/14 p-4 space-y-3">
-          <p className="text-xs font-medium text-neutral-400">
-            {t("cloud.cliLogin.apiKeyDetails", {
-              defaultValue: "API Key Details",
-            })}
-          </p>
-          <div className="text-sm space-y-2">
-            <div className="flex justify-between">
-              <span className="text-neutral-500">
-                {t("cloud.cliLogin.prefix", { defaultValue: "Prefix" })}
-              </span>
-              <span className="font-mono text-white">
-                {pageState.apiKeyPrefix}
-              </span>
-            </div>
-            <div className="flex justify-between">
-              <span className="text-neutral-500">
-                {t("cloud.cliLogin.createdFor", {
-                  defaultValue: "Created for",
-                })}
-              </span>
-              <span className="text-white">
-                {userEmail ||
-                  t("cloud.cliLogin.yourAccount", {
-                    defaultValue: "Your account",
-                  })}
-              </span>
-            </div>
-          </div>
-        </div>
-
         <div className="w-full border border-green-500/20 bg-green-500/5 p-4">
           <p className="text-sm text-green-400 flex items-center justify-center gap-2">
             <CheckCircle2 className="h-4 w-4" />
-            {t("cloud.cliLogin.returnToTerminal", {
-              defaultValue: "You can now close this window.",
+            {t("cloud.cliLogin.redirectingToDashboard", {
+              defaultValue: "Opening your dashboard...",
             })}
           </p>
         </div>


### PR DESCRIPTION
## Summary

- removes dead `window.close()` actions from `/auth/cli-login` and `/auth/success` public auth pages
- redirects successful CLI/device auth into `/dashboard` and replaces stranded success/error close controls with an `Open Eliza Cloud` affordance
- adds `/auth/*` COOP coverage alongside `/app-auth/*` in the checked-in Pages `_headers` source
- adds regression coverage for CLI completion, no dead close button, stripped API-key detail copy, and connector auth success

Refs #9961. This is the high-confidence auth completion slice; Developer-view/settings gating remains follow-up scope in the issue.

## Validation

- `bun run test src/cloud/public-pages/pages/auth/cli-login-page.test.tsx src/cloud/public-pages/pages/auth/auth-success-page.test.tsx` from `packages/ui` -> 7/7 passed
- `bun run typecheck` from `packages/ui` -> passed
- `bunx biome check packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.tsx packages/ui/src/cloud/public-pages/pages/auth/auth-success-page.tsx packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.test.tsx packages/ui/src/cloud/public-pages/pages/auth/auth-success-page.test.tsx packages/app/public/_headers` -> passed
- `git diff --check origin/develop...HEAD` -> passed
- `ELIZA_UI_SMOKE_DISABLE_VIDEO=1 bun run --cwd packages/app test:e2e test/ui-smoke/assistant-home-flow.spec.ts test/ui-smoke/cloud-provisioning-startup.spec.ts` -> 9/9 passed after rebase onto current develop

## Notes

- Browser plugin is not available in this Codex session, so rendered validation used the repo Playwright smoke suite.
- The issue mentions a generated `packages/cloud/frontend/dist/_headers`; that file is not present in the current checkout after the package reorg. I patched the checked-in `packages/app/public/_headers` source that actually exists here.
