### PR TITLE
fix(core): coding action-first gate + retry budget (last trivial-build narration residual, builds on #10141)

### DIFF
--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -176,12 +176,26 @@ export async function runPlannerLoop(
 		const raw = Number(process.env.ELIZA_CODING_MAX_TOOL_CALLS);
 		return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : 80;
 	})();
+	// Weak coding models (e.g. Cerebras glm-4.7) sometimes answer a trivial build
+	// with a terminal REPLY ("Creating the app now…") instead of calling FILE.
+	// The action-first gate below re-prompts that, but the chat default of 3
+	// misses gives up too soon to convert a stubborn narrator — give coding
+	// builds more attempts to actually act. Overridable via
+	// ELIZA_CODING_MAX_REQUIRED_TOOL_MISSES.
+	const codingMaxRequiredToolMisses = ((): number => {
+		const raw = Number(process.env.ELIZA_CODING_MAX_REQUIRED_TOOL_MISSES);
+		return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : 8;
+	})();
 	const config = ((): ChainingLoopConfig => {
 		const merged = mergeChainingLoopConfig(params.config);
 		return codingMode
 			? {
 					...merged,
 					maxToolCalls: Math.max(merged.maxToolCalls, codingMaxToolCalls),
+					maxRequiredToolMisses: Math.max(
+						merged.maxRequiredToolMisses,
+						codingMaxRequiredToolMisses,
+					),
 				}
 			: merged;
 	})();
@@ -198,8 +212,14 @@ export async function runPlannerLoop(
 	let unavailableToolCallRetries = 0;
 	let silentFailedFinishRecoveries = 0;
 	let repeatedNonTerminalToolCalls = 0;
+	// In coding mode the agent's whole job is to DO work via FILE/SHELL, so a
+	// terminal REPLY before any non-terminal tool has run is almost always the
+	// "Creating the app now…" narration that leaves nothing on disk. Force the
+	// gate on (when real coding tools are exposed) so such a turn is re-prompted
+	// into actually acting instead of being accepted as the final answer. A
+	// genuinely blocking question still surfaces after the miss budget.
 	const requireNonTerminalToolCall =
-		params.requireNonTerminalToolCall === true &&
+		(params.requireNonTerminalToolCall === true || codingMode) &&
 		hasExposedNonTerminalTool(params.tools);
 
 	// Cumulative gross prompt-token counter, summed across every planner


### PR DESCRIPTION
## What

Builds on the merged **#10141** (coding-mode `maxTokens` lift + `isCodingFullSurfaceMode()`) and **#10133** (act-don't-narrate preamble) to close the last residual on weak hosted coding models (Cerebras `zai-glm-4.7`): a *trivial* build request ("make a dice roller") is sometimes answered with a terminal REPLY ("Creating the app now…") and **nothing lands on disk**.

Two net-new pieces (#10141 did not include either):

1. **Force `requireNonTerminalToolCall` in coding mode.** The planner *already* re-prompts a premature terminal REPLY (the `toolCalls.every(isTerminalToolCall)` branch) — but only when `requireNonTerminalToolCall` is set, which the coding caller wasn't setting. Gating it on `isCodingFullSurfaceMode()` (when FILE/SHELL are exposed) re-prompts the narration into actually calling FILE. A genuinely blocking question still surfaces after the miss budget.
2. **Raise coding's `maxRequiredToolMisses` 3 → 8.** The chat default of 3 gave up before the re-prompt could convert a stubborn narrator. Overridable via `ELIZA_CODING_MAX_REQUIRED_TOOL_MISSES`.

Both scoped to coding mode via `isCodingFullSurfaceMode()`; chat is unchanged.

## Evidence (real Cerebras glm-4.7, direct ACP harness, verify the actual file on disk)

A bare "make a dice roller" build (the worst narration case):

| | before | + gate (misses 3) | + gate + misses 8 |
|---|---|---|---|
| dice roller | 1/4 | 2/5 | **4/6** |

The detailed-prompt builds that #10141 fixed (tip calculator, etc.) remain reliable; file/code/multi-file/edit stay 100%. Harness: `reliability-battery.mjs` (glm-4.7, `ELIZA_PLANNER_FULL_ACTION_SURFACE` set at runtime by `acp.ts` exactly as the live agent does).

Tracks #10132. Thanks @lalalune for the #10141 triage + salvaging the prompt rewrite to develop.
