### PR TITLE
perf(cloud): put /v1/embeddings on the IAC auth fast-path (agent recall hot path — ~1.5s+/reply)

### DIFF
--- a/packages/cloud/api/v1/embeddings/route.ts
+++ b/packages/cloud/api/v1/embeddings/route.ts
@@ -11,6 +11,7 @@ import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { enforceOrgRateLimit } from "@/lib/middleware/rate-limit";
+import { resolveInferenceAuthContext } from "@/lib/services/inference-auth-context";
 import {
   RateLimitPresets,
   rateLimit,
@@ -63,11 +64,42 @@ app.post("/", async (c) => {
   // been invoked, so the catch never double-applies a release on the success path.
   let billed = false;
   try {
-    const user = await requireUserOrApiKeyWithOrg(c);
-    // `requireUserOrApiKeyWithOrg` already validated the API key (when present)
-    // and exposed its id on the request context — reuse it instead of doing a
-    // second DB lookup per request.
-    const apiKeyId = c.get("apiKeyId") ?? null;
+    // Resolve auth (+ org + moderation) in a SINGLE cache read for API-key
+    // inference requests (#9899) — the same fast-path as /v1/chat/completions.
+    // This route is on the agent reply hot path: the always-on
+    // `relevant-conversations` recall provider embeds the incoming message on
+    // EVERY memory-backed turn (blocking Stage-1), so paying the old per-request
+    // auth+org+moderation DB chain here added ~1.5-6s to every reply. Non-API-key
+    // / cache-unavailable requests fall to the authoritative slow path verbatim.
+    let user: { id: string; organization_id: string | null };
+    let apiKeyId: string | null;
+    const resolution = await resolveInferenceAuthContext(c.req.raw);
+    if (resolution.kind === "suspended") {
+      return c.json(
+        {
+          error: {
+            message:
+              "Your account has been suspended due to policy violations.",
+            type: "account_suspended",
+            code: "moderation_violation",
+          },
+        },
+        403,
+      );
+    }
+    if (resolution.kind === "authorized") {
+      user = {
+        id: resolution.ctx.userId,
+        organization_id: resolution.ctx.orgId,
+      };
+      apiKeyId = resolution.ctx.apiKeyId;
+    } else {
+      // Slow path: `requireUserOrApiKeyWithOrg` validated the API key (when
+      // present) and exposed its id on the request context — reuse it instead of
+      // a second DB lookup.
+      user = await requireUserOrApiKeyWithOrg(c);
+      apiKeyId = c.get("apiKeyId") ?? null;
+    }
 
     if (user.organization_id) {
       const orgRateLimited = await enforceOrgRateLimit(


### PR DESCRIPTION
## Clean re-land of #10092

Re-lands the `/v1/embeddings` IAC auth fast-path. **#10092's branch was broken** — it had lost the rest of the repository tree (it contained only this one file), so merging it would have **deleted ~44.8k files** on `develop`. This branch is `develop` + that PR's single intended file change, byte-for-byte. #10092 is being closed in favor of this.

## Why
Agent-latency root-cause (#8434): a memory-backed agent's reply pays two serial cloud round-trips — a blocking recall-query embed (`relevant-conversations` provider → `useModel(TEXT_EMBEDDING)`, awaited before Stage-1) + the Stage-1 LLM. That embed hits `/v1/embeddings`, which (unlike `/v1/chat/completions`, fast-pathed in #9899) still ran the old per-request serial `requireUserOrApiKeyWithOrg` (auth+org+moderation DB chain).

## What
`resolveInferenceAuthContext(c.req.raw)` collapses auth+org+moderation into a single cache read for API-key inference requests — the same fast-path as the chat route. Non-API-key / cache-unavailable requests fall to the authoritative slow path (`requireUserOrApiKeyWithOrg`) verbatim. Suspended accounts now 403 on embeddings, consistent with chat.

## Scope
AUTH fast-path only — fails safe (cache miss/unavailable → slow path). The `reserveCredits` write is a separate real-money follow-up, not bundled here.

## Verify
- IAC contract confirmed against the helper on `develop`: `ctx.{userId, orgId, apiKeyId}`, `kind ∈ {authorized, suspended, slow_path}` — diff uses all correctly.
- Faithful mirror of the chat route's existing usage (`packages/cloud/api/v1/chat/completions/route.ts`).

Co-authored with @NubsCarson (original change author). Part of #8434.