### PR TITLE
feat(ui): resolve plugin view ids to their launcher icon via alias map

### DIFF
--- a/packages/ui/src/components/views/view-icon-aliases.test.ts
+++ b/packages/ui/src/components/views/view-icon-aliases.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { resolveViewIconId, VIEW_ICON_ALIASES } from "./view-icon-aliases";
+import { VIEW_ICONS } from "./view-icons.generated";
+
+describe("resolveViewIconId", () => {
+  it("maps known plugin view ids to their nearest baked icon", () => {
+    expect(resolveViewIconId("hyperliquid")).toBe("trade");
+    expect(resolveViewIconId("shopify")).toBe("shop");
+    expect(resolveViewIconId("smartglasses")).toBe("glasses");
+    expect(resolveViewIconId("trajectory-logger")).toBe("trajectory");
+    expect(resolveViewIconId("phone-companion")).toBe("companion");
+  });
+
+  it("passes through ids that have (or fall back from) their own icon", () => {
+    expect(resolveViewIconId("chat")).toBe("chat");
+    expect(resolveViewIconId("feed")).toBe("feed");
+    expect(resolveViewIconId("an-unknown-view")).toBe("an-unknown-view");
+  });
+
+  it("every alias target is a real baked icon key (no alias points at a missing icon)", () => {
+    for (const target of Object.values(VIEW_ICON_ALIASES)) {
+      expect(
+        VIEW_ICONS[target],
+        `alias target "${target}" must be baked`,
+      ).toBeTruthy();
+    }
+  });
+});

--- a/packages/ui/src/components/views/view-icon-aliases.ts
+++ b/packages/ui/src/components/views/view-icon-aliases.ts
@@ -1,0 +1,26 @@
+// Maps plugin/builtin view ids that have NO dedicated baked icon onto the
+// closest bundled icon key, so every launcher view resolves to a proper image
+// instead of the generic `default` glyph. These plugin view ids
+// (`registerAppShellPage` ids) differ from their nearest baked-icon key, e.g.
+// the Hyperliquid plugin registers `hyperliquid` but the trading icon is baked
+// as `trade`.
+//
+// This lives OUTSIDE `view-icons.generated.ts` (which the icon bake overwrites)
+// so the alias map survives icon regeneration. Ids that already have their own
+// baked icon (e.g. `feed`, `facewear`, `polymarket`) are intentionally absent —
+// they resolve directly.
+export const VIEW_ICON_ALIASES: Record<string, string> = {
+  hyperliquid: "trade",
+  shopify: "shop",
+  smartglasses: "glasses",
+  "trajectory-logger": "trajectory",
+  "phone-companion": "companion",
+};
+
+/**
+ * Resolve a view/app id to the id whose baked icon should represent it. Returns
+ * the id unchanged when it has (or should fall back from) its own icon.
+ */
+export function resolveViewIconId(id: string): string {
+  return VIEW_ICON_ALIASES[id] ?? id;
+}

--- a/packages/ui/src/hooks/view-catalog.ts
+++ b/packages/ui/src/hooks/view-catalog.ts
@@ -23,6 +23,7 @@ import {
 } from "@elizaos/core";
 import type { RegistryAppInfo } from "../api";
 import { viewIconDataUri } from "../components/views/view-icons.generated";
+import { resolveViewIconId } from "../components/views/view-icon-aliases";
 import type { ViewModality } from "../platform/platform-guards";
 import type { ViewRegistryEntry } from "./useAvailableViews";
 
@@ -99,7 +100,7 @@ export function viewToEntry(view: ViewRegistryEntry): ViewEntry {
     ? view.heroImageUrl
     : undefined;
   const hasHero = Boolean(view.hasHeroImage && heroUrl);
-  const bundledIcon = viewIconDataUri(view.id);
+  const bundledIcon = viewIconDataUri(resolveViewIconId(view.id));
   const fallbackIcon = viewIconDataUri("default") || bundledIcon;
   return {
     key: `view:${view.id}`,
@@ -134,7 +135,7 @@ function appToEntry(app: RegistryAppInfo, isActive: boolean): ViewEntry {
     ? app.heroImage
     : undefined;
   const hasHero = Boolean(heroUrl);
-  const bundledIcon = viewIconDataUri(app.name);
+  const bundledIcon = viewIconDataUri(resolveViewIconId(app.name));
   return {
     key: `app:${app.name}`,
     id: app.name,


### PR DESCRIPTION
## What

The launcher-wiring follow-up to #10292 (the icon refresh). Ensures **every** launcher view resolves to a real bundled icon instead of the generic `default` glyph.

`viewToEntry`/`appToEntry` set a tile's image from `viewIconDataUri(id)`, but five plugin views register an app-shell id that doesn't match the nearest baked-icon key, so they fell through to `default`:

| plugin view id | → icon |
|---|---|
| `hyperliquid` | `trade` |
| `shopify` | `shop` |
| `smartglasses` | `glasses` |
| `trajectory-logger` | `trajectory` |
| `phone-companion` | `companion` |

## Change

- New `packages/ui/src/components/views/view-icon-aliases.ts` — `VIEW_ICON_ALIASES` + `resolveViewIconId(id)`. Kept **outside** the bake-generated `view-icons.generated.ts` so it survives icon regeneration.
- `view-catalog.ts` applies `resolveViewIconId(...)` at both resolution sites (`view.id`, `app.name`) before `viewIconDataUri`.
- Test (`view-icon-aliases.test.ts`): the five mappings resolve, unknown ids pass through, and **every alias target is asserted to be a real baked icon key** — an alias can never silently point at a missing icon.

```
$ vitest run src/components/views/view-icon-aliases.test.ts
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Ids that already have their own baked icon (`feed`, `facewear`, `polymarket`, …) are intentionally not aliased — they resolve directly. Target keys (`trade`/`shop`/`glasses`/`trajectory`/`companion`) exist in the current icon set, so this is independent of #10292 (which refreshes the icon art + adds the `facewear`/`polymarket` art).

## Display verification

Rendered all icons exactly as `ViewTileImage` does (rounded gradient tile + white overlay + drop-shadow + `object-cover`): every tile shows a centered, recognizable, apple-style icon with no tile/border baked into the icon. With this alias map, no launcher view falls back to the generic default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)