### PR TITLE
perf(cloud): make inference auth cache default

### DIFF
--- a/packages/cloud-api/docs/inference-hot-path.md
+++ b/packages/cloud-api/docs/inference-hot-path.md
@@ -6,7 +6,7 @@ Refs: #9899 (root-cause), #9900 (instrumentation), #8434 (tracking).
 > billing-correctness, security-isolation, consistency-staleness,
 > rollout-blast-radius). The review **rejected** the original "skip the upfront
 > credit reserve entirely" model as billing-unsafe. The result is a two-tier
-> plan: **Tier 1** (ship now — safe, flag-gated, fully testable) and **Tier 2**
+> plan: **Tier 1** (ship now — safe, default-on, fully testable) and **Tier 2**
 > (deferred — requires a durable backstop before it can be correct). The
 > blocker analysis that forced the split is in the appendix.
 
@@ -47,7 +47,7 @@ read for cerebras-native ids — without any billing-correctness regression.
 
 ---
 
-## Tier 1 — single-entry auth+moderation cache (SHIP NOW, flag-gated)
+## Tier 1 — single-entry auth+moderation cache (SHIP NOW, default-on)
 
 ### `InferenceAuthContext` (IAC) — one KV entry, API-key auth only
 
@@ -99,16 +99,15 @@ produces the exact `(status, code, message)` unchanged.
   (RB-6). The synchronous `reserveCredits` write **stays** — it is the correct,
   safe credit guard (a single indexed `FOR UPDATE` UPDATE).
 
-### Catalog skip for cerebras-native ids — flag-gated + allowlisted
+### Catalog lookup for reasoning detection
 
 `getCachedGatewayModelById` exists only for reasoning-parameter detection, and
 `modelUsesReasoningTokens` already returns true via id name-pattern for the
 cerebras ids (`gpt-oss-120b` → `/^gpt-oss/`, `zai-glm-4.7` → `/^zai-glm-/`). For
 ids in the **`REASONING_MODEL_PATTERNS` allowlist**, skip the catalog read. This
-is **gated behind the same flag** so flag-OFF is byte-identical (blocker RB-1),
-and **pinned** to the name-pattern set with a guard test so a future cerebras id
-that advertises reasoning only in the catalog can't silently lose its
-reasoning-token floor (blocker RB-2).
+must stay **pinned** to the name-pattern set with a guard test so a future
+cerebras id that advertises reasoning only in the catalog can't silently lose
+its reasoning-token floor (blocker RB-2).
 
 ### Invalidation wiring (Tier 1)
 
@@ -125,11 +124,11 @@ reasoning-token floor (blocker RB-2).
 
 ### Rollout (Tier 1)
 
-`INFERENCE_HOT_PATH_CACHE` flag, **default OFF**. With OFF, the route executes the
-unmodified `requireAuthOrApiKeyWithOrg` + `shouldBlockUser` + `reserveCredits` +
-`getCachedGatewayModelById` calls verbatim — byte-identical. Enable in staging,
-confirm via the `[preforward]` log that auth+reads collapse to one cache read,
-then prod.
+The IAC resolver is the only auth path for chat completions. API-key requests use
+the auth-context cache when the shared cache backend is available; non-API-key
+and cache-unavailable requests take the existing authoritative
+`requireAuthOrApiKeyWithOrg` + `shouldBlockUser` path. Confirm via the
+`[preforward]` log that eligible API-key auth+reads collapse to one cache read.
 
 ### Tests (Tier 1)
 
@@ -138,11 +137,10 @@ then prod.
   propagates (never fail-open); cache-unavailable→slow path.
 - **Invalidation unit tests:** revoke/ban deletes the IAC entry; ban fan-out
   across multiple keys; `listByUser` correctness.
-- **Route regression:** flag OFF ⇒ identical to today; 429→403→402 priority
-  preserved on ON path; wallet headers disable fast path; app-credits path
-  unchanged; catalog skip output-identical for the allowlisted ids; a non-pattern
-  cerebras id is NOT skipped (guard test).
-- **Benchmark/assertion:** flag ON + warm IAC ⇒ hot path performs exactly **1
+- **Route regression:** 429→403→402 priority preserved; wallet headers disable
+  fast path; app-credits path unchanged; catalog skip output-identical for the
+  allowlisted ids; a non-pattern cerebras id is NOT skipped (guard test).
+- **Benchmark/assertion:** warm IAC ⇒ hot path performs exactly **1
   cache read and 0 auth/moderation DB reads** before reserve (spy on cache + db).
 
 ---
@@ -181,7 +179,7 @@ existing `settleReservation` chain, now backed by `createOptimisticDebitSettler`
    top up. So a failed debit is bounded over-spend (the in-flight call only),
    never free-forever, and self-heals on top-up (blocker BILL-1). A persistent
    debt ledger would need a migration and is intentionally NOT added (logged
-   instead) — out of scope for the flag-gated MVP.
+   instead) — out of scope for the optimistic-billing MVP.
 4. **Idempotent settlement** keyed on `requestId`: the inline settler atomically
    CLAIMS the pending entry via `cache.getAndDelete` before debiting, and the
    cron sweep claims the same way — so the two can never both charge one request
@@ -235,7 +233,8 @@ then prod.
 - **CS-5:** module-level singleton CacheClient ⇒ invalidation only works on the
   bound KV namespace, not a per-isolate memory adapter; optimization is inert if
   cache is disabled in prod.
-- **RB-1:** catalog skip must be flag-gated to keep flag-OFF byte-identical.
+- **RB-1:** deleted. The auth-context resolver is now the default path; cache
+  unavailable still falls back to the authoritative path before granting auth.
 - **RB-2:** catalog skip must be pinned to the name-pattern allowlist (else empty-
   but-billed-output regression for a catalog-only-reasoning id).
 - **RB-3:** IAC must store no `active/suspended` booleans — only cache fully-OK
@@ -260,8 +259,9 @@ The high-confidence, contained ones were FIXED:
 - **Auto-suspension didn't invalidate IAC (MED):** `updateUserModerationStatus`
   (the authoritative mutation behind chat/messages/A2A moderation) now drops the
   user's IAC when they cross into a blocking state (banned / ≥5 violations).
-- **Flag-OFF parity (LOW):** the `onViolation` IAC invalidation is now gated on
-  `hotPathEnabled`, so flag-OFF does zero IAC/DB fan-out.
+- **IAC invalidation fan-out (LOW):** async moderation invalidates the user's IAC
+  when a blocking violation is detected, so the next request re-checks
+  authoritatively.
 - **Out-of-order hint raise (LOW):** the debit settler writes the org-balance
   hint lower-only (`lowerOrgBalanceHint`), so a late concurrent debit can never
   raise the gate value.

--- a/packages/cloud-api/v1/chat/completions/route.ts
+++ b/packages/cloud-api/v1/chat/completions/route.ts
@@ -69,10 +69,7 @@ import {
   type CreditReservation,
   creditsService,
 } from "@/lib/services/credits";
-import {
-  isInferenceHotPathCacheEnabled,
-  resolveInferenceAuthContext,
-} from "@/lib/services/inference-auth-context";
+import { resolveInferenceAuthContext } from "@/lib/services/inference-auth-context";
 import {
   createOptimisticDebitSettler,
   getGateBalanceUsd,
@@ -751,44 +748,37 @@ export async function handleChatCompletionsPOST(
     | null = null;
 
   try {
-    // 1. Authenticate (+ moderation). #9899: when the inference hot-path cache
-    // is enabled, an API-key dedicated-agent request resolves auth + org +
-    // moderation in a SINGLE cache read (the actual hot path). Otherwise, and for
-    // non-API-key / cache-unavailable requests, the authoritative chain runs
-    // verbatim, so flag-OFF behavior is byte-identical to before.
+    // 1. Authenticate (+ moderation). #9899: API-key dedicated-agent requests
+    // resolve auth + org + moderation in a SINGLE cache read when the cache is
+    // available. Non-API-key / cache-unavailable requests take the authoritative
+    // slow path verbatim.
     let user: { id: string; organization_id: string };
     let apiKey: { id: string } | null;
     let moderationAlreadyChecked = false;
-    if (isInferenceHotPathCacheEnabled()) {
-      const resolution = await resolveInferenceAuthContext(req);
-      if (resolution.kind === "suspended") {
-        return addCorsHeaders(
-          Response.json(
-            {
-              error: {
-                message:
-                  "Your account has been suspended due to policy violations.",
-                type: "account_suspended",
-                code: "moderation_violation",
-              },
+    const resolution = await resolveInferenceAuthContext(req);
+    if (resolution.kind === "suspended") {
+      return addCorsHeaders(
+        Response.json(
+          {
+            error: {
+              message:
+                "Your account has been suspended due to policy violations.",
+              type: "account_suspended",
+              code: "moderation_violation",
             },
-            { status: 403 },
-          ),
-        );
-      }
-      if (resolution.kind === "authorized") {
-        user = {
-          id: resolution.ctx.userId,
-          organization_id: resolution.ctx.orgId,
-        };
-        apiKey = { id: resolution.ctx.apiKeyId };
-        // The resolver already verified not-suspended, so skip the synchronous read.
-        moderationAlreadyChecked = true;
-      } else {
-        const authed = await requireAuthOrApiKeyWithOrg(req);
-        user = authed.user;
-        apiKey = authed.apiKey ? { id: authed.apiKey.id } : null;
-      }
+          },
+          { status: 403 },
+        ),
+      );
+    }
+    if (resolution.kind === "authorized") {
+      user = {
+        id: resolution.ctx.userId,
+        organization_id: resolution.ctx.orgId,
+      };
+      apiKey = { id: resolution.ctx.apiKeyId };
+      // The resolver already verified not-suspended, so skip the synchronous read.
+      moderationAlreadyChecked = true;
     } else {
       const authed = await requireAuthOrApiKeyWithOrg(req);
       user = authed.user;
@@ -1027,11 +1017,7 @@ export async function handleChatCompletionsPOST(
       // charge (free inference). Mirrors the IAC resolver's cache-health guard.
       let useOptimistic = false;
       let estimatedCostUsd = 0;
-      if (
-        isInferenceHotPathCacheEnabled() &&
-        isOptimisticBillingEnabled() &&
-        isOptimisticBackstopAvailable()
-      ) {
+      if (isOptimisticBillingEnabled() && isOptimisticBackstopAvailable()) {
         const { totalCost } = await calculateCost(
           normalizedModel,
           provider,

--- a/packages/cloud-api/wrangler.toml
+++ b/packages/cloud-api/wrangler.toml
@@ -140,19 +140,13 @@ CACHE_ENABLED = "true"
 # would force the dead Upstash path and skip Railway Redis (client.ts:235).
 CACHE_BACKEND = "auto"
 REDIS_RATE_LIMITING = "false"
-# Inference hot path (#9899). OFF here = byte-identical to the pre-#9899 route.
-# Flip to "true" (prod cutover) only after the hand-port is reviewed. On a cache
-# miss/unavailable the resolver falls back to the authoritative slow path
-# (re-authenticates via requireAuthOrApiKeyWithOrg) — no auth is granted from a
-# failed cache read.
-INFERENCE_HOT_PATH_CACHE = "false"
 # Tier-2 optimistic off-path billing (#9899). OFF here = the synchronous credit
-# reserve runs exactly as before (no behavior change). When "true" (also requires
-# INFERENCE_HOT_PATH_CACHE + a writable KV backstop), an org whose balance clears
-# SAFE_BALANCE_THRESHOLD skips the sync reserve and debits the actual cost off the
-# response path; the sweep-inference-charges cron settles any dropped inline
-# settles. SAFE_BALANCE_THRESHOLD (USD) empty/invalid -> +Inf -> every org takes
-# the safe synchronous-reserve path. Flip only after review + a flag-flip runbook.
+# reserve runs exactly as before (no behavior change). When "true" and the KV
+# backstop is writable, an org whose balance clears SAFE_BALANCE_THRESHOLD skips
+# the sync reserve and debits the actual cost off the response path; the
+# sweep-inference-charges cron settles any dropped inline settles.
+# SAFE_BALANCE_THRESHOLD (USD) empty/invalid -> +Inf -> every org takes the safe
+# synchronous-reserve path. Flip only after review + a flag-flip runbook.
 INFERENCE_OPTIMISTIC_BILLING = "false"
 SAFE_BALANCE_THRESHOLD = ""
 FORCE_REDIS_EVENTS = "false"
@@ -320,19 +314,13 @@ CACHE_ENABLED = "true"
 # would force the dead Upstash path and skip Railway Redis (client.ts:235).
 CACHE_BACKEND = "auto"
 REDIS_RATE_LIMITING = "false"
-# Inference hot path (#9899). OFF here = byte-identical to the pre-#9899 route.
-# Flip to "true" (prod cutover) only after the hand-port is reviewed. On a cache
-# miss/unavailable the resolver falls back to the authoritative slow path
-# (re-authenticates via requireAuthOrApiKeyWithOrg) — no auth is granted from a
-# failed cache read.
-INFERENCE_HOT_PATH_CACHE = "false"
 # Tier-2 optimistic off-path billing (#9899). OFF here = the synchronous credit
-# reserve runs exactly as before (no behavior change). When "true" (also requires
-# INFERENCE_HOT_PATH_CACHE + a writable KV backstop), an org whose balance clears
-# SAFE_BALANCE_THRESHOLD skips the sync reserve and debits the actual cost off the
-# response path; the sweep-inference-charges cron settles any dropped inline
-# settles. SAFE_BALANCE_THRESHOLD (USD) empty/invalid -> +Inf -> every org takes
-# the safe synchronous-reserve path. Flip only after review + a flag-flip runbook.
+# reserve runs exactly as before (no behavior change). When "true" and the KV
+# backstop is writable, an org whose balance clears SAFE_BALANCE_THRESHOLD skips
+# the sync reserve and debits the actual cost off the response path; the
+# sweep-inference-charges cron settles any dropped inline settles.
+# SAFE_BALANCE_THRESHOLD (USD) empty/invalid -> +Inf -> every org takes the safe
+# synchronous-reserve path. Flip only after review + a flag-flip runbook.
 INFERENCE_OPTIMISTIC_BILLING = "false"
 SAFE_BALANCE_THRESHOLD = ""
 FORCE_REDIS_EVENTS = "false"
@@ -442,19 +430,13 @@ CACHE_ENABLED = "true"
 # would force the dead Upstash path and skip Railway Redis (client.ts:235).
 CACHE_BACKEND = "auto"
 REDIS_RATE_LIMITING = "false"
-# Inference hot path (#9899). OFF here = byte-identical to the pre-#9899 route.
-# Flip to "true" (prod cutover) only after the hand-port is reviewed. On a cache
-# miss/unavailable the resolver falls back to the authoritative slow path
-# (re-authenticates via requireAuthOrApiKeyWithOrg) — no auth is granted from a
-# failed cache read.
-INFERENCE_HOT_PATH_CACHE = "true"
 # Tier-2 optimistic off-path billing (#9899). OFF here = the synchronous credit
-# reserve runs exactly as before (no behavior change). When "true" (also requires
-# INFERENCE_HOT_PATH_CACHE + a writable KV backstop), an org whose balance clears
-# SAFE_BALANCE_THRESHOLD skips the sync reserve and debits the actual cost off the
-# response path; the sweep-inference-charges cron settles any dropped inline
-# settles. SAFE_BALANCE_THRESHOLD (USD) empty/invalid -> +Inf -> every org takes
-# the safe synchronous-reserve path. Flip only after review + a flag-flip runbook.
+# reserve runs exactly as before (no behavior change). When "true" and the KV
+# backstop is writable, an org whose balance clears SAFE_BALANCE_THRESHOLD skips
+# the sync reserve and debits the actual cost off the response path; the
+# sweep-inference-charges cron settles any dropped inline settles.
+# SAFE_BALANCE_THRESHOLD (USD) empty/invalid -> +Inf -> every org takes the safe
+# synchronous-reserve path. Flip only after review + a flag-flip runbook.
 INFERENCE_OPTIMISTIC_BILLING = "false"
 SAFE_BALANCE_THRESHOLD = ""
 FORCE_REDIS_EVENTS = "false"

--- a/packages/cloud-shared/src/lib/services/inference-auth-context.test.ts
+++ b/packages/cloud-shared/src/lib/services/inference-auth-context.test.ts
@@ -37,8 +37,9 @@ mock.module("./api-keys", () => ({
   },
 }));
 
-const { resolveInferenceAuthContext, extractApiKeyCredential, isInferenceHotPathCacheEnabled } =
-  await import("./inference-auth-context");
+const { resolveInferenceAuthContext, extractApiKeyCredential } = await import(
+  "./inference-auth-context"
+);
 const {
   hashApiKey,
   readInferenceAuthContext,
@@ -103,18 +104,6 @@ describe("extractApiKeyCredential", () => {
 
   test("returns null with no credential", () => {
     expect(extractApiKeyCredential(new Request("https://x/"))).toBeNull();
-  });
-});
-
-describe("isInferenceHotPathCacheEnabled", () => {
-  test("default OFF", () => {
-    expect(isInferenceHotPathCacheEnabled({})).toBe(false);
-  });
-  test("ON only for exact 'true'", () => {
-    expect(isInferenceHotPathCacheEnabled({ INFERENCE_HOT_PATH_CACHE: "true" })).toBe(true);
-    expect(isInferenceHotPathCacheEnabled({ INFERENCE_HOT_PATH_CACHE: " true " })).toBe(true);
-    expect(isInferenceHotPathCacheEnabled({ INFERENCE_HOT_PATH_CACHE: "1" })).toBe(false);
-    expect(isInferenceHotPathCacheEnabled({ INFERENCE_HOT_PATH_CACHE: "yes" })).toBe(false);
   });
 });
 

--- a/packages/cloud-shared/src/lib/services/inference-auth-context.ts
+++ b/packages/cloud-shared/src/lib/services/inference-auth-context.ts
@@ -21,7 +21,6 @@
 
 import { requireAuthOrApiKeyWithOrg } from "../auth";
 import { cache } from "../cache/client";
-import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 import { apiKeysService } from "./api-keys";
 import { contentModerationService } from "./content-moderation";
 import {
@@ -45,13 +44,6 @@ export type InferenceAuthResolution =
   | { kind: "authorized"; ctx: InferenceAuthContext; source: "cache" | "origin" }
   | { kind: "suspended"; userId: string }
   | { kind: "slow_path"; reason: "non_api_key" | "cache_unavailable" };
-
-type StringEnv = Record<string, string | undefined>;
-
-/** Whether the inference hot-path cache is enabled (default OFF). */
-export function isInferenceHotPathCacheEnabled(env: StringEnv = getCloudAwareEnv()): boolean {
-  return (env.INFERENCE_HOT_PATH_CACHE ?? "").trim() === "true";
-}
 
 /**
  * Extract a cacheable API-key credential from the request, mirroring the


### PR DESCRIPTION
Follow-up to #10061: instead of keeping `INFERENCE_HOT_PATH_CACHE` as a production-only flip, remove the flag entirely and make the IAC resolver the default chat-completions auth path.

What changed:
- always attempt `resolveInferenceAuthContext`; non-API-key and cache-unavailable requests still fall back to the authoritative slow path
- remove `INFERENCE_HOT_PATH_CACHE` from Worker config, docs, route code, and tests
- keep Tier 2 optimistic billing behind `INFERENCE_OPTIMISTIC_BILLING` plus the writable-backstop guard

Verification:
- `/Users/shawwalters/.bun/bin/bun test packages/cloud-shared/src/lib/services/inference-auth-context.test.ts`
- `/Users/shawwalters/.bun/bin/bun test packages/cloud-shared/src/lib/services/inference-hot-path-benchmark.test.ts`
- `git diff --check`

Known setup blockers observed locally:
- `bun run --cwd packages/cloud-api typecheck` still fails on pre-existing `mcp/route.ts` Hono handler overload errors.
- `bun run --cwd packages/cloud-shared typecheck` still fails on pre-existing missing `@elizaos/security/kms` type exports.