### PR TITLE
fix(cloud): don't double-refund the reservation on a post-settlement earnings error (MCP/A2A)

### DIFF
--- a/packages/cloud/api/agents/[id]/a2a/route.ts
+++ b/packages/cloud/api/agents/[id]/a2a/route.ts
@@ -369,24 +369,43 @@ async function handleChat(
     }
 
     if (character.monetization_enabled && actualCreatorMarkup > 0) {
-      await agentMonetizationService.recordCreatorEarnings({
-        agentId: character.id,
-        agentName: character.name,
-        ownerId: character.user_id,
-        earnings: actualCreatorMarkup,
-        consumerOrgId: authUser.organization_id,
-        model,
-        tokens: usage?.totalTokens,
-        protocol: "a2a",
-      });
-      logger.info(
-        "[Agent A2A] Creator earnings credited to redeemable balance",
-        {
+      // Earnings recording is a NON-CRITICAL post-settlement step. The consumer
+      // was already settled above (reconcile(actualTotal)); if this throws it
+      // must NOT propagate to the outer catch, whose reconcile(0) is
+      // non-idempotent and would refund the WHOLE reservation a second time →
+      // free inference + a net credit grant. Log and swallow.
+      try {
+        await agentMonetizationService.recordCreatorEarnings({
           agentId: character.id,
+          agentName: character.name,
           ownerId: character.user_id,
           earnings: actualCreatorMarkup,
-        },
-      );
+          consumerOrgId: authUser.organization_id,
+          model,
+          tokens: usage?.totalTokens,
+          protocol: "a2a",
+        });
+        logger.info(
+          "[Agent A2A] Creator earnings credited to redeemable balance",
+          {
+            agentId: character.id,
+            ownerId: character.user_id,
+            earnings: actualCreatorMarkup,
+          },
+        );
+      } catch (earningsError) {
+        logger.error(
+          "[Agent A2A] Failed to record creator earnings (settlement already applied — not rolling back)",
+          {
+            agentId: character.id,
+            ownerId: character.user_id,
+            error:
+              earningsError instanceof Error
+                ? earningsError.message
+                : String(earningsError),
+          },
+        );
+      }
     }
 
     return c.json({

--- a/packages/cloud/api/agents/[id]/mcp/route.ts
+++ b/packages/cloud/api/agents/[id]/mcp/route.ts
@@ -407,24 +407,44 @@ export async function handleToolCall(
       }
 
       if (character.monetization_enabled && actualCreatorMarkup > 0) {
-        await agentMonetizationService.recordCreatorEarnings({
-          agentId: character.id,
-          agentName: character.name,
-          ownerId: character.user_id,
-          earnings: actualCreatorMarkup,
-          consumerOrgId: authUser.organization_id,
-          model,
-          tokens: (usage?.inputTokens || 0) + (usage?.outputTokens || 0),
-          protocol: "mcp",
-        });
-        logger.info(
-          "[Agent MCP] Creator earnings credited to redeemable balance",
-          {
+        // Earnings recording is a NON-CRITICAL post-settlement step. The consumer
+        // was already settled above (reconcile(actualTotal)); if this throws it
+        // must NOT propagate to the outer catch, whose reconcile(0) is
+        // non-idempotent and would refund the WHOLE reservation a second time →
+        // free inference + a net credit grant (and the creator may already be
+        // credited). Log and swallow, matching processUsage's documented intent.
+        try {
+          await agentMonetizationService.recordCreatorEarnings({
             agentId: character.id,
+            agentName: character.name,
             ownerId: character.user_id,
             earnings: actualCreatorMarkup,
-          },
-        );
+            consumerOrgId: authUser.organization_id,
+            model,
+            tokens: (usage?.inputTokens || 0) + (usage?.outputTokens || 0),
+            protocol: "mcp",
+          });
+          logger.info(
+            "[Agent MCP] Creator earnings credited to redeemable balance",
+            {
+              agentId: character.id,
+              ownerId: character.user_id,
+              earnings: actualCreatorMarkup,
+            },
+          );
+        } catch (earningsError) {
+          logger.error(
+            "[Agent MCP] Failed to record creator earnings (settlement already applied — not rolling back)",
+            {
+              agentId: character.id,
+              ownerId: character.user_id,
+              error:
+                earningsError instanceof Error
+                  ? earningsError.message
+                  : String(earningsError),
+            },
+          );
+        }
       }
 
       return c.json({


### PR DESCRIPTION
Found by the cloud money-paths deep-scan, adversarially verified. Identical bug in two live monetized routes (`agents/[id]/mcp` + `agents/[id]/a2a`).

## Problem
Both chat paths settle the consumer with `reservation.reconcile(actualTotal)`, then call `recordCreatorEarnings()` **inside the same try**. `recordCreatorEarnings` can throw (its `addEarnings` transaction, or the subsequent unguarded `userCharacters` `dbWrite.update`, reject on any transient DB error). The outer catch then runs **`reservation.reconcile(0)`** — but `reconcile()` is **non-idempotent** (pure function of reserved/actual, no `settled` guard), so it refunds the **whole reservation a second time** → net consumer charge = `actualTotal - reservedAmount` (**free inference, often a net credit grant**), while the creator may already have been credited the markup (platform pays both sides).

## Fix
Wrap `recordCreatorEarnings` (a non-critical post-settlement step) in its own try/catch that logs + swallows — matching `processUsage`'s documented "don't fail the request on earnings failure" intent — so an earnings-recording failure can never reach the outer `reconcile(0)`. Settlement already happened correctly; the earnings write is best-effort.

Money path — flagging for review. Two files, same fix.