### PR TITLE
fix(mobile): derive native plugin mappings from manifest

### DIFF
--- a/.github/issue-evidence/10096-mobile-plugin-manifest.md
+++ b/.github/issue-evidence/10096-mobile-plugin-manifest.md
@@ -1,0 +1,53 @@
+# Issue 10096 — mobile plugin manifest evidence
+
+Scope: derives Android Capacitor package patching, iOS official pods, iOS custom
+pods, and CocoaPods-owned SPM strip sets from one annotated manifest in
+`packages/app-core/scripts/run-mobile-build.mjs`.
+
+Manual review:
+
+- Confirmed the manifest preserves the previous Android package list, including
+  `@capacitor-community/background-runner` and excluding `@capacitor/network`.
+- Confirmed the iOS official pod list is derived from manifest entries marked
+  `kind: "official"`.
+- Confirmed the conditional iOS custom pod behavior stayed the same:
+  default custom pods are always present; Bun runtime pods follow the Bun
+  runtime gates; the mobile-agent bridge stays out of App Store builds; llama
+  pods stay out of App Store builds even when requested.
+- Confirmed the CocoaPods-owned SPM strip set is derived from manifest
+  `spmHandling: "cocoapods-owned"` annotations.
+
+Verification run on the rebased branch:
+
+```bash
+bunx biome check packages/app-core/scripts/run-mobile-build.mjs packages/app-core/scripts/run-mobile-build-plugin-manifest.test.mjs
+# Checked 2 files. No fixes applied.
+
+bun run --cwd packages/app-core test -- scripts/run-mobile-build-plugin-manifest.test.mjs
+# Test Files 1 passed (1)
+# Tests 3 passed (3)
+
+bun test packages/app-core/scripts/run-mobile-build-plugin-manifest.test.mjs packages/app-core/scripts/run-mobile-build-android-app-actions.test.mjs packages/app-core/scripts/run-mobile-build-ios-engine-gate.test.mjs packages/app-core/scripts/run-mobile-build-brand-separation.test.mts
+# 27 pass
+# 0 fail
+
+node --check packages/app-core/scripts/run-mobile-build.mjs
+node --check packages/app-core/scripts/run-mobile-build-plugin-manifest.test.mjs
+# no syntax errors
+```
+
+Repo-wide verification notes:
+
+- `bun run verify` passed the type-safety ratchet, then the process was killed
+  with exit 137 before Turbo typecheck/lint started.
+- `bun run --cwd packages/app-core typecheck` fails on unrelated/generated or
+  optional-package surfaces in the current checkout, including missing generated
+  i18n data, missing optional Capacitor/contracts packages, account UI type
+  drift, and `@elizaos/tui`/`@elizaos/cloud-routing` resolution errors.
+
+Evidence marked N/A:
+
+- UI screenshots/video: N/A, no user-facing UI change.
+- Live LLM trajectory: N/A, no prompt/model/agent behavior change.
+- Native device capture: N/A for this PR slice; the change only deduplicates
+  package/pod mapping helpers and is covered by script-level regression tests.

--- a/packages/app-core/scripts/run-mobile-build-plugin-manifest.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-plugin-manifest.test.mjs
@@ -1,0 +1,89 @@
+import { expect, it } from "vitest";
+
+import {
+  ANDROID_OFFICIAL_CAPACITOR_PACKAGES,
+  IOS_COCOAPODS_OWNED_SPM_PLUGINS,
+  IOS_OFFICIAL_PODS,
+  MOBILE_CAPACITOR_PLUGIN_MANIFEST,
+  resolveIosCustomPods,
+} from "./run-mobile-build.mjs";
+
+function manifestIosPods() {
+  return MOBILE_CAPACITOR_PLUGIN_MANIFEST.flatMap((plugin) =>
+    (plugin.iosPods ?? []).map((pod) => [pod, plugin.packageName]),
+  );
+}
+
+it("derives the Android and iOS official package tables from the mobile plugin manifest", () => {
+  expect(ANDROID_OFFICIAL_CAPACITOR_PACKAGES).toEqual(
+    MOBILE_CAPACITOR_PLUGIN_MANIFEST.filter(
+      (plugin) => plugin.android?.patchAgp9,
+    ).map((plugin) => plugin.packageName),
+  );
+
+  expect(IOS_OFFICIAL_PODS).toEqual(
+    manifestIosPods()
+      .filter(([pod]) => pod.kind === "official")
+      .map(([pod, packageName]) => [pod.name, packageName]),
+  );
+
+  expect(ANDROID_OFFICIAL_CAPACITOR_PACKAGES).toContain(
+    "@capacitor-community/background-runner",
+  );
+  expect(ANDROID_OFFICIAL_CAPACITOR_PACKAGES).not.toContain(
+    "@capacitor/network",
+  );
+});
+
+it("keeps the existing iOS custom pod include gates", () => {
+  const defaultPods = new Map(resolveIosCustomPods());
+  expect(defaultPods.get("ElizaosCapacitorAgent")).toBe(
+    "@elizaos/capacitor-agent",
+  );
+  expect(defaultPods.has("ElizaosCapacitorBunRuntime")).toBe(false);
+  expect(defaultPods.has("ElizaosCapacitorMobileAgentBridge")).toBe(false);
+  expect(defaultPods.has("LlamaCpp")).toBe(false);
+  expect(defaultPods.has("ElizaBunEngine")).toBe(false);
+
+  const appStorePods = new Map(
+    resolveIosCustomPods({
+      appStoreBuild: true,
+      includeFullBunEngine: true,
+      includeLlama: true,
+      includeMobileAgentBridge: true,
+    }),
+  );
+  expect(appStorePods.get("ElizaosCapacitorBunRuntime")).toBe(
+    "@elizaos/capacitor-bun-runtime",
+  );
+  expect(appStorePods.get("ElizaBunEngine")).toBe("@elizaos/bun-ios-runtime");
+  expect(appStorePods.has("ElizaosCapacitorMobileAgentBridge")).toBe(false);
+  expect(appStorePods.has("LlamaCpp")).toBe(false);
+
+  const localPods = new Map(
+    resolveIosCustomPods({
+      appStoreBuild: false,
+      includeFullBunEngine: true,
+      includeLlama: true,
+    }),
+  );
+  expect(localPods.get("ElizaosCapacitorMobileAgentBridge")).toBe(
+    "@elizaos/capacitor-mobile-agent-bridge",
+  );
+  expect(localPods.get("LlamaCpp")).toBe("llama-cpp-capacitor");
+  expect(localPods.get("LlamaCppCapacitor")).toBe("llama-cpp-capacitor");
+});
+
+it("derives the iOS CocoaPods-owned SPM strip set from manifest annotations", () => {
+  const ownedSpmPlugins = new Set(
+    manifestIosPods()
+      .filter(([pod]) => pod.spmHandling === "cocoapods-owned")
+      .map(([pod]) => pod.name),
+  );
+
+  expect(IOS_COCOAPODS_OWNED_SPM_PLUGINS).toEqual(ownedSpmPlugins);
+  expect([...IOS_COCOAPODS_OWNED_SPM_PLUGINS].sort()).toEqual([
+    "LlamaCpp",
+    "LlamaCppCapacitor",
+  ]);
+});

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -2200,18 +2200,253 @@ export function injectAospAssetThinning(content) {
   return ensureCloudBuildAssetThinning(content);
 }
 
-const ANDROID_OFFICIAL_CAPACITOR_PACKAGES = [
-  "@capacitor/app",
-  "@capacitor/barcode-scanner",
-  "@capacitor/background-runner",
-  "@capacitor-community/background-runner",
-  "@capacitor/browser",
-  "@capacitor/haptics",
-  "@capacitor/keyboard",
-  "@capacitor/preferences",
-  "@capacitor/push-notifications",
-  "@capacitor/status-bar",
+export const MOBILE_CAPACITOR_PLUGIN_MANIFEST = [
+  {
+    packageName: "@capacitor/app",
+    android: { patchAgp9: true },
+    iosPods: [
+      { name: "CapacitorApp", kind: "official", spmHandling: "incompatible" },
+    ],
+  },
+  {
+    packageName: "@capacitor/barcode-scanner",
+    android: { patchAgp9: true },
+    iosPods: [
+      {
+        name: "CapacitorBarcodeScanner",
+        kind: "official",
+        spmHandling: "incompatible",
+      },
+    ],
+  },
+  {
+    packageName: "@capacitor/background-runner",
+    android: { patchAgp9: true },
+    iosPods: [
+      {
+        name: "CapacitorBackgroundRunner",
+        kind: "official",
+        spmHandling: "incompatible",
+      },
+    ],
+  },
+  {
+    packageName: "@capacitor-community/background-runner",
+    android: { patchAgp9: true },
+  },
+  {
+    packageName: "@capacitor/preferences",
+    android: { patchAgp9: true },
+    notes:
+      "Preferences stays on CocoaPods because the generated iOS SPM package is stripped.",
+    iosPods: [
+      {
+        name: "CapacitorPreferences",
+        kind: "official",
+        spmHandling: "incompatible",
+      },
+    ],
+  },
+  {
+    packageName: "@capacitor/haptics",
+    android: { patchAgp9: true },
+    iosPods: [
+      {
+        name: "CapacitorHaptics",
+        kind: "official",
+        spmHandling: "incompatible",
+      },
+    ],
+  },
+  {
+    packageName: "@capacitor/keyboard",
+    android: { patchAgp9: true },
+    iosPods: [
+      {
+        name: "CapacitorKeyboard",
+        kind: "official",
+        spmHandling: "incompatible",
+      },
+    ],
+  },
+  {
+    packageName: "@capacitor/network",
+    iosPods: [
+      {
+        name: "CapacitorNetwork",
+        kind: "official",
+        spmHandling: "incompatible",
+      },
+    ],
+  },
+  {
+    packageName: "@capacitor/push-notifications",
+    android: { patchAgp9: true },
+    iosPods: [
+      {
+        name: "CapacitorPushNotifications",
+        kind: "official",
+        spmHandling: "incompatible",
+      },
+    ],
+  },
+  {
+    packageName: "@capacitor/browser",
+    android: { patchAgp9: true },
+    iosPods: [
+      {
+        name: "CapacitorBrowser",
+        kind: "official",
+        spmHandling: "incompatible",
+      },
+    ],
+  },
+  {
+    packageName: "@capacitor/status-bar",
+    android: { patchAgp9: true },
+    iosPods: [
+      {
+        name: "CapacitorStatusBar",
+        kind: "official",
+        spmHandling: "incompatible",
+      },
+    ],
+  },
+  {
+    packageName: "@elizaos/capacitor-agent",
+    iosPods: [{ name: "ElizaosCapacitorAgent", kind: "custom" }],
+  },
+  {
+    packageName: "@elizaos/capacitor-appblocker",
+    iosPods: [{ name: "ElizaosCapacitorAppblocker", kind: "custom" }],
+  },
+  {
+    packageName: "@elizaos/capacitor-camera",
+    iosPods: [{ name: "ElizaosCapacitorCamera", kind: "custom" }],
+  },
+  {
+    packageName: "@elizaos/capacitor-calendar",
+    iosPods: [{ name: "ElizaosCapacitorCalendar", kind: "custom" }],
+  },
+  {
+    packageName: "@elizaos/capacitor-canvas",
+    iosPods: [{ name: "ElizaosCapacitorCanvas", kind: "custom" }],
+  },
+  {
+    packageName: "@elizaos/capacitor-eliza-tasks",
+    iosPods: [{ name: "ElizaosCapacitorElizaTasks", kind: "custom" }],
+  },
+  {
+    packageName: "@elizaos/capacitor-gateway",
+    iosPods: [{ name: "ElizaosCapacitorGateway", kind: "custom" }],
+  },
+  {
+    packageName: "@elizaos/capacitor-location",
+    iosPods: [{ name: "ElizaosCapacitorLocation", kind: "custom" }],
+  },
+  {
+    packageName: "@elizaos/capacitor-mobile-signals",
+    iosPods: [{ name: "ElizaosCapacitorMobileSignals", kind: "custom" }],
+  },
+  {
+    packageName: "@elizaos/capacitor-screencapture",
+    iosPods: [{ name: "ElizaosCapacitorScreencapture", kind: "custom" }],
+  },
+  {
+    packageName: "@elizaos/capacitor-swabble",
+    iosPods: [{ name: "ElizaosCapacitorSwabble", kind: "custom" }],
+  },
+  {
+    packageName: "@elizaos/capacitor-talkmode",
+    iosPods: [{ name: "ElizaosCapacitorTalkmode", kind: "custom" }],
+  },
+  {
+    packageName: "@elizaos/capacitor-websiteblocker",
+    iosPods: [{ name: "ElizaosCapacitorWebsiteblocker", kind: "custom" }],
+  },
+  {
+    packageName: "@elizaos/capacitor-bun-runtime",
+    iosPods: [
+      {
+        name: "ElizaosCapacitorBunRuntime",
+        kind: "custom",
+        include: "bunRuntime",
+      },
+    ],
+  },
+  {
+    packageName: "@elizaos/capacitor-mobile-agent-bridge",
+    iosPods: [
+      {
+        name: "ElizaosCapacitorMobileAgentBridge",
+        kind: "custom",
+        include: "mobileAgentTunnel",
+      },
+    ],
+  },
+  {
+    packageName: "llama-cpp-capacitor",
+    iosPods: [
+      {
+        name: "LlamaCpp",
+        kind: "custom",
+        include: "llama",
+        spmHandling: "cocoapods-owned",
+      },
+      {
+        name: "LlamaCppCapacitor",
+        kind: "custom",
+        include: "llama",
+        spmHandling: "cocoapods-owned",
+      },
+    ],
+  },
+  {
+    packageName: "@elizaos/bun-ios-runtime",
+    iosPods: [
+      {
+        name: "ElizaBunEngine",
+        kind: "custom",
+        include: "fullBunEngine",
+      },
+    ],
+  },
 ];
+
+function manifestIosPods() {
+  return MOBILE_CAPACITOR_PLUGIN_MANIFEST.flatMap((plugin) =>
+    (plugin.iosPods ?? []).map((pod) => ({
+      ...pod,
+      packageName: plugin.packageName,
+    })),
+  );
+}
+
+function iosPodTuple(pod) {
+  return [pod.name, pod.packageName];
+}
+
+function shouldIncludeIosCustomPod(pod, context) {
+  switch (pod.include ?? "always") {
+    case "always":
+      return true;
+    case "bunRuntime":
+      return context.includeBunRuntime;
+    case "mobileAgentTunnel":
+      return context.includeTunnelBridge;
+    case "llama":
+      return context.includeLlama && !context.appStoreBuild;
+    case "fullBunEngine":
+      return context.includeFullBunEngine;
+    default:
+      throw new Error(`Unknown iOS pod include gate: ${pod.include}`);
+  }
+}
+
+export const ANDROID_OFFICIAL_CAPACITOR_PACKAGES =
+  MOBILE_CAPACITOR_PLUGIN_MANIFEST.filter(
+    (plugin) => plugin.android?.patchAgp9,
+  ).map((plugin) => plugin.packageName);
 
 function patchInstalledCapacitorPluginGradleForAgp9(pkgName) {
   for (const pkgRoot of resolvePackageAbsolutePathCandidates(pkgName)) {
@@ -3758,20 +3993,9 @@ const IOS_PERMISSION_KEYS = [
   ],
 ];
 
-export const IOS_OFFICIAL_PODS = [
-  ["CapacitorApp", "@capacitor/app"],
-  ["CapacitorBarcodeScanner", "@capacitor/barcode-scanner"],
-  ["CapacitorBackgroundRunner", "@capacitor/background-runner"],
-  // Preferences is intentionally installed through CocoaPods on iOS because
-  // Capacitor's generated SPM package is stripped below for this plugin.
-  ["CapacitorPreferences", "@capacitor/preferences"],
-  ["CapacitorHaptics", "@capacitor/haptics"],
-  ["CapacitorKeyboard", "@capacitor/keyboard"],
-  ["CapacitorNetwork", "@capacitor/network"],
-  ["CapacitorPushNotifications", "@capacitor/push-notifications"],
-  ["CapacitorBrowser", "@capacitor/browser"],
-  ["CapacitorStatusBar", "@capacitor/status-bar"],
-];
+export const IOS_OFFICIAL_PODS = manifestIosPods()
+  .filter((pod) => pod.kind === "official")
+  .map(iosPodTuple);
 
 export function resolveIosCustomPods({
   includeLlama = false,
@@ -3783,51 +4007,30 @@ export function resolveIosCustomPods({
   const includeBunRuntime = includeCompatBunRuntime || includeFullBunEngine;
   const includeTunnelBridge =
     !appStoreBuild && (includeFullBunEngine || includeMobileAgentBridge);
-  return [
-    ["ElizaosCapacitorAgent", "@elizaos/capacitor-agent"],
-    ["ElizaosCapacitorAppblocker", "@elizaos/capacitor-appblocker"],
-    ["ElizaosCapacitorCamera", "@elizaos/capacitor-camera"],
-    ["ElizaosCapacitorCalendar", "@elizaos/capacitor-calendar"],
-    ["ElizaosCapacitorCanvas", "@elizaos/capacitor-canvas"],
-    ["ElizaosCapacitorElizaTasks", "@elizaos/capacitor-eliza-tasks"],
-    ["ElizaosCapacitorGateway", "@elizaos/capacitor-gateway"],
-    ["ElizaosCapacitorLocation", "@elizaos/capacitor-location"],
-    ["ElizaosCapacitorMobileSignals", "@elizaos/capacitor-mobile-signals"],
-    ["ElizaosCapacitorScreencapture", "@elizaos/capacitor-screencapture"],
-    ["ElizaosCapacitorSwabble", "@elizaos/capacitor-swabble"],
-    ["ElizaosCapacitorTalkmode", "@elizaos/capacitor-talkmode"],
-    ["ElizaosCapacitorWebsiteblocker", "@elizaos/capacitor-websiteblocker"],
-    ...(includeBunRuntime
-      ? [["ElizaosCapacitorBunRuntime", "@elizaos/capacitor-bun-runtime"]]
-      : []),
-    ...(includeTunnelBridge
-      ? [
-          [
-            "ElizaosCapacitorMobileAgentBridge",
-            "@elizaos/capacitor-mobile-agent-bridge",
-          ],
-        ]
-      : []),
-    ...(includeLlama && !appStoreBuild
-      ? [
-          ["LlamaCpp", "llama-cpp-capacitor"],
-          ["LlamaCppCapacitor", "llama-cpp-capacitor"],
-        ]
-      : []),
-    ...(includeFullBunEngine
-      ? [["ElizaBunEngine", "@elizaos/bun-ios-runtime"]]
-      : []),
-  ];
+  const context = {
+    appStoreBuild,
+    includeBunRuntime,
+    includeFullBunEngine,
+    includeLlama,
+    includeTunnelBridge,
+  };
+  return manifestIosPods()
+    .filter((pod) => pod.kind === "custom")
+    .filter((pod) => shouldIncludeIosCustomPod(pod, context))
+    .map(iosPodTuple);
 }
 
 const IOS_INCOMPATIBLE_SPM_PLUGINS = new Set(
-  IOS_OFFICIAL_PODS.map(([name]) => name),
+  manifestIosPods()
+    .filter((pod) => pod.spmHandling === "incompatible")
+    .map((pod) => pod.name),
 );
 
-const IOS_COCOAPODS_OWNED_SPM_PLUGINS = new Set([
-  "LlamaCpp",
-  "LlamaCppCapacitor",
-]);
+export const IOS_COCOAPODS_OWNED_SPM_PLUGINS = new Set(
+  manifestIosPods()
+    .filter((pod) => pod.spmHandling === "cocoapods-owned")
+    .map((pod) => pod.name),
+);
 
 const IOS_BONJOUR_SERVICES = [
   "_eliza-gw._tcp",


### PR DESCRIPTION
Relates to #10096.

## Summary
- Added `MOBILE_CAPACITOR_PLUGIN_MANIFEST` as the shared source for Android Capacitor AGP patch packages, iOS official pods, conditional custom pods, and CocoaPods-owned SPM strip sets.
- Replaced the separate hard-coded Android/iOS mapping tables with derived tables while preserving the existing include gates for Bun runtime, mobile-agent bridge, llama, and App Store builds.
- Added focused Vitest coverage and issue evidence in `.github/issue-evidence/10096-mobile-plugin-manifest.md`.

## Evidence
- `bunx biome check packages/app-core/scripts/run-mobile-build.mjs packages/app-core/scripts/run-mobile-build-plugin-manifest.test.mjs`
- `bun run --cwd packages/app-core test -- scripts/run-mobile-build-plugin-manifest.test.mjs`
- `bun test packages/app-core/scripts/run-mobile-build-plugin-manifest.test.mjs packages/app-core/scripts/run-mobile-build-android-app-actions.test.mjs packages/app-core/scripts/run-mobile-build-ios-engine-gate.test.mjs packages/app-core/scripts/run-mobile-build-brand-separation.test.mts`
- `node --check packages/app-core/scripts/run-mobile-build.mjs`
- `node --check packages/app-core/scripts/run-mobile-build-plugin-manifest.test.mjs`

## Verification notes
- `bun run verify` passed the type-safety ratchet, then the process was killed with exit 137 before Turbo typecheck/lint started.
- `bun run --cwd packages/app-core typecheck` currently fails on unrelated/generated or optional-package surfaces in this checkout; details are captured in the evidence note.
- UI screenshots/video, live LLM trajectories, and native device capture are N/A for this pure build-script mapping refactor.