### PR TITLE
fix(cloud): add /api/v1/stripe/webhook to the public path allowlist

### DIFF
--- a/packages/cloud/api/src/middleware/auth.ts
+++ b/packages/cloud/api/src/middleware/auth.ts
@@ -74,6 +74,13 @@ const publicPathPrefixes = [
   "/api/v1/market/preview",
   "/api/stripe/credit-packs",
   "/api/stripe/webhook",
+  // Unified payment_requests settlement webhook. Public like the legacy
+  // /api/stripe/webhook above; the handler enforces the stripe-signature and
+  // fails closed (400) without it. The `=== p || startsWith(p+"/")` match keeps
+  // this from exposing the authed /api/v1/stripe/checkout sibling. Without this
+  // entry the session gate 401s every Stripe delivery → a checkout would charge
+  // the card but never settle (payment_request stuck "pending").
+  "/api/v1/stripe/webhook",
   "/api/crypto/webhook",
   "/api/crypto/status",
   "/api/crypto/direct-payments/config",


### PR DESCRIPTION
Found by the launch-readiness scan. The unified `payment_requests` settlement webhook `/api/v1/stripe/webhook` is 'unauthed but signature-verified' (handler 400s without `stripe-signature`), but it wasn't in `publicPathPrefixes` — so the session gate **401s every Stripe delivery** before the route's own check (prod-confirmed). A checkout via `/api/v1/stripe/checkout` would charge but never settle.

Latent today (no in-repo caller hits v1 checkout; the core credit purchase uses the legacy `/api/stripe/webhook`, which is public). One-line allowlist add mirroring the legacy entry — handler already enforces `stripe-signature` + fails closed, and the `=== p || startsWith(p+'/')` match keeps the authed `/api/v1/stripe/checkout` sibling gated.

⚠️ If any launch surface actually wires `/api/v1/stripe/checkout` (e.g. agent-initiated payment requests), this escalates to a must-ship — worth confirming the Stripe dashboard endpoint config.