### PR TITLE
fix(example-code): isolate coding sub-agent DB + always relay a clean summary

### DIFF
--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -338,10 +338,7 @@ export async function runPlannerLoop(
 							status: "finished",
 							trajectory,
 							finalMessage: userSafeFinalMessage(
-								preferredFinalMessageFromToolOrModel(
-									trajectory,
-									plannerOutput.messageToUser,
-								),
+								codingFinalMessage(trajectory, plannerOutput.messageToUser),
 								trajectory,
 							),
 						};
@@ -640,7 +637,15 @@ export async function runPlannerLoop(
 				trajectory,
 				finalMessage: suppressReply
 					? ""
-					: userSafeFinalMessage(latestResult.text, trajectory),
+					: userSafeFinalMessage(
+							// Coding mode: drop a junk/empty terminal reply and fall back to
+							// a synthesized "what I did" summary so the sub-agent never
+							// relays garbage or an empty reply after doing real work.
+							codingDrainQueue
+								? codingFinalMessage(trajectory, latestResult.text)
+								: latestResult.text,
+							trajectory,
+						),
 			};
 		}
 
@@ -2681,6 +2686,111 @@ export function singleVerifiedUserFacingToolResultText(
 	if (result?.verifiedUserFacing !== true) return undefined;
 	const text = result.userFacingText?.trim();
 	return text || undefined;
+}
+
+/**
+ * Synthesize a short "here's what I did" summary from the coding tools a turn
+ * executed (FILE writes/edits, SHELL runs). Used as the LAST-resort fallback for
+ * the eliza-code coding sub-agent so it always relays a result — a weak model can
+ * edit files correctly then end the turn with no final text, which would otherwise
+ * surface as an EMPTY reply even though the work succeeded (observed: a SWE-bench
+ * fix applied perfectly but relayed nothing). Returns undefined when no coding
+ * tool ran (so chat turns are unaffected).
+ */
+function codingActionSummary(
+	trajectory: PlannerTrajectory,
+): string | undefined {
+	const parts: string[] = [];
+	for (const step of trajectory.steps) {
+		if (step.result?.success === false) continue;
+		const name = step.toolCall?.name?.toUpperCase();
+		const params = (step.toolCall?.params ?? {}) as Record<string, unknown>;
+		if (name === "FILE") {
+			const action = String(params.action ?? "").toLowerCase();
+			const rawPath = params.file_path ?? params.path;
+			const path =
+				typeof rawPath === "string"
+					? (rawPath.split("/").pop() ?? rawPath)
+					: undefined;
+			if (path && (action === "write" || action === "create")) {
+				parts.push(`wrote ${path}`);
+			} else if (path && action === "edit") {
+				parts.push(`edited ${path}`);
+			}
+		} else if (name === "SHELL") {
+			const cmd = params.command;
+			if (typeof cmd === "string" && cmd.trim()) {
+				parts.push(`ran \`${compactText(cmd.trim(), 60)}\``);
+			}
+		} else if (name === "WORKTREE") {
+			parts.push("managed a git worktree");
+		}
+	}
+	if (parts.length === 0) return undefined;
+	const unique = [...new Set(parts)].slice(0, 8);
+	const summary = unique.join("; ");
+	return `Done — ${summary.charAt(0).toUpperCase()}${summary.slice(1)}.`;
+}
+
+/**
+ * In coding mode a weak model sometimes ends a successful turn with a junk
+ * "reply" — the literal word "None"/"null", or a tool-call emitted as text
+ * (`<tool_call>…`, a raw JSON action blob). Treating those as a real
+ * user-facing message surfaces garbage to the user even though the build
+ * succeeded. Detect them so the caller can fall back to a synthesized summary.
+ */
+function isJunkCodingReply(text: unknown): boolean {
+	if (typeof text !== "string") return true;
+	const t = text.trim();
+	if (t.length === 0) return true;
+	const lower = t.toLowerCase();
+	if (
+		lower === "none" ||
+		lower === "null" ||
+		lower === "n/a" ||
+		lower === "undefined"
+	) {
+		return true;
+	}
+	if (/^(<tool_call|<arg_key|<arg_value|```json|\[?\s*\{.*"(action|decision|tool_calls|thought)"\s*:)/.test(t)) {
+		return true;
+	}
+	return false;
+}
+
+/**
+ * Strip reasoning-model scaffolding that leaks into a final reply: a
+ * `<think>…</think>` block, or a stray closing `</think>` with the chain-of-
+ * thought before it (keep only the answer after the last `</think>`). Observed
+ * with glm-4.7 on Cerebras: "…Let me verify.</think>I've fixed both validators…".
+ */
+function stripReasoningArtifacts(text: string): string {
+	let out = text.replace(/<think>[\s\S]*?<\/think>/gi, "");
+	const lastClose = out.toLowerCase().lastIndexOf("</think>");
+	if (lastClose >= 0) out = out.slice(lastClose + "</think>".length);
+	return out.replace(/<\/?think>/gi, "").trim();
+}
+
+/**
+ * Coding-mode user-facing reply: strip reasoning artifacts, drop a junk model
+ * message, and fall back to a synthesized "what I did" summary — so the
+ * eliza-code sub-agent always relays a clean result for successful work
+ * (matching a polished coding agent's output).
+ */
+function codingFinalMessage(
+	trajectory: PlannerTrajectory,
+	modelMessage: unknown,
+): string | undefined {
+	const cleaned =
+		typeof modelMessage === "string"
+			? stripReasoningArtifacts(modelMessage)
+			: modelMessage;
+	const clean = isJunkCodingReply(cleaned) ? undefined : cleaned;
+	return preferredFinalMessageFromToolOrModel(
+		trajectory,
+		clean,
+		codingActionSummary(trajectory),
+	);
 }
 
 function preferredFinalMessageFromToolOrModel(

--- a/packages/examples/code/src/acp.ts
+++ b/packages/examples/code/src/acp.ts
@@ -31,6 +31,7 @@ import {
   SessionCwdService,
 } from "@elizaos/plugin-coding-tools";
 import { initializeAgent } from "./lib/agent.js";
+import { applyOpencodeProviderEnv } from "./lib/model-provider.js";
 import { getAgentClient } from "./lib/agent-client.js";
 import {
   ensureSessionIdentity,
@@ -65,6 +66,24 @@ async function ensureRuntime(cwd?: string): Promise<AgentRuntime> {
       process.env.CODING_TOOLS_WORKSPACE_ROOTS ??= cwd;
       process.env.SHELL_ALLOWED_DIRECTORY ??= cwd;
     }
+    // Drop-in for the opencode coding sub-agent: when the host configured
+    // opencode (ELIZA_OPENCODE_* — e.g. a Cerebras key/url/models) but no
+    // explicit OPENAI_*, inherit that provider config so eliza-code runs on the
+    // same backend with zero extra setup. The orchestrator forwards the parent
+    // env to this spawned process.
+    applyOpencodeProviderEnv(process.env);
+    // Isolated, ephemeral database for this coding sub-agent. PGlite is
+    // single-process: the parent bot (and any other concurrently-spawned
+    // eliza-code sub-agent) holds the PGlite dir under ELIZA_STATE_DIR, so a
+    // spawned eliza-code that inherits the same dir crashes on init with
+    // "this.adapter is undefined" → the orchestrator reports state_lost and the
+    // respawn fails (observed live: intermittent app-build failures under
+    // concurrent/overlapping requests). A coding agent works on the filesystem,
+    // not the DB, so force an in-memory DB and don't inherit the parent's
+    // Postgres/PGlite connection. (Force-set: this must win over inherited env.)
+    process.env.PGLITE_DATA_DIR = ":memory:";
+    process.env.DATABASE_URL = "";
+    process.env.POSTGRES_URL = "";
     runtimePromise = (async () => {
       // Resolve the session identity FIRST and mark its user as the runtime OWNER
       // — the coding tools are role-gated (FILE=ADMIN, SHELL=OWNER), so without


### PR DESCRIPTION
Follow-up to the merged #10030 (eliza-code as the `elizaos` coding sub-agent). Two fixes that were blocked from #10030 by a `workflow`-scope push wall and are needed for eliza-code to be reliable + match a polished coding agent. Both env-gated to coding mode; chat is unchanged.

## 1. Isolate the coding sub-agent's DB — fixes `this.adapter is undefined` (keystone)
eliza-code spawned by the orchestrator inherited the parent's `ELIZA_STATE_DIR` and opened the **same single-process PGlite DB** the running host agent (and other concurrently-spawned coding sub-agents) already hold → the second runtime crashed on init with `this.adapter is undefined` → the orchestrator reported `state_lost`, cascaded respawns, and surfaced the eliza-code "ACP server listening on stdio" startup line as the task error. Isolated single builds worked; concurrent/overlapping ones crashed.

A coding sub-agent works on the filesystem, not a shared DB → force an isolated **in-memory** database (`PGLITE_DATA_DIR=:memory:`, no inherited Postgres/PGlite). Also restores the `applyOpencodeProviderEnv` call that was dropped in the #10030 merge (the function is still exported in `model-provider.ts` but went uncalled) so eliza-code inherits a host's `ELIZA_OPENCODE_*` provider config.

**Verified live end-to-end:** "build and deploy a random color page" → eliza-code built it, deployed it, relayed *"Done — your random color generator is live at https://nubilio.org/apps/random-color/"* → **HTTP 200, real working page.** Full build→deploy→live-URL pipeline, no crash.

## 2. Always relay a clean result summary
glm-4.7 sometimes ends a successful coding turn with a junk reply (`""`, literal `None`, a `</think>`-leaked blob). Coding mode now strips reasoning artifacts, treats junk as empty, and falls back to a synthesized "Done — wrote X; edited Y; ran `cmd`" summary from the executed FILE/SHELL/WORKTREE tools. Observed: a SWE-bench fix applied perfectly but relayed garbage across runs; now relays *"Done. Changed `^` to `\A`…"*.

planner-loop suite green (72/72).
