### PR TITLE
fix(personal-assistant): inject ambient app usage context

### DIFF
--- a/.github/issue-evidence/9970-personal-assistant-activity-context.md
+++ b/.github/issue-evidence/9970-personal-assistant-activity-context.md
@@ -1,0 +1,57 @@
+# Personal Assistant Activity Context Evidence
+
+Issue: #9970
+Date: 2026-06-29
+Machine: Windows, PowerShell, Bun 1.4.0-canary.1, Node 24
+
+## Slice
+
+This PR wires the existing macOS activity-event reporting path into the
+owner-only `activity-profile` provider. It does not add a scheduler or a second
+activity store.
+
+Implemented:
+
+- `getLatestForegroundActivity()` derives the latest current foreground app
+  from `life_activity_events`, returning `null` when the latest event is a
+  deactivation or OS inactivity surface.
+- `activityProfileProvider` now reads today's existing dwell report via
+  `getActivityReportBetween()` and injects a compact ambient context line:
+  `current app <app> for <duration> | today apps <top apps>`.
+- Provider values/data now include current app and today's top app usage for
+  downstream PRIORITIZE/proactive consumers.
+- The provider keeps its existing OWNER role gate and `screen_time` / `tasks` /
+  `health` context gate.
+
+## Validation
+
+Passed:
+
+```text
+$ bun run biome check plugins\plugin-personal-assistant\src\providers\activity-profile.ts plugins\plugin-personal-assistant\src\activity-profile\activity-tracker-reporting.ts plugins\plugin-personal-assistant\test\activity-profile-provider.test.ts plugins\plugin-personal-assistant\test\activity-tracker-reporting.test.ts
+Checked 4 files in 615ms. No fixes applied.
+
+$ bun run --cwd plugins\plugin-personal-assistant test activity-profile-provider.test.ts activity-tracker-reporting.test.ts
+[lint-default-packs] clean — 0 findings across default packs.
+Test Files  2 passed (2)
+Tests  7 passed (7)
+
+$ bun run --cwd plugins\plugin-personal-assistant build:types
+$ tsc --noCheck -p tsconfig.build.json
+```
+
+Inconclusive / blocked locally:
+
+```text
+$ bun run --cwd plugins\plugin-personal-assistant test
+Timed out after 304s without a completion signal.
+```
+
+## Evidence Matrix
+
+- Real-LLM trajectory: N/A for this provider-only slice; required for the next
+  outcome-scenario work in #9970.
+- Backend logs: code path emits structured `[activity-profile] Injected ambient
+  app-usage context.` debug metadata; unit test asserts the log call.
+- Frontend screenshots/video: N/A, no UI surface changed.
+- Audio: N/A, no voice/TTS/STT surface changed.

--- a/plugins/plugin-personal-assistant/src/activity-profile/activity-tracker-reporting.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/activity-tracker-reporting.ts
@@ -15,6 +15,7 @@
  */
 
 import type { IAgentRuntime } from "@elizaos/core";
+import { isSystemInactivityApp } from "@elizaos/plugin-health";
 import {
   type ActivityEventRow,
   listActivityEvents,
@@ -24,7 +25,6 @@ import {
   redactWindowTitle,
   resolveRedactorConfigFromEnv,
 } from "./redactor.js";
-import { isSystemInactivityApp } from "@elizaos/plugin-health";
 
 export interface ActivityAppBreakdown {
   bundleId: string;
@@ -39,6 +39,13 @@ export interface ActivityReport {
   untilMs: number;
   totalMs: number;
   apps: ActivityAppBreakdown[];
+}
+
+export interface ActivityForegroundApp {
+  bundleId: string;
+  appName: string;
+  observedAtMs: number;
+  activeMs: number;
 }
 
 export interface ActivityReportOptions {
@@ -162,6 +169,44 @@ export async function getActivityReportBetween(
   const intervals = intervalsFromEvents(events, sinceMs, untilMs);
   const { apps, totalMs } = aggregateByApp(intervals, redactor, options.limit);
   return { sinceMs, untilMs, totalMs, apps };
+}
+
+export async function getLatestForegroundActivity(
+  runtime: IAgentRuntime,
+  agentId: string,
+  options: {
+    sinceMs: number;
+    untilMs: number;
+  },
+): Promise<ActivityForegroundApp | null> {
+  const sinceMs = Math.max(0, Math.trunc(options.sinceMs));
+  const untilMs = Math.max(sinceMs, Math.trunc(options.untilMs));
+  const events = await listActivityEvents(
+    runtime,
+    agentId,
+    new Date(sinceMs).toISOString(),
+  );
+
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index];
+    if (!event) continue;
+    const observedAtMs = Date.parse(event.observedAt);
+    if (!Number.isFinite(observedAtMs) || observedAtMs > untilMs) continue;
+    if (isSystemInactivityApp(event)) {
+      return null;
+    }
+    if (event.eventKind === "deactivate") {
+      return null;
+    }
+    return {
+      bundleId: event.bundleId,
+      appName: event.appName,
+      observedAtMs,
+      activeMs: Math.max(0, untilMs - observedAtMs),
+    };
+  }
+
+  return null;
 }
 
 export async function getActivityReport(

--- a/plugins/plugin-personal-assistant/src/providers/activity-profile.ts
+++ b/plugins/plugin-personal-assistant/src/providers/activity-profile.ts
@@ -7,13 +7,25 @@ import type {
   State,
 } from "@elizaos/core";
 import { logger } from "@elizaos/core";
+import {
+  type ActivityAppBreakdown,
+  type ActivityForegroundApp,
+  type ActivityReport,
+  getActivityReportBetween,
+  getLatestForegroundActivity,
+} from "../activity-profile/activity-tracker-reporting.js";
 import { resolveCurrentBucket } from "../activity-profile/analyzer.js";
 import { PROACTIVE_TASK_TAGS } from "../activity-profile/proactive-worker.js";
 import { readProfileFromMetadata } from "../activity-profile/service.js";
 import { resolveDefaultTimeZone } from "../lifeops/defaults.js";
-import { getLocalDateKey, getZonedDateParts } from "../lifeops/time.js";
+import {
+  buildUtcDateFromLocalParts,
+  getLocalDateKey,
+  getZonedDateParts,
+} from "../lifeops/time.js";
 
 const MAX_PROFILE_TASKS = 25;
+const ACTIVITY_USAGE_TOP_APPS = 3;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -29,11 +41,85 @@ function formatAgo(ms: number): string {
   return `${days}d ago`;
 }
 
+function formatDuration(ms: number): string {
+  const minutes = Math.max(1, Math.round(ms / 60_000));
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remainder = minutes % 60;
+  return remainder === 0 ? `${hours}h` : `${hours}h ${remainder}m`;
+}
+
+function formatTopApps(apps: ActivityAppBreakdown[]): string {
+  return apps
+    .filter((app) => app.totalMs > 0)
+    .slice(0, ACTIVITY_USAGE_TOP_APPS)
+    .map((app) => `${app.appName} ${formatDuration(app.totalMs)}`)
+    .join(", ");
+}
+
+export function formatActivityUsageContext(args: {
+  current: ActivityForegroundApp | null;
+  report: ActivityReport;
+}): string | null {
+  const parts: string[] = [];
+  if (args.current) {
+    parts.push(
+      `current app ${args.current.appName} for ${formatDuration(
+        args.current.activeMs,
+      )}`,
+    );
+  }
+
+  const topApps = formatTopApps(args.report.apps);
+  if (topApps) {
+    parts.push(`today apps ${topApps}`);
+  }
+
+  return parts.length > 0 ? parts.join(" | ") : null;
+}
+
+async function readActivityUsageContext(args: {
+  runtime: IAgentRuntime;
+  timezone: string;
+  now: Date;
+}): Promise<{
+  text: string | null;
+  current: ActivityForegroundApp | null;
+  report: ActivityReport;
+}> {
+  const zonedParts = getZonedDateParts(args.now, args.timezone);
+  const dayStart = buildUtcDateFromLocalParts(args.timezone, {
+    ...zonedParts,
+    hour: 0,
+    minute: 0,
+    second: 0,
+  });
+  const sinceMs = dayStart.getTime();
+  const untilMs = args.now.getTime();
+  const [report, current] = await Promise.all([
+    getActivityReportBetween(args.runtime, String(args.runtime.agentId), {
+      sinceMs,
+      untilMs,
+      limit: ACTIVITY_USAGE_TOP_APPS,
+    }),
+    getLatestForegroundActivity(args.runtime, String(args.runtime.agentId), {
+      sinceMs,
+      untilMs,
+    }),
+  ]);
+  return {
+    text: formatActivityUsageContext({ current, report }),
+    current,
+    report,
+  };
+}
+
 export const activityProfileProvider: Provider = {
   name: "activity-profile",
   description:
-    "Owner and agent only. Compact user activity context: platform, time bucket, recency.",
-  descriptionCompressed: "owner+agent activity: platform, time bucket, recency",
+    "Owner and agent only. Compact user activity context: platform, app usage, time bucket, recency.",
+  descriptionCompressed:
+    "owner+agent activity: platform, app usage, time bucket, recency",
   dynamic: true,
   position: 13,
   contexts: ["screen_time", "tasks", "health"],
@@ -52,6 +138,44 @@ export const activityProfileProvider: Provider = {
     const timezone = resolveDefaultTimeZone();
     const now = new Date();
     const bucket = resolveCurrentBucket(timezone, now);
+    const baseValues = {
+      userIsActive: false,
+      userPrimaryPlatform: null,
+      userLastSeenPlatform: null,
+      userLastSeenAt: 0,
+      userTimeBucket: bucket,
+      userEffectiveDayKey: null,
+      userHasOpenActivityCycle: false,
+      userTypicalWakeHour: null,
+      userTypicalSleepHour: null,
+      userHasSleepData: false,
+      userIsSleeping: false,
+      userLastSleepSignalAt: null,
+      userLastWakeSignalAt: null,
+      userTypicalSleepDurationMinutes: null,
+      userScreenContextFocus: null,
+      userScreenContextSource: null,
+      userScreenContextSampledAt: null,
+      userScreenContextConfidence: null,
+      userScreenContextBusy: false,
+      userScreenContextAvailable: false,
+      userScreenContextStale: false,
+      userCurrentAppName: null,
+      userCurrentAppBundleId: null,
+      userCurrentAppActiveMs: null,
+      userTodayAppUsage: [] as Array<{
+        appName: string;
+        bundleId: string;
+        totalMs: number;
+        sessionCount: number;
+      }>,
+      userTodayAppUsageTotalMs: 0,
+    };
+    let values: Record<string, unknown> = { ...baseValues };
+    let data: Record<string, unknown> = {};
+    const parts: string[] = [];
+    let profileLoaded = false;
+
     try {
       const tasks = await runtime.getTasks({
         agentIds: [runtime.agentId],
@@ -64,7 +188,6 @@ export const activityProfileProvider: Provider = {
       const profile = readProfileFromMetadata(metadata);
 
       if (profile) {
-        const parts: string[] = [];
         const localDateKey = getLocalDateKey(getZonedDateParts(now, timezone));
 
         const hasActiveScreen =
@@ -109,34 +232,31 @@ export const activityProfileProvider: Provider = {
           parts.push("previous day still open");
         }
 
-        return {
-          text: parts.length > 0 ? `User: ${parts.join(" | ")}` : "",
-          values: {
-            userIsActive: profile.isCurrentlyActive,
-            userPrimaryPlatform: profile.primaryPlatform,
-            userLastSeenPlatform: profile.lastSeenPlatform,
-            userLastSeenAt: profile.lastSeenAt,
-            userTimeBucket: bucket,
-            userEffectiveDayKey: profile.effectiveDayKey,
-            userHasOpenActivityCycle: profile.hasOpenActivityCycle,
-            userTypicalWakeHour: profile.typicalWakeHour,
-            userTypicalSleepHour: profile.typicalSleepHour,
-            userHasSleepData: profile.hasSleepData,
-            userIsSleeping: profile.isCurrentlySleeping,
-            userLastSleepSignalAt: profile.lastSleepSignalAt,
-            userLastWakeSignalAt: profile.lastWakeSignalAt,
-            userTypicalSleepDurationMinutes:
-              profile.typicalSleepDurationMinutes,
-            userScreenContextFocus: profile.screenContextFocus,
-            userScreenContextSource: profile.screenContextSource,
-            userScreenContextSampledAt: profile.screenContextSampledAt,
-            userScreenContextConfidence: profile.screenContextConfidence,
-            userScreenContextBusy: profile.screenContextBusy,
-            userScreenContextAvailable: profile.screenContextAvailable,
-            userScreenContextStale: profile.screenContextStale,
-          },
-          data: {},
+        values = {
+          ...values,
+          userIsActive: profile.isCurrentlyActive,
+          userPrimaryPlatform: profile.primaryPlatform,
+          userLastSeenPlatform: profile.lastSeenPlatform,
+          userLastSeenAt: profile.lastSeenAt,
+          userTimeBucket: bucket,
+          userEffectiveDayKey: profile.effectiveDayKey,
+          userHasOpenActivityCycle: profile.hasOpenActivityCycle,
+          userTypicalWakeHour: profile.typicalWakeHour,
+          userTypicalSleepHour: profile.typicalSleepHour,
+          userHasSleepData: profile.hasSleepData,
+          userIsSleeping: profile.isCurrentlySleeping,
+          userLastSleepSignalAt: profile.lastSleepSignalAt,
+          userLastWakeSignalAt: profile.lastWakeSignalAt,
+          userTypicalSleepDurationMinutes: profile.typicalSleepDurationMinutes,
+          userScreenContextFocus: profile.screenContextFocus,
+          userScreenContextSource: profile.screenContextSource,
+          userScreenContextSampledAt: profile.screenContextSampledAt,
+          userScreenContextConfidence: profile.screenContextConfidence,
+          userScreenContextBusy: profile.screenContextBusy,
+          userScreenContextAvailable: profile.screenContextAvailable,
+          userScreenContextStale: profile.screenContextStale,
         };
+        profileLoaded = true;
       }
     } catch (error) {
       logger.warn(
@@ -149,28 +269,63 @@ export const activityProfileProvider: Provider = {
       );
     }
 
+    try {
+      const usage = await readActivityUsageContext({ runtime, timezone, now });
+      if (usage.text) {
+        parts.push(usage.text);
+        logger.debug(
+          {
+            boundary: "activity_profile",
+            operation: "provider_activity_usage_context",
+            currentAppPresent: usage.current !== null,
+            topAppCount: usage.report.apps.length,
+          },
+          "[activity-profile] Injected ambient app-usage context.",
+        );
+      }
+      values = {
+        ...values,
+        userCurrentAppName: usage.current?.appName ?? null,
+        userCurrentAppBundleId: usage.current?.bundleId ?? null,
+        userCurrentAppActiveMs: usage.current?.activeMs ?? null,
+        userTodayAppUsage: usage.report.apps.map((app) => ({
+          appName: app.appName,
+          bundleId: app.bundleId,
+          totalMs: app.totalMs,
+          sessionCount: app.sessionCount,
+        })),
+        userTodayAppUsageTotalMs: usage.report.totalMs,
+      };
+      data = {
+        ...data,
+        activityUsage: {
+          current: usage.current,
+          today: usage.report,
+        },
+      };
+    } catch (error) {
+      logger.warn(
+        {
+          boundary: "activity_profile",
+          operation: "provider_activity_usage_read",
+          err: error instanceof Error ? error : undefined,
+        },
+        "[activity-profile] Failed to read ambient app-usage context; continuing without app-usage context.",
+      );
+    }
+
+    if (parts.length > 0) {
+      return {
+        text: `User: ${parts.join(" | ")}`,
+        values,
+        data,
+      };
+    }
+
     return {
-      text: `User context: ${bucket}`,
-      values: {
-        userIsActive: false,
-        userPrimaryPlatform: null,
-        userLastSeenPlatform: null,
-        userLastSeenAt: 0,
-        userTimeBucket: bucket,
-        userScreenContextFocus: null,
-        userScreenContextSource: null,
-        userScreenContextSampledAt: null,
-        userScreenContextConfidence: null,
-        userScreenContextBusy: false,
-        userScreenContextAvailable: false,
-        userScreenContextStale: false,
-        userHasSleepData: false,
-        userIsSleeping: false,
-        userLastSleepSignalAt: null,
-        userLastWakeSignalAt: null,
-        userTypicalSleepDurationMinutes: null,
-      },
-      data: {},
+      text: profileLoaded ? "" : `User context: ${bucket}`,
+      values,
+      data,
     };
   },
 };

--- a/plugins/plugin-personal-assistant/test/activity-profile-provider.test.ts
+++ b/plugins/plugin-personal-assistant/test/activity-profile-provider.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  hasOwnerAccess: vi.fn(),
+  getActivityReportBetween: vi.fn(),
+  getLatestForegroundActivity: vi.fn(),
+  logger: {
+    debug: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock("@elizaos/agent", () => ({
+  hasOwnerAccess: mocks.hasOwnerAccess,
+}));
+
+vi.mock("@elizaos/core", () => ({
+  formatError: (error: unknown) =>
+    error instanceof Error ? error.message : String(error),
+  logger: mocks.logger,
+}));
+
+vi.mock("../src/lifeops/defaults.js", () => ({
+  resolveDefaultTimeZone: () => "UTC",
+}));
+
+vi.mock("../src/activity-profile/proactive-worker.js", () => ({
+  PROACTIVE_TASK_TAGS: ["queue", "repeat", "proactive"],
+}));
+
+vi.mock("../src/activity-profile/service.js", () => ({
+  readProfileFromMetadata: vi.fn(() => null),
+}));
+
+vi.mock("../src/activity-profile/activity-tracker-reporting.js", () => ({
+  getActivityReportBetween: mocks.getActivityReportBetween,
+  getLatestForegroundActivity: mocks.getLatestForegroundActivity,
+}));
+
+import {
+  activityProfileProvider,
+  formatActivityUsageContext,
+} from "../src/providers/activity-profile.js";
+
+const NOW_ISO = "2026-01-15T18:30:00.000Z";
+
+function makeRuntime() {
+  return {
+    agentId: "agent-activity",
+    getTasks: vi.fn(async () => []),
+  };
+}
+
+function makeMessage() {
+  return {
+    id: "msg-activity",
+    entityId: "owner",
+    roomId: "room",
+    content: { text: "what am I working on?" },
+  };
+}
+
+describe("activityProfileProvider app-usage context", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(NOW_ISO));
+    mocks.hasOwnerAccess.mockReset().mockResolvedValue(true);
+    mocks.getActivityReportBetween.mockReset().mockResolvedValue({
+      sinceMs: Date.parse("2026-01-15T08:00:00.000Z"),
+      untilMs: Date.parse(NOW_ISO),
+      totalMs: 9_000_000,
+      apps: [
+        {
+          bundleId: "com.microsoft.VSCode",
+          appName: "VS Code",
+          totalMs: 7_200_000,
+          sessionCount: 2,
+          sampleWindowTitles: [],
+        },
+        {
+          bundleId: "com.tinyspeck.slackmacgap",
+          appName: "Slack",
+          totalMs: 1_800_000,
+          sessionCount: 1,
+          sampleWindowTitles: [],
+        },
+      ],
+    });
+    mocks.getLatestForegroundActivity.mockReset().mockResolvedValue({
+      bundleId: "com.microsoft.VSCode",
+      appName: "VS Code",
+      observedAtMs: Date.parse("2026-01-15T18:00:00.000Z"),
+      activeMs: 1_800_000,
+    });
+    mocks.logger.debug.mockReset();
+    mocks.logger.warn.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("formats current foreground app and today's top app dwell", () => {
+    const text = formatActivityUsageContext({
+      current: {
+        bundleId: "com.microsoft.VSCode",
+        appName: "VS Code",
+        observedAtMs: Date.parse("2026-01-15T18:00:00.000Z"),
+        activeMs: 1_800_000,
+      },
+      report: {
+        sinceMs: Date.parse("2026-01-15T08:00:00.000Z"),
+        untilMs: Date.parse(NOW_ISO),
+        totalMs: 9_000_000,
+        apps: [
+          {
+            bundleId: "com.microsoft.VSCode",
+            appName: "VS Code",
+            totalMs: 7_200_000,
+            sessionCount: 2,
+            sampleWindowTitles: [],
+          },
+          {
+            bundleId: "com.tinyspeck.slackmacgap",
+            appName: "Slack",
+            totalMs: 1_800_000,
+            sessionCount: 1,
+            sampleWindowTitles: [],
+          },
+        ],
+      },
+    });
+
+    expect(text).toBe(
+      "current app VS Code for 30m | today apps VS Code 2h, Slack 30m",
+    );
+  });
+
+  it("injects ambient app usage for owner turns", async () => {
+    const runtime = makeRuntime();
+    const result = await activityProfileProvider.get(
+      runtime as never,
+      makeMessage() as never,
+      {} as never,
+    );
+
+    expect(result.text).toContain("current app VS Code for 30m");
+    expect(result.text).toContain("today apps VS Code 2h, Slack 30m");
+    expect(result.values?.userCurrentAppName).toBe("VS Code");
+    expect(result.values?.userTodayAppUsageTotalMs).toBe(9_000_000);
+    expect(result.values?.userTodayAppUsage).toEqual([
+      {
+        appName: "VS Code",
+        bundleId: "com.microsoft.VSCode",
+        totalMs: 7_200_000,
+        sessionCount: 2,
+      },
+      {
+        appName: "Slack",
+        bundleId: "com.tinyspeck.slackmacgap",
+        totalMs: 1_800_000,
+        sessionCount: 1,
+      },
+    ]);
+    expect(mocks.logger.debug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        boundary: "activity_profile",
+        operation: "provider_activity_usage_context",
+        currentAppPresent: true,
+        topAppCount: 2,
+      }),
+      "[activity-profile] Injected ambient app-usage context.",
+    );
+  });
+
+  it("does not read app usage for non-owner turns", async () => {
+    mocks.hasOwnerAccess.mockResolvedValueOnce(false);
+
+    const result = await activityProfileProvider.get(
+      makeRuntime() as never,
+      makeMessage() as never,
+      {} as never,
+    );
+
+    expect(result).toEqual({ text: "", values: {}, data: {} });
+    expect(mocks.getActivityReportBetween).not.toHaveBeenCalled();
+    expect(mocks.getLatestForegroundActivity).not.toHaveBeenCalled();
+  });
+
+  it("keeps base context when app usage read fails", async () => {
+    mocks.getActivityReportBetween.mockRejectedValueOnce(
+      new Error("activity table unavailable"),
+    );
+
+    const result = await activityProfileProvider.get(
+      makeRuntime() as never,
+      makeMessage() as never,
+      {} as never,
+    );
+
+    expect(result.text).toContain("User context:");
+    expect(result.values?.userCurrentAppName).toBeNull();
+    expect(mocks.logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        boundary: "activity_profile",
+        operation: "provider_activity_usage_read",
+      }),
+      "[activity-profile] Failed to read ambient app-usage context; continuing without app-usage context.",
+    );
+  });
+});

--- a/plugins/plugin-personal-assistant/test/activity-tracker-reporting.test.ts
+++ b/plugins/plugin-personal-assistant/test/activity-tracker-reporting.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  listActivityEvents: vi.fn(),
+}));
+
+vi.mock("@elizaos/plugin-health", () => ({
+  isSystemInactivityApp: (event: { bundleId?: string; appName?: string }) =>
+    event.bundleId === "com.apple.loginwindow" ||
+    event.appName === "loginwindow",
+}));
+
+vi.mock("../src/activity-profile/activity-tracker-repo.js", () => ({
+  listActivityEvents: mocks.listActivityEvents,
+}));
+
+import { getLatestForegroundActivity } from "../src/activity-profile/activity-tracker-reporting.js";
+
+const RUNTIME = { agentId: "agent-activity" };
+const SINCE_MS = Date.parse("2026-01-15T08:00:00.000Z");
+const UNTIL_MS = Date.parse("2026-01-15T18:30:00.000Z");
+
+function event(overrides: {
+  observedAt: string;
+  eventKind: "activate" | "deactivate";
+  bundleId: string;
+  appName: string;
+}) {
+  return {
+    id: `event-${overrides.observedAt}`,
+    agentId: "agent-activity",
+    windowTitle: null,
+    ...overrides,
+  };
+}
+
+describe("getLatestForegroundActivity", () => {
+  beforeEach(() => {
+    mocks.listActivityEvents.mockReset();
+  });
+
+  it("returns the latest active foreground app", async () => {
+    mocks.listActivityEvents.mockResolvedValueOnce([
+      event({
+        observedAt: "2026-01-15T17:00:00.000Z",
+        eventKind: "activate",
+        bundleId: "com.tinyspeck.slackmacgap",
+        appName: "Slack",
+      }),
+      event({
+        observedAt: "2026-01-15T18:00:00.000Z",
+        eventKind: "activate",
+        bundleId: "com.microsoft.VSCode",
+        appName: "VS Code",
+      }),
+    ]);
+
+    const current = await getLatestForegroundActivity(
+      RUNTIME as never,
+      "agent-activity",
+      { sinceMs: SINCE_MS, untilMs: UNTIL_MS },
+    );
+
+    expect(current).toEqual({
+      bundleId: "com.microsoft.VSCode",
+      appName: "VS Code",
+      observedAtMs: Date.parse("2026-01-15T18:00:00.000Z"),
+      activeMs: 30 * 60_000,
+    });
+  });
+
+  it("returns null when the latest real event is a deactivation", async () => {
+    mocks.listActivityEvents.mockResolvedValueOnce([
+      event({
+        observedAt: "2026-01-15T18:00:00.000Z",
+        eventKind: "activate",
+        bundleId: "com.microsoft.VSCode",
+        appName: "VS Code",
+      }),
+      event({
+        observedAt: "2026-01-15T18:20:00.000Z",
+        eventKind: "deactivate",
+        bundleId: "com.microsoft.VSCode",
+        appName: "VS Code",
+      }),
+    ]);
+
+    await expect(
+      getLatestForegroundActivity(RUNTIME as never, "agent-activity", {
+        sinceMs: SINCE_MS,
+        untilMs: UNTIL_MS,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("does not fall back to a stale app when inactivity is latest", async () => {
+    mocks.listActivityEvents.mockResolvedValueOnce([
+      event({
+        observedAt: "2026-01-15T18:00:00.000Z",
+        eventKind: "activate",
+        bundleId: "com.microsoft.VSCode",
+        appName: "VS Code",
+      }),
+      event({
+        observedAt: "2026-01-15T18:20:00.000Z",
+        eventKind: "activate",
+        bundleId: "com.apple.loginwindow",
+        appName: "loginwindow",
+      }),
+    ]);
+
+    await expect(
+      getLatestForegroundActivity(RUNTIME as never, "agent-activity", {
+        sinceMs: SINCE_MS,
+        untilMs: UNTIL_MS,
+      }),
+    ).resolves.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- wire existing `life_activity_events` dwell reporting into the owner-only `activity-profile` provider
- add latest-foreground-app derivation that returns no current app after deactivation or OS inactivity surfaces
- expose current app and today top-app usage in provider values/data for future PRIORITIZE/proactive consumers
- add focused tests plus issue evidence for #9970

## Evidence
- `bun run biome check plugins\plugin-personal-assistant\src\providers\activity-profile.ts plugins\plugin-personal-assistant\src\activity-profile\activity-tracker-reporting.ts plugins\plugin-personal-assistant\test\activity-profile-provider.test.ts plugins\plugin-personal-assistant\test\activity-tracker-reporting.test.ts`
- `bun run --cwd plugins\plugin-personal-assistant test activity-profile-provider.test.ts activity-tracker-reporting.test.ts`
- `bun run --cwd plugins\plugin-personal-assistant build:types`
- `git diff origin/develop...HEAD --check`
- Evidence file: `.github/issue-evidence/9970-personal-assistant-activity-context.md`

## Local limitation
- `bun run --cwd plugins\plugin-personal-assistant test` timed out after 304s without a completion signal on this Windows worktree; the focused provider/reporting tests and type-build passed after rebasing onto current `origin/develop`.

Fixes part of #9970.