### PR TITLE
test(cloud,ui): pin public charge projection and keep ratchet green

### DIFF
--- a/packages/cloud/api/__tests__/app-charge-public-route.test.ts
+++ b/packages/cloud/api/__tests__/app-charge-public-route.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { Context } from "hono";
+import { Hono } from "hono";
+
+const findPublicInfoById = mock();
+const getForApp = mock();
+
+mock.module("@/db/repositories/apps", () => ({
+  appsRepository: {
+    findPublicInfoById,
+  },
+}));
+
+mock.module("@/lib/services/app-charge-requests", () => ({
+  appChargeRequestsService: {
+    getForApp,
+  },
+}));
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: {} },
+  rateLimit: () => async (_c: Context, next: () => Promise<void>) => next(),
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    error: mock(),
+  },
+}));
+
+const { default: publicChargeRoute } = await import(
+  "../v1/apps/[id]/charges/[chargeId]/route"
+);
+
+const app = new Hono();
+app.route("/api/v1/apps/:id/charges/:chargeId", publicChargeRoute);
+
+type PublicChargeRouteBody = {
+  success: boolean;
+  charge: Record<string, string | number | boolean | null | string[]>;
+  app: Record<string, string | null>;
+};
+
+describe("public app charge route", () => {
+  beforeEach(() => {
+    findPublicInfoById.mockReset();
+    getForApp.mockReset();
+  });
+
+  test("returns only payer-facing charge fields, never internal metadata or IDs", async () => {
+    findPublicInfoById.mockResolvedValue({
+      id: "app-1",
+      name: "Demo App",
+      description: "Public demo",
+      logo_url: "https://cdn.example/logo.png",
+      website_url: "https://demo.example",
+      organization_id: "org-secret",
+      created_by_user_id: "user-secret",
+    });
+    getForApp.mockResolvedValue({
+      id: "charge-1",
+      appId: "app-1",
+      amountUsd: 12.5,
+      description: "Demo purchase",
+      providers: ["stripe", "oxapay"],
+      paymentContext: "any_payer",
+      paymentUrl: "https://pay.example/charge-1",
+      status: "requested",
+      paidAt: null,
+      paidProvider: undefined,
+      providerPaymentId: "pi_secret",
+      payerUserId: "payer-user-secret",
+      payerOrganizationId: "payer-org-secret",
+      expiresAt: new Date("2026-07-01T00:00:00.000Z"),
+      createdAt: new Date("2026-06-29T00:00:00.000Z"),
+      successUrl: "https://demo.example/success",
+      cancelUrl: "https://demo.example/cancel",
+      metadata: {
+        callback_secret: "secret",
+        callback_url: "https://creator.example/private-callback",
+        creator_organization_id: "creator-org-secret",
+        creator_user_id: "creator-user-secret",
+        room_id: "room-secret",
+      },
+    });
+
+    const response = await app.request("/api/v1/apps/app-1/charges/charge-1");
+
+    expect(response.status).toBe(200);
+    const body: PublicChargeRouteBody = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.charge).toMatchObject({
+      id: "charge-1",
+      appId: "app-1",
+      amountUsd: 12.5,
+      description: "Demo purchase",
+      providers: ["stripe", "oxapay"],
+      paymentContext: "any_payer",
+      paymentUrl: "https://pay.example/charge-1",
+      status: "requested",
+      successUrl: "https://demo.example/success",
+      cancelUrl: "https://demo.example/cancel",
+    });
+    expect(body.charge).not.toHaveProperty("metadata");
+    expect(body.charge).not.toHaveProperty("providerPaymentId");
+    expect(body.charge).not.toHaveProperty("payerUserId");
+    expect(body.charge).not.toHaveProperty("payerOrganizationId");
+    expect(JSON.stringify(body.charge)).not.toContain("secret");
+    expect(body.app).toEqual({
+      id: "app-1",
+      name: "Demo App",
+      description: "Public demo",
+      logo_url: "https://cdn.example/logo.png",
+      website_url: "https://demo.example",
+    });
+  });
+});

--- a/packages/ui/src/components/shell/__e2e__/conversation-swipe-fixture.tsx
+++ b/packages/ui/src/components/shell/__e2e__/conversation-swipe-fixture.tsx
@@ -164,24 +164,41 @@ function Harness(): React.JSX.Element {
     selectConversation,
   ]);
 
-  const controller = {
+  const controller: ShellController = {
     phase: "summoned",
     messages: threadFor(activeId),
     canSend: true,
     responding: false,
     turnStatus: null,
     recording: false,
+    waveformMode: "idle",
+    analyser: null,
+    open: () => {},
+    close: () => {},
+    isOpen: true,
     handsFree: false,
+    transcriptionMode: false,
     transcript: "",
     speaking: false,
     agentVoiceMuted: false,
     needsAudioUnlock: false,
-    modelStatus: { kind: "ready" },
+    modelStatus: {
+      kind: "ready",
+      blocksSend: false,
+      percent: null,
+      etaMs: null,
+      modelName: null,
+      errors: [],
+    },
+    captureVision: () => {},
+    visionCapturing: false,
     conversationNav,
     conversationLoading: false,
     send: () => {},
     toggleRecording: () => {},
     toggleHandsFree: () => {},
+    toggleTranscriptionMode: () => {},
+    stopTranscriptionAndMic: () => {},
     setDictationSink: () => {},
     setTranscriptSessionSink: () => {},
     setComposerHasDraft: () => {},
@@ -194,7 +211,7 @@ function Harness(): React.JSX.Element {
     navigateToViews: () => {},
     clearConversation: () => {},
     stop: () => {},
-  } as unknown as ShellController;
+  };
 
   return (
     <div


### PR DESCRIPTION
## Summary\n- adds the missing regression coverage for the already-merged public app-charge projection fix (#10158)\n- asserts the public charge endpoint never returns internal metadata, provider payment IDs, or payer IDs\n- replaces the conversation swipe e2e fixture's double-cast with a full typed ShellController shape so the type-safety ratchet stays green on latest develop\n\n## Validation\n- bun test __tests__/app-charge-public-route.test.ts (packages/cloud/api)\n- bun run --cwd packages/cloud/api typecheck\n- bun run --cwd packages/ui typecheck\n- bun run audit:type-safety-ratchet --json\n- bunx @biomejs/biome check packages/cloud/api/__tests__/app-charge-public-route.test.ts packages/ui/src/components/shell/__e2e__/conversation-swipe-fixture.tsx 'packages/cloud/api/v1/apps/[id]/charges/[chargeId]/route.ts'\n- git diff --check