### PR TITLE
test(app): real-touch pinch zooms the relationships graph (#9943 item 6 pinch)

### DIFF
--- a/packages/app/test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts
@@ -133,3 +133,76 @@ test("relationships decomposed view: renders the graph and toggles a kind filter
   await orgs.click();
   await expect.poll(() => orgs.getAttribute("aria-pressed")).not.toBe(before);
 });
+
+/**
+ * Drive a REAL two-finger pinch via CDP `Input.dispatchTouchEvent` (genuine
+ * multi-touch input, not desktop mouse) — #9943 item 6 "pinch case". `scale > 1`
+ * spreads the fingers apart (pinch-out → zoom in). Touch input is enabled at the
+ * CDP level so the view keeps its desktop layout; only the gesture is touch.
+ */
+async function touchPinch(
+  page: import("@playwright/test").Page,
+  selector: string,
+  scale: number,
+  steps = 16,
+) {
+  const box = await page.locator(selector).first().boundingBox();
+  if (!box) throw new Error(`no bounding box for ${selector}`);
+  const cx = box.x + box.width / 2;
+  const cy = box.y + box.height / 2;
+  const startGap = Math.min(60, box.width / 4);
+  const points = (gap: number) => [
+    { x: cx - gap, y: cy, id: 0 },
+    { x: cx + gap, y: cy, id: 1 },
+  ];
+  const client = await page.context().newCDPSession(page);
+  try {
+    await client.send("Emulation.setTouchEmulationEnabled", {
+      enabled: true,
+      maxTouchPoints: 2,
+    });
+    await client.send("Input.dispatchTouchEvent", {
+      type: "touchStart",
+      touchPoints: points(startGap),
+    });
+    for (let i = 1; i <= steps; i += 1) {
+      const gap = startGap * (1 + (scale - 1) * (i / steps));
+      await client.send("Input.dispatchTouchEvent", {
+        type: "touchMove",
+        touchPoints: points(gap),
+      });
+    }
+    await client.send("Input.dispatchTouchEvent", {
+      type: "touchEnd",
+      touchPoints: [],
+    });
+  } finally {
+    await client.detach();
+  }
+}
+
+test("relationships graph: two-finger pinch-out zooms in under REAL touch (not mouse)", async ({
+  page,
+}) => {
+  // Same mocked graph data as the test above (beforeEach). Go straight for the
+  // pinch surface ([data-graph-container]) — the RelationshipsGraphPanel viewer.
+  await openAppPath(page, "/relationships");
+  const container = page.locator("[data-graph-container]");
+  await expect(container).toBeVisible({ timeout: 60_000 });
+
+  const graphSvg = container.locator("svg").first();
+  await expect(graphSvg).toBeVisible({ timeout: 15_000 });
+  const widthOf = () =>
+    graphSvg.evaluate((el) => {
+      const styled = Number.parseFloat((el as SVGElement).style.width);
+      return Number.isFinite(styled)
+        ? styled
+        : el.getBoundingClientRect().width;
+    });
+  const before = await widthOf();
+
+  // Spread two fingers apart → the graph zooms in → its rendered width grows.
+  await touchPinch(page, "[data-graph-container]", 2);
+
+  await expect.poll(widthOf, { timeout: 10_000 }).toBeGreaterThan(before);
+});

--- a/packages/app/test/ui-smoke/chat-clear-swipe.spec.ts
+++ b/packages/app/test/ui-smoke/chat-clear-swipe.spec.ts
@@ -245,6 +245,45 @@ async function pointerDrag(
   await page.mouse.up();
 }
 
+/**
+ * Drive a REAL touch drag via CDP `Input.dispatchTouchEvent` — the same touch
+ * input `page.touchscreen` uses. Unlike `pointerDrag` above (`page.mouse` →
+ * pointerType "mouse"), this produces genuine touch input (pointerType "touch"),
+ * so the gesture is verified the way a finger drives it, not a desktop mouse
+ * (issue #9943 item 6: "swipe gesture simulated via page.mouse, not real touch").
+ */
+async function touchDrag(
+  page: import("@playwright/test").Page,
+  selector: string,
+  dx: number,
+  dy: number,
+  steps = 12,
+) {
+  const box = await page.locator(selector).first().boundingBox();
+  if (!box) throw new Error(`no bounding box for ${selector}`);
+  const cx = box.x + box.width / 2;
+  const cy = box.y + box.height / 2;
+  const client = await page.context().newCDPSession(page);
+  try {
+    await client.send("Input.dispatchTouchEvent", {
+      type: "touchStart",
+      touchPoints: [{ x: cx, y: cy }],
+    });
+    for (let i = 1; i <= steps; i += 1) {
+      await client.send("Input.dispatchTouchEvent", {
+        type: "touchMove",
+        touchPoints: [{ x: cx + (dx * i) / steps, y: cy + (dy * i) / steps }],
+      });
+    }
+    await client.send("Input.dispatchTouchEvent", {
+      type: "touchEnd",
+      touchPoints: [],
+    });
+  } finally {
+    await client.detach();
+  }
+}
+
 let store: Store;
 
 test.beforeEach(async ({ page }) => {
@@ -279,6 +318,36 @@ test("collapsed chat grabber horizontal swipe opens the launcher rail without op
     page.getByTestId("home-launcher-launcher-page"),
   ).toBeVisible();
   await expectNoPageDiagnostics(page, testInfo.title);
+});
+
+test.describe("real touch input (CDP dispatchTouchEvent) — #9943 item 6", () => {
+  test.use({ hasTouch: true });
+
+  test("collapsed chat grabber swipe under REAL TOUCH (not desktop mouse) opens the launcher rail", async ({
+    page,
+  }, testInfo) => {
+    await openAppPath(page, "/chat");
+    const overlay = page.getByTestId("continuous-chat-overlay");
+    await expect(overlay).toBeVisible({ timeout: 60_000 });
+
+    const surface = page.getByTestId("home-launcher-surface");
+    await expect(surface).toHaveAttribute("data-page", "home", {
+      timeout: 15_000,
+    });
+    await expect(overlay).not.toHaveAttribute("data-open", "true");
+
+    // Genuine finger swipe (touch input), not page.mouse.
+    await touchDrag(page, '[data-testid="chat-sheet-grabber"]', -180, -6, 12);
+
+    await expect(surface).toHaveAttribute("data-page", "launcher", {
+      timeout: 10_000,
+    });
+    await expect(overlay).not.toHaveAttribute("data-open", "true");
+    await expect(
+      page.getByTestId("home-launcher-launcher-page"),
+    ).toBeVisible();
+    await expectNoPageDiagnostics(page, testInfo.title);
+  });
 });
 
 test("swipe navigates conversations; clear lands on a fresh greeted chat with no undo toast", async ({


### PR DESCRIPTION
Adds the **pinch** case to #9943 item 6 (the swipe case landed real-touch in #10190; long-press is covered by Launcher storybook plays).

A `touchPinch` helper drives CDP `Input.dispatchTouchEvent` with two touch points spreading apart (genuine multi-touch — not desktop mouse), asserting `RelationshipsGraphPanel`'s two-pointer pinch-to-zoom grows the rendered graph (svg width). It is the direct sibling of the existing "relationships decomposed view" test (same view, same mocked data) and uses the same CDP touch mechanism already **verified** by the chat-grabber real-touch swipe (#10190).

⚠️ This runs on the `scenario-pr` ui-smoke lane (which builds the full plugin-view bundles). It is **not** runnable in the `eliza:packages` skip-artifact dev worktree — the dynamic plugin-view bundles (calendar/inbox/relationships/…) aren't built there, so the existing sibling test can't run there either, yet it's green in CI. **Please let the ui-smoke check confirm green before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)