### PR TITLE
test(aesthetic): machine-checkable "Her"-minimal density gate (#9950)

### DIFF
--- a/packages/app/test/audit/aesthetic-audit-rules.test.ts
+++ b/packages/app/test/audit/aesthetic-audit-rules.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   bucket,
   computeVerdict,
+  exceedsMinimalismBudget,
+  MINIMALISM_DENSITY_CEILING,
+  minimalismDensity,
   OVERLAY_NATIVE_OR_CANVAS_SLUGS,
   parseNavigationTabPaths,
   parseRgb,
@@ -163,5 +166,97 @@ describe("computeVerdict (#8796 verdict precedence)", () => {
     expect(computeVerdict(finding({ borderRadiusViolations: ["32px"] }))).toBe(
       "needs-eyeball",
     );
+  });
+
+  it("divider density over the minimal ceiling is a soft needs-eyeball (#9950)", () => {
+    // 100 dividers over a 1,000,000 px² viewport = 100/Mpx² » the 45 ceiling.
+    expect(
+      computeVerdict(
+        finding({ borderDividerCount: 100, viewportArea: 1_000_000 }),
+      ),
+    ).toBe("needs-eyeball");
+  });
+
+  it("a sparse view stays good; a real crash still outranks the soft minimalism signal (#9950)", () => {
+    // Under the ceiling → still good.
+    expect(
+      computeVerdict(
+        finding({ borderDividerCount: 10, viewportArea: 1_000_000 }),
+      ),
+    ).toBe("good");
+    // A console error outranks any minimalism breach.
+    expect(
+      computeVerdict(
+        finding({
+          consoleErrors: ["boom"],
+          borderDividerCount: 100,
+          viewportArea: 1_000_000,
+        }),
+      ),
+    ).toBe("broken");
+  });
+});
+
+describe("minimalism density gate (#9950)", () => {
+  const finding = (o: Partial<VerdictFinding> = {}): VerdictFinding => ({
+    slug: "plugin-foo-gui",
+    viewType: "gui",
+    consoleErrors: [],
+    qualityIssues: [],
+    readableChars: 500,
+    blueColors: [],
+    hoverViolations: [],
+    overlayPresent: true,
+    borderRadiusViolations: [],
+    ...o,
+  });
+
+  it("returns null when the finding carries no minimalism measurement", () => {
+    expect(minimalismDensity(finding())).toBeNull();
+    expect(exceedsMinimalismBudget(finding())).toBe(false);
+    // A zero/absent viewport area is treated as unmeasured, not a divide-by-zero.
+    expect(
+      minimalismDensity(finding({ borderDividerCount: 5, viewportArea: 0 })),
+    ).toBeNull();
+  });
+
+  it("normalizes border/divider count by viewport area (per 1,000,000 px²)", () => {
+    expect(
+      minimalismDensity(
+        finding({ borderDividerCount: 45, viewportArea: 1_000_000 }),
+      ),
+    ).toBe(45);
+    // Same divider count on a smaller viewport is a HIGHER density (more cramped).
+    expect(
+      minimalismDensity(
+        finding({ borderDividerCount: 45, viewportArea: 500_000 }),
+      ),
+    ).toBe(90);
+  });
+
+  it("trips only when density strictly exceeds the ceiling", () => {
+    // Exactly at the ceiling is not a breach.
+    expect(
+      exceedsMinimalismBudget(
+        finding({
+          borderDividerCount: MINIMALISM_DENSITY_CEILING,
+          viewportArea: 1_000_000,
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      exceedsMinimalismBudget(
+        finding({
+          borderDividerCount: MINIMALISM_DENSITY_CEILING + 1,
+          viewportArea: 1_000_000,
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("honors a caller-supplied ceiling (per-view ratcheting)", () => {
+    const f = finding({ borderDividerCount: 20, viewportArea: 1_000_000 });
+    expect(exceedsMinimalismBudget(f, 10)).toBe(true);
+    expect(exceedsMinimalismBudget(f, 30)).toBe(false);
   });
 });

--- a/packages/app/test/ui-smoke/aesthetic-audit-rules.ts
+++ b/packages/app/test/ui-smoke/aesthetic-audit-rules.ts
@@ -37,6 +37,51 @@ export interface VerdictFinding {
   hoverViolations: string[];
   overlayPresent: boolean;
   borderRadiusViolations: string[];
+  /**
+   * Count of rendered border/divider elements (a visible border on any side,
+   * plus `<hr>` / `role="separator"`). The "Her"-minimal axis (#9950): a cramped,
+   * divider-heavy view should not pass `good`. Optional so existing callers and
+   * unit fixtures need not set it; when present it is normalized by viewport area
+   * and checked against {@link MINIMALISM_DENSITY_CEILING}.
+   */
+  borderDividerCount?: number;
+  /** Rendered viewport area in px² (innerWidth × innerHeight), the density basis. */
+  viewportArea?: number;
+}
+
+/**
+ * Soft "Her"-minimal ceiling: border/divider elements per 1,000,000 px² of
+ * viewport. A density (area-normalized), not a raw per-view count, so one ceiling
+ * holds across the portrait / landscape / desktop matrix. Seeded generously so it
+ * only trips genuinely divider-dense screens today; ratchet down as the aesthetic
+ * pass lands (#9950). A breach is a SOFT `needs-eyeball`, never a hard fail — it
+ * records the regression without destabilizing the green baseline (same posture
+ * as the off-token border-radius signal).
+ */
+export const MINIMALISM_DENSITY_CEILING = 45;
+
+/**
+ * Border/divider density per 1,000,000 px², or null when the finding carries no
+ * minimalism measurement (the fields are optional). Pure.
+ */
+export function minimalismDensity(finding: VerdictFinding): number | null {
+  if (
+    finding.borderDividerCount === undefined ||
+    finding.viewportArea === undefined ||
+    finding.viewportArea <= 0
+  ) {
+    return null;
+  }
+  return (finding.borderDividerCount / finding.viewportArea) * 1_000_000;
+}
+
+/** True when a view's divider density exceeds the minimal-aesthetic ceiling. */
+export function exceedsMinimalismBudget(
+  finding: VerdictFinding,
+  ceiling: number = MINIMALISM_DENSITY_CEILING,
+): boolean {
+  const density = minimalismDensity(finding);
+  return density !== null && density > ceiling;
 }
 
 /** Parse the `TAB_PATHS` map out of the navigation index source. */
@@ -169,10 +214,13 @@ export function computeVerdict(finding: VerdictFinding): AestheticVerdict {
   ) {
     return "needs-work";
   }
-  // Off-scale border-radius is a soft signal (#8796 AC3 only asks the harness to
-  // FLAG non-token radius): a non-blocking `needs-eyeball` records it without
-  // destabilizing the green baseline.
-  if (finding.borderRadiusViolations.length > 0) {
+  // Off-scale border-radius (#8796) and divider-density over the "Her"-minimal
+  // ceiling (#9950) are both SOFT signals: a non-blocking `needs-eyeball` records
+  // them without destabilizing the green baseline.
+  if (
+    finding.borderRadiusViolations.length > 0 ||
+    exceedsMinimalismBudget(finding)
+  ) {
     return "needs-eyeball";
   }
   return "good";

--- a/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
@@ -6,6 +6,8 @@ import { expect, type Page, test } from "@playwright/test";
 import {
   bucket,
   computeVerdict,
+  MINIMALISM_DENSITY_CEILING,
+  minimalismDensity,
   parseNavigationTabPaths,
 } from "./aesthetic-audit-rules";
 import {
@@ -146,9 +148,50 @@ interface ViewFinding {
   viewType: "gui" | "tui";
   /** Readable text length in the view root; ~0 means the view never painted. */
   readableChars: number;
+  /** Border/divider element count + viewport area for the "Her"-minimal gate (#9950). */
+  borderDividerCount: number;
+  viewportArea: number;
   quality: ScreenshotQuality | null;
   qualityIssues: string[];
   verdict: "good" | "needs-work" | "needs-eyeball" | "broken";
+}
+
+/**
+ * Count rendered border/divider elements for the "Her"-minimal density gate
+ * (#9950): an element with a visible border on any side (width ≥ 1px, style not
+ * `none`/`hidden`), plus explicit `<hr>` and `role="separator"`. Returns the
+ * count and the viewport area (px²) so the verdict policy can normalize.
+ */
+async function collectBorderDividerMetrics(
+  page: Page,
+): Promise<{ borderDividerCount: number; viewportArea: number }> {
+  return page.evaluate(() => {
+    const nodes = Array.from(document.querySelectorAll("*")).slice(0, 4000);
+    let count = 0;
+    for (const node of nodes) {
+      const el = node as Element;
+      if (el.tagName === "HR" || el.getAttribute("role") === "separator") {
+        count += 1;
+        continue;
+      }
+      const cs = getComputedStyle(el);
+      const sides = [
+        [cs.borderTopWidth, cs.borderTopStyle],
+        [cs.borderRightWidth, cs.borderRightStyle],
+        [cs.borderBottomWidth, cs.borderBottomStyle],
+        [cs.borderLeftWidth, cs.borderLeftStyle],
+      ] as const;
+      const hasVisibleBorder = sides.some(
+        ([width, style]) =>
+          parseFloat(width) >= 1 && style !== "none" && style !== "hidden",
+      );
+      if (hasVisibleBorder) count += 1;
+    }
+    return {
+      borderDividerCount: count,
+      viewportArea: Math.max(1, window.innerWidth * window.innerHeight),
+    };
+  });
 }
 
 /** Scan the rendered DOM for any blue text/background/border color (banned). */
@@ -256,6 +299,12 @@ function renderManualReviewStub(finding: ViewFinding): string {
     `- **orange↔black hover violations:** ${finding.hoverViolations.length ? finding.hoverViolations.join("; ") : "none"}`,
     `- **floating chat overlay present:** ${finding.overlayPresent ? "yes" : "NO"}`,
     `- **readable content chars:** ${finding.readableChars}`,
+    `- **minimalism — border/divider density:** ${(() => {
+      const d = minimalismDensity(finding);
+      return d === null
+        ? "n/a"
+        : `${d.toFixed(1)}/Mpx² (${finding.borderDividerCount} dividers; ceiling ${MINIMALISM_DENSITY_CEILING})${d > MINIMALISM_DENSITY_CEILING ? " ⚠ over budget" : ""}`;
+    })()}`,
     `- **screenshot quality issues:** ${finding.qualityIssues.length ? finding.qualityIssues.join("; ") : "none"}`,
     "",
     "## Notes",
@@ -413,6 +462,11 @@ test.describe("all-views aesthetic audit (#8796)", () => {
         const borderRadiusViolations = await collectBorderRadiusViolations(
           page,
         ).catch(() => []);
+        const { borderDividerCount, viewportArea } =
+          await collectBorderDividerMetrics(page).catch(() => ({
+            borderDividerCount: 0,
+            viewportArea: 1,
+          }));
 
         const base = {
           slug: view.slug,
@@ -425,6 +479,8 @@ test.describe("all-views aesthetic audit (#8796)", () => {
           borderRadiusViolations,
           overlayPresent,
           readableChars,
+          borderDividerCount,
+          viewportArea,
           quality,
           qualityIssues,
         };


### PR DESCRIPTION
Part of #9950. Lands the **machine-checkable "Her"-minimal aesthetic gate** — the issue's headline gap ("the system view set has no machine-checkable 'Her'-minimal aesthetic gate"). Fully unit-tested; additive and green-safe.

## The gap
`aesthetic-audit-rules.ts`'s `VerdictFinding` measured only `blueColors` / `hoverViolations` / `borderRadiusViolations` / `readableChars` / `overlayPresent` — **no** border/divider-density, text-density, or whitespace metric. So a cramped, divider-heavy view (WorkflowEditor, AutomationsFeed, CharacterEditor) passed `good` with no objective minimal-aesthetic done-condition.

## What this adds
- `VerdictFinding` gains optional `borderDividerCount` + `viewportArea`.
- `minimalismDensity()` — border/divider elements per **1,000,000 px²** (area-normalized, so one ceiling holds across portrait/landscape/desktop rather than a brittle per-view absolute count).
- `exceedsMinimalismBudget(finding, ceiling?)` — checks density against `MINIMALISM_DENSITY_CEILING` (45), caller-overridable for **per-view ratcheting**.
- `computeVerdict` treats a breach as a **soft `needs-eyeball`** (identical posture to off-token border-radius) — it records the regression without destabilizing the green baseline.
- The spec measures it live (`collectBorderDividerMetrics`: a visible border on any side + `<hr>` / `role="separator"`) and prints the density in each per-view `manual-review/<slug>.md`.

## Verification
- `bun run --cwd packages/app test test/audit/aesthetic-audit-rules.test.ts` → **27/27** (6 new: null-when-unmeasured, area normalization, strict-ceiling boundary, caller ceiling, crash-outranks-soft-signal).
- `bun run --cwd packages/app typecheck` → **0 errors**; biome clean.

## Why a density ceiling, not the issue's raw per-view token counts
The issue suggests seeding budgets from source-token counts (WorkflowEditor 44, …). Those are grep-of-`.tsx` counts; the audit runs at **runtime**, where divider counts differ. A view-size-normalized **density** is the defensible runtime axis and needs no fabricated baseline. The ceiling starts generous (soft signal) and ratchets per-view as the aesthetic pass captures real baselines.

## Remaining (issue stays open)
Deeper per-control e2e for wallet/character(hub+full editor)/workflow-node-graph/browser asserting **outcomes**; the 4-cell mobile portrait/landscape matrix from `run-design-review.ts`; a landscape CI lane; replacing the crash-only `.catch(()=>{})` contract in `all-views-interaction.spec.ts` with action-level failure; text-density + whitespace-ratio dimensions; and the actual aesthetic pass of the 9 `ALL_TAB_GROUPS`.