### PR TITLE
ci: stop orphaned self-hosted-label jobs hanging queued forever

### DIFF
--- a/.github/workflows/scenario-matrix.yml
+++ b/.github/workflows/scenario-matrix.yml
@@ -75,9 +75,18 @@ jobs:
           - name: messaging
             runs-on: ubuntu-24.04
             globs: "packages/test/scenarios/messaging.*/**/*.scenario.ts"
-          - name: messaging-apple
-            runs-on: [self-hosted, eliza-e2e-macos]
-            globs: "packages/test/scenarios/messaging.imessage/**/*.scenario.ts packages/test/scenarios/messaging.signal/**/*.scenario.ts"
+          # NOTE: the two apple-ecosystem shards (messaging-apple,
+          # selfcontrol-activity) require a self-hosted macOS runner labeled
+          # `eliza-e2e-macos`, which is NOT currently registered on this repo. with
+          # the shards present, those matrix legs hang queued forever (no runner can
+          # claim them) and never expire cleanly. they are commented out until the
+          # runner is registered (Settings -> Actions -> Runners). to re-enable:
+          # register the macOS runner, then uncomment the two shards below. the
+          # imessage/signal/selfcontrol/activity scenarios need macOS, so do NOT
+          # just point them at ubuntu (they would fail rather than skip).
+          # - name: messaging-apple
+          #   runs-on: [self-hosted, eliza-e2e-macos]
+          #   globs: "packages/test/scenarios/messaging.imessage/**/*.scenario.ts packages/test/scenarios/messaging.signal/**/*.scenario.ts"
           - name: todos-reminders
             runs-on: ubuntu-24.04
             globs: "packages/test/scenarios/todos/**/*.scenario.ts packages/test/scenarios/reminders/**/*.scenario.ts"
@@ -87,9 +96,10 @@ jobs:
           - name: relationships
             runs-on: ubuntu-24.04
             globs: "packages/test/scenarios/relationships/**/*.scenario.ts"
-          - name: selfcontrol-activity
-            runs-on: [self-hosted, eliza-e2e-macos]
-            globs: "packages/test/scenarios/selfcontrol/**/*.scenario.ts packages/test/scenarios/activity/**/*.scenario.ts"
+          # - name: selfcontrol-activity  (apple shard, see note above; re-enable
+          #   with the macOS runner)
+          #   runs-on: [self-hosted, eliza-e2e-macos]
+          #   globs: "packages/test/scenarios/selfcontrol/**/*.scenario.ts packages/test/scenarios/activity/**/*.scenario.ts"
           - name: browser-social
             runs-on: ubuntu-24.04
             globs: "packages/test/scenarios/browser.*/**/*.scenario.ts packages/test/scenarios/social.*/**/*.scenario.ts"

--- a/.github/workflows/training-stack.yml
+++ b/.github/workflows/training-stack.yml
@@ -135,7 +135,13 @@ jobs:
 
   gpu-build:
     name: GPU build (QJL nvcc + Triton JIT)
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'gpu-ci')
+    # only run when a gpu-cuda-12.6 self-hosted runner is actually available.
+    # gated on an explicit opt-in (the `gpu-ci` PR label or a manual dispatch) so
+    # the job never auto-fires on push and hangs queued forever waiting for a
+    # runner label no registered runner currently has. flip on by adding the
+    # `gpu-ci` label to a PR, dispatching manually, or registering a gpu runner +
+    # relaxing this guard.
+    if: contains(github.event.pull_request.labels.*.name, 'gpu-ci') || github.event_name == 'workflow_dispatch'
     runs-on: [self-hosted, gpu-cuda-12.6]
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
## what

two CI jobs targeted self-hosted runner labels that no registered runner on this repo has, so they sat `queued` indefinitely (until GitHub's ~24h expiry) on normal push/PR activity. one `training-stack` GPU run was stuck ~13h.

the runner fleet itself is healthy (27 runners online: 22x `hetzner-robot`, 5x `eliza`, all Linux/X64). this is a workflow-config fix, not a runner-ops change.

## fixes

- **training-stack** "GPU build (QJL nvcc + Triton JIT)": fired on push to develop and waited on `[self-hosted, gpu-cuda-12.6]` (no such runner). now gated behind an explicit opt-in (`gpu-ci` PR label or manual dispatch), so it only runs when a GPU runner is actually available.
- **scenario-matrix** apple shards (`messaging-apple`, `selfcontrol-activity`): target `[self-hosted, eliza-e2e-macos]` (not registered — the workflow's own comments already flagged this as a TODO). commented out until the macOS runner exists, with a note to re-enable. NOT redirected to ubuntu, because the imessage/signal/selfcontrol scenarios need macOS and would fail rather than skip there.

## left alone (already safe)

other `gpu-cuda-12.6` / `eliza-e2e-macos` references are already gated behind explicit dispatch inputs and don't auto-hang: `build-llama-ffi-linux` build-cuda (`inputs.run_cuda`), `gpu-bench-nightly` (schedule/dispatch, skips gracefully), `mobile-resource-workbench` ios-sim (`workflow_dispatch && inputs.run_ios_sim`).

## to fully enable later

register the missing runners (Settings -> Actions -> Runners) with the exact labels `gpu-cuda-12.6` and `eliza-e2e-macos`, then relax the training-stack guard and uncomment the scenario-matrix apple shards.

Co-authored-by: wakesync <shadow@shad0w.xyz>
