### PR TITLE
ci(orchestrator): gate every PR on the multi-account selection e2e (#9960)

### DIFF
--- a/.github/workflows/orchestrator-multi-account.yml
+++ b/.github/workflows/orchestrator-multi-account.yml
@@ -1,0 +1,72 @@
+# Orchestrator — multi-account selection lane (per-PR, secret-free)
+#
+# The coding orchestrator's account pool — rotating sub-agent spawns across
+# distinct Claude (OAuth) and Codex (CODEX_HOME) accounts, dropping the parent's
+# API keys from each subprocess, and reusing a session's account on follow-ups —
+# had NO CI coverage (#9960). `test:e2e:multi-account` already proves all of
+# that end-to-end against a fake `acpx` subprocess with synthetic accounts, so it
+# needs ZERO secrets and is safe to gate every PR.
+#
+# This lane runs that e2e on any change to the orchestrator, the account bridge,
+# or the codex/claude auth surfaces. The real-account (live OAuth) lane is a
+# separate, secret-gated, scheduled job — this is the deterministic per-PR floor.
+
+name: Orchestrator multi-account
+
+on:
+  pull_request:
+    paths:
+      - "plugins/plugin-agent-orchestrator/**"
+      - "packages/app-core/src/services/coding-account-bridge.ts"
+      - "plugins/plugin-codex-cli/**"
+      - ".github/workflows/orchestrator-multi-account.yml"
+  push:
+    branches: [develop]
+    paths:
+      - "plugins/plugin-agent-orchestrator/**"
+      - "packages/app-core/src/services/coding-account-bridge.ts"
+      - "plugins/plugin-codex-cli/**"
+      - ".github/workflows/orchestrator-multi-account.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: orchestrator-multi-account-${{ github.ref }}
+  cancel-in-progress: true
+
+# Default to least privilege.
+permissions:
+  contents: read
+
+env:
+  BUN_VERSION: "canary"
+  NODE_VERSION: "24"
+
+jobs:
+  multi-account-e2e:
+    name: multi-account selection e2e
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: recursive
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          install-command: bun install --ignore-scripts --no-frozen-lockfile
+
+      # Drives the real AccountPool + coding-account-bridge + AcpService through a
+      # fake `acpx` subprocess: asserts distinct-account round-robin, per-account
+      # token/CODEX_HOME injection, parent-key scrubbing, and session reuse.
+      # Secret-free and deterministic.
+      - name: Run multi-account selection e2e
+        run: bun run --cwd plugins/plugin-agent-orchestrator test:e2e:multi-account


### PR DESCRIPTION
Part of #9960 (orchestrator: no live multi-account CI). This lands the **per-PR, secret-free** slice.

## What
Adds `.github/workflows/orchestrator-multi-account.yml` — a path-filtered lane that runs the existing `test:e2e:multi-account` on every PR touching `plugins/plugin-agent-orchestrator/**`, the `coding-account-bridge`, or `plugins/plugin-codex-cli/**`.

## Why this is the right first slice
That e2e already drives the **real** `AccountPool` + `coding-account-bridge` + `AcpService.spawnSession` through a real subprocess (a fake `acpx` binary) with synthetic accounts — so it proves the orchestrator's hardest-to-test behavior with **zero secrets and full determinism**:

```
PASS  two claude spawns used DISTINCT accounts (round-robin least-used)  [claude-A vs claude-B]
PASS  real subprocess received an injected Claude OAuth token
PASS  the two Claude subprocesses got DISTINCT injected tokens  [oat-AAA, oat-BBB]
PASS  parent ANTHROPIC_API_KEY was DROPPED from claude subprocess env
PASS  Claude follow-up subprocess reused spawn 1's selected account token  [oat-AAA -> oat-AAA]
PASS  codex subprocess received a per-account CODEX_HOME
PASS  parent OPENAI_API_KEY was DROPPED from codex subprocess env
PASS  codex auth.json has the selected account's token + account_id
11/11 checks passed
```

Before this, `grep` across `.github/workflows` for `test:e2e:multi-account` returned **zero** — the suite was green locally but ran nowhere.

## Scope / follow-ups (tracked on #9960)
- The **real-account** lane (live Claude OAuth + real Codex `auth.json`, rotation across real accounts) is a separate **secret-gated, scheduled** job — it skips cleanly when secrets are absent, so it never red-lights PRs.
- The untestable router timing code (pure `routerLoopTransition` + fuzz test) and the 3,931-line `OrchestratorWorkbench` decomposition are the other #9960 chunks.

## Verification
`bun run --cwd plugins/plugin-agent-orchestrator test:e2e:multi-account` → **11/11 passed** locally (output above). Additive workflow only; no source change.