### PR TITLE
fix(build): cache generated prompts outputs

### DIFF
--- a/.github/issue-evidence/10077-prompts-turbo-cache-outputs.md
+++ b/.github/issue-evidence/10077-prompts-turbo-cache-outputs.md
@@ -1,0 +1,92 @@
+# Issue #10077 - prompts Turbo cache outputs
+
+## Scope
+
+Fixes the highest-priority `@elizaos/prompts#build` cache correctness slice from
+#10077. The task is cacheable again, restores the generated prompt/action
+artifacts, and hashes plugin TypeScript because the generator scans
+`plugins/**/*.ts`.
+
+## Evidence
+
+### Turbo dry-run
+
+Command:
+
+```bash
+node packages/scripts/run-turbo.mjs run build --filter=@elizaos/prompts --dry-run=json
+```
+
+Parsed `@elizaos/prompts#build` task:
+
+```text
+cache   : True
+outputs : ../../packages/core/src/generated/action-docs.ts, specs/actions/plugins.generated.json
+inputs  : ../../plugins/**/*.ts, package.json, scripts/**, specs/**, src/**
+```
+
+### Generator
+
+Command:
+
+```bash
+bun run --cwd packages/prompts build
+```
+
+Result:
+
+```text
+Wrote 97 plugin actions to packages\prompts\specs\actions\plugins.generated.json
+Formatted 1 file in 498ms. Fixed 1 file.
+Generated action/provider docs.
+```
+
+No generated artifact diff remained after the build.
+
+### Tests and checks
+
+```bash
+bun test packages/scripts/__tests__/turbo-prompts-cache-outputs.test.ts
+```
+
+Result: 1 pass, 0 fail.
+
+```bash
+bun run --cwd packages/prompts test
+```
+
+Result: 25 pass, 0 fail.
+
+```bash
+bun run biome check turbo.json packages/scripts/__tests__/turbo-prompts-cache-outputs.test.ts
+```
+
+Result: checked 2 files, no fixes applied.
+
+```bash
+git diff --check
+```
+
+Result: pass.
+
+### Filtered Turbo build attempt
+
+Command:
+
+```bash
+node packages/scripts/run-turbo.mjs run build --filter=@elizaos/prompts --output-logs=new-only
+```
+
+Result: blocked before `@elizaos/prompts#build` by the local Windows dependency
+store. `@elizaos/core#build` failed resolving missing `drizzle-orm` package
+files such as `./sql/index.js`, `./subquery.js`, and `./table.js` from
+`node_modules/.bun/drizzle-orm@0.45.2+4eb8acfd097b6b37/node_modules/drizzle-orm`.
+
+## Evidence Type Notes
+
+- Backend logs: N/A, no backend code path changed.
+- Frontend logs: N/A, no frontend runtime path changed.
+- Screenshots: N/A, no UI changed.
+- Video: N/A, no UI flow changed.
+- Real-LLM trajectory: N/A, build orchestration cache metadata only.
+- Audio: N/A, no voice path changed.

--- a/packages/scripts/__tests__/turbo-prompts-cache-outputs.test.ts
+++ b/packages/scripts/__tests__/turbo-prompts-cache-outputs.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "..",
+);
+
+const turbo = JSON.parse(
+  readFileSync(path.join(repoRoot, "turbo.json"), "utf8"),
+);
+
+describe("@elizaos/prompts Turbo build cache outputs", () => {
+  test("restores generated artifacts and hashes scanned plugin sources", () => {
+    const task = turbo.tasks["@elizaos/prompts#build"];
+    const outputs = new Set(task.outputs ?? []);
+    const inputs = new Set(task.inputs ?? []);
+
+    expect(task.cache).not.toBe(false);
+    expect(outputs.has("specs/actions/plugins.generated.json")).toBe(true);
+    expect(
+      outputs.has("$TURBO_ROOT$/packages/core/src/generated/action-docs.ts"),
+    ).toBe(true);
+    expect(inputs.has("$TURBO_ROOT$/plugins/**/*.ts")).toBe(true);
+  });
+});

--- a/turbo.json
+++ b/turbo.json
@@ -85,8 +85,17 @@
     },
     "@elizaos/prompts#build": {
       "dependsOn": ["@elizaos/core#build", "^build"],
-      "outputs": [],
-      "cache": false
+      "outputs": [
+        "specs/actions/plugins.generated.json",
+        "$TURBO_ROOT$/packages/core/src/generated/action-docs.ts"
+      ],
+      "inputs": [
+        "package.json",
+        "scripts/**",
+        "src/**",
+        "specs/**",
+        "$TURBO_ROOT$/plugins/**/*.ts"
+      ]
     },
     "@elizaos/app-core#build": {
       "dependsOn": [


### PR DESCRIPTION
## Summary
- make `@elizaos/prompts#build` cacheable again by declaring the generated prompt artifacts as Turbo outputs
- add `plugins/**/*.ts` to the prompts build inputs so plugin action changes invalidate the generated action spec cache key
- add a focused regression test for the prompts Turbo task contract

## Evidence
- Evidence file: `.github/issue-evidence/10077-prompts-turbo-cache-outputs.md`
- `node packages/scripts/run-turbo.mjs run build --filter=@elizaos/prompts --dry-run=json` resolves the prompts task as cacheable with outputs `../../packages/core/src/generated/action-docs.ts` and `specs/actions/plugins.generated.json`, and inputs `../../plugins/**/*.ts, package.json, scripts/**, specs/**, src/**`.
- `bun run --cwd packages/prompts build` passed and left no generated artifact diff.
- `bun test packages/scripts/__tests__/turbo-prompts-cache-outputs.test.ts` passed: 1 pass, 0 fail.
- `bun run --cwd packages/prompts test` passed: 25 pass, 0 fail.
- `bun run biome check turbo.json packages/scripts/__tests__/turbo-prompts-cache-outputs.test.ts` passed.
- `git diff origin/develop...HEAD --check` passed.

## Known local validation limit
- `node packages/scripts/run-turbo.mjs run build --filter=@elizaos/prompts --output-logs=new-only` is blocked in this Windows worktree before the prompts task by the existing local `drizzle-orm` package-store issue during `@elizaos/core#build` (`Could not resolve ./sql/index.js`, `./subquery.js`, `./table.js`, etc.).

Refs #10077