### PR TITLE
ci(ui): gate chat-sheet + conversation-swipe gesture e2e on packages/ui PRs (#9954)

### DIFF
--- a/.github/workflows/ui-e2e-gate.yml
+++ b/.github/workflows/ui-e2e-gate.yml
@@ -1,0 +1,85 @@
+name: UI Chat Gesture E2E
+
+# #9954: the chat-sheet drag-detent and conversation-swipe gesture e2e runners
+# (src/components/shell/__e2e__/run-*.mjs) esbuild-bundle a fixture and drive it
+# with REAL pointer gestures in headless Chromium — coverage no jsdom unit test
+# can reach. They existed but were wired to NO workflow, so a swipe/sheet
+# regression could only be caught by hand. This gates them on packages/ui
+# changes. Mirrors ui-story-gate.yml (same lean bun workspace + Playwright
+# Chromium setup); the runners self-bundle, so no Storybook/dist build is needed.
+#
+# Only the two runners verified green are gated here. home-screen-e2e is left out
+# until its `client.listAutomations` drift is fixed; chat-ambient/onboarding have
+# their own follow-ups.
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - "packages/ui/src/components/shell/**"
+      - "packages/ui/src/state/**"
+      - "packages/ui/src/voice/**"
+      - ".github/workflows/ui-e2e-gate.yml"
+  push:
+    branches: [main, develop]
+    paths:
+      - "packages/ui/src/components/shell/**"
+      - "packages/ui/src/state/**"
+      - "packages/ui/src/voice/**"
+
+concurrency:
+  group: ui-e2e-gate-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  BUN_VERSION: "canary"
+  NODE_VERSION: "24.15.0"
+
+jobs:
+  chat-gesture-e2e:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          install-command: bun install
+          install-native-deps: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      - name: Install Playwright Chromium
+        run: bunx playwright install --with-deps chromium
+
+      # Chat-sheet drag detents (open/peek/close pull-sheet state machine).
+      - name: Chat sheet drag-gesture e2e
+        run: bun run --cwd packages/ui test:chat-sheet-e2e
+
+      # Horizontal swipe between conversations (#8929) + interleaving with the
+      # async create/select path the seq/epoch guard (#10042) protects.
+      - name: Chat conversation-swipe gesture e2e
+        run: bun run --cwd packages/ui test:chatux-gesture-e2e
+
+      - name: Upload chat gesture e2e artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: chat-gesture-e2e-output
+          path: |
+            packages/ui/src/components/shell/__e2e__/output
+            packages/ui/src/components/shell/__e2e__/output-chatux
+          retention-days: 14
+          if-no-files-found: ignore


### PR DESCRIPTION
## What

Closes the **"wire the chat gesture/sheet e2e runners into a CI workflow (none exist today)"** item of #9954.

The gesture e2e runners under `packages/ui/src/components/shell/__e2e__/` esbuild-bundle a fixture and drive it with **real pointer gestures in headless Chromium** — coverage no jsdom unit test can reach — but were wired to **no workflow**, so a chat-sheet detent or conversation-swipe regression could only be caught by running them by hand.

Adds `ui-e2e-gate.yml`, mirroring `ui-story-gate.yml`'s lean bun-workspace + Playwright-Chromium setup (the runners self-bundle, so no Storybook/dist build is needed), triggered on PRs/pushes touching the shell / state / voice sources.

## Verified green locally (real headless Chromium)

| runner | result |
|---|---|
| `test:chat-sheet-e2e` | `CHAT-SHEET E2E PASSED` — 51 screenshots, 0 page errors, 0 error-level console |
| `test:chatux-gesture-e2e` | `ALL PASSED` — swipe-left/right between conversations, 0 page errors, gesture webm |

Only these two are gated. **`home-screen-e2e` is intentionally excluded** — it fails today (`client.listAutomations is not a function`, an API drift), so wiring it would add a red job; `chat-ambient`/`onboarding` are separate follow-ups. The workflow is a **new, non-required** check, so it surfaces on `packages/ui` PRs immediately without risk of blocking merges before a maintainer promotes it.

YAML validated (`yaml.safe_load`); artifact path captures both runners' output dirs (`output` + `output-chatux`). CI is the verifier for in-Actions execution.

The remaining #9954 item — rewriting the chatux fixture to mount the **real** `ContinuousChatOverlay` instead of the local `ConversationSwiper` mock — is a larger follow-up; the regression-guard for the underlying race is #10143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)