### PR TITLE
fix(cloud): run service agent lifecycle jobs as owner org

### DIFF
--- a/packages/cloud/api/v1/agents/[agentId]/logs/route.test.ts
+++ b/packages/cloud/api/v1/agents/[agentId]/logs/route.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const requireServiceKey = mock(async () => ({
+  organizationId: "service-org",
+  userId: "service-user",
+}));
+const validateServiceKey = mock(async () => ({
+  organizationId: "service-org",
+  userId: "service-user",
+}));
+const getAgentById = mock(
+  async (): Promise<{
+    id: string;
+    organization_id: string;
+    user_id: string;
+    status: string;
+  } | null> => ({
+    id: "cloud-agent-1",
+    organization_id: "agent-wallet-org",
+    user_id: "agent-wallet-user",
+    status: "running",
+  }),
+);
+const enqueueAgentLogsOnce = mock(async () => ({
+  created: true,
+  job: {
+    id: "logs-job-1",
+    status: "pending",
+  },
+}));
+const triggerImmediate = mock(async () => undefined);
+
+mock.module("@/lib/auth/service-key-hono-worker", () => ({
+  requireServiceKey,
+  validateServiceKey,
+}));
+
+mock.module("@/lib/services/eliza-sandbox", () => ({
+  elizaSandboxService: {
+    getAgentById,
+  },
+}));
+
+mock.module("@/lib/services/provisioning-jobs", () => ({
+  provisioningJobService: {
+    enqueueAgentLogsOnce,
+    triggerImmediate,
+  },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+    error: mock(() => undefined),
+    debug: mock(() => undefined),
+  },
+}));
+
+const { default: logsRoute } = await import("./route");
+
+describe("service agent logs route", () => {
+  const app = new Hono();
+  app.route("/api/v1/agents/:agentId/logs", logsRoute);
+
+  beforeEach(() => {
+    requireServiceKey.mockClear();
+    validateServiceKey.mockClear();
+    getAgentById.mockClear();
+    getAgentById.mockResolvedValue({
+      id: "cloud-agent-1",
+      organization_id: "agent-wallet-org",
+      user_id: "agent-wallet-user",
+      status: "running",
+    });
+    enqueueAgentLogsOnce.mockClear();
+    enqueueAgentLogsOnce.mockResolvedValue({
+      created: true,
+      job: {
+        id: "logs-job-1",
+        status: "pending",
+      },
+    });
+    triggerImmediate.mockClear();
+  });
+
+  test("enqueues logs under the agent owner org and user", async () => {
+    const response = await app.fetch(
+      new Request(
+        "https://api.example.test/api/v1/agents/cloud-agent-1/logs?tail=10",
+        {
+          method: "GET",
+          headers: { "X-Service-Key": "svc" },
+        },
+      ),
+      { WAIFU_SERVICE_KEY: "svc" },
+    );
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      data: {
+        agentId: "cloud-agent-1",
+        jobId: "logs-job-1",
+        tail: 10,
+        agentStatus: "running",
+      },
+    });
+    expect(enqueueAgentLogsOnce).toHaveBeenCalledWith({
+      agentId: "cloud-agent-1",
+      organizationId: "agent-wallet-org",
+      userId: "agent-wallet-user",
+      tail: 10,
+    });
+  });
+
+  test("returns 404 before enqueueing when the agent id is unknown", async () => {
+    getAgentById.mockResolvedValueOnce(null);
+
+    const response = await app.fetch(
+      new Request("https://api.example.test/api/v1/agents/missing-agent/logs", {
+        method: "GET",
+        headers: { "X-Service-Key": "svc" },
+      }),
+      { WAIFU_SERVICE_KEY: "svc" },
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: "Agent not found",
+    });
+    expect(enqueueAgentLogsOnce).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/agents/[agentId]/logs/route.ts
+++ b/packages/cloud/api/v1/agents/[agentId]/logs/route.ts
@@ -29,7 +29,7 @@ const app = new Hono<AppEnv>();
 
 app.get("/", async (c) => {
   try {
-    const identity = await requireServiceKey(c);
+    await requireServiceKey(c);
     const agentId = c.req.param("agentId") ?? "";
     const agent = await elizaSandboxService.getAgentById(agentId);
 
@@ -45,8 +45,8 @@ app.get("/", async (c) => {
 
     const enqueueResult = await provisioningJobService.enqueueAgentLogsOnce({
       agentId,
-      organizationId: identity.organizationId,
-      userId: identity.userId,
+      organizationId: agent.organization_id,
+      userId: agent.user_id,
       tail,
     });
 

--- a/packages/cloud/api/v1/agents/[agentId]/restart/route.test.ts
+++ b/packages/cloud/api/v1/agents/[agentId]/restart/route.test.ts
@@ -5,9 +5,14 @@ const requireServiceKey = mock(async () => ({
   organizationId: "service-org",
   userId: "service-user",
 }));
+const validateServiceKey = mock(async () => ({
+  organizationId: "service-org",
+  userId: "service-user",
+}));
 const getAgentById = mock(async () => ({
   id: "cloud-agent-1",
   organization_id: "agent-org",
+  user_id: "agent-user",
 }));
 const getAgentForWrite = mock(async () => ({
   id: "cloud-agent-1",
@@ -27,6 +32,7 @@ const checkAgentCreditGate = mock(async () => ({
 
 mock.module("@/lib/auth/service-key-hono-worker", () => ({
   requireServiceKey,
+  validateServiceKey,
 }));
 
 mock.module("@/db/repositories/agent-billing", () => ({
@@ -77,6 +83,7 @@ describe("service agent restart route", () => {
 
   beforeEach(() => {
     requireServiceKey.mockClear();
+    validateServiceKey.mockClear();
     getAgentById.mockClear();
     getAgentForWrite.mockClear();
     getAgentForWrite.mockResolvedValue({
@@ -142,11 +149,11 @@ describe("service agent restart route", () => {
       success: true,
     });
     // The restart is delegated to the orchestrator via an enqueued job carrying
-    // the service-key identity, then sandbox billing is reactivated.
+    // the agent owner identity, then sandbox billing is reactivated.
     expect(enqueueAgentRestartOnce).toHaveBeenCalledWith({
       agentId: "cloud-agent-1",
-      organizationId: "service-org",
-      userId: "service-user",
+      organizationId: "agent-org",
+      userId: "agent-user",
     });
     expect(reactivateSandboxBillingAfterFunding).toHaveBeenCalledWith(
       "cloud-agent-1",

--- a/packages/cloud/api/v1/agents/[agentId]/restart/route.ts
+++ b/packages/cloud/api/v1/agents/[agentId]/restart/route.ts
@@ -32,7 +32,7 @@ app.use("*", rateLimit(RateLimitPresets.STANDARD));
 
 app.post("/", async (c) => {
   try {
-    const identity = await requireServiceKey(c);
+    await requireServiceKey(c);
     const agentId = c.req.param("agentId") ?? "";
     const agent = await elizaSandboxService.getAgentById(agentId);
     if (!agent) throw NotFoundError("Agent not found");
@@ -75,8 +75,8 @@ app.post("/", async (c) => {
 
     await provisioningJobService.enqueueAgentRestartOnce({
       agentId,
-      organizationId: identity.organizationId,
-      userId: identity.userId,
+      organizationId: agent.organization_id,
+      userId: agent.user_id,
     });
 
     await agentBillingRepository.reactivateSandboxBillingAfterFunding(

--- a/packages/cloud/api/v1/agents/[agentId]/suspend/route.test.ts
+++ b/packages/cloud/api/v1/agents/[agentId]/suspend/route.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const requireServiceKey = mock(async () => ({
+  organizationId: "service-org",
+  userId: "service-user",
+}));
+const validateServiceKey = mock(async () => ({
+  organizationId: "service-org",
+  userId: "service-user",
+}));
+const getAgentById = mock(
+  async (): Promise<{
+    id: string;
+    organization_id: string;
+    user_id: string;
+    status: string;
+  } | null> => ({
+    id: "cloud-agent-1",
+    organization_id: "agent-wallet-org",
+    user_id: "agent-wallet-user",
+    status: "running",
+  }),
+);
+const enqueueAgentSuspendOnce = mock(async () => ({
+  created: true,
+  job: {
+    id: "suspend-job-1",
+    status: "pending",
+  },
+}));
+const triggerImmediate = mock(async () => undefined);
+
+mock.module("@/lib/auth/service-key-hono-worker", () => ({
+  requireServiceKey,
+  validateServiceKey,
+}));
+
+mock.module("@/lib/services/eliza-sandbox", () => ({
+  elizaSandboxService: {
+    getAgentById,
+  },
+}));
+
+mock.module("@/lib/services/provisioning-jobs", () => ({
+  provisioningJobService: {
+    enqueueAgentSuspendOnce,
+    triggerImmediate,
+  },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+    error: mock(() => undefined),
+    debug: mock(() => undefined),
+  },
+}));
+
+const { default: suspendRoute } = await import("./route");
+
+describe("service agent suspend route", () => {
+  const app = new Hono();
+  app.route("/api/v1/agents/:agentId/suspend", suspendRoute);
+
+  beforeEach(() => {
+    requireServiceKey.mockClear();
+    validateServiceKey.mockClear();
+    getAgentById.mockClear();
+    getAgentById.mockResolvedValue({
+      id: "cloud-agent-1",
+      organization_id: "agent-wallet-org",
+      user_id: "agent-wallet-user",
+      status: "running",
+    });
+    enqueueAgentSuspendOnce.mockClear();
+    enqueueAgentSuspendOnce.mockResolvedValue({
+      created: true,
+      job: {
+        id: "suspend-job-1",
+        status: "pending",
+      },
+    });
+    triggerImmediate.mockClear();
+  });
+
+  test("enqueues suspend under the agent owner org and user", async () => {
+    const response = await app.fetch(
+      new Request(
+        "https://api.example.test/api/v1/agents/cloud-agent-1/suspend",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Service-Key": "svc",
+          },
+          body: JSON.stringify({ reason: "owner requested suspension" }),
+        },
+      ),
+      { WAIFU_SERVICE_KEY: "svc" },
+    );
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      data: {
+        agentId: "cloud-agent-1",
+        action: "suspend",
+        jobId: "suspend-job-1",
+        previousStatus: "running",
+      },
+    });
+    expect(enqueueAgentSuspendOnce).toHaveBeenCalledWith({
+      agentId: "cloud-agent-1",
+      organizationId: "agent-wallet-org",
+      userId: "agent-wallet-user",
+    });
+  });
+
+  test("returns an idempotent success without enqueueing when already stopped", async () => {
+    getAgentById.mockResolvedValueOnce({
+      id: "cloud-agent-1",
+      organization_id: "agent-wallet-org",
+      user_id: "agent-wallet-user",
+      status: "stopped",
+    });
+
+    const response = await app.fetch(
+      new Request(
+        "https://api.example.test/api/v1/agents/cloud-agent-1/suspend",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Service-Key": "svc",
+          },
+          body: JSON.stringify({}),
+        },
+      ),
+      { WAIFU_SERVICE_KEY: "svc" },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      data: {
+        agentId: "cloud-agent-1",
+        action: "suspend",
+        previousStatus: "stopped",
+      },
+    });
+    expect(enqueueAgentSuspendOnce).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/agents/[agentId]/suspend/route.ts
+++ b/packages/cloud/api/v1/agents/[agentId]/suspend/route.ts
@@ -29,7 +29,7 @@ const suspendSchema = z.object({
 
 app.post("/", async (c) => {
   try {
-    const identity = await requireServiceKey(c);
+    await requireServiceKey(c);
     const agentId = c.req.param("agentId") ?? "";
     const agent = await elizaSandboxService.getAgentById(agentId);
     if (!agent) throw NotFoundError("Agent not found");
@@ -63,8 +63,8 @@ app.post("/", async (c) => {
 
     const enqueueResult = await provisioningJobService.enqueueAgentSuspendOnce({
       agentId,
-      organizationId: identity.organizationId,
-      userId: identity.userId,
+      organizationId: agent.organization_id,
+      userId: agent.user_id,
     });
 
     void provisioningJobService.triggerImmediate(c.env).catch(() => {

--- a/packages/cloud/api/v1/jobs/[jobId]/route.test.ts
+++ b/packages/cloud/api/v1/jobs/[jobId]/route.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const validateServiceKey = mock(
+  async (): Promise<{ organizationId: string; userId: string } | null> => ({
+    organizationId: "service-org",
+    userId: "service-user",
+  }),
+);
+const requireServiceKey = mock(async () => ({
+  organizationId: "service-org",
+  userId: "service-user",
+}));
+const requireUserOrApiKeyWithOrg = mock(async () => ({
+  organization_id: "user-org",
+}));
+const getJob = mock(async () => ({
+  id: "job-1",
+  type: "agent_logs",
+  status: "completed",
+  result: { logs: "ok" },
+  error: null,
+  attempts: 1,
+  max_attempts: 2,
+  estimated_completion_at: null,
+  scheduled_for: null,
+  started_at: null,
+  completed_at: null,
+  created_at: new Date("2026-01-01T00:00:00Z"),
+  updated_at: new Date("2026-01-01T00:00:01Z"),
+}));
+const getJobForOrg = mock(async () => ({
+  id: "job-1",
+  type: "agent_logs",
+  status: "pending",
+  result: null,
+  error: null,
+  attempts: 0,
+  max_attempts: 2,
+  estimated_completion_at: null,
+  scheduled_for: null,
+  started_at: null,
+  completed_at: null,
+  created_at: new Date("2026-01-01T00:00:00Z"),
+  updated_at: new Date("2026-01-01T00:00:01Z"),
+}));
+
+mock.module("@/lib/auth/service-key-hono-worker", () => ({
+  requireServiceKey,
+  validateServiceKey,
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+}));
+
+mock.module("@/lib/services/provisioning-jobs", () => ({
+  provisioningJobService: {
+    getJob,
+    getJobForOrg,
+  },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+    error: mock(() => undefined),
+    debug: mock(() => undefined),
+  },
+}));
+
+const { default: jobsRoute } = await import("./route");
+
+describe("jobs route", () => {
+  const app = new Hono();
+  app.route("/api/v1/jobs/:jobId", jobsRoute);
+
+  beforeEach(() => {
+    validateServiceKey.mockClear();
+    requireServiceKey.mockClear();
+    validateServiceKey.mockResolvedValue({
+      organizationId: "service-org",
+      userId: "service-user",
+    });
+    requireUserOrApiKeyWithOrg.mockClear();
+    getJob.mockClear();
+    getJob.mockResolvedValue({
+      id: "job-1",
+      type: "agent_logs",
+      status: "completed",
+      result: { logs: "ok" },
+      error: null,
+      attempts: 1,
+      max_attempts: 2,
+      estimated_completion_at: null,
+      scheduled_for: null,
+      started_at: null,
+      completed_at: null,
+      created_at: new Date("2026-01-01T00:00:00Z"),
+      updated_at: new Date("2026-01-01T00:00:01Z"),
+    });
+    getJobForOrg.mockClear();
+    getJobForOrg.mockResolvedValue({
+      id: "job-1",
+      type: "agent_logs",
+      status: "pending",
+      result: null,
+      error: null,
+      attempts: 0,
+      max_attempts: 2,
+      estimated_completion_at: null,
+      scheduled_for: null,
+      started_at: null,
+      completed_at: null,
+      created_at: new Date("2026-01-01T00:00:00Z"),
+      updated_at: new Date("2026-01-01T00:00:01Z"),
+    });
+  });
+
+  test("service-key polling can read owner-org jobs by id", async () => {
+    const response = await app.fetch(
+      new Request("https://api.example.test/api/v1/jobs/job-1", {
+        method: "GET",
+        headers: { "X-Service-Key": "svc" },
+      }),
+      { WAIFU_SERVICE_KEY: "svc" },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      data: {
+        id: "job-1",
+        status: "completed",
+        result: { logs: "ok" },
+      },
+      polling: { shouldContinue: false },
+    });
+    expect(getJob).toHaveBeenCalledWith("job-1");
+    expect(getJobForOrg).not.toHaveBeenCalled();
+    expect(requireUserOrApiKeyWithOrg).not.toHaveBeenCalled();
+  });
+
+  test("user/API-key polling stays scoped to the caller organization", async () => {
+    validateServiceKey.mockResolvedValueOnce(null);
+
+    const response = await app.fetch(
+      new Request("https://api.example.test/api/v1/jobs/job-1", {
+        method: "GET",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      data: {
+        id: "job-1",
+        status: "pending",
+      },
+      polling: {
+        shouldContinue: true,
+        intervalMs: 5000,
+      },
+    });
+    expect(requireUserOrApiKeyWithOrg).toHaveBeenCalled();
+    expect(getJobForOrg).toHaveBeenCalledWith("job-1", "user-org");
+    expect(getJob).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/jobs/[jobId]/route.ts
+++ b/packages/cloud/api/v1/jobs/[jobId]/route.ts
@@ -18,11 +18,14 @@ const app = new Hono<AppEnv>();
 
 app.get("/", async (c) => {
   try {
-    let organizationId: string;
+    let organizationId: string | null = null;
 
     const serviceIdentity = await validateServiceKey(c);
     if (serviceIdentity) {
-      organizationId = serviceIdentity.organizationId;
+      // Service-key callers orchestrate jobs on behalf of wallet-owned agents,
+      // so their job rows may belong to the agent owner org rather than the
+      // service org configured on the key.
+      organizationId = null;
     } else {
       const user = await requireUserOrApiKeyWithOrg(c);
       organizationId = user.organization_id;
@@ -33,10 +36,9 @@ app.get("/", async (c) => {
       return c.json({ success: false, error: "Job ID is required" }, 400);
     }
 
-    const job = await provisioningJobService.getJobForOrg(
-      jobId,
-      organizationId,
-    );
+    const job = organizationId
+      ? await provisioningJobService.getJobForOrg(jobId, organizationId)
+      : await provisioningJobService.getJob(jobId);
 
     if (!job) {
       return c.json({ success: false, error: "Job not found" }, 404);


### PR DESCRIPTION
## Summary
- enqueue service-key `logs`, `suspend`, and `restart` daemon jobs under the agent's persisted owner org/user instead of `WAIFU_SERVICE_ORG_ID`
- allow trusted service-key callers to poll jobs by id even when the job row belongs to the wallet owner org; user/API-key polling remains org-scoped
- add focused route tests for owner-org enqueueing and service/user job polling behavior

## Root cause
The S2S routes resolve agents by id, but then queued daemon jobs under the service-key identity. The daemon executors call lifecycle operations with the job `organizationId`, so wallet-owned agents can be found by the route but then fail daemon execution as `Agent not found` under the service org.

This is the async lifecycle follow-up to #10112 / #10113.

## Validation
- `TMPDIR=/home/nubs/Git/wt-10074-acp/.tmp bun test 'packages/cloud/api/v1/agents/[agentId]/logs/route.test.ts' 'packages/cloud/api/v1/agents/[agentId]/suspend/route.test.ts' 'packages/cloud/api/v1/agents/[agentId]/restart/route.test.ts' 'packages/cloud/api/v1/jobs/[jobId]/route.test.ts'`
- `TMPDIR=/home/nubs/Git/wt-10074-acp/.tmp bun run --cwd packages/cloud/api codegen`
- `TMPDIR=/home/nubs/Git/wt-10074-acp/.tmp bun run --cwd packages/cloud/api typecheck`
- `TMPDIR=/home/nubs/Git/wt-10074-acp/.tmp bun run --cwd packages/cloud/api lint`
- `TMPDIR=/home/nubs/Git/wt-10074-acp/.tmp bun run --cwd packages/cloud/api test`
- `git diff --check`