### PR TITLE
fix(cloud): scope payment-request expire to its own id + org (#10117)

### DIFF
--- a/packages/cloud/api/v1/payment-requests/[id]/expire/route.ts
+++ b/packages/cloud/api/v1/payment-requests/[id]/expire/route.ts
@@ -9,7 +9,7 @@
  */
 
 import { Hono } from "hono";
-import { ApiError, failureResponse } from "@/lib/api/cloud-worker-errors";
+import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
   RateLimitPresets,
@@ -43,17 +43,11 @@ app.post("/", async (c) => {
       );
     }
 
-    const expiredIds = await service.expirePast(new Date());
-    const wasExpired = expiredIds.includes(id);
-
-    const after = await service.get(id, user.organization_id);
-    if (!after) {
-      throw new ApiError(
-        500,
-        "internal_error",
-        "Payment request vanished after expire",
-      );
-    }
+    // Scoped to THIS request id + the caller's org — not the global sweep.
+    const { paymentRequest: after, expired: wasExpired } = await service.expire(
+      id,
+      user.organization_id,
+    );
 
     return c.json({
       success: true,

--- a/packages/cloud/shared/src/db/repositories/payment-requests.ts
+++ b/packages/cloud/shared/src/db/repositories/payment-requests.ts
@@ -237,6 +237,28 @@ export class PaymentRequestsRepository {
     return rows.map((r) => r.id);
   }
 
+  /**
+   * Expire a SINGLE past-due payment request by id. Caller (service) enforces
+   * org ownership, mirroring cancel(). Only flips a row still in an expirable
+   * status AND past its expiry, so it is idempotent and never touches a
+   * settled/canceled request. Returns true iff a row changed.
+   */
+  async expirePastPaymentRequest(id: string, now: Date): Promise<boolean> {
+    const expirable: PaymentRequestStatus[] = ["pending", "delivered"];
+    const rows = await db
+      .update(paymentRequests)
+      .set({ status: "expired", updated_at: now })
+      .where(
+        and(
+          eq(paymentRequests.id, id),
+          inArray(paymentRequests.status, expirable),
+          lt(paymentRequests.expires_at, now),
+        ),
+      )
+      .returning({ id: paymentRequests.id });
+    return rows.length > 0;
+  }
+
   async findPaymentRequestByProviderIntentKey(
     key: ProviderIntentKey,
     value: string,

--- a/packages/cloud/shared/src/lib/services/payment-requests.ts
+++ b/packages/cloud/shared/src/lib/services/payment-requests.ts
@@ -84,6 +84,15 @@ export interface PaymentRequestsService {
   cancel(id: string, organizationId: string, reason?: string): Promise<PaymentRequestRow>;
   expirePast(now?: Date): Promise<string[]>;
   /**
+   * Expire a single payment request the caller's org owns (scoped). Use this
+   * from request handlers; `expirePast` is the unscoped system/cron sweep.
+   */
+  expire(
+    id: string,
+    organizationId: string,
+    now?: Date,
+  ): Promise<{ paymentRequest: PaymentRequestRow; expired: boolean }>;
+  /**
    * Settlement is provider-driven and called by provider webhook routes before
    * they fan out notifications on PaymentCallbackBus.
    */
@@ -306,6 +315,49 @@ class PaymentRequestsServiceImpl implements PaymentRequestsService {
     });
 
     return updated;
+  }
+
+  async expire(
+    id: string,
+    organizationId: string,
+    now: Date = new Date(),
+  ): Promise<{ paymentRequest: PaymentRequestRow; expired: boolean }> {
+    const existing = requireRow(
+      await this.repository.getPaymentRequest(id),
+      id,
+      "expire lookup",
+    );
+    if (existing.organizationId !== organizationId) {
+      throw new Error(
+        `Payment request ${id} does not belong to organization ${organizationId}`,
+      );
+    }
+
+    const expired = await this.repository.expirePastPaymentRequest(id, now);
+    if (expired) {
+      const row = await this.repository.getPaymentRequest(id);
+      if (row) {
+        await this.repository.recordPaymentRequestEvent({
+          paymentRequestId: id,
+          eventName: "payment.expired",
+          redactedPayload: redactSettlementPayload({
+            paymentRequest: row,
+            status: "expired",
+          }),
+        });
+      }
+      logger.info("[PaymentRequests] Expired payment request", {
+        paymentRequestId: id,
+        organizationId,
+      });
+    }
+
+    const after = requireRow(
+      await this.repository.getPaymentRequest(id),
+      id,
+      "expire after",
+    );
+    return { paymentRequest: after, expired };
   }
 
   async expirePast(now: Date = new Date()): Promise<string[]> {


### PR DESCRIPTION
## Problem

`POST /api/v1/payment-requests/:id/expire` authorizes the caller against `:id` (org-scoped `get` → 404 if not owned), but then calls **`service.expirePast()`** — a **global sweep that expires every org's past-due payment requests** and ignores `:id` entirely. The route only checks whether `:id` happened to be in the globally-expired set.

Net: any authenticated user's expire call mutates **other orgs'** payment-request rows, and the route's own `:id` is meaningless.

## Fix
- `repo.expirePastPaymentRequest(id, now)` — expire a **single** row, only if still expirable AND past expiry (idempotent; never touches settled/canceled).
- `service.expire(id, organizationId, now?)` — verifies org ownership (mirrors `cancel()`), records `payment.expired`, returns `{ paymentRequest, expired }`.
- Route calls `service.expire(id, user.organization_id)`.
- The unscoped `expirePast()` / `expirePastPaymentRequests()` stay as the **system/cron** sweep primitive.

## Severity
Money-neutral — only flips rows already past their `expires_at` (they'd expire anyway). But it removes a cross-tenant write reachable from a per-user route. Completes the `#10117` route-hygiene items (with the Connect-webhook #10139 and approval-deny #10144 PRs).