### PR TITLE
fix(elizaos): firewall personal memory out of portable archives + importAgent round-trip test (follow-up to #10211)

### DIFF
--- a/packages/elizaos/src/migrate/index.ts
+++ b/packages/elizaos/src/migrate/index.ts
@@ -73,6 +73,10 @@ export function buildMigrationPlan(opts: MigrateOptions): MigratePlan {
     roomId,
     entityId,
     agentId,
+    // Firewall the personal memory corpus out of portable archives (the same
+    // posture the character mapper uses for USER.md). Sovereign-local passes
+    // firewall=false to seed the full corpus on the owner's own machine.
+    firewall,
   });
 
   return {

--- a/packages/elizaos/src/migrate/memory-tiering.ts
+++ b/packages/elizaos/src/migrate/memory-tiering.ts
@@ -31,6 +31,17 @@ export interface TieringOptions {
   minChunkLen?: number;
   /** Max chars per memory (longer chunks are clipped). Default 6000. */
   maxChunkLen?: number;
+  /**
+   * When true (the posture `buildMigrationPlan` uses for a PORTABLE archive),
+   * the personal memory corpus is EXCLUDED: daily logs, `<agent>-awareness.md`,
+   * curated `MEMORY.md`, and the agent's own SELF journals all describe the
+   * owner / private life and must never leak off the owner's machine. Only a
+   * marker noting the exclusion is seeded. The sovereign-local path passes
+   * `false` to seed the full corpus on the owner's own machine. Default `false`
+   * (callers opt in — the firewall posture is decided one level up, from the
+   * same flag the character mapper firewalls USER.md with).
+   */
+  firewall?: boolean;
 }
 
 export interface TieringResult {
@@ -90,6 +101,7 @@ export function tierMemories(
   src: OcAgentSource,
   opts: TieringOptions,
 ): TieringResult {
+  const firewall = opts.firewall ?? false;
   const minLen = opts.minChunkLen ?? 20;
   const memories: Memory[] = [];
   const counts: Record<MemoryTier, number> = {
@@ -100,6 +112,26 @@ export function tierMemories(
   };
   const now = Date.now();
   const cutoff = now - opts.memoryDays * DAY_MS;
+
+  // ---- FIREWALL: a portable archive carries the persona, NOT the personal corpus ----
+  // Daily logs, <agent>-awareness.md, curated MEMORY.md, and SELF journals all
+  // describe the owner / private life. With the firewall on we seed NONE of them
+  // — only a marker — so a shared archive cannot leak personal context. The
+  // sovereign-local path passes firewall=false to seed the full corpus.
+  if (firewall) {
+    memories.push(
+      mkMemory(
+        "Personal memory (daily logs, journals, awareness, and curated long-term " +
+          "memory) was firewalled out of this portable archive for privacy. Re-seed " +
+          "it from a sovereign-local export on the owner's own machine if you need it.",
+        "MARKER",
+        opts,
+        now,
+      ),
+    );
+    counts.MARKER++;
+    return { memories, counts };
+  }
 
   // ---- T1 CURRENT: awareness (highest signal) + last-N-day daily logs ----
   if (src.awareness?.trim()) {

--- a/packages/elizaos/src/migrate/migrate.test.ts
+++ b/packages/elizaos/src/migrate/migrate.test.ts
@@ -13,12 +13,29 @@ import { readOcAgentHome } from "./openclaw-reader.js";
 
 const FIXTURE = path.join(__dirname, "__tests__", "fixtures", "oc-home");
 
-/** Build a real `.eliza-agent` archive from the fixture home. */
-function buildArchive(password: string): {
+/** Personal-context strings from the fixture that MUST never reach a firewalled archive. */
+const PERSONAL_TEXT = [
+  "Secret personal info", // USER.md (about the human)
+  "This is my becoming", // tess-thoughts.md (SELF journal)
+  "Current open thread", // tess-awareness.md (relationship/awareness state)
+  "recent daily log content", // 2026-06-29.md (daily log)
+  "Long-term fact", // MEMORY.md (curated long-term memory)
+];
+
+/**
+ * Build a real `.eliza-agent` archive from the fixture home. Defaults to the
+ * SOVEREIGN posture (firewall off) so the import-compatibility test exercises
+ * the full memory corpus (CURRENT/LONGTERM/SELF/MARKER); the firewall security
+ * guarantee is proven separately in its own suite.
+ */
+function buildArchive(
+  password: string,
+  firewall = false,
+): {
   archive: Buffer;
   memoryCount: number;
 } {
-  const plan = buildMigrationPlan({ from: FIXTURE, agentId: "tess" });
+  const plan = buildMigrationPlan({ from: FIXTURE, agentId: "tess", firewall });
   const { payload } = assemblePayload({
     agentId: plan.ids.agentId,
     sourceSlug: "tess",
@@ -165,6 +182,23 @@ describe("memory-tiering", () => {
     expect(all).not.toContain("old daily log that should NOT be flat-seeded");
     expect(all).toContain("Older history");
   });
+  it("firewall excludes ALL personal-context memory (marker only)", () => {
+    const src = readOcAgentHome(FIXTURE, "tess");
+    const { memories, counts } = tierMemories(src, {
+      memoryDays: 14,
+      firewall: true,
+      ...ids,
+    });
+    expect(counts.CURRENT).toBe(0);
+    expect(counts.LONGTERM).toBe(0);
+    expect(counts.SELF).toBe(0);
+    expect(counts.MARKER).toBe(1);
+    expect(memories.length).toBe(1);
+    const all = memories.map((m) => m.content.text).join("\n");
+    for (const needle of PERSONAL_TEXT) {
+      expect(all, needle).not.toContain(needle);
+    }
+  });
 });
 
 describe("archive format", () => {
@@ -238,5 +272,69 @@ describe("sovereign artifacts + plan", () => {
       buildMigrationPlan({ from: FIXTURE, agentId: "tess", firewall: false })
         .summary.firewalled,
     ).toBe(false);
+  });
+});
+
+/**
+ * The firewall is the headline privacy guarantee: a PORTABLE archive (the
+ * default posture) must carry the persona but NOT the owner's personal memory
+ * corpus. We prove it end-to-end — build → encrypt → import through the REAL
+ * `@elizaos/agent` importer — and inspect what actually lands in the (captured)
+ * store, so the assertion is on real restored rows, not a mock.
+ */
+describe("firewall keeps the personal memory corpus out of a portable archive", () => {
+  /** Build an archive at a given firewall posture + import it via the real importer. */
+  async function importWithFirewall(firewall: boolean) {
+    const plan = buildMigrationPlan({
+      from: FIXTURE,
+      agentId: "tess",
+      firewall,
+    });
+    const { payload } = assemblePayload({
+      agentId: plan.ids.agentId,
+      sourceSlug: "tess",
+      character: plan.character,
+      entityId: plan.ids.entityId,
+      roomId: plan.ids.roomId,
+      memories: plan.memories,
+    });
+    const archive = buildElizaAgentArchive(payload, "fw-password");
+    const { adapter, captured } = makeCapturingAdapter();
+    const runtime = { adapter } as unknown as ImportRuntime;
+    const result = await importAgent(runtime, archive, "fw-password");
+    return { plan, result, captured };
+  }
+
+  it("default (firewall ON): persona imports, but only a MARKER memory — no personal text", async () => {
+    const { plan, result, captured } = await importWithFirewall(true);
+
+    expect(plan.summary.firewalled).toBe(true);
+    expect(result.success).toBe(true);
+    // The persona still round-trips.
+    expect(captured.agents[0]?.name).toBe("Tess");
+    // The seeded corpus is exactly the firewall marker — nothing personal.
+    expect(
+      captured.memories.every((m) =>
+        m.memory.content.text.startsWith("[MARKER]"),
+      ),
+    ).toBe(true);
+    // Not a single byte of personal context anywhere in the restored store.
+    const blob = JSON.stringify(captured);
+    for (const needle of PERSONAL_TEXT) {
+      expect(blob, needle).not.toContain(needle);
+    }
+  });
+
+  it("sovereign (firewall OFF): the SAME personal text DOES round-trip", async () => {
+    const { captured } = await importWithFirewall(false);
+    const memText = captured.memories
+      .map((m) => m.memory.content.text)
+      .join("\n");
+    // Proof the firewall (not absence of source data) is what removed the text
+    // above: with it off, the journal / awareness / daily / MEMORY content lands.
+    expect(memText).toContain("This is my becoming"); // SELF journal
+    expect(memText).toContain("Current open thread"); // awareness
+    expect(memText).toContain("recent daily log content"); // daily log
+    expect(memText).toContain("Long-term fact"); // MEMORY.md
   });
 });

--- a/packages/elizaos/src/migrate/openclaw-reader.ts
+++ b/packages/elizaos/src/migrate/openclaw-reader.ts
@@ -8,7 +8,7 @@
  *
  * An OpenClaw home looks like:
  *   <home>/SOUL.md IDENTITY.md AGENTS.md USER.md TOOLS.md   (persona + ops)
- *   <home>/MEMORY.md HB_SIGNAL.md                            (curated memory + hb)
+ *   <home>/MEMORY.md                                         (curated memory)
  *   <home>/<agent>-awareness.md                              (live open-threads)
  *   <home>/memory/YYYY-MM-DD.md                              (daily logs)
  *   <home>/memory/<named>.md                                 (journals, playbooks, etc)
@@ -49,8 +49,6 @@ export interface OcAgentSource {
   tools?: string;
   /** MEMORY.md — curated long-term memory. */
   curatedMemory?: string;
-  /** HEARTBEAT.md — heartbeat checklist. */
-  hbSignal?: string;
   /** <agent>-awareness.md — live open-threads / relationship state. */
   awareness?: string;
   /** memory/YYYY-MM-DD.md — daily logs, sorted newest-first. */
@@ -160,7 +158,6 @@ export function readOcAgentHome(home: string, agentId: string): OcAgentSource {
     user: readIfPresent(path.join(resolvedHome, "USER.md")),
     tools: readIfPresent(path.join(resolvedHome, "TOOLS.md")),
     curatedMemory: readIfPresent(path.join(resolvedHome, "MEMORY.md")),
-    hbSignal: readIfPresent(path.join(resolvedHome, "HEARTBEAT.md")),
     awareness: findAwareness(memoryDir, agentId),
     dailyLogs,
     namedMemory,


### PR DESCRIPTION
Follow-up completing **#10211** (migrate-agent, merged). A deep review found the firewall — the PR's headline privacy guarantee — is **structurally non-functional for memories**, and the "round-trips through importAgent" claim was **untested**. Both re-verified against current develop.

## 1. Firewall now actually covers the memory corpus (security)
develop firewalls only `USER.md` (character.knowledge); `buildMigrationPlan`'s `firewall` flag is passed to the character mapper but **never to `tierMemories`** (confirmed: `tierMemories(src, { memoryDays, roomId, entityId, agentId })` — no `firewall`). So every **portable** `.eliza-agent` archive still shipped the full personal corpus: daily logs, `<agent>-awareness.md` (relationship state), curated `MEMORY.md`, and SELF journals. A user trusting `--firewall` leaked their private journals into a "shareable" archive.

Fix: pass `firewall` to `tierMemories`; when on (the portable default), seed **only a marker** — no personal memory reaches the archive. The sovereign-local path (`--no-firewall`, owner-machine only) still seeds the full corpus.

## 2. The promised importAgent round-trip test (headline claim was unverified)
develop's `migrate.test.ts` only checked the magic-header bytes + length. Added a real round-trip: `buildMigrationPlan → archiveFromPlan → importAgent(runtime, archive, password)`, asserting the persona round-trips **and** that firewalled personal text is absent — so the hand-mirrored crypto/format + `PayloadSchema` can't silently drift from `@elizaos/agent` undetected. (This also justifies the `@elizaos/agent` dep the review flagged — it's now used by the test.)

## 3. Dead field
Removed the `hbSignal`/`HEARTBEAT.md` field (read but never used; docstring named the wrong file `HB_SIGNAL.md`).

## Verification
`migrate.test.ts` — **15 pass / 0 fail** (incl. the round-trip + firewall-exclusion + no-personal-text-leak assertions). biome clean.

**Known design item (separate follow-up):** `firewall` is one plan-level boolean shared by both outputs, so a single run can't emit a firewalled archive AND an unfirewalled sovereign extract — secure-by-default (exclude unless `--no-firewall`) is the chosen posture; full dual-output separation is deferred.

Follows up #10211.

🤖 Generated with [Claude Code](https://claude.com/claude-code)