### PR TITLE
fix(cloud): CRITICAL — require verified email for @elizalabs.ai super_admin grant (privesc)

### DIFF
--- a/packages/cloud/api/v1/user/email/route.ts
+++ b/packages/cloud/api/v1/user/email/route.ts
@@ -16,6 +16,7 @@ import {
   RateLimitPresets,
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
+import { isElizaLabsAdminEmail } from "@/lib/services/admin";
 import { usersService } from "@/lib/services/users";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -56,6 +57,21 @@ app.patch("/", async (c) => {
     }
 
     const lower = parsed.data.email.toLowerCase().trim();
+
+    // SECURITY (defense-in-depth): this self-service route sets
+    // email_verified=false with NO ownership proof, so it must not accept a
+    // privileged-domain address. An unverified @elizalabs.ai email would
+    // otherwise be a super_admin grant vector (the admin grant now also requires
+    // email_verified, but reject it here too).
+    if (isElizaLabsAdminEmail(lower)) {
+      return c.json(
+        {
+          success: false,
+          error: "This email domain cannot be set here. Please contact support.",
+        },
+        403,
+      );
+    }
 
     const existingUser = await usersService.getByEmail(lower);
     if (existingUser && existingUser.id !== authed.id) {

--- a/packages/cloud/shared/src/lib/auth/workers-hono-auth.ts
+++ b/packages/cloud/shared/src/lib/auth/workers-hono-auth.ts
@@ -87,6 +87,7 @@ function toAuthedUser(user: UserWithOrganization): AuthedUser {
   return {
     id: user.id,
     email: user.email ?? null,
+    email_verified: user.email_verified ?? null,
     organization_id: user.organization_id ?? null,
     organization: user.organization
       ? {

--- a/packages/cloud/shared/src/lib/services/__tests__/admin-email.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/admin-email.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { isElizaLabsAdminEmail } from "../admin";
+import { adminService, isElizaLabsAdminEmail } from "../admin";
 
 // Admin gate: only @elizalabs.ai emails. The `@` anchor in the suffix is what
 // stops look-alike-domain spoofing — pin it so it can't regress to a bare-domain
@@ -22,5 +22,32 @@ describe("isElizaLabsAdminEmail", () => {
     expect(isElizaLabsAdminEmail("evil@notelizalabs.ai")).toBe(false);
     expect(isElizaLabsAdminEmail("user@elizalabs.ai.evil.com")).toBe(false);
     expect(isElizaLabsAdminEmail("elizalabs.ai@gmail.com")).toBe(false);
+  });
+});
+
+describe("getAdminStatusForUser email verification gate", () => {
+  test("grants super_admin to verified @elizalabs.ai email", async () => {
+    await expect(
+      adminService.getAdminStatusForUser({
+        email: "admin@elizalabs.ai",
+        email_verified: true,
+      }),
+    ).resolves.toEqual({ isAdmin: true, role: "super_admin" });
+  });
+
+  test("does not grant super_admin to unverified @elizalabs.ai email", async () => {
+    await expect(
+      adminService.getAdminStatusForUser({
+        email: "attacker@elizalabs.ai",
+        email_verified: false,
+      }),
+    ).resolves.toEqual({ isAdmin: false, role: null });
+
+    await expect(
+      adminService.getAdminStatusForUser({
+        email: "attacker@elizalabs.ai",
+        email_verified: null,
+      }),
+    ).resolves.toEqual({ isAdmin: false, role: null });
   });
 });

--- a/packages/cloud/shared/src/lib/services/admin.ts
+++ b/packages/cloud/shared/src/lib/services/admin.ts
@@ -58,6 +58,7 @@ const ELIZALABS_ADMIN_EMAIL_DOMAIN = "@elizalabs.ai";
 
 interface AdminIdentity {
   email?: string | null;
+  email_verified?: boolean | null;
   wallet_address?: string | null;
 }
 
@@ -111,7 +112,12 @@ class AdminService {
   async getAdminStatusForUser(
     user: AdminIdentity,
   ): Promise<{ isAdmin: boolean; role: AdminRole | null }> {
-    if (isElizaLabsAdminEmail(user.email)) {
+    // SECURITY: the @elizalabs.ai super_admin grant requires a VERIFIED email.
+    // Real admins arrive via Steward Google-Workspace SSO, which sets
+    // email_verified=true. Without this check, any user could set an UNVERIFIED
+    // @elizalabs.ai email (e.g. a free wallet account via PATCH /api/v1/user/email)
+    // and self-grant platform super_admin.
+    if (isElizaLabsAdminEmail(user.email) && user.email_verified === true) {
       return { isAdmin: true, role: "super_admin" };
     }
 

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -184,6 +184,8 @@ export interface Bindings {
 export interface AuthedUser {
   id: string;
   email?: string | null;
+  /** Whether `email` is verified — gates the @elizalabs.ai super_admin grant. */
+  email_verified?: boolean | null;
   organization_id?: string | null;
   organization?: { id: string; name?: string; is_active?: boolean } | null;
   is_active?: boolean;


### PR DESCRIPTION
## 🚨 CRITICAL privilege escalation (adversarial scan, fully verified)

`adminService.getAdminStatusForUser()` returns `super_admin` for **any** user whose email ends in `@elizalabs.ai` — and **never checks `email_verified`**. Combined with `PATCH /api/v1/user/email` (which lets any user with `email=null` set an **arbitrary** email, stored `email_verified=false`) and **public SIWE/SIWS wallet login** (creates users with `email=null`), this is a full self-service compromise:

1. Public `POST /api/auth/siwe/verify` with a throwaway wallet → `eliza_*` API key + `email=null` active-org user (free, no funds).
2. `PATCH /api/v1/user/email {"email":"x@elizalabs.ai"}` with that key → 200, stored unverified.
3. Every `/api/v1/admin/*` (cross-tenant orgs/users, moderation, node provision, pricing) and **`/api/admin/redemptions` approve (real-money payouts)** passes `requireAdmin` as **super_admin**.

→ Total tenant-isolation + platform compromise + money.

## Fix
- **`getAdminStatusForUser`**: grant `super_admin` only when `email_verified === true`. Real admins arrive via Steward Google-Workspace SSO (`email_verified=true`), so they're unaffected.
- **Plumb `email_verified` through `AuthedUser` + `toAuthedUser`** — `requireAdmin` passes the `AuthedUser` (not the full DB record), so without this it would carry no verification flag and the gate would deny everyone.
- **Defense-in-depth**: `PATCH /api/v1/user/email` now **rejects `@elizalabs.ai`** addresses (ownership is never proven there).

**Checking prod exposure now — if this is live on `main`, it needs an urgent prod hotfix. @lalalune please prioritize.**