### PR TITLE
test(chat-ux): real-overlay gesture e2e + CI wire + render-parity guard (#9954)

### DIFF
--- a/.github/workflows/chat-shell-gestures.yml
+++ b/.github/workflows/chat-shell-gestures.yml
@@ -103,6 +103,12 @@ jobs:
       - name: TopicGroup gesture e2e
         run: bun run --cwd packages/ui test:chatux-gesture-e2e
 
+      # Perf gate: drive the overlay under scroll + swipe, feed real
+      # PerformanceObserver + rAF entries into the shared frame-budget +
+      # layout-stability detectors, hard-fail on dropped-frame % / p95 / CLS.
+      - name: Chat overlay perf gate
+        run: bun run --cwd packages/ui test:chat-perf-gate
+
       - name: Upload gesture videos + screenshots
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
@@ -112,5 +118,6 @@ jobs:
             packages/ui/src/components/shell/__e2e__/output-conversation-swipe/
             packages/ui/src/components/shell/__e2e__/output/
             packages/ui/src/components/shell/__e2e__/output-chatux/
+            packages/ui/src/components/shell/__e2e__/output-perf-gate/
           if-no-files-found: warn
           retention-days: 14

--- a/.github/workflows/chat-shell-gestures.yml
+++ b/.github/workflows/chat-shell-gestures.yml
@@ -1,0 +1,116 @@
+name: Chat shell gestures
+
+# Real-browser gesture + interleaving e2e for the floating chat shell
+# (packages/ui ContinuousChatOverlay), plus the component-tree render-parity
+# contract. Before #9954 these runners (run-conversation-swipe-e2e,
+# run-chat-sheet-e2e, run-chatux-gesture-e2e) were wired to NO workflow and ran
+# only by hand, so swipe-nav / sheet-detent / topic-gesture regressions could
+# ship silently. This lane drives the REAL overlay with real pointer gestures in
+# headless chromium and the render-parity contract under vitest.
+#
+# Path-gated to packages/ui (and its UI deps) so it only runs when the surface
+# it covers actually changes. The e2e runners bundle the fixtures with esbuild
+# and stub @elizaos/core, so no core build is needed; the render-parity vitest
+# imports the real @elizaos/core, so the shared i18n data is generated first.
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - ".github/workflows/chat-shell-gestures.yml"
+      - "package.json"
+      - "bun.lock"
+      - "packages/ui/**"
+      - "packages/shared/**"
+      - "packages/core/src/i18n/**"
+  push:
+    branches: [main, develop]
+    paths:
+      - ".github/workflows/chat-shell-gestures.yml"
+      - "package.json"
+      - "bun.lock"
+      - "packages/ui/**"
+      - "packages/shared/**"
+      - "packages/core/src/i18n/**"
+  workflow_dispatch:
+
+concurrency:
+  group: chat-shell-gestures-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CI: "true"
+  BUN_VERSION: "canary"
+  NODE_VERSION: "24.15.0"
+  NODE_NO_WARNINGS: "1"
+
+jobs:
+  chat-shell-gestures:
+    name: Chat shell gesture + parity e2e
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          install-command: bun install --ignore-scripts --no-frozen-lockfile
+          install-native-deps: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      # The render-parity contract imports the real @elizaos/core, whose i18n
+      # module loads generated keyword data that is gitignored. Generate it so
+      # the vitest run resolves (mirrors the attachment-journey-videos lane).
+      - name: Ensure generated shared i18n data
+        run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
+
+      - name: Install Playwright chromium
+        run: bunx playwright install --with-deps chromium
+
+      # Component-tree render parity (jsdom/vitest) — ThreadLine vs MessageContent
+      # render the same structure for a shared message corpus.
+      - name: Render-parity contract
+        run: bun run --cwd packages/ui test -- src/components/chat/render-parity.contract.test.tsx
+
+      # Conversation-nav interleaving fuzz (jsdom) — the pure most-recent-first
+      # invariants across swipe / new / select sequences (#10042).
+      - name: Conversation-nav unit + interleaving
+        run: bun run --cwd packages/ui test -- src/components/shell/conversation-nav.test.ts src/hooks/useConversationSwipeJank.test.ts
+
+      # Real-overlay conversation-swipe interleaving (headless chromium, real
+      # pointer gestures): swipe-back → new → swipe-forward → new → forward →
+      # swipe-back with per-step interleaving invariants + swipe-jank telemetry.
+      - name: Conversation-swipe interleaving e2e
+        run: bun run --cwd packages/ui test:conversation-swipe-e2e
+
+      # The iOS-style chat-sheet detent/gesture state machine (mouse + touch).
+      - name: Chat-sheet gesture e2e
+        run: bun run --cwd packages/ui test:chat-sheet-e2e
+
+      # TopicGroup flick-collapse/expand gestures.
+      - name: TopicGroup gesture e2e
+        run: bun run --cwd packages/ui test:chatux-gesture-e2e
+
+      - name: Upload gesture videos + screenshots
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: chat-shell-gesture-artifacts
+          path: |
+            packages/ui/src/components/shell/__e2e__/output-conversation-swipe/
+            packages/ui/src/components/shell/__e2e__/output/
+            packages/ui/src/components/shell/__e2e__/output-chatux/
+          if-no-files-found: warn
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -1500,6 +1500,10 @@ waifu.fun/
 
 # chat-ux gesture e2e generated artifacts (video + screenshots)
 /packages/ui/src/components/shell/__e2e__/output-chatux/
+# conversation-swipe interleaving e2e artifacts (video + screenshots)
+/packages/ui/src/components/shell/__e2e__/output-conversation-swipe/
+# chat overlay perf-gate artifacts (final screenshot)
+/packages/ui/src/components/shell/__e2e__/output-perf-gate/
 railway.json
 .railwayignore
 .dockerignore

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -35,6 +35,7 @@
     "test:agent-surface-e2e": "bun run --cwd ../.. packages/ui/src/agent-surface/__e2e__/run-e2e.mjs",
     "test:chat-sheet-e2e": "bun run --cwd ../.. packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs",
     "test:chatux-gesture-e2e": "bun run --cwd ../.. packages/ui/src/components/shell/__e2e__/run-chatux-gesture-e2e.mjs",
+    "test:conversation-swipe-e2e": "bun run --cwd ../.. packages/ui/src/components/shell/__e2e__/run-conversation-swipe-e2e.mjs",
     "test:home-screen-e2e": "bun run --cwd ../.. packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs",
     "test:tutorial-e2e": "bun run --cwd ../.. packages/ui/src/components/pages/tutorial/__e2e__/run-tutorial-e2e.mjs",
     "test:onboarding-e2e": "bun run --cwd ../.. packages/ui/src/first-run/__e2e__/run-onboarding-e2e.mjs",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -36,6 +36,7 @@
     "test:chat-sheet-e2e": "bun run --cwd ../.. packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs",
     "test:chatux-gesture-e2e": "bun run --cwd ../.. packages/ui/src/components/shell/__e2e__/run-chatux-gesture-e2e.mjs",
     "test:conversation-swipe-e2e": "bun run --cwd ../.. packages/ui/src/components/shell/__e2e__/run-conversation-swipe-e2e.mjs",
+    "test:chat-perf-gate": "bun run --cwd ../.. packages/ui/src/components/shell/__e2e__/run-chat-perf-gate.mjs",
     "test:home-screen-e2e": "bun run --cwd ../.. packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs",
     "test:tutorial-e2e": "bun run --cwd ../.. packages/ui/src/components/pages/tutorial/__e2e__/run-tutorial-e2e.mjs",
     "test:onboarding-e2e": "bun run --cwd ../.. packages/ui/src/first-run/__e2e__/run-onboarding-e2e.mjs",

--- a/packages/ui/src/components/chat/render-parity.contract.test.tsx
+++ b/packages/ui/src/components/chat/render-parity.contract.test.tsx
@@ -1,0 +1,255 @@
+// @vitest-environment jsdom
+//
+// Component-tree render-parity contract (#9954).
+//
+// The chat thread renders through TWO React trees: the overlay
+// (ContinuousChatOverlay → ThreadLine → InlineWidgetText) and the full ChatView
+// (ChatTranscript → MessageContent). The PARSER layer is already deduped + pinned
+// (parser-parity.contract.test.ts, #9304) — both call the same `parseSegments`.
+// This contract guards the layer ABOVE the parser: that the two component trees
+// emit the SAME interactive-widget / code-block / reasoning / secret-request
+// STRUCTURE for a shared message corpus. If a future edit to either tree adds,
+// drops, or diverges a structural affordance, this fails.
+//
+// It is structural, not pixel-level: the two surfaces legitimately differ in
+// chrome (bubble glass vs flat row), animation, and the press-and-hold copy
+// affordance. What must NOT diverge is which rich blocks render — a code block
+// on one surface and leaked ``` text on the other, or a widget on one and a raw
+// `[CHOICE]` marker on the other, is exactly the drift this catches.
+
+import { cleanup, render } from "@testing-library/react";
+import type * as React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  ConversationMessage,
+  ConversationSecretRequest,
+} from "../../api/client-types-chat";
+import { __setAppValueForTests } from "../../state/app-store";
+import { AppContext } from "../../state/useApp";
+import type { ShellMessage } from "../shell/shell-state";
+
+vi.mock("@elizaos/ui", () => ({
+  useAgentElement: () => ({ ref: { current: null }, agentProps: {} }),
+}));
+
+const { clientMock } = vi.hoisted(() => ({
+  clientMock: {
+    getPermission: vi.fn().mockResolvedValue({
+      id: "reminders",
+      status: "not-determined",
+      lastChecked: 0,
+      canRequest: true,
+      platform: "darwin",
+    }),
+    getPlugins: vi.fn().mockResolvedValue([]),
+    openPermissionSettings: vi.fn(),
+    requestPermission: vi.fn(),
+    updatePlugin: vi.fn(),
+    startLocalInferenceDownload: vi.fn(),
+  },
+}));
+vi.mock("../../api/client", () => ({ client: clientMock }));
+
+// MessageContent (ChatView path) and ThreadLine (overlay path) both render real
+// inline widgets; import them after the mocks are in place.
+import { MessageContent } from "./MessageContent";
+import { __renderThreadLineForParity } from "../shell/ContinuousChatOverlay";
+// Side effect: register the built-in inline widgets so both surfaces resolve them.
+import "./widgets/inline-builtins";
+import { registerTaskWidget } from "./widgets/task-widget";
+
+registerTaskWidget();
+
+function withApp(node: React.ReactElement) {
+  const appValue = {
+    t: (key: string, vars?: Record<string, unknown>) =>
+      String(vars?.defaultValue ?? key),
+    loadPlugins: vi.fn(() => Promise.resolve()),
+    sendActionMessage: vi.fn(),
+    setActionNotice: vi.fn(),
+    setTab: vi.fn(),
+    handleChatRetry: vi.fn(),
+  } as never;
+  __setAppValueForTests(appValue);
+  return render(<AppContext.Provider value={appValue}>{node}</AppContext.Provider>);
+}
+
+/**
+ * The structural fingerprint of a rendered message: which rich, interactive
+ * affordances the tree emitted. Both render paths must produce the SAME set for
+ * a given message — that's the parity invariant. Chrome/animation/copy
+ * affordances are deliberately excluded (they legitimately differ).
+ */
+interface StructuralFingerprint {
+  hasChoiceWidget: boolean;
+  choiceOptionValues: string[];
+  hasCodeBlock: boolean;
+  codeBlockCount: number;
+  hasSecretRequest: boolean;
+  hasReasoning: boolean;
+  hasNoProviderGate: boolean;
+}
+
+function fingerprint(root: HTMLElement): StructuralFingerprint {
+  const choiceOptions = Array.from(
+    root.querySelectorAll('[data-testid^="choice-"]'),
+  )
+    .map((el) => el.getAttribute("data-testid") ?? "")
+    .filter((id) => id.startsWith("choice-") && !id.startsWith("choice-custom"))
+    .sort();
+  const codeBlocks = root.querySelectorAll('[data-testid="code-block"]');
+  // The reasoning block (ThinkingBlock) has no testid; it is the accent-bordered
+  // disclosure whose toggle includes the label "Thinking" (alongside a chevron
+  // glyph). Detect it structurally.
+  const hasReasoning = Array.from(root.querySelectorAll("button")).some((b) =>
+    b.textContent?.includes("Thinking"),
+  );
+  // The no_provider recovery gate renders the literal "Connect a provider to
+  // chat" heading on both surfaces.
+  const hasNoProviderGate = root.textContent?.includes(
+    "Connect a provider to chat",
+  );
+  return {
+    hasChoiceWidget: choiceOptions.length > 0,
+    choiceOptionValues: choiceOptions,
+    hasCodeBlock: codeBlocks.length > 0,
+    codeBlockCount: codeBlocks.length,
+    hasSecretRequest:
+      root.querySelector('[data-testid="sensitive-request"]') !== null,
+    hasReasoning,
+    hasNoProviderGate: Boolean(hasNoProviderGate),
+  };
+}
+
+function toShellMessage(m: ConversationMessage): ShellMessage {
+  return {
+    id: m.id,
+    role: m.role,
+    content: m.text,
+    createdAt: m.timestamp,
+    ...(m.reasoning ? { reasoning: m.reasoning } : {}),
+    ...(m.failureKind ? { failureKind: m.failureKind } : {}),
+    ...(m.secretRequest ? { secretRequest: m.secretRequest } : {}),
+  };
+}
+
+const SECRET_REQUEST: ConversationSecretRequest = {
+  key: "OPENAI_API_KEY",
+  reason: "to call the model",
+  status: "pending",
+};
+
+let nextId = 0;
+function assistant(
+  text: string,
+  extra: Partial<ConversationMessage> = {},
+): ConversationMessage {
+  nextId += 1;
+  return {
+    id: `msg-${nextId}`,
+    role: "assistant",
+    text,
+    timestamp: nextId,
+    ...extra,
+  };
+}
+
+// A shared corpus exercising every structural affordance both surfaces render.
+const CORPUS: Array<{ name: string; message: ConversationMessage }> = [
+  { name: "plain prose", message: assistant("Just a normal reply, nothing rich.") },
+  {
+    name: "fenced code block",
+    message: assistant("Here is the patch:\n```ts\nconst x = 1;\n```\nApply it."),
+  },
+  {
+    name: "two code blocks",
+    message: assistant(
+      "First:\n```sh\nbun install\n```\nThen:\n```sh\nbun run build\n```",
+    ),
+  },
+  {
+    name: "choice widget",
+    message: assistant(
+      "Pick a plan:\n[CHOICE:plan]\nfree=Free\npro=Pro\n[/CHOICE]",
+    ),
+  },
+  {
+    name: "prose + code + choice together",
+    message: assistant(
+      "Run this:\n```sh\nbun run dev\n```\nThen choose:\n[CHOICE:env]\nlocal=Local\ncloud=Cloud\n[/CHOICE]",
+    ),
+  },
+  {
+    name: "reasoning block (multi-segment)",
+    // Reasoning renders alongside rich segments on both surfaces; a code block
+    // makes the message multi-segment so MessageContent's reasoning branch (not
+    // its single-text fast path) runs — the apples-to-apples reasoning case.
+    message: assistant("The answer is:\n```txt\n42\n```", {
+      reasoning: "I considered several options and settled on 42.",
+    }),
+  },
+  {
+    name: "reasoning + code",
+    message: assistant("Use this:\n```py\nprint(42)\n```", {
+      reasoning: "Python is the simplest demonstration here.",
+    }),
+  },
+  {
+    name: "secret request",
+    message: assistant("I need a key to continue.", {
+      secretRequest: SECRET_REQUEST,
+    }),
+  },
+  {
+    name: "no_provider failure gate",
+    message: assistant("No model provider is configured.", {
+      failureKind: "no_provider",
+    }),
+  },
+];
+
+describe("chat render parity (ThreadLine vs MessageContent) — #9954", () => {
+  beforeEach(() => {
+    clientMock.getPlugins.mockResolvedValue([]);
+  });
+  afterEach(() => {
+    cleanup();
+    __setAppValueForTests(null);
+    vi.clearAllMocks();
+  });
+
+  for (const { name, message } of CORPUS) {
+    it(`renders the same structure on both surfaces: ${name}`, () => {
+      const view = withApp(<MessageContent message={message} />);
+      const viewPrint = fingerprint(view.container);
+      cleanup();
+
+      const overlay = withApp(
+        __renderThreadLineForParity(toShellMessage(message)),
+      );
+      const overlayPrint = fingerprint(overlay.container);
+
+      expect(overlayPrint).toEqual(viewPrint);
+    });
+  }
+
+  it("the corpus actually exercises every affordance (guards against an empty/no-op parity check)", () => {
+    const seen = new Set<string>();
+    for (const { message } of CORPUS) {
+      const view = withApp(<MessageContent message={message} />);
+      const fp = fingerprint(view.container);
+      if (fp.hasChoiceWidget) seen.add("choice");
+      if (fp.hasCodeBlock) seen.add("code");
+      if (fp.hasReasoning) seen.add("reasoning");
+      if (fp.hasSecretRequest) seen.add("secret");
+      if (fp.hasNoProviderGate) seen.add("no-provider");
+      cleanup();
+    }
+    // If the corpus stopped covering an affordance the parity check would pass
+    // trivially — assert all five rich structures actually appear.
+    expect([...seen].sort()).toEqual(
+      ["choice", "code", "no-provider", "reasoning", "secret"].sort(),
+    );
+  });
+});

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -44,6 +44,7 @@ import {
   TUTORIAL_CHAT_CONTROL_EVENT,
   type TutorialChatControlDetail,
 } from "../../events";
+import { useConversationSwipeJank } from "../../hooks/useConversationSwipeJank";
 import {
   LAYOUT_SHIFT_INTENT_ATTR,
   LAYOUT_SHIFT_INTENT_TRANSIENT,
@@ -1057,14 +1058,27 @@ export function ContinuousChatOverlay({
   // capture until a horizontal commit, so vertical thread scrolling is
   // unaffected; it is only bound while the sheet is open (below).
   const [swipeDx, setSwipeDx] = React.useState(0);
+  // Frame-budget telemetry scoped to the swipe gesture (#9954): begin sampling
+  // on the first live drag and flush a dropped-frame/p95/fps summary into the
+  // telemetry ring on release, so swipe jank is observable without the dev HUD.
+  const swipeJank = useConversationSwipeJank();
   const conversationSwipe = usePullGesture({
-    onDragX: setSwipeDx,
+    onDragX: (dx) => {
+      // A non-zero offset means the gesture is actively dragging; 0 is the
+      // settle/cancel reset the gesture emits on release. `begin` is idempotent,
+      // so calling it every frame only starts one sampling window per gesture.
+      if (dx !== 0) swipeJank.begin();
+      else swipeJank.end();
+      setSwipeDx(dx);
+    },
     onSwipeLeft: () => {
       setSwipeDx(0);
+      swipeJank.end();
       conversationNav.goNext();
     },
     onSwipeRight: () => {
       setSwipeDx(0);
+      swipeJank.end();
       conversationNav.goPrev();
     },
   });

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -1006,6 +1006,26 @@ const ThreadLine = React.memo(function ThreadLine({
   );
 });
 
+/**
+ * Render a settled `ThreadLine` exactly as the overlay does (floating, with copy
+ * + settings handlers, reasoning shown). Test-only seam for the component-tree
+ * render-parity contract (render-parity.contract.test.tsx, #9954), which diffs
+ * this surface's structure against ChatView's MessageContent over a shared
+ * corpus. Not part of the public overlay API — keep usage to that contract.
+ */
+export function __renderThreadLineForParity(
+  message: ShellMessage,
+): React.JSX.Element {
+  return (
+    <ThreadLine
+      message={message}
+      floating
+      onCopy={() => {}}
+      onOpenSettings={() => {}}
+    />
+  );
+}
+
 export function ContinuousChatOverlay({
   controller,
   agentName = "Eliza",

--- a/packages/ui/src/components/shell/__e2e__/chatux-gesture-fixture.tsx
+++ b/packages/ui/src/components/shell/__e2e__/chatux-gesture-fixture.tsx
@@ -1,20 +1,23 @@
 /**
- * Fixture for the chat-UX gesture e2e (#8928, #8929). Renders the three new,
- * gesture-driven surfaces standalone so a headless browser can drive REAL
- * pointer gestures against them and record a video:
+ * Fixture for the chat-UX TopicGroup gesture e2e (#8928). Renders the
+ * gesture-driven TopicGroup standalone so a headless browser can drive REAL
+ * pointer gestures against it and record a video:
  *
- *   - TopicGroup    — flick UP on the header collapses to a pill; tap the pill
- *                     (or flick DOWN) expands. NO visible buttons.
- *   - ConversationSwiper — a horizontal swipe between adjacent conversations,
- *                     using the same usePullGesture deltaX/onSwipeLeft/onSwipeRight
- *                     the overlay binds (sheet-open only) in production.
+ *   - TopicGroup — flick UP on the header collapses to a pill; tap the pill
+ *                  (or flick DOWN) expands. NO visible buttons.
+ *
+ * Conversation-swipe coverage lives in conversation-swipe-fixture.tsx, which
+ * mounts the REAL ContinuousChatOverlay. The local `ConversationSwiper` mock that
+ * used to live here (a hardcoded array + its own useState(index), sharing only
+ * usePullGesture, not the real overlay/nav/async-create path) was DELETED in
+ * #9954 — it gave false confidence by passing while exercising none of the real
+ * conversation-nav code.
  */
 
 import * as React from "react";
 import { createRoot } from "react-dom/client";
 import { TopicChipsBar } from "../TopicChipsBar";
 import { TopicGroup } from "../TopicGroup";
-import { usePullGesture } from "../use-pull-gesture";
 
 function Bubbles({ lines }: { lines: string[] }): React.JSX.Element {
   return (
@@ -54,61 +57,6 @@ function InteractiveTopicGroup(): React.JSX.Element {
   );
 }
 
-/**
- * A minimal conversation swiper mirroring the overlay wiring: the live deltaX
- * drives an edge hint, a committed swipe steps to the adjacent conversation.
- */
-function ConversationSwiper(): React.JSX.Element {
-  const conversations = ["Today's standup", "Billing thread", "Deploy incident"];
-  const [index, setIndex] = React.useState(0);
-  const [dx, setDx] = React.useState(0);
-  const gesture = usePullGesture({
-    onDragX: setDx,
-    onSwipeLeft: () => {
-      setDx(0);
-      setIndex((i) => Math.min(conversations.length - 1, i + 1));
-    },
-    onSwipeRight: () => {
-      setDx(0);
-      setIndex((i) => Math.max(0, i - 1));
-    },
-  });
-  return (
-    <div
-      data-testid="conversation-swiper"
-      {...gesture}
-      className="relative flex h-40 touch-pan-y select-none items-center justify-center overflow-hidden rounded-2xl border border-white/10 bg-white/5"
-    >
-      {dx < 0 && index > 0 ? (
-        <div
-          data-testid="swipe-hint-left"
-          className="pointer-events-none absolute inset-y-0 left-0 w-16 bg-gradient-to-r from-white/25 to-transparent"
-          style={{ opacity: Math.min(1, -dx / 96) }}
-        />
-      ) : null}
-      {dx > 0 && index < conversations.length - 1 ? (
-        <div
-          data-testid="swipe-hint-right"
-          className="pointer-events-none absolute inset-y-0 right-0 w-16 bg-gradient-to-l from-white/25 to-transparent"
-          style={{ opacity: Math.min(1, dx / 96) }}
-        />
-      ) : null}
-      <div className="text-center">
-        <div className="text-[10px] uppercase tracking-widest text-white/40">
-          conversation {index + 1} / {conversations.length}
-        </div>
-        <div
-          data-testid="active-conversation-title"
-          className="mt-1 text-lg font-medium text-white/90"
-        >
-          {conversations[index]}
-        </div>
-        <div className="mt-1 text-[11px] text-white/40">swipe ← / →</div>
-      </div>
-    </div>
-  );
-}
-
 function App(): React.JSX.Element {
   return (
     <div
@@ -126,7 +74,6 @@ function App(): React.JSX.Element {
       }}
     >
       <InteractiveTopicGroup />
-      <ConversationSwiper />
     </div>
   );
 }

--- a/packages/ui/src/components/shell/__e2e__/conversation-swipe-fixture.tsx
+++ b/packages/ui/src/components/shell/__e2e__/conversation-swipe-fixture.tsx
@@ -1,0 +1,229 @@
+// Fixture for the conversation-swipe interleaving e2e (#9954). Mounts the REAL
+// ContinuousChatOverlay over a STATEFUL controller whose conversation list and
+// active id actually mutate the way the production controller does:
+//
+//   - the list is most-recent-first; a new conversation PREPENDS at index 0 and
+//     becomes active (mirrors handleNewConversation),
+//   - a swipe re-resolves the adjacent conversation through the LATEST state via
+//     buildConversationNav (mirrors useShellController's ref-backed callbacks),
+//   - selectConversation flips the active id.
+//
+// So a headless browser drives the exact swipe-back → new → swipe-forward → new
+// → forward → swipe-back interleaving the issue names, against a live list, and
+// the overlay's data-conversation-id / data-conversation-index attributes report
+// the real navigation state for invariant assertions. The previous fixture's
+// `ConversationSwiper` was a local re-implementation (hardcoded array + its own
+// useState(index)); it is deleted so it can no longer pass for overlay coverage.
+//
+// Paired with run-conversation-swipe-e2e.mjs.
+
+import * as React from "react";
+import { createRoot } from "react-dom/client";
+
+import type { Conversation } from "../../../api/client-types-chat";
+import { MockAppProvider } from "../../../storybook/mock-providers";
+import { readViewInteractions } from "../../../view-telemetry";
+import { ContinuousChatOverlay } from "../ContinuousChatOverlay";
+import { buildConversationNav } from "../conversation-nav";
+import type { ShellMessage } from "../shell-state";
+import type { ConversationNav, ShellController } from "../useShellController";
+
+function conv(id: string, n: number): Conversation {
+  // Newest first, so a higher `n` is a more recent conversation. createdAt is
+  // only cosmetic here; ordering is the array order the harness maintains.
+  const ts = new Date(1_700_000_000_000 + n * 1000).toISOString();
+  return {
+    id,
+    title: id,
+    roomId: `room-${id}`,
+    createdAt: ts,
+    updatedAt: ts,
+  };
+}
+
+// Three seed conversations, most-recent-first: [c3 (newest), c2, c1 (oldest)].
+// Start active on the NEWEST (index 0) so the first "swipe back" toward a newer
+// chat is a boundary no-op — the named sequence starts from index 0.
+const SEED: Conversation[] = [conv("c3", 3), conv("c2", 2), conv("c1", 1)];
+
+// The thread reflects the ACTIVE conversation so the recorded screenshots /
+// video visibly change as the swipe navigates between chats (the invariant
+// assertions read the DOM, but the captured pixels should show the switch too).
+function threadFor(activeId: string): ShellMessage[] {
+  return [
+    {
+      id: `${activeId}-m1`,
+      role: "user",
+      content: `what's the plan in ${activeId}?`,
+      createdAt: 1,
+    },
+    {
+      id: `${activeId}-m2`,
+      role: "assistant",
+      content: `You're viewing conversation ${activeId}. Swipe left for the older chat, right for the newer one.`,
+      createdAt: 2,
+    },
+    { id: `${activeId}-m3`, role: "user", content: "got it", createdAt: 3 },
+  ];
+}
+
+function Harness(): React.JSX.Element {
+  const [conversations, setConversations] =
+    React.useState<Conversation[]>(SEED);
+  const [activeId, setActiveId] = React.useState<string>(SEED[0].id);
+  const [created, setCreated] = React.useState(0);
+
+  // Refs mirror the production controller: a swipe re-resolves through the
+  // LATEST list/active id, never a stale closure captured at render time.
+  const conversationsRef = React.useRef(conversations);
+  const activeIdRef = React.useRef(activeId);
+  conversationsRef.current = conversations;
+  activeIdRef.current = activeId;
+
+  const selectConversation = React.useCallback((id: string) => {
+    setActiveId(id);
+  }, []);
+
+  // Prepend a new conversation at index 0 and activate it (handleNewConversation).
+  const newConversation = React.useCallback(() => {
+    setCreated((n) => {
+      const id = `new-${n}`;
+      const next = conv(id, 100 + n);
+      setConversations((list) => [next, ...list]);
+      setActiveId(id);
+      return n + 1;
+    });
+  }, []);
+
+  // The real swipe callbacks re-resolve adjacent targets through the current
+  // refs (matching useShellController.selectAdjacentConversation), so the overlay
+  // never navigates against a stale index even mid-interleave.
+  const conversationNav = React.useMemo<ConversationNav>(() => {
+    const nav = buildConversationNav(conversations, activeId, selectConversation);
+    return {
+      ...nav,
+      goPrev: () => {
+        const adj = buildConversationNav(
+          conversationsRef.current,
+          activeIdRef.current,
+          selectConversation,
+        );
+        adj.goPrev();
+      },
+      goNext: () => {
+        const adj = buildConversationNav(
+          conversationsRef.current,
+          activeIdRef.current,
+          selectConversation,
+        );
+        adj.goNext();
+      },
+    };
+  }, [conversations, activeId, selectConversation]);
+
+  // Expose test hooks so the runner can drive new-conversation creation and read
+  // the live navigation/telemetry state without reaching into React internals.
+  React.useEffect(() => {
+    const w = window as typeof window & {
+      __convNav?: {
+        newConversation: () => void;
+        select: (id: string) => void;
+        state: () => {
+          activeId: string;
+          index: number;
+          hasPrev: boolean;
+          hasNext: boolean;
+          ids: string[];
+        };
+        swipeJankEvents: () => number;
+      };
+    };
+    w.__convNav = {
+      newConversation,
+      select: selectConversation,
+      state: () => ({
+        activeId,
+        index: conversations.findIndex((c) => c.id === activeId),
+        hasPrev: conversationNav.hasPrev,
+        hasNext: conversationNav.hasNext,
+        ids: conversations.map((c) => c.id),
+      }),
+      swipeJankEvents: () =>
+        readViewInteractions().filter(
+          (e) => e.action === "conversation-swipe-jank",
+        ).length,
+    };
+    return () => {
+      w.__convNav = undefined;
+    };
+  }, [
+    activeId,
+    conversations,
+    conversationNav,
+    newConversation,
+    selectConversation,
+  ]);
+
+  const controller = {
+    phase: "summoned",
+    messages: threadFor(activeId),
+    canSend: true,
+    responding: false,
+    turnStatus: null,
+    recording: false,
+    handsFree: false,
+    transcript: "",
+    speaking: false,
+    agentVoiceMuted: false,
+    needsAudioUnlock: false,
+    modelStatus: { kind: "ready" },
+    conversationNav,
+    conversationLoading: false,
+    send: () => {},
+    toggleRecording: () => {},
+    toggleHandsFree: () => {},
+    setDictationSink: () => {},
+    setTranscriptSessionSink: () => {},
+    setComposerHasDraft: () => {},
+    startRecording: () => {},
+    stopRecording: () => {},
+    toggleAgentVoiceMute: () => {},
+    unlockAudio: () => {},
+    openSettings: () => {},
+    navigateHome: () => {},
+    navigateToViews: () => {},
+    clearConversation: () => {},
+    stop: () => {},
+  } as unknown as ShellController;
+
+  return (
+    <div
+      data-testid="fake-view"
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "#ef5a1f",
+        color: "rgba(255,255,255,0.9)",
+        fontFamily: "ui-sans-serif, system-ui, sans-serif",
+        overflow: "hidden",
+      }}
+    >
+      <div style={{ padding: "40px 24px", maxWidth: 640 }}>
+        <h1 style={{ fontSize: 26, fontWeight: 600, margin: 0 }}>Workspace</h1>
+        <p style={{ opacity: 0.7, marginTop: 10, lineHeight: 1.6 }}>
+          The floating chat below is the REAL ContinuousChatOverlay. Swiping the
+          open thread navigates between live conversations.
+        </p>
+      </div>
+      <ContinuousChatOverlay controller={controller} />
+    </div>
+  );
+}
+
+const root = document.getElementById("root");
+if (root)
+  createRoot(root).render(
+    <MockAppProvider>
+      <Harness />
+    </MockAppProvider>,
+  );

--- a/packages/ui/src/components/shell/__e2e__/run-chat-perf-gate.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-perf-gate.mjs
@@ -1,0 +1,310 @@
+/**
+ * Conversation-overlay PERF GATE (#9954) — headless-Chromium harness that drives
+ * the REAL ContinuousChatOverlay under thread-scroll + repeated conversation
+ * swipes, harvests REAL PerformanceObserver + requestAnimationFrame entries from
+ * the page, feeds them into the SAME shared detectors the dev HUD uses
+ * (frame-budget.ts summarizeFrameSamples + shouldReportFrameBudget, and
+ * layout-stability.ts summarizeStability over real `layout-shift` entries), and
+ * HARD-FAILS on:
+ *   - dropped-frame ratio over threshold,
+ *   - p95 frame time over the budget factor,
+ *   - non-intentional cumulative layout shift (CLS) over budget.
+ *
+ * The detectors are pure + unit-tested; this is the live-surface driver that
+ * feeds them real numbers so a jank/CLS regression fails a build instead of
+ * only blinking in the dev PerfOverlay.
+ *
+ * Run: bun run --cwd packages/ui test:chat-perf-gate
+ * Exits non-zero on any breached threshold or page error.
+ */
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { builtinModules } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { build } from "esbuild";
+import { chromium } from "playwright";
+import {
+  shouldReportFrameBudget,
+  summarizeFrameSamples,
+} from "../../../hooks/frame-budget.ts";
+import {
+  LAYOUT_SHIFT_OBSERVER_INIT,
+  summarizeStability,
+} from "../../../testing/layout-stability.ts";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const outDir = join(here, "output-perf-gate");
+await mkdir(outDir, { recursive: true });
+
+// ── Thresholds. Deliberately not razor-thin so a single unavoidable frame in a
+// CI VM doesn't redden the lane, but tight enough that a real regression
+// (sustained jank, a content reflow during swipe) trips. ───────────────────────
+const FRAME_BUDGET_OPTIONS = {
+  // p95 frame may exceed the 16.67ms 60fps budget by up to 2× (33ms) before we
+  // flag — CI VMs are noisier than a device, but sustained 30fps still fails.
+  p95BudgetFactor: 2,
+  // Up to 25% of frames over budget is tolerated; beyond that it's visible jank.
+  droppedFrameRatio: 0.25,
+  // Long tasks are noisy on a shared CI runner; don't fail solely on them here.
+  reportOnLongTask: false,
+};
+const STABILITY_BUDGET = { maxCls: 0.1, flashMinDelta: 0.2 };
+
+let failures = 0;
+function check(cond, msg) {
+  console.log(`${cond ? "✓" : "✗"} ${msg}`);
+  if (!cond) failures += 1;
+  return cond;
+}
+
+// ── esbuild bundle (mirror run-conversation-swipe-e2e stubs). ──────────────────
+const stubPromptSuggestions = {
+  name: "stub-prompt-suggestions",
+  setup(b) {
+    b.onResolve({ filter: /usePromptSuggestions$/ }, () => ({
+      path: join(here, "usePromptSuggestions.stub.ts"),
+    }));
+  },
+};
+const stubElizaCore = {
+  name: "stub-eliza-core",
+  setup(b) {
+    b.onResolve({ filter: /^@elizaos\/core$/ }, (args) => ({
+      path: args.path,
+      namespace: "eliza-core-stub",
+    }));
+    b.onLoad({ filter: /.*/, namespace: "eliza-core-stub" }, () => ({
+      contents: `
+        const noop = new Proxy(() => noop, { get: () => noop });
+        module.exports = new Proxy(
+          {
+            isViewVisible: () => true,
+            dedupeModalities: (m) => Array.from(new Set(Array.isArray(m) ? m : [])),
+            findInteractionRegions: () => [],
+          },
+          { get: (t, p) => (p in t ? t[p] : noop) },
+        );
+      `,
+      loader: "js",
+    }));
+  },
+};
+const nodeBuiltins = new Set([
+  ...builtinModules,
+  ...builtinModules.map((m) => `node:${m}`),
+]);
+const stubNodeBuiltins = {
+  name: "stub-node-builtins",
+  setup(b) {
+    b.onResolve({ filter: /.*/ }, (args) => {
+      const bare = args.path.replace(/^node:/, "").split("/")[0];
+      if (
+        args.path.startsWith("node:") ||
+        nodeBuiltins.has(args.path) ||
+        builtinModules.includes(bare)
+      ) {
+        return { path: args.path, namespace: "node-stub" };
+      }
+      return null;
+    });
+    b.onLoad({ filter: /.*/, namespace: "node-stub" }, () => ({
+      contents:
+        "const n=()=>noop;const noop=new Proxy(n,{get:()=>noop});module.exports=noop;",
+      loader: "js",
+    }));
+  },
+};
+
+const result = await build({
+  entryPoints: [join(here, "conversation-swipe-fixture.tsx")],
+  bundle: true,
+  format: "iife",
+  platform: "browser",
+  jsx: "automatic",
+  loader: { ".tsx": "tsx", ".ts": "ts" },
+  define: { "process.env.NODE_ENV": '"production"' },
+  plugins: [stubPromptSuggestions, stubElizaCore, stubNodeBuiltins],
+  write: false,
+});
+const js = result.outputFiles[0].text;
+// Install the shared layout-shift observer + a rAF frame sampler BEFORE the app
+// boots, so every shift + frame during the run is captured into window globals.
+const observerInit = `
+${LAYOUT_SHIFT_OBSERVER_INIT}
+(() => {
+  const w = window;
+  if (w.__ELIZA_PERF_FRAMES__) return;
+  w.__ELIZA_PERF_FRAMES__ = [];
+  let last = null;
+  const tick = (now) => {
+    if (last !== null) w.__ELIZA_PERF_FRAMES__.push(now - last);
+    last = now;
+    requestAnimationFrame(tick);
+  };
+  requestAnimationFrame(tick);
+})();
+`;
+const html = `<!doctype html><html><head><meta charset="utf-8"><title>chat perf gate</title>
+<script src="https://cdn.tailwindcss.com"></script>
+<script>window.process=window.process||{env:{NODE_ENV:"production"},platform:"browser",cwd:function(){return "/"}};</script>
+<style>html,body{margin:0;height:100%;background:#16121c}</style>
+<script>${observerInit}</script>
+</head><body><div id="root"></div><script>${js}</script></body></html>`;
+const htmlPath = join(outDir, "chat-perf-gate.html");
+await writeFile(htmlPath, html);
+const url = `file://${htmlPath}`;
+
+/** Real touch-pointer drag from an element's centre by (dx, dy). */
+async function drag(p, selector, dx, dy, { steps = 14, stepMs = 16 } = {}) {
+  const box = await p.locator(selector).boundingBox();
+  const cx = box.x + box.width / 2;
+  const cy = box.y + box.height / 2;
+  await p.evaluate(
+    ({ cx, cy, selector }) => {
+      const el = document.querySelector(selector);
+      window.__t = el;
+      el?.dispatchEvent(
+        new PointerEvent("pointerdown", {
+          pointerId: 1,
+          pointerType: "touch",
+          clientX: cx,
+          clientY: cy,
+          bubbles: true,
+        }),
+      );
+    },
+    { cx, cy, selector },
+  );
+  for (let i = 1; i <= steps; i += 1) {
+    const x = cx + (dx * i) / steps;
+    const y = cy + (dy * i) / steps;
+    await p.evaluate(
+      ({ x, y }) =>
+        window.__t?.dispatchEvent(
+          new PointerEvent("pointermove", {
+            pointerId: 1,
+            pointerType: "touch",
+            clientX: x,
+            clientY: y,
+            bubbles: true,
+          }),
+        ),
+      { x, y },
+    );
+    await p.waitForTimeout(stepMs);
+  }
+  await p.evaluate(
+    ({ x, y }) =>
+      window.__t?.dispatchEvent(
+        new PointerEvent("pointerup", {
+          pointerId: 1,
+          pointerType: "touch",
+          clientX: x,
+          clientY: y,
+          bubbles: true,
+        }),
+      ),
+    { x: cx + dx, y: cy + dy },
+  );
+}
+
+const errors = [];
+const browser = await chromium.launch();
+const context = await browser.newContext({
+  viewport: { width: 420, height: 820 },
+  hasTouch: true,
+  isMobile: true,
+  deviceScaleFactor: 2,
+});
+const page = await context.newPage();
+page.on("pageerror", (e) => errors.push(String(e)));
+await page.goto(url);
+await page.waitForSelector('[data-testid="chat-sheet"]');
+await page.waitForTimeout(600);
+
+// Open the sheet to FULL so the thread (scroll + swipe surface) is mounted.
+await drag(page, '[data-testid="chat-sheet-grabber"]', 0, -120, { steps: 6 });
+await page.waitForTimeout(450);
+await drag(page, '[data-testid="chat-sheet-grabber"]', 0, -180, { steps: 6 });
+await page.waitForTimeout(450);
+check(
+  (await page.locator("#continuous-thread").count()) === 1,
+  "thread (perf surface) mounted",
+);
+
+// Reset the sampled windows AFTER the (one-time) open animation so the measured
+// window is the steady-state interaction, not the mount.
+await page.evaluate(() => {
+  window.__ELIZA_PERF_FRAMES__ = [];
+  window.__ELIZA_LAYOUT_SHIFTS__ = [];
+});
+
+// ── Drive a sustained interaction: alternate scroll + swipe several times. ─────
+for (let i = 0; i < 6; i += 1) {
+  // Vertical scroll the thread (mostly-vertical drag → axis-locks to scroll).
+  await drag(page, "#continuous-thread", 6, -160, { steps: 12, stepMs: 16 });
+  await page.waitForTimeout(120);
+  await drag(page, "#continuous-thread", 6, 160, { steps: 12, stepMs: 16 });
+  await page.waitForTimeout(120);
+  // Swipe forward then back between conversations.
+  await drag(page, "#continuous-thread", -180, 4, { steps: 14, stepMs: 16 });
+  await page.waitForTimeout(160);
+  await drag(page, "#continuous-thread", 180, 4, { steps: 14, stepMs: 16 });
+  await page.waitForTimeout(160);
+}
+
+// ── Harvest the REAL entries and feed the shared detectors. ────────────────────
+const { frames, shifts } = await page.evaluate(() => ({
+  frames: window.__ELIZA_PERF_FRAMES__ ?? [],
+  shifts: window.__ELIZA_LAYOUT_SHIFTS__ ?? [],
+}));
+
+const frameSummary = summarizeFrameSamples(frames);
+const stability = summarizeStability(shifts, [], STABILITY_BUDGET);
+
+console.log(
+  `\nframes: ${frameSummary.sampleCount} | fps ${frameSummary.fps.toFixed(1)} | ` +
+    `p95 ${frameSummary.p95FrameMs.toFixed(1)}ms | worst ${frameSummary.worstFrameMs.toFixed(1)}ms | ` +
+    `dropped ${frameSummary.droppedFrames}/${frameSummary.sampleCount}`,
+);
+console.log(
+  `layout: cls ${stability.cls.toFixed(4)} | non-intentional shifts ${stability.shiftCount}\n`,
+);
+await page.screenshot({ path: join(outDir, "perf-gate-final.png") });
+
+check(
+  frameSummary.sampleCount > 20,
+  `captured a meaningful frame window (${frameSummary.sampleCount} frames)`,
+);
+const droppedRatio = frameSummary.sampleCount
+  ? frameSummary.droppedFrames / frameSummary.sampleCount
+  : 1;
+check(
+  droppedRatio <= FRAME_BUDGET_OPTIONS.droppedFrameRatio,
+  `dropped-frame ratio ${(droppedRatio * 100).toFixed(1)}% within ${(FRAME_BUDGET_OPTIONS.droppedFrameRatio * 100).toFixed(0)}%`,
+);
+check(
+  frameSummary.p95FrameMs <=
+    frameSummary.budgetMs * FRAME_BUDGET_OPTIONS.p95BudgetFactor,
+  `p95 frame ${frameSummary.p95FrameMs.toFixed(1)}ms within ${(frameSummary.budgetMs * FRAME_BUDGET_OPTIONS.p95BudgetFactor).toFixed(1)}ms`,
+);
+// shouldReportFrameBudget is the same policy the HUD applies; assert the window
+// does NOT trip it (under our CI-tuned thresholds).
+check(
+  !shouldReportFrameBudget(frameSummary, FRAME_BUDGET_OPTIONS),
+  "frame-budget detector does not flag the interaction window",
+);
+check(
+  stability.cls <= STABILITY_BUDGET.maxCls,
+  `non-intentional CLS ${stability.cls.toFixed(4)} within ${STABILITY_BUDGET.maxCls}`,
+);
+check(!stability.flagged, "layout-stability detector does not flag the window");
+check(errors.length === 0, `no page errors (saw ${errors.length})`);
+if (errors.length) console.log(errors.join("\n"));
+
+await context.close();
+await browser.close();
+
+console.log(failures === 0 ? "\nPERF GATE PASSED" : `\n${failures} GATE CHECK(S) FAILED`);
+process.exit(failures === 0 ? 0 : 1);

--- a/packages/ui/src/components/shell/__e2e__/run-chatux-gesture-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chatux-gesture-e2e.mjs
@@ -1,12 +1,15 @@
 /**
- * Real-browser gesture e2e + video capture for the chat-UX surfaces (#8928,
- * #8929). Bundles chatux-gesture-fixture.tsx with esbuild, loads it in headless
- * chromium via Playwright, and drives REAL pointer gestures:
+ * Real-browser gesture e2e + video capture for the chat-UX TopicGroup (#8928).
+ * Bundles chatux-gesture-fixture.tsx with esbuild, loads it in headless chromium
+ * via Playwright, and drives REAL pointer gestures:
  *
  *   - TopicGroup: flick UP on the header → collapses to a pill (no buttons);
  *     tap the pill → expands.
- *   - ConversationSwiper: swipe LEFT → next conversation; swipe RIGHT → previous
- *     (edge hint lights with the drag).
+ *
+ * Conversation-swipe coverage moved to run-conversation-swipe-e2e.mjs, which
+ * drives the REAL ContinuousChatOverlay through a new-conversation interleaving
+ * (#9954). The local `ConversationSwiper` mock that used to be asserted here was
+ * deleted — it passed while exercising none of the real conversation-nav path.
  *
  * Captures a screenshot per state AND records a continuous .webm video of the
  * whole sequence. Exits non-zero on any failed assertion or page error.
@@ -181,22 +184,6 @@ assert(
   "Flick DOWN on the pill expands the group again",
 );
 await snap(page, "topic-expanded-after-flick-down");
-
-// ── 3. ConversationSwiper: swipe LEFT → next conversation ───────────────
-const title = page.getByTestId("active-conversation-title");
-const t0 = await title.textContent();
-await drag(page, "conversation-swiper", -160, 0, { steps: 12, slow: false });
-await page.waitForTimeout(250);
-const t1 = await title.textContent();
-assert(t0 !== t1, `Swipe LEFT navigates to the next conversation (${t0} → ${t1})`);
-await snap(page, "swipe-left-next");
-
-// Mid-swipe edge hint (hold to show the glow) — swipe RIGHT back.
-await drag(page, "conversation-swiper", 160, 0, { steps: 12, slow: false });
-await page.waitForTimeout(250);
-const t2 = await title.textContent();
-assert(t2 === t0, `Swipe RIGHT returns to the previous conversation (${t1} → ${t2})`);
-await snap(page, "swipe-right-prev");
 
 assert(errors.length === 0, `no page errors (saw ${errors.length})`);
 if (errors.length) console.log(errors.join("\n"));

--- a/packages/ui/src/components/shell/__e2e__/run-conversation-swipe-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-conversation-swipe-e2e.mjs
@@ -1,0 +1,363 @@
+/**
+ * Real-browser conversation-swipe INTERLEAVING e2e + video capture (#9954).
+ *
+ * Bundles conversation-swipe-fixture.tsx — which mounts the REAL
+ * ContinuousChatOverlay over a stateful controller whose conversation list +
+ * active id actually mutate (new conversation prepends at index 0; a swipe
+ * re-resolves the adjacent chat through the latest state) — and drives the named
+ * interleaving with REAL pointer gestures:
+ *
+ *   swipe-back → new → swipe-forward → new → forward → swipe-back
+ *
+ * After every step it asserts the interleaving invariants from the overlay's own
+ * data-conversation-id / data-conversation-index DOM, NOT just an error count:
+ *   - the active id is in the list,
+ *   - the rendered index matches the active id's position,
+ *   - hasPrev/hasNext are consistent with the index,
+ *   - a new conversation lands at index 0,
+ *   - a swipe at the index-0 boundary is a no-op.
+ * It also asserts the swipe-jank telemetry event fired during a real gesture.
+ *
+ * Records a continuous .webm of the whole sequence. Exits non-zero on any failed
+ * assertion or page error.
+ *
+ * Run: bun run --cwd packages/ui test:conversation-swipe-e2e
+ */
+
+import { mkdir, readdir, rename, writeFile } from "node:fs/promises";
+import { builtinModules } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { build } from "esbuild";
+import { chromium } from "playwright";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const outDir = join(here, "output-conversation-swipe");
+const videoDir = join(outDir, "video");
+await mkdir(outDir, { recursive: true });
+await mkdir(videoDir, { recursive: true });
+
+let failures = 0;
+function assert(cond, msg) {
+  console.log(`${cond ? "✓" : "✗"} ${msg}`);
+  if (!cond) failures += 1;
+  return cond;
+}
+
+// ── esbuild stubs (mirror run-chat-sheet-e2e): the prompt-suggestions hook hits
+// the API, @elizaos/core transitively reaches its Node graph, and node builtins
+// are dead in the browser. ───────────────────────────────────────────────────
+const stubPromptSuggestions = {
+  name: "stub-prompt-suggestions",
+  setup(b) {
+    b.onResolve({ filter: /usePromptSuggestions$/ }, () => ({
+      path: join(here, "usePromptSuggestions.stub.ts"),
+    }));
+  },
+};
+const stubElizaCore = {
+  name: "stub-eliza-core",
+  setup(b) {
+    b.onResolve({ filter: /^@elizaos\/core$/ }, (args) => ({
+      path: args.path,
+      namespace: "eliza-core-stub",
+    }));
+    b.onLoad({ filter: /.*/, namespace: "eliza-core-stub" }, () => ({
+      contents: `
+        const noop = new Proxy(() => noop, { get: () => noop });
+        module.exports = new Proxy(
+          {
+            isViewVisible: () => true,
+            dedupeModalities: (m) => Array.from(new Set(Array.isArray(m) ? m : [])),
+            findInteractionRegions: () => [],
+          },
+          { get: (t, p) => (p in t ? t[p] : noop) },
+        );
+      `,
+      loader: "js",
+    }));
+  },
+};
+const nodeBuiltins = new Set([
+  ...builtinModules,
+  ...builtinModules.map((m) => `node:${m}`),
+]);
+const stubNodeBuiltins = {
+  name: "stub-node-builtins",
+  setup(b) {
+    b.onResolve({ filter: /.*/ }, (args) => {
+      const bare = args.path.replace(/^node:/, "").split("/")[0];
+      if (
+        args.path.startsWith("node:") ||
+        nodeBuiltins.has(args.path) ||
+        builtinModules.includes(bare)
+      ) {
+        return { path: args.path, namespace: "node-stub" };
+      }
+      return null;
+    });
+    b.onLoad({ filter: /.*/, namespace: "node-stub" }, () => ({
+      contents:
+        "const n=()=>noop;const noop=new Proxy(n,{get:()=>noop});module.exports=noop;",
+      loader: "js",
+    }));
+  },
+};
+
+const result = await build({
+  entryPoints: [join(here, "conversation-swipe-fixture.tsx")],
+  bundle: true,
+  format: "iife",
+  platform: "browser",
+  jsx: "automatic",
+  loader: { ".tsx": "tsx", ".ts": "ts" },
+  define: { "process.env.NODE_ENV": '"production"' },
+  plugins: [stubPromptSuggestions, stubElizaCore, stubNodeBuiltins],
+  write: false,
+});
+const js = result.outputFiles[0].text;
+const html = `<!doctype html><html><head><meta charset="utf-8"><title>conversation swipe e2e</title>
+<script src="https://cdn.tailwindcss.com"></script>
+<script>window.process=window.process||{env:{NODE_ENV:"production"},platform:"browser",cwd:function(){return "/"}};</script>
+<style>html,body{margin:0;height:100%;background:#16121c}</style>
+</head><body><div id="root"></div><script>${js}</script></body></html>`;
+const htmlPath = join(outDir, "conversation-swipe.html");
+await writeFile(htmlPath, html);
+const url = `file://${htmlPath}`;
+
+let shot = 0;
+async function snap(p, name) {
+  shot += 1;
+  const file = `${String(shot).padStart(2, "0")}-${name}.png`;
+  await p.screenshot({ path: join(outDir, file) });
+  console.log(`  📸 ${file}`);
+}
+
+// Live navigation state read straight off the overlay's DOM attributes — the
+// SAME data-conversation-id / data-conversation-index the overlay surfaces in
+// production (not a fixture-private signal).
+const navState = (p) =>
+  p.evaluate(() => {
+    const sheet = document.querySelector('[data-testid="chat-sheet"]');
+    const harness = window.__convNav?.state?.() ?? null;
+    return {
+      domActiveId: sheet?.getAttribute("data-conversation-id") ?? null,
+      domIndex: Number(sheet?.getAttribute("data-conversation-index") ?? "NaN"),
+      harness,
+    };
+  });
+
+/** Assert the full interleaving invariant set for the current overlay state. */
+async function assertInvariants(p, label, { expectIndex } = {}) {
+  const { domActiveId, domIndex, harness } = await navState(p);
+  assert(!!harness, `[${label}] harness state readable`);
+  if (!harness) return;
+  const inList = harness.ids.includes(harness.activeId);
+  assert(inList, `[${label}] active id (${harness.activeId}) ∈ list`);
+  // The overlay's reported index must equal the active id's real position.
+  assert(
+    domIndex === harness.index && harness.index === harness.ids.indexOf(harness.activeId),
+    `[${label}] dom index ${domIndex} == active position ${harness.index}`,
+  );
+  assert(
+    domActiveId === harness.activeId,
+    `[${label}] dom active id (${domActiveId}) == ${harness.activeId}`,
+  );
+  // hasPrev/hasNext must be consistent with the index in a most-recent-first list.
+  assert(
+    harness.hasPrev === harness.index > 0,
+    `[${label}] hasPrev (${harness.hasPrev}) consistent with index ${harness.index}`,
+  );
+  assert(
+    harness.hasNext === (harness.index >= 0 && harness.index < harness.ids.length - 1),
+    `[${label}] hasNext (${harness.hasNext}) consistent with index ${harness.index}`,
+  );
+  if (typeof expectIndex === "number") {
+    assert(
+      harness.index === expectIndex,
+      `[${label}] index is ${expectIndex} (got ${harness.index})`,
+    );
+  }
+  return harness;
+}
+
+/** Dispatch a real touch-pointer drag from an element's centre by (dx, dy). */
+async function drag(p, selector, dx, dy, { steps = 12, slow = false } = {}) {
+  const box = await p.locator(selector).boundingBox();
+  const cx = box.x + box.width / 2;
+  const cy = box.y + box.height / 2;
+  await p.evaluate(
+    ({ cx, cy, selector }) => {
+      const el = document.querySelector(selector);
+      window.__t = el;
+      el?.dispatchEvent(
+        new PointerEvent("pointerdown", {
+          pointerId: 1,
+          pointerType: "touch",
+          clientX: cx,
+          clientY: cy,
+          bubbles: true,
+        }),
+      );
+    },
+    { cx, cy, selector },
+  );
+  for (let i = 1; i <= steps; i += 1) {
+    const x = cx + (dx * i) / steps;
+    const y = cy + (dy * i) / steps;
+    await p.evaluate(
+      ({ x, y }) =>
+        window.__t?.dispatchEvent(
+          new PointerEvent("pointermove", {
+            pointerId: 1,
+            pointerType: "touch",
+            clientX: x,
+            clientY: y,
+            bubbles: true,
+          }),
+        ),
+      { x, y },
+    );
+    if (slow) await p.waitForTimeout(20);
+  }
+  await p.evaluate(
+    ({ x, y }) =>
+      window.__t?.dispatchEvent(
+        new PointerEvent("pointerup", {
+          pointerId: 1,
+          pointerType: "touch",
+          clientX: x,
+          clientY: y,
+          bubbles: true,
+        }),
+      ),
+    { x: cx + dx, y: cy + dy },
+  );
+}
+
+// LEFT swipe (clientX decreases) → next/older conversation (index + 1). The
+// per-step waits let the swipe-jank FrameBudgetSampler's rAF actually tick
+// across the drag (a back-to-back synthetic burst can commit before a single
+// frame delta lands), so the telemetry window is non-empty.
+const swipeForward = (p) =>
+  drag(p, "#continuous-thread", -180, 4, { steps: 14, slow: true });
+// RIGHT swipe (clientX increases) → prev/newer conversation (index - 1).
+const swipeBack = (p) =>
+  drag(p, "#continuous-thread", 180, 4, { steps: 14, slow: true });
+
+const newConversation = (p) =>
+  p.evaluate(() => window.__convNav?.newConversation?.());
+
+const logs = [];
+const errors = [];
+const browser = await chromium.launch();
+const context = await browser.newContext({
+  viewport: { width: 420, height: 820 },
+  hasTouch: true,
+  isMobile: true,
+  deviceScaleFactor: 2,
+  recordVideo: { dir: videoDir, size: { width: 420, height: 820 } },
+});
+const page = await context.newPage();
+page.on("console", (m) => logs.push(`[${m.type()}] ${m.text()}`));
+page.on("pageerror", (e) => errors.push(String(e)));
+await page.goto(url);
+await page.waitForSelector('[data-testid="chat-sheet"]');
+await page.waitForTimeout(600);
+
+// Open the sheet to FULL so the thread (the swipe surface) is mounted + bound.
+// Two pull-ups on the grabber step collapsed → half → full.
+await drag(page, '[data-testid="chat-sheet-grabber"]', 0, -120, { steps: 6 });
+await page.waitForTimeout(450);
+await drag(page, '[data-testid="chat-sheet-grabber"]', 0, -180, { steps: 6 });
+await page.waitForTimeout(450);
+assert(
+  (await page.locator("#continuous-thread").count()) === 1,
+  "thread (swipe surface) is mounted with the sheet open",
+);
+await snap(page, "00-open-newest");
+
+// Start state: active on the NEWEST (index 0). The first "swipe back" toward a
+// newer chat is therefore a boundary no-op.
+let s = await assertInvariants(page, "start", { expectIndex: 0 });
+assert(s?.index === 0, "START: active on the newest conversation (index 0)");
+assert(s?.hasPrev === false, "START: index-0 has no newer neighbour (hasPrev false)");
+
+// ── 1. swipe-back at index 0 → BOUNDARY NO-OP ──────────────────────────────
+await swipeBack(page);
+await page.waitForTimeout(250);
+s = await assertInvariants(page, "swipe-back@0", { expectIndex: 0 });
+assert(s?.index === 0, "STEP1 swipe-back at index 0 is a no-op (still index 0)");
+await snap(page, "01-swipe-back-noop");
+
+// ── 2. new conversation → lands at index 0, list grows ─────────────────────
+const beforeNewLen = s?.ids.length ?? 0;
+await newConversation(page);
+await page.waitForTimeout(250);
+s = await assertInvariants(page, "after-new", { expectIndex: 0 });
+assert(s?.index === 0, "STEP2 new conversation lands at index 0");
+assert(
+  (s?.ids.length ?? 0) === beforeNewLen + 1,
+  "STEP2 the new conversation grew the list by one",
+);
+assert(s?.activeId === "new-0", "STEP2 active id is the new conversation");
+await snap(page, "02-new-conversation-index0");
+
+// ── 3. swipe-forward → moves toward the older neighbour (index + 1) ────────
+const beforeFwd = s?.activeId;
+await swipeForward(page);
+await page.waitForTimeout(250);
+s = await assertInvariants(page, "after-forward", { expectIndex: 1 });
+assert(s?.index === 1, "STEP3 swipe-forward moves to index 1 (older neighbour)");
+assert(s?.activeId !== beforeFwd, "STEP3 the active conversation actually changed");
+await snap(page, "03-swipe-forward");
+
+// ── 4. new conversation again → back to index 0 ────────────────────────────
+await newConversation(page);
+await page.waitForTimeout(250);
+s = await assertInvariants(page, "after-new-2", { expectIndex: 0 });
+assert(s?.index === 0, "STEP4 second new conversation lands at index 0 again");
+assert(s?.activeId === "new-1", "STEP4 active id is the second new conversation");
+await snap(page, "04-new-conversation-2");
+
+// ── 5. swipe-forward → index 1 ─────────────────────────────────────────────
+await swipeForward(page);
+await page.waitForTimeout(250);
+s = await assertInvariants(page, "forward-2", { expectIndex: 1 });
+assert(s?.index === 1, "STEP5 swipe-forward to index 1");
+await snap(page, "05-swipe-forward-2");
+
+// ── 6. swipe-back → back toward the newer neighbour (index 0) ──────────────
+await swipeBack(page);
+await page.waitForTimeout(250);
+s = await assertInvariants(page, "back-to-0", { expectIndex: 0 });
+assert(s?.index === 0, "STEP6 swipe-back returns to index 0 (newer neighbour)");
+await snap(page, "06-swipe-back");
+
+// ── Telemetry: a real swipe gesture must have emitted the jank event (#9954) ─
+const jankCount = await page.evaluate(
+  () => window.__convNav?.swipeJankEvents?.() ?? 0,
+);
+assert(
+  jankCount > 0,
+  `conversation-swipe-jank telemetry fired during real gestures (saw ${jankCount})`,
+);
+
+assert(errors.length === 0, `no page errors (saw ${errors.length})`);
+if (errors.length) console.log(errors.join("\n"));
+
+await page.close(); // flush the video
+await context.close();
+await browser.close();
+
+const vids = (await readdir(videoDir)).filter((f) => f.endsWith(".webm"));
+if (vids[0]) {
+  await rename(
+    join(videoDir, vids[0]),
+    join(outDir, "conversation-swipe-interleaving.webm"),
+  );
+  console.log("  🎬 conversation-swipe-interleaving.webm");
+}
+
+console.log(failures === 0 ? "\nALL PASSED" : `\n${failures} FAILED`);
+process.exit(failures === 0 ? 0 : 1);

--- a/packages/ui/src/components/shell/conversation-nav.ts
+++ b/packages/ui/src/components/shell/conversation-nav.ts
@@ -43,6 +43,12 @@ export function resolveAdjacentConversationId(
  * adjacent conversation by id. When the active conversation isn't in the list
  * (not-found), neither direction is navigable. Extracted as a pure function so
  * the index-walk is unit-testable without rendering the AppContext-bound hook.
+ *
+ * Invariant: a new conversation PREPENDS at index 0 and becomes active, so right
+ * after creating one the index-0 swipe toward a newer chat (`goPrev`) is a
+ * boundary no-op (`hasPrev` is false). The conversation-swipe interleaving e2e
+ * (`run-conversation-swipe-e2e.mjs`) drives + asserts exactly this against the
+ * real overlay.
  */
 export function buildConversationNav(
   conversations: readonly Pick<Conversation, "id">[] | null | undefined,

--- a/packages/ui/src/hooks/useConversationSwipeJank.test.ts
+++ b/packages/ui/src/hooks/useConversationSwipeJank.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  readViewInteractions,
+  type ViewInteractionEvent,
+} from "../view-telemetry";
+import { useConversationSwipeJank } from "./useConversationSwipeJank";
+
+// Drive rAF manually so a sampling window collects deterministic frame deltas
+// without waiting on the real display refresh.
+let rafQueue: Array<(t: number) => void> = [];
+let now = 0;
+
+function flushFrame(deltaMs: number) {
+  now += deltaMs;
+  const due = rafQueue;
+  rafQueue = [];
+  for (const cb of due) cb(now);
+}
+
+function resetRing() {
+  const g = globalThis as typeof globalThis & {
+    __ELIZA_VIEW_INTERACTION_TELEMETRY__?: ViewInteractionEvent[];
+  };
+  g.__ELIZA_VIEW_INTERACTION_TELEMETRY__ = [];
+}
+
+beforeEach(() => {
+  rafQueue = [];
+  now = 0;
+  resetRing();
+  globalThis.requestAnimationFrame = ((cb: (t: number) => void) => {
+    rafQueue.push(cb);
+    return rafQueue.length;
+  }) as typeof requestAnimationFrame;
+  globalThis.cancelAnimationFrame = (() => {}) as typeof cancelAnimationFrame;
+});
+
+afterEach(() => {
+  resetRing();
+});
+
+function swipeJankEvents(): ViewInteractionEvent[] {
+  return readViewInteractions().filter(
+    (e) => e.action === "conversation-swipe-jank",
+  );
+}
+
+describe("useConversationSwipeJank", () => {
+  it("emits a frame-budget summary to the telemetry ring on gesture end", () => {
+    const { result } = renderHook(() => useConversationSwipeJank());
+
+    act(() => result.current.begin());
+    // Seed the baseline, then push three on-budget (16ms) frames.
+    act(() => flushFrame(0));
+    act(() => flushFrame(16));
+    act(() => flushFrame(16));
+    act(() => flushFrame(16));
+    act(() => result.current.end());
+
+    const events = swipeJankEvents();
+    expect(events).toHaveLength(1);
+    const event = events[0];
+    expect(event.source).toBe("conversation-swipe");
+    expect(event.frameBudget).toBeDefined();
+    expect(event.frameBudget?.sampleCount).toBe(3);
+    // 16ms frames are under the 16.67ms 60fps budget → no dropped frames.
+    expect(event.frameBudget?.droppedFrames).toBe(0);
+    expect(event.count).toBe(0);
+  });
+
+  it("flags dropped frames when a window contains janky frames", () => {
+    const { result } = renderHook(() => useConversationSwipeJank());
+
+    act(() => result.current.begin());
+    act(() => flushFrame(0));
+    act(() => flushFrame(50)); // dropped
+    act(() => flushFrame(48)); // dropped
+    act(() => flushFrame(16)); // on budget
+    act(() => result.current.end());
+
+    const event = swipeJankEvents()[0];
+    expect(event.frameBudget?.droppedFrames).toBe(2);
+    expect(event.count).toBe(2);
+    expect(event.frameBudget?.worstFrameMs).toBeGreaterThanOrEqual(50);
+  });
+
+  it("does not emit when the gesture committed before a single frame settled", () => {
+    const { result } = renderHook(() => useConversationSwipeJank());
+
+    // begin → end with no rAF tick in between (synthetic test pointer): the
+    // window is empty, so there's nothing to report.
+    act(() => result.current.begin());
+    act(() => result.current.end());
+
+    expect(swipeJankEvents()).toHaveLength(0);
+  });
+
+  it("begin is idempotent — repeated calls do not restart the window", () => {
+    const { result } = renderHook(() => useConversationSwipeJank());
+
+    act(() => result.current.begin());
+    act(() => flushFrame(0));
+    act(() => flushFrame(16));
+    // A second begin mid-gesture (e.g. another onDragX frame) must not reset.
+    act(() => result.current.begin());
+    act(() => flushFrame(16));
+    act(() => result.current.end());
+
+    const event = swipeJankEvents()[0];
+    expect(event.frameBudget?.sampleCount).toBe(2);
+  });
+
+  it("starts a clean window for a subsequent gesture", () => {
+    const { result } = renderHook(() => useConversationSwipeJank());
+
+    act(() => result.current.begin());
+    act(() => flushFrame(0));
+    act(() => flushFrame(50));
+    act(() => result.current.end());
+
+    act(() => result.current.begin());
+    act(() => flushFrame(0));
+    act(() => flushFrame(16));
+    act(() => result.current.end());
+
+    const events = swipeJankEvents();
+    expect(events).toHaveLength(2);
+    // Second gesture's window did not inherit the first gesture's janky frame.
+    expect(events[1].frameBudget?.droppedFrames).toBe(0);
+  });
+});

--- a/packages/ui/src/hooks/useConversationSwipeJank.ts
+++ b/packages/ui/src/hooks/useConversationSwipeJank.ts
@@ -1,0 +1,74 @@
+// Conversation-swipe jank telemetry (#9954).
+//
+// The frame-budget HUD (useFrameBudgetMonitor) only runs behind the explicit
+// `__ELIZA_PERF_HUD__` dev opt-in, so a swipe-jank regression is invisible
+// outside a dev session. This hook scopes a FrameBudgetSampler to the lifetime
+// of a single conversation-swipe gesture: it starts sampling rAF deltas +
+// long-tasks when the gesture begins and, on release, flushes the summary into
+// the bounded view-interaction telemetry ring as a `conversation-swipe-jank`
+// event. The drop-frame %, p95 frame time, and fps are therefore observable in
+// the same ring every other interaction lands in — no HUD required.
+//
+// The math is the shared, unit-tested frame-budget summarizer; this file is
+// only the per-gesture lifecycle glue.
+
+import { useCallback, useEffect, useRef } from "react";
+import { emitConversationSwipeJank } from "../view-telemetry";
+import { type FrameBudget, FrameBudgetSampler } from "./frame-budget";
+
+export interface ConversationSwipeJankHandle {
+  /** Begin sampling — call when a swipe gesture starts driving the drag. */
+  begin: () => void;
+  /** Flush the sampled window as a telemetry event and stop sampling. */
+  end: () => void;
+}
+
+/**
+ * Sample frame budget over a single conversation-swipe gesture and emit the
+ * summary to the telemetry ring on release. `begin` is idempotent (a no-op while
+ * already sampling) so the per-frame `onDragX` can call it on every move without
+ * restarting the window; `end` flushes + resets so the next gesture starts clean.
+ */
+export function useConversationSwipeJank(
+  budget?: FrameBudget,
+): ConversationSwipeJankHandle {
+  const samplerRef = useRef<FrameBudgetSampler | null>(null);
+
+  const getSampler = useCallback((): FrameBudgetSampler => {
+    if (!samplerRef.current) {
+      samplerRef.current = new FrameBudgetSampler(
+        budget ? { budget } : undefined,
+      );
+    }
+    return samplerRef.current;
+  }, [budget]);
+
+  const begin = useCallback(() => {
+    const sampler = getSampler();
+    if (sampler.running) return;
+    sampler.reset();
+    sampler.start();
+  }, [getSampler]);
+
+  const end = useCallback(() => {
+    const sampler = samplerRef.current;
+    if (!sampler?.running) return;
+    const summary = sampler.summary();
+    sampler.stop();
+    // A gesture with no settled frames (instant commit, e.g. a synthetic test
+    // pointer with no rAF tick) yields an empty window — nothing meaningful to
+    // report, so skip the event rather than emit a zeroed summary.
+    if (summary.sampleCount === 0) return;
+    emitConversationSwipeJank(summary);
+  }, []);
+
+  // Stop any in-flight sampler if the overlay unmounts mid-gesture.
+  useEffect(
+    () => () => {
+      samplerRef.current?.stop();
+    },
+    [],
+  );
+
+  return { begin, end };
+}

--- a/packages/ui/src/view-telemetry.ts
+++ b/packages/ui/src/view-telemetry.ts
@@ -8,10 +8,15 @@
  * the ring is inspectable in dev. Keep it dependency-free and side-effect-light.
  */
 
+import type { FrameBudgetSummary } from "./hooks/frame-budget";
+
 export const VIEW_INTERACTION_TELEMETRY_EVENT =
   "eliza:view-interaction-telemetry";
 
-export type ViewInteractionSource = "launcher" | "view-catalog";
+export type ViewInteractionSource =
+  | "launcher"
+  | "view-catalog"
+  | "conversation-swipe";
 
 export type ViewInteractionAction =
   | "launch"
@@ -25,7 +30,13 @@ export type ViewInteractionAction =
   | "search-zero-results"
   | "hero-image-error"
   | "dynamic-view-edit"
-  | "dynamic-view-delete";
+  | "dynamic-view-delete"
+  // Frame-budget summary for a single conversation-swipe gesture (#9954). Until
+  // this action existed, swipe jank only surfaced through the dev-only PerfOverlay
+  // HUD; emitting it here makes dropped-frame/fps data observable in the same
+  // bounded ring every other interaction lands in, so a swipe-jank regression is
+  // visible to a harness/test without the HUD.
+  | "conversation-swipe-jank";
 
 export interface ViewInteractionEvent {
   source: ViewInteractionSource;
@@ -36,6 +47,13 @@ export interface ViewInteractionEvent {
   query?: string;
   /** Result count (for search) or page index (for page-swipe/reorder). */
   count?: number;
+  /**
+   * Frame-budget summary for a `conversation-swipe-jank` event (#9954) — the
+   * same {@link FrameBudgetSummary} the frame-budget HUD reads, so the dropped-
+   * frame %, p95 frame time, and long-task counts are computed by one source of
+   * truth. Present only on `conversation-swipe-jank`.
+   */
+  frameBudget?: FrameBudgetSummary;
   at: number;
   route?: string;
 }
@@ -92,4 +110,19 @@ export function emitViewInteraction(
 export function readViewInteractions(): ViewInteractionEvent[] {
   const g = globalThis as TelemetryGlobal;
   return g.__ELIZA_VIEW_INTERACTION_TELEMETRY__ ?? [];
+}
+
+/**
+ * Record the frame-budget summary captured over a single conversation-swipe
+ * gesture (#9954). The `count` field carries the dropped-frame count so a reader
+ * scanning the ring sees the headline number without unpacking `frameBudget`;
+ * the full summary (p95 frame time, fps, long tasks) rides in `frameBudget`.
+ */
+export function emitConversationSwipeJank(summary: FrameBudgetSummary): void {
+  emitViewInteraction({
+    source: "conversation-swipe",
+    action: "conversation-swipe-jank",
+    count: summary.droppedFrames,
+    frameBudget: summary,
+  });
 }


### PR DESCRIPTION
## Summary

Closes the REMAINING verification gaps in #9954 that PR #10042 did not cover. #10042 landed the pure conversation-nav helper extraction, interleaving coverage, and the seq/epoch guard on swipe callbacks. This PR adds the e2e/CI/render-parity/perf/telemetry chunks.

All work is **renderer-side** (packages/ui). No server, model, or agent code path changes.

## What's done

**1. Real-overlay conversation-swipe interleaving e2e** (`run-conversation-swipe-e2e.mjs` + `conversation-swipe-fixture.tsx`)
The old `chatux-gesture-fixture.tsx` exercised a local `ConversationSwiper` **mock** (hardcoded array + its own `useState(index)`, sharing only `usePullGesture`, not the real overlay/nav/async-create path) and asserted only title-change + `errors.length === 0`. Replaced with a fixture that mounts the **real `ContinuousChatOverlay`** over a stateful controller whose list + active id actually mutate the production way (new conversation prepends at index 0; a swipe re-resolves the adjacent chat through the latest state via `buildConversationNav`). The runner drives the named sequence **swipe-back → new → swipe-forward → new → forward → swipe-back** with real pointer gestures and asserts interleaving invariants from the overlay's own `data-conversation-id`/`data-conversation-index` DOM at every step (active id ∈ list; index matches position; hasPrev/hasNext consistent; new lands at index 0; index-0 swipe is a boundary no-op). The mock `ConversationSwiper` is **deleted**; the old runner is demoted to TopicGroup-only.

**2. CI wire** (`.github/workflows/chat-shell-gestures.yml`)
No workflow referenced the chat-shell e2e runners (`grep chatux/chat-sheet .github/workflows` → nothing). Added a focused lane, path-gated to `packages/ui/**`, running in headless chromium: render-parity contract, conversation-nav + swipe-jank unit tests, the conversation-swipe interleaving e2e, the chat-sheet detent e2e, the TopicGroup gesture e2e, and the perf gate — uploading videos/screenshots as artifacts.

**3. Component-tree render-parity guard** (`render-parity.contract.test.tsx`)
#9304 deduped + pinned the parser; the two React trees (`ThreadLine` overlay vs `MessageContent` ChatView) were still unguarded. New contract mounts **both** paths over a shared `ConversationMessage` corpus and diffs a structural fingerprint (choice widget + option set, code-block count, secret-request block, reasoning block, no_provider gate). A coverage guard asserts all five rich affordances actually appear, so the parity check can't pass trivially. Added a test-only `__renderThreadLineForParity` seam.

**4. Conversation-swipe perf telemetry event** (`view-telemetry.ts` + `useConversationSwipeJank.ts`)
`view-telemetry` had `page-swipe`/`reorder` but no jank/fps action, so swipe jank only surfaced via the dev `__ELIZA_PERF_HUD__` HUD. Added a `conversation-swipe-jank` action carrying a shared `FrameBudgetSummary`, and a hook that scopes a `FrameBudgetSampler` to a single swipe gesture (begin on drag, flush+reset on release), wired into the overlay's swipe gesture. The dropped-frame %/p95/fps are now in the bounded telemetry ring.

**5. Headless-Chromium perf gate** (`run-chat-perf-gate.mjs`)
Drives the real overlay under sustained scroll + swipe, installs the shared `LAYOUT_SHIFT_OBSERVER_INIT` + a rAF sampler, harvests **real** `PerformanceObserver` layout-shift entries + rAF deltas, feeds them into the same pure detectors the HUD uses (`summarizeFrameSamples`/`shouldReportFrameBudget`, `summarizeStability`), and hard-fails on dropped-frame ratio / p95 frame time / non-intentional CLS. Wired into the CI lane.

**Doc:** pinned the index-0 boundary no-op invariant next to `buildConversationNav`.

## Acceptance checklist

- [x] chatux-gesture e2e mounts the **real** `ContinuousChatOverlay` (not a local mock), drives real pointer gestures through a new-conversation interleaving, runs in a CI workflow on `packages/ui` changes
- [x] mock `ConversationSwiper` fixture **deleted** so it can't pass for overlay coverage
- [x] perf gate drives the live chat surface under gestures and hard-fails on dropped-frame % / p95 frame-time / non-intentional CLS thresholds
- [x] component-level parity test prevents `ThreadLine` vs `MessageContent` structural divergence for a shared corpus
- [x] swipe-jank telemetry event observable in the ring, not only the dev HUD

## Evidence (ran locally — all green)

- `vitest`: `useConversationSwipeJank.test.ts` (5) + `conversation-nav.test.ts` (8) + `render-parity.contract.test.tsx` (10) → **23 passed**
- `test:conversation-swipe-e2e` → **ALL PASSED** (full interleaving invariants + `conversation-swipe-jank` telemetry fired during real gestures; .webm + 7 screenshots recorded)
- `test:chat-sheet-e2e` → **PASSED** (51 screenshots)
- `test:chatux-gesture-e2e` (demoted to TopicGroup) → **ALL PASSED**
- `test:chat-perf-gate` → **PERF GATE PASSED** — 1105 frames @ 120fps, 0 dropped, p95 9.2ms, CLS 0.0421 (≤ 0.1), all 8 checks pass on **real** PerformanceObserver/rAF data
- `biome lint` clean on all touched `.ts`/`.tsx`; `git diff --check` clean; `tsc` shows zero errors in touched files (34 pre-existing React-19/worktree node_modules-dup `Ref` errors elsewhere, unrelated)

**Real-LLM trajectory** — N/A (no agent/action/prompt/model behavior changes).
**Backend logs** — N/A (renderer-side nav/perf/test work, no server code path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)