### PR TITLE
feat(health,personal-assistant): ingest approved iOS coarse screen-time summaries (#9970)

### DIFF
--- a/.github/issue-evidence/9970-ios-coarse-ingestion.md
+++ b/.github/issue-evidence/9970-ios-coarse-ingestion.md
@@ -1,0 +1,57 @@
+# #9970 — iOS coarse-summary screen-time ingestion (criterion #4)
+
+Implements the consumer side of criterion #4: ingest iOS **coarse** screen-time
+into the same screen-time read path as Android, **only when authorization is
+approved**, while keeping `rawUsageExportAvailable: false` as a permanent Apple
+constraint (documented in #10178).
+
+## What changed
+
+- `plugins/plugin-health/src/screen-time/mobile-signals.ts` —
+  `iosCoarseUsageRowsFromSignals(signals, sinceMs, untilMs)`, a parallel to the
+  existing `androidUsageRowsFromSignals`. It reads coarse **category** summaries
+  off `metadata.screenTime.categories` and emits `ScreenTimeAggregateRow`s
+  (`source: "app"`, `identifier: "ios.category.<id>"`, `metadata.platform: "ios"`),
+  gated on:
+  - `authorization.status === "approved"`,
+  - `coarseSummaryAvailable === true`,
+  - `rawUsageExportAvailable !== true` (raw per-app export is never ingested — a
+    permanent platform constraint).
+- `plugins/plugin-personal-assistant/src/lifeops/domains/screentime-service.ts` —
+  wires it into `collectScreenTimeRows`'s `source: "app"` block, immediately
+  after the Android reader, filtering the same `listActivitySignals` result to
+  `platform === "ios"` within the window.
+
+## Design notes
+
+- Apple's DeviceActivity / FamilyControls model only exposes coarse,
+  in-extension-rendered **category** summaries to the host — never raw per-app
+  usage. The reader therefore ingests category totals, not per-window dwell, and
+  refuses any signal that claims `rawUsageExportAvailable: true`.
+- The reader is **inert until a native iOS producer emits
+  `metadata.screenTime.categories`** — the contract mirrors the host-side coarse
+  model (category identifier + total active time, `totalSeconds` or `totalMs`).
+  No existing signal carries that field, so production behavior is unchanged
+  until the producer lands; the spine already accepts the `mobile_health`
+  signals that would carry it.
+
+## Verification
+
+- `vitest run src/screen-time/mobile-signals.test.ts` → **8 passed** (3 new):
+  - approved coarse categories → aggregated `ios.category.*` rows;
+  - `denied` / `not-determined` / `unavailable` auth → no rows;
+  - `coarseSummaryAvailable: false` → no rows;
+  - `rawUsageExportAvailable: true` → no rows (constraint).
+- `tsc --noEmit` (plugin-health) → **0 errors in the reader**; the 2 remaining
+  worktree errors are unbuilt `@elizaos/capacitor-*` `.d.ts` in `packages/ui`,
+  untouched by this PR.
+- `biome check` → clean.
+
+## Evidence types (per PR_EVIDENCE.md)
+
+- **Real-LLM trajectory:** N/A — pure data-ingestion read path, no model.
+- **Backend logs:** N/A — the reader emits rows; covered by unit tests with
+  injected signals (the only way to exercise it on a non-iOS host).
+- **Frontend / screenshots / video / audio:** N/A — no UI/voice surface; the
+  rows flow into the existing screen-time read path already rendered by the
+  dashboard.

--- a/plugins/plugin-health/src/screen-time/mobile-signals.test.ts
+++ b/plugins/plugin-health/src/screen-time/mobile-signals.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   androidUsageRowsFromSignals,
+  iosCoarseUsageRowsFromSignals,
   mobileScreenTimeDataSourceFromSignals,
   mobileSignalPermissionTargetForAction,
   mobileSignalSetupActionBadge,
@@ -191,6 +192,128 @@ describe("screen-time mobile signals", () => {
       statusLabel: "Unsupported",
       detail: "This iOS device has not reported Screen Time support.",
     });
+  });
+
+  it("ingests approved iOS coarse category summaries into aggregate rows", () => {
+    const sinceMs = Date.parse("2026-06-02T00:00:00.000Z");
+    const untilMs = Date.parse("2026-06-02T23:59:00.000Z");
+
+    expect(
+      iosCoarseUsageRowsFromSignals(
+        [
+          {
+            metadata: {
+              screenTime: {
+                authorization: { status: "approved" },
+                coarseSummaryAvailable: true,
+                rawUsageExportAvailable: false,
+                categories: [
+                  {
+                    identifier: "social",
+                    displayName: "Social",
+                    totalMs: 7_200_000,
+                  },
+                  { identifier: "productivity", totalSeconds: 5_400 },
+                ],
+              },
+            },
+          },
+        ],
+        sinceMs,
+        untilMs,
+      ),
+    ).toEqual([
+      {
+        source: "app",
+        identifier: "ios.category.social",
+        displayName: "Social",
+        totalSeconds: 7_200,
+        sessionCount: 1,
+        metadata: { platform: "ios", kind: "category", categoryId: "social" },
+      },
+      {
+        source: "app",
+        identifier: "ios.category.productivity",
+        displayName: "productivity",
+        totalSeconds: 5_400,
+        sessionCount: 1,
+        metadata: {
+          platform: "ios",
+          kind: "category",
+          categoryId: "productivity",
+        },
+      },
+    ]);
+  });
+
+  it("ignores iOS coarse summaries unless authorization is approved", () => {
+    const sinceMs = Date.parse("2026-06-02T00:00:00.000Z");
+    const untilMs = Date.parse("2026-06-02T23:59:00.000Z");
+    const categories = [{ identifier: "social", totalSeconds: 600 }];
+
+    // Not approved → never ingested.
+    for (const status of ["denied", "not-determined", "unavailable"]) {
+      expect(
+        iosCoarseUsageRowsFromSignals(
+          [
+            {
+              metadata: {
+                screenTime: {
+                  authorization: { status },
+                  coarseSummaryAvailable: true,
+                  categories,
+                },
+              },
+            },
+          ],
+          sinceMs,
+          untilMs,
+        ),
+      ).toEqual([]);
+    }
+
+    // Approved but coarse summaries not available → nothing to ingest.
+    expect(
+      iosCoarseUsageRowsFromSignals(
+        [
+          {
+            metadata: {
+              screenTime: {
+                authorization: { status: "approved" },
+                coarseSummaryAvailable: false,
+                categories,
+              },
+            },
+          },
+        ],
+        sinceMs,
+        untilMs,
+      ),
+    ).toEqual([]);
+  });
+
+  it("never ingests raw per-app export even if a signal claims it (platform constraint)", () => {
+    const sinceMs = Date.parse("2026-06-02T00:00:00.000Z");
+    const untilMs = Date.parse("2026-06-02T23:59:00.000Z");
+
+    expect(
+      iosCoarseUsageRowsFromSignals(
+        [
+          {
+            metadata: {
+              screenTime: {
+                authorization: { status: "approved" },
+                coarseSummaryAvailable: true,
+                rawUsageExportAvailable: true,
+                categories: [{ identifier: "social", totalSeconds: 600 }],
+              },
+            },
+          },
+        ],
+        sinceMs,
+        untilMs,
+      ),
+    ).toEqual([]);
   });
 
   it("owns mobile health/screen-time permission setup presentation policy", () => {

--- a/plugins/plugin-health/src/screen-time/mobile-signals.ts
+++ b/plugins/plugin-health/src/screen-time/mobile-signals.ts
@@ -85,6 +85,80 @@ export function androidUsageRowsFromSignals(
   return [...byPackage.values()];
 }
 
+function coarseCategoryTotalSeconds(
+  category: Record<string, unknown> | null,
+): number {
+  if (!category) return 0;
+  if (typeof category.totalSeconds === "number") {
+    return positiveNumber(category.totalSeconds);
+  }
+  const ms = positiveNumber(category.totalMs);
+  return ms > 0 ? Math.floor(ms / 1000) : 0;
+}
+
+/**
+ * iOS coarse screen-time ingestion (issue #9970). Apple's DeviceActivity /
+ * FamilyControls model exposes only coarse, in-extension-rendered *category*
+ * summaries to the host — never raw per-app export (`rawUsageExportAvailable`
+ * is permanently false). When Screen Time authorization is approved and the
+ * device reports coarse summaries, ingest those category totals into the same
+ * screen-time read path as Android, gated on
+ * `metadata.screenTime.authorization.status === "approved"` and
+ * `coarseSummaryAvailable === true`.
+ *
+ * The reader is inert until a native iOS producer emits
+ * `metadata.screenTime.categories`; the contract mirrors the host-side coarse
+ * model (a category identifier + its total active time). Raw per-app export is
+ * never read — if a signal ever set `rawUsageExportAvailable: true` it is
+ * skipped, since that violates the platform constraint.
+ */
+export function iosCoarseUsageRowsFromSignals(
+  signals: Array<{ metadata: Record<string, unknown> }>,
+  sinceMs: number,
+  untilMs: number,
+): ScreenTimeAggregateRow[] {
+  if (untilMs - sinceMs > DAY_MS) {
+    return [];
+  }
+
+  const byCategory = new Map<string, ScreenTimeAggregateRow>();
+  for (const signal of signals) {
+    const screenTime = asRecord(signal.metadata.screenTime);
+    if (!screenTime) continue;
+    // Raw per-app export is a permanent Apple constraint — never ingest it.
+    if (screenTime.rawUsageExportAvailable === true) continue;
+    if (screenTime.coarseSummaryAvailable !== true) continue;
+    const authorization = asRecord(screenTime.authorization);
+    if (authorization?.status !== "approved") continue;
+
+    for (const rawCategory of asArray(screenTime.categories)) {
+      const category = asRecord(rawCategory);
+      const identifier =
+        typeof category?.identifier === "string"
+          ? category.identifier.trim()
+          : "";
+      const totalSeconds = coarseCategoryTotalSeconds(category);
+      if (!identifier || totalSeconds <= 0) continue;
+      const displayName =
+        typeof category?.displayName === "string" && category.displayName.trim()
+          ? category.displayName.trim()
+          : identifier;
+      const key = `ios.category.${identifier}`;
+      const existing = byCategory.get(key);
+      if (existing && existing.totalSeconds >= totalSeconds) continue;
+      byCategory.set(key, {
+        source: "app",
+        identifier: key,
+        displayName,
+        totalSeconds,
+        sessionCount: 1,
+        metadata: { platform: "ios", kind: "category", categoryId: identifier },
+      });
+    }
+  }
+  return [...byCategory.values()];
+}
+
 export function mobileScreenTimeDataSourceFromSignals(
   signals: ScreenTimeMobileSignal[],
   platform: "android" | "ios",

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/screentime-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/screentime-service.ts
@@ -16,6 +16,7 @@ import {
   computePriorScreenTimeRange,
   computeScreenTimeRange,
   enumerateScreenTimeHistoryDays,
+  iosCoarseUsageRowsFromSignals,
   isSocialCategory,
   isSystemInactivityApp,
   mergeScreenTimeAggregateRows,
@@ -425,6 +426,17 @@ export class ScreenTimeDomain {
           mobileSignals.filter(
             (signal) =>
               signal.platform === "android" &&
+              inWindow(signal.observedAt, sinceMs, untilMs),
+          ),
+          sinceMs,
+          untilMs,
+        ),
+      );
+      rows.push(
+        ...iosCoarseUsageRowsFromSignals(
+          mobileSignals.filter(
+            (signal) =>
+              signal.platform === "ios" &&
               inWindow(signal.observedAt, sinceMs, untilMs),
           ),
           sinceMs,


### PR DESCRIPTION
## Summary

Implements the **consumer side of criterion #4** for #9970: ingest iOS **coarse**
screen-time into the same read path as Android, **only when authorization is
approved**, while keeping `rawUsageExportAvailable: false` as a permanent Apple
constraint (documented in merged #10178).

- `iosCoarseUsageRowsFromSignals` (plugin-health) — parallel to
  `androidUsageRowsFromSignals`; reads coarse **category** summaries off
  `metadata.screenTime.categories` and emits aggregate rows
  (`source: "app"`, `identifier: "ios.category.<id>"`, `metadata.platform: "ios"`),
  gated on `authorization.status === "approved"` + `coarseSummaryAvailable` and
  refusing any signal claiming `rawUsageExportAvailable: true`.
- Wired into `collectScreenTimeRows` alongside the Android reader (PA
  screentime-service), filtering the same `listActivitySignals` result to iOS.

## Design
Apple's DeviceActivity/FamilyControls model exposes only coarse, in-extension
**category** summaries to the host — never raw per-app export. The reader is
**inert until a native iOS producer emits `categories`** (the spine already
accepts the `mobile_health` signals that would carry it), so production behavior
is unchanged until that producer lands. This closes the actionable consumer side
of criterion #4; the native producer is a separate follow-up.

## Test plan
- `vitest src/screen-time/mobile-signals.test.ts` → **8 passed** (3 new: approved
  ingest, denied/not-determined/unavailable → none, no-coarse → none,
  raw-export → none).
- `tsc --noEmit` → 0 errors in the reader (2 remaining worktree errors are
  unbuilt `@elizaos/capacitor-*` `.d.ts` in `packages/ui`, untouched here).
- `biome check` → clean.

Evidence: `.github/issue-evidence/9970-ios-coarse-ingestion.md`.
Builds on merged #10083 / #10080 / #10170 / #10178; complements scenarios PR #10192.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
