### PR TITLE
fix(discord): warn at startup when config will suppress all auto-replies

### DIFF
--- a/plugins/plugin-discord/__tests__/banner-reply-warning.test.ts
+++ b/plugins/plugin-discord/__tests__/banner-reply-warning.test.ts
@@ -1,0 +1,138 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { warnIfRepliesSuppressed } from "../banner.ts";
+
+/**
+ * A freshly-configured Discord bot can connect, ingest messages, and never
+ * reply, because several independent default conditions each suppress all
+ * replies with no log. `warnIfRepliesSuppressed` is the startup diagnostic that
+ * names the active reason(s) and the exact env var(s) to flip. It is
+ * diagnostics-only: it must warn exactly once when replies are globally
+ * suppressed, name the specific active reason, and stay silent when every
+ * reply-enabling condition is met.
+ */
+
+// Env vars `lifeOpsPassiveConnectorsEnabled` falls back to when the runtime has
+// no override. Cleared per-test so process.env never leaks into assertions.
+const PASSIVE_ENV_KEYS = [
+	"ELIZA_LIFEOPS_PASSIVE_CONNECTORS",
+	"LIFEOPS_PASSIVE_CONNECTORS",
+] as const;
+
+type SettingMap = Record<string, string | undefined>;
+
+function makeRuntime(
+	settings: SettingMap,
+	characterSettings: Record<string, unknown> = {},
+): {
+	runtime: IAgentRuntime;
+	warn: ReturnType<typeof vi.fn>;
+} {
+	const warn = vi.fn();
+	const runtime = {
+		agentId: "agent-1",
+		character: { name: "TestBot", settings: characterSettings },
+		getSetting: (key: string) => settings[key],
+		logger: { info: vi.fn(), warn, debug: vi.fn(), error: vi.fn() },
+	} as unknown as IAgentRuntime;
+	return { runtime, warn };
+}
+
+/**
+ * Settings that satisfy every reply-enabling condition: passive mode explicitly
+ * off, autoReply on, DMs not ignored.
+ */
+function repliesEnabled(): SettingMap {
+	return {
+		// A token must be present or the diagnostic short-circuits (the bot can
+		// never connect, so the missing-token warning owns that path instead).
+		DISCORD_API_TOKEN: "test-token",
+		ELIZA_LIFEOPS_PASSIVE_CONNECTORS: "false",
+		DISCORD_AUTO_REPLY: "true",
+		DISCORD_SHOULD_IGNORE_DIRECT_MESSAGES: "false",
+	};
+}
+
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+	for (const key of PASSIVE_ENV_KEYS) {
+		savedEnv[key] = process.env[key];
+		delete process.env[key];
+	}
+});
+
+afterEach(() => {
+	for (const key of PASSIVE_ENV_KEYS) {
+		if (savedEnv[key] === undefined) {
+			delete process.env[key];
+		} else {
+			process.env[key] = savedEnv[key];
+		}
+	}
+	vi.restoreAllMocks();
+});
+
+describe("warnIfRepliesSuppressed", () => {
+	it("emits NO warning when every reply-enabling condition is met", () => {
+		const { runtime, warn } = makeRuntime(repliesEnabled());
+		warnIfRepliesSuppressed(runtime);
+		expect(warn).not.toHaveBeenCalled();
+	});
+
+	it("warns and names autoReply when autoReply is false", () => {
+		const { runtime, warn } = makeRuntime({
+			...repliesEnabled(),
+			DISCORD_AUTO_REPLY: "false",
+		});
+		warnIfRepliesSuppressed(runtime);
+		expect(warn).toHaveBeenCalledTimes(1);
+		const message = String(warn.mock.calls[0]?.[1] ?? "");
+		expect(message).toContain("autoReply");
+		expect(message).toContain("DISCORD_AUTO_REPLY=true");
+	});
+
+	it("warns and names passive mode when passive connectors are enabled", () => {
+		const { runtime, warn } = makeRuntime({
+			...repliesEnabled(),
+			ELIZA_LIFEOPS_PASSIVE_CONNECTORS: "true",
+		});
+		warnIfRepliesSuppressed(runtime);
+		expect(warn).toHaveBeenCalledTimes(1);
+		const message = String(warn.mock.calls[0]?.[1] ?? "");
+		expect(message).toContain("passive-connectors mode");
+		expect(message).toContain("ELIZA_LIFEOPS_PASSIVE_CONNECTORS=false");
+	});
+
+	it("stays silent when no bot token is configured (cannot connect)", () => {
+		// Passive on + autoReply off would normally warn, but with no token the
+		// bot can never connect, so claiming a live connection would mislead.
+		const { runtime, warn } = makeRuntime({
+			ELIZA_LIFEOPS_PASSIVE_CONNECTORS: "true",
+			DISCORD_AUTO_REPLY: "false",
+		});
+		warnIfRepliesSuppressed(runtime);
+		expect(warn).not.toHaveBeenCalled();
+	});
+
+	it("stays silent when a per-account autoReply re-enables replies", () => {
+		// Base autoReply is off, but a per-account config turns it on for that
+		// account, mirroring resolveDiscordSettingsForAccount. The bot is not
+		// globally silent, so the diagnostic must NOT warn.
+		const { runtime, warn } = makeRuntime(
+			{
+				ELIZA_LIFEOPS_PASSIVE_CONNECTORS: "false",
+				DISCORD_AUTO_REPLY: "false",
+			},
+			{
+				discord: {
+					accounts: {
+						default: { token: "acct-token", autoReply: true },
+					},
+				},
+			},
+		);
+		warnIfRepliesSuppressed(runtime);
+		expect(warn).not.toHaveBeenCalled();
+	});
+});

--- a/plugins/plugin-discord/banner.ts
+++ b/plugins/plugin-discord/banner.ts
@@ -5,10 +5,121 @@
  */
 
 import type { IAgentRuntime } from "@elizaos/core";
+import { lifeOpsPassiveConnectorsEnabled } from "@elizaos/core";
+import { listEnabledDiscordAccounts } from "./accounts";
+import { getDiscordSettings } from "./environment";
 import {
 	type DiscordPermissionValues,
 	getPermissionValues,
 } from "./permissions";
+
+/** Per-account reply-config overrides used by the suppression diagnostic. */
+type AccountReplyOverrides = {
+	autoReply?: boolean;
+	shouldIgnoreDirectMessages?: boolean;
+};
+
+/**
+ * Inspect the effective Discord reply configuration and, if it will suppress
+ * ALL auto-replies, emit a single startup warning naming the specific active
+ * reason(s) and the exact env var(s) an operator must flip to re-enable replies.
+ *
+ * Diagnostics only: this reads resolved settings and logs. It never mutates
+ * configuration or reply behavior. The reply gate it mirrors lives in
+ * `MessageManager.handleMessage` (messages.ts): a reply is suppressed when
+ * `!autoReply || lifeOpsPassiveConnectorsEnabled(runtime)`. DM ignore is a
+ * narrower gate (DMs only) surfaced here because it silently drops DM replies.
+ *
+ * Multi-account aware: per-account configs can override `autoReply` /
+ * `shouldIgnoreDirectMessages` (mirrors `resolveDiscordSettingsForAccount` in
+ * service.ts: `config.X ?? base.X`). The warning fires only when EVERY enabled
+ * account is globally suppressed, so a single reply-enabled account is never
+ * misreported as silent.
+ *
+ * @param runtime - The agent runtime used to resolve settings and log.
+ */
+export function warnIfRepliesSuppressed(runtime: IAgentRuntime): void {
+	// Skip the diagnostic when no enabled account has a token: index.ts still
+	// runs the banner in that path, but the bot can never connect, so a
+	// "Discord is connected but will NOT reply" warning would be misleading.
+	// listEnabledDiscordAccounts is the same connection gate the service uses
+	// (env DISCORD_API_TOKEN/DISCORD_BOT_TOKENS, character.settings.discord, and
+	// per-account tokens all flow through it), so this covers every supported
+	// credential path. The existing missing-token warning in index.ts owns the
+	// no-credentials case.
+	const accounts = listEnabledDiscordAccounts(runtime);
+	if (accounts.length === 0) {
+		return;
+	}
+
+	const base = getDiscordSettings(runtime);
+	// Passive mode is a runtime-global gate (not per-account); when on it
+	// suppresses replies for every account.
+	const passiveEnabled = lifeOpsPassiveConnectorsEnabled(runtime);
+
+	// Resolve each enabled account's effective reply settings, mirroring
+	// resolveDiscordSettingsForAccount's `config.X ?? base.X` precedence.
+	let anyAutoReplyOff = false;
+	let anyDmIgnored = false;
+	let allGloballySuppressed = true;
+
+	for (const account of accounts) {
+		const config = (account.config ?? {}) as AccountReplyOverrides;
+		const effectiveAutoReply = config.autoReply ?? base.autoReply;
+		const effectiveIgnoreDms =
+			config.shouldIgnoreDirectMessages ?? base.shouldIgnoreDirectMessages;
+
+		if (!effectiveAutoReply) {
+			anyAutoReplyOff = true;
+		}
+		if (effectiveIgnoreDms) {
+			anyDmIgnored = true;
+		}
+		// An account replies somewhere unless passive mode is on or its
+		// effective autoReply is off.
+		if (!passiveEnabled && effectiveAutoReply) {
+			allGloballySuppressed = false;
+		}
+	}
+
+	// Only warn when EVERY enabled account is globally suppressed. A lone
+	// DM-ignore setting is intentional config, not a silent total failure, and
+	// one reply-enabled account means the bot is not silent overall.
+	if (!allGloballySuppressed) {
+		return;
+	}
+
+	const reasons: string[] = [];
+	if (passiveEnabled) {
+		reasons.push(
+			"passive-connectors mode is ON (inbound persisted, replies suppressed); " +
+				"set ELIZA_LIFEOPS_PASSIVE_CONNECTORS=false " +
+				"(or LIFEOPS_PASSIVE_CONNECTORS=false) to allow replies",
+		);
+	}
+	if (anyAutoReplyOff) {
+		reasons.push(
+			"autoReply is OFF; set DISCORD_AUTO_REPLY=true " +
+				"(or character.settings.discord.autoReply=true, or the per-account " +
+				"autoReply) to allow replies",
+		);
+	}
+	// Narrower suppressor: only silences DM replies. Surfaced alongside the
+	// global reason(s) since the operator likely wants DMs working too.
+	if (anyDmIgnored) {
+		reasons.push(
+			"direct messages are IGNORED (affects DM replies only); set " +
+				"DISCORD_SHOULD_IGNORE_DIRECT_MESSAGES=false to reply in DMs",
+		);
+	}
+
+	runtime.logger.warn(
+		{ src: "plugin:discord", agentId: runtime.agentId },
+		`Discord is connected but will NOT auto-reply to any messages. Active reason(s): ${reasons
+			.map((r, i) => `(${i + 1}) ${r}`)
+			.join("; ")}.`,
+	);
+}
 
 const ANSI = {
 	reset: "\x1b[0m",
@@ -266,6 +377,10 @@ export function printBanner(options: BannerOptions): void {
 	lines.push("");
 
 	runtime.logger.info(lines.join("\n"));
+
+	// Diagnostics: if the effective config will suppress all auto-replies, warn
+	// the operator with the exact reason(s) instead of failing silently.
+	warnIfRepliesSuppressed(runtime);
 }
 
 /**


### PR DESCRIPTION
## Summary
A freshly-configured self-hosted Discord bot connects and ingests messages but silently never auto-replies, with no diagnostic explaining why (see #10216). The reply path is gated by several independent conditions and none of them logs anything. This adds ONE clear startup warning naming the active reason(s) and the exact env vars to flip. Diagnostics only: no default values change, no reply-path behavior changes.

## What it does
- `warnIfRepliesSuppressed(runtime)` in `banner.ts`, called from `printBanner()` at connect.
- Skips entirely when no Discord account can connect (token absent across env / character / per-account).
- Evaluates per-account effective settings (mirroring `resolveDiscordSettingsForAccount`) and treats passive-connectors mode as the runtime-global gate; only warns when every enabled account is globally suppressed (a single reply-enabled account never trips a false warning).
- Names the active reason(s): passive-connectors mode on / `autoReply` off / DMs ignored, each with the exact env var to set.

## Example
`Discord is connected but will NOT auto-reply to any messages. Active reason(s): (1) autoReply is OFF; set DISCORD_AUTO_REPLY=true ...; (2) passive-connectors mode is ON ...; set ELIZA_LIFEOPS_PASSIVE_CONNECTORS=false ...`

Single `runtime.logger.warn`, no console.

## Tests
- new `plugins/plugin-discord/__tests__/banner-reply-warning.test.ts`: replies-enabled -> no warn; autoReply false -> names autoReply; passive on -> names passive; no token -> silent; per-account autoReply override -> silent (5/5 pass)
- `biome check` clean; `codex review` clean (3 rounds, each finding addressed: token-presence gate, character/per-account tokens, per-account autoReply override)

Closes part of #10216 (the diagnostic). The DM-debouncer drop from that issue is addressed separately in #10221.
