### PR TITLE
chore(build): migrate agent-orchestrator (multi-target) onto shared buildPlugin (#10078)

### DIFF
--- a/plugins/plugin-agent-orchestrator/build.ts
+++ b/plugins/plugin-agent-orchestrator/build.ts
@@ -1,104 +1,50 @@
 #!/usr/bin/env bun
-
 /**
- * Build script for @elizaos/plugin-agent-orchestrator (Node + Browser)
+ * Build script for @elizaos/plugin-agent-orchestrator (Node + Node CJS).
+ * Orchestration lives in the shared driver (plugins/plugin-build.ts); this
+ * lists only what differs.
+ *
+ * No browser build: this plugin includes Node-only services (ACP subprocess
+ * sessions, workspace lifecycle, child_process spawn). Browser callers should
+ * only depend on the type definitions; the package's `exports` field points the
+ * browser condition at the same node bundle for resolution purposes but the
+ * runtime is Node/bun.
  */
+import { buildPlugin } from "../plugin-build";
 
-import { existsSync } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
-import { join } from "node:path";
-import { externalsFromPackageJson } from "../plugin-build-externals.ts";
-
-const externalDeps = await externalsFromPackageJson("./package.json");
-
-async function build() {
-  const totalStart = Date.now();
-  const distDir = join(process.cwd(), "dist");
-
-  const nodeStart = Date.now();
-  console.log("🔨 Building @elizaos/plugin-agent-orchestrator for Node...");
-  const nodeResult = await Bun.build({
-    entrypoints: ["index.node.ts"],
-    outdir: join(distDir, "node"),
-    target: "node",
-    format: "esm",
-    sourcemap: "external",
-    minify: false,
-    external: externalDeps,
-  });
-  if (!nodeResult.success) {
-    console.error("Node build failed:", nodeResult.logs);
-    throw new Error("Node build failed");
-  }
-  console.log(
-    `✅ Node build complete in ${((Date.now() - nodeStart) / 1000).toFixed(2)}s`,
-  );
-
-  // No browser build: this plugin includes Node-only services (ACP subprocess
-  // sessions, workspace lifecycle, child_process spawn). Browser callers should
-  // only depend on the type definitions; the package's `exports` field
-  // points the browser condition at the same node bundle for resolution
-  // purposes but the runtime is Node/bun.
-
-  const cjsStart = Date.now();
-  console.log(
-    "🧱 Building @elizaos/plugin-agent-orchestrator for Node (CJS)...",
-  );
-  const cjsResult = await Bun.build({
-    entrypoints: ["index.node.ts"],
-    outdir: join(distDir, "cjs"),
-    target: "node",
-    format: "cjs",
-    sourcemap: "external",
-    minify: false,
-    external: externalDeps,
-  });
-  if (!cjsResult.success) {
-    console.error("CJS build failed:", cjsResult.logs);
-    throw new Error("CJS build failed");
-  }
-  try {
-    const { rename } = await import("node:fs/promises");
-    await rename(
-      join(distDir, "cjs", "index.node.js"),
-      join(distDir, "cjs", "index.node.cjs"),
-    );
-  } catch (e) {
-    console.warn("CJS rename step warning:", e);
-  }
-  console.log(
-    `✅ CJS build complete in ${((Date.now() - cjsStart) / 1000).toFixed(2)}s`,
-  );
-
-  const dtsStart = Date.now();
-  console.log("📝 Generating TypeScript declarations...");
-  const { $ } = await import("bun");
-  await $`tsc --project tsconfig.build.json --noCheck`;
-
-  const nodeDir = join(distDir, "node");
-  const cjsDir = join(distDir, "cjs");
-
-  if (!existsSync(nodeDir)) await mkdir(nodeDir, { recursive: true });
-  if (!existsSync(cjsDir)) await mkdir(cjsDir, { recursive: true });
-
-  const rootAlias = `export * from "./node/index";\nexport { default } from "./node/index";\n`;
-  await writeFile(join(distDir, "index.d.ts"), rootAlias, "utf8");
-
-  const nodeAlias = `export * from "./index.node";\nexport { default } from "./index.node";\n`;
-  await writeFile(join(nodeDir, "index.d.ts"), nodeAlias, "utf8");
-
-  const cjsAlias = `export * from "./index.node";\nexport { default } from "./index.node";\n`;
-  await writeFile(join(cjsDir, "index.d.ts"), cjsAlias, "utf8");
-
-  console.log(
-    `✅ Declarations generated in ${((Date.now() - dtsStart) / 1000).toFixed(2)}s`,
-  );
-  console.log(
-    `🎉 All builds completed in ${((Date.now() - totalStart) / 1000).toFixed(2)}s`,
-  );
-}
-
-build().catch((err) => {
-  console.error("Build failed:", err);
-  process.exit(1);
+await buildPlugin({
+  name: "@elizaos/plugin-agent-orchestrator",
+  externals: "auto",
+  targets: [
+    {
+      label: "Node",
+      entry: "index.node.ts",
+      outSubdir: "node",
+      target: "node",
+      format: "esm",
+    },
+    {
+      label: "Node (CJS)",
+      entry: "index.node.ts",
+      outSubdir: "cjs",
+      target: "node",
+      format: "cjs",
+      renames: [["index.node.js", "index.node.cjs"]],
+    },
+  ],
+  dtsProject: "tsconfig.build.json",
+  dtsShims: [
+    {
+      path: "index.d.ts",
+      content: `export * from "./node/index";\nexport { default } from "./node/index";\n`,
+    },
+    {
+      path: "node/index.d.ts",
+      content: `export * from "./index.node";\nexport { default } from "./index.node";\n`,
+    },
+    {
+      path: "cjs/index.d.ts",
+      content: `export * from "./index.node";\nexport { default } from "./index.node";\n`,
+    },
+  ],
 });


### PR DESCRIPTION
Continues **#10078** — migrates `plugin-agent-orchestrator` (Node ESM + Node CJS + d.ts + 3 hand-written alias files) onto the shared `buildPlugin` driver, using the multi-target pattern established in #10230.

## Byte-identical
Original build → sorted per-file `sha256` of `dist/` (BEFORE) → `buildPlugin({...})` shim → rebuild → diff. **Empty diff; all 178 files match**, confirmed across three clean rebuilds.

- two `targets` (`node`→`dist/node`, `cjs`→`dist/cjs` with `renames:[["index.node.js","index.node.cjs"]]`, leaving the `.map` unrenamed to match the original exactly)
- `externals:"auto"`, `dtsProject:"tsconfig.build.json"` (`--noCheck`), 3 `dtsShims` reproducing `index.d.ts` / `node/index.d.ts` / `cjs/index.d.ts` verbatim
- `bun run build` exit 0 (178 files); shim typechecks against the driver.

Net **−54 lines**.

## Sibling finding — `plugin-elizacloud` deferred (real driver gap, not done here)
While batching, `plugin-elizacloud` was attempted and **reverted** because it can't be made byte-identical with the current driver: its build has a 4th `Bun.build` over a `src/**` glob (`naming:[dir]/[name]`) that emits to `dist/src/<...>`, which the hand-rolled script then **flattens** up into `dist/<...>` and removes `dist/src`. The driver's `renames` is single-file and doesn't `mkdir` the destination parent, so it can't express a recursive "move `dist/<subdir>/* → dist/` then rmdir" flatten. **Suggested driver enhancement for #10078:** an optional `flatten`/`moveUp` post-target hook (mkdir-p + recursive move + remove source dir) would unblock elizacloud and any plugin in that glob-subpath family. Filed here as signal; not implemented in this PR (scope = byte-identical migrations only).

Refs #10078.

🤖 Generated with [Claude Code](https://claude.com/claude-code)