### PR TITLE
fix(feed): keep railway start non-interactive so drizzle-kit push can't wedge the deploy

### DIFF
--- a/packages/feed/scripts/railway-start.sh
+++ b/packages/feed/scripts/railway-start.sh
@@ -17,10 +17,21 @@ FEED_DIR="$(dirname "$SCRIPT_DIR")" # packages/feed
 cd "$FEED_DIR"
 
 echo "[railway-start] Ensuring database schema (drizzle-kit push)..."
-if (cd packages/db && bunx drizzle-kit push --config=drizzle.config.cjs --force); then
+# `drizzle-kit push` can hit an interactive data-loss prompt (e.g. adding a
+# unique constraint to an already-populated table). The container has no TTY, so
+# the prompt would block on stdin and wedge the whole deploy until the Railway
+# healthcheck times out. Redirect stdin from /dev/null so the prompt resolves
+# immediately (push then exits non-zero), and keep it best-effort: an
+# already-provisioned database must still boot even when push can't apply a
+# change. Bounded by `timeout` as a hard backstop if `timeout` is available.
+DRIZZLE_PUSH=(bunx drizzle-kit push --config=drizzle.config.cjs --force)
+if command -v timeout >/dev/null 2>&1; then
+  DRIZZLE_PUSH=(timeout 240 "${DRIZZLE_PUSH[@]}")
+fi
+if (cd packages/db && "${DRIZZLE_PUSH[@]}" </dev/null); then
   echo "[railway-start] Schema ensured."
 else
-  echo "[railway-start] Schema push reported an issue; continuing (DB may already be provisioned)."
+  echo "[railway-start] Schema push skipped/failed; continuing (DB may already be provisioned)."
 fi
 
 echo "[railway-start] Starting Feed web server on port ${PORT:-3000}..."


### PR DESCRIPTION
## Root cause (why every recent feed deploy failed at the *deploy* phase)

feed-web's Railway start command (`packages/feed/scripts/railway-start.sh`) runs `drizzle-kit push` to provision the schema. A newly-added unique constraint on `UserChallengeProgress` made push hit drizzle-kit's destructive **"Do you want to truncate UserChallengeProgress table?"** data-loss prompt. The container has no TTY, so the prompt blocked on stdin and **wedged the container until the Railway healthcheck timed out** — the deploy then went `FAILED (reason: deploy)`.

This is independent of the build (the image builds fine) and independent of the OAuth fix — it's why deploys kept failing at the deploy phase regardless of how they were built/uploaded. Confirmed from the failed container's logs:

```
[railway-start] Ensuring database schema (drizzle-kit push)...
· You're about to add UserChallengeProgress_..._idx unique constraint ... Do you want to truncate UserChallengeProgress table?
error: Interactive prompts require a TTY terminal (process.stdin.isTTY ... is false)...
```

(No `Schema push ... continuing` line followed → the best-effort `if`-wrapper never completed → it hung.)

## Fix

- Redirect `drizzle-kit push` stdin from `/dev/null` so the prompt resolves immediately instead of blocking.
- Add a `timeout 240` backstop (only if `timeout` is available) as belt-and-suspenders against any future hang.
- Keep it best-effort (the existing `if`/else) so an already-provisioned DB still boots even when push can't apply a change.

This restores the start script's documented intent ("non-fatal on error so an already-provisioned database still boots"). Syntax-checked with `bash -n`; one file changed.

Once merged, the GitHub-connected feed-web build redeploys from main; the container will boot past schema provisioning and ship the Google-login fix (already on main via #10240).

🤖 Generated with [Claude Code](https://claude.com/claude-code)