### PR TITLE
fix(cloud): attribute service agent messages to owner org

### DIFF
--- a/packages/cloud/api/v1/agents/[agentId]/message/route.test.ts
+++ b/packages/cloud/api/v1/agents/[agentId]/message/route.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const requireServiceKey = mock(async () => ({
+  organizationId: "service-org",
+  userId: "service-user",
+}));
+const getAgentById = mock(
+  async (): Promise<{
+    id: string;
+    organization_id: string;
+    user_id: string;
+  } | null> => ({
+    id: "cloud-agent-1",
+    organization_id: "agent-wallet-org",
+    user_id: "agent-wallet-user",
+  }),
+);
+const enqueueAgentMessage = mock(async () => ({
+  created: true,
+  job: {
+    id: "message-job-1",
+    status: "pending",
+  },
+}));
+const triggerImmediate = mock(async () => undefined);
+const getJobForOrg = mock(async () => ({
+  id: "message-job-1",
+  status: "completed",
+  result: {
+    text: "hello back",
+    reason: "ok",
+  },
+}));
+
+mock.module("@/lib/auth/service-key-hono-worker", () => ({
+  requireServiceKey,
+}));
+
+mock.module("@/lib/services/eliza-sandbox", () => ({
+  elizaSandboxService: {
+    getAgentById,
+  },
+}));
+
+mock.module("@/lib/services/provisioning-jobs", () => ({
+  provisioningJobService: {
+    enqueueAgentMessage,
+    getJobForOrg,
+    triggerImmediate,
+  },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+    error: mock(() => undefined),
+    debug: mock(() => undefined),
+  },
+}));
+
+const { default: messageRoute } = await import("./route");
+
+describe("service agent message route", () => {
+  const app = new Hono();
+  app.route("/api/v1/agents/:agentId/message", messageRoute);
+
+  beforeEach(() => {
+    requireServiceKey.mockClear();
+    getAgentById.mockClear();
+    getAgentById.mockResolvedValue({
+      id: "cloud-agent-1",
+      organization_id: "agent-wallet-org",
+      user_id: "agent-wallet-user",
+    });
+    enqueueAgentMessage.mockClear();
+    enqueueAgentMessage.mockResolvedValue({
+      created: true,
+      job: {
+        id: "message-job-1",
+        status: "pending",
+      },
+    });
+    triggerImmediate.mockClear();
+    getJobForOrg.mockClear();
+    getJobForOrg.mockResolvedValue({
+      id: "message-job-1",
+      status: "completed",
+      result: {
+        text: "hello back",
+        reason: "ok",
+      },
+    });
+  });
+
+  test("routes wallet-owned agents through the agent owner org and user", async () => {
+    const response = await app.fetch(
+      new Request(
+        "https://api.example.test/api/v1/agents/cloud-agent-1/message",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Service-Key": "svc",
+          },
+          body: JSON.stringify({
+            text: "hello",
+            userId: "patron-user",
+            sessionId: "session-1",
+            roomId: "room-1",
+          }),
+        },
+      ),
+      { WAIFU_SERVICE_KEY: "svc" },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      text: "hello back",
+      reason: "ok",
+      jobId: "message-job-1",
+    });
+
+    expect(getAgentById).toHaveBeenCalledWith("cloud-agent-1");
+    expect(enqueueAgentMessage).toHaveBeenCalledWith({
+      agentId: "cloud-agent-1",
+      organizationId: "agent-wallet-org",
+      userId: "agent-wallet-user",
+      text: "hello",
+      senderId: "patron-user",
+      sessionId: "session-1",
+      roomId: "room-1",
+    });
+    expect(getJobForOrg).toHaveBeenCalledWith(
+      "message-job-1",
+      "agent-wallet-org",
+    );
+  });
+
+  test("returns 404 before enqueueing when the agent id is unknown", async () => {
+    getAgentById.mockResolvedValueOnce(null);
+
+    const response = await app.fetch(
+      new Request(
+        "https://api.example.test/api/v1/agents/missing-agent/message",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Service-Key": "svc",
+          },
+          body: JSON.stringify({ text: "hello" }),
+        },
+      ),
+      { WAIFU_SERVICE_KEY: "svc" },
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: "Agent not found",
+    });
+    expect(enqueueAgentMessage).not.toHaveBeenCalled();
+    expect(getJobForOrg).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/agents/[agentId]/message/route.ts
+++ b/packages/cloud/api/v1/agents/[agentId]/message/route.ts
@@ -14,9 +14,10 @@
  * component that can actually reach the bridge. Same pattern as the logs
  * route, but synchronous (we wait for the result instead of returning a 202).
  *
- * Auth: X-Service-Key (WAIFU_SERVICE_KEY) — same as provision. Org/user are
- * mapped from WAIFU_SERVICE_ORG_ID / WAIFU_SERVICE_USER_ID, so a service
- * caller can only chat agents owned by the service org.
+ * Auth: X-Service-Key (WAIFU_SERVICE_KEY) — same as provision. The service
+ * key authorizes the caller, but the message job is owned by the agent's
+ * persisted org/user so wallet-owned agents are reachable and billed to the
+ * actual owner.
  */
 
 import { Hono } from "hono";
@@ -43,7 +44,7 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 async function __hono_POST(c: AppContext) {
   try {
-    const identity = await requireServiceKey(c);
+    await requireServiceKey(c);
     const agentId = c.req.param("agentId") ?? "";
     const body = await c.req.json().catch(() => null);
 
@@ -61,19 +62,16 @@ async function __hono_POST(c: AppContext) {
 
     const { text, userId, sessionId, roomId } = parsed.data;
 
-    // Agent must exist under the service org before we enqueue.
-    const agent = await elizaSandboxService.getAgent(
-      agentId,
-      identity.organizationId,
-    );
+    // Resolve by id, then attribute the daemon job to the actual agent owner.
+    const agent = await elizaSandboxService.getAgentById(agentId);
     if (!agent) {
       return c.json({ success: false, error: "Agent not found" }, 404);
     }
 
     const { job } = await provisioningJobService.enqueueAgentMessage({
       agentId,
-      organizationId: identity.organizationId,
-      userId: identity.userId,
+      organizationId: agent.organization_id,
+      userId: agent.user_id,
       text,
       ...(userId ? { senderId: userId } : {}),
       ...(sessionId ? { sessionId } : {}),
@@ -90,7 +88,7 @@ async function __hono_POST(c: AppContext) {
       await sleep(POLL_INTERVAL_MS);
       const current = await provisioningJobService.getJobForOrg(
         job.id,
-        identity.organizationId,
+        agent.organization_id,
       );
       if (!current) continue;
 


### PR DESCRIPTION
## Summary
- resolve `POST /api/v1/agents/:agentId/message` agents by id instead of scoping lookup to the service org
- enqueue and poll the daemon `agent_message` job under the agent's persisted `organization_id` / `user_id`
- add a focused route test proving wallet-owned agents use the owner org/user and unknown agents still 404 before enqueue

## Root cause
The service-key identity authorizes the S2S caller, but this route was also using that service org as the agent lookup/job org. Wallet-owned agents live under their wallet org, so the route could 404 valid agents and would misattribute the daemon job to the service org.

Fixes #10112.

## Validation
- `TMPDIR=/home/nubs/Git/wt-10074-acp/.tmp bun test 'packages/cloud/api/v1/agents/[agentId]/message/route.test.ts' 'packages/cloud/api/v1/agents/[agentId]/resume/route.test.ts' 'packages/cloud/api/v1/agents/[agentId]/restart/route.test.ts'`
- `TMPDIR=/home/nubs/Git/wt-10074-acp/.tmp bun run --cwd packages/cloud/api typecheck`
- `TMPDIR=/home/nubs/Git/wt-10074-acp/.tmp bun run --cwd packages/cloud/api lint`
- `TMPDIR=/home/nubs/Git/wt-10074-acp/.tmp bun run --cwd packages/cloud/api codegen`
- `TMPDIR=/home/nubs/Git/wt-10074-acp/.tmp bun run --cwd packages/cloud/api test`
- `git diff --check`