### PR TITLE
chore(build): migrate ainex/app-manager/whatsapp build.ts onto shared buildPlugin (#10078)

### DIFF
--- a/plugins/plugin-ainex/build.ts
+++ b/plugins/plugin-ainex/build.ts
@@ -1,47 +1,24 @@
 #!/usr/bin/env bun
-import { spawnSync } from "node:child_process";
-import { join } from "node:path";
-import { externalsFromPackageJson } from "../plugin-build-externals.ts";
+/**
+ * Build script for @elizaos/plugin-ainex (Node). Orchestration lives in the shared
+ * driver (plugins/plugin-build.ts); this lists only what differs.
+ */
+import { buildPlugin } from "../plugin-build";
 
-const rmRecursiveScript = join(
-  import.meta.dirname,
-  "..",
-  "..",
-  "packages",
-  "scripts",
-  "rm-path-recursive.mjs",
-);
-
-function rmRecursive(targetPath: string) {
-  const result = spawnSync(process.execPath, [rmRecursiveScript, targetPath], {
-    stdio: "inherit",
-  });
-  if (result.status !== 0) {
-    throw new Error(
-      `failed to remove generated AiNex build output ${targetPath}`,
-    );
-  }
-}
-
-rmRecursive("dist");
-
-const external = await externalsFromPackageJson("./package.json");
-
-const result = await Bun.build({
-  entrypoints: ["src/index.ts"],
-  outdir: "dist",
-  target: "node",
-  format: "esm",
-  sourcemap: "external",
-  external,
+await buildPlugin({
+  name: "@elizaos/plugin-ainex",
+  clean: true,
+  externals: "auto",
+  targets: [
+    {
+      label: "Node",
+      entry: "src/index.ts",
+      outSubdir: "",
+      target: "node",
+      format: "esm",
+    },
+  ],
+  dtsProject: "tsconfig.build.json",
+  dtsEmitDeclarationOnly: true,
+  rewriteDistImports: true,
 });
-if (!result.success) {
-  console.error("Build failed:", result.logs);
-  process.exit(1);
-}
-
-const { $ } = await import("bun");
-await $`tsc --emitDeclarationOnly --noCheck -p tsconfig.build.json`;
-await $`node ../../packages/scripts/rewrite-dist-relative-imports-node-esm.mjs`;
-
-console.log("Build complete: @elizaos/plugin-ainex");

--- a/plugins/plugin-app-manager/build.ts
+++ b/plugins/plugin-app-manager/build.ts
@@ -1,62 +1,37 @@
 #!/usr/bin/env bun
-import { spawnSync } from "node:child_process";
-import { fileURLToPath } from "node:url";
-import { $ } from "bun";
+/**
+ * Build script for @elizaos/plugin-app-manager (Node). Orchestration lives in the
+ * shared driver (plugins/plugin-build.ts); this lists only what differs.
+ *
+ * Declarations are emitted via tsconfig.build.json, which bakes in the
+ * noEmit:false / rootDir:src / declarationDir overrides the hand-rolled build
+ * previously passed on the tsc CLI (the base tsconfig has noEmit:true because
+ * allowImportingTsExtensions forces it).
+ */
+import { buildPlugin } from "../plugin-build";
 
-const RM_RECURSIVE_SCRIPT = fileURLToPath(
-  new URL("../../packages/scripts/rm-path-recursive.mjs", import.meta.url),
-);
-
-const external = [
-  "@elizaos/core",
-  "@elizaos/agent",
-  "@elizaos/plugin-registry",
-  "@elizaos/shared",
-  "dotenv",
-  "node:*",
-  "bun:*",
-];
-
-console.log("🔨 Building @elizaos/plugin-app-manager...");
-const start = Date.now();
-
-function rmRecursive(target: string) {
-  const result = spawnSync(process.execPath, [RM_RECURSIVE_SCRIPT, target], {
-    stdio: "inherit",
-  });
-  if (result.error) {
-    throw result.error;
-  }
-  if (result.status !== 0) {
-    process.exit(result.status ?? 1);
-  }
-}
-
-rmRecursive("dist");
-
-const result = await Bun.build({
-  entrypoints: ["src/index.ts"],
-  outdir: "dist",
-  target: "node",
-  format: "esm",
-  sourcemap: "external",
-  external,
-  minify: false,
+await buildPlugin({
+  name: "@elizaos/plugin-app-manager",
+  clean: true,
+  externals: [
+    "@elizaos/core",
+    "@elizaos/agent",
+    "@elizaos/plugin-registry",
+    "@elizaos/shared",
+    "dotenv",
+    "node:*",
+    "bun:*",
+  ],
+  targets: [
+    {
+      label: "Node",
+      entry: "src/index.ts",
+      outSubdir: "",
+      target: "node",
+      format: "esm",
+    },
+  ],
+  dtsProject: "tsconfig.build.json",
+  dtsEmitDeclarationOnly: true,
+  rewriteDistImports: true,
 });
-
-if (!result.success) {
-  for (const log of result.logs) {
-    console.error(log);
-  }
-  process.exit(1);
-}
-
-console.log("📝 Generating TypeScript declarations...");
-// Override noEmit/rootDir so declarations land directly in dist/
-// allowImportingTsExtensions in tsconfig forces noEmit:true, so we override with --noEmit false
-await $`tsc --emitDeclarationOnly --declaration --noEmit false --declarationDir dist --rootDir src --noCheck --skipLibCheck -p tsconfig.json`.quiet();
-await $`node ../../packages/scripts/rewrite-dist-relative-imports-node-esm.mjs`.quiet();
-
-console.log(
-  `✅ Build complete in ${((Date.now() - start) / 1000).toFixed(2)}s`,
-);

--- a/plugins/plugin-app-manager/tsconfig.build.json
+++ b/plugins/plugin-app-manager/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationDir": "dist",
+    "rootDir": "src",
+    "skipLibCheck": true
+  }
+}

--- a/plugins/plugin-whatsapp/build.ts
+++ b/plugins/plugin-whatsapp/build.ts
@@ -1,95 +1,60 @@
 #!/usr/bin/env bun
-
 /**
- * Standalone build script for @elizaos/plugin-whatsapp.
- * Uses Bun's native bundler — no monorepo build-utils dependency.
+ * Build script for @elizaos/plugin-whatsapp (Node). Orchestration lives in the shared
+ * driver (plugins/plugin-build.ts); this lists only what differs.
+ *
+ * The `extra` externals preserve bare-string node builtins, transitive
+ * workspace packages, and optional native sub-packages the hand-list relied on.
+ * The `@node-llama-cpp/*` glob covers per-platform subpackages that aren't
+ * direct deps but must stay external so absent platforms don't fail to resolve.
  */
+import { buildPlugin } from "../plugin-build";
 
-import { execSync, spawnSync } from "node:child_process";
-import { join } from "node:path";
-import { externalsFromPackageJson } from "../plugin-build-externals.ts";
-
-const rmRecursiveScript = join(
-  import.meta.dirname,
-  "..",
-  "..",
-  "packages",
-  "scripts",
-  "rm-path-recursive.mjs"
-);
-
-function rmRecursive(targetPath: string) {
-  const result = spawnSync(process.execPath, [rmRecursiveScript, targetPath], {
-    stdio: "inherit",
-  });
-  if (result.status !== 0) {
-    throw new Error(`failed to remove generated WhatsApp build output ${targetPath}`);
-  }
-}
-
-rmRecursive("dist");
-
-const external = await externalsFromPackageJson("./package.json", {
-  // Preserve bare-string node builtins, transitive workspace packages, and
-  // optional native sub-packages the hand-list relied on. The
-  // `@node-llama-cpp/*` glob covers per-platform subpackages that aren't
-  // direct deps but must stay external so absent platforms don't fail
-  // to resolve.
-  extra: [
-    "fs",
-    "path",
-    "os",
-    "http",
-    "https",
-    "crypto",
-    "stream",
-    "events",
-    "util",
-    "url",
-    "net",
-    "tls",
-    "zlib",
-    "buffer",
-    "child_process",
-    "readline",
-    "@elizaos/shared",
-    "@elizaos/agent",
-    "@elizaos/vault",
-    "@elizaos/cloud-routing",
-    "node-llama-cpp",
-    "@node-llama-cpp/*",
-    "@napi-rs/keyring",
-    "@reflink/reflink",
-    "ipull",
-    "tailwindcss",
-    "zlib-sync",
+await buildPlugin({
+  name: "@elizaos/plugin-whatsapp",
+  clean: true,
+  externals: "auto",
+  externalsOptions: {
+    extra: [
+      "fs",
+      "path",
+      "os",
+      "http",
+      "https",
+      "crypto",
+      "stream",
+      "events",
+      "util",
+      "url",
+      "net",
+      "tls",
+      "zlib",
+      "buffer",
+      "child_process",
+      "readline",
+      "@elizaos/shared",
+      "@elizaos/agent",
+      "@elizaos/vault",
+      "@elizaos/cloud-routing",
+      "node-llama-cpp",
+      "@node-llama-cpp/*",
+      "@napi-rs/keyring",
+      "@reflink/reflink",
+      "ipull",
+      "tailwindcss",
+      "zlib-sync",
+    ],
+  },
+  targets: [
+    {
+      label: "Node",
+      entry: "src/index.ts",
+      outSubdir: "",
+      target: "node",
+      format: "esm",
+      sourcemap: "linked",
+    },
   ],
+  dtsProject: "tsconfig.build.json",
+  dtsTolerant: true,
 });
-
-const result = await Bun.build({
-  entrypoints: ["src/index.ts"],
-  outdir: "dist",
-  target: "node",
-  format: "esm",
-  external,
-  sourcemap: "linked",
-  minify: false,
-});
-
-if (!result.success) {
-  console.error("Build failed:");
-  for (const log of result.logs) {
-    console.error(log);
-  }
-  process.exit(1);
-}
-
-// Emit real declaration files via tsc
-try {
-  execSync("bunx tsc --noCheck -p tsconfig.build.json", { stdio: "inherit" });
-} catch {
-  // Non-fatal — plugin works at runtime without .d.ts files
-  console.warn("[plugin-whatsapp] tsc declaration emit failed (non-fatal)");
-}
-
-console.log("[plugin-whatsapp] Build complete");


### PR DESCRIPTION
Continues the **#10078** build-helper consolidation (after the maintainer's merged #10091 connector batch): migrates three more plugins' hand-rolled `build.ts` onto the shared `plugins/plugin-build.ts` `buildPlugin({...})` driver.

## Byte-identical (the #10091 bar)
For each plugin: built with the original `build.ts` → recorded per-file `sha256` of `dist/` (BEFORE) → replaced `build.ts` with the `buildPlugin` shim → rebuilt → diffed. **Every file matches on both file set and hash**, reconfirmed from the committed state via a clean rebuild:

| plugin | dist files | sha256 |
|---|---|---|
| plugin-ainex | 58 | all identical |
| plugin-app-manager | 10 | all identical |
| plugin-whatsapp | 51 | all identical |

## Per-plugin notes
- **ainex** — direct 1:1: `externals:"auto"`, single Node esm, `dtsProject` + `dtsEmitDeclarationOnly` + `rewriteDistImports`.
- **whatsapp** — `externals:"auto"` + `externalsOptions.extra` (node builtins, transitive workspace pkgs, optional native subpackages incl. the `@node-llama-cpp/*` glob), `sourcemap:"linked"`, `dtsTolerant:true` (original wrapped tsc in a non-fatal try/catch).
- **app-manager** — explicit `externals` list (`"auto"` under-derives from its 3 package.json deps), `dtsEmitDeclarationOnly` + `rewriteDistImports`. Adds `tsconfig.build.json` (extends `tsconfig.json`) to bake the `noEmit:false` / `rootDir:src` / `declarationDir:dist` overrides the original passed on the tsc CLI (the base config forces `noEmit:true` via `allowImportingTsExtensions`) — same shape as the slack precedent.

Net **−72 lines** of duplicated build orchestration.

## Verification
- `bun run --cwd plugins/plugin-<p> build` → exit 0 for all three (dist counts 58/10/51, matching the manifests).
- The three shims typecheck clean against the driver API.
- Pre-existing per-plugin `tsgo --noEmit` errors (unbuilt-workspace-dep resolution in a fresh worktree) are **byte-identical to the pristine `origin/develop` tree** — no regression introduced.

Scope deliberately small + byte-identical-only (pure-tsc plugins like nostr/line and complex multi-target ones like bluesky are out of scope for this batch). Refs #10078.

🤖 Generated with [Claude Code](https://claude.com/claude-code)