### PR TITLE
feat(personal-assistant): consume the ambient app-usage signal (proactive focus-defer) + document mobile constraint (#9970)

### DIFF
--- a/.github/issue-evidence/9970-consume-app-usage-signal.md
+++ b/.github/issue-evidence/9970-consume-app-usage-signal.md
@@ -1,0 +1,64 @@
+# #9970 — Consume the ambient app-usage signal (proactive focus-defer) + document mobile constraint
+
+Follow-up slice to merged #10083 (ambient app-usage provider) and #10080
+(PRIORITIZE production loaders). Closes the review gap: *"the app-usage signal
+is now injected into provider context, but I did not find a downstream
+PRIORITIZE/proactive consumer yet."*
+
+## What changed
+
+1. **Proactive worker now acts on the signal, not just displays it.**
+   - `plugins/plugin-personal-assistant/src/activity-profile/focus-session.ts` (new) —
+     pure helpers + a read path over the **same** `getLatestForegroundActivity`
+     source the ambient provider uses. A sustained single-app foreground dwell
+     (≥ `FOCUS_SESSION_MIN_MS` = 10m) is a focus session.
+   - `proactive-worker.ts::executeProactiveTask` — while the owner is in a focus
+     session, non-urgent `goal_check_in` nudges defer to the next tick instead of
+     interrupting deep work, logging `[proactive] Owner in focus session (<app>
+     <n>m); deferring <k> non-urgent nudge(s) to next tick.`
+   - Time-critical kinds always pass through: `pre_activity_nudge` (imminent
+     meetings), `gm`/`gn` (daily greetings), and `social_overuse_check` (already
+     self-gated on *detected* overuse — a sustained dwell in a distracting app is
+     exactly when it should fire).
+   - Deferral leaves the fired log untouched → deferred nudges retry once focus
+     ends. **No second scheduler; no dropped delivery** — respects the
+     single-LifeOps-scheduler rule.
+
+2. **Mobile constraint documented (acceptance criterion #4).**
+   - `plugins/plugin-native-mobile-signals/src/definitions.ts` — documents
+     `rawUsageExportAvailable: false` as a *permanent* Apple
+     DeviceActivity/FamilyControls constraint (not a TODO), plus the coarse
+     summary / threshold-event flags it pairs with.
+   - Scope note: iOS coarse-summary/threshold *ingestion* into the read path is
+     intentionally **not** implemented here. The current iOS signal carries only
+     availability flags + `authorization.status` — **no coarse usage data is
+     emitted by any producer yet**. A reader for non-existent data would be a
+     speculative extension point. The signal spine (`life_activity_signals`,
+     `source: "mobile_health"`) already accepts these signals when POSTed and is
+     gated on `authorization.status === "approved"`; the aggregator should follow
+     the Android `androidUsageRowsFromSignals` precedent **once a native iOS
+     coarse-summary producer lands**.
+
+## Verification
+
+- `vitest run src/activity-profile/focus-session.test.ts` → **9/9 pass**
+  (threshold classification, kind partitioning, read-path success/throw/idle).
+- `vitest run src/activity-profile/proactive-worker.test.ts` → **2/2 pass**
+  (no regression in delivery routing).
+- `tsc --noEmit` → **0 errors in the changed files** (`focus-session.ts`,
+  `proactive-worker.ts`, `definitions.ts`). Remaining worktree typecheck errors
+  are pre-existing unbuilt sibling-plugin `.d.ts` (`@elizaos/plugin-inbox`,
+  `-finances`, `-calendly`, `-blocker`, `-native-activity-tracker`) in files this
+  PR does not touch — a build-ordering artifact of an isolated worktree; turbo CI
+  builds deps first.
+- `biome check` on the changed files → **clean**.
+
+## Evidence types (per PR_EVIDENCE.md)
+
+- **Real-LLM trajectory:** N/A — this is a deterministic worker gate, not an
+  agent/action/prompt/model change. The decision is pure structural logic over
+  the activity spine, covered by unit tests.
+- **Backend logs:** the new `[proactive] Owner in focus session …` structured
+  log (`boundary: activity_profile`, `operation: proactive_focus_defer`) marks
+  the consumed signal and deferred kinds.
+- **Frontend / screenshots / video / audio:** N/A — no UI or voice surface.

--- a/plugins/plugin-native-mobile-signals/src/definitions.ts
+++ b/plugins/plugin-native-mobile-signals/src/definitions.ts
@@ -118,8 +118,19 @@ export interface MobileSignalsScreenTimeStatus {
     }>;
   };
   reportAvailable: boolean;
+  /** Coarse, in-extension-rendered category summaries are available (no raw export). */
   coarseSummaryAvailable: boolean;
+  /** `DeviceActivityMonitor` threshold-crossing events are available. */
   thresholdEventsAvailable: boolean;
+  /**
+   * Permanently `false` — a platform constraint, not a TODO. Apple's
+   * DeviceActivity / FamilyControls model (iOS 15+) forbids exporting raw
+   * per-app usage to the host app: usage is only readable inside a rendered
+   * `DeviceActivityReport` extension (never exfiltrated) plus
+   * `DeviceActivityMonitor` threshold events. Host-side mobile screen-time is
+   * therefore scoped to coarse summaries + threshold events; there is no
+   * macOS-style per-window dwell on iOS. See issue #9970.
+   */
   rawUsageExportAvailable: false;
   android?: {
     usageAccessGranted: boolean;

--- a/plugins/plugin-personal-assistant/src/activity-profile/focus-session.test.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/focus-session.test.ts
@@ -1,0 +1,133 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import type { ActivityForegroundApp } from "./activity-tracker-reporting.js";
+import * as reporting from "./activity-tracker-reporting.js";
+import {
+  FOCUS_DEFERRABLE_KINDS,
+  FOCUS_SESSION_MIN_MS,
+  partitionFocusDeferredActions,
+  readOwnerFocusSession,
+  resolveFocusSession,
+  shouldDeferDuringFocus,
+} from "./focus-session.js";
+import type { ProactiveAction } from "./types.js";
+
+function foregroundApp(activeMs: number): ActivityForegroundApp {
+  return {
+    bundleId: "com.microsoft.VSCode",
+    appName: "Code",
+    observedAtMs: 1_700_000_000_000,
+    activeMs,
+  };
+}
+
+function action(kind: ProactiveAction["kind"]): ProactiveAction {
+  return {
+    kind,
+    scheduledFor: 0,
+    targetPlatform: "internal",
+    contextSummary: "",
+    messageText: "",
+    status: "pending",
+  };
+}
+
+describe("resolveFocusSession", () => {
+  it("returns a session once dwell crosses the focus threshold", () => {
+    const session = resolveFocusSession(foregroundApp(FOCUS_SESSION_MIN_MS));
+    expect(session).not.toBeNull();
+    expect(session?.app.appName).toBe("Code");
+    expect(session?.focusedMs).toBe(FOCUS_SESSION_MIN_MS);
+  });
+
+  it("returns null below the threshold or when no app is foregrounded", () => {
+    expect(
+      resolveFocusSession(foregroundApp(FOCUS_SESSION_MIN_MS - 1)),
+    ).toBeNull();
+    expect(resolveFocusSession(null)).toBeNull();
+  });
+});
+
+describe("shouldDeferDuringFocus", () => {
+  it("defers only non-urgent goal check-ins", () => {
+    expect(shouldDeferDuringFocus("goal_check_in")).toBe(true);
+    for (const kind of [
+      "gm",
+      "gn",
+      "pre_activity_nudge",
+      "social_overuse_check",
+    ] as const) {
+      expect(shouldDeferDuringFocus(kind)).toBe(false);
+    }
+  });
+
+  it("never defers a time-critical pre-activity meeting nudge", () => {
+    expect(FOCUS_DEFERRABLE_KINDS.has("pre_activity_nudge")).toBe(false);
+  });
+});
+
+describe("partitionFocusDeferredActions", () => {
+  it("dispatches everything when no focus session is active", () => {
+    const actions = [action("goal_check_in"), action("pre_activity_nudge")];
+    const { dispatch, deferred } = partitionFocusDeferredActions(
+      actions,
+      false,
+    );
+    expect(dispatch).toHaveLength(2);
+    expect(deferred).toHaveLength(0);
+  });
+
+  it("defers goal check-ins but passes time-critical nudges during focus", () => {
+    const actions = [
+      action("goal_check_in"),
+      action("pre_activity_nudge"),
+      action("social_overuse_check"),
+    ];
+    const { dispatch, deferred } = partitionFocusDeferredActions(actions, true);
+    expect(deferred.map((a) => a.kind)).toEqual(["goal_check_in"]);
+    expect(dispatch.map((a) => a.kind)).toEqual([
+      "pre_activity_nudge",
+      "social_overuse_check",
+    ]);
+  });
+});
+
+describe("readOwnerFocusSession", () => {
+  const runtime = { agentId: "agent-1" } as unknown as IAgentRuntime;
+
+  it("returns a session for a sustained foreground app", async () => {
+    vi.spyOn(reporting, "getLatestForegroundActivity").mockResolvedValueOnce(
+      foregroundApp(FOCUS_SESSION_MIN_MS + 5 * 60_000),
+    );
+    const session = await readOwnerFocusSession({
+      runtime,
+      now: new Date(1_700_000_000_000),
+    });
+    expect(session?.app.appName).toBe("Code");
+    vi.restoreAllMocks();
+  });
+
+  it("returns null (no suppression) when the read throws", async () => {
+    vi.spyOn(reporting, "getLatestForegroundActivity").mockRejectedValueOnce(
+      new Error("db down"),
+    );
+    const session = await readOwnerFocusSession({
+      runtime,
+      now: new Date(1_700_000_000_000),
+    });
+    expect(session).toBeNull();
+    vi.restoreAllMocks();
+  });
+
+  it("returns null when no app is foregrounded (idle/deactivated)", async () => {
+    vi.spyOn(reporting, "getLatestForegroundActivity").mockResolvedValueOnce(
+      null,
+    );
+    const session = await readOwnerFocusSession({
+      runtime,
+      now: new Date(1_700_000_000_000),
+    });
+    expect(session).toBeNull();
+    vi.restoreAllMocks();
+  });
+});

--- a/plugins/plugin-personal-assistant/src/activity-profile/focus-session.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/focus-session.ts
@@ -1,0 +1,112 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { logger } from "@elizaos/core";
+import {
+  type ActivityForegroundApp,
+  getLatestForegroundActivity,
+} from "./activity-tracker-reporting.js";
+import type { ProactiveAction } from "./types.js";
+
+/**
+ * Consumer of the ambient app-usage signal (issue #9970): the activity-profile
+ * provider already injects "current app / today's dwell" into owner context;
+ * this module makes the proactive worker *act* on that signal instead of only
+ * displaying it. When the owner is heads-down in a single app, non-urgent
+ * proactive nudges defer to the next tick rather than interrupting deep work.
+ */
+
+/**
+ * A continuous single-app foreground dwell of at least this long is treated as
+ * an active focus session. `getLatestForegroundActivity` already returns null
+ * for idle / system-inactivity / deactivated states, so the only remaining
+ * signal we need is sustained `activeMs`.
+ */
+export const FOCUS_SESSION_MIN_MS = 10 * 60_000;
+
+/**
+ * How far back we look for the latest foreground event. A focus session is
+ * derived from that event's continuous active time, not the window length;
+ * the window only bounds the lookup.
+ */
+const FOCUS_LOOKBACK_MS = 12 * 60 * 60_000;
+
+/**
+ * Proactive action kinds that defer while the owner is in a focus session.
+ * These are non-urgent and retry on the next worker tick once focus ends.
+ *
+ * Intentionally excluded:
+ * - `pre_activity_nudge` — time-critical (imminent calendar/occurrence); never suppress.
+ * - `gm` / `gn` — once-a-day greetings, not interruptive churn.
+ * - `social_overuse_check` — already self-gated on *detected* overuse, so a
+ *   sustained dwell in a distracting app is exactly when it should fire.
+ */
+export const FOCUS_DEFERRABLE_KINDS: ReadonlySet<ProactiveAction["kind"]> =
+  new Set<ProactiveAction["kind"]>(["goal_check_in"]);
+
+export interface OwnerFocusSession {
+  app: ActivityForegroundApp;
+  focusedMs: number;
+}
+
+/** Pure: classify the latest foreground app as a sustained focus session. */
+export function resolveFocusSession(
+  current: ActivityForegroundApp | null,
+  minMs: number = FOCUS_SESSION_MIN_MS,
+): OwnerFocusSession | null {
+  if (!current) return null;
+  if (current.activeMs < minMs) return null;
+  return { app: current, focusedMs: current.activeMs };
+}
+
+/** Pure: does this action kind defer while a focus session is active? */
+export function shouldDeferDuringFocus(kind: ProactiveAction["kind"]): boolean {
+  return FOCUS_DEFERRABLE_KINDS.has(kind);
+}
+
+/**
+ * Pure: split actions into those to dispatch now vs defer to the next tick.
+ * When no focus session is active, everything dispatches unchanged.
+ */
+export function partitionFocusDeferredActions(
+  actions: ProactiveAction[],
+  focusActive: boolean,
+): { dispatch: ProactiveAction[]; deferred: ProactiveAction[] } {
+  if (!focusActive) return { dispatch: actions, deferred: [] };
+  const dispatch: ProactiveAction[] = [];
+  const deferred: ProactiveAction[] = [];
+  for (const action of actions) {
+    if (shouldDeferDuringFocus(action.kind)) deferred.push(action);
+    else dispatch.push(action);
+  }
+  return { dispatch, deferred };
+}
+
+/**
+ * Read the owner's current foreground focus session from the activity spine.
+ * Returns null (no suppression) when there is no sustained foreground app or
+ * the read fails — proactive delivery must never be blocked by this signal.
+ */
+export async function readOwnerFocusSession(args: {
+  runtime: IAgentRuntime;
+  now: Date;
+  minMs?: number;
+}): Promise<OwnerFocusSession | null> {
+  const { runtime, now } = args;
+  try {
+    const current = await getLatestForegroundActivity(
+      runtime,
+      String(runtime.agentId),
+      { sinceMs: now.getTime() - FOCUS_LOOKBACK_MS, untilMs: now.getTime() },
+    );
+    return resolveFocusSession(current, args.minMs ?? FOCUS_SESSION_MIN_MS);
+  } catch (error) {
+    logger.warn(
+      {
+        boundary: "activity_profile",
+        operation: "owner_focus_session_read",
+        err: error instanceof Error ? error : undefined,
+      },
+      "[proactive] Failed to read owner focus session; proceeding without focus suppression.",
+    );
+    return null;
+  }
+}

--- a/plugins/plugin-personal-assistant/src/activity-profile/proactive-worker.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/proactive-worker.ts
@@ -23,6 +23,10 @@ import { resolveDefaultTimeZone } from "../lifeops/defaults.js";
 import { ensureRuntimeAgentRecord } from "../lifeops/runtime.js";
 import { LifeOpsService, LifeOpsServiceError } from "../lifeops/service.js";
 import { resolveEffectiveDayKey } from "./analyzer.js";
+import {
+  partitionFocusDeferredActions,
+  readOwnerFocusSession,
+} from "./focus-session.js";
 import { proactiveInboxDigestRequest } from "./proactive-inbox-digest.js";
 import {
   type CalendarEventSlim,
@@ -487,13 +491,37 @@ export async function executeProactiveTask(
       action !== null && action.status === "pending",
   );
 
+  // Consume the ambient app-usage signal (#9970): when the owner is heads-down
+  // in a sustained focus session, defer non-urgent nudges to the next tick
+  // rather than interrupting deep work. Deferred actions are simply not
+  // dispatched this tick — the fired log is untouched, so they retry once focus
+  // ends. Time-critical kinds (pre_activity_nudge, gm/gn, social_overuse_check)
+  // always pass through.
+  const focusSession = await readOwnerFocusSession({ runtime, now });
+  const { dispatch: dispatchableActions, deferred: focusDeferredActions } =
+    partitionFocusDeferredActions(allActions, focusSession !== null);
+  if (focusSession && focusDeferredActions.length > 0) {
+    logger.info(
+      {
+        boundary: "activity_profile",
+        operation: "proactive_focus_defer",
+        focusApp: focusSession.app.appName,
+        focusedMs: focusSession.focusedMs,
+        deferredKinds: focusDeferredActions.map((action) => action.kind),
+      },
+      `[proactive] Owner in focus session (${focusSession.app.appName} ${Math.round(
+        focusSession.focusedMs / 60_000,
+      )}m); deferring ${focusDeferredActions.length} non-urgent nudge(s) to next tick.`,
+    );
+  }
+
   const ownerContacts = loadOwnerContactsConfig({
     boundary: "activity_profile",
     operation: "owner_contacts_config",
     message:
       "[proactive] Failed to load owner contacts config; proactive messages cannot route to owner channels until config is available.",
   });
-  for (const action of allActions) {
+  for (const action of dispatchableActions) {
     if (action.scheduledFor > now.getTime()) {
       continue;
     }

--- a/plugins/plugin-personal-assistant/test/proactive-nudge-pipeline.test.ts
+++ b/plugins/plugin-personal-assistant/test/proactive-nudge-pipeline.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { partitionFocusDeferredActions } from "../src/activity-profile/focus-session.js";
+import {
+  type GoalSlim,
+  planGoalCheckIns,
+} from "../src/activity-profile/proactive-planner.js";
+import type { ActivityProfile } from "../src/activity-profile/types.js";
+
+/**
+ * Wiring-regression guard for the proactive nudge pipeline (#9970). The issue
+ * calls out that the early `null`/`[]` returns make "no signal" and "pipeline
+ * broken" indistinguishable, so a wiring regression silently yields no nudges.
+ * This pins the happy path end to end: a real awake profile + an actionable
+ * goal must *produce* a nudge, and the focus-defer consumer must only defer it
+ * while the owner is heads-down. If a loader/planner regresses to an empty
+ * list, the first assertion fails loudly instead of the assistant going quiet.
+ */
+
+const NOW = new Date("2026-06-23T12:00:00Z");
+
+const profile = (o: Partial<ActivityProfile> = {}): ActivityProfile =>
+  ({
+    isCurrentlySleeping: false,
+    isCurrentlyActive: true,
+    lastSeenPlatform: "discord",
+    primaryPlatform: "client_chat",
+    ...o,
+  }) as unknown as ActivityProfile;
+
+const goal = (o: Partial<GoalSlim> = {}): GoalSlim => ({
+  id: "goal-1",
+  title: "Ship the release",
+  status: "active",
+  linkedDefinitionCount: 0,
+  recentCompletionRate: 0,
+  lastReviewedAt: null,
+  ...o,
+});
+
+describe("proactive nudge pipeline — produced then focus-gated", () => {
+  it("produces a goal check-in nudge from a real awake profile + actionable goal", () => {
+    const actions = planGoalCheckIns(profile(), [goal()], null, "UTC", NOW);
+    expect(actions).toHaveLength(1);
+    expect(actions[0]?.kind).toBe("goal_check_in");
+    expect(actions[0]?.status).toBe("pending");
+    expect(actions[0]?.goalId).toBe("goal-1");
+  });
+
+  it("yields no nudge while sleeping (no signal — distinct from a broken pipeline)", () => {
+    expect(
+      planGoalCheckIns(
+        profile({ isCurrentlySleeping: true }),
+        [goal()],
+        null,
+        "UTC",
+        NOW,
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("does not flood: at most one goal check-in across many goals", () => {
+    const actions = planGoalCheckIns(
+      profile(),
+      [goal({ id: "a" }), goal({ id: "b" }), goal({ id: "c" })],
+      null,
+      "UTC",
+      NOW,
+    );
+    expect(actions).toHaveLength(1);
+  });
+
+  it("dispatches the produced nudge when free, defers it during a focus session", () => {
+    const produced = planGoalCheckIns(profile(), [goal()], null, "UTC", NOW);
+    expect(produced).toHaveLength(1);
+
+    const free = partitionFocusDeferredActions(produced, false);
+    expect(free.dispatch).toHaveLength(1);
+    expect(free.deferred).toHaveLength(0);
+
+    const focused = partitionFocusDeferredActions(produced, true);
+    expect(focused.dispatch).toHaveLength(0);
+    expect(focused.deferred.map((a) => a.kind)).toEqual(["goal_check_in"]);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up slice for #9970, after merged **#10083** (ambient app-usage provider)
and **#10080** (PRIORITIZE production loaders). Closes the gap the last review
flagged: *"the app-usage signal is now injected into provider context, but I did
not find a downstream PRIORITIZE/proactive consumer yet."*

### 1. Proactive worker now *acts* on the signal (not just displays it)
- New `activity-profile/focus-session.ts` — pure, tested helpers
  (`resolveFocusSession`, `shouldDeferDuringFocus`, `partitionFocusDeferredActions`)
  + `readOwnerFocusSession`, reading the **same** `getLatestForegroundActivity`
  source the ambient provider uses. A sustained single-app foreground dwell
  (≥10m) is a focus session.
- `executeProactiveTask` defers non-urgent `goal_check_in` nudges to the next
  tick while the owner is heads-down, with a structured `[proactive]` log.
  Time-critical kinds always pass through — `pre_activity_nudge` (imminent
  meetings), `gm`/`gn` greetings, and `social_overuse_check` (already self-gated
  on *detected* overuse). Deferral leaves the fired log untouched → deferred
  nudges retry once focus ends. **No second scheduler; no dropped delivery.**

### 2. Mobile constraint documented (acceptance criterion #4)
- Documents `rawUsageExportAvailable: false` as a *permanent* Apple
  DeviceActivity/FamilyControls constraint, with the coarse-summary /
  threshold-event flags it pairs with.
- iOS coarse *ingestion* is intentionally **not** implemented here: the iOS
  signal currently carries only availability flags + `authorization.status` — no
  producer emits coarse usage data yet, so a reader for it would be a speculative
  extension point. The signal spine already accepts these signals (gated on
  `authorization.status === "approved"`); the aggregator should mirror the
  Android `androidUsageRowsFromSignals` precedent **once a native iOS producer
  lands**. Detail in the evidence file.

## Test plan
- `vitest src/activity-profile/focus-session.test.ts` → **9/9 pass**
- `vitest src/activity-profile/proactive-worker.test.ts` → **2/2 pass** (no regression)
- `tsc --noEmit` → **0 errors in changed files** (remaining worktree errors are
  unbuilt sibling-plugin `.d.ts` in untouched files — a build-ordering artifact;
  turbo CI builds deps first)
- `biome check` changed files → clean

Evidence: `.github/issue-evidence/9970-consume-app-usage-signal.md`.

Complements the in-flight outcome-scenario work in #10170; does not overlap it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
