### PR TITLE
fix(ui): scrub persisted JWT on cloud disconnect (supersedes #10229's stale branch)

### DIFF
--- a/packages/ui/src/state/useCloudState.ts
+++ b/packages/ui/src/state/useCloudState.ts
@@ -47,6 +47,7 @@ import {
   hasStewardLoginLauncher,
   launchStewardLogin,
 } from "./cloud-steward-login";
+import { scrubPersistedActiveServerToken } from "./persistence";
 import { isPrivateNetworkHost } from "./private-network-host";
 
 // ── Constants ──────────────────────────────────────────────────────────────
@@ -904,6 +905,12 @@ export function useCloudState({
         setElizaCloudStatusReason(null);
         lastElizaCloudPollConnectedRef.current = false;
         elizaCloudPreferDisconnectedUntilLoginRef.current = true;
+        // Drop the persisted JWT on disconnect. The full sign-out path
+        // (StewardProviderRuntime) already scrubs it; cloud-disconnect cleared
+        // in-memory state but left active-server.accessToken in localStorage —
+        // an at-rest JWT leak readable by XSS / plugin views. Keep the server
+        // selection (kind/apiBase/label) so we know where to re-authenticate.
+        scrubPersistedActiveServerToken();
         if (wasConnected) {
           setActionNotice("Disconnected from Eliza Cloud.", "success");
         }


### PR DESCRIPTION
Lands the net-new, genuine value of #10229 cleanly on current develop.

#10229's branch is badly stale (its diff vs current develop shows ~100 files of recent develop work as spurious deletions). Of its two changes:
- **`useChatSend.ts` empty-text/`failureKind` handling — already on develop** (both the streaming path and `sendActionMessage` already branch on `failureKind`). Superseded.
- **`useCloudState.ts` JWT scrub on disconnect — net-new.** A real at-rest credential leak: the disconnect handler cleared in-memory state but left `active-server.accessToken` (a bearer JWT) in `localStorage`, readable by XSS / plugin views. This scrubs it via `scrubPersistedActiveServerToken` (the same tested helper the full sign-out path uses), keeping the server selection for re-auth.

## Verification
```
bunx @biomejs/biome check packages/ui/src/state/useCloudState.ts   # clean (import order correct)
bun run --cwd packages/ui typecheck                                # exit 0
```

Closes #10229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)