### PR TITLE
refactor(ui): centralize DOM modality ownership in one shell-level SpatialSurface

### DIFF
--- a/packages/ui/src/components/views/DynamicViewLoader.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.tsx
@@ -55,6 +55,7 @@ import {
 } from "../../cache-telemetry";
 import { APP_PAUSE_EVENT } from "../../events";
 import { isDynamicViewLoadingAllowed } from "../../platform/platform-guards";
+import { SpatialSurface } from "../../spatial/index.ts";
 import {
   useAppSelector,
   useAppSelectorShallow,
@@ -1396,7 +1397,13 @@ export const DynamicViewLoader = memo(function DynamicViewLoader({
             />
           )}
         >
-          <View {...viewProps} />
+          {/* One shell-level SpatialSurface owns modality for every mounted
+              view — GUI by auto-detect, XR inside a headset host — so plugin
+              view components no longer each wrap themselves. Omitting `modality`
+              keeps the exact auto-detect behaviour the per-view wrappers had. */}
+          <SpatialSurface>
+            <View {...viewProps} />
+          </SpatialSurface>
         </ErrorBoundary>
         <AgentElementOverlay />
         <AgentSurfaceElementReporter />

--- a/plugins/app-model-tester/src/ModelTesterView.tsx
+++ b/plugins/app-model-tester/src/ModelTesterView.tsx
@@ -17,7 +17,7 @@
  */
 
 import type { OverlayAppContext } from "@elizaos/ui/components/apps/overlay-app-api";
-import { SpatialSurface } from "@elizaos/ui/spatial";
+
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   type ModelTesterProbeId,
@@ -301,9 +301,5 @@ export function ModelTesterView({
     error,
   };
 
-  return (
-    <SpatialSurface>
-      <ModelTesterSpatialView snapshot={snapshot} onAction={onAction} />
-    </SpatialSurface>
-  );
+  return <ModelTesterSpatialView snapshot={snapshot} onAction={onAction} />;
 }

--- a/plugins/plugin-app-control/src/views/ViewManagerView.tsx
+++ b/plugins/plugin-app-control/src/views/ViewManagerView.tsx
@@ -18,7 +18,6 @@
  * and externalized from this bundle.
  */
 
-import { SpatialSurface } from "@elizaos/ui/spatial";
 import { useCallback, useEffect, useState } from "react";
 import {
 	type ViewManagerSnapshot,
@@ -57,11 +56,7 @@ export function ViewManagerView() {
 
 	const snapshot: ViewManagerSnapshot = { views, loading, error };
 
-	return (
-		<SpatialSurface>
-			<ViewManagerSpatialView snapshot={snapshot} onOpenView={openView} />
-		</SpatialSurface>
-	);
+	return <ViewManagerSpatialView snapshot={snapshot} onOpenView={openView} />;
 }
 
 export default ViewManagerView;

--- a/plugins/plugin-blocker/src/components/focus/FocusView.tsx
+++ b/plugins/plugin-blocker/src/components/focus/FocusView.tsx
@@ -15,7 +15,7 @@
  */
 
 import { client } from "@elizaos/ui";
-import { SpatialSurface } from "@elizaos/ui/spatial";
+
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { SelfControlStatus } from "../../services/website-blocker/index.ts";
 import { type FocusSnapshot, FocusSpatialView } from "./FocusSpatialView.tsx";
@@ -184,11 +184,7 @@ export function FocusView({
 
   const snapshot = toSnapshot(state, releasing);
 
-  return (
-    <SpatialSurface>
-      <FocusSpatialView snapshot={snapshot} onAction={onAction} />
-    </SpatialSurface>
-  );
+  return <FocusSpatialView snapshot={snapshot} onAction={onAction} />;
 }
 
 export default FocusView;

--- a/plugins/plugin-calendar/src/components/calendar/CalendarView.tsx
+++ b/plugins/plugin-calendar/src/components/calendar/CalendarView.tsx
@@ -18,7 +18,7 @@
  */
 
 import type { LifeOpsCalendarEvent } from "@elizaos/shared";
-import { SpatialSurface } from "@elizaos/ui/spatial";
+
 import { useAppSelector } from "@elizaos/ui/state";
 import { useCallback, useMemo, useState } from "react";
 import {
@@ -152,11 +152,7 @@ export function CalendarView() {
     error: calendar.error,
   };
 
-  return (
-    <SpatialSurface>
-      <CalendarSpatialView snapshot={snapshot} onAction={onAction} />
-    </SpatialSurface>
-  );
+  return <CalendarSpatialView snapshot={snapshot} onAction={onAction} />;
 }
 
 export default CalendarView;

--- a/plugins/plugin-contacts/src/components/ContactsView.tsx
+++ b/plugins/plugin-contacts/src/components/ContactsView.tsx
@@ -25,7 +25,7 @@ import {
   navigateToPhoneWithNumber,
 } from "@elizaos/ui/app-navigate-view";
 import { isNative } from "@elizaos/ui/platform";
-import { SpatialSurface } from "@elizaos/ui/spatial";
+
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { matchesQuery } from "./ContactsAppView.helpers.ts";
 import {
@@ -190,9 +190,5 @@ export function ContactsView() {
     error,
   };
 
-  return (
-    <SpatialSurface>
-      <ContactsSpatialView snapshot={snapshot} onAction={onAction} />
-    </SpatialSurface>
-  );
+  return <ContactsSpatialView snapshot={snapshot} onAction={onAction} />;
 }

--- a/plugins/plugin-documents/src/components/documents/DocumentsView.tsx
+++ b/plugins/plugin-documents/src/components/documents/DocumentsView.tsx
@@ -24,14 +24,14 @@
  */
 
 import { client } from "@elizaos/ui";
-import { SpatialSurface } from "@elizaos/ui/spatial";
+
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { PresentedDocument } from "../../document-presenter.js";
 import {
   type DocumentCard,
-  type DocumentsSearchState,
   type DocumentSearchHit,
+  type DocumentsSearchState,
   type DocumentsSnapshot,
   DocumentsSpatialView,
 } from "./DocumentsSpatialView.tsx";
@@ -173,7 +173,9 @@ const SNIPPET_MAX = 100;
 function toHit(result: DocumentSearchResultWire): DocumentSearchHit {
   const trimmed = result.text.trim();
   const snippet =
-    trimmed.length > SNIPPET_MAX ? `${trimmed.slice(0, SNIPPET_MAX - 1)}…` : trimmed;
+    trimmed.length > SNIPPET_MAX
+      ? `${trimmed.slice(0, SNIPPET_MAX - 1)}…`
+      : trimmed;
   return {
     id: result.id,
     title: result.documentTitle,
@@ -249,7 +251,9 @@ export function DocumentsView(props: DocumentsViewProps = {}): ReactNode {
         setState({
           kind: "error",
           message:
-            error instanceof Error ? error.message : "Could not load documents.",
+            error instanceof Error
+              ? error.message
+              : "Could not load documents.",
         });
       });
     return () => {
@@ -281,7 +285,11 @@ export function DocumentsView(props: DocumentsViewProps = {}): ReactNode {
     fetchersRef.current
       .fetchSearch(trimmed)
       .then((response) => {
-        setSearch({ kind: "results", query: trimmed, results: response.results });
+        setSearch({
+          kind: "results",
+          query: trimmed,
+          results: response.results,
+        });
       })
       .catch((error: unknown) => {
         setSearch({
@@ -368,11 +376,7 @@ export function DocumentsView(props: DocumentsViewProps = {}): ReactNode {
     [load, updateSearch],
   );
 
-  return (
-    <SpatialSurface>
-      <DocumentsSpatialView snapshot={snapshot} onAction={onAction} />
-    </SpatialSurface>
-  );
+  return <DocumentsSpatialView snapshot={snapshot} onAction={onAction} />;
 }
 
 const EMPTY_SNAPSHOT: DocumentsSnapshot = {

--- a/plugins/plugin-facewear/src/components/FacewearView.tsx
+++ b/plugins/plugin-facewear/src/components/FacewearView.tsx
@@ -13,7 +13,6 @@
  * manifest declares and the component the app-shell page (`register.ts`) mounts.
  */
 
-import { SpatialSurface } from "@elizaos/ui/spatial";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { FacewearDeviceType } from "../devices/registry.ts";
 import {
@@ -108,9 +107,5 @@ export function FacewearView() {
     error,
   };
 
-  return (
-    <SpatialSurface>
-      <FacewearSpatialView snapshot={snapshot} onAction={onAction} />
-    </SpatialSurface>
-  );
+  return <FacewearSpatialView snapshot={snapshot} onAction={onAction} />;
 }

--- a/plugins/plugin-facewear/src/components/SmartglassesPanelView.tsx
+++ b/plugins/plugin-facewear/src/components/SmartglassesPanelView.tsx
@@ -19,7 +19,6 @@
  * panel is a real control surface rather than a static mirror.
  */
 
-import { SpatialSurface } from "@elizaos/ui/spatial";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   callWifiBridge,
@@ -180,9 +179,5 @@ export function SmartglassesPanelView() {
     error,
   };
 
-  return (
-    <SpatialSurface>
-      <SmartglassesSpatialView snapshot={snapshot} onAction={onAction} />
-    </SpatialSurface>
-  );
+  return <SmartglassesSpatialView snapshot={snapshot} onAction={onAction} />;
 }

--- a/plugins/plugin-feed/src/components/FeedView.tsx
+++ b/plugins/plugin-feed/src/components/FeedView.tsx
@@ -23,7 +23,7 @@ import {
   type FeedWallet,
   selectLatestRunForApp,
 } from "@elizaos/app-core/ui-compat";
-import { SpatialSurface } from "@elizaos/ui/spatial";
+
 import { useAppSelector } from "@elizaos/ui/state";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
@@ -265,9 +265,5 @@ export function FeedView() {
     sending,
   };
 
-  return (
-    <SpatialSurface>
-      <FeedSpatialView snapshot={snapshot} onAction={onAction} />
-    </SpatialSurface>
-  );
+  return <FeedSpatialView snapshot={snapshot} onAction={onAction} />;
 }

--- a/plugins/plugin-finances/src/components/finances/FinancesView.tsx
+++ b/plugins/plugin-finances/src/components/finances/FinancesView.tsx
@@ -25,7 +25,7 @@
  */
 
 import { client } from "@elizaos/ui";
-import { SpatialSurface } from "@elizaos/ui/spatial";
+
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
@@ -433,11 +433,7 @@ export function FinancesView(props: FinancesViewProps = {}): ReactNode {
     [load],
   );
 
-  return (
-    <SpatialSurface>
-      <FinancesSpatialView snapshot={snapshot} onAction={onAction} />
-    </SpatialSurface>
-  );
+  return <FinancesSpatialView snapshot={snapshot} onAction={onAction} />;
 }
 
 export default FinancesView;

--- a/plugins/plugin-goals/src/components/goals/GoalsView.tsx
+++ b/plugins/plugin-goals/src/components/goals/GoalsView.tsx
@@ -24,7 +24,7 @@
  */
 
 import { client } from "@elizaos/ui";
-import { SpatialSurface } from "@elizaos/ui/spatial";
+
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -273,11 +273,7 @@ export function GoalsView(props: GoalsViewProps = {}): ReactNode {
     return { status: "ready", goals: state.goals, activeStatuses: activeList };
   }, [state, activeStatuses]);
 
-  return (
-    <SpatialSurface>
-      <GoalsSpatialView snapshot={snapshot} onAction={onAction} />
-    </SpatialSurface>
-  );
+  return <GoalsSpatialView snapshot={snapshot} onAction={onAction} />;
 }
 
 export default GoalsView;

--- a/plugins/plugin-health/src/components/health/HealthView.tsx
+++ b/plugins/plugin-health/src/components/health/HealthView.tsx
@@ -25,7 +25,7 @@
  */
 
 import { client } from "@elizaos/ui";
-import { SpatialSurface } from "@elizaos/ui/spatial";
+
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
@@ -339,11 +339,7 @@ export function HealthView(props: HealthViewProps = {}): ReactNode {
     [load, windowDays],
   );
 
-  return (
-    <SpatialSurface>
-      <HealthSpatialView snapshot={snapshot} onAction={onAction} />
-    </SpatialSurface>
-  );
+  return <HealthSpatialView snapshot={snapshot} onAction={onAction} />;
 }
 
 export default HealthView;

--- a/plugins/plugin-hyperliquid/src/HyperliquidView.tsx
+++ b/plugins/plugin-hyperliquid/src/HyperliquidView.tsx
@@ -11,7 +11,6 @@
  * `register-terminal-view.tsx`).
  */
 
-import { SpatialSurface } from "@elizaos/ui/spatial";
 import { useCallback } from "react";
 import {
   type HyperliquidSnapshot,
@@ -30,8 +29,16 @@ function navigateHome(): void {
 }
 
 export function HyperliquidView() {
-  const { status, markets, positions, orders, loading, error, unavailable, refresh } =
-    useHyperliquidState();
+  const {
+    status,
+    markets,
+    positions,
+    orders,
+    loading,
+    error,
+    unavailable,
+    refresh,
+  } = useHyperliquidState();
 
   const onAction = useCallback(
     (action: string) => {
@@ -69,9 +76,5 @@ export function HyperliquidView() {
     error,
   };
 
-  return (
-    <SpatialSurface>
-      <HyperliquidSpatialView snapshot={snapshot} onAction={onAction} />
-    </SpatialSurface>
-  );
+  return <HyperliquidSpatialView snapshot={snapshot} onAction={onAction} />;
 }

--- a/plugins/plugin-inbox/src/components/inbox/InboxView.tsx
+++ b/plugins/plugin-inbox/src/components/inbox/InboxView.tsx
@@ -24,7 +24,7 @@
  */
 
 import { client } from "@elizaos/ui";
-import { SpatialSurface } from "@elizaos/ui/spatial";
+
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -324,11 +324,7 @@ export function InboxView(props: InboxViewProps = {}): ReactNode {
     };
   }, [state, items, filters, activeChannels]);
 
-  return (
-    <SpatialSurface>
-      <InboxSpatialView snapshot={snapshot} onAction={onAction} />
-    </SpatialSurface>
-  );
+  return <InboxSpatialView snapshot={snapshot} onAction={onAction} />;
 }
 
 export default InboxView;

--- a/plugins/plugin-messages/src/components/MessagesView.tsx
+++ b/plugins/plugin-messages/src/components/MessagesView.tsx
@@ -14,7 +14,7 @@ import type { SmsMessageSummary } from "@elizaos/capacitor-messages";
 import { Messages } from "@elizaos/capacitor-messages";
 import { System, type SystemStatus } from "@elizaos/capacitor-system";
 import { consumePendingMessageRecipient } from "@elizaos/ui/app-navigate-view";
-import { SpatialSurface } from "@elizaos/ui/spatial";
+
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   type MessagesSnapshot,
@@ -166,9 +166,5 @@ export function MessagesView() {
     error,
   };
 
-  return (
-    <SpatialSurface>
-      <MessagesSpatialView snapshot={snapshot} onAction={onAction} />
-    </SpatialSurface>
-  );
+  return <MessagesSpatialView snapshot={snapshot} onAction={onAction} />;
 }

--- a/plugins/plugin-phone/src/components/PhoneView.tsx
+++ b/plugins/plugin-phone/src/components/PhoneView.tsx
@@ -12,7 +12,7 @@
 
 import { Phone } from "@elizaos/capacitor-phone";
 import { consumePendingPhoneNumber } from "@elizaos/ui/app-navigate-view";
-import { SpatialSurface } from "@elizaos/ui/spatial";
+
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   type PhoneCallRow,
@@ -188,9 +188,5 @@ export function PhoneView() {
     error,
   };
 
-  return (
-    <SpatialSurface>
-      <PhoneSpatialView snapshot={snapshot} onAction={onAction} />
-    </SpatialSurface>
-  );
+  return <PhoneSpatialView snapshot={snapshot} onAction={onAction} />;
 }

--- a/plugins/plugin-polymarket/src/PolymarketView.tsx
+++ b/plugins/plugin-polymarket/src/PolymarketView.tsx
@@ -10,7 +10,6 @@
  * registry (see `register-terminal-view.tsx`).
  */
 
-import { SpatialSurface } from "@elizaos/ui/spatial";
 import { useCallback, useEffect } from "react";
 import {
   type PolymarketSnapshot,
@@ -69,9 +68,5 @@ export function PolymarketView() {
     error,
   };
 
-  return (
-    <SpatialSurface>
-      <PolymarketSpatialView snapshot={snapshot} onAction={onAction} />
-    </SpatialSurface>
-  );
+  return <PolymarketSpatialView snapshot={snapshot} onAction={onAction} />;
 }

--- a/plugins/plugin-relationships/src/components/relationships/RelationshipsView.tsx
+++ b/plugins/plugin-relationships/src/components/relationships/RelationshipsView.tsx
@@ -24,7 +24,7 @@
  */
 
 import { client } from "@elizaos/ui";
-import { SpatialSurface } from "@elizaos/ui/spatial";
+
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ENTITY_KIND_FILTERS, ENTITY_KIND_LABELS } from "../../types.ts";
@@ -349,11 +349,7 @@ export function RelationshipsView(
     [load],
   );
 
-  return (
-    <SpatialSurface>
-      <RelationshipsSpatialView snapshot={snapshot} onAction={onAction} />
-    </SpatialSurface>
-  );
+  return <RelationshipsSpatialView snapshot={snapshot} onAction={onAction} />;
 }
 
 export default RelationshipsView;

--- a/plugins/plugin-screenshare/src/components/ScreenshareView.tsx
+++ b/plugins/plugin-screenshare/src/components/ScreenshareView.tsx
@@ -10,12 +10,8 @@
  * through the terminal registry (see `register-terminal-view.tsx`).
  */
 
-import {
-  client,
-  selectLatestRunForApp,
-  useAppSelector,
-} from "@elizaos/ui";
-import { SpatialSurface } from "@elizaos/ui/spatial";
+import { client, selectLatestRunForApp, useAppSelector } from "@elizaos/ui";
+
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   buildViewerUrl,
@@ -58,11 +54,13 @@ function toCapabilitySnapshots(
   capabilities: CapabilitiesResponse | null,
 ): ScreenshareCapabilitySnapshot[] {
   if (!capabilities) return [];
-  return Object.entries(capabilities.capabilities).map(([name, capability]) => ({
-    name,
-    available: capability.available,
-    tool: capability.tool,
-  }));
+  return Object.entries(capabilities.capabilities).map(
+    ([name, capability]) => ({
+      name,
+      available: capability.available,
+      tool: capability.tool,
+    }),
+  );
 }
 
 export function ScreenshareView() {
@@ -314,9 +312,5 @@ export function ScreenshareView() {
     error,
   };
 
-  return (
-    <SpatialSurface>
-      <ScreenshareSpatialView snapshot={snapshot} onAction={onAction} />
-    </SpatialSurface>
-  );
+  return <ScreenshareSpatialView snapshot={snapshot} onAction={onAction} />;
 }

--- a/plugins/plugin-shopify/src/ShopifyView.tsx
+++ b/plugins/plugin-shopify/src/ShopifyView.tsx
@@ -11,12 +11,11 @@
  * `register-terminal-view.tsx`).
  */
 
-import { SpatialSurface } from "@elizaos/ui/spatial";
 import { useCallback, useState } from "react";
 import {
   type ShopifySnapshot,
-  type ShopifyTab,
   ShopifySpatialView,
+  type ShopifyTab,
 } from "./components/ShopifySpatialView.tsx";
 import { useShopifyDashboard } from "./useShopifyDashboard.ts";
 
@@ -172,9 +171,5 @@ export function ShopifyView() {
     error,
   };
 
-  return (
-    <SpatialSurface>
-      <ShopifySpatialView snapshot={snapshot} onAction={onAction} />
-    </SpatialSurface>
-  );
+  return <ShopifySpatialView snapshot={snapshot} onAction={onAction} />;
 }

--- a/plugins/plugin-social-alpha/src/frontend/SocialAlphaView.tsx
+++ b/plugins/plugin-social-alpha/src/frontend/SocialAlphaView.tsx
@@ -22,7 +22,7 @@
  */
 
 import { client } from "@elizaos/ui";
-import { SpatialSurface } from "@elizaos/ui/spatial";
+
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { LeaderboardEntry } from "../types";
@@ -197,11 +197,7 @@ export function SocialAlphaView(props: SocialAlphaViewProps = {}): ReactNode {
 		[load],
 	);
 
-	return (
-		<SpatialSurface>
-			<SocialAlphaSpatialView snapshot={snapshot} onAction={onAction} />
-		</SpatialSurface>
-	);
+	return <SocialAlphaSpatialView snapshot={snapshot} onAction={onAction} />;
 }
 
 export default SocialAlphaView;

--- a/plugins/plugin-task-coordinator/src/OrchestratorView.tsx
+++ b/plugins/plugin-task-coordinator/src/OrchestratorView.tsx
@@ -11,7 +11,7 @@
  * here is the statusless landing for hosts that evaluate this wrapper directly.
  */
 
-import { Escape, SpatialSurface } from "@elizaos/ui/spatial";
+import { Escape } from "@elizaos/ui/spatial";
 import {
   EMPTY_ORCHESTRATOR_SNAPSHOT,
   OrchestratorSpatialView,
@@ -20,14 +20,12 @@ import { OrchestratorWorkbench } from "./OrchestratorWorkbench.tsx";
 
 export function OrchestratorView() {
   return (
-    <SpatialSurface>
-      <Escape
-        width="100%"
-        height="100%"
-        tui={<OrchestratorSpatialView snapshot={EMPTY_ORCHESTRATOR_SNAPSHOT} />}
-      >
-        <OrchestratorWorkbench />
-      </Escape>
-    </SpatialSurface>
+    <Escape
+      width="100%"
+      height="100%"
+      tui={<OrchestratorSpatialView snapshot={EMPTY_ORCHESTRATOR_SNAPSHOT} />}
+    >
+      <OrchestratorWorkbench />
+    </Escape>
   );
 }

--- a/plugins/plugin-task-coordinator/src/TaskCoordinatorView.tsx
+++ b/plugins/plugin-task-coordinator/src/TaskCoordinatorView.tsx
@@ -23,7 +23,7 @@ import {
   type CodingAgentTaskThreadDetail,
   client,
 } from "@elizaos/ui";
-import { SpatialSurface } from "@elizaos/ui/spatial";
+
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   type TaskCoordinatorSnapshot,
@@ -40,7 +40,9 @@ function errorMessage(error: unknown): string {
 export function TaskCoordinatorView() {
   const [threads, setThreads] = useState<CodingAgentTaskThread[]>([]);
   const [selectedThreadId, setSelectedThreadId] = useState<string | null>(null);
-  const [detail, setDetail] = useState<CodingAgentTaskThreadDetail | null>(null);
+  const [detail, setDetail] = useState<CodingAgentTaskThreadDetail | null>(
+    null,
+  );
   const [showArchived, setShowArchived] = useState(false);
   const [search, setSearch] = useState("");
   const [loading, setLoading] = useState(true);
@@ -188,9 +190,7 @@ export function TaskCoordinatorView() {
         minWidth: 0,
       }}
     >
-      <SpatialSurface>
-        <TaskCoordinatorSpatialView snapshot={snapshot} onAction={onAction} />
-      </SpatialSurface>
+      <TaskCoordinatorSpatialView snapshot={snapshot} onAction={onAction} />
     </div>
   );
 }

--- a/plugins/plugin-todos/src/components/todos/TodosView.tsx
+++ b/plugins/plugin-todos/src/components/todos/TodosView.tsx
@@ -21,7 +21,7 @@
  */
 
 import { client } from "@elizaos/ui";
-import { SpatialSurface } from "@elizaos/ui/spatial";
+
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -275,11 +275,7 @@ export function TodosView(props: TodosViewProps = {}): ReactNode {
     [load],
   );
 
-  return (
-    <SpatialSurface>
-      <TodosSpatialView snapshot={snapshot} onAction={onAction} />
-    </SpatialSurface>
-  );
+  return <TodosSpatialView snapshot={snapshot} onAction={onAction} />;
 }
 
 export default TodosView;

--- a/plugins/plugin-training/src/ui/FineTuningView.tsx
+++ b/plugins/plugin-training/src/ui/FineTuningView.tsx
@@ -30,7 +30,7 @@ import {
 } from "@elizaos/ui/components";
 import { useIntervalWhenDocumentVisible } from "@elizaos/ui/hooks";
 import { ContentLayout } from "@elizaos/ui/layouts";
-import { Escape, SpatialSurface } from "@elizaos/ui/spatial";
+import { Escape } from "@elizaos/ui/spatial";
 import { type AppContextValue, useAppSelector } from "@elizaos/ui/state";
 import {
   confirmDesktopAction,
@@ -813,13 +813,11 @@ const EMPTY_FINE_TUNING_SNAPSHOT: FineTuningSnapshot = {
  */
 export function FineTuningView(props: { contentHeader?: ReactNode } = {}) {
   return (
-    <SpatialSurface>
-      <Escape
-        tui={<FineTuningSpatialView snapshot={EMPTY_FINE_TUNING_SNAPSHOT} />}
-      >
-        <FineTuningDashboard {...props} />
-      </Escape>
-    </SpatialSurface>
+    <Escape
+      tui={<FineTuningSpatialView snapshot={EMPTY_FINE_TUNING_SNAPSHOT} />}
+    >
+      <FineTuningDashboard {...props} />
+    </Escape>
   );
 }
 

--- a/plugins/plugin-trajectory-logger/src/components/TrajectoryLoggerView.tsx
+++ b/plugins/plugin-trajectory-logger/src/components/TrajectoryLoggerView.tsx
@@ -12,7 +12,7 @@
  */
 
 import type { OverlayAppContext } from "@elizaos/ui";
-import { SpatialSurface } from "@elizaos/ui/spatial";
+
 import { useCallback, useState } from "react";
 import type { PhaseName } from "../phases";
 import { summarizePhases } from "../phases";
@@ -94,8 +94,6 @@ export function TrajectoryLoggerView({
   };
 
   return (
-    <SpatialSurface>
-      <TrajectoryLoggerSpatialView snapshot={snapshot} onAction={onAction} />
-    </SpatialSurface>
+    <TrajectoryLoggerSpatialView snapshot={snapshot} onAction={onAction} />
   );
 }

--- a/plugins/plugin-vector-browser/src/VectorBrowserView.tsx
+++ b/plugins/plugin-vector-browser/src/VectorBrowserView.tsx
@@ -28,7 +28,7 @@ import { ListSkeleton } from "@elizaos/ui/components/ui/skeleton-layouts";
 import { getBootConfig } from "@elizaos/ui/config";
 import { useRenderGuard } from "@elizaos/ui/hooks";
 import { WorkspaceLayout } from "@elizaos/ui/layouts";
-import { Escape, SpatialSurface } from "@elizaos/ui/spatial";
+import { Escape } from "@elizaos/ui/spatial";
 import { useAppSelector } from "@elizaos/ui/state";
 import { Clock3, Database, Hash, Layers3 } from "lucide-react";
 import type { ReactNode } from "react";
@@ -1709,12 +1709,8 @@ export function VectorBrowserView(props: {
   contentHeader?: ReactNode;
 }) {
   return (
-    <SpatialSurface>
-      <Escape
-        tui={<VectorBrowserSpatialView snapshot={TUI_FALLBACK_SNAPSHOT} />}
-      >
-        <VectorBrowserRichView {...props} />
-      </Escape>
-    </SpatialSurface>
+    <Escape tui={<VectorBrowserSpatialView snapshot={TUI_FALLBACK_SNAPSHOT} />}>
+      <VectorBrowserRichView {...props} />
+    </Escape>
   );
 }

--- a/plugins/plugin-wallet-ui/src/InventoryView.tsx
+++ b/plugins/plugin-wallet-ui/src/InventoryView.tsx
@@ -21,7 +21,7 @@
  * this wrapper, never registered as a separate app/nav tab.
  */
 
-import { Escape, SpatialSurface } from "@elizaos/ui/spatial";
+import { Escape } from "@elizaos/ui/spatial";
 import { InventoryAppView } from "./components/InventoryAppView.tsx";
 import {
   InventorySpatialView,
@@ -44,17 +44,15 @@ const TUI_FALLBACK_SNAPSHOT: WalletSnapshot = {
 
 export function InventoryView() {
   return (
-    <SpatialSurface>
-      <Escape
-        tui={
-          <InventorySpatialView
-            snapshot={TUI_FALLBACK_SNAPSHOT}
-            onAction={() => {}}
-          />
-        }
-      >
-        <InventoryAppView />
-      </Escape>
-    </SpatialSurface>
+    <Escape
+      tui={
+        <InventorySpatialView
+          snapshot={TUI_FALLBACK_SNAPSHOT}
+          onAction={() => {}}
+        />
+      }
+    >
+      <InventoryAppView />
+    </Escape>
   );
 }


### PR DESCRIPTION
The deferred **DOM-modality centralization** from #9946 (its "(Lower)" item). Today GUI/XR modality is decided per-leaf: ~28 plugin view route components each wrap themselves in `<SpatialSurface>`, and `packages/app`/the shell owns **none** of it — splitting "what modality am I" between the host (TUI, via the terminal registry) and every GUI/XR leaf.

## What this does
- Mounts **one** shell-level `<SpatialSurface>` at the single GUI/XR chokepoint — **`DynamicViewLoader`**, which loads + mounts every plugin view bundle.
- Drops the per-view `<SpatialSurface>` wrappers from **28 route components** (they now return the spatial component directly).

## Why it's behaviour-preserving
- Every removed wrapper was a **bare `<SpatialSurface>`** — 0 passed `modality` or `onAction` (verified across all of them). The shell wrapper also omits `modality`, so it keeps the **exact auto-detect** behaviour (`gui`, or `xr` inside a headset host) the leaves had.
- The spatial context **defaults to `{ modality: "gui" }`** (`spatial/context.ts`), so a view rendered *outside* the loader (stories/standalone) still resolves cleanly without its own wrapper.
- Inner `*SpatialView` components keep their own `onAction`; only the redundant surface wrapper moved.
- Inner spatial components and **test/story harnesses** that explicitly mount `<SpatialSurface modality=...>` are unchanged.

## Verification
```
registered-view-parity   3 passed   (every view × gui/xr/tui)
plugin-framing           4 passed   (every view frames @ 56/40)
build:views              27 bundles ✓ exit 0   (all 28 route components compile)
typecheck (calendar, messages, wallet-ui, …)   exit 0
biome                    clean
```
The headless **story-gate** (`ui-story-gate.yml`) + the client-lane parity gate run automatically on this `packages/ui` change in CI as the visual safety net. `audit:app` run attached.

## #9946 acceptance criterion addressed
- [x] `SpatialSurface` is mounted **once** (in `DynamicViewLoader`, the packages/app view host) and plugin view files **no longer each wrap themselves**; `registered-view-parity` + `plugin-framing` stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)