### PR TITLE
fix(feed): Google/OAuth login bounce — capture callback fragment before App Router strips it

### DIFF
--- a/packages/feed/apps/web/src/app/auth/callback/[provider]/page.tsx
+++ b/packages/feed/apps/web/src/app/auth/callback/[provider]/page.tsx
@@ -21,6 +21,23 @@ function isFeedOAuthProvider(value: string): value is FeedStewardOAuthProvider {
 }
 
 /**
+ * Snapshot of the OAuth params, captured at client module-eval time.
+ *
+ * Steward returns the one-time code in the URL *fragment* (`#code=…`). Next.js's
+ * App Router normalizes the URL during hydration and drops the fragment before
+ * our mount effect runs, so reading `window.location.hash` inside the effect
+ * intermittently sees an empty hash and bounces the user back to `/` with
+ * `auth_error=missing_code`. Module scope runs as the route chunk first
+ * executes — earlier than the router's normalization — so the fragment is still
+ * present here. The effect prefers this snapshot and only falls back to the live
+ * location (for the legacy `?token=` query flow, which the router keeps).
+ */
+const INITIAL_OAUTH_LOCATION =
+  typeof window !== "undefined"
+    ? { hash: window.location.hash, search: window.location.search }
+    : { hash: "", search: "" };
+
+/**
  * OAuth callback page for Steward OAuth providers (Google, Discord, Twitter/X).
  *
  * PKCE code flow (current):
@@ -48,10 +65,14 @@ export default function OAuthCallbackPage() {
 
     // Steward's PKCE flow returns the one-time code in the URL *fragment*
     // (`#code=…&state=…`) — deliberately, so it stays out of server logs /
-    // Referer / browser history. Read the fragment first, then fall back to the
-    // query string for the legacy token-in-URL flow (`?token=…`).
-    const hashParams = new URLSearchParams(window.location.hash.replace(/^#/, ""));
-    const queryParams = new URLSearchParams(window.location.search);
+    // Referer / browser history. Read from the module-eval snapshot (see
+    // INITIAL_OAUTH_LOCATION) because the App Router strips the fragment before
+    // this effect runs; fall back to the live location for the legacy
+    // token-in-URL flow (`?token=…`).
+    const hash = INITIAL_OAUTH_LOCATION.hash || window.location.hash;
+    const search = INITIAL_OAUTH_LOCATION.search || window.location.search;
+    const hashParams = new URLSearchParams(hash.replace(/^#/, ""));
+    const queryParams = new URLSearchParams(search);
     const pick = (key: string): string | null =>
       hashParams.get(key) ?? queryParams.get(key);
     const error = pick("error");


### PR DESCRIPTION
## The bug

On feed.elizacloud.ai, "log in with Google" bounced the user straight back to the front page / login modal. Reproduced live end-to-end with an instrumented browser:

```
302 eliza.steward.fi/auth/oauth/google/callback?...&code=4/0A...   ← Google→Steward OK
200 feed.elizacloud.ai/auth/callback/google                        ← callback page loads
NAV feed.elizacloud.ai/auth/callback/google#code=WST8Tg2ge6...     ← Steward returns code in fragment ✓
NAV feed.elizacloud.ai/auth/callback/google                        ← fragment stripped
NAV feed.elizacloud.ai/?auth_error=missing_code                    ← BUG
```

Steward returns the one-time PKCE code in the URL **fragment** (`#code=…`, deliberately, to keep it out of logs/Referer). The callback page read `window.location.hash` inside its mount effect — but Next.js's App Router normalizes the callback URL during hydration and **drops the fragment before that effect runs**, so it saw an empty hash → `auth_error=missing_code` → redirect to `/`.

Everything server-side is healthy (verified independently): authorize 302→Google, `/auth/oauth/exchange` reachable + signed, PKCE, the `feed.elizacloud.ai/auth/callback/google` redirect_uri is allowlisted, JWT secret/issuer. The failure was purely the client losing the fragment.

## The fix

Snapshot `window.location.hash`/`search` at **client module-eval time** (the route chunk executes before the router's URL normalization) and read the OAuth params from that snapshot, falling back to the live location for the legacy `?token=` query flow. One file changed.

## Evidence

- Before: instrumented headed-browser run lands on `/?auth_error=missing_code` (above).
- After: re-run of the same flow logs in (token persisted, modal gone) — attaching the capture in a follow-up comment once the fixed build is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)