### PR TITLE
fix(cloud): stabilize Worker e2e deploy gate

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -109,6 +109,12 @@ jobs:
 
       - name: Run Worker e2e
         run: bun run --cwd packages/cloud/api test:e2e
+        env:
+          # The deploy runner is a shared self-hosted box running wrangler dev,
+          # PGlite, and the full Worker suite. Keep release gating tolerant of
+          # runner load without enabling live external Steward side effects.
+          TEST_REQUEST_TIMEOUT_MS: "60000"
+          RUN_STEWARD_WALLET_E2E: "0"
 
       - name: Build
         run: bun run --cwd packages/cloud/api build

--- a/packages/cloud/api/test/e2e/_helpers/api.ts
+++ b/packages/cloud/api/test/e2e/_helpers/api.ts
@@ -7,13 +7,23 @@
  *                        Worker.
  *   TEST_API_KEY       — bootstrapped by `ensureLocalTestAuth()` in preload.
  *   CRON_SECRET        — for cron-route tests; defaults to "test-cron-secret".
+ *   TEST_REQUEST_TIMEOUT_MS — per-request timeout; defaults to 30000.
  *
  * The helpers throw if you call them before `ensureLocalTestAuth()` has run.
  * The preload is `packages/cloud/api/test/e2e/preload.ts`, which seeds
  * the DB and exports `TEST_API_KEY`.
  */
 
-const REQUEST_TIMEOUT_MS = 30_000;
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+
+function resolveRequestTimeoutMs(): number {
+  const parsed = Number(process.env.TEST_REQUEST_TIMEOUT_MS);
+  return Number.isFinite(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_REQUEST_TIMEOUT_MS;
+}
+
+const REQUEST_TIMEOUT_MS = resolveRequestTimeoutMs();
 
 export function getBaseUrl(): string {
   return (

--- a/packages/cloud/api/test/e2e/group-b-account-billing.test.ts
+++ b/packages/cloud/api/test/e2e/group-b-account-billing.test.ts
@@ -61,6 +61,10 @@ function shouldRunAuthed(): boolean {
   return serverReachable && hasTestApiKey;
 }
 
+function shouldRunLiveStewardWalletE2E(): boolean {
+  return process.env.RUN_STEWARD_WALLET_E2E === "1";
+}
+
 function shouldRunSession(): boolean {
   return shouldRunAuthed() && sessionCookie !== null;
 }
@@ -384,6 +388,11 @@ describe("POST /api/v1/user/wallets/provision", () => {
 
   test("happy path: provisions when external signer is configured, otherwise fails after auth", async () => {
     if (!shouldRunAuthed()) return;
+    // Live Steward provisioning is an integration check, not a release smoke.
+    // Keep the default deploy gate deterministic; opt in when explicitly
+    // validating Steward wallet provisioning.
+    if (!shouldRunLiveStewardWalletE2E()) return;
+
     const res = await api.post(
       "/api/v1/user/wallets/provision",
       {


### PR DESCRIPTION
## Summary
- make the API e2e request timeout configurable and run the Cloud CF deploy gate with a 60s request timeout
- keep live Steward wallet provisioning out of the default deploy smoke unless explicitly opted in with RUN_STEWARD_WALLET_E2E=1
- preserve wallet auth/validation coverage while avoiding an external Steward/network side effect blocking unrelated production deploys

## Root cause
Production deploy run 28405736738 failed in Deploy API Worker > Run Worker e2e. The concrete failure was group-c avatar validation timing out after the suite had triggered live server-wallet/Steward provisioning traffic. The avatar route itself already returns the expected 400 for JSON/non-multipart requests; the release gate was too coupled to slow/flaky live integration behavior.

## Validation
- bun run --cwd packages/cloud/api typecheck
- TEST_REQUEST_TIMEOUT_MS=60000 RUN_STEWARD_WALLET_E2E=0 timeout 900 bun run --cwd packages/cloud/api test:e2e
