### PR TITLE
test(mobile): cover android build target fail-loud paths

### DIFF
--- a/.github/issue-evidence/10096-android-build-driver.md
+++ b/.github/issue-evidence/10096-android-build-driver.md
@@ -7,6 +7,7 @@
 - Moved the pure Android Gradle argument builder to `packages/app-core/scripts/mobile/android-gradle.mjs`.
 - Moved the Android build target table and target-name resolution to `packages/app-core/scripts/mobile/targets/android.mjs`, with data-only phase keys mapped back to the existing driver functions.
 - Added `packages/app-core/scripts/run-mobile-build-android-targets.test.mjs` for the target table and Gradle command contracts.
+- Intentional behavior delta: the shared driver runs configured source audits both before and after Gradle. For `android-system`, that adds a post-Gradle `auditAndroidSystemSource("post-gradle")` pass so generated privileged APK sources cannot drift after Gradle mutation.
 
 ## Verification
 
@@ -15,6 +16,7 @@
 - `bun run --cwd packages/app-core test -- scripts/run-mobile-build-android-targets.test.mjs scripts/run-mobile-build-ios-engine-gate.test.mjs`
 - `bun test packages/app-core/scripts/run-mobile-build-android-targets.test.mjs packages/app-core/scripts/run-mobile-build-android-app-actions.test.mjs packages/app-core/scripts/run-mobile-build-ios-engine-gate.test.mjs packages/app-core/scripts/run-mobile-build-brand-separation.test.mts`
 - `node packages/app-core/scripts/run-mobile-build.mjs android-cloud-debug`
+- Fail-loud coverage: the target-table unit test now asserts unknown public Android targets and unknown AAR metadata variants throw explicit `[mobile-build]` errors.
 
 ## Native Android Evidence
 

--- a/packages/app-core/scripts/run-mobile-build-android-targets.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-targets.test.mjs
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-
+import { resolveAndroidGradleCommandsForTarget } from "./mobile/android-gradle.mjs";
 import {
   ANDROID_BUILD_TARGETS,
   resolveAndroidBuildTarget,
@@ -58,6 +58,12 @@ describe("Android mobile build target table", () => {
     expect(
       resolveAndroidBuildTarget("android-cloud", { debug: true }).target,
     ).toBe("android-cloud-debug");
+  });
+
+  it("fails loudly for unknown public Android targets", () => {
+    expect(() => resolveAndroidBuildTarget("android-tv")).toThrow(
+      "[mobile-build] Unknown Android build target: android-tv",
+    );
   });
 });
 
@@ -147,6 +153,25 @@ describe("Android Gradle command table", () => {
         ],
         buildArgs: ["-PelizaAospBuild=true", ":app:assembleRelease"],
       },
+    );
+  });
+
+  it("fails loudly for unknown AAR metadata variants", () => {
+    const target = {
+      ...ANDROID_BUILD_TARGETS.android,
+      gradle: {
+        ...ANDROID_BUILD_TARGETS.android.gradle,
+        metadataVariant: "profile",
+      },
+    };
+
+    expect(() =>
+      resolveAndroidGradleCommandsForTarget(target, {
+        env: {},
+        settingsGradle: "",
+      }),
+    ).toThrow(
+      "[mobile-build] Unknown Android AAR metadata variant for android: profile",
     );
   });
 });


### PR DESCRIPTION
## Summary
- fast-follow after #10172 for Shaw's draft-review item on fail-loud coverage
- assert unknown public Android targets throw explicit mobile-build errors
- assert unknown AAR metadata variants throw explicit mobile-build errors
- document the intentional android-system post-Gradle source audit behavior in the issue evidence

## Validation
- `bunx vitest run packages/app-core/scripts/run-mobile-build-android-targets.test.mjs` — pass, 7/7
- `bun test packages/app-core/scripts/run-mobile-build-android-targets.test.mjs packages/app-core/scripts/run-mobile-build-android-app-actions.test.mjs packages/app-core/scripts/run-mobile-build-ios-engine-gate.test.mjs packages/app-core/scripts/run-mobile-build-brand-separation.test.mts` — pass, 31/31
- `bunx biome check packages/app-core/scripts/run-mobile-build-android-targets.test.mjs .github/issue-evidence/10096-android-build-driver.md` — pass
- `bun run audit:type-safety-ratchet --json` — pass
- `node --check packages/app-core/scripts/run-mobile-build-android-targets.test.mjs` — pass
- `git diff --check origin/develop...HEAD` — pass

Follow-up for #10172 / #10096.