### PR TITLE
fix(ui): surface failureKind on empty replies instead of silent drop (#10231)

### DIFF
--- a/packages/ui/src/state/useChatSend.test.tsx
+++ b/packages/ui/src/state/useChatSend.test.tsx
@@ -819,3 +819,60 @@ describe("useChatSend retry re-runs the turn in place (no duplicate)", () => {
     expect(mocks.client.sendConversationMessageStream).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("useChatSend empty-reply failure surfacing (#10231)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.client.getBaseUrl.mockReturnValue("");
+  });
+
+  it("surfaces a failureKind gate (not a silent drop) when the streamed terminal reply is empty", async () => {
+    // Regression: the empty-text terminal handler dropped any empty reply
+    // unconditionally, so an empty-text + failureKind response (e.g. the
+    // "Connect a provider" gate) vanished with no error. It must stamp the
+    // failureKind onto the assistant turn instead.
+    mocks.client.sendConversationMessageStream.mockImplementation(async () => ({
+      text: "",
+      completed: true,
+      failureKind: "no_provider",
+    }));
+
+    const deps = makeDeps({
+      activeConversationId: "conv-1",
+      conversations: [conversation("conv-1", "room-1")],
+    });
+    const { result } = renderHook(() => useChatSend(deps));
+
+    await act(async () => {
+      await result.current.sendChatText("hi", { conversationId: "conv-1" });
+    });
+
+    const assistant = deps.conversationMessagesRef.current.filter(
+      (m) => m.role === "assistant",
+    );
+    expect(assistant.length).toBe(1);
+    expect(assistant[0]?.failureKind).toBe("no_provider");
+  });
+
+  it("still drops an empty terminal reply that carries no failureKind", async () => {
+    mocks.client.sendConversationMessageStream.mockImplementation(async () => ({
+      text: "",
+      completed: true,
+    }));
+
+    const deps = makeDeps({
+      activeConversationId: "conv-1",
+      conversations: [conversation("conv-1", "room-1")],
+    });
+    const { result } = renderHook(() => useChatSend(deps));
+
+    await act(async () => {
+      await result.current.sendChatText("hi", { conversationId: "conv-1" });
+    });
+
+    const assistant = deps.conversationMessagesRef.current.filter(
+      (m) => m.role === "assistant",
+    );
+    expect(assistant.length).toBe(0);
+  });
+});

--- a/packages/ui/src/state/useChatSend.ts
+++ b/packages/ui/src/state/useChatSend.ts
@@ -971,10 +971,22 @@ export function useChatSend(deps: UseChatSendDeps) {
         flushStreamingText();
 
         if (!data.text.trim()) {
-          applyStreamingTextModification(setConversationMessages, {
-            messageId: assistantMsgId,
-            mode: "drop",
-          });
+          if (data.failureKind) {
+            // Empty reply but the server flagged a failure class — surface the
+            // gate UI (e.g. "Connect a provider") instead of silently dropping
+            // the turn. The failure branch below is an `else if`, unreachable
+            // once the text is empty, so it must be handled here.
+            applyStreamingTextModification(setConversationMessages, {
+              messageId: assistantMsgId,
+              mode: "fail",
+              failureKind: data.failureKind,
+            });
+          } else {
+            applyStreamingTextModification(setConversationMessages, {
+              messageId: assistantMsgId,
+              mode: "drop",
+            });
+          }
         } else if (
           shouldApplyFinalStreamText(streamedAssistantText, data.text) ||
           data.reasoning
@@ -1490,10 +1502,22 @@ export function useChatSend(deps: UseChatSendDeps) {
           flushStreamingText();
 
           if (!data.text.trim()) {
-            applyStreamingTextModification(setConversationMessages, {
-              messageId: assistantMsgId,
-              mode: "drop",
-            });
+            if (data.failureKind) {
+              // Empty reply but the server flagged a failure class — surface the
+              // gate UI instead of silently dropping the turn (the failure
+              // branch below is an `else if`, unreachable once the text is
+              // empty). Mirrors the non-terminal handler above.
+              applyStreamingTextModification(setConversationMessages, {
+                messageId: assistantMsgId,
+                mode: "fail",
+                failureKind: data.failureKind,
+              });
+            } else {
+              applyStreamingTextModification(setConversationMessages, {
+                messageId: assistantMsgId,
+                mode: "drop",
+              });
+            }
           } else if (
             shouldApplyFinalStreamText(streamedAssistantText, data.text)
           ) {


### PR DESCRIPTION
## Summary

Both empty-text reply handlers in `useChatSend` dropped the assistant turn unconditionally, leaving the `else if (data.failureKind)` failure branch **unreachable** once the text is empty. An empty-text + `failureKind` response (e.g. the `no_provider` *"Connect a provider"* gate, emitted server-side) therefore vanished with no error — the user saw nothing.

This guards **both** handlers (the non-terminal one and the terminal streaming one) to stamp the `failureKind` (mode `fail`) instead of dropping.

## Why this isn't already fixed

#10229 targeted this bug but was closed as *superseded*. The supersession was incomplete: the JWT-scrub hunk landed via #10251, and #10031 round-tripped `failureKind` for **retry**, but neither touched the empty-reply drop. Verified against current `develop`: both `if (!data.text.trim()) { … mode: "drop" }` branches are still unconditional.

## Tests

`useChatSend.test.tsx` (drives the real hook via `renderHook` + the streaming client mock):
- empty terminal reply **with** `failureKind` → assistant turn survives and carries `failureKind: "no_provider"` (gate surfaced).
- empty terminal reply **without** `failureKind` → still dropped (no regression).

`bun run --cwd packages/ui test -- src/state/useChatSend.test.tsx` → 17 passed.

Refs #10231. Supersedes the empty-reply hunk of closed #10229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)