### PR TITLE
fix(scripts): make turbo wrapper resilient without bin shim

### DIFF
--- a/.github/issue-evidence/9626-run-turbo-windows-fallback.md
+++ b/.github/issue-evidence/9626-run-turbo-windows-fallback.md
@@ -1,0 +1,60 @@
+# #9626 run-turbo Windows fallback evidence
+
+Date: 2026-06-29
+Machine: Windows, Node v24.15.0, Bun 1.4.0
+
+## Before
+
+`bun run verify` failed before any package checks could run because the wrapper
+hard-coded the missing Bun shim path:
+
+```text
+Error: spawn C:\Users\Administrator\.codex\worktrees\b862\eliza\node_modules\.bin\turbo ENOENT
+    at ChildProcess._handle.onexit (node:internal/child_process:287:19)
+```
+
+This checkout had `node_modules/turbo/bin/turbo`, but no `node_modules/.bin`
+directory after repeated `bun install` attempts hung or exited early.
+
+## After
+
+The wrapper now falls back to `node node_modules/turbo/bin/turbo` when no direct
+Turbo executable shim exists.
+
+```text
+> node packages\scripts\run-turbo.mjs --version
+2.10.0
+```
+
+```text
+> bun run biome check packages\scripts\run-turbo.mjs
+Checked 1 file in 514ms. No fixes applied.
+```
+
+```text
+> node packages\scripts\run-turbo.mjs run build --filter=@elizaos/logger --concurrency=1
+• turbo 2.10.0
+
+   • Packages in scope: @elizaos/logger
+   • Running build in 1 packages
+   • Remote caching disabled, using shared worktree cache
+
+@elizaos/logger:build: $ bun run build:dist
+@elizaos/logger:build: $ node ../scripts/rm-path-recursive.mjs dist && tsc --noCheck -p tsconfig.build.json && node ../scripts/prepare-package-dist.mjs packages/logger
+
+ Tasks:    1 successful, 1 total
+Cached:    0 cached, 1 total
+  Time:    44.096s
+```
+
+## Remaining Local Blocker
+
+Full `bun run verify` progressed past the Turbo wrapper and into package builds,
+then failed because this local `node_modules/.bun` store is incomplete
+(`vitest`, Drizzle internals, Mammoth transitives, and other package files are
+missing). Multiple repair attempts with `bun install`, `bun run install:light`,
+`bun install --ignore-scripts`, and `bun install --backend=copyfile` hung or
+exited before restoring the store. That is recorded separately from this
+wrapper fix.
+
+Screenshots/video: N/A, CLI-only build-script repair.

--- a/packages/scripts/run-turbo.mjs
+++ b/packages/scripts/run-turbo.mjs
@@ -1,30 +1,64 @@
 #!/usr/bin/env node
 
 import { spawn } from "node:child_process";
-import { fileURLToPath } from "node:url";
+import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
-const turboBin = path.join(repoRoot, "node_modules/.bin/turbo");
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+const turboShimCandidates =
+  process.platform === "win32"
+    ? [
+        path.join(repoRoot, "node_modules/.bin/turbo.exe"),
+        path.join(repoRoot, "node_modules/.bin/turbo"),
+      ]
+    : [path.join(repoRoot, "node_modules/.bin/turbo")];
+const turboShim = turboShimCandidates.find((candidate) =>
+  fs.existsSync(candidate),
+);
+const turboPackageBin = path.join(repoRoot, "node_modules/turbo/bin/turbo");
 const turboArgs = process.argv.slice(2);
 
 if (!turboArgs.some((arg) => arg === "--ui" || arg.startsWith("--ui="))) {
   turboArgs.unshift("--ui=stream");
 }
 
-const runIndex = turboArgs.findIndex((arg) => arg === "run");
+const runIndex = turboArgs.indexOf("run");
 if (
   runIndex !== -1 &&
-  !turboArgs.some((arg) => arg === "--log-order" || arg.startsWith("--log-order="))
+  !turboArgs.some(
+    (arg) => arg === "--log-order" || arg.startsWith("--log-order="),
+  )
 ) {
   turboArgs.splice(runIndex + 1, 0, "--log-order=stream");
 }
 
-const child = spawn(turboBin, turboArgs, {
-  cwd: process.cwd(),
-  env: process.env,
-  stdio: ["inherit", "pipe", "pipe"],
-});
+const turboCommand = turboShim ?? process.execPath;
+const turboCommandArgs = turboShim
+  ? turboArgs
+  : [turboPackageBin, ...turboArgs];
+
+if (!turboShim && !fs.existsSync(turboPackageBin)) {
+  console.error(
+    `Unable to find turbo. Expected one of ${turboShimCandidates.join(", ")} or ${turboPackageBin}.`,
+  );
+  process.exit(1);
+}
+
+let child;
+try {
+  child = spawn(turboCommand, turboCommandArgs, {
+    cwd: process.cwd(),
+    env: process.env,
+    stdio: ["inherit", "pipe", "pipe"],
+  });
+} catch (error) {
+  console.error(`Failed to start turbo: ${error.message}`);
+  process.exit(1);
+}
 
 const warningStart = "An issue occurred while attempting to parse";
 
@@ -66,4 +100,9 @@ child.on("exit", (code, signal) => {
     return;
   }
   process.exit(code ?? 1);
+});
+
+child.on("error", (error) => {
+  console.error(`Failed to start turbo: ${error.message}`);
+  process.exit(1);
 });


### PR DESCRIPTION
## Summary
- Make `packages/scripts/run-turbo.mjs` fall back to `node_modules/turbo/bin/turbo` when a direct `.bin` executable shim is missing.
- Report missing Turbo and spawn failures cleanly instead of crashing with an unhandled child-process error.
- Add CLI evidence for #9626 under `.github/issue-evidence/9626-run-turbo-windows-fallback.md`.

## Verification
- `bun run biome check packages\scripts\run-turbo.mjs`
- `node packages\scripts\run-turbo.mjs --version`
- `node packages\scripts\run-turbo.mjs run build --filter=@elizaos/logger --concurrency=1`

## Evidence
- `.github/issue-evidence/9626-run-turbo-windows-fallback.md`

## Notes
- Full `bun run verify` is still blocked on this Windows worktree because the local Bun dependency store is incomplete after repeated `bun install` / `install:light` / `--ignore-scripts` / `--backend=copyfile` attempts hung or exited before restoring missing transitive package files. The wrapper fix moves the failure past the original `node_modules\.bin\turbo` ENOENT and into that dependency-store issue.

Refs #9626