### PR TITLE
fix(cloud): embeddings optimistic backstop records real cost (+ route tests) — follow-up to #10106

### DIFF
--- a/packages/cloud/api/__tests__/embeddings-optimistic-billing.test.ts
+++ b/packages/cloud/api/__tests__/embeddings-optimistic-billing.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Route-level regression tests for the Tier-2 optimistic-billing DECISION in
+ * POST /api/v1/embeddings (#9899 / #10106 — the embeddings recall hot path).
+ *
+ * The service layer (eligibility math, exactly-once settle, sweep) is covered by
+ * `inference-billing-fast-path.test.ts`. What was NOT covered is the embeddings
+ * ROUTE's orchestration of those functions:
+ *
+ *   gate (org && flag && backstop-writable) → REAL isOptimisticEligible → write
+ *   the durable backstop → only on a durable write take the optimistic path;
+ *   otherwise fall back to the synchronous credit reserve.
+ *
+ * These drive the REAL embeddings route through that decision with the REAL
+ * `isOptimisticEligible`; only the env-gates, the gate-balance read, the backstop
+ * write, the optimistic settler factory, `reserveCredits`, and the embedder are
+ * mocked at the module boundary so we can prove which path the route chose.
+ *
+ * Invariants pinned (each with a POSITIVE assertion so an early bail can't make a
+ * negative-only test pass):
+ *   1. Eligible org → optimistic path: backstop written, synchronous reserve
+ *      SKIPPED, optimistic settler wired.
+ *   2. The backstop records the REAL input-token cost estimate (NOT 0) so a
+ *      DROPPED settle is recoverable by the cron sweep (#10106 leak guard).
+ *   3. Balance below SAFE_BALANCE_THRESHOLD → synchronous reserve (no backstop).
+ *   4. Backstop not writable (cache down) → synchronous reserve.
+ *   5. Flag OFF → synchronous reserve (default-safe).
+ *   6. Non-durable backstop write → fall back to synchronous reserve (settler
+ *      NOT wired) — never free inference.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import * as rateLimitActual from "@/lib/middleware/rate-limit";
+import * as languageModelActual from "@/lib/providers/language-model";
+import * as pricingActual from "@/lib/pricing";
+import * as aiBillingActual from "@/lib/services/ai-billing";
+import * as inferenceAuthActual from "@/lib/services/inference-auth-context";
+import * as fastPathActual from "@/lib/services/inference-billing-fast-path";
+import * as usageActual from "@/lib/services/usage";
+
+const aiActual = require("ai") as Record<string, unknown>;
+
+const ORG = "00000000-0000-4000-8000-0000000000aa";
+const USER = "00000000-0000-4000-8000-0000000000bb";
+const API_KEY_ID = "00000000-0000-4000-8000-0000000000cc";
+const EMBEDDING = [0.0125, -0.5, 0.333333];
+// The fixed total the mocked calculateCost returns — what the backstop must
+// record (proving the route no longer writes estimatedCostUsd: 0).
+const BACKSTOP_COST = 0.0123;
+
+// --- per-test knobs the mocks read by reference -----------------------------
+let billingEnabled = true;
+let backstopAvailable = true;
+let gateBalanceUsd = 100;
+let thresholdUsd = 5;
+let backstopPersists = true;
+
+// --- spies on the two terminal billing paths --------------------------------
+const writePendingInferenceCharge = mock(
+  (_charge: { estimatedCostUsd: number }, _now: number): Promise<boolean> =>
+    Promise.resolve(backstopPersists),
+);
+const reserveCredits = mock(async () => ({
+  reservedAmount: 0,
+  reconcile: async () => undefined,
+}));
+const createOptimisticDebitSettler = mock(() => async () => undefined);
+
+// Auth: resolve straight to an authorized org user via the hot-path resolver.
+mock.module("@/lib/services/inference-auth-context", () => ({
+  ...inferenceAuthActual,
+  resolveInferenceAuthContext: async () => ({
+    kind: "authorized",
+    ctx: { userId: USER, orgId: ORG, apiKeyId: API_KEY_ID },
+  }),
+}));
+
+// Rate limiting is not under test — make the org gate a no-op (no Redis).
+mock.module("@/lib/middleware/rate-limit", () => ({
+  ...rateLimitActual,
+  enforceOrgRateLimit: async () => null,
+}));
+
+// Provider config: pretend an embedding provider is configured; the model object
+// is unused because the embed call is stubbed.
+mock.module("@/lib/providers/language-model", () => ({
+  ...languageModelActual,
+  hasTextEmbeddingProviderConfigured: () => true,
+  getTextEmbeddingModel: () => ({}) as never,
+  resolveEmbeddingProviderSource: () => "openai",
+}));
+
+// Cost: the optimistic backstop now records the real input-token estimate. A
+// fixed total lets us assert the pending charge carries it (not 0).
+mock.module("@/lib/pricing", () => ({
+  ...pricingActual,
+  calculateCost: async () => ({
+    totalCost: BACKSTOP_COST,
+    inputCost: BACKSTOP_COST,
+    outputCost: 0,
+  }),
+}));
+
+// Component under test: the ROUTE's orchestration + the REAL isOptimisticEligible
+// (spread). Env-gates, the balance read, the backstop write and the optimistic
+// settler factory are controlled/spied.
+mock.module("@/lib/services/inference-billing-fast-path", () => ({
+  ...fastPathActual,
+  isOptimisticBillingEnabled: () => billingEnabled,
+  isOptimisticBackstopAvailable: () => backstopAvailable,
+  getGateBalanceUsd: async () => gateBalanceUsd,
+  resolveSafeBalanceThresholdUsd: () => thresholdUsd,
+  writePendingInferenceCharge,
+  createOptimisticDebitSettler,
+}));
+
+// Synchronous reserve path — spied so we can prove it is the fallback. billUsage
+// is a no-op return (the settle is not the observation point here).
+mock.module("@/lib/services/ai-billing", () => ({
+  ...aiBillingActual,
+  reserveCredits,
+  billUsage: async () => ({
+    inputCost: BACKSTOP_COST,
+    outputCost: 0,
+    totalCost: BACKSTOP_COST,
+    baseInputCost: BACKSTOP_COST,
+    baseOutputCost: 0,
+    baseTotalCost: BACKSTOP_COST,
+    platformMarkup: 0,
+    inputTokens: 5,
+    outputTokens: 0,
+    totalTokens: 5,
+    markupApplied: true,
+  }),
+}));
+
+mock.module("@/lib/services/usage", () => ({
+  ...usageActual,
+  usageService: { ...usageActual.usageService, create: async () => ({ id: "u" }) },
+}));
+
+// Embedder: succeeds so the route reaches AND passes the billing decision and
+// returns 200; the decision spies are the observation point.
+mock.module("ai", () => ({
+  ...aiActual,
+  embed: async () => ({ embedding: EMBEDDING, usage: { tokens: 5 } }),
+  embedMany: async () => ({ embeddings: [EMBEDDING], usage: { tokens: 5 } }),
+}));
+
+// Import the route AFTER the mocks so it binds to the stubs.
+const embeddingsRoute = (await import("../v1/embeddings/route")).default;
+
+afterAll(() => {
+  mock.module(
+    "@/lib/services/inference-auth-context",
+    () => inferenceAuthActual,
+  );
+  mock.module("@/lib/middleware/rate-limit", () => rateLimitActual);
+  mock.module("@/lib/providers/language-model", () => languageModelActual);
+  mock.module("@/lib/pricing", () => pricingActual);
+  mock.module(
+    "@/lib/services/inference-billing-fast-path",
+    () => fastPathActual,
+  );
+  mock.module("@/lib/services/ai-billing", () => aiBillingActual);
+  mock.module("@/lib/services/usage", () => usageActual);
+  mock.module("ai", () => aiActual);
+});
+
+function makeExecutionCtx() {
+  const scheduled: Promise<unknown>[] = [];
+  return {
+    ctx: {
+      waitUntil: (p: Promise<unknown>) => {
+        scheduled.push(Promise.resolve(p));
+      },
+      passThroughOnException: () => undefined,
+    } as unknown as ExecutionContext,
+    scheduled,
+  };
+}
+
+function post(body: unknown, ctx?: ExecutionContext) {
+  return embeddingsRoute.request(
+    "/",
+    {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer eliza_test_key",
+        "Content-Type": "application/json",
+        "x-request-id": "req-emb-optimistic",
+      },
+      body: JSON.stringify(body),
+    },
+    {},
+    ctx,
+  );
+}
+
+describe("POST /api/v1/embeddings optimistic-billing route decision (#9899/#10106)", () => {
+  beforeEach(() => {
+    billingEnabled = true;
+    backstopAvailable = true;
+    gateBalanceUsd = 100;
+    thresholdUsd = 5;
+    backstopPersists = true;
+    writePendingInferenceCharge.mockClear();
+    reserveCredits.mockClear();
+    createOptimisticDebitSettler.mockClear();
+  });
+
+  test("eligible org takes the optimistic path: writes backstop, skips the synchronous reserve", async () => {
+    const { ctx, scheduled } = makeExecutionCtx();
+    const res = await post({ model: "text-embedding-3-small", input: "hi" }, ctx);
+    await Promise.all(scheduled);
+    expect(res.status).toBe(200);
+    expect(writePendingInferenceCharge).toHaveBeenCalledTimes(1);
+    expect(createOptimisticDebitSettler).toHaveBeenCalledTimes(1);
+    expect(reserveCredits).not.toHaveBeenCalled();
+  });
+
+  test("backstop records the REAL input-token cost estimate (not 0) so a dropped settle is recoverable", async () => {
+    const { ctx, scheduled } = makeExecutionCtx();
+    await post({ model: "text-embedding-3-small", input: "hi" }, ctx);
+    await Promise.all(scheduled);
+    expect(writePendingInferenceCharge).toHaveBeenCalledTimes(1);
+    const pending = writePendingInferenceCharge.mock.calls[0]?.[0] as {
+      estimatedCostUsd: number;
+    };
+    expect(pending.estimatedCostUsd).toBe(BACKSTOP_COST);
+    expect(pending.estimatedCostUsd).toBeGreaterThan(0);
+  });
+
+  test("balance below SAFE_BALANCE_THRESHOLD falls back to the synchronous reserve", async () => {
+    gateBalanceUsd = 2; // < threshold 5 → not eligible
+    const { ctx, scheduled } = makeExecutionCtx();
+    await post({ model: "text-embedding-3-small", input: "hi" }, ctx);
+    await Promise.all(scheduled);
+    expect(reserveCredits).toHaveBeenCalledTimes(1);
+    expect(writePendingInferenceCharge).not.toHaveBeenCalled();
+    expect(createOptimisticDebitSettler).not.toHaveBeenCalled();
+  });
+
+  test("backstop not writable (cache down) falls back to the synchronous reserve", async () => {
+    backstopAvailable = false;
+    const { ctx, scheduled } = makeExecutionCtx();
+    await post({ model: "text-embedding-3-small", input: "hi" }, ctx);
+    await Promise.all(scheduled);
+    expect(reserveCredits).toHaveBeenCalledTimes(1);
+    expect(writePendingInferenceCharge).not.toHaveBeenCalled();
+  });
+
+  test("optimistic billing flag OFF takes the synchronous reserve (default-safe)", async () => {
+    billingEnabled = false;
+    const { ctx, scheduled } = makeExecutionCtx();
+    await post({ model: "text-embedding-3-small", input: "hi" }, ctx);
+    await Promise.all(scheduled);
+    expect(reserveCredits).toHaveBeenCalledTimes(1);
+    expect(writePendingInferenceCharge).not.toHaveBeenCalled();
+  });
+
+  test("non-durable backstop write falls back to the synchronous reserve (never forwards un-recorded)", async () => {
+    backstopPersists = false;
+    const { ctx, scheduled } = makeExecutionCtx();
+    await post({ model: "text-embedding-3-small", input: "hi" }, ctx);
+    await Promise.all(scheduled);
+    // POSITIVE: the backstop write was attempted (decision chose optimistic)...
+    expect(writePendingInferenceCharge).toHaveBeenCalledTimes(1);
+    // ...but a non-durable write must fall through to the synchronous reserve.
+    expect(reserveCredits).toHaveBeenCalledTimes(1);
+    expect(createOptimisticDebitSettler).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/embeddings/route.ts
+++ b/packages/cloud/api/v1/embeddings/route.ts
@@ -16,6 +16,7 @@ import {
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import {
+  calculateCost,
   estimateTokens,
   getProviderFromModel,
   normalizeModelName,
@@ -231,11 +232,20 @@ app.post("/", async (c) => {
         // backstop actually persisted. The inline debit only fires when it
         // CLAIMS this entry (getAndDelete) at settle time, so a missing entry
         // would mean free inference — fall back to the synchronous reserve
-        // instead. estimatedCostUsd:0 keeps this within the route's existing
-        // under-bill-on-Worker-death acceptance: the inline settler charges the
-        // REAL cost in steady state; only a DROPPED settle (isolate eviction)
-        // falls to the cron sweep, which then charges 0 — a sub-cent under-bill,
-        // NEVER an over-bill from a blind estimate.
+        // instead. The backstop records the REAL input-token cost estimate (NOT
+        // 0): in steady state the inline settler charges the actual cost, but a
+        // DROPPED settle (isolate eviction) falls to the cron sweep, which then
+        // recovers THIS estimate — so a bulk embedMany ingestion batch can't leak
+        // its whole cost. Embeddings have no output tokens and input tokens are
+        // known up front, so the estimate is accurate (no blind-over-bill risk),
+        // mirroring the chat path's `estimatedCostUsd = totalCost` backstop.
+        const { totalCost: backstopEstimateUsd } = await calculateCost(
+          model,
+          provider,
+          estimatedInputTokens,
+          0,
+          billingSource,
+        );
         const persisted = await writePendingInferenceCharge(
           {
             requestId,
@@ -245,7 +255,7 @@ app.post("/", async (c) => {
             model,
             provider,
             billingSource: billingSource ?? "",
-            estimatedCostUsd: 0,
+            estimatedCostUsd: backstopEstimateUsd,
           },
           Date.now(),
         );


### PR DESCRIPTION
Follow-up to **#10106** (merged), which landed Tier-2 optimistic billing on `/v1/embeddings`. A deep review surfaced two gaps on this **real-money** path; #10106 merged before they could be folded in, so this lands them on top.

## 1. Revenue leak — backstop recorded `estimatedCostUsd: 0`
The durable pending-charge backstop was written with `estimatedCostUsd: 0`. In steady state the inline settler charges the real cost, but a **dropped** inline settle (isolate eviction / dropped `waitUntil`) falls to the cron sweep — which then charges **`claimed.estimatedCostUsd` = $0**, i.e. the served embedding is **free**. This same endpoint serves bulk `embedMany` RAG-ingestion batches, so a dropped settle leaks the **whole batch** cost.

**Fix:** record the real input-token estimate via `calculateCost(model, provider, estimatedInputTokens, 0, billingSource)` — embeddings have no output tokens and input tokens are known up front, so the estimate is accurate (no blind-over-bill risk), mirroring the chat path's `estimatedCostUsd = totalCost` backstop. The eligibility **gate** keeps its intentional `0` (embeddings ~$0; `SAFE_BALANCE_THRESHOLD` is the guard).

## 2. Zero test coverage of the optimistic decision on a money path
Adds `embeddings-optimistic-billing.test.ts` (mirrors the chat #10102 test) driving the **real** route + **real** `isOptimisticEligible`:
- eligible → backstop written + synchronous reserve **skipped** + settler wired
- **backstop carries the REAL estimate** (regression guard for gap 1)
- below-threshold / cache-down / flag-off / non-durable-write → synchronous-reserve fallback

## Verification
```
bun test packages/cloud/api/__tests__/embeddings-optimistic-billing.test.ts   # 6/6 pass
bun test .../embeddings-route-billing .../embeddings-credit-leak               # unchanged, pass
bun run --cwd packages/cloud/api typecheck                                     # 0 errors
```

## ⚠️ Operational note (maintainer decision — not addressed here)
`INFERENCE_OPTIMISTIC_BILLING` is **shared with chat** and already `true` in prod. There is **no embeddings-specific kill switch**, so this activates embeddings optimistic billing in prod on the next `develop → main`. Left as a product/ops decision per scope discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)