### PR TITLE
fix(cloud): guard input-price lookup so a catalog miss can't 500 the chat path

### DIFF
--- a/packages/cloud/shared/src/lib/services/ai-pricing/lookup-missing-pricing.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/lookup-missing-pricing.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Regression: a missing INPUT price must degrade to $0, not throw a 500.
+ *
+ * `calculateTextCostFromCatalog` previously left the input-price lookup
+ * unguarded while the output lookup was `.catch(() => null)`. A catalog miss on
+ * the input row therefore threw `Pricing unavailable for language:input <model>`
+ * uncaught, which propagated through `calculateCost` → the chat-completions
+ * credit reserve → a 500 / masked "bridge unreachable". This is especially easy
+ * to hit with embedding models (input-only, and embedded on every turn) or any
+ * model whose input row simply isn't catalogued yet.
+ *
+ * Both seams (persisted repo + live gateway) are mocked empty so EVERY lookup
+ * misses — the worst case. The fix bills the missing side at $0 (mirroring the
+ * existing output handling) instead of failing the request.
+ */
+import { expect, mock, test } from "bun:test";
+
+mock.module("../../../db/repositories/ai-pricing", () => ({
+  aiPricingRepository: {
+    listActiveEntriesForProviderModelPairs: async () => [],
+  },
+}));
+mock.module("./providers/gateway", () => ({
+  fetchEntriesForSource: async () => [],
+}));
+
+const { calculateTextCostFromCatalog } = await import("./lookup");
+
+test("missing input pricing degrades to $0 instead of throwing a 500", async () => {
+  const result = await calculateTextCostFromCatalog({
+    model: "totally-uncatalogued-model",
+    provider: "someprovider",
+    inputTokens: 1000,
+    outputTokens: 500,
+  });
+
+  // Before the fix this rejected with "Pricing unavailable for language:input …".
+  expect(result.inputCost).toBe(0);
+  expect(result.outputCost).toBe(0);
+  expect(result.totalCost).toBe(0);
+});
+
+test("missing input pricing for an input-only embedding model does not throw", async () => {
+  const result = await calculateTextCostFromCatalog({
+    model: "uncatalogued-embedding-model",
+    provider: "someprovider",
+    inputTokens: 800,
+    outputTokens: 0,
+  });
+
+  expect(result.inputCost).toBe(0);
+  expect(result.totalCost).toBe(0);
+});

--- a/packages/cloud/shared/src/lib/services/ai-pricing/lookup.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/lookup.ts
@@ -210,13 +210,20 @@ export async function calculateTextCostFromCatalog(params: {
   outputTokens: number;
 }): Promise<TokenCostBreakdown> {
   const canonicalModel = canonicalModelId(params.model, params.provider);
+  // Both lookups degrade to null on a catalog miss. A missing INPUT price used
+  // to throw uncaught here (the OUTPUT lookup was already guarded), and the
+  // throw propagated through calculateCost → the chat-completions reserve →
+  // a 500 / masked "bridge unreachable" on any model whose input row isn't in
+  // the catalog (notably embedding models, which are input-only and run every
+  // turn). Mirror the output handling — bill the missing side at $0 rather than
+  // failing the request — but log loudly so the catalog gap gets priced.
   const inputEntry = await resolvePreparedPricingEntry({
     billingSource: params.billingSource,
     provider: params.provider,
     model: canonicalModel,
     productFamily: params.model.includes("embedding") ? "embedding" : "language",
     chargeType: "input",
-  });
+  }).catch(() => null);
   const outputEntry = await resolvePreparedPricingEntry({
     billingSource: params.billingSource,
     provider: params.provider,
@@ -225,7 +232,17 @@ export async function calculateTextCostFromCatalog(params: {
     chargeType: "output",
   }).catch(() => null);
 
-  const baseInputCost = asDecimal(inputEntry.unitPrice).mul(params.inputTokens);
+  if (!inputEntry) {
+    logger.warn("ai-pricing: input pricing unavailable; billing input at $0", {
+      canonicalModel,
+      provider: params.provider,
+      billingSource: params.billingSource,
+    });
+  }
+
+  const baseInputCost = inputEntry
+    ? asDecimal(inputEntry.unitPrice).mul(params.inputTokens)
+    : new Decimal(0);
   const baseOutputCost = outputEntry
     ? asDecimal(outputEntry.unitPrice).mul(params.outputTokens)
     : new Decimal(0);


### PR DESCRIPTION
Canonical develop fix for the residual `pricing-row→500` (launch-readiness Tier-3). Mirror of the prod hotfix **#10047** (main has the identical bug).

`calculateTextCostFromCatalog` (`ai-pricing/lookup.ts`) left the **input** price lookup unguarded while **output** was `.catch(() => null)`. A catalog miss on the input row threw `Pricing unavailable for language:input <model>` uncaught → propagated `calculateCost → reserveCredits → chat-completions route → 500` (or the masked `-32000 "bridge unreachable"`). Reachable via **embedding models** (input-only, embedded every turn) or any model whose input row isn't catalogued; the cerebras slash/colon + `:nitro` forms were already fixed (#8484/#8697) but the unguarded input lookup itself remained.

**Fix:** degrade a missing input price to $0 (mirroring output) + `logger.warn` for observability. Correctly-catalogued models — the 99% path — are unaffected. `lookup-missing-pricing.test.ts` covers the all-miss + input-only-embedding cases (asserts no-throw + $0).

Pairs with #10047 (main/prod) so the fix doesn't regress when the next release carries develop forward. Billing path — flagging @lalalune.