### PR TITLE
fix(cloud): don't lose app-creator earnings on webhook retry after partial failure

### DIFF
--- a/packages/cloud/api/src/queue/stripe-event.ts
+++ b/packages/cloud/api/src/queue/stripe-event.ts
@@ -187,7 +187,16 @@ async function handleCheckoutSessionCompleted(
     );
   }
 
-  if (isAppPurchase && !isDuplicate) {
+  // App purchases ALWAYS go through processPurchase — NOT gated on the org-credit
+  // `isDuplicate`. processPurchase is internally idempotent (its own app-earnings
+  // dedup via appEarningsRepository.findTransactionByPaymentIntent + addCredits'
+  // ON CONFLICT(stripe_payment_intent_id)), so this is safe on true duplicates
+  // AND lets a retry after a PARTIAL failure — org credit committed but creator
+  // earnings not yet written — re-enter and record the missing earnings. Gating
+  // on the org-credit dedup skipped that re-entry, permanently losing the
+  // creator's purchase-share earnings (org-credit and creator-earnings are
+  // written non-atomically; the org credit alone flips isDuplicate to true).
+  if (isAppPurchase) {
     logger.info(
       `[Stripe Queue] Processing app-specific credit purchase for app ${appId}`,
     );


### PR DESCRIPTION
## Problem (deep-scan; adversarially verified — money/creator under-payment)

`handleCheckoutSessionCompleted` gated the app-purchase path on the **org-credit** dedup (`isDuplicate`). But `processPurchase` writes the org credit and the creator's purchase-share earnings **non-atomically**: `addCredits` commits the org credit (carrying the `paymentIntentId`) first, then `recordCreatorEarnings` writes `app_earnings` + `redeemable_earnings`. A transient error between those commits leaves the org credit persisted (→ `isDuplicate=true` on retry) while creator earnings were never written — and on retry the `!isDuplicate` gate **skips `processPurchase` entirely**, so the creator **permanently loses** their earnings. (The non-app revenue-split path already runs every delivery via `dedupeBySourceId` to survive exactly this; the app path didn't.)

## Fix
App purchases always call `processPurchase`, which is itself idempotent — its app-earnings dedup (`appEarningsRepository.findTransactionByPaymentIntent`) + `addCredits`' **`ON CONFLICT (stripe_payment_intent_id) DO NOTHING`** (verified) make a true duplicate a no-op, while a partial-failure retry re-enters and records the missing earnings. No double org-credit. One-line gate change + rationale. 1 file.