### PR TITLE
fix(ui): simplify app auth consent

### DIFF
--- a/packages/ui/src/cloud-ui/components/auth/authorize-content.test.tsx
+++ b/packages/ui/src/cloud-ui/components/auth/authorize-content.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const authRef = vi.hoisted(() => ({
+  current: {
+    isLoading: false,
+    isAuthenticated: true,
+    getToken: vi.fn(() => "token-1"),
+    signOut: vi.fn(),
+    providers: [],
+    isProvidersLoading: false,
+  },
+}));
+
+const pushMock = vi.hoisted(() => vi.fn());
+const searchParamsRef = vi.hoisted(() => ({
+  current: new URLSearchParams(
+    "app_id=app-1&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&state=state-1",
+  ),
+}));
+
+vi.mock("@stwd/react", () => ({
+  StewardLogin: ({ title }: { title?: string }) => (
+    <div data-testid="steward-login">{title}</div>
+  ),
+  useAuth: () => authRef.current,
+}));
+
+vi.mock("../../runtime/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+  useSearchParams: () => searchParamsRef.current,
+}));
+
+vi.mock("../../runtime/image", () => ({
+  default: (props: { src: string; alt: string }) => (
+    <img src={props.src} alt={props.alt} />
+  ),
+}));
+
+import { AuthorizeContent } from "./authorize-content";
+
+function mockAppFetch() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        app: {
+          id: "app-1",
+          name: "Demo App",
+          website_url: "https://demo.example",
+        },
+      }),
+    })),
+  );
+}
+
+describe("AuthorizeContent", () => {
+  beforeEach(() => {
+    authRef.current = {
+      isLoading: false,
+      isAuthenticated: true,
+      getToken: vi.fn(() => "token-1"),
+      signOut: vi.fn(),
+      providers: [],
+      isProvidersLoading: false,
+    };
+    pushMock.mockReset();
+    searchParamsRef.current = new URLSearchParams(
+      "app_id=app-1&redirect_uri=https%3A%2F%2Fexample.com%2Fcallback&state=state-1",
+    );
+    mockAppFetch();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("renders a compact signed-in consent screen with one primary action and one cancel affordance", async () => {
+    render(<AuthorizeContent />);
+
+    await waitFor(() => expect(screen.getByText("Demo App")).toBeTruthy());
+
+    expect(
+      screen.getByText(
+        "Connect Demo App to your Eliza Cloud account. AI features may use your cloud credit balance.",
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByText("This app wants to:")).toBeNull();
+    expect(screen.queryByText("Access your Eliza Cloud account")).toBeNull();
+    expect(screen.queryByText(/By continuing/)).toBeNull();
+    expect(screen.queryByText("Signed in")).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Authorize Demo App" }),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy();
+  });
+
+  it("keeps the signed-out state to sign-in controls plus one cancel affordance", async () => {
+    authRef.current = {
+      ...authRef.current,
+      isAuthenticated: false,
+    };
+
+    render(<AuthorizeContent />);
+
+    await waitFor(() => expect(screen.getByText("Demo App")).toBeTruthy());
+
+    expect(screen.getByTestId("steward-login").textContent).toBe(
+      "Sign in to authorize",
+    );
+    expect(screen.queryByText("This app wants to:")).toBeNull();
+    expect(screen.queryByText(/By continuing/)).toBeNull();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy();
+  });
+});

--- a/packages/ui/src/cloud-ui/components/auth/authorize-content.tsx
+++ b/packages/ui/src/cloud-ui/components/auth/authorize-content.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { StewardLogin, useAuth } from "@stwd/react";
-import { AlertTriangle, CheckCircle2, Loader2, Shield } from "lucide-react";
+import { AlertTriangle, Loader2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import Image from "../../runtime/image";
 import { useRouter, useSearchParams } from "../../runtime/navigation";
@@ -247,7 +247,10 @@ function AuthorizeAuthenticatedContent({
   return (
     <Frame>
       <AppHeader appInfo={appInfo} />
-      <PermissionsList />
+      <p className="max-w-sm text-center text-sm text-white/60">
+        Connect {appInfo.name} to your Eliza Cloud account. AI features may use
+        your cloud credit balance.
+      </p>
 
       {error && (
         <div className="rounded-sm border border-red-400/40 bg-red-500/10 p-3 text-sm text-red-200">
@@ -267,11 +270,6 @@ function AuthorizeAuthenticatedContent({
           providersReady={providersReady}
         />
       )}
-
-      <p className="text-center text-xs text-white/40">
-        By continuing, you agree to share your account information with this
-        app.
-      </p>
     </Frame>
   );
 }
@@ -351,27 +349,6 @@ function AppHeader({ appInfo }: { appInfo: AppInfo }) {
   );
 }
 
-function PermissionsList() {
-  return (
-    <div className="space-y-3 p-4 rounded-sm bg-white/5 border border-white/10 w-full">
-      <div className="flex items-center gap-2 text-white/80">
-        <Shield className="h-4 w-4 text-[#FF5800]" />
-        <span className="text-sm font-medium">This app wants to:</span>
-      </div>
-      <ul className="space-y-2 text-sm text-white/60 ml-6">
-        <li className="flex items-center gap-2">
-          <div className="h-1.5 w-1.5 rounded-full bg-[#FF5800]" />
-          Access your Eliza Cloud account
-        </li>
-        <li className="flex items-center gap-2">
-          <div className="h-1.5 w-1.5 rounded-full bg-[#FF5800]" />
-          Use AI features paid for from your cloud credit balance
-        </li>
-      </ul>
-    </div>
-  );
-}
-
 function SignedInActions({
   appName,
   onAuthorize,
@@ -382,17 +359,17 @@ function SignedInActions({
   onCancel: () => void;
 }) {
   return (
-    <div className="flex w-full flex-col gap-3">
-      <div className="flex items-center justify-center gap-2 rounded-sm border border-white/10 bg-white/5 px-3 py-2 text-sm text-white/80">
-        <CheckCircle2 className="h-4 w-4 text-emerald-400" />
-        <span>Signed in</span>
-      </div>
+    <div className="flex w-full flex-col items-center gap-3">
       <BrandButton onClick={onAuthorize} className="w-full">
         Authorize {appName}
       </BrandButton>
-      <BrandButton variant="ghost" onClick={onCancel} className="w-full">
+      <button
+        type="button"
+        onClick={onCancel}
+        className="text-sm text-white/50 transition-colors hover:text-white"
+      >
         Cancel
-      </BrandButton>
+      </button>
     </div>
   );
 }
@@ -405,7 +382,7 @@ function SignedOutActions({
   providersReady: boolean;
 }) {
   return (
-    <div className="flex w-full flex-col gap-4">
+    <div className="flex w-full flex-col items-center gap-4">
       {providersReady ? (
         <StewardLogin
           variant="inline"
@@ -419,9 +396,13 @@ function SignedOutActions({
           <p className="text-sm text-white/60">Loading sign-in options...</p>
         </div>
       )}
-      <BrandButton variant="ghost" onClick={onCancel} className="w-full">
+      <button
+        type="button"
+        onClick={onCancel}
+        className="text-sm text-white/50 transition-colors hover:text-white"
+      >
         Cancel
-      </BrandButton>
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- collapses `/app-auth/authorize` consent chrome to app identity + one short connection sentence
- removes the hard-coded permissions text wall and footer disclaimer
- changes cancel from a full secondary button to a single inline affordance in signed-in and signed-out states
- adds `AuthorizeContent` unit coverage for the compact signed-in and signed-out layouts

Refs #9961. This is the `/app-auth/authorize` chrome cleanup slice; Developer-view/settings role gating remains separate follow-up scope.

## Validation

- `bun run test src/cloud-ui/components/auth/authorize-content.test.tsx` from `packages/ui` -> 2/2 passed
- `bun run typecheck` from `packages/ui` -> passed
- `bunx biome check packages/ui/src/cloud-ui/components/auth/authorize-content.tsx packages/ui/src/cloud-ui/components/auth/authorize-content.test.tsx` -> passed
- `git diff --check origin/develop...HEAD` -> passed
