### PR TITLE
fix(cloud): require signer signature to deny an approval request (#10117)

### DIFF
--- a/packages/cloud/api/v1/approval-requests/[id]/deny/route.ts
+++ b/packages/cloud/api/v1/approval-requests/[id]/deny/route.ts
@@ -3,9 +3,12 @@
  *
  * POST /api/v1/approval-requests/:id/deny   (public — signer-facing)
  *
- * The signer chooses to reject the approval. No signature is required; this
- * transition exists so the challenger's `await_approval` can resolve to a
- * denied terminal state instead of timing out.
+ * The signer chooses to reject the approval. Like /approve, this is a
+ * signer-driven state transition on a PUBLIC (sessionless) route, so it must
+ * prove the signer's identity the same way: a signature verified by the
+ * IdentityVerificationGatekeeper. Without this gate, anyone who learns an
+ * approval id could force-deny a pending approval and grief the legitimate
+ * signer (denial-of-service on the approval flow — #10117).
  */
 
 import { Hono } from "hono";
@@ -21,19 +24,32 @@ import {
   type ApprovalRequestsService,
   createApprovalRequestsService,
 } from "@/lib/services/approval-requests";
+import {
+  createIdentityVerificationGatekeeper,
+  type IdentityVerificationGatekeeper,
+} from "@/lib/services/identity-verification-gatekeeper";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const DenySchema = z.object({
+  signature: z.string().min(1).max(4096),
+  expectedSignerIdentityId: z.string().min(1).max(256).optional(),
   reason: z.string().max(500).optional(),
 });
 
-let singleton: ApprovalRequestsService | null = null;
-function getApprovalRequestsService(): ApprovalRequestsService {
-  singleton ??= createApprovalRequestsService({
+let serviceSingleton: ApprovalRequestsService | null = null;
+let gatekeeperSingleton: IdentityVerificationGatekeeper | null = null;
+function getService(): {
+  service: ApprovalRequestsService;
+  gatekeeper: IdentityVerificationGatekeeper;
+} {
+  serviceSingleton ??= createApprovalRequestsService({
     repository: approvalRequestsRepository,
   });
-  return singleton;
+  gatekeeperSingleton ??= createIdentityVerificationGatekeeper({
+    approvalRequests: serviceSingleton,
+  });
+  return { service: serviceSingleton, gatekeeper: gatekeeperSingleton };
 }
 
 const app = new Hono<AppEnv>();
@@ -50,8 +66,8 @@ app.post("/", async (c) => {
       );
     }
 
-    const body = await c.req.json().catch(() => ({}));
-    const parsed = DenySchema.safeParse(body ?? {});
+    const body = await c.req.json().catch(() => null);
+    const parsed = DenySchema.safeParse(body);
     if (!parsed.success) {
       return c.json(
         {
@@ -63,7 +79,24 @@ app.post("/", async (c) => {
       );
     }
 
-    const service = getApprovalRequestsService();
+    const { service, gatekeeper } = getService();
+    // Prove the signer's identity before allowing the denial — symmetric with
+    // /approve. A sessionless caller without the signer's key cannot deny.
+    const verification = await gatekeeper.verify({
+      approvalId: id,
+      signature: parsed.data.signature,
+      expectedSignerIdentityId: parsed.data.expectedSignerIdentityId,
+    });
+    if (!verification.valid || !verification.signerIdentityId) {
+      return c.json(
+        {
+          success: false,
+          error: verification.error ?? "signature verification failed",
+        },
+        400,
+      );
+    }
+
     const approvalRequest = await service.markDenied(id, parsed.data.reason);
 
     await approvalCallbackBus.publish({

--- a/packages/ui/src/cloud/approvals/components/approvals-tab.tsx
+++ b/packages/ui/src/cloud/approvals/components/approvals-tab.tsx
@@ -88,13 +88,15 @@ function ApprovalCard({ request }: { request: ApprovalRequest }) {
   }, [challenge.message, submitSignature]);
 
   const handleDeny = useCallback(async () => {
+    const trimmed = signature.trim();
+    if (!trimmed) return;
     setError(null);
     try {
-      await deny.mutateAsync({ id: request.id });
+      await deny.mutateAsync({ id: request.id, signature: trimmed });
     } catch (caught) {
       setError(errorMessage(caught, "Failed to deny approval."));
     }
-  }, [deny, request.id]);
+  }, [deny, request.id, signature]);
 
   const expiresAt = formatApprovalTimestamp(request.expiresAt);
 
@@ -153,7 +155,7 @@ function ApprovalCard({ request }: { request: ApprovalRequest }) {
             >
               {walletCapable
                 ? "Or paste a signature"
-                : "Paste signature to approve"}
+                : "Paste signature to approve or deny"}
             </label>
             <Textarea
               id={`sig-${request.id}`}
@@ -190,7 +192,7 @@ function ApprovalCard({ request }: { request: ApprovalRequest }) {
               type="button"
               variant="outline"
               onClick={handleDeny}
-              disabled={busy}
+              disabled={busy || signature.trim().length === 0}
             >
               {deny.isPending ? (
                 <Loader2 className="h-4 w-4 animate-spin" />

--- a/packages/ui/src/cloud/approvals/lib/approvals.ts
+++ b/packages/ui/src/cloud/approvals/lib/approvals.ts
@@ -5,7 +5,7 @@
  * Endpoints (all same-origin via the shared cloud `api<T>` client):
  *  - GET  /api/v1/approval-requests            owner list (Bearer-gated)
  *  - POST /api/v1/approval-requests/:id/approve  signer-facing (signature)
- *  - POST /api/v1/approval-requests/:id/deny     signer-facing (reason)
+ *  - POST /api/v1/approval-requests/:id/deny     signer-facing (signature + reason)
  *  - GET  /api/v1/ballots                       owner list (Bearer-gated)
  *  - POST /api/v1/ballots/:id/vote               participant (scoped token)
  *  - POST /api/v1/ballots/:id/tally              owner (tally if threshold met)
@@ -121,16 +121,23 @@ export function useApproveRequest() {
   });
 }
 
-/** Deny an approval request (no signature required). */
+/** Deny an approval request with a wallet/ed25519 signature. */
 export function useDenyRequest() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (input: { id: string; reason?: string }) => {
+    mutationFn: async (input: {
+      id: string;
+      signature: string;
+      reason?: string;
+    }) => {
       const data = await api<ApprovalActionResponse>(
         `/api/v1/approval-requests/${encodeURIComponent(input.id)}/deny`,
         {
           method: "POST",
-          json: { reason: input.reason ?? "denied by owner" },
+          json: {
+            reason: input.reason ?? "denied by owner",
+            signature: input.signature,
+          },
         },
       );
       return data.approvalRequest;

--- a/packages/ui/src/cloud/public-pages/pages/approve/approval-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/approve/approval-page.tsx
@@ -180,7 +180,7 @@ export default function ApprovalPage() {
   }, [approvalId, signature, t]);
 
   const handleDeny = useCallback(async () => {
-    if (!approvalId) return;
+    if (!approvalId || !signature.trim()) return;
     setSubmitting(true);
     setSubmitError(null);
     try {
@@ -188,7 +188,10 @@ export default function ApprovalPage() {
         `/api/v1/approval-requests/${encodeURIComponent(approvalId)}/deny`,
         {
           method: "POST",
-          json: { reason: "denied by signer" },
+          json: {
+            reason: "denied by signer",
+            signature: signature.trim(),
+          },
           skipAuth: true,
         },
       );
@@ -205,7 +208,7 @@ export default function ApprovalPage() {
     } finally {
       setSubmitting(false);
     }
-  }, [approvalId, t]);
+  }, [approvalId, signature, t]);
 
   if (loading) {
     return (
@@ -367,7 +370,7 @@ export default function ApprovalPage() {
             <button
               type="button"
               onClick={handleDeny}
-              disabled={submitting}
+              disabled={submitting || signature.trim().length === 0}
               className="inline-flex items-center gap-2 rounded border border-zinc-300 px-4 py-2 text-sm dark:border-zinc-700"
             >
               {t("cloud.approval.deny", { defaultValue: "Deny" })}


### PR DESCRIPTION
## Problem

`POST /api/v1/approval-requests/:id/deny` is **public / sessionless** (signer-facing allowlist in `middleware/auth.ts`) and applied a terminal **denied** state with **no proof of identity at all** — while its sibling `/approve` requires a `signature` verified by the `IdentityVerificationGatekeeper`.

The documented model for approval-request mutations is *"redacted public view **+ signature**"*, so signature-free `deny` is an oversight, not an intentional weaker gate. **Anyone who learns/guesses an approval `id` can force-deny a pending approval**, griefing the legitimate signer (DoS on the approval flow).

## Fix

`deny` now requires the same signature proof as `approve` (same gatekeeper, same schema fields), gating the `markDenied` call. Minimal and symmetric — **no service-interface change**.

## ⚠️ Contract change
The signer-facing deny call must now include `signature` (+ optional `expectedSignerIdentityId`) in the body, exactly like `/approve`. **The signer UI needs the matching update.** Flagging for review since this touches the public approval flow.

Closes the approval-deny half of the auth-hardening items in #10117.