### PR TITLE
docs(build): drop stale tsdown references from plugin-ainex/robot docs (#10078)

### DIFF
--- a/packages/research/robot/AGENTS.md
+++ b/packages/research/robot/AGENTS.md
@@ -123,7 +123,7 @@ bun run --cwd packages/research/robot robot:bridge:mujoco   # MuJoCo backend, po
 bun run --cwd packages/research/robot robot:demo            # voice + sim demo
 
 # TS surface
-bun run --cwd packages/research/robot build         # tsdown — emit dist/
+bun run --cwd packages/research/robot build         # build.ts: Bun.build + tsc d.ts emit → dist/
 bun run --cwd packages/research/robot typecheck     # tsgo --noEmit
 bun run --cwd packages/research/robot lint          # biome check --write
 bun run --cwd packages/research/robot test          # vitest run + pytest shim

--- a/packages/research/robot/CLAUDE.md
+++ b/packages/research/robot/CLAUDE.md
@@ -123,7 +123,7 @@ bun run --cwd packages/research/robot robot:bridge:mujoco   # MuJoCo backend, po
 bun run --cwd packages/research/robot robot:demo            # voice + sim demo
 
 # TS surface
-bun run --cwd packages/research/robot build         # tsdown — emit dist/
+bun run --cwd packages/research/robot build         # build.ts: Bun.build + tsc d.ts emit → dist/
 bun run --cwd packages/research/robot typecheck     # tsgo --noEmit
 bun run --cwd packages/research/robot lint          # biome check --write
 bun run --cwd packages/research/robot test          # vitest run + pytest shim

--- a/plugins/plugin-ainex/AGENTS.md
+++ b/plugins/plugin-ainex/AGENTS.md
@@ -84,7 +84,7 @@ src/
 ## Commands
 
 ```bash
-bun run --cwd plugins/plugin-ainex build      # tsdown build → dist/
+bun run --cwd plugins/plugin-ainex build      # build.ts: Bun.build + tsc d.ts emit → dist/
 bun run --cwd plugins/plugin-ainex typecheck  # tsgo --noEmit
 bun run --cwd plugins/plugin-ainex test       # vitest run
 bun run --cwd plugins/plugin-ainex clean      # rm dist/ .turbo/

--- a/plugins/plugin-ainex/CLAUDE.md
+++ b/plugins/plugin-ainex/CLAUDE.md
@@ -84,7 +84,7 @@ src/
 ## Commands
 
 ```bash
-bun run --cwd plugins/plugin-ainex build      # tsdown build → dist/
+bun run --cwd plugins/plugin-ainex build      # build.ts: Bun.build + tsc d.ts emit → dist/
 bun run --cwd plugins/plugin-ainex typecheck  # tsgo --noEmit
 bun run --cwd plugins/plugin-ainex test       # vitest run
 bun run --cwd plugins/plugin-ainex clean      # rm dist/ .turbo/


### PR DESCRIPTION
Small **#10078** "drop tsdown orphan / stale residue" slice (the doc part the maintainer flagged as remaining).

## What
`plugin-ainex` and `packages/research/robot` both build via `bun run build.ts` (`Bun.build` + `tsc --emitDeclarationOnly --noCheck`) and declare **no tsdown dependency** — the tsdown bundler was already removed from their active build scripts. But their `CLAUDE.md`/`AGENTS.md` command tables still labelled `build` as a "tsdown" build, which is stale and misleading. This updates those comments to match the real pipeline (CLAUDE.md + AGENTS.md kept identical per repo convention).

## Verification
- `plugins/plugin-ainex/package.json` → `"build": "bun run build.ts"`, no `tsdown` in deps/devDeps
- `packages/research/robot/package.json` → `"build": "bun run build.ts"`, no `tsdown` in deps/devDeps
- Both `build.ts` use `await Bun.build({...})` + `tsc --emitDeclarationOnly --noCheck -p tsconfig.build.json`
- Pure doc change (4 files, +4/-4); no code/build behavior touched

## Deferred (intentionally)
`plugins/plugin-wechat/bun.lock` still pins `tsdown@0.12.9` though its `package.json` dropped the dep. It's one of 11 plugins that keep a **nested standalone lock**; clearing it cleanly needs a standalone `bun install` regen (which would also pull unrelated version drift), not an in-monorepo hand-edit — so it's left for a dedicated lock-refresh rather than bundled into this focused doc fix.

Refs #10078.

🤖 Generated with [Claude Code](https://claude.com/claude-code)