### PR TITLE
fix(tui): kill fictional "SSH" naming + run packages/tui on PR CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "test:plugins": "bun run build:core && node packages/scripts/run-turbo.mjs run test --concurrency 3 --filter='./plugins/*' --filter='!@elizaos/plugin-personal-assistant' --filter='!@elizaos/plugin-agent-orchestrator' && bun run --cwd plugins/plugin-personal-assistant test && node packages/scripts/run-turbo.mjs run test --concurrency 1 --filter='@elizaos/plugin-agent-orchestrator'",
     "test:client": "bun run build:core && TEST_PACKAGE_FILTER='\\((packages/app|packages/ui|plugins/plugin-personal-assistant|plugins/plugin-companion|plugins/plugin-training)\\)' TEST_SCRIPT_FILTER='^test$' node packages/scripts/run-all-tests.mjs --no-cloud",
     "test:core": "node packages/scripts/with-test-runtime.mjs node packages/scripts/run-turbo.mjs run test --filter=./packages/core",
-    "test:server": "bun run build:core && TEST_PACKAGE_FILTER='\\((packages/agent|packages/app-core|packages/shared|packages/core|packages/vault|packages/elizaos|packages/skills|packages/scenario-runner|packages/test)\\)' TEST_SCRIPT_FILTER='^test$' node packages/scripts/run-all-tests.mjs --no-cloud",
+    "test:server": "bun run build:core && TEST_PACKAGE_FILTER='\\((packages/agent|packages/app-core|packages/shared|packages/core|packages/tui|packages/vault|packages/elizaos|packages/skills|packages/scenario-runner|packages/test)\\)' TEST_SCRIPT_FILTER='^test$' node packages/scripts/run-all-tests.mjs --no-cloud",
     "test:remote-capabilities": "bun run --cwd packages/agent test:remote-capabilities",
     "capability-router:fixture-server": "bun packages/scripts/capability-router-fixture-server.ts",
     "test:remote-capabilities:surface-audit": "bun packages/scripts/audit-capability-router-plugin-surface.ts",

--- a/packages/agent/docs/terminal-tui.md
+++ b/packages/agent/docs/terminal-tui.md
@@ -1,0 +1,88 @@
+# Terminal TUI run mode
+
+The agent ships an interactive **terminal UI** (TUI): a full-screen shell that
+lists every registered terminal view, mounts them inline, and keeps a chat
+composer pinned to the bottom rows. It is implemented in
+`src/tui/agent-terminal-tui.ts` and rendered with `@elizaos/tui`.
+
+This document is the contract for the run mode: how to start it, the transport
+it speaks, the security boundary it lives inside, and how a plugin view reaches
+the screen.
+
+## There is no SSH server
+
+The TUI talks to an **already-running backend over loopback HTTP**. It is not an
+SSH server and the agent does not embed one. Earlier code named the conversation
+`"SSH terminal"` and a test typed `"hello over ssh"`; that naming was aspirational
+— no `sshd` exists in the agent or the elizaOS Linux image. The conversation is
+now created as `"elizaOS terminal"` with `metadata.source = "terminal-tui"`,
+which reflects the actual mechanism.
+
+To reach the terminal from another machine, **SSH into the host the normal way
+and run the TUI locally on the box** (loopback stays valid, no proxy header). For
+hosted/remote cases use the cloud container control-plane
+(`packages/cloud/api/src/stubs/ssh2.ts` + the Node sidecar), which is a separate
+system from this in-process TUI.
+
+## Subcommands
+
+The `eliza-autonomous` binary (`src/cli/index.ts`) exposes two TUI commands:
+
+| Command | What it does |
+| --- | --- |
+| `eliza-autonomous tui` | Start the interactive terminal TUI against an already-running backend. Requires a TTY. |
+| `eliza-autonomous tui-smoke [--api <url>]` | Boot the TUI once against a backend, print the readiness marker `elizaos-tui-ready api=<url>`, and exit. Used as a boot smoke check (no TTY required). |
+
+Both resolve the backend URL from `--api`, then `ELIZA_AGENT_URL`, then
+`ELIZA_API_URL`, falling back to the default loopback API base
+(`resolveDefaultApiBaseUrl()` in `agent-terminal-tui.ts`).
+
+The in-process TUI (started from `serve`/`start` when a terminal is attached)
+is gated by `isTerminalTuiEnabled()` (`src/tui/tui-enabled.ts`):
+
+- `ELIZA_TERMINAL_TUI` = `1`/`true`/`on` forces it on; `0`/`false`/`off` forces
+  it off.
+- Otherwise it auto-enables only when **both** `stdin` and `stdout` are TTYs and
+  the process is not running under `CI`/`NODE_ENV=test`.
+
+## Transport and the loopback trust boundary
+
+The TUI client (`readJson` in `agent-terminal-tui.ts`) sends **only**
+`Content-Type: application/json` — there is no `Authorization`/`Bearer` token.
+It works because it hits `127.0.0.1`, which the backend treats as trusted via
+`isTrustedLocalRequest`.
+
+That trust gate is **disabled when `X-Forwarded-For` is present** (see
+`src/api/server-helpers-auth-trust.test.ts`) — i.e. through any reverse proxy or
+tunnel. The default API bind host is also `127.0.0.1`
+(`packages/shared/src/runtime-env.ts`). Together these mean the TUI is
+**loopback-only by construction**:
+
+- It is safe to run on the same host as the backend with no auth.
+- It will **not** work end-to-end through a proxy/tunnel that injects
+  `X-Forwarded-For`, because the loopback trust the client depends on is dropped
+  there and the client carries no token to fall back on.
+
+If a token-authenticated remote terminal is ever required, it must add an
+`Authorization` header to `readJson` and mint a local token — do **not** rely on
+the `X-Forwarded-For`-fragile loopback gate, and do **not** add an `sshd` to the
+agent.
+
+## How a registered terminal view reaches the screen
+
+1. A plugin authors one spatial view and registers it for the terminal with
+   `registerSpatialTerminalView(id, () => <View … />)`
+   (`@elizaos/ui/spatial/tui`), which adapts the React tree to an `@elizaos/tui`
+   `Component` and stores it in the process-global terminal-view registry
+   (`packages/tui/src/view-registry.ts`, keyed by `Symbol.for`).
+2. The backend advertises the view under `GET /api/views?viewType=tui`.
+3. The TUI lists every `viewType: "tui"` view; ids with a registered component
+   are flagged renderable (`hasTerminalView(id)`).
+4. Opening a view mounts it inline. The host builds it from the registered
+   factory (`getTerminalViewFactory(id)`) so it can supply `onActivate`; a
+   focused control's activation `POST`s `/api/views/:id/activate?viewType=tui`.
+   Navigating a view `POST`s `/api/views/:id/navigate?viewType=tui` so the
+   runtime marks it active.
+
+`listTerminalViewIds()` enumerates every registered view — the iteration target
+for per-view terminal coverage.

--- a/packages/agent/src/tui/agent-terminal-tui.ts
+++ b/packages/agent/src/tui/agent-terminal-tui.ts
@@ -506,7 +506,7 @@ class AgentTerminalView implements Component {
     }>(this.fetchImpl, this.apiBaseUrl, "/api/conversations", {
       method: "POST",
       body: JSON.stringify({
-        title: "SSH terminal",
+        title: "elizaOS terminal",
         metadata: { source: "terminal-tui" },
       }),
     });

--- a/packages/scripts/ci-path-gate.mjs
+++ b/packages/scripts/ci-path-gate.mjs
@@ -61,6 +61,12 @@ const CONFIGS = {
         reason: "app or shared UI",
       },
       {
+        lanes: ["server", "client", "plugins", "zero_key"],
+        patterns: ["packages/tui/**"],
+        reason:
+          "terminal UI library: its vitest suite runs on the server lane; the client and plugin lanes build it as a spatial-view dependency",
+      },
+      {
         lanes: ["server", "client", "desktop", "zero_key"],
         patterns: ["packages/app-core/**"],
         reason: "app-core host or desktop bridge",

--- a/packages/scripts/ci-path-gate.self-test.mjs
+++ b/packages/scripts/ci-path-gate.self-test.mjs
@@ -79,6 +79,19 @@ assertGate(
   },
 );
 
+assertGate(
+  "tui library changes",
+  runGate({ config: "test", files: ["packages/tui/src/terminal.ts"] }),
+  {
+    server: "true",
+    client: "true",
+    plugins: "true",
+    desktop: "false",
+    zero_key: "true",
+    cloud: "false",
+  },
+);
+
 assertGate("full label", runGate({ config: "test", labels: "ci:full" }), {
   server: "true",
   client: "true",


### PR DESCRIPTION
Part of the #9946 work order (high-confidence, low-risk slice). Lands the naming + CI-lane fixes; the real-PTY e2e and whole-app TUI harness follow in separate PRs (#9969).

## What this does

**1. Kill the fictional "SSH" naming.** The terminal TUI speaks loopback HTTP to an already-running backend — there is no `sshd` in the agent or the elizaOS Linux image. The conversation title was hardcoded to `"SSH terminal"` (`agent-terminal-tui.ts:509`) and a shell test typed/asserted `"hello over ssh"`. Renamed the conversation to `"elizaOS terminal"` (the `metadata.source` was already `"terminal-tui"`) and dropped the ssh test fixtures so the naming reflects reality.

**2. Run `packages/tui` on PR CI.** Its 479 unit tests ran on **no** PR lane — `packages/tui` was in neither the `test:server` nor `test:client` package filter, *and* `packages/tui/**` mapped to **no** `ci-path-gate` lane, so a PR touching only the TUI lib triggered zero test jobs.
- Added `packages/tui` to the `test:server` package filter.
- Added a `ci-path-gate` rule routing `packages/tui/**` → `server` / `client` / `plugins` / `zero_key` lanes (server runs its vitest suite; client/plugins already build it as a spatial-view dependency).
- Added a path-gate **self-test case** proving the routing.

**3. Document the run mode** (`packages/agent/docs/terminal-tui.md`): the `tui` / `tui-smoke` subcommands, the **loopback-only trust boundary** and why it breaks under `X-Forwarded-For` tunneling (resolving the trust-gate-vs-remote-terminal contradiction by documenting the constraint and removing the remote-access claim, per the issue's accepted option), the `ELIZA_TERMINAL_TUI` / `ELIZA_AGENT_URL` / `ELIZA_API_URL` env, and how a registered terminal view reaches the screen.

## Verification

```
$ node packages/scripts/ci-path-gate.self-test.mjs
ci-path-gate self-test passed                 # incl. new "tui library changes" case

$ bunx vitest run packages/agent/src/__tests__/agent-terminal-tui.test.ts
Test Files  1 passed (1)   Tests  5 passed (5)

$ bun run --cwd packages/tui test
Test Files  25 passed (25)  Tests  479 passed (479)

$ grep -rn "SSH terminal\|hello over ssh" packages plugins
# only the historical note in packages/agent/docs/terminal-tui.md

$ bunx biome check <changed files>
Checked 4 files in 70ms. No fixes applied.
```

## Acceptance criteria addressed (#9946)
- [x] No `"SSH terminal"` / `"hello over ssh"` strings remain (loopback-only constraint documented; remote-access claim removed from naming).
- [x] `packages/tui`'s 479 tests execute on PRs via `test:server`; CI fails if they fail. Path-gate now triggers the lane for TUI-only changes.
- [x] Loopback-only constraint explicitly documented; the remote-access naming is gone.

Remaining #9946 items (real-PTY e2e, `tui-smoke` PR step, XR-sim CI, optional DOM-modality centralization) and the whole-app TUI e2e harness (#9969) follow in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)