### PR TITLE
test(ui): unblock develop merge queue — accept 4 RoleGate/HomeWidgets a11y violations into story-gate burn-down baseline

### DIFF
--- a/packages/ui/test/story-gate/baseline/a11y-baseline.json
+++ b/packages/ui/test/story-gate/baseline/a11y-baseline.json
@@ -637,5 +637,9 @@
   "toolevents-toolcalleventlog--running": ["color-contrast"],
   "toolevents-toolcalleventlog--success": ["color-contrast"],
   "views-dynamicviewloader--failed-to-load": ["color-contrast"],
-  "views-shellviewagentsurface--character-view": ["color-contrast"]
+  "views-shellviewagentsurface--character-view": ["color-contrast"],
+  "primitives-rolegate--admin": ["color-contrast"],
+  "primitives-rolegate--owner": ["color-contrast"],
+  "primitives-rolegate--user": ["color-contrast"],
+  "widgets-homewidgets--populated": ["color-contrast"]
 }

--- a/packages/ui/test/story-gate/baseline/a11y-baseline.json
+++ b/packages/ui/test/story-gate/baseline/a11y-baseline.json
@@ -521,6 +521,9 @@
   "primitives-progress--empty": ["aria-progressbar-name"],
   "primitives-progress--quarter": ["aria-progressbar-name"],
   "primitives-progress--three-quarters": ["aria-progressbar-name"],
+  "primitives-rolegate--admin": ["color-contrast"],
+  "primitives-rolegate--owner": ["color-contrast"],
+  "primitives-rolegate--user": ["color-contrast"],
   "primitives-savefooter--default": ["color-contrast"],
   "primitives-savefooter--error-state": ["color-contrast"],
   "primitives-savefooter--saved": ["color-contrast"],
@@ -638,8 +641,5 @@
   "toolevents-toolcalleventlog--success": ["color-contrast"],
   "views-dynamicviewloader--failed-to-load": ["color-contrast"],
   "views-shellviewagentsurface--character-view": ["color-contrast"],
-  "primitives-rolegate--admin": ["color-contrast"],
-  "primitives-rolegate--owner": ["color-contrast"],
-  "primitives-rolegate--user": ["color-contrast"],
   "widgets-homewidgets--populated": ["color-contrast"]
 }


### PR DESCRIPTION
## Why
`story-gate` is currently **hard-failing on every open PR to develop** (mine #10031/#10034/#10037/#10041 + everyone's) with 4 `new-a11y-violation` regressions:
- `primitives-rolegate--admin` / `--owner` / `--user` — color-contrast
- `widgets-homewidgets--populated` — color-contrast

These came in with the RoleGate component (#9979) and weren't added to the gate's baseline, so the whole merge queue is blocked.

## Fix (sanctioned, non-invasive)
story-gate is an **eslint-style burn-down baseline** — per its README, new violations belong in the baseline so the backlog is *"visible and burn-downable without blocking."* This adds the 4 stories to `a11y-baseline.json` alongside the existing **337 accepted color-contrast entries**. 

- **No component or design change** — RoleGate/HomeWidgets colors are untouched; the contrasts stay tracked as backlog for codex to burn down properly.
- +4 lines, valid JSON, exact story IDs from the failing run.
- Unblocks develop CI for all open PRs immediately.

@lalalune / codex — flagging since it's your RoleGate component + gate; this just stops it blocking the queue. Happy to instead fix the actual contrasts if you'd prefer that over baselining.