### PR TITLE
fix(app): resolve Bun for UI smoke on Windows

### DIFF
--- a/.github/issue-evidence/9943-app-ui-smoke-bun-path.md
+++ b/.github/issue-evidence/9943-app-ui-smoke-bun-path.md
@@ -1,0 +1,69 @@
+# App UI-Smoke Bun Path Evidence
+
+Issue: #9943 testing / CI reliability umbrella
+Related: #9626 build process cross-platform audit
+Date: 2026-06-29
+Machine: Windows, PowerShell, Bun 1.4.0-canary.1, Node 24
+
+## Problem
+
+The app UI-smoke/aesthetic-audit wrapper seeded `BUN` as `bun.exe` / `bun`
+when Bun was installed through WinGet and no `BUN_INSTALL` was present. Node's
+child-process spawn could not resolve that fallback on this Windows machine.
+
+Observed before this change:
+
+```text
+$ bun run --cwd packages/app audit:app
+Error: spawn bun ENOENT
+  syscall: 'spawn bun'
+  path: 'bun'
+  spawnargs: [ 'run', 'build:views' ]
+```
+
+This blocked the required `packages/app audit:app` loop before any screenshots
+could be produced.
+
+## Fix
+
+Both UI-smoke launchers now resolve Bun from `PATH` using Windows `PATHEXT`
+before falling back to `bun.exe` / `bun`:
+
+- `packages/app/scripts/run-ui-playwright.mjs`
+- `packages/app-core/scripts/playwright-ui-live-stack.ts`
+
+On this machine, that resolves:
+
+```text
+C:\Users\Administrator\AppData\Local\Microsoft\WinGet\Links\bun.exe
+```
+
+## Validation
+
+```text
+$ bun run biome check --config-path biome.json --files-ignore-unknown=true --no-errors-on-unmatched packages\app\scripts\run-ui-playwright.mjs packages\app-core\scripts\playwright-ui-live-stack.ts
+Checked 2 files in 1603ms. No fixes applied.
+```
+
+After the patch, the same audit command gets past the previous spawn failure:
+
+```text
+$ bun run --cwd packages/app audit:app
+[build-views] plugins\plugin-app-control
+...
+[build-views] plugins\plugin-trajectory-logger
+...
+ERROR  @elizaos/core#build: command (...) C:\Users\Administrator\AppData\Local\Microsoft\WinGet\Links\bun.exe run build exited (1)
+```
+
+The remaining failure is the existing local dependency-store corruption in
+`drizzle-orm`:
+
+```text
+error: Could not resolve: "./table.js"
+error: Could not resolve: "../table.utils.js"
+error: Could not resolve: "../tracing.js"
+```
+
+So this change fixes the Windows Bun resolution blocker; the audit is now
+blocked later by the known incomplete `node_modules/.bun` store.

--- a/packages/app-core/scripts/playwright-ui-live-stack.ts
+++ b/packages/app-core/scripts/playwright-ui-live-stack.ts
@@ -189,8 +189,14 @@ function cleanupKnownStateDirsSync(): void {
 
 function resolveBunCommand(): string {
   const bunFromEnv = process.env.BUN?.trim();
-  if (bunFromEnv && existsSync(bunFromEnv)) {
-    return bunFromEnv;
+  if (bunFromEnv) {
+    if (existsSync(bunFromEnv)) {
+      return bunFromEnv;
+    }
+    const bunEnvFromPath = resolveExecutableFromPath(bunFromEnv);
+    if (bunEnvFromPath) {
+      return bunEnvFromPath;
+    }
   }
 
   const bunInstallRoot = process.env.BUN_INSTALL?.trim();
@@ -215,7 +221,41 @@ function resolveBunCommand(): string {
     return homeBun;
   }
 
+  const bunFromPath = resolveExecutableFromPath("bun");
+  if (bunFromPath) {
+    return bunFromPath;
+  }
+
   return process.platform === "win32" ? "bun.exe" : "bun";
+}
+
+function resolveExecutableFromPath(command: string): string | null {
+  const pathValue = process.env.PATH ?? "";
+  if (!pathValue) return null;
+
+  const hasExtension = path.extname(command).length > 0;
+  const pathExts =
+    process.platform === "win32"
+      ? (process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD")
+          .split(";")
+          .map((ext) => ext.trim())
+          .filter(Boolean)
+      : [""];
+  const binaryNames =
+    process.platform === "win32" && !hasExtension
+      ? pathExts.map((ext) => `${command}${ext.toLowerCase()}`)
+      : [command];
+
+  for (const dir of pathValue.split(path.delimiter)) {
+    if (!dir) continue;
+    for (const binaryName of binaryNames) {
+      const candidate = path.join(dir, binaryName);
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+    }
+  }
+  return null;
 }
 
 function contentTypeFor(filePath: string): string {

--- a/packages/app/scripts/run-ui-playwright.mjs
+++ b/packages/app/scripts/run-ui-playwright.mjs
@@ -45,10 +45,45 @@ function resolvePlaywrightCommand() {
   return binaryNames[0];
 }
 
+function resolveExecutableFromPath(command) {
+  const pathValue = process.env.PATH ?? "";
+  if (!pathValue) return null;
+
+  const hasExtension = path.extname(command).length > 0;
+  const pathExts =
+    process.platform === "win32"
+      ? (process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD")
+          .split(";")
+          .map((ext) => ext.trim())
+          .filter(Boolean)
+      : [""];
+  const binaryNames =
+    process.platform === "win32" && !hasExtension
+      ? pathExts.map((ext) => `${command}${ext.toLowerCase()}`)
+      : [command];
+
+  for (const dir of pathValue.split(path.delimiter)) {
+    if (!dir) continue;
+    for (const binaryName of binaryNames) {
+      const candidate = path.join(dir, binaryName);
+      if (fs.existsSync(candidate)) {
+        return candidate;
+      }
+    }
+  }
+  return null;
+}
+
 function resolveBunCommand() {
   const bunFromEnv = process.env.BUN?.trim();
-  if (bunFromEnv && fs.existsSync(bunFromEnv)) {
-    return bunFromEnv;
+  if (bunFromEnv) {
+    if (fs.existsSync(bunFromEnv)) {
+      return bunFromEnv;
+    }
+    const bunEnvFromPath = resolveExecutableFromPath(bunFromEnv);
+    if (bunEnvFromPath) {
+      return bunEnvFromPath;
+    }
   }
 
   if (
@@ -80,6 +115,11 @@ function resolveBunCommand() {
   );
   if (fs.existsSync(homeBun)) {
     return homeBun;
+  }
+
+  const bunFromPath = resolveExecutableFromPath("bun");
+  if (bunFromPath) {
+    return bunFromPath;
   }
 
   return process.platform === "win32" ? "bun.exe" : "bun";


### PR DESCRIPTION
## Summary
- resolve Bun from `PATH`/Windows `PATHEXT` in the app Playwright wrapper and app-core UI-smoke live stack
- allow WinGet-installed Bun (`...\Microsoft\WinGet\Links\bun.exe`) to be passed as an absolute executable instead of falling back to unspawnable `bun`/`bun.exe`
- add Windows evidence under `.github/issue-evidence/9943-app-ui-smoke-bun-path.md`

## Evidence
- `git diff --check origin/develop HEAD`
- `bun run biome check --config-path biome.json --files-ignore-unknown=true --no-errors-on-unmatched packages\app\scripts\run-ui-playwright.mjs packages\app-core\scripts\playwright-ui-live-stack.ts`
- `bun run --cwd packages/app audit:app` now gets past the previous `spawn bun ENOENT`, builds plugin view bundles, and invokes Turbo with `C:\Users\Administrator\AppData\Local\Microsoft\WinGet\Links\bun.exe`.

## Remaining local blocker
- The audit now fails later in `@elizaos/core#build` because the local Bun dependency store is missing Drizzle files (`./table.js`, `../table.utils.js`, `../tracing.js`). That is the existing incomplete `node_modules/.bun` issue, not a Bun path resolution failure.

Fixes part of #9943.
Related to #9626.
