### PR TITLE
chore(build): migrate bluesky + farcaster (multi-target) onto shared buildPlugin (#10078)

### DIFF
--- a/plugins/plugin-bluesky/build.ts
+++ b/plugins/plugin-bluesky/build.ts
@@ -1,163 +1,79 @@
 #!/usr/bin/env bun
-
 /**
- * Build script for @elizaos/plugin-bluesky (Node + Browser)
+ * Build script for @elizaos/plugin-bluesky (Node + Browser + Node CJS).
+ * Orchestration lives in the shared driver (plugins/plugin-build.ts); this
+ * lists only what differs. The emitted `dist/` is byte-identical to the
+ * previous hand-rolled build.
  *
- * This package is published from plugins/plugin-bluesky, so all outputs
- * must be written under ./dist (NOT ../dist).
+ * Each runtime target deliberately bundles `index.ts` (the real entry) rather
+ * than the `index.node.ts` re-export shim. Bundling the shim triggers a
+ * Bun.build codegen bug where the inlined default export is renamed to
+ * `default2` but the corresponding `var default2 = ...` declaration is never
+ * emitted, producing an unimportable bundle (`"default2" is not declared in
+ * this file`). The Node/CJS outputs are renamed to `index.node.js` /
+ * `index.node.cjs` afterwards (via `renames`) so the package.json `exports`
+ * map remains stable.
  */
+import { buildPlugin } from "../plugin-build";
 
-import { existsSync } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
-import { join } from "node:path";
-import { externalsFromPackageJson } from "../plugin-build-externals.ts";
-
-const externalDeps = await externalsFromPackageJson("./package.json");
-
-async function build(): Promise<void> {
-	const totalStart = Date.now();
-	const distDir = join(process.cwd(), "dist");
-
-	// Node build.
-	//
-	// We deliberately bundle `index.ts` (the real entry) rather than the
-	// `index.node.ts` re-export shim. Bundling the shim triggers a Bun.build
-	// codegen bug where the inlined default export is renamed to `default2`
-	// but the corresponding `var default2 = ...` declaration is never emitted,
-	// producing an unimportable bundle (`"default2" is not declared in this
-	// file`). The output is renamed to `index.node.js` afterwards so the
-	// package.json `exports` map remains stable.
-	const nodeStart = Date.now();
-	console.log("🔨 Building @elizaos/plugin-bluesky for Node...");
-	const nodeResult = await Bun.build({
-		entrypoints: ["index.ts"],
-		outdir: join(distDir, "node"),
-		target: "node",
-		format: "esm",
-		sourcemap: "external",
-		minify: false,
-		external: [...externalDeps],
-	});
-	if (!nodeResult.success) {
-		console.error("Node build failed:", nodeResult.logs);
-		throw new Error("Node build failed");
-	}
-	{
-		const { rename } = await import("node:fs/promises");
-		await rename(
-			join(distDir, "node", "index.js"),
-			join(distDir, "node", "index.node.js"),
-		);
-		await rename(
-			join(distDir, "node", "index.js.map"),
-			join(distDir, "node", "index.node.js.map"),
-		);
-	}
-	console.log(
-		`✅ Node build complete in ${((Date.now() - nodeStart) / 1000).toFixed(2)}s`,
-	);
-
-	// Browser build
-	const browserStart = Date.now();
-	console.log("🌐 Building @elizaos/plugin-bluesky for Browser...");
-	const browserResult = await Bun.build({
-		entrypoints: ["index.browser.ts"],
-		outdir: join(distDir, "browser"),
-		target: "browser",
-		format: "esm",
-		sourcemap: "external",
-		minify: false,
-		external: [...externalDeps],
-	});
-	if (!browserResult.success) {
-		console.error("Browser build failed:", browserResult.logs);
-		throw new Error("Browser build failed");
-	}
-	console.log(
-		`✅ Browser build complete in ${((Date.now() - browserStart) / 1000).toFixed(2)}s`,
-	);
-
-	// Node CJS build. Same rationale as the ESM build above: bundle `index.ts`
-	// directly and rename to `index.node.cjs` to avoid the Bun.build re-export
-	// shim codegen bug.
-	const cjsStart = Date.now();
-	console.log("🧱 Building @elizaos/plugin-bluesky for Node (CJS)...");
-	const cjsResult = await Bun.build({
-		entrypoints: ["index.ts"],
-		outdir: join(distDir, "cjs"),
-		target: "node",
-		format: "cjs",
-		sourcemap: "external",
-		minify: false,
-		external: [...externalDeps],
-	});
-	if (!cjsResult.success) {
-		console.error("CJS build failed:", cjsResult.logs);
-		throw new Error("CJS build failed");
-	}
-	{
-		const { rename } = await import("node:fs/promises");
-		await rename(
-			join(distDir, "cjs", "index.js"),
-			join(distDir, "cjs", "index.node.cjs"),
-		);
-		await rename(
-			join(distDir, "cjs", "index.js.map"),
-			join(distDir, "cjs", "index.node.cjs.map"),
-		);
-	}
-	console.log(
-		`✅ CJS build complete in ${((Date.now() - cjsStart) / 1000).toFixed(2)}s`,
-	);
-
-	// TypeScript declarations
-	const dtsStart = Date.now();
-	console.log("📝 Generating TypeScript declarations...");
-	const { $ } = await import("bun");
-	await $`tsc --project tsconfig.build.json --noCheck`;
-
-	// Ensure directories exist
-	const nodeDir = join(distDir, "node");
-	const browserDir = join(distDir, "browser");
-	const cjsDir = join(distDir, "cjs");
-
-	if (!existsSync(nodeDir)) await mkdir(nodeDir, { recursive: true });
-	if (!existsSync(browserDir)) await mkdir(browserDir, { recursive: true });
-	if (!existsSync(cjsDir)) await mkdir(cjsDir, { recursive: true });
-
-	// Root types alias to node by default
-	const rootIndexDtsPath = join(distDir, "index.d.ts");
-	const rootAlias = `export * from "./node/index";
+await buildPlugin({
+	name: "@elizaos/plugin-bluesky",
+	targets: [
+		{
+			label: "Node",
+			entry: "index.ts",
+			outSubdir: "node",
+			target: "node",
+			format: "esm",
+			sourcemap: "external",
+			renames: [
+				["index.js", "index.node.js"],
+				["index.js.map", "index.node.js.map"],
+			],
+		},
+		{
+			label: "Browser",
+			entry: "index.browser.ts",
+			outSubdir: "browser",
+			target: "browser",
+			format: "esm",
+			sourcemap: "external",
+		},
+		{
+			label: "Node (CJS)",
+			entry: "index.ts",
+			outSubdir: "cjs",
+			target: "node",
+			format: "cjs",
+			sourcemap: "external",
+			renames: [
+				["index.js", "index.node.cjs"],
+				["index.js.map", "index.node.cjs.map"],
+			],
+		},
+	],
+	dtsProject: "tsconfig.build.json",
+	dtsShims: [
+		// Root types alias to node by default.
+		{
+			path: "index.d.ts",
+			content: `export * from "./node/index";
 export { default } from "./node/index";
-`;
-	await writeFile(rootIndexDtsPath, rootAlias, "utf8");
-
-	// Keep the real declaration surface emitted from index.ts at
-	// dist/node/index.d.ts. index.node.d.ts re-exports it for the JS entrypoint.
-
-	// Browser alias
-	const browserIndexDtsPath = join(browserDir, "index.d.ts");
-	const browserAlias = `export * from "./index.browser";
+`,
+		},
+		// Browser alias.
+		{
+			path: "browser/index.d.ts",
+			content: `export * from "./index.browser";
 export { default } from "./index.browser";
-`;
-	await writeFile(browserIndexDtsPath, browserAlias, "utf8");
-
-	// CJS alias
-	const cjsIndexDtsPath = join(cjsDir, "index.d.ts");
-	const cjsAlias = `export * from "./index.node";
+`,
+		},
+		// CJS alias.
+		{
+			path: "cjs/index.d.ts",
+			content: `export * from "./index.node";
 export { default } from "./index.node";
-`;
-	await writeFile(cjsIndexDtsPath, cjsAlias, "utf8");
-
-	console.log(
-		`✅ Declarations generated in ${((Date.now() - dtsStart) / 1000).toFixed(2)}s`,
-	);
-	console.log(
-		`🎉 All builds completed in ${((Date.now() - totalStart) / 1000).toFixed(2)}s`,
-	);
-}
-
-build().catch((err) => {
-	console.error("Build failed:", err);
-	process.exit(1);
+`,
+		},
+	],
 });

--- a/plugins/plugin-farcaster/build.ts
+++ b/plugins/plugin-farcaster/build.ts
@@ -1,158 +1,88 @@
 #!/usr/bin/env bun
-
 /**
- * Build script for @elizaos/plugin-farcaster (Node + Browser)
+ * Build script for @elizaos/plugin-farcaster (Node + Browser + Node CJS).
+ * Orchestration lives in the shared driver (plugins/plugin-build.ts); this
+ * lists only what differs. The emitted `dist/` is byte-identical to the
+ * previous hand-rolled build.
  *
- * This script builds the TypeScript source for both Node.js and browser environments.
+ * Each runtime target deliberately bundles `index.ts` (the real entry) rather
+ * than the `index.node.ts` re-export shim. Bundling the shim triggers a
+ * Bun.build codegen bug where the inlined default export is renamed to
+ * `default2` but the corresponding `var default2 = ...` declaration is never
+ * emitted, producing an unimportable bundle (`"default2" is not declared in
+ * this file`). The Node/CJS outputs are renamed to `index.node.js` /
+ * `index.node.cjs` afterwards (via `renames`) so the package.json `exports`
+ * map remains stable.
  */
+import { buildPlugin } from "../plugin-build";
 
-import { spawnSync } from "node:child_process";
-import { mkdir, writeFile } from "node:fs/promises";
-import { join } from "node:path";
-import { externalsFromPackageJson } from "../plugin-build-externals.ts";
-
-const externalDeps = await externalsFromPackageJson("./package.json");
-const rmRecursiveScript = join(
-  import.meta.dirname,
-  "..",
-  "..",
-  "packages",
-  "scripts",
-  "rm-path-recursive.mjs"
-);
-
-function rmRecursive(targetPath: string) {
-  const result = spawnSync(process.execPath, [rmRecursiveScript, targetPath], {
-    stdio: "inherit",
-  });
-  if (result.status !== 0) {
-    throw new Error(`failed to remove generated Farcaster build output ${targetPath}`);
-  }
-}
-
-async function build() {
-  const totalStart = Date.now();
-  const distDir = join(process.cwd(), "dist");
-
-  rmRecursive(distDir);
-
-  // Node build.
-  //
-  // We deliberately bundle `index.ts` (the real entry) rather than the
-  // `index.node.ts` re-export shim. Bundling the shim triggers a Bun.build
-  // codegen bug where the inlined default export is renamed to `default2`
-  // but the corresponding `var default2 = ...` declaration is never emitted,
-  // producing an unimportable bundle (`"default2" is not declared in this
-  // file`). The output is renamed to `index.node.js` afterwards so the
-  // package.json `exports` map remains stable.
-  const nodeStart = Date.now();
-  console.log("🔨 Building @elizaos/plugin-farcaster for Node...");
-  const nodeResult = await Bun.build({
-    entrypoints: ["index.ts"],
-    outdir: join(distDir, "node"),
-    target: "node",
-    format: "esm",
-    sourcemap: "external",
-    minify: false,
-    external: externalDeps,
-  });
-  if (!nodeResult.success) {
-    console.error("Node build failed:", nodeResult.logs);
-    throw new Error("Node build failed");
-  }
-  {
-    const { rename } = await import("node:fs/promises");
-    await rename(join(distDir, "node", "index.js"), join(distDir, "node", "index.node.js"));
-    await rename(join(distDir, "node", "index.js.map"), join(distDir, "node", "index.node.js.map"));
-  }
-  console.log(`✅ Node build complete in ${((Date.now() - nodeStart) / 1000).toFixed(2)}s`);
-
-  // Browser build
-  const browserStart = Date.now();
-  console.log("🌐 Building @elizaos/plugin-farcaster for Browser...");
-  const browserResult = await Bun.build({
-    entrypoints: ["index.browser.ts"],
-    outdir: join(distDir, "browser"),
-    target: "browser",
-    format: "esm",
-    sourcemap: "external",
-    minify: false,
-    external: externalDeps,
-  });
-  if (!browserResult.success) {
-    console.error("Browser build failed:", browserResult.logs);
-    throw new Error("Browser build failed");
-  }
-  console.log(`✅ Browser build complete in ${((Date.now() - browserStart) / 1000).toFixed(2)}s`);
-
-  // Node CJS build. Same rationale as the ESM build above: bundle `index.ts`
-  // directly and rename to `index.node.cjs` to avoid the Bun.build re-export
-  // shim codegen bug.
-  const cjsStart = Date.now();
-  console.log("🧱 Building @elizaos/plugin-farcaster for Node (CJS)...");
-  const cjsResult = await Bun.build({
-    entrypoints: ["index.ts"],
-    outdir: join(distDir, "cjs"),
-    target: "node",
-    format: "cjs",
-    sourcemap: "external",
-    minify: false,
-    external: externalDeps,
-  });
-  if (!cjsResult.success) {
-    console.error("CJS build failed:", cjsResult.logs);
-    throw new Error("CJS build failed");
-  }
-  {
-    const { rename } = await import("node:fs/promises");
-    await rename(join(distDir, "cjs", "index.js"), join(distDir, "cjs", "index.node.cjs"));
-    await rename(join(distDir, "cjs", "index.js.map"), join(distDir, "cjs", "index.node.cjs.map"));
-  }
-  console.log(`✅ CJS build complete in ${((Date.now() - cjsStart) / 1000).toFixed(2)}s`);
-
-  // TypeScript declarations
-  const dtsStart = Date.now();
-  console.log("📝 Generating TypeScript declarations...");
-  const { $ } = await import("bun");
-  await $`tsc --project tsconfig.build.json --noCheck`;
-
-  const nodeDir = join(distDir, "node");
-  const browserDir = join(distDir, "browser");
-  const cjsDir = join(distDir, "cjs");
-
-  await mkdir(nodeDir, { recursive: true });
-  await mkdir(browserDir, { recursive: true });
-  await mkdir(cjsDir, { recursive: true });
-
-  // Package exports point types at dist/{node,browser,cjs}/index.d.ts; declarations
-  // for entry graphs live at dist/index.{node,browser}.d.ts from `tsc`.
-  const nodeIndexDtsPath = join(nodeDir, "index.d.ts");
-  const nodeAlias = `export * from "../index.node";
+await buildPlugin({
+  name: "@elizaos/plugin-farcaster",
+  clean: true,
+  targets: [
+    {
+      label: "Node",
+      entry: "index.ts",
+      outSubdir: "node",
+      target: "node",
+      format: "esm",
+      sourcemap: "external",
+      renames: [
+        ["index.js", "index.node.js"],
+        ["index.js.map", "index.node.js.map"],
+      ],
+    },
+    {
+      label: "Browser",
+      entry: "index.browser.ts",
+      outSubdir: "browser",
+      target: "browser",
+      format: "esm",
+      sourcemap: "external",
+    },
+    {
+      label: "Node (CJS)",
+      entry: "index.ts",
+      outSubdir: "cjs",
+      target: "node",
+      format: "cjs",
+      sourcemap: "external",
+      renames: [
+        ["index.js", "index.node.cjs"],
+        ["index.js.map", "index.node.cjs.map"],
+      ],
+    },
+  ],
+  dtsProject: "tsconfig.build.json",
+  dtsShims: [
+    // Package exports point types at dist/{node,browser,cjs}/index.d.ts;
+    // declarations for entry graphs live at dist/index.{node,browser}.d.ts
+    // from `tsc`.
+    {
+      path: "node/index.d.ts",
+      content: `export * from "../index.node";
 export { default } from "../index.node";
-`;
-  await writeFile(nodeIndexDtsPath, nodeAlias, "utf8");
-  // Adjacent to index.node.js: some TS (bundler + dynamic import) only look for
-  // index.node.d.ts here, not package.json "types".
-  await writeFile(join(nodeDir, "index.node.d.ts"), nodeAlias, "utf8");
-
-  const browserIndexDtsPath = join(browserDir, "index.d.ts");
-  const browserAlias = `export * from "../index.browser";
+`,
+    },
+    // Adjacent to index.node.js: some TS (bundler + dynamic import) only look
+    // for index.node.d.ts here, not package.json "types".
+    {
+      path: "node/index.node.d.ts",
+      content: `export * from "../index.node";
+export { default } from "../index.node";
+`,
+    },
+    {
+      path: "browser/index.d.ts",
+      content: `export * from "../index.browser";
 export { default } from "../index.browser";
-`;
-  await writeFile(browserIndexDtsPath, browserAlias, "utf8");
-
-  const cjsIndexDtsPath = join(cjsDir, "index.d.ts");
-  const cjsAlias = `export * from "../index.node";
+`,
+    },
+    {
+      path: "cjs/index.d.ts",
+      content: `export * from "../index.node";
 export { default } from "../index.node";
-`;
-  await writeFile(cjsIndexDtsPath, cjsAlias, "utf8");
-
-  console.log(`✅ Declarations generated in ${((Date.now() - dtsStart) / 1000).toFixed(2)}s`);
-
-  console.log(`🎉 All builds completed in ${((Date.now() - totalStart) / 1000).toFixed(2)}s`);
-}
-
-build().catch((err) => {
-  console.error("Build failed:", err);
-  process.exit(1);
+`,
+    },
+  ],
 });


### PR DESCRIPTION
Continues **#10078** into the **multi-target tier** — the first plugins migrated onto the shared `buildPlugin` driver that build **node + browser + cjs** (all prior adopters — discord, openai, signal, … — were single Node targets). Follows the byte-identical bar from the merged #10091 / the simple-batch #10228.

## Byte-identical
Built each with its original `build.ts` → recorded sorted per-file `sha256` of `dist/` (BEFORE) → replaced with the `buildPlugin({...})` shim → rebuilt → diffed. **Empty diff; every file's hash matches**, reconfirmed by a clean rebuild from the committed shim:

| plugin | dist files | sha256 |
|---|---|---|
| plugin-bluesky | 41 | all identical |
| plugin-farcaster | 72 | all identical |

Net **−154 lines** of duplicated multi-target orchestration.

## How the driver expressed the multi-target pattern (no gaps)
- `targets[]` → the three subdirs (`dist/node` esm, `dist/browser` esm, `dist/cjs`) with per-target `outSubdir`/`target`/`format`/`sourcemap`.
- **`renames` (not `naming`) is load-bearing.** The originals bundle the real `index.ts` and `fs.rename` `index.js`→`index.node.js`/`index.node.cjs` (+ `.map`) *in place*, leaving the inner `//# sourceMappingURL` comment and the map `file` field pointing at the old name. The driver's `renames` is a plain rename, so those stale internal refs are preserved exactly — `naming:{entry}` would make Bun emit the new name and rewrite those refs → NOT byte-identical. This also preserves the documented Bun "default2" re-export-shim codegen workaround (bundle the real entry, rename after).
- `dtsShims` reproduced the hand-written alias `index.d.ts` files exactly — including the two plugins' genuinely different shapes (bluesky: root + browser + cjs shims, keeps tsc's real `node/index.d.ts`; farcaster: overwrites `node/index.d.ts`→`../index.node`, adds `node/index.node.d.ts` + browser + cjs, no root shim).
- `clean` matched per-plugin (`true` for farcaster; default-false for bluesky).

## Verification
- `bun run --cwd plugins/plugin-{bluesky,farcaster} build` → exit 0, dist 41 / 72 (matching manifests).
- Both shims typecheck against the driver API (exit 0).

Refs #10078. Establishes the reusable multi-target migration pattern for the remaining node+browser+cjs plugins (elizacloud, agent-orchestrator, …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)