### PR TITLE
fix(discord): dispatch DMs directly, bypass message-debouncer

### DIFF
--- a/plugins/plugin-discord/__tests__/discord-events-dm-dispatch.test.ts
+++ b/plugins/plugin-discord/__tests__/discord-events-dm-dispatch.test.ts
@@ -1,0 +1,149 @@
+import { EventEmitter } from "node:events";
+import { ChannelType as DiscordChannelType } from "discord.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mirror the debouncer mock shape from discord-events-config.test.ts so we can
+// assert whether DM/channel messages were enqueued vs dispatched directly.
+const debouncerState = vi.hoisted(() => {
+	const messageEnqueue = vi.fn();
+	const channelEnqueue = vi.fn();
+	return {
+		messageEnqueue,
+		channelEnqueue,
+		createChannelDebouncer: vi.fn(() => ({
+			destroy: vi.fn(),
+			enqueue: channelEnqueue,
+			flushAll: vi.fn(),
+			markResponded: vi.fn(),
+			pendingCount: vi.fn(() => 0),
+		})),
+		createMessageDebouncer: vi.fn(() => ({
+			destroy: vi.fn(),
+			enqueue: messageEnqueue,
+			flushAll: vi.fn(),
+			pendingCount: vi.fn(() => 0),
+		})),
+	};
+});
+
+vi.mock("../debouncer", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../debouncer")>();
+	return {
+		...actual,
+		createChannelDebouncer: debouncerState.createChannelDebouncer,
+		createMessageDebouncer: debouncerState.createMessageDebouncer,
+	};
+});
+
+import { setupDiscordEventListeners } from "../discord-events";
+
+const BOT_ID = "123";
+
+function makeService() {
+	const client = new EventEmitter() as EventEmitter & {
+		user?: { id: string };
+	};
+	client.user = { id: BOT_ID };
+	return {
+		accountId: "test",
+		allowAllSlashCommands: new Set(),
+		allowedChannelIds: undefined,
+		buildMemoryFromMessage: vi.fn(),
+		character: {},
+		client,
+		discordSettings: {
+			shouldIgnoreBotMessages: true,
+			shouldRespondOnlyToMentions: false,
+		},
+		getChannelType: vi.fn(),
+		handleGuildCreate: vi.fn(),
+		handleGuildMemberAdd: vi.fn(),
+		handleInteractionCreate: vi.fn(),
+		handleReactionAdd: vi.fn(),
+		handleReactionRemove: vi.fn(),
+		isChannelAllowed: vi.fn(() => true),
+		messageDebouncer: undefined,
+		messageManager: { handleMessage: vi.fn() },
+		resolveDiscordEntityId: vi.fn(),
+		runtime: {
+			agentId: "agent",
+			emitEvent: vi.fn(),
+			getSetting: vi.fn(() => undefined),
+			logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+		},
+		slashCommands: [],
+		timeouts: [],
+		userSelections: new Map(),
+		voiceManager: undefined,
+	};
+}
+
+function makeMessage(channelType: DiscordChannelType, channelId: string) {
+	return {
+		id: `msg-${channelId}`,
+		content: "hello",
+		author: { id: "user-1", bot: false, username: "alice" },
+		channel: { id: channelId, type: channelType },
+	};
+}
+
+// Let the async messageCreate handler settle (it awaits handleMessage).
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+describe("setupDiscordEventListeners — DM dispatch", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("dispatches DMs directly to handleMessage, bypassing the message-debouncer", async () => {
+		const service = makeService();
+		// The message-debouncer is wired by setup; the DM path must still bypass it.
+		const { messageDebouncer } = setupDiscordEventListeners(service as never);
+		service.messageDebouncer = messageDebouncer as never;
+
+		service.client.emit(
+			"messageCreate",
+			makeMessage(DiscordChannelType.DM, "dm-1"),
+		);
+		await tick();
+
+		expect(service.messageManager.handleMessage).toHaveBeenCalledTimes(1);
+		expect(debouncerState.messageEnqueue).not.toHaveBeenCalled();
+		expect(debouncerState.channelEnqueue).not.toHaveBeenCalled();
+	});
+
+	it("dispatches group DMs directly to handleMessage, bypassing the message-debouncer", async () => {
+		const service = makeService();
+		const { messageDebouncer } = setupDiscordEventListeners(service as never);
+		service.messageDebouncer = messageDebouncer as never;
+
+		service.client.emit(
+			"messageCreate",
+			makeMessage(DiscordChannelType.GroupDM, "gdm-1"),
+		);
+		await tick();
+
+		expect(service.messageManager.handleMessage).toHaveBeenCalledTimes(1);
+		expect(debouncerState.messageEnqueue).not.toHaveBeenCalled();
+		expect(debouncerState.channelEnqueue).not.toHaveBeenCalled();
+	});
+
+	it("still routes guild-channel messages through the channel debouncer/enqueue path", async () => {
+		const service = makeService();
+		const { messageDebouncer, channelDebouncer } = setupDiscordEventListeners(
+			service as never,
+		);
+		service.messageDebouncer = messageDebouncer as never;
+		service.channelDebouncer = channelDebouncer as never;
+
+		service.client.emit(
+			"messageCreate",
+			makeMessage(DiscordChannelType.GuildText, "channel-1"),
+		);
+		await tick();
+
+		expect(debouncerState.channelEnqueue).toHaveBeenCalledTimes(1);
+		expect(service.messageManager.handleMessage).not.toHaveBeenCalled();
+		expect(debouncerState.messageEnqueue).not.toHaveBeenCalled();
+	});
+});

--- a/plugins/plugin-discord/discord-events.ts
+++ b/plugins/plugin-discord/discord-events.ts
@@ -489,11 +489,10 @@ export function setupDiscordEventListeners(service: DiscordServiceInternals): {
 				channelType === DiscordChannelType.GroupDM;
 
 			if (isDm) {
-				if (service.messageDebouncer) {
-					service.messageDebouncer.enqueue(message);
-				} else {
-					await service.messageManager.handleMessage(message);
-				}
+				// DMs are 1:1 and gain nothing from debouncing; the
+				// message-debouncer enqueue/flush path can intermittently drop
+				// them, leaving the bot silent. Dispatch DMs directly.
+				await service.messageManager.handleMessage(message);
 			} else if (service.channelDebouncer) {
 				service.channelDebouncer.enqueue(message);
 			} else if (service.messageDebouncer) {


### PR DESCRIPTION
## Summary
- DIRECT MESSAGES were intermittently dropped in `@elizaos/plugin-discord`: the gateway `messageCreate` fired for a DM, but the message-debouncer's enqueue/flush path could lose it, so `handleMessage` never ran and the bot stayed silent
- the message-debouncer is built for high-traffic channel batching; DMs are 1:1 and gain nothing from it
- dispatch DMs (and group DMs) directly to `handleMessage`; channel-message behavior is unchanged (still routes through the channel/message debouncer)

## Diff
6-line change in the `isDm` branch of `setupDiscordEventListeners` (`discord-events.ts`). Self/bot/interaction guards above the branch and the channel/group `else if` chain are untouched; `handleMessage` stays inside the same try/catch.

## Tests
- new `plugins/plugin-discord/__tests__/discord-events-dm-dispatch.test.ts`: DM -> `handleMessage` called once, NOT enqueued on the message-debouncer; group DM -> same; guild-channel -> channel debouncer enqueued, `handleMessage` not called directly (3/3 pass)
- existing `discord-events-config.test.ts` still passes (4/4, no regression)
- `biome check` clean on both files
