### PR TITLE
feat(reliability): agents never crash on background rejections + auto-restart everywhere

### DIFF
--- a/packages/agent/src/cli/index.ts
+++ b/packages/agent/src/cli/index.ts
@@ -107,6 +107,14 @@ export async function runAutonomousCli(
   }
 
   if (command === "serve" || command === "start") {
+    // Keep a serving agent alive across background promise rejections, and hand
+    // an uncaught exception off to the supervisor (Docker/K8s restart policy,
+    // desktop AgentManager, dev api-supervisor) for a clean restart instead of
+    // a silent death. One-shot commands and tests keep default behavior.
+    if (process.env.NODE_ENV !== "test") {
+      const { installProcessCrashGuards } = await import("@elizaos/shared");
+      installProcessCrashGuards({ onUncaughtException: "restart" });
+    }
     const keepAlive = setInterval(() => {}, 1 << 30);
     const { startEliza } = await import("../runtime/index.ts");
     const runtime = await startEliza({ serverOnly: true }).catch((error) => {

--- a/packages/app-core/deploy/cloud-agent-shared.ts
+++ b/packages/app-core/deploy/cloud-agent-shared.ts
@@ -788,7 +788,9 @@ export function startCloudAgent(userConfig: CloudAgentConfig = {}): void {
 
   const bridgeBindAddress = bridgeSecretGenerated ? "127.0.0.1" : "0.0.0.0";
   bridgeServer.listen(BRIDGE_PORT, bridgeBindAddress, () => {
-    logger.info(`Bridge server listening on ${bridgeBindAddress}:${BRIDGE_PORT}`);
+    logger.info(
+      `Bridge server listening on ${bridgeBindAddress}:${BRIDGE_PORT}`,
+    );
     if (bridgeSecretGenerated) {
       logger.warn(
         "CRITICAL: No BRIDGE_SECRET configured — generated ephemeral secret and bound to 127.0.0.1 only",
@@ -807,6 +809,30 @@ export function startCloudAgent(userConfig: CloudAgentConfig = {}): void {
   }
   process.on("SIGTERM", shutdown);
   process.on("SIGINT", shutdown);
+
+  // Crash guards. This file is bundled by esbuild for the cloud-agent image,
+  // which only installs @elizaos/core + @elizaos/plugin-sql, so we cannot import
+  // @elizaos/shared's installProcessCrashGuards here — the guards are inlined.
+  // A rejected background promise must never take down the container; a truly
+  // uncaught exception exits non-zero so the orchestrator (Docker
+  // `--restart unless-stopped` / K8s `restartPolicy: Always`) relaunches a clean
+  // container. Exit code matches @elizaos/shared RESTART_EXIT_CODE.
+  const CLOUD_AGENT_RESTART_EXIT_CODE = 75;
+  process.on("unhandledRejection", (reason) => {
+    logger.error("Unhandled promise rejection (non-fatal)", {
+      err:
+        reason instanceof Error
+          ? (reason.stack ?? reason.message)
+          : String(reason),
+    });
+  });
+  process.on("uncaughtException", (error) => {
+    logger.error("Uncaught exception — exiting for orchestrator restart", {
+      err:
+        error instanceof Error ? (error.stack ?? error.message) : String(error),
+    });
+    process.exit(CLOUD_AGENT_RESTART_EXIT_CODE);
+  });
 
   initRuntime()
     .then(() => {

--- a/packages/app-core/platforms/electrobun/src/native/agent.ts
+++ b/packages/app-core/platforms/electrobun/src/native/agent.ts
@@ -115,6 +115,15 @@ type BunSubprocess = ReturnType<typeof Bun.spawn>;
 const HEALTH_POLL_INTERVAL_MS = process.platform === "win32" ? 2_000 : 500;
 const SIGTERM_GRACE_MS = 5_000;
 const AGENT_NAME_FETCH_TIMEOUT_MS = 5_000;
+
+// Crash auto-restart: when the embedded agent child exits unexpectedly (a crash,
+// not a user-initiated stop), relaunch it with exponential backoff. A rolling
+// window guards against a tight crash loop — after the cap we leave the agent in
+// `error` so the renderer can surface a manual recovery action.
+const AGENT_CRASH_RESTART_WINDOW_MS = 60_000;
+const AGENT_CRASH_RESTART_MAX = 5;
+const AGENT_CRASH_RESTART_BASE_DELAY_MS = 1_000;
+const AGENT_CRASH_RESTART_MAX_DELAY_MS = 30_000;
 const WINDOWS_ABS_PATH_RE = /^[A-Za-z]:[\\/]/;
 const ELIZA_CONFIG_FILENAME = "eliza.json";
 
@@ -1363,6 +1372,10 @@ export class AgentManager {
   private startupPhase = "not_started";
   private databaseSnapshot: DatabaseSnapshot = createUnknownDatabaseSnapshot();
   private databaseStartupLock: DatabaseStartupLock | null = null;
+  /** Timestamps (ms) of recent crash-triggered restarts, for loop detection. */
+  private readonly crashRestartTimestamps: number[] = [];
+  /** Pending crash auto-restart timer, if one is scheduled. */
+  private autoRestartTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor() {
     this.persistStartupDiagnostics();
@@ -1398,6 +1411,9 @@ export class AgentManager {
       `[Agent] start() called, current state: ${this.status.state}`,
     );
     diagnosticLog(`[Agent] Diagnostic log file: ${getDiagnosticLogPath()}`);
+
+    // A start request (manual or auto-restart) supersedes any queued recovery.
+    this.cancelAutoRestart();
 
     if (this.status.state === "running" || this.status.state === "starting") {
       return this.status;
@@ -1916,6 +1932,10 @@ export class AgentManager {
 
   /** Stop the agent runtime. */
   async stop(): Promise<void> {
+    // A deliberate stop cancels any pending crash auto-restart, regardless of
+    // current state (the crash may have already moved us to `error`).
+    this.cancelAutoRestart();
+
     if (this.status.state !== "running" && this.status.state !== "starting") {
       return;
     }
@@ -2300,6 +2320,7 @@ export class AgentManager {
           );
           this.releaseDatabaseStartupLock();
           this.emitStatus();
+          this.scheduleCrashRestart();
         } else {
           // Expected exit (we called stop)
           this.childProcess = null;
@@ -2331,8 +2352,81 @@ export class AgentManager {
           };
           this.setStartupPhase("process_exit_error", shortError(err));
           this.emitStatus();
+          this.scheduleCrashRestart();
         }
       });
+  }
+
+  /**
+   * Cancel any pending crash auto-restart. Called on user-initiated start/stop
+   * so a deliberate action supersedes a queued recovery.
+   */
+  private cancelAutoRestart(): void {
+    if (this.autoRestartTimer) {
+      clearTimeout(this.autoRestartTimer);
+      this.autoRestartTimer = null;
+    }
+  }
+
+  /**
+   * Schedule an automatic restart after an unexpected child exit (a crash).
+   *
+   * Exponential backoff with a rolling-window loop guard: once the agent has
+   * crash-restarted more than {@link AGENT_CRASH_RESTART_MAX} times inside
+   * {@link AGENT_CRASH_RESTART_WINDOW_MS}, we stop and leave the agent in
+   * `error` (a deterministic failure — bad config, corrupt DB — won't fix itself
+   * by relaunching). PGLite errors are excluded entirely: they need the user's
+   * explicit database-recovery action, not a relaunch.
+   */
+  private scheduleCrashRestart(): void {
+    if (this.autoRestartTimer) return;
+    if (this.hasPgliteError) {
+      diagnosticLog(
+        "[Agent] Skipping crash auto-restart — PGLite error needs manual database recovery.",
+      );
+      return;
+    }
+
+    const now = Date.now();
+    this.crashRestartTimestamps.push(now);
+    while (
+      this.crashRestartTimestamps.length > 0 &&
+      this.crashRestartTimestamps[0] < now - AGENT_CRASH_RESTART_WINDOW_MS
+    ) {
+      this.crashRestartTimestamps.shift();
+    }
+    if (this.crashRestartTimestamps.length > AGENT_CRASH_RESTART_MAX) {
+      diagnosticLog(
+        `[Agent] Crash-restart loop detected (${this.crashRestartTimestamps.length} restarts in ${AGENT_CRASH_RESTART_WINDOW_MS / 1000}s) — leaving agent in error. Manual restart required.`,
+      );
+      return;
+    }
+
+    const attempt = this.crashRestartTimestamps.length;
+    const delay = Math.min(
+      AGENT_CRASH_RESTART_MAX_DELAY_MS,
+      AGENT_CRASH_RESTART_BASE_DELAY_MS * 2 ** (attempt - 1),
+    );
+    diagnosticLog(
+      `[Agent] Scheduling automatic restart after crash (attempt ${attempt}/${AGENT_CRASH_RESTART_MAX}) in ${delay}ms`,
+    );
+    this.autoRestartTimer = setTimeout(() => {
+      this.autoRestartTimer = null;
+      // A user-initiated start/stop since the crash supersedes this recovery.
+      if (this.status.state !== "error") {
+        diagnosticLog(
+          `[Agent] Skipping scheduled restart — state is now ${this.status.state}`,
+        );
+        return;
+      }
+      diagnosticLog("[Agent] Auto-restarting crashed agent...");
+      void this.start().catch((err) => {
+        diagnosticLog(
+          `[Agent] Auto-restart failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
+    }, delay);
+    this.autoRestartTimer.unref?.();
   }
 
   /**

--- a/packages/app-core/src/cli/run-main.ts
+++ b/packages/app-core/src/cli/run-main.ts
@@ -1,6 +1,7 @@
 import process from "node:process";
 import {
   getLogPrefix,
+  installProcessCrashGuards,
   RESTART_EXIT_CODE,
   setRestartHandler,
 } from "@elizaos/shared";
@@ -10,6 +11,58 @@ import {
 } from "../runtime/error-handlers";
 import { getPrimaryCommand, hasHelpOrVersion } from "./argv";
 import { registerSubCliByName } from "./program/register.subclis";
+
+/** Commands that boot a long-running server we must keep alive across faults. */
+const LONG_RUNNING_COMMANDS = new Set(["start", "serve"]);
+
+function isLongRunningServerCommand(argv: string[]): boolean {
+  const primary = getPrimaryCommand(argv);
+  return primary != null && LONG_RUNNING_COMMANDS.has(primary);
+}
+
+/**
+ * Install the global crash handlers.
+ *
+ * For a long-running server (`start` / `serve`) a background promise rejection
+ * must never take down the agent, and an uncaught exception should hand off to
+ * the supervisor for a clean restart — so we use {@link installProcessCrashGuards}.
+ * One-shot CLI commands keep the strict "fail the command" behavior. Tests opt
+ * out entirely so a rejection still fails the test.
+ */
+function installGlobalErrorHandlers(argv: string[]): void {
+  if (process.env.NODE_ENV === "test") return;
+
+  if (isLongRunningServerCommand(argv)) {
+    installProcessCrashGuards({
+      logPrefix: getLogPrefix(),
+      isIgnorable: shouldIgnoreUnhandledRejection,
+      onUncaughtException: "restart",
+    });
+    return;
+  }
+
+  process.on("unhandledRejection", (reason) => {
+    if (shouldIgnoreUnhandledRejection(reason)) {
+      console.warn(
+        `${getLogPrefix()} Provider credits appear exhausted; request failed without output. Top up credits and retry.`,
+      );
+      return;
+    }
+    console.error(
+      `${getLogPrefix()} Unhandled rejection:`,
+      formatUncaughtError(reason),
+    );
+    process.exit(1);
+  });
+
+  process.on("uncaughtException", (error) => {
+    console.error(
+      `${getLogPrefix()} Uncaught exception:`,
+      formatUncaughtError(error),
+    );
+    process.exit(1);
+  });
+}
 
 let cliRestartHandlerRegistered = false;
 
@@ -62,27 +115,7 @@ export async function runCli(argv: string[] = process.argv) {
   // has a chance to flush cleanly before the process spins down.
   program.exitOverride();
 
-  process.on("unhandledRejection", (reason) => {
-    if (shouldIgnoreUnhandledRejection(reason)) {
-      console.warn(
-        `${getLogPrefix()} Provider credits appear exhausted; request failed without output. Top up credits and retry.`,
-      );
-      return;
-    }
-    console.error(
-      `${getLogPrefix()} Unhandled rejection:`,
-      formatUncaughtError(reason),
-    );
-    process.exit(1);
-  });
-
-  process.on("uncaughtException", (error) => {
-    console.error(
-      `${getLogPrefix()} Uncaught exception:`,
-      formatUncaughtError(error),
-    );
-    process.exit(1);
-  });
+  installGlobalErrorHandlers(argv);
 
   const primary = getPrimaryCommand(argv);
   if (primary && !hasHelpOrVersion(argv)) {

--- a/packages/app-core/src/runtime/error-handlers.ts
+++ b/packages/app-core/src/runtime/error-handlers.ts
@@ -1,65 +1,12 @@
 /**
  * Shared error-formatting utilities for global process handlers.
- * Used by both the CLI (run-main.ts) and the dev-server (dev-server.ts).
- * Intentionally dependency-free — only string operations.
+ *
+ * The implementations now live in `@elizaos/shared` (`error-classification.ts`)
+ * so the agent package and the on-device bridges can reuse them without an
+ * `app-core → agent` cycle. Re-exported here so existing importers
+ * (`run-main.ts`, `dev-server.ts`) keep resolving.
  */
-
-export function formatUncaughtError(error: unknown): string {
-  if (error instanceof Error) {
-    return error.stack ?? error.message;
-  }
-  return String(error);
-}
-
-function hasInsufficientCreditsSignal(input: string): boolean {
-  return /\b(insufficient(?:[_\s]+(?:credits?|quota))|insufficient_quota|out of credits|payment required|statuscode:\s*402)\b/i.test(
-    input,
-  );
-}
-
-/**
- * Returns `true` when the rejection looks like an AI provider credit-exhaustion
- * error — these are noisy but not fatal, so callers should warn instead of crash.
- */
-export function shouldIgnoreUnhandledRejection(reason: unknown): boolean {
-  const formatted = formatUncaughtError(reason);
-  if (
-    !/AI_NoOutputGeneratedError|No output generated|AI_APICallError|AI_RetryError/i.test(
-      formatted,
-    )
-  ) {
-    return false;
-  }
-
-  if (hasInsufficientCreditsSignal(formatted)) {
-    return true;
-  }
-
-  const seen = new Set<unknown>();
-  let current: unknown = reason;
-  while (current && typeof current === "object" && !seen.has(current)) {
-    seen.add(current);
-
-    const statusCode = (current as { statusCode?: number }).statusCode;
-    if (statusCode === 402) return true;
-
-    const responseBody = (current as { responseBody?: unknown }).responseBody;
-    if (
-      typeof responseBody === "string" &&
-      hasInsufficientCreditsSignal(responseBody)
-    ) {
-      return true;
-    }
-
-    const errors = (current as { errors?: unknown }).errors;
-    if (Array.isArray(errors)) {
-      for (const inner of errors) {
-        if (shouldIgnoreUnhandledRejection(inner)) return true;
-      }
-    }
-
-    current = (current as { cause?: unknown }).cause;
-  }
-
-  return false;
-}
+export {
+  formatUncaughtError,
+  shouldIgnoreUnhandledRejection,
+} from "@elizaos/shared";

--- a/packages/shared/src/error-classification.ts
+++ b/packages/shared/src/error-classification.ts
@@ -1,0 +1,67 @@
+/**
+ * Error-formatting + classification utilities for global process handlers.
+ *
+ * Shared between the CLI (`run-main.ts`), the dev-server (`dev-server.ts`), the
+ * agent serve path, and `installProcessCrashGuards` (`process-guards.ts`).
+ * Intentionally dependency-free — only string/object inspection.
+ */
+
+export function formatUncaughtError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.stack ?? error.message;
+  }
+  return String(error);
+}
+
+function hasInsufficientCreditsSignal(input: string): boolean {
+  return /\b(insufficient(?:[_\s]+(?:credits?|quota))|insufficient_quota|out of credits|payment required|statuscode:\s*402)\b/i.test(
+    input,
+  );
+}
+
+/**
+ * Returns `true` when the rejection looks like an AI provider credit-exhaustion
+ * error — these are noisy but not fatal, so callers should warn instead of crash.
+ */
+export function shouldIgnoreUnhandledRejection(reason: unknown): boolean {
+  const formatted = formatUncaughtError(reason);
+  if (
+    !/AI_NoOutputGeneratedError|No output generated|AI_APICallError|AI_RetryError/i.test(
+      formatted,
+    )
+  ) {
+    return false;
+  }
+
+  if (hasInsufficientCreditsSignal(formatted)) {
+    return true;
+  }
+
+  const seen = new Set<unknown>();
+  let current: unknown = reason;
+  while (current && typeof current === "object" && !seen.has(current)) {
+    seen.add(current);
+
+    const statusCode = (current as { statusCode?: number }).statusCode;
+    if (statusCode === 402) return true;
+
+    const responseBody = (current as { responseBody?: unknown }).responseBody;
+    if (
+      typeof responseBody === "string" &&
+      hasInsufficientCreditsSignal(responseBody)
+    ) {
+      return true;
+    }
+
+    const errors = (current as { errors?: unknown }).errors;
+    if (Array.isArray(errors)) {
+      for (const inner of errors) {
+        if (shouldIgnoreUnhandledRejection(inner)) return true;
+      }
+    }
+
+    current = (current as { cause?: unknown }).cause;
+  }
+
+  return false;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -242,6 +242,7 @@ export * from "./elizacloud/index.js";
 // @elizaos/plugin-personal-assistant.
 export * from "./email-classification/index.js";
 export * from "./env-utils.js";
+export * from "./error-classification.js";
 export * from "./events/index.js";
 export * from "./format-error.js";
 // Knowledge-graph primitives — canonical Entity/Relationship types + the
@@ -263,6 +264,7 @@ export * from "./lifeops-normalize/index.js";
 export * from "./local-inference/index.js";
 export * from "./loopback-trust.js";
 export * from "./platform/is-native-server.js";
+export * from "./process-guards.js";
 export * from "./recent-messages-state.js";
 export * from "./restart.js";
 export * from "./runtime-env.js";

--- a/packages/shared/src/process-guards.test.ts
+++ b/packages/shared/src/process-guards.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { shouldIgnoreUnhandledRejection } from "./error-classification.js";
+import {
+  installProcessCrashGuards,
+  resetProcessCrashGuardsForTest,
+} from "./process-guards.js";
+import { RESTART_EXIT_CODE } from "./restart.js";
+
+/**
+ * Capture the listeners that `installProcessCrashGuards` registers without
+ * actually attaching them to the live process (which would let a deliberately
+ * triggered rejection escape into the test runner).
+ */
+function captureGuards(
+  options: Parameters<typeof installProcessCrashGuards>[0] = {},
+) {
+  const listeners: Record<string, (arg: unknown) => void> = {};
+  const spy = vi
+    .spyOn(process, "on")
+    .mockImplementation(
+      (event: string | symbol, fn: (...args: unknown[]) => void) => {
+        listeners[String(event)] = fn as (arg: unknown) => void;
+        return process;
+      },
+    );
+  const installed = installProcessCrashGuards(options);
+  spy.mockRestore();
+  return { installed, listeners };
+}
+
+describe("installProcessCrashGuards", () => {
+  beforeEach(() => resetProcessCrashGuardsForTest());
+  afterEach(() => resetProcessCrashGuardsForTest());
+
+  it("is idempotent across calls", () => {
+    const first = captureGuards({ exit: () => {} });
+    expect(first.installed).toBe(true);
+    const second = captureGuards({ exit: () => {} });
+    expect(second.installed).toBe(false);
+  });
+
+  it("treats a background rejection as non-fatal (logs, never exits)", () => {
+    const log = vi.fn();
+    const warn = vi.fn();
+    const exit = vi.fn();
+    const { listeners } = captureGuards({ log, warn, exit });
+
+    listeners.unhandledRejection?.(new Error("connector poll blew up"));
+
+    expect(exit).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log.mock.calls[0][0]).toContain("non-fatal");
+  });
+
+  it("warns (not errors) on provider credit-exhaustion rejections", () => {
+    const log = vi.fn();
+    const warn = vi.fn();
+    const exit = vi.fn();
+    const { listeners } = captureGuards({ log, warn, exit });
+
+    listeners.unhandledRejection?.(
+      new Error("AI_APICallError: insufficient_quota"),
+    );
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(log).not.toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  it("requests a supervised restart on uncaught exception (default policy)", () => {
+    const exit = vi.fn();
+    const { listeners } = captureGuards({ exit, log: () => {} });
+
+    listeners.uncaughtException?.(new Error("boom"));
+
+    expect(exit).toHaveBeenCalledWith(RESTART_EXIT_CODE);
+  });
+
+  it("keeps the agent alive on uncaught exception under keep-alive policy", () => {
+    const exit = vi.fn();
+    const { listeners } = captureGuards({
+      exit,
+      log: () => {},
+      onUncaughtException: "keep-alive",
+    });
+
+    listeners.uncaughtException?.(new Error("boom"));
+
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  it("exits with code 1 under exit policy", () => {
+    const exit = vi.fn();
+    const { listeners } = captureGuards({
+      exit,
+      log: () => {},
+      onUncaughtException: "exit",
+    });
+
+    listeners.uncaughtException?.(new Error("boom"));
+
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+});
+
+describe("shouldIgnoreUnhandledRejection", () => {
+  it("ignores AI provider credit-exhaustion errors", () => {
+    expect(
+      shouldIgnoreUnhandledRejection(
+        new Error("AI_NoOutputGeneratedError: No output generated"),
+      ),
+    ).toBe(false); // no credit signal → surfaced
+
+    const credit = Object.assign(
+      new Error("AI_APICallError: payment required"),
+      { statusCode: 402 },
+    );
+    expect(shouldIgnoreUnhandledRejection(credit)).toBe(true);
+  });
+
+  it("does not ignore ordinary runtime errors", () => {
+    expect(
+      shouldIgnoreUnhandledRejection(new Error("TypeError: x is undefined")),
+    ).toBe(false);
+  });
+});

--- a/packages/shared/src/process-guards.ts
+++ b/packages/shared/src/process-guards.ts
@@ -1,0 +1,123 @@
+/**
+ * Process-level crash guards for long-running Eliza agents.
+ *
+ * A serving agent — the desktop child process, a cloud container, the on-device
+ * Bun runtime — must survive a background promise rejection. Node and Bun both
+ * terminate the process on an *unhandled* rejection by default, so every
+ * fire-and-forget task that rejects (a deferred plugin import, a connector poll,
+ * an autonomy tick) is a self-inflicted outage. These guards make such
+ * rejections loud-but-non-fatal, and turn a genuinely uncaught synchronous
+ * exception into a *supervised restart* (or, on platforms without a supervisor,
+ * a deliberate keep-alive) instead of an ambiguous death.
+ *
+ * Install ONLY on long-running entry paths (serve / start). One-shot CLI
+ * commands and tests must keep the default behavior, where a rejection still
+ * fails the command.
+ *
+ * @module process-guards
+ */
+
+import { shouldIgnoreUnhandledRejection } from "./error-classification";
+import { RESTART_EXIT_CODE } from "./restart";
+
+/**
+ * What to do when a truly uncaught synchronous exception escapes all handlers.
+ *
+ * - `"restart"` — exit with {@link RESTART_EXIT_CODE} so the surrounding
+ *   supervisor (dev `api-supervisor`, desktop `AgentManager`, Docker/K8s restart
+ *   policy) relaunches a clean process. The right default for any supervised
+ *   agent.
+ * - `"exit"` — exit with code 1. For environments where a non-restart abnormal
+ *   exit is the desired signal.
+ * - `"keep-alive"` — log loudly and keep running. Last resort for an in-process
+ *   runtime that cannot be relaunched cheaply (the iOS WebView Bun host), where
+ *   a degraded-but-alive agent beats killing the whole app.
+ */
+export type UncaughtExceptionPolicy = "restart" | "exit" | "keep-alive";
+
+export interface ProcessCrashGuardOptions {
+  /** Prefix for log lines, e.g. `"[eliza]"`. Defaults to `"[eliza]"`. */
+  logPrefix?: string;
+  /**
+   * Classifies a rejection as benign-and-ignorable (warned, not surfaced as an
+   * error). Defaults to {@link shouldIgnoreUnhandledRejection} (provider
+   * credit-exhaustion noise).
+   */
+  isIgnorable?: (reason: unknown) => boolean;
+  /** Policy for an uncaught synchronous exception. Defaults to `"restart"`. */
+  onUncaughtException?: UncaughtExceptionPolicy;
+  /** Error-level logger. Defaults to `console.error` with the prefix. */
+  log?: (message: string) => void;
+  /** Warn-level logger. Defaults to `console.warn` with the prefix. */
+  warn?: (message: string) => void;
+  /** Test seam for the process exit call. Defaults to `process.exit`. */
+  exit?: (code: number) => void;
+}
+
+function formatReason(reason: unknown): string {
+  if (reason instanceof Error) {
+    return reason.stack ?? reason.message;
+  }
+  return String(reason);
+}
+
+let guardsInstalled = false;
+
+/** Test-only: clear the idempotency latch so guards can be re-installed. */
+export function resetProcessCrashGuardsForTest(): void {
+  guardsInstalled = false;
+}
+
+/**
+ * Install process-level `unhandledRejection` + `uncaughtException` guards.
+ *
+ * Idempotent across the whole process: the first call wins and subsequent calls
+ * (from a deeper entry layer that imports the same `@elizaos/shared`) are no-ops.
+ * Returns `true` when the guards were installed, `false` when skipped (already
+ * installed, or no `process` object — e.g. a browser bundle).
+ */
+export function installProcessCrashGuards(
+  options: ProcessCrashGuardOptions = {},
+): boolean {
+  if (guardsInstalled) return false;
+  if (typeof process === "undefined" || typeof process.on !== "function") {
+    return false;
+  }
+  guardsInstalled = true;
+
+  const prefix = options.logPrefix ?? "[eliza]";
+  const log = options.log ?? ((m: string) => console.error(`${prefix} ${m}`));
+  const warn = options.warn ?? ((m: string) => console.warn(`${prefix} ${m}`));
+  const isIgnorable = options.isIgnorable ?? shouldIgnoreUnhandledRejection;
+  const policy = options.onUncaughtException ?? "restart";
+  const exit = options.exit ?? ((code: number) => process.exit(code));
+
+  process.on("unhandledRejection", (reason: unknown) => {
+    if (isIgnorable(reason)) {
+      warn(
+        "Background request failed without output (provider credits exhausted?) — continuing.",
+      );
+      return;
+    }
+    // A rejected background promise must never take down a serving agent.
+    log(`Unhandled promise rejection (non-fatal): ${formatReason(reason)}`);
+  });
+
+  process.on("uncaughtException", (error: unknown) => {
+    log(`Uncaught exception: ${formatReason(error)}`);
+    if (policy === "keep-alive") {
+      log(
+        "Agent left running after uncaught exception (state may be degraded).",
+      );
+      return;
+    }
+    if (policy === "restart") {
+      log(`Requesting supervised restart (exit ${RESTART_EXIT_CODE}).`);
+      exit(RESTART_EXIT_CODE);
+      return;
+    }
+    exit(1);
+  });
+
+  return true;
+}

--- a/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/ios/bridge.ts
@@ -423,7 +423,68 @@ function hydrateIosEnvFromArgv(
 	return { appSupportDir, bundlePath };
 }
 
+/**
+ * Install process-level crash guards for the on-device iOS runtime.
+ *
+ * The Bun runtime here IS the iOS app's WebView host process, so a default
+ * `unhandledRejection`/`uncaughtException` termination kills the whole app and
+ * forces the user to relaunch from the home screen. Instead we keep the runtime
+ * alive: a rejected background promise is logged and ignored, and an uncaught
+ * exception is logged but does not exit — a degraded-but-alive agent beats a
+ * dead app, and the bridge's boot-retry recovers transient failures.
+ *
+ * Inlined (not imported from `@elizaos/shared`) so the mobile bundle's
+ * dependency set is unchanged. Idempotent via a globalThis latch.
+ */
+function installIosBackendCrashGuards(): void {
+	const slot = globalThis as { __elizaIosCrashGuardsInstalled?: boolean };
+	if (slot.__elizaIosCrashGuardsInstalled) return;
+	slot.__elizaIosCrashGuardsInstalled = true;
+	const format = (value: unknown): string =>
+		value instanceof Error ? (value.stack ?? value.message) : String(value);
+	process.on("unhandledRejection", (reason) => {
+		console.error(
+			"[ios-bridge] Unhandled promise rejection (non-fatal):",
+			format(reason),
+		);
+	});
+	process.on("uncaughtException", (error) => {
+		console.error(
+			"[ios-bridge] Uncaught exception (agent kept alive):",
+			format(error),
+		);
+	});
+}
+
+/**
+ * Boot the runtime with a bounded retry so a transient init failure (a slow
+ * keychain read, a model file still being written, a flaky first DB open)
+ * self-heals instead of permanently wedging the backend in `bootError`.
+ */
+async function bootRuntimeWithRetry(
+	boot: () => Promise<IAgentRuntime>,
+): Promise<IAgentRuntime> {
+	const maxAttempts = 3;
+	let lastError: unknown;
+	for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+		try {
+			return await boot();
+		} catch (error) {
+			lastError = error;
+			if (attempt >= maxAttempts) break;
+			const backoffMs = 1000 * 2 ** (attempt - 1);
+			console.error(
+				`[ios-bridge] runtime boot attempt ${attempt}/${maxAttempts} failed; retrying in ${backoffMs}ms:`,
+				error instanceof Error ? error.message : String(error),
+			);
+			await new Promise((resolve) => setTimeout(resolve, backoffMs));
+		}
+	}
+	throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
 async function startIosBridgeBackend(): Promise<IosBridgeBackend> {
+	installIosBackendCrashGuards();
 	const argvEnv = hydrateIosEnvFromArgv();
 	// ── Mobile filesystem sandbox ────────────────────────────────────────────
 	// Install the fs shim as the very first action — before any runtime code
@@ -468,7 +529,7 @@ async function startIosBridgeBackend(): Promise<IosBridgeBackend> {
 
 	const { bootElizaRuntime, dispatchRoute } = await loadAgentModule();
 
-	const runtime = await bootElizaRuntime();
+	const runtime = await bootRuntimeWithRetry(bootElizaRuntime);
 	installIosNativeLlamaHandlers(runtime);
 
 	maybeAutoRunModelGrind();


### PR DESCRIPTION
## Problem

A serving Eliza agent could be killed by a single **background promise rejection** — a deferred plugin import, a connector poll, an autonomy tick. Node and Bun terminate the process on an unhandled rejection by default, and a cross-cutting sweep found **no global `uncaughtException`/`unhandledRejection` handlers anywhere** in the runtime. Separately, the **desktop** (Electrobun) and **iOS** local agents had **no crash auto-restart** at all — a crash left the agent dead until the user intervened.

Goal: *the local and cloud agent build, start up, and never crash, and if they crash they can automatically process-restart on iOS, Android, cloud container, desktop — everywhere.*

## Pre-existing supervision (verified, left as-is)

| Surface | Auto-restart on crash | Mechanism |
|---|---|---|
| Cloud K8s | ✅ | Deployment `restartPolicy: Always` + liveness `/health` |
| Cloud Hetzner Docker | ✅ | `--restart unless-stopped` |
| Android | ✅ | foreground service + 10-min watchdog + exit-watcher + backoff + `START_STICKY` |
| Dev | ✅ | `api-supervisor.mjs` relaunch-on-any-non-shutdown-exit with crash-loop backoff |
| **Desktop** | ❌ → **fixed** | detected crash, never restarted |
| **iOS** | ❌ → **fixed** | in-process Bun host, zero supervision |
| **Every Node/Bun agent** | ❌ → **fixed** | a background rejection silently killed the process |

## Changes

**Centralized crash guards** — new `@elizaos/shared` `installProcessCrashGuards`:
- `unhandledRejection` → logged but **non-fatal** (a background rejection never kills a serving agent). Provider credit-exhaustion noise is warned, not surfaced.
- `uncaughtException` → hand off to the supervisor via `RESTART_EXIT_CODE` (75), or **keep-alive** on iOS where the Bun runtime *is* the app's WebView host.
- Idempotent across entry layers; opted out under `NODE_ENV=test`.
- Consolidated `formatUncaughtError`/`shouldIgnoreUnhandledRejection` into `@elizaos/shared/error-classification` (agent + on-device bridges can reuse without an `app-core→agent` cycle); `app-core/error-handlers` re-exports for back-compat.

**Wired into every long-running entry path:**
- `packages/agent/src/cli/index.ts` serve/start (CI/cloud `bin.js start` + mobile-bun) — restart policy.
- `packages/app-core/src/cli/run-main.ts` — server commands (`start`/`serve`) use the resilient guards; one-shot CLI commands keep strict fail-the-command behavior.
- `packages/app-core/deploy/cloud-agent-shared.ts` — inline guards (the minimal Docker/K8s image can't import shared); uncaught exits non-zero so the orchestrator restarts.
- `plugins/plugin-capacitor-bridge/src/ios/bridge.ts` — inline keep-alive guards + bounded boot retry so a transient init failure self-heals instead of wedging the backend.

**Desktop crash auto-restart** — `packages/app-core/platforms/electrobun/src/native/agent.ts`:
- On unexpected child exit, relaunch with exponential backoff + a rolling-window loop guard (`scheduleCrashRestart`). PGLite errors are excluded (need manual recovery). A deliberate start/stop cancels a queued restart.

## Evidence

- **Unit:** new `process-guards` suite (8 tests) ✅ + `api-supervisor` regression (7) ✅.
- **Behavioral (the core "never crash"):** a *real* unhandled rejection is **survived under both `bun` and `node`+tsx**; the control (no guard) crashes the process. 
- **Typecheck clean:** `shared`, `app-core`, `electrobun`, `agent`, `capacitor-bridge`.
- **Real local-agent boot** (`bin.js serve`, throwaway state dir):
  ```
  GET /api/health → 200
  {"ready":true,"canRespond":false,"runtime":"ok","database":"ok",
   "plugins":{"loaded":8,"failed":0},"agentState":"running","startup":{"phase":"running"}}
  ```
- **Cloud:** `cloud-agent` entrypoint esbuild/bun bundle compiles with the guards embedded.

> N/A — live-LLM trajectory / device capture / UI screenshots: this change is process-lifecycle/supervision only (no prompt, model, action, or UI surface touched). The behavioral proof above exercises the real failure path on the real runtimes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)