### PR TITLE
fix(cloud): don't refund settled/committed generations on a post-settle error

### DIFF
--- a/packages/cloud/api/v1/generate-music/route.ts
+++ b/packages/cloud/api/v1/generate-music/route.ts
@@ -354,6 +354,10 @@ async function runSunoMusic(
 app.post("/", async (c) => {
   let reservation: Awaited<ReturnType<typeof creditsService.reserve>> | null =
     null;
+  // Once the charge is SETTLED, a later (non-critical, post-settle) failure must
+  // NOT hit the catch's reconcile(0) — which is non-idempotent and would refund
+  // the already-correct charge, giving free music. Mirrors generate-image.
+  let chargeSettled = false;
 
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
@@ -447,6 +451,7 @@ app.post("/", async (c) => {
           : await runSunoMusic(c.env, request);
 
     await reservation.reconcile(cost.totalCost);
+    chargeSettled = true;
 
     const generation = await generationsService.create({
       organization_id: user.organization_id,
@@ -494,7 +499,7 @@ app.post("/", async (c) => {
       cost,
     });
   } catch (error) {
-    if (reservation) {
+    if (reservation && !chargeSettled) {
       await reservation.reconcile(0).catch((reconcileError) => {
         logger.error("[GenerateMusic] Failed to refund reservation", {
           error:

--- a/packages/cloud/api/v1/generate-video/route.ts
+++ b/packages/cloud/api/v1/generate-video/route.ts
@@ -173,6 +173,10 @@ function buildFalInput(request: VideoRequest): Record<string, unknown> {
 app.post("/", async (c) => {
   let reservation: Awaited<ReturnType<typeof creditsService.reserve>> | null =
     null;
+  // Once the charge is SETTLED, a later (non-critical, post-settle) failure must
+  // NOT hit the catch's reconcile(0) — which is non-idempotent and would refund
+  // the already-correct charge, giving a free video. Mirrors generate-image.
+  let chargeSettled = false;
 
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
@@ -282,6 +286,7 @@ app.post("/", async (c) => {
     }
 
     await reservation.reconcile(cost.totalCost);
+    chargeSettled = true;
 
     const generation = await generationsService.create({
       organization_id: user.organization_id,
@@ -332,7 +337,7 @@ app.post("/", async (c) => {
       cost,
     });
   } catch (error) {
-    if (reservation) {
+    if (reservation && !chargeSettled) {
       await reservation.reconcile(0).catch((reconcileError) => {
         logger.error("[GenerateVideo] Failed to refund reservation", {
           error:

--- a/packages/cloud/api/v1/voice/clone/route.ts
+++ b/packages/cloud/api/v1/voice/clone/route.ts
@@ -468,7 +468,13 @@ app.post("/", async (c) => {
       }
     }
 
-    if (reservation) {
+    // Only refund if the voice clone was NOT committed. Once userVoicePersisted
+    // is true the ElevenLabs voice exists and the user_voices row is usable for
+    // TTS, so a later (post-commit) failure — attachSamplesToVoice,
+    // completeCloningJob, or the affiliate lookup inside billFlatUsage — must NOT
+    // refund a delivered clone (the file's own note above). This also prevents a
+    // post-settle double-reconcile (settle happens after the commit).
+    if (reservation && !userVoicePersisted) {
       await reservation.reconcile(0);
       logger.info("[Voice Clone API] Credits refunded", {
         organizationId: user?.organization_id,


### PR DESCRIPTION
Found by the cloud money-paths deep-scan (adversarially verified). Three generation routes share a money leak that `generate-image` already guards against:

After settling the charge (`reservation.reconcile(cost.totalCost)`) and paying the upstream provider, a **non-critical post-settle DB write** (`generationsService.create`, etc.) can throw → the catch runs `reservation.reconcile(0)`, which is **non-idempotent and fully refunds the already-settled charge** → free generation while we ate the provider cost.

- **generate-video / generate-music**: add a `chargeSettled` flag (set after settle), gate the catch's `reconcile(0)` on `!chargeSettled` — mirrors generate-image.
- **voice/clone**: gate the refund on `!userVoicePersisted` (the existing clone-commit flag) — once the ElevenLabs voice + `user_voices` row exist (TTS-usable), a post-commit throw must not refund the delivered clone (the file's own note), and this also blocks a post-settle double-reconcile.

3 files, money path.