### PR TITLE
test(ui): cover welcome-kind ranking + WidgetHost sunset filter (#9959)

### DIFF
--- a/packages/ui/src/widgets/WidgetHost.home-rank.test.tsx
+++ b/packages/ui/src/widgets/WidgetHost.home-rank.test.tsx
@@ -2,6 +2,11 @@
 
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetHomeDismissalsForTests,
+  dismissHomeWidget,
+} from "./home-dismissal-store";
+import { homeWidgetKey } from "./home-priority";
 import { resolveWidgetsForSlot } from "./registry";
 import type { PluginWidgetDeclaration } from "./types";
 import { WidgetHost } from "./WidgetHost";
@@ -82,6 +87,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
+  __resetHomeDismissalsForTests();
 });
 
 function renderedIds(): string[] {
@@ -195,5 +201,35 @@ describe("WidgetHost home-slot ranking (#9143)", () => {
     render(<WidgetHost slot="home" />);
 
     expect(screen.queryByText("participant should not render")).toBeNull();
+  });
+
+  // #9959 — the show-once-then-sunset lifecycle: a home widget declaring a
+  // `sunset` policy must be dropped from the ranked home set once its condition
+  // is met (here: a dismissible card the user dismissed), while non-sunset
+  // widgets stay. This is the WidgetHost-level filter, complementing the
+  // pure-`isHomeWidgetSunset` unit tests in home-dismissal-store.test.ts.
+  it("filters a sunset-retired widget out of the home grid (#9959)", () => {
+    const ftu: PluginWidgetDeclaration = {
+      ...homeDecl("ftu-welcome", 0), // best base order → would otherwise rank first
+      sunset: { dismissible: true },
+    };
+    const declsFor = (slot: string) =>
+      (slot === "home" ? [ftu, homeDecl("keep", 10)] : []).map(
+        (declaration) => ({ declaration, Component: null }),
+      );
+    vi.mocked(resolveWidgetsForSlot).mockImplementation(declsFor);
+
+    // Before dismissal the sunset card renders (and, with order 0, ranks first).
+    const before = render(<WidgetHost slot="home" />);
+    expect(renderedIds()).toContain("ftu-welcome");
+    before.unmount();
+
+    // After the user dismisses it, WidgetHost retires it from the home grid…
+    dismissHomeWidget(homeWidgetKey({ id: "ftu-welcome", pluginId: "home-plugin" }));
+    render(<WidgetHost slot="home" />);
+    const ids = renderedIds();
+    expect(ids).not.toContain("ftu-welcome");
+    // …while the non-sunset widget is unaffected.
+    expect(ids).toContain("keep");
   });
 });

--- a/packages/ui/src/widgets/home-priority.test.ts
+++ b/packages/ui/src/widgets/home-priority.test.ts
@@ -168,6 +168,74 @@ describe("signalKindForEventType", () => {
   it("falls back to activity for unknown event types", () => {
     expect(signalKindForEventType("nonsense")).toBe("activity");
   });
+
+  it("maps the welcome event type to the welcome signal kind (#9959)", () => {
+    expect(signalKindForEventType("welcome")).toBe("welcome");
+  });
+});
+
+// #9959 — the FTU `welcome` card must outrank every cold/ambient widget for a
+// brand-new account, yet always lose to a real "act now" signal so it never
+// buries an approval/escalation/blocked card the moment real activity exists.
+describe("welcome (FTU) signal weight ordering — #9959", () => {
+  it("ranks above every cold/ambient kind", () => {
+    const w = HOME_SIGNAL_WEIGHTS;
+    for (const cold of [
+      "reminder",
+      "message",
+      "check-in",
+      "nudge",
+      "workflow",
+      "activity",
+    ]) {
+      expect(w.welcome).toBeGreaterThan(w[cold]);
+    }
+  });
+
+  it("stays strictly below every act-now signal", () => {
+    const w = HOME_SIGNAL_WEIGHTS;
+    for (const actNow of ["approval", "escalation", "blocked"]) {
+      expect(w.welcome).toBeLessThan(w[actNow]);
+    }
+  });
+
+  it("floats a cold welcome widget to the top yet yields to a fresh approval", () => {
+    const now = NOW;
+    const welcomeCard = { id: "ftu", pluginId: "welcome", order: 5 };
+    const inboxCard = { id: "inbox", pluginId: "p", order: 5 };
+    const decls = [inboxCard, welcomeCard];
+    // Cold account: only the welcome signal is live → welcome card ranks first.
+    const cold = rankHomeWidgets(
+      decls,
+      [
+        {
+          widgetKey: "welcome/ftu",
+          weight: HOME_SIGNAL_WEIGHTS.welcome,
+          timestamp: now,
+        },
+      ],
+      { now },
+    );
+    expect(cold[0].declaration.id).toBe("ftu");
+    // A real approval lands on the inbox card → it must outrank the welcome card.
+    const active = rankHomeWidgets(
+      decls,
+      [
+        {
+          widgetKey: "welcome/ftu",
+          weight: HOME_SIGNAL_WEIGHTS.welcome,
+          timestamp: now,
+        },
+        {
+          widgetKey: "p/inbox",
+          weight: HOME_SIGNAL_WEIGHTS.approval,
+          timestamp: now,
+        },
+      ],
+      { now },
+    );
+    expect(active[0].declaration.id).toBe("inbox");
+  });
 });
 
 describe("homeSignalsFromEvents", () => {


### PR DESCRIPTION
Closes the final test-completeness gap from #9959 (first-time-user home + sunset lifecycle). The FTU `welcome` signal and the show-once-then-sunset lifecycle were implemented, documented (`HOME_CONTENT_TAXONOMY.md`), and exercised by the FTU e2e — but not asserted at the ranking / host-filter layer. This adds those two unit tests.

## What
- **`home-priority.test.ts`** — `welcome` (weight 8) outranks every cold/ambient kind (reminder/message/check-in/nudge/workflow/activity) yet stays strictly below every act-now signal (approval/escalation/blocked); `signalKindForEventType("welcome") === "welcome"`; an end-to-end `rankHomeWidgets` check proves a cold welcome card ranks first but yields to a fresh `approval` landing on another card.
- **`WidgetHost.home-rank.test.tsx`** — a home widget declaring `sunset: { dismissible: true }` is filtered out of the ranked home grid once dismissed, while a non-sunset widget is unaffected (the WidgetHost-level complement to the pure `isHomeWidgetSunset` unit tests in `home-dismissal-store.test.ts`).

## Verify
```
bunx vitest run src/widgets/home-priority.test.ts src/widgets/WidgetHost.home-rank.test.tsx
→ Test Files  2 passed (2)   Tests  42 passed (42)
```
Run on latest `develop`. Test-only; no source change.