### PR TITLE
fix(agent): room-scope keyword message search so LIMIT applies after access-filter (#9955)

### DIFF
--- a/packages/agent/src/api/__tests__/conversation-message-search.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-message-search.test.ts
@@ -1,9 +1,13 @@
 /**
  * Endpoint test for `GET /api/conversations/messages/search` — the keyword
  * message search added for #9955. Drives the real `handleConversationRoutes`
- * with a mocked runtime whose `getMemories` honours the `textContains` predicate
- * (as the SQL / in-memory adapters do), and asserts validation, ranking,
- * snippeting, role attribution, and accessible-conversation scoping.
+ * with a mocked runtime whose `getMemoriesByRoomIds` models the real SQL /
+ * in-memory adapters: it room-scopes, applies the `textContains` predicate,
+ * orders by `createdAt` desc, and only THEN windows with `offset`/`limit`.
+ * Asserts validation, ranking, snippeting, role attribution, accessible-
+ * conversation scoping, and (the #9955 regression) that the LIMIT is applied
+ * after access-scoping so an accessible older hit is not dropped by newer
+ * matches in rooms the requester cannot see.
  */
 import type { AgentRuntime, Memory, UUID } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
@@ -82,13 +86,36 @@ function makeState(
   memories: Memory[],
   conversations: ConversationMeta[],
 ): ConversationRouteState {
-  const getMemories = vi.fn(async (params: { textContains?: string }) => {
-    const needle = params.textContains?.toLowerCase() ?? "";
-    return memories.filter((m) =>
-      (m.content as { text: string }).text.toLowerCase().includes(needle),
-    );
-  });
-  const runtime = { agentId, getMemories } as unknown as AgentRuntime;
+  // Model the real adapter (plugin-sql `getMemoriesByRoomIds`): room-scope
+  // first, apply the case-insensitive `textContains` predicate, order by
+  // createdAt desc, and ONLY THEN window with offset+limit. Modelling the
+  // limit/offset is what makes the #9955 regression test meaningful — a mock
+  // that ignored them could not catch a limit-before-filter bug.
+  const getMemoriesByRoomIds = vi.fn(
+    async (params: {
+      roomIds: UUID[];
+      textContains?: string;
+      limit?: number;
+      offset?: number;
+    }) => {
+      const rooms = new Set(params.roomIds);
+      const needle = params.textContains?.toLowerCase() ?? "";
+      const filtered = memories
+        .filter((m) => m.roomId !== undefined && rooms.has(m.roomId))
+        .filter((m) =>
+          String(m.content.text ?? "")
+            .toLowerCase()
+            .includes(needle),
+        )
+        .sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0));
+      const offset = params.offset ?? 0;
+      const windowed = offset > 0 ? filtered.slice(offset) : filtered;
+      return params.limit !== undefined
+        ? windowed.slice(0, params.limit)
+        : windowed;
+    },
+  );
+  const runtime = { agentId, getMemoriesByRoomIds } as unknown as AgentRuntime;
   return {
     runtime,
     conversations: new Map(conversations.map((c) => [c.id, c])),
@@ -168,5 +195,51 @@ describe("GET /api/conversations/messages/search", () => {
     };
     expect(body.count).toBe(1);
     expect(body.results[0].text).toContain("known room");
+  });
+
+  it("returns an accessible OLDER hit even when newer matches fill the limit in inaccessible rooms (#9955 limit-before-filter regression)", async () => {
+    // roomA is accessible and holds ONE older matching message. roomB is NOT an
+    // accessible conversation but holds several NEWER matching messages. With a
+    // small limit, the old "getMemories(global limit) then JS-filter" order
+    // would take the newest-N (all in roomB), filter them out, and return
+    // nothing. Room-scoping the SQL query keeps the accessible older hit.
+    const memories = [
+      mem("webxr in the accessible room — older", roomA, userId, 5),
+      mem("webxr newer noise in orphan room", roomB, userId, 10),
+      mem("webxr newer noise in orphan room", roomB, userId, 11),
+      mem("webxr newer noise in orphan room", roomB, userId, 12),
+    ];
+    const result = await runSearch(
+      "/api/conversations/messages/search?q=webxr&limit=2",
+      makeState(memories, [conv("c-a", roomA)]),
+    );
+    const body = result.body as {
+      results: Array<{ text: string; conversationId: string }>;
+      count: number;
+    };
+    expect(result.status).toBe(200);
+    expect(body.count).toBe(1);
+    expect(body.results[0].text).toContain("accessible room");
+    expect(body.results[0].conversationId).toBe("c-a");
+  });
+
+  it("returns no results (without touching the store) when the requester has no accessible conversations", async () => {
+    const memories = [mem("webxr in an orphan room", roomB, userId, 1)];
+    const state = makeState(memories, []);
+    const result = await runSearch(
+      "/api/conversations/messages/search?q=webxr",
+      state,
+    );
+    const body = result.body as { results: unknown[]; count: number };
+    expect(result.status).toBe(200);
+    expect(body.count).toBe(0);
+    expect(body.results).toEqual([]);
+    expect(
+      (
+        state.runtime as unknown as {
+          getMemoriesByRoomIds: { mock: { calls: unknown[] } };
+        }
+      ).getMemoriesByRoomIds.mock.calls,
+    ).toHaveLength(0);
   });
 });

--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -1367,16 +1367,26 @@ export async function handleConversationRoutes(
     );
     const runtime = state.runtime;
     const waifuAccess = resolveWaifuChatAccess(req);
-    const conversationsByRoomId = new Map<string, ConversationMeta>();
+    const conversationsByRoomId = new Map<UUID, ConversationMeta>();
     for (const conv of state.conversations.values()) {
       if (state.deletedConversationIds.has(conv.id)) continue;
       if (!canWaifuAccessConversation(waifuAccess, conv)) continue;
       conversationsByRoomId.set(conv.roomId, conv);
     }
+    // Scope the keyword search to the rooms the requester can actually see, in
+    // SQL. Filtering after a global LIMIT (newest-N across *all* the agent's
+    // rooms — discord/telegram/inbox/deleted/…) would silently drop accessible
+    // matches that fall outside that window. Pushing the room set into the store
+    // applies LIMIT/OFFSET after access-scoping.
+    const accessibleRoomIds = Array.from(conversationsByRoomId.keys());
+    if (accessibleRoomIds.length === 0) {
+      json(res, { results: [], count: 0 });
+      return true;
+    }
     try {
-      const memories = await runtime.getMemories({
+      const memories = await runtime.getMemoriesByRoomIds({
         tableName: "messages",
-        agentId: runtime.agentId,
+        roomIds: accessibleRoomIds,
         textContains: query,
         includeEmbedding: false,
         limit,
@@ -1389,7 +1399,7 @@ export async function handleConversationRoutes(
             ? conversationsByRoomId.get(roomId)
             : undefined;
           if (!roomId || !conversation) return null;
-          const text = (memory.content as { text?: unknown } | undefined)?.text;
+          const text = memory.content.text;
           if (typeof text !== "string") return null;
           const rawText = text.trim();
           if (!rawText) return null;
@@ -1398,8 +1408,10 @@ export async function handleConversationRoutes(
           if (score <= 0) return null;
           const role =
             memory.entityId === runtime.agentId ? "assistant" : "user";
-          const createdAt =
-            typeof memory.createdAt === "number" ? memory.createdAt : 0;
+          // A messages memory always carries a numeric createdAt; if it somehow
+          // does not, drop the row rather than inject epoch-0 into the DTO.
+          if (typeof memory.createdAt !== "number") return null;
+          const createdAt = memory.createdAt;
           return {
             messageId: memory.id,
             conversationId: conversation.id,

--- a/packages/core/src/database.ts
+++ b/packages/core/src/database.ts
@@ -252,6 +252,9 @@ export abstract class DatabaseAdapter<DB extends object = object>
 		roomIds: UUID[];
 		tableName: string;
 		limit?: number;
+		offset?: number;
+		textContains?: string;
+		includeEmbedding?: boolean;
 		accessContext?: AccessContext;
 	}): Promise<Memory[]>;
 

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -846,12 +846,11 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 		// adapter pushes down as ILIKE.
 		const textContains = params.textContains?.trim().toLowerCase();
 		if (textContains) {
-			all = all.filter((memory) => {
-				const text = (memory.content as { text?: unknown } | undefined)?.text;
-				return (
-					typeof text === "string" && text.toLowerCase().includes(textContains)
-				);
-			});
+			all = all.filter((memory) =>
+				String(memory.content.text ?? "")
+					.toLowerCase()
+					.includes(textContains),
+			);
 		}
 
 		// Match plugin-sql ordering: newest first, then id desc as tiebreaker.
@@ -890,19 +889,40 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 		tableName: string;
 		roomIds: UUID[];
 		limit?: number;
+		offset?: number;
+		textContains?: string;
+		includeEmbedding?: boolean;
 		accessContext?: AccessContext;
 	}): Promise<Memory[]> {
-		const limit = params.limit ?? 20;
-		const out: Memory[] = [];
+		let all: Memory[] = [];
 		for (const rid of params.roomIds) {
 			const list =
 				this.memoriesByRoom.get(roomTableKey(params.tableName, rid)) ?? [];
-			for (const m of list) {
-				out.push(m);
-				if (out.length >= limit) return out;
-			}
+			all.push(...list);
 		}
-		return out;
+
+		// Keyword filter — same case-insensitive `includes` semantics the SQL
+		// adapter pushes down as ILIKE.
+		const textContains = params.textContains?.trim().toLowerCase();
+		if (textContains) {
+			all = all.filter((memory) =>
+				String(memory.content.text ?? "")
+					.toLowerCase()
+					.includes(textContains),
+			);
+		}
+
+		// Match plugin-sql ordering: newest first so LIMIT/OFFSET window the
+		// freshest matches.
+		all = all.slice().sort((a, b) => {
+			const ta = typeof a.createdAt === "number" ? a.createdAt : 0;
+			const tb = typeof b.createdAt === "number" ? b.createdAt : 0;
+			return tb - ta;
+		});
+
+		const offset = typeof params.offset === "number" ? params.offset : 0;
+		const limit = params.limit ?? 20;
+		return all.slice(offset, offset + limit);
 	}
 
 	async getCachedEmbeddings(): Promise<

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -7931,6 +7931,9 @@ ${section_end}`;
 		tableName: string;
 		roomIds: UUID[];
 		limit?: number;
+		offset?: number;
+		textContains?: string;
+		includeEmbedding?: boolean;
 		accessContext?: AccessContext;
 	}): Promise<Memory[]> {
 		return this.adapter.getMemoriesByRoomIds(params);

--- a/packages/core/src/types/database.ts
+++ b/packages/core/src/types/database.ts
@@ -947,6 +947,21 @@ export interface IDatabaseAdapter<DB extends object = object> {
 		roomIds: UUID[];
 		limit?: number;
 		/**
+		 * Skip the first N matching results. Applied after room-scoping and the
+		 * `textContains` filter so the LIMIT/OFFSET window is taken over the
+		 * already-filtered, ordered result set. Used for paginated keyword search.
+		 */
+		offset?: number;
+		/**
+		 * Case-insensitive keyword predicate over `Memory.content.text`. SQL
+		 * adapters push this into the database (`ILIKE`); in-memory adapters apply
+		 * the same `includes` semantics. Lets keyword message search scope to a set
+		 * of accessible rooms AND filter by keyword in a single store query, so the
+		 * LIMIT is applied after access-scoping rather than across every room.
+		 */
+		textContains?: string;
+		includeEmbedding?: boolean;
+		/**
 		 * Requester identity to scope retrieval to. When omitted, no
 		 * access-context filtering is applied (single-tenant behavior).
 		 */

--- a/plugins/plugin-inmemorydb/adapter.ts
+++ b/plugins/plugin-inmemorydb/adapter.ts
@@ -580,10 +580,10 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
         }
       }
       if (textContains) {
-        const text = (m.content as { text?: unknown } | undefined)?.text;
         if (
-          typeof text !== "string" ||
-          !text.toLowerCase().includes(textContains)
+          !String(m.content.text ?? "")
+            .toLowerCase()
+            .includes(textContains)
         ) {
           return false;
         }
@@ -598,9 +598,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
       if (ta !== tb) return direction === "asc" ? ta - tb : tb - ta;
       const aId = typeof a.id === "string" ? a.id : "";
       const bId = typeof b.id === "string" ? b.id : "";
-      return direction === "asc"
-        ? aId.localeCompare(bId)
-        : bId.localeCompare(aId);
+      return direction === "asc" ? aId.localeCompare(bId) : bId.localeCompare(aId);
     });
 
     const offset = typeof params.offset === "number" ? params.offset : 0;
@@ -615,18 +613,33 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
     roomIds: UUID[];
     tableName: string;
     limit?: number;
+    offset?: number;
+    textContains?: string;
+    includeEmbedding?: boolean;
     accessContext?: AccessContext;
   }): Promise<Memory[]> {
     if (params.roomIds.length === 0) return [];
     const roomSet = new Set(params.roomIds);
-    const memories = await this.storage.getWhere<StoredMemory>(
-      COLLECTIONS.MEMORIES,
-      (m) =>
-        roomSet.has(m.roomId as UUID) &&
-        (params.tableName ? m.metadata?.type === params.tableName : true)
-    );
+    const textContains = params.textContains?.trim().toLowerCase();
+    const memories = await this.storage.getWhere<StoredMemory>(COLLECTIONS.MEMORIES, (m) => {
+      if (!roomSet.has(m.roomId as UUID)) return false;
+      if (params.tableName && m.metadata?.type !== params.tableName) return false;
+      // Same case-insensitive `includes` semantics the SQL adapter pushes
+      // down as ILIKE.
+      if (
+        textContains &&
+        !String(m.content.text ?? "")
+          .toLowerCase()
+          .includes(textContains)
+      ) {
+        return false;
+      }
+      return true;
+    });
     memories.sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0));
-    const sliced = params.limit ? memories.slice(0, params.limit) : memories;
+    const offset = typeof params.offset === "number" ? params.offset : 0;
+    let sliced = offset > 0 ? memories.slice(offset) : memories;
+    if (params.limit !== undefined) sliced = sliced.slice(0, params.limit);
     return sliced.map(toMemory);
   }
 

--- a/plugins/plugin-sql/src/__tests__/integration/memory-text-contains.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/memory-text-contains.real.test.ts
@@ -1,0 +1,214 @@
+import {
+  ChannelType,
+  type Content,
+  type Entity,
+  type Memory,
+  type MemoryMetadata,
+  MemoryType,
+  type Room,
+  type UUID,
+  type World,
+} from "@elizaos/core";
+import { v4 } from "uuid";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { PgDatabaseAdapter } from "../../pg/adapter";
+import type { PgliteDatabaseAdapter } from "../../pglite/adapter";
+import { embeddingTable, memoryTable } from "../../schema";
+import type { DrizzleDatabase } from "../../types";
+import { createIsolatedTestDatabase } from "../test-helpers";
+
+/**
+ * Focused correctness test for the keyword (`textContains`) predicate on the
+ * SQL `getMemories` path — the small, fast complement to the 200k-row
+ * `memory-keyword-search.real.test.ts` scale test.
+ *
+ * It pins the load-bearing details the scale test cannot exercise cheaply:
+ * literal `_` and backslash escaping (not just `%`), AND-composition with the
+ * existing `roomId` / `tableName` filters, and that the predicate targets
+ * `content->>'text'` ONLY (a token hidden in another `content` field or in
+ * `metadata` must NOT match). Runs on PGlite by default; set `POSTGRES_URL`
+ * to run against a real Postgres.
+ */
+describe("getMemories textContains keyword filter (real SQL adapter)", () => {
+  let adapter: PgliteDatabaseAdapter | PgDatabaseAdapter;
+  let cleanup: () => Promise<void>;
+  let testAgentId: UUID;
+  let roomA: UUID;
+  let roomB: UUID;
+  let entityId: UUID;
+
+  beforeAll(async () => {
+    const setup = await createIsolatedTestDatabase("memory_text_contains");
+    adapter = setup.adapter;
+    cleanup = setup.cleanup;
+    testAgentId = setup.testAgentId;
+
+    const worldId = v4() as UUID;
+    await adapter.createWorld({
+      id: worldId,
+      agentId: testAgentId,
+      name: "TextContains World",
+      serverId: "text-contains-server",
+    } as World);
+
+    roomA = v4() as UUID;
+    roomB = v4() as UUID;
+    await adapter.createRooms([
+      {
+        id: roomA,
+        agentId: testAgentId,
+        worldId,
+        name: "room-a",
+        source: "test",
+        type: ChannelType.DM,
+      } as Room,
+      {
+        id: roomB,
+        agentId: testAgentId,
+        worldId,
+        name: "room-b",
+        source: "test",
+        type: ChannelType.DM,
+      } as Room,
+    ]);
+
+    entityId = v4() as UUID;
+    await adapter.createEntities([
+      { id: entityId, agentId: testAgentId, names: ["Text Entity"] } as Entity,
+    ]);
+    await adapter.addParticipant(entityId, roomA);
+    await adapter.addParticipant(entityId, roomB);
+  });
+
+  afterAll(async () => {
+    if (cleanup) await cleanup();
+  });
+
+  beforeEach(async () => {
+    const db = adapter.getDatabase() as DrizzleDatabase;
+    await db.delete(embeddingTable);
+    await db.delete(memoryTable);
+  });
+
+  /** Seed one row (defaults to the `messages` table in `roomA`). */
+  const seed = async (
+    content: Content,
+    options: { roomId?: UUID; tableName?: string } = {}
+  ): Promise<void> => {
+    const memory: Memory & { metadata: MemoryMetadata } = {
+      id: v4() as UUID,
+      agentId: testAgentId,
+      roomId: options.roomId ?? roomA,
+      entityId,
+      content,
+      createdAt: Date.now(),
+      unique: false,
+      metadata: { type: MemoryType.MESSAGE, source: "test" },
+    };
+    await adapter.createMemory(memory, options.tableName ?? "messages");
+  };
+
+  const textsFor = async (
+    textContains: string,
+    options: { roomId?: UUID; tableName?: string } = {}
+  ): Promise<string[]> => {
+    const rows = await adapter.getMemories({
+      tableName: options.tableName ?? "messages",
+      roomId: options.roomId ?? roomA,
+      textContains,
+      includeEmbedding: false,
+    });
+    return rows
+      .map((row) => row.content.text)
+      .filter((text): text is string => typeof text === "string");
+  };
+
+  it("matches case-insensitively (ILIKE, not LIKE)", async () => {
+    await seed({ text: "Hello World" });
+    await seed({ text: "goodbye" });
+
+    for (const needle of ["hello", "HELLO", "HeLLo"]) {
+      const texts = await textsFor(needle);
+      expect(texts).toEqual(["Hello World"]);
+    }
+  });
+
+  it("matches an arbitrary substring, not just a prefix or whole word", async () => {
+    await seed({ text: "the quick brown fox" });
+
+    expect(await textsFor("quick")).toEqual(["the quick brown fox"]);
+    expect(await textsFor("own fo")).toEqual(["the quick brown fox"]);
+    expect(await textsFor("brown fox")).toEqual(["the quick brown fox"]);
+  });
+
+  it("returns nothing when no row contains the keyword", async () => {
+    await seed({ text: "alpha" });
+    await seed({ text: "beta" });
+
+    expect(await textsFor("gamma")).toEqual([]);
+  });
+
+  it("escapes a literal `%` so it is not a wildcard", async () => {
+    await seed({ text: "50% off sale" });
+    await seed({ text: "50 percent off" });
+
+    // Unescaped, `%50%%` would also match "50 percent off".
+    expect(await textsFor("50%")).toEqual(["50% off sale"]);
+  });
+
+  it("escapes a literal `_` so it is not a single-char wildcard", async () => {
+    await seed({ text: "user_name field" });
+    await seed({ text: "username field" });
+    await seed({ text: "userXname field" });
+
+    // Unescaped, `_` would match the X and the absent char too.
+    expect(await textsFor("user_name")).toEqual(["user_name field"]);
+  });
+
+  it("escapes a literal backslash so the ESCAPE char does not corrupt the pattern", async () => {
+    await seed({ text: "path\\to\\file" });
+    await seed({ text: "pathtofile" });
+
+    expect(await textsFor("path\\to")).toEqual(["path\\to\\file"]);
+  });
+
+  it("treats an empty / whitespace query as a no-op filter", async () => {
+    await seed({ text: "one" });
+    await seed({ text: "two" });
+    await seed({ text: "three" });
+
+    expect((await textsFor("")).sort()).toEqual(["one", "three", "two"]);
+    expect((await textsFor("   ")).sort()).toEqual(["one", "three", "two"]);
+  });
+
+  it("AND-combines with the roomId filter (scoped, not OR)", async () => {
+    await seed({ text: "find me here" }, { roomId: roomA });
+    await seed({ text: "find me there" }, { roomId: roomB });
+
+    expect(await textsFor("find", { roomId: roomA })).toEqual(["find me here"]);
+    expect(await textsFor("find", { roomId: roomB })).toEqual(["find me there"]);
+  });
+
+  it("AND-combines with the tableName (type) filter", async () => {
+    await seed({ text: "find me in messages" }, { tableName: "messages" });
+    await seed({ text: "find me in memories" }, { tableName: "memories" });
+
+    expect(await textsFor("find", { tableName: "messages" })).toEqual(["find me in messages"]);
+    expect(await textsFor("find", { tableName: "memories" })).toEqual(["find me in memories"]);
+  });
+
+  it("matches `content->>'text'` ONLY — not other content fields or metadata", async () => {
+    // The needle lives in `content.thought` / `content.source`, never in
+    // `content.text`. A whole-jsonb `content::text ILIKE` would wrongly match;
+    // the `->>'text'` extraction must not.
+    await seed({
+      text: "totally ordinary message body",
+      thought: "zzqhiddenxx internal reasoning",
+      source: "zzqhiddenxx",
+    });
+    // A control row whose text DOES carry the needle, so a positive match exists.
+    await seed({ text: "this line mentions zzqhiddenxx directly" });
+
+    expect(await textsFor("zzqhiddenxx")).toEqual(["this line mentions zzqhiddenxx directly"]);
+  });
+});

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -158,10 +158,7 @@ function normalizeAgentBio(value: unknown): string[] | undefined {
 
 /** Escape an ILIKE literal so user keywords match literally (no `%`/`_` wildcards). */
 function escapeIlikeLiteral(value: string): string {
-  return value
-    .replaceAll("\\", "\\\\")
-    .replaceAll("%", "\\%")
-    .replaceAll("_", "\\_");
+  return value.replaceAll("\\", "\\\\").replaceAll("%", "\\%").replaceAll("_", "\\_");
 }
 
 type CountMemoriesParams = {
@@ -1479,10 +1476,13 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
       }
 
       if (textContains) {
-        // Push the keyword filter into the store as an indexed ILIKE; user
-        // input is escaped so `%`/`_` match literally, not as wildcards.
+        // Push the keyword filter into the store as a case-insensitive ILIKE;
+        // user input is escaped so `%`/`_` match literally, not as wildcards.
+        // This is a sequential filter over `content->>'text'`, not index-backed.
+        // TODO(#9955): pg_trgm GIN index on content->>'text' for sub-linear
+        // keyword search at scale.
         conditions.push(
-          sql`(${memoryTable.content}->>'text') ILIKE ${`%${escapeIlikeLiteral(textContains)}%`} ESCAPE '\\'`,
+          sql`(${memoryTable.content}->>'text') ILIKE ${`%${escapeIlikeLiteral(textContains)}%`} ESCAPE '\\'`
         );
       }
 
@@ -1585,6 +1585,9 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
     roomIds: UUID[];
     tableName: string;
     limit?: number;
+    offset?: number;
+    textContains?: string;
+    includeEmbedding?: boolean;
     accessContext?: AccessContext;
   }): Promise<Memory[]> {
     return this.withDatabase(async () => {
@@ -1597,7 +1600,18 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
 
       conditions.push(eq(memoryTable.agentId, this.agentId));
 
-      const query = this.db
+      const textContains = params.textContains?.trim();
+      if (textContains) {
+        // Same case-insensitive keyword predicate as getMemories: a sequential
+        // ILIKE over `content->>'text'` (not index-backed). Escaped so `%`/`_`
+        // match literally. Scoping to roomIds first narrows the scan via the
+        // (type, roomId) index. TODO(#9955): pg_trgm GIN index for scale.
+        conditions.push(
+          sql`(${memoryTable.content}->>'text') ILIKE ${`%${escapeIlikeLiteral(textContains)}%`} ESCAPE '\\'`
+        );
+      }
+
+      const baseQuery = this.db
         .select({
           id: memoryTable.id,
           type: memoryTable.type,
@@ -1613,7 +1627,17 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         .where(and(...conditions))
         .orderBy(desc(memoryTable.createdAt));
 
-      const rows = params.limit ? await query.limit(params.limit) : await query;
+      const { limit, offset } = params;
+      const rows = await (async () => {
+        if (limit !== undefined && offset !== undefined && offset > 0) {
+          return baseQuery.limit(limit).offset(offset);
+        } else if (limit !== undefined) {
+          return baseQuery.limit(limit);
+        } else if (offset !== undefined && offset > 0) {
+          return baseQuery.offset(offset);
+        }
+        return baseQuery;
+      })();
 
       return rows.map((row) => ({
         id: row.id as UUID,

--- a/plugins/plugin-sql/src/package.json
+++ b/plugins/plugin-sql/src/package.json
@@ -76,6 +76,7 @@
     "test:migration": "vitest run __tests__/migration/",
     "test:migration:postgres": "vitest run __tests__/migration/",
     "test:real": "bun run test:integration && bun run test:migration",
+    "test:real:files": "vitest run --config vitest.real.config.ts",
     "test:e2e:upgrade": "bash __tests__/migration/e2e/run-upgrade-test.sh",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/plugins/plugin-sql/src/vitest.real.config.ts
+++ b/plugins/plugin-sql/src/vitest.real.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from "vitest/config";
+
+// Companion to `vitest.config.ts` that INCLUDES the real (`*.real.test.ts`)
+// suites the default config statically excludes — the focused
+// `memory-text-contains` adapter coverage plus the `memory-keyword-search`
+// scale test. These exercise a real SQL store: PGlite by default, or a live
+// Postgres via `POSTGRES_URL`.
+//
+// Why a separate config: `vitest.config.ts` hard-excludes the real suites
+// (kept intentionally — see #9955) and no `run-all-tests.mjs` lane runs them,
+// so they were otherwise unrunnable. Invoke on demand via
+// `bun run test:real:files`. Build `@elizaos/core` first (e.g. `bun run build`),
+// since this config relies on normal workspace resolution rather than aliasing
+// core to its TS source.
+export default defineConfig({
+  test: {
+    include: ["**/*.real.test.ts"],
+    exclude: ["**/node_modules/**", "**/dist/**", "**/*.real.e2e.test.ts"],
+    hookTimeout: 120000,
+    testTimeout: 300000,
+    pool: "forks",
+    isolate: true,
+    fileParallelism: false,
+    retry: 1,
+    reporters: process.env.CI ? ["verbose"] : ["default"],
+  },
+});


### PR DESCRIPTION
The #9955 keyword-search backend shipped in #10145 (+ #10169 scale test). An adversarial review of the merged code (3 verifier agents) found a **MAJOR correctness bug** plus type-discipline and test-lane gaps. This PR fixes them.

## The bug (silently dropped accessible results)
`GET /api/conversations/messages/search` called `getMemories({ agentId, textContains, limit, offset })` — applying `LIMIT` across **all** of the agent's rooms (discord/telegram/inbox/deleted/other-waifu — up to 2000) ordered by recency — and **only then** JS-filtered to the accessible dashboard conversations. So an accessible *older* match was silently evicted by newer matches in inaccessible rooms → `{results:[],count:0}`. This is exactly the "collapses on real histories" failure #9955 warns against, re-introduced as limit-before-filter.

## Fix — push room-scoping into SQL (single query, LIMIT after scoping)
- Added `textContains?` + `offset?` (+ `includeEmbedding?` for call-site parity) to **`getMemoriesByRoomIds`** across the contract (`core/types/database.ts`), `plugin-sql` (reuses the existing `escapeIlikeLiteral` + `ILIKE … ESCAPE` predicate over `content->>'text'`, now with `.offset()`), and both in-memory adapters (case-insensitive `includes`, identical semantics).
- The endpoint now calls `getMemoriesByRoomIds({ roomIds: accessibleRoomIds, textContains, limit, offset })` (early-returns on no accessible rooms). One SQL query: `type='messages' AND roomId IN (accessible) AND agentId=? AND content->>'text' ILIKE %q% ESCAPE '\' ORDER BY createdAt DESC LIMIT/OFFSET`. `LIMIT` now applies **after** access-scoping; no scan-all-rooms JS.

## Also fixed (repo type rules)
- Removed `?? 0` papering on the required `createdAt` DTO field → drop the row if `createdAt` isn't a number (don't inject epoch-0).
- Removed the redundant `(memory.content as { text?: unknown })?.text` casts (endpoint + both in-memory adapters) → typed `memory.content.text`.
- Corrected the misleading "indexed ILIKE" comment in `base.ts` to "sequential filter" + added `TODO(#9955)` for a pg_trgm GIN index (deferred — PGlite extension support is uncertain; room-scoping already narrows the common case via the `(type,roomId)` index).

## Tests
- **Regression test** (`conversation-message-search.test.ts`): mock now models the real room-scope→filter→order→offset→limit; new case = accessible **older** hit + newer **inaccessible** hits, `limit=N` → the accessible hit is returned. **Red/green proven**: reverting to the old path makes it FAIL (count 1→0). 5/5 pass.
- **Focused adapter real test** (cherry-picked from #9955 work): case-insensitive ILIKE, literal `%`/`_`/`\` escaping, AND-composition, `content->>'text'`-only scoping. **10/10 on PGlite** (independently re-run).
- Made the `*.real.test.ts` runnable (`vitest.real.config.ts` + `test:real:files`) — they were excluded from every lane.
- biome clean on all touched files; `packages/core` + `plugin-sql` + `plugin-inmemorydb` typecheck clean.

## Deferred (noted, not blocking)
- Wiring plugin-sql's full `*.real.test.ts` suite into the post-merge lane (the static exclusion predates #9955 and likely guards real-Postgres tests) — separate infra task.
- Adapter omitted-`limit` divergence (`core` caps at 20 when `limit` omitted; others don't) — moot here (the endpoint always passes `limit`).
- pg_trgm GIN index for sub-linear keyword search at very large single-room scale.

Closes the correctness gap in #9955.