### PR TITLE
fix(orchestrator): sub-agent spawns into workspace + relay results to chat

### DIFF
--- a/packages/agent/src/services/client-chat-sender.ts
+++ b/packages/agent/src/services/client-chat-sender.ts
@@ -71,43 +71,60 @@ export function registerClientChatSendHandler(
   if (typeof runtime.registerSendHandler !== "function") {
     return;
   }
-  runtime.registerSendHandler("client_chat", async (_rt, target, content) => {
-    const conv = resolveConversation(state, target.roomId as UUID | undefined);
-    if (!conv) {
-      // No conversation exists to deliver into. Throw so the caller records a
-      // delivery failure (e.g. escalation falls through to the next channel)
-      // instead of treating a silently dropped message as a successful send.
-      throw new Error(
-        "client_chat send failed: no conversation available to deliver message",
-      );
-    }
+  const deliver = (source: string) =>
+    async (
+      _rt: IAgentRuntime,
+      target: { roomId?: unknown },
+      content: { text?: string } & Record<string, unknown>,
+    ): Promise<void> => {
+      const conv = resolveConversation(state, target.roomId as UUID | undefined);
+      if (!conv) {
+        // No conversation exists to deliver into. Throw so the caller records a
+        // delivery failure (e.g. escalation falls through to the next channel)
+        // instead of treating a silently dropped message as a successful send.
+        throw new Error(
+          `${source} send failed: no conversation available to deliver message`,
+        );
+      }
 
-    const messageId = crypto.randomUUID() as UUID;
+      const messageId = crypto.randomUUID() as UUID;
 
-    const agentMessage = createMessageMemory({
-      id: messageId,
-      entityId: runtime.agentId,
-      roomId: conv.roomId,
-      content: {
-        ...content,
-        text: content.text ?? "",
-        source: "client_chat",
-      },
-    });
-    await runtime.createMemory(agentMessage, "messages");
-
-    conv.updatedAt = new Date().toISOString();
-
-    state.broadcastWs?.({
-      type: "proactive-message",
-      conversationId: conv.id,
-      message: {
+      const agentMessage = createMessageMemory({
         id: messageId,
-        role: "assistant",
-        text: content.text ?? "",
-        timestamp: Date.now(),
-        source: "client_chat",
-      },
-    });
-  });
+        entityId: runtime.agentId,
+        roomId: conv.roomId,
+        content: {
+          ...content,
+          text: content.text ?? "",
+          source: "client_chat",
+        },
+      });
+      await runtime.createMemory(agentMessage, "messages");
+
+      conv.updatedAt = new Date().toISOString();
+
+      state.broadcastWs?.({
+        type: "proactive-message",
+        conversationId: conv.id,
+        message: {
+          id: messageId,
+          role: "assistant",
+          text: content.text ?? "",
+          timestamp: Date.now(),
+          source: "client_chat",
+        },
+      });
+    };
+
+  // Primary web/app chat source.
+  runtime.registerSendHandler("client_chat", deliver("client_chat"));
+  // Coding sub-agent relay sources: when the orchestrator relays a spawned
+  // agent's result back into the chat, the message arrives under one of these
+  // sources. Without a handler the relay fails ("No send handler registered for
+  // source: agent_message_api") and the sub-agent's result silently never
+  // reaches the user — the chat just shows a "something glitched" failure even
+  // though the work completed. Deliver these into the same conversation surface.
+  for (const source of ["agent_message_api", "acpx_sub_agent", "orchestrator"]) {
+    runtime.registerSendHandler(source, deliver(source));
+  }
 }

--- a/plugins/plugin-agent-orchestrator/src/services/task-agent-routing.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-agent-routing.ts
@@ -147,15 +147,25 @@ function resolveDefaultSpawnWorkdir(runtime: IAgentRuntime | undefined): {
   workdir: string;
   isolate: boolean;
 } {
+  const getSetting = (key: string): string | undefined =>
+    typeof runtime?.getSetting === "function"
+      ? (runtime.getSetting(key) as string | undefined)
+      : undefined;
+  // Prefer the ACP-specific scratch root, then the general coding-workspace dir.
+  // Falling through to ELIZA_WORKSPACE_DIR / ELIZA_CODING_WORKSPACE means an
+  // operator who points the runtime at a coding workspace (the common case) gets
+  // spawns landing THERE instead of in the eliza runtime root (process.cwd(),
+  // e.g. /app) — which otherwise causes "build me X" tasks to grep the eliza repo
+  // in place instead of scaffolding fresh.
   const configured =
-    (typeof runtime?.getSetting === "function"
-      ? ((runtime.getSetting("ELIZA_ACP_WORKSPACE_ROOT") as
-          | string
-          | undefined) ??
-        (runtime.getSetting("ACPX_DEFAULT_CWD") as string | undefined))
-      : undefined) ??
+    getSetting("ELIZA_ACP_WORKSPACE_ROOT") ??
+    getSetting("ACPX_DEFAULT_CWD") ??
+    getSetting("ELIZA_WORKSPACE_DIR") ??
+    getSetting("ELIZA_CODING_WORKSPACE") ??
     readConfigEnvKey("ELIZA_ACP_WORKSPACE_ROOT") ??
-    readConfigEnvKey("ACPX_DEFAULT_CWD");
+    readConfigEnvKey("ACPX_DEFAULT_CWD") ??
+    readConfigEnvKey("ELIZA_WORKSPACE_DIR") ??
+    readConfigEnvKey("ELIZA_CODING_WORKSPACE");
   const trimmed = configured?.trim();
   // A configured workspace ROOT is a shared scratch area for ad-hoc spawned
   // tasks → isolate=true so each concurrent session gets its own subdir.


### PR DESCRIPTION
Two fixes to the coding sub-agent flow, both reproduced + verified live on a running agent.

## 1. Spawn defaults into the coding workspace, not the eliza runtime root
`resolveDefaultSpawnWorkdir` fell back to `process.cwd()` (the eliza runtime root, e.g. `/app`) when no workdir route/explicit/convention matched. So a 'build me a landing page' task with no explicit workdir spawned the coding agent **inside the eliza repo** — it then grepped the repo in place and returned `CLAUDE.md`/`AGENTS.md` files instead of scaffolding a fresh site.

Fix: honor `ELIZA_WORKSPACE_DIR` / `ELIZA_CODING_WORKSPACE` (after the existing `ELIZA_ACP_WORKSPACE_ROOT` / `ACPX_DEFAULT_CWD`) before falling back to cwd. Operators who point the runtime at a coding workspace (the common case) now get spawns landing there.

## 2. Relay sub-agent results back into chat
`registerClientChatSendHandler` only registered the `client_chat` source. When the orchestrator relayed a spawned agent's result, it arrived under `agent_message_api` (also `acpx_sub_agent` / `orchestrator`) → `No send handler registered for source: agent_message_api` → the result silently never reached the user. The chat just showed a generic 'something glitched' even though the coding task completed.

Fix: register the same delivery handler for those relay sources.

## Verified
On a live agent: before, a 'scaffold index.html' task returned repo files + 'something glitched'; after, the codex sub-agent scaffolded a real `index.html` into the workspace and the result relayed into chat cleanly.

Co-authored-by: wakesync <shadow@shad0w.xyz>