### PR TITLE
fix(ci): make feed-test lane self-contained

### DIFF
--- a/.github/workflows/feed-test.yml
+++ b/.github/workflows/feed-test.yml
@@ -89,6 +89,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Build @elizaos/core dist
+        run: bun run --cwd packages/core build
+
       - name: Run feed unit tests
         working-directory: packages/feed
         run: bun run test:unit

--- a/bun.lock
+++ b/bun.lock
@@ -188,9 +188,6 @@
         "vite": "^8.0.8",
         "vitest": "^4.0.18",
       },
-      "optionalDependencies": {
-        "node-pty": "^1.0.0",
-      },
       "peerDependencies": {
         "@elizaos/app-core": "workspace:*",
       },
@@ -1913,6 +1910,7 @@
         "@aws-sdk/lib-storage": "^3.943.0",
         "@feed/shared": "workspace:*",
         "@vercel/blob": "2.3.2",
+        "drizzle-orm": "^0.45.2",
         "graphql": "16.13.2",
         "graphql-request": "7.4.0",
         "ioredis": "5.10.1",
@@ -1955,6 +1953,7 @@
       "dependencies": {
         "@feed/db": "workspace:*",
         "@feed/shared": "workspace:*",
+        "drizzle-orm": "^0.45.2",
       },
       "devDependencies": {
         "@types/node": "^24.10.0",
@@ -12102,8 +12101,6 @@
 
     "node-mock-http": ["node-mock-http@1.0.4", "", {}, "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ=="],
 
-    "node-pty": ["node-pty@1.1.0", "", { "dependencies": { "node-addon-api": "^7.1.0" } }, "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg=="],
-
     "node-releases": ["node-releases@2.0.50", "", {}, "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg=="],
 
     "nodemailer": ["nodemailer@9.0.1", "", {}, "sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw=="],
@@ -15963,8 +15960,6 @@
     "node-gyp/which": ["which@6.0.1", "", { "dependencies": { "isexe": "^4.0.0" }, "bin": { "node-which": "bin/which.js" } }, "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg=="],
 
     "node-localstorage/write-file-atomic": ["write-file-atomic@1.3.4", "", { "dependencies": { "graceful-fs": "^4.1.11", "imurmurhash": "^0.1.4", "slide": "^1.1.5" } }, "sha512-SdrHoC/yVBPpV0Xq/mUZQIpW2sWXAShb/V4pomcJXh92RuaO+f3UTWItiR3Px+pLnV2PvC2/bfn5cwr5X6Vfxw=="],
-
-    "node-pty/node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
 
     "normalize-package-data/hosted-git-info": ["hosted-git-info@4.1.0", "", { "dependencies": { "lru-cache": "^6.0.0" } }, "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA=="],
 

--- a/packages/feed/packages/api/package.json
+++ b/packages/feed/packages/api/package.json
@@ -19,6 +19,7 @@
     "@aws-sdk/lib-storage": "^3.943.0",
     "@feed/shared": "workspace:*",
     "@vercel/blob": "2.3.2",
+    "drizzle-orm": "^0.45.2",
     "graphql": "16.13.2",
     "graphql-request": "7.4.0",
     "ioredis": "5.10.1",

--- a/packages/feed/packages/core/package.json
+++ b/packages/feed/packages/core/package.json
@@ -58,7 +58,8 @@
   },
   "dependencies": {
     "@feed/shared": "workspace:*",
-    "@feed/db": "workspace:*"
+    "@feed/db": "workspace:*",
+    "drizzle-orm": "^0.45.2"
   },
   "devDependencies": {
     "@types/node": "^24.10.0",


### PR DESCRIPTION
## Summary

- makes the new `feed-test` workflow self-contained by building `@elizaos/core` before feed unit tests import feed agent plugins
- declares `drizzle-orm` directly in `@feed/api` and `@feed/core`, the packages that import it
- reconciles `bun.lock` so the workflow `bun install --frozen-lockfile` step passes after #10055

## Why

#10055 was merged while I was validating it. The merged lane still fails on a clean runner path: first frozen install wants a lockfile update, then feed unit tests expose missing package links and an unbuilt workspace `@elizaos/core` dist. This follow-up keeps the lane honest without broadening the test scope.

## Validation

- `git diff --check origin/develop...HEAD`
- `bun install --frozen-lockfile`
- `bun run --cwd packages/core build`
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/feed_test DIRECT_DATABASE_URL=postgres://postgres:postgres@localhost:5432/feed_test NEXT_PUBLIC_STEWARD_API_URL=http://localhost:31337 STEWARD_JWT_SECRET=ci-feed-unit-placeholder-jwt-secret CRON_SECRET=ci-feed-unit-placeholder-cron-secret NODE_ENV=test CI=true bun run test:unit` from `packages/feed` -> 389 files passed, 0 failed
