### PR TITLE
fix(ci): retighten develop ratchet baseline

### DIFF
--- a/packages/scripts/type-safety-ratchet-baseline.json
+++ b/packages/scripts/type-safety-ratchet-baseline.json
@@ -47,7 +47,7 @@
     "asAny": 0,
     "explicitAny": 126,
     "tsSuppress": 0,
-    "nonNullAssertion": 568,
+    "nonNullAssertion": 567,
     "nullishEmptyString": 637,
     "nullishEmptyArray": 588,
     "nullishEmptyObject": 379,

--- a/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
@@ -294,9 +294,10 @@ describe("useShellController — conversation loading watchdog", () => {
     const { result } = renderHook(() => useShellController());
     const staleNav = result.current.conversationNav;
 
-    act(() => {
+    await act(async () => {
       staleNav.goNext();
       staleNav.goPrev();
+      await vi.advanceTimersByTimeAsync(0);
     });
 
     expect(


### PR DESCRIPTION
## Summary

- restore the non-null assertion ratchet baseline from 568 back to the measured current count of 567
- fix the newly merged shell-controller watchdog test so it flushes the async selection microtask before asserting

## Why

Latest develop bumped the non-null baseline to 568, but `bun run audit:type-safety-ratchet --json` reports the current count is still 567. Leaving the higher limit would silently allow a new non-null assertion. While validating latest develop, the shell-controller test added around stale swipe callbacks also failed deterministically because it asserted before `runWithConversationLoading` executed the selection microtask.

## Validation

- `bun run audit:type-safety-ratchet --json`
- `bun run --cwd packages/ui test src/components/shell/__tests__/useShellController.test.tsx`
- `bun run --cwd packages/ui typecheck`
- `bun run --cwd plugins/plugin-openai typecheck`
- `bun run --cwd packages/cloud/shared typecheck`
- `bun run --cwd packages/cloud/shared test src/lib/services/node-disk-manager.test.ts`
- `git diff --check`