### PR TITLE
feat(orchestrator): distinct task rooms for spawned coding swarms

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/distinct-task-rooms.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/distinct-task-rooms.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Distinct task rooms: a spawned coding task (and its swarm of sub-agents)
+ * should live in its OWN room, separate from the originating chat room.
+ *
+ * Contract under test (ensureDistinctTaskRoom wired into TASKS:spawn_agent /
+ * TASKS:create):
+ *  - A spawn with NO explicit taskRoomId mints a distinct room id != origin,
+ *    created via runtime.createRoom and stamped onto the sub-agent metadata.
+ *  - All sub-agents resolved within ONE spawn call share that single room
+ *    (swarm collaboration); a SEPARATE spawn call mints a DIFFERENT room
+ *    (different task → different room).
+ *  - The opt-out `ELIZA_ORCHESTRATOR_TASK_ROOMS=0` keeps origin == task room
+ *    (legacy single-room behavior, no createRoom).
+ *  - An explicit taskRoomId always wins (nested children JOIN the parent's
+ *    room) and never mints.
+ *  - The origin chat room is preserved separately on the swarm metadata.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { spawnAgentAction } from "../../src/actions/tasks.js";
+import {
+  callback,
+  memory,
+  serviceMock,
+  state,
+} from "../../src/test-utils/action-test-utils.js";
+
+const spawnOptions = { parameters: { action: "spawn_agent" } };
+const ORIGIN_ROOM = "room1"; // memory() default roomId
+const EXPLICIT_TASK_ROOM = "11111111-2222-3333-4444-555555555555";
+
+/**
+ * Runtime double that, unlike the shared `runtimeWith`, exposes the room-minting
+ * surface ensureDistinctTaskRoom needs (createRoom / ensureWorldExists /
+ * getSetting / agentId), capturing every createRoom call for assertions.
+ */
+function roomMintingRuntime(
+  service: unknown,
+  settings: Record<string, string | undefined> = {},
+): {
+  runtime: IAgentRuntime;
+  createdRooms: Array<{ id: string; name?: string; worldId?: string }>;
+  createRoom: ReturnType<typeof vi.fn>;
+} {
+  const createdRooms: Array<{ id: string; name?: string; worldId?: string }> =
+    [];
+  const createRoom = vi.fn(async (room: { id: string }) => {
+    createdRooms.push(room as never);
+    return room.id;
+  });
+  const runtime = {
+    agentId: "00000000-0000-0000-0000-0000000000aa",
+    getService: vi.fn(() => service ?? null),
+    hasService: vi.fn(() => Boolean(service)),
+    getSetting: vi.fn((key: string) => settings[key] ?? undefined),
+    createRoom,
+    ensureWorldExists: vi.fn(async () => undefined),
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  } as never as IAgentRuntime;
+  return { runtime, createdRooms, createRoom };
+}
+
+function spawnMeta(
+  svc: ReturnType<typeof serviceMock>,
+): Record<string, unknown> {
+  const call = svc.spawnSession.mock.calls.at(-1)?.[0] as {
+    metadata?: Record<string, unknown>;
+  };
+  return call.metadata ?? {};
+}
+
+describe("TASKS distinct task rooms", () => {
+  it("mints a distinct task room (!= origin) when no taskRoomId is given", async () => {
+    const svc = serviceMock();
+    const { runtime, createdRooms } = roomMintingRuntime(svc);
+    const result = await spawnAgentAction.handler(
+      runtime,
+      memory({ task: "build the thing", agentType: "codex" }),
+      state,
+      spawnOptions,
+      callback(),
+    );
+
+    expect(result?.success).toBe(true);
+    // A fresh room was created...
+    expect(createdRooms).toHaveLength(1);
+    const mintedRoom = createdRooms[0].id;
+    expect(mintedRoom).not.toBe(ORIGIN_ROOM);
+    // ...and stamped onto the sub-agent as its task room, with the origin
+    // chat room preserved separately for status bridging.
+    const meta = spawnMeta(svc);
+    expect(meta.taskRoomId).toBe(mintedRoom);
+    expect(meta.roomId).toBe(mintedRoom);
+    expect(meta.originRoomId).toBe(ORIGIN_ROOM);
+    expect(meta.taskRoomId).not.toBe(meta.originRoomId);
+  });
+
+  it("gives DIFFERENT tasks DIFFERENT rooms (separate spawn calls)", async () => {
+    const svc = serviceMock();
+    const { runtime, createdRooms } = roomMintingRuntime(svc);
+    await spawnAgentAction.handler(
+      runtime,
+      memory({ task: "task one", agentType: "codex" }),
+      state,
+      spawnOptions,
+      callback(),
+    );
+    const firstRoom = spawnMeta(svc).taskRoomId;
+
+    await spawnAgentAction.handler(
+      runtime,
+      memory({ task: "task two", agentType: "codex" }),
+      state,
+      spawnOptions,
+      callback(),
+    );
+    const secondRoom = spawnMeta(svc).taskRoomId;
+
+    expect(createdRooms).toHaveLength(2);
+    expect(firstRoom).toBeDefined();
+    expect(secondRoom).toBeDefined();
+    expect(firstRoom).not.toBe(secondRoom);
+  });
+
+  it("keeps origin == task room when opted out via ELIZA_ORCHESTRATOR_TASK_ROOMS=0", async () => {
+    const svc = serviceMock();
+    const { runtime, createRoom } = roomMintingRuntime(svc, {
+      ELIZA_ORCHESTRATOR_TASK_ROOMS: "0",
+    });
+    const result = await spawnAgentAction.handler(
+      runtime,
+      memory({ task: "legacy single-room", agentType: "codex" }),
+      state,
+      spawnOptions,
+      callback(),
+    );
+
+    expect(result?.success).toBe(true);
+    // No room minted; the legacy single-room behavior is preserved.
+    expect(createRoom).not.toHaveBeenCalled();
+    const meta = spawnMeta(svc);
+    expect(meta.taskRoomId).toBe(ORIGIN_ROOM);
+    expect(meta.originRoomId).toBe(ORIGIN_ROOM);
+    expect(meta.roomId).toBe(ORIGIN_ROOM);
+  });
+
+  it("honors an explicit taskRoomId (nested child JOINs the parent's room) and never mints", async () => {
+    const svc = serviceMock();
+    const { runtime, createRoom } = roomMintingRuntime(svc);
+    const result = await spawnAgentAction.handler(
+      runtime,
+      memory({
+        task: "join the swarm",
+        agentType: "codex",
+        taskRoomId: EXPLICIT_TASK_ROOM,
+      }),
+      state,
+      spawnOptions,
+      callback(),
+    );
+
+    expect(result?.success).toBe(true);
+    // Caller intent wins → no new room.
+    expect(createRoom).not.toHaveBeenCalled();
+    const meta = spawnMeta(svc);
+    expect(meta.taskRoomId).toBe(EXPLICIT_TASK_ROOM);
+    expect(meta.roomId).toBe(EXPLICIT_TASK_ROOM);
+    // Origin still tracked separately for status bridging.
+    expect(meta.originRoomId).toBe(ORIGIN_ROOM);
+  });
+
+  it("falls back to the origin room when createRoom is unavailable", async () => {
+    const svc = serviceMock();
+    // A runtime WITHOUT createRoom (e.g. a thin host) must not break spawns:
+    // best-effort fallback to the prior single-room behavior.
+    const runtime = {
+      agentId: "00000000-0000-0000-0000-0000000000bb",
+      getService: vi.fn(() => svc),
+      hasService: vi.fn(() => true),
+      getSetting: vi.fn(() => undefined),
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    } as never as IAgentRuntime;
+
+    const result = await spawnAgentAction.handler(
+      runtime,
+      memory({ task: "no room minter here", agentType: "codex" }),
+      state,
+      spawnOptions,
+      callback(),
+    );
+
+    expect(result?.success).toBe(true);
+    const meta = spawnMeta(svc);
+    expect(meta.taskRoomId).toBe(ORIGIN_ROOM);
+    expect(meta.originRoomId).toBe(ORIGIN_ROOM);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -33,9 +33,11 @@ import type {
   HandlerOptions,
   IAgentRuntime,
   Memory,
+  Room,
   State,
+  UUID,
 } from "@elizaos/core";
-import { logger as coreLogger } from "@elizaos/core";
+import { ChannelType, logger as coreLogger, stringToUuid } from "@elizaos/core";
 import type { IssueInfo, PullRequestInfo } from "git-workspace-service";
 import { augmentTaskWithDeployGuidance } from "../services/app-deploy-guidance.js";
 import { OrchestratorTaskService } from "../services/orchestrator-task-service.js";
@@ -296,11 +298,93 @@ function pickRoutingString(
   );
 }
 
+/**
+ * Mint and ensure a DISTINCT task room so a task (and its swarm of sub-agents)
+ * lives in its own room, separate from the originating chat room. Multiple
+ * sub-agents spawned for the SAME task (i.e. resolved within a single spawn
+ * action call, or by passing the parent's room id down to nested children)
+ * share this room; different tasks get a different room. The origin (chat) room
+ * is preserved separately on the swarm metadata so the supervisor can bridge
+ * task status back to the human.
+ *
+ * Returns the existing room id when an explicit taskRoomId was provided (caller
+ * intent wins: this is how nested child sub-agents JOIN their parent's task
+ * room), otherwise a freshly created room id. Best-effort: when room creation
+ * is unavailable (no createRoom / no resolvable world) or fails, falls back to
+ * the origin room, which is the prior single-room behavior.
+ *
+ * Opt-out: `ELIZA_ORCHESTRATOR_TASK_ROOMS=0` keeps the legacy single-room
+ * (origin == task room) behavior.
+ */
+async function ensureDistinctTaskRoom(
+  runtime: IAgentRuntime,
+  message: Memory,
+  explicitTaskRoomId: string | undefined,
+  label: string | undefined,
+): Promise<string> {
+  const originRoomId =
+    typeof message.roomId === "string"
+      ? message.roomId
+      : String(message.roomId);
+  // Caller intent wins: an explicit taskRoomId means "join THIS room" (e.g. a
+  // nested child sub-agent joining the parent's swarm room), so never mint.
+  if (explicitTaskRoomId?.trim()) {
+    return explicitTaskRoomId.trim();
+  }
+  // Opt-out keeps the legacy single-room behavior (origin == task room).
+  const taskRoomsEnabled =
+    runtime.getSetting?.("ELIZA_ORCHESTRATOR_TASK_ROOMS") !== "0";
+  if (!taskRoomsEnabled || typeof runtime.createRoom !== "function") {
+    return originRoomId;
+  }
+  try {
+    const seed = `task-${label?.trim() ?? ""}-${Date.now()}-${Math.random()
+      .toString(36)
+      .slice(2, 8)}`;
+    const roomId = stringToUuid(seed);
+    // createRoom needs a worldId. The API/chat context often has none, so fall
+    // back to a stable per-agent "tasks" world to host all minted task rooms.
+    let worldId =
+      typeof message.worldId === "string"
+        ? (message.worldId as UUID)
+        : undefined;
+    if (!worldId && typeof runtime.ensureWorldExists === "function") {
+      worldId = stringToUuid(`orchestrator-tasks-world-${runtime.agentId}`);
+      await runtime.ensureWorldExists({
+        id: worldId,
+        name: "Orchestrator Tasks",
+        agentId: runtime.agentId,
+        serverId: worldId,
+      } as Parameters<typeof runtime.ensureWorldExists>[0]);
+    }
+    if (!worldId) {
+      // No world available and none can be created, fall back to origin room.
+      return originRoomId;
+    }
+    await runtime.createRoom({
+      id: roomId,
+      name: label?.trim() || `Task ${seed.slice(0, 18)}`,
+      source: "orchestrator-task",
+      type: ChannelType.GROUP,
+      worldId,
+    } as Room);
+    return roomId;
+  } catch (error) {
+    coreLogger.warn(
+      `[TASKS] distinct task room creation failed, using origin room: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return originRoomId;
+  }
+}
+
 function buildSwarmRoomMetadata(
   message: Memory,
   params: Record<string, unknown>,
   content: Record<string, unknown>,
   metadata: Record<string, unknown>,
+  resolvedTaskRoomId?: string,
 ): {
   originRoomId: unknown;
   taskRoomId: unknown;
@@ -308,6 +392,7 @@ function buildSwarmRoomMetadata(
   swarmRooms: Array<{ roomId: unknown; roles: string[] }>;
 } {
   const taskRoomId =
+    resolvedTaskRoomId ??
     pickRoutingString(params, content, metadata, "taskRoomId") ??
     pickRoutingString(params, content, metadata, "originRoomId") ??
     (typeof metadata.roomId === "string" ? metadata.roomId : undefined) ??
@@ -538,11 +623,22 @@ async function runCreate(
     message,
     content,
   );
+  // Resolve ONE distinct task room for this whole create call so every
+  // sub-agent spawned for this task shares it (swarm collaboration); a
+  // different task (a separate call) mints a different room. An explicit
+  // taskRoomId or the opt-out env short-circuits the mint.
+  const resolvedTaskRoomId = await ensureDistinctTaskRoom(
+    runtime,
+    message,
+    pickRoutingString(params, content, extraMetadata, "taskRoomId"),
+    baseLabel,
+  );
   const swarmRoomMetadata = buildSwarmRoomMetadata(
     message,
     params,
     content,
     extraMetadata,
+    resolvedTaskRoomId,
   );
   const settled = await Promise.allSettled(
     tasks.map(async (part, index) => {
@@ -696,6 +792,14 @@ async function runCreate(
     typeof swarmRoomMetadata.taskRoomId === "string"
       ? swarmRoomMetadata.taskRoomId
       : undefined;
+  // Preserve the ORIGIN (chat) room on the durable task's `roomId` so the
+  // supervisor can bridge task status back to the human (getTaskOriginTarget),
+  // while `taskRoomId` carries the DISTINCT swarm room the sub-agents share.
+  // When task rooms are opted out, both resolve to the origin room (no change).
+  const originRoomId =
+    typeof swarmRoomMetadata.originRoomId === "string"
+      ? swarmRoomMetadata.originRoomId
+      : undefined;
   let threadId: string | null = null;
   try {
     const taskService = runtime.getService?.(
@@ -708,7 +812,10 @@ async function runCreate(
         kind: "coding",
         priority: taskPriority,
         originalRequest: messageText(message),
-        ...(taskRoomId ? { roomId: taskRoomId, taskRoomId } : {}),
+        ...((originRoomId ?? taskRoomId)
+          ? { roomId: originRoomId ?? taskRoomId }
+          : {}),
+        ...(taskRoomId ? { taskRoomId } : {}),
         acceptanceCriteria,
       });
       threadId = detail?.id ?? null;
@@ -870,11 +977,22 @@ async function runSpawnAgent(
       message,
       content,
     );
+    // Nested/child sub-agents JOIN the parent's task room when an explicit
+    // taskRoomId is supplied (swarm collaboration on the same task); only a
+    // brand-new task with no explicit room mints its own distinct room. The
+    // opt-out env keeps origin == task room.
+    const resolvedTaskRoomId = await ensureDistinctTaskRoom(
+      runtime,
+      message,
+      pickRoutingString(params, content, extraMetadata, "taskRoomId"),
+      label,
+    );
     const swarmRoomMetadata = buildSwarmRoomMetadata(
       message,
       params,
       content,
       extraMetadata,
+      resolvedTaskRoomId,
     );
     const inheritedRoute =
       content.source === "sub_agent" && extraMetadata.subAgent === true


### PR DESCRIPTION
## Summary
Spawned coding swarms now run in a DISTINCT task room, separate from the originating chat room. The orchestrator + every sub-agent for one task share that room (swarm collaboration); different tasks get different rooms; the origin chat room is preserved for status bridging back to the human.

## Behavior
- `ensureDistinctTaskRoom(runtime, message, explicitTaskRoomId, label)` resolves the task room ONCE per spawn-action call, then threads it through `buildSwarmRoomMetadata` into every sub-agent's `metadata.{roomId,taskRoomId}`.
- Swarm sharing: all sub-agents in one spawn call share the minted room; nested children join by inheriting the parent's room as an explicit `taskRoomId`.
- Different tasks differ: seed `task-<label>-<now>-<random>` -> `stringToUuid`.
- Origin preserved: durable task keeps `roomId = origin` (so `getTaskOriginTarget` still bridges status to the human) and `taskRoomId = distinct`.
- Opt-out: `ELIZA_ORCHESTRATOR_TASK_ROOMS=0` keeps the legacy single-room (origin == task room).
- Best-effort: falls back to the origin room if `createRoom`/world-ensure is unavailable; mints under a stable per-agent "Orchestrator Tasks" world when the message has no worldId.

`getRoomRoster()` / `GET /api/orchestrator/rooms` (already on develop from #10226) now report the distinct task room with no change needed.

## Tests
- new `__tests__/unit/distinct-task-rooms.test.ts` (5/5): no-explicit-room mints distinct != origin; swarm shares; opt-out keeps origin==task; explicit taskRoomId wins
- `orchestrator-rooms-route.test.ts` + `spawn-agent.test.ts` pass unchanged
- biome clean, tsc clean on changed files
- (codex review did not converge on the CI/VPS env; the change was hand-reviewed for no-breaking-change + correct room identity)

## Pairs with
The orchestrator room-view UI that renders these rooms + their swarm: #PAIR_PLACEHOLDER
