### PR TITLE
fix(core): reject empty document batch embeddings

### DIFF
--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -1634,7 +1634,13 @@ export class DocumentService extends Service {
 		let vectors: number[][];
 		try {
 			// Text source matches addEmbeddingToMemory exactly: memory.content.text.
-			const texts = fragments.map((fragment) => fragment.content.text ?? "");
+			const texts = fragments.map((fragment) => {
+				const text = fragment.content.text;
+				if (!text) {
+					throw new Error("Cannot generate embedding: Memory content is empty");
+				}
+				return text;
+			});
 			vectors = await this.runtime.useModel(ModelType.TEXT_EMBEDDING_BATCH, {
 				texts,
 			});


### PR DESCRIPTION
## Summary
- align batched document fragment embedding with the existing serial `addEmbeddingToMemory` behavior
- reject empty fragment text before calling `TEXT_EMBEDDING_BATCH` instead of silently embedding `""`
- removes the shared `?? ""` type-safety ratchet regression currently failing Quality Extended across open develop PRs

## Validation
- `bun run audit:type-safety-ratchet --json`
- `bun run --cwd packages/core test src/features/documents/service-batch-embed.test.ts`
- `bun run --cwd packages/core typecheck`
- `git diff --check origin/develop..HEAD -- packages/core/src/features/documents/service.ts`

## Notes
Typecheck required the same generated i18n artifacts/package-local dependency setup that CI performs; no generated files are committed.