### PR TITLE
feat(orchestrator-ui): account-health panel + workbench decomposition + pool-failure feedback (#9960)

### DIFF
--- a/packages/ui/src/api/client-agent.ts
+++ b/packages/ui/src/api/client-agent.ts
@@ -3778,10 +3778,13 @@ ElizaClient.prototype.getOrchestratorAccountReadiness = async function (
   opts,
 ) {
   const qs = opts?.rotation ? "?rotation=1" : "";
-  // Always 200 with the verdict body; `ready: false` + `problems` is the loud,
-  // displayable signal (the panel renders it; the CLI exits non-zero on it).
+  // The route returns 503 when the pool is degraded — but that 503 body IS the
+  // verdict the panel renders, not an error. allowNonOk skips the throw so we
+  // read the body on both 200 (ready) and 503 (degraded).
   return this.fetch<OrchestratorAccountReadiness>(
     `/api/orchestrator/accounts/readiness${qs}`,
+    undefined,
+    { allowNonOk: true },
   );
 };
 

--- a/packages/ui/src/api/client-agent.ts
+++ b/packages/ui/src/api/client-agent.ts
@@ -86,6 +86,7 @@ import type {
   LogsFilter,
   LogsResponse,
   OrchestratorAccountOverview,
+  OrchestratorAccountReadiness,
   OrchestratorRoomRosterOverview,
   PluginInfo,
   PluginMutationResult,
@@ -1007,6 +1008,9 @@ declare module "./client-base" {
     reopenCodingAgentTaskThread(threadId: string): Promise<boolean>;
     getOrchestratorStatus(): Promise<CodingAgentOrchestratorStatus | null>;
     getOrchestratorAccounts(): Promise<OrchestratorAccountOverview>;
+    getOrchestratorAccountReadiness(opts?: {
+      rotation?: boolean;
+    }): Promise<OrchestratorAccountReadiness>;
     getOrchestratorRooms(): Promise<OrchestratorRoomRosterOverview>;
     createOrchestratorTask(
       input: CodingAgentCreateTaskInput,
@@ -3767,6 +3771,18 @@ ElizaClient.prototype.getOrchestratorAccounts = async function (
   this: ElizaClient,
 ) {
   return this.fetch<OrchestratorAccountOverview>("/api/orchestrator/accounts");
+};
+
+ElizaClient.prototype.getOrchestratorAccountReadiness = async function (
+  this: ElizaClient,
+  opts,
+) {
+  const qs = opts?.rotation ? "?rotation=1" : "";
+  // Always 200 with the verdict body; `ready: false` + `problems` is the loud,
+  // displayable signal (the panel renders it; the CLI exits non-zero on it).
+  return this.fetch<OrchestratorAccountReadiness>(
+    `/api/orchestrator/accounts/readiness${qs}`,
+  );
 };
 
 ElizaClient.prototype.getOrchestratorRooms = async function (

--- a/packages/ui/src/api/client-types-cloud.ts
+++ b/packages/ui/src/api/client-types-cloud.ts
@@ -1155,6 +1155,27 @@ export interface OrchestratorAccountOverview {
   assignments: OrchestratorAccountAssignment[];
 }
 
+/** Per-provider readiness verdict from `GET /api/orchestrator/accounts/readiness`. */
+export interface OrchestratorProviderReadiness {
+  agentType: string;
+  total: number;
+  enabled: number;
+  healthy: number;
+  required: number;
+  ok: boolean;
+}
+
+/** Payload for `GET /api/orchestrator/accounts/readiness`: whether the pool has
+ * enough healthy accounts (≥1 Codex AND ≥1 Claude; ≥2 each under rotation) to
+ * run the multi-account orchestrator, with the human-readable problems when not. */
+export interface OrchestratorAccountReadiness {
+  ready: boolean;
+  rotation: boolean;
+  required: number;
+  providers: OrchestratorProviderReadiness[];
+  problems: string[];
+}
+
 export type OrchestratorRoomParticipantKind =
   | "orchestrator"
   | "user"

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -184,6 +184,10 @@ export * from "./chat/MessageAttachments";
 export * from "./chat/MessageContent";
 export * from "./chat/SaveCommandModal";
 export * from "./chat/TasksEventsPanel";
+export {
+  type OrchestratorAccountsViewProps,
+  OrchestratorAccountsView,
+} from "./chat/widgets/agent-orchestrator-accounts-view";
 export * from "./chat/widgets/shared";
 export * from "./chat/widgets/types";
 export * from "./cloud/CloudSourceControls";

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/account-failure-propagation.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/account-failure-propagation.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Account-failure propagation (#9960 error-handling audit): a spawned account's
+ * auth / rate-limit failure must feed back to the pool (markNeedsReauth /
+ * markRateLimited) so the selector stops handing out the dud account, instead
+ * of the failure being swallowed and the same account re-selected. Covers the
+ * conservative classifier and the router wiring that drives the pool bridge.
+ */
+
+import type { Content, HandlerCallback, Memory } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  classifyAccountFailure,
+  RATE_LIMIT_COOLOFF_MS,
+} from "../../src/services/coding-account-selection.js";
+import { SubAgentRouter } from "../../src/services/sub-agent-router.js";
+import type { SessionInfo } from "../../src/services/types.js";
+
+describe("classifyAccountFailure", () => {
+  it("flags unambiguous rate-limit signals", () => {
+    expect(classifyAccountFailure("HTTP 429 Too Many Requests")).toBe(
+      "rate-limited",
+    );
+    expect(classifyAccountFailure("rate limit exceeded for this account")).toBe(
+      "rate-limited",
+    );
+    expect(classifyAccountFailure("quota exhausted")).toBe("rate-limited");
+  });
+
+  it("flags unambiguous auth signals", () => {
+    expect(classifyAccountFailure("401 Unauthorized")).toBe("needs-reauth");
+    expect(classifyAccountFailure("invalid_grant")).toBe("needs-reauth");
+    expect(classifyAccountFailure("authentication failed")).toBe(
+      "needs-reauth",
+    );
+    expect(
+      classifyAccountFailure("token expired, please re-authenticate"),
+    ).toBe("needs-reauth");
+  });
+
+  it("does NOT flag ordinary build output (no healthy-account eviction)", () => {
+    expect(classifyAccountFailure(undefined)).toBeNull();
+    expect(classifyAccountFailure("")).toBeNull();
+    expect(
+      classifyAccountFailure("wrote OPENAI_API_KEY to .env and logged in"),
+    ).toBeNull();
+    expect(
+      classifyAccountFailure("TypeError: undefined is not a function"),
+    ).toBeNull();
+    expect(
+      classifyAccountFailure("build failed: missing login form"),
+    ).toBeNull();
+  });
+});
+
+const BRIDGE_SYMBOL: unique symbol = Symbol.for(
+  "eliza.account-pool.coding-agent.v1",
+);
+const ROOM = "11111111-2222-3333-4444-555555555555";
+const SESSION_ID = "01234567-89ab-cdef-0123-456789abcdef";
+
+function makeSession(account?: Record<string, unknown>): SessionInfo {
+  const now = new Date("2026-06-29T12:00:00.000Z");
+  return {
+    id: SESSION_ID,
+    name: "demo",
+    agentType: "claude",
+    workdir: "/tmp/wf",
+    status: "errored",
+    approvalPreset: "standard",
+    createdAt: now,
+    lastActivityAt: now,
+    metadata: {
+      label: "fix-bug",
+      roomId: ROOM,
+      source: "telegram",
+      messageId: "99999999-8888-7777-6666-555555555555",
+      ...(account ? { account } : {}),
+    },
+  };
+}
+
+function makeAcp(session: SessionInfo) {
+  let handler:
+    | ((sessionId: string, event: string, data: unknown) => void)
+    | undefined;
+  return {
+    service: {
+      onSessionEvent: vi.fn((fn: typeof handler) => {
+        handler = fn;
+        return () => {
+          handler = undefined;
+        };
+      }),
+      getSession: vi.fn(async (id: string) =>
+        id === session.id ? session : null,
+      ),
+      listSessions: vi.fn(async () => [session]),
+      stopSession: vi.fn(async () => {}),
+      updateSessionMetadata: vi.fn(async () => undefined),
+      getChangedPaths: vi.fn(() => [] as string[]),
+      sendToSession: vi.fn(async () => ({})),
+    },
+    emit(id: string, event: string, data: unknown) {
+      handler?.(id, event, data);
+    },
+  };
+}
+
+function makeRuntime(acp: unknown) {
+  const handleMessage = vi.fn<
+    (rt: unknown, m: Memory, cb?: HandlerCallback) => Promise<unknown>
+  >(async () => ({}));
+  const runtime = {
+    agentId: "00000000-0000-0000-0000-000000000001",
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    getService: vi.fn(() => acp),
+    getSetting: vi.fn(() => undefined),
+    createMemory: vi.fn(async () => undefined),
+    createEntity: vi.fn(async () => true),
+    addParticipant: vi.fn(async () => true),
+    emitEvent: vi.fn(async () => undefined),
+    sendMessageToTarget: vi.fn(async (_t: unknown, content: Content) => ({
+      id: "aaaaaaaa-0000-0000-0000-000000000000",
+      content,
+    })),
+    messageService: { handleMessage },
+  } as never;
+  return runtime;
+}
+
+describe("router → pool account-failure propagation", () => {
+  const bridge = {
+    markRateLimited: vi.fn(async () => undefined),
+    markNeedsReauth: vi.fn(async () => undefined),
+    describe: vi.fn(() => ({})),
+    select: vi.fn(async () => null),
+    recordUsage: vi.fn(async () => undefined),
+  };
+
+  beforeEach(() => {
+    bridge.markRateLimited.mockClear();
+    bridge.markNeedsReauth.mockClear();
+    (globalThis as Record<symbol, unknown>)[BRIDGE_SYMBOL] = bridge;
+  });
+  afterEach(() => {
+    delete (globalThis as Record<symbol, unknown>)[BRIDGE_SYMBOL];
+    vi.clearAllMocks();
+  });
+
+  const account = {
+    providerId: "anthropic-subscription",
+    accountId: "acct-1",
+    label: "Work",
+    source: "oauth",
+    strategy: "least-used",
+  };
+
+  it("marks the account needs-reauth on a 401 error", async () => {
+    const acp = makeAcp(makeSession(account));
+    const router = await SubAgentRouter.start(makeRuntime(acp.service));
+    acp.emit(SESSION_ID, "error", { message: "401 Unauthorized" });
+    await new Promise((r) => setImmediate(r));
+    expect(bridge.markNeedsReauth).toHaveBeenCalledWith(
+      "anthropic-subscription",
+      "acct-1",
+      expect.any(String),
+    );
+    expect(bridge.markRateLimited).not.toHaveBeenCalled();
+    await router.stop();
+  });
+
+  it("marks the account rate-limited (with a cool-off) on a 429 error", async () => {
+    const acp = makeAcp(makeSession(account));
+    const router = await SubAgentRouter.start(makeRuntime(acp.service));
+    acp.emit(SESSION_ID, "error", { message: "429 rate limit exceeded" });
+    await new Promise((r) => setImmediate(r));
+    expect(bridge.markRateLimited).toHaveBeenCalledTimes(1);
+    const [providerId, accountId, untilMs] =
+      bridge.markRateLimited.mock.calls[0] ?? [];
+    expect(providerId).toBe("anthropic-subscription");
+    expect(accountId).toBe("acct-1");
+    expect(typeof untilMs).toBe("number");
+    expect(untilMs as number).toBeGreaterThanOrEqual(Date.now());
+    expect((untilMs as number) - Date.now()).toBeLessThanOrEqual(
+      RATE_LIMIT_COOLOFF_MS + 1000,
+    );
+    await router.stop();
+  });
+
+  it("does NOT touch the pool on an ordinary task error", async () => {
+    const acp = makeAcp(makeSession(account));
+    const router = await SubAgentRouter.start(makeRuntime(acp.service));
+    acp.emit(SESSION_ID, "error", {
+      message: "TypeError: cannot read property 'x' of undefined",
+    });
+    await new Promise((r) => setImmediate(r));
+    expect(bridge.markNeedsReauth).not.toHaveBeenCalled();
+    expect(bridge.markRateLimited).not.toHaveBeenCalled();
+    await router.stop();
+  });
+
+  it("does NOT touch the pool when the session has no selected account", async () => {
+    const acp = makeAcp(makeSession()); // no account meta
+    const router = await SubAgentRouter.start(makeRuntime(acp.service));
+    acp.emit(SESSION_ID, "error", { message: "401 Unauthorized" });
+    await new Promise((r) => setImmediate(r));
+    expect(bridge.markNeedsReauth).not.toHaveBeenCalled();
+    await router.stop();
+  });
+});

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/account-readiness.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/account-readiness.test.ts
@@ -173,7 +173,7 @@ describe("GET /api/orchestrator/accounts/readiness", () => {
     );
   });
 
-  it("surfaces ready=false + problems (the loud verdict) when the pool is degraded", async () => {
+  it("fails loudly with 503 + problems when the pool is degraded", async () => {
     await withBridge(
       () => av("claude", [{ total: 1, enabled: 1, healthy: 1 }]), // no codex
       async () => {
@@ -187,7 +187,7 @@ describe("GET /api/orchestrator/accounts/readiness", () => {
           "/api/orchestrator/accounts/readiness",
           ctxWith(makeService()),
         );
-        expect(res.statusCode).toBe(200);
+        expect(res.statusCode).toBe(503);
         const body = res.json();
         expect(body.ready).toBe(false);
         expect((body.problems as string[]).join(" ")).toContain("codex");
@@ -212,6 +212,7 @@ describe("GET /api/orchestrator/accounts/readiness", () => {
           "/api/orchestrator/accounts/readiness",
           ctxWith(makeService()),
         );
+        expect(res.statusCode).toBe(503);
         expect(res.json().required).toBe(2);
         expect(res.json().ready).toBe(false);
       },

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/account-readiness.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/account-readiness.test.ts
@@ -173,7 +173,7 @@ describe("GET /api/orchestrator/accounts/readiness", () => {
     );
   });
 
-  it("fails loudly with 503 + problems when the pool is degraded", async () => {
+  it("surfaces ready=false + problems (the loud verdict) when the pool is degraded", async () => {
     await withBridge(
       () => av("claude", [{ total: 1, enabled: 1, healthy: 1 }]), // no codex
       async () => {
@@ -187,7 +187,7 @@ describe("GET /api/orchestrator/accounts/readiness", () => {
           "/api/orchestrator/accounts/readiness",
           ctxWith(makeService()),
         );
-        expect(res.statusCode).toBe(503);
+        expect(res.statusCode).toBe(200);
         const body = res.json();
         expect(body.ready).toBe(false);
         expect((body.problems as string[]).join(" ")).toContain("codex");
@@ -212,8 +212,8 @@ describe("GET /api/orchestrator/accounts/readiness", () => {
           "/api/orchestrator/accounts/readiness",
           ctxWith(makeService()),
         );
-        expect(res.statusCode).toBe(503);
         expect(res.json().required).toBe(2);
+        expect(res.json().ready).toBe(false);
       },
     );
   });

--- a/plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts
@@ -211,16 +211,17 @@ async function dispatchOrchestratorRoutes(
     return true;
   }
 
-  // GET /api/orchestrator/accounts/readiness — loud pool-readiness gate.
-  // Returns 200 when ≥1 healthy Codex AND ≥1 healthy Claude are connected
-  // (≥2 each with ?rotation=1), or 503 with the per-provider problems when not,
-  // so CI/ops catches a degraded pool instead of the silent single-account
-  // fallback. (#9960)
+  // GET /api/orchestrator/accounts/readiness — pool-readiness verdict.
+  // Always 200 with the structured verdict ({ ready, providers, problems }):
+  // `ready: false` + `problems` is the loud, displayable signal the dashboard
+  // panel renders and the `check:account-readiness` CLI exits non-zero on,
+  // surfacing a degraded pool instead of the silent single-account fallback.
+  // Requires ≥1 healthy Codex AND ≥1 healthy Claude (≥2 each with ?rotation=1).
+  // (#9960)
   if (method === "GET" && pathname === `${PREFIX}/accounts/readiness`) {
     const rotation =
       query.get("rotation") === "1" || query.get("rotation") === "true";
-    const readiness = service.getAccountReadiness({ rotation });
-    sendJson(res, readiness, readiness.ready ? 200 : 503);
+    sendJson(res, service.getAccountReadiness({ rotation }));
     return true;
   }
 

--- a/plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts
@@ -211,17 +211,17 @@ async function dispatchOrchestratorRoutes(
     return true;
   }
 
-  // GET /api/orchestrator/accounts/readiness — pool-readiness verdict.
-  // Always 200 with the structured verdict ({ ready, providers, problems }):
-  // `ready: false` + `problems` is the loud, displayable signal the dashboard
-  // panel renders and the `check:account-readiness` CLI exits non-zero on,
-  // surfacing a degraded pool instead of the silent single-account fallback.
-  // Requires ≥1 healthy Codex AND ≥1 healthy Claude (≥2 each with ?rotation=1).
-  // (#9960)
+  // GET /api/orchestrator/accounts/readiness — loud pool-readiness gate.
+  // Returns 200 when ≥1 healthy Codex AND ≥1 healthy Claude are connected
+  // (≥2 each with ?rotation=1), or 503 with the per-provider problems when not,
+  // so CI/ops catches a degraded pool instead of the silent single-account
+  // fallback. The dashboard account-health panel reads the verdict body on
+  // either status (allowNonOk). (#9960)
   if (method === "GET" && pathname === `${PREFIX}/accounts/readiness`) {
     const rotation =
       query.get("rotation") === "1" || query.get("rotation") === "true";
-    sendJson(res, service.getAccountReadiness({ rotation }));
+    const readiness = service.getAccountReadiness({ rotation });
+    sendJson(res, readiness, readiness.ready ? 200 : 503);
     return true;
   }
 

--- a/plugins/plugin-agent-orchestrator/src/services/coding-account-selection.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/coding-account-selection.ts
@@ -234,6 +234,66 @@ export function assessCodingAccountReadiness(
   };
 }
 
+export type CodingAccountFailureKind = "rate-limited" | "needs-reauth";
+
+/** Default cool-off applied to a rate-limited account (15 min). */
+export const RATE_LIMIT_COOLOFF_MS = 15 * 60_000;
+
+// Conservative classifiers: require an UNAMBIGUOUS provider auth/quota signal,
+// never a bare "api key" / "login" token (those appear in ordinary build
+// output). A false positive evicts a HEALTHY account from the pool, so the bar
+// is intentionally high.
+const RATE_LIMIT_RE =
+  /\b429\b|rate[\s-]?limit(?:ed|ing)?|too many requests|quota (?:exceeded|exhausted)|usage limit reached/i;
+const NEEDS_REAUTH_RE =
+  /\b401\b|\b403\b|unauthorized|invalid_grant|authentication failed|token (?:has )?expired|expired token|invalid token|please (?:re-?authenticate|log ?in again)/i;
+
+/**
+ * Pure: classify a sub-agent error message as a pooled-account failure, or null
+ * when it is an ordinary task error. Rate-limit is checked first (a 429 is a
+ * cool-off, not a credential problem).
+ */
+export function classifyAccountFailure(
+  text: string | undefined | null,
+): CodingAccountFailureKind | null {
+  if (!text) return null;
+  if (RATE_LIMIT_RE.test(text)) return "rate-limited";
+  if (NEEDS_REAUTH_RE.test(text)) return "needs-reauth";
+  return null;
+}
+
+/**
+ * Best-effort: tell the pool a spawned account hit a rate-limit / needs reauth
+ * so the selector stops handing it out (and the readiness gate + account-health
+ * panel reflect it) instead of the failure being swallowed and the same dud
+ * account re-selected. No-op when no bridge or no account; never throws.
+ */
+export async function reportCodingAccountFailure(
+  meta: CodingAccountMeta | null,
+  kind: CodingAccountFailureKind,
+  nowMs: number,
+  detail?: string,
+): Promise<void> {
+  if (!meta) return;
+  const bridge = getCodingAccountBridge();
+  if (!bridge) return;
+  try {
+    if (kind === "rate-limited") {
+      await bridge.markRateLimited(
+        meta.providerId,
+        meta.accountId,
+        nowMs + RATE_LIMIT_COOLOFF_MS,
+        detail,
+      );
+    } else {
+      await bridge.markNeedsReauth(meta.providerId, meta.accountId, detail);
+    }
+  } catch {
+    // Pool feedback is best-effort — a failure to record must not break the
+    // error path that is already surfacing the underlying problem.
+  }
+}
+
 /** Read the account descriptor previously stamped onto a session's metadata. */
 export function accountMetaFromSessionMetadata(
   metadata: Record<string, unknown> | undefined,

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -11,6 +11,11 @@ import type {
 import { Service, ServiceType } from "@elizaos/core";
 import type { AcpService } from "./acp-service.js";
 import {
+  accountMetaFromSessionMetadata,
+  classifyAccountFailure,
+  reportCodingAccountFailure,
+} from "./coding-account-selection.js";
+import {
   dispatchParentAgentDirective,
   extractParentAgentDirective,
   parentAgentMarkerIndex,
@@ -601,6 +606,34 @@ export class SubAgentRouter extends Service {
     // and suppress the dead session's narration entirely. Bounded per stable
     // origin lineage; once the cap is exhausted, post ONE honest terminal
     // failure instead of hanging silently.
+    // Propagate a spawned account's auth / rate-limit failure to the pool so the
+    // selector stops handing out the dud account (and the readiness gate +
+    // account-health panel reflect it), instead of swallowing it and re-picking
+    // the same account next spawn. Best-effort and conservative — see
+    // classifyAccountFailure (a false positive would evict a healthy account).
+    if (event === "error") {
+      const failureKind = classifyAccountFailure(
+        pickPayloadString(data, "message"),
+      );
+      const accountMeta = accountMetaFromSessionMetadata(
+        session.metadata as Record<string, unknown> | undefined,
+      );
+      if (failureKind && accountMeta) {
+        this.log("warn", "coding account failure reported to pool", {
+          sessionId,
+          providerId: accountMeta.providerId,
+          accountId: accountMeta.accountId,
+          failureKind,
+        });
+        void reportCodingAccountFailure(
+          accountMeta,
+          failureKind,
+          Date.now(),
+          `sub-agent session ${sessionId} (${session.agentType})`,
+        );
+      }
+    }
+
     let stateLostExhausted = false;
     let stateLostRespawnCount = 0;
     if (

--- a/plugins/plugin-task-coordinator/src/OrchestratorAccountHealthPanel.test.tsx
+++ b/plugins/plugin-task-coordinator/src/OrchestratorAccountHealthPanel.test.tsx
@@ -28,20 +28,17 @@ vi.mock("@elizaos/ui", () => ({
 }));
 
 // Stub the reused presentational view so the test targets THIS panel's wiring.
-vi.mock(
-  "@elizaos/ui/components/chat/widgets/agent-orchestrator-accounts-view",
-  () => ({
-    OrchestratorAccountsView: (props: {
-      overview?: { strategy?: string } | null;
-      onConnect?: () => void;
-    }) => (
-      <div
-        data-testid="accounts-view"
-        data-strategy={props.overview?.strategy ?? ""}
-      />
-    ),
-  }),
-);
+vi.mock("@elizaos/ui/components", () => ({
+  OrchestratorAccountsView: (props: {
+    overview?: { strategy?: string } | null;
+    onConnect?: () => void;
+  }) => (
+    <div
+      data-testid="accounts-view"
+      data-strategy={props.overview?.strategy ?? ""}
+    />
+  ),
+}));
 
 import { OrchestratorAccountHealthPanel } from "./OrchestratorAccountHealthPanel";
 

--- a/plugins/plugin-task-coordinator/src/OrchestratorAccountHealthPanel.test.tsx
+++ b/plugins/plugin-task-coordinator/src/OrchestratorAccountHealthPanel.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+//
+// The account-health panel (#9960) surfaces the multi-account pool's per-account
+// health + the server readiness verdict inside the orchestrator workbench (it
+// previously lived only in the chat sidebar). These tests pin: it fetches the
+// four sources, renders the reused accounts view, and renders the readiness
+// banner verbatim from the server DTO (ready vs degraded-with-problems).
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const calls = {
+  listAccounts: vi.fn(),
+  getOrchestratorAccounts: vi.fn(),
+  getOrchestratorRooms: vi.fn(),
+  getOrchestratorAccountReadiness: vi.fn(),
+};
+
+vi.mock("@elizaos/ui", () => ({
+  client: {
+    listAccounts: () => calls.listAccounts(),
+    getOrchestratorAccounts: () => calls.getOrchestratorAccounts(),
+    getOrchestratorRooms: () => calls.getOrchestratorRooms(),
+    getOrchestratorAccountReadiness: () =>
+      calls.getOrchestratorAccountReadiness(),
+  },
+}));
+
+// Stub the reused presentational view so the test targets THIS panel's wiring.
+vi.mock(
+  "@elizaos/ui/components/chat/widgets/agent-orchestrator-accounts-view",
+  () => ({
+    OrchestratorAccountsView: (props: {
+      overview?: { strategy?: string } | null;
+      onConnect?: () => void;
+    }) => (
+      <div
+        data-testid="accounts-view"
+        data-strategy={props.overview?.strategy ?? ""}
+      />
+    ),
+  }),
+);
+
+import { OrchestratorAccountHealthPanel } from "./OrchestratorAccountHealthPanel";
+
+beforeEach(() => {
+  for (const fn of Object.values(calls)) fn.mockReset();
+  calls.listAccounts.mockResolvedValue({ providers: [] });
+  calls.getOrchestratorAccounts.mockResolvedValue({
+    strategy: "least-used",
+    availability: {},
+    assignments: [],
+  });
+  calls.getOrchestratorRooms.mockResolvedValue({ rooms: [] });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("OrchestratorAccountHealthPanel (#9960)", () => {
+  it("renders the accounts view + a ready banner when the pool is ready", async () => {
+    calls.getOrchestratorAccountReadiness.mockResolvedValue({
+      ready: true,
+      rotation: false,
+      required: 1,
+      providers: [],
+      problems: [],
+    });
+
+    render(React.createElement(OrchestratorAccountHealthPanel));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("accounts-view")).toBeTruthy(),
+    );
+    const banner = screen.getByTestId("orchestrator-account-readiness");
+    expect(banner.getAttribute("data-ready")).toBe("true");
+    expect(
+      screen.getByTestId("accounts-view").getAttribute("data-strategy"),
+    ).toBe("least-used");
+  });
+
+  it("renders the degraded verdict + problems verbatim when the pool is not ready", async () => {
+    calls.getOrchestratorAccountReadiness.mockResolvedValue({
+      ready: false,
+      rotation: false,
+      required: 1,
+      providers: [],
+      problems: ["codex: 0 healthy account(s), need >= 1 (none connected)"],
+    });
+
+    render(React.createElement(OrchestratorAccountHealthPanel));
+
+    const banner = await screen.findByTestId("orchestrator-account-readiness");
+    expect(banner.getAttribute("data-ready")).toBe("false");
+    expect(banner.textContent).toContain("codex");
+    expect(banner.textContent).toContain("need >= 1");
+  });
+
+  it("calls all four data sources once on mount", async () => {
+    calls.getOrchestratorAccountReadiness.mockResolvedValue({
+      ready: true,
+      rotation: false,
+      required: 1,
+      providers: [],
+      problems: [],
+    });
+
+    render(React.createElement(OrchestratorAccountHealthPanel));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("accounts-view")).toBeTruthy(),
+    );
+    expect(calls.listAccounts).toHaveBeenCalledTimes(1);
+    expect(calls.getOrchestratorAccounts).toHaveBeenCalledTimes(1);
+    expect(calls.getOrchestratorRooms).toHaveBeenCalledTimes(1);
+    expect(calls.getOrchestratorAccountReadiness).toHaveBeenCalledTimes(1);
+  });
+});

--- a/plugins/plugin-task-coordinator/src/OrchestratorAccountHealthPanel.tsx
+++ b/plugins/plugin-task-coordinator/src/OrchestratorAccountHealthPanel.tsx
@@ -1,0 +1,137 @@
+/**
+ * Account-health panel for the orchestrator workbench (#9960).
+ *
+ * The multi-account pool's per-account health (ok / rate-limited / needs-reauth
+ * / invalid), live sub-agent → account assignments, and per-room roster already
+ * render in the presentational `OrchestratorAccountsView` — but it was surfaced
+ * only in the chat sidebar, never in the orchestrator view itself. This panel
+ * wires that view into the workbench and adds the pool-readiness verdict
+ * (`GET /api/orchestrator/accounts/readiness`) on top, so a degraded pool is
+ * visible where the operator manages tasks instead of silently degrading to a
+ * single account. A connect-accounts entry point routes to Settings.
+ *
+ * Data-fetch only; all derived values come from server DTOs (readiness verdict,
+ * availability, assignments) — the panel displays, it does not compute.
+ */
+
+import { client } from "@elizaos/ui";
+import { OrchestratorAccountsView } from "@elizaos/ui/components/chat/widgets/agent-orchestrator-accounts-view";
+import { CircleAlert, CircleCheck } from "lucide-react";
+import { type ComponentProps, useCallback, useEffect, useState } from "react";
+
+type Translate = (key: string, vars?: Record<string, unknown>) => string;
+
+// Derive the data-shape types from the consuming component + the client methods
+// so this panel never depends on whether a given DTO is re-exported from the
+// `@elizaos/ui` barrel (AccountsListResponse, e.g., is not).
+type AccountsViewProps = ComponentProps<typeof OrchestratorAccountsView>;
+type AccountsListResponse = AccountsViewProps["accounts"];
+type OrchestratorAccountOverview = AccountsViewProps["overview"];
+type OrchestratorRoomRosterOverview = AccountsViewProps["rooms"];
+type OrchestratorAccountReadiness = Awaited<
+  ReturnType<typeof client.getOrchestratorAccountReadiness>
+>;
+
+export interface OrchestratorAccountHealthPanelProps {
+  t?: Translate;
+  /** Invoked by the connect-accounts entry point (route to Settings). */
+  onConnect?: () => void;
+}
+
+const fallbackTranslate: Translate = (key, vars) =>
+  typeof vars?.defaultValue === "string" ? vars.defaultValue : key;
+
+/** Server-owned readiness verdict, rendered verbatim (no client computation). */
+function ReadinessBanner({
+  readiness,
+  t,
+}: {
+  readiness: OrchestratorAccountReadiness;
+  t: Translate;
+}) {
+  const ready = readiness.ready;
+  return (
+    <div
+      className={`flex items-start gap-2 rounded-md px-3 py-2 text-2xs ${
+        ready ? "bg-ok/10 text-ok" : "bg-warn/10 text-warn"
+      }`}
+      data-testid="orchestrator-account-readiness"
+      data-ready={ready ? "true" : "false"}
+    >
+      {ready ? (
+        <CircleCheck className="mt-px h-3.5 w-3.5 shrink-0" />
+      ) : (
+        <CircleAlert className="mt-px h-3.5 w-3.5 shrink-0" />
+      )}
+      <div className="space-y-0.5">
+        <div className="font-medium">
+          {ready
+            ? t("orchestrator.accountsReady", {
+                defaultValue: `Pool ready — ${readiness.required}+ healthy per provider`,
+                required: readiness.required,
+              })
+            : t("orchestrator.accountsNotReady", {
+                defaultValue: "Account pool degraded",
+              })}
+        </div>
+        {!ready &&
+          readiness.problems.map((p) => (
+            <div key={p} className="text-warn/90">
+              {p}
+            </div>
+          ))}
+      </div>
+    </div>
+  );
+}
+
+export function OrchestratorAccountHealthPanel({
+  t = fallbackTranslate,
+  onConnect,
+}: OrchestratorAccountHealthPanelProps) {
+  const [accounts, setAccounts] = useState<AccountsListResponse | null>(null);
+  const [overview, setOverview] = useState<OrchestratorAccountOverview | null>(
+    null,
+  );
+  const [rooms, setRooms] = useState<OrchestratorRoomRosterOverview | null>(
+    null,
+  );
+  const [readiness, setReadiness] =
+    useState<OrchestratorAccountReadiness | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    const [acctRes, ovRes, roomsRes, readyRes] = await Promise.allSettled([
+      client.listAccounts(),
+      client.getOrchestratorAccounts(),
+      client.getOrchestratorRooms(),
+      client.getOrchestratorAccountReadiness(),
+    ]);
+    if (acctRes.status === "fulfilled") setAccounts(acctRes.value);
+    if (ovRes.status === "fulfilled") setOverview(ovRes.value);
+    if (roomsRes.status === "fulfilled") setRooms(roomsRes.value);
+    if (readyRes.status === "fulfilled") setReadiness(readyRes.value);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+    const timer = window.setInterval(() => void refresh(), 15_000);
+    return () => window.clearInterval(timer);
+  }, [refresh]);
+
+  if (loading) return null;
+
+  return (
+    <div className="space-y-2" data-testid="orchestrator-account-health-panel">
+      {readiness ? <ReadinessBanner readiness={readiness} t={t} /> : null}
+      <OrchestratorAccountsView
+        accounts={accounts}
+        overview={overview}
+        rooms={rooms}
+        t={t}
+        onConnect={onConnect}
+      />
+    </div>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/OrchestratorAccountHealthPanel.tsx
+++ b/plugins/plugin-task-coordinator/src/OrchestratorAccountHealthPanel.tsx
@@ -15,7 +15,7 @@
  */
 
 import { client } from "@elizaos/ui";
-import { OrchestratorAccountsView } from "@elizaos/ui/components/chat/widgets/agent-orchestrator-accounts-view";
+import { OrchestratorAccountsView } from "@elizaos/ui/components";
 import { CircleAlert, CircleCheck } from "lucide-react";
 import { type ComponentProps, useCallback, useEffect, useState } from "react";
 

--- a/plugins/plugin-task-coordinator/src/OrchestratorWorkbench.tsx
+++ b/plugins/plugin-task-coordinator/src/OrchestratorWorkbench.tsx
@@ -1,3 +1,5 @@
+// Direct subpath: the app renderer resolves the bare `@elizaos/ui` root to the
+// browser barrel, which doesn't reliably re-export this newer component.
 import {
   AlertDialog,
   AlertDialogAction,
@@ -10,6 +12,7 @@ import {
   AlertDialogTrigger,
   Button,
   type ChangeSetData,
+  ChatEmptyStateWithRecommendations,
   type CodingAgentAddAgentInput,
   type CodingAgentOrchestratorStatus,
   type CodingAgentRerunFromEventInput,
@@ -27,9 +30,6 @@ import {
   DiffReviewPanel,
   useAppSelectorShallow,
 } from "@elizaos/ui";
-// Direct subpath: the app renderer resolves the bare `@elizaos/ui` root to the
-// browser barrel, which doesn't reliably re-export this newer component.
-import { ChatEmptyStateWithRecommendations } from "@elizaos/ui";
 import { useAgentElement } from "@elizaos/ui/agent-surface";
 import {
   Select,
@@ -79,6 +79,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { OrchestratorAccountHealthPanel } from "./OrchestratorAccountHealthPanel";
 import {
   paramPriority,
   TASK_LIST_LIMIT,
@@ -90,6 +91,32 @@ import {
   ToolBody,
 } from "./orchestrator-stream";
 import { buildConversation } from "./orchestrator-stream.helpers";
+import {
+  FILTER_OPTIONS,
+  fallbackTranslate,
+  labelPriority,
+  labelSender,
+  labelSessionStatus,
+  labelStatus,
+  PLAN_STEP_ICON,
+  PLAN_STEP_TONE,
+  PlanStepGlyph,
+  PRIORITY_ICON,
+  resolveSenderName,
+  SENDER_LABEL_KEY,
+  SESSION_PULSE,
+  SESSION_TONE,
+  SessionGlyph,
+  STATUS_ICON,
+  STATUS_LABEL_KEY,
+  STATUS_TONE,
+  type StatusFilter,
+  StatusGlyph,
+  type TaskStatus,
+  TERMINAL_TASK_STATUSES,
+  type Translate,
+  VerificationGlyph,
+} from "./orchestrator-workbench-glyphs";
 import {
   BackChip,
   SparseWatermark,
@@ -107,9 +134,6 @@ import {
   formatUsd,
 } from "./view-format";
 
-type Translate = (key: string, vars?: Record<string, unknown>) => string;
-type TaskStatus = CodingAgentTaskThread["status"];
-type StatusFilter = "all" | TaskStatus;
 type OperatorTab = "input" | "output" | "events" | "usage";
 type DetailDrawerSelection =
   | { kind: "session"; sessionId: string }
@@ -121,316 +145,11 @@ type DetailDrawerSelection =
       messageIds: string[];
     };
 
-const fallbackTranslate: Translate = (key, vars) =>
-  String(vars?.defaultValue ?? key);
-
 const TIMELINE_PAGE_LIMIT = 50;
 const POLL_INTERVAL_MS = 5_000;
 /** While a task has a working agent, poll its room fast so the conversation,
  * tool calls, and tokens stream in near-live instead of lurching every 5s. */
 const ACTIVE_POLL_INTERVAL_MS = 1_500;
-
-const STATUS_ICON: Record<TaskStatus, LucideIcon> = {
-  open: Circle,
-  active: CirclePlay,
-  waiting_on_user: UserRound,
-  blocked: OctagonX,
-  validating: CircleDashed,
-  done: CircleCheck,
-  failed: CircleX,
-  archived: Archive,
-  interrupted: CircleAlert,
-};
-
-const STATUS_TONE: Record<TaskStatus, string> = {
-  open: "text-muted",
-  active: "text-ok",
-  waiting_on_user: "text-warn",
-  blocked: "text-warn",
-  validating: "text-accent",
-  done: "text-ok",
-  failed: "text-danger",
-  archived: "text-muted",
-  interrupted: "text-warn",
-};
-
-const STATUS_PULSE: ReadonlySet<TaskStatus> = new Set<TaskStatus>([
-  "active",
-  "validating",
-]);
-
-/** Terminal task statuses — the task is settled and no longer mutable
- * through the Edit-group actions (fork, restart, add agent, edit plan)
- * or the priority dropdown. Reopen (when archived) and Delete remain the
- * only meaningful affordances. Mirrors the design doc's
- * {done, failed, archived} set; the `CodingAgentTaskThread["status"]`
- * union has no `"closed"` member. */
-const TERMINAL_TASK_STATUSES: ReadonlySet<TaskStatus> = new Set<TaskStatus>([
-  "done",
-  "failed",
-  "archived",
-]);
-
-const PRIORITY_ICON: Record<TaskPriority, LucideIcon | null> = {
-  low: ChevronDown,
-  normal: null,
-  high: ChevronUp,
-  urgent: ChevronsUp,
-};
-
-const SESSION_ICON: Record<string, LucideIcon> = {
-  active: CirclePlay,
-  running: CirclePlay,
-  tool_running: CirclePlay,
-  blocked: OctagonX,
-  idle: Circle,
-  completed: CircleCheck,
-  stopped: CircleStop,
-  error: CircleX,
-  errored: CircleX,
-};
-
-const SESSION_TONE: Record<string, string> = {
-  active: "text-ok",
-  running: "text-ok",
-  tool_running: "text-ok",
-  blocked: "text-warn",
-  idle: "text-muted",
-  completed: "text-ok",
-  stopped: "text-muted",
-  error: "text-danger",
-  errored: "text-danger",
-};
-
-const SESSION_PULSE: ReadonlySet<string> = new Set([
-  "active",
-  "running",
-  "tool_running",
-]);
-
-const VERIFICATION_ICON: Record<
-  CodingAgentTaskArtifactRecord["verificationStatus"],
-  LucideIcon
-> = {
-  passed: CircleCheck,
-  failed: CircleX,
-  pending: CircleDashed,
-  unknown: Circle,
-};
-
-const VERIFICATION_TONE: Record<
-  CodingAgentTaskArtifactRecord["verificationStatus"],
-  string
-> = {
-  passed: "text-ok",
-  failed: "text-danger",
-  pending: "text-warn",
-  unknown: "text-muted",
-};
-
-const PLAN_STEP_ICON: Record<string, LucideIcon> = {
-  done: CircleCheck,
-  completed: CircleCheck,
-  passed: CircleCheck,
-  in_progress: CircleDashed,
-  active: CircleDashed,
-  running: CircleDashed,
-  blocked: OctagonX,
-  failed: CircleX,
-  pending: Circle,
-  todo: Circle,
-};
-
-const PLAN_STEP_TONE: Record<string, string> = {
-  done: "text-ok",
-  completed: "text-ok",
-  passed: "text-ok",
-  in_progress: "text-accent",
-  active: "text-accent",
-  running: "text-accent",
-  blocked: "text-warn",
-  failed: "text-danger",
-  pending: "text-muted",
-  todo: "text-muted",
-};
-
-const FILTER_OPTIONS: StatusFilter[] = [
-  "all",
-  "active",
-  "blocked",
-  "validating",
-  "waiting_on_user",
-  "interrupted",
-  "open",
-  "done",
-  "failed",
-];
-
-const STATUS_LABEL_KEY: Record<TaskStatus, string> = {
-  open: "orchestrator.status.open",
-  active: "orchestrator.status.active",
-  waiting_on_user: "orchestrator.status.waitingOnUser",
-  blocked: "orchestrator.status.blocked",
-  validating: "orchestrator.status.validating",
-  done: "orchestrator.status.done",
-  failed: "orchestrator.status.failed",
-  archived: "orchestrator.status.archived",
-  interrupted: "orchestrator.status.interrupted",
-};
-
-function labelStatus(status: TaskStatus, t: Translate): string {
-  return t(STATUS_LABEL_KEY[status], {
-    defaultValue: status.replace(/_/g, " "),
-  });
-}
-
-function labelPriority(priority: TaskPriority, t: Translate): string {
-  return t(`orchestrator.priority.${priority}`, { defaultValue: priority });
-}
-
-function StatusGlyph({
-  status,
-  paused,
-  t,
-  size = "h-3.5 w-3.5",
-}: {
-  status: TaskStatus;
-  paused?: boolean;
-  t: Translate;
-  size?: string;
-}) {
-  const Icon = STATUS_ICON[status];
-  const label = labelStatus(status, t);
-  const pulse = STATUS_PULSE.has(status) && !paused ? " animate-pulse" : "";
-  return (
-    <span
-      className="inline-flex shrink-0"
-      title={label}
-      aria-label={label}
-      role="img"
-    >
-      <Icon className={`${size} ${STATUS_TONE[status]}${pulse}`} aria-hidden />
-    </span>
-  );
-}
-
-function SessionGlyph({
-  status,
-  t,
-  size = "h-3.5 w-3.5",
-}: {
-  status: string;
-  t: Translate;
-  size?: string;
-}) {
-  const Icon = SESSION_ICON[status] ?? Circle;
-  const tone = SESSION_TONE[status] ?? "text-muted";
-  const label = labelSessionStatus(status, t);
-  const pulse = SESSION_PULSE.has(status) ? " animate-pulse" : "";
-  return (
-    <span
-      className="inline-flex shrink-0"
-      title={label}
-      aria-label={label}
-      role="img"
-    >
-      <Icon className={`${size} ${tone}${pulse}`} aria-hidden />
-    </span>
-  );
-}
-
-function VerificationGlyph({
-  status,
-  t,
-}: {
-  status: CodingAgentTaskArtifactRecord["verificationStatus"];
-  t: Translate;
-}) {
-  const Icon = VERIFICATION_ICON[status];
-  const label = t(`orchestrator.verification.${status}`, {
-    defaultValue: status,
-  });
-  return (
-    <span
-      className="inline-flex shrink-0"
-      title={label}
-      aria-label={label}
-      role="img"
-    >
-      <Icon
-        className={`h-3.5 w-3.5 ${VERIFICATION_TONE[status]}`}
-        aria-hidden
-      />
-    </span>
-  );
-}
-
-function PlanStepGlyph({ status, t }: { status: string; t: Translate }) {
-  const key = status
-    .trim()
-    .toLowerCase()
-    .replace(/[\s-]+/g, "_");
-  const Icon = PLAN_STEP_ICON[key] ?? Circle;
-  const tone = PLAN_STEP_TONE[key] ?? "text-muted";
-  const label = t(`orchestrator.planStatus.${key}`, {
-    defaultValue: status.replace(/_/g, " "),
-  });
-  return (
-    <span
-      className="mt-px inline-flex shrink-0"
-      title={label}
-      aria-label={label}
-      role="img"
-    >
-      <Icon className={`h-3.5 w-3.5 ${tone}`} aria-hidden />
-    </span>
-  );
-}
-
-const SENDER_LABEL_KEY: Record<
-  CodingAgentTaskMessageRecord["senderKind"],
-  { key: string; fallback: string }
-> = {
-  user: { key: "orchestrator.sender.user", fallback: "You" },
-  orchestrator: {
-    key: "orchestrator.sender.orchestrator",
-    fallback: "Orchestrator",
-  },
-  sub_agent: { key: "orchestrator.sender.subAgent", fallback: "Sub-agent" },
-  system: { key: "orchestrator.sender.system", fallback: "System" },
-};
-
-function labelSender(
-  kind: CodingAgentTaskMessageRecord["senderKind"],
-  t: Translate,
-): string {
-  const meta = SENDER_LABEL_KEY[kind];
-  return t(meta.key, { defaultValue: meta.fallback });
-}
-
-/**
- * Resolve the display name for a timeline message's sender. Sub-agents render
- * their per-session label (the name they were spun up with); the orchestrator
- * renders the running agent's name (usually "Eliza"). Falls back to the generic
- * role label when no specific name is available.
- */
-function resolveSenderName(
-  message: CodingAgentTaskMessageRecord,
-  sessionLabelById: Map<string, string>,
-  mainAgentName: string | undefined,
-  t: Translate,
-): string {
-  if (message.senderKind === "sub_agent") {
-    const label = message.sessionId
-      ? sessionLabelById.get(message.sessionId)?.trim()
-      : undefined;
-    return label || labelSender("sub_agent", t);
-  }
-  if (message.senderKind === "orchestrator") {
-    return mainAgentName?.trim() || labelSender("orchestrator", t);
-  }
-  return labelSender(message.senderKind, t);
-}
 
 function getClientErrorMessage(error: unknown, fallback: string): string {
   return error instanceof Error && error.message ? error.message : fallback;
@@ -620,6 +339,8 @@ function WorkbenchHeader({
   isMobile,
   onPauseAll,
   onResumeAll,
+  accountsOpen,
+  onToggleAccounts,
   t,
   locale,
 }: {
@@ -628,6 +349,8 @@ function WorkbenchHeader({
   isMobile: boolean;
   onPauseAll: () => void;
   onResumeAll: () => void;
+  accountsOpen: boolean;
+  onToggleAccounts: () => void;
   t: Translate;
   locale?: string;
 }) {
@@ -712,6 +435,23 @@ function WorkbenchHeader({
       group: "orchestrator-header",
       description: "Resume every paused orchestrator task",
     });
+  const accountsLabel = t("orchestrator.toggleAccounts", {
+    defaultValue: "Coding accounts & pool health",
+  });
+  const accountsToggle = (
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={onToggleAccounts}
+      className="h-7 w-7 shrink-0 p-0"
+      aria-label={accountsLabel}
+      aria-pressed={accountsOpen}
+      title={accountsLabel}
+      data-testid="orchestrator-accounts-toggle"
+    >
+      <Gauge className="h-3.5 w-3.5" />
+    </Button>
+  );
   // Pause-all / resume-all only surface while there is something to act on, so a
   // quiet orchestrator shows no controls at all — the dashboard is read-only
   // until work is in flight. New tasks are started conversationally in chat.
@@ -758,7 +498,10 @@ function WorkbenchHeader({
       <header className="flex flex-col gap-2 bg-bg px-4 py-2.5">
         <div className="flex items-center gap-2">
           {title}
-          {actions}
+          <div className="ml-auto flex items-center gap-1.5">
+            {accountsToggle}
+            {actions}
+          </div>
         </div>
         <div className="flex items-center justify-between gap-2">
           {summary}
@@ -773,6 +516,7 @@ function WorkbenchHeader({
       {title}
       {summary}
       {usageReadout}
+      {accountsToggle}
       {actions}
     </header>
   );
@@ -993,14 +737,6 @@ function SubAgentCard({
       <div className="mt-0.5 truncate text-2xs text-muted/80">{workspace}</div>
     </div>
   );
-}
-
-/** Sub-agent status labels reuse task-status keys where they overlap and fall
- * back to the raw token otherwise (sessions carry framework-specific states). */
-function labelSessionStatus(status: string, t: Translate): string {
-  return t(`orchestrator.sessionStatus.${status}`, {
-    defaultValue: status.replace(/_/g, " "),
-  });
 }
 
 function PlanSection({ plan, t }: { plan: NormalizedPlan; t: Translate }) {
@@ -3031,11 +2767,13 @@ export function OrchestratorWorkbench() {
     uiLanguage,
     copyToClipboard,
     agentStatus,
+    setTab,
   } = useAppSelectorShallow((s) => ({
     t: s.t,
     uiLanguage: s.uiLanguage,
     copyToClipboard: s.copyToClipboard,
     agentStatus: s.agentStatus,
+    setTab: s.setTab,
   }));
   const t = appT ?? fallbackTranslate;
   const locale = typeof uiLanguage === "string" ? uiLanguage : undefined;
@@ -3061,6 +2799,7 @@ export function OrchestratorWorkbench() {
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
   const [showArchived, setShowArchived] = useState(false);
   const [addAgentOpen, setAddAgentOpen] = useState(false);
+  const [accountsOpen, setAccountsOpen] = useState(false);
   const [inspectorOpen, setInspectorOpen] = useState(false);
   const [detailDrawer, setDetailDrawer] =
     useState<DetailDrawerSelection | null>(null);
@@ -3510,9 +3249,20 @@ export function OrchestratorWorkbench() {
         onResumeAll={() =>
           runMutation(() => client.resumeAllOrchestratorTasks())
         }
+        accountsOpen={accountsOpen}
+        onToggleAccounts={() => setAccountsOpen((prev) => !prev)}
         t={t}
         locale={locale}
       />
+
+      {accountsOpen ? (
+        <div className="border-b border-border/40 px-4 py-2">
+          <OrchestratorAccountHealthPanel
+            t={t}
+            onConnect={() => setTab?.("settings")}
+          />
+        </div>
+      ) : null}
 
       {backendAbsent ? (
         <div className="px-4 py-1.5 text-2xs text-muted">

--- a/plugins/plugin-task-coordinator/src/OrchestratorWorkbench.tsx
+++ b/plugins/plugin-task-coordinator/src/OrchestratorWorkbench.tsx
@@ -24,7 +24,6 @@ import {
   type CodingAgentTaskSessionRecord,
   type CodingAgentTaskThread,
   type CodingAgentTaskThreadDetail,
-  type CodingAgentTaskTimelineItem,
   type CodingAgentTaskUsageSummary,
   client,
   DiffReviewPanel,
@@ -46,26 +45,17 @@ import {
   ChevronDown,
   ChevronsUp,
   ChevronUp,
-  Circle,
-  CircleAlert,
-  CircleCheck,
-  CircleDashed,
-  CirclePlay,
   CircleStop,
-  CircleX,
   Copy,
   Gauge,
   GitFork,
   Layers,
-  type LucideIcon,
-  OctagonX,
   PanelRightOpen,
   Pause,
   Play,
   RotateCcw,
   Trash2,
   UserPlus,
-  UserRound,
   X,
 } from "lucide-react";
 import {
@@ -80,11 +70,7 @@ import {
   useState,
 } from "react";
 import { OrchestratorAccountHealthPanel } from "./OrchestratorAccountHealthPanel";
-import {
-  paramPriority,
-  TASK_LIST_LIMIT,
-  type TaskPriority,
-} from "./orchestrator-params";
+import { paramPriority, type TaskPriority } from "./orchestrator-params";
 import {
   type ConversationBlock,
   ConversationBlockView,
@@ -95,24 +81,13 @@ import {
   FILTER_OPTIONS,
   fallbackTranslate,
   labelPriority,
-  labelSender,
-  labelSessionStatus,
   labelStatus,
-  PLAN_STEP_ICON,
-  PLAN_STEP_TONE,
   PlanStepGlyph,
   PRIORITY_ICON,
   resolveSenderName,
-  SENDER_LABEL_KEY,
-  SESSION_PULSE,
-  SESSION_TONE,
   SessionGlyph,
-  STATUS_ICON,
-  STATUS_LABEL_KEY,
-  STATUS_TONE,
   type StatusFilter,
   StatusGlyph,
-  type TaskStatus,
   TERMINAL_TASK_STATUSES,
   type Translate,
   VerificationGlyph,
@@ -125,6 +100,7 @@ import {
   TaskSearchInput,
   TaskStatusChip,
 } from "./TaskCardList";
+import { useOrchestratorData } from "./use-orchestrator-data";
 import {
   formatClockTime,
   formatCompactNumber,
@@ -144,56 +120,6 @@ type DetailDrawerSelection =
       eventIds: string[];
       messageIds: string[];
     };
-
-const TIMELINE_PAGE_LIMIT = 50;
-const POLL_INTERVAL_MS = 5_000;
-/** While a task has a working agent, poll its room fast so the conversation,
- * tool calls, and tokens stream in near-live instead of lurching every 5s. */
-const ACTIVE_POLL_INTERVAL_MS = 1_500;
-
-function getClientErrorMessage(error: unknown, fallback: string): string {
-  return error instanceof Error && error.message ? error.message : fallback;
-}
-
-/**
- * True when the connected agent simply doesn't serve the orchestrator backend
- * (a 404 on its routes) — e.g. a local on-device agent without
- * agent-orchestrator. This is NOT a failure: the workbench runs against
- * whatever agent the client points at, so a cloud or desktop agent that has the
- * backend just works. We surface a calm "connect a cloud/desktop agent" hint
- * instead of a red error in that case.
- */
-function isOrchestratorBackendAbsent(error: unknown): boolean {
-  const status = (error as { status?: unknown } | null)?.status;
-  if (status === 404) return true;
-  const msg = error instanceof Error ? error.message.toLowerCase() : "";
-  return msg === "not found" || msg.includes("404");
-}
-
-/** Merge timeline records by id and return them ascending by timestamp. */
-function mergeById<T extends { id: string; timestamp: number }>(
-  previous: T[],
-  incoming: T[],
-): T[] {
-  if (incoming.length === 0) return previous;
-  const byId = new Map<string, T>();
-  for (const item of previous) byId.set(item.id, item);
-  for (const item of incoming) byId.set(item.id, item);
-  return [...byId.values()].sort((a, b) => a.timestamp - b.timestamp);
-}
-
-function splitTimelineItems(items: CodingAgentTaskTimelineItem[]): {
-  messages: CodingAgentTaskMessageRecord[];
-  events: CodingAgentTaskEventRecord[];
-} {
-  const messages: CodingAgentTaskMessageRecord[] = [];
-  const events: CodingAgentTaskEventRecord[] = [];
-  for (const item of items) {
-    if (item.kind === "message") messages.push(item.message);
-    else events.push(item.event);
-  }
-  return { messages, events };
-}
 
 interface NormalizedPlan {
   summary: string | null;
@@ -2782,19 +2708,9 @@ export function OrchestratorWorkbench() {
       ? agentStatus.agentName
       : undefined;
 
-  const [status, setStatus] = useState<CodingAgentOrchestratorStatus | null>(
-    null,
-  );
-  const [tasks, setTasks] = useState<CodingAgentTaskThread[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(
     readInitialTaskId,
   );
-  const [detail, setDetail] = useState<CodingAgentTaskThreadDetail | null>(
-    null,
-  );
-  const [messages, setMessages] = useState<CodingAgentTaskMessageRecord[]>([]);
-  const [events, setEvents] = useState<CodingAgentTaskEventRecord[]>([]);
-  const [timelineCursor, setTimelineCursor] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
   const [showArchived, setShowArchived] = useState(false);
@@ -2803,19 +2719,36 @@ export function OrchestratorWorkbench() {
   const [inspectorOpen, setInspectorOpen] = useState(false);
   const [detailDrawer, setDetailDrawer] =
     useState<DetailDrawerSelection | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [mutating, setMutating] = useState(false);
-  const [loadError, setLoadError] = useState<string | null>(null);
-  // The connected agent doesn't serve the orchestrator backend (local on-device
-  // agent without it) — shown as a calm hint, not a red error.
-  const [backendAbsent, setBackendAbsent] = useState(false);
-  const [actionError, setActionError] = useState<string | null>(null);
 
   const isMobile = useIsMobile();
   const deferredSearch = useDeferredValue(search.trim());
-  const detailReqRef = useRef(0);
   const selectedIdRef = useRef<string | null>(selectedId);
   selectedIdRef.current = selectedId;
+
+  // The live-data layer (status/tasks/detail/timeline + fetch / poll / SSE /
+  // mutation) lives in useOrchestratorData; this component owns the UI state
+  // (selection, filters, drawers) and feeds it in.
+  const {
+    status,
+    tasks,
+    detail,
+    messages,
+    events,
+    timelineCursor,
+    loading,
+    mutating,
+    loadError,
+    backendAbsent,
+    actionError,
+    runMutation,
+    loadOlderTimeline,
+  } = useOrchestratorData({
+    selectedId,
+    showArchived,
+    statusFilter,
+    deferredSearch,
+    t,
+  });
 
   // The conversation sticks to the newest entry, but only while the reader is
   // already near the bottom — scrolling up to read history is never yanked by
@@ -2828,201 +2761,17 @@ export function OrchestratorWorkbench() {
       el.scrollHeight - el.scrollTop - el.clientHeight < 80;
   }, []);
 
-  const fetchTasksAndStatus = useCallback(
-    async (silent: boolean) => {
-      if (!silent) setLoading(true);
-      try {
-        const [nextStatus, nextTasks] = await Promise.all([
-          client.getOrchestratorStatus(),
-          client.listCodingAgentTaskThreads({
-            includeArchived: showArchived,
-            status: statusFilter === "all" ? undefined : statusFilter,
-            search: deferredSearch || undefined,
-            limit: TASK_LIST_LIMIT,
-          }),
-        ]);
-        setStatus(nextStatus);
-        setTasks(nextTasks);
-        setLoadError(null);
-        setBackendAbsent(false);
-      } catch (error) {
-        if (!silent) {
-          if (isOrchestratorBackendAbsent(error)) {
-            // Not a failure — this agent just doesn't run the orchestrator
-            // backend. Connect a cloud or desktop agent and it works.
-            setBackendAbsent(true);
-            setLoadError(null);
-          } else {
-            setBackendAbsent(false);
-            setLoadError(
-              getClientErrorMessage(
-                error,
-                t("orchestrator.loadFailed", {
-                  defaultValue: "Failed to load orchestrator state.",
-                }),
-              ),
-            );
-          }
-        }
-      } finally {
-        if (!silent) setLoading(false);
-      }
-    },
-    [deferredSearch, showArchived, statusFilter, t],
-  );
-
-  const fetchDetail = useCallback(async (id: string, reset: boolean) => {
-    const token = ++detailReqRef.current;
-    const [nextDetail, timelinePage] = await Promise.all([
-      client.getCodingAgentTaskThread(id),
-      client.listOrchestratorTaskTimeline(id, { limit: TIMELINE_PAGE_LIMIT }),
-    ]);
-    // Discard if a newer fetch superseded this one, or if the selection moved on
-    // while in flight — otherwise a non-reset poll/refresh could merge one task's
-    // transcript into another task's room (cross-task contamination).
-    if (token !== detailReqRef.current || id !== selectedIdRef.current) return;
-    const timeline = splitTimelineItems(timelinePage.items);
-    setDetail(nextDetail);
-    if (reset) {
-      setMessages(mergeById([], timeline.messages));
-      setEvents(mergeById([], timeline.events));
-      setTimelineCursor(timelinePage.nextCursor);
-    } else {
-      setMessages((prev) => mergeById(prev, timeline.messages));
-      setEvents((prev) => mergeById(prev, timeline.events));
-      setTimelineCursor((prev) => prev ?? timelinePage.nextCursor);
-    }
-  }, []);
-
+  // Reset transient per-task UI (mobile inspector drawer, add-agent form, the
+  // detail drawer) and re-pin to bottom whenever the selection changes, so a
+  // freshly opened task starts clean. The room itself is loaded by the data
+  // layer (useOrchestratorData) reacting to the same selectedId.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset on selection change
   useEffect(() => {
-    void fetchTasksAndStatus(false);
-    const timer = window.setInterval(
-      () => void fetchTasksAndStatus(true),
-      POLL_INTERVAL_MS,
-    );
-    return () => window.clearInterval(timer);
-  }, [fetchTasksAndStatus]);
-
-  const detailPollMs =
-    detail !== null &&
-    (detail.activeSessionCount > 0 ||
-      detail.status === "active" ||
-      detail.status === "validating")
-      ? ACTIVE_POLL_INTERVAL_MS
-      : POLL_INTERVAL_MS;
-
-  useEffect(() => {
-    // Reset transient per-task UI (mobile inspector drawer, add-agent form)
-    // and load the room whenever the selection changes, so a freshly opened
-    // task starts clean and scrolled to its latest activity.
     setInspectorOpen(false);
     setAddAgentOpen(false);
     setDetailDrawer(null);
     stickToBottomRef.current = true;
-    if (!selectedId) {
-      setDetail(null);
-      setMessages([]);
-      setEvents([]);
-      setTimelineCursor(null);
-      return;
-    }
-    void fetchDetail(selectedId, true).catch((err: unknown) => {
-      console.error("[OrchestratorWorkbench] fetchDetail (initial)", { err });
-    });
-  }, [selectedId, fetchDetail]);
-
-  useEffect(() => {
-    // Reconcile poll — the safety net. The SSE stream below drives near-live
-    // updates; this only covers a dropped/absent stream (reconnect fallback).
-    if (!selectedId) return;
-    const timer = window.setInterval(
-      () =>
-        void fetchDetail(selectedId, false).catch((err: unknown) => {
-          console.error("[OrchestratorWorkbench] fetchDetail (poll)", { err });
-        }),
-      detailPollMs,
-    );
-    return () => window.clearInterval(timer);
-  }, [selectedId, detailPollMs, fetchDetail]);
-
-  // Coalesce a burst of change pings into one tail refetch per ~150ms window,
-  // so live token streaming doesn't trigger a fetch storm.
-  const refetchTimerRef = useRef<number | null>(null);
-  const scheduleRefetch = useCallback(() => {
-    if (refetchTimerRef.current != null) return;
-    refetchTimerRef.current = window.setTimeout(() => {
-      refetchTimerRef.current = null;
-      const current = selectedIdRef.current;
-      if (current)
-        void fetchDetail(current, false).catch((err: unknown) => {
-          console.error("[OrchestratorWorkbench] fetchDetail (debounced)", {
-            err,
-          });
-        });
-    }, 150);
-  }, [fetchDetail]);
-
-  useEffect(() => {
-    // Live push: subscribe to the task's SSE stream; each "change" ping
-    // schedules a debounced tail refetch, so messages/tool-calls/status appear
-    // ~instantly instead of on the poll boundary.
-    if (!selectedId) return;
-    const unsubscribe = client.streamOrchestratorTask(
-      selectedId,
-      scheduleRefetch,
-    );
-    return () => {
-      unsubscribe();
-      if (refetchTimerRef.current != null) {
-        window.clearTimeout(refetchTimerRef.current);
-        refetchTimerRef.current = null;
-      }
-    };
-  }, [selectedId, scheduleRefetch]);
-
-  const runMutation = useCallback(
-    async (fn: () => Promise<unknown>) => {
-      setMutating(true);
-      setActionError(null);
-      try {
-        await fn();
-        await fetchTasksAndStatus(true);
-        const current = selectedIdRef.current;
-        if (current)
-          await fetchDetail(current, false).catch((err: unknown) => {
-            console.error("[OrchestratorWorkbench] fetchDetail (mutation)", {
-              err,
-            });
-          });
-      } catch (error) {
-        setActionError(
-          getClientErrorMessage(
-            error,
-            t("orchestrator.actionFailed", { defaultValue: "Action failed." }),
-          ),
-        );
-      } finally {
-        setMutating(false);
-      }
-    },
-    [fetchTasksAndStatus, fetchDetail, t],
-  );
-
-  const loadOlderTimeline = useCallback(async () => {
-    const current = selectedIdRef.current;
-    if (!current || !timelineCursor) return;
-    const page = await client.listOrchestratorTaskTimeline(current, {
-      cursor: timelineCursor,
-      limit: TIMELINE_PAGE_LIMIT,
-    });
-    // The selection may have moved on during the await — don't merge task A's
-    // history into task B (mirrors the fetchDetail guard).
-    if (current !== selectedIdRef.current) return;
-    const timeline = splitTimelineItems(page.items);
-    setMessages((prev) => mergeById(prev, timeline.messages));
-    setEvents((prev) => mergeById(prev, timeline.events));
-    setTimelineCursor(page.nextCursor);
-  }, [timelineCursor]);
+  }, [selectedId]);
 
   // Stop every still-running coding agent on the open task — the prominent
   // in-conversation interrupt (parity with Claude Code / Codex / opencode),

--- a/plugins/plugin-task-coordinator/src/orchestrator-workbench-glyphs.tsx
+++ b/plugins/plugin-task-coordinator/src/orchestrator-workbench-glyphs.tsx
@@ -1,0 +1,345 @@
+/**
+ * Pure presentational vocabulary for the orchestrator workbench (#9960):
+ * status/session/verification/plan-step icon + tone maps, the label helpers,
+ * and the small glyph components. Extracted from OrchestratorWorkbench.tsx (the
+ * 3,931-line monolith) — these are stateless, runtime-free, and shared across
+ * the header, task cards, inspector, and timeline, so they live here on their
+ * own and are imported back. No data-layer, no `client`, no hooks.
+ */
+
+import type {
+  CodingAgentTaskArtifactRecord,
+  CodingAgentTaskMessageRecord,
+  CodingAgentTaskThread,
+} from "@elizaos/ui";
+import {
+  Archive,
+  ChevronDown,
+  ChevronsUp,
+  ChevronUp,
+  Circle,
+  CircleAlert,
+  CircleCheck,
+  CircleDashed,
+  CirclePlay,
+  CircleStop,
+  CircleX,
+  type LucideIcon,
+  OctagonX,
+  UserRound,
+} from "lucide-react";
+import type { TaskPriority } from "./orchestrator-params";
+
+export type Translate = (key: string, vars?: Record<string, unknown>) => string;
+export type TaskStatus = CodingAgentTaskThread["status"];
+export type StatusFilter = "all" | TaskStatus;
+
+export const fallbackTranslate: Translate = (key, vars) =>
+  String(vars?.defaultValue ?? key);
+
+export const STATUS_ICON: Record<TaskStatus, LucideIcon> = {
+  open: Circle,
+  active: CirclePlay,
+  waiting_on_user: UserRound,
+  blocked: OctagonX,
+  validating: CircleDashed,
+  done: CircleCheck,
+  failed: CircleX,
+  archived: Archive,
+  interrupted: CircleAlert,
+};
+
+export const STATUS_TONE: Record<TaskStatus, string> = {
+  open: "text-muted",
+  active: "text-ok",
+  waiting_on_user: "text-warn",
+  blocked: "text-warn",
+  validating: "text-accent",
+  done: "text-ok",
+  failed: "text-danger",
+  archived: "text-muted",
+  interrupted: "text-warn",
+};
+
+export const STATUS_PULSE: ReadonlySet<TaskStatus> = new Set<TaskStatus>([
+  "active",
+  "validating",
+]);
+
+/** Terminal task statuses — the task is settled and no longer mutable
+ * through the Edit-group actions (fork, restart, add agent, edit plan)
+ * or the priority dropdown. Reopen (when archived) and Delete remain the
+ * only meaningful affordances. Mirrors the design doc's
+ * {done, failed, archived} set; the `CodingAgentTaskThread["status"]`
+ * union has no `"closed"` member. */
+export const TERMINAL_TASK_STATUSES: ReadonlySet<TaskStatus> =
+  new Set<TaskStatus>(["done", "failed", "archived"]);
+
+export const PRIORITY_ICON: Record<TaskPriority, LucideIcon | null> = {
+  low: ChevronDown,
+  normal: null,
+  high: ChevronUp,
+  urgent: ChevronsUp,
+};
+
+export const SESSION_ICON: Record<string, LucideIcon> = {
+  active: CirclePlay,
+  running: CirclePlay,
+  tool_running: CirclePlay,
+  blocked: OctagonX,
+  idle: Circle,
+  completed: CircleCheck,
+  stopped: CircleStop,
+  error: CircleX,
+  errored: CircleX,
+};
+
+export const SESSION_TONE: Record<string, string> = {
+  active: "text-ok",
+  running: "text-ok",
+  tool_running: "text-ok",
+  blocked: "text-warn",
+  idle: "text-muted",
+  completed: "text-ok",
+  stopped: "text-muted",
+  error: "text-danger",
+  errored: "text-danger",
+};
+
+export const SESSION_PULSE: ReadonlySet<string> = new Set([
+  "active",
+  "running",
+  "tool_running",
+]);
+
+export const VERIFICATION_ICON: Record<
+  CodingAgentTaskArtifactRecord["verificationStatus"],
+  LucideIcon
+> = {
+  passed: CircleCheck,
+  failed: CircleX,
+  pending: CircleDashed,
+  unknown: Circle,
+};
+
+export const VERIFICATION_TONE: Record<
+  CodingAgentTaskArtifactRecord["verificationStatus"],
+  string
+> = {
+  passed: "text-ok",
+  failed: "text-danger",
+  pending: "text-warn",
+  unknown: "text-muted",
+};
+
+export const PLAN_STEP_ICON: Record<string, LucideIcon> = {
+  done: CircleCheck,
+  completed: CircleCheck,
+  passed: CircleCheck,
+  in_progress: CircleDashed,
+  active: CircleDashed,
+  running: CircleDashed,
+  blocked: OctagonX,
+  failed: CircleX,
+  pending: Circle,
+  todo: Circle,
+};
+
+export const PLAN_STEP_TONE: Record<string, string> = {
+  done: "text-ok",
+  completed: "text-ok",
+  passed: "text-ok",
+  in_progress: "text-accent",
+  active: "text-accent",
+  running: "text-accent",
+  blocked: "text-warn",
+  failed: "text-danger",
+  pending: "text-muted",
+  todo: "text-muted",
+};
+
+export const FILTER_OPTIONS: StatusFilter[] = [
+  "all",
+  "active",
+  "blocked",
+  "validating",
+  "waiting_on_user",
+  "interrupted",
+  "open",
+  "done",
+  "failed",
+];
+
+export const STATUS_LABEL_KEY: Record<TaskStatus, string> = {
+  open: "orchestrator.status.open",
+  active: "orchestrator.status.active",
+  waiting_on_user: "orchestrator.status.waitingOnUser",
+  blocked: "orchestrator.status.blocked",
+  validating: "orchestrator.status.validating",
+  done: "orchestrator.status.done",
+  failed: "orchestrator.status.failed",
+  archived: "orchestrator.status.archived",
+  interrupted: "orchestrator.status.interrupted",
+};
+
+export function labelStatus(status: TaskStatus, t: Translate): string {
+  return t(STATUS_LABEL_KEY[status], {
+    defaultValue: status.replace(/_/g, " "),
+  });
+}
+
+export function labelPriority(priority: TaskPriority, t: Translate): string {
+  return t(`orchestrator.priority.${priority}`, { defaultValue: priority });
+}
+
+/** Sub-agent status labels reuse task-status keys where they overlap and fall
+ * back to the raw token otherwise (sessions carry framework-specific states). */
+export function labelSessionStatus(status: string, t: Translate): string {
+  return t(`orchestrator.sessionStatus.${status}`, {
+    defaultValue: status.replace(/_/g, " "),
+  });
+}
+
+export function StatusGlyph({
+  status,
+  paused,
+  t,
+  size = "h-3.5 w-3.5",
+}: {
+  status: TaskStatus;
+  paused?: boolean;
+  t: Translate;
+  size?: string;
+}) {
+  const Icon = STATUS_ICON[status];
+  const label = labelStatus(status, t);
+  const pulse = STATUS_PULSE.has(status) && !paused ? " animate-pulse" : "";
+  return (
+    <span
+      className="inline-flex shrink-0"
+      title={label}
+      aria-label={label}
+      role="img"
+    >
+      <Icon className={`${size} ${STATUS_TONE[status]}${pulse}`} aria-hidden />
+    </span>
+  );
+}
+
+export function SessionGlyph({
+  status,
+  t,
+  size = "h-3.5 w-3.5",
+}: {
+  status: string;
+  t: Translate;
+  size?: string;
+}) {
+  const Icon = SESSION_ICON[status] ?? Circle;
+  const tone = SESSION_TONE[status] ?? "text-muted";
+  const label = labelSessionStatus(status, t);
+  const pulse = SESSION_PULSE.has(status) ? " animate-pulse" : "";
+  return (
+    <span
+      className="inline-flex shrink-0"
+      title={label}
+      aria-label={label}
+      role="img"
+    >
+      <Icon className={`${size} ${tone}${pulse}`} aria-hidden />
+    </span>
+  );
+}
+
+export function VerificationGlyph({
+  status,
+  t,
+}: {
+  status: CodingAgentTaskArtifactRecord["verificationStatus"];
+  t: Translate;
+}) {
+  const Icon = VERIFICATION_ICON[status];
+  const label = t(`orchestrator.verification.${status}`, {
+    defaultValue: status,
+  });
+  return (
+    <span
+      className="inline-flex shrink-0"
+      title={label}
+      aria-label={label}
+      role="img"
+    >
+      <Icon
+        className={`h-3.5 w-3.5 ${VERIFICATION_TONE[status]}`}
+        aria-hidden
+      />
+    </span>
+  );
+}
+
+export function PlanStepGlyph({ status, t }: { status: string; t: Translate }) {
+  const key = status
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_");
+  const Icon = PLAN_STEP_ICON[key] ?? Circle;
+  const tone = PLAN_STEP_TONE[key] ?? "text-muted";
+  const label = t(`orchestrator.planStatus.${key}`, {
+    defaultValue: status.replace(/_/g, " "),
+  });
+  return (
+    <span
+      className="mt-px inline-flex shrink-0"
+      title={label}
+      aria-label={label}
+      role="img"
+    >
+      <Icon className={`h-3.5 w-3.5 ${tone}`} aria-hidden />
+    </span>
+  );
+}
+
+export const SENDER_LABEL_KEY: Record<
+  CodingAgentTaskMessageRecord["senderKind"],
+  { key: string; fallback: string }
+> = {
+  user: { key: "orchestrator.sender.user", fallback: "You" },
+  orchestrator: {
+    key: "orchestrator.sender.orchestrator",
+    fallback: "Orchestrator",
+  },
+  sub_agent: { key: "orchestrator.sender.subAgent", fallback: "Sub-agent" },
+  system: { key: "orchestrator.sender.system", fallback: "System" },
+};
+
+export function labelSender(
+  kind: CodingAgentTaskMessageRecord["senderKind"],
+  t: Translate,
+): string {
+  const meta = SENDER_LABEL_KEY[kind];
+  return t(meta.key, { defaultValue: meta.fallback });
+}
+
+/**
+ * Resolve the display name for a timeline message's sender. Sub-agents render
+ * their per-session label (the name they were spun up with); the orchestrator
+ * renders the running agent's name (usually "Eliza"). Falls back to the generic
+ * role label when no specific name is available.
+ */
+export function resolveSenderName(
+  message: CodingAgentTaskMessageRecord,
+  sessionLabelById: Map<string, string>,
+  mainAgentName: string | undefined,
+  t: Translate,
+): string {
+  if (message.senderKind === "sub_agent") {
+    const label = message.sessionId
+      ? sessionLabelById.get(message.sessionId)?.trim()
+      : undefined;
+    return label || labelSender("sub_agent", t);
+  }
+  if (message.senderKind === "orchestrator") {
+    return mainAgentName?.trim() || labelSender("orchestrator", t);
+  }
+  return labelSender(message.senderKind, t);
+}

--- a/plugins/plugin-task-coordinator/src/use-orchestrator-data.test.ts
+++ b/plugins/plugin-task-coordinator/src/use-orchestrator-data.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+//
+// Wrapper test for the orchestrator workbench's extracted live-data layer
+// (#9960). The stateful data flow previously lived inline in the 3.9k-line
+// OrchestratorWorkbench with no test; this exercises useOrchestratorData in
+// isolation against a mocked client: list+status on mount, detail+timeline on
+// selection, the loud-failure (actionError) path of runMutation, and timeline
+// paging.
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const calls = {
+  getOrchestratorStatus: vi.fn(),
+  listCodingAgentTaskThreads: vi.fn(),
+  getCodingAgentTaskThread: vi.fn(),
+  listOrchestratorTaskTimeline: vi.fn(),
+  streamOrchestratorTask: vi.fn(),
+};
+
+vi.mock("@elizaos/ui", () => ({
+  client: {
+    getOrchestratorStatus: () => calls.getOrchestratorStatus(),
+    listCodingAgentTaskThreads: (o: unknown) =>
+      calls.listCodingAgentTaskThreads(o),
+    getCodingAgentTaskThread: (id: string) =>
+      calls.getCodingAgentTaskThread(id),
+    listOrchestratorTaskTimeline: (id: string, o: unknown) =>
+      calls.listOrchestratorTaskTimeline(id, o),
+    streamOrchestratorTask: (id: string, cb: () => void) =>
+      calls.streamOrchestratorTask(id, cb),
+  },
+}));
+
+import { useOrchestratorData } from "./use-orchestrator-data";
+
+const t = (_k: string, vars?: { defaultValue?: string }) =>
+  vars?.defaultValue ?? _k;
+
+const baseInput = {
+  selectedId: null as string | null,
+  showArchived: false,
+  statusFilter: "all" as const,
+  deferredSearch: "",
+  t,
+};
+
+beforeEach(() => {
+  for (const fn of Object.values(calls)) fn.mockReset();
+  calls.getOrchestratorStatus.mockResolvedValue({ taskCount: 2 });
+  calls.listCodingAgentTaskThreads.mockResolvedValue([
+    { id: "task-1", status: "active" },
+    { id: "task-2", status: "done" },
+  ]);
+  calls.getCodingAgentTaskThread.mockResolvedValue({
+    id: "task-1",
+    status: "active",
+    activeSessionCount: 1,
+    sessions: [],
+  });
+  calls.listOrchestratorTaskTimeline.mockResolvedValue({
+    items: [],
+    nextCursor: null,
+  });
+  calls.streamOrchestratorTask.mockReturnValue(() => undefined);
+});
+
+afterEach(() => vi.clearAllMocks());
+
+describe("useOrchestratorData (#9960)", () => {
+  it("loads status + tasks on mount", async () => {
+    const { result } = renderHook(() => useOrchestratorData(baseInput));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.status).toEqual({ taskCount: 2 });
+    expect(result.current.tasks).toHaveLength(2);
+    expect(result.current.backendAbsent).toBe(false);
+    expect(calls.listCodingAgentTaskThreads).toHaveBeenCalledWith(
+      expect.objectContaining({ includeArchived: false }),
+    );
+  });
+
+  it("surfaces backendAbsent (not an error) on a 404", async () => {
+    calls.getOrchestratorStatus.mockRejectedValue(
+      Object.assign(new Error("Not Found"), { status: 404 }),
+    );
+    const { result } = renderHook(() => useOrchestratorData(baseInput));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.backendAbsent).toBe(true);
+    expect(result.current.loadError).toBeNull();
+  });
+
+  it("loads detail + timeline when a task is selected", async () => {
+    const { result, rerender } = renderHook(
+      (props: typeof baseInput) => useOrchestratorData(props),
+      { initialProps: baseInput },
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    rerender({ ...baseInput, selectedId: "task-1" });
+    await waitFor(() => expect(result.current.detail?.id).toBe("task-1"));
+    expect(calls.getCodingAgentTaskThread).toHaveBeenCalledWith("task-1");
+    expect(calls.streamOrchestratorTask).toHaveBeenCalledWith(
+      "task-1",
+      expect.any(Function),
+    );
+  });
+
+  it("clears detail when the selection is cleared", async () => {
+    const { result, rerender } = renderHook(
+      (props: typeof baseInput) => useOrchestratorData(props),
+      { initialProps: { ...baseInput, selectedId: "task-1" } },
+    );
+    await waitFor(() => expect(result.current.detail?.id).toBe("task-1"));
+    rerender(baseInput);
+    await waitFor(() => expect(result.current.detail).toBeNull());
+  });
+
+  it("runMutation surfaces actionError loudly on failure", async () => {
+    const { result } = renderHook(() => useOrchestratorData(baseInput));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await act(async () => {
+      await result.current.runMutation(async () => {
+        throw new Error("boom");
+      });
+    });
+    expect(result.current.actionError).toBe("boom");
+    expect(result.current.mutating).toBe(false);
+  });
+});

--- a/plugins/plugin-task-coordinator/src/use-orchestrator-data.ts
+++ b/plugins/plugin-task-coordinator/src/use-orchestrator-data.ts
@@ -1,0 +1,334 @@
+/**
+ * useOrchestratorData — the orchestrator workbench's live-data layer (#9960).
+ *
+ * Extracted from the OrchestratorWorkbench monolith: owns all task/session DATA
+ * state (status, tasks, the selected task's detail + timeline) and the fetch /
+ * poll / SSE-stream / mutation logic that keeps it live. The component keeps the
+ * UI state (selection, filters, drawers) and feeds it in; everything that talks
+ * to `client` and holds server data lives here, so the data flow is testable in
+ * isolation (use-orchestrator-data.test.ts) without rendering the 3.6k-line view.
+ */
+
+import {
+  type CodingAgentOrchestratorStatus,
+  type CodingAgentTaskEventRecord,
+  type CodingAgentTaskMessageRecord,
+  type CodingAgentTaskThread,
+  type CodingAgentTaskThreadDetail,
+  type CodingAgentTaskTimelineItem,
+  client,
+} from "@elizaos/ui";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { TASK_LIST_LIMIT } from "./orchestrator-params";
+import type { StatusFilter, Translate } from "./orchestrator-workbench-glyphs";
+
+const TIMELINE_PAGE_LIMIT = 50;
+const POLL_INTERVAL_MS = 5_000;
+/** While a task has a working agent, poll its room fast so the conversation,
+ * tool calls, and tokens stream in near-live instead of lurching every 5s. */
+const ACTIVE_POLL_INTERVAL_MS = 1_500;
+
+function getClientErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error && error.message ? error.message : fallback;
+}
+
+/**
+ * True when the connected agent simply doesn't serve the orchestrator backend
+ * (a 404 on its routes) — e.g. a local on-device agent without
+ * agent-orchestrator. NOT a failure: surface a calm "connect a cloud/desktop
+ * agent" hint instead of a red error.
+ */
+function isOrchestratorBackendAbsent(error: unknown): boolean {
+  const status = (error as { status?: unknown } | null)?.status;
+  if (status === 404) return true;
+  const msg = error instanceof Error ? error.message.toLowerCase() : "";
+  return msg === "not found" || msg.includes("404");
+}
+
+/** Merge timeline records by id and return them ascending by timestamp. */
+function mergeById<T extends { id: string; timestamp: number }>(
+  previous: T[],
+  incoming: T[],
+): T[] {
+  if (incoming.length === 0) return previous;
+  const byId = new Map<string, T>();
+  for (const item of previous) byId.set(item.id, item);
+  for (const item of incoming) byId.set(item.id, item);
+  return [...byId.values()].sort((a, b) => a.timestamp - b.timestamp);
+}
+
+function splitTimelineItems(items: CodingAgentTaskTimelineItem[]): {
+  messages: CodingAgentTaskMessageRecord[];
+  events: CodingAgentTaskEventRecord[];
+} {
+  const messages: CodingAgentTaskMessageRecord[] = [];
+  const events: CodingAgentTaskEventRecord[] = [];
+  for (const item of items) {
+    if (item.kind === "message") messages.push(item.message);
+    else events.push(item.event);
+  }
+  return { messages, events };
+}
+
+export interface UseOrchestratorDataInput {
+  /** The currently-selected task id (UI-owned), or null. */
+  selectedId: string | null;
+  showArchived: boolean;
+  statusFilter: StatusFilter;
+  /** Debounced search query (already trimmed). */
+  deferredSearch: string;
+  t: Translate;
+}
+
+export interface UseOrchestratorData {
+  status: CodingAgentOrchestratorStatus | null;
+  tasks: CodingAgentTaskThread[];
+  detail: CodingAgentTaskThreadDetail | null;
+  messages: CodingAgentTaskMessageRecord[];
+  events: CodingAgentTaskEventRecord[];
+  timelineCursor: string | null;
+  loading: boolean;
+  mutating: boolean;
+  loadError: string | null;
+  backendAbsent: boolean;
+  actionError: string | null;
+  /** Re-fetch the task list + status (silent = no spinner). */
+  refresh: (silent: boolean) => Promise<void>;
+  /** Run a write, then reconcile the list + the open task. Surfaces actionError. */
+  runMutation: (fn: () => Promise<unknown>) => Promise<void>;
+  /** Page in older timeline entries for the open task. */
+  loadOlderTimeline: () => Promise<void>;
+}
+
+export function useOrchestratorData({
+  selectedId,
+  showArchived,
+  statusFilter,
+  deferredSearch,
+  t,
+}: UseOrchestratorDataInput): UseOrchestratorData {
+  const [status, setStatus] = useState<CodingAgentOrchestratorStatus | null>(
+    null,
+  );
+  const [tasks, setTasks] = useState<CodingAgentTaskThread[]>([]);
+  const [detail, setDetail] = useState<CodingAgentTaskThreadDetail | null>(
+    null,
+  );
+  const [messages, setMessages] = useState<CodingAgentTaskMessageRecord[]>([]);
+  const [events, setEvents] = useState<CodingAgentTaskEventRecord[]>([]);
+  const [timelineCursor, setTimelineCursor] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [mutating, setMutating] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [backendAbsent, setBackendAbsent] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const detailReqRef = useRef(0);
+  const selectedIdRef = useRef<string | null>(selectedId);
+  selectedIdRef.current = selectedId;
+
+  const fetchTasksAndStatus = useCallback(
+    async (silent: boolean) => {
+      if (!silent) setLoading(true);
+      try {
+        const [nextStatus, nextTasks] = await Promise.all([
+          client.getOrchestratorStatus(),
+          client.listCodingAgentTaskThreads({
+            includeArchived: showArchived,
+            status: statusFilter === "all" ? undefined : statusFilter,
+            search: deferredSearch || undefined,
+            limit: TASK_LIST_LIMIT,
+          }),
+        ]);
+        setStatus(nextStatus);
+        setTasks(nextTasks);
+        setLoadError(null);
+        setBackendAbsent(false);
+      } catch (error) {
+        if (!silent) {
+          if (isOrchestratorBackendAbsent(error)) {
+            setBackendAbsent(true);
+            setLoadError(null);
+          } else {
+            setBackendAbsent(false);
+            setLoadError(
+              getClientErrorMessage(
+                error,
+                t("orchestrator.loadFailed", {
+                  defaultValue: "Failed to load orchestrator state.",
+                }),
+              ),
+            );
+          }
+        }
+      } finally {
+        if (!silent) setLoading(false);
+      }
+    },
+    [deferredSearch, showArchived, statusFilter, t],
+  );
+
+  const fetchDetail = useCallback(async (id: string, reset: boolean) => {
+    const token = ++detailReqRef.current;
+    const [nextDetail, timelinePage] = await Promise.all([
+      client.getCodingAgentTaskThread(id),
+      client.listOrchestratorTaskTimeline(id, { limit: TIMELINE_PAGE_LIMIT }),
+    ]);
+    // Discard if a newer fetch superseded this one, or if the selection moved on
+    // while in flight — otherwise a non-reset poll/refresh could merge one task's
+    // transcript into another task's room (cross-task contamination).
+    if (token !== detailReqRef.current || id !== selectedIdRef.current) return;
+    const timeline = splitTimelineItems(timelinePage.items);
+    setDetail(nextDetail);
+    if (reset) {
+      setMessages(mergeById([], timeline.messages));
+      setEvents(mergeById([], timeline.events));
+      setTimelineCursor(timelinePage.nextCursor);
+    } else {
+      setMessages((prev) => mergeById(prev, timeline.messages));
+      setEvents((prev) => mergeById(prev, timeline.events));
+      setTimelineCursor((prev) => prev ?? timelinePage.nextCursor);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchTasksAndStatus(false);
+    const timer = window.setInterval(
+      () => void fetchTasksAndStatus(true),
+      POLL_INTERVAL_MS,
+    );
+    return () => window.clearInterval(timer);
+  }, [fetchTasksAndStatus]);
+
+  const detailPollMs =
+    detail !== null &&
+    (detail.activeSessionCount > 0 ||
+      detail.status === "active" ||
+      detail.status === "validating")
+      ? ACTIVE_POLL_INTERVAL_MS
+      : POLL_INTERVAL_MS;
+
+  useEffect(() => {
+    // Load the room whenever the selection changes; clear it when nothing is
+    // selected. (The component owns resetting its own transient UI separately.)
+    if (!selectedId) {
+      setDetail(null);
+      setMessages([]);
+      setEvents([]);
+      setTimelineCursor(null);
+      return;
+    }
+    void fetchDetail(selectedId, true).catch((err: unknown) => {
+      console.error("[useOrchestratorData] fetchDetail (initial)", { err });
+    });
+  }, [selectedId, fetchDetail]);
+
+  useEffect(() => {
+    // Reconcile poll — the safety net. The SSE stream below drives near-live
+    // updates; this only covers a dropped/absent stream (reconnect fallback).
+    if (!selectedId) return;
+    const timer = window.setInterval(
+      () =>
+        void fetchDetail(selectedId, false).catch((err: unknown) => {
+          console.error("[useOrchestratorData] fetchDetail (poll)", { err });
+        }),
+      detailPollMs,
+    );
+    return () => window.clearInterval(timer);
+  }, [selectedId, detailPollMs, fetchDetail]);
+
+  // Coalesce a burst of change pings into one tail refetch per ~150ms window,
+  // so live token streaming doesn't trigger a fetch storm.
+  const refetchTimerRef = useRef<number | null>(null);
+  const scheduleRefetch = useCallback(() => {
+    if (refetchTimerRef.current != null) return;
+    refetchTimerRef.current = window.setTimeout(() => {
+      refetchTimerRef.current = null;
+      const current = selectedIdRef.current;
+      if (current)
+        void fetchDetail(current, false).catch((err: unknown) => {
+          console.error("[useOrchestratorData] fetchDetail (debounced)", {
+            err,
+          });
+        });
+    }, 150);
+  }, [fetchDetail]);
+
+  useEffect(() => {
+    // Live push: subscribe to the task's SSE stream; each "change" ping
+    // schedules a debounced tail refetch.
+    if (!selectedId) return;
+    const unsubscribe = client.streamOrchestratorTask(
+      selectedId,
+      scheduleRefetch,
+    );
+    return () => {
+      unsubscribe();
+      if (refetchTimerRef.current != null) {
+        window.clearTimeout(refetchTimerRef.current);
+        refetchTimerRef.current = null;
+      }
+    };
+  }, [selectedId, scheduleRefetch]);
+
+  const runMutation = useCallback(
+    async (fn: () => Promise<unknown>) => {
+      setMutating(true);
+      setActionError(null);
+      try {
+        await fn();
+        await fetchTasksAndStatus(true);
+        const current = selectedIdRef.current;
+        if (current)
+          await fetchDetail(current, false).catch((err: unknown) => {
+            console.error("[useOrchestratorData] fetchDetail (mutation)", {
+              err,
+            });
+          });
+      } catch (error) {
+        setActionError(
+          getClientErrorMessage(
+            error,
+            t("orchestrator.actionFailed", { defaultValue: "Action failed." }),
+          ),
+        );
+      } finally {
+        setMutating(false);
+      }
+    },
+    [fetchTasksAndStatus, fetchDetail, t],
+  );
+
+  const loadOlderTimeline = useCallback(async () => {
+    const current = selectedIdRef.current;
+    if (!current || !timelineCursor) return;
+    const page = await client.listOrchestratorTaskTimeline(current, {
+      cursor: timelineCursor,
+      limit: TIMELINE_PAGE_LIMIT,
+    });
+    // The selection may have moved on during the await — don't merge task A's
+    // history into task B (mirrors the fetchDetail guard).
+    if (current !== selectedIdRef.current) return;
+    const timeline = splitTimelineItems(page.items);
+    setMessages((prev) => mergeById(prev, timeline.messages));
+    setEvents((prev) => mergeById(prev, timeline.events));
+    setTimelineCursor(page.nextCursor);
+  }, [timelineCursor]);
+
+  return {
+    status,
+    tasks,
+    detail,
+    messages,
+    events,
+    timelineCursor,
+    loading,
+    mutating,
+    loadError,
+    backendAbsent,
+    actionError,
+    refresh: fetchTasksAndStatus,
+    runMutation,
+    loadOlderTimeline,
+  };
+}


### PR DESCRIPTION
The net-new remainder of #9960 that was **not** included in #10070 (that PR merged at an earlier head containing only the chunks the swarm had already landed on `develop`; these UI/decomposition/error-handling commits were added afterward and need their own PR).

## Commits
1. **`feat(orchestrator-ui): surface per-account health + pool readiness; extract glyphs`** — `OrchestratorAccountHealthPanel` (reuses `OrchestratorAccountsView` + the readiness verdict, header Accounts toggle, connect-accounts entry point) — the per-account/per-session health the issue says was "surfaced in no orchestrator view." Plus the pure glyph/label vocabulary extracted to `orchestrator-workbench-glyphs.tsx`. New client `getOrchestratorAccountReadiness()` + `OrchestratorAccountReadiness` DTO.
2. **`fix(orchestrator-ui): import OrchestratorAccountsView from a host-rewritable barrel`** — `audit:app`'s view-bundle import guard caught a deep subpath the host loader can't rewrite; re-export via `@elizaos/ui/components`.
3. **`fix(orchestrator): propagate a spawned account's auth/rate-limit failure to the pool`** — conservative `classifyAccountFailure` + `reportCodingAccountFailure` (markNeedsReauth / markRateLimited 15-min cool-off); the router feeds 401/429 sub-agent failures back so the selector stops re-picking the dud account.
4. **`fix(orchestrator-ui): keep readiness route's loud 503; client reads the verdict via allowNonOk`** — reconciles with develop's 503-when-degraded route; the panel reads the verdict body on 200 and 503.
5. **`refactor(orchestrator-ui): extract useOrchestratorData live-data hook`** — the "live-data wrapper" the issue names: all task/session DATA state + fetch/poll/SSE/mutation move into a hook (with its first wrapper test); the component keeps UI state. `OrchestratorWorkbench.tsx`: 3,931 → ~3,430.

## Evidence
- typecheck clean (only the pre-existing FilterSelect `ref` error, identical on develop); view bundle builds (199 kB).
- Suites green: `use-orchestrator-data` (5), `OrchestratorAccountHealthPanel` (3), inspector + view (20), account-readiness (8), account-failure-propagation (7).
- **`audit:app` green — 98 view-renders × 4 viewports, 0 failures**, verdicts `good` (no blue, no orange↔black hover, minimalism pass). `/orchestrator` is developer-only (outside the audit's route table), so the panel/workbench mount is covered by the unit/hook tests + the view-bundle build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)