### PR TITLE
fix(agent,core,scripts): green develop bridge tests + #9941 boundary guard + #9940 fallback budget

### DIFF
--- a/packages/agent/src/services/remote-plugin-bridge.ts
+++ b/packages/agent/src/services/remote-plugin-bridge.ts
@@ -148,6 +148,32 @@ const HostRpcArgsSchema = {
   composeState: z.object({ message: MemorySchema }).passthrough(),
 } as const;
 
+/**
+ * Envelope-level validation for the worker→host RPC messages this bridge
+ * dispatches. The producer always stamps a string `requestId` on these
+ * envelopes; a message that reaches a handler without its required fields is a
+ * protocol violation that must surface rather than be silently dropped (an
+ * rpc-result with no `requestId` would otherwise no-op against the pending map).
+ */
+const HandledWorkerEnvelopeSchemas: Partial<
+  Record<RemotePluginWorkerMessage["type"], z.ZodTypeAny>
+> = {
+  "worker-rpc-result": z
+    .object({
+      type: z.literal("worker-rpc-result"),
+      requestId: z.string(),
+      ok: z.boolean(),
+    })
+    .passthrough(),
+  "host-rpc": z
+    .object({
+      type: z.literal("host-rpc"),
+      requestId: z.string(),
+      method: z.string(),
+    })
+    .passthrough(),
+};
+
 function toActionResult(
   value: z.infer<typeof ActionHandlerWireResultSchema>,
 ): ActionResult | undefined {
@@ -355,6 +381,13 @@ export class RemotePluginBridge {
     if (isWorkerActionCallbackEnvelope(message)) {
       await this.handleActionCallback(message);
       return;
+    }
+
+    const envelopeSchema = HandledWorkerEnvelopeSchemas[message.type];
+    if (envelopeSchema && !envelopeSchema.safeParse(message).success) {
+      throw new Error(
+        `Invalid remote plugin worker message: ${message.type}`,
+      );
     }
 
     switch (message.type) {
@@ -729,7 +762,9 @@ export class RemotePluginBridge {
       if (result && typeof result === "object" && !Array.isArray(result)) {
         return result as ProviderResult;
       }
-      return { values: {}, data: {}, text: "" } as ProviderResult;
+      throw new Error(
+        `Remote provider ${name} returned invalid ProviderResult`,
+      );
     };
 
     const provider: Provider = {

--- a/packages/agent/src/services/remote-plugin-bridge.ts
+++ b/packages/agent/src/services/remote-plugin-bridge.ts
@@ -150,25 +150,29 @@ const HostRpcArgsSchema = {
 
 /**
  * Envelope-level validation for the worker→host RPC messages this bridge
- * dispatches. The producer always stamps a string `requestId` on these
- * envelopes; a message that reaches a handler without its required fields is a
- * protocol violation that must surface rather than be silently dropped (an
- * rpc-result with no `requestId` would otherwise no-op against the pending map).
+ * dispatches. The producer stamps a numeric `requestId` (see
+ * `nextRequestId`); a message that reaches a handler without its required
+ * fields is a protocol violation that must surface rather than be silently
+ * dropped (an rpc-result with no `requestId` would otherwise no-op against the
+ * pending map). Malformed *payloads* (vs. malformed envelopes) are still
+ * validated downstream and answered with a graceful `ok: false` result, so this
+ * gate intentionally checks only the envelope shape.
  */
+const RequestIdSchema = z.union([z.string(), z.number()]);
 const HandledWorkerEnvelopeSchemas: Partial<
   Record<RemotePluginWorkerMessage["type"], z.ZodTypeAny>
 > = {
   "worker-rpc-result": z
     .object({
       type: z.literal("worker-rpc-result"),
-      requestId: z.string(),
+      requestId: RequestIdSchema,
       ok: z.boolean(),
     })
     .passthrough(),
   "host-rpc": z
     .object({
       type: z.literal("host-rpc"),
-      requestId: z.string(),
+      requestId: RequestIdSchema,
       method: z.string(),
     })
     .passthrough(),

--- a/packages/agent/src/services/remote-plugin-bridge.ts
+++ b/packages/agent/src/services/remote-plugin-bridge.ts
@@ -385,9 +385,7 @@ export class RemotePluginBridge {
 
     const envelopeSchema = HandledWorkerEnvelopeSchemas[message.type];
     if (envelopeSchema && !envelopeSchema.safeParse(message).success) {
-      throw new Error(
-        `Invalid remote plugin worker message: ${message.type}`,
-      );
+      throw new Error(`Invalid remote plugin worker message: ${message.type}`);
     }
 
     switch (message.type) {

--- a/packages/core/src/contracts/core-plugin-coupling.contract.test.ts
+++ b/packages/core/src/contracts/core-plugin-coupling.contract.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Boundary guard for #9941: the innermost layer (`@elizaos/core`) must not
+ * re-couple to concrete `@elizaos/plugin-*` packages.
+ *
+ * Two violations are enforced, both AST-classified so a plugin name mentioned
+ * in a comment, an error message, or an action example (all legitimate) is not
+ * miscounted:
+ *
+ *  1. **No plugin module imports.** `import`/`export … from`, dynamic
+ *     `import()`, and `require()` of an `@elizaos/plugin-*` specifier point the
+ *     dependency graph outward (Presentation/Infrastructure ← Domain), which
+ *     violates "dependencies point inward only". Zero are allowed.
+ *
+ *  2. **No env-var → plugin "provider map" literal.** The specific dead,
+ *     divergent copy this issue deleted (`buildCharacterPlugins`) was an object
+ *     literal keyed by env-var names (`ANTHROPIC_API_KEY`, …) whose values were
+ *     `@elizaos/plugin-*` names. That business rule lives in the `@elizaos/registry`
+ *     generator now (`provider-plugin-map.json`); a fresh copy must not reappear
+ *     in core. Detected structurally: an object literal with ≥2 UPPER_SNAKE_CASE
+ *     keys whose values are plugin-name string literals.
+ *
+ * A `pluginName: "@elizaos/plugin-openai"` field (camelCase key — the first-run
+ * options contract) and an action-example `text: "install @elizaos/plugin-discord"`
+ * are intentionally NOT flagged: they are data/UX, not a connector business rule
+ * or a module dependency.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+const CORE_SRC = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"..",
+);
+
+const PLUGIN_SPECIFIER = /^@elizaos\/plugin-[a-z0-9-]+$/;
+const PLUGIN_NAME_LITERAL =
+	/@elizaos\/plugin-[a-z0-9-]+|(?:^|[^a-z])plugin-[a-z0-9-]+/;
+const ENV_KEY = /^[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+$/;
+
+function isTestLikeFile(rel: string): boolean {
+	if (/\.d\.ts$/.test(rel)) return true;
+	if (/\.(test|spec|e2e|stories?|fixture|mock)\.(ts|tsx)$/.test(rel)) {
+		return true;
+	}
+	const segments = rel.split(path.sep);
+	// `testing/` ships first-party test utilities that legitimately print
+	// example `import … from '@elizaos/plugin-sql'` snippets and live-provider
+	// fixtures; it is not production runtime code and is excluded.
+	return segments.some((seg) =>
+		["__tests__", "__mocks__", "__fixtures__", "testing", "test"].includes(seg),
+	);
+}
+
+function listSourceFiles(dir: string): string[] {
+	const out: string[] = [];
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const full = path.join(dir, entry.name);
+		if (entry.isDirectory()) {
+			out.push(...listSourceFiles(full));
+			continue;
+		}
+		if (!/\.(ts|tsx)$/.test(entry.name)) continue;
+		const rel = path.relative(CORE_SRC, full);
+		if (isTestLikeFile(rel)) continue;
+		out.push(full);
+	}
+	return out;
+}
+
+function literalText(node: ts.Node): string | undefined {
+	if (ts.isStringLiteralLike(node)) return node.text;
+	return undefined;
+}
+
+interface Violation {
+	file: string;
+	line: number;
+	kind: "import" | "provider-map";
+	detail: string;
+}
+
+function classify(relPath: string, sourceText: string): Violation[] {
+	const sourceFile = ts.createSourceFile(
+		relPath,
+		sourceText,
+		ts.ScriptTarget.Latest,
+		true,
+		relPath.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+	);
+	const violations: Violation[] = [];
+	const at = (node: ts.Node) =>
+		sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line +
+		1;
+
+	const recordImport = (spec: ts.Expression | undefined) => {
+		if (!spec) return;
+		const text = literalText(spec);
+		if (text && PLUGIN_SPECIFIER.test(text)) {
+			violations.push({
+				file: relPath,
+				line: at(spec),
+				kind: "import",
+				detail: text,
+			});
+		}
+	};
+
+	const isProviderMap = (obj: ts.ObjectLiteralExpression): boolean => {
+		let envKeyedPluginValues = 0;
+		for (const prop of obj.properties) {
+			if (!ts.isPropertyAssignment(prop)) continue;
+			const key = prop.name;
+			const keyText = ts.isIdentifier(key)
+				? key.text
+				: ts.isStringLiteralLike(key)
+					? key.text
+					: undefined;
+			if (!keyText || !ENV_KEY.test(keyText)) continue;
+			const value = literalText(prop.initializer);
+			if (value && PLUGIN_NAME_LITERAL.test(value)) {
+				envKeyedPluginValues += 1;
+			}
+		}
+		return envKeyedPluginValues >= 2;
+	};
+
+	const visit = (node: ts.Node) => {
+		if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+			recordImport(node.moduleSpecifier as ts.Expression | undefined);
+		}
+		if (
+			ts.isCallExpression(node) &&
+			(node.expression.kind === ts.SyntaxKind.ImportKeyword ||
+				(ts.isIdentifier(node.expression) &&
+					node.expression.text === "require"))
+		) {
+			recordImport(node.arguments[0]);
+		}
+		if (ts.isObjectLiteralExpression(node) && isProviderMap(node)) {
+			violations.push({
+				file: relPath,
+				line: at(node),
+				kind: "provider-map",
+				detail: "env-var → @elizaos/plugin-* object literal",
+			});
+		}
+		ts.forEachChild(node, visit);
+	};
+	visit(sourceFile);
+	return violations;
+}
+
+describe("core plugin-coupling boundary (#9941)", () => {
+	const files = listSourceFiles(CORE_SRC);
+
+	it("scans a non-trivial slice of core production source", () => {
+		expect(files.length).toBeGreaterThan(50);
+	});
+
+	it("never imports a concrete @elizaos/plugin-* package", () => {
+		const offenders = files.flatMap((file) =>
+			classify(
+				path.relative(CORE_SRC, file),
+				readFileSync(file, "utf8"),
+			).filter((v) => v.kind === "import"),
+		);
+		expect(
+			offenders,
+			`@elizaos/core must not import @elizaos/plugin-* (dependencies point inward):\n${offenders
+				.map((v) => `  ${v.file}:${v.line} ${v.detail}`)
+				.join("\n")}`,
+		).toEqual([]);
+	});
+
+	it("never hosts an env-var → plugin provider map (no fresh buildCharacterPlugins)", () => {
+		const offenders = files.flatMap((file) =>
+			classify(
+				path.relative(CORE_SRC, file),
+				readFileSync(file, "utf8"),
+			).filter((v) => v.kind === "provider-map"),
+		);
+		expect(
+			offenders,
+			`The provider env→plugin map is owned by @elizaos/registry; it must not be copied into core:\n${offenders
+				.map((v) => `  ${v.file}:${v.line} ${v.detail}`)
+				.join("\n")}`,
+		).toEqual([]);
+	});
+
+	it("flags a deliberately-added plugin import and provider map (self-check)", () => {
+		const bad = classify(
+			"synthetic.ts",
+			[
+				`import anthropic from "@elizaos/plugin-anthropic";`,
+				`const m = await import("@elizaos/plugin-openai");`,
+				`const MAP = {`,
+				`  ANTHROPIC_API_KEY: "@elizaos/plugin-anthropic",`,
+				`  OPENAI_API_KEY: "@elizaos/plugin-openai",`,
+				`};`,
+			].join("\n"),
+		);
+		expect(bad.filter((v) => v.kind === "import")).toHaveLength(2);
+		expect(bad.filter((v) => v.kind === "provider-map")).toHaveLength(1);
+	});
+
+	it("does not flag legitimate data contracts or action examples (self-check)", () => {
+		const ok = classify(
+			"synthetic.ts",
+			[
+				`// install @elizaos/plugin-discord to enable Discord`,
+				`const option = { pluginName: "@elizaos/plugin-openai", label: "OpenAI" };`,
+				`const example = { text: "install @elizaos/plugin-discord" };`,
+				`const deps = { dependencies: ["@elizaos/plugin-sql"] };`,
+			].join("\n"),
+		);
+		expect(ok).toEqual([]);
+	});
+});

--- a/packages/scripts/type-safety-ratchet-baseline.json
+++ b/packages/scripts/type-safety-ratchet-baseline.json
@@ -1,6 +1,6 @@
 {
   "schema": "eliza_type_safety_ratchet_v1",
-  "updatedAt": "2026-06-29T04:59:46.866Z",
+  "updatedAt": "2026-06-29T05:40:10.276Z",
   "scope": {
     "trackedOnly": true,
     "enumeration": "git ls-files",
@@ -48,9 +48,9 @@
     "explicitAny": 126,
     "tsSuppress": 0,
     "nonNullAssertion": 567,
-    "nullishEmptyString": 636,
-    "nullishEmptyArray": 589,
-    "nullishEmptyObject": 378,
+    "nullishEmptyString": 637,
+    "nullishEmptyArray": 588,
+    "nullishEmptyObject": 379,
     "nullishZero": 406
   },
   "filesScanned": 9873

--- a/packages/scripts/type-safety-ratchet-baseline.json
+++ b/packages/scripts/type-safety-ratchet-baseline.json
@@ -1,6 +1,6 @@
 {
   "schema": "eliza_type_safety_ratchet_v1",
-  "updatedAt": "2026-06-28T22:11:45.423Z",
+  "updatedAt": "2026-06-29T04:59:46.866Z",
   "scope": {
     "trackedOnly": true,
     "enumeration": "git ls-files",
@@ -35,6 +35,11 @@
       "**/mocks/**",
       "**/test/**",
       "**/tests/**"
+    ],
+    "emptyFallbackScope": [
+      "packages/core/src/",
+      "packages/agent/src/",
+      "packages/app-core/src/"
     ]
   },
   "limits": {
@@ -42,7 +47,11 @@
     "asAny": 0,
     "explicitAny": 126,
     "tsSuppress": 0,
-    "nonNullAssertion": 572
+    "nonNullAssertion": 567,
+    "nullishEmptyString": 636,
+    "nullishEmptyArray": 589,
+    "nullishEmptyObject": 378,
+    "nullishZero": 406
   },
-  "filesScanned": 9867
+  "filesScanned": 9873
 }

--- a/packages/scripts/type-safety-ratchet.mjs
+++ b/packages/scripts/type-safety-ratchet.mjs
@@ -38,7 +38,47 @@ const KIND_LABELS = {
   explicitAny: "explicit `: any` annotation",
   tsSuppress: "@ts-expect-error / @ts-ignore",
   nonNullAssertion: "non-null assertion (!)",
+  // Empty-fallback sludge (#9940). A nullish-coalescing default that is an
+  // empty string / array / object / 0 at a pipeline edge conflates "not loaded"
+  // / "broken upstream" with "legitimately empty", so a broken pipeline renders
+  // as a silent no-op instead of failing observably. Scoped to the runtime
+  // packages (core/agent/app-core) via EMPTY_FALLBACK_SCOPE — those are the
+  // measured hotspots and the layers architecture rule 8 governs.
+  nullishEmptyString: '`?? ""` (core/agent/app-core)',
+  nullishEmptyArray: "`?? []` (core/agent/app-core)",
+  nullishEmptyObject: "`?? {}` (core/agent/app-core)",
+  nullishZero: "`?? 0` (core/agent/app-core)",
 };
+
+// The empty-fallback budget only governs the runtime packages named in #9940;
+// the cast/suppression kinds above stay repo-wide.
+const EMPTY_FALLBACK_SCOPE = [
+  "packages/core/src/",
+  "packages/agent/src/",
+  "packages/app-core/src/",
+];
+
+function inEmptyFallbackScope(relPath) {
+  return EMPTY_FALLBACK_SCOPE.some((prefix) => relPath.startsWith(prefix));
+}
+
+// Classify the right operand of a `??` as an empty-fallback default, or return
+// undefined. Parenthesized operands are unwrapped by the caller.
+function emptyFallbackKind(node, ts) {
+  if (ts.isStringLiteral(node) && node.text === "") {
+    return "nullishEmptyString";
+  }
+  if (ts.isArrayLiteralExpression(node) && node.elements.length === 0) {
+    return "nullishEmptyArray";
+  }
+  if (ts.isObjectLiteralExpression(node) && node.properties.length === 0) {
+    return "nullishEmptyObject";
+  }
+  if (ts.isNumericLiteral(node) && Number(node.text) === 0) {
+    return "nullishZero";
+  }
+  return undefined;
+}
 
 const EXCLUDED_SEGMENTS = new Set([
   "__fixtures__",
@@ -168,7 +208,20 @@ function collectUnsafeCasts(sourceText, relPath) {
     return current;
   }
 
+  const trackEmptyFallbacks = inEmptyFallbackScope(relPath);
+
   function visit(node) {
+    if (
+      trackEmptyFallbacks &&
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken
+    ) {
+      const kind = emptyFallbackKind(unwrapExpression(node.right), ts);
+      if (kind) {
+        record(kind, node);
+      }
+    }
+
     if (ts.isAsExpression(node)) {
       if (node.type.kind === ts.SyntaxKind.AnyKeyword) {
         record("asAny", node);
@@ -230,13 +283,9 @@ function collectUnsafeCasts(sourceText, relPath) {
 }
 
 function summarize(findings) {
-  const counts = {
-    asUnknownAs: 0,
-    asAny: 0,
-    explicitAny: 0,
-    tsSuppress: 0,
-    nonNullAssertion: 0,
-  };
+  const counts = Object.fromEntries(
+    Object.keys(KIND_LABELS).map((kind) => [kind, 0]),
+  );
   for (const finding of findings) {
     counts[finding.kind] += 1;
   }
@@ -304,6 +353,9 @@ function baselinePayload(files, counts) {
         "**/test/**",
         "**/tests/**",
       ],
+      // The nullish* empty-fallback kinds are additionally scoped to these
+      // runtime packages (#9940); the cast/suppression kinds are repo-wide.
+      emptyFallbackScope: EMPTY_FALLBACK_SCOPE,
     },
     limits: counts,
     filesScanned: files.length,
@@ -418,8 +470,18 @@ function runSelfTest() {
     const ten = (value as Result)!;
     let eleven!: Result;
     const twelve: any = value;
+    const emptyStr = (value as { s?: string }).s ?? "";
+    const nonEmptyStr = (value as { s?: string }).s ?? "fallback";
+    const emptyArr = (value as { a?: number[] }).a ?? [];
+    const emptyObj = (value as { o?: object }).o ?? {};
+    const zero = (value as { n?: number }).n ?? 0;
+    const parenEmpty = (value as { s?: string }).s ?? ("");
   `;
-  const counts = summarize(collectUnsafeCasts(sample, "sample.ts"));
+  // Use an in-scope path so the empty-fallback budget (scoped to
+  // core/agent/app-core) is exercised alongside the repo-wide cast kinds.
+  const counts = summarize(
+    collectUnsafeCasts(sample, "packages/core/src/sample.ts"),
+  );
   if (
     counts.asUnknownAs !== 2 ||
     counts.asAny !== 1 ||
@@ -429,10 +491,33 @@ function runSelfTest() {
     counts.tsSuppress !== 2 ||
     // `ten` is a NonNullExpression; `eleven!` is a definite-assignment
     // assertion (not counted), so exactly one non-null assertion is expected.
-    counts.nonNullAssertion !== 1
+    counts.nonNullAssertion !== 1 ||
+    // `?? ""` appears twice (plain + parenthesized); `?? "fallback"` is not an
+    // empty-string fallback and must not be counted.
+    counts.nullishEmptyString !== 2 ||
+    counts.nullishEmptyArray !== 1 ||
+    counts.nullishEmptyObject !== 1 ||
+    counts.nullishZero !== 1
   ) {
     console.error(
       `[type-safety-ratchet] self-test failed: ${JSON.stringify(counts)}`,
+    );
+    process.exit(1);
+  }
+
+  // Out-of-scope files must NOT contribute empty-fallback findings (the budget
+  // is scoped; only the runtime packages are governed).
+  const outOfScope = summarize(
+    collectUnsafeCasts(sample, "packages/ui/src/sample.ts"),
+  );
+  if (
+    outOfScope.nullishEmptyString !== 0 ||
+    outOfScope.nullishEmptyArray !== 0 ||
+    outOfScope.nullishEmptyObject !== 0 ||
+    outOfScope.nullishZero !== 0
+  ) {
+    console.error(
+      `[type-safety-ratchet] self-test failed (scope leak): ${JSON.stringify(outOfScope)}`,
     );
     process.exit(1);
   }


### PR DESCRIPTION
## Summary

Finishing work for **#9941** (retire hardcoded `@elizaos/plugin-*` couplings) and **#9940** (empty-fallback sludge + remote-plugin trust boundary). The bulk of both issues already landed on `develop` (provider-plugin-map registry derivation, route-race fix at source, TTS registry resolution, message/media pipeline-edge fixes, #10022 bridge-cast removal, #10029 dead-map deletion). This PR adds the three pieces that are **not yet on develop**:

### 1. Bridge envelope/result validation — greens a currently-RED develop ⚠️
`develop`'s `remote-plugin-bridge.test.ts` already asserts:
- *"rejects handled worker messages that do not match the wire envelope"*
- *"rejects non-object remote provider results instead of returning empty context"*

…but the **source** for both was never merged, so those two tests fail on `develop` today. This PR adds:
- Envelope-level zod validation of `worker-rpc-result` / `host-rpc` messages (numeric `requestId` + required fields). Malformed *payloads* still flow to the downstream validators that answer with a graceful `ok:false` result; only malformed *envelopes* throw.
- A non-object remote `ProviderResult` now throws instead of silently composing an empty `{ values:{}, data:{}, text:"" }` context (#9940 "ban silent send-empty-forward").

Local: **13/13** `remote-plugin-bridge.test.ts` pass.

### 2. `#9941` core boundary guard
`core-plugin-coupling.contract.test.ts` (AST-classified) fails if `@elizaos/core` imports a concrete `@elizaos/plugin-*` package or hosts an env-var→plugin "provider map" object literal (the deleted `buildCharacterPlugins` anti-pattern). Comments, error text, action examples, and the camelCase first-run options contract are intentionally allowed. Self-checks prove both directions. **5/5** pass; no offenders on current `develop` core.

### 3. `#9940` CI empty-fallback budget
`type-safety-ratchet.mjs` now AST-counts `?? "" / [] / {} / 0` in `packages/{core,agent,app-core}/src` (tests excluded) with current counts as the ceiling, so a new silent send-empty-forward at a pipeline edge fails CI. Self-test asserts detection + scope isolation; baseline aligned to current `develop`.

## Verification (Linux, local)
- `type-safety-ratchet --self-test` + full scan → **green**
- biome check on changed files → **clean**; core typecheck → **0 errors**
- `madge --circular packages/{core,agent,app-core}/src` → **0 cycles**
- vitest: remote-plugin-bridge **13/13**, core plugin-coupling boundary **5/5** (run against this content in a node_modules-equipped tree).

Supersedes #10033.

🤖 Generated with [Claude Code](https://claude.com/claude-code)