### PR TITLE
fix(agent): repair provisioned cloud topology from config env

### DIFF
--- a/packages/agent/src/runtime/eliza-cloud-config.test.ts
+++ b/packages/agent/src/runtime/eliza-cloud-config.test.ts
@@ -100,6 +100,71 @@ describe("provisioned cloud container topology (#9887)", () => {
     });
   });
 
+  it("repairs topology from config.env when container env has only the provisioned marker", () => {
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+
+    const config: ElizaConfig = {
+      env: {
+        vars: {
+          ELIZAOS_CLOUD_API_KEY: "cloud-test",
+          ELIZAOS_CLOUD_BASE_URL: "https://cloud.example/api",
+          ELIZA_CLOUD_AGENT_ID: "agent-test",
+          ELIZAOS_CLOUD_SMALL_MODEL: "small-from-config-env",
+        },
+      },
+    } as ElizaConfig;
+
+    const changed = ensureProvisionedCloudContainerConfig(config);
+    const topology = resolveElizaCloudTopology(
+      config as Record<string, unknown>,
+    );
+
+    expect(changed).toBe(true);
+    expect(config.cloud).toMatchObject({
+      enabled: true,
+      apiKey: "cloud-test",
+      baseUrl: "https://cloud.example/api",
+      agentId: "agent-test",
+    });
+    expect(config.deploymentTarget).toEqual({
+      runtime: "cloud",
+      provider: "elizacloud",
+    });
+    expect(topology.runtime).toBe("cloud");
+    expect(topology.services.inference).toBe(true);
+    expect(config.serviceRouting?.llmText).toMatchObject({
+      backend: "elizacloud",
+      transport: "cloud-proxy",
+      smallModel: "small-from-config-env",
+    });
+  });
+
+  it("uses a real config.env cloud key when config.cloud carries the redacted placeholder", () => {
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+
+    const config: ElizaConfig = {
+      cloud: {
+        enabled: true,
+        apiKey: "[REDACTED]",
+        agentId: "agent-test",
+      },
+      env: {
+        vars: {
+          ELIZAOS_CLOUD_API_KEY: "cloud-test",
+        },
+      },
+    } as ElizaConfig;
+
+    const changed = ensureProvisionedCloudContainerConfig(config);
+
+    expect(changed).toBe(true);
+    expect(config.cloud?.apiKey).toBe("cloud-test");
+    expect(
+      resolveElizaCloudTopology(config as Record<string, unknown>).services
+        .inference,
+    ).toBe(true);
+  });
+
   it("forces cloud inference env from repaired managed-container topology", () => {
     process.env.ELIZA_CLOUD_PROVISIONED = "1";
 

--- a/packages/agent/src/runtime/eliza-cloud-config.test.ts
+++ b/packages/agent/src/runtime/eliza-cloud-config.test.ts
@@ -24,7 +24,20 @@ const ENV_KEYS = [
   "ELIZAOS_CLOUD_API_KEY",
   "ELIZAOS_CLOUD_BASE_URL",
   "ELIZA_CLOUD_AGENT_ID",
+  "ELIZAOS_CLOUD_NANO_MODEL",
   "ELIZAOS_CLOUD_SMALL_MODEL",
+  "ELIZAOS_CLOUD_MEDIUM_MODEL",
+  "ELIZAOS_CLOUD_LARGE_MODEL",
+  "ELIZAOS_CLOUD_MEGA_MODEL",
+  "ELIZAOS_CLOUD_RESPONSE_HANDLER_MODEL",
+  "ELIZAOS_CLOUD_SHOULD_RESPOND_MODEL",
+  "ELIZAOS_CLOUD_ACTION_PLANNER_MODEL",
+  "ELIZAOS_CLOUD_PLANNER_MODEL",
+  "NANO_MODEL",
+  "SMALL_MODEL",
+  "MEDIUM_MODEL",
+  "LARGE_MODEL",
+  "MEGA_MODEL",
 ] as const;
 
 let savedEnv: Record<string, string | undefined>;
@@ -184,6 +197,48 @@ describe("provisioned cloud container topology (#9887)", () => {
     ).toBe(true);
     expect(process.env.ELIZAOS_CLOUD_USE_INFERENCE).toBe("true");
     expect(process.env.ELIZAOS_CLOUD_ENABLED).toBe("true");
+  });
+
+  it("keeps effective model pins when managed topology is already canonical", () => {
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+    process.env.ELIZAOS_CLOUD_LARGE_MODEL = "large-from-env";
+
+    const config: ElizaConfig = {
+      deploymentTarget: {
+        runtime: "cloud",
+        provider: "elizacloud",
+      },
+      serviceRouting: {
+        llmText: {
+          backend: "elizacloud",
+          transport: "cloud-proxy",
+        },
+      },
+      cloud: {
+        enabled: true,
+        apiKey: "cloud-test",
+        agentId: "agent-test",
+      },
+      env: {
+        vars: {
+          ELIZAOS_CLOUD_SMALL_MODEL: "small-from-config-env",
+          ELIZAOS_CLOUD_RESPONSE_HANDLER_MODEL: "responder-from-config-env",
+        },
+      },
+    } as ElizaConfig;
+
+    applyCloudConfigToEnv(config);
+
+    expect(process.env.ELIZAOS_CLOUD_SMALL_MODEL).toBe("small-from-config-env");
+    expect(process.env.SMALL_MODEL).toBe("small-from-config-env");
+    expect(process.env.ELIZAOS_CLOUD_LARGE_MODEL).toBe("large-from-env");
+    expect(process.env.LARGE_MODEL).toBe("large-from-env");
+    expect(process.env.ELIZAOS_CLOUD_RESPONSE_HANDLER_MODEL).toBe(
+      "responder-from-config-env",
+    );
+    expect(process.env.ELIZAOS_CLOUD_SHOULD_RESPOND_MODEL).toBe(
+      "responder-from-config-env",
+    );
   });
 
   it("keeps repaired managed containers off local-inference fallback", () => {

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -1075,6 +1075,12 @@ function trimEnvString(value: unknown): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
+function trimCloudCredential(value: unknown): string | undefined {
+  const trimmed = trimEnvString(value);
+  if (!trimmed || trimmed.toUpperCase() === "[REDACTED]") return undefined;
+  return trimmed;
+}
+
 type MutableConfigEnv = Record<string, unknown> & {
   vars?: Record<string, unknown>;
 };
@@ -1121,6 +1127,17 @@ function readEffectiveEnvValue(
   return trimEnvString(env[key]) ?? readConfigEnvValue(config, key);
 }
 
+function readEffectiveCloudCredential(
+  config: ElizaConfig,
+  key: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  return (
+    trimCloudCredential(env[key]) ??
+    trimCloudCredential(readConfigEnvValue(config, key))
+  );
+}
+
 function isProvisionedCloudContainer(env: NodeJS.ProcessEnv = process.env) {
   return env.ELIZA_CLOUD_PROVISIONED === "1";
 }
@@ -1135,8 +1152,8 @@ export function ensureProvisionedCloudContainerConfig(
   }
 
   const apiKey =
-    trimEnvString(config.cloud?.apiKey) ??
-    trimEnvString(env.ELIZAOS_CLOUD_API_KEY);
+    trimCloudCredential(config.cloud?.apiKey) ??
+    readEffectiveCloudCredential(config, "ELIZAOS_CLOUD_API_KEY", env);
   if (!apiKey) {
     return false;
   }
@@ -1145,11 +1162,11 @@ export function ensureProvisionedCloudContainerConfig(
   const cloud = config.cloud ?? {};
   const baseUrl =
     trimEnvString(config.cloud?.baseUrl) ??
-    trimEnvString(env.ELIZAOS_CLOUD_BASE_URL);
+    readEffectiveEnvValue(config, "ELIZAOS_CLOUD_BASE_URL", env);
   const agentId =
     trimEnvString(config.cloud?.agentId) ??
-    trimEnvString(env.ELIZA_CLOUD_AGENT_ID) ??
-    trimEnvString(env.WAIFU_ELIZA_CLOUD_AGENT_ID);
+    readEffectiveEnvValue(config, "ELIZA_CLOUD_AGENT_ID", env) ??
+    readEffectiveEnvValue(config, "WAIFU_ELIZA_CLOUD_AGENT_ID", env);
 
   if (
     config.cloud?.enabled !== true ||
@@ -1188,20 +1205,52 @@ export function ensureProvisionedCloudContainerConfig(
     );
     const cloudRouting = buildDefaultElizaCloudServiceRouting({
       includeInference: true,
-      nanoModel: trimEnvString(env.ELIZAOS_CLOUD_NANO_MODEL),
-      smallModel: trimEnvString(env.ELIZAOS_CLOUD_SMALL_MODEL),
-      mediumModel: trimEnvString(env.ELIZAOS_CLOUD_MEDIUM_MODEL),
-      largeModel: trimEnvString(env.ELIZAOS_CLOUD_LARGE_MODEL),
-      megaModel: trimEnvString(env.ELIZAOS_CLOUD_MEGA_MODEL),
-      responseHandlerModel: trimEnvString(
-        env.ELIZAOS_CLOUD_RESPONSE_HANDLER_MODEL,
+      nanoModel: readEffectiveEnvValue(config, "ELIZAOS_CLOUD_NANO_MODEL", env),
+      smallModel: readEffectiveEnvValue(
+        config,
+        "ELIZAOS_CLOUD_SMALL_MODEL",
+        env,
       ),
-      shouldRespondModel: trimEnvString(env.ELIZAOS_CLOUD_SHOULD_RESPOND_MODEL),
-      actionPlannerModel: trimEnvString(env.ELIZAOS_CLOUD_ACTION_PLANNER_MODEL),
-      plannerModel: trimEnvString(env.ELIZAOS_CLOUD_PLANNER_MODEL),
-      responseModel: trimEnvString(env.ELIZAOS_CLOUD_RESPONSE_MODEL),
-      mediaDescriptionModel: trimEnvString(
-        env.ELIZAOS_CLOUD_MEDIA_DESCRIPTION_MODEL,
+      mediumModel: readEffectiveEnvValue(
+        config,
+        "ELIZAOS_CLOUD_MEDIUM_MODEL",
+        env,
+      ),
+      largeModel: readEffectiveEnvValue(
+        config,
+        "ELIZAOS_CLOUD_LARGE_MODEL",
+        env,
+      ),
+      megaModel: readEffectiveEnvValue(config, "ELIZAOS_CLOUD_MEGA_MODEL", env),
+      responseHandlerModel: readEffectiveEnvValue(
+        config,
+        "ELIZAOS_CLOUD_RESPONSE_HANDLER_MODEL",
+        env,
+      ),
+      shouldRespondModel: readEffectiveEnvValue(
+        config,
+        "ELIZAOS_CLOUD_SHOULD_RESPOND_MODEL",
+        env,
+      ),
+      actionPlannerModel: readEffectiveEnvValue(
+        config,
+        "ELIZAOS_CLOUD_ACTION_PLANNER_MODEL",
+        env,
+      ),
+      plannerModel: readEffectiveEnvValue(
+        config,
+        "ELIZAOS_CLOUD_PLANNER_MODEL",
+        env,
+      ),
+      responseModel: readEffectiveEnvValue(
+        config,
+        "ELIZAOS_CLOUD_RESPONSE_MODEL",
+        env,
+      ),
+      mediaDescriptionModel: readEffectiveEnvValue(
+        config,
+        "ELIZAOS_CLOUD_MEDIA_DESCRIPTION_MODEL",
+        env,
       ),
     });
     config.serviceRouting = {

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -2146,17 +2146,40 @@ export function applyCloudConfigToEnv(config: ElizaConfig): void {
     | undefined;
   if (effectivelyEnabled) {
     const nano =
-      llmText?.nanoModel || models?.nano || DEFAULT_ELIZA_CLOUD_TEXT_MODEL;
+      llmText?.nanoModel ||
+      models?.nano ||
+      readEffectiveEnvValue(config, "ELIZAOS_CLOUD_NANO_MODEL") ||
+      DEFAULT_ELIZA_CLOUD_TEXT_MODEL;
     const small =
-      llmText?.smallModel || models?.small || DEFAULT_ELIZA_CLOUD_TEXT_MODEL;
-    const medium = llmText?.mediumModel || models?.medium || small;
+      llmText?.smallModel ||
+      models?.small ||
+      readEffectiveEnvValue(config, "ELIZAOS_CLOUD_SMALL_MODEL") ||
+      DEFAULT_ELIZA_CLOUD_TEXT_MODEL;
+    const medium =
+      llmText?.mediumModel ||
+      models?.medium ||
+      readEffectiveEnvValue(config, "ELIZAOS_CLOUD_MEDIUM_MODEL") ||
+      small;
     const large =
-      llmText?.largeModel || models?.large || DEFAULT_ELIZA_CLOUD_TEXT_MODEL;
-    const mega = llmText?.megaModel || models?.mega || large;
+      llmText?.largeModel ||
+      models?.large ||
+      readEffectiveEnvValue(config, "ELIZAOS_CLOUD_LARGE_MODEL") ||
+      DEFAULT_ELIZA_CLOUD_TEXT_MODEL;
+    const mega =
+      llmText?.megaModel ||
+      models?.mega ||
+      readEffectiveEnvValue(config, "ELIZAOS_CLOUD_MEGA_MODEL") ||
+      large;
     const responseHandlerModel =
-      llmText?.responseHandlerModel || llmText?.shouldRespondModel;
+      llmText?.responseHandlerModel ||
+      llmText?.shouldRespondModel ||
+      readEffectiveEnvValue(config, "ELIZAOS_CLOUD_RESPONSE_HANDLER_MODEL") ||
+      readEffectiveEnvValue(config, "ELIZAOS_CLOUD_SHOULD_RESPOND_MODEL");
     const actionPlannerModel =
-      llmText?.actionPlannerModel || llmText?.plannerModel;
+      llmText?.actionPlannerModel ||
+      llmText?.plannerModel ||
+      readEffectiveEnvValue(config, "ELIZAOS_CLOUD_ACTION_PLANNER_MODEL") ||
+      readEffectiveEnvValue(config, "ELIZAOS_CLOUD_PLANNER_MODEL");
     process.env.SMALL_MODEL = small;
     process.env.NANO_MODEL = nano;
     process.env.MEDIUM_MODEL = medium;


### PR DESCRIPTION

## Summary
- Repair provisioned Eliza Cloud container topology from effective `config.env` / `config.env.vars` values when process env only carries `ELIZA_CLOUD_PROVISIONED`.
- Treat `[REDACTED]` cloud API keys as absent so a real `ELIZAOS_CLOUD_API_KEY` from effective config env can hydrate cloud routing.
- Add regression coverage for config-env topology repair, model pin propagation, and redacted-key fallback.

Follow-up for #9887. This builds on the already-merged #9905 topology fix and #9888/#9890 local-inference export fix, and closes the remaining packaged-config residual I found in another pass.

## Evidence
- `bun install`
- `bun run --cwd packages/agent test -- src/runtime/plugin-collector-aosp.test.ts src/runtime/eliza-cloud-config.test.ts src/runtime/plugin-collector-mode-policy.test.ts src/runtime/plugin-collector-lean-chat.test.ts` - 28 passed
- `bunx @biomejs/biome check packages/agent/src/runtime/eliza.ts packages/agent/src/runtime/eliza-cloud-config.test.ts --no-errors-on-unmatched`
- `bun run --cwd packages/agent typecheck`
- `bun run --cwd plugins/plugin-local-inference test -- src/local-inference-routes.test.ts` - 8 passed
- `bun run --cwd plugins/plugin-local-inference build`
- `TURBO_DAEMON=false bun run verify` - 504/504 workspace typecheck/lint tasks, repo audits, 28 dist-path consumer configs
- `TURBO_DAEMON=false bun run build` - 223/223 workspace builds, desktop packaging/signing, view-bundle guard OK
- `git diff --check origin/develop..HEAD`

## Evidence N/A
- App visual audit: no `packages/app` or shared UI source changes.
- Live dedicated cloud-agent provision/chat: not run from this local workspace; requires live cloud credentials and deployed image access.
