### PR TITLE
fix(cloud): type domain buy test responses

### DIFF
--- a/packages/cloud/api/__tests__/domains-buy-credit-debit.test.ts
+++ b/packages/cloud/api/__tests__/domains-buy-credit-debit.test.ts
@@ -154,6 +154,12 @@ const { default: buyRoute } = await import("../v1/apps/[id]/domains/buy/route");
 const app = new Hono();
 app.route("/api/v1/apps/:id/domains/buy", buyRoute);
 
+type DomainBuyResponseBody = {
+  success?: boolean;
+  code?: string;
+  domain?: string;
+};
+
 function buy(domain = "example.com", appId = "app-1") {
   return app.request(`/api/v1/apps/${appId}/domains/buy`, {
     method: "POST",
@@ -225,7 +231,7 @@ describe("POST /apps/:id/domains/buy — credit debit gates registration", () =>
     });
 
     const res = await buy();
-    const body = await res.json();
+    const body = (await res.json()) as DomainBuyResponseBody;
 
     expect(res.status).toBe(402);
     expect(body.success).toBe(false);
@@ -245,7 +251,7 @@ describe("POST /apps/:id/domains/buy — credit debit gates registration", () =>
     });
 
     const res = await buy();
-    const body = await res.json();
+    const body = (await res.json()) as DomainBuyResponseBody;
 
     expect(res.status).toBe(402);
     expect(body.success).toBe(false);
@@ -263,7 +269,7 @@ describe("POST /apps/:id/domains/buy — credit debit gates registration", () =>
     });
 
     const res = await buy();
-    const body = await res.json();
+    const body = (await res.json()) as DomainBuyResponseBody;
 
     expect(res.status).toBe(402);
     expect(body.code).toBe("org_not_found");
@@ -280,7 +286,7 @@ describe("POST /apps/:id/domains/buy — credit debit gates registration", () =>
     registerDomain.mockResolvedValue({ registrationId: "reg-1" });
 
     const res = await buy();
-    const body = await res.json();
+    const body = (await res.json()) as DomainBuyResponseBody;
 
     expect(res.status).toBe(200);
     expect(body.success).toBe(true);


### PR DESCRIPTION
## Summary

Fixes the Cloud API deploy typecheck failure in `domains-buy-credit-debit.test.ts` by typing the four `res.json()` bodies used by the new domain-buy debit regression tests.

## Root Cause

`Response.json()` is typed as `unknown` under the current Cloud API TypeScript settings. The test asserted `body.success`, `body.code`, and `body.domain` without narrowing or casting, causing TS18046 during the Cloud CF deploy job.

## Validation

- `git diff --check`
- `bun test packages/cloud/api/__tests__/domains-buy-credit-debit.test.ts` -> 4 tests passed / 22 assertions
- Re-ran `packages/cloud/api typecheck` locally enough to confirm the previous `domains-buy-credit-debit.test.ts` TS18046 errors no longer appear. Full local package typecheck is noisy in the temp worktree because dependency symlink/install state does not match CI; CI should be authoritative for the clean runner.

This is intentionally test-only and has no runtime behavior change.
