### PR TITLE
feat(plugin-cloud-apps): agent can list/describe your Eliza Cloud apps (all connectors)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -109,6 +109,7 @@
         "@elizaos/plugin-background-runner": "workspace:*",
         "@elizaos/plugin-browser": "workspace:*",
         "@elizaos/plugin-capacitor-bridge": "workspace:*",
+        "@elizaos/plugin-cloud-apps": "workspace:*",
         "@elizaos/plugin-coding-tools": "workspace:*",
         "@elizaos/plugin-commands": "workspace:*",
         "@elizaos/plugin-computeruse": "workspace:*",
@@ -712,6 +713,7 @@
         "@electric-sql/pglite-socket": "0.1.6",
         "@elevenlabs/elevenlabs-js": "^2.45.0",
         "@elizaos/core": "workspace:*",
+        "@elizaos/plugin-cloud-apps": "workspace:*",
         "@elizaos/plugin-elevenlabs": "workspace:*",
         "@elizaos/plugin-elizacloud": "workspace:*",
         "@elizaos/plugin-sql": "workspace:*",
@@ -3121,6 +3123,21 @@
       "peerDependencies": {
         "@elizaos/core": "workspace:*",
         "zod": "^4.4.3",
+      },
+    },
+    "plugins/plugin-cloud-apps": {
+      "name": "@elizaos/plugin-cloud-apps",
+      "version": "2.0.3-beta.7",
+      "dependencies": {
+        "@elizaos/cloud-sdk": "workspace:*",
+      },
+      "devDependencies": {
+        "@elizaos/core": "workspace:*",
+        "@types/bun": "^1.1.0",
+        "typescript": "^6.0.3",
+      },
+      "peerDependencies": {
+        "@elizaos/core": "workspace:*",
       },
     },
     "plugins/plugin-codex-cli": {
@@ -6275,6 +6292,8 @@
     "@elizaos/plugin-cli": ["@elizaos/plugin-cli@workspace:plugins/plugin-cli"],
 
     "@elizaos/plugin-cli-inference": ["@elizaos/plugin-cli-inference@workspace:plugins/plugin-cli-inference"],
+
+    "@elizaos/plugin-cloud-apps": ["@elizaos/plugin-cloud-apps@workspace:plugins/plugin-cloud-apps"],
 
     "@elizaos/plugin-codex-cli": ["@elizaos/plugin-codex-cli@workspace:plugins/plugin-codex-cli"],
 

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -288,6 +288,7 @@
     "@elizaos/plugin-background-runner": "workspace:*",
     "@elizaos/plugin-browser": "workspace:*",
     "@elizaos/plugin-capacitor-bridge": "workspace:*",
+    "@elizaos/plugin-cloud-apps": "workspace:*",
     "@elizaos/plugin-coding-tools": "workspace:*",
     "@elizaos/plugin-commands": "workspace:*",
     "@elizaos/plugin-computeruse": "workspace:*",

--- a/packages/agent/src/api/suggestions-routes.ts
+++ b/packages/agent/src/api/suggestions-routes.ts
@@ -126,6 +126,9 @@ const SCOPE_STARTERS: Record<string, readonly string[]> = {
     "List my automations",
     "What ran today?",
   ],
+  // "What apps do I have?" is served by the LIST_CLOUD_APPS action
+  // (@elizaos/plugin-cloud-apps) — its WHAT_APPS_DO_I_HAVE / MY_APPS similes
+  // match this exact phrase, so clicking the chip lists the user's Cloud apps.
   "page-apps": ["What apps do I have?", "Recommend an app", "Build me an app"],
   "page-connectors": [
     "Check my connections",

--- a/packages/agent/src/runtime/core-plugins.ts
+++ b/packages/agent/src/runtime/core-plugins.ts
@@ -129,6 +129,7 @@ export const CORE_PLUGINS: readonly string[] = [
   // @elizaos/plugin-agent-orchestrator — opt-in via ELIZA_AGENT_ORCHESTRATOR (Eliza app enables by default)
   // Recurring work uses runtime TaskService + triggers (no @elizaos/plugin-cron).
   "@elizaos/plugin-app-control", // launch, close, and list running Eliza apps from agent chat
+  "@elizaos/plugin-cloud-apps", // read-core for Eliza Cloud Apps: LIST_CLOUD_APPS / GET_APP + CLOUD_APPS provider (reaches local/native + Discord/Telegram via the shared pipeline). Read-only; mutating/money actions are deferred to Phase 3b. Cloud-hosted agents add this separately via agent-loader, gated behind CLOUD_APPS_PLUGIN_ENABLED.
   "@elizaos/plugin-native-filesystem", // mobile-safe FILE target=device via Capacitor on iOS/Android, Node fs/promises rooted under resolveStateDir()/workspace on desktop/AOSP
   "@elizaos/plugin-shell", // shell service, approvals, and history provider
   "@elizaos/plugin-coding-tools", // native FILE/SHELL/WORKTREE coding tools (desktop-only

--- a/packages/cloud/api/__tests__/containers-create-contract.test.ts
+++ b/packages/cloud/api/__tests__/containers-create-contract.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Container create/update wire-contract tests.
+ *
+ * Proves the fix for the casing bug that silently dropped `ELIZA_APP_ID`:
+ * the `@elizaos/cloud-sdk` request types are camelCase, and the server zod
+ * schema (the source of truth, here imported directly — no mock) is camelCase
+ * too, so an SDK-shaped body now round-trips with every field intact. The
+ * regression cases reproduce the original bug: a snake_case body parses
+ * "successfully" but with `projectName`, `environmentVars` (and thus
+ * `ELIZA_APP_ID`), `memoryMb`, and `healthCheckPath` silently stripped.
+ *
+ * The bodies below are the exact shapes the SDK serializes for
+ * `createContainer(req: CreateContainerRequest)` and
+ * `updateContainer(id, req: UpdateContainerRequest)` — those types are pinned
+ * to these keys by the compile-time test in
+ * `packages/cloud/sdk/src/client.test.ts`.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  CreateContainerSchema,
+  PatchContainerSchema,
+} from "../v1/containers/schema";
+
+describe("POST /api/v1/containers — create contract (casing bug fix)", () => {
+  test("a camelCase SDK body round-trips with ELIZA_APP_ID and projectName intact", () => {
+    // Exactly what ElizaCloudClient.createContainer puts on the wire for the
+    // fixed CreateContainerRequest type.
+    const sdkBody = {
+      name: "My App",
+      image: "ghcr.io/elizaos/my-app:latest",
+      projectName: "my-app",
+      port: 3000,
+      cpu: 1792,
+      memoryMb: 1792,
+      environmentVars: { ELIZA_APP_ID: "app_abc123", FOO: "bar" },
+      healthCheckPath: "/health",
+    };
+    // Simulate the JSON transit the Worker performs (c.req.json()).
+    const wire = JSON.parse(JSON.stringify(sdkBody));
+
+    const parsed = CreateContainerSchema.safeParse(wire);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+
+    // The two fields the bug dropped now survive end to end.
+    expect(parsed.data.projectName).toBe("my-app");
+    expect(parsed.data.environmentVars?.ELIZA_APP_ID).toBe("app_abc123");
+    // And the rest of the camelCase surface survives too.
+    expect(parsed.data.memoryMb).toBe(1792);
+    expect(parsed.data.healthCheckPath).toBe("/health");
+    expect(parsed.data.port).toBe(3000);
+    expect(parsed.data.cpu).toBe(1792);
+  });
+
+  test("REGRESSION: the old snake_case body silently drops ELIZA_APP_ID and projectName", () => {
+    // The body the pre-fix SDK type produced. zod strips unknown keys, so this
+    // parses "successfully" while losing everything but name+image.
+    const legacyBody = {
+      name: "My App",
+      image: "ghcr.io/elizaos/my-app:latest",
+      project_name: "my-app",
+      environment_vars: { ELIZA_APP_ID: "app_abc123" },
+      memory: 1792,
+      health_check_path: "/health",
+    };
+    const wire = JSON.parse(JSON.stringify(legacyBody));
+
+    const parsed = CreateContainerSchema.safeParse(wire);
+    // It does NOT fail — that is the insidious part: no error surfaces.
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+
+    // Everything carried in snake_case is gone — environmentVars never existed,
+    // so ELIZA_APP_ID (per-app monetization attribution) is lost.
+    expect(parsed.data.projectName).toBeUndefined();
+    expect(parsed.data.environmentVars).toBeUndefined();
+    expect(parsed.data.environmentVars?.ELIZA_APP_ID).toBeUndefined();
+    expect(parsed.data.memoryMb).toBeUndefined();
+    expect(parsed.data.healthCheckPath).toBeUndefined();
+
+    // And none of the snake_case keys leaked through onto the parsed output.
+    expect(parsed.data).not.toHaveProperty("project_name");
+    expect(parsed.data).not.toHaveProperty("environment_vars");
+  });
+
+  test("rejects a body missing the required image (server is the source of truth)", () => {
+    const parsed = CreateContainerSchema.safeParse({ name: "no-image" });
+    expect(parsed.success).toBe(false);
+  });
+});
+
+describe("PATCH /api/v1/containers/:id — update contract (SDK union ↔ server)", () => {
+  test("every UpdateContainerRequest variant passes the server PatchSchema", () => {
+    // The three shapes of the SDK's UpdateContainerRequest discriminated union.
+    const restart = { action: "restart" };
+    const setEnv = {
+      action: "setEnv",
+      environmentVars: { ELIZA_APP_ID: "app_abc123" },
+    };
+    const scale = { action: "scale", desiredCount: 1 };
+
+    expect(PatchContainerSchema.safeParse(restart).success).toBe(true);
+    expect(PatchContainerSchema.safeParse(setEnv).success).toBe(true);
+    expect(PatchContainerSchema.safeParse(scale).success).toBe(true);
+  });
+
+  test("REGRESSION: the old { desired_count } / partial-create body is rejected", () => {
+    // The pre-fix UpdateContainerRequest extended Partial<CreateContainerRequest>,
+    // so callers sent bodies with no `action` — which the server always 400s.
+    expect(PatchContainerSchema.safeParse({ desired_count: 1 }).success).toBe(
+      false,
+    );
+    expect(
+      PatchContainerSchema.safeParse({ name: "x", projectName: "y" }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/cloud/api/v1/containers/[id]/route.ts
+++ b/packages/cloud/api/v1/containers/[id]/route.ts
@@ -28,20 +28,11 @@ import { getHetznerContainersClient } from "@/lib/services/containers/hetzner-cl
 import { HetznerClientError } from "@/lib/services/containers/hetzner-client/types";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
+import { PatchContainerSchema } from "../schema";
 
 const app = new Hono<AppEnv>();
 
-const PatchSchema = z.discriminatedUnion("action", [
-  z.object({ action: z.literal("restart") }),
-  z.object({
-    action: z.literal("setEnv"),
-    environmentVars: z.record(z.string(), z.string()),
-  }),
-  z.object({
-    action: z.literal("scale"),
-    desiredCount: z.number().int().positive(),
-  }),
-]);
+const PatchSchema = PatchContainerSchema;
 
 function hetznerErrorStatus(
   code: HetznerClientError["code"],

--- a/packages/cloud/api/v1/containers/route.ts
+++ b/packages/cloud/api/v1/containers/route.ts
@@ -37,7 +37,6 @@
  */
 
 import { Hono } from "hono";
-import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { containersEnv } from "@/lib/config/containers-env";
@@ -54,21 +53,9 @@ import {
 import { findReservedEnvKeys } from "@/lib/services/reserved-env-keys";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
+import { CreateContainerSchema } from "./schema";
 
 const app = new Hono<AppEnv>();
-
-const CreateContainerSchema = z.object({
-  name: z.string().min(1).max(100),
-  /** Container image reference, e.g. `ghcr.io/elizaos/my-app:latest`. */
-  image: z.string().min(1).max(512),
-  /** Stable project key (sticky scheduling/volumes). Defaults to a slug of `name`. */
-  projectName: z.string().min(1).max(100).optional(),
-  port: z.number().int().positive().max(65535).optional(),
-  cpu: z.number().int().positive().optional(),
-  memoryMb: z.number().int().positive().optional(),
-  environmentVars: z.record(z.string(), z.string()).optional(),
-  healthCheckPath: z.string().max(256).optional(),
-});
 
 function slugify(name: string): string {
   return (

--- a/packages/cloud/api/v1/containers/schema.ts
+++ b/packages/cloud/api/v1/containers/schema.ts
@@ -1,0 +1,47 @@
+/**
+ * Container request schemas — the source of truth for the `/api/v1/containers`
+ * wire contract.
+ *
+ * Extracted from the route handlers so the contract can be unit-tested in
+ * isolation (no Hono/Drizzle imports) and so the `@elizaos/cloud-sdk` types that
+ * mirror it can be validated against the *real* schema.
+ *
+ * IMPORTANT: these are camelCase. zod's `z.object` strips unknown keys, so a
+ * snake_case body (`project_name`, `environment_vars`, …) is silently dropped
+ * before a handler ever runs — that previously discarded
+ * `environmentVars.ELIZA_APP_ID` (per-app monetization attribution) and
+ * `projectName` (the sticky deploy key) on every container create. The SDK's
+ * `CreateContainerRequest` / `UpdateContainerRequest` must stay in exact
+ * agreement with these shapes.
+ */
+import { z } from "zod";
+
+/** Body for `POST /api/v1/containers`. */
+export const CreateContainerSchema = z.object({
+  name: z.string().min(1).max(100),
+  /** Container image reference, e.g. `ghcr.io/elizaos/my-app:latest`. */
+  image: z.string().min(1).max(512),
+  /** Stable project key (sticky scheduling/volumes). Defaults to a slug of `name`. */
+  projectName: z.string().min(1).max(100).optional(),
+  port: z.number().int().positive().max(65535).optional(),
+  cpu: z.number().int().positive().optional(),
+  memoryMb: z.number().int().positive().optional(),
+  environmentVars: z.record(z.string(), z.string()).optional(),
+  healthCheckPath: z.string().max(256).optional(),
+});
+
+/**
+ * Body for `PATCH /api/v1/containers/:id` — action-discriminated:
+ * restart | setEnv | scale.
+ */
+export const PatchContainerSchema = z.discriminatedUnion("action", [
+  z.object({ action: z.literal("restart") }),
+  z.object({
+    action: z.literal("setEnv"),
+    environmentVars: z.record(z.string(), z.string()),
+  }),
+  z.object({
+    action: z.literal("scale"),
+    desiredCount: z.number().int().positive(),
+  }),
+]);

--- a/packages/cloud/sdk/src/apps.client.test.ts
+++ b/packages/cloud/sdk/src/apps.client.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "vitest";
+import { ElizaCloudClient } from "./client.js";
+
+type RecordedRequest = {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body?: unknown;
+};
+
+function createClientRecorder(
+  responseBody: Record<string, unknown> = { success: true },
+) {
+  const requests: RecordedRequest[] = [];
+  const fetchImpl = (async (input, init = {}) => {
+    const headers = new Headers(init.headers);
+    requests.push({
+      url: String(input),
+      method: init.method ?? "GET",
+      headers: Object.fromEntries(headers.entries()),
+      body:
+        typeof init.body === "string" && init.body.length > 0
+          ? JSON.parse(init.body)
+          : undefined,
+    });
+
+    return new Response(JSON.stringify(responseBody), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+
+  return {
+    requests,
+    client: new ElizaCloudClient({
+      baseUrl: "https://cloud.test",
+      apiKey: "eliza_test_key",
+      fetchImpl,
+    }),
+  };
+}
+
+describe("ElizaCloudClient typed app methods", () => {
+  it("listApps GETs /api/v1/apps and returns a typed ListAppsResponse", async () => {
+    const { client, requests } = createClientRecorder({
+      success: true,
+      apps: [],
+    });
+    const res = await client.listApps();
+    // Compile-time proof the result is typed, not `unknown`: `res.apps` is
+    // AppDto[] (Array.isArray would not type-check on `unknown`).
+    expect(Array.isArray(res.apps)).toBe(true);
+    expect(requests[0]).toMatchObject({
+      url: "https://cloud.test/api/v1/apps",
+      method: "GET",
+    });
+  });
+
+  it("getApp GETs /api/v1/apps/:id with the id encoded into the path", async () => {
+    const { client, requests } = createClientRecorder({
+      success: true,
+      app: { id: "app_1" },
+    });
+    const res = await client.getApp("app_1");
+    expect(res.app.id).toBe("app_1");
+    expect(requests[0]).toMatchObject({
+      url: "https://cloud.test/api/v1/apps/app_1",
+      method: "GET",
+    });
+  });
+
+  it("createApp POSTs /api/v1/apps with the snake_case create body", async () => {
+    const { client, requests } = createClientRecorder({
+      success: true,
+      app: { id: "app_1" },
+      apiKey: "eliza_app_secret",
+    });
+    const res = await client.createApp({
+      name: "My App",
+      app_url: "https://my.app",
+      monetization_enabled: true,
+      inference_markup_percentage: 20,
+    });
+    expect(res.apiKey).toBe("eliza_app_secret");
+    expect(requests[0]).toMatchObject({
+      url: "https://cloud.test/api/v1/apps",
+      method: "POST",
+      body: {
+        name: "My App",
+        app_url: "https://my.app",
+        monetization_enabled: true,
+        inference_markup_percentage: 20,
+      },
+    });
+  });
+
+  it("updateApp PATCHes /api/v1/apps/:id with the patch body", async () => {
+    const { client, requests } = createClientRecorder({
+      success: true,
+      app: { id: "app_1" },
+    });
+    await client.updateApp("app_1", { name: "Renamed", is_active: false });
+    expect(requests[0]).toMatchObject({
+      url: "https://cloud.test/api/v1/apps/app_1",
+      method: "PATCH",
+      body: { name: "Renamed", is_active: false },
+    });
+  });
+
+  it("updateMonetization PUTs /api/v1/apps/:id/monetization with camelCase settings", async () => {
+    const { client, requests } = createClientRecorder({
+      success: true,
+      monetization: {
+        monetizationEnabled: true,
+        inferenceMarkupPercentage: 20,
+        purchaseSharePercentage: 10,
+        platformOffsetAmount: 0,
+        totalCreatorEarnings: 0,
+      },
+    });
+    const res = await client.updateMonetization("app_1", {
+      monetizationEnabled: true,
+      inferenceMarkupPercentage: 20,
+      purchaseSharePercentage: 10,
+    });
+    expect(res.monetization?.monetizationEnabled).toBe(true);
+    expect(requests[0]).toMatchObject({
+      url: "https://cloud.test/api/v1/apps/app_1/monetization",
+      method: "PUT",
+      body: {
+        monetizationEnabled: true,
+        inferenceMarkupPercentage: 20,
+        purchaseSharePercentage: 10,
+      },
+    });
+  });
+
+  it("deployApp POSTs /api/v1/apps/:id/deploy (empty body by default)", async () => {
+    const { client, requests } = createClientRecorder({
+      success: true,
+      deploymentId: "dep_1",
+      status: "building",
+      startedAt: "2026-06-29T00:00:00.000Z",
+    });
+    const res = await client.deployApp("app_1");
+    expect(res.deploymentId).toBe("dep_1");
+    expect(requests[0]).toMatchObject({
+      url: "https://cloud.test/api/v1/apps/app_1/deploy",
+      method: "POST",
+      body: {},
+    });
+  });
+
+  it("getAppDeployStatus GETs /api/v1/apps/:id/deploy/status", async () => {
+    const { client, requests } = createClientRecorder({
+      success: true,
+      deploymentId: "dep_1",
+      status: "DEPLOYED",
+      vercelUrl: null,
+      error: null,
+      startedAt: null,
+    });
+    const res = await client.getAppDeployStatus("app_1");
+    expect(res.status).toBe("DEPLOYED");
+    expect(requests[0]).toMatchObject({
+      url: "https://cloud.test/api/v1/apps/app_1/deploy/status",
+      method: "GET",
+    });
+  });
+
+  it("deleteApp DELETEs /api/v1/apps/:id", async () => {
+    const { client, requests } = createClientRecorder({
+      success: true,
+      message: "deleted",
+    });
+    const res = await client.deleteApp("app_1");
+    expect(res.message).toBe("deleted");
+    expect(requests[0]).toMatchObject({
+      url: "https://cloud.test/api/v1/apps/app_1",
+      method: "DELETE",
+    });
+  });
+
+  it("buyAppDomain (deferred stub) POSTs /api/v1/apps/:id/domains/buy with { domain }", async () => {
+    const { client, requests } = createClientRecorder({
+      success: true,
+      domain: "example.com",
+    });
+    const res = await client.buyAppDomain("app_1", { domain: "example.com" });
+    expect(res.success).toBe(true);
+    expect(requests[0]).toMatchObject({
+      url: "https://cloud.test/api/v1/apps/app_1/domains/buy",
+      method: "POST",
+      body: { domain: "example.com" },
+    });
+  });
+});

--- a/packages/cloud/sdk/src/client.test.ts
+++ b/packages/cloud/sdk/src/client.test.ts
@@ -246,6 +246,74 @@ describe("ElizaCloudClient.getContainerLogs", () => {
   });
 });
 
+describe("ElizaCloudClient.createContainer wire contract", () => {
+  it("serializes a camelCase body so projectName and environmentVars.ELIZA_APP_ID survive (per-app monetization)", async () => {
+    const { client, requests } = createClientRecorder({
+      success: true,
+      data: { id: "c_1" },
+    });
+
+    // Typed against CreateContainerRequest: this object only compiles if the
+    // SDK type is camelCase. A revert to snake_case fails the build here.
+    await client.createContainer({
+      name: "My App",
+      image: "ghcr.io/elizaos/my-app:latest",
+      projectName: "my-app",
+      port: 3000,
+      cpu: 1792,
+      memoryMb: 1792,
+      environmentVars: { ELIZA_APP_ID: "app_abc123", FOO: "bar" },
+      healthCheckPath: "/health",
+    });
+
+    expect(requests[0]).toMatchObject({
+      url: "https://cloud.test/api/v1/containers",
+      method: "POST",
+    });
+
+    const body = requests[0]?.body as Record<string, unknown>;
+    // The exact keys the server's CreateContainerSchema accepts — all camelCase.
+    expect(body).toMatchObject({
+      name: "My App",
+      image: "ghcr.io/elizaos/my-app:latest",
+      projectName: "my-app",
+      port: 3000,
+      cpu: 1792,
+      memoryMb: 1792,
+      healthCheckPath: "/health",
+    });
+    // ELIZA_APP_ID rides through environmentVars — the field the casing bug dropped.
+    expect((body.environmentVars as Record<string, string>).ELIZA_APP_ID).toBe(
+      "app_abc123",
+    );
+
+    // Regression guard: none of the legacy snake_case keys may reach the wire.
+    // Those are exactly what the server zod silently stripped, taking
+    // ELIZA_APP_ID and the sticky projectName with them.
+    for (const dropped of [
+      "project_name",
+      "environment_vars",
+      "health_check_path",
+      "memory",
+      "desired_count",
+    ]) {
+      expect(body).not.toHaveProperty(dropped);
+    }
+  });
+
+  it("sends the action-discriminated PATCH body verbatim for updateContainer", async () => {
+    const { client, requests } = createClientRecorder({ success: true });
+
+    await client.updateContainer("c_1", { action: "scale", desiredCount: 1 });
+
+    expect(requests[0]).toMatchObject({
+      url: "https://cloud.test/api/v1/containers/c_1",
+      method: "PATCH",
+      body: { action: "scale", desiredCount: 1 },
+    });
+  });
+});
+
 describe("ElizaCloudClient path parameter encoding", () => {
   it("percent-encodes path parameters that contain slashes, query markers, and fragments", async () => {
     const { client, requests } = createClientRecorder();

--- a/packages/cloud/sdk/src/client.ts
+++ b/packages/cloud/sdk/src/client.ts
@@ -9,9 +9,14 @@ import {
   type ApiKeyCreateResponse,
   type ApiKeyListResponse,
   type AppCreditsBalanceResponse,
+  type AppDeployStatusResponse,
   type AppEarningsHistoryResponse,
   type AppEarningsResponse,
+  type AppMonetizationResponse,
+  type AppResponse,
   type AuthPairResponse,
+  type BuyAppDomainInput,
+  type BuyAppDomainResponse,
   type ChatCompletionRequest,
   type ChatCompletionResponse,
   type CliLoginPollResponse,
@@ -31,6 +36,8 @@ import {
   type CreateAppChargeResponse,
   type CreateAppCreditsCheckoutRequest,
   type CreateAppCreditsCheckoutResponse,
+  type CreateAppInput,
+  type CreateAppResponse,
   type CreateContainerRequest,
   type CreateContainerResponse,
   type CreateCreditsCheckoutRequest,
@@ -44,6 +51,9 @@ import {
   DEFAULT_ELIZA_CLOUD_API_BASE_URL,
   DEFAULT_ELIZA_CLOUD_API_ORIGIN,
   DEFAULT_ELIZA_CLOUD_BASE_URL,
+  type DeleteAppResponse,
+  type DeployAppInput,
+  type DeployAppResponse,
   type ElizaCloudClientOptions,
   type EmbeddingsRequest,
   type EmbeddingsResponse,
@@ -59,6 +69,7 @@ import {
   type LinkAffiliateRequest,
   type LinkAffiliateResponse,
   type ListAppChargesResponse,
+  type ListAppsResponse,
   type ListRedemptionsResponse,
   type ListX402PaymentRequestsResponse,
   type ModelListResponse,
@@ -74,6 +85,8 @@ import {
   type SettleX402PaymentRequestResponse,
   type SnapshotListResponse,
   type SnapshotType,
+  type UpdateAppInput,
+  type UpdateAppMonetizationInput,
   type UpdateContainerRequest,
   type UpsertAffiliateCodeRequest,
   type UserProfileResponse,
@@ -711,6 +724,95 @@ export class ElizaCloudClient {
   ): Promise<ListRedemptionsResponse> {
     return this.request<ListRedemptionsResponse>("GET", "/api/v1/redemptions", {
       query: options.limit === undefined ? undefined : { limit: options.limit },
+    });
+  }
+
+  // ─── Apps (Eliza Cloud Apps product) ──────────────────────────────────────
+  // Typed wrappers over the generated `routes.*` app endpoints. These are the
+  // foundation the agent plugin builds on: every method returns a concrete DTO
+  // (no `unknown` in the public signature) and targets the same route + verb the
+  // server exposes.
+
+  /** `GET /api/v1/apps` — list apps for the authenticated org. */
+  listApps(): Promise<ListAppsResponse> {
+    return this.routes.getApiV1Apps<ListAppsResponse>();
+  }
+
+  /** `GET /api/v1/apps/:id` — fetch a single app. */
+  getApp(appId: string): Promise<AppResponse> {
+    return this.routes.getApiV1AppsById<AppResponse>({
+      pathParams: { id: appId },
+    });
+  }
+
+  /** `POST /api/v1/apps` — create an app (provisions its API key + optional repo). */
+  createApp(input: CreateAppInput): Promise<CreateAppResponse> {
+    return this.routes.postApiV1Apps<CreateAppResponse>({ json: input });
+  }
+
+  /** `PATCH /api/v1/apps/:id` — partially update an app. */
+  updateApp(appId: string, patch: UpdateAppInput): Promise<AppResponse> {
+    return this.routes.patchApiV1AppsById<AppResponse>({
+      pathParams: { id: appId },
+      json: patch,
+    });
+  }
+
+  /** `PUT /api/v1/apps/:id/monetization` — update an app's monetization settings. */
+  updateMonetization(
+    appId: string,
+    settings: UpdateAppMonetizationInput,
+  ): Promise<AppMonetizationResponse> {
+    return this.routes.putApiV1AppsByIdMonetization<AppMonetizationResponse>({
+      pathParams: { id: appId },
+      json: settings,
+    });
+  }
+
+  /**
+   * `POST /api/v1/apps/:id/deploy` — kick off a container deploy (202 Accepted).
+   * Body is optional: defaults pull from the app's linked repo + stored env.
+   */
+  deployApp(
+    appId: string,
+    input: DeployAppInput = {},
+  ): Promise<DeployAppResponse> {
+    return this.routes.postApiV1AppsByIdDeploy<DeployAppResponse>({
+      pathParams: { id: appId },
+      json: input,
+    });
+  }
+
+  /** `GET /api/v1/apps/:id/deploy/status` — latest deploy status (poll target). */
+  getAppDeployStatus(appId: string): Promise<AppDeployStatusResponse> {
+    return this.routes.getApiV1AppsByIdDeployStatus<AppDeployStatusResponse>({
+      pathParams: { id: appId },
+    });
+  }
+
+  /** `DELETE /api/v1/apps/:id` — delete an app and clean up its resources. */
+  deleteApp(appId: string): Promise<DeleteAppResponse> {
+    return this.routes.deleteApiV1AppsById<DeleteAppResponse>({
+      pathParams: { id: appId },
+    });
+  }
+
+  /**
+   * `POST /api/v1/apps/:id/domains/buy` — buy + attach a custom domain.
+   *
+   * DEFERRED: domain purchase is the last slice of the apps launch. The method
+   * is typed and wired so the agent plugin can compile against it, but the
+   * server response envelope is not yet finalized ({@link BuyAppDomainResponse}
+   * captures only the stable fields) — treat as experimental until the domain
+   * branch lands.
+   */
+  buyAppDomain(
+    appId: string,
+    input: BuyAppDomainInput,
+  ): Promise<BuyAppDomainResponse> {
+    return this.routes.postApiV1AppsByIdDomainsBuy<BuyAppDomainResponse>({
+      pathParams: { id: appId },
+      json: input,
     });
   }
 

--- a/packages/cloud/sdk/src/live.e2e.test.ts
+++ b/packages/cloud/sdk/src/live.e2e.test.ts
@@ -315,7 +315,7 @@ containerDescribe("ElizaCloudClient real API e2e: container lifecycle", () => {
 
     const created = await client.createContainer({
       name: `sdk-e2e-${Date.now()}`,
-      project_name: "sdk-e2e",
+      projectName: "sdk-e2e",
       image: imageUri,
     });
     const containerId = created.data.id;
@@ -327,7 +327,10 @@ containerDescribe("ElizaCloudClient real API e2e: container lifecycle", () => {
         true,
       );
       await expect(
-        client.updateContainer(containerId, { desired_count: 1 }),
+        client.updateContainer(containerId, {
+          action: "scale",
+          desiredCount: 1,
+        }),
       ).resolves.toBeTruthy();
       await expect(
         client.getContainerHealth(containerId),

--- a/packages/cloud/sdk/src/types.ts
+++ b/packages/cloud/sdk/src/types.ts
@@ -639,28 +639,47 @@ export interface CloudContainer {
   updated_at: string;
 }
 
+/**
+ * Body for `POST /api/v1/containers`.
+ *
+ * Field names MUST match the server zod schema (`CreateContainerSchema` in
+ * `packages/cloud/api/v1/containers/route.ts`) verbatim — the server is
+ * camelCase. The server validates with `z.object`, which strips unknown keys,
+ * so a snake_case body (`project_name`, `environment_vars`, …) is silently
+ * dropped before the handler ever runs. That previously discarded
+ * `environmentVars.ELIZA_APP_ID` (per-app monetization attribution) and
+ * `projectName` (the sticky deploy key) on every container create, even on the
+ * happy path. Keep this in exact camelCase agreement with the server.
+ */
 export interface CreateContainerRequest {
+  /** Human-readable container name (1–100 chars). */
   name: string;
-  project_name: string;
-  description?: string;
-  port?: number;
-  desired_count?: number;
-  cpu?: number;
-  memory?: number;
-  environment_vars?: Record<string, string>;
-  health_check_path?: string;
-  /** Internal coding-container bootstrap mount. Defaults to /data. */
-  volume_mount_path?: string;
-  /** Internal coding-container source bundle, written into the mounted volume before start. */
-  bootstrap_source?: JsonValue;
   /** Full image reference (e.g. `ghcr.io/owner/repo:tag`). The Hetzner-Docker backend pulls it directly. */
   image: string;
+  /** Stable project key (sticky scheduling/volumes). Defaults to a slug of `name` server-side. */
+  projectName?: string;
+  port?: number;
+  cpu?: number;
+  memoryMb?: number;
+  /**
+   * Caller-supplied environment. Carries `ELIZA_APP_ID` for per-app
+   * monetization attribution; platform-reserved keys are rejected server-side.
+   */
+  environmentVars?: Record<string, string>;
+  healthCheckPath?: string;
 }
 
-export interface UpdateContainerRequest
-  extends Partial<CreateContainerRequest> {
-  status?: ContainerStatus;
-}
+/**
+ * Body for `PATCH /api/v1/containers/:id`. Mirrors the server's
+ * action-discriminated union (`PatchSchema` in
+ * `packages/cloud/api/v1/containers/[id]/route.ts`): restart | setEnv | scale.
+ * The server rejects any body without a recognized `action`, so this is a
+ * discriminated union, not a partial of the create body.
+ */
+export type UpdateContainerRequest =
+  | { action: "restart" }
+  | { action: "setEnv"; environmentVars: Record<string, string> }
+  | { action: "scale"; desiredCount: number };
 
 export interface CreateContainerResponse {
   success: boolean;

--- a/packages/cloud/sdk/src/types.ts
+++ b/packages/cloud/sdk/src/types.ts
@@ -722,6 +722,274 @@ export interface ContainerCredentialsResponse extends Record<string, unknown> {
   success?: boolean;
 }
 
+// ─── Apps (Eliza Cloud Apps product) ────────────────────────────────────────
+// DTOs mirror the server apps routes (`packages/cloud/api/v1/apps/**`) and the
+// `apps` Drizzle table (`packages/cloud/shared/src/db/schemas/apps.ts`). The app
+// payload is snake_case (it serializes the row directly via
+// `appsService.withDatabaseState`); the monetization payload is camelCase
+// (`appCreditsService.getMonetizationSettings`). Match the server exactly.
+
+/** Deployment lifecycle of an app (server enum `app_deployment_status`). */
+export type AppDeploymentStatus =
+  | "draft"
+  | "building"
+  | "deploying"
+  | "deployed"
+  | "failed";
+
+/** Discord social-automation config stored on an app (jsonb column). */
+export interface AppDiscordAutomation {
+  enabled: boolean;
+  guildId?: string;
+  channelId?: string;
+  autoAnnounce: boolean;
+  announceIntervalMin: number;
+  announceIntervalMax: number;
+  vibeStyle?: string;
+  lastAnnouncementAt?: string;
+  totalMessages?: number;
+}
+
+/** Telegram social-automation config stored on an app (jsonb column). */
+export interface AppTelegramAutomation {
+  enabled: boolean;
+  botUsername?: string;
+  channelId?: string;
+  groupId?: string;
+  autoReply: boolean;
+  autoAnnounce: boolean;
+  announceIntervalMin: number;
+  announceIntervalMax: number;
+  welcomeMessage?: string;
+  vibeStyle?: string;
+  lastAnnouncementAt?: string;
+  totalMessages?: number;
+}
+
+/** X/Twitter social-automation config stored on an app (jsonb column). */
+export interface AppTwitterAutomation {
+  enabled: boolean;
+  autoPost: boolean;
+  autoReply: boolean;
+  autoEngage: boolean;
+  discovery: boolean;
+  postIntervalMin: number;
+  postIntervalMax: number;
+  vibeStyle?: string;
+  topics?: string[];
+  lastPostAt?: string;
+  totalPosts?: number;
+  agentCharacterId?: string;
+}
+
+/** A generated promotional asset stored on an app (jsonb column). */
+export interface AppPromotionalAsset {
+  type: "social_card" | "banner";
+  url: string;
+  size: { width: number; height: number };
+  generatedAt: string;
+}
+
+/**
+ * An Eliza Cloud App as returned by the apps routes. Mirrors the `apps` Drizzle
+ * row serialized over the wire: timestamps are ISO strings, `numeric` columns
+ * are decimal strings, and `real` columns are numbers. Field names are
+ * snake_case to match the server payload exactly.
+ */
+export interface AppDto {
+  id: string;
+  name: string;
+  description: string | null;
+  slug: string;
+  organization_id: string;
+  created_by_user_id: string;
+  app_url: string;
+  allowed_origins: string[];
+  api_key_id: string | null;
+  affiliate_code: string | null;
+  /** `numeric` decimal string. */
+  referral_bonus_credits: string | null;
+  total_requests: number;
+  total_users: number;
+  /** `numeric` decimal string. */
+  total_credits_used: string | null;
+  logo_url: string | null;
+  website_url: string | null;
+  contact_email: string | null;
+  metadata: Record<string, unknown>;
+  deployment_status: AppDeploymentStatus;
+  production_url: string | null;
+  last_deployed_at: string | null;
+  github_repo: string | null;
+  linked_character_ids: string[] | null;
+  monetization_enabled: boolean;
+  inference_markup_percentage: number | null;
+  purchase_share_percentage: number | null;
+  platform_offset_amount: number | null;
+  custom_pricing_enabled: boolean | null;
+  /** `numeric` decimal string. */
+  total_creator_earnings: string | null;
+  /** `numeric` decimal string. */
+  total_platform_revenue: string | null;
+  discord_automation: AppDiscordAutomation | null;
+  telegram_automation: AppTelegramAutomation | null;
+  twitter_automation: AppTwitterAutomation | null;
+  promotional_assets: AppPromotionalAsset[] | null;
+  email_notifications: boolean | null;
+  response_notifications: boolean | null;
+  is_active: boolean;
+  is_approved: boolean;
+  created_at: string;
+  updated_at: string;
+  last_used_at: string | null;
+}
+
+/** `GET /api/v1/apps` */
+export interface ListAppsResponse {
+  success: boolean;
+  apps: AppDto[];
+}
+
+/** Single-app envelope: `GET /api/v1/apps/:id`, `PUT|PATCH /api/v1/apps/:id`. */
+export interface AppResponse {
+  success: boolean;
+  app: AppDto;
+}
+
+/** `POST /api/v1/apps` request body (snake_case — matches `CreateAppSchema`). */
+export interface CreateAppInput {
+  name: string;
+  description?: string;
+  app_url: string;
+  website_url?: string;
+  contact_email?: string;
+  allowed_origins?: string[];
+  logo_url?: string;
+  /** Skip provisioning a GitHub repo for the app. */
+  skipGitHubRepo?: boolean;
+  /** Apply monetization at creation, saving a follow-up call. */
+  monetization_enabled?: boolean;
+  /** Inference markup percentage, 0–1000. */
+  inference_markup_percentage?: number;
+}
+
+/** `POST /api/v1/apps` response. */
+export interface CreateAppResponse {
+  success: boolean;
+  app: AppDto;
+  /** Plaintext app API key — returned once, at creation. */
+  apiKey: string;
+  githubRepo?: string;
+  warnings?: string[];
+}
+
+/** `PATCH /api/v1/apps/:id` request body (snake_case — matches `UpdateAppSchema`). */
+export interface UpdateAppInput {
+  name?: string;
+  description?: string;
+  app_url?: string;
+  website_url?: string;
+  contact_email?: string;
+  allowed_origins?: string[];
+  logo_url?: string;
+  is_active?: boolean;
+  /** Up to 4 linked character UUIDs. */
+  linked_character_ids?: string[];
+}
+
+/**
+ * App monetization settings, returned by `GET /api/v1/apps/:id/monetization`
+ * and `PUT .../monetization` (server `appCreditsService.getMonetizationSettings`).
+ */
+export interface AppMonetizationSettings {
+  monetizationEnabled: boolean;
+  inferenceMarkupPercentage: number;
+  purchaseSharePercentage: number;
+  platformOffsetAmount: number;
+  totalCreatorEarnings: number;
+}
+
+/**
+ * `PUT /api/v1/apps/:id/monetization` request body (camelCase — matches
+ * `UpdateMonetizationSchema`).
+ */
+export interface UpdateAppMonetizationInput {
+  monetizationEnabled?: boolean;
+  /** Inference markup percentage, 0–1000. */
+  inferenceMarkupPercentage?: number;
+  /** Purchase share percentage, 0–100. */
+  purchaseSharePercentage?: number;
+}
+
+/** `GET|PUT /api/v1/apps/:id/monetization` response. */
+export interface AppMonetizationResponse {
+  success: boolean;
+  monetization: AppMonetizationSettings | null;
+}
+
+/** `POST /api/v1/apps/:id/deploy` request body — all fields optional. */
+export interface DeployAppInput {
+  repoUrl?: string;
+  ref?: string;
+  dockerfile?: string;
+  env?: Record<string, string>;
+}
+
+/**
+ * `POST /api/v1/apps/:id/deploy` response (202 Accepted). `status` is the
+ * server-side deployment status string (the deploy lifecycle is polled via
+ * {@link AppDeployStatusResponse}).
+ */
+export interface DeployAppResponse {
+  success: boolean;
+  deploymentId: string;
+  status: string;
+  startedAt: string;
+}
+
+/** `GET /api/v1/apps/:id/deploy/status` response. */
+export interface AppDeployStatusResponse {
+  success: boolean;
+  deploymentId: string | null;
+  status: string;
+  vercelUrl: string | null;
+  error: string | null;
+  startedAt: string | null;
+}
+
+/** Per-resource counts the cleanup pass reports on app deletion. */
+export interface AppCleanupSummary {
+  domainsRemoved: number;
+  githubRepoDeleted: boolean;
+  secretBindingsRemoved: number;
+  managedDomainsUnlinked: number;
+  containersTornDown: number;
+}
+
+/** `DELETE /api/v1/apps/:id` response. */
+export interface DeleteAppResponse {
+  success: boolean;
+  message: string;
+  cleaned?: AppCleanupSummary;
+  errors?: string[];
+}
+
+/** `POST /api/v1/apps/:id/domains/buy` request body. */
+export interface BuyAppDomainInput {
+  domain: string;
+}
+
+/**
+ * `POST /api/v1/apps/:id/domains/buy` response. DEFERRED: the domain-purchase
+ * flow is the last piece of the apps launch and its response envelope is not yet
+ * finalized server-side, so this captures only the stable fields.
+ */
+export interface BuyAppDomainResponse {
+  success: boolean;
+  domain?: string;
+  error?: string;
+}
+
 export interface CreateAgentRequest {
   agentName: string;
   characterId?: string;

--- a/packages/cloud/shared/package.json
+++ b/packages/cloud/shared/package.json
@@ -48,6 +48,7 @@
     "@electric-sql/pglite-socket": "0.1.6",
     "@elevenlabs/elevenlabs-js": "^2.45.0",
     "@elizaos/core": "workspace:*",
+    "@elizaos/plugin-cloud-apps": "workspace:*",
     "@elizaos/plugin-elizacloud": "workspace:*",
     "@elizaos/plugin-elevenlabs": "workspace:*",
     "@elizaos/plugin-sql": "workspace:*",

--- a/packages/cloud/shared/src/lib/eliza/agent-loader.ts
+++ b/packages/cloud/shared/src/lib/eliza/agent-loader.ts
@@ -6,6 +6,7 @@ import {
   type Provider,
   parseCharacter,
 } from "@elizaos/core";
+import { cloudAppsPlugin } from "@elizaos/plugin-cloud-apps";
 import { memoriesRepository } from "../../db/repositories/agents/memories";
 import { charactersService } from "../services/characters/characters";
 import type { ElizaCharacter } from "../types/eliza-character";
@@ -20,6 +21,22 @@ import {
 import { cloudModelProviderPlugin } from "./cloud-model-provider";
 import { buildElevenLabsSettings, getElizaCloudApiUrl } from "./config";
 import mcpPlugin from "./plugin-mcp";
+
+/**
+ * Feature flag for the Eliza Cloud Apps read-core on the cloud-hosted path.
+ *
+ * `cloudAppsPlugin` runs as a FULL plugin (its LIST_CLOUD_APPS / GET_APP actions
+ * + CLOUD_APPS provider) on EVERY dedicated prod agent when enabled, so it stays
+ * OFF by default until staged + proven. Enable per-agent via the character
+ * setting `CLOUD_APPS_PLUGIN_ENABLED` or process-wide via the
+ * `CLOUD_APPS_PLUGIN_ENABLED` env var (both accept `true`). The
+ * local/native + Discord/Telegram path enables it separately via CORE_PLUGINS.
+ */
+function isCloudAppsPluginEnabled(characterSettings: Record<string, unknown>): boolean {
+  const fromSetting = characterSettings.CLOUD_APPS_PLUGIN_ENABLED;
+  if (fromSetting === true || fromSetting === "true") return true;
+  return process.env.CLOUD_APPS_PLUGIN_ENABLED === "true";
+}
 
 // Plugin cache - preloaded at module init to eliminate dynamic import latency
 let _documentsPlugin: Plugin | null = null;
@@ -218,6 +235,16 @@ export class AgentLoader {
     options?: { hasDocuments?: boolean },
   ): Promise<Plugin[]> {
     const plugins: Plugin[] = [cloudModelProviderPlugin];
+
+    // Eliza Cloud Apps read-core (#10218 apps launch). Added as a FULL plugin
+    // (NOT via AVAILABLE_PLUGINS, which strips to models-only) so its actions +
+    // provider reach cloud-hosted agents. Gated OFF by default — see
+    // isCloudAppsPluginEnabled — because it loads on every dedicated prod agent.
+    if (isCloudAppsPluginEnabled(characterSettings)) {
+      plugins.push(asPlugin(cloudAppsPlugin));
+      logger.info("[AgentLoader] Cloud Apps plugin enabled (read-core)");
+    }
+
     const conditionalPlugins = getConditionalPlugins(characterSettings);
     const modePlugins = isValidAgentMode(agentMode)
       ? AGENT_MODE_PLUGINS[agentMode]

--- a/packages/scenario-runner/test/scenarios/cloud-apps-read-core.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/cloud-apps-read-core.scenario.ts
@@ -1,0 +1,43 @@
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+/**
+ * Live trajectory for the Eliza Cloud Apps read-core (#10218).
+ *
+ * FOLLOW-UP EVIDENCE — lane: "live-only". This needs BOTH a live model (to route
+ * "what apps do I have?" to LIST_CLOUD_APPS) AND a real `ELIZAOS_CLOUD_API_KEY`
+ * (so `client.listApps()` reaches Eliza Cloud). It is intentionally excluded
+ * from the keyless `pr-deterministic` lane: LIST_CLOUD_APPS calls the Cloud API,
+ * which cannot be satisfied by a proxy fixture. Run it manually with a key:
+ *
+ *   ELIZAOS_CLOUD_API_KEY=eliza_... \
+ *   bun packages/scenario-runner/src/cli.ts run packages/scenario-runner/test/scenarios \
+ *     --scenario cloud-apps-read-core --report /tmp/cloud-apps.json
+ *
+ * The bun:test unit suite in plugins/plugin-cloud-apps/__tests__ is the
+ * gating proof; this scenario captures the end-to-end agent trajectory.
+ */
+export default scenario({
+  id: "cloud-apps-read-core",
+  lane: "live-only",
+  title: "Eliza Cloud Apps read-core: what apps do I have?",
+  domain: "cloud-apps",
+  status: "active",
+  requires: {
+    plugins: ["@elizaos/plugin-cloud-apps"],
+  },
+  turns: [
+    {
+      kind: "message",
+      name: "user asks for their cloud apps",
+      text: "what apps do I have?",
+    },
+  ],
+  finalChecks: [
+    {
+      type: "actionCalled",
+      name: "LIST_CLOUD_APPS routed and executed",
+      actionName: "LIST_CLOUD_APPS",
+      minCount: 1,
+    },
+  ],
+});

--- a/plugins/plugin-cloud-apps/.gitignore
+++ b/plugins/plugin-cloud-apps/.gitignore
@@ -1,0 +1,7 @@
+dist
+node_modules
+.env
+.elizadb
+.turbo
+*.tsbuildinfo
+.DS_Store

--- a/plugins/plugin-cloud-apps/__tests__/cloud-apps-provider.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/cloud-apps-provider.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+  FakeElizaCloudClient,
+  keyedRuntime,
+  makeApp,
+  makeMessage,
+  resetSdk,
+  setListApps,
+  unkeyedRuntime,
+} from "./helpers";
+
+mock.module("@elizaos/cloud-sdk", () => ({
+  ElizaCloudClient: FakeElizaCloudClient,
+}));
+
+const { cloudAppsProvider } = await import("../src/providers/cloud-apps.ts");
+
+const STATE = {} as never;
+
+describe("CLOUD_APPS provider", () => {
+  beforeEach(() => {
+    resetSdk();
+  });
+
+  it("injects the app inventory when a key is present", async () => {
+    setListApps(() =>
+      Promise.resolve({
+        success: true,
+        apps: [
+          makeApp({
+            name: "Acme Bot",
+            production_url: "https://acme.elizacloud.ai",
+            deployment_status: "deployed",
+          }),
+          makeApp({ name: "Side Project", deployment_status: "draft" }),
+        ],
+      }),
+    );
+
+    const result = await cloudAppsProvider.get(
+      keyedRuntime(),
+      makeMessage("my apps"),
+      STATE,
+    );
+
+    expect(result.text).toContain("2 Eliza Cloud apps");
+    expect(result.text).toContain("Acme Bot");
+    expect(result.text).toContain("https://acme.elizacloud.ai");
+    expect(result.text).toContain("Side Project");
+    expect(result.values?.cloudAppCount).toBe(2);
+  });
+
+  it("returns EMPTY when no Cloud API key is configured", async () => {
+    let called = false;
+    setListApps(() => {
+      called = true;
+      return Promise.resolve({ success: true, apps: [] });
+    });
+
+    const result = await cloudAppsProvider.get(
+      unkeyedRuntime(),
+      makeMessage("my apps"),
+      STATE,
+    );
+
+    expect(result.text).toBe("");
+    expect(result.values).toBeUndefined();
+    // No key → never even constructs a client / calls the SDK.
+    expect(called).toBe(false);
+  });
+
+  it("renders a 'none yet' inventory when the user has zero apps", async () => {
+    setListApps(() => Promise.resolve({ success: true, apps: [] }));
+    const result = await cloudAppsProvider.get(
+      keyedRuntime(),
+      makeMessage("my apps"),
+      STATE,
+    );
+    expect(result.text).toContain("none yet");
+    expect(result.values?.cloudAppCount).toBe(0);
+  });
+
+  it("respects the 60s cache — a second call within TTL does not re-fetch", async () => {
+    let calls = 0;
+    setListApps(() => {
+      calls += 1;
+      return Promise.resolve({
+        success: true,
+        apps: [makeApp({ name: "Cached App" })],
+      });
+    });
+
+    // Same runtime object across both calls → cache key identity holds.
+    const runtime = keyedRuntime();
+
+    const first = await cloudAppsProvider.get(
+      runtime,
+      makeMessage("apps"),
+      STATE,
+    );
+    const second = await cloudAppsProvider.get(
+      runtime,
+      makeMessage("apps"),
+      STATE,
+    );
+
+    expect(first.text).toContain("Cached App");
+    expect(second.text).toContain("Cached App");
+    expect(calls).toBe(1);
+  });
+
+  it("falls back to a stale cache if a later fetch fails", async () => {
+    let calls = 0;
+    setListApps(() => {
+      calls += 1;
+      return Promise.resolve({
+        success: true,
+        apps: [makeApp({ name: "Warm App" })],
+      });
+    });
+
+    const runtime = keyedRuntime();
+    const first = await cloudAppsProvider.get(
+      runtime,
+      makeMessage("apps"),
+      STATE,
+    );
+    expect(first.text).toContain("Warm App");
+    expect(calls).toBe(1);
+
+    // The first call cached for 60s, so a second call within TTL is served from
+    // cache and never reaches the (now-failing) SDK. Inventory stays intact.
+    setListApps(() => Promise.reject(new Error("down")));
+    const second = await cloudAppsProvider.get(
+      runtime,
+      makeMessage("apps"),
+      STATE,
+    );
+    expect(second.text).toContain("Warm App");
+  });
+
+  it("stays EMPTY when the first fetch fails and there is no cache", async () => {
+    setListApps(() => Promise.reject(new Error("down")));
+    const result = await cloudAppsProvider.get(
+      keyedRuntime(),
+      makeMessage("apps"),
+      STATE,
+    );
+    expect(result.text).toBe("");
+  });
+});

--- a/plugins/plugin-cloud-apps/__tests__/get-app.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/get-app.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+  captureCallback,
+  FakeElizaCloudClient,
+  keyedRuntime,
+  makeApp,
+  makeMessage,
+  resetSdk,
+  setGetApp,
+  setListApps,
+  unkeyedRuntime,
+} from "./helpers";
+
+mock.module("@elizaos/cloud-sdk", () => ({
+  ElizaCloudClient: FakeElizaCloudClient,
+}));
+
+const { getAppAction } = await import("../src/actions/get-app.ts");
+
+describe("GET_APP", () => {
+  beforeEach(() => {
+    resetSdk();
+  });
+
+  it("validates only when a Cloud API key is present", async () => {
+    expect(await getAppAction.validate(keyedRuntime(), makeMessage("x"))).toBe(
+      true,
+    );
+    expect(
+      await getAppAction.validate(unkeyedRuntime(), makeMessage("x")),
+    ).toBe(false);
+  });
+
+  it("resolves an app by name from free-text and formats its detail", async () => {
+    setListApps(() =>
+      Promise.resolve({
+        success: true,
+        apps: [
+          makeApp({
+            id: "id-acme",
+            name: "Acme Bot",
+            slug: "acme-bot",
+            description: "Customer support bot",
+            production_url: "https://acme.elizacloud.ai",
+            deployment_status: "deployed",
+            total_credits_used: "12.4",
+            monetization_enabled: true,
+            total_creator_earnings: "3.5",
+          }),
+          makeApp({ id: "id-other", name: "Other", slug: "other" }),
+        ],
+      }),
+    );
+
+    const cb = captureCallback();
+    const result = await getAppAction.handler(
+      keyedRuntime(),
+      makeMessage("tell me about my Acme Bot app"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+
+    expect(result?.success).toBe(true);
+    const reply = cb.calls[0]?.text ?? "";
+    expect(reply).toContain("Acme Bot");
+    expect(reply).toContain("Customer support bot");
+    expect(reply).toContain("https://acme.elizacloud.ai");
+    expect(reply).toContain("deployed");
+    expect(reply).toContain("$12.40");
+    expect(reply).toContain("$3.50");
+    expect((result?.data as { app: { id: string } }).app.id).toBe("id-acme");
+  });
+
+  it("resolves an app via an explicit planner option", async () => {
+    setListApps(() =>
+      Promise.resolve({
+        success: true,
+        apps: [makeApp({ id: "id-7", name: "Widget", slug: "widget" })],
+      }),
+    );
+    const cb = captureCallback();
+    const result = await getAppAction.handler(
+      keyedRuntime(),
+      makeMessage("show it"),
+      undefined,
+      { appName: "Widget" },
+      cb.fn,
+    );
+    expect(result?.success).toBe(true);
+    expect(cb.calls[0]?.text).toContain("Widget");
+  });
+
+  it("fetches by id directly when the reference is a UUID", async () => {
+    const uuid = "11111111-2222-3333-4444-555555555555";
+    let listCalled = false;
+    setListApps(() => {
+      listCalled = true;
+      return Promise.resolve({ success: true, apps: [] });
+    });
+    setGetApp((id) =>
+      Promise.resolve({
+        success: true,
+        app: makeApp({ id, name: "By Id App", slug: "by-id" }),
+      }),
+    );
+
+    const cb = captureCallback();
+    const result = await getAppAction.handler(
+      keyedRuntime(),
+      makeMessage(uuid),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+
+    expect(result?.success).toBe(true);
+    expect(cb.calls[0]?.text).toContain("By Id App");
+    // The id path must not fall back to listApps.
+    expect(listCalled).toBe(false);
+  });
+
+  it("returns a graceful not-found when nothing matches", async () => {
+    setListApps(() =>
+      Promise.resolve({
+        success: true,
+        apps: [makeApp({ name: "Acme Bot", slug: "acme-bot" })],
+      }),
+    );
+
+    const cb = captureCallback();
+    const result = await getAppAction.handler(
+      keyedRuntime(),
+      makeMessage("tell me about Zephyr"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+
+    expect(result?.success).toBe(false);
+    expect((result?.data as { reason: string }).reason).toBe("not_found");
+    const reply = cb.calls[0]?.text ?? "";
+    expect(reply).toContain("couldn't find an app");
+    expect(reply).toContain("Acme Bot");
+  });
+
+  it("degrades gracefully when no Cloud API key is configured", async () => {
+    const cb = captureCallback();
+    const result = await getAppAction.handler(
+      unkeyedRuntime(),
+      makeMessage("tell me about my app"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+    expect(result?.success).toBe(false);
+    expect((result?.data as { reason: string }).reason).toBe("no_key");
+    expect(cb.calls[0]?.text).toContain("no Cloud API key");
+  });
+
+  it("handles a Cloud API error without throwing", async () => {
+    setListApps(() => Promise.reject(new Error("network")));
+    const cb = captureCallback();
+    const result = await getAppAction.handler(
+      keyedRuntime(),
+      makeMessage("tell me about something"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+    expect(result?.success).toBe(false);
+    expect((result?.data as { reason: string }).reason).toBe("error");
+  });
+});

--- a/plugins/plugin-cloud-apps/__tests__/helpers.ts
+++ b/plugins/plugin-cloud-apps/__tests__/helpers.ts
@@ -1,0 +1,133 @@
+/**
+ * Shared test helpers for plugin-cloud-apps.
+ *
+ * Only the SDK client is mocked: {@link FakeElizaCloudClient} stands in for
+ * `@elizaos/cloud-sdk`'s `ElizaCloudClient`, and its `listApps` / `getApp`
+ * methods delegate to per-test functions installed via {@link setListApps} /
+ * {@link setGetApp}. The actions/provider/formatters under test all run for real.
+ */
+
+import { mock } from "bun:test";
+import type { AppDto, AppResponse, ListAppsResponse } from "@elizaos/cloud-sdk";
+import type { IAgentRuntime, Memory } from "@elizaos/core";
+
+type ListAppsFn = () => Promise<ListAppsResponse>;
+type GetAppFn = (id: string) => Promise<AppResponse>;
+
+const state: { listApps: ListAppsFn; getApp: GetAppFn } = {
+  listApps: () => Promise.resolve({ success: true, apps: [] }),
+  getApp: () =>
+    Promise.resolve({ success: true, app: undefined as unknown as AppDto }),
+};
+
+export function setListApps(fn: ListAppsFn): void {
+  state.listApps = fn;
+}
+
+export function setGetApp(fn: GetAppFn): void {
+  state.getApp = fn;
+}
+
+/** Restore default (empty / no-op) behavior between tests. */
+export function resetSdk(): void {
+  state.listApps = () => Promise.resolve({ success: true, apps: [] });
+  state.getApp = () =>
+    Promise.resolve({ success: true, app: undefined as unknown as AppDto });
+}
+
+/** Stand-in for `ElizaCloudClient` — only the methods the read-core calls. */
+export class FakeElizaCloudClient {
+  listApps(): Promise<ListAppsResponse> {
+    return state.listApps();
+  }
+  getApp(id: string): Promise<AppResponse> {
+    return state.getApp(id);
+  }
+}
+
+/** Build a minimal runtime exposing just `getSetting`. */
+export function makeRuntime(
+  settings: Record<string, string | undefined> = {},
+): IAgentRuntime {
+  return {
+    getSetting: (key: string) => settings[key] as unknown,
+  } as unknown as IAgentRuntime;
+}
+
+/** A runtime with a valid Cloud API key configured. */
+export function keyedRuntime(): IAgentRuntime {
+  return makeRuntime({ ELIZAOS_CLOUD_API_KEY: "eliza_test_key" });
+}
+
+/** A runtime with no Cloud API key. */
+export function unkeyedRuntime(): IAgentRuntime {
+  return makeRuntime({});
+}
+
+/** Build a message Memory with the given text. */
+export function makeMessage(text: string): Memory {
+  return {
+    content: { text },
+  } as unknown as Memory;
+}
+
+/** A callback that records the content it was called with. */
+export function captureCallback(): {
+  fn: (content: { text?: string; actions?: string[] }) => Promise<Memory[]>;
+  calls: Array<{ text?: string; actions?: string[] }>;
+} {
+  const calls: Array<{ text?: string; actions?: string[] }> = [];
+  const fn = mock((content: { text?: string; actions?: string[] }) => {
+    calls.push(content);
+    return Promise.resolve([] as Memory[]);
+  });
+  return { fn, calls };
+}
+
+/** Minimal AppDto factory — fills only the fields the read-core reads. */
+export function makeApp(overrides: Partial<AppDto> = {}): AppDto {
+  return {
+    id: "00000000-0000-0000-0000-000000000001",
+    name: "Test App",
+    description: null,
+    slug: "test-app",
+    organization_id: "org-1",
+    created_by_user_id: "user-1",
+    app_url: "https://test-app.example.com",
+    allowed_origins: [],
+    api_key_id: null,
+    affiliate_code: null,
+    referral_bonus_credits: null,
+    total_requests: 0,
+    total_users: 0,
+    total_credits_used: null,
+    logo_url: null,
+    website_url: null,
+    contact_email: null,
+    metadata: {},
+    deployment_status: "draft",
+    production_url: null,
+    last_deployed_at: null,
+    github_repo: null,
+    linked_character_ids: null,
+    monetization_enabled: false,
+    inference_markup_percentage: null,
+    purchase_share_percentage: null,
+    platform_offset_amount: null,
+    custom_pricing_enabled: null,
+    total_creator_earnings: null,
+    total_platform_revenue: null,
+    discord_automation: null,
+    telegram_automation: null,
+    twitter_automation: null,
+    promotional_assets: null,
+    email_notifications: null,
+    response_notifications: null,
+    is_active: true,
+    is_approved: true,
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+    last_used_at: null,
+    ...overrides,
+  };
+}

--- a/plugins/plugin-cloud-apps/__tests__/list-cloud-apps.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/list-cloud-apps.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+  captureCallback,
+  FakeElizaCloudClient,
+  keyedRuntime,
+  makeApp,
+  makeMessage,
+  resetSdk,
+  setListApps,
+  unkeyedRuntime,
+} from "./helpers";
+
+// Mock ONLY the SDK client; the action under test runs for real.
+mock.module("@elizaos/cloud-sdk", () => ({
+  ElizaCloudClient: FakeElizaCloudClient,
+}));
+
+const { listCloudAppsAction } = await import(
+  "../src/actions/list-cloud-apps.ts"
+);
+
+describe("LIST_CLOUD_APPS", () => {
+  beforeEach(() => {
+    resetSdk();
+  });
+
+  describe("validate", () => {
+    it("returns true when a Cloud API key is present", async () => {
+      expect(
+        await listCloudAppsAction.validate(keyedRuntime(), makeMessage("x")),
+      ).toBe(true);
+    });
+
+    it("returns false when no Cloud API key is configured", async () => {
+      expect(
+        await listCloudAppsAction.validate(unkeyedRuntime(), makeMessage("x")),
+      ).toBe(false);
+    });
+  });
+
+  describe("handler", () => {
+    it("lists several apps with names and urls", async () => {
+      setListApps(() =>
+        Promise.resolve({
+          success: true,
+          apps: [
+            makeApp({
+              id: "id-1",
+              name: "Acme Bot",
+              slug: "acme-bot",
+              production_url: "https://acme.elizacloud.ai",
+              deployment_status: "deployed",
+            }),
+            makeApp({
+              id: "id-2",
+              name: "Side Project",
+              slug: "side-project",
+              app_url: "https://side.example.com",
+              deployment_status: "draft",
+            }),
+          ],
+        }),
+      );
+
+      const cb = captureCallback();
+      const result = await listCloudAppsAction.handler(
+        keyedRuntime(),
+        makeMessage("what apps do I have?"),
+        undefined,
+        undefined,
+        cb.fn,
+      );
+
+      expect(result?.success).toBe(true);
+      const reply = cb.calls[0]?.text ?? "";
+      expect(reply).toContain("You have 2 apps");
+      expect(reply).toContain("Acme Bot");
+      expect(reply).toContain("https://acme.elizacloud.ai");
+      expect(reply).toContain("Side Project");
+      expect(reply).toContain("https://side.example.com");
+      expect(reply).toContain("deployed");
+      // userFacingText mirrors the reply for the planner terminal fallback.
+      expect(result?.userFacingText).toBe(reply);
+      expect((result?.data as { count: number }).count).toBe(2);
+    });
+
+    it("prefers production_url over app_url when both exist", async () => {
+      setListApps(() =>
+        Promise.resolve({
+          success: true,
+          apps: [
+            makeApp({
+              name: "Dual",
+              app_url: "https://staging.example.com",
+              production_url: "https://prod.example.com",
+            }),
+          ],
+        }),
+      );
+      const cb = captureCallback();
+      await listCloudAppsAction.handler(
+        keyedRuntime(),
+        makeMessage("my apps"),
+        undefined,
+        undefined,
+        cb.fn,
+      );
+      const reply = cb.calls[0]?.text ?? "";
+      expect(reply).toContain("https://prod.example.com");
+      expect(reply).not.toContain("staging.example.com");
+    });
+
+    it("returns a friendly message when the user has no apps", async () => {
+      setListApps(() => Promise.resolve({ success: true, apps: [] }));
+
+      const cb = captureCallback();
+      const result = await listCloudAppsAction.handler(
+        keyedRuntime(),
+        makeMessage("list my cloud apps"),
+        undefined,
+        undefined,
+        cb.fn,
+      );
+
+      expect(result?.success).toBe(true);
+      expect((result?.data as { count: number }).count).toBe(0);
+      expect(cb.calls[0]?.text).toContain("haven't created any apps");
+    });
+
+    it("degrades gracefully when no Cloud API key is configured", async () => {
+      const cb = captureCallback();
+      const result = await listCloudAppsAction.handler(
+        unkeyedRuntime(),
+        makeMessage("what apps do I have?"),
+        undefined,
+        undefined,
+        cb.fn,
+      );
+
+      expect(result?.success).toBe(false);
+      expect((result?.data as { reason: string }).reason).toBe("no_key");
+      expect(cb.calls[0]?.text).toContain("no Cloud API key");
+    });
+
+    it("handles a Cloud API error without throwing", async () => {
+      setListApps(() => Promise.reject(new Error("boom")));
+
+      const cb = captureCallback();
+      const result = await listCloudAppsAction.handler(
+        keyedRuntime(),
+        makeMessage("my apps"),
+        undefined,
+        undefined,
+        cb.fn,
+      );
+
+      expect(result?.success).toBe(false);
+      expect((result?.data as { reason: string }).reason).toBe("error");
+      expect(cb.calls[0]?.text).toContain("couldn't fetch");
+    });
+  });
+});

--- a/plugins/plugin-cloud-apps/build.ts
+++ b/plugins/plugin-cloud-apps/build.ts
@@ -1,0 +1,22 @@
+#!/usr/bin/env bun
+/**
+ * Build script for @elizaos/plugin-cloud-apps (Node). Orchestration lives in the
+ * shared driver (plugins/plugin-build.ts); this lists only what differs.
+ */
+import { buildPlugin } from "../plugin-build";
+
+await buildPlugin({
+  name: "@elizaos/plugin-cloud-apps",
+  externals: ["@elizaos/core", "@elizaos/cloud-sdk"],
+  targets: [
+    {
+      label: "Node",
+      entry: "./src/index.ts",
+      outSubdir: "",
+      target: "node",
+      format: "esm",
+    },
+  ],
+  dtsProject: "tsconfig.json",
+  dtsEmitDeclarationOnly: true,
+});

--- a/plugins/plugin-cloud-apps/package.json
+++ b/plugins/plugin-cloud-apps/package.json
@@ -1,0 +1,96 @@
+{
+  "name": "@elizaos/plugin-cloud-apps",
+  "version": "2.0.3-beta.7",
+  "description": "Read-core agent plugin for Eliza Cloud Apps — answer \"what apps do I have?\" and \"tell me about app X\" across every connector",
+  "type": "module",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "sideEffects": false,
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/elizaos/eliza.git",
+    "directory": "plugins/plugin-cloud-apps"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "eliza-source": {
+        "types": "./src/index.ts",
+        "import": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./*": {
+      "types": "./dist/*.d.ts",
+      "eliza-source": {
+        "types": "./src/*.ts",
+        "import": "./src/*.ts",
+        "default": "./src/*.ts"
+      },
+      "import": "./dist/*.js",
+      "default": "./dist/*.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "elizaos": {
+    "plugin": {
+      "capabilities": [
+        "cloud",
+        "apps"
+      ]
+    }
+  },
+  "keywords": [
+    "elizaos",
+    "plugin",
+    "eliza-cloud",
+    "apps"
+  ],
+  "scripts": {
+    "build": "bun run build.ts",
+    "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist",
+    "test": "bun test __tests__",
+    "typecheck": "tsgo --noEmit",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check ."
+  },
+  "dependencies": {
+    "@elizaos/cloud-sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@elizaos/core": "workspace:*",
+    "@types/bun": "^1.1.0",
+    "typescript": "^6.0.3"
+  },
+  "peerDependencies": {
+    "@elizaos/core": "workspace:*"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "agentConfig": {
+    "pluginType": "elizaos:plugin:1.0.0",
+    "pluginParameters": {
+      "ELIZAOS_CLOUD_API_KEY": {
+        "type": "string",
+        "description": "Eliza Cloud API key (eliza_xxx). Required to list/inspect your Cloud apps.",
+        "required": false,
+        "sensitive": true
+      },
+      "ELIZAOS_CLOUD_BASE_URL": {
+        "type": "string",
+        "description": "Eliza Cloud API base URL (defaults to https://www.elizacloud.ai/api/v1).",
+        "required": false,
+        "sensitive": false
+      }
+    }
+  }
+}

--- a/plugins/plugin-cloud-apps/src/actions/get-app.ts
+++ b/plugins/plugin-cloud-apps/src/actions/get-app.ts
@@ -1,0 +1,178 @@
+/**
+ * GET_APP — "tell me about app X".
+ *
+ * Resolves an app by id or name from the user's text (or planner-supplied
+ * options), then formats a detail block. Id-shaped references take the direct
+ * `client.getApp(id)` path; names resolve via `client.listApps()` +
+ * find-by-name. Read-only: no mutating calls.
+ */
+
+import type {
+  Action,
+  ActionResult,
+  HandlerCallback,
+  IAgentRuntime,
+  Memory,
+  State,
+} from "@elizaos/core";
+import { logger } from "@elizaos/core";
+import {
+  findAppByReference,
+  formatAppDetail,
+  getCloudClient,
+  looksLikeAppId,
+  resolveCloudApiKey,
+} from "../client.js";
+
+const NO_KEY_MESSAGE =
+  "I can't reach Eliza Cloud yet — no Cloud API key is configured. Add your ELIZAOS_CLOUD_API_KEY and I can look up your apps.";
+const NO_REFERENCE_MESSAGE =
+  "Which app would you like to know about? Tell me its name and I'll pull up the details.";
+const ERROR_MESSAGE =
+  "I couldn't fetch that app's details right now — the Cloud API returned an error. Try again in a moment.";
+
+const OPTION_KEYS = ["app", "appName", "name", "id", "appId", "query"] as const;
+
+/** Pull an app reference from planner options or the raw message text. */
+function resolveReference(message: Memory, options?: unknown): string {
+  if (options && typeof options === "object") {
+    const opts = options as Record<string, unknown>;
+    for (const key of OPTION_KEYS) {
+      const value = opts[key];
+      if (typeof value === "string" && value.trim().length > 0) {
+        return value.trim();
+      }
+    }
+  }
+  return (message.content?.text ?? "").trim();
+}
+
+function notFoundMessage(reference: string, available: string[]): string {
+  const base = `I couldn't find an app matching "${reference}".`;
+  if (available.length === 0) {
+    return `${base} You don't have any apps on Eliza Cloud yet.`;
+  }
+  return `${base} Your apps are: ${available.join(", ")}.`;
+}
+
+export const getAppAction: Action = {
+  name: "GET_APP",
+  similes: [
+    "APP_DETAILS",
+    "SHOW_APP",
+    "TELL_ME_ABOUT_APP",
+    "APP_INFO",
+    "DESCRIBE_APP",
+  ],
+  description:
+    "Show details about one specific Eliza Cloud app the user owns (URL, deployment status, credits used, earnings, users). Use when the user asks about a particular app by name or id.",
+  descriptionCompressed: "Show details for one Eliza Cloud app by name/id.",
+  contexts: ["settings", "finance", "apps"],
+  contextGate: { anyOf: ["settings", "finance", "apps"] },
+
+  validate: async (runtime: IAgentRuntime): Promise<boolean> => {
+    return resolveCloudApiKey(runtime) !== null;
+  },
+
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory,
+    _state?: State,
+    options?: unknown,
+    callback?: HandlerCallback,
+  ): Promise<ActionResult> => {
+    const client = getCloudClient(runtime);
+    if (!client) {
+      await callback?.({ text: NO_KEY_MESSAGE, actions: ["GET_APP"] });
+      return {
+        success: false,
+        text: "No Eliza Cloud API key configured.",
+        userFacingText: NO_KEY_MESSAGE,
+        data: { reason: "no_key" },
+      };
+    }
+
+    const reference = resolveReference(message, options);
+    if (!reference) {
+      await callback?.({ text: NO_REFERENCE_MESSAGE, actions: ["GET_APP"] });
+      return {
+        success: false,
+        text: "No app reference supplied.",
+        userFacingText: NO_REFERENCE_MESSAGE,
+        data: { reason: "no_reference" },
+      };
+    }
+
+    try {
+      // Id-shaped reference → direct single-app fetch.
+      if (looksLikeAppId(reference)) {
+        const { app } = await client.getApp(reference);
+        if (app) {
+          const detail = formatAppDetail(app);
+          await callback?.({ text: detail, actions: ["GET_APP"] });
+          return {
+            success: true,
+            text: `Fetched app ${app.name}.`,
+            userFacingText: detail,
+            verifiedUserFacing: true,
+            data: { app: { id: app.id, name: app.name, slug: app.slug } },
+          };
+        }
+      }
+
+      // Name/slug reference → list + find.
+      const { apps } = await client.listApps();
+      const found = findAppByReference(apps ?? [], reference);
+      if (!found) {
+        const names = (apps ?? []).map((a) => a.name);
+        const msg = notFoundMessage(reference, names);
+        await callback?.({ text: msg, actions: ["GET_APP"] });
+        return {
+          success: false,
+          text: `No app matched "${reference}".`,
+          userFacingText: msg,
+          data: { reason: "not_found", reference },
+        };
+      }
+
+      const detail = formatAppDetail(found);
+      await callback?.({ text: detail, actions: ["GET_APP"] });
+      return {
+        success: true,
+        text: `Fetched app ${found.name}.`,
+        userFacingText: detail,
+        verifiedUserFacing: true,
+        data: { app: { id: found.id, name: found.name, slug: found.slug } },
+      };
+    } catch (err) {
+      logger.warn(
+        `[GET_APP] Failed to fetch app "${reference}": ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      await callback?.({ text: ERROR_MESSAGE, actions: ["GET_APP"] });
+      return {
+        success: false,
+        text: "Failed to fetch Eliza Cloud app.",
+        userFacingText: ERROR_MESSAGE,
+        error: err instanceof Error ? err : new Error(String(err)),
+        data: { reason: "error" },
+      };
+    }
+  },
+
+  examples: [
+    [
+      { name: "{{user}}", content: { text: "tell me about my Acme Bot app" } },
+      {
+        name: "{{agent}}",
+        content: {
+          text: "Acme Bot (acme-bot)\nURL: https://acme.elizacloud.ai\nStatus: deployed\nCredits used: $12.40",
+          actions: ["GET_APP"],
+        },
+      },
+    ],
+  ],
+};
+
+export default getAppAction;

--- a/plugins/plugin-cloud-apps/src/actions/list-cloud-apps.ts
+++ b/plugins/plugin-cloud-apps/src/actions/list-cloud-apps.ts
@@ -1,0 +1,146 @@
+/**
+ * LIST_CLOUD_APPS — answer "what apps do I have on Eliza Cloud?".
+ *
+ * Reads the authenticated org's apps via the typed SDK (`client.listApps()`),
+ * formats a clean reply (name / url / status), and handles the empty + no-key +
+ * error paths gracefully. Read-only: no mutating calls.
+ */
+
+import type {
+  Action,
+  ActionResult,
+  HandlerCallback,
+  IAgentRuntime,
+  Memory,
+  State,
+} from "@elizaos/core";
+import { logger } from "@elizaos/core";
+import {
+  formatAppLine,
+  getCloudClient,
+  resolveCloudApiKey,
+} from "../client.js";
+
+const NO_KEY_MESSAGE =
+  "I can't reach Eliza Cloud yet — no Cloud API key is configured. Add your ELIZAOS_CLOUD_API_KEY (from elizacloud.ai → dashboard → API keys) and I can list your apps.";
+const EMPTY_MESSAGE =
+  "You haven't created any apps on Eliza Cloud yet. You can build one from the Apps view or just ask me to create an app.";
+const ERROR_MESSAGE =
+  "I couldn't fetch your Eliza Cloud apps right now — the Cloud API returned an error. Try again in a moment.";
+
+export const listCloudAppsAction: Action = {
+  name: "LIST_CLOUD_APPS",
+  similes: [
+    "MY_APPS",
+    "GET_APPS",
+    "WHAT_APPS_DO_I_HAVE",
+    "MY_CLOUD_APPS",
+    "LIST_APPS",
+  ],
+  description:
+    "List the Eliza Cloud apps the user owns (name, URL, deployment status, and credits/earnings when present). Use when the user asks what apps they have, to see their apps, or to list their Cloud apps.",
+  descriptionCompressed: "List the user's Eliza Cloud apps (name/url/status).",
+  // Read-only inventory lookup; safe on any user turn.
+  contexts: ["settings", "finance", "apps"],
+  contextGate: { anyOf: ["settings", "finance", "apps"] },
+
+  validate: async (runtime: IAgentRuntime): Promise<boolean> => {
+    return resolveCloudApiKey(runtime) !== null;
+  },
+
+  handler: async (
+    runtime: IAgentRuntime,
+    _message: Memory,
+    _state?: State,
+    _options?: unknown,
+    callback?: HandlerCallback,
+  ): Promise<ActionResult> => {
+    const client = getCloudClient(runtime);
+    if (!client) {
+      await callback?.({ text: NO_KEY_MESSAGE, actions: ["LIST_CLOUD_APPS"] });
+      return {
+        success: false,
+        text: "No Eliza Cloud API key configured.",
+        userFacingText: NO_KEY_MESSAGE,
+        data: { reason: "no_key" },
+      };
+    }
+
+    try {
+      const { apps } = await client.listApps();
+
+      if (!apps || apps.length === 0) {
+        await callback?.({ text: EMPTY_MESSAGE, actions: ["LIST_CLOUD_APPS"] });
+        return {
+          success: true,
+          text: "User has no Eliza Cloud apps.",
+          userFacingText: EMPTY_MESSAGE,
+          data: { count: 0, apps: [] },
+        };
+      }
+
+      const header =
+        apps.length === 1
+          ? "You have 1 app on Eliza Cloud:"
+          : `You have ${apps.length} apps on Eliza Cloud:`;
+      const body = apps.map(formatAppLine).join("\n");
+      const reply = `${header}\n${body}`;
+
+      await callback?.({ text: reply, actions: ["LIST_CLOUD_APPS"] });
+      return {
+        success: true,
+        text: `Listed ${apps.length} Eliza Cloud app(s).`,
+        userFacingText: reply,
+        verifiedUserFacing: true,
+        data: {
+          count: apps.length,
+          apps: apps.map((a) => ({
+            id: a.id,
+            name: a.name,
+            slug: a.slug,
+            status: a.deployment_status,
+          })),
+        },
+      };
+    } catch (err) {
+      logger.warn(
+        `[LIST_CLOUD_APPS] Failed to list apps: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      await callback?.({ text: ERROR_MESSAGE, actions: ["LIST_CLOUD_APPS"] });
+      return {
+        success: false,
+        text: "Failed to list Eliza Cloud apps.",
+        userFacingText: ERROR_MESSAGE,
+        error: err instanceof Error ? err : new Error(String(err)),
+        data: { reason: "error" },
+      };
+    }
+  },
+
+  examples: [
+    [
+      { name: "{{user}}", content: { text: "what apps do I have?" } },
+      {
+        name: "{{agent}}",
+        content: {
+          text: "You have 2 apps on Eliza Cloud:\n• Acme Bot — https://acme.elizacloud.ai — deployed\n• Side Project — https://side.example.com — draft",
+          actions: ["LIST_CLOUD_APPS"],
+        },
+      },
+    ],
+    [
+      { name: "{{user}}", content: { text: "list my cloud apps" } },
+      {
+        name: "{{agent}}",
+        content: {
+          text: "You haven't created any apps on Eliza Cloud yet.",
+          actions: ["LIST_CLOUD_APPS"],
+        },
+      },
+    ],
+  ],
+};
+
+export default listCloudAppsAction;

--- a/plugins/plugin-cloud-apps/src/client.ts
+++ b/plugins/plugin-cloud-apps/src/client.ts
@@ -1,0 +1,180 @@
+/**
+ * Eliza Cloud client construction + app resolution/formatting helpers.
+ *
+ * The agent reaches Eliza Cloud with the same credentials plugin-elizacloud
+ * uses: the `ELIZAOS_CLOUD_API_KEY` setting (sent as the bearer/API key) and the
+ * `ELIZAOS_CLOUD_BASE_URL` setting (the API base, e.g.
+ * `https://www.elizacloud.ai/api/v1`). We mirror plugin-elizacloud's
+ * `createElizaCloudClient` construction shape: the configured value is the API
+ * base (it ends at `/api/v1`), so it is passed as `apiBaseUrl`; the site
+ * `baseUrl` is the same origin with the `/api/v1` suffix stripped.
+ */
+
+import type { AppDto } from "@elizaos/cloud-sdk";
+import { ElizaCloudClient } from "@elizaos/cloud-sdk";
+import type { IAgentRuntime } from "@elizaos/core";
+
+/** Default Eliza Cloud API base URL (matches the cloud runtime default). */
+export const DEFAULT_CLOUD_API_BASE_URL = "https://www.elizacloud.ai/api/v1";
+
+/** Settings key holding the Eliza Cloud API key. */
+export const CLOUD_API_KEY_SETTING = "ELIZAOS_CLOUD_API_KEY";
+/** Settings key holding the Eliza Cloud API base URL. */
+export const CLOUD_BASE_URL_SETTING = "ELIZAOS_CLOUD_BASE_URL";
+
+function normalizeSecret(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+/** Strip a trailing `/api/v1` so the SDK gets the bare site origin for `baseUrl`. */
+function apiBaseToSiteBaseUrl(apiBaseUrl: string): string {
+  const trimmed = trimTrailingSlash(apiBaseUrl);
+  return trimmed.endsWith("/api/v1")
+    ? trimmed.slice(0, -"/api/v1".length)
+    : trimmed;
+}
+
+/** Resolve the Eliza Cloud API key from runtime settings. Returns null when unset. */
+export function resolveCloudApiKey(runtime: IAgentRuntime): string | null {
+  return normalizeSecret(runtime.getSetting(CLOUD_API_KEY_SETTING));
+}
+
+/** Resolve the Eliza Cloud API base URL (ends at `/api/v1`). */
+export function resolveCloudApiBaseUrl(runtime: IAgentRuntime): string {
+  return (
+    normalizeSecret(runtime.getSetting(CLOUD_BASE_URL_SETTING)) ??
+    DEFAULT_CLOUD_API_BASE_URL
+  );
+}
+
+/**
+ * Construct an authenticated {@link ElizaCloudClient} from runtime settings.
+ * Returns `null` when no API key is configured so callers can degrade
+ * gracefully (no key → no cloud calls).
+ */
+export function getCloudClient(
+  runtime: IAgentRuntime,
+): ElizaCloudClient | null {
+  const apiKey = resolveCloudApiKey(runtime);
+  if (!apiKey) return null;
+
+  const apiBaseUrl = trimTrailingSlash(resolveCloudApiBaseUrl(runtime));
+  return new ElizaCloudClient({
+    apiBaseUrl,
+    baseUrl: apiBaseToSiteBaseUrl(apiBaseUrl),
+    apiKey,
+  });
+}
+
+// ─── Formatting ─────────────────────────────────────────────────────────────
+
+/** Coerce a `numeric` decimal string (or number/null) into a finite number. */
+function toNumber(value: string | number | null | undefined): number | null {
+  if (value === null || value === undefined) return null;
+  const n = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+/** A live, reachable URL for an app: prefer its production deploy, else its app URL. */
+export function appUrl(app: AppDto): string | null {
+  return normalizeSecret(app.production_url) ?? normalizeSecret(app.app_url);
+}
+
+/** Short human status combining deployment + active flags. */
+export function appStatus(app: AppDto): string {
+  const deployment = app.deployment_status ?? "draft";
+  if (app.is_active === false) return `${deployment} (inactive)`;
+  return deployment;
+}
+
+/** One-line summary for the list view: "Name — url — status". */
+export function formatAppLine(app: AppDto): string {
+  const parts = [app.name];
+  const url = appUrl(app);
+  if (url) parts.push(url);
+  parts.push(appStatus(app));
+  return `• ${parts.join(" — ")}`;
+}
+
+/** Multi-line detail block for a single app (GET_APP / provider). */
+export function formatAppDetail(app: AppDto): string {
+  const lines: string[] = [`${app.name} (${app.slug})`];
+  if (normalizeSecret(app.description)) {
+    lines.push(app.description as string);
+  }
+  const url = appUrl(app);
+  if (url) lines.push(`URL: ${url}`);
+  lines.push(`Status: ${appStatus(app)}`);
+
+  const creditsUsed = toNumber(app.total_credits_used);
+  if (creditsUsed !== null) {
+    lines.push(`Credits used: $${creditsUsed.toFixed(2)}`);
+  }
+  if (app.monetization_enabled) {
+    const earnings = toNumber(app.total_creator_earnings);
+    lines.push(
+      earnings !== null
+        ? `Monetization: on — earnings $${earnings.toFixed(2)}`
+        : "Monetization: on",
+    );
+  }
+  if (typeof app.total_users === "number" && app.total_users > 0) {
+    lines.push(`Users: ${app.total_users}`);
+  }
+  if (typeof app.total_requests === "number" && app.total_requests > 0) {
+    lines.push(`Requests: ${app.total_requests}`);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Resolve an app from a free-text reference (id or name) against a list.
+ *
+ * Match priority:
+ *   1. exact id
+ *   2. exact (case-insensitive) name or slug
+ *   3. bidirectional substring on name/slug — the reference may be a fragment of
+ *      the name ("acme") OR a full sentence containing the name ("tell me about
+ *      my Acme Bot app"). The "reference contains name" direction requires a
+ *      name/slug of >= 3 chars to avoid spurious matches inside a sentence.
+ *
+ * Returns null when nothing matches.
+ */
+export function findAppByReference(
+  apps: AppDto[],
+  reference: string,
+): AppDto | null {
+  const ref = reference.trim();
+  if (!ref) return null;
+  const lower = ref.toLowerCase();
+
+  const byId = apps.find((a) => a.id === ref);
+  if (byId) return byId;
+
+  const byExactName = apps.find(
+    (a) => a.name.toLowerCase() === lower || a.slug.toLowerCase() === lower,
+  );
+  if (byExactName) return byExactName;
+
+  const matchesField = (field: string): boolean => {
+    const f = field.toLowerCase();
+    if (!f) return false;
+    if (f.includes(lower)) return true; // reference is a fragment of the name
+    return f.length >= 3 && lower.includes(f); // sentence contains the name
+  };
+
+  return apps.find((a) => matchesField(a.name) || matchesField(a.slug)) ?? null;
+}
+
+/** RFC-4122-ish UUID shape check (used to take the direct `getApp(id)` path). */
+export function looksLikeAppId(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+    value.trim(),
+  );
+}

--- a/plugins/plugin-cloud-apps/src/index.ts
+++ b/plugins/plugin-cloud-apps/src/index.ts
@@ -1,0 +1,56 @@
+/**
+ * @elizaos/plugin-cloud-apps
+ *
+ * Lets an Eliza agent answer questions about the user's Eliza Cloud Apps —
+ * "what apps do I have?" and "tell me about app X" — from a single plugin
+ * registration that reaches every connector (in-app, Discord, Telegram, and
+ * cloud-hosted) through the shared AgentRuntime pipeline.
+ *
+ * This is the READ-CORE: it ships only non-mutating capabilities.
+ *
+ *   - Action  LIST_CLOUD_APPS — list the user's apps (name / url / status).
+ *   - Action  GET_APP         — details for one app by name or id.
+ *   - Provider CLOUD_APPS     — injects the app inventory into planner context.
+ *
+ * Auth: reads `ELIZAOS_CLOUD_API_KEY` (+ optional `ELIZAOS_CLOUD_BASE_URL`) via
+ * runtime settings — the same credentials plugin-elizacloud uses. With no key
+ * the actions degrade gracefully and the provider stays EMPTY.
+ *
+ * ───────────────────────────────────────────────────────────────────────────
+ * DEFERRED to Phase 3b (mutating / money actions — intentionally NOT here):
+ *   - CREATE_APP
+ *   - UPDATE_APP
+ *   - UPDATE_MONETIZATION
+ *   - DEPLOY_APP
+ *   - GET_APP_DEPLOY_STATUS
+ *   - DELETE_APP
+ *   - GET_APP_EARNINGS
+ *   - WITHDRAW_APP_EARNINGS
+ *   - REGENERATE_APP_API_KEY
+ *   - BUY_APP_DOMAIN
+ * Those require the confirm/CTA pattern and a facts/knowledge cache, and they
+ * move real money — they ship on a later, separately-reviewed branch. The typed
+ * SDK methods (`client.createApp`, `client.deployApp`, …) already exist on the
+ * base branch; only the agent-facing actions are deferred.
+ * ───────────────────────────────────────────────────────────────────────────
+ */
+
+import type { Plugin } from "@elizaos/core";
+import { getAppAction } from "./actions/get-app.js";
+import { listCloudAppsAction } from "./actions/list-cloud-apps.js";
+import { cloudAppsProvider } from "./providers/cloud-apps.js";
+
+export { getAppAction } from "./actions/get-app.js";
+export { listCloudAppsAction } from "./actions/list-cloud-apps.js";
+export * from "./client.js";
+export { cloudAppsProvider } from "./providers/cloud-apps.js";
+
+export const cloudAppsPlugin: Plugin = {
+  name: "cloud-apps",
+  description:
+    "Read-core for Eliza Cloud Apps: list the user's apps and describe a single app, across every connector.",
+  actions: [listCloudAppsAction, getAppAction],
+  providers: [cloudAppsProvider],
+};
+
+export default cloudAppsPlugin;

--- a/plugins/plugin-cloud-apps/src/providers/cloud-apps.ts
+++ b/plugins/plugin-cloud-apps/src/providers/cloud-apps.ts
@@ -1,0 +1,112 @@
+/**
+ * CLOUD_APPS provider — injects the user's Eliza Cloud app inventory into the
+ * planner context so the agent can reason about "my apps" without first calling
+ * an action. Modeled on plugin-elizacloud's `creditBalanceProvider`: 60s
+ * in-memory cache keyed by runtime, context-gated to apps/finance/settings, and
+ * EMPTY when no Cloud API key is configured.
+ */
+
+import type { AppDto } from "@elizaos/cloud-sdk";
+import type {
+  IAgentRuntime,
+  Memory,
+  Provider,
+  ProviderResult,
+  State,
+} from "@elizaos/core";
+import { logger } from "@elizaos/core";
+import {
+  appStatus,
+  appUrl,
+  getCloudClient,
+  resolveCloudApiKey,
+} from "../client.js";
+
+const TTL = 60_000;
+const MAX_APPS_RENDERED = 10;
+const appsCaches = new WeakMap<IAgentRuntime, { apps: AppDto[]; at: number }>();
+
+const EMPTY: ProviderResult = { text: "" };
+
+function render(apps: AppDto[]): ProviderResult {
+  if (apps.length === 0) {
+    return {
+      text: "Eliza Cloud apps: none yet.",
+      values: { cloudAppCount: 0 },
+      data: { apps: [] },
+    };
+  }
+
+  const shown = apps.slice(0, MAX_APPS_RENDERED);
+  const lines = shown.map((a) => {
+    const url = appUrl(a);
+    return `- ${a.name}${url ? ` (${url})` : ""} — ${appStatus(a)}`;
+  });
+  if (apps.length > shown.length) {
+    lines.push(`…and ${apps.length - shown.length} more`);
+  }
+
+  const header =
+    apps.length === 1
+      ? "The user has 1 Eliza Cloud app:"
+      : `The user has ${apps.length} Eliza Cloud apps:`;
+
+  return {
+    text: `${header}\n${lines.join("\n")}`,
+    values: { cloudAppCount: apps.length },
+    data: {
+      apps: shown.map((a) => ({
+        id: a.id,
+        name: a.name,
+        slug: a.slug,
+        status: a.deployment_status,
+      })),
+    },
+  };
+}
+
+export const cloudAppsProvider: Provider = {
+  name: "CLOUD_APPS",
+  description: "The user's Eliza Cloud apps (name, URL, deployment status).",
+  descriptionCompressed: "User's Eliza Cloud apps.",
+  dynamic: true,
+  contexts: ["settings", "finance", "apps"],
+  contextGate: { anyOf: ["settings", "finance", "apps"] },
+  cacheStable: false,
+  cacheScope: "turn",
+  position: 92,
+
+  async get(
+    runtime: IAgentRuntime,
+    _message: Memory,
+    _state: State,
+  ): Promise<ProviderResult> {
+    if (resolveCloudApiKey(runtime) === null) return EMPTY;
+
+    const cached = appsCaches.get(runtime);
+    if (cached && Date.now() - cached.at < TTL) {
+      return render(cached.apps);
+    }
+
+    const client = getCloudClient(runtime);
+    if (!client) return EMPTY;
+
+    try {
+      const { apps } = await client.listApps();
+      const list = apps ?? [];
+      appsCaches.set(runtime, { apps: list, at: Date.now() });
+      return render(list);
+    } catch (err) {
+      logger.warn(
+        `[CloudApps] Failed to fetch apps: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      // Serve a stale cache if we have one; otherwise stay EMPTY (no prompt bloat).
+      if (cached) return render(cached.apps);
+      return EMPTY;
+    }
+  },
+};
+
+export default cloudAppsProvider;

--- a/plugins/plugin-cloud-apps/tsconfig.json
+++ b/plugins/plugin-cloud-apps/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "lib": ["ES2022"],
+    "types": []
+  },
+  "include": ["src/**/*"],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/__tests__/**",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "__tests__/**",
+    "**/__tests__/**",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.e2e.test.ts"
+  ]
+}


### PR DESCRIPTION
## What

New `@elizaos/plugin-cloud-apps` — lets the agent answer **"what apps do I have on Eliza Cloud?"** and "tell me about app X" from chat, on **every connector** (in-app, Discord, Telegram, cloud-hosted) from one registration. Closes the gap where the "What apps do I have?" suggestion chip was a false promise (no action behind it).

This is the **read-core**; the mutating actions (create/deploy/manage/monetize) land in a follow-up PR.

## How

- **`LIST_CLOUD_APPS`** (similes `MY_APPS`/`WHAT_APPS_DO_I_HAVE`/…) → `ElizaCloudClient.listApps()`, formats name/url/status; empty + no-key + error handled.
- **`GET_APP`** → by name or id, formatted detail; graceful not-found.
- **`CLOUD_APPS` provider** → injects the user's app inventory into context, modeled on `creditBalanceProvider`: 60s cache, context-gated to apps/finance/settings topics, EMPTY when no cloud key.
- **Dual registration (both sites — the whole point):**
  - (a) `core-plugins.ts` `CORE_PLUGINS` — reaches local/native + Discord/Telegram via the shared runtime pipeline (default on, read-only).
  - (b) `agent-loader.ts resolvePlugins()` — as a **full** plugin (not via `AVAILABLE_PLUGINS`, which strips to models-only), gated behind **`CLOUD_APPS_PLUGIN_ENABLED`** (**default OFF** — it runs on every dedicated prod agent, so it must be staged + proven with real trajectories first).
- Suggestion chip `"What apps do I have?"` now matched by `LIST_CLOUD_APPS`'s similes.

## Evidence
- `bun run --cwd plugins/plugin-cloud-apps test` → **20 pass / 0 fail / 63 expect()** (mocks only the SDK client; actions/provider/formatters run for real).
- Plugin typecheck + biome clean; `packages/agent` typecheck 0 errors; `packages/cloud/shared` typecheck 0 errors.
- A live-only scenario (`cloud-apps-read-core.scenario.ts`) asserts `LIST_CLOUD_APPS` fires on "what apps do I have?" — runs once a live model + Cloud key are available (follow-up evidence).

## Notes
- **Stacked on #10267** (typed SDK methods). Base will retarget to `develop` once #10267 merges.
- Part of the apps launch (tracker #8434).
