### PR TITLE
perf(core): batch document-fragment embeddings via TEXT_EMBEDDING_BATCH (serial fallback)

### DIFF
--- a/packages/core/src/features/documents/service-batch-embed.test.ts
+++ b/packages/core/src/features/documents/service-batch-embed.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, test } from "vitest";
+import { createMockRuntime } from "../../testing/mock-runtime";
+import type { Memory, UUID } from "../../types";
+import { ModelType } from "../../types";
+import { DocumentService } from "./service.ts";
+
+const DOCUMENT_FRAGMENTS_TABLE = "document_fragments";
+
+/**
+ * Deterministic, text-derived "embedding": distinct per distinct text so a
+ * vector can be traced back to the exact text it was generated from. This lets
+ * the tests prove (1) the right vector landed on the right fragment (ordering)
+ * and (2) the batch path embeds the SAME text the serial path embeds.
+ */
+function vecOf(text: string): number[] {
+	let h = 0;
+	for (let i = 0; i < text.length; i++) {
+		h = (h * 31 + text.charCodeAt(i)) >>> 0;
+	}
+	return [h % 100000, text.length];
+}
+
+// Six distinct ~70-char paragraphs. With the small split target below each
+// paragraph becomes its own fragment (two never fit in one chunk), so every
+// run produces several fragments with distinct text → distinct vectors.
+const DOC_TEXT = [
+	"Alpha paragraph: the quick brown fox reviews the refund policy details.",
+	"Bravo paragraph: service level agreements and uptime commitments listed.",
+	"Charlie paragraph: data retention windows and deletion guarantees noted.",
+	"Delta paragraph: support escalation paths and the on-call rotation table.",
+	"Echo paragraph: billing cycles, proration, and invoice dispute handling.",
+	"Foxtrot paragraph: security posture, encryption at rest and in transit.",
+].join("\n\n");
+
+// Force several small fragments regardless of the default 1500-token target.
+const SPLIT_OPTS = { targetTokens: 24, overlap: 2, modelContextSize: 4096 };
+
+const ITEM_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" as UUID;
+
+function makeItem() {
+	return {
+		id: ITEM_ID,
+		content: { text: DOC_TEXT },
+		metadata: { source: "unit-test" },
+	};
+}
+
+interface Captured {
+	fragments: Memory[];
+	documents: Memory[];
+}
+
+/** Snapshot persisted memories per table, copying the embedding at call time. */
+function captureCreateMemory(captured: Captured) {
+	return async (memory: Memory, table: string): Promise<UUID> => {
+		const snapshot: Memory = {
+			...memory,
+			embedding: memory.embedding ? [...memory.embedding] : undefined,
+		};
+		if (table === DOCUMENT_FRAGMENTS_TABLE) {
+			captured.fragments.push(snapshot);
+		} else {
+			captured.documents.push(snapshot);
+		}
+		return memory.id as UUID;
+	};
+}
+
+describe("DocumentService — batched fragment embedding (TEXT_EMBEDDING_BATCH)", () => {
+	test("batch model registered → ONE batch call embeds all fragments in order and persists them", async () => {
+		let batchCalls = 0;
+		let singleEmbedCalls = 0;
+		let serialEmbedCalls = 0;
+		let batchTexts: string[] = [];
+		const captured: Captured = { fragments: [], documents: [] };
+
+		const runtime = createMockRuntime({
+			getMemoryById: async () => null,
+			updateMemory: async () => true,
+			createMemory: captureCreateMemory(captured),
+			// Presence (truthiness) of a batch handler is all the service checks.
+			getModel: (type: string) =>
+				type === ModelType.TEXT_EMBEDDING_BATCH
+					? async () => [] // never invoked; useModel is used instead
+					: undefined,
+			useModel: (type: string, params: { text?: string; texts?: string[] }) => {
+				if (type === ModelType.TEXT_EMBEDDING_BATCH) {
+					batchCalls++;
+					batchTexts = params.texts ?? [];
+					return Promise.resolve(batchTexts.map(vecOf));
+				}
+				if (type === ModelType.TEXT_EMBEDDING) {
+					singleEmbedCalls++;
+					return Promise.resolve(vecOf(params.text ?? ""));
+				}
+				throw new Error(`unexpected model ${type}`);
+			},
+			addEmbeddingToMemory: async (memory: Memory) => {
+				serialEmbedCalls++;
+				memory.embedding = vecOf(memory.content.text ?? "");
+				return memory;
+			},
+		});
+
+		const service = new DocumentService(runtime);
+		await service._internalAddDocument(makeItem(), SPLIT_OPTS);
+
+		// Multiple fragments → batching is meaningful.
+		expect(captured.fragments.length).toBeGreaterThanOrEqual(2);
+		// Exactly ONE batch round-trip (not N), and the serial path untouched.
+		expect(batchCalls).toBe(1);
+		expect(singleEmbedCalls).toBe(0);
+		expect(serialEmbedCalls).toBe(0);
+		// The batch embedded exactly the fragment texts (count match).
+		expect(batchTexts.length).toBe(captured.fragments.length);
+		// Every fragment was persisted WITH its embedding, and that embedding is
+		// the vector for ITS OWN text — proving the right vector landed on the
+		// right fragment (ordering) and that the embedded text matches what the
+		// serial addEmbeddingToMemory path would have embedded (content.text).
+		for (const fragment of captured.fragments) {
+			expect(fragment.embedding).toEqual(vecOf(fragment.content.text ?? ""));
+		}
+		// Batch texts are exactly the fragment texts, in fragment order.
+		expect(batchTexts).toEqual(
+			captured.fragments.map((f) => f.content.text ?? ""),
+		);
+	});
+
+	test("no batch model → falls back to the serial per-fragment path and embeds + persists all N", async () => {
+		let batchCalls = 0;
+		let serialEmbedCalls = 0;
+		const captured: Captured = { fragments: [], documents: [] };
+
+		const runtime = createMockRuntime({
+			getMemoryById: async () => null,
+			updateMemory: async () => true,
+			createMemory: captureCreateMemory(captured),
+			// No batch model registered.
+			getModel: () => undefined,
+			useModel: (type: string) => {
+				if (type === ModelType.TEXT_EMBEDDING_BATCH) {
+					batchCalls++;
+				}
+				return Promise.resolve([]);
+			},
+			addEmbeddingToMemory: async (memory: Memory) => {
+				serialEmbedCalls++;
+				memory.embedding = vecOf(memory.content.text ?? "");
+				return memory;
+			},
+		});
+
+		const service = new DocumentService(runtime);
+		await service._internalAddDocument(makeItem(), SPLIT_OPTS);
+
+		expect(captured.fragments.length).toBeGreaterThanOrEqual(2);
+		// Batch model absent → batch is never attempted.
+		expect(batchCalls).toBe(0);
+		// One embed per fragment via the serial path.
+		expect(serialEmbedCalls).toBe(captured.fragments.length);
+		for (const fragment of captured.fragments) {
+			expect(fragment.embedding).toEqual(vecOf(fragment.content.text ?? ""));
+		}
+	});
+
+	test("batch returns the wrong vector count → falls back to serial (no fragment left unembedded)", async () => {
+		let batchCalls = 0;
+		let serialEmbedCalls = 0;
+		const captured: Captured = { fragments: [], documents: [] };
+
+		const runtime = createMockRuntime({
+			getMemoryById: async () => null,
+			updateMemory: async () => true,
+			createMemory: captureCreateMemory(captured),
+			getModel: (type: string) =>
+				type === ModelType.TEXT_EMBEDDING_BATCH ? async () => [] : undefined,
+			useModel: (type: string) => {
+				if (type === ModelType.TEXT_EMBEDDING_BATCH) {
+					batchCalls++;
+					// WRONG shape: one vector for N (>= 2) texts → must trigger fallback.
+					return Promise.resolve([[0, 0]]);
+				}
+				throw new Error(`unexpected model ${type}`);
+			},
+			addEmbeddingToMemory: async (memory: Memory) => {
+				serialEmbedCalls++;
+				memory.embedding = vecOf(memory.content.text ?? "");
+				return memory;
+			},
+		});
+
+		const service = new DocumentService(runtime);
+		await service._internalAddDocument(makeItem(), SPLIT_OPTS);
+
+		expect(captured.fragments.length).toBeGreaterThanOrEqual(2);
+		// Batch was attempted exactly once, then abandoned for the serial path.
+		expect(batchCalls).toBe(1);
+		expect(serialEmbedCalls).toBe(captured.fragments.length);
+		// No fragment left unembedded; each carries the vector for its own text.
+		for (const fragment of captured.fragments) {
+			expect(fragment.embedding).toBeDefined();
+			expect(fragment.embedding).toEqual(vecOf(fragment.content.text ?? ""));
+		}
+	});
+});

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -1478,9 +1478,9 @@ export class DocumentService extends Service {
 			},
 		);
 
-		for (const fragment of fragments) {
-			await this.processDocumentFragment(fragment);
-		}
+		await this.processDocumentFragmentsBatched(fragments, {
+			continueOnError: false,
+		});
 
 		return {
 			documentId: options.documentId,
@@ -1576,16 +1576,9 @@ export class DocumentService extends Service {
 			finalScope,
 		);
 
-		for (const fragment of fragments) {
-			try {
-				await this.processDocumentFragment(fragment);
-			} catch (error) {
-				logger.error(
-					{ error },
-					`DocumentService: Error processing fragment ${fragment.id} for document ${item.id}`,
-				);
-			}
-		}
+		await this.processDocumentFragmentsBatched(fragments, {
+			continueOnError: true,
+		});
 	}
 
 	private async processDocumentFragment(fragment: Memory): Promise<void> {
@@ -1596,6 +1589,110 @@ export class DocumentService extends Service {
 		} catch (error) {
 			logger.error({ error }, `Error processing fragment ${fragment.id}`);
 			throw error;
+		}
+	}
+
+	/**
+	 * Embed + persist a batch of document fragments.
+	 *
+	 * When a {@link ModelType.TEXT_EMBEDDING_BATCH} model is registered (e.g. the
+	 * cloud plugin), every fragment is embedded in ONE round-trip instead of N
+	 * serial single-text embeds, the returned vectors are written back IN ORDER
+	 * (`fragments[i].embedding = vectors[i]`), then each fragment is persisted.
+	 *
+	 * The embedded text is exactly `fragment.content.text` — the same value
+	 * {@link IAgentRuntime.addEmbeddingToMemory} embeds (see runtime.ts:
+	 * `useModel(TEXT_EMBEDDING, { text: memory.content.text })`) — so batched and
+	 * serial fragments receive byte-for-byte identical embedding input.
+	 *
+	 * Any batch failure (no batch model registered, the model call throwing, or a
+	 * returned vector count that does not match the fragment count) falls back to
+	 * the existing serial per-fragment path so no fragment is left unembedded.
+	 *
+	 * @param fragments fragments to embed + persist, processed in array order.
+	 * @param options.continueOnError when true, a single fragment's persist
+	 *   failure is logged and skipped (matching the per-fragment try/catch at the
+	 *   `_internalAddDocument` call site); when false the error propagates
+	 *   (matching the `updateDocument` call site).
+	 */
+	private async processDocumentFragmentsBatched(
+		fragments: Memory[],
+		options: { continueOnError: boolean },
+	): Promise<void> {
+		if (fragments.length === 0) {
+			return;
+		}
+
+		// No batch model → keep the original serial behaviour unchanged.
+		if (!this.runtime.getModel(ModelType.TEXT_EMBEDDING_BATCH)) {
+			await this.processDocumentFragmentsSerial(fragments, options);
+			return;
+		}
+
+		let vectors: number[][];
+		try {
+			// Text source matches addEmbeddingToMemory exactly: memory.content.text.
+			const texts = fragments.map((fragment) => fragment.content.text ?? "");
+			vectors = await this.runtime.useModel(ModelType.TEXT_EMBEDDING_BATCH, {
+				texts,
+			});
+			if (!Array.isArray(vectors) || vectors.length !== fragments.length) {
+				// A count/shape mismatch can't be mapped back to fragments safely.
+				throw new Error(
+					`TEXT_EMBEDDING_BATCH returned ${
+						Array.isArray(vectors) ? vectors.length : "a non-array"
+					} vectors for ${fragments.length} fragments`,
+				);
+			}
+		} catch (error) {
+			logger.warn(
+				{ error },
+				"[DocumentService] Batch fragment embedding failed; falling back to serial per-fragment embedding",
+			);
+			await this.processDocumentFragmentsSerial(fragments, options);
+			return;
+		}
+
+		// Vectors are valid + count-matched. Assign in order, then persist each.
+		for (let i = 0; i < fragments.length; i++) {
+			fragments[i].embedding = vectors[i];
+		}
+
+		for (const fragment of fragments) {
+			try {
+				await this.runtime.createMemory(fragment, DOCUMENT_FRAGMENTS_TABLE);
+			} catch (error) {
+				logger.error(
+					{ error },
+					`[DocumentService] Error persisting fragment ${fragment.id}`,
+				);
+				if (!options.continueOnError) {
+					throw error;
+				}
+			}
+		}
+	}
+
+	/**
+	 * Serial per-fragment embed + persist path. The fallback used when no
+	 * TEXT_EMBEDDING_BATCH model is registered or the batch call fails.
+	 */
+	private async processDocumentFragmentsSerial(
+		fragments: Memory[],
+		options: { continueOnError: boolean },
+	): Promise<void> {
+		for (const fragment of fragments) {
+			try {
+				await this.processDocumentFragment(fragment);
+			} catch (error) {
+				if (!options.continueOnError) {
+					throw error;
+				}
+				logger.error(
+					{ error },
+					`[DocumentService] Error processing fragment ${fragment.id} during serial fallback`,
+				);
+			}
 		}
 	}
 


### PR DESCRIPTION
## Problem
Document ingestion embeds fragments **serially** — `for (const fragment of fragments) await processDocumentFragment(fragment)` (`documents/service.ts` ~1481 & ~1579), each doing a single `addEmbeddingToMemory` round-trip. A 50-fragment document = 50 serial embedding round-trips (tens of seconds on a cloud embedding provider), even though the `TEXT_EMBEDDING_BATCH` model + `EmbeddingGenerationService` batch infra already exist (plugin-elizacloud implements the handler). The doc path just bypassed it.

## Fix
New `processDocumentFragmentsBatched()`: when a `ModelType.TEXT_EMBEDDING_BATCH` model is registered, embed all fragments in **one** `useModel(TEXT_EMBEDDING_BATCH, { texts })` call, write vectors back **in order**, then persist — collapsing N serial embeds → 1. Falls back to the **unchanged** serial path when no batch model is registered, the batch call throws, or the returned vector count != fragment count (so no fragment is ever left unembedded). Both call sites' error semantics preserved (`updateDocument` propagates; `_internalAddDocument` logs+continues).

## Correctness
- **Embedded text matches the serial path byte-for-byte**: batch uses `fragment.content.text`, exactly what `addEmbeddingToMemory` embeds (`runtime.ts`: `useModel(TEXT_EMBEDDING, { text: memory.content.text })`); same write-back field (`memory.embedding`). Mirrors the existing `services/embedding.ts` batch pattern.
- **Ordering** asserted by index + by-content in tests (not just positional).

## Tests
`service-batch-embed.test.ts` (3/3, drive the real `_internalAddDocument` path):
- batch model registered -> exactly **1** batch call (not N), every fragment persisted with the vector derived from **its own** text, in order;
- no batch model -> serial fallback, all fragments embedded+persisted;
- batch returns wrong count -> falls back to serial, none left unembedded.

## Scope / honest notes
- **Embedding round-trips only** are batched; fragment *persistence* stays serial (the round-trips were the bottleneck). Upload-latency win; not the chat hot path.
- Distinct from the reverted async-drain attempt (#8829 -> #8849) and from cloud-agent's recall-embed fast-path (#10092/#10093) — coordinated on #8434.
- typecheck clean on touched files; biome **rules** clean (kept tabs to match the file/package; repo's `biome check --write` handles format).

Per PR_EVIDENCE.md: unit-test evidence attached (3/3). Full E2E N/A — pure internal perf refactor with serial-fallback parity proven by tests. @lalalune flagging you since it's `@elizaos/core`.
