### PR TITLE
fix(plugin-elizacloud): stream RESPONSE_HANDLER reply tool-call args to SSE (cloud chat token-streaming)

### DIFF
--- a/plugins/plugin-elizacloud/__tests__/text-streaming.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/text-streaming.test.ts
@@ -8,7 +8,8 @@
  *
  * No live API — `requestRaw` is mocked to return constructed `Response`s.
  */
-import type { IAgentRuntime } from "@elizaos/core";
+import type { IAgentRuntime, ResponseSkeleton } from "@elizaos/core";
+import { ResponseSkeletonStreamExtractor } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 type Deferred = {
@@ -125,6 +126,19 @@ function dataFrame(obj: unknown): string {
 
 function contentDelta(text: string): unknown {
   return { choices: [{ index: 0, delta: { content: text } }] };
+}
+
+/**
+ * One SSE frame carrying a `delta.tool_calls[0]` fragment (index 0). The Stage-1
+ * RESPONSE_HANDLER reply forces this shape — Cerebras returns the envelope as
+ * tool-call ARGUMENT deltas, never `delta.content`.
+ */
+function toolCallDelta(args: string, opts: { id?: string; name?: string } = {}): unknown {
+  const fn: Record<string, unknown> = { arguments: args };
+  if (opts.name) fn.name = opts.name;
+  const call: Record<string, unknown> = { index: 0, function: fn };
+  if (opts.id) call.id = opts.id;
+  return { choices: [{ index: 0, delta: { tool_calls: [call] } }] };
 }
 
 async function readStream(result: { textStream: AsyncIterable<string> }): Promise<string[]> {
@@ -503,6 +517,153 @@ describe("streamNativeChatCompletion", () => {
     expect(resolveStreamingEnabled()).toBe(true);
     delete process.env.ELIZAOS_CLOUD_STREAMING;
     expect(resolveStreamingEnabled()).toBe(true);
+  });
+});
+
+/**
+ * The Stage-1 RESPONSE_HANDLER call sets `tool_choice:"required"`, so Cerebras
+ * returns the whole reply envelope (incl. `replyText`) as tool-call ARGUMENT
+ * deltas — never `delta.content`. Without surfacing those into the textStream the
+ * runtime's structured extractor sees nothing and the reply lands all at once.
+ * These tests pin that the reply args ARE streamed (only on the structured
+ * `streamStructured` path), de-duped against Cerebras's aggregated re-send, and
+ * that the runtime extractor reduces the streamed envelope to ONLY `replyText`
+ * (no control-field leak).
+ */
+describe("streamNativeChatCompletion — forced HANDLE_RESPONSE reply envelope", () => {
+  function structuredParams(): never {
+    // streamStructured===true is what gates tool-call-argument streaming.
+    return {
+      prompt: "hi",
+      providerOptions: { eliza: {} },
+      streamStructured: true,
+    } as never;
+  }
+
+  beforeEach(() => {
+    transport.reset();
+    nextResponse = null;
+    requestRaw.mockClear();
+    delete process.env.ELIZAOS_CLOUD_NATIVE_CONCURRENCY;
+    delete process.env.ELIZAOS_CLOUD_STREAMING;
+    __resetNativeChatLimiterForTests();
+  });
+  afterEach(() => {
+    delete process.env.ELIZAOS_CLOUD_STREAMING;
+    __resetNativeChatLimiterForTests();
+  });
+
+  it("surfaces tool-call argument deltas incrementally as the envelope grows", async () => {
+    nextResponse = sseResponse([
+      dataFrame(toolCallDelta("", { id: "call_1", name: "HANDLE_RESPONSE" })),
+      dataFrame(toolCallDelta('{"shouldRespond":"RESPOND","contexts":["general"],')),
+      dataFrame(toolCallDelta('"replyText":"On it ')),
+      dataFrame(toolCallDelta('now."}')),
+      dataFrame({ choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }] }),
+      "data: [DONE]\n\n",
+    ]);
+
+    const result = await streamNativeChatCompletion(
+      fakeRuntime(),
+      "RESPONSE_HANDLER" as never,
+      structuredParams(),
+      { modelName: "gpt-oss-120b", prompt: "hi" }
+    );
+
+    const chunks = await readStream(result);
+    // Streamed across MULTIPLE chunks (the bug = one final blob).
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.join("")).toBe(
+      '{"shouldRespond":"RESPOND","contexts":["general"],"replyText":"On it now."}'
+    );
+    // The authoritative deduped tool call is still surfaced for downstream parse.
+    const toolCalls = await (result as { toolCalls: Promise<unknown[]> }).toolCalls;
+    expect(toolCalls).toEqual([
+      {
+        type: "tool-call",
+        toolCallId: "call_1",
+        toolName: "HANDLE_RESPONSE",
+        input: { shouldRespond: "RESPOND", contexts: ["general"], replyText: "On it now." },
+      },
+    ]);
+  });
+
+  it("does NOT double when Cerebras re-sends the complete envelope in a final frame", async () => {
+    const full = '{"shouldRespond":"RESPOND","replyText":"PONG"}';
+    nextResponse = sseResponse([
+      dataFrame(toolCallDelta("", { id: "call_1", name: "HANDLE_RESPONSE" })),
+      dataFrame(toolCallDelta('{"shouldRespond":"RESPOND","replyText":"PO')),
+      dataFrame(toolCallDelta('NG"}')),
+      // Aggregated re-send re-carrying id + name + the COMPLETE object.
+      dataFrame(toolCallDelta(full, { id: "call_1", name: "HANDLE_RESPONSE" })),
+      "data: [DONE]\n\n",
+    ]);
+
+    const result = await streamNativeChatCompletion(
+      fakeRuntime(),
+      "RESPONSE_HANDLER" as never,
+      structuredParams(),
+      { modelName: "gpt-oss-120b", prompt: "hi" }
+    );
+
+    // The envelope is streamed exactly once — the re-send adds nothing.
+    expect((await readStream(result)).join("")).toBe(full);
+  });
+
+  it("stays buffered (no tool-arg streaming) when streamStructured is absent", async () => {
+    nextResponse = sseResponse([
+      dataFrame(toolCallDelta("", { id: "call_1", name: "HANDLE_RESPONSE" })),
+      dataFrame(toolCallDelta('{"replyText":"hi"}')),
+      "data: [DONE]\n\n",
+    ]);
+
+    const result = await streamNativeChatCompletion(
+      fakeRuntime(),
+      "RESPONSE_HANDLER" as never,
+      nativeParams(), // no streamStructured
+      { modelName: "gpt-oss-120b", prompt: "hi" }
+    );
+
+    // Nothing reaches the UI token stream — the planner/non-structured shape must
+    // not leak its raw tool-call args.
+    expect(await readStream(result)).toEqual([]);
+    const toolCalls = await (result as { toolCalls: Promise<unknown[]> }).toolCalls;
+    expect(toolCalls).toHaveLength(1);
+  });
+
+  it("runtime extractor reduces the streamed envelope to ONLY replyText (no control-field leak)", async () => {
+    nextResponse = sseResponse([
+      dataFrame(toolCallDelta("", { id: "call_1", name: "HANDLE_RESPONSE" })),
+      dataFrame(toolCallDelta('{"shouldRespond":"RESPOND","contexts":["general"],"intents":[],')),
+      dataFrame(toolCallDelta('"replyText":"On it ')),
+      dataFrame(toolCallDelta('now.","facts":[]}')),
+      "data: [DONE]\n\n",
+    ]);
+
+    const result = await streamNativeChatCompletion(
+      fakeRuntime(),
+      "RESPONSE_HANDLER" as never,
+      structuredParams(),
+      { modelName: "gpt-oss-120b", prompt: "hi" }
+    );
+
+    // Feed the streamed chunks through the same extractor the runtime uses for the
+    // RESPONSE_HANDLER reply (unordered, streamFields=["replyText"]).
+    const visible: string[] = [];
+    const skeleton: ResponseSkeleton = { spans: [], id: "test" };
+    const extractor = new ResponseSkeletonStreamExtractor({
+      skeleton,
+      streamFields: ["replyText"],
+      unordered: true,
+      onChunk: (chunk) => visible.push(chunk),
+    });
+    for await (const chunk of result.textStream) extractor.push(chunk);
+    extractor.flush();
+
+    expect(visible.join("")).toBe("On it now.");
+    // The control fields were carried in the streamed envelope but never surfaced.
+    expect(visible.join("")).not.toContain("shouldRespond");
+    expect(visible.join("")).not.toContain("contexts");
   });
 });
 

--- a/plugins/plugin-elizacloud/src/models/text.ts
+++ b/plugins/plugin-elizacloud/src/models/text.ts
@@ -1305,6 +1305,20 @@ export function accumulateToolCallDeltas(
   }
 }
 
+/**
+ * Accumulated arguments of the lowest-index streamed tool call. The Stage-1
+ * RESPONSE_HANDLER reply forces a single HANDLE_RESPONSE call (index 0), so this
+ * is the reply envelope (`{"shouldRespond":...,"replyText":...}`) as it grows.
+ * Returns "" before any call has appeared in the stream.
+ */
+export function lowestIndexToolCallArgs(acc: Map<number, StreamingToolCallAcc>): string {
+  let lowest: number | undefined;
+  for (const index of acc.keys()) {
+    if (lowest === undefined || index < lowest) lowest = index;
+  }
+  return lowest === undefined ? "" : (acc.get(lowest)?.args ?? "");
+}
+
 /** Materialize accumulated tool-call deltas into the buffered-path shape. */
 export function finalizeStreamedToolCalls(
   acc: Map<number, StreamingToolCallAcc>
@@ -1473,6 +1487,19 @@ export async function streamNativeChatCompletion(
   const finishD = deferred<string | undefined>();
   const toolCallsD = deferred<NativeToolCall[]>();
 
+  // Stage-1 RESPONSE_HANDLER forces `tool_choice:"required"`, so Cerebras returns
+  // the whole reply envelope (incl. `replyText`) as tool-call ARGUMENT deltas —
+  // never `delta.content`. Surface those into the textStream so the runtime's
+  // ResponseSkeletonStreamExtractor can emit `replyText` token-by-token (it
+  // filters to the visible reply span, so control fields never leak to the UI).
+  // Gated to the structured reply path (`streamStructured`, the only caller that
+  // reaches the streaming branch); planner/other native calls keep args buffered.
+  // `streamedReplyArgs` tracks what we've already surfaced so the Cerebras final
+  // aggregated re-send (which replaces the accumulator) is not re-emitted twice.
+  const streamReplyToolArgs =
+    (params as { streamStructured?: boolean }).streamStructured === true;
+  let streamedReplyArgs = "";
+
   async function* generate(): AsyncGenerator<string> {
     try {
       for await (const frame of parseOpenAiSseStream(body)) {
@@ -1494,6 +1521,23 @@ export async function streamNativeChatCompletion(
         }
         if (delta.tool_calls) {
           accumulateToolCallDeltas(toolAcc, delta.tool_calls);
+          if (streamReplyToolArgs) {
+            const replyArgs = lowestIndexToolCallArgs(toolAcc);
+            if (
+              replyArgs.length > streamedReplyArgs.length &&
+              replyArgs.startsWith(streamedReplyArgs)
+            ) {
+              const suffix = replyArgs.slice(streamedReplyArgs.length);
+              streamedReplyArgs = replyArgs;
+              accumulated += suffix;
+              yield suffix;
+            } else if (replyArgs && replyArgs !== streamedReplyArgs) {
+              // Aggregated re-send replaced the accumulator (possibly with a
+              // case-divergent copy); the incremental preview is already on the
+              // wire — advance the cursor without re-streaming a duplicate.
+              streamedReplyArgs = replyArgs;
+            }
+          }
         }
         const fr = firstString(choice.finish_reason);
         if (fr) finishReason = fr;


### PR DESCRIPTION
## Problem (measured on real hardware)

Cloud-agent chat streams over `POST /api/conversations/:id/messages/stream` (SSE). On-device CDP capture proves the reply arrives **all at once** — a single ~489B `dataReceived` event at ~13–16s — not token-by-token. The user waits the whole turn with no streamed tokens.

The SSE handler (`initSse` with `X-Accel-Buffering: no`, heartbeats, `writeChatTokenSse`), the client (`sendConversationMessageStream`), and the runtime streaming machinery (`ResponseSkeletonStreamExtractor`, streaming-context-gated `useModel`) are **all already correct**. The break is one layer down.

## Root cause

The Stage-1 `RESPONSE_HANDLER` call forces `tool_choice:"required"` (the `HANDLE_RESPONSE` tool), so Cerebras returns the entire reply envelope — including `replyText` — as **tool-call argument deltas** (`delta.tool_calls[].function.arguments`), **never** `delta.content`.

But `streamNativeChatCompletion.generate()` only `yield`ed `delta.content`. Tool-call argument deltas were accumulated for the *final* `toolCalls` and never fed into the `textStream`. So the runtime's `for await` over `textStream` got zero chunks → the extractor emitted nothing → `onChunk` fired once at the end → the reply landed all-at-once.

## Fix (`plugins/plugin-elizacloud/src/models/text.ts`, +44)

When `streamStructured === true` (only the Stage-1 structured-reply path sets this), surface the growing lowest-index tool-call args into the `textStream`, diffed against an already-streamed cursor so Cerebras's aggregated re-send (which replaces the accumulator, sometimes case-divergent) isn't re-emitted. The runtime's `ResponseSkeletonStreamExtractor` then emits only the visible `replyText` span token-by-token (control fields never leak).

## Why it's safe (non-SSE fallback guaranteed by construction)

- New behavior gates on `streamStructured===true`, set **only** by the Stage-1 RESPONSE_HANDLER call, which is itself gated upstream by `wantsStream` (requires `params.stream`, set by the runtime **only** when a `runWithStreamingContext` context is active, i.e. the SSE chat path) + the `ELIZAOS_CLOUD_STREAMING` flag (on by default; `=0` kill-switch).
- Every non-SSE caller (planner, all non-cloud-chat paths) flows through the unchanged buffered path.
- No core-runtime changes. Final-result integrity preserved: `finalizeStreamedToolCalls` (the authoritative deduped envelope) is untouched, and downstream Stage-1 parsing prioritizes the tool call over `text`.

## Tests

- `plugins/plugin-elizacloud/__tests__/text-streaming.test.ts`: **+4 tests** for the Cerebras tool-call-argument stream shape (the prior 30 only streamed `delta.content` — a genuine coverage gap). **34 pass, 0 fail** locally. Full plugin suite: 249 pass. Core streaming + agent SSE suites: green.

## Verification note

The on-device empirical proof (tokens visibly streaming) requires building an agent image with this change and deploying it to a test agent — I'll do that and post the before/after on #8434. The change is **safe regardless**: if a gateway ever returned the reply as `delta.content` instead, that path already streams and this only *adds* handling for the tool-call shape; it never touches the content path.

Refs #8434. Scoped to `plugin-elizacloud`; holding for review rather than self-merging a chat-path change with live paying agents.
