### PR TITLE
fix(ui): expose webxr polyfill types to consumers

### DIFF
--- a/packages/ui/src/spatial/webxr-runtime.ts
+++ b/packages/ui/src/spatial/webxr-runtime.ts
@@ -1,3 +1,5 @@
+/// <reference path="./webxr-polyfill.types.ts" />
+
 /**
  * WebXR runtime — the packaging seam that makes the XR modality *real* on every
  * platform where WebXR is supported, and gracefully available where it isn't.


### PR DESCRIPTION
## Summary
- add a non-emitting reference from `webxr-runtime.ts` to the local `webxr-polyfill` ambient declaration
- fixes `packages/agent` typecheck when it consumes `@elizaos/ui/*` source through path aliases

## Root cause
`packages/ui` includes `packages/ui/src/spatial/webxr-polyfill.types.ts` in its own tsconfig, so UI typecheck passes. `packages/agent` imports `packages/ui/src/spatial/webxr-runtime.ts` directly through the `@elizaos/ui/*` path alias, but does not include the sibling ambient declaration file, so TypeScript reported `webxr-polyfill` as untyped.

## Validation
- `bun run --cwd packages/agent typecheck`
- `bun run --cwd packages/ui typecheck`
- `bun run audit:type-safety-ratchet --json`
- `git diff --check`
