### PR TITLE
fix(desktop): wire bottom-bar diagnostics and tray popover boot

### DIFF
--- a/.github/issue-evidence/9953-desktop-bottom-bar-followups.md
+++ b/.github/issue-evidence/9953-desktop-bottom-bar-followups.md
@@ -1,0 +1,53 @@
+# Desktop Bottom-Bar Follow-Up Evidence
+
+Issue: #9953
+Follow-up to merged PR: #10032
+Date: 2026-06-29
+Machine: Windows, PowerShell, Bun 1.4.0-canary.1, Node 24
+
+## Fixes
+
+- Main-window diagnostics now use the same shell presentation metadata as
+  `createMainWindow()`, so bottom-bar and kiosk windows report
+  `titleBarStyle: "hidden"` instead of the old platform default.
+- Tray popover now opens as an app renderer window with the app URL, preload,
+  RPC object, app partition, and API-base injection on `dom-ready`.
+- Open tray popovers are included in later API-base broadcasts alongside the
+  main and detached surface windows.
+
+## Validation
+
+```text
+$ git diff --check
+passed
+
+$ bunx @biomejs/biome check packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.ts packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.test.ts packages/app-core/platforms/electrobun/src/index.ts packages/app-core/platforms/electrobun/src/native/desktop.ts packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
+Checked 5 files in 2s. No fixes applied.
+```
+
+Direct Vitest without the app-core config:
+
+```text
+$ bunx vitest run packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.test.ts packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts --environment node
+packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.test.ts: 13 passed
+packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts: blocked before collection by missing local dependency `chalk`
+```
+
+Configured app-core Vitest remains blocked before collection by the incomplete
+local install:
+
+```text
+Cannot find module 'react/package.json'
+```
+
+Package typecheck is also blocked locally because `tsgo` is absent from the
+workspace install:
+
+```text
+bun: command not found: tsgo
+```
+
+Screenshots/video are N/A for this follow-up: the patch is native window boot
+plumbing and diagnostics metadata, not a visual renderer change. The merged
+bottom-bar UI still needs the broader packaged Electrobun/aesthetic evidence
+loop before #9953 can be closed.

--- a/packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.test.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.test.ts
@@ -3,6 +3,7 @@ import {
   appendChatOverlayShellModeParam,
   computeBottomBarFrame,
   DEFAULT_BOTTOM_BAR_HEIGHT,
+  resolveDesktopShellWindowPresentation,
   shouldStartBottomBar,
 } from "./desktop-bottom-bar-config";
 
@@ -103,6 +104,52 @@ describe("desktop bottom-bar config", () => {
         { height: 1 },
       );
       expect(frame.height).toBe(48);
+    });
+  });
+
+  describe("resolveDesktopShellWindowPresentation", () => {
+    it("reports the default platform titlebar metadata", () => {
+      expect(resolveDesktopShellWindowPresentation({}, [], "win32")).toEqual({
+        mode: "default",
+        titleBarStyle: "default",
+        transparent: false,
+      });
+      expect(resolveDesktopShellWindowPresentation({}, [], "darwin")).toEqual({
+        mode: "default",
+        titleBarStyle: "hiddenInset",
+        transparent: true,
+      });
+    });
+
+    it("reports hidden titlebar metadata for the bottom-bar shell", () => {
+      expect(
+        resolveDesktopShellWindowPresentation(
+          { ELIZA_DESKTOP_BOTTOM_BAR: "1" },
+          [],
+          "darwin",
+        ),
+      ).toEqual({
+        mode: "bottom-bar",
+        titleBarStyle: "hidden",
+        transparent: true,
+      });
+    });
+
+    it("reports kiosk as hidden and opaque", () => {
+      expect(
+        resolveDesktopShellWindowPresentation(
+          {
+            ELIZA_DESKTOP_BOTTOM_BAR: "1",
+            ELIZAOS_SHELL_MODE: "kiosk",
+          },
+          [],
+          "darwin",
+        ),
+      ).toEqual({
+        mode: "kiosk",
+        titleBarStyle: "hidden",
+        transparent: false,
+      });
     });
   });
 });

--- a/packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.ts
@@ -74,6 +74,34 @@ export interface BottomBarFrame {
   height: number;
 }
 
+export type DesktopShellWindowMode = "default" | "kiosk" | "bottom-bar";
+export type DesktopShellTitleBarStyle = "hidden" | "hiddenInset" | "default";
+
+export interface DesktopShellWindowPresentation {
+  mode: DesktopShellWindowMode;
+  titleBarStyle: DesktopShellTitleBarStyle;
+  transparent: boolean;
+}
+
+export function resolveDesktopShellWindowPresentation(
+  env: Record<string, string | undefined> = process.env,
+  argv: readonly string[] = process.argv,
+  platform: typeof process.platform = process.platform,
+): DesktopShellWindowPresentation {
+  const kiosk = isKioskShellMode(env, argv);
+  const bottomBar = !kiosk && shouldStartBottomBar(env, argv);
+  return {
+    mode: kiosk ? "kiosk" : bottomBar ? "bottom-bar" : "default",
+    titleBarStyle:
+      kiosk || bottomBar
+        ? "hidden"
+        : platform === "darwin"
+          ? "hiddenInset"
+          : "default",
+    transparent: !kiosk && platform === "darwin",
+  };
+}
+
 /** Default bar height — tall enough for the glass composer + a few message lines. */
 export const DEFAULT_BOTTOM_BAR_HEIGHT = 140;
 

--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -37,7 +37,7 @@ import { readNavigationEventUrl } from "./cloud-auth-window";
 import {
   appendChatOverlayShellModeParam,
   computeBottomBarFrame,
-  shouldStartBottomBar,
+  resolveDesktopShellWindowPresentation,
 } from "./desktop-bottom-bar-config";
 import { readOpenUrlEventUrl } from "./desktop-deep-link-events";
 import { startDesktopTestBridgeServer } from "./desktop-test-bridge-server";
@@ -995,11 +995,12 @@ function resolveBottomBarFrame(): {
 }
 
 async function createMainWindow(rpc: ElizaDesktopRpc): Promise<BrowserWindow> {
-  const kiosk = isKioskShellMode();
+  const presentation = resolveDesktopShellWindowPresentation();
+  const kiosk = presentation.mode === "kiosk";
   // Chromeless bottom-bar shell (#9953): a frameless, transparent, always-on-top
   // bar pinned to the screen bottom that renders the chat-overlay shell only.
   // Opt-in and mutually exclusive with kiosk.
-  const bottomBar = !kiosk && shouldStartBottomBar();
+  const bottomBar = presentation.mode === "bottom-bar";
   const baseRendererUrl = await resolveRendererUrlForCurrentRuntime();
   const rendererUrl = kiosk
     ? appendKioskShellModeParam(baseRendererUrl)
@@ -1044,16 +1045,11 @@ async function createMainWindow(rpc: ElizaDesktopRpc): Promise<BrowserWindow> {
         x: state.x,
         y: state.y,
       };
-  const titleBarStyle =
-    kiosk || bottomBar
-      ? "hidden"
-      : process.platform === "darwin"
-        ? "hiddenInset"
-        : "default";
+  const titleBarStyle = presentation.titleBarStyle;
   // Bottom bar wants a transparent surface so the desktop shows through the
   // empty region above the bar; on darwin it pairs with vibrancy. Win/Linux
   // transparency support varies, so the bar stays opaque there for now.
-  const transparent = !kiosk && process.platform === "darwin";
+  const transparent = presentation.transparent;
   const forceMainWindowCef = shouldForceMainWindowCef(
     process.env,
     process.platform,
@@ -1188,9 +1184,10 @@ function attachMainWindow(
   wireMainWindowAfterCreate(win, rpc, sendToWebview);
   currentWindow = win;
   currentSendToWebview = sendToWebview;
+  const presentation = resolveDesktopShellWindowPresentation();
   setCurrentMainWindow(win, {
-    titleBarStyle: process.platform === "darwin" ? "hiddenInset" : "default",
-    transparent: process.platform === "darwin",
+    titleBarStyle: presentation.titleBarStyle,
+    transparent: presentation.transparent,
   });
   trackFocusedWindow(win);
   // Reveal the Dock icon in tray-first mode whenever a main window is attached,
@@ -1775,6 +1772,10 @@ function injectApiBaseIntoOpenRendererWindows(): void {
   surfaceWindowManager?.forEachWindow((w) => {
     injectApiBase(w as BrowserWindow);
   });
+
+  getDesktopManager().forEachTrayPopoverWindow((w) => {
+    injectApiBase(w);
+  });
 }
 
 /**
@@ -1789,6 +1790,9 @@ function collectOpenRendererWindows(): BrowserWindow[] {
   }
   surfaceWindowManager?.forEachWindow((w) => {
     windows.push(w as BrowserWindow);
+  });
+  getDesktopManager().forEachTrayPopoverWindow((w) => {
+    windows.push(w);
   });
   return windows;
 }
@@ -2790,10 +2794,26 @@ async function main(): Promise<void> {
     // shouldEnableTrayPopover); Win/Linux keep the text context menu.
     if (shouldEnableTrayPopover()) {
       try {
-        const base = await resolveRendererUrl();
+        const base = await resolveRendererUrlForCurrentRuntime();
         const popoverUrl = new URL(base);
         popoverUrl.searchParams.set("shellMode", "tray-popover");
-        desktop.configureTrayPopover(popoverUrl.href);
+        const { rpc } = createDesktopRpc("tray-popover");
+        const buildInfo = await BuildConfig.get();
+        const mainWindowPartition = resolveMainWindowPartition(process.env, {
+          platform: process.platform,
+          buildInfo,
+        });
+        desktop.configureTrayPopover({
+          url: popoverUrl.href,
+          preload: readResolvedPreloadScript(import.meta.dir),
+          partition: mainWindowPartition,
+          rpc,
+          wireRpc: () => wireSettingsRpcAfterCreate(rpc),
+          injectApiBase,
+          onWindowFocused: (window) => {
+            lastFocusedWindow = window;
+          },
+        });
         logger.info("[Main] Tray popover enabled");
       } catch (err) {
         logger.warn(

--- a/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
@@ -8,6 +8,13 @@ vi.mock("@elizaos/core", () => ({
   writeWorkspaceFolderConfig: vi.fn(),
 }));
 
+vi.mock("./mac-window-effects", () => ({
+  enableVibrancy: vi.fn(() => false),
+  ensureShadow: vi.fn(() => false),
+  setNativeDragRegion: vi.fn(),
+  setTrafficLightsPosition: vi.fn(),
+}));
+
 const electrobunMock = vi.hoisted(() => {
   type Handler = (event?: unknown) => void;
   const handlers = new Map<string, Handler[]>();

--- a/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
@@ -3,6 +3,8 @@ import { DesktopManager, resetDesktopManagerForTesting } from "./desktop";
 
 vi.mock("@elizaos/core", () => ({
   clearWorkspaceFolderConfig: vi.fn(),
+  formatError: (error: unknown) =>
+    error instanceof Error ? error.message : String(error),
   writeWorkspaceFolderConfig: vi.fn(),
 }));
 

--- a/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
@@ -1,9 +1,31 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DesktopManager, resetDesktopManagerForTesting } from "./desktop";
 
+vi.mock("@elizaos/core", () => ({
+  clearWorkspaceFolderConfig: vi.fn(),
+  writeWorkspaceFolderConfig: vi.fn(),
+}));
+
 const electrobunMock = vi.hoisted(() => {
   type Handler = (event?: unknown) => void;
   const handlers = new Map<string, Handler[]>();
+  type MockBrowserWindow = {
+    id: number;
+    frame: { x: number; y: number; width: number; height: number };
+    options: Record<string, unknown>;
+    webview: {
+      on: ReturnType<typeof vi.fn>;
+      remove: ReturnType<typeof vi.fn>;
+    };
+    on: ReturnType<typeof vi.fn>;
+    close: ReturnType<typeof vi.fn>;
+    focus: ReturnType<typeof vi.fn>;
+    setAlwaysOnTop: ReturnType<typeof vi.fn>;
+    emit: (event: string) => void;
+    emitWebview: (event: string) => void;
+  };
+  let nextBrowserWindowId = 1;
+  const browserWindowInstances: MockBrowserWindow[] = [];
   const trayInstances: Array<{
     on: ReturnType<typeof vi.fn>;
     off: ReturnType<typeof vi.fn>;
@@ -30,6 +52,52 @@ const electrobunMock = vi.hoisted(() => {
       }
     },
   };
+  const BrowserWindow = vi.fn(function FakeNativeBrowserWindow(
+    this: MockBrowserWindow,
+    options: Record<string, unknown>,
+  ) {
+    const windowHandlers = new Map<string, Array<() => void>>();
+    const webviewHandlers = new Map<string, Array<() => void>>();
+    this.id = nextBrowserWindowId++;
+    this.options = options;
+    this.frame = (options.frame as MockBrowserWindow["frame"] | undefined) ?? {
+      x: 0,
+      y: 0,
+      width: 800,
+      height: 600,
+    };
+    this.webview = {
+      on: vi.fn((event: string, handler: () => void) => {
+        const list = webviewHandlers.get(event) ?? [];
+        list.push(handler);
+        webviewHandlers.set(event, list);
+      }),
+      remove: vi.fn(),
+    };
+    this.on = vi.fn((event: string, handler: () => void) => {
+      const list = windowHandlers.get(event) ?? [];
+      list.push(handler);
+      windowHandlers.set(event, list);
+    });
+    this.close = vi.fn(() => {
+      for (const handler of windowHandlers.get("close") ?? []) {
+        handler();
+      }
+    });
+    this.focus = vi.fn();
+    this.setAlwaysOnTop = vi.fn();
+    this.emit = (event: string) => {
+      for (const handler of windowHandlers.get(event) ?? []) {
+        handler();
+      }
+    };
+    this.emitWebview = (event: string) => {
+      for (const handler of webviewHandlers.get(event) ?? []) {
+        handler();
+      }
+    };
+    browserWindowInstances.push(this);
+  });
   const Tray = vi.fn(function FakeTray(this: {
     on: ReturnType<typeof vi.fn>;
     off: ReturnType<typeof vi.fn>;
@@ -79,13 +147,18 @@ const electrobunMock = vi.hoisted(() => {
   return {
     events,
     handlers,
+    browserWindowInstances,
     trayInstances,
+    BrowserWindow,
     GlobalShortcut,
     Tray,
     Utils,
     reset() {
       handlers.clear();
+      nextBrowserWindowId = 1;
+      browserWindowInstances.splice(0);
       trayInstances.splice(0);
+      BrowserWindow.mockClear();
       events.on.mockClear();
       events.off.mockClear();
       GlobalShortcut.isRegistered.mockClear();
@@ -104,11 +177,22 @@ const electrobunMock = vi.hoisted(() => {
 
 vi.mock("electrobun/bun", () => {
   return {
-    default: { events: electrobunMock.events },
+    default: {
+      events: electrobunMock.events,
+      BrowserWindow: electrobunMock.BrowserWindow,
+    },
+    BrowserWindow: electrobunMock.BrowserWindow,
     BrowserView: vi.fn(),
     BuildConfig: {
       appIdentifier: "test.eliza",
       appVersion: "0.0.0-test",
+      get: vi.fn(async () => ({
+        defaultRenderer: "native",
+        availableRenderers: ["native"],
+        cefVersion: "cef-test",
+        bunVersion: "bun-test",
+        runtime: "test",
+      })),
     },
     ContextMenu: {
       on: vi.fn(),
@@ -116,6 +200,9 @@ vi.mock("electrobun/bun", () => {
     GlobalShortcut: electrobunMock.GlobalShortcut,
     Screen: {
       getAllDisplays: vi.fn(() => []),
+      getPrimaryDisplay: vi.fn(() => ({
+        workArea: { x: 100, y: 50, width: 900, height: 700 },
+      })),
     },
     Session: {
       defaultSession: {},
@@ -394,6 +481,56 @@ describe("DesktopManager main window controls", () => {
 
     await vi.waitFor(() => expect(requestQuit).toHaveBeenCalledTimes(1));
     expect(electrobunMock.Utils.quit).not.toHaveBeenCalled();
+  });
+
+  it("opens tray popover as an app renderer with preload, rpc, partition, and API injection", async () => {
+    const manager = new DesktopManager();
+    const rpc = { request: {}, send: {} };
+    const injectApiBase = vi.fn();
+    const wireRpc = vi.fn();
+    const onWindowFocused = vi.fn();
+
+    manager.configureTrayPopover({
+      url: "http://127.0.0.1:5173/?shellMode=tray-popover",
+      preload: "// preload",
+      partition: "persist:eliza-main",
+      rpc,
+      injectApiBase,
+      wireRpc,
+      onWindowFocused,
+    });
+
+    await manager.toggleTrayPopover();
+
+    const win = electrobunMock.browserWindowInstances[0];
+    expect(electrobunMock.BrowserWindow).toHaveBeenCalledTimes(1);
+    expect(win.options).toMatchObject({
+      url: "http://127.0.0.1:5173/?shellMode=tray-popover",
+      preload: "// preload",
+      partition: "persist:eliza-main",
+      rpc,
+      renderer: "native",
+      transparent: true,
+      titleBarStyle: "hidden",
+    });
+    expect(win.frame).toEqual({
+      x: 100 + 900 - 360 - 8,
+      y: 50 + 8,
+      width: 360,
+      height: 480,
+    });
+    expect(win.webview.remove).not.toHaveBeenCalled();
+    expect(wireRpc).toHaveBeenCalledWith(win);
+    expect(onWindowFocused).toHaveBeenCalledWith(win);
+    expect(win.setAlwaysOnTop).toHaveBeenCalledWith(true);
+    expect(win.focus).toHaveBeenCalledTimes(1);
+
+    const seen: unknown[] = [];
+    manager.forEachTrayPopoverWindow((window) => seen.push(window));
+    expect(seen).toEqual([win]);
+
+    win.emitWebview("dom-ready");
+    expect(injectApiBase).toHaveBeenCalledWith(win);
   });
 
   it("awaits tray teardown during dispose", async () => {

--- a/packages/app-core/platforms/electrobun/src/native/desktop.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop.ts
@@ -115,6 +115,24 @@ interface OpenExternalOptions {
   url: string;
 }
 
+type TrayPopoverBrowserWindowOptions = NonNullable<
+  ConstructorParameters<typeof Electrobun.BrowserWindow>[0]
+> & {
+  partition?: string | null;
+  preload?: string;
+  rpc?: unknown;
+};
+
+interface TrayPopoverConfig {
+  url: string;
+  preload: string;
+  partition?: string | null;
+  rpc?: unknown;
+  injectApiBase?: (window: BrowserWindow) => void;
+  wireRpc?: (window: BrowserWindow) => void;
+  onWindowFocused?: (window: BrowserWindow) => void;
+}
+
 interface ShowItemInFolderOptions {
   path: string;
 }
@@ -287,10 +305,9 @@ export class DesktopManager {
   private releaseNotesWindow: BrowserWindow | null = null;
   private releaseNotesView: BrowserView | null = null;
   // Tray popover (#9953 Phase 4): a frameless, transparent, always-on-top
-  // BrowserView panel anchored at the tray that renders the widget surface.
+  // app renderer window anchored at the tray that renders the widget surface.
   private trayPopoverWindow: BrowserWindow | null = null;
-  private trayPopoverView: BrowserView | null = null;
-  private trayPopoverUrl: string | null = null;
+  private trayPopoverConfig: TrayPopoverConfig | null = null;
   private shortcuts: Map<string, ShortcutOptions> = new Map();
   private notificationCounter = 0;
   private sendToWebview: SendToWebview | null = null;
@@ -684,7 +701,7 @@ export class DesktopManager {
     this.trayClickHandler = () => {
       // When a tray popover is configured (#9953 Phase 4), a click toggles the
       // widget popover instead of restoring the full window.
-      if (this.trayPopoverUrl) {
+      if (this.trayPopoverConfig) {
         void this.toggleTrayPopover().catch((err: unknown) => {
           logger.warn(
             `[Desktop] Failed to toggle tray popover: ${err instanceof Error ? err.message : String(err)}`,
@@ -1880,12 +1897,23 @@ X-GNOME-Autostart-enabled=true
   // MARK: - Tray popover (#9953 Phase 4)
 
   /**
-   * Enable the tray popover. `rendererUrl` must already carry
+   * Enable the tray popover. The URL must already carry
    * `?shellMode=tray-popover` (the caller builds it). Once configured, a tray
    * click toggles the popover instead of restoring the full window.
+   *
+   * This is an app renderer surface, not external content: it needs the app
+   * preload/RPC/API-base boot path and app partition so auth, settings, and
+   * runtime updates match the main window.
    */
-  configureTrayPopover(rendererUrl: string): void {
-    this.trayPopoverUrl = rendererUrl;
+  configureTrayPopover(config: TrayPopoverConfig): void {
+    this.trayPopoverConfig = config;
+  }
+
+  /** Push an update to the open tray-popover app renderer, if present. */
+  forEachTrayPopoverWindow(fn: (window: BrowserWindow) => void): void {
+    if (this.trayPopoverWindow) {
+      fn(this.trayPopoverWindow);
+    }
   }
 
   /** Whether the tray popover window is currently open. */
@@ -1895,12 +1923,12 @@ X-GNOME-Autostart-enabled=true
 
   /**
    * Toggle the tray popover: close it if open, otherwise open a frameless,
-   * transparent, always-on-top BrowserView panel anchored at the top-right of
-   * the primary display's work area (under the macOS menu-bar tray). Mirrors the
-   * proven release-notes BrowserView pattern.
+   * transparent, always-on-top app renderer window anchored at the top-right of
+   * the primary display's work area (under the macOS menu-bar tray).
    */
   async toggleTrayPopover(): Promise<void> {
-    if (!this.trayPopoverUrl) return;
+    const config = this.trayPopoverConfig;
+    if (!config) return;
 
     if (this.trayPopoverWindow) {
       this.closeTrayPopover();
@@ -1924,22 +1952,21 @@ X-GNOME-Autostart-enabled=true
 
     const buildConfig = await BuildConfig.get();
     const renderer = this.resolvePreferredBrowserRenderer(buildConfig);
-    const win = new Electrobun.BrowserWindow({
+    const options: TrayPopoverBrowserWindowOptions = {
       title: `${getBrandConfig().appName}`,
+      url: config.url,
+      preload: config.preload,
       frame: { x, y, width: POPOVER_WIDTH, height: POPOVER_HEIGHT },
       renderer,
       transparent: true,
       titleBarStyle: "hidden",
-    });
-    win.webview.remove();
-
-    const view = new BrowserView({
-      url: this.trayPopoverUrl,
-      renderer,
-      windowId: win.id,
-      partition: RELEASE_NOTES_PARTITION,
-      sandbox: true,
-      frame: { x: 0, y: 0, width: win.frame.width, height: win.frame.height },
+      ...(config.partition ? { partition: config.partition } : {}),
+      ...(config.rpc ? { rpc: config.rpc } : {}),
+    };
+    const win = new Electrobun.BrowserWindow(options);
+    config.wireRpc?.(win);
+    win.webview.on("dom-ready", () => {
+      config.injectApiBase?.(win);
     });
 
     try {
@@ -1951,13 +1978,11 @@ X-GNOME-Autostart-enabled=true
     }
 
     win.on("close", () => {
-      this.trayPopoverView?.remove();
       this.trayPopoverWindow = null;
-      this.trayPopoverView = null;
     });
 
     this.trayPopoverWindow = win;
-    this.trayPopoverView = view;
+    config.onWindowFocused?.(win);
     win.focus();
   }
 
@@ -1971,9 +1996,7 @@ X-GNOME-Autostart-enabled=true
         `[Desktop] Failed to close tray popover: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
-    this.trayPopoverView?.remove();
     this.trayPopoverWindow = null;
-    this.trayPopoverView = null;
   }
 
   // MARK: - Clipboard


### PR DESCRIPTION
## Summary
- make main-window diagnostics use the same shell presentation metadata as `createMainWindow()`, so bottom-bar/kiosk snapshots report `titleBarStyle: "hidden"`
- open the tray popover as an app renderer window with preload, RPC, app partition, and API-base injection instead of a release-notes-style raw BrowserView
- include open tray popovers in later API-base broadcasts

## Evidence
- `git fetch origin develop && git rebase origin/develop`
- `git diff --check origin/develop...HEAD`
- `bunx @biomejs/biome check packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.ts packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.test.ts packages/app-core/platforms/electrobun/src/index.ts packages/app-core/platforms/electrobun/src/native/desktop.ts packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts`
- `bunx vitest run packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.test.ts --environment node` -> 13 passed

## Local blockers / N/A
- Configured app-core Vitest is blocked in this worktree by missing `react/package.json`.
- Package typecheck is blocked because `tsgo` is absent from the local install.
- Direct native desktop-window Vitest is blocked before collection by missing transitive local dependency `chalk`; the new test is still committed for hosted CI.
- Screenshots/video are N/A for this follow-up because it changes native window boot plumbing and diagnostics metadata, not renderer visuals. The broader #9953 packaged/aesthetic evidence loop remains required before #9953 can close.

Refs #9953. Follow-up to #10032.