### PR TITLE
perf(cloud): put /v1/embeddings on the IAC auth fast-path (agent recall hot path — ~1.5s+/reply)

### DIFF
--- a/packages/cloud/api/__tests__/embeddings-credit-leak.test.ts
+++ b/packages/cloud/api/__tests__/embeddings-credit-leak.test.ts
@@ -20,6 +20,7 @@ import * as workersHonoAuthActual from "@/lib/auth/workers-hono-auth";
 import * as rateLimitActual from "@/lib/middleware/rate-limit";
 import * as languageModelActual from "@/lib/providers/language-model";
 import * as aiBillingActual from "@/lib/services/ai-billing";
+import * as inferenceAuthContextActual from "@/lib/services/inference-auth-context";
 import * as usageActual from "@/lib/services/usage";
 
 const aiActual = require("ai") as Record<string, unknown>;
@@ -32,6 +33,12 @@ const requireUserOrApiKeyWithOrg = mock();
 mock.module("@/lib/auth/workers-hono-auth", () => ({
   ...workersHonoAuthActual,
   requireUserOrApiKeyWithOrg,
+}));
+
+const resolveInferenceAuthContext = mock();
+mock.module("@/lib/services/inference-auth-context", () => ({
+  ...inferenceAuthContextActual,
+  resolveInferenceAuthContext,
 }));
 
 const enforceOrgRateLimit = mock();
@@ -76,6 +83,10 @@ const embeddingsRoute = (await import("../v1/embeddings/route")).default;
 
 afterAll(() => {
   mock.module("@/lib/auth/workers-hono-auth", () => workersHonoAuthActual);
+  mock.module(
+    "@/lib/services/inference-auth-context",
+    () => inferenceAuthContextActual,
+  );
   mock.module("@/lib/middleware/rate-limit", () => rateLimitActual);
   mock.module("@/lib/providers/language-model", () => languageModelActual);
   mock.module("@/lib/services/ai-billing", () => aiBillingActual);
@@ -149,6 +160,7 @@ function post(body: unknown, ctx?: ExecutionContext) {
 
 beforeEach(() => {
   requireUserOrApiKeyWithOrg.mockReset();
+  resolveInferenceAuthContext.mockReset();
   enforceOrgRateLimit.mockReset();
   reserveCredits.mockReset();
   billUsage.mockReset();
@@ -164,6 +176,10 @@ beforeEach(() => {
       organization: { id: ORG, name: "Org", is_active: true },
       is_active: true,
     };
+  });
+  resolveInferenceAuthContext.mockResolvedValue({
+    kind: "slow_path",
+    reason: "cache_unavailable",
   });
   enforceOrgRateLimit.mockResolvedValue(null);
   usageCreate.mockResolvedValue({ id: "usage-1" });

--- a/packages/cloud/api/__tests__/embeddings-route-billing.test.ts
+++ b/packages/cloud/api/__tests__/embeddings-route-billing.test.ts
@@ -26,6 +26,7 @@ import * as rateLimitActual from "@/lib/middleware/rate-limit";
 // that import from these modules. afterAll restores them.
 import * as aiBillingActual from "@/lib/services/ai-billing";
 import * as apiKeysActual from "@/lib/services/api-keys";
+import * as inferenceAuthContextActual from "@/lib/services/inference-auth-context";
 import * as usageActual from "@/lib/services/usage";
 
 const ORG = "00000000-0000-4000-8000-0000000000aa";
@@ -47,6 +48,12 @@ const validateApiKey = mock();
 mock.module("@/lib/services/api-keys", () => ({
   ...apiKeysActual,
   apiKeysService: { ...apiKeysActual.apiKeysService, validateApiKey },
+}));
+
+const resolveInferenceAuthContext = mock();
+mock.module("@/lib/services/inference-auth-context", () => ({
+  ...inferenceAuthContextActual,
+  resolveInferenceAuthContext,
 }));
 
 // Rate limiting is not under test — make the org gate a no-op (no Redis).
@@ -95,6 +102,10 @@ const embeddingsRoute = (await import("../v1/embeddings/route")).default;
 afterAll(() => {
   mock.module("@/lib/auth/workers-hono-auth", () => workersHonoAuthActual);
   mock.module("@/lib/services/api-keys", () => apiKeysActual);
+  mock.module(
+    "@/lib/services/inference-auth-context",
+    () => inferenceAuthContextActual,
+  );
   mock.module("@/lib/middleware/rate-limit", () => rateLimitActual);
   mock.module("@/lib/services/ai-billing", () => aiBillingActual);
   mock.module("@/lib/services/usage", () => usageActual);
@@ -133,6 +144,7 @@ function post(body: unknown, ctx?: ExecutionContext) {
 beforeEach(() => {
   requireUserOrApiKeyWithOrg.mockReset();
   validateApiKey.mockReset();
+  resolveInferenceAuthContext.mockReset();
   enforceOrgRateLimit.mockReset();
   reserveCredits.mockReset();
   billUsage.mockReset();
@@ -150,6 +162,10 @@ beforeEach(() => {
       organization: { id: ORG, name: "Org", is_active: true },
       is_active: true,
     };
+  });
+  resolveInferenceAuthContext.mockResolvedValue({
+    kind: "slow_path",
+    reason: "cache_unavailable",
   });
   enforceOrgRateLimit.mockResolvedValue(null);
   reserveCredits.mockResolvedValue({
@@ -261,19 +277,80 @@ describe("POST /api/v1/embeddings — insufficient-credits guard", () => {
   });
 });
 
-describe("POST /api/v1/embeddings — single key validation", () => {
-  test("the route does not re-validate the API key (no second DB lookup)", async () => {
+describe("POST /api/v1/embeddings — auth context", () => {
+  test("slow path does not re-validate the API key (no second DB lookup)", async () => {
     const { ctx, scheduled } = makeExecutionCtx();
     await post({ model: "text-embedding-3-small", input: "hi" }, ctx);
     await Promise.all(scheduled);
 
     // The auth helper validated the key once; the route reads apiKeyId from the
     // context and must NOT call apiKeysService.validateApiKey again.
+    expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(1);
+    expect(requireUserOrApiKeyWithOrg).toHaveBeenCalledTimes(1);
     expect(validateApiKey).not.toHaveBeenCalled();
 
     // And the apiKeyId from context flows into billing + usage attribution.
     expect(billUsage.mock.calls[0][0].apiKeyId).toBe(API_KEY_ID);
     expect(usageCreate.mock.calls[0][0].api_key_id).toBe(API_KEY_ID);
+  });
+
+  test("cached authorized IAC skips slow auth and preserves API-key attribution", async () => {
+    resolveInferenceAuthContext.mockResolvedValueOnce({
+      kind: "authorized",
+      source: "cache",
+      ctx: {
+        v: 1,
+        cachedAt: Date.now(),
+        userId: USER,
+        orgId: ORG,
+        apiKeyId: API_KEY_ID,
+        keyHash: "key-hash",
+      },
+    });
+
+    const { ctx, scheduled } = makeExecutionCtx();
+    const res = await post(
+      { model: "text-embedding-3-small", input: "hi" },
+      ctx,
+    );
+    await Promise.all(scheduled);
+
+    expect(res.status).toBe(200);
+    expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(1);
+    expect(requireUserOrApiKeyWithOrg).not.toHaveBeenCalled();
+    expect(validateApiKey).not.toHaveBeenCalled();
+    expect(enforceOrgRateLimit).toHaveBeenCalledWith(ORG, "embeddings");
+    expect(billUsage.mock.calls[0][0].apiKeyId).toBe(API_KEY_ID);
+    expect(usageCreate.mock.calls[0][0].api_key_id).toBe(API_KEY_ID);
+  });
+
+  test("suspended IAC returns the account-suspended 403 without charging", async () => {
+    resolveInferenceAuthContext.mockResolvedValueOnce({
+      kind: "suspended",
+      userId: USER,
+    });
+
+    const { ctx, scheduled } = makeExecutionCtx();
+    const res = await post(
+      { model: "text-embedding-3-small", input: "hi" },
+      ctx,
+    );
+
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as {
+      error: { code: string; type: string };
+    };
+    expect(body.error).toMatchObject({
+      type: "account_suspended",
+      code: "moderation_violation",
+    });
+    expect(requireUserOrApiKeyWithOrg).not.toHaveBeenCalled();
+    expect(enforceOrgRateLimit).not.toHaveBeenCalled();
+    expect(reserveCredits).not.toHaveBeenCalled();
+    expect(embed).not.toHaveBeenCalled();
+    expect(embedMany).not.toHaveBeenCalled();
+    expect(billUsage).not.toHaveBeenCalled();
+    expect(scheduled.length).toBe(0);
   });
 });
 

--- a/packages/cloud/api/v1/embeddings/route.ts
+++ b/packages/cloud/api/v1/embeddings/route.ts
@@ -31,6 +31,7 @@ import {
   InsufficientCreditsError,
   reserveCredits,
 } from "@/lib/services/ai-billing";
+import { resolveInferenceAuthContext } from "@/lib/services/inference-auth-context";
 import { usageService } from "@/lib/services/usage";
 import { createCreditReservationSettler } from "@/lib/utils/credit-reservation";
 import { logger } from "@/lib/utils/logger";
@@ -63,11 +64,42 @@ app.post("/", async (c) => {
   // been invoked, so the catch never double-applies a release on the success path.
   let billed = false;
   try {
-    const user = await requireUserOrApiKeyWithOrg(c);
-    // `requireUserOrApiKeyWithOrg` already validated the API key (when present)
-    // and exposed its id on the request context — reuse it instead of doing a
-    // second DB lookup per request.
-    const apiKeyId = c.get("apiKeyId") ?? null;
+    // Resolve auth (+ org + moderation) in a SINGLE cache read for API-key
+    // inference requests (#9899) — the same fast-path as /v1/chat/completions.
+    // This route is on the agent reply hot path: the always-on
+    // `relevant-conversations` recall provider embeds the incoming message on
+    // EVERY memory-backed turn (blocking Stage-1), so paying the old per-request
+    // auth+org+moderation DB chain here added ~1.5-6s to every reply. Non-API-key
+    // / cache-unavailable requests fall to the authoritative slow path verbatim.
+    let user: { id: string; organization_id: string };
+    let apiKeyId: string | null;
+    const resolution = await resolveInferenceAuthContext(c.req.raw);
+    if (resolution.kind === "suspended") {
+      return c.json(
+        {
+          error: {
+            message:
+              "Your account has been suspended due to policy violations.",
+            type: "account_suspended",
+            code: "moderation_violation",
+          },
+        },
+        403,
+      );
+    }
+    if (resolution.kind === "authorized") {
+      user = {
+        id: resolution.ctx.userId,
+        organization_id: resolution.ctx.orgId,
+      };
+      apiKeyId = resolution.ctx.apiKeyId;
+    } else {
+      // Slow path: `requireUserOrApiKeyWithOrg` validated the API key (when
+      // present) and exposed its id on the request context — reuse it instead of
+      // a second DB lookup.
+      user = await requireUserOrApiKeyWithOrg(c);
+      apiKeyId = c.get("apiKeyId") ?? null;
+    }
 
     if (user.organization_id) {
       const orgRateLimited = await enforceOrgRateLimit(

--- a/packages/cloud/shared/src/lib/services/inference-auth-lifecycle.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-lifecycle.test.ts
@@ -13,12 +13,16 @@
  * Plus: invalidation is best-effort and must never throw into the lifecycle write.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import * as cacheClientActual from "../cache/client";
+import * as loggerActual from "../utils/logger";
+import * as inferenceAuthCacheActual from "./inference-auth-cache";
 
 // ── Captured side effects + per-test repository state ───────────────────────
 const invalidatedHashBatches: string[][] = [];
 const userDeleteCalls: string[] = [];
 const orgDeleteCalls: string[] = [];
+const cacheValues = new Map<string, unknown>();
 
 let userApiKeys: Array<{ key_hash: string }> = [];
 let orgApiKeys: Array<{ key_hash: string }> = [];
@@ -62,9 +66,14 @@ mock.module("../../db/repositories", () => ({
 
 mock.module("../cache/client", () => ({
   cache: {
-    get: async () => null,
-    set: async () => {},
-    del: async () => {},
+    get: async (key: string) => cacheValues.get(key) ?? null,
+    set: async (key: string, value: unknown) => {
+      cacheValues.set(key, value);
+    },
+    del: async (key: string) => {
+      cacheValues.delete(key);
+    },
+    isAvailable: () => true,
   },
 }));
 
@@ -76,11 +85,19 @@ beforeEach(() => {
   invalidatedHashBatches.length = 0;
   userDeleteCalls.length = 0;
   orgDeleteCalls.length = 0;
+  cacheValues.clear();
   userApiKeys = [];
   orgApiKeys = [];
   userRecord = undefined;
   listByOrganizationUsers = [];
   listByUserError = null;
+});
+
+afterAll(() => {
+  mock.module("./inference-auth-cache", () => inferenceAuthCacheActual);
+  mock.module("../cache/client", () => cacheClientActual);
+  mock.module("../utils/logger", () => loggerActual);
+  mock.restore();
 });
 
 describe("UsersService — IAC invalidation on lifecycle", () => {


### PR DESCRIPTION
## Why
The agent-latency root-cause (4-tracer workflow, #8434) found a dedicated, memory-backed agent's ~12s reply is **two serial cloud round-trips**: a blocking **recall-query embed** (`relevant-conversations` provider → `useModel(TEXT_EMBEDDING)`, awaited before Stage-1) + the Stage-1 LLM. That recall embed cost **~3–6.6s** — and the smoking gun is that **`/v1/embeddings` never got the IAC fast-path that `/v1/chat/completions` did.** It still ran the old per-request serial `requireUserOrApiKeyWithOrg` (auth+org+moderation DB chain).

## What
Mirror the chat route (#9899): `resolveInferenceAuthContext(c.req.raw)` collapses auth+org+moderation into a **single cache read** for API-key inference requests. Non-API-key / cache-unavailable requests fall to the authoritative slow path verbatim (`requireUserOrApiKeyWithOrg`). The route only uses `user.{id, organization_id}` + `apiKeyId`, so the narrowed IAC identity fits exactly (same as chat). Suspended accounts now 403 on embeddings too — consistent with chat (a suspended user shouldn't embed either).

## Scope (deliberately tight)
**AUTH fast-path only** — low-risk, fails-safe (cache miss/unavailable → authoritative slow path, no auth from a failed read). The synchronous `reserveCredits` write (the bigger ~846–1686ms remaining cost on this route) is a **separate real-money follow-up** (optimistic billing on embeddings, like #10026 did for chat) — not bundled here.

## Verify
Transpiles clean; IAC return type matches (`authorized`→`ctx.{userId,orgId,apiKeyId}`, `suspended`→403, `slow_path`→fallback); import resolves (chat uses the same). 

Part of the agent-side latency work on #8434. cc @lalalune — this is the cloud-api half of the recall-embed fix; the agent-runtime half (decouple the recall embed from Stage-1 / restore your fail-open) is #2 on the ranked list.