### PR TITLE
feat(app-control): settings + voice/transcription terminal views

### DIFF
--- a/packages/ui/src/spatial/__tests__/plugin-framing.test.ts
+++ b/packages/ui/src/spatial/__tests__/plugin-framing.test.ts
@@ -28,10 +28,14 @@ const registeredIds: string[] = [];
 beforeAll(async () => {
   for (const load of Object.values(registerModules)) {
     const mod = (await load()) as Record<string, unknown>;
-    const entry = Object.entries(mod).find(
-      ([k, v]) => typeof v === "function" && /^register.*TerminalView$/.test(k),
-    );
-    if (entry) (entry[1] as () => void)();
+    // A plugin may register more than one terminal view from one module
+    // (e.g. plugin-app-control: views-manager + settings + voice). Call every
+    // `register*TerminalView` export, not just the first.
+    for (const [k, v] of Object.entries(mod)) {
+      if (typeof v === "function" && /^register.*TerminalView$/.test(k)) {
+        (v as () => void)();
+      }
+    }
   }
   registeredIds.push(...listTerminalViewIds().sort());
 }, 30_000);

--- a/packages/ui/src/spatial/__tests__/registered-view-parity.test.tsx
+++ b/packages/ui/src/spatial/__tests__/registered-view-parity.test.tsx
@@ -48,10 +48,14 @@ const registeredIds: string[] = [];
 beforeAll(async () => {
   for (const load of Object.values(registerModules)) {
     const mod = (await load()) as Record<string, unknown>;
-    const entry = Object.entries(mod).find(
-      ([k, v]) => typeof v === "function" && /^register.*TerminalView$/.test(k),
-    );
-    if (entry) (entry[1] as () => void)();
+    // A plugin may register more than one terminal view from one module
+    // (e.g. plugin-app-control: views-manager + settings + voice). Call every
+    // `register*TerminalView` export, not just the first.
+    for (const [k, v] of Object.entries(mod)) {
+      if (typeof v === "function" && /^register.*TerminalView$/.test(k)) {
+        (v as () => void)();
+      }
+    }
   }
   registeredIds.push(...listTerminalViewIds().sort());
 }, 30_000);

--- a/plugins/plugin-app-control/src/components/SettingsSpatialView.tsx
+++ b/plugins/plugin-app-control/src/components/SettingsSpatialView.tsx
@@ -1,0 +1,95 @@
+/**
+ * SettingsSpatialView — the agent settings/config surface authored once with the
+ * spatial vocabulary, so it renders wherever it is mounted:
+ *
+ *   - GUI / XR — inside `<SpatialSurface>` (DOM; XR scales up).
+ *   - TUI      — rendered to real terminal lines by the agent terminal via
+ *                `registerSpatialTerminalView` (see `register-terminal-view.tsx`).
+ *
+ * Purely presentational: a snapshot of already-exposed settings in, primitives
+ * out — no fetch, no React state, no shell-host import — so it is safe to render
+ * in the Node agent process where the terminal lives. A host pushes live values
+ * from `GET /api/config` via `setSettingsTerminalSnapshot`; with no host it shows
+ * the labelled rows with em-dash placeholders, so the panel is always meaningful.
+ */
+
+import {
+	Card,
+	Divider,
+	HStack,
+	List,
+	type SpatialTone,
+	Text,
+} from "@elizaos/ui/spatial";
+
+/** One displayed setting: a label and its current value. */
+export interface SettingsRow {
+	label: string;
+	value: string;
+	/** Tone for the value (e.g. "success" for an enabled feature). */
+	tone?: SpatialTone;
+}
+
+export interface SettingsSnapshot {
+	rows: SettingsRow[];
+	loading?: boolean;
+	error?: string | null;
+}
+
+/** Labelled rows with placeholders, so the panel renders before a host pushes. */
+export const EMPTY_SETTINGS_SNAPSHOT: SettingsSnapshot = {
+	rows: [
+		{ label: "Theme", value: "—" },
+		{ label: "Background", value: "—" },
+		{ label: "Voice", value: "—" },
+		{ label: "Model", value: "—" },
+	],
+};
+
+export interface SettingsSpatialViewProps {
+	snapshot: SettingsSnapshot;
+}
+
+export function SettingsSpatialView({ snapshot }: SettingsSpatialViewProps) {
+	const rows = snapshot.rows;
+	return (
+		<Card gap={1} padding={1}>
+			<HStack gap={1} align="center">
+				<Text style="caption" tone="success" grow={1}>
+					{snapshot.loading ? "loading" : "settings"}
+				</Text>
+				<Text style="caption" tone="muted">
+					config
+				</Text>
+			</HStack>
+
+			{snapshot.error ? (
+				<Text tone="danger" style="caption">
+					{snapshot.error}
+				</Text>
+			) : null}
+
+			<Divider label="settings" />
+			{rows.length === 0 ? (
+				<Text tone="muted" align="center" style="caption">
+					No settings loaded
+				</Text>
+			) : (
+				<List gap={0}>
+					{rows.map((row) => (
+						<HStack key={row.label} gap={1} align="center">
+							<Text grow={1} wrap={false}>
+								{row.label}
+							</Text>
+							<Text tone={row.tone ?? "muted"} wrap={false}>
+								{row.value}
+							</Text>
+						</HStack>
+					))}
+				</List>
+			)}
+		</Card>
+	);
+}
+
+export default SettingsSpatialView;

--- a/plugins/plugin-app-control/src/components/VoiceSpatialView.tsx
+++ b/plugins/plugin-app-control/src/components/VoiceSpatialView.tsx
@@ -1,0 +1,119 @@
+/**
+ * VoiceSpatialView — the voice/transcription surface authored once with the
+ * spatial vocabulary (GUI / XR / TUI), purely presentational over a snapshot.
+ *
+ * It surfaces the EXISTING voice configuration (provider, mode, ASR) from
+ * `GET /api/config` plus the most recent transcript lines a host chooses to push
+ * via `setVoiceTerminalSnapshot`. It does NOT open a microphone or run ASR — the
+ * live capture pipeline is browser-side (WebRTC + AudioContext) and out of reach
+ * of the Node terminal; this view renders the state that pipeline produces.
+ */
+
+import {
+	Card,
+	Divider,
+	HStack,
+	List,
+	type SpatialTone,
+	Text,
+	VStack,
+} from "@elizaos/ui/spatial";
+
+/** A finalized transcript line surfaced for display. */
+export interface TranscriptLine {
+	speaker: string;
+	text: string;
+}
+
+export interface VoiceSnapshot {
+	provider?: string;
+	mode?: string;
+	asrProvider?: string;
+	/** "ready" once a TTS/ASR provider is configured, else "unconfigured". */
+	status?: "ready" | "unconfigured" | "error";
+	/** Recent finalized transcript lines (most recent last). */
+	transcript: TranscriptLine[];
+	error?: string | null;
+}
+
+export const EMPTY_VOICE_SNAPSHOT: VoiceSnapshot = {
+	status: "unconfigured",
+	transcript: [],
+};
+
+function statusTone(status: VoiceSnapshot["status"]): SpatialTone {
+	if (status === "ready") return "success";
+	if (status === "error") return "danger";
+	return "muted";
+}
+
+export interface VoiceSpatialViewProps {
+	snapshot: VoiceSnapshot;
+}
+
+export function VoiceSpatialView({ snapshot }: VoiceSpatialViewProps) {
+	const transcript = snapshot.transcript;
+	return (
+		<Card gap={1} padding={1}>
+			<HStack gap={1} align="center">
+				<Text style="caption" tone={statusTone(snapshot.status)} grow={1}>
+					{snapshot.status ?? "unconfigured"}
+				</Text>
+				<Text style="caption" tone="muted">
+					voice
+				</Text>
+			</HStack>
+
+			{snapshot.error ? (
+				<Text tone="danger" style="caption">
+					{snapshot.error}
+				</Text>
+			) : null}
+
+			<Divider label="config" />
+			<List gap={0}>
+				<HStack gap={1} align="center">
+					<Text grow={1} wrap={false}>
+						Provider
+					</Text>
+					<Text tone="muted" wrap={false}>
+						{snapshot.provider ?? "—"}
+					</Text>
+				</HStack>
+				<HStack gap={1} align="center">
+					<Text grow={1} wrap={false}>
+						Mode
+					</Text>
+					<Text tone="muted" wrap={false}>
+						{snapshot.mode ?? "—"}
+					</Text>
+				</HStack>
+				<HStack gap={1} align="center">
+					<Text grow={1} wrap={false}>
+						ASR
+					</Text>
+					<Text tone="muted" wrap={false}>
+						{snapshot.asrProvider ?? "—"}
+					</Text>
+				</HStack>
+			</List>
+
+			<Divider label="transcript" />
+			{transcript.length === 0 ? (
+				<Text tone="muted" align="center" style="caption">
+					No transcript yet
+				</Text>
+			) : (
+				<VStack gap={0}>
+					{transcript.slice(-8).map((line) => (
+						<Text key={`${line.speaker}:${line.text}`} wrap={false}>
+							{`${line.speaker}: ${line.text}`}
+						</Text>
+					))}
+				</VStack>
+			)}
+		</Card>
+	);
+}
+
+export default VoiceSpatialView;

--- a/plugins/plugin-app-control/src/index.ts
+++ b/plugins/plugin-app-control/src/index.ts
@@ -105,12 +105,16 @@ export type {
 } from "./types.js";
 export { appAction, availableAppsProvider, createAppAction };
 
-// In a terminal host (the Node agent, no DOM), register the views-manager view
-// so it renders inline in the terminal. Lazy + DOM-guarded so the terminal
-// engine stays out of browser/mobile bundles.
+// In a terminal host (the Node agent, no DOM), register the views-manager,
+// settings, and voice views so they render inline in the terminal. Lazy +
+// DOM-guarded so the terminal engine stays out of browser/mobile bundles.
 if (typeof window === "undefined") {
 	void import("./register-terminal-view.js")
-		.then((m) => m.registerViewManagerTerminalView())
+		.then((m) => {
+			m.registerViewManagerTerminalView();
+			m.registerSettingsTerminalView();
+			m.registerVoiceTerminalView();
+		})
 		.catch(() => {
 			// Terminal rendering is best-effort; never block plugin load.
 		});
@@ -241,6 +245,44 @@ export const appControlPlugin: Plugin = {
 				}
 				return { success: false, error: `unknown capability: ${capability}` };
 			},
+		},
+		// Terminal-only surfaces: settings and voice/transcription render in the
+		// agent terminal via the spatial terminal registry (see
+		// register-terminal-view.tsx). They have no GUI bundle — the TUI mounts the
+		// registered SettingsSpatialView / VoiceSpatialView directly. `modalities:
+		// ["tui"]` lists them under GET /api/views?viewType=tui so the terminal can
+		// open them; a host pushes live config via set*TerminalSnapshot.
+		{
+			id: "settings",
+			label: "Settings",
+			description: "Agent settings and configuration",
+			icon: "Settings",
+			path: "/settings/tui",
+			modalities: ["tui"],
+			visibleInManager: true,
+			capabilities: [
+				{
+					id: "settings-get-state",
+					description:
+						"Return the current settings snapshot as structured data",
+				},
+			],
+		},
+		{
+			id: "voice",
+			label: "Voice",
+			description: "Voice configuration and recent transcript",
+			icon: "Mic",
+			path: "/voice/tui",
+			modalities: ["tui"],
+			visibleInManager: true,
+			capabilities: [
+				{
+					id: "voice-get-state",
+					description:
+						"Return the current voice/transcript snapshot as structured data",
+				},
+			],
 		},
 	],
 };

--- a/plugins/plugin-app-control/src/register-terminal-view.tsx
+++ b/plugins/plugin-app-control/src/register-terminal-view.tsx
@@ -1,19 +1,29 @@
 /**
- * Register the views-manager view for terminal rendering.
+ * Register plugin-app-control's terminal views (views-manager, settings, voice).
  *
  * The agent terminal mounts plugin views by id from the `@elizaos/tui` terminal
- * registry. This makes the `views-manager` `viewType: "tui"` declaration render
- * for real in the terminal (the unified {@link ViewManagerSpatialView}) rather
- * than only navigating a GUI shell. A module-level snapshot lets a host push the
- * live view list; with no host it defaults to an empty list.
+ * registry. This makes each view's `viewType: "tui"` declaration render for real
+ * in the terminal (the unified spatial view) rather than only navigating a GUI
+ * shell. A module-level snapshot per view lets a host push live data; with no
+ * host each renders its sensible empty/placeholder state.
  */
 
 import { registerSpatialTerminalView } from "@elizaos/ui/spatial/tui";
 import { createElement } from "react";
 import {
+	EMPTY_SETTINGS_SNAPSHOT,
+	type SettingsSnapshot,
+	SettingsSpatialView,
+} from "./components/SettingsSpatialView.tsx";
+import {
 	type ViewManagerSnapshot,
 	ViewManagerSpatialView,
 } from "./components/ViewManagerSpatialView.tsx";
+import {
+	EMPTY_VOICE_SNAPSHOT,
+	type VoiceSnapshot,
+	VoiceSpatialView,
+} from "./components/VoiceSpatialView.tsx";
 
 const EMPTY: ViewManagerSnapshot = { views: [] };
 let current: ViewManagerSnapshot = EMPTY;
@@ -29,5 +39,33 @@ export function setViewManagerTerminalSnapshot(
 export function registerViewManagerTerminalView(): () => void {
 	return registerSpatialTerminalView("views-manager", () =>
 		createElement(ViewManagerSpatialView, { snapshot: current }),
+	);
+}
+
+let currentSettings: SettingsSnapshot = EMPTY_SETTINGS_SNAPSHOT;
+
+/** Update the snapshot the registered settings terminal view renders from. */
+export function setSettingsTerminalSnapshot(next: SettingsSnapshot): void {
+	currentSettings = next;
+}
+
+/** Register the settings terminal view; returns an unregister function. */
+export function registerSettingsTerminalView(): () => void {
+	return registerSpatialTerminalView("settings", () =>
+		createElement(SettingsSpatialView, { snapshot: currentSettings }),
+	);
+}
+
+let currentVoice: VoiceSnapshot = EMPTY_VOICE_SNAPSHOT;
+
+/** Update the snapshot the registered voice/transcript terminal view renders. */
+export function setVoiceTerminalSnapshot(next: VoiceSnapshot): void {
+	currentVoice = next;
+}
+
+/** Register the voice/transcription terminal view; returns an unregister function. */
+export function registerVoiceTerminalView(): () => void {
+	return registerSpatialTerminalView("voice", () =>
+		createElement(VoiceSpatialView, { snapshot: currentVoice }),
 	);
 }


### PR DESCRIPTION
The deferred **live settings + voice/transcription terminal views** from #9969 — the two surfaces it flagged as having no terminal view. Lands both as real spatial views in `plugin-app-control` (alongside `views-manager`), surfacing **already-exposed state — no new pipeline**.

## What's added
- **`SettingsSpatialView`** — agent settings/config (theme, background, voice, model) from a `SettingsSnapshot`; labelled placeholder rows so the panel is meaningful before a host pushes live values from `GET /api/config`.
- **`VoiceSpatialView`** — voice configuration (provider, mode, ASR) + recent **finalized transcript lines**. It does **not** open a mic or run ASR — that capture pipeline is browser-side (WebRTC + AudioContext) and out of reach of the Node terminal; this view renders the state that pipeline produces, pushed via a snapshot. Matches the issue's *"do not invent a parallel voice pipeline"* constraint.
- `register-terminal-view.tsx` registers both via `registerSpatialTerminalView` with `set*TerminalSnapshot` setters (the `views-manager` pattern); `index.ts` calls the registrations in the DOM-guarded terminal block and declares both as `modalities: ["tui"]` views so `GET /api/views?viewType=tui` lists them in the agent terminal.

Authored once with the spatial primitives → they render in **GUI/XR/TUI from one tree**.

## Test-harness fix
The `registered-view-parity` + `plugin-framing` gates glob every `register-terminal-view.tsx`, but each only invoked the **first** `register*TerminalView` per module. A plugin can now register multiple (app-control: views-manager + settings + voice), so both gates were fixed to call **every** one — which is what now exercises settings + voice across all three modalities.

## Verification
```
plugin-app-control typecheck   exit 0
plugin-app-control build        ✓ (views bundle unchanged — these are TUI-only)
registered-view-parity          3 passed   (settings + voice render gui/xr/tui w/ parity)
plugin-framing                  4 passed   (settings + voice frame cleanly @ 56/40)
plugin-tui-view-coverage        6 passed   (settings-get-state / voice-get-state dispatch)
biome                           clean
```

## #9969 acceptance criterion addressed
- [x] Settings + voice/transcription are covered through the real shell (registered terminal views, parity-tested in all three modalities). Live config population is a host-pushed snapshot (the established `views-manager`/`task-coordinator` pattern); live browser-side transcript streaming remains out of scope per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)