### PR TITLE
ci: add PR concurrency cancel-groups to 8 hosted-runner workflows

### DIFF
--- a/.github/workflows/build-agent-image.yml
+++ b/.github/workflows/build-agent-image.yml
@@ -33,6 +33,13 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 # Default to least privilege. Override per-job where needed.
+# cancel superseded in-flight runs for the same PR to free hosted-runner
+# capacity. only cancels pull_request runs; push runs on protected branches
+# (main/develop) are never cancelled mid-flight.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,6 +10,13 @@ on:
   workflow_dispatch:
 
 # Default to least privilege. Override per-job where needed.
+# cancel superseded in-flight runs for the same PR to free hosted-runner
+# capacity. only cancels pull_request runs; push runs on protected branches
+# (main/develop) are never cancelled mid-flight.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -18,6 +18,13 @@ on:
   pull_request:
     branches: ["main", "develop"]
 
+# cancel superseded in-flight runs for the same PR to free hosted-runner
+# capacity. only cancels pull_request runs; push runs on protected branches
+# (main/develop) are never cancelled mid-flight.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/electrobun-submodule-guard.yml
+++ b/.github/workflows/electrobun-submodule-guard.yml
@@ -25,6 +25,13 @@ on:
       - "upstreams/electrobun"
       - ".gitmodules"
 
+# cancel superseded in-flight runs for the same PR to free hosted-runner
+# capacity. only cancels pull_request runs; push runs on protected branches
+# (main/develop) are never cancelled mid-flight.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -10,6 +10,13 @@ on:
   push:
     branches: ["main", "develop"]
 
+# cancel superseded in-flight runs for the same PR to free hosted-runner
+# capacity. only cancels pull_request runs; push runs on protected branches
+# (main/develop) are never cancelled mid-flight.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/riscv64-smoke.yml
+++ b/.github/workflows/riscv64-smoke.yml
@@ -13,6 +13,13 @@ on:
   pull_request:
     types: [labeled, synchronize, reopened]
 
+# cancel superseded in-flight runs for the same PR to free hosted-runner
+# capacity. only cancels pull_request runs; push runs on protected branches
+# (main/develop) are never cancelled mid-flight.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/test-elizaos-setup.yml
+++ b/.github/workflows/test-elizaos-setup.yml
@@ -7,6 +7,13 @@ on:
       - ".github/workflows/test-elizaos-setup.yml"
 
 # Default to least privilege. Override per-job where needed.
+# cancel superseded in-flight runs for the same PR to free hosted-runner
+# capacity. only cancels pull_request runs; push runs on protected branches
+# (main/develop) are never cancelled mid-flight.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/verify-patches.yml
+++ b/.github/workflows/verify-patches.yml
@@ -15,6 +15,13 @@ on:
     paths:
       - "patches/**"
 
+# cancel superseded in-flight runs for the same PR to free hosted-runner
+# capacity. only cancels pull_request runs; push runs on protected branches
+# (main/develop) are never cancelled mid-flight.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## what

8 push/PR workflows had no `concurrency` group, so every push to a PR stacked a brand-new run instead of superseding the stale one. when the org GitHub-hosted runner queue is backed up (as it is during the launch), that stacking is a real demand multiplier — N pushes to a PR = N concurrent hosted runs instead of 1.

## fix

add the standard cancel-superseded pattern, scoped to PR runs only:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

a new push to a PR cancels that PR's own in-flight run, but push runs on protected branches (main/develop) are **never** cancelled mid-flight — so no risk of a half-finished protected-branch build or release step.

workflows touched: `coverage-gate`, `gitleaks`, `codeql`, `verify-patches`, `electrobun-submodule-guard`, `riscv64-smoke`, `test-elizaos-setup`, `build-agent-image`.

## why now

the live launch CI clog is primarily an org hosted-runner capacity/concurrency cap (admin-side, being handled separately). this PR is the config-side complement: it stops the org from burning hosted minutes on superseded runs, which drains the queue faster and lowers steady-state hosted demand. pure CI-config, no product/runtime change.

Co-authored-by: wakesync <shadow@shad0w.xyz>
