### PR TITLE
feat(plugin-build): additive flatten hook + migrate plugin-elizacloud (#10078)

### DIFF
--- a/plugins/plugin-build.ts
+++ b/plugins/plugin-build.ts
@@ -9,8 +9,8 @@
  * on. The emitted `dist/` is byte-identical to the previous hand-rolled build.
  */
 import { existsSync } from "node:fs";
-import { mkdir, rename, writeFile } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
+import { mkdir, readdir, rename, writeFile } from "node:fs/promises";
+import { dirname, join, relative, resolve } from "node:path";
 import {
   type ExternalsFromPackageJsonOptions,
   externalsFromPackageJson,
@@ -80,6 +80,15 @@ export interface BuildPluginConfig {
   dtsTolerant?: boolean;
   /** Declaration-alias shim files to write after tsc. */
   dtsShims?: readonly DtsShim[];
+  /**
+   * After the JS targets build (and before declaration emit), recursively move
+   * everything under `dist/<from>` up into `dist/<to ?? ".">`, then remove the
+   * now-empty `dist/<from>`. Reproduces the hand-rolled "flatten `dist/src` into
+   * `dist`" step used by plugins whose glob target (`naming: "[dir]/[name]"`
+   * over `src/**`) emits under a `src/` prefix. Off by default; existing
+   * single-/multi-target adopters that don't set it are unaffected.
+   */
+  flatten?: ReadonlyArray<{ from: string; to?: string }>;
 }
 
 const RM_RECURSIVE = resolve(
@@ -97,6 +106,29 @@ const REWRITE_DIST_IMPORTS = resolve(
   "scripts",
   "rewrite-dist-relative-imports-node-esm.mjs",
 );
+
+/**
+ * Recursively move every file under `fromDir` into `toDir`, preserving the
+ * sub-tree below `fromDir` and creating parent dirs as needed. A plain rename
+ * preserves file bytes (and any inner `//# sourceMappingURL` / map `file`
+ * references) exactly. The caller removes the now-empty `fromDir`.
+ */
+async function moveTreeContents(
+  fromDir: string,
+  toDir: string,
+): Promise<void> {
+  const entries = await readdir(fromDir, {
+    recursive: true,
+    withFileTypes: true,
+  });
+  for (const e of entries) {
+    if (!e.isFile()) continue;
+    const abs = join(e.parentPath, e.name);
+    const dest = join(toDir, relative(fromDir, abs));
+    await mkdir(dirname(dest), { recursive: true });
+    await rename(abs, dest);
+  }
+}
 
 export async function buildPlugin(config: BuildPluginConfig): Promise<void> {
   const totalStart = Date.now();
@@ -146,6 +178,15 @@ export async function buildPlugin(config: BuildPluginConfig): Promise<void> {
     console.log(
       `✅ ${t.label} complete in ${((Date.now() - start) / 1000).toFixed(2)}s`,
     );
+  }
+
+  for (const f of config.flatten ?? []) {
+    const fromDir = join(distDir, f.from);
+    if (!existsSync(fromDir)) continue;
+    const toDir = join(distDir, f.to ?? ".");
+    console.log(`📂 Flattening dist/${f.from} → dist/${f.to ?? "."}…`);
+    await moveTreeContents(fromDir, toDir);
+    await Bun.$`node ${RM_RECURSIVE} ${fromDir}`;
   }
 
   if (config.dtsProject) {

--- a/plugins/plugin-elizacloud/build.ts
+++ b/plugins/plugin-elizacloud/build.ts
@@ -1,171 +1,80 @@
 #!/usr/bin/env bun
+/**
+ * Build script for @elizaos/plugin-elizacloud. Orchestration lives in the
+ * shared driver; this lists only what differs:
+ *   - Node ESM bundle  -> dist/node
+ *   - Browser bundle (minified) -> dist/browser
+ *   - Node CJS bundle  -> dist/cjs (index.node.js renamed to index.node.cjs)
+ *   - per-file subpath glob over src/** (minus the dedicated entrypoints and
+ *     tests) that emits under dist/src via `naming`, then is flattened up into
+ *     dist/ (and dist/src removed) by the shared driver's `flatten` hook.
+ * Declarations come from tsconfig.build.json (emitDeclarationOnly), followed by
+ * three hand-written alias shims. The emitted dist/ is byte-identical to the
+ * previous hand-rolled build.
+ */
+import { buildPlugin } from "../plugin-build";
 
-import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { cp, mkdir, readdir, rename, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
-import { externalsFromPackageJson } from "../plugin-build-externals.ts";
+// Per-file subpath bundles: every src module except the dedicated Node/Browser
+// entrypoints and tests. Emitted under dist/src (naming "[dir]/[name]"), then
+// flattened up into dist/ by the driver's `flatten` step.
+const subpathEntries = Array.from(new Bun.Glob("src/**/*.{ts,tsx}").scanSync("."))
+  .filter((entry) => {
+    if (entry.includes("__tests__/") || entry.endsWith(".test.ts")) return false;
+    if (entry === "src/index.node.ts" || entry === "src/index.browser.ts") return false;
+    return true;
+  })
+  .sort();
 
-const RM_RECURSIVE_SCRIPT = fileURLToPath(
-  new URL("../../packages/scripts/rm-path-recursive.mjs", import.meta.url)
-);
+// Single-quoted re-exports to keep the emitted alias .d.ts byte-stable.
+const nodeReexport = "export * from '../index.node';\nexport { default } from '../index.node';\n";
+const browserReexport = "export * from '../index';\nexport { default } from '../index';\n";
 
-function rmRecursive(targetPath: string) {
-  const result = spawnSync(process.execPath, [RM_RECURSIVE_SCRIPT, targetPath], {
-    stdio: "inherit",
-  });
-  if (result.error) throw result.error;
-  if (result.status !== 0) {
-    throw new Error(`rm-path-recursive failed for ${targetPath} with status ${result.status}`);
-  }
-}
-
-const externalDeps = await externalsFromPackageJson("./package.json");
-
-async function build() {
-  const totalStart = Date.now();
-  const distDir = join(process.cwd(), "dist");
-
-  // Clean dist directory
-  if (existsSync(distDir)) {
-    rmRecursive(distDir);
-  }
-
-  await mkdir(distDir, { recursive: true });
-
-  const nodeStart = Date.now();
-  console.log("🔨 Building @elizaos/plugin-elizacloud for Node...");
-  await mkdir("dist/node", { recursive: true });
-  const nodeResult = await Bun.build({
-    entrypoints: ["src/index.node.ts"],
-    outdir: "dist/node",
-    target: "node",
-    format: "esm",
-    sourcemap: "external",
-    minify: false,
-    external: externalDeps,
-  });
-  if (!nodeResult.success) {
-    console.error(nodeResult.logs);
-    throw new Error("Node build failed");
-  }
-  console.log(`✅ Node build complete in ${((Date.now() - nodeStart) / 1000).toFixed(2)}s`);
-
-  const browserStart = Date.now();
-  console.log("🌐 Building @elizaos/plugin-elizacloud for Browser...");
-  await mkdir("dist/browser", { recursive: true });
-  const browserResult = await Bun.build({
-    entrypoints: ["src/index.browser.ts"],
-    outdir: "dist/browser",
-    target: "browser",
-    format: "esm",
-    sourcemap: "external",
-    minify: true,
-    external: externalDeps,
-  });
-  if (!browserResult.success) {
-    console.error(browserResult.logs);
-    throw new Error("Browser build failed");
-  }
-  console.log(`✅ Browser build complete in ${((Date.now() - browserStart) / 1000).toFixed(2)}s`);
-
-  const cjsStart = Date.now();
-  console.log("🧱 Building @elizaos/plugin-elizacloud for Node (CJS)...");
-  await mkdir("dist/cjs", { recursive: true });
-  const cjsResult = await Bun.build({
-    entrypoints: ["src/index.node.ts"],
-    outdir: "dist/cjs",
-    target: "node",
-    format: "cjs",
-    sourcemap: "external",
-    minify: false,
-    external: externalDeps,
-  });
-  if (!cjsResult.success) {
-    console.error(cjsResult.logs);
-    throw new Error("CJS build failed");
-  }
-  try {
-    await rename("dist/cjs/index.node.js", "dist/cjs/index.node.cjs");
-  } catch (e) {
-    console.warn("CJS rename step warning:", e);
-  }
-  console.log(`✅ CJS build complete in ${((Date.now() - cjsStart) / 1000).toFixed(2)}s`);
-
-  const subpathStart = Date.now();
-  console.log("📦 Building exported subpaths...");
-  const subpathEntries = Array.from(new Bun.Glob("src/**/*.{ts,tsx}").scanSync("."))
-    .filter((entry) => {
-      if (entry.includes("__tests__/") || entry.endsWith(".test.ts")) return false;
-      if (entry === "src/index.node.ts" || entry === "src/index.browser.ts") return false;
-      return true;
-    })
-    .sort();
-  await Promise.all(
-    Array.from(new Set(subpathEntries.map((entry) => join("dist", dirname(entry))))).map((dir) =>
-      mkdir(dir, { recursive: true })
-    )
-  );
-  const subpathResult = await Bun.build({
-    entrypoints: subpathEntries,
-    outdir: "dist",
-    target: "node",
-    format: "esm",
-    sourcemap: "external",
-    minify: false,
-    external: externalDeps,
-    naming: {
-      entry: "[dir]/[name].[ext]",
-      chunk: "chunks/[name]-[hash].[ext]",
-      asset: "assets/[name]-[hash].[ext]",
+await buildPlugin({
+  name: "@elizaos/plugin-elizacloud",
+  clean: true,
+  externals: "auto",
+  targets: [
+    {
+      label: "Node",
+      entry: "src/index.node.ts",
+      outSubdir: "node",
+      target: "node",
+      format: "esm",
     },
-  });
-  if (!subpathResult.success) {
-    console.error(subpathResult.logs);
-    throw new Error("Subpath build failed");
-  }
-  if (existsSync("dist/src")) {
-    const nestedDistDir = join(distDir, "src");
-    await Promise.all(
-      (await readdir(nestedDistDir)).map((entry) =>
-        cp(join(nestedDistDir, entry), join(distDir, entry), { recursive: true, force: true })
-      )
-    );
-    rmRecursive(nestedDistDir);
-  }
-  console.log(`✅ Exported subpaths built in ${((Date.now() - subpathStart) / 1000).toFixed(2)}s`);
-
-  const dtsStart = Date.now();
-  console.log("📝 Generating TypeScript declarations...");
-  await Bun.$`tsc --project tsconfig.build.json --noCheck`;
-  await mkdir("dist/node", { recursive: true });
-  await mkdir("dist/browser", { recursive: true });
-  await mkdir("dist/cjs", { recursive: true });
-  await writeFile(
-    "dist/node/index.d.ts",
-    `export * from '../index.node';
-export { default } from '../index.node';
-`
-  );
-  await writeFile(
-    "dist/browser/index.d.ts",
-    `export * from '../index';
-export { default } from '../index';
-`
-  );
-  await writeFile(
-    "dist/cjs/index.d.ts",
-    `export * from '../index.node';
-export { default } from '../index.node';
-`
-  );
-  console.log(`✅ Declarations generated in ${((Date.now() - dtsStart) / 1000).toFixed(2)}s`);
-
-  console.log(`🎉 All builds finished in ${((Date.now() - totalStart) / 1000).toFixed(2)}s`);
-}
-
-build().catch((err) => {
-  console.error("Build failed:", err);
-  process.exit(1);
+    {
+      label: "Browser",
+      entry: "src/index.browser.ts",
+      outSubdir: "browser",
+      target: "browser",
+      format: "esm",
+      minify: true,
+    },
+    {
+      label: "Node (CJS)",
+      entry: "src/index.node.ts",
+      outSubdir: "cjs",
+      target: "node",
+      format: "cjs",
+      renames: [["index.node.js", "index.node.cjs"]],
+    },
+    {
+      label: "Exported subpaths",
+      entry: subpathEntries,
+      outSubdir: "",
+      target: "node",
+      format: "esm",
+      naming: {
+        entry: "[dir]/[name].[ext]",
+        chunk: "chunks/[name]-[hash].[ext]",
+        asset: "assets/[name]-[hash].[ext]",
+      },
+    },
+  ],
+  flatten: [{ from: "src" }],
+  dtsProject: "tsconfig.build.json",
+  dtsShims: [
+    { path: "node/index.d.ts", content: nodeReexport },
+    { path: "browser/index.d.ts", content: browserReexport },
+    { path: "cjs/index.d.ts", content: nodeReexport },
+  ],
 });


### PR DESCRIPTION
Extends the shared `buildPlugin` driver (**#10078**) with the one capability the remaining glob-subpath plugins need, and migrates its first consumer (`plugin-elizacloud`).

## The hook (additive, off-by-default)
`plugins/plugin-build.ts` gains an optional `flatten?: ReadonlyArray<{ from: string; to?: string }>`. After the JS targets build and before declaration emit, it recursively moves `dist/<from>/* → dist/<to ?? ".">` (plain `rename`, preserving bytes + inner `//# sourceMappingURL`/map `file` refs exactly) then removes `dist/<from>`. This reproduces the hand-rolled "flatten `dist/src` into `dist`" step used by plugins whose glob target (`naming:"[dir]/[name]"` over `src/**`) emits under a `src/` prefix — the gap that blocked `plugin-elizacloud` from migrating in #10232.

**Purely additive — existing adopters cannot regress:** the diff only adds the field, a `moveTreeContents` helper, and a `for (const f of config.flatten ?? [])` loop. The common path (targets loop, d.ts, shims, rewriteDistImports) is untouched; for the 27 adopters that don't set `flatten`, `?? []` makes it a no-op.

### Regression check (NEW vs OLD driver, empirical)
Built two differing-shape migrated adopters on the new driver, `git stash`'d the change, rebuilt on the old driver, diffed sha256:
- **plugin-openai** (Node + Browser-min, dtsShims): 42 files — **byte-identical**
- **plugin-discord** (single Node, clean + rewriteDistImports): 124 files — **byte-identical**

## First consumer — plugin-elizacloud
Migrated its 4-`Bun.build` script (Node ESM / Browser-min / Node CJS+rename / `src/**` glob → `dist/src` then flatten) onto `buildPlugin({ …, flatten: [{ from: "src" }] })`.

**Byte-identical: 353/357 files exactly match** the original. The other 4 (`dist/index.js`, `dist/cloud/index.js` + their `.map`s) are **pre-existing Bun-bundler non-determinism, not introduced here** — two consecutive runs of the *unchanged original* `build.ts` flip those same 4 files between two module-ordering states; the migrated shim reproduces the identical two-state set and adds no new bytes. (Worth a separate look as a Bun determinism issue, independent of #10078.)

`bun run --cwd plugins/plugin-elizacloud build` → exit 0, 357 files.

## Net
Driver: +45 lines (additive). elizacloud build.ts: −122 net. Unblocks the remaining glob-subpath plugin family for future byte-identical migrations. Refs #10078.

🤖 Generated with [Claude Code](https://claude.com/claude-code)