### PR TITLE
test: add voice live matrix coverage

### DIFF
--- a/.github/issue-evidence/9958-voice-matrix-ios-run/index.html
+++ b/.github/issue-evidence/9958-voice-matrix-ios-run/index.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Voice Live Matrix</title>
+<style>
+body{font-family:system-ui,-apple-system,Segoe UI,sans-serif;margin:24px;background:#fafafa;color:#151515}
+table{width:100%;border-collapse:collapse;background:white}
+th,td{border:1px solid #ddd;padding:8px;vertical-align:top;white-space:pre-wrap}
+th{background:#f1f1f1;text-align:left}
+.pass td:nth-child(2){color:#116b2d;font-weight:700}
+.fail td:nth-child(2){color:#9a1b1b;font-weight:700}
+.skip td:nth-child(2),.pending td:nth-child(2){color:#7a5b00;font-weight:700}
+code{font-size:12px}
+</style>
+<h1>Voice Live Matrix</h1>
+<p>Generated 2026-06-29T20:52:27.019Z on darwin arm64 (Shaws-MacBook-Pro.local).</p>
+<p>Pass 2 · Fail 0 · Pending 0 · Skip 1</p>
+<table><thead><tr><th>Cell</th><th>Status</th><th>Platform</th><th>Class</th><th>Dimensions</th><th>Probe / Result</th><th>Command</th><th>Evidence</th></tr></thead><tbody><tr class="skip"><td><code>ios.sim-or-device.voice-roundtrip</code><br>iOS simulator/device voice self-test and capture evidence</td><td>skip</td><td>ios</td><td>mobile-live-voice</td><td>transcriptionState=off
+chimeIn=should-respond
+wakewordContext=idle-wake
+noiseRejection=quiet
+voices=owner</td><td>set ELIZA_VOICE_IOS_READY=1 after installing a current iOS simulator/device build with voice assets</td><td><code>bun run --cwd packages/app capture:ios-sim -- --issue 9958 --slug voice-ios</code></td><td>.github/issue-evidence/9958-voice-ios-ios-sim.*</td></tr>
+<tr class="pass"><td><code>ios.talkmode.native-bridge</code><br>TalkMode iOS transcript, permission, state, and barge-in bridge contracts</td><td>pass</td><td>ios</td><td>native-bridge-unit</td><td>transcriptionState=off
+chimeIn=should-respond
+wakewordContext=already-listening-wake-inert
+noiseRejection=echo-self-voice
+voices=owner</td><td>command passed (2026-06-29T20:52:26.366Z)</td><td><code>swift test --package-path plugins/plugin-native-talkmode/ios</code></td><td>plugins/plugin-native-talkmode/ios/Tests</td></tr>
+<tr class="pass"><td><code>ios.swabble.native-bridge</code><br>Swabble iOS wake-firing -&gt; JS bridge event contract</td><td>pass</td><td>ios</td><td>native-bridge-unit</td><td>transcriptionState=off
+chimeIn=should-respond
+wakewordContext=idle-wake
+noiseRejection=quiet
+voices=owner</td><td>command passed (2026-06-29T20:52:27.019Z)</td><td><code>swift test --package-path plugins/plugin-native-swabble/ios</code></td><td>plugins/plugin-native-swabble/ios/Tests</td></tr></tbody></table>

--- a/.github/issue-evidence/9958-voice-matrix-ios-run/voice-matrix.json
+++ b/.github/issue-evidence/9958-voice-matrix-ios-run/voice-matrix.json
@@ -1,0 +1,166 @@
+{
+  "schema": "eliza_voice_live_matrix_v1",
+  "issue": 9958,
+  "generatedAt": "2026-06-29T20:52:27.019Z",
+  "mode": "run",
+  "dimensions": {
+    "platform": [
+      "web",
+      "linux",
+      "macos-electrobun",
+      "windows-electrobun",
+      "ios",
+      "android"
+    ],
+    "transcriptionState": [
+      "off",
+      "on"
+    ],
+    "chimeIn": [
+      "should-respond",
+      "should-not-respond"
+    ],
+    "wakewordContext": [
+      "idle-wake",
+      "already-listening-wake-inert",
+      "mid-transcription-wake"
+    ],
+    "noiseRejection": [
+      "quiet",
+      "noisy-reverberant",
+      "echo-self-voice",
+      "overlapping-speech"
+    ],
+    "voices": [
+      "owner",
+      "enrolled-contact",
+      "unknown",
+      "multi-speaker"
+    ]
+  },
+  "host": {
+    "platform": "darwin",
+    "arch": "arm64",
+    "hostname": "Shaws-MacBook-Pro.local",
+    "runnerOs": null,
+    "runnerArch": null
+  },
+  "summary": {
+    "pass": 2,
+    "fail": 0,
+    "pending": 0,
+    "skip": 1
+  },
+  "cells": [
+    {
+      "id": "ios.sim-or-device.voice-roundtrip",
+      "title": "iOS simulator/device voice self-test and capture evidence",
+      "platform": "ios",
+      "dimensions": {
+        "transcriptionState": "off",
+        "chimeIn": "should-respond",
+        "wakewordContext": "idle-wake",
+        "noiseRejection": "quiet",
+        "voices": "owner"
+      },
+      "class": "mobile-live-voice",
+      "command": [
+        "bun",
+        "run",
+        "--cwd",
+        "packages/app",
+        "capture:ios-sim",
+        "--",
+        "--issue",
+        "9958",
+        "--slug",
+        "voice-ios"
+      ],
+      "evidence": [
+        ".github/issue-evidence/9958-voice-ios-ios-sim.*"
+      ],
+      "probe": {
+        "available": false,
+        "reason": "set ELIZA_VOICE_IOS_READY=1 after installing a current iOS simulator/device build with voice assets"
+      },
+      "cwd": ".",
+      "env": {},
+      "execution": null,
+      "status": "skip"
+    },
+    {
+      "id": "ios.talkmode.native-bridge",
+      "title": "TalkMode iOS transcript, permission, state, and barge-in bridge contracts",
+      "platform": "ios",
+      "dimensions": {
+        "transcriptionState": "off",
+        "chimeIn": "should-respond",
+        "wakewordContext": "already-listening-wake-inert",
+        "noiseRejection": "echo-self-voice",
+        "voices": "owner"
+      },
+      "class": "native-bridge-unit",
+      "command": [
+        "swift",
+        "test",
+        "--package-path",
+        "plugins/plugin-native-talkmode/ios"
+      ],
+      "evidence": [
+        "plugins/plugin-native-talkmode/ios/Tests"
+      ],
+      "probe": {
+        "available": true,
+        "reason": "command passed (2026-06-29T20:52:26.366Z)"
+      },
+      "cwd": ".",
+      "env": {},
+      "execution": {
+        "exitCode": 0,
+        "signal": null,
+        "startedAt": "2026-06-29T20:52:25.347Z",
+        "finishedAt": "2026-06-29T20:52:26.366Z",
+        "stdoutTail": "Test Suite 'All tests' started at 2026-06-29 16:52:26.323.\nTest Suite 'ElizaosCapacitorTalkModeIOSContractsPackageTests.xctest' started at 2026-06-29 16:52:26.324.\nTest Suite 'TalkModeBridgeContractTests' started at 2026-06-29 16:52:26.324.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testBargeInInterruptIgnoresShortBlipsAndSelfEcho]' started.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testBargeInInterruptIgnoresShortBlipsAndSelfEcho]' passed (0.000 seconds).\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testStateAndPermissionPayloads]' started.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testStateAndPermissionPayloads]' passed (0.000 seconds).\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testTranscriptPayloadPreservesBridgeFields]' started.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testTranscriptPayloadPreservesBridgeFields]' passed (0.000 seconds).\nTest Suite 'TalkModeBridgeContractTests' passed at 2026-06-29 16:52:26.326.\n\t Executed 3 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds\nTest Suite 'ElizaosCapacitorTalkModeIOSContractsPackageTests.xctest' passed at 2026-06-29 16:52:26.326.\n\t Executed 3 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds\nTest Suite 'All tests' passed at 2026-06-29 16:52:26.326.\n\t Executed 3 tests, with 0 failures (0 unexpected) in 0.001 (0.002) seconds\n◇ Test run started.\n↳ Testing Library Version: 1743\n↳ Target Platform: arm64e-apple-macos14.0\n✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.\n",
+        "stderrTail": "[0/1] Planning build\nBuilding for debugging...\n[0/2] Write swift-version--58304C5D6DBC2206.txt\nBuild complete! (0.18s)\n"
+      },
+      "status": "pass"
+    },
+    {
+      "id": "ios.swabble.native-bridge",
+      "title": "Swabble iOS wake-firing -> JS bridge event contract",
+      "platform": "ios",
+      "dimensions": {
+        "transcriptionState": "off",
+        "chimeIn": "should-respond",
+        "wakewordContext": "idle-wake",
+        "noiseRejection": "quiet",
+        "voices": "owner"
+      },
+      "class": "native-bridge-unit",
+      "command": [
+        "swift",
+        "test",
+        "--package-path",
+        "plugins/plugin-native-swabble/ios"
+      ],
+      "evidence": [
+        "plugins/plugin-native-swabble/ios/Tests"
+      ],
+      "probe": {
+        "available": true,
+        "reason": "command passed (2026-06-29T20:52:27.019Z)"
+      },
+      "cwd": ".",
+      "env": {},
+      "execution": {
+        "exitCode": 0,
+        "signal": null,
+        "startedAt": "2026-06-29T20:52:26.373Z",
+        "finishedAt": "2026-06-29T20:52:27.019Z",
+        "stdoutTail": "Test Suite 'All tests' started at 2026-06-29 16:52:26.973.\nTest Suite 'ElizaosCapacitorSwabbleIOSContractsPackageTests.xctest' started at 2026-06-29 16:52:26.974.\nTest Suite 'SwabbleBridgeContractTests' started at 2026-06-29 16:52:26.974.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testFuzzyTriggerStillFiresFromSpeechRecognizerMiss]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testFuzzyTriggerStillFiresFromSpeechRecognizerMiss]' passed (0.001 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTextOnlyWakeCommandUsesTriggerAndMinimumLength]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTextOnlyWakeCommandUsesTriggerAndMinimumLength]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTriggerOnlyPayloadStartsCaptureWithoutCommand]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTriggerOnlyPayloadStartsCaptureWithoutCommand]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testWakePayloadMatchesJsBridgeContract]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testWakePayloadMatchesJsBridgeContract]' passed (0.000 seconds).\nTest Suite 'SwabbleBridgeContractTests' passed at 2026-06-29 16:52:26.976.\n\t Executed 4 tests, with 0 failures (0 unexpected) in 0.001 (0.002) seconds\nTest Suite 'ElizaosCapacitorSwabbleIOSContractsPackageTests.xctest' passed at 2026-06-29 16:52:26.976.\n\t Executed 4 tests, with 0 failures (0 unexpected) in 0.001 (0.002) seconds\nTest Suite 'All tests' passed at 2026-06-29 16:52:26.976.\n\t Executed 4 tests, with 0 failures (0 unexpected) in 0.001 (0.003) seconds\n◇ Test run started.\n↳ Testing Library Version: 1743\n↳ Target Platform: arm64e-apple-macos14.0\n✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.\n",
+        "stderrTail": "[0/1] Planning build\nBuilding for debugging...\n[0/2] Write swift-version--58304C5D6DBC2206.txt\nBuild complete! (0.16s)\n"
+      },
+      "status": "pass"
+    }
+  ]
+}

--- a/.github/issue-evidence/9958-voice-matrix-ios-run/voice-matrix.md
+++ b/.github/issue-evidence/9958-voice-matrix-ios-run/voice-matrix.md
@@ -1,0 +1,19 @@
+# Voice Live Matrix
+
+Generated: 2026-06-29T20:52:27.019Z
+Host: darwin arm64 (Shaws-MacBook-Pro.local)
+
+| Cell | Status | Platform | Class | Probe / Result | Command |
+|---|---:|---|---|---|---|
+| `ios.sim-or-device.voice-roundtrip` | skip | ios | mobile-live-voice | set ELIZA_VOICE_IOS_READY=1 after installing a current iOS simulator/device build with voice assets | `bun run --cwd packages/app capture:ios-sim -- --issue 9958 --slug voice-ios` |
+| `ios.talkmode.native-bridge` | pass | ios | native-bridge-unit | command passed (2026-06-29T20:52:26.366Z) | `swift test --package-path plugins/plugin-native-talkmode/ios` |
+| `ios.swabble.native-bridge` | pass | ios | native-bridge-unit | command passed (2026-06-29T20:52:27.019Z) | `swift test --package-path plugins/plugin-native-swabble/ios` |
+
+## Summary
+
+- Pass: 2
+- Fail: 0
+- Pending: 0
+- Skip: 1
+
+Hardware-unavailable cells are explicit `skip` rows. They are not evidence of platform coverage.

--- a/.github/issue-evidence/9958-voice-matrix-web-run/index.html
+++ b/.github/issue-evidence/9958-voice-matrix-web-run/index.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Voice Live Matrix</title>
+<style>
+body{font-family:system-ui,-apple-system,Segoe UI,sans-serif;margin:24px;background:#fafafa;color:#151515}
+table{width:100%;border-collapse:collapse;background:white}
+th,td{border:1px solid #ddd;padding:8px;vertical-align:top;white-space:pre-wrap}
+th{background:#f1f1f1;text-align:left}
+.pass td:nth-child(2){color:#116b2d;font-weight:700}
+.fail td:nth-child(2){color:#9a1b1b;font-weight:700}
+.skip td:nth-child(2),.pending td:nth-child(2){color:#7a5b00;font-weight:700}
+code{font-size:12px}
+</style>
+<h1>Voice Live Matrix</h1>
+<p>Generated 2026-06-29T20:55:04.433Z on darwin arm64 (Shaws-MacBook-Pro.local).</p>
+<p>Pass 3 · Fail 0 · Pending 0 · Skip 0</p>
+<table><thead><tr><th>Cell</th><th>Status</th><th>Platform</th><th>Class</th><th>Dimensions</th><th>Probe / Result</th><th>Command</th><th>Evidence</th></tr></thead><tbody><tr class="pass"><td><code>web.fake-mic.roundtrip</code><br>Web fake-device mic capture -&gt; ASR -&gt; agent -&gt; TTS</td><td>pass</td><td>web</td><td>live-client-audio</td><td>transcriptionState=off
+chimeIn=should-respond
+wakewordContext=idle-wake
+noiseRejection=quiet
+voices=owner</td><td>command passed (2026-06-29T20:53:49.234Z)</td><td><code>bun run --cwd packages/app test:e2e test/ui-smoke/voice-realaudio.spec.ts</code></td><td>packages/app/test-results
+e2e-recordings/app/test-results</td></tr>
+<tr class="pass"><td><code>web.fake-mic.transcript-roundtrip</code><br>Web fake-device transcript capture -&gt; record -&gt; player -&gt; chat attachment</td><td>pass</td><td>web</td><td>transcripts-roundtrip</td><td>transcriptionState=on
+chimeIn=should-not-respond
+wakewordContext=mid-transcription-wake
+noiseRejection=quiet
+voices=owner</td><td>command passed (2026-06-29T20:54:52.229Z)</td><td><code>bun run --cwd packages/app test:e2e test/ui-smoke/transcript-realaudio.spec.ts</code></td><td>packages/app/test-results
+e2e-recordings/app/test-results</td></tr>
+<tr class="pass"><td><code>web.workbench.respond-no-respond</code><br>Headful workbench should-respond / should-not-respond client cells</td><td>pass</td><td>web</td><td>chime-in-matrix</td><td>transcriptionState=off
+chimeIn=should-not-respond
+wakewordContext=idle-wake
+noiseRejection=quiet
+voices=multi-speaker</td><td>command passed (2026-06-29T20:55:04.433Z)</td><td><code>bun run --cwd packages/app test:e2e test/ui-smoke/voice-workbench-respond-no-respond.spec.ts</code></td><td>.github/issue-evidence/8785-voice-headful
+packages/app/test-results</td></tr></tbody></table>

--- a/.github/issue-evidence/9958-voice-matrix-web-run/voice-matrix.json
+++ b/.github/issue-evidence/9958-voice-matrix-web-run/voice-matrix.json
@@ -1,0 +1,182 @@
+{
+  "schema": "eliza_voice_live_matrix_v1",
+  "issue": 9958,
+  "generatedAt": "2026-06-29T20:55:04.433Z",
+  "mode": "run",
+  "dimensions": {
+    "platform": [
+      "web",
+      "linux",
+      "macos-electrobun",
+      "windows-electrobun",
+      "ios",
+      "android"
+    ],
+    "transcriptionState": [
+      "off",
+      "on"
+    ],
+    "chimeIn": [
+      "should-respond",
+      "should-not-respond"
+    ],
+    "wakewordContext": [
+      "idle-wake",
+      "already-listening-wake-inert",
+      "mid-transcription-wake"
+    ],
+    "noiseRejection": [
+      "quiet",
+      "noisy-reverberant",
+      "echo-self-voice",
+      "overlapping-speech"
+    ],
+    "voices": [
+      "owner",
+      "enrolled-contact",
+      "unknown",
+      "multi-speaker"
+    ]
+  },
+  "host": {
+    "platform": "darwin",
+    "arch": "arm64",
+    "hostname": "Shaws-MacBook-Pro.local",
+    "runnerOs": null,
+    "runnerArch": null
+  },
+  "summary": {
+    "pass": 3,
+    "fail": 0,
+    "pending": 0,
+    "skip": 0
+  },
+  "cells": [
+    {
+      "id": "web.fake-mic.roundtrip",
+      "title": "Web fake-device mic capture -> ASR -> agent -> TTS",
+      "platform": "web",
+      "dimensions": {
+        "transcriptionState": "off",
+        "chimeIn": "should-respond",
+        "wakewordContext": "idle-wake",
+        "noiseRejection": "quiet",
+        "voices": "owner"
+      },
+      "class": "live-client-audio",
+      "command": [
+        "bun",
+        "run",
+        "--cwd",
+        "packages/app",
+        "test:e2e",
+        "test/ui-smoke/voice-realaudio.spec.ts"
+      ],
+      "env": {
+        "ELIZA_UI_SMOKE_SKIP_VIEW_BUILD": "1"
+      },
+      "evidence": [
+        "packages/app/test-results",
+        "e2e-recordings/app/test-results"
+      ],
+      "probe": {
+        "available": true,
+        "reason": "command passed (2026-06-29T20:53:49.234Z)"
+      },
+      "cwd": ".",
+      "execution": {
+        "exitCode": 0,
+        "signal": null,
+        "startedAt": "2026-06-29T20:52:32.726Z",
+        "finishedAt": "2026-06-29T20:53:49.234Z",
+        "stdoutTail": ": \n@elizaos/core:build: Bundling with Bun...\n@elizaos/core:build: ✓ Configuration prepared (1.67ms)\n@elizaos/core:build: \n@elizaos/core:build: Bundling with Bun...\n@elizaos/core:build: ✓ Configuration prepared (1.17ms)\n@elizaos/core:build: \n@elizaos/core:build: Bundling with Bun...\n@elizaos/core:build: ✓ Built 4 file(s) - 28.74MB (351.32ms)\n@elizaos/core:build: \n@elizaos/core:build: ✅ @elizaos/core build complete!\n@elizaos/core:build: ⏱️  Total build time: 352.41ms\n@elizaos/core:build: ✅ Node.js build complete in 0.35s\n@elizaos/core:build: ✓ Built 4 file(s) - 21.32MB (453.77ms)\n@elizaos/core:build: \n@elizaos/core:build: ✅ @elizaos/core build complete!\n@elizaos/core:build: ⏱️  Total build time: 455.44ms\n@elizaos/core:build: ✅ Browser build complete in 0.46s\n@elizaos/core:build: ✓ Built 2 file(s) - 18.55MB (528.79ms)\n@elizaos/core:build: \n@elizaos/core:build: ✅ @elizaos/core build complete!\n@elizaos/core:build: ⏱️  Total build time: 530.50ms\n@elizaos/core:build: ✅ Edge build complete in 0.53s\n@elizaos/core:build: ✓ Built 4 file(s) - 0.02MB (532.30ms)\n@elizaos/core:build: \n@elizaos/core:build: ✅ @elizaos/core build complete!\n@elizaos/core:build: ⏱️  Total build time: 534.00ms\n@elizaos/core:build: ✅ Testing module build complete in 0.53s\n@elizaos/core:build: 📝 Generating TypeScript declarations...\n@elizaos/core:build:    Compiling TypeScript declarations...\n@elizaos/core:build:    Rewrote 1492 relative specifier(s) in 458 .d.ts file(s) for NodeNext ESM\n@elizaos/core:build: ✅ TypeScript declarations generated in 7.86s\n@elizaos/core:build: \n@elizaos/core:build: 🎉 All builds complete in 8.39s\n@elizaos/registry:build: cache miss, executing 23f6cffa06319ada\n@elizaos/registry:build: $ bun run src/generate.ts && bun run src/first-party/generate.ts\n@elizaos/registry:build: Generated /Users/shawwalters/.codex/worktrees/740a/eliza/packages/registry/generated-registry.json (18 third-party entries)\n@elizaos/registry:build: [registry/generate] wrote 116 entries + 10 curated-app definitions\n@elizaos/shared:build: cache miss, executing 75f8243295b28436\n@elizaos/shared:build: $ bun run build:i18n && bun run build:dist\n@elizaos/shared:build: $ node scripts/generate-keywords.mjs --target ts\n@elizaos/shared:build: Generating keyword code from JSON...\n@elizaos/shared:build: \n@elizaos/shared:build:   Loaded action-search.generated.keywords.json: 114 entries\n@elizaos/shared:build:   Loaded context-search.keywords.json: 38 entries\n@elizaos/shared:build:   Loaded shared.keywords.json: 71 entries\n@elizaos/shared:build:   Loaded typescript.keywords.json: 16 entries\n@elizaos/shared:build:   Loaded validate.keywords.json: 2 entries\n@elizaos/shared:build: \n@elizaos/shared:build: Total: 239 entries, 6 locales\n@elizaos/shared:build: \n@elizaos/shared:build:   TypeScript (shared): /Users/shawwalters/.codex/worktrees/740a/eliza/packages/shared/src/i18n/generated/validation-keyword-data.ts\n@elizaos/shared:build:   JavaScript (shared): /Users/shawwalters/.codex/worktrees/740a/eliza/packages/shared/src/i18n/generated/validation-keyword-data.js\n@elizaos/shared:build:   TypeScript (core):   /Users/shawwalters/.codex/worktrees/740a/eliza/packages/core/src/i18n/generated/validation-keyword-data.ts\n@elizaos/shared:build: \n@elizaos/shared:build: Done!\n@elizaos/shared:build: $ node ../scripts/rm-path-recursive.mjs dist && tsc --noCheck -p tsconfig.build.json && node ../scripts/prepare-package-dist.mjs packages/shared && node ../scripts/rewrite-dist-relative-imports-node-esm.mjs packages/shared && node ../scripts/copy-package-assets.mjs packages/shared src/brand/brand.css src/brand-classic/brand.css\n@elizaos/shared:build: [rewrite-dist-relative-imports] rewrote 5 file(s)\n\n Tasks:    5 successful, 5 total\nCached:    0 cached, 5 total\n  Time:    16.475s \n\n\nRunning 1 test using 1 worker\n\n  ✓  1 [chromium-voice-mic] › test/ui-smoke/voice-realaudio.spec.ts:108:1 › pressing the mic button captures REAL injected audio and completes the voice round-trip (6.5s)\n\n  1 passed (59.1s)\n",
+        "stderrTail": "$ node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts test/ui-smoke/voice-realaudio.spec.ts\n• turbo 2.10.0\n"
+      },
+      "status": "pass"
+    },
+    {
+      "id": "web.fake-mic.transcript-roundtrip",
+      "title": "Web fake-device transcript capture -> record -> player -> chat attachment",
+      "platform": "web",
+      "dimensions": {
+        "transcriptionState": "on",
+        "chimeIn": "should-not-respond",
+        "wakewordContext": "mid-transcription-wake",
+        "noiseRejection": "quiet",
+        "voices": "owner"
+      },
+      "class": "transcripts-roundtrip",
+      "command": [
+        "bun",
+        "run",
+        "--cwd",
+        "packages/app",
+        "test:e2e",
+        "test/ui-smoke/transcript-realaudio.spec.ts"
+      ],
+      "env": {
+        "ELIZA_UI_SMOKE_SKIP_VIEW_BUILD": "1"
+      },
+      "evidence": [
+        "packages/app/test-results",
+        "e2e-recordings/app/test-results"
+      ],
+      "probe": {
+        "available": true,
+        "reason": "command passed (2026-06-29T20:54:52.229Z)"
+      },
+      "cwd": ".",
+      "execution": {
+        "exitCode": 0,
+        "signal": null,
+        "startedAt": "2026-06-29T20:53:49.241Z",
+        "finishedAt": "2026-06-29T20:54:52.229Z",
+        "stdoutTail": "aos/core build complete!\n@elizaos/core:build: ⏱️  Total build time: 352.41ms\n@elizaos/core:build: ✅ Node.js build complete in 0.35s\n@elizaos/core:build: ✓ Built 4 file(s) - 21.32MB (453.77ms)\n@elizaos/core:build: \n@elizaos/core:build: ✅ @elizaos/core build complete!\n@elizaos/core:build: ⏱️  Total build time: 455.44ms\n@elizaos/core:build: ✅ Browser build complete in 0.46s\n@elizaos/core:build: ✓ Built 2 file(s) - 18.55MB (528.79ms)\n@elizaos/core:build: \n@elizaos/core:build: ✅ @elizaos/core build complete!\n@elizaos/core:build: ⏱️  Total build time: 530.50ms\n@elizaos/core:build: ✅ Edge build complete in 0.53s\n@elizaos/core:build: ✓ Built 4 file(s) - 0.02MB (532.30ms)\n@elizaos/core:build: \n@elizaos/core:build: ✅ @elizaos/core build complete!\n@elizaos/core:build: ⏱️  Total build time: 534.00ms\n@elizaos/core:build: ✅ Testing module build complete in 0.53s\n@elizaos/core:build: 📝 Generating TypeScript declarations...\n@elizaos/core:build:    Compiling TypeScript declarations...\n@elizaos/core:build:    Rewrote 1492 relative specifier(s) in 458 .d.ts file(s) for NodeNext ESM\n@elizaos/core:build: ✅ TypeScript declarations generated in 7.86s\n@elizaos/core:build: \n@elizaos/core:build: 🎉 All builds complete in 8.39s\n@elizaos/registry:build: cache hit, replaying logs 23f6cffa06319ada\n@elizaos/registry:build: $ bun run src/generate.ts && bun run src/first-party/generate.ts\n@elizaos/registry:build: Generated /Users/shawwalters/.codex/worktrees/740a/eliza/packages/registry/generated-registry.json (18 third-party entries)\n@elizaos/registry:build: [registry/generate] wrote 116 entries + 10 curated-app definitions\n@elizaos/shared:build: cache hit, replaying logs 75f8243295b28436\n@elizaos/shared:build: $ bun run build:i18n && bun run build:dist\n@elizaos/shared:build: $ node scripts/generate-keywords.mjs --target ts\n@elizaos/shared:build: Generating keyword code from JSON...\n@elizaos/shared:build: \n@elizaos/shared:build:   Loaded action-search.generated.keywords.json: 114 entries\n@elizaos/shared:build:   Loaded context-search.keywords.json: 38 entries\n@elizaos/shared:build:   Loaded shared.keywords.json: 71 entries\n@elizaos/shared:build:   Loaded typescript.keywords.json: 16 entries\n@elizaos/shared:build:   Loaded validate.keywords.json: 2 entries\n@elizaos/shared:build: \n@elizaos/shared:build: Total: 239 entries, 6 locales\n@elizaos/shared:build: \n@elizaos/shared:build:   TypeScript (shared): /Users/shawwalters/.codex/worktrees/740a/eliza/packages/shared/src/i18n/generated/validation-keyword-data.ts\n@elizaos/shared:build:   JavaScript (shared): /Users/shawwalters/.codex/worktrees/740a/eliza/packages/shared/src/i18n/generated/validation-keyword-data.js\n@elizaos/shared:build:   TypeScript (core):   /Users/shawwalters/.codex/worktrees/740a/eliza/packages/core/src/i18n/generated/validation-keyword-data.ts\n@elizaos/shared:build: \n@elizaos/shared:build: Done!\n@elizaos/shared:build: $ node ../scripts/rm-path-recursive.mjs dist && tsc --noCheck -p tsconfig.build.json && node ../scripts/prepare-package-dist.mjs packages/shared && node ../scripts/rewrite-dist-relative-imports-node-esm.mjs packages/shared && node ../scripts/copy-package-assets.mjs packages/shared src/brand/brand.css src/brand-classic/brand.css\n@elizaos/shared:build: [rewrite-dist-relative-imports] rewrote 5 file(s)\n\n Tasks:    5 successful, 5 total\nCached:    5 cached, 5 total\n  Time:    1.898s >>> FULL TURBO\n\n\nRunning 3 tests using 1 worker\n\n  ✓  1 [chromium-voice-mic] › test/ui-smoke/transcript-realaudio.spec.ts:692:1 › REAL audio: /transcribe records the injected WAV, POSTs it to ASR + /api/transcripts, keeps the mic active, and drops a transcript attachment (17.0s)\n  ✓  2 [chromium-voice-mic] › test/ui-smoke/transcript-realaudio.spec.ts:800:1 › VIEWER + TRANSCRIPTS + KNOWLEDGE: every transcript surface action works (20.5s)\n  ✓  3 [chromium-voice-mic] › test/ui-smoke/transcript-realaudio.spec.ts:987:1 › VIEWER: open-in-transcripts navigates to the Transcripts view (17.6s)\n\n  3 passed (1.0m)\n",
+        "stderrTail": "$ node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts test/ui-smoke/transcript-realaudio.spec.ts\n• turbo 2.10.0\n"
+      },
+      "status": "pass"
+    },
+    {
+      "id": "web.workbench.respond-no-respond",
+      "title": "Headful workbench should-respond / should-not-respond client cells",
+      "platform": "web",
+      "dimensions": {
+        "transcriptionState": "off",
+        "chimeIn": "should-not-respond",
+        "wakewordContext": "idle-wake",
+        "noiseRejection": "quiet",
+        "voices": "multi-speaker"
+      },
+      "class": "chime-in-matrix",
+      "command": [
+        "bun",
+        "run",
+        "--cwd",
+        "packages/app",
+        "test:e2e",
+        "test/ui-smoke/voice-workbench-respond-no-respond.spec.ts"
+      ],
+      "env": {
+        "ELIZA_UI_SMOKE_SKIP_VIEW_BUILD": "1"
+      },
+      "evidence": [
+        ".github/issue-evidence/8785-voice-headful",
+        "packages/app/test-results"
+      ],
+      "probe": {
+        "available": true,
+        "reason": "command passed (2026-06-29T20:55:04.433Z)"
+      },
+      "cwd": ".",
+      "execution": {
+        "exitCode": 0,
+        "signal": null,
+        "startedAt": "2026-06-29T20:54:52.249Z",
+        "finishedAt": "2026-06-29T20:55:04.433Z",
+        "stdoutTail": "zaos/core:build: Bundling with Bun...\n@elizaos/core:build: ✓ Configuration prepared (1.67ms)\n@elizaos/core:build: \n@elizaos/core:build: Bundling with Bun...\n@elizaos/core:build: ✓ Configuration prepared (1.17ms)\n@elizaos/core:build: \n@elizaos/core:build: Bundling with Bun...\n@elizaos/core:build: ✓ Built 4 file(s) - 28.74MB (351.32ms)\n@elizaos/core:build: \n@elizaos/core:build: ✅ @elizaos/core build complete!\n@elizaos/core:build: ⏱️  Total build time: 352.41ms\n@elizaos/core:build: ✅ Node.js build complete in 0.35s\n@elizaos/core:build: ✓ Built 4 file(s) - 21.32MB (453.77ms)\n@elizaos/core:build: \n@elizaos/core:build: ✅ @elizaos/core build complete!\n@elizaos/core:build: ⏱️  Total build time: 455.44ms\n@elizaos/core:build: ✅ Browser build complete in 0.46s\n@elizaos/core:build: ✓ Built 2 file(s) - 18.55MB (528.79ms)\n@elizaos/core:build: \n@elizaos/core:build: ✅ @elizaos/core build complete!\n@elizaos/core:build: ⏱️  Total build time: 530.50ms\n@elizaos/core:build: ✅ Edge build complete in 0.53s\n@elizaos/core:build: ✓ Built 4 file(s) - 0.02MB (532.30ms)\n@elizaos/core:build: \n@elizaos/core:build: ✅ @elizaos/core build complete!\n@elizaos/core:build: ⏱️  Total build time: 534.00ms\n@elizaos/core:build: ✅ Testing module build complete in 0.53s\n@elizaos/core:build: 📝 Generating TypeScript declarations...\n@elizaos/core:build:    Compiling TypeScript declarations...\n@elizaos/core:build:    Rewrote 1492 relative specifier(s) in 458 .d.ts file(s) for NodeNext ESM\n@elizaos/core:build: ✅ TypeScript declarations generated in 7.86s\n@elizaos/core:build: \n@elizaos/core:build: 🎉 All builds complete in 8.39s\n@elizaos/registry:build: cache hit, replaying logs 23f6cffa06319ada\n@elizaos/registry:build: $ bun run src/generate.ts && bun run src/first-party/generate.ts\n@elizaos/registry:build: Generated /Users/shawwalters/.codex/worktrees/740a/eliza/packages/registry/generated-registry.json (18 third-party entries)\n@elizaos/registry:build: [registry/generate] wrote 116 entries + 10 curated-app definitions\n@elizaos/shared:build: cache hit, replaying logs 75f8243295b28436\n@elizaos/shared:build: $ bun run build:i18n && bun run build:dist\n@elizaos/shared:build: $ node scripts/generate-keywords.mjs --target ts\n@elizaos/shared:build: Generating keyword code from JSON...\n@elizaos/shared:build: \n@elizaos/shared:build:   Loaded action-search.generated.keywords.json: 114 entries\n@elizaos/shared:build:   Loaded context-search.keywords.json: 38 entries\n@elizaos/shared:build:   Loaded shared.keywords.json: 71 entries\n@elizaos/shared:build:   Loaded typescript.keywords.json: 16 entries\n@elizaos/shared:build:   Loaded validate.keywords.json: 2 entries\n@elizaos/shared:build: \n@elizaos/shared:build: Total: 239 entries, 6 locales\n@elizaos/shared:build: \n@elizaos/shared:build:   TypeScript (shared): /Users/shawwalters/.codex/worktrees/740a/eliza/packages/shared/src/i18n/generated/validation-keyword-data.ts\n@elizaos/shared:build:   JavaScript (shared): /Users/shawwalters/.codex/worktrees/740a/eliza/packages/shared/src/i18n/generated/validation-keyword-data.js\n@elizaos/shared:build:   TypeScript (core):   /Users/shawwalters/.codex/worktrees/740a/eliza/packages/core/src/i18n/generated/validation-keyword-data.ts\n@elizaos/shared:build: \n@elizaos/shared:build: Done!\n@elizaos/shared:build: $ node ../scripts/rm-path-recursive.mjs dist && tsc --noCheck -p tsconfig.build.json && node ../scripts/prepare-package-dist.mjs packages/shared && node ../scripts/rewrite-dist-relative-imports-node-esm.mjs packages/shared && node ../scripts/copy-package-assets.mjs packages/shared src/brand/brand.css src/brand-classic/brand.css\n@elizaos/shared:build: [rewrite-dist-relative-imports] rewrote 5 file(s)\n\n Tasks:    5 successful, 5 total\nCached:    5 cached, 5 total\n  Time:    3.81s >>> FULL TURBO\n\n\nRunning 1 test using 1 worker\n\n  ✓  1 [chromium] › test/ui-smoke/voice-workbench-cases.ts:212:3 › voice workbench [respond-no-respond] scenario respond-decision-mix scores every turn (1.8s)\n\n  1 passed (7.3s)\n",
+        "stderrTail": "$ node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts test/ui-smoke/voice-workbench-respond-no-respond.spec.ts\n• turbo 2.10.0\n"
+      },
+      "status": "pass"
+    }
+  ]
+}

--- a/.github/issue-evidence/9958-voice-matrix-web-run/voice-matrix.md
+++ b/.github/issue-evidence/9958-voice-matrix-web-run/voice-matrix.md
@@ -1,0 +1,19 @@
+# Voice Live Matrix
+
+Generated: 2026-06-29T20:55:04.433Z
+Host: darwin arm64 (Shaws-MacBook-Pro.local)
+
+| Cell | Status | Platform | Class | Probe / Result | Command |
+|---|---:|---|---|---|---|
+| `web.fake-mic.roundtrip` | pass | web | live-client-audio | command passed (2026-06-29T20:53:49.234Z) | `bun run --cwd packages/app test:e2e test/ui-smoke/voice-realaudio.spec.ts` |
+| `web.fake-mic.transcript-roundtrip` | pass | web | transcripts-roundtrip | command passed (2026-06-29T20:54:52.229Z) | `bun run --cwd packages/app test:e2e test/ui-smoke/transcript-realaudio.spec.ts` |
+| `web.workbench.respond-no-respond` | pass | web | chime-in-matrix | command passed (2026-06-29T20:55:04.433Z) | `bun run --cwd packages/app test:e2e test/ui-smoke/voice-workbench-respond-no-respond.spec.ts` |
+
+## Summary
+
+- Pass: 3
+- Fail: 0
+- Pending: 0
+- Skip: 0
+
+Hardware-unavailable cells are explicit `skip` rows. They are not evidence of platform coverage.

--- a/.github/issue-evidence/9958-voice-matrix/index.html
+++ b/.github/issue-evidence/9958-voice-matrix/index.html
@@ -1,0 +1,96 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Voice Live Matrix</title>
+<style>
+body{font-family:system-ui,-apple-system,Segoe UI,sans-serif;margin:24px;background:#fafafa;color:#151515}
+table{width:100%;border-collapse:collapse;background:white}
+th,td{border:1px solid #ddd;padding:8px;vertical-align:top;white-space:pre-wrap}
+th{background:#f1f1f1;text-align:left}
+.pass td:nth-child(2){color:#116b2d;font-weight:700}
+.fail td:nth-child(2){color:#9a1b1b;font-weight:700}
+.skip td:nth-child(2),.pending td:nth-child(2){color:#7a5b00;font-weight:700}
+code{font-size:12px}
+</style>
+<h1>Voice Live Matrix</h1>
+<p>Generated 2026-06-29T20:52:25.406Z on darwin arm64 (Shaws-MacBook-Pro.local).</p>
+<p>Pass 0 · Fail 0 · Pending 5 · Skip 10</p>
+<table><thead><tr><th>Cell</th><th>Status</th><th>Platform</th><th>Class</th><th>Dimensions</th><th>Probe / Result</th><th>Command</th><th>Evidence</th></tr></thead><tbody><tr class="pending"><td><code>web.fake-mic.roundtrip</code><br>Web fake-device mic capture -&gt; ASR -&gt; agent -&gt; TTS</td><td>pending</td><td>web</td><td>live-client-audio</td><td>transcriptionState=off
+chimeIn=should-respond
+wakewordContext=idle-wake
+noiseRejection=quiet
+voices=owner</td><td>Chromium fake-device mic lane is host-runnable</td><td><code>bun run --cwd packages/app test:e2e test/ui-smoke/voice-realaudio.spec.ts</code></td><td>packages/app/test-results
+e2e-recordings/app/test-results</td></tr>
+<tr class="pending"><td><code>web.fake-mic.transcript-roundtrip</code><br>Web fake-device transcript capture -&gt; record -&gt; player -&gt; chat attachment</td><td>pending</td><td>web</td><td>transcripts-roundtrip</td><td>transcriptionState=on
+chimeIn=should-not-respond
+wakewordContext=mid-transcription-wake
+noiseRejection=quiet
+voices=owner</td><td>Chromium fake-device mic lane is host-runnable</td><td><code>bun run --cwd packages/app test:e2e test/ui-smoke/transcript-realaudio.spec.ts</code></td><td>packages/app/test-results
+e2e-recordings/app/test-results</td></tr>
+<tr class="pending"><td><code>web.workbench.respond-no-respond</code><br>Headful workbench should-respond / should-not-respond client cells</td><td>pending</td><td>web</td><td>chime-in-matrix</td><td>transcriptionState=off
+chimeIn=should-not-respond
+wakewordContext=idle-wake
+noiseRejection=quiet
+voices=multi-speaker</td><td>Chromium fake-device mic lane is host-runnable</td><td><code>bun run --cwd packages/app test:e2e test/ui-smoke/voice-workbench-respond-no-respond.spec.ts</code></td><td>.github/issue-evidence/8785-voice-headful
+packages/app/test-results</td></tr>
+<tr class="skip"><td><code>linux.fused-acoustic.workbench-real</code><br>Linux fused ASR/VAD/diarization/Kokoro workbench real-service matrix</td><td>skip</td><td>linux</td><td>real-acoustic-workbench</td><td>transcriptionState=off
+chimeIn=should-respond
+wakewordContext=idle-wake
+noiseRejection=noisy-reverberant
+voices=multi-speaker</td><td>requires Linux runner; current=darwin</td><td><code>bun run --cwd plugins/plugin-local-inference voice:workbench --real</code></td><td>$VOICE_REAL_MATRIX_OUT/voice-workbench-real
+.github/issue-evidence/9147-real-audio-matrix-m4max.md</td></tr>
+<tr class="skip"><td><code>linux.fused-acoustic.barge-in</code><br>Linux fused voice barge-in latency and cancellation harness</td><td>skip</td><td>linux</td><td>barge-in</td><td>transcriptionState=off
+chimeIn=should-respond
+wakewordContext=already-listening-wake-inert
+noiseRejection=echo-self-voice
+voices=owner</td><td>requires Linux runner; current=darwin</td><td><code>bun run --cwd plugins/plugin-local-inference voice:bargein-bench</code></td><td>plugins/plugin-local-inference/native/verify</td></tr>
+<tr class="skip"><td><code>macos.electrobun.live-roundtrip</code><br>macOS Electrobun live mic -&gt; ASR -&gt; agent -&gt; Kokoro -&gt; speaker loop</td><td>skip</td><td>macos-electrobun</td><td>desktop-live-voice</td><td>transcriptionState=off
+chimeIn=should-respond
+wakewordContext=idle-wake
+noiseRejection=quiet
+voices=owner</td><td>set ELIZA_VOICE_MACOS_ELECTROBUN_READY=1 on a macOS Electrobun voice runner with loopback mic/audio capture</td><td><code>bun run --cwd packages/app capture:macos-desktop -- --issue 9958 --slug voice-macos-electrobun</code></td><td>.github/issue-evidence/9958-voice-macos-electrobun-macos-desktop.*</td></tr>
+<tr class="skip"><td><code>windows.electrobun.live-roundtrip</code><br>Windows Electrobun live mic -&gt; ASR -&gt; agent -&gt; Kokoro -&gt; speaker loop</td><td>skip</td><td>windows-electrobun</td><td>desktop-live-voice</td><td>transcriptionState=off
+chimeIn=should-respond
+wakewordContext=idle-wake
+noiseRejection=quiet
+voices=owner</td><td>requires Windows runner; current=darwin</td><td><code>bun run --cwd packages/app capture:windows-desktop -- --issue 9958 --slug voice-windows-electrobun</code></td><td>.github/issue-evidence/9958-voice-windows-electrobun-windows-desktop.*</td></tr>
+<tr class="skip"><td><code>ios.sim-or-device.voice-roundtrip</code><br>iOS simulator/device voice self-test and capture evidence</td><td>skip</td><td>ios</td><td>mobile-live-voice</td><td>transcriptionState=off
+chimeIn=should-respond
+wakewordContext=idle-wake
+noiseRejection=quiet
+voices=owner</td><td>set ELIZA_VOICE_IOS_READY=1 after installing a current iOS simulator/device build with voice assets</td><td><code>bun run --cwd packages/app capture:ios-sim -- --issue 9958 --slug voice-ios</code></td><td>.github/issue-evidence/9958-voice-ios-ios-sim.*</td></tr>
+<tr class="pending"><td><code>ios.talkmode.native-bridge</code><br>TalkMode iOS transcript, permission, state, and barge-in bridge contracts</td><td>pending</td><td>ios</td><td>native-bridge-unit</td><td>transcriptionState=off
+chimeIn=should-respond
+wakewordContext=already-listening-wake-inert
+noiseRejection=echo-self-voice
+voices=owner</td><td>macOS Swift Package test toolchain is available</td><td><code>swift test --package-path plugins/plugin-native-talkmode/ios</code></td><td>plugins/plugin-native-talkmode/ios/Tests</td></tr>
+<tr class="pending"><td><code>ios.swabble.native-bridge</code><br>Swabble iOS wake-firing -&gt; JS bridge event contract</td><td>pending</td><td>ios</td><td>native-bridge-unit</td><td>transcriptionState=off
+chimeIn=should-respond
+wakewordContext=idle-wake
+noiseRejection=quiet
+voices=owner</td><td>macOS Swift Package test toolchain is available</td><td><code>swift test --package-path plugins/plugin-native-swabble/ios</code></td><td>plugins/plugin-native-swabble/ios/Tests</td></tr>
+<tr class="skip"><td><code>android.device.voice-roundtrip</code><br>Android device WebView real on-device STT -&gt; agent -&gt; TTS voice self-test</td><td>skip</td><td>android</td><td>mobile-live-voice</td><td>transcriptionState=off
+chimeIn=should-respond
+wakewordContext=idle-wake
+noiseRejection=quiet
+voices=owner</td><td>set ELIZA_VOICE_ANDROID_READY=1 on an Android device runner with the current APK and voice assets installed</td><td><code>bun run --cwd packages/app test:e2e:android:local</code></td><td>packages/app/test-results
+.github/issue-evidence</td></tr>
+<tr class="skip"><td><code>android.talkmode.native-bridge</code><br>TalkMode Android capture lifecycle, transcript, permission, and barge-in bridge contracts</td><td>skip</td><td>android</td><td>native-bridge-unit</td><td>transcriptionState=off
+chimeIn=should-respond
+wakewordContext=already-listening-wake-inert
+noiseRejection=echo-self-voice
+voices=owner</td><td>packages/app/android is not generated; run packages/app cap:sync:android or build:android first</td><td><code>./gradlew :elizaos-capacitor-talkmode:testDebugUnitTest</code></td><td>plugins/plugin-native-talkmode/android/src/test/java</td></tr>
+<tr class="skip"><td><code>android.swabble.native-bridge</code><br>Swabble Android wake-firing -&gt; JS bridge event contract</td><td>skip</td><td>android</td><td>native-bridge-unit</td><td>transcriptionState=off
+chimeIn=should-respond
+wakewordContext=idle-wake
+noiseRejection=quiet
+voices=owner</td><td>packages/app/android is not generated; run packages/app cap:sync:android or build:android first</td><td><code>./gradlew :elizaos-capacitor-swabble:testDebugUnitTest</code></td><td>plugins/plugin-native-swabble/android/src/test/java</td></tr>
+<tr class="skip"><td><code>wake.openwakeword.real-head</code><br>Real openWakeWord head wake-context cells</td><td>skip</td><td>linux</td><td>wakeword-device-gap</td><td>transcriptionState=on
+chimeIn=should-not-respond
+wakewordContext=mid-transcription-wake
+noiseRejection=overlapping-speech
+voices=multi-speaker</td><td>ELIZA_OPENWAKEWORD_REAL_READY is not set for a real wake-word head run</td><td><code>bun run --cwd plugins/plugin-local-inference voice:workbench --real</code></td><td>$VOICE_REAL_MATRIX_OUT/voice-workbench-real</td></tr>
+<tr class="skip"><td><code>stt.stage-b.evaluation</code><br>Stage-B STT evaluation: iOS SFSpeechRecognizer vs Android SpeechRecognizer vs fused ASR</td><td>skip</td><td>android</td><td>stt-evaluation</td><td>transcriptionState=on
+chimeIn=should-respond
+wakewordContext=idle-wake
+noiseRejection=noisy-reverberant
+voices=multi-speaker</td><td>Stage-B STT battery/latency evaluation needs paired iOS+Android device runners and power telemetry</td><td><code>bun packages/scripts/voice-matrix.mjs --stage-b-eval-placeholder</code></td><td>.github/issue-evidence/9147-voice-asr-m4max.md</td></tr></tbody></table>

--- a/.github/issue-evidence/9958-voice-matrix/voice-matrix.json
+++ b/.github/issue-evidence/9958-voice-matrix/voice-matrix.json
@@ -1,0 +1,542 @@
+{
+  "schema": "eliza_voice_live_matrix_v1",
+  "issue": 9958,
+  "generatedAt": "2026-06-29T20:52:25.406Z",
+  "mode": "probe",
+  "dimensions": {
+    "platform": [
+      "web",
+      "linux",
+      "macos-electrobun",
+      "windows-electrobun",
+      "ios",
+      "android"
+    ],
+    "transcriptionState": [
+      "off",
+      "on"
+    ],
+    "chimeIn": [
+      "should-respond",
+      "should-not-respond"
+    ],
+    "wakewordContext": [
+      "idle-wake",
+      "already-listening-wake-inert",
+      "mid-transcription-wake"
+    ],
+    "noiseRejection": [
+      "quiet",
+      "noisy-reverberant",
+      "echo-self-voice",
+      "overlapping-speech"
+    ],
+    "voices": [
+      "owner",
+      "enrolled-contact",
+      "unknown",
+      "multi-speaker"
+    ]
+  },
+  "host": {
+    "platform": "darwin",
+    "arch": "arm64",
+    "hostname": "Shaws-MacBook-Pro.local",
+    "runnerOs": null,
+    "runnerArch": null
+  },
+  "summary": {
+    "pass": 0,
+    "fail": 0,
+    "pending": 5,
+    "skip": 10
+  },
+  "cells": [
+    {
+      "id": "web.fake-mic.roundtrip",
+      "title": "Web fake-device mic capture -> ASR -> agent -> TTS",
+      "platform": "web",
+      "dimensions": {
+        "transcriptionState": "off",
+        "chimeIn": "should-respond",
+        "wakewordContext": "idle-wake",
+        "noiseRejection": "quiet",
+        "voices": "owner"
+      },
+      "class": "live-client-audio",
+      "command": [
+        "bun",
+        "run",
+        "--cwd",
+        "packages/app",
+        "test:e2e",
+        "test/ui-smoke/voice-realaudio.spec.ts"
+      ],
+      "env": {
+        "ELIZA_UI_SMOKE_SKIP_VIEW_BUILD": "1"
+      },
+      "evidence": [
+        "packages/app/test-results",
+        "e2e-recordings/app/test-results"
+      ],
+      "probe": {
+        "available": true,
+        "reason": "Chromium fake-device mic lane is host-runnable"
+      },
+      "cwd": ".",
+      "execution": null,
+      "status": "pending"
+    },
+    {
+      "id": "web.fake-mic.transcript-roundtrip",
+      "title": "Web fake-device transcript capture -> record -> player -> chat attachment",
+      "platform": "web",
+      "dimensions": {
+        "transcriptionState": "on",
+        "chimeIn": "should-not-respond",
+        "wakewordContext": "mid-transcription-wake",
+        "noiseRejection": "quiet",
+        "voices": "owner"
+      },
+      "class": "transcripts-roundtrip",
+      "command": [
+        "bun",
+        "run",
+        "--cwd",
+        "packages/app",
+        "test:e2e",
+        "test/ui-smoke/transcript-realaudio.spec.ts"
+      ],
+      "env": {
+        "ELIZA_UI_SMOKE_SKIP_VIEW_BUILD": "1"
+      },
+      "evidence": [
+        "packages/app/test-results",
+        "e2e-recordings/app/test-results"
+      ],
+      "probe": {
+        "available": true,
+        "reason": "Chromium fake-device mic lane is host-runnable"
+      },
+      "cwd": ".",
+      "execution": null,
+      "status": "pending"
+    },
+    {
+      "id": "web.workbench.respond-no-respond",
+      "title": "Headful workbench should-respond / should-not-respond client cells",
+      "platform": "web",
+      "dimensions": {
+        "transcriptionState": "off",
+        "chimeIn": "should-not-respond",
+        "wakewordContext": "idle-wake",
+        "noiseRejection": "quiet",
+        "voices": "multi-speaker"
+      },
+      "class": "chime-in-matrix",
+      "command": [
+        "bun",
+        "run",
+        "--cwd",
+        "packages/app",
+        "test:e2e",
+        "test/ui-smoke/voice-workbench-respond-no-respond.spec.ts"
+      ],
+      "env": {
+        "ELIZA_UI_SMOKE_SKIP_VIEW_BUILD": "1"
+      },
+      "evidence": [
+        ".github/issue-evidence/8785-voice-headful",
+        "packages/app/test-results"
+      ],
+      "probe": {
+        "available": true,
+        "reason": "Chromium fake-device mic lane is host-runnable"
+      },
+      "cwd": ".",
+      "execution": null,
+      "status": "pending"
+    },
+    {
+      "id": "linux.fused-acoustic.workbench-real",
+      "title": "Linux fused ASR/VAD/diarization/Kokoro workbench real-service matrix",
+      "platform": "linux",
+      "dimensions": {
+        "transcriptionState": "off",
+        "chimeIn": "should-respond",
+        "wakewordContext": "idle-wake",
+        "noiseRejection": "noisy-reverberant",
+        "voices": "multi-speaker"
+      },
+      "class": "real-acoustic-workbench",
+      "command": [
+        "bun",
+        "run",
+        "--cwd",
+        "plugins/plugin-local-inference",
+        "voice:workbench",
+        "--real"
+      ],
+      "evidence": [
+        "$VOICE_REAL_MATRIX_OUT/voice-workbench-real",
+        ".github/issue-evidence/9147-real-audio-matrix-m4max.md"
+      ],
+      "probe": {
+        "available": false,
+        "reason": "requires Linux runner; current=darwin"
+      },
+      "cwd": ".",
+      "env": {},
+      "execution": null,
+      "status": "skip"
+    },
+    {
+      "id": "linux.fused-acoustic.barge-in",
+      "title": "Linux fused voice barge-in latency and cancellation harness",
+      "platform": "linux",
+      "dimensions": {
+        "transcriptionState": "off",
+        "chimeIn": "should-respond",
+        "wakewordContext": "already-listening-wake-inert",
+        "noiseRejection": "echo-self-voice",
+        "voices": "owner"
+      },
+      "class": "barge-in",
+      "command": [
+        "bun",
+        "run",
+        "--cwd",
+        "plugins/plugin-local-inference",
+        "voice:bargein-bench"
+      ],
+      "evidence": [
+        "plugins/plugin-local-inference/native/verify"
+      ],
+      "probe": {
+        "available": false,
+        "reason": "requires Linux runner; current=darwin"
+      },
+      "cwd": ".",
+      "env": {},
+      "execution": null,
+      "status": "skip"
+    },
+    {
+      "id": "macos.electrobun.live-roundtrip",
+      "title": "macOS Electrobun live mic -> ASR -> agent -> Kokoro -> speaker loop",
+      "platform": "macos-electrobun",
+      "dimensions": {
+        "transcriptionState": "off",
+        "chimeIn": "should-respond",
+        "wakewordContext": "idle-wake",
+        "noiseRejection": "quiet",
+        "voices": "owner"
+      },
+      "class": "desktop-live-voice",
+      "command": [
+        "bun",
+        "run",
+        "--cwd",
+        "packages/app",
+        "capture:macos-desktop",
+        "--",
+        "--issue",
+        "9958",
+        "--slug",
+        "voice-macos-electrobun"
+      ],
+      "evidence": [
+        ".github/issue-evidence/9958-voice-macos-electrobun-macos-desktop.*"
+      ],
+      "probe": {
+        "available": false,
+        "reason": "set ELIZA_VOICE_MACOS_ELECTROBUN_READY=1 on a macOS Electrobun voice runner with loopback mic/audio capture"
+      },
+      "cwd": ".",
+      "env": {},
+      "execution": null,
+      "status": "skip"
+    },
+    {
+      "id": "windows.electrobun.live-roundtrip",
+      "title": "Windows Electrobun live mic -> ASR -> agent -> Kokoro -> speaker loop",
+      "platform": "windows-electrobun",
+      "dimensions": {
+        "transcriptionState": "off",
+        "chimeIn": "should-respond",
+        "wakewordContext": "idle-wake",
+        "noiseRejection": "quiet",
+        "voices": "owner"
+      },
+      "class": "desktop-live-voice",
+      "command": [
+        "bun",
+        "run",
+        "--cwd",
+        "packages/app",
+        "capture:windows-desktop",
+        "--",
+        "--issue",
+        "9958",
+        "--slug",
+        "voice-windows-electrobun"
+      ],
+      "evidence": [
+        ".github/issue-evidence/9958-voice-windows-electrobun-windows-desktop.*"
+      ],
+      "probe": {
+        "available": false,
+        "reason": "requires Windows runner; current=darwin"
+      },
+      "cwd": ".",
+      "env": {},
+      "execution": null,
+      "status": "skip"
+    },
+    {
+      "id": "ios.sim-or-device.voice-roundtrip",
+      "title": "iOS simulator/device voice self-test and capture evidence",
+      "platform": "ios",
+      "dimensions": {
+        "transcriptionState": "off",
+        "chimeIn": "should-respond",
+        "wakewordContext": "idle-wake",
+        "noiseRejection": "quiet",
+        "voices": "owner"
+      },
+      "class": "mobile-live-voice",
+      "command": [
+        "bun",
+        "run",
+        "--cwd",
+        "packages/app",
+        "capture:ios-sim",
+        "--",
+        "--issue",
+        "9958",
+        "--slug",
+        "voice-ios"
+      ],
+      "evidence": [
+        ".github/issue-evidence/9958-voice-ios-ios-sim.*"
+      ],
+      "probe": {
+        "available": false,
+        "reason": "set ELIZA_VOICE_IOS_READY=1 after installing a current iOS simulator/device build with voice assets"
+      },
+      "cwd": ".",
+      "env": {},
+      "execution": null,
+      "status": "skip"
+    },
+    {
+      "id": "ios.talkmode.native-bridge",
+      "title": "TalkMode iOS transcript, permission, state, and barge-in bridge contracts",
+      "platform": "ios",
+      "dimensions": {
+        "transcriptionState": "off",
+        "chimeIn": "should-respond",
+        "wakewordContext": "already-listening-wake-inert",
+        "noiseRejection": "echo-self-voice",
+        "voices": "owner"
+      },
+      "class": "native-bridge-unit",
+      "command": [
+        "swift",
+        "test",
+        "--package-path",
+        "plugins/plugin-native-talkmode/ios"
+      ],
+      "evidence": [
+        "plugins/plugin-native-talkmode/ios/Tests"
+      ],
+      "probe": {
+        "available": true,
+        "reason": "macOS Swift Package test toolchain is available"
+      },
+      "cwd": ".",
+      "env": {},
+      "execution": null,
+      "status": "pending"
+    },
+    {
+      "id": "ios.swabble.native-bridge",
+      "title": "Swabble iOS wake-firing -> JS bridge event contract",
+      "platform": "ios",
+      "dimensions": {
+        "transcriptionState": "off",
+        "chimeIn": "should-respond",
+        "wakewordContext": "idle-wake",
+        "noiseRejection": "quiet",
+        "voices": "owner"
+      },
+      "class": "native-bridge-unit",
+      "command": [
+        "swift",
+        "test",
+        "--package-path",
+        "plugins/plugin-native-swabble/ios"
+      ],
+      "evidence": [
+        "plugins/plugin-native-swabble/ios/Tests"
+      ],
+      "probe": {
+        "available": true,
+        "reason": "macOS Swift Package test toolchain is available"
+      },
+      "cwd": ".",
+      "env": {},
+      "execution": null,
+      "status": "pending"
+    },
+    {
+      "id": "android.device.voice-roundtrip",
+      "title": "Android device WebView real on-device STT -> agent -> TTS voice self-test",
+      "platform": "android",
+      "dimensions": {
+        "transcriptionState": "off",
+        "chimeIn": "should-respond",
+        "wakewordContext": "idle-wake",
+        "noiseRejection": "quiet",
+        "voices": "owner"
+      },
+      "class": "mobile-live-voice",
+      "command": [
+        "bun",
+        "run",
+        "--cwd",
+        "packages/app",
+        "test:e2e:android:local"
+      ],
+      "evidence": [
+        "packages/app/test-results",
+        ".github/issue-evidence"
+      ],
+      "probe": {
+        "available": false,
+        "reason": "set ELIZA_VOICE_ANDROID_READY=1 on an Android device runner with the current APK and voice assets installed"
+      },
+      "cwd": ".",
+      "env": {},
+      "execution": null,
+      "status": "skip"
+    },
+    {
+      "id": "android.talkmode.native-bridge",
+      "title": "TalkMode Android capture lifecycle, transcript, permission, and barge-in bridge contracts",
+      "platform": "android",
+      "dimensions": {
+        "transcriptionState": "off",
+        "chimeIn": "should-respond",
+        "wakewordContext": "already-listening-wake-inert",
+        "noiseRejection": "echo-self-voice",
+        "voices": "owner"
+      },
+      "class": "native-bridge-unit",
+      "command": [
+        "./gradlew",
+        ":elizaos-capacitor-talkmode:testDebugUnitTest"
+      ],
+      "cwd": "packages/app/android",
+      "evidence": [
+        "plugins/plugin-native-talkmode/android/src/test/java"
+      ],
+      "probe": {
+        "available": false,
+        "reason": "packages/app/android is not generated; run packages/app cap:sync:android or build:android first"
+      },
+      "env": {},
+      "execution": null,
+      "status": "skip"
+    },
+    {
+      "id": "android.swabble.native-bridge",
+      "title": "Swabble Android wake-firing -> JS bridge event contract",
+      "platform": "android",
+      "dimensions": {
+        "transcriptionState": "off",
+        "chimeIn": "should-respond",
+        "wakewordContext": "idle-wake",
+        "noiseRejection": "quiet",
+        "voices": "owner"
+      },
+      "class": "native-bridge-unit",
+      "command": [
+        "./gradlew",
+        ":elizaos-capacitor-swabble:testDebugUnitTest"
+      ],
+      "cwd": "packages/app/android",
+      "evidence": [
+        "plugins/plugin-native-swabble/android/src/test/java"
+      ],
+      "probe": {
+        "available": false,
+        "reason": "packages/app/android is not generated; run packages/app cap:sync:android or build:android first"
+      },
+      "env": {},
+      "execution": null,
+      "status": "skip"
+    },
+    {
+      "id": "wake.openwakeword.real-head",
+      "title": "Real openWakeWord head wake-context cells",
+      "platform": "linux",
+      "dimensions": {
+        "transcriptionState": "on",
+        "chimeIn": "should-not-respond",
+        "wakewordContext": "mid-transcription-wake",
+        "noiseRejection": "overlapping-speech",
+        "voices": "multi-speaker"
+      },
+      "class": "wakeword-device-gap",
+      "command": [
+        "bun",
+        "run",
+        "--cwd",
+        "plugins/plugin-local-inference",
+        "voice:workbench",
+        "--real"
+      ],
+      "evidence": [
+        "$VOICE_REAL_MATRIX_OUT/voice-workbench-real"
+      ],
+      "probe": {
+        "available": false,
+        "reason": "ELIZA_OPENWAKEWORD_REAL_READY is not set for a real wake-word head run"
+      },
+      "cwd": ".",
+      "env": {},
+      "execution": null,
+      "status": "skip"
+    },
+    {
+      "id": "stt.stage-b.evaluation",
+      "title": "Stage-B STT evaluation: iOS SFSpeechRecognizer vs Android SpeechRecognizer vs fused ASR",
+      "platform": "android",
+      "dimensions": {
+        "transcriptionState": "on",
+        "chimeIn": "should-respond",
+        "wakewordContext": "idle-wake",
+        "noiseRejection": "noisy-reverberant",
+        "voices": "multi-speaker"
+      },
+      "class": "stt-evaluation",
+      "command": [
+        "bun",
+        "packages/scripts/voice-matrix.mjs",
+        "--stage-b-eval-placeholder"
+      ],
+      "evidence": [
+        ".github/issue-evidence/9147-voice-asr-m4max.md"
+      ],
+      "probe": {
+        "available": false,
+        "reason": "Stage-B STT battery/latency evaluation needs paired iOS+Android device runners and power telemetry"
+      },
+      "cwd": ".",
+      "env": {},
+      "execution": null,
+      "status": "skip"
+    }
+  ]
+}

--- a/.github/issue-evidence/9958-voice-matrix/voice-matrix.md
+++ b/.github/issue-evidence/9958-voice-matrix/voice-matrix.md
@@ -1,0 +1,31 @@
+# Voice Live Matrix
+
+Generated: 2026-06-29T20:52:25.406Z
+Host: darwin arm64 (Shaws-MacBook-Pro.local)
+
+| Cell | Status | Platform | Class | Probe / Result | Command |
+|---|---:|---|---|---|---|
+| `web.fake-mic.roundtrip` | pending | web | live-client-audio | Chromium fake-device mic lane is host-runnable | `bun run --cwd packages/app test:e2e test/ui-smoke/voice-realaudio.spec.ts` |
+| `web.fake-mic.transcript-roundtrip` | pending | web | transcripts-roundtrip | Chromium fake-device mic lane is host-runnable | `bun run --cwd packages/app test:e2e test/ui-smoke/transcript-realaudio.spec.ts` |
+| `web.workbench.respond-no-respond` | pending | web | chime-in-matrix | Chromium fake-device mic lane is host-runnable | `bun run --cwd packages/app test:e2e test/ui-smoke/voice-workbench-respond-no-respond.spec.ts` |
+| `linux.fused-acoustic.workbench-real` | skip | linux | real-acoustic-workbench | requires Linux runner; current=darwin | `bun run --cwd plugins/plugin-local-inference voice:workbench --real` |
+| `linux.fused-acoustic.barge-in` | skip | linux | barge-in | requires Linux runner; current=darwin | `bun run --cwd plugins/plugin-local-inference voice:bargein-bench` |
+| `macos.electrobun.live-roundtrip` | skip | macos-electrobun | desktop-live-voice | set ELIZA_VOICE_MACOS_ELECTROBUN_READY=1 on a macOS Electrobun voice runner with loopback mic/audio capture | `bun run --cwd packages/app capture:macos-desktop -- --issue 9958 --slug voice-macos-electrobun` |
+| `windows.electrobun.live-roundtrip` | skip | windows-electrobun | desktop-live-voice | requires Windows runner; current=darwin | `bun run --cwd packages/app capture:windows-desktop -- --issue 9958 --slug voice-windows-electrobun` |
+| `ios.sim-or-device.voice-roundtrip` | skip | ios | mobile-live-voice | set ELIZA_VOICE_IOS_READY=1 after installing a current iOS simulator/device build with voice assets | `bun run --cwd packages/app capture:ios-sim -- --issue 9958 --slug voice-ios` |
+| `ios.talkmode.native-bridge` | pending | ios | native-bridge-unit | macOS Swift Package test toolchain is available | `swift test --package-path plugins/plugin-native-talkmode/ios` |
+| `ios.swabble.native-bridge` | pending | ios | native-bridge-unit | macOS Swift Package test toolchain is available | `swift test --package-path plugins/plugin-native-swabble/ios` |
+| `android.device.voice-roundtrip` | skip | android | mobile-live-voice | set ELIZA_VOICE_ANDROID_READY=1 on an Android device runner with the current APK and voice assets installed | `bun run --cwd packages/app test:e2e:android:local` |
+| `android.talkmode.native-bridge` | skip | android | native-bridge-unit | packages/app/android is not generated; run packages/app cap:sync:android or build:android first | `./gradlew :elizaos-capacitor-talkmode:testDebugUnitTest` |
+| `android.swabble.native-bridge` | skip | android | native-bridge-unit | packages/app/android is not generated; run packages/app cap:sync:android or build:android first | `./gradlew :elizaos-capacitor-swabble:testDebugUnitTest` |
+| `wake.openwakeword.real-head` | skip | linux | wakeword-device-gap | ELIZA_OPENWAKEWORD_REAL_READY is not set for a real wake-word head run | `bun run --cwd plugins/plugin-local-inference voice:workbench --real` |
+| `stt.stage-b.evaluation` | skip | android | stt-evaluation | Stage-B STT battery/latency evaluation needs paired iOS+Android device runners and power telemetry | `bun packages/scripts/voice-matrix.mjs --stage-b-eval-placeholder` |
+
+## Summary
+
+- Pass: 0
+- Fail: 0
+- Pending: 5
+- Skip: 10
+
+Hardware-unavailable cells are explicit `skip` rows. They are not evidence of platform coverage.

--- a/.github/workflows/voice-live-e2e.yml
+++ b/.github/workflows/voice-live-e2e.yml
@@ -25,7 +25,28 @@ on:
     # 08:30 UTC daily — after app-live-e2e (07:00) settles, to avoid runner
     # contention on the shared GPU host.
     - cron: "30 8 * * *"
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      run_macos_electrobun:
+        description: "Attempt the macOS Electrobun live-voice matrix lane"
+        required: false
+        default: false
+        type: boolean
+      run_windows_electrobun:
+        description: "Attempt the Windows Electrobun live-voice matrix lane"
+        required: false
+        default: false
+        type: boolean
+      run_ios:
+        description: "Attempt the iOS simulator/device live-voice matrix lane"
+        required: false
+        default: false
+        type: boolean
+      run_android:
+        description: "Attempt the Android device/emulator live-voice matrix lane"
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: voice-live-e2e-${{ github.ref }}
@@ -40,6 +61,34 @@ env:
   BUN_VERSION: "canary"
   NODE_OPTIONS: "--experimental-sqlite"
 jobs:
+  voice-platform-matrix-index:
+    name: Canonical voice matrix index
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          show-progress: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Emit matrix probe report
+        run: |
+          set -euo pipefail
+          bun run voice:matrix -- --out "$RUNNER_TEMP/voice-platform-matrix"
+
+      - name: Upload matrix probe report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: voice-platform-matrix-index
+          path: ${{ runner.temp }}/voice-platform-matrix
+          if-no-files-found: error
+
   voice-roundtrip:
     name: Real fused ASR + optional mixed round-trip (self-hosted)
     runs-on: [self-hosted, Linux, X64, eliza]
@@ -338,4 +387,168 @@ jobs:
         with:
           name: voice-real-acoustic-matrix
           path: ${{ runner.temp }}/voice-real-matrix
+          if-no-files-found: error
+
+  voice-macos-electrobun-matrix:
+    name: macOS Electrobun live-voice matrix
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run_macos_electrobun) || vars.ELIZA_VOICE_MACOS_ELECTROBUN_READY == '1' }}
+    runs-on: macos-15
+    timeout-minutes: 90
+    env:
+      ELIZA_VOICE_MACOS_ELECTROBUN_READY: ${{ vars.ELIZA_VOICE_MACOS_ELECTROBUN_READY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: recursive
+          show-progress: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run macOS Electrobun matrix
+        run: |
+          set -euo pipefail
+          bun run voice:matrix -- --run --platform macos-electrobun --out "$RUNNER_TEMP/voice-macos-electrobun-matrix"
+
+      - name: Upload macOS Electrobun matrix
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: voice-macos-electrobun-matrix
+          path: ${{ runner.temp }}/voice-macos-electrobun-matrix
+          if-no-files-found: error
+
+  voice-windows-electrobun-matrix:
+    name: Windows Electrobun live-voice matrix
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run_windows_electrobun) || vars.ELIZA_VOICE_WINDOWS_ELECTROBUN_READY == '1' }}
+    runs-on: windows-2025
+    timeout-minutes: 90
+    env:
+      ELIZA_VOICE_WINDOWS_ELECTROBUN_READY: ${{ vars.ELIZA_VOICE_WINDOWS_ELECTROBUN_READY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: recursive
+          show-progress: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run Windows Electrobun matrix
+        shell: bash
+        run: |
+          set -euo pipefail
+          bun run voice:matrix -- --run --platform windows-electrobun --out "$RUNNER_TEMP/voice-windows-electrobun-matrix"
+
+      - name: Upload Windows Electrobun matrix
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: voice-windows-electrobun-matrix
+          path: ${{ runner.temp }}/voice-windows-electrobun-matrix
+          if-no-files-found: error
+
+  voice-ios-matrix:
+    name: iOS simulator/device live-voice matrix
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run_ios) || vars.ELIZA_VOICE_IOS_READY == '1' }}
+    runs-on: macos-15
+    timeout-minutes: 90
+    env:
+      ELIZA_VOICE_IOS_READY: ${{ vars.ELIZA_VOICE_IOS_READY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: recursive
+          show-progress: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run iOS matrix
+        run: |
+          set -euo pipefail
+          bun run voice:matrix -- --run --platform ios --out "$RUNNER_TEMP/voice-ios-matrix"
+
+      - name: Upload iOS matrix
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: voice-ios-matrix
+          path: ${{ runner.temp }}/voice-ios-matrix
+          if-no-files-found: error
+
+  voice-android-matrix:
+    name: Android live-voice + native bridge matrix
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run_android) || vars.ELIZA_VOICE_ANDROID_READY == '1' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    env:
+      ELIZA_VOICE_ANDROID_READY: ${{ vars.ELIZA_VOICE_ANDROID_READY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: recursive
+          show-progress: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Generate Android project for native unit tests
+        run: bun run --cwd packages/app cap:sync:android
+
+      - name: Run Android matrix
+        run: |
+          set -euo pipefail
+          bun run voice:matrix -- --run --platform android --out "$RUNNER_TEMP/voice-android-matrix"
+
+      - name: Upload Android matrix
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: voice-android-matrix
+          path: ${{ runner.temp }}/voice-android-matrix
           if-no-files-found: error

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "voice:interactive": "bun packages/app-core/scripts/voice-interactive.mjs",
     "voice:duet": "bun packages/app-core/scripts/voice-duet.mjs",
     "voice:create-profile": "bun packages/app-core/scripts/voice-create-profile.mjs",
+    "voice:matrix": "node packages/scripts/voice-matrix.mjs",
     "voice-models:publish-all": "node packages/scripts/voice-models-publish-all.mjs",
     "bench:voice-emotion-roundtrip": "node packages/scripts/run-python.mjs -m pytest packages/benchmarks/voice-emotion/tests/test_emotion_roundtrip.py -v --tb=short",
     "eliza1:cost-reconciliation": "bun run packages/scripts/cloud/eliza1/cost-reconciliation.ts",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -45,6 +45,7 @@
     "test:sim:auth:ios": "node ../../packages/app-core/scripts/mobile-auth-simulator-smoke.mjs --platform ios",
     "capture:ios-sim": "node scripts/capture-ios-sim.mjs",
     "capture:android-emu": "node scripts/capture-android-emu.mjs",
+    "capture:macos-desktop": "node scripts/capture-macos-desktop.mjs",
     "test:watch": "vitest --config vitest.config.ts",
     "plugin:build": "bun scripts/plugin-build.mjs",
     "build": "bun scripts/build.mjs",

--- a/packages/app/scripts/capture-macos-desktop.mjs
+++ b/packages/app/scripts/capture-macos-desktop.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+// macOS desktop evidence capture: screenshot + best-effort screen recording +
+// backend log for headed Electrobun/manual voice runs. Skips cleanly on non-macOS
+// hosts; records video only when ffmpeg can access the avfoundation screen input.
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync, statSync, writeFileSync } from "node:fs";
+import {
+  captureBackendLog,
+  evidenceBaseName,
+  evidencePath,
+  logFor,
+  mirrorToRecordings,
+  parseFlags,
+  skip,
+} from "./lib/issue-evidence.mjs";
+
+const PLATFORM = "macos-desktop";
+const log = logFor(PLATFORM);
+
+function hasCommand(name) {
+  return spawnSync("which", [name], { stdio: "ignore" }).status === 0;
+}
+
+function captureScreenshot(outPath) {
+  const res = spawnSync("screencapture", ["-x", outPath], { stdio: "ignore" });
+  return res.status === 0 && existsSync(outPath);
+}
+
+function recordVideo(outPath, durationSec) {
+  if (!hasCommand("ffmpeg")) return Promise.resolve(false);
+  return new Promise((resolve) => {
+    const proc = spawn(
+      "ffmpeg",
+      [
+        "-y",
+        "-f",
+        "avfoundation",
+        "-framerate",
+        "15",
+        "-capture_cursor",
+        "1",
+        "-i",
+        "Capture screen 0:none",
+        "-t",
+        String(durationSec),
+        "-pix_fmt",
+        "yuv420p",
+        outPath,
+      ],
+      { stdio: "ignore" },
+    );
+    proc.on("close", () => resolve(existsSync(outPath)));
+    proc.on("error", () => resolve(false));
+  });
+}
+
+async function main() {
+  if (process.platform !== "darwin") {
+    skip(
+      PLATFORM,
+      `macos-desktop capture requires a macOS host (host is ${process.platform})`,
+    );
+  }
+  if (!hasCommand("screencapture")) {
+    skip(PLATFORM, "screencapture not found");
+  }
+
+  const flags = parseFlags();
+  const base = evidenceBaseName({
+    issue: flags.issue,
+    slug: flags.slug,
+    platform: PLATFORM,
+  });
+  const durationSec = Number(flags.duration ?? 6);
+
+  const pngPath = evidencePath(base, "png");
+  if (captureScreenshot(pngPath)) {
+    log(`screenshot -> ${pngPath} (${statSync(pngPath).size} bytes)`);
+  } else {
+    log("screenshot failed (screen capture permission may be missing)");
+  }
+
+  const mp4Path = evidencePath(base, "mp4");
+  log(`recording ${durationSec}s -> ${mp4Path}`);
+  const recorded = await recordVideo(mp4Path, durationSec);
+  log(
+    recorded
+      ? `recording -> ${mp4Path} (${statSync(mp4Path).size} bytes)`
+      : "recording skipped or failed (ffmpeg avfoundation screen input unavailable)",
+  );
+
+  const infoPath = evidencePath(base, "log");
+  writeFileSync(
+    infoPath,
+    `[capture:${PLATFORM}] host=${process.platform}\n` +
+      `screencapture=${hasCommand("screencapture") ? "present" : "missing"}\n` +
+      `ffmpeg=${spawnSync("ffmpeg", ["-version"], { encoding: "utf8" }).stdout?.split("\n")[0] ?? "missing"}\n`,
+    "utf8",
+  );
+  log(`info log -> ${infoPath}`);
+  const backendLog = captureBackendLog(base);
+  if (backendLog) log(`backend log -> ${backendLog}`);
+
+  mirrorToRecordings(PLATFORM, pngPath);
+  if (recorded) mirrorToRecordings(PLATFORM, mp4Path);
+  log("done");
+}
+
+main().catch((error) => {
+  console.error(`[capture:${PLATFORM}] failed: ${error.message}`);
+  process.exit(1);
+});

--- a/packages/scripts/voice-matrix.mjs
+++ b/packages/scripts/voice-matrix.mjs
@@ -1,0 +1,754 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+);
+const ISSUE = "9958";
+
+const DIMENSIONS = {
+  platform: [
+    "web",
+    "linux",
+    "macos-electrobun",
+    "windows-electrobun",
+    "ios",
+    "android",
+  ],
+  transcriptionState: ["off", "on"],
+  chimeIn: ["should-respond", "should-not-respond"],
+  wakewordContext: [
+    "idle-wake",
+    "already-listening-wake-inert",
+    "mid-transcription-wake",
+  ],
+  noiseRejection: [
+    "quiet",
+    "noisy-reverberant",
+    "echo-self-voice",
+    "overlapping-speech",
+  ],
+  voices: ["owner", "enrolled-contact", "unknown", "multi-speaker"],
+};
+
+const CELLS = [
+  {
+    id: "web.fake-mic.roundtrip",
+    title: "Web fake-device mic capture -> ASR -> agent -> TTS",
+    platform: "web",
+    dimensions: {
+      transcriptionState: "off",
+      chimeIn: "should-respond",
+      wakewordContext: "idle-wake",
+      noiseRejection: "quiet",
+      voices: "owner",
+    },
+    class: "live-client-audio",
+    command: [
+      "bun",
+      "run",
+      "--cwd",
+      "packages/app",
+      "test:e2e",
+      "test/ui-smoke/voice-realaudio.spec.ts",
+    ],
+    env: { ELIZA_UI_SMOKE_SKIP_VIEW_BUILD: "1" },
+    evidence: ["packages/app/test-results", "e2e-recordings/app/test-results"],
+    probe: "web",
+  },
+  {
+    id: "web.fake-mic.transcript-roundtrip",
+    title:
+      "Web fake-device transcript capture -> record -> player -> chat attachment",
+    platform: "web",
+    dimensions: {
+      transcriptionState: "on",
+      chimeIn: "should-not-respond",
+      wakewordContext: "mid-transcription-wake",
+      noiseRejection: "quiet",
+      voices: "owner",
+    },
+    class: "transcripts-roundtrip",
+    command: [
+      "bun",
+      "run",
+      "--cwd",
+      "packages/app",
+      "test:e2e",
+      "test/ui-smoke/transcript-realaudio.spec.ts",
+    ],
+    env: { ELIZA_UI_SMOKE_SKIP_VIEW_BUILD: "1" },
+    evidence: ["packages/app/test-results", "e2e-recordings/app/test-results"],
+    probe: "web",
+  },
+  {
+    id: "web.workbench.respond-no-respond",
+    title: "Headful workbench should-respond / should-not-respond client cells",
+    platform: "web",
+    dimensions: {
+      transcriptionState: "off",
+      chimeIn: "should-not-respond",
+      wakewordContext: "idle-wake",
+      noiseRejection: "quiet",
+      voices: "multi-speaker",
+    },
+    class: "chime-in-matrix",
+    command: [
+      "bun",
+      "run",
+      "--cwd",
+      "packages/app",
+      "test:e2e",
+      "test/ui-smoke/voice-workbench-respond-no-respond.spec.ts",
+    ],
+    env: { ELIZA_UI_SMOKE_SKIP_VIEW_BUILD: "1" },
+    evidence: [
+      ".github/issue-evidence/8785-voice-headful",
+      "packages/app/test-results",
+    ],
+    probe: "web",
+  },
+  {
+    id: "linux.fused-acoustic.workbench-real",
+    title:
+      "Linux fused ASR/VAD/diarization/Kokoro workbench real-service matrix",
+    platform: "linux",
+    dimensions: {
+      transcriptionState: "off",
+      chimeIn: "should-respond",
+      wakewordContext: "idle-wake",
+      noiseRejection: "noisy-reverberant",
+      voices: "multi-speaker",
+    },
+    class: "real-acoustic-workbench",
+    command: [
+      "bun",
+      "run",
+      "--cwd",
+      "plugins/plugin-local-inference",
+      "voice:workbench",
+      "--real",
+    ],
+    evidence: [
+      "$VOICE_REAL_MATRIX_OUT/voice-workbench-real",
+      ".github/issue-evidence/9147-real-audio-matrix-m4max.md",
+    ],
+    probe: "linuxFused",
+  },
+  {
+    id: "linux.fused-acoustic.barge-in",
+    title: "Linux fused voice barge-in latency and cancellation harness",
+    platform: "linux",
+    dimensions: {
+      transcriptionState: "off",
+      chimeIn: "should-respond",
+      wakewordContext: "already-listening-wake-inert",
+      noiseRejection: "echo-self-voice",
+      voices: "owner",
+    },
+    class: "barge-in",
+    command: [
+      "bun",
+      "run",
+      "--cwd",
+      "plugins/plugin-local-inference",
+      "voice:bargein-bench",
+    ],
+    evidence: ["plugins/plugin-local-inference/native/verify"],
+    probe: "linuxFused",
+  },
+  {
+    id: "macos.electrobun.live-roundtrip",
+    title:
+      "macOS Electrobun live mic -> ASR -> agent -> Kokoro -> speaker loop",
+    platform: "macos-electrobun",
+    dimensions: {
+      transcriptionState: "off",
+      chimeIn: "should-respond",
+      wakewordContext: "idle-wake",
+      noiseRejection: "quiet",
+      voices: "owner",
+    },
+    class: "desktop-live-voice",
+    command: [
+      "bun",
+      "run",
+      "--cwd",
+      "packages/app",
+      "capture:macos-desktop",
+      "--",
+      "--issue",
+      ISSUE,
+      "--slug",
+      "voice-macos-electrobun",
+    ],
+    evidence: [
+      `.github/issue-evidence/${ISSUE}-voice-macos-electrobun-macos-desktop.*`,
+    ],
+    probe: "macosElectrobun",
+  },
+  {
+    id: "windows.electrobun.live-roundtrip",
+    title:
+      "Windows Electrobun live mic -> ASR -> agent -> Kokoro -> speaker loop",
+    platform: "windows-electrobun",
+    dimensions: {
+      transcriptionState: "off",
+      chimeIn: "should-respond",
+      wakewordContext: "idle-wake",
+      noiseRejection: "quiet",
+      voices: "owner",
+    },
+    class: "desktop-live-voice",
+    command: [
+      "bun",
+      "run",
+      "--cwd",
+      "packages/app",
+      "capture:windows-desktop",
+      "--",
+      "--issue",
+      ISSUE,
+      "--slug",
+      "voice-windows-electrobun",
+    ],
+    evidence: [
+      `.github/issue-evidence/${ISSUE}-voice-windows-electrobun-windows-desktop.*`,
+    ],
+    probe: "windowsElectrobun",
+  },
+  {
+    id: "ios.sim-or-device.voice-roundtrip",
+    title: "iOS simulator/device voice self-test and capture evidence",
+    platform: "ios",
+    dimensions: {
+      transcriptionState: "off",
+      chimeIn: "should-respond",
+      wakewordContext: "idle-wake",
+      noiseRejection: "quiet",
+      voices: "owner",
+    },
+    class: "mobile-live-voice",
+    command: [
+      "bun",
+      "run",
+      "--cwd",
+      "packages/app",
+      "capture:ios-sim",
+      "--",
+      "--issue",
+      ISSUE,
+      "--slug",
+      "voice-ios",
+    ],
+    evidence: [`.github/issue-evidence/${ISSUE}-voice-ios-ios-sim.*`],
+    probe: "ios",
+  },
+  {
+    id: "ios.talkmode.native-bridge",
+    title:
+      "TalkMode iOS transcript, permission, state, and barge-in bridge contracts",
+    platform: "ios",
+    dimensions: {
+      transcriptionState: "off",
+      chimeIn: "should-respond",
+      wakewordContext: "already-listening-wake-inert",
+      noiseRejection: "echo-self-voice",
+      voices: "owner",
+    },
+    class: "native-bridge-unit",
+    command: [
+      "swift",
+      "test",
+      "--package-path",
+      "plugins/plugin-native-talkmode/ios",
+    ],
+    evidence: ["plugins/plugin-native-talkmode/ios/Tests"],
+    probe: "swiftPackage",
+  },
+  {
+    id: "ios.swabble.native-bridge",
+    title: "Swabble iOS wake-firing -> JS bridge event contract",
+    platform: "ios",
+    dimensions: {
+      transcriptionState: "off",
+      chimeIn: "should-respond",
+      wakewordContext: "idle-wake",
+      noiseRejection: "quiet",
+      voices: "owner",
+    },
+    class: "native-bridge-unit",
+    command: [
+      "swift",
+      "test",
+      "--package-path",
+      "plugins/plugin-native-swabble/ios",
+    ],
+    evidence: ["plugins/plugin-native-swabble/ios/Tests"],
+    probe: "swiftPackage",
+  },
+  {
+    id: "android.device.voice-roundtrip",
+    title:
+      "Android device WebView real on-device STT -> agent -> TTS voice self-test",
+    platform: "android",
+    dimensions: {
+      transcriptionState: "off",
+      chimeIn: "should-respond",
+      wakewordContext: "idle-wake",
+      noiseRejection: "quiet",
+      voices: "owner",
+    },
+    class: "mobile-live-voice",
+    command: ["bun", "run", "--cwd", "packages/app", "test:e2e:android:local"],
+    evidence: ["packages/app/test-results", ".github/issue-evidence"],
+    probe: "android",
+  },
+  {
+    id: "android.talkmode.native-bridge",
+    title:
+      "TalkMode Android capture lifecycle, transcript, permission, and barge-in bridge contracts",
+    platform: "android",
+    dimensions: {
+      transcriptionState: "off",
+      chimeIn: "should-respond",
+      wakewordContext: "already-listening-wake-inert",
+      noiseRejection: "echo-self-voice",
+      voices: "owner",
+    },
+    class: "native-bridge-unit",
+    command: ["./gradlew", ":elizaos-capacitor-talkmode:testDebugUnitTest"],
+    cwd: "packages/app/android",
+    evidence: ["plugins/plugin-native-talkmode/android/src/test/java"],
+    probe: "androidGradle",
+  },
+  {
+    id: "android.swabble.native-bridge",
+    title: "Swabble Android wake-firing -> JS bridge event contract",
+    platform: "android",
+    dimensions: {
+      transcriptionState: "off",
+      chimeIn: "should-respond",
+      wakewordContext: "idle-wake",
+      noiseRejection: "quiet",
+      voices: "owner",
+    },
+    class: "native-bridge-unit",
+    command: ["./gradlew", ":elizaos-capacitor-swabble:testDebugUnitTest"],
+    cwd: "packages/app/android",
+    evidence: ["plugins/plugin-native-swabble/android/src/test/java"],
+    probe: "androidGradle",
+  },
+  {
+    id: "wake.openwakeword.real-head",
+    title: "Real openWakeWord head wake-context cells",
+    platform: "linux",
+    dimensions: {
+      transcriptionState: "on",
+      chimeIn: "should-not-respond",
+      wakewordContext: "mid-transcription-wake",
+      noiseRejection: "overlapping-speech",
+      voices: "multi-speaker",
+    },
+    class: "wakeword-device-gap",
+    command: [
+      "bun",
+      "run",
+      "--cwd",
+      "plugins/plugin-local-inference",
+      "voice:workbench",
+      "--real",
+    ],
+    evidence: ["$VOICE_REAL_MATRIX_OUT/voice-workbench-real"],
+    probe: "openWakeWord",
+  },
+  {
+    id: "stt.stage-b.evaluation",
+    title:
+      "Stage-B STT evaluation: iOS SFSpeechRecognizer vs Android SpeechRecognizer vs fused ASR",
+    platform: "android",
+    dimensions: {
+      transcriptionState: "on",
+      chimeIn: "should-respond",
+      wakewordContext: "idle-wake",
+      noiseRejection: "noisy-reverberant",
+      voices: "multi-speaker",
+    },
+    class: "stt-evaluation",
+    command: [
+      "bun",
+      "packages/scripts/voice-matrix.mjs",
+      "--stage-b-eval-placeholder",
+    ],
+    evidence: [".github/issue-evidence/9147-voice-asr-m4max.md"],
+    probe: "stageBStt",
+  },
+];
+
+function parseArgs(argv) {
+  const args = {
+    run: false,
+    out: path.join(".github", "issue-evidence", `${ISSUE}-voice-matrix`),
+    platforms: new Set(),
+    includeHeavy: false,
+    requireGreen: false,
+    stageBPlaceholder: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i];
+    if (token === "--run") args.run = true;
+    else if (token === "--include-heavy") args.includeHeavy = true;
+    else if (token === "--require-green") args.requireGreen = true;
+    else if (token === "--stage-b-eval-placeholder")
+      args.stageBPlaceholder = true;
+    else if (token === "--out") args.out = argv[++i] ?? args.out;
+    else if (token === "--platform") {
+      for (const p of String(argv[++i] ?? "").split(",")) {
+        if (p.trim()) args.platforms.add(p.trim());
+      }
+    }
+  }
+  return args;
+}
+
+function commandExists(name) {
+  const cmd = process.platform === "win32" ? "where" : "which";
+  return spawnSync(cmd, [name], { stdio: "ignore" }).status === 0;
+}
+
+function runCapture(command, cwd, extraEnv = {}) {
+  const startedAt = new Date().toISOString();
+  const result = spawnSync(command[0], command.slice(1), {
+    cwd: path.resolve(REPO_ROOT, cwd ?? "."),
+    encoding: "utf8",
+    env: { ...process.env, ...extraEnv },
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return {
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    exitCode: result.status ?? 1,
+    signal: result.signal,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+function probeCell(cell) {
+  if (!commandExists("bun")) {
+    return { available: false, reason: "bun is not available on PATH" };
+  }
+  switch (cell.probe) {
+    case "web":
+      return {
+        available: true,
+        reason: "Chromium fake-device mic lane is host-runnable",
+      };
+    case "linuxFused":
+      if (process.platform !== "linux")
+        return {
+          available: false,
+          reason: `requires Linux runner; current=${process.platform}`,
+        };
+      if (!process.env.ELIZA_INFERENCE_LIBRARY)
+        return {
+          available: false,
+          reason: "ELIZA_INFERENCE_LIBRARY is not set",
+        };
+      if (!process.env.ELIZA_ASR_BUNDLE)
+        return { available: false, reason: "ELIZA_ASR_BUNDLE is not set" };
+      return {
+        available: true,
+        reason: "Linux fused voice environment is provisioned",
+      };
+    case "openWakeWord":
+      if (!process.env.ELIZA_OPENWAKEWORD_REAL_READY) {
+        return {
+          available: false,
+          reason:
+            "ELIZA_OPENWAKEWORD_REAL_READY is not set for a real wake-word head run",
+        };
+      }
+      return { available: true, reason: "real openWakeWord head gate enabled" };
+    case "macosElectrobun":
+      if (process.platform !== "darwin")
+        return {
+          available: false,
+          reason: `requires macOS runner; current=${process.platform}`,
+        };
+      if (process.env.ELIZA_VOICE_MACOS_ELECTROBUN_READY !== "1") {
+        return {
+          available: false,
+          reason:
+            "set ELIZA_VOICE_MACOS_ELECTROBUN_READY=1 on a macOS Electrobun voice runner with loopback mic/audio capture",
+        };
+      }
+      return {
+        available: true,
+        reason: "macOS Electrobun voice runner enabled",
+      };
+    case "windowsElectrobun":
+      if (process.platform !== "win32")
+        return {
+          available: false,
+          reason: `requires Windows runner; current=${process.platform}`,
+        };
+      if (process.env.ELIZA_VOICE_WINDOWS_ELECTROBUN_READY !== "1") {
+        return {
+          available: false,
+          reason:
+            "set ELIZA_VOICE_WINDOWS_ELECTROBUN_READY=1 on a Windows Electrobun voice runner with loopback mic/audio capture",
+        };
+      }
+      return {
+        available: true,
+        reason: "Windows Electrobun voice runner enabled",
+      };
+    case "ios":
+      if (process.platform !== "darwin")
+        return {
+          available: false,
+          reason: `requires macOS host with xcrun; current=${process.platform}`,
+        };
+      if (!commandExists("xcrun"))
+        return { available: false, reason: "xcrun is not available" };
+      if (process.env.ELIZA_VOICE_IOS_READY !== "1") {
+        return {
+          available: false,
+          reason:
+            "set ELIZA_VOICE_IOS_READY=1 after installing a current iOS simulator/device build with voice assets",
+        };
+      }
+      return { available: true, reason: "iOS voice capture runner enabled" };
+    case "swiftPackage":
+      if (process.platform !== "darwin")
+        return {
+          available: false,
+          reason: `requires macOS Swift toolchain; current=${process.platform}`,
+        };
+      if (!commandExists("swift"))
+        return { available: false, reason: "swift is not available on PATH" };
+      return {
+        available: true,
+        reason: "macOS Swift Package test toolchain is available",
+      };
+    case "android":
+      if (!commandExists("adb"))
+        return { available: false, reason: "adb is not available" };
+      if (process.env.ELIZA_VOICE_ANDROID_READY !== "1") {
+        return {
+          available: false,
+          reason:
+            "set ELIZA_VOICE_ANDROID_READY=1 on an Android device runner with the current APK and voice assets installed",
+        };
+      }
+      return { available: true, reason: "Android voice runner enabled" };
+    case "androidGradle": {
+      const androidDir = path.join(REPO_ROOT, "packages", "app", "android");
+      if (!fs.existsSync(androidDir)) {
+        return {
+          available: false,
+          reason:
+            "packages/app/android is not generated; run packages/app cap:sync:android or build:android first",
+        };
+      }
+      const gradlew = path.join(
+        androidDir,
+        process.platform === "win32" ? "gradlew.bat" : "gradlew",
+      );
+      if (!fs.existsSync(gradlew))
+        return {
+          available: false,
+          reason: "generated Android project has no Gradle wrapper",
+        };
+      return {
+        available: true,
+        reason: "generated Android Gradle project exists",
+      };
+    }
+    case "stageBStt":
+      return {
+        available: false,
+        reason:
+          "Stage-B STT battery/latency evaluation needs paired iOS+Android device runners and power telemetry",
+      };
+    default:
+      return { available: false, reason: `unknown probe ${cell.probe}` };
+  }
+}
+
+function statusFor(args, probe, execution) {
+  if (!probe.available) return "skip";
+  if (!args.run) return "pending";
+  if (!execution) return "pending";
+  return execution.exitCode === 0 ? "pass" : "fail";
+}
+
+function renderMarkdown(report) {
+  const rows = report.cells.map((cell) => {
+    const cmd = cell.command
+      .map((part) => (part.includes(" ") ? JSON.stringify(part) : part))
+      .join(" ");
+    return `| \`${cell.id}\` | ${cell.status} | ${cell.platform} | ${cell.class} | ${cell.probe.reason.replaceAll("|", "\\|")} | \`${cmd.replaceAll("|", "\\|")}\` |`;
+  });
+  return [
+    "# Voice Live Matrix",
+    "",
+    `Generated: ${report.generatedAt}`,
+    `Host: ${report.host.platform} ${report.host.arch} (${report.host.hostname})`,
+    "",
+    "| Cell | Status | Platform | Class | Probe / Result | Command |",
+    "|---|---:|---|---|---|---|",
+    ...rows,
+    "",
+    "## Summary",
+    "",
+    `- Pass: ${report.summary.pass}`,
+    `- Fail: ${report.summary.fail}`,
+    `- Pending: ${report.summary.pending}`,
+    `- Skip: ${report.summary.skip}`,
+    "",
+    "Hardware-unavailable cells are explicit `skip` rows. They are not evidence of platform coverage.",
+    "",
+  ].join("\n");
+}
+
+function renderHtml(report) {
+  const esc = (s) =>
+    String(s)
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;");
+  const rows = report.cells
+    .map(
+      (cell) =>
+        `<tr class="${esc(cell.status)}"><td><code>${esc(cell.id)}</code><br>${esc(cell.title)}</td><td>${esc(cell.status)}</td><td>${esc(cell.platform)}</td><td>${esc(cell.class)}</td><td>${esc(
+          Object.entries(cell.dimensions)
+            .map(([k, v]) => `${k}=${v}`)
+            .join("\n"),
+        )}</td><td>${esc(cell.probe.reason)}</td><td><code>${esc(cell.command.join(" "))}</code></td><td>${esc(cell.evidence.join("\n"))}</td></tr>`,
+    )
+    .join("\n");
+  return `<!doctype html>
+<meta charset="utf-8">
+<title>Voice Live Matrix</title>
+<style>
+body{font-family:system-ui,-apple-system,Segoe UI,sans-serif;margin:24px;background:#fafafa;color:#151515}
+table{width:100%;border-collapse:collapse;background:white}
+th,td{border:1px solid #ddd;padding:8px;vertical-align:top;white-space:pre-wrap}
+th{background:#f1f1f1;text-align:left}
+.pass td:nth-child(2){color:#116b2d;font-weight:700}
+.fail td:nth-child(2){color:#9a1b1b;font-weight:700}
+.skip td:nth-child(2),.pending td:nth-child(2){color:#7a5b00;font-weight:700}
+code{font-size:12px}
+</style>
+<h1>Voice Live Matrix</h1>
+<p>Generated ${esc(report.generatedAt)} on ${esc(report.host.platform)} ${esc(report.host.arch)} (${esc(report.host.hostname)}).</p>
+<p>Pass ${report.summary.pass} · Fail ${report.summary.fail} · Pending ${report.summary.pending} · Skip ${report.summary.skip}</p>
+<table><thead><tr><th>Cell</th><th>Status</th><th>Platform</th><th>Class</th><th>Dimensions</th><th>Probe / Result</th><th>Command</th><th>Evidence</th></tr></thead><tbody>${rows}</tbody></table>`;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.stageBPlaceholder) {
+    console.error(
+      "Stage-B STT evaluation must run on paired iOS/Android device lanes with power telemetry.",
+    );
+    process.exit(2);
+  }
+
+  const selected = CELLS.filter(
+    (cell) =>
+      args.platforms.size === 0 ||
+      args.platforms.has(cell.platform) ||
+      args.platforms.has(cell.id),
+  );
+  const cells = [];
+  for (const cell of selected) {
+    const probe = probeCell(cell);
+    let execution = null;
+    if (args.run && probe.available) {
+      execution = runCapture(cell.command, cell.cwd, cell.env);
+      probe.reason =
+        execution.exitCode === 0
+          ? `command passed (${execution.finishedAt})`
+          : `command failed with exit ${execution.exitCode}${execution.signal ? ` signal ${execution.signal}` : ""}`;
+    }
+    cells.push({
+      ...cell,
+      cwd: cell.cwd ?? ".",
+      env: cell.env ?? {},
+      probe,
+      execution: execution
+        ? {
+            exitCode: execution.exitCode,
+            signal: execution.signal,
+            startedAt: execution.startedAt,
+            finishedAt: execution.finishedAt,
+            stdoutTail: execution.stdout.slice(-4000),
+            stderrTail: execution.stderr.slice(-4000),
+          }
+        : null,
+      status: statusFor(args, probe, execution),
+    });
+  }
+
+  const summary = { pass: 0, fail: 0, pending: 0, skip: 0 };
+  for (const cell of cells) summary[cell.status] += 1;
+
+  const report = {
+    schema: "eliza_voice_live_matrix_v1",
+    issue: Number(ISSUE),
+    generatedAt: new Date().toISOString(),
+    mode: args.run ? "run" : "probe",
+    dimensions: DIMENSIONS,
+    host: {
+      platform: process.platform,
+      arch: process.arch,
+      hostname: os.hostname(),
+      runnerOs: process.env.RUNNER_OS ?? null,
+      runnerArch: process.env.RUNNER_ARCH ?? null,
+    },
+    summary,
+    cells,
+  };
+
+  const outDir = path.resolve(REPO_ROOT, args.out);
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(outDir, "voice-matrix.json"),
+    JSON.stringify(report, null, 2),
+  );
+  fs.writeFileSync(
+    path.join(outDir, "voice-matrix.md"),
+    renderMarkdown(report),
+  );
+  fs.writeFileSync(path.join(outDir, "index.html"), renderHtml(report));
+  console.log(
+    `[voice:matrix] wrote ${path.relative(REPO_ROOT, outDir)}/voice-matrix.json`,
+  );
+  console.log(
+    `[voice:matrix] pass=${summary.pass} fail=${summary.fail} pending=${summary.pending} skip=${summary.skip}`,
+  );
+
+  if (
+    summary.fail > 0 ||
+    (args.requireGreen && (summary.pending > 0 || summary.skip > 0))
+  ) {
+    process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  console.error(
+    `[voice:matrix] ${error instanceof Error ? error.stack : String(error)}`,
+  );
+  process.exit(1);
+});

--- a/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
@@ -641,8 +641,41 @@ function installFakeCapture(): void {
 }
 
 /** Fire a final transcript through the most recent capture. */
-function fireFinalTranscript(text: string): void {
-  lastCaptureOpts?.onTranscript?.({ text, final: true, backend: "browser" });
+function fireFinalTranscript(
+  text: string,
+  extra: Partial<Parameters<NonNullable<CaptureOpts["onTranscript"]>>[0]> = {},
+): void {
+  lastCaptureOpts?.onTranscript?.({
+    text,
+    final: true,
+    backend: "browser",
+    ...extra,
+  });
+}
+
+function makeWav(nSamples: number, sampleRate = 16000): Uint8Array {
+  const dataBytes = nSamples * 2;
+  const buf = new ArrayBuffer(44 + dataBytes);
+  const view = new DataView(buf);
+  const ascii = (offset: number, value: string) => {
+    for (let i = 0; i < value.length; i++) {
+      view.setUint8(offset + i, value.charCodeAt(i));
+    }
+  };
+  ascii(0, "RIFF");
+  view.setUint32(4, 36 + dataBytes, true);
+  ascii(8, "WAVE");
+  ascii(12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, 1, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * 2, true);
+  view.setUint16(32, 2, true);
+  view.setUint16(34, 16, true);
+  ascii(36, "data");
+  view.setUint32(40, dataBytes, true);
+  return new Uint8Array(buf);
 }
 
 describe("useShellController — voice capture routing", () => {
@@ -1010,12 +1043,14 @@ describe("useShellController — transcription mode", () => {
     const sessions: Array<{
       segments: Array<{ text: string }>;
       startedAt: number;
+      audioWav: Uint8Array | null;
     }> = [];
     act(() =>
-      result.current.setTranscriptSessionSink((segments, startedAt) =>
+      result.current.setTranscriptSessionSink((segments, startedAt, audioWav) =>
         sessions.push({
           segments: segments as Array<{ text: string }>,
           startedAt,
+          audioWav,
         }),
       ),
     );
@@ -1046,6 +1081,43 @@ describe("useShellController — transcription mode", () => {
       "schedule a meeting with",
       "the design team tomorrow",
     ]);
+  });
+
+  it("waits for stop-drained transcript audio before finalizing the session", async () => {
+    const capturedWav = makeWav(1600);
+    createVoiceCaptureMock.mockImplementationOnce((opts: CaptureOpts) => {
+      lastCaptureOpts = opts;
+      const handle = {
+        start: vi.fn(() => Promise.resolve()),
+        stop: vi.fn(async () => {
+          await Promise.resolve();
+          opts.onTranscript?.({
+            text: "captured note",
+            final: true,
+            backend: "local-inference",
+            audioWav: capturedWav,
+          });
+          opts.onStateChange?.("stopped");
+        }),
+        dispose: vi.fn(),
+        getAnalyser: vi.fn(() => null),
+      };
+      captureHandles.push(handle);
+      return handle as never;
+    });
+
+    const { result } = renderHook(() => useShellController());
+    const sessions = sinkSessions(result);
+    await act(async () => {
+      await result.current.toggleTranscriptionMode();
+    });
+    await act(async () => {
+      await result.current.toggleTranscriptionMode();
+    });
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].segments.map((s) => s.text)).toEqual(["captured note"]);
+    expect(sessions[0].audioWav?.byteLength).toBeGreaterThan(1000);
   });
 
   it("an exit phrase finalizes the session and exits (exit utterance not recorded)", async () => {

--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -143,10 +143,10 @@ export interface ShellController {
   /** Toggle transcription mode on/off. Enabling opens a long-running capture
    *  that suppresses replies; disabling stops it and RESUMES the hands-free mic
    *  loop it paused (transcript off leaves the mic on — they are linked). */
-  toggleTranscriptionMode: () => void;
+  toggleTranscriptionMode: () => void | Promise<void>;
   /** End transcription AND turn the mic fully off (the mic button's action while
    *  transcribing — turning off the mic turns off transcript). */
-  stopTranscriptionAndMic: () => void;
+  stopTranscriptionAndMic: () => void | Promise<void>;
   /** Register where push-to-talk dictation drops its final transcript (the
    *  overlay wires this to its composer draft). Pass null to clear. */
   setDictationSink: (sink: ((text: string) => void) | null) => void;
@@ -433,7 +433,9 @@ export function useShellController(): ShellController {
   // Forward handle to `toggleTranscriptionMode` (defined far below) so the
   // converse capture loop can flip INTO transcription on a spoken "start
   // transcription" without a definition-order/closure problem.
-  const toggleTranscriptionModeRef = React.useRef<() => void>(() => {});
+  const toggleTranscriptionModeRef = React.useRef<() => void | Promise<void>>(
+    () => {},
+  );
   // The continuous-chat-mode persisted before hands-free engaged, restored when
   // the user taps the mic off so a deliberate ChatView "vad-gated" choice isn't
   // clobbered to "off". Defaults to "off" — tapping the mic off means voice off.
@@ -624,7 +626,7 @@ export function useShellController(): ShellController {
     [sendChatText],
   );
 
-  const stopCapture = React.useCallback(() => {
+  const stopCaptureAndDrain = React.useCallback(async () => {
     const handle = captureRef.current;
     captureRef.current = null;
     // Mark this as a user-initiated stop so the clean-auto-stop carryover does
@@ -634,13 +636,22 @@ export function useShellController(): ShellController {
     turnCarryoverRef.current = "";
     turnAggregatorRef.current?.reset();
     if (handle) {
-      void handle.stop().catch(() => {});
-      handle.dispose();
+      try {
+        await handle.stop();
+      } catch {
+        /* stop is best-effort from UI controls */
+      } finally {
+        handle.dispose();
+      }
     }
     setAnalyser(null);
     setRecording(false);
     setTranscript("");
   }, []);
+
+  const stopCapture = React.useCallback(() => {
+    void stopCaptureAndDrain();
+  }, [stopCaptureAndDrain]);
 
   const startCapture = React.useCallback(
     (intent?: CaptureIntent) => {
@@ -867,7 +878,7 @@ export function useShellController(): ShellController {
     else startCapture();
   }, [recording, startCapture, stopCapture]);
 
-  React.useEffect(() => stopCapture, [stopCapture]);
+  React.useEffect(() => () => stopCapture(), [stopCapture]);
 
   // Restore a persisted "always-on" continuous-chat mode on boot: engage the
   // hands-free re-listen LOOP (not a one-shot capture) so always-on survives a
@@ -1035,11 +1046,11 @@ export function useShellController(): ShellController {
   // silently. Turning it off (this toggle, the mic button, or a spoken exit
   // phrase) finalizes the session, which drops the transcript into the composer
   // as an attachment the user sends with their next message.
-  const toggleTranscriptionMode = React.useCallback(() => {
+  const toggleTranscriptionMode = React.useCallback(async () => {
     if (transcriptionModeRef.current) {
       setTranscriptionMode(false);
       transcriptionModeRef.current = false;
-      if (captureRef.current) stopCapture();
+      if (captureRef.current) await stopCaptureAndDrain();
       // Close the recording session → Transcript record + chat link-widget.
       finalizeTranscriptSession();
       // Turning transcript OFF must leave the mic ON: resume the hands-free
@@ -1071,6 +1082,7 @@ export function useShellController(): ShellController {
   }, [
     startCapture,
     stopCapture,
+    stopCaptureAndDrain,
     voiceOutput,
     beginTranscriptSession,
     finalizeTranscriptSession,
@@ -1079,10 +1091,10 @@ export function useShellController(): ShellController {
   // The mic button while transcribing: turn the mic (and thus transcript) fully
   // OFF. Distinct from `toggleTranscriptionMode`'s off-path, which leaves the
   // mic listening — "turning off the mic turns off transcript" (mic = parent).
-  const stopTranscriptionAndMic = React.useCallback(() => {
+  const stopTranscriptionAndMic = React.useCallback(async () => {
     setTranscriptionMode(false);
     transcriptionModeRef.current = false;
-    if (captureRef.current) stopCapture();
+    if (captureRef.current) await stopCaptureAndDrain();
     finalizeTranscriptSession();
     resumeHandsFreeAfterTranscriptRef.current = false;
     // Turn the mic fully off like a hands-free tap-off: persist the prior
@@ -1090,7 +1102,7 @@ export function useShellController(): ShellController {
     saveContinuousChatMode(priorContinuousModeRef.current);
     setHandsFree(false);
     handsFreeRef.current = false;
-  }, [stopCapture, finalizeTranscriptSession]);
+  }, [stopCaptureAndDrain, finalizeTranscriptSession]);
   // Keep the forward ref current so the converse capture loop (defined above)
   // can flip into transcription on a spoken start phrase.
   toggleTranscriptionModeRef.current = toggleTranscriptionMode;

--- a/packages/ui/src/voice/VOICE_LIVE_MATRIX.md
+++ b/packages/ui/src/voice/VOICE_LIVE_MATRIX.md
@@ -1,0 +1,94 @@
+# Voice Live Matrix
+
+Issue #9958 defines the live-voice verification product surface. This document
+is the canonical matrix and `bun run voice:matrix` is the canonical artifact
+producer. The matrix is evidence-oriented: every cell is either `pass`, `fail`,
+`pending`, or `skip` with a hardware-unavailable reason. A skipped cell is never
+platform coverage.
+
+## Dimensions
+
+The full product is:
+
+| Dimension | Values |
+| --- | --- |
+| platform | `web`, `linux`, `macos-electrobun`, `windows-electrobun`, `ios`, `android` |
+| transcription-state | `off`, `on` |
+| chime-in | `should-respond`, `should-not-respond` |
+| wakeword-context | `idle-wake`, `already-listening-wake-inert`, `mid-transcription-wake` |
+| noise/rejection | `quiet`, `noisy-reverberant`, `echo-self-voice`, `overlapping-speech` |
+| voices | `owner`, `enrolled-contact`, `unknown`, `multi-speaker` |
+
+The matrix runner records these dimensions per cell rather than expanding every
+Cartesian-product row into a separate CI job. The existing Voice Workbench
+scenarios cover the multi-row acoustic classes; platform live cells prove the
+device boundary.
+
+## Canonical Command
+
+```bash
+bun run voice:matrix
+```
+
+By default the command probes the current host and writes:
+
+```text
+.github/issue-evidence/9958-voice-matrix/
+  voice-matrix.json
+  voice-matrix.md
+  index.html
+```
+
+Use `--run` to execute available cell commands:
+
+```bash
+bun run voice:matrix -- --run --platform web
+bun run voice:matrix -- --run --platform android
+bun run voice:matrix -- --run --platform linux
+```
+
+Use `--require-green` only on a lane where every selected hardware dependency is
+known to be present; it turns `pending` or `skip` into a failing exit.
+
+## Cells
+
+| Cell | Existing runner | Evidence |
+| --- | --- | --- |
+| `web.fake-mic.roundtrip` | `packages/app` Playwright `voice-realaudio.spec.ts` with Chromium fake audio capture | real browser getUserMedia/WAV encode/client ASR post, screenshots/video when recorded |
+| `web.fake-mic.transcript-roundtrip` | `packages/app` Playwright `transcript-realaudio.spec.ts` | capture -> transcript record -> player -> chat attachment |
+| `web.workbench.respond-no-respond` | headful workbench Playwright scenario | chime-in should-respond/should-not-respond UI behavior |
+| `linux.fused-acoustic.workbench-real` | `plugins/plugin-local-inference voice:workbench --real` | fused ASR, diarization, VAD, Kokoro TTS, noisy and multi-speaker workbench report |
+| `linux.fused-acoustic.barge-in` | `plugins/plugin-local-inference voice:bargein-bench` | cancellation/latency harness for barge-in |
+| `macos.electrobun.live-roundtrip` | headed Electrobun runner plus `capture:macos-desktop` | screen/video/log artifact when `ELIZA_VOICE_MACOS_ELECTROBUN_READY=1` |
+| `windows.electrobun.live-roundtrip` | headed Electrobun runner plus `capture:windows-desktop` | screen/video/log artifact when `ELIZA_VOICE_WINDOWS_ELECTROBUN_READY=1` |
+| `ios.sim-or-device.voice-roundtrip` | installed iOS simulator/device build plus `capture:ios-sim` | simulator screenshot/video/log when `ELIZA_VOICE_IOS_READY=1` |
+| `ios.talkmode.native-bridge` | `swift test --package-path plugins/plugin-native-talkmode/ios` | TalkMode transcript/permission/state/barge-in bridge tests |
+| `ios.swabble.native-bridge` | `swift test --package-path plugins/plugin-native-swabble/ios` | Swabble wake-firing -> JS bridge event tests |
+| `android.device.voice-roundtrip` | `packages/app test:e2e:android:local` | real WebView on-device STT -> agent -> TTS self-test |
+| `android.talkmode.native-bridge` | generated Android Gradle `:elizaos-capacitor-talkmode:testDebugUnitTest` | TalkMode capture lifecycle/transcript/permission/barge-in bridge tests |
+| `android.swabble.native-bridge` | generated Android Gradle `:elizaos-capacitor-swabble:testDebugUnitTest` | Swabble wake-firing -> JS bridge event tests |
+| `wake.openwakeword.real-head` | gated real openWakeWord head run | idle wake, always-on inert wake, and mid-transcription non-corruption evidence |
+| `stt.stage-b.evaluation` | paired iOS/Android device benchmark | iOS `SFSpeechRecognizer`, Android `SpeechRecognizer`, and fused ASR latency/battery/accept matrix |
+
+## Hardware Gates
+
+The runner uses environment gates for cells that cannot be proven from a generic
+developer laptop:
+
+| Gate | Meaning |
+| --- | --- |
+| `ELIZA_VOICE_MACOS_ELECTROBUN_READY=1` | current macOS runner has a built Electrobun app, loopback mic/audio capture, and permission grants |
+| `ELIZA_VOICE_WINDOWS_ELECTROBUN_READY=1` | current Windows runner has a built Electrobun app, loopback mic/audio capture, and permission grants |
+| `ELIZA_VOICE_IOS_READY=1` | current macOS runner has a freshly installed iOS simulator/device build with voice assets |
+| `ELIZA_VOICE_ANDROID_READY=1` | current runner has an attached Android device/emulator, current APK, voice assets, and granted mic permissions |
+| `ELIZA_OPENWAKEWORD_REAL_READY=1` | current runner has the real openWakeWord head and audio fixture/device path |
+| `ELIZA_INFERENCE_LIBRARY` + `ELIZA_ASR_BUNDLE` | Linux fused real-service runner has the provisioned local-inference bundle |
+
+The matrix report records these gates in the `probe.reason` field. This keeps
+Linux green separate from missing macOS/iOS/Android evidence.
+
+## TTS Policy
+
+Kokoro TTS stays unchanged. This matrix verifies live voice breadth and Stage-B
+STT choices; it does not replace the provider defaults in
+`voice-provider-defaults.ts`.

--- a/packages/ui/src/voice/VOICE_UX.md
+++ b/packages/ui/src/voice/VOICE_UX.md
@@ -162,6 +162,11 @@ on what counts as "the wake word".
 What runs the always-on Stage-A detector on each target, and therefore which path
 the controller selects:
 
+The live verification surface for this table is
+[`VOICE_LIVE_MATRIX.md`](./VOICE_LIVE_MATRIX.md). `bun run voice:matrix` emits
+the reviewer-facing JSON/Markdown/HTML report and records skipped hardware cells
+explicitly instead of treating Linux-only evidence as cross-platform coverage.
+
 | Platform | Stage-A detector | Stage-B ASR confirm | Selected path | Always-on battery |
 |---|---|---|---|---|
 | **macOS** (desktop) | fused openWakeWord (CPU/Metal) | fused transcription / Whisper.cpp | head fast-path → two-stage | ✅ ~0.23 ms/frame |

--- a/plugins/plugin-native-swabble/android/src/main/java/ai/eliza/plugins/swabble/SwabblePlugin.kt
+++ b/plugins/plugin-native-swabble/android/src/main/java/ai/eliza/plugins/swabble/SwabblePlugin.kt
@@ -21,8 +21,6 @@ import com.getcapacitor.annotation.Permission
 import com.getcapacitor.annotation.PermissionCallback
 import kotlinx.coroutines.*
 import java.util.Locale
-import kotlin.math.abs
-import kotlin.math.min
 
 /**
  * Swabble (Voice Wake) Plugin for Capacitor Android
@@ -120,12 +118,6 @@ class SwabblePlugin : Plugin() {
     ) {
         val end: Double get() = start + duration
     }
-
-    data class WakeWordMatch(
-        val wakeWord: String,
-        val command: String,
-        val postGap: Double
-    )
 
     // ── Plugin methods ──────────────────────────────────────────────────
 
@@ -499,7 +491,21 @@ class SwabblePlugin : Plugin() {
         // Check for wake word — use all recognition alternatives for robustness
         val cfg = config ?: return
         for (alternative in matches) {
-            val match = matchWakeWord(alternative, segments, cfg)
+            val match = SwabbleWakeBridgeContract.matchWakeWord(
+                transcript = alternative,
+                segments = segments.map {
+                    SwabbleWakeBridgeContract.Segment(
+                        text = it.text,
+                        start = it.start,
+                        duration = it.duration
+                    )
+                },
+                config = SwabbleWakeBridgeContract.Config(
+                    triggers = cfg.triggers,
+                    minPostTriggerGap = cfg.minPostTriggerGap,
+                    minCommandLength = cfg.minCommandLength
+                )
+            )
             if (match != null) {
                 // Dedup: skip if we already dispatched this exact command
                 if (match.command == lastDispatchedCommand) continue
@@ -507,13 +513,11 @@ class SwabblePlugin : Plugin() {
 
                 transitionState(SwabbleState.TRIGGERED)
 
-                notifyListeners("wakeWord", JSObject().apply {
-                    put("wakeWord", match.wakeWord)
-                    put("command", match.command)
-                    put("transcript", alternative)
-                    put("postGap", match.postGap)
-                    put("confidence", confidence?.firstOrNull()?.toDouble() ?: 0.0)
-                })
+                notifyListeners("wakeWord", SwabbleWakeBridgeContract.wakeWordPayload(
+                    match = match,
+                    transcript = alternative,
+                    confidence = confidence?.firstOrNull()?.toDouble() ?: 0.0
+                ).toJSObject())
 
                 // Move to capturing state briefly, then back to listening
                 scope.launch {
@@ -529,142 +533,6 @@ class SwabblePlugin : Plugin() {
         }
 
         lastTranscript = transcript
-    }
-
-    // ── Wake word matching (regex + Levenshtein fuzzy) ──────────────────
-
-    /**
-     * Two-pass wake word matching:
-     * 1. Exact regex match (ported from classic VoiceWakeCommandExtractor)
-     * 2. Fuzzy match using Levenshtein distance for misheard trigger words
-     */
-    private fun matchWakeWord(
-        transcript: String,
-        segments: List<SpeechSegment>,
-        config: SwabbleConfig
-    ): WakeWordMatch? {
-        // Pass 1: exact regex match (from classic VoiceWakeCommandExtractor)
-        for (trigger in config.triggers) {
-            val command = extractCommandExact(transcript, trigger)
-            if (command != null && command.length >= config.minCommandLength) {
-                return WakeWordMatch(
-                    wakeWord = trigger,
-                    command = command,
-                    postGap = config.minPostTriggerGap
-                )
-            }
-        }
-
-        // Pass 2: fuzzy match using Levenshtein distance
-        val words = transcript.split("\\s+".toRegex()).filter { it.isNotEmpty() }
-        for ((wordIndex, _) in words.withIndex()) {
-            for (trigger in config.triggers) {
-                val triggerWords = trigger.split("\\s+".toRegex()).filter { it.isNotEmpty() }
-                val triggerLen = triggerWords.size
-
-                // Check if enough words remain to form the trigger
-                if (wordIndex + triggerLen > words.size) continue
-
-                val candidate = words.subList(wordIndex, wordIndex + triggerLen).joinToString(" ")
-                val distance = levenshteinDistance(candidate.lowercase(), trigger.lowercase())
-                val maxLen = maxOf(candidate.length, trigger.length)
-
-                // Accept if within 30% edit distance (fuzzy threshold)
-                if (maxLen > 0 && distance.toDouble() / maxLen <= 0.3) {
-                    val commandStart = wordIndex + triggerLen
-                    if (commandStart >= words.size) continue
-
-                    val command = words.subList(commandStart, words.size).joinToString(" ").trim()
-                    if (command.length < config.minCommandLength) continue
-
-                    // Estimate post-trigger gap from segments
-                    val gap = if (commandStart < segments.size && wordIndex + triggerLen - 1 < segments.size) {
-                        val triggerEnd = segments[wordIndex + triggerLen - 1].end
-                        val commandBegin = segments[commandStart].start
-                        commandBegin - triggerEnd
-                    } else {
-                        config.minPostTriggerGap
-                    }
-
-                    return WakeWordMatch(
-                        wakeWord = trigger,
-                        command = cleanCommand(command),
-                        postGap = gap
-                    )
-                }
-            }
-        }
-
-        return null
-    }
-
-    /**
-     * Exact command extraction using regex — ported from classic
-     * VoiceWakeCommandExtractor.extractCommand()
-     */
-    private fun extractCommandExact(text: String, trigger: String): String? {
-        val raw = text.trim()
-        if (raw.isEmpty()) return null
-
-        val normalizedTrigger = trigger.trim().lowercase()
-        if (normalizedTrigger.isEmpty()) return null
-
-        val escaped = Regex.escape(normalizedTrigger)
-        val regex = Regex("(?i)(?:^|\\s)($escaped)\\b[\\s\\p{Punct}]*([\\s\\S]+)$")
-        val match = regex.find(raw) ?: return null
-        val extracted = match.groupValues.getOrNull(2)?.trim() ?: return null
-        if (extracted.isEmpty()) return null
-
-        return cleanCommand(extracted)
-    }
-
-    /** Strip leading punctuation/whitespace from a command string. */
-    private fun cleanCommand(text: String): String {
-        return text.trimStart { it.isWhitespace() || it.isPunctuation() }.trim()
-    }
-
-    private fun Char.isPunctuation(): Boolean {
-        return when (Character.getType(this)) {
-            Character.CONNECTOR_PUNCTUATION.toInt(),
-            Character.DASH_PUNCTUATION.toInt(),
-            Character.START_PUNCTUATION.toInt(),
-            Character.END_PUNCTUATION.toInt(),
-            Character.INITIAL_QUOTE_PUNCTUATION.toInt(),
-            Character.FINAL_QUOTE_PUNCTUATION.toInt(),
-            Character.OTHER_PUNCTUATION.toInt() -> true
-            else -> false
-        }
-    }
-
-    /**
-     * Levenshtein edit distance between two strings.
-     * Used for fuzzy trigger word matching (handles speech recognition errors).
-     */
-    private fun levenshteinDistance(a: String, b: String): Int {
-        val m = a.length
-        val n = b.length
-        if (m == 0) return n
-        if (n == 0) return m
-
-        // Single-row DP to save memory
-        var prev = IntArray(n + 1) { it }
-        var curr = IntArray(n + 1)
-
-        for (i in 1..m) {
-            curr[0] = i
-            for (j in 1..n) {
-                val cost = if (a[i - 1] == b[j - 1]) 0 else 1
-                curr[j] = minOf(
-                    prev[j] + 1,       // deletion
-                    curr[j - 1] + 1,   // insertion
-                    prev[j - 1] + cost  // substitution
-                )
-            }
-            val tmp = prev
-            prev = curr
-            curr = tmp
-        }
-        return prev[n]
     }
 
     // ── State machine ───────────────────────────────────────────────────

--- a/plugins/plugin-native-swabble/android/src/main/java/ai/eliza/plugins/swabble/SwabbleWakeBridgeContract.kt
+++ b/plugins/plugin-native-swabble/android/src/main/java/ai/eliza/plugins/swabble/SwabbleWakeBridgeContract.kt
@@ -1,0 +1,157 @@
+package ai.eliza.plugins.swabble
+
+import com.getcapacitor.JSObject
+
+internal object SwabbleWakeBridgeContract {
+    data class Config(
+        val triggers: List<String>,
+        val minPostTriggerGap: Double,
+        val minCommandLength: Int
+    )
+
+    data class Segment(
+        val text: String,
+        val start: Double,
+        val duration: Double
+    ) {
+        val end: Double get() = start + duration
+    }
+
+    data class WakeWordMatch(
+        val wakeWord: String,
+        val command: String,
+        val postGap: Double
+    )
+
+    fun matchWakeWord(
+        transcript: String,
+        segments: List<Segment>,
+        config: Config
+    ): WakeWordMatch? {
+        for (trigger in config.triggers) {
+            val command = extractCommandExact(transcript, trigger)
+            if (command != null && command.length >= config.minCommandLength) {
+                return WakeWordMatch(
+                    wakeWord = trigger,
+                    command = command,
+                    postGap = config.minPostTriggerGap
+                )
+            }
+        }
+
+        val words = transcript.split("\\s+".toRegex()).filter { it.isNotEmpty() }
+        for ((wordIndex, _) in words.withIndex()) {
+            for (trigger in config.triggers) {
+                val triggerWords = trigger.split("\\s+".toRegex()).filter { it.isNotEmpty() }
+                val triggerLen = triggerWords.size
+                if (wordIndex + triggerLen > words.size) continue
+
+                val candidate = words.subList(wordIndex, wordIndex + triggerLen).joinToString(" ")
+                val distance = levenshteinDistance(candidate.lowercase(), trigger.lowercase())
+                val maxLen = maxOf(candidate.length, trigger.length)
+                if (maxLen == 0 || distance.toDouble() / maxLen > 0.3) continue
+
+                val commandStart = wordIndex + triggerLen
+                if (commandStart >= words.size) continue
+
+                val command = words.subList(commandStart, words.size).joinToString(" ").trim()
+                if (command.length < config.minCommandLength) continue
+
+                val gap = if (commandStart < segments.size && wordIndex + triggerLen - 1 < segments.size) {
+                    val triggerEnd = segments[wordIndex + triggerLen - 1].end
+                    val commandBegin = segments[commandStart].start
+                    commandBegin - triggerEnd
+                } else {
+                    config.minPostTriggerGap
+                }
+
+                return WakeWordMatch(
+                    wakeWord = trigger,
+                    command = cleanCommand(command),
+                    postGap = gap
+                )
+            }
+        }
+
+        return null
+    }
+
+    fun wakeWordPayload(
+        match: WakeWordMatch,
+        transcript: String,
+        confidence: Double
+    ): Map<String, Any?> = mapOf(
+        "wakeWord" to match.wakeWord,
+        "command" to match.command,
+        "transcript" to transcript,
+        "postGap" to match.postGap,
+        "confidence" to confidence
+    )
+
+    private fun extractCommandExact(text: String, trigger: String): String? {
+        val raw = text.trim()
+        if (raw.isEmpty()) return null
+
+        val normalizedTrigger = trigger.trim().lowercase()
+        if (normalizedTrigger.isEmpty()) return null
+
+        val escaped = Regex.escape(normalizedTrigger)
+        val regex = Regex("(?i)(?:^|\\s)($escaped)\\b[\\s\\p{Punct}]*([\\s\\S]+)$")
+        val match = regex.find(raw) ?: return null
+        val extracted = match.groupValues.getOrNull(2)?.trim() ?: return null
+        if (extracted.isEmpty()) return null
+
+        return cleanCommand(extracted)
+    }
+
+    private fun cleanCommand(text: String): String {
+        return text.trimStart { it.isWhitespace() || it.isPunctuation() }.trim()
+    }
+
+    private fun Char.isPunctuation(): Boolean {
+        return when (Character.getType(this)) {
+            Character.CONNECTOR_PUNCTUATION.toInt(),
+            Character.DASH_PUNCTUATION.toInt(),
+            Character.START_PUNCTUATION.toInt(),
+            Character.END_PUNCTUATION.toInt(),
+            Character.INITIAL_QUOTE_PUNCTUATION.toInt(),
+            Character.FINAL_QUOTE_PUNCTUATION.toInt(),
+            Character.OTHER_PUNCTUATION.toInt() -> true
+            else -> false
+        }
+    }
+
+    private fun levenshteinDistance(a: String, b: String): Int {
+        val m = a.length
+        val n = b.length
+        if (m == 0) return n
+        if (n == 0) return m
+
+        var prev = IntArray(n + 1) { it }
+        var curr = IntArray(n + 1)
+
+        for (i in 1..m) {
+            curr[0] = i
+            for (j in 1..n) {
+                val cost = if (a[i - 1] == b[j - 1]) 0 else 1
+                curr[j] = minOf(
+                    prev[j] + 1,
+                    curr[j - 1] + 1,
+                    prev[j - 1] + cost
+                )
+            }
+            val tmp = prev
+            prev = curr
+            curr = tmp
+        }
+        return prev[n]
+    }
+}
+
+internal fun Map<String, Any?>.toJSObject(): JSObject {
+    val obj = JSObject()
+    for ((key, value) in this) {
+        obj.put(key, value)
+    }
+    return obj
+}

--- a/plugins/plugin-native-swabble/android/src/test/java/ai/eliza/plugins/swabble/SwabbleWakeBridgeContractTest.kt
+++ b/plugins/plugin-native-swabble/android/src/test/java/ai/eliza/plugins/swabble/SwabbleWakeBridgeContractTest.kt
@@ -1,0 +1,68 @@
+package ai.eliza.plugins.swabble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SwabbleWakeBridgeContractTest {
+    private val config = SwabbleWakeBridgeContract.Config(
+        triggers = listOf("eliza"),
+        minPostTriggerGap = 0.45,
+        minCommandLength = 3
+    )
+
+    @Test
+    fun `exact wake phrase extracts command and builds bridge event payload`() {
+        val match = SwabbleWakeBridgeContract.matchWakeWord(
+            transcript = "hey eliza, turn on the lights",
+            segments = emptyList(),
+            config = config
+        )
+
+        assertNotNull(match)
+        assertEquals("eliza", match!!.wakeWord)
+        assertEquals("turn on the lights", match.command)
+        assertEquals(0.45, match.postGap, 0.001)
+
+        val payload = SwabbleWakeBridgeContract.wakeWordPayload(
+            match = match,
+            transcript = "hey eliza, turn on the lights",
+            confidence = 0.92
+        )
+        assertEquals("eliza", payload["wakeWord"])
+        assertEquals("turn on the lights", payload["command"])
+        assertEquals("hey eliza, turn on the lights", payload["transcript"])
+        assertEquals(0.92, payload["confidence"])
+    }
+
+    @Test
+    fun `fuzzy wake phrase still fires when speech recognizer mishears trigger`() {
+        val match = SwabbleWakeBridgeContract.matchWakeWord(
+            transcript = "hey aliza start the timer",
+            segments = listOf(
+                SwabbleWakeBridgeContract.Segment("hey", 0.0, 0.2),
+                SwabbleWakeBridgeContract.Segment("aliza", 0.3, 0.3),
+                SwabbleWakeBridgeContract.Segment("start", 1.0, 0.3),
+                SwabbleWakeBridgeContract.Segment("the", 1.4, 0.2),
+                SwabbleWakeBridgeContract.Segment("timer", 1.7, 0.3)
+            ),
+            config = config
+        )
+
+        assertNotNull(match)
+        assertEquals("start the timer", match!!.command)
+        assertEquals(0.4, match.postGap, 0.001)
+    }
+
+    @Test
+    fun `command shorter than minimum length does not dispatch wake event`() {
+        val match = SwabbleWakeBridgeContract.matchWakeWord(
+            transcript = "eliza go",
+            segments = emptyList(),
+            config = config.copy(minCommandLength = 3)
+        )
+
+        assertNull(match)
+    }
+}

--- a/plugins/plugin-native-swabble/ios/Package.swift
+++ b/plugins/plugin-native-swabble/ios/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "ElizaosCapacitorSwabbleIOSContracts",
+    platforms: [
+        .iOS(.v15),
+        .macOS(.v13),
+    ],
+    targets: [
+        .target(
+            name: "SwabbleIOSContracts",
+            path: "Sources/SwabbleBridgeContract"
+        ),
+        .testTarget(
+            name: "SwabbleBridgeContractTests",
+            dependencies: ["SwabbleIOSContracts"],
+            path: "Tests/SwabbleBridgeContractTests"
+        ),
+    ]
+)

--- a/plugins/plugin-native-swabble/ios/Sources/SwabbleBridgeContract/SwabbleBridgeContract.swift
+++ b/plugins/plugin-native-swabble/ios/Sources/SwabbleBridgeContract/SwabbleBridgeContract.swift
@@ -1,0 +1,137 @@
+import Foundation
+
+struct SwabbleBridgeMatch {
+    let triggerWord: String
+    let triggerEndTime: TimeInterval
+    let postGap: TimeInterval
+    let command: String
+}
+
+enum SwabbleWakeBridgeContract {
+    static func wakeWordPayload(
+        match: SwabbleBridgeMatch,
+        transcript: String,
+        confidence: Double
+    ) -> [String: Any] {
+        [
+            "wakeWord": match.triggerWord,
+            "command": match.command,
+            "transcript": transcript,
+            "postGap": match.postGap,
+            "confidence": confidence,
+        ]
+    }
+
+    static func triggerOnlyPayload(trigger: String, transcript: String) -> [String: Any] {
+        [
+            "wakeWord": trigger,
+            "command": "",
+            "transcript": transcript,
+            "postGap": 0.0,
+            "confidence": 0.0,
+        ]
+    }
+
+    static func textOnlyCommand(
+        transcript: String,
+        triggers: [String],
+        minCommandLength: Int
+    ) -> String? {
+        guard matchesTextOnly(text: transcript, triggers: triggers),
+              startsWithTrigger(transcript: transcript, triggers: triggers) else { return nil }
+        let after = textAfterTrigger(transcript, triggers: triggers)
+        return after.count >= minCommandLength ? after : nil
+    }
+
+    static func isTriggerOnly(transcript: String, triggers: [String]) -> Bool {
+        guard matchesTextOnly(text: transcript, triggers: triggers),
+              startsWithTrigger(transcript: transcript, triggers: triggers) else {
+            return false
+        }
+        return textAfterTrigger(transcript, triggers: triggers).isEmpty
+    }
+
+    static func matchesTextOnly(text: String, triggers: [String]) -> Bool {
+        guard !text.isEmpty else { return false }
+        let lower = text.lowercased()
+        for trigger in triggers {
+            let token = trigger.trimmingCharacters(in: wsPunct).lowercased()
+            if token.isEmpty { continue }
+            if lower.contains(token) { return true }
+            let words = lower.split(whereSeparator: \.isWhitespace).map(String.init)
+            if words.contains(where: { fuzzyTokenMatch($0, token) }) { return true }
+        }
+        return false
+    }
+
+    static func startsWithTrigger(transcript: String, triggers: [String]) -> Bool {
+        let words = transcript.split(whereSeparator: \.isWhitespace)
+            .map { normalizeToken(String($0)) }.filter { !$0.isEmpty }
+        guard !words.isEmpty else { return false }
+        for trigger in triggers {
+            let triggerWords = trigger.split(whereSeparator: \.isWhitespace)
+                .map { normalizeToken(String($0)) }.filter { !$0.isEmpty }
+            guard !triggerWords.isEmpty, words.count >= triggerWords.count else { continue }
+            if zip(triggerWords, words.prefix(triggerWords.count))
+                .allSatisfy({ $0 == $1 || fuzzyTokenMatch($0, $1) }) {
+                return true
+            }
+        }
+        return false
+    }
+
+    static func textAfterTrigger(_ text: String, triggers: [String]) -> String {
+        let words = text.split(whereSeparator: \.isWhitespace).map(String.init)
+        guard !words.isEmpty else { return "" }
+        for trigger in triggers {
+            let triggerWords = trigger.split(whereSeparator: \.isWhitespace)
+                .map { normalizeToken(String($0)) }.filter { !$0.isEmpty }
+            guard !triggerWords.isEmpty, words.count >= triggerWords.count else { continue }
+            for i in 0...(words.count - triggerWords.count) {
+                let matched = (0..<triggerWords.count).allSatisfy { j in
+                    let word = normalizeToken(words[i + j])
+                    return word == triggerWords[j] || fuzzyTokenMatch(word, triggerWords[j])
+                }
+                if matched {
+                    let afterIdx = i + triggerWords.count
+                    return afterIdx < words.count
+                        ? words[afterIdx...].joined(separator: " ").trimmingCharacters(in: wsPunct)
+                        : ""
+                }
+            }
+        }
+        return text
+    }
+
+    static func fuzzyTokenMatch(_ a: String, _ b: String) -> Bool {
+        if a == b { return true }
+        let maxLen = max(a.count, b.count)
+        guard maxLen > 2 else { return false }
+        let threshold = max(1, (maxLen + 1) / 3)
+        return editDistance(a, b) <= threshold
+    }
+
+    private static let wsPunct = CharacterSet.whitespacesAndNewlines.union(.punctuationCharacters)
+
+    private static func normalizeToken(_ value: String) -> String {
+        value.trimmingCharacters(in: wsPunct).lowercased()
+    }
+
+    private static func editDistance(_ a: String, _ b: String) -> Int {
+        let ac = Array(a), bc = Array(b)
+        let m = ac.count, n = bc.count
+        if m == 0 { return n }
+        if n == 0 { return m }
+        var prev = Array(0...n), curr = Array(repeating: 0, count: n + 1)
+        for i in 1...m {
+            curr[0] = i
+            for j in 1...n {
+                curr[j] = ac[i - 1] == bc[j - 1]
+                    ? prev[j - 1]
+                    : min(prev[j - 1], prev[j], curr[j - 1]) + 1
+            }
+            swap(&prev, &curr)
+        }
+        return prev[n]
+    }
+}

--- a/plugins/plugin-native-swabble/ios/Sources/SwabblePlugin/SwabblePlugin.swift
+++ b/plugins/plugin-native-swabble/ios/Sources/SwabblePlugin/SwabblePlugin.swift
@@ -800,9 +800,11 @@ public class SwabblePlugin: CAPPlugin, CAPBridgedPlugin {
 
         // 2) Text-only fallback on final results (timing data absent/unreliable)
         if isFinal,
-           let command = WakeGate.textOnlyCommand(transcript: transcript,
-                                                  triggers: config.triggers,
-                                                  minCommandLength: config.minCommandLength) {
+           let command = SwabbleWakeBridgeContract.textOnlyCommand(
+                transcript: transcript,
+                triggers: config.triggers,
+                minCommandLength: config.minCommandLength
+           ) {
             let trigger = config.triggers.first ?? ""
             let fallback = GateMatch(triggerWord: trigger, triggerEndTime: 0,
                                      postGap: 0, command: command)
@@ -846,13 +848,16 @@ public class SwabblePlugin: CAPPlugin, CAPBridgedPlugin {
 
     private func triggerWakeWord(match: GateMatch, transcript: String, confidence: Float) {
         state = .triggered
-        notifyListeners("wakeWord", data: [
-            "wakeWord": match.triggerWord,
-            "command": match.command,
-            "transcript": transcript,
-            "postGap": match.postGap,
-            "confidence": Double(confidence),
-        ])
+        notifyListeners("wakeWord", data: SwabbleWakeBridgeContract.wakeWordPayload(
+            match: SwabbleBridgeMatch(
+                triggerWord: match.triggerWord,
+                triggerEndTime: match.triggerEndTime,
+                postGap: match.postGap,
+                command: match.command
+            ),
+            transcript: transcript,
+            confidence: Double(confidence)
+        ))
         beginCapture(initialCommand: match.command, triggerEndTime: match.triggerEndTime)
     }
 
@@ -928,11 +933,10 @@ public class SwabblePlugin: CAPPlugin, CAPBridgedPlugin {
     /// Check if the transcript is just the trigger word with no command after it.
     private func isTriggerOnly(transcript: String) -> Bool {
         guard let config else { return false }
-        guard WakeGate.matchesTextOnly(text: transcript, triggers: config.triggers),
-              WakeGate.startsWithTrigger(transcript: transcript, triggers: config.triggers) else {
-            return false
-        }
-        return WakeGate.textAfterTrigger(transcript, triggers: config.triggers).isEmpty
+        return SwabbleWakeBridgeContract.isTriggerOnly(
+            transcript: transcript,
+            triggers: config.triggers
+        )
     }
 
     /// If the transcript hasn't changed after the pause window, start capture.
@@ -946,10 +950,10 @@ public class SwabblePlugin: CAPPlugin, CAPBridgedPlugin {
 
             let trigger = self.config?.triggers.first ?? ""
             self.state = .triggered
-            self.notifyListeners("wakeWord", data: [
-                "wakeWord": trigger, "command": "", "transcript": transcript,
-                "postGap": 0.0, "confidence": 0.0,
-            ])
+            self.notifyListeners("wakeWord", data: SwabbleWakeBridgeContract.triggerOnlyPayload(
+                trigger: trigger,
+                transcript: transcript
+            ))
             self.beginCapture(initialCommand: "", triggerEndTime: 0)
         }
     }

--- a/plugins/plugin-native-swabble/ios/Tests/SwabbleBridgeContractTests/SwabbleBridgeContractTests.swift
+++ b/plugins/plugin-native-swabble/ios/Tests/SwabbleBridgeContractTests/SwabbleBridgeContractTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import SwabbleIOSContracts
+
+final class SwabbleBridgeContractTests: XCTestCase {
+    func testTextOnlyWakeCommandUsesTriggerAndMinimumLength() {
+        let command = SwabbleWakeBridgeContract.textOnlyCommand(
+            transcript: "eliza turn on the lights",
+            triggers: ["eliza"],
+            minCommandLength: 3
+        )
+        XCTAssertEqual(command, "turn on the lights")
+
+        let tooShort = SwabbleWakeBridgeContract.textOnlyCommand(
+            transcript: "eliza go",
+            triggers: ["eliza"],
+            minCommandLength: 3
+        )
+        XCTAssertNil(tooShort)
+    }
+
+    func testFuzzyTriggerStillFiresFromSpeechRecognizerMiss() {
+        let command = SwabbleWakeBridgeContract.textOnlyCommand(
+            transcript: "aliza start the timer",
+            triggers: ["eliza"],
+            minCommandLength: 3
+        )
+        XCTAssertEqual(command, "start the timer")
+    }
+
+    func testWakePayloadMatchesJsBridgeContract() {
+        let payload = SwabbleWakeBridgeContract.wakeWordPayload(
+            match: SwabbleBridgeMatch(
+                triggerWord: "eliza",
+                triggerEndTime: 0.6,
+                postGap: 0.45,
+                command: "turn on the lights"
+            ),
+            transcript: "eliza turn on the lights",
+            confidence: 0.92
+        )
+
+        XCTAssertEqual(payload["wakeWord"] as? String, "eliza")
+        XCTAssertEqual(payload["command"] as? String, "turn on the lights")
+        XCTAssertEqual(payload["transcript"] as? String, "eliza turn on the lights")
+        XCTAssertEqual(payload["postGap"] as? Double, 0.45)
+        XCTAssertEqual(payload["confidence"] as? Double, 0.92)
+    }
+
+    func testTriggerOnlyPayloadStartsCaptureWithoutCommand() {
+        let payload = SwabbleWakeBridgeContract.triggerOnlyPayload(
+            trigger: "eliza",
+            transcript: "eliza"
+        )
+        XCTAssertEqual(payload["wakeWord"] as? String, "eliza")
+        XCTAssertEqual(payload["command"] as? String, "")
+        XCTAssertEqual(payload["postGap"] as? Double, 0.0)
+    }
+}

--- a/plugins/plugin-native-talkmode/android/src/main/java/ai/eliza/plugins/talkmode/TalkModeAndroidBridgeContract.kt
+++ b/plugins/plugin-native-talkmode/android/src/main/java/ai/eliza/plugins/talkmode/TalkModeAndroidBridgeContract.kt
@@ -1,0 +1,86 @@
+package ai.eliza.plugins.talkmode
+
+import com.getcapacitor.JSObject
+
+internal object TalkModeAndroidBridgeContract {
+    const val FINAL_TRANSCRIPT_DEDUP_WINDOW_MS = 2000L
+
+    fun audioFramesStartedPayload(
+        sampleRate: Int,
+        frameSamples: Int,
+        suspendedStt: Boolean
+    ): Map<String, Any?> = mapOf(
+        "started" to true,
+        "sampleRate" to sampleRate,
+        "frameSamples" to frameSamples,
+        "suspendedStt" to suspendedStt
+    )
+
+    fun transcriptPayload(transcript: String, isFinal: Boolean): Map<String, Any?> =
+        mapOf("transcript" to transcript, "isFinal" to isFinal)
+
+    fun statePayload(
+        state: String,
+        previousState: String,
+        statusText: String,
+        usingSystemTts: Boolean
+    ): Map<String, Any?> = mapOf(
+        "state" to state,
+        "previousState" to previousState,
+        "statusText" to statusText,
+        "usingSystemTts" to usingSystemTts
+    )
+
+    fun permissionPayload(
+        microphoneGranted: Boolean,
+        speechRecognitionAvailable: Boolean
+    ): Map<String, Any?> = mapOf(
+        "microphone" to if (microphoneGranted) "granted" else "denied",
+        "speechRecognition" to if (speechRecognitionAvailable) {
+            if (microphoneGranted) "granted" else "prompt"
+        } else {
+            "not_supported"
+        }
+    )
+
+    fun shouldDropDuplicateFinal(
+        transcript: String,
+        previousTranscript: String,
+        nowElapsedMs: Long,
+        previousElapsedMs: Long
+    ): Boolean {
+        val text = transcript.trim()
+        return text.isNotEmpty() &&
+            text == previousTranscript &&
+            nowElapsedMs - previousElapsedMs < FINAL_TRANSCRIPT_DEDUP_WINDOW_MS
+    }
+
+    fun interruptedAtSeconds(
+        isSpeaking: Boolean,
+        nowElapsedMs: Long,
+        speakStartTimeMs: Long
+    ): Double? {
+        if (!isSpeaking) return null
+        return (nowElapsedMs - speakStartTimeMs).toDouble() / 1000.0
+    }
+
+    fun shouldInterruptSpeech(transcript: String, lastSpokenText: String?): Boolean {
+        val trimmed = transcript.trim()
+        val lower = trimmed.lowercase()
+        val words = lower.split(Regex("\\s+")).filter { it.isNotBlank() }
+        // Need real intent: at least two words, or one long word.
+        if (words.size < 2 && trimmed.length < 8) return false
+        val spoken = lastSpokenText?.lowercase() ?: return true
+        if (spoken.contains(lower)) return false
+        val echoed = words.count { spoken.contains(it) }
+        return words.isEmpty() || echoed.toDouble() / words.size < 0.6
+    }
+}
+
+internal fun Map<String, Any?>.toJSObject(): JSObject {
+    val obj = JSObject()
+    for ((key, value) in this) {
+        obj.put(key, value)
+    }
+    return obj
+}

--- a/plugins/plugin-native-talkmode/android/src/main/java/ai/eliza/plugins/talkmode/TalkModePlugin.kt
+++ b/plugins/plugin-native-talkmode/android/src/main/java/ai/eliza/plugins/talkmode/TalkModePlugin.kt
@@ -517,12 +517,11 @@ class TalkModePlugin : Plugin() {
 
     private fun startAudioFramesInternal(call: PluginCall) {
         if (audioFrameRunning.get()) {
-            call.resolve(JSObject().apply {
-                put("started", true)
-                put("sampleRate", lastFrameSampleRate)
-                put("frameSamples", lastFrameSamples)
-                put("suspendedStt", sttSuspendedForFrames)
-            })
+            call.resolve(TalkModeAndroidBridgeContract.audioFramesStartedPayload(
+                sampleRate = lastFrameSampleRate,
+                frameSamples = lastFrameSamples,
+                suspendedStt = sttSuspendedForFrames
+            ).toJSObject())
             return
         }
 
@@ -581,12 +580,11 @@ class TalkModePlugin : Plugin() {
         audioFrameRunning.set(true)
         launchFrameLoop(record, frameSamples)
 
-        call.resolve(JSObject().apply {
-            put("started", true)
-            put("sampleRate", actualRate)
-            put("frameSamples", frameSamples)
-            put("suspendedStt", sttSuspendedForFrames)
-        })
+        call.resolve(TalkModeAndroidBridgeContract.audioFramesStartedPayload(
+            sampleRate = actualRate,
+            frameSamples = frameSamples,
+            suspendedStt = sttSuspendedForFrames
+        ).toJSObject())
     }
 
     @PluginMethod
@@ -934,10 +932,10 @@ class TalkModePlugin : Plugin() {
         } else {
             lastTranscript = transcript
             lastHeardAtMs = SystemClock.elapsedRealtime()
-            notifyListeners("transcript", JSObject().apply {
-                put("transcript", transcript)
-                put("isFinal", false)
-            })
+            notifyListeners("transcript", TalkModeAndroidBridgeContract.transcriptPayload(
+                transcript = transcript,
+                isFinal = false
+            ).toJSObject())
         }
     }
 
@@ -950,13 +948,18 @@ class TalkModePlugin : Plugin() {
         val text = transcript.trim()
         if (text.isEmpty()) return
         val now = SystemClock.elapsedRealtime()
-        if (text == lastEmittedFinal && now - lastEmittedFinalAtMs < 2000L) return
+        if (TalkModeAndroidBridgeContract.shouldDropDuplicateFinal(
+            transcript = text,
+            previousTranscript = lastEmittedFinal,
+            nowElapsedMs = now,
+            previousElapsedMs = lastEmittedFinalAtMs
+        )) return
         lastEmittedFinal = text
         lastEmittedFinalAtMs = now
-        notifyListeners("transcript", JSObject().apply {
-            put("transcript", text)
-            put("isFinal", true)
-        })
+        notifyListeners("transcript", TalkModeAndroidBridgeContract.transcriptPayload(
+            transcript = text,
+            isFinal = true
+        ).toJSObject())
     }
 
     /**
@@ -967,21 +970,10 @@ class TalkModePlugin : Plugin() {
      * genuine couple-of-words utterance from the user does.
      */
     private fun shouldInterrupt(transcript: String): Boolean {
-        val trimmed = transcript.trim()
-        val lower = trimmed.lowercase()
-        val words = lower.split(Regex("\\s+")).filter { it.isNotBlank() }
-        // Need real intent: at least two words, or one long word (≥ 8 chars).
-        if (words.size < 2 && trimmed.length < 8) return false
-        val spoken = lastSpokenText?.lowercase() ?: return true
-        // Exact echo of what we're saying → speaker bleed, not the user.
-        if (spoken.contains(lower)) return false
-        // Fuzzy echo: if most of the heard words appear in the text we're
-        // currently speaking, treat it as echo (ASR mishears of our own audio).
-        val echoed = words.count { spoken.contains(it) }
-        if (words.isNotEmpty() && echoed.toDouble() / words.size >= 0.6) {
-            return false
-        }
-        return true
+        return TalkModeAndroidBridgeContract.shouldInterruptSpeech(
+            transcript = transcript,
+            lastSpokenText = lastSpokenText
+        )
     }
 
     /**
@@ -1943,9 +1935,11 @@ class TalkModePlugin : Plugin() {
     }
 
     private fun computeInterruptedAt(): Double? {
-        if (!isSpeaking) return null
-        val elapsed = SystemClock.elapsedRealtime() - speakStartTimeMs
-        return elapsed.toDouble() / 1000.0
+        return TalkModeAndroidBridgeContract.interruptedAtSeconds(
+            isSpeaking = isSpeaking,
+            nowElapsedMs = SystemClock.elapsedRealtime(),
+            speakStartTimeMs = speakStartTimeMs
+        )
     }
 
     // ── Voice alias resolution ──────────────────────────────────────────
@@ -2051,26 +2045,22 @@ class TalkModePlugin : Plugin() {
         state = newState
         statusText = newStatusText
 
-        notifyListeners("stateChange", JSObject().apply {
-            put("state", newState)
-            put("previousState", previousState)
-            put("statusText", newStatusText)
-            put("usingSystemTts", usedSystemTts)
-        })
+        notifyListeners("stateChange", TalkModeAndroidBridgeContract.statePayload(
+            state = newState,
+            previousState = previousState,
+            statusText = newStatusText,
+            usingSystemTts = usedSystemTts
+        ).toJSObject())
     }
 
     private fun buildPermissionResult(): JSObject {
         val micGranted = isPermissionGranted(Manifest.permission.RECORD_AUDIO)
         val speechAvailable = SpeechRecognizer.isRecognitionAvailable(context)
 
-        return JSObject().apply {
-            put("microphone", if (micGranted) "granted" else "denied")
-            put("speechRecognition", if (speechAvailable) {
-                if (micGranted) "granted" else "prompt"
-            } else {
-                "not_supported"
-            })
-        }
+        return TalkModeAndroidBridgeContract.permissionPayload(
+            microphoneGranted = micGranted,
+            speechRecognitionAvailable = speechAvailable
+        ).toJSObject()
     }
 
     private fun isPermissionGranted(permission: String): Boolean {

--- a/plugins/plugin-native-talkmode/android/src/test/java/ai/eliza/plugins/talkmode/TalkModeAndroidBridgeContractTest.kt
+++ b/plugins/plugin-native-talkmode/android/src/test/java/ai/eliza/plugins/talkmode/TalkModeAndroidBridgeContractTest.kt
@@ -1,0 +1,94 @@
+package ai.eliza.plugins.talkmode
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TalkModeAndroidBridgeContractTest {
+    @Test
+    fun `audio frame capture start payload preserves lifecycle fields`() {
+        val payload = TalkModeAndroidBridgeContract.audioFramesStartedPayload(
+            sampleRate = 16000,
+            frameSamples = 320,
+            suspendedStt = true
+        )
+
+        assertEquals(true, payload["started"])
+        assertEquals(16000, payload["sampleRate"])
+        assertEquals(320, payload["frameSamples"])
+        assertEquals(true, payload["suspendedStt"])
+    }
+
+    @Test
+    fun `transcript bridge payload distinguishes interim and final turns`() {
+        assertEquals(
+            mapOf("transcript" to " hello eliza ", "isFinal" to false),
+            TalkModeAndroidBridgeContract.transcriptPayload(" hello eliza ", false)
+        )
+        assertEquals(
+            mapOf("transcript" to "hello eliza", "isFinal" to true),
+            TalkModeAndroidBridgeContract.transcriptPayload("hello eliza", true)
+        )
+    }
+
+    @Test
+    fun `duplicate final transcript is suppressed only inside the debounce window`() {
+        assertTrue(
+            TalkModeAndroidBridgeContract.shouldDropDuplicateFinal(
+                transcript = "hello eliza",
+                previousTranscript = "hello eliza",
+                nowElapsedMs = 11_000,
+                previousElapsedMs = 10_000
+            )
+        )
+        assertFalse(
+            TalkModeAndroidBridgeContract.shouldDropDuplicateFinal(
+                transcript = "hello eliza",
+                previousTranscript = "hello eliza",
+                nowElapsedMs = 13_000,
+                previousElapsedMs = 10_000
+            )
+        )
+    }
+
+    @Test
+    fun `barge in ignores one word blips and self echo but accepts user speech`() {
+        assertFalse(
+            TalkModeAndroidBridgeContract.shouldInterruptSpeech(
+                transcript = "ok",
+                lastSpokenText = "The answer is coming now"
+            )
+        )
+        assertFalse(
+            TalkModeAndroidBridgeContract.shouldInterruptSpeech(
+                transcript = "The answer is coming",
+                lastSpokenText = "The answer is coming now"
+            )
+        )
+        assertTrue(
+            TalkModeAndroidBridgeContract.shouldInterruptSpeech(
+                transcript = "stop talking",
+                lastSpokenText = "The answer is coming now"
+            )
+        )
+    }
+
+    @Test
+    fun `permission payload exposes speech recognition availability separately`() {
+        assertEquals(
+            mapOf("microphone" to "denied", "speechRecognition" to "prompt"),
+            TalkModeAndroidBridgeContract.permissionPayload(
+                microphoneGranted = false,
+                speechRecognitionAvailable = true
+            )
+        )
+        assertEquals(
+            mapOf("microphone" to "granted", "speechRecognition" to "not_supported"),
+            TalkModeAndroidBridgeContract.permissionPayload(
+                microphoneGranted = true,
+                speechRecognitionAvailable = false
+            )
+        )
+    }
+}

--- a/plugins/plugin-native-talkmode/ios/Package.swift
+++ b/plugins/plugin-native-talkmode/ios/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "ElizaosCapacitorTalkModeIOSContracts",
+    platforms: [
+        .iOS(.v13),
+        .macOS(.v13),
+    ],
+    targets: [
+        .target(
+            name: "TalkModeIOSContracts",
+            path: "Sources/TalkModeBridgeContract"
+        ),
+        .testTarget(
+            name: "TalkModeBridgeContractTests",
+            dependencies: ["TalkModeIOSContracts"],
+            path: "Tests/TalkModeBridgeContractTests"
+        ),
+    ]
+)

--- a/plugins/plugin-native-talkmode/ios/Sources/TalkModeBridgeContract/TalkModeBridgeContract.swift
+++ b/plugins/plugin-native-talkmode/ios/Sources/TalkModeBridgeContract/TalkModeBridgeContract.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+enum TalkModeBridgeContract {
+    static func transcriptPayload(transcript: String, isFinal: Bool) -> [String: Any] {
+        [
+            "transcript": transcript,
+            "isFinal": isFinal,
+        ]
+    }
+
+    static func statePayload(
+        state: String,
+        previousState: String,
+        statusText: String,
+        usingSystemTts: Bool
+    ) -> [String: Any] {
+        [
+            "state": state,
+            "previousState": previousState,
+            "statusText": statusText,
+            "usingSystemTts": usingSystemTts,
+        ]
+    }
+
+    static func permissionPayload(microphone: String, speechRecognition: String) -> [String: Any] {
+        [
+            "microphone": microphone,
+            "speechRecognition": speechRecognition,
+        ]
+    }
+
+    static func shouldInterruptSpeech(transcript: String, lastSpokenText: String?) -> Bool {
+        let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count >= 3 else { return false }
+
+        if let spoken = lastSpokenText?.lowercased() {
+            let probe = trimmed.lowercased()
+            if spoken.contains(probe) { return false }
+        }
+
+        return true
+    }
+}

--- a/plugins/plugin-native-talkmode/ios/Sources/TalkModePlugin/TalkModePlugin.swift
+++ b/plugins/plugin-native-talkmode/ios/Sources/TalkModePlugin/TalkModePlugin.swift
@@ -354,26 +354,19 @@ public class TalkModePlugin: CAPPlugin, CAPBridgedPlugin {
             lastTranscript = trimmed
         }
 
-        notifyListeners("transcript", data: [
-            "transcript": trimmed,
-            "isFinal": isFinal
-        ])
+        notifyListeners("transcript", data: TalkModeBridgeContract.transcriptPayload(
+            transcript: trimmed,
+            isFinal: isFinal
+        ))
     }
 
     /// Determines whether detected speech should interrupt current TTS playback.
     /// Filters out echo where the mic picks up our own TTS output.
     private func shouldInterrupt(with transcript: String) -> Bool {
-        let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmed.count >= 3 else { return false }
-
-        // Echo detection: if the transcript is a substring of the text being spoken,
-        // it's likely the microphone picking up the TTS output, not user speech.
-        if let spoken = lastSpokenText?.lowercased() {
-            let probe = trimmed.lowercased()
-            if spoken.contains(probe) { return false }
-        }
-
-        return true
+        return TalkModeBridgeContract.shouldInterruptSpeech(
+            transcript: transcript,
+            lastSpokenText: lastSpokenText
+        )
     }
 
     // MARK: - Silence Detection
@@ -417,10 +410,10 @@ public class TalkModePlugin: CAPPlugin, CAPBridgedPlugin {
         setState("processing", "Processing")
         stopRecognition()
 
-        notifyListeners("transcript", data: [
-            "transcript": transcript,
-            "isFinal": true
-        ])
+        notifyListeners("transcript", data: TalkModeBridgeContract.transcriptPayload(
+            transcript: transcript,
+            isFinal: true
+        ))
     }
 
     // MARK: - TTS Orchestration
@@ -1166,10 +1159,10 @@ public class TalkModePlugin: CAPPlugin, CAPBridgedPlugin {
         @unknown default: speechStatus = "prompt"
         }
 
-        return [
-            "microphone": micStatus,
-            "speechRecognition": speechStatus
-        ]
+        return TalkModeBridgeContract.permissionPayload(
+            microphone: micStatus,
+            speechRecognition: speechStatus
+        )
     }
 
     // MARK: - Audio Session
@@ -1192,12 +1185,12 @@ public class TalkModePlugin: CAPPlugin, CAPBridgedPlugin {
         state = newState
         statusText = newStatusText
 
-        notifyListeners("stateChange", data: [
-            "state": newState,
-            "previousState": previousState,
-            "statusText": newStatusText,
-            "usingSystemTts": usedSystemTts
-        ])
+        notifyListeners("stateChange", data: TalkModeBridgeContract.statePayload(
+            state: newState,
+            previousState: previousState,
+            statusText: newStatusText,
+            usingSystemTts: usedSystemTts
+        ))
     }
 
     private func emitError(code: String, message: String, recoverable: Bool) {

--- a/plugins/plugin-native-talkmode/ios/Tests/TalkModeBridgeContractTests/TalkModeBridgeContractTests.swift
+++ b/plugins/plugin-native-talkmode/ios/Tests/TalkModeBridgeContractTests/TalkModeBridgeContractTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import TalkModeIOSContracts
+
+final class TalkModeBridgeContractTests: XCTestCase {
+    func testTranscriptPayloadPreservesBridgeFields() {
+        let interim = TalkModeBridgeContract.transcriptPayload(
+            transcript: " hello eliza ",
+            isFinal: false
+        )
+        XCTAssertEqual(interim["transcript"] as? String, " hello eliza ")
+        XCTAssertEqual(interim["isFinal"] as? Bool, false)
+
+        let final = TalkModeBridgeContract.transcriptPayload(
+            transcript: "hello eliza",
+            isFinal: true
+        )
+        XCTAssertEqual(final["transcript"] as? String, "hello eliza")
+        XCTAssertEqual(final["isFinal"] as? Bool, true)
+    }
+
+    func testBargeInInterruptIgnoresShortBlipsAndSelfEcho() {
+        XCTAssertFalse(TalkModeBridgeContract.shouldInterruptSpeech(
+            transcript: "ok",
+            lastSpokenText: "The answer is coming now"
+        ))
+        XCTAssertFalse(TalkModeBridgeContract.shouldInterruptSpeech(
+            transcript: "answer is coming",
+            lastSpokenText: "The answer is coming now"
+        ))
+        XCTAssertTrue(TalkModeBridgeContract.shouldInterruptSpeech(
+            transcript: "stop",
+            lastSpokenText: "The answer is coming now"
+        ))
+    }
+
+    func testStateAndPermissionPayloads() {
+        let state = TalkModeBridgeContract.statePayload(
+            state: "speaking",
+            previousState: "processing",
+            statusText: "Speaking",
+            usingSystemTts: true
+        )
+        XCTAssertEqual(state["state"] as? String, "speaking")
+        XCTAssertEqual(state["previousState"] as? String, "processing")
+        XCTAssertEqual(state["statusText"] as? String, "Speaking")
+        XCTAssertEqual(state["usingSystemTts"] as? Bool, true)
+
+        let permission = TalkModeBridgeContract.permissionPayload(
+            microphone: "granted",
+            speechRecognition: "prompt"
+        )
+        XCTAssertEqual(permission["microphone"] as? String, "granted")
+        XCTAssertEqual(permission["speechRecognition"] as? String, "prompt")
+    }
+}


### PR DESCRIPTION
Refs #9958

## Summary
- Adds `bun run voice:matrix` as the canonical voice live-coverage matrix with JSON, Markdown, and HTML reports under `.github/issue-evidence/9958-*`.
- Adds web, Linux, macOS, Windows, iOS, Android, openWakeWord, and Stage-B STT matrix cells, with unavailable hardware reported as explicit skips instead of passes.
- Adds optional GitHub Actions lanes for platform-specific voice evidence and a macOS desktop capture helper.
- Adds Android Kotlin and iOS Swift bridge contract helpers/tests for TalkMode and Swabble.
- Fixes the local-ASR transcript finalization race by awaiting capture stop/drain before creating the Transcript session record.

## Evidence Captured
- Rebased onto latest `origin/develop` before push.
- `node --check packages/scripts/voice-matrix.mjs && node --check packages/app/scripts/capture-macos-desktop.mjs && git diff --check HEAD~1..HEAD` passed after final rebase.
- `bunx @biomejs/biome check ...` passed for edited files.
- `bun run --cwd packages/ui test src/components/shell/__tests__/useShellController.test.tsx`: 39 passed.
- `bun run --cwd plugins/plugin-native-talkmode test`: 4 passed.
- `bun run --cwd plugins/plugin-native-swabble test`: 10 passed.
- `swift test --package-path plugins/plugin-native-talkmode/ios`: 3 passed.
- `swift test --package-path plugins/plugin-native-swabble/ios`: 4 passed.
- `bun run voice:matrix -- --out .github/issue-evidence/9958-voice-matrix`: pass=0 fail=0 pending=5 skip=10.
- `bun run voice:matrix -- --run --platform ios --out .github/issue-evidence/9958-voice-matrix-ios-run`: pass=2 fail=0 pending=0 skip=1.
- `bun run voice:matrix -- --run --platform web --out .github/issue-evidence/9958-voice-matrix-web-run`: pass=3 fail=0 pending=0 skip=0.
- `bun run --cwd packages/app audit:app`: 369 passed in 2.1h; broken=0, needs-work=0, needs-eyeball=228, good=140.

## Still Draft / Residuals
- Real macOS Electrobun, Windows Electrobun, iOS device/simulator, and Android device live voice lanes still need actual hardware/simulator/device envs.
- Android Gradle native bridge tests were added to the matrix but not run locally because the generated Capacitor Android project/device lane was not available here.
- openWakeWord real-head and Stage-B STT power/latency evaluation remain gated and not executed locally.
- Full `bun run verify` was not run after the final rebase; focused checks and the full app audit were run instead.
