### PR TITLE
fix(app): force re-auth on stale Steward token instead of false connected state

### DIFF
--- a/packages/ui/src/state/cloud-steward-login.test.ts
+++ b/packages/ui/src/state/cloud-steward-login.test.ts
@@ -9,6 +9,22 @@ import {
 
 const STEWARD_TOKEN_KEY = "steward_session_token";
 
+/** Build a minimal (unsigned) JWT whose payload carries the given `exp`. */
+function makeJwt(expSecondsFromNow: number | null): string {
+  const enc = (obj: unknown) =>
+    btoa(JSON.stringify(obj))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+  const header = enc({ alg: "none", typ: "JWT" });
+  const payload = enc(
+    expSecondsFromNow === null
+      ? {}
+      : { exp: Math.floor(Date.now() / 1000) + expSecondsFromNow },
+  );
+  return `${header}.${payload}.sig`;
+}
+
 describe("cloud-steward-login seam", () => {
   beforeEach(() => {
     localStorage.removeItem(STEWARD_TOKEN_KEY);
@@ -23,18 +39,71 @@ describe("cloud-steward-login seam", () => {
     expect(hasStewardLoginLauncher()).toBe(false);
   });
 
-  it("resolves immediately with the stored Steward token (no launcher call)", async () => {
-    localStorage.setItem(STEWARD_TOKEN_KEY, "existing-jwt");
+  it("resolves immediately with an opaque stored token (device-code/Remote, no launcher call)", async () => {
+    // Non-JWT opaque session tokens have no decodable `exp` → left to the legacy
+    // flow (preserved), so they still short-circuit.
+    localStorage.setItem(STEWARD_TOKEN_KEY, "opaque-device-code-token");
     const launcher = vi.fn(async () => ({ token: "launcher-jwt" }));
     const unregister = registerStewardLoginLauncher(launcher);
     try {
       await expect(launchStewardLogin()).resolves.toEqual({
-        token: "existing-jwt",
+        token: "opaque-device-code-token",
       });
       expect(launcher).not.toHaveBeenCalled();
     } finally {
       unregister();
     }
+  });
+
+  it("short-circuits on a still-valid Steward JWT (no launcher call)", async () => {
+    const token = makeJwt(600);
+    localStorage.setItem(STEWARD_TOKEN_KEY, token);
+    const launcher = vi.fn(async () => ({ token: "launcher-jwt" }));
+    const unregister = registerStewardLoginLauncher(launcher);
+    try {
+      await expect(launchStewardLogin()).resolves.toEqual({ token });
+      expect(launcher).not.toHaveBeenCalled();
+    } finally {
+      unregister();
+    }
+  });
+
+  it("forces re-auth on an expired Steward JWT (clears stale token, invokes launcher)", async () => {
+    localStorage.setItem(STEWARD_TOKEN_KEY, makeJwt(-60));
+    const launcher = vi.fn(async () => ({ token: "fresh-jwt" }));
+    const unregister = registerStewardLoginLauncher(launcher);
+    try {
+      await expect(launchStewardLogin()).resolves.toEqual({
+        token: "fresh-jwt",
+      });
+      expect(launcher).toHaveBeenCalledTimes(1);
+      // Stale token must be drained so it can't 401 later flows in a loop.
+      expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
+    } finally {
+      unregister();
+    }
+  });
+
+  it("forces re-auth on a JWT expiring within the safety margin", async () => {
+    localStorage.setItem(STEWARD_TOKEN_KEY, makeJwt(5));
+    const launcher = vi.fn(async () => ({ token: "fresh-jwt" }));
+    const unregister = registerStewardLoginLauncher(launcher);
+    try {
+      await expect(launchStewardLogin()).resolves.toEqual({
+        token: "fresh-jwt",
+      });
+      expect(launcher).toHaveBeenCalledTimes(1);
+    } finally {
+      unregister();
+    }
+  });
+
+  it("clears the stale token and throws when an expired JWT has no launcher", async () => {
+    localStorage.setItem(STEWARD_TOKEN_KEY, makeJwt(-60));
+    await expect(launchStewardLogin()).rejects.toThrow(
+      /Steward login surface is not mounted/,
+    );
+    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
   });
 
   it("invokes the registered launcher when no token is stored", async () => {

--- a/packages/ui/src/state/cloud-steward-login.ts
+++ b/packages/ui/src/state/cloud-steward-login.ts
@@ -18,11 +18,37 @@
  * the shell-router's lazy cloud path.
  */
 
-import { readStoredStewardToken } from "@elizaos/shared/steward-session-client";
+import {
+  clearStoredStewardToken,
+  readStoredStewardToken,
+} from "@elizaos/shared/steward-session-client";
+import { cloudTokenSecsRemaining } from "../api/client-cloud";
 
 export interface StewardLoginResult {
   /** The Steward session JWT now present in localStorage. */
   token: string;
+}
+
+/**
+ * Minimum lifetime (seconds) a stored Steward JWT must still have for the
+ * short-circuit to trust it. A token at or under this margin is treated as
+ * already dead: rather than hand the caller an expired session (which would
+ * 401 the agent picker / subsequent calls in a loop) we clear it and force a
+ * real re-auth.
+ */
+const STEWARD_TOKEN_MIN_VALID_SECS = 10;
+
+/**
+ * Whether a stored Steward token can be trusted to short-circuit sign-in.
+ * Opaque (non-JWT) device-code / Remote session tokens have no decodable `exp`
+ * (`cloudTokenSecsRemaining` → null) and are left to the legacy flow, matching
+ * the cloud token-lifecycle refresh which also no-ops on a null result. A JWT
+ * is usable only while it has more than a small safety margin of life left.
+ */
+function isStoredStewardTokenUsable(token: string): boolean {
+  const secs = cloudTokenSecsRemaining(token);
+  if (secs === null) return true; // opaque/device-code token — not our concern
+  return secs > STEWARD_TOKEN_MIN_VALID_SECS;
 }
 
 /**
@@ -55,14 +81,20 @@ export function hasStewardLoginLauncher(): boolean {
 }
 
 /**
- * Drive the Cloud=Steward sign-in. If a session token is already stored we
- * resolve immediately; otherwise we invoke the registered launcher. Throws when
- * no launcher is registered (the shell-router has not mounted the Cloud
- * provider) so the caller can fall back to a legacy path during migration.
+ * Drive the Cloud=Steward sign-in. If a *still-valid* session token is already
+ * stored we resolve immediately; otherwise we invoke the registered launcher.
+ * A stored-but-expired Steward JWT must NOT short-circuit — doing so produces a
+ * false "connected" state whose subsequent authed calls 401 in a loop — so we
+ * drain the stale value and fall through to a real re-auth. Throws when no
+ * launcher is registered (the shell-router has not mounted the Cloud provider)
+ * so the caller can fall back to a legacy path during migration.
  */
 export async function launchStewardLogin(): Promise<StewardLoginResult> {
   const existing = readStoredStewardToken()?.trim();
-  if (existing) return { token: existing };
+  if (existing && isStoredStewardTokenUsable(existing)) {
+    return { token: existing };
+  }
+  if (existing) clearStoredStewardToken();
 
   if (!registeredLauncher) {
     throw new Error(

--- a/packages/ui/src/state/useCloudState.ts
+++ b/packages/ui/src/state/useCloudState.ts
@@ -486,15 +486,27 @@ export function useCloudState({
         closePrePoppedWindow();
         try {
           await launchStewardLogin();
-          await pollCloudCredits();
+          // Gate the connected state + success toast on an ACTUAL authed status
+          // call. `launchStewardLogin` short-circuits on a stored token; if that
+          // token is stale/revoked the status poll reports disconnected, so
+          // declaring "connected" + toasting here would be a false success that
+          // 401s the agent picker in a loop. Only celebrate a verified session;
+          // otherwise surface the re-auth path the login UI already renders.
+          const connected = await pollCloudCredits();
           await loadWalletConfig().catch(() => undefined);
-          setElizaCloudConnected(true);
-          setElizaCloudLoginError(null);
-          setActionNotice(
-            "Logged in to Eliza Cloud successfully.",
-            "success",
-            6000,
-          );
+          if (connected) {
+            setElizaCloudConnected(true);
+            setElizaCloudLoginError(null);
+            setActionNotice(
+              "Logged in to Eliza Cloud successfully.",
+              "success",
+              6000,
+            );
+          } else {
+            setElizaCloudLoginError(
+              "Could not verify your Eliza Cloud session. Please sign in again.",
+            );
+          }
         } catch (err) {
           setElizaCloudLoginError(
             err instanceof Error ? err.message : "Eliza Cloud login failed",


### PR DESCRIPTION
## Problem

A launch-readiness audit found a sign-in reliability defect in the Cloud =
Steward flow: a **stale/expired Steward auth token short-circuits sign-in and
produces a false "connected" state plus a success toast**, after which the agent
picker and every subsequent authed call **401s in a loop**.

Two cooperating bugs:

1. **`packages/ui/src/state/cloud-steward-login.ts` — `launchStewardLogin()`**
   short-circuited on *any* stored Steward token without validating it. An
   expired JWT was handed straight back as if it were a live session.

2. **`packages/ui/src/state/useCloudState.ts` — `handleCloudLogin()` Steward
   branch** fired `setElizaCloudConnected(true)` **and** the
   "Logged in to Eliza Cloud successfully." toast **unconditionally** on the
   short-circuit path — the `await pollCloudCredits()` result (the real
   "did the authed call succeed" signal) was discarded.

Together: stale token → instant short-circuit → unconditional success → UI
claims connected → agent picker calls 401 forever.

## Fix (minimal, happy-path preserving)

**`cloud-steward-login.ts`** — validate the stored token before short-circuiting,
reusing the existing `cloudTokenSecsRemaining()` helper (`api/client-cloud.ts`):

- Valid JWT (more than a small safety margin of life left) → short-circuit as
  before (happy path unchanged).
- Expired / about-to-expire JWT → **clear the stale token and fall through to
  the real auth launcher** (force re-auth); if no launcher is mounted, throw the
  existing "sign-in unavailable" error instead of a false success.
- Opaque / non-JWT token (`cloudTokenSecsRemaining` → `null`, e.g. the legacy
  device-code / Remote session) → still short-circuits, exactly as before. This
  mirrors the mount-time `checkAndRefresh` lifecycle, which also no-ops on a
  `null` result, so the device-code path is preserved.

**`useCloudState.ts`** — gate the connected state + success toast on the
**actual** `pollCloudCredits()` result. On a verified connection it sets
connected + toasts as before; on failure it does **not** claim connected and
surfaces the re-auth path the login UI already renders
(`setElizaCloudLoginError(...)`) instead of a false-success toast.
`pollCloudCredits()` returns the genuine server `connected` status (direct mode
hits `/api/v1/user` with the Bearer token → `connected:false` on 401; proxy mode
hits `/api/cloud/status`), so a stale/revoked token now correctly resolves to
"not connected → re-auth".

The independent `StewardProviderRuntime` mount-time `checkAndRefresh` self-heal
is untouched — this PR fixes the separate unconditional-success-signaling defect.

Only the **stale/expired-token** path changes. A valid token still connects and
toasts as before.

## Evidence (per PR_EVIDENCE.md)

**Lint** — `bunx biome check` on all touched files:
```
Checked 3 files in 39ms. No fixes applied.
```

**Typecheck** — `bun run --cwd packages/ui typecheck`, filtered to touched files:
```
$ ... | grep -iE "cloud-steward-login|useCloudState"
(no matches — both touched files are clean)
```
The package has 58 pre-existing, unrelated typecheck errors on `develop`
(accounts / contracts / wallet / hooks — e.g. `AccountCard.tsx`,
`service-routing.ts`, `useWalletState.ts`); none are in the files this PR
touches. Full run executed (exit 1 from the pre-existing backlog), 58 `error TS`
lines, zero referencing the touched files.

**Frontend unit tests** — `bun run --cwd packages/ui test cloud-steward-login`:
```
 Test Files  1 passed (1)
      Tests  9 passed (9)
```
New/updated cases assert the validity gate end-to-end via the public
`launchStewardLogin()` seam:
- valid JWT → short-circuits, launcher NOT called;
- opaque/device-code token → still short-circuits (legacy path preserved);
- expired JWT → stale token cleared + launcher invoked (force re-auth);
- JWT within the safety margin → force re-auth;
- expired JWT with no launcher → stale token cleared + throws.

> Note: a fresh worktree needs the core i18n generated file
> (`packages/core/src/i18n/generated/validation-keyword-data.ts`, produced by
> core's `prebuild`) before any UI test that transitively imports `@elizaos/core`
> can load — generated here via
> `node ../shared/scripts/generate-keywords.mjs --target ts`. This is a
> pre-existing build prerequisite, not introduced by this PR (the pre-existing
> `client-cloud-steward-token.test.ts` fails identically without it).

**Screenshots / video walkthrough** — **N/A.** Reproducing the bug requires a
live OAuth session that has expired server-side (or a revoked Steward JWT in
localStorage); it is not reproducible in a headless capture harness. The behavior
change is covered by the unit tests above. The `useCloudState` connected+toast
gating itself is not exercised by a rendered-hook test (it lives inside the large
`AppContext` hook); it is verified by reasoning + the proven `pollCloudCredits()`
return semantics and is called out honestly here.

## Relates to

Launch-readiness sign-in reliability audit (Tier-3 "steward false-success"
finding).
