### PR TITLE
fix(app-core): require owner role for secrets routes

### DIFF
--- a/.github/issue-evidence/9948-app-core-owner-route-gate.md
+++ b/.github/issue-evidence/9948-app-core-owner-route-gate.md
@@ -1,0 +1,72 @@
+# Issue #9948 - app-core owner route gate
+
+Date: 2026-06-29
+Branch: `codex/fix/app-core-owner-route-gate`
+
+## Change
+
+- Added `ensureRouteMinRole(req, res, state, minRole)` in `packages/app-core/src/api/auth.ts`.
+- The helper preserves the existing route auth paths:
+  - trusted loopback requests resolve to `OWNER`;
+  - cookie sessions still require CSRF for state-changing methods;
+  - session bearer auth is still accepted;
+  - Android `ELIZA_REQUIRE_LOCAL_AUTH=1` configured bearer compatibility remains `OWNER`;
+  - owner identities resolve to `OWNER`;
+  - machine identities resolve to `USER`.
+- Switched `/api/secrets/*` in `packages/app-core/src/api/server.ts` from binary `ensureRouteAuthorized` to `ensureRouteMinRole(..., "OWNER")`.
+
+## Validation
+
+Passed:
+
+```text
+bunx vitest run packages/app-core/src/api/__tests__/ensure-route-min-role.test.ts --environment node
+Test Files  1 passed (1)
+Tests       5 passed (5)
+```
+
+```text
+bunx @biomejs/biome check packages/app-core/src/api/auth.ts packages/app-core/src/api/auth/index.ts packages/app-core/src/api/server.ts packages/app-core/src/api/__tests__/ensure-route-min-role.test.ts
+Checked 4 files. No fixes applied.
+```
+
+```text
+git diff --check
+passed
+```
+
+Blocked locally:
+
+```text
+bun install
+Resolved, downloaded and extracted [430]
+exit code 1 with no additional captured error line
+```
+
+```text
+bun run verify
+@elizaos/logger:build: bun: command not found: tsc
+error: script "verify" exited with code 1
+```
+
+```text
+bun run --cwd packages/app-core typecheck
+bun: command not found: tsgo
+```
+
+```text
+bunx -p typescript tsc --noEmit -p packages/app-core/tsconfig.json --pretty false
+timed out after 244s without diagnostics
+```
+
+```text
+bunx vitest run packages/app-core/src/api/__tests__/ensure-min-role.test.ts --environment node
+After bun install repaired handlebars/chalk, this older test still blocks on:
+Error: Cannot find module './generated/validation-keyword-data.ts' imported from packages/core/src/i18n/validation-keywords.ts
+```
+
+## Evidence notes
+
+- Backend logs: N/A for this unit-scope route guard slice; the regression is covered by direct handler assertions for owner, machine, CSRF, and configured-token paths.
+- Real-LLM trajectory: N/A; no agent prompt/model behavior changed.
+- Screenshots/video/audio: N/A; no UI surface changed.

--- a/packages/app-core/src/api/__tests__/ensure-route-min-role.test.ts
+++ b/packages/app-core/src/api/__tests__/ensure-route-min-role.test.ts
@@ -1,0 +1,217 @@
+import http from "node:http";
+import { Socket } from "node:net";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ensureRouteMinRole } from "../auth.js";
+
+const mocks = vi.hoisted(() => ({
+  findActiveSession: vi.fn(),
+  findIdentity: vi.fn(),
+  verifyCsrfToken: vi.fn(),
+}));
+
+vi.mock("@elizaos/core", () => ({
+  roleRank: (role: string | undefined) =>
+    (
+      ({
+        NONE: 0,
+        GUEST: 1,
+        USER: 2,
+        MEMBER: 2,
+        ADMIN: 3,
+        OWNER: 4,
+      }) as Record<string, number>
+    )[role ?? "NONE"] ?? 0,
+}));
+
+vi.mock("@elizaos/shared", () => ({
+  resolveApiToken: (env: NodeJS.ProcessEnv) =>
+    env.ELIZA_API_TOKEN?.trim() || null,
+}));
+
+vi.mock("../auth/sessions.js", () => ({
+  CSRF_HEADER_NAME: "x-eliza-csrf",
+  findActiveSession: mocks.findActiveSession,
+  verifyCsrfToken: mocks.verifyCsrfToken,
+}));
+
+vi.mock("../compat-route-shared.js", () => ({
+  isTrustedLocalRequest: (
+    req: Pick<http.IncomingMessage, "headers" | "socket">,
+  ) => {
+    const host = Array.isArray(req.headers.host)
+      ? req.headers.host[0]
+      : req.headers.host;
+    return (
+      req.socket.remoteAddress === "127.0.0.1" &&
+      typeof host === "string" &&
+      host.startsWith("localhost")
+    );
+  },
+}));
+
+vi.mock("../../services/auth-store.js", () => ({
+  AuthStore: class MockAuthStore {
+    findIdentity = mocks.findIdentity;
+  },
+}));
+
+const STATE_WITH_DB = {
+  current: { adapter: { db: {} } },
+};
+
+function makeReq(options: {
+  method?: string;
+  headers?: http.IncomingHttpHeaders;
+  remoteAddress?: string;
+}): http.IncomingMessage {
+  const req = new http.IncomingMessage(new Socket());
+  req.method = options.method ?? "GET";
+  req.headers = {
+    host: "example.test:2138",
+    "x-forwarded-for": options.remoteAddress ?? "203.0.113.9",
+    ...(options.headers ?? {}),
+  };
+  Object.defineProperty(req.socket, "remoteAddress", {
+    value: options.remoteAddress ?? "203.0.113.9",
+    configurable: true,
+  });
+  return req;
+}
+
+function makeSession(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "session-id",
+    identityId: "identity-id",
+    kind: "browser",
+    createdAt: 0,
+    lastSeenAt: 0,
+    expiresAt: Date.now() + 60_000,
+    rememberDevice: false,
+    csrfSecret: "csrf-secret",
+    ip: null,
+    userAgent: null,
+    scopes: [],
+    revokedAt: null,
+    ...overrides,
+  };
+}
+
+function makeIdentity(kind: "owner" | "machine") {
+  return {
+    id: `${kind}-identity`,
+    kind,
+    displayName: kind,
+    createdAt: 0,
+    passwordHash: null,
+    cloudUserId: null,
+  };
+}
+
+function fakeRes() {
+  let body = "";
+  const req = new http.IncomingMessage(new Socket());
+  const res = new http.ServerResponse(req);
+  res.statusCode = 200;
+  res.end = ((chunk?: string | Buffer) => {
+    if (typeof chunk === "string") body += chunk;
+    else if (chunk) body += chunk.toString("utf8");
+    return res;
+  }) as typeof res.end;
+  return {
+    res,
+    status: () => res.statusCode,
+    json: () => (body ? JSON.parse(body) : null),
+  };
+}
+
+function clearEnv() {
+  delete process.env.ELIZA_API_TOKEN;
+  delete process.env.ELIZA_REQUIRE_LOCAL_AUTH;
+}
+
+describe("ensureRouteMinRole", () => {
+  beforeEach(() => {
+    clearEnv();
+    vi.clearAllMocks();
+    mocks.verifyCsrfToken.mockReturnValue(true);
+  });
+
+  afterEach(clearEnv);
+
+  it("allows an owner browser session to reach OWNER routes", async () => {
+    mocks.findActiveSession.mockResolvedValue(makeSession());
+    mocks.findIdentity.mockResolvedValue(makeIdentity("owner"));
+    const req = makeReq({ headers: { cookie: "eliza_session=owner-session" } });
+    const res = fakeRes();
+
+    await expect(
+      ensureRouteMinRole(req, res.res, STATE_WITH_DB, "OWNER"),
+    ).resolves.toBe(true);
+    expect(res.status()).toBe(200);
+  });
+
+  it("rejects a machine session from OWNER routes", async () => {
+    mocks.findActiveSession.mockResolvedValue(
+      makeSession({ id: "machine-session", kind: "machine" }),
+    );
+    mocks.findIdentity.mockResolvedValue(makeIdentity("machine"));
+    const req = makeReq({
+      headers: { authorization: "Bearer machine-session" },
+    });
+    const res = fakeRes();
+
+    await expect(
+      ensureRouteMinRole(req, res.res, STATE_WITH_DB, "OWNER"),
+    ).resolves.toBe(false);
+    expect(res.status()).toBe(403);
+    expect(res.json()).toEqual({ error: "Insufficient role" });
+  });
+
+  it("still treats a machine session as an authenticated USER tier", async () => {
+    mocks.findActiveSession.mockResolvedValue(
+      makeSession({ id: "machine-session", kind: "machine" }),
+    );
+    mocks.findIdentity.mockResolvedValue(makeIdentity("machine"));
+    const req = makeReq({
+      headers: { authorization: "Bearer machine-session" },
+    });
+    const res = fakeRes();
+
+    await expect(
+      ensureRouteMinRole(req, res.res, STATE_WITH_DB, "USER"),
+    ).resolves.toBe(true);
+    expect(res.status()).toBe(200);
+  });
+
+  it("preserves CSRF rejection before role checks on cookie writes", async () => {
+    mocks.findActiveSession.mockResolvedValue(makeSession());
+    mocks.verifyCsrfToken.mockReturnValue(false);
+    const req = makeReq({
+      method: "PUT",
+      headers: { cookie: "eliza_session=owner-session" },
+    });
+    const res = fakeRes();
+
+    await expect(
+      ensureRouteMinRole(req, res.res, STATE_WITH_DB, "OWNER"),
+    ).resolves.toBe(false);
+    expect(res.status()).toBe(403);
+    expect(res.json()).toEqual({ error: "csrf_required" });
+    expect(mocks.findIdentity).not.toHaveBeenCalled();
+  });
+
+  it("keeps Android local-auth API token compatibility as OWNER", async () => {
+    process.env.ELIZA_REQUIRE_LOCAL_AUTH = "1";
+    process.env.ELIZA_API_TOKEN = "owner-token";
+    mocks.findActiveSession.mockResolvedValue(null);
+    const req = makeReq({
+      headers: { authorization: "Bearer owner-token" },
+    });
+    const res = fakeRes();
+
+    await expect(
+      ensureRouteMinRole(req, res.res, STATE_WITH_DB, "OWNER"),
+    ).resolves.toBe(true);
+    expect(res.status()).toBe(200);
+  });
+});

--- a/packages/app-core/src/api/auth.ts
+++ b/packages/app-core/src/api/auth.ts
@@ -10,7 +10,7 @@ import { type RoleGateRole, roleRank } from "@elizaos/core";
 import { resolveApiToken } from "@elizaos/shared";
 // AuthStore is statically imported elsewhere in the package; the dynamic
 // import below was INEFFECTIVE_DYNAMIC_IMPORT.
-import { AuthStore } from "../services/auth-store.js";
+import { type AuthIdentityRow, AuthStore } from "../services/auth-store.js";
 import {
   CSRF_HEADER_NAME,
   findActiveSession,
@@ -21,6 +21,10 @@ import { isTrustedLocalRequest } from "./compat-route-shared.js";
 import { sendJsonError } from "./response.js";
 
 export { tokenMatches } from "./auth/tokens.js";
+
+interface CompatStateLike {
+  current: { adapter?: { db?: unknown } | null } | null;
+}
 
 /**
  * Normalise a potentially multi-valued HTTP header into a single string.
@@ -398,6 +402,144 @@ export function ensureMinRole(
   return roleRank(resolveBoundaryRole(req, env)) >= roleRank(minRole);
 }
 
+type RouteRoleResolution =
+  | { ok: true; role: RoleGateRole }
+  | { ok: false; status: 401 | 403 | 429; reason: string };
+
+function roleForAuthIdentity(
+  identity: Pick<AuthIdentityRow, "kind"> | null,
+): RoleGateRole {
+  if (identity?.kind === "owner") return "OWNER";
+  if (identity?.kind === "machine") return "USER";
+  return "NONE";
+}
+
+async function resolveSessionRole(
+  store: AuthStore,
+  identityId: string,
+): Promise<RoleGateRole> {
+  const identity = await store.findIdentity(identityId).catch(() => null);
+  return roleForAuthIdentity(identity);
+}
+
+async function resolveAuthorizedRouteRole(
+  req: Pick<http.IncomingMessage, "headers" | "socket" | "method">,
+  state: CompatStateLike,
+  options: { skipCsrf?: boolean; now?: number } = {},
+): Promise<RouteRoleResolution> {
+  const ip = req.socket.remoteAddress ?? null;
+  if (isAuthRateLimited(ip)) {
+    return {
+      ok: false,
+      status: 429,
+      reason: "Too many authentication attempts",
+    };
+  }
+
+  if (isTrustedLocalRequest(req)) return { ok: true, role: "OWNER" };
+
+  const adapter = state.current?.adapter;
+  const db = adapter?.db;
+  if (!db) {
+    const expectedToken = getCompatApiToken();
+    if (!expectedToken) {
+      recordFailedAuth(ip);
+      return { ok: false, status: 401, reason: "Unauthorized" };
+    }
+
+    const providedToken = getProvidedApiToken(req);
+    if (providedToken && tokenMatches(expectedToken, providedToken)) {
+      return { ok: true, role: "OWNER" };
+    }
+
+    recordFailedAuth(ip);
+    return { ok: false, status: 401, reason: "Unauthorized" };
+  }
+
+  const store = new AuthStore(db as ConstructorParameters<typeof AuthStore>[0]);
+  const method = (req.method ?? "GET").toUpperCase();
+  const csrfRequired = !options.skipCsrf && CSRF_REQUIRED_METHODS.has(method);
+
+  const sessionCookie = readCookie(req, SESSION_COOKIE_NAME);
+  if (sessionCookie) {
+    const session = await findActiveSession(
+      store,
+      sessionCookie,
+      options.now,
+    ).catch(() => null);
+    if (session) {
+      if (csrfRequired) {
+        const csrfHeader = extractHeaderValue(
+          (req.headers as http.IncomingHttpHeaders)[CSRF_HEADER_NAME],
+        );
+        if (!verifyCsrfToken(session, csrfHeader)) {
+          return { ok: false, status: 403, reason: "csrf_required" };
+        }
+      }
+      return {
+        ok: true,
+        role: await resolveSessionRole(store, session.identityId),
+      };
+    }
+  }
+
+  const provided = getProvidedApiToken(req);
+  if (provided) {
+    const sessionFromBearer = await findActiveSession(
+      store,
+      provided,
+      options.now,
+    ).catch(() => null);
+    if (sessionFromBearer) {
+      return {
+        ok: true,
+        role: await resolveSessionRole(store, sessionFromBearer.identityId),
+      };
+    }
+
+    const expectedToken = getCompatApiToken();
+    if (
+      process.env.ELIZA_REQUIRE_LOCAL_AUTH === "1" &&
+      expectedToken &&
+      tokenMatches(expectedToken, provided)
+    ) {
+      return { ok: true, role: "OWNER" };
+    }
+  }
+
+  recordFailedAuth(ip);
+  return { ok: false, status: 401, reason: "Unauthorized" };
+}
+
+/**
+ * Cookie/session-aware route guard with a canonical minimum role.
+ *
+ * This is the async counterpart to {@link ensureMinRole}: it preserves the
+ * existing route auth semantics (trusted loopback, session cookie with CSRF,
+ * session bearer, and Android's configured local-auth bearer) while letting
+ * sensitive HTTP routes require OWNER instead of accepting any valid session.
+ */
+export async function ensureRouteMinRole(
+  req: Pick<http.IncomingMessage, "headers" | "socket" | "method">,
+  res: http.ServerResponse,
+  state: CompatStateLike,
+  minRole: RoleGateRole,
+  options: { skipCsrf?: boolean; now?: number } = {},
+): Promise<boolean> {
+  const resolved = await resolveAuthorizedRouteRole(req, state, options);
+  if (!resolved.ok) {
+    sendJsonError(res, resolved.status, resolved.reason);
+    return false;
+  }
+
+  if (roleRank(resolved.role) < roleRank(minRole)) {
+    sendJsonError(res, 403, "Insufficient role");
+    return false;
+  }
+
+  return true;
+}
+
 /**
  * Gate a sensitive route. Without a configured token, only trusted same-machine
  * dashboard requests are allowed. Remote callers need a real auth method.
@@ -422,10 +564,6 @@ export function ensureCompatSensitiveRouteAuthorized(
     return false;
   }
   return ensureCompatApiAuthorized(req, res);
-}
-
-interface CompatStateLike {
-  current: { adapter?: { db?: unknown } | null } | null;
 }
 
 /**

--- a/packages/app-core/src/api/auth/index.ts
+++ b/packages/app-core/src/api/auth/index.ts
@@ -12,6 +12,7 @@ export {
   ensureCompatApiAuthorizedAsync,
   ensureCompatSensitiveRouteAuthorized,
   ensureRouteAuthorized,
+  ensureRouteMinRole,
   extractHeaderValue,
   getCompatApiToken,
   getProvidedApiToken,

--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -39,6 +39,7 @@ import { applyRouteModeGuard } from "../runtime/mode/route-mode-guard";
 import {
   ensureCompatSensitiveRouteAuthorized,
   ensureRouteAuthorized,
+  ensureRouteMinRole,
 } from "./auth.ts";
 import { handleAutomationsCompatRoutes } from "./automations-compat-routes";
 import {
@@ -794,7 +795,7 @@ async function handleCompatRouteInner(
   if (await handleWorkbenchCompatRoutes(req, res, state)) return true;
 
   if (url.pathname.startsWith("/api/secrets/")) {
-    if (!(await ensureRouteAuthorized(req, res, state))) return true;
+    if (!(await ensureRouteMinRole(req, res, state, "OWNER"))) return true;
     if (await handleSecretsInventoryRoute(req, res, url.pathname, method)) {
       return true;
     }


### PR DESCRIPTION
## Summary
- add `ensureRouteMinRole` for app-core routes so cookie/session auth can require a canonical minimum role
- map owner identities to `OWNER` and machine identities to `USER` while preserving loopback, CSRF, bearer-session, and Android local-auth behavior
- require `OWNER` for `/api/secrets/*` instead of allowing any authenticated session

Fixes part of #9948.

## Validation
- `bunx vitest run packages/app-core/src/api/__tests__/ensure-route-min-role.test.ts --environment node` (5 passed)
- `bunx @biomejs/biome check packages/app-core/src/api/auth.ts packages/app-core/src/api/auth/index.ts packages/app-core/src/api/server.ts packages/app-core/src/api/__tests__/ensure-route-min-role.test.ts`
- `git diff HEAD^ HEAD --check`

## Local blockers
- `bun install` downloaded packages but exited 1 without a useful captured error line
- `bun run --cwd packages/app-core typecheck` fails: `bun: command not found: tsgo`
- `bun run verify` fails before this package's code: `@elizaos/logger:build: bun: command not found: tsc`
- the pre-existing `ensure-min-role.test.ts` now gets past missing packages but blocks on missing generated `packages/core/src/i18n/generated/validation-keyword-data.ts`

Evidence: `.github/issue-evidence/9948-app-core-owner-route-gate.md`