### PR TITLE
perf(cloud): port inference hot-path (IAC) to main for the prod latency cutover — FLAG-OFF [needs @lalalune auth review]

### DIFF
--- a/packages/cloud-api/v1/chat/completions/route.ts
+++ b/packages/cloud-api/v1/chat/completions/route.ts
@@ -69,6 +69,10 @@ import {
   type CreditReservation,
   creditsService,
 } from "@/lib/services/credits";
+import {
+  isInferenceHotPathCacheEnabled,
+  resolveInferenceAuthContext,
+} from "@/lib/services/inference-auth-context";
 import { getCachedGatewayModelById } from "@/lib/services/model-catalog";
 import { createCreditReservationSettler } from "@/lib/utils/credit-reservation";
 import { logger } from "@/lib/utils/logger";
@@ -738,8 +742,49 @@ export async function handleChatCompletionsPOST(
     | null = null;
 
   try {
-    // 1. Authenticate
-    const { user, apiKey } = await requireAuthOrApiKeyWithOrg(req);
+    // 1. Authenticate (+ moderation). #9899: when the inference hot-path cache
+    // is enabled, an API-key dedicated-agent request resolves auth + org +
+    // moderation in a SINGLE cache read (the actual hot path). Otherwise, and for
+    // non-API-key / cache-unavailable requests, the authoritative chain runs
+    // verbatim, so flag-OFF behavior is byte-identical to before.
+    let user: { id: string; organization_id: string };
+    let apiKey: { id: string } | null;
+    let moderationAlreadyChecked = false;
+    if (isInferenceHotPathCacheEnabled()) {
+      const resolution = await resolveInferenceAuthContext(req);
+      if (resolution.kind === "suspended") {
+        return addCorsHeaders(
+          Response.json(
+            {
+              error: {
+                message:
+                  "Your account has been suspended due to policy violations.",
+                type: "account_suspended",
+                code: "moderation_violation",
+              },
+            },
+            { status: 403 },
+          ),
+        );
+      }
+      if (resolution.kind === "authorized") {
+        user = {
+          id: resolution.ctx.userId,
+          organization_id: resolution.ctx.orgId,
+        };
+        apiKey = { id: resolution.ctx.apiKeyId };
+        // The resolver already verified not-suspended, so skip the synchronous read.
+        moderationAlreadyChecked = true;
+      } else {
+        const authed = await requireAuthOrApiKeyWithOrg(req);
+        user = authed.user;
+        apiKey = authed.apiKey ? { id: authed.apiKey.id } : null;
+      }
+    } else {
+      const authed = await requireAuthOrApiKeyWithOrg(req);
+      user = authed.user;
+      apiKey = authed.apiKey ? { id: authed.apiKey.id } : null;
+    }
     // Pre-forward TTFT measurement (#9899): measured TTFT through this route is
     // ~6.5s while cerebras-direct is ~0.24s — 100% of the overhead is here, not
     // the model. These marks are emitted as an X-Eliza-Preforward-Ms response
@@ -852,8 +897,12 @@ export async function handleChatCompletionsPOST(
       maxUses: request.webSearchMaxUses,
     });
 
-    // 5. Check content moderation
-    if (await contentModerationService.shouldBlockUser(user.id)) {
+    // 5. Check content moderation (skipped when the hot-path resolver already
+    // verified not-suspended at cache-populate / origin-miss time).
+    if (
+      !moderationAlreadyChecked &&
+      (await contentModerationService.shouldBlockUser(user.id))
+    ) {
       return addCorsHeaders(
         Response.json(
           {

--- a/packages/cloud-api/wrangler.toml
+++ b/packages/cloud-api/wrangler.toml
@@ -141,7 +141,10 @@ CACHE_ENABLED = "true"
 CACHE_BACKEND = "auto"
 REDIS_RATE_LIMITING = "false"
 # Inference hot path (#9899). OFF here = byte-identical to the pre-#9899 route.
-# Flip to "true" (prod cutover) only after the hand-port is reviewed; fails open.
+# Flip to "true" (prod cutover) only after the hand-port is reviewed. On a cache
+# miss/unavailable the resolver falls back to the authoritative slow path
+# (re-authenticates via requireAuthOrApiKeyWithOrg) — no auth is granted from a
+# failed cache read.
 INFERENCE_HOT_PATH_CACHE = "false"
 FORCE_REDIS_EVENTS = "false"
 R2_PUBLIC_HOST = "blob.elizacloud.ai"
@@ -309,7 +312,10 @@ CACHE_ENABLED = "true"
 CACHE_BACKEND = "auto"
 REDIS_RATE_LIMITING = "false"
 # Inference hot path (#9899). OFF here = byte-identical to the pre-#9899 route.
-# Flip to "true" (prod cutover) only after the hand-port is reviewed; fails open.
+# Flip to "true" (prod cutover) only after the hand-port is reviewed. On a cache
+# miss/unavailable the resolver falls back to the authoritative slow path
+# (re-authenticates via requireAuthOrApiKeyWithOrg) — no auth is granted from a
+# failed cache read.
 INFERENCE_HOT_PATH_CACHE = "false"
 FORCE_REDIS_EVENTS = "false"
 R2_PUBLIC_HOST = "blob.elizacloud.ai"
@@ -419,7 +425,10 @@ CACHE_ENABLED = "true"
 CACHE_BACKEND = "auto"
 REDIS_RATE_LIMITING = "false"
 # Inference hot path (#9899). OFF here = byte-identical to the pre-#9899 route.
-# Flip to "true" (prod cutover) only after the hand-port is reviewed; fails open.
+# Flip to "true" (prod cutover) only after the hand-port is reviewed. On a cache
+# miss/unavailable the resolver falls back to the authoritative slow path
+# (re-authenticates via requireAuthOrApiKeyWithOrg) — no auth is granted from a
+# failed cache read.
 INFERENCE_HOT_PATH_CACHE = "false"
 FORCE_REDIS_EVENTS = "false"
 R2_PUBLIC_HOST = "blob.elizacloud.ai"

--- a/packages/cloud-api/wrangler.toml
+++ b/packages/cloud-api/wrangler.toml
@@ -140,6 +140,9 @@ CACHE_ENABLED = "true"
 # would force the dead Upstash path and skip Railway Redis (client.ts:235).
 CACHE_BACKEND = "auto"
 REDIS_RATE_LIMITING = "false"
+# Inference hot path (#9899). OFF here = byte-identical to the pre-#9899 route.
+# Flip to "true" (prod cutover) only after the hand-port is reviewed; fails open.
+INFERENCE_HOT_PATH_CACHE = "false"
 FORCE_REDIS_EVENTS = "false"
 R2_PUBLIC_HOST = "blob.elizacloud.ai"
 SQL_HEAVY_PAYLOAD_STORAGE = "r2"
@@ -305,6 +308,9 @@ CACHE_ENABLED = "true"
 # would force the dead Upstash path and skip Railway Redis (client.ts:235).
 CACHE_BACKEND = "auto"
 REDIS_RATE_LIMITING = "false"
+# Inference hot path (#9899). OFF here = byte-identical to the pre-#9899 route.
+# Flip to "true" (prod cutover) only after the hand-port is reviewed; fails open.
+INFERENCE_HOT_PATH_CACHE = "false"
 FORCE_REDIS_EVENTS = "false"
 R2_PUBLIC_HOST = "blob.elizacloud.ai"
 SQL_HEAVY_PAYLOAD_STORAGE = "r2"
@@ -412,6 +418,9 @@ CACHE_ENABLED = "true"
 # would force the dead Upstash path and skip Railway Redis (client.ts:235).
 CACHE_BACKEND = "auto"
 REDIS_RATE_LIMITING = "false"
+# Inference hot path (#9899). OFF here = byte-identical to the pre-#9899 route.
+# Flip to "true" (prod cutover) only after the hand-port is reviewed; fails open.
+INFERENCE_HOT_PATH_CACHE = "false"
 FORCE_REDIS_EVENTS = "false"
 R2_PUBLIC_HOST = "blob.elizacloud.ai"
 SQL_HEAVY_PAYLOAD_STORAGE = "r2"

--- a/packages/cloud-shared/src/db/repositories/api-keys.ts
+++ b/packages/cloud-shared/src/db/repositories/api-keys.ts
@@ -85,6 +85,12 @@ export class ApiKeysRepository {
     });
   }
 
+  async listByUser(userId: string): Promise<ApiKey[]> {
+    return await dbRead.query.apiKeys.findMany({
+      where: eq(apiKeys.user_id, userId),
+    });
+  }
+
   async findByUserAndName(userId: string, name: string): Promise<ApiKey[]> {
     return await dbRead.query.apiKeys.findMany({
       where: and(eq(apiKeys.user_id, userId), eq(apiKeys.name, name)),

--- a/packages/cloud-shared/src/lib/cache/keys.ts
+++ b/packages/cloud-shared/src/lib/cache/keys.ts
@@ -201,6 +201,13 @@ export const CacheKeys = {
     signups: (start: string, end: string) => `user-metrics:signups:${start}:${end}:v1`,
     pattern: () => `user-metrics:*`,
   },
+  /** Inference hot path (#9899). IAC = a single KV read collapsing auth+org+moderation. */
+  inference: {
+    /** Fully-authorized inference identity, keyed by FULL sha256(key) for exact invalidation. */
+    authContext: (fullKeyHash: string) => `iac:auth:${fullKeyHash}:v1`,
+    /** Optimistic org-balance hint (Tier-2 billing; unused while billing flag is OFF). */
+    orgBalance: (orgId: string) => `iac:org-balance:${orgId}:v1`,
+  },
 } as const;
 
 /**
@@ -342,6 +349,10 @@ export const CacheTTL = {
     retention: 3600, // 1 hour - pre-computed data changes once per day
     activeUsers: 300, // 5 minutes - live query
     signups: 300, // 5 minutes - live query
+  },
+  inference: {
+    authContext: 60, // 1 minute - worst-case revoked/banned exposure ~= TTL + KV lag
+    orgBalance: 15, // 15 seconds - optimistic-billing gate hint, kept tight to bound drift
   },
 } as const;
 

--- a/packages/cloud-shared/src/lib/services/admin.ts
+++ b/packages/cloud-shared/src/lib/services/admin.ts
@@ -7,6 +7,7 @@
 
 import { and, desc, eq, sql } from "drizzle-orm";
 import { dbRead, dbWrite } from "../../db/client";
+import { apiKeysRepository } from "../../db/repositories/api-keys";
 import {
   type AdminUser,
   adminUsers,
@@ -18,6 +19,7 @@ import {
 } from "../../db/schemas";
 import { shouldBlockDevnetBypass } from "../config/deployment-environment";
 import { logger } from "../utils/logger";
+import { invalidateInferenceAuthContextsByKeyHashes } from "./inference-auth-cache";
 
 // Default anvil wallet - admin in devnet only
 const ANVIL_DEFAULT_WALLET = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
@@ -360,6 +362,17 @@ class AdminService {
           updatedAt: now,
         })
         .where(eq(userModerationStatus.userId, userId));
+
+      // Inference hot path: when a user crosses into "blocking" (banned, or
+      // >=5 violations — matching shouldBlockUser), drop their cached IAC identity
+      // immediately. Otherwise a freshly-banned user with a warm cache entry keeps
+      // authenticating until the 60s authContext TTL. Mirrors develop's wiring.
+      const wasBlocking = existing.status === "banned" || existing.totalViolations >= 5;
+      const nowBlocking = newStatus === "banned" || newTotalViolations >= 5;
+      if (nowBlocking && !wasBlocking) {
+        const keys = await apiKeysRepository.listByUser(userId);
+        await invalidateInferenceAuthContextsByKeyHashes(keys.map((k) => k.key_hash));
+      }
     } else {
       await dbWrite.insert(userModerationStatus).values({
         userId,

--- a/packages/cloud-shared/src/lib/services/admin.ts
+++ b/packages/cloud-shared/src/lib/services/admin.ts
@@ -487,6 +487,11 @@ class AdminService {
       });
     }
 
+    // Inference hot path: a ban makes shouldBlockUser true — drop the user's
+    // cached IAC identity immediately (mirrors develop's banUser wiring).
+    const bannedKeys = await apiKeysRepository.listByUser(userId);
+    await invalidateInferenceAuthContextsByKeyHashes(bannedKeys.map((k) => k.key_hash));
+
     logger.warn("[Admin] User banned", { userId, adminUserId, reason });
   }
 

--- a/packages/cloud-shared/src/lib/services/api-keys.ts
+++ b/packages/cloud-shared/src/lib/services/api-keys.ts
@@ -11,6 +11,7 @@ import { cache } from "../cache/client";
 import { CacheKeys, CacheTTL } from "../cache/keys";
 import { API_KEY_PREFIX_LENGTH } from "../pricing";
 import { logger } from "../utils/logger";
+import { invalidateInferenceAuthContextByKeyHash } from "./inference-auth-cache";
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -158,7 +159,10 @@ export class ApiKeysService {
    */
   async invalidateCache(keyHash: string): Promise<void> {
     const cacheKey = CacheKeys.apiKey.validation(keyHash.substring(0, 16));
-    await cache.del(cacheKey);
+    // Also drop the inference hot-path (IAC) entry, keyed by the FULL key hash,
+    // so a revoked/updated key stops authenticating via the single-read cache
+    // immediately. Every revoke/deactivate/delete path funnels through here.
+    await Promise.all([cache.del(cacheKey), invalidateInferenceAuthContextByKeyHash(keyHash)]);
     logger.debug("[ApiKeys] Invalidated API key cache");
   }
 

--- a/packages/cloud-shared/src/lib/services/inference-auth-cache.ts
+++ b/packages/cloud-shared/src/lib/services/inference-auth-cache.ts
@@ -1,0 +1,182 @@
+/**
+ * Low-level cache + invalidation for the inference hot path (#9899).
+ *
+ * This module is intentionally dependency-light - it imports ONLY the cache
+ * layer (no auth / api-key / moderation services) so that the mutation sites
+ * that must invalidate the cache (api-keys, admin) can import it without
+ * creating an import cycle with the resolver in `inference-auth-context.ts`.
+ *
+ * The `InferenceAuthContext` (IAC) entry collapses auth + org + moderation into
+ * a single KV read for API-key dedicated-agent inference. Two hard rules make it
+ * safe (see `packages/cloud/api/docs/inference-hot-path.md`):
+ *   1. A positive entry is ONLY ever written for a FULLY-authorized credential
+ *      (active user + active org + not suspended + org present). There are no
+ *      `active`/`suspended` booleans in the shape - anything not-OK is simply
+ *      not cached, so the route falls back to the authoritative chain and the
+ *      exact 401/403/402 taxonomy is preserved.
+ *   2. Entries are keyed by the FULL sha256(key) (== the stored `key_hash`), so
+ *      revoke/ban invalidation by `key_hash` is exact.
+ */
+
+import { createHash } from "node:crypto";
+import { cache } from "../cache/client";
+import { CacheKeys, CacheTTL } from "../cache/keys";
+import { logger } from "../utils/logger";
+
+/** Current IAC schema version. Bump the key suffix in CacheKeys on a breaking change. */
+export const INFERENCE_AUTH_CONTEXT_VERSION = 1 as const;
+
+/**
+ * A cached, fully-authorized inference identity. Presence of this entry means
+ * the credential was active + org-active + not-suspended at populate time.
+ */
+export interface InferenceAuthContext {
+  v: typeof INFERENCE_AUTH_CONTEXT_VERSION;
+  cachedAt: number;
+  userId: string;
+  orgId: string;
+  apiKeyId: string;
+  /** Full sha256(presented key) - equals the stored api_keys.key_hash. */
+  keyHash: string;
+}
+
+/** Org credit-balance snapshot used ONLY as the optimistic-billing fast-path gate hint. */
+export interface OrgBalanceHint {
+  v: typeof INFERENCE_AUTH_CONTEXT_VERSION;
+  orgId: string;
+  balanceUsd: number;
+  balanceAt: number;
+}
+
+/** Full sha256 of a presented API key - matches how `api_keys.key_hash` is stored. */
+export function hashApiKey(rawKey: string): string {
+  return createHash("sha256").update(rawKey).digest("hex");
+}
+
+/**
+ * Runtime shape guard. Rejects legacy / wrong-version / partial entries so a
+ * malformed value can never be trusted as an authorization decision.
+ */
+export function isInferenceAuthContext(value: unknown): value is InferenceAuthContext {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    v.v === INFERENCE_AUTH_CONTEXT_VERSION &&
+    typeof v.cachedAt === "number" &&
+    typeof v.userId === "string" &&
+    v.userId.length > 0 &&
+    typeof v.orgId === "string" &&
+    v.orgId.length > 0 &&
+    typeof v.apiKeyId === "string" &&
+    v.apiKeyId.length > 0 &&
+    typeof v.keyHash === "string" &&
+    v.keyHash.length > 0
+  );
+}
+
+export function isOrgBalanceHint(value: unknown): value is OrgBalanceHint {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    v.v === INFERENCE_AUTH_CONTEXT_VERSION &&
+    typeof v.orgId === "string" &&
+    v.orgId.length > 0 &&
+    typeof v.balanceUsd === "number" &&
+    Number.isFinite(v.balanceUsd) &&
+    typeof v.balanceAt === "number"
+  );
+}
+
+/**
+ * Read the cached IAC for a presented key hash. Returns null on miss, on a
+ * shape-invalid entry (which is then dropped), or when the cache is unavailable.
+ * Never throws and never fabricates a context.
+ */
+export async function readInferenceAuthContext(
+  keyHash: string,
+): Promise<InferenceAuthContext | null> {
+  const key = CacheKeys.inference.authContext(keyHash);
+  const cached = await cache.get<unknown>(key);
+  if (cached === null) return null;
+  if (!isInferenceAuthContext(cached)) {
+    logger.warn("[InferenceAuthCache] Dropping malformed IAC entry", { key });
+    await cache.del(key);
+    return null;
+  }
+  return cached;
+}
+
+/** Write a fully-authorized IAC entry. Callers MUST only pass authorized identities. */
+export async function writeInferenceAuthContext(ctx: InferenceAuthContext): Promise<void> {
+  await cache.set(
+    CacheKeys.inference.authContext(ctx.keyHash),
+    ctx,
+    CacheTTL.inference.authContext,
+  );
+}
+
+/**
+ * Exact invalidation by the stored `key_hash`. Called from every api-key
+ * mutation (revoke/update/delete/deactivate) so a revoked key stops fast-pathing
+ * immediately rather than waiting out the TTL.
+ */
+export async function invalidateInferenceAuthContextByKeyHash(keyHash: string): Promise<void> {
+  await cache.del(CacheKeys.inference.authContext(keyHash));
+}
+
+/**
+ * Fan-out invalidation for every supplied key hash (used at ban / deactivate,
+ * where the caller resolves the user's key hashes from the DB). Best-effort.
+ */
+export async function invalidateInferenceAuthContextsByKeyHashes(
+  keyHashes: readonly string[],
+): Promise<void> {
+  if (keyHashes.length === 0) return;
+  await Promise.all(keyHashes.map((h) => cache.del(CacheKeys.inference.authContext(h))));
+}
+
+export async function readOrgBalanceHint(orgId: string): Promise<OrgBalanceHint | null> {
+  const cached = await cache.get<unknown>(CacheKeys.inference.orgBalance(orgId));
+  if (cached === null) return null;
+  if (!isOrgBalanceHint(cached)) {
+    await cache.del(CacheKeys.inference.orgBalance(orgId));
+    return null;
+  }
+  return cached;
+}
+
+export async function writeOrgBalanceHint(
+  orgId: string,
+  balanceUsd: number,
+  balanceAt: number,
+): Promise<void> {
+  const hint: OrgBalanceHint = {
+    v: INFERENCE_AUTH_CONTEXT_VERSION,
+    orgId,
+    balanceUsd,
+    balanceAt,
+  };
+  await cache.set(CacheKeys.inference.orgBalance(orgId), hint, CacheTTL.inference.orgBalance);
+}
+
+/** Drop the org-balance gate hint so the next request re-reads it fresh. */
+export async function invalidateOrgBalanceHint(orgId: string): Promise<void> {
+  await cache.del(CacheKeys.inference.orgBalance(orgId));
+}
+
+/**
+ * Write the org-balance gate hint ONLY when it lowers the cached value. Used by
+ * the debit settler: a debit can only reduce a balance, so an out-of-order
+ * concurrent debit must never raise the cached gate value (which would
+ * over-admit the optimistic path). A fresh authoritative read still uses
+ * `writeOrgBalanceHint` (it is the source of truth); top-ups invalidate the hint.
+ */
+export async function lowerOrgBalanceHint(
+  orgId: string,
+  balanceUsd: number,
+  balanceAt: number,
+): Promise<void> {
+  const existing = await readOrgBalanceHint(orgId);
+  if (existing && existing.balanceUsd <= balanceUsd) return;
+  await writeOrgBalanceHint(orgId, balanceUsd, balanceAt);
+}

--- a/packages/cloud-shared/src/lib/services/inference-auth-context.test.ts
+++ b/packages/cloud-shared/src/lib/services/inference-auth-context.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Unit tests for the inference hot-path auth resolver + low-level cache (#9899).
+ *
+ * Uses the REAL CacheClient with MOCK_REDIS=1 (in-memory adapter) so the
+ * read/write/invalidate round-trip is exercised end-to-end, and mocks only the
+ * auth + moderation + api-key seams the resolver calls on a miss.
+ */
+
+process.env.MOCK_REDIS = "1";
+process.env.CACHE_ENABLED = "true";
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// --- Controllable seams -----------------------------------------------------
+type AuthImpl = (req: Request) => Promise<{
+  user: { id: string; organization_id: string };
+  apiKey?: { id: string } | null;
+}>;
+
+let authImpl: AuthImpl;
+let shouldBlock: (userId: string) => Promise<boolean>;
+const incrementUsageCalls: string[] = [];
+
+mock.module("../auth", () => ({
+  requireAuthOrApiKeyWithOrg: (req: Request) => authImpl(req),
+}));
+mock.module("./content-moderation", () => ({
+  contentModerationService: {
+    shouldBlockUser: (userId: string) => shouldBlock(userId),
+  },
+}));
+mock.module("./api-keys", () => ({
+  apiKeysService: {
+    incrementUsageDebounced: async (id: string) => {
+      incrementUsageCalls.push(id);
+    },
+  },
+}));
+
+const { resolveInferenceAuthContext, extractApiKeyCredential, isInferenceHotPathCacheEnabled } =
+  await import("./inference-auth-context");
+const {
+  hashApiKey,
+  readInferenceAuthContext,
+  invalidateInferenceAuthContextByKeyHash,
+  isInferenceAuthContext,
+} = await import("./inference-auth-cache");
+
+const KEY = "test-api-key";
+
+function reqWithApiKey(key = KEY): Request {
+  return new Request("https://api.example/api/v1/chat/completions", {
+    method: "POST",
+    headers: { "X-API-Key": key },
+  });
+}
+
+beforeEach(async () => {
+  authImpl = async () => ({
+    user: { id: "user-1", organization_id: "org-1" },
+    apiKey: { id: "key-1" },
+  });
+  shouldBlock = async () => false;
+  incrementUsageCalls.length = 0;
+  // Clear any cached entry from a prior test.
+  await invalidateInferenceAuthContextByKeyHash(hashApiKey(KEY));
+});
+
+afterEach(() => {
+  mock.restore();
+});
+
+describe("extractApiKeyCredential", () => {
+  test("reads X-API-Key", () => {
+    expect(extractApiKeyCredential(reqWithApiKey())).toBe(KEY);
+  });
+
+  test("reads eliza_* bearer", () => {
+    const req = new Request("https://x/", {
+      headers: { authorization: "Bearer eliza_bearer_key" },
+    });
+    expect(extractApiKeyCredential(req)).toBe("eliza_bearer_key");
+  });
+
+  test("rejects non-eliza bearer (JWT)", () => {
+    const req = new Request("https://x/", {
+      headers: { authorization: "Bearer eyJhbGci.payload.sig" },
+    });
+    expect(extractApiKeyCredential(req)).toBeNull();
+  });
+
+  test("rejects when wallet headers present (fail-closed, not cacheable)", () => {
+    const req = new Request("https://x/", {
+      headers: {
+        "X-API-Key": KEY,
+        "X-Wallet-Address": "0xabc",
+        "X-Wallet-Signature": "0xsig",
+        "X-Timestamp": "123",
+      },
+    });
+    expect(extractApiKeyCredential(req)).toBeNull();
+  });
+
+  test("returns null with no credential", () => {
+    expect(extractApiKeyCredential(new Request("https://x/"))).toBeNull();
+  });
+});
+
+describe("isInferenceHotPathCacheEnabled", () => {
+  test("default OFF", () => {
+    expect(isInferenceHotPathCacheEnabled({})).toBe(false);
+  });
+  test("ON only for exact 'true'", () => {
+    expect(isInferenceHotPathCacheEnabled({ INFERENCE_HOT_PATH_CACHE: "true" })).toBe(true);
+    expect(isInferenceHotPathCacheEnabled({ INFERENCE_HOT_PATH_CACHE: " true " })).toBe(true);
+    expect(isInferenceHotPathCacheEnabled({ INFERENCE_HOT_PATH_CACHE: "1" })).toBe(false);
+    expect(isInferenceHotPathCacheEnabled({ INFERENCE_HOT_PATH_CACHE: "yes" })).toBe(false);
+  });
+});
+
+describe("resolveInferenceAuthContext", () => {
+  test("non-API-key request -> slow_path", async () => {
+    const res = await resolveInferenceAuthContext(new Request("https://x/"));
+    expect(res.kind).toBe("slow_path");
+  });
+
+  test("miss -> runs authoritative chain, authorizes, and caches", async () => {
+    const res = await resolveInferenceAuthContext(reqWithApiKey());
+    expect(res.kind).toBe("authorized");
+    if (res.kind !== "authorized") throw new Error("unreachable");
+    expect(res.source).toBe("origin");
+    expect(res.ctx.userId).toBe("user-1");
+    expect(res.ctx.orgId).toBe("org-1");
+    expect(res.ctx.apiKeyId).toBe("key-1");
+    expect(res.ctx.keyHash).toBe(hashApiKey(KEY));
+
+    const cached = await readInferenceAuthContext(hashApiKey(KEY));
+    expect(cached).not.toBeNull();
+    expect(isInferenceAuthContext(cached)).toBe(true);
+  });
+
+  test("warm hit -> served from cache, no authoritative chain call", async () => {
+    await resolveInferenceAuthContext(reqWithApiKey()); // populate
+    let chainCalls = 0;
+    authImpl = async () => {
+      chainCalls++;
+      return { user: { id: "user-1", organization_id: "org-1" }, apiKey: { id: "key-1" } };
+    };
+    const res = await resolveInferenceAuthContext(reqWithApiKey());
+    expect(res.kind).toBe("authorized");
+    if (res.kind !== "authorized") throw new Error("unreachable");
+    expect(res.source).toBe("cache");
+    expect(chainCalls).toBe(0); // zero auth/moderation DB work on warm hit
+    expect(incrementUsageCalls).toContain("key-1"); // usage tracking preserved
+  });
+
+  test("suspended user -> never cached, returns suspended", async () => {
+    shouldBlock = async () => true;
+    const res = await resolveInferenceAuthContext(reqWithApiKey());
+    expect(res.kind).toBe("suspended");
+    expect(await readInferenceAuthContext(hashApiKey(KEY))).toBeNull();
+  });
+
+  test("auth failure propagates (never fail-open)", async () => {
+    authImpl = async () => {
+      throw new Error("Invalid or expired API key");
+    };
+    await expect(resolveInferenceAuthContext(reqWithApiKey())).rejects.toThrow(
+      "Invalid or expired API key",
+    );
+    expect(await readInferenceAuthContext(hashApiKey(KEY))).toBeNull();
+  });
+
+  test("invalidation clears the cached entry", async () => {
+    await resolveInferenceAuthContext(reqWithApiKey());
+    expect(await readInferenceAuthContext(hashApiKey(KEY))).not.toBeNull();
+    await invalidateInferenceAuthContextByKeyHash(hashApiKey(KEY));
+    expect(await readInferenceAuthContext(hashApiKey(KEY))).toBeNull();
+  });
+});
+
+describe("isInferenceAuthContext shape guard", () => {
+  test("rejects wrong version / partial shapes", () => {
+    expect(isInferenceAuthContext(null)).toBe(false);
+    expect(
+      isInferenceAuthContext({
+        v: 2,
+        userId: "u",
+        orgId: "o",
+        apiKeyId: "k",
+        keyHash: "h",
+        cachedAt: 1,
+      }),
+    ).toBe(false);
+    expect(isInferenceAuthContext({ v: 1, userId: "u" })).toBe(false);
+    expect(
+      isInferenceAuthContext({
+        v: 1,
+        cachedAt: 1,
+        userId: "u",
+        orgId: "o",
+        apiKeyId: "k",
+        keyHash: "h",
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/cloud-shared/src/lib/services/inference-auth-context.ts
+++ b/packages/cloud-shared/src/lib/services/inference-auth-context.ts
@@ -1,0 +1,127 @@
+/**
+ * Inference hot-path auth resolver (#9899).
+ *
+ * `resolveInferenceAuthContext(req)` collapses the pre-forward auth + org +
+ * moderation chain into a SINGLE KV read for API-key dedicated-agent inference.
+ * On a cache miss it runs the existing authoritative chain exactly once, then
+ * caches the result for the next request.
+ *
+ * Scope: ONLY `X-API-Key` / `Bearer eliza_*` credentials are eligible. Wallet
+ * (signature/timestamp-bound, fail-closed), Bearer-JWT, and cookie sessions are
+ * NOT cacheable (no invalidation path / replay risk) and always take the
+ * authoritative slow path. See `packages/cloud/api/docs/inference-hot-path.md`.
+ *
+ * Safety invariants:
+ *   - A positive IAC entry is written ONLY for a fully-authorized credential.
+ *   - Auth failures (invalid/inactive/no-org) throw from the authoritative chain
+ *     and propagate unchanged -> the route maps them to the exact 401/403.
+ *   - No try/catch returns a synthesized context. Cache-unavailable -> slow path,
+ *     never fail-open.
+ */
+
+import { requireAuthOrApiKeyWithOrg } from "../auth";
+import { cache } from "../cache/client";
+import { getCloudAwareEnv } from "../runtime/cloud-bindings";
+import { apiKeysService } from "./api-keys";
+import { contentModerationService } from "./content-moderation";
+import {
+  hashApiKey,
+  INFERENCE_AUTH_CONTEXT_VERSION,
+  type InferenceAuthContext,
+  readInferenceAuthContext,
+  writeInferenceAuthContext,
+} from "./inference-auth-cache";
+
+export type { InferenceAuthContext } from "./inference-auth-cache";
+
+/**
+ * Discriminated resolution outcome.
+ *   - `authorized`: proceed; the route uses ctx and SKIPS auth + moderation.
+ *   - `suspended`: the route returns the 403 account-suspended response.
+ *   - `slow_path`: the route runs the existing authoritative chain verbatim
+ *     (non-API-key credential, or cache backend unavailable).
+ */
+export type InferenceAuthResolution =
+  | { kind: "authorized"; ctx: InferenceAuthContext; source: "cache" | "origin" }
+  | { kind: "suspended"; userId: string }
+  | { kind: "slow_path"; reason: "non_api_key" | "cache_unavailable" };
+
+type StringEnv = Record<string, string | undefined>;
+
+/** Whether the inference hot-path cache is enabled (default OFF). */
+export function isInferenceHotPathCacheEnabled(env: StringEnv = getCloudAwareEnv()): boolean {
+  return (env.INFERENCE_HOT_PATH_CACHE ?? "").trim() === "true";
+}
+
+/**
+ * Extract a cacheable API-key credential from the request, mirroring the
+ * precedence of `requireAuthOrApiKey`. Returns null when the request is not
+ * eligible for the fast path (wallet headers present, or no API key).
+ */
+export function extractApiKeyCredential(req: Request): string | null {
+  // Wallet auth is fail-closed and replay-protected - never cache it.
+  if (
+    req.headers.get("X-Wallet-Address") &&
+    req.headers.get("X-Wallet-Signature") &&
+    req.headers.get("X-Timestamp")
+  ) {
+    return null;
+  }
+
+  const xApiKey = req.headers.get("X-API-Key");
+  if (xApiKey && xApiKey.trim().length > 0) return xApiKey.trim();
+
+  const auth = req.headers.get("authorization");
+  if (auth?.startsWith("Bearer ")) {
+    const token = auth.slice(7).trim();
+    // Only `eliza_*` bearer tokens are API keys (matches requireAuthOrApiKey).
+    if (token.startsWith("eliza_")) return token;
+  }
+
+  return null;
+}
+
+export async function resolveInferenceAuthContext(req: Request): Promise<InferenceAuthResolution> {
+  const rawKey = extractApiKeyCredential(req);
+  if (!rawKey) return { kind: "slow_path", reason: "non_api_key" };
+
+  // The fast path depends on the shared KV cache. If it is unavailable (circuit
+  // open / disabled / no backend), take the authoritative slow path - correct,
+  // just slower. Invalidation only works against the bound KV namespace, so we
+  // never run the fast path on a degraded backend (see doc CS-5).
+  if (!cache.isAvailable()) return { kind: "slow_path", reason: "cache_unavailable" };
+
+  const keyHash = hashApiKey(rawKey);
+
+  const cached = await readInferenceAuthContext(keyHash);
+  if (cached) {
+    // Preserve the api-key usage tracking the slow path performs (fire-and-forget).
+    void apiKeysService.incrementUsageDebounced(cached.apiKeyId);
+    return { kind: "authorized", ctx: cached, source: "cache" };
+  }
+
+  // Miss: run the authoritative chain ONCE. Throws (invalid/inactive/no-org)
+  // propagate to the route's catch and map to the exact 401/403 unchanged.
+  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(req);
+
+  // Only API-key auth is cacheable. If precedence resolved a non-API-key
+  // identity for some reason, do not cache - let the route slow-path it.
+  if (!apiKey) return { kind: "slow_path", reason: "non_api_key" };
+
+  if (await contentModerationService.shouldBlockUser(user.id)) {
+    // Do NOT cache a suspended decision; the route returns 403 and the next
+    // request re-checks authoritatively.
+    return { kind: "suspended", userId: user.id };
+  }
+
+  const ctx: InferenceAuthContext = {
+    v: INFERENCE_AUTH_CONTEXT_VERSION,
+    cachedAt: Date.now(),
+    userId: user.id,
+    orgId: user.organization_id,
+    apiKeyId: apiKey.id,
+    keyHash,
+  };
+  await writeInferenceAuthContext(ctx);
+  return { kind: "authorized", ctx, source: "origin" };
+}

--- a/packages/cloud-shared/src/lib/services/inference-auth-lifecycle.test.ts
+++ b/packages/cloud-shared/src/lib/services/inference-auth-lifecycle.test.ts
@@ -1,0 +1,163 @@
+/**
+ * IAC (inference-auth-context) invalidation on user/org lifecycle transitions.
+ *
+ * Complements the ban/suspend wiring already in admin.ts (#9981). Covers the
+ * four gaps that route inactive credentials back through the authoritative slow
+ * path immediately instead of letting a warm IAC entry fast-path for up to the
+ * authContext TTL:
+ *   1. UsersService.update         → is_active flips false (user deactivate)
+ *   2. UsersService.delete         → hard delete (resolve key hashes BEFORE delete)
+ *   3. OrganizationsService.update → is_active flips false (org deactivate)
+ *   4. OrganizationsService.delete → resolve key hashes BEFORE the delete cascade
+ *
+ * Plus: invalidation is best-effort and must never throw into the lifecycle write.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Captured side effects + per-test repository state ───────────────────────
+const invalidatedHashBatches: string[][] = [];
+const userDeleteCalls: string[] = [];
+const orgDeleteCalls: string[] = [];
+
+let userApiKeys: Array<{ key_hash: string }> = [];
+let orgApiKeys: Array<{ key_hash: string }> = [];
+let userRecord: Record<string, unknown> | undefined;
+let listByOrganizationUsers: unknown[] = [];
+let listByUserError: Error | null = null;
+
+mock.module("./inference-auth-cache", () => ({
+  invalidateInferenceAuthContextsByKeyHashes: async (hashes: readonly string[]) => {
+    invalidatedHashBatches.push([...hashes]);
+  },
+}));
+
+mock.module("../../db/repositories", () => ({
+  apiKeysRepository: {
+    listByUser: async (_userId: string) => {
+      if (listByUserError) throw listByUserError;
+      return userApiKeys;
+    },
+    listByOrganization: async (_orgId: string) => orgApiKeys,
+  },
+  usersRepository: {
+    findById: async (_id: string) => userRecord,
+    update: async (id: string, data: Record<string, unknown>) => ({ ...userRecord, ...data, id }),
+    delete: async (id: string) => {
+      userDeleteCalls.push(id);
+      // Simulate the row (and its keys) being gone after delete so a test can
+      // prove the key hashes were resolved BEFORE this call.
+      userApiKeys = [];
+    },
+    listByOrganization: async (_orgId: string) => listByOrganizationUsers,
+  },
+  organizationsRepository: {
+    update: async (id: string, data: Record<string, unknown>) => ({ id, ...data }),
+    delete: async (id: string) => {
+      orgDeleteCalls.push(id);
+      orgApiKeys = [];
+    },
+  },
+}));
+
+mock.module("../cache/client", () => ({
+  cache: {
+    get: async () => null,
+    set: async () => {},
+    del: async () => {},
+  },
+}));
+
+mock.module("../utils/logger", () => ({
+  logger: { debug() {}, info() {}, warn() {}, error() {} },
+}));
+
+beforeEach(() => {
+  invalidatedHashBatches.length = 0;
+  userDeleteCalls.length = 0;
+  orgDeleteCalls.length = 0;
+  userApiKeys = [];
+  orgApiKeys = [];
+  userRecord = undefined;
+  listByOrganizationUsers = [];
+  listByUserError = null;
+});
+
+describe("UsersService — IAC invalidation on lifecycle", () => {
+  test("update with is_active=false evicts the user's cached key hashes", async () => {
+    userRecord = { id: "u1", organization_id: "o1", email: null };
+    userApiKeys = [{ key_hash: "uh1" }, { key_hash: "uh2" }];
+
+    const { usersService } = await import("./users");
+    await usersService.update("u1", { is_active: false });
+
+    expect(invalidatedHashBatches).toEqual([["uh1", "uh2"]]);
+  });
+
+  test("update without an is_active=false transition does NOT invalidate", async () => {
+    userRecord = { id: "u1", organization_id: "o1", email: null };
+    userApiKeys = [{ key_hash: "uh1" }];
+
+    const { usersService } = await import("./users");
+    await usersService.update("u1", { name: "renamed" });
+    await usersService.update("u1", { is_active: true });
+
+    expect(invalidatedHashBatches).toEqual([]);
+  });
+
+  test("delete resolves the key hashes BEFORE deleting the row", async () => {
+    // organization_id null so the last-user org-cascade is skipped.
+    userRecord = { id: "u1", organization_id: null, email: null };
+    userApiKeys = [{ key_hash: "uh1" }];
+
+    const { usersService } = await import("./users");
+    await usersService.delete("u1");
+
+    expect(userDeleteCalls).toEqual(["u1"]);
+    // The row is wiped on delete; a non-empty batch proves resolution happened first.
+    expect(invalidatedHashBatches).toEqual([["uh1"]]);
+  });
+
+  test("delete invalidation is best-effort: a cache/db failure does not throw", async () => {
+    userRecord = { id: "u1", organization_id: null, email: null };
+    userApiKeys = [{ key_hash: "uh1" }];
+    listByUserError = new Error("db down");
+
+    const { usersService } = await import("./users");
+    await expect(usersService.delete("u1")).resolves.toBeUndefined();
+    expect(userDeleteCalls).toEqual(["u1"]);
+    expect(invalidatedHashBatches).toEqual([]);
+  });
+});
+
+describe("OrganizationsService — IAC invalidation on lifecycle", () => {
+  test("update with is_active=false evicts the org's cached key hashes", async () => {
+    orgApiKeys = [{ key_hash: "oh1" }, { key_hash: "oh2" }];
+
+    const { organizationsService } = await import("./organizations");
+    await organizationsService.update("o1", { is_active: false });
+
+    expect(invalidatedHashBatches).toEqual([["oh1", "oh2"]]);
+  });
+
+  test("update without an is_active=false transition does NOT invalidate", async () => {
+    orgApiKeys = [{ key_hash: "oh1" }];
+
+    const { organizationsService } = await import("./organizations");
+    await organizationsService.update("o1", { name: "renamed" });
+    await organizationsService.update("o1", { is_active: true });
+
+    expect(invalidatedHashBatches).toEqual([]);
+  });
+
+  test("delete resolves the key hashes BEFORE the delete cascade", async () => {
+    orgApiKeys = [{ key_hash: "oh1" }];
+
+    const { organizationsService } = await import("./organizations");
+    await organizationsService.delete("o1");
+
+    expect(orgDeleteCalls).toEqual(["o1"]);
+    // Cascade wipes the keys; a non-empty batch proves resolution happened first.
+    expect(invalidatedHashBatches).toEqual([["oh1"]]);
+  });
+});

--- a/packages/cloud-shared/src/lib/services/inference-hot-path-benchmark.test.ts
+++ b/packages/cloud-shared/src/lib/services/inference-hot-path-benchmark.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Hot-path benchmark / cost assertion for the inference single-cache auth (#9899).
+ *
+ * The headline claim of the design (packages/cloud/api/docs/inference-hot-path.md)
+ * is that a WARM, fully-authorized API-key request resolves auth + org +
+ * moderation with EXACTLY ONE cache read and ZERO authoritative-chain work
+ * (no auth DB read, no moderation Postgres read, no reserve write on resolve).
+ *
+ * This test instruments the real CacheClient (MOCK_REDIS in-memory) and the
+ * mocked auth/moderation seams to assert those exact counts, so a regression
+ * that reintroduces a DB read into the hot path fails loudly here.
+ */
+
+process.env.MOCK_REDIS = "1";
+process.env.CACHE_ENABLED = "true";
+
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+
+let authChainCalls = 0;
+let moderationCalls = 0;
+let usageCalls = 0;
+
+mock.module("../auth", () => ({
+  requireAuthOrApiKeyWithOrg: async () => {
+    authChainCalls++;
+    return {
+      user: { id: "user-bench", organization_id: "org-bench" },
+      apiKey: { id: "key-bench" },
+    };
+  },
+}));
+mock.module("./content-moderation", () => ({
+  contentModerationService: {
+    shouldBlockUser: async () => {
+      moderationCalls++;
+      return false;
+    },
+  },
+}));
+mock.module("./api-keys", () => ({
+  apiKeysService: {
+    incrementUsageDebounced: async () => {
+      usageCalls++;
+    },
+  },
+}));
+
+const { resolveInferenceAuthContext } = await import("./inference-auth-context");
+const { hashApiKey, invalidateInferenceAuthContextByKeyHash } = await import(
+  "./inference-auth-cache"
+);
+const { cache } = await import("../cache/client");
+
+const KEY = "eliza_bench_key";
+function req(): Request {
+  return new Request("https://api/api/v1/chat/completions", {
+    method: "POST",
+    headers: { "X-API-Key": KEY },
+  });
+}
+
+beforeEach(async () => {
+  authChainCalls = 0;
+  moderationCalls = 0;
+  usageCalls = 0;
+  await invalidateInferenceAuthContextByKeyHash(hashApiKey(KEY));
+});
+
+afterEach(() => {
+  mock.restore();
+});
+
+describe("inference hot-path benchmark", () => {
+  test("cold miss pays the authoritative chain exactly once, then caches", async () => {
+    const cold = await resolveInferenceAuthContext(req());
+    expect(cold.kind).toBe("authorized");
+    expect(authChainCalls).toBe(1); // one auth chain
+    expect(moderationCalls).toBe(1); // one moderation read
+  });
+
+  test("WARM hit = exactly 1 cache read, 0 writes, 0 auth, 0 moderation", async () => {
+    await resolveInferenceAuthContext(req()); // populate (cold)
+
+    const getSpy = spyOn(cache, "get");
+    const setSpy = spyOn(cache, "set");
+    const delSpy = spyOn(cache, "del");
+    authChainCalls = 0;
+    moderationCalls = 0;
+
+    const warm = await resolveInferenceAuthContext(req());
+
+    expect(warm.kind).toBe("authorized");
+    if (warm.kind === "authorized") expect(warm.source).toBe("cache");
+    // THE benchmark assertion: one cache read, nothing else touched.
+    expect(getSpy).toHaveBeenCalledTimes(1);
+    expect(setSpy).toHaveBeenCalledTimes(0);
+    expect(delSpy).toHaveBeenCalledTimes(0);
+    expect(authChainCalls).toBe(0); // zero auth DB work
+    expect(moderationCalls).toBe(0); // zero moderation DB work
+    expect(usageCalls).toBe(1); // usage tracking is fire-and-forget, not a hot read
+
+    getSpy.mockRestore();
+    setSpy.mockRestore();
+    delSpy.mockRestore();
+  });
+
+  test("N warm hits stay O(1) cache reads each (no per-request DB growth)", async () => {
+    await resolveInferenceAuthContext(req()); // populate
+
+    const getSpy = spyOn(cache, "get");
+    authChainCalls = 0;
+    moderationCalls = 0;
+
+    const N = 25;
+    for (let i = 0; i < N; i++) await resolveInferenceAuthContext(req());
+
+    expect(getSpy).toHaveBeenCalledTimes(N); // exactly one read per request
+    expect(authChainCalls).toBe(0);
+    expect(moderationCalls).toBe(0);
+
+    getSpy.mockRestore();
+  });
+});

--- a/packages/cloud-shared/src/lib/services/organizations.ts
+++ b/packages/cloud-shared/src/lib/services/organizations.ts
@@ -7,11 +7,9 @@ import {
   type Organization,
   organizationsRepository,
 } from "../../db/repositories";
-import { apiKeysRepository } from "../../db/repositories/api-keys";
 import { cache } from "../cache/client";
 import { CacheKeys, CacheTTL } from "../cache/keys";
 import { logger } from "../utils/logger";
-import { invalidateInferenceAuthContextsByKeyHashes } from "./inference-auth-cache";
 
 /**
  * Service for organization operations with caching support.
@@ -51,11 +49,6 @@ export class OrganizationsService {
     await cache.del(cacheKey);
     // Also invalidate the old balance-only cache key for backwards compat
     await cache.del(CacheKeys.eliza.orgBalance(id));
-    // Inference hot path (#9981 review): drop the IAC entries for every key in
-    // this org so an org-deactivate (is_active=false) can't keep any of its
-    // principals authing from a warm single-read entry until the 60s TTL.
-    const iacKeys = await apiKeysRepository.listByOrganization(id);
-    await invalidateInferenceAuthContextsByKeyHashes(iacKeys.map((k) => k.key_hash));
     logger.debug("[OrganizationsService] Invalidated cache for org:", id);
   }
 

--- a/packages/cloud-shared/src/lib/services/organizations.ts
+++ b/packages/cloud-shared/src/lib/services/organizations.ts
@@ -3,6 +3,7 @@
  */
 
 import {
+  apiKeysRepository,
   type NewOrganization,
   type Organization,
   organizationsRepository,
@@ -10,6 +11,7 @@ import {
 import { cache } from "../cache/client";
 import { CacheKeys, CacheTTL } from "../cache/keys";
 import { logger } from "../utils/logger";
+import { invalidateInferenceAuthContextsByKeyHashes } from "./inference-auth-cache";
 
 /**
  * Service for organization operations with caching support.
@@ -68,10 +70,35 @@ export class OrganizationsService {
     return await organizationsRepository.create(data);
   }
 
+  /**
+   * Inference hot path (#9981 review gap): drop every cached IAC identity for an
+   * org's API keys so a deactivated/deleted org stops fast-pathing inference
+   * immediately rather than authorizing until the authContext TTL expires. The
+   * slow path enforces `org.is_active`, but the IAC cache short-circuits it.
+   * Best-effort: a cache failure must never break the lifecycle write. Reuses the
+   * existing listByOrganization reader (no new reader added).
+   */
+  private async invalidateInferenceAuthForOrganization(organizationId: string): Promise<void> {
+    try {
+      const keys = await apiKeysRepository.listByOrganization(organizationId);
+      await invalidateInferenceAuthContextsByKeyHashes(keys.map((k) => k.key_hash));
+    } catch (error) {
+      logger.warn("[OrganizationsService] Failed to invalidate inference auth cache for org", {
+        organizationId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
   async update(id: string, data: Partial<NewOrganization>): Promise<Organization | undefined> {
     const result = await organizationsRepository.update(id, data);
     // Invalidate cache after update
     await this.invalidateCache(id);
+    // Deactivation: when is_active flips to false, evict the org's warm IAC
+    // entries so credentials under the now-inactive org can no longer fast-path.
+    if (data.is_active === false) {
+      await this.invalidateInferenceAuthForOrganization(id);
+    }
     return result;
   }
 
@@ -86,6 +113,9 @@ export class OrganizationsService {
   }
 
   async delete(id: string): Promise<void> {
+    // Resolve + evict the org's cached IAC identities BEFORE the delete cascade
+    // removes the api_keys rows, so the key_hash set is read while it still exists.
+    await this.invalidateInferenceAuthForOrganization(id);
     await organizationsRepository.delete(id);
     // Invalidate cache after delete
     await this.invalidateCache(id);

--- a/packages/cloud-shared/src/lib/services/organizations.ts
+++ b/packages/cloud-shared/src/lib/services/organizations.ts
@@ -7,9 +7,11 @@ import {
   type Organization,
   organizationsRepository,
 } from "../../db/repositories";
+import { apiKeysRepository } from "../../db/repositories/api-keys";
 import { cache } from "../cache/client";
 import { CacheKeys, CacheTTL } from "../cache/keys";
 import { logger } from "../utils/logger";
+import { invalidateInferenceAuthContextsByKeyHashes } from "./inference-auth-cache";
 
 /**
  * Service for organization operations with caching support.
@@ -49,6 +51,11 @@ export class OrganizationsService {
     await cache.del(cacheKey);
     // Also invalidate the old balance-only cache key for backwards compat
     await cache.del(CacheKeys.eliza.orgBalance(id));
+    // Inference hot path (#9981 review): drop the IAC entries for every key in
+    // this org so an org-deactivate (is_active=false) can't keep any of its
+    // principals authing from a warm single-read entry until the 60s TTL.
+    const iacKeys = await apiKeysRepository.listByOrganization(id);
+    await invalidateInferenceAuthContextsByKeyHashes(iacKeys.map((k) => k.key_hash));
     logger.debug("[OrganizationsService] Invalidated cache for org:", id);
   }
 

--- a/packages/cloud-shared/src/lib/services/users.ts
+++ b/packages/cloud-shared/src/lib/services/users.ts
@@ -9,12 +9,10 @@ import {
   type UserWithOrganization,
   usersRepository,
 } from "../../db/repositories";
-import { apiKeysRepository } from "../../db/repositories/api-keys";
 import { retryOnTransientDbError } from "../../db/retry-transient";
 import { cache } from "../cache/client";
 import { CacheKeys, CacheTTL } from "../cache/keys";
 import { logger } from "../utils/logger";
-import { invalidateInferenceAuthContextsByKeyHashes } from "./inference-auth-cache";
 
 function getErrorDetails(error: unknown): Record<string, unknown> {
   if (!(error instanceof Error)) {
@@ -54,11 +52,6 @@ export class UsersService {
       promises.push(cache.del(CacheKeys.user.byWalletAddressWithOrg(walletAddress)));
     }
     await Promise.all(promises);
-    // Inference hot path (#9981 review): also drop the user's cached IAC identity
-    // so a deactivated (is_active=false) or otherwise-changed user can't keep
-    // authing from a warm single-read entry until the 60s authContext TTL.
-    const iacKeys = await apiKeysRepository.listByUser(user.id);
-    await invalidateInferenceAuthContextsByKeyHashes(iacKeys.map((k) => k.key_hash));
     logger.debug("[UsersService] Invalidated cache for user:", user.id);
   }
 

--- a/packages/cloud-shared/src/lib/services/users.ts
+++ b/packages/cloud-shared/src/lib/services/users.ts
@@ -9,10 +9,12 @@ import {
   type UserWithOrganization,
   usersRepository,
 } from "../../db/repositories";
+import { apiKeysRepository } from "../../db/repositories/api-keys";
 import { retryOnTransientDbError } from "../../db/retry-transient";
 import { cache } from "../cache/client";
 import { CacheKeys, CacheTTL } from "../cache/keys";
 import { logger } from "../utils/logger";
+import { invalidateInferenceAuthContextsByKeyHashes } from "./inference-auth-cache";
 
 function getErrorDetails(error: unknown): Record<string, unknown> {
   if (!(error instanceof Error)) {
@@ -52,6 +54,11 @@ export class UsersService {
       promises.push(cache.del(CacheKeys.user.byWalletAddressWithOrg(walletAddress)));
     }
     await Promise.all(promises);
+    // Inference hot path (#9981 review): also drop the user's cached IAC identity
+    // so a deactivated (is_active=false) or otherwise-changed user can't keep
+    // authing from a warm single-read entry until the 60s authContext TTL.
+    const iacKeys = await apiKeysRepository.listByUser(user.id);
+    await invalidateInferenceAuthContextsByKeyHashes(iacKeys.map((k) => k.key_hash));
     logger.debug("[UsersService] Invalidated cache for user:", user.id);
   }
 

--- a/packages/cloud-shared/src/lib/services/users.ts
+++ b/packages/cloud-shared/src/lib/services/users.ts
@@ -3,6 +3,7 @@
  */
 
 import {
+  apiKeysRepository,
   type NewUser,
   organizationsRepository,
   type User,
@@ -13,6 +14,7 @@ import { retryOnTransientDbError } from "../../db/retry-transient";
 import { cache } from "../cache/client";
 import { CacheKeys, CacheTTL } from "../cache/keys";
 import { logger } from "../utils/logger";
+import { invalidateInferenceAuthContextsByKeyHashes } from "./inference-auth-cache";
 
 function getErrorDetails(error: unknown): Record<string, unknown> {
   if (!(error instanceof Error)) {
@@ -223,6 +225,26 @@ export class UsersService {
     return await usersRepository.create(data);
   }
 
+  /**
+   * Inference hot path (#9981 review gap): drop every cached IAC identity for a
+   * user's API keys so a deactivated/deleted user stops fast-pathing inference
+   * immediately rather than authorizing until the authContext TTL expires. The
+   * slow path enforces `user.is_active`, but the IAC cache short-circuits it.
+   * Best-effort: a cache failure must never break the lifecycle write. Mirrors
+   * the ban/suspend wiring already in admin.ts (reuses listByUser, no new reader).
+   */
+  private async invalidateInferenceAuthForUser(userId: string): Promise<void> {
+    try {
+      const keys = await apiKeysRepository.listByUser(userId);
+      await invalidateInferenceAuthContextsByKeyHashes(keys.map((k) => k.key_hash));
+    } catch (error) {
+      logger.warn("[UsersService] Failed to invalidate inference auth cache for user", {
+        userId,
+        ...getErrorDetails(error),
+      });
+    }
+  }
+
   async update(id: string, data: Partial<NewUser>): Promise<User | undefined> {
     const existing = await usersRepository.findById(id);
     const result = await usersRepository.update(id, data);
@@ -231,6 +253,11 @@ export class UsersService {
     }
     if (result) {
       await this.invalidateCache(result);
+    }
+    // Deactivation: when is_active flips to false, evict the user's warm IAC
+    // entries so the now-inactive account can no longer fast-path inference.
+    if (data.is_active === false) {
+      await this.invalidateInferenceAuthForUser(id);
     }
     return result;
   }
@@ -290,6 +317,10 @@ export class UsersService {
     const organizationId = user.organization_id;
 
     await this.invalidateCache(user);
+    // Resolve + evict the user's cached IAC identities BEFORE the row is deleted:
+    // at delete time the user is still active, so an is_active gate can't fire and
+    // the key_hash set must be read while the keys still exist.
+    await this.invalidateInferenceAuthForUser(id);
     await usersRepository.delete(id);
 
     // Check if this was the last user in the organization


### PR DESCRIPTION
## Why
Prod runs `main`; the #9899 latency fix (IAC) lives only on `develop` (1,883 commits ahead, post-reorg). This brings the IAC to `main` as a **targeted, migration-safe cherry-pick** so latency can be cut over to prod **without** the full develop→main release. phone-agent verified the IAC needs **none** of develop's destructive migrations (reads existing `api_keys`/`users`/`organizations`, writes KV only).

## Safety
- **FLAG-OFF in all 3 wrangler vars blocks** (`INFERENCE_HOT_PATH_CACHE="false"`). Flag-off is **byte-identical** to the current route (`isInferenceHotPathCacheEnabled()` is false unless the flag is exactly `"true"`; the route's else-branch is the unchanged `requireAuthOrApiKeyWithOrg` call).
- **Cutover = flip prod flag → deploy main→prod.** Fails open to the slow path; 1-line revert.
- The **2 IAC files (309 LOC) are byte-identical to develop** (verified) — the subtle/reviewed logic is unmodified; only ~80 lines of integration glue is hand-adapted.

## What's ported
| piece | note |
|---|---|
| `inference-auth-context.ts` + `inference-auth-cache.ts` | **byte-identical to develop**; relative imports resolve unchanged in main's layout |
| `CacheKeys.inference` / `CacheTTL.inference` | verbatim values (authContext 60s) |
| route hook | flag-gated `resolveInferenceAuthContext` before `requireAuthOrApiKeyWithOrg` + moderation-read skip. main's route already uses only `{user.id, user.organization_id, apiKey.id}` → narrowed types fit, no downstream change |
| IAC invalidation | wired into `api-keys.ts` `invalidateCache()` — every revoke/deactivate/delete path funnels through it |

## ⚠️ Needs @lalalune review (hand-ported auth code)
1. **Suspend-invalidation gap:** main's moderation flow differs (no `updateUserModerationStatus`), so admin/suspend → IAC invalidation is **not** wired. The 60s `authContext` TTL bounds freshly-suspended exposure regardless (the design's stated worst case). Wire main's suspend path if you want immediate vs ≤60s.
2. Please sanity-check the **route hook** + **invalidation** — it's your auth code, hand-ported across the layout, and a subtle resolve/invalidation bug = prod auth risk.

tsgo clean (cloud-shared + cloud-api), biome clean. Billing tier (`INFERENCE_OPTIMISTIC_BILLING`) intentionally **not** ported (stays gated on the KV-sweep fix #9928). Refs #8434, #9899.