### PR TITLE
fix(personal-assistant): repair LifeOps package-boundary test after #9927 (0-byte sleep mixin)

### DIFF
--- a/plugins/plugin-personal-assistant/test/package-boundaries.test.ts
+++ b/plugins/plugin-personal-assistant/test/package-boundaries.test.ts
@@ -44,10 +44,10 @@ describe("LifeOps package boundaries", () => {
     const rendererEntrypoint = readPackageFile("src/ui.ts");
     const sleepRoutes = readPackageFile("src/routes/sleep-routes.ts");
     const sleepServiceMixin = readPackageFile(
-      "src/lifeops/service-mixin-sleep.ts",
+      "src/lifeops/domains/sleep-service.ts",
     );
     const screenTimeServiceMixin = readPackageFile(
-      "src/lifeops/service-mixin-screentime.ts",
+      "src/lifeops/domains/screentime-service.ts",
     );
 
     expect(healthAction).toContain('from "@elizaos/plugin-health"');
@@ -195,12 +195,14 @@ describe("LifeOps package boundaries", () => {
   });
 
   it("imports browser bridge readiness policy from plugin-browser", () => {
-    const statusMixin = readPackageFile("src/lifeops/service-mixin-status.ts");
+    const statusMixin = readPackageFile(
+      "src/lifeops/domains/status-service.ts",
+    );
     const screenTimeMixin = readPackageFile(
-      "src/lifeops/service-mixin-screentime.ts",
+      "src/lifeops/domains/screentime-service.ts",
     );
     const browserMixin = readPackageFile(
-      "src/lifeops/service-mixin-browser.ts",
+      "src/lifeops/domains/browser-service.ts",
     );
     const coreMixin = readPackageFile("src/lifeops/service-mixin-core.ts");
     const repository = readPackageFile("src/lifeops/repository.ts");


### PR DESCRIPTION
## Problem (live on develop — breaks the Plugin Tests CI lane)

The #9927 refactor *("replace LifeOpsService mixin god-class with namespaced sub-service composition")* moved each domain's implementation out of `plugins/plugin-personal-assistant/src/lifeops/service-mixin-*.ts` and into `src/lifeops/domains/*-service.ts`, leaving the old `service-mixin-*` files as thin interface-only stubs. It also left **`src/lifeops/service-mixin-sleep.ts` behind as a 0-byte orphan** — nothing imports it; the real sleep wrapper now lives in `src/lifeops/domains/sleep-service.ts`.

`test/package-boundaries.test.ts` was only partially repointed, so it still `readPackageFile`s the stale mixin paths and asserts moved symbols against them. Result: `package-boundaries.test.ts` is red on `develop`:

- **`sleepServiceMixin`** read the 0-byte orphan → `""` → every `toContain` assertion failed.
- **`screenTimeServiceMixin` / `screenTimeMixin`** read the interface stub `service-mixin-screentime.ts`, which no longer contains `buildScreenTimeBreakdown` et al.
- **`statusMixin` / `browserMixin`** read interface stubs missing the `from "@elizaos/plugin-browser"` import and browser-bridge symbols.

## Fix (test-only + orphan removal — no source/behavior change)

- Repoint the four stale `readPackageFile` targets to their new `src/lifeops/domains/*-service.ts` homes: **sleep, screentime, status, browser**. Every existing `toContain` / `.not.toContain` assertion was verified against the new target file before repointing.
- `git rm` the 0-byte orphan `src/lifeops/service-mixin-sleep.ts`. Grepped the whole package (src, barrels `src/lifeops/index.ts` / `src/index.ts`, configs) — **zero references** anywhere outside this test, so a plain deletion is safe; no re-export shim is needed.

`coreMixin` (`service-mixin-core.ts`) keeps its symbols and is left untouched.

### Note on scope
The original ticket scoped this to "the 0-byte sleep mixin" and assumed screen-time was unaffected. It is **not** — #9927 broke screentime/status/browser in the *identical* way it broke sleep (impl moved to `domains/`, mixin became a stub). The sleep repoint alone leaves `package-boundaries.test.ts` red (the screentime assertions live in the same `it()` block), so the lane would stay broken. The screentime/status/browser assertions are repointed alongside sleep, with the same per-assertion verification, to actually green the lane. All changes are confined to the one test file plus the orphan deletion.

## Verification

```
bun --cwd plugins/plugin-personal-assistant test package-boundaries
# before: 2 failed | 10 passed
# after:  12 passed (12)
```

Biome format clean on the edited file. Diff: `7 insertions(+), 5 deletions(-)` across 2 files.

Refs #9927.

🤖 Generated with [Claude Code](https://claude.com/claude-code)