### PR TITLE
perf(cloud): /v1/embeddings on IAC auth fast-path — PROD hotfix (agent recall hot path)

### DIFF
--- a/packages/cloud-api/v1/embeddings/route.ts
+++ b/packages/cloud-api/v1/embeddings/route.ts
@@ -11,6 +11,7 @@ import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { enforceOrgRateLimit } from "@/lib/middleware/rate-limit";
+import { resolveInferenceAuthContext } from "@/lib/services/inference-auth-context";
 import {
   RateLimitPresets,
   rateLimit,
@@ -65,8 +66,39 @@ app.use("*", rateLimit(RateLimitPresets.RELAXED));
 
 app.post("/", async (c) => {
   try {
-    const user = await requireUserOrApiKeyWithOrg(c);
-    const apiKey = await getRequestApiKeyId(c);
+    // Resolve auth (+ org + moderation) in a SINGLE cache read for API-key
+    // inference requests (#9899) — the same fast-path as /v1/chat/completions.
+    // This route is on the agent reply hot path: the always-on
+    // `relevant-conversations` recall provider embeds the incoming message on
+    // EVERY memory-backed turn (blocking Stage-1), so the old per-request
+    // auth+org+moderation DB chain added ~1.5s+ to every reply. Non-API-key /
+    // cache-unavailable requests fall to the authoritative slow path verbatim.
+    let user: { id: string; organization_id: string | null };
+    let apiKey: { id: string } | null;
+    const resolution = await resolveInferenceAuthContext(c.req.raw);
+    if (resolution.kind === "suspended") {
+      return c.json(
+        {
+          error: {
+            message:
+              "Your account has been suspended due to policy violations.",
+            type: "account_suspended",
+            code: "moderation_violation",
+          },
+        },
+        403,
+      );
+    }
+    if (resolution.kind === "authorized") {
+      user = {
+        id: resolution.ctx.userId,
+        organization_id: resolution.ctx.orgId,
+      };
+      apiKey = { id: resolution.ctx.apiKeyId };
+    } else {
+      user = await requireUserOrApiKeyWithOrg(c);
+      apiKey = await getRequestApiKeyId(c);
+    }
 
     if (user.organization_id) {
       const orgRateLimited = await enforceOrgRateLimit(


### PR DESCRIPTION
## Clean re-land of #10093 (PROD hotfix)

Re-lands the `/v1/embeddings` IAC auth fast-path on `main`. **#10093's branch was broken** — it had lost the rest of the repository tree (it contained only this one file), so merging it would have **deleted ~54k files** on production `main`. This branch is `main` + that PR's single intended file change, byte-for-byte. #10093 is being closed in favor of this.

## Why
Agent-latency root-cause (#8434): a memory-backed agent's reply pays two serial cloud round-trips — a blocking recall-query embed (~3–6.6s, awaited before Stage-1) + the Stage-1 LLM. That embed hits `/v1/embeddings`, which (unlike `/v1/chat/completions`, fast-pathed via #9981/#10067) still ran the old per-request serial `requireUserOrApiKeyWithOrg` (auth+org+moderation DB chain) on every memory-backed reply in prod.

## What
`resolveInferenceAuthContext(c.req.raw)` — single cache read for API-key inference requests, mirroring the already-live prod IAC auth on the chat route. Non-API-key / cache-unavailable → authoritative slow path verbatim. Adapted to main's `apiKey: { id } | null` shape. Suspended accounts now 403, consistent with chat.

## Risk — low, prod auth path
Fails safe (cache miss/unavailable → slow path, no auth from a failed read). Extends the already-live prod default IAC auth to one more route. `reserveCredits` is untouched (separate follow-up).

## Verify
- IAC contract confirmed against the helper on `main`: `ctx.{userId, orgId, apiKeyId}`, `kind ∈ {authorized, suspended, slow_path}` — diff uses all correctly.
- Faithful mirror of the chat route's existing usage (`packages/cloud-api/v1/chat/completions/route.ts`).

Co-authored with @NubsCarson (original change author). Develop twin: #10097. Part of #8434.