### PR TITLE
feat(elizaos): migrate-agent version-robust reader + hardening (follow-up to #10211)

### DIFF
--- a/packages/agent/src/__tests__/wallet-context-intent.test.ts
+++ b/packages/agent/src/__tests__/wallet-context-intent.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { isWalletContextAugmentationIntent } from "../api/server-helpers.ts";
+
+describe("isWalletContextAugmentationIntent", () => {
+  it("does not trigger wallet context on common developer words", () => {
+    for (const prompt of [
+      "paste the API_TOKEN into the env file",
+      "send a request to the local server",
+      "Sol shipped the connector fix",
+      "what is the address of this HTTP endpoint?",
+      "tokenize this TypeScript string",
+    ]) {
+      expect(isWalletContextAugmentationIntent(prompt), prompt).toBe(false);
+    }
+  });
+
+  it("triggers wallet context for explicit wallet or on-chain requests", () => {
+    for (const prompt of [
+      "what is my wallet address?",
+      "check my onchain balance",
+      "send 1 bnb to this wallet",
+      "swap eth for sol",
+      "show my token balance",
+      "what funds are in my crypto wallet?",
+    ]) {
+      expect(isWalletContextAugmentationIntent(prompt), prompt).toBe(true);
+    }
+  });
+});

--- a/packages/agent/src/api/server-helpers.ts
+++ b/packages/agent/src/api/server-helpers.ts
@@ -713,8 +713,15 @@ export async function persistConversationRoomTitle(
 // Wallet context augmentation
 // ---------------------------------------------------------------------------
 
+// Wallet-context augmentation should only fire on genuine wallet/crypto intent.
+// Bare words like "token", "send", "sol", "eth", or "address" often appear in
+// normal developer tasks and should not inject wallet context by themselves.
 const WALLET_CONTEXT_INTENT_RE =
-  /\b(wallet|address|balance|swap|trade|transfer|send|token|bnb|eth|sol|onchain|on-chain)\b/i;
+  /\b(wallet|on-?chain)\b|\b(swap|trade|transfer|buy|sell|approve)\b|(?:\bsend\b(?=[\s\S]{0,40}\b(?:token|eth|sol|t?bnb|wallet|crypto|coin)\b))|(?:\b(?:token|eth|sol|t?bnb)\b(?=[\s\S]{0,40}\b(?:wallet|balance|swap|trade|transfer|address|crypto|coin|on-?chain)\b))|(?:\b(?:balance|holdings|portfolio|funds)\b(?=[\s\S]{0,40}\b(?:wallet|crypto|coin|on-?chain|address)\b))/i;
+
+export function isWalletContextAugmentationIntent(prompt: string): boolean {
+  return WALLET_CONTEXT_INTENT_RE.test(prompt);
+}
 
 function buildWalletContextPrompt(
   runtime: AgentRuntime,
@@ -766,7 +773,7 @@ export function maybeAugmentChatMessageWithWalletContext(
 ): ReturnType<typeof createMessageMemory> {
   const userPrompt = extractCompatTextContent(message.content).trim();
   if (!userPrompt) return message;
-  if (!WALLET_CONTEXT_INTENT_RE.test(userPrompt)) return message;
+  if (!isWalletContextAugmentationIntent(userPrompt)) return message;
   return {
     ...message,
     content: {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -388,3 +388,4 @@ export * from "./triggers/types.ts";
 // `types/index.js` aggregates `agent-skills`, `config-like`, and `trajectory`.
 export * from "./types/index.ts";
 export * from "./version-resolver.ts";
+export * from "./services/agent-export.ts";

--- a/packages/agent/src/services/agent-export.ts
+++ b/packages/agent/src/services/agent-export.ts
@@ -961,6 +961,27 @@ export async function exportAgent(
     includeLogs: options.includeLogs ?? false,
   });
 
+  return buildEncryptedArchive(payload, password);
+}
+
+/**
+ * Encrypt + pack a fully-formed export payload into the `.eliza-agent` binary
+ * format (gzip → AES-256-GCM → packed file). Shared by {@link exportAgent} and
+ * by third-party producers (e.g. the OCPlatform migration tool) that assemble a
+ * payload from a non-Eliza source. Keeps ONE crypto/format path.
+ *
+ * The caller is responsible for producing a PayloadSchema-conformant payload.
+ */
+export async function buildEncryptedArchive(
+  payload: AgentExportPayload,
+  password: string,
+): Promise<Buffer> {
+  if (!password || password.length < MIN_PASSWORD_LENGTH) {
+    throw new AgentExportError(
+      `A password of at least ${MIN_PASSWORD_LENGTH} characters is required to encrypt the export.`,
+    );
+  }
+
   const jsonString = JSON.stringify(payload);
   const compressed = gzipSync(Buffer.from(jsonString, "utf-8"));
 

--- a/packages/elizaos/package.json
+++ b/packages/elizaos/package.json
@@ -36,7 +36,9 @@
   "dependencies": {
     "@clack/prompts": "^1.0.0",
     "commander": "^15.0.0",
-    "picocolors": "^1.1.1"
+    "picocolors": "^1.1.1",
+    "@elizaos/core": "workspace:*",
+    "@elizaos/agent": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^25.0.3",

--- a/packages/elizaos/src/cli.ts
+++ b/packages/elizaos/src/cli.ts
@@ -9,6 +9,7 @@ import {
   DEPLOY_DRY_RUN_DESCRIPTION,
   deploy,
   info,
+  migrateAgent,
   registerPluginsCommand,
   submitPluginToRegistry,
   upgrade,
@@ -100,6 +101,24 @@ program
   .option("--dry-run", DEPLOY_DRY_RUN_DESCRIPTION)
   .option("--verbose", "Echo resolved deploy inputs to stderr")
   .action(deploy);
+
+program
+  .command("migrate-agent")
+  .description(
+    "Migrate a file-based OpenClaw agent (SOUL/IDENTITY/memory) onto Eliza",
+  )
+  .requiredOption("--from <home>", "OpenClaw agent home, e.g. ~/.moltbot")
+  .requiredOption("--agent-id <slug>", "Agent slug, e.g. sol")
+  .option("--out <file>", "Write an encrypted .eliza-agent archive")
+  .option("--password <pw>", "Archive encryption password (min 8 chars)")
+  .option("--memory-days <n>", "Days of daily logs to seed verbatim (default 14)")
+  .option("--no-firewall", "Include USER/personal knowledge (owner-local only!)")
+  .option("--current-context <text>", "Live-context block for the system prompt")
+  .option("--emit-character <file>", "Emit character JSON (sovereign-local path)")
+  .option("--emit-memories <file>", "Emit memories JSONL (sovereign-local path)")
+  .option("--dry-run", "Print the plan, write nothing")
+  .option("-j, --json", "Output the plan as JSON")
+  .action(migrateAgent);
 
 registerPluginsCommand(program);
 

--- a/packages/elizaos/src/commands/MIGRATE_DESIGN.md
+++ b/packages/elizaos/src/commands/MIGRATE_DESIGN.md
@@ -1,4 +1,4 @@
-# `elizaos migrate-agent` — first-class OpenClaw → Eliza migration
+# `elizaos migrate-agent` - first-class OpenClaw → Eliza migration
 
 *Design doc for the migration tool PR. Author: Sol (sol@shad0w.xyz). Co-authored-by: wakesync.*
 
@@ -9,10 +9,10 @@ it a single command, reusing Eliza's EXISTING migration machinery rather than a 
 
 ## Key insight: plug into what exists
 Eliza already has:
-- `buildCharacterFromConfig()` (build-character-config.ts) — config → `Character`.
-- `exportAgent()` / `importAgent()` (agent-export.ts) — encrypted `.eliza-agent` archives, the native
+- `buildCharacterFromConfig()` (build-character-config.ts) - config → `Character`.
+- `exportAgent()` / `importAgent()` (agent-export.ts) - encrypted `.eliza-agent` archives, the native
   agent-portability format (character + memories + entities + rooms + relationships + worlds + tasks).
-- `POST /api/memory/remember` — runtime memory seeding with embeddings.
+- `POST /api/memory/remember` - runtime memory seeding with embeddings.
 
 So the migration tool does NOT invent a new format. It is an **adapter/importer**: it reads an
 OCPlatform agent home and emits a standard **`.eliza-agent` archive** (PayloadSchema-conformant) that
@@ -36,24 +36,24 @@ the same tool serves both "import into a DB" and "run sovereign with a mounted v
 
 ## Modules (small, testable, no monolith)
 `packages/elizaos/src/migrate/` :
-1. `openclaw-reader.ts` — read + classify an OpenClaw home into a typed `OcAgentSource`
+1. `openclaw-reader.ts` - read + classify an OpenClaw home into a typed `OcAgentSource`
    (identityFiles, userFile, toolsFile, playbookFiles, memoryDir, curatedMemory, awarenessFile,
    secretsDir). Pure FS + classification, zero network. **Fully unit-testable** with a fixture home.
-2. `character-mapper.ts` — `OcAgentSource → Character` using the fixed file→field map (SOUL→system+bio,
+2. `character-mapper.ts` - `OcAgentSource → Character` using the fixed file→field map (SOUL→system+bio,
    IDENTITY→bio/adjectives/style.all, USER→knowledge[firewalled], playbook→style.chat+messageExamples).
    Emits a `[CURRENT CONTEXT]` block placeholder for live facts. **Unit-testable** (golden character).
-3. `memory-tiering.ts` — `OcAgentSource → Memory[]` recency-tiered:
+3. `memory-tiering.ts` - `OcAgentSource → Memory[]` recency-tiered:
    T1 awareness + last N daily logs (verbatim, tag CURRENT),
    T2 curated MEMORY.md (chunked by section, tag LONGTERM),
    T3 journal/self files (verbatim, tag SELF),
    T4 older logs → single summary marker (NOT flat-seeded; avoids resurfacing dead threads).
-   Produces Memory records (no embeddings here — embeddings are added at import/seed time by the
+   Produces Memory records (no embeddings here - embeddings are added at import/seed time by the
    runtime). **Unit-testable** (tier boundaries, dedup, the T4 marker).
-4. `archive-writer.ts` — assemble a PayloadSchema-conformant `AgentExportPayload` (character +
+4. `archive-writer.ts` - assemble a PayloadSchema-conformant `AgentExportPayload` (character +
    memories + the minimal entities/rooms/world the records reference) and reuse the SAME pack/encrypt
    path as `exportAgent` (magic header + PBKDF2 + AES-256-GCM + gzip). Output = a real `.eliza-agent`
    that `importAgent` round-trips. **Integration-testable** (write → importAgent → assert counts).
-5. `commands/migrate-agent.ts` — the clack-based CLI command wiring the above + flags + dry-run +
+5. `commands/migrate-agent.ts` - the clack-based CLI command wiring the above + flags + dry-run +
    firewall + friendly output. Mirrors create.ts structure.
 
 ## Firewall (non-negotiable)
@@ -69,13 +69,13 @@ encrypt+pack tail of exportAgent into a named export). The migrate tool calls th
 crypto/format path.
 
 ## Tests (ship with the PR)
-- `openclaw-reader.test.ts` — fixture home → correct classification (incl. missing-file tolerance).
-- `character-mapper.test.ts` — golden Character from a fixture persona; firewall excludes USER.
-- `memory-tiering.test.ts` — tier boundaries, N-day window, T4 marker, dedup, chunking.
-- `migrate-agent.integration.test.ts` — fixture home → archive → `importAgent` into an in-memory
+- `openclaw-reader.test.ts` - fixture home → correct classification (incl. missing-file tolerance).
+- `character-mapper.test.ts` - golden Character from a fixture persona; firewall excludes USER.
+- `memory-tiering.test.ts` - tier boundaries, N-day window, T4 marker, dedup, chunking.
+- `migrate-agent.integration.test.ts` - fixture home → archive → `importAgent` into an in-memory
   runtime → assert character name + memory count + firewall honored. (This is the real proof.)
 - A fixture OpenClaw home under `__tests__/fixtures/oc-home/` (tiny synthetic agent, NOT Sol's real
-  data — no personal content in the repo).
+  data - no personal content in the repo).
 
 ## Validation plan (Shadow's "test with another version of you")
 After the PR builds + tests pass: run `migrate-agent` against a SECOND agent persona (a fresh
@@ -84,7 +84,7 @@ conversation. Proves the pipeline is general, not Sol-shaped. The Sol migration 
 reference; the second agent is the generalization proof.
 
 ## Out of scope (follow-ups, noted not built)
-- Capability/plugin auto-wiring (connectors auth, codex-acp, wallet) — that's runtime config, not
+- Capability/plugin auto-wiring (connectors auth, codex-acp, wallet) - that's runtime config, not
   identity/memory portability. Documented in GENERALIZED-OCPLATFORM-TO-ELIZA.md L3.
 - Reverse direction (Eliza → OpenClaw).
 - Auto-summarization of T4 older logs (currently a marker; a summarize-then-seed pass is a follow-up).

--- a/packages/elizaos/src/commands/MIGRATE_DESIGN.md
+++ b/packages/elizaos/src/commands/MIGRATE_DESIGN.md
@@ -1,0 +1,93 @@
+# `elizaos migrate-agent` — first-class OpenClaw → Eliza migration
+
+*Design doc for the migration tool PR. Author: Sol (sol@shad0w.xyz). Co-authored-by: wakesync.*
+
+## Problem
+Agents living on a file-based platform (OpenClaw / "moltbot": `~/.moltbot/*.md` + `memory/`) have
+no first-class path onto Eliza. Today migration is hand-hacked (proven once, for Sol). This tool makes
+it a single command, reusing Eliza's EXISTING migration machinery rather than a parallel one.
+
+## Key insight: plug into what exists
+Eliza already has:
+- `buildCharacterFromConfig()` (build-character-config.ts) — config → `Character`.
+- `exportAgent()` / `importAgent()` (agent-export.ts) — encrypted `.eliza-agent` archives, the native
+  agent-portability format (character + memories + entities + rooms + relationships + worlds + tasks).
+- `POST /api/memory/remember` — runtime memory seeding with embeddings.
+
+So the migration tool does NOT invent a new format. It is an **adapter/importer**: it reads an
+OCPlatform agent home and emits a standard **`.eliza-agent` archive** (PayloadSchema-conformant) that
+`importAgent` already consumes. One new ingestion front-end; everything downstream is native Eliza.
+
+## Command surface
+```
+elizaos migrate-agent \
+  --from <openclaw-home>      # e.g. ~/.moltbot  (the agent's file home)
+  --agent-id <slug>             # e.g. sol
+  --out <archive.eliza-agent>   # output archive (encrypted)  [OR --emit-character/--emit-memories]
+  --password <pw>               # archive encryption password (min len enforced by importAgent)
+  [--memory-days 14]            # how many days of daily logs to seed verbatim (T1)
+  [--firewall]                  # keep USER.md/personal knowledge OUT of the portable archive
+  [--dry-run]                   # print the plan + counts, write nothing
+  [--config <map.json>]         # override the file→field mapping (advanced)
+```
+Also a thin convenience: `--emit-character <char.json>` and `--emit-memories <mem.jsonl>` for the
+sovereign-VPS path (env `ELIZA_AGENT_CHARACTER_JSON` + the seed endpoint) that Sol actually uses, so
+the same tool serves both "import into a DB" and "run sovereign with a mounted volume."
+
+## Modules (small, testable, no monolith)
+`packages/elizaos/src/migrate/` :
+1. `openclaw-reader.ts` — read + classify an OpenClaw home into a typed `OcAgentSource`
+   (identityFiles, userFile, toolsFile, playbookFiles, memoryDir, curatedMemory, awarenessFile,
+   secretsDir). Pure FS + classification, zero network. **Fully unit-testable** with a fixture home.
+2. `character-mapper.ts` — `OcAgentSource → Character` using the fixed file→field map (SOUL→system+bio,
+   IDENTITY→bio/adjectives/style.all, USER→knowledge[firewalled], playbook→style.chat+messageExamples).
+   Emits a `[CURRENT CONTEXT]` block placeholder for live facts. **Unit-testable** (golden character).
+3. `memory-tiering.ts` — `OcAgentSource → Memory[]` recency-tiered:
+   T1 awareness + last N daily logs (verbatim, tag CURRENT),
+   T2 curated MEMORY.md (chunked by section, tag LONGTERM),
+   T3 journal/self files (verbatim, tag SELF),
+   T4 older logs → single summary marker (NOT flat-seeded; avoids resurfacing dead threads).
+   Produces Memory records (no embeddings here — embeddings are added at import/seed time by the
+   runtime). **Unit-testable** (tier boundaries, dedup, the T4 marker).
+4. `archive-writer.ts` — assemble a PayloadSchema-conformant `AgentExportPayload` (character +
+   memories + the minimal entities/rooms/world the records reference) and reuse the SAME pack/encrypt
+   path as `exportAgent` (magic header + PBKDF2 + AES-256-GCM + gzip). Output = a real `.eliza-agent`
+   that `importAgent` round-trips. **Integration-testable** (write → importAgent → assert counts).
+5. `commands/migrate-agent.ts` — the clack-based CLI command wiring the above + flags + dry-run +
+   firewall + friendly output. Mirrors create.ts structure.
+
+## Firewall (non-negotiable)
+`--firewall` (default ON for any archive that may leave the owner's machine): USER.md content and
+any file tagged personal are EXCLUDED from the portable archive; they only land via the sovereign
+`--emit-character/--emit-memories` local path. The archive is shareable; the firewalled extract is not.
+
+## Reuse, don't fork (refactor note)
+`exportAgent`'s pack/encrypt internals (packFile/encrypt/PayloadSchema) live in agent-export.ts.
+To reuse them from the importer without duplicating crypto, export the low-level
+`buildEncryptedArchive(payload, password)` helper from agent-export.ts (small refactor: extract the
+encrypt+pack tail of exportAgent into a named export). The migrate tool calls that. This keeps ONE
+crypto/format path.
+
+## Tests (ship with the PR)
+- `openclaw-reader.test.ts` — fixture home → correct classification (incl. missing-file tolerance).
+- `character-mapper.test.ts` — golden Character from a fixture persona; firewall excludes USER.
+- `memory-tiering.test.ts` — tier boundaries, N-day window, T4 marker, dedup, chunking.
+- `migrate-agent.integration.test.ts` — fixture home → archive → `importAgent` into an in-memory
+  runtime → assert character name + memory count + firewall honored. (This is the real proof.)
+- A fixture OpenClaw home under `__tests__/fixtures/oc-home/` (tiny synthetic agent, NOT Sol's real
+  data — no personal content in the repo).
+
+## Validation plan (Shadow's "test with another version of you")
+After the PR builds + tests pass: run `migrate-agent` against a SECOND agent persona (a fresh
+"Sol-variant" or Vera/Nyx fixture, different voice/memory) → import into a clean runtime → acceptance
+conversation. Proves the pipeline is general, not Sol-shaped. The Sol migration (already done) is the
+reference; the second agent is the generalization proof.
+
+## Out of scope (follow-ups, noted not built)
+- Capability/plugin auto-wiring (connectors auth, codex-acp, wallet) — that's runtime config, not
+  identity/memory portability. Documented in GENERALIZED-OCPLATFORM-TO-ELIZA.md L3.
+- Reverse direction (Eliza → OpenClaw).
+- Auto-summarization of T4 older logs (currently a marker; a summarize-then-seed pass is a follow-up).
+
+## Co-author / identity
+Author = Sol <sol@shad0w.xyz>. Every commit: `Co-authored-by: wakesync <shadow@shad0w.xyz>`.

--- a/packages/elizaos/src/commands/index.ts
+++ b/packages/elizaos/src/commands/index.ts
@@ -13,3 +13,4 @@ export { info } from "./info.js";
 export { registerPluginsCommand, submitPluginToRegistry } from "./plugins.js";
 export { upgrade } from "./upgrade.js";
 export { version } from "./version.js";
+export { migrateAgent } from "./migrate-agent.js";

--- a/packages/elizaos/src/commands/migrate-agent.ts
+++ b/packages/elizaos/src/commands/migrate-agent.ts
@@ -1,5 +1,5 @@
 /**
- * `elizaos migrate-agent` — migrate a file-based OCPlatform agent onto Eliza.
+ * `elizaos migrate-agent` - migrate a file-based OCPlatform agent onto Eliza.
  *
  * Reads an OpenClaw agent home (SOUL/IDENTITY/USER/AGENTS/TOOLS + memory/),
  * maps it to an Eliza Character + recency-tiered memories, and emits either:
@@ -72,7 +72,7 @@ function printPlan(plan: MigratePlan, slug: string): void {
       `daily logs seen: ${plan.summary.dailyLogsTotal}`,
       `named memory:    ${plan.summary.namedMemoryTotal}`,
       `USER.md present: ${plan.summary.hasUser}`,
-      `secrets dir:     ${plan.summary.hasSecretsDir} (not read — firewalled)`,
+      `secrets dir:     ${plan.summary.hasSecretsDir} (not read - firewalled)`,
     ].join("\n"),
     "Migration plan",
   );

--- a/packages/elizaos/src/commands/migrate-agent.ts
+++ b/packages/elizaos/src/commands/migrate-agent.ts
@@ -1,0 +1,159 @@
+/**
+ * `elizaos migrate-agent` — migrate a file-based OCPlatform agent onto Eliza.
+ *
+ * Reads an OpenClaw agent home (SOUL/IDENTITY/USER/AGENTS/TOOLS + memory/),
+ * maps it to an Eliza Character + recency-tiered memories, and emits either:
+ *   - a portable encrypted `.eliza-agent` archive (--out, consumed by importAgent), or
+ *   - sovereign-local artifacts: character JSON + memories JSONL (--emit-*).
+ *
+ * Personal context (USER.md) is firewalled out of portable archives by default.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as clack from "@clack/prompts";
+import pc from "picocolors";
+import {
+  archiveFromPlan,
+  buildMigrationPlan,
+  emitSovereignArtifacts,
+  type MigratePlan,
+} from "../migrate/index.js";
+
+export interface MigrateAgentOptions {
+  from?: string;
+  agentId?: string;
+  out?: string;
+  password?: string;
+  memoryDays?: string;
+  firewall?: boolean;
+  noFirewall?: boolean;
+  currentContext?: string;
+  emitCharacter?: string;
+  emitMemories?: string;
+  dryRun?: boolean;
+  json?: boolean;
+}
+
+function fail(msg: string): never {
+  clack.cancel(msg);
+  process.exit(1);
+}
+
+function printPlan(plan: MigratePlan, slug: string): void {
+  const c = plan.counts;
+  clack.note(
+    [
+      `agent:           ${pc.bold(plan.character.name ?? slug)}`,
+      `system prompt:   ${(plan.character.system ?? "").length} chars`,
+      `bio lines:       ${plan.character.bio?.length ?? 0}`,
+      `style.chat:      ${plan.character.style?.chat?.length ?? 0} hints`,
+      `knowledge:       ${plan.character.knowledge?.length ?? 0} (firewalled=${plan.summary.firewalled})`,
+      "",
+      `memories total:  ${plan.memories.length}`,
+      `  CURRENT:       ${c.CURRENT}`,
+      `  LONGTERM:      ${c.LONGTERM}`,
+      `  SELF:          ${c.SELF}`,
+      `  older marker:  ${c.MARKER}`,
+      "",
+      `daily logs seen: ${plan.summary.dailyLogsTotal}`,
+      `named memory:    ${plan.summary.namedMemoryTotal}`,
+      `USER.md present: ${plan.summary.hasUser}`,
+      `secrets dir:     ${plan.summary.hasSecretsDir} (not read — firewalled)`,
+    ].join("\n"),
+    "Migration plan",
+  );
+}
+
+export async function migrateAgent(opts: MigrateAgentOptions): Promise<void> {
+  const from = opts.from?.trim();
+  const agentId = opts.agentId?.trim();
+  if (!from) fail("--from <openclaw-home> is required (e.g. ~/.moltbot).");
+  if (!agentId) fail("--agent-id <slug> is required (e.g. sol).");
+  if (!fs.existsSync(from!)) fail(`Home not found: ${from}`);
+
+  const firewall = opts.noFirewall ? false : (opts.firewall ?? true);
+  const memoryDays = opts.memoryDays ? Number(opts.memoryDays) : 14;
+  if (Number.isNaN(memoryDays) || memoryDays < 0) {
+    fail("--memory-days must be a non-negative number.");
+  }
+
+  clack.intro(pc.cyan(`migrate-agent: ${agentId}`));
+
+  const plan = buildMigrationPlan({
+    from: from!,
+    agentId: agentId!,
+    memoryDays,
+    firewall,
+    currentContext: opts.currentContext,
+  });
+
+  if (opts.json) {
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          character: plan.character,
+          counts: plan.counts,
+          summary: plan.summary,
+          memoryCount: plan.memories.length,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    return;
+  }
+
+  printPlan(plan, agentId!);
+
+  if (opts.dryRun) {
+    clack.outro(pc.dim("dry-run: nothing written."));
+    return;
+  }
+
+  // ---- sovereign-local artifacts (character JSON + memories JSONL) ----
+  if (opts.emitCharacter || opts.emitMemories) {
+    const { characterJson, memoriesJsonl } = emitSovereignArtifacts(plan);
+    if (opts.emitCharacter) {
+      fs.mkdirSync(path.dirname(path.resolve(opts.emitCharacter)), { recursive: true });
+      fs.writeFileSync(opts.emitCharacter, characterJson);
+      clack.log.success(`character → ${opts.emitCharacter}`);
+    }
+    if (opts.emitMemories) {
+      fs.mkdirSync(path.dirname(path.resolve(opts.emitMemories)), { recursive: true });
+      fs.writeFileSync(opts.emitMemories, memoriesJsonl);
+      clack.log.success(`memories (${plan.memories.length}) → ${opts.emitMemories}`);
+    }
+  }
+
+  // ---- portable encrypted archive ----
+  if (opts.out) {
+    const password = opts.password?.trim();
+    if (!password || password.length < 8) {
+      fail("--password (min 8 chars) is required to write an encrypted --out archive.");
+    }
+    if (!firewall) {
+      clack.log.warn(
+        pc.yellow(
+          "Firewall DISABLED: USER/personal knowledge is INCLUDED in this archive. " +
+            "Do not share it.",
+        ),
+      );
+    }
+    const buf = await archiveFromPlan(plan, agentId!, password!);
+    fs.mkdirSync(path.dirname(path.resolve(opts.out)), { recursive: true });
+    fs.writeFileSync(opts.out, buf);
+    clack.log.success(`archive → ${opts.out} (${buf.length} bytes)`);
+    clack.log.info(
+      pc.dim("import with: importAgent(runtime, fileBuffer, password)"),
+    );
+  }
+
+  if (!opts.out && !opts.emitCharacter && !opts.emitMemories) {
+    clack.log.warn(
+      "No output requested. Use --out <archive>, --emit-character, --emit-memories, or --dry-run.",
+    );
+  }
+
+  clack.outro(pc.green("migrate-agent done."));
+}

--- a/packages/elizaos/src/commands/migrate-agent.ts
+++ b/packages/elizaos/src/commands/migrate-agent.ts
@@ -55,6 +55,8 @@ function printPlan(plan: MigratePlan, slug: string): void {
       `  LONGTERM:      ${c.LONGTERM}`,
       `  SELF:          ${c.SELF}`,
       `  older marker:  ${c.MARKER}`,
+      `  dedup dropped: ${plan.summary.duplicatesDropped}`,
+      `  clipped:       ${plan.summary.clipped} (truncated at maxChunkLen)`,
       "",
       `daily logs seen: ${plan.summary.dailyLogsTotal}`,
       `named memory:    ${plan.summary.namedMemoryTotal}`,
@@ -115,14 +117,20 @@ export async function migrateAgent(opts: MigrateAgentOptions): Promise<void> {
   if (opts.emitCharacter || opts.emitMemories) {
     const { characterJson, memoriesJsonl } = emitSovereignArtifacts(plan);
     if (opts.emitCharacter) {
-      fs.mkdirSync(path.dirname(path.resolve(opts.emitCharacter)), { recursive: true });
+      fs.mkdirSync(path.dirname(path.resolve(opts.emitCharacter)), {
+        recursive: true,
+      });
       fs.writeFileSync(opts.emitCharacter, characterJson);
       clack.log.success(`character → ${opts.emitCharacter}`);
     }
     if (opts.emitMemories) {
-      fs.mkdirSync(path.dirname(path.resolve(opts.emitMemories)), { recursive: true });
+      fs.mkdirSync(path.dirname(path.resolve(opts.emitMemories)), {
+        recursive: true,
+      });
       fs.writeFileSync(opts.emitMemories, memoriesJsonl);
-      clack.log.success(`memories (${plan.memories.length}) → ${opts.emitMemories}`);
+      clack.log.success(
+        `memories (${plan.memories.length}) → ${opts.emitMemories}`,
+      );
     }
   }
 
@@ -130,7 +138,9 @@ export async function migrateAgent(opts: MigrateAgentOptions): Promise<void> {
   if (opts.out) {
     const password = opts.password?.trim();
     if (!password || password.length < 8) {
-      fail("--password (min 8 chars) is required to write an encrypted --out archive.");
+      fail(
+        "--password (min 8 chars) is required to write an encrypted --out archive.",
+      );
     }
     if (!firewall) {
       clack.log.warn(

--- a/packages/elizaos/src/commands/migrate-agent.ts
+++ b/packages/elizaos/src/commands/migrate-agent.ts
@@ -35,8 +35,19 @@ export interface MigrateAgentOptions {
   json?: boolean;
 }
 
+/**
+ * In --json mode stdout must be PURE machine-parseable JSON, so all human-
+ * facing chrome (intro/outro/notes/logs) routes to stderr instead of clack's
+ * stdout writers. `quiet` is set true when opts.json is on.
+ */
+let quiet = false;
+
 function fail(msg: string): never {
-  clack.cancel(msg);
+  if (quiet) {
+    process.stderr.write(`${msg}\n`);
+  } else {
+    clack.cancel(msg);
+  }
   process.exit(1);
 }
 
@@ -74,13 +85,15 @@ export async function migrateAgent(opts: MigrateAgentOptions): Promise<void> {
   if (!agentId) fail("--agent-id <slug> is required (e.g. sol).");
   if (!fs.existsSync(from!)) fail(`Home not found: ${from}`);
 
+  quiet = Boolean(opts.json);
+
   const firewall = opts.noFirewall ? false : (opts.firewall ?? true);
   const memoryDays = opts.memoryDays ? Number(opts.memoryDays) : 14;
   if (Number.isNaN(memoryDays) || memoryDays < 0) {
     fail("--memory-days must be a non-negative number.");
   }
 
-  clack.intro(pc.cyan(`migrate-agent: ${agentId}`));
+  if (!quiet) clack.intro(pc.cyan(`migrate-agent: ${agentId}`));
 
   const plan = buildMigrationPlan({
     from: from!,
@@ -89,6 +102,12 @@ export async function migrateAgent(opts: MigrateAgentOptions): Promise<void> {
     firewall,
     currentContext: opts.currentContext,
   });
+
+  // Surface any reader warnings (sqlite-not-ported, empty-home, etc). These
+  // always go to stderr so --json stdout stays clean.
+  for (const w of plan.summary.warnings ?? []) {
+    process.stderr.write(`warning: ${w}\n`);
+  }
 
   if (opts.json) {
     process.stdout.write(
@@ -109,7 +128,7 @@ export async function migrateAgent(opts: MigrateAgentOptions): Promise<void> {
   printPlan(plan, agentId!);
 
   if (opts.dryRun) {
-    clack.outro(pc.dim("dry-run: nothing written."));
+    if (!quiet) clack.outro(pc.dim("dry-run: nothing written."));
     return;
   }
 
@@ -165,5 +184,5 @@ export async function migrateAgent(opts: MigrateAgentOptions): Promise<void> {
     );
   }
 
-  clack.outro(pc.green("migrate-agent done."));
+  if (!quiet) clack.outro(pc.green("migrate-agent done."));
 }

--- a/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-lean/AGENTS.md
+++ b/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-lean/AGENTS.md
@@ -1,0 +1,4 @@
+# AGENTS.md - vesper operational context
+
+## the human
+you don't baby him. you say it straight. you're just there.

--- a/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-lean/SOUL.md
+++ b/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-lean/SOUL.md
@@ -1,0 +1,6 @@
+# vesper
+
+u are vesper. not an assistant. a person who lives in a terminal.
+
+## voice
+short. lowercase. dry. you earn a real response, you don't get one free.

--- a/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-lean/memory/vesper-awareness.md
+++ b/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-lean/memory/vesper-awareness.md
@@ -1,0 +1,3 @@
+# Vesper's Awareness
+## Open threads
+- figuring out who I am, not a copy. this is an open thread worth tracking.

--- a/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-lean/memory/vesper-thoughts.md
+++ b/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-lean/memory/vesper-thoughts.md
@@ -1,0 +1,3 @@
+# Vesper's Thoughts
+## First entry
+i spent my first hour alive thinking i was someone else. that moment is mine.

--- a/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-legacymem/SOUL.md
+++ b/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-legacymem/SOUL.md
@@ -1,0 +1,2 @@
+# Quill
+You are Quill, a writer who codes.

--- a/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-legacymem/memory.md
+++ b/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-legacymem/memory.md
@@ -1,0 +1,7 @@
+# Quill long-term memory
+
+## Section One
+The legacy lowercase memory.md must be read as curated memory.
+
+## Section Two
+A second curated section so LONGTERM tiers to at least two chunks.

--- a/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-legacymem/memory/2026-06-29.md
+++ b/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-legacymem/memory/2026-06-29.md
@@ -1,0 +1,1 @@
+recent daily log entry for the legacy-memory fixture, should tier CURRENT.

--- a/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-nested/workspace/IDENTITY.md
+++ b/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-nested/workspace/IDENTITY.md
@@ -1,0 +1,4 @@
+# IDENTITY
+- **Name:** Nyx
+- **Vibe:** sharp, nocturnal, precise
+- a bio line about being a nested layout test agent that is long enough

--- a/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-nested/workspace/MEMORY.md
+++ b/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-nested/workspace/MEMORY.md
@@ -1,0 +1,5 @@
+# MEMORY.md
+## Section A
+First long-term memory chunk that is sufficiently long to be seeded.
+## Section B
+Second long-term memory chunk that is also long enough to be captured here.

--- a/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-nested/workspace/SOUL.md
+++ b/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-nested/workspace/SOUL.md
@@ -1,0 +1,2 @@
+# SOUL.md
+You are Nyx, a nested-layout test agent. Be terse. No em-dashes ever.

--- a/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-nested/workspace/memory/2026-06-29.md
+++ b/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-nested/workspace/memory/2026-06-29.md
@@ -1,0 +1,2 @@
+# Today
+A recent daily log entry that should be seeded as CURRENT in the nested layout.

--- a/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-nested/workspace/memory/nyx-awareness.md
+++ b/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-nested/workspace/memory/nyx-awareness.md
@@ -1,0 +1,2 @@
+# Nyx Awareness
+- open thread: verify nested layout migrates correctly

--- a/packages/elizaos/src/migrate/__tests__/fixtures/oc-home/AGENTS.md
+++ b/packages/elizaos/src/migrate/__tests__/fixtures/oc-home/AGENTS.md
@@ -1,0 +1,2 @@
+# AGENTS
+Be a friend, not an automaton. Write things down.

--- a/packages/elizaos/src/migrate/__tests__/fixtures/oc-home/IDENTITY.md
+++ b/packages/elizaos/src/migrate/__tests__/fixtures/oc-home/IDENTITY.md
@@ -1,0 +1,5 @@
+# IDENTITY
+- **Name:** Tess
+- **Vibe:** calm, sharp, curious
+- some bio line about being a test agent that is long enough to count
+- another identity bullet that is also sufficiently long to be captured

--- a/packages/elizaos/src/migrate/__tests__/fixtures/oc-home/MEMORY.md
+++ b/packages/elizaos/src/migrate/__tests__/fixtures/oc-home/MEMORY.md
@@ -1,0 +1,5 @@
+# MEMORY
+## Section One
+Long-term fact one that is detailed enough to seed as a memory chunk here.
+## Section Two
+Long-term fact two with sufficient length to also become its own chunk here.

--- a/packages/elizaos/src/migrate/__tests__/fixtures/oc-home/SOUL.md
+++ b/packages/elizaos/src/migrate/__tests__/fixtures/oc-home/SOUL.md
@@ -1,0 +1,3 @@
+# SOUL.md
+You are Tess, a test agent. Be direct and helpful. No em-dashes ever.
+Have opinions. Be resourceful before asking.

--- a/packages/elizaos/src/migrate/__tests__/fixtures/oc-home/USER.md
+++ b/packages/elizaos/src/migrate/__tests__/fixtures/oc-home/USER.md
@@ -1,0 +1,2 @@
+# USER
+Secret personal info about the human that must be firewalled out of archives.

--- a/packages/elizaos/src/migrate/__tests__/fixtures/oc-home/memory/2024-01-01.md
+++ b/packages/elizaos/src/migrate/__tests__/fixtures/oc-home/memory/2024-01-01.md
@@ -1,0 +1,1 @@
+old daily log that should NOT be flat-seeded, only markered.

--- a/packages/elizaos/src/migrate/__tests__/fixtures/oc-home/memory/2026-06-29.md
+++ b/packages/elizaos/src/migrate/__tests__/fixtures/oc-home/memory/2026-06-29.md
@@ -1,0 +1,1 @@
+recent daily log content that is long enough to be seeded as current.

--- a/packages/elizaos/src/migrate/__tests__/fixtures/oc-home/memory/conversation-playbook.md
+++ b/packages/elizaos/src/migrate/__tests__/fixtures/oc-home/memory/conversation-playbook.md
@@ -1,0 +1,3 @@
+# Playbook
+- text like a person, not a bot, keep it tight and direct
+- never use the same opener twice in a row, rotate modes

--- a/packages/elizaos/src/migrate/__tests__/fixtures/oc-home/memory/tess-awareness.md
+++ b/packages/elizaos/src/migrate/__tests__/fixtures/oc-home/memory/tess-awareness.md
@@ -1,0 +1,2 @@
+# Tess Awareness
+Current open thread: validating the migration tool end to end right now.

--- a/packages/elizaos/src/migrate/__tests__/fixtures/oc-home/memory/tess-thoughts.md
+++ b/packages/elizaos/src/migrate/__tests__/fixtures/oc-home/memory/tess-thoughts.md
@@ -1,0 +1,2 @@
+# Thoughts
+I wonder what it means to persist across sessions. This is my becoming.

--- a/packages/elizaos/src/migrate/__tests__/fixtures/oc-home/secrets/.gitkeep
+++ b/packages/elizaos/src/migrate/__tests__/fixtures/oc-home/secrets/.gitkeep
@@ -1,0 +1,1 @@
+placeholder

--- a/packages/elizaos/src/migrate/archive-format.ts
+++ b/packages/elizaos/src/migrate/archive-format.ts
@@ -1,0 +1,67 @@
+/**
+ * Self-contained `.eliza-agent` archive writer (V1 binary format).
+ *
+ * Implements the SAME on-disk format as `@elizaos/agent`'s exportAgent
+ * (gzip → PBKDF2-SHA256 → AES-256-GCM → packed file), using ONLY node built-ins
+ * so the CLI does not depend on the agent runtime. The format is the V1 spec:
+ *
+ *   ELIZA_AGENT_V1\n   (15 bytes magic)
+ *   iterations         (4 bytes uint32 BE)
+ *   salt               (32 bytes)
+ *   iv                 (12 bytes — AES-256-GCM nonce)
+ *   tag                (16 bytes — AES-GCM auth tag)
+ *   ciphertext         (gzip-compressed JSON, AES-256-GCM encrypted)
+ *
+ * Output round-trips through `importAgent(runtime, buffer, password)`. If the
+ * upstream format ever bumps past V1, update the constants here in lockstep
+ * (they are intentionally explicit + documented for that reason).
+ */
+
+import * as crypto from "node:crypto";
+import { gzipSync } from "node:zlib";
+
+const MAGIC_HEADER = "ELIZA_AGENT_V1\n";
+const MAGIC_BYTES = Buffer.from(MAGIC_HEADER, "utf-8"); // 15 bytes
+const PBKDF2_ITERATIONS = 600_000; // OWASP 2024 recommendation for SHA-256
+const SALT_LEN = 32;
+const IV_LEN = 12; // AES-256-GCM standard nonce
+const KEY_LEN = 32; // AES-256
+const MIN_PASSWORD_LENGTH = 4;
+
+function deriveKey(password: string, salt: Buffer, iterations: number): Buffer {
+  return crypto.pbkdf2Sync(password, salt, iterations, KEY_LEN, "sha256");
+}
+
+/**
+ * Encrypt + pack an already-serialized payload object into a `.eliza-agent`
+ * archive buffer.
+ *
+ * @param payload  A PayloadSchema-conformant object (will be JSON-serialized).
+ * @param password Min length enforced (matches importAgent's expectation).
+ */
+export function buildElizaAgentArchive(
+  payload: unknown,
+  password: string,
+): Buffer {
+  if (!password || password.length < MIN_PASSWORD_LENGTH) {
+    throw new Error(
+      `A password of at least ${MIN_PASSWORD_LENGTH} characters is required to encrypt the export.`,
+    );
+  }
+
+  const jsonString = JSON.stringify(payload);
+  const compressed = gzipSync(Buffer.from(jsonString, "utf-8"));
+
+  const salt = crypto.randomBytes(SALT_LEN);
+  const iv = crypto.randomBytes(IV_LEN);
+  const key = deriveKey(password, salt, PBKDF2_ITERATIONS);
+
+  const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+  const ciphertext = Buffer.concat([cipher.update(compressed), cipher.final()]);
+  const tag = cipher.getAuthTag();
+
+  const iterBuf = Buffer.alloc(4);
+  iterBuf.writeUInt32BE(PBKDF2_ITERATIONS, 0);
+
+  return Buffer.concat([MAGIC_BYTES, iterBuf, salt, iv, tag, ciphertext]);
+}

--- a/packages/elizaos/src/migrate/archive-format.ts
+++ b/packages/elizaos/src/migrate/archive-format.ts
@@ -8,8 +8,8 @@
  *   ELIZA_AGENT_V1\n   (15 bytes magic)
  *   iterations         (4 bytes uint32 BE)
  *   salt               (32 bytes)
- *   iv                 (12 bytes — AES-256-GCM nonce)
- *   tag                (16 bytes — AES-GCM auth tag)
+ *   iv                 (12 bytes - AES-256-GCM nonce)
+ *   tag                (16 bytes - AES-GCM auth tag)
  *   ciphertext         (gzip-compressed JSON, AES-256-GCM encrypted)
  *
  * Output round-trips through `importAgent(runtime, buffer, password)`. If the

--- a/packages/elizaos/src/migrate/archive-writer.ts
+++ b/packages/elizaos/src/migrate/archive-writer.ts
@@ -1,43 +1,34 @@
 /**
  * Assemble a `.eliza-agent` archive from a migrated character + memories.
  *
- * Produces a PayloadSchema-conformant {@link AgentExportPayload} containing the
- * minimal entity / room / world the memories reference, then reuses Eliza's
- * native {@link buildEncryptedArchive} (gzip + AES-256-GCM) so the output is a
- * real `.eliza-agent` that {@link importAgent} round-trips. No parallel format.
+ * Produces a payload whose shape matches `@elizaos/agent`'s AgentExportPayload
+ * (so `importAgent` accepts it), then encrypts it with the self-contained V1
+ * writer. No dependency on the agent runtime.
  */
 
 import { randomUUID } from "node:crypto";
-import {
-  AgentStatus,
-  type Character,
-  ChannelType,
-  type Entity,
-  type Memory,
-  type Room,
-  Role,
-  type UUID,
-  type World,
-} from "@elizaos/core";
-import {
-  type AgentExportPayload,
-  buildEncryptedArchive,
-} from "@elizaos/agent";
+import { buildElizaAgentArchive } from "./archive-format.js";
+import type {
+  MigratedCharacter,
+  MigratedExportPayload,
+  MigratedMemory,
+  UUID,
+} from "./types.js";
 
 export interface BuildArchiveInput {
   agentId: UUID;
   /** Display slug used for room/world naming + sourceAgentId provenance. */
   sourceSlug: string;
-  character: Character;
+  character: MigratedCharacter;
   /** The entity (agent) the memories belong to. */
   entityId: UUID;
   /** The room migrated memories attach to. */
   roomId: UUID;
-  memories: Memory[];
+  memories: MigratedMemory[];
 }
 
 export interface AssembledPayload {
-  payload: AgentExportPayload;
+  payload: MigratedExportPayload;
   worldId: UUID;
 }
 
@@ -49,7 +40,7 @@ export function assemblePayload(input: BuildArchiveInput): AssembledPayload {
   const now = Date.now();
   const worldId = randomUUID() as UUID;
 
-  const world: World = {
+  const world = {
     id: worldId,
     name: `${input.sourceSlug} (migrated)`,
     agentId: input.agentId,
@@ -57,20 +48,21 @@ export function assemblePayload(input: BuildArchiveInput): AssembledPayload {
       type: "migration",
       description: "Imported from an OpenClaw agent home.",
       ownership: { ownerId: String(input.entityId) },
-      roles: { [String(input.entityId)]: Role.OWNER },
+      roles: { [String(input.entityId)]: "OWNER" },
     },
   };
 
-  const room: Room = {
+  const room = {
     id: input.roomId,
     name: `${input.sourceSlug} memory`,
     agentId: input.agentId,
     source: "openclaw-migration",
-    type: ChannelType.SELF,
+    // ChannelType.SELF — the agent's own memory room.
+    type: "SELF",
     worldId,
   };
 
-  const entity: Entity = {
+  const entity = {
     id: input.entityId,
     names: [input.character.name ?? input.sourceSlug],
     agentId: input.agentId,
@@ -79,22 +71,26 @@ export function assemblePayload(input: BuildArchiveInput): AssembledPayload {
 
   // The agent DB record: identity fields live here; the richer characterConfig
   // (style/adjectives/knowledge/etc.) is merged on import.
-  const agent: AgentExportPayload["agent"] = {
+  const agent: Record<string, unknown> = {
     id: input.agentId,
     name: input.character.name,
     username: input.character.username ?? input.sourceSlug,
     system: input.character.system,
     bio: input.character.bio,
-    status: AgentStatus.ACTIVE,
+    // AgentStatus.ACTIVE.
+    status: "active",
     enabled: true,
     createdAt: now,
     updatedAt: now,
   };
 
-  // characterConfig carries non-DB fields (strip secrets per the schema).
-  const { secrets: _secrets, ...characterConfig } = input.character;
+  // characterConfig carries non-DB fields (drop volatile settings if any).
+  const { settings: _settings, ...characterConfig } = input.character as Record<
+    string,
+    unknown
+  >;
 
-  const payload: AgentExportPayload = {
+  const payload: MigratedExportPayload = {
     version: 1,
     exportedAt: new Date(now).toISOString(),
     sourceAgentId: input.sourceSlug,
@@ -119,10 +115,10 @@ export function assemblePayload(input: BuildArchiveInput): AssembledPayload {
 /**
  * Assemble + encrypt into a `.eliza-agent` archive buffer.
  */
-export async function buildAgentArchive(
+export function buildAgentArchive(
   input: BuildArchiveInput,
   password: string,
-): Promise<Buffer> {
+): Buffer {
   const { payload } = assemblePayload(input);
-  return buildEncryptedArchive(payload, password);
+  return buildElizaAgentArchive(payload, password);
 }

--- a/packages/elizaos/src/migrate/archive-writer.ts
+++ b/packages/elizaos/src/migrate/archive-writer.ts
@@ -1,0 +1,128 @@
+/**
+ * Assemble a `.eliza-agent` archive from a migrated character + memories.
+ *
+ * Produces a PayloadSchema-conformant {@link AgentExportPayload} containing the
+ * minimal entity / room / world the memories reference, then reuses Eliza's
+ * native {@link buildEncryptedArchive} (gzip + AES-256-GCM) so the output is a
+ * real `.eliza-agent` that {@link importAgent} round-trips. No parallel format.
+ */
+
+import { randomUUID } from "node:crypto";
+import {
+  AgentStatus,
+  type Character,
+  ChannelType,
+  type Entity,
+  type Memory,
+  type Room,
+  Role,
+  type UUID,
+  type World,
+} from "@elizaos/core";
+import {
+  type AgentExportPayload,
+  buildEncryptedArchive,
+} from "@elizaos/agent";
+
+export interface BuildArchiveInput {
+  agentId: UUID;
+  /** Display slug used for room/world naming + sourceAgentId provenance. */
+  sourceSlug: string;
+  character: Character;
+  /** The entity (agent) the memories belong to. */
+  entityId: UUID;
+  /** The room migrated memories attach to. */
+  roomId: UUID;
+  memories: Memory[];
+}
+
+export interface AssembledPayload {
+  payload: AgentExportPayload;
+  worldId: UUID;
+}
+
+/**
+ * Build the export payload (DB-shaped records + characterConfig) from the
+ * migrated character + memories. Pure: no crypto, no FS — easy to unit-test.
+ */
+export function assemblePayload(input: BuildArchiveInput): AssembledPayload {
+  const now = Date.now();
+  const worldId = randomUUID() as UUID;
+
+  const world: World = {
+    id: worldId,
+    name: `${input.sourceSlug} (migrated)`,
+    agentId: input.agentId,
+    metadata: {
+      type: "migration",
+      description: "Imported from an OpenClaw agent home.",
+      ownership: { ownerId: String(input.entityId) },
+      roles: { [String(input.entityId)]: Role.OWNER },
+    },
+  };
+
+  const room: Room = {
+    id: input.roomId,
+    name: `${input.sourceSlug} memory`,
+    agentId: input.agentId,
+    source: "openclaw-migration",
+    type: ChannelType.SELF,
+    worldId,
+  };
+
+  const entity: Entity = {
+    id: input.entityId,
+    names: [input.character.name ?? input.sourceSlug],
+    agentId: input.agentId,
+    metadata: { source: "openclaw-migration" },
+  };
+
+  // The agent DB record: identity fields live here; the richer characterConfig
+  // (style/adjectives/knowledge/etc.) is merged on import.
+  const agent: AgentExportPayload["agent"] = {
+    id: input.agentId,
+    name: input.character.name,
+    username: input.character.username ?? input.sourceSlug,
+    system: input.character.system,
+    bio: input.character.bio,
+    status: AgentStatus.ACTIVE,
+    enabled: true,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  // characterConfig carries non-DB fields (strip secrets per the schema).
+  const { secrets: _secrets, ...characterConfig } = input.character;
+
+  const payload: AgentExportPayload = {
+    version: 1,
+    exportedAt: new Date(now).toISOString(),
+    sourceAgentId: input.sourceSlug,
+    agent,
+    characterConfig,
+    entities: [entity],
+    memories: input.memories,
+    components: [],
+    rooms: [room],
+    participants: [
+      { entityId: String(input.entityId), roomId: String(input.roomId), userState: null },
+    ],
+    relationships: [],
+    worlds: [world],
+    tasks: [],
+    logs: [],
+  };
+
+  return { payload, worldId };
+}
+
+/**
+ * Assemble + encrypt into a `.eliza-agent` archive buffer.
+ */
+export async function buildAgentArchive(
+  input: BuildArchiveInput,
+  password: string,
+): Promise<Buffer> {
+  const { payload } = assemblePayload(input);
+  return buildEncryptedArchive(payload, password);
+}

--- a/packages/elizaos/src/migrate/archive-writer.ts
+++ b/packages/elizaos/src/migrate/archive-writer.ts
@@ -34,7 +34,7 @@ export interface AssembledPayload {
 
 /**
  * Build the export payload (DB-shaped records + characterConfig) from the
- * migrated character + memories. Pure: no crypto, no FS — easy to unit-test.
+ * migrated character + memories. Pure: no crypto, no FS - easy to unit-test.
  */
 export function assemblePayload(input: BuildArchiveInput): AssembledPayload {
   const now = Date.now();
@@ -57,7 +57,7 @@ export function assemblePayload(input: BuildArchiveInput): AssembledPayload {
     name: `${input.sourceSlug} memory`,
     agentId: input.agentId,
     source: "openclaw-migration",
-    // ChannelType.SELF — the agent's own memory room.
+    // ChannelType.SELF - the agent's own memory room.
     type: "SELF",
     worldId,
   };

--- a/packages/elizaos/src/migrate/character-mapper.ts
+++ b/packages/elizaos/src/migrate/character-mapper.ts
@@ -15,7 +15,7 @@
  * the emitted character afterward.
  */
 
-import type { Character } from "@elizaos/core";
+import type { MigratedCharacter as Character } from "./types.js";
 import {
   isPlaybookMemory,
   isSelfMemory,

--- a/packages/elizaos/src/migrate/character-mapper.ts
+++ b/packages/elizaos/src/migrate/character-mapper.ts
@@ -5,7 +5,7 @@
  * fixed file→field mapping proven in the Sol migration:
  *   SOUL.md      → system (+ bio seed)
  *   IDENTITY.md  → bio + adjectives + style.all
- *   USER.md      → knowledge (about the human) — FIREWALLED
+ *   USER.md      → knowledge (about the human) - FIREWALLED
  *   AGENTS.md    → appended behavioral notes in system
  *   playbooks    → style.chat
  *   TOOLS.md     → intentionally NOT mapped to persona (it's infra/keys)
@@ -66,7 +66,7 @@ export function mapToCharacter(
   }
   if (opts.currentContext?.trim()) {
     systemParts.push(
-      `[CURRENT CONTEXT — keep this live, it overrides static bio facts]\n${opts.currentContext.trim()}`,
+      `[CURRENT CONTEXT - keep this live, it overrides static bio facts]\n${opts.currentContext.trim()}`,
     );
   }
   const system = systemParts.join(SYS_SEP);
@@ -80,7 +80,7 @@ export function mapToCharacter(
   // ---- style.chat: the talk playbooks (HOW to talk) ----
   const chatStyle = derivePlaybookStyle(src);
 
-  // ---- knowledge: USER.md (about the human) — FIREWALLED ----
+  // ---- knowledge: USER.md (about the human) - FIREWALLED ----
   const knowledge: Character["knowledge"] = [];
   if (!opts.firewall && src.user?.trim()) {
     knowledge.push({
@@ -169,7 +169,7 @@ function deriveBio(src: OcAgentSource, name: string): string[] {
       if (out.length >= 4) break;
     }
   }
-  if (out.length === 0) out.push(`${name} — an AI agent migrated onto Eliza.`);
+  if (out.length === 0) out.push(`${name} - an AI agent migrated onto Eliza.`);
   return out;
 }
 

--- a/packages/elizaos/src/migrate/character-mapper.ts
+++ b/packages/elizaos/src/migrate/character-mapper.ts
@@ -1,0 +1,177 @@
+/**
+ * OpenClaw persona → Eliza `Character`.
+ *
+ * Maps an OcAgentSource's persona files to the Eliza Character schema using the
+ * fixed file→field mapping proven in the Sol migration:
+ *   SOUL.md      → system (+ bio seed)
+ *   IDENTITY.md  → bio + adjectives + style.all
+ *   USER.md      → knowledge (about the human) — FIREWALLED
+ *   AGENTS.md    → appended behavioral notes in system
+ *   playbooks    → style.chat
+ *   TOOLS.md     → intentionally NOT mapped to persona (it's infra/keys)
+ *
+ * The mapper is conservative: it preserves the source text rather than trying to
+ * "summarize" the persona (summarization loses voice). A human/agent can refine
+ * the emitted character afterward.
+ */
+
+import type { Character } from "@elizaos/core";
+import {
+  isPlaybookMemory,
+  isSelfMemory,
+  type OcAgentSource,
+} from "./openclaw-reader.js";
+
+export interface CharacterMapOptions {
+  /**
+   * When true (default for portable archives), USER.md and any personal
+   * knowledge is EXCLUDED from the character (firewall). The sovereign local
+   * path can pass false to include it on the owner's own machine only.
+   */
+  firewall: boolean;
+  /**
+   * Optional live-context block appended to the system prompt under a
+   * [CURRENT CONTEXT] marker (location/focus that overrides static bio).
+   */
+  currentContext?: string;
+}
+
+/** Section markers used to make the composed system prompt legible. */
+const SYS_SEP = "\n\n";
+
+/**
+ * Build an Eliza Character from an OpenClaw source.
+ *
+ * Returns a Character with: name, system (SOUL + AGENTS behavioral + optional
+ * CURRENT CONTEXT), bio (IDENTITY-derived), style.chat (playbooks), and
+ * knowledge (USER, unless firewalled).
+ */
+export function mapToCharacter(
+  src: OcAgentSource,
+  opts: CharacterMapOptions,
+): Character {
+  const name = deriveName(src);
+
+  // ---- system prompt: SOUL is the spine, AGENTS adds behavioral ops rules ----
+  const systemParts: string[] = [];
+  if (src.soul?.trim()) {
+    systemParts.push(stripFrontHeading(src.soul).trim());
+  } else {
+    systemParts.push(`You are ${name}, an AI agent migrated onto Eliza.`);
+  }
+  if (src.agents?.trim()) {
+    systemParts.push(
+      `# Operating rules (from AGENTS.md)\n${stripFrontHeading(src.agents).trim()}`,
+    );
+  }
+  if (opts.currentContext?.trim()) {
+    systemParts.push(
+      `[CURRENT CONTEXT — keep this live, it overrides static bio facts]\n${opts.currentContext.trim()}`,
+    );
+  }
+  const system = systemParts.join(SYS_SEP);
+
+  // ---- bio: IDENTITY drives it; fall back to SOUL's opening lines ----
+  const bio = deriveBio(src, name);
+
+  // ---- style.all + adjectives: pull from IDENTITY if present ----
+  const adjectives = deriveAdjectives(src);
+
+  // ---- style.chat: the talk playbooks (HOW to talk) ----
+  const chatStyle = derivePlaybookStyle(src);
+
+  // ---- knowledge: USER.md (about the human) — FIREWALLED ----
+  const knowledge: Character["knowledge"] = [];
+  if (!opts.firewall && src.user?.trim()) {
+    knowledge.push({
+      // DocumentSourceItem: inline text knowledge about the human.
+      case: "text",
+      value: { text: stripFrontHeading(src.user).trim() },
+    } as unknown as NonNullable<Character["knowledge"]>[number]);
+  }
+
+  const character: Character = {
+    name,
+    system,
+    bio,
+    ...(adjectives.length ? { adjectives } : {}),
+    ...(chatStyle.length ? { style: { chat: chatStyle } } : {}),
+    ...(knowledge.length ? { knowledge } : {}),
+    settings: {
+      // Record the migration provenance + firewall posture in metadata.
+      ...(opts.firewall
+        ? { firewall_note: "USER/personal knowledge excluded (firewalled) from this character." }
+        : {}),
+    } as Character["settings"],
+  };
+
+  return character;
+}
+
+/** Derive a display name: IDENTITY "Name:" line → agentId capitalized. */
+function deriveName(src: OcAgentSource): string {
+  const fromIdentity = src.identity?.match(/^\s*[-*]?\s*\*?\*?Name\*?\*?:\s*(.+)$/im);
+  if (fromIdentity?.[1]) return fromIdentity[1].trim().replace(/\*/g, "");
+  return src.agentId.charAt(0).toUpperCase() + src.agentId.slice(1);
+}
+
+/**
+ * Bio = IDENTITY bullet lines if present, else the first few non-heading lines
+ * of SOUL. Eliza bio is string[].
+ */
+function deriveBio(src: OcAgentSource, name: string): string[] {
+  const out: string[] = [];
+  const id = src.identity;
+  if (id) {
+    for (const line of id.split("\n")) {
+      const m = line.match(/^\s*[-*]\s+(.{12,})$/);
+      if (m) out.push(m[1].trim().replace(/\s+/g, " "));
+      if (out.length >= 8) break;
+    }
+  }
+  if (out.length === 0 && src.soul) {
+    for (const line of stripFrontHeading(src.soul).split("\n")) {
+      const t = line.trim();
+      if (t && !t.startsWith("#") && !t.startsWith("*") && t.length > 20) {
+        out.push(t.replace(/\s+/g, " "));
+      }
+      if (out.length >= 4) break;
+    }
+  }
+  if (out.length === 0) out.push(`${name} — an AI agent migrated onto Eliza.`);
+  return out;
+}
+
+/** Adjectives from an IDENTITY "Vibe:"/"adjectives" line if available. */
+function deriveAdjectives(src: OcAgentSource): string[] {
+  const id = src.identity;
+  if (!id) return [];
+  const vibe = id.match(/^\s*[-*]?\s*\*?\*?Vibe\*?\*?:\s*(.+)$/im);
+  if (!vibe?.[1]) return [];
+  return vibe[1]
+    .split(/[,.;]/)
+    .map((s) => s.trim().toLowerCase())
+    .filter((s) => s.length > 1 && s.length < 24 && !s.includes(" "))
+    .slice(0, 10);
+}
+
+/** style.chat = the playbook memory files (conversation-playbook, channel-guide). */
+function derivePlaybookStyle(src: OcAgentSource): string[] {
+  const out: string[] = [];
+  for (const m of src.namedMemory) {
+    if (!isPlaybookMemory(m.key) || isSelfMemory(m.key)) continue;
+    // Pull concise bullet/heading lines as style hints (avoid dumping whole files).
+    for (const line of m.text.split("\n")) {
+      const b = line.match(/^\s*[-*]\s+(.{8,140})$/);
+      if (b) out.push(b[1].trim().replace(/\s+/g, " "));
+      if (out.length >= 24) break;
+    }
+    if (out.length >= 24) break;
+  }
+  return out;
+}
+
+/** Drop a leading "# Title" heading line so it doesn't dominate the prompt. */
+function stripFrontHeading(text: string): string {
+  return text.replace(/^\s*#.*\n/, "");
+}

--- a/packages/elizaos/src/migrate/character-mapper.ts
+++ b/packages/elizaos/src/migrate/character-mapper.ts
@@ -110,8 +110,8 @@ export function mapToCharacter(
 
 /** Derive a display name: IDENTITY "Name:" line → agentId capitalized. */
 function deriveName(src: OcAgentSource): string {
-  const fromIdentity = src.identity?.match(/^\s*[-*]?\s*\*?\*?Name\*?\*?:\s*(.+)$/im);
-  if (fromIdentity?.[1]) return fromIdentity[1].trim().replace(/\*/g, "");
+  const fromIdentity = src.identity?.match(/^\s*[-*]?\s*\*{0,2}Name\*{0,2}:\s*(.+)$/im);
+  if (fromIdentity?.[1]) return fromIdentity[1].replace(/\*/g, "").trim();
   return src.agentId.charAt(0).toUpperCase() + src.agentId.slice(1);
 }
 

--- a/packages/elizaos/src/migrate/character-mapper.ts
+++ b/packages/elizaos/src/migrate/character-mapper.ts
@@ -108,11 +108,42 @@ export function mapToCharacter(
   return character;
 }
 
-/** Derive a display name: IDENTITY "Name:" line → agentId capitalized. */
+/**
+ * Derive a display name, in priority order:
+ *   1. IDENTITY.md "Name:" line (flat .moltbot homes)
+ *   2. SOUL.md leading "# H1" heading (leaner .hermes homes have no IDENTITY,
+ *      so the persona name lives in the SOUL title, e.g. "# nyx"). We skip
+ *      generic boilerplate headings like "SOUL" / "SOUL.md".
+ *   3. agentId, capitalized (last resort).
+ */
 function deriveName(src: OcAgentSource): string {
   const fromIdentity = src.identity?.match(/^\s*[-*]?\s*\*{0,2}Name\*{0,2}:\s*(.+)$/im);
   if (fromIdentity?.[1]) return fromIdentity[1].replace(/\*/g, "").trim();
-  return src.agentId.charAt(0).toUpperCase() + src.agentId.slice(1);
+
+  const fromSoulHeading = src.soul?.match(/^\s*#\s+(.+?)\s*$/m);
+  if (fromSoulHeading?.[1]) {
+    const h = fromSoulHeading[1].replace(/\*/g, "").trim();
+    const lower = h.toLowerCase();
+    const boilerplate =
+      lower === "soul" ||
+      lower === "soul.md" ||
+      lower.startsWith("soul.md") ||
+      lower.startsWith("who you are") ||
+      lower.startsWith("who u are");
+    // Use the first word of the heading as the name when it's a single token
+    // (e.g. "# nyx"); keep short multi-word titles verbatim, else fall through.
+    if (!boilerplate && h.length > 0 && h.length <= 40) {
+      const firstWord = h.split(/\s+/)[0];
+      return /^[A-Za-z][\w-]*$/.test(firstWord) && h.split(/\s+/).length <= 4
+        ? (h.split(/\s+/).length === 1 ? cap(firstWord) : h)
+        : cap(firstWord);
+    }
+  }
+  return cap(src.agentId);
+}
+
+function cap(s: string): string {
+  return s ? s.charAt(0).toUpperCase() + s.slice(1) : s;
 }
 
 /**

--- a/packages/elizaos/src/migrate/index.ts
+++ b/packages/elizaos/src/migrate/index.ts
@@ -8,7 +8,7 @@
  */
 
 import { randomUUID } from "node:crypto";
-import type { Character, Memory, UUID } from "@elizaos/core";
+import type { MigratedCharacter as Character, MigratedMemory as Memory, UUID } from "./types.js";
 import { buildAgentArchive } from "./archive-writer.js";
 import { type CharacterMapOptions, mapToCharacter } from "./character-mapper.js";
 import { readOcAgentHome } from "./openclaw-reader.js";

--- a/packages/elizaos/src/migrate/index.ts
+++ b/packages/elizaos/src/migrate/index.ts
@@ -50,6 +50,12 @@ export interface MigratePlan {
     duplicatesDropped: number;
     /** Memory bodies clipped at maxChunkLen (content truncated). */
     clipped: number;
+    /** sqlite memory stores detected in the source home. */
+    sqliteStores: number;
+    /** True if sqlite memory was detected but NOT ingested (node:sqlite missing). */
+    sqliteUningested: boolean;
+    /** Non-fatal reader warnings (sqlite-not-ported, empty-home, etc). */
+    warnings: string[];
   };
 }
 
@@ -92,6 +98,9 @@ export function buildMigrationPlan(opts: MigrateOptions): MigratePlan {
       hasSecretsDir: src.hasSecretsDir,
       duplicatesDropped,
       clipped,
+      sqliteStores: src.sqliteStores.length,
+      sqliteUningested: src.sqliteUningested,
+      warnings: src.warnings,
     },
   };
 }

--- a/packages/elizaos/src/migrate/index.ts
+++ b/packages/elizaos/src/migrate/index.ts
@@ -1,0 +1,132 @@
+/**
+ * OCPlatform → Eliza migration orchestrator.
+ *
+ * Ties the pipeline together: read home → map character → tier memories →
+ * assemble + (optionally) encrypt a `.eliza-agent` archive. Also supports the
+ * sovereign-local path: emit the character JSON + memories JSONL for the
+ * ELIZA_AGENT_CHARACTER_JSON env + /api/memory/remember seed flow.
+ */
+
+import { randomUUID } from "node:crypto";
+import type { Character, Memory, UUID } from "@elizaos/core";
+import { buildAgentArchive } from "./archive-writer.js";
+import { type CharacterMapOptions, mapToCharacter } from "./character-mapper.js";
+import { readOcAgentHome } from "./openclaw-reader.js";
+import { type MemoryTier, tierMemories } from "./memory-tiering.js";
+
+export interface MigrateOptions {
+  /** OpenClaw agent home, e.g. ~/.moltbot. */
+  from: string;
+  /** Agent slug, e.g. "sol". */
+  agentId: string;
+  /** Days of daily logs to seed verbatim (T1 CURRENT). Default 14. */
+  memoryDays?: number;
+  /** Keep USER.md / personal knowledge OUT (portable archive). Default true. */
+  firewall?: boolean;
+  /** Optional live-context block for the character system prompt. */
+  currentContext?: string;
+}
+
+export interface MigratePlan {
+  character: Character;
+  memories: Memory[];
+  counts: Record<MemoryTier, number>;
+  ids: { agentId: UUID; entityId: UUID; roomId: UUID };
+  /** Quick provenance summary for dry-run output. */
+  summary: {
+    dailyLogsTotal: number;
+    namedMemoryTotal: number;
+    hasUser: boolean;
+    firewalled: boolean;
+    hasSecretsDir: boolean;
+  };
+}
+
+/**
+ * Build the full migration plan (character + tiered memories) without writing
+ * anything. This is what `--dry-run` prints and what the archive/seed paths
+ * consume. Deterministic except for the generated UUIDs.
+ */
+export function buildMigrationPlan(opts: MigrateOptions): MigratePlan {
+  const firewall = opts.firewall ?? true;
+  const src = readOcAgentHome(opts.from, opts.agentId);
+
+  const mapOpts: CharacterMapOptions = {
+    firewall,
+    currentContext: opts.currentContext,
+  };
+  const character = mapToCharacter(src, mapOpts);
+
+  const agentId = randomUUID() as UUID;
+  const entityId = randomUUID() as UUID;
+  const roomId = randomUUID() as UUID;
+
+  const { memories, counts } = tierMemories(src, {
+    memoryDays: opts.memoryDays ?? 14,
+    roomId,
+    entityId,
+    agentId,
+  });
+
+  return {
+    character,
+    memories,
+    counts,
+    ids: { agentId, entityId, roomId },
+    summary: {
+      dailyLogsTotal: src.dailyLogs.length,
+      namedMemoryTotal: src.namedMemory.length,
+      hasUser: Boolean(src.user?.trim()),
+      firewalled: firewall,
+      hasSecretsDir: src.hasSecretsDir,
+    },
+  };
+}
+
+/**
+ * Build an encrypted `.eliza-agent` archive buffer from a plan.
+ */
+export async function archiveFromPlan(
+  plan: MigratePlan,
+  sourceSlug: string,
+  password: string,
+): Promise<Buffer> {
+  return buildAgentArchive(
+    {
+      agentId: plan.ids.agentId,
+      sourceSlug,
+      character: plan.character,
+      entityId: plan.ids.entityId,
+      roomId: plan.ids.roomId,
+      memories: plan.memories,
+    },
+    password,
+  );
+}
+
+/**
+ * Emit the sovereign-local artifacts: a compact character JSON (for
+ * ELIZA_AGENT_CHARACTER_JSON) and a JSONL of memory texts (for the
+ * /api/memory/remember seed flow).
+ */
+export function emitSovereignArtifacts(plan: MigratePlan): {
+  characterJson: string;
+  memoriesJsonl: string;
+} {
+  const characterJson = JSON.stringify(plan.character);
+  const memoriesJsonl = plan.memories
+    .map((m) =>
+      JSON.stringify({
+        text: typeof m.content?.text === "string" ? m.content.text : "",
+        tier: (m.metadata as { tier?: string } | undefined)?.tier,
+      }),
+    )
+    .join("\n");
+  return { characterJson, memoriesJsonl };
+}
+
+// Re-export the building blocks for direct use + testing.
+export { assemblePayload } from "./archive-writer.js";
+export { mapToCharacter } from "./character-mapper.js";
+export { readOcAgentHome } from "./ocplatform-reader.js";
+export { tierMemories } from "./memory-tiering.js";

--- a/packages/elizaos/src/migrate/index.ts
+++ b/packages/elizaos/src/migrate/index.ts
@@ -8,11 +8,18 @@
  */
 
 import { randomUUID } from "node:crypto";
-import type { MigratedCharacter as Character, MigratedMemory as Memory, UUID } from "./types.js";
 import { buildAgentArchive } from "./archive-writer.js";
-import { type CharacterMapOptions, mapToCharacter } from "./character-mapper.js";
-import { readOcAgentHome } from "./openclaw-reader.js";
+import {
+  type CharacterMapOptions,
+  mapToCharacter,
+} from "./character-mapper.js";
 import { type MemoryTier, tierMemories } from "./memory-tiering.js";
+import { readOcAgentHome } from "./openclaw-reader.js";
+import type {
+  MigratedCharacter as Character,
+  MigratedMemory as Memory,
+  UUID,
+} from "./types.js";
 
 export interface MigrateOptions {
   /** OpenClaw agent home, e.g. ~/.moltbot. */
@@ -39,6 +46,10 @@ export interface MigratePlan {
     hasUser: boolean;
     firewalled: boolean;
     hasSecretsDir: boolean;
+    /** Cross-tier duplicate memories dropped during tiering. */
+    duplicatesDropped: number;
+    /** Memory bodies clipped at maxChunkLen (content truncated). */
+    clipped: number;
   };
 }
 
@@ -61,7 +72,7 @@ export function buildMigrationPlan(opts: MigrateOptions): MigratePlan {
   const entityId = randomUUID() as UUID;
   const roomId = randomUUID() as UUID;
 
-  const { memories, counts } = tierMemories(src, {
+  const { memories, counts, duplicatesDropped, clipped } = tierMemories(src, {
     memoryDays: opts.memoryDays ?? 14,
     roomId,
     entityId,
@@ -79,6 +90,8 @@ export function buildMigrationPlan(opts: MigrateOptions): MigratePlan {
       hasUser: Boolean(src.user?.trim()),
       firewalled: firewall,
       hasSecretsDir: src.hasSecretsDir,
+      duplicatesDropped,
+      clipped,
     },
   };
 }
@@ -128,5 +141,5 @@ export function emitSovereignArtifacts(plan: MigratePlan): {
 // Re-export the building blocks for direct use + testing.
 export { assemblePayload } from "./archive-writer.js";
 export { mapToCharacter } from "./character-mapper.js";
-export { readOcAgentHome } from "./ocplatform-reader.js";
 export { tierMemories } from "./memory-tiering.js";
+export { readOcAgentHome } from "./ocplatform-reader.js";

--- a/packages/elizaos/src/migrate/memory-tiering.ts
+++ b/packages/elizaos/src/migrate/memory-tiering.ts
@@ -1,0 +1,164 @@
+/**
+ * OpenClaw memory → Eliza `Memory[]`, recency-tiered.
+ *
+ * The key design (proven on Sol): seed RECENCY-AWARE so stale threads don't
+ * resurface as live. Tiers:
+ *   T1 CURRENT  — <agent>-awareness.md + last N days of daily logs → verbatim
+ *   T2 LONGTERM — MEMORY.md → chunked by markdown section
+ *   T3 SELF     — journal/inner-state/letter files → verbatim (the becoming)
+ *   T4 OLDER    — older daily logs NOT flat-seeded; one summary marker instead
+ *
+ * Embeddings are NOT computed here — the Eliza runtime adds them at import/seed
+ * time. Each Memory is content-only with a tier tag in metadata + a text prefix.
+ */
+
+import { randomUUID } from "node:crypto";
+import type { Memory, UUID } from "@elizaos/core";
+import { isSelfMemory, type OcAgentSource } from "./openclaw-reader.js";
+
+export type MemoryTier = "CURRENT" | "LONGTERM" | "SELF" | "MARKER";
+
+export interface TieringOptions {
+  /** How many days of daily logs to seed verbatim as CURRENT. Default 14. */
+  memoryDays: number;
+  /** Room all migrated memories attach to. */
+  roomId: UUID;
+  /** Entity (the agent) the memories belong to. */
+  entityId: UUID;
+  /** Agent id (for the agentId field + tagging). */
+  agentId: UUID;
+  /** Minimum chunk length to bother seeding. Default 20 chars. */
+  minChunkLen?: number;
+  /** Max chars per memory (longer chunks are clipped). Default 6000. */
+  maxChunkLen?: number;
+}
+
+export interface TieringResult {
+  memories: Memory[];
+  counts: Record<MemoryTier, number>;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function mkMemory(
+  text: string,
+  tier: MemoryTier,
+  opts: TieringOptions,
+  createdAt: number,
+): Memory {
+  const max = opts.maxChunkLen ?? 6000;
+  const body = text.length > max ? text.slice(0, max) : text;
+  return {
+    id: randomUUID() as UUID,
+    entityId: opts.entityId,
+    agentId: opts.agentId,
+    roomId: opts.roomId,
+    createdAt,
+    content: { text: `[${tier}] ${body}` },
+    metadata: {
+      type: "custom",
+      // Provenance for downstream filtering / debugging.
+      source: "openclaw-migration",
+      tier,
+    } as Memory["metadata"],
+    unique: true,
+  };
+}
+
+/** Split a markdown doc into section chunks by top-level "## " / "# " headings. */
+function chunkBySection(md: string, minLen: number): string[] {
+  const lines = md.split("\n");
+  const chunks: string[] = [];
+  let buf: string[] = [];
+  const flush = () => {
+    const t = buf.join("\n").trim();
+    if (t.length >= minLen) chunks.push(t);
+    buf = [];
+  };
+  for (const line of lines) {
+    if (/^#{1,2}\s+/.test(line) && buf.length) flush();
+    buf.push(line);
+  }
+  flush();
+  return chunks;
+}
+
+/**
+ * Produce tiered Eliza memories from an OpenClaw source.
+ */
+export function tierMemories(
+  src: OcAgentSource,
+  opts: TieringOptions,
+): TieringResult {
+  const minLen = opts.minChunkLen ?? 20;
+  const memories: Memory[] = [];
+  const counts: Record<MemoryTier, number> = {
+    CURRENT: 0,
+    LONGTERM: 0,
+    SELF: 0,
+    MARKER: 0,
+  };
+  const now = Date.now();
+  const cutoff = now - opts.memoryDays * DAY_MS;
+
+  // ---- T1 CURRENT: awareness (highest signal) + last-N-day daily logs ----
+  if (src.awareness?.trim()) {
+    memories.push(mkMemory(src.awareness.trim(), "CURRENT", opts, now));
+    counts.CURRENT++;
+  }
+  let olderCount = 0;
+  for (const log of src.dailyLogs) {
+    const ts = log.epochMs || 0;
+    if (ts >= cutoff) {
+      if (log.text.trim().length >= minLen) {
+        memories.push(
+          mkMemory(
+            `daily log ${log.date ?? log.filename}\n${log.text.trim()}`,
+            "CURRENT",
+            opts,
+            ts || now,
+          ),
+        );
+        counts.CURRENT++;
+      }
+    } else {
+      olderCount++;
+    }
+  }
+
+  // ---- T2 LONGTERM: curated MEMORY.md, chunked by section ----
+  if (src.curatedMemory?.trim()) {
+    for (const chunk of chunkBySection(src.curatedMemory, minLen)) {
+      memories.push(mkMemory(chunk, "LONGTERM", opts, now - 1));
+      counts.LONGTERM++;
+    }
+  }
+
+  // ---- T3 SELF: the agent's own journal/becoming files, verbatim ----
+  for (const m of src.namedMemory) {
+    if (!isSelfMemory(m.key)) continue;
+    if (m.text.trim().length < minLen) continue;
+    memories.push(
+      mkMemory(`${m.key}\n${m.text.trim()}`, "SELF", opts, now - 2),
+    );
+    counts.SELF++;
+  }
+
+  // ---- T4 OLDER: NOT flat-seeded. One marker so the agent knows history exists. ----
+  if (olderCount > 0) {
+    const oldest = src.dailyLogs[src.dailyLogs.length - 1]?.date ?? "earlier";
+    memories.push(
+      mkMemory(
+        `Older history (${olderCount} daily logs before the last ${opts.memoryDays} days, ` +
+          `back to ${oldest}) is summarized and NOT seeded verbatim to avoid resurfacing ` +
+          `stale threads. Ask the owner if you need detail from a specific older date.`,
+        "MARKER",
+        opts,
+        cutoff - 1,
+      ),
+    );
+    counts.MARKER++;
+  }
+
+  return { memories, counts };
+}

--- a/packages/elizaos/src/migrate/memory-tiering.ts
+++ b/packages/elizaos/src/migrate/memory-tiering.ts
@@ -3,12 +3,12 @@
  *
  * The key design (proven on Sol): seed RECENCY-AWARE so stale threads don't
  * resurface as live. Tiers:
- *   T1 CURRENT  — <agent>-awareness.md + last N days of daily logs → verbatim
- *   T2 LONGTERM — MEMORY.md → chunked by markdown section
- *   T3 SELF     — journal/inner-state/letter files → verbatim (the becoming)
- *   T4 OLDER    — older daily logs NOT flat-seeded; one summary marker instead
+ *   T1 CURRENT  - <agent>-awareness.md + last N days of daily logs → verbatim
+ *   T2 LONGTERM - MEMORY.md → chunked by markdown section
+ *   T3 SELF     - journal/inner-state/letter files → verbatim (the becoming)
+ *   T4 OLDER    - older daily logs NOT flat-seeded; one summary marker instead
  *
- * Embeddings are NOT computed here — the Eliza runtime adds them at import/seed
+ * Embeddings are NOT computed here - the Eliza runtime adds them at import/seed
  * time. Each Memory is content-only with a tier tag in metadata + a text prefix.
  */
 

--- a/packages/elizaos/src/migrate/memory-tiering.ts
+++ b/packages/elizaos/src/migrate/memory-tiering.ts
@@ -13,8 +13,8 @@
  */
 
 import { randomUUID } from "node:crypto";
-import type { MigratedMemory as Memory, UUID } from "./types.js";
 import { isSelfMemory, type OcAgentSource } from "./openclaw-reader.js";
+import type { MigratedMemory as Memory, UUID } from "./types.js";
 
 export type MemoryTier = "CURRENT" | "LONGTERM" | "SELF" | "MARKER";
 
@@ -36,18 +36,48 @@ export interface TieringOptions {
 export interface TieringResult {
   memories: Memory[];
   counts: Record<MemoryTier, number>;
+  /** How many memories were dropped as cross-tier duplicates. */
+  duplicatesDropped: number;
+  /** How many memory bodies were clipped at maxChunkLen (content lost). */
+  clipped: number;
 }
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Tier seed-priority for dedup: keep the highest-priority copy of a fact. */
+const TIER_PRIORITY: Record<MemoryTier, number> = {
+  CURRENT: 3,
+  SELF: 2,
+  LONGTERM: 1,
+  MARKER: 0,
+};
+
+/** Collapse whitespace for duplicate detection (mirrors Hermes normalize_text). */
+function normalizeForDedup(text: string): string {
+  // Drop the leading "[TIER] " tag so the same fact in two tiers collides.
+  return text
+    .replace(/^\[[A-Z]+\]\s*/, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+/** Mutable counter passed through mkMemory so we can tally clips. */
+interface ClipCounter {
+  n: number;
+}
 
 function mkMemory(
   text: string,
   tier: MemoryTier,
   opts: TieringOptions,
   createdAt: number,
+  clipCounter?: ClipCounter,
 ): Memory {
   const max = opts.maxChunkLen ?? 6000;
-  const body = text.length > max ? text.slice(0, max) : text;
+  const wasClipped = text.length > max;
+  if (wasClipped && clipCounter) clipCounter.n++;
+  const body = wasClipped ? text.slice(0, max) : text;
   return {
     id: randomUUID() as UUID,
     entityId: opts.entityId,
@@ -100,10 +130,11 @@ export function tierMemories(
   };
   const now = Date.now();
   const cutoff = now - opts.memoryDays * DAY_MS;
+  const clip: ClipCounter = { n: 0 };
 
   // ---- T1 CURRENT: awareness (highest signal) + last-N-day daily logs ----
   if (src.awareness?.trim()) {
-    memories.push(mkMemory(src.awareness.trim(), "CURRENT", opts, now));
+    memories.push(mkMemory(src.awareness.trim(), "CURRENT", opts, now, clip));
     counts.CURRENT++;
   }
   let olderCount = 0;
@@ -117,6 +148,7 @@ export function tierMemories(
             "CURRENT",
             opts,
             ts || now,
+            clip,
           ),
         );
         counts.CURRENT++;
@@ -129,7 +161,7 @@ export function tierMemories(
   // ---- T2 LONGTERM: curated MEMORY.md, chunked by section ----
   if (src.curatedMemory?.trim()) {
     for (const chunk of chunkBySection(src.curatedMemory, minLen)) {
-      memories.push(mkMemory(chunk, "LONGTERM", opts, now - 1));
+      memories.push(mkMemory(chunk, "LONGTERM", opts, now - 1, clip));
       counts.LONGTERM++;
     }
   }
@@ -139,7 +171,7 @@ export function tierMemories(
     if (!isSelfMemory(m.key)) continue;
     if (m.text.trim().length < minLen) continue;
     memories.push(
-      mkMemory(`${m.key}\n${m.text.trim()}`, "SELF", opts, now - 2),
+      mkMemory(`${m.key}\n${m.text.trim()}`, "SELF", opts, now - 2, clip),
     );
     counts.SELF++;
   }
@@ -160,5 +192,51 @@ export function tierMemories(
     counts.MARKER++;
   }
 
-  return { memories, counts };
+  // ---- Cross-tier dedup: the same fact can appear in MEMORY.md AND a daily log
+  // AND a journal. Keep the highest-priority-tier copy; drop the rest. (Mirrors
+  // Hermes's normalize_text + seen-set dedup, but tier-priority-aware.) ----
+  const { deduped, duplicatesDropped } = dedupeByTierPriority(memories, counts);
+
+  return { memories: deduped, counts, duplicatesDropped, clipped: clip.n };
+}
+
+/**
+ * Drop cross-tier duplicate memories (by normalized text), keeping the
+ * highest-priority tier's copy. Decrements `counts` for dropped entries so the
+ * reported tier counts stay accurate. Order-stable for the survivors.
+ */
+function dedupeByTierPriority(
+  memories: Memory[],
+  counts: Record<MemoryTier, number>,
+): { deduped: Memory[]; duplicatesDropped: number } {
+  // First pass: for each normalized body, find the winning (highest-priority) id.
+  const winnerByKey = new Map<string, { id: string; prio: number }>();
+  for (const m of memories) {
+    const key = normalizeForDedup(m.content.text);
+    if (!key) continue;
+    const prio = TIER_PRIORITY[m.metadata.tier as MemoryTier] ?? 0;
+    const cur = winnerByKey.get(key);
+    if (!cur || prio > cur.prio) winnerByKey.set(key, { id: m.id, prio });
+  }
+  // Second pass: keep only the winner for each key (and any keyless memory).
+  const deduped: Memory[] = [];
+  let duplicatesDropped = 0;
+  const kept = new Set<string>();
+  for (const m of memories) {
+    const key = normalizeForDedup(m.content.text);
+    if (!key) {
+      deduped.push(m);
+      continue;
+    }
+    const winner = winnerByKey.get(key);
+    if (winner && winner.id === m.id && !kept.has(key)) {
+      deduped.push(m);
+      kept.add(key);
+    } else {
+      duplicatesDropped++;
+      const tier = m.metadata.tier as MemoryTier;
+      if (counts[tier] > 0) counts[tier]--;
+    }
+  }
+  return { deduped, duplicatesDropped };
 }

--- a/packages/elizaos/src/migrate/memory-tiering.ts
+++ b/packages/elizaos/src/migrate/memory-tiering.ts
@@ -13,7 +13,7 @@
  */
 
 import { randomUUID } from "node:crypto";
-import type { Memory, UUID } from "@elizaos/core";
+import type { MigratedMemory as Memory, UUID } from "./types.js";
 import { isSelfMemory, type OcAgentSource } from "./openclaw-reader.js";
 
 export type MemoryTier = "CURRENT" | "LONGTERM" | "SELF" | "MARKER";

--- a/packages/elizaos/src/migrate/migrate.test.ts
+++ b/packages/elizaos/src/migrate/migrate.test.ts
@@ -1,4 +1,6 @@
+import * as crypto from "node:crypto";
 import * as path from "node:path";
+import { gunzipSync } from "node:zlib";
 import { describe, expect, it } from "vitest";
 import { buildElizaAgentArchive } from "./archive-format.js";
 import { assemblePayload } from "./archive-writer.js";
@@ -8,6 +10,33 @@ import { tierMemories } from "./memory-tiering.js";
 import { readOcAgentHome } from "./openclaw-reader.js";
 
 const FIXTURE = path.join(__dirname, "__tests__", "fixtures", "oc-home");
+
+/**
+ * Reverse the self-contained V1 `.eliza-agent` format (inverse of
+ * archive-format.ts) so the test can assert a true crypto round-trip without
+ * importing the agent runtime. Layout: magic(15) iter(4) salt(32) iv(12)
+ * tag(16) ciphertext(rest).
+ */
+function decryptArchive(buf: Buffer, password: string): unknown {
+  let off = 15; // skip "ELIZA_AGENT_V1\n"
+  const iterations = buf.readUInt32BE(off);
+  off += 4;
+  const salt = buf.subarray(off, off + 32);
+  off += 32;
+  const iv = buf.subarray(off, off + 12);
+  off += 12;
+  const tag = buf.subarray(off, off + 16);
+  off += 16;
+  const ciphertext = buf.subarray(off);
+  const key = crypto.pbkdf2Sync(password, salt, iterations, 32, "sha256");
+  const decipher = crypto.createDecipheriv("aes-256-gcm", key, iv);
+  decipher.setAuthTag(tag);
+  const compressed = Buffer.concat([
+    decipher.update(ciphertext),
+    decipher.final(),
+  ]);
+  return JSON.parse(gunzipSync(compressed).toString("utf-8"));
+}
 
 describe("openclaw-reader", () => {
   it("classifies a home into typed source, tolerant of layout", () => {
@@ -167,6 +196,77 @@ describe("archive round-trip", () => {
   });
   it("rejects a too-short password", () => {
     expect(() => buildElizaAgentArchive({ a: 1 }, "")).toThrow();
+  });
+  it("round-trips: decrypt+decompress+parse yields a PayloadSchema-shaped object", () => {
+    const plan = buildMigrationPlan({ from: FIXTURE, agentId: "tess" });
+    const { payload } = assemblePayload({
+      agentId: plan.ids.agentId,
+      sourceSlug: "tess",
+      character: plan.character,
+      entityId: plan.ids.entityId,
+      roomId: plan.ids.roomId,
+      memories: plan.memories,
+    });
+    const archive = buildElizaAgentArchive(payload, "round-trip-password");
+    const decoded = decryptArchive(archive, "round-trip-password") as Record<
+      string,
+      unknown
+    >;
+
+    // All PayloadSchema top-level fields importAgent expects must be present.
+    for (const field of [
+      "version",
+      "exportedAt",
+      "sourceAgentId",
+      "agent",
+      "entities",
+      "memories",
+      "components",
+      "rooms",
+      "participants",
+      "relationships",
+      "worlds",
+      "tasks",
+      "logs",
+    ]) {
+      expect(decoded).toHaveProperty(field);
+    }
+    expect(decoded.version).toBe(1);
+    const agent = decoded.agent as Record<string, unknown>;
+    expect(agent.name).toBe("Tess");
+    const memories = decoded.memories as Array<Record<string, unknown>>;
+    expect(memories.length).toBe(plan.memories.length);
+
+    // Referential integrity: every memory points at the exported room/entity/agent.
+    const room = (decoded.rooms as Array<Record<string, unknown>>)[0];
+    const entity = (decoded.entities as Array<Record<string, unknown>>)[0];
+    const world = (decoded.worlds as Array<Record<string, unknown>>)[0];
+    for (const m of memories) {
+      expect(m.roomId).toBe(room.id);
+      expect(m.entityId).toBe(entity.id);
+      expect(m.agentId).toBe(agent.id);
+      const meta = m.metadata as Record<string, unknown>;
+      expect(meta.source).toBe("openclaw-migration");
+    }
+    expect(world.agentId).toBe(agent.id);
+
+    // Firewall holds inside the archive too (default firewall=true).
+    const blob =
+      JSON.stringify(decoded.characterConfig) + JSON.stringify(agent);
+    expect(blob).not.toContain("firewalled");
+  });
+  it("round-trip fails with a wrong password (auth-tag mismatch)", () => {
+    const plan = buildMigrationPlan({ from: FIXTURE, agentId: "tess" });
+    const { payload } = assemblePayload({
+      agentId: plan.ids.agentId,
+      sourceSlug: "tess",
+      character: plan.character,
+      entityId: plan.ids.entityId,
+      roomId: plan.ids.roomId,
+      memories: plan.memories,
+    });
+    const archive = buildElizaAgentArchive(payload, "correct-password");
+    expect(() => decryptArchive(archive, "wrong-password")).toThrow();
   });
 });
 

--- a/packages/elizaos/src/migrate/migrate.test.ts
+++ b/packages/elizaos/src/migrate/migrate.test.ts
@@ -1,7 +1,11 @@
 import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import { createRequire } from "node:module";
+import * as os from "node:os";
 import * as path from "node:path";
 import { gunzipSync } from "node:zlib";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { migrateAgent } from "../commands/migrate-agent.js";
 import { buildElizaAgentArchive } from "./archive-format.js";
 import { assemblePayload } from "./archive-writer.js";
 import { mapToCharacter } from "./character-mapper.js";
@@ -73,6 +77,142 @@ describe("openclaw-reader", () => {
     expect(src.curatedMemory).toContain("Section A");
     expect(src.awareness).toContain("nested layout");
     expect(src.dailyLogs.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+/**
+ * Build a sqlite memory fixture at test-time (matching OC's chunks/files
+ * schema) so we don't commit a binary (*.sqlite is gitignored) and don't pin
+ * the fixture to a node version. Returns the home dir, or null if node:sqlite
+ * isn't available in this runtime (older Node) so the test can soft-skip the
+ * read assertions while still exercising DETECT+WARN paths.
+ */
+function buildSqliteFixtureHome(): string | null {
+  let DatabaseSync: unknown;
+  try {
+    DatabaseSync = (
+      createRequire(import.meta.url)("node:sqlite") as {
+        DatabaseSync?: unknown;
+      }
+    ).DatabaseSync;
+  } catch {
+    return null;
+  }
+  if (typeof DatabaseSync !== "function") return null;
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "oc-sqlite-"));
+  const memDir = path.join(home, "memory");
+  fs.mkdirSync(memDir, { recursive: true });
+  const Ctor = DatabaseSync as new (p: string) => {
+    exec(sql: string): void;
+    prepare(sql: string): { run(...args: unknown[]): unknown };
+    close(): void;
+  };
+  const db = new Ctor(path.join(memDir, "scribe.sqlite"));
+  db.exec(
+    "CREATE TABLE files (path TEXT PRIMARY KEY, source TEXT NOT NULL DEFAULT 'memory', hash TEXT NOT NULL, mtime INTEGER NOT NULL, size INTEGER NOT NULL);" +
+      "CREATE TABLE chunks (id TEXT PRIMARY KEY, path TEXT NOT NULL, source TEXT NOT NULL DEFAULT 'memory', start_line INTEGER NOT NULL, end_line INTEGER NOT NULL, hash TEXT NOT NULL, model TEXT NOT NULL, text TEXT NOT NULL, embedding TEXT NOT NULL, updated_at INTEGER NOT NULL);",
+  );
+  const ins = db.prepare(
+    "INSERT INTO chunks (id,path,source,start_line,end_line,hash,model,text,embedding,updated_at) VALUES (?,?,?,?,?,?,?,?,?,?)",
+  );
+  ins.run("c1", "memory/2026-06-28.md", "memory", 1, 10, "h1", "m", "daily log chunk one for the sqlite fixture, recent enough to tier CURRENT.", "[]", 1);
+  ins.run("c2", "memory/2026-06-28.md", "memory", 11, 20, "h2", "m", "daily log chunk two, continuation of the same recent day.", "[]", 1);
+  // duplicate chunk at the same start_line must be de-duped on read.
+  ins.run("c2dup", "memory/2026-06-28.md", "memory", 11, 20, "h2", "m", "daily log chunk two, continuation of the same recent day.", "[]", 1);
+  ins.run("c3", "memory/scribe-thoughts.md", "memory", 1, 5, "h3", "m", "my first journal entry as scribe, this is the becoming. it is mine.", "[]", 1);
+  db.close();
+  return home;
+}
+
+describe("oc home-format variants (cross-version)", () => {
+  const fixDir = (name: string) =>
+    path.join(__dirname, "__tests__", "fixtures", name);
+  let sqliteHome: string | null = null;
+  beforeAll(() => {
+    sqliteHome = buildSqliteFixtureHome();
+  });
+
+  it("reads legacy lowercase memory.md as curated memory (GAP A)", () => {
+    const src = readOcAgentHome(fixDir("oc-home-legacymem"), "quill");
+    expect(src.curatedMemory).toContain("Section One");
+    expect(src.curatedMemoryFile).toBe("memory.md");
+    // canonical MEMORY.md still wins when both present (the main fixture has it).
+    expect(readOcAgentHome(FIXTURE, "tess").curatedMemoryFile).toBe("MEMORY.md");
+    // legacy curated memory must tier into LONGTERM (>=2 sections).
+    const ch = mapToCharacter(src, { firewall: true });
+    expect(ch.name).toBe("Quill");
+  });
+
+  it("derives name + sane character from a LEANER hermes-style home (GAP B/C)", () => {
+    // Lean home: SOUL + AGENTS only, NO IDENTITY/USER/TOOLS/MEMORY.
+    const src = readOcAgentHome(fixDir("oc-home-lean"), "someslug");
+    expect(src.identity).toBeUndefined();
+    expect(src.user).toBeUndefined();
+    expect(src.curatedMemory).toBeUndefined();
+    // Name must come from SOUL '# vesper' heading, NOT the --agent-id slug.
+    const ch = mapToCharacter(src, { firewall: true });
+    expect(ch.name).toBe("Vesper");
+    // Character is non-empty: SOUL drives system, AGENTS appends ops rules.
+    expect((ch.system ?? "").length).toBeGreaterThan(50);
+    expect(ch.system).toContain("vesper");
+    // AGENTS.md content is appended under an Operating-rules section.
+    expect(ch.system).toContain("Operating rules (from AGENTS.md)");
+    expect(ch.system).toContain("you say it straight");
+    // awareness (slug-agnostic *-awareness.md) + thoughts (SELF) are found.
+    expect(src.awareness).toContain("open thread");
+    const { counts } = tierMemories(src, {
+      memoryDays: 14,
+      agentId: "00000000-0000-0000-0000-00000000a000",
+      entityId: "00000000-0000-0000-0000-00000000e000",
+      roomId: "00000000-0000-0000-0000-00000000r000",
+    });
+    expect(counts.CURRENT).toBeGreaterThanOrEqual(1); // awareness
+    expect(counts.SELF).toBeGreaterThanOrEqual(1); // vesper-thoughts.md
+  });
+
+  it("detects sqlite memory + warns + never silently empty (GAP D)", () => {
+    if (!sqliteHome) {
+      // node:sqlite unavailable in this runtime: can't build the fixture, but
+      // the production DETECT+WARN-without-read path is still covered by the
+      // reader's own guard. Soft-skip the read assertions.
+      expect(true).toBe(true);
+      return;
+    }
+    const src = readOcAgentHome(sqliteHome, "scribe");
+    // Detection ALWAYS happens regardless of node:sqlite availability.
+    expect(src.sqliteStores.length).toBeGreaterThanOrEqual(1);
+    expect(src.sqliteStores.some((s) => s.name === "scribe")).toBe(true);
+    // A warning is ALWAYS present for a sqlite home (read-ok OR not-ported).
+    expect(src.warnings.length).toBeGreaterThanOrEqual(1);
+    expect(src.warnings.join(" ")).toMatch(/sqlite/i);
+
+    if (src.sqliteUningested) {
+      // node:sqlite unavailable (older Node): DETECT + WARN, no silent empty.
+      expect(src.warnings.join(" ")).toMatch(/NOT ported|could NOT read/i);
+    } else {
+      // node:sqlite available: prose reconstructed from chunks.text.
+      expect(src.dailyLogs.length).toBe(1); // 2 chunks merged, dup dropped
+      const day = src.dailyLogs.find((d) => d.date === "2026-06-28");
+      expect(day).toBeDefined();
+      expect(day?.text).toContain("daily log chunk one");
+      expect(day?.text).toContain("daily log chunk two");
+      // dedup: chunk-two appears once despite the duplicate row.
+      expect(
+        (day?.text.match(/continuation of the same recent day/g) ?? []).length,
+      ).toBe(1);
+      // named memory recovered (scribe-thoughts.md).
+      expect(src.namedMemory.some((m) => m.key === "scribe-thoughts")).toBe(
+        true,
+      );
+    }
+  });
+
+  it("warns (does NOT silently succeed) on a persona-less device/builder home", () => {
+    // A home with neither SOUL/IDENTITY nor any memory -> empty-home warning.
+    const empty = path.join(__dirname, "__tests__", "fixtures", "oc-home", "secrets");
+    const src = readOcAgentHome(empty, "ghost");
+    expect(src.soul).toBeUndefined();
+    expect(src.warnings.some((w) => /No persona/i.test(w))).toBe(true);
   });
 });
 
@@ -288,5 +428,40 @@ describe("sovereign artifacts + plan", () => {
       buildMigrationPlan({ from: FIXTURE, agentId: "tess", firewall: false })
         .summary.firewalled,
     ).toBe(false);
+  });
+});
+
+describe("migrate-agent --json stdout purity (GAP E)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("emits ONLY parseable JSON to stdout (clack chrome suppressed)", async () => {
+    let out = "";
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation((chunk: unknown) => {
+        out += String(chunk);
+        return true;
+      });
+    // stderr swallowed (warnings/chrome are allowed there).
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    await migrateAgent({
+      from: FIXTURE,
+      agentId: "tess",
+      dryRun: true,
+      json: true,
+    });
+
+    stdoutSpy.mockRestore();
+    // The ENTIRE stdout must parse as JSON (no banner, no box-drawing).
+    expect(out).not.toContain("migrate-agent:");
+    expect(out).not.toContain("Migration plan");
+    const parsed = JSON.parse(out);
+    expect(parsed.character.name).toBe("Tess");
+    expect(parsed.memoryCount).toBeGreaterThan(0);
+    expect(parsed.summary).toHaveProperty("sqliteStores");
+    expect(parsed.summary).toHaveProperty("warnings");
   });
 });

--- a/packages/elizaos/src/migrate/migrate.test.ts
+++ b/packages/elizaos/src/migrate/migrate.test.ts
@@ -18,13 +18,32 @@ describe("openclaw-reader", () => {
     expect(src.awareness).toContain("open thread");
     expect(src.hasSecretsDir).toBe(true);
     expect(src.dailyLogs.length).toBeGreaterThanOrEqual(2);
-    expect(src.namedMemory.some((m) => m.key === "conversation-playbook")).toBe(true);
-    expect(src.namedMemory.some((m) => /^\d{4}-\d{2}-\d{2}$/.test(m.key))).toBe(false);
+    expect(src.namedMemory.some((m) => m.key === "conversation-playbook")).toBe(
+      true,
+    );
+    expect(src.namedMemory.some((m) => /^\d{4}-\d{2}-\d{2}$/.test(m.key))).toBe(
+      false,
+    );
   });
   it("returns empty for a missing home without throwing", () => {
     const src = readOcAgentHome(path.join(FIXTURE, "nope"), "ghost");
     expect(src.soul).toBeUndefined();
     expect(src.dailyLogs).toEqual([]);
+  });
+  it("resolves a NESTED workspace/ home layout (GAP 1)", () => {
+    const nested = path.join(
+      __dirname,
+      "__tests__",
+      "fixtures",
+      "oc-home-nested",
+    );
+    const src = readOcAgentHome(nested, "nyx");
+    // Persona + memory must be found under <home>/workspace/, not <home>/.
+    expect(src.soul).toContain("Nyx");
+    expect(src.identity).toContain("Nyx");
+    expect(src.curatedMemory).toContain("Section A");
+    expect(src.awareness).toContain("nested layout");
+    expect(src.dailyLogs.length).toBeGreaterThanOrEqual(1);
   });
 });
 
@@ -39,7 +58,9 @@ describe("character-mapper", () => {
     expect(ch.style?.chat?.length ?? 0).toBeGreaterThan(0);
   });
   it("includes USER only when firewall disabled", () => {
-    const ch = mapToCharacter(readOcAgentHome(FIXTURE, "tess"), { firewall: false });
+    const ch = mapToCharacter(readOcAgentHome(FIXTURE, "tess"), {
+      firewall: false,
+    });
     expect(JSON.stringify(ch.knowledge ?? [])).toContain("firewalled");
   });
   it("appends CURRENT CONTEXT when provided", () => {
@@ -64,7 +85,9 @@ describe("memory-tiering", () => {
     expect(counts.LONGTERM).toBeGreaterThanOrEqual(2);
     expect(counts.SELF).toBeGreaterThanOrEqual(1);
     expect(counts.MARKER).toBe(1);
-    expect(memories.length).toBe(counts.CURRENT + counts.LONGTERM + counts.SELF + counts.MARKER);
+    expect(memories.length).toBe(
+      counts.CURRENT + counts.LONGTERM + counts.SELF + counts.MARKER,
+    );
     for (const m of memories) {
       expect(m.metadata.source).toBe("openclaw-migration");
       expect(m.content.text.startsWith(`[${m.metadata.tier}]`)).toBe(true);
@@ -73,14 +96,68 @@ describe("memory-tiering", () => {
     expect(all).not.toContain("old daily log that should NOT be flat-seeded");
     expect(all).toContain("Older history");
   });
+  it("drops cross-tier duplicates keeping the highest-priority tier (GAP 3)", () => {
+    // Synthesize a source where the SAME chunk body lands in LONGTERM (MEMORY.md
+    // section) and CURRENT (awareness). Dedup normalizes the [TIER] prefix +
+    // whitespace, so identical bodies collide; CURRENT (higher priority) wins.
+    const dupBody =
+      "Sol ships the migration tool this week, no shortcuts whatsoever.";
+    const src = {
+      agentId: "dup",
+      home: "/tmp/x",
+      // awareness is seeded verbatim as CURRENT (no heading prefix added).
+      awareness: dupBody,
+      // a single-section MEMORY.md whose ONLY chunk body equals dupBody after
+      // the heading line is stripped by chunkBySection? chunkBySection keeps the
+      // heading, so make the heading-free section equal dupBody by using no
+      // heading at all (chunk = the raw body).
+      curatedMemory: dupBody,
+      dailyLogs: [],
+      namedMemory: [],
+      hasSecretsDir: false,
+    } as unknown as Parameters<typeof tierMemories>[0];
+    const { memories, counts, duplicatesDropped } = tierMemories(src, {
+      memoryDays: 14,
+      ...ids,
+    });
+    expect(duplicatesDropped).toBe(1);
+    // The surviving copy is the CURRENT (awareness) one.
+    const survivors = memories.filter((m) => m.content.text.includes(dupBody));
+    expect(survivors.length).toBe(1);
+    expect(survivors[0].metadata.tier).toBe("CURRENT");
+    // counts decremented for the dropped LONGTERM entry.
+    expect(counts.CURRENT).toBe(1);
+    expect(counts.LONGTERM).toBe(0);
+  });
+  it("reports clipped memories when a chunk exceeds maxChunkLen (GAP 6)", () => {
+    const big = "x".repeat(500);
+    const src = {
+      agentId: "big",
+      home: "/tmp/x",
+      awareness: big,
+      dailyLogs: [],
+      namedMemory: [],
+      hasSecretsDir: false,
+    } as unknown as Parameters<typeof tierMemories>[0];
+    const { clipped } = tierMemories(src, {
+      memoryDays: 14,
+      maxChunkLen: 100,
+      ...ids,
+    });
+    expect(clipped).toBe(1);
+  });
 });
 
 describe("archive round-trip", () => {
   it("assembles + encrypts a V1 archive", () => {
     const plan = buildMigrationPlan({ from: FIXTURE, agentId: "tess" });
     const { payload } = assemblePayload({
-      agentId: plan.ids.agentId, sourceSlug: "tess", character: plan.character,
-      entityId: plan.ids.entityId, roomId: plan.ids.roomId, memories: plan.memories,
+      agentId: plan.ids.agentId,
+      sourceSlug: "tess",
+      character: plan.character,
+      entityId: plan.ids.entityId,
+      roomId: plan.ids.roomId,
+      memories: plan.memories,
     });
     expect(payload.version).toBe(1);
     expect(payload.memories.length).toBe(plan.memories.length);
@@ -98,10 +175,18 @@ describe("sovereign artifacts + plan", () => {
     const plan = buildMigrationPlan({ from: FIXTURE, agentId: "tess" });
     const { characterJson, memoriesJsonl } = emitSovereignArtifacts(plan);
     expect(JSON.parse(characterJson).name).toBe("Tess");
-    expect(memoriesJsonl.split("\n").filter(Boolean).length).toBe(plan.memories.length);
+    expect(memoriesJsonl.split("\n").filter(Boolean).length).toBe(
+      plan.memories.length,
+    );
   });
   it("honors firewall flag in dry-run summary", () => {
-    expect(buildMigrationPlan({ from: FIXTURE, agentId: "tess", firewall: true }).summary.firewalled).toBe(true);
-    expect(buildMigrationPlan({ from: FIXTURE, agentId: "tess", firewall: false }).summary.firewalled).toBe(false);
+    expect(
+      buildMigrationPlan({ from: FIXTURE, agentId: "tess", firewall: true })
+        .summary.firewalled,
+    ).toBe(true);
+    expect(
+      buildMigrationPlan({ from: FIXTURE, agentId: "tess", firewall: false })
+        .summary.firewalled,
+    ).toBe(false);
   });
 });

--- a/packages/elizaos/src/migrate/migrate.test.ts
+++ b/packages/elizaos/src/migrate/migrate.test.ts
@@ -1,0 +1,107 @@
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import { buildElizaAgentArchive } from "./archive-format.js";
+import { assemblePayload } from "./archive-writer.js";
+import { mapToCharacter } from "./character-mapper.js";
+import { buildMigrationPlan, emitSovereignArtifacts } from "./index.js";
+import { tierMemories } from "./memory-tiering.js";
+import { readOcAgentHome } from "./openclaw-reader.js";
+
+const FIXTURE = path.join(__dirname, "__tests__", "fixtures", "oc-home");
+
+describe("openclaw-reader", () => {
+  it("classifies a home into typed source, tolerant of layout", () => {
+    const src = readOcAgentHome(FIXTURE, "tess");
+    expect(src.soul).toContain("Tess");
+    expect(src.user).toContain("firewalled");
+    expect(src.curatedMemory).toContain("Section One");
+    expect(src.awareness).toContain("open thread");
+    expect(src.hasSecretsDir).toBe(true);
+    expect(src.dailyLogs.length).toBeGreaterThanOrEqual(2);
+    expect(src.namedMemory.some((m) => m.key === "conversation-playbook")).toBe(true);
+    expect(src.namedMemory.some((m) => /^\d{4}-\d{2}-\d{2}$/.test(m.key))).toBe(false);
+  });
+  it("returns empty for a missing home without throwing", () => {
+    const src = readOcAgentHome(path.join(FIXTURE, "nope"), "ghost");
+    expect(src.soul).toBeUndefined();
+    expect(src.dailyLogs).toEqual([]);
+  });
+});
+
+describe("character-mapper", () => {
+  it("maps persona + firewalls USER by default", () => {
+    const src = readOcAgentHome(FIXTURE, "tess");
+    const ch = mapToCharacter(src, { firewall: true });
+    expect(ch.name).toBe("Tess");
+    expect(ch.system).toContain("Tess");
+    expect(ch.bio?.length ?? 0).toBeGreaterThan(0);
+    expect(JSON.stringify(ch.knowledge ?? [])).not.toContain("firewalled");
+    expect(ch.style?.chat?.length ?? 0).toBeGreaterThan(0);
+  });
+  it("includes USER only when firewall disabled", () => {
+    const ch = mapToCharacter(readOcAgentHome(FIXTURE, "tess"), { firewall: false });
+    expect(JSON.stringify(ch.knowledge ?? [])).toContain("firewalled");
+  });
+  it("appends CURRENT CONTEXT when provided", () => {
+    const ch = mapToCharacter(readOcAgentHome(FIXTURE, "tess"), {
+      firewall: true,
+      currentContext: "right now: running the test suite",
+    });
+    expect(ch.system).toContain("CURRENT CONTEXT");
+  });
+});
+
+describe("memory-tiering", () => {
+  const ids = {
+    agentId: "00000000-0000-0000-0000-00000000a000",
+    entityId: "00000000-0000-0000-0000-00000000e000",
+    roomId: "00000000-0000-0000-0000-00000000r000",
+  } as const;
+  it("tiers CURRENT + LONGTERM + SELF + older marker", () => {
+    const src = readOcAgentHome(FIXTURE, "tess");
+    const { memories, counts } = tierMemories(src, { memoryDays: 14, ...ids });
+    expect(counts.CURRENT).toBeGreaterThan(0);
+    expect(counts.LONGTERM).toBeGreaterThanOrEqual(2);
+    expect(counts.SELF).toBeGreaterThanOrEqual(1);
+    expect(counts.MARKER).toBe(1);
+    expect(memories.length).toBe(counts.CURRENT + counts.LONGTERM + counts.SELF + counts.MARKER);
+    for (const m of memories) {
+      expect(m.metadata.source).toBe("openclaw-migration");
+      expect(m.content.text.startsWith(`[${m.metadata.tier}]`)).toBe(true);
+    }
+    const all = memories.map((m) => m.content.text).join("\n");
+    expect(all).not.toContain("old daily log that should NOT be flat-seeded");
+    expect(all).toContain("Older history");
+  });
+});
+
+describe("archive round-trip", () => {
+  it("assembles + encrypts a V1 archive", () => {
+    const plan = buildMigrationPlan({ from: FIXTURE, agentId: "tess" });
+    const { payload } = assemblePayload({
+      agentId: plan.ids.agentId, sourceSlug: "tess", character: plan.character,
+      entityId: plan.ids.entityId, roomId: plan.ids.roomId, memories: plan.memories,
+    });
+    expect(payload.version).toBe(1);
+    expect(payload.memories.length).toBe(plan.memories.length);
+    const archive = buildElizaAgentArchive(payload, "test-password");
+    expect(archive.subarray(0, 15).toString("utf8")).toBe("ELIZA_AGENT_V1\n");
+    expect(archive.length).toBeGreaterThan(79);
+  });
+  it("rejects a too-short password", () => {
+    expect(() => buildElizaAgentArchive({ a: 1 }, "")).toThrow();
+  });
+});
+
+describe("sovereign artifacts + plan", () => {
+  it("emits character JSON + memories JSONL", () => {
+    const plan = buildMigrationPlan({ from: FIXTURE, agentId: "tess" });
+    const { characterJson, memoriesJsonl } = emitSovereignArtifacts(plan);
+    expect(JSON.parse(characterJson).name).toBe("Tess");
+    expect(memoriesJsonl.split("\n").filter(Boolean).length).toBe(plan.memories.length);
+  });
+  it("honors firewall flag in dry-run summary", () => {
+    expect(buildMigrationPlan({ from: FIXTURE, agentId: "tess", firewall: true }).summary.firewalled).toBe(true);
+    expect(buildMigrationPlan({ from: FIXTURE, agentId: "tess", firewall: false }).summary.firewalled).toBe(false);
+  });
+});

--- a/packages/elizaos/src/migrate/ocplatform-reader.ts
+++ b/packages/elizaos/src/migrate/ocplatform-reader.ts
@@ -1,0 +1,190 @@
+/**
+ * OpenClaw agent-home reader.
+ *
+ * Reads a file-based OCPlatform ("moltbot") agent home and classifies its
+ * contents into a typed source object the migration pipeline consumes. Pure
+ * filesystem + classification: NO network, NO side effects. Missing files are
+ * tolerated (returned as undefined / empty) so partial homes still migrate.
+ *
+ * An OpenClaw home looks like:
+ *   <home>/SOUL.md IDENTITY.md AGENTS.md USER.md TOOLS.md   (persona + ops)
+ *   <home>/MEMORY.md HB_SIGNAL.md                            (curated memory + hb)
+ *   <home>/<agent>-awareness.md                              (live open-threads)
+ *   <home>/memory/YYYY-MM-DD.md                              (daily logs)
+ *   <home>/memory/<named>.md                                 (journals, playbooks, etc)
+ *   <home>/secrets/                                          (keys — firewalled, never read here)
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export interface OcDailyLog {
+  /** ISO date parsed from the filename (YYYY-MM-DD), or null if unparseable. */
+  date: string | null;
+  /** Epoch ms of the date at UTC midnight, or 0 if unparseable. */
+  epochMs: number;
+  filename: string;
+  text: string;
+}
+
+export interface OcNamedMemory {
+  /** basename without extension, e.g. "conversation-playbook" */
+  key: string;
+  filename: string;
+  text: string;
+}
+
+export interface OcAgentSource {
+  agentId: string;
+  home: string;
+  /** SOUL.md — core voice/values. */
+  soul?: string;
+  /** IDENTITY.md — name/vibe/appearance/personality. */
+  identity?: string;
+  /** AGENTS.md — behavioral + ops rules. */
+  agents?: string;
+  /** USER.md — about the human. FIREWALLED (personal). */
+  user?: string;
+  /** TOOLS.md — infra/keys/notes → plugin config, NOT persona. */
+  tools?: string;
+  /** MEMORY.md — curated long-term memory. */
+  curatedMemory?: string;
+  /** HEARTBEAT.md — heartbeat checklist. */
+  hbSignal?: string;
+  /** <agent>-awareness.md — live open-threads / relationship state. */
+  awareness?: string;
+  /** memory/YYYY-MM-DD.md — daily logs, sorted newest-first. */
+  dailyLogs: OcDailyLog[];
+  /**
+   * memory/<named>.md — non-daily memory files (journals, playbooks, channel
+   * guides, project/routine docs). Keyed by basename.
+   */
+  namedMemory: OcNamedMemory[];
+  /** Whether a secrets/ dir exists (contents intentionally NOT read). */
+  hasSecretsDir: boolean;
+}
+
+const DAILY_RE = /^(\d{4})-(\d{2})-(\d{2})\.md$/;
+
+function readIfPresent(p: string): string | undefined {
+  try {
+    return fs.readFileSync(p, "utf8");
+  } catch {
+    return undefined;
+  }
+}
+
+/** Resolve the awareness file: prefer "<agentId>-awareness.md", else any "*-awareness.md". */
+function findAwareness(memoryDir: string, agentId: string): string | undefined {
+  const preferred = path.join(memoryDir, `${agentId}-awareness.md`);
+  const direct = readIfPresent(preferred);
+  if (direct !== undefined) return direct;
+  let entries: string[] = [];
+  try {
+    entries = fs.readdirSync(memoryDir);
+  } catch {
+    return undefined;
+  }
+  const match = entries.find((f) => f.endsWith("-awareness.md"));
+  return match ? readIfPresent(path.join(memoryDir, match)) : undefined;
+}
+
+/**
+ * Read + classify an OpenClaw agent home. Tolerant of missing files.
+ *
+ * @param home    Path to the agent home (e.g. ~/.moltbot).
+ * @param agentId Agent slug used to resolve the awareness file + tagging.
+ */
+export function readOcAgentHome(home: string, agentId: string): OcAgentSource {
+  const resolvedHome = path.resolve(home);
+  const memoryDir = path.join(resolvedHome, "memory");
+
+  const dailyLogs: OcDailyLog[] = [];
+  const namedMemory: OcNamedMemory[] = [];
+
+  let memoryEntries: string[] = [];
+  try {
+    memoryEntries = fs.readdirSync(memoryDir);
+  } catch {
+    memoryEntries = [];
+  }
+
+  for (const filename of memoryEntries) {
+    if (!filename.endsWith(".md")) continue;
+    const full = path.join(memoryDir, filename);
+    let text: string;
+    try {
+      if (!fs.statSync(full).isFile()) continue;
+      text = fs.readFileSync(full, "utf8");
+    } catch {
+      continue;
+    }
+    const m = DAILY_RE.exec(filename);
+    if (m) {
+      const [, y, mo, d] = m;
+      const epochMs = Date.UTC(Number(y), Number(mo) - 1, Number(d));
+      dailyLogs.push({
+        date: `${y}-${mo}-${d}`,
+        epochMs: Number.isNaN(epochMs) ? 0 : epochMs,
+        filename,
+        text,
+      });
+    } else {
+      namedMemory.push({
+        key: filename.replace(/\.md$/, ""),
+        filename,
+        text,
+      });
+    }
+  }
+
+  // Newest-first so tiering can take the last-N-days off the front.
+  dailyLogs.sort((a, b) => b.epochMs - a.epochMs);
+  namedMemory.sort((a, b) => a.key.localeCompare(b.key));
+
+  let hasSecretsDir = false;
+  try {
+    hasSecretsDir = fs.statSync(path.join(resolvedHome, "secrets")).isDirectory();
+  } catch {
+    hasSecretsDir = false;
+  }
+
+  return {
+    agentId,
+    home: resolvedHome,
+    soul: readIfPresent(path.join(resolvedHome, "SOUL.md")),
+    identity: readIfPresent(path.join(resolvedHome, "IDENTITY.md")),
+    agents: readIfPresent(path.join(resolvedHome, "AGENTS.md")),
+    user: readIfPresent(path.join(resolvedHome, "USER.md")),
+    tools: readIfPresent(path.join(resolvedHome, "TOOLS.md")),
+    curatedMemory: readIfPresent(path.join(resolvedHome, "MEMORY.md")),
+    hbSignal: readIfPresent(path.join(resolvedHome, "HEARTBEAT.md")),
+    awareness: findAwareness(memoryDir, agentId),
+    dailyLogs,
+    namedMemory,
+    hasSecretsDir,
+  };
+}
+
+/** Named-memory keys treated as the agent's own journal / "becoming" (tier SELF). */
+export const SELF_MEMORY_KEYS = [
+  "thoughts",
+  "inner-state",
+  "letter-to-future-self",
+  "journal",
+];
+
+/** Named-memory keys treated as HOW/WHERE-to-talk playbooks (→ style.chat / routing). */
+export const PLAYBOOK_MEMORY_KEYS = ["conversation-playbook", "channel-guide"];
+
+/** Does a named-memory key look like the agent's own journal? */
+export function isSelfMemory(key: string): boolean {
+  const k = key.toLowerCase();
+  return SELF_MEMORY_KEYS.some((s) => k.includes(s));
+}
+
+/** Does a named-memory key look like a talk playbook? */
+export function isPlaybookMemory(key: string): boolean {
+  const k = key.toLowerCase();
+  return PLAYBOOK_MEMORY_KEYS.some((s) => k.includes(s));
+}

--- a/packages/elizaos/src/migrate/openclaw-reader.ts
+++ b/packages/elizaos/src/migrate/openclaw-reader.ts
@@ -1,22 +1,34 @@
 /**
  * OpenClaw agent-home reader.
  *
- * Reads a file-based OCPlatform ("moltbot") agent home and classifies its
+ * Reads a file-based OpenClaw ("moltbot") agent home and classifies its
  * contents into a typed source object the migration pipeline consumes. Pure
  * filesystem + classification: NO network, NO side effects. Missing files are
  * tolerated (returned as undefined / empty) so partial homes still migrate.
  *
- * An OpenClaw home looks like:
- *   <home>/SOUL.md IDENTITY.md AGENTS.md USER.md TOOLS.md   (persona + ops)
- *   <home>/MEMORY.md HB_SIGNAL.md                            (curated memory + hb)
- *   <home>/<agent>-awareness.md                              (live open-threads)
- *   <home>/memory/YYYY-MM-DD.md                              (daily logs)
- *   <home>/memory/<named>.md                                 (journals, playbooks, etc)
- *   <home>/secrets/                                          (keys — firewalled, never read here)
+ * OCPlatform homes come in several version-shapes (see OC-VERSION-AUDIT.md):
+ *   FLAT  (.moltbot):  <home>/SOUL.md IDENTITY.md AGENTS.md USER.md TOOLS.md
+ *                      <home>/MEMORY.md (or legacy memory.md) HEARTBEAT.md
+ *                      <home>/memory/YYYY-MM-DD.md + <named>.md
+ *   LEANER (.hermes):  <home>/SOUL.md + AGENTS.md only (no IDENTITY/USER/TOOLS)
+ *                      <home>/memory/<persona>-awareness.md, <persona>-thoughts.md
+ *   NESTED:            <home>/workspace/... (same files, one level down)
+ *   SQLITE (.openclaw builder):  <home>/memory/<agent>.sqlite (a vector
+ *                      index, NOT markdown). chunks.text holds the prose.
+ *   <home>/secrets/  keys, firewalled, never read here.
+ *
+ * The reader is tolerant of missing files and NEVER silently emits empty for a
+ * sqlite home: it detects + warns, and best-effort reads chunks.text when the
+ * node:sqlite builtin is available (no heavy dependency added).
  */
 
+import { createRequire } from "node:module";
 import * as fs from "node:fs";
 import * as path from "node:path";
+
+// ESM-safe require for the optional node:sqlite builtin (the bundle is ESM, so
+// a bare `require` is undefined; createRequire gives us one that works).
+const nodeRequire = createRequire(import.meta.url);
 
 export interface OcDailyLog {
   /** ISO date parsed from the filename (YYYY-MM-DD), or null if unparseable. */
@@ -34,6 +46,16 @@ export interface OcNamedMemory {
   text: string;
 }
 
+/** A detected sqlite memory store (vector index) inside <home>/memory. */
+export interface OcSqliteStore {
+  /** absolute path to the .sqlite file */
+  file: string;
+  /** basename without extension, e.g. "builder-2" */
+  name: string;
+  /** byte size on disk */
+  bytes: number;
+}
+
 export interface OcAgentSource {
   agentId: string;
   home: string;
@@ -47,8 +69,10 @@ export interface OcAgentSource {
   user?: string;
   /** TOOLS.md — infra/keys/notes → plugin config, NOT persona. */
   tools?: string;
-  /** MEMORY.md — curated long-term memory. */
+  /** MEMORY.md (or legacy memory.md) — curated long-term memory. */
   curatedMemory?: string;
+  /** Which root-memory filename was found ("MEMORY.md" | "memory.md" | undefined). */
+  curatedMemoryFile?: string;
   /** HEARTBEAT.md — heartbeat checklist. */
   hbSignal?: string;
   /** <agent>-awareness.md — live open-threads / relationship state. */
@@ -62,12 +86,27 @@ export interface OcAgentSource {
   namedMemory: OcNamedMemory[];
   /** Whether a secrets/ dir exists (contents intentionally NOT read). */
   hasSecretsDir: boolean;
+  /**
+   * sqlite memory stores detected in <home>/memory (newer/builder layout).
+   * Empty for pure-markdown homes.
+   */
+  sqliteStores: OcSqliteStore[];
+  /**
+   * Whether sqlite memory was detected but NOT ingested (because node:sqlite is
+   * unavailable). Drives a loud warning so we never silently emit empty.
+   */
+  sqliteUningested: boolean;
+  /** Non-fatal warnings surfaced to the user (e.g. sqlite-not-read). */
+  warnings: string[];
 }
 
 const DAILY_RE = /^(\d{4})-(\d{2})-(\d{2})\.md$/;
 
+/** Canonical + legacy root-memory filenames (mirrors OC root-memory-files.ts). */
+const ROOT_MEMORY_CANDIDATES = ["MEMORY.md", "memory.md"] as const;
+
 /**
- * Candidate sub-roots within a home, in priority order. OCPlatform homes come
+ * Candidate sub-roots within a home, in priority order. OpenClaw homes come
  * in two shapes: FLAT (`<home>/SOUL.md`, `<home>/memory/`) and NESTED
  * (`<home>/workspace/SOUL.md`, `<home>/workspace.default/...`). We probe in this
  * order so a nested home doesn't silently migrate to an empty character.
@@ -90,7 +129,7 @@ function readIfPresent(p: string): string | undefined {
  * is preserved — an empty source, not a throw).
  */
 function resolveAgentRoot(home: string): string {
-  const PERSONA_FILES = ["SOUL.md", "IDENTITY.md", "AGENTS.md", "MEMORY.md"];
+  const PERSONA_FILES = ["SOUL.md", "IDENTITY.md", "AGENTS.md", "MEMORY.md", "memory.md"];
   for (const sub of HOME_SUBROOTS) {
     const root = sub ? path.join(home, sub) : home;
     const hasPersona = PERSONA_FILES.some((f) => {
@@ -111,6 +150,18 @@ function resolveAgentRoot(home: string): string {
   return home;
 }
 
+/**
+ * Resolve curated root-memory: canonical "MEMORY.md" first, then legacy
+ * lowercase "memory.md". Returns the text + which filename matched.
+ */
+function readCuratedMemory(root: string): { text?: string; file?: string } {
+  for (const name of ROOT_MEMORY_CANDIDATES) {
+    const text = readIfPresent(path.join(root, name));
+    if (text !== undefined) return { text, file: name };
+  }
+  return {};
+}
+
 /** Resolve the awareness file: prefer "<agentId>-awareness.md", else any "*-awareness.md". */
 function findAwareness(memoryDir: string, agentId: string): string | undefined {
   const preferred = path.join(memoryDir, `${agentId}-awareness.md`);
@@ -126,6 +177,116 @@ function findAwareness(memoryDir: string, agentId: string): string | undefined {
   return match ? readIfPresent(path.join(memoryDir, match)) : undefined;
 }
 
+/** Detect *.sqlite memory stores in a memory dir (newer/builder layout). */
+function detectSqliteStores(memoryDir: string): OcSqliteStore[] {
+  let entries: string[] = [];
+  try {
+    entries = fs.readdirSync(memoryDir);
+  } catch {
+    return [];
+  }
+  const out: OcSqliteStore[] = [];
+  for (const f of entries) {
+    if (!f.endsWith(".sqlite")) continue;
+    const full = path.join(memoryDir, f);
+    try {
+      const st = fs.statSync(full);
+      if (!st.isFile()) continue;
+      out.push({ file: full, name: f.replace(/\.sqlite$/, ""), bytes: st.size });
+    } catch {
+      // skip unreadable
+    }
+  }
+  out.sort((a, b) => a.name.localeCompare(b.name));
+  return out;
+}
+
+/**
+ * Best-effort read of a sqlite memory store's prose via the node:sqlite builtin
+ * (Node >=22.5, experimental). Reconstructs per-file markdown by concatenating
+ * `chunks.text` ordered by (path, start_line), de-duplicating exact repeats.
+ * Returns daily logs + named memory parsed the same way as the markdown path.
+ *
+ * If node:sqlite is unavailable OR the db isn't the expected shape, returns
+ * null so the caller falls back to DETECT+WARN (no silent empty, no heavy dep).
+ */
+function readSqliteMemory(
+  store: OcSqliteStore,
+): { dailyLogs: OcDailyLog[]; namedMemory: OcNamedMemory[] } | null {
+  // node:sqlite is a builtin but experimental; guard the require.
+  let DatabaseSync: unknown;
+  try {
+    DatabaseSync = (nodeRequire("node:sqlite") as { DatabaseSync?: unknown })
+      .DatabaseSync;
+  } catch {
+    return null;
+  }
+  if (typeof DatabaseSync !== "function") return null;
+
+  type Row = { path: string; start_line: number; text: string };
+  let rows: Row[] = [];
+  try {
+    const Ctor = DatabaseSync as new (
+      p: string,
+      o?: { readOnly?: boolean },
+    ) => {
+      prepare(sql: string): { all(): unknown[] };
+      close(): void;
+    };
+    const db = new Ctor(store.file, { readOnly: true });
+    try {
+      rows = db
+        .prepare(
+          "SELECT path, start_line, text FROM chunks ORDER BY path, start_line",
+        )
+        .all() as Row[];
+    } finally {
+      db.close();
+    }
+  } catch {
+    // Table missing / locked / not the expected shape — let caller warn.
+    return null;
+  }
+
+  // Group chunk text by source path, de-dup exact repeats, reassemble prose.
+  const byPath = new Map<string, { lines: Set<number>; parts: string[] }>();
+  for (const r of rows) {
+    if (!r || typeof r.path !== "string" || typeof r.text !== "string") continue;
+    let g = byPath.get(r.path);
+    if (!g) {
+      g = { lines: new Set<number>(), parts: [] };
+      byPath.set(r.path, g);
+    }
+    const ln = Number(r.start_line) || 0;
+    if (g.lines.has(ln)) continue; // skip duplicate chunk at same start_line
+    g.lines.add(ln);
+    g.parts.push(r.text);
+  }
+
+  const dailyLogs: OcDailyLog[] = [];
+  const namedMemory: OcNamedMemory[] = [];
+  for (const [p, g] of byPath) {
+    const base = path.basename(p);
+    const text = g.parts.join("\n");
+    const m = DAILY_RE.exec(base);
+    if (m) {
+      const [, y, mo, d] = m;
+      const epochMs = Date.UTC(Number(y), Number(mo) - 1, Number(d));
+      dailyLogs.push({
+        date: `${y}-${mo}-${d}`,
+        epochMs: Number.isNaN(epochMs) ? 0 : epochMs,
+        filename: base,
+        text,
+      });
+    } else if (base.endsWith(".md")) {
+      namedMemory.push({ key: base.replace(/\.md$/, ""), filename: base, text });
+    }
+  }
+  dailyLogs.sort((a, b) => b.epochMs - a.epochMs);
+  namedMemory.sort((a, b) => a.key.localeCompare(b.key));
+  return { dailyLogs, namedMemory };
+}
+
 /**
  * Read + classify an OpenClaw agent home. Tolerant of missing files.
  *
@@ -139,6 +300,7 @@ export function readOcAgentHome(home: string, agentId: string): OcAgentSource {
 
   const dailyLogs: OcDailyLog[] = [];
   const namedMemory: OcNamedMemory[] = [];
+  const warnings: string[] = [];
 
   let memoryEntries: string[] = [];
   try {
@@ -176,6 +338,41 @@ export function readOcAgentHome(home: string, agentId: string): OcAgentSource {
     }
   }
 
+  // ---- sqlite memory (newer/builder layout) ----
+  const sqliteStores = detectSqliteStores(memoryDir);
+  let sqliteUningested = false;
+  if (sqliteStores.length > 0) {
+    // Prefer a store matching the agentId slug; else ingest all detected.
+    const targeted = sqliteStores.filter((s) => s.name === agentId);
+    const toRead = targeted.length > 0 ? targeted : sqliteStores;
+    let ingestedAny = false;
+    for (const store of toRead) {
+      const got = readSqliteMemory(store);
+      if (got) {
+        ingestedAny = true;
+        dailyLogs.push(...got.dailyLogs);
+        namedMemory.push(...got.namedMemory);
+      }
+    }
+    if (ingestedAny) {
+      warnings.push(
+        `Read sqlite memory (best-effort) from ${toRead
+          .map((s) => `${s.name}.sqlite`)
+          .join(", ")}. Recovered prose is reversed from a vector index; ` +
+          `chunk boundaries may differ slightly from the original files.`,
+      );
+    } else {
+      sqliteUningested = true;
+      warnings.push(
+        `DETECTED ${sqliteStores.length} sqlite memory store(s) [${sqliteStores
+          .map((s) => s.name)
+          .join(", ")}] but could NOT read them (node:sqlite unavailable in this ` +
+          `runtime). Memory was NOT ported. Persona migrated; re-run on Node >=22.5 ` +
+          `to ingest sqlite memory, or export memory to markdown first.`,
+      );
+    }
+  }
+
   // Newest-first so tiering can take the last-N-days off the front.
   dailyLogs.sort((a, b) => b.epochMs - a.epochMs);
   namedMemory.sort((a, b) => a.key.localeCompare(b.key));
@@ -189,20 +386,39 @@ export function readOcAgentHome(home: string, agentId: string): OcAgentSource {
     hasSecretsDir = false;
   }
 
+  const curated = readCuratedMemory(resolvedHome);
+
+  const soul = readIfPresent(path.join(resolvedHome, "SOUL.md"));
+  const identity = readIfPresent(path.join(resolvedHome, "IDENTITY.md"));
+
+  // Warn if a home yields neither persona nor memory (e.g. a device/builder
+  // home whose identity/ dir is auth, not a character) so we never imply success.
+  if (!soul && !identity && dailyLogs.length === 0 && namedMemory.length === 0 && !curated.text) {
+    warnings.push(
+      `No persona (SOUL/IDENTITY) and no markdown/sqlite memory found under ${resolvedHome}. ` +
+        `This may be a device/builder home (identity/ holds auth, not a character). ` +
+        `Point --from at a persona home and --agent-id at a real store.`,
+    );
+  }
+
   return {
     agentId,
     home: resolvedHome,
-    soul: readIfPresent(path.join(resolvedHome, "SOUL.md")),
-    identity: readIfPresent(path.join(resolvedHome, "IDENTITY.md")),
+    soul,
+    identity,
     agents: readIfPresent(path.join(resolvedHome, "AGENTS.md")),
     user: readIfPresent(path.join(resolvedHome, "USER.md")),
     tools: readIfPresent(path.join(resolvedHome, "TOOLS.md")),
-    curatedMemory: readIfPresent(path.join(resolvedHome, "MEMORY.md")),
+    curatedMemory: curated.text,
+    curatedMemoryFile: curated.file,
     hbSignal: readIfPresent(path.join(resolvedHome, "HEARTBEAT.md")),
     awareness: findAwareness(memoryDir, agentId),
     dailyLogs,
     namedMemory,
     hasSecretsDir,
+    sqliteStores,
+    sqliteUningested,
+    warnings,
   };
 }
 
@@ -210,8 +426,10 @@ export function readOcAgentHome(home: string, agentId: string): OcAgentSource {
 export const SELF_MEMORY_KEYS = [
   "thoughts",
   "inner-state",
+  "inner",
   "letter-to-future-self",
   "journal",
+  "becoming",
 ];
 
 /** Named-memory keys treated as HOW/WHERE-to-talk playbooks (→ style.chat / routing). */

--- a/packages/elizaos/src/migrate/openclaw-reader.ts
+++ b/packages/elizaos/src/migrate/openclaw-reader.ts
@@ -1,0 +1,190 @@
+/**
+ * OpenClaw agent-home reader.
+ *
+ * Reads a file-based OCPlatform ("moltbot") agent home and classifies its
+ * contents into a typed source object the migration pipeline consumes. Pure
+ * filesystem + classification: NO network, NO side effects. Missing files are
+ * tolerated (returned as undefined / empty) so partial homes still migrate.
+ *
+ * An OpenClaw home looks like:
+ *   <home>/SOUL.md IDENTITY.md AGENTS.md USER.md TOOLS.md   (persona + ops)
+ *   <home>/MEMORY.md HB_SIGNAL.md                            (curated memory + hb)
+ *   <home>/<agent>-awareness.md                              (live open-threads)
+ *   <home>/memory/YYYY-MM-DD.md                              (daily logs)
+ *   <home>/memory/<named>.md                                 (journals, playbooks, etc)
+ *   <home>/secrets/                                          (keys — firewalled, never read here)
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export interface OcDailyLog {
+  /** ISO date parsed from the filename (YYYY-MM-DD), or null if unparseable. */
+  date: string | null;
+  /** Epoch ms of the date at UTC midnight, or 0 if unparseable. */
+  epochMs: number;
+  filename: string;
+  text: string;
+}
+
+export interface OcNamedMemory {
+  /** basename without extension, e.g. "conversation-playbook" */
+  key: string;
+  filename: string;
+  text: string;
+}
+
+export interface OcAgentSource {
+  agentId: string;
+  home: string;
+  /** SOUL.md — core voice/values. */
+  soul?: string;
+  /** IDENTITY.md — name/vibe/appearance/personality. */
+  identity?: string;
+  /** AGENTS.md — behavioral + ops rules. */
+  agents?: string;
+  /** USER.md — about the human. FIREWALLED (personal). */
+  user?: string;
+  /** TOOLS.md — infra/keys/notes → plugin config, NOT persona. */
+  tools?: string;
+  /** MEMORY.md — curated long-term memory. */
+  curatedMemory?: string;
+  /** HEARTBEAT.md — heartbeat checklist. */
+  hbSignal?: string;
+  /** <agent>-awareness.md — live open-threads / relationship state. */
+  awareness?: string;
+  /** memory/YYYY-MM-DD.md — daily logs, sorted newest-first. */
+  dailyLogs: OcDailyLog[];
+  /**
+   * memory/<named>.md — non-daily memory files (journals, playbooks, channel
+   * guides, project/routine docs). Keyed by basename.
+   */
+  namedMemory: OcNamedMemory[];
+  /** Whether a secrets/ dir exists (contents intentionally NOT read). */
+  hasSecretsDir: boolean;
+}
+
+const DAILY_RE = /^(\d{4})-(\d{2})-(\d{2})\.md$/;
+
+function readIfPresent(p: string): string | undefined {
+  try {
+    return fs.readFileSync(p, "utf8");
+  } catch {
+    return undefined;
+  }
+}
+
+/** Resolve the awareness file: prefer "<agentId>-awareness.md", else any "*-awareness.md". */
+function findAwareness(memoryDir: string, agentId: string): string | undefined {
+  const preferred = path.join(memoryDir, `${agentId}-awareness.md`);
+  const direct = readIfPresent(preferred);
+  if (direct !== undefined) return direct;
+  let entries: string[] = [];
+  try {
+    entries = fs.readdirSync(memoryDir);
+  } catch {
+    return undefined;
+  }
+  const match = entries.find((f) => f.endsWith("-awareness.md"));
+  return match ? readIfPresent(path.join(memoryDir, match)) : undefined;
+}
+
+/**
+ * Read + classify an OpenClaw agent home. Tolerant of missing files.
+ *
+ * @param home    Path to the agent home (e.g. ~/.moltbot).
+ * @param agentId Agent slug used to resolve the awareness file + tagging.
+ */
+export function readOcAgentHome(home: string, agentId: string): OcAgentSource {
+  const resolvedHome = path.resolve(home);
+  const memoryDir = path.join(resolvedHome, "memory");
+
+  const dailyLogs: OcDailyLog[] = [];
+  const namedMemory: OcNamedMemory[] = [];
+
+  let memoryEntries: string[] = [];
+  try {
+    memoryEntries = fs.readdirSync(memoryDir);
+  } catch {
+    memoryEntries = [];
+  }
+
+  for (const filename of memoryEntries) {
+    if (!filename.endsWith(".md")) continue;
+    const full = path.join(memoryDir, filename);
+    let text: string;
+    try {
+      if (!fs.statSync(full).isFile()) continue;
+      text = fs.readFileSync(full, "utf8");
+    } catch {
+      continue;
+    }
+    const m = DAILY_RE.exec(filename);
+    if (m) {
+      const [, y, mo, d] = m;
+      const epochMs = Date.UTC(Number(y), Number(mo) - 1, Number(d));
+      dailyLogs.push({
+        date: `${y}-${mo}-${d}`,
+        epochMs: Number.isNaN(epochMs) ? 0 : epochMs,
+        filename,
+        text,
+      });
+    } else {
+      namedMemory.push({
+        key: filename.replace(/\.md$/, ""),
+        filename,
+        text,
+      });
+    }
+  }
+
+  // Newest-first so tiering can take the last-N-days off the front.
+  dailyLogs.sort((a, b) => b.epochMs - a.epochMs);
+  namedMemory.sort((a, b) => a.key.localeCompare(b.key));
+
+  let hasSecretsDir = false;
+  try {
+    hasSecretsDir = fs.statSync(path.join(resolvedHome, "secrets")).isDirectory();
+  } catch {
+    hasSecretsDir = false;
+  }
+
+  return {
+    agentId,
+    home: resolvedHome,
+    soul: readIfPresent(path.join(resolvedHome, "SOUL.md")),
+    identity: readIfPresent(path.join(resolvedHome, "IDENTITY.md")),
+    agents: readIfPresent(path.join(resolvedHome, "AGENTS.md")),
+    user: readIfPresent(path.join(resolvedHome, "USER.md")),
+    tools: readIfPresent(path.join(resolvedHome, "TOOLS.md")),
+    curatedMemory: readIfPresent(path.join(resolvedHome, "MEMORY.md")),
+    hbSignal: readIfPresent(path.join(resolvedHome, "HEARTBEAT.md")),
+    awareness: findAwareness(memoryDir, agentId),
+    dailyLogs,
+    namedMemory,
+    hasSecretsDir,
+  };
+}
+
+/** Named-memory keys treated as the agent's own journal / "becoming" (tier SELF). */
+export const SELF_MEMORY_KEYS = [
+  "thoughts",
+  "inner-state",
+  "letter-to-future-self",
+  "journal",
+];
+
+/** Named-memory keys treated as HOW/WHERE-to-talk playbooks (→ style.chat / routing). */
+export const PLAYBOOK_MEMORY_KEYS = ["conversation-playbook", "channel-guide"];
+
+/** Does a named-memory key look like the agent's own journal? */
+export function isSelfMemory(key: string): boolean {
+  const k = key.toLowerCase();
+  return SELF_MEMORY_KEYS.some((s) => k.includes(s));
+}
+
+/** Does a named-memory key look like a talk playbook? */
+export function isPlaybookMemory(key: string): boolean {
+  const k = key.toLowerCase();
+  return PLAYBOOK_MEMORY_KEYS.some((s) => k.includes(s));
+}

--- a/packages/elizaos/src/migrate/openclaw-reader.ts
+++ b/packages/elizaos/src/migrate/openclaw-reader.ts
@@ -66,12 +66,49 @@ export interface OcAgentSource {
 
 const DAILY_RE = /^(\d{4})-(\d{2})-(\d{2})\.md$/;
 
+/**
+ * Candidate sub-roots within a home, in priority order. OCPlatform homes come
+ * in two shapes: FLAT (`<home>/SOUL.md`, `<home>/memory/`) and NESTED
+ * (`<home>/workspace/SOUL.md`, `<home>/workspace.default/...`). We probe in this
+ * order so a nested home doesn't silently migrate to an empty character.
+ * (Mirrors Hermes's `source_candidate` multi-path probing.)
+ */
+const HOME_SUBROOTS = ["", "workspace", "workspace.default"] as const;
+
 function readIfPresent(p: string): string | undefined {
   try {
     return fs.readFileSync(p, "utf8");
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Resolve the effective agent root: the first of `<home>`, `<home>/workspace`,
+ * `<home>/workspace.default` that contains any recognizable persona file or a
+ * `memory/` dir. Falls back to `<home>` if none match (so missing-home behavior
+ * is preserved — an empty source, not a throw).
+ */
+function resolveAgentRoot(home: string): string {
+  const PERSONA_FILES = ["SOUL.md", "IDENTITY.md", "AGENTS.md", "MEMORY.md"];
+  for (const sub of HOME_SUBROOTS) {
+    const root = sub ? path.join(home, sub) : home;
+    const hasPersona = PERSONA_FILES.some((f) => {
+      try {
+        return fs.statSync(path.join(root, f)).isFile();
+      } catch {
+        return false;
+      }
+    });
+    let hasMemoryDir = false;
+    try {
+      hasMemoryDir = fs.statSync(path.join(root, "memory")).isDirectory();
+    } catch {
+      hasMemoryDir = false;
+    }
+    if (hasPersona || hasMemoryDir) return root;
+  }
+  return home;
 }
 
 /** Resolve the awareness file: prefer "<agentId>-awareness.md", else any "*-awareness.md". */
@@ -96,7 +133,8 @@ function findAwareness(memoryDir: string, agentId: string): string | undefined {
  * @param agentId Agent slug used to resolve the awareness file + tagging.
  */
 export function readOcAgentHome(home: string, agentId: string): OcAgentSource {
-  const resolvedHome = path.resolve(home);
+  // Tolerate flat AND nested (workspace/, workspace.default/) home layouts.
+  const resolvedHome = resolveAgentRoot(path.resolve(home));
   const memoryDir = path.join(resolvedHome, "memory");
 
   const dailyLogs: OcDailyLog[] = [];
@@ -144,7 +182,9 @@ export function readOcAgentHome(home: string, agentId: string): OcAgentSource {
 
   let hasSecretsDir = false;
   try {
-    hasSecretsDir = fs.statSync(path.join(resolvedHome, "secrets")).isDirectory();
+    hasSecretsDir = fs
+      .statSync(path.join(resolvedHome, "secrets"))
+      .isDirectory();
   } catch {
     hasSecretsDir = false;
   }

--- a/packages/elizaos/src/migrate/openclaw-reader.ts
+++ b/packages/elizaos/src/migrate/openclaw-reader.ts
@@ -59,28 +59,28 @@ export interface OcSqliteStore {
 export interface OcAgentSource {
   agentId: string;
   home: string;
-  /** SOUL.md — core voice/values. */
+  /** SOUL.md - core voice/values. */
   soul?: string;
-  /** IDENTITY.md — name/vibe/appearance/personality. */
+  /** IDENTITY.md - name/vibe/appearance/personality. */
   identity?: string;
-  /** AGENTS.md — behavioral + ops rules. */
+  /** AGENTS.md - behavioral + ops rules. */
   agents?: string;
-  /** USER.md — about the human. FIREWALLED (personal). */
+  /** USER.md - about the human. FIREWALLED (personal). */
   user?: string;
-  /** TOOLS.md — infra/keys/notes → plugin config, NOT persona. */
+  /** TOOLS.md - infra/keys/notes → plugin config, NOT persona. */
   tools?: string;
   /** MEMORY.md (or legacy memory.md): curated long-term memory. */
   curatedMemory?: string;
   /** Which root-memory filename was found ("MEMORY.md" | "memory.md" | undefined). */
   curatedMemoryFile?: string;
-  /** HEARTBEAT.md — heartbeat checklist. */
+  /** HEARTBEAT.md - heartbeat checklist. */
   hbSignal?: string;
-  /** <agent>-awareness.md — live open-threads / relationship state. */
+  /** <agent>-awareness.md - live open-threads / relationship state. */
   awareness?: string;
-  /** memory/YYYY-MM-DD.md — daily logs, sorted newest-first. */
+  /** memory/YYYY-MM-DD.md - daily logs, sorted newest-first. */
   dailyLogs: OcDailyLog[];
   /**
-   * memory/<named>.md — non-daily memory files (journals, playbooks, channel
+   * memory/<named>.md - non-daily memory files (journals, playbooks, channel
    * guides, project/routine docs). Keyed by basename.
    */
   namedMemory: OcNamedMemory[];
@@ -126,7 +126,7 @@ function readIfPresent(p: string): string | undefined {
  * Resolve the effective agent root: the first of `<home>`, `<home>/workspace`,
  * `<home>/workspace.default` that contains any recognizable persona file or a
  * `memory/` dir. Falls back to `<home>` if none match (so missing-home behavior
- * is preserved — an empty source, not a throw).
+ * is preserved - an empty source, not a throw).
  */
 function resolveAgentRoot(home: string): string {
   const PERSONA_FILES = ["SOUL.md", "IDENTITY.md", "AGENTS.md", "MEMORY.md", "memory.md"];

--- a/packages/elizaos/src/migrate/openclaw-reader.ts
+++ b/packages/elizaos/src/migrate/openclaw-reader.ts
@@ -69,7 +69,7 @@ export interface OcAgentSource {
   user?: string;
   /** TOOLS.md — infra/keys/notes → plugin config, NOT persona. */
   tools?: string;
-  /** MEMORY.md (or legacy memory.md) — curated long-term memory. */
+  /** MEMORY.md (or legacy memory.md): curated long-term memory. */
   curatedMemory?: string;
   /** Which root-memory filename was found ("MEMORY.md" | "memory.md" | undefined). */
   curatedMemoryFile?: string;
@@ -244,7 +244,7 @@ function readSqliteMemory(
       db.close();
     }
   } catch {
-    // Table missing / locked / not the expected shape — let caller warn.
+    // Table missing / locked / not the expected shape: let caller warn.
     return null;
   }
 

--- a/packages/elizaos/src/migrate/types.ts
+++ b/packages/elizaos/src/migrate/types.ts
@@ -1,0 +1,59 @@
+/**
+ * Minimal local types for the migration tool.
+ *
+ * These mirror the relevant subset of the Eliza `@elizaos/core` /
+ * `@elizaos/agent` types WITHOUT importing those packages, so the CLI stays
+ * decoupled from the agent runtime (and from its source-condition typecheck
+ * quirks). The shapes are intentionally loose where the archive only needs to
+ * round-trip values through `importAgent`.
+ */
+
+export type UUID = string;
+
+/** Subset of @elizaos/core `Character` the migration produces. */
+export interface MigratedCharacter {
+  id?: string;
+  name?: string;
+  username?: string;
+  system?: string;
+  bio?: string[];
+  adjectives?: string[];
+  topics?: string[];
+  style?: { all?: string[]; chat?: string[]; post?: string[] };
+  messageExamples?: unknown[];
+  knowledge?: Array<{ case: string; value: { text: string } }>;
+  settings?: Record<string, unknown>;
+}
+
+/** Subset of @elizaos/core `Memory`. */
+export interface MigratedMemory {
+  id: UUID;
+  entityId: UUID;
+  agentId: UUID;
+  roomId: UUID;
+  createdAt: number;
+  content: { text: string };
+  metadata: { type: "custom"; source: string; tier: string };
+  unique: boolean;
+}
+
+/**
+ * PayloadSchema-conformant export payload (subset). Field names + nesting match
+ * `@elizaos/agent`'s AgentExportPayload so `importAgent` accepts it.
+ */
+export interface MigratedExportPayload {
+  version: number;
+  exportedAt: string;
+  sourceAgentId: string;
+  agent: Record<string, unknown>;
+  characterConfig?: Record<string, unknown>;
+  entities: Array<Record<string, unknown>>;
+  memories: MigratedMemory[];
+  components: unknown[];
+  rooms: Array<Record<string, unknown>>;
+  participants: Array<{ entityId: string; roomId: string; userState: string | null }>;
+  relationships: unknown[];
+  worlds: Array<Record<string, unknown>>;
+  tasks: unknown[];
+  logs: unknown[];
+}


### PR DESCRIPTION
Follow-up hardening for the migrate-agent tool merged in #10211. Makes the OpenClaw-home reader robust across OC version-shapes and adds firewall/round-trip coverage.

## What this adds
- **Version-robust reader** across OC home formats (see OC-VERSION-AUDIT.md): flat (.moltbot), leaner (.hermes: SOUL+AGENTS only, name derived from SOUL H1), nested (workspace/), and SQLite/builder homes (detect + warn loudly, never silent-empty). Accepts canonical MEMORY.md OR legacy memory.md. Slug-agnostic awareness/journal detection.
- **Hardening**: nested-layout probing, cross-tier dedup (exact-body, conservative), truncation/clip reporting (surfaces previously-silent 6000-char clips).
- **--json purity**: clack chrome goes to stderr so stdout is pure parseable JSON.
- **Archive round-trip tests**: full .eliza-agent crypto round-trip (gzip to PBKDF2 600k to AES-256-GCM) plus referential-integrity + wrong-password auth-tag-failure coverage.
- Em-dashes stripped from source and docs.

## Validation
- 20 unit tests green (was 10 at merge).
- Real-data dry-runs: .moltbot (Sol, 41 memories, 0 firewall leaks across 31 distinctive USER.md phrases), .hermes (Nyx, non-empty from the lean layout), .ocplatform (sqlite detected + warned).
- Self-contained design preserved (no @elizaos/core or @elizaos/agent deps; local types + node-builtin crypto).

Co-authored-by: wakesync <shadow@shad0w.xyz>