### PR TITLE
fix(cloud): stop leaking internal charge metadata on the public charge endpoint

### DIFF
--- a/packages/cloud/api/v1/apps/[id]/charges/[chargeId]/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/charges/[chargeId]/route.ts
@@ -34,9 +34,33 @@ app.get("/", async (c) => {
       return c.json({ success: false, error: "Charge request not found" }, 404);
     }
 
+    // Payer-facing PUBLIC projection. This route is on the unauthenticated
+    // allowlist, so we must NOT return the raw `charge` — its `metadata` carries
+    // internal data (creator org/user UUIDs, the creator's callback_url, and the
+    // agent/room/channel routing ids), and `payerUserId`/`payerOrganizationId`/
+    // `providerPaymentId` are internal identifiers. Whitelist only what a payment
+    // page needs. The full charge (incl. metadata) stays on the org-scoped
+    // authenticated `GET /charges` list.
+    const publicCharge = {
+      id: charge.id,
+      appId: charge.appId,
+      amountUsd: charge.amountUsd,
+      description: charge.description,
+      providers: charge.providers,
+      paymentContext: charge.paymentContext,
+      paymentUrl: charge.paymentUrl,
+      status: charge.status,
+      paidAt: charge.paidAt,
+      paidProvider: charge.paidProvider,
+      expiresAt: charge.expiresAt,
+      createdAt: charge.createdAt,
+      successUrl: charge.successUrl,
+      cancelUrl: charge.cancelUrl,
+    };
+
     return c.json({
       success: true,
-      charge,
+      charge: publicCharge,
       app: {
         id: targetApp.id,
         name: targetApp.name,


### PR DESCRIPTION
## Problem (deep-scan; adversarially verified — info disclosure)

`GET /api/v1/apps/:id/charges/:chargeId` is on the **unauthenticated** public allowlist (`auth.ts:148` — it's the payer-facing payment page) and returned the **full** `charge` object. `sanitizeAppChargeMetadata` only strips `callback_secret`; every other metadata key passes through, including `creator_user_id`, `creator_organization_id`, the creator's `callback_url`, and `callback_channel` (roomId/agentId/channelId) — plus top-level `payerUserId`/`payerOrganizationId`/`providerPaymentId` after payment.

So anyone with the (shareable) charge link could read the creator's internal org/user UUIDs, private callback endpoint, and agent/room/channel routing ids. The one true secret (`callback_secret`) was already stripped, so **no signed-callback forgery** — disclosure only, bounded by the non-enumerable random chargeId.

## Fix
Return an explicit payer-facing projection (id, amount, description, providers, paymentContext, status, paymentUrl, success/cancel URLs, expiresAt, paidAt/paidProvider) and **omit `metadata` + internal payer ids**. The full charge (incl. metadata) stays on the authenticated **org-scoped** `GET /charges` list. One file.