### PR TITLE
fix(orchestrator): elizaos agent type resolves to eliza-code-acp by default

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -1430,6 +1430,12 @@ export class AcpService extends Service {
         this.setting("ELIZA_CLAUDE_ACP_COMMAND") ??
         "npx -y @agentclientprotocol/claude-agent-acp@0.34.0"
       );
+    // The elizaos native agent is the eliza-code ACP server
+    // (packages/examples/code, bin `eliza-code-acp`). The elizaos CLI has no
+    // ACP mode, so the bare-name fallback below would spawn the wrong binary —
+    // resolve to the eliza-code bin unless an explicit command is configured.
+    if (normalizedAgentType === "elizaos")
+      return this.setting("ELIZA_ELIZAOS_ACP_COMMAND") ?? "eliza-code-acp";
     return String(normalizedAgentType);
   }
 


### PR DESCRIPTION
## What

`AcpService.nativeAgentCommand()` resolved the `elizaos` agent type by falling through to `return String(normalizedAgentType)` — i.e. the bare string `"elizaos"`. But the `elizaos` CLI has **no ACP mode**, so that bare name spawns the wrong binary. The elizaOS-native coding agent is the **eliza-code ACP server** (`packages/examples/code`, bin `eliza-code-acp`).

This only worked at all on hosts that set `ELIZA_ELIZAOS_ACP_COMMAND` explicitly (the env override is read first). Any host that doesn't — notably Eliza Cloud agent containers — got a broken `elizaos` agent type.

## Change

Resolve `elizaos` → `eliza-code-acp` by default, keeping the `ELIZA_ELIZAOS_ACP_COMMAND` override as the first choice (same pattern as `codex`/`claude` just above it):

```ts
if (normalizedAgentType === "elizaos")
  return this.setting("ELIZA_ELIZAOS_ACP_COMMAND") ?? "eliza-code-acp";
```

## Why it's safe

- Hosts that set `ELIZA_ELIZAOS_ACP_COMMAND` are **unchanged** (override still wins).
- The only behavior change is the previously-broken unset case: `"elizaos"` (wrong binary) → `"eliza-code-acp"` (the real ACP server).
- 6-line addition, no other code touched.

## Evidence

Verified live on a VPS bot (Cerebras `zai-glm-4.7`) running eliza-code as the `elizaos` agent type: file builds, app deploys to live URLs, runs code and relays real output, zero `session_state_lost`. This PR lets the same `elizaos` agent type resolve correctly on hosts without the env override (cloud). Part of the eliza-code → opencode-replacement effort (tracking: #10059).
