### PR TITLE
fix(ui): preserve launcher migration order and retire FTU on first reply

### DIFF
--- a/packages/ui/src/components/chat/widgets/ftu-welcome.test.tsx
+++ b/packages/ui/src/components/chat/widgets/ftu-welcome.test.tsx
@@ -61,14 +61,27 @@ describe("FtuWelcomeWidget", () => {
     expect(dismissedState()).toMatchObject({ dismissed: true });
   });
 
-  it("retires once the user has sent a first message", () => {
+  it.each([
+    "message_sent",
+    "message_received",
+  ])("retires once the first chat event arrives (%s)", (eventType) => {
     render(
       <FtuWelcome
         slot="home"
-        events={[{ id: "1", eventType: "message_sent", timestamp: 1 } as never]}
+        events={[{ id: "1", eventType, timestamp: 1 } as never]}
       />,
     );
     expect(dismissedState()).toMatchObject({ acted: true });
+  });
+
+  it("does not retire for unrelated activity", () => {
+    render(
+      <FtuWelcome
+        slot="home"
+        events={[{ id: "1", eventType: "blocked", timestamp: 1 } as never]}
+      />,
+    );
+    expect(dismissedState()).toMatchObject({ seen: 1 });
   });
 
   it("declares the show-once-then-retire sunset policy", () => {

--- a/packages/ui/src/components/chat/widgets/ftu-welcome.tsx
+++ b/packages/ui/src/components/chat/widgets/ftu-welcome.tsx
@@ -28,6 +28,10 @@ const PLUGIN_ID = "welcome";
 const WIDGET_ID = "welcome.ftu";
 const WIDGET_KEY = `${PLUGIN_ID}/${WIDGET_ID}`;
 const DEFAULT_SPAN = "col-span-4 row-span-1";
+const FIRST_USER_CHAT_EVENT_TYPES: ReadonlySet<string> = new Set([
+  "message_received",
+  "message_sent",
+]);
 
 function FtuWelcomeWidget({
   slot,
@@ -48,10 +52,10 @@ function FtuWelcomeWidget({
   // model set. Three tappable chips.
   const suggestions = usePromptSuggestions([], { enabled: onHome });
 
-  // Retire once the user actually sends a message (typed, not via a chip) — the
-  // welcome has served its purpose.
-  const sentAMessage = (events ?? []).some(
-    (event) => event.eventType === "message_sent",
+  // Retire once a real chat turn starts. Some paths surface the first completed
+  // turn as `message_received` without a preceding `message_sent` event.
+  const sentAMessage = (events ?? []).some((event) =>
+    FIRST_USER_CHAT_EVENT_TYPES.has(event.eventType),
   );
   useEffect(() => {
     if (onHome && sentAMessage) markHomeWidgetActed(WIDGET_KEY);

--- a/packages/ui/src/components/pages/Launcher.test.tsx
+++ b/packages/ui/src/components/pages/Launcher.test.tsx
@@ -36,6 +36,7 @@ function imageEntry(id: string, label: string, imageUrl: string): ViewEntry {
 }
 
 const FEW = [entry("chat", "Chat"), entry("settings", "Settings")];
+const LEGACY_SPRINGBOARD_STORAGE_KEY = "elizaos.views.springboard";
 
 /**
  * Enter edit mode the only way the launcher now offers it — a long-press on a
@@ -68,6 +69,28 @@ describe("Launcher", () => {
     expect(screen.getByTestId("launcher-tile-settings")).toBeTruthy();
     // Label text is present (names below icons), no descriptions.
     expect(screen.getByText("Chat")).toBeTruthy();
+  });
+
+  it("preserves the manual order from a migrated Springboard layout", () => {
+    window.localStorage.setItem(
+      LEGACY_SPRINGBOARD_STORAGE_KEY,
+      JSON.stringify({
+        favorites: [],
+        pages: [["settings", "chat"]],
+        manual: true,
+      }),
+    );
+
+    render(<Launcher entries={FEW} onLaunch={() => {}} />);
+
+    const tileIds = Array.from(
+      screen
+        .getByTestId("launcher-page-0")
+        .querySelectorAll<HTMLElement>('[data-testid^="launcher-tile-"]'),
+    ).map((node) =>
+      node.getAttribute("data-testid")?.replace("launcher-tile-", ""),
+    );
+    expect(tileIds).toEqual(["settings", "chat"]);
   });
 
   it("marks preview and developer tiles without changing release tiles", () => {

--- a/packages/ui/src/components/pages/Launcher.tsx
+++ b/packages/ui/src/components/pages/Launcher.tsx
@@ -279,7 +279,11 @@ export function Launcher({
   const [layout, setLayout] = useState<LauncherLayout>(() => {
     const stored = readLauncherLayout();
     return reconcileLayout(
-      { favorites: favorites ?? stored.favorites, pages: stored.pages },
+      {
+        favorites: favorites ?? stored.favorites,
+        pages: stored.pages,
+        manual: stored.manual,
+      },
       entries.map((e) => e.id),
     );
   });
@@ -315,7 +319,11 @@ export function Launcher({
   useEffect(() => {
     setLayout((prev) =>
       reconcileLayout(
-        { favorites: favorites ?? prev.favorites, pages: prev.pages },
+        {
+          favorites: favorites ?? prev.favorites,
+          pages: prev.pages,
+          manual: prev.manual,
+        },
         availableIds,
       ),
     );


### PR DESCRIPTION
## Summary

- Preserves the `manual` flag when `Launcher` reconciles a migrated pre-rename Springboard layout, so user-arranged icon order survives the `springboard` → `launcher` migration.
- Retires the FTU welcome widget on the first real chat turn whether the event arrives as `message_sent` or `message_received`.
- Adds focused regressions for both behaviors.

## Context

This is the narrow useful UI slice identified during the #10040 conflict/scope audit. #10040 is broad, conflicting, and stale against already-merged auth/runtime work; this PR avoids that overlap and only carries the two launcher/FTU lifecycle fixes.

## Validation

- `TMPDIR=/home/nubs/.tmp bunx @biomejs/biome check packages/ui/src/components/chat/widgets/ftu-welcome.tsx packages/ui/src/components/chat/widgets/ftu-welcome.test.tsx packages/ui/src/components/pages/Launcher.tsx packages/ui/src/components/pages/Launcher.test.tsx`
- `git diff --check origin/develop...HEAD`
- `bun run --cwd packages/ui test src/components/chat/widgets/ftu-welcome.test.tsx src/components/pages/Launcher.test.tsx` — 2 files / 30 tests passed.

Note: this clean worktree used ignored symlinks to the existing installed checkout for node_modules/generated test artifacts; no dependency or lockfile changes were made.