### PR TITLE
fix(personal-assistant): repoint lifeops tests after mixin->domain refactor (#9927)

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/service-mixin-reminders.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/service-mixin-reminders.ts
@@ -1,2 +1,3 @@
 export type { LifeOpsReminderService } from "./domains/reminders-service.js";
+export { buildReminderDispatchPrompt } from "./domains/reminders-service.js";
 export { REMINDER_DISPATCH_INSTRUCTIONS } from "./optimized-prompt-instructions.js";

--- a/plugins/plugin-personal-assistant/test/lifeops-llm-consumer-robustness.test.ts
+++ b/plugins/plugin-personal-assistant/test/lifeops-llm-consumer-robustness.test.ts
@@ -20,10 +20,9 @@ import type {
   UUID,
 } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { LifeOpsServiceBase } from "../src/lifeops/service-mixin-core.js";
-import { withReminders } from "../src/lifeops/service-mixin-reminders.js";
+import { LifeOpsService } from "../src/lifeops/service.js";
 
-const ReminderService = withReminders(LifeOpsServiceBase);
+const ReminderService = LifeOpsService;
 
 const mocks = vi.hoisted(() => ({
   hasOwnerAccess: vi.fn(async () => true),
@@ -50,7 +49,10 @@ function userMessage(text: string): Memory {
  * case decide what the model returns or whether it throws.
  */
 function runtimeWithModel(
-  useModel: (modelType: unknown, params: { prompt?: string }) => Promise<unknown>,
+  useModel: (
+    modelType: unknown,
+    params: { prompt?: string },
+  ) => Promise<unknown>,
 ): IAgentRuntime {
   return {
     agentId: "00000000-0000-0000-0000-000000000204" as UUID,
@@ -175,7 +177,9 @@ describe("composeNarrative (BRIEF) — throwing / malformed model", () => {
       runtime,
       userMessage("give me my morning brief"),
       undefined,
-      { parameters: { subaction: "compose_morning" } } as unknown as HandlerOptions,
+      {
+        parameters: { subaction: "compose_morning" },
+      } as unknown as HandlerOptions,
       async () => undefined,
     );
   }

--- a/plugins/plugin-personal-assistant/test/lifeops-optimized-prompts.test.ts
+++ b/plugins/plugin-personal-assistant/test/lifeops-optimized-prompts.test.ts
@@ -1,9 +1,8 @@
 import type { IAgentRuntime, Memory } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
-import { LifeOpsServiceBase } from "../src/lifeops/service-mixin-core.js";
-import { withReminders } from "../src/lifeops/service-mixin-reminders.js";
+import { LifeOpsService } from "../src/lifeops/service.js";
 
-const ReminderService = withReminders(LifeOpsServiceBase);
+const ReminderService = LifeOpsService;
 
 function userMessage(text: string): Memory {
   return {

--- a/plugins/plugin-personal-assistant/test/package-boundaries.test.ts
+++ b/plugins/plugin-personal-assistant/test/package-boundaries.test.ts
@@ -44,10 +44,10 @@ describe("LifeOps package boundaries", () => {
     const rendererEntrypoint = readPackageFile("src/ui.ts");
     const sleepRoutes = readPackageFile("src/routes/sleep-routes.ts");
     const sleepServiceMixin = readPackageFile(
-      "src/lifeops/service-mixin-sleep.ts",
+      "src/lifeops/domains/sleep-service.ts",
     );
     const screenTimeServiceMixin = readPackageFile(
-      "src/lifeops/service-mixin-screentime.ts",
+      "src/lifeops/domains/screentime-service.ts",
     );
 
     expect(healthAction).toContain('from "@elizaos/plugin-health"');
@@ -195,12 +195,14 @@ describe("LifeOps package boundaries", () => {
   });
 
   it("imports browser bridge readiness policy from plugin-browser", () => {
-    const statusMixin = readPackageFile("src/lifeops/service-mixin-status.ts");
+    const statusMixin = readPackageFile(
+      "src/lifeops/domains/status-service.ts",
+    );
     const screenTimeMixin = readPackageFile(
-      "src/lifeops/service-mixin-screentime.ts",
+      "src/lifeops/domains/screentime-service.ts",
     );
     const browserMixin = readPackageFile(
-      "src/lifeops/service-mixin-browser.ts",
+      "src/lifeops/domains/browser-service.ts",
     );
     const coreMixin = readPackageFile("src/lifeops/service-mixin-core.ts");
     const repository = readPackageFile("src/lifeops/repository.ts");


### PR DESCRIPTION
## Summary

PR #9927 merged the `LifeOpsService` mixin → namespaced-domain refactor but the test suite still referenced symbols the refactor deleted, leaving **develop red** in the plugin-personal-assistant lane:

- `lifeops-optimized-prompts.test.ts` / `lifeops-llm-consumer-robustness.test.ts` imported the removed `withReminders` mixin factory → repointed to the concrete `LifeOpsService`.
- `brief-optimized-prompt.test.ts` imported `buildReminderDispatchPrompt` from the reminders shim → re-exported it from `domains/reminders-service`.
- `package-boundaries.test.ts` structure guards read the old `service-mixin-{sleep,screentime,status,browser}.ts` → repointed to `domains/*-service.ts` where the logic now lives.

No production behaviour change — test/guard repointing + one re-export only.

## Verification

`bunx vitest run --config vitest.config.ts` (full plugin-personal-assistant suite): **771 passed, 2 skipped, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)