### PR TITLE
ci: gate develop PRs with prompt-secret scan + UI-determinism (Tier-1 of #10104)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -185,3 +185,50 @@ jobs:
 
       - name: Run biome format check
         run: bun run format:check
+
+  # Develop-gate extension (#10104): the canonical `ci.yaml` quality job — which
+  # runs the prompt-secret scan and the UI-determinism gate — fires only on PRs
+  # to `main` (`ci.yaml` `pull_request: branches: [main]`), while the default
+  # merge target is `develop`. So these two checks never gated a develop PR.
+  # This job re-runs them on develop (and main) PRs. Both are static scans (no
+  # build step needed), mirroring the lean install used by `format-check`.
+  #
+  # NOTE: `bun run lint` (biome) is the third develop-gate gap from #10104 but is
+  # intentionally NOT included here — under turbo it depends on `build`, so it
+  # needs the heavier build-enabled lane rather than this lean static gate. Wire
+  # it into a build-enabled develop lane as the follow-up.
+  develop-static-gate:
+    name: Develop Gate (secret scan + UI determinism)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 8
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          install-command: bun install --ignore-scripts --no-frozen-lockfile
+          install-native-deps: "false"
+          # Both gates are static AST/text scans over source — no Python/protoc,
+          # Rust, or postinstall artifacts needed (same lean install as the
+          # format gate above).
+          setup-python: "false"
+          install-protoc: "false"
+          run-postinstall: "false"
+
+      - name: Prompt secret scan
+        run: cd packages/prompts && bun run check:secrets
+
+      - name: UI determinism self-test
+        run: bun run audit:ui-determinism:self-test
+
+      - name: UI determinism gate
+        run: bun run audit:ui-determinism


### PR DESCRIPTION
## What

Closes #10104's **"single most important finding"** for the build-free checks: the canonical `ci.yaml` quality job (prompt-secret scan, UI-determinism, biome lint) fires **only on PRs to `main`** (`ci.yaml`: `pull_request: branches: [main]`), but the default merge target is `develop` — so these gates never ran on a develop PR.

Adds a `develop-static-gate` job to `quality.yml` (already triggered on develop+main PRs) running the two **build-free** static gates:
- prompt secret scan — `packages/prompts` `check:secrets`
- UI-determinism self-test + gate — `audit:ui-determinism`

## Design choices

- **Separate, non-required job** (not folded into the required `format-check`): it surfaces on develop PRs immediately without risk of blocking merges before a maintainer promotes it to required. If it's red on day one, that *is* the develop debt #10104 set out to surface.
- **Lean install** (`--ignore-scripts`, no Python/protoc/postinstall) — both gates are static AST/text scans needing no build, so it reuses the exact lean setup the existing `format-check` job uses.
- **`bun run lint` deferred**: under turbo it `dependsOn: build`, so it belongs in a build-enabled develop lane, not this lean static gate. Called out in the job comment as the remaining develop-gate follow-up.

## Evidence (verified locally on this tree)

- `cd packages/prompts && bun run check:secrets` → exit `0`
- `bun run audit:ui-determinism:self-test` → `self-test PASSED`
- `bun run audit:ui-determinism` → `OK audit-ui-determinism PASSED (no new render-time nondeterminism)` (render-time=47 deferred=122 module=209, baseline 39 files)

YAML validated (`yaml.safe_load`); referenced scripts confirmed to exist. CI is the verifier for in-Actions execution.

Tier-1 of #10104. (The larp/coverage-theater/runner items landed in #10105; the `passWithNoTests` item is #10126.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)