### PR TITLE
feat(agent): bundle referenced media in agent backup/export (#9963)

### DIFF
--- a/packages/agent/src/api/media-store.ts
+++ b/packages/agent/src/api/media-store.ts
@@ -310,6 +310,38 @@ export function persistMediaBytes(
   return { url: `${MEDIA_URL_PREFIX}${fileName}`, hash, fileName };
 }
 
+/**
+ * Read a stored media file's raw bytes by its `<sha256>.<ext>` name, or null if
+ * absent/unreadable. Path-traversal-safe (the resolved path must stay in the
+ * store dir). Used by agent backup/export to bundle referenced media bytes.
+ */
+export function readStoredMediaBytes(fileName: string): Buffer | null {
+  const filePath = path.join(mediaDir(), fileName);
+  if (path.dirname(filePath) !== mediaDir()) return null;
+  try {
+    return fs.existsSync(filePath) ? fs.readFileSync(filePath) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write raw bytes to a stored media file by its `<sha256>.<ext>` name (the name
+ * is the content hash, so this is idempotent). Path-traversal-safe. Used by
+ * agent restore/import to rehydrate the content-addressed media store.
+ */
+export function writeStoredMediaFile(fileName: string, bytes: Buffer): boolean {
+  const filePath = path.join(mediaDir(), fileName);
+  if (path.dirname(filePath) !== mediaDir()) return false;
+  try {
+    fs.mkdirSync(mediaDir(), { recursive: true });
+    if (!fs.existsSync(filePath)) fs.writeFileSync(filePath, bytes);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 const DATA_URL_RE = /^data:([^;,]*)(;base64)?,([\s\S]*)$/;
 
 /** Persist a `data:` URL's bytes to the store; returns null for non-data URLs. */

--- a/packages/agent/src/services/agent-export.media.test.ts
+++ b/packages/agent/src/services/agent-export.media.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Media capture/restore for the agent backup/export (#9963): the export now
+ * bundles the content-addressed media bytes referenced by exported memories, so
+ * a restored agent keeps its message images/attachments (the DB rows alone point
+ * at media that wouldn't exist on the target).
+ */
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Memory, UUID } from "@elizaos/core";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  readStoredMediaBytes,
+  writeStoredMediaFile,
+} from "../api/media-store.ts";
+import { collectReferencedMediaFileNames } from "./agent-export.ts";
+
+const SHA_A = "a".repeat(64);
+const SHA_B = "b".repeat(64);
+
+function mem(content: Record<string, unknown>): Memory {
+  return {
+    id: "00000000-0000-0000-0000-000000000001" as UUID,
+    entityId: "00000000-0000-0000-0000-000000000002" as UUID,
+    agentId: "00000000-0000-0000-0000-000000000003" as UUID,
+    roomId: "00000000-0000-0000-0000-000000000004" as UUID,
+    content,
+    createdAt: 1,
+  };
+}
+
+describe("collectReferencedMediaFileNames", () => {
+  it("collects media file names from attachments and embedded text URLs, deduped", () => {
+    const memories = [
+      mem({ attachments: [{ url: `/api/media/${SHA_A}.png` }] }),
+      mem({ text: `see /api/media/${SHA_B}.jpg here` }),
+      // duplicate of A via text — must dedupe
+      mem({ text: `again /api/media/${SHA_A}.png` }),
+    ];
+    expect(collectReferencedMediaFileNames(memories).sort()).toEqual(
+      [`${SHA_A}.png`, `${SHA_B}.jpg`].sort(),
+    );
+  });
+
+  it("ignores non-stored and malformed URLs", () => {
+    const memories = [
+      mem({ attachments: [{ url: "https://example.com/cat.png" }] }),
+      mem({ text: "no media here, just /api/media/short.png" }),
+      mem({ content: undefined } as never),
+    ];
+    expect(collectReferencedMediaFileNames(memories)).toEqual([]);
+  });
+});
+
+describe("media-store read/write round-trip", () => {
+  let dir: string;
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "media-store-test-"));
+    process.env.ELIZA_STATE_DIR = dir;
+    process.env.MILADY_STATE_DIR = dir;
+  });
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writes bytes by content-hash name and reads them back", () => {
+    const bytes = Buffer.from("the webxr panels render now");
+    const fileName = `${SHA_A}.bin`;
+    expect(writeStoredMediaFile(fileName, bytes)).toBe(true);
+    expect(readStoredMediaBytes(fileName)?.equals(bytes)).toBe(true);
+    expect(readStoredMediaBytes(`${SHA_B}.bin`)).toBeNull(); // absent
+  });
+
+  it("refuses path traversal on both read and write", () => {
+    expect(writeStoredMediaFile("../escape.bin", Buffer.from("x"))).toBe(false);
+    expect(readStoredMediaBytes("../../etc/passwd")).toBeNull();
+    expect(existsSync(join(dir, "..", "escape.bin"))).toBe(false);
+  });
+});

--- a/packages/agent/src/services/agent-export.media.test.ts
+++ b/packages/agent/src/services/agent-export.media.test.ts
@@ -7,7 +7,7 @@
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { Memory, UUID } from "@elizaos/core";
+import type { Content, Memory, UUID } from "@elizaos/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   readStoredMediaBytes,
@@ -18,7 +18,7 @@ import { collectReferencedMediaFileNames } from "./agent-export.ts";
 const SHA_A = "a".repeat(64);
 const SHA_B = "b".repeat(64);
 
-function mem(content: Record<string, unknown>): Memory {
+function mem(content: Content): Memory {
   return {
     id: "00000000-0000-0000-0000-000000000001" as UUID,
     entityId: "00000000-0000-0000-0000-000000000002" as UUID,
@@ -32,7 +32,7 @@ function mem(content: Record<string, unknown>): Memory {
 describe("collectReferencedMediaFileNames", () => {
   it("collects media file names from attachments and embedded text URLs, deduped", () => {
     const memories = [
-      mem({ attachments: [{ url: `/api/media/${SHA_A}.png` }] }),
+      mem({ attachments: [{ id: "media-a", url: `/api/media/${SHA_A}.png` }] }),
       mem({ text: `see /api/media/${SHA_B}.jpg here` }),
       // duplicate of A via text — must dedupe
       mem({ text: `again /api/media/${SHA_A}.png` }),
@@ -44,9 +44,11 @@ describe("collectReferencedMediaFileNames", () => {
 
   it("ignores non-stored and malformed URLs", () => {
     const memories = [
-      mem({ attachments: [{ url: "https://example.com/cat.png" }] }),
+      mem({
+        attachments: [{ id: "remote-cat", url: "https://example.com/cat.png" }],
+      }),
       mem({ text: "no media here, just /api/media/short.png" }),
-      mem({ content: undefined } as never),
+      mem({}),
     ];
     expect(collectReferencedMediaFileNames(memories)).toEqual([]);
   });

--- a/packages/agent/src/services/agent-export.ts
+++ b/packages/agent/src/services/agent-export.ts
@@ -256,12 +256,12 @@ export function collectReferencedMediaFileNames(memories: Memory[]): string[] {
     if (fileName) names.add(fileName);
   };
   for (const mem of memories) {
-    const content = mem.content as
-      | { text?: string; attachments?: Array<{ url?: string }> }
-      | undefined;
-    for (const attachment of content?.attachments ?? []) add(attachment?.url);
-    if (typeof content?.text === "string") {
-      for (const match of content.text.matchAll(MEDIA_URL_IN_TEXT_RE)) {
+    const { attachments, text } = mem.content;
+    if (attachments) {
+      for (const attachment of attachments) add(attachment.url);
+    }
+    if (typeof text === "string") {
+      for (const match of text.matchAll(MEDIA_URL_IN_TEXT_RE)) {
         add(match[0]);
       }
     }
@@ -286,7 +286,8 @@ function restoreMedia(
   media: Array<{ fileName: string; base64: string }> | undefined,
 ): number {
   let restored = 0;
-  for (const { fileName, base64 } of media ?? []) {
+  if (!media) return restored;
+  for (const { fileName, base64 } of media) {
     if (writeStoredMediaFile(fileName, Buffer.from(base64, "base64"))) {
       restored++;
     }

--- a/packages/agent/src/services/agent-export.ts
+++ b/packages/agent/src/services/agent-export.ts
@@ -37,6 +37,12 @@ import type {
 } from "@elizaos/core";
 import { logger } from "@elizaos/core";
 import { z } from "zod";
+import {
+  isStoredMediaUrl,
+  mediaFileNameFromUrl,
+  readStoredMediaBytes,
+  writeStoredMediaFile,
+} from "../api/media-store.ts";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -100,6 +106,13 @@ export interface AgentExportPayload {
   worlds: World[];
   tasks: Task[];
   logs: Log[];
+  /**
+   * Content-addressed media bytes referenced by the exported memories (avatars,
+   * attachments). Each entry is a `<sha256>.<ext>` file name + its base64 bytes,
+   * so a restored agent's messages keep their images/files. Optional + additive:
+   * an export without media (or an older reader) still round-trips the DB.
+   */
+  media?: Array<{ fileName: string; base64: string }>;
 }
 
 export interface ImportResult {
@@ -116,6 +129,7 @@ export interface ImportResult {
     worlds: number;
     tasks: number;
     logs: number;
+    media: number;
   };
 }
 
@@ -190,6 +204,9 @@ const PayloadSchema = z.object({
   worlds: z.array(WorldSchema),
   tasks: z.array(TaskSchema),
   logs: z.array(LogSchema),
+  media: z
+    .array(z.object({ fileName: z.string(), base64: z.string() }))
+    .optional(),
 });
 
 type ValidatedAgentExportPayload = z.infer<typeof PayloadSchema>;
@@ -216,7 +233,65 @@ function toAgentExportPayload(
     worlds: payload.worlds,
     tasks: payload.tasks,
     logs: payload.logs,
+    media: payload.media,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Media (content-addressed store) capture / restore
+// ---------------------------------------------------------------------------
+
+const MEDIA_URL_IN_TEXT_RE = /\/api\/media\/[a-f0-9]{64}\.[a-z0-9]+/gi;
+
+/**
+ * The set of `<sha256>.<ext>` media file names referenced by the exported
+ * memories — from each message's `attachments[].url` and any media URL embedded
+ * in its text. Pure (no fs) so it unit-tests in isolation.
+ */
+export function collectReferencedMediaFileNames(memories: Memory[]): string[] {
+  const names = new Set<string>();
+  const add = (url: string | undefined | null) => {
+    if (!url || !isStoredMediaUrl(url)) return;
+    const fileName = mediaFileNameFromUrl(url);
+    if (fileName) names.add(fileName);
+  };
+  for (const mem of memories) {
+    const content = mem.content as
+      | { text?: string; attachments?: Array<{ url?: string }> }
+      | undefined;
+    for (const attachment of content?.attachments ?? []) add(attachment?.url);
+    if (typeof content?.text === "string") {
+      for (const match of content.text.matchAll(MEDIA_URL_IN_TEXT_RE)) {
+        add(match[0]);
+      }
+    }
+  }
+  return [...names];
+}
+
+/** Read each referenced media file's bytes into the base64 export entries. */
+function captureReferencedMedia(
+  memories: Memory[],
+): Array<{ fileName: string; base64: string }> {
+  const out: Array<{ fileName: string; base64: string }> = [];
+  for (const fileName of collectReferencedMediaFileNames(memories)) {
+    const bytes = readStoredMediaBytes(fileName);
+    if (bytes) out.push({ fileName, base64: bytes.toString("base64") });
+  }
+  return out;
+}
+
+/** Rehydrate the content-addressed store from the export's media entries. */
+function restoreMedia(
+  media: Array<{ fileName: string; base64: string }> | undefined,
+): number {
+  let restored = 0;
+  for (const { fileName, base64 } of media ?? []) {
+    if (writeStoredMediaFile(fileName, Buffer.from(base64, "base64"))) {
+      restored++;
+    }
+  }
+  return restored;
 }
 
 // ---------------------------------------------------------------------------
@@ -588,6 +663,7 @@ async function extractAgentData(
     worlds: agentWorlds,
     tasks: agentTasks,
     logs,
+    media: captureReferencedMedia(allMemories),
   };
 }
 
@@ -809,6 +885,11 @@ async function restoreAgentData(
   }
   logger.info(`[agent-import] Imported ${logsImported} logs`);
 
+  const mediaRestored = restoreMedia(payload.media);
+  if (mediaRestored > 0) {
+    logger.info(`[agent-import] Restored ${mediaRestored} media files`);
+  }
+
   return {
     success: true,
     agentId: newAgentId,
@@ -823,6 +904,7 @@ async function restoreAgentData(
       worlds: worldsImported,
       tasks: tasksImported,
       logs: logsImported,
+      media: mediaRestored,
     },
   };
 }


### PR DESCRIPTION
Advances #9963 by closing the **"DB rows but no media"** gap in the local agent backup. The existing encrypted `.eliza-agent` export captures the full DB (memories, entities, rooms, …) but a restored agent's messages pointed at media bytes that don't exist on the target. Now the export bundles them.

## What
- **`media-store.ts`** — `readStoredMediaBytes(fileName)` + `writeStoredMediaFile(fileName, bytes)`, both path-traversal-safe (resolved path must stay in the store dir); the content-hash name makes the write idempotent.
- **`agent-export.ts`**:
  - `collectReferencedMediaFileNames(memories)` — pure: scans each message's `attachments[].url` + any embedded `/api/media/<sha256>.<ext>` text URL, deduped.
  - `captureReferencedMedia()` reads those bytes into the payload's new **optional** `media: { fileName, base64 }[]` (the whole payload is already AES-256-GCM encrypted).
  - `restoreMedia()` rehydrates the content-addressed store on import.
  - **Additive + backward/forward compatible**: `version` stays `1`; an export without media — or an older reader (zod strips the unknown field) — still round-trips the DB.
- `ImportResult.counts.media` surfaces the restored count; the existing Settings export/import UI consumes `counts` as a `Record<string, number>`, so no UI change is needed.

## Tests — 4/4
`agent-export.media.test.ts`: collect from attachments + text (deduped), ignore non-stored/malformed URLs, write→read round-trip, and path-traversal refused on both read and write.

## Scope (honest)
This is the **media** half of #9963's "DB + media + vault" backup. Deliberately **not** included, with rationale:
- **Vault/secrets** — the export *intentionally* strips `secrets`; including them changes the product's threat model (the backup password would then guard secrets). That's a security/product decision for the maintainer, not a unilateral change.
- **Cloud real-image restore + auto-scheduling + R2 dual-target** — backend/image-gated (`SNAPSHOT_ENDPOINT_UNSUPPORTED`), tracked on the issue.

The earlier local DB export/import + Settings UI already shipped; this makes that backup actually complete for **DB + media**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)