### PR TITLE
fix(personal-assistant): load PRIORITIZE data from production stores

### DIFF
--- a/.github/issue-evidence/9970-prioritize-production-loaders.md
+++ b/.github/issue-evidence/9970-prioritize-production-loaders.md
@@ -1,0 +1,49 @@
+# Issue #9970: PRIORITIZE Production Loader Evidence
+
+Date: 2026-06-28
+Platform: Windows, PowerShell, `C:\Users\Administrator\.codex\worktrees\b862\eliza`
+Branch: `fix/9970-prioritize-production-loaders`
+
+## What Changed
+
+- `PRIORITIZE` default loaders now read production data instead of always returning empty arrays:
+  - `rank_todos` reads the registered `todos` runtime service for pending/in-progress owner todos.
+  - `rank_threads` reads LifeOps work threads scoped by `ownerEntityId`.
+  - `rank_decisions` reads pending approval queue requests scoped by `subjectUserId`.
+- Loader calls now receive the triggering `Memory` so production reads use the owner entity from the actual request.
+- Unit coverage verifies the production default path for todos, work threads, and approvals.
+
+## Validation
+
+```text
+bun run biome check --write plugins\plugin-personal-assistant\src\actions\prioritize.ts plugins\plugin-personal-assistant\test\prioritize-action.test.ts
+Checked 2 files in 894ms. No fixes applied.
+```
+
+```text
+bun run --cwd plugins\plugin-personal-assistant test test\prioritize-action.test.ts
+Test Files  1 passed (1)
+Tests       14 passed (14)
+Duration    108.59s
+```
+
+```text
+bun run --cwd plugins\plugin-personal-assistant build:types
+$ tsc --noCheck -p tsconfig.build.json
+```
+
+```text
+bun run --cwd plugins\plugin-personal-assistant build:js
+ESM Build success in 8293ms
+```
+
+```text
+git diff --check
+passed with no output
+```
+
+## Blocked/Not Covered In This Chunk
+
+- `bun run --cwd plugins\plugin-personal-assistant typecheck` is blocked by existing unrelated package-wide errors, beginning with missing workspace subpath declarations such as `@elizaos/plugin-blocker/services/app-blocker/index` and existing scheduled-task re-export errors.
+- `bun run --cwd plugins\plugin-personal-assistant test` exceeded 5 minutes without producing output; the orphaned test processes from this worktree were stopped. The focused `PRIORITIZE` unit file passed.
+- This chunk addresses the `PRIORITIZE` empty-list production wiring from issue #9970. Ambient app-usage provider injection and broader outcome scenario work remain for follow-up chunks.

--- a/plugins/plugin-personal-assistant/src/actions/prioritize.ts
+++ b/plugins/plugin-personal-assistant/src/actions/prioritize.ts
@@ -76,26 +76,313 @@ export interface PrioritizeRankedItem extends PrioritizeRankableItem {
   readonly reasoning: string;
 }
 
+export interface PrioritizeLoaderArgs {
+  runtime: IAgentRuntime;
+  message: Memory;
+}
+
 /**
- * Per-subject loader hooks. Default loaders return empty lists so tests can
- * inject per-subject inputs without standing up the full service graph.
+ * Per-subject loader hooks. Defaults read the production stores and degrade to
+ * empty lists when an optional store is not installed.
  */
 export interface PrioritizeLoaders {
-  loadTodos: (args: {
-    runtime: IAgentRuntime;
-  }) => Promise<readonly PrioritizeRankableItem[]>;
-  loadThreads: (args: {
-    runtime: IAgentRuntime;
-  }) => Promise<readonly PrioritizeRankableItem[]>;
-  loadDecisions: (args: {
-    runtime: IAgentRuntime;
-  }) => Promise<readonly PrioritizeRankableItem[]>;
+  loadTodos: (
+    args: PrioritizeLoaderArgs,
+  ) => Promise<readonly PrioritizeRankableItem[]>;
+  loadThreads: (
+    args: PrioritizeLoaderArgs,
+  ) => Promise<readonly PrioritizeRankableItem[]>;
+  loadDecisions: (
+    args: PrioritizeLoaderArgs,
+  ) => Promise<readonly PrioritizeRankableItem[]>;
+}
+
+const MAX_PRIORITIZE_SOURCE_ITEMS = 50;
+const TODOS_SERVICE_TYPE = "todos";
+
+type PrioritizeTodoStatus = "pending" | "in_progress";
+
+interface PrioritizeTodoRecord {
+  readonly id?: unknown;
+  readonly content?: unknown;
+  readonly activeForm?: unknown;
+  readonly status?: unknown;
+  readonly metadata?: unknown;
+  readonly createdAt?: unknown;
+  readonly updatedAt?: unknown;
+}
+
+interface PrioritizeTodosService {
+  list(filter: {
+    entityId: string;
+    agentId?: string;
+    status?: PrioritizeTodoStatus[];
+    includeCompleted?: boolean;
+    limit?: number;
+  }): Promise<readonly PrioritizeTodoRecord[]>;
+}
+
+interface ApprovalRequestLike {
+  readonly id: string;
+  readonly createdAt: Date;
+  readonly state: string;
+  readonly requestedBy: string;
+  readonly subjectUserId: string;
+  readonly action: string;
+  readonly payload: unknown;
+  readonly channel: string;
+  readonly reason: string;
+  readonly expiresAt: Date;
+}
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
+function ownerEntityIdFromMessage(message: Memory): string | null {
+  return nonEmptyString(message.entityId);
+}
+
+function runtimeAgentId(runtime: IAgentRuntime): string | null {
+  return nonEmptyString(runtime.agentId);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readString(
+  record: Record<string, unknown>,
+  key: string,
+): string | null {
+  return nonEmptyString(record[key]);
+}
+
+function readFirstString(
+  record: Record<string, unknown>,
+  keys: readonly string[],
+): string | null {
+  for (const key of keys) {
+    const value = readString(record, key);
+    if (value) return value;
+  }
+  return null;
+}
+
+function isoish(value: unknown): string | null {
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return value.toISOString();
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value.trim();
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date.toISOString();
+  }
+  return null;
+}
+
+function metadata(
+  entries: readonly (readonly [string, unknown])[],
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of entries) {
+    if (value !== undefined && value !== null && value !== "") {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+function errorDetail(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function getRuntimeService(
+  runtime: IAgentRuntime,
+  serviceName: string,
+): unknown {
+  const getService = (runtime as { getService?: (name: string) => unknown })
+    .getService;
+  if (typeof getService !== "function") return null;
+  return getService.call(runtime, serviceName);
+}
+
+function isTodosService(value: unknown): value is PrioritizeTodosService {
+  return isRecord(value) && typeof value.list === "function";
+}
+
+function mapTodoToRankable(
+  todo: PrioritizeTodoRecord,
+): PrioritizeRankableItem | null {
+  const id = nonEmptyString(todo.id);
+  const content = nonEmptyString(todo.content);
+  const title = nonEmptyString(todo.activeForm) ?? content;
+  if (!id || !title) return null;
+  const todoMetadata = isRecord(todo.metadata) ? todo.metadata : {};
+  const dueAt = readFirstString(todoMetadata, [
+    "dueAt",
+    "deadline",
+    "scheduledFor",
+    "scheduledAt",
+  ]);
+  return {
+    id,
+    title,
+    ...(content && content !== title ? { summary: content } : {}),
+    ...(dueAt ? { dueAt } : {}),
+    metadata: metadata([
+      ["source", "todos"],
+      ["status", nonEmptyString(todo.status)],
+      ["createdAt", isoish(todo.createdAt)],
+      ["updatedAt", isoish(todo.updatedAt)],
+      ["priority", todoMetadata.priority],
+    ]),
+  };
+}
+
+async function loadTodosFromRuntime({
+  runtime,
+  message,
+}: PrioritizeLoaderArgs): Promise<readonly PrioritizeRankableItem[]> {
+  const entityId = ownerEntityIdFromMessage(message);
+  const agentId = runtimeAgentId(runtime);
+  if (!entityId || !agentId) return [];
+  const service = getRuntimeService(runtime, TODOS_SERVICE_TYPE);
+  if (!isTodosService(service)) return [];
+  try {
+    const todos = await service.list({
+      entityId,
+      agentId,
+      status: ["pending", "in_progress"],
+      includeCompleted: false,
+      limit: MAX_PRIORITIZE_SOURCE_ITEMS,
+    });
+    return todos
+      .slice(0, MAX_PRIORITIZE_SOURCE_ITEMS)
+      .map(mapTodoToRankable)
+      .filter((item): item is PrioritizeRankableItem => item !== null);
+  } catch (error) {
+    logger.warn(`[PRIORITIZE] rank_todos load failed: ${errorDetail(error)}`);
+    return [];
+  }
+}
+
+async function loadThreadsFromRuntime({
+  runtime,
+  message,
+}: PrioritizeLoaderArgs): Promise<readonly PrioritizeRankableItem[]> {
+  const ownerEntityId = ownerEntityIdFromMessage(message);
+  if (!ownerEntityId) return [];
+  try {
+    const { createWorkThreadStore } = await import(
+      "../lifeops/work-threads/index.js"
+    );
+    const threads = await createWorkThreadStore(runtime).list({
+      statuses: ["active", "waiting", "paused"],
+      ownerEntityId,
+      limit: MAX_PRIORITIZE_SOURCE_ITEMS,
+    });
+    return threads.slice(0, MAX_PRIORITIZE_SOURCE_ITEMS).map((thread) => ({
+      id: thread.id,
+      title: thread.title,
+      summary: thread.currentPlanSummary ?? thread.summary,
+      metadata: metadata([
+        ["source", "work_threads"],
+        ["status", thread.status],
+        ["connector", thread.primarySourceRef.connector],
+        ["channelName", thread.primarySourceRef.channelName],
+        ["lastActivityAt", thread.lastActivityAt],
+        ["currentScheduledTaskId", thread.currentScheduledTaskId],
+        ["approvalId", thread.approvalId],
+      ]),
+    }));
+  } catch (error) {
+    logger.warn(`[PRIORITIZE] rank_threads load failed: ${errorDetail(error)}`);
+    return [];
+  }
+}
+
+function approvalPayloadTitle(request: ApprovalRequestLike): string {
+  const payload = isRecord(request.payload) ? request.payload : {};
+  switch (request.action) {
+    case "send_message":
+      return `Send message to ${readString(payload, "recipient") ?? "recipient"}`;
+    case "send_email":
+      return `Send email: ${readString(payload, "subject") ?? "untitled"}`;
+    case "schedule_event":
+      return `Schedule event: ${readString(payload, "title") ?? "untitled"}`;
+    case "modify_event":
+      return `Modify calendar event ${readString(payload, "eventId") ?? request.id}`;
+    case "cancel_event":
+      return `Cancel calendar event ${readString(payload, "eventId") ?? request.id}`;
+    case "book_travel":
+      return `Book ${readString(payload, "kind") ?? "travel"} via ${readString(payload, "provider") ?? "provider"}`;
+    case "make_call":
+      return `Make call to ${readString(payload, "to") ?? "recipient"}`;
+    case "sign_document":
+      return `Sign document: ${readString(payload, "documentName") ?? "document"}`;
+    case "execute_workflow":
+      return `Execute workflow ${readString(payload, "workflowId") ?? request.id}`;
+    case "spend_money":
+      return `Spend money with ${readString(payload, "vendor") ?? "vendor"}`;
+    default:
+      return `Approve ${request.action}`;
+  }
+}
+
+async function loadDecisionsFromRuntime({
+  runtime,
+  message,
+}: PrioritizeLoaderArgs): Promise<readonly PrioritizeRankableItem[]> {
+  const subjectUserId = ownerEntityIdFromMessage(message);
+  const agentId = runtimeAgentId(runtime);
+  if (!subjectUserId || !agentId) return [];
+  try {
+    const { createApprovalQueue } = await import(
+      "../lifeops/approval-queue.js"
+    );
+    const requests = await createApprovalQueue(runtime, { agentId }).list({
+      subjectUserId,
+      state: "pending",
+      action: null,
+      limit: MAX_PRIORITIZE_SOURCE_ITEMS,
+    });
+    return requests
+      .slice(0, MAX_PRIORITIZE_SOURCE_ITEMS)
+      .map((request): PrioritizeRankableItem => {
+        const approval = request as ApprovalRequestLike;
+        return {
+          id: approval.id,
+          title: approvalPayloadTitle(approval),
+          summary: approval.reason,
+          dueAt: approval.expiresAt.toISOString(),
+          metadata: metadata([
+            ["source", "approval_queue"],
+            ["action", approval.action],
+            ["channel", approval.channel],
+            ["state", approval.state],
+            ["requestedBy", approval.requestedBy],
+            ["createdAt", approval.createdAt.toISOString()],
+            ["expiresAt", approval.expiresAt.toISOString()],
+          ]),
+        };
+      });
+  } catch (error) {
+    logger.warn(
+      `[PRIORITIZE] rank_decisions load failed: ${errorDetail(error)}`,
+    );
+    return [];
+  }
 }
 
 const defaultLoaders: PrioritizeLoaders = {
-  loadTodos: async () => [],
-  loadThreads: async () => [],
-  loadDecisions: async () => [],
+  loadTodos: loadTodosFromRuntime,
+  loadThreads: loadThreadsFromRuntime,
+  loadDecisions: loadDecisionsFromRuntime,
 };
 
 let activeLoaders: PrioritizeLoaders = defaultLoaders;
@@ -154,14 +441,15 @@ function resolveSubaction(
 async function loadItemsForSubaction(
   subaction: Subaction,
   runtime: IAgentRuntime,
+  message: Memory,
 ): Promise<readonly PrioritizeRankableItem[]> {
   switch (subaction) {
     case "rank_todos":
-      return activeLoaders.loadTodos({ runtime });
+      return activeLoaders.loadTodos({ runtime, message });
     case "rank_threads":
-      return activeLoaders.loadThreads({ runtime });
+      return activeLoaders.loadThreads({ runtime, message });
     case "rank_decisions":
-      return activeLoaders.loadDecisions({ runtime });
+      return activeLoaders.loadDecisions({ runtime, message });
   }
 }
 
@@ -356,7 +644,7 @@ export const prioritizeAction: Action & {
         ? Math.floor(params.topN)
         : 5;
 
-    const items = await loadItemsForSubaction(subaction, runtime);
+    const items = await loadItemsForSubaction(subaction, runtime, message);
     if (items.length === 0) {
       const text = `No open ${subject} to rank.`;
       logger.info(`[PRIORITIZE] ${subaction} empty topN=${topN}`);

--- a/plugins/plugin-personal-assistant/test/prioritize-action.test.ts
+++ b/plugins/plugin-personal-assistant/test/prioritize-action.test.ts
@@ -17,10 +17,20 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   hasOwnerAccess: vi.fn(async () => true),
+  createWorkThreadStore: vi.fn(),
+  createApprovalQueue: vi.fn(),
 }));
 
 vi.mock("@elizaos/agent", () => ({
   hasOwnerAccess: mocks.hasOwnerAccess,
+}));
+
+vi.mock("../src/lifeops/work-threads/index.js", () => ({
+  createWorkThreadStore: mocks.createWorkThreadStore,
+}));
+
+vi.mock("../src/lifeops/approval-queue.js", () => ({
+  createApprovalQueue: mocks.createApprovalQueue,
 }));
 
 import {
@@ -32,8 +42,10 @@ import {
 function makeRuntime(
   options: {
     useModel?: (modelType: string, args: { prompt: string }) => Promise<string>;
+    services?: Record<string, unknown>;
   } = {},
 ): IAgentRuntime {
+  const services = options.services ?? {};
   return {
     agentId: "agent-prioritize-test" as UUID,
     logger: {
@@ -42,6 +54,7 @@ function makeRuntime(
       error: () => undefined,
       debug: () => undefined,
     },
+    getService: (name: string) => services[name] ?? null,
     useModel:
       options.useModel ??
       (async () =>
@@ -81,6 +94,12 @@ describe("PRIORITIZE umbrella action — focus ranking", () => {
   beforeEach(() => {
     __resetPrioritizeLoadersForTests();
     mocks.hasOwnerAccess.mockReset().mockResolvedValue(true);
+    mocks.createWorkThreadStore.mockReset().mockReturnValue({
+      list: vi.fn(async () => []),
+    });
+    mocks.createApprovalQueue.mockReset().mockReturnValue({
+      list: vi.fn(async () => []),
+    });
   });
 
   describe("metadata", () => {
@@ -159,8 +178,7 @@ describe("PRIORITIZE umbrella action — focus ranking", () => {
       );
       expect(result.success).toBe(true);
       expect(useModel).toHaveBeenCalledTimes(1);
-      const [modelType] = useModel.mock.calls[0]!;
-      expect(modelType).toBe(ModelType.TEXT_LARGE);
+      expect(useModel.mock.calls[0]?.[0]).toBe(ModelType.TEXT_LARGE);
       const data = result.data as {
         ranked: {
           id: string;
@@ -176,6 +194,60 @@ describe("PRIORITIZE umbrella action — focus ranking", () => {
         score: 0.95,
       });
       expect(data.ranked[1]).toMatchObject({ id: "todo-3", rank: 2 });
+    });
+
+    it("loads pending todos from the registered production service", async () => {
+      const listTodos = vi.fn(async () => [
+        {
+          id: "todo-prod-1",
+          content: "Send partner proposal",
+          activeForm: "Sending partner proposal",
+          status: "pending",
+          metadata: {
+            dueAt: "2026-07-01T09:00:00.000Z",
+            priority: 1,
+          },
+          createdAt: new Date("2026-06-29T08:00:00.000Z"),
+          updatedAt: new Date("2026-06-29T08:30:00.000Z"),
+        },
+      ]);
+      const useModel = vi.fn(async (_modelType, args) => {
+        expect(args.prompt).toContain("Sending partner proposal");
+        return JSON.stringify({
+          ranked: [
+            {
+              id: "todo-prod-1",
+              score: 0.88,
+              reasoning: "near deadline",
+            },
+          ],
+        });
+      });
+      const runtime = makeRuntime({
+        useModel,
+        services: {
+          todos: { list: listTodos },
+        },
+      });
+      const result = await callPrioritize(runtime, makeMessage(), {
+        subaction: "rank_todos",
+      });
+      expect(result.success).toBe(true);
+      expect(listTodos).toHaveBeenCalledWith({
+        entityId: "owner-1",
+        agentId: "agent-prioritize-test",
+        status: ["pending", "in_progress"],
+        includeCompleted: false,
+        limit: 50,
+      });
+      const data = result.data as {
+        ranked: { id: string; title: string; dueAt?: string | null }[];
+      };
+      expect(data.ranked[0]).toMatchObject({
+        id: "todo-prod-1",
+        title: "Sending partner proposal",
+        dueAt: "2026-07-01T09:00:00.000Z",
+      });
     });
 
     it("respects topN by truncating the model's ranked list", async () => {
@@ -220,6 +292,69 @@ describe("PRIORITIZE umbrella action — focus ranking", () => {
   });
 
   describe("rank_decisions", () => {
+    it("loads pending approvals from the production queue by owner", async () => {
+      const listApprovals = vi.fn(async () => [
+        {
+          id: "approve-prod-1",
+          createdAt: new Date("2026-06-29T08:00:00.000Z"),
+          updatedAt: new Date("2026-06-29T08:00:00.000Z"),
+          state: "pending",
+          requestedBy: "PERSONAL_ASSISTANT",
+          subjectUserId: "owner-1",
+          action: "send_email",
+          payload: {
+            action: "send_email",
+            to: ["partner@example.com"],
+            cc: [],
+            bcc: [],
+            subject: "NDA follow-up",
+            body: "Following up.",
+            threadId: null,
+          },
+          channel: "email",
+          reason: "Owner must approve outbound NDA follow-up.",
+          expiresAt: new Date("2026-06-29T18:00:00.000Z"),
+          resolvedAt: null,
+          resolvedBy: null,
+          resolutionReason: null,
+        },
+      ]);
+      mocks.createApprovalQueue.mockReturnValue({ list: listApprovals });
+      const useModel = vi.fn(async () =>
+        JSON.stringify({
+          ranked: [
+            {
+              id: "approve-prod-1",
+              score: 0.93,
+              reasoning: "blocks partner",
+            },
+          ],
+        }),
+      );
+      const runtime = makeRuntime({ useModel });
+      const result = await callPrioritize(runtime, makeMessage(), {
+        subaction: "rank_decisions",
+      });
+      expect(result.success).toBe(true);
+      expect(mocks.createApprovalQueue).toHaveBeenCalledWith(runtime, {
+        agentId: "agent-prioritize-test",
+      });
+      expect(listApprovals).toHaveBeenCalledWith({
+        subjectUserId: "owner-1",
+        state: "pending",
+        action: null,
+        limit: 50,
+      });
+      const data = result.data as {
+        ranked: { id: string; title: string; dueAt?: string | null }[];
+      };
+      expect(data.ranked[0]).toMatchObject({
+        id: "approve-prod-1",
+        title: "Send email: NDA follow-up",
+        dueAt: "2026-06-29T18:00:00.000Z",
+      });
+    });
+
     it("calls the decisions loader and returns ranking from the model", async () => {
       setPrioritizeLoaders({
         loadDecisions: async () => [
@@ -245,6 +380,70 @@ describe("PRIORITIZE umbrella action — focus ranking", () => {
       };
       expect(data.subaction).toBe("rank_decisions");
       expect(data.ranked[0]?.id).toBe("approve-1");
+    });
+  });
+
+  describe("rank_threads", () => {
+    it("loads open owner work threads from the production store", async () => {
+      const listThreads = vi.fn(async () => [
+        {
+          id: "thread-prod-1",
+          agentId: "agent-prioritize-test",
+          ownerEntityId: "owner-1",
+          status: "waiting",
+          title: "Vendor contract thread",
+          summary: "Waiting on vendor contract redlines.",
+          currentPlanSummary: "Review vendor redlines before replying.",
+          primarySourceRef: {
+            connector: "gmail",
+            channelName: "Inbox",
+            canRead: true,
+            canMutate: true,
+          },
+          sourceRefs: [],
+          participantEntityIds: ["owner-1"],
+          currentScheduledTaskId: null,
+          workflowRunId: null,
+          approvalId: null,
+          lastMessageMemoryId: "msg-1",
+          version: 1,
+          createdAt: "2026-06-29T07:00:00.000Z",
+          updatedAt: "2026-06-29T08:00:00.000Z",
+          lastActivityAt: "2026-06-29T08:00:00.000Z",
+          metadata: {},
+        },
+      ]);
+      mocks.createWorkThreadStore.mockReturnValue({ list: listThreads });
+      const useModel = vi.fn(async () =>
+        JSON.stringify({
+          ranked: [
+            {
+              id: "thread-prod-1",
+              score: 0.76,
+              reasoning: "needs reply",
+            },
+          ],
+        }),
+      );
+      const runtime = makeRuntime({ useModel });
+      const result = await callPrioritize(runtime, makeMessage(), {
+        subaction: "rank_threads",
+      });
+      expect(result.success).toBe(true);
+      expect(mocks.createWorkThreadStore).toHaveBeenCalledWith(runtime);
+      expect(listThreads).toHaveBeenCalledWith({
+        statuses: ["active", "waiting", "paused"],
+        ownerEntityId: "owner-1",
+        limit: 50,
+      });
+      const data = result.data as {
+        ranked: { id: string; title: string; summary?: string }[];
+      };
+      expect(data.ranked[0]).toMatchObject({
+        id: "thread-prod-1",
+        title: "Vendor contract thread",
+        summary: "Review vendor redlines before replying.",
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- Wire `PRIORITIZE` default loaders to production data instead of empty arrays.
- Scope ranking reads by the triggering owner `message.entityId`.
- Cover default production paths for todos, work threads, and approval decisions.

## Evidence
- `.github/issue-evidence/9970-prioritize-production-loaders.md`
- `bun run biome check plugins\plugin-personal-assistant\src\actions\prioritize.ts plugins\plugin-personal-assistant\test\prioritize-action.test.ts`
- `bun run --cwd plugins\plugin-personal-assistant test test\prioritize-action.test.ts` -> 14 passed
- `bun run --cwd plugins\plugin-personal-assistant build:types`
- `bun run --cwd plugins\plugin-personal-assistant build:js`
- `git diff --check`

## Notes
- Refs #9970. This is the PRIORITIZE production-loader chunk only; ambient app-usage provider injection and broader outcome scenario work remain.
- Package-wide `typecheck` is currently blocked by unrelated pre-existing missing workspace subpath declarations / scheduled-task export errors. Full package test exceeded 5 minutes locally; focused PRIORITIZE tests passed.