### PR TITLE
feat(app): universal/App Links — open https://eliza.app/<path> in the installed app (#9965)

### DIFF
--- a/packages/app/src/deep-link-handler.test.ts
+++ b/packages/app/src/deep-link-handler.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createDeepLinkHandler,
+  type DeepLinkHandlerContext,
+  isTrustedAppLink,
+} from "./deep-link-handler";
+
+function makeHandler(over: Partial<DeepLinkHandlerContext> = {}) {
+  const dispatchShareTarget = vi.fn();
+  const dispatchDeepLinkCallback = vi.fn();
+  const ctx: DeepLinkHandlerContext = {
+    urlScheme: "elizaos",
+    appId: "ai.elizaos.app",
+    desktopBundleId: undefined,
+    logPrefix: "[test]",
+    trustPolicy: { isTrustedDeepLinkApiBaseUrl: () => true } as never,
+    dispatchShareTarget,
+    dispatchDeepLinkCallback,
+    appLinkHosts: ["eliza.app"],
+    ...over,
+  };
+  return {
+    handle: createDeepLinkHandler(ctx),
+    dispatchShareTarget,
+    dispatchDeepLinkCallback,
+  };
+}
+
+beforeEach(() => {
+  window.location.hash = "";
+});
+
+describe("isTrustedAppLink", () => {
+  it("accepts https on a configured host or subdomain, rejects others", () => {
+    const hosts = ["eliza.app"];
+    expect(isTrustedAppLink(new URL("https://eliza.app/wallet"), hosts)).toBe(
+      true,
+    );
+    expect(isTrustedAppLink(new URL("https://share.eliza.app/x"), hosts)).toBe(
+      true,
+    );
+    expect(isTrustedAppLink(new URL("http://eliza.app/wallet"), hosts)).toBe(
+      false,
+    ); // not https
+    expect(isTrustedAppLink(new URL("https://evil.com/wallet"), hosts)).toBe(
+      false,
+    );
+    expect(isTrustedAppLink(new URL("https://eliza.app/x"), undefined)).toBe(
+      false,
+    );
+  });
+});
+
+describe("createDeepLinkHandler — universal (https) app links", () => {
+  it("routes https://eliza.app/<path> into the same hash route as the custom scheme", () => {
+    const { handle } = makeHandler();
+    handle("elizaos://wallet");
+    expect(window.location.hash).toBe("#wallet");
+
+    window.location.hash = "";
+    handle("https://eliza.app/wallet");
+    expect(window.location.hash).toBe("#wallet");
+  });
+
+  it("maps the connectors deep path from a universal link", () => {
+    const { handle } = makeHandler();
+    handle("https://eliza.app/settings/connectors/discord");
+    expect(window.location.hash).toBe("#connectors");
+  });
+
+  it("carries query params through a universal link", () => {
+    const { handle } = makeHandler();
+    handle("https://eliza.app/messages?to=alice");
+    expect(window.location.hash).toBe("#messages?to=alice");
+  });
+
+  it("ignores an untrusted https host", () => {
+    const { handle } = makeHandler();
+    handle("https://evil.com/wallet");
+    expect(window.location.hash).toBe("");
+  });
+
+  it("ignores https when no appLinkHosts are configured", () => {
+    const { handle } = makeHandler({ appLinkHosts: undefined });
+    handle("https://eliza.app/wallet");
+    expect(window.location.hash).toBe("");
+  });
+});

--- a/packages/app/src/deep-link-handler.ts
+++ b/packages/app/src/deep-link-handler.ts
@@ -19,6 +19,25 @@ export interface DeepLinkHandlerContext {
   trustPolicy: UrlTrustPolicy;
   dispatchShareTarget: (payload: ShareTargetPayload) => void;
   dispatchDeepLinkCallback: (url: string) => void;
+  /**
+   * Universal/App-Link hosts (e.g. `eliza.app`) whose `https://<host>/<path>`
+   * links route into the same hash routes as the custom `<scheme>://` links.
+   * iOS associated-domains + Android `assetlinks.json` make the OS hand these
+   * to the installed app; this is the in-app routing half. Subdomains match.
+   */
+  appLinkHosts?: string[];
+}
+
+/** True for an `https://<trusted-host>/<path>` universal/App link. */
+export function isTrustedAppLink(
+  parsed: URL,
+  appLinkHosts: string[] | undefined,
+): boolean {
+  if (parsed.protocol !== "https:") return false;
+  const host = parsed.host.toLowerCase();
+  return (appLinkHosts ?? []).some(
+    (h) => host === h.toLowerCase() || host.endsWith(`.${h.toLowerCase()}`),
+  );
 }
 
 export function createDeepLinkHandler(ctx: DeepLinkHandlerContext) {
@@ -34,8 +53,14 @@ export function createDeepLinkHandler(ctx: DeepLinkHandlerContext) {
       return;
     }
 
-    if (parsed.protocol !== `${ctx.urlScheme}:`) return;
-    const path = getDeepLinkPath(parsed);
+    const isCustomScheme = parsed.protocol === `${ctx.urlScheme}:`;
+    const isAppLink = isTrustedAppLink(parsed, ctx.appLinkHosts);
+    if (!isCustomScheme && !isAppLink) return;
+    // A universal link's path is its URL pathname; a custom-scheme link encodes
+    // it as host(+pathname). Both feed the same route switch below.
+    const path = isAppLink
+      ? parsed.pathname.replace(/^\/+|\/+$/g, "")
+      : getDeepLinkPath(parsed);
 
     if (/^settings\/connectors\/[a-z0-9-]+$/i.test(path)) {
       window.location.hash = "#connectors";

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -134,6 +134,7 @@ import {
 } from "./app-config";
 import { APP_ENV_ALIASES, APP_ENV_PREFIX } from "./brand-env";
 import { APP_CHARACTER_CATALOG } from "./character-catalog";
+import { isTrustedAppLink } from "./deep-link-handler";
 import { buildAssistantLaunchHashRoute } from "./deep-link-routing";
 import {
   apiBaseToDeviceBridgeUrl,
@@ -1791,6 +1792,11 @@ async function initializeNetworkListener(): Promise<void> {
   }
 }
 
+// Universal/App-Link hosts whose `https://<host>/<path>` links route into the
+// app (paired with the iOS associated-domains entitlement + the Android/web
+// `assetlinks.json` + `apple-app-site-association` served from eliza.app).
+const APP_LINK_HOSTS = ["eliza.app"];
+
 function handleDeepLink(url: string): void {
   if (routeFirstRunDeepLink(url, APP_URL_SCHEME)) {
     return;
@@ -1803,8 +1809,14 @@ function handleDeepLink(url: string): void {
     return;
   }
 
-  if (parsed.protocol !== `${APP_URL_SCHEME}:`) return;
-  const path = getDeepLinkPath(parsed);
+  // Accept both the custom `<scheme>://` links and `https://eliza.app/<path>`
+  // universal/App links (iOS associated-domains + Android assetlinks hand these
+  // to the installed app); both route into the same hash routes below.
+  const isAppLink = isTrustedAppLink(parsed, APP_LINK_HOSTS);
+  if (parsed.protocol !== `${APP_URL_SCHEME}:` && !isAppLink) return;
+  const path = isAppLink
+    ? parsed.pathname.replace(/^\/+|\/+$/g, "")
+    : getDeepLinkPath(parsed);
 
   // eliza://settings/connectors/<provider> — open Settings → Connectors.
   // The new Connectors section renders one inline expansion per connector;

--- a/packages/homepage/public/.well-known/README.md
+++ b/packages/homepage/public/.well-known/README.md
@@ -1,0 +1,37 @@
+# Universal / App Links for `eliza.app`
+
+These files let an `https://eliza.app/<path>` link open the **installed native app**
+(iOS Universal Links + Android App Links) instead of only the website, paired with
+the in-app router in `packages/app/src/deep-link-handler.ts` (`isTrustedAppLink` +
+the `https://eliza.app/...` path → hash-route mapping) and the `main.tsx`
+`handleDeepLink` that consumes them.
+
+- **`apple-app-site-association`** — served at
+  `https://eliza.app/.well-known/apple-app-site-association` (no extension,
+  `Content-Type: application/json`). Lists the app bundle + the paths it claims.
+- **`assetlinks.json`** — served at `https://eliza.app/.well-known/assetlinks.json`.
+  Android App Links statement for `ai.elizaos.app`.
+
+## Deferred — requires the release signing identity (release/ops owner)
+
+The structure here is complete; two values are signing-identity-specific and must
+be filled by whoever holds the release certs (they are **not** in the repo):
+
+1. **`apple-app-site-association` → `appIDs`**: replace `TEAMID` with the Apple
+   Developer **Team ID** (`<TeamID>.ai.elizaos.app`).
+2. **`assetlinks.json` → `sha256_cert_fingerprints`**: replace the `TODO:` with the
+   **release** keystore SHA-256 fingerprint
+   (`keytool -list -v -keystore <release.keystore>`).
+
+The matching native config also needs to be added in the app shells (the entitlement
++ intent-filter that tell the OS to consult these files):
+
+- **iOS**: `com.apple.developer.associated-domains` entitlement with
+  `applinks:eliza.app` (Capacitor iOS project entitlements).
+- **Android**: an `autoVerify="true"` intent-filter for `https://eliza.app` in the
+  app's `AndroidManifest.xml`.
+
+Until those land + the DNS for `eliza.app` is cut over (tracked separately), the
+app handles the custom `elizaos://` scheme as before; the `https` path is wired and
+unit-tested (`deep-link-handler.test.ts`) so it works the moment the OS hands the
+link over.

--- a/packages/homepage/public/.well-known/apple-app-site-association
+++ b/packages/homepage/public/.well-known/apple-app-site-association
@@ -1,0 +1,22 @@
+{
+  "applinks": {
+    "details": [
+      {
+        "appIDs": ["TEAMID.ai.elizaos.app"],
+        "components": [
+          { "/": "/chat*" },
+          { "/": "/wallet" },
+          { "/": "/inventory" },
+          { "/": "/messages*" },
+          { "/": "/contacts" },
+          { "/": "/phone*" },
+          { "/": "/browser" },
+          { "/": "/settings*" },
+          { "/": "/connect*" },
+          { "/": "/share*" },
+          { "/": "/api/*", "exclude": true }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/homepage/public/.well-known/assetlinks.json
+++ b/packages/homepage/public/.well-known/assetlinks.json
@@ -1,0 +1,12 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "ai.elizaos.app",
+      "sha256_cert_fingerprints": [
+        "TODO:REPLACE_WITH_RELEASE_SIGNING_KEY_SHA256_FINGERPRINT"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
Addresses the **App-Links gap** in #9965: an `https://eliza.app/<path>` link (from web/email/SMS) could never hand off to the installed native app — only the custom `elizaos://` scheme was handled. This wires the app-side routing + ships the domain association files.

## App-side routing (testable)
- **`deep-link-handler.ts`** — `isTrustedAppLink(url, hosts)` (https + a configured host/subdomain) and accept universal links alongside the custom scheme, mapping the URL **pathname** to the same route switch (`wallet`/`chat`/`messages`/`settings`/`connect`/`share`/…).
- **`main.tsx` `handleDeepLink`** — mirrors it on the live dispatcher (`APP_LINK_HOSTS = ["eliza.app"]`), so `https://eliza.app/wallet` opens the wallet view the same as `elizaos://wallet`.

## Domain association files (served from the eliza.app GitHub Pages root)
- `packages/homepage/public/.well-known/apple-app-site-association`
- `packages/homepage/public/.well-known/assetlinks.json`
- a README documenting what remains.

## Tests
`deep-link-handler.test.ts` — **6/6**: https→hash routing parity with the custom scheme, the connectors deep path, query passthrough, untrusted-host + no-hosts-configured rejection, and the subdomain/`http` guards.

## Deferred (needs the release signing identity + ops — documented in the README, not finishable in-repo)
- Fill the Apple **Team ID** in the AASA and the Android **release SHA-256 fingerprint** in `assetlinks.json` (held by the release owner, not in the repo).
- Add the iOS `com.apple.developer.associated-domains` (`applinks:eliza.app`) entitlement + the Android `autoVerify` intent-filter in the native shells.
- The `eliza.app` DNS cutover (registrar/ops).

Until those land the app keeps handling `elizaos://` as before; the `https` path is wired + unit-tested so it works the moment the OS hands the link over. (The branding-URL divergence + marketing CTA + README parts of #9965 already landed via #10016.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)