### PR TITLE
fix(core): green develop type-safety ratchet (explicit guard over `?? ""` in batch embed)

### DIFF
--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -1634,7 +1634,18 @@ export class DocumentService extends Service {
 		let vectors: number[][];
 		try {
 			// Text source matches addEmbeddingToMemory exactly: memory.content.text.
-			const texts = fragments.map((fragment) => fragment.content.text ?? "");
+			// Document fragments are built from text chunks, so text is always a
+			// string; surface a genuinely-malformed fragment explicitly rather than
+			// silently embedding "" (the try/catch below then falls back to serial).
+			const texts = fragments.map((fragment) => {
+				const text = fragment.content.text;
+				if (typeof text !== "string") {
+					throw new Error(
+						"[DocumentService] document fragment missing text; cannot batch-embed",
+					);
+				}
+				return text;
+			});
 			vectors = await this.runtime.useModel(ModelType.TEXT_EMBEDDING_BATCH, {
 				texts,
 			});


### PR DESCRIPTION
## Problem
`develop` is **red** on the type-safety ratchet:
```
[type-safety-ratchet] `?? ""` (core/agent/app-core): 638 current > 637 baseline
```
The batched document-fragment embedding path (added in #10094) maps fragment text with `fragment.content.text ?? ""` (`service.ts:1637`), the 638th occurrence.

## Fix
Document fragments are always built from text chunks, so the empty-string fallback masks a would-be-broken pipeline (AGENTS.md commandment 8). Replace it with an explicit guard that surfaces a genuinely-malformed fragment; the batch path's existing `try/catch` then falls back to the serial per-fragment embed, so behavior is unchanged for real inputs.

## Verification
```
[type-safety-ratchet] `?? ""` (core/agent/app-core): 637 / 637   # exit 0
bun run --cwd packages/core test -- service-batch-embed           # 3/3 pass
bun run --cwd packages/core typecheck                              # exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)