### PR TITLE
chore(build): migrate feishu + inmemorydb off the second build helper (runBuild) onto buildPlugin (#10078)

### DIFF
--- a/plugins/plugin-feishu/build.ts
+++ b/plugins/plugin-feishu/build.ts
@@ -1,34 +1,51 @@
 #!/usr/bin/env bun
-
 /**
- * Build script for @elizaos/plugin-feishu TypeScript implementation
+ * Build script for @elizaos/plugin-feishu (Node). Orchestration lives in the
+ * shared driver (plugins/plugin-build.ts); this lists only what differs.
+ *
+ * Migrated from the legacy `runBuild` (packages/core/build) driver to the
+ * shared `buildPlugin` driver as part of issue #10078 (one build helper). The
+ * emitted `dist/` is byte-identical to the previous `runBuild` output.
+ *
+ * runBuild → buildPlugin mapping:
+ *  - entrypoints ["src/index.ts"] → a single Node target (entry "./src/index.ts",
+ *    outSubdir "" so the bundle lands at dist/index.js, target "node", esm).
+ *  - sourcemap: true → "linked": runBuild passes the boolean `true` straight to
+ *    Bun.build, which (in this Bun) emits an external `.js.map` plus a
+ *    `//# sourceMappingURL=` + `//# debugId=` comment — exactly Bun's "linked"
+ *    mode (verified byte-for-byte, including the debugId).
+ *  - naming: createElizaBuildConfig sets a fixed naming template; it is what
+ *    determines the sourcemap bytes (hence the debugId). Reproduced verbatim
+ *    here so dist/index.js + dist/index.js.map are byte-identical.
+ *  - external: runBuild appends Node built-ins + @elizaos/* to the passed list,
+ *    but feishu's source only imports @elizaos/core + @larksuiteoapi/node-sdk,
+ *    so the explicit two-entry list yields the identical bundle (verified).
+ *  - generateDts: true → dtsProject "tsconfig.build.json" +
+ *    dtsEmitDeclarationOnly (runBuild's generateDts runs
+ *    `tsc --emitDeclarationOnly --noCheck`). No d.ts import rewrite / root alias
+ *    is performed by runBuild, so none is configured here.
  */
+import { buildPlugin } from "../plugin-build";
 
-import { runBuild } from "../../packages/core/build";
-
-async function buildAll(): Promise<boolean> {
-	const ok = await runBuild({
-		packageName: "@elizaos/plugin-feishu",
-		buildOptions: {
-			entrypoints: ["src/index.ts"],
-			outdir: "dist",
+await buildPlugin({
+	name: "@elizaos/plugin-feishu",
+	clean: true,
+	externals: ["@elizaos/core", "@larksuiteoapi/node-sdk"],
+	targets: [
+		{
+			label: "Node",
+			entry: "./src/index.ts",
+			outSubdir: "",
 			target: "node",
 			format: "esm",
-			external: ["@elizaos/core", "@larksuiteoapi/node-sdk"],
-			sourcemap: true,
-			minify: false,
-			generateDts: true,
+			sourcemap: "linked",
+			naming: {
+				entry: "[dir]/[name].[ext]",
+				chunk: "[name]-[hash].[ext]",
+				asset: "[name]-[hash].[ext]",
+			},
 		},
-	});
-
-	return ok;
-}
-
-buildAll()
-	.then((ok) => {
-		if (!ok) process.exit(1);
-	})
-	.catch((error) => {
-		console.error("Build script error:", error);
-		process.exit(1);
-	});
+	],
+	dtsProject: "tsconfig.build.json",
+	dtsEmitDeclarationOnly: true,
+});

--- a/plugins/plugin-inmemorydb/build.ts
+++ b/plugins/plugin-inmemorydb/build.ts
@@ -1,90 +1,90 @@
 #!/usr/bin/env bun
+/**
+ * Build script for @elizaos/plugin-inmemorydb (Node + Browser). Orchestration
+ * lives in the shared driver (plugins/plugin-build.ts); this lists only what
+ * differs.
+ *
+ * Migrated from the legacy `runBuild`/`generateDts` (packages/core/build)
+ * driver to the shared `buildPlugin` driver as part of issue #10078 (one build
+ * helper). The emitted `dist/` is byte-identical to the previous output.
+ *
+ * runBuild → buildPlugin mapping:
+ *  - Two `runBuild` calls → two `targets[]`: Node (entry "./index.ts",
+ *    outSubdir "node", target "node") and Browser (entry "./index.browser.ts",
+ *    outSubdir "browser", target "browser"), both esm.
+ *  - sourcemap: true → "linked": runBuild forwards the boolean `true` to
+ *    Bun.build, which emits an external `.js.map` + `//# sourceMappingURL=` /
+ *    `//# debugId=` comments — exactly Bun's "linked" mode (verified, including
+ *    debugId).
+ *  - naming: createElizaBuildConfig sets a fixed naming template; it determines
+ *    the sourcemap bytes (and thus the debugId), so it is reproduced verbatim
+ *    here to keep the `.js` + `.js.map` byte-identical.
+ *  - external: both runBuild calls pass ["@elizaos/core"]; the plugin's only
+ *    non-builtin import is @elizaos/core (everything else is `node:*`), so the
+ *    single explicit entry reproduces both bundles byte-for-byte. buildPlugin
+ *    applies one externals list to every target; that is fine here because both
+ *    targets share the same effective set.
+ *  - generateDts("tsconfig.build.json", false) [false = throwOnError] →
+ *    dtsProject "tsconfig.build.json" + dtsEmitDeclarationOnly (runBuild's
+ *    generateDts runs `tsc --emitDeclarationOnly --noCheck …`) + dtsTolerant
+ *    (the `false` throwOnError = warn-and-continue). runBuild additionally
+ *    passed `--composite false --incremental false`, which suppressed the
+ *    `dist/tsconfig.tsbuildinfo` emit; buildPlugin cannot pass extra tsc flags,
+ *    so that suppression is now encoded directly in tsconfig.build.json
+ *    (composite:false, tsBuildInfoFile removed). The per-file `.d.ts` tree is
+ *    byte-identical either way; this only avoids the stray tsbuildinfo.
+ *  - The two post-emit alias writes (root + node) → dtsShims, reproduced
+ *    byte-for-byte (double-quoted specifiers, trailing newline).
+ */
+import { buildPlugin } from "../plugin-build";
 
-import { existsSync } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
-import { generateDts, runBuild } from "../../packages/core/build";
+const naming = {
+  entry: "[dir]/[name].[ext]",
+  chunk: "[name]-[hash].[ext]",
+  asset: "[name]-[hash].[ext]",
+} as const;
 
-const PLUGIN_ROOT = dirname(import.meta.path);
+const rootAlias = [
+  'export * from "./browser/index";',
+  'export { default } from "./browser/index";',
+  "",
+].join("\n");
 
-async function buildAll() {
-  const originalCwd = process.cwd();
-  process.chdir(PLUGIN_ROOT);
+const nodeAlias = [
+  'export * from "../browser/index";',
+  'export { default } from "../browser/index";',
+  "",
+].join("\n");
 
-  try {
-    const nodeOk = await runBuild({
-      packageName: "@elizaos/plugin-inmemorydb",
-      buildOptions: {
-        entrypoints: ["index.ts"],
-        outdir: "dist/node",
-        target: "node",
-        format: "esm",
-        external: ["@elizaos/core"],
-        sourcemap: true,
-        minify: false,
-        generateDts: false,
-      },
-    });
-
-    if (!nodeOk) return false;
-
-    const browserOk = await runBuild({
-      packageName: "@elizaos/plugin-inmemorydb",
-      buildOptions: {
-        entrypoints: ["index.browser.ts"],
-        outdir: "dist/browser",
-        target: "browser",
-        format: "esm",
-        external: ["@elizaos/core"],
-        sourcemap: true,
-        minify: false,
-        generateDts: false,
-      },
-    });
-
-    if (!browserOk) return false;
-
-    console.log("📝 Generating type declarations...");
-    await generateDts("tsconfig.build.json", false);
-
-    const distDir = join(PLUGIN_ROOT, "dist");
-    const browserDir = join(distDir, "browser");
-    const nodeDir = join(distDir, "node");
-
-    if (!existsSync(browserDir)) {
-      await mkdir(browserDir, { recursive: true });
-    }
-    if (!existsSync(nodeDir)) {
-      await mkdir(nodeDir, { recursive: true });
-    }
-
-    const rootIndexDtsPath = join(distDir, "index.d.ts");
-    const rootAlias = [
-      'export * from "./browser/index";',
-      'export { default } from "./browser/index";',
-      "",
-    ].join("\n");
-    await writeFile(rootIndexDtsPath, rootAlias, "utf8");
-
-    const nodeIndexDtsPath = join(nodeDir, "index.d.ts");
-    const nodeAlias = [
-      'export * from "../browser/index";',
-      'export { default } from "../browser/index";',
-      "",
-    ].join("\n");
-    await writeFile(nodeIndexDtsPath, nodeAlias, "utf8");
-
-    return true;
-  } finally {
-    process.chdir(originalCwd);
-  }
-}
-
-buildAll()
-  .then((ok) => {
-    if (!ok) process.exit(1);
-  })
-  .catch((error) => {
-    console.error("Build script error:", error);
-    process.exit(1);
-  });
+await buildPlugin({
+  name: "@elizaos/plugin-inmemorydb",
+  clean: true,
+  externals: ["@elizaos/core"],
+  targets: [
+    {
+      label: "Node",
+      entry: "./index.ts",
+      outSubdir: "node",
+      target: "node",
+      format: "esm",
+      sourcemap: "linked",
+      naming,
+    },
+    {
+      label: "Browser",
+      entry: "./index.browser.ts",
+      outSubdir: "browser",
+      target: "browser",
+      format: "esm",
+      sourcemap: "linked",
+      naming,
+    },
+  ],
+  dtsProject: "tsconfig.build.json",
+  dtsEmitDeclarationOnly: true,
+  dtsTolerant: true,
+  dtsShims: [
+    { path: "index.d.ts", content: rootAlias },
+    { path: "node/index.d.ts", content: nodeAlias },
+  ],
+});

--- a/plugins/plugin-inmemorydb/tsconfig.build.json
+++ b/plugins/plugin-inmemorydb/tsconfig.build.json
@@ -5,8 +5,7 @@
     "outDir": "./dist/browser",
     "declaration": true,
     "declarationMap": true,
-    "composite": true,
-    "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
+    "composite": false,
     "types": ["node"],
     "skipLibCheck": true
   },


### PR DESCRIPTION
**#10078 "one build helper" consolidation.** `plugin-feishu` and `plugin-inmemorydb` were the last plugins still using the *other* helper — `runBuild` from `packages/core/build` — instead of the shared `buildPlugin` driver. Migrates both onto `buildPlugin`, byte-identical.

## Byte-identical
Built each with its original `build.ts` → sorted per-file `sha256` of `dist/` (BEFORE) → `buildPlugin` shim → rebuild → diff. Both deterministic across multiple runs.

| plugin | dist files | sha256 |
|---|---|---|
| plugin-feishu | 28 | all identical |
| plugin-inmemorydb | 22 | all identical |

## runBuild → buildPlugin mapping (the non-obvious bits)
- **`sourcemap:true` → `"linked"`** — runBuild forwards `true` to Bun.build, which emits an external `.js.map` + `//# sourceMappingURL=` + `//# debugId=`. That's exactly Bun's `"linked"` mode (verified byte-for-byte incl. the content-derived `debugId`).
- **`naming` is load-bearing** — `createElizaBuildConfig` always sets `naming:{entry:"[dir]/[name].[ext]", chunk/asset:"[name]-[hash].[ext]"}`. A controlled matrix proved this template (not the externals list, not true-vs-linked) is the *sole* differentiator of the `.js.map` bytes / `debugId`. Reproduced verbatim.
- **`generateDts:true` → `dtsProject` + `dtsEmitDeclarationOnly`** — runBuild's d.ts pass adds `--composite false --incremental false`, which only suppressed `dist/tsconfig.tsbuildinfo`. `buildPlugin` can't pass extra tsc flags, so that suppression is encoded in inmemorydb's build-only `tsconfig.build.json` (`composite:false`, no `tsBuildInfoFile`) — verified safe (nothing references it as a TS-project `references`; typecheck uses `tsconfig.json`). feishu needed no tsconfig change. inmemorydb's `throwOnError=false` → `dtsTolerant:true`.
- Post-emit alias `index.d.ts` writes → `dtsShims` (reproduced byte-for-byte).

## Second helper now has zero cross-package consumers
After this, **no `import … from ".../core/build"` remains** anywhere outside `node_modules`/`dist`. `packages/core/build`'s `runBuild`/`generateDts` is now used only by core's own `import.meta.main` self-build — a green light toward deleting the shared exports of the second helper in a follow-up.

Refs #10078.

🤖 Generated with [Claude Code](https://claude.com/claude-code)