### PR TITLE
fix(tui): authenticate the TUI client past the loopback-trust gate (#9946)

### DIFF
--- a/.github/issue-evidence/9946-tui-client-auth/README.md
+++ b/.github/issue-evidence/9946-tui-client-auth/README.md
@@ -1,0 +1,23 @@
+# Evidence — #9946 residual: TUI client authentication
+
+Most of #9946 already landed on develop while this work was in flight:
+- `#9982` — killed the fictional "SSH" naming + put `packages/tui` on a PR CI lane.
+- `#9986` — whole-app TUI e2e harness driving the real shell via a VirtualTerminal.
+
+This PR closes the **one remaining gap** from the issue's critical-assessment
+point 2: *"The TUI client sends zero auth and depends on a loopback trust gate
+that breaks under tunneling."*
+
+## Change
+`agent-terminal-tui.ts`: `readJson` now attaches `Authorization: Bearer
+$ELIZA_API_TOKEN` when that env var is set (via exported `resolveTuiApiToken` /
+`buildTuiAuthHeaders` helpers). `ELIZA_API_TOKEN` is the exact key `isAuthorized`
+validates — no phantom fallbacks. Omitted when unset, so same-host loopback
+sessions are unchanged. This is what lets a tunneled/reverse-proxied terminal
+(which injects `X-Forwarded-For`, disabling the loopback-trust gate) actually
+authenticate.
+
+## Test — `tui-client-auth.test.ts`: 2 passed
+- `resolveTuiApiToken` returns the trimmed token when set, null when empty/unset.
+- `buildTuiAuthHeaders` returns `{ Authorization: "Bearer <tok>" }` only when a
+  token is configured, `{}` otherwise.

--- a/packages/agent/src/__tests__/tui-client-auth.test.ts
+++ b/packages/agent/src/__tests__/tui-client-auth.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildTuiAuthHeaders,
+  resolveTuiApiToken,
+} from "../tui/agent-terminal-tui";
+
+/**
+ * #9946: the TUI client must be able to authenticate past the backend's
+ * loopback-trust gate (a tunnel/proxy injects X-Forwarded-For, disabling it).
+ * It reads ELIZA_API_TOKEN — the exact key isAuthorized validates — and sends a
+ * Bearer header when present, and nothing when absent (loopback unchanged).
+ */
+describe("TUI client auth (#9946)", () => {
+  it("resolves ELIZA_API_TOKEN when set, null otherwise", () => {
+    expect(resolveTuiApiToken({ ELIZA_API_TOKEN: "secret-123" })).toBe(
+      "secret-123",
+    );
+    expect(resolveTuiApiToken({ ELIZA_API_TOKEN: "  padded  " })).toBe(
+      "padded",
+    );
+    expect(resolveTuiApiToken({})).toBeNull();
+    expect(resolveTuiApiToken({ ELIZA_API_TOKEN: "   " })).toBeNull();
+  });
+
+  it("attaches an Authorization: Bearer header only when a token is configured", () => {
+    expect(buildTuiAuthHeaders({ ELIZA_API_TOKEN: "tok" })).toEqual({
+      Authorization: "Bearer tok",
+    });
+    expect(buildTuiAuthHeaders({})).toEqual({});
+  });
+});

--- a/packages/agent/src/tui/agent-terminal-tui.ts
+++ b/packages/agent/src/tui/agent-terminal-tui.ts
@@ -65,6 +65,27 @@ function resolveDefaultApiBaseUrl(): string {
   return `http://${displayHost}:${port}`;
 }
 
+/**
+ * The TUI talks to the agent over HTTP. On the same host it rides the backend's
+ * loopback-trust gate, but a tunnel/reverse-proxy injects `X-Forwarded-For`,
+ * which disables that gate — so a remote terminal needs a real credential.
+ * `ELIZA_API_TOKEN` is the exact key `isAuthorized` validates; when set we send
+ * it as a Bearer token, otherwise nothing changes for loopback sessions.
+ */
+export function resolveTuiApiToken(
+  env: NodeJS.ProcessEnv = process.env,
+): string | null {
+  const token = env.ELIZA_API_TOKEN?.trim();
+  return token ? token : null;
+}
+
+export function buildTuiAuthHeaders(
+  env: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
+  const token = resolveTuiApiToken(env);
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
 async function readJson<T>(
   fetchImpl: typeof fetch,
   apiBaseUrl: string,
@@ -75,6 +96,7 @@ async function readJson<T>(
     ...init,
     headers: {
       "Content-Type": "application/json",
+      ...buildTuiAuthHeaders(),
       ...init?.headers,
     },
   });


### PR DESCRIPTION
Closes the one residual gap on #9946 after #9982 (SSH-naming + tui PR CI) and #9986 (whole-app TUI e2e) already merged.

**Critical-assessment point 2 of #9946:** *"The TUI client sends zero auth and depends on a loopback trust gate that breaks under tunneling."* — `readJson` set only `Content-Type`, so the TUI only worked against `127.0.0.1`. A tunnel/reverse-proxy injects `X-Forwarded-For`, which disables `isTrustedLocalRequest`, leaving the TUI with no credential to fall back on.

**Fix:** `readJson` now attaches `Authorization: Bearer $ELIZA_API_TOKEN` when set — the exact key `isAuthorized` validates (no phantom fallbacks) — via exported `resolveTuiApiToken` / `buildTuiAuthHeaders` helpers. Omitted when unset, so same-host loopback sessions are unchanged.

**Tests** (`tui-client-auth.test.ts`, verified locally — 2 passed): token resolved/trimmed when set, null when empty/unset; Bearer header present only when configured.

Independently verified on this Linux host that the rest of #9946 is in good shape: drove the packaged `tui` CLI through a real `script(1)` pseudo-terminal → `{ready:true, noSsh:true, hasMessagesView:true, hasComposerEcho:true}` (zero `ssh` strings, real view list, live composer echo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)