### PR TITLE
fix(config): de-fragment setting/env resolution; fix twitter-xai example (#10166)

### DIFF
--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -189,6 +189,7 @@ export * from "./utils/environment";
 export { getEnv } from "./utils/environment";
 export { formatError } from "./utils/format-error";
 export * from "./utils/read-env";
+export * from "./utils/resolve-setting";
 export * from "./utils/streaming";
 export { ResponseSkeletonStreamExtractor } from "./utils/streaming";
 // Validation helpers (validateActionKeywords / validateActionRegex /

--- a/packages/core/src/index.edge.ts
+++ b/packages/core/src/index.edge.ts
@@ -105,6 +105,7 @@ export * from "./utils/description-compressed-lint";
 export * from "./utils/environment";
 export * from "./utils/prompt-compression";
 export * from "./utils/read-env";
+export * from "./utils/resolve-setting";
 export * from "./utils/streaming";
 export * from "./validation";
 

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -378,6 +378,8 @@ export * from "./utils/plugin-loader";
 export * from "./utils/prompt-compression";
 // Canonical env-var reader with legacy-alias back-compat
 export * from "./utils/read-env";
+// Canonical runtime-setting → env resolver (per-agent setting first, then env)
+export * from "./utils/resolve-setting";
 export * from "./utils/server-health";
 // Eliza state-dir resolution (ELIZA_STATE_DIR → XDG state home)
 export * from "./utils/state-dir";

--- a/packages/core/src/utils/resolve-setting.test.ts
+++ b/packages/core/src/utils/resolve-setting.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { resolveSetting, type SettingReader } from "./resolve-setting.ts";
+
+const reader = (
+	values: Record<string, string | boolean | number | null>,
+): SettingReader => ({
+	getSetting: (key) => (key in values ? values[key] : null),
+});
+
+describe("resolveSetting", () => {
+	it("prefers the runtime setting over env", () => {
+		expect(
+			resolveSetting(reader({ KEY: "from-runtime" }), "KEY", {
+				env: { KEY: "from-env" },
+			}),
+		).toBe("from-runtime");
+	});
+
+	it("coerces non-string runtime values to string", () => {
+		const r = reader({ FLAG: true, COUNT: 5 });
+		expect(resolveSetting(r, "FLAG", { env: {} })).toBe("true");
+		expect(resolveSetting(r, "COUNT", { env: {} })).toBe("5");
+	});
+
+	it("falls back to env when the runtime returns null", () => {
+		expect(
+			resolveSetting(reader({ OTHER: "x" }), "KEY", {
+				env: { KEY: "from-env" },
+			}),
+		).toBe("from-env");
+	});
+
+	it("falls back to env when there is no runtime", () => {
+		expect(resolveSetting(null, "KEY", { env: { KEY: "from-env" } })).toBe(
+			"from-env",
+		);
+		expect(resolveSetting(undefined, "KEY", { env: { KEY: "from-env" } })).toBe(
+			"from-env",
+		);
+	});
+
+	it("returns the default when neither runtime nor env has the key", () => {
+		expect(
+			resolveSetting(reader({}), "KEY", { env: {}, defaultValue: "d" }),
+		).toBe("d");
+		expect(resolveSetting(reader({}), "KEY", { env: {} })).toBeUndefined();
+	});
+
+	it("uses readEnv semantics for the env fallback (whitespace is unset)", () => {
+		expect(
+			resolveSetting(reader({}), "KEY", {
+				env: { KEY: "   " },
+				defaultValue: "d",
+			}),
+		).toBe("d");
+	});
+
+	it("does NOT read process.env when the runtime has the key (no leak past runtime)", () => {
+		// Runtime value present → env is never consulted, even the real one.
+		expect(resolveSetting(reader({ KEY: "runtime" }), "KEY")).toBe("runtime");
+	});
+});

--- a/packages/core/src/utils/resolve-setting.ts
+++ b/packages/core/src/utils/resolve-setting.ts
@@ -1,0 +1,49 @@
+/** Canonical setting resolver: per-agent runtime setting first, then env. */
+
+import { type ReadEnvOptions, readEnv } from "./read-env.js";
+
+/**
+ * Minimal structural shape of a runtime that can resolve a setting. Kept local
+ * (rather than importing `IAgentRuntime`) so this helper stays browser/edge-safe
+ * and free of the runtime type graph.
+ */
+export interface SettingReader {
+	getSetting(key: string): string | boolean | number | null;
+}
+
+export type ResolveSettingOptions = ReadEnvOptions;
+
+/**
+ * Resolve a configuration value the way single-tenant / headless plugins want
+ * it: the per-agent runtime setting first, then `process.env` as a deployment
+ * fallback, then an optional default.
+ *
+ * **WHY a shared helper:** core `AgentRuntime.getSetting()` is intentionally
+ * per-agent and does **not** read `process.env` — host/infra secrets must not
+ * leak into every agent sharing a multi-tenant process. Plugins that still want
+ * a dotenv fallback (single-tenant, headless, local dev) each reimplemented the
+ * same runtime→env chain (plugin-x, plugin-elizacloud, plugin-embeddings,
+ * plugin-edge-tts, plugin-elevenlabs, …). This is the one canonical
+ * implementation they should delegate to instead. It does not change
+ * `getSetting()` semantics — multi-tenant hosts that never call it are
+ * unaffected.
+ *
+ * Runtime values are coerced to string. The env fallback uses {@link readEnv}
+ * semantics (trimmed; empty strings treated as unset).
+ *
+ * @param runtime - Runtime to read the per-agent setting from (may be null)
+ * @param key - Setting / environment variable name
+ * @param options - `defaultValue` and/or an explicit `env` record
+ * @returns The resolved string, `options.defaultValue`, or `undefined`
+ */
+export function resolveSetting(
+	runtime: SettingReader | null | undefined,
+	key: string,
+	options: ResolveSettingOptions = {},
+): string | undefined {
+	const fromRuntime = runtime?.getSetting(key);
+	if (fromRuntime !== undefined && fromRuntime !== null) {
+		return String(fromRuntime);
+	}
+	return readEnv(key, options);
+}

--- a/packages/examples/twitter-xai/README.md
+++ b/packages/examples/twitter-xai/README.md
@@ -18,13 +18,14 @@ plugins:
 
 - An **xAI API key** for Grok (`XAI_API_KEY`).
 - An **X developer app** with **user-context write access**.
-  - Default: **OAuth 1.0a user-context** credentials (`TWITTER_API_KEY`,
-    `TWITTER_API_SECRET_KEY`, `TWITTER_ACCESS_TOKEN`,
-    `TWITTER_ACCESS_TOKEN_SECRET`).
+  - Default: **OAuth 1.0a user-context** credentials (`TWITTER_AUTH_MODE=env`):
+    `TWITTER_API_KEY`, `TWITTER_API_SECRET_KEY`, `TWITTER_ACCESS_TOKEN`,
+    `TWITTER_ACCESS_TOKEN_SECRET`.
   - Alternative: **OAuth 2.0 PKCE** (interactive login) with
     `TWITTER_AUTH_MODE=oauth`.
-  - Alternative: **Eliza Cloud broker** with `TWITTER_AUTH_MODE=broker` —
-    delegates OAuth to a managed service.
+  - Managed: **Eliza Cloud broker** (`TWITTER_AUTH_MODE=broker`) delegates OAuth
+    to a managed service. `@elizaos/plugin-x` runs `env|oauth`, so this
+    standalone example does not wire the broker flow — run it via Eliza Cloud.
 
 ## Quick start
 
@@ -61,7 +62,8 @@ bun run start
 
 ### X API v2 auth — `@elizaos/plugin-x`
 
-- `TWITTER_AUTH_MODE` — `broker` (default), `oauth`, or `env`.
+- `TWITTER_AUTH_MODE` — `env` (default, standalone), `oauth`, or `broker`
+  (managed Eliza Cloud).
 
 OAuth 1.0a user context (`TWITTER_AUTH_MODE=env`):
 
@@ -76,10 +78,11 @@ OAuth 2.0 PKCE (`TWITTER_AUTH_MODE=oauth`):
 - `TWITTER_REDIRECT_URI`
 - `TWITTER_SCOPES` (default `tweet.read tweet.write users.read offline.access`)
 
-Eliza Cloud broker (`TWITTER_AUTH_MODE=broker`):
+Eliza Cloud broker (`TWITTER_AUTH_MODE=broker`) — managed only:
 
 - `TWITTER_BROKER_TOKEN` or `ELIZAOS_CLOUD_API_KEY`
 - `TWITTER_BROKER_URL` (optional service URL override)
+- Not wired in this standalone example; run via Eliza Cloud to use it.
 
 ### Agent behavior toggles
 

--- a/packages/examples/twitter-xai/agent.test.ts
+++ b/packages/examples/twitter-xai/agent.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, expect, test } from "bun:test";
+import { AgentRuntime, getBasicCapabilitiesSettings } from "@elizaos/core";
 import { requireEnv, validateEnvironment } from "./agent";
+import { character } from "./character";
 
 const ENV_KEYS = [
   "XAI_API_KEY",
@@ -12,6 +14,7 @@ const ENV_KEYS = [
   "TWITTER_API_SECRET_KEY",
   "TWITTER_ACCESS_TOKEN",
   "TWITTER_ACCESS_TOKEN_SECRET",
+  "POSTGRES_URL",
 ];
 
 const originalEnv = Object.fromEntries(
@@ -85,5 +88,29 @@ test("validateEnvironment rejects invalid auth modes and missing model key", () 
   process.env.TWITTER_AUTH_MODE = "cookies";
   expect(() => validateEnvironment()).toThrow(
     "Invalid TWITTER_AUTH_MODE=cookies",
+  );
+});
+
+test("auth mode defaults to env (the mode plugin-x supports standalone)", () => {
+  // With TWITTER_AUTH_MODE unset, the example must default to `env` — the only
+  // mode @elizaos/plugin-x implements standalone — not the unimplemented
+  // `broker`. Proven by the env-mode credential check firing.
+  resetExampleEnv();
+  process.env.XAI_API_KEY = "xai-test-key";
+  expect(() => validateEnvironment()).toThrow("TWITTER_API_KEY");
+});
+
+test("runtime resolves POSTGRES_URL from the environment via the settings bridge", () => {
+  // Regression for #10166: core getSetting() does not read process.env, so the
+  // headless host must merge env into settings. Without the bridge, plugin-sql's
+  // getSetting("POSTGRES_URL") misses the .env value and falls back to PGlite.
+  resetExampleEnv();
+  process.env.POSTGRES_URL = "postgresql://user:pass@db.example:5432/eliza";
+  const runtime = new AgentRuntime({
+    character,
+    settings: getBasicCapabilitiesSettings(character),
+  });
+  expect(runtime.getSetting("POSTGRES_URL")).toBe(
+    "postgresql://user:pass@db.example:5432/eliza",
   );
 });

--- a/packages/examples/twitter-xai/agent.ts
+++ b/packages/examples/twitter-xai/agent.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { AgentRuntime } from "@elizaos/core";
+import { AgentRuntime, getBasicCapabilitiesSettings } from "@elizaos/core";
 import { config as loadDotEnv } from "dotenv";
 
 import { character } from "./character";
@@ -18,7 +18,10 @@ export function validateEnvironment(): void {
   requireEnv("XAI_API_KEY");
 
   // X (Twitter) is provided by @elizaos/plugin-x. Pick one of the three modes.
-  const authMode = (process.env.TWITTER_AUTH_MODE ?? "broker").toLowerCase();
+  // Default to `env`: it is the only mode @elizaos/plugin-x implements purely
+  // standalone (it accepts `env | oauth`). `broker` is a managed Eliza Cloud
+  // path and is left as an explicit opt-in.
+  const authMode = (process.env.TWITTER_AUTH_MODE ?? "env").toLowerCase();
   switch (authMode) {
     case "broker":
       if (
@@ -68,9 +71,15 @@ async function main(): Promise<void> {
   const { XAIPlugin } = await import("@elizaos/plugin-xai");
   const xPlugin = (await import("@elizaos/plugin-x")).default;
 
+  // Bridge the dotenv-loaded environment into the runtime's settings. Core
+  // `getSetting()` is per-agent and does NOT read `process.env`, so a headless
+  // host must merge env in explicitly — otherwise plugin-sql's
+  // `getSetting("POSTGRES_URL")` misses the `.env` value and silently falls back
+  // to PGlite. getBasicCapabilitiesSettings layers env under character config.
   const runtime = new AgentRuntime({
     character,
     plugins: [sqlPlugin, XAIPlugin, xPlugin],
+    settings: getBasicCapabilitiesSettings(character),
   });
 
   console.log("⏳ Initializing runtime...");

--- a/packages/examples/twitter-xai/env.example
+++ b/packages/examples/twitter-xai/env.example
@@ -18,28 +18,31 @@ XAI_API_KEY=your-xai-api-key
 # =============================================================================
 # X (Twitter) API v2 authentication — provided by @elizaos/plugin-x
 # =============================================================================
-# Mode (recommended → least): broker | oauth | env
-TWITTER_AUTH_MODE=broker
+# @elizaos/plugin-x accepts `env | oauth`. `env` is the default here because it
+# runs fully standalone with X developer tokens.
+TWITTER_AUTH_MODE=env
 
-# --- broker (Eliza Cloud, recommended) ---
-# Connect your X account on the Eliza Cloud connectors page, then this agent
-# uses your existing ELIZAOS_CLOUD_API_KEY to fetch tokens at runtime — no
-# extra config needed. Override TWITTER_BROKER_URL only for self-hosted brokers.
-ELIZAOS_CLOUD_API_KEY=your-eliza-cloud-api-key
-# TWITTER_BROKER_URL=https://www.elizacloud.ai/api/v1/twitter
-# TWITTER_BROKER_TOKEN=  # optional: defaults to ELIZAOS_CLOUD_API_KEY
+# --- env (developer tokens, OAuth 1.0a) — default, standalone ---
+TWITTER_API_KEY=your-x-api-key
+TWITTER_API_SECRET_KEY=your-x-api-secret
+TWITTER_ACCESS_TOKEN=your-x-access-token
+TWITTER_ACCESS_TOKEN_SECRET=your-x-access-token-secret
+# TWITTER_BEARER_TOKEN=your-app-only-bearer-token  # read-only endpoints
 
 # --- oauth (OAuth 2.0 PKCE, self-hosted) ---
+# TWITTER_AUTH_MODE=oauth
 # TWITTER_CLIENT_ID=your-oauth-client-id
 # TWITTER_REDIRECT_URI=http://127.0.0.1:1717/callback
 # TWITTER_SCOPES=tweet.read tweet.write users.read offline.access
 
-# --- env (developer tokens, OAuth 1.0a) ---
-# TWITTER_API_KEY=your-x-api-key
-# TWITTER_API_SECRET_KEY=your-x-api-secret
-# TWITTER_ACCESS_TOKEN=your-x-access-token
-# TWITTER_ACCESS_TOKEN_SECRET=your-x-access-token-secret
-# TWITTER_BEARER_TOKEN=your-app-only-bearer-token  # read-only endpoints
+# --- broker (managed Eliza Cloud) ---
+# Connect your X account on the Eliza Cloud connectors page and let the managed
+# runtime broker tokens for you. This standalone example does not wire the
+# broker flow (plugin-x runs env|oauth), so use Eliza Cloud to run in this mode.
+# TWITTER_AUTH_MODE=broker
+# ELIZAOS_CLOUD_API_KEY=your-eliza-cloud-api-key
+# TWITTER_BROKER_URL=https://www.elizacloud.ai/api/v1/twitter
+# TWITTER_BROKER_TOKEN=  # optional: defaults to ELIZAOS_CLOUD_API_KEY
 
 # =============================================================================
 # Agent Behavior

--- a/plugins/plugin-x/src/utils/settings.ts
+++ b/plugins/plugin-x/src/utils/settings.ts
@@ -1,7 +1,12 @@
-import type { IAgentRuntime } from "@elizaos/core";
+import { type IAgentRuntime, resolveSetting } from "@elizaos/core";
 
 /**
- * Safely gets a setting from runtime or environment variables
+ * Safely gets a setting from runtime or environment variables.
+ *
+ * Thin wrapper over core `resolveSetting` (runtime per-agent setting first, then
+ * `process.env`). Kept as a local export so call sites read `getSetting(...)`,
+ * but the precedence lives in one canonical place in core.
+ *
  * @param runtime The agent runtime instance
  * @param key The setting key to retrieve
  * @param defaultValue Optional default value if setting is not found
@@ -12,14 +17,5 @@ export function getSetting(
   key: string,
   defaultValue?: string,
 ): string | undefined {
-  // Try runtime.getSetting if it exists
-  if (runtime && typeof runtime.getSetting === "function") {
-    const value = runtime.getSetting(key);
-    if (value !== undefined && value !== null) {
-      return String(value);
-    }
-  }
-
-  // Fall back to process.env
-  return process.env[key] ?? defaultValue;
+  return resolveSetting(runtime, key, { defaultValue });
 }


### PR DESCRIPTION
## What & why

Scopes #10166 to the **real, safe** fixes and rejects its dangerous one. Full review: [#10166 comment](https://github.com/elizaOS/eliza/issues/10166#issuecomment-4835593464).

**The issue's headline fix — adding `process.env` as a fallback in core `getSetting()` — would be a multi-tenant secret leak.** Cloud runs many tenants' agents in one process where `process.env` holds host/infra secrets; it deliberately curates a per-agent env allowlist (`cloud/shared/.../runtime/settings.ts buildSettings`) and strips sensitive keys. `getSetting()` staying per-agent is load-bearing isolation, not an oversight. The DB symptom is only reachable from a hand-rolled `new AgentRuntime({ character })` that forgets to merge env — i.e. the `twitter-xai` example itself.

## Changes

- **core:** add `resolveSetting(runtime, key, { defaultValue })` (`packages/core/src/utils/resolve-setting.ts`) — the canonical runtime-setting → `process.env` resolver that ~5 plugins each reimplement. **Additive, opt-in; does NOT change `getSetting()` semantics.** Exported from node/edge/browser + unit tests.
- **examples/twitter-xai:** pass `settings: getBasicCapabilitiesSettings(character)` so a dotenv `POSTGRES_URL` is honored (it was silently falling back to PGlite). Default `TWITTER_AUTH_MODE` to `env` — `broker` was the documented copy-paste default but `@elizaos/plugin-x` only accepts `env|oauth` and has **zero** broker code (`TWITTER_BROKER_*` have no consumers), so the example broke on copy-paste. README + env.example reconciled; regression tests added.
- **plugin-x:** delegate the local `getSetting` helper to core `resolveSetting`, removing one duplicate precedence implementation.

## Out of scope (follow-ups)

- Migrate the other ~4 plugin env-fallback reimplementations (elizacloud, embeddings, edge-tts, elevenlabs) to `resolveSetting`.
- Collapse the duplicated `DATABASE_URL→POSTGRES_URL` host bridge (≥4 copies).
- Documentation: precedence table + host-obligation note (issue acceptance criterion #1).

## Verification

- `packages/core` `resolve-setting.test.ts` — **7/7 pass** (precedence, coercion, env fallback, default, no-leak-past-runtime).
- `packages/examples/twitter-xai` — **6/6 pass**, incl. new `runtime resolves POSTGRES_URL from the environment via the settings bridge` (regression for #10166) and `auth mode defaults to env`.
- `plugins/plugin-x` full suite — **67 pass / 15 skipped** with the delegated helper.
- `biome check` clean on all touched files.

`getSetting()` itself is untouched — no behavior change for multi-tenant hosts.
