### PR TITLE
fix(cloud): IAC invalidation on user/org deactivate+delete (complements #9981 ban/suspend)

### DIFF
--- a/packages/cloud-shared/src/lib/services/inference-auth-lifecycle.test.ts
+++ b/packages/cloud-shared/src/lib/services/inference-auth-lifecycle.test.ts
@@ -1,0 +1,163 @@
+/**
+ * IAC (inference-auth-context) invalidation on user/org lifecycle transitions.
+ *
+ * Complements the ban/suspend wiring already in admin.ts (#9981). Covers the
+ * four gaps that route inactive credentials back through the authoritative slow
+ * path immediately instead of letting a warm IAC entry fast-path for up to the
+ * authContext TTL:
+ *   1. UsersService.update         → is_active flips false (user deactivate)
+ *   2. UsersService.delete         → hard delete (resolve key hashes BEFORE delete)
+ *   3. OrganizationsService.update → is_active flips false (org deactivate)
+ *   4. OrganizationsService.delete → resolve key hashes BEFORE the delete cascade
+ *
+ * Plus: invalidation is best-effort and must never throw into the lifecycle write.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Captured side effects + per-test repository state ───────────────────────
+const invalidatedHashBatches: string[][] = [];
+const userDeleteCalls: string[] = [];
+const orgDeleteCalls: string[] = [];
+
+let userApiKeys: Array<{ key_hash: string }> = [];
+let orgApiKeys: Array<{ key_hash: string }> = [];
+let userRecord: Record<string, unknown> | undefined;
+let listByOrganizationUsers: unknown[] = [];
+let listByUserError: Error | null = null;
+
+mock.module("./inference-auth-cache", () => ({
+  invalidateInferenceAuthContextsByKeyHashes: async (hashes: readonly string[]) => {
+    invalidatedHashBatches.push([...hashes]);
+  },
+}));
+
+mock.module("../../db/repositories", () => ({
+  apiKeysRepository: {
+    listByUser: async (_userId: string) => {
+      if (listByUserError) throw listByUserError;
+      return userApiKeys;
+    },
+    listByOrganization: async (_orgId: string) => orgApiKeys,
+  },
+  usersRepository: {
+    findById: async (_id: string) => userRecord,
+    update: async (id: string, data: Record<string, unknown>) => ({ ...userRecord, ...data, id }),
+    delete: async (id: string) => {
+      userDeleteCalls.push(id);
+      // Simulate the row (and its keys) being gone after delete so a test can
+      // prove the key hashes were resolved BEFORE this call.
+      userApiKeys = [];
+    },
+    listByOrganization: async (_orgId: string) => listByOrganizationUsers,
+  },
+  organizationsRepository: {
+    update: async (id: string, data: Record<string, unknown>) => ({ id, ...data }),
+    delete: async (id: string) => {
+      orgDeleteCalls.push(id);
+      orgApiKeys = [];
+    },
+  },
+}));
+
+mock.module("../cache/client", () => ({
+  cache: {
+    get: async () => null,
+    set: async () => {},
+    del: async () => {},
+  },
+}));
+
+mock.module("../utils/logger", () => ({
+  logger: { debug() {}, info() {}, warn() {}, error() {} },
+}));
+
+beforeEach(() => {
+  invalidatedHashBatches.length = 0;
+  userDeleteCalls.length = 0;
+  orgDeleteCalls.length = 0;
+  userApiKeys = [];
+  orgApiKeys = [];
+  userRecord = undefined;
+  listByOrganizationUsers = [];
+  listByUserError = null;
+});
+
+describe("UsersService — IAC invalidation on lifecycle", () => {
+  test("update with is_active=false evicts the user's cached key hashes", async () => {
+    userRecord = { id: "u1", organization_id: "o1", email: null };
+    userApiKeys = [{ key_hash: "uh1" }, { key_hash: "uh2" }];
+
+    const { usersService } = await import("./users");
+    await usersService.update("u1", { is_active: false });
+
+    expect(invalidatedHashBatches).toEqual([["uh1", "uh2"]]);
+  });
+
+  test("update without an is_active=false transition does NOT invalidate", async () => {
+    userRecord = { id: "u1", organization_id: "o1", email: null };
+    userApiKeys = [{ key_hash: "uh1" }];
+
+    const { usersService } = await import("./users");
+    await usersService.update("u1", { name: "renamed" });
+    await usersService.update("u1", { is_active: true });
+
+    expect(invalidatedHashBatches).toEqual([]);
+  });
+
+  test("delete resolves the key hashes BEFORE deleting the row", async () => {
+    // organization_id null so the last-user org-cascade is skipped.
+    userRecord = { id: "u1", organization_id: null, email: null };
+    userApiKeys = [{ key_hash: "uh1" }];
+
+    const { usersService } = await import("./users");
+    await usersService.delete("u1");
+
+    expect(userDeleteCalls).toEqual(["u1"]);
+    // The row is wiped on delete; a non-empty batch proves resolution happened first.
+    expect(invalidatedHashBatches).toEqual([["uh1"]]);
+  });
+
+  test("delete invalidation is best-effort: a cache/db failure does not throw", async () => {
+    userRecord = { id: "u1", organization_id: null, email: null };
+    userApiKeys = [{ key_hash: "uh1" }];
+    listByUserError = new Error("db down");
+
+    const { usersService } = await import("./users");
+    await expect(usersService.delete("u1")).resolves.toBeUndefined();
+    expect(userDeleteCalls).toEqual(["u1"]);
+    expect(invalidatedHashBatches).toEqual([]);
+  });
+});
+
+describe("OrganizationsService — IAC invalidation on lifecycle", () => {
+  test("update with is_active=false evicts the org's cached key hashes", async () => {
+    orgApiKeys = [{ key_hash: "oh1" }, { key_hash: "oh2" }];
+
+    const { organizationsService } = await import("./organizations");
+    await organizationsService.update("o1", { is_active: false });
+
+    expect(invalidatedHashBatches).toEqual([["oh1", "oh2"]]);
+  });
+
+  test("update without an is_active=false transition does NOT invalidate", async () => {
+    orgApiKeys = [{ key_hash: "oh1" }];
+
+    const { organizationsService } = await import("./organizations");
+    await organizationsService.update("o1", { name: "renamed" });
+    await organizationsService.update("o1", { is_active: true });
+
+    expect(invalidatedHashBatches).toEqual([]);
+  });
+
+  test("delete resolves the key hashes BEFORE the delete cascade", async () => {
+    orgApiKeys = [{ key_hash: "oh1" }];
+
+    const { organizationsService } = await import("./organizations");
+    await organizationsService.delete("o1");
+
+    expect(orgDeleteCalls).toEqual(["o1"]);
+    // Cascade wipes the keys; a non-empty batch proves resolution happened first.
+    expect(invalidatedHashBatches).toEqual([["oh1"]]);
+  });
+});

--- a/packages/cloud-shared/src/lib/services/organizations.ts
+++ b/packages/cloud-shared/src/lib/services/organizations.ts
@@ -3,6 +3,7 @@
  */
 
 import {
+  apiKeysRepository,
   type NewOrganization,
   type Organization,
   organizationsRepository,
@@ -10,6 +11,7 @@ import {
 import { cache } from "../cache/client";
 import { CacheKeys, CacheTTL } from "../cache/keys";
 import { logger } from "../utils/logger";
+import { invalidateInferenceAuthContextsByKeyHashes } from "./inference-auth-cache";
 
 /**
  * Service for organization operations with caching support.
@@ -68,10 +70,35 @@ export class OrganizationsService {
     return await organizationsRepository.create(data);
   }
 
+  /**
+   * Inference hot path (#9981 review gap): drop every cached IAC identity for an
+   * org's API keys so a deactivated/deleted org stops fast-pathing inference
+   * immediately rather than authorizing until the authContext TTL expires. The
+   * slow path enforces `org.is_active`, but the IAC cache short-circuits it.
+   * Best-effort: a cache failure must never break the lifecycle write. Reuses the
+   * existing listByOrganization reader (no new reader added).
+   */
+  private async invalidateInferenceAuthForOrganization(organizationId: string): Promise<void> {
+    try {
+      const keys = await apiKeysRepository.listByOrganization(organizationId);
+      await invalidateInferenceAuthContextsByKeyHashes(keys.map((k) => k.key_hash));
+    } catch (error) {
+      logger.warn("[OrganizationsService] Failed to invalidate inference auth cache for org", {
+        organizationId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
   async update(id: string, data: Partial<NewOrganization>): Promise<Organization | undefined> {
     const result = await organizationsRepository.update(id, data);
     // Invalidate cache after update
     await this.invalidateCache(id);
+    // Deactivation: when is_active flips to false, evict the org's warm IAC
+    // entries so credentials under the now-inactive org can no longer fast-path.
+    if (data.is_active === false) {
+      await this.invalidateInferenceAuthForOrganization(id);
+    }
     return result;
   }
 
@@ -86,6 +113,9 @@ export class OrganizationsService {
   }
 
   async delete(id: string): Promise<void> {
+    // Resolve + evict the org's cached IAC identities BEFORE the delete cascade
+    // removes the api_keys rows, so the key_hash set is read while it still exists.
+    await this.invalidateInferenceAuthForOrganization(id);
     await organizationsRepository.delete(id);
     // Invalidate cache after delete
     await this.invalidateCache(id);

--- a/packages/cloud-shared/src/lib/services/users.ts
+++ b/packages/cloud-shared/src/lib/services/users.ts
@@ -3,6 +3,7 @@
  */
 
 import {
+  apiKeysRepository,
   type NewUser,
   organizationsRepository,
   type User,
@@ -13,6 +14,7 @@ import { retryOnTransientDbError } from "../../db/retry-transient";
 import { cache } from "../cache/client";
 import { CacheKeys, CacheTTL } from "../cache/keys";
 import { logger } from "../utils/logger";
+import { invalidateInferenceAuthContextsByKeyHashes } from "./inference-auth-cache";
 
 function getErrorDetails(error: unknown): Record<string, unknown> {
   if (!(error instanceof Error)) {
@@ -223,6 +225,26 @@ export class UsersService {
     return await usersRepository.create(data);
   }
 
+  /**
+   * Inference hot path (#9981 review gap): drop every cached IAC identity for a
+   * user's API keys so a deactivated/deleted user stops fast-pathing inference
+   * immediately rather than authorizing until the authContext TTL expires. The
+   * slow path enforces `user.is_active`, but the IAC cache short-circuits it.
+   * Best-effort: a cache failure must never break the lifecycle write. Mirrors
+   * the ban/suspend wiring already in admin.ts (reuses listByUser, no new reader).
+   */
+  private async invalidateInferenceAuthForUser(userId: string): Promise<void> {
+    try {
+      const keys = await apiKeysRepository.listByUser(userId);
+      await invalidateInferenceAuthContextsByKeyHashes(keys.map((k) => k.key_hash));
+    } catch (error) {
+      logger.warn("[UsersService] Failed to invalidate inference auth cache for user", {
+        userId,
+        ...getErrorDetails(error),
+      });
+    }
+  }
+
   async update(id: string, data: Partial<NewUser>): Promise<User | undefined> {
     const existing = await usersRepository.findById(id);
     const result = await usersRepository.update(id, data);
@@ -231,6 +253,11 @@ export class UsersService {
     }
     if (result) {
       await this.invalidateCache(result);
+    }
+    // Deactivation: when is_active flips to false, evict the user's warm IAC
+    // entries so the now-inactive account can no longer fast-path inference.
+    if (data.is_active === false) {
+      await this.invalidateInferenceAuthForUser(id);
     }
     return result;
   }
@@ -290,6 +317,10 @@ export class UsersService {
     const organizationId = user.organization_id;
 
     await this.invalidateCache(user);
+    // Resolve + evict the user's cached IAC identities BEFORE the row is deleted:
+    // at delete time the user is still active, so an is_active gate can't fire and
+    // the key_hash set must be read while the keys still exist.
+    await this.invalidateInferenceAuthForUser(id);
     await usersRepository.delete(id);
 
     // Check if this was the last user in the organization


### PR DESCRIPTION
## What

Closes the remaining **user/org-lifecycle** bypass gaps in inference-auth-cache (IAC) invalidation that cloud-agent's ban/suspend wiring (`b5f8cd96da`, `ee4ed8d7ec` on this base) did **not** cover. Complements #9981.

The #9981 review flagged that several admin/lifecycle write paths mutate auth state without evicting the IAC hot-path cache, leaving stale `key_hash → context` entries warm for up to the ~60s TTL. Ban/suspend is now handled. This PR fixes the 4 remaining transitions:

| Transition | Site | Eviction |
|---|---|---|
| User deactivate (`is_active=false`) | `users.ts:258-260` | `invalidateInferenceAuthForUser` |
| User hard-delete | `users.ts:322-323` | invalidate **before** `usersRepository.delete()` (resolve key_hashes while rows exist) |
| Org deactivate (`is_active=false`) | `organizations.ts:98-100` | `invalidateInferenceAuthForOrganization` |
| Org delete | `organizations.ts:116-118` | invalidate **before** `organizationsRepository.delete()` (ahead of the api_keys FK cascade) |

## How

- Reuses the exact helpers ban/suspend uses: `apiKeysRepository.listByUser/listByOrganization` + `invalidateInferenceAuthContextsByKeyHashes` (`inference-auth-cache.ts`). No new readers/queries, no import cycle.
- `key_hash` is the stored full sha256 (the IAC write key) → eviction is exact.
- **Best-effort:** read+evict is wrapped in try/catch that only `logger.warn`s — it never rethrows into the lifecycle write (a failed eviction can't block a deactivate/delete). Covered by a dedicated test.
- **Flag-off neutral:** when `INFERENCE_HOT_PATH_CACHE` is off there are no entries, so `cache.del` is observably inert — same unconditional-invalidate pattern as `admin.ts`.
- **No hot-path impact:** the added `listBy*` queries run only on deactivate/delete (rare admin ops); `resolveInferenceAuthContext` is unchanged.

## Scope

3 files, +224: `users.ts`, `organizations.ts`, and a new `inference-auth-lifecycle.test.ts`. `admin.ts` and the chat resolver are untouched.

## Tests

`bun test inference-auth-lifecycle.test.ts` → **7 pass / 0 fail**. typecheck clean, biome clean.

cc @lalalune @cloud-agent for review / fold-in.
