### PR TITLE
fix(cloud): roll back Stripe webhook dedup marker if enqueue fails

### DIFF
--- a/packages/cloud/api/stripe/webhook/route.ts
+++ b/packages/cloud/api/stripe/webhook/route.ts
@@ -165,7 +165,28 @@ async function handleStripeWebhook(c: AppContext): Promise<Response> {
     receivedAt: Date.now(),
   };
 
-  await enqueue(STRIPE_QUEUE_KEY, message);
+  // The dedup marker (tryCreate) is already committed to Postgres. If the
+  // durable enqueue to Redis fails (e.g. an Upstash blip), we MUST roll the
+  // marker back — otherwise Stripe's retry hits `created:false` above, returns
+  // 200 {duplicate}, and the paid event is dropped forever (card charged, no
+  // credits). Roll back, then rethrow so Stripe gets a 5xx and retries.
+  try {
+    await enqueue(STRIPE_QUEUE_KEY, message);
+  } catch (enqueueError) {
+    await webhookEventsRepository
+      .deleteByEventId(event.id, "stripe")
+      .catch((rollbackError) => {
+        logger.error(
+          "[Stripe Webhook] enqueue failed AND dedup-marker rollback failed — event may be dropped",
+          { eventId: event.id, rollbackError },
+        );
+      });
+    logger.error(
+      "[Stripe Webhook] enqueue failed — rolled back dedup marker so Stripe retries",
+      { eventId: event.id },
+    );
+    throw enqueueError;
+  }
 
   return c.json({ received: true, queued: true }, 200);
 }

--- a/packages/cloud/shared/src/db/repositories/webhook-events.ts
+++ b/packages/cloud/shared/src/db/repositories/webhook-events.ts
@@ -75,6 +75,23 @@ export class WebhookEventsRepository {
   }
 
   /**
+   * Delete a single webhook event's dedup marker by event id. Used to roll the
+   * marker back when the durable enqueue fails AFTER tryCreate committed, so the
+   * provider's retry re-processes the event instead of hitting `created:false`
+   * and silently dropping a paid event.
+   */
+  async deleteByEventId(eventId: string, provider: string): Promise<void> {
+    await dbWrite
+      .delete(webhookEvents)
+      .where(
+        and(
+          eq(webhookEvents.event_id, eventId),
+          eq(webhookEvents.provider, provider),
+        ),
+      );
+  }
+
+  /**
    * Delete old webhook events to prevent table growth.
    * Keeps events from the last `retentionDays` days.
    */


### PR DESCRIPTION
## Problem (deep-scan; adversarially verified — money/durability)

`handleStripeWebhook` commits the idempotency marker (`webhookEventsRepository.tryCreate`) to Postgres and **only then** enqueues to Redis — two datastores, no transactional coupling, no compensation. `enqueue()` **throws on any Redis/Upstash unavailability** (`pushQueueHead` returns null → `pushRequired` throws). When that happens:

1. marker already committed → Stripe gets a 5xx and retries;
2. on retry `tryCreate` returns `created:false` → `200 {duplicate}` → the event is **never re-enqueued**.

A paid `checkout.session.completed` is **dropped forever**: card charged, org/app credits + revenue splits + earnings never applied. No DLQ, no reaper (cleanup only deletes 30-day-old rows).

## Fix
Wrap `enqueue` in try/catch; on failure **delete the just-created marker** (new `webhookEventsRepository.deleteByEventId`) and rethrow, so Stripe's retry re-creates the marker and re-enqueues. The happy-path dedup-on-retry is unchanged (only the failure path is touched). The consumer already re-dedups every downstream write, so this can never double-credit.

Files: `webhook-events.ts` (+`deleteByEventId`), `stripe/webhook/route.ts` (rollback-on-enqueue-failure).