### PR TITLE
fix(scenario-runner): load scheduling for LifeOps scenarios

### DIFF
--- a/packages/scenario-runner/src/runtime-factory.ts
+++ b/packages/scenario-runner/src/runtime-factory.ts
@@ -484,20 +484,6 @@ export async function createScenarioRuntime(
   }
   await runtime.registerPlugin(agentSkillsPlugin);
 
-  const lifeOpsModule = (await import(
-    "@elizaos/plugin-personal-assistant/plugin"
-  )) as Record<string, unknown>;
-  const lifeOpsPlugin = extractPlugin(lifeOpsModule, [
-    "default",
-    "personalAssistantPlugin",
-  ]);
-  if (!lifeOpsPlugin) {
-    throw new Error(
-      "[scenario-runner] @elizaos/plugin-personal-assistant did not export a Plugin",
-    );
-  }
-  await runtime.registerPlugin(lifeOpsPlugin);
-
   const schedulingModule = (await import(
     "@elizaos/plugin-scheduling"
   )) as Record<string, unknown>;
@@ -511,6 +497,20 @@ export async function createScenarioRuntime(
     );
   }
   await runtime.registerPlugin(schedulingPlugin);
+
+  const lifeOpsModule = (await import(
+    "@elizaos/plugin-personal-assistant/plugin"
+  )) as Record<string, unknown>;
+  const lifeOpsPlugin = extractPlugin(lifeOpsModule, [
+    "default",
+    "personalAssistantPlugin",
+  ]);
+  if (!lifeOpsPlugin) {
+    throw new Error(
+      "[scenario-runner] @elizaos/plugin-personal-assistant did not export a Plugin",
+    );
+  }
+  await runtime.registerPlugin(lifeOpsPlugin);
 
   for (const extra of options?.extraPlugins ?? []) {
     await runtime.registerPlugin(extra);


### PR DESCRIPTION
## Summary
- load `@elizaos/plugin-scheduling` in the scenario shared runtime before LifeOps/personal-assistant registration
- keep the PR rebased on `develop` commit `c18e167efd`, which already added the scenario `requires` entry and executor `schedulingPlugin` export handling

## Root Cause
The shared Zero-Key scenario lane was running `deterministic-lifeops-scheduled-tasks` through the shared scenario runtime. After the LifeOps service composition changes, `ScheduledTaskRunnerService` is hosted by `@elizaos/plugin-scheduling`, but `createScenarioRuntime()` still registered LifeOps without registering the scheduling plugin first.

That left the action path failing with: `ScheduledTaskRunnerService is not registered on this runtime`.

## Validation
- `git diff --check`
- `bunx biome check packages/scenario-runner/src/runtime-factory.ts`
- `bun run --cwd packages/scenario-runner test src/runtime-factory.test.ts src/scenario-pr-workflow.test.ts src/__tests__/deterministic-action-coverage.test.ts`
- `SCENARIO_USE_LLM_PROXY=1 SCENARIO_LLM_PROXY_STRICT=1 bun --cwd packages/scenario-runner --conditions eliza-source --tsconfig-override ../../tsconfig.json src/cli.ts run test/scenarios --lane pr-deterministic --scenario deterministic-lifeops-scheduled-tasks --report-dir ../../reports/scenarios/local-lifeops-rebased --run-dir ../../reports/scenarios/local-lifeops-rebased`

Focused scenario result on rebased branch: `1 passed, 0 failed, 0 skipped`.