### PR TITLE
fix(cloud): refund credit reservation on /v1/chat stream provider error

### DIFF
--- a/packages/cloud/api/__tests__/chat-stream-credit-leak.test.ts
+++ b/packages/cloud/api/__tests__/chat-stream-credit-leak.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Money-leak reproduction test for POST /api/v1/chat streaming.
+ *
+ * The route reserves credits before forwarding to the model provider. AI SDK
+ * provider failures during streaming call streamText.onError, not onFinish or
+ * onAbort. This drives the real Hono route with mocked auth/provider seams and
+ * a real credit-reservation settler, proving onError releases the upfront hold.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const aiActual = require("ai") as Record<string, unknown>;
+const languageModelActual = await import("@/lib/providers/language-model");
+
+const ORG = "00000000-0000-4000-8000-0000000000cc";
+const USER = "00000000-0000-4000-8000-0000000000dd";
+
+let streamTextImpl: ((config: Record<string, unknown>) => unknown) | null =
+  null;
+const streamText = mock((config: Record<string, unknown>) => {
+  if (!streamTextImpl) throw new Error("streamTextImpl not set");
+  return streamTextImpl(config);
+});
+
+mock.module("ai", () => ({
+  ...aiActual,
+  convertToModelMessages: mock(async (messages: unknown) => messages),
+  streamText,
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  getCurrentUser: mock(async () => ({ id: USER, organization_id: ORG })),
+}));
+
+mock.module("@/lib/auth-anonymous", () => ({
+  checkAnonymousLimit: mock(),
+  getAnonymousUser: mock(),
+}));
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+
+mock.module("@/lib/models", () => ({
+  resolveModel: () => ({ modelId: "openai/gpt-oss-120b", provider: "openai" }),
+}));
+
+mock.module("@/lib/providers/language-model", () => ({
+  ...languageModelActual,
+  getAiProviderConfigurationError: () => "AI services are not configured",
+  getLanguageModel: () => ({}) as never,
+  hasLanguageModelProviderConfigured: () => true,
+}));
+
+mock.module("@/lib/services/content-moderation", () => ({
+  contentModerationService: {
+    moderateInBackground: mock(),
+    shouldBlockUser: mock(async () => false),
+  },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    error: mock(),
+    info: mock(),
+    warn: mock(),
+  },
+}));
+
+class TestInsufficientCreditsError extends Error {}
+
+function makeLedgerReservation(startBalance: number, hold: number) {
+  let balance = startBalance - hold;
+  let reconcileCalls = 0;
+  return {
+    startBalance,
+    hold,
+    get balance() {
+      return balance;
+    },
+    get reconcileCalls() {
+      return reconcileCalls;
+    },
+    reservation: {
+      reservedAmount: hold,
+      reconcile: async (actualCost: number) => {
+        reconcileCalls++;
+        balance += hold - actualCost;
+        return null;
+      },
+    },
+  };
+}
+
+let ledger = makeLedgerReservation(100, 0.015);
+
+mock.module("@/lib/services/credits", () => ({
+  creditsService: {
+    createAnonymousReservation: mock(
+      () => makeLedgerReservation(0, 0).reservation,
+    ),
+    reserve: mock(async () => ledger.reservation),
+  },
+  InsufficientCreditsError: TestInsufficientCreditsError,
+}));
+
+const { default: chatRoute } = await import("../v1/chat/route");
+
+afterAll(() => {
+  mock.module("ai", () => aiActual);
+  mock.module("@/lib/providers/language-model", () => languageModelActual);
+});
+
+beforeEach(() => {
+  ledger = makeLedgerReservation(100, 0.015);
+  streamText.mockClear();
+  streamTextImpl = null;
+});
+
+describe("/v1/chat streaming credit reservation", () => {
+  test("provider onError releases the hold and a later abort cannot double-refund", async () => {
+    expect(ledger.balance).toBeCloseTo(ledger.startBalance - ledger.hold, 10);
+
+    let onErrorPromise: Promise<unknown> | undefined;
+    let capturedConfig: Record<string, unknown> | undefined;
+    streamTextImpl = (config) => {
+      capturedConfig = config;
+      const onError = config.onError as
+        | ((event: { error: unknown }) => Promise<unknown>)
+        | undefined;
+      onErrorPromise = Promise.resolve(
+        onError?.({ error: new Error("provider returned 503") }),
+      );
+      return {
+        toUIMessageStreamResponse: () => new Response("stream-started"),
+      };
+    };
+
+    const response = await chatRoute.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    await onErrorPromise;
+
+    expect(ledger.reconcileCalls).toBe(1);
+    expect(ledger.balance).toBeCloseTo(ledger.startBalance, 10);
+
+    const onAbort = capturedConfig?.onAbort as
+      | (() => Promise<unknown>)
+      | undefined;
+    await onAbort?.();
+    expect(ledger.reconcileCalls).toBe(1);
+    expect(ledger.balance).toBeCloseTo(ledger.startBalance, 10);
+  });
+});

--- a/packages/cloud/api/v1/chat/route.ts
+++ b/packages/cloud/api/v1/chat/route.ts
@@ -514,6 +514,20 @@ app.post("/", async (c) => {
           model: selectedModel,
         });
       },
+      // A provider error during streaming (e.g. cerebras 429/5xx) fires onError
+      // — NOT onFinish or onAbort — so without this the upfront credit
+      // reservation is never reconciled and the paying user is billed ~1.5x the
+      // estimate for zero output. Mirrors v1/messages and v1/chat/completions.
+      // The settler is idempotent (first-call-wins), so this cannot
+      // double-refund if onFinish/onAbort also fire.
+      onError: async ({ error }: { error: unknown }) => {
+        await settleReservation?.(0);
+        logger.error("chat-api", "Stream provider error — reservation refunded", {
+          userId: user.id,
+          model: selectedModel,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      },
     });
 
     return result.toUIMessageStreamResponse();

--- a/packages/cloud/api/v1/chat/route.ts
+++ b/packages/cloud/api/v1/chat/route.ts
@@ -522,11 +522,15 @@ app.post("/", async (c) => {
       // double-refund if onFinish/onAbort also fire.
       onError: async ({ error }: { error: unknown }) => {
         await settleReservation?.(0);
-        logger.error("chat-api", "Stream provider error — reservation refunded", {
-          userId: user.id,
-          model: selectedModel,
-          error: error instanceof Error ? error.message : String(error),
-        });
+        logger.error(
+          "chat-api",
+          "Stream provider error — reservation refunded",
+          {
+            userId: user.id,
+            model: selectedModel,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
       },
     });
 


### PR DESCRIPTION
## Problem (deep-scan; adversarially verified — money/over-charge)

`/v1/chat` takes a **real ~1.5× upfront credit debit** (`creditsService.reserve`) and only settles it from `onFinish` / `onAbort` / the outer try-catch. But a provider error mid-stream (cerebras 429/5xx fail-fast) fires the AI SDK's **`onError`** — *not* `onFinish` or `onAbort` — and the outer try-catch can't catch it (the error is async inside the already-returned stream). The `streamText` config had **no `onError`**, so the upfront hold leaked: **every paying user whose stream hits a provider error is charged ~1.5× the estimate for zero output**, silently, no refund.

The two sibling routes (`v1/messages:988`, `v1/chat/completions:1443`) already added `onError → settleReservation(0)` with comments explaining exactly this. This route was missed.

## Fix
Add the same `onError` handler. The settler is idempotent (first-call-wins) so it can't double-refund if `onFinish`/`onAbort` also fire. One file, mirrors proven sibling code.