### PR TITLE
fix(ci): skip feed postinstall in unit lane

### DIFF
--- a/.github/workflows/feed-test.yml
+++ b/.github/workflows/feed-test.yml
@@ -82,13 +82,14 @@ jobs:
       # Install the repo root first so Bun links the root-owned elizaOS packages
       # and the feed sub-workspaces that the root package.json globs. Then install
       # the excluded feed root so its own app-level dependencies (drizzle-orm,
-      # Next, etc.) are available to `packages/feed/test:unit`.
+      # Next, etc.) are available to `packages/feed/test:unit`. Feed postinstall
+      # bootstraps dev-only external agent frameworks, so skip scripts here.
       - name: Install root workspace dependencies
         run: bun install --frozen-lockfile
 
       - name: Install feed root dependencies
         working-directory: packages/feed
-        run: bun install --frozen-lockfile
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Build @elizaos/core dist
         run: bun run --cwd packages/core build


### PR DESCRIPTION
## Summary

- keeps Shaw's feed-test dependency install/build structure, but runs the feed-root install with `--ignore-scripts`
- documents why: feed `postinstall` bootstraps Python deps plus Hermes/OpenClaw external agent frameworks, which are not required for `test:unit`
- avoids the risky lockfile/package churn from the closed #10062 follow-up

## Why

I retested current `origin/develop` after #10062 was closed as superseded by `b78862721a`. The feed-root install now reaches the right dependency graph, but it spends the unit CI lane bootstrapping external framework dev assets and timed out locally before tests started. The unit lane only needs the feed root/package dependencies linked; skipping scripts keeps that scope honest.

Current-develop repro before this change:

- `timeout 420s bun install --frozen-lockfile` from `packages/feed` -> exited 124 after Python deps, Hermes clone/install, OpenClaw clone/pnpm install, OpenClaw `tsdown` ~321s, then more OpenClaw build work still running

## Validation

On rebased head `ac8ff39bf2` over `origin/develop` `71eaf74fcb`:

- `git diff --check origin/develop...HEAD` ✅
- `bun install --frozen-lockfile --ignore-scripts` from `packages/feed` ✅ (~3.5s, no lockfile changes)
- `bun run --cwd packages/core build` ✅
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/feed_test DIRECT_DATABASE_URL=postgres://postgres:postgres@localhost:5432/feed_test NEXT_PUBLIC_STEWARD_API_URL=http://localhost:31337 STEWARD_JWT_SECRET=ci-feed-unit-placeholder-jwt-secret CRON_SECRET=ci-feed-unit-placeholder-cron-secret NODE_ENV=test CI=true bun run test:unit` from `packages/feed` ✅ 389 files passed / 0 failed

Also ran the same feed unit suite once before the final rebase with the same result: 389 files passed / 0 failed.