### PR TITLE
test(ui): attribute swipe direction + cover dispatch path in conversation-swipe jank telemetry (#9954 item 6)

### DIFF
--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -1093,12 +1093,14 @@ export function ContinuousChatOverlay({
     },
     onSwipeLeft: () => {
       setSwipeDx(0);
-      swipeJank.end();
+      // Tag the flushed window with the committed direction so the ring shows
+      // which way a janky swipe went (left → "next", the older conversation).
+      swipeJank.end("next");
       conversationNav.goNext();
     },
     onSwipeRight: () => {
       setSwipeDx(0);
-      swipeJank.end();
+      swipeJank.end("prev");
       conversationNav.goPrev();
     },
   });

--- a/packages/ui/src/hooks/useConversationSwipeJank.test.ts
+++ b/packages/ui/src/hooks/useConversationSwipeJank.test.ts
@@ -4,6 +4,7 @@ import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   readViewInteractions,
+  VIEW_INTERACTION_TELEMETRY_EVENT,
   type ViewInteractionEvent,
 } from "../view-telemetry";
 import { useConversationSwipeJank } from "./useConversationSwipeJank";
@@ -12,6 +13,7 @@ import { useConversationSwipeJank } from "./useConversationSwipeJank";
 // without waiting on the real display refresh.
 let rafQueue: Array<(t: number) => void> = [];
 let now = 0;
+let canceledFrames = 0;
 
 function flushFrame(deltaMs: number) {
   now += deltaMs;
@@ -30,12 +32,15 @@ function resetRing() {
 beforeEach(() => {
   rafQueue = [];
   now = 0;
+  canceledFrames = 0;
   resetRing();
   globalThis.requestAnimationFrame = ((cb: (t: number) => void) => {
     rafQueue.push(cb);
     return rafQueue.length;
   }) as typeof requestAnimationFrame;
-  globalThis.cancelAnimationFrame = (() => {}) as typeof cancelAnimationFrame;
+  globalThis.cancelAnimationFrame = (() => {
+    canceledFrames += 1;
+  }) as typeof cancelAnimationFrame;
 });
 
 afterEach(() => {
@@ -130,5 +135,64 @@ describe("useConversationSwipeJank", () => {
     expect(events).toHaveLength(2);
     // Second gesture's window did not inherit the first gesture's janky frame.
     expect(events[1].frameBudget?.droppedFrames).toBe(0);
+  });
+
+  it("tags the emitted event with the committed swipe direction", () => {
+    const { result } = renderHook(() => useConversationSwipeJank());
+
+    act(() => result.current.begin());
+    act(() => flushFrame(0));
+    act(() => flushFrame(16));
+    act(() => result.current.end("next"));
+
+    expect(swipeJankEvents()[0].direction).toBe("next");
+  });
+
+  it("omits direction when a drag settled back without committing a swipe", () => {
+    const { result } = renderHook(() => useConversationSwipeJank());
+
+    act(() => result.current.begin());
+    act(() => flushFrame(0));
+    act(() => flushFrame(16));
+    // A cancelled drag (onDragX settle to 0) flushes with no direction.
+    act(() => result.current.end());
+
+    expect(swipeJankEvents()[0].direction).toBeUndefined();
+  });
+
+  it("dispatches the window CustomEvent with the full summary and direction", () => {
+    const { result } = renderHook(() => useConversationSwipeJank());
+    const seen: ViewInteractionEvent[] = [];
+    const handler = (e: Event) => {
+      seen.push((e as CustomEvent<ViewInteractionEvent>).detail);
+    };
+    window.addEventListener(VIEW_INTERACTION_TELEMETRY_EVENT, handler);
+
+    act(() => result.current.begin());
+    act(() => flushFrame(0));
+    act(() => flushFrame(120)); // dropped frame
+    act(() => result.current.end("prev"));
+
+    window.removeEventListener(VIEW_INTERACTION_TELEMETRY_EVENT, handler);
+    expect(seen).toHaveLength(1);
+    expect(seen[0].action).toBe("conversation-swipe-jank");
+    expect(seen[0].direction).toBe("prev");
+    expect(seen[0].frameBudget?.worstFrameMs).toBeGreaterThanOrEqual(120);
+    expect(seen[0].frameBudget?.droppedFrames).toBeGreaterThanOrEqual(1);
+  });
+
+  it("stops an in-flight sampler when the overlay unmounts mid-gesture", () => {
+    const { result, unmount } = renderHook(() => useConversationSwipeJank());
+
+    act(() => result.current.begin());
+    act(() => flushFrame(0));
+    act(() => flushFrame(16));
+    expect(canceledFrames).toBe(0);
+
+    // Unmounting mid-gesture (end never called) must cancel the running rAF so
+    // no sampling loop dangles, and must not emit a telemetry event.
+    unmount();
+    expect(canceledFrames).toBeGreaterThan(0);
+    expect(swipeJankEvents()).toHaveLength(0);
   });
 });

--- a/packages/ui/src/hooks/useConversationSwipeJank.ts
+++ b/packages/ui/src/hooks/useConversationSwipeJank.ts
@@ -19,8 +19,12 @@ import { type FrameBudget, FrameBudgetSampler } from "./frame-budget";
 export interface ConversationSwipeJankHandle {
   /** Begin sampling — call when a swipe gesture starts driving the drag. */
   begin: () => void;
-  /** Flush the sampled window as a telemetry event and stop sampling. */
-  end: () => void;
+  /**
+   * Flush the sampled window as a telemetry event and stop sampling. Pass the
+   * committed swipe `direction` ("prev"/"next") so the emitted event attributes
+   * the jank to a navigation; omit it for a cancelled drag that settled back.
+   */
+  end: (direction?: "prev" | "next") => void;
 }
 
 /**
@@ -50,7 +54,7 @@ export function useConversationSwipeJank(
     sampler.start();
   }, [getSampler]);
 
-  const end = useCallback(() => {
+  const end = useCallback((direction?: "prev" | "next") => {
     const sampler = samplerRef.current;
     if (!sampler?.running) return;
     const summary = sampler.summary();
@@ -59,7 +63,7 @@ export function useConversationSwipeJank(
     // pointer with no rAF tick) yields an empty window — nothing meaningful to
     // report, so skip the event rather than emit a zeroed summary.
     if (summary.sampleCount === 0) return;
-    emitConversationSwipeJank(summary);
+    emitConversationSwipeJank(summary, direction);
   }, []);
 
   // Stop any in-flight sampler if the overlay unmounts mid-gesture.

--- a/packages/ui/src/view-telemetry.test.ts
+++ b/packages/ui/src/view-telemetry.test.ts
@@ -1,11 +1,25 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { FrameBudgetSummary } from "./hooks/frame-budget";
 import {
+  emitConversationSwipeJank,
   emitViewInteraction,
   readViewInteractions,
   VIEW_INTERACTION_RING_MAX,
   VIEW_INTERACTION_TELEMETRY_EVENT,
+  type ViewInteractionEvent,
 } from "./view-telemetry";
+
+const SAMPLE_SUMMARY: FrameBudgetSummary = {
+  sampleCount: 8,
+  fps: 42,
+  meanFrameMs: 23.8,
+  p95FrameMs: 48,
+  worstFrameMs: 120,
+  droppedFrames: 3,
+  longTasks: 1,
+  budgetMs: 16.67,
+};
 
 function clearRing() {
   (
@@ -65,5 +79,38 @@ describe("view-telemetry", () => {
     expect(events[events.length - 1].count).toBe(
       VIEW_INTERACTION_RING_MAX + 24,
     );
+  });
+
+  it("retains a conversation-swipe-jank summary + direction into the ring and CustomEvent", () => {
+    const seen: ViewInteractionEvent[] = [];
+    const handler = (e: Event) => {
+      seen.push((e as CustomEvent<ViewInteractionEvent>).detail);
+    };
+    window.addEventListener(VIEW_INTERACTION_TELEMETRY_EVENT, handler);
+
+    emitConversationSwipeJank(SAMPLE_SUMMARY, "next");
+
+    window.removeEventListener(VIEW_INTERACTION_TELEMETRY_EVENT, handler);
+
+    const latest = readViewInteractions().at(-1);
+    expect(latest).toMatchObject({
+      source: "conversation-swipe",
+      action: "conversation-swipe-jank",
+      direction: "next",
+      // Headline dropped-frame count is surfaced on `count` for ring scanners.
+      count: SAMPLE_SUMMARY.droppedFrames,
+    });
+    // The full frame-budget summary survives intact into the ring…
+    expect(latest?.frameBudget?.droppedFrames).toBe(3);
+    expect(latest?.frameBudget?.p95FrameMs).toBe(48);
+    // …and the dispatched CustomEvent carries the same payload.
+    expect(seen).toHaveLength(1);
+    expect(seen[0].direction).toBe("next");
+    expect(seen[0].frameBudget?.worstFrameMs).toBe(120);
+  });
+
+  it("omits direction for a cancelled (uncommitted) swipe window", () => {
+    emitConversationSwipeJank(SAMPLE_SUMMARY);
+    expect(readViewInteractions().at(-1)?.direction).toBeUndefined();
   });
 });

--- a/packages/ui/src/view-telemetry.ts
+++ b/packages/ui/src/view-telemetry.ts
@@ -48,6 +48,14 @@ export interface ViewInteractionEvent {
   /** Result count (for search) or page index (for page-swipe/reorder). */
   count?: number;
   /**
+   * Swipe direction for a `conversation-swipe-jank` event (#9954): `"prev"`
+   * navigates toward the newer conversation, `"next"` toward the older one (same
+   * meaning as {@link ./components/shell/conversation-nav}'s direction). Lets a
+   * ring reader attribute jank to a specific swipe direction without unpacking
+   * `frameBudget`. Present only on `conversation-swipe-jank`.
+   */
+  direction?: "prev" | "next";
+  /**
    * Frame-budget summary for a `conversation-swipe-jank` event (#9954) — the
    * same {@link FrameBudgetSummary} the frame-budget HUD reads, so the dropped-
    * frame %, p95 frame time, and long-task counts are computed by one source of
@@ -117,12 +125,18 @@ export function readViewInteractions(): ViewInteractionEvent[] {
  * gesture (#9954). The `count` field carries the dropped-frame count so a reader
  * scanning the ring sees the headline number without unpacking `frameBudget`;
  * the full summary (p95 frame time, fps, long tasks) rides in `frameBudget`.
+ * `direction` (when the swipe committed a navigation) attributes the window to a
+ * `"prev"`/`"next"` swipe; it is omitted for a cancelled drag that settled back.
  */
-export function emitConversationSwipeJank(summary: FrameBudgetSummary): void {
+export function emitConversationSwipeJank(
+  summary: FrameBudgetSummary,
+  direction?: ViewInteractionEvent["direction"],
+): void {
   emitViewInteraction({
     source: "conversation-swipe",
     action: "conversation-swipe-jank",
     count: summary.droppedFrames,
     frameBudget: summary,
+    ...(direction ? { direction } : {}),
   });
 }


### PR DESCRIPTION
Builds on #10156's conversation-swipe jank telemetry (already on develop). Net-new value:
- Adds optional `direction?: "prev"|"next"` to the emitted event (additive-widen), threaded overlay swipe handlers → `useConversationSwipeJank.end(direction)` → `emitConversationSwipeJank`.
- Closes the real coverage gaps the existing tests missed: the CustomEvent **dispatch path** carrying the full frame-budget summary + direction, unmount-mid-gesture sampler teardown, cancelled-drag omits direction, and view-telemetry ring/CustomEvent retention.

14 tests pass (8 pre-existing + 6 new); useShellController (38) + overlay flow suites (17) green; `packages/ui` typecheck 0 errors; biome clean. Adversarial verdict: PASS. Test/telemetry-only, no behavior change.

Follow-up (flagged, out of scope): the sampler window currently ends *before* the conversation-switch re-render, so it misses the heaviest post-switch paint jank — extending it needs a settle window that would break the synchronous-emit contract.