### PR TITLE
fix(app): round-trip failureKind so Retry + provider/credits gates persist; retry-in-place

### DIFF
--- a/packages/agent/src/api/__tests__/conversation-failurekind-roundtrip.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-failurekind-roundtrip.test.ts
@@ -1,0 +1,361 @@
+/**
+ * Round-trip coverage for the chat `failureKind` so the renderer's
+ * provider/credits/no-provider gate + Retry button survive a turn:
+ *
+ *  (a) GET /api/conversations/:id/messages re-emits `failureKind` for a
+ *      persisted failed assistant turn (from `content.failureKind` on the live
+ *      result OR `metadata.chatFailureKind` from markSyntheticChatFailureContent).
+ *  (b) The streaming `done` frame includes `failureKind` when a NON-throwing
+ *      result carries one (e.g. a canned provider-issue phrase folded into the
+ *      reply), mirroring the error branch.
+ *  (c) The non-streaming JSON response includes `failureKind` likewise.
+ *
+ * Before the fix the GET mapping dropped the field entirely (full-replace wiped
+ * the gate) and both success writers omitted it.
+ */
+
+import http from "node:http";
+import { ChannelType, logger, stringToUuid, type UUID } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Configurable result returned by the mocked generateChatResponse so each test
+// can drive the success writers with/without a carried failureKind.
+let generateResult: Record<string, unknown> = {};
+
+vi.mock("../chat-routes.ts", async () => {
+  const actual =
+    await vi.importActual<typeof import("../chat-routes.ts")>(
+      "../chat-routes.ts",
+    );
+  return {
+    ...actual,
+    initSse: vi.fn((res: http.ServerResponse) => {
+      res.setHeader("Content-Type", "text/event-stream");
+    }),
+    writeSse: vi.fn((res: http.ServerResponse, payload: object) => {
+      res.write(`data: ${JSON.stringify(payload)}\n\n`);
+    }),
+    writeSseJson: vi.fn((res: http.ServerResponse, payload: object) => {
+      res.write(`data: ${JSON.stringify(payload)}\n\n`);
+    }),
+    writeChatTokenSse: vi.fn(
+      (res: http.ServerResponse, chunk: string, fullText: string) => {
+        res.write(
+          `data: ${JSON.stringify({ type: "token", text: chunk, fullText })}\n\n`,
+        );
+      },
+    ),
+    writeChatStatusSse: vi.fn(),
+    readChatRequestPayload: vi.fn(async () => ({
+      prompt: "hello",
+      channelType: ChannelType.DM,
+      images: undefined,
+      preferredLanguage: undefined,
+      source: "api",
+      metadata: undefined,
+    })),
+    persistConversationMemory: vi.fn(async () => undefined),
+    persistAssistantConversationMemory: vi.fn(async () => undefined),
+    hasRecentVisibleAssistantMemorySince: vi.fn(async () => false),
+    generateChatResponse: vi.fn(
+      async (
+        _runtime,
+        _msg,
+        agentName: string,
+        opts: { onChunk?: (chunk: string) => void },
+      ) => {
+        opts?.onChunk?.("ok");
+        return {
+          text: "ok",
+          agentName,
+          usage: undefined,
+          usedActionCallbacks: false,
+          actionCallbackHistory: undefined,
+          noResponseReason: undefined,
+          ...generateResult,
+        };
+      },
+    ),
+    normalizeChatResponseText: (text: string) => text,
+    resolveNoResponseFallback: () => "",
+  };
+});
+
+vi.mock("../server-helpers.ts", async () => {
+  const actual = await vi.importActual<typeof import("../server-helpers.ts")>(
+    "../server-helpers.ts",
+  );
+  return {
+    ...actual,
+    buildUserMessages: vi.fn(({ prompt, userId, agentId, roomId }) => ({
+      userMessage: {
+        id: stringToUuid("user-msg"),
+        entityId: userId,
+        agentId,
+        roomId,
+        content: { text: prompt, source: "api", channelType: ChannelType.DM },
+      },
+      messageToStore: {
+        id: stringToUuid("user-msg-store"),
+        entityId: userId,
+        agentId,
+        roomId,
+        content: { text: prompt, source: "api", channelType: ChannelType.DM },
+      },
+    })),
+    resolveWalletModeGuidanceReply: () => null,
+    resolveAppUserName: () => "tester",
+  };
+});
+
+import type {
+  ConversationRouteContext,
+  ConversationRouteState,
+} from "../conversation-routes.ts";
+import { handleConversationRoutes } from "../conversation-routes.ts";
+
+const AGENT_ID = stringToUuid("agent-1") as UUID;
+const USER_ID = stringToUuid("user-1") as UUID;
+const ROOM_ID = stringToUuid("room-1") as UUID;
+
+interface MockResponseRecord {
+  writes: string[];
+  ended: boolean;
+}
+
+function createMockRes(): {
+  res: http.ServerResponse;
+  record: MockResponseRecord;
+} {
+  const record: MockResponseRecord = { writes: [], ended: false };
+  const res = {
+    setHeader: vi.fn(),
+    write: vi.fn((chunk: string | Buffer) => {
+      record.writes.push(
+        typeof chunk === "string" ? chunk : chunk.toString("utf-8"),
+      );
+      return true;
+    }),
+    end: vi.fn(() => {
+      record.ended = true;
+    }),
+    writableEnded: false,
+  } as unknown as http.ServerResponse;
+  return { res, record };
+}
+
+function createState(
+  memories: Array<Record<string, unknown>> = [],
+): ConversationRouteState {
+  const conv = {
+    id: "conv-1",
+    title: "Test conv",
+    roomId: ROOM_ID,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+  const runtime = {
+    agentId: AGENT_ID,
+    character: { name: "Test Agent" },
+    logger,
+    getMemories: vi.fn(async () => memories),
+    ensureConnection: vi.fn(async () => undefined),
+    updateWorld: vi.fn(async () => undefined),
+    getWorld: vi.fn(async () => null),
+    getRoom: vi.fn(async () => null),
+    adapter: {},
+  };
+  return {
+    runtime: runtime as never,
+    config: { user: { name: "tester" } } as never,
+    agentName: "Test Agent",
+    adminEntityId: USER_ID,
+    chatUserId: USER_ID,
+    logBuffer: [],
+    conversations: new Map([[conv.id, conv]]),
+    activeChatTurnCount: 0,
+    conversationRestorePromise: null,
+    deletedConversationIds: new Set(),
+    broadcastWs: null,
+  };
+}
+
+function createReq(method: string, url: string): http.IncomingMessage {
+  return Object.assign(new http.IncomingMessage(null as never), {
+    method,
+    url,
+    headers: {},
+  }) as http.IncomingMessage;
+}
+
+function assistantMemory(
+  content: Record<string, unknown>,
+  metadata: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    id: stringToUuid("assistant-mem"),
+    entityId: AGENT_ID,
+    agentId: AGENT_ID,
+    roomId: ROOM_ID,
+    createdAt: 2_000,
+    content: { source: "agent_response", ...content },
+    metadata: { type: "message", ...metadata },
+  };
+}
+
+function userMemory(): Record<string, unknown> {
+  return {
+    id: stringToUuid("user-mem"),
+    entityId: USER_ID,
+    agentId: AGENT_ID,
+    roomId: ROOM_ID,
+    createdAt: 1_000,
+    content: { text: "are you there", source: "api" },
+    metadata: { type: "message" },
+  };
+}
+
+interface CapturedJson {
+  payload: unknown;
+}
+
+function createCtx(
+  method: string,
+  pathname: string,
+  state: ConversationRouteState,
+): {
+  ctx: ConversationRouteContext;
+  record: MockResponseRecord;
+  captured: CapturedJson;
+} {
+  const { res, record } = createMockRes();
+  const captured: CapturedJson = { payload: undefined };
+  const ctx: ConversationRouteContext = {
+    req: createReq(method, pathname),
+    res,
+    method,
+    pathname,
+    state,
+    readJsonBody: vi.fn(async () => ({ prompt: "hello" })),
+    json: vi.fn((_res, payload) => {
+      captured.payload = payload;
+    }),
+    error: vi.fn((response, message, status) => {
+      response.write(`error ${status}: ${message}`);
+      response.end();
+    }),
+  } as unknown as ConversationRouteContext;
+  return { ctx, record, captured };
+}
+
+describe("conversation failureKind round-trip", () => {
+  beforeEach(() => {
+    generateResult = {};
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("GET /messages re-emits failureKind from metadata.chatFailureKind (synthetic fallback)", async () => {
+    const state = createState([
+      userMemory(),
+      assistantMemory(
+        { text: "I'm having trouble reaching the model provider." },
+        { chatFailureKind: "provider_issue" },
+      ),
+    ]);
+    const { ctx, captured } = createCtx(
+      "GET",
+      "/api/conversations/conv-1/messages",
+      state,
+    );
+
+    await handleConversationRoutes(ctx);
+
+    const payload = captured.payload as {
+      messages: Array<{ role: string; failureKind?: string }>;
+    };
+    const assistant = payload.messages.find((m) => m.role === "assistant");
+    expect(assistant).toBeDefined();
+    expect(assistant?.failureKind).toBe("provider_issue");
+  });
+
+  it("GET /messages re-emits failureKind from content.failureKind (live result)", async () => {
+    const state = createState([
+      userMemory(),
+      assistantMemory({
+        text: "Out of credits.",
+        failureKind: "insufficient_credits",
+      }),
+    ]);
+    const { ctx, captured } = createCtx(
+      "GET",
+      "/api/conversations/conv-1/messages",
+      state,
+    );
+
+    await handleConversationRoutes(ctx);
+
+    const payload = captured.payload as {
+      messages: Array<{ role: string; failureKind?: string }>;
+    };
+    const assistant = payload.messages.find((m) => m.role === "assistant");
+    expect(assistant?.failureKind).toBe("insufficient_credits");
+  });
+
+  it("GET /messages omits failureKind for a normal (successful) turn", async () => {
+    const state = createState([
+      userMemory(),
+      assistantMemory({ text: "All good!" }),
+    ]);
+    const { ctx, captured } = createCtx(
+      "GET",
+      "/api/conversations/conv-1/messages",
+      state,
+    );
+
+    await handleConversationRoutes(ctx);
+
+    const payload = captured.payload as {
+      messages: Array<{ role: string; failureKind?: string }>;
+    };
+    const assistant = payload.messages.find((m) => m.role === "assistant");
+    expect(assistant?.failureKind).toBeUndefined();
+  });
+
+  it("streaming `done` frame carries failureKind when the result carries one", async () => {
+    generateResult = { failureKind: "provider_issue" };
+    const state = createState();
+    const { ctx, record } = createCtx(
+      "POST",
+      "/api/conversations/conv-1/messages/stream",
+      state,
+    );
+
+    const done = handleConversationRoutes(ctx);
+    for (let i = 0; i < 12; i++) await new Promise((r) => setImmediate(r));
+    await done;
+
+    const doneFrame = record.writes.find((w) => w.includes('"type":"done"'));
+    expect(doneFrame).toBeDefined();
+    const parsed = JSON.parse(
+      (doneFrame as string).replace(/^data: /, "").trim(),
+    ) as { failureKind?: string };
+    expect(parsed.failureKind).toBe("provider_issue");
+  });
+
+  it("non-streaming JSON response carries failureKind when the result carries one", async () => {
+    generateResult = { failureKind: "insufficient_credits" };
+    const state = createState();
+    const { ctx, captured } = createCtx(
+      "POST",
+      "/api/conversations/conv-1/messages",
+      state,
+    );
+
+    await handleConversationRoutes(ctx);
+
+    const payload = captured.payload as { failureKind?: string };
+    expect(payload.failureKind).toBe("insufficient_credits");
+  });
+});

--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -35,7 +35,11 @@ import {
 } from "@elizaos/shared";
 import type { ElizaConfig } from "../config/config.ts";
 import { resolveStateDir } from "../config/paths.ts";
-import type { ChatGenerationResult, LogEntry } from "./chat-routes.ts";
+import type {
+  ChatFailureKind,
+  ChatGenerationResult,
+  LogEntry,
+} from "./chat-routes.ts";
 import {
   classifyChatFailure,
   generateChatResponse,
@@ -1109,6 +1113,14 @@ type ConversationRouteMessageRecord = {
   rawDiscordMessageId?: string;
   rawSenderId?: string;
   senderEntityId?: string;
+  /**
+   * Synthetic-failure classification for this turn (provider-issue /
+   * no-provider / insufficient-credits / …). Persisted on the failed
+   * assistant memory as `content.failureKind` (live result) or
+   * `metadata.chatFailureKind` (markSyntheticChatFailureContent). Round-tripped
+   * here so the renderer's gate + Retry survive a GET /messages full-replace.
+   */
+  failureKind?: ChatFailureKind;
 };
 
 async function ensureConversationGreetingStored(
@@ -1421,6 +1433,25 @@ export async function handleConversationRoutes(
           const actionCallbackHistory = normalizeActionCallbackHistory(
             content.actionCallbackHistory,
           );
+          // The failed assistant turn carries its classification on the live
+          // result (`content.failureKind`) or, for synthetic fallbacks, on
+          // `metadata.chatFailureKind` (markSyntheticChatFailureContent). Round
+          // it back so the renderer's provider/credits gate + Retry survive the
+          // GET /messages full-replace instead of vanishing.
+          const rawFailureKind =
+            typeof content.failureKind === "string"
+              ? content.failureKind
+              : typeof meta?.chatFailureKind === "string"
+                ? meta.chatFailureKind
+                : undefined;
+          const failureKind: ChatFailureKind | undefined =
+            rawFailureKind === "insufficient_credits" ||
+            rawFailureKind === "no_provider" ||
+            rawFailureKind === "provider_issue" ||
+            rawFailureKind === "rate_limited" ||
+            rawFailureKind === "local_inference"
+              ? rawFailureKind
+              : undefined;
           const role = m.entityId === agentId ? "assistant" : "user";
           const rawText = formatConversationMessageText(
             (m.content as { text?: string })?.text ?? "",
@@ -1502,6 +1533,7 @@ export async function handleConversationRoutes(
             rawSenderId: extractConversationMetaString(m, "fromId"),
             senderEntityId:
               typeof m.entityId === "string" ? m.entityId : undefined,
+            ...(failureKind ? { failureKind } : {}),
           } satisfies ConversationRouteMessageRecord;
         })
         // Drop action-log memories that have no visible text (e.g.
@@ -2065,6 +2097,13 @@ export async function handleConversationRoutes(
             ...(result.actionResults?.length
               ? { actionResults: result.actionResults }
               : {}),
+            // A non-throwing result can still carry a failure classification
+            // (e.g. a canned provider-issue phrase folded into the reply). Mirror
+            // the error branch so the renderer's gate + Retry persist.
+            ...(result.failureKind ? { failureKind: result.failureKind } : {}),
+            ...(result.localInference
+              ? { localInference: result.localInference }
+              : {}),
           });
           deferredPersistence = (async () => {
             if (result.actionCallbackHistory?.length) {
@@ -2361,6 +2400,13 @@ export async function handleConversationRoutes(
           agentName: result.agentName,
           ...(result.actionResults?.length
             ? { actionResults: result.actionResults }
+            : {}),
+          // A non-throwing result can still carry a failure classification
+          // (e.g. a canned provider-issue phrase folded into the reply). Mirror
+          // the error branch so the renderer's gate + Retry persist.
+          ...(result.failureKind ? { failureKind: result.failureKind } : {}),
+          ...(result.localInference
+            ? { localInference: result.localInference }
             : {}),
         });
       } else {

--- a/packages/ui/src/state/useChatSend.test.tsx
+++ b/packages/ui/src/state/useChatSend.test.tsx
@@ -33,6 +33,7 @@ const mocks = vi.hoisted(() => ({
     sendWsMessage: vi.fn(),
     stopCodingAgent: vi.fn(),
     renameConversation: vi.fn(() => Promise.resolve()),
+    truncateConversationMessages: vi.fn(() => Promise.resolve()),
     getBaseUrl: vi.fn(() => ""),
   },
 }));
@@ -719,6 +720,102 @@ describe("useChatSend freeze-on-shared during handoff (PR2)", () => {
       await result.current.sendChatText("hello", { conversationId: "conv-1" });
     });
 
+    expect(mocks.client.sendConversationMessageStream).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("useChatSend retry re-runs the turn in place (no duplicate)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.client.getBaseUrl.mockReturnValue("");
+    mocks.client.renameConversation.mockResolvedValue(undefined);
+    mocks.client.truncateConversationMessages.mockResolvedValue(undefined);
+  });
+
+  function seedFailedTurn(deps: UseChatSendDeps): void {
+    const seeded: ConversationMessage[] = [
+      { id: "u1", role: "user", text: "hello", timestamp: 1 },
+      {
+        id: "a1",
+        role: "assistant",
+        text: "I'm having trouble reaching the model provider.",
+        timestamp: 2,
+        failureKind: "provider_issue",
+      },
+    ];
+    deps.conversationMessagesRef.current = seeded;
+  }
+
+  it("truncates from the user message (inclusive) and resends, leaving exactly one user turn", async () => {
+    // Regression: the old retry only dropped the failed assistant bubble in
+    // memory and resent, producing [Q, fail, Q-dup, new]. The fix mirrors
+    // handleChatEdit — truncate [Q, fail] server-side, then re-run Q in place.
+    mocks.client.sendConversationMessageStream.mockResolvedValue({
+      text: "recovered reply",
+      completed: true,
+    });
+
+    const deps = makeDeps({
+      activeConversationId: "conv-1",
+      conversations: [conversation("conv-1", "room-1")],
+    });
+    seedFailedTurn(deps);
+    const { result } = renderHook(() => useChatSend(deps));
+
+    await act(async () => {
+      await result.current.handleChatRetry("a1");
+    });
+
+    // The turn was truncated from the user message inclusive, in place.
+    expect(mocks.client.truncateConversationMessages).toHaveBeenCalledTimes(1);
+    expect(mocks.client.truncateConversationMessages).toHaveBeenCalledWith(
+      "conv-1",
+      "u1",
+      { inclusive: true },
+    );
+    // The text was resent once (re-run), not as a brand-new extra turn.
+    expect(mocks.client.sendConversationMessageStream).toHaveBeenCalledTimes(1);
+
+    // No duplicate user message: exactly one "hello" user turn remains, and the
+    // failed assistant bubble (a1) is gone.
+    const remaining = deps.conversationMessagesRef.current;
+    const userHellos = remaining.filter(
+      (m) => m.role === "user" && m.text === "hello",
+    );
+    expect(userHellos).toHaveLength(1);
+    expect(remaining.some((m) => m.id === "a1")).toBe(false);
+  });
+
+  it("falls back to in-memory resend for an optimistic (temp-) user turn", async () => {
+    mocks.client.sendConversationMessageStream.mockResolvedValue({
+      text: "recovered reply",
+      completed: true,
+    });
+
+    const deps = makeDeps({
+      activeConversationId: "conv-1",
+      conversations: [conversation("conv-1", "room-1")],
+    });
+    // An optimistic user turn whose server id hasn't landed yet — not safe to
+    // truncate server-side, so retry drops the failed bubble in memory + resends.
+    deps.conversationMessagesRef.current = [
+      { id: "temp-u1", role: "user", text: "hello", timestamp: 1 },
+      {
+        id: "a1",
+        role: "assistant",
+        text: "I'm having trouble reaching the model provider.",
+        timestamp: 2,
+        failureKind: "provider_issue",
+      },
+    ];
+    const { result } = renderHook(() => useChatSend(deps));
+
+    await act(async () => {
+      await result.current.handleChatRetry("a1");
+    });
+
+    // temp- user id → cannot truncate; resend still fires.
+    expect(mocks.client.truncateConversationMessages).not.toHaveBeenCalled();
     expect(mocks.client.sendConversationMessageStream).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/ui/src/state/useChatSend.ts
+++ b/packages/ui/src/state/useChatSend.ts
@@ -1596,37 +1596,72 @@ export function useChatSend(deps: UseChatSendDeps) {
   }, [interruptActiveChatPipeline, ptySessionsRef]);
 
   const handleChatRetry = useCallback(
-    (assistantMsgId: string) => {
-      let retryText: string | null = null;
-      setConversationMessages((prev) => {
-        // Find the interrupted assistant message
-        const assistantIdx = prev.findIndex(
-          (m) => m.id === assistantMsgId && m.role === "assistant",
-        );
-        if (assistantIdx < 0) return prev;
-
-        // Find the preceding user message
-        let userMsg: ConversationMessage | null = null;
-        for (let i = assistantIdx - 1; i >= 0; i--) {
-          if (prev[i].role === "user") {
-            userMsg = prev[i];
-            break;
-          }
+    async (assistantMsgId: string) => {
+      const currentMessages = conversationMessagesRef.current;
+      // Find the failed/interrupted assistant message + its preceding user turn.
+      const assistantIdx = currentMessages.findIndex(
+        (m) => m.id === assistantMsgId && m.role === "assistant",
+      );
+      if (assistantIdx < 0) return;
+      let userIdx = -1;
+      for (let i = assistantIdx - 1; i >= 0; i--) {
+        if (currentMessages[i].role === "user") {
+          userIdx = i;
+          break;
         }
-        if (!userMsg) return prev;
-
-        // Remove the interrupted assistant message
-        const next = prev.filter((m) => m.id !== assistantMsgId);
-
-        retryText = userMsg.text;
-
-        return next;
-      });
-      if (retryText) {
-        void sendChatText(retryText);
       }
+      if (userIdx < 0) return;
+      const userMsg = currentMessages[userIdx];
+      const retryText = userMsg.text;
+      if (!retryText) return;
+
+      const convId = activeConversationIdRef.current;
+      const canTruncate =
+        Boolean(convId) &&
+        userMsg.source !== "local_command" &&
+        !userMsg.id.startsWith("temp-");
+
+      // Preferred path: re-run the turn IN PLACE. Truncate from the user message
+      // (inclusive) so [Q, fail] is removed server-side, then resend Q — exactly
+      // like handleChatEdit. The old behaviour only dropped the assistant bubble
+      // in memory and resent, producing a duplicate [Q, fail, Q-dup, new] turn.
+      if (canTruncate && convId) {
+        interruptActiveChatPipeline();
+        const preservedMessages = currentMessages.slice(0, userIdx);
+        conversationMessagesRef.current = preservedMessages;
+        setConversationMessages(preservedMessages);
+        try {
+          await client.truncateConversationMessages(convId, userMsg.id, {
+            inclusive: true,
+          });
+          await sendChatText(retryText, { conversationId: convId });
+        } catch (err) {
+          await loadConversationMessages(convId);
+          setActionNotice(
+            `Failed to retry message: ${err instanceof Error ? err.message : "network error"}`,
+            "error",
+            4200,
+          );
+        }
+        return;
+      }
+
+      // Fallback (no conversation id yet, optimistic/local user turn): drop the
+      // failed assistant bubble in memory and resend.
+      setConversationMessages((prev) =>
+        prev.filter((m) => m.id !== assistantMsgId),
+      );
+      void sendChatText(retryText);
     },
-    [sendChatText, setConversationMessages],
+    [
+      sendChatText,
+      setConversationMessages,
+      conversationMessagesRef,
+      activeConversationIdRef,
+      interruptActiveChatPipeline,
+      loadConversationMessages,
+      setActionNotice,
+    ],
   );
 
   const handleChatEdit = useCallback(


### PR DESCRIPTION
## What this fixes

The chat **Retry** button and the provider/credits failure gates silently disappeared on reload. When a turn failed (rate-limited, provider issue, no provider, insufficient credits, local-inference fallback), the UI rendered the gate/Retry correctly **in the live SSE frame**, but the classification (`failureKind`) was never persisted in a way the conversation GET re-emitted. So:

- The assistant memory was written with the canned failure reply **text**, but `failureKind` was dropped.
- On the next `GET /conversations/:id/messages` (reload, route change, app relaunch), the failed bubble came back as an ordinary assistant message — **no Retry button, no provider/credits gate**.
- Retry, when it did fire live, re-sent without truncating the stale failed bubble, leaving a duplicate user turn / lingering dead bubble.

This is launch-readiness relevant: the provider/credits gates are how a user understands "you're out of credits / the provider is down, here's what to do," and they evaporated the moment the surface re-rendered.

## The fix

**1. Round-trip `failureKind` through persistence (server).**
`packages/agent/src/api/conversation-routes.ts`
- The GET serializer now reads `failureKind` from **both** sources: the live result's `content.failureKind` and the synthetic fallback's `metadata.chatFailureKind` (written by `markSyntheticChatFailureContent` in `chat-routes.ts`), whitelisting exactly the 5 `ChatFailureKind` values (`rate_limited`, `provider_issue`, `no_provider`, `insufficient_credits`, `local_inference`).
- The robust error paths (streaming + non-streaming) persist the canned reply text; `markSyntheticChatFailureContent` classifies it and writes `metadata.chatFailureKind`, which the GET re-emits. So all gate-relevant kinds survive a reload.
- Success path is unchanged: `failureKind`/`localInference` are added only via **conditional spreads**, so a normal reply emits neither.

**2. Surface it to the UI (client).**
`ConversationMessage` carries `failureKind`; `getConversationMessages` passes it through; `MessageContent.tsx` already renders the `no_provider` gate and the `rate_limited`/`provider_issue` Retry button off `message.failureKind`. So Retry + gates now survive a reload.

**3. Retry truncates + resends in place (client).**
`packages/ui/src/state/useChatSend.ts` — `handleChatRetry` now mirrors the `handleChatEdit` pattern: it finds the failed assistant + preceding user turn, interrupts the pipeline, truncates the transcript back to before the user message (`truncateConversationMessages(convId, userMsg.id, {inclusive:true})`), and resends — no duplicate user message, no lingering failed bubble. A narrow fallback (no conversation id / local command / temp- optimistic id) drops only the failed bubble and resends.

## Reproduction-test evidence

`bun run verify` lane (scoped to touched files) + the new tests:

```
# agent typecheck (filtered to conversation-routes): clean (no output)
# ui typecheck (filtered to useChatSend|client-chat): clean (no output)
# biome check on both touched files: 1 pre-existing warning at useChatSend.ts:1372
#   (useExhaustiveDependencies biome-ignore) — present verbatim on origin/develop,
#   NOT introduced here; my changes are at lines 1598-1665.

packages/agent  (bunx vitest run src/api/__tests__/conversation-failurekind-roundtrip.test.ts)
  Test Files  1 passed (1)
       Tests  5 passed (5)
  # covers: GET re-emit from metadata.chatFailureKind; GET re-emit from
  #   content.failureKind; normal-turn omission; failureKind on the streaming
  #   `done` frame AND the non-streaming json.

packages/ui  (vitest run src/state/useChatSend.test.tsx)
  Test Files  1 passed (1)
       Tests  15 passed (15)
  # 2 new: Retry calls truncate("conv-1","u1",{inclusive:true}) with exactly one
  #   resend, exactly one remaining user "hello", failed bubble gone; temp-id
  #   fallback resends WITHOUT truncate.
```

### PR_EVIDENCE.md matrix

| Evidence | Status |
| --- | --- |
| Reproduction/unit tests (real behavior, not mock-asserting-mock) | **Attached** — agent 5/5, ui 15/15 above; assert the actual round-trip + truncate/resend |
| Backend logs | **N/A** — change is request/response shape + persistence; covered by the agent vitest exercising the real GET serializer and persist paths |
| Frontend logs / network trace | **N/A** — covered by the ui vitest asserting `truncateConversationMessages`/`sendChatText` call shapes |
| Before/after screenshots + video | **N/A (not run)** — gate/Retry rendering in `MessageContent.tsx` is unchanged by this PR; this PR only makes the existing renderer's `message.failureKind` survive a reload. A live on-device capture (provoke a real `insufficient_credits`/`provider_issue`, reload, confirm gate persists) is the recommended human pre-merge check. |
| Real-LLM trajectory | **N/A** — no prompt/model/action behavior changed |

## Relates to

Launch-readiness audit (chat-UX failure surfaces). Sibling to the cloud-api credit-reservation fix (separate PR).
