### PR TITLE
feat(plugin-cloud-apps): manage actions — update / monetization / earnings / safe withdraw / rotate key

### DIFF
--- a/packages/cloud/sdk/src/apps.client.test.ts
+++ b/packages/cloud/sdk/src/apps.client.test.ts
@@ -181,6 +181,21 @@ describe("ElizaCloudClient typed app methods", () => {
     });
   });
 
+  it("regenerateAppApiKey POSTs /api/v1/apps/:id/regenerate-api-key and returns the new key", async () => {
+    const { client, requests } = createClientRecorder({
+      success: true,
+      apiKey: "eliza_app_rotated_secret",
+      message:
+        "API key regenerated successfully. Make sure to save it securely.",
+    });
+    const res = await client.regenerateAppApiKey("app_1");
+    expect(res.apiKey).toBe("eliza_app_rotated_secret");
+    expect(requests[0]).toMatchObject({
+      url: "https://cloud.test/api/v1/apps/app_1/regenerate-api-key",
+      method: "POST",
+    });
+  });
+
   it("buyAppDomain (deferred stub) POSTs /api/v1/apps/:id/domains/buy with { domain }", async () => {
     const { client, requests } = createClientRecorder({
       success: true,

--- a/packages/cloud/sdk/src/client.ts
+++ b/packages/cloud/sdk/src/client.ts
@@ -79,6 +79,7 @@ import {
   type RedemptionBalanceResponse,
   type RedemptionQuoteResponse,
   type RedemptionStatusResponse,
+  type RegenerateAppApiKeyResponse,
   type RegisterGatewayRelaySessionResponse,
   type ResponsesCreateRequest,
   type ResponsesCreateResponse,
@@ -795,6 +796,19 @@ export class ElizaCloudClient {
     return this.routes.deleteApiV1AppsById<DeleteAppResponse>({
       pathParams: { id: appId },
     });
+  }
+
+  /**
+   * `POST /api/v1/apps/:id/regenerate-api-key` — rotate the app's API key.
+   *
+   * SECURITY-SENSITIVE: the previous key is invalidated immediately and the new
+   * plaintext key is returned ONCE in the response (`apiKey`). Surface it to the
+   * user a single time and never log or persist it.
+   */
+  regenerateAppApiKey(appId: string): Promise<RegenerateAppApiKeyResponse> {
+    return this.routes.postApiV1AppsByIdRegenerateApiKey<RegenerateAppApiKeyResponse>(
+      { pathParams: { id: appId } },
+    );
   }
 
   /**

--- a/packages/cloud/sdk/src/types.ts
+++ b/packages/cloud/sdk/src/types.ts
@@ -974,6 +974,20 @@ export interface DeleteAppResponse {
   errors?: string[];
 }
 
+/**
+ * `POST /api/v1/apps/:id/regenerate-api-key` response.
+ *
+ * SECURITY: `apiKey` is the new plaintext app API key, returned ONCE. The
+ * previous key is invalidated immediately. Surface it to the user a single time
+ * and never log or persist it.
+ */
+export interface RegenerateAppApiKeyResponse {
+  success: boolean;
+  apiKey?: string;
+  message?: string;
+  error?: string;
+}
+
 /** `POST /api/v1/apps/:id/domains/buy` request body. */
 export interface BuyAppDomainInput {
   domain: string;

--- a/plugins/plugin-cloud-apps/__tests__/get-app-earnings.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/get-app-earnings.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+  captureCallback,
+  FakeElizaCloudClient,
+  keyedRuntime,
+  makeApp,
+  makeMessage,
+  resetSdk,
+  setGetAppEarnings,
+  setListApps,
+  unkeyedRuntime,
+} from "./helpers";
+
+mock.module("@elizaos/cloud-sdk", () => ({
+  ElizaCloudClient: FakeElizaCloudClient,
+}));
+
+const { getAppEarningsAction } = await import(
+  "../src/actions/get-app-earnings.ts"
+);
+
+const APP = makeApp({
+  id: "id-acme",
+  name: "Acme Bot",
+  slug: "acme-bot",
+  monetization_enabled: true,
+});
+
+function earnings(summary: Record<string, number>, enabled = true) {
+  return {
+    success: true,
+    earnings: { summary },
+    monetization: { enabled },
+  };
+}
+
+describe("GET_APP_EARNINGS", () => {
+  beforeEach(() => {
+    resetSdk();
+    setListApps(() => Promise.resolve({ success: true, apps: [APP] }));
+  });
+
+  it("validates only when a Cloud API key is present", async () => {
+    expect(
+      await getAppEarningsAction.validate(keyedRuntime(), makeMessage("x")),
+    ).toBe(true);
+    expect(
+      await getAppEarningsAction.validate(unkeyedRuntime(), makeMessage("x")),
+    ).toBe(false);
+  });
+
+  it("formats the earnings balance", async () => {
+    setGetAppEarnings(() =>
+      Promise.resolve(
+        earnings({
+          withdrawableBalance: 42,
+          pendingBalance: 3,
+          totalLifetimeEarnings: 58,
+          totalWithdrawn: 13,
+          payoutThreshold: 25,
+        }),
+      ),
+    );
+    const cb = captureCallback();
+    const result = await getAppEarningsAction.handler(
+      keyedRuntime(),
+      makeMessage("how much have I earned from Acme Bot?"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+    expect(result?.success).toBe(true);
+    const text = cb.calls[0]?.text ?? "";
+    expect(text).toContain("$42.00");
+    expect(text).toContain("$58.00");
+    expect(text.toLowerCase()).toContain("withdraw now");
+    expect(
+      (result?.data as { withdrawableBalance: number }).withdrawableBalance,
+    ).toBe(42);
+  });
+
+  it("handles empty earnings (monetized, nothing earned yet)", async () => {
+    setGetAppEarnings(() =>
+      Promise.resolve(
+        earnings({
+          withdrawableBalance: 0,
+          pendingBalance: 0,
+          totalLifetimeEarnings: 0,
+          totalWithdrawn: 0,
+          payoutThreshold: 25,
+        }),
+      ),
+    );
+    const cb = captureCallback();
+    const result = await getAppEarningsAction.handler(
+      keyedRuntime(),
+      makeMessage("Acme Bot earnings"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+    expect(result?.success).toBe(true);
+    expect(cb.calls[0]?.text?.toLowerCase()).toContain("no earnings yet");
+  });
+
+  it("explains when monetization is off", async () => {
+    const offApp = makeApp({
+      id: "id-acme",
+      name: "Acme Bot",
+      slug: "acme-bot",
+      monetization_enabled: false,
+    });
+    setListApps(() => Promise.resolve({ success: true, apps: [offApp] }));
+    setGetAppEarnings(() => Promise.resolve({ success: true }));
+    const cb = captureCallback();
+    const result = await getAppEarningsAction.handler(
+      keyedRuntime(),
+      makeMessage("Acme Bot earnings"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+    expect(result?.success).toBe(true);
+    expect(cb.calls[0]?.text?.toLowerCase()).toContain("monetization is off");
+  });
+
+  it("returns not-found for an unknown app", async () => {
+    const cb = captureCallback();
+    const result = await getAppEarningsAction.handler(
+      keyedRuntime(),
+      makeMessage("Zephyr earnings"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+    expect((result?.data as { reason: string }).reason).toBe("not_found");
+  });
+
+  it("degrades gracefully with no Cloud API key", async () => {
+    const result = await getAppEarningsAction.handler(
+      unkeyedRuntime(),
+      makeMessage("Acme Bot earnings"),
+      undefined,
+      undefined,
+      captureCallback().fn,
+    );
+    expect((result?.data as { reason: string }).reason).toBe("no_key");
+  });
+
+  it("surfaces an earnings API error", async () => {
+    setGetAppEarnings(() => Promise.reject(new Error("boom")));
+    const result = await getAppEarningsAction.handler(
+      keyedRuntime(),
+      makeMessage("Acme Bot earnings"),
+      undefined,
+      undefined,
+      captureCallback().fn,
+    );
+    expect(result?.success).toBe(false);
+    expect((result?.data as { reason: string }).reason).toBe("error");
+  });
+});

--- a/plugins/plugin-cloud-apps/__tests__/helpers.ts
+++ b/plugins/plugin-cloud-apps/__tests__/helpers.ts
@@ -11,6 +11,8 @@ import { mock } from "bun:test";
 import type {
   AppDeployStatusResponse,
   AppDto,
+  AppEarningsResponse,
+  AppMonetizationResponse,
   AppResponse,
   CreateAppInput,
   CreateAppResponse,
@@ -18,6 +20,11 @@ import type {
   DeployAppInput,
   DeployAppResponse,
   ListAppsResponse,
+  RegenerateAppApiKeyResponse,
+  UpdateAppInput,
+  UpdateAppMonetizationInput,
+  WithdrawAppEarningsRequest,
+  WithdrawAppEarningsResponse,
 } from "@elizaos/cloud-sdk";
 import type { IAgentRuntime, Memory } from "@elizaos/core";
 
@@ -30,6 +37,22 @@ type DeployAppFn = (
 ) => Promise<DeployAppResponse>;
 type GetAppDeployStatusFn = (id: string) => Promise<AppDeployStatusResponse>;
 type DeleteAppFn = (id: string) => Promise<DeleteAppResponse>;
+type UpdateAppFn = (id: string, patch: UpdateAppInput) => Promise<AppResponse>;
+type UpdateMonetizationFn = (
+  id: string,
+  settings: UpdateAppMonetizationInput,
+) => Promise<AppMonetizationResponse>;
+type GetAppEarningsFn = (
+  id: string,
+  options?: { days?: number },
+) => Promise<AppEarningsResponse>;
+type WithdrawAppEarningsFn = (
+  id: string,
+  request: WithdrawAppEarningsRequest,
+) => Promise<WithdrawAppEarningsResponse>;
+type RegenerateAppApiKeyFn = (
+  id: string,
+) => Promise<RegenerateAppApiKeyResponse>;
 
 interface SdkState {
   listApps: ListAppsFn;
@@ -38,6 +61,11 @@ interface SdkState {
   deployApp: DeployAppFn;
   getAppDeployStatus: GetAppDeployStatusFn;
   deleteApp: DeleteAppFn;
+  updateApp: UpdateAppFn;
+  updateMonetization: UpdateMonetizationFn;
+  getAppEarnings: GetAppEarningsFn;
+  withdrawAppEarnings: WithdrawAppEarningsFn;
+  regenerateAppApiKey: RegenerateAppApiKeyFn;
 }
 
 function defaultState(): SdkState {
@@ -68,6 +96,15 @@ function defaultState(): SdkState {
         startedAt: null,
       }),
     deleteApp: () => Promise.resolve({ success: true, message: "deleted" }),
+    updateApp: () =>
+      Promise.resolve({ success: true, app: undefined as unknown as AppDto }),
+    updateMonetization: () =>
+      Promise.resolve({ success: true, monetization: null }),
+    getAppEarnings: () => Promise.resolve({ success: true }),
+    withdrawAppEarnings: () =>
+      Promise.resolve({ success: true, message: "withdrawn", newBalance: 0 }),
+    regenerateAppApiKey: () =>
+      Promise.resolve({ success: true, apiKey: "eliza_app_rotated" }),
   };
 }
 
@@ -90,6 +127,21 @@ export function setGetAppDeployStatus(fn: GetAppDeployStatusFn): void {
 }
 export function setDeleteApp(fn: DeleteAppFn): void {
   state.deleteApp = fn;
+}
+export function setUpdateApp(fn: UpdateAppFn): void {
+  state.updateApp = fn;
+}
+export function setUpdateMonetization(fn: UpdateMonetizationFn): void {
+  state.updateMonetization = fn;
+}
+export function setGetAppEarnings(fn: GetAppEarningsFn): void {
+  state.getAppEarnings = fn;
+}
+export function setWithdrawAppEarnings(fn: WithdrawAppEarningsFn): void {
+  state.withdrawAppEarnings = fn;
+}
+export function setRegenerateAppApiKey(fn: RegenerateAppApiKeyFn): void {
+  state.regenerateAppApiKey = fn;
 }
 
 /** Restore default (empty / no-op) behavior between tests. */
@@ -116,6 +168,30 @@ export class FakeElizaCloudClient {
   }
   deleteApp(id: string): Promise<DeleteAppResponse> {
     return state.deleteApp(id);
+  }
+  updateApp(id: string, patch: UpdateAppInput): Promise<AppResponse> {
+    return state.updateApp(id, patch);
+  }
+  updateMonetization(
+    id: string,
+    settings: UpdateAppMonetizationInput,
+  ): Promise<AppMonetizationResponse> {
+    return state.updateMonetization(id, settings);
+  }
+  getAppEarnings(
+    id: string,
+    options?: { days?: number },
+  ): Promise<AppEarningsResponse> {
+    return state.getAppEarnings(id, options);
+  }
+  withdrawAppEarnings(
+    id: string,
+    request: WithdrawAppEarningsRequest,
+  ): Promise<WithdrawAppEarningsResponse> {
+    return state.withdrawAppEarnings(id, request);
+  }
+  regenerateAppApiKey(id: string): Promise<RegenerateAppApiKeyResponse> {
+    return state.regenerateAppApiKey(id);
   }
 }
 

--- a/plugins/plugin-cloud-apps/__tests__/regenerate-app-api-key.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/regenerate-app-api-key.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+  captureCallback,
+  FakeElizaCloudClient,
+  keyedRuntime,
+  makeApp,
+  makeMessage,
+  resetSdk,
+  setListApps,
+  setRegenerateAppApiKey,
+  unkeyedRuntime,
+} from "./helpers";
+
+mock.module("@elizaos/cloud-sdk", () => ({
+  ElizaCloudClient: FakeElizaCloudClient,
+}));
+
+const { regenerateAppApiKeyAction } = await import(
+  "../src/actions/regenerate-app-api-key.ts"
+);
+
+const APP = makeApp({ id: "id-acme", name: "Acme Bot", slug: "acme-bot" });
+const NEW_KEY = "eliza_app_rotated_secret_value";
+
+/** Track rotate calls; returns the new key once. */
+function trackRotations(): { count: () => number } {
+  let count = 0;
+  setRegenerateAppApiKey(() => {
+    count += 1;
+    return Promise.resolve({ success: true, apiKey: NEW_KEY });
+  });
+  return { count: () => count };
+}
+
+describe("REGENERATE_APP_API_KEY", () => {
+  beforeEach(() => {
+    resetSdk();
+    setListApps(() => Promise.resolve({ success: true, apps: [APP] }));
+  });
+
+  it("validates only when a Cloud API key is present", async () => {
+    expect(
+      await regenerateAppApiKeyAction.validate(
+        keyedRuntime(),
+        makeMessage("x"),
+      ),
+    ).toBe(true);
+    expect(
+      await regenerateAppApiKeyAction.validate(
+        unkeyedRuntime(),
+        makeMessage("x"),
+      ),
+    ).toBe(false);
+  });
+
+  it("first ask: confirms and does NOT rotate", async () => {
+    const rotations = trackRotations();
+    const cb = captureCallback();
+    const result = await regenerateAppApiKeyAction.handler(
+      keyedRuntime(),
+      makeMessage("regenerate the API key for Acme Bot"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+
+    expect(rotations.count()).toBe(0);
+    expect((result?.data as { rotated: boolean }).rotated).toBe(false);
+    expect(
+      (result?.data as { confirmationRequired: boolean }).confirmationRequired,
+    ).toBe(true);
+    const prompt = cb.calls[0]?.text ?? "";
+    expect(prompt).toContain("Acme Bot");
+    expect(prompt.toLowerCase()).toContain("immediately");
+    // The new key must NOT leak in the confirmation prompt.
+    expect(prompt).not.toContain(NEW_KEY);
+  });
+
+  it("explicit confirmation: rotates once and shows the new key exactly once", async () => {
+    const rotations = trackRotations();
+    const cb = captureCallback();
+    const result = await regenerateAppApiKeyAction.handler(
+      keyedRuntime(),
+      makeMessage("rotate Acme Bot — yes"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+
+    expect(rotations.count()).toBe(1);
+    expect(result?.success).toBe(true);
+    expect((result?.data as { rotated: boolean }).rotated).toBe(true);
+
+    // The key is shown ONCE in the user-facing reply...
+    const replies = cb.calls.filter((c) => (c.text ?? "").includes(NEW_KEY));
+    expect(replies).toHaveLength(1);
+    expect(cb.calls[0]?.text?.toLowerCase()).toContain("won't be shown again");
+
+    // ...but never placed in the persisted `data` or summary `text`.
+    expect(JSON.stringify(result?.data)).not.toContain(NEW_KEY);
+    expect(result?.text ?? "").not.toContain(NEW_KEY);
+  });
+
+  it("handles a rotate that returns no key", async () => {
+    setRegenerateAppApiKey(() => Promise.resolve({ success: true }));
+    const cb = captureCallback();
+    const result = await regenerateAppApiKeyAction.handler(
+      keyedRuntime(),
+      makeMessage("rotate Acme Bot — yes"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+    expect(result?.success).toBe(false);
+    expect((result?.data as { reason: string }).reason).toBe("no_key_returned");
+  });
+
+  it("returns not-found for an unknown app (no rotate)", async () => {
+    const rotations = trackRotations();
+    const result = await regenerateAppApiKeyAction.handler(
+      keyedRuntime(),
+      makeMessage("rotate Zephyr — yes"),
+      undefined,
+      undefined,
+      captureCallback().fn,
+    );
+    expect(rotations.count()).toBe(0);
+    expect((result?.data as { reason: string }).reason).toBe("not_found");
+  });
+
+  it("degrades gracefully with no Cloud API key", async () => {
+    const result = await regenerateAppApiKeyAction.handler(
+      unkeyedRuntime(),
+      makeMessage("rotate Acme Bot — yes"),
+      undefined,
+      undefined,
+      captureCallback().fn,
+    );
+    expect((result?.data as { reason: string }).reason).toBe("no_key");
+  });
+
+  it("surfaces a rotate API error", async () => {
+    setRegenerateAppApiKey(() => Promise.reject(new Error("boom")));
+    const result = await regenerateAppApiKeyAction.handler(
+      keyedRuntime(),
+      makeMessage("rotate Acme Bot — yes"),
+      undefined,
+      undefined,
+      captureCallback().fn,
+    );
+    expect(result?.success).toBe(false);
+    expect((result?.data as { reason: string }).reason).toBe("error");
+  });
+});

--- a/plugins/plugin-cloud-apps/__tests__/update-app.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/update-app.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { UpdateAppInput } from "@elizaos/cloud-sdk";
+import {
+  captureCallback,
+  FakeElizaCloudClient,
+  keyedRuntime,
+  makeApp,
+  makeMessage,
+  resetSdk,
+  setListApps,
+  setUpdateApp,
+  unkeyedRuntime,
+} from "./helpers";
+
+mock.module("@elizaos/cloud-sdk", () => ({
+  ElizaCloudClient: FakeElizaCloudClient,
+}));
+
+const { updateAppAction } = await import("../src/actions/update-app.ts");
+const { parseUpdateAppIntent } = await import("../src/actions/update-app.ts");
+
+const APP = makeApp({ id: "id-acme", name: "Acme Bot", slug: "acme-bot" });
+
+/** Track updateApp calls; echoes the patch into the returned app. */
+function trackUpdates(): {
+  calls: Array<{ id: string; patch: UpdateAppInput }>;
+} {
+  const calls: Array<{ id: string; patch: UpdateAppInput }> = [];
+  setUpdateApp((id, patch) => {
+    calls.push({ id, patch });
+    return Promise.resolve({
+      success: true,
+      app: makeApp({
+        id: "id-acme",
+        slug: "acme-bot",
+        name: patch.name ?? "Acme Bot",
+        description: patch.description ?? null,
+        logo_url: patch.logo_url ?? null,
+      }),
+    });
+  });
+  return { calls };
+}
+
+describe("parseUpdateAppIntent", () => {
+  it("parses a rename into a reference + name patch", () => {
+    const intent = parseUpdateAppIntent("rename Acme Bot to Zephyr");
+    expect(intent.reference).toBe("Acme Bot");
+    expect(intent.patch.name).toBe("Zephyr");
+  });
+
+  it("parses a description set with an explicit app", () => {
+    const intent = parseUpdateAppIntent(
+      "set the description of Acme Bot to a friendly support bot",
+    );
+    expect(intent.reference).toBe("Acme Bot");
+    expect(intent.patch.description).toBe("a friendly support bot");
+  });
+
+  it("prefers planner options over text", () => {
+    const intent = parseUpdateAppIntent("change something", {
+      appName: "Acme Bot",
+      name: "Beta",
+    });
+    expect(intent.reference).toBe("Acme Bot");
+    expect(intent.patch.name).toBe("Beta");
+  });
+
+  it("returns an empty patch when nothing is parseable", () => {
+    const intent = parseUpdateAppIntent("do something to my app");
+    expect(Object.keys(intent.patch)).toHaveLength(0);
+  });
+});
+
+describe("UPDATE_APP", () => {
+  beforeEach(() => {
+    resetSdk();
+    setListApps(() => Promise.resolve({ success: true, apps: [APP] }));
+  });
+
+  it("validates only when a Cloud API key is present", async () => {
+    expect(
+      await updateAppAction.validate(keyedRuntime(), makeMessage("x")),
+    ).toBe(true);
+    expect(
+      await updateAppAction.validate(unkeyedRuntime(), makeMessage("x")),
+    ).toBe(false);
+  });
+
+  it("renames an app: calls updateApp with the name patch and confirms", async () => {
+    const updates = trackUpdates();
+    const cb = captureCallback();
+    const result = await updateAppAction.handler(
+      keyedRuntime(),
+      makeMessage("rename Acme Bot to Zephyr"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+
+    expect(updates.calls).toHaveLength(1);
+    expect(updates.calls[0]?.id).toBe("id-acme");
+    expect(updates.calls[0]?.patch).toEqual({ name: "Zephyr" });
+    expect(result?.success).toBe(true);
+    expect(cb.calls[0]?.text).toContain("Zephyr");
+    expect((result?.data as { updated: string[] }).updated).toEqual(["name"]);
+  });
+
+  it("updates a description", async () => {
+    const updates = trackUpdates();
+    const cb = captureCallback();
+    const result = await updateAppAction.handler(
+      keyedRuntime(),
+      makeMessage("set the description of Acme Bot to a helpful bot"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+    expect(updates.calls[0]?.patch).toEqual({ description: "a helpful bot" });
+    expect(result?.success).toBe(true);
+    expect(cb.calls[0]?.text?.toLowerCase()).toContain("description updated");
+  });
+
+  it("rejects a malformed logo URL before calling the API", async () => {
+    const updates = trackUpdates();
+    const cb = captureCallback();
+    const result = await updateAppAction.handler(
+      keyedRuntime(),
+      makeMessage("set the logo of Acme Bot to not-a-url"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+    expect(updates.calls).toHaveLength(0);
+    expect((result?.data as { reason: string }).reason).toBe("invalid_url");
+  });
+
+  it("asks what to change when no field is parseable", async () => {
+    const updates = trackUpdates();
+    const cb = captureCallback();
+    const result = await updateAppAction.handler(
+      keyedRuntime(),
+      makeMessage("update my app"),
+      undefined,
+      { appName: "Acme Bot" },
+      cb.fn,
+    );
+    expect(updates.calls).toHaveLength(0);
+    expect((result?.data as { reason: string }).reason).toBe("no_change");
+  });
+
+  it("returns not-found for an unknown app", async () => {
+    const updates = trackUpdates();
+    const cb = captureCallback();
+    const result = await updateAppAction.handler(
+      keyedRuntime(),
+      makeMessage("rename Zephyr to Gamma"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+    expect(updates.calls).toHaveLength(0);
+    expect((result?.data as { reason: string }).reason).toBe("not_found");
+  });
+
+  it("degrades gracefully with no Cloud API key", async () => {
+    const cb = captureCallback();
+    const result = await updateAppAction.handler(
+      unkeyedRuntime(),
+      makeMessage("rename Acme Bot to Zephyr"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+    expect(result?.success).toBe(false);
+    expect((result?.data as { reason: string }).reason).toBe("no_key");
+  });
+
+  it("surfaces an update API error", async () => {
+    setUpdateApp(() => Promise.reject(new Error("boom")));
+    const cb = captureCallback();
+    const result = await updateAppAction.handler(
+      keyedRuntime(),
+      makeMessage("rename Acme Bot to Zephyr"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+    expect(result?.success).toBe(false);
+    expect((result?.data as { reason: string }).reason).toBe("error");
+  });
+});

--- a/plugins/plugin-cloud-apps/__tests__/update-monetization.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/update-monetization.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { UpdateAppMonetizationInput } from "@elizaos/cloud-sdk";
+import {
+  captureCallback,
+  FakeElizaCloudClient,
+  keyedRuntime,
+  makeApp,
+  makeMessage,
+  resetSdk,
+  setListApps,
+  setUpdateMonetization,
+  unkeyedRuntime,
+} from "./helpers";
+
+mock.module("@elizaos/cloud-sdk", () => ({
+  ElizaCloudClient: FakeElizaCloudClient,
+}));
+
+const { updateMonetizationAction } = await import(
+  "../src/actions/update-monetization.ts"
+);
+const { parseMonetizationIntent } = await import(
+  "../src/actions/update-monetization.ts"
+);
+
+const APP = makeApp({
+  id: "id-acme",
+  name: "Acme Bot",
+  slug: "acme-bot",
+  monetization_enabled: true,
+});
+
+/** Track updateMonetization calls; echoes settings back as the result. */
+function trackMonetization(): {
+  calls: Array<{ id: string; settings: UpdateAppMonetizationInput }>;
+} {
+  const calls: Array<{ id: string; settings: UpdateAppMonetizationInput }> = [];
+  setUpdateMonetization((id, settings) => {
+    calls.push({ id, settings });
+    return Promise.resolve({
+      success: true,
+      monetization: {
+        monetizationEnabled: settings.monetizationEnabled ?? true,
+        inferenceMarkupPercentage: settings.inferenceMarkupPercentage ?? 0,
+        purchaseSharePercentage: settings.purchaseSharePercentage ?? 0,
+        platformOffsetAmount: 0,
+        totalCreatorEarnings: 0,
+      },
+    });
+  });
+  return { calls };
+}
+
+describe("parseMonetizationIntent", () => {
+  it("parses a markup percentage and implies enabling", () => {
+    const intent = parseMonetizationIntent("set the markup to 20%");
+    expect(intent.settings.inferenceMarkupPercentage).toBe(20);
+    expect(intent.settings.monetizationEnabled).toBe(true);
+  });
+
+  it("parses a disable intent", () => {
+    const intent = parseMonetizationIntent("turn off monetization");
+    expect(intent.settings.monetizationEnabled).toBe(false);
+  });
+
+  it("flags an out-of-range markup", () => {
+    expect(parseMonetizationIntent("set markup to 5000%").rejected?.field).toBe(
+      "markup",
+    );
+    expect(parseMonetizationIntent("set markup to -10%").rejected?.field).toBe(
+      "markup",
+    );
+  });
+});
+
+describe("UPDATE_MONETIZATION", () => {
+  beforeEach(() => {
+    resetSdk();
+    setListApps(() => Promise.resolve({ success: true, apps: [APP] }));
+  });
+
+  it("validates only when a Cloud API key is present", async () => {
+    expect(
+      await updateMonetizationAction.validate(keyedRuntime(), makeMessage("x")),
+    ).toBe(true);
+    expect(
+      await updateMonetizationAction.validate(
+        unkeyedRuntime(),
+        makeMessage("x"),
+      ),
+    ).toBe(false);
+  });
+
+  it("sets the inference markup and echoes the resulting settings", async () => {
+    const tracked = trackMonetization();
+    const cb = captureCallback();
+    const result = await updateMonetizationAction.handler(
+      keyedRuntime(),
+      makeMessage("set Acme Bot's inference markup to 20%"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+    expect(tracked.calls).toHaveLength(1);
+    expect(tracked.calls[0]?.settings.inferenceMarkupPercentage).toBe(20);
+    expect(result?.success).toBe(true);
+    expect(cb.calls[0]?.text).toContain("20%");
+  });
+
+  it("disables monetization", async () => {
+    const tracked = trackMonetization();
+    const cb = captureCallback();
+    const result = await updateMonetizationAction.handler(
+      keyedRuntime(),
+      makeMessage("turn off monetization for Acme Bot"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+    expect(tracked.calls[0]?.settings.monetizationEnabled).toBe(false);
+    expect(result?.success).toBe(true);
+    expect(cb.calls[0]?.text?.toUpperCase()).toContain("OFF");
+  });
+
+  it("rejects an out-of-range markup WITHOUT calling the API", async () => {
+    const tracked = trackMonetization();
+    const cb = captureCallback();
+    const result = await updateMonetizationAction.handler(
+      keyedRuntime(),
+      makeMessage("set Acme Bot markup to 5000%"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+    expect(tracked.calls).toHaveLength(0);
+    expect((result?.data as { reason: string }).reason).toBe("out_of_range");
+    expect(cb.calls[0]?.text?.toLowerCase()).toContain("out of range");
+  });
+
+  it("rejects a negative markup", async () => {
+    const tracked = trackMonetization();
+    const result = await updateMonetizationAction.handler(
+      keyedRuntime(),
+      makeMessage("set Acme Bot markup to -10%"),
+      undefined,
+      undefined,
+      captureCallback().fn,
+    );
+    expect(tracked.calls).toHaveLength(0);
+    expect((result?.data as { reason: string }).reason).toBe("out_of_range");
+  });
+
+  it("asks what to change when nothing is parseable", async () => {
+    const tracked = trackMonetization();
+    const result = await updateMonetizationAction.handler(
+      keyedRuntime(),
+      makeMessage("do something with monetization later"),
+      undefined,
+      { appName: "Acme Bot" },
+      captureCallback().fn,
+    );
+    expect(tracked.calls).toHaveLength(0);
+    expect((result?.data as { reason: string }).reason).toBe("no_change");
+  });
+
+  it("degrades gracefully with no Cloud API key", async () => {
+    const result = await updateMonetizationAction.handler(
+      unkeyedRuntime(),
+      makeMessage("set Acme Bot markup to 20%"),
+      undefined,
+      undefined,
+      captureCallback().fn,
+    );
+    expect((result?.data as { reason: string }).reason).toBe("no_key");
+  });
+
+  it("surfaces a monetization API error", async () => {
+    setUpdateMonetization(() => Promise.reject(new Error("boom")));
+    const result = await updateMonetizationAction.handler(
+      keyedRuntime(),
+      makeMessage("set Acme Bot's markup to 20%"),
+      undefined,
+      undefined,
+      captureCallback().fn,
+    );
+    expect(result?.success).toBe(false);
+    expect((result?.data as { reason: string }).reason).toBe("error");
+  });
+});

--- a/plugins/plugin-cloud-apps/__tests__/withdraw-app-earnings.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/withdraw-app-earnings.test.ts
@@ -1,0 +1,272 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { WithdrawAppEarningsRequest } from "@elizaos/cloud-sdk";
+import type { ConnectorCta } from "../src/safety.ts";
+import {
+  captureCallback,
+  FakeElizaCloudClient,
+  keyedRuntime,
+  makeApp,
+  makeMessage,
+  resetSdk,
+  setGetAppEarnings,
+  setListApps,
+  setWithdrawAppEarnings,
+  unkeyedRuntime,
+} from "./helpers";
+
+mock.module("@elizaos/cloud-sdk", () => ({
+  ElizaCloudClient: FakeElizaCloudClient,
+}));
+
+const { withdrawAppEarningsAction } = await import(
+  "../src/actions/withdraw-app-earnings.ts"
+);
+
+const APP = makeApp({
+  id: "id-acme",
+  name: "Acme Bot",
+  slug: "acme-bot",
+  monetization_enabled: true,
+});
+
+const API_KEY = "eliza_test_key"; // what keyedRuntime() configures
+
+/** Configure earnings with a withdrawable balance + threshold. */
+function setBalance(withdrawableBalance: number, payoutThreshold = 25): void {
+  setGetAppEarnings(() =>
+    Promise.resolve({
+      success: true,
+      earnings: {
+        summary: {
+          withdrawableBalance,
+          pendingBalance: 0,
+          totalLifetimeEarnings: withdrawableBalance,
+          totalWithdrawn: 0,
+          payoutThreshold,
+        },
+      },
+      monetization: { enabled: true },
+    }),
+  );
+}
+
+/** Track withdraw calls (the money-out path). */
+function trackWithdrawals(): {
+  calls: Array<{ id: string; request: WithdrawAppEarningsRequest }>;
+} {
+  const calls: Array<{ id: string; request: WithdrawAppEarningsRequest }> = [];
+  setWithdrawAppEarnings((id, request) => {
+    calls.push({ id, request });
+    return Promise.resolve({
+      success: true,
+      message: "withdrawn",
+      transactionId: "txn_1",
+      newBalance: 0,
+    });
+  });
+  return { calls };
+}
+
+describe("WITHDRAW_APP_EARNINGS", () => {
+  beforeEach(() => {
+    resetSdk();
+    setListApps(() => Promise.resolve({ success: true, apps: [APP] }));
+    setBalance(100, 25);
+  });
+
+  it("validates only when a Cloud API key is present", async () => {
+    expect(
+      await withdrawAppEarningsAction.validate(
+        keyedRuntime(),
+        makeMessage("x"),
+      ),
+    ).toBe(true);
+    expect(
+      await withdrawAppEarningsAction.validate(
+        unkeyedRuntime(),
+        makeMessage("x"),
+      ),
+    ).toBe(false);
+  });
+
+  it("first ask: returns a confirm prompt + CTA and makes NO money call", async () => {
+    const withdrawals = trackWithdrawals();
+    const cb = captureCallback();
+    const result = await withdrawAppEarningsAction.handler(
+      keyedRuntime(),
+      makeMessage("withdraw my Acme Bot earnings"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+
+    // No money moved on the first ask.
+    expect(withdrawals.calls).toHaveLength(0);
+    expect((result?.data as { withdrawn: boolean }).withdrawn).toBe(false);
+    expect(
+      (result?.data as { confirmationRequired: boolean }).confirmationRequired,
+    ).toBe(true);
+
+    // Confirm prompt names the amount (defaults to the full withdrawable balance).
+    const prompt = cb.calls[0]?.text ?? "";
+    expect(prompt).toContain("$100.00");
+    expect(prompt.toLowerCase()).toContain("reply");
+
+    // A connector-agnostic CTA is handed back — label + https URL only.
+    const cta = (result?.data as { cta: ConnectorCta }).cta;
+    expect(cta.url.startsWith("https://")).toBe(true);
+    expect(cta.url).toContain("/dashboard/apps/id-acme");
+    expect(prompt).toContain(cta.url);
+
+    // NO secret/credential transits the connector output.
+    expect(Object.keys(cta).sort()).toEqual(["kind", "label", "url"]);
+    const ctaBlob = JSON.stringify(cta);
+    expect(ctaBlob).not.toContain(API_KEY);
+    expect(ctaBlob.toLowerCase()).not.toContain("secret");
+    expect(ctaBlob.toLowerCase()).not.toContain("token");
+    expect([...new URL(cta.url).searchParams.keys()]).toEqual(["tab"]);
+    expect(prompt).not.toContain(API_KEY);
+  });
+
+  it("explicit confirmation: the safe withdraw path fires exactly once", async () => {
+    const withdrawals = trackWithdrawals();
+    const cb = captureCallback();
+    const result = await withdrawAppEarningsAction.handler(
+      keyedRuntime(),
+      makeMessage("withdraw Acme Bot — yes"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+
+    expect(withdrawals.calls).toHaveLength(1);
+    expect(withdrawals.calls[0]?.id).toBe("id-acme");
+    expect(withdrawals.calls[0]?.request.amount).toBe(100);
+
+    // Idempotency key present and within the server's 16–64 char bound.
+    const key = withdrawals.calls[0]?.request.idempotency_key ?? "";
+    expect(key.length).toBeGreaterThanOrEqual(16);
+    expect(key.length).toBeLessThanOrEqual(64);
+
+    expect(result?.success).toBe(true);
+    expect((result?.data as { withdrawn: boolean }).withdrawn).toBe(true);
+
+    // No secret transits the connector output on confirm either.
+    const cta = (result?.data as { cta: ConnectorCta }).cta;
+    expect(JSON.stringify(cta)).not.toContain(API_KEY);
+    expect(cb.calls[0]?.text).not.toContain(API_KEY);
+  });
+
+  it("honors an explicit amount on confirm", async () => {
+    const withdrawals = trackWithdrawals();
+    const result = await withdrawAppEarningsAction.handler(
+      keyedRuntime(),
+      makeMessage("withdraw $50 from Acme Bot — yes"),
+      undefined,
+      undefined,
+      captureCallback().fn,
+    );
+    expect(withdrawals.calls[0]?.request.amount).toBe(50);
+    expect(result?.success).toBe(true);
+  });
+
+  it("refuses (no call) when the balance is below the payout threshold", async () => {
+    setBalance(10, 25);
+    const withdrawals = trackWithdrawals();
+    const result = await withdrawAppEarningsAction.handler(
+      keyedRuntime(),
+      makeMessage("withdraw my Acme Bot earnings"),
+      undefined,
+      undefined,
+      captureCallback().fn,
+    );
+    expect(withdrawals.calls).toHaveLength(0);
+    expect((result?.data as { reason: string }).reason).toBe("below_threshold");
+  });
+
+  it("refuses (no call) when nothing is withdrawable", async () => {
+    setBalance(0, 25);
+    const withdrawals = trackWithdrawals();
+    const result = await withdrawAppEarningsAction.handler(
+      keyedRuntime(),
+      makeMessage("withdraw Acme Bot — yes"),
+      undefined,
+      undefined,
+      captureCallback().fn,
+    );
+    expect(withdrawals.calls).toHaveLength(0);
+    expect((result?.data as { reason: string }).reason).toBe("no_balance");
+  });
+
+  it("refuses (no call) when monetization is off", async () => {
+    setGetAppEarnings(() =>
+      Promise.resolve({
+        success: true,
+        earnings: {
+          summary: { withdrawableBalance: 100, payoutThreshold: 25 },
+        },
+        monetization: { enabled: false },
+      }),
+    );
+    const withdrawals = trackWithdrawals();
+    const result = await withdrawAppEarningsAction.handler(
+      keyedRuntime(),
+      makeMessage("withdraw Acme Bot — yes"),
+      undefined,
+      undefined,
+      captureCallback().fn,
+    );
+    expect(withdrawals.calls).toHaveLength(0);
+    expect((result?.data as { reason: string }).reason).toBe("not_monetized");
+  });
+
+  it("rejects an amount above the withdrawable balance (no call)", async () => {
+    const withdrawals = trackWithdrawals();
+    const result = await withdrawAppEarningsAction.handler(
+      keyedRuntime(),
+      makeMessage("withdraw $500 from Acme Bot — yes"),
+      undefined,
+      undefined,
+      captureCallback().fn,
+    );
+    expect(withdrawals.calls).toHaveLength(0);
+    expect((result?.data as { reason: string }).reason).toBe("exceeds_balance");
+  });
+
+  it("returns not-found for an unknown app", async () => {
+    const withdrawals = trackWithdrawals();
+    const result = await withdrawAppEarningsAction.handler(
+      keyedRuntime(),
+      makeMessage("withdraw Zephyr — yes"),
+      undefined,
+      undefined,
+      captureCallback().fn,
+    );
+    expect(withdrawals.calls).toHaveLength(0);
+    expect((result?.data as { reason: string }).reason).toBe("not_found");
+  });
+
+  it("degrades gracefully with no Cloud API key", async () => {
+    const result = await withdrawAppEarningsAction.handler(
+      unkeyedRuntime(),
+      makeMessage("withdraw Acme Bot — yes"),
+      undefined,
+      undefined,
+      captureCallback().fn,
+    );
+    expect((result?.data as { reason: string }).reason).toBe("no_key");
+  });
+
+  it("surfaces a withdraw API error on confirm", async () => {
+    setWithdrawAppEarnings(() => Promise.reject(new Error("boom")));
+    const result = await withdrawAppEarningsAction.handler(
+      keyedRuntime(),
+      makeMessage("withdraw Acme Bot — yes"),
+      undefined,
+      undefined,
+      captureCallback().fn,
+    );
+    expect(result?.success).toBe(false);
+    expect((result?.data as { reason: string }).reason).toBe("error");
+  });
+});

--- a/plugins/plugin-cloud-apps/src/actions/get-app-earnings.ts
+++ b/plugins/plugin-cloud-apps/src/actions/get-app-earnings.ts
@@ -1,0 +1,257 @@
+/**
+ * GET_APP_EARNINGS — "how much have I earned from app X?" READ-ONLY.
+ *
+ * Resolves the app, calls the typed `client.getAppEarnings(id)` (wrapping
+ * `GET /api/v1/apps/:id/earnings`), and formats the earnings summary:
+ * withdrawable balance, pending balance, lifetime earnings, total withdrawn, and
+ * the payout threshold. Degrades gracefully when there is no key, no earnings, or
+ * monetization is off. No mutating calls, no money movement.
+ */
+
+import type { AppDto } from "@elizaos/cloud-sdk";
+import type {
+  Action,
+  ActionResult,
+  HandlerCallback,
+  IAgentRuntime,
+  Memory,
+  State,
+} from "@elizaos/core";
+import { logger } from "@elizaos/core";
+import {
+  extractAppReference,
+  getCloudClient,
+  resolveApp,
+  resolveCloudApiKey,
+} from "../client.js";
+
+const NO_KEY_MESSAGE =
+  "I can't reach Eliza Cloud yet — no Cloud API key is configured. Add your ELIZAOS_CLOUD_API_KEY and I can check your earnings.";
+const NO_REFERENCE_MESSAGE =
+  "Which app's earnings would you like to see? Tell me its name.";
+const ERROR_MESSAGE =
+  "I couldn't fetch those earnings right now — the Cloud API returned an error. Try again in a moment.";
+
+/** The earnings fields the summary block reads. */
+export interface EarningsView {
+  withdrawableBalance: number;
+  pendingBalance: number;
+  totalLifetimeEarnings: number;
+  totalWithdrawn: number;
+  payoutThreshold: number;
+}
+
+function asNum(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const n = Number(value);
+    if (Number.isFinite(n)) return n;
+  }
+  return null;
+}
+
+/** Pull the earnings summary out of the (loosely-typed) earnings envelope. */
+export function extractEarningsView(
+  earnings: Record<string, unknown> | undefined,
+): EarningsView | null {
+  const summary =
+    earnings && typeof earnings.summary === "object" && earnings.summary
+      ? (earnings.summary as Record<string, unknown>)
+      : null;
+  if (!summary) return null;
+  return {
+    withdrawableBalance: asNum(summary.withdrawableBalance) ?? 0,
+    pendingBalance: asNum(summary.pendingBalance) ?? 0,
+    totalLifetimeEarnings: asNum(summary.totalLifetimeEarnings) ?? 0,
+    totalWithdrawn: asNum(summary.totalWithdrawn) ?? 0,
+    payoutThreshold: asNum(summary.payoutThreshold) ?? 0,
+  };
+}
+
+function monetizationEnabled(
+  monetization: Record<string, unknown> | undefined,
+): boolean {
+  return monetization?.enabled === true;
+}
+
+/** Human earnings block for the reply (exported for tests). */
+export function formatEarnings(
+  app: AppDto,
+  earnings: Record<string, unknown> | undefined,
+  monetization: Record<string, unknown> | undefined,
+): string {
+  const view = extractEarningsView(earnings);
+  const enabled = monetizationEnabled(monetization) || app.monetization_enabled;
+
+  if (!view || view.totalLifetimeEarnings === 0) {
+    if (!enabled) {
+      return `"${app.name}" isn't earning yet — monetization is off. Turn it on and I'll start tracking earnings.`;
+    }
+    return `"${app.name}" has no earnings yet. Once users run paid inference through it, earnings will show up here.`;
+  }
+
+  const usd = (n: number): string => `$${n.toFixed(2)}`;
+  const lines = [
+    `"${app.name}" earnings:`,
+    `• Withdrawable now: ${usd(view.withdrawableBalance)}`,
+  ];
+  if (view.pendingBalance > 0) {
+    lines.push(`• Pending (clearing): ${usd(view.pendingBalance)}`);
+  }
+  lines.push(`• Lifetime: ${usd(view.totalLifetimeEarnings)}`);
+  if (view.totalWithdrawn > 0) {
+    lines.push(`• Withdrawn so far: ${usd(view.totalWithdrawn)}`);
+  }
+  if (view.payoutThreshold > 0) {
+    const ready = view.withdrawableBalance >= view.payoutThreshold;
+    lines.push(
+      ready
+        ? `You can withdraw now (minimum payout ${usd(view.payoutThreshold)}).`
+        : `Minimum payout is ${usd(view.payoutThreshold)} — keep earning to reach it.`,
+    );
+  }
+  return lines.join("\n");
+}
+
+function notFoundMessage(reference: string, available: string[]): string {
+  const base = `I couldn't find an app matching "${reference}".`;
+  if (available.length === 0) {
+    return `${base} You don't have any apps on Eliza Cloud yet.`;
+  }
+  return `${base} Your apps are: ${available.join(", ")}.`;
+}
+
+export const getAppEarningsAction: Action = {
+  name: "GET_APP_EARNINGS",
+  similes: [
+    "HOW_MUCH_HAVE_I_EARNED",
+    "MY_EARNINGS",
+    "APP_EARNINGS",
+    "SHOW_EARNINGS",
+    "CHECK_EARNINGS",
+  ],
+  description:
+    "Show how much an Eliza Cloud app has earned — withdrawable balance, pending balance, lifetime earnings, and amount withdrawn. Read-only. Use when the user asks how much they've earned or about an app's revenue/earnings.",
+  descriptionCompressed: "Show a Cloud app's earnings (read-only).",
+  contexts: ["settings", "finance", "apps"],
+  contextGate: { anyOf: ["settings", "finance", "apps"] },
+
+  validate: async (runtime: IAgentRuntime): Promise<boolean> => {
+    return resolveCloudApiKey(runtime) !== null;
+  },
+
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory,
+    _state?: State,
+    options?: unknown,
+    callback?: HandlerCallback,
+  ): Promise<ActionResult> => {
+    const client = getCloudClient(runtime);
+    if (!client) {
+      await callback?.({ text: NO_KEY_MESSAGE, actions: ["GET_APP_EARNINGS"] });
+      return {
+        success: false,
+        text: "No Eliza Cloud API key configured.",
+        userFacingText: NO_KEY_MESSAGE,
+        data: { reason: "no_key" },
+      };
+    }
+
+    const reference = extractAppReference(message, options);
+    if (!reference) {
+      await callback?.({
+        text: NO_REFERENCE_MESSAGE,
+        actions: ["GET_APP_EARNINGS"],
+      });
+      return {
+        success: false,
+        text: "No app reference supplied.",
+        userFacingText: NO_REFERENCE_MESSAGE,
+        data: { reason: "no_reference" },
+      };
+    }
+
+    let app: AppDto | null;
+    let available: string[];
+    try {
+      ({ app, available } = await resolveApp(client, reference));
+    } catch (err) {
+      logger.warn(
+        `[GET_APP_EARNINGS] Failed to resolve app "${reference}": ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      await callback?.({ text: ERROR_MESSAGE, actions: ["GET_APP_EARNINGS"] });
+      return {
+        success: false,
+        text: "Failed to resolve Eliza Cloud app.",
+        userFacingText: ERROR_MESSAGE,
+        error: err instanceof Error ? err : new Error(String(err)),
+        data: { reason: "error" },
+      };
+    }
+
+    if (!app) {
+      const msg = notFoundMessage(reference, available);
+      await callback?.({ text: msg, actions: ["GET_APP_EARNINGS"] });
+      return {
+        success: false,
+        text: `No app matched "${reference}".`,
+        userFacingText: msg,
+        data: { reason: "not_found", reference },
+      };
+    }
+
+    const target = app;
+    try {
+      const res = await client.getAppEarnings(target.id);
+      const reply = formatEarnings(target, res.earnings, res.monetization);
+      const view = extractEarningsView(res.earnings);
+      await callback?.({ text: reply, actions: ["GET_APP_EARNINGS"] });
+      return {
+        success: true,
+        text: `Fetched earnings for ${target.name}.`,
+        userFacingText: reply,
+        verifiedUserFacing: true,
+        data: {
+          app: { id: target.id, name: target.name, slug: target.slug },
+          withdrawableBalance: view?.withdrawableBalance ?? 0,
+          lifetimeEarnings: view?.totalLifetimeEarnings ?? 0,
+        },
+      };
+    } catch (err) {
+      logger.warn(
+        `[GET_APP_EARNINGS] getAppEarnings(${target.id}) failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      await callback?.({ text: ERROR_MESSAGE, actions: ["GET_APP_EARNINGS"] });
+      return {
+        success: false,
+        text: "Failed to fetch earnings.",
+        userFacingText: ERROR_MESSAGE,
+        error: err instanceof Error ? err : new Error(String(err)),
+        data: { reason: "error" },
+      };
+    }
+  },
+
+  examples: [
+    [
+      {
+        name: "{{user}}",
+        content: { text: "how much have I earned from Acme Bot?" },
+      },
+      {
+        name: "{{agent}}",
+        content: {
+          text: '"Acme Bot" earnings:\n• Withdrawable now: $42.00\n• Lifetime: $58.00\nYou can withdraw now (minimum payout $25.00).',
+          actions: ["GET_APP_EARNINGS"],
+        },
+      },
+    ],
+  ],
+};
+
+export default getAppEarningsAction;

--- a/plugins/plugin-cloud-apps/src/actions/regenerate-app-api-key.ts
+++ b/plugins/plugin-cloud-apps/src/actions/regenerate-app-api-key.ts
@@ -1,0 +1,275 @@
+/**
+ * REGENERATE_APP_API_KEY — SECURITY-SENSITIVE. Rotates the app's API key.
+ *
+ * Rotating invalidates the current key IMMEDIATELY — anything using it stops
+ * working until updated — so this action never rotates on the first ask:
+ *   1. First turn ("rotate my Acme key"): resolve the app, return a confirmation
+ *      prompt spelling out that the old key dies right away. No rotate call.
+ *   2. Follow-up with an explicit confirmation token ("rotate Acme — yes"):
+ *      `client.regenerateAppApiKey(id)` runs exactly once.
+ *
+ * The new plaintext key is shown EXACTLY ONCE in the reply with a "save it now"
+ * warning, and is NEVER logged or placed in the structured `data`/`text` fields
+ * (which may be persisted) — only in the user-facing message the connector shows.
+ */
+
+import type { AppDto } from "@elizaos/cloud-sdk";
+import type {
+  Action,
+  ActionResult,
+  HandlerCallback,
+  IAgentRuntime,
+  Memory,
+  State,
+} from "@elizaos/core";
+import { logger } from "@elizaos/core";
+import {
+  extractAppReference,
+  getCloudClient,
+  resolveApp,
+  resolveCloudApiKey,
+} from "../client.js";
+import { type ConfirmTarget, isExplicitConfirmation } from "../safety.js";
+
+const NO_KEY_MESSAGE =
+  "I can't reach Eliza Cloud yet — no Cloud API key is configured. Add your ELIZAOS_CLOUD_API_KEY and I can rotate your app keys.";
+const NO_REFERENCE_MESSAGE =
+  "Which app's API key would you like to regenerate? Tell me its name.";
+const ERROR_MESSAGE =
+  "I couldn't rotate that app's API key right now — the Cloud API returned an error. The existing key is unchanged. Try again in a moment.";
+
+/** Verbs that, with an affirmation word, count as a rotate confirmation. */
+const ROTATE_VERBS = [
+  "regenerate",
+  "rotate",
+  "reset",
+  "new key",
+  "new api key",
+  "roll",
+];
+
+function confirmTargetFor(app: AppDto): ConfirmTarget {
+  return { name: app.name, id: app.id, aliases: [app.slug] };
+}
+
+function notFoundMessage(reference: string, available: string[]): string {
+  const base = `I couldn't find an app matching "${reference}".`;
+  if (available.length === 0) {
+    return `${base} You don't have any apps on Eliza Cloud yet.`;
+  }
+  return `${base} Your apps are: ${available.join(", ")}.`;
+}
+
+export const regenerateAppApiKeyAction: Action = {
+  name: "REGENERATE_APP_API_KEY",
+  similes: [
+    "ROTATE_KEY",
+    "NEW_API_KEY",
+    "REGENERATE_API_KEY",
+    "RESET_API_KEY",
+    "ROTATE_APP_KEY",
+  ],
+  description:
+    "Regenerate (rotate) an Eliza Cloud app's API key. SECURITY-SENSITIVE: invalidates the current key immediately. Requires an explicit confirmation — the first ask only confirms intent. Use when the user asks to rotate, regenerate, reset, or get a new API key for an app.",
+  descriptionCompressed:
+    "Rotate a Cloud app's API key (security; two-step confirm).",
+  contexts: ["settings", "finance", "apps"],
+  contextGate: { anyOf: ["settings", "finance", "apps"] },
+  suppressPostActionContinuation: true,
+
+  validate: async (runtime: IAgentRuntime): Promise<boolean> => {
+    return resolveCloudApiKey(runtime) !== null;
+  },
+
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory,
+    _state?: State,
+    options?: unknown,
+    callback?: HandlerCallback,
+  ): Promise<ActionResult> => {
+    const client = getCloudClient(runtime);
+    if (!client) {
+      await callback?.({
+        text: NO_KEY_MESSAGE,
+        actions: ["REGENERATE_APP_API_KEY"],
+      });
+      return {
+        success: false,
+        text: "No Eliza Cloud API key configured.",
+        userFacingText: NO_KEY_MESSAGE,
+        data: { reason: "no_key" },
+      };
+    }
+
+    const reference = extractAppReference(message, options);
+    if (!reference) {
+      await callback?.({
+        text: NO_REFERENCE_MESSAGE,
+        actions: ["REGENERATE_APP_API_KEY"],
+      });
+      return {
+        success: false,
+        text: "No app reference supplied.",
+        userFacingText: NO_REFERENCE_MESSAGE,
+        data: { reason: "no_reference" },
+      };
+    }
+
+    let app: AppDto | null;
+    let available: string[];
+    try {
+      ({ app, available } = await resolveApp(client, reference));
+    } catch (err) {
+      logger.warn(
+        `[REGENERATE_APP_API_KEY] Failed to resolve app "${reference}": ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      await callback?.({
+        text: ERROR_MESSAGE,
+        actions: ["REGENERATE_APP_API_KEY"],
+      });
+      return {
+        success: false,
+        text: "Failed to resolve Eliza Cloud app.",
+        userFacingText: ERROR_MESSAGE,
+        error: err instanceof Error ? err : new Error(String(err)),
+        data: { reason: "error" },
+      };
+    }
+
+    if (!app) {
+      const msg = notFoundMessage(reference, available);
+      await callback?.({ text: msg, actions: ["REGENERATE_APP_API_KEY"] });
+      return {
+        success: false,
+        text: `No app matched "${reference}".`,
+        userFacingText: msg,
+        data: { reason: "not_found", reference },
+      };
+    }
+
+    const target = app;
+    const confirmTarget = confirmTargetFor(target);
+    const messageText = message.content?.text ?? "";
+
+    // Phase 1 — no explicit confirmation → confirm, do NOT rotate.
+    if (
+      !isExplicitConfirmation(messageText, confirmTarget, {
+        verbs: ROTATE_VERBS,
+      })
+    ) {
+      const prompt =
+        `This will regenerate the API key for "${target.name}" (${target.id}). ` +
+        `The current key stops working immediately, so any app or integration ` +
+        `using it will break until you paste in the new one. This can't be undone. ` +
+        `To go ahead, reply: rotate ${target.name} — yes.`;
+      await callback?.({
+        text: prompt,
+        actions: ["REGENERATE_APP_API_KEY"],
+      });
+      return {
+        success: true,
+        text: `Awaiting explicit confirmation to rotate the API key for ${target.name}.`,
+        userFacingText: prompt,
+        verifiedUserFacing: true,
+        data: {
+          app: { id: target.id, name: target.name, slug: target.slug },
+          rotated: false,
+          confirmationRequired: true,
+        },
+      };
+    }
+
+    // Phase 2 — explicit confirmation → rotate exactly once.
+    try {
+      const result = await client.regenerateAppApiKey(target.id);
+      const newKey =
+        typeof result.apiKey === "string" && result.apiKey.length > 0
+          ? result.apiKey
+          : null;
+
+      if (result.success === false || !newKey) {
+        const msg = `I rotated the request for "${target.name}", but the Cloud API didn't return a new key. Check your dashboard to confirm the key, then try again if needed.`;
+        await callback?.({
+          text: msg,
+          actions: ["REGENERATE_APP_API_KEY"],
+        });
+        return {
+          success: false,
+          text: "Rotation returned no key.",
+          userFacingText: msg,
+          data: { reason: "no_key_returned", rotated: false },
+        };
+      }
+
+      // Show the key EXACTLY ONCE. Never logged; never placed in `data`/`text`.
+      const reply =
+        `Done — here is the new API key for "${target.name}":\n\n${newKey}\n\n` +
+        `Save this now: it won't be shown again, and the old key no longer works. ` +
+        `Update anything that used the previous key.`;
+      await callback?.({
+        text: reply,
+        actions: ["REGENERATE_APP_API_KEY"],
+      });
+      return {
+        success: true,
+        // Note: no key in `text`/`data` — only in the one-time user-facing reply.
+        text: `Regenerated the API key for ${target.name}.`,
+        userFacingText: reply,
+        verifiedUserFacing: true,
+        data: {
+          app: { id: target.id, name: target.name, slug: target.slug },
+          rotated: true,
+          keyShown: true,
+        },
+      };
+    } catch (err) {
+      logger.warn(
+        `[REGENERATE_APP_API_KEY] regenerateAppApiKey(${target.id}) failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      await callback?.({
+        text: ERROR_MESSAGE,
+        actions: ["REGENERATE_APP_API_KEY"],
+      });
+      return {
+        success: false,
+        text: "Failed to regenerate API key.",
+        userFacingText: ERROR_MESSAGE,
+        error: err instanceof Error ? err : new Error(String(err)),
+        data: { reason: "error", rotated: false },
+      };
+    }
+  },
+
+  examples: [
+    [
+      {
+        name: "{{user}}",
+        content: { text: "regenerate the API key for Acme Bot" },
+      },
+      {
+        name: "{{agent}}",
+        content: {
+          text: 'This will regenerate the API key for "Acme Bot" (…). The current key stops working immediately, so any app or integration using it will break until you paste in the new one. This can\'t be undone. To go ahead, reply: rotate Acme Bot — yes.',
+          actions: ["REGENERATE_APP_API_KEY"],
+        },
+      },
+    ],
+    [
+      { name: "{{user}}", content: { text: "rotate Acme Bot — yes" } },
+      {
+        name: "{{agent}}",
+        content: {
+          text: 'Done — here is the new API key for "Acme Bot":\n\neliza_app_…\n\nSave this now: it won\'t be shown again, and the old key no longer works. Update anything that used the previous key.',
+          actions: ["REGENERATE_APP_API_KEY"],
+        },
+      },
+    ],
+  ],
+};
+
+export default regenerateAppApiKeyAction;

--- a/plugins/plugin-cloud-apps/src/actions/update-app.ts
+++ b/plugins/plugin-cloud-apps/src/actions/update-app.ts
@@ -1,0 +1,413 @@
+/**
+ * UPDATE_APP — "rename / edit app X".
+ *
+ * Parses the field(s) to change (name, description, logo, website, contact email)
+ * from the user's text (planner options win when present), resolves the target
+ * app, then calls the typed `client.updateApp(id, patch)` and confirms the change.
+ *
+ * Non-destructive + reversible, so there is no two-phase confirm — an edit is
+ * applied directly. Validation is light (the server is authoritative); we only
+ * reject obviously malformed input (e.g. a non-http logo URL) before the call.
+ */
+
+import type { AppDto, UpdateAppInput } from "@elizaos/cloud-sdk";
+import type {
+  Action,
+  ActionResult,
+  HandlerCallback,
+  IAgentRuntime,
+  Memory,
+  State,
+} from "@elizaos/core";
+import { logger } from "@elizaos/core";
+import {
+  extractAppReference,
+  getCloudClient,
+  resolveApp,
+  resolveCloudApiKey,
+} from "../client.js";
+
+const NO_KEY_MESSAGE =
+  "I can't reach Eliza Cloud yet — no Cloud API key is configured. Add your ELIZAOS_CLOUD_API_KEY and I can update your apps.";
+const NO_REFERENCE_MESSAGE =
+  "Which app would you like to update? Tell me its name.";
+const NO_CHANGE_MESSAGE =
+  "What would you like to change? You can rename the app, or set its description, logo, website, or contact email.";
+const ERROR_MESSAGE =
+  "I couldn't update that app right now — the Cloud API returned an error. Try again in a moment.";
+
+export interface UpdateAppIntent {
+  /** App reference (name/slug/id) parsed from the request, if any. */
+  reference: string | null;
+  /** The partial update to apply. Empty when nothing parseable was found. */
+  patch: UpdateAppInput;
+}
+
+const OPTION_REFERENCE_KEYS = ["app", "appName", "appId", "id"] as const;
+const OPTION_NAME_KEYS = ["name", "newName", "new_name", "title"] as const;
+const OPTION_DESCRIPTION_KEYS = ["description", "desc", "about"] as const;
+const OPTION_LOGO_KEYS = ["logo", "logo_url", "logoUrl"] as const;
+const OPTION_WEBSITE_KEYS = ["website", "website_url", "websiteUrl"] as const;
+const OPTION_EMAIL_KEYS = ["email", "contact_email", "contactEmail"] as const;
+
+// Bounded captures: a value never swallows a trailing clause/punctuation.
+const VALUE_END = `["”']?\\s*[.!?]?\\s*$`;
+const REF = `(?:my\\s+|the\\s+)?(?:app\\s+)?["“']?([^"”']+?)["”']?`;
+
+// "rename Acme to Beta" / "rename my app Acme to Beta"
+const RENAME_PATTERN = new RegExp(
+  `\\brename\\s+${REF}\\s+to\\s+["“']?([^"”'.!?\\n]+?)${VALUE_END}`,
+  "i",
+);
+// "set Acme's name to Beta"
+const POSSESSIVE_NAME_PATTERN = new RegExp(
+  `\\b(?:set|change|update)\\s+(?:my\\s+|the\\s+)?["“']?([^"”']+?)["”']?(?:'s|s')\\s+name\\s+to\\s+["“']?([^"”'.!?\\n]+?)${VALUE_END}`,
+  "i",
+);
+// "change the name of Acme to Beta" / "set the name to Beta"
+const NAME_OF_PATTERN = new RegExp(
+  `\\b(?:change|set|update)\\s+(?:the\\s+)?name\\s+(?:of\\s+${REF}\\s+)?to\\s+["“']?([^"”'.!?\\n]+?)${VALUE_END}`,
+  "i",
+);
+// "set Acme's description to ..." (possessive form, ref captured)
+const POSSESSIVE_DESC_PATTERN = new RegExp(
+  `\\b(?:set|change|update)\\s+(?:my\\s+|the\\s+)?["“']?([^"”']+?)["”']?(?:'s|s')\\s+(?:description|desc)\\s+to\\s+["“']?(.+?)${VALUE_END}`,
+  "i",
+);
+// "set the description (of Acme) to ..."
+const DESC_OF_PATTERN = new RegExp(
+  `\\b(?:set|change|update)\\s+(?:the\\s+)?(?:description|desc|about)\\s+(?:(?:of|for)\\s+${REF}\\s+)?to\\s+["“']?(.+?)${VALUE_END}`,
+  "i",
+);
+// "set the logo (of Acme) to <url>"
+const LOGO_PATTERN = new RegExp(
+  `\\b(?:set|change|update)\\s+(?:the\\s+)?logo\\s+(?:url\\s+)?(?:(?:of|for)\\s+${REF}\\s+)?to\\s+(\\S+)`,
+  "i",
+);
+// "set the website (of Acme) to <url>"
+const WEBSITE_PATTERN = new RegExp(
+  `\\b(?:set|change|update)\\s+(?:the\\s+)?(?:website|site|url)\\s+(?:(?:of|for)\\s+${REF}\\s+)?to\\s+(\\S+)`,
+  "i",
+);
+// "set the contact email (of Acme) to <email>"
+const EMAIL_PATTERN = new RegExp(
+  `\\b(?:set|change|update)\\s+(?:the\\s+)?(?:contact\\s+)?email\\s+(?:(?:of|for)\\s+${REF}\\s+)?to\\s+(\\S+)`,
+  "i",
+);
+
+function asString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function firstOption(
+  opts: Record<string, unknown>,
+  keys: readonly string[],
+): string | null {
+  for (const key of keys) {
+    const v = asString(opts[key]);
+    if (v) return v;
+  }
+  return null;
+}
+
+function cleanCapture(value: string | undefined): string | null {
+  if (!value) return null;
+  const v = value.trim().replace(/\s+/g, " ");
+  return v.length > 0 && v.length <= 200 ? v : null;
+}
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const u = new URL(value);
+    return u.protocol === "https:" || u.protocol === "http:";
+  } catch {
+    return false;
+  }
+}
+
+/** Parse the app reference + the field patch from planner options and raw text. */
+export function parseUpdateAppIntent(
+  text: string,
+  options?: unknown,
+): UpdateAppIntent {
+  const opts =
+    options && typeof options === "object"
+      ? (options as Record<string, unknown>)
+      : {};
+  const body = text ?? "";
+
+  const patch: UpdateAppInput = {};
+  let reference: string | null = firstOption(opts, OPTION_REFERENCE_KEYS);
+
+  // 1) Planner options take priority for the patch fields.
+  const optName = firstOption(opts, OPTION_NAME_KEYS);
+  if (optName) patch.name = optName;
+  const optDesc = firstOption(opts, OPTION_DESCRIPTION_KEYS);
+  if (optDesc) patch.description = optDesc;
+  const optLogo = firstOption(opts, OPTION_LOGO_KEYS);
+  if (optLogo) patch.logo_url = optLogo;
+  const optWebsite = firstOption(opts, OPTION_WEBSITE_KEYS);
+  if (optWebsite) patch.website_url = optWebsite;
+  const optEmail = firstOption(opts, OPTION_EMAIL_KEYS);
+  if (optEmail) patch.contact_email = optEmail;
+
+  // 2) Text patterns fill any field not supplied via options.
+  const applyRefName = (ref?: string, name?: string): void => {
+    const r = cleanCapture(ref);
+    const n = cleanCapture(name);
+    if (!reference && r) reference = r;
+    if (patch.name === undefined && n) patch.name = n;
+  };
+
+  if (patch.name === undefined) {
+    for (const pattern of [
+      RENAME_PATTERN,
+      POSSESSIVE_NAME_PATTERN,
+      NAME_OF_PATTERN,
+    ]) {
+      const m = pattern.exec(body);
+      if (m) {
+        applyRefName(m[1], m[2]);
+        if (patch.name !== undefined) break;
+      }
+    }
+  }
+
+  if (patch.description === undefined) {
+    for (const pattern of [POSSESSIVE_DESC_PATTERN, DESC_OF_PATTERN]) {
+      const m = pattern.exec(body);
+      if (m) {
+        if (!reference) reference = cleanCapture(m[1]);
+        const d = cleanCapture(m[2]);
+        if (d) patch.description = d;
+        if (patch.description !== undefined) break;
+      }
+    }
+  }
+
+  if (patch.logo_url === undefined) {
+    const m = LOGO_PATTERN.exec(body);
+    if (m) {
+      if (!reference) reference = cleanCapture(m[1]);
+      const url = cleanCapture(m[2]);
+      if (url) patch.logo_url = url;
+    }
+  }
+
+  if (patch.website_url === undefined) {
+    const m = WEBSITE_PATTERN.exec(body);
+    if (m) {
+      if (!reference) reference = cleanCapture(m[1]);
+      const url = cleanCapture(m[2]);
+      if (url) patch.website_url = url;
+    }
+  }
+
+  if (patch.contact_email === undefined) {
+    const m = EMAIL_PATTERN.exec(body);
+    if (m) {
+      if (!reference) reference = cleanCapture(m[1]);
+      const email = cleanCapture(m[2]);
+      if (email) patch.contact_email = email;
+    }
+  }
+
+  return { reference, patch };
+}
+
+function patchHasFields(patch: UpdateAppInput): boolean {
+  return Object.keys(patch).length > 0;
+}
+
+/** Describe the applied change(s) for the reply, using the updated app's values. */
+function describeChange(patch: UpdateAppInput, updated: AppDto): string[] {
+  const parts: string[] = [];
+  if (patch.name !== undefined) parts.push(`renamed to "${updated.name}"`);
+  if (patch.description !== undefined) parts.push("description updated");
+  if (patch.logo_url !== undefined) parts.push("logo updated");
+  if (patch.website_url !== undefined) parts.push("website updated");
+  if (patch.contact_email !== undefined) parts.push("contact email updated");
+  if (patch.is_active !== undefined) {
+    parts.push(updated.is_active === false ? "deactivated" : "activated");
+  }
+  return parts;
+}
+
+function notFoundMessage(reference: string, available: string[]): string {
+  const base = `I couldn't find an app matching "${reference}".`;
+  if (available.length === 0) {
+    return `${base} You don't have any apps on Eliza Cloud yet.`;
+  }
+  return `${base} Your apps are: ${available.join(", ")}.`;
+}
+
+export const updateAppAction: Action = {
+  name: "UPDATE_APP",
+  similes: ["RENAME_APP", "EDIT_APP", "UPDATE_CLOUD_APP", "CHANGE_APP"],
+  description:
+    "Update an existing Eliza Cloud app's details — rename it, or change its description, logo, website, or contact email. Use when the user asks to rename, edit, or change an app's settings (not its monetization).",
+  descriptionCompressed: "Rename or edit a Cloud app's details.",
+  contexts: ["settings", "finance", "apps"],
+  contextGate: { anyOf: ["settings", "finance", "apps"] },
+  suppressPostActionContinuation: true,
+
+  validate: async (runtime: IAgentRuntime): Promise<boolean> => {
+    return resolveCloudApiKey(runtime) !== null;
+  },
+
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory,
+    _state?: State,
+    options?: unknown,
+    callback?: HandlerCallback,
+  ): Promise<ActionResult> => {
+    const client = getCloudClient(runtime);
+    if (!client) {
+      await callback?.({ text: NO_KEY_MESSAGE, actions: ["UPDATE_APP"] });
+      return {
+        success: false,
+        text: "No Eliza Cloud API key configured.",
+        userFacingText: NO_KEY_MESSAGE,
+        data: { reason: "no_key" },
+      };
+    }
+
+    const intent = parseUpdateAppIntent(message.content?.text ?? "", options);
+    const reference = intent.reference ?? extractAppReference(message, options);
+    if (!reference) {
+      await callback?.({ text: NO_REFERENCE_MESSAGE, actions: ["UPDATE_APP"] });
+      return {
+        success: false,
+        text: "No app reference supplied.",
+        userFacingText: NO_REFERENCE_MESSAGE,
+        data: { reason: "no_reference" },
+      };
+    }
+
+    if (!patchHasFields(intent.patch)) {
+      await callback?.({ text: NO_CHANGE_MESSAGE, actions: ["UPDATE_APP"] });
+      return {
+        success: false,
+        text: "No update fields supplied.",
+        userFacingText: NO_CHANGE_MESSAGE,
+        data: { reason: "no_change" },
+      };
+    }
+
+    // Reject obviously malformed URLs before hitting the API.
+    for (const [field, value] of [
+      ["logo", intent.patch.logo_url],
+      ["website", intent.patch.website_url],
+    ] as const) {
+      if (typeof value === "string" && !isHttpUrl(value)) {
+        const msg = `That ${field} URL doesn't look like a valid http(s) URL. Give me a full URL like https://example.com/logo.png.`;
+        await callback?.({ text: msg, actions: ["UPDATE_APP"] });
+        return {
+          success: false,
+          text: `Invalid ${field} URL.`,
+          userFacingText: msg,
+          data: { reason: "invalid_url", field },
+        };
+      }
+    }
+
+    let app: AppDto | null;
+    let available: string[];
+    try {
+      ({ app, available } = await resolveApp(client, reference));
+    } catch (err) {
+      logger.warn(
+        `[UPDATE_APP] Failed to resolve app "${reference}": ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      await callback?.({ text: ERROR_MESSAGE, actions: ["UPDATE_APP"] });
+      return {
+        success: false,
+        text: "Failed to resolve Eliza Cloud app.",
+        userFacingText: ERROR_MESSAGE,
+        error: err instanceof Error ? err : new Error(String(err)),
+        data: { reason: "error" },
+      };
+    }
+
+    if (!app) {
+      const msg = notFoundMessage(reference, available);
+      await callback?.({ text: msg, actions: ["UPDATE_APP"] });
+      return {
+        success: false,
+        text: `No app matched "${reference}".`,
+        userFacingText: msg,
+        data: { reason: "not_found", reference },
+      };
+    }
+
+    const target = app;
+    try {
+      const { app: updated } = await client.updateApp(target.id, intent.patch);
+      const result = updated ?? target;
+      const changes = describeChange(intent.patch, result);
+      const summary =
+        changes.length > 0 ? changes.join(", ") : "settings updated";
+      const reply = `Updated "${target.name}" — ${summary}.`;
+      await callback?.({ text: reply, actions: ["UPDATE_APP"] });
+      return {
+        success: true,
+        text: `Updated Eliza Cloud app ${result.name}.`,
+        userFacingText: reply,
+        verifiedUserFacing: true,
+        data: {
+          app: { id: result.id, name: result.name, slug: result.slug },
+          updated: Object.keys(intent.patch),
+        },
+      };
+    } catch (err) {
+      logger.warn(
+        `[UPDATE_APP] updateApp(${target.id}) failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      await callback?.({ text: ERROR_MESSAGE, actions: ["UPDATE_APP"] });
+      return {
+        success: false,
+        text: "Failed to update Eliza Cloud app.",
+        userFacingText: ERROR_MESSAGE,
+        error: err instanceof Error ? err : new Error(String(err)),
+        data: { reason: "error" },
+      };
+    }
+  },
+
+  examples: [
+    [
+      { name: "{{user}}", content: { text: "rename Acme Bot to Zephyr" } },
+      {
+        name: "{{agent}}",
+        content: {
+          text: 'Updated "Acme Bot" — renamed to "Zephyr".',
+          actions: ["UPDATE_APP"],
+        },
+      },
+    ],
+    [
+      {
+        name: "{{user}}",
+        content: {
+          text: "set the description of Zephyr to a friendly support bot",
+        },
+      },
+      {
+        name: "{{agent}}",
+        content: {
+          text: 'Updated "Zephyr" — description updated.',
+          actions: ["UPDATE_APP"],
+        },
+      },
+    ],
+  ],
+};
+
+export default updateAppAction;

--- a/plugins/plugin-cloud-apps/src/actions/update-monetization.ts
+++ b/plugins/plugin-cloud-apps/src/actions/update-monetization.ts
@@ -1,0 +1,437 @@
+/**
+ * UPDATE_MONETIZATION — "set the price / change the markup / enable monetization".
+ *
+ * Parses the monetization change (enable/disable, inference markup %, purchase
+ * share %) from the user's text (planner options win), resolves the app, then
+ * calls the typed `client.updateMonetization(id, settings)` and echoes the
+ * resulting settings.
+ *
+ * Absurd values are rejected BEFORE the call with a clear message. The bounds
+ * mirror the server's zod schema exactly (`UpdateMonetizationSchema`):
+ *   - inference markup: 0–1000 %
+ *   - purchase share:   0–100 %
+ * Rejecting a value the server would accept (or sending one it would reject) is
+ * a bug, so the guard is the server's contract — not a stricter local opinion.
+ */
+
+import type { AppDto, UpdateAppMonetizationInput } from "@elizaos/cloud-sdk";
+import type {
+  Action,
+  ActionResult,
+  HandlerCallback,
+  IAgentRuntime,
+  Memory,
+  State,
+} from "@elizaos/core";
+import { logger } from "@elizaos/core";
+import {
+  extractAppReference,
+  getCloudClient,
+  resolveApp,
+  resolveCloudApiKey,
+} from "../client.js";
+
+/** Server-enforced bounds (mirror `UpdateMonetizationSchema` in cloud-api). */
+export const MARKUP_MIN = 0;
+export const MARKUP_MAX = 1000;
+export const SHARE_MIN = 0;
+export const SHARE_MAX = 100;
+
+const NO_KEY_MESSAGE =
+  "I can't reach Eliza Cloud yet — no Cloud API key is configured. Add your ELIZAOS_CLOUD_API_KEY and I can change your app's monetization.";
+const NO_REFERENCE_MESSAGE =
+  "Which app's monetization would you like to change? Tell me its name.";
+const NO_CHANGE_MESSAGE =
+  "What should I change? You can turn monetization on or off, set the inference markup % (0–1000), or set the purchase share % (0–100).";
+const ERROR_MESSAGE =
+  "I couldn't update that app's monetization right now — the Cloud API returned an error. Try again in a moment.";
+
+export interface MonetizationIntent {
+  reference: string | null;
+  settings: UpdateAppMonetizationInput;
+  /** Out-of-range value that was parsed but rejected (for a clear message). */
+  rejected?: {
+    field: "markup" | "share";
+    value: number;
+    min: number;
+    max: number;
+  };
+}
+
+const OPTION_REFERENCE_KEYS = ["app", "appName", "appId", "id"] as const;
+const OPTION_ENABLE_KEYS = [
+  "monetization",
+  "monetize",
+  "monetizationEnabled",
+  "monetization_enabled",
+  "enabled",
+  "enable",
+] as const;
+const OPTION_MARKUP_KEYS = [
+  "markup",
+  "markupPercentage",
+  "inferenceMarkupPercentage",
+  "inference_markup_percentage",
+] as const;
+const OPTION_SHARE_KEYS = [
+  "purchaseShare",
+  "purchaseSharePercentage",
+  "purchase_share_percentage",
+  "share",
+] as const;
+
+function asBool(value: unknown): boolean | null {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    const v = value.trim().toLowerCase();
+    if (["true", "yes", "on", "1", "enable", "enabled"].includes(v))
+      return true;
+    if (["false", "no", "off", "0", "disable", "disabled"].includes(v)) {
+      return false;
+    }
+  }
+  return null;
+}
+
+function asNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const n = Number(value.replace(/%/g, "").trim());
+    if (Number.isFinite(n)) return n;
+  }
+  return null;
+}
+
+function firstOption(
+  opts: Record<string, unknown>,
+  keys: readonly string[],
+): unknown {
+  for (const key of keys) {
+    if (opts[key] !== undefined) return opts[key];
+  }
+  return undefined;
+}
+
+/** Parse the enable/markup/share change + app reference from options + text. */
+export function parseMonetizationIntent(
+  text: string,
+  options?: unknown,
+): MonetizationIntent {
+  const opts =
+    options && typeof options === "object"
+      ? (options as Record<string, unknown>)
+      : {};
+  const body = text ?? "";
+  const settings: UpdateAppMonetizationInput = {};
+  let reference: string | null = null;
+
+  for (const key of OPTION_REFERENCE_KEYS) {
+    const v = opts[key];
+    if (typeof v === "string" && v.trim()) {
+      reference = v.trim();
+      break;
+    }
+  }
+
+  // Enable / disable.
+  let enable = asBool(firstOption(opts, OPTION_ENABLE_KEYS));
+  if (enable === null) {
+    if (
+      /\b(disable|turn\s+off|deactivate|stop|switch\s+off)\b[^.!?\n]*\bmoneti/i.test(
+        body,
+      ) ||
+      /\bmoneti\w*\s+(off|disabled?)\b/i.test(body)
+    ) {
+      enable = false;
+    } else if (
+      /\b(enable|turn\s+on|activate|start|switch\s+on)\b[^.!?\n]*\bmoneti/i.test(
+        body,
+      ) ||
+      /\bmoneti\w*\s+(on|enabled?)\b/i.test(body)
+    ) {
+      enable = true;
+    }
+  }
+  if (enable !== null) settings.monetizationEnabled = enable;
+
+  // Inference markup %.
+  let markup = asNumber(firstOption(opts, OPTION_MARKUP_KEYS));
+  if (markup === null) {
+    const m =
+      /\bmarkup\b[^%\d-]*(-?\d+(?:\.\d+)?)\s*%?/i.exec(body) ??
+      /(-?\d+(?:\.\d+)?)\s*%\s*markup\b/i.exec(body);
+    if (m) markup = asNumber(m[1]);
+  }
+
+  // Purchase share %.
+  let share = asNumber(firstOption(opts, OPTION_SHARE_KEYS));
+  if (share === null) {
+    const m =
+      /\b(?:purchase\s+share|revenue\s+share|share)\b[^%\d-]*(-?\d+(?:\.\d+)?)\s*%?/i.exec(
+        body,
+      );
+    if (m) share = asNumber(m[1]);
+  }
+
+  // Range-guard absurd values; surface the first offender for a clear message.
+  if (markup !== null) {
+    if (markup < MARKUP_MIN || markup > MARKUP_MAX) {
+      return {
+        reference,
+        settings,
+        rejected: {
+          field: "markup",
+          value: markup,
+          min: MARKUP_MIN,
+          max: MARKUP_MAX,
+        },
+      };
+    }
+    settings.inferenceMarkupPercentage = markup;
+    // Enabling monetization is implied by setting a markup if not stated.
+    if (settings.monetizationEnabled === undefined && markup > 0) {
+      settings.monetizationEnabled = true;
+    }
+  }
+  if (share !== null) {
+    if (share < SHARE_MIN || share > SHARE_MAX) {
+      return {
+        reference,
+        settings,
+        rejected: {
+          field: "share",
+          value: share,
+          min: SHARE_MIN,
+          max: SHARE_MAX,
+        },
+      };
+    }
+    settings.purchaseSharePercentage = share;
+  }
+
+  return { reference, settings };
+}
+
+function settingsHaveFields(settings: UpdateAppMonetizationInput): boolean {
+  return Object.keys(settings).length > 0;
+}
+
+function notFoundMessage(reference: string, available: string[]): string {
+  const base = `I couldn't find an app matching "${reference}".`;
+  if (available.length === 0) {
+    return `${base} You don't have any apps on Eliza Cloud yet.`;
+  }
+  return `${base} Your apps are: ${available.join(", ")}.`;
+}
+
+/** Echo the resulting monetization settings from the server response. */
+function formatSettings(
+  name: string,
+  monetization: {
+    monetizationEnabled?: boolean;
+    inferenceMarkupPercentage?: number;
+    purchaseSharePercentage?: number;
+  } | null,
+): string {
+  if (!monetization) {
+    return `Updated "${name}"'s monetization.`;
+  }
+  if (monetization.monetizationEnabled === false) {
+    return `Monetization is now OFF for "${name}".`;
+  }
+  const lines = [`Monetization is ON for "${name}".`];
+  if (typeof monetization.inferenceMarkupPercentage === "number") {
+    lines.push(`Inference markup: ${monetization.inferenceMarkupPercentage}%`);
+  }
+  if (typeof monetization.purchaseSharePercentage === "number") {
+    lines.push(`Purchase share: ${monetization.purchaseSharePercentage}%`);
+  }
+  return lines.join("\n");
+}
+
+export const updateMonetizationAction: Action = {
+  name: "UPDATE_MONETIZATION",
+  similes: [
+    "SET_PRICE",
+    "CHANGE_MARKUP",
+    "ENABLE_MONETIZATION",
+    "DISABLE_MONETIZATION",
+    "SET_MARKUP",
+  ],
+  description:
+    "Change an Eliza Cloud app's monetization — turn it on or off, set the inference markup percentage, or set the purchase share percentage. Use when the user asks to monetize, set a price/markup, or enable/disable earning on an app.",
+  descriptionCompressed: "Set a Cloud app's monetization (markup / on-off).",
+  contexts: ["settings", "finance", "apps"],
+  contextGate: { anyOf: ["settings", "finance", "apps"] },
+  suppressPostActionContinuation: true,
+
+  validate: async (runtime: IAgentRuntime): Promise<boolean> => {
+    return resolveCloudApiKey(runtime) !== null;
+  },
+
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory,
+    _state?: State,
+    options?: unknown,
+    callback?: HandlerCallback,
+  ): Promise<ActionResult> => {
+    const client = getCloudClient(runtime);
+    if (!client) {
+      await callback?.({
+        text: NO_KEY_MESSAGE,
+        actions: ["UPDATE_MONETIZATION"],
+      });
+      return {
+        success: false,
+        text: "No Eliza Cloud API key configured.",
+        userFacingText: NO_KEY_MESSAGE,
+        data: { reason: "no_key" },
+      };
+    }
+
+    const intent = parseMonetizationIntent(
+      message.content?.text ?? "",
+      options,
+    );
+
+    if (intent.rejected) {
+      const { field, value, min, max } = intent.rejected;
+      const label = field === "markup" ? "inference markup" : "purchase share";
+      const msg = `${value}% is out of range for the ${label} — it has to be between ${min}% and ${max}%. Tell me a value in that range.`;
+      await callback?.({ text: msg, actions: ["UPDATE_MONETIZATION"] });
+      return {
+        success: false,
+        text: `Out-of-range ${label}: ${value}%.`,
+        userFacingText: msg,
+        data: { reason: "out_of_range", field, value, min, max },
+      };
+    }
+
+    const reference = intent.reference ?? extractAppReference(message, options);
+    if (!reference) {
+      await callback?.({
+        text: NO_REFERENCE_MESSAGE,
+        actions: ["UPDATE_MONETIZATION"],
+      });
+      return {
+        success: false,
+        text: "No app reference supplied.",
+        userFacingText: NO_REFERENCE_MESSAGE,
+        data: { reason: "no_reference" },
+      };
+    }
+
+    if (!settingsHaveFields(intent.settings)) {
+      await callback?.({
+        text: NO_CHANGE_MESSAGE,
+        actions: ["UPDATE_MONETIZATION"],
+      });
+      return {
+        success: false,
+        text: "No monetization change supplied.",
+        userFacingText: NO_CHANGE_MESSAGE,
+        data: { reason: "no_change" },
+      };
+    }
+
+    let app: AppDto | null;
+    let available: string[];
+    try {
+      ({ app, available } = await resolveApp(client, reference));
+    } catch (err) {
+      logger.warn(
+        `[UPDATE_MONETIZATION] Failed to resolve app "${reference}": ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      await callback?.({
+        text: ERROR_MESSAGE,
+        actions: ["UPDATE_MONETIZATION"],
+      });
+      return {
+        success: false,
+        text: "Failed to resolve Eliza Cloud app.",
+        userFacingText: ERROR_MESSAGE,
+        error: err instanceof Error ? err : new Error(String(err)),
+        data: { reason: "error" },
+      };
+    }
+
+    if (!app) {
+      const msg = notFoundMessage(reference, available);
+      await callback?.({ text: msg, actions: ["UPDATE_MONETIZATION"] });
+      return {
+        success: false,
+        text: `No app matched "${reference}".`,
+        userFacingText: msg,
+        data: { reason: "not_found", reference },
+      };
+    }
+
+    const target = app;
+    try {
+      const { monetization } = await client.updateMonetization(
+        target.id,
+        intent.settings,
+      );
+      const reply = formatSettings(target.name, monetization);
+      await callback?.({ text: reply, actions: ["UPDATE_MONETIZATION"] });
+      return {
+        success: true,
+        text: `Updated monetization for ${target.name}.`,
+        userFacingText: reply,
+        verifiedUserFacing: true,
+        data: {
+          app: { id: target.id, name: target.name, slug: target.slug },
+          monetization: monetization ?? null,
+        },
+      };
+    } catch (err) {
+      logger.warn(
+        `[UPDATE_MONETIZATION] updateMonetization(${target.id}) failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      await callback?.({
+        text: ERROR_MESSAGE,
+        actions: ["UPDATE_MONETIZATION"],
+      });
+      return {
+        success: false,
+        text: "Failed to update monetization.",
+        userFacingText: ERROR_MESSAGE,
+        error: err instanceof Error ? err : new Error(String(err)),
+        data: { reason: "error" },
+      };
+    }
+  },
+
+  examples: [
+    [
+      {
+        name: "{{user}}",
+        content: { text: "set Acme Bot's inference markup to 20%" },
+      },
+      {
+        name: "{{agent}}",
+        content: {
+          text: 'Monetization is ON for "Acme Bot".\nInference markup: 20%',
+          actions: ["UPDATE_MONETIZATION"],
+        },
+      },
+    ],
+    [
+      { name: "{{user}}", content: { text: "turn off monetization for Acme" } },
+      {
+        name: "{{agent}}",
+        content: {
+          text: 'Monetization is now OFF for "Acme Bot".',
+          actions: ["UPDATE_MONETIZATION"],
+        },
+      },
+    ],
+  ],
+};
+
+export default updateMonetizationAction;

--- a/plugins/plugin-cloud-apps/src/actions/withdraw-app-earnings.ts
+++ b/plugins/plugin-cloud-apps/src/actions/withdraw-app-earnings.ts
@@ -1,0 +1,462 @@
+/**
+ * WITHDRAW_APP_EARNINGS — MONEY-OUT. Handled with maximum care.
+ *
+ * ── Safety model (documented per PR_EVIDENCE) ────────────────────────────────
+ * Two layers protect the user's money, and NO secret/credential ever transits a
+ * connector:
+ *
+ *   1. Two-phase confirm (reuses {@link isExplicitConfirmation} from safety.ts).
+ *      The first ask NEVER moves money — it returns a confirmation prompt naming
+ *      the exact app + amount, plus a connector-agnostic CTA to the dashboard
+ *      earnings page. Money moves only when the FOLLOW-UP message carries an
+ *      explicit confirmation token ("withdraw Acme — yes").
+ *
+ *   2. The "safe path" on confirm calls `client.withdrawAppEarnings(id, …)`,
+ *      which wraps `POST /api/v1/apps/:id/earnings/withdraw`. That endpoint is
+ *      idempotent (accepts an `idempotency_key`) and SERVER-GATED: the server
+ *      independently verifies org ownership, app-creator identity, monetization,
+ *      the minimum-payout threshold, and a sufficient withdrawable balance. It
+ *      does NOT itself wire cash to a bank — it records the withdrawal request
+ *      and moves the funds into the creator's redeemable balance; the actual
+ *      cash-out (admin-gated Stripe Connect transfer / token redemption) is
+ *      completed by the user IN THE BROWSER via the CTA. We therefore call the
+ *      safe, idempotent, server-gated request endpoint on confirm AND hand off
+ *      the dashboard CTA so the user finishes the money/credential step there.
+ *
+ * The CTA ({@link buildConnectorCta}) carries ONLY a human label + an https URL —
+ * never a token, signed payload, secret, or amount baked into a credential.
+ */
+
+import type { AppDto, WithdrawAppEarningsRequest } from "@elizaos/cloud-sdk";
+import type {
+  Action,
+  ActionResult,
+  HandlerCallback,
+  IAgentRuntime,
+  Memory,
+  State,
+} from "@elizaos/core";
+import { logger } from "@elizaos/core";
+import {
+  extractAppReference,
+  getCloudClient,
+  resolveApp,
+  resolveCloudApiKey,
+  resolveCloudSiteBaseUrl,
+} from "../client.js";
+import {
+  buildConnectorCta,
+  type ConfirmTarget,
+  type ConnectorCta,
+  isExplicitConfirmation,
+} from "../safety.js";
+import { extractEarningsView } from "./get-app-earnings.js";
+
+const NO_KEY_MESSAGE =
+  "I can't reach Eliza Cloud yet — no Cloud API key is configured. Add your ELIZAOS_CLOUD_API_KEY and I can help you withdraw earnings.";
+const NO_REFERENCE_MESSAGE =
+  "Which app's earnings would you like to withdraw? Tell me its name.";
+const ERROR_MESSAGE =
+  "I couldn't process that withdrawal right now — the Cloud API returned an error. Nothing was withdrawn. Try again in a moment.";
+
+/** Verbs that, with an affirmation word, count as a withdraw confirmation. */
+const WITHDRAW_VERBS = ["withdraw", "cash out", "cashout", "pay out", "payout"];
+
+function usd(n: number): string {
+  return `$${n.toFixed(2)}`;
+}
+
+function newIdempotencyKey(): string {
+  const uuid = globalThis.crypto?.randomUUID?.();
+  if (uuid) return uuid; // 36 chars — within the server's 16–64 bound.
+  return `wd-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 12)}`;
+}
+
+const AMOUNT_OPTION_KEYS = ["amount", "usd", "value"] as const;
+
+/** Parse a withdrawal amount (USD) from planner options or text; null = "all". */
+export function parseWithdrawAmount(
+  text: string,
+  options?: unknown,
+): number | null {
+  if (options && typeof options === "object") {
+    const opts = options as Record<string, unknown>;
+    for (const key of AMOUNT_OPTION_KEYS) {
+      const v = opts[key];
+      if (typeof v === "number" && Number.isFinite(v) && v > 0) return v;
+      if (typeof v === "string") {
+        const n = Number(v.replace(/[$,]/g, "").trim());
+        if (Number.isFinite(n) && n > 0) return n;
+      }
+    }
+  }
+  const body = text ?? "";
+  // Prefer an explicit currency amount: "$50", "50 dollars", "50 usd".
+  const m =
+    /\$\s*(\d+(?:\.\d+)?)/.exec(body) ??
+    /(\d+(?:\.\d+)?)\s*(?:dollars?|usd)\b/i.exec(body) ??
+    /\b(?:withdraw(?:al)?|cash\s*out|pay\s*out|payout)\b[^$\d]*?(\d+(?:\.\d+)?)\b/i.exec(
+      body,
+    );
+  if (m) {
+    const n = Number(m[1]);
+    if (Number.isFinite(n) && n > 0) return n;
+  }
+  return null;
+}
+
+function confirmTargetFor(app: AppDto): ConfirmTarget {
+  return { name: app.name, id: app.id, aliases: [app.slug] };
+}
+
+function notFoundMessage(reference: string, available: string[]): string {
+  const base = `I couldn't find an app matching "${reference}".`;
+  if (available.length === 0) {
+    return `${base} You don't have any apps on Eliza Cloud yet.`;
+  }
+  return `${base} Your apps are: ${available.join(", ")}.`;
+}
+
+export const withdrawAppEarningsAction: Action = {
+  name: "WITHDRAW_APP_EARNINGS",
+  similes: [
+    "CASH_OUT",
+    "PAYOUT",
+    "WITHDRAW_EARNINGS",
+    "REQUEST_PAYOUT",
+    "CASH_OUT_APP",
+  ],
+  description:
+    "Withdraw (cash out) an Eliza Cloud app's earnings. MONEY-OUT: requires an explicit confirmation — the first ask only confirms intent and hands off a dashboard link. Use when the user asks to withdraw, cash out, or request a payout of an app's earnings.",
+  descriptionCompressed:
+    "Withdraw a Cloud app's earnings (money-out; two-step confirm).",
+  contexts: ["settings", "finance", "apps"],
+  contextGate: { anyOf: ["settings", "finance", "apps"] },
+  suppressPostActionContinuation: true,
+
+  validate: async (runtime: IAgentRuntime): Promise<boolean> => {
+    return resolveCloudApiKey(runtime) !== null;
+  },
+
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory,
+    _state?: State,
+    options?: unknown,
+    callback?: HandlerCallback,
+  ): Promise<ActionResult> => {
+    const client = getCloudClient(runtime);
+    if (!client) {
+      await callback?.({
+        text: NO_KEY_MESSAGE,
+        actions: ["WITHDRAW_APP_EARNINGS"],
+      });
+      return {
+        success: false,
+        text: "No Eliza Cloud API key configured.",
+        userFacingText: NO_KEY_MESSAGE,
+        data: { reason: "no_key" },
+      };
+    }
+
+    const reference = extractAppReference(message, options);
+    if (!reference) {
+      await callback?.({
+        text: NO_REFERENCE_MESSAGE,
+        actions: ["WITHDRAW_APP_EARNINGS"],
+      });
+      return {
+        success: false,
+        text: "No app reference supplied.",
+        userFacingText: NO_REFERENCE_MESSAGE,
+        data: { reason: "no_reference" },
+      };
+    }
+
+    let app: AppDto | null;
+    let available: string[];
+    try {
+      ({ app, available } = await resolveApp(client, reference));
+    } catch (err) {
+      logger.warn(
+        `[WITHDRAW_APP_EARNINGS] Failed to resolve app "${reference}": ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      await callback?.({
+        text: ERROR_MESSAGE,
+        actions: ["WITHDRAW_APP_EARNINGS"],
+      });
+      return {
+        success: false,
+        text: "Failed to resolve Eliza Cloud app.",
+        userFacingText: ERROR_MESSAGE,
+        error: err instanceof Error ? err : new Error(String(err)),
+        data: { reason: "error" },
+      };
+    }
+
+    if (!app) {
+      const msg = notFoundMessage(reference, available);
+      await callback?.({ text: msg, actions: ["WITHDRAW_APP_EARNINGS"] });
+      return {
+        success: false,
+        text: `No app matched "${reference}".`,
+        userFacingText: msg,
+        data: { reason: "not_found", reference },
+      };
+    }
+
+    const target = app;
+
+    // Read the authoritative balance/threshold (read-only) before doing anything.
+    let withdrawable = 0;
+    let threshold = 0;
+    let monetizationOn = target.monetization_enabled;
+    try {
+      const earnings = await client.getAppEarnings(target.id);
+      const view = extractEarningsView(earnings.earnings);
+      if (view) {
+        withdrawable = view.withdrawableBalance;
+        threshold = view.payoutThreshold;
+      }
+      if (earnings.monetization?.enabled === true) monetizationOn = true;
+      if (earnings.monetization?.enabled === false) monetizationOn = false;
+    } catch (err) {
+      logger.warn(
+        `[WITHDRAW_APP_EARNINGS] getAppEarnings(${target.id}) failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      await callback?.({
+        text: ERROR_MESSAGE,
+        actions: ["WITHDRAW_APP_EARNINGS"],
+      });
+      return {
+        success: false,
+        text: "Failed to read earnings before withdrawal.",
+        userFacingText: ERROR_MESSAGE,
+        error: err instanceof Error ? err : new Error(String(err)),
+        data: { reason: "error" },
+      };
+    }
+
+    // Connector-agnostic CTA — label + https URL only; never a secret/amount-token.
+    const dashboardUrl = `${resolveCloudSiteBaseUrl(runtime)}/dashboard/apps/${
+      target.id
+    }?tab=earnings`;
+    let cta: ConnectorCta;
+    try {
+      cta = buildConnectorCta(
+        `Open ${target.name}'s earnings dashboard`,
+        dashboardUrl,
+        "link",
+      );
+    } catch (err) {
+      // A malformed base URL must never block the read-only guidance.
+      logger.warn(
+        `[WITHDRAW_APP_EARNINGS] Could not build CTA: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      cta = {
+        label: "Open your earnings dashboard",
+        url: dashboardUrl,
+        kind: "link",
+      };
+    }
+
+    // Pre-checks: never start a withdrawal that the server would reject anyway.
+    if (!monetizationOn) {
+      const msg = `"${target.name}" isn't monetized, so there's nothing to withdraw. Turn on monetization first.`;
+      await callback?.({ text: msg, actions: ["WITHDRAW_APP_EARNINGS"] });
+      return {
+        success: false,
+        text: "Monetization disabled — nothing to withdraw.",
+        userFacingText: msg,
+        data: { reason: "not_monetized", withdrawn: false, cta },
+      };
+    }
+
+    if (withdrawable <= 0) {
+      const msg = `"${target.name}" has no withdrawable balance yet. Earn a bit more and I'll help you cash out.`;
+      await callback?.({ text: msg, actions: ["WITHDRAW_APP_EARNINGS"] });
+      return {
+        success: false,
+        text: "No withdrawable balance.",
+        userFacingText: msg,
+        data: { reason: "no_balance", withdrawn: false, cta },
+      };
+    }
+
+    if (threshold > 0 && withdrawable < threshold) {
+      const msg = `"${target.name}" has ${usd(
+        withdrawable,
+      )} withdrawable, but the minimum payout is ${usd(
+        threshold,
+      )}. Keep earning to reach it.`;
+      await callback?.({ text: msg, actions: ["WITHDRAW_APP_EARNINGS"] });
+      return {
+        success: false,
+        text: "Below minimum payout threshold.",
+        userFacingText: msg,
+        data: { reason: "below_threshold", withdrawn: false, cta },
+      };
+    }
+
+    // Amount: explicit request, else the full withdrawable balance.
+    const requested = parseWithdrawAmount(message.content?.text ?? "", options);
+    const amount = requested ?? withdrawable;
+
+    if (amount > withdrawable + 1e-9) {
+      const msg = `You asked to withdraw ${usd(amount)}, but only ${usd(
+        withdrawable,
+      )} is withdrawable right now. Ask for ${usd(withdrawable)} or less.`;
+      await callback?.({ text: msg, actions: ["WITHDRAW_APP_EARNINGS"] });
+      return {
+        success: false,
+        text: "Requested amount exceeds withdrawable balance.",
+        userFacingText: msg,
+        data: { reason: "exceeds_balance", withdrawn: false, cta },
+      };
+    }
+    if (threshold > 0 && amount < threshold) {
+      const msg = `The minimum payout is ${usd(
+        threshold,
+      )}. Ask for at least that much (you have ${usd(withdrawable)} available).`;
+      await callback?.({ text: msg, actions: ["WITHDRAW_APP_EARNINGS"] });
+      return {
+        success: false,
+        text: "Requested amount below minimum payout.",
+        userFacingText: msg,
+        data: { reason: "below_threshold", withdrawn: false, cta },
+      };
+    }
+
+    const confirmTarget = confirmTargetFor(target);
+    const messageText = message.content?.text ?? "";
+
+    // Phase 1 — no explicit confirmation → confirm + hand off CTA, NO money call.
+    if (
+      !isExplicitConfirmation(messageText, confirmTarget, {
+        verbs: WITHDRAW_VERBS,
+      })
+    ) {
+      const prompt =
+        `This will request a payout of ${usd(amount)} from "${target.name}" ` +
+        `(${target.id}). The funds move to your redeemable balance; you finish ` +
+        `the cash-out on your dashboard — I never touch your bank details or keys. ` +
+        `To go ahead, reply: withdraw ${usd(amount)} from ${target.name} — yes. ` +
+        `Or open the dashboard: ${cta.url}`;
+      await callback?.({ text: prompt, actions: ["WITHDRAW_APP_EARNINGS"] });
+      return {
+        success: true,
+        text: `Awaiting explicit confirmation to withdraw ${usd(amount)} from ${target.name}.`,
+        userFacingText: prompt,
+        verifiedUserFacing: true,
+        data: {
+          app: { id: target.id, name: target.name, slug: target.slug },
+          amount,
+          withdrawn: false,
+          confirmationRequired: true,
+          cta,
+        },
+      };
+    }
+
+    // Phase 2 — explicit confirmation → the safe, idempotent, server-gated path.
+    try {
+      const request: WithdrawAppEarningsRequest = {
+        amount,
+        idempotency_key: newIdempotencyKey(),
+      };
+      const result = await client.withdrawAppEarnings(target.id, request);
+      if (result.success === false) {
+        const msg = `Couldn't withdraw from "${target.name}": ${
+          result.error ?? result.message ?? "the request was rejected"
+        }. Nothing was withdrawn.`;
+        await callback?.({ text: msg, actions: ["WITHDRAW_APP_EARNINGS"] });
+        return {
+          success: false,
+          text: "Withdrawal rejected by the Cloud API.",
+          userFacingText: msg,
+          data: { reason: "rejected", withdrawn: false, cta },
+        };
+      }
+      const newBalance =
+        typeof result.newBalance === "number" ? result.newBalance : null;
+      const reply =
+        `Requested a payout of ${usd(amount)} from "${target.name}". ` +
+        (result.message
+          ? `${result.message} `
+          : "It's now in your redeemable balance. ") +
+        (newBalance !== null
+          ? `Remaining withdrawable: ${usd(newBalance)}. `
+          : "") +
+        `Finish the cash-out here: ${cta.url}`;
+      await callback?.({ text: reply, actions: ["WITHDRAW_APP_EARNINGS"] });
+      return {
+        success: true,
+        text: `Withdrawal of ${usd(amount)} requested for ${target.name}.`,
+        userFacingText: reply,
+        verifiedUserFacing: true,
+        data: {
+          app: { id: target.id, name: target.name, slug: target.slug },
+          amount,
+          withdrawn: true,
+          transactionId: result.transactionId ?? null,
+          newBalance,
+          cta,
+        },
+      };
+    } catch (err) {
+      logger.warn(
+        `[WITHDRAW_APP_EARNINGS] withdrawAppEarnings(${target.id}) failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      await callback?.({
+        text: ERROR_MESSAGE,
+        actions: ["WITHDRAW_APP_EARNINGS"],
+      });
+      return {
+        success: false,
+        text: "Failed to withdraw earnings.",
+        userFacingText: ERROR_MESSAGE,
+        error: err instanceof Error ? err : new Error(String(err)),
+        data: { reason: "error", withdrawn: false, cta },
+      };
+    }
+  },
+
+  examples: [
+    [
+      {
+        name: "{{user}}",
+        content: { text: "withdraw my Acme Bot earnings" },
+      },
+      {
+        name: "{{agent}}",
+        content: {
+          text: 'This will request a payout of $42.00 from "Acme Bot" (…). The funds move to your redeemable balance; you finish the cash-out on your dashboard — I never touch your bank details or keys. To go ahead, reply: withdraw $42.00 from Acme Bot — yes.',
+          actions: ["WITHDRAW_APP_EARNINGS"],
+        },
+      },
+    ],
+    [
+      {
+        name: "{{user}}",
+        content: { text: "withdraw $42 from Acme Bot — yes" },
+      },
+      {
+        name: "{{agent}}",
+        content: {
+          text: 'Requested a payout of $42.00 from "Acme Bot". $42.00 marked as withdrawn. Check your Earnings page to redeem as elizaOS tokens. Finish the cash-out here: https://www.elizacloud.ai/dashboard/apps/…?tab=earnings',
+          actions: ["WITHDRAW_APP_EARNINGS"],
+        },
+      },
+    ],
+  ],
+};
+
+export default withdrawAppEarningsAction;

--- a/plugins/plugin-cloud-apps/src/client.ts
+++ b/plugins/plugin-cloud-apps/src/client.ts
@@ -54,6 +54,16 @@ export function resolveCloudApiBaseUrl(runtime: IAgentRuntime): string {
 }
 
 /**
+ * Resolve the Eliza Cloud dashboard (site) origin — the API base with a trailing
+ * `/api/v1` stripped (e.g. `https://www.elizacloud.ai`). Used to build the
+ * connector-agnostic CTA URLs the paid actions hand back so the user finishes a
+ * money/credential step in the browser, never over the connector.
+ */
+export function resolveCloudSiteBaseUrl(runtime: IAgentRuntime): string {
+  return apiBaseToSiteBaseUrl(resolveCloudApiBaseUrl(runtime));
+}
+
+/**
  * Construct an authenticated {@link ElizaCloudClient} from runtime settings.
  * Returns `null` when no API key is configured so callers can degrade
  * gracefully (no key → no cloud calls).

--- a/plugins/plugin-cloud-apps/src/index.ts
+++ b/plugins/plugin-cloud-apps/src/index.ts
@@ -19,19 +19,23 @@
  *   - Action  GET_APP_DEPLOY_STATUS — report DRAFT/BUILDING/DEPLOYING/READY/ERROR + url.
  *   - Action  DELETE_APP            — DESTRUCTIVE: two-phase, connector-agnostic confirm.
  *
+ * Manage layer (edit / monetize / earnings / money-out / key rotation):
+ *   - Action  UPDATE_APP            — rename / edit name, description, logo, website, email.
+ *   - Action  UPDATE_MONETIZATION   — enable/disable + markup % / purchase share %; range-guarded.
+ *   - Action  GET_APP_EARNINGS      — READ-ONLY: withdrawable / pending / lifetime / withdrawn.
+ *   - Action  WITHDRAW_APP_EARNINGS — MONEY-OUT: two-phase confirm + dashboard CTA; the safe,
+ *                                     idempotent, server-gated request endpoint fires on confirm;
+ *                                     money/credentials NEVER transit the connector.
+ *   - Action  REGENERATE_APP_API_KEY— SECURITY: two-phase confirm; new key shown ONCE, never logged.
+ *
  * Auth: reads `ELIZAOS_CLOUD_API_KEY` (+ optional `ELIZAOS_CLOUD_BASE_URL`) via
  * runtime settings — the same credentials plugin-elizacloud uses. With no key
  * the actions degrade gracefully and the provider stays EMPTY.
  *
  * ───────────────────────────────────────────────────────────────────────────
- * DEFERRED to Phase 3c (paid / CTA-bearing / last-mile — intentionally NOT here):
- *   - UPDATE_APP
- *   - UPDATE_MONETIZATION
- *   - GET_APP_EARNINGS
- *   - WITHDRAW_APP_EARNINGS   (paid → reuse the `buildConnectorCta` seam in safety.ts)
- *   - REGENERATE_APP_API_KEY
+ * DEFERRED (last slice — intentionally NOT here):
  *   - BUY_APP_DOMAIN          (domain is the last slice; SDK envelope not finalized)
- * The paid actions reuse the two-phase-confirm + connector CTA helper already
+ * The paid/destructive actions reuse the two-phase-confirm + connector CTA helper
  * built here (`src/safety.ts`); money/credentials never transit the connector.
  *
  * NOTE: a real end-to-end deploy can't be verified until the staging deploy
@@ -46,7 +50,12 @@ import { deleteAppAction } from "./actions/delete-app.js";
 import { deployAppAction } from "./actions/deploy-app.js";
 import { getAppAction } from "./actions/get-app.js";
 import { getAppDeployStatusAction } from "./actions/get-app-deploy-status.js";
+import { getAppEarningsAction } from "./actions/get-app-earnings.js";
 import { listCloudAppsAction } from "./actions/list-cloud-apps.js";
+import { regenerateAppApiKeyAction } from "./actions/regenerate-app-api-key.js";
+import { updateAppAction } from "./actions/update-app.js";
+import { updateMonetizationAction } from "./actions/update-monetization.js";
+import { withdrawAppEarningsAction } from "./actions/withdraw-app-earnings.js";
 import { cloudAppsProvider } from "./providers/cloud-apps.js";
 
 export { createAppAction } from "./actions/create-app.js";
@@ -54,7 +63,12 @@ export { deleteAppAction } from "./actions/delete-app.js";
 export { deployAppAction } from "./actions/deploy-app.js";
 export { getAppAction } from "./actions/get-app.js";
 export { getAppDeployStatusAction } from "./actions/get-app-deploy-status.js";
+export { getAppEarningsAction } from "./actions/get-app-earnings.js";
 export { listCloudAppsAction } from "./actions/list-cloud-apps.js";
+export { regenerateAppApiKeyAction } from "./actions/regenerate-app-api-key.js";
+export { updateAppAction } from "./actions/update-app.js";
+export { updateMonetizationAction } from "./actions/update-monetization.js";
+export { withdrawAppEarningsAction } from "./actions/withdraw-app-earnings.js";
 export * from "./app-facts.js";
 export * from "./client.js";
 export * from "./deploy-gate.js";
@@ -73,6 +87,11 @@ export const cloudAppsPlugin: Plugin = {
     deployAppAction,
     getAppDeployStatusAction,
     deleteAppAction,
+    updateAppAction,
+    updateMonetizationAction,
+    getAppEarningsAction,
+    withdrawAppEarningsAction,
+    regenerateAppApiKeyAction,
   ],
   providers: [cloudAppsProvider],
 };


### PR DESCRIPTION
## What

Completes `@elizaos/plugin-cloud-apps` with the remaining management actions, so the agent can fully manage a user's monetized apps from chat (app / Discord / Telegram). After this the plugin is feature-complete except `BUY_APP_DOMAIN` (intentionally domain-last).

Stacked on #10290 (create/deploy/delete). Diff is the 5 manage actions + their SDK glue.

## Actions added
- **`UPDATE_APP`** — rename / edit description etc. → `client.updateApp(id, patch)`.
- **`UPDATE_MONETIZATION`** — set markup % / enable-disable → `client.updateMonetization`. **Range-guards** markup to the server's 0–1000 (share 0–100); rejects out-of-range with no API call.
- **`GET_APP_EARNINGS`** — read-only earnings (balance/lifetime/pending).
- **`WITHDRAW_APP_EARNINGS`** *(money-out — handled with care)*: two-phase confirm; first ask = confirm prompt (named app + amount) + a `buildConnectorCta` link to the dashboard earnings tab, **no money call**. On explicit confirm it calls the **server-gated, idempotent** `withdrawAppEarnings(id,{amount,idempotency_key})` once (route is org+creator+monetization+min-payout+balance gated; it records into redeemable balance — the actual cash-out is finished in the browser via the CTA). **No API key / secret / token ever transits the connector** (asserted in tests).
- **`REGENERATE_APP_API_KEY`** *(security)*: two-phase confirm; new `regenerateAppApiKey()` SDK method wrapping `POST /api/v1/apps/:id/regenerate-api-key`. On confirm, rotates once and shows the new key **exactly once** with a "save it now" warning — never logged, never persisted in `data`/`text`.

## Evidence
- `bun run --cwd plugins/plugin-cloud-apps test` → **116 pass / 0 fail** (68 prior + 48 new).
- `bun run --cwd packages/cloud/sdk test` → **51 pass / 0 fail** (+ regenerate wire-contract test).
- Typecheck + biome clean across plugin, SDK, and `packages/agent`.
- Money-out + key-rotation safety asserted: confirm-gating, idempotency, no-secret-in-connector, key-shown-once-never-logged.

## Notes
- The earnings/withdraw/update SDK methods already existed; only `regenerateAppApiKey` was added (verified against the real route).
- Part of the apps launch (tracker #8434).
