### PR TITLE
feat(benchmarks): recall-bench IR-metrics foundation for memory-recall quality (#9956)

### DIFF
--- a/packages/benchmarks/recall-bench/README.md
+++ b/packages/benchmarks/recall-bench/README.md
@@ -1,0 +1,45 @@
+# recall-bench (#9956)
+
+Quality benchmark for the agent's **memory-recall + knowledge-retrieval** path —
+`AgentRuntime.searchMemories`, `DocumentService.searchDocuments` (hybrid /
+vector / keyword), and the `DOCUMENTS` / `FACTS` recall providers. The repo
+measures retrieval *cost* (`memperf`) and LLM *context-window* attention
+(`context_bench`) but never retrieval *correctness* at document scale, and the
+recall path **fails open** (a slow/errored embed silently degrades semantic
+recall to keyword-only) with no metric guarding it. See #9956.
+
+## Status
+
+This package currently ships the **deterministic scoring foundation** that the
+rest of #9956 builds on, fully unit-tested in isolation:
+
+- `metrics.ts` — Precision@K, Recall@K, MRR, nDCG@K, HitRate@K, nearest-rank
+  latency percentiles, and `summarizeRecall()`. Pure functions, no I/O. Honesty
+  contract from `memperf`: unmeasured rows are `null` (never `0`), and a summary
+  is `measured: true` only when at least one query was actually scored.
+- `metrics.test.ts` — 19 cases with hand-computed expected values, including a
+  guard that a fail-open keyword regression scores **strictly below** the vector
+  path (the silent-degradation risk #9956 names).
+
+```bash
+bunx vitest run packages/benchmarks/recall-bench/metrics.test.ts
+```
+
+## Remaining work-order (the harness + CI gate)
+
+These need the **real** `@elizaos/core` pipeline stood up over a labelled
+corpus, and a CI runner — tracked in #9956, not yet in this package:
+
+- [ ] Driver that ingests a document-scale corpus through the real
+      `DocumentService` (no Python/mock reimpl) + a query set with ground-truth
+      relevant fragment ids, runs each `SearchMode`, and feeds results through
+      `summarizeRecall`.
+- [ ] Per-mode emission (hybrid / vector / keyword) so the hard-coded
+      `HYBRID_VECTOR_WEIGHT 0.6 / 0.4` and the fail-open degradation are each
+      quantified.
+- [ ] A fail-open assertion: force `embedRecallQuery` to return `null` and
+      assert a measured recall drop vs the vector path.
+- [ ] Cover the keyword chat-search surface (`scoreMemoryText`) and a
+      `FACTS`-provider recall slice against the same corpus.
+- [ ] Register in `registry/commands.py` + `registry/scores.py` and wire
+      `recall-bench.yml` with a committed `budgets.json`, mirroring `memperf`.

--- a/packages/benchmarks/recall-bench/metrics.test.ts
+++ b/packages/benchmarks/recall-bench/metrics.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import {
+  dcgAtK,
+  hitRateAtK,
+  idealDcgAtK,
+  mean,
+  ndcgAtK,
+  percentile,
+  precisionAtK,
+  type QueryResult,
+  recallAtK,
+  reciprocalRank,
+  summarizeRecall,
+} from "./metrics";
+
+// retrieved [d1, d2, d3, d4]; relevant {d2, d4, d9}. Hand-computed throughout.
+const R: QueryResult = {
+  retrieved: ["d1", "d2", "d3", "d4"],
+  relevant: new Set(["d2", "d4", "d9"]),
+};
+
+describe("precisionAtK", () => {
+  it("divides hits by the fixed K", () => {
+    expect(precisionAtK(R, 1)).toBe(0); // [d1] — no hit
+    expect(precisionAtK(R, 2)).toBe(0.5); // [d1,d2] — 1/2
+    expect(precisionAtK(R, 4)).toBe(0.5); // {d2,d4} — 2/4
+  });
+  it("counts unfilled slots as non-relevant (K beyond list length)", () => {
+    expect(precisionAtK(R, 8)).toBe(2 / 8); // 2 hits, denominator stays K
+  });
+  it("is 0 for non-positive K", () => {
+    expect(precisionAtK(R, 0)).toBe(0);
+  });
+});
+
+describe("recallAtK", () => {
+  it("divides hits by |relevant|", () => {
+    expect(recallAtK(R, 2)).toBeCloseTo(1 / 3, 10); // d2 of {d2,d4,d9}
+    expect(recallAtK(R, 4)).toBeCloseTo(2 / 3, 10); // d2,d4
+  });
+  it("is 0 when nothing is relevant", () => {
+    expect(recallAtK({ retrieved: ["a"], relevant: new Set() }, 5)).toBe(0);
+  });
+});
+
+describe("hitRateAtK", () => {
+  it("is 1 iff a relevant doc is in the top-k", () => {
+    expect(hitRateAtK(R, 1)).toBe(0);
+    expect(hitRateAtK(R, 2)).toBe(1);
+  });
+});
+
+describe("reciprocalRank", () => {
+  it("is 1 / (rank of first relevant)", () => {
+    expect(reciprocalRank(R)).toBe(1 / 2); // d2 at rank 2
+    expect(
+      reciprocalRank({ retrieved: ["d2", "x"], relevant: new Set(["d2"]) }),
+    ).toBe(1); // rank 1
+  });
+  it("is 0 when no relevant doc is retrieved", () => {
+    expect(
+      reciprocalRank({ retrieved: ["x", "y"], relevant: new Set(["z"]) }),
+    ).toBe(0);
+  });
+});
+
+describe("nDCG@k", () => {
+  it("computes DCG with a log2(rank+1) discount", () => {
+    // d2 at i=1 → 1/log2(3); d4 at i=3 → 1/log2(5).
+    const expected = 1 / Math.log2(3) + 1 / Math.log2(5);
+    expect(dcgAtK(R, 4)).toBeCloseTo(expected, 10);
+  });
+  it("ideal DCG packs relevant docs into the top slots (capped at k)", () => {
+    // min(|relevant|=3, k=4)=3 → 1/log2(2)+1/log2(3)+1/log2(4).
+    const expected = 1 / Math.log2(2) + 1 / Math.log2(3) + 1 / Math.log2(4);
+    expect(idealDcgAtK(R, 4)).toBeCloseTo(expected, 10);
+  });
+  it("normalizes DCG by the ideal", () => {
+    expect(ndcgAtK(R, 4)).toBeCloseTo(dcgAtK(R, 4) / idealDcgAtK(R, 4), 10);
+    // A perfectly-ranked result scores 1.0.
+    const perfect: QueryResult = {
+      retrieved: ["a", "b", "c"],
+      relevant: new Set(["a", "b"]),
+    };
+    expect(ndcgAtK(perfect, 3)).toBeCloseTo(1, 10);
+  });
+  it("is 0 when there is no ideal gain", () => {
+    expect(ndcgAtK({ retrieved: ["a"], relevant: new Set() }, 5)).toBe(0);
+  });
+});
+
+describe("percentile (nearest-rank)", () => {
+  const xs = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
+  it("returns the nearest-rank value", () => {
+    expect(percentile(xs, 50)).toBe(50);
+    expect(percentile(xs, 90)).toBe(90);
+    expect(percentile(xs, 95)).toBe(100);
+    expect(percentile(xs, 100)).toBe(100);
+  });
+  it("is order-independent (nearest-rank p50 of even n is the lower-middle)", () => {
+    // sorted [10,30,50,100]; rank = ceil(0.5*4) = 2 → 30.
+    expect(percentile([100, 10, 50, 30], 50)).toBe(30);
+  });
+  it("returns null for an empty sample (never 0 — memperf honesty contract)", () => {
+    expect(percentile([], 95)).toBeNull();
+  });
+});
+
+describe("mean", () => {
+  it("averages, or null when empty", () => {
+    expect(mean([1, 2, 3])).toBe(2);
+    expect(mean([])).toBeNull();
+  });
+});
+
+describe("summarizeRecall", () => {
+  it("aggregates per-query metrics and latency percentiles", () => {
+    const s = summarizeRecall([R], 4, [12, 30, 9, 100]);
+    expect(s.queries).toBe(1);
+    expect(s.k).toBe(4);
+    expect(s.precisionAtK).toBe(0.5);
+    expect(s.recallAtK).toBeCloseTo(2 / 3, 10);
+    expect(s.mrr).toBe(0.5);
+    expect(s.ndcgAtK).toBeCloseTo(dcgAtK(R, 4) / idealDcgAtK(R, 4), 10);
+    expect(s.hitRateAtK).toBe(1);
+    // sorted [9,12,30,100]; nearest-rank p50 = ceil(0.5*4)=2 → 12, p95 → 100.
+    expect(s.p50LatencyMs).toBe(12);
+    expect(s.p95LatencyMs).toBe(100);
+    expect(s.measured).toBe(true);
+  });
+  it("marks an empty run unmeasured with null metrics (no fake zeros)", () => {
+    const s = summarizeRecall([], 5);
+    expect(s.measured).toBe(false);
+    expect(s.precisionAtK).toBeNull();
+    expect(s.recallAtK).toBeNull();
+    expect(s.p95LatencyMs).toBeNull();
+  });
+  it("scores a fail-open keyword regression strictly below the vector path", () => {
+    // The #9956 silent-degradation risk: vector recall retrieves the relevant
+    // doc high; keyword fallback misses it. The metric must reflect the drop.
+    const q = new Set(["target"]);
+    const vector = summarizeRecall(
+      [{ retrieved: ["target", "x", "y"], relevant: q }],
+      3,
+    );
+    const keywordFallback = summarizeRecall(
+      [{ retrieved: ["x", "y", "z"], relevant: q }],
+      3,
+    );
+    expect(vector.recallAtK).toBe(1);
+    expect(keywordFallback.recallAtK).toBe(0);
+    expect((keywordFallback.ndcgAtK ?? 0) < (vector.ndcgAtK ?? 0)).toBe(true);
+  });
+});

--- a/packages/benchmarks/recall-bench/metrics.ts
+++ b/packages/benchmarks/recall-bench/metrics.ts
@@ -1,0 +1,150 @@
+/**
+ * recall-bench — information-retrieval quality metrics (#9956).
+ *
+ * Pure, deterministic scoring for the memory-recall / knowledge-retrieval
+ * benchmark: Precision@K, Recall@K, MRR, nDCG@K, HitRate@K, and latency
+ * percentiles. This is the foundation the rest of #9956 builds on — the harness
+ * that drives the REAL `@elizaos/core` recall path (`AgentRuntime.searchMemories`
+ * + `DocumentService.searchDocuments`) over a labelled, document-scale corpus
+ * feeds its per-query results through these functions, then compares the
+ * summary against committed budgets in CI.
+ *
+ * Definitions are the standard IR ones, fixed here so a regression in the bench
+ * itself is caught by `metrics.test.ts`:
+ *   - A "result" is an ordered list of retrieved ids (most-relevant first).
+ *   - "relevant" is the ground-truth set of ids that SHOULD be retrieved.
+ *   - Precision@K divides by K (unfilled slots below `retrieved.length` count as
+ *     non-relevant — the standard fixed-K convention), so P@K is comparable
+ *     across queries regardless of how many docs a mode returned.
+ *   - Recall@K divides by |relevant|; 0 when there are no relevant ids.
+ *   - nDCG@K uses binary gains (1 relevant / 0 not) and log2(rank+1) discount.
+ */
+
+export interface QueryResult {
+  /** Retrieved ids in rank order (index 0 = top hit). */
+  readonly retrieved: readonly string[];
+  /** Ground-truth relevant ids for this query. */
+  readonly relevant: ReadonlySet<string>;
+}
+
+function topK(retrieved: readonly string[], k: number): readonly string[] {
+  if (k <= 0) return [];
+  return retrieved.slice(0, k);
+}
+
+/** |relevant ∩ retrieved[:k]| / k. Denominator is K (fixed-K convention). */
+export function precisionAtK(result: QueryResult, k: number): number {
+  if (k <= 0) return 0;
+  const hits = topK(result.retrieved, k).filter((id) =>
+    result.relevant.has(id),
+  ).length;
+  return hits / k;
+}
+
+/** |relevant ∩ retrieved[:k]| / |relevant|. 0 when nothing is relevant. */
+export function recallAtK(result: QueryResult, k: number): number {
+  if (result.relevant.size === 0) return 0;
+  const hits = topK(result.retrieved, k).filter((id) =>
+    result.relevant.has(id),
+  ).length;
+  return hits / result.relevant.size;
+}
+
+/** 1 if any of the top-k are relevant, else 0. */
+export function hitRateAtK(result: QueryResult, k: number): number {
+  return topK(result.retrieved, k).some((id) => result.relevant.has(id))
+    ? 1
+    : 0;
+}
+
+/** 1 / (1-based rank of the first relevant hit); 0 when none is retrieved. */
+export function reciprocalRank(result: QueryResult): number {
+  const idx = result.retrieved.findIndex((id) => result.relevant.has(id));
+  return idx === -1 ? 0 : 1 / (idx + 1);
+}
+
+/** Discounted cumulative gain over the top-k with binary relevance. */
+export function dcgAtK(result: QueryResult, k: number): number {
+  return topK(result.retrieved, k).reduce((acc, id, i) => {
+    if (!result.relevant.has(id)) return acc;
+    // gain 1, discounted by log2(rank+1) with rank = i+1 → log2(i+2).
+    return acc + 1 / Math.log2(i + 2);
+  }, 0);
+}
+
+/** Ideal DCG@k: all relevant docs packed into the top positions. */
+export function idealDcgAtK(result: QueryResult, k: number): number {
+  const ideal = Math.min(result.relevant.size, Math.max(k, 0));
+  let sum = 0;
+  for (let i = 0; i < ideal; i += 1) sum += 1 / Math.log2(i + 2);
+  return sum;
+}
+
+/** nDCG@k = DCG@k / IDCG@k; 0 when there is no ideal gain (no relevant docs). */
+export function ndcgAtK(result: QueryResult, k: number): number {
+  const idcg = idealDcgAtK(result, k);
+  if (idcg === 0) return 0;
+  return dcgAtK(result, k) / idcg;
+}
+
+/**
+ * Nearest-rank percentile of a sample set (e.g. latency ms). p in [0,100].
+ * Returns null for an empty sample (the memperf honesty contract: unmeasured
+ * rows are null, never 0).
+ */
+export function percentile(
+  values: readonly number[],
+  p: number,
+): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const clamped = Math.min(100, Math.max(0, p));
+  if (clamped === 0) return sorted[0];
+  const rank = Math.ceil((clamped / 100) * sorted.length);
+  return sorted[Math.min(sorted.length, Math.max(1, rank)) - 1];
+}
+
+export function mean(values: readonly number[]): number | null {
+  if (values.length === 0) return null;
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+export interface RecallSummary {
+  readonly queries: number;
+  readonly k: number;
+  /** Mean metric across all queries, or null when there are no queries. */
+  readonly precisionAtK: number | null;
+  readonly recallAtK: number | null;
+  readonly mrr: number | null;
+  readonly ndcgAtK: number | null;
+  readonly hitRateAtK: number | null;
+  /** Latency percentiles (ms), null when no latencies were supplied. */
+  readonly p50LatencyMs: number | null;
+  readonly p95LatencyMs: number | null;
+  /** True only when at least one query was actually scored (memperf contract). */
+  readonly measured: boolean;
+}
+
+/**
+ * Aggregate per-query results into the summary CI compares against budgets.
+ * `latenciesMs` is optional and independent of the result count (a run may
+ * score quality without timing, or vice versa).
+ */
+export function summarizeRecall(
+  results: readonly QueryResult[],
+  k: number,
+  latenciesMs: readonly number[] = [],
+): RecallSummary {
+  return {
+    queries: results.length,
+    k,
+    precisionAtK: mean(results.map((r) => precisionAtK(r, k))),
+    recallAtK: mean(results.map((r) => recallAtK(r, k))),
+    mrr: mean(results.map((r) => reciprocalRank(r))),
+    ndcgAtK: mean(results.map((r) => ndcgAtK(r, k))),
+    hitRateAtK: mean(results.map((r) => hitRateAtK(r, k))),
+    p50LatencyMs: percentile(latenciesMs, 50),
+    p95LatencyMs: percentile(latenciesMs, 95),
+    measured: results.length > 0,
+  };
+}


### PR DESCRIPTION
## What

Starts #9956 (previously untouched): the memory-recall / knowledge-retrieval path has **no retrieval-quality benchmark and no regression gate**, and it **fails open** — a slow/errored embed silently degrades semantic recall to keyword-only with nothing measuring the drop.

This lands the **deterministic scoring foundation** the rest of #9956 builds on — fully unit-tested in isolation, no real pipeline or corpus needed yet:

- **`metrics.ts`** — `precisionAtK`, `recallAtK`, `reciprocalRank`/MRR, `dcgAtK`/`idealDcgAtK`/`ndcgAtK` (binary gain, log2 discount), `hitRateAtK`, nearest-rank `percentile` (p50/p95 latency), and `summarizeRecall()`. Pure functions, no I/O. Adopts the `memperf` honesty contract: unmeasured rows are `null` (never `0`); `measured: true` only when ≥1 query was actually scored.
- **`metrics.test.ts`** — 19 hand-computed cases, including a guard that a **fail-open keyword regression scores strictly below the vector path** (the silent-degradation risk #9956 names).
- **`README.md`** — documents the remaining work-order as explicit follow-ups.

## Evidence

```
$ bunx vitest run packages/benchmarks/recall-bench/metrics.test.ts
 Test Files  1 passed (1)
      Tests  19 passed (19)
```

biome clean. Pure-TS, no deps, runs under the root runner like `memperf` (no package.json needed).

## Scope (honest)

**Foundation only.** The document-scale harness that drives the real `@elizaos/core` recall path (`searchMemories` + `DocumentService.searchDocuments` over a labelled corpus), per-mode emission, the live fail-open assertion, the keyword/FACTS slices, and the `recall-bench.yml` CI budget gate **remain open** (tracked in #9956, listed in the README). Those need the live pipeline + a CI runner stood up; this scoring core will consume their per-query results unchanged. I'm shipping the verifiable, deterministic part now rather than bundling it with the unverified pipeline work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)