### PR TITLE
fix(cloud): proxy billing — refund on upstream failure + safer pricing fallback

### DIFF
--- a/packages/cloud/shared/src/lib/services/proxy/birdeye-handler.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/birdeye-handler.ts
@@ -97,6 +97,37 @@ export async function handleBirdeyeMarketDataProxyGet(c: Context<AppEnv>): Promi
 
     const body = await upstreamResponse.text();
 
+    // Mirror the engine's billing policy (resolveBillableCost refunds on >=500):
+    // we already debited `cost` upfront, so refund it when the upstream FAILS
+    // server-side (Birdeye 5xx outage) — the customer got no usable response. We
+    // keep the charge on 4xx (the customer's own bad request still consumed our
+    // Birdeye quota). Engine-backed market-data routes already refund; this
+    // direct handler must match.
+    if (upstreamResponse.status >= 500) {
+      await creditsService
+        .refundCredits({
+          organizationId: organization_id,
+          amount: cost,
+          description: `API proxy refund: market-data — ${pricedMethod} (upstream ${upstreamResponse.status})`,
+          metadata: {
+            type: "proxy_market-data_refund",
+            service: "market-data",
+            provider: "birdeye",
+            method: pricedMethod,
+          },
+        })
+        .catch((refundError) => {
+          logger.warn("[BirdeyeProxy] refund after upstream failure failed", {
+            method: pricedMethod,
+            status: upstreamResponse.status,
+            error:
+              refundError instanceof Error
+                ? refundError.message
+                : String(refundError),
+          });
+        });
+    }
+
     return new Response(body, {
       status: upstreamResponse.status,
       headers: {

--- a/packages/cloud/shared/src/lib/services/proxy/dexscreener-handler.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/dexscreener-handler.ts
@@ -78,6 +78,30 @@ export async function handleDexscreenerProxyGet(c: Context<AppEnv>): Promise<Res
         status: upstreamResponse.status,
         path: pathStr,
       });
+      // DexScreener is a FREE upstream, so a non-ok response cost us nothing —
+      // refund the upfront charge so the customer isn't billed for a failed call
+      // (matches the engine routes' refund-on-failure policy).
+      await creditsService
+        .refundCredits({
+          organizationId: organization_id,
+          amount: cost,
+          description: `API proxy refund: dexscreener — getRequest (upstream ${upstreamResponse.status})`,
+          metadata: {
+            type: "proxy_dexscreener_refund",
+            service: "dexscreener",
+            method: "getRequest",
+            path: pathStr,
+          },
+        })
+        .catch((refundError) => {
+          logger.warn("[DexscreenerProxy] refund after upstream failure failed", {
+            status: upstreamResponse.status,
+            error:
+              refundError instanceof Error
+                ? refundError.message
+                : String(refundError),
+          });
+        });
     }
 
     return new Response(body, {

--- a/packages/cloud/shared/src/lib/services/proxy/pricing.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/pricing.ts
@@ -3,8 +3,12 @@ import { cache } from "../../cache/client";
 import { logger } from "../../utils/logger";
 import { getProxyConfig } from "./config";
 
-// Hardcoded fallback to prevent service outage if DB pricing is misconfigured.
-const FALLBACK_COST = 1.0;
+// Fallback used only when a service's DB pricing rows are missing (a data fault,
+// e.g. a partially-seeded DB or a new serviceId shipped without a seed). Kept at
+// the low end of real per-call prices (sub-cent; cf. the legacy proxy-billing
+// defaults of $0.0003–$0.001) so a pricing miss UNDER-charges rather than billing
+// $1.00/call (~1,000–20,000x the true price). Fail-safe for the customer.
+const FALLBACK_COST = 0.001;
 const inflightPricingLoads = new Map<string, Promise<Record<string, string>>>();
 
 export class PricingNotFoundError extends Error {
@@ -39,7 +43,9 @@ async function loadPricingMap(serviceId: string): Promise<Record<string, string>
         serviceId,
         fallback: FALLBACK_COST,
       });
-      await cache.set(cacheKey, pricingMap, cacheTtl);
+      // Do NOT cache the empty map: caching it would pin the fallback for the
+      // whole TTL (up to 5 min) even after the pricing rows land. Leaving it
+      // uncached lets a transient/partial-seed miss self-heal on the next call.
       return pricingMap;
     }
 


### PR DESCRIPTION
Two LOW billing-correctness defects in the API-proxy handlers (cloud money-paths deep-scan, adversarially verified). Both over-charge **the customer's own balance** only, bounded by the 100 req/min cap — fixing for billing fairness + fail-safe.

**1. No refund on upstream failure** — `birdeye-handler` / `dexscreener-handler` debit the per-call cost upfront then return the upstream response verbatim with **no refund on 4xx/5xx**, unlike the engine-backed routes (which refund on >=500). So the same Birdeye call is refunded via the engine route but charged via the direct handler on a failure. Fix: refund on failure — birdeye on >=500 (keep 4xx; paid upstream), dexscreener on any non-ok (free upstream). Best-effort/logged.

**2. `$1.00` pricing fallback** — `FALLBACK_COST = 1.0` (~1,000–20,000× real sub-cent prices) fired when a service's DB pricing rows are missing, and the empty map was **cached for the full TTL** (pinning the over-charge up to 5 min). Fix: lower to `$0.001` (fail-safe under-charge) + **don't cache the empty map** so a partial-seed miss self-heals next call.

3 files.