### PR TITLE
fix(cloud): malformed request body → 400 not 500 on chat/embeddings/api-keys

### DIFF
--- a/packages/cloud/api/__tests__/malformed-json-body-routes.test.ts
+++ b/packages/cloud/api/__tests__/malformed-json-body-routes.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Regression coverage for launch-audit input validation: these routes used to
+ * let malformed JSON escape as a 500 from req.json(). They should fail closed
+ * as caller-error 400s before provider, billing, or API-key side effects.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import * as authActual from "@/lib/auth";
+import * as workersHonoAuthActual from "@/lib/auth/workers-hono-auth";
+import * as rateLimitActual from "@/lib/middleware/rate-limit";
+import * as rateLimitHonoActual from "@/lib/middleware/rate-limit-hono-cloudflare";
+import * as inferenceAuthActual from "@/lib/services/inference-auth-context";
+
+const ORG = "00000000-0000-4000-8000-0000000000aa";
+const USER = "00000000-0000-4000-8000-0000000000bb";
+
+const requireAuthOrApiKeyWithOrg = mock();
+const requireUserOrApiKeyWithOrg = mock();
+const requireUserWithOrg = mock();
+const enforceOrgRateLimit = mock();
+const resolveInferenceAuthContext = mock();
+
+mock.module("@/lib/auth", () => ({
+  ...authActual,
+  requireAuthOrApiKeyWithOrg,
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  ...workersHonoAuthActual,
+  requireUserOrApiKeyWithOrg,
+  requireUserWithOrg,
+}));
+
+mock.module("@/lib/middleware/rate-limit", () => ({
+  ...rateLimitActual,
+  enforceOrgRateLimit,
+}));
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  ...rateLimitHonoActual,
+  RateLimitPresets: {
+    ...rateLimitHonoActual.RateLimitPresets,
+    RELAXED: {},
+    STANDARD: {},
+  },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => {
+    await next();
+  },
+}));
+
+mock.module("@/lib/services/inference-auth-context", () => ({
+  ...inferenceAuthActual,
+  resolveInferenceAuthContext,
+}));
+
+const chatModule = await import("../v1/chat/completions/route");
+const { handleChatCompletionsPOST } = chatModule;
+const embeddingsRoute = (await import("../v1/embeddings/route")).default;
+const apiKeysRoute = (await import("../v1/api-keys/route")).default;
+
+afterAll(() => {
+  mock.module("@/lib/auth", () => authActual);
+  mock.module("@/lib/auth/workers-hono-auth", () => workersHonoAuthActual);
+  mock.module("@/lib/middleware/rate-limit", () => rateLimitActual);
+  mock.module(
+    "@/lib/middleware/rate-limit-hono-cloudflare",
+    () => rateLimitHonoActual,
+  );
+  mock.module(
+    "@/lib/services/inference-auth-context",
+    () => inferenceAuthActual,
+  );
+});
+
+beforeEach(() => {
+  requireAuthOrApiKeyWithOrg.mockReset();
+  requireUserOrApiKeyWithOrg.mockReset();
+  requireUserWithOrg.mockReset();
+  enforceOrgRateLimit.mockReset();
+  resolveInferenceAuthContext.mockReset();
+
+  requireAuthOrApiKeyWithOrg.mockResolvedValue({
+    user: { id: USER, organization_id: ORG },
+    apiKey: { id: "api-key-id" },
+  });
+  requireUserOrApiKeyWithOrg.mockImplementation(
+    async (c: { set: (k: string, v: unknown) => void }) => {
+      c.set("apiKeyId", "api-key-id");
+      return { id: USER, organization_id: ORG };
+    },
+  );
+  requireUserWithOrg.mockResolvedValue({ id: USER, organization_id: ORG });
+  enforceOrgRateLimit.mockResolvedValue(null);
+  resolveInferenceAuthContext.mockResolvedValue({
+    kind: "slow_path",
+    reason: "non_api_key",
+  });
+});
+
+function malformedJsonRequest(path = "/") {
+  return new Request(`http://test.local${path}`, {
+    method: "POST",
+    headers: {
+      Authorization: "Bearer eliza_test_key",
+      "Content-Type": "application/json",
+    },
+    body: "{",
+  });
+}
+
+async function expectStatus(res: Response, expected: number) {
+  if (res.status !== expected) {
+    throw new Error(
+      `expected HTTP ${expected}, got ${res.status}: ${await res.text()}`,
+    );
+  }
+}
+
+describe("malformed JSON body handling", () => {
+  test("chat completions returns 400 before model/provider work", async () => {
+    const res = await handleChatCompletionsPOST(malformedJsonRequest(), {
+      skipOrgRateLimit: true,
+    });
+
+    await expectStatus(res, 400);
+    const body = (await res.json()) as {
+      error?: { type?: string; code?: string };
+    };
+    expect(body.error?.type).toBe("invalid_request_error");
+    expect(body.error?.code).toBe("missing_required_parameter");
+  });
+
+  test("embeddings returns 400 before embedding or billing work", async () => {
+    const res = await embeddingsRoute.fetch(malformedJsonRequest());
+
+    await expectStatus(res, 400);
+    const body = (await res.json()) as {
+      error?: { type?: string; code?: string };
+    };
+    expect(body.error?.type).toBe("invalid_request_error");
+    expect(body.error?.code).toBe("missing_required_parameter");
+  });
+
+  test("api key creation returns 400 for an unparseable body", async () => {
+    const res = await apiKeysRoute.fetch(malformedJsonRequest());
+
+    await expectStatus(res, 400);
+    const body = (await res.json()) as { error?: string; details?: string };
+    expect(body.error).toBe("Invalid JSON body");
+    expect(body.details).toBe("Request body must be a valid JSON object");
+  });
+});

--- a/packages/cloud/api/v1/api-keys/route.ts
+++ b/packages/cloud/api/v1/api-keys/route.ts
@@ -59,7 +59,18 @@ app.get("/", async (c) => {
 app.post("/", async (c) => {
   try {
     const user = await requireUserWithOrg(c);
-    const body = await c.req.json();
+    // Guard a malformed/empty body to a 400 instead of a 500 — the ZodError
+    // branch in the catch only handles bad FIELDS, not an unparseable body.
+    const body = await c.req.json().catch(() => null);
+    if (!body || typeof body !== "object") {
+      return c.json(
+        {
+          error: "Invalid JSON body",
+          details: "Request body must be a valid JSON object",
+        },
+        400,
+      );
+    }
     const { name, description, rate_limit, expires_at } =
       createApiKeySchema.parse(body);
 

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -825,8 +825,7 @@ export async function handleChatCompletionsPOST(
 
     // 4. Validate
     if (
-      !request ||
-      !request.model ||
+      !request?.model ||
       !Array.isArray(request.messages) ||
       !request.messages.length
     ) {
@@ -1922,7 +1921,7 @@ async function handleNonStreamingRequest(
       }),
     );
   } catch (error) {
-    await settleReservation(0);
+    await settleReservation?.(0);
     throw error;
   }
 }

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -816,11 +816,20 @@ export async function handleChatCompletionsPOST(
       }
     }
 
-    // 3. Parse request
-    const request: ChatRequest = await req.json();
+    // 3. Parse request — guard a malformed/empty body to a 400 instead of a 500.
+    // An unguarded parse throws a SyntaxError that the outer catch maps to 500
+    // (and echoes the raw parse text); the sibling agents routes already guard
+    // this. Also require `messages` to be an ARRAY so a non-array value can't
+    // slip past the length check and TypeError later in `messages.filter(...)`.
+    const request = (await req.json().catch(() => null)) as ChatRequest | null;
 
     // 4. Validate
-    if (!request.model || !request.messages?.length) {
+    if (
+      !request ||
+      !request.model ||
+      !Array.isArray(request.messages) ||
+      !request.messages.length
+    ) {
       return addCorsHeaders(
         Response.json(
           {

--- a/packages/cloud/api/v1/embeddings/route.ts
+++ b/packages/cloud/api/v1/embeddings/route.ts
@@ -112,15 +112,17 @@ app.post("/", async (c) => {
     // Guard a malformed/empty body to a 400 instead of a 500 (mirrors the agents
     // routes). An unguarded parse throws a SyntaxError that failureResponse maps
     // to 500 on this always-on agent-recall hot path.
-    const request = (await c.req.json().catch(() => null)) as EmbeddingsRequest | null;
+    const request = (await c.req
+      .json()
+      .catch(() => null)) as EmbeddingsRequest | null;
 
-    if (!request || !request.model || !request.input) {
+    if (!request?.model || !request.input) {
       return c.json(
         {
           error: {
             message: "Missing required fields: model and input",
             type: "invalid_request_error",
-            param: !request.model ? "model" : "input",
+            param: !request?.model ? "model" : "input",
             code: "missing_required_parameter",
           },
         },

--- a/packages/cloud/api/v1/embeddings/route.ts
+++ b/packages/cloud/api/v1/embeddings/route.ts
@@ -109,9 +109,12 @@ app.post("/", async (c) => {
       if (orgRateLimited) return orgRateLimited;
     }
 
-    const request = (await c.req.json()) as EmbeddingsRequest;
+    // Guard a malformed/empty body to a 400 instead of a 500 (mirrors the agents
+    // routes). An unguarded parse throws a SyntaxError that failureResponse maps
+    // to 500 on this always-on agent-recall hot path.
+    const request = (await c.req.json().catch(() => null)) as EmbeddingsRequest | null;
 
-    if (!request.model || !request.input) {
+    if (!request || !request.model || !request.input) {
       return c.json(
         {
           error: {


### PR DESCRIPTION
## What

Three cloud API routes call `await req.json()` **unguarded**. On an empty/invalid body the parse throws a `SyntaxError` that the route's catch maps to **HTTP 500** (`api_error`) instead of **400 `invalid_request_error`** — and on the inference routes it echoes the raw parser text back to the caller. The codebase's own sibling `agents` routes already guard this exact call with `.catch(() => null)` → 400, so these are deviations, not design.

| Route | Line | Fix |
|---|---|---|
| `POST /v1/chat/completions` | parse + validate | `.catch(() => null)` → reuse the existing 400; also require `messages` to be an **array** (a non-array string slipped past `?.length` and then TypeError'd in `messages.filter(...)` → 500) |
| `POST /v1/embeddings` | parse | `.catch(() => null)` → 400 (always-on agent-recall hot path) |
| `POST /v1/api-keys` | parse | `.catch(() => null)` → 400 (the catch only special-cased `ZodError` = bad *fields*, not an unparseable body) |

## Why it matters (modest, not a launch-blocker)

- Correct status hygiene: malformed input is a client error (4xx), not a server error (5xx).
- Well-behaved OpenAI-compatible clients **retry on 5xx** — a body-dropping client/proxy currently produces a retry loop against the inference routes; a 400 stops that.
- Stops the inference routes echoing a raw `SyntaxError` message to callers.

## Safety

Pure input-validation hardening — **zero behavior change for valid requests**, and **no auth/billing/key-scoping logic touched**. On chat/embeddings the parse runs *before* credit reservation, so there is no billing side-effect on this path. The api-keys change only converts an unparseable-body 500 into a 400 ahead of the existing Zod field validation.

## Provenance

Found by an adversarial launch-readiness audit of the launch-critical cloud routes (money/auth/ownership/500), each finding independently verified (default-refuted) against current `develop`. These three are the confirmed, self-contained, non-money findings. A separate **agent-ownership** finding (the `agents/[id]/message` route org-scope mismatch) touches billing + an external caller and is being escalated separately for scope confirmation rather than bundled here.

cc @lalalune — small hygiene; flagging since one hunk is on the api-keys route (validation only, no auth-logic change).