### PR TITLE
fix(cloud): fail-closed debit on Stripe Connect payout — never over-pay

### DIFF
--- a/packages/cloud/api/v1/earnings/payout/stripe-connect/transfer/route.ts
+++ b/packages/cloud/api/v1/earnings/payout/stripe-connect/transfer/route.ts
@@ -86,6 +86,12 @@ async function handleTransfer(c: AppContext) {
   }
 
   // Debit first so a crash can never transfer more than was reserved.
+  // requireSufficientBalance makes the debit fail CLOSED (no floor-and-pass)
+  // under the row lock on the primary, so a stale getBalance pre-check, a
+  // concurrent double-submit (distinct idempotency keys), or read-replica lag
+  // can never let us transfer more fiat than the creator actually earned. On
+  // success exactly `amount` is debited, so the compensation below (which
+  // re-credits `amount`) is also exact.
   const debit = await redeemableEarningsService.reduceEarnings({
     userId: user_id,
     amount,
@@ -93,6 +99,7 @@ async function handleTransfer(c: AppContext) {
     sourceId: idempotency_key,
     description: "Stripe Connect fiat payout",
     metadata: { payout_method: "stripe_connect" },
+    requireSufficientBalance: true,
   });
   if (!debit.success) {
     return Response.json(

--- a/packages/cloud/shared/src/lib/services/__tests__/container-billing-idempotency.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/container-billing-idempotency.test.ts
@@ -16,7 +16,7 @@
  * executes. They self-skip if PGlite is unavailable.
  */
 
-import { beforeAll, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 
 process.env.DATABASE_URL ||= "pglite://memory";
 process.env.NODE_ENV ||= "test";
@@ -30,13 +30,14 @@ const USER_ID = "00000000-0000-0000-0000-0000000000b2";
 const CONTAINER_ID = "00000000-0000-0000-0000-0000000000c3";
 
 let dbWrite: typeof import("../../../db/client").dbWrite;
+let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
 let redeemableEarningsService: typeof import("../redeemable-earnings").redeemableEarningsService;
 let containerBillingRepository: typeof import("../../../db/repositories/container-billing").containerBillingRepository;
 let pgliteReady = true;
 
 beforeAll(async () => {
   try {
-    ({ dbWrite } = await import("../../../db/client"));
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
     ({ redeemableEarningsService } = await import("../redeemable-earnings"));
     ({ containerBillingRepository } = await import("../../../db/repositories/container-billing"));
 
@@ -139,6 +140,10 @@ beforeAll(async () => {
   }
 }, PGLITE_TIMEOUT);
 
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
 describe("computeContainerBillingPeriod", () => {
   test("normalizes to the UTC day regardless of time of day", () => {
     const { periodStart, periodEnd } = computeContainerBillingPeriod(
@@ -228,6 +233,86 @@ describe("convertToCredits idempotency", () => {
         `SELECT count(*)::int AS n FROM redeemable_earnings_ledger WHERE entry_type = 'credit_conversion';`,
       );
       expect((ledger.rows[0] as { n: number }).n).toBe(2);
+    },
+    PGLITE_TIMEOUT,
+  );
+});
+
+describe("reduceEarnings money-out guard", () => {
+  test(
+    "requireSufficientBalance fails closed without writing when live balance is short",
+    async () => {
+      if (!pgliteReady) return;
+      await dbWrite.execute(`DELETE FROM redeemable_earnings_ledger;`);
+      await dbWrite.execute(`DELETE FROM redeemable_earnings;`);
+      await dbWrite.execute(
+        `INSERT INTO redeemable_earnings
+          (user_id, total_earned, available_balance, earned_from_creator_shares)
+         VALUES ('${USER_ID}', '5', '5', '5');`,
+      );
+
+      const result = await redeemableEarningsService.reduceEarnings({
+        userId: USER_ID,
+        amount: 8,
+        source: "creator_revenue_share",
+        sourceId: "stripe-connect:payout:guarded-short-balance",
+        description: "Stripe Connect fiat payout",
+        requireSufficientBalance: true,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Insufficient redeemable balance");
+      expect(result.newBalance).toBe(5);
+      expect(result.ledgerEntryId).toBe("");
+
+      const earnings = await dbWrite.execute(
+        `SELECT available_balance FROM redeemable_earnings WHERE user_id = '${USER_ID}';`,
+      );
+      const ledger = await dbWrite.execute(
+        `SELECT count(*)::int AS n FROM redeemable_earnings_ledger WHERE user_id = '${USER_ID}';`,
+      );
+      expect(
+        Number((earnings.rows[0] as { available_balance: string }).available_balance),
+      ).toBeCloseTo(5, 4);
+      expect((ledger.rows[0] as { n: number }).n).toBe(0);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "default reconciliation mode keeps legacy floor-to-zero behavior",
+    async () => {
+      if (!pgliteReady) return;
+      await dbWrite.execute(`DELETE FROM redeemable_earnings_ledger;`);
+      await dbWrite.execute(`DELETE FROM redeemable_earnings;`);
+      await dbWrite.execute(
+        `INSERT INTO redeemable_earnings
+          (user_id, total_earned, available_balance, earned_from_creator_shares)
+         VALUES ('${USER_ID}', '5', '5', '5');`,
+      );
+
+      const result = await redeemableEarningsService.reduceEarnings({
+        userId: USER_ID,
+        amount: 8,
+        source: "creator_revenue_share",
+        sourceId: "reconciliation:legacy-floor",
+        description: "Reconciliation adjustment",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.newBalance).toBe(0);
+      expect(result.ledgerEntryId).not.toBe("");
+
+      const earnings = await dbWrite.execute(
+        `SELECT available_balance FROM redeemable_earnings WHERE user_id = '${USER_ID}';`,
+      );
+      const ledger = await dbWrite.execute(
+        `SELECT count(*)::int AS n FROM redeemable_earnings_ledger WHERE user_id = '${USER_ID}' AND entry_type = 'adjustment';`,
+      );
+      expect(
+        Number((earnings.rows[0] as { available_balance: string }).available_balance),
+      ).toBeCloseTo(0, 4);
+      expect((ledger.rows[0] as { n: number }).n).toBe(1);
     },
     PGLITE_TIMEOUT,
   );

--- a/packages/cloud/shared/src/lib/services/redeemable-earnings.ts
+++ b/packages/cloud/shared/src/lib/services/redeemable-earnings.ts
@@ -366,13 +366,31 @@ class RedeemableEarningsService {
     sourceId: string;
     description: string;
     metadata?: Record<string, unknown>;
+    /**
+     * When true, the debit FAILS CLOSED (success:false, no write) if the
+     * locked `available_balance` is < amount, instead of flooring the balance
+     * to 0 and reporting success. Required for real money-out debits (Stripe
+     * Connect payout) so a stale pre-check, a concurrent double-submit, or
+     * read-replica lag can never transfer more than the user actually has.
+     * Default false preserves the flooring reconciliation behavior for
+     * internal callers.
+     */
+    requireSufficientBalance?: boolean;
   }): Promise<{
     success: boolean;
     newBalance: number;
     ledgerEntryId: string;
     error?: string;
   }> {
-    const { userId, amount, source, sourceId, description, metadata = {} } = params;
+    const {
+      userId,
+      amount,
+      source,
+      sourceId,
+      description,
+      metadata = {},
+      requireSufficientBalance = false,
+    } = params;
 
     if (amount <= 0) {
       return {
@@ -409,6 +427,24 @@ class RedeemableEarningsService {
           earnings: null,
           ledgerEntryId: "",
           skipped: true,
+          insufficient: false,
+          currentBalance: 0,
+        };
+      }
+
+      // Fail-closed money-out guard (computed under the row lock, on the
+      // primary): never floor-and-pass when the caller requires the full
+      // amount to be debitable.
+      if (
+        requireSufficientBalance &&
+        new Decimal(earnings.available_balance).lessThan(amount)
+      ) {
+        return {
+          earnings: null,
+          ledgerEntryId: "",
+          skipped: false,
+          insufficient: true,
+          currentBalance: Number(earnings.available_balance),
         };
       }
 
@@ -458,8 +494,19 @@ class RedeemableEarningsService {
         earnings: updated,
         ledgerEntryId: ledgerEntry.id,
         skipped: false,
+        insufficient: false,
+        currentBalance: 0,
       };
     });
+
+    if (result.insufficient) {
+      return {
+        success: false,
+        newBalance: result.currentBalance,
+        ledgerEntryId: "",
+        error: "Insufficient redeemable balance",
+      };
+    }
 
     if (result.skipped) {
       logger.info("[RedeemableEarnings] No earnings to reduce (user has no record)", {


### PR DESCRIPTION
## Problem (found by the cloud deep-scan; adversarially verified — money-out)

`POST /api/v1/earnings/payout/stripe-connect/transfer` debits the creator's redeemable balance with **`reduceEarnings()`**, a *flooring* reconciliation primitive: it sets `available_balance = GREATEST(0, balance - amount)` and **returns `success` even when it debited less than `amount`**. The only balance guard is a `getBalance()` pre-check that reads the **replica** (`dbRead`) **outside** the debit transaction. So the debit can never fail closed:

- **Double-submit:** two near-simultaneous admin transfers (distinct idempotency keys) both pass the stale pre-check, both floor `balance→0` and "succeed", and Stripe doesn't dedupe distinct keys → **2× fiat for 1× earned**.
- **Replica lag:** primary already `$0` (e.g. a redemption just locked it) → stale pre-check passes → floor `0→0` "succeeds" → full fiat settles for `$0` of real balance.
- The failure-compensation re-credited the **full** `amount` even when only a floored partial was actually debited.

Admin-gated (`requireAdmin`), so not externally exploitable — but it's real platform funds and the balance invariant is silently violated under normal prod states (replica lag, ops double-click).

## Fix
`reduceEarnings({ requireSufficientBalance: true })` — under the **existing** per-user advisory lock + `SELECT … FOR UPDATE` on the **primary**, fail closed (`success:false`, no write) when `available_balance < amount`. The payout route passes it; mirrors the proven `lockForRedemption` guard. On success **exactly `amount`** is debited, so the existing compensation re-credit is exact too. `default false` preserves flooring behavior for internal reconciliation callers.

## Files
- `redeemable-earnings.ts` — opt-in `requireSufficientBalance` (checked under the row lock).
- `…/stripe-connect/transfer/route.ts` — pass `requireSufficientBalance: true`.

**Money path — your review/merge, not self-merged.**