### PR TITLE
fix(ci): green main — ratchet ?? "" baseline, docker-smoke false-positive, chip ruff format

### DIFF
--- a/packages/app-core/scripts/docker-ci-smoke.sh
+++ b/packages/app-core/scripts/docker-ci-smoke.sh
@@ -77,7 +77,13 @@ BOOT_CRASH_PATTERNS=(
   # signature instead of waiting out the full health timeout.
   'ERR_UNKNOWN_FILE_EXTENSION'
   'Unknown file extension'
-  'Failed to start'
+  # The real entrypoint fatal: bin.ts's top-level catch prints exactly this and
+  # exits 1 (packages/agent/src/bin.ts). Anchored to that prefix on purpose — a
+  # bare 'Failed to start' substring also matches benign, by-design-non-fatal
+  # WARNs such as "Service lifeops_scheduled_task_runner not found or failed to
+  # start" (scheduling boot-seed, which logs "tasks can still be scheduled at
+  # runtime"), which false-flapped this gate.
+  '[eliza-autonomous] Failed to start'
   'crashed during init'
 )
 

--- a/packages/research/chip/scripts/check_android_launcher_runtime_evidence.py
+++ b/packages/research/chip/scripts/check_android_launcher_runtime_evidence.py
@@ -35,18 +35,20 @@ FALSE_CLAIM_FLAGS = {
     "hardware_boot_claim_allowed": False,
     "production_readiness_claim_allowed": False,
 }
-RUNTIME_CAPTURE_SCRIPT = "packages/research/chip/scripts/android/capture_launcher_runtime_evidence.py"
+RUNTIME_CAPTURE_SCRIPT = (
+    "packages/research/chip/scripts/android/capture_launcher_runtime_evidence.py"
+)
 DEFAULT_CAPTURE_EVIDENCE = (
     "packages/research/chip/docs/evidence/android/eliza_launcher_runtime_evidence.json"
 )
-DEFAULT_CAPTURE_LOGCAT = "packages/research/chip/docs/evidence/android/eliza_launcher_runtime_logcat.txt"
+DEFAULT_CAPTURE_LOGCAT = (
+    "packages/research/chip/docs/evidence/android/eliza_launcher_runtime_logcat.txt"
+)
 DEFAULT_CAPTURE_TRANSCRIPT = (
     "packages/research/chip/docs/evidence/android/eliza_launcher_runtime_transcript.log"
 )
 SERIAL_CAPTURE_EVIDENCE = "packages/research/chip/docs/evidence/android/eliza_launcher_runtime_evidence.$CHIP_ANDROID_ADB_SERIAL.json"
-SERIAL_CAPTURE_LOGCAT = (
-    "packages/research/chip/docs/evidence/android/eliza_launcher_runtime_logcat.$CHIP_ANDROID_ADB_SERIAL.txt"
-)
+SERIAL_CAPTURE_LOGCAT = "packages/research/chip/docs/evidence/android/eliza_launcher_runtime_logcat.$CHIP_ANDROID_ADB_SERIAL.txt"
 SERIAL_CAPTURE_TRANSCRIPT = "packages/research/chip/docs/evidence/android/eliza_launcher_runtime_transcript.$CHIP_ANDROID_ADB_SERIAL.log"
 RECHECK_COMMAND = (
     "python3 packages/research/chip/scripts/check_android_launcher_runtime_evidence.py --json-only"

--- a/packages/research/chip/scripts/check_android_simulated_peripheral_evidence.py
+++ b/packages/research/chip/scripts/check_android_simulated_peripheral_evidence.py
@@ -42,9 +42,7 @@ FALSE_CLAIM_FLAGS = {
     "production_readiness_claim_allowed": False,
 }
 CAPTURE_SCRIPT = "packages/research/chip/scripts/android/capture_simulated_peripheral_evidence.py"
-RECHECK_COMMAND = (
-    "python3 packages/research/chip/scripts/check_android_simulated_peripheral_evidence.py --json-only"
-)
+RECHECK_COMMAND = "python3 packages/research/chip/scripts/check_android_simulated_peripheral_evidence.py --json-only"
 ADB_CONNECT_CANDIDATES = ("127.0.0.1:6520", "127.0.0.1:5555")
 ADB_HOSTPORT_SENTINEL = "$CHIP_ANDROID_ADB_HOSTPORT"
 REQUIRED_COMPONENTS = {

--- a/packages/research/chip/scripts/check_android_system_bridge_contract.py
+++ b/packages/research/chip/scripts/check_android_system_bridge_contract.py
@@ -110,9 +110,15 @@ FALSE_CLAIM_FLAGS = {
     "cts_vts_claim_allowed": False,
     "gms_claim_allowed": False,
 }
-RUNTIME_CAPTURE_SCRIPT = "packages/research/chip/scripts/android/capture_system_bridge_runtime_evidence.py"
-DEFAULT_RUNTIME_OUTPUT = "packages/research/chip/docs/evidence/android/system_bridge_runtime_evidence.json"
-DEFAULT_RUNTIME_LOGCAT = "packages/research/chip/docs/evidence/android/system_bridge_runtime_logcat.log"
+RUNTIME_CAPTURE_SCRIPT = (
+    "packages/research/chip/scripts/android/capture_system_bridge_runtime_evidence.py"
+)
+DEFAULT_RUNTIME_OUTPUT = (
+    "packages/research/chip/docs/evidence/android/system_bridge_runtime_evidence.json"
+)
+DEFAULT_RUNTIME_LOGCAT = (
+    "packages/research/chip/docs/evidence/android/system_bridge_runtime_logcat.log"
+)
 RUNTIME_CAPTURE_BASE_COMMAND = (
     f"python3 {RUNTIME_CAPTURE_SCRIPT} "
     f"--launcher-package {APP_PACKAGE} "

--- a/packages/research/chip/scripts/check_chip_os_evidence_provenance.py
+++ b/packages/research/chip/scripts/check_chip_os_evidence_provenance.py
@@ -170,7 +170,9 @@ TIMESTAMP_KEYS = {
     "result_recorded_at",
 }
 
-GENERIC_RECHECK_COMMAND = "python3 packages/research/chip/scripts/check_chip_os_evidence_provenance.py"
+GENERIC_RECHECK_COMMAND = (
+    "python3 packages/research/chip/scripts/check_chip_os_evidence_provenance.py"
+)
 NPU_NNAPI_CAPTURE_COMMAND = (
     "E1_NPU_WRITE_PROOF_JSON=1 "
     "E1_NPU_MACS_PER_INFERENCE=<measured-macs> "
@@ -205,9 +207,13 @@ def provenance_commands(category: str, path: Path) -> list[str]:
     path_parts = set(path.parts)
     commands: list[str] = []
     if category == "host_local_path":
-        commands.append(f"python3 packages/research/chip/scripts/provenance_sanitize.py {path_text}")
+        commands.append(
+            f"python3 packages/research/chip/scripts/provenance_sanitize.py {path_text}"
+        )
     if category in {"missing_timestamp", "missing_claim_boundary"}:
-        commands.append(f"python3 packages/research/chip/scripts/normalize_report_provenance.py {path_text}")
+        commands.append(
+            f"python3 packages/research/chip/scripts/normalize_report_provenance.py {path_text}"
+        )
 
     if "peripherals" in path_parts or path_text.endswith("_sim.log"):
         commands.append(
@@ -237,7 +243,9 @@ def provenance_commands(category: str, path: Path) -> list[str]:
             "python3 packages/research/chip/scripts/check_os_rv64_chip_boot_contract.py --json-only"
         )
     elif path.name == "chip-os-optimization-gap-inventory.json":
-        commands.append("python3 packages/research/chip/scripts/check_chip_os_optimization_gap_inventory.py")
+        commands.append(
+            "python3 packages/research/chip/scripts/check_chip_os_optimization_gap_inventory.py"
+        )
     elif path_text.startswith("packages/research/chip/build/reports/"):
         commands.append("python3 packages/research/chip/scripts/check_chip_os_report_freshness.py")
 

--- a/packages/research/chip/scripts/check_chip_os_gap_keyword_inventory.py
+++ b/packages/research/chip/scripts/check_chip_os_gap_keyword_inventory.py
@@ -111,10 +111,13 @@ CLASSIFIED_BLOCKER_INVENTORY_PATH_PATTERNS = (
     re.compile(r"^packages/research/chip/docs/.+evidence-manifest\.json$", re.I),
     re.compile(r"^packages/research/chip/docs/security/tee-plan/.*\.md$", re.I),
     re.compile(
-        r"^packages/research/chip/docs/architecture-optimization/(?:sota-2028/)?[^/]*report.*\.md$", re.I
+        r"^packages/research/chip/docs/architecture-optimization/(?:sota-2028/)?[^/]*report.*\.md$",
+        re.I,
     ),
     re.compile(r"^packages/research/chip/docs/spec-db/competitor-.*\.(?:json|md|yaml|yml)$", re.I),
-    re.compile(r"^packages/research/chip/docs/spec-db/requirements/.*\.(?:json|md|yaml|yml)$", re.I),
+    re.compile(
+        r"^packages/research/chip/docs/spec-db/requirements/.*\.(?:json|md|yaml|yml)$", re.I
+    ),
 )
 TEST_FILE_PATTERNS = (
     re.compile(r"(^|/)test_[^/]+\.(c|cc|cpp|h|java|kt|py|rs|ts|tsx)$"),
@@ -411,7 +414,9 @@ PATTERNS: tuple[tuple[str, str, re.Pattern[str]], ...] = (
     ),
 )
 
-GENERIC_RECHECK_COMMAND = "python3 packages/research/chip/scripts/check_chip_os_gap_keyword_inventory.py"
+GENERIC_RECHECK_COMMAND = (
+    "python3 packages/research/chip/scripts/check_chip_os_gap_keyword_inventory.py"
+)
 
 
 def cleanup_commands(path: Path, line_number: int) -> list[str]:
@@ -424,7 +429,9 @@ def cleanup_commands(path: Path, line_number: int) -> list[str]:
     if "npu" in lower_path:
         commands.append("python3 packages/research/chip/scripts/check_npu_scope.py")
     if "benchmark" in lower_path or "benchmarks" in parts:
-        commands.append("python3 packages/research/chip/scripts/check_benchmark_efficiency_scope.py")
+        commands.append(
+            "python3 packages/research/chip/scripts/check_benchmark_efficiency_scope.py"
+        )
     if "cpu_ap" in lower_path or "chipyard" in lower_path or "riscv" in lower_path:
         commands.append("python3 packages/research/chip/scripts/check_cpu_ap_scope.py")
     if "android" in parts or "aosp" in lower_path:
@@ -434,7 +441,9 @@ def cleanup_commands(path: Path, line_number: int) -> list[str]:
             "python3 packages/research/chip/scripts/check_os_rv64_chip_boot_contract.py --json-only"
         )
     if "runtime" in lower_path or "peripheral" in lower_path:
-        commands.append("python3 packages/research/chip/scripts/check_phone_runtime_readiness_contract.py")
+        commands.append(
+            "python3 packages/research/chip/scripts/check_phone_runtime_readiness_contract.py"
+        )
     commands.append(GENERIC_RECHECK_COMMAND)
     deduped: list[str] = []
     for command in commands:

--- a/packages/research/chip/scripts/check_chip_os_report_freshness.py
+++ b/packages/research/chip/scripts/check_chip_os_report_freshness.py
@@ -58,9 +58,13 @@ GATE_REPORT_ALIAS_SOURCES = {
         "packages/research/chip/scripts/run_mvp_simulator.py",
         "packages/research/chip/scripts/check_mvp_simulator.py",
     ),
-    "chipyard_payload_path.json": ("packages/research/chip/scripts/check_chipyard_payload_path.py",),
+    "chipyard_payload_path.json": (
+        "packages/research/chip/scripts/check_chipyard_payload_path.py",
+    ),
     "cpu_ap_scope.json": ("packages/research/chip/scripts/check_cpu_ap_scope.py",),
-    "cpu_ap_boot_readiness.json": ("packages/research/chip/scripts/check_cpu_ap_boot_readiness.py",),
+    "cpu_ap_boot_readiness.json": (
+        "packages/research/chip/scripts/check_cpu_ap_boot_readiness.py",
+    ),
     "software_bsp.json": ("packages/research/chip/scripts/check_software_bsp.py",),
     "aosp_product_contract.json": (
         "packages/research/chip/scripts/check_aosp_product_contract.py",
@@ -291,7 +295,9 @@ def dynamic_gate_report_specs() -> list[ReportSpec]:
             report = ROOT / "build/reports" / report_name
             if not report.is_file():
                 continue
-            source = f"packages/research/chip/{script}" if not Path(script).is_absolute() else script
+            source = (
+                f"packages/research/chip/{script}" if not Path(script).is_absolute() else script
+            )
             sources = GATE_REPORT_ALIAS_SOURCES.get(report_name, (source,))
             ident = f"gate_{gate.name}_{Path(report_name).stem}".replace("-", "_")
             specs.append(

--- a/packages/research/chip/scripts/check_os_rv64_chip_boot_contract.py
+++ b/packages/research/chip/scripts/check_os_rv64_chip_boot_contract.py
@@ -75,7 +75,9 @@ STAGE_RISCV64_AGENT_RUNTIME_COMMAND = (
 )
 CAPTURE_TRANSCRIPT_PLACEHOLDER = "/path/to/generated-ap-serial.log"
 AGENT_TRANSCRIPT_PLACEHOLDER = "/path/to/agent-health.log"
-RECHECK_COMMAND = "python3 packages/research/chip/scripts/check_os_rv64_chip_boot_contract.py --json-only"
+RECHECK_COMMAND = (
+    "python3 packages/research/chip/scripts/check_os_rv64_chip_boot_contract.py --json-only"
+)
 
 CHIP_BOOT_EVIDENCE_IDS = {
     "generated-eliza-ap-boot",

--- a/packages/research/chip/scripts/check_tee_confidential_domain_contract.py
+++ b/packages/research/chip/scripts/check_tee_confidential_domain_contract.py
@@ -8,7 +8,9 @@ import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
-DEFAULT_CONTRACT = REPO_ROOT / "packages/research/chip/docs/spec-db/tee-confidential-domain-contract.json"
+DEFAULT_CONTRACT = (
+    REPO_ROOT / "packages/research/chip/docs/spec-db/tee-confidential-domain-contract.json"
+)
 
 
 def require(condition: bool, message: str, errors: list[str]) -> None:

--- a/packages/research/chip/scripts/check_tee_iopmp_policy.py
+++ b/packages/research/chip/scripts/check_tee_iopmp_policy.py
@@ -8,7 +8,9 @@ import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
-DEFAULT_CONTRACT = REPO_ROOT / "packages/research/chip/docs/spec-db/tee-confidential-domain-contract.json"
+DEFAULT_CONTRACT = (
+    REPO_ROOT / "packages/research/chip/docs/spec-db/tee-confidential-domain-contract.json"
+)
 DEFAULT_POLICY = REPO_ROOT / "packages/research/chip/docs/spec-db/tee-iopmp-source-id-map.json"
 
 

--- a/packages/research/chip/scripts/check_tee_side_channel_claims.py
+++ b/packages/research/chip/scripts/check_tee_side_channel_claims.py
@@ -8,7 +8,9 @@ import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
-DEFAULT_MATRIX = REPO_ROOT / "packages/research/chip/docs/spec-db/tee-side-channel-claim-matrix.json"
+DEFAULT_MATRIX = (
+    REPO_ROOT / "packages/research/chip/docs/spec-db/tee-side-channel-claim-matrix.json"
+)
 REQUIRED_STATE_HANDLING = {"cache", "tlb", "bpu", "prefetcher"}
 
 

--- a/packages/research/chip/scripts/test_aggregate_tapeout_readiness.py
+++ b/packages/research/chip/scripts/test_aggregate_tapeout_readiness.py
@@ -975,7 +975,9 @@ class BuildReportTests(unittest.TestCase):
             )
             self.assertEqual(
                 report["next_runtime_capture_action"]["validation_commands"],
-                ["python3 packages/research/chip/scripts/check_phone_runtime_readiness_contract.py"],
+                [
+                    "python3 packages/research/chip/scripts/check_phone_runtime_readiness_contract.py"
+                ],
             )
         finally:
             if original is None:
@@ -3162,7 +3164,9 @@ class E1PhoneMechanicalCadEvidenceInventoryTests(unittest.TestCase):
 
     def test_mechanical_resolvers_accept_chip_and_repo_relative_paths(self) -> None:
         chip_relative = "mechanical/e1-phone/review/board-step-readiness.json"
-        repo_relative = "packages/research/chip/mechanical/e1-phone/review/board-step-readiness.json"
+        repo_relative = (
+            "packages/research/chip/mechanical/e1-phone/review/board-step-readiness.json"
+        )
 
         self.assertEqual(
             release_contract.resolve_repo_path(chip_relative),

--- a/packages/research/chip/scripts/test_android_sim_boot_status.py
+++ b/packages/research/chip/scripts/test_android_sim_boot_status.py
@@ -339,7 +339,10 @@ def test_aosp_linux_preflight_sanitizes_host_local_paths() -> None:
             raise AssertionError("AOSP Linux preflight must include generated_utc")
         if "/home/shaw" in encoded:
             raise AssertionError(encoded)
-        if "packages/research/chip/tools/bin/renode" not in encoded and "<host-path>/renode" not in encoded:
+        if (
+            "packages/research/chip/tools/bin/renode" not in encoded
+            and "<host-path>/renode" not in encoded
+        ):
             raise AssertionError(encoded)
     finally:
         if saved is None:

--- a/packages/research/chip/scripts/test_chip_os_evidence_provenance.py
+++ b/packages/research/chip/scripts/test_chip_os_evidence_provenance.py
@@ -247,7 +247,9 @@ class ChipOsEvidenceProvenanceTests(unittest.TestCase):
             finding for finding in data["findings"] if finding["category"] == "host_local_path"
         ]
         self.assertEqual(len(host_findings), 1)
-        self.assertEqual(host_findings[0]["path"], "packages/research/chip/docs/evidence/qemu-raw.log")
+        self.assertEqual(
+            host_findings[0]["path"], "packages/research/chip/docs/evidence/qemu-raw.log"
+        )
 
     def test_keyword_inventory_excerpts_do_not_expand_marker_counts(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/packages/research/chip/scripts/test_chip_os_gap_keyword_inventory.py
+++ b/packages/research/chip/scripts/test_chip_os_gap_keyword_inventory.py
@@ -126,7 +126,9 @@ class ChipOsGapKeywordInventoryTests(unittest.TestCase):
             bench.write_text("echo placeholder benchmark path\n", encoding="utf-8")
 
             with mock.patch.object(inv, "REPO", repo):
-                report = inv.build_report(["packages/research/chip/docs", "packages/research/chip/sw"])
+                report = inv.build_report(
+                    ["packages/research/chip/docs", "packages/research/chip/sw"]
+                )
 
         self.assertEqual(report["status"], "blocked")
         self.assertEqual(report["summary"]["findings"], 2)
@@ -144,7 +146,9 @@ class ChipOsGapKeywordInventoryTests(unittest.TestCase):
     def test_binary_payloads_are_not_scanned_as_source(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo = Path(tmp)
-            binary = repo / "packages/research/chip/sw/firemarshal/eliza-e1-linux-smoke/e1-npu-ml-smoke"
+            binary = (
+                repo / "packages/research/chip/sw/firemarshal/eliza-e1-linux-smoke/e1-npu-ml-smoke"
+            )
             binary.parent.mkdir(parents=True)
             binary.write_bytes(b"\x7fELF\x00unsupported workload: %s (expected %s)\x00")
 
@@ -263,7 +267,9 @@ class ChipOsGapKeywordInventoryTests(unittest.TestCase):
                 "Current scaffold remains blocked until AP and benchmark evidence lands.\n",
                 encoding="utf-8",
             )
-            task_audit = repo / "packages/research/chip/docs/project/android-on-simulated-chip-task-audit.md"
+            task_audit = (
+                repo / "packages/research/chip/docs/project/android-on-simulated-chip-task-audit.md"
+            )
             task_audit.write_text(
                 f"# {inv.OPEN_TASK_MARKER} audit\n\n"
                 f"| {inv.OPEN_TASK_MARKER} | placeholder evidence remains blocked |\n",
@@ -318,7 +324,9 @@ class ChipOsGapKeywordInventoryTests(unittest.TestCase):
             )
 
             with mock.patch.object(inv, "REPO", repo):
-                report = inv.build_report(["packages/research/chip/docs", "packages/research/chip/scripts"])
+                report = inv.build_report(
+                    ["packages/research/chip/docs", "packages/research/chip/scripts"]
+                )
 
         self.assertEqual(report["status"], "pass")
         self.assertEqual(report["summary"]["findings"], 0)
@@ -346,7 +354,9 @@ class ChipOsGapKeywordInventoryTests(unittest.TestCase):
             )
 
             with mock.patch.object(inv, "REPO", repo):
-                report = inv.build_report(["packages/research/chip/sw", "packages/os/linux/elizaos/scripts"])
+                report = inv.build_report(
+                    ["packages/research/chip/sw", "packages/os/linux/elizaos/scripts"]
+                )
 
         self.assertEqual(report["status"], "pass")
         self.assertEqual(report["summary"]["findings"], 0)
@@ -419,7 +429,9 @@ class ChipOsGapKeywordInventoryTests(unittest.TestCase):
     def test_plan_and_survey_docs_are_not_source_gaps(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo = Path(tmp)
-            tee_plan = repo / "packages/research/chip/docs/security/tee-plan/05-cpu-memory-performance.md"
+            tee_plan = (
+                repo / "packages/research/chip/docs/security/tee-plan/05-cpu-memory-performance.md"
+            )
             tee_plan.parent.mkdir(parents=True)
             tee_plan.write_text(
                 "This experiment plan says vector arithmetic remains BLOCKED.\n"
@@ -427,7 +439,8 @@ class ChipOsGapKeywordInventoryTests(unittest.TestCase):
                 encoding="utf-8",
             )
             sota_report = (
-                repo / "packages/research/chip/docs/architecture-optimization/sota-2028/cache-report.md"
+                repo
+                / "packages/research/chip/docs/architecture-optimization/sota-2028/cache-report.md"
             )
             sota_report.parent.mkdir(parents=True)
             sota_report.write_text(

--- a/packages/research/chip/scripts/test_chip_os_optimization_gap_inventory.py
+++ b/packages/research/chip/scripts/test_chip_os_optimization_gap_inventory.py
@@ -388,7 +388,10 @@ class ChipOsOptimizationGapInventoryTests(unittest.TestCase):
     def test_command_plan_harvests_nested_runtime_logging_commands(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo = Path(tmp)
-            artifact = repo / "packages/research/chip/build/reports/android_release_readiness_contract.json"
+            artifact = (
+                repo
+                / "packages/research/chip/build/reports/android_release_readiness_contract.json"
+            )
             artifact.parent.mkdir(parents=True)
             artifact.write_text(
                 json.dumps(
@@ -499,7 +502,10 @@ class ChipOsOptimizationGapInventoryTests(unittest.TestCase):
     def test_command_plan_sanitizes_host_local_aosp_paths(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo = Path(tmp)
-            artifact = repo / "packages/research/chip/build/reports/android_release_readiness_contract.json"
+            artifact = (
+                repo
+                / "packages/research/chip/build/reports/android_release_readiness_contract.json"
+            )
             artifact.parent.mkdir(parents=True)
             artifact.write_text(
                 json.dumps(

--- a/packages/research/chip/scripts/test_cross_fork_agent_payload_contract.py
+++ b/packages/research/chip/scripts/test_cross_fork_agent_payload_contract.py
@@ -120,8 +120,7 @@ class CrossForkAgentPayloadContractTests(unittest.TestCase):
             "const url = process.env.ELIZA_BUN_RISCV64_URL;\n",
         )
         android_service = write(
-            app_core
-            / "platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java",
+            app_core / "platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java",
             'private static final String HEALTH_URL = "http://127.0.0.1:31337/api/health";\n',
         )
         linux_agent_hook = write(

--- a/packages/research/chip/scripts/test_provenance_sanitize.py
+++ b/packages/research/chip/scripts/test_provenance_sanitize.py
@@ -21,7 +21,9 @@ def test_sanitize_host_local_paths_preserves_repo_relative_context() -> None:
 
     assert "/home/" not in sanitized
     assert "/tmp/" not in sanitized
-    assert "packages/research/chip/verify/cocotb/integration/Makefile.opensbi-cva6-boot" in sanitized
+    assert (
+        "packages/research/chip/verify/cocotb/integration/Makefile.opensbi-cva6-boot" in sanitized
+    )
     assert "packages/research/chip/external/cva6/cva6/core/raw_checker.sv:50:41:" in sanitized
     assert "<host-tmp>/sim.log" in sanitized
 

--- a/packages/scripts/type-safety-ratchet-baseline.json
+++ b/packages/scripts/type-safety-ratchet-baseline.json
@@ -1,6 +1,6 @@
 {
   "schema": "eliza_type_safety_ratchet_v1",
-  "updatedAt": "2026-06-29T05:40:10.276Z",
+  "updatedAt": "2026-06-29T16:13:14.610Z",
   "scope": {
     "trackedOnly": true,
     "enumeration": "git ls-files",
@@ -48,10 +48,10 @@
     "explicitAny": 126,
     "tsSuppress": 0,
     "nonNullAssertion": 567,
-    "nullishEmptyString": 637,
+    "nullishEmptyString": 638,
     "nullishEmptyArray": 588,
     "nullishEmptyObject": 379,
     "nullishZero": 406
   },
-  "filesScanned": 9873
+  "filesScanned": 9883
 }


### PR DESCRIPTION
Fixes the deterministic, reproducible CI failures on `main`. Three independent, surgical fixes.

## 1. type-safety ratchet — `Format + Type Safety Ratchet` (quality.yml) + `lint-and-format` (ci.yaml)

```
[type-safety-ratchet] `?? ""` (core/agent/app-core): 638 current > 637 baseline
```
A production `?? ""` was added in `packages/core/src/features/documents/service.ts` (the `TEXT_EMBEDDING_BATCH` path from #10094) — `fragment.content.text ?? ""`, which the code comment notes mirrors `addEmbeddingToMemory`'s text source exactly (and lines 1002/1081 of the same file already use the identical pattern). The count went 637 → 638. Bumped the `nullishEmptyString` limit to 638 — the same accepted move as prior `fix(ci): bump … ratchet baseline` commits.

**Verified:** `node packages/scripts/type-safety-ratchet.mjs` → exit 0 (638/638); `--self-test` passes. Only `nullishEmptyString` (637→638) + `filesScanned` change; all other limits untouched.

## 2. docker-ci-smoke false positive — `Build Agent Image` / `build-and-push` (build-agent-image.yml)

```
[docker-ci-smoke] Detected startup crash signature in container logs: 'Failed to start'
##[error]docker-ci-smoke: Agent crashed on startup (matched 'Failed to start'); image is NOT bootable
```
The boot-crash scanner greps container logs (case-insensitive substring) for `Failed to start`. That matched a **benign, by-design-non-fatal WARN**:
```
Warn [SCHEDULING:BOOT-SEED] … (error=Service lifeops_scheduled_task_runner not found or failed to start)
```
…whose own message says "tasks can still be scheduled at runtime." The agent boots fine (subsequent plugins register in the same log), but the gate declared the image "NOT bootable." Last green build (3a94084f4) had the `Failed to start` pattern already present, so this is purely the WARN newly firing and tripping an over-broad substring.

Anchored the pattern to the **real** entrypoint fatal — `[eliza-autonomous] Failed to start` (`packages/agent/src/bin.ts` top-level catch, which `process.exit(1)`s) — so real crashes still trip the gate and the benign WARN no longer does.

**Verified** with a grep harness: new pattern matches a real `[eliza-autonomous] Failed to start: …` crash line, does **not** match the benign WARN; `bash -n` clean.

## 3. chip ruff format — `e1-chip` / `docker-regression` (e1-chip.yml)

```
FAIL: python ruff format: exit 1
make: *** [Makefile:178: lint] Error 1
```
The recent packages reorg left 17 Python files under `packages/research/chip/scripts/` unformatted. Reformatted with the **exact CI ruff** (`0.15.20`, per the docker build log).

**Verified:** `uvx ruff@0.15.20 format --check .` and `ruff check .` both clean.

## Not addressed here — not code failures / not reproducible from this environment

- **`ci` / `test` job — exit 143.** `##[error]The runner has received a shutdown signal` = SIGTERM/infra termination (GitHub runner reclaimed mid-build), not a test failure. A re-run should clear it.
- **`windows-ci` — `ensure-route-min-role.test.ts`.** Chronically red since ~06-19 (every non-cancelled run). Windows-only `SyntaxError: Invalid or unexpected token` thrown inside the session auth path (`resolveAuthorizedRouteRole`), caught → returns 401, so the role assertions see 401/false instead of 403/true. **Passes 5/5 on macOS locally** — a Windows-specific vitest module-resolution/parse issue that needs a Windows host to diagnose without guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)