### PR TITLE
fix(cloud): enable Tier-2 optimistic billing in prod (sync main → develop)

### DIFF
--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -453,8 +453,8 @@ REDIS_RATE_LIMITING = "false"
 # SAFE_BALANCE_THRESHOLD (USD) empty/invalid -> +Inf -> every org takes the safe
 # synchronous-reserve path. The auth+moderation hot-path cache is the default now
 # (no flag); a cache miss falls back to the authoritative slow path.
-INFERENCE_OPTIMISTIC_BILLING = "false"
-SAFE_BALANCE_THRESHOLD = ""
+INFERENCE_OPTIMISTIC_BILLING = "true"
+SAFE_BALANCE_THRESHOLD = "5.00"
 FORCE_REDIS_EVENTS = "false"
 R2_PUBLIC_HOST = "blob.elizacloud.ai"
 SQL_HEAVY_PAYLOAD_STORAGE = "r2"


### PR DESCRIPTION
Enables Tier-2 optimistic off-path billing in **production** on `develop`, matching the cutover already set on `main`.

## What changed
`packages/cloud/api/wrangler.toml`, **`[env.production.vars]` only**:
- `INFERENCE_OPTIMISTIC_BILLING`: `"false"` → `"true"`
- `SAFE_BALANCE_THRESHOLD`: `""` → `"5.00"`

Default and `[env.staging]` are **unchanged** (stay on the safe synchronous-reserve path) — exactly mirroring `main`, where only `[env.production.vars]` was flipped.

## Why not just merge #10089 (main → develop)
`main` predates develop's `packages/cloud-api/` → `packages/cloud/api/` reorg, so a branch merge drags main's stale pre-reorg tree into develop (GitHub reports it non-mergeable). This delivers the same value flip surgically against the current develop layout. **#10089 is superseded by this.**

## Verification
```
$ grep -nE "INFERENCE_OPTIMISTIC_BILLING|SAFE_BALANCE_THRESHOLD" packages/cloud/api/wrangler.toml
150: INFERENCE_OPTIMISTIC_BILLING = "false"   # default — unchanged
151: SAFE_BALANCE_THRESHOLD = ""
324: INFERENCE_OPTIMISTIC_BILLING = "false"   # staging — unchanged
325: SAFE_BALANCE_THRESHOLD = ""
456: INFERENCE_OPTIMISTIC_BILLING = "true"    # production — flipped
457: SAFE_BALANCE_THRESHOLD = "5.00"
```
Config-only; affects prod behavior only on the next `wrangler deploy --env production`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)