### PR TITLE
fix(core): ack async action turns without planner prose

### DIFF
--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -2515,6 +2515,102 @@ describe("runV5MessageRuntimeStage1", () => {
 		}
 	});
 
+	it("uses the Stage 1 ack when an async action finishes without planner prose", async () => {
+		const runtime = makeRuntime([
+			stage1Response({
+				thought: "Spawn the coding task.",
+				contexts: ["general"],
+				candidateActionNames: ["TASKS_SPAWN_AGENT"],
+				replyText: "On it.",
+				extra: { requiresTool: true },
+			}),
+			{
+				text: "",
+				toolCalls: [
+					{
+						id: "spawn-1",
+						name: "TASKS_SPAWN_AGENT",
+						arguments: {},
+					},
+				],
+			},
+		]);
+		runtime.actions = [
+			{
+				name: "TASKS_SPAWN_AGENT",
+				description: "Spawn a coding task.",
+				contexts: ["general"],
+				validate: vi.fn(async () => true),
+				handler: vi.fn(async () => ({
+					success: true,
+					text: "",
+					continueChain: false,
+				})),
+			},
+		] as IAgentRuntime["actions"];
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage(),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+		});
+
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind === "planned_reply") {
+			expect(result.result.responseContent?.text).toBe("On it.");
+		}
+	});
+
+	it("keeps suppressPlannerReply action turns silent", async () => {
+		const runtime = makeRuntime([
+			stage1Response({
+				thought: "The terminal action should stay silent.",
+				contexts: ["general"],
+				candidateActionNames: ["SILENT_ACTION"],
+				replyText: "On it.",
+				extra: { requiresTool: true },
+			}),
+			{
+				text: "",
+				toolCalls: [
+					{
+						id: "silent-1",
+						name: "SILENT_ACTION",
+						arguments: {},
+					},
+				],
+			},
+		]);
+		runtime.actions = [
+			{
+				name: "SILENT_ACTION",
+				description: "Stop the turn without replying.",
+				contexts: ["general"],
+				validate: vi.fn(async () => true),
+				handler: vi.fn(async () => ({
+					success: true,
+					text: "",
+					continueChain: false,
+					data: { suppressPlannerReply: true },
+				})),
+			},
+		] as IAgentRuntime["actions"];
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage(),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+		});
+
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind === "planned_reply") {
+			expect(result.result.responseContent).toBeNull();
+			expect(result.result.responseMessages).toEqual([]);
+		}
+	});
+
 	it("voice turn signal can force IGNORE before early reply/planning", async () => {
 		const runtime = makeRuntime([
 			stage1Response({

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -6455,12 +6455,35 @@ export async function runV5MessageRuntimeStage1(args: {
 			plannedTextRaw,
 			deliveredMediaUrls,
 		);
+		// Some action turns intentionally finish without planner prose. For async
+		// work (for example spawning a coding task), still return a non-empty
+		// synchronous acknowledgement so HTTP/connector callers don't render a blank
+		// "(no response)" while the real work continues in the background. Respect
+		// explicit suppressPlannerReply terminal actions (IGNORE/STOP-style flows),
+		// which are deliberately silent.
+		const suppressesPlannerReply = actionResults.some(
+			(result) =>
+				(result.data as { suppressPlannerReply?: unknown } | undefined)
+					?.suppressPlannerReply === true,
+		);
+		const ranNonSilentAction =
+			actionResults.length > 0 && !suppressesPlannerReply;
+		const stageOneAck =
+			typeof messageHandler.plan.reply === "string"
+				? messageHandler.plan.reply.trim()
+				: "";
+		const ackFallback =
+			!plannedText && !earlyReplySent && !suppressesPlannerReply
+				? stageOneAck ||
+					(ranNonSilentAction ? "on it, working on that now." : "")
+				: "";
+		const effectiveReplyText = plannedText || ackFallback;
 		const plannedTextRepeatsEarlyReply =
 			earlyReplySent &&
-			normalizeVisibleTextForDuplicateCheck(plannedText) ===
+			normalizeVisibleTextForDuplicateCheck(effectiveReplyText) ===
 				normalizeVisibleTextForDuplicateCheck(earlyReplyText);
 		const shouldSendPlannedText =
-			Boolean(plannedText) && !plannedTextRepeatsEarlyReply;
+			Boolean(effectiveReplyText) && !plannedTextRepeatsEarlyReply;
 
 		return {
 			kind: "planned_reply",
@@ -6469,7 +6492,7 @@ export async function runV5MessageRuntimeStage1(args: {
 				? createV5ReplyStrategyResult({
 						...args,
 						state: finalPlannerState,
-						text: plannedText,
+						text: effectiveReplyText,
 						thought:
 							plannerResult.evaluator?.thought ??
 							plannerResult.trajectory.steps.at(-1)?.thought ??


### PR DESCRIPTION
## Summary
- return a non-empty synchronous ack when a planner action finishes without final prose, such as fire-and-forget async work
- reuse the Stage 1 ack when available, otherwise synthesize a generic ack for non-silent action turns
- preserve explicit `suppressPlannerReply` silence and early-reply duplicate suppression

## Tests
- `bunx biome check packages/core/src/services/message.ts packages/core/src/__tests__/message-runtime-stage1.test.ts`
- `bun run --cwd packages/core test -- src/__tests__/message-runtime-stage1.test.ts`
- `codex review --uncommitted` (no findings)
