### PR TITLE
refactor(app-core): extract iOS plist transformers to scripts/mobile/ (#10096 item 2)

### DIFF
--- a/packages/app-core/scripts/mobile/escape.mjs
+++ b/packages/app-core/scripts/mobile/escape.mjs
@@ -1,0 +1,21 @@
+/**
+ * Shared string-escaping leaf utilities for the mobile build orchestrator.
+ *
+ * These are pure, dependency-free helpers used by the manifest/plist/gradle
+ * transformer modules and by the build spine. They live in their own leaf
+ * module so the transformer modules can import them without creating a cycle
+ * back into `run-mobile-build.mjs`.
+ */
+
+/** Escape XML text content (`&`, `<`, `>`) for safe insertion into a node. */
+export function escapeXmlText(value) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+/** Escape a string for literal use inside a `RegExp`. */
+export function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/packages/app-core/scripts/mobile/ios-plist.mjs
+++ b/packages/app-core/scripts/mobile/ios-plist.mjs
@@ -1,0 +1,83 @@
+/**
+ * Pure iOS Info.plist / project.pbxproj string transformers.
+ *
+ * Each function takes file content (and options) and returns transformed
+ * content — no filesystem or module state. The build spine
+ * (`run-mobile-build.mjs`) reads/writes the files and calls these to mutate
+ * the text.
+ */
+import { escapeRegExp, escapeXmlText } from "./escape.mjs";
+
+/** Set (or insert before `</dict>`) a `<key>`/`<string>` pair in a plist. */
+export function replaceOrInsertPlistString(content, key, value) {
+  const escapedValue = escapeXmlText(value);
+  const keyRe = escapeRegExp(key);
+  const existingRe = new RegExp(
+    `(<key>${keyRe}</key>\\s*<string>)[^<]*(</string>)`,
+  );
+  if (existingRe.test(content)) {
+    return content.replace(existingRe, `$1${escapedValue}$2`);
+  }
+  return content.replace(
+    "</dict>",
+    `\t<key>${key}</key>\n\t<string>${escapedValue}</string>\n</dict>`,
+  );
+}
+
+/** Ensure a plist `<array>` under `key` contains every value in `values`. */
+export function ensurePlistArrayStrings(content, key, values) {
+  const escapedValues = values.map(escapeXmlText);
+  const keyRe = escapeRegExp(key);
+  const arrayRe = new RegExp(
+    `(<key>${keyRe}</key>\\s*<array>)([\\s\\S]*?)(\\s*</array>)`,
+  );
+  const match = content.match(arrayRe);
+  if (!match) {
+    const body = escapedValues
+      .map((value) => `\t\t<string>${value}</string>`)
+      .join("\n");
+    return insertBeforeRootPlistDictClose(
+      content,
+      `\t<key>${key}</key>\n\t<array>\n${body}\n\t</array>\n</dict>`,
+    );
+  }
+  let body = match[2];
+  for (const value of escapedValues) {
+    if (!body.includes(`<string>${value}</string>`)) {
+      body += `\n\t\t<string>${value}</string>`;
+    }
+  }
+  return content.replace(arrayRe, `$1${body}$3`);
+}
+
+/** Insert text immediately before the plist's root `</dict>`. */
+export function insertBeforeRootPlistDictClose(content, insertion) {
+  const rootClose = "\n</dict>\n</plist>";
+  const index = content.lastIndexOf(rootClose);
+  if (index >= 0) {
+    return `${content.slice(0, index)}\n${insertion}${content.slice(index + "\n</dict>".length)}`;
+  }
+  const fallbackIndex = content.lastIndexOf("</dict>");
+  if (fallbackIndex < 0) return content;
+  return `${content.slice(0, fallbackIndex)}${insertion}${content.slice(fallbackIndex + "</dict>".length)}`;
+}
+
+/** Rewrite hard-coded `group.<bundle>` app-group ids to the build's app group. */
+export function replaceIosAppGroupPlaceholders(content, appGroup) {
+  return content.replace(
+    /(^|[^A-Za-z0-9_.-])group\.(ai\.elizaos\.app|app\.eliza|com\.elizaai\.eliza)(?![A-Za-z0-9_.-])/g,
+    `$1${appGroup}`,
+  );
+}
+
+/** Remove the named id entries from a pbxproj list section. */
+export function removePbxListEntries(content, ids) {
+  let next = content;
+  for (const id of ids) {
+    next = next.replace(
+      new RegExp(`\\n\\t+${escapeRegExp(id)} /\\* [^\\n]+ \\*/,`, "g"),
+      "",
+    );
+  }
+  return next;
+}

--- a/packages/app-core/scripts/mobile/ios-plist.test.mjs
+++ b/packages/app-core/scripts/mobile/ios-plist.test.mjs
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+
+import { escapeRegExp, escapeXmlText } from "./escape.mjs";
+import {
+  ensurePlistArrayStrings,
+  insertBeforeRootPlistDictClose,
+  removePbxListEntries,
+  replaceIosAppGroupPlaceholders,
+  replaceOrInsertPlistString,
+} from "./ios-plist.mjs";
+
+// These pure transformers were extracted verbatim out of the 7.8k-line
+// run-mobile-build.mjs spine (#10096 item 2). The orchestrators that call them
+// run real Gradle/Xcode builds and have no unit coverage, but the transformers
+// themselves are deterministic string functions — so they get locked here so a
+// regression in the decomposition is caught without a device build.
+
+const PLIST = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+\t<key>CFBundleName</key>
+\t<string>Eliza</string>
+</dict>
+</plist>`;
+
+describe("escape leaf utilities", () => {
+  it("escapeXmlText escapes the XML-significant characters", () => {
+    expect(escapeXmlText("a & b < c > d")).toBe("a &amp; b &lt; c &gt; d");
+  });
+
+  it("escapeXmlText escapes ampersands before angle brackets (no double-escape)", () => {
+    expect(escapeXmlText("<&>")).toBe("&lt;&amp;&gt;");
+  });
+
+  it("escapeRegExp neutralizes regex metacharacters", () => {
+    const escaped = escapeRegExp("a.b+c(d)");
+    expect(new RegExp(escaped).test("a.b+c(d)")).toBe(true);
+    expect(new RegExp(escaped).test("axbxcxd")).toBe(false);
+  });
+});
+
+describe("replaceOrInsertPlistString", () => {
+  it("replaces the value of an existing key", () => {
+    const out = replaceOrInsertPlistString(PLIST, "CFBundleName", "Milady");
+    expect(out).toContain("<key>CFBundleName</key>\n\t<string>Milady</string>");
+    expect(out).not.toContain("<string>Eliza</string>");
+  });
+
+  it("inserts a new key/string before </dict> when absent", () => {
+    const out = replaceOrInsertPlistString(PLIST, "NewKey", "NewValue");
+    expect(out).toContain("<key>NewKey</key>");
+    expect(out).toContain("<string>NewValue</string>");
+  });
+
+  it("escapes the inserted value", () => {
+    const out = replaceOrInsertPlistString(PLIST, "CFBundleName", "A & B");
+    expect(out).toContain("<string>A &amp; B</string>");
+  });
+});
+
+describe("ensurePlistArrayStrings", () => {
+  it("creates the array when the key is missing", () => {
+    const out = ensurePlistArrayStrings(PLIST, "Modes", ["a", "b"]);
+    expect(out).toContain("<key>Modes</key>");
+    expect(out).toContain("<string>a</string>");
+    expect(out).toContain("<string>b</string>");
+  });
+
+  it("appends only missing entries to an existing array (idempotent)", () => {
+    const withArray = ensurePlistArrayStrings(PLIST, "Modes", ["a"]);
+    const out = ensurePlistArrayStrings(withArray, "Modes", ["a", "b"]);
+    expect(out.match(/<string>a<\/string>/g)).toHaveLength(1);
+    expect(out).toContain("<string>b</string>");
+  });
+});
+
+describe("insertBeforeRootPlistDictClose", () => {
+  it("inserts before the root </dict></plist>, not a nested one", () => {
+    const nested = `<plist version="1.0">
+<dict>
+\t<key>Inner</key>
+\t<dict>
+\t\t<key>X</key>
+\t\t<string>1</string>
+\t</dict>
+</dict>
+</plist>`;
+    const out = insertBeforeRootPlistDictClose(nested, "\t<key>Added</key>");
+    // The injected key lands after the inner dict closes, before the root dict.
+    expect(out.indexOf("<key>Added</key>")).toBeGreaterThan(
+      out.indexOf("<key>X</key>"),
+    );
+    expect(out.endsWith("</plist>")).toBe(true);
+  });
+});
+
+describe("replaceIosAppGroupPlaceholders", () => {
+  it("rewrites known placeholder app groups to the build app group", () => {
+    const src = "group.ai.elizaos.app and group.app.eliza";
+    const out = replaceIosAppGroupPlaceholders(src, "group.custom.app");
+    expect(out).toBe("group.custom.app and group.custom.app");
+  });
+
+  it("leaves unrelated group ids untouched", () => {
+    const src = "group.com.other.thing";
+    expect(replaceIosAppGroupPlaceholders(src, "group.custom.app")).toBe(src);
+  });
+});
+
+describe("removePbxListEntries", () => {
+  it("removes the named id lines from a pbxproj list section", () => {
+    const pbx = `\n\t\tAAAA1111 /* Foo.swift */,\n\t\tBBBB2222 /* Bar.swift */,`;
+    const out = removePbxListEntries(pbx, ["AAAA1111"]);
+    expect(out).not.toContain("AAAA1111");
+    expect(out).toContain("BBBB2222 /* Bar.swift */,");
+  });
+});

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -91,6 +91,13 @@ import {
   stageAndroidAgentRuntime,
 } from "./lib/stage-android-agent.mjs";
 import { resolveAndroidGradleCommandsForTarget } from "./mobile/android-gradle.mjs";
+import { escapeRegExp, escapeXmlText } from "./mobile/escape.mjs";
+import {
+  ensurePlistArrayStrings,
+  removePbxListEntries,
+  replaceIosAppGroupPlaceholders,
+  replaceOrInsertPlistString,
+} from "./mobile/ios-plist.mjs";
 import { resolveAndroidBuildTarget } from "./mobile/targets/android.mjs";
 
 export {
@@ -554,66 +561,8 @@ function escapeJavaString(value) {
   return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }
 
-function escapeXmlText(value) {
-  return value
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
-}
-
 function escapeXcodeBuildSetting(value) {
   return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
-}
-
-function replaceOrInsertPlistString(content, key, value) {
-  const escapedValue = escapeXmlText(value);
-  const keyRe = escapeRegExp(key);
-  const existingRe = new RegExp(
-    `(<key>${keyRe}</key>\\s*<string>)[^<]*(</string>)`,
-  );
-  if (existingRe.test(content)) {
-    return content.replace(existingRe, `$1${escapedValue}$2`);
-  }
-  return content.replace(
-    "</dict>",
-    `\t<key>${key}</key>\n\t<string>${escapedValue}</string>\n</dict>`,
-  );
-}
-
-function ensurePlistArrayStrings(content, key, values) {
-  const escapedValues = values.map(escapeXmlText);
-  const keyRe = escapeRegExp(key);
-  const arrayRe = new RegExp(
-    `(<key>${keyRe}</key>\\s*<array>)([\\s\\S]*?)(\\s*</array>)`,
-  );
-  const match = content.match(arrayRe);
-  if (!match) {
-    const body = escapedValues
-      .map((value) => `\t\t<string>${value}</string>`)
-      .join("\n");
-    return insertBeforeRootPlistDictClose(
-      content,
-      `\t<key>${key}</key>\n\t<array>\n${body}\n\t</array>\n</dict>`,
-    );
-  }
-  let body = match[2];
-  for (const value of escapedValues) {
-    if (!body.includes(`<string>${value}</string>`)) {
-      body += `\n\t\t<string>${value}</string>`;
-    }
-  }
-  return content.replace(arrayRe, `$1${body}$3`);
-}
-
-function insertBeforeRootPlistDictClose(content, insertion) {
-  const rootClose = "\n</dict>\n</plist>";
-  const index = content.lastIndexOf(rootClose);
-  if (index >= 0) {
-    return `${content.slice(0, index)}\n${insertion}${content.slice(index + "\n</dict>".length)}`;
-  }
-  const fallbackIndex = content.lastIndexOf("</dict>");
-  if (fallbackIndex < 0) return content;
-  return `${content.slice(0, fallbackIndex)}${insertion}${content.slice(fallbackIndex + "</dict>".length)}`;
 }
 
 /**
@@ -727,13 +676,6 @@ function replaceInFile(filePath, replacements) {
   return true;
 }
 
-function replaceIosAppGroupPlaceholders(content, appGroup) {
-  return content.replace(
-    /(^|[^A-Za-z0-9_.-])group\.(ai\.elizaos\.app|app\.eliza|com\.elizaai\.eliza)(?![A-Za-z0-9_.-])/g,
-    `$1${appGroup}`,
-  );
-}
-
 function replaceIosAppGroupPlaceholdersInFile(filePath, appGroup) {
   if (!fs.existsSync(filePath)) return false;
   const content = fs.readFileSync(filePath, "utf8");
@@ -759,17 +701,6 @@ function writeIosPersonalTeamEntitlements(filePath) {
   }
   fs.writeFileSync(filePath, IOS_PERSONAL_TEAM_ENTITLEMENTS, "utf8");
   return true;
-}
-
-function removePbxListEntries(content, ids) {
-  let next = content;
-  for (const id of ids) {
-    next = next.replace(
-      new RegExp(`\\n\\t+${escapeRegExp(id)} /\\* [^\\n]+ \\*/,`, "g"),
-      "",
-    );
-  }
-  return next;
 }
 
 function stripIosPrivilegedExtensionTargets({
@@ -2595,10 +2526,6 @@ function appendMissingAndroidManifestBlock(xml, marker, block) {
 function appendMissingApplicationBlock(xml, marker, block) {
   if (xml.includes(marker)) return xml;
   return xml.replace("</application>", `${block}\n    </application>`);
-}
-
-function escapeRegExp(value) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function removeApplicationComponentBlock(xml, componentName) {


### PR DESCRIPTION
## What

First landed slice of the `run-mobile-build.mjs` decomposition tracked in #10096 (item 2 — "Split the 7.8k-line `run-mobile-build.mjs` into `scripts/mobile/*`").

Extracts the **pure** Info.plist / `project.pbxproj` string transformers out of the build spine into a dedicated leaf module so they can be unit-tested and reused without dragging in the build orchestrator:

- `scripts/mobile/ios-plist.mjs` — `replaceOrInsertPlistString`, `ensurePlistArrayStrings`, `insertBeforeRootPlistDictClose`, `replaceIosAppGroupPlaceholders`, `removePbxListEntries`
- `scripts/mobile/escape.mjs` — `escapeXmlText`, `escapeRegExp` leaf utilities (broken out so the transformer modules import them without a cycle back into the spine)

The build spine now imports the relocated helpers; the functions moved **verbatim** (no behavior change). This composes with the already-landed Android target-table extraction (#10172) without touching it.

## Scope note

This is deliberately the device/CI-independent subset of #10096. The remaining checklist items (Android `buildAndroid*` orchestrator dedup, full file split of the targets, pod/capacitor mapping tables, Linux ISO GHA cache, agent-image Turbo build, CI workflow dedup) all require a real Gradle/Xcode/GHA environment to verify safely and stay open on #10096 for their own evidence-backed PRs. The *pure* transformers are exactly the part that can be moved and locked from a local box without risking the mobile/CI pipelines.

## Evidence

- **No-larp unit test:** `scripts/mobile/ios-plist.test.mjs` — 12 vitest cases driving the real transformers: existing-key replace, new-key insert-before-`</dict>`, XML escaping of inserted values, idempotent `<array>` merge, root-vs-nested `</dict></plist>` insertion targeting, app-group placeholder rewrite (and leaving unrelated groups untouched), and pbx list-entry removal.
- **No regression in the spine:** full module load of `run-mobile-build.mjs` succeeds; existing mobile suites stay green —
  - vitest: `ios-plist` (12), `ios-engine-gate` (9), `android-targets` (10), `plugin-manifest` — 31 passed
  - node:test: `android-app-actions` — 11 passed
- **Lint:** `biome check` clean on all four files (also removed a now-unused `insertBeforeRootPlistDictClose` import the rebase surfaced in the spine).

Device-build verification of a full `build:ios` / `build:android` is **N/A for this PR** — no `.mjs` callsite changed behavior; the helpers moved verbatim and are covered by the unit tests above. The installable-app verification belongs to the file-split / orchestrator-dedup items still open on #10096.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
