### PR TITLE
fix(ui): restore Tests lane — no-focus-ring gate green

### DIFF
--- a/packages/ui/src/cloud-ui/components/auth/authorize-content.tsx
+++ b/packages/ui/src/cloud-ui/components/auth/authorize-content.tsx
@@ -404,7 +404,7 @@ function InlineCancelButton({ onCancel }: { onCancel: () => void }) {
     <button
       type="button"
       onClick={onCancel}
-      className="min-h-10 cursor-pointer rounded-sm px-3 text-sm text-white/50 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#FF5800]/60"
+      className="min-h-10 cursor-pointer rounded-sm px-3 text-sm text-white/50 transition-colors hover:text-white"
     >
       Cancel
     </button>


### PR DESCRIPTION
## Summary

The Tests CI workflow on `develop` was red. This PR fixes the one genuine source regression in the unit lane.

## Root cause analysis

The original report (CI run 28340432631, commit 5572341) listed many `@elizaos/ui` failures (springboard→launcher rename, col-span, Apps page 2, etc.) and one `@elizaos/plugin-anthropic` failure (`honors a per-call model override` → `expected undefined to be 'claude-workflow'`). Reproducing against current `origin/develop`:

- **Most listed ui failures were already reconciled on develop** since 5572341 (the springboard→launcher rename test/source already agree on `home-launcher-indicator`; col-span / Apps-page-2 / icon-order assertions all pass). They no longer reproduce.
- **The plugin-anthropic failure no longer reproduces** either — all 21 tests pass once `@elizaos/core` is built. The failures only appear when `packages/core/dist` is absent (Vite "Failed to resolve entry for package @elizaos/core"), which CI's prebuild handles. No source regression remains.
- **The one real remaining unit failure** is `packages/ui/src/no-focus-ring-gate.test.ts`: the `InlineCancelButton` in `cloud-ui/components/auth/authorize-content.tsx` (added by the recent embed-auth/RoleGate work) used `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#FF5800]/60`, which the gate forbids across authored UI source.

## Fix

Removed the focus-visible/ring utilities from `InlineCancelButton`; it keeps its `hover:text-white` affordance. This is the correct side to fix — the gate is an intentional, repo-wide design rule (no Tailwind focus/ring utilities in authored UI), so the stray utilities are the bug, not the test.

## Files changed
- `packages/ui/src/cloud-ui/components/auth/authorize-content.tsx`

## Test results

`bun run --cwd packages/ui test`
```
Test Files  425 passed (425)
     Tests  4550 passed | 14 skipped (4564)
```

`bun run --cwd plugins/plugin-anthropic test` (with core built)
```
Test Files  4 passed | 1 skipped (5)
     Tests  21 passed | 2 skipped (23)
```

## Zero-Key jobs
Not addressed (e2e/environmental). They are unrelated to this unit-lane gate; nothing here touches the app browser / scenario-runner / deterministic-e2e paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)