### PR TITLE
feat(plugin-cloud-apps): create → deploy (completion gate) → delete + facts cache

### DIFF
--- a/packages/agent/src/runtime/core-plugins.ts
+++ b/packages/agent/src/runtime/core-plugins.ts
@@ -129,7 +129,7 @@ export const CORE_PLUGINS: readonly string[] = [
   // @elizaos/plugin-agent-orchestrator — opt-in via ELIZA_AGENT_ORCHESTRATOR (Eliza app enables by default)
   // Recurring work uses runtime TaskService + triggers (no @elizaos/plugin-cron).
   "@elizaos/plugin-app-control", // launch, close, and list running Eliza apps from agent chat
-  "@elizaos/plugin-cloud-apps", // read-core for Eliza Cloud Apps: LIST_CLOUD_APPS / GET_APP + CLOUD_APPS provider (reaches local/native + Discord/Telegram via the shared pipeline). Read-only; mutating/money actions are deferred to Phase 3b. Cloud-hosted agents add this separately via agent-loader, gated behind CLOUD_APPS_PLUGIN_ENABLED.
+  "@elizaos/plugin-cloud-apps", // Eliza Cloud Apps: LIST_CLOUD_APPS / GET_APP + CLOUD_APPS provider, plus CREATE_APP / DEPLOY_APP (READY+reachability completion gate) / GET_APP_DEPLOY_STATUS / DELETE_APP (two-phase confirm) + deploy-success facts cache. Reaches local/native + Discord/Telegram via the shared pipeline. Cloud-hosted agents add this separately via agent-loader, gated behind CLOUD_APPS_PLUGIN_ENABLED.
   "@elizaos/plugin-native-filesystem", // mobile-safe FILE target=device via Capacitor on iOS/Android, Node fs/promises rooted under resolveStateDir()/workspace on desktop/AOSP
   "@elizaos/plugin-shell", // shell service, approvals, and history provider
   "@elizaos/plugin-coding-tools", // native FILE/SHELL/WORKTREE coding tools (desktop-only

--- a/plugins/plugin-cloud-apps/__tests__/create-app.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/create-app.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { CreateAppInput } from "@elizaos/cloud-sdk";
+import {
+  captureCallback,
+  FakeElizaCloudClient,
+  keyedRuntime,
+  makeApp,
+  makeMessage,
+  resetSdk,
+  setCreateApp,
+  unkeyedRuntime,
+} from "./helpers";
+
+mock.module("@elizaos/cloud-sdk", () => ({
+  ElizaCloudClient: FakeElizaCloudClient,
+}));
+
+const { createAppAction, parseCreateAppIntent, DRAFT_APP_URL } = await import(
+  "../src/actions/create-app.ts"
+);
+
+describe("parseCreateAppIntent", () => {
+  it("extracts a name from natural phrasing", () => {
+    expect(parseCreateAppIntent("build me an app called Acme Bot").name).toBe(
+      "Acme Bot",
+    );
+    expect(parseCreateAppIntent("make a bot named Zephyr please").name).toBe(
+      "Zephyr",
+    );
+    expect(parseCreateAppIntent('create an app "Side Project"').name).toBe(
+      "Side Project",
+    );
+  });
+
+  it("prefers an explicit planner option over the text", () => {
+    const intent = parseCreateAppIntent("make something", { name: "Widget" });
+    expect(intent.name).toBe("Widget");
+  });
+
+  it("detects monetization intent + markup percentage", () => {
+    const intent = parseCreateAppIntent(
+      "build a monetized app called Coin with 20% markup",
+    );
+    expect(intent.name).toBe("Coin");
+    expect(intent.monetization).toBe(true);
+    expect(intent.markupPercentage).toBe(20);
+  });
+
+  it("defaults monetization off and name null when absent", () => {
+    const intent = parseCreateAppIntent("hello there");
+    expect(intent.name).toBeNull();
+    expect(intent.monetization).toBe(false);
+    expect(intent.markupPercentage).toBeUndefined();
+  });
+});
+
+describe("CREATE_APP", () => {
+  beforeEach(() => {
+    resetSdk();
+  });
+
+  it("validates only when a Cloud API key is present", async () => {
+    expect(
+      await createAppAction.validate(keyedRuntime(), makeMessage("x")),
+    ).toBe(true);
+    expect(
+      await createAppAction.validate(unkeyedRuntime(), makeMessage("x")),
+    ).toBe(false);
+  });
+
+  it("creates an app with the parsed name + draft url and offers to deploy", async () => {
+    let received: CreateAppInput | null = null;
+    setCreateApp((input) => {
+      received = input;
+      return Promise.resolve({
+        success: true,
+        app: makeApp({ id: "id-acme", name: "Acme Bot", slug: "acme-bot" }),
+        apiKey: "eliza_app_secret_do_not_leak",
+      });
+    });
+
+    const cb = captureCallback();
+    const result = await createAppAction.handler(
+      keyedRuntime(),
+      makeMessage("build me an app called Acme Bot"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+
+    expect(result?.success).toBe(true);
+    expect(received).not.toBeNull();
+    expect((received as unknown as CreateAppInput).name).toBe("Acme Bot");
+    expect((received as unknown as CreateAppInput).app_url).toBe(DRAFT_APP_URL);
+    const reply = cb.calls[0]?.text ?? "";
+    expect(reply).toContain("Acme Bot");
+    expect(reply.toLowerCase()).toContain("deploy");
+    // The one-time app API key must NOT be echoed into chat.
+    expect(reply).not.toContain("eliza_app_secret_do_not_leak");
+  });
+
+  it("passes monetization config through to createApp", async () => {
+    let received: CreateAppInput | null = null;
+    setCreateApp((input) => {
+      received = input;
+      return Promise.resolve({
+        success: true,
+        app: makeApp({
+          name: "Coin",
+          monetization_enabled: true,
+          inference_markup_percentage: 20,
+        }),
+        apiKey: "k",
+      });
+    });
+
+    await createAppAction.handler(
+      keyedRuntime(),
+      makeMessage("create a monetized app called Coin with 20% markup"),
+      undefined,
+      undefined,
+      captureCallback().fn,
+    );
+
+    const body = received as unknown as CreateAppInput;
+    expect(body.monetization_enabled).toBe(true);
+    expect(body.inference_markup_percentage).toBe(20);
+  });
+
+  it("asks for a name when none can be parsed (no create call)", async () => {
+    let called = false;
+    setCreateApp((_input) => {
+      called = true;
+      return Promise.resolve({
+        success: true,
+        app: makeApp(),
+        apiKey: "k",
+      });
+    });
+
+    const cb = captureCallback();
+    const result = await createAppAction.handler(
+      keyedRuntime(),
+      makeMessage("make me something cool"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+
+    expect(result?.success).toBe(false);
+    expect((result?.data as { reason: string }).reason).toBe("no_name");
+    expect(called).toBe(false);
+    expect(cb.calls[0]?.text?.toLowerCase()).toContain("what should i call");
+  });
+
+  it("degrades gracefully with no Cloud API key", async () => {
+    const cb = captureCallback();
+    const result = await createAppAction.handler(
+      unkeyedRuntime(),
+      makeMessage("build an app called X"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+    expect(result?.success).toBe(false);
+    expect((result?.data as { reason: string }).reason).toBe("no_key");
+  });
+
+  it("handles a Cloud API error without throwing", async () => {
+    setCreateApp(() => Promise.reject(new Error("boom")));
+    const cb = captureCallback();
+    const result = await createAppAction.handler(
+      keyedRuntime(),
+      makeMessage("build an app called Acme"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+    expect(result?.success).toBe(false);
+    expect((result?.data as { reason: string }).reason).toBe("error");
+  });
+});

--- a/plugins/plugin-cloud-apps/__tests__/delete-app.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/delete-app.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+  captureCallback,
+  FakeElizaCloudClient,
+  keyedRuntime,
+  makeApp,
+  makeMessage,
+  resetSdk,
+  setDeleteApp,
+  setListApps,
+  unkeyedRuntime,
+} from "./helpers";
+
+mock.module("@elizaos/cloud-sdk", () => ({
+  ElizaCloudClient: FakeElizaCloudClient,
+}));
+
+const { deleteAppAction } = await import("../src/actions/delete-app.ts");
+
+const APP = makeApp({ id: "id-acme", name: "Acme Bot", slug: "acme-bot" });
+
+/** Track delete calls; returns the call count getter. */
+function trackDeletes(): { count: () => number } {
+  let count = 0;
+  setDeleteApp(() => {
+    count += 1;
+    return Promise.resolve({ success: true, message: "deleted" });
+  });
+  return { count: () => count };
+}
+
+describe("DELETE_APP", () => {
+  beforeEach(() => {
+    resetSdk();
+    setListApps(() => Promise.resolve({ success: true, apps: [APP] }));
+  });
+
+  it("validates only when a Cloud API key is present", async () => {
+    expect(
+      await deleteAppAction.validate(keyedRuntime(), makeMessage("x")),
+    ).toBe(true);
+    expect(
+      await deleteAppAction.validate(unkeyedRuntime(), makeMessage("x")),
+    ).toBe(false);
+  });
+
+  it("first ask: returns a confirmation prompt and does NOT delete", async () => {
+    const deletes = trackDeletes();
+    const cb = captureCallback();
+    const result = await deleteAppAction.handler(
+      keyedRuntime(),
+      makeMessage("delete my Acme Bot app"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+
+    expect(deletes.count()).toBe(0);
+    expect((result?.data as { deleted: boolean }).deleted).toBe(false);
+    expect(
+      (result?.data as { confirmationRequired: boolean }).confirmationRequired,
+    ).toBe(true);
+    const prompt = cb.calls[0]?.text ?? "";
+    expect(prompt).toContain("Acme Bot");
+    expect(prompt).toContain("tenant database");
+    expect(prompt.toLowerCase()).toContain("can't be undone");
+  });
+
+  it("explicit confirmation: deletes exactly once", async () => {
+    const deletes = trackDeletes();
+    const cb = captureCallback();
+    const result = await deleteAppAction.handler(
+      keyedRuntime(),
+      makeMessage("delete Acme Bot — yes"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+
+    expect(deletes.count()).toBe(1);
+    expect(result?.success ?? false).toBe(true);
+    expect((result?.data as { deleted: boolean }).deleted).toBe(true);
+    expect(cb.calls[0]?.text).toContain("Deleted");
+  });
+
+  it("a bare 'yes' is NOT enough to delete (connector-agnostic safety)", async () => {
+    const deletes = trackDeletes();
+    const cb = captureCallback();
+    // resolve via planner option; confirmation parsed from the text only
+    const result = await deleteAppAction.handler(
+      keyedRuntime(),
+      makeMessage("yes"),
+      undefined,
+      { appName: "Acme Bot" },
+      cb.fn,
+    );
+    expect(deletes.count()).toBe(0);
+    expect(
+      (result?.data as { confirmationRequired: boolean }).confirmationRequired,
+    ).toBe(true);
+  });
+
+  it("a hesitant follow-up does NOT delete", async () => {
+    const deletes = trackDeletes();
+    const result = await deleteAppAction.handler(
+      keyedRuntime(),
+      makeMessage("hmm not sure, maybe later"),
+      undefined,
+      { appName: "Acme Bot" },
+      captureCallback().fn,
+    );
+    expect(deletes.count()).toBe(0);
+    expect((result?.data as { deleted: boolean }).deleted).toBe(false);
+  });
+
+  it("returns not-found for an unknown app (no confirmation, no delete)", async () => {
+    const deletes = trackDeletes();
+    const cb = captureCallback();
+    const result = await deleteAppAction.handler(
+      keyedRuntime(),
+      makeMessage("delete Zephyr"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+    expect(deletes.count()).toBe(0);
+    expect((result?.data as { reason: string }).reason).toBe("not_found");
+  });
+
+  it("degrades gracefully with no Cloud API key", async () => {
+    const cb = captureCallback();
+    const result = await deleteAppAction.handler(
+      unkeyedRuntime(),
+      makeMessage("delete Acme Bot — yes"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+    expect(result?.success).toBe(false);
+    expect((result?.data as { reason: string }).reason).toBe("no_key");
+  });
+
+  it("surfaces a delete API error", async () => {
+    setDeleteApp(() => Promise.reject(new Error("boom")));
+    const cb = captureCallback();
+    const result = await deleteAppAction.handler(
+      keyedRuntime(),
+      makeMessage("delete Acme Bot — yes"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+    expect(result?.success).toBe(false);
+    expect((result?.data as { reason: string }).reason).toBe("error");
+  });
+});

--- a/plugins/plugin-cloud-apps/__tests__/deploy-app.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/deploy-app.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+  captureCallback,
+  FakeElizaCloudClient,
+  keyedRuntime,
+  type MemoryRuntime,
+  makeApp,
+  makeRoomMessage,
+  memoryRuntime,
+  resetSdk,
+  setDeployApp,
+  setGetApp,
+  setGetAppDeployStatus,
+  setListApps,
+  unkeyedRuntime,
+} from "./helpers";
+
+mock.module("@elizaos/cloud-sdk", () => ({
+  ElizaCloudClient: FakeElizaCloudClient,
+}));
+
+const { deployAppAction } = await import("../src/actions/deploy-app.ts");
+const { APP_DEPLOY_FACT_SOURCE } = await import("../src/app-facts.ts");
+
+const realFetch = globalThis.fetch;
+
+/** Stub the reachability probe's global fetch. */
+function stubFetch(result: { ok: boolean; status: number } | Error): void {
+  globalThis.fetch = mock(() =>
+    result instanceof Error
+      ? Promise.reject(result)
+      : Promise.resolve(result as unknown as Response),
+  ) as unknown as typeof fetch;
+}
+
+/** Wire the SDK so resolveApp + the gate see one deployable app. */
+function wireApp(
+  app = makeApp({
+    id: "id-acme",
+    name: "Acme Bot",
+    slug: "acme-bot",
+    production_url: "https://acme.elizacloud.ai",
+    deployment_status: "deployed",
+  }),
+): void {
+  setListApps(() => Promise.resolve({ success: true, apps: [app] }));
+  setGetApp(() => Promise.resolve({ success: true, app }));
+  setDeployApp(() =>
+    Promise.resolve({
+      success: true,
+      deploymentId: "dep_1",
+      status: "BUILDING",
+      startedAt: "2026-06-29T00:00:00.000Z",
+    }),
+  );
+}
+
+describe("DEPLOY_APP", () => {
+  beforeEach(() => {
+    resetSdk();
+    stubFetch({ ok: true, status: 200 });
+  });
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it("validates only when a Cloud API key is present", async () => {
+    expect(
+      await deployAppAction.validate(keyedRuntime(), makeRoomMessage("x")),
+    ).toBe(true);
+    expect(
+      await deployAppAction.validate(unkeyedRuntime(), makeRoomMessage("x")),
+    ).toBe(false);
+  });
+
+  it("deploys, waits for READY, probes /health, and reports the live url", async () => {
+    wireApp();
+    setGetAppDeployStatus(() =>
+      Promise.resolve({
+        success: true,
+        deploymentId: "dep_1",
+        status: "READY",
+        vercelUrl: null,
+        error: null,
+        startedAt: null,
+      }),
+    );
+
+    const cb = captureCallback();
+    const result = await deployAppAction.handler(
+      keyedRuntime(),
+      makeRoomMessage("deploy my Acme Bot app"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+
+    expect(result?.success).toBe(true);
+    expect((result?.data as { phase: string }).phase).toBe("ready");
+    expect((result?.data as { url: string }).url).toBe(
+      "https://acme.elizacloud.ai",
+    );
+    const finalReply = cb.calls[cb.calls.length - 1]?.text ?? "";
+    expect(finalReply).toContain("live at https://acme.elizacloud.ai");
+  });
+
+  it("does NOT claim live when /health is unreachable", async () => {
+    wireApp();
+    setGetAppDeployStatus(() =>
+      Promise.resolve({
+        success: true,
+        deploymentId: "dep_1",
+        status: "READY",
+        vercelUrl: null,
+        error: null,
+        startedAt: null,
+      }),
+    );
+    stubFetch({ ok: false, status: 503 });
+
+    const cb = captureCallback();
+    const result = await deployAppAction.handler(
+      keyedRuntime(),
+      makeRoomMessage("ship Acme Bot"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+
+    expect(result?.success).toBe(false);
+    expect((result?.data as { phase: string }).phase).toBe("unreachable");
+    const reply = cb.calls[cb.calls.length - 1]?.text ?? "";
+    expect(reply.toLowerCase()).not.toContain("is live at");
+    expect(reply.toLowerCase()).toContain("isn't answering");
+  });
+
+  it("surfaces a failed deploy as an error (not live)", async () => {
+    wireApp();
+    setGetAppDeployStatus(() =>
+      Promise.resolve({
+        success: true,
+        deploymentId: "dep_1",
+        status: "ERROR",
+        vercelUrl: null,
+        error: "image build failed",
+        startedAt: null,
+      }),
+    );
+
+    const cb = captureCallback();
+    const result = await deployAppAction.handler(
+      keyedRuntime(),
+      makeRoomMessage("deploy Acme Bot"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+
+    expect(result?.success).toBe(false);
+    expect((result?.data as { phase: string }).phase).toBe("error");
+    expect(cb.calls[cb.calls.length - 1]?.text).toContain("failed");
+  });
+
+  it("returns a graceful not-found when the app does not exist", async () => {
+    setListApps(() =>
+      Promise.resolve({
+        success: true,
+        apps: [makeApp({ name: "Other", slug: "other" })],
+      }),
+    );
+    const cb = captureCallback();
+    const result = await deployAppAction.handler(
+      keyedRuntime(),
+      makeRoomMessage("deploy Zephyr"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+    expect(result?.success).toBe(false);
+    expect((result?.data as { reason: string }).reason).toBe("not_found");
+  });
+
+  it("degrades gracefully with no Cloud API key", async () => {
+    const cb = captureCallback();
+    const result = await deployAppAction.handler(
+      unkeyedRuntime(),
+      makeRoomMessage("deploy Acme"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+    expect(result?.success).toBe(false);
+    expect((result?.data as { reason: string }).reason).toBe("no_key");
+  });
+
+  describe("facts cache (idempotent)", () => {
+    it("writes exactly one deploy fact, and re-deploy updates it in place", async () => {
+      wireApp();
+      setGetAppDeployStatus(() =>
+        Promise.resolve({
+          success: true,
+          deploymentId: "dep_1",
+          status: "READY",
+          vercelUrl: null,
+          error: null,
+          startedAt: null,
+        }),
+      );
+
+      const runtime: MemoryRuntime = memoryRuntime();
+      const msg = makeRoomMessage("deploy my Acme Bot app");
+
+      const first = await deployAppAction.handler(
+        runtime,
+        msg,
+        undefined,
+        undefined,
+        captureCallback().fn,
+      );
+      expect((first?.data as { factWritten: boolean }).factWritten).toBe(true);
+      expect((first?.data as { factUpdated: boolean }).factUpdated).toBe(false);
+      expect(runtime.__facts).toHaveLength(1);
+      expect(runtime.__facts[0]?.content.text).toContain("Acme Bot");
+      expect(runtime.__facts[0]?.content.text).toContain(
+        "https://acme.elizacloud.ai",
+      );
+      expect((runtime.__facts[0]?.metadata as { source?: string }).source).toBe(
+        APP_DEPLOY_FACT_SOURCE,
+      );
+      expect((runtime.__facts[0]?.metadata as { appId?: string }).appId).toBe(
+        "id-acme",
+      );
+
+      const second = await deployAppAction.handler(
+        runtime,
+        msg,
+        undefined,
+        undefined,
+        captureCallback().fn,
+      );
+      expect((second?.data as { factUpdated: boolean }).factUpdated).toBe(true);
+      // Still exactly one fact — no duplicate for the same app.id.
+      expect(runtime.__facts).toHaveLength(1);
+    });
+  });
+});

--- a/plugins/plugin-cloud-apps/__tests__/deploy-gate.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/deploy-gate.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "bun:test";
+import type { AppDeployStatusResponse, AppResponse } from "@elizaos/cloud-sdk";
+import {
+  classifyDeployStatus,
+  type DeployGateConfig,
+  type DeployGateDeps,
+  runDeployGate,
+} from "../src/deploy-gate.ts";
+import type { ReachabilityResult } from "../src/reachability.ts";
+import { makeApp } from "./helpers";
+
+const FAST_CONFIG: DeployGateConfig = {
+  maxAttempts: 5,
+  initialDelayMs: 1,
+  maxDelayMs: 2,
+  probeTimeoutMs: 10,
+  healthPath: "/health",
+};
+
+function statusRes(
+  overrides: Partial<AppDeployStatusResponse>,
+): AppDeployStatusResponse {
+  return {
+    success: true,
+    deploymentId: "dep_1",
+    status: "BUILDING",
+    vercelUrl: null,
+    error: null,
+    startedAt: null,
+    ...overrides,
+  };
+}
+
+function appRes(productionUrl: string | null): AppResponse {
+  return {
+    success: true,
+    app: makeApp({
+      production_url: productionUrl,
+      deployment_status: "deployed",
+    }),
+  };
+}
+
+/** Build deps that walk a fixed status sequence, then probe a fixed result. */
+function makeDeps(args: {
+  statuses: AppDeployStatusResponse[];
+  productionUrl?: string | null;
+  probe?: ReachabilityResult;
+  onProbe?: (url: string) => void;
+}): DeployGateDeps & { statusCalls: number; appCalls: number } {
+  let statusCalls = 0;
+  let appCalls = 0;
+  const deps: DeployGateDeps & { statusCalls: number; appCalls: number } = {
+    statusCalls: 0,
+    appCalls: 0,
+    getStatus: () => {
+      const idx = Math.min(statusCalls, args.statuses.length - 1);
+      statusCalls += 1;
+      deps.statusCalls = statusCalls;
+      return Promise.resolve(args.statuses[idx]);
+    },
+    getApp: () => {
+      appCalls += 1;
+      deps.appCalls = appCalls;
+      return Promise.resolve(appRes(args.productionUrl ?? null));
+    },
+    probe: (url) => {
+      args.onProbe?.(url);
+      return Promise.resolve(args.probe ?? { ok: true, status: 200 });
+    },
+    sleep: () => Promise.resolve(),
+  };
+  return deps;
+}
+
+describe("classifyDeployStatus", () => {
+  it("maps the public lifecycle to success/error/pending", () => {
+    expect(classifyDeployStatus("READY")).toBe("success");
+    expect(classifyDeployStatus("deployed")).toBe("success");
+    expect(classifyDeployStatus("ERROR")).toBe("error");
+    expect(classifyDeployStatus("failed")).toBe("error");
+    expect(classifyDeployStatus("BUILDING")).toBe("pending");
+    expect(classifyDeployStatus("DEPLOYING")).toBe("pending");
+    expect(classifyDeployStatus("DRAFT")).toBe("pending");
+    expect(classifyDeployStatus(null)).toBe("pending");
+  });
+});
+
+describe("runDeployGate", () => {
+  it("succeeds: BUILDING → BUILDING → READY + reachable /health → live url", async () => {
+    let probedUrl = "";
+    const deps = makeDeps({
+      statuses: [
+        statusRes({ status: "BUILDING" }),
+        statusRes({ status: "BUILDING" }),
+        statusRes({ status: "READY" }),
+      ],
+      productionUrl: "https://acme.elizacloud.ai",
+      probe: { ok: true, status: 200 },
+      onProbe: (u) => {
+        probedUrl = u;
+      },
+    });
+
+    const result = await runDeployGate(deps, FAST_CONFIG);
+
+    expect(result.phase).toBe("ready");
+    expect(result.url).toBe("https://acme.elizacloud.ai");
+    expect(result.attempts).toBe(3);
+    expect(probedUrl).toBe("https://acme.elizacloud.ai/health");
+    expect(result.reachability?.ok).toBe(true);
+  });
+
+  it("reads the authoritative production_url, not the status vercelUrl", async () => {
+    const deps = makeDeps({
+      // status reports a stale/placeholder url; the app row is authoritative
+      statuses: [
+        statusRes({ status: "READY", vercelUrl: "https://stale.example" }),
+      ],
+      productionUrl: "https://fresh.elizacloud.ai",
+      probe: { ok: true, status: 200 },
+    });
+    const result = await runDeployGate(deps, FAST_CONFIG);
+    expect(result.url).toBe("https://fresh.elizacloud.ai");
+  });
+
+  it("times out when status never reaches READY", async () => {
+    const deps = makeDeps({
+      statuses: [statusRes({ status: "BUILDING" })],
+      probe: { ok: true, status: 200 },
+    });
+    const result = await runDeployGate(deps, {
+      ...FAST_CONFIG,
+      maxAttempts: 3,
+    });
+    expect(result.phase).toBe("timeout");
+    expect(result.attempts).toBe(3);
+    expect(deps.statusCalls).toBe(3);
+  });
+
+  it("returns ERROR immediately on a failed deploy", async () => {
+    const deps = makeDeps({
+      statuses: [statusRes({ status: "ERROR", error: "build failed: exit 1" })],
+    });
+    const result = await runDeployGate(deps, FAST_CONFIG);
+    expect(result.phase).toBe("error");
+    expect(result.error).toBe("build failed: exit 1");
+    expect(deps.statusCalls).toBe(1);
+  });
+
+  it("reports unreachable when READY but /health is not 2xx (does NOT claim live)", async () => {
+    const deps = makeDeps({
+      statuses: [statusRes({ status: "READY" })],
+      productionUrl: "https://acme.elizacloud.ai",
+      probe: { ok: false, status: 503 },
+    });
+    const result = await runDeployGate(deps, FAST_CONFIG);
+    expect(result.phase).toBe("unreachable");
+    expect(result.url).toBe("https://acme.elizacloud.ai");
+    expect(result.reachability?.status).toBe(503);
+  });
+
+  it("reports unreachable when READY but no production_url exists", async () => {
+    const deps = makeDeps({
+      statuses: [statusRes({ status: "READY", vercelUrl: null })],
+      productionUrl: null,
+      probe: { ok: true, status: 200 },
+    });
+    const result = await runDeployGate(deps, FAST_CONFIG);
+    expect(result.phase).toBe("unreachable");
+    expect(result.error).toBe("no_production_url");
+  });
+});

--- a/plugins/plugin-cloud-apps/__tests__/get-app-deploy-status.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/get-app-deploy-status.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { AppDeployStatusResponse } from "@elizaos/cloud-sdk";
+import {
+  captureCallback,
+  FakeElizaCloudClient,
+  keyedRuntime,
+  makeApp,
+  makeMessage,
+  resetSdk,
+  setGetAppDeployStatus,
+  setListApps,
+  unkeyedRuntime,
+} from "./helpers";
+
+mock.module("@elizaos/cloud-sdk", () => ({
+  ElizaCloudClient: FakeElizaCloudClient,
+}));
+
+const { getAppDeployStatusAction, formatDeployStatus } = await import(
+  "../src/actions/get-app-deploy-status.ts"
+);
+
+const APP = makeApp({
+  id: "id-acme",
+  name: "Acme Bot",
+  slug: "acme-bot",
+  production_url: "https://acme.elizacloud.ai",
+});
+
+function status(
+  overrides: Partial<AppDeployStatusResponse>,
+): AppDeployStatusResponse {
+  return {
+    success: true,
+    deploymentId: "dep_1",
+    status: "DRAFT",
+    vercelUrl: null,
+    error: null,
+    startedAt: null,
+    ...overrides,
+  };
+}
+
+describe("formatDeployStatus", () => {
+  it("formats each public lifecycle status", () => {
+    expect(formatDeployStatus(APP, status({ status: "DRAFT" }))).toContain(
+      "hasn't been deployed",
+    );
+    expect(formatDeployStatus(APP, status({ status: "BUILDING" }))).toContain(
+      "building",
+    );
+    expect(formatDeployStatus(APP, status({ status: "DEPLOYING" }))).toContain(
+      "building",
+    );
+    expect(
+      formatDeployStatus(
+        APP,
+        status({ status: "READY", vercelUrl: "https://acme.elizacloud.ai" }),
+      ),
+    ).toContain("live at https://acme.elizacloud.ai");
+    expect(
+      formatDeployStatus(APP, status({ status: "ERROR", error: "oom" })),
+    ).toContain("failed: oom");
+  });
+
+  it("falls back to the app production_url for READY when status has none", () => {
+    expect(formatDeployStatus(APP, status({ status: "READY" }))).toContain(
+      "https://acme.elizacloud.ai",
+    );
+  });
+});
+
+describe("GET_APP_DEPLOY_STATUS", () => {
+  beforeEach(() => {
+    resetSdk();
+    setListApps(() => Promise.resolve({ success: true, apps: [APP] }));
+  });
+
+  it("validates only when a Cloud API key is present", async () => {
+    expect(
+      await getAppDeployStatusAction.validate(keyedRuntime(), makeMessage("x")),
+    ).toBe(true);
+    expect(
+      await getAppDeployStatusAction.validate(
+        unkeyedRuntime(),
+        makeMessage("x"),
+      ),
+    ).toBe(false);
+  });
+
+  it("resolves the app and reports its live status", async () => {
+    setGetAppDeployStatus(() =>
+      status({ status: "READY", vercelUrl: "https://acme.elizacloud.ai" }),
+    );
+    const cb = captureCallback();
+    const result = await getAppDeployStatusAction.handler(
+      keyedRuntime(),
+      makeMessage("is my Acme Bot app live?"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+    expect(result?.success).toBe(true);
+    expect((result?.data as { status: string }).status).toBe("READY");
+    expect(cb.calls[0]?.text).toContain("live at https://acme.elizacloud.ai");
+  });
+
+  it("reports a building app", async () => {
+    setGetAppDeployStatus(() => status({ status: "BUILDING" }));
+    const cb = captureCallback();
+    const result = await getAppDeployStatusAction.handler(
+      keyedRuntime(),
+      makeMessage("Acme Bot deploy status"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+    expect(result?.success).toBe(true);
+    expect(cb.calls[0]?.text).toContain("building");
+  });
+
+  it("degrades gracefully with no Cloud API key", async () => {
+    const cb = captureCallback();
+    const result = await getAppDeployStatusAction.handler(
+      unkeyedRuntime(),
+      makeMessage("is Acme live?"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+    expect(result?.success).toBe(false);
+    expect((result?.data as { reason: string }).reason).toBe("no_key");
+  });
+
+  it("returns not-found for an unknown app", async () => {
+    const cb = captureCallback();
+    const result = await getAppDeployStatusAction.handler(
+      keyedRuntime(),
+      makeMessage("is Zephyr live?"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+    expect(result?.success).toBe(false);
+    expect((result?.data as { reason: string }).reason).toBe("not_found");
+  });
+});

--- a/plugins/plugin-cloud-apps/__tests__/helpers.ts
+++ b/plugins/plugin-cloud-apps/__tests__/helpers.ts
@@ -8,40 +8,114 @@
  */
 
 import { mock } from "bun:test";
-import type { AppDto, AppResponse, ListAppsResponse } from "@elizaos/cloud-sdk";
+import type {
+  AppDeployStatusResponse,
+  AppDto,
+  AppResponse,
+  CreateAppInput,
+  CreateAppResponse,
+  DeleteAppResponse,
+  DeployAppInput,
+  DeployAppResponse,
+  ListAppsResponse,
+} from "@elizaos/cloud-sdk";
 import type { IAgentRuntime, Memory } from "@elizaos/core";
 
 type ListAppsFn = () => Promise<ListAppsResponse>;
 type GetAppFn = (id: string) => Promise<AppResponse>;
+type CreateAppFn = (input: CreateAppInput) => Promise<CreateAppResponse>;
+type DeployAppFn = (
+  id: string,
+  input?: DeployAppInput,
+) => Promise<DeployAppResponse>;
+type GetAppDeployStatusFn = (id: string) => Promise<AppDeployStatusResponse>;
+type DeleteAppFn = (id: string) => Promise<DeleteAppResponse>;
 
-const state: { listApps: ListAppsFn; getApp: GetAppFn } = {
-  listApps: () => Promise.resolve({ success: true, apps: [] }),
-  getApp: () =>
-    Promise.resolve({ success: true, app: undefined as unknown as AppDto }),
-};
+interface SdkState {
+  listApps: ListAppsFn;
+  getApp: GetAppFn;
+  createApp: CreateAppFn;
+  deployApp: DeployAppFn;
+  getAppDeployStatus: GetAppDeployStatusFn;
+  deleteApp: DeleteAppFn;
+}
+
+function defaultState(): SdkState {
+  return {
+    listApps: () => Promise.resolve({ success: true, apps: [] }),
+    getApp: () =>
+      Promise.resolve({ success: true, app: undefined as unknown as AppDto }),
+    createApp: () =>
+      Promise.resolve({
+        success: true,
+        app: undefined as unknown as AppDto,
+        apiKey: "eliza_app_secret",
+      }),
+    deployApp: () =>
+      Promise.resolve({
+        success: true,
+        deploymentId: "dep_1",
+        status: "BUILDING",
+        startedAt: "2026-06-29T00:00:00.000Z",
+      }),
+    getAppDeployStatus: () =>
+      Promise.resolve({
+        success: true,
+        deploymentId: "dep_1",
+        status: "READY",
+        vercelUrl: null,
+        error: null,
+        startedAt: null,
+      }),
+    deleteApp: () => Promise.resolve({ success: true, message: "deleted" }),
+  };
+}
+
+const state: SdkState = defaultState();
 
 export function setListApps(fn: ListAppsFn): void {
   state.listApps = fn;
 }
-
 export function setGetApp(fn: GetAppFn): void {
   state.getApp = fn;
+}
+export function setCreateApp(fn: CreateAppFn): void {
+  state.createApp = fn;
+}
+export function setDeployApp(fn: DeployAppFn): void {
+  state.deployApp = fn;
+}
+export function setGetAppDeployStatus(fn: GetAppDeployStatusFn): void {
+  state.getAppDeployStatus = fn;
+}
+export function setDeleteApp(fn: DeleteAppFn): void {
+  state.deleteApp = fn;
 }
 
 /** Restore default (empty / no-op) behavior between tests. */
 export function resetSdk(): void {
-  state.listApps = () => Promise.resolve({ success: true, apps: [] });
-  state.getApp = () =>
-    Promise.resolve({ success: true, app: undefined as unknown as AppDto });
+  Object.assign(state, defaultState());
 }
 
-/** Stand-in for `ElizaCloudClient` — only the methods the read-core calls. */
+/** Stand-in for `ElizaCloudClient` — the methods the plugin calls. */
 export class FakeElizaCloudClient {
   listApps(): Promise<ListAppsResponse> {
     return state.listApps();
   }
   getApp(id: string): Promise<AppResponse> {
     return state.getApp(id);
+  }
+  createApp(input: CreateAppInput): Promise<CreateAppResponse> {
+    return state.createApp(input);
+  }
+  deployApp(id: string, input?: DeployAppInput): Promise<DeployAppResponse> {
+    return state.deployApp(id, input);
+  }
+  getAppDeployStatus(id: string): Promise<AppDeployStatusResponse> {
+    return state.getAppDeployStatus(id);
+  }
+  deleteApp(id: string): Promise<DeleteAppResponse> {
+    return state.deleteApp(id);
   }
 }
 
@@ -62,6 +136,54 @@ export function keyedRuntime(): IAgentRuntime {
 /** A runtime with no Cloud API key. */
 export function unkeyedRuntime(): IAgentRuntime {
   return makeRuntime({});
+}
+
+/**
+ * A keyed runtime backed by a real in-memory `facts` store, so the facts-cache
+ * code under test exercises its actual create/get/update logic (only the store
+ * boundary is faked — the dedup + write path runs for real).
+ */
+export interface MemoryRuntime extends IAgentRuntime {
+  __facts: Memory[];
+}
+
+export function memoryRuntime(
+  settings: Record<string, string | undefined> = {
+    ELIZAOS_CLOUD_API_KEY: "eliza_test_key",
+  },
+): MemoryRuntime {
+  const facts: Memory[] = [];
+  let counter = 0;
+  const runtime = {
+    agentId: "agent-0000-0000-0000-000000000000",
+    __facts: facts,
+    getSetting: (key: string) => settings[key] as unknown,
+    getMemories: (params: { tableName: string }) =>
+      Promise.resolve(params.tableName === "facts" ? [...facts] : []),
+    createMemory: (memory: Memory, tableName: string) => {
+      const id = `mem-${++counter}`;
+      if (tableName === "facts") facts.push({ ...memory, id } as Memory);
+      return Promise.resolve(id);
+    },
+    updateMemory: (patch: Partial<Memory> & { id: string }) => {
+      const idx = facts.findIndex(
+        (m) => (m as { id?: string }).id === patch.id,
+      );
+      if (idx >= 0) facts[idx] = { ...facts[idx], ...patch } as Memory;
+      return Promise.resolve(idx >= 0);
+    },
+  } as unknown as MemoryRuntime;
+  return runtime;
+}
+
+/** Build a message Memory with entity/room ids (for memory-writing actions). */
+export function makeRoomMessage(text: string): Memory {
+  return {
+    id: "msg-0000-0000-0000-000000000000",
+    entityId: "entity-0000-0000-0000-000000000000",
+    roomId: "room-0000-0000-0000-000000000000",
+    content: { text },
+  } as unknown as Memory;
 }
 
 /** Build a message Memory with the given text. */

--- a/plugins/plugin-cloud-apps/__tests__/safety.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/safety.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "bun:test";
+import {
+  buildConnectorCta,
+  confirmationPrompt,
+  isExplicitConfirmation,
+} from "../src/safety.ts";
+
+const TARGET = {
+  name: "Acme Bot",
+  id: "11111111-2222-3333-4444-555555555555",
+  aliases: ["acme-bot"],
+};
+
+describe("isExplicitConfirmation", () => {
+  it("rejects a plain first ask (no affirmation word)", () => {
+    expect(isExplicitConfirmation("delete my Acme Bot app", TARGET)).toBe(
+      false,
+    );
+    expect(isExplicitConfirmation("remove acme-bot please", TARGET)).toBe(
+      false,
+    );
+  });
+
+  it("accepts an affirmation + verb", () => {
+    expect(isExplicitConfirmation("yes delete it", TARGET)).toBe(true);
+    expect(isExplicitConfirmation("delete Acme Bot — yes", TARGET)).toBe(true);
+    expect(isExplicitConfirmation("confirm, delete the app", TARGET)).toBe(
+      true,
+    );
+  });
+
+  it("accepts an affirmation + target reference (name/slug/id)", () => {
+    expect(isExplicitConfirmation("yes, Acme Bot", TARGET)).toBe(true);
+    expect(isExplicitConfirmation("go ahead with acme-bot", TARGET)).toBe(true);
+    expect(
+      isExplicitConfirmation(
+        "yes 11111111-2222-3333-4444-555555555555",
+        TARGET,
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects a bare affirmation with no verb and no target", () => {
+    expect(isExplicitConfirmation("yes", TARGET)).toBe(false);
+    expect(isExplicitConfirmation("ok sure", TARGET)).toBe(false);
+  });
+
+  it("rejects negative / hesitant replies", () => {
+    expect(isExplicitConfirmation("no, keep it", TARGET)).toBe(false);
+    expect(isExplicitConfirmation("hmm not sure, maybe later", TARGET)).toBe(
+      false,
+    );
+    expect(isExplicitConfirmation("", TARGET)).toBe(false);
+  });
+
+  it("does not match a short alias inside unrelated prose", () => {
+    // 'go' alias would be < 3 chars and must be ignored.
+    expect(
+      isExplicitConfirmation("yes let's go", { name: "go", aliases: ["go"] }),
+    ).toBe(false);
+  });
+});
+
+describe("confirmationPrompt", () => {
+  it("names the target, what is destroyed, and the exact token", () => {
+    const prompt = confirmationPrompt(TARGET, [
+      "its running container",
+      "its tenant database",
+    ]);
+    expect(prompt).toContain("Acme Bot");
+    expect(prompt).toContain(TARGET.id);
+    expect(prompt).toContain("its running container");
+    expect(prompt).toContain("its tenant database");
+    expect(prompt.toLowerCase()).toContain("can't be undone");
+    expect(prompt).toContain("delete Acme Bot — yes");
+    // The prompt itself is an explicit-confirmation template; sanity-check that
+    // re-feeding the suggested token confirms.
+    expect(isExplicitConfirmation("delete Acme Bot — yes", TARGET)).toBe(true);
+  });
+});
+
+describe("buildConnectorCta", () => {
+  it("builds a neutral {label,url,kind} for an https URL", () => {
+    const cta = buildConnectorCta(
+      "Withdraw",
+      "https://x.test/withdraw",
+      "button",
+    );
+    expect(cta).toEqual({
+      label: "Withdraw",
+      url: "https://x.test/withdraw",
+      kind: "button",
+    });
+  });
+
+  it("rejects non-http(s) URLs (no creds/money smuggling)", () => {
+    expect(() => buildConnectorCta("x", "javascript:alert(1)")).toThrow();
+    expect(() => buildConnectorCta("x", "not a url")).toThrow();
+  });
+});

--- a/plugins/plugin-cloud-apps/src/actions/create-app.ts
+++ b/plugins/plugin-cloud-apps/src/actions/create-app.ts
@@ -1,0 +1,297 @@
+/**
+ * CREATE_APP — "build me an app called X".
+ *
+ * Parses the app name + description + monetization intent from the user's text
+ * (planner options win when present), calls the typed `client.createApp({...})`,
+ * and replies with the created draft app and an offer to deploy it.
+ *
+ * Security: the create response returns the app's plaintext API key ONCE. We do
+ * NOT echo it into the chat reply (credentials must never transit a connector) —
+ * the key lives in the user's dashboard.
+ *
+ * A brand-new app has no public URL yet, so we register it with the draft
+ * sentinel `app_url` the server recognizes; DEPLOY_APP later assigns the real
+ * `production_url`.
+ */
+
+import type { CreateAppInput } from "@elizaos/cloud-sdk";
+import type {
+  Action,
+  ActionResult,
+  HandlerCallback,
+  IAgentRuntime,
+  Memory,
+  State,
+} from "@elizaos/core";
+import { logger } from "@elizaos/core";
+import { getCloudClient, resolveCloudApiKey } from "../client.js";
+
+/** Draft sentinel URL the server treats as "not yet deployed" (no launch alert). */
+export const DRAFT_APP_URL = "https://placeholder.local";
+
+const NO_KEY_MESSAGE =
+  "I can't reach Eliza Cloud yet — no Cloud API key is configured. Add your ELIZAOS_CLOUD_API_KEY and I can create apps for you.";
+const NO_NAME_MESSAGE =
+  "Sure — what should I call the app? Give me a name and I'll create it on Eliza Cloud.";
+const ERROR_MESSAGE =
+  "I couldn't create that app right now — the Cloud API returned an error. Try again in a moment.";
+
+export interface CreateAppIntent {
+  name: string | null;
+  description?: string;
+  monetization: boolean;
+  markupPercentage?: number;
+}
+
+const OPTION_NAME_KEYS = ["name", "appName", "app", "title"] as const;
+const OPTION_DESCRIPTION_KEYS = ["description", "desc", "about"] as const;
+const OPTION_MONETIZATION_KEYS = [
+  "monetization",
+  "monetize",
+  "monetization_enabled",
+  "monetizationEnabled",
+  "paid",
+] as const;
+const OPTION_MARKUP_KEYS = [
+  "markup",
+  "markupPercentage",
+  "inference_markup_percentage",
+  "inferenceMarkupPercentage",
+] as const;
+
+// Free-text name extraction. Bounded captures so a name never swallows a clause.
+// The lookahead ends a name at punctuation, a continuation clause, or common
+// trailing filler ("please", "now", "thanks", …) so "named Zephyr please" → "Zephyr".
+const NAME_STOP =
+  "(?=$|[.,;!?\\n]|\\s+(?:that|which|with|to|for|and|please|now|thanks|thank|asap|today|right now|for me)\\b)";
+const NAME_PATTERNS: RegExp[] = [
+  new RegExp(
+    `(?:app|bot|project|tool|site|game|agent)\\s+(?:called|named|titled)\\s+["“']?([^"”'.,\\n]{1,60}?)["”']?${NAME_STOP}`,
+    "i",
+  ),
+  new RegExp(
+    `\\b(?:called|named|titled)\\s+["“']?([^"”'.,\\n]{1,60}?)["”']?${NAME_STOP}`,
+    "i",
+  ),
+  /\bname\s*[:=]\s*["“']?([^"”'.,\n]{1,60}?)["”']?(?=$|[.,;!?\n])/i,
+  /["“']([^"”'\n]{2,60})["”']/,
+];
+
+function asString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function asBool(value: unknown): boolean | null {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    const v = value.trim().toLowerCase();
+    if (["true", "yes", "on", "1"].includes(v)) return true;
+    if (["false", "no", "off", "0"].includes(v)) return false;
+  }
+  return null;
+}
+
+function asNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const n = Number(value.replace(/%/g, "").trim());
+    if (Number.isFinite(n)) return n;
+  }
+  return null;
+}
+
+function parseNameFromText(text: string): string | null {
+  for (const pattern of NAME_PATTERNS) {
+    const match = pattern.exec(text);
+    const captured = match?.[1]?.trim();
+    if (captured && captured.length >= 1 && captured.length <= 100) {
+      return captured.replace(/\s+/g, " ");
+    }
+  }
+  return null;
+}
+
+/** Parse name/description/monetization intent from planner options + raw text. */
+export function parseCreateAppIntent(
+  text: string,
+  options?: unknown,
+): CreateAppIntent {
+  const opts =
+    options && typeof options === "object"
+      ? (options as Record<string, unknown>)
+      : {};
+
+  const firstOption = (keys: readonly string[]): unknown => {
+    for (const key of keys) {
+      if (opts[key] !== undefined) return opts[key];
+    }
+    return undefined;
+  };
+
+  let name: string | null = null;
+  for (const key of OPTION_NAME_KEYS) {
+    const v = asString(opts[key]);
+    if (v) {
+      name = v;
+      break;
+    }
+  }
+  if (!name) name = parseNameFromText(text ?? "");
+
+  let description: string | undefined;
+  for (const key of OPTION_DESCRIPTION_KEYS) {
+    const v = asString(opts[key]);
+    if (v) {
+      description = v;
+      break;
+    }
+  }
+
+  const monetizationOpt = asBool(firstOption(OPTION_MONETIZATION_KEYS));
+  const monetization =
+    monetizationOpt ??
+    /\b(monetiz\w*|charge(?:s|d)?\s+(?:users|for)|paid\s+app|make\s+money|earn\b|revenue|premium|subscription)\b/i.test(
+      text ?? "",
+    );
+
+  let markupPercentage = asNumber(firstOption(OPTION_MARKUP_KEYS)) ?? undefined;
+  if (markupPercentage === undefined && monetization) {
+    const m = /(\d+(?:\.\d+)?)\s*%/.exec(text ?? "");
+    if (m) {
+      const n = Number(m[1]);
+      if (Number.isFinite(n)) markupPercentage = n;
+    }
+  }
+  if (
+    markupPercentage !== undefined &&
+    (markupPercentage < 0 || markupPercentage > 1000)
+  ) {
+    markupPercentage = undefined; // out of the server's 0–1000 range; drop it
+  }
+
+  return { name, description, monetization, markupPercentage };
+}
+
+function buildCreateBody(intent: CreateAppIntent): CreateAppInput {
+  const body: CreateAppInput = {
+    name: intent.name as string,
+    app_url: DRAFT_APP_URL,
+  };
+  if (intent.description) body.description = intent.description;
+  if (intent.monetization) body.monetization_enabled = true;
+  if (intent.markupPercentage !== undefined) {
+    body.inference_markup_percentage = intent.markupPercentage;
+  }
+  return body;
+}
+
+export const createAppAction: Action = {
+  name: "CREATE_APP",
+  similes: ["BUILD_APP", "MAKE_APP", "NEW_APP", "CREATE_CLOUD_APP"],
+  description:
+    "Create a new Eliza Cloud app for the user from a name (and optional description / monetization intent). Use when the user asks to build, make, create, or start a new app.",
+  descriptionCompressed: "Create a new Eliza Cloud app from the user's intent.",
+  contexts: ["settings", "finance", "apps"],
+  contextGate: { anyOf: ["settings", "finance", "apps"] },
+  suppressPostActionContinuation: true,
+
+  validate: async (runtime: IAgentRuntime): Promise<boolean> => {
+    return resolveCloudApiKey(runtime) !== null;
+  },
+
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory,
+    _state?: State,
+    options?: unknown,
+    callback?: HandlerCallback,
+  ): Promise<ActionResult> => {
+    const client = getCloudClient(runtime);
+    if (!client) {
+      await callback?.({ text: NO_KEY_MESSAGE, actions: ["CREATE_APP"] });
+      return {
+        success: false,
+        text: "No Eliza Cloud API key configured.",
+        userFacingText: NO_KEY_MESSAGE,
+        data: { reason: "no_key" },
+      };
+    }
+
+    const intent = parseCreateAppIntent(message.content?.text ?? "", options);
+    if (!intent.name) {
+      await callback?.({ text: NO_NAME_MESSAGE, actions: ["CREATE_APP"] });
+      return {
+        success: false,
+        text: "No app name supplied.",
+        userFacingText: NO_NAME_MESSAGE,
+        data: { reason: "no_name" },
+      };
+    }
+
+    try {
+      const body = buildCreateBody(intent);
+      const { app, warnings } = await client.createApp(body);
+
+      const lines = [`Created "${app.name}" on Eliza Cloud (status: draft).`];
+      if (intent.description) lines.push(intent.description);
+      if (app.monetization_enabled) {
+        const markup =
+          typeof app.inference_markup_percentage === "number"
+            ? ` (${app.inference_markup_percentage}% inference markup)`
+            : "";
+        lines.push(`Monetization is on${markup}.`);
+      }
+      if (warnings && warnings.length > 0) {
+        lines.push(`Note: ${warnings.join(" ")}`);
+      }
+      lines.push(`Want me to deploy it now? Just say "deploy ${app.name}".`);
+      const reply = lines.join("\n");
+
+      await callback?.({ text: reply, actions: ["CREATE_APP"] });
+      return {
+        success: true,
+        text: `Created Eliza Cloud app ${app.name}.`,
+        userFacingText: reply,
+        verifiedUserFacing: true,
+        data: {
+          app: { id: app.id, name: app.name, slug: app.slug },
+          monetization: app.monetization_enabled,
+        },
+      };
+    } catch (err) {
+      logger.warn(
+        `[CREATE_APP] Failed to create app "${intent.name}": ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      await callback?.({ text: ERROR_MESSAGE, actions: ["CREATE_APP"] });
+      return {
+        success: false,
+        text: "Failed to create Eliza Cloud app.",
+        userFacingText: ERROR_MESSAGE,
+        error: err instanceof Error ? err : new Error(String(err)),
+        data: { reason: "error" },
+      };
+    }
+  },
+
+  examples: [
+    [
+      {
+        name: "{{user}}",
+        content: { text: "build me an app called Acme Bot" },
+      },
+      {
+        name: "{{agent}}",
+        content: {
+          text: 'Created "Acme Bot" on Eliza Cloud (status: draft).\nWant me to deploy it now? Just say "deploy Acme Bot".',
+          actions: ["CREATE_APP"],
+        },
+      },
+    ],
+  ],
+};
+
+export default createAppAction;

--- a/plugins/plugin-cloud-apps/src/actions/delete-app.ts
+++ b/plugins/plugin-cloud-apps/src/actions/delete-app.ts
@@ -1,0 +1,212 @@
+/**
+ * DELETE_APP — DESTRUCTIVE. Two-phase confirm, connector-agnostic.
+ *
+ * Deleting an app tears down its container AND its tenant database — irreversible.
+ * So this action NEVER deletes on the first ask:
+ *   1. First turn ("delete my Acme app"): resolve the app, return a confirmation
+ *      prompt naming the exact app + what's destroyed. `deleteApp` is NOT called.
+ *   2. Follow-up turn carrying an explicit confirmation token ("delete Acme —
+ *      yes"): `client.deleteApp(id)` runs exactly once.
+ *
+ * The confirm signal is parsed from the user's plain message text via the shared
+ * {@link isExplicitConfirmation} helper, so it works the same on every connector
+ * and does not rely on a GUI button.
+ */
+
+import type { AppDto } from "@elizaos/cloud-sdk";
+import type {
+  Action,
+  ActionResult,
+  HandlerCallback,
+  IAgentRuntime,
+  Memory,
+  State,
+} from "@elizaos/core";
+import { logger } from "@elizaos/core";
+import {
+  extractAppReference,
+  getCloudClient,
+  resolveApp,
+  resolveCloudApiKey,
+} from "../client.js";
+import { confirmationPrompt, isExplicitConfirmation } from "../safety.js";
+
+const NO_KEY_MESSAGE =
+  "I can't reach Eliza Cloud yet — no Cloud API key is configured. Add your ELIZAOS_CLOUD_API_KEY and I can manage your apps.";
+const NO_REFERENCE_MESSAGE =
+  "Which app would you like to delete? Tell me its name.";
+const ERROR_MESSAGE =
+  "I couldn't delete that app right now — the Cloud API returned an error. Try again in a moment.";
+
+/** What `deleteApp` destroys — surfaced verbatim in the confirmation prompt. */
+const DESTROYED_RESOURCES = ["its running container", "its tenant database"];
+
+function notFoundMessage(reference: string, available: string[]): string {
+  const base = `I couldn't find an app matching "${reference}".`;
+  if (available.length === 0) {
+    return `${base} You don't have any apps on Eliza Cloud yet.`;
+  }
+  return `${base} Your apps are: ${available.join(", ")}.`;
+}
+
+function confirmTargetFor(app: AppDto): {
+  name: string;
+  id: string;
+  aliases: string[];
+} {
+  return { name: app.name, id: app.id, aliases: [app.slug] };
+}
+
+export const deleteAppAction: Action = {
+  name: "DELETE_APP",
+  similes: ["REMOVE_APP", "DELETE_MY_APP", "DESTROY_APP", "DELETE_CLOUD_APP"],
+  description:
+    "Delete an Eliza Cloud app. DESTRUCTIVE: tears down the app's container and tenant database. Requires an explicit confirmation — the first ask only confirms intent. Use when the user asks to delete, remove, or destroy an app.",
+  descriptionCompressed: "Delete a Cloud app (destructive; two-step confirm).",
+  contexts: ["settings", "finance", "apps"],
+  contextGate: { anyOf: ["settings", "finance", "apps"] },
+  suppressPostActionContinuation: true,
+
+  validate: async (runtime: IAgentRuntime): Promise<boolean> => {
+    return resolveCloudApiKey(runtime) !== null;
+  },
+
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory,
+    _state?: State,
+    options?: unknown,
+    callback?: HandlerCallback,
+  ): Promise<ActionResult> => {
+    const client = getCloudClient(runtime);
+    if (!client) {
+      await callback?.({ text: NO_KEY_MESSAGE, actions: ["DELETE_APP"] });
+      return {
+        success: false,
+        text: "No Eliza Cloud API key configured.",
+        userFacingText: NO_KEY_MESSAGE,
+        data: { reason: "no_key" },
+      };
+    }
+
+    const reference = extractAppReference(message, options);
+    if (!reference) {
+      await callback?.({ text: NO_REFERENCE_MESSAGE, actions: ["DELETE_APP"] });
+      return {
+        success: false,
+        text: "No app reference supplied.",
+        userFacingText: NO_REFERENCE_MESSAGE,
+        data: { reason: "no_reference" },
+      };
+    }
+
+    let app: AppDto | null;
+    let available: string[];
+    try {
+      ({ app, available } = await resolveApp(client, reference));
+    } catch (err) {
+      logger.warn(
+        `[DELETE_APP] Failed to resolve app "${reference}": ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      await callback?.({ text: ERROR_MESSAGE, actions: ["DELETE_APP"] });
+      return {
+        success: false,
+        text: "Failed to resolve Eliza Cloud app.",
+        userFacingText: ERROR_MESSAGE,
+        error: err instanceof Error ? err : new Error(String(err)),
+        data: { reason: "error" },
+      };
+    }
+
+    if (!app) {
+      const msg = notFoundMessage(reference, available);
+      await callback?.({ text: msg, actions: ["DELETE_APP"] });
+      return {
+        success: false,
+        text: `No app matched "${reference}".`,
+        userFacingText: msg,
+        data: { reason: "not_found", reference },
+      };
+    }
+
+    const target = app;
+    const confirmTarget = confirmTargetFor(target);
+    const messageText = message.content?.text ?? "";
+
+    // Phase 1 — no explicit confirmation in THIS message → ask, do not delete.
+    if (!isExplicitConfirmation(messageText, confirmTarget)) {
+      const prompt = confirmationPrompt(confirmTarget, DESTROYED_RESOURCES);
+      await callback?.({ text: prompt, actions: ["DELETE_APP"] });
+      return {
+        success: true,
+        text: `Awaiting explicit confirmation to delete ${target.name}.`,
+        userFacingText: prompt,
+        verifiedUserFacing: true,
+        data: {
+          app: { id: target.id, name: target.name, slug: target.slug },
+          deleted: false,
+          confirmationRequired: true,
+        },
+      };
+    }
+
+    // Phase 2 — explicit confirmation present → delete exactly once.
+    try {
+      const result = await client.deleteApp(target.id);
+      const reply = `Deleted "${target.name}". Its container and tenant database are gone.`;
+      await callback?.({ text: reply, actions: ["DELETE_APP"] });
+      return {
+        success: true,
+        text: result.message || `Deleted ${target.name}.`,
+        userFacingText: reply,
+        verifiedUserFacing: true,
+        data: {
+          app: { id: target.id, name: target.name, slug: target.slug },
+          deleted: true,
+          cleaned: result.cleaned,
+        },
+      };
+    } catch (err) {
+      logger.warn(
+        `[DELETE_APP] deleteApp(${target.id}) failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      await callback?.({ text: ERROR_MESSAGE, actions: ["DELETE_APP"] });
+      return {
+        success: false,
+        text: "Failed to delete Eliza Cloud app.",
+        userFacingText: ERROR_MESSAGE,
+        error: err instanceof Error ? err : new Error(String(err)),
+        data: { reason: "error", deleted: false },
+      };
+    }
+  },
+
+  examples: [
+    [
+      { name: "{{user}}", content: { text: "delete my Acme Bot app" } },
+      {
+        name: "{{agent}}",
+        content: {
+          text: 'This will delete "Acme Bot" (…). This permanently destroys its running container and its tenant database. This can\'t be undone. To go ahead, reply: delete Acme Bot — yes.',
+          actions: ["DELETE_APP"],
+        },
+      },
+    ],
+    [
+      { name: "{{user}}", content: { text: "delete Acme Bot — yes" } },
+      {
+        name: "{{agent}}",
+        content: {
+          text: 'Deleted "Acme Bot". Its container and tenant database are gone.',
+          actions: ["DELETE_APP"],
+        },
+      },
+    ],
+  ],
+};
+
+export default deleteAppAction;

--- a/plugins/plugin-cloud-apps/src/actions/deploy-app.ts
+++ b/plugins/plugin-cloud-apps/src/actions/deploy-app.ts
@@ -1,0 +1,245 @@
+/**
+ * DEPLOY_APP — "ship / go live with app X".
+ *
+ * Resolves the app, kicks off the deploy (`client.deployApp(id)` → 202), then
+ * runs the COMPLETION GATE (deploy-gate.ts): poll `getAppDeployStatus` until
+ * READY, then probe the authoritative `production_url` + `/health` for a 2xx.
+ * Only when both pass do we report the app live. Building/timeout/error/
+ * unreachable each produce a clear, honest failure — we never claim "live"
+ * without the reachability proof.
+ *
+ * On a verified-live deploy we also write the idempotent facts cache so the
+ * agent recalls the app later (convenience, not the gate).
+ *
+ * NOTE: a real end-to-end deploy cannot be verified until the staging deploy
+ * backend is armed (#9853 / Phase 4). The unit tests drive the gate with a
+ * mocked status progression + reachability — that is the proof for now.
+ */
+
+import type { AppDto } from "@elizaos/cloud-sdk";
+import type {
+  Action,
+  ActionResult,
+  HandlerCallback,
+  IAgentRuntime,
+  Memory,
+  State,
+} from "@elizaos/core";
+import { logger } from "@elizaos/core";
+import { recordAppDeployFact } from "../app-facts.js";
+import {
+  extractAppReference,
+  getCloudClient,
+  resolveApp,
+  resolveCloudApiKey,
+} from "../client.js";
+import {
+  DEFAULT_DEPLOY_GATE_CONFIG,
+  type DeployGateConfig,
+  runDeployGate,
+} from "../deploy-gate.js";
+import { probeReachable } from "../reachability.js";
+
+const NO_KEY_MESSAGE =
+  "I can't reach Eliza Cloud yet — no Cloud API key is configured. Add your ELIZAOS_CLOUD_API_KEY and I can deploy your apps.";
+const NO_REFERENCE_MESSAGE =
+  "Which app would you like to deploy? Tell me its name.";
+const ERROR_MESSAGE =
+  "I couldn't start that deploy right now — the Cloud API returned an error. Try again in a moment.";
+
+function notFoundMessage(reference: string, available: string[]): string {
+  const base = `I couldn't find an app matching "${reference}".`;
+  if (available.length === 0) {
+    return `${base} You don't have any apps on Eliza Cloud yet — ask me to create one first.`;
+  }
+  return `${base} Your apps are: ${available.join(", ")}.`;
+}
+
+async function reportLive(
+  runtime: IAgentRuntime,
+  message: Memory,
+  app: AppDto,
+  url: string,
+  callback?: HandlerCallback,
+): Promise<ActionResult> {
+  const reply = `"${app.name}" is live at ${url} 🎉`;
+  // Best-effort, idempotent facts cache — never fails the deploy.
+  const fact = await recordAppDeployFact(runtime, message, app, url);
+  await callback?.({ text: reply, actions: ["DEPLOY_APP"] });
+  return {
+    success: true,
+    text: `Deployed ${app.name} — live at ${url}.`,
+    userFacingText: reply,
+    verifiedUserFacing: true,
+    data: {
+      app: { id: app.id, name: app.name, slug: app.slug },
+      url,
+      phase: "ready",
+      factWritten: fact.written,
+      factUpdated: fact.updated,
+    },
+  };
+}
+
+export const deployAppAction: Action = {
+  name: "DEPLOY_APP",
+  similes: ["SHIP_APP", "GO_LIVE", "DEPLOY_CLOUD_APP", "LAUNCH_APP"],
+  description:
+    "Deploy an existing Eliza Cloud app and confirm it is live (waits for the build to finish and verifies the public URL responds). Use when the user asks to deploy, ship, launch, or go live with an app.",
+  descriptionCompressed: "Deploy a Cloud app and verify it is live.",
+  contexts: ["settings", "finance", "apps"],
+  contextGate: { anyOf: ["settings", "finance", "apps"] },
+  suppressPostActionContinuation: true,
+
+  validate: async (runtime: IAgentRuntime): Promise<boolean> => {
+    return resolveCloudApiKey(runtime) !== null;
+  },
+
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory,
+    _state?: State,
+    options?: unknown,
+    callback?: HandlerCallback,
+  ): Promise<ActionResult> => {
+    const client = getCloudClient(runtime);
+    if (!client) {
+      await callback?.({ text: NO_KEY_MESSAGE, actions: ["DEPLOY_APP"] });
+      return {
+        success: false,
+        text: "No Eliza Cloud API key configured.",
+        userFacingText: NO_KEY_MESSAGE,
+        data: { reason: "no_key" },
+      };
+    }
+
+    const reference = extractAppReference(message, options);
+    if (!reference) {
+      await callback?.({ text: NO_REFERENCE_MESSAGE, actions: ["DEPLOY_APP"] });
+      return {
+        success: false,
+        text: "No app reference supplied.",
+        userFacingText: NO_REFERENCE_MESSAGE,
+        data: { reason: "no_reference" },
+      };
+    }
+
+    let app: AppDto | null;
+    let available: string[];
+    try {
+      ({ app, available } = await resolveApp(client, reference));
+    } catch (err) {
+      logger.warn(
+        `[DEPLOY_APP] Failed to resolve app "${reference}": ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      await callback?.({ text: ERROR_MESSAGE, actions: ["DEPLOY_APP"] });
+      return {
+        success: false,
+        text: "Failed to resolve Eliza Cloud app.",
+        userFacingText: ERROR_MESSAGE,
+        error: err instanceof Error ? err : new Error(String(err)),
+        data: { reason: "error" },
+      };
+    }
+
+    if (!app) {
+      const msg = notFoundMessage(reference, available);
+      await callback?.({ text: msg, actions: ["DEPLOY_APP"] });
+      return {
+        success: false,
+        text: `No app matched "${reference}".`,
+        userFacingText: msg,
+        data: { reason: "not_found", reference },
+      };
+    }
+
+    const target = app;
+
+    try {
+      await client.deployApp(target.id);
+    } catch (err) {
+      logger.warn(
+        `[DEPLOY_APP] deployApp(${target.id}) failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      await callback?.({ text: ERROR_MESSAGE, actions: ["DEPLOY_APP"] });
+      return {
+        success: false,
+        text: "Failed to start deploy.",
+        userFacingText: ERROR_MESSAGE,
+        error: err instanceof Error ? err : new Error(String(err)),
+        data: { reason: "error" },
+      };
+    }
+
+    // Acknowledge the long-running build before the gate blocks.
+    await callback?.({
+      text: `Deploying "${target.name}"… this can take a minute. I'll confirm once it's live.`,
+      actions: ["DEPLOY_APP"],
+    });
+
+    const config: DeployGateConfig = DEFAULT_DEPLOY_GATE_CONFIG;
+    const result = await runDeployGate(
+      {
+        getStatus: () => client.getAppDeployStatus(target.id),
+        getApp: () => client.getApp(target.id),
+        probe: (url) =>
+          probeReachable(url, { timeoutMs: config.probeTimeoutMs }),
+      },
+      config,
+    );
+
+    if (result.phase === "ready" && result.url) {
+      return reportLive(runtime, message, target, result.url, callback);
+    }
+
+    // Honest failure — never claim "live" without the reachability proof.
+    let reply: string;
+    if (result.phase === "error") {
+      reply = `"${target.name}"'s deploy failed${
+        result.error ? `: ${result.error}` : ""
+      }. Nothing is live yet — want me to retry?`;
+    } else if (result.phase === "timeout") {
+      reply = `"${target.name}" is still building after a while (last status: ${result.status}). It may finish shortly — ask me "is ${target.name} live?" in a bit.`;
+    } else {
+      // unreachable
+      reply = result.url
+        ? `"${target.name}" finished building, but ${result.url} isn't answering yet, so I won't call it live. Give it a moment and ask me to check the deploy status.`
+        : `"${target.name}" finished building, but it has no public URL yet, so I can't confirm it's live.`;
+    }
+
+    await callback?.({ text: reply, actions: ["DEPLOY_APP"] });
+    return {
+      success: false,
+      text: `Deploy of ${target.name} not confirmed live (${result.phase}).`,
+      userFacingText: reply,
+      verifiedUserFacing: true,
+      data: {
+        app: { id: target.id, name: target.name, slug: target.slug },
+        phase: result.phase,
+        status: result.status,
+        url: result.url,
+        attempts: result.attempts,
+        reason: result.phase,
+      },
+    };
+  },
+
+  examples: [
+    [
+      { name: "{{user}}", content: { text: "deploy my Acme Bot app" } },
+      {
+        name: "{{agent}}",
+        content: {
+          text: '"Acme Bot" is live at https://acme.elizacloud.ai 🎉',
+          actions: ["DEPLOY_APP"],
+        },
+      },
+    ],
+  ],
+};
+
+export default deployAppAction;

--- a/plugins/plugin-cloud-apps/src/actions/get-app-deploy-status.ts
+++ b/plugins/plugin-cloud-apps/src/actions/get-app-deploy-status.ts
@@ -1,0 +1,187 @@
+/**
+ * GET_APP_DEPLOY_STATUS — "is my app live? / what's the deploy status?".
+ *
+ * Resolves the app, reads `client.getAppDeployStatus(id)`, and formats the
+ * public lifecycle (DRAFT / BUILDING / DEPLOYING / READY / ERROR) plus the URL.
+ * Read-only.
+ */
+
+import type { AppDeployStatusResponse, AppDto } from "@elizaos/cloud-sdk";
+import type {
+  Action,
+  ActionResult,
+  HandlerCallback,
+  IAgentRuntime,
+  Memory,
+  State,
+} from "@elizaos/core";
+import { logger } from "@elizaos/core";
+import {
+  appUrl,
+  extractAppReference,
+  getCloudClient,
+  resolveApp,
+  resolveCloudApiKey,
+} from "../client.js";
+
+const NO_KEY_MESSAGE =
+  "I can't reach Eliza Cloud yet — no Cloud API key is configured. Add your ELIZAOS_CLOUD_API_KEY and I can check your deploys.";
+const NO_REFERENCE_MESSAGE =
+  "Which app's deploy status would you like? Tell me its name.";
+const ERROR_MESSAGE =
+  "I couldn't check that deploy status right now — the Cloud API returned an error. Try again in a moment.";
+
+function notFoundMessage(reference: string, available: string[]): string {
+  const base = `I couldn't find an app matching "${reference}".`;
+  if (available.length === 0) {
+    return `${base} You don't have any apps on Eliza Cloud yet.`;
+  }
+  return `${base} Your apps are: ${available.join(", ")}.`;
+}
+
+/** Format the public deploy status into a human reply. */
+export function formatDeployStatus(
+  app: AppDto,
+  statusRes: AppDeployStatusResponse,
+): string {
+  const raw = (statusRes.status ?? "").trim();
+  const s = raw.toUpperCase();
+  const url = statusRes.vercelUrl ?? appUrl(app);
+
+  switch (s) {
+    case "DRAFT":
+      return `"${app.name}" hasn't been deployed yet (draft). Say "deploy ${app.name}" to ship it.`;
+    case "BUILDING":
+    case "DEPLOYING":
+      return `"${app.name}" is building right now — I'll have a live URL once it finishes.`;
+    case "READY":
+    case "DEPLOYED":
+      return url
+        ? `"${app.name}" is live at ${url}.`
+        : `"${app.name}" is deployed.`;
+    case "ERROR":
+    case "FAILED":
+      return `"${app.name}"'s last deploy failed${
+        statusRes.error ? `: ${statusRes.error}` : ""
+      }. Want me to retry?`;
+    default:
+      return `"${app.name}" deploy status: ${raw || "unknown"}.`;
+  }
+}
+
+export const getAppDeployStatusAction: Action = {
+  name: "GET_APP_DEPLOY_STATUS",
+  similes: [
+    "IS_MY_APP_LIVE",
+    "DEPLOY_STATUS",
+    "APP_DEPLOY_STATUS",
+    "IS_APP_DEPLOYED",
+  ],
+  description:
+    "Report the deployment status of an Eliza Cloud app (draft / building / live / failed) and its URL. Use when the user asks whether an app is live, deployed, or done building.",
+  descriptionCompressed:
+    "Report an app's deploy status (draft/building/live/failed).",
+  contexts: ["settings", "finance", "apps"],
+  contextGate: { anyOf: ["settings", "finance", "apps"] },
+
+  validate: async (runtime: IAgentRuntime): Promise<boolean> => {
+    return resolveCloudApiKey(runtime) !== null;
+  },
+
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory,
+    _state?: State,
+    options?: unknown,
+    callback?: HandlerCallback,
+  ): Promise<ActionResult> => {
+    const client = getCloudClient(runtime);
+    if (!client) {
+      await callback?.({
+        text: NO_KEY_MESSAGE,
+        actions: ["GET_APP_DEPLOY_STATUS"],
+      });
+      return {
+        success: false,
+        text: "No Eliza Cloud API key configured.",
+        userFacingText: NO_KEY_MESSAGE,
+        data: { reason: "no_key" },
+      };
+    }
+
+    const reference = extractAppReference(message, options);
+    if (!reference) {
+      await callback?.({
+        text: NO_REFERENCE_MESSAGE,
+        actions: ["GET_APP_DEPLOY_STATUS"],
+      });
+      return {
+        success: false,
+        text: "No app reference supplied.",
+        userFacingText: NO_REFERENCE_MESSAGE,
+        data: { reason: "no_reference" },
+      };
+    }
+
+    try {
+      const { app, available } = await resolveApp(client, reference);
+      if (!app) {
+        const msg = notFoundMessage(reference, available);
+        await callback?.({ text: msg, actions: ["GET_APP_DEPLOY_STATUS"] });
+        return {
+          success: false,
+          text: `No app matched "${reference}".`,
+          userFacingText: msg,
+          data: { reason: "not_found", reference },
+        };
+      }
+
+      const statusRes = await client.getAppDeployStatus(app.id);
+      const reply = formatDeployStatus(app, statusRes);
+      await callback?.({ text: reply, actions: ["GET_APP_DEPLOY_STATUS"] });
+      return {
+        success: true,
+        text: `Deploy status for ${app.name}: ${statusRes.status}.`,
+        userFacingText: reply,
+        verifiedUserFacing: true,
+        data: {
+          app: { id: app.id, name: app.name, slug: app.slug },
+          status: statusRes.status,
+          url: statusRes.vercelUrl ?? appUrl(app),
+        },
+      };
+    } catch (err) {
+      logger.warn(
+        `[GET_APP_DEPLOY_STATUS] Failed for "${reference}": ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      await callback?.({
+        text: ERROR_MESSAGE,
+        actions: ["GET_APP_DEPLOY_STATUS"],
+      });
+      return {
+        success: false,
+        text: "Failed to check deploy status.",
+        userFacingText: ERROR_MESSAGE,
+        error: err instanceof Error ? err : new Error(String(err)),
+        data: { reason: "error" },
+      };
+    }
+  },
+
+  examples: [
+    [
+      { name: "{{user}}", content: { text: "is my Acme Bot app live yet?" } },
+      {
+        name: "{{agent}}",
+        content: {
+          text: '"Acme Bot" is live at https://acme.elizacloud.ai.',
+          actions: ["GET_APP_DEPLOY_STATUS"],
+        },
+      },
+    ],
+  ],
+};
+
+export default getAppDeployStatusAction;

--- a/plugins/plugin-cloud-apps/src/app-facts.ts
+++ b/plugins/plugin-cloud-apps/src/app-facts.ts
@@ -1,0 +1,135 @@
+/**
+ * Facts/knowledge cache for app deploys (the "completion saves to memory" idea).
+ *
+ * On a successful deploy we persist ONE durable fact keyed on `app.id` to the
+ * runtime's real `facts` memory table, so the agent recalls "you built <name>
+ * at <url>" later across surfaces. This is a derived convenience cache — it is
+ * explicitly NOT the completion gate (the gate is READY + reachability in
+ * deploy-gate.ts). The write is best-effort: a memory failure never fails the
+ * deploy.
+ *
+ * Idempotency is keyed on `app.id`: re-deploying the same app updates the single
+ * fact in place (status/url/timestamp refresh) rather than appending a duplicate.
+ * Core IS importable in the agent runtime (unlike the Worker), so we use the real
+ * `runtime.createMemory` / `getMemories` / `updateMemory` API.
+ */
+
+import type { AppDto } from "@elizaos/cloud-sdk";
+import type { IAgentRuntime, Memory } from "@elizaos/core";
+import { logger, MemoryType } from "@elizaos/core";
+
+/** Marks facts written by this cache so we can find + dedupe them. */
+export const APP_DEPLOY_FACT_SOURCE = "cloud_apps_deploy";
+
+export interface RecordDeployFactResult {
+  /** True when a fact was written (created or updated). */
+  written: boolean;
+  /** True when an existing fact for this app.id was updated in place. */
+  updated: boolean;
+  /** The memory id, when one was written/updated. */
+  memoryId?: string;
+}
+
+function factText(app: AppDto, url: string): string {
+  const date = new Date().toISOString().slice(0, 10);
+  return `User deployed Eliza Cloud app "${app.name}" — live at ${url} (app ${app.id}) on ${date}.`;
+}
+
+async function findExistingDeployFact(
+  runtime: IAgentRuntime,
+  message: Memory,
+  appId: string,
+): Promise<Memory | null> {
+  if (typeof runtime.getMemories !== "function") return null;
+  try {
+    const rows = await runtime.getMemories({
+      tableName: "facts",
+      roomId: message.roomId,
+      count: 200,
+      unique: false,
+    });
+    if (!Array.isArray(rows)) return null;
+    return (
+      rows.find((m) => {
+        const md = m.metadata as Record<string, unknown> | undefined;
+        return md?.source === APP_DEPLOY_FACT_SOURCE && md?.appId === appId;
+      }) ?? null
+    );
+  } catch (err) {
+    // A read failure disables dedup for this write; degrade to create (the worst
+    // case is a duplicate fact, never a lost deploy) but surface the failure.
+    logger.warn(
+      `[CloudApps] deploy-fact dedup read failed for ${appId}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return null;
+  }
+}
+
+/**
+ * Write (or idempotently update) the deploy fact for `app` at `url`. Returns
+ * `{ written: false }` when the runtime has no memory API or the write fails —
+ * the caller treats this as a non-fatal cache miss.
+ */
+export async function recordAppDeployFact(
+  runtime: IAgentRuntime,
+  message: Memory,
+  app: AppDto,
+  url: string,
+): Promise<RecordDeployFactResult> {
+  if (typeof runtime.createMemory !== "function") {
+    return { written: false, updated: false };
+  }
+
+  const text = factText(app, url);
+  const metadata = {
+    type: MemoryType.CUSTOM,
+    source: APP_DEPLOY_FACT_SOURCE,
+    appId: app.id,
+    appName: app.name,
+    appSlug: app.slug,
+    appUrl: url,
+    tags: ["fact", "cloud_app", "deploy", app.id],
+    // Confirmed live-deploy state is a durable identity fact, not a transient
+    // single-message claim — keep it out of the time-decay path.
+    kind: "durable" as const,
+    confidence: 1,
+    deployedAt: new Date().toISOString(),
+  };
+
+  try {
+    const existing = await findExistingDeployFact(runtime, message, app.id);
+    if (existing?.id && typeof runtime.updateMemory === "function") {
+      await runtime.updateMemory({
+        id: existing.id,
+        content: { text, type: "fact" },
+        metadata: {
+          ...(existing.metadata ?? {}),
+          ...metadata,
+        } as Memory["metadata"],
+      });
+      return { written: true, updated: true, memoryId: existing.id };
+    }
+
+    const id = await runtime.createMemory(
+      {
+        entityId: message.entityId,
+        agentId: runtime.agentId,
+        roomId: message.roomId,
+        content: { text, type: "fact" },
+        metadata,
+      } as Memory,
+      "facts",
+      true,
+    );
+    return { written: true, updated: false, memoryId: id };
+  } catch (err) {
+    logger.warn(
+      `[CloudApps] Failed to record deploy fact for ${app.id}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return { written: false, updated: false };
+  }
+}

--- a/plugins/plugin-cloud-apps/src/client.ts
+++ b/plugins/plugin-cloud-apps/src/client.ts
@@ -12,7 +12,7 @@
 
 import type { AppDto } from "@elizaos/cloud-sdk";
 import { ElizaCloudClient } from "@elizaos/cloud-sdk";
-import type { IAgentRuntime } from "@elizaos/core";
+import type { IAgentRuntime, Memory } from "@elizaos/core";
 
 /** Default Eliza Cloud API base URL (matches the cloud runtime default). */
 export const DEFAULT_CLOUD_API_BASE_URL = "https://www.elizacloud.ai/api/v1";
@@ -177,4 +177,66 @@ export function looksLikeAppId(value: string): boolean {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
     value.trim(),
   );
+}
+
+// ─── Reference resolution (shared by the mutating actions) ───────────────────
+
+/** Planner-option keys that may carry an app reference, in priority order. */
+const REFERENCE_OPTION_KEYS = [
+  "app",
+  "appName",
+  "name",
+  "id",
+  "appId",
+  "query",
+] as const;
+
+/**
+ * Pull an app reference from planner-supplied options or, failing that, the raw
+ * message text. Mirrors the read-core's `resolveReference` so the mutating
+ * actions resolve apps identically.
+ */
+export function extractAppReference(
+  message: Memory,
+  options?: unknown,
+): string {
+  if (options && typeof options === "object") {
+    const opts = options as Record<string, unknown>;
+    for (const key of REFERENCE_OPTION_KEYS) {
+      const value = opts[key];
+      if (typeof value === "string" && value.trim().length > 0) {
+        return value.trim();
+      }
+    }
+  }
+  return (message.content?.text ?? "").trim();
+}
+
+export interface ResolvedApp {
+  /** The matched app, or null when nothing matched. */
+  app: AppDto | null;
+  /** Names of the user's apps (for a helpful not-found message). */
+  available: string[];
+}
+
+/**
+ * Resolve an app from a free-text reference against the user's apps. Id-shaped
+ * references take the direct `getApp(id)` path; names resolve via `listApps()` +
+ * {@link findAppByReference}. Read-only — used by the mutating actions to locate
+ * the target before they mutate it.
+ */
+export async function resolveApp(
+  client: ElizaCloudClient,
+  reference: string,
+): Promise<ResolvedApp> {
+  if (looksLikeAppId(reference)) {
+    const { app } = await client.getApp(reference);
+    if (app) return { app, available: [app.name] };
+  }
+  const { apps } = await client.listApps();
+  const list = apps ?? [];
+  return {
+    app: findAppByReference(list, reference),
+    available: list.map((a) => a.name),
+  };
 }

--- a/plugins/plugin-cloud-apps/src/deploy-gate.ts
+++ b/plugins/plugin-cloud-apps/src/deploy-gate.ts
@@ -1,0 +1,180 @@
+/**
+ * The DEPLOY_APP completion gate.
+ *
+ * "Done" is not "the deploy was accepted (202)". The gate runs two checks:
+ *   1. COMPLETION — poll `getAppDeployStatus` until the public status is READY
+ *      (bounded retries with exponential backoff + an overall timeout). A
+ *      server-reported ERROR/FAILED short-circuits immediately.
+ *   2. REACHABILITY — once READY, read the authoritative `production_url` from
+ *      the app row (deriveAppPublicUrl semantics — NOT the create response) and
+ *      probe `<production_url>/health` for a 2xx.
+ * Only when BOTH pass do we report the app live.
+ *
+ * The gate is pure and fully injectable (status fetch, app fetch, probe, sleep)
+ * so it can be unit-tested against a mocked status progression + reachability —
+ * which is the proof for now: a real end-to-end deploy cannot be verified until
+ * the staging deploy backend is armed (#9853 / Phase 4).
+ */
+
+import type { AppDeployStatusResponse, AppResponse } from "@elizaos/cloud-sdk";
+import { healthUrl, type ReachabilityResult } from "./reachability.js";
+
+/** Terminal outcome of the gate. */
+export type DeployPhase = "ready" | "error" | "timeout" | "unreachable";
+
+export interface DeployGateResult {
+  phase: DeployPhase;
+  /** The app's public production URL, when one was resolved. */
+  url: string | null;
+  /** The last public deploy status string observed. */
+  status: string;
+  /** How many status polls ran. */
+  attempts: number;
+  /** The reachability probe result (present once status reached READY). */
+  reachability?: ReachabilityResult;
+  /** Server-reported error / failure reason, when relevant. */
+  error?: string;
+}
+
+export interface DeployGateConfig {
+  /** Max status polls before declaring a timeout. */
+  maxAttempts: number;
+  /** First backoff delay (ms). */
+  initialDelayMs: number;
+  /** Backoff ceiling (ms). */
+  maxDelayMs: number;
+  /** Per-probe HTTP timeout passed through to the reachability probe (ms). */
+  probeTimeoutMs: number;
+  /** Health path probed after READY. */
+  healthPath: string;
+}
+
+export interface DeployGateDeps {
+  /** `client.getAppDeployStatus(id)`. */
+  getStatus: () => Promise<AppDeployStatusResponse>;
+  /** `client.getApp(id)` — re-read to get the authoritative production_url. */
+  getApp: () => Promise<AppResponse>;
+  /** Probe a fully-qualified URL for reachability. */
+  probe: (url: string) => Promise<ReachabilityResult>;
+  /** Sleep between polls (injected so tests run instantly). */
+  sleep?: (ms: number) => Promise<void>;
+  /** Optional progress hook for streaming "still building…" updates. */
+  onProgress?: (status: string, attempt: number) => void;
+}
+
+/** Production defaults: ~ up to ~2 min of polling with capped backoff. */
+export const DEFAULT_DEPLOY_GATE_CONFIG: DeployGateConfig = {
+  maxAttempts: 24,
+  initialDelayMs: 2_000,
+  maxDelayMs: 10_000,
+  probeTimeoutMs: 10_000,
+  healthPath: "/health",
+};
+
+const TERMINAL_SUCCESS = new Set(["READY", "DEPLOYED"]);
+const TERMINAL_ERROR = new Set(["ERROR", "FAILED"]);
+
+type StatusClass = "success" | "error" | "pending";
+
+/**
+ * Map the public deploy status to a terminal/pending class. The server's public
+ * lifecycle is DRAFT | BUILDING | READY | ERROR (with `deploying` folded into
+ * BUILDING); we also accept the `DEPLOYED` synonym defensively.
+ */
+export function classifyDeployStatus(
+  status: string | null | undefined,
+): StatusClass {
+  const s = (status ?? "").trim().toUpperCase();
+  if (TERMINAL_SUCCESS.has(s)) return "success";
+  if (TERMINAL_ERROR.has(s)) return "error";
+  return "pending";
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function normalizeUrl(value: string | null | undefined): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export async function runDeployGate(
+  deps: DeployGateDeps,
+  config: DeployGateConfig = DEFAULT_DEPLOY_GATE_CONFIG,
+): Promise<DeployGateResult> {
+  const sleep = deps.sleep ?? defaultSleep;
+  let lastStatus = "";
+  let delay = config.initialDelayMs;
+
+  for (let attempt = 1; attempt <= config.maxAttempts; attempt++) {
+    const statusRes = await deps.getStatus();
+    lastStatus = statusRes.status ?? "";
+    deps.onProgress?.(lastStatus, attempt);
+
+    const cls = classifyDeployStatus(lastStatus);
+
+    if (cls === "error") {
+      return {
+        phase: "error",
+        url: normalizeUrl(statusRes.vercelUrl),
+        status: lastStatus,
+        attempts: attempt,
+        error: statusRes.error ?? undefined,
+      };
+    }
+
+    if (cls === "success") {
+      // Authoritative URL is the app row's production_url (deriveAppPublicUrl),
+      // NOT the create/deploy response. Fall back to the status' vercelUrl only
+      // if the re-read fails or hasn't populated production_url yet.
+      let url = normalizeUrl(statusRes.vercelUrl);
+      try {
+        const { app } = await deps.getApp();
+        url = normalizeUrl(app?.production_url) ?? url;
+      } catch {
+        // keep vercelUrl fallback
+      }
+      if (!url) {
+        return {
+          phase: "unreachable",
+          url: null,
+          status: lastStatus,
+          attempts: attempt,
+          error: "no_production_url",
+        };
+      }
+      const reachability = await deps.probe(healthUrl(url, config.healthPath));
+      return reachability.ok
+        ? {
+            phase: "ready",
+            url,
+            status: lastStatus,
+            attempts: attempt,
+            reachability,
+          }
+        : {
+            phase: "unreachable",
+            url,
+            status: lastStatus,
+            attempts: attempt,
+            reachability,
+            error: reachability.error,
+          };
+    }
+
+    // pending — wait then retry (skip the final wait so the loop exits to timeout)
+    if (attempt < config.maxAttempts) {
+      await sleep(delay);
+      delay = Math.min(delay * 2, config.maxDelayMs);
+    }
+  }
+
+  return {
+    phase: "timeout",
+    url: null,
+    status: lastStatus,
+    attempts: config.maxAttempts,
+  };
+}

--- a/plugins/plugin-cloud-apps/src/index.ts
+++ b/plugins/plugin-cloud-apps/src/index.ts
@@ -1,55 +1,62 @@
 /**
  * @elizaos/plugin-cloud-apps
  *
- * Lets an Eliza agent answer questions about the user's Eliza Cloud Apps —
- * "what apps do I have?" and "tell me about app X" — from a single plugin
+ * Lets an Eliza agent manage the user's Eliza Cloud Apps — list them, describe
+ * one, and run the create → deploy → live loop — from a single plugin
  * registration that reaches every connector (in-app, Discord, Telegram, and
  * cloud-hosted) through the shared AgentRuntime pipeline.
  *
- * This is the READ-CORE: it ships only non-mutating capabilities.
+ * Read-core (non-mutating):
+ *   - Action  LIST_CLOUD_APPS       — list the user's apps (name / url / status).
+ *   - Action  GET_APP               — details for one app by name or id.
+ *   - Provider CLOUD_APPS           — injects the app inventory into planner context.
  *
- *   - Action  LIST_CLOUD_APPS — list the user's apps (name / url / status).
- *   - Action  GET_APP         — details for one app by name or id.
- *   - Provider CLOUD_APPS     — injects the app inventory into planner context.
+ * Create → deploy → live loop (this layer):
+ *   - Action  CREATE_APP            — create an app from name/description/monetization intent.
+ *   - Action  DEPLOY_APP            — deploy + COMPLETION GATE (READY status, then
+ *                                     probe production_url `/health` for 2xx before
+ *                                     claiming live) + idempotent facts cache.
+ *   - Action  GET_APP_DEPLOY_STATUS — report DRAFT/BUILDING/DEPLOYING/READY/ERROR + url.
  *
  * Auth: reads `ELIZAOS_CLOUD_API_KEY` (+ optional `ELIZAOS_CLOUD_BASE_URL`) via
  * runtime settings — the same credentials plugin-elizacloud uses. With no key
  * the actions degrade gracefully and the provider stays EMPTY.
  *
- * ───────────────────────────────────────────────────────────────────────────
- * DEFERRED to Phase 3b (mutating / money actions — intentionally NOT here):
- *   - CREATE_APP
- *   - UPDATE_APP
- *   - UPDATE_MONETIZATION
- *   - DEPLOY_APP
- *   - GET_APP_DEPLOY_STATUS
- *   - DELETE_APP
- *   - GET_APP_EARNINGS
- *   - WITHDRAW_APP_EARNINGS
- *   - REGENERATE_APP_API_KEY
- *   - BUY_APP_DOMAIN
- * Those require the confirm/CTA pattern and a facts/knowledge cache, and they
- * move real money — they ship on a later, separately-reviewed branch. The typed
- * SDK methods (`client.createApp`, `client.deployApp`, …) already exist on the
- * base branch; only the agent-facing actions are deferred.
- * ───────────────────────────────────────────────────────────────────────────
+ * NOTE: a real end-to-end deploy can't be verified until the staging deploy
+ * backend is armed (#9853 / Phase 4). DEPLOY_APP's tests drive the completion
+ * gate with a mocked status progression + reachability — that is the proof for now.
  */
 
 import type { Plugin } from "@elizaos/core";
+import { createAppAction } from "./actions/create-app.js";
+import { deployAppAction } from "./actions/deploy-app.js";
 import { getAppAction } from "./actions/get-app.js";
+import { getAppDeployStatusAction } from "./actions/get-app-deploy-status.js";
 import { listCloudAppsAction } from "./actions/list-cloud-apps.js";
 import { cloudAppsProvider } from "./providers/cloud-apps.js";
 
+export { createAppAction } from "./actions/create-app.js";
+export { deployAppAction } from "./actions/deploy-app.js";
 export { getAppAction } from "./actions/get-app.js";
+export { getAppDeployStatusAction } from "./actions/get-app-deploy-status.js";
 export { listCloudAppsAction } from "./actions/list-cloud-apps.js";
+export * from "./app-facts.js";
 export * from "./client.js";
+export * from "./deploy-gate.js";
 export { cloudAppsProvider } from "./providers/cloud-apps.js";
+export * from "./reachability.js";
 
 export const cloudAppsPlugin: Plugin = {
   name: "cloud-apps",
   description:
-    "Read-core for Eliza Cloud Apps: list the user's apps and describe a single app, across every connector.",
-  actions: [listCloudAppsAction, getAppAction],
+    "Eliza Cloud Apps: list and describe the user's apps, create them, deploy them with a live-verification gate, and check deploy status — across every connector.",
+  actions: [
+    listCloudAppsAction,
+    getAppAction,
+    createAppAction,
+    deployAppAction,
+    getAppDeployStatusAction,
+  ],
   providers: [cloudAppsProvider],
 };
 

--- a/plugins/plugin-cloud-apps/src/index.ts
+++ b/plugins/plugin-cloud-apps/src/index.ts
@@ -11,24 +11,38 @@
  *   - Action  GET_APP               — details for one app by name or id.
  *   - Provider CLOUD_APPS           — injects the app inventory into planner context.
  *
- * Create → deploy → live loop (this layer):
+ * Create → deploy → live loop + safe delete (this layer):
  *   - Action  CREATE_APP            — create an app from name/description/monetization intent.
  *   - Action  DEPLOY_APP            — deploy + COMPLETION GATE (READY status, then
  *                                     probe production_url `/health` for 2xx before
  *                                     claiming live) + idempotent facts cache.
  *   - Action  GET_APP_DEPLOY_STATUS — report DRAFT/BUILDING/DEPLOYING/READY/ERROR + url.
+ *   - Action  DELETE_APP            — DESTRUCTIVE: two-phase, connector-agnostic confirm.
  *
  * Auth: reads `ELIZAOS_CLOUD_API_KEY` (+ optional `ELIZAOS_CLOUD_BASE_URL`) via
  * runtime settings — the same credentials plugin-elizacloud uses. With no key
  * the actions degrade gracefully and the provider stays EMPTY.
  *
+ * ───────────────────────────────────────────────────────────────────────────
+ * DEFERRED to Phase 3c (paid / CTA-bearing / last-mile — intentionally NOT here):
+ *   - UPDATE_APP
+ *   - UPDATE_MONETIZATION
+ *   - GET_APP_EARNINGS
+ *   - WITHDRAW_APP_EARNINGS   (paid → reuse the `buildConnectorCta` seam in safety.ts)
+ *   - REGENERATE_APP_API_KEY
+ *   - BUY_APP_DOMAIN          (domain is the last slice; SDK envelope not finalized)
+ * The paid actions reuse the two-phase-confirm + connector CTA helper already
+ * built here (`src/safety.ts`); money/credentials never transit the connector.
+ *
  * NOTE: a real end-to-end deploy can't be verified until the staging deploy
  * backend is armed (#9853 / Phase 4). DEPLOY_APP's tests drive the completion
  * gate with a mocked status progression + reachability — that is the proof for now.
+ * ───────────────────────────────────────────────────────────────────────────
  */
 
 import type { Plugin } from "@elizaos/core";
 import { createAppAction } from "./actions/create-app.js";
+import { deleteAppAction } from "./actions/delete-app.js";
 import { deployAppAction } from "./actions/deploy-app.js";
 import { getAppAction } from "./actions/get-app.js";
 import { getAppDeployStatusAction } from "./actions/get-app-deploy-status.js";
@@ -36,6 +50,7 @@ import { listCloudAppsAction } from "./actions/list-cloud-apps.js";
 import { cloudAppsProvider } from "./providers/cloud-apps.js";
 
 export { createAppAction } from "./actions/create-app.js";
+export { deleteAppAction } from "./actions/delete-app.js";
 export { deployAppAction } from "./actions/deploy-app.js";
 export { getAppAction } from "./actions/get-app.js";
 export { getAppDeployStatusAction } from "./actions/get-app-deploy-status.js";
@@ -45,17 +60,19 @@ export * from "./client.js";
 export * from "./deploy-gate.js";
 export { cloudAppsProvider } from "./providers/cloud-apps.js";
 export * from "./reachability.js";
+export * from "./safety.js";
 
 export const cloudAppsPlugin: Plugin = {
   name: "cloud-apps",
   description:
-    "Eliza Cloud Apps: list and describe the user's apps, create them, deploy them with a live-verification gate, and check deploy status — across every connector.",
+    "Eliza Cloud Apps: list and describe the user's apps, create them, deploy them with a live-verification gate, check deploy status, and safely delete them — across every connector.",
   actions: [
     listCloudAppsAction,
     getAppAction,
     createAppAction,
     deployAppAction,
     getAppDeployStatusAction,
+    deleteAppAction,
   ],
   providers: [cloudAppsProvider],
 };

--- a/plugins/plugin-cloud-apps/src/reachability.ts
+++ b/plugins/plugin-cloud-apps/src/reachability.ts
@@ -1,0 +1,84 @@
+/**
+ * HTTP reachability probe for the DEPLOY_APP completion gate.
+ *
+ * After the deploy status flips to READY we still don't claim an app is "live"
+ * until its public endpoint actually answers. {@link probeReachable} does a
+ * bounded HTTP GET (default `/health`) and reports whether it returned 2xx.
+ *
+ * The network boundary (`fetchImpl`) is injectable so the deploy gate's unit
+ * tests can drive reachable / unreachable / timeout without a live container —
+ * production passes the global `fetch`.
+ */
+
+export interface ReachabilityResult {
+  /** True iff the endpoint answered with a 2xx status. */
+  ok: boolean;
+  /** The HTTP status code, when a response was received. */
+  status?: number;
+  /** A short reason when the probe failed (network error / abort / no-fetch). */
+  error?: string;
+}
+
+/** Minimal fetch surface the probe needs — satisfied by the global `fetch`. */
+export type FetchLike = (
+  input: string,
+  init?: {
+    method?: string;
+    signal?: AbortSignal;
+    redirect?: "follow" | "manual";
+  },
+) => Promise<{ ok: boolean; status: number }>;
+
+export interface ProbeOptions {
+  /** Abort the probe after this many ms (default 10s). */
+  timeoutMs?: number;
+  /** Injected fetch (defaults to the global `fetch`). */
+  fetchImpl?: FetchLike;
+}
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+/** Append `/health` (or another path) to a base URL, collapsing slashes. */
+export function healthUrl(base: string, path = "/health"): string {
+  const trimmedBase = base.replace(/\/+$/, "");
+  const trimmedPath = path.startsWith("/") ? path : `/${path}`;
+  return `${trimmedBase}${trimmedPath}`;
+}
+
+/**
+ * Probe a URL with a bounded HTTP GET. Never throws — a network error, abort, or
+ * non-2xx all resolve to `{ ok: false, … }` so the caller can report a clear
+ * "deployed but not reachable" failure instead of crashing the action.
+ */
+export async function probeReachable(
+  url: string,
+  options: ProbeOptions = {},
+): Promise<ReachabilityResult> {
+  const fetchImpl =
+    options.fetchImpl ?? (globalThis.fetch as unknown as FetchLike | undefined);
+  if (typeof fetchImpl !== "function") {
+    return { ok: false, error: "no_fetch" };
+  }
+
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetchImpl(url, {
+      method: "GET",
+      signal: controller.signal,
+      redirect: "follow",
+    });
+    const ok =
+      res.ok === true ||
+      (typeof res.status === "number" && res.status >= 200 && res.status < 300);
+    return { ok, status: res.status };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/plugins/plugin-cloud-apps/src/safety.ts
+++ b/plugins/plugin-cloud-apps/src/safety.ts
@@ -1,0 +1,162 @@
+/**
+ * Shared safety primitives for the plugin's destructive + paid actions.
+ *
+ * ── Two-phase confirm (connector-agnostic) ───────────────────────────────────
+ * A destructive or paid action NEVER acts on the first ask. On the first turn it
+ * returns a confirmation prompt that names the exact target and spells out what
+ * will be destroyed, and it acts only when the FOLLOW-UP message carries an
+ * explicit confirmation token (e.g. "yes delete <name>"). The token lives in the
+ * user's plain message text, so the pattern behaves identically on Discord,
+ * Telegram, the in-app chat, or any other surface — it never depends on a GUI
+ * button or a connector-specific affordance. A bare first ask ("delete my Acme
+ * app") carries no affirmation word, so it can never be mistaken for a
+ * confirmation: the only way to proceed is to deliberately type the token.
+ *
+ * ── Connector-agnostic CTA (for the DEFERRED paid actions) ────────────────────
+ * Paid actions that must hand the user off to a browser (withdraw earnings, buy
+ * a domain — both deferred to Phase 3c) build a neutral {label,url,kind} object
+ * the connector renders however it can (Discord link button, Telegram URL
+ * button, in-app card). Money and credentials NEVER transit the connector: the
+ * CTA carries only a human label plus an https URL the user opens themselves.
+ * {@link buildConnectorCta} is the single seam those actions will reuse.
+ */
+
+/** How a connector should render a call-to-action handed back by an action. */
+export type CtaKind = "link" | "button" | "card";
+
+/**
+ * A neutral call-to-action a connector renders. Carries ONLY a label + URL —
+ * never a token, secret, signed payload, or money amount. The user completes
+ * any payment/credential step in the browser the URL opens.
+ */
+export interface ConnectorCta {
+  label: string;
+  url: string;
+  kind: CtaKind;
+}
+
+/** The thing a destructive/paid action is about to act on. */
+export interface ConfirmTarget {
+  /** Human-facing label, e.g. the app name. */
+  name: string;
+  /** Stable id, e.g. the app id (matched verbatim when present). */
+  id?: string;
+  /** Other strings that also identify the target (slug, etc.). */
+  aliases?: string[];
+}
+
+export interface ConfirmCheckOptions {
+  /**
+   * Verbs that, combined with an affirmation word, count as confirmation even
+   * when the target is not named. Defaults to the destructive set.
+   */
+  verbs?: string[];
+}
+
+/** Affirmation words that signal intent. Absent on a plain first ask. */
+const AFFIRMATION =
+  /\b(yes|yep|yeah|yup|confirm|confirmed|do it|go ahead|proceed|i'm sure|im sure)\b/i;
+
+const DEFAULT_CONFIRM_VERBS = ["delete", "remove", "destroy"];
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Lowercased references that unambiguously name the target. */
+function targetReferences(target: ConfirmTarget): string[] {
+  const refs: string[] = [];
+  const pushIf = (value: string | undefined, minLen: number): void => {
+    if (typeof value !== "string") return;
+    const v = value.trim().toLowerCase();
+    if (v.length >= minLen) refs.push(v);
+  };
+  // Names/slugs need >= 3 chars so a short alias can't match random words.
+  pushIf(target.name, 3);
+  for (const alias of target.aliases ?? []) pushIf(alias, 3);
+  // The id is matched verbatim (a UUID fragment never collides with prose).
+  pushIf(target.id, 6);
+  return refs;
+}
+
+/**
+ * True only when `text` is an EXPLICIT confirmation of acting on `target`.
+ *
+ * Requires an affirmation word AND either an action verb ("delete"/"remove"/…)
+ * or a direct reference to the target (its name/slug/id). This is deliberately
+ * strict: a first ask like "delete my Acme app" has no affirmation word and so
+ * returns false, guaranteeing the destructive call never fires on the first ask.
+ */
+export function isExplicitConfirmation(
+  text: string,
+  target: ConfirmTarget,
+  options: ConfirmCheckOptions = {},
+): boolean {
+  const raw = (text ?? "").trim();
+  if (!raw) return false;
+  const lower = raw.toLowerCase();
+  if (!AFFIRMATION.test(lower)) return false;
+
+  const verbs = options.verbs ?? DEFAULT_CONFIRM_VERBS;
+  const mentionsVerb = verbs.some((v) =>
+    new RegExp(`\\b${escapeRegExp(v.toLowerCase())}\\b`).test(lower),
+  );
+  const mentionsTarget = targetReferences(target).some((ref) =>
+    lower.includes(ref),
+  );
+  return mentionsVerb || mentionsTarget;
+}
+
+/**
+ * Build the first-phase confirmation prompt for a destructive action.
+ *
+ * Names the exact target (+ id when present), lists what is destroyed, and tells
+ * the user the exact token to send back. `verb` defaults to "delete".
+ */
+export function confirmationPrompt(
+  target: ConfirmTarget,
+  destroys: string[],
+  verb = "delete",
+): string {
+  const label = target.id
+    ? `"${target.name}" (${target.id})`
+    : `"${target.name}"`;
+  const destroyClause =
+    destroys.length > 0
+      ? ` This permanently destroys ${joinList(destroys)}.`
+      : "";
+  return (
+    `This will ${verb} ${label}.${destroyClause} This can't be undone. ` +
+    `To go ahead, reply: ${verb} ${target.name} — yes.`
+  );
+}
+
+function joinList(items: string[]): string {
+  if (items.length === 1) return items[0];
+  if (items.length === 2) return `${items[0]} and ${items[1]}`;
+  return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;
+}
+
+/**
+ * Build a neutral connector CTA. The seam the DEFERRED paid actions reuse so a
+ * connector can surface a "complete in browser" affordance. Throws if the URL is
+ * not an http(s) URL — money/credentials must never be smuggled into the CTA.
+ */
+export function buildConnectorCta(
+  label: string,
+  url: string,
+  kind: CtaKind = "link",
+): ConnectorCta {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`buildConnectorCta: invalid URL "${url}"`);
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    throw new Error(
+      `buildConnectorCta: refusing non-http(s) URL "${parsed.protocol}"`,
+    );
+  }
+  return { label, url: parsed.toString(), kind };
+}

--- a/plugins/plugin-cloud-apps/tsconfig.json
+++ b/plugins/plugin-cloud-apps/tsconfig.json
@@ -13,7 +13,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM"],
     "types": []
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
## What

Extends `@elizaos/plugin-cloud-apps` (read-core in the parent PR) with the **create → deploy → live** loop, safe destructive delete, and the deploy-success **facts cache** — so a user can build, ship, and manage a monetized app entirely from chat (app / Discord / Telegram).

Builds on the merged read-core (#10277, now in `develop`); diff is **plugin-only** (the create/deploy/delete additions).

## Actions added
- **`CREATE_APP`** — parse name/description/monetization intent → typed `client.createApp(...)`, offer to deploy.
- **`DEPLOY_APP`** — deploy, then a real **completion gate** (`deploy-gate.ts`): poll `getAppDeployStatus` until `READY` (bounded exp-backoff + timeout; ERROR/FAILED short-circuit), then probe the authoritative post-deploy `production_url` `/health` for 2xx. Only `READY + reachable` reports "live"; `timeout`/`error`/`unreachable` are honest failures. **A 202 is never "done."**
- **`GET_APP_DEPLOY_STATUS`** — formats DRAFT/BUILDING/DEPLOYING/READY/ERROR + url.
- **`DELETE_APP`** — DESTRUCTIVE → **two-phase, connector-agnostic confirm** (`safety.ts`): first ask names the app + what's destroyed (container + tenant DB) and does NOT delete; only an explicit confirmation in the follow-up calls `deleteApp`. Never relies on GUI buttons; a bare "yes" is insufficient.

## Safety + memory
- **`safety.ts`** — reusable two-phase confirm + a neutral `buildConnectorCta({label,url,kind})` (https-only) seam for the deferred paid actions; money/credentials never transit the connector.
- **`app-facts.ts`** — on a verified-live deploy, writes ONE durable fact to the real `facts` memory table via `runtime.createMemory`, keyed on `app.id`, idempotent (re-deploy updates in place). Convenience recall cache — **explicitly NOT the completion gate**. (This is the "save completed app to facts/knowledge" idea, done right.)

## Evidence
- `bun run --cwd plugins/plugin-cloud-apps test` → **68 pass / 0 fail** (mocks only the SDK client, runtime memory, and the `fetch` boundary; actions/gate/safety run for real). Covers gate progression/timeout/error/unreachable, create intent + no-name/no-key/error + API-key-never-echoed, delete first-ask/confirmed/bare-yes/not-found, facts idempotency.
- Plugin typecheck + biome clean; `packages/agent` typecheck clean; plugin build OK.

## Notes
- **Real end-to-end deploy is gated on the staging deploy backend (#9853 / Phase 4)** — can't fire until armed, so the proof here is the mocked status-progression + reachability gate tests.
- Deferred to a follow-up (TODO in `index.ts`): `UPDATE_APP`, `UPDATE_MONETIZATION`, `GET_APP_EARNINGS`, `WITHDRAW_APP_EARNINGS` (paid → reuse the CTA seam), `REGENERATE_APP_API_KEY`, `BUY_APP_DOMAIN` (domain last).
- Part of the apps launch (tracker #8434).
