### PR TITLE
test(plugin-anthropic): align model override mock

### DIFF
--- a/plugins/plugin-anthropic/__tests__/native-plumbing.shape.test.ts
+++ b/plugins/plugin-anthropic/__tests__/native-plumbing.shape.test.ts
@@ -77,7 +77,10 @@ describe("Anthropic native text plumbing", () => {
       streamText: vi.fn(),
     }));
     vi.doMock("../providers/anthropic", () => ({
-      createAnthropicClientWithTopPSupport: () => (modelName: string) => ({ modelName }),
+      createAnthropicClientWithTopPSupport: () => (modelName: string) => ({
+        modelId: modelName,
+        modelName,
+      }),
     }));
 
     const { handleTextSmall } = await import("../models/text");
@@ -139,7 +142,10 @@ describe("Anthropic native text plumbing", () => {
       streamText: vi.fn(),
     }));
     vi.doMock("../providers/anthropic", () => ({
-      createAnthropicClientWithTopPSupport: () => (modelName: string) => ({ modelName }),
+      createAnthropicClientWithTopPSupport: () => (modelName: string) => ({
+        modelId: modelName,
+        modelName,
+      }),
     }));
 
     const { handleTextLarge } = await import("../models/text");


### PR DESCRIPTION
## Summary
- align the Anthropic native plumbing test mock with the real AI SDK model shape by exposing `modelId`
- fixes the shared Windows/plugin-anthropic CI failure seen on #9971 where the per-call model override assertion received `undefined`

## Validation
- `bun run --cwd plugins/plugin-anthropic test __tests__/native-plumbing.shape.test.ts`
- `bun run --cwd plugins/plugin-anthropic test`
- `bunx biome check plugins/plugin-anthropic/__tests__/native-plumbing.shape.test.ts`
- `git diff --check`
