### PR TITLE
feat(ui): orchestrator room view, live task-room swarm widget

### DIFF
--- a/packages/ui/src/components/chat/widgets/agent-orchestrator-room-view.stories.tsx
+++ b/packages/ui/src/components/chat/widgets/agent-orchestrator-room-view.stories.tsx
@@ -1,0 +1,128 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import type { ReactNode } from "react";
+import type { OrchestratorRoomRosterOverview } from "../../../api/client-types-cloud";
+import { OrchestratorRoomView } from "./agent-orchestrator-room-view";
+
+// The widget lives in the chat sidebar, render stories in a matching column.
+function Sidebar({ children }: { children: ReactNode }) {
+  return (
+    <div className="w-[320px] rounded-lg border border-border/40 bg-bg/40 p-3">
+      {children}
+    </div>
+  );
+}
+
+/** Two live rooms with a mixed swarm: a multi-party room with three sub-agents
+ * (one running a tool, one working, one idle/ready) and a single-agent room. */
+const rooms: OrchestratorRoomRosterOverview = {
+  rooms: [
+    {
+      taskId: "task-parser",
+      taskTitle: "Refactor the streaming parser",
+      status: "active",
+      roomId: "room-1",
+      activeAgentCount: 2,
+      multiParty: true,
+      participants: [
+        { kind: "orchestrator", id: "orchestrator", label: "Orchestrator" },
+        { kind: "user", id: "owner", label: "You" },
+        {
+          kind: "sub_agent",
+          id: "s1",
+          label: "Ada",
+          framework: "claude",
+          status: "tool_running",
+          active: true,
+          activeTool: "edit_file",
+          accountProviderId: "anthropic-subscription",
+          accountId: "claude-work",
+          accountLabel: "Claude — Work",
+          totalTokens: 48200,
+          usageState: "measured",
+        },
+        {
+          kind: "sub_agent",
+          id: "s2",
+          label: "Cody",
+          framework: "codex",
+          status: "running",
+          active: true,
+          accountProviderId: "openai-codex",
+          accountId: "codex-main",
+          accountLabel: "Codex — Main",
+          totalTokens: 13800,
+          usageState: "measured",
+        },
+        {
+          kind: "sub_agent",
+          id: "s3",
+          label: "Mara",
+          framework: "opencode",
+          status: "stopped",
+          active: false,
+          accountProviderId: "cerebras-api",
+          accountId: "cerebras-1",
+          accountLabel: "Cerebras — Team",
+          totalTokens: 6100,
+          usageState: "estimated",
+        },
+      ],
+    },
+    {
+      taskId: "task-migration",
+      taskTitle: "Migrate the room view to react-query",
+      status: "waiting_on_user",
+      roomId: "room-2",
+      activeAgentCount: 1,
+      multiParty: false,
+      participants: [
+        { kind: "orchestrator", id: "orchestrator", label: "Orchestrator" },
+        { kind: "user", id: "owner", label: "You" },
+        {
+          kind: "sub_agent",
+          id: "s4",
+          label: "Vera",
+          framework: "claude",
+          status: "ready",
+          active: true,
+          accountProviderId: "anthropic-subscription",
+          accountId: "claude-personal",
+          accountLabel: "Claude — Personal",
+          totalTokens: 2300,
+          usageState: "measured",
+        },
+      ],
+    },
+  ],
+};
+
+const meta = {
+  title: "Chat/Widgets/OrchestratorRooms",
+  component: OrchestratorRoomView,
+  decorators: [
+    (Story) => (
+      <Sidebar>
+        <Story />
+      </Sidebar>
+    ),
+  ],
+  args: { rooms: null },
+} satisfies Meta<typeof OrchestratorRoomView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** No active rooms: the empty state that explains where rooms come from. */
+export const Empty: Story = {
+  args: { rooms: { rooms: [] } },
+};
+
+/** The live board: a multi-party room and a single-agent room side by side. */
+export const LiveRooms: Story = {
+  args: { rooms },
+};
+
+/** A single multi-party room with a running tool, a worker, and an idle agent. */
+export const MultiPartyRoom: Story = {
+  args: { rooms: { rooms: [rooms.rooms[0]] } },
+};

--- a/packages/ui/src/components/chat/widgets/agent-orchestrator-room-view.test.tsx
+++ b/packages/ui/src/components/chat/widgets/agent-orchestrator-room-view.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { OrchestratorRoomRosterOverview } from "../../../api/client-types-cloud";
+import { OrchestratorRoomView } from "./agent-orchestrator-room-view";
+
+afterEach(cleanup);
+
+const rooms: OrchestratorRoomRosterOverview = {
+  rooms: [
+    {
+      taskId: "task-parser",
+      taskTitle: "Refactor the parser",
+      status: "active",
+      roomId: "room-1",
+      activeAgentCount: 2,
+      multiParty: true,
+      participants: [
+        { kind: "orchestrator", id: "orchestrator", label: "Orchestrator" },
+        { kind: "user", id: "owner", label: "You" },
+        {
+          kind: "sub_agent",
+          id: "s1",
+          label: "Ada",
+          framework: "claude",
+          status: "tool_running",
+          active: true,
+          activeTool: "edit_file",
+          totalTokens: 48200,
+          usageState: "measured",
+        },
+        {
+          kind: "sub_agent",
+          id: "s2",
+          label: "Mara",
+          framework: "opencode",
+          status: "stopped",
+          active: false,
+          totalTokens: 6100,
+          usageState: "estimated",
+        },
+      ],
+    },
+    {
+      taskId: "task-done",
+      taskTitle: "Already shipped",
+      status: "done",
+      roomId: "room-2",
+      activeAgentCount: 0,
+      multiParty: false,
+      participants: [
+        { kind: "orchestrator", id: "orchestrator", label: "Orchestrator" },
+      ],
+    },
+  ],
+};
+
+describe("OrchestratorRoomView", () => {
+  it("renders an empty state when there are no live rooms", () => {
+    render(<OrchestratorRoomView rooms={{ rooms: [] }} />);
+    expect(screen.getByText("No active task rooms.")).toBeTruthy();
+  });
+
+  it("hides terminal (done/failed/archived) rooms from the live board", () => {
+    render(<OrchestratorRoomView rooms={rooms} />);
+    const cards = screen.getAllByTestId("orchestrator-room-card");
+    // The "done" room is filtered out, only the active room remains.
+    expect(cards).toHaveLength(1);
+    expect(screen.getByText("Refactor the parser")).toBeTruthy();
+    expect(screen.queryByText("Already shipped")).toBeNull();
+  });
+
+  it("renders the swarm with the active tool surfaced and the live count", () => {
+    render(<OrchestratorRoomView rooms={rooms} />);
+    const card = screen.getByTestId("orchestrator-room-card");
+    // Active tool of the running sub-agent is surfaced.
+    expect(within(card).getByText("edit_file")).toBeTruthy();
+    // Both sub-agents render plus the two anchors.
+    expect(within(card).getByText("Ada")).toBeTruthy();
+    expect(within(card).getByText("Mara")).toBeTruthy();
+    expect(within(card).getByText("Orchestrator")).toBeTruthy();
+    expect(within(card).getByText("You")).toBeTruthy();
+    // Header total reflects the one live room's active agent count.
+    expect(screen.getByText("2 live")).toBeTruthy();
+  });
+
+  it("orders live sub-agents ahead of idle ones", () => {
+    render(<OrchestratorRoomView rooms={rooms} />);
+    const card = screen.getByTestId("orchestrator-room-card");
+    const rows = within(card).getAllByTestId("room-participant");
+    const labels = rows.map((row) => row.textContent ?? "");
+    const adaIdx = labels.findIndex((l) => l.includes("Ada"));
+    const maraIdx = labels.findIndex((l) => l.includes("Mara"));
+    // Ada is live (tool_running), Mara is stopped, so Ada must sort first.
+    expect(adaIdx).toBeLessThan(maraIdx);
+  });
+});

--- a/packages/ui/src/components/chat/widgets/agent-orchestrator-room-view.tsx
+++ b/packages/ui/src/components/chat/widgets/agent-orchestrator-room-view.tsx
@@ -1,0 +1,304 @@
+/**
+ * Presentational orchestrator ROOM view: renders each live coding-task room as
+ * a card with its swarm of participants (the orchestrator, the owning user, and
+ * every sub-agent) so an operator can see at a glance which agents are live,
+ * what each is doing, and the multi-party state of the room.
+ *
+ * Props-driven and free of any data-layer (`client`) import (the same split as
+ * `agent-orchestrator-accounts-view.tsx`) so it bundles for the browser and
+ * renders in Storybook / the screenshot harness across every state. The
+ * fetching container lives in `agent-orchestrator.tsx`.
+ */
+import { Bot, CircleUser, Users, Workflow, Wrench } from "lucide-react";
+import { useMemo } from "react";
+import type {
+  OrchestratorRoomParticipant,
+  OrchestratorRoomRoster,
+  OrchestratorRoomRosterOverview,
+} from "../../../api/client-types-cloud";
+import type { TranslateFn } from "../../../types";
+import { fallbackTranslate } from "./agent-orchestrator-accounts-view";
+import { EmptyWidgetState, WidgetSection } from "./shared";
+
+/** Sub-agent session statuses that mean the session is finished. Mirrors the
+ * orchestrator's TERMINAL_TASK_SESSION_STATUSES so a stopped agent reads as
+ * idle, never live. */
+const TERMINAL_SESSION_STATUSES: ReadonlySet<string> = new Set([
+  "stopped",
+  "completed",
+  "done",
+  "error",
+  "errored",
+  "cancelled",
+]);
+
+/** Task-room lifecycle states that mean the room is no longer working. */
+const TERMINAL_ROOM_STATUSES: ReadonlySet<string> = new Set([
+  "done",
+  "failed",
+  "archived",
+]);
+
+function roomStatusTone(status: string): string {
+  if (TERMINAL_ROOM_STATUSES.has(status)) return "bg-muted/50";
+  if (status === "blocked" || status === "failed") return "bg-destructive";
+  if (status === "waiting_on_user" || status === "validating") return "bg-warn";
+  if (status === "interrupted") return "bg-warn";
+  return "bg-ok";
+}
+
+/** A participant is "live" when it is a non-terminal, active sub-agent. The
+ * orchestrator and user rows are always-present anchors, not live workers. */
+function isLiveSubAgent(p: OrchestratorRoomParticipant): boolean {
+  if (p.kind !== "sub_agent") return false;
+  if (p.active === false) return false;
+  return !TERMINAL_SESSION_STATUSES.has(p.status ?? "");
+}
+
+function participantIcon(kind: OrchestratorRoomParticipant["kind"]) {
+  if (kind === "orchestrator") return Workflow;
+  if (kind === "user") return CircleUser;
+  return Bot;
+}
+
+/** Human-friendly status label for a sub-agent row. */
+function statusLabel(p: OrchestratorRoomParticipant, t: TranslateFn): string {
+  const status = p.status ?? "";
+  if (p.activeTool) {
+    return t("agentorchestrator.runningTool", {
+      defaultValue: "{{tool}}",
+      tool: p.activeTool,
+    });
+  }
+  if (status === "tool_running")
+    return t("agentorchestrator.statusToolRunning", {
+      defaultValue: "running tool",
+    });
+  if (status === "running" || status === "busy")
+    return t("agentorchestrator.statusWorking", { defaultValue: "working" });
+  if (status === "ready")
+    return t("agentorchestrator.statusReady", { defaultValue: "ready" });
+  if (TERMINAL_SESSION_STATUSES.has(status))
+    return t("agentorchestrator.statusDone", { defaultValue: "done" });
+  return status || t("agentorchestrator.statusIdle", { defaultValue: "idle" });
+}
+
+function ParticipantRow({
+  participant,
+  t,
+}: {
+  participant: OrchestratorRoomParticipant;
+  t: TranslateFn;
+}) {
+  const Icon = participantIcon(participant.kind);
+  const live = isLiveSubAgent(participant);
+  const isSubAgent = participant.kind === "sub_agent";
+  const tokens =
+    typeof participant.totalTokens === "number" && participant.totalTokens > 0
+      ? `${Math.round(participant.totalTokens / 1000)}k`
+      : null;
+
+  return (
+    <div
+      className="flex items-center gap-1.5 py-0.5"
+      data-testid="room-participant"
+    >
+      <span className="relative inline-flex shrink-0">
+        <Icon
+          className={`h-3.5 w-3.5 ${
+            isSubAgent ? (live ? "text-txt" : "text-muted/50") : "text-muted/70"
+          }`}
+        />
+        {isSubAgent ? (
+          <span
+            className={`absolute -bottom-0.5 -right-0.5 h-1.5 w-1.5 rounded-full ring-1 ring-bg ${
+              live ? "bg-ok" : "bg-muted/40"
+            }`}
+            role="img"
+            aria-label={
+              live
+                ? t("agentorchestrator.live", { defaultValue: "live" })
+                : t("agentorchestrator.statusIdle", { defaultValue: "idle" })
+            }
+          />
+        ) : null}
+      </span>
+      <span
+        className={`truncate font-medium ${
+          isSubAgent && !live ? "text-muted" : "text-txt"
+        }`}
+      >
+        {participant.label}
+      </span>
+      {participant.framework ? (
+        <span className="shrink-0 rounded-full bg-muted/10 px-1.5 py-0.5 text-3xs text-muted/70">
+          {participant.framework}
+        </span>
+      ) : null}
+      {isSubAgent ? (
+        <span
+          className={`ml-auto flex shrink-0 items-center gap-1 text-3xs ${
+            participant.activeTool ? "text-accent" : "text-muted/70"
+          }`}
+        >
+          {participant.activeTool ? <Wrench className="h-3 w-3" /> : null}
+          <span className="max-w-[7rem] truncate">
+            {statusLabel(participant, t)}
+          </span>
+        </span>
+      ) : null}
+      {tokens ? (
+        <span className="shrink-0 tabular-nums text-3xs text-muted/60">
+          {tokens}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+function RoomCard({
+  room,
+  t,
+}: {
+  room: OrchestratorRoomRoster;
+  t: TranslateFn;
+}) {
+  // Orchestrator + user anchors first, then sub-agents (live before idle) so
+  // the working swarm reads top-down without re-sorting the wire order.
+  const orderedParticipants = useMemo(() => {
+    const anchors = room.participants.filter((p) => p.kind !== "sub_agent");
+    const subAgents = room.participants
+      .filter((p) => p.kind === "sub_agent")
+      .slice()
+      .sort((a, b) => Number(isLiveSubAgent(b)) - Number(isLiveSubAgent(a)));
+    return [...anchors, ...subAgents];
+  }, [room.participants]);
+
+  return (
+    <div
+      className="space-y-1.5 rounded-sm border border-border/50 bg-bg-accent/30 p-2"
+      data-testid="orchestrator-room-card"
+    >
+      <div className="flex items-center gap-1.5">
+        <span
+          className={`h-1.5 w-1.5 shrink-0 rounded-full ${roomStatusTone(room.status)}`}
+          role="img"
+          aria-label={room.status}
+          title={room.status}
+        />
+        <span className="truncate text-2xs font-semibold text-txt">
+          {room.taskTitle}
+        </span>
+        <span className="ml-auto flex shrink-0 items-center gap-1 text-3xs text-muted">
+          {room.multiParty ? (
+            <Users
+              className="h-3 w-3"
+              aria-label={t("agentorchestrator.multiPartyRoom", {
+                defaultValue: "Multi-party room",
+              })}
+            />
+          ) : null}
+          <span
+            className="tabular-nums"
+            title={t("agentorchestrator.activeAgents", {
+              defaultValue: "{{count}} active",
+              count: room.activeAgentCount,
+            })}
+          >
+            {room.activeAgentCount}
+          </span>
+        </span>
+      </div>
+      <div className="space-y-0.5">
+        {orderedParticipants.map((p) => (
+          <ParticipantRow
+            key={`${room.taskId}:${p.kind}:${p.id}`}
+            participant={p}
+            t={t}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export interface OrchestratorRoomViewProps {
+  rooms: OrchestratorRoomRosterOverview | null;
+  t?: TranslateFn;
+}
+
+/**
+ * The live room swarm: one card per task room, each showing the room title +
+ * status, an active-agent count, a multi-party indicator, and the participant
+ * roster (orchestrator + user + sub-agents with their framework, live state,
+ * active tool, and token usage).
+ */
+export function OrchestratorRoomView({
+  rooms,
+  t = fallbackTranslate,
+}: OrchestratorRoomViewProps) {
+  // Surface every non-terminal room so an operator sees the full live board, not
+  // just rooms that currently have a busy worker (an idle room still matters).
+  const liveRooms = useMemo(
+    () =>
+      (rooms?.rooms ?? []).filter(
+        (room) => !TERMINAL_ROOM_STATUSES.has(room.status),
+      ),
+    [rooms],
+  );
+
+  const totalActive = useMemo(
+    () => liveRooms.reduce((n, room) => n + room.activeAgentCount, 0),
+    [liveRooms],
+  );
+
+  if (liveRooms.length === 0) {
+    return (
+      <WidgetSection
+        title={t("agentorchestrator.rooms", { defaultValue: "Task rooms" })}
+        icon={<Users className="h-4 w-4" />}
+        testId="chat-widget-rooms"
+      >
+        <EmptyWidgetState
+          icon={<Users className="h-5 w-5" />}
+          title={t("agentorchestrator.noRooms", {
+            defaultValue: "No active task rooms.",
+          })}
+          description={t("agentorchestrator.noRoomsHint", {
+            defaultValue:
+              "Sub-agents spawned for a coding task appear here as a live swarm.",
+          })}
+        />
+      </WidgetSection>
+    );
+  }
+
+  return (
+    <WidgetSection
+      title={t("agentorchestrator.rooms", { defaultValue: "Task rooms" })}
+      icon={<Users className="h-4 w-4" />}
+      action={
+        <span
+          className="shrink-0 rounded-full bg-muted/15 px-1.5 py-0.5 text-3xs font-medium text-muted"
+          title={t("agentorchestrator.activeAgentsTotal", {
+            defaultValue: "{{count}} active across {{rooms}} rooms",
+            count: totalActive,
+            rooms: liveRooms.length,
+          })}
+        >
+          {t("agentorchestrator.activeShort", {
+            defaultValue: "{{count}} live",
+            count: totalActive,
+          })}
+        </span>
+      }
+      testId="chat-widget-rooms"
+    >
+      <div className="space-y-2" data-testid="orchestrator-room-list">
+        {liveRooms.map((room) => (
+          <RoomCard key={room.taskId} room={room} t={t} />
+        ))}
+      </div>
+    </WidgetSection>
+  );
+}

--- a/packages/ui/src/components/chat/widgets/agent-orchestrator.tsx
+++ b/packages/ui/src/components/chat/widgets/agent-orchestrator.tsx
@@ -64,6 +64,7 @@ import {
   fallbackTranslate,
   OrchestratorAccountsView,
 } from "./agent-orchestrator-accounts-view";
+import { OrchestratorRoomView } from "./agent-orchestrator-room-view";
 import { HomeWidgetCard, useWidgetNavigation } from "./home-widget-card";
 import { EmptyWidgetState, WidgetSection } from "./shared";
 import type {
@@ -766,6 +767,45 @@ function OrchestratorAccountsWidget(_props: ChatSidebarWidgetProps) {
   );
 }
 
+/**
+ * The live room swarm: every active coding-task room and the orchestrator +
+ * sub-agents working inside it. A room-scoped sibling to the accounts widget:
+ * accounts answers "who's connected and how much have they spent", rooms answers
+ * "which agents are live in which task right now and what is each doing".
+ */
+function OrchestratorRoomWidget(_props: ChatSidebarWidgetProps) {
+  const { t: appT } = useAppSelectorShallow((s) => ({ t: s.t }));
+  const t = appT ?? fallbackTranslate;
+  const [rooms, setRooms] = useState<OrchestratorRoomRosterOverview | null>(
+    null,
+  );
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    try {
+      const next = await client.getOrchestratorRooms();
+      setRooms(next);
+    } catch {
+      // Leave the last good roster in place on a transient poll failure.
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  // Same visibility-gated cadence as the accounts widget so a backgrounded
+  // window stops polling the orchestrator API.
+  useIntervalWhenDocumentVisible(() => void refresh(), 15_000);
+
+  if (loading) return null;
+  if ((rooms?.rooms?.length ?? 0) === 0) return null;
+
+  return <OrchestratorRoomView rooms={rooms} t={t} />;
+}
+
 export const AGENT_ORCHESTRATOR_PLUGIN_WIDGETS: ChatSidebarWidgetDefinition[] =
   [
     {
@@ -781,6 +821,13 @@ export const AGENT_ORCHESTRATOR_PLUGIN_WIDGETS: ChatSidebarWidgetDefinition[] =
       order: 250,
       defaultEnabled: true,
       Component: OrchestratorAccountsWidget,
+    },
+    {
+      id: "agent-orchestrator.rooms",
+      pluginId: "agent-orchestrator",
+      order: 275,
+      defaultEnabled: true,
+      Component: OrchestratorRoomWidget,
     },
     {
       id: "agent-orchestrator.activity",


### PR DESCRIPTION
## Summary
Adds the **orchestrator room view**: a live widget that renders each coding-task room and the swarm of agents inside it (orchestrator + sub-agents), so you can watch your agents work at a glance.

## What it shows
- One card per live task room: task title + status, an active-agent count, a multi-party indicator.
- Per participant: role icon (orchestrator / user / bot), a live/idle status dot, framework tag, the active tool it's running (accent + wrench), and token usage.
- Live sub-agents sort above idle; terminal rooms are filtered out.

## Integration
- Registered as widget `agent-orchestrator.rooms` (order 275) in the orchestrator widget set, so it renders in the chat sidebar between Accounts (250) and Activity (300). Self-hides while loading and when no room is live, matching the existing app-runs/activity widgets.
- Consumes the existing `client.getOrchestratorRooms()` (`GET /api/orchestrator/rooms`) with the same `useIntervalWhenDocumentVisible(15s)` poll the accounts widget uses. No new data layer, no client method added, **no backend touched**.
- Presentational/container split mirrors the existing accounts view; reuses the established tokens + primitives.

## Tests
- new component test (4/4), Storybook story with Empty / LiveRooms / MultiPartyRoom fixtures
- biome clean, tsc clean on changed files
- (codex review did not converge on the CI/VPS env; hand-reviewed for pattern-match + no backend edits + reachability)

## Pairs with
The backend that mints these distinct task rooms: #10256
