### PR TITLE
fix(cloud-sdk): container-create dropped ELIZA_APP_ID (camelCase) + typed app SDK methods

### DIFF
--- a/packages/cloud/api/__tests__/containers-create-contract.test.ts
+++ b/packages/cloud/api/__tests__/containers-create-contract.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Container create/update wire-contract tests.
+ *
+ * Proves the fix for the casing bug that silently dropped `ELIZA_APP_ID`:
+ * the `@elizaos/cloud-sdk` request types are camelCase, and the server zod
+ * schema (the source of truth, here imported directly — no mock) is camelCase
+ * too, so an SDK-shaped body now round-trips with every field intact. The
+ * regression cases reproduce the original bug: a snake_case body parses
+ * "successfully" but with `projectName`, `environmentVars` (and thus
+ * `ELIZA_APP_ID`), `memoryMb`, and `healthCheckPath` silently stripped.
+ *
+ * The bodies below are the exact shapes the SDK serializes for
+ * `createContainer(req: CreateContainerRequest)` and
+ * `updateContainer(id, req: UpdateContainerRequest)` — those types are pinned
+ * to these keys by the compile-time test in
+ * `packages/cloud/sdk/src/client.test.ts`.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  CreateContainerSchema,
+  PatchContainerSchema,
+} from "../v1/containers/schema";
+
+describe("POST /api/v1/containers — create contract (casing bug fix)", () => {
+  test("a camelCase SDK body round-trips with ELIZA_APP_ID and projectName intact", () => {
+    // Exactly what ElizaCloudClient.createContainer puts on the wire for the
+    // fixed CreateContainerRequest type.
+    const sdkBody = {
+      name: "My App",
+      image: "ghcr.io/elizaos/my-app:latest",
+      projectName: "my-app",
+      port: 3000,
+      cpu: 1792,
+      memoryMb: 1792,
+      environmentVars: { ELIZA_APP_ID: "app_abc123", FOO: "bar" },
+      healthCheckPath: "/health",
+    };
+    // Simulate the JSON transit the Worker performs (c.req.json()).
+    const wire = JSON.parse(JSON.stringify(sdkBody));
+
+    const parsed = CreateContainerSchema.safeParse(wire);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+
+    // The two fields the bug dropped now survive end to end.
+    expect(parsed.data.projectName).toBe("my-app");
+    expect(parsed.data.environmentVars?.ELIZA_APP_ID).toBe("app_abc123");
+    // And the rest of the camelCase surface survives too.
+    expect(parsed.data.memoryMb).toBe(1792);
+    expect(parsed.data.healthCheckPath).toBe("/health");
+    expect(parsed.data.port).toBe(3000);
+    expect(parsed.data.cpu).toBe(1792);
+  });
+
+  test("REGRESSION: the old snake_case body silently drops ELIZA_APP_ID and projectName", () => {
+    // The body the pre-fix SDK type produced. zod strips unknown keys, so this
+    // parses "successfully" while losing everything but name+image.
+    const legacyBody = {
+      name: "My App",
+      image: "ghcr.io/elizaos/my-app:latest",
+      project_name: "my-app",
+      environment_vars: { ELIZA_APP_ID: "app_abc123" },
+      memory: 1792,
+      health_check_path: "/health",
+    };
+    const wire = JSON.parse(JSON.stringify(legacyBody));
+
+    const parsed = CreateContainerSchema.safeParse(wire);
+    // It does NOT fail — that is the insidious part: no error surfaces.
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+
+    // Everything carried in snake_case is gone — environmentVars never existed,
+    // so ELIZA_APP_ID (per-app monetization attribution) is lost.
+    expect(parsed.data.projectName).toBeUndefined();
+    expect(parsed.data.environmentVars).toBeUndefined();
+    expect(parsed.data.environmentVars?.ELIZA_APP_ID).toBeUndefined();
+    expect(parsed.data.memoryMb).toBeUndefined();
+    expect(parsed.data.healthCheckPath).toBeUndefined();
+
+    // And none of the snake_case keys leaked through onto the parsed output.
+    expect(parsed.data).not.toHaveProperty("project_name");
+    expect(parsed.data).not.toHaveProperty("environment_vars");
+  });
+
+  test("rejects a body missing the required image (server is the source of truth)", () => {
+    const parsed = CreateContainerSchema.safeParse({ name: "no-image" });
+    expect(parsed.success).toBe(false);
+  });
+});
+
+describe("PATCH /api/v1/containers/:id — update contract (SDK union ↔ server)", () => {
+  test("every UpdateContainerRequest variant passes the server PatchSchema", () => {
+    // The three shapes of the SDK's UpdateContainerRequest discriminated union.
+    const restart = { action: "restart" };
+    const setEnv = {
+      action: "setEnv",
+      environmentVars: { ELIZA_APP_ID: "app_abc123" },
+    };
+    const scale = { action: "scale", desiredCount: 1 };
+
+    expect(PatchContainerSchema.safeParse(restart).success).toBe(true);
+    expect(PatchContainerSchema.safeParse(setEnv).success).toBe(true);
+    expect(PatchContainerSchema.safeParse(scale).success).toBe(true);
+  });
+
+  test("REGRESSION: the old { desired_count } / partial-create body is rejected", () => {
+    // The pre-fix UpdateContainerRequest extended Partial<CreateContainerRequest>,
+    // so callers sent bodies with no `action` — which the server always 400s.
+    expect(PatchContainerSchema.safeParse({ desired_count: 1 }).success).toBe(
+      false,
+    );
+    expect(
+      PatchContainerSchema.safeParse({ name: "x", projectName: "y" }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/cloud/api/v1/containers/[id]/route.ts
+++ b/packages/cloud/api/v1/containers/[id]/route.ts
@@ -28,20 +28,11 @@ import { getHetznerContainersClient } from "@/lib/services/containers/hetzner-cl
 import { HetznerClientError } from "@/lib/services/containers/hetzner-client/types";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
+import { PatchContainerSchema } from "../schema";
 
 const app = new Hono<AppEnv>();
 
-const PatchSchema = z.discriminatedUnion("action", [
-  z.object({ action: z.literal("restart") }),
-  z.object({
-    action: z.literal("setEnv"),
-    environmentVars: z.record(z.string(), z.string()),
-  }),
-  z.object({
-    action: z.literal("scale"),
-    desiredCount: z.number().int().positive(),
-  }),
-]);
+const PatchSchema = PatchContainerSchema;
 
 function hetznerErrorStatus(
   code: HetznerClientError["code"],

--- a/packages/cloud/api/v1/containers/route.ts
+++ b/packages/cloud/api/v1/containers/route.ts
@@ -37,7 +37,6 @@
  */
 
 import { Hono } from "hono";
-import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { containersEnv } from "@/lib/config/containers-env";
@@ -54,21 +53,9 @@ import {
 import { findReservedEnvKeys } from "@/lib/services/reserved-env-keys";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
+import { CreateContainerSchema } from "./schema";
 
 const app = new Hono<AppEnv>();
-
-const CreateContainerSchema = z.object({
-  name: z.string().min(1).max(100),
-  /** Container image reference, e.g. `ghcr.io/elizaos/my-app:latest`. */
-  image: z.string().min(1).max(512),
-  /** Stable project key (sticky scheduling/volumes). Defaults to a slug of `name`. */
-  projectName: z.string().min(1).max(100).optional(),
-  port: z.number().int().positive().max(65535).optional(),
-  cpu: z.number().int().positive().optional(),
-  memoryMb: z.number().int().positive().optional(),
-  environmentVars: z.record(z.string(), z.string()).optional(),
-  healthCheckPath: z.string().max(256).optional(),
-});
 
 function slugify(name: string): string {
   return (

--- a/packages/cloud/api/v1/containers/schema.ts
+++ b/packages/cloud/api/v1/containers/schema.ts
@@ -1,0 +1,47 @@
+/**
+ * Container request schemas — the source of truth for the `/api/v1/containers`
+ * wire contract.
+ *
+ * Extracted from the route handlers so the contract can be unit-tested in
+ * isolation (no Hono/Drizzle imports) and so the `@elizaos/cloud-sdk` types that
+ * mirror it can be validated against the *real* schema.
+ *
+ * IMPORTANT: these are camelCase. zod's `z.object` strips unknown keys, so a
+ * snake_case body (`project_name`, `environment_vars`, …) is silently dropped
+ * before a handler ever runs — that previously discarded
+ * `environmentVars.ELIZA_APP_ID` (per-app monetization attribution) and
+ * `projectName` (the sticky deploy key) on every container create. The SDK's
+ * `CreateContainerRequest` / `UpdateContainerRequest` must stay in exact
+ * agreement with these shapes.
+ */
+import { z } from "zod";
+
+/** Body for `POST /api/v1/containers`. */
+export const CreateContainerSchema = z.object({
+  name: z.string().min(1).max(100),
+  /** Container image reference, e.g. `ghcr.io/elizaos/my-app:latest`. */
+  image: z.string().min(1).max(512),
+  /** Stable project key (sticky scheduling/volumes). Defaults to a slug of `name`. */
+  projectName: z.string().min(1).max(100).optional(),
+  port: z.number().int().positive().max(65535).optional(),
+  cpu: z.number().int().positive().optional(),
+  memoryMb: z.number().int().positive().optional(),
+  environmentVars: z.record(z.string(), z.string()).optional(),
+  healthCheckPath: z.string().max(256).optional(),
+});
+
+/**
+ * Body for `PATCH /api/v1/containers/:id` — action-discriminated:
+ * restart | setEnv | scale.
+ */
+export const PatchContainerSchema = z.discriminatedUnion("action", [
+  z.object({ action: z.literal("restart") }),
+  z.object({
+    action: z.literal("setEnv"),
+    environmentVars: z.record(z.string(), z.string()),
+  }),
+  z.object({
+    action: z.literal("scale"),
+    desiredCount: z.number().int().positive(),
+  }),
+]);

--- a/packages/cloud/sdk/src/apps.client.test.ts
+++ b/packages/cloud/sdk/src/apps.client.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "vitest";
+import { ElizaCloudClient } from "./client.js";
+
+type RecordedRequest = {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body?: unknown;
+};
+
+function createClientRecorder(
+  responseBody: Record<string, unknown> = { success: true },
+) {
+  const requests: RecordedRequest[] = [];
+  const fetchImpl = (async (input, init = {}) => {
+    const headers = new Headers(init.headers);
+    requests.push({
+      url: String(input),
+      method: init.method ?? "GET",
+      headers: Object.fromEntries(headers.entries()),
+      body:
+        typeof init.body === "string" && init.body.length > 0
+          ? JSON.parse(init.body)
+          : undefined,
+    });
+
+    return new Response(JSON.stringify(responseBody), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+
+  return {
+    requests,
+    client: new ElizaCloudClient({
+      baseUrl: "https://cloud.test",
+      apiKey: "eliza_test_key",
+      fetchImpl,
+    }),
+  };
+}
+
+describe("ElizaCloudClient typed app methods", () => {
+  it("listApps GETs /api/v1/apps and returns a typed ListAppsResponse", async () => {
+    const { client, requests } = createClientRecorder({
+      success: true,
+      apps: [],
+    });
+    const res = await client.listApps();
+    // Compile-time proof the result is typed, not `unknown`: `res.apps` is
+    // AppDto[] (Array.isArray would not type-check on `unknown`).
+    expect(Array.isArray(res.apps)).toBe(true);
+    expect(requests[0]).toMatchObject({
+      url: "https://cloud.test/api/v1/apps",
+      method: "GET",
+    });
+  });
+
+  it("getApp GETs /api/v1/apps/:id with the id encoded into the path", async () => {
+    const { client, requests } = createClientRecorder({
+      success: true,
+      app: { id: "app_1" },
+    });
+    const res = await client.getApp("app_1");
+    expect(res.app.id).toBe("app_1");
+    expect(requests[0]).toMatchObject({
+      url: "https://cloud.test/api/v1/apps/app_1",
+      method: "GET",
+    });
+  });
+
+  it("createApp POSTs /api/v1/apps with the snake_case create body", async () => {
+    const { client, requests } = createClientRecorder({
+      success: true,
+      app: { id: "app_1" },
+      apiKey: "eliza_app_secret",
+    });
+    const res = await client.createApp({
+      name: "My App",
+      app_url: "https://my.app",
+      monetization_enabled: true,
+      inference_markup_percentage: 20,
+    });
+    expect(res.apiKey).toBe("eliza_app_secret");
+    expect(requests[0]).toMatchObject({
+      url: "https://cloud.test/api/v1/apps",
+      method: "POST",
+      body: {
+        name: "My App",
+        app_url: "https://my.app",
+        monetization_enabled: true,
+        inference_markup_percentage: 20,
+      },
+    });
+  });
+
+  it("updateApp PATCHes /api/v1/apps/:id with the patch body", async () => {
+    const { client, requests } = createClientRecorder({
+      success: true,
+      app: { id: "app_1" },
+    });
+    await client.updateApp("app_1", { name: "Renamed", is_active: false });
+    expect(requests[0]).toMatchObject({
+      url: "https://cloud.test/api/v1/apps/app_1",
+      method: "PATCH",
+      body: { name: "Renamed", is_active: false },
+    });
+  });
+
+  it("updateMonetization PUTs /api/v1/apps/:id/monetization with camelCase settings", async () => {
+    const { client, requests } = createClientRecorder({
+      success: true,
+      monetization: {
+        monetizationEnabled: true,
+        inferenceMarkupPercentage: 20,
+        purchaseSharePercentage: 10,
+        platformOffsetAmount: 0,
+        totalCreatorEarnings: 0,
+      },
+    });
+    const res = await client.updateMonetization("app_1", {
+      monetizationEnabled: true,
+      inferenceMarkupPercentage: 20,
+      purchaseSharePercentage: 10,
+    });
+    expect(res.monetization?.monetizationEnabled).toBe(true);
+    expect(requests[0]).toMatchObject({
+      url: "https://cloud.test/api/v1/apps/app_1/monetization",
+      method: "PUT",
+      body: {
+        monetizationEnabled: true,
+        inferenceMarkupPercentage: 20,
+        purchaseSharePercentage: 10,
+      },
+    });
+  });
+
+  it("deployApp POSTs /api/v1/apps/:id/deploy (empty body by default)", async () => {
+    const { client, requests } = createClientRecorder({
+      success: true,
+      deploymentId: "dep_1",
+      status: "building",
+      startedAt: "2026-06-29T00:00:00.000Z",
+    });
+    const res = await client.deployApp("app_1");
+    expect(res.deploymentId).toBe("dep_1");
+    expect(requests[0]).toMatchObject({
+      url: "https://cloud.test/api/v1/apps/app_1/deploy",
+      method: "POST",
+      body: {},
+    });
+  });
+
+  it("getAppDeployStatus GETs /api/v1/apps/:id/deploy/status", async () => {
+    const { client, requests } = createClientRecorder({
+      success: true,
+      deploymentId: "dep_1",
+      status: "DEPLOYED",
+      vercelUrl: null,
+      error: null,
+      startedAt: null,
+    });
+    const res = await client.getAppDeployStatus("app_1");
+    expect(res.status).toBe("DEPLOYED");
+    expect(requests[0]).toMatchObject({
+      url: "https://cloud.test/api/v1/apps/app_1/deploy/status",
+      method: "GET",
+    });
+  });
+
+  it("deleteApp DELETEs /api/v1/apps/:id", async () => {
+    const { client, requests } = createClientRecorder({
+      success: true,
+      message: "deleted",
+    });
+    const res = await client.deleteApp("app_1");
+    expect(res.message).toBe("deleted");
+    expect(requests[0]).toMatchObject({
+      url: "https://cloud.test/api/v1/apps/app_1",
+      method: "DELETE",
+    });
+  });
+
+  it("buyAppDomain (deferred stub) POSTs /api/v1/apps/:id/domains/buy with { domain }", async () => {
+    const { client, requests } = createClientRecorder({
+      success: true,
+      domain: "example.com",
+    });
+    const res = await client.buyAppDomain("app_1", { domain: "example.com" });
+    expect(res.success).toBe(true);
+    expect(requests[0]).toMatchObject({
+      url: "https://cloud.test/api/v1/apps/app_1/domains/buy",
+      method: "POST",
+      body: { domain: "example.com" },
+    });
+  });
+});

--- a/packages/cloud/sdk/src/client.test.ts
+++ b/packages/cloud/sdk/src/client.test.ts
@@ -246,6 +246,74 @@ describe("ElizaCloudClient.getContainerLogs", () => {
   });
 });
 
+describe("ElizaCloudClient.createContainer wire contract", () => {
+  it("serializes a camelCase body so projectName and environmentVars.ELIZA_APP_ID survive (per-app monetization)", async () => {
+    const { client, requests } = createClientRecorder({
+      success: true,
+      data: { id: "c_1" },
+    });
+
+    // Typed against CreateContainerRequest: this object only compiles if the
+    // SDK type is camelCase. A revert to snake_case fails the build here.
+    await client.createContainer({
+      name: "My App",
+      image: "ghcr.io/elizaos/my-app:latest",
+      projectName: "my-app",
+      port: 3000,
+      cpu: 1792,
+      memoryMb: 1792,
+      environmentVars: { ELIZA_APP_ID: "app_abc123", FOO: "bar" },
+      healthCheckPath: "/health",
+    });
+
+    expect(requests[0]).toMatchObject({
+      url: "https://cloud.test/api/v1/containers",
+      method: "POST",
+    });
+
+    const body = requests[0]?.body as Record<string, unknown>;
+    // The exact keys the server's CreateContainerSchema accepts — all camelCase.
+    expect(body).toMatchObject({
+      name: "My App",
+      image: "ghcr.io/elizaos/my-app:latest",
+      projectName: "my-app",
+      port: 3000,
+      cpu: 1792,
+      memoryMb: 1792,
+      healthCheckPath: "/health",
+    });
+    // ELIZA_APP_ID rides through environmentVars — the field the casing bug dropped.
+    expect((body.environmentVars as Record<string, string>).ELIZA_APP_ID).toBe(
+      "app_abc123",
+    );
+
+    // Regression guard: none of the legacy snake_case keys may reach the wire.
+    // Those are exactly what the server zod silently stripped, taking
+    // ELIZA_APP_ID and the sticky projectName with them.
+    for (const dropped of [
+      "project_name",
+      "environment_vars",
+      "health_check_path",
+      "memory",
+      "desired_count",
+    ]) {
+      expect(body).not.toHaveProperty(dropped);
+    }
+  });
+
+  it("sends the action-discriminated PATCH body verbatim for updateContainer", async () => {
+    const { client, requests } = createClientRecorder({ success: true });
+
+    await client.updateContainer("c_1", { action: "scale", desiredCount: 1 });
+
+    expect(requests[0]).toMatchObject({
+      url: "https://cloud.test/api/v1/containers/c_1",
+      method: "PATCH",
+      body: { action: "scale", desiredCount: 1 },
+    });
+  });
+});
+
 describe("ElizaCloudClient path parameter encoding", () => {
   it("percent-encodes path parameters that contain slashes, query markers, and fragments", async () => {
     const { client, requests } = createClientRecorder();

--- a/packages/cloud/sdk/src/client.ts
+++ b/packages/cloud/sdk/src/client.ts
@@ -9,9 +9,14 @@ import {
   type ApiKeyCreateResponse,
   type ApiKeyListResponse,
   type AppCreditsBalanceResponse,
+  type AppDeployStatusResponse,
   type AppEarningsHistoryResponse,
   type AppEarningsResponse,
+  type AppMonetizationResponse,
+  type AppResponse,
   type AuthPairResponse,
+  type BuyAppDomainInput,
+  type BuyAppDomainResponse,
   type ChatCompletionRequest,
   type ChatCompletionResponse,
   type CliLoginPollResponse,
@@ -31,6 +36,8 @@ import {
   type CreateAppChargeResponse,
   type CreateAppCreditsCheckoutRequest,
   type CreateAppCreditsCheckoutResponse,
+  type CreateAppInput,
+  type CreateAppResponse,
   type CreateContainerRequest,
   type CreateContainerResponse,
   type CreateCreditsCheckoutRequest,
@@ -44,6 +51,9 @@ import {
   DEFAULT_ELIZA_CLOUD_API_BASE_URL,
   DEFAULT_ELIZA_CLOUD_API_ORIGIN,
   DEFAULT_ELIZA_CLOUD_BASE_URL,
+  type DeleteAppResponse,
+  type DeployAppInput,
+  type DeployAppResponse,
   type ElizaCloudClientOptions,
   type EmbeddingsRequest,
   type EmbeddingsResponse,
@@ -59,6 +69,7 @@ import {
   type LinkAffiliateRequest,
   type LinkAffiliateResponse,
   type ListAppChargesResponse,
+  type ListAppsResponse,
   type ListRedemptionsResponse,
   type ListX402PaymentRequestsResponse,
   type ModelListResponse,
@@ -74,6 +85,8 @@ import {
   type SettleX402PaymentRequestResponse,
   type SnapshotListResponse,
   type SnapshotType,
+  type UpdateAppInput,
+  type UpdateAppMonetizationInput,
   type UpdateContainerRequest,
   type UpsertAffiliateCodeRequest,
   type UserProfileResponse,
@@ -711,6 +724,95 @@ export class ElizaCloudClient {
   ): Promise<ListRedemptionsResponse> {
     return this.request<ListRedemptionsResponse>("GET", "/api/v1/redemptions", {
       query: options.limit === undefined ? undefined : { limit: options.limit },
+    });
+  }
+
+  // ─── Apps (Eliza Cloud Apps product) ──────────────────────────────────────
+  // Typed wrappers over the generated `routes.*` app endpoints. These are the
+  // foundation the agent plugin builds on: every method returns a concrete DTO
+  // (no `unknown` in the public signature) and targets the same route + verb the
+  // server exposes.
+
+  /** `GET /api/v1/apps` — list apps for the authenticated org. */
+  listApps(): Promise<ListAppsResponse> {
+    return this.routes.getApiV1Apps<ListAppsResponse>();
+  }
+
+  /** `GET /api/v1/apps/:id` — fetch a single app. */
+  getApp(appId: string): Promise<AppResponse> {
+    return this.routes.getApiV1AppsById<AppResponse>({
+      pathParams: { id: appId },
+    });
+  }
+
+  /** `POST /api/v1/apps` — create an app (provisions its API key + optional repo). */
+  createApp(input: CreateAppInput): Promise<CreateAppResponse> {
+    return this.routes.postApiV1Apps<CreateAppResponse>({ json: input });
+  }
+
+  /** `PATCH /api/v1/apps/:id` — partially update an app. */
+  updateApp(appId: string, patch: UpdateAppInput): Promise<AppResponse> {
+    return this.routes.patchApiV1AppsById<AppResponse>({
+      pathParams: { id: appId },
+      json: patch,
+    });
+  }
+
+  /** `PUT /api/v1/apps/:id/monetization` — update an app's monetization settings. */
+  updateMonetization(
+    appId: string,
+    settings: UpdateAppMonetizationInput,
+  ): Promise<AppMonetizationResponse> {
+    return this.routes.putApiV1AppsByIdMonetization<AppMonetizationResponse>({
+      pathParams: { id: appId },
+      json: settings,
+    });
+  }
+
+  /**
+   * `POST /api/v1/apps/:id/deploy` — kick off a container deploy (202 Accepted).
+   * Body is optional: defaults pull from the app's linked repo + stored env.
+   */
+  deployApp(
+    appId: string,
+    input: DeployAppInput = {},
+  ): Promise<DeployAppResponse> {
+    return this.routes.postApiV1AppsByIdDeploy<DeployAppResponse>({
+      pathParams: { id: appId },
+      json: input,
+    });
+  }
+
+  /** `GET /api/v1/apps/:id/deploy/status` — latest deploy status (poll target). */
+  getAppDeployStatus(appId: string): Promise<AppDeployStatusResponse> {
+    return this.routes.getApiV1AppsByIdDeployStatus<AppDeployStatusResponse>({
+      pathParams: { id: appId },
+    });
+  }
+
+  /** `DELETE /api/v1/apps/:id` — delete an app and clean up its resources. */
+  deleteApp(appId: string): Promise<DeleteAppResponse> {
+    return this.routes.deleteApiV1AppsById<DeleteAppResponse>({
+      pathParams: { id: appId },
+    });
+  }
+
+  /**
+   * `POST /api/v1/apps/:id/domains/buy` — buy + attach a custom domain.
+   *
+   * DEFERRED: domain purchase is the last slice of the apps launch. The method
+   * is typed and wired so the agent plugin can compile against it, but the
+   * server response envelope is not yet finalized ({@link BuyAppDomainResponse}
+   * captures only the stable fields) — treat as experimental until the domain
+   * branch lands.
+   */
+  buyAppDomain(
+    appId: string,
+    input: BuyAppDomainInput,
+  ): Promise<BuyAppDomainResponse> {
+    return this.routes.postApiV1AppsByIdDomainsBuy<BuyAppDomainResponse>({
+      pathParams: { id: appId },
+      json: input,
     });
   }
 

--- a/packages/cloud/sdk/src/live.e2e.test.ts
+++ b/packages/cloud/sdk/src/live.e2e.test.ts
@@ -315,7 +315,7 @@ containerDescribe("ElizaCloudClient real API e2e: container lifecycle", () => {
 
     const created = await client.createContainer({
       name: `sdk-e2e-${Date.now()}`,
-      project_name: "sdk-e2e",
+      projectName: "sdk-e2e",
       image: imageUri,
     });
     const containerId = created.data.id;
@@ -327,7 +327,10 @@ containerDescribe("ElizaCloudClient real API e2e: container lifecycle", () => {
         true,
       );
       await expect(
-        client.updateContainer(containerId, { desired_count: 1 }),
+        client.updateContainer(containerId, {
+          action: "scale",
+          desiredCount: 1,
+        }),
       ).resolves.toBeTruthy();
       await expect(
         client.getContainerHealth(containerId),

--- a/packages/cloud/sdk/src/types.ts
+++ b/packages/cloud/sdk/src/types.ts
@@ -639,28 +639,47 @@ export interface CloudContainer {
   updated_at: string;
 }
 
+/**
+ * Body for `POST /api/v1/containers`.
+ *
+ * Field names MUST match the server zod schema (`CreateContainerSchema` in
+ * `packages/cloud/api/v1/containers/route.ts`) verbatim — the server is
+ * camelCase. The server validates with `z.object`, which strips unknown keys,
+ * so a snake_case body (`project_name`, `environment_vars`, …) is silently
+ * dropped before the handler ever runs. That previously discarded
+ * `environmentVars.ELIZA_APP_ID` (per-app monetization attribution) and
+ * `projectName` (the sticky deploy key) on every container create, even on the
+ * happy path. Keep this in exact camelCase agreement with the server.
+ */
 export interface CreateContainerRequest {
+  /** Human-readable container name (1–100 chars). */
   name: string;
-  project_name: string;
-  description?: string;
-  port?: number;
-  desired_count?: number;
-  cpu?: number;
-  memory?: number;
-  environment_vars?: Record<string, string>;
-  health_check_path?: string;
-  /** Internal coding-container bootstrap mount. Defaults to /data. */
-  volume_mount_path?: string;
-  /** Internal coding-container source bundle, written into the mounted volume before start. */
-  bootstrap_source?: JsonValue;
   /** Full image reference (e.g. `ghcr.io/owner/repo:tag`). The Hetzner-Docker backend pulls it directly. */
   image: string;
+  /** Stable project key (sticky scheduling/volumes). Defaults to a slug of `name` server-side. */
+  projectName?: string;
+  port?: number;
+  cpu?: number;
+  memoryMb?: number;
+  /**
+   * Caller-supplied environment. Carries `ELIZA_APP_ID` for per-app
+   * monetization attribution; platform-reserved keys are rejected server-side.
+   */
+  environmentVars?: Record<string, string>;
+  healthCheckPath?: string;
 }
 
-export interface UpdateContainerRequest
-  extends Partial<CreateContainerRequest> {
-  status?: ContainerStatus;
-}
+/**
+ * Body for `PATCH /api/v1/containers/:id`. Mirrors the server's
+ * action-discriminated union (`PatchSchema` in
+ * `packages/cloud/api/v1/containers/[id]/route.ts`): restart | setEnv | scale.
+ * The server rejects any body without a recognized `action`, so this is a
+ * discriminated union, not a partial of the create body.
+ */
+export type UpdateContainerRequest =
+  | { action: "restart" }
+  | { action: "setEnv"; environmentVars: Record<string, string> }
+  | { action: "scale"; desiredCount: number };
 
 export interface CreateContainerResponse {
   success: boolean;

--- a/packages/cloud/sdk/src/types.ts
+++ b/packages/cloud/sdk/src/types.ts
@@ -722,6 +722,274 @@ export interface ContainerCredentialsResponse extends Record<string, unknown> {
   success?: boolean;
 }
 
+// ─── Apps (Eliza Cloud Apps product) ────────────────────────────────────────
+// DTOs mirror the server apps routes (`packages/cloud/api/v1/apps/**`) and the
+// `apps` Drizzle table (`packages/cloud/shared/src/db/schemas/apps.ts`). The app
+// payload is snake_case (it serializes the row directly via
+// `appsService.withDatabaseState`); the monetization payload is camelCase
+// (`appCreditsService.getMonetizationSettings`). Match the server exactly.
+
+/** Deployment lifecycle of an app (server enum `app_deployment_status`). */
+export type AppDeploymentStatus =
+  | "draft"
+  | "building"
+  | "deploying"
+  | "deployed"
+  | "failed";
+
+/** Discord social-automation config stored on an app (jsonb column). */
+export interface AppDiscordAutomation {
+  enabled: boolean;
+  guildId?: string;
+  channelId?: string;
+  autoAnnounce: boolean;
+  announceIntervalMin: number;
+  announceIntervalMax: number;
+  vibeStyle?: string;
+  lastAnnouncementAt?: string;
+  totalMessages?: number;
+}
+
+/** Telegram social-automation config stored on an app (jsonb column). */
+export interface AppTelegramAutomation {
+  enabled: boolean;
+  botUsername?: string;
+  channelId?: string;
+  groupId?: string;
+  autoReply: boolean;
+  autoAnnounce: boolean;
+  announceIntervalMin: number;
+  announceIntervalMax: number;
+  welcomeMessage?: string;
+  vibeStyle?: string;
+  lastAnnouncementAt?: string;
+  totalMessages?: number;
+}
+
+/** X/Twitter social-automation config stored on an app (jsonb column). */
+export interface AppTwitterAutomation {
+  enabled: boolean;
+  autoPost: boolean;
+  autoReply: boolean;
+  autoEngage: boolean;
+  discovery: boolean;
+  postIntervalMin: number;
+  postIntervalMax: number;
+  vibeStyle?: string;
+  topics?: string[];
+  lastPostAt?: string;
+  totalPosts?: number;
+  agentCharacterId?: string;
+}
+
+/** A generated promotional asset stored on an app (jsonb column). */
+export interface AppPromotionalAsset {
+  type: "social_card" | "banner";
+  url: string;
+  size: { width: number; height: number };
+  generatedAt: string;
+}
+
+/**
+ * An Eliza Cloud App as returned by the apps routes. Mirrors the `apps` Drizzle
+ * row serialized over the wire: timestamps are ISO strings, `numeric` columns
+ * are decimal strings, and `real` columns are numbers. Field names are
+ * snake_case to match the server payload exactly.
+ */
+export interface AppDto {
+  id: string;
+  name: string;
+  description: string | null;
+  slug: string;
+  organization_id: string;
+  created_by_user_id: string;
+  app_url: string;
+  allowed_origins: string[];
+  api_key_id: string | null;
+  affiliate_code: string | null;
+  /** `numeric` decimal string. */
+  referral_bonus_credits: string | null;
+  total_requests: number;
+  total_users: number;
+  /** `numeric` decimal string. */
+  total_credits_used: string | null;
+  logo_url: string | null;
+  website_url: string | null;
+  contact_email: string | null;
+  metadata: Record<string, unknown>;
+  deployment_status: AppDeploymentStatus;
+  production_url: string | null;
+  last_deployed_at: string | null;
+  github_repo: string | null;
+  linked_character_ids: string[] | null;
+  monetization_enabled: boolean;
+  inference_markup_percentage: number | null;
+  purchase_share_percentage: number | null;
+  platform_offset_amount: number | null;
+  custom_pricing_enabled: boolean | null;
+  /** `numeric` decimal string. */
+  total_creator_earnings: string | null;
+  /** `numeric` decimal string. */
+  total_platform_revenue: string | null;
+  discord_automation: AppDiscordAutomation | null;
+  telegram_automation: AppTelegramAutomation | null;
+  twitter_automation: AppTwitterAutomation | null;
+  promotional_assets: AppPromotionalAsset[] | null;
+  email_notifications: boolean | null;
+  response_notifications: boolean | null;
+  is_active: boolean;
+  is_approved: boolean;
+  created_at: string;
+  updated_at: string;
+  last_used_at: string | null;
+}
+
+/** `GET /api/v1/apps` */
+export interface ListAppsResponse {
+  success: boolean;
+  apps: AppDto[];
+}
+
+/** Single-app envelope: `GET /api/v1/apps/:id`, `PUT|PATCH /api/v1/apps/:id`. */
+export interface AppResponse {
+  success: boolean;
+  app: AppDto;
+}
+
+/** `POST /api/v1/apps` request body (snake_case — matches `CreateAppSchema`). */
+export interface CreateAppInput {
+  name: string;
+  description?: string;
+  app_url: string;
+  website_url?: string;
+  contact_email?: string;
+  allowed_origins?: string[];
+  logo_url?: string;
+  /** Skip provisioning a GitHub repo for the app. */
+  skipGitHubRepo?: boolean;
+  /** Apply monetization at creation, saving a follow-up call. */
+  monetization_enabled?: boolean;
+  /** Inference markup percentage, 0–1000. */
+  inference_markup_percentage?: number;
+}
+
+/** `POST /api/v1/apps` response. */
+export interface CreateAppResponse {
+  success: boolean;
+  app: AppDto;
+  /** Plaintext app API key — returned once, at creation. */
+  apiKey: string;
+  githubRepo?: string;
+  warnings?: string[];
+}
+
+/** `PATCH /api/v1/apps/:id` request body (snake_case — matches `UpdateAppSchema`). */
+export interface UpdateAppInput {
+  name?: string;
+  description?: string;
+  app_url?: string;
+  website_url?: string;
+  contact_email?: string;
+  allowed_origins?: string[];
+  logo_url?: string;
+  is_active?: boolean;
+  /** Up to 4 linked character UUIDs. */
+  linked_character_ids?: string[];
+}
+
+/**
+ * App monetization settings, returned by `GET /api/v1/apps/:id/monetization`
+ * and `PUT .../monetization` (server `appCreditsService.getMonetizationSettings`).
+ */
+export interface AppMonetizationSettings {
+  monetizationEnabled: boolean;
+  inferenceMarkupPercentage: number;
+  purchaseSharePercentage: number;
+  platformOffsetAmount: number;
+  totalCreatorEarnings: number;
+}
+
+/**
+ * `PUT /api/v1/apps/:id/monetization` request body (camelCase — matches
+ * `UpdateMonetizationSchema`).
+ */
+export interface UpdateAppMonetizationInput {
+  monetizationEnabled?: boolean;
+  /** Inference markup percentage, 0–1000. */
+  inferenceMarkupPercentage?: number;
+  /** Purchase share percentage, 0–100. */
+  purchaseSharePercentage?: number;
+}
+
+/** `GET|PUT /api/v1/apps/:id/monetization` response. */
+export interface AppMonetizationResponse {
+  success: boolean;
+  monetization: AppMonetizationSettings | null;
+}
+
+/** `POST /api/v1/apps/:id/deploy` request body — all fields optional. */
+export interface DeployAppInput {
+  repoUrl?: string;
+  ref?: string;
+  dockerfile?: string;
+  env?: Record<string, string>;
+}
+
+/**
+ * `POST /api/v1/apps/:id/deploy` response (202 Accepted). `status` is the
+ * server-side deployment status string (the deploy lifecycle is polled via
+ * {@link AppDeployStatusResponse}).
+ */
+export interface DeployAppResponse {
+  success: boolean;
+  deploymentId: string;
+  status: string;
+  startedAt: string;
+}
+
+/** `GET /api/v1/apps/:id/deploy/status` response. */
+export interface AppDeployStatusResponse {
+  success: boolean;
+  deploymentId: string | null;
+  status: string;
+  vercelUrl: string | null;
+  error: string | null;
+  startedAt: string | null;
+}
+
+/** Per-resource counts the cleanup pass reports on app deletion. */
+export interface AppCleanupSummary {
+  domainsRemoved: number;
+  githubRepoDeleted: boolean;
+  secretBindingsRemoved: number;
+  managedDomainsUnlinked: number;
+  containersTornDown: number;
+}
+
+/** `DELETE /api/v1/apps/:id` response. */
+export interface DeleteAppResponse {
+  success: boolean;
+  message: string;
+  cleaned?: AppCleanupSummary;
+  errors?: string[];
+}
+
+/** `POST /api/v1/apps/:id/domains/buy` request body. */
+export interface BuyAppDomainInput {
+  domain: string;
+}
+
+/**
+ * `POST /api/v1/apps/:id/domains/buy` response. DEFERRED: the domain-purchase
+ * flow is the last piece of the apps launch and its response envelope is not yet
+ * finalized server-side, so this captures only the stable fields.
+ */
+export interface BuyAppDomainResponse {
+  success: boolean;
+  domain?: string;
+  error?: string;
+}
+
 export interface CreateAgentRequest {
   agentName: string;
   characterId?: string;


### PR DESCRIPTION
## What

Two cloud-SDK correctness changes that unblock per-app monetization attribution and the agent app-management plugin.

### 1. fix: container-create request was silently dropping `ELIZA_APP_ID` (and `projectName`/`memoryMb`/`healthCheckPath`)

The server schema `CreateContainerSchema` (`packages/cloud/api/v1/containers/route.ts`) is **camelCase**; the SDK's `CreateContainerRequest` was **snake_case**. Zod's `z.object` strips unknown keys, so `environment_vars` (which carries `ELIZA_APP_ID`) and `project_name` were silently dropped on **every** container create → per-app monetization attribution breaks even on the happy path.

- Align the SDK `CreateContainerRequest` to the server camelCase field-for-field; fix `UpdateContainerRequest` to the real PATCH discriminated union (`restart | setEnv | scale`).
- Extract the server zod into `packages/cloud/api/v1/containers/schema.ts` (single source of truth, unit-testable) — no behavior change.
- **Proof (new `containers-create-contract.test.ts`):** parses bodies through the *real* exported `CreateContainerSchema` — camelCase body → `environmentVars.ELIZA_APP_ID` present; old snake_case body → `projectName`/`environmentVars` `undefined` (reproduces the bug). SDK wire test drives a real `ElizaCloudClient.createContainer(...)` and asserts the serialized POST body is camelCase with `ELIZA_APP_ID`.

### 2. feat: typed app methods on `ElizaCloudClient`

Adds typed `listApps / getApp / createApp / updateApp / updateMonetization / deployApp / getAppDeployStatus / deleteApp` (+ a deferred `buyAppDomain` stub), each wrapping the existing generated `routes.*` with real DTO types derived from the server routes — no `unknown` in any public signature, no `as` casts. Foundation for the agent app-management plugin.

## Evidence
- `bun run --cwd packages/cloud/sdk test` → **50 pass / 0 fail**
- cloud-api `containers-create-contract` **5 pass**, `containers-reserved-env` **6 pass**, `containers/route.test` **6 pass**
- SDK lint clean (25 files); SDK + cloud-api typecheck clean.

## Notes
- De-vendoring the duplicate SDK copy under `plugins/plugin-elizacloud/src/utils/cloud-sdk/` (same snake_case bug) is a tracked follow-up.
- Part of the apps launch (tracker #8434).
