### PR TITLE
fix(agent): validate remote plugin bridge payloads

### DIFF
--- a/.github/issue-evidence/9940-remote-plugin-bridge-validation.md
+++ b/.github/issue-evidence/9940-remote-plugin-bridge-validation.md
@@ -1,0 +1,66 @@
+# Issue 9940 Evidence: Remote Plugin Bridge Validation
+
+Date: 2026-06-29
+
+## Scope
+
+This chunk addresses the high-priority trust-boundary item from #9940:
+
+- Removed the six production `as unknown as` laundering casts from `packages/agent/src/services/remote-plugin-bridge.ts`.
+- Added zod validation for remote action results, remote route handler results, and host-rpc runtime argument shapes before they enter the runtime.
+- Added negative tests proving malformed action results, route handler results, and `createMemory` host-rpc payloads are rejected at the bridge boundary.
+
+The broader empty-fallback cleanup and smell-budget CI guard remain follow-up work under #9940.
+
+## Local Verification
+
+Passed:
+
+```text
+bunx @biomejs/biome check packages/agent/src/services/remote-plugin-bridge.ts packages/agent/src/services/remote-plugin-bridge.test.ts
+Checked 2 files in 1095ms. No fixes applied.
+```
+
+```text
+bunx vitest run --config packages/agent/vitest.config.ts packages/agent/src/services/remote-plugin-bridge.test.ts
+Test Files  1 passed (1)
+Tests       8 passed (8)
+```
+
+```text
+git diff --check
+```
+
+```text
+rg -n "as unknown as" packages/agent/src/services/remote-plugin-bridge.ts
+no matches
+```
+
+Additional check:
+
+```text
+node node_modules\@typescript\native-preview\bin\tsgo --noEmit -p packages\agent\tsconfig.json --pretty false 2>&1 | Select-String -Pattern "remote-plugin-bridge"
+no remote-plugin-bridge diagnostics
+```
+
+Attempted but blocked by the Windows worktree dependency state:
+
+```text
+bun install
+timed out after 300s with no useful output; the hung install process was stopped.
+```
+
+```text
+bun run verify
+[type-safety-ratchet] scanned 9861 tracked production source files
+[type-safety-ratchet] as unknown as: 77 / 82
+[type-safety-ratchet] baseline can shrink: as unknown as 82 -> 77
+Error: spawn ...\node_modules\.bin\turbo ENOENT
+```
+
+Package-level verify is blocked because the install did not produce `node_modules/.bin/turbo`. The filtered check above confirms the touched bridge file is no longer contributing diagnostics, and the ratchet output confirms this chunk reduces the production `as unknown as` count.
+
+## Evidence N/A
+
+- Real-LLM trajectory: N/A, no model behavior changed.
+- Screenshots/video/audio: N/A, no UI or voice surface changed.

--- a/packages/agent/src/services/remote-plugin-bridge.test.ts
+++ b/packages/agent/src/services/remote-plugin-bridge.test.ts
@@ -178,6 +178,51 @@ describe("RemotePluginBridge action callbacks", () => {
 
     await expect(resultPromise).resolves.toEqual({ success: true });
   });
+
+  it("rejects malformed worker action results before returning to the runtime", async () => {
+    const channel = new TestChannel();
+    let registeredActions: Action[] = [];
+    const runtime = {
+      registerPlugin: async (plugin: Plugin) => {
+        registeredActions = plugin.actions ?? [];
+      },
+      unloadPlugin: async () => {},
+    } as unknown as IAgentRuntime;
+    const bridge = new RemotePluginBridge({ channel, runtime });
+    bridge.attach();
+
+    await channel.emit({
+      type: "worker-announce-plugin",
+      descriptor: {
+        name: "remote-test",
+        actions: [
+          {
+            name: "REMOTE_ACTION",
+            description: "Remote action",
+            handler: { rpc: true, id: "action:remote:handler" },
+          },
+        ],
+      },
+    });
+
+    const actionPromise = registeredActions[0]?.handler(
+      runtime,
+      { content: { text: "run" } } as never,
+      undefined,
+      undefined,
+      undefined,
+      [],
+    );
+    const rpc = channel.sent[0] as WorkerRpcMessage;
+    await channel.emit({
+      type: "worker-rpc-result",
+      requestId: rpc.requestId,
+      ok: true,
+      payload: { ok: true },
+    });
+
+    await expect(actionPromise).rejects.toThrow();
+  });
 });
 
 describe("RemotePluginBridge descriptor schema", () => {
@@ -331,6 +376,61 @@ describe("RemotePluginBridge descriptor schema", () => {
     await expect(quotePromise).resolves.toEqual({ quoted: "ETH:42" });
   });
 
+  it("defaults remote routes to GET and validates route handler results", async () => {
+    const descriptor = buildAnnounceDescriptor(
+      {
+        name: "route-surface",
+        routes: [
+          {
+            path: "/route",
+            routeHandler: () => ({ status: 200, body: { ok: true } }),
+          },
+        ],
+      },
+      createHandlerRegistry(),
+    );
+
+    const channel = new TestChannel();
+    let registered: Plugin | null = null;
+    const runtime = {
+      registerPlugin: async (plugin: Plugin) => {
+        registered = plugin;
+      },
+      unloadPlugin: async () => {},
+    } as unknown as IAgentRuntime;
+    const bridge = new RemotePluginBridge({ channel, runtime });
+    bridge.attach();
+
+    await channel.emit({ type: "worker-announce-plugin", descriptor });
+
+    const plugin = registered as Plugin | null;
+    const route = plugin?.routes?.[0] as Route | undefined;
+    expect(route?.type).toBe("GET");
+
+    const badResult = route?.routeHandler?.({} as never);
+    const badRpc = channel.sent.at(-1) as WorkerRpcMessage;
+    await channel.emit({
+      type: "worker-rpc-result",
+      requestId: badRpc.requestId,
+      ok: true,
+      payload: { body: "missing status" },
+    });
+    await expect(badResult).rejects.toThrow();
+
+    const goodResult = route?.routeHandler?.({} as never);
+    const goodRpc = channel.sent.at(-1) as WorkerRpcMessage;
+    await channel.emit({
+      type: "worker-rpc-result",
+      requestId: goodRpc.requestId,
+      ok: true,
+      payload: { status: 200, body: { ok: true } },
+    });
+    await expect(goodResult).resolves.toEqual({
+      status: 200,
+      body: { ok: true },
+    });
+  });
+
   it("parses a minimal descriptor and a descriptor that only carries metadata", async () => {
     const minimal = buildAnnounceDescriptor(
       { name: "minimal" },
@@ -403,5 +503,40 @@ describe("RemotePluginBridge descriptor schema", () => {
 
     expect(await rejection).toBeTruthy();
     expect(registerCalls).toBe(0);
+  });
+});
+
+describe("RemotePluginBridge host-rpc validation", () => {
+  it("rejects malformed createMemory payloads before calling the runtime", async () => {
+    const channel = new TestChannel();
+    let createMemoryCalls = 0;
+    const runtime = {
+      createMemory: async () => {
+        createMemoryCalls += 1;
+        return "memory-id";
+      },
+      registerPlugin: async () => {},
+      unloadPlugin: async () => {},
+    } as unknown as IAgentRuntime;
+    const bridge = new RemotePluginBridge({ channel, runtime });
+    bridge.attach();
+
+    await channel.emit({
+      type: "host-rpc",
+      requestId: 1,
+      api: "runtime",
+      method: "createMemory",
+      args: {
+        memory: {
+          content: { text: "missing entityId and roomId" },
+        },
+        tableName: "messages",
+      },
+    });
+
+    const reply = channel.sent[0] as { type: string; ok: boolean };
+    expect(reply.type).toBe("host-rpc-result");
+    expect(reply.ok).toBe(false);
+    expect(createMemoryCalls).toBe(0);
   });
 });

--- a/packages/agent/src/services/remote-plugin-bridge.ts
+++ b/packages/agent/src/services/remote-plugin-bridge.ts
@@ -20,6 +20,7 @@
 
 import type {
   Action,
+  ActionResult,
   IAgentRuntime,
   Memory,
   Plugin,
@@ -44,8 +45,120 @@ import type {
 import {
   fromWireError,
   toWireError,
+  type WireError,
 } from "@elizaos/plugin-remote-manifest/worker-runtime/error";
 import * as z from "zod";
+
+const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.null(),
+    z.array(JsonValueSchema),
+    z.record(z.string(), JsonValueSchema),
+  ]),
+) as z.ZodType<JsonValue>;
+
+const JsonObjectSchema = z.record(z.string(), JsonValueSchema);
+
+const WireErrorSchema = z
+  .object({
+    name: z.string(),
+    message: z.string(),
+    stack: z.string().optional(),
+    cause: JsonValueSchema.optional(),
+    code: z.string().optional(),
+  })
+  .passthrough() as z.ZodType<WireError>;
+
+const MemorySchema = z
+  .object({
+    entityId: z.string(),
+    roomId: z.string(),
+    content: JsonObjectSchema,
+  })
+  .catchall(JsonValueSchema) as z.ZodType<Memory>;
+
+const UpdateMemorySchema = z
+  .object({
+    id: z.string(),
+    content: JsonObjectSchema.optional(),
+  })
+  .catchall(JsonValueSchema) as z.ZodType<
+  Parameters<IAgentRuntime["updateMemory"]>[0]
+>;
+
+const ActionResultSchema = z
+  .object({
+    success: z.boolean(),
+    text: z.string().optional(),
+    userFacingText: z.string().optional(),
+    verifiedUserFacing: z.boolean().optional(),
+    values: JsonObjectSchema.optional(),
+    data: JsonObjectSchema.optional(),
+    error: z.union([z.string(), WireErrorSchema]).optional(),
+    continueChain: z.boolean().optional(),
+  })
+  .catchall(JsonValueSchema);
+
+const ActionHandlerWireResultSchema = z.union([ActionResultSchema, z.null()]);
+
+const RouteTypeSchema = z.enum([
+  "GET",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+  "STATIC",
+]);
+
+const RouteHandlerResultSchema = z.object({
+  status: z.number().int(),
+  headers: z.record(z.string(), z.string()).optional(),
+  body: JsonValueSchema.optional(),
+});
+
+const HostRpcArgsSchema = {
+  getService: z.object({ serviceType: z.string() }).passthrough(),
+  useModel: z
+    .object({ modelType: z.string(), params: JsonValueSchema })
+    .passthrough(),
+  getMemory: z.object({ memoryId: z.string() }).passthrough(),
+  createMemory: z
+    .object({
+      memory: MemorySchema,
+      tableName: z.string().optional(),
+    })
+    .passthrough(),
+  updateMemory: z.object({ memory: UpdateMemorySchema }).passthrough(),
+  emitEvent: z
+    .object({
+      name: z.string(),
+      payload: JsonObjectSchema.optional(),
+    })
+    .passthrough(),
+  getSetting: z.object({ key: z.string() }).passthrough(),
+  setSetting: z
+    .object({
+      key: z.string(),
+      value: JsonValueSchema,
+    })
+    .passthrough(),
+  composeState: z.object({ message: MemorySchema }).passthrough(),
+} as const;
+
+function toActionResult(
+  value: z.infer<typeof ActionHandlerWireResultSchema>,
+): ActionResult | undefined {
+  if (value === null) return undefined;
+  return {
+    ...value,
+    ...(typeof value.error === "object" && value.error !== null
+      ? { error: fromWireError(value.error, "remote worker action") }
+      : {}),
+  };
+}
 
 /**
  * Schema for the announce/dynamic descriptor the worker emits via
@@ -104,10 +217,10 @@ const RouteDescriptorSchema = z
   .object({
     path: z.string(),
     routeHandler: RemoteFunctionRefSchema.optional(),
-    type: z.unknown().optional(),
-    name: z.unknown().optional(),
-    public: z.unknown().optional(),
-    isMultipart: z.unknown().optional(),
+    type: RouteTypeSchema.optional(),
+    name: z.string().optional(),
+    public: z.boolean().optional(),
+    isMultipart: z.boolean().optional(),
   })
   .passthrough();
 
@@ -559,7 +672,8 @@ export class RemotePluginBridge {
             ...(callbackId ? { callbackId } : {}),
           },
         );
-        return result as unknown as ReturnType<Action["handler"]>;
+        const parsed = ActionHandlerWireResultSchema.parse(result);
+        return toActionResult(parsed);
       } finally {
         if (callbackId) {
           this.state.actionCallbacks.delete(callbackId);
@@ -692,21 +806,35 @@ export class RemotePluginBridge {
     if (!descriptor.routeHandler) return null;
     const ref = descriptor.routeHandler;
     const routeHandler = async (ctx: unknown) =>
-      this.workerRpc("route", ref.id, { ctx: this.normalize(ctx) });
+      RouteHandlerResultSchema.parse(
+        await this.workerRpc("route", ref.id, { ctx: this.normalize(ctx) }),
+      );
 
-    const route = {
+    const routeBase = {
       path: descriptor.path,
-      ...(descriptor.type ? { type: descriptor.type as string } : {}),
-      ...(descriptor.name ? { name: descriptor.name as string } : {}),
-      ...(descriptor.public !== undefined
-        ? { public: Boolean(descriptor.public) }
-        : {}),
+      type: descriptor.type ?? "GET",
       ...(descriptor.isMultipart !== undefined
-        ? { isMultipart: Boolean(descriptor.isMultipart) }
+        ? { isMultipart: descriptor.isMultipart }
         : {}),
       routeHandler,
-    } as unknown as NonNullable<Plugin["routes"]>[number];
-    return route;
+    };
+    if (descriptor.public === true) {
+      if (!descriptor.name) {
+        throw new Error(
+          `[RemotePluginBridge] public route ${descriptor.path} must declare a name`,
+        );
+      }
+      return {
+        ...routeBase,
+        public: true,
+        name: descriptor.name,
+      };
+    }
+    return {
+      ...routeBase,
+      ...(descriptor.name ? { name: descriptor.name } : {}),
+      ...(descriptor.public === false ? { public: false } : {}),
+    };
   }
 
   private makeEventHandlerProxy(ref: ParsedFunctionRef) {
@@ -815,73 +943,65 @@ export class RemotePluginBridge {
   private async dispatchRuntimeMethod(
     message: HostRpcMessage,
   ): Promise<JsonValue> {
-    const args = (message.args ?? {}) as Record<string, JsonValue>;
     switch (message.method) {
       case "getService": {
-        const serviceType = String(args.serviceType);
+        const args = HostRpcArgsSchema.getService.parse(message.args);
+        const serviceType = args.serviceType;
         const service = this.runtime.getService(serviceType);
         return service ? { available: true } : null;
       }
       case "useModel": {
-        const modelType = String(args.modelType);
-        const params = args.params as JsonValue;
+        const args = HostRpcArgsSchema.useModel.parse(message.args);
         const result = await this.runtime.useModel(
-          modelType as Parameters<IAgentRuntime["useModel"]>[0],
-          params as Parameters<IAgentRuntime["useModel"]>[1],
+          args.modelType as Parameters<IAgentRuntime["useModel"]>[0],
+          args.params as Parameters<IAgentRuntime["useModel"]>[1],
         );
         return (result ?? null) as JsonValue;
       }
       case "getMemory": {
-        const memoryId = String(args.memoryId);
+        const args = HostRpcArgsSchema.getMemory.parse(message.args);
         const memory = await this.runtime.getMemoryById(
-          memoryId as Parameters<IAgentRuntime["getMemoryById"]>[0],
+          args.memoryId as Parameters<IAgentRuntime["getMemoryById"]>[0],
         );
         return JSON.parse(JSON.stringify(memory ?? null)) as JsonValue;
       }
       case "createMemory": {
-        const memory = args.memory as JsonValue;
-        const tableName =
-          typeof args.tableName === "string" ? args.tableName : undefined;
+        const args = HostRpcArgsSchema.createMemory.parse(message.args);
         const created = await this.runtime.createMemory(
-          memory as unknown as Memory,
-          tableName ?? "messages",
+          args.memory,
+          args.tableName ?? "messages",
         );
         return String(created);
       }
       case "updateMemory": {
-        await this.runtime.updateMemory(
-          args.memory as unknown as Parameters<
-            IAgentRuntime["updateMemory"]
-          >[0],
-        );
+        const args = HostRpcArgsSchema.updateMemory.parse(message.args);
+        await this.runtime.updateMemory(args.memory);
         return null;
       }
       case "emitEvent": {
-        const eventName = String(args.name);
-        const payload = args.payload as JsonValue;
-        await this.runtime.emitEvent(
-          eventName as Parameters<IAgentRuntime["emitEvent"]>[0],
-          payload as unknown as Parameters<IAgentRuntime["emitEvent"]>[1],
-        );
+        const args = HostRpcArgsSchema.emitEvent.parse(message.args);
+        await this.runtime.emitEvent(args.name, {
+          ...(args.payload ?? {}),
+          runtime: this.runtime,
+        });
         return null;
       }
       case "getSetting": {
-        const key = String(args.key);
-        const value = this.runtime.getSetting(key);
+        const args = HostRpcArgsSchema.getSetting.parse(message.args);
+        const value = this.runtime.getSetting(args.key);
         return (value ?? null) as JsonValue;
       }
       case "setSetting": {
-        const key = String(args.key);
-        const value = args.value;
+        const args = HostRpcArgsSchema.setSetting.parse(message.args);
         this.runtime.setSetting(
-          key,
-          value as Parameters<IAgentRuntime["setSetting"]>[1],
+          args.key,
+          args.value as Parameters<IAgentRuntime["setSetting"]>[1],
         );
         return null;
       }
       case "composeState": {
-        const memory = args.message as unknown as Memory;
-        const result = await this.runtime.composeState(memory);
+        const args = HostRpcArgsSchema.composeState.parse(message.args);
+        const result = await this.runtime.composeState(args.message);
         return JSON.parse(JSON.stringify(result ?? null)) as JsonValue;
       }
       default:


### PR DESCRIPTION
## Summary

Part of #9940. This PR lands the high-priority remote-plugin trust-boundary slice:

- validates remote action handler results before returning them to core
- validates remote route handler results and route descriptor fields before registration
- validates host-rpc runtime argument shapes before calling runtime methods such as createMemory/updateMemory/composeState/emitEvent
- removes all production `as unknown as` casts from `packages/agent/src/services/remote-plugin-bridge.ts`

The broader empty-fallback cleanup and smell-budget guard from #9940 remain follow-up work.

## Evidence

- `bunx @biomejs/biome check packages/agent/src/services/remote-plugin-bridge.ts packages/agent/src/services/remote-plugin-bridge.test.ts` - passed
- `bunx vitest run --config packages/agent/vitest.config.ts packages/agent/src/services/remote-plugin-bridge.test.ts` - passed, 8 tests
- `git diff --check origin/develop...HEAD` - passed
- `rg -n "as unknown as" packages/agent/src/services/remote-plugin-bridge.ts` - no matches
- `bun run verify` - blocked after ratchet scan because this Windows worktree install is missing `node_modules/.bin/turbo`; see `.github/issue-evidence/9940-remote-plugin-bridge-validation.md`

## Required evidence N/A

- Real-LLM trajectory: N/A, no model behavior changed
- Screenshots/video/audio: N/A, no UI or voice surface changed