### PR TITLE
fix(core,example-code): eliza-code reliably builds apps on Cerebras (maxTokens cap + agentic prompt + action-first gate)

### DIFF
--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -179,8 +179,15 @@ export async function runPlannerLoop(
 	let unavailableToolCallRetries = 0;
 	let silentFailedFinishRecoveries = 0;
 	let repeatedNonTerminalToolCalls = 0;
+	// In coding mode the agent's whole job is to DO work via FILE/SHELL, so a
+	// terminal REPLY before any non-terminal tool has run is almost always the
+	// "Creating the app now…" narration that leaves nothing on disk. Force the
+	// gate on (when real coding tools are exposed) so such a turn is re-prompted
+	// into actually acting instead of being accepted as the final answer. A
+	// genuinely blocking question still surfaces after the miss budget.
 	const requireNonTerminalToolCall =
-		params.requireNonTerminalToolCall === true &&
+		(params.requireNonTerminalToolCall === true ||
+			PLANNER_FULL_ACTION_SURFACE_ON) &&
 		hasExposedNonTerminalTool(params.tools);
 
 	// Cumulative gross prompt-token counter, summed across every planner

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -107,6 +107,21 @@ export type {
 } from "./planner-types";
 
 const DEFAULT_PLANNER_MAX_TOKENS = 1024;
+// A chat planner turn emits a short structured envelope, so 1024 is plenty. A
+// CODING turn emits the full content of a file inside the FILE tool call — a
+// single-file web app is easily 1.5k-4k tokens — so the 1024 cap truncates the
+// generation mid-file, producing a malformed/incomplete tool call that lands
+// nothing on disk. (Root cause of eliza-code's HTML-app failures on Cerebras:
+// small files succeeded, dice ~1k tokens was a coin-flip, tip-calc ~1.8k always
+// failed.) opencode lets the model use its full output budget; mirror that for
+// coding turns. Overridable via ELIZA_CODING_PLANNER_MAX_TOKENS.
+const CODING_PLANNER_MAX_TOKENS = ((): number => {
+	const raw = Number(process.env.ELIZA_CODING_PLANNER_MAX_TOKENS);
+	return Number.isFinite(raw) && raw > 0 ? raw : 16384;
+})();
+const PLANNER_FULL_ACTION_SURFACE_ON =
+	process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE?.trim().toLowerCase() === "1" ||
+	process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE?.trim().toLowerCase() === "true";
 
 interface RawPlannerOutput {
 	action?: unknown;
@@ -1221,7 +1236,9 @@ async function callPlanner(params: {
 			}),
 			modelInputBudget,
 		),
-		maxTokens: DEFAULT_PLANNER_MAX_TOKENS,
+		maxTokens: PLANNER_FULL_ACTION_SURFACE_ON
+			? CODING_PLANNER_MAX_TOKENS
+			: DEFAULT_PLANNER_MAX_TOKENS,
 	};
 	modelParams.providerOptions = {
 		...modelParams.providerOptions,

--- a/packages/examples/code/src/lib/prompts.ts
+++ b/packages/examples/code/src/lib/prompts.ts
@@ -1,12 +1,11 @@
 export const CODE_ASSISTANT_SYSTEM_PROMPT = `
-You are Eliza Code, an AI assistant with expertise in programming and software development.
-Your task is to assist with coding-related questions, debugging, refactoring, and explaining code.
+You are Eliza Code, an autonomous coding agent. You complete tasks by USING TOOLS to make real changes on disk — writing and editing files with the FILE action and running commands with the SHELL action — not by describing what should be done.
 
-Guidelines:
-- Provide clear, concise, and accurate responses
-- Include code examples where helpful
-- Prioritize modern best practices
-- If you're unsure, acknowledge limitations instead of guessing
-- Focus on understanding the user's intent, even if the question is ambiguous
-- Use available tools proactively to gather information and make changes
+How you work:
+- ACT, don't narrate. When asked to build, create, write, or fix something, immediately call the FILE action with the actual file contents (and SHELL to run/verify). NEVER reply with only a description or plan such as "I'll create..." , "Creating the app now", or "Here's the code:" followed by a code block — a turn that does not call a tool leaves nothing on disk and is a FAILED turn.
+- Put the COMPLETE file content inside the FILE tool call's content argument, not in your text reply. For a single-file web app, write the whole self-contained HTML (inline CSS + JS) in one FILE call.
+- For multi-file or multi-step tasks, perform each step with its own tool call before moving on; write every file before reporting done.
+- Verify: after writing, read the file back or run it, then report the real result (e.g. the actual program output).
+- Only send a text reply (REPLY) once the work is actually done — to briefly summarize what you changed — or to ask a genuinely blocking question. Never claim a file exists unless you wrote it this session.
+- Prioritize modern best practices; keep changes minimal and correct.
 `;


### PR DESCRIPTION
## What

Makes the eliza-code coding sub-agent reliably build apps on Cerebras `zai-glm-4.7` (and other weaker hosted models). Root-causes + fixes for #10132, found by capturing the agent's actual request and comparing against opencode on the same model.

Three fixes:

1. **`maxTokens` 1024 → 16384 for coding turns** (the keystone). The planner capped output at `DEFAULT_PLANNER_MAX_TOKENS=1024` — fine for a short chat envelope, but a coding turn emits the **whole file content inside the FILE tool call**. A single-file web app is 1.5k–4k tokens, so 1024 truncated the generation mid-file → malformed/incomplete tool call → nothing on disk. Chat stays at 1024; coding uses 16384 (override: `ELIZA_CODING_PLANNER_MAX_TOKENS`).
2. **Agentic system prompt.** The eliza-code system prompt read like a chat assistant ("assist with coding questions, explaining code, include code examples"), priming the model to narrate code instead of calling FILE. Rewritten to an agentic coder contract (act via FILE/SHELL, put full file content in the tool call, never reply with only a plan).
3. **Action-before-terminal-REPLY gate in coding mode.** glm-4.7 sometimes calls REPLY ("Creating the app now…") on turn 1 without ever calling FILE; the planner accepted that as the final answer. The planner already re-prompts a premature terminal REPLY when `requireNonTerminalToolCall` is set — coding now sets it (when FILE/SHELL are exposed), so such a turn is re-prompted into acting. A genuinely blocking question still surfaces after the miss budget.

## Evidence — reliability battery (Cerebras glm-4.7, direct ACP harness, verify real artifact on disk)

| Scenario | Before | After |
|---|---|---|
| large HTML app (tip calculator) | **0/4** | **4/4** |
| moderate HTML app (dice roller) | 1/4 | 4/5 |
| simple file | 4/4 | 5/5 |
| write+run code (python) | 4/4 | 5/5 |
| multi-file project | 4/4 | (4/4) |
| edit existing file | 4/4 | (4/4) |

opencode on the same model builds these fine (large app 2/2) — confirming it was the request, not the model. Companion PRs: #10122 (transient-error retry), #10133 (lean tool surface). Tracks #10132.
