### PR TITLE
test(security): record remote-plugin-bridge public-route site in audit baseline (#9948)

### DIFF
--- a/packages/agent/src/api/public-route-audit.baseline.json
+++ b/packages/agent/src/api/public-route-audit.baseline.json
@@ -1,6 +1,7 @@
 [
   "packages/agent/src/api/media-runtime.ts::/api/media/:filename",
   "packages/agent/src/services/remote-plugin-adapter.ts::(no-path)",
+  "packages/agent/src/services/remote-plugin-bridge.ts::(no-path)",
   "packages/core/src/capabilities/index.ts::/fixture/route",
   "packages/core/src/features/oauth/plugin.ts::/api/oauth/callback",
   "packages/core/src/features/secrets/setup/config.ts::(no-path)",


### PR DESCRIPTION
The public:true allowlist gate (#10021) correctly flagged a new occurrence after #10022 merged: `remote-plugin-bridge.ts` builds a route from a remote plugin descriptor and propagates `public: true` — and #10022 **hardened** that path by requiring such a route to declare a name (throws otherwise). Legitimate, name-guarded route-building site (not a new hardcoded unauthenticated endpoint), so it's recorded in the baseline. **Greens the `public-route-audit` lane on develop** (it was red because #10022 didn't update the baseline).

`bun run --cwd packages/agent test public-route-audit` → 2 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)