### PR TITLE
fix(release): make eliza-code ACP publishable

### DIFF
--- a/.github/issue-evidence/10059-cloud-eliza-code-package-publish.md
+++ b/.github/issue-evidence/10059-cloud-eliza-code-package-publish.md
@@ -1,0 +1,47 @@
+# Issue #10059 Evidence: eliza-code ACP package publishability
+
+## Scope
+
+Prepared `@elizaos/example-code` for the existing Lerna npm release train so the cloud agent image can install the `eliza-code-acp` bin once maintainers publish the next release tag.
+
+## Registry Research
+
+- `npm view @elizaos/example-code dist-tags --json` returns E404: the package is not published yet.
+- `npm view @elizaos/plugin-coding-tools dist-tags --json` shows `latest: 2.0.0-beta.1` and `beta: 2.0.3-beta.7`, with no `alpha` tag.
+- `npm view @elizaos/plugin-agent-orchestrator dist-tags --json` shows `alpha: 2.0.0-alpha.537` and `beta: 2.0.3-beta.7`.
+- `npm view @elizaos/plugin-shell dist-tags --json` shows `alpha: 2.0.0-alpha.537` and `beta: 2.0.3-beta.7`.
+
+## Changes
+
+- Added `packages/examples/code` to `lerna.json` so release versioning/publishing sees `@elizaos/example-code`.
+- Added package publish metadata and a `files` allowlist for the built ACP/TUI entrypoints.
+- Added a shebang to `src/acp.ts` so the npm-installed `eliza-code-acp` bin is directly executable.
+- Made npm pack/publish helper scripts invoke npm through `node npm-cli.js` on Windows, avoiding `execFileSync("npm")` and `.cmd` spawn failures.
+
+## Validation
+
+- `bun run --cwd packages/examples/code build`
+  - Passes.
+  - Builds `dist/index.js` and `dist/acp.js`.
+  - `dist/acp.js` starts with `#!/usr/bin/env node`.
+- `bunx lerna ls --all --json --scope @elizaos/example-code --loglevel error`
+  - Passes.
+  - Returns exactly one public package: `@elizaos/example-code` at `packages/examples/code`.
+- `node packages/scripts/verify-npm-pack-dist.mjs packages/examples/code`
+  - Passes after temporarily moving the generated `packages/examples/code/node_modules` aside on Windows.
+  - Output: `ok @elizaos/example-code: 4 packed file(s), dist included`.
+  - Note: plain `npm pack` hangs in this Windows checkout when Bun's per-workspace `node_modules` symlink tree is present; a clean staging copy packs normally.
+- Clean staging npm dry-run pack:
+  - Passes.
+  - Files included: `README.md`, `dist/acp.js`, `dist/index.js`, `package.json`.
+
+## Evidence N/A
+
+- Screenshots/video: N/A, packaging/release metadata only.
+- Live cloud task: N/A, requires npm publish credentials plus Hetzner/GHCR cloud redeploy access.
+
+## Remaining Cloud Work
+
+- Publish `@elizaos/example-code` under the intended release tag.
+- Decide whether cloud should install `@elizaos/plugin-coding-tools@beta` or wait for an `alpha` tag.
+- Extend the cloud agent image/runtime to install/load the coding packages and redeploy the Hetzner cloud agent stack.

--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,7 @@
   "packages": [
     "packages/*",
     "packages/app-core/platforms/*",
+    "packages/examples/code",
     "plugins/*",
     "packages/cloud/sdk"
   ],
@@ -19,11 +20,7 @@
         "new-beginnings",
         "beta"
       ],
-      "ignoreChanges": [
-        "**/*.md",
-        "**/test/**",
-        "**/__tests__/**"
-      ],
+      "ignoreChanges": ["**/*.md", "**/test/**", "**/__tests__/**"],
       "verifyAccess": false
     },
     "version": {

--- a/packages/examples/code/package.json
+++ b/packages/examples/code/package.json
@@ -2,11 +2,23 @@
   "name": "@elizaos/example-code",
   "version": "2.0.0-beta.0",
   "description": "Async coding agent terminal app - Claude Code meets ElizaOS",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/elizaos/eliza.git",
+    "directory": "packages/examples/code"
+  },
   "type": "module",
   "main": "dist/index.js",
   "bin": {
     "eliza-code": "./dist/index.js",
     "eliza-code-acp": "./dist/acp.js"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "start": "bun src/index.ts",

--- a/packages/examples/code/src/acp.ts
+++ b/packages/examples/code/src/acp.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /**
  * eliza-code ACP server — lets eliza-code run AS a coding sub-agent that the
  * elizaOS orchestrator (plugin-agent-orchestrator) can spawn over the Agent
@@ -31,13 +32,13 @@ import {
   SessionCwdService,
 } from "@elizaos/plugin-coding-tools";
 import { initializeAgent } from "./lib/agent.js";
-import { applyOpencodeProviderEnv } from "./lib/model-provider.js";
 import { getAgentClient } from "./lib/agent-client.js";
 import {
   ensureSessionIdentity,
   getMainRoomElizaId,
   type SessionIdentity,
 } from "./lib/identity.js";
+import { applyOpencodeProviderEnv } from "./lib/model-provider.js";
 import type { ChatRoom } from "./types.js";
 
 /** A `console.error` logger (stdout is the ACP JSON-RPC channel — never log there). */

--- a/packages/scripts/publish-from-dist.mjs
+++ b/packages/scripts/publish-from-dist.mjs
@@ -27,6 +27,22 @@ import { fileURLToPath } from "node:url";
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 
+function npmInvocation(args) {
+  if (process.platform === "win32") {
+    const npmCliPath = join(
+      dirname(process.execPath),
+      "node_modules",
+      "npm",
+      "bin",
+      "npm-cli.js",
+    );
+    if (existsSync(npmCliPath)) {
+      return { command: process.execPath, args: [npmCliPath, ...args] };
+    }
+  }
+  return { command: "npm", args };
+}
+
 function parseArgs() {
   const argv = process.argv.slice(2);
   const flags = {
@@ -109,7 +125,8 @@ function main() {
 
     try {
       console.log(`  ${pkg.name}@${pkg.version}: ${args.join(" ")}`);
-      execFileSync("npm", args, { cwd: distDir, stdio: "inherit" });
+      const npm = npmInvocation(args);
+      execFileSync(npm.command, npm.args, { cwd: distDir, stdio: "inherit" });
       succeeded++;
     } catch (err) {
       failed++;

--- a/packages/scripts/verify-npm-pack-dist.mjs
+++ b/packages/scripts/verify-npm-pack-dist.mjs
@@ -188,6 +188,22 @@ function parsePackJson(output) {
   }
 }
 
+function npmInvocation(args) {
+  if (process.platform === "win32") {
+    const npmCliPath = join(
+      dirname(process.execPath),
+      "node_modules",
+      "npm",
+      "bin",
+      "npm-cli.js",
+    );
+    if (existsSync(npmCliPath)) {
+      return { command: process.execPath, args: [npmCliPath, ...args] };
+    }
+  }
+  return { command: "npm", args };
+}
+
 if (allPublicDistPackages) {
   for (const packageDir of discoverPublicPackageDirs()) {
     if (!packageDirs.includes(packageDir)) {
@@ -243,7 +259,8 @@ for (const info of packageInfos) {
     continue;
   }
 
-  const output = execFileSync("npm", ["pack", "--dry-run", "--json"], {
+  const npm = npmInvocation(["pack", "--dry-run", "--json"]);
+  const output = execFileSync(npm.command, npm.args, {
     cwd: absoluteDir,
     encoding: "utf8",
     env: {


### PR DESCRIPTION
## Summary

- Add \packages/examples/code\ to the Lerna release package set so \@elizaos/example-code\ can be versioned/published by the existing npm release workflow.
- Add npm publish metadata/files allowlist for the eliza-code package and a shebang for the \liza-code-acp\ bin.
- Make npm pack/publish helper scripts invoke npm through \
ode npm-cli.js\ on Windows, avoiding \xecFileSync('npm')\ / \.cmd\ spawn failures.
- Attach issue evidence in \.github/issue-evidence/10059-cloud-eliza-code-package-publish.md\.

Fixes part of #10059.

## Validation

- \un run --cwd packages/examples/code build\ ✅
- \un run --cwd packages/examples/code test\ ✅ (package currently has no matching test files)
- \unx @biomejs/biome check lerna.json packages/examples/code/package.json packages/examples/code/src/acp.ts packages/scripts/publish-from-dist.mjs packages/scripts/verify-npm-pack-dist.mjs .github/issue-evidence/10059-cloud-eliza-code-package-publish.md\ ✅
- \git diff --check\ ✅
- \unx lerna ls --all --json --scope @elizaos/example-code --loglevel error\ ✅ returns the package
- \
ode packages/scripts/verify-npm-pack-dist.mjs packages/examples/code\ ✅ after temporarily moving generated \packages/examples/code/node_modules\ aside on Windows; plain npm pack hangs on this checkout's Bun symlink tree, while a clean staging copy packs normally
- Clean staging \
pm pack --dry-run --json\ ✅ includes \README.md\, \dist/acp.js\, \dist/index.js\, and \package.json\

## Not validated

- \un run --cwd packages/examples/code typecheck\ is still blocked by unresolved workspace plugin declaration outputs unless those plugin dists are built first; this package was already excluded from the root Turbo typecheck path.
- Live Cloud cutover remains blocked on npm publish credentials and Hetzner/GHCR redeploy access.
