### PR TITLE
build(plugins): consolidate connector build.ts onto shared buildPlugin driver (#10078)

### DIFF
--- a/plugins/plugin-build.ts
+++ b/plugins/plugin-build.ts
@@ -60,6 +60,19 @@ export interface BuildPluginConfig {
   /** tsconfig project passed to `tsc` for declaration emit. */
   dtsProject?: string;
   /**
+   * Pass `--emitDeclarationOnly` to the declaration `tsc` invocation (for
+   * plugins whose `dtsProject` tsconfig would otherwise also emit JS). Default:
+   * false. */
+  dtsEmitDeclarationOnly?: boolean;
+  /**
+   * After declaration emit, rewrite bare relative specifiers in the emitted
+   * files to explicit NodeNext-resolvable paths (`./x` -> `./x.js`,
+   * `./dir` -> `./dir/index.js`). Needed by single-entrypoint connector plugins
+   * that ship a bundled `dist/index.js` but a per-file `.d.ts` tree whose
+   * re-exports would otherwise stay bare and fail to resolve for NodeNext
+   * consumers. Default: false. */
+  rewriteDistImports?: boolean;
+  /**
    * Tolerate a failed `tsc` declaration emit (warn + continue with JS-only
    * outputs) instead of aborting. Mirrors the per-package fallback some plugins
    * carried; default false (fail loud).
@@ -75,6 +88,14 @@ const RM_RECURSIVE = resolve(
   "packages",
   "scripts",
   "rm-path-recursive.mjs",
+);
+
+const REWRITE_DIST_IMPORTS = resolve(
+  import.meta.dir,
+  "..",
+  "packages",
+  "scripts",
+  "rewrite-dist-relative-imports-node-esm.mjs",
 );
 
 export async function buildPlugin(config: BuildPluginConfig): Promise<void> {
@@ -130,16 +151,20 @@ export async function buildPlugin(config: BuildPluginConfig): Promise<void> {
   if (config.dtsProject) {
     console.log("📝 Generating TypeScript declarations…");
     const project = config.dtsProject;
+    const emitDeclOnly = config.dtsEmitDeclarationOnly ?? false;
+    const run = emitDeclOnly
+      ? () => Bun.$`tsc --project ${project} --emitDeclarationOnly --noCheck`
+      : () => Bun.$`tsc --project ${project} --noCheck`;
     if (config.dtsTolerant) {
       try {
-        await Bun.$`tsc --project ${project} --noCheck`;
+        await run();
       } catch {
         console.warn(
           "Warning: TypeScript declaration generation failed; continuing with bundled JS outputs only.",
         );
       }
     } else {
-      await Bun.$`tsc --project ${project} --noCheck`;
+      await run();
     }
   }
 
@@ -147,6 +172,11 @@ export async function buildPlugin(config: BuildPluginConfig): Promise<void> {
     const target = join(distDir, shim.path);
     await mkdir(dirname(target), { recursive: true });
     await writeFile(target, shim.content, "utf8");
+  }
+
+  if (config.rewriteDistImports) {
+    console.log("🔧 Rewriting dist relative imports for NodeNext…");
+    await Bun.$`node ${REWRITE_DIST_IMPORTS}`;
   }
 
   console.log(

--- a/plugins/plugin-coding-tools/build.ts
+++ b/plugins/plugin-coding-tools/build.ts
@@ -1,70 +1,29 @@
-import { spawnSync } from "node:child_process";
-import { join } from "node:path";
-import { fileURLToPath } from "node:url";
-import { build } from "bun";
+#!/usr/bin/env bun
+/**
+ * Build script for @elizaos/plugin-coding-tools (Node). Orchestration lives in the shared
+ * driver (plugins/plugin-build.ts); this lists only what differs.
+ */
+import { buildPlugin } from "../plugin-build";
 
-const distDir = join(import.meta.dir, "dist");
-const RM_RECURSIVE_SCRIPT = fileURLToPath(
-  new URL("../../packages/scripts/rm-path-recursive.mjs", import.meta.url),
-);
-
-function rmRecursive(target: string) {
-  const result = spawnSync(process.execPath, [RM_RECURSIVE_SCRIPT, target], {
-    stdio: "inherit",
-  });
-  if (result.error) throw result.error;
-  if (result.status !== 0) {
-    throw new Error(
-      `rm-path-recursive failed for ${target} with status ${result.status}`,
-    );
-  }
-}
-
-try {
-  rmRecursive(distDir);
-} catch {
-  // ignore
-}
-
-console.log("Building @elizaos/plugin-coding-tools...");
-
-await build({
-  entrypoints: ["./src/index.ts"],
-  outdir: "./dist",
-  target: "node",
-  format: "esm",
-  sourcemap: "external",
-  minify: false,
-  external: [
+await buildPlugin({
+  name: "@elizaos/plugin-coding-tools",
+  clean: true,
+  externals: [
     "@elizaos/core",
     "@elizaos/shared",
     "@vscode/ripgrep",
     "phonemizer",
     "figlet",
   ],
-});
-
-console.log("Build complete.");
-
-const proc = Bun.spawn(
-  [
-    "bunx",
-    "tsc",
-    "-p",
-    "tsconfig.build.json",
-    "--emitDeclarationOnly",
-    "--noCheck",
+  targets: [
+    {
+      label: "Node",
+      entry: "./src/index.ts",
+      outSubdir: "",
+      target: "node",
+      format: "esm",
+    },
   ],
-  {
-    cwd: import.meta.dir,
-    stdio: ["inherit", "inherit", "inherit"],
-  },
-);
-
-await proc.exited;
-
-if (proc.exitCode !== 0) {
-  process.exit(proc.exitCode ?? 1);
-}
-
-console.log("Types generated.");
+  dtsProject: "tsconfig.build.json",
+  dtsEmitDeclarationOnly: true,
+});

--- a/plugins/plugin-discord/build.ts
+++ b/plugins/plugin-discord/build.ts
@@ -1,84 +1,24 @@
 #!/usr/bin/env bun
+/**
+ * Build script for @elizaos/plugin-discord (Node). Orchestration lives in the
+ * shared driver; this lists only what differs. Single bundled `dist/index.js`
+ * plus a per-file `.d.ts` tree, whose bare relative re-exports are rewritten to
+ * NodeNext-resolvable paths.
+ */
+import { buildPlugin } from "../plugin-build";
 
-import { spawnSync } from "node:child_process";
-import { fileURLToPath } from "node:url";
-import { build } from "bun";
-
-const RM_RECURSIVE_SCRIPT = fileURLToPath(
-	new URL("../../packages/scripts/rm-path-recursive.mjs", import.meta.url),
-);
-
-function rmRecursive(target: string) {
-	const result = spawnSync(process.execPath, [RM_RECURSIVE_SCRIPT, target], {
-		stdio: "inherit",
-	});
-	if (result.error) throw result.error;
-	if (result.status !== 0) {
-		throw new Error(
-			`rm-path-recursive failed for ${target} with status ${result.status}`,
-		);
-	}
-}
-
-try {
-	rmRecursive("dist");
-} catch {
-	// ignore
-}
-
-const pkg = await Bun.file("./package.json").json();
-const external = [
-	...Object.keys(pkg.dependencies ?? {}),
-	...Object.keys(pkg.peerDependencies ?? {}),
-];
-
-console.log("Building TypeScript plugin...");
-
-const result = await build({
-	entrypoints: ["index.ts"],
-	outdir: "dist",
-	target: "node",
-	format: "esm",
-	sourcemap: "external",
-	minify: false,
-	external,
+await buildPlugin({
+	name: "@elizaos/plugin-discord",
+	clean: true,
+	targets: [
+		{
+			label: "Node",
+			entry: "index.ts",
+			outSubdir: "",
+			target: "node",
+			format: "esm",
+		},
+	],
+	dtsProject: "tsconfig.build.json",
+	rewriteDistImports: true,
 });
-
-if (!result.success) {
-	console.error("Build failed:");
-	for (const log of result.logs) {
-		console.error(log);
-	}
-	process.exit(1);
-}
-
-const proc = Bun.spawn(
-	["bunx", "tsc", "--noCheck", "-p", "tsconfig.build.json"],
-	{
-		stdio: ["inherit", "inherit", "inherit"],
-	},
-);
-
-await proc.exited;
-
-if (proc.exitCode !== 0) {
-	process.exit(proc.exitCode ?? 1);
-}
-
-// Rewrite bare relative specifiers in the emitted .d.ts files to explicit
-// NodeNext-resolvable paths (`./x` -> `./x.js`, `./dir` -> `./dir/index.js`).
-// The single-entrypoint bundle emits one dist/index.js but per-file .d.ts
-// declarations, whose re-exports otherwise stay bare and fail to resolve for
-// NodeNext consumers (e.g. plugin-personal-assistant importing the CDP helpers).
-const rewrite = Bun.spawn(
-	["node", "../../packages/scripts/rewrite-dist-relative-imports-node-esm.mjs"],
-	{ stdio: ["inherit", "inherit", "inherit"] },
-);
-
-await rewrite.exited;
-
-if (rewrite.exitCode !== 0) {
-	process.exit(rewrite.exitCode ?? 1);
-}
-
-console.log("Build complete!");

--- a/plugins/plugin-instagram/build.ts
+++ b/plugins/plugin-instagram/build.ts
@@ -1,21 +1,16 @@
-import { build } from "bun";
+#!/usr/bin/env bun
+/**
+ * Build script for @elizaos/plugin-instagram (Node). Orchestration lives in the shared
+ * driver (plugins/plugin-build.ts); this lists only what differs.
+ */
+import { buildPlugin } from "../plugin-build";
 
-await build({
-  entrypoints: ["./src/index.ts"],
-  outdir: "./dist",
-  target: "node",
-  format: "esm",
-  minify: false,
-  sourcemap: "external",
-  external: ["@elizaos/core"],
+await buildPlugin({
+  name: "@elizaos/plugin-instagram",
+  externals: ["@elizaos/core"],
+  targets: [
+    { label: "Node", entry: "./src/index.ts", outSubdir: "", target: "node", format: "esm" },
+  ],
+  dtsProject: "tsconfig.build.json",
+  dtsEmitDeclarationOnly: true,
 });
-
-// Generate type declarations
-const proc = Bun.spawn(["tsc", "--emitDeclarationOnly", "--noCheck", "-p", "tsconfig.build.json"], {
-  stdout: "inherit",
-  stderr: "inherit",
-});
-
-await proc.exited;
-
-console.log("Build completed successfully");

--- a/plugins/plugin-matrix/build.ts
+++ b/plugins/plugin-matrix/build.ts
@@ -1,17 +1,16 @@
-import { build } from "bun";
+#!/usr/bin/env bun
+/**
+ * Build script for @elizaos/plugin-matrix (Node). Orchestration lives in the shared
+ * driver (plugins/plugin-build.ts); this lists only what differs.
+ */
+import { buildPlugin } from "../plugin-build";
 
-await build({
-  entrypoints: ["./src/index.ts"],
-  outdir: "./dist",
-  target: "node",
-  format: "esm",
-  sourcemap: "external",
-  external: ["@elizaos/core", "matrix-js-sdk"],
+await buildPlugin({
+  name: "@elizaos/plugin-matrix",
+  externals: ["@elizaos/core", "matrix-js-sdk"],
+  targets: [
+    { label: "Node", entry: "./src/index.ts", outSubdir: "", target: "node", format: "esm" },
+  ],
+  dtsProject: "tsconfig.json",
+  dtsEmitDeclarationOnly: true,
 });
-
-// Also emit declarations with tsc
-import { spawnSync } from "node:child_process";
-
-spawnSync("bunx", ["tsc", "--emitDeclarationOnly", "--noCheck"], { stdio: "inherit" });
-
-console.log("Build complete");

--- a/plugins/plugin-native-filesystem/build.ts
+++ b/plugins/plugin-native-filesystem/build.ts
@@ -1,60 +1,23 @@
-import { spawnSync } from "node:child_process";
-import { join } from "node:path";
-import { fileURLToPath } from "node:url";
-import { build } from "bun";
+#!/usr/bin/env bun
+/**
+ * Build script for @elizaos/plugin-native-filesystem (Node). Orchestration lives in the shared
+ * driver (plugins/plugin-build.ts); this lists only what differs.
+ */
+import { buildPlugin } from "../plugin-build";
 
-const distDir = join(import.meta.dir, "dist");
-const RM_RECURSIVE_SCRIPT = fileURLToPath(
-	new URL("../../packages/scripts/rm-path-recursive.mjs", import.meta.url),
-);
-
-function rmRecursive(target: string) {
-	const result = spawnSync(process.execPath, [RM_RECURSIVE_SCRIPT, target], {
-		stdio: "inherit",
-	});
-	if (result.error) throw result.error;
-	if (result.status !== 0) {
-		throw new Error(
-			`rm-path-recursive failed for ${target} with status ${result.status}`,
-		);
-	}
-}
-
-try {
-	rmRecursive(distDir);
-} catch {
-	// ignore
-}
-
-console.log("Building @elizaos/plugin-native-filesystem...");
-
-await build({
-	entrypoints: ["./src/index.ts"],
-	outdir: "./dist",
-	target: "node",
-	format: "esm",
-	sourcemap: "external",
-	minify: false,
-	external: ["@elizaos/core", "@capacitor/filesystem", "zod"],
-});
-
-console.log("Build complete.");
-
-const proc = Bun.spawn(
-	[
-		"bunx",
-		"tsc",
-		"-p",
-		"tsconfig.build.json",
-		"--emitDeclarationOnly",
-		"--noCheck",
+await buildPlugin({
+	name: "@elizaos/plugin-native-filesystem",
+	clean: true,
+	externals: ["@elizaos/core", "@capacitor/filesystem", "zod"],
+	targets: [
+		{
+			label: "Node",
+			entry: "./src/index.ts",
+			outSubdir: "",
+			target: "node",
+			format: "esm",
+		},
 	],
-	{
-		cwd: import.meta.dir,
-		stdio: ["inherit", "inherit", "inherit"],
-	},
-);
-
-await proc.exited;
-
-console.log("Types generated.");
+	dtsProject: "tsconfig.build.json",
+	dtsEmitDeclarationOnly: true,
+});

--- a/plugins/plugin-native-filesystem/tsconfig.json
+++ b/plugins/plugin-native-filesystem/tsconfig.json
@@ -27,6 +27,7 @@
 	"exclude": [
 		"node_modules",
 		"dist",
+		"build.ts",
 		"**/__tests__/**",
 		"**/*.test.ts",
 		"**/*.test.tsx",

--- a/plugins/plugin-remote-desktop/build.ts
+++ b/plugins/plugin-remote-desktop/build.ts
@@ -1,72 +1,23 @@
-import { spawnSync } from "node:child_process";
-import { join } from "node:path";
-import { fileURLToPath } from "node:url";
-import { build } from "bun";
+#!/usr/bin/env bun
+/**
+ * Build script for @elizaos/plugin-remote-desktop (Node). Orchestration lives in the shared
+ * driver (plugins/plugin-build.ts); this lists only what differs.
+ */
+import { buildPlugin } from "../plugin-build";
 
-const distDir = join(import.meta.dir, "dist");
-const RM_RECURSIVE_SCRIPT = fileURLToPath(
-  new URL("../../packages/scripts/rm-path-recursive.mjs", import.meta.url),
-);
-
-function rmRecursive(target: string) {
-  const result = spawnSync(process.execPath, [RM_RECURSIVE_SCRIPT, target], {
-    stdio: "inherit",
-  });
-  if (result.error) throw result.error;
-  if (result.status !== 0) {
-    throw new Error(
-      `rm-path-recursive failed for ${target} with status ${result.status}`,
-    );
-  }
-}
-
-try {
-  rmRecursive(distDir);
-} catch {
-  // ignore
-}
-
-console.log("Building @elizaos/plugin-remote-desktop...");
-
-const result = await build({
-  entrypoints: ["./src/index.ts"],
-  outdir: "./dist",
-  target: "node",
-  format: "esm",
-  sourcemap: "external",
-  minify: false,
-  external: ["@elizaos/core"],
-});
-
-if (!result.success) {
-  for (const log of result.logs) {
-    console.error(log);
-  }
-  throw new Error("Bun bundle failed");
-}
-
-console.log("Build complete.");
-
-const proc = Bun.spawn(
-  [
-    "bunx",
-    "tsc",
-    "-p",
-    "tsconfig.build.json",
-    "--emitDeclarationOnly",
-    "--noCheck",
+await buildPlugin({
+  name: "@elizaos/plugin-remote-desktop",
+  clean: true,
+  externals: ["@elizaos/core"],
+  targets: [
+    {
+      label: "Node",
+      entry: "./src/index.ts",
+      outSubdir: "",
+      target: "node",
+      format: "esm",
+    },
   ],
-  {
-    cwd: import.meta.dir,
-    stdio: ["inherit", "inherit", "inherit"],
-  },
-);
-
-const exitCode = await proc.exited;
-if (exitCode !== 0) {
-  throw new Error(
-    `Type declaration generation failed with exit code ${exitCode}`,
-  );
-}
-
-console.log("Types generated.");
+  dtsProject: "tsconfig.build.json",
+  dtsEmitDeclarationOnly: true,
+});

--- a/plugins/plugin-shell/build.ts
+++ b/plugins/plugin-shell/build.ts
@@ -1,63 +1,15 @@
-import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { join } from "node:path";
-import { build } from "bun";
+#!/usr/bin/env bun
+/**
+ * Build script for @elizaos/plugin-shell (Node). Orchestration lives in the
+ * shared driver (plugins/plugin-build.ts); this lists only what differs.
+ */
+import { buildPlugin } from "../plugin-build";
 
-const distDir = join(import.meta.dir, "dist");
-const rmRecursiveScript = join(
-  import.meta.dir,
-  "..",
-  "..",
-  "packages",
-  "scripts",
-  "rm-path-recursive.mjs"
-);
-
-function rmRecursive(targetPath: string) {
-  const result = spawnSync(process.execPath, [rmRecursiveScript, targetPath], {
-    stdio: "inherit",
-  });
-  if (result.status !== 0) {
-    throw new Error(`failed to remove generated Shell build output ${targetPath}`);
-  }
-}
-
-try {
-  rmRecursive(distDir);
-} catch {
-  // ignore
-}
-
-console.log("Building TypeScript plugin...");
-
-await build({
-  entrypoints: ["./index.ts"],
-  outdir: "./dist",
-  target: "node",
-  format: "esm",
-  sourcemap: "external",
-  minify: false,
-  external: ["@elizaos/core", "@elizaos/shared", "cross-spawn", "zod", "@lydell/node-pty"],
+await buildPlugin({
+  name: "@elizaos/plugin-shell",
+  clean: true,
+  externals: ["@elizaos/core", "@elizaos/shared", "cross-spawn", "zod", "@lydell/node-pty"],
+  targets: [{ label: "Node", entry: "./index.ts", outSubdir: "", target: "node", format: "esm" }],
+  dtsProject: "tsconfig.build.json",
+  dtsEmitDeclarationOnly: true,
 });
-
-console.log("Build complete!");
-
-const proc = Bun.spawn(
-  ["bunx", "tsc", "-p", "tsconfig.build.json", "--emitDeclarationOnly", "--noCheck"],
-  {
-    cwd: import.meta.dir,
-    stdio: ["inherit", "inherit", "inherit"],
-  }
-);
-
-const exitCode = await proc.exited;
-
-if (exitCode !== 0) {
-  throw new Error(`Type declaration generation failed with exit code ${exitCode}`);
-}
-
-if (!existsSync(join(distDir, "index.d.ts"))) {
-  throw new Error("Type declaration generation did not emit dist/index.d.ts");
-}
-
-console.log("Types generated!");

--- a/plugins/plugin-shell/tsconfig.json
+++ b/plugins/plugin-shell/tsconfig.json
@@ -30,6 +30,7 @@
   "exclude": [
     "node_modules",
     "dist",
+    "build.ts",
     "**/__tests__/**",
     "**/*.test.ts",
     "**/*.test.tsx",

--- a/plugins/plugin-signal/build.ts
+++ b/plugins/plugin-signal/build.ts
@@ -1,29 +1,15 @@
-import { build } from "bun";
+#!/usr/bin/env bun
+/**
+ * Build script for @elizaos/plugin-signal (Node). Orchestration lives in the shared
+ * driver (plugins/plugin-build.ts); this lists only what differs.
+ */
+import { buildPlugin } from "../plugin-build";
 
-await build({
-  entrypoints: ["./src/index.ts"],
-  outdir: "./dist",
-  target: "node",
-  format: "esm",
-  splitting: false,
-  sourcemap: "external",
-  minify: false,
-  external: ["@elizaos/core", "zod"],
+await buildPlugin({
+  name: "@elizaos/plugin-signal",
+  externals: ["@elizaos/core", "zod"],
+  targets: [
+    { label: "Node", entry: "./src/index.ts", outSubdir: "", target: "node", format: "esm" },
+  ],
+  dtsProject: "tsconfig.build.json",
 });
-
-// Emit declarations without semantic type-checking, matching this package's
-// own `typecheck: "skipped for release"` script and the @elizaos/skills build
-// (`tsc --noCheck`). The release d.ts emit must not hard-fail on cross-package
-// type resolution (e.g. when @elizaos/core is consumed at a different version).
-const proc = Bun.spawn(["bunx", "tsc", "-p", "tsconfig.build.json", "--noCheck"], {
-  cwd: import.meta.dir,
-  stdout: "inherit",
-  stderr: "inherit",
-});
-
-const code = await proc.exited;
-if (code !== 0) {
-  process.exit(code);
-}
-
-console.log("Build complete!");

--- a/plugins/plugin-slack/build.ts
+++ b/plugins/plugin-slack/build.ts
@@ -1,29 +1,21 @@
-import { build } from "bun";
+#!/usr/bin/env bun
+/**
+ * Build script for @elizaos/plugin-slack (Node). Orchestration lives in the shared
+ * driver (plugins/plugin-build.ts); this lists only what differs.
+ */
+import { buildPlugin } from "../plugin-build";
 
-await build({
-  entrypoints: ["./src/index.ts"],
-  outdir: "./dist",
-  target: "node",
-  format: "esm",
-  splitting: false,
-  sourcemap: "external",
-  minify: false,
-  external: ["@elizaos/core", "@slack/bolt", "@slack/web-api", "zod"],
+await buildPlugin({
+  name: "@elizaos/plugin-slack",
+  externals: ["@elizaos/core", "@slack/bolt", "@slack/web-api", "zod"],
+  targets: [
+    {
+      label: "Node",
+      entry: "./src/index.ts",
+      outSubdir: "",
+      target: "node",
+      format: "esm",
+    },
+  ],
+  dtsProject: "tsconfig.build.json",
 });
-
-const proc = Bun.spawn(
-  ["bunx", "tsc", "-p", "tsconfig.build.json", "--noCheck"],
-  {
-    cwd: import.meta.dir,
-    stdout: "inherit",
-    stderr: "inherit",
-  },
-);
-
-const exitCode = await proc.exited;
-if (exitCode !== 0) {
-  console.error("TypeScript declaration generation failed");
-  process.exit(exitCode);
-}
-
-console.log("Build complete!");

--- a/plugins/plugin-twitch/build.ts
+++ b/plugins/plugin-twitch/build.ts
@@ -1,19 +1,22 @@
-import { build } from "bun";
+#!/usr/bin/env bun
+/**
+ * Build script for @elizaos/plugin-twitch (Node). Orchestration lives in the shared
+ * driver (plugins/plugin-build.ts); this lists only what differs.
+ */
+import { buildPlugin } from "../plugin-build";
 
-await build({
-  entrypoints: ["./src/index.ts"],
-  outdir: "./dist",
-  target: "node",
-  format: "esm",
-  sourcemap: "external",
-  external: ["@elizaos/core", "@twurple/auth", "@twurple/chat"],
+await buildPlugin({
+  name: "@elizaos/plugin-twitch",
+  externals: ["@elizaos/core", "@twurple/auth", "@twurple/chat"],
+  targets: [
+    {
+      label: "Node",
+      entry: "./src/index.ts",
+      outSubdir: "",
+      target: "node",
+      format: "esm",
+    },
+  ],
+  dtsProject: "tsconfig.json",
+  dtsEmitDeclarationOnly: true,
 });
-
-// Also emit declarations with tsc
-import { spawnSync } from "node:child_process";
-
-spawnSync("bunx", ["tsc", "--emitDeclarationOnly", "--noCheck"], {
-  stdio: "inherit",
-});
-
-console.log("Build complete");

--- a/plugins/plugin-x402/build.ts
+++ b/plugins/plugin-x402/build.ts
@@ -1,28 +1,21 @@
-import { build } from "bun";
+#!/usr/bin/env bun
+/**
+ * Build script for @elizaos/plugin-x402 (Node). Orchestration lives in the shared
+ * driver (plugins/plugin-build.ts); this lists only what differs.
+ */
+import { buildPlugin } from "../plugin-build";
 
-await build({
-  entrypoints: ["./src/index.ts"],
-  outdir: "./dist",
-  target: "node",
-  format: "esm",
-  splitting: false,
-  sourcemap: "external",
-  minify: false,
-  external: ["@elizaos/core", "viem", "drizzle-orm", "@solana/web3.js"],
+await buildPlugin({
+  name: "@elizaos/plugin-x402",
+  externals: ["@elizaos/core", "viem", "drizzle-orm", "@solana/web3.js"],
+  targets: [
+    {
+      label: "Node",
+      entry: "./src/index.ts",
+      outSubdir: "",
+      target: "node",
+      format: "esm",
+    },
+  ],
+  dtsProject: "tsconfig.dts.json",
 });
-
-const proc = Bun.spawn(
-  ["bunx", "tsc", "--noCheck", "-p", "tsconfig.dts.json"],
-  {
-    cwd: import.meta.dir,
-    stdout: "inherit",
-    stderr: "inherit",
-  },
-);
-
-const procExit = await proc.exited;
-if (procExit !== 0) {
-  process.exit(procExit);
-}
-
-console.log("Build complete!");


### PR DESCRIPTION
Implements #10078 — consolidate connector `build.ts` onto the shared `buildPlugin` driver, plus an audit of the issue's other items against current `develop`.

## Shipped here
- **Extended `plugins/plugin-build.ts`** with two opt-in flags (default off → the 16 existing model-provider adopters are unaffected):
  - `rewriteDistImports` — runs `rewrite-dist-relative-imports-node-esm.mjs` after declaration emit.
  - `dtsEmitDeclarationOnly` — passes `--emitDeclarationOnly` to the declaration `tsc`.
- **Converted 11 hand-rolled connector `build.ts` to declarative shims**: discord, signal, slack, coding-tools, remote-desktop, native-filesystem, x402, shell, instagram, matrix, twitch.
- **Excluded `build.ts` from typecheck** for native-filesystem + shell (matching the existing adopters' convention) — their shims now import `../plugin-build`.

### Verification
- **Byte-identical `dist/`** before vs after each migration (per-file sha256): discord 124, signal 24, slack 20, coding-tools 62, remote-desktop 16, native-filesystem 10, x402 26, shell 54, instagram 22, matrix 16, twitch 14 — all identical.
- All 11 migrated plugins `typecheck` clean (24/24 turbo tasks); `audit:turbo-build-deps` green; biome clean.

## Already done on `develop` (verified, no change needed)
- **tsdown orphan removed** (no `tsdown` users remain).
- **`typecheck:dist` wired into `verify`**.
- **Single type-check**: builds emit declarations with `tsc --noCheck` (emit-only); `tsgo` is the sole checker.

## Deferred (documented in #10078) — not safely landable in this pass
- **Drop blanket `^build` from `typecheck`**: investigated empirically. A handful of packages resolve `@elizaos/*` to **dist** (e.g. polymarket→ui/app-core, tailscale→plugin-tunnel) and `tsgo` segfaults on the resulting module-not-found cascade, so the full set can't be reliably enumerated in one run. Doing it right needs per-package source-resolution fixes / overrides — a dedicated effort, tracked separately.
- **Pure-`tsc` transpile plugins** (nostr, imessage, line, google, google-chat, bluebubbles) and the bespoke `app-manager` / multi-build `commands` use a different (non-bundling) build pattern and intentionally stay off the bundle driver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)