### PR TITLE
chore(cloud): namespace outbound waifu webhook/meter env vars to ELIZA_CLOUD_* (dual-read)

### DIFF
--- a/packages/cloud/api/billing/checkout/verify/route.ts
+++ b/packages/cloud/api/billing/checkout/verify/route.ts
@@ -264,6 +264,7 @@ async function notifyWaifuCreditsToppedUp(params: {
   const webhookSecret =
     stringField(config, "webhookSecret") ??
     stringField(waifuWebhook, "secret") ??
+    process.env.ELIZA_CLOUD_WEBHOOK_SECRET ??
     process.env.WAIFU_WEBHOOK_SECRET;
   if (!webhookUrl || !webhookSecret) return;
 

--- a/packages/cloud/api/cron/agent-billing/route.ts
+++ b/packages/cloud/api/cron/agent-billing/route.ts
@@ -315,6 +315,7 @@ async function notifyWaifuCreditWebhook(
   const webhookSecret =
     stringField(config, "webhookSecret") ??
     stringField(waifuWebhook, "secret") ??
+    process.env.ELIZA_CLOUD_WEBHOOK_SECRET ??
     process.env.WAIFU_WEBHOOK_SECRET;
   if (!webhookUrl || !webhookSecret) return;
 

--- a/packages/cloud/api/src/queue/stripe-event.ts
+++ b/packages/cloud/api/src/queue/stripe-event.ts
@@ -458,6 +458,7 @@ async function notifyWaifuCreditsToppedUp(params: {
   const webhookSecret =
     stringField(config, "webhookSecret") ??
     stringField(waifuWebhook, "secret") ??
+    process.env.ELIZA_CLOUD_WEBHOOK_SECRET ??
     process.env.WAIFU_WEBHOOK_SECRET;
   if (!webhookUrl || !webhookSecret) return;
 

--- a/packages/cloud/shared/.env.example
+++ b/packages/cloud/shared/.env.example
@@ -847,6 +847,20 @@ ELIZA_APP_WHATSAPP_PHONE_NUMBER=
 # Create a dedicated org + user in the platform for this purpose.
 # WAIFU_SERVICE_ORG_ID=uuid-of-waifu-service-org
 # WAIFU_SERVICE_USER_ID=uuid-of-waifu-service-user
+#
+# Outbound webhooks + metering: Eliza Cloud -> waifu.fun credit/inference
+# receivers. These are SENT BY us (HMAC-signed over `timestamp.body`); the
+# env-var NAMES are internal to Eliza Cloud (the secret VALUE is shared with the
+# waifu receiver and is unchanged). Canonical names are ELIZA_CLOUD_*; the
+# WAIFU_* names are deprecated aliases still read as a fallback for zero-downtime
+# migration — drop them once the prod secret is re-set under
+# ELIZA_CLOUD_WEBHOOK_SECRET.
+# ELIZA_CLOUD_WEBHOOK_URL=https://api.waifu.fun/v2/webhooks/eliza-cloud/credits
+# ELIZA_CLOUD_WEBHOOK_SECRET=hmac_secret_shared_with_waifu_receiver  (was WAIFU_WEBHOOK_SECRET)
+# ELIZA_CLOUD_INFERENCE_WEBHOOK_URL=https://api.waifu.fun/v2/webhooks/eliza-cloud/inference
+# ELIZA_CLOUD_INFERENCE_WEBHOOK_SECRET=hmac_secret_shared_with_waifu_receiver
+# ELIZA_CLOUD_METER_USD_PER_1K_INPUT=0.003   (was WAIFU_METER_USD_PER_1K_INPUT)
+# ELIZA_CLOUD_METER_USD_PER_1K_OUTPUT=0.015
 
 # Steward auth note:
 # GitHub / Google / Discord / Twitter OAuth credentials are configured on the

--- a/packages/cloud/shared/src/lib/services/waifu-webhook.test.ts
+++ b/packages/cloud/shared/src/lib/services/waifu-webhook.test.ts
@@ -73,6 +73,28 @@ describe("resolveWaifuWebhookTarget", () => {
     const target = resolveWaifuWebhookTarget();
     expect(target).toEqual({ baseUrl: "https://api.waifu.fun", secret: "s".repeat(40) });
   });
+
+  test("resolves from the canonical ELIZA_CLOUD_WEBHOOK_URL + ELIZA_CLOUD_WEBHOOK_SECRET", () => {
+    process.env.ELIZA_CLOUD_WEBHOOK_URL = "https://api.waifu.fun/v2/webhooks/eliza-cloud/credits";
+    process.env.ELIZA_CLOUD_WEBHOOK_SECRET = "e".repeat(40);
+    const target = resolveWaifuWebhookTarget();
+    expect(target).toEqual({
+      baseUrl: "https://api.waifu.fun/v2/webhooks/eliza-cloud/credits",
+      secret: "e".repeat(40),
+    });
+  });
+
+  test("ELIZA_CLOUD_* takes precedence over the deprecated WAIFU_* aliases", () => {
+    process.env.ELIZA_CLOUD_WEBHOOK_URL = "https://api.example.test/new";
+    process.env.ELIZA_CLOUD_WEBHOOK_SECRET = "new".padEnd(40, "x");
+    process.env.WAIFU_WEBHOOK_URL = "https://api.example.test/old";
+    process.env.WAIFU_WEBHOOK_SECRET = "old".padEnd(40, "y");
+    const target = resolveWaifuWebhookTarget();
+    expect(target).toEqual({
+      baseUrl: "https://api.example.test/new",
+      secret: "new".padEnd(40, "x"),
+    });
+  });
 });
 
 describe("emitWaifuWebhook signing + delivery", () => {

--- a/packages/cloud/shared/src/lib/services/waifu-webhook.ts
+++ b/packages/cloud/shared/src/lib/services/waifu-webhook.ts
@@ -65,13 +65,18 @@ export interface EmitWaifuWebhookParams {
  * not wired to a waifu deployment (local dev, CI without secrets).
  */
 export function resolveWaifuWebhookTarget(): WaifuWebhookTarget | null {
+  // ELIZA_CLOUD_* are the canonical names; WAIFU_* are deprecated legacy
+  // aliases kept for zero-downtime migration. WAIFU_API_BASE_URL/WAIFU_CORE_URL
+  // stay as inbound waifu.fun identifiers (not renamed).
   const baseUrl = (
+    process.env.ELIZA_CLOUD_WEBHOOK_URL ??
     process.env.WAIFU_WEBHOOK_URL ??
     process.env.WAIFU_API_BASE_URL ??
     process.env.WAIFU_CORE_URL ??
     ""
   ).trim();
   const secret = (
+    process.env.ELIZA_CLOUD_WEBHOOK_SECRET ??
     process.env.WAIFU_WEBHOOK_SECRET ??
     process.env.WEBHOOK_RECEIVER_SECRET ??
     ""

--- a/plugins/plugin-elizacloud/__tests__/unit/waifu-metering.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/waifu-metering.test.ts
@@ -85,6 +85,40 @@ describe("resolveWaifuMeteringConfig", () => {
     expect(resolved?.usdPer1kOutput).toBeGreaterThan(0);
   });
 
+  it("resolves config from the canonical ELIZA_CLOUD_* names", () => {
+    const runtime = makeRuntime({
+      ELIZA_CLOUD_INFERENCE_WEBHOOK_URL: CONFIG.webhookUrl,
+      ELIZA_CLOUD_WEBHOOK_SECRET: CONFIG.secret,
+      ELIZA_CLOUD_METER_USD_PER_1K_INPUT: "0.009",
+      ELIZA_CLOUD_METER_USD_PER_1K_OUTPUT: "0.018",
+      WAIFU_AGENT_ID: CONFIG.agentId,
+    });
+    const resolved = resolveWaifuMeteringConfig(runtime);
+    expect(resolved).toMatchObject({
+      webhookUrl: CONFIG.webhookUrl,
+      secret: CONFIG.secret,
+      agentId: CONFIG.agentId,
+    });
+    expect(resolved?.usdPer1kInput).toBe(0.009);
+    expect(resolved?.usdPer1kOutput).toBe(0.018);
+  });
+
+  it("ELIZA_CLOUD_* takes precedence over the deprecated WAIFU_* aliases", () => {
+    const runtime = makeRuntime({
+      ELIZA_CLOUD_INFERENCE_WEBHOOK_URL: "https://api.example.test/new/inference",
+      ELIZA_CLOUD_WEBHOOK_SECRET: "new-secret",
+      ELIZA_CLOUD_METER_USD_PER_1K_INPUT: "0.001",
+      WAIFU_INFERENCE_WEBHOOK_URL: "https://api.example.test/old/inference",
+      WAIFU_WEBHOOK_SECRET: "old-secret",
+      WAIFU_METER_USD_PER_1K_INPUT: "0.999",
+      WAIFU_AGENT_ID: CONFIG.agentId,
+    });
+    const resolved = resolveWaifuMeteringConfig(runtime);
+    expect(resolved?.webhookUrl).toBe("https://api.example.test/new/inference");
+    expect(resolved?.secret).toBe("new-secret");
+    expect(resolved?.usdPer1kInput).toBe(0.001);
+  });
+
   it("never reuses the credits URL for inference; derives the /inference sibling instead", () => {
     const runtime = makeRuntime({
       WAIFU_WEBHOOK_URL: "https://api.waifu.fun/v2/webhooks/eliza-cloud/credits",

--- a/plugins/plugin-elizacloud/src/utils/waifu-metering.ts
+++ b/plugins/plugin-elizacloud/src/utils/waifu-metering.ts
@@ -83,8 +83,14 @@ export function resolveWaifuMeteringConfig(
   runtime: IAgentRuntime
 ): WaifuMeteringConfig | null {
   const webhookUrl = resolveInferenceWebhookUrl(runtime);
+  // Prefer the ELIZA_CLOUD_* names; the WAIFU_* names are kept as deprecated
+  // legacy aliases for zero-downtime migration (drop once prod secrets are
+  // re-set under ELIZA_CLOUD_*).
   const secret =
-    readEnv(runtime, "WAIFU_WEBHOOK_SECRET") ?? readEnv(runtime, "WAIFU_INFERENCE_WEBHOOK_SECRET");
+    readEnv(runtime, "ELIZA_CLOUD_WEBHOOK_SECRET") ??
+    readEnv(runtime, "ELIZA_CLOUD_INFERENCE_WEBHOOK_SECRET") ??
+    readEnv(runtime, "WAIFU_WEBHOOK_SECRET") ??
+    readEnv(runtime, "WAIFU_INFERENCE_WEBHOOK_SECRET");
   const agentId = readEnv(runtime, "WAIFU_AGENT_ID") ?? readEnv(runtime, "WAIFU_CORE_AGENT_ID");
 
   if (!webhookUrl || !secret || !agentId) {
@@ -95,11 +101,15 @@ export function resolveWaifuMeteringConfig(
     webhookUrl,
     secret,
     agentId,
-    usdPer1kInput: readNumberEnv(runtime, "WAIFU_METER_USD_PER_1K_INPUT", DEFAULT_USD_PER_1K_INPUT),
+    usdPer1kInput: readNumberEnv(
+      runtime,
+      "ELIZA_CLOUD_METER_USD_PER_1K_INPUT",
+      readNumberEnv(runtime, "WAIFU_METER_USD_PER_1K_INPUT", DEFAULT_USD_PER_1K_INPUT)
+    ),
     usdPer1kOutput: readNumberEnv(
       runtime,
-      "WAIFU_METER_USD_PER_1K_OUTPUT",
-      DEFAULT_USD_PER_1K_OUTPUT
+      "ELIZA_CLOUD_METER_USD_PER_1K_OUTPUT",
+      readNumberEnv(runtime, "WAIFU_METER_USD_PER_1K_OUTPUT", DEFAULT_USD_PER_1K_OUTPUT)
     ),
   };
 }
@@ -116,10 +126,14 @@ export function resolveWaifuMeteringConfig(
  * disabled.
  */
 export function resolveInferenceWebhookUrl(runtime: IAgentRuntime): string | undefined {
-  const explicit = readEnv(runtime, "WAIFU_INFERENCE_WEBHOOK_URL");
+  const explicit =
+    readEnv(runtime, "ELIZA_CLOUD_INFERENCE_WEBHOOK_URL") ??
+    readEnv(runtime, "WAIFU_INFERENCE_WEBHOOK_URL");
   if (explicit) return explicit;
 
-  const creditsUrl = readEnv(runtime, "WAIFU_WEBHOOK_URL");
+  const creditsUrl =
+    readEnv(runtime, "ELIZA_CLOUD_WEBHOOK_URL") ??
+    readEnv(runtime, "WAIFU_WEBHOOK_URL");
   if (!creditsUrl) return undefined;
 
   // Only derive when the credits URL ends in a recognizable `/credits` segment.


### PR DESCRIPTION
## What & why
`WAIFU_*` env vars are the **live waifu.fun partner integration** (waifu.fun uses Eliza Cloud as its metered inference/billing backend), not stray branding — so a blanket `WAIFU_`→`ELIZA_` rename would break a running, billing-coupled integration (and collides with the existing `ELIZA_AGENT_ID` / `ELIZA_API_BASE_URL`).

This PR scopes the rename to the **outbound** vars only — the ones where **we are the sender**, so the env-var *name* is internal to Eliza Cloud — and gives them canonical `ELIZA_CLOUD_*` names with a **backward-compatible dual-read** (`ELIZA_CLOUD_* ?? WAIFU_*`). **waifu.fun is unaffected**: the secret *value* and the HMAC signing scheme don't change, only which env var name we read it from.

### Renamed (canonical `ELIZA_CLOUD_*`, deprecated `WAIFU_*` fallback retained)
| was | now |
|---|---|
| `WAIFU_WEBHOOK_SECRET` / `_URL` | `ELIZA_CLOUD_WEBHOOK_SECRET` / `_URL` |
| `WAIFU_INFERENCE_WEBHOOK_SECRET` / `_URL` | `ELIZA_CLOUD_INFERENCE_WEBHOOK_SECRET` / `_URL` |
| `WAIFU_METER_USD_PER_1K_INPUT` / `_OUTPUT` | `ELIZA_CLOUD_METER_USD_PER_1K_INPUT` / `_OUTPUT` |

### Deliberately NOT renamed
The inbound / partner-identity vars stay as-is — they identify the *waifu.fun side*, would collide with existing `ELIZA_*` vars, or need waifu.fun's coordination: `WAIFU_SERVICE_KEY/ORG_ID/USER_ID`, `WAIFU_BRIDGE_*`, `WAIFU_API_BASE_URL`, `WAIFU_CORE_URL`, `WAIFU_AGENT_ID`, `WAIFU_ACCESS_*`, `WAIFU_AGENT_EVM_*`, `WAIFU_CHAT_*`, `WAIFU_AUTO_PROVISION`.

## Evidence
```
$ bun test packages/cloud/shared/.../waifu-webhook.test.ts          # 23 passed
$ bunx vitest run plugins/plugin-elizacloud/.../waifu-metering.test.ts  # 26 passed
```
- The **existing `WAIFU_*` tests now prove the fallback** (they still pass unchanged).
- **New tests** prove the canonical `ELIZA_CLOUD_*` names resolve AND that `ELIZA_CLOUD_*` **wins precedence** over the deprecated `WAIFU_*` alias.
- `biome` + typecheck clean on all 8 files. The diff is additive (no `WAIFU_` fallback dropped). `.env.example` documents the new names.

## Ops follow-up (zero-downtime)
Re-set the prod wrangler secret under `ELIZA_CLOUD_WEBHOOK_SECRET` (same value), then a later PR can drop the `WAIFU_*` fallback. Until then, both names work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
