### PR TITLE
fix(app): block selecting a failed agent in first-run picker + friendly status labels

### DIFF
--- a/packages/ui/src/first-run/AgentPicker.test.tsx
+++ b/packages/ui/src/first-run/AgentPicker.test.tsx
@@ -62,8 +62,9 @@ describe("AgentPicker", () => {
     expect(screen.getByTestId("onboarding-agent-picker")).toBeTruthy();
     expect(screen.getByTestId("onboarding-agent-option-a1")).toBeTruthy();
     expect(screen.getByTestId("onboarding-agent-option-a2")).toBeTruthy();
-    // StatusBadge label is the title-cased status string.
-    expect(screen.getByText("Running")).toBeTruthy();
+    // StatusBadge shows friendly lifecycle copy (agentLifecycleLabel), so a
+    // "running" agent reads "Ready" rather than the raw DB enum.
+    expect(screen.getByText("Ready")).toBeTruthy();
     expect(screen.getByText("Stopped")).toBeTruthy();
 
     fireEvent.click(screen.getByTestId("onboarding-agent-option-a2"));
@@ -165,6 +166,32 @@ describe("AgentPicker", () => {
     );
     expect(row.disabled).toBe(true);
     fireEvent.click(row);
+    expect(onPick).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "error",
+    "failed",
+  ])("disables a %s agent row so chat can't bind to a dead base", (status) => {
+    const onPick = vi.fn();
+    render(
+      <AgentPicker
+        {...props({
+          agents: [agent({ agent_id: "a1", agent_name: "Alpha", status })],
+          onPick,
+        })}
+      />,
+    );
+
+    // Friendly lifecycle copy for a broken agent.
+    expect(screen.getByText("Failed to start")).toBeTruthy();
+    const row = screen.getByTestId<HTMLButtonElement>(
+      "onboarding-agent-option-a1",
+    );
+    expect(row.disabled).toBe(true);
+    fireEvent.click(row);
+    // The failed agent must never be selected into chat — the user recovers
+    // via the always-present "Create new" affordance instead.
     expect(onPick).not.toHaveBeenCalled();
   });
 

--- a/packages/ui/src/first-run/AgentPicker.tsx
+++ b/packages/ui/src/first-run/AgentPicker.tsx
@@ -11,7 +11,7 @@ import type * as React from "react";
 import type { CloudCompatAgent } from "../api/client-types-cloud";
 import { StatusBadge } from "../components/ui/status-badge";
 import {
-  statusLabelForState,
+  agentLifecycleLabel,
   statusToneForState,
 } from "../components/ui/status-badge.helpers";
 
@@ -41,6 +41,19 @@ export interface AgentPickerProps {
 function isDeletingStatus(status: string): boolean {
   const normalized = status.trim().toLowerCase();
   return normalized === "deletion_pending" || normalized === "deleting";
+}
+
+/**
+ * Statuses that mean the agent failed to start — not selectable. Binding chat to
+ * a failed/error agent points the client at an unreachable base that 503s every
+ * message with no recovery (`error`/`failed` are NOT in the server's
+ * RESUMABLE_STATUSES, so nothing auto-recovers). The user recovers via the
+ * always-present "Create new" affordance instead of dead-ending in chat.
+ * Mirrors CloudAgentsSection's ERROR_STATES.
+ */
+function isFailedStatus(status: string): boolean {
+  const normalized = status.trim().toLowerCase();
+  return normalized === "error" || normalized === "failed";
 }
 
 function formatLastActive(agent: CloudCompatAgent): string | null {
@@ -137,8 +150,9 @@ export function AgentPicker({
               const isActive =
                 activeAgentId !== null && agent.agent_id === activeAgentId;
               const deleting = isDeletingStatus(agent.status);
+              const failed = isFailedStatus(agent.status);
               const isBinding = binding && bindingAgentId === agent.agent_id;
-              const disabled = binding || deleting || isActive;
+              const disabled = binding || deleting || failed || isActive;
               const label = agent.agent_name || agent.agent_id;
               const lastActive = formatLastActive(agent);
               return (
@@ -164,7 +178,7 @@ export function AgentPicker({
                         label={
                           deleting
                             ? "Deleting"
-                            : statusLabelForState(agent.status)
+                            : agentLifecycleLabel(agent.status)
                         }
                       />
                     </span>


### PR DESCRIPTION
## What & why

Two contained launch-readiness fixes in the cloud first-run agent picker
(`packages/ui/src/first-run/AgentPicker.tsx`), surfaced by the launch-readiness
onboarding audit.

### Fix 8 — block selecting a FAILED agent (the dead-end bug)

Before this change a user could tap a dedicated agent whose status is
`error`/`failed` in the post-sign-in picker. `onPick` → `finishCloudWithSelection`
binds chat to that agent's base, which is unreachable — so **every message 503s
with no recovery**. `error`/`failed` are **not** in the server's
`RESUMABLE_STATUSES` (`["pending","stopped","disconnected"]` — see
`packages/cloud/api/src/dedicated-agent-proxy.ts` /
`.../agents/[agentId]/pairing-token/route.ts`), so nothing auto-resumes the dead
base. The user is permanently stuck in a 503'ing chat.

Fix: treat `error`/`failed` like the existing non-selectable `deletion_pending`
state. A new `isFailedStatus()` helper (mirrors `CloudAgentsSection`'s
`ERROR_STATES = new Set(["error","failed"])`) feeds the row's `disabled`
computation, so a failed row is non-clickable and `onPick` is never called for
it. The badge shows the friendly **"Failed to start"** (danger/red tone via the
existing `statusToneForState`). The user recovers via the always-present
**"Create new"** affordance instead of dead-ending in chat.

This matches the file's existing pattern (`isDeletingStatus` → `disabled`)
rather than inventing a new per-agent recreate prop/controller wiring.

### Fix 9 — friendly status labels (polish, same file)

The badge previously rendered the raw title-cased DB enum via
`statusLabelForState` (e.g. "Running", "Provisioning", "Resuming"). Swapped to
`agentLifecycleLabel()` (the helper purpose-built for user-facing lifecycle
copy), so the badge reads "Ready" / "Setting up" / "Starting up" / "Failed to
start", consistent with `CloudAgentsSection`. Tone is unchanged
(`statusToneForState`), and the `deleting → "Deleting"` special-case is kept.
States not in the lifecycle map (Disconnected/Pending) fall back to the
title-cased label — intentional and fine.

## Changes

- `packages/ui/src/first-run/AgentPicker.tsx`
  - import `agentLifecycleLabel` (replaces now-unused `statusLabelForState`)
  - new `isFailedStatus(status)` helper (`error` | `failed`)
  - row selectability: `disabled = binding || deleting || failed || isActive`
  - badge label: `deleting ? "Deleting" : agentLifecycleLabel(agent.status)`
- `packages/ui/src/first-run/AgentPicker.test.tsx`
  - updated the existing label assertion (`"Running"` → `"Ready"`)
  - added a parameterized test asserting an `error`/`failed` row is disabled,
    labeled "Failed to start", and never fires `onPick`

## Evidence (per PR_EVIDENCE.md)

- **Unit/component tests** (`bun run --cwd packages/ui test AgentPicker`):
  `Test Files 1 passed (1) · Tests 9 passed (9)`. Covers the new
  error/failed-not-selectable behavior + the friendly-label change.
- **Typecheck** (`bun run --cwd packages/ui typecheck`): clean on the touched
  files (no `AgentPicker`/`first-run` diagnostics).
- **Lint/format** (`bunx biome check` on both files): clean.
- **Before/after behavior** (described):
  - *Before:* tapping a red `error`/`failed` agent → chat binds to a dead base →
    every message returns 503, no recovery path.
  - *After:* the failed row is greyed/non-clickable with a red "Failed to start"
    badge; the user taps "Create new" to get a working agent.
- **Screenshots / video walkthrough: N/A.** The picker only renders after a live
  Eliza Cloud OAuth sign-in that returns an org with a real `error`/`failed`
  dedicated agent — not reproducible in a headless worktree, and forcing it via
  injected client state was avoided per the "no hacky on-device tests" rule. The
  behavior is fully pinned by the added component test (disabled row + `onPick`
  never called). Real-LLM trajectory / audio / per-platform capture are N/A
  (presentational UI gating only; no agent/model/prompt or native surface
  touched).

Surgical, ESM, no `as any`, no business logic in render.
