### PR TITLE
fix(ci): restore type-safety ratchet (as-unknown-as 83->82 | baseline 82)

### DIFF
--- a/packages/core/src/features/trust/should-respond-risk-gate.ts
+++ b/packages/core/src/features/trust/should-respond-risk-gate.ts
@@ -182,7 +182,10 @@ function writeRiskFactors(message: Memory, factors: RiskFactors): void {
 			: {};
 	message.content.metadata = {
 		...existing,
-		[METADATA_KEY]: factors as unknown as ContentValue,
+		// `RiskFactors` is a flat JSON object (numbers + a string array), so a
+		// fresh spread is structurally a `{ [key: string]: ContentValue }` member
+		// without any cast.
+		[METADATA_KEY]: { ...factors },
 	} as { [key: string]: ContentValue };
 }
 


### PR DESCRIPTION
## What was failing

The Quality lane gate `bun run audit:type-safety-ratchet` failed on `develop`:

```
as unknown as: 83 current > 82 baseline
```

A merge storm pushed the in-scope (`src/**/*.ts(x)`, non-test) `as unknown as` count to 83.

## Root cause — the single net-new *counted* cast

`packages/core/src/features/trust/should-respond-risk-gate.ts`, the risk-factor metadata write:

```ts
[METADATA_KEY]: factors as unknown as ContentValue,
```

The other `as unknown as` lines added by the storm — `setInterval`/timer return, `ViewsClient`, `matchMedia`, `fetch`/`fetchMock`, and `IAgentRuntime`/`Memory` builders — all live in `*.test.ts(x)` files, which the ratchet excludes (`src/**` non-test scope). So they are **not** counted. The risk-gate write is the only in-scope addition, accounting for the exact +1.

## Fix (option: clean removal, no baseline bump)

`RiskFactors` is a flat JSON object — six `number` fields plus one `string[]`. The double-cast existed only because an `interface` carries no implicit index signature and therefore isn't directly assignable to `{ [key: string]: ContentValue }`. A fresh spread produces an object literal whose members are each assignable to `ContentValue`:

```ts
[METADATA_KEY]: { ...factors },
```

No `any`, no `unknown`, no weakening — verified with `tsc --strict` that `RiskFactors` direct-assignment fails (`Index signature ... missing`) while `{ ...factors }` compiles. The outer `as { [key: string]: ContentValue }` is a single (non-`as unknown as`) cast that predates the storm and is untouched. **Baseline unchanged at 82.**

## Verification

```
$ node packages/scripts/type-safety-ratchet.mjs
[type-safety-ratchet] as unknown as: 82 / 82
... (exit 0)

$ node packages/scripts/type-safety-ratchet.mjs --self-test
[type-safety-ratchet] self-test passed   (exit 0)

$ bun run --cwd packages/core typecheck
(exit 0, no errors)
```

(`packages/core` typecheck required running the gitignored keyword codegen — `node packages/shared/scripts/generate-keywords.mjs --target ts` — which a fresh checkout lacks; unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)