### PR TITLE
fix(ui): launcher swipe-to-apps silently fails on Android WebView (pointer capture)

### DIFF
--- a/.github/issue-evidence/9967-launcher-swipe-pointer-capture.md
+++ b/.github/issue-evidence/9967-launcher-swipe-pointer-capture.md
@@ -1,0 +1,63 @@
+# Issue 9967 Evidence: Launcher Touch Swipe Pointer Capture
+
+Date: 2026-06-29
+
+## Scope
+
+This PR addresses one device-reported launcher failure from #9967: on Android
+WebView, a touch swipe from the home page to the apps page can be cancelled when
+the horizontal pager calls `setPointerCapture()` on the live touch pointer.
+
+The code change is limited to `packages/ui/src/hooks/useHorizontalPager.ts`:
+
+- touch pointers rely on the browser's implicit pointer capture;
+- mouse and pen pointers still call `setPointerCapture()` explicitly;
+- `packages/ui/src/components/pages/Launcher.gestures.test.tsx` simulates the
+  Android WebView `pointercancel` quirk and verifies the touch swipe commits.
+
+## Local Verification On Windows
+
+Passed:
+
+```text
+bunx @biomejs/biome check packages/ui/src/hooks/useHorizontalPager.ts packages/ui/src/components/pages/Launcher.gestures.test.tsx
+Checked 2 files. No fixes applied.
+```
+
+```text
+git diff --check origin/develop...HEAD
+```
+
+```text
+bunx vitest run --config vitest.config.ts src/components/pages/Launcher.gestures.test.tsx
+Test Files  1 passed (1)
+Tests       9 passed (9)
+```
+
+The focused test initially could not import because this Windows worktree had
+an incomplete dependency store. Before the successful run, the local environment
+was repaired with package links for generated core i18n data, `@elizaos/registry`,
+`drizzle-orm`, and `get-east-asian-width`. Those repairs were local
+`node_modules`/generated-file setup only; no tracked source files were changed.
+
+## Device Evidence
+
+The PR body records the on-device diagnosis from a Pixel 9a:
+
+```text
+pointerdown -> pointermove -> pointercancel -> lostpointercapture
+```
+
+It also records that the APK was rebuilt and reinstalled after the fix. That
+device was not attached to this Windows review session, so this file records the
+unit regression proof from this machine and leaves real-device rerun/recording
+to the device holder.
+
+## Evidence N/A
+
+- Real-LLM trajectory: N/A, no model behavior changed.
+- Backend logs: N/A, client gesture handler only.
+- Audio: N/A, no voice/audio behavior changed.
+- Screenshots/video from this Windows box: N/A for the Android WebView
+  cancellation itself; the regression is covered by the simulated
+  `pointercancel` unit test above.

--- a/packages/ui/src/components/pages/Launcher.gestures.test.tsx
+++ b/packages/ui/src/components/pages/Launcher.gestures.test.tsx
@@ -210,6 +210,65 @@ describe("Launcher swipe paging (onDragEnd)", () => {
   });
 });
 
+describe("Launcher touch swipe (Android WebView pointer-capture guard)", () => {
+  // Reproduces the launcher-swipe regression seen on a real Pixel: on Android
+  // WebView, calling setPointerCapture on a TOUCH pointer mid-gesture makes the
+  // browser fire `pointercancel`, which the pager's onLostPointerCapture /
+  // onPointerCancel turns into an aborted drag — the flick silently snaps back
+  // and never reaches the apps page. The fix skips explicit capture for touch
+  // (touch pointers are implicitly captured to the target), so the cancel never
+  // fires.
+  function touchSwipeWithCaptureCancel(dx: number): { captureCalls: number } {
+    const pageWindow = screen.getByTestId("launcher-page-window");
+    let captureCalls = 0;
+    (pageWindow as HTMLElement).setPointerCapture = (pointerId: number) => {
+      captureCalls += 1;
+      // Mirror the WebView: an explicit capture on a live touch is answered with
+      // a pointercancel.
+      fireEvent.pointerCancel(pageWindow, {
+        pointerId,
+        pointerType: "touch",
+        isPrimary: true,
+      });
+    };
+    (pageWindow as HTMLElement).releasePointerCapture = () => {};
+    fireEvent.pointerDown(pageWindow, {
+      pointerId: 1,
+      pointerType: "touch",
+      clientX: 500,
+      clientY: 100,
+      isPrimary: true,
+    });
+    fireEvent.pointerMove(pageWindow, {
+      pointerId: 1,
+      pointerType: "touch",
+      clientX: 500 + dx,
+      clientY: 102,
+      isPrimary: true,
+    });
+    fireEvent.pointerUp(pageWindow, {
+      pointerId: 1,
+      pointerType: "touch",
+      clientX: 500 + dx,
+      clientY: 102,
+      isPrimary: true,
+    });
+    return { captureCalls };
+  }
+
+  it("advances a page on a touch swipe without taking pointer capture", () => {
+    render(<Launcher entries={PAGE2} onLaunch={() => {}} />);
+    let result: { captureCalls: number } = { captureCalls: -1 };
+    act(() => {
+      result = touchSwipeWithCaptureCancel(-300);
+    });
+    // The fix must not capture touch pointers (so the WebView never cancels) …
+    expect(result.captureCalls).toBe(0);
+    // … and the flick therefore commits to the next page.
+    expect(actions()).toContain("page-swipe");
+  });
+});
+
 describe("Launcher interaction telemetry", () => {
   it("emits launch on tap", () => {
     const onLaunch = vi.fn();

--- a/packages/ui/src/hooks/useHorizontalPager.ts
+++ b/packages/ui/src/hooks/useHorizontalPager.ts
@@ -303,7 +303,14 @@ export function useHorizontalPager<
       }
       if (state.axis !== "horizontal") return;
 
-      if (!state.captured) {
+      // Touch pointers are IMPLICITLY captured to the target on pointerdown, so
+      // an explicit setPointerCapture is redundant — and on Android WebView it
+      // makes the browser fire `pointercancel` + `lostpointercapture` the instant
+      // it is called mid-gesture, which `onLostPointerCapture` then turns into an
+      // aborted drag (the launcher flick silently snaps back). Capture explicitly
+      // only for mouse/pen, where it is needed to keep receiving moves once the
+      // pointer leaves the element.
+      if (!state.captured && event.pointerType !== "touch") {
         try {
           event.currentTarget.setPointerCapture(event.pointerId);
           state.captured = true;


### PR DESCRIPTION
## What & why

On a real Pixel 9a, the launcher's **home ↔ apps swipe is broken** — you can't flick over to the apps page. A horizontal touch swipe starts to drag and then silently snaps back to the home page. (Reported while testing a device build.)

## Root cause (diagnosed on-device)

Instrumenting the launcher's pointer events on the device showed this sequence for a horizontal swipe:

```
pointerdown(724) → pointermove(698)  →  pointercancel  →  lostpointercapture  → (raw touchmoves continue) → touchend
```

The browser fires **`pointercancel`** after the *first* horizontal `pointermove`. That move is exactly where `useHorizontalPager` calls **`setPointerCapture`** — and on Android WebView, taking an explicit pointer capture on a *live touch pointer* makes the browser cancel the touch. The pager's `onLostPointerCapture` / `onPointerCancel` then treat the cancel as an aborted drag (`finish(cancelled=true)` → snap back), so the flick never commits.

Verified on-device that this is **not** a `touch-action`/scroll/history issue — forcing `touch-action: none` on the whole subtree **and** `overscroll-behavior-x: none` (already set) on the root still produced the same `pointercancel`. The trigger is the `setPointerCapture` call itself.

## Fix

Touch pointers are **implicitly** captured to the target element on `pointerdown`, so the explicit `setPointerCapture` is redundant for touch — and harmful on Android WebView. Guard it to mouse/pen only:

```ts
if (!state.captured && event.pointerType !== "touch") {
  event.currentTarget.setPointerCapture(event.pointerId);
  state.captured = true;
}
```

Mouse/pen still capture explicitly (needed to keep receiving moves once the pointer leaves the element); touch relies on the implicit capture and is never cancelled.

## Tests

Added a regression test (`Launcher.gestures.test.tsx`) that **simulates the WebView quirk** — it stubs `setPointerCapture` to fire a `pointercancel` (exactly what the device does) and asserts that a touch swipe:
1. advances to the next page (`page-swipe` emitted), and
2. does so **without** taking pointer capture (`captureCalls === 0`).

This test fails against the old code (capture is taken → pointercancel fires → no page change) and passes with the fix. Full `Launcher.gestures` suite: **9/9 pass**. Biome clean; `packages/ui` typecheck of the hook clean.

## Evidence per PR_EVIDENCE.md

- **On-device repro + diagnosis** — REQUIRED & done: reproduced on a connected Pixel 9a via faithful CDP touch injection (the swipe left the rail at `translateX:0`, `data-page=home`), with the `pointerdown→pointermove→pointercancel` event trace above isolating the cause. The fix was rebuilt into the APK and reinstalled on the device.
- **Unit regression test** — attached (faithful WebView-quirk simulation).
- **Real-LLM trajectory / audio** — N/A: pure client gesture-handling fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
