### PR TITLE
fix(cloud): catch wrapped tenant pk reads

### DIFF
--- a/.github/issue-evidence/9853-tenant-scope-gate-recursive-pk.md
+++ b/.github/issue-evidence/9853-tenant-scope-gate-recursive-pk.md
@@ -1,0 +1,67 @@
+# Issue #9853 - tenant-scope gate recursive pk predicates
+
+Date: 2026-06-29
+Branch: `codex/fix/cloud-tenant-scope-gate`
+
+## Change
+
+- Hardened `packages/cloud/shared/scripts/check-tenant-scope.ts` so the static tenant-scope gate catches pk-only predicates when wrapped in:
+  - `and(eq(table.id, ...))`
+  - `or(eq(table.id, ...))`
+  - `inArray(table.id, ...)`
+  - `and(...conditions)` where `conditions` is a simple `const` array of pk-only predicates.
+- Kept the existing narrow semantics: a predicate on another column, such as `organization_id`, means the query is not considered pk-only by this gate.
+- Expanded tenant-scope fixtures and tests to prove both the new detections and scoped non-regressions.
+
+## Validation
+
+Passed:
+
+```text
+bun test packages/cloud/shared/src/db/repositories/__tests__/tenant-scope-gate.test.ts
+2 pass
+```
+
+```text
+bun run --cwd packages/cloud/shared check:tenant-scope
+tenant-scope gate: no unannotated pk-only reads across 74 repository file(s)
+```
+
+```text
+bunx @biomejs/biome check packages/cloud/shared/scripts/check-tenant-scope.ts packages/cloud/shared/scripts/__fixtures__/tenant-scope/unscoped.ts packages/cloud/shared/scripts/__fixtures__/tenant-scope/scoped.ts packages/cloud/shared/src/db/repositories/__tests__/tenant-scope-gate.test.ts
+Checked 4 files. No fixes applied.
+```
+
+```text
+bun run --cwd packages/cloud/shared lint
+Checked 1195 files. No fixes applied.
+Only existing Biome config schema/deprecation info emitted.
+```
+
+```text
+git diff --check
+passed
+```
+
+Blocked locally:
+
+```text
+bun install
+timed out after 364s
+```
+
+```text
+bun run verify
+timed out after 304s
+```
+
+```text
+bun run --cwd packages/cloud/shared typecheck
+bun: command not found: tsgo
+```
+
+## Evidence notes
+
+- Backend logs: N/A; this is a static CI gate script and fixture test.
+- Real-LLM trajectory: N/A; no agent behavior changed.
+- Screenshots/video/audio: N/A; no UI or media surface changed.

--- a/packages/cloud/shared/scripts/__fixtures__/tenant-scope/scoped.ts
+++ b/packages/cloud/shared/scripts/__fixtures__/tenant-scope/scoped.ts
@@ -7,6 +7,7 @@
 declare const dbRead: { query: { apps: { findFirst(args: unknown): Promise<unknown> } } };
 declare function eq(a: unknown, b: unknown): unknown;
 declare function and(...parts: unknown[]): unknown;
+declare function inArray(a: unknown, b: unknown): unknown;
 declare const apps: { id: unknown; organization_id: unknown };
 
 export class ScopedFixtureRepo {
@@ -19,5 +20,16 @@ export class ScopedFixtureRepo {
     return await dbRead.query.apps.findFirst({
       where: and(eq(apps.organization_id, orgId), eq(apps.id, id)),
     });
+  }
+
+  async findScopedIds(orgId: string, ids: string[]): Promise<unknown> {
+    return await dbRead.query.apps.findFirst({
+      where: and(eq(apps.organization_id, orgId), inArray(apps.id, ids)),
+    });
+  }
+
+  async findScopedSpread(orgId: string, id: string): Promise<unknown> {
+    const conditions = [eq(apps.id, id), eq(apps.organization_id, orgId)];
+    return await dbRead.query.apps.findFirst({ where: and(...conditions) });
   }
 }

--- a/packages/cloud/shared/scripts/__fixtures__/tenant-scope/unscoped.ts
+++ b/packages/cloud/shared/scripts/__fixtures__/tenant-scope/unscoped.ts
@@ -32,4 +32,9 @@ export class UnscopedFixtureRepo {
     const conditions = [eq(apps.id, id)];
     return await dbRead.query.apps.findFirst({ where: and(...conditions) });
   }
+
+  async findScopedSpreadWithSameLocalName(orgId: string, id: string): Promise<unknown> {
+    const conditions = [eq(apps.id, id), eq(apps.organization_id, orgId)];
+    return await dbRead.query.apps.findFirst({ where: and(...conditions) });
+  }
 }

--- a/packages/cloud/shared/scripts/__fixtures__/tenant-scope/unscoped.ts
+++ b/packages/cloud/shared/scripts/__fixtures__/tenant-scope/unscoped.ts
@@ -6,10 +6,30 @@
  */
 declare const dbRead: { query: { apps: { findFirst(args: unknown): Promise<unknown> } } };
 declare function eq(a: unknown, b: unknown): unknown;
+declare function and(...parts: unknown[]): unknown;
+declare function or(...parts: unknown[]): unknown;
+declare function inArray(a: unknown, b: unknown): unknown;
 declare const apps: { id: unknown; organization_id: unknown };
 
 export class UnscopedFixtureRepo {
   async findById(id: string): Promise<unknown> {
     return await dbRead.query.apps.findFirst({ where: eq(apps.id, id) });
+  }
+
+  async findByIdWrappedInAnd(id: string): Promise<unknown> {
+    return await dbRead.query.apps.findFirst({ where: and(eq(apps.id, id)) });
+  }
+
+  async findByIdWrappedInOr(id: string): Promise<unknown> {
+    return await dbRead.query.apps.findFirst({ where: or(eq(apps.id, id)) });
+  }
+
+  async findByIds(ids: string[]): Promise<unknown> {
+    return await dbRead.query.apps.findFirst({ where: inArray(apps.id, ids) });
+  }
+
+  async findBySpreadConditions(id: string): Promise<unknown> {
+    const conditions = [eq(apps.id, id)];
+    return await dbRead.query.apps.findFirst({ where: and(...conditions) });
   }
 }

--- a/packages/cloud/shared/scripts/check-tenant-scope.ts
+++ b/packages/cloud/shared/scripts/check-tenant-scope.ts
@@ -67,8 +67,6 @@ function primaryKeyPredicateTable(where: ts.Expression): string | undefined {
   return TENANT_DATA_PLANE_TABLES.has(lhs.expression.text) ? lhs.expression.text : undefined;
 }
 
-type ConstArrayInitializers = Map<string, ts.ArrayLiteralExpression>;
-
 function isConstArrayDeclaration(node: ts.VariableDeclaration): boolean {
   return (
     ts.isIdentifier(node.name) &&
@@ -79,21 +77,48 @@ function isConstArrayDeclaration(node: ts.VariableDeclaration): boolean {
   );
 }
 
-function collectConstArrayInitializers(source: ts.SourceFile): ConstArrayInitializers {
-  const arrays: ConstArrayInitializers = new Map();
-  const visit = (node: ts.Node): void => {
-    if (ts.isVariableDeclaration(node) && isConstArrayDeclaration(node)) {
-      arrays.set(node.name.text, node.initializer);
+function constArrayInitializerFromStatement(
+  statement: ts.Statement,
+  name: string,
+): ts.ArrayLiteralExpression | undefined {
+  if (!ts.isVariableStatement(statement)) return undefined;
+  let found: ts.ArrayLiteralExpression | undefined;
+  for (const declaration of statement.declarationList.declarations) {
+    if (isConstArrayDeclaration(declaration) && declaration.name.text === name) {
+      found = declaration.initializer;
     }
-    ts.forEachChild(node, visit);
-  };
-  visit(source);
-  return arrays;
+  }
+  return found;
+}
+
+function statementScope(node: ts.Node): ts.NodeArray<ts.Statement> | undefined {
+  if (ts.isBlock(node) || ts.isSourceFile(node) || ts.isModuleBlock(node)) {
+    return node.statements;
+  }
+  return undefined;
+}
+
+function findVisibleConstArrayInitializer(
+  name: string,
+  from: ts.Node,
+): ts.ArrayLiteralExpression | undefined {
+  for (let scope: ts.Node | undefined = from.parent; scope; scope = scope.parent) {
+    const statements = statementScope(scope);
+    if (!statements) continue;
+
+    let found: ts.ArrayLiteralExpression | undefined;
+    for (const statement of statements) {
+      if (statement.pos >= from.pos) break;
+      if (statement.end > from.pos) continue;
+      found = constArrayInitializerFromStatement(statement, name) ?? found;
+    }
+    if (found) return found;
+  }
+  return undefined;
 }
 
 function expandedExpressions(
   expression: ts.Expression,
-  arrays: ConstArrayInitializers,
   seenArrays: Set<string>,
 ): ts.Expression[] | undefined {
   if (!ts.isSpreadElement(expression)) return [expression];
@@ -106,7 +131,7 @@ function expandedExpressions(
     return undefined;
   }
 
-  const initializer = arrays.get(spread.text);
+  const initializer = findVisibleConstArrayInitializer(spread.text, expression);
   if (!initializer) return undefined;
   seenArrays.add(spread.text);
   const expanded = [...initializer.elements];
@@ -122,7 +147,6 @@ function expandedExpressions(
  */
 function primaryKeyOnlyTables(
   where: ts.Expression,
-  arrays: ConstArrayInitializers,
   seenArrays = new Set<string>(),
 ): Set<string> | undefined {
   const direct = primaryKeyPredicateTable(where);
@@ -135,10 +159,10 @@ function primaryKeyOnlyTables(
   const tables = new Set<string>();
   let sawPkPredicate = false;
   for (const arg of where.arguments) {
-    const expanded = expandedExpressions(arg, arrays, seenArrays);
+    const expanded = expandedExpressions(arg, seenArrays);
     if (!expanded?.length) return undefined;
     for (const expr of expanded) {
-      const childTables = primaryKeyOnlyTables(expr, arrays, seenArrays);
+      const childTables = primaryKeyOnlyTables(expr, seenArrays);
       if (!childTables) return undefined;
       sawPkPredicate = true;
       for (const table of childTables) tables.add(table);
@@ -195,11 +219,10 @@ export function findUnscopedTenantReads(repoFiles: string[]): TenantScopeViolati
   const violations: TenantScopeViolation[] = [];
   for (const file of repoFiles) {
     const source = parse(file);
-    const arrays = collectConstArrayInitializers(source);
     const visit = (node: ts.Node): void => {
       const where = whereExpression(node);
       if (where) {
-        const tables = primaryKeyOnlyTables(where, arrays);
+        const tables = primaryKeyOnlyTables(where);
         if (tables) {
           const fn = enclosingFunction(node);
           if (!ALLOW_ANNOTATION.test(fn.text)) {

--- a/packages/cloud/shared/scripts/check-tenant-scope.ts
+++ b/packages/cloud/shared/scripts/check-tenant-scope.ts
@@ -3,9 +3,11 @@
  *
  * Scans the cloud-shared repositories for reads/updates/deletes against the
  * Product-2 *apps tenant data-plane* whose WHERE clause is ONLY the primary-key
- * `id` (`eq(<table>.id, _)`) with no organization/app ownership predicate. Such
- * pk-only access trusts the caller to have already authorized ownership, so a
- * NEW unscoped query against a tenant table must not land silently before GA.
+ * `id` (`eq(<table>.id, _)`, `inArray(<table>.id, _)`, or those predicates
+ * wrapped in `and(...)`/`or(...)`) with no organization/app ownership
+ * predicate. Such pk-only access trusts the caller to have already authorized
+ * ownership, so a NEW unscoped query against a tenant table must not land
+ * silently before GA.
  *
  * A method may opt out with an explicit annotation that documents WHY the
  * lookup is intentionally id-only (e.g. authorization happens in the route
@@ -55,19 +57,95 @@ function parse(file: string): ts.SourceFile {
   return ts.createSourceFile(file, readFileSync(file, "utf8"), ts.ScriptTarget.Latest, true);
 }
 
-/**
- * If `where` is a SOLE `eq(<table>.id, _)` against a tenant data-plane table,
- * return that table's identifier name; otherwise undefined. An `and(...)`/`or(...)`
- * combinator or a predicate on any other column is — by construction — not a
- * single eq on the pk, so it is never flagged.
- */
-function solePrimaryKeyTable(where: ts.Expression): string | undefined {
+function primaryKeyPredicateTable(where: ts.Expression): string | undefined {
   if (!ts.isCallExpression(where)) return undefined;
-  if (!ts.isIdentifier(where.expression) || where.expression.text !== "eq") return undefined;
+  if (!ts.isIdentifier(where.expression)) return undefined;
+  if (where.expression.text !== "eq" && where.expression.text !== "inArray") return undefined;
   const lhs = where.arguments[0];
   if (!lhs || !ts.isPropertyAccessExpression(lhs)) return undefined;
   if (!ts.isIdentifier(lhs.expression) || lhs.name.text !== "id") return undefined;
   return TENANT_DATA_PLANE_TABLES.has(lhs.expression.text) ? lhs.expression.text : undefined;
+}
+
+type ConstArrayInitializers = Map<string, ts.ArrayLiteralExpression>;
+
+function isConstArrayDeclaration(node: ts.VariableDeclaration): boolean {
+  return (
+    ts.isIdentifier(node.name) &&
+    node.initializer !== undefined &&
+    ts.isArrayLiteralExpression(node.initializer) &&
+    ts.isVariableDeclarationList(node.parent) &&
+    Boolean(node.parent.flags & ts.NodeFlags.Const)
+  );
+}
+
+function collectConstArrayInitializers(source: ts.SourceFile): ConstArrayInitializers {
+  const arrays: ConstArrayInitializers = new Map();
+  const visit = (node: ts.Node): void => {
+    if (ts.isVariableDeclaration(node) && isConstArrayDeclaration(node)) {
+      arrays.set(node.name.text, node.initializer);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  return arrays;
+}
+
+function expandedExpressions(
+  expression: ts.Expression,
+  arrays: ConstArrayInitializers,
+  seenArrays: Set<string>,
+): ts.Expression[] | undefined {
+  if (!ts.isSpreadElement(expression)) return [expression];
+
+  const spread = expression.expression;
+  if (ts.isArrayLiteralExpression(spread)) {
+    return [...spread.elements];
+  }
+  if (!ts.isIdentifier(spread) || seenArrays.has(spread.text)) {
+    return undefined;
+  }
+
+  const initializer = arrays.get(spread.text);
+  if (!initializer) return undefined;
+  seenArrays.add(spread.text);
+  const expanded = [...initializer.elements];
+  seenArrays.delete(spread.text);
+  return expanded;
+}
+
+/**
+ * If `where` is composed only of pk predicates against tenant data-plane
+ * tables, return those table identifier names; otherwise undefined. Any
+ * predicate on another column (for example `organization_id` / `app_id`) makes
+ * the query scoped for this narrow gate and therefore not a violation.
+ */
+function primaryKeyOnlyTables(
+  where: ts.Expression,
+  arrays: ConstArrayInitializers,
+  seenArrays = new Set<string>(),
+): Set<string> | undefined {
+  const direct = primaryKeyPredicateTable(where);
+  if (direct) return new Set([direct]);
+
+  if (!ts.isCallExpression(where)) return undefined;
+  if (!ts.isIdentifier(where.expression)) return undefined;
+  if (where.expression.text !== "and" && where.expression.text !== "or") return undefined;
+
+  const tables = new Set<string>();
+  let sawPkPredicate = false;
+  for (const arg of where.arguments) {
+    const expanded = expandedExpressions(arg, arrays, seenArrays);
+    if (!expanded?.length) return undefined;
+    for (const expr of expanded) {
+      const childTables = primaryKeyOnlyTables(expr, arrays, seenArrays);
+      if (!childTables) return undefined;
+      sawPkPredicate = true;
+      for (const table of childTables) tables.add(table);
+    }
+  }
+
+  return sawPkPredicate ? tables : undefined;
 }
 
 /** Outermost enclosing function/method: its name (for reporting) and full text.
@@ -117,15 +195,18 @@ export function findUnscopedTenantReads(repoFiles: string[]): TenantScopeViolati
   const violations: TenantScopeViolation[] = [];
   for (const file of repoFiles) {
     const source = parse(file);
+    const arrays = collectConstArrayInitializers(source);
     const visit = (node: ts.Node): void => {
       const where = whereExpression(node);
       if (where) {
-        const table = solePrimaryKeyTable(where);
-        if (table) {
+        const tables = primaryKeyOnlyTables(where, arrays);
+        if (tables) {
           const fn = enclosingFunction(node);
           if (!ALLOW_ANNOTATION.test(fn.text)) {
             const { line } = source.getLineAndCharacterOfPosition(node.getStart());
-            violations.push({ file, line: line + 1, table, method: fn.name });
+            for (const table of tables) {
+              violations.push({ file, line: line + 1, table, method: fn.name });
+            }
           }
         }
       }
@@ -147,7 +228,7 @@ if (import.meta.main) {
     );
     for (const v of violations) {
       console.error(
-        `  ${relative(process.cwd(), v.file)}:${v.line}  ${v.method}() → eq(${v.table}.id, …)`,
+        `  ${relative(process.cwd(), v.file)}:${v.line}  ${v.method}() → pk-only ${v.table}.id predicate`,
       );
     }
     console.error(

--- a/packages/cloud/shared/src/db/repositories/__tests__/tenant-scope-gate.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/tenant-scope-gate.test.ts
@@ -17,8 +17,17 @@ const fixture = (name: string): string =>
 describe("tenant-scope gate (#9853 P1.6)", () => {
   test("flags a pk-only read against a tenant data-plane table", () => {
     const violations = findUnscopedTenantReads([fixture("unscoped.ts")]);
-    expect(violations).toHaveLength(1);
-    expect(violations[0]).toMatchObject({ table: "apps", method: "findById" });
+    expect(violations).toHaveLength(5);
+    expect(violations.map((v) => v.method).sort()).toEqual([
+      "findById",
+      "findByIdWrappedInAnd",
+      "findByIdWrappedInOr",
+      "findByIds",
+      "findBySpreadConditions",
+    ]);
+    for (const violation of violations) {
+      expect(violation.table).toBe("apps");
+    }
   });
 
   test("passes when the read is annotated global-scope or carries an ownership predicate", () => {


### PR DESCRIPTION
## Summary
- harden the tenant-scope static gate so pk-only reads are detected when wrapped in `and(...)`, `or(...)`, `inArray(...)`, and simple `const conditions = [...]` spreads
- preserve the current narrow semantics: any ownership predicate such as `organization_id` makes the query non-pk-only for this gate
- expand fixtures so the previous blind spots fail the test if they regress

Fixes the #9853 follow-up noted in https://github.com/elizaOS/eliza/issues/9853#issuecomment-4825144753.

## Validation
- `bun test packages/cloud/shared/src/db/repositories/__tests__/tenant-scope-gate.test.ts` (2 passed)
- `bun run --cwd packages/cloud/shared check:tenant-scope` (74 repository files clean)
- `bun run --cwd packages/cloud/shared lint` (1195 files clean; existing Biome schema/deprecation infos only)
- `git diff HEAD^ HEAD --check`

## Local blockers
- `bun install` timed out after 364s
- `bun run verify` timed out after 304s
- `bun run --cwd packages/cloud/shared typecheck` fails: `bun: command not found: tsgo`

Evidence: `.github/issue-evidence/9853-tenant-scope-gate-recursive-pk.md`