### PR TITLE
test(orchestrator): fix red develop — elizaos ACP command now eliza-code-acp

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -398,7 +398,9 @@ describe("AcpService", () => {
     expect(spawned.agentType).toBe("elizaos");
     expect(spawnMock).not.toHaveBeenCalled();
     expect(nativeClientMock.instances).toHaveLength(1);
-    expect(nativeClientMock.instances[0]?.opts.command).toBe("elizaos");
+    // The "elizaos" agent type resolves to the eliza-code ACP server binary
+    // (the elizaos CLI has no ACP mode); the spawn command is eliza-code-acp.
+    expect(nativeClientMock.instances[0]?.opts.command).toBe("eliza-code-acp");
   });
 
   it("supports pi-agent as a configured native default", async () => {


### PR DESCRIPTION
## Problem

`develop` is currently **red**. PR #10074 (commit `1627c5de52`) changed `AcpService.nativeAgentCommand()` so the `elizaos` native agent type resolves to the **eliza-code ACP server** binary (`eliza-code-acp`) instead of the bare `elizaos` string — correct, because the `elizaos` CLI has no ACP mode. But the matching unit test was not updated:

```
AssertionError: expected 'eliza-code-acp' to be 'elizaos'
 ❯ plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts:401
```

## Fix

One-line test-expectation update in `acp-service.test.ts` (`"defaults untyped native sessions to the elizaos agent"`): the resolved spawn `command` is now `eliza-code-acp`. The session `agentType` stays `"elizaos"` (unchanged), so only the command assertion moves. Added a clarifying comment.

## Verification

```
$ bun run --cwd plugins/plugin-agent-orchestrator test -- acp-service.test
 Test Files  1 passed (1)
      Tests  41 passed (41)
```

Before this PR the same file ran `1 failed | 40 passed`; the single failure is the assertion fixed here. No production code changes — test-only alignment with already-merged #10074.

🤖 Generated with [Claude Code](https://claude.com/claude-code)