### PR TITLE
fix(discord): serialize direct DM dispatch + remove dead debouncer; root-cause the drop (follow-up to #10221)

### DIFF
--- a/plugins/plugin-discord/__tests__/discord-events-config.test.ts
+++ b/plugins/plugin-discord/__tests__/discord-events-config.test.ts
@@ -19,12 +19,6 @@ const debouncerState = vi.hoisted(() => {
 				pendingCount: vi.fn(() => 0),
 			};
 		}),
-		createMessageDebouncer: vi.fn(() => ({
-			destroy: vi.fn(),
-			enqueue: vi.fn(),
-			flushAll: vi.fn(),
-			pendingCount: vi.fn(() => 0),
-		})),
 	};
 });
 
@@ -33,7 +27,6 @@ vi.mock("../debouncer", async (importOriginal) => {
 	return {
 		...actual,
 		createChannelDebouncer: debouncerState.createChannelDebouncer,
-		createMessageDebouncer: debouncerState.createMessageDebouncer,
 	};
 });
 
@@ -64,7 +57,6 @@ function makeService(shouldRespondOnlyToMentions: boolean) {
 		handleReactionAdd: vi.fn(),
 		handleReactionRemove: vi.fn(),
 		isChannelAllowed: vi.fn(() => true),
-		messageDebouncer: undefined,
 		// A truthy manager so the flush callback runs past its early-return; the
 		// cooldown gate fires after handleMessage regardless of what it does.
 		messageManager: { handleMessage: vi.fn() },

--- a/plugins/plugin-discord/__tests__/discord-events-dm-dispatch.test.ts
+++ b/plugins/plugin-discord/__tests__/discord-events-dm-dispatch.test.ts
@@ -3,24 +3,18 @@ import { ChannelType as DiscordChannelType } from "discord.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mirror the debouncer mock shape from discord-events-config.test.ts so we can
-// assert whether DM/channel messages were enqueued vs dispatched directly.
+// assert whether channel messages were enqueued vs. DMs dispatched directly.
+// The message-debouncer was removed (DMs no longer batch), so only the channel
+// debouncer is mocked here.
 const debouncerState = vi.hoisted(() => {
-	const messageEnqueue = vi.fn();
 	const channelEnqueue = vi.fn();
 	return {
-		messageEnqueue,
 		channelEnqueue,
 		createChannelDebouncer: vi.fn(() => ({
 			destroy: vi.fn(),
 			enqueue: channelEnqueue,
 			flushAll: vi.fn(),
 			markResponded: vi.fn(),
-			pendingCount: vi.fn(() => 0),
-		})),
-		createMessageDebouncer: vi.fn(() => ({
-			destroy: vi.fn(),
-			enqueue: messageEnqueue,
-			flushAll: vi.fn(),
 			pendingCount: vi.fn(() => 0),
 		})),
 	};
@@ -31,7 +25,6 @@ vi.mock("../debouncer", async (importOriginal) => {
 	return {
 		...actual,
 		createChannelDebouncer: debouncerState.createChannelDebouncer,
-		createMessageDebouncer: debouncerState.createMessageDebouncer,
 	};
 });
 
@@ -51,6 +44,7 @@ function makeService() {
 		buildMemoryFromMessage: vi.fn(),
 		character: {},
 		client,
+		channelDebouncer: undefined,
 		discordSettings: {
 			shouldIgnoreBotMessages: true,
 			shouldRespondOnlyToMentions: false,
@@ -62,7 +56,6 @@ function makeService() {
 		handleReactionAdd: vi.fn(),
 		handleReactionRemove: vi.fn(),
 		isChannelAllowed: vi.fn(() => true),
-		messageDebouncer: undefined,
 		messageManager: { handleMessage: vi.fn() },
 		resolveDiscordEntityId: vi.fn(),
 		runtime: {
@@ -78,16 +71,21 @@ function makeService() {
 	};
 }
 
-function makeMessage(channelType: DiscordChannelType, channelId: string) {
+function makeMessage(
+	channelType: DiscordChannelType,
+	channelId: string,
+	id = `msg-${channelId}`,
+) {
 	return {
-		id: `msg-${channelId}`,
+		id,
 		content: "hello",
 		author: { id: "user-1", bot: false, username: "alice" },
 		channel: { id: channelId, type: channelType },
 	};
 }
 
-// Let the async messageCreate handler settle (it awaits handleMessage).
+// Let the async messageCreate handler settle (it awaits handleMessage). One
+// macrotask tick drains the pending microtasks queued by the promise chain.
 const tick = () => new Promise((resolve) => setImmediate(resolve));
 
 describe("setupDiscordEventListeners — DM dispatch", () => {
@@ -95,11 +93,10 @@ describe("setupDiscordEventListeners — DM dispatch", () => {
 		vi.clearAllMocks();
 	});
 
-	it("dispatches DMs directly to handleMessage, bypassing the message-debouncer", async () => {
+	it("dispatches DMs directly to handleMessage, bypassing the channel debouncer", async () => {
 		const service = makeService();
-		// The message-debouncer is wired by setup; the DM path must still bypass it.
-		const { messageDebouncer } = setupDiscordEventListeners(service as never);
-		service.messageDebouncer = messageDebouncer as never;
+		const { channelDebouncer } = setupDiscordEventListeners(service as never);
+		service.channelDebouncer = channelDebouncer as never;
 
 		service.client.emit(
 			"messageCreate",
@@ -108,14 +105,13 @@ describe("setupDiscordEventListeners — DM dispatch", () => {
 		await tick();
 
 		expect(service.messageManager.handleMessage).toHaveBeenCalledTimes(1);
-		expect(debouncerState.messageEnqueue).not.toHaveBeenCalled();
 		expect(debouncerState.channelEnqueue).not.toHaveBeenCalled();
 	});
 
-	it("dispatches group DMs directly to handleMessage, bypassing the message-debouncer", async () => {
+	it("dispatches group DMs directly to handleMessage, bypassing the channel debouncer", async () => {
 		const service = makeService();
-		const { messageDebouncer } = setupDiscordEventListeners(service as never);
-		service.messageDebouncer = messageDebouncer as never;
+		const { channelDebouncer } = setupDiscordEventListeners(service as never);
+		service.channelDebouncer = channelDebouncer as never;
 
 		service.client.emit(
 			"messageCreate",
@@ -124,16 +120,12 @@ describe("setupDiscordEventListeners — DM dispatch", () => {
 		await tick();
 
 		expect(service.messageManager.handleMessage).toHaveBeenCalledTimes(1);
-		expect(debouncerState.messageEnqueue).not.toHaveBeenCalled();
 		expect(debouncerState.channelEnqueue).not.toHaveBeenCalled();
 	});
 
 	it("still routes guild-channel messages through the channel debouncer/enqueue path", async () => {
 		const service = makeService();
-		const { messageDebouncer, channelDebouncer } = setupDiscordEventListeners(
-			service as never,
-		);
-		service.messageDebouncer = messageDebouncer as never;
+		const { channelDebouncer } = setupDiscordEventListeners(service as never);
 		service.channelDebouncer = channelDebouncer as never;
 
 		service.client.emit(
@@ -144,6 +136,78 @@ describe("setupDiscordEventListeners — DM dispatch", () => {
 
 		expect(debouncerState.channelEnqueue).toHaveBeenCalledTimes(1);
 		expect(service.messageManager.handleMessage).not.toHaveBeenCalled();
-		expect(debouncerState.messageEnqueue).not.toHaveBeenCalled();
+	});
+
+	it("serializes rapid DMs in the same channel: the second awaits the first, neither dropped", async () => {
+		const service = makeService();
+		const { channelDebouncer } = setupDiscordEventListeners(service as never);
+		service.channelDebouncer = channelDebouncer as never;
+
+		// Record the order handleMessage is entered. The first call hangs on a
+		// gate so we can prove the second message cannot start until the first
+		// resolves (strict per-channel serialization, one at a time).
+		const entered: string[] = [];
+		let releaseFirst: () => void = () => {};
+		const firstGate = new Promise<void>((resolve) => {
+			releaseFirst = resolve;
+		});
+		service.messageManager.handleMessage = vi.fn((message: { id: string }) => {
+			entered.push(message.id);
+			return entered.length === 1 ? firstGate : Promise.resolve();
+		}) as never;
+
+		// Two DMs in the SAME DM channel, emitted back-to-back (the gateway fires
+		// messageCreate synchronously in order; the listener is not awaited).
+		service.client.emit(
+			"messageCreate",
+			makeMessage(DiscordChannelType.DM, "dm-serial", "dm-msg-1"),
+		);
+		service.client.emit(
+			"messageCreate",
+			makeMessage(DiscordChannelType.DM, "dm-serial", "dm-msg-2"),
+		);
+		await tick();
+
+		// Only the first DM is in flight; the second is queued behind it and must
+		// NOT have started while the first is still running.
+		expect(service.messageManager.handleMessage).toHaveBeenCalledTimes(1);
+		expect(entered).toEqual(["dm-msg-1"]);
+
+		// Releasing the first lets the queue advance to the second, in order.
+		releaseFirst();
+		await tick();
+		await tick();
+
+		expect(service.messageManager.handleMessage).toHaveBeenCalledTimes(2);
+		expect(entered).toEqual(["dm-msg-1", "dm-msg-2"]);
+	});
+
+	it("a failed DM turn does not stall the queue or drop the next DM", async () => {
+		const service = makeService();
+		const { channelDebouncer } = setupDiscordEventListeners(service as never);
+		service.channelDebouncer = channelDebouncer as never;
+
+		const entered: string[] = [];
+		service.messageManager.handleMessage = vi.fn((message: { id: string }) => {
+			entered.push(message.id);
+			// First turn rejects; the per-channel queue must still run the second.
+			return entered.length === 1
+				? Promise.reject(new Error("boom"))
+				: Promise.resolve();
+		}) as never;
+
+		service.client.emit(
+			"messageCreate",
+			makeMessage(DiscordChannelType.DM, "dm-fail", "fail-1"),
+		);
+		service.client.emit(
+			"messageCreate",
+			makeMessage(DiscordChannelType.DM, "dm-fail", "fail-2"),
+		);
+		await tick();
+		await tick();
+
+		expect(service.messageManager.handleMessage).toHaveBeenCalledTimes(2);
+		expect(entered).toEqual(["fail-1", "fail-2"]);
 	});
 });

--- a/plugins/plugin-discord/__tests__/message-coalesce.test.ts
+++ b/plugins/plugin-discord/__tests__/message-coalesce.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { createChannelDebouncer, createMessageDebouncer } from "../debouncer";
+import { createChannelDebouncer } from "../debouncer";
 import {
 	getDiscordMessageCoalesceConfig,
 	makeCoalescedDiscordMessage,
@@ -63,53 +63,6 @@ describe("Discord message coalescing", () => {
 		expect(combined.content).toContain("first");
 		expect(combined.content).toContain("second");
 		expect(combined.__discordCoalescedMessageIds).toEqual(["1", "2"]);
-	});
-
-	it("flushes the receive window when max-batch is reached", () => {
-		vi.useFakeTimers();
-		try {
-			const flushed: unknown[][] = [];
-			const debouncer = createMessageDebouncer(
-				(messages) => flushed.push([...messages]),
-				8000,
-				{ maxBatch: 2 },
-			);
-
-			debouncer.enqueue(mockMessage("1", "first"));
-			expect(flushed).toHaveLength(0);
-
-			debouncer.enqueue(mockMessage("2", "second"));
-			expect(flushed).toHaveLength(1);
-			expect(flushed[0]).toHaveLength(2);
-			expect(debouncer.pendingCount()).toBe(0);
-		} finally {
-			vi.useRealTimers();
-		}
-	});
-
-	it("flushes after the coalescing window expires", () => {
-		vi.useFakeTimers();
-		try {
-			const flushed: unknown[][] = [];
-			const debouncer = createMessageDebouncer(
-				(messages) => flushed.push([...messages]),
-				8000,
-				{ maxBatch: 5 },
-			);
-
-			debouncer.enqueue(mockMessage("1", "first"));
-			debouncer.enqueue(mockMessage("2", "second"));
-			expect(flushed).toHaveLength(0);
-
-			vi.advanceTimersByTime(7999);
-			expect(flushed).toHaveLength(0);
-
-			vi.advanceTimersByTime(1);
-			expect(flushed).toHaveLength(1);
-			expect(flushed[0]).toHaveLength(2);
-		} finally {
-			vi.useRealTimers();
-		}
 	});
 
 	it("does not immediately flush a channel message that mentions the bot incidentally", () => {

--- a/plugins/plugin-discord/account-client-pool.ts
+++ b/plugins/plugin-discord/account-client-pool.ts
@@ -4,7 +4,7 @@ import {
 	normalizeAccountId,
 	type ResolvedDiscordAccount,
 } from "./accounts";
-import type { ChannelDebouncer, MessageDebouncer } from "./debouncer";
+import type { ChannelDebouncer } from "./debouncer";
 import type { MessageManager } from "./messages";
 import type { DiscordSettings } from "./types";
 import type { VoiceManager } from "./voice";
@@ -21,7 +21,6 @@ export interface DiscordAccountClientState {
 	loginFailed: boolean;
 	messageManager?: MessageManager;
 	voiceManager?: VoiceManager;
-	messageDebouncer?: MessageDebouncer;
 	channelDebouncer?: ChannelDebouncer;
 }
 

--- a/plugins/plugin-discord/debouncer.ts
+++ b/plugins/plugin-discord/debouncer.ts
@@ -3,19 +3,6 @@ import { isDiscordUserAddressed } from "./addressing";
 
 export type DebouncerFlushCallback = (messages: DiscordMessage[]) => void;
 
-export interface MessageDebouncer {
-	enqueue: (message: DiscordMessage) => void;
-	flushAll: () => void;
-	pendingCount: () => number;
-	destroy: () => void;
-}
-
-interface PendingEntry {
-	messages: DiscordMessage[];
-	timer: ReturnType<typeof setTimeout>;
-}
-
-const DEFAULT_DEBOUNCE_MS = 400;
 const DEFAULT_CHANNEL_DEBOUNCE_MS = 3_000;
 
 function runSafely(callback: () => void): void {
@@ -288,87 +275,6 @@ export function createChannelDebouncer(
 			pending.clear();
 			lastResponseTime.clear();
 			recentUnaddressed.clear();
-		},
-	};
-}
-
-export function createMessageDebouncer(
-	onFlush: DebouncerFlushCallback,
-	debounceMs: number = DEFAULT_DEBOUNCE_MS,
-	options: { maxBatch?: number } = {},
-): MessageDebouncer {
-	const pending = new Map<string, PendingEntry>();
-	const maxBatch = Math.max(1, options.maxBatch ?? Number.POSITIVE_INFINITY);
-
-	const makeKey = (message: DiscordMessage) =>
-		`${message.channel.id}:${message.author.id}`;
-
-	const flush = (key: string) => {
-		const entry = pending.get(key);
-		if (!entry) {
-			return;
-		}
-		clearTimeout(entry.timer);
-		pending.delete(key);
-		if (entry.messages.length > 0) {
-			runSafely(() => onFlush(entry.messages));
-		}
-	};
-
-	const hasMedia = (message: DiscordMessage) =>
-		(message.attachments?.size ?? 0) > 0 || (message.stickers?.size ?? 0) > 0;
-
-	const enqueue = (message: DiscordMessage) => {
-		if (debounceMs <= 0) {
-			runSafely(() => onFlush([message]));
-			return;
-		}
-
-		const key = makeKey(message);
-		if (hasMedia(message)) {
-			const entry = pending.get(key);
-			if (entry) {
-				clearTimeout(entry.timer);
-				pending.delete(key);
-				if (entry.messages.length > 0) {
-					runSafely(() => onFlush(entry.messages));
-				}
-			}
-			runSafely(() => onFlush([message]));
-			return;
-		}
-
-		const existing = pending.get(key);
-		if (existing) {
-			clearTimeout(existing.timer);
-			existing.messages.push(message);
-			if (existing.messages.length >= maxBatch) {
-				flush(key);
-				return;
-			}
-			existing.timer = setTimeout(() => flush(key), debounceMs);
-			return;
-		}
-
-		pending.set(key, {
-			messages: [message],
-			timer: setTimeout(() => flush(key), debounceMs),
-		});
-	};
-
-	return {
-		enqueue,
-		flushAll: () => {
-			for (const key of [...pending.keys()]) {
-				flush(key);
-			}
-		},
-		pendingCount: () => pending.size,
-		destroy: () => {
-			for (const [, entry] of pending) {
-				clearTimeout(entry.timer);
-			}
-			pending.clear();
 		},
 	};
 }

--- a/plugins/plugin-discord/discord-events.ts
+++ b/plugins/plugin-discord/discord-events.ts
@@ -23,12 +23,7 @@ import {
 	type User,
 } from "discord.js";
 import { isDiscordUserAddressed } from "./addressing";
-import {
-	type ChannelDebouncer,
-	createChannelDebouncer,
-	createMessageDebouncer,
-	type MessageDebouncer,
-} from "./debouncer";
+import { type ChannelDebouncer, createChannelDebouncer } from "./debouncer";
 import {
 	getDiscordMessageCoalesceConfig,
 	makeCoalescedDiscordMessage,
@@ -64,7 +59,6 @@ export interface DiscordServiceInternals {
 	character: DiscordService["character"];
 	messageManager: DiscordService["messageManager"];
 	voiceManager: DiscordService["voiceManager"];
-	messageDebouncer: MessageDebouncer | undefined;
 	channelDebouncer: ChannelDebouncer | undefined;
 	discordSettings: {
 		shouldIgnoreBotMessages: boolean;
@@ -200,13 +194,11 @@ function parseEventListenerConfig(
  * instance (they must be destroyed on stop).
  */
 export function setupDiscordEventListeners(service: DiscordServiceInternals): {
-	messageDebouncer: MessageDebouncer;
 	channelDebouncer: ChannelDebouncer;
 } {
 	const accountId = service.accountId ?? "default";
 	const {
 		listenCids,
-		debounceMs,
 		channelDebounceMs,
 		responseCooldownMs,
 		recentContextTtlMs,
@@ -215,62 +207,9 @@ export function setupDiscordEventListeners(service: DiscordServiceInternals): {
 	const messageCoalesce = getDiscordMessageCoalesceConfig((key) =>
 		service.runtime.getSetting(key),
 	);
-	const effectiveDebounceMs = messageCoalesce.enabled
-		? messageCoalesce.windowMs
-		: debounceMs;
 	const effectiveChannelDebounceMs = messageCoalesce.enabled
 		? messageCoalesce.windowMs
 		: channelDebounceMs;
-
-	// ── Message debouncer ──────────────────────────────────────────────
-	const messageDebouncer = createMessageDebouncer(
-		(messages) => {
-			if (!service.messageManager || messages.length === 0) {
-				return;
-			}
-
-			const anchor = messages[0];
-			if (messageCoalesce.enabled) {
-				const combined = makeCoalescedDiscordMessage(
-					messages,
-					anchor,
-					messageCoalesce,
-				);
-				if (messages.length > 1) {
-					service.runtime.logger.info(
-						{
-							src: "plugin:discord",
-							agentId: service.runtime.agentId,
-							channelId: messages[0]?.channel?.id,
-							messageIds: messages.map((message) => message.id),
-							count: messages.length,
-							path: "messageDebouncer",
-						},
-						"Coalesced inbound Discord messages",
-					);
-				}
-				void service.messageManager.handleMessage(combined as Message);
-				return;
-			}
-
-			if (messages.length === 1) {
-				void service.messageManager.handleMessage(anchor);
-				return;
-			}
-
-			const combinedText = messages
-				.map((message) => message.content)
-				.join("\n");
-			const combined = Object.create(anchor, {
-				content: { value: combinedText, writable: true, enumerable: true },
-			});
-			void service.messageManager.handleMessage(combined as Message);
-		},
-		effectiveDebounceMs,
-		{
-			maxBatch: messageCoalesce.enabled ? messageCoalesce.maxBatch : undefined,
-		},
-	);
 
 	// ── Channel debouncer ──────────────────────────────────────────────
 	const channelDebouncer = createChannelDebouncer(
@@ -359,8 +298,51 @@ export function setupDiscordEventListeners(service: DiscordServiceInternals): {
 		},
 	);
 
-	service.messageDebouncer = messageDebouncer;
 	service.channelDebouncer = channelDebouncer;
+
+	// ── Per-DM-channel serialization ───────────────────────────────────
+	// discord.js invokes the messageCreate listener WITHOUT awaiting it, so N
+	// rapid DMs from one author would otherwise launch N concurrent
+	// handleMessage runs → interleaved / out-of-order / duplicate replies. (The
+	// removed message-debouncer used to serialize per author as a side effect of
+	// batching.) DMs are now dispatched directly, so we chain each DM channel's
+	// handleMessage calls through a promise tail: a given DM channel is processed
+	// strictly in order, one message at a time, and nothing is dropped. Guild
+	// channels are unaffected — they still route through the channel debouncer.
+	const dmChannelQueues = new Map<string, Promise<void>>();
+	const dispatchDmInOrder = (
+		channelId: string,
+		message: Message,
+	): Promise<void> => {
+		// Start only after the prior message on this channel settles — success OR
+		// failure (a failed turn must never stall the queue).
+		const prior = dmChannelQueues.get(channelId) ?? Promise.resolve();
+		const run = prior
+			.catch(() => undefined)
+			.then(() => {
+				// Re-read at dispatch time: the manager can be torn down between
+				// enqueue and this deferred run (service stop). If it's gone, skip
+				// rather than throw.
+				const manager = service.messageManager;
+				if (!manager) {
+					return;
+				}
+				return manager.handleMessage(message);
+			});
+		dmChannelQueues.set(channelId, run);
+		// Once this settles and nothing newer is queued behind it, drop the map
+		// entry so the map stays bounded by the number of *active* DM channels.
+		// The extra `.catch` keeps this cleanup branch from surfacing as an
+		// unhandled rejection; the awaiting caller still observes + logs failures.
+		void run
+			.catch(() => undefined)
+			.finally(() => {
+				if (dmChannelQueues.get(channelId) === run) {
+					dmChannelQueues.delete(channelId);
+				}
+			});
+		return run;
+	};
 
 	// ── messageCreate ──────────────────────────────────────────────────
 	service.client.on("messageCreate", async (message) => {
@@ -489,14 +471,20 @@ export function setupDiscordEventListeners(service: DiscordServiceInternals): {
 				channelType === DiscordChannelType.GroupDM;
 
 			if (isDm) {
-				// DMs are 1:1 and gain nothing from debouncing; the
-				// message-debouncer enqueue/flush path can intermittently drop
-				// them, leaving the bot silent. Dispatch DMs directly.
-				await service.messageManager.handleMessage(message);
+				// DMs are 1:1 and gain nothing from channel-style debouncing.
+				// Dispatch directly, but serialize per DM channel so rapid messages
+				// from one author are handled strictly in order, one at a time, with
+				// no drop (see dispatchDmInOrder above).
+				//
+				// Intentional behavior change: the removed message-debouncer used to
+				// COALESCE rapid same-author multi-part DM text (and an
+				// attachment-then-text pair) into a single handleMessage turn. Direct
+				// dispatch no longer coalesces — each DM is its own turn. For 1:1 DMs
+				// this is acceptable and removes the debounce-window drop; ordering
+				// and no-drop are guaranteed by the per-channel queue.
+				await dispatchDmInOrder(message.channel.id, message);
 			} else if (service.channelDebouncer) {
 				service.channelDebouncer.enqueue(message);
-			} else if (service.messageDebouncer) {
-				service.messageDebouncer.enqueue(message);
 			} else {
 				await service.messageManager.handleMessage(message);
 			}
@@ -1127,5 +1115,5 @@ export function setupDiscordEventListeners(service: DiscordServiceInternals): {
 		});
 	} // end if (isAuditLogEnabled)
 
-	return { messageDebouncer, channelDebouncer };
+	return { channelDebouncer };
 }

--- a/plugins/plugin-discord/service.ts
+++ b/plugins/plugin-discord/service.ts
@@ -94,7 +94,7 @@ import {
 } from "./accounts";
 import type { ICompatRuntime } from "./compat";
 import { DISCORD_SERVICE_NAME } from "./constants";
-import type { ChannelDebouncer, MessageDebouncer } from "./debouncer";
+import type { ChannelDebouncer } from "./debouncer";
 import {
 	handleGuildCreate as handleGuildCreateExtracted,
 	isGuildOnlyCommand,
@@ -483,7 +483,6 @@ export class DiscordService extends Service implements IDiscordService {
 	discordSettings: DiscordSettings;
 	messageManager?: MessageManager;
 	voiceManager?: VoiceManager;
-	private messageDebouncer?: MessageDebouncer;
 	private channelDebouncer?: ChannelDebouncer;
 	private _loginFailed = false;
 	private userSelections: Map<string, Record<string, unknown>> = new Map();
@@ -942,7 +941,6 @@ export class DiscordService extends Service implements IDiscordService {
 		this.discordSettings = state?.settings ?? getDiscordSettings(this.runtime);
 		this.messageManager = state?.messageManager;
 		this.voiceManager = state?.voiceManager;
-		this.messageDebouncer = state?.messageDebouncer;
 		this.channelDebouncer = state?.channelDebouncer;
 		this.allowedChannelIds = state?.allowedChannelIds;
 		this.dynamicChannelIds = state?.dynamicChannelIds ?? new Set();
@@ -1084,17 +1082,6 @@ export class DiscordService extends Service implements IDiscordService {
 				}
 				if (!state || state.accountId === parent.defaultAccountId) {
 					parent.voiceManager = value;
-				}
-			},
-			get messageDebouncer() {
-				return state?.messageDebouncer ?? parent.messageDebouncer;
-			},
-			set messageDebouncer(value: MessageDebouncer | undefined) {
-				if (state) {
-					state.messageDebouncer = value;
-				}
-				if (!state || state.accountId === parent.defaultAccountId) {
-					parent.messageDebouncer = value;
 				}
 			},
 			get channelDebouncer() {
@@ -2648,14 +2635,12 @@ export class DiscordService extends Service implements IDiscordService {
 			return;
 		}
 
-		const { messageDebouncer, channelDebouncer } = setupDiscordEventListeners(
+		const { channelDebouncer } = setupDiscordEventListeners(
 			this.createAccountServiceFacade(state),
 		);
 
-		state.messageDebouncer = messageDebouncer;
 		state.channelDebouncer = channelDebouncer;
 		if (state.accountId === this.defaultAccountId) {
-			this.messageDebouncer = messageDebouncer;
 			this.channelDebouncer = channelDebouncer;
 		}
 	}
@@ -3338,12 +3323,9 @@ export class DiscordService extends Service implements IDiscordService {
 
 		const states = this.accountPool.list();
 		for (const state of states) {
-			state.messageDebouncer?.destroy();
 			state.channelDebouncer?.destroy();
-			state.messageDebouncer = undefined;
 			state.channelDebouncer = undefined;
 		}
-		this.messageDebouncer = undefined;
 		this.channelDebouncer = undefined;
 
 		this.userSelections.clear();


### PR DESCRIPTION
Follow-up completing **#10221** (merged) and getting to the actual root cause of the DM drop in **#10216**.

## What the merged #10221 left incomplete (deep-review findings, re-verified on develop)
- The `messageDebouncer` is now **dead code** — direct DM dispatch was its only live consumer; the channel `else if (service.messageDebouncer)` fallback is unreachable (`channelDebouncer` is always created). develop still carries the full create/assign/destroy wiring (8 refs).
- Direct dispatch fires `await handleMessage(message)` from each un-awaited gateway listener with **no per-conversation lock** → N rapid DMs launch N **concurrent** `handleMessage` runs (the old debouncer serialized per-author) → interleaved/out-of-order/duplicate replies.

## Fixes
1. **Per-DM-channel serialization, no drop.** `dispatchDmInOrder(channelId, message)` chains each DM off the channel's promise tail (`Map<channelId, Promise>`), self-cleaning, with `.catch` so a failed turn settles the tail instead of stalling the queue. DMs in a channel now process strictly in order, one at a time — concurrency hazard gone, still zero drop. Guild channels unchanged.
2. **Remove the dead `messageDebouncer`** entirely (`debouncer.ts` `createMessageDebouncer`/interface/`DEFAULT_DEBOUNCE_MS` ~94 lines; `discord-events.ts` wiring + unreachable fallback; `service.ts` field/getter/create/destroy; `account-client-pool.ts` field; obsolete tests) — grep-confirmed no remaining live caller.
3. **Coalescing**: intentionally not reintroduced for DMs (consistent with the maintainer's direct-dispatch choice; re-adding a debounce window would re-create the drop). Documented as a deliberate behavior change (rapid multi-part DMs are now separate, strictly-ordered turns).

## Root cause of the "intermittent drop" (the PR mis-attributed it)
There is **no** steady-state message-loss bug in the debouncer's enqueue/flush (single-threaded JS; every enqueue eventually flushes). The **real** loss path is `destroy()`: it `clearTimeout` + `pending.clear()` with **no final flush**, so any message still inside the ~400ms debounce window when the service stops/reconnects is silently lost — matching the reported symptom. Direct DM dispatch removes the window for DMs, so this can no longer hit DMs.

⚠️ **Deeper issue still open (separate follow-up recommended):** the **identical bug still affects guild channels** — `createChannelDebouncer.destroy()` (debouncer.ts:271-278) also clears `pending` with no `flushAll()`, and its flush dispatches via fire-and-forget `void handleMessage(...)` (unhandled rejection = silent dropped turn). A proper fix (flush pending on `destroy()` and make teardown observe the in-flight `handleMessage` promises — likely an async `destroy()`) is a deliberate shutdown-semantics change deserving its own PR; intentionally NOT bundled here to avoid a half-considered channel-behavior change.

## Tests (153 pass)
`discord-events-dm-dispatch.test.ts`: retargeted 3 cases + "serializes rapid DMs in same channel" (second `handleMessage` not called until first settles; then both, in order, no drop) + "a failed DM turn does not stall the queue". typecheck + biome clean.

Refs #10216, follows up #10221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)