### PR TITLE
fix(app): harden ui smoke launch on Windows

### DIFF
--- a/.github/issue-evidence/9943-app-ui-smoke-windows-followups.md
+++ b/.github/issue-evidence/9943-app-ui-smoke-windows-followups.md
@@ -1,0 +1,87 @@
+# App UI-Smoke Windows Follow-Up Evidence
+
+Issue: #9943 testing / CI reliability umbrella  
+Related: #9626 build process cross-platform audit  
+Date: 2026-06-29  
+Machine: Windows, PowerShell, Bun 1.4.0-canary.1, Node 24
+
+## Problem
+
+After PR #10045 fixed the original `spawn bun ENOENT` blocker, continuing the
+same `packages/app audit:app` run uncovered the next Windows launch failures:
+
+1. `playwright.ui-smoke.config.ts` invoked the app-core live-stack helper with a
+   bare `node`, which failed on this machine with `'node' is not recognized`.
+2. The app config imports `@elizaos/shared/brand` before Vite aliases apply, so
+   a fresh checkout without `packages/shared/dist` can fail before the UI smoke
+   server starts.
+3. The Node build of `@elizaos/core` exposed `VIEW_KINDS` in its export list
+   without importing/exporting the value from `types/view-kind`, causing bare
+   Node imports to fail.
+
+Observed before the follow-up:
+
+```text
+[WebServer] 'node' is not recognized as an internal or external command,
+operable program or batch file.
+```
+
+and, after the web server launched:
+
+```text
+SyntaxError: Export 'VIEW_KINDS' is not defined in module
+```
+
+## Fix
+
+- Resolve a real Node executable once in `packages/app/scripts/run-ui-playwright.mjs`
+  and pass it as `ELIZA_NODE_PATH`.
+- Use `ELIZA_NODE_PATH` in `packages/app/playwright.ui-smoke.config.ts` instead
+  of a bare `node` command.
+- Normalize both `PATH` and Windows `Path` when prepending Bun's directory.
+- Make `packages/app-core/scripts/playwright-ui-live-stack.ts` honor Windows
+  `Path` when resolving executables.
+- Prebuild both `@elizaos/shared` and `@elizaos/core` before UI-smoke runs so
+  app config loading and renderer bundling have the workspace package dists.
+- Explicitly export `VIEW_KINDS`, `VIEW_KIND_META`, and view-kind helpers from
+  `packages/core/src/index.node.ts`.
+
+## Validation
+
+Targeted checks passed:
+
+```text
+$ bun run biome check packages\core\src\index.node.ts packages\app\scripts\run-ui-playwright.mjs packages\app\playwright.ui-smoke.config.ts packages\app-core\scripts\playwright-ui-live-stack.ts
+Checked 4 files in 1390ms. No fixes applied.
+
+$ bun run --cwd packages/core build:node --skip-testing
+... declarations emitted successfully ...
+
+$ node -e "import('@elizaos/core').then(m=>console.log('ok core', JSON.stringify(m.VIEW_KINDS)))"
+ok core ["system","release","developer","preview"]
+
+$ node packages\scripts\run-turbo.mjs run build --filter=@elizaos/shared --filter=@elizaos/core
+Tasks: 5 successful, 5 total
+```
+
+The app audit now launches the live-stack through the absolute Node executable:
+
+```text
+"C:\Program Files\nodejs\node.exe" packages/app-core/scripts/run-node-tsx.mjs packages/app-core/scripts/playwright-ui-live-stack.ts
+"C:\Program Files\nodejs\node.exe" --conditions=eliza-source --import tsx packages/app-core/scripts/playwright-ui-live-stack.ts
+```
+
+The remaining local blocker is the incomplete local `node_modules/.bun` package
+store. After repairing several missing local package payloads/links, `build:web`
+advanced into the wallet/Solana graph and transformed more than 7,000 modules,
+then failed on additional missing nested package links, for example:
+
+```text
+✓ 7191 modules transformed.
+[vite]: Rollup failed to resolve import "@solana/subscribable" from
+node_modules/.bun/@solana+rpc-subscriptions-channel-websocket@5.5.1+009971104ee2239c/...
+```
+
+This prevents producing fresh screenshots/video on this machine right now, but
+it is downstream of the Windows launcher and workspace prebuild issues fixed by
+this PR.

--- a/packages/app-core/scripts/playwright-ui-live-stack.ts
+++ b/packages/app-core/scripts/playwright-ui-live-stack.ts
@@ -230,7 +230,7 @@ function resolveBunCommand(): string {
 }
 
 function resolveExecutableFromPath(command: string): string | null {
-  const pathValue = process.env.PATH ?? "";
+  const pathValue = process.env.PATH ?? process.env.Path ?? "";
   if (!pathValue) return null;
 
   const hasExtension = path.extname(command).length > 0;

--- a/packages/app/playwright.ui-smoke.config.ts
+++ b/packages/app/playwright.ui-smoke.config.ts
@@ -23,6 +23,10 @@ const uiSmokeLiveStack = path.join(
 const uiSmokeApiPort = Number(process.env.ELIZA_UI_SMOKE_API_PORT || "31337");
 const uiSmokePort = Number(process.env.ELIZA_UI_SMOKE_PORT || "2138");
 const reuseExistingServer = process.env.ELIZA_UI_SMOKE_REUSE_SERVER === "1";
+const nodeExecutable =
+  process.env.ELIZA_NODE_PATH?.trim() ||
+  process.env.npm_node_execpath?.trim() ||
+  process.execPath;
 const chromiumExecutablePath =
   process.env.ELIZA_UI_SMOKE_CHROMIUM_EXECUTABLE?.trim();
 // Real audio fed to the browser mic for the voice button-press e2e: Chromium
@@ -146,7 +150,7 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: `node ${JSON.stringify(path.join(repoRoot, "packages", "app-core", "scripts", "run-node-tsx.mjs"))} ${JSON.stringify(uiSmokeLiveStack)}`,
+    command: `${JSON.stringify(nodeExecutable)} ${JSON.stringify(path.join(repoRoot, "packages", "app-core", "scripts", "run-node-tsx.mjs"))} ${JSON.stringify(uiSmokeLiveStack)}`,
     cwd: repoRoot,
     url: `http://127.0.0.1:${uiSmokePort}`,
     reuseExistingServer,

--- a/packages/app/scripts/run-ui-playwright.mjs
+++ b/packages/app/scripts/run-ui-playwright.mjs
@@ -46,7 +46,7 @@ function resolvePlaywrightCommand() {
 }
 
 function resolveExecutableFromPath(command) {
-  const pathValue = process.env.PATH ?? "";
+  const pathValue = process.env.PATH ?? process.env.Path ?? "";
   if (!pathValue) return null;
 
   const hasExtension = path.extname(command).length > 0;
@@ -125,15 +125,42 @@ function resolveBunCommand() {
   return process.platform === "win32" ? "bun.exe" : "bun";
 }
 
+function looksLikeBun(command) {
+  const binaryName = path.basename(command).toLowerCase();
+  return binaryName === "bun" || binaryName === "bun.exe";
+}
+
+function resolveNodeCommand() {
+  for (const candidate of [
+    process.env.ELIZA_NODE_PATH?.trim(),
+    process.env.npm_node_execpath?.trim(),
+    process.execPath,
+    resolveExecutableFromPath("node"),
+  ]) {
+    if (candidate && fs.existsSync(candidate) && !looksLikeBun(candidate)) {
+      return candidate;
+    }
+  }
+
+  return process.platform === "win32" ? "node.exe" : "node";
+}
+
 const env = { ...process.env };
 delete env.NO_COLOR;
 delete env.FORCE_COLOR;
 delete env.CLICOLOR_FORCE;
 env.BUN = env.BUN || resolveBunCommand();
+env.ELIZA_NODE_PATH = env.ELIZA_NODE_PATH || resolveNodeCommand();
 
 const bunBinDir = path.dirname(env.BUN);
 const pathDelimiter = process.platform === "win32" ? ";" : ":";
-env.PATH = env.PATH ? `${bunBinDir}${pathDelimiter}${env.PATH}` : bunBinDir;
+const existingPath = env.PATH ?? env.Path ?? "";
+env.PATH = existingPath
+  ? `${bunBinDir}${pathDelimiter}${existingPath}`
+  : bunBinDir;
+if (process.platform === "win32") {
+  env.Path = env.PATH;
+}
 
 function hasPlaywrightConfig(configName) {
   return (
@@ -356,13 +383,13 @@ if (
 
 // The ui-smoke web server builds the renderer (`packages/app build:web`) whenever
 // the dist is stale — in BOTH stub and live mode (see playwright-ui-live-stack.ts
-// `viteRendererBuildNeeded` → `build:web`). That vite build BUNDLES @elizaos/core
-// (resolved via its `browser` export condition → dist/browser/index.browser.js).
-// On a fresh CI checkout (e.g. the scenario-pr `Zero-Key app browser *` jobs,
-// which run stub mode and never build core) that dist isn't built, so the build
-// aborts with `Failed to resolve entry for package "@elizaos/core"` and the whole
-// stack fails to start. Build core first — gated only on the ui-smoke config (NOT
-// on live mode), mirroring the view-build step above. Turbo-cached → a fast no-op
+// `viteRendererBuildNeeded` → `build:web`). That vite build needs linked
+// workspace package dists during config load and renderer bundling:
+// - @elizaos/shared/brand is imported by app.config.ts before Vite aliases apply.
+// - @elizaos/core is bundled through its browser export.
+// On a fresh CI checkout these dists may not exist, so the stack fails before any
+// smoke spec runs. Build them first — gated only on the ui-smoke config (NOT on
+// live mode), mirroring the view-build step above. Turbo-cached → a fast no-op
 // when already up to date; skip with ELIZA_UI_SMOKE_SKIP_CORE_BUILD=1.
 if (
   hasPlaywrightConfig("playwright.ui-smoke.config.ts") &&
@@ -374,6 +401,7 @@ if (
       path.join(repoRoot, "packages", "scripts", "run-turbo.mjs"),
       "run",
       "build",
+      "--filter=@elizaos/shared",
       "--filter=@elizaos/core",
     ],
     {

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -326,6 +326,19 @@ export * from "./types/plugin-manifest";
 export type { JsonObject, JsonValue, ProcessEnvLike } from "./types/primitives";
 // Export setup types and utilities
 export * from "./types/setup";
+export type {
+	EnabledViewKinds,
+	ViewKind,
+	ViewKindBearer,
+} from "./types/view-kind";
+export {
+	isAlwaysOnViewKind,
+	isViewKindEnabled,
+	isViewVisible,
+	resolveViewKind,
+	VIEW_KIND_META,
+	VIEW_KINDS,
+} from "./types/view-kind";
 // Export utils first to avoid circular dependency issues
 export * from "./utils";
 export {


### PR DESCRIPTION
## Summary
- pass a resolved Node executable from the app Playwright wrapper into the UI-smoke webServer so Windows does not depend on a bare `node` lookup
- normalize Windows `Path`/`PATH` while preserving the already-fixed Bun path behavior
- prebuild `@elizaos/shared` alongside `@elizaos/core` before UI-smoke renderer startup
- fix the `@elizaos/core` Node entry so bare Node imports expose `VIEW_KINDS` without a dangling export

## Evidence
- `bun run biome check packages\core\src\index.node.ts packages\app\scripts\run-ui-playwright.mjs packages\app\playwright.ui-smoke.config.ts packages\app-core\scripts\playwright-ui-live-stack.ts`
- `bun run --cwd packages/core build:node --skip-testing`
- `node -e "import('@elizaos/core').then(m=>console.log('ok core', JSON.stringify(m.VIEW_KINDS))).catch(e=>{console.error(e);process.exit(1)})"`
- `node packages\scripts\run-turbo.mjs run build --filter=@elizaos/shared --filter=@elizaos/core`
- `git diff --check`
- Evidence file: `.github/issue-evidence/9943-app-ui-smoke-windows-followups.md`

## Remaining local blocker
- Continuing `packages/app build:web` / `packages/app audit:app` on this Windows machine is now blocked downstream by an incomplete local `node_modules/.bun` store in the wallet/Solana graph. After repairing several local package payloads/links, Vite reached 7k+ transformed modules and then failed on another missing nested dependency link such as `@solana/subscribable` from `@solana/rpc-subscriptions-channel-websocket`.
- No screenshot/video artifact was produced because the local package-store issue stops the app build before browser pages launch.

Fixes part of #9943.
Related to #9626.