### PR TITLE
fix(tui): kill fictional "SSH" naming + run packages/tui tests on PR CI (#9946)

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "test:plugins": "bun run build:core && node packages/scripts/run-turbo.mjs run test --concurrency 3 --filter='./plugins/*' --filter='!@elizaos/plugin-personal-assistant' --filter='!@elizaos/plugin-agent-orchestrator' && bun run --cwd plugins/plugin-personal-assistant test && node packages/scripts/run-turbo.mjs run test --concurrency 1 --filter='@elizaos/plugin-agent-orchestrator'",
     "test:client": "bun run build:core && TEST_PACKAGE_FILTER='\\((packages/app|packages/ui|plugins/plugin-personal-assistant|plugins/plugin-companion|plugins/plugin-training)\\)' TEST_SCRIPT_FILTER='^test$' node packages/scripts/run-all-tests.mjs --no-cloud",
     "test:core": "node packages/scripts/with-test-runtime.mjs node packages/scripts/run-turbo.mjs run test --filter=./packages/core",
-    "test:server": "bun run build:core && TEST_PACKAGE_FILTER='\\((packages/agent|packages/app-core|packages/shared|packages/core|packages/vault|packages/elizaos|packages/skills|packages/scenario-runner|packages/test)\\)' TEST_SCRIPT_FILTER='^test$' node packages/scripts/run-all-tests.mjs --no-cloud",
+    "test:server": "bun run build:core && TEST_PACKAGE_FILTER='\\((packages/agent|packages/app-core|packages/shared|packages/core|packages/tui|packages/vault|packages/elizaos|packages/skills|packages/scenario-runner|packages/test)\\)' TEST_SCRIPT_FILTER='^test$' node packages/scripts/run-all-tests.mjs --no-cloud",
     "test:remote-capabilities": "bun run --cwd packages/agent test:remote-capabilities",
     "capability-router:fixture-server": "bun packages/scripts/capability-router-fixture-server.ts",
     "test:remote-capabilities:surface-audit": "bun packages/scripts/audit-capability-router-plugin-surface.ts",

--- a/packages/agent/src/__tests__/agent-terminal-tui.test.ts
+++ b/packages/agent/src/__tests__/agent-terminal-tui.test.ts
@@ -187,7 +187,7 @@ describe("agent terminal tui", () => {
     // (b) Type into the composer + Enter while a view is mounted: a message
     // send fires and the view stays mounted.
     terminal.send(CTRL_L); // focus the composer
-    terminal.send("hello over ssh");
+    terminal.send("hello over terminal");
     terminal.send("\r");
     expect(
       await waitForCall(calls, (call) =>
@@ -199,7 +199,7 @@ describe("agent terminal tui", () => {
       call.url.endsWith("/api/conversations/conv-terminal/messages"),
     );
     expect(JSON.parse(String(chatCall?.init?.body))).toMatchObject({
-      text: "hello over ssh",
+      text: "hello over terminal",
       source: "terminal-tui",
       metadata: { viewId: "wallet", viewType: "tui" },
     });

--- a/packages/agent/src/tui/agent-terminal-tui.ts
+++ b/packages/agent/src/tui/agent-terminal-tui.ts
@@ -506,7 +506,7 @@ class AgentTerminalView implements Component {
     }>(this.fetchImpl, this.apiBaseUrl, "/api/conversations", {
       method: "POST",
       body: JSON.stringify({
-        title: "SSH terminal",
+        title: "Terminal session",
         metadata: { source: "terminal-tui" },
       }),
     });


### PR DESCRIPTION
Part of #9946 (first chunk — naming + CI safety net).

## What

1. **Kill the fictional "SSH" naming.** The agent terminal TUI never had an SSH server anywhere in the agent. The conversation title `"SSH terminal"` and the `"hello over ssh"` test fixtures named a feature that does not exist; the real run mode is a loopback terminal client (`eliza-autonomous tui` against an already-running backend). Renamed the title to `"Terminal session"` (the `metadata.source` was already `"terminal-tui"`) and the test fixture text to `"hello over terminal"`.
   - The two remaining `SSH` references in `packages/tui/src/terminal.ts` are kept on purpose — they are accurate technical comments about flush/Ctrl+D behavior when a user SSHes into a box and runs the TUI **locally** over that session (the actual supported remote flow), not the fictional "SSH server in the agent".
2. **Run `packages/tui`'s tests on PR CI.** `packages/tui` (479 tests, 25 files) was in neither the `test:server` nor `test:client` filter, so its suite ran only on a bare full `bun run test`, never on the per-area jobs that gate PRs. CI *built* the package as a dependency but never *ran* its suite. Added `packages/tui` to the `test:server` filter so the `server-tests` PR job now gates it.

## Why

Aspirational naming for an unbuilt feature actively misleads (see #9946 critical assessment); and the TUI's only real safety net was invisible to PRs.

## Evidence

```
$ bun run --cwd packages/tui test
 Test Files  25 passed (25)
      Tests  479 passed (479)

$ bun run --cwd packages/agent test -- agent-terminal-tui
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

- **Real-LLM trajectory:** N/A — string + CI-filter change, no agent/model/prompt behavior touched.
- **Screenshots/video:** N/A — no UI surface rendered differently; the rendered TUI frame is unchanged (only an off-screen conversation title string).
- **Backend logs:** the renamed title flows into `POST /api/conversations` `{ title: "Terminal session", metadata: { source: "terminal-tui" } }` (`agent-terminal-tui.ts` `ensureConversation`).

Subsequent chunks of #9946 (real-PTY e2e, `tui-smoke` PR lane, XR-sim CI wiring, trust-gate decision, modality centralization) will follow as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)