### PR TITLE
fix(ui): guard conversation swipe interleavings

### DIFF
--- a/.github/issue-evidence/9954-conversation-nav-interleaving.md
+++ b/.github/issue-evidence/9954-conversation-nav-interleaving.md
@@ -1,0 +1,80 @@
+# Conversation Nav Interleaving Evidence
+
+Issue: #9954 chat-ux conversation-nav interleaving
+Date: 2026-06-29
+Machine: Windows, PowerShell, Bun 1.4.0-canary.1, Node 24
+
+## Change
+
+This PR chunk addresses the cheapest, highest-confidence part of #9954:
+conversation-swipe interleavings.
+
+- Extracted pure adjacent-conversation navigation to
+  `packages/ui/src/components/shell/conversation-nav.ts`.
+- Added `resolveAdjacentConversationId`, so hook-level callbacks can resolve the
+  latest adjacent target at gesture time instead of trusting a stale closure.
+- Kept `buildConversationNav` re-exported from `useShellController.ts` for
+  compatibility with existing tests/imports.
+- Added a conversation-transition busy ref tied to the existing loading sequence
+  so a second swipe during an in-flight select/create is dropped.
+- Added a fast-check generated interleaving test for the pure most-recent-first
+  nav invariants.
+- Added hook regression tests for:
+  - dropping a second stale swipe while the first switch is pending;
+  - re-resolving an old callback against the latest active conversation after a
+    rerender.
+
+## Validation
+
+```text
+$ bun run biome check --config-path biome.json --files-ignore-unknown=true --no-errors-on-unmatched packages\ui\src\components\shell\conversation-nav.ts packages\ui\src\components\shell\useShellController.ts packages\ui\src\components\shell\conversation-nav.test.ts packages\ui\src\components\shell\__tests__\useShellController.test.tsx
+Checked 4 files in 1691ms. No fixes applied.
+```
+
+```text
+$ bun run --cwd packages/ui test -- src/components/shell/conversation-nav.test.ts
+Test Files  1 passed (1)
+Tests       8 passed (8)
+```
+
+```text
+$ git diff --check
+# no output
+```
+
+## Local Blockers
+
+The hook regression file cannot run on this workstation because the local Bun
+dependency store is incomplete before the test imports:
+
+```text
+$ bun run --cwd packages/ui test -- src/components/shell/__tests__/useShellController.test.tsx
+Error: Cannot find module '...node_modules\.bun\drizzle-orm@0.45.2...\node_modules\drizzle-orm\table.utils.js'
+```
+
+The package typecheck is also blocked by the current local dependency/type graph,
+starting with Drizzle and missing charting/runtime types:
+
+```text
+$ bun run --cwd packages/ui typecheck
+../cloud/shared/src/db/client.ts(33,55): error TS2344: Type 'ExtractTablesWithRelations<...>' does not satisfy the constraint 'TablesRelationalConfig'.
+../cloud/shared/src/db/schemas/ad-accounts.ts(1,15): error TS2305: Module '"drizzle-orm"' has no exported member 'InferInsertModel'.
+src/cloud/analytics/_components/projections-chart.tsx(23,8): error TS2307: Cannot find module 'recharts' or its corresponding type declarations.
+```
+
+Those failures occur outside the changed shell nav files and match the broader
+Windows dependency-store limitation noted in the current issue-board triage.
+
+The repo-required app visual audit was attempted because this touches
+`packages/ui`, but it is blocked by an existing Windows UI-smoke launcher issue:
+
+```text
+$ bun run --cwd packages/app audit:app
+Error: spawn bun ENOENT
+  syscall: 'spawn bun'
+  path: 'bun'
+  spawnargs: [ 'run', 'build:views' ]
+```
+
+This branch does not change visible layout or styling; the audit blocker is
+queued as a separate workflow-fix follow-up.

--- a/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
@@ -279,6 +279,58 @@ describe("useShellController — conversation loading watchdog", () => {
     expect(appMock.value.handleSelectConversation).toHaveBeenCalledWith("b");
     expect(result.current.conversationLoading).toBe(false);
   });
+
+  it("drops stale swipe callbacks while a conversation switch is pending", async () => {
+    let resolveSwitch: (() => void) | undefined;
+    appMock.value.conversations = [{ id: "a" }, { id: "b" }, { id: "c" }];
+    appMock.value.activeConversationId = "b";
+    appMock.value.handleSelectConversation = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSwitch = resolve;
+        }),
+    );
+
+    const { result } = renderHook(() => useShellController());
+    const staleNav = result.current.conversationNav;
+
+    act(() => {
+      staleNav.goNext();
+      staleNav.goPrev();
+    });
+
+    expect(
+      appMock.value.handleSelectConversation,
+    ).toHaveBeenCalledExactlyOnceWith("c");
+    expect(result.current.conversationLoading).toBe(true);
+
+    await act(async () => {
+      resolveSwitch?.();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(result.current.conversationLoading).toBe(false);
+  });
+
+  it("re-resolves a stale swipe callback against the latest active conversation", async () => {
+    appMock.value.conversations = [{ id: "a" }, { id: "b" }, { id: "c" }];
+    appMock.value.activeConversationId = "b";
+
+    const { result, rerender } = renderHook(() => useShellController());
+    const staleNav = result.current.conversationNav;
+
+    appMock.value.activeConversationId = "a";
+    rerender();
+
+    await act(async () => {
+      staleNav.goNext();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(
+      appMock.value.handleSelectConversation,
+    ).toHaveBeenCalledExactlyOnceWith("b");
+    expect(result.current.conversationLoading).toBe(false);
+  });
 });
 
 // ── Rich turn status derivation (#8813) ──────────────────────────────────────

--- a/packages/ui/src/components/shell/conversation-nav.test.ts
+++ b/packages/ui/src/components/shell/conversation-nav.test.ts
@@ -1,6 +1,10 @@
+import fc from "fast-check";
 import { describe, expect, it, vi } from "vitest";
 import type { Conversation } from "../../api/client-types-chat";
-import { buildConversationNav } from "./useShellController";
+import {
+  buildConversationNav,
+  resolveAdjacentConversationId,
+} from "./conversation-nav";
 
 /**
  * The conversation list is most-recent-first, so index 0 is the newest. "prev"
@@ -90,5 +94,71 @@ describe("buildConversationNav", () => {
       nav.goNext();
     }
     expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("resolves adjacent ids without invoking a selection callback", () => {
+    expect(resolveAdjacentConversationId(LIST, "b", "prev")).toBe("a");
+    expect(resolveAdjacentConversationId(LIST, "b", "next")).toBe("c");
+    expect(resolveAdjacentConversationId(LIST, "a", "prev")).toBeNull();
+    expect(resolveAdjacentConversationId(LIST, "c", "next")).toBeNull();
+    expect(resolveAdjacentConversationId(LIST, "missing", "next")).toBeNull();
+  });
+
+  it("preserves most-recent-first invariants across generated interleavings", () => {
+    type Step = "prev" | "next" | "new" | "selectNewest" | "selectOldest";
+
+    fc.assert(
+      fc.property(
+        fc.array(
+          fc.constantFrom<Step>(
+            "prev",
+            "next",
+            "new",
+            "selectNewest",
+            "selectOldest",
+          ),
+          { minLength: 1, maxLength: 50 },
+        ),
+        (steps) => {
+          let list = [conv("a"), conv("b"), conv("c")];
+          let activeId = "b";
+          let created = 0;
+
+          const assertNavInvariants = () => {
+            const nav = buildConversationNav(list, activeId, (id) => {
+              activeId = id;
+            });
+            const index = list.findIndex((item) => item.id === activeId);
+            expect(index).toBeGreaterThanOrEqual(0);
+            expect(nav.activeId).toBe(activeId);
+            expect(nav.index).toBe(index);
+            expect(nav.hasPrev).toBe(index > 0);
+            expect(nav.hasNext).toBe(index < list.length - 1);
+            return nav;
+          };
+
+          for (const step of steps) {
+            const nav = assertNavInvariants();
+            if (step === "prev") {
+              nav.goPrev();
+            } else if (step === "next") {
+              nav.goNext();
+            } else if (step === "new") {
+              const id = `new-${created}`;
+              created += 1;
+              list = [conv(id), ...list];
+              activeId = id;
+            } else if (step === "selectNewest") {
+              activeId = list[0].id;
+            } else {
+              activeId = list[list.length - 1].id;
+            }
+          }
+
+          assertNavInvariants();
+        },
+      ),
+      { numRuns: 100 },
+    );
   });
 });

--- a/packages/ui/src/components/shell/conversation-nav.ts
+++ b/packages/ui/src/components/shell/conversation-nav.ts
@@ -1,0 +1,78 @@
+import type { Conversation } from "../../api/client-types-chat";
+
+/** Adjacent-conversation navigation for the overlay's horizontal swipe. */
+export interface ConversationNav {
+  /** A newer conversation exists to swipe toward. */
+  hasPrev: boolean;
+  /** An older conversation exists to swipe toward. */
+  hasNext: boolean;
+  /** Select the newer (previous) conversation. */
+  goPrev: () => void;
+  /** Select the older (next) conversation. */
+  goNext: () => void;
+  /** The active conversation's id, or null when none is selected/known. */
+  activeId: string | null;
+  /** The active conversation's position in the most-recent-first list, or -1
+   *  when it isn't in the list (new/not-found). Surfaced on the chat-sheet DOM so
+   *  flows like the tutorial can observe a switch/new-chat without reaching into
+   *  controller internals. */
+  index: number;
+}
+
+export type ConversationNavDirection = "prev" | "next";
+
+export function resolveAdjacentConversationId(
+  conversations: readonly Pick<Conversation, "id">[] | null | undefined,
+  activeConversationId: string | null | undefined,
+  direction: ConversationNavDirection,
+): string | null {
+  const list = Array.isArray(conversations) ? conversations : [];
+  const index = list.findIndex((c) => c.id === activeConversationId);
+  const targetIndex = direction === "prev" ? index - 1 : index + 1;
+  if (index < 0 || targetIndex < 0 || targetIndex >= list.length) {
+    return null;
+  }
+  return list[targetIndex]?.id ?? null;
+}
+
+/**
+ * Pure adjacent-conversation navigation for the overlay's horizontal swipe
+ * (#8929). The list is most-recent-first, so "prev" moves toward the newer
+ * (lower index) conversation and "next" toward the older (higher index) one.
+ * `hasPrev`/`hasNext` drive the swipe edge hints; `goPrev`/`goNext` select the
+ * adjacent conversation by id. When the active conversation isn't in the list
+ * (not-found), neither direction is navigable. Extracted as a pure function so
+ * the index-walk is unit-testable without rendering the AppContext-bound hook.
+ */
+export function buildConversationNav(
+  conversations: readonly Pick<Conversation, "id">[] | null | undefined,
+  activeConversationId: string | null | undefined,
+  onSelect: (id: string) => void,
+): ConversationNav {
+  const list = Array.isArray(conversations) ? conversations : [];
+  const index = list.findIndex((c) => c.id === activeConversationId);
+  const hasPrev = index > 0;
+  const hasNext = index >= 0 && index < list.length - 1;
+  const prevId = resolveAdjacentConversationId(
+    list,
+    activeConversationId,
+    "prev",
+  );
+  const nextId = resolveAdjacentConversationId(
+    list,
+    activeConversationId,
+    "next",
+  );
+  return {
+    hasPrev,
+    hasNext,
+    goPrev: () => {
+      if (prevId) onSelect(prevId);
+    },
+    goNext: () => {
+      if (nextId) onSelect(nextId);
+    },
+    activeId: activeConversationId ?? null,
+    index,
+  };
+}

--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -2,7 +2,6 @@ import type { TranscriptSegment } from "@elizaos/shared/transcripts";
 import * as React from "react";
 import type {
   ChatTurnStatus,
-  Conversation,
   ImageAttachment,
 } from "../../api/client-types-chat";
 import {
@@ -41,9 +40,24 @@ import {
 import { buildVoiceTurnSignal } from "../../voice/voice-turn-signal";
 import { matchWakeName } from "../../voice/wake-name-match";
 import { useHomeModelStatus } from "../local-inference/useHomeModelStatus";
+import {
+  buildConversationNav,
+  type ConversationNav,
+  type ConversationNavDirection,
+  resolveAdjacentConversationId,
+} from "./conversation-nav";
 import { dispatchHomeLauncherNavigation } from "./home-launcher-events";
 import type { ShellMessage, ShellPhase } from "./shell-state";
 import { useShellVoiceOutput } from "./useShellVoiceOutput";
+
+export type {
+  ConversationNav,
+  ConversationNavDirection,
+} from "./conversation-nav";
+export {
+  buildConversationNav,
+  resolveAdjacentConversationId,
+} from "./conversation-nav";
 
 /** Upper bound (ms) the conversation-switch / clear loading spinner may show
  *  before it is force-cleared — see `runWithConversationLoading`. */
@@ -168,57 +182,6 @@ export interface ShellController {
   conversationLoading?: boolean;
 }
 
-/** Adjacent-conversation navigation for the overlay's horizontal swipe. */
-export interface ConversationNav {
-  /** A newer conversation exists to swipe toward. */
-  hasPrev: boolean;
-  /** An older conversation exists to swipe toward. */
-  hasNext: boolean;
-  /** Select the newer (previous) conversation. */
-  goPrev: () => void;
-  /** Select the older (next) conversation. */
-  goNext: () => void;
-  /** The active conversation's id, or null when none is selected/known. */
-  activeId: string | null;
-  /** The active conversation's position in the most-recent-first list, or -1
-   *  when it isn't in the list (new/not-found). Surfaced on the chat-sheet DOM so
-   *  flows like the tutorial can observe a switch/new-chat without reaching into
-   *  controller internals. */
-  index: number;
-}
-
-/**
- * Pure adjacent-conversation navigation for the overlay's horizontal swipe
- * (#8929). The list is most-recent-first, so "prev" moves toward the newer
- * (lower index) conversation and "next" toward the older (higher index) one.
- * `hasPrev`/`hasNext` drive the swipe edge hints; `goPrev`/`goNext` select the
- * adjacent conversation by id. When the active conversation isn't in the list
- * (not-found), neither direction is navigable. Extracted as a pure function so
- * the index-walk is unit-testable without rendering the AppContext-bound hook.
- */
-export function buildConversationNav(
-  conversations: readonly Pick<Conversation, "id">[] | null | undefined,
-  activeConversationId: string | null | undefined,
-  onSelect: (id: string) => void,
-): ConversationNav {
-  const list = Array.isArray(conversations) ? conversations : [];
-  const index = list.findIndex((c) => c.id === activeConversationId);
-  const hasPrev = index > 0;
-  const hasNext = index >= 0 && index < list.length - 1;
-  return {
-    hasPrev,
-    hasNext,
-    goPrev: () => {
-      if (hasPrev) onSelect(list[index - 1].id);
-    },
-    goNext: () => {
-      if (hasNext) onSelect(list[index + 1].id);
-    },
-    activeId: activeConversationId ?? null,
-    index,
-  };
-}
-
 /**
  * Bridges the shell foundation (HomePill + AssistantOverlay + ChatSurface) to
  * the real agent message flow exposed by {@link useApp}. Replaces the v1
@@ -291,6 +254,10 @@ export function useShellController(): ShellController {
   // Live server-reported phase of the in-flight turn (from the chat-send SSE),
   // read from its dedicated context so status events re-render only chat surfaces.
   const { serverTurnStatus } = useChatTurnStatus();
+  const conversationsRef = React.useRef(conversations);
+  const activeConversationIdRef = React.useRef(activeConversationId);
+  conversationsRef.current = conversations;
+  activeConversationIdRef.current = activeConversationId;
 
   // Jump to Settings from the chat's no_provider gate. Stable identity.
   const openSettings = React.useCallback(() => setTab("settings"), [setTab]);
@@ -312,12 +279,20 @@ export function useShellController(): ShellController {
   // renders the spinner when the visible thread is still empty.
   const [conversationLoading, setConversationLoading] = React.useState(false);
   const conversationLoadingSeqRef = React.useRef(0);
+  const conversationTransitionBusyRef = React.useRef(false);
 
   const runWithConversationLoading = React.useCallback(
     (task: () => Promise<unknown>) => {
       const seq = conversationLoadingSeqRef.current + 1;
       conversationLoadingSeqRef.current = seq;
+      conversationTransitionBusyRef.current = true;
       setConversationLoading(true);
+      const clearLoadingForSeq = () => {
+        if (conversationLoadingSeqRef.current === seq) {
+          conversationTransitionBusyRef.current = false;
+          setConversationLoading(false);
+        }
+      };
       // Watchdog: never let the empty-thread spinner outlive a stuck switch or
       // create. A cache-hit switch resolves in the same tick and a network load
       // in a few seconds, but the on-device agent can be model-bound (a warming
@@ -325,17 +300,16 @@ export function useShellController(): ShellController {
       // hangs there reads as a permanently frozen new chat. Force-clear after a
       // bound so the (already-activated) conversation is usable while a slow
       // greeting backfills. Seq-guarded so a newer switch owns the flag.
-      const watchdog = setTimeout(() => {
-        if (conversationLoadingSeqRef.current === seq) {
-          setConversationLoading(false);
-        }
-      }, CONVERSATION_LOADING_MAX_MS);
-      void task().finally(() => {
-        clearTimeout(watchdog);
-        if (conversationLoadingSeqRef.current === seq) {
-          setConversationLoading(false);
-        }
-      });
+      const watchdog = setTimeout(
+        clearLoadingForSeq,
+        CONVERSATION_LOADING_MAX_MS,
+      );
+      void Promise.resolve()
+        .then(task)
+        .finally(() => {
+          clearTimeout(watchdog);
+          clearLoadingForSeq();
+        });
     },
     [],
   );
@@ -361,18 +335,45 @@ export function useShellController(): ShellController {
     [handleSelectConversation, runWithConversationLoading],
   );
 
+  const selectAdjacentConversation = React.useCallback(
+    (direction: ConversationNavDirection) => {
+      if (conversationTransitionBusyRef.current) {
+        return;
+      }
+      const targetId = resolveAdjacentConversationId(
+        conversationsRef.current,
+        activeConversationIdRef.current,
+        direction,
+      );
+      if (targetId) {
+        selectConversation(targetId);
+      }
+    },
+    [selectConversation],
+  );
+
   // Horizontal-swipe navigation between conversations (#8929). Computed by the
   // pure `buildConversationNav` helper (unit-tested) so the index-walk and
   // boundary logic stay verifiable independent of this AppContext-bound hook.
-  const conversationNav = React.useMemo<ConversationNav>(
-    () =>
-      buildConversationNav(
-        conversations,
-        activeConversationId,
-        selectConversation,
-      ),
-    [conversations, activeConversationId, selectConversation],
-  );
+  // The callbacks re-resolve through refs at gesture time so a stale overlay
+  // closure cannot navigate against an old active index after the list rerenders.
+  const conversationNav = React.useMemo<ConversationNav>(() => {
+    const nav = buildConversationNav(
+      conversations,
+      activeConversationId,
+      selectConversation,
+    );
+    return {
+      ...nav,
+      goPrev: () => selectAdjacentConversation("prev"),
+      goNext: () => selectAdjacentConversation("next"),
+    };
+  }, [
+    conversations,
+    activeConversationId,
+    selectConversation,
+    selectAdjacentConversation,
+  ]);
 
   // "Ready" here means the agent's FIRST-TURN CAPABILITY is online (it can
   // answer) — NOT that the startup coordinator finished hydrating. The shell now


### PR DESCRIPTION
## Summary
- extract the pure conversation swipe nav helper into `conversation-nav.ts` and keep compatibility re-exports from `useShellController`
- add `resolveAdjacentConversationId` so hook callbacks can resolve against the latest conversation refs at gesture time
- drop adjacent swipe callbacks while a conversation select/create is already in flight, using the existing loading sequence as the transition guard
- add generated interleaving coverage for most-recent-first nav invariants plus hook regression tests for pending-switch and stale-callback behavior
- add evidence under `.github/issue-evidence/9954-conversation-nav-interleaving.md`

## Evidence
- `git diff --check origin/develop HEAD`
- `bun run biome check --config-path biome.json --files-ignore-unknown=true --no-errors-on-unmatched packages\ui\src\components\shell\conversation-nav.ts packages\ui\src\components\shell\useShellController.ts packages\ui\src\components\shell\conversation-nav.test.ts packages\ui\src\components\shell\__tests__\useShellController.test.tsx`
- `bun run --cwd packages/ui test -- src/components/shell/conversation-nav.test.ts` -> 8 passed

## Blocked locally
- `bun run --cwd packages/ui test -- src/components/shell/__tests__/useShellController.test.tsx` fails before tests import because the local Bun dependency store is missing `drizzle-orm/table.utils.js`.
- `bun run --cwd packages/ui typecheck` is blocked by unrelated Drizzle/cloud-shared/recharts/viem/wagmi type graph failures in this worktree.
- `bun run --cwd packages/app audit:app` was attempted because this touches `packages/ui`, but it currently fails on Windows with the existing UI-smoke launcher issue: `Error: spawn bun ENOENT` for `bun run build:views`. This PR does not change visible layout or styling; the launcher issue is queued separately.

Fixes part of #9954.
