### PR TITLE
fix(agent): stabilize #9948/#9949 security audit gates

### DIFF
--- a/packages/agent/src/api/public-route-audit.test.ts
+++ b/packages/agent/src/api/public-route-audit.test.ts
@@ -1,6 +1,6 @@
-import { readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { publicRouteKey, scanPublicRoutes } from "./public-route-audit.ts";
 
 const BASELINE_PATH = join(
@@ -48,5 +48,42 @@ describe("public:true route allowlist (#9948)", () => {
       keys.some((k) => k.includes("/api/media/:filename")),
       "scanner should detect the pre-auth media route",
     ).toBe(true);
+  });
+
+  it("fails closed to a full scan when git change detection is unavailable", async () => {
+    const fixtureDir = join(import.meta.dirname, "__tmp-public-route-audit");
+    const fixturePath = join(fixtureDir, "new-public-route.ts");
+    mkdirSync(fixtureDir, { recursive: true });
+    writeFileSync(
+      fixturePath,
+      `export const routes = [
+  {
+    path: "/__public-route-audit-fixture",
+    public: true,
+    handler: () => new Response("ok"),
+  },
+];
+`,
+    );
+
+    vi.resetModules();
+    vi.doMock("node:child_process", () => ({
+      execFileSync: vi.fn(() => {
+        throw new Error("git unavailable");
+      }),
+    }));
+
+    try {
+      const audit = await import("./public-route-audit.ts");
+      const keys = audit.scanPublicRoutes().map(audit.publicRouteKey);
+      expect(
+        keys.some((key) => key.includes("/__public-route-audit-fixture")),
+        "scanner must not pass baseline-only when git diff data is missing",
+      ).toBe(true);
+    } finally {
+      vi.doUnmock("node:child_process");
+      vi.resetModules();
+      rmSync(fixtureDir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/agent/src/api/public-route-audit.ts
+++ b/packages/agent/src/api/public-route-audit.ts
@@ -170,7 +170,12 @@ function listCandidateFiles(): string[] {
   if (process.env.UPDATE_PUBLIC_ROUTE_BASELINE === "1") {
     return allCandidateFiles();
   }
-  const files = [...baselineCandidateFiles(), ...changedCandidateFiles()];
+  const baselineFiles = baselineCandidateFiles();
+  const changedFiles = changedCandidateFiles();
+  const files =
+    changedFiles.length > 0
+      ? [...baselineFiles, ...changedFiles]
+      : [...baselineFiles, ...allCandidateFiles()];
   return files.filter((file, index) => files.indexOf(file) === index);
 }
 

--- a/packages/agent/src/api/public-route-audit.ts
+++ b/packages/agent/src/api/public-route-audit.ts
@@ -3,13 +3,14 @@
  *
  * Every `public: true` route bypasses the central `isAuthorized()` gate
  * (`runtime-plugin-routes.ts`: `route.public !== true && !isAuthorized()`), so a
- * new one is a new unauthenticated surface. This scanner enumerates every
- * `public: true` route declaration in the source tree; the companion test pins
- * the set against a checked-in baseline so a NEW public route can't be added
- * without an explicit, reviewed baseline entry (regenerate with
- * `UPDATE_PUBLIC_ROUTE_BASELINE=1`).
+ * new one is a new unauthenticated surface. Normal test runs scan the reviewed
+ * baseline files plus branch-changed source files; baseline regeneration walks
+ * the full source tree. The companion test pins the set against a checked-in
+ * baseline so a NEW public route can't be added without an explicit, reviewed
+ * baseline entry (regenerate with `UPDATE_PUBLIC_ROUTE_BASELINE=1`).
  */
 
+import { execFileSync } from "node:child_process";
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, relative, sep } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -17,6 +18,7 @@ import { fileURLToPath } from "node:url";
 const HERE = dirname(fileURLToPath(import.meta.url));
 // packages/agent/src/api → repo root is four levels up.
 export const REPO_ROOT = join(HERE, "..", "..", "..", "..");
+const BASELINE_PATH = join(HERE, "public-route-audit.baseline.json");
 
 const SCAN_ROOTS = ["packages", "plugins"];
 const SKIP_DIR = new Set([
@@ -60,6 +62,120 @@ function* walk(dir: string): Generator<string> {
   }
 }
 
+function isCandidateSourceFile(file: string): boolean {
+  const normalized = file.split(sep).join("/");
+  const basename = normalized.slice(normalized.lastIndexOf("/") + 1);
+  if (!(basename.endsWith(".ts") || basename.endsWith(".tsx"))) return false;
+  if (SKIP_FILE.test(basename) || basename.startsWith(SELF)) return false;
+  return !normalized.split("/").some((segment) => SKIP_DIR.has(segment));
+}
+
+function gitOutput(args: string[]): string | null {
+  try {
+    return execFileSync("git", ["-C", REPO_ROOT, ...args], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch {
+    return null;
+  }
+}
+
+function baselineCandidateFiles(): string[] {
+  try {
+    const baseline = JSON.parse(
+      readFileSync(BASELINE_PATH, "utf8"),
+    ) as string[];
+    return baseline
+      .map((key) => key.split("::")[0])
+      .filter((file, index, files) => files.indexOf(file) === index)
+      .filter(isCandidateSourceFile)
+      .map((file) => join(REPO_ROOT, file));
+  } catch {
+    return [];
+  }
+}
+
+function splitGitPathOutput(output: string | null): string[] {
+  if (!output) return [];
+  return output.split("\0").filter(Boolean);
+}
+
+function changedCandidateFiles(): string[] {
+  const candidates = [
+    ...splitGitPathOutput(
+      gitOutput([
+        "diff",
+        "--name-only",
+        "--diff-filter=ACMR",
+        "-z",
+        "--",
+        ...SCAN_ROOTS,
+      ]),
+    ),
+    ...splitGitPathOutput(
+      gitOutput([
+        "diff",
+        "--cached",
+        "--name-only",
+        "--diff-filter=ACMR",
+        "-z",
+        "--",
+        ...SCAN_ROOTS,
+      ]),
+    ),
+    ...splitGitPathOutput(
+      gitOutput([
+        "diff",
+        "--name-only",
+        "--diff-filter=ACMR",
+        "-z",
+        "origin/develop...HEAD",
+        "--",
+        ...SCAN_ROOTS,
+      ]),
+    ),
+    ...splitGitPathOutput(
+      gitOutput([
+        "ls-files",
+        "--others",
+        "--exclude-standard",
+        "-z",
+        "--",
+        ...SCAN_ROOTS,
+      ]),
+    ),
+  ];
+  return candidates
+    .filter((file, index, files) => files.indexOf(file) === index)
+    .filter(isCandidateSourceFile)
+    .map((file) => join(REPO_ROOT, file));
+}
+
+function allCandidateFiles(): string[] {
+  const files: string[] = [];
+  for (const root of SCAN_ROOTS) {
+    const base = join(REPO_ROOT, root);
+    try {
+      if (!statSync(base).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    files.push(...walk(base));
+  }
+  return files;
+}
+
+function listCandidateFiles(): string[] {
+  if (process.env.UPDATE_PUBLIC_ROUTE_BASELINE === "1") {
+    return allCandidateFiles();
+  }
+  const files = [...baselineCandidateFiles(), ...changedCandidateFiles()];
+  return files.filter((file, index) => files.indexOf(file) === index);
+}
+
+let cachedPublicRoutes: PublicRouteEntry[] | undefined;
+
 /** One `public: true` route occurrence: the source file and its HTTP path (when
  *  the declaration carries a `path:` within the same object). */
 export interface PublicRouteEntry {
@@ -74,36 +190,39 @@ export function publicRouteKey(entry: PublicRouteEntry): string {
   return `${entry.file}::${entry.path ?? "(no-path)"}`;
 }
 
-/** Scan the source tree for every `public: true` declaration. Pure (filesystem
- *  read only); deterministic order. */
+/** Scan the reviewed public-route ledger plus branch-changed source files. */
 export function scanPublicRoutes(): PublicRouteEntry[] {
+  if (cachedPublicRoutes && process.env.UPDATE_PUBLIC_ROUTE_BASELINE !== "1") {
+    return cachedPublicRoutes;
+  }
   const found: PublicRouteEntry[] = [];
-  for (const root of SCAN_ROOTS) {
-    const base = join(REPO_ROOT, root);
+  for (const file of listCandidateFiles()) {
+    let text: string;
     try {
-      if (!statSync(base).isDirectory()) continue;
+      text = readFileSync(file, "utf8");
     } catch {
       continue;
     }
-    for (const file of walk(base)) {
-      const text = readFileSync(file, "utf8");
-      if (!text.includes("public: true")) continue;
-      const lines = text.split("\n");
-      const rel = relative(REPO_ROOT, file).split(sep).join("/");
-      for (let i = 0; i < lines.length; i += 1) {
-        if (!/\bpublic:\s*true\b/.test(lines[i])) continue;
-        // The route's `path:` lives in the same object literal — look a few
-        // lines either side for it.
-        let path: string | null = null;
-        for (let d = -6; d <= 6 && path === null; d += 1) {
-          const m = lines[i + d]?.match(/\bpath:\s*["'`]([^"'`]+)["'`]/);
-          if (m) path = m[1];
-        }
-        found.push({ file: rel, path });
+    if (!text.includes("public: true")) continue;
+    const lines = text.split("\n");
+    const rel = relative(REPO_ROOT, file).split(sep).join("/");
+    for (let i = 0; i < lines.length; i += 1) {
+      if (!/\bpublic:\s*true\b/.test(lines[i])) continue;
+      // The route's `path:` lives in the same object literal — look a few
+      // lines either side for it.
+      let path: string | null = null;
+      for (let d = -6; d <= 6 && path === null; d += 1) {
+        const m = lines[i + d]?.match(/\bpath:\s*["'`]([^"'`]+)["'`]/);
+        if (m) path = m[1];
       }
+      found.push({ file: rel, path });
     }
   }
-  return found.sort((a, b) =>
+  const sorted = found.sort((a, b) =>
     publicRouteKey(a).localeCompare(publicRouteKey(b)),
   );
+  if (process.env.UPDATE_PUBLIC_ROUTE_BASELINE !== "1") {
+    cachedPublicRoutes = sorted;
+  }
+  return sorted;
 }

--- a/packages/app-core/src/api/__tests__/ensure-route-min-role.test.ts
+++ b/packages/app-core/src/api/__tests__/ensure-route-min-role.test.ts
@@ -3,11 +3,14 @@ import { Socket } from "node:net";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ensureRouteMinRole } from "../auth.js";
 
-const mocks = vi.hoisted(() => ({
-  findActiveSession: vi.fn(),
-  findIdentity: vi.fn(),
-  verifyCsrfToken: vi.fn(),
-}));
+const mocks = vi.hoisted(() => {
+  vi.resetModules();
+  return {
+    findActiveSession: vi.fn(),
+    findIdentity: vi.fn(),
+    verifyCsrfToken: vi.fn(),
+  };
+});
 
 vi.mock("@elizaos/core", () => ({
   roleRank: (role: string | undefined) =>

--- a/packages/ui/src/components/chat/render-parity.contract.test.tsx
+++ b/packages/ui/src/components/chat/render-parity.contract.test.tsx
@@ -51,10 +51,10 @@ const { clientMock } = vi.hoisted(() => ({
 }));
 vi.mock("../../api/client", () => ({ client: clientMock }));
 
+import { __renderThreadLineForParity } from "../shell/ContinuousChatOverlay";
 // MessageContent (ChatView path) and ThreadLine (overlay path) both render real
 // inline widgets; import them after the mocks are in place.
 import { MessageContent } from "./MessageContent";
-import { __renderThreadLineForParity } from "../shell/ContinuousChatOverlay";
 // Side effect: register the built-in inline widgets so both surfaces resolve them.
 import "./widgets/inline-builtins";
 import { registerTaskWidget } from "./widgets/task-widget";
@@ -72,7 +72,9 @@ function withApp(node: React.ReactElement) {
     handleChatRetry: vi.fn(),
   } as never;
   __setAppValueForTests(appValue);
-  return render(<AppContext.Provider value={appValue}>{node}</AppContext.Provider>);
+  return render(
+    <AppContext.Provider value={appValue}>{node}</AppContext.Provider>,
+  );
 }
 
 /**
@@ -157,10 +159,15 @@ function assistant(
 
 // A shared corpus exercising every structural affordance both surfaces render.
 const CORPUS: Array<{ name: string; message: ConversationMessage }> = [
-  { name: "plain prose", message: assistant("Just a normal reply, nothing rich.") },
+  {
+    name: "plain prose",
+    message: assistant("Just a normal reply, nothing rich."),
+  },
   {
     name: "fenced code block",
-    message: assistant("Here is the patch:\n```ts\nconst x = 1;\n```\nApply it."),
+    message: assistant(
+      "Here is the patch:\n```ts\nconst x = 1;\n```\nApply it.",
+    ),
   },
   {
     name: "two code blocks",

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -185,8 +185,8 @@ export * from "./chat/MessageContent";
 export * from "./chat/SaveCommandModal";
 export * from "./chat/TasksEventsPanel";
 export {
-  type OrchestratorAccountsViewProps,
   OrchestratorAccountsView,
+  type OrchestratorAccountsViewProps,
 } from "./chat/widgets/agent-orchestrator-accounts-view";
 export * from "./chat/widgets/shared";
 export * from "./chat/widgets/types";

--- a/packages/ui/src/spatial/xr-scene-math.ts
+++ b/packages/ui/src/spatial/xr-scene-math.ts
@@ -403,7 +403,10 @@ export interface ArrangeArcOptions {
  * both the CSS {@link XRSpatialScene} and the immersive bridge use for panels that
  * have no explicit position. Returns world centre positions, left → right.
  */
-export function arrangeOnArc(count: number, opts: ArrangeArcOptions = {}): Vec3[] {
+export function arrangeOnArc(
+  count: number,
+  opts: ArrangeArcOptions = {},
+): Vec3[] {
   const distance = opts.distance ?? 2.4;
   const center = opts.center ?? { x: 0, y: 1.6, z: 0 };
   const spread = opts.spread ?? (Math.PI / 180) * 50;

--- a/packages/ui/src/widgets/WidgetHost.home-rank.test.tsx
+++ b/packages/ui/src/widgets/WidgetHost.home-rank.test.tsx
@@ -225,7 +225,9 @@ describe("WidgetHost home-slot ranking (#9143)", () => {
     before.unmount();
 
     // After the user dismisses it, WidgetHost retires it from the home grid…
-    dismissHomeWidget(homeWidgetKey({ id: "ftu-welcome", pluginId: "home-plugin" }));
+    dismissHomeWidget(
+      homeWidgetKey({ id: "ftu-welcome", pluginId: "home-plugin" }),
+    );
     render(<WidgetHost slot="home" />);
     const ids = renderedIds();
     expect(ids).not.toContain("ftu-welcome");


### PR DESCRIPTION
## Summary

Refs #9948 and #9949.

This branch closes the remaining local regression-gate problems around the role/security work that is already present on `develop`:

- bounds `public:true` route auditing to reviewed baseline files plus branch-changed package/plugin sources, so the #9948 audit remains a practical test instead of a full source-tree timeout
- includes untracked/staged/committed branch files in the audit scan so new public routes are still caught locally and in CI
- makes `ensure-route-min-role` deterministic when run with the neighboring `ensure-min-role` test by clearing the module cache before its mocks attach
- applies safe Biome formatting/import-order fixes in UI files that blocked `packages/ui` lint on current `develop`

## Verification

Focused checks run after rebasing on latest `origin/develop`:

- `bun test packages/core/src/features/trust/__tests__/should-respond-risk-gate.test.ts packages/core/src/roles.test.ts packages/core/src/security/external-content.test.ts` — 76 passed
- `bun run --cwd packages/agent test -- src/api/public-route-audit.test.ts src/api/auth-routes.role.test.ts` — 4 passed
- `bun run --cwd packages/app-core test -- src/api/__tests__/ensure-min-role.test.ts src/api/__tests__/ensure-route-min-role.test.ts` — 14 passed
- `bun run --cwd packages/ui test -- src/components/RoleGate.test.tsx src/components/ShellRoleProvider.test.tsx` — 12 passed
- `bun run --cwd packages/ui lint` — passed with existing non-null assertion warnings
- `bun run --cwd plugins/plugin-wallet test -- src/chains/evm/routes/sign.test.ts src/chains/solana/routes/sign.test.ts src/plugin.routes.test.ts src/security/__tests__/wallet-context-safety.test.ts` — 25 passed
- `bunx biome check packages/agent/src/api/public-route-audit.ts packages/app-core/src/api/__tests__/ensure-route-min-role.test.ts packages/ui/src/components/chat/render-parity.contract.test.tsx packages/ui/src/components/index.ts packages/ui/src/spatial/xr-scene-math.ts packages/ui/src/widgets/WidgetHost.home-rank.test.tsx` — passed

Repo-wide `bun run verify` was attempted multiple times. It cleared the earlier cloud-shared/UI blockers after this branch/upstream formatting fixes, but the latest run is still blocked outside this branch by `@elizaos/cloud-api#lint`:

- `packages/cloud/api/__tests__/embeddings-optimistic-billing.test.ts` needs import ordering/formatting
- `packages/cloud/api/__tests__/containers-reserved-env.test.ts` reports `useTemplate` infos

## Evidence status

Draft until the remaining repo-wide verify blocker is resolved and the required live evidence in `PR_EVIDENCE.md` is attached for #9948/#9949.
