### PR TITLE
test: strip inert passWithNoTests:true from 40 plugins with tests (Tier-1 of #10104)

### DIFF
--- a/plugins/app-model-tester/vitest.config.ts
+++ b/plugins/app-model-tester/vitest.config.ts
@@ -42,6 +42,5 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["src/**/*.test.{ts,tsx}"],
-    passWithNoTests: true,
   },
 });

--- a/plugins/plugin-ainex/vitest.config.ts
+++ b/plugins/plugin-ainex/vitest.config.ts
@@ -13,7 +13,6 @@ export default defineConfig({
       "**/*.real.test.*",
       "**/*.real.e2e.test.*",
     ],
-    passWithNoTests: true,
     testTimeout: 30000,
   },
 });

--- a/plugins/plugin-anthropic/vitest.config.ts
+++ b/plugins/plugin-anthropic/vitest.config.ts
@@ -12,6 +12,5 @@ export default defineConfig({
 			"**/*.live.test.ts",
 			"**/*.harness.test.ts",
 		],
-		passWithNoTests: true,
 	},
 });

--- a/plugins/plugin-blocker/vitest.config.ts
+++ b/plugins/plugin-blocker/vitest.config.ts
@@ -7,6 +7,5 @@ export default defineConfig({
       "src/**/*.{test,spec}.{ts,tsx}",
       "test/**/*.{test,spec}.{ts,tsx}",
     ],
-    passWithNoTests: true,
   },
 });

--- a/plugins/plugin-bluesky/vitest.config.ts
+++ b/plugins/plugin-bluesky/vitest.config.ts
@@ -17,6 +17,5 @@ export default defineConfig({
 			"**/*.live.test.ts",
 			"**/*.e2e.test.ts",
 		],
-		passWithNoTests: true,
 	},
 });

--- a/plugins/plugin-calendar/vitest.config.ts
+++ b/plugins/plugin-calendar/vitest.config.ts
@@ -52,7 +52,6 @@ export default defineConfig({
       // integration specs out of the unit run (they need a full-build lane).
       "**/*.integration.test.{ts,tsx}",
     ],
-    passWithNoTests: true,
     server: {
       deps: {
         // @elizaos/agent's built dist dynamically imports every optional

--- a/plugins/plugin-calendly/vitest.config.ts
+++ b/plugins/plugin-calendly/vitest.config.ts
@@ -14,6 +14,5 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.{test,spec}.ts"],
     exclude: ["node_modules/**", "dist/**"],
-    passWithNoTests: true,
   },
 });

--- a/plugins/plugin-cli/vitest.config.ts
+++ b/plugins/plugin-cli/vitest.config.ts
@@ -22,7 +22,6 @@ export default defineConfig({
 		fileParallelism: false,
 		maxWorkers: 1,
 		setupFiles: ["./__tests__/core-test-mock.ts"],
-		passWithNoTests: true,
 		sequence: {
 			concurrent: false,
 		},

--- a/plugins/plugin-coding-tools/vitest.config.ts
+++ b/plugins/plugin-coding-tools/vitest.config.ts
@@ -36,7 +36,6 @@ export default defineConfig({
     environment: "node",
     include: ["__tests__/**/*.test.ts", "src/**/*.test.ts"],
     testTimeout: 15_000,
-    passWithNoTests: true,
     pool: "forks",
     server: {
       deps: {

--- a/plugins/plugin-commands/vitest.config.ts
+++ b/plugins/plugin-commands/vitest.config.ts
@@ -4,6 +4,5 @@ export default defineConfig({
 	test: {
 		include: ["__tests__/**/*.test.ts"],
 		environment: "node",
-		passWithNoTests: true,
 	},
 });

--- a/plugins/plugin-contacts/vitest.config.ts
+++ b/plugins/plugin-contacts/vitest.config.ts
@@ -77,7 +77,6 @@ export default defineConfig({
   },
   test: {
     include: ["test/**/*.test.ts", "src/**/*.test.ts", "src/**/*.test.tsx"],
-    passWithNoTests: true,
     environment: "node",
   },
 });

--- a/plugins/plugin-farcaster/vitest.config.ts
+++ b/plugins/plugin-farcaster/vitest.config.ts
@@ -12,6 +12,5 @@ export default defineConfig({
   test: {
     include: ["__tests__/**/*.test.ts", "src/**/*.test.ts"],
     exclude: ["dist/**", "**/node_modules/**"],
-    passWithNoTests: true,
   },
 });

--- a/plugins/plugin-feishu/vitest.config.ts
+++ b/plugins/plugin-feishu/vitest.config.ts
@@ -14,7 +14,6 @@ export default defineConfig({
 			"**/*.live.test.ts",
 			"**/*.e2e.test.ts",
 		],
-		passWithNoTests: true,
 		environment: "node",
 	},
 });

--- a/plugins/plugin-finances/vitest.config.ts
+++ b/plugins/plugin-finances/vitest.config.ts
@@ -41,6 +41,5 @@ export default defineConfig({
       "src/**/*.{test,spec}.{ts,tsx}",
       "test/**/*.{test,spec}.{ts,tsx}",
     ],
-    passWithNoTests: true,
   },
 });

--- a/plugins/plugin-goals/vitest.config.ts
+++ b/plugins/plugin-goals/vitest.config.ts
@@ -60,6 +60,5 @@ export default defineConfig({
     // `*.harness.test.ts` boot a real PGLite runtime and need the workspace
     // source aliases from vitest.harness.config.ts — run via `test:harness`.
     exclude: ["**/node_modules/**", "dist/**", "**/*.harness.test.ts"],
-    passWithNoTests: true,
   },
 });

--- a/plugins/plugin-google-genai/vitest.config.ts
+++ b/plugins/plugin-google-genai/vitest.config.ts
@@ -12,6 +12,5 @@ export default defineConfig({
       "**/*.live.test.ts",
       "**/*.harness.test.ts",
     ],
-    passWithNoTests: true,
   },
 });

--- a/plugins/plugin-inmemorydb/vitest.config.ts
+++ b/plugins/plugin-inmemorydb/vitest.config.ts
@@ -3,7 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["__tests__/**/*.test.ts", "src/**/*.test.ts", "*.test.ts"],
-    passWithNoTests: true,
     environment: "node",
   },
 });

--- a/plugins/plugin-instagram/vitest.config.ts
+++ b/plugins/plugin-instagram/vitest.config.ts
@@ -11,7 +11,6 @@ export default defineConfig({
   plugins: [providerSdkShimPlugin()],
   test: {
     include: ["__tests__/**/*.test.ts", "src/**/__tests__/**/*.test.ts", "src/**/*.test.ts"],
-    passWithNoTests: true,
     environment: "node",
   },
 });

--- a/plugins/plugin-linear/vitest.config.ts
+++ b/plugins/plugin-linear/vitest.config.ts
@@ -4,7 +4,6 @@ export default defineConfig({
   test: {
     include: ["src/**/*.test.ts", "src/**/__tests__/**/*.test.ts", "__tests__/**/*.test.ts"],
     exclude: ["dist/**", "**/node_modules/**", "**/*.live.test.ts", "**/*.e2e.test.ts"],
-    passWithNoTests: true,
     environment: "node",
   },
 });

--- a/plugins/plugin-local-storage/vitest.config.ts
+++ b/plugins/plugin-local-storage/vitest.config.ts
@@ -7,6 +7,5 @@ export default defineConfig({
 		exclude: ["**/node_modules/**", "**/dist/**"],
 		testTimeout: 30_000,
 		hookTimeout: 30_000,
-		passWithNoTests: true,
 	},
 });

--- a/plugins/plugin-messages/vitest.config.ts
+++ b/plugins/plugin-messages/vitest.config.ts
@@ -63,7 +63,6 @@ export default defineConfig({
   },
   test: {
     include: ["test/**/*.test.{ts,tsx}", "src/**/*.test.{ts,tsx}"],
-    passWithNoTests: true,
     environment: "node",
   },
 });

--- a/plugins/plugin-native-filesystem/vitest.config.ts
+++ b/plugins/plugin-native-filesystem/vitest.config.ts
@@ -13,7 +13,6 @@ export default defineConfig({
 		environment: "node",
 		include: ["src/**/__tests__/**/*.test.ts", "src/**/*.test.ts"],
 		testTimeout: 15_000,
-		passWithNoTests: true,
 		pool: "forks",
 		server: {
 			deps: {

--- a/plugins/plugin-native-settings/vitest.config.ts
+++ b/plugins/plugin-native-settings/vitest.config.ts
@@ -15,7 +15,6 @@ export default defineConfig({
   },
   test: {
     include: ["test/**/*.test.ts", "src/**/*.test.ts"],
-    passWithNoTests: true,
     environment: "node",
   },
 });

--- a/plugins/plugin-nostr/vitest.config.ts
+++ b/plugins/plugin-nostr/vitest.config.ts
@@ -12,6 +12,5 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["src/__tests__/**/*.test.ts"],
-    passWithNoTests: true,
   },
 });

--- a/plugins/plugin-pdf/vitest.config.ts
+++ b/plugins/plugin-pdf/vitest.config.ts
@@ -7,6 +7,5 @@ export default defineConfig({
     testTimeout: 60_000,
     hookTimeout: 60_000,
     setupFiles: ["./__tests__/core-test-mock.ts"],
-    passWithNoTests: true,
   },
 });

--- a/plugins/plugin-phone/vitest.config.ts
+++ b/plugins/plugin-phone/vitest.config.ts
@@ -86,7 +86,6 @@ export default defineConfig({
   },
   test: {
     include: ["test/**/*.test.ts", "src/**/*.test.ts", "src/**/*.test.tsx"],
-    passWithNoTests: true,
     environment: "node",
   },
 });

--- a/plugins/plugin-reminders/vitest.config.ts
+++ b/plugins/plugin-reminders/vitest.config.ts
@@ -7,6 +7,5 @@ export default defineConfig({
       "src/**/*.{test,spec}.{ts,tsx}",
       "test/**/*.{test,spec}.{ts,tsx}",
     ],
-    passWithNoTests: true,
   },
 });

--- a/plugins/plugin-scheduling/vitest.config.ts
+++ b/plugins/plugin-scheduling/vitest.config.ts
@@ -7,6 +7,5 @@ export default defineConfig({
       "src/**/*.{test,spec}.{ts,tsx}",
       "test/**/*.{test,spec}.{ts,tsx}",
     ],
-    passWithNoTests: true,
   },
 });

--- a/plugins/plugin-streaming/vitest.config.ts
+++ b/plugins/plugin-streaming/vitest.config.ts
@@ -4,6 +4,5 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
-    passWithNoTests: true,
   },
 });

--- a/plugins/plugin-tailscale/vitest.config.ts
+++ b/plugins/plugin-tailscale/vitest.config.ts
@@ -10,7 +10,6 @@ export default defineConfig({
     testTimeout: 15_000,
     hookTimeout: 5_000,
     pool: "threads",
-    passWithNoTests: true,
   },
   resolve: {
     alias: {

--- a/plugins/plugin-tee/vitest.config.ts
+++ b/plugins/plugin-tee/vitest.config.ts
@@ -4,6 +4,5 @@ export default defineConfig({
   test: {
     include: ["src/__tests__/**/*.test.ts"],
     exclude: ["dist/**", "**/node_modules/**"],
-    passWithNoTests: true,
   },
 });

--- a/plugins/plugin-todos/vitest.config.ts
+++ b/plugins/plugin-todos/vitest.config.ts
@@ -17,7 +17,6 @@ export default defineConfig({
       "test/**/*.{test,spec}.{ts,tsx}",
     ],
     testTimeout: 15_000,
-    passWithNoTests: true,
     pool: "forks",
     server: {
       deps: {

--- a/plugins/plugin-training/vitest.config.ts
+++ b/plugins/plugin-training/vitest.config.ts
@@ -177,7 +177,6 @@ export default defineConfig({
     ],
     exclude: unitExcludes,
     globals: false,
-    passWithNoTests: true,
     testTimeout: 30000,
   },
 });

--- a/plugins/plugin-trajectory-logger/vitest.config.ts
+++ b/plugins/plugin-trajectory-logger/vitest.config.ts
@@ -36,7 +36,6 @@ export default defineConfig({
   },
   test: {
     include: ["test/**/*.test.{ts,tsx}", "src/**/*.test.{ts,tsx}"],
-    passWithNoTests: true,
     environment: "node",
   },
 });

--- a/plugins/plugin-vector-browser/vitest.config.ts
+++ b/plugins/plugin-vector-browser/vitest.config.ts
@@ -58,6 +58,5 @@ export default defineConfig({
       "src/**/*.{test,spec}.{ts,tsx}",
       "test/**/*.{test,spec}.{ts,tsx}",
     ],
-    passWithNoTests: true,
   },
 });

--- a/plugins/plugin-vision/vitest.config.ts
+++ b/plugins/plugin-vision/vitest.config.ts
@@ -13,8 +13,6 @@ export default defineConfig({
       "**/*.real.test.*",
       "**/*.real.e2e.test.*",
     ],
-    // Skip tests gracefully when native dependencies are missing
-    passWithNoTests: true,
     // Give more time for tests that load heavy dependencies
     testTimeout: 30000,
   },

--- a/plugins/plugin-wallet-ui/vitest.config.ts
+++ b/plugins/plugin-wallet-ui/vitest.config.ts
@@ -42,7 +42,6 @@ export default defineConfig({
   },
   test: {
     include: ["test/**/*.test.ts", "src/**/*.test.ts", "src/**/*.test.tsx"],
-    passWithNoTests: true,
     environment: "node",
   },
 });

--- a/plugins/plugin-wechat/vitest.config.ts
+++ b/plugins/plugin-wechat/vitest.config.ts
@@ -5,6 +5,5 @@ export default defineConfig({
     environment: "node",
     globals: true,
     include: ["src/**/*.test.ts"],
-    passWithNoTests: true,
   },
 });

--- a/plugins/plugin-wifi/vitest.config.ts
+++ b/plugins/plugin-wifi/vitest.config.ts
@@ -15,7 +15,6 @@ export default defineConfig({
   },
   test: {
     include: ["test/**/*.test.ts", "src/**/*.test.ts"],
-    passWithNoTests: true,
     environment: "node",
   },
 });

--- a/plugins/plugin-xai/vitest.config.ts
+++ b/plugins/plugin-xai/vitest.config.ts
@@ -4,6 +4,5 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["__tests__/**/*.test.ts"],
-    passWithNoTests: true,
   },
 });


### PR DESCRIPTION
## What

Closes the remaining **Tier-1** item of #10104. The larp/coverage-theater/runner-parallelization Tier-1 items already landed in #10105; this removes the inert `passWithNoTests: true` footgun from the 40 plugins that carry it.

## Why

`passWithNoTests: true` only changes behavior when a vitest run globs **zero** test files — it then exits green instead of failing. #10104 flags this as a footgun: a future suite-deletion (or a glob that silently matches nothing) would still pass CI green, defeating "green CI ⇒ tested."

## Why it's safe (provably discovery-neutral)

- **Every one of the 40 plugins has at least one plain `*.test.ts`/`*.spec.ts` unit file** — not just `*.real`/`*.e2e`/`*.live` (which the PR lane excludes). So both the default lane and the PR lane always glob ≥1 file, and `passWithNoTests` is never reached. Removing it cannot change the result of any current run.
- `passWithNoTests` guards **only** the zero-files-globbed case. It never affected import-failure or skip behavior, so native-dep-heavy plugins (e.g. `plugin-vision`) are unaffected — their test files exist on disk regardless of whether native deps are present. (Also drops a now-orphaned comment in `plugin-vision` that described the removed flag.)
- The only behavior change: if a plugin's entire suite were deleted in the future, CI would now **fail** instead of passing green — which is the intended footgun removal.

## Evidence

Representative suites still discover and run their tests (Test Files > 0 in every case, proving the flag was moot):

| plugin | result |
|---|---|
| plugin-anthropic | `Test Files 4 passed \| 1 skipped`, `21 passed` |
| plugin-tee | `Test Files 1 passed`, `6 passed` |
| plugin-todos | `51 passed` (Test Files discovered) |
| plugin-goals | `42 passed` (Test Files discovered) |

Static safety proof: `find` over each of the 40 plugin dirs confirms a non-`real`/`e2e`/`live` `*.test.ts`/`*.spec.ts` exists.

CI is the verifier for the full 40-plugin sweep (every lane globs ≥1 file → no lane flips to the no-tests path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)