### PR TITLE
fix(ui): gate cloud developer settings

### DIFF
--- a/packages/app/test/ui-smoke/settings-mobile-load.spec.ts
+++ b/packages/app/test/ui-smoke/settings-mobile-load.spec.ts
@@ -156,9 +156,6 @@ const CLOUD_SECTION_IDS = [
   "cloud-agents",
   "cloud-account",
   "cloud-billing",
-  "cloud-api-keys",
-  "cloud-applications",
-  "cloud-monetization",
   "cloud-organization",
   "cloud-connectors",
   "mcps",
@@ -166,10 +163,22 @@ const CLOUD_SECTION_IDS = [
   "cloud-plugin-grants",
 ] as const;
 
+const DEVELOPER_CLOUD_SECTION_IDS = [
+  "cloud-api-keys",
+  "cloud-applications",
+  "cloud-monetization",
+] as const;
+
 test.describe("cloud settings sections load at mobile width", () => {
   test.use({ viewport: VIEWPORT_SIZES.mobile });
 
-  for (const id of CLOUD_SECTION_IDS) {
+  for (const { id, developerMode } of [
+    ...CLOUD_SECTION_IDS.map((id) => ({ id, developerMode: false })),
+    ...DEVELOPER_CLOUD_SECTION_IDS.map((id) => ({
+      id,
+      developerMode: true,
+    })),
+  ] as const) {
     test(`${id} renders without crashing`, async ({ page }) => {
       await mkdir(OUT_DIR, { recursive: true });
 
@@ -185,7 +194,10 @@ test.describe("cloud settings sections load at mobile width", () => {
         consoleErrors.push(text);
       });
 
-      await seedAppStorage(page);
+      await seedAppStorage(
+        page,
+        developerMode ? { "eliza:developerMode": "1" } : {},
+      );
       await installDefaultAppRoutes(page);
       await openAppPath(page, "/settings");
 

--- a/packages/ui/src/cloud/settings/cloud-settings-group.ts
+++ b/packages/ui/src/cloud/settings/cloud-settings-group.ts
@@ -4,10 +4,11 @@
  *
  * The canonical group set lives in `settings-section-meta.ts`
  * (`SETTINGS_GROUP_ORDER` / `SETTINGS_GROUP_LABEL`), which is intentionally
- * frozen — the app-core `dev-route-catalog` parity test pins it. To add a "Cloud"
- * group without mutating that pinned list, host code registers the group here at
- * boot and the Settings view reads {@link listExtraSettingsGroups} to render any
- * group a section declares that the built-in order does not already cover.
+ * frozen — the app-core `dev-route-catalog` parity test pins it. To add groups
+ * such as "Cloud" or "Developer" without mutating that pinned list, host code
+ * registers them here at boot and the Settings view reads
+ * {@link listExtraSettingsGroups} to render any group a section declares that
+ * the built-in order does not already cover.
  *
  * Mirrors the section registry's global-symbol store so every bundle in the
  * process shares one group list even across module-identity splits.
@@ -65,3 +66,6 @@ export function getExtraSettingsGroup(
 
 /** The Cloud group id used by every cloud settings section in this directory. */
 export const CLOUD_SETTINGS_GROUP_ID = "cloud";
+
+/** Developer-only cloud settings group. Visibility is controlled per section. */
+export const DEVELOPER_SETTINGS_GROUP_ID = "developer";

--- a/packages/ui/src/cloud/settings/register-cloud-settings.test.ts
+++ b/packages/ui/src/cloud/settings/register-cloud-settings.test.ts
@@ -4,6 +4,7 @@ import { beforeAll, describe, expect, it } from "vitest";
 import { listSettingsSections } from "../../components/settings/settings-section-registry";
 import {
   CLOUD_SETTINGS_GROUP_ID,
+  DEVELOPER_SETTINGS_GROUP_ID,
   listExtraSettingsGroups,
 } from "./cloud-settings-group";
 import { registerCloudSettingsSections } from "./register-cloud-settings";
@@ -11,10 +12,13 @@ import { registerCloudSettingsSections } from "./register-cloud-settings";
 const CLOUD_SECTION_IDS = [
   "cloud-account",
   "cloud-billing",
+  "cloud-organization",
+] as const;
+
+const DEVELOPER_SECTION_IDS = [
   "cloud-api-keys",
   "cloud-applications",
   "cloud-monetization",
-  "cloud-organization",
 ] as const;
 
 const SECURITY_ADDITION_IDS = [
@@ -38,12 +42,33 @@ describe("register-cloud-settings", () => {
     expect(cloud?.order).toBeLessThan(2);
   });
 
+  it("registers the Developer group between Cloud and Security", () => {
+    const developer = listExtraSettingsGroups().find(
+      (g) => g.id === DEVELOPER_SETTINGS_GROUP_ID,
+    );
+    expect(developer).toBeDefined();
+    expect(developer?.label).toBe("Developer");
+    expect(developer?.order).toBeGreaterThan(1.5);
+    expect(developer?.order).toBeLessThan(2);
+  });
+
   it("registers every Cloud-group section with group=cloud", () => {
     const byId = new Map(listSettingsSections().map((s) => [s.id, s]));
     for (const id of CLOUD_SECTION_IDS) {
       const section = byId.get(id);
       expect(section, `missing section ${id}`).toBeDefined();
       expect(section?.group).toBe(CLOUD_SETTINGS_GROUP_ID);
+      expect(section?.Component).toBeTypeOf("function");
+    }
+  });
+
+  it("registers developer cloud sections into the Developer group behind the developer view gate", () => {
+    const byId = new Map(listSettingsSections().map((s) => [s.id, s]));
+    for (const id of DEVELOPER_SECTION_IDS) {
+      const section = byId.get(id);
+      expect(section, `missing section ${id}`).toBeDefined();
+      expect(section?.group).toBe(DEVELOPER_SETTINGS_GROUP_ID);
+      expect(section?.viewKind).toBe("developer");
       expect(section?.Component).toBeTypeOf("function");
     }
   });

--- a/packages/ui/src/cloud/settings/register-cloud-settings.ts
+++ b/packages/ui/src/cloud/settings/register-cloud-settings.ts
@@ -3,7 +3,8 @@
  * (re-IA Step 2).
  *
  * Calling {@link registerCloudSettingsSections} registers:
- *  - a new **Cloud** settings group (between System and Security), and
+ *  - new **Cloud** and **Developer** settings groups (between System and
+ *    Security), and
  *  - the cloud sections that re-home the lifted cloud dashboard pages as in-app
  *    Settings sections, plus two additions to the existing **Security** group.
  *
@@ -17,9 +18,9 @@
  *  |-----------------------|----------|------------------------------------------|
  *  | cloud-account         | cloud    | account-security (AccountSurface)        |
  *  | cloud-billing         | cloud    | billing (BillingSectionBody + invoices)  |
- *  | cloud-api-keys        | cloud    | api-keys (ApiKeysSurface)                |
- *  | cloud-applications    | cloud    | applications (entry → /dashboard/apps)   |
- *  | cloud-monetization    | cloud    | monetization (Earnings + Affiliates)     |
+ *  | cloud-api-keys        | developer| api-keys (ApiKeysSurface)                |
+ *  | cloud-applications    | developer| applications (entry → /dashboard/apps)   |
+ *  | cloud-monetization    | developer| monetization (Earnings + Affiliates)     |
  *  | cloud-organization    | cloud    | organization (OrganizationSection)       |
  *  | cloud-security        | security | account-security (SecuritySurface)       |
  *  | cloud-plugin-grants   | security | account-security (PermissionsSurface)    |
@@ -45,6 +46,7 @@ import { registerCloudConnectorsSettingsSection } from "../connectors";
 import { registerMcpsSettingsSection } from "../mcps";
 import {
   CLOUD_SETTINGS_GROUP_ID,
+  DEVELOPER_SETTINGS_GROUP_ID,
   registerSettingsGroup,
 } from "./cloud-settings-group";
 import {
@@ -59,8 +61,9 @@ import {
 } from "./sections";
 
 /**
- * The Cloud group sits between System (built-in order 1) and Security (built-in
- * order 2), matching the IA in `docs/cloud-into-eliza/PLAN.md` §4.3.
+ * The Cloud + Developer groups sit between System (built-in order 1) and
+ * Security (built-in order 2), matching the IA in
+ * `docs/cloud-into-eliza/PLAN.md` §4.3.
  */
 let cloudSettingsRegistered = false;
 
@@ -72,6 +75,12 @@ export function registerCloudSettingsSections(): void {
     id: CLOUD_SETTINGS_GROUP_ID,
     label: "Cloud",
     order: 1.5,
+  });
+
+  registerSettingsGroup({
+    id: DEVELOPER_SETTINGS_GROUP_ID,
+    label: "Developer",
+    order: 1.6,
   });
 
   // ── Cloud group ──────────────────────────────────────────────────────────────
@@ -111,10 +120,11 @@ export function registerCloudSettingsSections(): void {
     icon: KeyRound,
     tone: "accent",
     hue: "accent",
-    group: CLOUD_SETTINGS_GROUP_ID,
+    group: DEVELOPER_SETTINGS_GROUP_ID,
     titleKey: "settings.sections.cloudApiKeys.title",
     defaultTitle: "API Keys",
-    order: 2,
+    order: 0,
+    viewKind: "developer",
     Component: CloudApiKeysSection,
   });
 
@@ -125,10 +135,11 @@ export function registerCloudSettingsSections(): void {
     icon: Grid3x3,
     tone: "accent",
     hue: "accent",
-    group: CLOUD_SETTINGS_GROUP_ID,
+    group: DEVELOPER_SETTINGS_GROUP_ID,
     titleKey: "settings.sections.cloudApplications.title",
     defaultTitle: "Applications",
-    order: 3,
+    order: 1,
+    viewKind: "developer",
     Component: CloudApplicationsSection,
   });
 
@@ -139,10 +150,11 @@ export function registerCloudSettingsSections(): void {
     icon: TrendingUp,
     tone: "accent",
     hue: "accent",
-    group: CLOUD_SETTINGS_GROUP_ID,
+    group: DEVELOPER_SETTINGS_GROUP_ID,
     titleKey: "settings.sections.cloudMonetization.title",
     defaultTitle: "Monetization",
-    order: 4,
+    order: 2,
+    viewKind: "developer",
     Component: CloudMonetizationSection,
   });
 
@@ -156,7 +168,7 @@ export function registerCloudSettingsSections(): void {
     group: CLOUD_SETTINGS_GROUP_ID,
     titleKey: "settings.sections.cloudOrganization.title",
     defaultTitle: "Organization",
-    order: 5,
+    order: 2,
     Component: CloudOrganizationSection,
   });
 


### PR DESCRIPTION
## Summary

- Adds a registered Developer settings group alongside Cloud without changing the pinned built-in settings group list.
- Moves Cloud API Keys, Applications, and Monetization into the Developer group and gates them with `viewKind: "developer"`.
- Keeps everyday Cloud settings (Account, Billing, Organization) in the normal Cloud group and keeps Security/Plugin Grants in Security.
- Updates mobile settings smoke coverage so developer-gated Cloud sections are still rendered with Developer Mode explicitly enabled.

## Validation

- `bun run test src/cloud/settings/register-cloud-settings.test.ts` from `packages/ui` — 5/5 passed
- `bun run typecheck` from `packages/ui` — passed
- `bunx biome check packages/ui/src/cloud/settings/cloud-settings-group.ts packages/ui/src/cloud/settings/register-cloud-settings.ts packages/ui/src/cloud/settings/register-cloud-settings.test.ts packages/app/test/ui-smoke/settings-mobile-load.spec.ts` — passed
- `ELIZA_UI_SMOKE_DISABLE_VIDEO=1 bun run --cwd packages/app test:e2e test/ui-smoke/settings-mobile-load.spec.ts` — 25 passed, 2 expected skips
- `git diff --check` — passed

## Note

`bun run typecheck` from `packages/app` is currently blocked in this checkout before reaching this patch by unresolved workspace packages (`@elizaos/app-core`, `@elizaos/capacitor-mobile-agent-bridge`, `@elizaos/tui`). The targeted app Playwright smoke compiled and exercised the changed settings path successfully.