### PR TITLE
fix(cloud): avoid node disk ratchet regression

### DIFF
--- a/packages/cloud/shared/src/lib/services/node-disk-manager.ts
+++ b/packages/cloud/shared/src/lib/services/node-disk-manager.ts
@@ -133,7 +133,8 @@ export function parseDfUsedPercent(output: string): number | null {
     .filter((line) => line.length > 0 && !line.startsWith("[stderr]"));
 
   for (let i = lines.length - 1; i >= 0; i--) {
-    const line = lines[i]!;
+    const line = lines[i];
+    if (line === undefined) continue;
     // Skip the df header row.
     if (/^Filesystem\b/i.test(line)) continue;
     const match = line.match(/(\d+)%/);


### PR DESCRIPTION
## Problem
Latest `develop` (`03e0b1fc94`) went red on the type-safety ratchet after the node disk manager merge:

```json
"nonNullAssertion": 568,
"limits": { "nonNullAssertion": 567 }
```

The new occurrence is `const line = lines[i]!;` in `parseDfUsedPercent`.

## Fix
Replace the non-null assertion with an explicit indexed-read guard:

```ts
const line = lines[i];
if (line === undefined) continue;
```

No baseline bump and no behavior change.

## Verification
- `bun run audit:type-safety-ratchet --json` ✅ (`nonNullAssertion` back to 567/567)
- `bun run --cwd packages/cloud/shared test src/lib/services/node-disk-manager.test.ts` ✅ 21 tests
- `bun run --cwd packages/cloud/shared typecheck` ✅
- `git diff --check origin/develop..HEAD` ✅
