### PR TITLE
fix(coding-tools): don't rewrite the coding sub-agent's explicit shell commands (94s→31s builds)

### DIFF
--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -1009,6 +1009,43 @@ describeIfPosix("shellAction", () => {
     // so give this real-I/O case its own generous budget.
   }, 90_000);
 
+  it("runs explicit coding sub-agent shell commands without message-text rewrites", async () => {
+    const previousMode = process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE;
+    const tempDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "shell-coding-subagent-"),
+    );
+    await fs.writeFile(path.join(tempDir, "sentinel.txt"), "sentinel", "utf8");
+    process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE = "true";
+
+    try {
+      const { runtime } = await makeRuntime();
+      const result = await shellAction.handler?.(
+        runtime,
+        makeMessage(
+          "11111111-aaaa-bbbb-cccc-636363636363",
+          "check disk space and free RAM on this server, summarize cleanup candidates and memory availability",
+        ),
+        undefined,
+        { command: "ls -1", cwd: tempDir },
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.text).toContain("$ ls -1");
+      expect(result.text).toContain("sentinel.txt");
+      expect(result.text).not.toContain("df -h / /home");
+      expect(result.text).not.toContain("--- memory ---");
+      expect(result.userFacingText).toBe("sentinel.txt");
+      expect(result.verifiedUserFacing).toBe(true);
+    } finally {
+      if (previousMode === undefined) {
+        delete process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE;
+      } else {
+        process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE = previousMode;
+      }
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("does not treat later output section markers as cleanup candidates", () => {
     const stdout = [
       "Filesystem      Size  Used Avail Use% Mounted on",

--- a/plugins/plugin-coding-tools/src/actions/bash.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.ts
@@ -1303,45 +1303,62 @@ export const shellAction: Action = {
         `${CODING_TOOLS_LOG_PREFIX} SHELL removed ungrounded runtime directory override; using cwd=${cwd}`,
       );
     }
-    const localStatusCommand = resolveLocalStatusCommand({
-      command,
-      messageText: messageText(message),
-    });
-    if (localStatusCommand.rewritten) {
-      command = localStatusCommand.command;
-      coreLogger.warn(
-        `${CODING_TOOLS_LOG_PREFIX} SHELL replaced local status probe with canonical command`,
-      );
-    }
-    const sourceInspectionCommand = resolveSourceInspectionCommand({
-      command,
-      messageText: messageText(message),
-    });
-    if (sourceInspectionCommand.rewritten) {
-      command = sourceInspectionCommand.command;
-      coreLogger.warn(
-        `${CODING_TOOLS_LOG_PREFIX} SHELL replaced broad source search with bounded workspace search`,
-      );
-    }
-    const diskCommand = resolveDiskInspectionCommand({
-      command,
-      messageText: messageText(message),
-    });
-    if (diskCommand.rewritten) {
-      command = diskCommand.command;
-      coreLogger.warn(
-        `${CODING_TOOLS_LOG_PREFIX} SHELL replaced broad disk scan with bounded cleanup-candidate probe`,
-      );
-    }
-    const cryptoCommand = resolveCryptoSpotPriceCommand({
-      command,
-      messageText: messageText(message),
-    });
-    if (cryptoCommand.rewritten) {
-      command = cryptoCommand.command;
-      coreLogger.warn(
-        `${CODING_TOOLS_LOG_PREFIX} SHELL replaced unreliable crypto spot-price endpoint with neutral no-key API`,
-      );
+    // The disk / memory / source-search / crypto command rewrites below are
+    // CHAT conveniences keyed on the *message text*: when a user asks "check
+    // disk space", a weak probe is rewritten into a good bounded one. The
+    // eliza-code coding sub-agent (ELIZA_PLANNER_FULL_ACTION_SURFACE) instead
+    // issues precise explicit commands (ls / mkdir / git / …) and must NEVER
+    // have them rewritten — when the build task incidentally mentioned a trigger
+    // word, EVERY `ls`/`mkdir` was replaced by an ~19s `df` cleanup scan, so the
+    // shell produced no real output, the model gave up on SHELL, and a 30s build
+    // took 90s+. Skip all message-text-keyed rewrites for the coding sub-agent;
+    // its commands run verbatim.
+    const codingSubAgentShell = ((): boolean => {
+      const v =
+        process.env.ELIZA_PLANNER_FULL_ACTION_SURFACE?.trim().toLowerCase();
+      return v === "1" || v === "true" || v === "yes" || v === "on";
+    })();
+    if (!codingSubAgentShell) {
+      const localStatusCommand = resolveLocalStatusCommand({
+        command,
+        messageText: messageText(message),
+      });
+      if (localStatusCommand.rewritten) {
+        command = localStatusCommand.command;
+        coreLogger.warn(
+          `${CODING_TOOLS_LOG_PREFIX} SHELL replaced local status probe with canonical command`,
+        );
+      }
+      const sourceInspectionCommand = resolveSourceInspectionCommand({
+        command,
+        messageText: messageText(message),
+      });
+      if (sourceInspectionCommand.rewritten) {
+        command = sourceInspectionCommand.command;
+        coreLogger.warn(
+          `${CODING_TOOLS_LOG_PREFIX} SHELL replaced broad source search with bounded workspace search`,
+        );
+      }
+      const diskCommand = resolveDiskInspectionCommand({
+        command,
+        messageText: messageText(message),
+      });
+      if (diskCommand.rewritten) {
+        command = diskCommand.command;
+        coreLogger.warn(
+          `${CODING_TOOLS_LOG_PREFIX} SHELL replaced broad disk scan with bounded cleanup-candidate probe`,
+        );
+      }
+      const cryptoCommand = resolveCryptoSpotPriceCommand({
+        command,
+        messageText: messageText(message),
+      });
+      if (cryptoCommand.rewritten) {
+        command = cryptoCommand.command;
+        coreLogger.warn(
+          `${CODING_TOOLS_LOG_PREFIX} SHELL replaced unreliable crypto spot-price endpoint with neutral no-key API`,
+        );
+      }
     }
 
     const defaultTimeout = readPositiveIntSetting(


### PR DESCRIPTION
## What

The SHELL action rewrites the agent's command into a canned disk/memory/source-search/crypto probe when the **message text** trips a chat-convenience heuristic (e.g. a user asking "check disk space" gets a good bounded `df` instead of a weak one). That's fine for chat, but the **eliza-code coding sub-agent** issues precise, explicit commands (`ls`, `mkdir`, `git`, …) — and when a build task incidentally contained a trigger word, **every** `ls`/`mkdir` was replaced by an ~19-second `df` cleanup scan.

Consequences observed live (a "build and deploy a pomodoro timer" request, full trajectory):
- SHELL returned `df`/cleanup output for an `ls -la <dir>` call — the real command never ran.
- The model logged `DECISION: Shell commands are not producing output; proceeding directly with FILE operations` (which **leaked to the user**) and fell back to slow FILE-only probing.
- A ~30s build took **94 seconds**.

## Fix

Skip all message-text-keyed command rewrites (`resolveLocalStatusCommand`, `resolveSourceInspectionCommand`, `resolveDiskInspectionCommand`, `resolveCryptoSpotPriceCommand`) when running as the coding sub-agent (`ELIZA_PLANNER_FULL_ACTION_SURFACE`). Its commands now run verbatim. Chat behavior is unchanged (the rewrites still apply when the flag is unset).

## Evidence (live, Cerebras glm-4.7)

- Direct SHELL probe: "run `ls -la` and `cat probe.txt`" → before: returned a `df`/cleanup dump; **after: returns the real `ls` listing + `marker-content-xyz` file contents.**
- Full app build "build and deploy a coin flip web app": **94s → 31s**, **0** command-rewrite log lines (was every shell call), deployed to `https://nubilio.org/apps/coinflip/` (HTTP 200), clean relay "Done! The coin flip web app is live at …". Trajectory shows `ls`/`mkdir` running as issued.
