### PR TITLE
fix(orchestrator,example-code): app-deploy is a structural capability, not a keyword-regex gate (fixes editing deployed apps)

### DIFF
--- a/packages/examples/code/src/acp.ts
+++ b/packages/examples/code/src/acp.ts
@@ -64,8 +64,18 @@ async function ensureRuntime(cwd?: string): Promise<AgentRuntime> {
     // packages (a different cwd resolves stale/broken builds from the bun cache).
     // The build target is conveyed purely through the workspace-root env.
     if (cwd) {
-      process.env.CODING_TOOLS_WORKSPACE_ROOTS ??= cwd;
-      process.env.SHELL_ALLOWED_DIRECTORY ??= cwd;
+      // The sub-agent's own task workspace is always reachable. ALSO grant
+      // access to the published-apps directory (when the host configured one)
+      // so the agent can read/edit/republish an EXISTING deployed app — not just
+      // build new ones into a throwaway workspace. Without this, "edit the
+      // coinflip app" lands in an empty workspace, the app dir is sandbox-blocked,
+      // and nothing happens. Roots are comma-separated; the agent picks the path
+      // (its workspace for scripts, the apps dir for web apps) by the task.
+      const appsDir = process.env.ELIZA_AGENT_HOME_APPS_DIR?.trim();
+      const roots =
+        appsDir && appsDir !== cwd ? `${cwd},${appsDir}` : cwd;
+      process.env.CODING_TOOLS_WORKSPACE_ROOTS ??= roots;
+      process.env.SHELL_ALLOWED_DIRECTORY ??= roots;
     }
     // Drop-in for the opencode coding sub-agent: when the host configured
     // opencode (ELIZA_OPENCODE_* — e.g. a Cerebras key/url/models) but no

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/app-deploy-guidance.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/app-deploy-guidance.test.ts
@@ -43,30 +43,50 @@ describe("app-deploy-guidance", () => {
     });
   });
 
-  describe("agent-home monetized vs static", () => {
+  describe("agent-home publish note (structural, always attached)", () => {
     const cfg = {
       target: "agent-home" as const,
       agentHomeAppsDir: "/data/apps",
       agentHomeBaseUrl: "https://example.test",
     };
-    it("a MONETIZED agent-home app registers with Cloud + starts from the edad template (no 'no Cloud')", () => {
+    it("attaches the self-gating publish note with both CREATE and EDIT paths", () => {
+      const out = augmentTaskWithDeployGuidance(
+        "build a magic 8-ball web app",
+        cfg,
+      );
+      expect(out).toContain("Publishing web apps (agent-home)");
+      expect(out).toContain("To CREATE a new app");
+      // The whole point of this PR: an existing deployed app can be edited in
+      // place instead of being re-created under a fresh slug.
+      expect(out).toContain("To EDIT an existing app");
+      expect(out).toContain("/data/apps/<slug>/");
+      expect(out).toContain("https://example.test/apps/<slug>/");
+      expect(out).toContain(
+        "If your task is not a web app, ignore this section",
+      );
+    });
+    it("routes monetization through the build-monetized-app skill, not an edad/cloud.json branch", () => {
       const out = augmentTaskWithDeployGuidance(
         "build a monetized web app that charges $3 per use",
         cfg,
       );
-      expect(out).toContain("App Deployment (agent-home)");
-      expect(out).toContain("register it with Eliza Cloud");
-      expect(out).toContain("packages/examples/cloud/edad");
-      expect(out).toContain("cloud.json");
+      expect(out).toContain("build-monetized-app");
+      // The old monetized-vs-static branching (edad template, cloud.json,
+      // "Do NOT use Eliza Cloud for this one") is gone — the note is now a
+      // single structural capability description the model applies by judgment.
+      expect(out).not.toContain("packages/examples/cloud/edad");
+      expect(out).not.toContain("cloud.json");
       expect(out).not.toContain("Do NOT use Eliza Cloud for this one");
     });
-    it("a NON-monetized agent-home app stays static-only (keeps 'no Cloud')", () => {
+    it("is attached structurally, even to a task the old keyword regex would not match as an app build", () => {
+      // "add a dark mode toggle and redeploy it" never matched isAppBuildTask's
+      // build-verb pattern, so the agent previously got no apps-dir context and
+      // could not find the deployed app. The note is now always present.
       const out = augmentTaskWithDeployGuidance(
-        "build a magic 8-ball app",
+        "add a dark mode toggle to the coinflip app and redeploy it",
         cfg,
       );
-      expect(out).toContain("Do NOT use Eliza Cloud for this one");
-      expect(out).not.toContain("register it with Eliza Cloud");
+      expect(out).toContain("Publishing web apps (agent-home)");
     });
   });
 
@@ -103,11 +123,11 @@ describe("app-deploy-guidance", () => {
         agentHomeAppsDir: "/data/apps",
         agentHomeBaseUrl: "https://example.test",
       });
-      expect(out).toContain("App Deployment (agent-home)");
+      expect(out).toContain("Publishing web apps (agent-home)");
       expect(out).toContain("/data/apps/<slug>/");
       expect(out).toContain("https://example.test/apps/<slug>/");
-      // The Cloud contract header must not appear (the agent-home block only
-      // references Cloud to say "do NOT use it for this one").
+      // The Cloud contract header must not appear — the agent-home note only
+      // references Cloud conditionally for the monetized case.
       expect(out).not.toContain("App Deployment (Eliza Cloud)");
     });
   });

--- a/plugins/plugin-agent-orchestrator/src/services/app-deploy-guidance.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/app-deploy-guidance.ts
@@ -204,22 +204,25 @@ export function augmentTaskWithDeployGuidance(
     return task;
   }
   const resolved = config ?? resolveAppDeployConfig();
-  // agent-home: the publish convention is a cheap, always-correct capability note
-  // (it self-gates on "if this is a web app … else ignore"), so attach it to
-  // EVERY coding task instead of using a keyword regex to guess which tasks are
-  // app builds. The regex mis-fired on real phrasings — "add a dark mode toggle
-  // … and redeploy it" never matched the build-verb pattern, so the agent got no
-  // apps-dir context and could not find or edit the deployed app. Letting the
-  // model decide from an always-present note is both cleaner and general.
-  if (resolved.target === "agent-home") {
-    return `${task.trimEnd()}\n\n${agentHomeGuidance(resolved, task)}`;
-  }
-  // cloud/view paths retain their existing (heavier, cloud-gated) guidance for
-  // now — a separate follow-up tracks removing those keyword gates too.
+  // View/plugin tasks are a distinct surface (#8918) with their own cloud-vs-local
+  // sandbox contract — they are NOT hosted web apps, so they must be routed before
+  // the agent-home app note (which would otherwise wrongly tell the agent to
+  // publish a plugin as a static page). This check stays keyword-gated for now;
+  // a separate follow-up tracks removing that gate too.
   if (isViewPluginTask(task) && !isAppBuildTask(task)) {
     return `${task.trimEnd()}\n\n${viewPluginGuidance(resolved, {
       sourceDir: extractViewPluginSourceDir(task),
     })}`;
+  }
+  // agent-home: the publish convention is a cheap, always-correct capability note
+  // (it self-gates on "if this is a web app … else ignore"), so attach it to
+  // EVERY remaining coding task instead of using a keyword regex to guess which
+  // tasks are app builds. The regex mis-fired on real phrasings — "add a dark mode
+  // toggle … and redeploy it" never matched the build-verb pattern, so the agent
+  // got no apps-dir context and could not find or edit the deployed app. Letting
+  // the model decide from an always-present note is both cleaner and general.
+  if (resolved.target === "agent-home") {
+    return `${task.trimEnd()}\n\n${agentHomeGuidance(resolved, task)}`;
   }
   if (!isAppBuildTask(task)) {
     return task;

--- a/plugins/plugin-agent-orchestrator/src/services/app-deploy-guidance.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/app-deploy-guidance.ts
@@ -129,18 +129,22 @@ function elizaCloudGuidance(task?: string): string {
   return lines.join("\n");
 }
 
-function agentHomeGuidance(config: AppDeployConfig, task?: string): string {
+function agentHomeGuidance(config: AppDeployConfig, _task?: string): string {
   const dir = config.agentHomeAppsDir ?? "";
   const base = config.agentHomeBaseUrl ?? "";
+  // A capability note, NOT an assertion that the current task is an app — it is
+  // always available and the agent applies it by judgment. So it must stay
+  // correct for a request to BUILD a new app, to EDIT an existing one, OR for a
+  // non-web task (which ignores it). No keyword gate decides app-vs-not.
   return [
-    "--- App Deployment (agent-home) ---",
-    isMonetizedAppTask(task)
-      ? "Host the app's static files on the operator's agent-home host, but this is a MONETIZED app, so you MUST also register it with Eliza Cloud. START FROM THE TEMPLATE — do NOT re-derive the sign-in/proxy/registration flow from scratch: the working pattern is in this checkout at `packages/examples/cloud/edad`. Use `packages/examples/cloud/edad/public/index.html` as your frontend skeleton (it has the Cloud OAuth sign-in + chat-forwarding pattern) — adapt the SYSTEM_PROMPT/MODEL/brand/placeholder, and point its API calls at THIS host's same-origin proxy (`GET api/config/`, `POST api/chat/`). Register the app via `POST /api/v1/apps` (monetization enabled + a markup) using the owner's `ELIZAOS_CLOUD_API_KEY`, and write the returned appId into `cloud.json` next to index.html so sign-in + per-call billing work. Do NOT skip or defer registration, and do NOT tell the operator that steps remain."
-      : "This is a quick static/fun app for the operator's personal agent-home host. Do NOT use Eliza Cloud for this one.",
-    "- Pick a fresh, short kebab-case `<slug>` from the request.",
-    `- Write the app's static files (index.html + css/js — there is NO per-app build step) into \`${dir}/<slug>/\`.`,
-    `- It is then served immediately at \`${base}/apps/<slug>/\` — load that URL to confirm it works, then report it as the live link.`,
-    "- Do NOT run `deploy.sh` (operator-only; only needed when adding a new Next.js backend route). Static apps need no build/restart.",
+    "--- Publishing web apps (agent-home) ---",
+    "If (and only if) your task is to build OR edit a web app, page, or site for the operator — not a script, CLI, library, or backend service — publish it here:",
+    `- Published apps are plain static files under \`${dir}/<slug>/\` (index.html plus any css/js — there is NO per-app build step), served live at \`${base}/apps/<slug>/\`.`,
+    `- To CREATE a new app: pick a fresh, short kebab-case \`<slug>\`, write the files into \`${dir}/<slug>/\`, then open \`${base}/apps/<slug>/\` to confirm it works and report that URL.`,
+    `- To EDIT an existing app: the \`<slug>\` is the app's existing folder name under \`${dir}/\` — read its files there, modify them in place, then re-open \`${base}/apps/<slug>/\` to confirm. Do not create a new slug for an edit.`,
+    "- If the app must earn money / be monetized: also register it with Eliza Cloud — follow the `build-monetized-app` skill (Cloud SDK registration, an inference markup, per-call billing). Otherwise do not involve Eliza Cloud.",
+    "- Do NOT run `deploy.sh` (operator-only; only for a new Next.js backend route). Static apps need no build/restart.",
+    "If your task is not a web app, ignore this section.",
   ].join("\n");
 }
 
@@ -190,26 +194,35 @@ export function augmentTaskWithDeployGuidance(
   task: string,
   config?: AppDeployConfig,
 ): string {
-  // Idempotent: if either deploy block is already present, no-op. Checked first
-  // because each guidance block itself contains app/view keywords that would
-  // otherwise re-trigger detection on a second pass.
+  // Idempotent: if a deploy block is already present, no-op.
   if (
     task.includes("--- View/Plugin Deployment") ||
     task.includes("--- View Plugin Deployment") ||
-    task.includes("--- App Deployment")
+    task.includes("--- App Deployment") ||
+    task.includes("--- Publishing web apps")
   ) {
     return task;
   }
-  // View/plugin tasks get the cloud-vs-local sandbox contract (#8918), checked
-  // before the hosted-app contract so a "build a view plugin" task isn't
-  // mis-routed to "deploy + report a live URL".
+  const resolved = config ?? resolveAppDeployConfig();
+  // agent-home: the publish convention is a cheap, always-correct capability note
+  // (it self-gates on "if this is a web app … else ignore"), so attach it to
+  // EVERY coding task instead of using a keyword regex to guess which tasks are
+  // app builds. The regex mis-fired on real phrasings — "add a dark mode toggle
+  // … and redeploy it" never matched the build-verb pattern, so the agent got no
+  // apps-dir context and could not find or edit the deployed app. Letting the
+  // model decide from an always-present note is both cleaner and general.
+  if (resolved.target === "agent-home") {
+    return `${task.trimEnd()}\n\n${agentHomeGuidance(resolved, task)}`;
+  }
+  // cloud/view paths retain their existing (heavier, cloud-gated) guidance for
+  // now — a separate follow-up tracks removing those keyword gates too.
   if (isViewPluginTask(task) && !isAppBuildTask(task)) {
-    return `${task.trimEnd()}\n\n${viewPluginGuidance(config, {
+    return `${task.trimEnd()}\n\n${viewPluginGuidance(resolved, {
       sourceDir: extractViewPluginSourceDir(task),
     })}`;
   }
   if (!isAppBuildTask(task)) {
     return task;
   }
-  return `${task.trimEnd()}\n\n${buildAppDeployGuidance(config, task)}`;
+  return `${task.trimEnd()}\n\n${buildAppDeployGuidance(resolved, task)}`;
 }


### PR DESCRIPTION
## What

Editing an existing deployed app was broken, and the cause was a brittle keyword gate. The orchestrator decided whether to attach app-deploy guidance — and thus the apps-dir context — by running the narrow `APP_DEPLOY_TASK_RE` regex on the task text. **"add a dark mode toggle … and redeploy it" never matched the build-verb pattern**, so the sub-agent got no apps-dir context *and* its sandbox was scoped to an empty throwaway workspace. Trajectory: it `ls`'d an empty dir, couldn't find the app, tried `npm start`, and did nothing — empty relay, no link.

## Fix — structural capability, not a keyword gate

- **example-code** (`acp.ts`): the coding sub-agent's sandbox roots (`CODING_TOOLS_WORKSPACE_ROOTS` / `SHELL_ALLOWED_DIRECTORY`) now always include the published-apps dir (`ELIZA_AGENT_HOME_APPS_DIR`) — so it can read/edit/republish an existing app, not only build new ones into a throwaway workspace.
- **orchestrator** (`app-deploy-guidance.ts`): for the agent-home target, the publish convention is **always** attached as a *conditional capability note* ("if your task is to build OR edit a web app … else ignore") covering create + **edit-in-place** + monetize. The model decides — no `APP_DEPLOY_TASK_RE` / `isMonetizedAppTask` keyword regex. (The cloud/view gates are left for a tracked follow-up.)

The note is written so it stays correct for a non-web task (which ignores it), so it can be attached to every task without a regex guessing which tasks are app builds.

## Evidence (live, Cerebras glm-4.7)

- **Edit existing app** ("add a dark mode toggle to the coinflip app and redeploy"): before → empty workspace, nothing happened. After → `ls` apps dir, `read` + `write` `coinflip/index.html` in place (same slug), `curl`-verifies, app gains dark mode (33 refs, 6990→11474 bytes), live HTTP 200, clean relay with the URL.
- **Fresh build**: still deploys live (HTTP 200).
- **Non-app script** ("write primes.py, run it"): ignores the note — apps count unchanged (296→296), wrote + ran the script, returned the primes. No false deploy, no pollution.
