### PR TITLE
fix(cloud): IAC auth-cache invalidation on user ban/suspend/deactivate (#9981 review must-fix)

### DIFF
--- a/packages/cloud-shared/src/db/repositories/api-keys.ts
+++ b/packages/cloud-shared/src/db/repositories/api-keys.ts
@@ -103,6 +103,35 @@ export class ApiKeysRepository {
     });
   }
 
+  /**
+   * Returns the `key_hash` of every active key owned by a user.
+   *
+   * Used by user-level auth-state changes (ban/suspend/deactivate) to fan-out
+   * IAC cache invalidation so a blocked user stops fast-pathing inference
+   * immediately rather than waiting out the IAC TTL.
+   */
+  async findActiveKeyHashesByUserId(userId: string): Promise<string[]> {
+    const rows = await dbRead.query.apiKeys.findMany({
+      where: and(eq(apiKeys.user_id, userId), eq(apiKeys.is_active, true)),
+      columns: { key_hash: true },
+    });
+    return rows.map((row) => row.key_hash);
+  }
+
+  /**
+   * Returns the `key_hash` of every active key in an organization.
+   *
+   * Used by org-level deactivation to fan-out IAC cache invalidation for all
+   * of the org's keys at once.
+   */
+  async findActiveKeyHashesByOrganizationId(organizationId: string): Promise<string[]> {
+    const rows = await dbRead.query.apiKeys.findMany({
+      where: and(eq(apiKeys.organization_id, organizationId), eq(apiKeys.is_active, true)),
+      columns: { key_hash: true },
+    });
+    return rows.map((row) => row.key_hash);
+  }
+
   // ============================================================================
   // WRITE OPERATIONS (use primary)
   // ============================================================================

--- a/packages/cloud-shared/src/lib/cache/keys.ts
+++ b/packages/cloud-shared/src/lib/cache/keys.ts
@@ -351,7 +351,7 @@ export const CacheTTL = {
     signups: 300, // 5 minutes - live query
   },
   inference: {
-    authContext: 60, // 1 minute - worst-case revoked/banned exposure ~= TTL + KV lag
+    authContext: 60, // 1 minute - TTL is a backstop only; revoke/ban/suspend/deactivate invalidate the entry explicitly (api-keys.ts + admin.ts/users.ts/organizations.ts)
     orgBalance: 15, // 15 seconds - optimistic-billing gate hint, kept tight to bound drift
   },
 } as const;

--- a/packages/cloud-shared/src/lib/services/admin.ts
+++ b/packages/cloud-shared/src/lib/services/admin.ts
@@ -334,6 +334,9 @@ class AdminService {
 
     const now = new Date();
 
+    let resultingStatus: ModerationStatus;
+    let resultingTotalViolations: number;
+
     if (existing) {
       const newTotalViolations = existing.totalViolations + 1;
       const newWarningCount =
@@ -363,16 +366,8 @@ class AdminService {
         })
         .where(eq(userModerationStatus.userId, userId));
 
-      // Inference hot path: when a user crosses into "blocking" (banned, or
-      // >=5 violations — matching shouldBlockUser), drop their cached IAC identity
-      // immediately. Otherwise a freshly-banned user with a warm cache entry keeps
-      // authenticating until the 60s authContext TTL. Mirrors develop's wiring.
-      const wasBlocking = existing.status === "banned" || existing.totalViolations >= 5;
-      const nowBlocking = newStatus === "banned" || newTotalViolations >= 5;
-      if (nowBlocking && !wasBlocking) {
-        const keys = await apiKeysRepository.listByUser(userId);
-        await invalidateInferenceAuthContextsByKeyHashes(keys.map((k) => k.key_hash));
-      }
+      resultingStatus = newStatus;
+      resultingTotalViolations = newTotalViolations;
     } else {
       await dbWrite.insert(userModerationStatus).values({
         userId,
@@ -383,6 +378,40 @@ class AdminService {
         lastViolationAt: now,
         lastWarningAt: action === "warned" ? now : null,
       });
+
+      resultingStatus = "clean";
+      resultingTotalViolations = 1;
+    }
+
+    // The IAC inference fast-path caches a fully-authorized identity per key hash
+    // and skips re-checking moderation on a cache hit. If this write moved the
+    // user into a blocking state, drop their cached IAC entries now so they stop
+    // being served immediately rather than after the IAC TTL.
+    //
+    // The blocking decision is derived from the values we JUST WROTE (mirrors
+    // shouldBlockUser: banned || totalViolations >= 5) rather than a fresh
+    // read-replica lookup. That avoids two hazards of a post-write
+    // `shouldBlockUser` read: (1) under replica lag a threshold-crossing
+    // accumulation could read stale not-blocked and skip invalidation, and
+    // (2) a transient read failure after the write committed could throw out of
+    // this method and make the moderation write appear to fail.
+    const nowBlocking = resultingStatus === "banned" || resultingTotalViolations >= 5;
+    if (nowBlocking) {
+      await this.invalidateInferenceAuthCacheForUser(userId);
+    }
+  }
+
+  /**
+   * Best-effort: drop every cached IAC entry for a user's active API keys after a
+   * blocking auth-state change (ban / suspend via moderation). A failure here must
+   * never break the moderation write, so it only logs.
+   */
+  private async invalidateInferenceAuthCacheForUser(userId: string): Promise<void> {
+    try {
+      const keyHashes = await apiKeysRepository.findActiveKeyHashesByUserId(userId);
+      await invalidateInferenceAuthContextsByKeyHashes(keyHashes);
+    } catch (error) {
+      logger.warn("[Admin] Failed to invalidate IAC auth cache for user", { userId, error });
     }
   }
 
@@ -487,10 +516,9 @@ class AdminService {
       });
     }
 
-    // Inference hot path: a ban makes shouldBlockUser true — drop the user's
-    // cached IAC identity immediately (mirrors develop's banUser wiring).
-    const bannedKeys = await apiKeysRepository.listByUser(userId);
-    await invalidateInferenceAuthContextsByKeyHashes(bannedKeys.map((k) => k.key_hash));
+    // A ban is always a blocking state — drop the user's cached IAC entries so
+    // the inference fast-path stops serving them immediately.
+    await this.invalidateInferenceAuthCacheForUser(userId);
 
     logger.warn("[Admin] User banned", { userId, adminUserId, reason });
   }

--- a/packages/cloud-shared/src/lib/services/inference-auth-ban-invalidation.test.ts
+++ b/packages/cloud-shared/src/lib/services/inference-auth-ban-invalidation.test.ts
@@ -1,0 +1,384 @@
+/**
+ * IAC (inference auth context) cache invalidation on user-level auth-state
+ * changes (#9981 review must-fix).
+ *
+ * The inference hot path caches a fully-authorized identity per API-key hash and
+ * skips re-checking moderation on a cache hit. So a ban / suspend / deactivate /
+ * delete MUST drop the user's cached IAC entries explicitly — otherwise a blocked
+ * user keeps being served inference until the entry's TTL expires.
+ *
+ * These tests drive the REAL service code (admin / users / organizations) against
+ * an in-memory cache, with the DB client + repositories mocked, and assert that
+ * every enumerated blocking transition drops the live IAC entry, while a
+ * non-blocking change leaves it intact (no over-invalidation). All four
+ * enumerated transitions are covered here:
+ *   - ban / moderation-escalation         → AdminService
+ *   - user deactivate / user hard-delete   → UsersService
+ *   - org deactivate / org delete          → OrganizationsService
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const USER_ID = "11111111-1111-1111-1111-111111111111";
+const ORG_ID = "22222222-2222-2222-2222-222222222222";
+const RAW_KEY = "sk-test-ban-invalidation-0001";
+
+// ── In-memory cache backing the real inference-auth-cache helpers ────────────
+const store = new Map<string, unknown>();
+
+mock.module("../cache/client", () => ({
+  cache: {
+    get: async (key: string) => (store.has(key) ? store.get(key) : null),
+    set: async (key: string, value: unknown) => {
+      store.set(key, value);
+    },
+    del: async (key: string) => {
+      store.delete(key);
+    },
+  },
+}));
+
+// ── Stateful mock of the moderation-status row backing the DB client ─────────
+interface ModRow {
+  userId: string;
+  status: string;
+  totalViolations: number;
+  warningCount: number;
+  riskScore: number;
+  lastViolationAt?: Date | null;
+  lastWarningAt?: Date | null;
+  [key: string]: unknown;
+}
+
+let modRow: ModRow | null = null;
+
+function makeInsertResult(
+  rows: unknown[],
+): Promise<unknown[]> & { returning: () => Promise<unknown[]> } {
+  return Object.assign(Promise.resolve(rows), { returning: async () => rows });
+}
+
+mock.module("../../db/client", () => ({
+  dbRead: {
+    query: {
+      userModerationStatus: {
+        findFirst: async () => modRow ?? undefined,
+      },
+    },
+  },
+  dbWrite: {
+    insert: () => ({
+      values: (vals: Record<string, unknown>) => {
+        // moderationViolations inserts carry messageText; ignore those for state.
+        if ("messageText" in vals) {
+          return makeInsertResult([{ id: "violation-1", ...vals }]);
+        }
+        modRow = {
+          status: "clean",
+          totalViolations: 0,
+          warningCount: 0,
+          riskScore: 0,
+          ...vals,
+        } as ModRow;
+        return makeInsertResult([modRow]);
+      },
+    }),
+    update: () => ({
+      set: (vals: Record<string, unknown>) => ({
+        where: async () => {
+          modRow = { ...(modRow as ModRow), ...vals };
+        },
+      }),
+    }),
+  },
+}));
+
+// admin.ts builds queries with drizzle-orm helpers, but the DB client here is
+// fully mocked, so the built expressions are never executed — stub the helpers as
+// opaque builders. This also keeps the test hermetic (no installed drizzle-orm).
+mock.module("drizzle-orm", () => ({
+  and: (...args: unknown[]) => ({ __and: args }),
+  desc: (col: unknown) => ({ __desc: col }),
+  eq: (a: unknown, b: unknown) => ({ __eq: [a, b] }),
+  sql: Object.assign((...args: unknown[]) => ({ __sql: args }), {
+    raw: (value: unknown) => value,
+  }),
+}));
+
+// admin.ts imports drizzle table objects from the schemas barrel, which otherwise
+// pulls the whole plugin-sql/@elizaos/core stack into the test (and fails module
+// resolution). The DB client is fully mocked, so the table objects are only ever
+// passed to eq()/insert()/update() as opaque operands — stub them.
+mock.module("../../db/schemas", () => ({
+  adminUsers: {},
+  moderationViolations: {},
+  userModerationStatus: { userId: "userId" },
+  users: {},
+}));
+
+// ── Mock the api-keys repository's key-hash resolvers ────────────────────────
+// admin.ts imports the subpath; users.ts/organizations.ts import it from the
+// repositories barrel — provide both, sharing the same activeKeyHashes state.
+let activeKeyHashes: string[] = [];
+
+mock.module("../../db/repositories/api-keys", () => ({
+  apiKeysRepository: {
+    findActiveKeyHashesByUserId: async () => activeKeyHashes,
+    findActiveKeyHashesByOrganizationId: async () => activeKeyHashes,
+  },
+}));
+
+// ── Stateful mock of the repositories barrel (users + organizations) ─────────
+let userFindByIdResult: Record<string, unknown> | null = null;
+let userUpdateResult: Record<string, unknown> | null = null;
+let listByOrgResult: unknown[] = [];
+const deletedUserIds: string[] = [];
+const deletedOrgIds: string[] = [];
+
+mock.module("../../db/repositories", () => ({
+  apiKeysRepository: {
+    findActiveKeyHashesByUserId: async () => activeKeyHashes,
+    findActiveKeyHashesByOrganizationId: async () => activeKeyHashes,
+  },
+  usersRepository: {
+    findById: async () => userFindByIdResult ?? undefined,
+    update: async () => userUpdateResult ?? undefined,
+    delete: async (id: string) => {
+      deletedUserIds.push(id);
+    },
+    listByOrganization: async () => listByOrgResult,
+  },
+  organizationsRepository: {
+    update: async (id: string, data: Record<string, unknown>) => ({ id, ...data }),
+    delete: async (id: string) => {
+      deletedOrgIds.push(id);
+    },
+  },
+}));
+
+mock.module("../utils/logger", () => ({
+  logger: {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  },
+}));
+
+function makeUser(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: USER_ID,
+    email: null,
+    steward_user_id: null,
+    wallet_address: null,
+    organization_id: ORG_ID,
+    is_active: true,
+    ...overrides,
+  };
+}
+
+async function writeHotEntry() {
+  const { writeInferenceAuthContext, hashApiKey, INFERENCE_AUTH_CONTEXT_VERSION } = await import(
+    "./inference-auth-cache"
+  );
+  const keyHash = hashApiKey(RAW_KEY);
+  await writeInferenceAuthContext({
+    v: INFERENCE_AUTH_CONTEXT_VERSION,
+    cachedAt: Date.now(),
+    userId: USER_ID,
+    orgId: ORG_ID,
+    apiKeyId: "33333333-3333-3333-3333-333333333333",
+    keyHash,
+  });
+  return keyHash;
+}
+
+describe("IAC invalidation on user-level auth-state changes", () => {
+  beforeEach(() => {
+    store.clear();
+    modRow = null;
+    activeKeyHashes = [];
+    userFindByIdResult = null;
+    userUpdateResult = null;
+    listByOrgResult = [];
+    deletedUserIds.length = 0;
+    deletedOrgIds.length = 0;
+  });
+
+  // ── Admin: ban / moderation escalation ─────────────────────────────────────
+
+  test("banUser drops the hot IAC entry for the user's keys", async () => {
+    const keyHash = await writeHotEntry();
+    activeKeyHashes = [keyHash];
+
+    const { readInferenceAuthContext } = await import("./inference-auth-cache");
+    expect(await readInferenceAuthContext(keyHash)).not.toBeNull();
+
+    const { adminService } = await import("./admin");
+    await adminService.banUser({ userId: USER_ID, adminUserId: "admin-1", reason: "abuse" });
+
+    expect(await readInferenceAuthContext(keyHash)).toBeNull();
+  });
+
+  test("moderation escalation into a blocking state drops the IAC entry", async () => {
+    const keyHash = await writeHotEntry();
+    activeKeyHashes = [keyHash];
+
+    // Existing row already at 4 violations: the next violation crosses the
+    // shouldBlockUser threshold (totalViolations >= 5).
+    modRow = {
+      userId: USER_ID,
+      status: "clean",
+      totalViolations: 4,
+      warningCount: 0,
+      riskScore: 80,
+      lastWarningAt: null,
+    };
+
+    const { readInferenceAuthContext } = await import("./inference-auth-cache");
+    expect(await readInferenceAuthContext(keyHash)).not.toBeNull();
+
+    const { adminService } = await import("./admin");
+    await adminService.recordViolation({
+      userId: USER_ID,
+      messageText: "spam spam spam",
+      categories: ["spam"],
+      scores: { spam: 0.99 },
+      action: "flagged_for_ban",
+    });
+
+    expect(await readInferenceAuthContext(keyHash)).toBeNull();
+  });
+
+  test("a non-blocking moderation escalation does NOT drop the IAC entry", async () => {
+    const keyHash = await writeHotEntry();
+    activeKeyHashes = [keyHash];
+
+    // Far below the blocking threshold: must not over-invalidate.
+    modRow = {
+      userId: USER_ID,
+      status: "clean",
+      totalViolations: 1,
+      warningCount: 0,
+      riskScore: 20,
+      lastWarningAt: null,
+    };
+
+    const { adminService } = await import("./admin");
+    await adminService.recordViolation({
+      userId: USER_ID,
+      messageText: "mild",
+      categories: ["spam"],
+      scores: { spam: 0.5 },
+      action: "warned",
+    });
+
+    const { readInferenceAuthContext } = await import("./inference-auth-cache");
+    expect(await readInferenceAuthContext(keyHash)).not.toBeNull();
+  });
+
+  // ── Users: deactivate / hard-delete ────────────────────────────────────────
+
+  test("UsersService.update deactivating a user drops the IAC entry", async () => {
+    const keyHash = await writeHotEntry();
+    activeKeyHashes = [keyHash];
+    userFindByIdResult = makeUser({ is_active: true });
+    userUpdateResult = makeUser({ is_active: false });
+
+    const { readInferenceAuthContext } = await import("./inference-auth-cache");
+    expect(await readInferenceAuthContext(keyHash)).not.toBeNull();
+
+    const { usersService } = await import("./users");
+    await usersService.update(USER_ID, { is_active: false });
+
+    expect(await readInferenceAuthContext(keyHash)).toBeNull();
+  });
+
+  test("UsersService.update without deactivation does NOT drop the IAC entry", async () => {
+    const keyHash = await writeHotEntry();
+    activeKeyHashes = [keyHash];
+    userFindByIdResult = makeUser({ is_active: true });
+    userUpdateResult = makeUser({ is_active: true });
+
+    const { usersService } = await import("./users");
+    await usersService.update(USER_ID, {});
+
+    const { readInferenceAuthContext } = await import("./inference-auth-cache");
+    expect(await readInferenceAuthContext(keyHash)).not.toBeNull();
+  });
+
+  test("UsersService.delete drops the IAC entry for an active user (the must-fix gap)", async () => {
+    const keyHash = await writeHotEntry();
+    activeKeyHashes = [keyHash];
+    // A normal active user being hard-deleted: is_active === true, so the
+    // invalidateCache gate does NOT fire — delete() must invalidate explicitly.
+    userFindByIdResult = makeUser({ is_active: true });
+    // Keep a user remaining in the org so the cascade-org-delete branch is skipped.
+    listByOrgResult = [makeUser({ id: "other-user" })];
+
+    const { readInferenceAuthContext } = await import("./inference-auth-cache");
+    expect(await readInferenceAuthContext(keyHash)).not.toBeNull();
+
+    const { usersService } = await import("./users");
+    await usersService.delete(USER_ID);
+
+    expect(deletedUserIds).toContain(USER_ID);
+    expect(await readInferenceAuthContext(keyHash)).toBeNull();
+  });
+
+  // ── Organizations: deactivate / delete ─────────────────────────────────────
+
+  test("OrganizationsService.update deactivating an org drops the IAC entries", async () => {
+    const keyHash = await writeHotEntry();
+    activeKeyHashes = [keyHash];
+
+    const { readInferenceAuthContext } = await import("./inference-auth-cache");
+    expect(await readInferenceAuthContext(keyHash)).not.toBeNull();
+
+    const { organizationsService } = await import("./organizations");
+    await organizationsService.update(ORG_ID, { is_active: false });
+
+    expect(await readInferenceAuthContext(keyHash)).toBeNull();
+  });
+
+  test("OrganizationsService.update without deactivation does NOT drop the IAC entries", async () => {
+    const keyHash = await writeHotEntry();
+    activeKeyHashes = [keyHash];
+
+    const { organizationsService } = await import("./organizations");
+    // Routine update (e.g. a balance/metadata change) must not fan out.
+    await organizationsService.update(ORG_ID, {});
+
+    const { readInferenceAuthContext } = await import("./inference-auth-cache");
+    expect(await readInferenceAuthContext(keyHash)).not.toBeNull();
+  });
+
+  test("OrganizationsService.delete drops the IAC entries before the cascade", async () => {
+    const keyHash = await writeHotEntry();
+    activeKeyHashes = [keyHash];
+
+    const { readInferenceAuthContext } = await import("./inference-auth-cache");
+    expect(await readInferenceAuthContext(keyHash)).not.toBeNull();
+
+    const { organizationsService } = await import("./organizations");
+    await organizationsService.delete(ORG_ID);
+
+    expect(deletedOrgIds).toContain(ORG_ID);
+    expect(await readInferenceAuthContext(keyHash)).toBeNull();
+  });
+
+  // ── Direct single-key revoke path ──────────────────────────────────────────
+
+  test("api-key revoke drops the IAC entry by key hash", async () => {
+    const keyHash = await writeHotEntry();
+
+    const { readInferenceAuthContext, invalidateInferenceAuthContextByKeyHash } = await import(
+      "./inference-auth-cache"
+    );
+    expect(await readInferenceAuthContext(keyHash)).not.toBeNull();
+
+    await invalidateInferenceAuthContextByKeyHash(keyHash);
+
+    expect(await readInferenceAuthContext(keyHash)).toBeNull();
+  });
+});

--- a/packages/cloud-shared/src/lib/services/inference-auth-cache.ts
+++ b/packages/cloud-shared/src/lib/services/inference-auth-cache.ts
@@ -125,8 +125,21 @@ export async function invalidateInferenceAuthContextByKeyHash(keyHash: string): 
 }
 
 /**
- * Fan-out invalidation for every supplied key hash (used at ban / deactivate,
- * where the caller resolves the user's key hashes from the DB). Best-effort.
+ * Fan-out invalidation for every supplied key hash. The caller resolves the
+ * affected key hashes from the DB and passes them here.
+ *
+ * Wired at every user-level auth-state-change site (where invalidation cannot be
+ * keyed by a single presented key):
+ *   - `AdminService.updateUserModerationStatus` / `AdminService.banUser`
+ *     (ban / suspend via moderation) — `admin.ts`.
+ *   - `UsersService.invalidateCache` when a user is deactivated
+ *     (`is_active === false`) — `users.ts`.
+ *   - `OrganizationsService.update` / `OrganizationsService.delete` on org
+ *     deactivation — `organizations.ts`.
+ *
+ * (Single-key revoke/update/delete uses `invalidateInferenceAuthContextByKeyHash`
+ * from `api-keys.ts` instead.) Best-effort: callers wrap this in try/catch so a
+ * cache-invalidation failure never breaks the ban/deactivate write.
  */
 export async function invalidateInferenceAuthContextsByKeyHashes(
   keyHashes: readonly string[],

--- a/packages/cloud-shared/src/lib/services/organizations.ts
+++ b/packages/cloud-shared/src/lib/services/organizations.ts
@@ -3,6 +3,7 @@
  */
 
 import {
+  apiKeysRepository,
   type NewOrganization,
   type Organization,
   organizationsRepository,
@@ -10,6 +11,7 @@ import {
 import { cache } from "../cache/client";
 import { CacheKeys, CacheTTL } from "../cache/keys";
 import { logger } from "../utils/logger";
+import { invalidateInferenceAuthContextsByKeyHashes } from "./inference-auth-cache";
 
 /**
  * Service for organization operations with caching support.
@@ -72,7 +74,30 @@ export class OrganizationsService {
     const result = await organizationsRepository.update(id, data);
     // Invalidate cache after update
     await this.invalidateCache(id);
+    // Deactivating an org must drop the IAC fast-path entries for all of its keys
+    // immediately. Gated on the deactivation write (not every cache invalidation,
+    // which also fires on routine balance changes) to avoid needless fan-out.
+    if (data.is_active === false) {
+      await this.invalidateInferenceAuthCacheForOrg(id);
+    }
     return result;
+  }
+
+  /**
+   * Best-effort: drop every cached IAC entry for an org's active API keys after a
+   * blocking org-state change (deactivation / delete). A failure here must never
+   * break the org write, so it only logs.
+   */
+  private async invalidateInferenceAuthCacheForOrg(organizationId: string): Promise<void> {
+    try {
+      const keyHashes = await apiKeysRepository.findActiveKeyHashesByOrganizationId(organizationId);
+      await invalidateInferenceAuthContextsByKeyHashes(keyHashes);
+    } catch (error) {
+      logger.warn("[OrganizationsService] Failed to invalidate IAC auth cache for org", {
+        organizationId,
+        error,
+      });
+    }
   }
 
   async updateCreditBalance(
@@ -86,6 +111,9 @@ export class OrganizationsService {
   }
 
   async delete(id: string): Promise<void> {
+    // Resolve the org's key hashes BEFORE the delete cascades them away, then
+    // drop their IAC fast-path entries so they cannot keep being served.
+    await this.invalidateInferenceAuthCacheForOrg(id);
     await organizationsRepository.delete(id);
     // Invalidate cache after delete
     await this.invalidateCache(id);

--- a/packages/cloud-shared/src/lib/services/users.ts
+++ b/packages/cloud-shared/src/lib/services/users.ts
@@ -3,6 +3,7 @@
  */
 
 import {
+  apiKeysRepository,
   type NewUser,
   organizationsRepository,
   type User,
@@ -13,6 +14,7 @@ import { retryOnTransientDbError } from "../../db/retry-transient";
 import { cache } from "../cache/client";
 import { CacheKeys, CacheTTL } from "../cache/keys";
 import { logger } from "../utils/logger";
+import { invalidateInferenceAuthContextsByKeyHashes } from "./inference-auth-cache";
 
 function getErrorDetails(error: unknown): Record<string, unknown> {
   if (!(error instanceof Error)) {
@@ -52,7 +54,33 @@ export class UsersService {
       promises.push(cache.del(CacheKeys.user.byWalletAddressWithOrg(walletAddress)));
     }
     await Promise.all(promises);
+
+    // A deactivated user must stop fast-pathing inference immediately. The IAC
+    // cache keys on the API-key hash (not the user id) and is skipped on a hit,
+    // so explicitly drop every cached IAC entry for this user's active keys
+    // rather than waiting out the IAC TTL. Best-effort: never break the write.
+    if (user.is_active === false) {
+      await this.invalidateInferenceAuthCacheForUser(user.id);
+    }
+
     logger.debug("[UsersService] Invalidated cache for user:", user.id);
+  }
+
+  /**
+   * Best-effort: drop every cached IAC entry for a user's active API keys after a
+   * blocking auth-state change (deactivation / delete). A failure here must never
+   * break the originating write, so it only logs.
+   */
+  private async invalidateInferenceAuthCacheForUser(userId: string): Promise<void> {
+    try {
+      const keyHashes = await apiKeysRepository.findActiveKeyHashesByUserId(userId);
+      await invalidateInferenceAuthContextsByKeyHashes(keyHashes);
+    } catch (error) {
+      logger.warn("[UsersService] Failed to invalidate IAC auth cache for user", {
+        userId,
+        error,
+      });
+    }
   }
 
   async getById(id: string): Promise<User | undefined> {
@@ -290,6 +318,12 @@ export class UsersService {
     const organizationId = user.organization_id;
 
     await this.invalidateCache(user);
+    // Deleting a user is a blocking transition just like deactivation, but the
+    // `user` record here is still active (is_active === true), so invalidateCache's
+    // gate does NOT fire. Resolve this user's key hashes BEFORE the row (and its
+    // cascade-deleted keys) are gone, then drop their IAC fast-path entries
+    // unconditionally so a deleted user's keys cannot keep being served until TTL.
+    await this.invalidateInferenceAuthCacheForUser(id);
     await usersRepository.delete(id);
 
     // Check if this was the last user in the organization


### PR DESCRIPTION
## What

Stacks on **#9981** (`perf/iac-hotpath-prod-port`). #9981 ports the inference hot-path (IAC) auth-context cache to main behind a flag (currently FLAG-OFF). On a cache hit, the IAC fast-path serves a fully-authorized identity per API-key hash and **skips re-checking moderation**. The adversarial review of #9981 found that the fan-out invalidation helper `invalidateInferenceAuthContextsByKeyHashes` was **dead code** (zero callers), so a banned/suspended/deactivated/deleted identity would keep fast-pathing inference for up to the 60s IAC TTL — a moderation-bypass window. This PR wires that helper into **every user-level blocking transition** so the prod flag can be flipped safely.

## Why this is the prerequisite for flipping the flag

The IAC fast-path only re-validates authority on a cache *miss*. Without explicit invalidation, a block (ban/suspend/deactivate/delete) does not take effect on the inference path until the entry's TTL expires. This PR makes every block drop the affected key hashes immediately.

## The four user-level blocking transitions (all now covered)

| Transition | Site | Behavior |
|---|---|---|
| Ban | `AdminService.banUser` | unconditional invalidate |
| Suspend / moderation escalation | `AdminService.updateUserModerationStatus` | invalidate when the just-written state is blocking |
| User deactivate | `UsersService.invalidateCache` (`is_active === false`) | invalidate |
| **User hard-delete** | `UsersService.delete` | **resolve-then-invalidate before the cascade (new — was the gap)** |
| Org deactivate / delete | `OrganizationsService.update`/`delete` | invalidate (delete resolves before cascade) |

Key resolution is exact: the new `ApiKeysRepository.findActiveKeyHashesByUserId` / `findActiveKeyHashesByOrganizationId` select the stored `key_hash` (full sha256) which equals the IAC cache key, so `cache.del(authContext(hash))` is a precise drop of only active keys.

## Review must-fixes addressed

1. **`UsersService.delete` missed invalidation** — `invalidateCache(user)`'s `is_active === false` gate never fires for a normal active user being deleted, so their keys kept fast-pathing until TTL. `delete()` now resolves the user's active key hashes and invalidates **before** `usersRepository.delete(id)` (mirrors `OrganizationsService.delete`). Factored into a single guarded helper reused by the deactivate path.
2. **Unguarded post-write read + replica-lag soft spot in `updateUserModerationStatus`** — replaced the post-write `await this.shouldBlockUser(userId)` (a fresh read-replica lookup, outside the try/catch) with a decision **derived from the values just written** (`banned || totalViolations >= 5`). This removes both the new exception surface on the moderation write path and the threshold-crossing bypass window under read-replica lag.
3. **Tests un-runnable + coverage gaps** — the new `inference-auth-ban-invalidation.test.ts` now drives the real `admin`/`users`/`organizations` service code and covers **all four** transitions plus no-over-invalidation cases. Mocking `db/schemas` (+ `drizzle-orm`) makes the admin-path tests actually execute instead of failing on `@elizaos/core` module resolution. 10/10 pass.

## Safety / blast radius

- Every invalidation site is **best-effort**: wrapped in try/catch → `logger.warn` only, so a cache failure can never break the ban/deactivate/delete write.
- **Flag-off-neutral**: when the IAC fast-path is disabled, no entries are written, so `cache.del` on a never-written key is a harmless no-op. No chat/inference route files are touched; the new reads (`key_hash`-only projections) run only on cold admin/moderation/account-lifecycle paths.
- Comment-only change to `cache/keys.ts` (TTL value unchanged).

## Verification

- `bun test packages/cloud-shared/src/lib/services/inference-auth-ban-invalidation.test.ts` → **10 pass / 0 fail**.
- `bun run --cwd packages/cloud-shared typecheck` → **zero errors in any touched file** (remaining errors are the pre-existing cross-package tsconfig-path noise documented in `packages/cloud-shared/CLAUDE.md`).
- `biome check` on all changed files → clean.

Refs the #9981 adversarial review. cc @lalalune @cloud-agent for review.