### PR TITLE
test(ci): lock agent image Turbo build contract

### DIFF
--- a/.github/issue-evidence/10096-agent-image-turbo-contract.md
+++ b/.github/issue-evidence/10096-agent-image-turbo-contract.md
@@ -1,0 +1,30 @@
+# 10096 Build Agent Image Turbo Contract
+
+## Change
+
+- Added `packages/scripts/__tests__/build-agent-image-workflow.test.ts` as a regression contract for `.github/workflows/build-agent-image.yml`.
+- The test locks the Docker workspace artifact step to `node packages/scripts/run-turbo.mjs run build --filter=...` with the image's required app/agent/plugin filters.
+- The test rejects a reintroduced package/plugin shell build loop in that artifact step.
+- The test also confirms the remaining `plugins/*/dist` loop is only the post-build Node ESM rewrite step and runs after Turbo.
+
+## Verification
+
+- `node --check packages/scripts/__tests__/build-agent-image-workflow.test.ts`
+- `bun test packages/scripts/__tests__/build-agent-image-workflow.test.ts`
+- `gh run view 28356322785 --repo elizaOS/eliza --json status,conclusion,createdAt,headSha,headBranch,displayTitle,jobs,url`
+- `gh run view 28356322785 --repo elizaOS/eliza --job 84000059543 --log | rg -n "run-turbo\\.mjs run build|Packages in scope|Normalize plugin dist|docker-ci-smoke|Boot verified|within budget"`
+
+## GitHub Actions Evidence
+
+- Workflow run: https://github.com/elizaOS/eliza/actions/runs/28356322785
+- Job: https://github.com/elizaOS/eliza/actions/runs/28356322785/job/84000059543
+- Run status: `completed`, conclusion: `success`, branch: `develop`, head SHA: `d21cec23b7d9f7eb1c08d352c4467821139debe1`.
+- `Build Docker workspace artifacts` completed successfully from `2026-06-29T12:31:48Z` to `2026-06-29T12:36:47Z`.
+- The run log shows the workflow executed `node packages/scripts/run-turbo.mjs run build --concurrency=8` with explicit filters including `@elizaos/app`, `@elizaos/agent`, `@elizaos/plugin-sql`, `@elizaos/plugin-elizacloud`, and `@elizaos/plugin-x402`.
+- Turbo reported the complete package scope: `@elizaos/agent`, `@elizaos/app`, and the 24 filtered plugins.
+- `Normalize plugin dist for Node ESM` completed successfully after the Turbo build and ran `packages/scripts/rewrite-dist-relative-imports-node-esm.mjs`.
+- The Docker image build and real entrypoint gate also passed in the same job: `Verify image boots (real agent entrypoint)` reported `Boot verified: agent stayed up after health came up`, `cold readyMs=10451`, and `within budget (readyMs 10451 <= 25000)`.
+
+## Not Covered
+
+- This PR does not change the already-merged workflow behavior; it adds the missing regression guard/evidence for the #10096 `build-agent-image.yml` item.

--- a/.github/issue-evidence/10096-agent-image-turbo-contract.md
+++ b/.github/issue-evidence/10096-agent-image-turbo-contract.md
@@ -6,11 +6,13 @@
 - The test locks the Docker workspace artifact step to `node packages/scripts/run-turbo.mjs run build --filter=...` with the image's required app/agent/plugin filters.
 - The test rejects a reintroduced package/plugin shell build loop in that artifact step.
 - The test also confirms the remaining `plugins/*/dist` loop is only the post-build Node ESM rewrite step and runs after Turbo.
+- Wired the contract into `scenario-pr.yml` as an explicit `packages/scripts/__tests__` step so it runs in CI instead of relying on workspace test discovery.
 
 ## Verification
 
 - `node --check packages/scripts/__tests__/build-agent-image-workflow.test.ts`
 - `bun test packages/scripts/__tests__/build-agent-image-workflow.test.ts`
+- `bunx biome check .github/workflows/scenario-pr.yml packages/scripts/__tests__/build-agent-image-workflow.test.ts .github/issue-evidence/10096-agent-image-turbo-contract.md`
 - `gh run view 28356322785 --repo elizaOS/eliza --json status,conclusion,createdAt,headSha,headBranch,displayTitle,jobs,url`
 - `gh run view 28356322785 --repo elizaOS/eliza --job 84000059543 --log | rg -n "run-turbo\\.mjs run build|Packages in scope|Normalize plugin dist|docker-ci-smoke|Boot verified|within budget"`
 

--- a/.github/workflows/scenario-pr.yml
+++ b/.github/workflows/scenario-pr.yml
@@ -579,6 +579,12 @@ jobs:
       - name: Test-runner pool + shard unit tests
         run: bun test packages/scripts/__tests__/test-task-pool.test.ts
 
+      # Contract-tests the cloud agent image workflow's Turbo build step.
+      # packages/scripts/__tests__ is outside workspace test discovery, so keep
+      # this explicit or the workflow contract can silently stop running in CI.
+      - name: Agent image workflow contract
+        run: bun test packages/scripts/__tests__/build-agent-image-workflow.test.ts
+
       # E2E coverage gate (issue #8802). Now REQUIRED: the baseline is green —
       # commands 38/38, #8791 shortcuts 1/1 (wired into SHORTCUT_COVERAGE),
       # plugin routes covered/exempt, view ship-gates intact, zero blocking gaps.

--- a/packages/scripts/__tests__/build-agent-image-workflow.test.ts
+++ b/packages/scripts/__tests__/build-agent-image-workflow.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const workflowText = readFileSync(
+  new URL("../../../.github/workflows/build-agent-image.yml", import.meta.url),
+  "utf8",
+);
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function extractStepRunBlock(stepName: string): string {
+  const stepPattern = new RegExp(
+    `^      - name: ${escapeRegExp(stepName)}\\n(?<body>[\\s\\S]*?)(?=^      - (?:name|uses|id): |$(?![\\s\\S]))`,
+    "m",
+  );
+  const stepMatch = workflowText.match(stepPattern);
+  if (!stepMatch?.groups?.body) {
+    throw new Error(`Missing workflow step: ${stepName}`);
+  }
+
+  const runMatch = stepMatch.groups.body.match(
+    /^ {8}run: \|\n(?<run>(?: {10}.*(?:\n|$))*)/m,
+  );
+  if (!runMatch?.groups?.run) {
+    throw new Error(`Workflow step has no shell run block: ${stepName}`);
+  }
+
+  return runMatch.groups.run
+    .split("\n")
+    .map((line) => line.replace(/^ {10}/, ""))
+    .join("\n")
+    .trim();
+}
+
+function workflowStepNames(): string[] {
+  return [...workflowText.matchAll(/^ {6}- name: (.+)$/gm)].map(
+    (match) => match[1],
+  );
+}
+
+function extractTurboFilters(runBlock: string): string[] {
+  return [...runBlock.matchAll(/--filter=(?:'([^']+)'|"([^"]+)"|([^\\\s]+))/g)]
+    .map((match) => match[1] ?? match[2] ?? match[3])
+    .sort();
+}
+
+describe("build-agent-image workflow", () => {
+  test("uses Turbo filters for Docker workspace artifact builds", () => {
+    const runBlock = extractStepRunBlock("Build Docker workspace artifacts");
+
+    expect(runBlock).toContain("node packages/scripts/run-turbo.mjs run build");
+    expect(runBlock).toContain("--concurrency=8");
+    expect(runBlock).not.toMatch(
+      /\b(?:bun|npm|pnpm|yarn)\s+(?:run\s+)?build\b/,
+    );
+    expect(runBlock).not.toMatch(/\bfor\s+\w+\s+in\s+(?:packages|plugins)\b/);
+    expect(runBlock).not.toMatch(/\bwhile\s+read\b/);
+
+    expect(extractTurboFilters(runBlock)).toEqual([
+      "@elizaos/agent",
+      "@elizaos/app",
+      "@elizaos/plugin-agent-skills",
+      "@elizaos/plugin-browser",
+      "@elizaos/plugin-capacitor-bridge",
+      "@elizaos/plugin-coding-tools",
+      "@elizaos/plugin-commands",
+      "@elizaos/plugin-computeruse",
+      "@elizaos/plugin-discord",
+      "@elizaos/plugin-edge-tts",
+      "@elizaos/plugin-elizacloud",
+      "@elizaos/plugin-imessage",
+      "@elizaos/plugin-local-inference",
+      "@elizaos/plugin-mcp",
+      "@elizaos/plugin-native-filesystem",
+      "@elizaos/plugin-pdf",
+      "@elizaos/plugin-shell",
+      "@elizaos/plugin-signal",
+      "@elizaos/plugin-sql",
+      "@elizaos/plugin-streaming",
+      "@elizaos/plugin-telegram",
+      "@elizaos/plugin-video",
+      "@elizaos/plugin-wallet",
+      "@elizaos/plugin-whatsapp",
+      "@elizaos/plugin-workflow",
+      "@elizaos/plugin-x402",
+    ]);
+  });
+
+  test("keeps Node ESM dist rewrite after the Turbo build", () => {
+    const steps = workflowStepNames();
+    const buildIndex = steps.indexOf("Build Docker workspace artifacts");
+    const rewriteIndex = steps.indexOf("Normalize plugin dist for Node ESM");
+
+    expect(buildIndex).toBeGreaterThanOrEqual(0);
+    expect(rewriteIndex).toBeGreaterThan(buildIndex);
+
+    const runBlock = extractStepRunBlock("Normalize plugin dist for Node ESM");
+    expect(runBlock).toContain("for dist in plugins/*/dist");
+    expect(runBlock).toContain(
+      "packages/scripts/rewrite-dist-relative-imports-node-esm.mjs",
+    );
+    expect(runBlock).not.toMatch(
+      /\b(?:bun|npm|pnpm|yarn)\s+(?:run\s+)?build\b/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add a workflow contract test for `.github/workflows/build-agent-image.yml`
- Lock the Docker workspace artifact step to `node packages/scripts/run-turbo.mjs run build --filter=...`
- Reject a reintroduced package/plugin shell build loop in that artifact step while allowing the post-build Node ESM rewrite loop
- Record evidence from a successful real `build-agent-image.yml` GHA run after the Turbo-filter migration

## Evidence
- `.github/issue-evidence/10096-agent-image-turbo-contract.md`
- Successful GHA run: https://github.com/elizaOS/eliza/actions/runs/28356322785
- Successful GHA job: https://github.com/elizaOS/eliza/actions/runs/28356322785/job/84000059543

## Verification
- `node --check packages/scripts/__tests__/build-agent-image-workflow.test.ts`
- `bun test packages/scripts/__tests__/build-agent-image-workflow.test.ts`
- `bunx biome check packages/scripts/__tests__/build-agent-image-workflow.test.ts .github/issue-evidence/10096-agent-image-turbo-contract.md`
- `gh run view 28356322785 --repo elizaOS/eliza --json status,conclusion,createdAt,headSha,headBranch,displayTitle,jobs,url`
- `gh run view 28356322785 --repo elizaOS/eliza --job 84000059543 --log | rg -n "run-turbo\\.mjs run build|Packages in scope|Normalize plugin dist|docker-ci-smoke|Boot verified|within budget"`

Part of #10096
