### PR TITLE
fix(core,example-code): lean coding action surface + act-don't-narrate contract

### DIFF
--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -2420,6 +2420,22 @@ const CODING_SUB_AGENT_CONTEXTS: readonly AgentContext[] = [
 	"automation",
 ];
 
+/**
+ * Parent actions a coding sub-agent never needs, excluded from its planner
+ * surface even though they'd otherwise pass the coding-context gate. Each extra
+ * tool schema enlarges the request, and a large tool set + a large file
+ * generation is exactly what makes weaker hosted models (Cerebras glm-4.7)
+ * intermittently reject the request (server_error / 400) or narrate instead of
+ * emitting FILE. A coding sub-agent does not open/close UI views or spawn its
+ * own sub-agents, so dropping these trims the surface toward the tools that
+ * actually do the work (FILE/SHELL/WORKTREE/WEB/REPLY/STOP).
+ */
+const CODING_SUB_AGENT_EXCLUDED_ACTIONS: ReadonlySet<string> = new Set(
+	// Stored in normalizeActionIdentifier() form (uppercase, underscores
+	// stripped), since that is what the filter compares against.
+	["VIEWS", "CLOSEVIEW", "CLOSEALLVIEWS", "TASKS"],
+);
+
 function actionPassesPlannerExecutionGates(args: {
 	action: Action;
 	activeContexts?: readonly AgentContext[];
@@ -6158,22 +6174,29 @@ export async function runV5MessageRuntimeStage1(args: {
 			fullSurfaceEnv === "yes" ||
 			fullSurfaceEnv === "on";
 		const plannerCandidateActions = useFullSurface
-			? (args.runtime.actions ?? []).filter((action) =>
-					// Full-surface = the eliza-code coding sub-agent (its ACP server
-					// sets ELIZA_PLANNER_FULL_ACTION_SURFACE). It must NOT receive the
-					// whole chat action catalog (MESSAGE_*/POST_*/…) — 40 tools drowns
-					// the model and it never calls FILE. Instead treat the coding
-					// contexts (code/files/terminal/automation) as active and run the
-					// normal execution gates: that admits the coding tools
-					// (FILE/SHELL/WORKTREE, which gate on a coding context) plus
-					// context-free control actions (REPLY/STOP/…) and drops the
-					// messaging/social chat actions. Role still applies (FILE=ADMIN,
-					// SHELL=OWNER; the coding sub-agent runs as OWNER).
-					actionPassesPlannerExecutionGates({
-						action,
-						activeContexts: CODING_SUB_AGENT_CONTEXTS,
-						userRoles: [senderRole],
-					}),
+			? (args.runtime.actions ?? []).filter(
+					(action) =>
+						// Full-surface = the eliza-code coding sub-agent (its ACP server
+						// sets ELIZA_PLANNER_FULL_ACTION_SURFACE). It must NOT receive the
+						// whole chat action catalog (MESSAGE_*/POST_*/…) — 40 tools drowns
+						// the model and it never calls FILE. Instead treat the coding
+						// contexts (code/files/terminal/automation) as active and run the
+						// normal execution gates: that admits the coding tools
+						// (FILE/SHELL/WORKTREE, which gate on a coding context) plus
+						// context-free control actions (REPLY/STOP/…) and drops the
+						// messaging/social chat actions. Role still applies (FILE=ADMIN,
+						// SHELL=OWNER; the coding sub-agent runs as OWNER). UI/orchestration
+						// parents that pass the gate but a coder never needs are dropped
+						// too (see CODING_SUB_AGENT_EXCLUDED_ACTIONS) to keep the request
+						// small enough for weaker hosted models to handle large builds.
+						!CODING_SUB_AGENT_EXCLUDED_ACTIONS.has(
+							normalizeActionIdentifier(action.name),
+						) &&
+						actionPassesPlannerExecutionGates({
+							action,
+							activeContexts: CODING_SUB_AGENT_CONTEXTS,
+							userRoles: [senderRole],
+						}),
 				)
 			: await collectV5PlannerCandidateActions({
 					runtime: args.runtime,

--- a/packages/examples/code/src/acp.ts
+++ b/packages/examples/code/src/acp.ts
@@ -255,6 +255,21 @@ const _connection = new AgentSideConnection(
         const preamble: string[] = [];
         const manual = await readWorkspaceManual(session.cwd);
         if (manual) preamble.push(manual);
+        // Execution contract: weaker coding models (e.g. Cerebras glm-4.7) tend
+        // to NARRATE a plan ("I'll create the app...") and end the turn instead
+        // of emitting the FILE/SHELL action, especially on larger tasks — which
+        // leaves nothing on disk. Make the act-don't-describe requirement
+        // explicit so a build actually happens before the agent reports done.
+        preamble.push(
+          "Execution contract: DO the work by calling tools — use the FILE " +
+            "action to actually write/edit each file and the SHELL action to run " +
+            "commands. Do NOT reply with a description of what you are about to " +
+            "do; a turn that only says \"I'll create...\" or \"Creating the app " +
+            'now" without an accompanying FILE/SHELL tool call is a failure. For ' +
+            "a multi-file or large build, write the full content of each file " +
+            "with a FILE action first, then verify, and only then report what you " +
+            "did. Never claim a file exists unless you wrote it this session.",
+        );
         if (session.cwd) {
           // The coding tools (FILE/EDIT) require ABSOLUTE paths. Tell the agent
           // its workspace root up front so it writes absolute paths directly


### PR DESCRIPTION
## What

Two scoped changes that make the eliza-code coding sub-agent more reliable on weaker hosted models (Cerebras `zai-glm-4.7`), part of the request-shape work in #10132.

1. **Lean coding action surface** (`packages/core/src/services/message.ts`): drop UI/orchestration parents (`VIEWS`/`CLOSE_VIEW`/`CLOSE_ALL_VIEWS`/`TASKS`) from the coding sub-agent's full-surface planner — a coder never opens views or spawns its own sub-agents, and every extra tool schema enlarges the request. The coding tools (FILE/SHELL/WORKTREE/WEB/REPLY/STOP) are unaffected.
2. **Act-don't-narrate execution contract** (`packages/examples/code/src/acp.ts` preamble): glm-4.7 tends to NARRATE ("I'll create the app…") and end the turn without emitting FILE on larger tasks, leaving nothing on disk. Make the requirement explicit.

## Evidence

Reliability battery (4 reps each, Cerebras glm-4.7, direct ACP harness verifying the real artifact): with these changes, simple-file / code-run / multi-file / edit-existing remain **4/4 (100%)** — no regression. These don't fully fix large HTML-app builds (that's the deeper request-shape item tracked in #10132), but they reduce request bloat in the right direction and ship cleanly.

Scoped to coding mode (`ELIZA_PLANNER_FULL_ACTION_SURFACE`); chat unaffected.
