### PR TITLE
fix(orchestrator): align elizaos ACP command defaults

### DIFF
--- a/plugins/plugin-agent-orchestrator/AGENTS.md
+++ b/plugins/plugin-agent-orchestrator/AGENTS.md
@@ -254,7 +254,7 @@ All are optional unless noted. Read by `src/services/config-env.ts` and
 | `ELIZA_ACP_DEFAULT_AGENT` | `elizaos` | Default agent type: `elizaos`, `pi-agent`, `opencode` |
 | `ELIZA_DEFAULT_AGENT_TYPE` | `elizaos` | Compatibility alias for `ELIZA_ACP_DEFAULT_AGENT` |
 | `ELIZA_AGENT_SELECTION_STRATEGY` | `fixed` | Adapter selection policy: `fixed` or `dynamic` |
-| `ELIZA_ELIZAOS_ACP_COMMAND` | `elizaos` | Native elizaOS ACP command |
+| `ELIZA_ELIZAOS_ACP_COMMAND` | `eliza-code-acp` | Native elizaOS ACP command |
 | `ELIZA_PI_AGENT_ACP_COMMAND` | `pi-agent` | Native Pi Agent ACP command |
 | `ELIZA_CODEX_ACP_COMMAND` | `npx -y @zed-industries/codex-acp@0.14.0` | Native Codex ACP command |
 | `ELIZA_CLAUDE_ACP_COMMAND` | `npx -y @agentclientprotocol/claude-agent-acp@0.34.0` | Native Claude ACP command |

--- a/plugins/plugin-agent-orchestrator/CLAUDE.md
+++ b/plugins/plugin-agent-orchestrator/CLAUDE.md
@@ -254,7 +254,7 @@ All are optional unless noted. Read by `src/services/config-env.ts` and
 | `ELIZA_ACP_DEFAULT_AGENT` | `elizaos` | Default agent type: `elizaos`, `pi-agent`, `opencode` |
 | `ELIZA_DEFAULT_AGENT_TYPE` | `elizaos` | Compatibility alias for `ELIZA_ACP_DEFAULT_AGENT` |
 | `ELIZA_AGENT_SELECTION_STRATEGY` | `fixed` | Adapter selection policy: `fixed` or `dynamic` |
-| `ELIZA_ELIZAOS_ACP_COMMAND` | `elizaos` | Native elizaOS ACP command |
+| `ELIZA_ELIZAOS_ACP_COMMAND` | `eliza-code-acp` | Native elizaOS ACP command |
 | `ELIZA_PI_AGENT_ACP_COMMAND` | `pi-agent` | Native Pi Agent ACP command |
 | `ELIZA_CODEX_ACP_COMMAND` | `npx -y @zed-industries/codex-acp@0.14.0` | Native Codex ACP command |
 | `ELIZA_CLAUDE_ACP_COMMAND` | `npx -y @agentclientprotocol/claude-agent-acp@0.34.0` | Native Claude ACP command |

--- a/plugins/plugin-agent-orchestrator/README.md
+++ b/plugins/plugin-agent-orchestrator/README.md
@@ -27,7 +27,7 @@ Native TypeScript ACP is the default transport. Set the default coding agent wit
 ```bash
 export ELIZA_ACP_TRANSPORT=native
 export ELIZA_ACP_DEFAULT_AGENT=elizaos
-export ELIZA_ELIZAOS_ACP_COMMAND="elizaos"
+export ELIZA_ELIZAOS_ACP_COMMAND="eliza-code-acp"
 export ELIZA_PI_AGENT_ACP_COMMAND="pi-agent"
 export ELIZA_CODEX_ACP_COMMAND="npx -y @zed-industries/codex-acp@0.14.0"
 export ELIZA_CLAUDE_ACP_COMMAND="npx -y @agentclientprotocol/claude-agent-acp@0.34.0"
@@ -141,7 +141,7 @@ All configuration is via environment variables. Use `ELIZA_ACP_TRANSPORT=native`
 | `ELIZA_ACP_TRANSPORT` | `native` | Transport mode. Accepted values include `native`/`direct` and `cli`/`acpx`. |
 | `ELIZA_ACP_CLI` | `acpx` | ACPX executable name or absolute path for the CLI transport. |
 | `ELIZA_ACP_DEFAULT_AGENT` | `elizaos` | Default agent type. Primary choices: `elizaos`, `pi-agent`, `opencode`. |
-| `ELIZA_ELIZAOS_ACP_COMMAND` | `elizaos` | Native elizaOS ACP command. |
+| `ELIZA_ELIZAOS_ACP_COMMAND` | `eliza-code-acp` | Native elizaOS ACP command. |
 | `ELIZA_PI_AGENT_ACP_COMMAND` | `pi-agent` | Native Pi Agent ACP command. |
 | `ELIZA_CODEX_ACP_COMMAND` | `npx -y @zed-industries/codex-acp@0.14.0` | Native Codex ACP command. |
 | `ELIZA_CLAUDE_ACP_COMMAND` | `npx -y @agentclientprotocol/claude-agent-acp@0.34.0` | Native Claude ACP command. |

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -386,7 +386,7 @@ describe("AcpService", () => {
     );
   });
 
-  it("defaults untyped native sessions to the elizaos agent", async () => {
+  it("defaults untyped native sessions to the elizaos agent via eliza-code-acp", async () => {
     const service = new AcpService(runtime({ ELIZA_ACP_TRANSPORT: undefined }));
     await service.start();
 
@@ -401,6 +401,29 @@ describe("AcpService", () => {
     // The "elizaos" agent type resolves to the eliza-code ACP server binary
     // (the elizaos CLI has no ACP mode); the spawn command is eliza-code-acp.
     expect(nativeClientMock.instances[0]?.opts.command).toBe("eliza-code-acp");
+  });
+
+  it("honors explicit elizaos ACP command overrides", async () => {
+    const service = new AcpService(
+      runtime({
+        ELIZA_ACP_TRANSPORT: undefined,
+        ELIZA_ELIZAOS_ACP_COMMAND: "custom-eliza-acp --stdio",
+      }),
+    );
+    await service.start();
+
+    const spawned = await service.spawnSession({
+      name: "custom-elizaos",
+      agentType: "elizaos",
+      workdir: "/tmp/acp-test",
+    });
+
+    expect(spawned.agentType).toBe("elizaos");
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(nativeClientMock.instances).toHaveLength(1);
+    expect(nativeClientMock.instances[0]?.opts.command).toBe(
+      "custom-eliza-acp --stdio",
+    );
   });
 
   it("supports pi-agent as a configured native default", async () => {

--- a/plugins/plugin-agent-orchestrator/package.json
+++ b/plugins/plugin-agent-orchestrator/package.json
@@ -155,7 +155,7 @@
         "type": "string",
         "description": "Native ACP command used for ElizaOS coding-agent sessions when ELIZA_ACP_TRANSPORT=native.",
         "required": false,
-        "default": "elizaos",
+        "default": "eliza-code-acp",
         "sensitive": false
       },
       "ELIZA_PI_AGENT_ACP_COMMAND": {

--- a/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
@@ -634,7 +634,7 @@ function hasFrameworkBinary(id: SupportedTaskAgentAdapter): boolean {
     case "elizaos":
       return (
         Boolean(readConfigEnvKey("ELIZA_ELIZAOS_ACP_COMMAND")) ||
-        hasBinaryOnPath("elizaos")
+        hasBinaryOnPath("eliza-code-acp")
       );
     case "pi-agent":
       return (
@@ -802,7 +802,7 @@ async function computeTaskAgentFrameworkState(
         installCommand:
           preflight?.installCommand ??
           (id === "elizaos"
-            ? "Configure ELIZA_ELIZAOS_ACP_COMMAND or install an elizaos ACP command on PATH"
+            ? "Configure ELIZA_ELIZAOS_ACP_COMMAND or install eliza-code-acp on PATH"
             : id === "pi-agent"
               ? "Configure ELIZA_PI_AGENT_ACP_COMMAND or install pi-agent on PATH"
               : id === "opencode"


### PR DESCRIPTION
## Summary

- align the plugin manifest, docs, and framework availability check with the new `elizaos` native command default from #10074
- use `eliza-code-acp` as the default command everywhere instead of the legacy `elizaos` CLI
- add unit coverage for the new default and for explicit `ELIZA_ELIZAOS_ACP_COMMAND` overrides

## Root cause

#10074 changed the runtime fallback to `eliza-code-acp`, but the plugin parameter default, docs, discovery preflight, and an ACP unit expectation still referenced `elizaos`. If runtime settings hydrate package defaults, or if framework discovery checks PATH, the new default can be defeated or reported unavailable.

## Validation

- `bun install --frozen-lockfile --ignore-scripts`
- `bun run --cwd packages/logger build`
- `bun run --cwd packages/core build`
- `bunx vitest run --config vitest.config.ts __tests__/unit/acp-service.test.ts` (42 passed)
- `bunx vitest run --config vitest.config.ts __tests__/unit/task-agent-frameworks.test.ts` (8 passed)
- `bunx @biomejs/biome check plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts plugins/plugin-agent-orchestrator/package.json plugins/plugin-agent-orchestrator/README.md plugins/plugin-agent-orchestrator/AGENTS.md plugins/plugin-agent-orchestrator/CLAUDE.md --files-ignore-unknown=true --no-errors-on-unmatched`
- `git diff --check origin/develop...HEAD`
