### PR TITLE
fix(cloud): verify Stripe signature on Connect payout webhook (#10117)

### DIFF
--- a/packages/cloud/api/v1/earnings/payout/stripe-connect/webhook/route.ts
+++ b/packages/cloud/api/v1/earnings/payout/stripe-connect/webhook/route.ts
@@ -1,35 +1,95 @@
 import { stripeConnectAccountsRepository } from "@elizaos/cloud-shared/db/repositories/stripe-connect-accounts";
 import { mapConnectWebhookEvent } from "@elizaos/cloud-shared/lib/services/stripe-connect-payout";
 import { Hono } from "hono";
+import type Stripe from "stripe";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import { isStripeConfigured, requireStripe } from "@/lib/stripe";
 import { logger } from "@/lib/utils/logger";
-import type { AppEnv } from "@/types/cloud-worker-env";
+import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
+
+/**
+ * Stripe signature tolerance window (seconds) — matches the main
+ * `/api/stripe/webhook` handler so Connect webhooks share Stripe's default
+ * 300s replay window.
+ */
+const STRIPE_WEBHOOK_TOLERANCE_SECONDS = 300;
 
 /**
  * POST /api/v1/earnings/payout/stripe-connect/webhook (#8922)
+ *
  * Advance connect-account status from Stripe Connect events
- * (`transfer.created` / `payout.paid` / `account.updated`). Signature
- * verification is handled by the existing Stripe webhook middleware ahead of
- * this handler; here we apply the already-trusted event's status change.
+ * (`transfer.created` / `payout.paid` / `account.updated`).
+ *
+ * SECURITY: this route is on the PUBLIC (unauthenticated) allowlist in
+ * `middleware/auth.ts` because Stripe calls it directly — so its ONLY trust
+ * boundary is the Stripe signature. We verify the `stripe-signature` header
+ * with `constructEventAsync` (WebCrypto; Workers-safe) BEFORE applying any
+ * state change, exactly like the main `/api/stripe/webhook` handler. Without
+ * this, anyone who knows an `acct_*` id could POST a forged `account.updated`
+ * / `payout.paid` and flip a creator's payout-account status (#10117).
+ *
+ * Connect endpoints may be configured with a dedicated signing secret, so we
+ * accept `STRIPE_CONNECT_WEBHOOK_SECRET` and fall back to the main
+ * `STRIPE_WEBHOOK_SECRET` (Connect events delivered to the primary endpoint
+ * verify with that one — already wired in prod). Fail-closed: missing/invalid
+ * signature → 400; missing config → 500.
  */
-async function handlePOST(request: Request) {
-  let event: {
-    type: string;
-    account?: string;
-    data?: { object?: Record<string, unknown> };
-  };
+async function handlePOST(c: AppContext): Promise<Response> {
+  const body = await c.req.text();
+  const signature = c.req.header("stripe-signature");
+  if (!signature) {
+    return c.json({ success: false, error: "No signature provided" }, 400);
+  }
+
+  const webhookSecret =
+    c.env.STRIPE_CONNECT_WEBHOOK_SECRET || c.env.STRIPE_WEBHOOK_SECRET;
+  if (!webhookSecret) {
+    logger.error(
+      "[StripeConnect] webhook secret not set (STRIPE_CONNECT_WEBHOOK_SECRET / STRIPE_WEBHOOK_SECRET)",
+    );
+    return c.json(
+      { success: false, error: "Webhook configuration error" },
+      500,
+    );
+  }
+  if (!isStripeConfigured()) {
+    logger.error("[StripeConnect] STRIPE_SECRET_KEY is not set");
+    return c.json({ success: false, error: "Stripe configuration error" }, 500);
+  }
+
+  let event: Stripe.Event;
   try {
-    event = (await request.json()) as typeof event;
-  } catch {
-    return Response.json(
-      { success: false, error: "Invalid JSON" },
-      { status: 400 },
+    // constructEventAsync uses WebCrypto and works on Workers; the sync
+    // variant calls into node:crypto which is unavailable here.
+    event = await requireStripe().webhooks.constructEventAsync(
+      body,
+      signature,
+      webhookSecret,
+      STRIPE_WEBHOOK_TOLERANCE_SECONDS,
+    );
+  } catch (err) {
+    const reason =
+      err instanceof Error && /timestamp/i.test(err.message)
+        ? "stale_timestamp"
+        : "invalid_signature";
+    logger.error("[StripeConnect] webhook signature verification failed", {
+      reason,
+    });
+    return c.json(
+      { success: false, error: "Signature verification failed" },
+      400,
     );
   }
 
-  const outcome = mapConnectWebhookEvent(event);
+  const outcome = mapConnectWebhookEvent({
+    type: event.type,
+    account: typeof event.account === "string" ? event.account : undefined,
+    data: {
+      object: event.data?.object as Record<string, unknown> | undefined,
+    },
+  });
   if (outcome.ignored || !outcome.accountId) {
-    return Response.json({ success: true, ignored: true });
+    return c.json({ success: true, ignored: true });
   }
 
   await stripeConnectAccountsRepository.updateByAccountId(outcome.accountId, {
@@ -41,13 +101,13 @@ async function handlePOST(request: Request) {
     payoutStatus: outcome.payoutStatus,
     status: outcome.status,
   });
-  return Response.json({ success: true });
+  return c.json({ success: true });
 }
 
 const honoRouter = new Hono<AppEnv>();
 honoRouter.post("/", async (c) => {
   try {
-    return await handlePOST(c.req.raw);
+    return await handlePOST(c);
   } catch (error) {
     return failureResponse(c, error);
   }

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -114,6 +114,13 @@ export interface Bindings {
   // ---- Stripe ----
   STRIPE_SECRET_KEY?: string;
   STRIPE_WEBHOOK_SECRET?: string;
+  /**
+   * Optional dedicated signing secret for the Stripe Connect webhook endpoint
+   * (`/api/v1/earnings/payout/stripe-connect/webhook`). Set this only if
+   * Connect events are delivered to a separate Stripe endpoint with its own
+   * `whsec_`; otherwise the handler falls back to STRIPE_WEBHOOK_SECRET.
+   */
+  STRIPE_CONNECT_WEBHOOK_SECRET?: string;
   STRIPE_CURRENCY?: string;
 
   // ---- Crypto payments ----


### PR DESCRIPTION
## Problem (live, from the money-out audit — issue #10117)

`POST /api/v1/earnings/payout/stripe-connect/webhook` is on the **public / unauthenticated** allowlist (`packages/cloud/api/src/middleware/auth.ts:104`) because Stripe calls it directly — so its **only** trust boundary is the Stripe signature. But the handler parsed the raw JSON body and applied a Connect-account **status change** with **zero signature verification**.

The docstring claimed *"Signature verification is handled by the existing Stripe webhook middleware ahead of this handler"* — **but no such middleware exists.** The main `/api/stripe/webhook` verifies **inline** (`constructEventAsync`), and nothing verifies this route. So anyone who knows/guesses an `acct_*` id could `POST` a forged `account.updated` / `payout.paid` / `transfer.created` and **flip a creator's payout-account status** (integrity/availability on the payout path).

## Fix

Verify `stripe-signature` with `constructEventAsync` (WebCrypto; Workers-safe) **before** applying any state change — mirroring the main webhook exactly (same 300s tolerance, fail-closed). Only the verified `Stripe.Event` is passed to `mapConnectWebhookEvent`.

**On the secret (re: "is it already set?"):** the codebase references exactly one Stripe webhook secret — `STRIPE_WEBHOOK_SECRET` — already bound on the prod Worker (the main webhook works in prod). This fix uses `STRIPE_CONNECT_WEBHOOK_SECRET ?? STRIPE_WEBHOOK_SECRET`, so it **works today with the already-wired secret** and supports a dedicated one only if Connect is later moved to a separate Stripe endpoint with its own `whsec_`. **No new secret required to ship.**

## Changes
- `…/stripe-connect/webhook/route.ts` — inline signature verification, fail-closed (bad sig → 400, missing config → 500); corrects the false docstring.
- `cloud-worker-env.ts` — optional `STRIPE_CONNECT_WEBHOOK_SECRET` env field.

## Notes
- Medium severity (no direct fund movement — the real transfer goes through Stripe's API, gated by Stripe's own account checks — but it's an unauthenticated write to a payout table). Targeting `develop`; happy to cut a `main` hotfix like #10118 if you want it in prod immediately.
- Closes the webhook half of #10117. (Payment-request expire-scoping = separate follow-up.)