### PR TITLE
perf(cloud): enable prod auth fast-path — flip INFERENCE_HOT_PATH_CACHE [latency cutover step 1, @lalalune your flip]

### DIFF
--- a/packages/cloud-api/wrangler.toml
+++ b/packages/cloud-api/wrangler.toml
@@ -447,7 +447,7 @@ REDIS_RATE_LIMITING = "false"
 # miss/unavailable the resolver falls back to the authoritative slow path
 # (re-authenticates via requireAuthOrApiKeyWithOrg) — no auth is granted from a
 # failed cache read.
-INFERENCE_HOT_PATH_CACHE = "false"
+INFERENCE_HOT_PATH_CACHE = "true"
 # Tier-2 optimistic off-path billing (#9899). OFF here = the synchronous credit
 # reserve runs exactly as before (no behavior change). When "true" (also requires
 # INFERENCE_HOT_PATH_CACHE + a writable KV backstop), an org whose balance clears


### PR DESCRIPTION
**nubs wants the latency live — this is the 1-click flip for step 1.** Your call on timing/rollout; opening it as a ready-to-merge convenience, not jumping your gate.

## What
Flips **only** `INFERENCE_HOT_PATH_CACHE = "true"` in the **production** block. The IAC auth code (#9981) is already in prod, flag-OFF; this turns the auth fast-path ON → collapses auth+org+moderation into a single KV read, killing the measured **~1.5s cold-auth spike** (1557ms cold → 7ms warm).

## Risk: low, fails SAFE
- On any cache miss/unavailable, the resolver falls back to the authoritative slow path (re-auth via `requireAuthOrApiKeyWithOrg`). **No auth is ever granted from a failed cache read.**
- **Billing flag left OFF** (`INFERENCE_OPTIMISTIC_BILLING = "false"`) — that's step 2 and the separate real-money call. SAFE_BALANCE_THRESHOLD stays `""` (+Inf).
- Default + staging blocks untouched (and staging deploys from develop anyway).

## Runbook
1. Merge this → main→prod auto-deploys → auth fast-path live.
2. Watch error rates / `failureKind:local_inference` for a few min.
3. If clean → step 2 PR flips `INFERENCE_OPTIMISTIC_BILLING="true"` + sets `SAFE_BALANCE_THRESHOLD` (the credit-reserve skip, the bigger lever — real-money, your explicit call).
4. I'll verify prod latency live the moment it's flipped (need a fresh explorer key / on-device sign-in).

Revert = flip back to `"false"` + redeploy. Code is byte-identical to flag-OFF, so revert is clean.