### PR TITLE
fix(cloud): align stripe webhook test api version

### DIFF
--- a/packages/cloud/api/__tests__/stripe-connect-webhook-route.test.ts
+++ b/packages/cloud/api/__tests__/stripe-connect-webhook-route.test.ts
@@ -225,7 +225,7 @@ describe("Stripe Connect payout webhook route", () => {
 // issue describes (#10117). Signature ops are local HMAC-SHA256 — no network.
 describe("Stripe Connect webhook — real signature verification (no mock)", () => {
   const realStripe = new Stripe("sk_test_dummy_for_signature_only", {
-    apiVersion: "2024-11-20.acacia",
+    apiVersion: "2026-06-24.dahlia",
   });
   const secret = "whsec_connect_realtest";
   const payload = JSON.stringify(accountUpdatedEvent);


### PR DESCRIPTION
## Summary

- update the new Stripe Connect webhook crypto test to use the Stripe package's current constructor API-version literal

## Why

Latest `develop` after #10127 fails `packages/cloud/api` typecheck:

```
__tests__/stripe-connect-webhook-route.test.ts(228,5): error TS2322: Type '2024-11-20.acacia' is not assignable to type '2026-06-24.dahlia'.
```

The test client is only used for local webhook HMAC helper methods, so the API version does not affect the signature behavior under test. Aligning the literal with the installed Stripe constructor type keeps the test type-safe without changing runtime route behavior.

## Validation

- `bun run --cwd packages/cloud/api typecheck`
- `bun test --cwd packages/cloud/api __tests__/stripe-connect-webhook-route.test.ts`
- `bun run --cwd packages/cloud/shared test src/lib/services/payment-requests.test.ts`
- `bun run --cwd packages/cloud/shared typecheck`
- `bun run --cwd packages/core typecheck`
- `bun run audit:type-safety-ratchet --json`
- `git diff --check`