### PR TITLE
fix(ui): co-render connector setup panel alongside config form in Settings (#10281)

### DIFF
--- a/packages/ui/src/components/settings/ConnectorsSection.test.tsx
+++ b/packages/ui/src/components/settings/ConnectorsSection.test.tsx
@@ -43,6 +43,39 @@ vi.mock("../connectors/WhatsAppQrOverlay", () => ({
   WhatsAppQrOverlay: () => <div />,
 }));
 
+// Controllable connector-mode per plugin id. Defaults to a benign mode so the
+// pre-existing icon test is unaffected; tests opt into telegram/discord modes.
+const connectorModeMock = vi.hoisted(() => ({
+  byId: {} as Record<
+    string,
+    {
+      setupPluginId: string | null;
+      selectedMode: string;
+      modes: Array<{ id: string; managementMode: string | undefined }>;
+    }
+  >,
+}));
+vi.mock("../connectors/ConnectorModeSelector.hooks", () => ({
+  useConnectorMode: (pluginId: string) =>
+    connectorModeMock.byId[pluginId] ?? {
+      setupPluginId: pluginId,
+      selectedMode: "default",
+      modes: [{ id: "default", managementMode: undefined }],
+    },
+}));
+vi.mock("../connectors/ConnectorModeSelector", () => ({
+  ConnectorModeSelector: () => <div data-testid="mode-selector" />,
+}));
+vi.mock("../connectors/ConnectorSetupPanel", () => ({
+  ConnectorSetupPanel: ({ pluginId }: { pluginId: string }) => (
+    <div data-testid="connector-setup-panel">setup:{pluginId}</div>
+  ),
+}));
+vi.mock("../pages/PluginConfigForm", () => ({
+  PluginConfigForm: () => <div data-testid="plugin-config-form" />,
+  TelegramPluginConfig: () => <div data-testid="telegram-config-form" />,
+}));
+
 import { ConnectorsSection } from "./ConnectorsSection";
 
 function plugin(overrides: Partial<PluginInfo> = {}): PluginInfo {
@@ -74,6 +107,7 @@ describe("ConnectorsSection", () => {
       pluginSaveSuccess: new Set<string>(),
       t: (_key, options) => options?.defaultValue ?? _key,
     };
+    connectorModeMock.byId = {};
   });
 
   afterEach(() => {
@@ -93,5 +127,62 @@ describe("ConnectorsSection", () => {
     expect(container.textContent ?? "").not.toContain(rawConnectorGlyph);
     expect(container.textContent ?? "").not.toContain(rawPuzzleGlyph);
     expect(container.querySelector("svg")).toBeTruthy();
+  });
+
+  function tokenParam(key: string): PluginInfo["parameters"][number] {
+    return {
+      key,
+      type: "string",
+      description: "",
+      required: true,
+      sensitive: true,
+      currentValue: null,
+      isSet: false,
+    };
+  }
+
+  // Regression #10281: Settings → Connectors must co-render the live setup
+  // panel alongside the env-config form (the canonical /connectors page does).
+  // Before the fix, the showPluginConfig branch dropped the panel.
+  it("co-renders the live setup panel alongside the config form for telegram bot mode", () => {
+    connectorModeMock.byId.telegram = {
+      setupPluginId: "telegram",
+      selectedMode: "bot",
+      modes: [{ id: "bot", managementMode: "local-config" }],
+    };
+    appMock.value.plugins = [
+      plugin({
+        id: "telegram",
+        name: "Telegram",
+        parameters: [tokenParam("TELEGRAM_BOT_TOKEN")],
+      }),
+    ];
+
+    render(<ConnectorsSection />);
+
+    expect(screen.getByTestId("telegram-config-form")).toBeTruthy();
+    const panel = screen.getByTestId("connector-setup-panel");
+    expect(panel).toBeTruthy();
+    expect(panel.textContent ?? "").toContain("telegram");
+  });
+
+  it("renders no setup panel for a local-config connector that has none (discord)", () => {
+    connectorModeMock.byId.discord = {
+      setupPluginId: "discord",
+      selectedMode: "bot",
+      modes: [{ id: "bot", managementMode: "local-config" }],
+    };
+    appMock.value.plugins = [
+      plugin({
+        id: "discord",
+        name: "Discord",
+        parameters: [tokenParam("DISCORD_API_TOKEN")],
+      }),
+    ];
+
+    render(<ConnectorsSection />);
+
+    expect(screen.getByTestId("plugin-config-form")).toBeTruthy();
+    expect(screen.queryByTestId("connector-setup-panel")).toBeNull();
   });
 });

--- a/packages/ui/src/components/settings/ConnectorsSection.test.tsx
+++ b/packages/ui/src/components/settings/ConnectorsSection.test.tsx
@@ -166,6 +166,32 @@ describe("ConnectorsSection", () => {
     expect(panel.textContent ?? "").toContain("telegram");
   });
 
+  // whatsapp business mode is the third local-config + has-panel case; it must
+  // co-render like /connectors does (the panel is the whatsapp pairing surface).
+  it("co-renders the setup panel for whatsapp business mode", () => {
+    connectorModeMock.byId.whatsapp = {
+      setupPluginId: "whatsapp",
+      selectedMode: "business",
+      modes: [{ id: "business", managementMode: "local-config" }],
+    };
+    appMock.value.plugins = [
+      plugin({
+        id: "whatsapp",
+        name: "WhatsApp",
+        parameters: [tokenParam("WHATSAPP_ACCESS_TOKEN")],
+      }),
+    ];
+
+    render(<ConnectorsSection />);
+
+    expect(screen.getByTestId("plugin-config-form")).toBeTruthy();
+    expect(
+      (screen.getByTestId("connector-setup-panel").textContent ?? "").includes(
+        "whatsapp",
+      ),
+    ).toBe(true);
+  });
+
   it("renders no setup panel for a local-config connector that has none (discord)", () => {
     connectorModeMock.byId.discord = {
       setupPluginId: "discord",

--- a/packages/ui/src/components/settings/ConnectorsSection.tsx
+++ b/packages/ui/src/components/settings/ConnectorsSection.tsx
@@ -220,6 +220,13 @@ function ConnectorBody({ plugin }: { plugin: PluginInfo }) {
               </span>
             ) : null}
           </div>
+          {/* Co-render the live setup/status panel (e.g. Telegram bot-token
+              validation + identity) alongside the env-config form, matching the
+              canonical /connectors surface (plugin-view-connectors.tsx). Without
+              this, a `local-config` connector that also has a setup panel
+              (telegram bot mode) showed the raw-token form only. `setupPanel` is
+              already null-gated to `setupPluginId`, so it is a no-op otherwise. */}
+          {setupPanel}
         </div>
       ) : setupPanel ? (
         setupPanel

--- a/packages/ui/src/components/settings/ConnectorsSection.tsx
+++ b/packages/ui/src/components/settings/ConnectorsSection.tsx
@@ -192,6 +192,14 @@ function ConnectorBody({ plugin }: { plugin: PluginInfo }) {
               onParamChange={handleParamChange}
             />
           )}
+          {/* Co-render the live setup/status panel (e.g. Telegram bot-token
+              validation + identity) directly under the env-config form, matching
+              the canonical /connectors surface (plugin-view-connectors.tsx) where
+              the panel sits between the form and the save action. Without this, a
+              `local-config` connector that also has a setup panel (telegram bot
+              mode) showed the raw-token form only. `setupPanel` is already
+              null-gated to `setupPluginId`, so it is a no-op otherwise. */}
+          {setupPanel}
           <div className="flex flex-wrap items-center gap-2">
             <Button
               variant="default"
@@ -220,13 +228,6 @@ function ConnectorBody({ plugin }: { plugin: PluginInfo }) {
               </span>
             ) : null}
           </div>
-          {/* Co-render the live setup/status panel (e.g. Telegram bot-token
-              validation + identity) alongside the env-config form, matching the
-              canonical /connectors surface (plugin-view-connectors.tsx). Without
-              this, a `local-config` connector that also has a setup panel
-              (telegram bot mode) showed the raw-token form only. `setupPanel` is
-              already null-gated to `setupPluginId`, so it is a no-op otherwise. */}
-          {setupPanel}
         </div>
       ) : setupPanel ? (
         setupPanel


### PR DESCRIPTION
## Summary

Closes #10281 (surfaced by the closed-PR gap audit; the unaddressed `[major]` rework note on closed PR #9877).

Settings → Connectors (`ConnectorsSection.tsx` → `ConnectorBody`) rendered the env-config form **OR** the live setup panel (either/or), whereas the canonical `/connectors` page (`plugin-view-connectors.tsx`, ~L1177) co-renders **both**. So a `local-config` connector that also has a setup panel — **Telegram bot-token mode** — showed the raw-token form only and dropped the live `TelegramBotSetupPanel` (token validation + bot-identity confirmation + disconnect).

## Fix

Co-render `{setupPanel}` inside the `showPluginConfig` branch. `setupPanel` is already null-gated to `setupPluginId` (`setupPluginId && hasConnectorSetupPanel(setupPluginId)`), so it is a **no-op** for connectors without a panel (e.g. Discord — `hasConnectorSetupPanel("discord") === false`). Branches stay mutually exclusive, so no double-render.

## Tests (`ConnectorsSection.test.tsx`)

- **telegram bot mode** → asserts BOTH `telegram-config-form` and `connector-setup-panel` render. **This test fails on develop without the fix** (verified by reverting the one-line change → red).
- **discord (local-config, no panel)** → asserts the form renders and **no** spurious setup panel appears.

`bun run --cwd packages/ui test -- src/components/settings/ConnectorsSection.test.tsx src/components/settings/ConnectorsSection.routing.test.ts` → **7 passed**.

## Visual evidence

N/A by nature — this co-renders a **pre-existing** component (`ConnectorSetupPanel`/`TelegramBotSetupPanel`) that already renders on `/connectors` and in this component's else-branch; no new visual surface is introduced. The render test asserts the DOM wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)