### PR TITLE
fix(cloud): guard input-price lookup so a catalog miss can't 500 the chat path [money — needs @lalalune review]

### DIFF
--- a/packages/cloud-shared/src/lib/services/ai-pricing/lookup-missing-pricing.test.ts
+++ b/packages/cloud-shared/src/lib/services/ai-pricing/lookup-missing-pricing.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Regression: a missing INPUT price must degrade to $0, not throw a 500.
+ *
+ * `calculateTextCostFromCatalog` previously left the input-price lookup
+ * unguarded while the output lookup was `.catch(() => null)`. A catalog miss on
+ * the input row therefore threw `Pricing unavailable for language:input <model>`
+ * uncaught, which propagated through `calculateCost` → the chat-completions
+ * credit reserve → a 500 / masked "bridge unreachable". This is especially easy
+ * to hit with embedding models (input-only, and embedded on every turn) or any
+ * model whose input row simply isn't catalogued yet.
+ *
+ * Both seams (persisted repo + live gateway) are mocked empty so EVERY lookup
+ * misses — the worst case. The fix bills the missing side at $0 (mirroring the
+ * existing output handling) instead of failing the request.
+ */
+import { expect, mock, test } from "bun:test";
+
+mock.module("../../../db/repositories/ai-pricing", () => ({
+  aiPricingRepository: {
+    listActiveEntriesForProviderModelPairs: async () => [],
+  },
+}));
+mock.module("./providers/gateway", () => ({
+  fetchEntriesForSource: async () => [],
+}));
+
+const { calculateTextCostFromCatalog } = await import("./lookup");
+
+test("missing input pricing degrades to $0 instead of throwing a 500", async () => {
+  const result = await calculateTextCostFromCatalog({
+    model: "totally-uncatalogued-model",
+    provider: "someprovider",
+    inputTokens: 1000,
+    outputTokens: 500,
+  });
+
+  // Before the fix this rejected with "Pricing unavailable for language:input …".
+  expect(result.inputCost).toBe(0);
+  expect(result.outputCost).toBe(0);
+  expect(result.totalCost).toBe(0);
+});
+
+test("missing input pricing for an input-only embedding model does not throw", async () => {
+  const result = await calculateTextCostFromCatalog({
+    model: "uncatalogued-embedding-model",
+    provider: "someprovider",
+    inputTokens: 800,
+    outputTokens: 0,
+  });
+
+  expect(result.inputCost).toBe(0);
+  expect(result.totalCost).toBe(0);
+});

--- a/packages/cloud-shared/src/lib/services/ai-pricing/lookup.ts
+++ b/packages/cloud-shared/src/lib/services/ai-pricing/lookup.ts
@@ -210,13 +210,20 @@ export async function calculateTextCostFromCatalog(params: {
   outputTokens: number;
 }): Promise<TokenCostBreakdown> {
   const canonicalModel = canonicalModelId(params.model, params.provider);
+  // Both lookups degrade to null on a catalog miss. A missing INPUT price used
+  // to throw uncaught here (the OUTPUT lookup was already guarded), and the
+  // throw propagated through calculateCost → the chat-completions reserve →
+  // a 500 / masked "bridge unreachable" on any model whose input row isn't in
+  // the catalog (notably embedding models, which are input-only and run every
+  // turn). Mirror the output handling — bill the missing side at $0 rather than
+  // failing the request — but log loudly so the catalog gap gets priced.
   const inputEntry = await resolvePreparedPricingEntry({
     billingSource: params.billingSource,
     provider: params.provider,
     model: canonicalModel,
     productFamily: params.model.includes("embedding") ? "embedding" : "language",
     chargeType: "input",
-  });
+  }).catch(() => null);
   const outputEntry = await resolvePreparedPricingEntry({
     billingSource: params.billingSource,
     provider: params.provider,
@@ -225,7 +232,17 @@ export async function calculateTextCostFromCatalog(params: {
     chargeType: "output",
   }).catch(() => null);
 
-  const baseInputCost = asDecimal(inputEntry.unitPrice).mul(params.inputTokens);
+  if (!inputEntry) {
+    logger.warn("ai-pricing: input pricing unavailable; billing input at $0", {
+      canonicalModel,
+      provider: params.provider,
+      billingSource: params.billingSource,
+    });
+  }
+
+  const baseInputCost = inputEntry
+    ? asDecimal(inputEntry.unitPrice).mul(params.inputTokens)
+    : new Decimal(0);
   const baseOutputCost = outputEntry
     ? asDecimal(outputEntry.unitPrice).mul(params.outputTokens)
     : new Decimal(0);


### PR DESCRIPTION
## Bug (residual `pricing-row→500` from the launch-readiness audit)

`calculateTextCostFromCatalog` (`ai-pricing/lookup.ts`) left the **input** price lookup unguarded while the **output** lookup was already `.catch(() => null)`:

```ts
const inputEntry  = await resolvePreparedPricingEntry({ …, chargeType: "input" });          // ← throws on miss
const outputEntry = await resolvePreparedPricingEntry({ …, chargeType: "output" }).catch(() => null);  // ← guarded
const baseInputCost = asDecimal(inputEntry.unitPrice).mul(params.inputTokens);              // ← assumes non-null
```

A catalog miss on the input row throws `Pricing unavailable for language:input <model>` **uncaught**, which propagates `calculateCost → reserveCredits → the chat-completions route → a 500` (or the masked `-32000 "bridge unreachable"` the shared-runtime path reports). 

**Why it's reachable:** the cerebras slash/colon + `:nitro` forms were fixed by #8484/#8697, but the *unguarded input lookup itself* remained. It still fires for **embedding models** — which are input-only and embedded on **every** turn — and for any model whose input row isn't catalogued yet. An asymmetric catalog row (output present, input absent, or vice-versa) is exactly the shape that 500s.

## Fix

Mirror the output handling: degrade a missing input price to **$0** instead of failing the request, and `logger.warn` so the catalog gap is observable and gets priced. **Correctly-catalogued models — the 99% path — are completely unaffected.** A 500 (user can't chat at all) is strictly worse than a logged under-bill on a mis-catalogued model.

## Tests

`lookup-missing-pricing.test.ts` — both seams (persisted repo + live gateway) mocked empty so every lookup misses; asserts the all-miss and input-only-embedding cases return `$0` **without throwing** (before the fix they rejected). Runs in CI (the bare worktree can't load `decimal.js`); fix + test transpile clean locally.

## Money-code + targeting

This is on the billing path → **requesting @lalalune review, not auto-merging.** Targeted at `main` because that's prod and the precedent for the prior pricing-500s (#8484/#8697) was a scoped main→prod hotfix. **The identical bug exists on develop** — a matching develop PR follows so it doesn't regress on the next release.

Part of the #8434 launch-readiness Tier-3 cleanup.