### PR TITLE
feat(benchmarks): recall-bench — real-core memory-recall quality gate (#9956)

### DIFF
--- a/.github/issue-evidence/9956-recall-bench/README.md
+++ b/.github/issue-evidence/9956-recall-bench/README.md
@@ -1,0 +1,56 @@
+# Evidence — recall-bench (#9956)
+
+A registered, document-scale, CI-gated Precision/Recall/nDCG/latency benchmark for
+the **real** `@elizaos/core` memory-recall + knowledge-retrieval path. All numbers
+come from driving shipped code (`DocumentService.searchDocuments`,
+`AgentRuntime.searchMemories`, `factsProvider.get`, `scoreMemoryText`) over a
+committed labeled corpus ingested through the real `DocumentService.addDocument`
+— no Python re-implementation, no mocked `searchMemories`.
+
+## Reproduce
+
+```bash
+bun run --cwd packages/shared build:i18n        # fresh checkout: generated keyword data
+bun run bench:recall:1k                          # the document-scale CI gate
+bun run --cwd packages/benchmarks/recall-bench test   # unit tests
+python3 packages/benchmarks/recall-bench/scripts/check-registry.py   # orchestrator registration
+```
+
+The embedding is a deterministic in-bench function (no model bundle, no
+credentials), so every number is byte-reproducible run-to-run and on CI.
+
+## Artifacts
+
+| file | what it proves |
+| --- | --- |
+| `metrics-1k.json` | Committed before/after metrics JSON: per-`SearchMode` P@K/R@K/MRR/nDCG/HitRate + p50/p95 over the 1,000-doc corpus, `measured:true` only on a real run (`null`, never `0`, otherwise). Mirrors `packages/benchmarks/recall-bench/baseline-1k.json`. |
+| `run-1k.stdout.txt` | The real 1k run: per-mode recall/nDCG/p95 and `budgets PASS (16/16)`. |
+| `failopen-path.debug.log` | Backend `[CORE:DOCUMENTS:RECALL-EMBED]` structured logs (`LOG_LEVEL=debug`) showing `embedRecallQuery` returning null and `_vectorSearch` failing open to keyword — **once per query** in the forced fail-open slice. |
+
+## Headline result (1k tier, deterministic)
+
+| mode | Recall@5 | nDCG@5 |
+| --- | --- | --- |
+| `document-hybrid` | 0.880 | 0.864 |
+| `document-vector` | 0.715 | 0.684 |
+| `document-keyword` | 0.370 | 0.422 |
+| `searchMemories-vector` | 0.965 | 0.974 |
+| `keyword-chat-scoreMemoryText` | 0.095 | 0.125 |
+| `facts-provider-keyword` | 1.000 | 1.000 |
+| `document-vector-failopen` | 0.370 | 0.422 |
+
+**Fail-open recall drop = 0.345 (observable).** Forcing `embedRecallQuery → null`
+collapses `document-vector` (0.715) to keyword level (0.370) — the silent
+degradation #9956 names, now measured and gated. `scoreMemoryText` degrades sharply
+at document scale (0.095), making the keyword-vs-semantic gap explicit.
+
+## Evidence checklist (PR_EVIDENCE.md)
+
+- **Real-runtime trajectory** — `run-1k.stdout.txt` + `metrics-1k.json`: the real
+  `searchMemories`/`DocumentService` path over the 1k corpus (not a mock).
+- **Backend logs** — `failopen-path.debug.log`: structured `[CORE:DOCUMENTS:RECALL-EMBED]`
+  logs showing the path taken, including the forced fail-open run.
+- **Before/after metrics JSON** — `metrics-1k.json` + committed `budgets.json`.
+- **Screenshots / video / audio** — N/A: this is a benchmark/CI harness with no UI
+  or voice surface; the metrics JSON, the budget gate, and `recall-bench.yml` are the
+  verifiable artifacts.

--- a/.github/issue-evidence/9956-recall-bench/README.md
+++ b/.github/issue-evidence/9956-recall-bench/README.md
@@ -25,7 +25,7 @@ credentials), so every number is byte-reproducible run-to-run and on CI.
 | --- | --- |
 | `metrics-1k.json` | Committed before/after metrics JSON: per-`SearchMode` P@K/R@K/MRR/nDCG/HitRate + p50/p95 over the 1,000-doc corpus, `measured:true` only on a real run (`null`, never `0`, otherwise). Mirrors `packages/benchmarks/recall-bench/baseline-1k.json`. |
 | `run-1k.stdout.txt` | The real 1k run: per-mode recall/nDCG/p95 and `budgets PASS (16/16)`. |
-| `failopen-path.debug.log` | Backend `[CORE:DOCUMENTS:RECALL-EMBED]` structured logs (`LOG_LEVEL=debug`) showing `embedRecallQuery` returning null and `_vectorSearch` failing open to keyword — **once per query** in the forced fail-open slice. |
+| `failopen-path.debug.txt` | Backend `[CORE:DOCUMENTS:RECALL-EMBED]` structured logs (`LOG_LEVEL=debug`) showing `embedRecallQuery` returning null and `_vectorSearch` failing open to keyword — **once per query** in the forced fail-open slice. |
 
 ## Headline result (1k tier, deterministic)
 
@@ -48,7 +48,7 @@ at document scale (0.095), making the keyword-vs-semantic gap explicit.
 
 - **Real-runtime trajectory** — `run-1k.stdout.txt` + `metrics-1k.json`: the real
   `searchMemories`/`DocumentService` path over the 1k corpus (not a mock).
-- **Backend logs** — `failopen-path.debug.log`: structured `[CORE:DOCUMENTS:RECALL-EMBED]`
+- **Backend logs** — `failopen-path.debug.txt`: structured `[CORE:DOCUMENTS:RECALL-EMBED]`
   logs showing the path taken, including the forced fail-open run.
 - **Before/after metrics JSON** — `metrics-1k.json` + committed `budgets.json`.
 - **Screenshots / video / audio** — N/A: this is a benchmark/CI harness with no UI

--- a/.github/issue-evidence/9956-recall-bench/failopen-path.debug.txt
+++ b/.github/issue-evidence/9956-recall-bench/failopen-path.debug.txt
@@ -1,0 +1,12 @@
+# Forced fail-open: structured [CORE:DOCUMENTS:RECALL-EMBED] logs (LOG_LEVEL=debug, smoke tier)
+# embedRecallQuery returns null -> _vectorSearch falls open to _keywordSearch, once per query:
+
+ Debug      [CORE:DOCUMENTS:RECALL-EMBED] Recall-query embed failed; failing open to keyword recall (error=[recall-bench] forced embed failure (fail-open test))
+ Debug      [CORE:DOCUMENTS:RECALL-EMBED] Recall-query embed failed; failing open to keyword recall (error=[recall-bench] forced embed failure (fail-open test))
+ Debug      [CORE:DOCUMENTS:RECALL-EMBED] Recall-query embed failed; failing open to keyword recall (error=[recall-bench] forced embed failure (fail-open test))
+ Debug      [CORE:DOCUMENTS:RECALL-EMBED] Recall-query embed failed; failing open to keyword recall (error=[recall-bench] forced embed failure (fail-open test))
+ Debug      [CORE:DOCUMENTS:RECALL-EMBED] Recall-query embed failed; failing open to keyword recall (error=[recall-bench] forced embed failure (fail-open test))
+ Debug      [CORE:DOCUMENTS:RECALL-EMBED] Recall-query embed failed; failing open to keyword recall (error=[recall-bench] forced embed failure (fail-open test))
+
+# fail-open recall drop (from the same run):
+[recall-bench] fail-open recall drop 0.444 (observable=true)

--- a/.github/issue-evidence/9956-recall-bench/metrics-1k.json
+++ b/.github/issue-evidence/9956-recall-bench/metrics-1k.json
@@ -1,0 +1,237 @@
+{
+  "benchmark": "recall-bench",
+  "generatedAt": "2026-06-29T18:46:05.716Z",
+  "corpus": {
+    "committed": true,
+    "tier": "1k",
+    "topics": 40,
+    "documents": 1000,
+    "queries": 40
+  },
+  "k": 5,
+  "modes": [
+    {
+      "mode": "document-hybrid",
+      "corpusSize": 1000,
+      "queries": 40,
+      "k": 5,
+      "precisionAtK": 0.8800000000000002,
+      "recallAtK": 0.8800000000000002,
+      "mrr": 0.8875,
+      "ndcgAtK": 0.863868262740087,
+      "hitRateAtK": 1,
+      "p50LatencyMs": 7.87350399999923,
+      "p95LatencyMs": 8.733158999999432,
+      "measured": true
+    },
+    {
+      "mode": "document-vector",
+      "corpusSize": 1000,
+      "queries": 40,
+      "k": 5,
+      "precisionAtK": 0.7150000000000001,
+      "recallAtK": 0.7150000000000001,
+      "mrr": 0.7274999999999999,
+      "ndcgAtK": 0.6835947682141241,
+      "hitRateAtK": 1,
+      "p50LatencyMs": 5.489093000000139,
+      "p95LatencyMs": 6.346172999999908,
+      "measured": true
+    },
+    {
+      "mode": "document-keyword",
+      "corpusSize": 1000,
+      "queries": 40,
+      "k": 5,
+      "precisionAtK": 0.37,
+      "recallAtK": 0.37,
+      "mrr": 0.6666666666666667,
+      "ndcgAtK": 0.4224540926172685,
+      "hitRateAtK": 0.775,
+      "p50LatencyMs": 53.38742900000034,
+      "p95LatencyMs": 68.2267869999996,
+      "measured": true
+    },
+    {
+      "mode": "searchMemories-vector",
+      "corpusSize": 1000,
+      "queries": 40,
+      "k": 5,
+      "precisionAtK": 0.9650000000000001,
+      "recallAtK": 0.9650000000000001,
+      "mrr": 1,
+      "ndcgAtK": 0.9738548363300084,
+      "hitRateAtK": 1,
+      "p50LatencyMs": 5.904946000000564,
+      "p95LatencyMs": 6.941863000000012,
+      "measured": true
+    },
+    {
+      "mode": "keyword-chat-scoreMemoryText",
+      "corpusSize": 1000,
+      "queries": 40,
+      "k": 5,
+      "precisionAtK": 0.09500000000000001,
+      "recallAtK": 0.09500000000000001,
+      "mrr": 0.30164605575829423,
+      "ndcgAtK": 0.12477920234057101,
+      "hitRateAtK": 0.4,
+      "p50LatencyMs": 0.6530650000004243,
+      "p95LatencyMs": 0.7631700000001729,
+      "measured": true
+    },
+    {
+      "mode": "facts-provider-keyword",
+      "corpusSize": 70,
+      "queries": 40,
+      "k": 5,
+      "precisionAtK": 0.2000000000000001,
+      "recallAtK": 1,
+      "mrr": 1,
+      "ndcgAtK": 1,
+      "hitRateAtK": 1,
+      "p50LatencyMs": 6.4611970000005385,
+      "p95LatencyMs": 7.460430999999517,
+      "measured": true
+    },
+    {
+      "mode": "document-vector-failopen",
+      "corpusSize": 1000,
+      "queries": 40,
+      "k": 5,
+      "precisionAtK": 0.37,
+      "recallAtK": 0.37,
+      "mrr": 0.6666666666666667,
+      "ndcgAtK": 0.4224540926172685,
+      "hitRateAtK": 0.775,
+      "p50LatencyMs": 50.9256549999991,
+      "p95LatencyMs": 68.0599000000002,
+      "measured": true
+    }
+  ],
+  "failOpen": {
+    "vectorRecallAt5": 0.7150000000000001,
+    "failOpenRecallAt5": 0.37,
+    "recallDrop": 0.3450000000000001,
+    "observable": true
+  },
+  "metrics": {
+    "overall_recall_at_5": 0.8800000000000002,
+    "overall_ndcg_at_5": 0.863868262740087,
+    "overall_p95_latency_ms": 8.733158999999432
+  },
+  "checks": [
+    {
+      "name": "document-hybrid.minRecallAt5",
+      "value": 0.8800000000000002,
+      "budget": 0.7,
+      "unit": "ratio",
+      "pass": true
+    },
+    {
+      "name": "document-hybrid.minNdcgAt5",
+      "value": 0.863868262740087,
+      "budget": 0.68,
+      "unit": "ratio",
+      "pass": true
+    },
+    {
+      "name": "document-hybrid.maxP95LatencyMs",
+      "value": 8.733158999999432,
+      "budget": 750,
+      "unit": "ms",
+      "pass": true
+    },
+    {
+      "name": "document-vector.minRecallAt5",
+      "value": 0.7150000000000001,
+      "budget": 0.55,
+      "unit": "ratio",
+      "pass": true
+    },
+    {
+      "name": "document-vector.minNdcgAt5",
+      "value": 0.6835947682141241,
+      "budget": 0.54,
+      "unit": "ratio",
+      "pass": true
+    },
+    {
+      "name": "document-vector.maxP95LatencyMs",
+      "value": 6.346172999999908,
+      "budget": 750,
+      "unit": "ms",
+      "pass": true
+    },
+    {
+      "name": "document-keyword.minRecallAt5",
+      "value": 0.37,
+      "budget": 0.25,
+      "unit": "ratio",
+      "pass": true
+    },
+    {
+      "name": "document-keyword.maxP95LatencyMs",
+      "value": 68.2267869999996,
+      "budget": 750,
+      "unit": "ms",
+      "pass": true
+    },
+    {
+      "name": "searchMemories-vector.minRecallAt5",
+      "value": 0.9650000000000001,
+      "budget": 0.8,
+      "unit": "ratio",
+      "pass": true
+    },
+    {
+      "name": "searchMemories-vector.minNdcgAt5",
+      "value": 0.9738548363300084,
+      "budget": 0.78,
+      "unit": "ratio",
+      "pass": true
+    },
+    {
+      "name": "searchMemories-vector.maxP95LatencyMs",
+      "value": 6.941863000000012,
+      "budget": 750,
+      "unit": "ms",
+      "pass": true
+    },
+    {
+      "name": "keyword-chat-scoreMemoryText.minRecallAt5",
+      "value": 0.09500000000000001,
+      "budget": 0.05,
+      "unit": "ratio",
+      "pass": true
+    },
+    {
+      "name": "keyword-chat-scoreMemoryText.maxP95LatencyMs",
+      "value": 0.7631700000001729,
+      "budget": 750,
+      "unit": "ms",
+      "pass": true
+    },
+    {
+      "name": "facts-provider-keyword.minRecallAt5",
+      "value": 1,
+      "budget": 0.8,
+      "unit": "ratio",
+      "pass": true
+    },
+    {
+      "name": "facts-provider-keyword.maxP95LatencyMs",
+      "value": 7.460430999999517,
+      "budget": 750,
+      "unit": "ms",
+      "pass": true
+    },
+    {
+      "name": "failOpen.minObservableRecallDrop",
+      "value": 0.3450000000000001,
+      "budget": 0.15,
+      "unit": "ratio",
+      "pass": true
+    }
+  ]
+}

--- a/.github/issue-evidence/9956-recall-bench/run-1k.stdout.txt
+++ b/.github/issue-evidence/9956-recall-bench/run-1k.stdout.txt
@@ -1,0 +1,10 @@
+[recall-bench] document-hybrid: recall@5=0.880 ndcg@5=0.864 p95=12.661ms (measured)
+[recall-bench] document-vector: recall@5=0.715 ndcg@5=0.684 p95=15.672ms (measured)
+[recall-bench] document-keyword: recall@5=0.370 ndcg@5=0.422 p95=126.246ms (measured)
+[recall-bench] searchMemories-vector: recall@5=0.965 ndcg@5=0.974 p95=13.851ms (measured)
+[recall-bench] keyword-chat-scoreMemoryText: recall@5=0.095 ndcg@5=0.125 p95=2.195ms (measured)
+[recall-bench] facts-provider-keyword: recall@5=1.000 ndcg@5=1.000 p95=10.265ms (measured)
+[recall-bench] document-vector-failopen: recall@5=0.370 ndcg@5=0.422 p95=65.507ms (measured)
+[recall-bench] fail-open recall drop 0.345 (observable=true)
+[recall-bench] → /home/shaw/milady/eliza-wt-recall/packages/benchmarks/recall-bench/results/recall-bench-results.json
+[recall-bench] budgets PASS (16/16)

--- a/.github/workflows/recall-bench.yml
+++ b/.github/workflows/recall-bench.yml
@@ -1,0 +1,83 @@
+name: recall-bench
+
+# Memory-recall + knowledge-retrieval quality benchmark + regression gate (#9956).
+#
+# Drives the REAL @elizaos/core recall path — DocumentService.searchDocuments
+# (hybrid/vector/keyword), AgentRuntime.searchMemories, the FACTS provider, and
+# the scoreMemoryText keyword chat-search — over a committed, document-scale,
+# labeled corpus ingested through the real DocumentService. The embedding is a
+# deterministic in-bench function, so the harness needs NO model bundle and NO
+# credentials and is fully reproducible on a hosted runner.
+#
+# The harness exits:
+#   0  measured rows present, all committed budgets pass                  → green
+#   1  a Recall@5 / nDCG / p95 / fail-open budget REGRESSED               → red (gate)
+#   2  nothing measurable                                                 → skip
+# so a healthy baseline is green and a real recall regression (e.g. a bad
+# hybrid-weight change, or semantic recall silently collapsing to keyword) is red.
+
+on:
+  pull_request:
+    paths:
+      - "packages/benchmarks/recall-bench/**"
+      - "packages/benchmarks/registry/**"
+      - "packages/core/src/features/documents/**"
+      - "packages/core/src/features/advanced-capabilities/providers/facts.ts"
+      - "packages/core/src/runtime.ts"
+      - "packages/agent/src/api/memory-routes.ts"
+      - ".github/workflows/recall-bench.yml"
+  schedule:
+    # 05:50 UTC — alongside the other nightly benchmark lanes.
+    - cron: "50 5 * * *"
+  workflow_dispatch: {}
+
+concurrency:
+  group: recall-bench-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  recall-gate:
+    name: recall quality + budget regression gate (no models)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: oven-sh/setup-bun@v2
+        with:
+          # Match local dev's moving canary channel (historical canary tags can
+          # disappear from GitHub releases and break scheduled runs).
+          bun-version: canary
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+      - name: Install workspace
+        run: bun install
+      - name: Generate shared i18n assets
+        # The bench imports @elizaos/core source, which expects the generated
+        # keyword data to exist in a fresh checkout.
+        run: bun run --cwd packages/shared build:i18n
+      - name: recall-bench unit tests (metrics + embedding + corpus invariants)
+        run: bun run --cwd packages/benchmarks/recall-bench test
+      - name: registry score-extractor contract
+        run: python3 packages/benchmarks/recall-bench/scripts/check-registry.py
+      - name: recall-bench harness + budget regression gate (1k tier)
+        run: |
+          set +e
+          bun run bench:recall:1k
+          code=$?
+          set -e
+          case "$code" in
+            0) echo "recall-bench: all budgets pass" ;;
+            2) echo "recall-bench: skipped (nothing measurable on this runner)" ;;
+            1) echo "::error::recall-bench Recall@5 / nDCG / p95 / fail-open budget regression (exit 1)"; exit 1 ;;
+            *) echo "::error::recall-bench harness errored (exit $code)"; exit "$code" ;;
+          esac
+      - name: Upload recall-bench results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: recall-bench-results
+          path: packages/benchmarks/recall-bench/results/recall-bench-results.json
+          if-no-files-found: ignore

--- a/package.json
+++ b/package.json
@@ -190,6 +190,8 @@
     "bench:eliza-1": "bun run --cwd packages/benchmarks/eliza-1 start",
     "bench:memperf": "node packages/benchmarks/memperf/run-all.mjs",
     "bench:memperf:json": "node packages/benchmarks/memperf/run-all.mjs --json",
+    "bench:recall": "bun run --cwd packages/benchmarks/recall-bench bench",
+    "bench:recall:1k": "bun run --cwd packages/benchmarks/recall-bench bench:1k",
     "bench:three-agent": "bun run --cwd packages/benchmarks/three-agent-dialogue bench",
     "bench:voice-speaker": "node packages/scripts/run-python.mjs -m pytest packages/benchmarks/voice-speaker-validation/tests/ -v --tb=short",
     "bench:voice-speaker:smoke": "node packages/scripts/run-python.mjs -m pytest packages/benchmarks/voice-speaker-validation/tests/test_diarization.py::TestDiarization::test_single_speaker_control -v",

--- a/packages/benchmarks/recall-bench/AGENTS.md
+++ b/packages/benchmarks/recall-bench/AGENTS.md
@@ -1,0 +1,69 @@
+# @elizaos/recall-bench
+
+Precision/Recall/nDCG/latency benchmark + CI gate for the **real** memory-recall
++ knowledge-retrieval pipeline (#9956). Drives shipped `@elizaos/core` code over
+a committed, document-scale, labeled corpus — see [README.md](./README.md) for
+the what/why and the committed baseline.
+
+## Layout
+
+```
+metrics.ts        Pure IR metrics (P@K/R@K/MRR/nDCG/HitRate, percentiles) + summarizeRecall()
+embedding.ts      Deterministic feature-hash embedding (FNV-1a tokens + char trigrams, L2-norm, 384d)
+corpus.ts         buildCorpus(tier) + buildFacts(tier) — labeled, three doc classes, deterministic PRNG
+runtime.ts        buildBenchRuntime() — real AgentRuntime + plugin-sql/PGlite + DocumentService
+run.ts            The runner: ingest → drive every SearchMode → emit report → budget gate (exit 0/1/2)
+budgets.json      Committed per-mode floors + min observable fail-open drop (1k baseline + ~20% headroom)
+baseline-1k.json  Committed reference metrics (the "before/after" artifact)
+scripts/check-registry.py   Orchestrator-registration contract check (CI)
+*.test.ts         Unit tests for the pure pieces + corpus design invariants
+```
+
+Run: `bun run bench:recall` (smoke) / `bun run bench:recall:1k` (gate) from the
+repo root, or `bun run --cwd packages/benchmarks/recall-bench test` for units.
+
+## Why these exact construction choices (do not "simplify" them away)
+
+- **PGlite via `@elizaos/plugin-sql`, not `InMemoryDatabaseAdapter` or
+  `plugin-inmemorydb`.** Core's in-memory `searchMemories` is a stub that returns
+  `[]`; `plugin-inmemorydb` overwrites `metadata.type` with the table name, so
+  `DocumentService` filters out every fragment. Only PGlite gives real pgvector
+  cosine while preserving `metadata.type` — and it is embedded WASM (no server,
+  no secrets).
+- **`DocumentService.start(runtime)` directly**, not `runtime.getService("documents")`
+  — the service getter is gated by `isNativeFeatureServiceEnabled`, off in a bare
+  benchmark runtime. `start()` drives the same ingest/search code.
+- **`addDocument({ content })` must be base64-encoded** (`Buffer.from(text).toString("base64")`).
+  The text path base64-decodes `content` as a heuristic; raw text misfires it
+  ("File … appears to be corrupted or incorrectly encoded").
+- **`runtime.searchMemories` for the raw-vector slice omits `query`.** Passing a
+  `query` triggers `rerankMemories` (BM25), which *drops* zero-keyword-overlap
+  candidates — that is the right behavior for DocumentService's `vector` mode but
+  would hide pure-vector recall in the `searchMemories-vector` slice.
+- **The fail-open slice calls `runtime.startRun()` before flipping the embedder
+  to throw.** `embedRecallQuery` memoizes successful query vectors per run id; a
+  fresh run id busts that cache so the throw actually reaches `_vectorSearch` and
+  the keyword fall-open is observed (otherwise the drop reads as 0).
+
+## Determinism contract
+
+Every number is reproducible run-to-run: seeded `mulberry32` corpus, deterministic
+`embedText`, deterministic pgvector cosine. **Never** introduce `Date.now()` /
+`Math.random()` / wall-clock into the corpus or embedding — it would flake the CI
+gate. (Latency is timed with `performance.now()` and only feeds p50/p95, never
+ranking.) Honesty contract from `memperf`: unmeasured rows are `null`, never `0`;
+`measured: true` only on a real run.
+
+## Gotchas
+
+- Run with `bun --conditions=eliza-source` so `@elizaos/*` resolves to workspace
+  source; the runner calls `process.exit()` (lingering DB/task services otherwise
+  keep the event loop alive).
+- Fresh checkout: `bun run --cwd packages/shared build:i18n` first — the bench
+  imports `@elizaos/core` source, which needs the generated keyword data.
+- `factsProvider` is internal to core (not on the public barrel); the bench
+  imports it via a relative source path — a benchmark legitimately reaches into
+  the same tree to measure it.
+
+Repo-wide rules (logger-only, ESM, naming) live in the root
+[AGENTS.md](../../../AGENTS.md).

--- a/packages/benchmarks/recall-bench/CLAUDE.md
+++ b/packages/benchmarks/recall-bench/CLAUDE.md
@@ -1,0 +1,69 @@
+# @elizaos/recall-bench
+
+Precision/Recall/nDCG/latency benchmark + CI gate for the **real** memory-recall
++ knowledge-retrieval pipeline (#9956). Drives shipped `@elizaos/core` code over
+a committed, document-scale, labeled corpus — see [README.md](./README.md) for
+the what/why and the committed baseline.
+
+## Layout
+
+```
+metrics.ts        Pure IR metrics (P@K/R@K/MRR/nDCG/HitRate, percentiles) + summarizeRecall()
+embedding.ts      Deterministic feature-hash embedding (FNV-1a tokens + char trigrams, L2-norm, 384d)
+corpus.ts         buildCorpus(tier) + buildFacts(tier) — labeled, three doc classes, deterministic PRNG
+runtime.ts        buildBenchRuntime() — real AgentRuntime + plugin-sql/PGlite + DocumentService
+run.ts            The runner: ingest → drive every SearchMode → emit report → budget gate (exit 0/1/2)
+budgets.json      Committed per-mode floors + min observable fail-open drop (1k baseline + ~20% headroom)
+baseline-1k.json  Committed reference metrics (the "before/after" artifact)
+scripts/check-registry.py   Orchestrator-registration contract check (CI)
+*.test.ts         Unit tests for the pure pieces + corpus design invariants
+```
+
+Run: `bun run bench:recall` (smoke) / `bun run bench:recall:1k` (gate) from the
+repo root, or `bun run --cwd packages/benchmarks/recall-bench test` for units.
+
+## Why these exact construction choices (do not "simplify" them away)
+
+- **PGlite via `@elizaos/plugin-sql`, not `InMemoryDatabaseAdapter` or
+  `plugin-inmemorydb`.** Core's in-memory `searchMemories` is a stub that returns
+  `[]`; `plugin-inmemorydb` overwrites `metadata.type` with the table name, so
+  `DocumentService` filters out every fragment. Only PGlite gives real pgvector
+  cosine while preserving `metadata.type` — and it is embedded WASM (no server,
+  no secrets).
+- **`DocumentService.start(runtime)` directly**, not `runtime.getService("documents")`
+  — the service getter is gated by `isNativeFeatureServiceEnabled`, off in a bare
+  benchmark runtime. `start()` drives the same ingest/search code.
+- **`addDocument({ content })` must be base64-encoded** (`Buffer.from(text).toString("base64")`).
+  The text path base64-decodes `content` as a heuristic; raw text misfires it
+  ("File … appears to be corrupted or incorrectly encoded").
+- **`runtime.searchMemories` for the raw-vector slice omits `query`.** Passing a
+  `query` triggers `rerankMemories` (BM25), which *drops* zero-keyword-overlap
+  candidates — that is the right behavior for DocumentService's `vector` mode but
+  would hide pure-vector recall in the `searchMemories-vector` slice.
+- **The fail-open slice calls `runtime.startRun()` before flipping the embedder
+  to throw.** `embedRecallQuery` memoizes successful query vectors per run id; a
+  fresh run id busts that cache so the throw actually reaches `_vectorSearch` and
+  the keyword fall-open is observed (otherwise the drop reads as 0).
+
+## Determinism contract
+
+Every number is reproducible run-to-run: seeded `mulberry32` corpus, deterministic
+`embedText`, deterministic pgvector cosine. **Never** introduce `Date.now()` /
+`Math.random()` / wall-clock into the corpus or embedding — it would flake the CI
+gate. (Latency is timed with `performance.now()` and only feeds p50/p95, never
+ranking.) Honesty contract from `memperf`: unmeasured rows are `null`, never `0`;
+`measured: true` only on a real run.
+
+## Gotchas
+
+- Run with `bun --conditions=eliza-source` so `@elizaos/*` resolves to workspace
+  source; the runner calls `process.exit()` (lingering DB/task services otherwise
+  keep the event loop alive).
+- Fresh checkout: `bun run --cwd packages/shared build:i18n` first — the bench
+  imports `@elizaos/core` source, which needs the generated keyword data.
+- `factsProvider` is internal to core (not on the public barrel); the bench
+  imports it via a relative source path — a benchmark legitimately reaches into
+  the same tree to measure it.
+
+Repo-wide rules (logger-only, ESM, naming) live in the root
+[AGENTS.md](../../../AGENTS.md).

--- a/packages/benchmarks/recall-bench/README.md
+++ b/packages/benchmarks/recall-bench/README.md
@@ -1,45 +1,112 @@
 # recall-bench (#9956)
 
-Quality benchmark for the agent's **memory-recall + knowledge-retrieval** path —
-`AgentRuntime.searchMemories`, `DocumentService.searchDocuments` (hybrid /
-vector / keyword), and the `DOCUMENTS` / `FACTS` recall providers. The repo
-measures retrieval *cost* (`memperf`) and LLM *context-window* attention
-(`context_bench`) but never retrieval *correctness* at document scale, and the
-recall path **fails open** (a slow/errored embed silently degrades semantic
-recall to keyword-only) with no metric guarding it. See #9956.
+Precision / Recall / nDCG / latency benchmark for the agent's **memory-recall +
+knowledge-retrieval** path, plus a CI regression gate. The repo measures
+retrieval *cost* (`memperf`) and LLM *context-window* attention (`context_bench`)
+but never retrieval *correctness* at document scale — and the recall path **fails
+open** (a slow/errored embed silently degrades semantic recall to keyword-only)
+with no metric guarding it. This bench closes that gap.
 
-## Status
+It drives the **real `@elizaos/core` code** — no Python re-implementation, no
+mocked `searchMemories`:
 
-This package currently ships the **deterministic scoring foundation** that the
-rest of #9956 builds on, fully unit-tested in isolation:
+- `DocumentService.searchDocuments` in all three `SearchMode`s (`hybrid` /
+  `vector` / `keyword`), ingested through the real `DocumentService.addDocument`.
+- `AgentRuntime.searchMemories` (the raw cosine path the providers ride).
+- The `FACTS` provider (`factsProvider.get`) — keyword + recency, no vectors.
+- `scoreMemoryText` — the keyword chat-search surface (`memory-routes.ts`).
+- A forced **fail-open**: `embedRecallQuery → null` (via a throwing query
+  embedder) so `_vectorSearch` falls open to keyword, and the recall drop is
+  measured.
 
-- `metrics.ts` — Precision@K, Recall@K, MRR, nDCG@K, HitRate@K, nearest-rank
-  latency percentiles, and `summarizeRecall()`. Pure functions, no I/O. Honesty
-  contract from `memperf`: unmeasured rows are `null` (never `0`), and a summary
-  is `measured: true` only when at least one query was actually scored.
-- `metrics.test.ts` — 19 cases with hand-computed expected values, including a
-  guard that a fail-open keyword regression scores **strictly below** the vector
-  path (the silent-degradation risk #9956 names).
+The runtime is a real `AgentRuntime` backed by `@elizaos/plugin-sql` + **PGlite**
+(embedded WASM Postgres with real pgvector cosine) — no DB server, no model
+bundle, no credentials. The embedding is a deterministic in-bench function
+(`embedding.ts`), so every number is **fully reproducible** run-to-run and on a
+hosted CI runner.
+
+## What it is NOT
+
+The deterministic embedding measures **ranking-pipeline correctness** (does the
+hybrid/vector/keyword/fail-open machinery rank the right fragments?), not
+production embedding *quality*. It is a regression gate on the recall *code*, not
+a leaderboard for an embedding model. That separation is deliberate: a real
+embedding model would make the bench non-deterministic and credential-bound,
+defeating the CI gate.
+
+## Run
 
 ```bash
-bunx vitest run packages/benchmarks/recall-bench/metrics.test.ts
+bun run bench:recall           # smoke tier (60 docs) — fast local check
+bun run bench:recall:1k        # 1k tier — the document-scale CI gate
+bun run --cwd packages/benchmarks/recall-bench test   # unit tests (pure pieces)
 ```
 
-## Remaining work-order (the harness + CI gate)
+Or via the orchestrator (registered as `recall_bench` in `registry/commands.py`):
+the command resolves to `bun --conditions=eliza-source run.ts --tier <tier>` with
+`tier ∈ {smoke, 1k, 10k}`.
 
-These need the **real** `@elizaos/core` pipeline stood up over a labelled
-corpus, and a CI runner — tracked in #9956, not yet in this package:
+Exit codes follow the `memperf` contract: `0` budgets pass · `1` a budget
+regressed (the gate) · `2` nothing measurable.
 
-- [ ] Driver that ingests a document-scale corpus through the real
-      `DocumentService` (no Python/mock reimpl) + a query set with ground-truth
-      relevant fragment ids, runs each `SearchMode`, and feeds results through
-      `summarizeRecall`.
-- [ ] Per-mode emission (hybrid / vector / keyword) so the hard-coded
-      `HYBRID_VECTOR_WEIGHT 0.6 / 0.4` and the fail-open degradation are each
-      quantified.
-- [ ] A fail-open assertion: force `embedRecallQuery` to return `null` and
-      assert a measured recall drop vs the vector path.
-- [ ] Cover the keyword chat-search surface (`scoreMemoryText`) and a
-      `FACTS`-provider recall slice against the same corpus.
-- [ ] Register in `registry/commands.py` + `registry/scores.py` and wire
-      `recall-bench.yml` with a committed `budgets.json`, mirroring `memperf`.
+## Corpus (deterministic, committed as code)
+
+`corpus.ts` generates a labeled corpus deterministically (seeded PRNG) — it is
+committed *as code*, reproducible and diffable, rather than as a giant JSON
+fixture. Three doc classes per topic make the metrics meaningful:
+
+- **relevant** — the topic's ground-truth answers; carry the query's exact base
+  token *and* extra same-root morphological forms (rich trigram mass).
+- **confusable** — carry the same base token but a *foreign* body (disjoint
+  roots). Keyword/BM25 can't tell them from relevant; the vector embedding sits
+  far from the query. These are what a healthy vector pass ranks out and a
+  fail-open keyword pass lets pollute the top-K — the mechanism that makes the
+  fail-open a **measurable** recall drop.
+- **noise** — disjoint roots, no query token; pad to document scale.
+
+Tiers: `smoke` = 60 docs / 6 queries · `1k` = 1,000 / 40 · `10k` = 10,000 / 40.
+Relevance is labeled at the *document* level (robust to how `DocumentService`
+chunks each doc into fragments).
+
+## Output (`results/recall-bench-results.json`, baseline in `baseline-1k.json`)
+
+Per-`SearchMode` rows with Precision@5, Recall@5, MRR, nDCG@5, HitRate@5, p50/p95
+latency, each `measured: true` only on a real run (`null`, never `0`, otherwise).
+Plus the `failOpen` block (`vectorRecallAt5`, `failOpenRecallAt5`, `recallDrop`,
+`observable`) and the budget `checks`.
+
+### Committed 1k baseline (deterministic)
+
+| mode | Recall@5 | nDCG@5 |
+| --- | --- | --- |
+| `document-hybrid` | 0.880 | 0.864 |
+| `document-vector` | 0.715 | 0.684 |
+| `document-keyword` | 0.370 | 0.422 |
+| `searchMemories-vector` | 0.965 | 0.974 |
+| `keyword-chat-scoreMemoryText` | 0.095 | 0.125 |
+| `facts-provider-keyword` | 1.000 | 1.000 |
+| `document-vector-failopen` | 0.370 | 0.422 |
+
+**Fail-open recall drop 0.345 (observable).** Hybrid/vector clearly out-recall
+keyword; forcing the query embed to fail collapses `document-vector` (0.715) to
+keyword level (0.370). `scoreMemoryText` (substring/term) degrades sharply at
+document scale — exactly the keyword-vs-semantic gap #9956 wants tracked.
+
+## Budgets & CI
+
+`budgets.json` holds per-mode floors (Recall@5 / nDCG@5 / p95) and a minimum
+observable fail-open drop, calibrated to the 1k baseline with ~20% headroom.
+`.github/workflows/recall-bench.yml` runs the unit tests, the registry-contract
+check (`scripts/check-registry.py`), and the 1k gate; it turns red when a budget
+is crossed (e.g. a bad hybrid-weight change, or semantic recall silently
+collapsing into keyword).
+
+## Files
+
+- `metrics.ts` / `metrics.test.ts` — pure IR metrics + `summarizeRecall()`.
+- `embedding.ts` / `embedding.test.ts` — deterministic feature-hash embedding.
+- `corpus.ts` / `corpus.test.ts` — the labeled corpus + facts + design invariants.
+- `runtime.ts` — the real `AgentRuntime` + PGlite + `DocumentService` harness.
+- `run.ts` — the runner (ingests, drives every mode, emits the report, gates).
+- `budgets.json` / `baseline-1k.json` — committed budgets + reference metrics.
+- `scripts/check-registry.py` — orchestrator-registration contract check.

--- a/packages/benchmarks/recall-bench/baseline-1k.json
+++ b/packages/benchmarks/recall-bench/baseline-1k.json
@@ -1,0 +1,237 @@
+{
+  "benchmark": "recall-bench",
+  "generatedAt": "2026-06-29T18:46:05.716Z",
+  "corpus": {
+    "committed": true,
+    "tier": "1k",
+    "topics": 40,
+    "documents": 1000,
+    "queries": 40
+  },
+  "k": 5,
+  "modes": [
+    {
+      "mode": "document-hybrid",
+      "corpusSize": 1000,
+      "queries": 40,
+      "k": 5,
+      "precisionAtK": 0.8800000000000002,
+      "recallAtK": 0.8800000000000002,
+      "mrr": 0.8875,
+      "ndcgAtK": 0.863868262740087,
+      "hitRateAtK": 1,
+      "p50LatencyMs": 7.87350399999923,
+      "p95LatencyMs": 8.733158999999432,
+      "measured": true
+    },
+    {
+      "mode": "document-vector",
+      "corpusSize": 1000,
+      "queries": 40,
+      "k": 5,
+      "precisionAtK": 0.7150000000000001,
+      "recallAtK": 0.7150000000000001,
+      "mrr": 0.7274999999999999,
+      "ndcgAtK": 0.6835947682141241,
+      "hitRateAtK": 1,
+      "p50LatencyMs": 5.489093000000139,
+      "p95LatencyMs": 6.346172999999908,
+      "measured": true
+    },
+    {
+      "mode": "document-keyword",
+      "corpusSize": 1000,
+      "queries": 40,
+      "k": 5,
+      "precisionAtK": 0.37,
+      "recallAtK": 0.37,
+      "mrr": 0.6666666666666667,
+      "ndcgAtK": 0.4224540926172685,
+      "hitRateAtK": 0.775,
+      "p50LatencyMs": 53.38742900000034,
+      "p95LatencyMs": 68.2267869999996,
+      "measured": true
+    },
+    {
+      "mode": "searchMemories-vector",
+      "corpusSize": 1000,
+      "queries": 40,
+      "k": 5,
+      "precisionAtK": 0.9650000000000001,
+      "recallAtK": 0.9650000000000001,
+      "mrr": 1,
+      "ndcgAtK": 0.9738548363300084,
+      "hitRateAtK": 1,
+      "p50LatencyMs": 5.904946000000564,
+      "p95LatencyMs": 6.941863000000012,
+      "measured": true
+    },
+    {
+      "mode": "keyword-chat-scoreMemoryText",
+      "corpusSize": 1000,
+      "queries": 40,
+      "k": 5,
+      "precisionAtK": 0.09500000000000001,
+      "recallAtK": 0.09500000000000001,
+      "mrr": 0.30164605575829423,
+      "ndcgAtK": 0.12477920234057101,
+      "hitRateAtK": 0.4,
+      "p50LatencyMs": 0.6530650000004243,
+      "p95LatencyMs": 0.7631700000001729,
+      "measured": true
+    },
+    {
+      "mode": "facts-provider-keyword",
+      "corpusSize": 70,
+      "queries": 40,
+      "k": 5,
+      "precisionAtK": 0.2000000000000001,
+      "recallAtK": 1,
+      "mrr": 1,
+      "ndcgAtK": 1,
+      "hitRateAtK": 1,
+      "p50LatencyMs": 6.4611970000005385,
+      "p95LatencyMs": 7.460430999999517,
+      "measured": true
+    },
+    {
+      "mode": "document-vector-failopen",
+      "corpusSize": 1000,
+      "queries": 40,
+      "k": 5,
+      "precisionAtK": 0.37,
+      "recallAtK": 0.37,
+      "mrr": 0.6666666666666667,
+      "ndcgAtK": 0.4224540926172685,
+      "hitRateAtK": 0.775,
+      "p50LatencyMs": 50.9256549999991,
+      "p95LatencyMs": 68.0599000000002,
+      "measured": true
+    }
+  ],
+  "failOpen": {
+    "vectorRecallAt5": 0.7150000000000001,
+    "failOpenRecallAt5": 0.37,
+    "recallDrop": 0.3450000000000001,
+    "observable": true
+  },
+  "metrics": {
+    "overall_recall_at_5": 0.8800000000000002,
+    "overall_ndcg_at_5": 0.863868262740087,
+    "overall_p95_latency_ms": 8.733158999999432
+  },
+  "checks": [
+    {
+      "name": "document-hybrid.minRecallAt5",
+      "value": 0.8800000000000002,
+      "budget": 0.7,
+      "unit": "ratio",
+      "pass": true
+    },
+    {
+      "name": "document-hybrid.minNdcgAt5",
+      "value": 0.863868262740087,
+      "budget": 0.68,
+      "unit": "ratio",
+      "pass": true
+    },
+    {
+      "name": "document-hybrid.maxP95LatencyMs",
+      "value": 8.733158999999432,
+      "budget": 750,
+      "unit": "ms",
+      "pass": true
+    },
+    {
+      "name": "document-vector.minRecallAt5",
+      "value": 0.7150000000000001,
+      "budget": 0.55,
+      "unit": "ratio",
+      "pass": true
+    },
+    {
+      "name": "document-vector.minNdcgAt5",
+      "value": 0.6835947682141241,
+      "budget": 0.54,
+      "unit": "ratio",
+      "pass": true
+    },
+    {
+      "name": "document-vector.maxP95LatencyMs",
+      "value": 6.346172999999908,
+      "budget": 750,
+      "unit": "ms",
+      "pass": true
+    },
+    {
+      "name": "document-keyword.minRecallAt5",
+      "value": 0.37,
+      "budget": 0.25,
+      "unit": "ratio",
+      "pass": true
+    },
+    {
+      "name": "document-keyword.maxP95LatencyMs",
+      "value": 68.2267869999996,
+      "budget": 750,
+      "unit": "ms",
+      "pass": true
+    },
+    {
+      "name": "searchMemories-vector.minRecallAt5",
+      "value": 0.9650000000000001,
+      "budget": 0.8,
+      "unit": "ratio",
+      "pass": true
+    },
+    {
+      "name": "searchMemories-vector.minNdcgAt5",
+      "value": 0.9738548363300084,
+      "budget": 0.78,
+      "unit": "ratio",
+      "pass": true
+    },
+    {
+      "name": "searchMemories-vector.maxP95LatencyMs",
+      "value": 6.941863000000012,
+      "budget": 750,
+      "unit": "ms",
+      "pass": true
+    },
+    {
+      "name": "keyword-chat-scoreMemoryText.minRecallAt5",
+      "value": 0.09500000000000001,
+      "budget": 0.05,
+      "unit": "ratio",
+      "pass": true
+    },
+    {
+      "name": "keyword-chat-scoreMemoryText.maxP95LatencyMs",
+      "value": 0.7631700000001729,
+      "budget": 750,
+      "unit": "ms",
+      "pass": true
+    },
+    {
+      "name": "facts-provider-keyword.minRecallAt5",
+      "value": 1,
+      "budget": 0.8,
+      "unit": "ratio",
+      "pass": true
+    },
+    {
+      "name": "facts-provider-keyword.maxP95LatencyMs",
+      "value": 7.460430999999517,
+      "budget": 750,
+      "unit": "ms",
+      "pass": true
+    },
+    {
+      "name": "failOpen.minObservableRecallDrop",
+      "value": 0.3450000000000001,
+      "budget": 0.15,
+      "unit": "ratio",
+      "pass": true
+    }
+  ]
+}

--- a/packages/benchmarks/recall-bench/budgets.json
+++ b/packages/benchmarks/recall-bench/budgets.json
@@ -1,0 +1,16 @@
+{
+  "_comment": "Committed regression budgets for recall-bench (#9956), mirroring memperf/budgets.json. The runner compares MEASURED per-SearchMode rows against these and exits non-zero when a hard budget is crossed; a skipped (unmeasured) row never fails a budget. Numbers are the deterministic-embedding pipeline baseline at the 1k tier with ~20% headroom — they catch ranking/weight/fail-open regressions, not production embedding quality (see README). 'null' is never conflated with a measured 0. The same floors also pass the (easier) smoke tier, so either tier is green on the current baseline.",
+  "tier": "1k",
+  "k": 5,
+  "modes": {
+    "document-hybrid": { "minRecallAt5": 0.7, "minNdcgAt5": 0.68, "maxP95LatencyMs": 750 },
+    "document-vector": { "minRecallAt5": 0.55, "minNdcgAt5": 0.54, "maxP95LatencyMs": 750 },
+    "document-keyword": { "minRecallAt5": 0.25, "maxP95LatencyMs": 750 },
+    "searchMemories-vector": { "minRecallAt5": 0.8, "minNdcgAt5": 0.78, "maxP95LatencyMs": 750 },
+    "keyword-chat-scoreMemoryText": { "minRecallAt5": 0.05, "maxP95LatencyMs": 750 },
+    "facts-provider-keyword": { "minRecallAt5": 0.8, "maxP95LatencyMs": 750 }
+  },
+  "failOpen": {
+    "minObservableRecallDrop": 0.15
+  }
+}

--- a/packages/benchmarks/recall-bench/corpus.test.ts
+++ b/packages/benchmarks/recall-bench/corpus.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { buildCorpus, buildFacts, type CorpusTier } from "./corpus.ts";
+import { cosine, embedText, tokenize } from "./embedding.ts";
+
+const mean = (xs: number[]) =>
+  xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0;
+
+describe("recall-bench corpus", () => {
+  it("is deterministic", () => {
+    expect(buildCorpus("smoke")).toEqual(buildCorpus("smoke"));
+    expect(buildFacts("smoke")).toEqual(buildFacts("smoke"));
+  });
+
+  it("builds the labelled tiers at the documented scale", () => {
+    const cases: Array<[CorpusTier, number]> = [
+      ["smoke", 60],
+      ["1k", 1000],
+    ];
+    for (const [tier, count] of cases) {
+      const c = buildCorpus(tier);
+      expect(c.docs).toHaveLength(count);
+      expect(c.queries).toHaveLength(c.topics);
+      // Every query's relevant ids exist and belong to one topic.
+      const ids = new Set(c.docs.map((d) => d.id));
+      for (const q of c.queries) {
+        expect(q.relevantDocIds.length).toBeGreaterThan(0);
+        for (const id of q.relevantDocIds) expect(ids.has(id)).toBe(true);
+      }
+    }
+  });
+
+  // The fail-open gap is real only if the vector embedding separates a topic's
+  // relevant docs from its keyword-confusable distractors (both carry the query's
+  // base token, so keyword/BM25 cannot). Assert that separation directly with the
+  // bench's own embedding — this is the invariant the document run depends on.
+  it("vector-separates relevant from keyword-confusable distractors", () => {
+    const c = buildCorpus("1k");
+    const docById = new Map(c.docs.map((d) => [d.id, d]));
+    let relWins = 0;
+    for (const q of c.queries) {
+      const qv = embedText(q.text);
+      const relMean = mean(
+        q.relevantDocIds.map((id) =>
+          cosine(qv, embedText(docById.get(id)!.text)),
+        ),
+      );
+      const confMean = mean(
+        c.docs
+          .filter((d) => d.id.startsWith(`confuse-${q.topic}-`))
+          .map((d) => cosine(qv, embedText(d.text))),
+      );
+      // Both share the base token, yet relevant sits clearly closer to the query.
+      if (relMean > confMean + 0.1) relWins += 1;
+    }
+    expect(relWins / c.queries.length).toBeGreaterThan(0.9);
+  });
+
+  // Keyword has no topic signal to rank by: a query shares exactly one non-filler
+  // token (the base) with BOTH its relevant and its confusable docs.
+  it("keyword cannot separate relevant from confusable on topic tokens", () => {
+    const c = buildCorpus("smoke");
+    const docById = new Map(c.docs.map((d) => [d.id, d]));
+    for (const q of c.queries) {
+      const qTokens = new Set(tokenize(q.text));
+      const base = `${tokenize(q.text)[0]}`; // query text starts with the base token
+      const shared = (id: string) =>
+        [...new Set(tokenize(docById.get(id)!.text))].filter((t) =>
+          qTokens.has(t),
+        );
+      const rel = shared(q.relevantDocIds[0]);
+      const conf = shared(
+        c.docs.find((d) => d.id.startsWith(`confuse-${q.topic}-`))!.id,
+      );
+      // The base token is the only query-overlapping signal, present in both.
+      expect(rel).toContain(base);
+      expect(conf).toContain(base);
+    }
+  });
+});

--- a/packages/benchmarks/recall-bench/corpus.ts
+++ b/packages/benchmarks/recall-bench/corpus.ts
@@ -1,0 +1,369 @@
+/**
+ * recall-bench — deterministic, labelled, document-scale corpus (#9956).
+ *
+ * A retrieval benchmark needs (a) documents ingested through the REAL
+ * `DocumentService`, and (b) a query set with ground-truth *relevant document
+ * ids*. Labelling at the **document** level (not fragment) is deliberate: the
+ * real ingestion chunks a document into fragments with service-assigned ids we
+ * don't control, so the bench resolves each retrieved fragment back to its
+ * `documentId` and scores against the labelled doc set.
+ *
+ * Construction (seeded, reproducible): `topics` distinct subjects, each pinned
+ * to a unique English **root** + numeric tag so topics never share vocabulary.
+ * Per topic there are three doc classes (see TIERS below): *relevant* answers
+ * (the topic's base token + extra same-root forms), *confusable* distractors
+ * (the same base token but a foreign body — keyword-indistinguishable from
+ * relevant, yet vector-distant), and *noise* (disjoint roots, no query token).
+ * Keyword/BM25 cannot separate relevant from confusable (their only query
+ * overlap is the shared base token), but the bench embedding ranks the
+ * confusables out — so the **vector path out-recalls keyword on the same
+ * corpus**, which is what makes the embed fail-open a *measurable* recall drop
+ * rather than a silent one. Shared English filler is sprinkled in as noise.
+ */
+
+/** A corpus document (ingested whole; the service chunks it into fragments). */
+export interface CorpusDoc {
+  id: string;
+  text: string;
+  topic: number;
+}
+
+/** A query with its ground-truth relevant document ids. */
+export interface CorpusQuery {
+  id: string;
+  text: string;
+  topic: number;
+  relevantDocIds: string[];
+}
+
+export interface Corpus {
+  tier: string;
+  topics: number;
+  docs: CorpusDoc[];
+  queries: CorpusQuery[];
+}
+
+export type CorpusTier = "smoke" | "1k" | "10k";
+
+/**
+ * A labelled fact for the FACTS-provider slice. The provider retrieves from the
+ * `facts` table by keyword + recency (no vectors), so each fact carries the
+ * `keywords` the provider ranks on. Exactly one fact is relevant to each query
+ * (`relevantQueryId`); the rest are distractors drawn from unused roots, so the
+ * pool exceeds the provider's top-K and ranking is actually exercised.
+ */
+export interface FactItem {
+  id: string;
+  text: string;
+  keywords: string[];
+  kind: "durable" | "current";
+  relevantQueryId?: string;
+}
+
+const FACT_DISTRACTORS = 30;
+
+/**
+ * Build the facts corpus for a tier: one durable fact answering each query
+ * (keyworded on that query's exact tokens) plus `FACT_DISTRACTORS` durable
+ * distractors on roots the document corpus never uses (disjoint tokens → they
+ * score ~0 and must be ranked out). Deterministic given the tier.
+ */
+export function buildFacts(tier: CorpusTier): FactItem[] {
+  const { topics } = TIERS[tier];
+  const facts: FactItem[] = [];
+
+  for (let t = 0; t < topics; t++) {
+    const root = ROOTS[t % ROOTS.length];
+    facts.push({
+      id: `fact-${t}`,
+      // Keyworded on the query's two tokens so the real BM25 ranker surfaces it.
+      keywords: [`${root}${t}`, queryForm(root, t)],
+      text: `the user configured the ${root}${t} subsystem and relies on ${queryForm(root, t)}`,
+      kind: "durable",
+      relevantQueryId: `q-${t}`,
+    });
+  }
+
+  // Distractors: roots beyond the document corpus's topic span → no token
+  // overlap with any query, so the ranker must keep them out of the top-K.
+  for (let d = 0; d < FACT_DISTRACTORS; d++) {
+    const idx = topics + d;
+    const root = ROOTS[idx % ROOTS.length];
+    facts.push({
+      id: `fact-distractor-${d}`,
+      keywords: [`${root}${idx}`, queryForm(root, idx)],
+      text: `the user noted the ${root}${idx} subsystem in passing`,
+      kind: "durable",
+    });
+  }
+
+  return facts;
+}
+
+// Each query has a small fixed relevant set (so Recall@5 spans [0,1]); scale
+// comes from *distractor* docs, NOT from more relevant docs or more topics.
+// Topics stay ≤ TOPIC_ROOT_COUNT so every topic gets a UNIQUE root — reusing a
+// root across topics would let the vector path's subword (root-trigram) signal
+// bleed between same-root topics and erase its edge over keyword.
+//
+// Three doc classes per corpus:
+//  - relevant     — the topic's ground-truth answers; every one carries the
+//                   query's exact base token AND extra same-root forms (rich
+//                   root-trigram mass) → both keyword and vector retrieve them.
+//  - confusable   — carry the topic's exact base token but a FOREIGN body
+//                   (disjoint roots). Keyword/BM25 can't tell them from relevant
+//                   (same query-overlapping tokens), but their vector embedding
+//                   sits far from the query. So pure-keyword pollutes its top-K
+//                   with these while the vector path ranks them out — which is
+//                   exactly what makes the embed fail-open a *measurable* drop.
+//  - noise        — disjoint roots, no query token at all; pad to document scale.
+const TIERS: Record<
+  CorpusTier,
+  {
+    topics: number;
+    relevantPerTopic: number;
+    confusablePerTopic: number;
+    totalDocs: number;
+  }
+> = {
+  // 18 rel + 30 confusable + 12 noise = 60
+  smoke: {
+    topics: 6,
+    relevantPerTopic: 3,
+    confusablePerTopic: 5,
+    totalDocs: 60,
+  },
+  // 200 rel + 200 confusable + 600 noise = 1,000
+  "1k": {
+    topics: 40,
+    relevantPerTopic: 5,
+    confusablePerTopic: 5,
+    totalDocs: 1000,
+  },
+  // 200 rel + 200 confusable + 9,600 noise = 10,000
+  "10k": {
+    topics: 40,
+    relevantPerTopic: 5,
+    confusablePerTopic: 5,
+    totalDocs: 10000,
+  },
+};
+
+/** Real English roots; each topic pins one + a numeric tag for uniqueness. */
+const ROOTS = [
+  "configure",
+  "retrieve",
+  "embed",
+  "cluster",
+  "schema",
+  "query",
+  "index",
+  "memory",
+  "vector",
+  "document",
+  "fragment",
+  "rank",
+  "search",
+  "ingest",
+  "encode",
+  "decode",
+  "compress",
+  "validate",
+  "migrate",
+  "replicate",
+  "authenticate",
+  "authorize",
+  "serialize",
+  "normalize",
+  "tokenize",
+  "aggregate",
+  "partition",
+  "cache",
+  "stream",
+  "buffer",
+  "compile",
+  "deploy",
+  "monitor",
+  "profile",
+  "benchmark",
+  "optimize",
+  "schedule",
+  "dispatch",
+  "render",
+  "navigate",
+  "annotate",
+  "summarize",
+  "translate",
+  "classify",
+  "predict",
+  "calibrate",
+  "synthesize",
+  "orchestrate",
+  "provision",
+  "federate",
+];
+
+// The first TOPIC_ROOT_COUNT roots back the topics (one unique root per topic);
+// the remainder back distractor docs. The two pools are disjoint, so a query's
+// root never trigram-matches a distractor — distractors are pure noise.
+const TOPIC_ROOT_COUNT = 40;
+const DISTRACTOR_ROOTS = ROOTS.slice(TOPIC_ROOT_COUNT);
+
+/** Morphological forms a topic's *documents* use. */
+function docForms(root: string, tag: number): string[] {
+  return [
+    `${root}${tag}`,
+    `${root}d${tag}`,
+    `${root}s${tag}`,
+    `re${root}${tag}`,
+    `${root}ation${tag}`,
+  ];
+}
+
+/** A form the topic's *query* uses — absent from docForms (subword-only match). */
+function queryForm(root: string, tag: number): string {
+  return `${root}ing${tag}`;
+}
+
+const FILLER = [
+  "the",
+  "agent",
+  "should",
+  "handle",
+  "this",
+  "case",
+  "when",
+  "the",
+  "system",
+  "processes",
+  "incoming",
+  "requests",
+  "and",
+  "stores",
+  "results",
+  "for",
+  "later",
+  "retrieval",
+  "across",
+  "many",
+  "rooms",
+  "over",
+  "time",
+  "reliably",
+];
+
+/** Tiny deterministic PRNG (mulberry32). */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function pick<T>(arr: readonly T[], rnd: () => number): T {
+  return arr[Math.floor(rnd() * arr.length)];
+}
+
+/** A doc built from a few explicit tokens + a little filler. */
+function buildDoc(
+  id: string,
+  topic: number,
+  tokens: string[],
+  rnd: () => number,
+): CorpusDoc {
+  return {
+    id,
+    topic,
+    text: [pick(FILLER, rnd), ...tokens, pick(FILLER, rnd)].join(" "),
+  };
+}
+
+/** A foreign two-token body from the disjoint distractor roots (no query root). */
+function foreignBody(seed: number, rnd: () => number): string[] {
+  const a = DISTRACTOR_ROOTS[seed % DISTRACTOR_ROOTS.length];
+  const b = DISTRACTOR_ROOTS[(seed + 1) % DISTRACTOR_ROOTS.length];
+  return [
+    pick(docForms(a, 1000 + seed), rnd),
+    pick(docForms(b, 2000 + seed), rnd),
+  ];
+}
+
+/** Build the labelled corpus for a tier. Deterministic given the tier. */
+export function buildCorpus(tier: CorpusTier): Corpus {
+  const { topics, relevantPerTopic, confusablePerTopic, totalDocs } =
+    TIERS[tier];
+  if (topics > TOPIC_ROOT_COUNT) {
+    throw new Error(
+      `recall-bench: topics ${topics} exceeds unique topic roots ${TOPIC_ROOT_COUNT}`,
+    );
+  }
+  const rnd = mulberry32(0x9956 + topics * 131 + totalDocs);
+  const docs: CorpusDoc[] = [];
+  const queries: CorpusQuery[] = [];
+
+  for (let t = 0; t < topics; t++) {
+    const root = ROOTS[t]; // unique per topic — no cross-topic subword bleed
+    const tag = t;
+    const base = `${root}${tag}`;
+    const forms = docForms(root, tag);
+    const relevantDocIds: string[] = [];
+
+    // Relevant: the base token (so keyword + vector both retrieve them) plus two
+    // more same-root forms (extra trigram mass the vector path rides to outrank
+    // the confusables — whose only shared token with the query is `base`).
+    for (let d = 0; d < relevantPerTopic; d++) {
+      const id = `doc-${t}-${d}`;
+      relevantDocIds.push(id);
+      docs.push(
+        buildDoc(id, t, [base, pick(forms, rnd), pick(forms, rnd)], rnd),
+      );
+    }
+
+    // Confusable: same base token, foreign body → keyword-indistinguishable from
+    // relevant, vector-distant. These are what a healthy vector pass ranks out
+    // and a fail-open keyword pass lets pollute the top-K.
+    for (let c = 0; c < confusablePerTopic; c++) {
+      docs.push(
+        buildDoc(
+          `confuse-${t}-${c}`,
+          -1,
+          [base, ...foreignBody(t * 97 + c, rnd)],
+          rnd,
+        ),
+      );
+    }
+
+    queries.push({
+      id: `q-${t}`,
+      topic: t,
+      relevantDocIds,
+      // base form (exact token shared by relevant AND confusable → keyword can't
+      // separate them) + the `-ing` form (in no doc; only the vector path's
+      // subword signal binds it) + one filler word.
+      text: `${base} ${queryForm(root, tag)} ${pick(FILLER, rnd)}`,
+    });
+  }
+
+  // Noise: disjoint roots, no query token at all — pure padding to document
+  // scale that every healthy mode must rank out.
+  const placed = topics * (relevantPerTopic + confusablePerTopic);
+  for (let i = 0; i < totalDocs - placed; i++) {
+    const root = DISTRACTOR_ROOTS[i % DISTRACTOR_ROOTS.length];
+    const tag = 5000 + i; // unique, never equal to a query tag
+    const forms = docForms(root, tag);
+    docs.push(
+      buildDoc(
+        `noise-${i}`,
+        -1,
+        [forms[0], pick(forms, rnd), pick(forms, rnd)],
+        rnd,
+      ),
+    );
+  }
+
+  return { tier, topics, docs, queries };
+}

--- a/packages/benchmarks/recall-bench/embedding.test.ts
+++ b/packages/benchmarks/recall-bench/embedding.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  cosine,
+  embedText,
+  RECALL_BENCH_EMBEDDING_DIM,
+  tokenize,
+} from "./embedding.ts";
+
+describe("recall-bench embedding", () => {
+  it("is deterministic and unit-normalized", () => {
+    const a = embedText("the agent recalls relevant memories");
+    const b = embedText("the agent recalls relevant memories");
+    expect(a).toEqual(b);
+    expect(a).toHaveLength(RECALL_BENCH_EMBEDDING_DIM);
+    const norm = Math.sqrt(a.reduce((s, x) => s + x * x, 0));
+    expect(norm).toBeCloseTo(1, 6);
+    expect(cosine(a, b)).toBeCloseTo(1, 6);
+  });
+
+  it("returns a zero vector for empty / token-free text", () => {
+    const z = embedText("   !!!  ");
+    expect(z.every((x) => x === 0)).toBe(true);
+  });
+
+  it("ranks lexical overlap above unrelated text", () => {
+    const q = embedText("how do I configure the database adapter");
+    const related = embedText("configure the database adapter settings");
+    const unrelated = embedText("bananas are a tropical yellow fruit");
+    expect(cosine(q, related)).toBeGreaterThan(cosine(q, unrelated));
+  });
+
+  it("gives morphological variants a real semantic edge over an unrelated term — the signal that lets vector out-recall keyword", () => {
+    const q = embedText("configuring");
+    // "configuration" shares no whole token with "configuring", but shares
+    // character trigrams → the subword signal keyword/substring matching lacks.
+    const morph = cosine(q, embedText("configuration"));
+    const unrelated = cosine(q, embedText("banana"));
+    expect(morph).toBeGreaterThan(unrelated);
+    expect(morph).toBeGreaterThan(0.1);
+  });
+
+  it("tokenize lowercases + splits on non-alphanumerics", () => {
+    expect(tokenize("Hello, World! 007")).toEqual(["hello", "world", "007"]);
+  });
+});

--- a/packages/benchmarks/recall-bench/embedding.ts
+++ b/packages/benchmarks/recall-bench/embedding.ts
@@ -1,0 +1,86 @@
+/**
+ * recall-bench — a deterministic, secret-free text embedding (#9956).
+ *
+ * A recall benchmark must run in CI without API keys yet still exercise the REAL
+ * semantic-recall path (`DocumentService` vector/hybrid search over a vector
+ * index), and it must be reproducible so a metric change means a *pipeline*
+ * regression, not embedding noise. A real model (OpenAI / a local transformer)
+ * is neither deterministic-in-CI nor secret-free, so this provides a fixed,
+ * principled stand-in.
+ *
+ * Design — a hashed bag-of-features over two signals, TF-weighted then L2
+ * normalized so cosine ∈ [0,1]:
+ *   1. **whole tokens** — lexical overlap (what BM25 / keyword also see).
+ *   2. **character trigrams** of each token — a *subword* signal, so
+ *      morphological variants ("configure" / "configuring" / "configuration")
+ *      land near each other. This is the bit keyword/substring matching misses,
+ *      and it is *why* the vector path can out-recall keyword on the labelled
+ *      corpus — which is exactly what makes the fail-open degradation (vector →
+ *      keyword) a measurable drop rather than a silent one.
+ *
+ * This is a pipeline-characterization embedding: the ABSOLUTE numbers are not
+ * production recall quality, but they are stable, so regressions in ranking /
+ * weights / the fail-open are caught. The README states this explicitly.
+ */
+
+export const RECALL_BENCH_EMBEDDING_DIM = 384;
+
+/** Lowercase alphanumeric tokens (matches the core `tokenize` convention). */
+export function tokenize(text: string): string[] {
+  return text.toLowerCase().match(/[a-z0-9]+/g) ?? [];
+}
+
+/** FNV-1a → a stable non-negative bucket in [0, dim). */
+function bucket(feature: string, dim: number): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < feature.length; i++) {
+    h ^= feature.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0) % dim;
+}
+
+/** Character trigrams of a token, padded so short tokens still contribute. */
+function trigrams(token: string): string[] {
+  const padded = `^${token}$`;
+  if (padded.length <= 3) return [padded];
+  const out: string[] = [];
+  for (let i = 0; i + 3 <= padded.length; i++) out.push(padded.slice(i, i + 3));
+  return out;
+}
+
+/**
+ * Embed text into a fixed-dimension unit vector. Deterministic: the same text
+ * always yields the same vector. Whole-token features are weighted above
+ * subword features so exact lexical overlap dominates, with subwords adding the
+ * morphological similarity that separates the vector path from keyword.
+ */
+export function embedText(
+  text: string,
+  dim: number = RECALL_BENCH_EMBEDDING_DIM,
+): number[] {
+  const vec = new Array<number>(dim).fill(0);
+  const tokens = tokenize(text);
+  const TOKEN_WEIGHT = 3;
+  const TRIGRAM_WEIGHT = 1;
+  for (const token of tokens) {
+    vec[bucket(`tok:${token}`, dim)] += TOKEN_WEIGHT;
+    for (const tri of trigrams(token)) {
+      vec[bucket(`tri:${tri}`, dim)] += TRIGRAM_WEIGHT;
+    }
+  }
+  let norm = 0;
+  for (const v of vec) norm += v * v;
+  norm = Math.sqrt(norm);
+  if (norm === 0) return vec;
+  for (let i = 0; i < dim; i++) vec[i] /= norm;
+  return vec;
+}
+
+/** Cosine similarity of two equal-length vectors (already unit-norm → dot). */
+export function cosine(a: readonly number[], b: readonly number[]): number {
+  let dot = 0;
+  const n = Math.min(a.length, b.length);
+  for (let i = 0; i < n; i++) dot += a[i] * b[i];
+  return dot;
+}

--- a/packages/benchmarks/recall-bench/package.json
+++ b/packages/benchmarks/recall-bench/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@elizaos/recall-bench",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Precision/Recall/nDCG/latency benchmark for the real @elizaos/core memory-recall + knowledge-retrieval pipeline (#9956).",
+  "scripts": {
+    "bench": "bun --conditions=eliza-source run.ts --tier smoke",
+    "bench:1k": "bun --conditions=eliza-source run.ts --tier 1k",
+    "bench:10k": "bun --conditions=eliza-source run.ts --tier 10k",
+    "test": "vitest run"
+  }
+}

--- a/packages/benchmarks/recall-bench/results/.gitignore
+++ b/packages/benchmarks/recall-bench/results/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/packages/benchmarks/recall-bench/run.ts
+++ b/packages/benchmarks/recall-bench/run.ts
@@ -1,0 +1,467 @@
+/**
+ * recall-bench runner (#9956) — drives the REAL `@elizaos/core` recall path over
+ * a labelled, document-scale corpus and reports per-`SearchMode` IR quality +
+ * latency, the fail-open degradation, and the keyword chat-search baseline.
+ *
+ * Run:  bun --conditions=eliza-source run.ts [--tier smoke|1k|10k] [--out DIR]
+ *
+ * Emits `<out>/recall-bench-results.json` (the orchestrator + the budget gate
+ * both read it) and exits per the memperf contract: 0 = budgets pass, 1 = a
+ * budget regression, 2 = nothing measurable.
+ *
+ * Honesty contract (memperf): a mode is `measured:true` only when a real run
+ * produced its numbers; unmeasured metrics are `null`, never `0`.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { scoreMemoryText } from "@elizaos/agent/api";
+import type { Memory, State, UUID } from "@elizaos/core";
+// The FACTS provider is internal to @elizaos/core (not on the public barrel);
+// a benchmark legitimately reaches into the same source tree to drive the real
+// keyword-recall path it measures. Resolved via the eliza-source condition.
+import { factsProvider } from "../../core/src/features/advanced-capabilities/providers/facts.ts";
+import budgets from "./budgets.json" with { type: "json" };
+import {
+  buildCorpus,
+  buildFacts,
+  type Corpus,
+  type CorpusTier,
+} from "./corpus.ts";
+import { embedText } from "./embedding.ts";
+import {
+  type QueryResult,
+  type RecallSummary,
+  summarizeRecall,
+} from "./metrics.ts";
+import { type BenchRuntime, buildBenchRuntime } from "./runtime.ts";
+
+// The bench is a pure retrieval-quality measurement — trajectory writes are just
+// noise (and a stray state dir). Disable them before the runtime initializes, so
+// a credential-free orchestrator invocation needs no env wrapper.
+process.env.ELIZA_DISABLE_TRAJECTORY_LOGGING ??= "1";
+
+const K = 5;
+const FRAGMENTS_TABLE = "document_fragments";
+
+interface ModeReport extends RecallSummary {
+  mode: string;
+  corpusSize: number;
+  skipReason?: string;
+}
+
+interface BudgetCheck {
+  name: string;
+  pass: boolean;
+  value: number | null;
+  budget: number;
+  unit: string;
+}
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
+function parseArgs(argv: string[]): { tier: CorpusTier; out: string } {
+  let tier: CorpusTier = "smoke";
+  let out = join(import.meta.dirname, "results");
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--tier") tier = argv[++i] as CorpusTier;
+    else if (argv[i] === "--out") out = argv[++i];
+  }
+  return { tier, out };
+}
+
+const uuid = () => crypto.randomUUID() as UUID;
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+/** Resolve a search hit (StoredDocument fragment) back to its corpus doc id. */
+function hitDocId(
+  hit: { id: UUID; metadata?: { documentId?: string } },
+  docIdByMemId: Map<string, string>,
+): string | undefined {
+  const memId = hit.metadata?.documentId;
+  return memId ? docIdByMemId.get(memId) : docIdByMemId.get(hit.id);
+}
+
+/** Unique corpus doc ids in rank order from a list of fragment hits. */
+function rankedDocIds(
+  hits: Array<{ id: UUID; metadata?: { documentId?: string } }>,
+  docIdByMemId: Map<string, string>,
+): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const hit of hits) {
+    const docId = hitDocId(hit, docIdByMemId);
+    if (docId && !seen.has(docId)) {
+      seen.add(docId);
+      out.push(docId);
+    }
+  }
+  return out;
+}
+
+function makeMessage(bench: BenchRuntime, text: string): Memory {
+  return {
+    id: uuid(),
+    entityId: bench.agentId,
+    agentId: bench.agentId,
+    roomId: bench.agentId,
+    content: { text },
+    createdAt: Date.now(),
+  };
+}
+
+// ── per-mode runners (drive the REAL code) ────────────────────────────────────
+
+/** DocumentService.searchDocuments in one of the three SearchModes. */
+async function runDocumentMode(
+  bench: BenchRuntime,
+  corpus: Corpus,
+  docIdByMemId: Map<string, string>,
+  mode: "hybrid" | "vector" | "keyword",
+  label: string,
+): Promise<ModeReport> {
+  const results: QueryResult[] = [];
+  const latencies: number[] = [];
+  for (const q of corpus.queries) {
+    const message = makeMessage(bench, q.text);
+    const t0 = performance.now();
+    const hits = await bench.documents.searchDocuments(
+      message,
+      { roomId: bench.agentId },
+      mode,
+    );
+    latencies.push(performance.now() - t0);
+    results.push({
+      retrieved: rankedDocIds(hits, docIdByMemId),
+      relevant: new Set(q.relevantDocIds),
+    });
+  }
+  return {
+    mode: label,
+    corpusSize: corpus.docs.length,
+    ...summarizeRecall(results, K, latencies),
+  };
+}
+
+/** runtime.searchMemories directly over document_fragments (pure vector recall,
+ *  no `query` rerank — measures the adapter's cosine path the providers ride). */
+async function runSearchMemories(
+  bench: BenchRuntime,
+  corpus: Corpus,
+  docIdByMemId: Map<string, string>,
+): Promise<ModeReport> {
+  const results: QueryResult[] = [];
+  const latencies: number[] = [];
+  for (const q of corpus.queries) {
+    const embedding = embedText(q.text);
+    const t0 = performance.now();
+    const mems = await bench.runtime.searchMemories({
+      tableName: FRAGMENTS_TABLE,
+      embedding,
+      roomId: bench.agentId,
+      count: 20,
+    });
+    latencies.push(performance.now() - t0);
+    results.push({
+      retrieved: rankedDocIds(
+        mems as Array<{ id: UUID; metadata?: { documentId?: string } }>,
+        docIdByMemId,
+      ),
+      relevant: new Set(q.relevantDocIds),
+    });
+  }
+  return {
+    mode: "searchMemories-vector",
+    corpusSize: corpus.docs.length,
+    ...summarizeRecall(results, K, latencies),
+  };
+}
+
+/** The keyword chat-search scorer (`scoreMemoryText`) over the same corpus. */
+async function runKeywordChat(
+  bench: BenchRuntime,
+  corpus: Corpus,
+  docIdByMemId: Map<string, string>,
+): Promise<ModeReport> {
+  const fragments = (await bench.runtime.getMemories({
+    tableName: FRAGMENTS_TABLE,
+    roomId: bench.agentId,
+    count: corpus.docs.length * 4,
+  })) as Array<{
+    id: UUID;
+    content: { text?: string };
+    metadata?: { documentId?: string };
+  }>;
+  const results: QueryResult[] = [];
+  const latencies: number[] = [];
+  for (const q of corpus.queries) {
+    const t0 = performance.now();
+    const ranked = fragments
+      .map((m) => ({ m, score: scoreMemoryText(m.content.text ?? "", q.text) }))
+      .filter((r) => r.score > 0)
+      .sort((a, b) => b.score - a.score)
+      .map((r) => r.m);
+    latencies.push(performance.now() - t0);
+    results.push({
+      retrieved: rankedDocIds(ranked, docIdByMemId),
+      relevant: new Set(q.relevantDocIds),
+    });
+  }
+  return {
+    mode: "keyword-chat-scoreMemoryText",
+    corpusSize: corpus.docs.length,
+    ...summarizeRecall(results, K, latencies),
+  };
+}
+
+/** The FACTS provider: keyword + recency recall over the `facts` table (no
+ *  vectors). Ingests labelled facts (one per query + distractors) and measures
+ *  whether `factsProvider.get` surfaces the right fact among the distractors. */
+async function runFactsProvider(
+  bench: BenchRuntime,
+  corpus: Corpus,
+): Promise<ModeReport> {
+  const facts = buildFacts(corpus.tier as CorpusTier);
+  // Insert facts as `facts`-table memories. id is tracked → query mapping.
+  const relevantByQuery = new Map<string, Set<string>>();
+  for (const fact of facts) {
+    const factMemId = uuid();
+    await bench.runtime.createMemory(
+      {
+        id: factMemId,
+        entityId: bench.agentId,
+        agentId: bench.agentId,
+        roomId: bench.agentId,
+        content: { text: fact.text },
+        metadata: {
+          kind: fact.kind,
+          category: "identity",
+          confidence: 0.9,
+          keywords: fact.keywords,
+        },
+        createdAt: Date.now(),
+      } as Memory,
+      "facts",
+    );
+    if (fact.relevantQueryId) {
+      const set = relevantByQuery.get(fact.relevantQueryId) ?? new Set();
+      set.add(factMemId);
+      relevantByQuery.set(fact.relevantQueryId, set);
+    }
+  }
+
+  const emptyState: State = { values: {}, data: {}, text: "" };
+  const results: QueryResult[] = [];
+  const latencies: number[] = [];
+  for (const q of corpus.queries) {
+    const message = makeMessage(bench, q.text);
+    const t0 = performance.now();
+    const res = await factsProvider.get(bench.runtime, message, emptyState);
+    latencies.push(performance.now() - t0);
+    const ranked = (res.data?.facts ?? []) as Array<{ id: UUID }>;
+    results.push({
+      retrieved: ranked.map((f) => f.id as string),
+      relevant: relevantByQuery.get(q.id) ?? new Set<string>(),
+    });
+  }
+  return {
+    mode: "facts-provider-keyword",
+    corpusSize: facts.length,
+    ...summarizeRecall(results, K, latencies),
+  };
+}
+
+// ── budget gate ───────────────────────────────────────────────────────────────
+
+function checkBudgets(modes: ModeReport[]): BudgetCheck[] {
+  const checks: BudgetCheck[] = [];
+  const byMode = new Map(modes.map((m) => [m.mode, m]));
+  for (const [modeName, rules] of Object.entries(budgets.modes)) {
+    const report = byMode.get(modeName);
+    if (!report?.measured) continue; // skipped rows never fail a budget
+    const r = rules as {
+      minRecallAt5?: number;
+      minNdcgAt5?: number;
+      maxP95LatencyMs?: number;
+    };
+    if (r.minRecallAt5 !== undefined) {
+      checks.push({
+        name: `${modeName}.minRecallAt5`,
+        value: report.recallAtK,
+        budget: r.minRecallAt5,
+        unit: "ratio",
+        pass: (report.recallAtK ?? 0) >= r.minRecallAt5,
+      });
+    }
+    if (r.minNdcgAt5 !== undefined) {
+      checks.push({
+        name: `${modeName}.minNdcgAt5`,
+        value: report.ndcgAtK,
+        budget: r.minNdcgAt5,
+        unit: "ratio",
+        pass: (report.ndcgAtK ?? 0) >= r.minNdcgAt5,
+      });
+    }
+    if (r.maxP95LatencyMs !== undefined) {
+      checks.push({
+        name: `${modeName}.maxP95LatencyMs`,
+        value: report.p95LatencyMs,
+        budget: r.maxP95LatencyMs,
+        unit: "ms",
+        pass: (report.p95LatencyMs ?? 0) <= r.maxP95LatencyMs,
+      });
+    }
+  }
+  return checks;
+}
+
+// ── main ──────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<number> {
+  const { tier, out } = parseArgs(process.argv.slice(2));
+  const corpus = buildCorpus(tier);
+  const bench = await buildBenchRuntime();
+
+  // Ingest the labelled corpus through the REAL DocumentService.
+  const docIdByMemId = new Map<string, string>();
+  for (const doc of corpus.docs) {
+    const res = await bench.documents.addDocument({
+      worldId: bench.agentId,
+      roomId: bench.agentId,
+      entityId: bench.agentId,
+      clientDocumentId: uuid(),
+      contentType: "text/plain",
+      originalFilename: `${doc.id}.txt`,
+      // addDocument expects base64-encoded file bytes for text documents (the
+      // service base64-decodes them); encode so the heuristic decodes cleanly.
+      content: Buffer.from(doc.text, "utf8").toString("base64"),
+    });
+    docIdByMemId.set(res.storedDocumentMemoryId, doc.id);
+  }
+
+  const hybrid = await runDocumentMode(
+    bench,
+    corpus,
+    docIdByMemId,
+    "hybrid",
+    "document-hybrid",
+  );
+  const vector = await runDocumentMode(
+    bench,
+    corpus,
+    docIdByMemId,
+    "vector",
+    "document-vector",
+  );
+  const keyword = await runDocumentMode(
+    bench,
+    corpus,
+    docIdByMemId,
+    "keyword",
+    "document-keyword",
+  );
+  const searchMem = await runSearchMemories(bench, corpus, docIdByMemId);
+  const keywordChat = await runKeywordChat(bench, corpus, docIdByMemId);
+  const factsProv = await runFactsProvider(bench, corpus);
+
+  // Fail-open: make the QUERY embedder throw → embedRecallQuery returns null →
+  // _vectorSearch falls open to keyword. Re-run the vector mode and measure the
+  // recall drop — the silent degradation #9956 asks us to make observable.
+  // Mint a fresh run id first: embedRecallQuery memoizes successful query
+  // embeddings per-run-id, so without this the throw would be masked by the
+  // vectors cached during the healthy `document-vector` slice above.
+  bench.runtime.startRun();
+  bench.setEmbedMode("throw");
+  const failOpen = await runDocumentMode(
+    bench,
+    corpus,
+    docIdByMemId,
+    "vector",
+    "document-vector-failopen",
+  );
+  bench.setEmbedMode("ok");
+
+  await bench.cleanup();
+
+  const modes: ModeReport[] = [
+    hybrid,
+    vector,
+    keyword,
+    searchMem,
+    keywordChat,
+    factsProv,
+    failOpen,
+  ];
+  const checks = checkBudgets(modes);
+
+  const failOpenDrop = (vector.recallAtK ?? 0) - (failOpen.recallAtK ?? 0);
+  const failOpenObservable =
+    failOpenDrop >= budgets.failOpen.minObservableRecallDrop;
+  checks.push({
+    name: "failOpen.minObservableRecallDrop",
+    value: failOpenDrop,
+    budget: budgets.failOpen.minObservableRecallDrop,
+    unit: "ratio",
+    pass: failOpenObservable,
+  });
+
+  const report = {
+    benchmark: "recall-bench",
+    generatedAt: new Date().toISOString(),
+    corpus: {
+      committed: true,
+      tier: corpus.tier,
+      topics: corpus.topics,
+      documents: corpus.docs.length,
+      queries: corpus.queries.length,
+    },
+    k: K,
+    modes,
+    failOpen: {
+      vectorRecallAt5: vector.recallAtK,
+      failOpenRecallAt5: failOpen.recallAtK,
+      recallDrop: failOpenDrop,
+      observable: failOpenObservable,
+    },
+    // The single score the orchestrator extracts — hybrid is production default.
+    metrics: {
+      overall_recall_at_5: hybrid.recallAtK,
+      overall_ndcg_at_5: hybrid.ndcgAtK,
+      overall_p95_latency_ms: hybrid.p95LatencyMs,
+    },
+    checks,
+  };
+
+  mkdirSync(out, { recursive: true });
+  const outFile = join(out, "recall-bench-results.json");
+  writeFileSync(outFile, `${JSON.stringify(report, null, 2)}\n`);
+
+  const measuredCount = modes.filter((m) => m.measured).length;
+  const pass = checks.every((c) => c.pass);
+  for (const m of modes) {
+    console.log(
+      `[recall-bench] ${m.mode}: recall@5=${fmt(m.recallAtK)} ndcg@5=${fmt(m.ndcgAtK)} p95=${fmt(m.p95LatencyMs)}ms (${m.measured ? "measured" : `skip: ${m.skipReason}`})`,
+    );
+  }
+  console.log(
+    `[recall-bench] fail-open recall drop ${fmt(failOpenDrop)} (observable=${failOpenObservable})`,
+  );
+  console.log(`[recall-bench] → ${outFile}`);
+  console.log(
+    `[recall-bench] budgets ${pass ? "PASS" : "FAIL"} (${checks.filter((c) => c.pass).length}/${checks.length})`,
+  );
+
+  if (measuredCount === 0) return 2;
+  return pass ? 0 : 1;
+}
+
+function fmt(n: number | null): string {
+  return n === null ? "null" : n.toFixed(3);
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((err) => {
+    console.error("[recall-bench] fatal:", err);
+    process.exit(1);
+  });

--- a/packages/benchmarks/recall-bench/runtime.ts
+++ b/packages/benchmarks/recall-bench/runtime.ts
@@ -1,0 +1,126 @@
+/**
+ * recall-bench — a headless, secret-free REAL runtime (#9956).
+ *
+ * Builds an `AgentRuntime` backed by `@elizaos/plugin-sql` + PGlite (embedded
+ * WASM Postgres with real pgvector cosine — no DB server, no secrets) and the
+ * real `DocumentService`, with this bench's deterministic embedding registered
+ * as the `TEXT_EMBEDDING` model. The bench drives the SAME `addDocument` /
+ * `searchDocuments` / `searchMemories` code shipped to users — not a re-impl.
+ *
+ * Construction mirrors plugin-sql's own `createIsolatedTestDatabase` (the
+ * canonical integration-test bootstrap): PGlite manager → adapter → runtime
+ * (`enableDocuments`) → register adapter + embedding → run plugin migrations →
+ * create the agent → `initialize()` (starts `DocumentService`).
+ *
+ * A mutable `embedMode` lets the fail-open slice flip the query embedder to
+ * throw mid-run — so `embedRecallQuery` returns null and `_vectorSearch` falls
+ * open to keyword, exactly the silent degradation #9956 asks us to make visible.
+ */
+
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  AgentRuntime,
+  type Character,
+  DocumentService,
+  ModelType,
+  type UUID,
+} from "@elizaos/core";
+import {
+  createDatabaseAdapter,
+  DatabaseMigrationService,
+  plugin as sqlPlugin,
+} from "@elizaos/plugin-sql";
+import { embedText, RECALL_BENCH_EMBEDDING_DIM } from "./embedding.ts";
+
+export type EmbedMode = "ok" | "throw";
+
+export interface BenchRuntime {
+  runtime: AgentRuntime;
+  documents: DocumentService;
+  agentId: UUID;
+  /** Flip to "throw" to make the QUERY embedder fail (fail-open regression). */
+  setEmbedMode(mode: EmbedMode): void;
+  cleanup(): Promise<void>;
+}
+
+const BENCH_CHARACTER: Character = {
+  name: "recall-bench",
+  bio: ["A headless agent used to benchmark memory recall."],
+};
+
+/** Build + initialize the real runtime. Caller must `await cleanup()`. */
+export async function buildBenchRuntime(): Promise<BenchRuntime> {
+  const agentId = crypto.randomUUID() as UUID;
+  const tempDir = mkdtempSync(join(tmpdir(), "recall-bench-"));
+
+  // The factory creates an embedded PGlite (WASM Postgres) adapter — no server,
+  // no secrets — and is the only public entry (the manager/adapter classes are
+  // not re-exported). `init()` brings up the embedded database.
+  const adapter = createDatabaseAdapter({ dataDir: tempDir }, agentId);
+  await adapter.init();
+
+  const runtime = new AgentRuntime({
+    character: { ...BENCH_CHARACTER, id: undefined },
+    agentId,
+    plugins: [sqlPlugin],
+    settings: { CTX_DOCUMENTS_ENABLED: "false" },
+  });
+  runtime.registerDatabaseAdapter(adapter);
+
+  // Deterministic, secret-free embedding. A mutable mode lets the fail-open
+  // slice make the QUERY embed throw without disturbing already-stored vectors.
+  const mode = { current: "ok" as EmbedMode };
+  runtime.registerModel(
+    ModelType.TEXT_EMBEDDING,
+    async (_rt: unknown, params: { text?: string } | string | null) => {
+      const text = typeof params === "string" ? params : (params?.text ?? "");
+      if (mode.current === "throw") {
+        throw new Error("[recall-bench] forced embed failure (fail-open test)");
+      }
+      return embedText(text, RECALL_BENCH_EMBEDDING_DIM);
+    },
+    "recall-bench",
+  );
+
+  const migration = new DatabaseMigrationService();
+  // biome-ignore lint/suspicious/noExplicitAny: drizzle db type is adapter-internal
+  await migration.initializeWithDatabase(adapter.getDatabase() as any);
+  migration.discoverAndRegisterPluginSchemas([sqlPlugin]);
+  await migration.runAllPluginMigrations();
+
+  const created = await adapter.createAgent({
+    ...BENCH_CHARACTER,
+    id: agentId,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  });
+  if (!created) throw new Error("[recall-bench] failed to create bench agent");
+
+  await runtime.initialize();
+
+  // Construct DocumentService directly against the real runtime (the pattern
+  // core's own document-search test uses) — this drives the SAME ingest/search
+  // code, and avoids the `getService` native-feature gate that a bare runtime
+  // (no agent feature-wiring) leaves off. `start()` runs config validation +
+  // the (disabled) startup loaders; we only need the ingest/search methods.
+  const documents = await DocumentService.start(runtime);
+
+  return {
+    runtime,
+    documents,
+    agentId,
+    setEmbedMode: (m) => {
+      mode.current = m;
+    },
+    cleanup: async () => {
+      try {
+        await adapter.close();
+      } finally {
+        if (existsSync(tempDir))
+          rmSync(tempDir, { recursive: true, force: true });
+      }
+    },
+  };
+}

--- a/packages/benchmarks/recall-bench/scripts/check-registry.py
+++ b/packages/benchmarks/recall-bench/scripts/check-registry.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""recall-bench registry contract check (#9956).
+
+Fails (non-zero) if `recall_bench` is not discoverable in the orchestrator
+registry, if its command does not build, or if the `_score_from_recall_json`
+extractor cannot read the committed baseline. Keeps the Python registration
+honest in CI alongside the TS harness.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+BENCH_DIR = Path(__file__).resolve().parents[1]
+BENCHMARKS_DIR = BENCH_DIR.parent  # packages/benchmarks
+REPO_ROOT = BENCHMARKS_DIR.parents[1]  # eliza repo root
+
+sys.path.insert(0, str(BENCHMARKS_DIR))
+
+from registry.commands import get_benchmark_registry  # noqa: E402
+from registry.scores import _score_from_recall_json  # noqa: E402
+
+
+def main() -> int:
+    reg = get_benchmark_registry(REPO_ROOT)
+    by_id = {b.id: b for b in reg}
+    if "recall_bench" not in by_id:
+        print("FAIL: recall_bench not registered in registry/commands.py", file=sys.stderr)
+        return 1
+    rb = by_id["recall_bench"]
+
+    out = Path("/tmp/recall-registry-check")
+    cmd = rb.build_command(out, type("M", (), {"provider": "", "model": ""})(), {"tier": "1k"})
+    if cmd[0] != "bun" or "run.ts" not in cmd or "--tier" not in cmd:
+        print(f"FAIL: unexpected recall_bench command: {cmd}", file=sys.stderr)
+        return 1
+    if rb.locate_result(out).name != "recall-bench-results.json":
+        print("FAIL: unexpected recall_bench result path", file=sys.stderr)
+        return 1
+
+    baseline = BENCH_DIR / "baseline-1k.json"
+    score = _score_from_recall_json(json.loads(baseline.read_text()))
+    if not (0.0 <= score.score <= 1.0):
+        print(f"FAIL: baseline headline score out of range: {score.score}", file=sys.stderr)
+        return 1
+    if score.metrics.get("fail_open_observable") is not True:
+        print("FAIL: committed baseline does not show an observable fail-open", file=sys.stderr)
+        return 1
+
+    print(
+        f"OK: recall_bench registered; baseline Recall@5={score.score:.3f}, "
+        f"fail-open drop={score.metrics.get('fail_open_recall_drop')}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/benchmarks/registry/commands.py
+++ b/packages/benchmarks/registry/commands.py
@@ -38,6 +38,7 @@ try:
         _score_from_orchestrator_lifecycle_json,
         _score_from_osworld_json,
         _score_from_realm_json,
+        _score_from_recall_json,
         _score_from_rlmbench_json,
         _score_from_scambench_json,
         _score_from_social_alpha_json,
@@ -90,6 +91,7 @@ except ImportError:
         _score_from_orchestrator_lifecycle_json,
         _score_from_osworld_json,
         _score_from_realm_json,
+        _score_from_recall_json,
         _score_from_rlmbench_json,
         _score_from_scambench_json,
         _score_from_social_alpha_json,
@@ -465,6 +467,28 @@ def get_benchmark_registry(repo_root: Path) -> list[BenchmarkDefinition]:
 
     def _contextbench_result(output_dir: Path) -> Path:
         return find_latest_file(output_dir, glob_pattern="context_bench_*.json")
+
+    def _recall_cmd(output_dir: Path, model: ModelSpec, extra: Mapping[str, JSONValue]) -> list[str]:
+        # recall-bench (#9956): drives the REAL @elizaos/core recall path over a
+        # labeled, document-scale corpus. No model/provider — the embedding is a
+        # deterministic in-bench function, so it is secret-free and CI-safe.
+        tier = str(extra.get("tier") or "1k").strip().lower()
+        if tier not in {"smoke", "1k", "10k"}:
+            tier = "1k"
+        _ = model
+        # `--conditions=eliza-source` resolves @elizaos/* to workspace source.
+        return [
+            "bun",
+            "--conditions=eliza-source",
+            "run.ts",
+            "--tier",
+            tier,
+            "--out",
+            str(output_dir),
+        ]
+
+    def _recall_result(output_dir: Path) -> Path:
+        return output_dir / "recall-bench-results.json"
 
     def _terminalbench_cmd(output_dir: Path, model: ModelSpec, extra: Mapping[str, JSONValue]) -> list[str]:
         # Run module from its python project root.
@@ -2327,6 +2351,25 @@ def get_benchmark_registry(repo_root: Path) -> list[BenchmarkDefinition]:
             build_command=_contextbench_cmd,
             locate_result=_contextbench_result,
             extract_score=_score_from_contextbench_json,
+        ),
+        BenchmarkDefinition(
+            id="recall_bench",
+            display_name="RecallBench",
+            description="Precision/Recall/nDCG/latency over the real @elizaos/core memory-recall + knowledge-retrieval path (document-scale, per SearchMode, with a forced embed fail-open).",
+            cwd_rel="packages/benchmarks/recall-bench",
+            requirements=BenchmarkRequirements(
+                env_vars=(),
+                paths=(),
+                notes=(
+                    "Secret-free and CI-safe: drives the real DocumentService / "
+                    "searchMemories / FACTS path over a deterministic, committed "
+                    "labeled corpus with a deterministic in-bench embedding (no "
+                    "model/provider/credentials). 'tier' extra selects smoke/1k/10k."
+                ),
+            ),
+            build_command=_recall_cmd,
+            locate_result=_recall_result,
+            extract_score=_score_from_recall_json,
         ),
         BenchmarkDefinition(
             id="terminal_bench",

--- a/packages/benchmarks/registry/scores.py
+++ b/packages/benchmarks/registry/scores.py
@@ -219,6 +219,45 @@ def _score_from_contextbench_json(data: JSONValue) -> ScoreExtraction:
     )
 
 
+def _score_from_recall_json(data: JSONValue) -> ScoreExtraction:
+    """recall-bench (#9956): headline score is hybrid Recall@5 over the real
+    @elizaos/core document-recall path; surface the per-mode gap + fail-open drop.
+    """
+    root = expect_dict(data, ctx="recall:root")
+    metrics = expect_dict(
+        get_required(root, "metrics", ctx="recall:root"), ctx="recall:metrics"
+    )
+    recall = get_optional(metrics, "overall_recall_at_5")
+    if not isinstance(recall, (int, float)):
+        # Honesty contract: a null (unmeasured) headline is not publishable.
+        raise ValueError("recall: overall_recall_at_5 is null/unmeasured")
+    overall = float(recall)
+    fail_open = expect_dict(
+        get_required(root, "failOpen", ctx="recall:root"), ctx="recall:failOpen"
+    )
+    corpus = expect_dict(
+        get_required(root, "corpus", ctx="recall:root"), ctx="recall:corpus"
+    )
+    documents = expect_float(
+        get_required(corpus, "documents", ctx="recall:corpus"), ctx="recall:documents"
+    )
+    if documents <= 0:
+        raise ValueError("recall: empty corpus score is not publishable")
+    return ScoreExtraction(
+        score=overall,
+        unit="ratio",
+        higher_is_better=True,
+        metrics={
+            "overall_recall_at_5": overall,
+            "overall_ndcg_at_5": metrics.get("overall_ndcg_at_5"),
+            "overall_p95_latency_ms": metrics.get("overall_p95_latency_ms"),
+            "fail_open_recall_drop": fail_open.get("recallDrop"),
+            "fail_open_observable": fail_open.get("observable"),
+            "corpus_documents": documents,
+        },
+    )
+
+
 def _score_from_terminalbench_json(data: JSONValue) -> ScoreExtraction:
     root = expect_dict(data, ctx="terminal_bench:root")
     summary = expect_dict(get_required(root, "summary", ctx="terminal_bench:root"), ctx="terminal_bench:summary")


### PR DESCRIPTION
Closes #9956.

## What

A registered, document-scale, **CI-gated** Precision/Recall/nDCG/latency benchmark for the agent's memory-recall + knowledge-retrieval hot path — the code that decides *what context the model actually sees*. It drives the **real `@elizaos/core`** path (no Python reimpl, no mocked `searchMemories`):

- `DocumentService.searchDocuments` in all three `SearchMode`s (`hybrid`/`vector`/`keyword`), ingested through the real `DocumentService.addDocument`
- `AgentRuntime.searchMemories` (raw cosine path the providers ride)
- `factsProvider.get` (FACTS provider — keyword + recency, no vectors)
- `scoreMemoryText` (the keyword chat-search surface)
- a forced **fail-open**: `embedRecallQuery → null` so `_vectorSearch` falls open to keyword, and the recall drop is measured

The runtime is a real `AgentRuntime` backed by `@elizaos/plugin-sql` + **PGlite** (embedded WASM Postgres, real pgvector cosine) with a **deterministic in-bench embedding** — so it needs no model bundle and no credentials, and every number is byte-reproducible run-to-run and on CI.

## Why the corpus has three doc classes

`corpus.ts` is committed *as code* (seeded PRNG, diffable) with **relevant** / keyword-**confusable** / **noise** docs per topic. The confusables carry the query's exact base token but a foreign body: keyword/BM25 can't separate them from relevant, but the vector embedding ranks them out. That's what makes the embed fail-open a *measurable* recall drop rather than a silent one (the issue's core concern).

## Results (1k tier, deterministic — `baseline-1k.json`)

| mode | Recall@5 | nDCG@5 |
| --- | --- | --- |
| `document-hybrid` | 0.880 | 0.864 |
| `document-vector` | 0.715 | 0.684 |
| `document-keyword` | 0.370 | 0.422 |
| `searchMemories-vector` | 0.965 | 0.974 |
| `keyword-chat-scoreMemoryText` | 0.095 | 0.125 |
| `facts-provider-keyword` | 1.000 | 1.000 |
| `document-vector-failopen` | 0.370 | 0.422 |

**Fail-open recall drop = 0.345 (observable).** `budgets PASS (16/16)`.

## Acceptance criteria

- [x] Registered in `registry/commands.py` (`recall_bench`) + `registry/scores.py` (`_score_from_recall_json`); runnable via the orchestrator (contract checked by `scripts/check-registry.py`).
- [x] Committed labeled corpus (≥1k fragments, +10k tier) ingested through the real `DocumentService`, with ground-truth relevant ids.
- [x] Committed per-`SearchMode` P@K/R@K/MRR/nDCG/HitRate + p50/p95 JSON; `null` (never `0`) for unmeasured rows.
- [x] Hard fail-open assertion: forces `embedRecallQuery → null` and asserts a measured Recall drop vs the vector path.
- [x] `scoreMemoryText` keyword chat-search scored separately.
- [x] FACTS-provider recall slice.
- [x] `.github/workflows/recall-bench.yml` exits non-zero on a budget regression; green on baseline.

## Reproduce

```bash
bun run --cwd packages/shared build:i18n
bun run bench:recall:1k                                   # 1k gate
bun run --cwd packages/benchmarks/recall-bench test       # units
python3 packages/benchmarks/recall-bench/scripts/check-registry.py
```

## Evidence

`.github/issue-evidence/9956-recall-bench/` — metrics JSON, 1k run stdout, and the structured `[CORE:DOCUMENTS:RECALL-EMBED]` fail-open path logs (one per query). Screenshots/video/audio N/A (benchmark/CI harness, no UI/voice surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)