### PR TITLE
fix(ui): burn down story-gate contrast debt

### DIFF
--- a/packages/ui/src/components/RoleGate.stories.tsx
+++ b/packages/ui/src/components/RoleGate.stories.tsx
@@ -22,15 +22,15 @@ function RoleCard() {
     <div
       style={{
         fontFamily: "system-ui, sans-serif",
-        color: "#e5e5e5",
+        color: "#f5f5f5",
         background: "#111",
         padding: 24,
         borderRadius: 12,
         width: 360,
       }}
     >
-      <div style={{ fontSize: 13, opacity: 0.7, marginBottom: 12 }}>
-        current role: <strong style={{ color: "#ff5800" }}>{role}</strong> ·
+      <div style={{ fontSize: 13, color: "#cbd5e1", marginBottom: 12 }}>
+        current role: <strong style={{ color: "#ff8a3d" }}>{role}</strong> ·
         owner={String(isOwner)} · admin={String(isAdmin)}
       </div>
       <RoleGate
@@ -59,8 +59,8 @@ function Row({ label, denied }: { label: string; denied?: boolean }) {
         padding: "8px 12px",
         marginBottom: 6,
         borderRadius: 8,
-        background: denied ? "#1a1a1a" : "#222",
-        color: denied ? "#555" : "#e5e5e5",
+        background: denied ? "#202020" : "#262626",
+        color: denied ? "#a3a3a3" : "#f5f5f5",
         textDecoration: denied ? "line-through" : "none",
       }}
     >

--- a/packages/ui/src/components/chat/widgets/ftu-welcome.tsx
+++ b/packages/ui/src/components/chat/widgets/ftu-welcome.tsx
@@ -97,7 +97,7 @@ function FtuWelcomeWidget({
           data-testid="ftu-welcome-dismiss"
           aria-label="Dismiss welcome"
           onClick={() => dismissHomeWidget(WIDGET_KEY)}
-          className="text-sm text-white/40 transition-colors hover:text-white/70"
+          className="text-sm text-white/60 transition-colors hover:text-white/80"
         >
           Dismiss
         </button>

--- a/packages/ui/test/story-gate/baseline/a11y-baseline.json
+++ b/packages/ui/test/story-gate/baseline/a11y-baseline.json
@@ -521,9 +521,6 @@
   "primitives-progress--empty": ["aria-progressbar-name"],
   "primitives-progress--quarter": ["aria-progressbar-name"],
   "primitives-progress--three-quarters": ["aria-progressbar-name"],
-  "primitives-rolegate--admin": ["color-contrast"],
-  "primitives-rolegate--owner": ["color-contrast"],
-  "primitives-rolegate--user": ["color-contrast"],
   "primitives-savefooter--default": ["color-contrast"],
   "primitives-savefooter--error-state": ["color-contrast"],
   "primitives-savefooter--saved": ["color-contrast"],
@@ -640,6 +637,5 @@
   "toolevents-toolcalleventlog--running": ["color-contrast"],
   "toolevents-toolcalleventlog--success": ["color-contrast"],
   "views-dynamicviewloader--failed-to-load": ["color-contrast"],
-  "views-shellviewagentsurface--character-view": ["color-contrast"],
-  "widgets-homewidgets--populated": ["color-contrast"]
+  "views-shellviewagentsurface--character-view": ["color-contrast"]
 }


### PR DESCRIPTION
## Summary

Burns down the four story-gate contrast entries that were accepted in #10082 to unblock the develop merge queue:

- Fixes RoleGate story contrast directly instead of keeping `primitives-rolegate--admin/owner/user` in the a11y baseline.
- Fixes the FTU welcome dismiss button contrast that surfaced through `widgets-homewidgets--populated`.
- Removes those four entries from `packages/ui/test/story-gate/baseline/a11y-baseline.json`.

## Validation

- `git diff --check origin/develop...HEAD`
- `bun run biome check packages/ui/src/components/RoleGate.stories.tsx packages/ui/src/components/chat/widgets/ftu-welcome.tsx packages/ui/test/story-gate/baseline/a11y-baseline.json`
- `PATH=/home/nubs/.nvm/versions/node/v24.15.0/bin:$PATH bun run --cwd packages/ui build-storybook --output-dir storybook-static --quiet`
- `PATH=/home/nubs/.nvm/versions/node/v24.15.0/bin:$PATH node test/story-gate/run-story-gate.mjs --grep rolegate --no-screenshots` -> 4/4 good, a11y=0
- `PATH=/home/nubs/.nvm/versions/node/v24.15.0/bin:$PATH node test/story-gate/run-story-gate.mjs --grep homewidgets --no-screenshots` -> 1/1 good, a11y=0
- `bun run --cwd packages/ui test RoleGate.test.tsx` -> 7 passed
- `bun run --cwd packages/ui test ftu-welcome.test.tsx` -> 8 passed

Browser plugin was not available in this Codex session, so rendered validation used the repo Storybook/story-gate Playwright path.
