### PR TITLE
fix(core): lift coding-mode planner token cap (#10132) + accept elizaos cloud coding agent (#10059)

### DIFF
--- a/.github/issue-evidence/10059-cloud-coding-agent-enum.md
+++ b/.github/issue-evidence/10059-cloud-coding-agent-enum.md
@@ -1,0 +1,73 @@
+# #10059 — Cloud: accept `elizaos` as a coding-container agent
+
+## Scope of this change
+
+The app-side eliza-code work is merged (#10030/#10056) and the orchestrator
+already resolves `elizaos` → `eliza-code-acp` (`plugins/plugin-agent-orchestrator/
+src/services/acp-service.ts`). One concrete cloud-side **code** gap from the
+issue's review was still open:
+
+> `/api/v1/coding-containers` only accepts `claude | codex | opencode`; `elizaos`
+> is not a valid cloud coding agent yet.
+
+This change closes that gap. It is the safe, additive, in-repo prerequisite that
+must land before any cloud deploy can route coding to eliza-code.
+
+## Change
+
+`packages/shared/src/contracts/cloud-coding-containers.ts`:
+
+```ts
+export const CloudCodingAgentSchema = z.enum([
+  "claude", "codex", "opencode", "elizaos",
+]);
+```
+
+`CloudCodingAgent` is inferred from this schema, and it drives the
+`RequestCodingAgentContainerRequest.agent` / `preferredAgent` validation used by
+`packages/cloud/api/v1/coding-containers/route.ts`. The `agent` value only flows
+into the runner env (`ELIZA_CODING_AGENT` / `ELIZA_CLOUD_CODING_AGENT`) and the
+container name/description — **nothing selects or installs a CLI from it** — so
+widening the enum is purely additive and safe.
+
+The **default stays `claude`** on purpose: the runner image must actually ship the
+`eliza-code-acp` bin before `elizaos` can become the default, otherwise a
+defaulted request would target an agent the image can't run. Flipping the default
+is a deploy-time decision, not a contract change.
+
+## Verification
+
+`packages/cloud/shared/src/lib/services/coding-containers.test.ts`:
+- `accepts elizaos (the eliza-code cloud coding agent, #10059)` → parses `agent:"elizaos"`
+  and asserts the create payload injects `ELIZA_CODING_AGENT=elizaos` /
+  `ELIZA_CLOUD_CODING_AGENT=elizaos`.
+- `rejects an unknown coding agent` → guards the enum boundary.
+- Existing `defaults a missing agent to claude` / `still honors an explicit agent`
+  unchanged.
+
+```
+$ bun test packages/cloud/shared/src/lib/services/coding-containers.test.ts
+ 22 pass  0 fail
+```
+
+## Remaining work — deploy-gated (cloud team / creds), documented not done
+
+Verified from this build host (no `wrangler`, gh token lacks `write:packages`,
+prod hosts unreachable). These are NOT code-doable safely here and were left out
+deliberately rather than shipped as stubs:
+
+1. **Publish `@elizaos/example-code`** to npm (ships `eliza-code-acp`). Packaging
+   metadata is already in-repo (#10086: bin + files allowlist + shebang +
+   `lerna.json`); only the `npm publish` (creds) remains. `@elizaos/plugin-coding-tools`
+   needs an `alpha` dist-tag (today only `latest`/`beta`).
+2. **Install eliza-code in the coding-runner image** —
+   `packages/cloud/services/coding-remote-runner/Dockerfile` installs codex/
+   claude-code/opencode globally; add an `eliza-code` install once (1) publishes.
+   (Left out now: an install line for an unpublished package would red the image build.)
+3. **Architecture decision (cloud team):** does the managed *chat* agent host the
+   orchestrator (un-strip it from the `lean-chat` set / `Dockerfile.ci`'s `rm -rf`),
+   or does cloud coding flow exclusively through the coding-container runner above?
+   The lean-chat policy deliberately strips the orchestrator for cold-start (#8434),
+   so the managed-env `ELIZA_ACP_DEFAULT_AGENT=elizaos` default cannot work
+   standalone — it needs this decision first. Not implemented here to avoid a
+   speculative product change.

--- a/.github/issue-evidence/10132-coding-planner-maxtokens.md
+++ b/.github/issue-evidence/10132-coding-planner-maxtokens.md
@@ -1,0 +1,76 @@
+# #10132 — eliza-code large single-file builds fail on Cerebras glm-4.7
+
+## Root cause (request shape, confirmed — matches the issue's framing)
+
+The eliza-code coding sub-agent drives builds through the runtime **planner loop**
+(`packages/core/src/runtime/planner-loop.ts`). In coding mode
+(`ELIZA_PLANNER_FULL_ACTION_SURFACE=1`, set by the eliza-code ACP server) the
+planner already uses **native tool-calling** with `toolChoice:"required"` and
+**no `responseFormat`/`responseSchema`** — i.e. there is *no* `json_object`
+structured-output envelope on the coding path. The actual constrained envelope is
+the planner's **per-call output-token cap**, hardcoded to:
+
+```
+const DEFAULT_PLANNER_MAX_TOKENS = 1024;          // planner-loop.ts
+...
+maxTokens: DEFAULT_PLANNER_MAX_TOKENS,            // every callPlanner() call
+```
+
+A single-file app is emitted as **one `FILE`/`WRITE` tool call whose entire file
+body is a JSON-escaped argument**. The reference `packages/examples/code/tetris.html`
+is **14,850 bytes ≈ 4,640 tokens once JSON-escaped** — far past 1024. So the
+model's tool-call argument is **truncated mid-stream**: the call never completes
+(the model "narrates then stops", nothing lands on disk) or the provider 400s.
+
+This is exactly the success-rate-vs-filesize gradient the issue reports:
+
+| build size | eliza-code (before) | why |
+|---|---|---|
+| simple file / code-run / multi-file / edit | 100% | small outputs fit under 1024 |
+| moderate HTML (dice roller, ~2–3 KB) | ~25% | right at the 1024-token boundary |
+| large HTML (tip calc / tetris, ~5–15 KB) | 0% | physically cannot fit in 1024 |
+
+opencode on the **same** Cerebras `zai-glm-4.7` builds the large app 2/2 precisely
+because it does not clamp the file-emitting completion to a chat-sized budget.
+
+## Fix
+
+Raise the planner's output-token cap **only in coding/full-surface mode**, leaving
+chat planner turns at the cheap 1024 default. Env-overridable.
+
+`packages/core/src/runtime/planner-loop.ts`:
+- `isCodingFullSurfaceMode()` — single source of truth for the coding-mode signal
+  (deduped the check that was inlined in `runPlannerLoop`).
+- `DEFAULT_CODING_PLANNER_MAX_TOKENS = 16384` (~3.5× headroom over tetris.html),
+  overridable via `ELIZA_CODING_PLANNER_MAX_TOKENS`.
+- `resolvePlannerMaxTokens()` → 1024 for chat, the coding budget for coding mode.
+- `callPlanner()` now uses `resolvePlannerMaxTokens()` instead of the hardcoded 1024.
+
+The cap is a ceiling, not a target — small read/think iterations still emit only
+what they need, so there is **no cost regression** for chat or for small coding
+steps; only file-emitting turns use the headroom.
+
+## Verification
+
+Unit (deterministic, no key needed) — `packages/core/src/runtime/__tests__/planner-loop.test.ts`:
+- `raises the planner output-token cap in coding/full-surface mode (#10132)` →
+  asserts `maxTokens === 16384` when `ELIZA_PLANNER_FULL_ACTION_SURFACE=1`.
+- `honors ELIZA_CODING_PLANNER_MAX_TOKENS in coding mode (#10132)` → override to 32768.
+- Existing chat-mode test still asserts `maxTokens === 1024` (unchanged).
+
+```
+$ vitest run src/runtime/__tests__/planner-loop.test.ts
+ Test Files  1 passed (1)
+      Tests  57 passed (57)
+```
+
+## Live-LLM trajectory — N/A in this environment (re-run on the reference bot)
+
+A live Cerebras `zai-glm-4.7` build trajectory could not be captured here: this
+build host has **no Cerebras/OpenAI key** (only `ANTHROPIC_BASE_URL` is present).
+The change is deterministic at the request-shaping layer and unit-proven. To close
+the live-evidence loop, re-run the issue's `reliability-battery.mjs` large-app
+matrix (tip calculator) on the live VPS reference bot — the same harness that
+measured 0/4 before — and confirm it now matches opencode's success rate. The
+single env knob to tune if a given model needs more/less is
+`ELIZA_CODING_PLANNER_MAX_TOKENS`.

--- a/packages/cloud/shared/src/lib/services/coding-containers.test.ts
+++ b/packages/cloud/shared/src/lib/services/coding-containers.test.ts
@@ -55,6 +55,22 @@ describe("request schema", () => {
     expect(parsed.agent).toBe("codex");
   });
 
+  it("accepts elizaos (the eliza-code cloud coding agent, #10059)", () => {
+    const parsed = RequestCodingAgentContainerRequestSchema.parse({ agent: "elizaos" });
+    expect(parsed.agent).toBe("elizaos");
+    const payload = buildCodingContainerCreatePayload({ agent: parsed.agent });
+    // The agent value is injected into the runner env so the container picks
+    // eliza-code; nothing else keys off it, so widening the enum is additive.
+    expect(payload.environment_vars.ELIZA_CODING_AGENT).toBe("elizaos");
+    expect(payload.environment_vars.ELIZA_CLOUD_CODING_AGENT).toBe("elizaos");
+  });
+
+  it("rejects an unknown coding agent", () => {
+    expect(() =>
+      RequestCodingAgentContainerRequestSchema.parse({ agent: "totally-made-up" }),
+    ).toThrow();
+  });
+
   it("rejects dropped container fields instead of silently ignoring them", () => {
     expect(() =>
       RequestCodingAgentContainerRequestSchema.parse({ container: { cpu: 2 } }),

--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -401,6 +401,93 @@ describe("v5 planner loop skeleton", () => {
 		expect(result.finalMessage).toBe("Done.");
 	});
 
+	// #10132: in chat mode the planner's 1024-token output cap is fine, but a
+	// coding sub-agent (ELIZA_PLANNER_FULL_ACTION_SURFACE=1) must emit a whole
+	// file as a single FILE/WRITE tool-call argument — a real single-file app is
+	// ~4.6k+ tokens once JSON-escaped, so 1024 truncates it mid-stream and the
+	// build silently fails. Coding mode lifts the cap.
+	const buildCodingPlannerRuntime = () => ({
+		useModel: vi.fn(async () => ({
+			text: "",
+			toolCalls: [
+				{ id: "call-1", name: "REPLY", arguments: { text: "Built it." } },
+			],
+		})),
+	});
+	const codingPlannerContext = {
+		id: "ctx",
+		events: [
+			{
+				id: "msg",
+				type: "message" as const,
+				message: {
+					role: "user" as const,
+					content: { text: "Build a tip calculator app." },
+				},
+			},
+		],
+	};
+
+	it("raises the planner output-token cap in coding/full-surface mode (#10132)", async () => {
+		const prevSurface = process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE;
+		const prevMax = process.env.ELIZA_CODING_PLANNER_MAX_TOKENS;
+		process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE = "1";
+		delete process.env.ELIZA_CODING_PLANNER_MAX_TOKENS;
+		try {
+			const runtime = buildCodingPlannerRuntime();
+			await runPlannerLoop({
+				runtime,
+				context: codingPlannerContext,
+				executeToolCall: vi.fn(async () => ({ success: true, text: "ok" })),
+				evaluate: vi.fn(async () => ({
+					success: true,
+					decision: "FINISH" as const,
+					thought: "Done.",
+					messageToUser: "Done.",
+				})),
+			});
+			const plannerParams = runtime.useModel.mock.calls[0][1];
+			expect(plannerParams.maxTokens).toBe(16384);
+		} finally {
+			if (prevSurface === undefined)
+				delete process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE;
+			else process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE = prevSurface;
+			if (prevMax === undefined)
+				delete process.env.ELIZA_CODING_PLANNER_MAX_TOKENS;
+			else process.env.ELIZA_CODING_PLANNER_MAX_TOKENS = prevMax;
+		}
+	});
+
+	it("honors ELIZA_CODING_PLANNER_MAX_TOKENS in coding mode (#10132)", async () => {
+		const prevSurface = process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE;
+		const prevMax = process.env.ELIZA_CODING_PLANNER_MAX_TOKENS;
+		process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE = "1";
+		process.env.ELIZA_CODING_PLANNER_MAX_TOKENS = "32768";
+		try {
+			const runtime = buildCodingPlannerRuntime();
+			await runPlannerLoop({
+				runtime,
+				context: codingPlannerContext,
+				executeToolCall: vi.fn(async () => ({ success: true, text: "ok" })),
+				evaluate: vi.fn(async () => ({
+					success: true,
+					decision: "FINISH" as const,
+					thought: "Done.",
+					messageToUser: "Done.",
+				})),
+			});
+			const plannerParams = runtime.useModel.mock.calls[0][1];
+			expect(plannerParams.maxTokens).toBe(32768);
+		} finally {
+			if (prevSurface === undefined)
+				delete process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE;
+			else process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE = prevSurface;
+			if (prevMax === undefined)
+				delete process.env.ELIZA_CODING_PLANNER_MAX_TOKENS;
+			else process.env.ELIZA_CODING_PLANNER_MAX_TOKENS = prevMax;
+		}
+	});
+
 	it("evaluates terminal-only planner output without executing tools", async () => {
 		const runtime = {
 			useModel: vi.fn(

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -108,6 +108,44 @@ export type {
 
 const DEFAULT_PLANNER_MAX_TOKENS = 1024;
 
+/**
+ * Coding/full-surface mode is on when the eliza-code sub-agent sets
+ * `ELIZA_PLANNER_FULL_ACTION_SURFACE` (the ACP server does). Centralized so the
+ * tool-call ceiling, the queue-drain cadence, and the output-token cap all read
+ * the same signal.
+ */
+function isCodingFullSurfaceMode(): boolean {
+	const v = process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE?.trim().toLowerCase();
+	return v === "1" || v === "true" || v === "yes" || v === "on";
+}
+
+/**
+ * Default per-call output-token ceiling for a coding planner turn. A single
+ * FILE/WRITE tool call must carry the entire file as a JSON-escaped argument —
+ * a real single-file app (the reference `tetris.html` is ~4.6k tokens once
+ * escaped) blows straight past the chat default of {@link DEFAULT_PLANNER_MAX_TOKENS}
+ * (1024), which truncates the tool-call argument mid-stream so the model either
+ * narrates without ever completing the call or the provider 400s. opencode on
+ * the same Cerebras `zai-glm-4.7` builds the same app reliably precisely because
+ * it does not clamp the file-emitting completion to a chat-sized budget.
+ * Overridable via `ELIZA_CODING_PLANNER_MAX_TOKENS`. See issue #10132.
+ */
+const DEFAULT_CODING_PLANNER_MAX_TOKENS = 16384;
+
+/**
+ * Resolve the planner's per-call `maxTokens`: the small chat default, or — in
+ * coding/full-surface mode — a budget large enough to emit a full file in one
+ * tool call ({@link DEFAULT_CODING_PLANNER_MAX_TOKENS}, overridable via
+ * `ELIZA_CODING_PLANNER_MAX_TOKENS`).
+ */
+function resolvePlannerMaxTokens(): number {
+	if (!isCodingFullSurfaceMode()) return DEFAULT_PLANNER_MAX_TOKENS;
+	const raw = Number(process.env.ELIZA_CODING_PLANNER_MAX_TOKENS);
+	return Number.isFinite(raw) && raw > 0
+		? Math.floor(raw)
+		: DEFAULT_CODING_PLANNER_MAX_TOKENS;
+}
+
 interface RawPlannerOutput {
 	action?: unknown;
 	parameters?: unknown;
@@ -133,11 +171,7 @@ export async function runPlannerLoop(
 	// TrajectoryLimitExceeded with no terminal REPLY → an EMPTY relay to the user.
 	// Raise the ceiling for coding builds (still bounded). Overridable via
 	// ELIZA_CODING_MAX_TOOL_CALLS.
-	const codingMode = ((): boolean => {
-		const v =
-			process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE?.trim().toLowerCase();
-		return v === "1" || v === "true" || v === "yes" || v === "on";
-	})();
+	const codingMode = isCodingFullSurfaceMode();
 	const codingMaxToolCalls = ((): number => {
 		const raw = Number(process.env.ELIZA_CODING_MAX_TOOL_CALLS);
 		return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : 80;
@@ -1221,7 +1255,10 @@ async function callPlanner(params: {
 			}),
 			modelInputBudget,
 		),
-		maxTokens: DEFAULT_PLANNER_MAX_TOKENS,
+		// Chat planner turns stay at the small DEFAULT_PLANNER_MAX_TOKENS; a coding
+		// turn must be able to emit a whole file in one tool call, so coding mode
+		// raises the cap (see resolvePlannerMaxTokens / issue #10132).
+		maxTokens: resolvePlannerMaxTokens(),
 	};
 	modelParams.providerOptions = {
 		...modelParams.providerOptions,

--- a/packages/shared/src/contracts/cloud-coding-containers.ts
+++ b/packages/shared/src/contracts/cloud-coding-containers.ts
@@ -1,6 +1,17 @@
 import z from "zod";
 
-export const CloudCodingAgentSchema = z.enum(["claude", "codex", "opencode"]);
+// `elizaos` = the elizaOS-owned coding sub-agent (eliza-code, runtime +
+// plugin-coding-tools + orchestrator). It resolves to the `eliza-code-acp` bin
+// in plugin-agent-orchestrator and is a drop-in for opencode on the same model.
+// Accepting it here lets a Cloud coding-container request explicitly select
+// eliza-code once the runner image ships the bin (issue #10059). The default
+// stays `claude` — the image must contain the agent before it becomes default.
+export const CloudCodingAgentSchema = z.enum([
+  "claude",
+  "codex",
+  "opencode",
+  "elizaos",
+]);
 
 export const CloudCodingContainerStatusSchema = z.enum([
   "requested",


### PR DESCRIPTION
Two small, independent changes for the eliza-code coding sub-agent (one core fix, one cloud contract prerequisite). Kept as two clean commits so they can be split if a reviewer prefers.

---

## 1. `fix(core)`: lift planner output-token cap in coding mode — closes #10132

**Root cause (request shape, not model — confirms the issue's framing).** The eliza-code coding sub-agent drives builds through the runtime planner loop. In coding mode (`ELIZA_PLANNER_FULL_ACTION_SURFACE=1`) the planner already uses native tool-calling with `toolChoice:"required"` and **no `json_object` envelope** — but it hardcoded `maxTokens = 1024` on every `callPlanner()` call. A single-file app is emitted as **one `FILE`/`WRITE` tool call whose whole body is a JSON-escaped argument**; the reference `packages/examples/code/tetris.html` is 14,850 bytes ≈ **4,640 tokens** once escaped — far past 1024 — so the tool-call argument was truncated mid-stream (model narrates then stops, nothing on disk; or the provider 400s). That is exactly the issue's gradient: simple=100%, dice≈25% (at the boundary), large=0%. opencode on the **same** Cerebras `zai-glm-4.7` builds the large app 2/2 because it doesn't clamp the file-emitting completion to a chat-sized budget.

**Fix.** Raise the cap **only** in coding/full-surface mode; chat planner turns stay at 1024.
- `DEFAULT_CODING_PLANNER_MAX_TOKENS = 16384` (~3.5× headroom over tetris.html), overridable via `ELIZA_CODING_PLANNER_MAX_TOKENS`.
- `isCodingFullSurfaceMode()` dedupes the coding-mode check; `resolvePlannerMaxTokens()` returns 1024 (chat) or the coding budget.
- The cap is a ceiling, not a target → no cost regression for chat or for small coding steps.

**Tests** (`packages/core/src/runtime/__tests__/planner-loop.test.ts`): coding mode raises to 16384; `ELIZA_CODING_PLANNER_MAX_TOKENS` override honored; chat mode still 1024. `57 passed`.

## 2. `feat(cloud)`: accept `elizaos` as a coding-container agent — advances #10059

The orchestrator already resolves `elizaos` → `eliza-code-acp`, but `CloudCodingAgentSchema` only accepted `claude|codex|opencode`, so `/api/v1/coding-containers` rejected `elizaos`. Widened the enum so a request can explicitly select eliza-code. The value only flows into runner env (`ELIZA_CODING_AGENT`/`ELIZA_CLOUD_CODING_AGENT`) + container naming — nothing keys off it to select/install a CLI — so it's additive and safe. **Default stays `claude`**: the runner image must ship the `eliza-code-acp` bin before `elizaos` can be the default (deploy-gated).

**Tests** (`packages/cloud/shared/src/lib/services/coding-containers.test.ts`): accepts `elizaos` + injects the env; rejects unknown agents; existing default/explicit cases unchanged. `22 pass`.

### #10059 remaining work — deploy-gated (documented, not stubbed)
Verified unreachable from the build host (no `wrangler`, gh token lacks `write:packages`, prod hosts down): publish `@elizaos/example-code` + add `plugin-coding-tools@alpha` tag; install eliza-code in the coding-runner image; and the cloud-team architecture decision (managed chat-agent orchestration vs coding-container-only path — lean-chat strips the orchestrator for cold-start per #8434). Left out deliberately rather than shipped as stubs. Full breakdown in the evidence file.

---

## Evidence
- `.github/issue-evidence/10132-coding-planner-maxtokens.md`
- `.github/issue-evidence/10059-cloud-coding-agent-enum.md`

**Live-LLM trajectory: N/A in CI/build host** (no Cerebras/OpenAI key here). #10132 is deterministic at the request-shaping layer and unit-proven; re-run the issue's `reliability-battery.mjs` large-app matrix on the live VPS reference bot to close the live loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)