### PR TITLE
test(app): chat-grabber swipe under REAL touch input (#9943 item 6)

### DIFF
--- a/packages/app/test/ui-smoke/chat-clear-swipe.spec.ts
+++ b/packages/app/test/ui-smoke/chat-clear-swipe.spec.ts
@@ -245,6 +245,45 @@ async function pointerDrag(
   await page.mouse.up();
 }
 
+/**
+ * Drive a REAL touch drag via CDP `Input.dispatchTouchEvent` — the same touch
+ * input `page.touchscreen` uses. Unlike `pointerDrag` above (`page.mouse` →
+ * pointerType "mouse"), this produces genuine touch input (pointerType "touch"),
+ * so the gesture is verified the way a finger drives it, not a desktop mouse
+ * (issue #9943 item 6: "swipe gesture simulated via page.mouse, not real touch").
+ */
+async function touchDrag(
+  page: import("@playwright/test").Page,
+  selector: string,
+  dx: number,
+  dy: number,
+  steps = 12,
+) {
+  const box = await page.locator(selector).first().boundingBox();
+  if (!box) throw new Error(`no bounding box for ${selector}`);
+  const cx = box.x + box.width / 2;
+  const cy = box.y + box.height / 2;
+  const client = await page.context().newCDPSession(page);
+  try {
+    await client.send("Input.dispatchTouchEvent", {
+      type: "touchStart",
+      touchPoints: [{ x: cx, y: cy }],
+    });
+    for (let i = 1; i <= steps; i += 1) {
+      await client.send("Input.dispatchTouchEvent", {
+        type: "touchMove",
+        touchPoints: [{ x: cx + (dx * i) / steps, y: cy + (dy * i) / steps }],
+      });
+    }
+    await client.send("Input.dispatchTouchEvent", {
+      type: "touchEnd",
+      touchPoints: [],
+    });
+  } finally {
+    await client.detach();
+  }
+}
+
 let store: Store;
 
 test.beforeEach(async ({ page }) => {
@@ -279,6 +318,36 @@ test("collapsed chat grabber horizontal swipe opens the launcher rail without op
     page.getByTestId("home-launcher-launcher-page"),
   ).toBeVisible();
   await expectNoPageDiagnostics(page, testInfo.title);
+});
+
+test.describe("real touch input (CDP dispatchTouchEvent) — #9943 item 6", () => {
+  test.use({ hasTouch: true });
+
+  test("collapsed chat grabber swipe under REAL TOUCH (not desktop mouse) opens the launcher rail", async ({
+    page,
+  }, testInfo) => {
+    await openAppPath(page, "/chat");
+    const overlay = page.getByTestId("continuous-chat-overlay");
+    await expect(overlay).toBeVisible({ timeout: 60_000 });
+
+    const surface = page.getByTestId("home-launcher-surface");
+    await expect(surface).toHaveAttribute("data-page", "home", {
+      timeout: 15_000,
+    });
+    await expect(overlay).not.toHaveAttribute("data-open", "true");
+
+    // Genuine finger swipe (touch input), not page.mouse.
+    await touchDrag(page, '[data-testid="chat-sheet-grabber"]', -180, -6, 12);
+
+    await expect(surface).toHaveAttribute("data-page", "launcher", {
+      timeout: 10_000,
+    });
+    await expect(overlay).not.toHaveAttribute("data-open", "true");
+    await expect(
+      page.getByTestId("home-launcher-launcher-page"),
+    ).toBeVisible();
+    await expectNoPageDiagnostics(page, testInfo.title);
+  });
 });
 
 test("swipe navigates conversations; clear lands on a fresh greeted chat with no undo toast", async ({


### PR DESCRIPTION
Addresses work-order item 6 of #9943 — "make swipe/gesture e2e real (real touch emulation, not desktop mouse)."

The existing grabber-swipe test drives the gesture with `page.mouse.move/down/up` (pointerType "mouse") — the exact thing the issue flags. This adds a **real-touch** variant: a `touchDrag` helper using CDP `Input.dispatchTouchEvent` (the same touch input `page.touchscreen` uses) in a `hasTouch` context, asserting the collapsed chat-grabber swipe opens the launcher rail under a **genuine finger drag** (pointerType "touch").

## Verification (real ui-smoke harness)
```
✓ real touch input (CDP) › collapsed chat grabber swipe under REAL TOUCH (not desktop mouse) opens the launcher rail (4.0s)
1 passed
```

### Gesture surface status for item 6
- **swipe** under real touch — this PR ✅
- **long-press** — already covered by the Launcher storybook plays (real browser, pointer-driven long-press → edit mode + travel-abort) ✅
- **pinch** — `RelationshipsGraphPanel` has a real two-pointer pinch-to-zoom; a relationships-view e2e with seeded graph data is the natural follow-up.
- **app-switch** — not a gesture in this app (view switching is launcher-tap / keyboard), so N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)