### PR TITLE
test(plugin-cli-inference): correct misleading backend-resolver test name after #9935

### DIFF
--- a/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/cli-inference.test.ts
@@ -408,9 +408,10 @@ describe("models map gating (large-tier only)", () => {
     expect(keys.sort()).toEqual([...LARGE_TIER_MODEL_TYPES].sort());
   });
 
-  it("resolveCliBackend accepts only claude|codex (case-insensitive)", () => {
+  it("resolveCliBackend accepts claude|codex|claude-sdk (case-insensitive)", () => {
     expect(resolveCliBackend({ ELIZA_CHAT_VIA_CLI: "Claude" })).toBe("claude");
     expect(resolveCliBackend({ ELIZA_CHAT_VIA_CLI: "CODEX" })).toBe("codex");
+    expect(resolveCliBackend({ ELIZA_CHAT_VIA_CLI: "Claude-SDK" })).toBe("claude-sdk");
     expect(resolveCliBackend({ ELIZA_CHAT_VIA_CLI: "gemini" })).toBeUndefined();
     expect(resolveCliBackend({ ELIZA_CHAT_VIA_CLI: "" })).toBeUndefined();
   });


### PR DESCRIPTION
## What

After #9935 added the `claude-sdk` backend, `resolveCliBackend`
(`plugins/plugin-cli-inference/index.ts:89-93`) accepts
`claude` | `claude-sdk` | `codex` (case-insensitive). But the unit test still
named itself `"resolveCliBackend accepts only claude|codex (case-insensitive)"`
and its body never exercised `claude-sdk` — the name lied and coverage had a hole.

## Change

`plugins/plugin-cli-inference/__tests__/cli-inference.test.ts`:

- Rename the test to `"resolveCliBackend accepts claude|codex|claude-sdk (case-insensitive)"`.
- Add an assertion for `claude-sdk` using mixed-case `"Claude-SDK"` so the test
  body now covers **every** accepted backend and the "case-insensitive" claim
  stays honest for the new value too.
- Existing assertions (`Claude`, `CODEX`, `gemini`→undefined, `""`→undefined)
  are untouched.

```diff
-  it("resolveCliBackend accepts only claude|codex (case-insensitive)", () => {
+  it("resolveCliBackend accepts claude|codex|claude-sdk (case-insensitive)", () => {
     expect(resolveCliBackend({ ELIZA_CHAT_VIA_CLI: "Claude" })).toBe("claude");
     expect(resolveCliBackend({ ELIZA_CHAT_VIA_CLI: "CODEX" })).toBe("codex");
+    expect(resolveCliBackend({ ELIZA_CHAT_VIA_CLI: "Claude-SDK" })).toBe("claude-sdk");
     expect(resolveCliBackend({ ELIZA_CHAT_VIA_CLI: "gemini" })).toBeUndefined();
     expect(resolveCliBackend({ ELIZA_CHAT_VIA_CLI: "" })).toBeUndefined();
   });
```

## Verification

- Static-verified the new test set exactly matches `resolveCliBackend`'s accepted
  values (`raw === "claude" || raw === "claude-sdk" || raw === "codex"` after
  `.trim().toLowerCase()`).
- Could not run the suite locally from this isolated worktree: the shared
  `node_modules` symlink resolves `@elizaos/core` via a workspace path that points
  outside the worktree, so vitest fails to import the package. Relying on CI for
  execution. Diff is a one-line assertion + a string rename — no logic change.

## Recommended follow-up (deferred — lockfile change)

`plugins/plugin-cli-inference/package.json` does **not** declare
`@anthropic-ai/claude-agent-sdk` anywhere, yet the `claude-sdk` backend
dynamically imports it (`src/claude-sdk-session.ts:128` / `:154`). The feature
only works if the dep happens to already be installed. It should be added to
`optionalDependencies` and the lockfile regenerated. I deferred that here to
avoid churning `bun.lock` from an isolated worktree with a shared/symlinked
`node_modules`; it warrants its own focused PR run from a clean install.

Refs #9935

🤖 Generated with [Claude Code](https://claude.com/claude-code)