### PR TITLE
fix(cache): count empty SCAN pages toward delPattern runaway guard (#9928 follow-up)

### DIFF
--- a/packages/cloud/shared/src/lib/cache/client.ts
+++ b/packages/cloud/shared/src/lib/cache/client.ts
@@ -802,11 +802,16 @@ export class CacheClient {
       cursor = String(result[0]);
       const keys = result[1];
 
+      // Count every scan iteration toward the runaway guard, including empty
+      // pages. A backend that returns many empty pages with a non-terminal
+      // cursor would otherwise never trip the guard and loop unbounded.
+      iterations++;
+
       if (keys.length > 0) {
         await redis.del(...keys);
         totalDeleted += keys.length;
         logger.debug(
-          `[Cache] DEL_PATTERN iteration ${++iterations}: deleted ${keys.length} keys (total: ${totalDeleted})`,
+          `[Cache] DEL_PATTERN iteration ${iterations}: deleted ${keys.length} keys (total: ${totalDeleted})`,
         );
       }
 


### PR DESCRIPTION
## Summary

Follow-up to #9928, which correctly fixed opaque cursor threading in `CacheClient` SCAN loops. This addresses the residual nit in `delPattern()`.

In `packages/cloud/shared/src/lib/cache/client.ts`, `delPattern()` incremented its runaway-iteration guard **inside** the `if (keys.length > 0)` block (it was folded into the `++iterations` in the debug-log template literal). A backend that returns many **empty** SCAN pages with a non-terminal (non-`"0"`) cursor would therefore never advance `iterations`, so neither the top-of-loop break (`if (iterations >= maxIterations)`) nor the `do...while (… && iterations < maxIterations)` condition could ever trip — a potential unbounded loop.

## Fix

Move `iterations++` so it runs on **every** scan iteration, regardless of `keys.length`. Everything else is byte-for-byte identical:

- Cursor still threaded as an opaque string; still terminates on `cursor === "0"`.
- Deletion still happens only when `keys.length > 0`; `totalDeleted` accounting unchanged.
- The debug log now references `iterations` (already incremented) instead of `${++iterations}` — same displayed value.

The sibling sweep `scanByPrefix()` in the same file already increments unconditionally (`if (++iterations >= 1000) break`), so it does **not** share the bug and is left untouched.

## Verification

- Read the final loop and reasoned through it: (a) the guard now trips after `maxIterations` total iterations even when every page is empty; (b) normal termination on cursor `"0"` is unchanged; (c) deletion semantics are unchanged.
- `bun run --cwd packages/cloud/shared typecheck` — zero errors referencing `cache/client.ts`. (The only errors are pre-existing, unrelated transitive `core`/`shared` i18n generated-file errors that require a build step, as documented in the package CLAUDE.md "typecheck noise" note.)
- Did not run the full cloud/shared test suite (those use `bun --isolate`); change is a single guard-placement move with no contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)