### PR TITLE
feat(cloud-e2e): drive every spec through the real SIWE login (follow-up to #10069)

### DIFF
--- a/packages/cloud/shared/src/lib/cache/mock-redis.ts
+++ b/packages/cloud/shared/src/lib/cache/mock-redis.ts
@@ -1,32 +1,23 @@
 /**
- * In-memory mock of the {@link SocketRedis} client surface, backed by
- * `ioredis-mock`. Selected only when `MOCK_REDIS=1` is set in the
- * environment — never used as a silent fallback.
+ * In-memory mock of the {@link SocketRedis} client surface. Selected only when
+ * `MOCK_REDIS=1` is set in the environment — never used as a silent fallback.
  *
  * The exposed methods match the subset of `SocketRedis` that callers in this
- * repo use (rate limiters, credit events, agent gateway relay, A2A task
- * store, generic cache). Values are JSON-encoded on the way in and decoded
- * on the way out so the round-trip behaviour matches `SocketRedis`.
+ * repo use (rate limiters, credit events, agent gateway relay, A2A task store,
+ * generic cache). Values are JSON-encoded on the way in and decoded on the way
+ * out so the round-trip behaviour matches `SocketRedis`.
+ *
+ * The backing store is a plain module-global `Map`, not `ioredis-mock`. Two
+ * runtimes have to share one implementation: the Bun unit/integration tests AND
+ * the cloud-api Worker bundle (wrangler `--local`) the cloud-e2e stack boots.
+ * `ioredis-mock` resolves to its browser build under wrangler/esbuild and throws
+ * `ReferenceError: window is not defined` inside workerd, so any nonce-storage
+ * route (e.g. SIWE nonce/verify) 500s. A dependency-free store runs identically
+ * everywhere. It is process-global on purpose: `buildRedisClient()` is called
+ * per request, so SIWE's nonce (written by one request, consumed by the next)
+ * must persist across instances within a process — matching `ioredis-mock`'s
+ * shared-store default.
  */
-
-import { createRequire } from "node:module";
-
-// Lazy: `import.meta.url` is undefined in some bundle contexts (e.g. the
-// Cloudflare Workers dev bundle reload path), so building createRequire at
-// module load throws. Defer until first use, which only happens when
-// MOCK_REDIS=1 and ioredis-mock is actually needed.
-let _requireCJS: NodeJS.Require | null = null;
-function getRequireCJS(): NodeJS.Require {
-  if (_requireCJS) return _requireCJS;
-  const url = import.meta.url;
-  if (!url) {
-    throw new Error(
-      "mock-redis: import.meta.url is undefined; cannot resolve ioredis-mock via createRequire",
-    );
-  }
-  _requireCJS = createRequire(url);
-  return _requireCJS;
-}
 
 interface IoRedisLike {
   get(key: string): Promise<string | null>;
@@ -57,12 +48,299 @@ interface IoRedisLike {
   quit(): Promise<string>;
 }
 
-type IoRedisMockCtor = new () => IoRedisLike;
+type StringEntry = { kind: "string"; value: string; expireAt: number | null };
+type ListEntry = { kind: "list"; value: string[]; expireAt: number | null };
+type SetEntry = { kind: "set"; value: Set<string>; expireAt: number | null };
+type ZSetEntry = { kind: "zset"; value: Map<string, number>; expireAt: number | null };
+type Entry = StringEntry | ListEntry | SetEntry | ZSetEntry;
 
-function createIoRedisMock(): IoRedisLike {
-  const mod = getRequireCJS()("ioredis-mock") as IoRedisMockCtor | { default: IoRedisMockCtor };
-  const Ctor: IoRedisMockCtor = "default" in mod ? mod.default : mod;
-  return new Ctor();
+/**
+ * Process-global store shared by every {@link InMemoryRedis} instance — see the
+ * file header for why this must outlive a single `buildRedisClient()` call.
+ */
+const GLOBAL_STORE = new Map<string, Entry>();
+
+function nowMs(): number {
+  return Date.now();
+}
+
+function globToRegExp(pattern: string): RegExp {
+  let out = "";
+  for (const ch of pattern) {
+    if (ch === "*") out += ".*";
+    else if (ch === "?") out += ".";
+    else out += ch.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+  }
+  return new RegExp(`^${out}$`);
+}
+
+function parseScoreBound(bound: number | string, fallback: number): number {
+  if (typeof bound === "number") return bound;
+  const s = bound.trim();
+  if (s === "-inf") return Number.NEGATIVE_INFINITY;
+  if (s === "+inf" || s === "inf") return Number.POSITIVE_INFINITY;
+  // Exclusive "(" prefix is treated as inclusive here; callers in this repo use
+  // inclusive numeric / ±inf ranges only, so the distinction never bites.
+  const n = Number.parseFloat(s.startsWith("(") ? s.slice(1) : s);
+  return Number.isNaN(n) ? fallback : n;
+}
+
+/**
+ * Dependency-free in-memory Redis matching the {@link IoRedisLike} surface used
+ * in this repo. Lazy TTL expiry: a key past its `expireAt` is treated as absent
+ * and dropped on next access.
+ */
+class InMemoryRedis implements IoRedisLike {
+  private read(key: string): Entry | undefined {
+    const entry = GLOBAL_STORE.get(key);
+    if (!entry) return undefined;
+    if (entry.expireAt !== null && entry.expireAt <= nowMs()) {
+      GLOBAL_STORE.delete(key);
+      return undefined;
+    }
+    return entry;
+  }
+
+  async get(key: string): Promise<string | null> {
+    const entry = this.read(key);
+    return entry?.kind === "string" ? entry.value : null;
+  }
+
+  async set(...args: Array<string | number>): Promise<string | null> {
+    const key = String(args[0]);
+    const value = String(args[1]);
+    let expireAt: number | null = null;
+    let nx = false;
+    for (let i = 2; i < args.length; i++) {
+      const token = String(args[i]).toUpperCase();
+      if (token === "EX") expireAt = nowMs() + Number(args[++i]) * 1000;
+      else if (token === "PX") expireAt = nowMs() + Number(args[++i]);
+      else if (token === "NX") nx = true;
+    }
+    if (nx && this.read(key)) return null;
+    GLOBAL_STORE.set(key, { kind: "string", value, expireAt });
+    return "OK";
+  }
+
+  async setex(key: string, seconds: number, value: string): Promise<string> {
+    GLOBAL_STORE.set(key, { kind: "string", value, expireAt: nowMs() + seconds * 1000 });
+    return "OK";
+  }
+
+  async getdel(key: string): Promise<string | null> {
+    const entry = this.read(key);
+    if (entry?.kind !== "string") return null;
+    GLOBAL_STORE.delete(key);
+    return entry.value;
+  }
+
+  async incr(key: string): Promise<number> {
+    const entry = this.read(key);
+    const current = entry?.kind === "string" ? Number.parseInt(entry.value, 10) || 0 : 0;
+    const next = current + 1;
+    GLOBAL_STORE.set(key, {
+      kind: "string",
+      value: String(next),
+      // INCR preserves an existing TTL.
+      expireAt: entry?.kind === "string" ? entry.expireAt : null,
+    });
+    return next;
+  }
+
+  async expire(key: string, seconds: number): Promise<number> {
+    const entry = this.read(key);
+    if (!entry) return 0;
+    entry.expireAt = nowMs() + seconds * 1000;
+    return 1;
+  }
+
+  async pexpire(key: string, ms: number): Promise<number> {
+    const entry = this.read(key);
+    if (!entry) return 0;
+    entry.expireAt = nowMs() + ms;
+    return 1;
+  }
+
+  async pttl(key: string): Promise<number> {
+    const entry = this.read(key);
+    if (!entry) return -2;
+    if (entry.expireAt === null) return -1;
+    return Math.max(0, entry.expireAt - nowMs());
+  }
+
+  async del(...keys: string[]): Promise<number> {
+    let count = 0;
+    for (const key of keys) {
+      if (this.read(key)) {
+        GLOBAL_STORE.delete(key);
+        count++;
+      }
+    }
+    return count;
+  }
+
+  async mget(...keys: string[]): Promise<Array<string | null>> {
+    return keys.map((key) => {
+      const entry = this.read(key);
+      return entry?.kind === "string" ? entry.value : null;
+    });
+  }
+
+  async scan(
+    _cursor: string | number,
+    ...args: Array<string | number>
+  ): Promise<[string, string[]]> {
+    let match = "*";
+    for (let i = 0; i < args.length; i++) {
+      if (String(args[i]).toUpperCase() === "MATCH") match = String(args[i + 1]);
+    }
+    const re = globToRegExp(match);
+    const keys: string[] = [];
+    for (const key of GLOBAL_STORE.keys()) {
+      if (this.read(key) && re.test(key)) keys.push(key);
+    }
+    // Single-page scan: cursor "0" signals completion, so the caller's
+    // until-"0" loop terminates after one pass with every matching key.
+    return ["0", keys];
+  }
+
+  private list(key: string): string[] {
+    const entry = this.read(key);
+    if (entry?.kind === "list") return entry.value;
+    const fresh: ListEntry = { kind: "list", value: [], expireAt: null };
+    GLOBAL_STORE.set(key, fresh);
+    return fresh.value;
+  }
+
+  async lpush(key: string, ...values: string[]): Promise<number> {
+    const list = this.list(key);
+    for (const v of values) list.unshift(v);
+    return list.length;
+  }
+
+  async rpush(key: string, ...values: string[]): Promise<number> {
+    const list = this.list(key);
+    for (const v of values) list.push(v);
+    return list.length;
+  }
+
+  async lpop(key: string, count?: number): Promise<string | string[] | null> {
+    const entry = this.read(key);
+    if (entry?.kind !== "list" || entry.value.length === 0) return null;
+    if (count === undefined) return entry.value.shift() ?? null;
+    return entry.value.splice(0, count);
+  }
+
+  async rpop(key: string): Promise<string | null> {
+    const entry = this.read(key);
+    if (entry?.kind !== "list" || entry.value.length === 0) return null;
+    return entry.value.pop() ?? null;
+  }
+
+  async llen(key: string): Promise<number> {
+    const entry = this.read(key);
+    return entry?.kind === "list" ? entry.value.length : 0;
+  }
+
+  private set_(key: string): Set<string> {
+    const entry = this.read(key);
+    if (entry?.kind === "set") return entry.value;
+    const fresh: SetEntry = { kind: "set", value: new Set(), expireAt: null };
+    GLOBAL_STORE.set(key, fresh);
+    return fresh.value;
+  }
+
+  async sadd(key: string, ...members: string[]): Promise<number> {
+    const set = this.set_(key);
+    let added = 0;
+    for (const m of members) {
+      if (!set.has(m)) {
+        set.add(m);
+        added++;
+      }
+    }
+    return added;
+  }
+
+  async srem(key: string, ...members: string[]): Promise<number> {
+    const entry = this.read(key);
+    if (entry?.kind !== "set") return 0;
+    let removed = 0;
+    for (const m of members) {
+      if (entry.value.delete(m)) removed++;
+    }
+    return removed;
+  }
+
+  async smembers(key: string): Promise<string[]> {
+    const entry = this.read(key);
+    return entry?.kind === "set" ? [...entry.value] : [];
+  }
+
+  private zset(key: string): Map<string, number> {
+    const entry = this.read(key);
+    if (entry?.kind === "zset") return entry.value;
+    const fresh: ZSetEntry = { kind: "zset", value: new Map(), expireAt: null };
+    GLOBAL_STORE.set(key, fresh);
+    return fresh.value;
+  }
+
+  async zadd(key: string, score: number, member: string): Promise<number> {
+    const zset = this.zset(key);
+    const isNew = !zset.has(member);
+    zset.set(member, score);
+    return isNew ? 1 : 0;
+  }
+
+  async zcard(key: string): Promise<number> {
+    const entry = this.read(key);
+    return entry?.kind === "zset" ? entry.value.size : 0;
+  }
+
+  async zrange(key: string, start: number, stop: number): Promise<string[]> {
+    const entry = this.read(key);
+    if (entry?.kind !== "zset") return [];
+    const sorted = [...entry.value.entries()]
+      .sort((a, b) => a[1] - b[1] || (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0))
+      .map(([member]) => member);
+    const len = sorted.length;
+    const from = start < 0 ? Math.max(len + start, 0) : start;
+    const to = stop < 0 ? len + stop : stop;
+    return sorted.slice(from, to + 1);
+  }
+
+  async zrem(key: string, ...members: string[]): Promise<number> {
+    const entry = this.read(key);
+    if (entry?.kind !== "zset") return 0;
+    let removed = 0;
+    for (const m of members) {
+      if (entry.value.delete(m)) removed++;
+    }
+    return removed;
+  }
+
+  async zremrangebyscore(key: string, min: number | string, max: number | string): Promise<number> {
+    const entry = this.read(key);
+    if (entry?.kind !== "zset") return 0;
+    const lo = parseScoreBound(min, Number.NEGATIVE_INFINITY);
+    const hi = parseScoreBound(max, Number.POSITIVE_INFINITY);
+    let removed = 0;
+    for (const [member, score] of entry.value) {
+      if (score >= lo && score <= hi) {
+        entry.value.delete(member);
+        removed++;
+      }
+    }
+    return removed;
+  }
+
+  async ping(): Promise<string> {
+    return "PONG";
+  }
+
+  async quit(): Promise<string> {
+    return "OK";
+  }
 }
 
 function serializeArg(value: unknown): string {
@@ -94,7 +372,7 @@ export class MockSocketRedis {
   private readonly client: IoRedisLike;
 
   constructor(client?: IoRedisLike) {
-    this.client = client ?? createIoRedisMock();
+    this.client = client ?? new InMemoryRedis();
   }
 
   async get<T = string>(key: string): Promise<T | null> {

--- a/packages/scripts/cloud/admin/dev/cloud-api-dev.mjs
+++ b/packages/scripts/cloud/admin/dev/cloud-api-dev.mjs
@@ -244,6 +244,18 @@ async function main() {
         `ELIZA_CLOUD_AGENT_BASE_DOMAIN:${agentBaseDomainOverride}`,
       ]
     : [];
+  // Redis selection must reach the Worker's `c.env`, not just this launcher's
+  // process.env: routes build their client via `buildRedisClient(c.env)`, and
+  // wrangler `--local` only exposes vars passed through wrangler.toml/.dev.vars/
+  // `--var` — ambient process.env does NOT leak into `c.env`. Without this, the
+  // e2e env's `MOCK_REDIS=1` is invisible inside the Worker and any nonce-storage
+  // route (e.g. SIWE nonce/verify) returns 503 "Nonce storage unavailable". Most
+  // redis consumers (rate-limit) fail open, so this only surfaced once a spec
+  // drove the real SIWE login. Forward whichever redis selector is set.
+  const redisDevVars = ["MOCK_REDIS", "REDIS_URL"].flatMap((key) => {
+    const value = process.env[key];
+    return value ? ["--var", `${key}:${value}`] : [];
+  });
   const appDeployDevVars = [
     "APPS_DEPLOY_ENABLED",
     "APPS_DEPLOY_ALLOWED_ORG_IDS",
@@ -264,6 +276,7 @@ async function main() {
           apiPort,
           "--local",
           ...testModeVars,
+          ...redisDevVars,
           ...appDeployDevVars,
         ];
 

--- a/packages/test/cloud-e2e/README.md
+++ b/packages/test/cloud-e2e/README.md
@@ -43,10 +43,20 @@ The same flow is available as a dev/CI gate: `bun run cloud:login:test-wallet`
 (defaults to `https://api.elizacloud.ai`; pass `--base <url>` for a local stack).
 It exits non-zero if login or the authenticated probe fails.
 
+**The `seededUser` fixture now uses this real path for every spec.** Instead of
+inserting rows directly, it calls `loginAsSeededUser(stack.urls.api)`, which runs
+the genuine SIWE handshake and then elevates the fresh wallet account to the
+suite's privileged baseline (admin role, funded org, known verified email) via a
+direct DB update — exactly the end-state `seedTestUser` produced. So every spec
+that consumes `seededUser` authenticates with a credential the real login flow
+minted, with no other changes. `seedTestUser` is kept for specs that need extra
+secondary identities (attacker / other-user / end-user).
+
 ## Specs
 
 | File                          | Covers                                                                        |
 | ----------------------------- | ----------------------------------------------------------------------------- |
+| `tests/siwe-login.spec.ts`    | real nonce → sign → verify mints a usable key; forged sig 401s; re-login is idempotent; fixture identity is real-login-minted |
 | `tests/dashboard.spec.ts`     | seeded user reaches dashboard with test-auth session, localStorage writable   |
 | `tests/provision.spec.ts`     | create agent → cron tick → sandbox `running`, control-plane sees the sandbox  |
 | `tests/deprovision.spec.ts`   | DELETE agent → async `agent_delete` job → polls to `deleted` / 404            |

--- a/packages/test/cloud-e2e/src/helpers/test-fixtures.ts
+++ b/packages/test/cloud-e2e/src/helpers/test-fixtures.ts
@@ -1,19 +1,24 @@
 /**
  * Playwright test extension wiring the cloud stack as a worker-scoped fixture.
  *
- * One stack boot per worker. Per-test we seed a fresh user + inject the
- * playwright-test-session cookie before the page navigates.
+ * One stack boot per worker. Per-test the `seededUser` identity is minted by the
+ * REAL SIWE login handshake against the booted cloud-api (nonce → sign → verify
+ * → find-or-create wallet account), then elevated to the suite's privileged
+ * baseline (admin + funded org). So every spec authenticates with a credential
+ * the genuine login path produced — not a direct DB-inserted key. We then inject
+ * the playwright-test-session cookie for that identity before the page navigates.
  */
 
 import crypto from "node:crypto";
 import { test as base, expect, type Page } from "@playwright/test";
 import { PLAYWRIGHT_TEST_AUTH_SECRET } from "../fixtures/env";
-import { type SeededUser, seedTestUser } from "../fixtures/seed";
+import type { SeededUser } from "../fixtures/seed";
 import {
   type StackHandle,
   type StartCloudStackOptions,
   startCloudStack,
 } from "../fixtures/stack";
+import { loginAsSeededUser } from "./wallet-login";
 
 function buildPlaywrightSessionToken(
   userId: string,
@@ -57,9 +62,11 @@ export const test = base.extend<CloudTestFixtures, CloudStackFixtures>({
     { scope: "worker", timeout: 240_000 },
   ],
 
-  seededUser: async ({ stack: _stack }, use) => {
-    // _stack ensures DATABASE_URL pointed at PGlite is live before we seed.
-    const user = await seedTestUser();
+  seededUser: async ({ stack }, use) => {
+    // Drive the real login path against the booted cloud-api, then elevate to
+    // the privileged baseline. `stack` also guarantees DATABASE_URL is pointed
+    // at the live PGlite bridge the elevation writes to.
+    const user = await loginAsSeededUser(stack.urls.api);
     await use(user);
   },
 

--- a/packages/test/cloud-e2e/src/helpers/wallet-login.ts
+++ b/packages/test/cloud-e2e/src/helpers/wallet-login.ts
@@ -44,3 +44,68 @@ export function asSeededUser(login: SiweTestLoginResult): SeededUser {
     apiKey: login.apiKey,
   };
 }
+
+/**
+ * Privileged baseline the cloud-e2e suite assumes for its primary identity:
+ * an `admin` of a funded org with a known, verified email. `seedTestUser`
+ * produced exactly this end-state by inserting rows directly; here we instead
+ * reach it through the REAL login path and then elevate.
+ */
+const SEEDED_BASELINE_CREDIT_BALANCE = "1000.000000";
+const SEEDED_BASELINE_ROLE = "admin";
+
+/**
+ * Drive the genuine SIWE handshake and return a `SeededUser` that is a drop-in
+ * replacement for `seedTestUser()`.
+ *
+ * The API key, user, and organization are all minted by the REAL login flow
+ * (nonce → sign → verify → find-or-create wallet account). The only thing we
+ * add on top is the privileged baseline the suite's specs depend on — admin
+ * role, a funded credit balance, and a known verified email — applied with a
+ * direct DB write, exactly as `seedTestUser` did. So every spec that consumes
+ * the `seededUser` fixture now authenticates with a credential produced by the
+ * real login path, while its role/credit assumptions stay intact.
+ *
+ * The caller must have `DATABASE_URL` pointed at the running PGlite bridge (the
+ * cloud-e2e `stack` fixture guarantees this), since the elevation writes to the
+ * same DB the booted worker just created the account in.
+ */
+export async function loginAsSeededUser(
+  baseUrl: string,
+  privateKey?: `0x${string}`,
+): Promise<SeededUser> {
+  const login = await siweTestLogin({ baseUrl, privateKey });
+
+  const normalizedAddress = login.address.toLowerCase();
+  const email = `${normalizedAddress}@e2e.test`;
+  const name = `wallet-${normalizedAddress.slice(2, 10)}`;
+
+  // Reuse the cloud-shared repositories (same DB connection + drizzle instance)
+  // so we don't reimplement schema knowledge or risk a duplicate drizzle copy.
+  const { usersRepository } = await import(
+    "@elizaos/cloud-shared/db/repositories/users"
+  );
+  const { organizationsRepository } = await import(
+    "@elizaos/cloud-shared/db/repositories/organizations"
+  );
+
+  await usersRepository.update(login.userId, {
+    email,
+    email_verified: true,
+    name,
+    role: SEEDED_BASELINE_ROLE,
+  });
+
+  await organizationsRepository.update(login.organizationId, {
+    credit_balance: SEEDED_BASELINE_CREDIT_BALANCE,
+    billing_email: email,
+  });
+
+  return {
+    userId: login.userId,
+    organizationId: login.organizationId,
+    stewardUserId: `wallet:evm:${normalizedAddress}`,
+    email,
+    apiKey: login.apiKey,
+  };
+}

--- a/packages/test/cloud-e2e/tests/siwe-login.spec.ts
+++ b/packages/test/cloud-e2e/tests/siwe-login.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test } from "../src/helpers/test-fixtures";
+import { loginWithTestWallet } from "../src/helpers/wallet-login";
+
+/**
+ * Proves the REAL wallet sign-in path works end-to-end against the booted
+ * cloud-api — the gap `seedTestUser` (direct DB insert) never covered.
+ *
+ * Every assertion runs the genuine EIP-4361 handshake: `GET /api/auth/siwe/nonce`
+ * → build + sign the message with a throwaway viem wallet → `POST
+ * /api/auth/siwe/verify`. The server re-validates signature + nonce + domain via
+ * the same `validateAndConsumeSIWE` production uses, so a green run here means the
+ * login crypto, nonce single-use, and find-or-create wallet account all work.
+ */
+test.describe("SIWE wallet login (real handshake)", () => {
+  const BALANCE = "/api/v1/credits/balance";
+
+  test("nonce → sign → verify mints a real API key for a fresh free account", async ({
+    stack,
+  }) => {
+    const login = await loginWithTestWallet(stack.urls.api);
+
+    expect(login.apiKey, "verify must return a real API key").toMatch(
+      /^eliza_/,
+    );
+    expect(login.address).toMatch(/^0x[0-9a-fA-F]{40}$/);
+    expect(login.userId, "login must resolve a user id").toBeTruthy();
+    expect(
+      login.organizationId,
+      "login must resolve an organization id",
+    ).toBeTruthy();
+    expect(
+      login.isNewAccount,
+      "a fresh throwaway wallet must create a new account",
+    ).toBe(true);
+
+    // The credential the login minted authorizes a real authed request — this
+    // is the whole point: the key is usable, not a dead string.
+    const res = await fetch(`${stack.urls.api}${BALANCE}`, {
+      headers: { Authorization: `Bearer ${login.apiKey}` },
+    });
+    expect(
+      res.status,
+      `authed balance probe with the minted key: ${res.status}: ${await res.clone().text()}`,
+    ).toBe(200);
+  });
+
+  test("a present-but-forged signature is rejected (no key issued)", async ({
+    stack,
+  }) => {
+    const res = await fetch(`${stack.urls.api}/api/auth/siwe/verify`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        message: "I am definitely not a valid EIP-4361 message",
+        signature: "0xdeadbeef",
+      }),
+    });
+    expect(
+      res.status,
+      `forged verify must be rejected, got ${res.status}: ${await res.clone().text()}`,
+    ).toBe(401);
+  });
+
+  test("signing in again with the same wallet returns the same account", async ({
+    stack,
+  }) => {
+    const first = await loginWithTestWallet(stack.urls.api);
+    // Reuse the first login's private key → the find-or-create path must return
+    // the existing account (a real second login, not a new signup).
+    const second = await loginWithTestWallet(stack.urls.api, first.privateKey);
+
+    expect(second.address).toBe(first.address);
+    expect(second.userId).toBe(first.userId);
+    expect(second.organizationId).toBe(first.organizationId);
+    expect(first.isNewAccount).toBe(true);
+    expect(
+      second.isNewAccount,
+      "the second sign-in must resolve the existing account, not create one",
+    ).toBe(false);
+  });
+
+  test("the seededUser fixture identity is itself minted by the real login path", async ({
+    stack,
+    seededUser,
+  }) => {
+    // seededUser now comes from loginAsSeededUser (real handshake → elevate).
+    // Its key must authorize the admin-scoped members endpoint and resolve to
+    // the elevated identity.
+    const res = await fetch(`${stack.urls.api}/api/organizations/members`, {
+      headers: { Authorization: `Bearer ${seededUser.apiKey}` },
+    });
+    expect(
+      res.status,
+      `members with fixture key: ${res.status}: ${await res.clone().text()}`,
+    ).toBe(200);
+    const body = (await res.json()) as {
+      data?: Array<{ id: string; email: string | null; role: string | null }>;
+    };
+    const self = body.data?.find((m) => m.id === seededUser.userId);
+    expect(self, "fixture identity must appear in its org").toBeTruthy();
+    expect(self?.role).toBe("admin");
+    expect(self?.email).toBe(seededUser.email);
+  });
+});


### PR DESCRIPTION
## What

Follow-up to **#10069** (which merged the headless SIWE helper). That PR added the helper but nothing drove it in e2e, and `seedTestUser` still inserted rows directly — so no spec actually proved the real wallet sign-in path. **This PR wires the real login into every cloud-e2e spec** and fixes two latent worker-env bugs that only the real login path exposes.

## How

### Every spec now authenticates via the real SIWE handshake

The cloud-e2e `seededUser` fixture (`src/helpers/test-fixtures.ts`) — the single auth chokepoint consumed by 25 of 29 specs — now calls **`loginAsSeededUser(stack.urls.api)`** (`src/helpers/wallet-login.ts`) instead of inserting rows. It runs the genuine `nonce → sign → verify` handshake against the booted cloud-api, then elevates the fresh wallet account to the suite's privileged baseline (admin role, funded org, known verified email) — the exact end-state `seedTestUser` produced. So **every spec authenticates with a credential the real login flow minted**, with no other per-spec change. `seedTestUser` is kept for specs that need extra secondary identities (attacker / other-user / end-user).

New `tests/siwe-login.spec.ts` directly proves the handshake: it mints a usable key + authorizes a real request, forged signatures 401, re-login is idempotent (same wallet → same account, `isNewAccount:false`), and the fixture identity is itself real-login-minted (admin + correct email via `/api/organizations/members`).

### Two pre-existing worker-env bugs this surfaced

Driving real login through the wrangler worker the cloud-e2e stack boots exposed two latent bugs (the old direct-insert path never hit a redis-strict route):

1. **`MOCK_REDIS` never reached the Worker's `c.env`.** Routes build redis via `buildRedisClient(c.env)`, and wrangler `--local` only exposes vars via wrangler.toml/.dev.vars/`--var` — ambient `process.env` does not leak in. So `MOCK_REDIS=1` was invisible inside the Worker and SIWE nonce/verify returned **503 "Nonce storage unavailable."** `cloud-api-dev.mjs` now forwards `MOCK_REDIS`/`REDIS_URL` via `--var` in test mode. (Most redis consumers fail open, which is why only the real login exposed this.)
2. **`MockSocketRedis` couldn't run in workerd.** It used `ioredis-mock`, which resolves to its **browser** build under wrangler/esbuild and throws `ReferenceError: window is not defined` (→ 500). Replaced with a dependency-free, process-global in-memory store (`packages/cloud/shared/src/lib/cache/mock-redis.ts`) that runs identically in Bun and workerd and preserves the shared-store semantics SIWE's two-request nonce needs (nonce written by one request, consumed by the next).

## Files

| File | Purpose |
|---|---|
| `packages/test/cloud-e2e/src/helpers/test-fixtures.ts` | `seededUser` now minted via the real handshake |
| `packages/test/cloud-e2e/src/helpers/wallet-login.ts` | adds `loginAsSeededUser` (real login → privileged baseline) |
| `packages/test/cloud-e2e/tests/siwe-login.spec.ts` | dedicated end-to-end proof of the real login path |
| `packages/scripts/cloud/admin/dev/cloud-api-dev.mjs` | forward `MOCK_REDIS`/`REDIS_URL` into the Worker's `c.env` in test mode |
| `packages/cloud/shared/src/lib/cache/mock-redis.ts` | dependency-free in-memory redis (runs in Bun **and** workerd) |
| `packages/test/cloud-e2e/README.md` | documents the real-login fixture path |

## Verification (local)

- **Full cloud-e2e suite** — `bun run --cwd packages/test/cloud-e2e test` → **55 passed, 2 failed, 3 skipped.** SIWE `nonce`/`verify` now return **200** (were 503/500); `siwe-login` + `auth-errors` + `steward-session` = 15/15; provisioning / pairing / billing / skill / suspend-resume / etc. all pass through the real-login `seededUser`.
  - 3 skipped = secret-gated real-LLM / real-deploy specs (skip loudly without `CEREBRAS_API_KEY` / deploy creds) — expected.
  - **2 failed = a pre-existing, unrelated frontend bug, not auth.** Both (`dashboard` deploy + `frontend-monetization`) crash at render with the React error boundary `"usePageHeader must be used within a PageHeaderProvider"` (from `packages/ui/src/cloud-ui/components/layout/`). The pages authenticate and render, then crash in a React provider — independent of how the user logged in, and in a package this PR doesn't touch. Tracked separately.
- **cloud-shared suite** — `bun run --cwd packages/cloud/shared test` → **1850 pass / 31 skip / 0 fail** (the mock rewrite preserves ioredis-mock semantics; `redis-factory-mock` + `cache-scan-pagination` green).
- Targeted `typecheck` (cloud-shared + cloud-e2e) and `biome check` on all changed files: clean.

Builds on #10069. 🤖 Generated with [Claude Code](https://claude.com/claude-code)
