### PR TITLE
ci(coverage): enforce the changed-files coverage gate (#9943 item 8)

### DIFF
--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -1,20 +1,18 @@
 name: coverage-gate
 
-# SOC2 CC4.1 — track unit-test coverage on changed files. ADVISORY at first
-# (warns but does not fail the build). Flip to required by setting the env
-# var COVERAGE_GATE_ENFORCE=1 in this workflow once the baseline is stable.
+# SOC2 CC4.1 — track unit-test coverage on changed files. ENFORCED (issue #9943):
+# a PR that changes a source file AND a Bun-native test which exercises it at
+# below the line-coverage floor fails this gate. Source-only / docs-only / no-Bun-
+# test PRs are not gated (the changed file simply never appears in the lcov, so
+# there is nothing to fail). This bounds the blast radius to genuinely
+# under-tested changes.
 #
-# The real per-package coverage floors live in the shared base vitest config
+# The per-package coverage floors live in the shared base vitest config
 # (packages/test/vitest/default.config.ts, sourced from coverage-policy.mjs) and
-# only apply on a `--coverage` run. The intended progression: measure the real
-# per-package baseline, raise the shared floors toward it, then flip
-# COVERAGE_GATE_ENFORCE to "1" here so this changed-files gate also fails the
-# build. Until then this layer stays advisory so develop CI cannot regress to
-# red on coverage alone. See issue #10104 for the broader test-gating audit.
-#
-# TODO(security): promote to required once the team agrees on a per-package
-# threshold floor. See docs/security/ai-pr-review-policy.md for the broader
-# review checklist.
+# apply on a `--coverage` run. This changed-files gate is the second layer: it
+# enforces a per-changed-file floor (`threshold` below), set to a ratchetable 50%
+# — raise it toward the long-term 70% target as suites fill in. See issue #9943
+# (the umbrella) and #10104 for the broader test-gating audit.
 
 on:
   pull_request:
@@ -64,9 +62,9 @@ jobs:
 
       - name: Setup Bun workspace
         if: steps.changed.outputs.tests != ''
-        # Keep dependency setup behind the changed-test check. The coverage gate
-        # is advisory for changed Bun-native tests, so docs-only and no-test PRs
-        # should not spend CI time or fail on unrelated registry/install noise.
+        # Keep dependency setup behind the changed-test check so docs-only and
+        # no-Bun-test PRs spend no CI time and are never gated (the gate only runs
+        # when a changed Bun-native test exists).
         uses: ./.github/actions/setup-bun-workspace
         with:
           install-native-deps: "false"
@@ -84,16 +82,16 @@ jobs:
             echo "no changed Bun-native test files; skipping coverage run"
             exit 0
           fi
-          bun test "${changed_tests[@]}" --coverage --coverage-reporter=lcov --coverage-dir=coverage || true
+          bun test "${changed_tests[@]}" --coverage --coverage-reporter=lcov --coverage-dir=coverage
         env:
           # Tests must produce coverage/lcov.info. If a package emits to a
           # different path, surface it here.
           BUN_COVERAGE_DIR: coverage
 
-      - name: Apply coverage gate (advisory)
+      - name: Apply coverage gate (enforced)
         if: steps.changed.outputs.tests != ''
         env:
-          COVERAGE_GATE_ENFORCE: "0"   # flip to "1" once baseline established
+          COVERAGE_GATE_ENFORCE: "1"   # enforced (issue #9943)
         run: |
           if [ ! -f coverage/lcov.info ]; then
             echo "no coverage/lcov.info produced; skipping gate"
@@ -101,6 +99,6 @@ jobs:
           fi
           awk \
             -v changed="${{ steps.changed.outputs.files }}" \
-            -v threshold=70 \
+            -v threshold=50 \
             -f scripts/security/coverage-gate.awk \
             coverage/lcov.info


### PR DESCRIPTION
Closes work-order item 8 of #9943 — "set a real coverage floor: flip `COVERAGE_GATE_ENFORCE` to 1, remove the `|| true`, so the gate can fail."

The `coverage-gate` was permanently advisory (`COVERAGE_GATE_ENFORCE=0` + `|| true` on the run step), so it could never fail a PR. This flips it on:

- `COVERAGE_GATE_ENFORCE` `0` → `1` (the awk now `exit 1`s on a below-floor changed file)
- drop the `|| true` on the coverage test run
- per-changed-file line floor `70` → **`50`** — achievable + ratchetable (raise toward the long-term 70 as suites fill in). 70 up front would red too many legit PRs, which is exactly why it sat advisory.

**Blast radius is bounded by design:** the gate only fails a file that is *both* changed *and* exercised by a changed Bun-native test below the floor. Source-only, docs-only, and no-Bun-test PRs never appear in the lcov → not gated. The per-package vitest floors (`coverage-policy.mjs`, 25%/15%) remain the first layer on full `--coverage` runs.

## Verification (awk self-test)
```
40% changed file → "coverage gate FAILED (enforcement enabled)"  exit 1
80% changed file → "coverage gate OK"                            exit 0
```
(This PR touches only the workflow YAML, so the gate itself doesn't run on it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)