### PR TITLE
fix(build): skip checks during declaration emit

### DIFF
--- a/.github/issue-evidence/10078-declaration-emit-no-check.md
+++ b/.github/issue-evidence/10078-declaration-emit-no-check.md
@@ -1,0 +1,127 @@
+# Issue #10078 - declaration emit without second typecheck
+
+## Scope
+
+Partial #10078 build-performance slice. Remaining declaration-emission build
+paths now pass `--noCheck`, so `build` emits `.d.ts` files without re-running a
+full TypeScript semantic check. Type safety remains owned by the separate
+`typecheck`/`tsgo --noEmit` lanes.
+
+Changed emit paths:
+
+- `packages/core/build.ts`
+- `packages/elizaos/templates/plugin/build.ts`
+- `plugins/plugin-streaming/package.json`
+- `plugins/plugin-wechat/package.json`
+
+## Evidence
+
+### Regression Guard
+
+Command:
+
+```bash
+bun test packages/scripts/__tests__/declaration-emit-no-check.test.ts
+```
+
+Result:
+
+```text
+1 pass
+0 fail
+```
+
+The guard scans tracked `packages/` and `plugins/` build scripts/package build
+commands for `tsc --emitDeclarationOnly` without `--noCheck`.
+
+### Formatting
+
+Command:
+
+```bash
+bun run biome check packages/scripts/__tests__/declaration-emit-no-check.test.ts packages/core/build.ts packages/elizaos/templates/plugin/build.ts plugins/plugin-wechat/package.json plugins/plugin-streaming/package.json
+```
+
+Result:
+
+```text
+Checked 4 files in 1291ms. No fixes applied.
+```
+
+### Affected Builds and Tests
+
+Command:
+
+```bash
+bun run --cwd plugins/plugin-streaming build
+```
+
+Result: passed. The logged command includes
+`tsc --declaration --emitDeclarationOnly --noEmit false --noCheck`.
+
+Command:
+
+```bash
+bun run --cwd plugins/plugin-wechat build
+```
+
+Result: passed. The logged command includes
+`tsc --declaration --emitDeclarationOnly --noEmit false --noCheck --outDir dist --rootDir src`.
+
+Command:
+
+```bash
+bun run --cwd packages/elizaos test
+```
+
+Result:
+
+```text
+7 passed
+46 passed
+```
+
+Command:
+
+```bash
+bun run --cwd packages/elizaos build
+```
+
+Result: passed. No tracked generated manifest/template diff remained.
+
+### Repository Check
+
+Command:
+
+```bash
+git diff --check
+```
+
+Result: pass.
+
+### Local Core Build Limit
+
+Command:
+
+```bash
+bun run --cwd packages/core build
+```
+
+Result: blocked during Bun bundling by the existing local Windows dependency
+store issue in `drizzle-orm`, before this change's declaration emit path is the
+meaningful failure point. Representative errors:
+
+```text
+Could not resolve: "./sql/index.js"
+Could not resolve: "./subquery.js"
+Could not resolve: "./table.js"
+```
+
+## Evidence Type Notes
+
+- Backend logs: N/A, build-command configuration only.
+- Frontend logs: N/A, no frontend runtime path changed.
+- Screenshots: N/A, no UI changed.
+- Video: N/A, no user flow changed.
+- Real-LLM trajectory: N/A, build orchestration/performance only.
+- Audio: N/A, no voice path changed.

--- a/packages/core/build.ts
+++ b/packages/core/build.ts
@@ -339,7 +339,7 @@ export async function generateDts(
 	console.log("Generating TypeScript declarations...");
 	try {
 		// Use incremental compilation for faster subsequent builds
-		await $`${resolveTscBin()} --emitDeclarationOnly --project ${tsconfigPath} --composite false --incremental false --types node,bun`;
+		await $`${resolveTscBin()} --emitDeclarationOnly --noCheck --project ${tsconfigPath} --composite false --incremental false --types node,bun`;
 		console.log(
 			`✓ TypeScript declarations generated successfully (${timer.elapsed()}ms)`,
 		);

--- a/packages/elizaos/templates/plugin/build.ts
+++ b/packages/elizaos/templates/plugin/build.ts
@@ -67,7 +67,7 @@ async function build() {
 
 			(async () => {
 				console.log("📝 Generating TypeScript declarations...");
-				await $`tsc --emitDeclarationOnly --incremental --project ./tsconfig.build.json`.quiet();
+				await $`tsc --emitDeclarationOnly --incremental --noCheck --project ./tsconfig.build.json`.quiet();
 				console.log("✓ TypeScript declarations generated");
 				return { success: true };
 			})(),

--- a/packages/scripts/__tests__/declaration-emit-no-check.test.ts
+++ b/packages/scripts/__tests__/declaration-emit-no-check.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "..",
+);
+
+function trackedBuildFiles(): string[] {
+  return execFileSync("git", ["ls-files", "packages", "plugins"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    maxBuffer: 50 * 1024 * 1024,
+  })
+    .split(/\r?\n/)
+    .filter((file) =>
+      /(?:^|\/)(?:package\.json|build\.(?:ts|mjs))$/.test(file),
+    );
+}
+
+function hasDeclarationEmit(command: string): boolean {
+  return /\btsc\b/.test(command) && command.includes("--emitDeclarationOnly");
+}
+
+describe("declaration emit build commands", () => {
+  test("use --noCheck so build emits declarations without a second typecheck", () => {
+    const missingNoCheck: string[] = [];
+
+    for (const file of trackedBuildFiles()) {
+      const text = readFileSync(path.join(repoRoot, file), "utf8");
+
+      if (file.endsWith("package.json")) {
+        const manifest = JSON.parse(text);
+        const buildScript = manifest.scripts?.build;
+        if (
+          typeof buildScript === "string" &&
+          hasDeclarationEmit(buildScript) &&
+          !buildScript.includes("--noCheck")
+        ) {
+          missingNoCheck.push(`${file} scripts.build`);
+        }
+        continue;
+      }
+
+      if (
+        text.includes("--emitDeclarationOnly") &&
+        !text.includes("--noCheck")
+      ) {
+        missingNoCheck.push(file);
+      }
+    }
+
+    expect(missingNoCheck).toEqual([]);
+  });
+});

--- a/plugins/plugin-streaming/package.json
+++ b/plugins/plugin-streaming/package.json
@@ -47,7 +47,7 @@
     "vitest": "^4.0.0"
   },
   "scripts": {
-    "build": "tsup && tsc --declaration --emitDeclarationOnly --noEmit false",
+    "build": "tsup && tsc --declaration --emitDeclarationOnly --noEmit false --noCheck",
     "dev": "tsup --watch",
     "test": "vitest run",
     "lint": "bunx @biomejs/biome check --write --unsafe src",

--- a/plugins/plugin-wechat/package.json
+++ b/plugins/plugin-wechat/package.json
@@ -50,7 +50,7 @@
     }
   },
   "scripts": {
-    "build": "tsup --config tsup.config.ts && tsc --declaration --emitDeclarationOnly --noEmit false --outDir dist --rootDir src",
+    "build": "tsup --config tsup.config.ts && tsc --declaration --emitDeclarationOnly --noEmit false --noCheck --outDir dist --rootDir src",
     "check": "tsc --noEmit",
     "test": "vitest run --config ./vitest.config.ts",
     "test:watch": "vitest --config ./vitest.config.ts",


### PR DESCRIPTION
## Summary
- add `--noCheck` to the remaining declaration emit build paths in core, the plugin template, plugin-streaming, and plugin-wechat
- keep semantic checking in the dedicated typecheck lanes instead of repeating it during build declaration emit
- add a tracked-file guard that fails if package/plugin build scripts reintroduce `tsc --emitDeclarationOnly` without `--noCheck`

## Evidence
- Evidence file: `.github/issue-evidence/10078-declaration-emit-no-check.md`
- `bun test packages/scripts/__tests__/declaration-emit-no-check.test.ts` passed: 1 pass, 0 fail.
- `bun run biome check packages/scripts/__tests__/declaration-emit-no-check.test.ts packages/core/build.ts packages/elizaos/templates/plugin/build.ts plugins/plugin-wechat/package.json plugins/plugin-streaming/package.json` passed.
- `bun run --cwd plugins/plugin-streaming build` passed.
- `bun run --cwd plugins/plugin-wechat build` passed.
- `bun run --cwd packages/elizaos test` passed: 7 files, 46 tests.
- `bun run --cwd packages/elizaos build` passed and left no tracked generated diff.
- `git diff origin/develop...HEAD --check` passed.

## Known local validation limit
- `bun run --cwd packages/core build` is still blocked in this Windows worktree during Bun bundling by the existing local `drizzle-orm` package-store issue (`Could not resolve ./sql/index.js`, `./subquery.js`, `./table.js`, etc.).

Refs #10078