### PR TITLE
refactor(mobile): split Android manifest helpers

### DIFF
--- a/.github/issue-evidence/10096-android-manifest-module.md
+++ b/.github/issue-evidence/10096-android-manifest-module.md
@@ -1,0 +1,19 @@
+# 10096 Android Manifest Module Split
+
+## Change
+
+- Moved pure Android manifest XML transforms from `packages/app-core/scripts/run-mobile-build.mjs` into `packages/app-core/scripts/mobile/android-manifest.mjs`.
+- Kept `run-mobile-build.mjs` as the compatibility re-export surface for existing App Actions tests and downstream imports.
+- Left filesystem build orchestration, source stripping, source audits, and artifact audits in `run-mobile-build.mjs`; they still call the split manifest helpers.
+- Added focused contract coverage for component removal, permission removal markers, malformed application closure repair, cleartext policy, MainActivity intent filters, and comment stripping.
+
+## Verification
+
+- `node --check packages/app-core/scripts/run-mobile-build.mjs && node --check packages/app-core/scripts/mobile/android-manifest.mjs && node --check packages/app-core/scripts/run-mobile-build-android-manifest.test.mjs && node --check packages/app-core/scripts/run-mobile-build-android-app-actions.test.mjs && node --check packages/app-core/scripts/run-mobile-build-android-targets.test.mjs`
+- `bunx biome check packages/app-core/scripts/run-mobile-build.mjs packages/app-core/scripts/mobile/android-manifest.mjs packages/app-core/scripts/run-mobile-build-android-manifest.test.mjs packages/app-core/scripts/run-mobile-build-android-targets.test.mjs .github/issue-evidence/10096-android-manifest-module.md`
+- `bun run --cwd packages/app-core test -- scripts/run-mobile-build-android-manifest.test.mjs scripts/run-mobile-build-android-targets.test.mjs`
+- `node --test packages/app-core/scripts/run-mobile-build-android-app-actions.test.mjs`
+
+## Not Covered
+
+- This is a pure module split. It does not claim a new full Android device/emulator build; that evidence is already attached to the Android target driver PR for issue #10096.

--- a/packages/app-core/scripts/mobile/android-manifest.mjs
+++ b/packages/app-core/scripts/mobile/android-manifest.mjs
@@ -1,0 +1,387 @@
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function appendMissingAndroidManifestBlock(xml, marker, block) {
+  if (xml.includes(marker)) return xml;
+  return xml.replace("</manifest>", `${block}\n</manifest>`);
+}
+
+export function appendMissingApplicationBlock(xml, marker, block) {
+  if (xml.includes(marker)) return xml;
+  return xml.replace("</application>", `${block}\n    </application>`);
+}
+
+export function removeApplicationComponentBlock(xml, componentName) {
+  const escapedName = escapeRegExp(componentName);
+  const pairedRe = new RegExp(
+    `\\n\\s*<(activity|service|receiver)\\b(?=[^>]*android:name="${escapedName}")[\\s\\S]*?<\\/\\1>\\s*`,
+    "g",
+  );
+  const selfClosingRe = new RegExp(
+    `\\n\\s*<(activity|service|receiver)\\b(?=[^>]*android:name="${escapedName}")[^>]*/>\\s*`,
+    "g",
+  );
+  return xml.replace(selfClosingRe, "\n").replace(pairedRe, "\n");
+}
+
+export function removeApplicationComponentClassBlock(xml, className) {
+  const escapedName = escapeRegExp(className);
+  const pairedRe = new RegExp(
+    `\\n\\s*<(activity|service|receiver)\\b(?=[^>]*android:name="[^"]*\\.?${escapedName}")[\\s\\S]*?<\\/\\1>\\s*`,
+    "g",
+  );
+  const selfClosingRe = new RegExp(
+    `\\n\\s*<(activity|service|receiver)\\b(?=[^>]*android:name="[^"]*\\.?${escapedName}")[^>]*/>\\s*`,
+    "g",
+  );
+  return xml.replace(selfClosingRe, "\n").replace(pairedRe, "\n");
+}
+
+export function stripXmlComments(source) {
+  return source.replace(/<!--[\s\S]*?-->/g, "");
+}
+
+export function removeXmlCommentsContaining(xml, markers) {
+  let patched = xml;
+  for (const marker of markers) {
+    const escapedMarker = escapeRegExp(marker);
+    patched = patched.replace(
+      new RegExp(
+        `\\n?\\s*<!--[\\s\\S]*?${escapedMarker}[\\s\\S]*?-->\\s*`,
+        "g",
+      ),
+      "\n",
+    );
+  }
+  return patched;
+}
+
+function ensureManifestToolsNamespace(xml) {
+  if (/\bxmlns:tools=/.test(xml)) return xml;
+  return xml.replace(
+    /<manifest\b([^>]*)>/,
+    '<manifest$1 xmlns:tools="http://schemas.android.com/tools">',
+  );
+}
+
+export function hasAndroidPermissionRequest(xml, fullPermissionName) {
+  const escaped = escapeRegExp(fullPermissionName);
+  const re = new RegExp(
+    `<uses-permission\\b(?=[^>]*android:name="${escaped}")[^>]*>`,
+    "g",
+  );
+  for (const match of xml.matchAll(re)) {
+    if (!/\btools:node\s*=\s*"remove"/.test(match[0])) return true;
+  }
+  return false;
+}
+
+export function removeAndroidPermissionRequests(xml, permissions) {
+  let patched = xml;
+  for (const perm of permissions) {
+    const escaped = escapeRegExp(`android.permission.${perm}`);
+    const re = new RegExp(
+      `\\n\\s*<uses-permission\\b(?=[^>]*android:name="${escaped}")(?![^>]*tools:node="remove")[^>]*/>\\s*`,
+      "g",
+    );
+    patched = patched.replace(re, "\n");
+  }
+  return patched;
+}
+
+export function ensureAndroidPermissionRemovalMarkers(xml, permissions) {
+  let patched = ensureManifestToolsNamespace(xml);
+  for (const perm of permissions) {
+    const full = `android.permission.${perm}`;
+    const escaped = escapeRegExp(full);
+    const removalRe = new RegExp(
+      `<uses-permission\\b(?=[^>]*android:name="${escaped}")(?=[^>]*tools:node="remove")[^>]*/>`,
+      "m",
+    );
+    if (removalRe.test(patched)) continue;
+    patched = patched.replace(
+      "</manifest>",
+      `    <uses-permission android:name="${full}" tools:node="remove" />\n</manifest>`,
+    );
+  }
+  return patched;
+}
+
+export function ensureManifestApplicationClosedBeforeTopLevelEntries(xml) {
+  if (xml.includes("</application>")) return xml;
+  const appStart = xml.indexOf("<application");
+  if (appStart === -1) return xml;
+  const afterApplicationStart = xml.indexOf(">", appStart);
+  if (afterApplicationStart === -1) return xml;
+  const afterApplication = xml.slice(afterApplicationStart + 1);
+  const topLevelEntry = afterApplication.search(
+    /\n\s*<(?:uses-permission|uses-feature)\b/,
+  );
+  if (topLevelEntry !== -1) {
+    const insertAt = afterApplicationStart + 1 + topLevelEntry;
+    return `${xml.slice(0, insertAt)}\n    </application>\n${xml.slice(insertAt)}`;
+  }
+  return xml.replace("</manifest>", "    </application>\n</manifest>");
+}
+
+function removeElizaOsHomeActivityFilter(xml) {
+  return xml.replace(
+    /\n\s*<intent-filter>\s*<action\s+android:name="android\.intent\.action\.MAIN"\s*\/>\s*<category\s+android:name="android\.intent\.category\.HOME"\s*\/>\s*<category\s+android:name="android\.intent\.category\.DEFAULT"\s*\/>\s*<\/intent-filter>\s*/g,
+    "\n",
+  );
+}
+
+export function ensureElizaOsActivityFilters(xml, { enabled = true } = {}) {
+  if (!enabled) {
+    return removeElizaOsHomeActivityFilter(xml);
+  }
+  if (xml.includes("android.intent.category.HOME")) {
+    return xml;
+  }
+  const mainActivityRe =
+    /(<activity\b(?=[\s\S]*?android:name="\.?MainActivity")[\s\S]*?)(\n\s*<\/activity>)/m;
+  const homeFilter = `
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.HOME" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+`;
+  return xml.replace(mainActivityRe, `$1${homeFilter}$2`);
+}
+
+export function ensureAndroidMainActivityUrlSchemeFilter(xml, { urlScheme }) {
+  const mainActivityRe =
+    /(<activity\b(?=[\s\S]*?android:name="\.?MainActivity")[\s\S]*?)(\n\s*<\/activity>)/m;
+  const match = xml.match(mainActivityRe);
+  if (!match) return xml;
+
+  const mainActivity = `${match[1]}${match[2]}`;
+  const hasCustomSchemeFilter =
+    mainActivity.includes("android.intent.action.VIEW") &&
+    mainActivity.includes("android.intent.category.BROWSABLE") &&
+    (mainActivity.includes('android:scheme="@string/custom_url_scheme"') ||
+      mainActivity.includes(`android:scheme="${urlScheme}"`));
+  if (hasCustomSchemeFilter) return xml;
+
+  const authFilter = `
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="@string/custom_url_scheme" />
+            </intent-filter>
+`;
+  return xml.replace(mainActivityRe, `$1${authFilter}$2`);
+}
+
+export function ensureAndroidMainActivityShortcutsMetadata(xml) {
+  const mainActivityRe =
+    /(<activity\b(?=[\s\S]*?android:name="\.?MainActivity")[\s\S]*?)(\n\s*<\/activity>)/m;
+  const match = xml.match(mainActivityRe);
+  if (!match) return xml;
+
+  const mainActivity = `${match[1]}${match[2]}`;
+  if (
+    mainActivity.includes('android:name="android.app.shortcuts"') &&
+    mainActivity.includes('android:resource="@xml/shortcuts"')
+  ) {
+    return xml;
+  }
+
+  const shortcutsMetadata = `
+            <meta-data
+                android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts" />
+`;
+  return xml.replace(mainActivityRe, `$1${shortcutsMetadata}$2`);
+}
+
+export function patchAndroidAppActionsXmlResource(
+  xml,
+  { androidPackage, urlScheme },
+) {
+  let patched = xml
+    .replace(
+      /\bandroid:targetPackage="[^"]+"/g,
+      `android:targetPackage="${androidPackage}"`,
+    )
+    .replace(
+      /\bandroid:targetClass="[^"]*\.MainActivity"/g,
+      `android:targetClass="${androidPackage}.MainActivity"`,
+    );
+
+  const escapedSchemes = [
+    "eliza",
+    "elizaos",
+    "ai.elizaos.app",
+    "app.eliza",
+    androidPackage,
+  ].filter(Boolean);
+  for (const scheme of escapedSchemes) {
+    patched = patched.replace(
+      new RegExp(`${escapeRegExp(scheme)}://`, "g"),
+      `${urlScheme}://`,
+    );
+  }
+
+  return patched;
+}
+
+export const ANDROID_APP_ACTION_CAPABILITIES = [
+  "actions.intent.OPEN_APP_FEATURE",
+  "actions.intent.CREATE_MESSAGE",
+  "actions.intent.GET_THING",
+];
+
+export const ANDROID_APP_ACTION_SHORTCUT_IDS = [
+  "eliza_app_action_chat",
+  "eliza_app_action_voice",
+  "eliza_app_action_daily_brief",
+  "eliza_app_action_new_task",
+  "eliza_app_action_tasks",
+];
+
+export const ANDROID_APP_ACTION_REQUIRED_DEEP_LINKS = [
+  "feature/open?source=android-app-actions",
+  "chat?source=android-app-actions&amp;action=ask",
+  "chat?source=android-app-actions&amp;action=chat",
+  "voice?source=android-static-shortcut",
+  "lifeops/daily-brief?source=android-static-shortcut",
+  "lifeops/task/new?source=android-static-shortcut",
+  "lifeops/tasks?source=android-static-shortcut",
+];
+
+export const ANDROID_APP_ACTION_FORBIDDEN_MARKERS = [
+  "actions.intent.CREATE_THING",
+  "android.intent.action.ASSIST",
+  "android.intent.action.VOICE_COMMAND",
+  "android.app.role.ASSISTANT",
+  "android.permission.BIND_VOICE_INTERACTION",
+  "assistant/open",
+];
+
+function extractAndroidAppActionCapabilityBlocks(xml) {
+  const blocks = new Map();
+  const capabilityRe =
+    /<capability\b[^>]*android:name="(actions\.intent\.[^"]+)"[^>]*>([\s\S]*?)<\/capability>/g;
+  for (const match of xml.matchAll(capabilityRe)) {
+    blocks.set(match[1], match[2]);
+  }
+  return blocks;
+}
+
+export function validateAndroidAppActionsXmlResource(
+  xml,
+  { androidPackage, urlScheme },
+) {
+  const failures = [];
+  const capabilityBlocks = extractAndroidAppActionCapabilityBlocks(xml);
+
+  for (const capability of ANDROID_APP_ACTION_CAPABILITIES) {
+    if (!xml.includes(`android:name="${capability}"`)) {
+      failures.push(`shortcuts.xml is missing ${capability}`);
+    }
+    const block = capabilityBlocks.get(capability);
+    if (!block) continue;
+    const intentBlocks = [
+      ...block.matchAll(/<intent\b[^>]*\/>|<intent\b[\s\S]*?<\/intent>/g),
+    ].map((match) => match[0]);
+    const hasFallbackIntent = intentBlocks.some(
+      (intent) => !/android:required="true"/.test(intent),
+    );
+    if (!hasFallbackIntent) {
+      failures.push(
+        `shortcuts.xml ${capability} is missing a no-required-parameter fallback intent`,
+      );
+    }
+  }
+
+  for (const match of xml.matchAll(
+    /\bandroid:name="(actions\.intent\.[^"]+)"/g,
+  )) {
+    const action = match[1];
+    if (!ANDROID_APP_ACTION_CAPABILITIES.includes(action)) {
+      failures.push(`shortcuts.xml declares unsupported App Action ${action}`);
+    }
+  }
+
+  for (const shortcutId of ANDROID_APP_ACTION_SHORTCUT_IDS) {
+    if (!xml.includes(`android:shortcutId="${shortcutId}"`)) {
+      failures.push(`shortcuts.xml is missing ${shortcutId}`);
+    }
+  }
+
+  for (const source of ["android-app-actions", "android-static-shortcut"]) {
+    if (!xml.includes(`source=${source}`)) {
+      failures.push(`shortcuts.xml is missing source=${source} deep links`);
+    }
+  }
+
+  for (const deepLink of ANDROID_APP_ACTION_REQUIRED_DEEP_LINKS) {
+    if (!xml.includes(`${urlScheme}://${deepLink}`)) {
+      failures.push(`shortcuts.xml is missing ${urlScheme}://${deepLink}`);
+    }
+  }
+
+  for (const marker of ANDROID_APP_ACTION_FORBIDDEN_MARKERS) {
+    if (xml.includes(marker)) {
+      failures.push(`shortcuts.xml contains forbidden marker ${marker}`);
+    }
+  }
+
+  for (const match of xml.matchAll(/\bandroid:targetPackage="([^"]+)"/g)) {
+    if (match[1] !== androidPackage) {
+      failures.push(
+        `shortcuts.xml targetPackage ${match[1]} was not rewritten to ${androidPackage}`,
+      );
+    }
+  }
+
+  const expectedTargetClass = `${androidPackage}.MainActivity`;
+  for (const match of xml.matchAll(/\bandroid:targetClass="([^"]+)"/g)) {
+    if (match[1] !== expectedTargetClass) {
+      failures.push(
+        `shortcuts.xml targetClass ${match[1]} was not rewritten to ${expectedTargetClass}`,
+      );
+    }
+  }
+
+  if (!xml.includes(`${urlScheme}://`)) {
+    failures.push(
+      `shortcuts.xml URL templates were not rewritten to ${urlScheme}://`,
+    );
+  }
+
+  const staleLiterals = [
+    androidPackage === "app.eliza" ? null : 'android:targetPackage="app.eliza"',
+    androidPackage === "ai.elizaos.app"
+      ? null
+      : 'android:targetClass="ai.elizaos.app.MainActivity"',
+    urlScheme === "eliza" ? null : "eliza://",
+    urlScheme === "ai.elizaos.app" ? null : "ai.elizaos.app://",
+    urlScheme === "app.eliza" ? null : "app.eliza://",
+  ].filter(Boolean);
+  for (const stale of staleLiterals) {
+    if (xml.includes(stale)) {
+      failures.push(`shortcuts.xml still contains stale literal ${stale}`);
+    }
+  }
+
+  return failures;
+}
+
+export function applyAndroidCleartextPolicy(xml, { allowCleartext }) {
+  const value = allowCleartext ? "true" : "false";
+  if (/android:usesCleartextTraffic="(?:true|false)"/.test(xml)) {
+    return xml.replace(
+      /android:usesCleartextTraffic="(?:true|false)"/g,
+      `android:usesCleartextTraffic="${value}"`,
+    );
+  }
+  return xml.replace(
+    "<application",
+    `<application\n        android:usesCleartextTraffic="${value}"`,
+  );
+}

--- a/packages/app-core/scripts/run-mobile-build-android-manifest.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-manifest.test.mjs
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyAndroidCleartextPolicy,
+  ensureAndroidMainActivityUrlSchemeFilter,
+  ensureAndroidPermissionRemovalMarkers,
+  ensureElizaOsActivityFilters,
+  ensureManifestApplicationClosedBeforeTopLevelEntries,
+  hasAndroidPermissionRequest,
+  removeAndroidPermissionRequests,
+  removeApplicationComponentBlock,
+  removeApplicationComponentClassBlock,
+  removeXmlCommentsContaining,
+  stripXmlComments,
+} from "./mobile/android-manifest.mjs";
+
+const manifest = `<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.READ_SMS" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <application>
+        <activity android:name="com.example.ElizaDialActivity" />
+        <service android:name="com.example.ElizaAgentService">
+            <intent-filter>
+                <action android:name="ai.eliza.AGENT" />
+            </intent-filter>
+        </service>
+        <activity android:name=".MainActivity">
+        </activity>
+    </application>
+</manifest>`;
+
+describe("Android manifest XML helpers", () => {
+  it("removes exact and package-relative component blocks", () => {
+    const withoutAgent = removeApplicationComponentBlock(
+      manifest,
+      "com.example.ElizaAgentService",
+    );
+    const withoutDial = removeApplicationComponentClassBlock(
+      withoutAgent,
+      "ElizaDialActivity",
+    );
+
+    expect(withoutDial).not.toContain("ElizaAgentService");
+    expect(withoutDial).not.toContain("ElizaDialActivity");
+    expect(withoutDial).toContain(".MainActivity");
+  });
+
+  it("removes active permission requests but preserves tools removal markers", () => {
+    const withMarker = ensureAndroidPermissionRemovalMarkers(manifest, [
+      "READ_SMS",
+    ]);
+    const stripped = removeAndroidPermissionRequests(withMarker, ["READ_SMS"]);
+
+    expect(stripped).toContain(
+      'xmlns:tools="http://schemas.android.com/tools"',
+    );
+    expect(stripped).toContain(
+      'android:name="android.permission.READ_SMS" tools:node="remove"',
+    );
+    expect(
+      hasAndroidPermissionRequest(stripped, "android.permission.READ_SMS"),
+    ).toBe(false);
+    expect(
+      hasAndroidPermissionRequest(
+        stripped,
+        "android.permission.ACCESS_FINE_LOCATION",
+      ),
+    ).toBe(true);
+  });
+
+  it("closes application before top-level manifest entries when a merge leaves it open", () => {
+    const malformed = `<manifest>
+    <application>
+    <uses-permission android:name="android.permission.CAMERA" />
+</manifest>`;
+
+    expect(
+      ensureManifestApplicationClosedBeforeTopLevelEntries(malformed),
+    ).toContain("</application>\n\n    <uses-permission");
+  });
+
+  it("applies cleartext policy and MainActivity filters idempotently", () => {
+    const cleartext = applyAndroidCleartextPolicy(manifest, {
+      allowCleartext: false,
+    });
+    const withHome = ensureElizaOsActivityFilters(cleartext, { enabled: true });
+    const withoutHome = ensureElizaOsActivityFilters(withHome, {
+      enabled: false,
+    });
+    const withScheme = ensureAndroidMainActivityUrlSchemeFilter(withoutHome, {
+      urlScheme: "example",
+    });
+
+    expect(cleartext).toContain('android:usesCleartextTraffic="false"');
+    expect(withHome).toContain("android.intent.category.HOME");
+    expect(withoutHome).not.toContain("android.intent.category.HOME");
+    expect(withScheme).toContain("android.intent.action.VIEW");
+    expect(
+      ensureAndroidMainActivityUrlSchemeFilter(withScheme, {
+        urlScheme: "example",
+      }),
+    ).toBe(withScheme);
+  });
+
+  it("strips comments containing removed markers before source audits", () => {
+    const xml = `<!-- ElizaAgentService legacy note -->
+<manifest><!-- keep me --></manifest>`;
+
+    expect(
+      removeXmlCommentsContaining(xml, ["ElizaAgentService"]),
+    ).not.toContain("ElizaAgentService");
+    expect(stripXmlComments(xml)).toBe("\n<manifest></manifest>");
+  });
+});

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -91,6 +91,24 @@ import {
   stageAndroidAgentRuntime,
 } from "./lib/stage-android-agent.mjs";
 import { resolveAndroidGradleCommandsForTarget } from "./mobile/android-gradle.mjs";
+import {
+  appendMissingAndroidManifestBlock,
+  appendMissingApplicationBlock,
+  applyAndroidCleartextPolicy,
+  ensureAndroidMainActivityShortcutsMetadata,
+  ensureAndroidMainActivityUrlSchemeFilter,
+  ensureAndroidPermissionRemovalMarkers,
+  ensureElizaOsActivityFilters,
+  ensureManifestApplicationClosedBeforeTopLevelEntries,
+  hasAndroidPermissionRequest,
+  patchAndroidAppActionsXmlResource,
+  removeAndroidPermissionRequests,
+  removeApplicationComponentBlock,
+  removeApplicationComponentClassBlock,
+  removeXmlCommentsContaining,
+  stripXmlComments,
+  validateAndroidAppActionsXmlResource,
+} from "./mobile/android-manifest.mjs";
 import { resolveAndroidBuildTarget } from "./mobile/targets/android.mjs";
 
 export {
@@ -100,6 +118,28 @@ export {
   mtpForceRebuildRequested,
   mtpSliceReuse,
 } from "./lib/mobile-build-decisions.mjs";
+export {
+  ANDROID_APP_ACTION_CAPABILITIES,
+  ANDROID_APP_ACTION_FORBIDDEN_MARKERS,
+  ANDROID_APP_ACTION_REQUIRED_DEEP_LINKS,
+  ANDROID_APP_ACTION_SHORTCUT_IDS,
+  appendMissingAndroidManifestBlock,
+  appendMissingApplicationBlock,
+  applyAndroidCleartextPolicy,
+  ensureAndroidMainActivityShortcutsMetadata,
+  ensureAndroidMainActivityUrlSchemeFilter,
+  ensureAndroidPermissionRemovalMarkers,
+  ensureElizaOsActivityFilters,
+  ensureManifestApplicationClosedBeforeTopLevelEntries,
+  hasAndroidPermissionRequest,
+  patchAndroidAppActionsXmlResource,
+  removeAndroidPermissionRequests,
+  removeApplicationComponentBlock,
+  removeApplicationComponentClassBlock,
+  removeXmlCommentsContaining,
+  stripXmlComments,
+  validateAndroidAppActionsXmlResource,
+} from "./mobile/android-manifest.mjs";
 export {
   ANDROID_BUILD_TARGETS,
   resolveAndroidBuildTarget,
@@ -2587,131 +2627,8 @@ function patchNativePluginGradleForAgp9() {
   }
 }
 
-function appendMissingAndroidManifestBlock(xml, marker, block) {
-  if (xml.includes(marker)) return xml;
-  return xml.replace("</manifest>", `${block}\n</manifest>`);
-}
-
-function appendMissingApplicationBlock(xml, marker, block) {
-  if (xml.includes(marker)) return xml;
-  return xml.replace("</application>", `${block}\n    </application>`);
-}
-
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function removeApplicationComponentBlock(xml, componentName) {
-  const escapedName = escapeRegExp(componentName);
-  const pairedRe = new RegExp(
-    `\\n\\s*<(activity|service|receiver)\\b(?=[^>]*android:name="${escapedName}")[\\s\\S]*?<\\/\\1>\\s*`,
-    "g",
-  );
-  const selfClosingRe = new RegExp(
-    `\\n\\s*<(activity|service|receiver)\\b(?=[^>]*android:name="${escapedName}")[^>]*/>\\s*`,
-    "g",
-  );
-  return xml.replace(selfClosingRe, "\n").replace(pairedRe, "\n");
-}
-
-function removeApplicationComponentClassBlock(xml, className) {
-  const escapedName = escapeRegExp(className);
-  const pairedRe = new RegExp(
-    `\\n\\s*<(activity|service|receiver)\\b(?=[^>]*android:name="[^"]*\\.?${escapedName}")[\\s\\S]*?<\\/\\1>\\s*`,
-    "g",
-  );
-  const selfClosingRe = new RegExp(
-    `\\n\\s*<(activity|service|receiver)\\b(?=[^>]*android:name="[^"]*\\.?${escapedName}")[^>]*/>\\s*`,
-    "g",
-  );
-  return xml.replace(selfClosingRe, "\n").replace(pairedRe, "\n");
-}
-
-function stripXmlComments(source) {
-  return source.replace(/<!--[\s\S]*?-->/g, "");
-}
-
-function removeXmlCommentsContaining(xml, markers) {
-  let patched = xml;
-  for (const marker of markers) {
-    const escapedMarker = escapeRegExp(marker);
-    patched = patched.replace(
-      new RegExp(
-        `\\n?\\s*<!--[\\s\\S]*?${escapedMarker}[\\s\\S]*?-->\\s*`,
-        "g",
-      ),
-      "\n",
-    );
-  }
-  return patched;
-}
-
-function ensureManifestToolsNamespace(xml) {
-  if (/\bxmlns:tools=/.test(xml)) return xml;
-  return xml.replace(
-    /<manifest\b([^>]*)>/,
-    '<manifest$1 xmlns:tools="http://schemas.android.com/tools">',
-  );
-}
-
-function hasAndroidPermissionRequest(xml, fullPermissionName) {
-  const escaped = escapeRegExp(fullPermissionName);
-  const re = new RegExp(
-    `<uses-permission\\b(?=[^>]*android:name="${escaped}")[^>]*>`,
-    "g",
-  );
-  for (const match of xml.matchAll(re)) {
-    if (!/\btools:node\s*=\s*"remove"/.test(match[0])) return true;
-  }
-  return false;
-}
-
-function removeAndroidPermissionRequests(xml, permissions) {
-  let patched = xml;
-  for (const perm of permissions) {
-    const escaped = escapeRegExp(`android.permission.${perm}`);
-    const re = new RegExp(
-      `\\n\\s*<uses-permission\\b(?=[^>]*android:name="${escaped}")(?![^>]*tools:node="remove")[^>]*/>\\s*`,
-      "g",
-    );
-    patched = patched.replace(re, "\n");
-  }
-  return patched;
-}
-
-function ensureAndroidPermissionRemovalMarkers(xml, permissions) {
-  let patched = ensureManifestToolsNamespace(xml);
-  for (const perm of permissions) {
-    const full = `android.permission.${perm}`;
-    const escaped = escapeRegExp(full);
-    const removalRe = new RegExp(
-      `<uses-permission\\b(?=[^>]*android:name="${escaped}")(?=[^>]*tools:node="remove")[^>]*/>`,
-      "m",
-    );
-    if (removalRe.test(patched)) continue;
-    patched = patched.replace(
-      "</manifest>",
-      `    <uses-permission android:name="${full}" tools:node="remove" />\n</manifest>`,
-    );
-  }
-  return patched;
-}
-
-function ensureManifestApplicationClosedBeforeTopLevelEntries(xml) {
-  if (xml.includes("</application>")) return xml;
-  const appStart = xml.indexOf("<application");
-  if (appStart === -1) return xml;
-  const afterApplicationStart = xml.indexOf(">", appStart);
-  if (afterApplicationStart === -1) return xml;
-  const afterApplication = xml.slice(afterApplicationStart + 1);
-  const topLevelEntry = afterApplication.search(
-    /\n\s*<(?:uses-permission|uses-feature)\b/,
-  );
-  if (topLevelEntry !== -1) {
-    const insertAt = afterApplicationStart + 1 + topLevelEntry;
-    return `${xml.slice(0, insertAt)}\n    </application>\n${xml.slice(insertAt)}`;
-  }
-  return xml.replace("</manifest>", "    </application>\n</manifest>");
 }
 
 export function shouldRemoveAndroidJavaSourceRoot(
@@ -2774,32 +2691,6 @@ function injectBrandUserAgentMarkers(javaSource, markers) {
   return javaSource.replace(arrayRe, `$1\n${lines.join("\n")}\n    $3`);
 }
 
-function removeElizaOsHomeActivityFilter(xml) {
-  return xml.replace(
-    /\n\s*<intent-filter>\s*<action\s+android:name="android\.intent\.action\.MAIN"\s*\/>\s*<category\s+android:name="android\.intent\.category\.HOME"\s*\/>\s*<category\s+android:name="android\.intent\.category\.DEFAULT"\s*\/>\s*<\/intent-filter>\s*/g,
-    "\n",
-  );
-}
-
-function ensureElizaOsActivityFilters(xml, { enabled = true } = {}) {
-  if (!enabled) {
-    return removeElizaOsHomeActivityFilter(xml);
-  }
-  if (xml.includes("android.intent.category.HOME")) {
-    return xml;
-  }
-  const mainActivityRe =
-    /(<activity\b(?=[\s\S]*?android:name="\.?MainActivity")[\s\S]*?)(\n\s*<\/activity>)/m;
-  const homeFilter = `
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.HOME" />
-                <category android:name="android.intent.category.DEFAULT" />
-            </intent-filter>
-`;
-  return xml.replace(mainActivityRe, `$1${homeFilter}$2`);
-}
-
 export function androidAospRoleLauncherIntentFilter({
   enabled = false,
   category = null,
@@ -2813,227 +2704,6 @@ export function androidAospRoleLauncherIntentFilter({
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />${extraCategory}
             </intent-filter>`;
-}
-
-function ensureAndroidMainActivityUrlSchemeFilter(xml) {
-  const mainActivityRe =
-    /(<activity\b(?=[\s\S]*?android:name="\.?MainActivity")[\s\S]*?)(\n\s*<\/activity>)/m;
-  const match = xml.match(mainActivityRe);
-  if (!match) return xml;
-
-  const mainActivity = `${match[1]}${match[2]}`;
-  const hasCustomSchemeFilter =
-    mainActivity.includes("android.intent.action.VIEW") &&
-    mainActivity.includes("android.intent.category.BROWSABLE") &&
-    (mainActivity.includes('android:scheme="@string/custom_url_scheme"') ||
-      mainActivity.includes(`android:scheme="${APP.urlScheme}"`));
-  if (hasCustomSchemeFilter) return xml;
-
-  const authFilter = `
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="@string/custom_url_scheme" />
-            </intent-filter>
-`;
-  return xml.replace(mainActivityRe, `$1${authFilter}$2`);
-}
-
-export function ensureAndroidMainActivityShortcutsMetadata(xml) {
-  const mainActivityRe =
-    /(<activity\b(?=[\s\S]*?android:name="\.?MainActivity")[\s\S]*?)(\n\s*<\/activity>)/m;
-  const match = xml.match(mainActivityRe);
-  if (!match) return xml;
-
-  const mainActivity = `${match[1]}${match[2]}`;
-  if (
-    mainActivity.includes('android:name="android.app.shortcuts"') &&
-    mainActivity.includes('android:resource="@xml/shortcuts"')
-  ) {
-    return xml;
-  }
-
-  const shortcutsMetadata = `
-            <meta-data
-                android:name="android.app.shortcuts"
-                android:resource="@xml/shortcuts" />
-`;
-  return xml.replace(mainActivityRe, `$1${shortcutsMetadata}$2`);
-}
-
-export function patchAndroidAppActionsXmlResource(
-  xml,
-  { androidPackage, urlScheme },
-) {
-  let patched = xml
-    .replace(
-      /\bandroid:targetPackage="[^"]+"/g,
-      `android:targetPackage="${androidPackage}"`,
-    )
-    .replace(
-      /\bandroid:targetClass="[^"]*\.MainActivity"/g,
-      `android:targetClass="${androidPackage}.MainActivity"`,
-    );
-
-  const escapedSchemes = [
-    "eliza",
-    "elizaos",
-    "ai.elizaos.app",
-    "app.eliza",
-    androidPackage,
-  ].filter(Boolean);
-  for (const scheme of escapedSchemes) {
-    patched = patched.replace(
-      new RegExp(`${escapeRegExp(scheme)}://`, "g"),
-      `${urlScheme}://`,
-    );
-  }
-
-  return patched;
-}
-
-export const ANDROID_APP_ACTION_CAPABILITIES = [
-  "actions.intent.OPEN_APP_FEATURE",
-  "actions.intent.CREATE_MESSAGE",
-  "actions.intent.GET_THING",
-];
-
-export const ANDROID_APP_ACTION_SHORTCUT_IDS = [
-  "eliza_app_action_chat",
-  "eliza_app_action_voice",
-  "eliza_app_action_daily_brief",
-  "eliza_app_action_new_task",
-  "eliza_app_action_tasks",
-];
-
-export const ANDROID_APP_ACTION_REQUIRED_DEEP_LINKS = [
-  "feature/open?source=android-app-actions",
-  "chat?source=android-app-actions&amp;action=ask",
-  "chat?source=android-app-actions&amp;action=chat",
-  "voice?source=android-static-shortcut",
-  "lifeops/daily-brief?source=android-static-shortcut",
-  "lifeops/task/new?source=android-static-shortcut",
-  "lifeops/tasks?source=android-static-shortcut",
-];
-
-export const ANDROID_APP_ACTION_FORBIDDEN_MARKERS = [
-  "actions.intent.CREATE_THING",
-  "android.intent.action.ASSIST",
-  "android.intent.action.VOICE_COMMAND",
-  "android.app.role.ASSISTANT",
-  "android.permission.BIND_VOICE_INTERACTION",
-  "assistant/open",
-];
-
-function extractAndroidAppActionCapabilityBlocks(xml) {
-  const blocks = new Map();
-  const capabilityRe =
-    /<capability\b[^>]*android:name="(actions\.intent\.[^"]+)"[^>]*>([\s\S]*?)<\/capability>/g;
-  for (const match of xml.matchAll(capabilityRe)) {
-    blocks.set(match[1], match[2]);
-  }
-  return blocks;
-}
-
-export function validateAndroidAppActionsXmlResource(
-  xml,
-  { androidPackage, urlScheme },
-) {
-  const failures = [];
-  const capabilityBlocks = extractAndroidAppActionCapabilityBlocks(xml);
-
-  for (const capability of ANDROID_APP_ACTION_CAPABILITIES) {
-    if (!xml.includes(`android:name="${capability}"`)) {
-      failures.push(`shortcuts.xml is missing ${capability}`);
-    }
-    const block = capabilityBlocks.get(capability);
-    if (!block) continue;
-    const intentBlocks = [
-      ...block.matchAll(/<intent\b[^>]*\/>|<intent\b[\s\S]*?<\/intent>/g),
-    ].map((match) => match[0]);
-    const hasFallbackIntent = intentBlocks.some(
-      (intent) => !/android:required="true"/.test(intent),
-    );
-    if (!hasFallbackIntent) {
-      failures.push(
-        `shortcuts.xml ${capability} is missing a no-required-parameter fallback intent`,
-      );
-    }
-  }
-
-  for (const match of xml.matchAll(
-    /\bandroid:name="(actions\.intent\.[^"]+)"/g,
-  )) {
-    const action = match[1];
-    if (!ANDROID_APP_ACTION_CAPABILITIES.includes(action)) {
-      failures.push(`shortcuts.xml declares unsupported App Action ${action}`);
-    }
-  }
-
-  for (const shortcutId of ANDROID_APP_ACTION_SHORTCUT_IDS) {
-    if (!xml.includes(`android:shortcutId="${shortcutId}"`)) {
-      failures.push(`shortcuts.xml is missing ${shortcutId}`);
-    }
-  }
-
-  for (const source of ["android-app-actions", "android-static-shortcut"]) {
-    if (!xml.includes(`source=${source}`)) {
-      failures.push(`shortcuts.xml is missing source=${source} deep links`);
-    }
-  }
-
-  for (const deepLink of ANDROID_APP_ACTION_REQUIRED_DEEP_LINKS) {
-    if (!xml.includes(`${urlScheme}://${deepLink}`)) {
-      failures.push(`shortcuts.xml is missing ${urlScheme}://${deepLink}`);
-    }
-  }
-
-  for (const marker of ANDROID_APP_ACTION_FORBIDDEN_MARKERS) {
-    if (xml.includes(marker)) {
-      failures.push(`shortcuts.xml contains forbidden marker ${marker}`);
-    }
-  }
-
-  for (const match of xml.matchAll(/\bandroid:targetPackage="([^"]+)"/g)) {
-    if (match[1] !== androidPackage) {
-      failures.push(
-        `shortcuts.xml targetPackage ${match[1]} was not rewritten to ${androidPackage}`,
-      );
-    }
-  }
-
-  const expectedTargetClass = `${androidPackage}.MainActivity`;
-  for (const match of xml.matchAll(/\bandroid:targetClass="([^"]+)"/g)) {
-    if (match[1] !== expectedTargetClass) {
-      failures.push(
-        `shortcuts.xml targetClass ${match[1]} was not rewritten to ${expectedTargetClass}`,
-      );
-    }
-  }
-
-  if (!xml.includes(`${urlScheme}://`)) {
-    failures.push(
-      `shortcuts.xml URL templates were not rewritten to ${urlScheme}://`,
-    );
-  }
-
-  const staleLiterals = [
-    androidPackage === "app.eliza" ? null : 'android:targetPackage="app.eliza"',
-    androidPackage === "ai.elizaos.app"
-      ? null
-      : 'android:targetClass="ai.elizaos.app.MainActivity"',
-    urlScheme === "eliza" ? null : "eliza://",
-    urlScheme === "ai.elizaos.app" ? null : "ai.elizaos.app://",
-    urlScheme === "app.eliza" ? null : "app.eliza://",
-  ].filter(Boolean);
-  for (const stale of staleLiterals) {
-    if (xml.includes(stale)) {
-      failures.push(`shortcuts.xml still contains stale literal ${stale}`);
-    }
-  }
-
-  return failures;
 }
 
 function assertSharedTreeOnlyForEliza(what) {
@@ -3132,20 +2802,6 @@ function syncAndroidAppActionsResources() {
       "[mobile-build] Rewrote Android App Actions package and scheme.",
     );
   }
-}
-
-export function applyAndroidCleartextPolicy(xml, { allowCleartext }) {
-  const value = allowCleartext ? "true" : "false";
-  if (/android:usesCleartextTraffic="(?:true|false)"/.test(xml)) {
-    return xml.replace(
-      /android:usesCleartextTraffic="(?:true|false)"/g,
-      `android:usesCleartextTraffic="${value}"`,
-    );
-  }
-  return xml.replace(
-    "<application",
-    `<application\n        android:usesCleartextTraffic="${value}"`,
-  );
 }
 
 function writeAndroidCleartextPolicy({ allowCleartext, label }) {
@@ -3390,7 +3046,9 @@ function overlayAndroid({ includeAospRoleLaunchers = false } = {}) {
       xml = withElizaOsActivityFilters;
       dirty = true;
     }
-    const withUrlSchemeFilter = ensureAndroidMainActivityUrlSchemeFilter(xml);
+    const withUrlSchemeFilter = ensureAndroidMainActivityUrlSchemeFilter(xml, {
+      urlScheme: APP.urlScheme,
+    });
     if (withUrlSchemeFilter !== xml) {
       xml = withUrlSchemeFilter;
       dirty = true;


### PR DESCRIPTION
## Summary
- Move pure Android manifest XML transforms into `packages/app-core/scripts/mobile/android-manifest.mjs`
- Keep `run-mobile-build.mjs` as a compatibility re-export surface for existing App Actions tests/downstream imports
- Leave filesystem build orchestration, source stripping, source audits, and artifact audits in the main mobile build script while delegating their manifest edits to the split module

## Evidence
- `.github/issue-evidence/10096-android-manifest-module.md`

## Verification
- `node --check packages/app-core/scripts/run-mobile-build.mjs && node --check packages/app-core/scripts/mobile/android-manifest.mjs && node --check packages/app-core/scripts/run-mobile-build-android-manifest.test.mjs && node --check packages/app-core/scripts/run-mobile-build-android-app-actions.test.mjs && node --check packages/app-core/scripts/run-mobile-build-android-targets.test.mjs`
- `bunx biome check packages/app-core/scripts/run-mobile-build.mjs packages/app-core/scripts/mobile/android-manifest.mjs packages/app-core/scripts/run-mobile-build-android-manifest.test.mjs packages/app-core/scripts/run-mobile-build-android-targets.test.mjs .github/issue-evidence/10096-android-manifest-module.md`
- `bun run --cwd packages/app-core test -- scripts/run-mobile-build-android-manifest.test.mjs scripts/run-mobile-build-android-targets.test.mjs`
- `node --test packages/app-core/scripts/run-mobile-build-android-app-actions.test.mjs`

Part of #10096
