### PR TITLE
test(ui): assert nav-lock per tutorial frame + wire tutorial e2e into CI (#9957)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -264,6 +264,20 @@ jobs:
       - name: XR sim Playwright coverage
         run: bun run --cwd packages/ui test:xr-sim
 
+      # Tutorial spotlight e2e (#9957): per-frame themed-accent color + glow
+      # framing + Z_TUTORIAL + nav-lock assertions under dark/light/gold, in
+      # headless chromium. Previously ran in no workflow.
+      - name: Tutorial spotlight e2e (#9957)
+        run: bun run --cwd packages/ui test:tutorial-e2e
+
+      - name: Upload tutorial e2e artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: tutorial-e2e-artifacts
+          path: packages/ui/src/components/pages/tutorial/__e2e__/output-tutorial/
+          if-no-files-found: ignore
+
   xr-harness-e2e:
     name: XR harness e2e
     needs: changes

--- a/packages/ui/src/components/pages/tutorial/__e2e__/run-tutorial-e2e.mjs
+++ b/packages/ui/src/components/pages/tutorial/__e2e__/run-tutorial-e2e.mjs
@@ -207,6 +207,32 @@ try {
       );
       assert(z === "9500", `[${view.name}] ${step.id}: spotlight z is Z_TUTORIAL 9500 (${z})`);
 
+      // Nav-lock per frame (#9957 acceptance criterion (d)): the frame's
+      // capability lock must actually block an off-path tab, not merely declare
+      // a lockTabs array. The fixture applies the real `setNavLock(step.lockTabs)`
+      // the live tour applies; assert it blocks here.
+      const lock = await page.evaluate((lockTabs) => {
+        const nav = window.__tutorial.navLock;
+        const offPath = ["settings", "camera", "apps", "views", "wallet"].find(
+          (t) => !lockTabs.includes(t),
+        );
+        return {
+          locked: nav.isLocked(),
+          onPathAllowed: nav.isAllowed(lockTabs[0]),
+          offPath,
+          offPathBlocked: offPath ? !nav.isAllowed(offPath) : true,
+        };
+      }, step.lockTabs);
+      assert(lock.locked, `[${view.name}] ${step.id}: nav-lock active for the frame`);
+      assert(
+        lock.onPathAllowed,
+        `[${view.name}] ${step.id}: on-path tab "${step.lockTabs[0]}" allowed`,
+      );
+      assert(
+        lock.offPathBlocked,
+        `[${view.name}] ${step.id}: off-path tab "${lock.offPath}" blocked by nav-lock`,
+      );
+
       if (step.targetSelector) {
         const framing = await page.evaluate((sel) => {
           const root = document.querySelector('[data-testid="tutorial-spotlight"]');

--- a/packages/ui/src/components/pages/tutorial/__e2e__/tutorial-fixture.tsx
+++ b/packages/ui/src/components/pages/tutorial/__e2e__/tutorial-fixture.tsx
@@ -15,6 +15,11 @@
  */
 import * as React from "react";
 import { createRoot } from "react-dom/client";
+import {
+  isNavAllowed,
+  isNavLocked,
+  setNavLock,
+} from "../../../../navigation/nav-lock";
 import { TutorialSpotlight } from "../TutorialSpotlight";
 import { buildTutorialSteps, type TutorialStep } from "../tutorial-steps";
 
@@ -123,6 +128,14 @@ function Harness(): React.JSX.Element {
   setStepId = setS;
   const step: TutorialStep =
     STEPS.find((s) => s.id === stepId) ?? STEPS[0];
+  // Apply the real per-frame capability lock the live tour applies
+  // (TutorialOverlay does `setNavLock(step.lockTabs ?? ["chat"])`), so the e2e
+  // can assert nav-lock actually blocks an off-path tab on every frame — not
+  // just that the frame declares a lockTabs array (#9957).
+  React.useEffect(() => {
+    setNavLock(step.lockTabs ?? ["chat"]);
+    return () => setNavLock(null);
+  }, [step]);
   return (
     <>
       <ChatScaffold />
@@ -153,6 +166,9 @@ declare global {
         lockTabs: string[];
       }>;
       show: (id: string) => void;
+      // Live nav-lock state for the currently-shown frame, so the runner can
+      // assert the capability lock actually blocks an off-path tab per frame.
+      navLock: { isLocked: () => boolean; isAllowed: (tab: string) => boolean };
     };
   }
 }
@@ -165,6 +181,7 @@ window.__tutorial = {
     lockTabs: s.lockTabs ?? ["chat"],
   })),
   show: (id) => setStepId(id),
+  navLock: { isLocked: () => isNavLocked(), isAllowed: (tab) => isNavAllowed(tab) },
 };
 
 const root = document.getElementById("root");


### PR DESCRIPTION
Closes the two remaining gaps from #9957's verification. The product fixes (themed spotlight tokens, `Z_TUTORIAL`, hardened `measure()`, themed card, `new-chat`/`swipe-between-chats` frames, stale-copy removal) all shipped in #10002 and are verified on `develop`. The gaps were both in test coverage / CI:

## 1. Nav-lock per frame (acceptance criterion (d))
The e2e read `window.__tutorial.steps` but never asserted the per-frame capability lock. Now:
- `tutorial-fixture.tsx` applies the real `setNavLock(step.lockTabs ?? ["chat"])` the live tour applies (mirrors `TutorialOverlay`), and exposes a `navLock` query.
- `run-tutorial-e2e.mjs` asserts, on **every frame, desktop + mobile**: the lock is active, the on-path tab is allowed, and an **off-path tab is actually blocked**. The off-path tab is computed per frame, so `use-voice` (which also allows `settings`) is correctly tested against `camera`.

## 2. Tutorial e2e wired into CI
It previously ran in **no** workflow. Added to the **Client Tests** job in `test.yml` (already installs Playwright Chromium), with artifact upload of the per-frame screenshots + walkthrough video.

## Verify
```
bun run --cwd packages/ui test:tutorial-e2e
→ TUTORIAL E2E PASSED
  8 frames × {desktop,mobile} × {Z_TUTORIAL=9500, nav-lock active/on-path-allowed/off-path-blocked, glow frames target Δ0,0,0}
  dark(255,88,0) / light(255,255,255, not orange) / gold(240,185,11) accent assertions
  19 screenshots + mobile video, 0 page errors
```
Run on latest `develop`. Test/CI-only; no product source change.