### PR TITLE
fix(cloud): retryable error (not bare 500) on shared-runtime chat failure

### DIFF
--- a/packages/cloud/api/__tests__/shared-agent-messages-route.test.ts
+++ b/packages/cloud/api/__tests__/shared-agent-messages-route.test.ts
@@ -1,0 +1,132 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import * as realResolveSharedAgent from "@/lib/services/shared-runtime/resolve-shared-agent";
+import * as realSharedRestAdapter from "@/lib/services/shared-runtime/shared-rest-adapter";
+import * as realLogger from "@/lib/utils/logger";
+
+const resolveSharedAgent = mock();
+const sharedRestMessageSend = mock();
+const sharedRestMessagesGet = mock();
+const loggerWarn = mock(() => undefined);
+
+mock.module("@/lib/services/shared-runtime/resolve-shared-agent", () => ({
+  ...realResolveSharedAgent,
+  resolveSharedAgent,
+}));
+
+mock.module("@/lib/services/shared-runtime/shared-rest-adapter", () => ({
+  ...realSharedRestAdapter,
+  sharedRestMessageSend,
+  sharedRestMessagesGet,
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  ...realLogger,
+  logger: {
+    ...realLogger.logger,
+    warn: loggerWarn,
+  },
+}));
+
+const messagesRoute = (
+  await import(
+    "../v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/route"
+  )
+).default;
+
+afterAll(() => {
+  mock.module(
+    "@/lib/services/shared-runtime/resolve-shared-agent",
+    () => realResolveSharedAgent,
+  );
+  mock.module(
+    "@/lib/services/shared-runtime/shared-rest-adapter",
+    () => realSharedRestAdapter,
+  );
+  mock.module("@/lib/utils/logger", () => realLogger);
+});
+
+const AGENT = "de42b5ff-72d3-4a1a-8a16-19aee293bfea";
+const ORG = "org-1";
+const APP_ORIGIN = "https://localhost";
+
+function postMessage(body: unknown, origin?: string) {
+  const headers: Record<string, string> = {
+    Authorization: "Bearer user-api-key",
+    "Content-Type": "application/json",
+  };
+  if (origin) headers.Origin = origin;
+  return messagesRoute.request("/", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+describe("shared agent messages route", () => {
+  beforeEach(() => {
+    resolveSharedAgent.mockReset();
+    sharedRestMessageSend.mockReset();
+    sharedRestMessagesGet.mockReset();
+    loggerWarn.mockClear();
+    resolveSharedAgent.mockResolvedValue({
+      agent: {},
+      agentId: AGENT,
+      orgId: ORG,
+      agentName: "Eliza",
+    });
+  });
+
+  test("returns assistant text from the shared REST adapter", async () => {
+    sharedRestMessageSend.mockResolvedValue({
+      text: "hello",
+      agentName: "Eliza",
+    });
+
+    const res = await postMessage({ text: "say hi" });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      text: "hello",
+      agentName: "Eliza",
+    });
+    expect(sharedRestMessageSend).toHaveBeenCalledWith(
+      AGENT,
+      ORG,
+      AGENT,
+      "say hi",
+      "Eliza",
+    );
+  });
+
+  test("returns a sanitized retryable 503 when shared runtime inference fails", async () => {
+    sharedRestMessageSend.mockRejectedValue(
+      new Error("provider secret detail: upstream 500"),
+    );
+
+    const res = await postMessage({ text: "hello" }, APP_ORIGIN);
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get("access-control-allow-origin")).toBe(APP_ORIGIN);
+    expect(res.headers.get("access-control-allow-credentials")).toBe("true");
+    await expect(res.json()).resolves.toEqual({
+      success: false,
+      error: "The agent is temporarily unavailable. Please try again.",
+      code: "inference_unavailable",
+      retryable: true,
+    });
+    expect(loggerWarn).toHaveBeenCalledWith(
+      "[shared-runtime REST] message.send failed",
+      {
+        agentId: AGENT,
+        error: "provider secret detail: upstream 500",
+      },
+    );
+  });
+
+  test("empty text returns 400 without calling the adapter", async () => {
+    const res = await postMessage({ text: "  " });
+    expect(res.status).toBe(400);
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/conversations/[conversationId]/messages/route.ts
@@ -5,6 +5,7 @@ import {
   sharedRestMessageSend,
   sharedRestMessagesGet,
 } from "@/lib/services/shared-runtime/shared-rest-adapter";
+import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 /**
@@ -66,13 +67,39 @@ app.post("/", async (c) => {
       origin,
     );
   }
-  const result = await sharedRestMessageSend(
-    r.agentId,
-    r.orgId,
-    conversationId,
-    text,
-    r.agentName,
-  );
+  let result: { text: string; agentName: string };
+  try {
+    result = await sharedRestMessageSend(
+      r.agentId,
+      r.orgId,
+      conversationId,
+      text,
+      r.agentName,
+    );
+  } catch (error) {
+    // A shared-bridge / inference failure (transient: cold sandbox, provider
+    // 429/5xx, timeout) would otherwise surface as a bare 500 on the
+    // launch-critical first chat turn. Return a structured, retryable error so
+    // the app can show a "try again" affordance instead of a hard failure. The
+    // message is sanitized (no internal/provider details leak to the client).
+    logger.warn("[shared-runtime REST] message.send failed", {
+      agentId: r.agentId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return applyCorsHeaders(
+      Response.json(
+        {
+          success: false,
+          error: "The agent is temporarily unavailable. Please try again.",
+          code: "inference_unavailable",
+          retryable: true,
+        },
+        { status: 503 },
+      ),
+      CORS_METHODS,
+      origin,
+    );
+  }
   return applyCorsHeaders(Response.json(result), CORS_METHODS, origin);
 });
 


### PR DESCRIPTION
Found by the launch-readiness scan. The shared-runtime REST chat `POST .../messages` called `sharedRestMessageSend` with **no try/catch** — and it throws on any bridge/inference failure (cold sandbox, provider 429/5xx, timeout). So a transient failure on the **launch-critical first chat turn** surfaced as a bare **500** with no retry affordance.

Fix: catch it and return a structured, sanitized, **retryable** response (`503 {code:'inference_unavailable', retryable:true}`) so the app can show a 'try again' instead of a hard failure. No internal/provider detail leaks. One file.