### PR TITLE
test(os): lock Linux ISO GHA cache contract

### DIFF
--- a/.github/issue-evidence/10096-linux-iso-cache-contract.md
+++ b/.github/issue-evidence/10096-linux-iso-cache-contract.md
@@ -1,0 +1,38 @@
+# Issue 10096 — Linux ISO GHA cache contract evidence
+
+Scope: adds a CPU-light contract test proving `packages/os/linux/build.sh`
+switches from plain `docker build` to `docker buildx build` with GitHub Actions
+layer-cache flags when `ELIZAOS_DOCKER_BUILDX_GHA_CACHE=1` is set. The test is
+wired into the existing Linux ISO `static-smoke.sh` path.
+
+Manual review:
+
+- Confirmed the cache-off path invokes plain
+  `docker build --platform linux/amd64 --build-arg TARGETARCH=amd64 ...`.
+- Confirmed the cache-on path checks `docker buildx version`.
+- Confirmed the cache-on path invokes
+  `docker buildx build --load --cache-from type=gha,scope=contract-scope --cache-to type=gha,scope=contract-scope,mode=max ...`.
+- Confirmed the test uses a temporary Tails source and fake Docker binary, so it
+  validates command construction without building an image or reaching the
+  network.
+
+Verification:
+
+```bash
+bash packages/os/linux/scripts/build-cache-contract.test.sh
+# build.sh Docker cache contract OK
+
+ELIZAOS_STATIC_SOURCE_ONLY=1 bash packages/os/linux/scripts/static-smoke.sh
+# ==> shell syntax
+# build.sh Docker cache contract OK
+# ...
+# static smoke passed
+```
+
+Evidence marked N/A:
+
+- UI screenshots/video: N/A, no UI change.
+- Live LLM trajectory: N/A, no prompt/model/agent behavior change.
+- Native device capture: N/A for this contract-test PR. Full ISO cache-hit and
+  no-regression proof still requires the GitHub Actions runner path and is
+  expected from the PR checks / release workflow run.

--- a/packages/os/linux/scripts/build-cache-contract.test.sh
+++ b/packages/os/linux/scripts/build-cache-contract.test.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Contract test for build.sh's Docker builder-cache switch. Uses a fake Docker
+# binary so the test proves command construction without building an image.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+CREATED_OUT=0
+if [ ! -e "${ROOT}/out" ]; then
+    CREATED_OUT=1
+fi
+
+cleanup() {
+    rm -rf "${TMP}"
+    if [ "${CREATED_OUT}" = "1" ]; then
+        rm -rf "${ROOT}/out"
+    fi
+}
+trap cleanup EXIT
+
+mkdir -p "${TMP}/bin" "${TMP}/tails/config" "${TMP}/tails/submodules/live-build"
+printf 'fake live-build checkout\n' >"${TMP}/tails/submodules/live-build/README"
+
+cat >"${TMP}/bin/docker" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >>"${DOCKER_LOG}"
+
+case "${1:-}" in
+    build)
+        exit 0
+        ;;
+    buildx)
+        case "${2:-}" in
+            version|build)
+                exit 0
+                ;;
+        esac
+        ;;
+    volume)
+        case "${2:-}" in
+            inspect|create)
+                exit 0
+                ;;
+        esac
+        ;;
+    run)
+        exit 0
+        ;;
+esac
+
+echo "unexpected fake docker invocation: $*" >&2
+exit 64
+SH
+chmod +x "${TMP}/bin/docker"
+
+run_build_with_log() {
+    local log="$1"
+    shift
+    : >"${log}"
+    (
+        cd "${ROOT}"
+        env \
+            PATH="${TMP}/bin:${PATH}" \
+            TAILS_SRC="${TMP}/tails" \
+            DOCKER_LOG="${log}" \
+            "$@" \
+            ./build.sh config
+    ) >/dev/null
+}
+
+plain_log="${TMP}/plain.log"
+run_build_with_log "${plain_log}" ELIZAOS_DOCKER_BUILDX_GHA_CACHE=0
+grep -Fqx "build --platform linux/amd64 --build-arg TARGETARCH=amd64 -t elizaos-builder-amd64 ${ROOT}" "${plain_log}"
+if grep -Fq "buildx build" "${plain_log}"; then
+    echo "build.sh used buildx while ELIZAOS_DOCKER_BUILDX_GHA_CACHE=0" >&2
+    exit 1
+fi
+if grep -Fq -- "--cache-from" "${plain_log}"; then
+    echo "build.sh passed cache flags while ELIZAOS_DOCKER_BUILDX_GHA_CACHE=0" >&2
+    exit 1
+fi
+
+cache_log="${TMP}/cache.log"
+run_build_with_log \
+    "${cache_log}" \
+    ELIZAOS_DOCKER_BUILDX_GHA_CACHE=1 \
+    ELIZAOS_DOCKER_BUILDX_CACHE_SCOPE=contract-scope
+grep -Fqx "buildx version" "${cache_log}"
+grep -Fqx "buildx build --platform linux/amd64 --build-arg TARGETARCH=amd64 -t elizaos-builder-amd64 --load --cache-from type=gha,scope=contract-scope --cache-to type=gha,scope=contract-scope,mode=max ${ROOT}" "${cache_log}"
+
+echo "build.sh Docker cache contract OK"

--- a/packages/os/linux/scripts/static-smoke.sh
+++ b/packages/os/linux/scripts/static-smoke.sh
@@ -69,6 +69,7 @@ do
     grep -qx "${custom_tails_package}" tails/config/chroot_local-hooks/99-custom-packages-check
 done
 bash -n build.sh build-iso.sh tails/auto/build \
+    scripts/build-cache-contract.test.sh \
     scripts/dev-sign-update-manifest.sh \
     scripts/usb-write.sh \
     scripts/generate-elizaos-brand-assets.sh \
@@ -78,6 +79,7 @@ bash -n build.sh build-iso.sh tails/auto/build \
 grep -Fq 'if [ -f "${SRC}/binary.iso" ]' build-iso.sh
 grep -Fq 'find "${SRC}" -maxdepth 1 -name' build-iso.sh
 grep -Fq "sort -nr" build-iso.sh
+bash scripts/build-cache-contract.test.sh
 bash -n scripts/sync-runtime-to-chroot.sh
 sh -n \
     tails/auto/config \


### PR DESCRIPTION
Relates to #10096.

## Summary
- Added a fake-Docker contract test for `packages/os/linux/build.sh` that proves the default path stays on plain `docker build`.
- Proves `ELIZAOS_DOCKER_BUILDX_GHA_CACHE=1` switches to `docker buildx build --load` with `--cache-from type=gha` and `--cache-to type=gha,mode=max`.
- Wired the contract into `packages/os/linux/scripts/static-smoke.sh` so the existing Linux ISO static gate covers the cache wiring.
- Added evidence in `.github/issue-evidence/10096-linux-iso-cache-contract.md`.

## Evidence
- `bash packages/os/linux/scripts/build-cache-contract.test.sh`
- `ELIZAOS_STATIC_SOURCE_ONLY=1 bash packages/os/linux/scripts/static-smoke.sh`
- `bash -n packages/os/linux/scripts/build-cache-contract.test.sh packages/os/linux/scripts/static-smoke.sh`
- `git diff --check`

## Verification notes
- This PR proves command construction locally without Docker, network, or an ISO build.
- Full cache-hit and no-regression proof still requires the actual GitHub Actions Linux ISO workflow runner, per the issue text.
- UI screenshots/video, live LLM trajectories, and native device capture are N/A for this build-script contract test.