### PR TITLE
feat(first-run): chat-centric in-chat onboarding — seed onboarding into the real floating chat (#9952)

### DIFF
--- a/.github/workflows/app-live-e2e.yml
+++ b/.github/workflows/app-live-e2e.yml
@@ -126,6 +126,75 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+  # Full continuous walkthrough against the REAL backend agent + model: cold
+  # launch → in-chat onboarding (greeting → runtime CHOICE → provider → one real
+  # POST /api/first-run) → all 8 tutorial frames → help/settings/wallet → a real
+  # chat round-trip (trajectory captured) → view switching → settings edit. Runs
+  # WITHOUT --skip-review so the AI vision reviewer scores every NN-step.png and
+  # writes WALKTHROUGH_VERDICTS.md (the PR mock lane is keyless and can't).
+  walkthrough-live:
+    name: full walkthrough (real backend + model + vision verdicts)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      TURBO_CACHE: remote:rw
+      PGLITE_WASM_MODE: node
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+
+      - name: Free disk space for browser smoke
+        run: |
+          set -euxo pipefail
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android /opt/hostedtoolcache/CodeQL || true
+          docker system prune -af || true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          install-command: bun install
+          install-native-deps: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      - name: Install Playwright Chromium
+        run: bunx playwright install --with-deps chromium
+
+      - name: Install ffmpeg (recording stitch)
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
+      - name: Generate shared i18n assets
+        run: bun run --cwd packages/shared build:i18n
+
+      # Prebuild the renderer dist so the live stack reuses a fresh bundle instead
+      # of a cold ~12 min in-harness vite build.
+      - name: Build app renderer bundle
+        run: bun run --cwd packages/app build:web
+
+      - name: Drive + record + vision-review the full walkthrough (live)
+        run: bun run --cwd packages/app test:e2e:walkthrough:live
+
+      - name: Upload walkthrough screenshots + recording + verdicts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: app-live-e2e-walkthrough
+          path: |
+            reports/walkthrough/
+            e2e-recordings/app/walkthrough/
+            packages/app/test/ui-smoke/walkthrough/WALKTHROUGH_VERDICTS.md
+          if-no-files-found: ignore
+          retention-days: 7
+
   # Real CLOUD login + provisioning + chat through the app UI against real Eliza
   # Cloud. cloud-live.spec.ts mocks nothing; ELIZA_UI_SMOKE_CLOUD_LIVE=1 leaves
   # first-run open so the spec drives cloud onboarding, and ELIZAOS_CLOUD_API_KEY

--- a/.github/workflows/scenario-pr.yml
+++ b/.github/workflows/scenario-pr.yml
@@ -495,6 +495,60 @@ jobs:
           if-no-files-found: ignore
           retention-days: 3
 
+  app-walkthrough-mock:
+    name: Zero-Key full-walkthrough (mock lane)
+    needs: changes
+    if: needs.changes.outputs.run_scenario_pr == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          install-command: bun install --ignore-scripts --no-frozen-lockfile
+          install-native-deps: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      - name: Ensure generated shared i18n data
+        run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
+
+      - name: Install Playwright browsers
+        run: bunx playwright install --with-deps chromium
+
+      - name: Install ffmpeg (recording stitch)
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
+      # Drives the REAL in-chat onboarding (greeting → runtime CHOICE →
+      # provider → one POST /api/first-run) and all 8 tutorial frames, then
+      # stitches the ordered NN-*.png frames into one step-labeled mp4 per
+      # viewport. Keyless: the lane forces ELIZA_UI_SMOKE_FORCE_STUB=1; the PR
+      # env blanks every provider key, so `--skip-review` (no vision verdicts).
+      - name: Drive + record the in-chat onboarding + tutorial walkthrough
+        run: bun run --cwd packages/app test:e2e:walkthrough -- --skip-review
+
+      - name: Upload walkthrough screenshots + stitched recording + verdicts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: scenario-pr-app-walkthrough-mock
+          path: |
+            reports/walkthrough/
+            e2e-recordings/app/walkthrough/
+            packages/app/test/ui-smoke/walkthrough/WALKTHROUGH_VERDICTS.md
+          if-no-files-found: ignore
+          retention-days: 7
+
   app-diagnostics:
     name: Zero-Key app diagnostics
     needs: changes
@@ -630,6 +684,7 @@ jobs:
       - app-browser-cloud-keyless
       - app-browser-ratcheted
       - app-browser-auto-discovered
+      - app-walkthrough-mock
       - app-diagnostics
       - scenario-runner-e2e
     if: ${{ !cancelled() && always() && needs.changes.outputs.run_scenario_pr == 'true' }}
@@ -649,6 +704,7 @@ jobs:
             "app-browser-cloud-keyless:${{ needs.app-browser-cloud-keyless.result }}" \
             "app-browser-ratcheted:${{ needs.app-browser-ratcheted.result }}" \
             "app-browser-auto-discovered:${{ needs.app-browser-auto-discovered.result }}" \
+            "app-walkthrough-mock:${{ needs.app-walkthrough-mock.result }}" \
             "app-diagnostics:${{ needs.app-diagnostics.result }}" \
             "scenario-runner-e2e:${{ needs.scenario-runner-e2e.result }}"; do
             name="${pair%%:*}"

--- a/packages/app/test/ui-smoke/in-chat-onboarding.spec.ts
+++ b/packages/app/test/ui-smoke/in-chat-onboarding.spec.ts
@@ -103,12 +103,14 @@ test("in-chat onboarding seeds the greeting + runtime choice into the real float
     fullPage: true,
   });
 
-  // Picking a runtime is intercepted locally (consumeFirstRunChoice) and appends
-  // the acknowledgement instead of dispatching an agent send.
+  // Picking a runtime is intercepted locally (consumeFirstRunChoice) and routed
+  // through the headless first-run use case — the agent send is skipped and the
+  // next ConductorStep (the provider sub-choice) is seeded into the transcript.
   await local.click();
-  await expect(page.getByText(/local agent on this device/i)).toBeVisible({
+  await expect(page.getByTestId("choice-provider:on-device")).toBeVisible({
     timeout: 10_000,
   });
+  await expect(page.getByTestId("choice-provider:elizacloud")).toBeVisible();
 
   await expectNoRenderTelemetryErrors(page, "in-chat onboarding");
 });

--- a/packages/app/test/ui-smoke/in-chat-onboarding.spec.ts
+++ b/packages/app/test/ui-smoke/in-chat-onboarding.spec.ts
@@ -1,0 +1,114 @@
+import { expect, type Page, type Route, test } from "@playwright/test";
+import {
+  expectNoRenderTelemetryErrors,
+  installDefaultAppRoutes,
+  installRenderTelemetryGuard,
+  seedAppStorage,
+} from "./helpers";
+
+// Chat-centric first-run (#9952, Phase 1). With the `inChatOnboarding` flag ON
+// a fresh profile lands directly on the homescreen with the REAL floating chat
+// (ContinuousChatOverlay) auto-opened, and the onboarding greeting + runtime
+// CHOICE are seeded into that live transcript — NOT the legacy full-screen
+// FirstRunChat surface. This spec boots that path and asserts the real overlay
+// renders the greeting + the runtime choice buttons, and that picking a choice
+// is intercepted locally (no agent send) instead of going to the model.
+
+async function fulfillJson(
+  route: Route,
+  status: number,
+  body: Record<string, unknown>,
+): Promise<void> {
+  await route.fulfill({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+// A full-capability host (real API base) so the runtime choice offers every
+// option rather than falling back to cloud-only.
+async function injectFullCapabilityHost(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    (window as unknown as Record<string, unknown>).__ELIZA_APP_API_BASE__ =
+      window.location.origin;
+    (window as unknown as Record<string, number>).__electrobunWindowId = 1;
+  });
+}
+
+async function routeFirstRunIncomplete(page: Page): Promise<void> {
+  await page.route("**/api/auth/status", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    await fulfillJson(route, 200, {
+      required: false,
+      authenticated: true,
+      loginRequired: false,
+      localAccess: true,
+      passwordConfigured: false,
+      pairingEnabled: false,
+      expiresAt: null,
+    });
+  });
+  await page.route("**/api/first-run/status", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    await fulfillJson(route, 200, { complete: false, cloudProvisioned: false });
+  });
+}
+
+test("in-chat onboarding seeds the greeting + runtime choice into the real floating chat", async ({
+  page,
+}) => {
+  await installRenderTelemetryGuard(page);
+  await installDefaultAppRoutes(page);
+  await routeFirstRunIncomplete(page);
+  await injectFullCapabilityHost(page);
+  // Fresh device + flag ON: no persisted first-run completion, in-chat path.
+  await seedAppStorage(page, {
+    "eliza:first-run-complete": "",
+    "eliza:in-chat-onboarding": "1",
+  });
+
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+
+  // The shell paints during first-run (flag ON) — the REAL ContinuousChatOverlay
+  // mounts and auto-opens; the legacy full-screen FirstRunChat must NOT appear.
+  const overlay = page.getByTestId("continuous-chat-overlay");
+  await expect(overlay).toBeVisible({ timeout: 20_000 });
+  await expect(page.getByTestId("first-run-chat")).toHaveCount(0);
+
+  // The seeded greeting renders as a normal assistant message.
+  await expect(page.getByText(/hey there! I'm Eliza/i)).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(page.getByText(/How would you like to run me/i)).toBeVisible({
+    timeout: 15_000,
+  });
+
+  // The runtime CHOICE renders for free via InlineWidgetText as real buttons.
+  const cloud = page.getByTestId("choice-cloud");
+  const local = page.getByTestId("choice-local");
+  const other = page.getByTestId("choice-other");
+  await expect(cloud).toBeVisible({ timeout: 15_000 });
+  await expect(local).toBeVisible();
+  await expect(other).toBeVisible();
+
+  await page.screenshot({
+    path: "test/ui-smoke/__inchat__/in-chat-onboarding-runtime-choice.png",
+    fullPage: true,
+  });
+
+  // Picking a runtime is intercepted locally (consumeFirstRunChoice) and appends
+  // the acknowledgement instead of dispatching an agent send.
+  await local.click();
+  await expect(page.getByText(/local agent on this device/i)).toBeVisible({
+    timeout: 10_000,
+  });
+
+  await expectNoRenderTelemetryErrors(page, "in-chat onboarding");
+});

--- a/packages/app/test/ui-smoke/walkthrough/JOURNEY.md
+++ b/packages/app/test/ui-smoke/walkthrough/JOURNEY.md
@@ -41,10 +41,20 @@ journey.
   - Composer: `[data-testid="chat-composer-textarea"]`
   - Send: `[data-testid="chat-composer-action"]`
   - Chat thread lines: `[data-testid="thread-line"]`
-  - First-run chat (current in-chat onboarding, replaced the old
-    `onboarding-toast`): `[data-testid="first-run-chat"]` +
-    `[data-testid="first-run-greeting"]`; runtime choices
-    `[data-choice-scope="first-run-runtime"] [data-testid="choice-cloud|local|remote"]`
+  - In-chat onboarding (#9952): the fresh-profile shell auto-opens the REAL
+    `[data-testid="continuous-chat-overlay"]` and seeds the greeting + runtime
+    CHOICE into it (no dedicated full-screen surface — the legacy
+    `first-run-chat` is absent). Enable via `localStorage` seed
+    `eliza:in-chat-onboarding="1"`. Greeting asserted by text
+    (`/hey there! I'm Eliza/i`, `/How would you like to run me/i`); the runtime
+    CHOICE is `[data-choice-scope="first-run"] [data-testid="choice-cloud|local|other"]`;
+    the provider sub-choice is `choice-provider:on-device|elizacloud`; the
+    post-provision tutorial offer is `choice-tutorial:take|skip`. Custom path:
+    `choice-custom-open → choice-custom-input → choice-custom-send`.
+  - Tutorial frames: the spotlight card stamps `data-tutorial-step-id` (welcome,
+    open-chat, resize-chat, ask-to-navigate, use-voice, new-chat,
+    swipe-between-chats, done); `tutorial-continue` advances manual/stalled
+    frames, `tutorial-skip` ends the tour.
   - Tutorial: `/tutorial` route → `[data-testid="tutorial-launcher"]` →
     `[data-testid="tutorial-start"]` → `[data-testid="tutorial-card"]`
   - Launcher: `[data-testid="launcher"]`
@@ -55,8 +65,11 @@ journey.
 
 ## Existing Coverage To Reuse
 
-- `first-run-startup.spec.ts` covers fresh first-run onboarding and runtime
-  choice rendering.
+- `in-chat-onboarding.spec.ts` covers the flag-ON in-chat first-run in isolation:
+  the real overlay auto-opens, the greeting + runtime CHOICE seed in, and a
+  `choice-local` pick is intercepted into the headless use case (no agent send).
+- `first-run-startup.spec.ts` covers the legacy full-screen onboarding surface
+  (flag OFF — the default until #9952 P3 flips it).
 - `cloud-provisioning-startup.spec.ts` and `warming-shell-startup.spec.ts`
   cover startup/provisioning readiness.
 - `tts-stt-e2e.spec.ts` covers browser STT and cloud TTS wiring with mocks.
@@ -138,37 +151,41 @@ extends the original 22 states with the asked-for **tutorial / help / settings /
 wallet / settings-edit** rows so no captured state is accepted "on sight."
 
 Lanes: the **mock** lane (default, keyless) page-mocks the conversation store so
-chat is deterministic; the **live** lane (`--live`,
-`ELIZA_UI_SMOKE_LIVE_STACK=1`) installs no conversation mock, so step 08 drives
-the real backend agent + model and writes the trajectory to
-`reports/walkthrough/<runId>/<viewport>/trajectory/chat-step.json`. Rows marked
-**live-persist** assert real persistence (`PUT /api/character` / `PUT /api/config`
-+ reload read-back) only in the live lane; the mock lane still captures them.
+chat is deterministic and stubs the single onboarding `POST /api/first-run` so
+the REAL in-chat onboarding completes with no provider key; the **live** lane
+(`--live`, `ELIZA_UI_SMOKE_LIVE_STACK=1`) installs no conversation mock, so step
+09 drives the real backend agent + model and writes the trajectory to
+`reports/walkthrough/<runId>/<viewport>/trajectory/chat-step.json`. In **both**
+lanes the onboarding choices and the tutorial are exercised for real — nothing
+flips first-run complete to skip onboarding. Rows marked **live-persist** assert
+real persistence (`PUT /api/character` / `PUT /api/config` + reload read-back)
+only in the live lane; the mock lane still captures them.
 
 | Step | Action | Expected state | Required assertions | Capture |
 | --- | --- | --- | --- | --- |
-| 01 | Cold app launch | `/` loads with first-run incomplete; the in-chat first-run greeting renders over the startup background. | No page error / no `console.error` / no 5xx; `first-run-chat` + `first-run-greeting` visible ≤20s. | `01-cold-launch.png` |
-| 02 | Onboarding runtime choice | The in-chat first-run asks how to run Eliza with the runtime choices. | Runtime question text visible; `[data-choice-scope="first-run-runtime"]` `choice-cloud` / `choice-local` / `choice-remote` all visible. | `02-onboarding-runtime.png` |
-| 03 | Choose runtime → ready | Clicking the local choice advances first-run (provider step), then resolves to a ready agent. | `choice-local` clicked; first-run flips complete; `continuous-chat-overlay` + `chat-composer-textarea` reachable. | `03-provisioning-ready.png` |
-| 04 | Interactive tutorial | The `/tutorial` launcher starts the tour spotlight. | `tutorial-launcher` → `tutorial-start` → `tutorial-card`; "Meet Eliza" text visible; tour dismissed via `tutorial-skip`. | `04-tutorial.png` |
-| 05 | Help search | The Help view searches the KB. | `help-view` visible; search "change the model" → `help-entry-change-model` references "AI Model". | `05-help.png` |
-| 06 | Open settings | The Settings shell opens. | `settings-shell` visible; "Models & Providers" section opened. | `06-settings-open.png` |
-| 07 | Wallet view | The Wallet view renders. | `wallet-shell` (or Wallet heading) visible at `/wallet`. | `07-wallet.png` |
-| 08 | Chat a conversation | A real round-trip: user line + assistant reply. | user `thread-line` visible; assistant `thread-line` visible & non-empty; **live**: reply from the real model (trajectory captured). | `08-chat-round-trip.png` |
-| 09 | Maximize chat | Overlay expands to full detent. | desktop: `chat-sheet` `data-detent=full` + `data-maximized=true`; mobile: overlay `data-open=true` (no separate maximize). | `09-chat-full-detent.png` |
-| 10 | Navigate to character editor | Chat-driven navigation reaches `/character`. | URL `/character`; `character-editor-view` visible. | `10-chat-navigate-character.png` |
-| 11 | Edit character personality | Personality panel opens; About Me edited. | field filled; **live-persist**: `PUT /api/character` + reload read-back matches. | `11-character-edit.png` |
-| 12 | Start a new chat | Fresh conversation; composer empty. | new conversation created; composer value empty for the new thread. | `12-new-chat.png` |
-| 13 | Return home from chat | Home/dashboard shows, chat collapsed. | `widget-host-home` / `home-launcher-surface` visible; overlay not `data-open=true`. | `13-home-from-chat.png` |
-| 14 | Restore the conversation | Reopening chat restores the prior thread. | `continuous-chat-overlay` visible; prior `thread-line` restored. | `14-restore-chat.png` |
-| 15 | Copy a message | A message exposes selectable/copyable text. | `data-chat-selectable="true"` (or message text) captured. | `15-copy-message.png` |
-| 16 | Paste large text → attachment | Large paste collapses to a `pasted-text.md` chip. | clipboard paste event dispatched; `pasted-text.md` chip visible; composer value stays short. | `16-paste-large.png` |
-| 17 | Clear the draft | Draft cleared, no pending chip. | composer value empty. | `17-clear-draft.png` |
-| 18 | Collapse chat to the pill | Overlay collapses to rest while composer stays reachable. | overlay no longer `data-open=true` (or composer reachable at rest). | `18-chat-pill.png` |
-| 19 | Re-open chat to full | Overlay expands back to open. | overlay `data-open=true`. | `19-chat-full-again.png` |
-| 20 | Focus the composer | Clicking the composer focuses it. | `document.activeElement` is the composer textarea. | `20-input-focused.png` |
-| 21 | Open the view launcher | Launcher grid shows. | `launcher` visible; ≥1 `launcher-tile-*`. | `21-launcher.png` |
-| 22 | Launch a view | A tile launches a real view. | first tile clicked; URL leaves `/views`. | `22-launch-view.png` |
-| 23 | Open chat over the view | Focusing the composer opens chat over the launched view without remounting it. | composer reachable over the view; `continuous-chat-overlay` present; route still on the view. | `23-chat-over-view.png` |
-| 24 | Edit a setting (persist + read-back) | A settings toggle changes and persists. | Capabilities → `capability-wallet` `aria-checked` flips; **live-persist**: `PUT /api/config` + reload read-back. | `24-settings-edit.png` |
-| 25 | Back to dashboard | App returns home; no diagnostics accumulated. | home surface visible; gate (page/console errors + 5xx) clean over the whole journey. | `25-dashboard-rest.png` |
+| 01 | Cold app launch | `/` loads with first-run incomplete + in-chat onboarding flag ON; the REAL floating chat auto-opens and seeds the greeting. | No page error / no `console.error` / no 5xx; `continuous-chat-overlay` visible ≤30s; legacy `first-run-chat` count 0; greeting text `/hey there! I'm Eliza/i` + `/How would you like to run me/i`. | `01-cold-launch.png` |
+| 02 | Onboarding runtime choice | The seeded runtime CHOICE renders as real buttons in the live chat. | `[data-choice-scope="first-run"]` `choice-cloud` / `choice-local` / `choice-other` all visible. | `02-onboarding-runtime.png` |
+| 03 | Pick local → provider choice | Clicking `choice-local` is intercepted (no agent send) and seeds the provider sub-choice. | `choice-provider:on-device` + `choice-provider:elizacloud` visible. | `03-onboarding-provider.png` |
+| 04 | Provision local agent → ready | Choosing on-device runs the real headless local setup (one `POST /api/first-run`) and offers the tutorial. | `choice-tutorial:take` + `choice-tutorial:skip` visible ≤60s; `chat-composer-textarea` reachable. | `04-provisioning-ready.png` |
+| 05 | Interactive tutorial (all 8 frames) | Taking the tour walks every frame and completes. | `tutorial-card` starts; frames welcome→open-chat→resize-chat→ask-to-navigate→use-voice→new-chat→swipe-between-chats→done all walked (real controls + stalled-frame skip); `tutorial-card` count 0 at the end. | `05-tutorial.png` |
+| 06 | Help search | The Help view searches the KB. | `help-view` visible; search "change the model" → `help-entry-change-model` references "AI Model". | `06-help.png` |
+| 07 | Open settings | The Settings shell opens. | `settings-shell` visible; "Models & Providers" section opened. | `07-settings-open.png` |
+| 08 | Wallet view | The Wallet view renders. | `wallet-shell` (or Wallet heading) visible at `/wallet`. | `08-wallet.png` |
+| 09 | Chat a conversation | A real round-trip: user line + assistant reply. | user `thread-line` visible; assistant `thread-line` visible & non-empty; **live**: reply from the real model (trajectory captured). | `09-chat-round-trip.png` |
+| 10 | Maximize chat | Overlay expands to full detent. | desktop: `chat-sheet` `data-detent=full` + `data-maximized=true`; mobile: overlay `data-open=true` (no separate maximize). | `10-chat-full-detent.png` |
+| 11 | Navigate to character editor | Chat-driven navigation reaches `/character`. | URL `/character`; `character-editor-view` visible. | `11-chat-navigate-character.png` |
+| 12 | Edit character personality | Personality panel opens; About Me edited. | field filled; **live-persist**: `PUT /api/character` + reload read-back matches. | `12-character-edit.png` |
+| 13 | Start a new chat | Fresh conversation; composer empty. | new conversation created; composer value empty for the new thread. | `13-new-chat.png` |
+| 14 | Return home from chat | Home/dashboard shows, chat collapsed. | `widget-host-home` / `home-launcher-surface` visible; overlay not `data-open=true`. | `14-home-from-chat.png` |
+| 15 | Restore the conversation | Reopening chat restores the prior thread. | `continuous-chat-overlay` visible; prior `thread-line` restored. | `15-restore-chat.png` |
+| 16 | Copy a message | A message exposes selectable/copyable text. | `data-chat-selectable="true"` (or message text) captured. | `16-copy-message.png` |
+| 17 | Paste large text → attachment | Large paste collapses to a `pasted-text.md` chip. | clipboard paste event dispatched; `pasted-text.md` chip visible; composer value stays short. | `17-paste-large.png` |
+| 18 | Clear the draft | Draft cleared, no pending chip. | composer value empty. | `18-clear-draft.png` |
+| 19 | Collapse chat to the pill | Overlay collapses to rest while composer stays reachable. | overlay no longer `data-open=true` (or composer reachable at rest). | `19-chat-pill.png` |
+| 20 | Re-open chat to full | Overlay expands back to open. | overlay `data-open=true`. | `20-chat-full-again.png` |
+| 21 | Focus the composer | Clicking the composer focuses it. | `document.activeElement` is the composer textarea. | `21-input-focused.png` |
+| 22 | Open the view launcher | Launcher grid shows. | `launcher` visible; ≥1 `launcher-tile-*`. | `22-launcher.png` |
+| 23 | Launch a view | A tile launches a real view. | first tile clicked; URL leaves `/views`. | `23-launch-view.png` |
+| 24 | Open chat over the view | Focusing the composer opens chat over the launched view without remounting it. | composer reachable over the view; `continuous-chat-overlay` present; route still on the view. | `24-chat-over-view.png` |
+| 25 | Edit a setting (persist + read-back) | A settings toggle changes and persists. | Capabilities → `capability-wallet` `aria-checked` flips; **live-persist**: `PUT /api/config` + reload read-back. | `25-settings-edit.png` |
+| 26 | Back to dashboard | App returns home; no diagnostics accumulated. | home surface visible; gate (page/console errors + 5xx) clean over the whole journey. | `26-dashboard-rest.png` |

--- a/packages/app/test/ui-smoke/walkthrough/WALKTHROUGH_VERDICTS.md
+++ b/packages/app/test/ui-smoke/walkthrough/WALKTHROUGH_VERDICTS.md
@@ -3,67 +3,75 @@
 Per-step screenshot verdicts for the continuous full-walkthrough run, scored
 against each step's expectation row in [`JOURNEY.md`](./JOURNEY.md).
 
-- Run: `2026-06-29_20-20-57_mock` (keyless mock lane, desktop + mobile)
-- Method: hand-reviewed by vision-capable agents. The automated reviewer
-  (`scripts/ai-qa/review-walkthrough.mjs`) is wired and ran 50 real
-  `api.anthropic.com` calls, but the host key is unfunded (HTTP 400 billing),
-  so verdicts were produced by human/agent review against the same criteria.
-- Totals: **45 good · 5 needs-work · 0 broken** (of 50). Gate passes (0 broken).
-
-The `needs-work` rows are **pre-existing app defects the walkthrough surfaced**
-(out of scope to fix per #10198 — it drives/records existing surfaces, it does
-not change them): the character editor leaks i18n placeholder keys in its Style
-Rules section, and the settings floating back-button overlaps the sidebar title.
+> **Re-capture pending (#9952 P4).** The journey was rewritten to drive the REAL
+> in-chat onboarding (#9952) — greeting → runtime CHOICE → provider → one
+> `POST /api/first-run` — plus all 8 tutorial frames, replacing the old faked
+> first-run flip and the dead `first-run-chat` / `first-run-runtime` / `choice-remote`
+> selectors. The 26-step layout below is regenerated from the rewritten
+> `journey.ts`. The vision verdicts are produced by the nightly **live** lane
+> (`app-live-e2e.yml` → `walkthrough-live`, no `--skip-review`) and by
+> `bun run --cwd packages/app test:e2e:walkthrough:live` locally; the keyless PR
+> lane (`scenario-pr.yml` → `app-walkthrough-mock`, `--skip-review`) records the
+> screenshots + stitched mp4 without vision scoring (no funded key). Fill the
+> verdict per row (`good` · `needs-work` · `needs-eyeball` · `broken`) from the
+> uploaded artifact bundle after the lane runs; no row ships blank.
+>
+> Method: the automated reviewer (`scripts/ai-qa/review-walkthrough.mjs`) scores
+> each `NN-step.png` against its JOURNEY.md expectation; any `needs-work` /
+> `broken` row that is a pre-existing app defect (the walkthrough drives existing
+> surfaces, it does not change them) is annotated as such.
 
 | Step | Viewport | Verdict | Notes |
 | --- | --- | --- | --- |
-| 01 cold-launch | desktop | ✅ good | clean |
-| 02 onboarding-runtime | desktop | ✅ good | clean |
-| 03 provisioning-ready | desktop | ✅ good | clean |
-| 04 tutorial | desktop | ✅ good | clean |
-| 05 help | desktop | ✅ good | clean |
-| 06 settings-open | desktop | ✅ good | clean |
-| 07 wallet | desktop | ✅ good | clean |
-| 08 chat-round-trip | desktop | ✅ good | clean |
-| 09 chat-full-detent | desktop | ✅ good | clean |
-| 10 chat-navigate-character | desktop | ✅ good | clean |
-| 11 character-edit | desktop | ✅ good | clean |
-| 12 new-chat | desktop | ✅ good | clean |
-| 13 home-from-chat | desktop | ✅ good | clean |
-| 14 restore-chat | desktop | ✅ good | clean |
-| 15 copy-message | desktop | ✅ good | clean |
-| 16 paste-large | desktop | ✅ good | clean |
-| 17 clear-draft | desktop | ✅ good | clean |
-| 18 chat-pill | desktop | ✅ good | clean |
-| 19 chat-full-again | desktop | ✅ good | clean |
-| 20 input-focused | desktop | ✅ good | clean |
-| 21 launcher | desktop | ✅ good | clean |
-| 22 launch-view | desktop | ✅ good | clean |
-| 23 chat-over-view | desktop | ✅ good | clean |
-| 24 settings-edit | desktop | ✅ good | clean |
-| 25 dashboard-rest | desktop | ✅ good | clean |
-| 01 cold-launch | mobile | ✅ good | clean |
-| 02 onboarding-runtime | mobile | ✅ good | clean |
-| 03 provisioning-ready | mobile | ✅ good | clean |
-| 04 tutorial | mobile | ✅ good | clean |
-| 05 help | mobile | ✅ good | clean |
-| 06 settings-open | mobile | ✅ good | clean |
-| 07 wallet | mobile | ✅ good | clean |
-| 08 chat-round-trip | mobile | ✅ good | clean |
-| 09 chat-full-detent | mobile | ✅ good | clean |
-| 10 chat-navigate-character | mobile | ✅ good | clean |
-| 11 character-edit | mobile | 🟡 needs-work | Three labels render as leaked placeholder/label tokens instead of real copy: 'Style Rules Header', 'Style Rules Help', and the button 'Add Style Rule Short'.; Otherwise the Persona |
-| 12 new-chat | mobile | ✅ good | clean |
-| 13 home-from-chat | mobile | ✅ good | clean |
-| 14 restore-chat | mobile | ✅ good | clean |
-| 15 copy-message | mobile | ✅ good | clean |
-| 16 paste-large | mobile | 🟡 needs-work | The chat sheet's drag handle and toolbar buttons (expand/copy/refresh and grid) overlap the home dashboard cards behind them ('W… just now' / 'Connect cal…' / 'Dismiss' row), colli |
-| 17 clear-draft | mobile | ✅ good | clean |
-| 18 chat-pill | mobile | ✅ good | clean |
-| 19 chat-full-again | mobile | ✅ good | clean |
-| 20 input-focused | mobile | ✅ good | clean |
-| 21 launcher | mobile | ✅ good | clean |
-| 22 launch-view | mobile | 🟡 needs-work | Launched Settings view content is correct (Agent + System sections with rows), satisfying 'not the launcher grid'.; Defect: the floating circular back button overlaps and clips the |
-| 23 chat-over-view | mobile | 🟡 needs-work | Chat overlay is correctly reachable over the Settings view (shows 'open my character' / 'Saved — walkthrough reply captured'), meeting expectation.; Defect: same header issue — the |
-| 24 settings-edit | mobile | 🟡 needs-work | Capabilities section renders with toggles (Wallet/Browser ON in orange, Computer Use/Auto-training off) and a Proactive-suggestions Off/Subtle/Chatty segmented control — matches th |
-| 25 dashboard-rest | mobile | ✅ good | clean |
+| 01 cold-launch | desktop | ⏳ pending | re-capture on next walkthrough run |
+| 02 onboarding-runtime | desktop | ⏳ pending | re-capture on next walkthrough run |
+| 03 onboarding-provider | desktop | ⏳ pending | re-capture on next walkthrough run |
+| 04 provisioning-ready | desktop | ⏳ pending | re-capture on next walkthrough run |
+| 05 tutorial | desktop | ⏳ pending | re-capture on next walkthrough run |
+| 06 help | desktop | ⏳ pending | re-capture on next walkthrough run |
+| 07 settings-open | desktop | ⏳ pending | re-capture on next walkthrough run |
+| 08 wallet | desktop | ⏳ pending | re-capture on next walkthrough run |
+| 09 chat-round-trip | desktop | ⏳ pending | re-capture on next walkthrough run |
+| 10 chat-full-detent | desktop | ⏳ pending | re-capture on next walkthrough run |
+| 11 chat-navigate-character | desktop | ⏳ pending | re-capture on next walkthrough run |
+| 12 character-edit | desktop | ⏳ pending | re-capture on next walkthrough run |
+| 13 new-chat | desktop | ⏳ pending | re-capture on next walkthrough run |
+| 14 home-from-chat | desktop | ⏳ pending | re-capture on next walkthrough run |
+| 15 restore-chat | desktop | ⏳ pending | re-capture on next walkthrough run |
+| 16 copy-message | desktop | ⏳ pending | re-capture on next walkthrough run |
+| 17 paste-large | desktop | ⏳ pending | re-capture on next walkthrough run |
+| 18 clear-draft | desktop | ⏳ pending | re-capture on next walkthrough run |
+| 19 chat-pill | desktop | ⏳ pending | re-capture on next walkthrough run |
+| 20 chat-full-again | desktop | ⏳ pending | re-capture on next walkthrough run |
+| 21 input-focused | desktop | ⏳ pending | re-capture on next walkthrough run |
+| 22 launcher | desktop | ⏳ pending | re-capture on next walkthrough run |
+| 23 launch-view | desktop | ⏳ pending | re-capture on next walkthrough run |
+| 24 chat-over-view | desktop | ⏳ pending | re-capture on next walkthrough run |
+| 25 settings-edit | desktop | ⏳ pending | re-capture on next walkthrough run |
+| 26 dashboard-rest | desktop | ⏳ pending | re-capture on next walkthrough run |
+| 01 cold-launch | mobile | ⏳ pending | re-capture on next walkthrough run |
+| 02 onboarding-runtime | mobile | ⏳ pending | re-capture on next walkthrough run |
+| 03 onboarding-provider | mobile | ⏳ pending | re-capture on next walkthrough run |
+| 04 provisioning-ready | mobile | ⏳ pending | re-capture on next walkthrough run |
+| 05 tutorial | mobile | ⏳ pending | re-capture on next walkthrough run |
+| 06 help | mobile | ⏳ pending | re-capture on next walkthrough run |
+| 07 settings-open | mobile | ⏳ pending | re-capture on next walkthrough run |
+| 08 wallet | mobile | ⏳ pending | re-capture on next walkthrough run |
+| 09 chat-round-trip | mobile | ⏳ pending | re-capture on next walkthrough run |
+| 10 chat-full-detent | mobile | ⏳ pending | re-capture on next walkthrough run |
+| 11 chat-navigate-character | mobile | ⏳ pending | re-capture on next walkthrough run |
+| 12 character-edit | mobile | ⏳ pending | re-capture on next walkthrough run |
+| 13 new-chat | mobile | ⏳ pending | re-capture on next walkthrough run |
+| 14 home-from-chat | mobile | ⏳ pending | re-capture on next walkthrough run |
+| 15 restore-chat | mobile | ⏳ pending | re-capture on next walkthrough run |
+| 16 copy-message | mobile | ⏳ pending | re-capture on next walkthrough run |
+| 17 paste-large | mobile | ⏳ pending | re-capture on next walkthrough run |
+| 18 clear-draft | mobile | ⏳ pending | re-capture on next walkthrough run |
+| 19 chat-pill | mobile | ⏳ pending | re-capture on next walkthrough run |
+| 20 chat-full-again | mobile | ⏳ pending | re-capture on next walkthrough run |
+| 21 input-focused | mobile | ⏳ pending | re-capture on next walkthrough run |
+| 22 launcher | mobile | ⏳ pending | re-capture on next walkthrough run |
+| 23 launch-view | mobile | ⏳ pending | re-capture on next walkthrough run |
+| 24 chat-over-view | mobile | ⏳ pending | re-capture on next walkthrough run |
+| 25 settings-edit | mobile | ⏳ pending | re-capture on next walkthrough run |
+| 26 dashboard-rest | mobile | ⏳ pending | re-capture on next walkthrough run |

--- a/packages/app/test/ui-smoke/walkthrough/journey.ts
+++ b/packages/app/test/ui-smoke/walkthrough/journey.ts
@@ -523,7 +523,13 @@ export async function installJourneyRoutes(
   lane: Lane,
 ): Promise<JourneyRoutes> {
   await injectFullCapabilityHost(page);
-  await seedAppStorage(page, { "eliza:first-run-complete": "" });
+  // Fresh device + in-chat onboarding flag ON (the e2e localStorage override
+  // flips the flag without a host rebuild — see in-chat-onboarding.ts). The
+  // onboarding steps drive the REAL in-chat first-run; nothing fakes completion.
+  await seedAppStorage(page, {
+    "eliza:first-run-complete": "",
+    "eliza:in-chat-onboarding": "1",
+  });
   await installDefaultAppRoutes(page);
   // The agent's TTS playback (e.g. the tutorial tour narrating) posts far-end
   // reference frames to this OPTIONAL echo-cancellation route. The keyless stub
@@ -557,6 +563,18 @@ async function installMockLaneWrites(page: Page): Promise<void> {
   await page.route("**/api/character", async (route) => {
     const method = route.request().method();
     if (method === "PUT" || method === "PATCH") {
+      await fulfillJson(route, 200, { ok: true });
+      return;
+    }
+    await route.fallback();
+  });
+  // The headless first-run use case submits the profile exactly once via
+  // `POST /api/first-run` (server sets meta.firstRunComplete). The keyless stub
+  // stack 501s unmocked writes; ack it so the REAL on-device onboarding path
+  // (start → await agent → submit) completes deterministically with no key. The
+  // live lane installs none of this — its onboarding POST hits the real backend.
+  await page.route("**/api/first-run", async (route) => {
+    if (route.request().method() === "POST") {
       await fulfillJson(route, 200, { ok: true });
       return;
     }
@@ -616,15 +634,155 @@ async function navigateViaAgentEvent(
   }, detail);
 }
 
+/**
+ * Re-enter chat after the REAL in-chat onboarding has already completed (steps
+ * 01–05). This never fakes first-run — onboarding ran for real and flipped the
+ * mutable `/api/first-run/status` mock to complete (step 05), so a navigation to
+ * `/chat` lands on the ready chat surface. Used by the later chat steps.
+ */
 async function reachChatReady(ctx: StepContext): Promise<void> {
-  ctx.routes.firstRun.setComplete(true);
-  await ctx.page.evaluate(() => {
-    localStorage.setItem("eliza:first-run-complete", "1");
-  });
   await openAppPath(ctx.page, "/chat");
   await expect(ctx.page.getByTestId("continuous-chat-overlay")).toBeVisible({
     timeout: 60_000,
   });
+}
+
+// --- tutorial driving -------------------------------------------------------
+
+/** The interactive tour's eight frames, in order (tutorial-steps.ts). */
+const TUTORIAL_FRAME_ORDER = [
+  "welcome",
+  "open-chat",
+  "resize-chat",
+  "ask-to-navigate",
+  "use-voice",
+  "new-chat",
+  "swipe-between-chats",
+  "done",
+] as const;
+
+/** The active tour frame id, stamped on the spotlight card, or null when the
+ * tour is not showing a card. */
+async function currentTutorialStepId(page: Page): Promise<string | null> {
+  const card = page.getByTestId("tutorial-card");
+  if (!(await card.isVisible().catch(() => false))) return null;
+  return card.getAttribute("data-tutorial-step-id").catch(() => null);
+}
+
+/** Resolve true once the active frame id differs from `fromStepId` (advanced)
+ * or the tour has ended (card gone), within `timeoutMs`. */
+async function pollTutorialAdvance(
+  page: Page,
+  fromStepId: string,
+  timeoutMs: number,
+): Promise<boolean> {
+  try {
+    await expect
+      .poll(async () => (await currentTutorialStepId(page)) ?? "__ended__", {
+        timeout: timeoutMs,
+        intervals: [250],
+      })
+      .not.toBe(fromStepId);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Perform the real per-frame action. Manual frames (welcome/done) click the
+ * spotlight's continue button; interactive frames drive the actual chat control
+ * the frame points at so the tour auto-advances on its own success signal. */
+async function performTutorialAction(
+  page: Page,
+  stepId: string,
+): Promise<void> {
+  const clickIfVisible = async (testId: string) => {
+    const el = page.getByTestId(testId).first();
+    if (await el.isVisible().catch(() => false))
+      await el.click().catch(() => undefined);
+  };
+  switch (stepId) {
+    case "welcome":
+    case "done":
+      // manualContinue frames — the spotlight's primary button advances.
+      await clickIfVisible("tutorial-continue");
+      return;
+    case "open-chat":
+      await clickIfVisible("chat-pill");
+      return;
+    case "resize-chat": {
+      const grabber = page.getByTestId("chat-sheet-grabber");
+      if (await grabber.isVisible().catch(() => false)) {
+        await grabber.focus().catch(() => undefined);
+        await page.keyboard.press("ArrowUp").catch(() => undefined); // expand (beat 1)
+        await page.keyboard.press("ArrowDown").catch(() => undefined); // shrink (beat 2)
+        await page.keyboard.press("ArrowDown").catch(() => undefined);
+      }
+      return;
+    }
+    case "ask-to-navigate":
+      // The frame pre-fills "open settings"; sending it satisfies the frame and
+      // navigates to Settings for real (navigateOnDone).
+      await clickIfVisible("chat-composer-action");
+      return;
+    case "use-voice":
+      // No real microphone in headless Chromium — engage the mic, then let the
+      // tour's stalled-frame skip affordance advance the frame.
+      await clickIfVisible("chat-composer-mic");
+      return;
+    case "new-chat":
+      await clickIfVisible("shell-new-chat");
+      return;
+    case "swipe-between-chats": {
+      // Best-effort horizontal swipe across the chat sheet; the stalled-frame
+      // skip advances if a single conversation makes the swipe a no-op.
+      const sheet = page.getByTestId("chat-sheet");
+      const box = await sheet.boundingBox().catch(() => null);
+      if (box) {
+        const y = box.y + box.height / 2;
+        await page.mouse.move(box.x + box.width * 0.8, y);
+        await page.mouse.down();
+        await page.mouse.move(box.x + box.width * 0.2, y, { steps: 12 });
+        await page.mouse.up();
+      }
+      return;
+    }
+  }
+}
+
+/**
+ * Drive the interactive tour through every frame and return the ordered frame
+ * ids actually walked. Each frame: perform its real action; if the tour does not
+ * auto-advance (a frame that needs a real mic/swipe signal headless can't
+ * produce), use the tour's own stalled-frame "Skip" control — the real skip
+ * affordance — to advance. Forward progress is always guaranteed, so the tour
+ * reaches `done` and completes.
+ */
+async function driveTutorial(page: Page): Promise<string[]> {
+  await expect(page.getByTestId("tutorial-card")).toBeVisible({
+    timeout: 15_000,
+  });
+  const seen: string[] = [];
+  for (let i = 0; i < TUTORIAL_FRAME_ORDER.length + 4; i++) {
+    const stepId = await currentTutorialStepId(page);
+    if (!stepId) break;
+    if (seen[seen.length - 1] !== stepId) seen.push(stepId);
+    await performTutorialAction(page, stepId);
+    if (await pollTutorialAdvance(page, stepId, 6_000)) continue;
+    // Frame stalled (a real mic/swipe signal isn't available headless): wait for
+    // the late "Skip" control to surface, then advance through it.
+    const cont = page.getByTestId("tutorial-continue");
+    await cont
+      .waitFor({ state: "visible", timeout: 16_000 })
+      .catch(() => undefined);
+    if (await cont.isVisible().catch(() => false)) {
+      await cont.click().catch(() => undefined);
+      await pollTutorialAdvance(page, stepId, 6_000);
+    } else {
+      break;
+    }
+  }
+  return seen;
 }
 
 async function domMarkers(
@@ -650,23 +808,31 @@ export const JOURNEY_STEPS: readonly JourneyStep[] = [
     id: "cold-launch",
     title: "Cold app launch",
     expectation:
-      "First app load from / with first-run incomplete: the in-chat first-run greeting ('hey there! I'm Eliza.') renders over the startup background. No render failure, no stack trace.",
+      "First load from / with first-run incomplete and the in-chat onboarding flag ON: the REAL floating chat (ContinuousChatOverlay) auto-opens and seeds the onboarding greeting ('hey there! I'm Eliza…'). The legacy full-screen onboarding never appears.",
     async run({ page }) {
       await page.goto("/", { waitUntil: "domcontentloaded" });
-      await expect(page.getByTestId("first-run-chat")).toBeVisible({
+      await expect(page.getByTestId("continuous-chat-overlay")).toBeVisible({
+        timeout: 30_000,
+      });
+      // The legacy full-screen first-run surface must NOT mount.
+      await expect(page.getByTestId("first-run-chat")).toHaveCount(0);
+      await expect(page.getByText(/hey there! I'm Eliza/i)).toBeVisible({
         timeout: 20_000,
       });
-      await expect(page.getByTestId("first-run-greeting")).toBeVisible({
-        timeout: 10_000,
-      });
+      await expect(page.getByText(/How would you like to run me/i)).toBeVisible(
+        {
+          timeout: 10_000,
+        },
+      );
       return {
         assertions: [
-          "Loaded / with first-run incomplete",
-          "first-run-chat + greeting became visible within 20s",
+          "Loaded / with first-run incomplete + in-chat onboarding flag ON",
+          "continuous-chat-overlay auto-opened with the seeded greeting",
+          "legacy full-screen first-run surface absent",
         ],
         dom: await domMarkers(page, {
-          firstRunChat: '[data-testid="first-run-chat"]',
-          firstRunGreeting: '[data-testid="first-run-greeting"]',
+          overlay: '[data-testid="continuous-chat-overlay"]',
+          choiceScope: '[data-choice-scope="first-run"]',
           root: "#root",
         }),
       };
@@ -677,97 +843,119 @@ export const JOURNEY_STEPS: readonly JourneyStep[] = [
     id: "onboarding-runtime",
     title: "Onboarding runtime choice",
     expectation:
-      "The in-chat first-run asks how to run Eliza and offers the cloud, local, and remote runtime choices.",
+      "The seeded runtime CHOICE renders as real buttons in the live chat (scope first-run): Log in with Eliza Cloud / Run locally / Something else.",
     async run({ page }) {
-      await expect(
-        page.getByText(/log in with your Eliza Cloud account/i),
-      ).toBeVisible({ timeout: 15_000 });
-      const runtime = page.locator('[data-choice-scope="first-run-runtime"]');
-      await expect(runtime.getByTestId("choice-cloud")).toBeVisible();
-      await expect(runtime.getByTestId("choice-local")).toBeVisible();
-      await expect(runtime.getByTestId("choice-remote")).toBeVisible();
+      const scope = page.locator('[data-choice-scope="first-run"]').first();
+      await expect(scope.getByTestId("choice-cloud")).toBeVisible({
+        timeout: 20_000,
+      });
+      await expect(scope.getByTestId("choice-local")).toBeVisible();
+      await expect(scope.getByTestId("choice-other")).toBeVisible();
       return {
         assertions: [
-          "Runtime question visible (Eliza Cloud vs local vs own agent)",
-          "choice-cloud / choice-local / choice-remote all visible",
+          "first-run runtime CHOICE rendered in the real chat transcript",
+          "choice-cloud / choice-local / choice-other all visible",
         ],
         dom: await domMarkers(page, {
-          cloud:
-            '[data-choice-scope="first-run-runtime"] [data-testid="choice-cloud"]',
-          local:
-            '[data-choice-scope="first-run-runtime"] [data-testid="choice-local"]',
-          remote:
-            '[data-choice-scope="first-run-runtime"] [data-testid="choice-remote"]',
+          cloud: '[data-choice-scope="first-run"] [data-testid="choice-cloud"]',
+          local: '[data-choice-scope="first-run"] [data-testid="choice-local"]',
+          other: '[data-choice-scope="first-run"] [data-testid="choice-other"]',
         }),
       };
     },
   },
   {
     n: "03",
-    id: "provisioning-ready",
-    title: "Choose runtime → ready",
+    id: "onboarding-provider",
+    title: "Pick local runtime → provider choice",
     expectation:
-      "Choosing the local runtime advances first-run (the 'Where should I run my AI?' provider step) and resolves to a ready agent: the chat overlay + composer are reachable.",
-    async run(ctx) {
-      const { page } = ctx;
-      // Drive the real local-runtime selection (advances to the provider step),
-      // then resolve first-run so the journey lands on a ready agent (real cloud
-      // provisioning is out of scope per JOURNEY.md's surface decision).
-      const local = page
-        .locator('[data-choice-scope="first-run-runtime"]')
-        .getByTestId("choice-local");
-      if (await local.isVisible().catch(() => false)) {
-        await local.click().catch(() => undefined);
-      }
-      await reachChatReady(ctx);
-      await expect(composer(page)).toBeVisible({ timeout: 30_000 });
+      "Clicking 'Run locally' is intercepted by the headless first-run use case (no agent send) and seeds the provider sub-choice: On-device vs Eliza Cloud inference.",
+    async run({ page }) {
+      await page.getByTestId("choice-local").click();
+      await expect(page.getByTestId("choice-provider:on-device")).toBeVisible({
+        timeout: 15_000,
+      });
+      await expect(
+        page.getByTestId("choice-provider:elizacloud"),
+      ).toBeVisible();
       return {
         assertions: [
-          "Selected the local runtime choice",
-          "first-run resolved to complete",
-          "chat overlay + composer reachable (ready agent)",
+          "choice-local picked → intercepted by consumeFirstRunChoice (no agent send)",
+          "provider sub-choice seeded (on-device / elizacloud)",
         ],
         dom: await domMarkers(page, {
-          overlay: '[data-testid="continuous-chat-overlay"]',
-          composer: '[data-testid="chat-composer-textarea"]',
+          onDevice: '[data-testid="choice-provider:on-device"]',
+          cloudInference: '[data-testid="choice-provider:elizacloud"]',
         }),
       };
     },
   },
   {
     n: "04",
-    id: "tutorial",
-    title: "Interactive tutorial",
+    id: "provisioning-ready",
+    title: "Provision local agent → ready + tutorial offer",
     expectation:
-      "The /tutorial launcher starts the interactive tour and the 'Meet Eliza' spotlight card renders.",
-    async run({ page }) {
-      await openAppPath(page, "/tutorial");
-      await expect(page.getByTestId("tutorial-launcher")).toBeVisible({
-        timeout: 20_000,
+      "Choosing on-device runs the REAL headless local setup (start → await agent → exactly one POST /api/first-run), resolves to a ready agent, then offers the tutorial-or-skip choice. The chat composer is reachable.",
+    async run(ctx) {
+      const { page } = ctx;
+      await page.getByTestId("choice-provider:on-device").click();
+      // The real local-setup completes, then the conductor seeds the
+      // tutorial-or-skip choice — proof provisioning resolved end to end.
+      await expect(page.getByTestId("choice-tutorial:take")).toBeVisible({
+        timeout: 60_000,
       });
-      await page.getByTestId("tutorial-start").click();
-      await expect(page.getByTestId("tutorial-card")).toBeVisible({
-        timeout: 15_000,
-      });
-      await expect(page.getByText(/Meet Eliza/i)).toBeVisible({
-        timeout: 10_000,
-      });
-      // NOTE: do not dismiss the spotlight here — the per-step screenshot is
-      // taken right after this returns, so the 'Meet Eliza' card must still be on
-      // screen to be captured. The next step's full navigation unmounts the tour.
+      await expect(page.getByTestId("choice-tutorial:skip")).toBeVisible();
+      await expect(composer(page)).toBeVisible({ timeout: 30_000 });
       return {
         assertions: [
-          "/tutorial launcher started the tour",
-          "tutorial-card 'Meet Eliza' spotlight visible (captured before dismissal)",
+          "choice-provider:on-device picked → real local setup ran (one POST /api/first-run)",
+          "tutorial-or-skip choice offered after provisioning",
+          "chat composer reachable (ready agent)",
         ],
         dom: await domMarkers(page, {
-          tutorialCard: '[data-testid="tutorial-card"]',
+          tutorialTake: '[data-testid="choice-tutorial:take"]',
+          composer: '[data-testid="chat-composer-textarea"]',
         }),
       };
     },
   },
   {
     n: "05",
+    id: "tutorial",
+    title: "Interactive tutorial (all 8 frames)",
+    expectation:
+      "Taking the tour starts the interactive spotlight and walks every frame in order (welcome → open-chat → resize-chat → ask-to-navigate → use-voice → new-chat → swipe-between-chats → done), exercising the real chat controls and the stalled-frame skip affordance, then completes.",
+    async run(ctx) {
+      const { page } = ctx;
+      await page.getByTestId("choice-tutorial:take").click();
+      // Onboarding is now complete for real (finalizeFirstRun → completeFirstRun
+      // + startTutorial). Flip the mutable first-run status mock to complete so
+      // later reloads stay on the ready chat surface — NOT a fake of onboarding,
+      // which already ran end to end above.
+      ctx.routes.firstRun.setComplete(true);
+      const seen = await driveTutorial(page);
+      await expect(page.getByTestId("tutorial-card")).toHaveCount(0, {
+        timeout: 15_000,
+      });
+      const droppedFrames = TUTORIAL_FRAME_ORDER.filter(
+        (f) => !seen.includes(f),
+      );
+      expect(
+        droppedFrames,
+        `tour skipped frames: ${droppedFrames.join(", ")}`,
+      ).toEqual([]);
+      return {
+        assertions: [
+          "choice-tutorial:take started the interactive tour",
+          `walked all ${seen.length} tour frames: ${seen.join(" → ")}`,
+          "tour completed (no spotlight card remaining)",
+        ],
+        dom: { framesSeen: seen },
+      };
+    },
+  },
+  {
+    n: "06",
     id: "help",
     title: "Help search",
     expectation:
@@ -797,7 +985,7 @@ export const JOURNEY_STEPS: readonly JourneyStep[] = [
     },
   },
   {
-    n: "06",
+    n: "07",
     id: "settings-open",
     title: "Open settings",
     expectation:
@@ -820,7 +1008,7 @@ export const JOURNEY_STEPS: readonly JourneyStep[] = [
     },
   },
   {
-    n: "07",
+    n: "08",
     id: "wallet",
     title: "Wallet view",
     expectation:
@@ -840,7 +1028,7 @@ export const JOURNEY_STEPS: readonly JourneyStep[] = [
     },
   },
   {
-    n: "08",
+    n: "09",
     id: "chat-round-trip",
     title: "Chat a conversation",
     expectation:
@@ -917,7 +1105,7 @@ export const JOURNEY_STEPS: readonly JourneyStep[] = [
     },
   },
   {
-    n: "09",
+    n: "10",
     id: "chat-full-detent",
     title: "Maximize chat",
     expectation:
@@ -957,7 +1145,7 @@ export const JOURNEY_STEPS: readonly JourneyStep[] = [
     },
   },
   {
-    n: "10",
+    n: "11",
     id: "chat-navigate-character",
     title: "Navigate to character editor",
     expectation:
@@ -988,7 +1176,7 @@ export const JOURNEY_STEPS: readonly JourneyStep[] = [
     },
   },
   {
-    n: "11",
+    n: "12",
     id: "character-edit",
     title: "Edit character personality",
     expectation:
@@ -1063,7 +1251,7 @@ export const JOURNEY_STEPS: readonly JourneyStep[] = [
     },
   },
   {
-    n: "12",
+    n: "13",
     id: "new-chat",
     title: "Start a new chat",
     expectation:
@@ -1104,7 +1292,7 @@ export const JOURNEY_STEPS: readonly JourneyStep[] = [
     },
   },
   {
-    n: "13",
+    n: "14",
     id: "home-from-chat",
     title: "Return home from chat",
     expectation:
@@ -1130,7 +1318,7 @@ export const JOURNEY_STEPS: readonly JourneyStep[] = [
     },
   },
   {
-    n: "14",
+    n: "15",
     id: "restore-chat",
     title: "Restore the conversation",
     expectation:
@@ -1162,7 +1350,7 @@ export const JOURNEY_STEPS: readonly JourneyStep[] = [
     },
   },
   {
-    n: "15",
+    n: "16",
     id: "copy-message",
     title: "Copy a message",
     desktopOnly: false,
@@ -1197,7 +1385,7 @@ export const JOURNEY_STEPS: readonly JourneyStep[] = [
     },
   },
   {
-    n: "16",
+    n: "17",
     id: "paste-large",
     title: "Paste large text → attachment",
     expectation:
@@ -1245,7 +1433,7 @@ export const JOURNEY_STEPS: readonly JourneyStep[] = [
     },
   },
   {
-    n: "17",
+    n: "18",
     id: "clear-draft",
     title: "Clear the draft",
     expectation:
@@ -1269,7 +1457,7 @@ export const JOURNEY_STEPS: readonly JourneyStep[] = [
     },
   },
   {
-    n: "18",
+    n: "19",
     id: "chat-pill",
     title: "Collapse chat to the pill",
     expectation:
@@ -1296,7 +1484,7 @@ export const JOURNEY_STEPS: readonly JourneyStep[] = [
     },
   },
   {
-    n: "19",
+    n: "20",
     id: "chat-full-again",
     title: "Re-open chat to full",
     expectation:
@@ -1322,7 +1510,7 @@ export const JOURNEY_STEPS: readonly JourneyStep[] = [
     },
   },
   {
-    n: "20",
+    n: "21",
     id: "input-focused",
     title: "Focus the composer",
     expectation:
@@ -1345,7 +1533,7 @@ export const JOURNEY_STEPS: readonly JourneyStep[] = [
     },
   },
   {
-    n: "21",
+    n: "22",
     id: "launcher",
     title: "Open the view launcher",
     expectation:
@@ -1373,7 +1561,7 @@ export const JOURNEY_STEPS: readonly JourneyStep[] = [
     },
   },
   {
-    n: "22",
+    n: "23",
     id: "launch-view",
     title: "Launch a view",
     expectation:
@@ -1409,7 +1597,7 @@ export const JOURNEY_STEPS: readonly JourneyStep[] = [
     },
   },
   {
-    n: "23",
+    n: "24",
     id: "chat-over-view",
     title: "Open chat over the view",
     expectation:
@@ -1453,7 +1641,7 @@ export const JOURNEY_STEPS: readonly JourneyStep[] = [
     },
   },
   {
-    n: "24",
+    n: "25",
     id: "settings-edit",
     title: "Edit a setting (persist + read-back)",
     expectation:
@@ -1522,7 +1710,7 @@ export const JOURNEY_STEPS: readonly JourneyStep[] = [
     },
   },
   {
-    n: "25",
+    n: "26",
     id: "dashboard-rest",
     title: "Back to dashboard",
     expectation:

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -78,6 +78,7 @@ import {
   FOCUS_CONNECTOR_EVENT,
   type FocusConnectorEventDetail,
 } from "./events";
+import { isInChatOnboardingEnabled } from "./first-run/in-chat-onboarding";
 import { BugReportProvider, useBugReportState, useContextMenu } from "./hooks";
 import { useAuthStatus } from "./hooks/useAuthStatus";
 import { useSecretsManagerShortcut } from "./hooks/useSecretsManagerShortcut";
@@ -102,7 +103,6 @@ import {
 } from "./state";
 import { goHome } from "./state/shell-surface-store";
 import { isShellPaintable } from "./state/startup-coordinator";
-import { isInChatOnboardingEnabled } from "./first-run/in-chat-onboarding";
 import { VoiceSelfTestShell } from "./voice/voice-selftest/VoiceSelfTestShell";
 import { VoiceWorkbenchShell } from "./voice/voice-selftest/VoiceWorkbenchShell";
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -102,6 +102,7 @@ import {
 } from "./state";
 import { goHome } from "./state/shell-surface-store";
 import { isShellPaintable } from "./state/startup-coordinator";
+import { isInChatOnboardingEnabled } from "./first-run/in-chat-onboarding";
 import { VoiceSelfTestShell } from "./voice/voice-selftest/VoiceSelfTestShell";
 import { VoiceWorkbenchShell } from "./voice/voice-selftest/VoiceWorkbenchShell";
 
@@ -1689,7 +1690,10 @@ export function App() {
   // pre-shell phases (session restore, backend polling, first-run, pairing,
   // error) keep the full-screen StartupScreen. Runtime-dependent effects and
   // overlay apps below stay gated on `isCoordinatorReady` and defer safely.
-  const isShellPaintableNow = isShellPaintable(startupCoordinator.phase);
+  const isShellPaintableNow =
+    isShellPaintable(startupCoordinator.phase) ||
+    (isInChatOnboardingEnabled() &&
+      startupCoordinator.phase === "first-run-required");
 
   const { state: authState, refetch: refetchAuth } = useAuthStatus({
     skip: !isShellPaintableNow || isPopout,

--- a/packages/ui/src/components/pages/tutorial/TutorialOverlay.tsx
+++ b/packages/ui/src/components/pages/tutorial/TutorialOverlay.tsx
@@ -223,6 +223,7 @@ export function TutorialOverlay(): React.ReactElement | null {
         />
       )}
       <TutorialSpotlight
+        stepId={step.id}
         targetSelector={step.targetSelector}
         dimOutside={!succeeded}
         title={step.title}

--- a/packages/ui/src/components/pages/tutorial/TutorialSpotlight.tsx
+++ b/packages/ui/src/components/pages/tutorial/TutorialSpotlight.tsx
@@ -19,6 +19,8 @@ import { Z_TUTORIAL } from "../../../lib/floating-layers";
 const PAD = 8; // glow  inset around the target
 
 export interface SpotlightCardProps {
+  /** Active tour frame id — stamped on the card so e2e can drive frame-by-frame. */
+  stepId: string;
   title: string;
   body: string;
   /** Narration muted — toggles the speaker control. */
@@ -246,6 +248,7 @@ function BackdropWithHole({ hole }: { hole: Rect }): React.ReactElement {
 }
 
 function SpotlightCard({
+  stepId,
   title,
   body,
   muted,
@@ -262,6 +265,7 @@ function SpotlightCard({
       className="absolute w-[300px] max-w-[calc(100vw-28px)] rounded-2xl border border-border bg-card p-4 text-card-foreground shadow-xl motion-safe:animate-[shell-overlay-in_220ms_ease-out]"
       style={{ ...cardStyle, pointerEvents: "auto" }}
       data-testid="tutorial-card"
+      data-tutorial-step-id={stepId}
       role="dialog"
       aria-label="Tour step"
     >

--- a/packages/ui/src/components/pages/tutorial/__e2e__/tutorial-fixture.tsx
+++ b/packages/ui/src/components/pages/tutorial/__e2e__/tutorial-fixture.tsx
@@ -140,6 +140,7 @@ function Harness(): React.JSX.Element {
     <>
       <ChatScaffold />
       <TutorialSpotlight
+        stepId={step.id}
         targetSelector={step.targetSelector}
         dimOutside
         title={step.title}

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -41,6 +41,7 @@ import type { SlashCommandController } from "../../chat/useSlashCommandControlle
 import {
   CHAT_PREFILL_EVENT,
   type ChatPrefillEventDetail,
+  OPEN_IN_CHAT_ONBOARDING_EVENT,
   TUTORIAL_CHAT_CONTROL_EVENT,
   type TutorialChatControlDetail,
 } from "../../events";
@@ -2374,6 +2375,18 @@ export function ContinuousChatOverlay({
     window.addEventListener(TUTORIAL_CHAT_CONTROL_EVENT, onControl);
     return () =>
       window.removeEventListener(TUTORIAL_CHAT_CONTROL_EVENT, onControl);
+  }, [goToDetent]);
+
+  // Chat-centric first-run (#9952, Phase 1): the onboarding conductor seeds the
+  // greeting + runtime choice into the transcript, then dispatches this event so
+  // the floating chat opens to reveal them. The conductor is the parent; this
+  // deep child's effect runs first, so the listener is attached before dispatch.
+  React.useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+    const onOpen = () => goToDetent("half");
+    window.addEventListener(OPEN_IN_CHAT_ONBOARDING_EVENT, onOpen);
+    return () =>
+      window.removeEventListener(OPEN_IN_CHAT_ONBOARDING_EVENT, onOpen);
   }, [goToDetent]);
 
   React.useEffect(() => {

--- a/packages/ui/src/config/boot-config-store.ts
+++ b/packages/ui/src/config/boot-config-store.ts
@@ -312,6 +312,13 @@ export interface AppBootConfig {
   envAliases?: readonly (readonly [string, string])[];
   /** Client middleware flags — replaces the post-construction patches. */
   clientMiddleware?: ClientMiddleware;
+  /**
+   * Chat-centric first-run (#9952, Phase 1). When true, a fresh profile lands
+   * directly on the homescreen with the real floating chat auto-opened and the
+   * onboarding greeting + runtime choice seeded into it, instead of the legacy
+   * full-screen FirstRunChat. Default false (legacy path unchanged).
+   */
+  inChatOnboarding?: boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/ui/src/events/index.ts
+++ b/packages/ui/src/events/index.ts
@@ -77,6 +77,14 @@ export function dispatchVoiceControl(detail: VoiceControlEventDetail): void {
   window.dispatchEvent(new CustomEvent(VOICE_CONTROL_EVENT, { detail }));
 }
 
+/**
+ * In-chat onboarding (Phase 1): the first-run conductor asks the floating chat
+ * (ContinuousChatOverlay) to open so the seeded greeting + runtime choice are
+ * visible. UI-only, no payload — the overlay listens and opens its sheet.
+ */
+export const OPEN_IN_CHAT_ONBOARDING_EVENT =
+  "eliza:open-in-chat-onboarding" as const;
+
 // ── Shared → dedicated cloud-agent handoff ───────────────────────────────
 /**
  * First-run provisions a personal cloud agent and lands the user in chat on the

--- a/packages/ui/src/first-run/IN_CHAT_ONBOARDING_DESIGN.md
+++ b/packages/ui/src/first-run/IN_CHAT_ONBOARDING_DESIGN.md
@@ -1,0 +1,91 @@
+# In-chat onboarding (chat-centric first-run) — design + work order
+
+Closes the real intent of #9952 (and feeds #10198's walkthrough). The first
+surface a fresh user sees is the **real floating chat over the homescreen**, with
+the agent greeting + onboarding choices rendered as the SAME inline widgets the
+live chat uses — not a separate full-screen wizard, and not a separate
+chat-looking surface.
+
+## What shipped before this (verified gap)
+
+- `CompactOnboarding.tsx` was deleted (#10167), but first-run is still a
+  **full-screen pre-shell gate**: `App.tsx:2122` (`!isShellPaintableNow →
+  <StartupScreen/>`) → `StartupShell` (`view.kind === "first-run"`) →
+  `StartupFirstRunBackground` → `FirstRunChat`. The chat shell never paints
+  during first-run, so the agent is not the first surface.
+- `FirstRunChat.tsx` is a **separate** `fixed inset-0` surface that hand-renders
+  an `AgentBubble` transcript with `ChoiceWidget`/`CredentialRequestWidget` — a
+  second chat-looking UI, not the live `ContinuousChatOverlay`.
+- `useFirstRunController.ts` (1,454 LOC) is still a step machine; a **duplicate**
+  provisioning path lives in `useFirstRunCallbacks.ts:runFirstRunChatHandoff`.
+- A dedicated first-run **voice TTS/ASR** stack exists only for onboarding.
+- No **tutorial-or-skip** step after onboarding.
+
+## Target architecture
+
+1. **Land in chat.** When `firstRunComplete=false`, the startup coordinator's
+   `first-run-required` phase is **shell-paintable** (`startup-coordinator.ts`
+   `isShellPaintable`) and `use-startup-shell-controller.ts` no longer forces a
+   `first-run` view. The app mounts the homescreen + `ContinuousChatOverlay`,
+   auto-opened.
+2. **Seed onboarding into the live transcript.** A headless first-run conductor
+   pushes synthetic assistant `ConversationMessage`s via `setConversationMessages`:
+   greeting → `[CHOICE:first-run id=runtime]` (Cloud / Local / Other) → Cloud OAuth
+   via the message `secretRequest` field → `[CHOICE:first-run id=provider]`
+   (role-correct default pre-highlighted) → "other" → Settings handoff → final
+   `[CHOICE:first-run id=tutorial]` (Take the tutorial / Skip). Widgets render for
+   free via `InlineWidgetText` (`ContinuousChatOverlay:974`) + `SensitiveRequestBlock`.
+3. **Display-only widgets, logic in a use case.** First-run-scoped choice
+   `sendAction(value)` is intercepted and routed to the headless use case
+   (the surviving `finishLocal`/`finishCloud`/`finishCloudWithSelection`/
+   `selectOrProvisionCloudAgent`/`submitFirstRun` from `useFirstRunController`,
+   plus `first-run-config.ts` defaults). One `POST /api/first-run`.
+4. **Delete** `FirstRunChat.tsx`, the first-run startup phase +
+   `StartupFirstRunBackground`, the dead `.eliza-onboarding-overlay-shell` CSS,
+   the step/picker presentation, the duplicate `runFirstRunChatHandoff`, and the
+   dedicated first-run voice stack (voice = normal chat voice).
+5. **Test the whole walkthrough in chat** — deterministic "ideal" mock-LLM lane
+   (seeded onboarding driven end-to-end + SSE-mock chat round-trip) AND a
+   real-LLM scenario for the post-onboarding chat; per-step screenshots
+   desktop+mobile + vision review; tutorial-or-skip exercised.
+
+## Key seams (file:line)
+
+- Floating chat + widget render: `components/shell/ContinuousChatOverlay.tsx:974`
+  (`InlineWidgetText content={message.content}`), `:978` (`secretRequest`).
+- CHOICE marker grammar: `components/chat/message-choice-parser.ts` —
+  `[CHOICE:<scope> id=<id> allow_custom]\nvalue=label\n[/CHOICE]`; pick →
+  `ctx.sendAction(value)`.
+- Seed point: `state/ConversationMessagesContext.hooks.ts` `setConversationMessages`
+  (functional form precedent at `state/useChatCallbacks.ts:644`).
+- Startup gating: `state/startup-coordinator.ts` (`isShellPaintable` ~:463,
+  phase union ~:41), `state/use-startup-shell-controller.ts:248-260` (`showFirstRun`),
+  `App.tsx:1661/2122`.
+- Use case to keep/move: `first-run/use-first-run-controller.ts`
+  (`finishLocal` @562, `finishCloud` @933, `finishCloudWithSelection` @744,
+  `selectOrProvisionCloudAgent` via client, `submitFirstRun` @544);
+  `first-run/first-run-config.ts` (`defaultProviderForRuntime`, `needsProviderSetup`);
+  `first-run/first-run.ts` (`buildFirstRunSubmitPlan`).
+- Persist: `app-core/src/api/first-run-routes.ts:167` (POST /api/first-run, sets
+  `meta.firstRunComplete`).
+- Tutorial: `components/pages/tutorial/tutorial-controller.ts` (`startTutorial`).
+
+## Test harnesses
+
+- Deterministic/"ideal" mock LLM: Playwright `page.route` SSE interception of
+  `/messages/stream` (precedent: `walkthrough/walkthrough-capture-smoke.spec.ts`
+  `installWalkthroughConversationStore`). Onboarding itself is seeded (deterministic
+  by construction); the post-onboarding chat round-trip uses the SSE mock.
+- Real LLM: `packages/scenario-runner` scenario with a live key (`--report`);
+  `SCENARIO_USE_LLM_PROXY=1` flips to the deterministic proxy.
+- Screenshots/review: `bun run --cwd packages/app audit:app` + a dedicated
+  `full-walkthrough` ui-smoke spec writing `NN-step.png` (desktop+mobile) fed to
+  `scripts/ai-qa/review-screenshots.mjs`.
+
+## Status
+
+- [ ] Phase 1: land-in-chat gating + seed onboarding into `ContinuousChatOverlay`.
+- [ ] Phase 2: route first-run choices → headless use case; persist once; tutorial-or-skip.
+- [ ] Phase 3: delete `FirstRunChat` + gate + dead CSS + duplicate handoff + voice stack.
+- [ ] Phase 4: full in-chat walkthrough spec (mock-LLM) + real-LLM scenario + screenshots/review.
+- [ ] Phase 5: `audit:app` 5-loop, evidence, PR.

--- a/packages/ui/src/first-run/first-run-use-case.test.ts
+++ b/packages/ui/src/first-run/first-run-use-case.test.ts
@@ -1,0 +1,246 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { client } = vi.hoisted(() => ({
+  client: {
+    getBaseUrl: vi.fn(() => ""),
+    setBaseUrl: vi.fn(),
+    setToken: vi.fn(),
+    submitFirstRun: vi.fn(async () => undefined),
+    getCloudStatus: vi.fn(async () => ({ connected: true, reason: undefined })),
+    getCloudCompatAgents: vi.fn(async () => ({ success: true, data: [] })),
+    selectOrProvisionCloudAgent: vi.fn(async () => ({
+      agentId: "agent-1",
+      agentName: "Eliza",
+      apiBase: "https://agent-1.elizacloud.ai",
+      bridgeUrl: null,
+      created: true,
+    })),
+  },
+}));
+
+vi.mock("../api", () => ({ client }));
+vi.mock("../api/client-cloud", () => ({
+  getCloudAuthToken: vi.fn(() => "cloud-token"),
+  isDirectCloudSharedAgentBase: vi.fn(() => false),
+}));
+vi.mock("../api/app-shell-capabilities", () => ({
+  supportsFullAppShellRoutes: vi.fn(() => true),
+}));
+vi.mock("../config/boot-config", () => ({
+  getBootConfig: vi.fn(() => ({
+    cloudApiBase: "https://www.elizacloud.ai",
+    preferSharedCloudTier: false,
+  })),
+}));
+vi.mock("../state", () => ({
+  addAgentProfile: vi.fn(() => ({ id: "profile-1" })),
+  createPersistedActiveServer: vi.fn((args: Record<string, unknown>) => ({
+    label: "Cloud agent",
+    apiBase: args.apiBase,
+    accessToken: args.accessToken,
+  })),
+  savePersistedActiveServer: vi.fn(),
+}));
+vi.mock("../utils", () => ({
+  isCloudStatusAuthenticated: vi.fn((connected: boolean) => connected),
+  preOpenWindow: vi.fn(() => null),
+}));
+vi.mock("./use-first-run-controller", () => ({
+  startLocalRuntime: vi.fn(async () => undefined),
+  waitForAgentApi: vi.fn(async () => undefined),
+}));
+vi.mock("./voice-readiness", () => ({
+  resolveFirstRunLocalAgentApiBase: vi.fn(() => "http://127.0.0.1:31337"),
+}));
+vi.mock("./auto-download-recommended", () => ({
+  autoDownloadRecommendedLocalModelInBackground: vi.fn(),
+}));
+
+import type { FirstRunProfileDraft } from "./first-run";
+import {
+  beginCloudOAuth,
+  chooseProvider,
+  completeCloudProvisioning,
+  type FirstRunPorts,
+  finalizeFirstRun,
+  routeOtherToSettings,
+  runFirstRunRuntimeChoice,
+} from "./first-run-use-case";
+
+function makePorts(overrides: Partial<FirstRunPorts> = {}): FirstRunPorts {
+  return {
+    uiLanguage: "en",
+    elizaCloudConnected: true,
+    setState: vi.fn(),
+    handleCloudLogin: vi.fn(async () => undefined),
+    completeFirstRun: vi.fn(),
+    showActionBanner: vi.fn(),
+    setTab: vi.fn(),
+    startTutorial: vi.fn(),
+    onProgress: vi.fn(),
+    ...overrides,
+  };
+}
+
+const DRAFT: FirstRunProfileDraft = {
+  agentName: "Eliza",
+  runtime: "local",
+  localInference: "all-local",
+  remoteApiBase: "",
+  remoteToken: "",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  client.getCloudCompatAgents.mockResolvedValue({ success: true, data: [] });
+});
+
+describe("runFirstRunRuntimeChoice", () => {
+  it("routes local → the provider sub-choice with the on-device default", async () => {
+    const step = await runFirstRunRuntimeChoice(makePorts(), "local", {
+      ...DRAFT,
+      runtime: "local",
+    });
+    expect(step.kind).toBe("choice");
+    if (step.kind !== "choice") throw new Error("expected choice");
+    expect(step.choice.id).toBe("provider");
+    expect(step.choice.options.map((o) => o.value)).toEqual([
+      "provider:on-device",
+      "provider:elizacloud",
+    ]);
+  });
+
+  it("routes other → Settings handoff", async () => {
+    const ports = makePorts();
+    const step = await runFirstRunRuntimeChoice(ports, "other", DRAFT);
+    expect(step.kind).toBe("prompt");
+    expect(ports.setTab).toHaveBeenCalledWith("settings");
+    expect(ports.completeFirstRun).toHaveBeenCalledWith("settings");
+  });
+});
+
+describe("beginCloudOAuth", () => {
+  it("auto-provisions when the account has zero agents (exactly one POST)", async () => {
+    const ports = makePorts();
+    const step = await beginCloudOAuth(ports, { ...DRAFT, runtime: "cloud" });
+    expect(step.kind).toBe("done");
+    expect(client.selectOrProvisionCloudAgent).toHaveBeenCalledTimes(1);
+    expect(client.submitFirstRun).toHaveBeenCalledTimes(1);
+  });
+
+  it("offers the agent picker when ≥1 agents exist", async () => {
+    client.getCloudCompatAgents.mockResolvedValue({
+      success: true,
+      data: [
+        {
+          agent_id: "a1",
+          agent_name: "Existing",
+          node_id: null,
+          container_id: null,
+          status: "running",
+          created_at: "2026-01-01",
+        },
+      ],
+    } as never);
+    const step = await beginCloudOAuth(makePorts(), {
+      ...DRAFT,
+      runtime: "cloud",
+    });
+    expect(step.kind).toBe("choice");
+    if (step.kind !== "choice") throw new Error("expected choice");
+    expect(step.choice.id).toBe("agent");
+    const values = step.choice.options.map((o) => o.value);
+    expect(values).toContain("agent:a1");
+    expect(values).toContain("agent:new");
+    // The picker does NOT provision yet.
+    expect(client.selectOrProvisionCloudAgent).not.toHaveBeenCalled();
+  });
+
+  it("runs the OAuth gate when not connected, then errors+retries on failure", async () => {
+    client.getCloudStatus.mockResolvedValue({
+      connected: false,
+      reason: undefined,
+    });
+    const ports = makePorts({ elizaCloudConnected: false });
+    // getCloudAuthToken is mocked to a truthy token, so resolveCloudConnection
+    // would pass; force the token-less path by re-mocking.
+    const cloud = await import("../api/client-cloud");
+    vi.mocked(cloud.getCloudAuthToken).mockReturnValueOnce(null);
+    const step = await beginCloudOAuth(ports, { ...DRAFT, runtime: "cloud" });
+    expect(ports.handleCloudLogin).toHaveBeenCalledTimes(1);
+    expect(step.kind).toBe("error");
+  });
+});
+
+describe("completeCloudProvisioning", () => {
+  it("provisions a preferred agent and persists it", async () => {
+    const ports = makePorts();
+    const step = await completeCloudProvisioning(
+      ports,
+      { ...DRAFT, runtime: "cloud" },
+      {
+        preferAgentId: "a1",
+      },
+    );
+    expect(step.kind).toBe("done");
+    expect(client.selectOrProvisionCloudAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ preferAgentId: "a1" }),
+    );
+    expect(ports.onProgress).toHaveBeenLastCalledWith(null);
+  });
+
+  it("force-creates a new agent on demand", async () => {
+    await completeCloudProvisioning(
+      makePorts(),
+      { ...DRAFT, runtime: "cloud" },
+      {
+        forceCreate: true,
+      },
+    );
+    expect(client.selectOrProvisionCloudAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ forceCreate: true }),
+    );
+  });
+});
+
+describe("chooseProvider", () => {
+  it("on-device starts the local agent and submits once", async () => {
+    const ports = makePorts();
+    const step = await chooseProvider(ports, DRAFT, "on-device");
+    expect(step.kind).toBe("done");
+    expect(client.submitFirstRun).toHaveBeenCalledTimes(1);
+  });
+
+  it("elizacloud (hybrid) connects cloud before local setup", async () => {
+    const ports = makePorts({ elizaCloudConnected: true });
+    const step = await chooseProvider(ports, DRAFT, "elizacloud");
+    expect(step.kind).toBe("done");
+    expect(ports.setState).toHaveBeenCalledWith(
+      "firstRunRuntimeTarget",
+      "elizacloud-hybrid",
+    );
+  });
+});
+
+describe("routeOtherToSettings / finalizeFirstRun", () => {
+  it("opens settings and completes first-run there", () => {
+    const ports = makePorts();
+    const step = routeOtherToSettings(ports);
+    expect(step.kind).toBe("prompt");
+    expect(ports.setTab).toHaveBeenCalledWith("settings");
+  });
+
+  it("starts the tutorial only when the user takes it", () => {
+    const take = makePorts();
+    finalizeFirstRun(take, true);
+    expect(take.completeFirstRun).toHaveBeenCalledWith("chat", {
+      launchCompanionOverlay: true,
+    });
+    expect(take.startTutorial).toHaveBeenCalledTimes(1);
+
+    const skip = makePorts();
+    finalizeFirstRun(skip, false);
+    expect(skip.startTutorial).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/first-run/first-run-use-case.ts
+++ b/packages/ui/src/first-run/first-run-use-case.ts
@@ -1,0 +1,530 @@
+/**
+ * Headless first-run use case (#9952, Phase 2).
+ *
+ * Presentation-free provisioning logic the in-chat onboarding conductor drives.
+ * No React, no DOM rendering — every app setter / store action is supplied via
+ * the injected {@link FirstRunPorts}, and progress is reported through
+ * `onProgress` (the seam that replaces the controller's `setBusyText`). Each
+ * entry point returns a {@link ConductorStep} the conductor renders as the next
+ * synthetic assistant message (a prompt, a CHOICE marker, an OAuth secret card,
+ * an error, or a terminal "done").
+ *
+ * The mechanics here are lifted from `use-first-run-controller.ts`
+ * (`submitFirstRun` @590, `finishLocal` agent-start tail @646-716,
+ * `finishCloudWithSelection` core @815-889). The shared on-device agent-start
+ * primitives (`startLocalRuntime` / `waitForAgentApi`) are imported from the
+ * controller rather than re-implemented. Logger only — no `console`.
+ */
+
+import { logger } from "@elizaos/logger";
+import { client } from "../api";
+import { supportsFullAppShellRoutes } from "../api/app-shell-capabilities";
+import { getCloudAuthToken } from "../api/client-cloud";
+import type { ConversationSecretRequest } from "../api/client-types-chat";
+import type { CloudCompatAgent } from "../api/client-types-cloud";
+import type { ChoiceOption } from "../components/chat/widgets/ChoiceWidget";
+import { getBootConfig } from "../config/boot-config";
+import type { UiLanguage } from "../i18n";
+import type { Tab } from "../navigation";
+import { isAndroid, isIOS } from "../platform/init";
+import {
+  addAgentProfile,
+  createPersistedActiveServer,
+  savePersistedActiveServer,
+} from "../state";
+import type { ActionBanner } from "../state/action-banner";
+import type { AppActions } from "../state/types";
+import { isCloudStatusAuthenticated, preOpenWindow } from "../utils";
+import { autoDownloadRecommendedLocalModelInBackground } from "./auto-download-recommended";
+import {
+  buildFirstRunSubmitPlan,
+  clearPersistedFirstRunState,
+  type FirstRunProfileDraft,
+  type FirstRunRuntime,
+  firstRunDownloadsLocalModel,
+  firstRunNeedsCloudConnect,
+  firstRunRuntimeTarget,
+} from "./first-run";
+import { defaultProviderForRuntime } from "./first-run-config";
+import {
+  ANDROID_LOCAL_AGENT_LABEL,
+  ANDROID_LOCAL_AGENT_SERVER_ID,
+  MOBILE_LOCAL_AGENT_LABEL,
+  MOBILE_LOCAL_AGENT_SERVER_ID,
+  persistMobileRuntimeModeForServerTarget,
+} from "./mobile-runtime-mode";
+import { startLocalRuntime, waitForAgentApi } from "./use-first-run-controller";
+import { resolveFirstRunLocalAgentApiBase } from "./voice-readiness";
+
+// ── Ports ──────────────────────────────────────────────────────────────────
+
+/** Subset of the app store the use case mutates, all injected (no React). */
+export interface FirstRunPorts {
+  uiLanguage: UiLanguage;
+  /** Latest known Eliza Cloud connection state at call time. */
+  elizaCloudConnected: boolean;
+  setState: AppActions["setState"];
+  handleCloudLogin: (prePoppedWindow?: Window | null) => Promise<void>;
+  completeFirstRun: AppActions["completeFirstRun"];
+  showActionBanner: (banner: ActionBanner) => void;
+  setTab: (tab: Tab) => void;
+  startTutorial: () => void;
+  /** Replaces the controller's `setBusyText`. `null` clears the indicator. */
+  onProgress: (text: string | null) => void;
+}
+
+// ── Conductor step contract ──────────────────────────────────────────────────
+
+/** A first-run-scoped CHOICE the conductor renders via the CHOICE marker. */
+export interface ChoiceSpec {
+  scope: "first-run";
+  id: "runtime" | "provider" | "agent" | "tutorial";
+  allowCustom?: boolean;
+  options: ChoiceOption[];
+}
+
+export type ConductorStep =
+  | { kind: "prompt"; text: string }
+  | { kind: "choice"; text: string; choice: ChoiceSpec }
+  | { kind: "secret"; text: string; secretRequest: ConversationSecretRequest }
+  | { kind: "error"; text: string; choice?: ChoiceSpec }
+  | { kind: "done"; text?: string };
+
+/** Either reuse/prefer a known agent id, or force a brand-new agent. */
+export type CloudAgentSelection =
+  | { preferAgentId?: string | null }
+  | { forceCreate: true };
+
+// ── Internal shared mechanics ────────────────────────────────────────────────
+
+function isHttpLoopbackBase(value: string): boolean {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return false;
+    return (
+      url.hostname === "localhost" ||
+      url.hostname === "127.0.0.1" ||
+      url.hostname === "::1" ||
+      url.hostname === "[::1]"
+    );
+  } catch {
+    return false;
+  }
+}
+
+function shouldUseAppShellLocalAgentProxy(apiBase: string): boolean {
+  if (!isHttpLoopbackBase(apiBase)) return false;
+  if (typeof window === "undefined") return false;
+  const { origin, protocol } = window.location;
+  if (protocol !== "http:" && protocol !== "https:") return false;
+  try {
+    return new URL(apiBase).origin !== origin;
+  } catch {
+    return false;
+  }
+}
+
+function localAgentClientBase(apiBase: string): string | null {
+  return shouldUseAppShellLocalAgentProxy(apiBase) ? null : apiBase;
+}
+
+function localAgentFetchBase(apiBase: string): string {
+  return shouldUseAppShellLocalAgentProxy(apiBase) &&
+    typeof window !== "undefined"
+    ? window.location.origin
+    : apiBase;
+}
+
+function shouldSubmitFirstRunViaAppShellOrigin(
+  runtime: FirstRunRuntime,
+  baseUrl: string,
+): boolean {
+  if (runtime !== "local") return false;
+  return shouldUseAppShellLocalAgentProxy(baseUrl);
+}
+
+function canProbeCloudStatus(): boolean {
+  const baseUrl =
+    typeof client.getBaseUrl === "function" ? client.getBaseUrl().trim() : "";
+  if (!supportsFullAppShellRoutes(baseUrl)) return false;
+  if (baseUrl) return true;
+  if (typeof window !== "undefined" && window.location.port === "2138") {
+    return false;
+  }
+  return true;
+}
+
+async function getCloudStatusIfSupported() {
+  if (!canProbeCloudStatus()) return null;
+  return client.getCloudStatus().catch(() => null);
+}
+
+function readSyncOnDeviceAgentBearer(): string | null {
+  try {
+    const bridge = (
+      globalThis as typeof globalThis & {
+        ElizaNative?: { getLocalAgentToken?: () => string | null };
+      }
+    ).ElizaNative;
+    const token = bridge?.getLocalAgentToken?.();
+    if (typeof token !== "string") return null;
+    const trimmed = token.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** The single `POST /api/first-run` — server sets `meta.firstRunComplete`. */
+export async function submitFirstRunProfile(
+  ports: FirstRunPorts,
+  draft: FirstRunProfileDraft,
+  runtime: FirstRunRuntime,
+): Promise<void> {
+  const plan = buildFirstRunSubmitPlan({
+    draft: { ...draft, runtime },
+    uiLanguage: ports.uiLanguage,
+  });
+  const currentBase =
+    typeof client.getBaseUrl === "function" ? client.getBaseUrl() : "";
+  if (shouldSubmitFirstRunViaAppShellOrigin(runtime, currentBase.trim())) {
+    client.setBaseUrl(null);
+    try {
+      await client.submitFirstRun(plan.payload);
+    } finally {
+      client.setBaseUrl(currentBase || null);
+    }
+  } else {
+    await client.submitFirstRun(plan.payload);
+  }
+  if (plan.runtimeConfig.needsProviderSetup) {
+    ports.showActionBanner({
+      text: "Choose a model provider in Settings before sending the first message.",
+      actionLabel: "Open Settings",
+      onAction: () => ports.setTab("settings"),
+    });
+  }
+}
+
+/**
+ * Resolve the Eliza Cloud connection: true when already connected (or a session
+ * token is present), otherwise run the in-app Steward sign-in and re-probe.
+ * Mirrors the controller's OAuth gate (`finishCloud` @1010-1044).
+ */
+async function resolveCloudConnection(ports: FirstRunPorts): Promise<boolean> {
+  let connected = ports.elizaCloudConnected;
+  if (!connected) {
+    const status = await getCloudStatusIfSupported();
+    connected = isCloudStatusAuthenticated(
+      Boolean(status?.connected),
+      status?.reason,
+    );
+  }
+  if (connected) return true;
+
+  const authWindow = preOpenWindow();
+  await ports.handleCloudLogin(authWindow);
+  const status = await getCloudStatusIfSupported();
+  connected = isCloudStatusAuthenticated(
+    Boolean(status?.connected),
+    status?.reason,
+  );
+  // A present session token is authoritative even if the status proxy lags.
+  if (!connected && getCloudAuthToken(client)) connected = true;
+  return connected;
+}
+
+// ── Use-case entry points ────────────────────────────────────────────────────
+
+/** Route the runtime CHOICE pick. */
+export async function runFirstRunRuntimeChoice(
+  ports: FirstRunPorts,
+  value: "cloud" | "local" | "other",
+  draft: FirstRunProfileDraft,
+): Promise<ConductorStep> {
+  switch (value) {
+    case "cloud":
+      return beginCloudOAuth(ports, draft);
+    case "local":
+      return providerChoiceStep("local");
+    case "other":
+      return routeOtherToSettings(ports);
+  }
+}
+
+/** The provider sub-choice with the role-correct default pre-highlighted. */
+function providerChoiceStep(runtime: FirstRunRuntime): ConductorStep {
+  const preferred = defaultProviderForRuntime(runtime);
+  const options: ChoiceOption[] = [
+    { value: "provider:on-device", label: "On-device (everything local)" },
+    { value: "provider:elizacloud", label: "Eliza Cloud inference" },
+  ];
+  const text =
+    preferred === "elizacloud"
+      ? "How should I think? Eliza Cloud is recommended for this setup."
+      : "How should I think? On-device keeps everything on this machine.";
+  return {
+    kind: "choice",
+    text,
+    choice: { scope: "first-run", id: "provider", options },
+  };
+}
+
+/**
+ * Cloud runtime entry. When not yet connected, run the OAuth gate; when
+ * connected, offer the agent picker (≥1 existing agents) or auto-provision (0).
+ */
+export async function beginCloudOAuth(
+  ports: FirstRunPorts,
+  draft: FirstRunProfileDraft,
+): Promise<ConductorStep> {
+  ports.setState("firstRunRuntimeTarget", firstRunRuntimeTarget("cloud"));
+  ports.setState("firstRunProvider", "elizacloud");
+
+  const connected = await resolveCloudConnection(ports);
+  if (!connected) {
+    return {
+      kind: "error",
+      text: "I couldn't reach Eliza Cloud sign-in. Want to try again?",
+      choice: {
+        scope: "first-run",
+        id: "runtime",
+        allowCustom: true,
+        options: [
+          { value: "cloud", label: "Retry Eliza Cloud" },
+          { value: "local", label: "Run locally instead" },
+          { value: "other", label: "Something else…" },
+        ],
+      },
+    };
+  }
+
+  const authToken = getCloudAuthToken(client);
+  if (!authToken) {
+    return {
+      kind: "error",
+      text: "Signed in, but I couldn't read your Cloud token. Want to try again?",
+      choice: {
+        scope: "first-run",
+        id: "runtime",
+        options: [{ value: "cloud", label: "Retry Eliza Cloud" }],
+      },
+    };
+  }
+
+  const listed = await client.getCloudCompatAgents().catch(() => ({
+    success: false,
+    data: [] as CloudCompatAgent[],
+  }));
+  const agents = listed.success ? listed.data : [];
+  if (agents.length === 0) {
+    return completeCloudProvisioning(ports, draft, { preferAgentId: null });
+  }
+
+  const options: ChoiceOption[] = [
+    ...agents.map((agent) => ({
+      value: `agent:${agent.agent_id}`,
+      label: agent.agent_name || agent.agent_id,
+    })),
+    { value: "agent:new", label: "Create a new agent" },
+  ];
+  return {
+    kind: "choice",
+    text: "Welcome back — which agent should I run?",
+    choice: { scope: "first-run", id: "agent", options },
+  };
+}
+
+/**
+ * Provision (or reuse) the cloud agent, persist it, submit the profile once.
+ * Lifted from `finishCloudWithSelection` @815-889. The shared→dedicated
+ * background handoff (controller @906-999, gated on `preferSharedCloudTier`)
+ * stays in the legacy controller for now and is not part of this entry point.
+ */
+export async function completeCloudProvisioning(
+  ports: FirstRunPorts,
+  draft: FirstRunProfileDraft,
+  selection: CloudAgentSelection,
+): Promise<ConductorStep> {
+  ports.onProgress("Setting up your cloud agent");
+  const plan = buildFirstRunSubmitPlan({
+    draft: { ...draft, runtime: "cloud" },
+    uiLanguage: ports.uiLanguage,
+  });
+  const name =
+    typeof plan.payload.name === "string" ? plan.payload.name : "Eliza";
+  const bio = Array.isArray(plan.payload.bio)
+    ? plan.payload.bio.filter(
+        (entry): entry is string => typeof entry === "string",
+      )
+    : ["An autonomous AI agent."];
+
+  const authToken = getCloudAuthToken(client) ?? "";
+  const preferAgentId =
+    "preferAgentId" in selection ? selection.preferAgentId : undefined;
+  const forceCreate =
+    "forceCreate" in selection ? selection.forceCreate : false;
+
+  const selectedAgent = await client.selectOrProvisionCloudAgent({
+    cloudApiBase: getBootConfig().cloudApiBase || "https://www.elizacloud.ai",
+    authToken,
+    name,
+    bio,
+    ...(preferAgentId ? { preferAgentId } : {}),
+    ...(forceCreate ? { forceCreate: true } : {}),
+    ...(getBootConfig().preferSharedCloudTier
+      ? { preferSharedTier: true }
+      : {}),
+    onProgress: (status, detail) => ports.onProgress(detail ?? status),
+  });
+  const cloudAgentApiBase = selectedAgent.apiBase;
+  client.setBaseUrl(cloudAgentApiBase);
+  client.setToken(authToken);
+  const activeServer = createPersistedActiveServer({
+    kind: "cloud",
+    id: `cloud:${selectedAgent.agentId}`,
+    apiBase: cloudAgentApiBase,
+    accessToken: authToken,
+  });
+  savePersistedActiveServer(activeServer);
+  addAgentProfile({
+    kind: "cloud",
+    label: activeServer.label,
+    ...(activeServer.apiBase ? { apiBase: activeServer.apiBase } : {}),
+    ...(activeServer.accessToken
+      ? { accessToken: activeServer.accessToken }
+      : {}),
+  });
+  persistMobileRuntimeModeForServerTarget("elizacloud");
+  ports.onProgress("Saving first-run profile");
+  if (supportsFullAppShellRoutes(cloudAgentApiBase)) {
+    await client.submitFirstRun(plan.payload);
+  }
+  clearPersistedFirstRunState();
+  ports.onProgress(null);
+  logger.info("[FirstRunUseCase] cloud agent provisioned");
+  return { kind: "done", text: "Your cloud agent is ready." };
+}
+
+/** Provider sub-choice → set inference mode → (hybrid: connect cloud) → local. */
+export async function chooseProvider(
+  ports: FirstRunPorts,
+  draft: FirstRunProfileDraft,
+  providerId: "on-device" | "elizacloud",
+): Promise<ConductorStep> {
+  const localInference =
+    providerId === "elizacloud" ? "cloud-inference" : "all-local";
+  const nextDraft: FirstRunProfileDraft = { ...draft, localInference };
+
+  if (firstRunNeedsCloudConnect(nextDraft, ports.elizaCloudConnected)) {
+    ports.setState("firstRunRuntimeTarget", "elizacloud-hybrid");
+    ports.setState("firstRunProvider", "elizacloud");
+    const connected = await resolveCloudConnection(ports);
+    if (!connected) {
+      return {
+        kind: "error",
+        text: "I couldn't connect Eliza Cloud for hybrid inference. Want to try again?",
+        choice: {
+          scope: "first-run",
+          id: "provider",
+          options: [
+            { value: "provider:elizacloud", label: "Retry Eliza Cloud" },
+            { value: "provider:on-device", label: "Run fully on-device" },
+          ],
+        },
+      };
+    }
+  }
+  return runLocalSetup(ports, nextDraft);
+}
+
+/**
+ * Start + await the on-device agent, persist it, submit the profile once.
+ * Lifted from `finishLocal` agent-start tail @646-716.
+ */
+export async function runLocalSetup(
+  ports: FirstRunPorts,
+  draft: FirstRunProfileDraft,
+): Promise<ConductorStep> {
+  const serverTarget = firstRunRuntimeTarget(
+    draft.runtime,
+    draft.localInference,
+  );
+  persistMobileRuntimeModeForServerTarget(serverTarget);
+  ports.setState("firstRunRuntimeTarget", serverTarget);
+  ports.onProgress("Starting local agent");
+  const apiBase = resolveFirstRunLocalAgentApiBase();
+  const clientBase = localAgentClientBase(apiBase);
+  client.setBaseUrl(clientBase);
+  client.setToken(isAndroid || isIOS ? readSyncOnDeviceAgentBearer() : null);
+  await startLocalRuntime();
+  await waitForAgentApi();
+  if (isAndroid || isIOS) {
+    savePersistedActiveServer({
+      id: isAndroid
+        ? ANDROID_LOCAL_AGENT_SERVER_ID
+        : MOBILE_LOCAL_AGENT_SERVER_ID,
+      kind: "remote",
+      label: isAndroid ? ANDROID_LOCAL_AGENT_LABEL : MOBILE_LOCAL_AGENT_LABEL,
+      apiBase,
+    });
+    addAgentProfile({
+      kind: "remote",
+      label: isAndroid ? ANDROID_LOCAL_AGENT_LABEL : MOBILE_LOCAL_AGENT_LABEL,
+      apiBase,
+    });
+  } else if (clientBase) {
+    savePersistedActiveServer({
+      id: "local:desktop",
+      kind: "remote",
+      label: "Local agent",
+      apiBase: clientBase,
+    });
+    addAgentProfile({
+      kind: "remote",
+      label: "Local agent",
+      apiBase: clientBase,
+    });
+  } else {
+    savePersistedActiveServer({
+      id: "local:app-shell",
+      kind: "local",
+      label: "Local agent",
+    });
+    addAgentProfile({ kind: "local", label: "Local agent" });
+  }
+  ports.onProgress("Saving first-run profile");
+  await submitFirstRunProfile(ports, draft, "local");
+  if (firstRunDownloadsLocalModel(draft.localInference)) {
+    void autoDownloadRecommendedLocalModelInBackground(
+      localAgentFetchBase(apiBase),
+    );
+  }
+  clearPersistedFirstRunState();
+  ports.onProgress(null);
+  logger.info("[FirstRunUseCase] local agent started + profile saved");
+  return { kind: "done", text: "Your local agent is ready." };
+}
+
+/** "Something else" → hand off to Settings and finish first-run there. */
+export function routeOtherToSettings(ports: FirstRunPorts): ConductorStep {
+  ports.setTab("settings");
+  ports.completeFirstRun("settings");
+  logger.info("[FirstRunUseCase] routed to settings handoff");
+  return {
+    kind: "prompt",
+    text: "No problem — I've opened Settings so you can configure things your way.",
+  };
+}
+
+/** Post-provision tutorial-or-skip resolution. */
+export function finalizeFirstRun(
+  ports: FirstRunPorts,
+  takeTutorial: boolean,
+): void {
+  ports.completeFirstRun("chat", { launchCompanionOverlay: true });
+  if (takeTutorial) ports.startTutorial();
+  logger.info(
+    `[FirstRunUseCase] first-run finalized (tutorial=${takeTutorial})`,
+  );
+}

--- a/packages/ui/src/first-run/in-chat-onboarding.test.ts
+++ b/packages/ui/src/first-run/in-chat-onboarding.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { findChoiceRegions } from "../components/chat/message-choice-parser";
+import {
+  buildFirstRunAckMessage,
+  buildFirstRunSeedMessages,
+  consumeFirstRunChoice,
+  FIRST_RUN_CHOICE_SCOPE,
+  FIRST_RUN_RUNTIME_VALUES,
+  isInChatOnboardingEnabled,
+  setFirstRunChoiceInterceptor,
+} from "./in-chat-onboarding";
+
+afterEach(() => {
+  setFirstRunChoiceInterceptor(null);
+  try {
+    window.localStorage.removeItem("eliza:in-chat-onboarding");
+  } catch {
+    // jsdom always has localStorage; ignore if a runtime lacks it.
+  }
+});
+
+describe("buildFirstRunSeedMessages", () => {
+  it("seeds a greeting then a runtime CHOICE the live parser accepts", () => {
+    const [greeting, choice] = buildFirstRunSeedMessages(1000);
+
+    expect(greeting.role).toBe("assistant");
+    expect(greeting.text).toMatch(/hey there! I'm Eliza/i);
+    expect(greeting.text).toMatch(/How would you like to run me/i);
+    expect(choice.timestamp).toBeGreaterThan(greeting.timestamp);
+
+    const regions = findChoiceRegions(choice.text ?? "");
+    expect(regions).toHaveLength(1);
+    const region = regions[0];
+    expect(region.scope).toBe(FIRST_RUN_CHOICE_SCOPE);
+    expect(region.id).toBe("runtime");
+    expect(region.allowCustom).toBe(true);
+    expect(region.options.map((o) => o.value)).toEqual([
+      ...FIRST_RUN_RUNTIME_VALUES,
+    ]);
+  });
+
+  it("produces stable, deterministic ids for idempotent re-seeding", () => {
+    const a = buildFirstRunSeedMessages(1).map((m) => m.id);
+    const b = buildFirstRunSeedMessages(999).map((m) => m.id);
+    expect(a).toEqual(b);
+  });
+});
+
+describe("consumeFirstRunChoice", () => {
+  it("is a no-op when no interceptor is registered (flag-OFF byte-identical)", () => {
+    expect(consumeFirstRunChoice("cloud")).toBe(false);
+  });
+
+  it("routes only first-run runtime values to the registered handler", () => {
+    const handler = vi.fn();
+    setFirstRunChoiceInterceptor(handler);
+
+    for (const value of FIRST_RUN_RUNTIME_VALUES) {
+      expect(consumeFirstRunChoice(value)).toBe(true);
+    }
+    expect(handler).toHaveBeenCalledTimes(FIRST_RUN_RUNTIME_VALUES.length);
+
+    handler.mockClear();
+    expect(consumeFirstRunChoice("hello world")).toBe(false);
+    expect(consumeFirstRunChoice("/settings")).toBe(false);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("clears the interceptor with null", () => {
+    setFirstRunChoiceInterceptor(vi.fn());
+    setFirstRunChoiceInterceptor(null);
+    expect(consumeFirstRunChoice("local")).toBe(false);
+  });
+});
+
+describe("buildFirstRunAckMessage", () => {
+  it("acknowledges the picked runtime as an assistant message", () => {
+    const ack = buildFirstRunAckMessage("local", 5);
+    expect(ack.role).toBe("assistant");
+    expect(ack.text).toMatch(/local agent/i);
+    expect(ack.timestamp).toBe(5);
+  });
+});
+
+describe("isInChatOnboardingEnabled", () => {
+  it("defaults to false (legacy full-screen first-run)", () => {
+    expect(isInChatOnboardingEnabled()).toBe(false);
+  });
+
+  it("is enabled by the localStorage override the e2e harness sets", () => {
+    window.localStorage.setItem("eliza:in-chat-onboarding", "1");
+    expect(isInChatOnboardingEnabled()).toBe(true);
+  });
+});

--- a/packages/ui/src/first-run/in-chat-onboarding.test.ts
+++ b/packages/ui/src/first-run/in-chat-onboarding.test.ts
@@ -2,11 +2,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { findChoiceRegions } from "../components/chat/message-choice-parser";
 import {
-  buildFirstRunAckMessage,
   buildFirstRunSeedMessages,
   consumeFirstRunChoice,
   FIRST_RUN_CHOICE_SCOPE,
   FIRST_RUN_RUNTIME_VALUES,
+  isFirstRunChoiceValue,
   isInChatOnboardingEnabled,
   setFirstRunChoiceInterceptor,
 } from "./in-chat-onboarding";
@@ -52,14 +52,23 @@ describe("consumeFirstRunChoice", () => {
     expect(consumeFirstRunChoice("cloud")).toBe(false);
   });
 
-  it("routes only first-run runtime values to the registered handler", () => {
+  it("routes runtime + scoped (provider/agent/tutorial) values to the handler", () => {
     const handler = vi.fn();
     setFirstRunChoiceInterceptor(handler);
 
-    for (const value of FIRST_RUN_RUNTIME_VALUES) {
+    const firstRunValues = [
+      ...FIRST_RUN_RUNTIME_VALUES,
+      "provider:on-device",
+      "provider:elizacloud",
+      "agent:abc",
+      "agent:new",
+      "tutorial:take",
+      "tutorial:skip",
+    ];
+    for (const value of firstRunValues) {
       expect(consumeFirstRunChoice(value)).toBe(true);
     }
-    expect(handler).toHaveBeenCalledTimes(FIRST_RUN_RUNTIME_VALUES.length);
+    expect(handler).toHaveBeenCalledTimes(firstRunValues.length);
 
     handler.mockClear();
     expect(consumeFirstRunChoice("hello world")).toBe(false);
@@ -74,12 +83,14 @@ describe("consumeFirstRunChoice", () => {
   });
 });
 
-describe("buildFirstRunAckMessage", () => {
-  it("acknowledges the picked runtime as an assistant message", () => {
-    const ack = buildFirstRunAckMessage("local", 5);
-    expect(ack.role).toBe("assistant");
-    expect(ack.text).toMatch(/local agent/i);
-    expect(ack.timestamp).toBe(5);
+describe("isFirstRunChoiceValue", () => {
+  it("recognizes runtime + scoped choice values, rejects free text", () => {
+    expect(isFirstRunChoiceValue("cloud")).toBe(true);
+    expect(isFirstRunChoiceValue("provider:on-device")).toBe(true);
+    expect(isFirstRunChoiceValue("agent:new")).toBe(true);
+    expect(isFirstRunChoiceValue("tutorial:skip")).toBe(true);
+    expect(isFirstRunChoiceValue("hello")).toBe(false);
+    expect(isFirstRunChoiceValue("providerish")).toBe(false);
   });
 });
 

--- a/packages/ui/src/first-run/in-chat-onboarding.ts
+++ b/packages/ui/src/first-run/in-chat-onboarding.ts
@@ -1,5 +1,5 @@
 /**
- * In-chat onboarding (Phase 1) — chat-centric first-run.
+ * In-chat onboarding (#9952) — chat-centric first-run.
  *
  * When the `inChatOnboarding` boot-config flag is ON, a fresh profile lands
  * directly on the homescreen with the real floating chat (ContinuousChatOverlay)
@@ -7,23 +7,31 @@
  * into that real chat as synthetic assistant messages. The choice renders for
  * free via the existing `InlineWidgetText` marker path — no separate surface.
  *
- * This module owns ONLY the flag read, the seed-message construction, and a
- * tiny interceptor registry so a first-run choice pick is handled locally
- * instead of being sent to the agent. The headless first-run use case
- * (provisioning) is wired in Phase 2 — see the SEAM marker in
- * `consumeFirstRunChoice`.
+ * This module owns the flag read, the seed-message construction, and the
+ * first-run choice interceptor registry. The provisioning logic lives in the
+ * headless `first-run-use-case.ts`; the conductor (`useInChatOnboarding`)
+ * registers a handler here that routes each pick into that use case.
+ *
+ * Choice grammar: every first-run pick encodes its scope id into the choice
+ * `value` (`provider:on-device`, `agent:new`, `tutorial:take`, …) so the
+ * existing value-only `sendAction(value)` round-trips it without threading the
+ * `ChoiceMatch.id` through `InlineWidgetText`. The bare runtime values
+ * (`cloud` / `local` / `other`) keep their short form.
  */
 
 import { logger } from "@elizaos/logger";
 import type { ConversationMessage } from "../api";
 import { getBootConfig } from "../config/boot-config-store";
 
-/** Scope tag carried by the onboarding `[CHOICE:first-run …]` marker. */
+/** Scope tag carried by every onboarding `[CHOICE:first-run …]` marker. */
 export const FIRST_RUN_CHOICE_SCOPE = "first-run";
 
-/** The runtime-selection choice values seeded at first-run. */
+/** The runtime-selection choice values seeded first. */
 export const FIRST_RUN_RUNTIME_VALUES = ["cloud", "local", "other"] as const;
 export type FirstRunRuntimeValue = (typeof FIRST_RUN_RUNTIME_VALUES)[number];
+
+/** Scoped value prefixes for the later choice steps (provider / agent / tutorial). */
+const FIRST_RUN_SCOPED_PREFIXES = ["provider:", "agent:", "tutorial:"] as const;
 
 /** localStorage override the e2e harness sets to flip the flag on without a host build. */
 const LOCAL_STORAGE_FLAG_KEY = "eliza:in-chat-onboarding";
@@ -59,15 +67,14 @@ const RUNTIME_CHOICE_MARKER = [
   "[/CHOICE]",
 ].join("\n");
 
-/** Labels keyed by runtime value, for the local acknowledgement message. */
-const RUNTIME_VALUE_LABELS: Record<FirstRunRuntimeValue, string> = {
-  cloud: "Eliza Cloud",
-  local: "a local agent on this device",
-  other: "a custom setup",
-};
-
 function isFirstRunRuntimeValue(value: string): value is FirstRunRuntimeValue {
   return (FIRST_RUN_RUNTIME_VALUES as readonly string[]).includes(value);
+}
+
+/** True for any value the in-chat onboarding interceptor owns. */
+export function isFirstRunChoiceValue(value: string): boolean {
+  if (isFirstRunRuntimeValue(value)) return true;
+  return FIRST_RUN_SCOPED_PREFIXES.some((prefix) => value.startsWith(prefix));
 }
 
 /**
@@ -92,19 +99,6 @@ export function buildFirstRunSeedMessages(now: number): ConversationMessage[] {
   ];
 }
 
-/** The local acknowledgement appended when a first-run runtime choice is picked. */
-export function buildFirstRunAckMessage(
-  value: FirstRunRuntimeValue,
-  now: number,
-): ConversationMessage {
-  return {
-    id: `first-run-ack-${value}`,
-    role: "assistant",
-    text: `Great — setting up ${RUNTIME_VALUE_LABELS[value]}…`,
-    timestamp: now,
-  };
-}
-
 // ---------------------------------------------------------------------------
 // First-run choice interceptor registry
 //
@@ -114,7 +108,7 @@ export function buildFirstRunAckMessage(
 // send path is byte-identical.
 // ---------------------------------------------------------------------------
 
-type FirstRunChoiceHandler = (value: FirstRunRuntimeValue) => void;
+export type FirstRunChoiceHandler = (value: string) => void;
 
 let activeFirstRunChoiceHandler: FirstRunChoiceHandler | null = null;
 
@@ -127,14 +121,14 @@ export function setFirstRunChoiceInterceptor(
 
 /**
  * Intercept a chat-send value while in-chat onboarding is active. Returns true
- * (and routes to the registered handler) when `value` is a first-run runtime
- * choice; false otherwise, so the caller proceeds with a normal send.
+ * (and routes to the registered handler) when `value` is a first-run choice;
+ * false otherwise, so the caller proceeds with a normal send.
  */
 export function consumeFirstRunChoice(value: string): boolean {
   const handler = activeFirstRunChoiceHandler;
   if (!handler) return false;
-  if (!isFirstRunRuntimeValue(value)) return false;
-  logger.info(`[InChatOnboarding] intercepted first-run runtime choice: ${value}`);
+  if (!isFirstRunChoiceValue(value)) return false;
+  logger.info(`[InChatOnboarding] intercepted first-run choice: ${value}`);
   handler(value);
   return true;
 }

--- a/packages/ui/src/first-run/in-chat-onboarding.ts
+++ b/packages/ui/src/first-run/in-chat-onboarding.ts
@@ -1,0 +1,140 @@
+/**
+ * In-chat onboarding (Phase 1) — chat-centric first-run.
+ *
+ * When the `inChatOnboarding` boot-config flag is ON, a fresh profile lands
+ * directly on the homescreen with the real floating chat (ContinuousChatOverlay)
+ * auto-opened, and the onboarding greeting + a runtime CHOICE widget are seeded
+ * into that real chat as synthetic assistant messages. The choice renders for
+ * free via the existing `InlineWidgetText` marker path — no separate surface.
+ *
+ * This module owns ONLY the flag read, the seed-message construction, and a
+ * tiny interceptor registry so a first-run choice pick is handled locally
+ * instead of being sent to the agent. The headless first-run use case
+ * (provisioning) is wired in Phase 2 — see the SEAM marker in
+ * `consumeFirstRunChoice`.
+ */
+
+import { logger } from "@elizaos/logger";
+import type { ConversationMessage } from "../api";
+import { getBootConfig } from "../config/boot-config-store";
+
+/** Scope tag carried by the onboarding `[CHOICE:first-run …]` marker. */
+export const FIRST_RUN_CHOICE_SCOPE = "first-run";
+
+/** The runtime-selection choice values seeded at first-run. */
+export const FIRST_RUN_RUNTIME_VALUES = ["cloud", "local", "other"] as const;
+export type FirstRunRuntimeValue = (typeof FIRST_RUN_RUNTIME_VALUES)[number];
+
+/** localStorage override the e2e harness sets to flip the flag on without a host build. */
+const LOCAL_STORAGE_FLAG_KEY = "eliza:in-chat-onboarding";
+
+/**
+ * True when the chat-centric first-run experience is enabled. Reads the
+ * `inChatOnboarding` boot-config flag (host-provided) OR a localStorage
+ * override (so the e2e harness can enable it on a stock build). Defaults to
+ * false — flag OFF is byte-identical to the legacy full-screen FirstRunChat.
+ */
+export function isInChatOnboardingEnabled(): boolean {
+  if (getBootConfig().inChatOnboarding === true) return true;
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(LOCAL_STORAGE_FLAG_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+const GREETING_MESSAGE_ID = "first-run-greeting";
+const RUNTIME_CHOICE_MESSAGE_ID = "first-run-runtime-choice";
+
+const GREETING_TEXT =
+  "hey there! I'm Eliza — your local-first AI assistant. Let's get you set up. " +
+  "How would you like to run me?";
+
+const RUNTIME_CHOICE_MARKER = [
+  `[CHOICE:${FIRST_RUN_CHOICE_SCOPE} id=runtime allow_custom]`,
+  "cloud=Log in with Eliza Cloud",
+  "local=Run locally on this device",
+  "other=Something else…",
+  "[/CHOICE]",
+].join("\n");
+
+/** Labels keyed by runtime value, for the local acknowledgement message. */
+const RUNTIME_VALUE_LABELS: Record<FirstRunRuntimeValue, string> = {
+  cloud: "Eliza Cloud",
+  local: "a local agent on this device",
+  other: "a custom setup",
+};
+
+function isFirstRunRuntimeValue(value: string): value is FirstRunRuntimeValue {
+  return (FIRST_RUN_RUNTIME_VALUES as readonly string[]).includes(value);
+}
+
+/**
+ * The two synthetic assistant messages seeded into the live transcript: the
+ * greeting, then the runtime `[CHOICE]` block (rendered as buttons by
+ * `InlineWidgetText`). `now` is injected so callers stay deterministic.
+ */
+export function buildFirstRunSeedMessages(now: number): ConversationMessage[] {
+  return [
+    {
+      id: GREETING_MESSAGE_ID,
+      role: "assistant",
+      text: GREETING_TEXT,
+      timestamp: now,
+    },
+    {
+      id: RUNTIME_CHOICE_MESSAGE_ID,
+      role: "assistant",
+      text: RUNTIME_CHOICE_MARKER,
+      timestamp: now + 1,
+    },
+  ];
+}
+
+/** The local acknowledgement appended when a first-run runtime choice is picked. */
+export function buildFirstRunAckMessage(
+  value: FirstRunRuntimeValue,
+  now: number,
+): ConversationMessage {
+  return {
+    id: `first-run-ack-${value}`,
+    role: "assistant",
+    text: `Great — setting up ${RUNTIME_VALUE_LABELS[value]}…`,
+    timestamp: now,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// First-run choice interceptor registry
+//
+// `sendActionMessage` (useChatSend) consults this before sending a choice pick
+// to the agent. Only the in-chat onboarding conductor registers a handler, so
+// when onboarding is inactive `consumeFirstRunChoice` is a no-op and the normal
+// send path is byte-identical.
+// ---------------------------------------------------------------------------
+
+type FirstRunChoiceHandler = (value: FirstRunRuntimeValue) => void;
+
+let activeFirstRunChoiceHandler: FirstRunChoiceHandler | null = null;
+
+/** Register (or clear, with `null`) the active first-run choice handler. */
+export function setFirstRunChoiceInterceptor(
+  handler: FirstRunChoiceHandler | null,
+): void {
+  activeFirstRunChoiceHandler = handler;
+}
+
+/**
+ * Intercept a chat-send value while in-chat onboarding is active. Returns true
+ * (and routes to the registered handler) when `value` is a first-run runtime
+ * choice; false otherwise, so the caller proceeds with a normal send.
+ */
+export function consumeFirstRunChoice(value: string): boolean {
+  const handler = activeFirstRunChoiceHandler;
+  if (!handler) return false;
+  if (!isFirstRunRuntimeValue(value)) return false;
+  logger.info(`[InChatOnboarding] intercepted first-run runtime choice: ${value}`);
+  handler(value);
+  return true;
+}

--- a/packages/ui/src/first-run/use-first-run-controller.ts
+++ b/packages/ui/src/first-run/use-first-run-controller.ts
@@ -275,7 +275,7 @@ async function startMobileLocalAgent(): Promise<void> {
   }
 }
 
-async function startLocalRuntime(): Promise<void> {
+export async function startLocalRuntime(): Promise<void> {
   if (isDesktopPlatform()) {
     try {
       const desktopRuntimeMode = await getDesktopRuntimeMode().catch(
@@ -301,7 +301,7 @@ async function startLocalRuntime(): Promise<void> {
   await startMobileLocalAgent();
 }
 
-async function waitForAgentApi(): Promise<void> {
+export async function waitForAgentApi(): Promise<void> {
   const deadline = Date.now() + FIRST_RUN_AGENT_WAIT_MS;
   let delayMs = 750;
   while (Date.now() < deadline) {

--- a/packages/ui/src/first-run/useInChatOnboarding.ts
+++ b/packages/ui/src/first-run/useInChatOnboarding.ts
@@ -1,31 +1,124 @@
 /**
- * useInChatOnboarding — Phase 1 conductor for chat-centric first-run.
+ * useInChatOnboarding — conductor for chat-centric first-run (#9952).
  *
  * When `active` (in-chat onboarding flag ON + the startup coordinator is in the
  * `first-run-required` phase), this hook seeds the greeting + runtime `[CHOICE]`
  * into the real conversation transcript, asks the floating chat to open, and
- * registers an interceptor so a first-run choice pick appends a local
- * acknowledgement instead of being sent to the agent.
+ * registers an interceptor so each first-run pick is routed into the headless
+ * `first-run-use-case.ts` instead of being sent to the agent. Every returned
+ * `ConductorStep` is seeded back into the transcript as a synthetic assistant
+ * message (a prompt, a CHOICE marker, an OAuth secret card, or a terminal
+ * "done" that triggers the tutorial-or-skip choice).
  *
- * Kept out of App.tsx on purpose — App.tsx calls this once with the live
- * `setConversationMessages`. Flag OFF (`active === false`) means the hook does
- * nothing and the legacy full-screen FirstRunChat path is unchanged.
+ * Called once from `AppContext.tsx` with the live `setConversationMessages` and
+ * a `FirstRunPorts` built from the in-scope app actions. Flag OFF
+ * (`active === false`) means the hook does nothing and the legacy full-screen
+ * FirstRunChat path is unchanged.
  */
 
-import { useEffect } from "react";
+import { logger } from "@elizaos/logger";
 import type { Dispatch, SetStateAction } from "react";
+import { useEffect } from "react";
 import type { ConversationMessage } from "../api";
 import { OPEN_IN_CHAT_ONBOARDING_EVENT } from "../events";
+import type { FirstRunProfileDraft, FirstRunRuntime } from "./first-run";
 import {
-  buildFirstRunAckMessage,
+  type ChoiceSpec,
+  type ConductorStep,
+  chooseProvider,
+  completeCloudProvisioning,
+  type FirstRunPorts,
+  finalizeFirstRun,
+  runFirstRunRuntimeChoice,
+} from "./first-run-use-case";
+import {
   buildFirstRunSeedMessages,
-  type FirstRunRuntimeValue,
   setFirstRunChoiceInterceptor,
 } from "./in-chat-onboarding";
+
+const STATUS_MESSAGE_ID = "first-run-status";
+const TUTORIAL_CHOICE_MESSAGE_ID = "first-run-tutorial-choice";
+
+const TUTORIAL_CHOICE: ChoiceSpec = {
+  scope: "first-run",
+  id: "tutorial",
+  options: [
+    { value: "tutorial:take", label: "Take the quick tour" },
+    { value: "tutorial:skip", label: "Skip for now" },
+  ],
+};
+
+function buildChoiceMarker(choice: ChoiceSpec): string {
+  const header = `[CHOICE:${choice.scope} id=${choice.id}${
+    choice.allowCustom ? " allow_custom" : ""
+  }]`;
+  const lines = choice.options.map((o) => `${o.value}=${o.label}`);
+  return [header, ...lines, "[/CHOICE]"].join("\n");
+}
+
+function stepToMessage(step: ConductorStep, now: number): ConversationMessage {
+  switch (step.kind) {
+    case "prompt":
+      return {
+        id: `first-run-step-${now}`,
+        role: "assistant",
+        text: step.text,
+        timestamp: now,
+      };
+    case "choice":
+      return {
+        id: `first-run-choice-${step.choice.id}-${now}`,
+        role: "assistant",
+        text: `${step.text}\n${buildChoiceMarker(step.choice)}`,
+        timestamp: now,
+      };
+    case "secret":
+      return {
+        id: `first-run-secret-${now}`,
+        role: "assistant",
+        text: step.text,
+        timestamp: now,
+        secretRequest: step.secretRequest,
+      };
+    case "error":
+      return {
+        id: `first-run-error-${now}`,
+        role: "assistant",
+        text: step.choice
+          ? `${step.text}\n${buildChoiceMarker(step.choice)}`
+          : step.text,
+        timestamp: now,
+      };
+    case "done":
+      return {
+        id: `first-run-done-${now}`,
+        role: "assistant",
+        text: step.text ?? "All set.",
+        timestamp: now,
+      };
+  }
+}
+
+function tutorialChoiceMessage(now: number): ConversationMessage {
+  return {
+    id: TUTORIAL_CHOICE_MESSAGE_ID,
+    role: "assistant",
+    text: `Want a quick tour of the basics?\n${buildChoiceMarker(TUTORIAL_CHOICE)}`,
+    timestamp: now,
+  };
+}
+
+/** Infer the draft runtime from a pick value so a continued flow stays coherent. */
+function runtimeForValue(value: string): FirstRunRuntime {
+  if (value === "cloud" || value.startsWith("agent:")) return "cloud";
+  if (value === "local" || value.startsWith("provider:")) return "local";
+  return "local";
+}
 
 export function useInChatOnboarding(
   active: boolean,
   setConversationMessages: Dispatch<SetStateAction<ConversationMessage[]>>,
+  ports: FirstRunPorts,
 ): void {
   useEffect(() => {
     if (!active) return undefined;
@@ -39,14 +132,96 @@ export function useInChatOnboarding(
       return [...prev, ...buildFirstRunSeedMessages(Date.now())];
     });
 
-    setFirstRunChoiceInterceptor((value: FirstRunRuntimeValue) => {
-      // Phase 1: demonstrate the wiring with a local acknowledgement.
-      // SEAM (Phase 2): route `value` to the headless first-run use case
-      // (finishLocal / finishCloud / settings handoff) and persist once.
-      setConversationMessages((prev) => [
-        ...prev,
-        buildFirstRunAckMessage(value, Date.now()),
-      ]);
+    const appendStep = (step: ConductorStep): void => {
+      setConversationMessages((prev) => {
+        // A terminal step clears any lingering status indicator.
+        const base = prev.filter((m) => m.id !== STATUS_MESSAGE_ID);
+        const next = [...base, stepToMessage(step, Date.now())];
+        if (step.kind === "done")
+          next.push(tutorialChoiceMessage(Date.now() + 1));
+        return next;
+      });
+    };
+
+    const onProgress = (text: string | null): void => {
+      setConversationMessages((prev) => {
+        const base = prev.filter((m) => m.id !== STATUS_MESSAGE_ID);
+        if (text === null) return base;
+        return [
+          ...base,
+          {
+            id: STATUS_MESSAGE_ID,
+            role: "assistant",
+            text,
+            timestamp: Date.now(),
+          },
+        ];
+      });
+    };
+
+    const livePorts: FirstRunPorts = { ...ports, onProgress };
+
+    const route = async (value: string): Promise<void> => {
+      const draft: FirstRunProfileDraft = {
+        agentName: "Eliza",
+        runtime: runtimeForValue(value),
+        localInference: "all-local",
+        remoteApiBase: "",
+        remoteToken: "",
+      };
+
+      if (value === "tutorial:take" || value === "tutorial:skip") {
+        finalizeFirstRun(livePorts, value === "tutorial:take");
+        setConversationMessages((prev) =>
+          prev.filter((m) => m.id !== TUTORIAL_CHOICE_MESSAGE_ID),
+        );
+        return;
+      }
+      if (value === "cloud" || value === "local" || value === "other") {
+        appendStep(await runFirstRunRuntimeChoice(livePorts, value, draft));
+        return;
+      }
+      if (value === "provider:on-device" || value === "provider:elizacloud") {
+        const providerId =
+          value === "provider:elizacloud" ? "elizacloud" : "on-device";
+        appendStep(await chooseProvider(livePorts, draft, providerId));
+        return;
+      }
+      if (value.startsWith("agent:")) {
+        const agentId = value.slice("agent:".length);
+        appendStep(
+          await completeCloudProvisioning(
+            livePorts,
+            draft,
+            agentId === "new"
+              ? { forceCreate: true }
+              : { preferAgentId: agentId },
+          ),
+        );
+      }
+    };
+
+    setFirstRunChoiceInterceptor((value: string) => {
+      void route(value).catch((error: unknown) => {
+        logger.error(
+          `[InChatOnboarding] choice routing failed: ${String(error)}`,
+        );
+        onProgress(null);
+        appendStep({
+          kind: "error",
+          text: "Something went wrong setting that up. Want to try again?",
+          choice: {
+            scope: "first-run",
+            id: "runtime",
+            allowCustom: true,
+            options: [
+              { value: "cloud", label: "Log in with Eliza Cloud" },
+              { value: "local", label: "Run locally on this device" },
+              { value: "other", label: "Something else…" },
+            ],
+          },
+        });
+      });
     });
 
     if (typeof window !== "undefined") {
@@ -54,5 +229,5 @@ export function useInChatOnboarding(
     }
 
     return () => setFirstRunChoiceInterceptor(null);
-  }, [active, setConversationMessages]);
+  }, [active, setConversationMessages, ports]);
 }

--- a/packages/ui/src/first-run/useInChatOnboarding.ts
+++ b/packages/ui/src/first-run/useInChatOnboarding.ts
@@ -1,0 +1,58 @@
+/**
+ * useInChatOnboarding — Phase 1 conductor for chat-centric first-run.
+ *
+ * When `active` (in-chat onboarding flag ON + the startup coordinator is in the
+ * `first-run-required` phase), this hook seeds the greeting + runtime `[CHOICE]`
+ * into the real conversation transcript, asks the floating chat to open, and
+ * registers an interceptor so a first-run choice pick appends a local
+ * acknowledgement instead of being sent to the agent.
+ *
+ * Kept out of App.tsx on purpose — App.tsx calls this once with the live
+ * `setConversationMessages`. Flag OFF (`active === false`) means the hook does
+ * nothing and the legacy full-screen FirstRunChat path is unchanged.
+ */
+
+import { useEffect } from "react";
+import type { Dispatch, SetStateAction } from "react";
+import type { ConversationMessage } from "../api";
+import { OPEN_IN_CHAT_ONBOARDING_EVENT } from "../events";
+import {
+  buildFirstRunAckMessage,
+  buildFirstRunSeedMessages,
+  type FirstRunRuntimeValue,
+  setFirstRunChoiceInterceptor,
+} from "./in-chat-onboarding";
+
+export function useInChatOnboarding(
+  active: boolean,
+  setConversationMessages: Dispatch<SetStateAction<ConversationMessage[]>>,
+): void {
+  useEffect(() => {
+    if (!active) return undefined;
+
+    const seedIds = new Set(
+      buildFirstRunSeedMessages(0).map((message) => message.id),
+    );
+    setConversationMessages((prev) => {
+      // Idempotent: never double-seed if the effect re-runs.
+      if (prev.some((message) => seedIds.has(message.id))) return prev;
+      return [...prev, ...buildFirstRunSeedMessages(Date.now())];
+    });
+
+    setFirstRunChoiceInterceptor((value: FirstRunRuntimeValue) => {
+      // Phase 1: demonstrate the wiring with a local acknowledgement.
+      // SEAM (Phase 2): route `value` to the headless first-run use case
+      // (finishLocal / finishCloud / settings handoff) and persist once.
+      setConversationMessages((prev) => [
+        ...prev,
+        buildFirstRunAckMessage(value, Date.now()),
+      ]);
+    });
+
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new CustomEvent(OPEN_IN_CHAT_ONBOARDING_EVENT));
+    }
+
+    return () => setFirstRunChoiceInterceptor(null);
+  }, [active, setConversationMessages]);
+}

--- a/packages/ui/src/state/AppContext.tsx
+++ b/packages/ui/src/state/AppContext.tsx
@@ -13,21 +13,23 @@ import {
   useState,
 } from "react";
 import { type ChatTurnStatus, client } from "../api";
+import { startTutorial } from "../components/pages/tutorial/tutorial-controller";
 import { ConfirmDialog, PromptDialog } from "../components/ui/confirm-dialog";
 import { useConfirm, usePrompt } from "../components/ui/confirm-dialog.hooks";
 import { AppBootContext } from "../config/boot-config-react.hooks";
 import { getBootConfig } from "../config/boot-config-store";
 import { BrandingContext, DEFAULT_BRANDING } from "../config/branding";
+import type { FirstRunPorts } from "../first-run/first-run-use-case";
+import { isInChatOnboardingEnabled } from "../first-run/in-chat-onboarding";
 import {
   isMobileLocalAgentIpcBase,
   persistMobileRuntimeModeForServerTarget,
 } from "../first-run/mobile-runtime-mode";
-import { isInChatOnboardingEnabled } from "../first-run/in-chat-onboarding";
-import { useInChatOnboarding } from "../first-run/useInChatOnboarding";
 import {
   activeServerKindToFirstRunRuntimeTarget,
   type FirstRunRuntimeTarget,
 } from "../first-run/runtime-target";
+import { useInChatOnboarding } from "../first-run/useInChatOnboarding";
 import type { UiLanguage } from "../i18n";
 import {
   getWindowNavigationPath,
@@ -1714,15 +1716,40 @@ function AppProviderInner({
   coordinatorResetRef.current = startupCoordinator.reset;
   coordinatorFirstRunCompleteRef.current = startupCoordinator.firstRunComplete;
 
-  // Chat-centric first-run (#9952, Phase 1): when the flag is ON and a fresh
-  // profile is still in the `first-run-required` phase, seed the onboarding
-  // greeting + runtime choice into the live transcript and open the floating
-  // chat. Flag OFF → no-op (legacy full-screen first-run path unchanged).
+  // Chat-centric first-run (#9952): when the flag is ON and a fresh profile is
+  // still in the `first-run-required` phase, seed the onboarding greeting +
+  // runtime choice into the live transcript, open the floating chat, and route
+  // each pick through the headless first-run use case. Flag OFF → no-op (legacy
+  // full-screen first-run path unchanged). `onProgress` is replaced by the
+  // conductor with a transcript-status writer.
+  const firstRunPorts = useMemo<FirstRunPorts>(
+    () => ({
+      uiLanguage,
+      elizaCloudConnected,
+      setState,
+      handleCloudLogin,
+      completeFirstRun,
+      showActionBanner,
+      setTab,
+      startTutorial,
+      onProgress: () => undefined,
+    }),
+    [
+      uiLanguage,
+      elizaCloudConnected,
+      setState,
+      handleCloudLogin,
+      completeFirstRun,
+      showActionBanner,
+      setTab,
+    ],
+  );
   useInChatOnboarding(
     isInChatOnboardingEnabled() &&
       startupCoordinator.phase === "first-run-required" &&
       !firstRunComplete,
     setConversationMessages,
+    firstRunPorts,
   );
 
   // Memoize the coordinator handle so that unrelated re-renders (e.g. chatInput

--- a/packages/ui/src/state/AppContext.tsx
+++ b/packages/ui/src/state/AppContext.tsx
@@ -22,6 +22,8 @@ import {
   isMobileLocalAgentIpcBase,
   persistMobileRuntimeModeForServerTarget,
 } from "../first-run/mobile-runtime-mode";
+import { isInChatOnboardingEnabled } from "../first-run/in-chat-onboarding";
+import { useInChatOnboarding } from "../first-run/useInChatOnboarding";
 import {
   activeServerKindToFirstRunRuntimeTarget,
   type FirstRunRuntimeTarget,
@@ -1711,6 +1713,17 @@ function AppProviderInner({
   coordinatorRetryRef.current = startupCoordinator.retry;
   coordinatorResetRef.current = startupCoordinator.reset;
   coordinatorFirstRunCompleteRef.current = startupCoordinator.firstRunComplete;
+
+  // Chat-centric first-run (#9952, Phase 1): when the flag is ON and a fresh
+  // profile is still in the `first-run-required` phase, seed the onboarding
+  // greeting + runtime choice into the live transcript and open the floating
+  // chat. Flag OFF → no-op (legacy full-screen first-run path unchanged).
+  useInChatOnboarding(
+    isInChatOnboardingEnabled() &&
+      startupCoordinator.phase === "first-run-required" &&
+      !firstRunComplete,
+    setConversationMessages,
+  );
 
   // Memoize the coordinator handle so that unrelated re-renders (e.g. chatInput
   // keystrokes) don't produce a new object reference and bust the value useMemo below.

--- a/packages/ui/src/state/use-startup-shell-controller.ts
+++ b/packages/ui/src/state/use-startup-shell-controller.ts
@@ -3,6 +3,7 @@ import { client } from "../api";
 import type { StartupShellView } from "../components/shell/startup-shell-types";
 import { CONNECT_EVENT } from "../events";
 import { ensureStoreBuildWorkspaceFolder } from "../first-run/ensure-store-build-workspace-folder";
+import { isInChatOnboardingEnabled } from "../first-run/in-chat-onboarding";
 import { persistMobileRuntimeModeForServerTarget } from "../first-run/mobile-runtime-mode";
 import { applyLaunchConnection } from "../platform";
 import { confirmDesktopAction } from "../utils/desktop-dialogs";
@@ -245,9 +246,14 @@ export function useStartupShellController(): StartupShellController {
     phase === "first-run-required" &&
     (showBootstrap ||
       (firstRunCloudProvisionedContainer && needsBootstrapSession()));
+  // Chat-centric first-run (Phase 1): when the flag is ON we do NOT produce the
+  // full-screen first-run startup view — the live shell paints and onboarding is
+  // seeded into the real floating chat instead. Flag OFF keeps the legacy path.
+  const inChatOnboardingActive = isInChatOnboardingEnabled();
   const showFirstRun =
-    (phase === "first-run-required" && !bootstrapRequired) ||
-    (phase === "ready" && !firstRunComplete);
+    !inChatOnboardingActive &&
+    ((phase === "first-run-required" && !bootstrapRequired) ||
+      (phase === "ready" && !firstRunComplete));
 
   let view: StartupShellView;
   if (startupErrorState) {

--- a/packages/ui/src/state/useChatSend.ts
+++ b/packages/ui/src/state/useChatSend.ts
@@ -27,6 +27,7 @@ import {
   CLOUD_HANDOFF_PHASE_EVENT,
   type CloudHandoffPhaseDetail,
 } from "../events";
+import { consumeFirstRunChoice } from "../first-run/in-chat-onboarding";
 import { getWindowNavigationPath, type Tab } from "../navigation";
 import { clearChatDraft } from "./ChatComposerContext.hooks";
 import { isConversationRecord } from "./chat-conversation-guards";
@@ -1386,6 +1387,9 @@ export function useChatSend(deps: UseChatSendDeps) {
     async (text: string) => {
       const trimmed = text.trim();
       if (!trimmed) return;
+      // In-chat onboarding (Phase 1): a first-run runtime choice pick is handled
+      // locally (no-op when onboarding is inactive — no interceptor registered).
+      if (consumeFirstRunChoice(trimmed)) return;
       if (chatSendBusyRef.current) return;
       chatSendBusyRef.current = true;
       const sendNonce = ++chatSendNonceRef.current;


### PR DESCRIPTION
**Draft / in progress.** Rebuilds first-run onboarding to happen inside the **real floating chat**, closing the actual intent of #9952 and feeding #10198's walkthrough. Opening early to surface the review findings and the plan.

## Why this is needed — #9952 was closed but only cosmetically done

Verified in the current tree (`develop`):
- `CompactOnboarding` is gone, but first-run is **still a full-screen pre-shell gate**: `App.tsx:2122` (`!isShellPaintableNow → <StartupScreen/>`) → `StartupShell(view.kind==="first-run")` → `StartupFirstRunBackground` → `FirstRunChat`. The chat shell **cannot paint** during first-run — so the agent is *not* the first surface, failing #9952's own acceptance criterion ("the first painted surface is the chat shell with the agent greeting").
- `FirstRunChat.tsx` is a **separate `fixed inset-0` chat-looking surface** (its own `AgentBubble` transcript), **not** the live `ContinuousChatOverlay`. That's "chat on the onboarding screen / a duplicate component."
- The 1,454-LOC `useFirstRunController` step machine survives, **plus a duplicate provisioning path** in `useFirstRunCallbacks.ts:runFirstRunChatHandoff`.
- A dedicated first-run **voice TTS/ASR** stack exists only for onboarding.
- **No tutorial-or-skip** after onboarding.

And #10198: there's no `full-walkthrough.spec.ts`; the real-shell walkthrough captures the onboarding screen but **skips provisioning** and uses a **canned SSE reply** — no real onboarding drive, no real LLM; `JOURNEY.md` selectors are stale.

## Plan (chat-centric)

The floating chat (`ContinuousChatOverlay`) already renders inline widgets from **text markers** (`[CHOICE:first-run id=… ]…[/CHOICE]`) in message content and OAuth cards via the message `secretRequest` field. So onboarding becomes **seeded synthetic assistant messages** in the *real* chat, driven by a **headless** first-run use case:

1. Land a fresh profile directly on homescreen + auto-opened floating chat (remove the first-run startup phase).
2. Seed: greeting → Cloud/Local/Other choice → Cloud OAuth card → provider choice (role-correct default) → "other"→Settings → **Take the tutorial / Skip**.
3. Widgets are display-only; choices drive the surviving `finishLocal/finishCloud/selectOrProvisionCloudAgent/submitFirstRun` logic; one `POST /api/first-run`.
4. Delete `FirstRunChat`, the gate, dead CSS, the duplicate handoff, and the dedicated voice stack.
5. Test the whole walkthrough in chat — deterministic "ideal" mock-LLM lane **and** a real-LLM scenario — screenshots desktop+mobile per step + vision review.

Full design + exact seams: `packages/ui/src/first-run/IN_CHAT_ONBOARDING_DESIGN.md` (in this PR).

Closes #9952. Refs #10198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
