### PR TITLE
fix(local-inference): gate eliza-1 text model on Gemma-4 GGUF architecture

### DIFF
--- a/packages/shared/src/local-inference/catalog.ts
+++ b/packages/shared/src/local-inference/catalog.ts
@@ -136,7 +136,17 @@ export function isDefaultEligibleId(id: string): boolean {
  */
 export const ELIZA_1_TIER_PUBLISH_STATUS: Readonly<
   Partial<Record<Eliza1TierId, "published" | "pending">>
-> = {};
+> = {
+  // 2026-06-28: the HuggingFace `elizaos/eliza-1` 9b / 27b / 27b-256k text
+  // GGUFs still report `general.architecture = qwen35` (Qwen3.5 / "Qwen3.6
+  // 27B") — the Gemma-4 cutover only landed for the 2b and 4b tiers. Mark the
+  // un-cut tiers `pending` so first-run never recommends a non-Gemma model as
+  // the default Eliza-1; flip back to published once the Gemma-4 fine-tunes are
+  // staged + pass the text-architecture provenance gate (text-provenance.ts).
+  "eliza-1-9b": "pending",
+  "eliza-1-27b": "pending",
+  "eliza-1-27b-256k": "pending",
+};
 
 export function eliza1TierPublishStatus(
   id: Eliza1TierId | string,

--- a/plugins/plugin-local-inference/src/services/manifest/validator.ts
+++ b/plugins/plugin-local-inference/src/services/manifest/validator.ts
@@ -26,6 +26,7 @@ import {
 	collectQwenAsrProvenanceBlockers,
 	QWEN_PROVENANCE_RE,
 } from "../asr-provenance";
+import { readBundleTextArchitectureBlockers } from "../text-provenance";
 import {
 	ELIZA_1_TOKENIZER_FAMILY,
 	ELIZA_1_TOKENIZER_VOCAB_SIZE,
@@ -67,7 +68,10 @@ export type ValidationResult = ValidationOk | ValidationErr;
  * `{ ok: false, errors }`. Truly exceptional cases (non-object input)
  * surface as Zod issues, not exceptions.
  */
-export function validateManifest(input: unknown): ValidationResult {
+export function validateManifest(
+	input: unknown,
+	opts?: { bundleRoot?: string },
+): ValidationResult {
 	const parsed = Eliza1ManifestSchema.safeParse(input);
 	if (!parsed.success) {
 		return {
@@ -81,6 +85,13 @@ export function validateManifest(input: unknown): ValidationResult {
 	const errors = collectContractErrors(parsed.data, {
 		allowVersionStaging: true,
 	});
+	// Ground-truth provenance: when the caller has the staged bundle on disk and
+	// the manifest claims a strict release, verify the text GGUF's architecture
+	// is actually Gemma-4. `lineage.text.base` (checked above) is operator-
+	// authored and can drift from the bytes shipped; the GGUF header cannot.
+	if (opts?.bundleRoot && isStrictReleaseManifest(parsed.data)) {
+		errors.push(...readBundleTextArchitectureBlockers(opts.bundleRoot));
+	}
 	if (errors.length > 0) {
 		return { ok: false, errors };
 	}

--- a/plugins/plugin-local-inference/src/services/text-provenance.test.ts
+++ b/plugins/plugin-local-inference/src/services/text-provenance.test.ts
@@ -1,0 +1,132 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	collectTextArchitectureBlockers,
+	readBundleTextArchitectureBlockers,
+	readGgufArchitecture,
+} from "./text-provenance";
+
+// ---- minimal GGUF v3 header writer (mirrors the gguf spec) ----
+function u32(n: number): Buffer {
+	const b = Buffer.alloc(4);
+	b.writeUInt32LE(n >>> 0);
+	return b;
+}
+function u64(n: number): Buffer {
+	const b = Buffer.alloc(8);
+	b.writeBigUInt64LE(BigInt(n));
+	return b;
+}
+function gstr(s: string): Buffer {
+	const bytes = Buffer.from(s, "utf8");
+	return Buffer.concat([u64(bytes.length), bytes]);
+}
+function kvString(key: string, value: string): Buffer {
+	return Buffer.concat([gstr(key), u32(8), gstr(value)]);
+}
+function kvU32(key: string, value: number): Buffer {
+	return Buffer.concat([gstr(key), u32(4), u32(value)]);
+}
+function kvArrayU32(key: string, values: number[]): Buffer {
+	// type 9 (array): elem-type u32, count u64, then the elements.
+	return Buffer.concat([
+		gstr(key),
+		u32(9),
+		u32(4),
+		u64(values.length),
+		...values.map(u32),
+	]);
+}
+function gguf(kvs: Buffer[]): Buffer {
+	return Buffer.concat([
+		u32(0x4655_4747),
+		u32(3),
+		u64(0),
+		u64(kvs.length),
+		...kvs,
+	]);
+}
+
+function writeGguf(arch: string | null): string {
+	const dir = mkdtempSync(path.join(tmpdir(), "text-provenance-"));
+	const file = path.join(dir, "model.gguf");
+	// Put non-target KVs (a scalar + an array) before the architecture so the
+	// reader's skip-value paths are exercised, not just a happy first-KV hit.
+	const kvs: Buffer[] = [
+		kvU32("general.quantization_version", 2),
+		kvArrayU32("tokenizer.ggml.scores", [1, 2, 3]),
+	];
+	if (arch !== null) kvs.push(kvString("general.architecture", arch));
+	kvs.push(kvString("general.name", "test"));
+	writeFileSync(file, gguf(kvs));
+	return file;
+}
+
+describe("readGgufArchitecture", () => {
+	it("reads gemma4 past preceding scalar + array KVs", () => {
+		expect(readGgufArchitecture(writeGguf("gemma4"))).toBe("gemma4");
+	});
+	it("reads a Qwen architecture", () => {
+		expect(readGgufArchitecture(writeGguf("qwen35"))).toBe("qwen35");
+	});
+	it("returns null when the architecture key is absent", () => {
+		expect(readGgufArchitecture(writeGguf(null))).toBeNull();
+	});
+	it("returns null for a non-GGUF file (fails closed)", () => {
+		const dir = mkdtempSync(path.join(tmpdir(), "text-provenance-"));
+		const file = path.join(dir, "not.gguf");
+		writeFileSync(file, Buffer.from("not a gguf file at all"));
+		expect(readGgufArchitecture(file)).toBeNull();
+	});
+	it("returns null for a missing file (fails closed)", () => {
+		expect(readGgufArchitecture("/nonexistent/model.gguf")).toBeNull();
+	});
+});
+
+describe("collectTextArchitectureBlockers", () => {
+	it("passes a Gemma-4 text GGUF", () => {
+		expect(collectTextArchitectureBlockers(writeGguf("gemma4"))).toEqual([]);
+	});
+	it("blocks a Qwen text GGUF and names Qwen", () => {
+		const blockers = collectTextArchitectureBlockers(writeGguf("qwen35"));
+		expect(blockers).toHaveLength(1);
+		expect(blockers[0]).toMatch(/Qwen stand-in/);
+		expect(blockers[0]).toMatch(/qwen35/);
+	});
+	it("blocks any non-Gemma architecture", () => {
+		const blockers = collectTextArchitectureBlockers(writeGguf("llama"));
+		expect(blockers).toHaveLength(1);
+		expect(blockers[0]).toMatch(/expected gemma/);
+	});
+	it("does not manufacture a blocker from an unreadable GGUF", () => {
+		expect(collectTextArchitectureBlockers("/nonexistent.gguf")).toEqual([]);
+	});
+});
+
+describe("readBundleTextArchitectureBlockers", () => {
+	function bundleWith(arch: string): string {
+		const root = mkdtempSync(path.join(tmpdir(), "bundle-"));
+		mkdirSync(path.join(root, "text"));
+		writeFileSync(
+			path.join(root, "text", `eliza-1-2b-128k.gguf`),
+			gguf([kvString("general.architecture", arch)]),
+		);
+		return root;
+	}
+	it("passes a Gemma-4 bundle", () => {
+		expect(readBundleTextArchitectureBlockers(bundleWith("gemma4"))).toEqual(
+			[],
+		);
+	});
+	it("blocks a Qwen bundle", () => {
+		expect(
+			readBundleTextArchitectureBlockers(bundleWith("qwen35")),
+		).toHaveLength(1);
+	});
+	it("is empty when no text/ directory exists", () => {
+		const root = mkdtempSync(path.join(tmpdir(), "bundle-"));
+		expect(readBundleTextArchitectureBlockers(root)).toEqual([]);
+	});
+});

--- a/plugins/plugin-local-inference/src/services/text-provenance.ts
+++ b/plugins/plugin-local-inference/src/services/text-provenance.ts
@@ -1,0 +1,202 @@
+import { closeSync, openSync, readdirSync, readSync, statSync } from "node:fs";
+import path from "node:path";
+import { QWEN_PROVENANCE_RE } from "./asr-provenance";
+
+// "GGUF" little-endian. The header is the source of truth for a model's
+// architecture: a Qwen text GGUF reports `general.architecture = "qwen35"` (or
+// "qwen3"), a Gemma-4 text GGUF reports `"gemma4"`. The manifest `lineage.text`
+// string is operator-authored and can drift from the bytes actually shipped, so
+// the strict-release gate reads the architecture out of the GGUF itself.
+const GGUF_MAGIC = 0x4655_4747;
+
+// Eliza-1 is a Gemma-4 family release. Any text GGUF whose architecture does not
+// start with `gemma` is a stand-in (the pre-cutover bundles shipped Qwen3.5).
+const GEMMA_TEXT_ARCHITECTURE_RE = /^gemma/i;
+
+const MAX_GGUF_HEADER_BYTES = 1 << 20; // 1 MiB — `general.architecture` is one of the first KV entries.
+
+// GGUF metadata value-type tags (gguf spec v2/v3).
+enum GgufType {
+	Uint8 = 0,
+	Int8 = 1,
+	Uint16 = 2,
+	Int16 = 3,
+	Uint32 = 4,
+	Int32 = 5,
+	Float32 = 6,
+	Bool = 7,
+	String = 8,
+	Array = 9,
+	Uint64 = 10,
+	Int64 = 11,
+	Float64 = 12,
+}
+
+const SCALAR_BYTE_WIDTH: Partial<Record<GgufType, number>> = {
+	[GgufType.Uint8]: 1,
+	[GgufType.Int8]: 1,
+	[GgufType.Uint16]: 2,
+	[GgufType.Int16]: 2,
+	[GgufType.Uint32]: 4,
+	[GgufType.Int32]: 4,
+	[GgufType.Float32]: 4,
+	[GgufType.Bool]: 1,
+	[GgufType.Uint64]: 8,
+	[GgufType.Int64]: 8,
+	[GgufType.Float64]: 8,
+};
+
+/**
+ * Minimal forward-only GGUF header cursor. Every read is bounds-checked against
+ * the buffer; an overrun throws so the public reader can fail closed (return
+ * null) rather than mis-parse a truncated header.
+ */
+class GgufCursor {
+	private offset = 0;
+	constructor(private readonly buf: Buffer) {}
+
+	private ensure(n: number): void {
+		if (this.offset + n > this.buf.length) {
+			throw new RangeError("gguf header truncated");
+		}
+	}
+
+	u32(): number {
+		this.ensure(4);
+		const v = this.buf.readUInt32LE(this.offset);
+		this.offset += 4;
+		return v;
+	}
+
+	/** GGUF lengths/counts are u64; header-scale values fit in a JS number. */
+	u64(): number {
+		this.ensure(8);
+		const v = this.buf.readBigUInt64LE(this.offset);
+		this.offset += 8;
+		if (v > BigInt(Number.MAX_SAFE_INTEGER)) {
+			throw new RangeError("gguf u64 exceeds safe integer range");
+		}
+		return Number(v);
+	}
+
+	string(): string {
+		const len = this.u64();
+		this.ensure(len);
+		const s = this.buf.toString("utf8", this.offset, this.offset + len);
+		this.offset += len;
+		return s;
+	}
+
+	skip(n: number): void {
+		this.ensure(n);
+		this.offset += n;
+	}
+
+	/** Advance past one metadata value of the given type without decoding it. */
+	skipValue(type: GgufType): void {
+		const width = SCALAR_BYTE_WIDTH[type];
+		if (width !== undefined) {
+			this.skip(width);
+			return;
+		}
+		if (type === GgufType.String) {
+			this.skip(this.u64());
+			return;
+		}
+		if (type === GgufType.Array) {
+			const elemType = this.u32() as GgufType;
+			const count = this.u64();
+			const elemWidth = SCALAR_BYTE_WIDTH[elemType];
+			if (elemWidth !== undefined) {
+				this.skip(elemWidth * count);
+				return;
+			}
+			for (let i = 0; i < count; i += 1) this.skipValue(elemType);
+			return;
+		}
+		throw new RangeError(`unsupported gguf value type ${type}`);
+	}
+}
+
+/**
+ * Read `general.architecture` from a GGUF file header. Returns the architecture
+ * string (e.g. `"gemma4"`, `"qwen35"`) or `null` when the file is missing,
+ * unreadable, not a GGUF, or the key is absent. The reader fails closed (null)
+ * so it can never *manufacture* a blocker from a parse failure.
+ */
+export function readGgufArchitecture(filePath: string): string | null {
+	let fd: number | undefined;
+	try {
+		fd = openSync(filePath, "r");
+		const size = Math.min(statSync(filePath).size, MAX_GGUF_HEADER_BYTES);
+		const buf = Buffer.allocUnsafe(size);
+		const read = readSync(fd, buf, 0, size, 0);
+		const cursor = new GgufCursor(buf.subarray(0, read));
+		if (cursor.u32() !== GGUF_MAGIC) return null;
+		cursor.u32(); // version
+		cursor.u64(); // tensor_count
+		const kvCount = cursor.u64();
+		for (let i = 0; i < kvCount; i += 1) {
+			const key = cursor.string();
+			const type = cursor.u32() as GgufType;
+			if (key === "general.architecture") {
+				return type === GgufType.String ? cursor.string() : null;
+			}
+			cursor.skipValue(type);
+		}
+		return null;
+	} catch {
+		return null;
+	} finally {
+		if (fd !== undefined) closeSync(fd);
+	}
+}
+
+/**
+ * Blocker if a text GGUF's on-disk architecture is not Gemma-4. Eliza-1 is a
+ * Gemma-4 release; a Qwen (or any non-Gemma) text model shipped under the
+ * eliza-1 name is rejected so it can never become the default. An unreadable
+ * architecture is *not* a blocker (the reader fails closed) — pair this with the
+ * existing `files.text` presence checks if a GGUF is required.
+ */
+export function collectTextArchitectureBlockers(
+	textGgufPath: string,
+): string[] {
+	const arch = readGgufArchitecture(textGgufPath);
+	if (arch === null) return [];
+	if (GEMMA_TEXT_ARCHITECTURE_RE.test(arch)) return [];
+	const rel = path.basename(textGgufPath);
+	if (QWEN_PROVENANCE_RE.test(arch)) {
+		return [
+			`files.text (${rel}): a strict/defaultEligible Eliza-1 release must ship the Gemma-4 text model, not a Qwen stand-in (general.architecture=${arch})`,
+		];
+	}
+	return [
+		`files.text (${rel}): a strict/defaultEligible Eliza-1 release must ship a Gemma-4 text model (general.architecture=${arch}, expected gemma*)`,
+	];
+}
+
+function bundleTextGgufs(bundleRoot: string): string[] {
+	const textDir = path.join(bundleRoot, "text");
+	let entries: string[];
+	try {
+		entries = readdirSync(textDir);
+	} catch {
+		return [];
+	}
+	return entries
+		.filter((name) => name.toLowerCase().endsWith(".gguf"))
+		.map((name) => path.join(textDir, name));
+}
+
+/**
+ * Read every text GGUF staged under `<bundleRoot>/text/` and block any whose
+ * architecture is not Gemma-4. The companion to `readBundleAsrProvenanceBlockers`
+ * for the text model: the manifest's `lineage.text.base` is operator-authored,
+ * this verifies the bytes that actually ship.
+ */
+export function readBundleTextArchitectureBlockers(
+	bundleRoot: string,
+): string[] {
+	return bundleTextGgufs(bundleRoot).flatMap(collectTextArchitectureBlockers);
+}


### PR DESCRIPTION
## Problem

`elizaos/eliza-1` was shipping **Qwen text models under the Gemma-4 name**. Reading `general.architecture` straight out of the published GGUF headers:

| tier | HF gguf arch |
|---|---|
| 2b, 4b | `gemma4` ✅ |
| 9b, 27b, 27b-256k | `qwen35` / "Qwen3.6" ❌ |
| 0_6b, 0_8b, 1_7b (stale) | `qwen3`/`qwen35` ❌ |

The manifest validator only checked **operator-authored lineage strings** (`lineage.text.base`) + an **ASR**-provenance gate. Nothing read the actual text-GGUF architecture, so a Qwen text model could ship under eliza-1 while the manifest claimed otherwise.

## Fix

- **`text-provenance.ts`** — a minimal, bounds-checked GGUF header reader (`readGgufArchitecture`) + `collectTextArchitectureBlockers` / `readBundleTextArchitectureBlockers` that reject any text GGUF whose `general.architecture` is not Gemma-4 (fails closed on unreadable files — never manufactures a blocker).
- **`validateManifest(input, { bundleRoot })`** — optional `bundleRoot` runs the ground-truth gate in the existing strict-release path; existing callers are unaffected.
- **catalog** — `9b`/`27b`/`27b-256k` marked `pending` so first-run never recommends a non-Gemma tier.

## Evidence

- New unit tests synthesize real GGUF headers (gemma4/qwen35/llama/non-gguf/missing) and assert the gate + fail-closed behavior: **12/12 pass**.
- Existing manifest validator suite: **53/53 pass** (non-breaking).
- `plugin-local-inference` + `shared` typecheck clean.
- Companion op: the 6 Qwen tiers were removed from `elizaos/eliza-1` (HF now hosts only the Gemma-4 2b/4b bundles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)