### PR TITLE
Close out 8-issue sweep: cloud login IA, multi-tenant hardening, agent backup/rollback, TEE consolidation

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "audit:ui-determinism:update": "node packages/scripts/audit-ui-determinism.mjs --update-baseline",
     "audit:type-safety-ratchet": "node packages/scripts/type-safety-ratchet.mjs",
     "audit:type-safety-ratchet:self-test": "node packages/scripts/type-safety-ratchet.mjs --self-test",
+    "audit:tee-secret-leak": "node packages/scripts/audit-tee-secret-leak.mjs",
+    "audit:tee-secret-leak:self-test": "node packages/scripts/audit-tee-secret-leak.mjs --self-test",
     "audit:apple-store-sandbox": "bun run --cwd packages/app-core audit:apple-store-sandbox",
     "test:launch-qa:docs": "node packages/scripts/launch-qa/check-docs.mjs --scope=launchdocs --json",
     "test:launch-qa": "bun test packages/scripts/launch-qa/*.test.ts && bun run test:launch-qa:docs && node packages/scripts/launch-qa/check-mobile-artifacts.mjs --json --allow-missing-generated && node packages/scripts/launch-qa/check-model-data.mjs --json && node packages/scripts/launch-qa/run.mjs --suite quick --dry-run",

--- a/packages/agent/docs/tee-agent-implementation-plan.md
+++ b/packages/agent/docs/tee-agent-implementation-plan.md
@@ -2,10 +2,15 @@
 
 Date: 2026-05-21
 Lane: AGENT-RUNTIME (confidential agent + confidential inference)
-Status: planning. The agent-side primitives exist and are unit-tested; the
-production wiring, the confidential-inference unseal path, and all real
-hardware quote verification are not yet built. Real TDX/CoVE quote
-verification is **BLOCKED on hardware** and is called out as such throughout.
+Status: **Phase A landed (software-only).** The agent-side primitives, the
+production boot-gate wiring, the production profile, the nonce/`report_data`
+replay binding, the signed revocation manifest, and the confidential-inference
+unseal *plumbing* (against the local mock KMS) are built and unit-tested — see
+the Phase A table in §7 and the DONE markers in §1.2. **All real hardware quote
+verification (real TDX/CoVE quote signature, RTMR, and `report_data` validation;
+the dstack guest agent; RA-TLS KMS; H100 GPU attestation) is Phase B/C and stays
+BLOCKED on hardware** — called out as such throughout. Phase A verifies a signed
+evidence *document* and fails closed; it does not claim hardware-verified trust.
 
 Scope discipline (repo `AGENTS.md`): this document is the plan only. It does
 not refactor production code. It proposes strongly-typed additions (no `any`,
@@ -77,6 +82,15 @@ they are good:
 
 ### 1.2 What is mock, stubbed, or thin — be specific
 
+> **Status reconciliation (Phase A landed).** Several gaps called out below have
+> since been closed in software (Phase A — no hardware required) and are marked
+> **DONE** inline with the implementing file. What remains genuinely blocked is
+> **real hardware quote verification** (TDX signature / RTMR / `report_data`
+> validation, the dstack guest agent, RA-TLS KMS, H100 GPU attestation) — Phase
+> B/C, **BLOCKED on hardware**. The software items below do **not** make the
+> system hardware-trusted; they verify a signed evidence *document* and fail
+> closed when it is absent, simulated, replayed, or tampered.
+
 - **No real quote verification anywhere.** `dstack-tee-provider.ts` *fetches or
   reads* a `TeeEvidence` JSON blob (`ELIZA_TEE_EVIDENCE_JSON/_URL/_PATH`,
   `DSTACK_TAPPD_URL`) and normalizes it. It never parses a TDX quote, never
@@ -88,35 +102,51 @@ they are good:
   for the macOS-feasible lane and unit tests, but it is **not** the security
   property the product claims, and the codebase does not currently hide that —
   it just hasn't built the verifier. (Honest gap, not slop.)
-- **`HttpTeeKeyReleaseClient` does not generate or bind a fresh nonce.** The
-  *policy* can carry an `expectedNonce`, but the client sends whatever nonce is
-  already in the evidence; it does not (a) request a challenge nonce from the KMS,
-  (b) generate an ephemeral keypair, or (c) bind `report_data = H(nonce || epk)`.
-  So the HTTP path as written is replayable against a passive collector. The
-  `tee-protected-agent-vm.md` and chip §3.2 docs *specify* the `report_data`
-  binding, but the client does not implement it.
+- **DONE (A7) — nonce + `report_data` replay binding.** `tee-key-release.ts` now
+  generates a fresh ephemeral X25519 keypair and a fresh nonce per request and
+  binds `report_data = SHA256(nonce || epk_pub)` (`TeeReportDataChallenge`,
+  `collectEvidenceWithReportData`). The issued nonce is set as `policy.expectedNonce`
+  so `evaluateTeeEvidencePolicy` rejects `nonce-mismatch`, closing the replay gap
+  for a passive collector. (Originally: the client sent whatever nonce was already
+  in the evidence — replayable.) The crypto binding is real; **the quote that
+  carries `report_data` is still not hardware-verified — Phase B2, BLOCKED.**
 - **`LocalTeeKeyReleaseClient` is an HMAC KDF, not a KMS.** It derives key
   material with `HMAC-SHA256(masterSecret, keyId|context|agent|policy|device)`.
   This is a faithful *model* of "deterministic app-key bound to measurement" and
   it correctly varies output per agent/policy measurement (proven by test), but
   the `masterSecret` lives in agent memory. It is a local-dev stand-in for the
   dstack decentralized KMS, not the KMS.
-- **No production wiring.** `grep` of `packages/agent/src/index.ts` shows the
-  `tee-*` modules are only `export *`-ed. **Nothing in the agent boot path calls
-  `resolveTeeRuntimePolicy`, installs the dstack provider, gates secret/model-key
-  release, or wraps the signer with `TeeSignerBackend` at runtime.** The suite is
-  a tested library with two scripts; it is not yet on the agent's actual startup
-  path. `ELIZA_TEE_REQUIRED=true` resolves a policy object but no boot code
-  *consumes* it to fail closed.
-- **No confidential-inference path at all.** There is no model-weights unseal,
-  no encrypted-at-rest weights, no `model-key` release wired into the local model
-  runtime. `secretScopes: ["agent-session","model-key","remote-signing"]` exists
-  only in the example deployment JSON; `model-key` has no consumer.
-- **DevMode / fake-quote defenses are not centralized.** The policy *can* require
-  `debugDisabled:true`, but there is no single "production profile" that a caller
-  can't forget to apply, and no rejection of dstack DevMode evidence beyond a
-  caller remembering to set the claim. No KMS-identity pinning, no RA-TLS cert
-  verification toggle, no refusal of HTTP (non-TLS) KMS in production.
+- **DONE (A4) — production boot-gate wiring.** `runtime/eliza.ts` now runs
+  `runTeeBootGate` at startup: it calls `evaluateTeeBootGate` (which resolves the
+  runtime policy, merges the production profile, collects evidence, and evaluates
+  trust ONCE), fails closed on any error, and publishes the decision via
+  `setTeeBootGateState`. Secret-bearing paths consult `teeBootGateBlocksSecrets()`
+  (`tee-boot-gate-state.ts`), and `assertTeeBootGateAllowsSecrets` throws
+  fail-closed when secrets are disabled. `ELIZA_TEE_REQUIRED=true` with no trusted
+  evidence ⇒ no model-key release, no signing, no remote-plugin sync; degraded
+  boot allowed, silent secret release never. (Originally: `tee-*` was only
+  `export *`-ed with no boot consumer.)
+- **DONE (A8) — confidential-inference unseal plumbing.**
+  `tee-confidential-inference.ts` releases the `model-key` (`MODEL_KEY_ID`) only
+  after the key-release client's evidence satisfies the policy, then decrypts the
+  at-rest weights blob in process memory and hands it to the local runtime. The
+  test asserts the weights and key never touch disk, env, or the structured
+  logger, and that tampered/absent evidence makes the key unavailable so unseal
+  throws (negative path enforced by data unavailability). (Originally: no unseal
+  path, `model-key` had no consumer.) This runs against the **local HMAC KDF /
+  mock KMS** — the **real RA-TLS KMS and real quote verification are Phase B,
+  BLOCKED.**
+- **DONE (A3/A6) — centralized production profile rejecting DevMode/simulated
+  evidence.** `tee-production-profile.ts` (`mergeTeeProductionProfile`) forces
+  `required`, `requiredClaims` (`debugDisabled`/`productionLifecycle`), and
+  `rejectSimulatedEvidence` on, so a caller cannot accept DevMode evidence by
+  forgetting a claim. `evaluateTeeEvidencePolicy` rejects evidence that
+  self-identifies as mock/simulated/debug/devmode (kind, hardwareVendor, provider,
+  quote markers, verifier) — the `tee-production-profile.test.ts` matrix proves
+  it. This is an agent-side compensating control against dstack #608 (DevMode
+  allow-all); it does **not** replace **real quote-signature verification —
+  Phase B2, BLOCKED.** KMS-identity pinning / RA-TLS cert verification config
+  fields exist (A6) but the live RA-TLS handshake is Phase B.
 - **Two `Tee*` type homes.** `packages/core/src/types/tee.ts` defines a *legacy*
   `TeeAgent`/`RemoteAttestationQuote`/`TEEMode`/`TeeType` set (old plugin-tee
   shape). The *new* canonical types live in `packages/agent/src/services/tee-evidence.ts`.
@@ -473,20 +503,24 @@ fail-closed.
 
 ### Phase A — buildable now (no hardware), software-only
 
-| ID | Work item | Effort | Gate |
+All Phase A items are **DONE** (software-only, no hardware). They verify a signed
+evidence *document* and fail closed; none of them claims hardware-verified trust —
+that stays Phase B/C, BLOCKED.
+
+| ID | Status | Work item | Gate |
 | --- | --- | --- | --- |
-| A1 | Extend `tee-full-stack-local.ts` with real policy vectors: per-topology policies (local-only, desktop, cloud-routed) + golden/tampered fixtures for every decision reason (kind/provider/measurement/version/nonce/timestamp/claim/revoked). | 1 | `tee-full-stack-local` |
-| A2 | Negative-test matrix: a vitest fixture asserting each `reason` in the decision union for crafted evidence. Pure data, no `any`. | 1 | new `tee-evidence-policy.matrix.test.ts` |
-| A3 | `teeProductionProfile()` + profile-merge helper (§4.2); unit tests that prove DevMode/debug evidence is rejected under it. | 1 | unit |
-| A4 | Boot wiring (§4.1): consume `resolveTeeRuntimePolicy` at agent startup, fail-closed `[TeeBootGate]`, wrap signer in `TeeSignerBackend`, gate model-key + agent-session release. | 2 | integration test + smoke |
-| A5 | Revocation-manifest signature verification at load (§3.4); deny unsigned/invalid manifests. | 1 | unit |
-| A6 | dstack provider hardening that needs no hardware: payload size cap (§5.6), https-only + KMS-identity-pin config fields (§5.3/5.4), constant-time nonce/key compare (§5.7), reject mock `verifier`/`hardwareVendor`/simulated quotes under production profile (§5.2). | 2 | unit |
-| A7 | Nonce + epk binding in the key-release client (§3.2): generate epk, request/echo nonce, set `report_data`, verify key wrapped to epk. (Crypto only; no real quote yet.) | 2 | unit |
-| A8 | Confidential-inference unseal *plumbing* (§2.2 steps 4–7) against the mock KMS: encrypt a weights blob at rest, release `model-key`, decrypt in-memory, hand to the local runtime; assert no temp-file/plaintext on disk and no secret in logs (§4.4). | 3 | new `tee-confidential-inference-local` script |
-| A9 | CI gate (§4.4): grep crash/telemetry serializers + env-dump paths for secret-scope keys; fail on leak. | 0.5 | new lint gate |
+| A1 | DONE | Extend `tee-full-stack-local.ts` with real policy vectors: per-topology policies (local-only, desktop, cloud-routed) + golden/tampered fixtures for every decision reason (kind/provider/measurement/version/nonce/timestamp/claim/revoked). | `tee-full-stack-local` |
+| A2 | DONE | Negative-test matrix asserting each `reason` in the decision union for crafted evidence. Pure data, no `any`. | `tee-evidence-policy.matrix.test.ts` |
+| A3 | DONE | `teeProductionProfile()` + profile-merge helper (§4.2); rejects DevMode/debug evidence. | `tee-production-profile.ts` / `.test.ts` |
+| A4 | DONE | Boot wiring (§4.1): `runTeeBootGate` in `runtime/eliza.ts`, fail-closed `[TeeBootGate]`, gate model-key + agent-session release; cross-module state via `tee-boot-gate-state.ts`. | `tee-boot-gate*.ts` / `.test.ts` |
+| A5 | DONE | Revocation-manifest Ed25519 signature verification at load (§3.4); deny unsigned/invalid manifests. | `tee-revocation.ts` / `tee-revocation-signature.test.ts` |
+| A6 | DONE | dstack provider hardening (no hardware): payload size cap, https-only + KMS-identity-pin config fields, constant-time nonce/key compare, reject mock `verifier`/`hardwareVendor`/simulated quotes under production profile. | unit |
+| A7 | DONE | Nonce + epk binding in the key-release client (§3.2): generate epk, issue/echo nonce, set `report_data`, verify key wrapped to epk. (Crypto only; no real quote yet.) | `tee-key-release.ts` / `.test.ts` |
+| A8 | DONE | Confidential-inference unseal *plumbing* (§2.2 steps 4–7) against the mock KMS: encrypt weights at rest, release `model-key`, decrypt in-memory, hand to the local runtime; assert no temp-file/plaintext on disk and no secret in logs (§4.4). | `tee-confidential-inference.ts` / `.test.ts` |
+| A9 | DONE | CI gate (§4.4): grep crash/telemetry serializers + env-dump paths for secret-scope keys; fail on leak. In-lane via `tee-secret-hygiene.test.ts`; repo-wide CLI gate `packages/scripts/audit-tee-secret-leak.mjs` (`--self-test`). | lint gate |
 
 Critical path for Phase A: A3 → A4 → A8 (the headline unseal plumbing depends on
-the production profile and boot wiring). A1/A2/A5/A6/A7/A9 parallelize.
+the production profile and boot wiring). A1/A2/A5/A6/A7/A9 parallelized.
 
 ### Phase B — cloud-TDX-gated (real dstack KMS on TDX + H100)
 

--- a/packages/app-core/deploy/cloud-agent-shared.ts
+++ b/packages/app-core/deploy/cloud-agent-shared.ts
@@ -9,6 +9,29 @@
 import * as crypto from "node:crypto";
 import * as http from "node:http";
 
+// ─── Logger ─────────────────────────────────────────────────────────────
+//
+// This file is bundled with `--external:@elizaos/*` and runs in a minimal
+// container before any `@elizaos/*` package is statically resolvable, so it
+// cannot import the shared structured logger. This tiny shim gives the same
+// `[ClassName]`-prefixed, level-tagged, single-line structured output the
+// logger commandment requires (message + optional context object), without a
+// hard dependency. All cloud-agent runtime logging goes through it.
+const logger = {
+  info(message: string, context?: Record<string, unknown>): void {
+    if (context) console.log(`[cloud-agent] ${message}`, context);
+    else console.log(`[cloud-agent] ${message}`);
+  },
+  warn(message: string, context?: Record<string, unknown>): void {
+    if (context) console.warn(`[cloud-agent] ${message}`, context);
+    else console.warn(`[cloud-agent] ${message}`);
+  },
+  error(message: string, context?: Record<string, unknown>): void {
+    if (context) console.error(`[cloud-agent] ${message}`, context);
+    else console.error(`[cloud-agent] ${message}`);
+  },
+};
+
 // ─── Types ──────────────────────────────────────────────────────────────
 
 export interface BridgeRpcParams {
@@ -459,11 +482,9 @@ export function startCloudAgent(userConfig: CloudAgentConfig = {}): void {
         getConfig: () => state.config,
       };
 
-      console.log("[cloud-agent] elizaOS runtime initialized with real agent");
+      logger.info("elizaOS runtime initialized with real agent");
     } else {
-      console.warn(
-        "[cloud-agent] @elizaos/core not available, running in echo mode",
-      );
+      logger.warn("@elizaos/core not available, running in echo mode");
       agentRuntime = {
         processMessage: async (params: BridgeRpcParams): Promise<string> => {
           const normalized = normalizeBridgeMessage(params);
@@ -565,7 +586,7 @@ export function startCloudAgent(userConfig: CloudAgentConfig = {}): void {
   });
 
   healthServer.listen(PORT, "0.0.0.0", () => {
-    console.log(`[cloud-agent] Health endpoint listening on port ${PORT}`);
+    logger.info(`Health endpoint listening on port ${PORT}`);
   });
 
   // ─── Bridge HTTP server ───────────────────────────────────────────────
@@ -610,7 +631,7 @@ export function startCloudAgent(userConfig: CloudAgentConfig = {}): void {
       if (incoming.config) state.config = incoming.config;
       if (incoming.workspaceFiles)
         state.workspaceFiles = incoming.workspaceFiles;
-      console.log("[cloud-agent] State restored from snapshot");
+      logger.info("State restored from snapshot");
       res.writeHead(200);
       res.end(JSON.stringify({ success: true }));
       return;
@@ -767,21 +788,19 @@ export function startCloudAgent(userConfig: CloudAgentConfig = {}): void {
 
   const bridgeBindAddress = bridgeSecretGenerated ? "127.0.0.1" : "0.0.0.0";
   bridgeServer.listen(BRIDGE_PORT, bridgeBindAddress, () => {
-    console.log(
-      `[cloud-agent] Bridge server listening on ${bridgeBindAddress}:${BRIDGE_PORT}`,
-    );
+    logger.info(`Bridge server listening on ${bridgeBindAddress}:${BRIDGE_PORT}`);
     if (bridgeSecretGenerated) {
-      console.warn(
-        "[cloud-agent] CRITICAL: No BRIDGE_SECRET configured — generated ephemeral secret and bound to 127.0.0.1 only",
+      logger.warn(
+        "CRITICAL: No BRIDGE_SECRET configured — generated ephemeral secret and bound to 127.0.0.1 only",
       );
-      console.log(`[cloud-agent] Generated BRIDGE_SECRET: ${BRIDGE_SECRET}`);
+      logger.info(`Generated BRIDGE_SECRET: ${BRIDGE_SECRET}`);
     }
   });
 
   // ─── Startup ──────────────────────────────────────────────────────────
 
   function shutdown() {
-    console.log("[cloud-agent] Shutting down...");
+    logger.info("Shutting down...");
     healthServer.close();
     bridgeServer.close();
     process.exit(0);
@@ -791,10 +810,12 @@ export function startCloudAgent(userConfig: CloudAgentConfig = {}): void {
 
   initRuntime()
     .then(() => {
-      console.log("[cloud-agent] Ready");
+      logger.info("Ready");
     })
     .catch((err) => {
-      console.error("[cloud-agent] Runtime init failed:", err);
+      logger.error("Runtime init failed", {
+        err: err instanceof Error ? err.message : String(err),
+      });
       process.exit(1);
     });
 }

--- a/packages/cloud/infra/cloud/CONFIDENTIAL_COMPUTE.md
+++ b/packages/cloud/infra/cloud/CONFIDENTIAL_COMPUTE.md
@@ -1,0 +1,94 @@
+# Confidential compute: host verdict and routing
+
+This doc records the verified verdict for **where confidential (memory-encrypted,
+hardware-attested) workloads run** in the elizaOS Cloud stack, so nobody assumes
+the Hetzner control/data plane can host them.
+
+## Verdict: Hetzner ships no managed confidential-compute product
+
+Hetzner Cloud offers **no SEV-SNP, no TDX, no memory-encryption, and no remote
+attestation** product. There is no Hetzner-managed confidential-VM SKU, no
+attestation service, and no enclave primitive to target.
+
+This is verifiable against the IaC in this repo. Grepping the entire Hetzner
+Terraform tree returns **zero hits** for every confidential-compute keyword:
+
+```bash
+grep -rniE 'confidential|sev|snp|tdx|attestation|enclave' \
+  packages/cloud/infra/cloud/terraform/hetzner/
+# → 0 matches
+```
+
+The strongest isolation any Hetzner server type in this repo provides is the
+**dedicated-vCPU `ccx`** line (e.g. `ccx23` = 4 dedicated vCPU / 16 GB, used for
+the apps data-plane that runs untrusted user containers; see
+[`apps-data-plane/variables.tf`](./terraform/hetzner/apps-data-plane/variables.tf)).
+Dedicated vCPU means **dedicated physical cores** — no CPU steal from noisy
+neighbors, which reduces (does not eliminate) cross-tenant timing side-channel
+exposure. It is **scheduling isolation, not cryptographic isolation**:
+
+- RAM is **not** encrypted against the host/hypervisor. A compromised or
+  malicious host can read guest memory in cleartext.
+- There is **no measured launch and no attestation quote** — nothing proves to a
+  remote party which code/firmware/policy actually booted.
+
+`ccx23` is therefore the right choice for "don't let other tenants steal my CPU,"
+and the wrong choice for "the cloud operator must be unable to read my model
+weights, prompts, KV-cache, or signing keys." Confidential compute requires
+**hardware memory encryption plus remote attestation** — AMD **SEV-SNP** or Intel
+**TDX** at the CPU level (and, for confidential GPU inference, NVIDIA H100
+confidential computing). Hetzner provides none of these.
+
+## Where confidential workloads route: Phala dStack CVM (Intel TDX)
+
+Confidential workloads route to **Phala dStack Confidential VMs on Intel TDX**,
+**not** to Hetzner:
+
+- **Deploy as-is.** dStack runs an existing `docker-compose.yml` inside a TDX
+  CVM with no app rewrite — the same compose this stack already produces.
+- **Built-in remote attestation.** The CVM emits a TDX quote that binds the
+  **image hash, launch arguments, and environment** of what actually booted, so a
+  remote verifier can confirm the measured workload before trusting it.
+- **KMS-in-TEE, attestation-gated.** dStack's decentralized KMS **verifies the
+  TDX quote before releasing** deterministic, per-app keys. Keys are released
+  *only* against a quote that matches the expected measurements — fail-closed by
+  data unavailability, not by a software check that could be patched out.
+- **Optional confidential GPU.** For GPU inference, dStack supports an NVIDIA
+  confidential-GPU (H100 CC) path so weights/activations stay encrypted on the
+  GPU as well.
+
+These are the exact hardware properties Hetzner lacks: **SEV-SNP / TDX hardware
+attestation** (measured launch + signed quote + memory encryption) is the
+non-negotiable requirement for confidential compute, and only the TDX platform
+under dStack satisfies it here.
+
+## Division of responsibility
+
+| Plane | Runs on | Confidential? |
+| --- | --- | --- |
+| Control plane (orchestrator, routing, monitoring) | Hetzner `cpx`/`ccx` VMs | No — non-confidential by design |
+| Data plane (agent sandboxes, app workers) | Hetzner `cpx`/`ccx` VMs | No — dedicated vCPU isolation only |
+| Confidential workloads (sealed weights, attested key release, private inference) | **Phala dStack CVM (Intel TDX)** | **Yes — hardware attestation + memory encryption** |
+
+Hetzner stays the **non-confidential control/data plane**. Anything that needs
+the operator to be unable to read in-domain secrets routes to dStack TDX.
+
+## Agent-side trust contract
+
+The agent never trusts a workload as "confidential" because of where it runs. The
+provider-neutral evidence + trust-decision contract is enforced in code:
+
+- `packages/agent/src/services/tee-evidence.ts` — normalized `TeeEvidence` shape.
+- `packages/agent/src/services/tee-policy.ts` — `evaluateTeeEvidencePolicy`, the
+  single fail-closed trust-decision path (kind/provider allowlist, measurement
+  match, security-version floor, nonce + freshness, required claims).
+- `packages/agent/src/services/tee-boot-gate.ts` — boots fail-closed: no trusted
+  evidence ⇒ no model-key release, no signing, no remote-plugin sync.
+
+**Not yet hardware-verified (BLOCKED on hardware):** real TDX quote-signature /
+RTMR / `report_data` verification, the dStack guest agent, RA-TLS KMS, and H100
+GPU attestation are not implemented here and stay BLOCKED. Until they land the
+agent verifies a *signed evidence document*, not a hardware quote, and must not
+claim hardware-verified trust. See
+[`packages/agent/docs/tee-agent-implementation-plan.md`](../../../agent/docs/tee-agent-implementation-plan.md)
+Phase B/C for the blocked items and their hardware dependencies.

--- a/packages/cloud/infra/cloud/terraform/hetzner/ARCHITECTURE.md
+++ b/packages/cloud/infra/cloud/terraform/hetzner/ARCHITECTURE.md
@@ -53,6 +53,17 @@ traffic spike" failure mode. Pulling sandboxes off the data plane is the
 autoscaler's job; the orchestrator that issues drain commands must stay up
 to coordinate it.
 
+## Confidential compute is not on Hetzner
+
+Both tiers above are **non-confidential**. Hetzner ships no SEV-SNP / TDX /
+memory-encryption / attestation product — the strongest isolation here is the
+dedicated-vCPU `ccx` line (scheduling isolation, not cryptographic isolation; the
+host can still read guest RAM). Confidential workloads (sealed model weights,
+attestation-gated key release, private inference) route to **Phala dStack CVM on
+Intel TDX**, never to these Hetzner VMs. See
+[`CONFIDENTIAL_COMPUTE.md`](../../CONFIDENTIAL_COMPUTE.md) for the verified verdict
+and the SEV-SNP/TDX hardware-attestation requirement.
+
 ## Code ↔ infrastructure mapping
 
 | Component | Code | Infra |

--- a/packages/cloud/shared/docs/agent-backup.md
+++ b/packages/cloud/shared/docs/agent-backup.md
@@ -1,0 +1,105 @@
+# Agent backup — real state surface (spec)
+
+> Status: **specification / gap analysis.** This documents what a *real*
+> full-agent backup must cover so a backup → wipe → restore round-trip across
+> topologies is faithful. It is the contract the next backup-engine PR builds
+> to. Issue #9963.
+
+## Why this exists
+
+Today's snapshot payload is a 3-field toy. `AgentBackupStateData`
+([`src/db/schemas/agent-sandboxes.ts:207`](../src/db/schemas/agent-sandboxes.ts))
+is:
+
+```ts
+interface AgentBackupStateData {
+  memories: Array<{ role: string; text: string; timestamp: number }>;
+  config: Record<string, unknown>;
+  workspaceFiles: Record<string, string>;
+}
+```
+
+It is produced by the cloud-agent template's demo `/api/snapshot` handler
+([`packages/app-core/deploy/cloud-agent-shared.ts`](../../../app-core/deploy/cloud-agent-shared.ts),
+the `/api/snapshot` + `/api/restore` block) and pulled by
+`ElizaSandboxService.fetchSnapshotState`
+([`src/lib/services/eliza-sandbox.ts:4771`](../src/lib/services/eliza-sandbox.ts)).
+The deployed elizaOS V2 agent image does not even serve `/api/snapshot`, so a
+real backup against it is a no-op today (the `SNAPSHOT_ENDPOINT_UNSUPPORTED`
+sentinel). `memories` / `config` / `workspaceFiles` capture none of the durable
+agent state below. A wipe-and-restore using this payload silently loses the
+database, all media, and every secret.
+
+## The real state surface a backup MUST cover
+
+A faithful backup is a manifest of components, each with its own integrity hash,
+so a partial/corrupt restore is detectable and **fails loudly** rather than
+booting a half-restored agent.
+
+| Component | Source of truth | Notes |
+| --- | --- | --- |
+| **Database** | plugin-sql PGlite dir (`resolvePgliteDir()`, [`plugins/plugin-sql/src/utils.ts:31`](../../../../plugins/plugin-sql/src/utils.ts)) **or** external `POSTGRES_URL` | Local agents store everything in the PGlite dir (memories, entities, relationships, rooms, tasks, embeddings). Back it up as a consistent snapshot of the data dir; for an external Postgres, take a logical dump (`pg_dump`), not a file copy. This — not the `memories` array — is the canonical conversation/memory store. |
+| **Content-addressed media** | `${STATE_DIR}/media/<sha256>.<ext>` ([`packages/agent/src/api/media-store.ts:173`](../../../../packages/agent/src/api/media-store.ts), served at `/api/media/<sha256>.<ext>`) | The single attachment store. The sha256 filename IS the integrity hash — verify each file's bytes hash to its name on restore. The DB references media by URL; restoring the DB without these files yields dangling attachments. GC (`gcUnreferencedMedia`) runs on a grace window, so capture media and DB as one consistent point. |
+| **Vault / secrets** | encrypted secret store (org encryption keys: [`src/db/schemas/organization-encryption-keys.ts`](../src/db/schemas/organization-encryption-keys.ts)) | API keys, wallet keys, connector tokens. **Back up the ciphertext only — never plaintext.** The decryption key is org-scoped and lives outside the per-agent backup; a backup must be restorable only by an actor who already holds that key. |
+| **Character + remaining state-dir** | `agent_config` / character JSON + everything else under `${STATE_DIR}` | Character definition, plugin config, scheduled-task records, and any plugin-written state-dir files (logs excluded). |
+
+### Per-component integrity hashes
+
+The manifest stores a sha256 per component (the DB dump, the media set as a
+whole or per file, the secrets blob, the character) plus a top-level manifest
+hash. Restore verifies each hash before applying; **a mismatch aborts the whole
+restore** — no silent partial restore, no "best-effort" merge. This mirrors the
+existing `content_hash` integrity check already used for incremental backup
+chain reconstruction in
+[`src/db/repositories/agent-sandboxes.ts`](../src/db/repositories/agent-sandboxes.ts)
+(`getReconstructedBackupState`).
+
+## Storage target — dual: local file + cloud R2
+
+The backup must land in two places, selectable per deployment:
+
+1. **Local file** — a manifest + component blobs under the state dir, for
+   local-only / desktop agents with no cloud.
+2. **Cloud R2** — via the bound `BLOB` R2 bucket
+   ([`src/types/cloud-worker-env.ts:19`](../src/types/cloud-worker-env.ts)),
+   for managed-fleet agents.
+
+The schema is already wired for the R2 leg but the columns are **currently
+dead** — every backup row is written with `state_data_storage = 'inline'` and a
+null `state_data_key`
+([`src/db/schemas/agent-sandboxes.ts:226`](../src/db/schemas/agent-sandboxes.ts)).
+The offload helpers exist (`ObjectStorageMode = "inline" | "r2"`,
+`offloadJsonField` / `getObjectText` in
+[`src/lib/storage/object-store.ts`](../src/lib/storage/object-store.ts)) and the
+backup repository already calls them on the `state_data` jsonb, but for the
+full-surface manifest the backup engine must set `state_data_storage = 'r2'` and
+populate `state_data_key` with the R2 object key of the offloaded manifest.
+
+## Relationship to existing primitives (reuse, do NOT duplicate)
+
+- **Backup rows:** reuse the `agent_sandbox_backups` table and the
+  `agent-backup-diff` full/incremental delta engine
+  ([`src/lib/services/agent-backup-diff.ts`](../src/lib/services/agent-backup-diff.ts)).
+  Do NOT add a second backup table or a parallel snapshot store.
+- **Snapshot types:** the real manifest still flows through `snapshot_type`
+  (`auto` | `manual` | `pre-shutdown` | `pre-upgrade`). The `pre-upgrade` type
+  is the restore point `executeDowngrade` replays on rollback (#9964).
+- **Restore:** reuse `getReconstructedBackupState()` for chain replay and the
+  bridge `/api/restore` push.
+
+## Out of scope for the current pass (next-PR steps)
+
+These are explicitly deferred — the current PR only lands the schema/type/code
+scaffolding and this spec:
+
+1. **R2 offload wiring for the full manifest** — flip `state_data_storage='r2'`
+   + populate `state_data_key` for the real backup engine (helpers exist; not
+   yet called for the full surface).
+2. **The full local backup engine** — DB dump/restore, media set capture +
+   hash-verify, encrypted-secrets capture, character + state-dir, manifest
+   assembly with per-component integrity hashes.
+3. **Cross-topology backup → wipe → restore e2e** — requires an armed staging
+   provisioning daemon + a real `@elizaos/agent` container image; cannot run in
+   a unit context.
+4. **Local LifeOps-scheduled backup** — schedule recurring backups via the
+   existing LifeOps scheduled-task runner; do NOT add a second scheduler.

--- a/packages/cloud/shared/package.json
+++ b/packages/cloud/shared/package.json
@@ -21,6 +21,7 @@
     "lint:fix": "bunx @biomejs/biome check --write .",
     "typecheck": "tsgo --noEmit",
     "check:tenant-scope": "bun scripts/check-tenant-scope.ts",
+    "check:tenant-scope:self-test": "bun test scripts/check-tenant-scope.test.ts",
     "verify:tenant-isolation": "bun scripts/verify-tenant-db-isolation.ts",
     "test": "bun test --isolate",
     "preflight:messaging-gateways": "node scripts/messaging-gateway-preflight.mjs",

--- a/packages/cloud/shared/scripts/check-tenant-scope.test.ts
+++ b/packages/cloud/shared/scripts/check-tenant-scope.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { findUnscopedTenantReads } from "./check-tenant-scope";
+
+// Each fixture is a tiny repository module; the gate parses it from disk, so we
+// write a temp file per case and feed its path to findUnscopedTenantReads. The
+// preamble imports the drizzle combinators + tenant table identifiers the gate
+// pattern-matches on (only the identifier names matter — never executed).
+const PREAMBLE = `
+import { and, or, eq, inArray } from "drizzle-orm";
+import { apps, appUsers } from "../schemas";
+declare const dbRead: any;
+`;
+
+let tempDir: string | undefined;
+
+function fixture(body: string): string {
+  if (!tempDir) tempDir = mkdtempSync(join(tmpdir(), "tenant-scope-"));
+  const file = join(tempDir, `f-${Math.random().toString(36).slice(2)}.ts`);
+  writeFileSync(file, PREAMBLE + body);
+  return file;
+}
+
+function flags(body: string): boolean {
+  return findUnscopedTenantReads([fixture(body)]).length > 0;
+}
+
+afterEach(() => {
+  if (tempDir) {
+    rmSync(tempDir, { recursive: true, force: true });
+    tempDir = undefined;
+  }
+});
+
+describe("findUnscopedTenantReads — combinator-wrapped pk-only reads (FLAG)", () => {
+  test("bare eq(table.id, id) — the original case", () => {
+    expect(
+      flags(`function f(id: string) { dbRead.query.apps.findFirst({ where: eq(apps.id, id) }); }`),
+    ).toBe(true);
+  });
+
+  test("and(eq(table.id, id)) — single-operand combinator wrapper", () => {
+    expect(
+      flags(
+        `function f(id: string) { dbRead.query.apps.findFirst({ where: and(eq(apps.id, id)) }); }`,
+      ),
+    ).toBe(true);
+  });
+
+  test("or(eq(table.id, a), eq(table.id, b)) — all operands pk predicates", () => {
+    expect(
+      flags(
+        `function f(a: string, b: string) { dbRead.query.apps.findFirst({ where: or(eq(apps.id, a), eq(apps.id, b)) }); }`,
+      ),
+    ).toBe(true);
+  });
+
+  test("inArray(table.id, ids) — bulk pk read", () => {
+    expect(
+      flags(
+        `function f(ids: string[]) { dbRead.query.apps.findMany({ where: inArray(apps.id, ids) }); }`,
+      ),
+    ).toBe(true);
+  });
+
+  test("and(inArray(table.id, ids)) — combinator-wrapped bulk pk read", () => {
+    expect(
+      flags(
+        `function f(ids: string[]) { dbRead.query.apps.findMany({ where: and(inArray(apps.id, ids)) }); }`,
+      ),
+    ).toBe(true);
+  });
+
+  test("and(...conditions) where conditions = [eq(table.id, id)] — dynamic spread idiom", () => {
+    expect(
+      flags(`function f(id: string) {
+        const conditions = [eq(apps.id, id)];
+        dbRead.query.apps.findFirst({ where: and(...conditions) });
+      }`),
+    ).toBe(true);
+  });
+
+  test("the .where() builder form is caught too", () => {
+    expect(
+      flags(`function f(id: string) { dbRead.update(apps).set({}).where(and(eq(apps.id, id))); }`),
+    ).toBe(true);
+  });
+});
+
+describe("findUnscopedTenantReads — properly ownership-scoped reads (NO FLAG)", () => {
+  test("and(eq(table.id, id), eq(table.organization_id, orgId)) — org-scoped", () => {
+    expect(
+      flags(`function f(id: string, orgId: string) {
+        dbRead.query.apps.findFirst({ where: and(eq(apps.id, id), eq(apps.organization_id, orgId)) });
+      }`),
+    ).toBe(false);
+  });
+
+  test("and(...conditions) carrying an ownership predicate is not flagged", () => {
+    expect(
+      flags(`function f(id: string, orgId: string) {
+        const conditions = [eq(apps.id, id), eq(apps.organization_id, orgId)];
+        dbRead.query.apps.findFirst({ where: and(...conditions) });
+      }`),
+    ).toBe(false);
+  });
+
+  test("a non-pk ownership-only read (no id predicate) is not flagged", () => {
+    expect(
+      flags(`function f(appId: string, userId: string) {
+        dbRead.query.appUsers.findFirst({ where: and(eq(appUsers.app_id, appId), eq(appUsers.user_id, userId)) });
+      }`),
+    ).toBe(false);
+  });
+
+  test("a pk read against a NON-tenant table is not flagged", () => {
+    expect(
+      flags(
+        `function f(id: string) { dbRead.query.organizations.findFirst({ where: eq(organizations.id, id) }); }`,
+      ),
+    ).toBe(false);
+  });
+
+  test("a /* global-scope */ annotation opts the method out", () => {
+    expect(
+      flags(`function f(id: string) {
+        /* global-scope: route handler authorizes ownership first. */
+        return dbRead.query.apps.findFirst({ where: and(eq(apps.id, id)) });
+      }`),
+    ).toBe(false);
+  });
+});
+
+describe("findUnscopedTenantReads — reporting", () => {
+  test("reports the table and method name for an unscoped read", () => {
+    const violations = findUnscopedTenantReads([
+      fixture(
+        `function loadApp(id: string) { dbRead.query.apps.findFirst({ where: inArray(apps.id, [id]) }); }`,
+      ),
+    ]);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].table).toBe("apps");
+    expect(violations[0].method).toBe("loadApp");
+  });
+});

--- a/packages/cloud/shared/src/db/ensure-agent-sandbox-schema.ts
+++ b/packages/cloud/shared/src/db/ensure-agent-sandbox-schema.ts
@@ -11,7 +11,9 @@ async function runEnsureAgentSandboxSchema(): Promise<void> {
     ALTER TABLE "agent_sandboxes"
       ADD COLUMN IF NOT EXISTS "pool_status" text,
       ADD COLUMN IF NOT EXISTS "pool_ready_at" timestamptz,
-      ADD COLUMN IF NOT EXISTS "claimed_at" timestamptz
+      ADD COLUMN IF NOT EXISTS "claimed_at" timestamptz,
+      ADD COLUMN IF NOT EXISTS "previous_image_digest" text,
+      ADD COLUMN IF NOT EXISTS "previous_docker_image" text
   `);
 
   await dbWrite.execute(sql`

--- a/packages/cloud/shared/src/db/migrations/0152_agent_sandboxes_previous_image.sql
+++ b/packages/cloud/shared/src/db/migrations/0152_agent_sandboxes_previous_image.sql
@@ -1,0 +1,18 @@
+-- Persist the prior-good image so a fleet upgrade can be rolled back.
+--
+-- `executeUpgrade` blue/green-swaps an agent onto a new image. Before this
+-- migration the old digest was lost at swap time, so there was no rollback
+-- target (image-rollout-status reported `rollback` as Unsupported). These two
+-- nullable columns capture the pre-upgrade image:
+--   previous_image_digest  — the sha256 digest the agent ran on before the swap
+--   previous_docker_image  — the docker image reference it ran on before the swap
+-- `executeDowngrade` reads them to swap the agent back onto the prior good
+-- image. Both are null until the first upgrade — agents that have never been
+-- upgraded have no rollback target, which is the correct "rollback unavailable"
+-- state. See packages/cloud/shared/src/lib/services/eliza-sandbox.ts.
+--
+-- Additive + idempotent: ADD COLUMN IF NOT EXISTS, no backfill, no drops.
+
+ALTER TABLE "agent_sandboxes"
+  ADD COLUMN IF NOT EXISTS "previous_image_digest" text,
+  ADD COLUMN IF NOT EXISTS "previous_docker_image" text;

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1051,6 +1051,13 @@
       "when": 1780014000000,
       "tag": "0151_app_database_tenant_cluster_placement",
       "breakpoints": true
+    },
+    {
+      "idx": 150,
+      "version": "7",
+      "when": 1780100400000,
+      "tag": "0152_agent_sandboxes_previous_image",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -835,6 +835,29 @@ export class AgentSandboxesRepository {
     return r ? await hydrateAgentSandboxBackup(r) : undefined;
   }
 
+  /**
+   * The newest backup of a given `snapshot_type` for a sandbox. Used by
+   * `executeDowngrade` to find the `pre-upgrade` restore point captured right
+   * before the most recent fleet upgrade.
+   */
+  async getLatestBackupByType(
+    sandboxRecordId: string,
+    snapshotType: AgentBackupSnapshotType,
+  ): Promise<AgentSandboxBackup | undefined> {
+    const [r] = await dbRead
+      .select()
+      .from(agentSandboxBackups)
+      .where(
+        and(
+          eq(agentSandboxBackups.sandbox_record_id, sandboxRecordId),
+          eq(agentSandboxBackups.snapshot_type, snapshotType),
+        ),
+      )
+      .orderBy(desc(agentSandboxBackups.created_at))
+      .limit(1);
+    return r ? await hydrateAgentSandboxBackup(r) : undefined;
+  }
+
   async getBackupById(backupId: string): Promise<AgentSandboxBackup | undefined> {
     const [r] = await dbRead
       .select()

--- a/packages/cloud/shared/src/db/schemas/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/schemas/agent-sandboxes.ts
@@ -141,6 +141,22 @@ export const agentSandboxes = pgTable(
      * those are treated as "upgrade on next cycle".
      */
     image_digest: text("image_digest"),
+    /**
+     * The image digest the agent ran on BEFORE its most recent fleet upgrade —
+     * the rollback target. Stamped at upgrade swap time from the old row's
+     * `image_digest`; `executeDowngrade` swaps the agent back onto this digest.
+     * Null until the first upgrade. Additive: pre-upgrade rows have no prior
+     * good image to roll back to, so rollback is simply unavailable for them.
+     */
+    previous_image_digest: text("previous_image_digest"),
+    /**
+     * The `docker_image` ref the agent ran on before its most recent upgrade.
+     * For managed-fleet agents this matches the current `docker_image`, but it
+     * is captured explicitly so a rollback can reconstruct the exact prior
+     * image reference (`<ref>@<previous_image_digest>`) without assuming the
+     * tag is unchanged. Null until the first upgrade.
+     */
+    previous_docker_image: text("previous_docker_image"),
     // Billing tracking fields (mirrors containers table pattern)
     billing_status: text("billing_status").$type<AgentBillingStatus>().notNull().default("active"),
     last_billed_at: timestamp("last_billed_at", { withTimezone: true }),
@@ -178,7 +194,7 @@ export const WARM_POOL_USER_ID = "00000000-0000-4000-8000-000000077002";
 
 export type AgentSandboxPoolStatus = "unclaimed";
 
-export type AgentBackupSnapshotType = "auto" | "manual" | "pre-shutdown";
+export type AgentBackupSnapshotType = "auto" | "manual" | "pre-shutdown" | "pre-upgrade";
 
 /**
  * Whether a backup row stores the agent's complete state (`full`) or only the

--- a/packages/cloud/shared/src/lib/security/outbound-url.test.ts
+++ b/packages/cloud/shared/src/lib/security/outbound-url.test.ts
@@ -46,6 +46,13 @@ describe("outbound URL SSRF validation", () => {
     "::ffff:127.0.0.1",
     "::ffff:7f00:1",
     "0:0:0:0:0:ffff:a00:1",
+    // Deprecated IPv4-compatible IPv6 (`::/96`): the embedded IPv4 must be
+    // screened — `::169.254.169.254` would otherwise reach cloud metadata.
+    "::169.254.169.254",
+    "::127.0.0.1",
+    "::10.0.0.1",
+    "::a9fe:a9fe", // compressed-hex form of ::169.254.169.254
+    "::7f00:1", // compressed-hex form of ::127.0.0.1
   ])("classifies %s as forbidden", (address) => {
     expect(isForbiddenIpAddress(address)).toBe(true);
   });

--- a/packages/cloud/shared/src/lib/security/outbound-url.ts
+++ b/packages/cloud/shared/src/lib/security/outbound-url.ts
@@ -52,6 +52,40 @@ function ipv4FromMappedIpv6(address: string): string | null {
     }
   }
 
+  // Deprecated IPv4-compatible IPv6 (`::/96`, RFC 4291 §2.5.5.1): `::a.b.c.d` or
+  // its compressed-hex form `::HHHH:LLLL` with the high 96 bits all zero. These
+  // embed an IPv4 address that resolvers may route — `::169.254.169.254` reaches
+  // the cloud metadata endpoint — so decode the IPv4 and screen it. `::` and
+  // `::1` are NOT IPv4-compatible host addresses and are handled elsewhere.
+  if (normalized.startsWith("::") && normalized !== "::" && normalized !== "::1") {
+    const tail = normalized.slice("::".length);
+    if (tail.includes(".")) {
+      // `::a.b.c.d` — the only colon-less, dotted tail after `::`.
+      if (!tail.includes(":")) {
+        return tail;
+      }
+    } else {
+      const tailParts = tail.split(":");
+      if (tailParts.length === 2) {
+        const high = Number.parseInt(tailParts[0], 16);
+        const low = Number.parseInt(tailParts[1], 16);
+        if (
+          Number.isInteger(high) &&
+          Number.isInteger(low) &&
+          high >= 0 &&
+          high <= 0xffff &&
+          low >= 0 &&
+          low <= 0xffff &&
+          // Exclude the tiny low range (`::0`–`::ffff`) that is not a routable
+          // IPv4-compatible host: a single trailing group is `::N`, not `::H:L`.
+          (high !== 0 || low !== 0)
+        ) {
+          return `${high >> 8}.${high & 0xff}.${low >> 8}.${low & 0xff}`;
+        }
+      }
+    }
+  }
+
   return null;
 }
 

--- a/packages/cloud/shared/src/lib/services/__tests__/app-deploy-runner.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-deploy-runner.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { runWithCloudBindingsAsync } from "../../runtime/cloud-bindings";
 import type { AppDeployRunnerDeps } from "../app-deploy-runner";
 import { containerNameForApp, resolveImageRef } from "../app-deploy-runner";
 
@@ -123,5 +124,51 @@ describe("resolveImageRef: image allowlist gate", () => {
       metadata: { imageTag: "ghcr.io/onlyme/app:v1" },
     });
     expect(img).toBe("ghcr.io/onlyme/app:v1");
+  });
+});
+
+// #9853 follow-up — an app deploy is the THIRD shared-node image path (alongside
+// the /v1/containers and /v1/coding-containers routes). When the opt-in
+// digest-pin gate (CONTAINER_IMAGE_REQUIRE_DIGEST) is armed, all three must
+// reject a mutable `:tag`/`:latest` ref so the registry cannot swap the bytes
+// behind an allowed name after the check; previously this path skipped the gate.
+describe("resolveImageRef: digest-pin gate (#9853 follow-up)", () => {
+  const baseApp = { id: "app-1", name: "demo", metadata: {} as Record<string, unknown> };
+  const buildOff = { resolveImage: undefined } as unknown as AppDeployRunnerDeps;
+  // An allowlisted first-party digest-pinned ref (passes both gates).
+  const PINNED = `ghcr.io/elizaos/eliza@sha256:a${"0".repeat(63)}`;
+
+  test("flag ON: a mutable :tag app image is rejected", async () => {
+    await runWithCloudBindingsAsync({ CONTAINER_IMAGE_REQUIRE_DIGEST: "true" }, async () => {
+      await expect(
+        resolveImageRef(buildOff, {
+          ...baseApp,
+          metadata: { imageTag: "ghcr.io/elizaos/myapp:v1" },
+        }),
+      ).rejects.toThrow(/must be pinned to a full sha256 digest/);
+    });
+  });
+
+  test("flag ON: an implicit-latest (untagged) app image is rejected", async () => {
+    await runWithCloudBindingsAsync({ CONTAINER_IMAGE_REQUIRE_DIGEST: "true" }, async () => {
+      await expect(
+        resolveImageRef(buildOff, { ...baseApp, metadata: { imageTag: "ghcr.io/elizaos/myapp" } }),
+      ).rejects.toThrow(/must be pinned to a full sha256 digest/);
+    });
+  });
+
+  test("flag ON: a digest-pinned app image passes", async () => {
+    await runWithCloudBindingsAsync({ CONTAINER_IMAGE_REQUIRE_DIGEST: "true" }, async () => {
+      const img = await resolveImageRef(buildOff, { ...baseApp, metadata: { imageTag: PINNED } });
+      expect(img).toBe(PINNED);
+    });
+  });
+
+  test("flag OFF (default): a mutable :tag app image is unchanged (passes)", async () => {
+    const img = await resolveImageRef(buildOff, {
+      ...baseApp,
+      metadata: { imageTag: "ghcr.io/elizaos/myapp:v1" },
+    });
+    expect(img).toBe("ghcr.io/elizaos/myapp:v1");
   });
 });

--- a/packages/cloud/shared/src/lib/services/app-deploy-runner.ts
+++ b/packages/cloud/shared/src/lib/services/app-deploy-runner.ts
@@ -57,7 +57,7 @@ import {
 } from "./app-deploy-orchestrator";
 import { deriveAppPublicUrl } from "./app-url";
 import { appsService } from "./apps";
-import { isCodingContainerImageAllowed } from "./coding-containers";
+import { imageRequiresDigestPin, isCodingContainerImageAllowed } from "./coding-containers";
 import { ContainerJobEnqueuer, type ContainerJobsWriter } from "./container-job-service";
 import type { TenantDbProvisioning } from "./tenant-db/tenant-db-provisioning";
 import type { UserDatabaseService } from "./user-database";
@@ -151,6 +151,21 @@ export async function resolveImageRef(
         `allowed image namespaces (${permitted}). Set app.metadata.imageTag (or ` +
         `APP_DEFAULT_IMAGE) to an allowlisted image, or widen ` +
         `CODING_CONTAINER_IMAGE_ALLOWLIST.`,
+    );
+  }
+  // SECURITY (opt-in, default OFF): when the digest-pin gate is armed, reject a
+  // mutable `:tag`/`:latest` reference so the registry cannot swap the bytes
+  // behind an allowed name after this check. This is the SAME gate the two
+  // container routes (`/v1/containers`, `/v1/coding-containers`) enforce; an
+  // app deploy is the third shared-node image path, so it must enforce it too —
+  // otherwise CONTAINER_IMAGE_REQUIRE_DIGEST=true would still let an app deploy
+  // run a mutable tag while the routes reject it.
+  if (imageRequiresDigestPin(image, containersEnv.requireDigestPinnedImages())) {
+    throw new Error(
+      `Image '${image}' for app ${app.id} must be pinned to a full sha256 digest ` +
+        `(e.g. repo@sha256:<64 hex>): the digest-pin gate ` +
+        `(CONTAINER_IMAGE_REQUIRE_DIGEST) is enabled and a mutable tag can be ` +
+        `swapped after this check.`,
     );
   }
   return image;

--- a/packages/cloud/shared/src/lib/services/containers/image-rollout-status.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/image-rollout-status.test.ts
@@ -196,12 +196,17 @@ describe("summarizeImageRollout — status state machine", () => {
     expect(dup?.count).toBe(2);
   });
 
-  test("canary + rollback are always reported as unsupported", () => {
+  test("canary stays unsupported; rollback is an operator-gated supported action", () => {
     const s = summarizeImageRollout({
       desiredImage: DESIRED,
       enabled: true,
       rows: [row("a", DESIRED)],
     });
-    expect(s.unsupportedActions.map((a) => a.action).sort()).toEqual(["canary", "rollback"]);
+    // canary remains unsupported until cohort routing + health gates exist.
+    expect(s.unsupportedActions.map((a) => a.action)).toEqual(["canary"]);
+    // rollback is now supported but never automatic — it is operator-gated and
+    // backed by the persisted previous_image_digest / executeDowngrade.
+    expect(s.supportedActions.map((a) => a.action)).toEqual(["rollback"]);
+    expect(s.supportedActions[0]?.requiresOperatorApproval).toBe(true);
   });
 });

--- a/packages/cloud/shared/src/lib/services/containers/image-rollout-status.ts
+++ b/packages/cloud/shared/src/lib/services/containers/image-rollout-status.ts
@@ -60,8 +60,20 @@ export interface ImageRolloutSummary {
     poolReadyAt: Date | null;
     healthUrl: string | null;
   }>;
+  /**
+   * Operator-gated actions that ARE supported but never run automatically. A
+   * rollback swaps each agent back onto its persisted `previous_image_digest`
+   * via `elizaSandboxService.executeDowngrade`; it requires an explicit
+   * operator action (`requiresOperatorApproval`) and is only available once a
+   * prior good image has been persisted (i.e. after at least one upgrade).
+   */
+  supportedActions: Array<{
+    action: "rollback";
+    requiresOperatorApproval: true;
+    note: string;
+  }>;
   unsupportedActions: Array<{
-    action: "canary" | "rollback";
+    action: "canary";
     reason: string;
   }>;
 }
@@ -197,16 +209,18 @@ export function summarizeImageRollout(params: {
       a.image.localeCompare(b.image),
     ),
     staleRows,
+    supportedActions: [
+      {
+        action: "rollback",
+        requiresOperatorApproval: true,
+        note: "Operator-gated: swaps each agent back onto its persisted previous_image_digest via executeDowngrade. Never runs automatically.",
+      },
+    ],
     unsupportedActions: [
       {
         action: "canary",
         reason:
           "Unsupported until per-cohort claim routing and health gates protect ready-pool replacement.",
-      },
-      {
-        action: "rollback",
-        reason:
-          "Unsupported until previous desired images are persisted and operator approval gates automated rollback.",
       },
     ],
   };

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-create-idempotency.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-create-idempotency.test.ts
@@ -112,6 +112,8 @@ function baseRow(): AgentSandbox {
     headscale_ip: null,
     docker_image: "ghcr.io/example/agent:latest",
     image_digest: null,
+    previous_image_digest: null,
+    previous_docker_image: null,
     billing_status: "active",
     last_billed_at: null,
     hourly_rate: "0.0100",

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-dedicated-bootstrap.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-dedicated-bootstrap.test.ts
@@ -126,6 +126,8 @@ function dedicatedSandbox(overrides: Partial<AgentSandbox> = {}): AgentSandbox {
     headscale_ip: null,
     docker_image: null,
     image_digest: null,
+    previous_image_digest: null,
+    previous_docker_image: null,
     billing_status: "active",
     last_billed_at: null,
     hourly_rate: "0.0100",

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-shared-billing.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-shared-billing.test.ts
@@ -156,6 +156,8 @@ function sharedSandbox(): AgentSandbox {
     headscale_ip: null,
     docker_image: null,
     image_digest: null,
+    previous_image_digest: null,
+    previous_docker_image: null,
     billing_status: "active",
     last_billed_at: null,
     hourly_rate: "0.0100",

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -99,6 +99,8 @@ function customSandbox(): AgentSandbox {
     headscale_ip: "100.64.0.10",
     docker_image: "ghcr.io/example/bnancy:latest",
     image_digest: null,
+    previous_image_digest: null,
+    previous_docker_image: null,
     billing_status: "active",
     last_billed_at: null,
     hourly_rate: "0.0100",
@@ -1716,6 +1718,15 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
       },
       "getAgentForLifecycleMutation",
     ).mockResolvedValue(agent);
+    // A pre-upgrade restore point MUST be captured before the swap. Stub the
+    // snapshot itself (its own DB/bridge path is covered elsewhere) so we can
+    // assert it ran with the "pre-upgrade" type before any swap params.
+    const snapshotSpy = spyOn(
+      svc as unknown as {
+        snapshot: (...a: unknown[]) => Promise<{ success: boolean }>;
+      },
+      "snapshot",
+    ).mockResolvedValue({ success: true });
     // Capture the raw UPDATE the swap issues so we can assert the new values
     // bound into it (drizzle SQL chunks carry the bound params).
     let executedSql: unknown;
@@ -1734,13 +1745,19 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
       expect(res.newNodeId).toBe("node-new");
       expect(res.newContainerName).toBe("agent-new-1");
       expect(res.newDigest).toBe(TO_DIGEST);
-      // The swap's UPDATE binds blue's identity + the target digest.
+      // A pre-upgrade snapshot was taken BEFORE the swap transaction ran.
+      expect(snapshotSpy).toHaveBeenCalledTimes(1);
+      expect(snapshotSpy).toHaveBeenCalledWith(AGENT, ORG, "pre-upgrade");
+      // The swap's UPDATE binds blue's identity + the target digest + the prior
+      // image as the rollback target.
       const params = sqlBoundParams(executedSql);
       expect(params).toContain("sandbox-new-1"); // blue sandbox id
       expect(params).toContain("https://new-bridge.example"); // blue bridge_url
       expect(params).toContain("node-new"); // blue node_id
       expect(params).toContain("agent-new-1"); // blue container_name
       expect(params).toContain(TO_DIGEST); // image_digest := toDigest
+      expect(params).toContain(FROM_DIGEST); // previous_image_digest := fromDigest
+      expect(params).toContain(DOCKER_IMAGE); // previous_docker_image (agent.docker_image is null → dockerImage)
       // The old container is best-effort torn down on its specific node; the
       // blue is the live one and is NOT stopped.
       expect(stopOnSpecificNode).toHaveBeenCalledTimes(1);
@@ -1752,6 +1769,7 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
       nodeSpy.mockRestore();
       lockSpy.mockRestore();
       readSpy.mockRestore();
+      snapshotSpy.mockRestore();
     }
   });
 
@@ -1782,6 +1800,12 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
       },
       "getAgentForLifecycleMutation",
     ).mockResolvedValue(movedRow);
+    const snapshotSpy = spyOn(
+      svc as unknown as {
+        snapshot: (...a: unknown[]) => Promise<{ success: boolean }>;
+      },
+      "snapshot",
+    ).mockResolvedValue({ success: true });
     let executeCalled = false;
     upgradeTransactionImpl = async (fn) => {
       const tx: UpgradeTx = {
@@ -1808,6 +1832,206 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
     } finally {
       findSpy.mockRestore();
       nodeSpy.mockRestore();
+      lockSpy.mockRestore();
+      readSpy.mockRestore();
+      snapshotSpy.mockRestore();
+    }
+  });
+});
+
+// #9964 — executeDowngrade() symmetric blue/green rollback onto the persisted
+// previous_image_digest. Mirrors the executeUpgrade harness: a real
+// DockerSandboxProvider with spied I/O so `instanceof` holds, a genuine
+// DockerSandboxMetadata for blue, and the swap driven through
+// upgradeTransactionImpl + spies on the private lifecycle seams. The pre-upgrade
+// restore point and its reconstruction are stubbed on the repository.
+describe("ElizaSandboxService.executeDowngrade rollback onto previous_image_digest (#9964)", () => {
+  const AGENT = "e06bb509-6c52-4c33-a9f7-66addc43e8c8";
+  const ORG = "22222222-2222-4222-8222-222222222222";
+  const DOCKER_IMAGE = "ghcr.io/elizaos/eliza-agent:latest";
+  // The agent currently runs on the post-upgrade digest; rollback targets PREV.
+  const CURRENT_DIGEST = "sha256:1111111111111111111111111111111111111111111111111111111111111bbb";
+  const PREV_DIGEST = "sha256:0000000000000000000000000000000000000000000000000000000000000aaa";
+
+  // A live fleet agent that HAS a persisted rollback target.
+  function upgradedAgentRow(): AgentSandbox {
+    return {
+      ...customSandbox(),
+      id: AGENT,
+      organization_id: ORG,
+      status: "running",
+      sandbox_id: "sandbox-cur-1",
+      node_id: "node-cur",
+      container_name: "agent-cur-1",
+      bridge_url: "https://cur-bridge.example",
+      health_url: "https://cur-bridge.example/health",
+      docker_image: null,
+      image_digest: CURRENT_DIGEST,
+      previous_image_digest: PREV_DIGEST,
+      previous_docker_image: DOCKER_IMAGE,
+    };
+  }
+
+  function curNode(): DockerNode {
+    return {
+      node_id: "node-cur",
+      hostname: "node-cur.internal",
+      ssh_port: 22,
+      ssh_user: "root",
+      host_key_fingerprint: null,
+    } as unknown as DockerNode;
+  }
+
+  function blueMetadata(imageDigest: string | null) {
+    return {
+      provider: "docker" as const,
+      nodeId: "node-rb",
+      hostname: "node-rb.internal",
+      containerName: "agent-rb-1",
+      bridgePort: 21090,
+      webUiPort: 23960,
+      agentId: AGENT,
+      volumePath: "/var/lib/eliza/agent-rb-1",
+      dockerImage: DOCKER_IMAGE,
+      imageDigest,
+    };
+  }
+
+  function blueHandle(imageDigest: string | null) {
+    return {
+      sandboxId: "sandbox-rb-1",
+      bridgeUrl: "https://rb-bridge.example",
+      healthUrl: "https://rb-bridge.example/health",
+      metadata: blueMetadata(imageDigest),
+    };
+  }
+
+  async function makeDockerProvider(overrides: {
+    create: () => Promise<unknown>;
+    checkHealth: () => Promise<boolean>;
+  }) {
+    const { DockerSandboxProvider } = await import("./docker-sandbox-provider");
+    const provider = new DockerSandboxProvider();
+    const create = mock(overrides.create);
+    const checkHealth = mock(overrides.checkHealth);
+    const stop = mock(async () => {});
+    const stopOnSpecificNode = mock(async () => {});
+    Object.assign(provider, { create, checkHealth, stop, stopOnSpecificNode });
+    return {
+      provider: provider as unknown as SandboxProvider,
+      create,
+      checkHealth,
+      stop,
+      stopOnSpecificNode,
+    };
+  }
+
+  afterEach(() => {
+    upgradeTransactionImpl = null;
+  });
+
+  test("no previous_image_digest → refuses, never touches the live agent", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const agent: AgentSandbox = { ...upgradedAgentRow(), previous_image_digest: null };
+    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(agent);
+    const { provider, create } = await makeDockerProvider({
+      create: async () => blueHandle(PREV_DIGEST),
+      checkHealth: async () => true,
+    });
+    try {
+      const res = await new ElizaSandboxService(provider).executeDowngrade(
+        AGENT,
+        ORG,
+        DOCKER_IMAGE,
+        CURRENT_DIGEST,
+      );
+      expect(res.success).toBe(false);
+      expect(res.error).toContain("nothing to roll back to");
+      // No blue is ever provisioned — there is no rollback target.
+      expect(create).not.toHaveBeenCalled();
+    } finally {
+      findSpy.mockRestore();
+    }
+  });
+
+  test("happy path → restores pre-upgrade snapshot then swaps back onto PREV_DIGEST + clears prior columns", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const agent = upgradedAgentRow();
+    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(agent);
+    const nodeSpy = spyOn(dockerNodesRepository, "findByNodeId").mockResolvedValue(curNode());
+    // The pre-upgrade restore point + its reconstruction.
+    const preUpgradeBackup = {
+      id: "backup-preupgrade-1",
+      sandbox_record_id: AGENT,
+      snapshot_type: "pre-upgrade",
+    } as unknown as AgentSandboxBackup;
+    const byTypeSpy = spyOn(agentSandboxesRepository, "getLatestBackupByType").mockResolvedValue(
+      preUpgradeBackup,
+    );
+    const reconstructSpy = spyOn(
+      agentSandboxesRepository,
+      "getReconstructedBackupState",
+    ).mockResolvedValue({ memories: [], config: { restored: true }, workspaceFiles: {} });
+    const { provider, create, checkHealth, stop, stopOnSpecificNode } = await makeDockerProvider({
+      create: async () => blueHandle(PREV_DIGEST),
+      checkHealth: async () => true,
+    });
+    const svc = new ElizaSandboxService(provider);
+    // The pre-cutover state push lands on blue's /api/restore — stub the private
+    // pushState so the test stays offline; assert it received blue's bridge URL.
+    const pushSpy = spyOn(
+      svc as unknown as { pushState: (...a: unknown[]) => Promise<void> },
+      "pushState",
+    ).mockResolvedValue(undefined);
+    const lockSpy = spyOn(
+      svc as unknown as { lockLifecycle: (...a: unknown[]) => Promise<void> },
+      "lockLifecycle",
+    ).mockResolvedValue(undefined);
+    const readSpy = spyOn(
+      svc as unknown as {
+        getAgentForLifecycleMutation: (...a: unknown[]) => Promise<AgentSandbox | undefined>;
+      },
+      "getAgentForLifecycleMutation",
+    ).mockResolvedValue(agent);
+    let executedSql: unknown;
+    upgradeTransactionImpl = async (fn) => {
+      const tx: UpgradeTx = {
+        execute: async (query: unknown) => {
+          executedSql = query;
+          return { rows: [{ id: AGENT }] };
+        },
+      };
+      return fn(tx);
+    };
+    try {
+      const res = await svc.executeDowngrade(AGENT, ORG, DOCKER_IMAGE, CURRENT_DIGEST);
+      expect(res.success).toBe(true);
+      expect(res.newNodeId).toBe("node-rb");
+      expect(res.newContainerName).toBe("agent-rb-1");
+      // Rolls the agent back ONTO the prior digest.
+      expect(res.newDigest).toBe(PREV_DIGEST);
+      // The pre-upgrade snapshot was looked up and reconstructed before cutover.
+      expect(byTypeSpy).toHaveBeenCalledWith(AGENT, "pre-upgrade");
+      expect(reconstructSpy).toHaveBeenCalledWith("backup-preupgrade-1");
+      // ...and pushed onto BLUE (the rollback container) before the swap.
+      expect(pushSpy).toHaveBeenCalledTimes(1);
+      expect(pushSpy.mock.calls[0]?.[0]).toBe("https://rb-bridge.example");
+      // The swap binds blue's identity + PREV_DIGEST and NULLs the prior columns.
+      const params = sqlBoundParams(executedSql);
+      expect(params).toContain("sandbox-rb-1");
+      expect(params).toContain("node-rb");
+      expect(params).toContain(PREV_DIGEST); // image_digest := previous
+      expect(create).toHaveBeenCalledTimes(1);
+      expect(checkHealth).toHaveBeenCalledTimes(1);
+      // The old (post-upgrade) container is torn down; blue stays.
+      expect(stopOnSpecificNode).toHaveBeenCalledTimes(1);
+      expect(stop).not.toHaveBeenCalled();
+    } finally {
+      findSpy.mockRestore();
+      nodeSpy.mockRestore();
+      byTypeSpy.mockRestore();
+      reconstructSpy.mockRestore();
+      pushSpy.mockRestore();
       lockSpy.mockRestore();
       readSpy.mockRestore();
     }

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -4269,6 +4269,18 @@ export class ElizaSandboxService {
       };
     }
 
+    // Capture a restore point on the OLD (still-live) container before the
+    // cutover. This is the snapshot `executeDowngrade` replays when rolling
+    // back. Like every snapshot path, an image that does not serve
+    // /api/snapshot is a benign skip (SNAPSHOT_ENDPOINT_UNSUPPORTED), not an
+    // upgrade failure — the digest swap below is still the real rollback lever.
+    await this.snapshot(agentId, orgId, "pre-upgrade").catch((err) => {
+      logger.warn("[agent-sandbox] Pre-upgrade snapshot failed; continuing upgrade", {
+        agentId,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    });
+
     try {
       const swapped = await dbWrite.transaction(async (tx) => {
         await this.lockLifecycle(tx, agentId, orgId);
@@ -4296,6 +4308,8 @@ export class ElizaSandboxService {
             web_ui_port = ${blueMeta.webUiPort},
             headscale_ip = ${blueMeta.headscaleIp ?? null},
             image_digest = ${toDigest},
+            previous_image_digest = ${fromDigest},
+            previous_docker_image = ${current.docker_image ?? dockerImage},
             last_heartbeat_at = NOW(),
             updated_at = NOW()
           WHERE id = ${agentId}
@@ -4339,6 +4353,314 @@ export class ElizaSandboxService {
       newContainerName: blueMeta.containerName,
       newDigest: toDigest,
       requestedDigest: toDigest,
+    });
+
+    return {
+      success: true,
+      oldNodeId,
+      oldContainerName,
+      newNodeId: blueMeta.nodeId,
+      newContainerName: blueMeta.containerName,
+      newDigest: toDigest,
+    };
+  }
+
+  /**
+   * Operator-gated rollback of the most recent fleet upgrade. Symmetric to
+   * `executeUpgrade`: a blue/green swap back onto `previous_image_digest`, the
+   * digest captured at the last upgrade's swap.
+   *
+   * Flow:
+   *   1. Resolve the rollback target from `previous_image_digest` /
+   *      `previous_docker_image`. If there is none, there is nothing to roll
+   *      back to — bail without touching the live agent.
+   *   2. Provision a fresh container (blue) on the prior image, on a different
+   *      node, and health-check it (same guarantees as upgrade).
+   *   3. Restore the `pre-upgrade` snapshot onto blue BEFORE cutover so the
+   *      rolled-back agent comes up with the state it had before the upgrade.
+   *      The bridge push is guarded: an image without /api/restore (custom
+   *      tier) is a benign skip, mirroring how snapshot no-ops on
+   *      SNAPSHOT_ENDPOINT_UNSUPPORTED.
+   *   4. Atomic CAS swap: point the row at blue, set `image_digest` to the
+   *      prior digest, and clear the previous-image columns (the upgrade we
+   *      just undid is no longer the rollback target).
+   *   5. Best-effort teardown of the old (post-upgrade) container.
+   *
+   * This is invoked only behind an explicit operator action — it never runs
+   * automatically (image-rollout-status reports `rollback` as a gated,
+   * operator-approved action, not an automatic one).
+   */
+  async executeDowngrade(
+    agentId: string,
+    orgId: string,
+    dockerImage: string,
+    fromDigest: string,
+  ): Promise<{
+    success: boolean;
+    oldNodeId?: string;
+    oldContainerName?: string;
+    newNodeId?: string;
+    newContainerName?: string;
+    newDigest?: string | null;
+    error?: string;
+  }> {
+    const agent = await agentSandboxesRepository.findByIdAndOrg(agentId, orgId);
+    if (!agent) return { success: false, error: "Agent not found" };
+    if (agent.status !== "running") {
+      return {
+        success: false,
+        error: `Agent not running (status: ${agent.status})`,
+      };
+    }
+    if (!agent.node_id || !agent.container_name) {
+      return {
+        success: false,
+        error: "Agent has no node_id or container_name to roll back from",
+      };
+    }
+    if (agent.docker_image && agent.docker_image !== dockerImage) {
+      return {
+        success: false,
+        error: "Agent uses a custom docker image; refusing fleet rollback",
+      };
+    }
+    const toDigest = agent.previous_image_digest;
+    if (!toDigest) {
+      return {
+        success: false,
+        error: "No previous image digest persisted; nothing to roll back to",
+      };
+    }
+    if (agent.image_digest !== fromDigest) {
+      return {
+        success: false,
+        error: `Agent is not on the expected post-upgrade digest (expected ${fromDigest}, found ${agent.image_digest})`,
+      };
+    }
+
+    const oldNodeId = agent.node_id;
+    const oldContainerName = agent.container_name;
+    const oldSandboxId = agent.sandbox_id;
+    const oldNode = await dockerNodesRepository.findByNodeId(oldNodeId);
+    if (!oldNode) {
+      return {
+        success: false,
+        error: `Old node ${oldNodeId} not registered in docker_nodes`,
+      };
+    }
+
+    const provider = await this.getProvider();
+    const { DockerSandboxProvider } = await import("./docker-sandbox-provider");
+    if (!(provider instanceof DockerSandboxProvider)) {
+      return {
+        success: false,
+        error: "Fleet rollback only supported on docker provider",
+      };
+    }
+
+    const rollbackImage = agent.previous_docker_image ?? dockerImage;
+    const config = {
+      agentId,
+      agentName: agent.agent_name ?? "",
+      organizationId: orgId,
+      environmentVars: {
+        ...((agent.environment_vars as Record<string, string>) ?? {}),
+        ...applyManagedAgentInferenceEnvDefaults(
+          (agent.environment_vars as Record<string, string>) ?? {},
+        ),
+      },
+      dockerImage: digestPinnedImageRef(rollbackImage, toDigest),
+      excludeNodeId: oldNodeId,
+    };
+
+    let blueHandle: Awaited<ReturnType<typeof provider.create>>;
+    try {
+      blueHandle = await provider.create(config);
+    } catch (err) {
+      return {
+        success: false,
+        oldNodeId,
+        oldContainerName,
+        error: `Blue provision failed: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+
+    if (!(await provider.checkHealth(blueHandle))) {
+      await provider.stop(blueHandle.sandboxId).catch((err) =>
+        logger.warn("[agent-sandbox] Failed to tear down unhealthy blue during rollback", {
+          agentId,
+          err: err instanceof Error ? err.message : String(err),
+        }),
+      );
+      return {
+        success: false,
+        oldNodeId,
+        oldContainerName,
+        error: "Blue health check failed; kept agent on current image",
+      };
+    }
+
+    const blueMeta = isDockerSandboxMetadata(blueHandle.metadata) ? blueHandle.metadata : undefined;
+    if (!blueMeta) {
+      await provider.stop(blueHandle.sandboxId).catch((err) =>
+        logger.warn(
+          "[agent-sandbox] Failed to tear down blue with non-docker metadata in rollback",
+          {
+            agentId,
+            err: err instanceof Error ? err.message : String(err),
+          },
+        ),
+      );
+      return {
+        success: false,
+        oldNodeId,
+        oldContainerName,
+        error: "Blue provisioner returned non-docker metadata",
+      };
+    }
+    if (blueMeta.imageDigest && blueMeta.imageDigest !== toDigest) {
+      await provider.stop(blueHandle.sandboxId).catch((stopErr) =>
+        logger.warn("[agent-sandbox] Failed to tear down blue after rollback digest mismatch", {
+          agentId,
+          err: stopErr instanceof Error ? stopErr.message : String(stopErr),
+        }),
+      );
+      return {
+        success: false,
+        oldNodeId,
+        oldContainerName,
+        error: `Blue image digest mismatch: expected ${toDigest}, got ${blueMeta.imageDigest}`,
+      };
+    }
+
+    // Restore the pre-upgrade state onto blue BEFORE cutover. A missing
+    // restore point is not fatal — blue still serves the prior IMAGE, it just
+    // starts from whatever persisted state it has. An image without
+    // /api/restore (custom tier) is a benign skip, mirroring the snapshot path.
+    const preUpgradeBackup = await agentSandboxesRepository.getLatestBackupByType(
+      agent.id,
+      "pre-upgrade",
+    );
+    if (preUpgradeBackup) {
+      const restoreState = await agentSandboxesRepository.getReconstructedBackupState(
+        preUpgradeBackup.id,
+      );
+      if (restoreState) {
+        try {
+          await this.pushState(blueHandle.bridgeUrl, restoreState, { trusted: true });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          if (
+            agent.execution_tier !== "custom" ||
+            !message.startsWith("State restore failed: HTTP 404")
+          ) {
+            await provider.stop(blueHandle.sandboxId).catch((stopErr) =>
+              logger.warn(
+                "[agent-sandbox] Failed to tear down blue after rollback restore failure",
+                {
+                  agentId,
+                  err: stopErr instanceof Error ? stopErr.message : String(stopErr),
+                },
+              ),
+            );
+            return {
+              success: false,
+              oldNodeId,
+              oldContainerName,
+              error: `Pre-upgrade state restore failed: ${message}`,
+            };
+          }
+          logger.info(
+            "[agent-sandbox] Rollback restore skipped: custom image has no restore endpoint",
+            { agentId, backupId: preUpgradeBackup.id },
+          );
+        }
+      } else {
+        logger.warn("[agent-sandbox] Rollback restore skipped: reconstructed state was null", {
+          agentId,
+          backupId: preUpgradeBackup.id,
+        });
+      }
+    } else {
+      logger.warn("[agent-sandbox] Rollback proceeding without a pre-upgrade snapshot", {
+        agentId,
+      });
+    }
+
+    try {
+      const swapped = await dbWrite.transaction(async (tx) => {
+        await this.lockLifecycle(tx, agentId, orgId);
+        const current = await this.getAgentForLifecycleMutation(tx, agentId, orgId);
+        if (!current) return false;
+        if (
+          current.status !== "running" ||
+          current.node_id !== oldNodeId ||
+          current.container_name !== oldContainerName ||
+          current.sandbox_id !== oldSandboxId ||
+          current.image_digest !== fromDigest ||
+          (current.docker_image && current.docker_image !== dockerImage)
+        ) {
+          return false;
+        }
+        const result = await tx.execute<{ id: string }>(sql`
+          UPDATE ${agentSandboxes}
+          SET
+            sandbox_id = ${blueHandle.sandboxId},
+            bridge_url = ${blueHandle.bridgeUrl},
+            health_url = ${blueHandle.healthUrl},
+            node_id = ${blueMeta.nodeId},
+            container_name = ${blueMeta.containerName},
+            bridge_port = ${blueMeta.bridgePort},
+            web_ui_port = ${blueMeta.webUiPort},
+            headscale_ip = ${blueMeta.headscaleIp ?? null},
+            image_digest = ${toDigest},
+            previous_image_digest = NULL,
+            previous_docker_image = NULL,
+            last_heartbeat_at = NOW(),
+            updated_at = NOW()
+          WHERE id = ${agentId}
+            AND organization_id = ${orgId}
+            AND status = 'running'
+          RETURNING id
+        `);
+        return result.rows.length === 1;
+      });
+      if (!swapped) {
+        throw new Error("Agent changed during rollback; abandoned stale swap");
+      }
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      logger.error(
+        "[agent-sandbox] Rollback atomic swap UPDATE failed; tearing down orphaned blue",
+        {
+          agentId,
+          err: errMsg,
+        },
+      );
+      await provider.stop(blueHandle.sandboxId).catch((stopErr) =>
+        logger.warn("[agent-sandbox] Failed to tear down blue after rollback swap UPDATE failure", {
+          agentId,
+          err: stopErr instanceof Error ? stopErr.message : String(stopErr),
+        }),
+      );
+      return {
+        success: false,
+        oldNodeId,
+        oldContainerName,
+        error: `Rollback atomic swap UPDATE failed: ${errMsg}`,
+      };
+    }
+
+    // Old (post-upgrade) container teardown is best-effort: traffic is on blue.
+    await provider.stopOnSpecificNode(oldNode, oldContainerName, 30);
+
+    logger.info("[agent-sandbox] Fleet rollback completed", {
+      agentId,
+      oldNodeId,
+      oldContainerName,
+      newNodeId: blueMeta.nodeId,
+      newContainerName: blueMeta.containerName,
+      newDigest: toDigest,
     });
 
     return {

--- a/packages/cloud/shared/src/lib/services/signup-grant-guard.test.ts
+++ b/packages/cloud/shared/src/lib/services/signup-grant-guard.test.ts
@@ -1,45 +1,201 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-// Each call to dbRead.execute returns the next queued count row.
-let nextCount = 0;
-const execute = mock(async () => ({ rows: [{ count: String(nextCount) }] }));
+// A minimal in-memory Postgres stand-in that models the load-bearing semantics:
+//   1. `pg_advisory_xact_lock(...)` serializes transactions sharing a lock key,
+//   2. the per-IP COUNT only sees grant rows from already-COMMITTED transactions.
+// This lets the concurrency regression assert the cap holds under a race the old
+// (count-then-insert, no lock) guard would have lost.
+
+interface GrantRow {
+  ip: string;
+}
+
+// Committed grant rows, visible to every new transaction's COUNT.
+let committedGrants: GrantRow[] = [];
+// Per-lock-key queue of waiters, enforcing FIFO mutual exclusion.
+const lockHolders = new Map<string, Promise<void>>();
+// SQL strings each tx.execute saw, for asserting the advisory lock is acquired.
+let executedSql: string[] = [];
+
+function sqlText(query: unknown): string {
+  // drizzle `sql` template → the queryChunks carry the static text; we only need
+  // to recognize which statement ran, so stringify and scan.
+  return JSON.stringify(query);
+}
+
+class FakeTx {
+  // Grant rows staged in THIS (uncommitted) transaction.
+  readonly pending: GrantRow[] = [];
+  // The IP this transaction is counting/granting for, captured from the lock key.
+  ip: string | undefined;
+
+  async execute(query: unknown): Promise<{ rows: Array<{ count: string }> }> {
+    const text = sqlText(query);
+    executedSql.push(text);
+
+    if (text.includes("pg_advisory_xact_lock")) {
+      // The lock key is `free_grant:<ip>`; pull the ip out of the params.
+      this.ip = extractIp(query, "free_grant:");
+      return { rows: [] };
+    }
+
+    if (text.includes("COUNT(*)")) {
+      // The guard always runs the advisory-lock statement before the COUNT, so
+      // `this.ip` is set; count only COMMITTED grant rows for this IP.
+      const count = committedGrants.filter((g) => g.ip === this.ip).length;
+      return { rows: [{ count: String(count) }] };
+    }
+
+    return { rows: [] };
+  }
+}
+
+// Pull the `free_grant:<ip>` lock key out of a drizzle `sql` template. Bound
+// params sit in `queryChunks` as bare values; static SQL text is wrapped as
+// `{ value: [...] }`. So a bare string param starting with the prefix is the key.
+function extractIp(query: unknown, prefix: string): string | undefined {
+  const chunks = (query as { queryChunks?: unknown[] }).queryChunks;
+  if (!Array.isArray(chunks)) return undefined;
+  for (const chunk of chunks) {
+    if (typeof chunk === "string" && chunk.startsWith(prefix)) {
+      return chunk.slice(prefix.length);
+    }
+  }
+  return undefined;
+}
+
+// Mock dbWrite.transaction with advisory-lock-aware serialization: a transaction
+// whose lock key is already held waits behind the current holder; on commit its
+// pending grant rows become visible and the lock is released to the next waiter.
+const transaction = mock(async (fn: (tx: FakeTx) => Promise<boolean>): Promise<boolean> => {
+  const tx = new FakeTx();
+  // Run the body to discover the lock key (the advisory-lock execute sets tx.ip),
+  // but gate the *grant + count* behind the lock by re-entering once acquired.
+  // Simpler: serialize the whole body per resolved ip via a two-phase approach.
+  // Phase 1: peek the ip by executing only the lock statement is impractical here,
+  // so we serialize on first use of the lock inside the body via a shared mutex.
+  return await runSerialized(tx, fn);
+});
+
+// Serialize transaction bodies that share a lock key. Because the ip isn't known
+// until the lock statement runs inside the body, we wrap the body so the first
+// `pg_advisory_xact_lock` call blocks until the prior same-ip tx has committed.
+async function runSerialized(tx: FakeTx, fn: (tx: FakeTx) => Promise<boolean>): Promise<boolean> {
+  let release!: () => void;
+  const held = new Promise<void>((r) => {
+    release = r;
+  });
+
+  const originalExecute = tx.execute.bind(tx);
+  let acquired = false;
+  tx.execute = async (query: unknown) => {
+    const text = sqlText(query);
+    if (text.includes("pg_advisory_xact_lock") && !acquired) {
+      acquired = true;
+      const result = await originalExecute(query);
+      const key = tx.ip ?? "";
+      const prior = lockHolders.get(key);
+      lockHolders.set(
+        key,
+        (async () => {
+          if (prior) await prior;
+          await held; // released when this tx commits
+        })(),
+      );
+      if (prior) await prior; // block until the prior same-ip tx committed
+      return result;
+    }
+    return originalExecute(query);
+  };
+
+  try {
+    const granted = await fn(tx);
+    // Commit: a granted body's row becomes visible to subsequent counts.
+    if (granted && tx.ip) committedGrants.push({ ip: tx.ip });
+    return granted;
+  } finally {
+    release(); // release the advisory lock to the next same-ip waiter
+  }
+}
 
 mock.module("../../db/client", () => ({
-  dbRead: { execute },
+  dbWrite: { transaction },
 }));
 
 mock.module("../utils/logger", () => ({
   logger: { warn: () => {}, info: () => {}, error: () => {}, debug: () => {} },
 }));
 
-const { signupGrantAllowedForIp, FREE_GRANT_IP_LIMITS } = await import("./signup-grant-guard");
+const { runWithSignupGrantIpCap, FREE_GRANT_IP_LIMITS } = await import("./signup-grant-guard");
 
 const CAP = FREE_GRANT_IP_LIMITS.MAX_FREE_GRANTS_PER_IP_DAILY;
 
-describe("signupGrantAllowedForIp (anti-sybil free-grant cap)", () => {
+describe("runWithSignupGrantIpCap (anti-sybil free-grant cap)", () => {
   beforeEach(() => {
-    execute.mockClear();
-    nextCount = 0;
+    transaction.mockClear();
+    committedGrants = [];
+    executedSql = [];
+    lockHolders.clear();
   });
 
-  test("falls open without querying when no IP is known", async () => {
-    expect(await signupGrantAllowedForIp(undefined)).toBe(true);
-    expect(execute).not.toHaveBeenCalled();
+  test("falls open and runs the grant without a transaction when no IP is known", async () => {
+    let granted = false;
+    const ran = await runWithSignupGrantIpCap(undefined, async () => {
+      granted = true;
+    });
+    expect(ran).toBe(true);
+    expect(granted).toBe(true);
+    expect(transaction).not.toHaveBeenCalled();
   });
 
-  test("allows grants below the daily cap", async () => {
-    nextCount = CAP - 1;
-    expect(await signupGrantAllowedForIp("1.2.3.4")).toBe(true);
-    expect(execute).toHaveBeenCalledTimes(1);
+  test("acquires a per-IP advisory xact lock before counting", async () => {
+    await runWithSignupGrantIpCap("1.2.3.4", async () => {});
+    expect(executedSql.some((s) => s.includes("pg_advisory_xact_lock"))).toBe(true);
+    // The lock statement must precede the COUNT.
+    const lockIdx = executedSql.findIndex((s) => s.includes("pg_advisory_xact_lock"));
+    const countIdx = executedSql.findIndex((s) => s.includes("COUNT(*)"));
+    expect(lockIdx).toBeGreaterThanOrEqual(0);
+    expect(countIdx).toBeGreaterThan(lockIdx);
   });
 
-  test("withholds the grant once the daily cap is reached", async () => {
-    nextCount = CAP;
-    expect(await signupGrantAllowedForIp("1.2.3.4")).toBe(false);
+  test("grants below the cap and withholds once it is reached", async () => {
+    // Seed CAP-1 prior committed grants for this IP.
+    committedGrants = Array.from({ length: CAP - 1 }, () => ({ ip: "9.9.9.9" }));
+    let grants = 0;
+    expect(await runWithSignupGrantIpCap("9.9.9.9", async () => void grants++)).toBe(true);
+    // Now at CAP committed; the next attempt is withheld.
+    expect(await runWithSignupGrantIpCap("9.9.9.9", async () => void grants++)).toBe(false);
+    expect(grants).toBe(1);
   });
 
-  test("withholds the grant when the cap is exceeded", async () => {
-    nextCount = CAP + 5;
-    expect(await signupGrantAllowedForIp("1.2.3.4")).toBe(false);
+  // The regression: with the cap one slot below the limit, fire TWO simultaneous
+  // same-IP grant attempts. The advisory lock must serialize them so the second
+  // sees the first's committed row and is denied — only ONE grant lands. The old
+  // count-then-insert guard (no lock) let both read `count < cap` and both grant.
+  test("two concurrent same-IP attempts cannot both pass the cap (TOCTOU)", async () => {
+    // Seed CAP-1 so exactly one more grant is permitted.
+    committedGrants = Array.from({ length: CAP - 1 }, () => ({ ip: "5.5.5.5" }));
+
+    let grantsRun = 0;
+    const attempt = () =>
+      runWithSignupGrantIpCap("5.5.5.5", async () => {
+        grantsRun++;
+      });
+
+    const [a, b] = await Promise.all([attempt(), attempt()]);
+
+    // Exactly one of the two racers may grant; the other is withheld at the cap.
+    expect([a, b].filter(Boolean).length).toBe(1);
+    expect(grantsRun).toBe(1);
+    expect(committedGrants.filter((g) => g.ip === "5.5.5.5").length).toBe(CAP);
+  });
+
+  test("a grant failure propagates (no swallow) and is not counted as committed", async () => {
+    await expect(
+      runWithSignupGrantIpCap("7.7.7.7", async () => {
+        throw new Error("addCredits failed");
+      }),
+    ).rejects.toThrow("addCredits failed");
+    expect(committedGrants.filter((g) => g.ip === "7.7.7.7").length).toBe(0);
   });
 });

--- a/packages/cloud/shared/src/lib/services/signup-grant-guard.ts
+++ b/packages/cloud/shared/src/lib/services/signup-grant-guard.ts
@@ -9,10 +9,20 @@
  *
  * The grant sites record `metadata.ip_address` on each grant so this count is
  * meaningful; when no IP is known the check falls open (cannot attribute).
+ *
+ * CONCURRENCY: the cap is enforced under a per-IP advisory transaction lock so
+ * N concurrent same-IP signups cannot each read `count < cap` before any of
+ * them commit (a TOCTOU that would let every racer mint the bonus). The COUNT
+ * and the grant run inside ONE transaction that holds
+ * `pg_advisory_xact_lock(hashtext('free_grant:' + ip))` for its whole duration,
+ * the same per-key advisory-lock serialization the redeemable-earnings promo
+ * guard (`redeemable-earnings.ts`) uses for double-spend prevention. A second
+ * racer for the same IP blocks on the lock until the first commits its grant
+ * row, then re-counts and sees it — so the cap holds across concurrency.
  */
 
 import { sql } from "drizzle-orm";
-import { dbRead } from "../../db/client";
+import { dbWrite } from "../../db/client";
 import { logger } from "../utils/logger";
 
 export const FREE_GRANT_IP_LIMITS = {
@@ -27,32 +37,58 @@ function maskIp(ip: string): string {
 }
 
 /**
- * Returns `true` if a new-org welcome bonus may be granted for this IP, `false`
- * if the per-IP daily cap is already reached. Falls open when `ip` is undefined.
+ * Run `grant` iff this IP is under the per-IP daily free-grant cap, serialized
+ * against concurrent same-IP attempts by a per-IP advisory transaction lock.
+ *
+ * The COUNT and `grant` execute inside a single write transaction that holds
+ * `pg_advisory_xact_lock(hashtext('free_grant:' + ip))` until it commits, so a
+ * concurrent racer for the same IP blocks until this transaction's grant row is
+ * committed and then counts it — the cap cannot be raced past.
+ *
+ * Returns `true` if `grant` ran (the bonus was granted), `false` if it was
+ * withheld because the cap is already reached. Falls open (always grants) when
+ * `ip` is undefined, since an unattributable signup cannot be capped. Errors
+ * from `grant` propagate (and roll back the lock) — the guard never swallows.
  */
-export async function signupGrantAllowedForIp(ip: string | undefined): Promise<boolean> {
-  if (!ip) return true;
+export async function runWithSignupGrantIpCap(
+  ip: string | undefined,
+  grant: () => Promise<void>,
+): Promise<boolean> {
+  if (!ip) {
+    await grant();
+    return true;
+  }
 
   const dayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
-  const result = await dbRead.execute(sql`
-    SELECT COUNT(*) AS count
-    FROM credit_transactions
-    WHERE metadata->>'ip_address' = ${ip}
-      AND metadata->>'type' IN ('initial_free_credits', 'wallet_signup')
-      AND created_at >= ${dayAgo}
-  `);
 
-  const granted = Number((result.rows[0] as { count: string } | undefined)?.count ?? 0);
-  if (granted >= FREE_GRANT_IP_LIMITS.MAX_FREE_GRANTS_PER_IP_DAILY) {
-    logger.warn(
-      "[SignupGrantGuard] Per-IP daily free-grant cap reached; withholding welcome bonus",
-      {
-        ip: maskIp(ip),
-        granted,
-        cap: FREE_GRANT_IP_LIMITS.MAX_FREE_GRANTS_PER_IP_DAILY,
-      },
-    );
-    return false;
-  }
-  return true;
+  return await dbWrite.transaction(async (tx) => {
+    // Serialize same-IP grant attempts: the lock is held for the whole
+    // transaction, so a concurrent racer blocks here until we commit our grant
+    // row (released on commit), then re-reads the count below and sees it.
+    await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${`free_grant:${ip}`}))`);
+
+    const result = await tx.execute(sql`
+      SELECT COUNT(*) AS count
+      FROM credit_transactions
+      WHERE metadata->>'ip_address' = ${ip}
+        AND metadata->>'type' IN ('initial_free_credits', 'wallet_signup')
+        AND created_at >= ${dayAgo}
+    `);
+
+    const granted = Number((result.rows[0] as { count: string } | undefined)?.count ?? 0);
+    if (granted >= FREE_GRANT_IP_LIMITS.MAX_FREE_GRANTS_PER_IP_DAILY) {
+      logger.warn(
+        "[SignupGrantGuard] Per-IP daily free-grant cap reached; withholding welcome bonus",
+        {
+          ip: maskIp(ip),
+          granted,
+          cap: FREE_GRANT_IP_LIMITS.MAX_FREE_GRANTS_PER_IP_DAILY,
+        },
+      );
+      return false;
+    }
+
+    await grant();
+    return true;
+  });
 }

--- a/packages/cloud/shared/src/lib/services/wallet-signup.ts
+++ b/packages/cloud/shared/src/lib/services/wallet-signup.ts
@@ -13,7 +13,7 @@ import { getClientIp } from "../runtime/request-context";
 import { logger } from "../utils/logger";
 import { creditsService } from "./credits";
 import { organizationsService } from "./organizations";
-import { signupGrantAllowedForIp } from "./signup-grant-guard";
+import { runWithSignupGrantIpCap } from "./signup-grant-guard";
 import { usersService } from "./users";
 
 export const INITIAL_FREE_CREDITS = ((): number => {
@@ -39,21 +39,20 @@ async function grantWalletSignupCredits(params: {
 }): Promise<boolean> {
   if (params.amount <= 0) return false;
 
-  // Anti-sybil: withhold the bonus when this IP has hit the daily free-grant cap.
+  // Anti-sybil: withhold the bonus when this IP has hit the daily free-grant
+  // cap. The cap check and the grant run under a per-IP advisory lock so
+  // concurrent same-IP signups cannot each pass the cap before any commits.
   const signupIp = getClientIp();
-  if (!(await signupGrantAllowedForIp(signupIp))) {
-    return false;
-  }
-
   try {
-    await creditsService.addCredits({
-      organizationId: params.organizationId,
-      amount: params.amount,
-      description: "Wallet sign-up bonus",
-      stripePaymentIntentId: params.idempotencyKey,
-      metadata: { type: "wallet_signup", chain: params.chain, ip_address: signupIp },
+    return await runWithSignupGrantIpCap(signupIp, async () => {
+      await creditsService.addCredits({
+        organizationId: params.organizationId,
+        amount: params.amount,
+        description: "Wallet sign-up bonus",
+        stripePaymentIntentId: params.idempotencyKey,
+        metadata: { type: "wallet_signup", chain: params.chain, ip_address: signupIp },
+      });
     });
-    return true;
   } catch (err) {
     logger.error("[WalletSignup] Failed to grant initial credits:", err);
     if (params.requireInitialCredits) {

--- a/packages/cloud/shared/src/lib/steward-sync.ts
+++ b/packages/cloud/shared/src/lib/steward-sync.ts
@@ -18,7 +18,7 @@ import { discordService } from "./services/discord";
 import { emailService } from "./services/email";
 import { invitesService } from "./services/invites";
 import { organizationsService } from "./services/organizations";
-import { signupGrantAllowedForIp } from "./services/signup-grant-guard";
+import { runWithSignupGrantIpCap } from "./services/signup-grant-guard";
 import { usersService } from "./services/users";
 import type { UserWithOrganization } from "./types";
 import { getDefaultElizaCharacterData } from "./utils/default-eliza-character";
@@ -429,17 +429,21 @@ export async function syncUserFromSteward(
   const initialCredits = getInitialCredits();
   const signupIp = getClientIp();
 
-  if (initialCredits > 0 && (await signupGrantAllowedForIp(signupIp))) {
+  if (initialCredits > 0) {
     try {
-      await creditsService.addCredits({
-        organizationId: organization.id,
-        amount: initialCredits,
-        description: "Initial free credits - Welcome bonus",
-        metadata: {
-          type: "initial_free_credits",
-          source: "signup",
-          ip_address: signupIp,
-        },
+      // The cap check and the grant run under a per-IP advisory lock so
+      // concurrent same-IP signups cannot each pass the cap before any commits.
+      await runWithSignupGrantIpCap(signupIp, async () => {
+        await creditsService.addCredits({
+          organizationId: organization.id,
+          amount: initialCredits,
+          description: "Initial free credits - Welcome bonus",
+          metadata: {
+            type: "initial_free_credits",
+            source: "signup",
+            ip_address: signupIp,
+          },
+        });
       });
     } catch (error) {
       logger.error(

--- a/packages/core/src/types/tee.ts
+++ b/packages/core/src/types/tee.ts
@@ -1,6 +1,32 @@
 import type { JsonObject } from "./primitives";
 
 /**
+ * LEGACY plugin-tee TEE shapes. `TEEMode`, `TeeType`, `TeeAgent`,
+ * `RemoteAttestationQuote`, and the surrounding `DeriveKeyAttestationData` /
+ * `AttestedMessage` / `RemoteAttestationMessage` / `TeePluginConfig` types model
+ * the original Phala/dstack plugin-tee surface (deterministic key derivation +
+ * per-derivation TDX quote). They are NOT the trust contract the agent boot path
+ * uses, and they are not the place to add new confidential-compute fields.
+ *
+ * The canonical, provider-neutral evidence + trust-decision contract lives in
+ * the agent runtime:
+ *
+ *   - `packages/agent/src/services/tee-evidence.ts` — the normalized `TeeEvidence`
+ *     shape and `TeeKind` union (the single source of truth for attestation
+ *     evidence: `kind`, `measurements`, `freshness`, `claims`, `quote`,
+ *     `reportData`, ...). Add new evidence fields there, not here.
+ *   - `packages/agent/src/services/tee-policy.ts` — `evaluateTeeEvidencePolicy`,
+ *     the ONE fail-closed trust-decision path. Every gate (boot, key release,
+ *     signer, remote-capability sync) routes its trust call through it.
+ *
+ * These legacy types and the canonical `TeeEvidence` contract describe different
+ * concepts and do not conflict; the naming overlap is the only trap. Treat the
+ * `tee-evidence.ts` / `tee-policy.ts` pair as authoritative for any new
+ * confidential-AI / attestation work. See
+ * `packages/agent/docs/tee-agent-implementation-plan.md` §1.2.
+ */
+
+/**
  * Operational modes for a TEE.
  */
 export const TEEMode = {

--- a/packages/scripts/audit-tee-secret-leak.mjs
+++ b/packages/scripts/audit-tee-secret-leak.mjs
@@ -1,0 +1,274 @@
+#!/usr/bin/env node
+
+/**
+ * audit-tee-secret-leak — repo-wide CI gate that fails when an off-device
+ * crash / telemetry / env-dump serializer, or a TEE confidential module, would
+ * emit a TEE secret to a sink that leaves the confidential process boundary.
+ *
+ * This promotes the in-lane checks in
+ * `packages/agent/src/services/tee-secret-hygiene.test.ts` (plan §4.4 / A9) into
+ * a standalone repo-wide gate that runs outside the agent's vitest lane, so a
+ * later edit anywhere in the scanned set fails CI immediately — even in a config
+ * where the agent test suite is not run.
+ *
+ * Two scans, mirroring the in-lane test:
+ *
+ *   1. CONFIDENTIAL MODULES — the modules that hold cleartext secret *material*
+ *      (decrypted weights, raw key material, KDF master secret, derived wrap key,
+ *      ECDH shared secret). They must never pass that material to an off-domain
+ *      SINK (console / logger / JSON.stringify / process.stdout|stderr.write).
+ *      Matches secret *material* identifiers, not scope labels: logging the id
+ *      string "model-key" is fine; logging `keyMaterialHex` or the `weights`
+ *      buffer is not.
+ *
+ *   2. OFF-DEVICE SERIALIZERS — the crash/bug/telemetry/redaction serializers
+ *      that ship startup context, logs, and error detail OFF the device (to
+ *      GitHub / remote intake) or persist them to disk. None of them may
+ *      reference a TEE secret-*scope* identifier as code (field access / payload
+ *      key). String/comment mentions are stripped before matching, so a label
+ *      like the message "model-key blocked" does not trip the gate.
+ *
+ * Commandment 9 + the TEE contract: decrypted weights/keys stay in process
+ * memory and never leak to logs, env dumps, or crash reports.
+ *
+ *   node packages/scripts/audit-tee-secret-leak.mjs            # gate
+ *   node packages/scripts/audit-tee-secret-leak.mjs --json     # machine output
+ *   node packages/scripts/audit-tee-secret-leak.mjs --self-test
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+const args = new Set(process.argv.slice(2));
+const asJson = args.has("--json");
+const selfTest = args.has("--self-test");
+
+const SERVICES_DIR = path.join("packages", "agent", "src", "services");
+
+// Modules that hold cleartext secret material inside the confidential domain.
+const CONFIDENTIAL_MODULES = [
+  path.join(SERVICES_DIR, "tee-confidential-inference.ts"),
+  path.join(SERVICES_DIR, "tee-key-release.ts"),
+  path.join(SERVICES_DIR, "tee-sealed-volume.ts"),
+];
+
+// Off-device crash/telemetry/env-dump/redaction serializers. These ship or
+// persist context OFF the confidential boundary.
+const OFF_DEVICE_SERIALIZERS = [
+  path.join("packages", "agent", "src", "api", "bug-report-routes.ts"),
+  path.join(
+    "packages",
+    "agent",
+    "src",
+    "runtime",
+    "tool-call-cache",
+    "redact.ts",
+  ),
+];
+
+// Off-domain sinks: anything that serializes or emits a value outside the
+// confidential process boundary.
+const SINK =
+  /\b(?:console\.\w+|logger\.\w+|JSON\.stringify|process\.stdout\.write|process\.stderr\.write)\s*\(/;
+
+// Names that hold cleartext secret material inside the domain.
+const SECRET_MATERIAL =
+  /\b(?:keyMaterial|keyMaterialHex|masterSecret|wrapKey|sharedSecret|decryptedWeights|plaintextWeights)\b|\bweights\b/;
+
+// TEE secret-scope identifiers (key ids / scope labels / sealed handles).
+const SECRET_SCOPE =
+  /\b(?:model-key|modelKey|state-volume|stateVolume|keyMaterial|keyMaterialHex|masterSecret|privateKey|sealedWeights|wrapKey|sharedSecret)\b|\bweights\b/;
+
+/** Drop a `// ...` line comment. */
+function stripLineComment(line) {
+  return line.replace(/\/\/.*$/, "");
+}
+
+/** Drop line comments, then string/template literals (keep only code). */
+function stripCommentsAndStrings(line) {
+  return stripLineComment(line)
+    .replace(/"(?:[^"\\]|\\.)*"/g, '""')
+    .replace(/'(?:[^'\\]|\\.)*'/g, "''")
+    .replace(/`(?:[^`\\]|\\.)*`/g, "``");
+}
+
+/**
+ * Scan a confidential-module source for a SINK that also references secret
+ * MATERIAL on the same line. Line comments are ignored; string literals are
+ * NOT stripped here because emitting a secret via a template string IS a leak.
+ * @returns {{line:number, text:string}[]}
+ */
+function scanConfidentialModule(source) {
+  const offenders = [];
+  source.split("\n").forEach((line, index) => {
+    const code = stripLineComment(line);
+    if (SINK.test(code) && SECRET_MATERIAL.test(code)) {
+      offenders.push({ line: index + 1, text: line.trim() });
+    }
+  });
+  return offenders;
+}
+
+/**
+ * Scan an off-device serializer source for any TEE secret-scope identifier
+ * referenced as code (comments + string/template literals stripped first).
+ * @returns {{line:number, text:string}[]}
+ */
+function scanSerializer(source) {
+  const offenders = [];
+  source.split("\n").forEach((line, index) => {
+    const code = stripCommentsAndStrings(line);
+    if (SECRET_SCOPE.test(code)) {
+      offenders.push({ line: index + 1, text: line.trim() });
+    }
+  });
+  return offenders;
+}
+
+function readSource(relPath) {
+  const abs = path.join(repoRoot, relPath);
+  if (!fs.existsSync(abs)) {
+    return null;
+  }
+  return fs.readFileSync(abs, "utf8");
+}
+
+// ---------------------------------------------------------------------------
+// self-test
+// ---------------------------------------------------------------------------
+function runSelfTest() {
+  let failed = 0;
+  const check = (label, actual, expected) => {
+    if (actual === expected) {
+      console.log(`OK ${label}`);
+    } else {
+      failed++;
+      console.error(`FAIL ${label}: expected ${expected}, got ${actual}`);
+    }
+  };
+
+  // Confidential-module scan: secret material to a sink is a leak.
+  check(
+    "logger.info(keyMaterialHex) flagged",
+    scanConfidentialModule("logger.info({ keyMaterialHex });").length,
+    1,
+  );
+  check(
+    "console.log(weights) flagged",
+    scanConfidentialModule("console.log(weights);").length,
+    1,
+  );
+  check(
+    "JSON.stringify(masterSecret) flagged",
+    scanConfidentialModule("const s = JSON.stringify(masterSecret);").length,
+    1,
+  );
+  check(
+    "logger.info(model-key id label) NOT flagged",
+    scanConfidentialModule('logger.info("releasing model-key");').length,
+    0,
+  );
+  check(
+    "comment mentioning weights NOT flagged",
+    scanConfidentialModule("// never logger.info(weights) here").length,
+    0,
+  );
+  check(
+    "sink without material NOT flagged",
+    scanConfidentialModule("logger.info({ keyId, agentId });").length,
+    0,
+  );
+
+  // Serializer scan: secret scope as code is a leak; as a string/comment it is not.
+  check(
+    "serializer emits ctx.keyMaterial flagged",
+    scanSerializer("body.detail = ctx.keyMaterial;").length,
+    1,
+  );
+  check(
+    "serializer emits payload.weights flagged",
+    scanSerializer("payload.weights = buf;").length,
+    1,
+  );
+  check(
+    "serializer string label NOT flagged",
+    scanSerializer('logger.warn("model-key withheld");').length,
+    0,
+  );
+  check(
+    "serializer comment NOT flagged",
+    scanSerializer("// privateKey must never appear below").length,
+    0,
+  );
+
+  if (failed) {
+    console.error(`\nself-test FAILED (${failed})`);
+    process.exit(1);
+  }
+  console.log("\nself-test PASSED");
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+function main() {
+  if (selfTest) return runSelfTest();
+
+  /** @type {{file:string, line:number, text:string, scan:string}[]} */
+  const offenders = [];
+  /** @type {string[]} */
+  const missing = [];
+
+  for (const relPath of CONFIDENTIAL_MODULES) {
+    const source = readSource(relPath);
+    if (source === null) {
+      missing.push(relPath);
+      continue;
+    }
+    for (const o of scanConfidentialModule(source)) {
+      offenders.push({ file: relPath, ...o, scan: "confidential-material" });
+    }
+  }
+
+  for (const relPath of OFF_DEVICE_SERIALIZERS) {
+    const source = readSource(relPath);
+    if (source === null) {
+      missing.push(relPath);
+      continue;
+    }
+    for (const o of scanSerializer(source)) {
+      offenders.push({ file: relPath, ...o, scan: "serializer-scope" });
+    }
+  }
+
+  if (asJson) {
+    console.log(JSON.stringify({ offenders, missing }, null, 2));
+  }
+
+  // A scanned file going missing (rename) is a regression: the gate would
+  // silently pass. Fail closed.
+  if (missing.length > 0) {
+    console.error(
+      "audit-tee-secret-leak: scanned file(s) not found (rename without updating the gate, or run from repo root in local mode):",
+    );
+    for (const m of missing) console.error(`  - ${m}`);
+    process.exit(2);
+  }
+
+  if (offenders.length > 0) {
+    console.error(
+      "audit-tee-secret-leak: TEE secret leak(s) detected — a secret must never reach an off-device sink (Commandment 9 / plan §4.4):",
+    );
+    for (const o of offenders) {
+      console.error(`  [${o.scan}] ${o.file}:${o.line}: ${o.text}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(
+    `audit-tee-secret-leak: PASS — ${CONFIDENTIAL_MODULES.length} confidential module(s) + ${OFF_DEVICE_SERIALIZERS.length} off-device serializer(s) clean.`,
+  );
+}
+
+main();

--- a/packages/ui/src/cloud/api-keys/ApiKeysRoute.tsx
+++ b/packages/ui/src/cloud/api-keys/ApiKeysRoute.tsx
@@ -1,5 +1,5 @@
 /**
- * API-keys cloud route entry.
+ * API-keys surface.
  *
  * Lifted from `@elizaos/cloud-frontend/src/dashboard/api-keys/Page.tsx`. Gates
  * on the Steward session, fetches the keys with {@link useApiKeys}, maps the
@@ -7,8 +7,7 @@
  * renders {@link ApiKeysView}. Loading / error states use the cloud-ui dashboard
  * placeholders; the page title is set via {@link useDocumentTitle} (no Helmet).
  *
- * The same component is exported for both the registered standalone route and
- * the Wave-3 settings-section wrapper (see `index.ts`).
+ * Mounted only through the Settings → Developer section ({@link ApiKeysSection}).
  */
 
 import { useContext } from "react";
@@ -61,10 +60,7 @@ function deriveSummary(keys: ApiKeyDisplay[]): ApiKeysSummaryData {
   };
 }
 
-/**
- * The API-keys surface. Embeddable: used directly by the Wave-3 settings
- * section and wrapped by {@link ApiKeysRoute} for the standalone route.
- */
+/** The API-keys surface, rendered by the Settings → Developer section. */
 export function ApiKeysSurface() {
   const t = useCloudT();
   const auth = useContext(LocalStewardAuthContext);
@@ -105,9 +101,4 @@ export function ApiKeysSurface() {
   return (
     <ApiKeysView keys={displayKeys} summary={deriveSummary(displayKeys)} />
   );
-}
-
-/** Default export consumed by the cloud-route registry. */
-export default function ApiKeysRoute() {
-  return <ApiKeysSurface />;
 }

--- a/packages/ui/src/cloud/api-keys/ApiKeysSection.tsx
+++ b/packages/ui/src/cloud/api-keys/ApiKeysSection.tsx
@@ -1,15 +1,11 @@
 /**
- * Settings-section wrapper for the API-keys surface (Wave 3 mount point).
+ * Settings-section wrapper for the API-keys surface — the single mount.
  *
- * The canonical home for API keys is a Settings → Cloud section
- * (DECISIONS / PLAN §"`dashboard/api-keys` → SECTION (API keys)"; the legacy
- * `/dashboard/api-keys` path is a compat redirect to `/settings#api-keys` in
- * `CloudRouterShell`). The settings-section registry renders a no-prop
- * `Component`, so this is the zero-prop adapter Wave 3 hands to
- * `registerSettingsSection({ id: "api-keys", Component: ApiKeysSection, ... })`.
- *
- * It reuses the exact same {@link ApiKeysSurface} as the standalone route, so
- * the section and any direct mount stay byte-for-byte identical.
+ * The only home for API keys is the Settings → Developer section; legacy
+ * `/dashboard/api-keys` deep links resolve here via the `dashboard/api-keys →
+ * /settings#api-keys` compat redirect in `CloudRouterShell`. The settings-
+ * section registry renders a no-prop `Component`, so this is the zero-prop
+ * adapter handed to `registerSettingsSection({ Component: ApiKeysSection, ... })`.
  */
 
 import { ApiKeysSurface } from "./ApiKeysRoute";

--- a/packages/ui/src/cloud/api-keys/index.ts
+++ b/packages/ui/src/cloud/api-keys/index.ts
@@ -1,31 +1,18 @@
 /**
- * API-keys cloud domain — barrel + route/section registration.
+ * API-keys cloud domain — barrel + canonical section mount.
  *
  * Lifted from `@elizaos/cloud-frontend/src/dashboard/api-keys/*` and its data
- * hook (`src/lib/data/api-keys.ts`). The canonical home is a Settings → Cloud
- * section (PLAN: "`dashboard/api-keys` → SECTION (API keys)"); the legacy
- * `/dashboard/api-keys` path is a compat redirect to `/settings#api-keys`
- * carried by `CloudRouterShell`. So:
+ * hook (`src/lib/data/api-keys.ts`). There is exactly ONE mount for this
+ * surface: the Settings → Developer section. {@link ApiKeysSection} is the
+ * zero-prop component registered as the `api-keys` settings section (see
+ * `cloud/settings/register-cloud-settings.ts`, behind `viewKind: "developer"`).
  *
- *  - {@link ApiKeysSection} is the zero-prop component Wave 3 hands to
- *    `registerSettingsSection({ id: "api-keys", Component: ApiKeysSection })`.
- *    This is the primary mount point.
- *  - {@link registerApiKeysCloudRoute} registers a standalone cloud route for
- *    the surface. It is **opt-in** (not called at import time) so it never
- *    shadows the documented `/dashboard/api-keys` → `/settings#api-keys`
- *    redirect: the shell maps registered routes before the redirect map, and a
- *    `dashboard/api-keys` registration would silently disable that redirect.
- *    The shell or Wave 3 calls this once the redirect is retired (or with a
- *    non-legacy path), keeping route ownership explicit.
+ * Legacy `/dashboard/api-keys` deep links resolve to that section via the
+ * `dashboard/api-keys → /settings#api-keys` compat redirect in
+ * `CloudRouterShell`; there is no standalone `/dashboard/api-keys` route.
  */
 
-import { lazy } from "react";
-import {
-  type CloudRouteDef,
-  registerCloudRoute,
-} from "../shell/cloud-route-registry";
-
-export { ApiKeysSurface, default as ApiKeysRoute } from "./ApiKeysRoute";
+export { ApiKeysSurface } from "./ApiKeysRoute";
 export { ApiKeysSection } from "./ApiKeysSection";
 export { ApiKeysView } from "./ApiKeysView";
 export { copyApiKeyToClipboard } from "./copy-api-key";
@@ -37,29 +24,3 @@ export {
 
 /** Stable settings-section id + URL hash for the API-keys surface. */
 export const API_KEYS_SECTION_ID = "api-keys";
-
-/** Lazy route element for the standalone API-keys surface (code-split). */
-const ApiKeysRouteLazy = lazy(() => import("./ApiKeysRoute"));
-
-/**
- * Cloud-route definition for the standalone API-keys surface. Exported so the
- * shell/Wave 3 can mount it at an explicit, non-colliding path instead of the
- * legacy `dashboard/api-keys` (which is a redirect to the settings section).
- */
-export const apiKeysCloudRoute: CloudRouteDef = {
-  path: "dashboard/api-keys",
-  element: ApiKeysRouteLazy,
-  group: "dashboard",
-};
-
-/**
- * Opt-in registration of the standalone API-keys route. Call this only when the
- * `/dashboard/api-keys` → `/settings#api-keys` redirect is being retired (or
- * pass a custom path), so the route and the redirect never both claim the same
- * path. Not invoked at import time.
- */
-export function registerApiKeysCloudRoute(
-  override?: Partial<CloudRouteDef>,
-): void {
-  registerCloudRoute({ ...apiKeysCloudRoute, ...override });
-}

--- a/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.test.tsx
@@ -88,11 +88,17 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
   delete (window as { opener?: unknown }).opener;
 });
 
 describe("CliLoginPage", () => {
   it("auto-redirects an unauthenticated visitor straight to /login (no CLI interstitial) and arms the per-session guard", async () => {
+    // No window.opener (not script-closable): the page must never offer a
+    // "Close Window" button nor call window.close().
+    const closeSpy = vi.spyOn(window, "close").mockImplementation(() => {});
+    expect((window as { opener?: unknown }).opener).toBeUndefined();
+
     render(<CliLoginPage />);
 
     await waitFor(() =>
@@ -106,6 +112,8 @@ describe("CliLoginPage", () => {
     expect(screen.getByText("Signing in")).toBeTruthy();
     expect(screen.queryByText("CLI Authentication")).toBeNull();
     expect(screen.queryByRole("button", { name: "Sign In" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Close Window" })).toBeNull();
+    expect(closeSpy).not.toHaveBeenCalled();
   });
 
   it("does NOT redirect again when the guard is already set — shows the manual sign-in fallback (loop-safety)", async () => {
@@ -120,7 +128,7 @@ describe("CliLoginPage", () => {
     expect(link.getAttribute("href")).toBe(SIGN_IN_HREF);
   });
 
-  it("completes the session when authenticated: POSTs /complete, notifies the opener, shows success, never redirects", async () => {
+  it("completes the session when authenticated: POSTs /complete, notifies the opener, and lands in Cloud", async () => {
     sessionAuthRef.current = {
       ready: true,
       authenticated: true,
@@ -137,6 +145,7 @@ describe("CliLoginPage", () => {
       value: { postMessage },
       configurable: true,
     });
+    const closeSpy = vi.spyOn(window, "close").mockImplementation(() => {});
 
     render(<CliLoginPage />);
 
@@ -151,18 +160,19 @@ describe("CliLoginPage", () => {
       { type: "eliza-cloud-auth-complete", sessionId: "sess-1" },
       "*",
     );
-    expect(
-      screen
-        .getByRole("link", { name: "Continue to dashboard" })
-        .getAttribute("href"),
-    ).toBe("/");
+    expect(screen.getByText("Opening your dashboard...")).toBeTruthy();
     expect(screen.queryByText("API Key Details")).toBeNull();
     expect(screen.queryByText("ek_live_abc")).toBeNull();
     expect(screen.queryByRole("button", { name: "Close Window" })).toBeNull();
-    expect(navigateMock).not.toHaveBeenCalled();
+    // The page navigates the SPA to the cloud landing — it never tries to
+    // script-close the tab, even when an opener is present.
+    expect(navigateMock).toHaveBeenCalledWith("/join", {
+      replace: true,
+    });
+    expect(closeSpy).not.toHaveBeenCalled();
   });
 
-  it("renders the error panel when the session id is missing — no POST, no redirect", async () => {
+  it("renders the error panel when the session id is missing — no POST, no redirect, no dead close button", async () => {
     searchParamsRef.current = new URLSearchParams("");
 
     render(<CliLoginPage />);
@@ -170,9 +180,14 @@ describe("CliLoginPage", () => {
     expect(
       screen.getByText("Invalid authentication link. Missing session ID."),
     ).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "Close Window" })).toBeNull();
     expect(apiFetchMock).not.toHaveBeenCalled();
     expect(navigateMock).not.toHaveBeenCalled();
+    expect(screen.queryByRole("button", { name: "Close Window" })).toBeNull();
+    expect(
+      screen
+        .getByRole("link", { name: "Open Eliza Cloud" })
+        .getAttribute("href"),
+    ).toBe("/join");
   });
 
   it("surfaces a completion failure as the error panel", async () => {

--- a/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.test.tsx
@@ -128,7 +128,7 @@ describe("CliLoginPage", () => {
     expect(link.getAttribute("href")).toBe(SIGN_IN_HREF);
   });
 
-  it("completes the session when authenticated: POSTs /complete, notifies the opener, and lands in Cloud", async () => {
+  it("completes the session when authenticated: POSTs /complete, notifies the opener, shows success, never redirects or script-closes", async () => {
     sessionAuthRef.current = {
       ready: true,
       authenticated: true,
@@ -160,15 +160,15 @@ describe("CliLoginPage", () => {
       { type: "eliza-cloud-auth-complete", sessionId: "sess-1" },
       "*",
     );
-    expect(screen.getByText("Opening your dashboard...")).toBeTruthy();
+    expect(
+      screen
+        .getByRole("link", { name: "Continue to dashboard" })
+        .getAttribute("href"),
+    ).toBe("/");
     expect(screen.queryByText("API Key Details")).toBeNull();
     expect(screen.queryByText("ek_live_abc")).toBeNull();
     expect(screen.queryByRole("button", { name: "Close Window" })).toBeNull();
-    // The page navigates the SPA to the cloud landing — it never tries to
-    // script-close the tab, even when an opener is present.
-    expect(navigateMock).toHaveBeenCalledWith("/join", {
-      replace: true,
-    });
+    expect(navigateMock).not.toHaveBeenCalled();
     expect(closeSpy).not.toHaveBeenCalled();
   });
 
@@ -183,11 +183,6 @@ describe("CliLoginPage", () => {
     expect(apiFetchMock).not.toHaveBeenCalled();
     expect(navigateMock).not.toHaveBeenCalled();
     expect(screen.queryByRole("button", { name: "Close Window" })).toBeNull();
-    expect(
-      screen
-        .getByRole("link", { name: "Open Eliza Cloud" })
-        .getAttribute("href"),
-    ).toBe("/join");
   });
 
   it("surfaces a completion failure as the error panel", async () => {

--- a/packages/ui/src/cloud/register-all.test.ts
+++ b/packages/ui/src/cloud/register-all.test.ts
@@ -14,7 +14,6 @@ describe("registerAllCloudSurfaces", () => {
     for (const p of [
       "join",
       "dashboard/agents",
-      "dashboard/api-keys",
       "dashboard/billing",
       "dashboard/account",
       "dashboard/security",
@@ -34,5 +33,16 @@ describe("registerAllCloudSurfaces", () => {
     ]) {
       expect(paths, `missing route ${p}`).toContain(p);
     }
+  });
+
+  it("mounts the API-keys surface only once — no standalone dashboard/api-keys route", () => {
+    registerAllCloudSurfaces();
+    const apiKeysRoutes = listCloudRoutes().filter(
+      (r) => r.path === "dashboard/api-keys",
+    );
+    // The single API-keys mount is the Settings → Developer section; legacy
+    // `/dashboard/api-keys` deep links resolve to it via the CloudRouterShell
+    // compat redirect, NOT a registered route.
+    expect(apiKeysRoutes).toHaveLength(0);
   });
 });

--- a/packages/ui/src/cloud/register-all.ts
+++ b/packages/ui/src/cloud/register-all.ts
@@ -23,7 +23,6 @@ import "./organization/routes";
 
 import { registerAdminCloudRoutes } from "./admin";
 import { registerApiExplorerCloudRoute } from "./api-explorer";
-import { registerApiKeysCloudRoute } from "./api-keys";
 import { registerApplicationsCloudRoutes } from "./applications";
 import { registerApprovalsCloudRoute } from "./approvals";
 import { registerJoinFlow } from "./join";
@@ -45,7 +44,6 @@ export function registerAllCloudSurfaces(): void {
   registerJoinFlow();
   registerPublicPages();
 
-  registerApiKeysCloudRoute();
   registerApiExplorerCloudRoute();
   registerApplicationsCloudRoutes();
   registerApprovalsCloudRoute();

--- a/packages/ui/src/cloud/settings/register-cloud-settings.test.ts
+++ b/packages/ui/src/cloud/settings/register-cloud-settings.test.ts
@@ -52,22 +52,30 @@ describe("register-cloud-settings", () => {
     expect(developer?.order).toBeLessThan(2);
   });
 
-  it("registers every Cloud-group section with group=cloud", () => {
+  it("registers every Cloud-group section with group=cloud, visible to a plain user", () => {
     const byId = new Map(listSettingsSections().map((s) => [s.id, s]));
     for (const id of CLOUD_SECTION_IDS) {
       const section = byId.get(id);
       expect(section, `missing section ${id}`).toBeDefined();
       expect(section?.group).toBe(CLOUD_SETTINGS_GROUP_ID);
       expect(section?.Component).toBeTypeOf("function");
+      // Account / Billing / Organization stay in normal Settings — no developer
+      // gate, so a plain USER role sees them.
+      expect(section?.viewKind).not.toBe("developer");
+      expect(section?.viewKind).not.toBe("preview");
+      expect(section?.developerOnly).not.toBe(true);
     }
   });
 
-  it("registers developer cloud sections into the Developer group behind the developer view gate", () => {
+  it("hides the developer cloud sections from a plain user via the developer view gate", () => {
     const byId = new Map(listSettingsSections().map((s) => [s.id, s]));
     for (const id of DEVELOPER_SECTION_IDS) {
       const section = byId.get(id);
       expect(section, `missing section ${id}`).toBeDefined();
       expect(section?.group).toBe(DEVELOPER_SETTINGS_GROUP_ID);
+      // viewKind "developer" is the gate input the SettingsView reads to hide
+      // these from a non-developer USER role (dev builds default the toggle on;
+      // prod defaults it off).
       expect(section?.viewKind).toBe("developer");
       expect(section?.Component).toBeTypeOf("function");
     }

--- a/packages/ui/src/cloud/shell/CloudRouterShell.test.tsx
+++ b/packages/ui/src/cloud/shell/CloudRouterShell.test.tsx
@@ -3,7 +3,7 @@ import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
 import { cleanup, render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, describe, expect, it } from "vitest";
-import { AppCatchAllRoute } from "./CloudRouterShell";
+import { AppCatchAllRoute, DASHBOARD_REDIRECTS } from "./CloudRouterShell";
 
 /**
  * Gate B regression. elizacloud.ai (an apex control-plane host) serves
@@ -102,5 +102,18 @@ describe("CloudRouterShell apex catch-all (Gate B)", () => {
     renderCatchAll();
     expect(screen.getByTestId("agent-app")).toBeTruthy();
     expect(screen.queryByTestId("login-page")).toBeNull();
+  });
+});
+
+describe("CloudRouterShell dashboard compat redirects", () => {
+  it("routes legacy /dashboard/api-keys to the single Settings mount via one redirect", () => {
+    const apiKeysRedirects = DASHBOARD_REDIRECTS.filter(
+      (r) => r.from === "dashboard/api-keys",
+    );
+    // Exactly one redirect entry — the api-keys surface is mounted only as the
+    // Settings → Developer section, so /dashboard/api-keys resolves to it and
+    // never to a (now-removed) standalone route.
+    expect(apiKeysRedirects).toHaveLength(1);
+    expect(apiKeysRedirects[0]?.to).toBe("/settings#api-keys");
   });
 });

--- a/packages/ui/src/cloud/shell/CloudRouterShell.tsx
+++ b/packages/ui/src/cloud/shell/CloudRouterShell.tsx
@@ -54,29 +54,32 @@ import { StewardAuthProvider } from "./StewardProvider";
  * old bookmarks may still point at. `:param` segments are substituted from the
  * matched route params, and the original query string is preserved.
  */
-const DASHBOARD_REDIRECTS: ReadonlyArray<{ from: string; to: string }> = [
-  // Legacy build/* surface → agents.
-  { from: "dashboard/build/*", to: "/dashboard/my-agents" },
-  // Media generators were folded into the API explorer.
-  { from: "dashboard/image", to: "/dashboard/api-explorer" },
-  { from: "dashboard/video", to: "/dashboard/api-explorer" },
-  { from: "dashboard/gallery", to: "/dashboard/api-explorer" },
-  { from: "dashboard/voices", to: "/dashboard/api-explorer" },
-  // Containers were unified under agents.
-  { from: "dashboard/containers", to: "/dashboard/agents" },
-  { from: "dashboard/containers/:id", to: "/dashboard/agents/:id" },
-  { from: "dashboard/containers/agents/:id", to: "/dashboard/agents/:id" },
-  // In-dashboard quick chat was removed; real chat lives in the app. Send old
-  // deep links back to the agent detail page.
-  { from: "dashboard/agents/:id/chat", to: "/dashboard/agents/:id" },
-  // App-create modal is opened from the apps list, not its own route.
-  { from: "dashboard/apps/create", to: "/dashboard/apps" },
-  // New app-IA targets: billing / api-keys move into settings sections.
-  { from: "dashboard/billing", to: "/settings#billing" },
-  { from: "dashboard/api-keys", to: "/settings#api-keys" },
-  // Knowledge/Documents now lives in the app; old deep links land on the agents list.
-  { from: "dashboard/documents", to: "/dashboard/agents" },
-];
+export const DASHBOARD_REDIRECTS: ReadonlyArray<{ from: string; to: string }> =
+  [
+    // Legacy build/* surface → agents.
+    { from: "dashboard/build/*", to: "/dashboard/my-agents" },
+    // Media generators were folded into the API explorer.
+    { from: "dashboard/image", to: "/dashboard/api-explorer" },
+    { from: "dashboard/video", to: "/dashboard/api-explorer" },
+    { from: "dashboard/gallery", to: "/dashboard/api-explorer" },
+    { from: "dashboard/voices", to: "/dashboard/api-explorer" },
+    // Containers were unified under agents.
+    { from: "dashboard/containers", to: "/dashboard/agents" },
+    { from: "dashboard/containers/:id", to: "/dashboard/agents/:id" },
+    { from: "dashboard/containers/agents/:id", to: "/dashboard/agents/:id" },
+    // In-dashboard quick chat was removed; real chat lives in the app. Send old
+    // deep links back to the agent detail page.
+    { from: "dashboard/agents/:id/chat", to: "/dashboard/agents/:id" },
+    // App-create modal is opened from the apps list, not its own route.
+    { from: "dashboard/apps/create", to: "/dashboard/apps" },
+    // New app-IA targets: billing / api-keys move into settings sections. The
+    // API-keys surface has no standalone route — this redirect is its sole entry
+    // for every in-repo `/dashboard/api-keys` link and old deep link.
+    { from: "dashboard/billing", to: "/settings#billing" },
+    { from: "dashboard/api-keys", to: "/settings#api-keys" },
+    // Knowledge/Documents now lives in the app; old deep links land on the agents list.
+    { from: "dashboard/documents", to: "/dashboard/agents" },
+  ];
 
 /** Substitute `:param` segments from the matched route params. */
 function ParamRedirect({ to }: { to: string }): React.JSX.Element {

--- a/packages/vault/AGENTS.md
+++ b/packages/vault/AGENTS.md
@@ -17,7 +17,7 @@ src/
   vault.ts           — createVault() factory (PgliteVaultImpl wired with defaults)
   pglite-vault.ts    — PgliteVaultImpl: storage engine (PGlite DB, migration, stale-lock healing)
   crypto.ts          — encrypt/decrypt (AES-256-GCM, v1:<nonce>:<tag>:<ct> wire format)
-  master-key.ts      — MasterKeyResolver variants: osKeychainMasterKey, passphraseMasterKey, inMemoryMasterKey, defaultMasterKey
+  master-key.ts      — MasterKeyResolver variants: osKeychainMasterKey, passphraseMasterKey, inMemoryMasterKey, attestationMasterKey, defaultMasterKey (attestationMasterKey is fail-closed: releases the sealed-volume key only on trusted TEE evidence via an injected TeeAttestationVerifier)
   manager.ts         — createManager(), SecretsManager: routing layer over Vault; backend detection (1Password, Bitwarden, Proton Pass)
   inventory.ts       — listVaultInventory(), categorizeKey(), setEntryMeta(): UI-renderable metadata layer
   profiles.ts        — resolveActiveValue(), readRoutingConfig(), writeRoutingConfig(): per-key profiles + per-context routing
@@ -53,8 +53,10 @@ import {
   passphraseMasterKey,    // scrypt from ELIZA_VAULT_PASSPHRASE
   passphraseMasterKeyFromEnv,
   inMemoryMasterKey,      // tests only
+  attestationMasterKey,   // sealed-volume key, released only on trusted TEE evidence (fail-closed)
   MasterKeyUnavailableError,
 } from "@elizaos/vault";
+import type { TeeAttestationVerifier } from "@elizaos/vault"; // injected TEE trust boundary
 
 // Inventory / metadata
 import { listVaultInventory, categorizeKey, inferProviderId, setEntryMeta, readEntryMeta, removeEntryMeta } from "@elizaos/vault";

--- a/packages/vault/CLAUDE.md
+++ b/packages/vault/CLAUDE.md
@@ -17,7 +17,7 @@ src/
   vault.ts           — createVault() factory (PgliteVaultImpl wired with defaults)
   pglite-vault.ts    — PgliteVaultImpl: storage engine (PGlite DB, migration, stale-lock healing)
   crypto.ts          — encrypt/decrypt (AES-256-GCM, v1:<nonce>:<tag>:<ct> wire format)
-  master-key.ts      — MasterKeyResolver variants: osKeychainMasterKey, passphraseMasterKey, inMemoryMasterKey, defaultMasterKey
+  master-key.ts      — MasterKeyResolver variants: osKeychainMasterKey, passphraseMasterKey, inMemoryMasterKey, attestationMasterKey, defaultMasterKey (attestationMasterKey is fail-closed: releases the sealed-volume key only on trusted TEE evidence via an injected TeeAttestationVerifier)
   manager.ts         — createManager(), SecretsManager: routing layer over Vault; backend detection (1Password, Bitwarden, Proton Pass)
   inventory.ts       — listVaultInventory(), categorizeKey(), setEntryMeta(): UI-renderable metadata layer
   profiles.ts        — resolveActiveValue(), readRoutingConfig(), writeRoutingConfig(): per-key profiles + per-context routing
@@ -53,8 +53,10 @@ import {
   passphraseMasterKey,    // scrypt from ELIZA_VAULT_PASSPHRASE
   passphraseMasterKeyFromEnv,
   inMemoryMasterKey,      // tests only
+  attestationMasterKey,   // sealed-volume key, released only on trusted TEE evidence (fail-closed)
   MasterKeyUnavailableError,
 } from "@elizaos/vault";
+import type { TeeAttestationVerifier } from "@elizaos/vault"; // injected TEE trust boundary
 
 // Inventory / metadata
 import { listVaultInventory, categorizeKey, inferProviderId, setEntryMeta, readEntryMeta, removeEntryMeta } from "@elizaos/vault";

--- a/packages/vault/src/index.ts
+++ b/packages/vault/src/index.ts
@@ -98,8 +98,10 @@ export type {
   MasterKeyResolver,
   OsKeychainOptions,
   PassphraseOptions,
+  TeeAttestationVerifier,
 } from "./master-key.js";
 export {
+  attestationMasterKey,
   defaultMasterKey,
   inMemoryMasterKey,
   MasterKeyUnavailableError,

--- a/packages/vault/src/master-key.ts
+++ b/packages/vault/src/master-key.ts
@@ -21,11 +21,22 @@ const execFileAsync = promisify(execFile);
  *      Operator opts in by setting the env var; we never derive from a
  *      hard-coded fallback.
  *   3. **In-memory** — `inMemoryMasterKey(buffer)`. Tests only.
+ *   4. **Attestation-bound** — `attestationMasterKey(verifier)`. Releases the
+ *      sealed-state-volume master key ONLY when trusted TEE evidence is present.
+ *      For a confidential-compute deployment where the vault sits on an
+ *      attestation-gated sealed volume: the key is bound to the measured
+ *      agent/policy/device identity, so absent or tampered attestation yields
+ *      NO key (fail-closed) — never a fallback key. The TEE trust decision lives
+ *      in the agent runtime (`packages/agent/src/services/tee-*`), which vault
+ *      must not import; the caller injects it through the
+ *      {@link TeeAttestationVerifier} interface.
  *
  * `defaultMasterKey()` walks 1 → 2 and throws a single
  * `MasterKeyUnavailableError` with both paths' diagnostic messages when
  * neither is available. Operators see a single line that names every
- * remediation option.
+ * remediation option. The attestation resolver is opt-in (the caller wires it),
+ * not part of the default walk, because it requires the agent's TEE policy to be
+ * injected.
  */
 
 export interface MasterKeyResolver {
@@ -52,6 +63,77 @@ export function inMemoryMasterKey(key: Buffer): MasterKeyResolver {
     },
     describe() {
       return "inMemory";
+    },
+  };
+}
+
+/**
+ * Injected TEE trust boundary for {@link attestationMasterKey}. The vault
+ * package is a leaf and must NOT depend on `@elizaos/agent` / `@elizaos/core`,
+ * so the attestation policy + sealed-volume key-release path is supplied by the
+ * caller (the agent wires its `evaluateTeeEvidencePolicy` / boot-gate state and
+ * `unsealStateVolumeKey` here).
+ *
+ * Contract (fail-closed):
+ *
+ *   - `releaseSealedVolumeKey()` MUST resolve with the 32-byte sealed-volume
+ *     master key ONLY when fresh TEE evidence is trusted by the agent's policy.
+ *   - It MUST reject (throw) when attestation is absent, stale, simulated, or
+ *     tampered, or when the boot gate already blocked secrets. It MUST NEVER
+ *     resolve with a fallback / default / host-readable key — the negative path
+ *     is "no key", enforced by the agent's key-release client refusing to
+ *     release one.
+ *
+ * `attestationMasterKey` adds only shape/length validation on top: a verifier
+ * that returns a non-32-byte buffer is a programming error and is rejected.
+ */
+export interface TeeAttestationVerifier {
+  /**
+   * Release the sealed-state-volume master key, gated on trusted TEE evidence.
+   * Rejects (never returns a fallback key) when attestation is missing/tampered.
+   */
+  releaseSealedVolumeKey(): Promise<Buffer>;
+  /** Short identifier for diagnostics/`describe()`, e.g. `"tdx-dstack"`. */
+  describe(): string;
+}
+
+/**
+ * Attestation-bound master key (resolver #4). Releases the sealed-volume master
+ * key ONLY when the injected {@link TeeAttestationVerifier} confirms trusted TEE
+ * evidence. When attestation is absent or tampered the verifier rejects, and
+ * this resolver surfaces a {@link MasterKeyUnavailableError} — it never falls
+ * back to an unsealed or default key. This is the vault-side half of the
+ * confidential-compute sealed-volume contract; the trust decision itself is the
+ * agent's `tee-*` policy path, injected via `verifier`.
+ */
+export function attestationMasterKey(
+  verifier: TeeAttestationVerifier,
+): MasterKeyResolver {
+  return {
+    async load() {
+      let key: Buffer;
+      try {
+        key = await verifier.releaseSealedVolumeKey();
+      } catch (err) {
+        // Fail closed: a refused/absent/tampered attestation means the key is
+        // UNAVAILABLE. Never substitute a fallback key.
+        throw new MasterKeyUnavailableError(
+          `attestation-bound master key unavailable (${verifier.describe()}): ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+      if (!Buffer.isBuffer(key) || key.length !== KEY_BYTES) {
+        throw new MasterKeyUnavailableError(
+          `attestationMasterKey: verifier (${verifier.describe()}) returned ${
+            Buffer.isBuffer(key) ? `${key.length} bytes` : typeof key
+          }, expected a ${KEY_BYTES}-byte Buffer`,
+        );
+      }
+      return key;
+    },
+    describe() {
+      return `attestation://${verifier.describe()}`;
     },
   };
 }

--- a/packages/vault/test/master-key.test.ts
+++ b/packages/vault/test/master-key.test.ts
@@ -336,9 +336,7 @@ describe("attestationMasterKey — fail-closed sealed-volume binding", () => {
 
   test("tampered attestation → key unavailable (throws, no fallback)", async () => {
     const r = attestationMasterKey(
-      refusingVerifier(
-        "state-volume key release denied: measurement-mismatch",
-      ),
+      refusingVerifier("state-volume key release denied: measurement-mismatch"),
     );
     // Fail closed: a tampered agent/policy/device yields NO key — never a
     // fallback/default/unsealed key.

--- a/packages/vault/test/master-key.test.ts
+++ b/packages/vault/test/master-key.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
-import { KEY_BYTES } from "../src/crypto.js";
+import { generateMasterKey, KEY_BYTES } from "../src/crypto.js";
 import {
+  attestationMasterKey,
   defaultMasterKey,
   inMemoryMasterKey,
   MasterKeyUnavailableError,
   passphraseMasterKey,
   passphraseMasterKeyFromEnv,
+  type TeeAttestationVerifier,
 } from "../src/master-key.js";
 import { runtimePassphraseMasterKeyCaller } from "./vitest-assertion-shim.js";
 
@@ -289,5 +291,79 @@ describe("inMemoryMasterKey — sanity (regression baseline)", () => {
     const k = Buffer.alloc(KEY_BYTES, 7);
     const r = inMemoryMasterKey(k);
     expect((await r.load()).equals(k)).toBe(true);
+  });
+});
+
+describe("attestationMasterKey — fail-closed sealed-volume binding", () => {
+  /** Trusted: attestation passes → verifier releases the sealed-volume key. */
+  function trustedVerifier(key: Buffer): TeeAttestationVerifier {
+    return {
+      async releaseSealedVolumeKey() {
+        return key;
+      },
+      describe() {
+        return "tdx-dstack";
+      },
+    };
+  }
+
+  /** Untrusted: attestation absent/tampered → verifier refuses (throws). */
+  function refusingVerifier(reason: string): TeeAttestationVerifier {
+    return {
+      async releaseSealedVolumeKey() {
+        throw new Error(reason);
+      },
+      describe() {
+        return "tdx-dstack";
+      },
+    };
+  }
+
+  test("trusted evidence → releases the sealed-volume master key", async () => {
+    const sealedKey = generateMasterKey();
+    const r = attestationMasterKey(trustedVerifier(sealedKey));
+    const loaded = await r.load();
+    expect(loaded.equals(sealedKey)).toBe(true);
+  });
+
+  test("absent attestation → key unavailable (throws, no fallback)", async () => {
+    const r = attestationMasterKey(
+      refusingVerifier("no TEE evidence collected at boot"),
+    );
+    await expect(r.load()).rejects.toBeInstanceOf(MasterKeyUnavailableError);
+    await expect(r.load()).rejects.toThrow(/no TEE evidence/);
+  });
+
+  test("tampered attestation → key unavailable (throws, no fallback)", async () => {
+    const r = attestationMasterKey(
+      refusingVerifier(
+        "state-volume key release denied: measurement-mismatch",
+      ),
+    );
+    // Fail closed: a tampered agent/policy/device yields NO key — never a
+    // fallback/default/unsealed key.
+    await expect(r.load()).rejects.toBeInstanceOf(MasterKeyUnavailableError);
+    await expect(r.load()).rejects.toThrow(/measurement-mismatch/);
+  });
+
+  test("boot gate blocking secrets → key unavailable (throws)", async () => {
+    const r = attestationMasterKey(
+      refusingVerifier(
+        "state-volume key release refused: TEE boot gate blocks secrets",
+      ),
+    );
+    await expect(r.load()).rejects.toBeInstanceOf(MasterKeyUnavailableError);
+    await expect(r.load()).rejects.toThrow(/boot gate blocks secrets/);
+  });
+
+  test("verifier returns a wrong-size buffer → rejected (no short key)", async () => {
+    const r = attestationMasterKey(trustedVerifier(Buffer.alloc(16, 1)));
+    await expect(r.load()).rejects.toBeInstanceOf(MasterKeyUnavailableError);
+    await expect(r.load()).rejects.toThrow(/expected a 32-byte Buffer/);
+  });
+
+  test("describe surfaces the attestation provider for audit", () => {
+    const r = attestationMasterKey(trustedVerifier(generateMasterKey()));
+    expect(r.describe()).toBe("attestation://tdx-dstack");
   });
 });

--- a/plugins/plugin-tee/AGENTS.md
+++ b/plugins/plugin-tee/AGENTS.md
@@ -90,7 +90,7 @@ bun run --cwd plugins/plugin-tee clean           # rm -rf dist .turbo .turbo-tsc
 
 ## Conventions / gotchas
 
-- The plugin currently registers **no actions**. The README's mention of a `REMOTE_ATTESTATION` action is inaccurate — PhalaVendor.getActions() returns [].
+- The plugin currently registers **no actions** — `PhalaVendor.getActions()` returns `[]`. Remote attestation is the `phala-remote-attestation` **provider**, not an action. The README states this explicitly; do not reintroduce a `REMOTE_ATTESTATION` action claim.
 - `TEEService` uses `PhalaDeriveKeyProvider` unconditionally regardless of `TEE_VENDOR`; vendor selection in `teePlugin.init` only affects which vendor's providers/actions are registered.
 - `WALLET_SECRET_SALT` doubles as the derivation `path` argument inside `phalaDeriveKeyProvider`; it is passed directly to `TappdClient.deriveKey(secretSalt, "solana"|"evm")`.
 - `uploadAttestationQuote` POSTs to `https://proof.t16z.com/api/upload` — requires network access in production.

--- a/plugins/plugin-tee/CLAUDE.md
+++ b/plugins/plugin-tee/CLAUDE.md
@@ -90,7 +90,7 @@ bun run --cwd plugins/plugin-tee clean           # rm -rf dist .turbo .turbo-tsc
 
 ## Conventions / gotchas
 
-- The plugin currently registers **no actions**. The README's mention of a `REMOTE_ATTESTATION` action is inaccurate — PhalaVendor.getActions() returns [].
+- The plugin currently registers **no actions** — `PhalaVendor.getActions()` returns `[]`. Remote attestation is the `phala-remote-attestation` **provider**, not an action. The README states this explicitly; do not reintroduce a `REMOTE_ATTESTATION` action claim.
 - `TEEService` uses `PhalaDeriveKeyProvider` unconditionally regardless of `TEE_VENDOR`; vendor selection in `teePlugin.init` only affects which vendor's providers/actions are registered.
 - `WALLET_SECRET_SALT` doubles as the derivation `path` argument inside `phalaDeriveKeyProvider`; it is passed directly to `TappdClient.deriveKey(secretSalt, "solana"|"evm")`.
 - `uploadAttestationQuote` POSTs to `https://proof.t16z.com/api/upload` — requires network access in production.

--- a/plugins/plugin-tee/README.md
+++ b/plugins/plugin-tee/README.md
@@ -4,9 +4,16 @@ Trusted Execution Environment (TEE) integration plugin for elizaOS. Adds secure 
 
 ## What it does
 
-- **Remote attestation** — generates a verifiable TDX quote proving an agent is executing inside a real TEE (Phala Network / dstack).
-- **Key derivation** — deterministically derives Ed25519 (Solana) and ECDSA (EVM) keypairs from a secret salt inside the TEE, with per-derivation attestation.
+- **Remote attestation** — a `phala-remote-attestation` **provider** that generates a TDX quote over the current message payload (Phala Network / dstack). This is a context provider, **not** an action; the plugin registers no actions (`PhalaVendor.getActions()` returns `[]`).
+- **Key derivation** — a `phala-derive-key` **provider** plus the `TEEService`: deterministically derives Ed25519 (Solana) and ECDSA (EVM) keypairs from a secret salt, with per-derivation attestation.
 - **TEEService** — a runtime service (`ServiceType.TEE`) that other plugins can call to derive keys without going through providers.
+
+> This plugin exposes **providers + a service only — no actions**. An earlier
+> revision of this README implied a `REMOTE_ATTESTATION` action; there is no such
+> action. The attestation surface is the `phala-remote-attestation` provider above.
+> The provider-neutral evidence/policy/key-release trust contract used by the
+> agent boot path lives separately in `packages/agent/src/services/tee-*`
+> (`tee-evidence.ts` + `evaluateTeeEvidencePolicy`), not in this plugin.
 
 ## Quick start
 


### PR DESCRIPTION
## Summary

Closes out the tractable, software-only work across **8 issues** in one focused sweep (built by parallel sub-agents on disjoint file sets, then consolidated, rebased onto latest `develop`, and verified together). Each issue's remaining acceptance items that genuinely require an **armed staging daemon**, **TDX hardware**, or a **prod ops flag-flip** are documented as blocked on the issue itself — those cannot be proven from a code worktree.

One commit per cluster:

| Commit | Issues | What |
|---|---|---|
| `fix(ui): collapse API-keys to one Developer-view mount` | **#9966, #9961** | The standalone `dashboard/api-keys` route was registered at boot and **shadowed** the `→ /settings#api-keys` redirect (the real duplicate mount). Removed the route + dead `registerApiKeysCloudRoute`/`ApiKeysRoute` machinery; the Settings → Developer section is now the single mount. Kept the redirect (5+ live in-repo links depend on it). Regression tests: one mount only, no dead "Close Window" button / `window.close()`, developer sections gated `viewKind:"developer"`. |
| `fix(cloud): multi-tenant hardening follow-ups` | **#9853** | The 3 adversarial-review follow-ups + IPv6: free-grant per-IP cap **TOCTOU** closed via `pg_advisory_xact_lock` (one txn COUNT+grant); digest-pin **parity** on the app-deploy image path; SSRF screens deprecated IPv4-compatible IPv6 (`::/96`). The tenant-scope CI gate combinator fix **already landed on develop independently (#9943/#9991)** — took develop's reviewed gate and kept our 13-case regression test as added coverage. |
| `feat(cloud): pre-upgrade snapshot + executeDowngrade rollback` | **#9964, #9963** | `pre-upgrade` snapshot type + `previous_image_digest`/`previous_docker_image` columns (additive migration 0152); `executeUpgrade()` snapshots before the swap and persists the prior digest; new `executeDowngrade()` rolls back onto it + restores the snapshot; `image-rollout-status` flips `rollback` from Unsupported → operator-gated. `/api/snapshot` console.log → structured logger. `docs/agent-backup.md` specs the real backup surface. |
| `feat(tee): Phala-dStack host verdict + attestation-bound key resolver` | **#9962** | Records the host verdict (Hetzner = no managed confidential compute → Phala dStack TDX) in `CONFIDENTIAL_COMPUTE.md`; adds a 4th vault master-key resolver released only on trusted TEE evidence (injectable verifier, no vault→agent edge); a repo-wide `audit:tee-secret-leak` CI gate; consolidates the TEE type homes in docs; reconciles the implementation plan. Hardware TDX (B1–B4 / Phase C) stays BLOCKED + fail-closed. |

**#9899** (perf TTFT) and **#9939** (shared→dedicated handoff): the root-cause engineering already merged on develop; the remainder is ops/soak (prod flag-flip, warm-pool config) — status documented on each issue, no code in this PR.

## Verification

- `cloud/shared`: typecheck ✓ · biome ✓ · **1865 pass / 30 skip / 0 fail** (216 files)
- `ui`: typecheck ✓ · biome ✓ · changed-file tests **19 pass**
- `vault`: typecheck ✓ · **193 pass** (incl. 7 new attestation-resolver tests)
- `cloud/api`: typecheck ✓ (consumes the cloud/shared type changes)
- CI gates: `audit:tee-secret-leak` + self-test ✓ · tenant-scope self-test (13) + real-tree **0 violations** ✓ · `plugin-tee` **6 pass** · migration `drizzle-kit check` ✓
- Rebased onto latest `origin/develop`; 2 semantic conflicts resolved in favor of develop's already-merged work (tenant-scope gate, retired plugin-tee test exemption).

## Pre-existing red (not from this PR)

`audit:e2e-coverage` fails for **`plugin-task-coordinator`** ("exposes actions but no keyless e2e / not baselined") — unrelated to this diff (that plugin, the checker, and `keyless-e2e-baseline.json` are untouched here). Pre-existing on develop.

## Blocked / out of scope (documented on each issue)

- **#9853 P2**, **#9963/#9964 e2e**: backup→wipe→restore and upgrade→downgrade round-trips need the **armed staging provisioning daemon** + a real `@elizaos/agent` image. Code paths are real and unit-tested offline.
- **#9962 B1–B4 / C**: real TDX quote verification needs **silicon** — intentionally BLOCKED, fail-closed.
- **#9899 / #9939**: prod flag-flip + warm-pool config are **ops** steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
