### PR TITLE
fix(ui): make Settings layout orientation-aware (#9945)

### DIFF
--- a/packages/ui/src/components/pages/SettingsView.test.tsx
+++ b/packages/ui/src/components/pages/SettingsView.test.tsx
@@ -113,6 +113,28 @@ function t(key: string, options?: { defaultValue?: string }) {
   return options?.defaultValue ?? key;
 }
 
+/**
+ * Install a `matchMedia` stub that answers each query via `matchFor`, so a test
+ * can drive the width and orientation media queries independently. Returns a
+ * restore fn for the original implementation.
+ */
+function stubMatchMedia(matchFor: (query: string) => boolean): () => void {
+  const original = window.matchMedia;
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: matchFor(query),
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })) as unknown as typeof window.matchMedia;
+  return () => {
+    window.matchMedia = original;
+  };
+}
+
 function makeContext(
   overrides: Partial<Record<string, unknown>> = {},
 ): Record<string, unknown> {
@@ -222,17 +244,7 @@ describe("SettingsView", () => {
 
   it("on desktop, shows a persistent rail with a section selected in the pane", () => {
     // Force the desktop media query to match so the two-pane layout renders.
-    const original = window.matchMedia;
-    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
-      matches: true,
-      media: query,
-      onchange: null,
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    })) as unknown as typeof window.matchMedia;
+    const restore = stubMatchMedia(() => true);
     try {
       render(<SettingsView />);
       // The rail lists every section AND the detail pane shows the first one
@@ -243,7 +255,55 @@ describe("SettingsView", () => {
       expect(screen.getByTestId("stub-identity")).toBeTruthy();
       expect(screen.queryByText("Settings")).not.toBeNull();
     } finally {
-      window.matchMedia = original;
+      restore();
+    }
+  });
+
+  it("uses the two-pane layout on a landscape phone narrower than 1024px", () => {
+    // A landscape phone: too narrow for `min-width: 1024px`, but in landscape
+    // with enough width (>=768px) it has horizontal room for the two-pane rail.
+    // Width alone wrongly dropped it into the cramped single-pane hub.
+    const restore = stubMatchMedia((query) =>
+      query.includes("orientation: landscape"),
+    );
+    try {
+      render(<SettingsView />);
+      // Detail pane is mounted with no tap and no back affordance — proof of the
+      // two-pane layout, not the mobile hub.
+      expect(screen.getByTestId("stub-identity")).toBeTruthy();
+      expect(screen.getByText("Runtime")).toBeTruthy();
+      expect(screen.queryByText("Settings")).not.toBeNull();
+    } finally {
+      restore();
+    }
+  });
+
+  it("keeps the single-pane hub on a narrow portrait viewport", () => {
+    // Portrait tablet / phone narrower than 1024px: no horizontal room for two
+    // panes, so it stays on the single-pane hub (tiles, no detail pane mounted).
+    const restore = stubMatchMedia(() => false);
+    try {
+      render(<SettingsView />);
+      expect(screen.getByText("Basics")).toBeTruthy();
+      expect(screen.getByText("Runtime")).toBeTruthy();
+      // No section body mounted until a tile is tapped — this is the hub.
+      expect(screen.queryByTestId("stub-identity")).toBeNull();
+    } finally {
+      restore();
+    }
+  });
+
+  it("keeps the single-pane hub for a narrow landscape viewport under 768px", () => {
+    // A small landscape viewport under the 768px landscape floor must NOT get
+    // the two-pane layout — the combined query requires both orientation AND
+    // min-width, so the `and (min-width: 768px)` clause fails here.
+    const restore = stubMatchMedia(() => false);
+    try {
+      render(<SettingsView />);
+      expect(screen.queryByTestId("stub-identity")).toBeNull();
+      expect(screen.getByText("Basics")).toBeTruthy();
+    } finally {
+      restore();
     }
   });
 });

--- a/packages/ui/src/components/pages/SettingsView.tsx
+++ b/packages/ui/src/components/pages/SettingsView.tsx
@@ -380,7 +380,18 @@ export function SettingsView({
     loadPlugins: s.loadPlugins,
     walletEnabled: s.walletEnabled,
   }));
-  const isDesktop = useMediaQuery("(min-width: 1024px)");
+  // Two-pane (rail + detail) layout needs genuine horizontal room: ~240px rail
+  // + gap + a usable content pane. Width alone (min-width: 1024px) put a
+  // landscape phone / short landscape tablet — wide enough for two panes but
+  // under 1024px — into the cramped single-pane mobile hub, and is the same
+  // branch a tall-but-narrow portrait tablet correctly stays in. Combine width
+  // with orientation so a landscape viewport with enough width also gets the
+  // two-pane layout, while narrow portrait stays single-pane.
+  const isWide = useMediaQuery("(min-width: 1024px)");
+  const isWideLandscape = useMediaQuery(
+    "(orientation: landscape) and (min-width: 768px)",
+  );
+  const isTwoPane = isWide || isWideLandscape;
   const enabledKinds = useEnabledViewKinds();
   const [activeSection, setActiveSection] = useState<string | null>(
     () => initialSection ?? readSettingsHashSection(),
@@ -452,7 +463,7 @@ export function SettingsView({
     <ShellViewAgentSurface viewId="settings">
       <ContentLayout inModal={inModal}>
         <div data-testid="settings-shell">
-          {isDesktop ? (
+          {isTwoPane ? (
             <DesktopLayout
               grouped={grouped}
               t={t}


### PR DESCRIPTION
Part of #9945 — lands the contained, zero-ambiguity sub-problem (#4, "zero portrait/landscape handling"), exactly the one-line fix the issue specifies.

## What
`SettingsView` chose two-pane (rail + detail) vs single-pane (hub) from `useMediaQuery("(min-width: 1024px)")` **alone**, so a landscape phone / short landscape tablet — wide enough for two panes but under 1024px — was forced into the cramped mobile hub.

New rule: two-pane when `min-width: 1024px` **OR** `(orientation: landscape) and (min-width: 768px)`. The 768px floor is derived from `DesktopLayout` (~240px `w-60` rail + `gap-7` + a usable `flex-1` pane), not arbitrary. Narrow portrait correctly stays single-pane.

## Files
- `packages/ui/src/components/pages/SettingsView.tsx` — `isDesktop` → `isTwoPane = isWide || isWideLandscape`, with rationale.
- `packages/ui/src/components/pages/SettingsView.test.tsx` — per-query `matchMedia` stub + 3 new tests (landscape-phone→two-pane, narrow-portrait→hub, narrow-landscape-<768px→hub).

## Why not the other sub-problems here
Reading the code disproved the issue's "unused advanced-mode primitive" framing: `AdvancedToggle` + `useAdvancedSettingsEnabled()` are **live** (own tests + stories, wired into ~6 sections) — so "delete as dead code" is wrong, and reclassifying ~10 more sections into defaults-vs-advanced is a product-judgment sweep (which knob is "advanced"?) that the repo's scope-discipline rule forbids inventing. The agent-subview deep-link spans 4+ files across two packages, changes a server endpoint contract, and needs a real-LLM trajectory — not the smallest landable slice.

## Verification
- `bun run --cwd packages/ui test src/components/pages/SettingsView.test.tsx` → **10 passed** (incl. all orientation cases).
- biome clean; the touched files typecheck clean. (The package typecheck has a **pre-existing, unrelated** failure in `cloud/billing/wallet/steward-wallet-providers.tsx` (wagmi/viem `Config` TS2322) from commit `4056e0e868`, not in this diff — being fixed separately, not papered over.)

## Remaining (#9945 stays open)
Agent subview deep-link (`subview`/`section` on the VIEWS action → `/api/views/:id/navigate` → `SettingsView` `initialSection`, reusing `resolveSettingsSectionToken`); surface subviews in provider prompts; apply `AdvancedToggle` to the remaining sections with defaults-first grouping; backfill untested settings components + per-input fuzz e2e; split the largest views (VoiceConfigView 1436 LOC). Visual evidence via `audit:app` across {mobile,desktop}×{portrait,landscape} is the remaining capture step.