### PR TITLE
perf(cloud): enable Tier-2 optimistic billing in prod — latency cutover step 2 [REAL-MONEY, @lalalune your call + confirm threshold]

### DIFF
--- a/packages/cloud-api/wrangler.toml
+++ b/packages/cloud-api/wrangler.toml
@@ -437,8 +437,8 @@ REDIS_RATE_LIMITING = "false"
 # sweep-inference-charges cron settles any dropped inline settles.
 # SAFE_BALANCE_THRESHOLD (USD) empty/invalid -> +Inf -> every org takes the safe
 # synchronous-reserve path. Flip only after review + a flag-flip runbook.
-INFERENCE_OPTIMISTIC_BILLING = "false"
-SAFE_BALANCE_THRESHOLD = ""
+INFERENCE_OPTIMISTIC_BILLING = "true"
+SAFE_BALANCE_THRESHOLD = "5.00"
 FORCE_REDIS_EVENTS = "false"
 R2_PUBLIC_HOST = "blob.elizacloud.ai"
 SQL_HEAVY_PAYLOAD_STORAGE = "r2"


### PR DESCRIPTION
**Step 2 of the latency cutover. Ready to merge, but it's the real-money one — your call on timing AND the threshold value.** Step 1 (auth fast-path, #10061) is already live in prod.

## What
Flips, in the **production** block only:
- `INFERENCE_OPTIMISTIC_BILLING = "true"`
- `SAFE_BALANCE_THRESHOLD = "5.00"`  ← **conservative recommended start; tune before merge**

This removes the **synchronous credit-reserve DB write (846–1686ms on *every* call)** — the bigger steady-state latency lever — for orgs whose balance comfortably clears $5. They skip the reserve and debit the actual cost off the response path, backed by the durable KV pending-charge backstop + the `sweep-inference-charges` cron.

## Risk (real money, but bounded)
- Only orgs with **balance > $5** fast-path (and > the request's est. cost). Near-empty orgs keep the safe synchronous reserve.
- Worst case = a **rare under-bill**: a crash between the KV `getAndDelete` claim and the debit loses a single charge (**under-bill, never double-bill**). `credit_balance` has a DB `CHECK(>=0)` so it can't go negative; a failed debit forces the org back onto the safe path + logs.
- The code is byte-identical to develop's adversarially-hardened #9899 + my own adversarial pass (#10026); auth flag is already on; prod has CACHE_KV.

## The threshold is yours
$5.00 = my conservative recommendation (most active paying users benefit; near-empty orgs excluded). Higher = safer/less benefit; lower = more orgs get the speed-up + slightly more under-bill exposure. **Set it to your target before merging.**

## Runbook
Merge → main→prod auto-deploys → the credit-reserve skip goes live for eligible orgs → chat ~8s. Watch for `uncollected inference charge` logs (the under-bill signal). Revert = both flags back to prod-safe + redeploy.