### PR TITLE
fix(core): remove dead character plugin map

### DIFF
--- a/.github/issue-evidence/9941-remove-dead-build-character-plugins.md
+++ b/.github/issue-evidence/9941-remove-dead-build-character-plugins.md
@@ -1,0 +1,51 @@
+# Issue 9941 Evidence: Remove Dead Core Plugin Map
+
+Date: 2026-06-29
+
+## Scope
+
+This chunk addresses the first high-confidence #9941 item:
+
+- Deleted dead `buildCharacterPlugins()` from `packages/core/src/character.ts`.
+- Removed the divergent env-var to `@elizaos/plugin-*` map from the innermost `@elizaos/core` layer.
+
+No runtime behavior should change: the function had no live source callers and was not exported from the core barrels.
+
+## Local Verification
+
+Passed:
+
+```text
+rg -n "buildCharacterPlugins" packages plugins scripts -g "*.ts" -g "*.tsx" -g "*.mjs" -g "*.cjs" -g "*.js" --glob "!**/dist/**" --glob "!**/node_modules/**"
+no matches
+```
+
+```text
+bunx @biomejs/biome check packages/core/src/character.ts
+Checked 1 file in 577ms. No fixes applied.
+```
+
+```text
+git diff --check
+```
+
+Attempted but blocked by the Windows worktree dependency state:
+
+```text
+bun run verify
+[type-safety-ratchet] scanned 9862 tracked production source files
+[type-safety-ratchet] as unknown as: 82 / 82
+Error: spawn ...\node_modules\.bin\turbo ENOENT
+```
+
+```text
+node node_modules\@typescript\native-preview\bin\tsgo --noEmit -p packages\core\tsconfig.json --pretty false
+```
+
+The command fails before reaching this change because the local install is incomplete: missing packages such as `fs-extra`, `mammoth`, `unpdf`, `dedent`, `file-type`, `handlebars`, `dotenv`, `json5`, and generated `validation-keyword-data` modules, plus a broken `drizzle-orm` type surface. No diagnostic referenced `packages/core/src/character.ts`.
+
+## Evidence N/A
+
+- Backend logs: N/A for dead-code deletion.
+- Real-LLM trajectory: N/A, no model behavior changed.
+- Screenshots/video/audio: N/A, no UI or voice surface changed.

--- a/packages/core/src/character.ts
+++ b/packages/core/src/character.ts
@@ -228,33 +228,3 @@ export function mergeCharacterDefaults(char: CharacterInput): Character {
 		name: normalized.name || "Unnamed Character",
 	} as Character;
 }
-
-export function buildCharacterPlugins(
-	env: Record<string, string | undefined> = process.env,
-): string[] {
-	const plugins = [
-		"@elizaos/plugin-sql",
-		...(env.ANTHROPIC_API_KEY?.trim() ? ["@elizaos/plugin-anthropic"] : []),
-		...(env.OPENROUTER_API_KEY?.trim() ? ["@elizaos/plugin-openrouter"] : []),
-		...(env.OPENAI_API_KEY?.trim() ? ["@elizaos/plugin-openai"] : []),
-		...(env.GOOGLE_GENERATIVE_AI_API_KEY?.trim()
-			? ["@elizaos/plugin-google-genai"]
-			: []),
-		...(env.DISCORD_API_TOKEN?.trim() ? ["@elizaos/plugin-discord"] : []),
-		...(env.X_API_KEY?.trim() &&
-		env.X_API_SECRET?.trim() &&
-		env.X_ACCESS_TOKEN?.trim() &&
-		env.X_ACCESS_TOKEN_SECRET?.trim()
-			? ["@elizaos/plugin-x"]
-			: []),
-		...(env.TELEGRAM_BOT_TOKEN?.trim() ? ["@elizaos/plugin-telegram"] : []),
-		...(!env.ANTHROPIC_API_KEY?.trim() &&
-		!env.OPENROUTER_API_KEY?.trim() &&
-		!env.OPENAI_API_KEY?.trim() &&
-		!env.GOOGLE_GENERATIVE_AI_API_KEY?.trim()
-			? ["@elizaos/plugin-ollama"]
-			: []),
-	];
-
-	return plugins;
-}


### PR DESCRIPTION
## Summary

Part of #9941. This removes the dead `buildCharacterPlugins()` helper from `packages/core/src/character.ts`, deleting the divergent env-var to `@elizaos/plugin-*` map from the innermost core package.

This is the first high-confidence #9941 item only. Follow-up work remains for registry-derived `PROVIDER_PLUGIN_MAP`, app-route plugin boot-race cleanup, TTS capability resolution, and a broader core boundary guard.

## Evidence

- `rg -n "buildCharacterPlugins" packages plugins scripts -g "*.ts" -g "*.tsx" -g "*.mjs" -g "*.cjs" -g "*.js" --glob "!**/dist/**" --glob "!**/node_modules/**"` - no matches
- `bunx @biomejs/biome check packages/core/src/character.ts` - passed
- `git diff --check origin/develop...HEAD` - passed
- filtered core typecheck for `character.ts` diagnostics - no matches
- `bun run verify` - blocked after ratchet scan because this Windows worktree install is missing `node_modules/.bin/turbo`; see `.github/issue-evidence/9941-remove-dead-build-character-plugins.md`

## Required evidence N/A

- Backend logs: N/A, dead-code deletion only
- Real-LLM trajectory: N/A, no model behavior changed
- Screenshots/video/audio: N/A, no UI or voice surface changed