### PR TITLE
fix(cloud): close apps-launch cross-tenant + orphan money holes (#10253, #10247)

### DIFF
--- a/packages/cloud/api/__tests__/domains-buy-credit-debit.test.ts
+++ b/packages/cloud/api/__tests__/domains-buy-credit-debit.test.ts
@@ -35,6 +35,7 @@ const computeDomainPrice = mock();
 const upsertCloudflareRegisteredDomain = mock();
 const assignToResource = mock();
 const setCustomDomain = mock();
+const hasUnrefundedDomainPurchase = mock<() => Promise<boolean>>();
 
 // Chainable Drizzle write builder. The route uses:
 //   insert().values().onConflictDoNothing().returning()   -> [claim]
@@ -112,6 +113,10 @@ mock.module("@/lib/services/credits", () => ({
 
 mock.module("@/lib/services/domain-pricing", () => ({
   computeDomainPrice,
+}));
+
+mock.module("@/db/repositories/credit-transactions", () => ({
+  creditTransactionsRepository: { hasUnrefundedDomainPurchase },
 }));
 
 mock.module("@/lib/services/app-domains-compat", () => ({
@@ -220,6 +225,9 @@ describe("POST /apps/:id/domains/buy — credit debit gates registration", () =>
     idempotencyReturning.mockResolvedValue([{ id: "claim-1" }]);
     dbWriteTerminal.mockClear();
     dbReadLimit.mockClear();
+
+    hasUnrefundedDomainPurchase.mockReset();
+    hasUnrefundedDomainPurchase.mockResolvedValue(false);
   });
 
   test("insufficient balance → 402, no registration, no refund", async () => {
@@ -302,5 +310,254 @@ describe("POST /apps/:id/domains/buy — credit debit gates registration", () =>
     expect(registerDomain).toHaveBeenCalledWith("example.com");
     // A successful purchase is not refunded.
     expect(refundCredits).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /apps/:id/domains/buy — refund-on-failure + recoverable orphan (#10247, #10253)", () => {
+  beforeEach(() => {
+    requireUserOrApiKeyWithOrg.mockReset();
+    requireUserOrApiKeyWithOrg.mockResolvedValue({ organization_id: "org-1" });
+    getById.mockReset();
+    getById.mockResolvedValue({
+      organization_id: "org-1",
+      app_url: "https://x.apps.elizacloud.ai",
+    });
+    getDomainByName.mockReset();
+    getDomainByName.mockResolvedValue(null);
+    checkAvailability.mockReset();
+    checkAvailability.mockResolvedValue({
+      available: true,
+      priceUsdCents: 1000,
+      renewalUsdCents: 1000,
+      currency: "USD",
+    });
+    computeDomainPrice.mockReset();
+    computeDomainPrice.mockReturnValue({
+      totalUsdCents: 1495,
+      wholesaleUsdCents: 1100,
+      marginUsdCents: 395,
+    });
+    registerDomain.mockReset();
+    getRegisteredDomain.mockReset();
+    getRegisteredDomain.mockResolvedValue(null);
+    deductCredits.mockReset();
+    deductCredits.mockResolvedValue({
+      success: true,
+      newBalance: 5,
+      transaction: { id: "txn-1" },
+    });
+    refundCredits.mockReset();
+    refundCredits.mockResolvedValue({
+      transaction: { id: "refund-1" },
+      newBalance: 6,
+    });
+    upsertCloudflareRegisteredDomain.mockReset();
+    upsertCloudflareRegisteredDomain.mockResolvedValue({
+      id: "md-1",
+      status: "pending",
+      verified: false,
+    });
+    assignToResource.mockReset();
+    assignToResource.mockResolvedValue({ id: "app-domain-1" });
+    setCustomDomain.mockReset();
+    setCustomDomain.mockResolvedValue(undefined);
+    idempotencyReturning.mockClear();
+    idempotencyReturning.mockResolvedValue([{ id: "claim-1" }]);
+    dbWriteTerminal.mockClear();
+    dbReadLimit.mockClear();
+    hasUnrefundedDomainPurchase.mockReset();
+    hasUnrefundedDomainPurchase.mockResolvedValue(false);
+  });
+
+  test("registrar throws after debit → refunds EXACTLY once, assigns no domain, returns 502", async () => {
+    registerDomain.mockRejectedValue(new Error("cf registrar 500"));
+
+    const res = await buy();
+    const body = (await res.json()) as DomainBuyResponseBody;
+
+    expect(res.status).toBe(502);
+    expect(body.success).toBe(false);
+    expect(deductCredits).toHaveBeenCalledTimes(1);
+    // Exactly-once refund, reconciling the original debit as a refund.
+    expect(refundCredits).toHaveBeenCalledTimes(1);
+    const refundArg = refundCredits.mock.calls[0]?.[0] as {
+      organizationId: string;
+      metadata: { type: string; domain: string };
+    };
+    expect(refundArg.organizationId).toBe("org-1");
+    expect(refundArg.metadata.type).toBe("domain_purchase_refund");
+    expect(refundArg.metadata.domain).toBe("example.com");
+    // No domain row written / assigned on a failed registration.
+    expect(upsertCloudflareRegisteredDomain).not.toHaveBeenCalled();
+    expect(assignToResource).not.toHaveBeenCalled();
+  });
+
+  test("post-register persist failure → 502 persist_failed_recoverable, NOT refunded (domain kept)", async () => {
+    registerDomain.mockResolvedValue({ registrationId: "reg-1" });
+    upsertCloudflareRegisteredDomain.mockRejectedValue(
+      new Error("db write failed"),
+    );
+
+    const res = await buy();
+    const body = (await res.json()) as DomainBuyResponseBody & {
+      code?: string;
+    };
+
+    expect(res.status).toBe(502);
+    expect(body.code).toBe("persist_failed_recoverable");
+    expect(registerDomain).toHaveBeenCalledTimes(1);
+    // The domain was registered + charged; it is genuinely the org's, so it is
+    // NOT refunded — it is recoverable via the unrefunded-debit ownership proof.
+    expect(refundCredits).not.toHaveBeenCalled();
+  });
+
+  test("recover an orphaned (registered, no row) domain WITHOUT a prior purchase → 409, no assign, no debit", async () => {
+    // Domain has no managed_domains row and is unavailable (already registered
+    // on our CF account) — the orphan shape. The caller never paid for it.
+    getDomainByName.mockResolvedValue(null);
+    checkAvailability.mockResolvedValue({ available: false });
+    getRegisteredDomain.mockResolvedValue({
+      domain: "example.com",
+      zoneId: "zone-1",
+      expiresAt: "2027-01-01T00:00:00Z",
+      autoRenew: true,
+    });
+    hasUnrefundedDomainPurchase.mockResolvedValue(false);
+
+    const res = await buy();
+    const body = (await res.json()) as DomainBuyResponseBody;
+
+    expect(res.status).toBe(409);
+    expect(body.success).toBe(false);
+    // Cross-tenant takeover blocked: no assignment, and never a free debit-less grab.
+    expect(upsertCloudflareRegisteredDomain).not.toHaveBeenCalled();
+    expect(assignToResource).not.toHaveBeenCalled();
+    expect(deductCredits).not.toHaveBeenCalled();
+    expect(hasUnrefundedDomainPurchase).toHaveBeenCalledWith(
+      "org-1",
+      "example.com",
+    );
+  });
+
+  test("recover OWN orphan (unrefunded prior purchase) → 200, assigns for free (no new debit)", async () => {
+    getDomainByName.mockResolvedValue(null);
+    checkAvailability.mockResolvedValue({ available: false });
+    getRegisteredDomain.mockResolvedValue({
+      domain: "example.com",
+      zoneId: "zone-1",
+      expiresAt: "2027-01-01T00:00:00Z",
+      autoRenew: true,
+    });
+    hasUnrefundedDomainPurchase.mockResolvedValue(true);
+
+    const res = await buy();
+    const body = (await res.json()) as DomainBuyResponseBody & {
+      recoveredFromRegistrar?: boolean;
+    };
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.recoveredFromRegistrar).toBe(true);
+    expect(upsertCloudflareRegisteredDomain).toHaveBeenCalledTimes(1);
+    expect(assignToResource).toHaveBeenCalledTimes(1);
+    // Self-recovery does NOT re-charge.
+    expect(deductCredits).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /apps/:id/domains/buy — idempotency single-flights the purchase (#10247)", () => {
+  beforeEach(() => {
+    requireUserOrApiKeyWithOrg.mockReset();
+    requireUserOrApiKeyWithOrg.mockResolvedValue({ organization_id: "org-1" });
+    getById.mockReset();
+    getById.mockResolvedValue({
+      organization_id: "org-1",
+      app_url: "https://x.apps.elizacloud.ai",
+    });
+    getDomainByName.mockReset();
+    getDomainByName.mockResolvedValue(null);
+    checkAvailability.mockReset();
+    checkAvailability.mockResolvedValue({
+      available: true,
+      priceUsdCents: 1000,
+      currency: "USD",
+    });
+    computeDomainPrice.mockReset();
+    computeDomainPrice.mockReturnValue({
+      totalUsdCents: 1495,
+      wholesaleUsdCents: 1100,
+      marginUsdCents: 395,
+    });
+    deductCredits.mockReset();
+    deductCredits.mockResolvedValue({
+      success: true,
+      newBalance: 5,
+      transaction: { id: "txn-1" },
+    });
+    registerDomain.mockReset();
+    registerDomain.mockResolvedValue({ registrationId: "reg-1" });
+    refundCredits.mockReset();
+    getRegisteredDomain.mockReset();
+    getRegisteredDomain.mockResolvedValue(null);
+    upsertCloudflareRegisteredDomain.mockReset();
+    upsertCloudflareRegisteredDomain.mockResolvedValue({
+      id: "md-1",
+      status: "pending",
+      verified: false,
+    });
+    assignToResource.mockReset();
+    assignToResource.mockResolvedValue({ id: "app-domain-1" });
+    setCustomDomain.mockReset();
+    setCustomDomain.mockResolvedValue(undefined);
+    hasUnrefundedDomainPurchase.mockReset();
+    hasUnrefundedDomainPurchase.mockResolvedValue(false);
+    dbWriteTerminal.mockClear();
+    dbReadLimit.mockReset();
+  });
+
+  test("concurrent duplicate (claim lost the race, prior still processing) → 409, never charges/registers twice", async () => {
+    // This caller lost the unique-insert race: onConflictDoNothing returns no row.
+    idempotencyReturning.mockResolvedValue([]);
+    // The winning claim is still in flight.
+    dbReadLimit.mockResolvedValue([
+      { status: "processing", expires_at: new Date(Date.now() + 3_600_000) },
+    ]);
+
+    const res = await buy();
+    const body = (await res.json()) as DomainBuyResponseBody & {
+      code?: string;
+    };
+
+    expect(res.status).toBe(409);
+    expect(body.code).toBe("idempotency_in_progress");
+    // The losing caller must NOT charge or register — the winner owns the purchase.
+    expect(deductCredits).not.toHaveBeenCalled();
+    expect(registerDomain).not.toHaveBeenCalled();
+  });
+
+  test("retried duplicate of a completed purchase → replays the cached 200 without re-charging", async () => {
+    idempotencyReturning.mockResolvedValue([]);
+    dbReadLimit.mockResolvedValue([
+      {
+        status: "completed",
+        expires_at: new Date(Date.now() + 3_600_000),
+        response_body: { success: true, domain: "example.com", replayed: true },
+      },
+    ]);
+
+    const res = await buy();
+    const body = (await res.json()) as DomainBuyResponseBody & {
+      replayed?: boolean;
+    };
+
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({
+      success: true,
+      domain: "example.com",
+      replayed: true,
+    });
+    // A replay never re-charges or re-registers.
+    expect(deductCredits).not.toHaveBeenCalled();
+    expect(registerDomain).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/v1/apps/[id]/domains/buy/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/buy/route.ts
@@ -15,6 +15,7 @@
 import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { dbRead, dbWrite } from "@/db/client";
+import { creditTransactionsRepository } from "@/db/repositories/credit-transactions";
 import { domainPurchaseIdempotency } from "@/db/schemas/domain-purchase-idempotency";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
@@ -250,6 +251,32 @@ async function executeDomainPurchase(
       "unavailable",
     );
     if (registered) {
+      // The domain is registered on our Cloudflare account but has NO
+      // managed_domains row — the orphan left behind when a prior buy's
+      // post-register persist failed (charged + registered, never assigned).
+      // Only the org that actually paid (debit not refunded) may re-claim it
+      // here without a fresh debit. Any other org is denied so a registered
+      // orphan can't be assigned cross-tenant for free (#10253). The 409 copy
+      // is identical to the not-registered case so it never leaks that the
+      // domain exists on our account.
+      const ownsOrphan =
+        await creditTransactionsRepository.hasUnrefundedDomainPurchase(
+          organizationId,
+          domain,
+        );
+      if (!ownsOrphan) {
+        logger.warn(
+          "[Domains Buy] refusing to assign a registered domain with no prior purchase by this org",
+          { appId, domain, organizationId },
+        );
+        return {
+          status: 409,
+          body: {
+            success: false,
+            error: "Domain is not available for registration",
+          },
+        };
+      }
       const result = await persistAndAssignCloudflareDomain({
         organizationId,
         appId,
@@ -352,16 +379,47 @@ async function executeDomainPurchase(
     appId,
     "post-register",
   );
-  const result = await persistAndAssignCloudflareDomain({
-    organizationId,
-    appId,
-    appUrl,
-    domain,
-    cloudflareRegistrationId: registrationId,
-    purchasePriceCents: price.totalUsdCents,
-    renewalPriceCents: renewalPrice.totalUsdCents,
-    registered: reg,
-  });
+  let result: Awaited<ReturnType<typeof persistAndAssignCloudflareDomain>>;
+  try {
+    result = await persistAndAssignCloudflareDomain({
+      organizationId,
+      appId,
+      appUrl,
+      domain,
+      cloudflareRegistrationId: registrationId,
+      purchasePriceCents: price.totalUsdCents,
+      renewalPriceCents: renewalPrice.totalUsdCents,
+      registered: reg,
+    });
+  } catch (persistErr) {
+    // Register + debit already succeeded, so the domain genuinely belongs to
+    // this org — we do NOT refund and do NOT deregister (the registration
+    // stands). The unrefunded domain_purchase debit makes it recoverable: the
+    // org can re-call buy and the recovery branch above will assign it for free
+    // (ownership proven by that debit). Surfacing a clear 502 (instead of the
+    // bare outer-catch failure, which would leave a silent charged orphan) tells
+    // the caller to retry to finish setup. (#10253)
+    logger.error(
+      "[Domains Buy] post-register persist failed — domain registered + charged, recoverable on retry",
+      {
+        appId,
+        domain,
+        organizationId,
+        registrationId,
+        error: extractErrorMessage(persistErr),
+      },
+    );
+    return {
+      status: 502,
+      body: {
+        success: false,
+        error:
+          "Domain was registered and charged, but final setup did not complete. Retry to finish assigning it to your app.",
+        code: "persist_failed_recoverable",
+        domain,
+      },
+    };
+  }
 
   return {
     status: 200,

--- a/packages/cloud/shared/src/db/repositories/__tests__/domain-purchase-ownership.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/domain-purchase-ownership.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Real-DB coverage for `hasUnrefundedDomainPurchase` — the ownership proof that
+ * gates orphan-domain recovery in the buy route (#10253).
+ *
+ * When a domain's post-register persist fails, the domain is registered on our
+ * Cloudflare account + the org is charged, but there is no `managed_domains`
+ * row. The recovery branch will assign such a registered-but-unrowed domain
+ * WITHOUT a fresh debit — so it must first confirm the caller actually paid and
+ * was not refunded, or any org could grab another org's orphan for free. The
+ * single source of that truth is the credit ledger: a `domain_purchase` debit
+ * for the domain that outnumbers its `domain_purchase_refund`s.
+ *
+ * Runs the REAL count SQL against in-process PGlite. Self-skips if unavailable.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS ||= "1";
+
+const PGLITE_TIMEOUT = 60000;
+const ORG_A = "00000000-0000-0000-0000-0000000000a1";
+const ORG_B = "00000000-0000-0000-0000-0000000000b1";
+
+let dbWrite: typeof import("../../client").dbWrite;
+let closeDb: typeof import("../../client").closeDatabaseConnectionsForTests | undefined;
+let repo: typeof import("../credit-transactions").creditTransactionsRepository;
+let pgliteReady = true;
+
+let txnSeq = 0;
+async function addTxn(org: string, type: string, metadata: Record<string, unknown>): Promise<void> {
+  txnSeq += 1;
+  const meta = JSON.stringify(metadata).replace(/'/g, "''");
+  await dbWrite.execute(
+    `INSERT INTO credit_transactions (id, organization_id, amount, type, metadata)
+     VALUES (gen_random_uuid(), '${org}', '${txnSeq}', '${type}', '${meta}'::jsonb);`,
+  );
+}
+
+beforeAll(async () => {
+  try {
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../client"));
+    ({ creditTransactionsRepository: repo } = await import("../credit-transactions"));
+    await dbWrite.execute(
+      `CREATE TABLE IF NOT EXISTS credit_transactions (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        organization_id uuid NOT NULL,
+        user_id uuid,
+        amount numeric(12,6) NOT NULL,
+        type text NOT NULL,
+        description text,
+        metadata jsonb NOT NULL DEFAULT '{}',
+        stripe_payment_intent_id text,
+        created_at timestamp NOT NULL DEFAULT now()
+      )`,
+    );
+  } catch (error) {
+    pgliteReady = false;
+    console.warn("[domain-purchase-ownership] PGlite unavailable, skipping:", error);
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
+describe("hasUnrefundedDomainPurchase", () => {
+  beforeEach(async () => {
+    if (!pgliteReady) return;
+    await dbWrite.execute(`DELETE FROM credit_transactions;`);
+  });
+
+  test("no transactions → false", async () => {
+    if (!pgliteReady) return;
+    expect(await repo.hasUnrefundedDomainPurchase(ORG_A, "example.com")).toBe(false);
+  });
+
+  test("an unrefunded domain_purchase debit → true", async () => {
+    if (!pgliteReady) return;
+    await addTxn(ORG_A, "debit", { type: "domain_purchase", domain: "example.com" });
+    expect(await repo.hasUnrefundedDomainPurchase(ORG_A, "example.com")).toBe(true);
+  });
+
+  test("debit fully refunded → false", async () => {
+    if (!pgliteReady) return;
+    await addTxn(ORG_A, "debit", { type: "domain_purchase", domain: "example.com" });
+    await addTxn(ORG_A, "refund", { type: "domain_purchase_refund", domain: "example.com" });
+    expect(await repo.hasUnrefundedDomainPurchase(ORG_A, "example.com")).toBe(false);
+  });
+
+  test("re-purchased after a refund (debits > refunds) → true", async () => {
+    if (!pgliteReady) return;
+    await addTxn(ORG_A, "debit", { type: "domain_purchase", domain: "example.com" });
+    await addTxn(ORG_A, "refund", { type: "domain_purchase_refund", domain: "example.com" });
+    await addTxn(ORG_A, "debit", { type: "domain_purchase", domain: "example.com" });
+    expect(await repo.hasUnrefundedDomainPurchase(ORG_A, "example.com")).toBe(true);
+  });
+
+  test("a different org's purchase does not grant ownership", async () => {
+    if (!pgliteReady) return;
+    await addTxn(ORG_A, "debit", { type: "domain_purchase", domain: "example.com" });
+    // Org B never bought example.com — must be denied (cross-tenant guard).
+    expect(await repo.hasUnrefundedDomainPurchase(ORG_B, "example.com")).toBe(false);
+  });
+
+  test("a purchase of a different domain does not match", async () => {
+    if (!pgliteReady) return;
+    await addTxn(ORG_A, "debit", { type: "domain_purchase", domain: "other.com" });
+    expect(await repo.hasUnrefundedDomainPurchase(ORG_A, "example.com")).toBe(false);
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/credit-transactions.ts
+++ b/packages/cloud/shared/src/db/repositories/credit-transactions.ts
@@ -105,6 +105,35 @@ export class CreditTransactionsRepository {
     return !!row;
   }
 
+  /**
+   * Returns true if the organization has a `domain_purchase` debit for this
+   * domain that has NOT been fully refunded (debits outnumber refunds).
+   *
+   * This is the ownership proof for recovering an already-registered domain
+   * that has no `managed_domains` row (the orphan left when the post-register
+   * persist fails). Only the org that actually paid — and was not refunded —
+   * may re-claim such a domain without a fresh debit; any other org is denied,
+   * closing the cross-tenant free-domain takeover (#10253).
+   *
+   * WHY dbWrite (primary): the buy flow calls this right after writing the debit
+   * row, so it must not race a stale read replica.
+   */
+  async hasUnrefundedDomainPurchase(organizationId: string, domain: string): Promise<boolean> {
+    const [row] = await dbWrite
+      .select({
+        debits: sql<number>`count(*) filter (where ${creditTransactions.metadata}->>'type' = 'domain_purchase')`,
+        refunds: sql<number>`count(*) filter (where ${creditTransactions.metadata}->>'type' = 'domain_purchase_refund')`,
+      })
+      .from(creditTransactions)
+      .where(
+        and(
+          eq(creditTransactions.organization_id, organizationId),
+          sql`${creditTransactions.metadata}->>'domain' = ${domain}`,
+        ),
+      );
+    return Number(row?.debits ?? 0) > Number(row?.refunds ?? 0);
+  }
+
   // ============================================================================
   // WRITE OPERATIONS (use primary)
   // ============================================================================

--- a/packages/cloud/shared/src/db/repositories/eliza-room-characters.ts
+++ b/packages/cloud/shared/src/db/repositories/eliza-room-characters.ts
@@ -6,6 +6,7 @@ import {
   type ElizaRoomCharacter,
   elizaRoomCharactersTable,
   type NewElizaRoomCharacter,
+  userCharacters,
 } from "../schemas";
 
 /**
@@ -94,6 +95,28 @@ export const elizaRoomCharactersRepository = {
     });
 
     return character;
+  },
+
+  /**
+   * Resolves the owning organization of a room via its mapped character.
+   *
+   * `eliza_room_characters.room_id → character_id → user_characters.organization_id`
+   * is the authority for which org a conversation room belongs to. Used to
+   * confirm a payment-callback channel targets a room the charge creator owns
+   * before writing an agent message into it (cross-tenant guard, #10253).
+   *
+   * Returns `undefined` when the room has no character mapping (callers must
+   * treat that as unverifiable and fail closed).
+   */
+  async findOrganizationIdByRoomId(roomId: string): Promise<string | undefined> {
+    const [row] = await dbRead
+      .select({ organizationId: userCharacters.organization_id })
+      .from(elizaRoomCharactersTable)
+      .innerJoin(userCharacters, eq(userCharacters.id, elizaRoomCharactersTable.character_id))
+      .where(eq(elizaRoomCharactersTable.room_id, roomId))
+      .limit(1);
+
+    return row?.organizationId ?? undefined;
   },
 
   /**

--- a/packages/cloud/shared/src/lib/services/__tests__/app-charge-callback-cross-tenant.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-charge-callback-cross-tenant.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Real-DB coverage for the cross-tenant guard on payment-settlement callbacks
+ * (#10253).
+ *
+ * A charge's `callback_channel.{roomId, agentId}` is attacker-controlled — set by
+ * whoever created the charge and stored verbatim. The settlement dispatch writes
+ * a `role:'agent'` "Payment went through for $X." memory into that room. Without
+ * a guard, an attacker could create their own app + charge, point the channel at
+ * a VICTIM org's room, self-pay, and have a forged agent message injected into
+ * the victim's conversation.
+ *
+ * This suite runs the REAL room→org resolution
+ * (`eliza_room_characters → user_characters`) and the REAL
+ * `appChargeCallbacksService.dispatch` path against in-process PGlite, seeding
+ * real rows and asserting the observable effect: the downstream memory write is
+ * performed for a same-tenant channel and REFUSED for a cross-tenant or unmapped
+ * channel. The only thing stubbed is `memoriesRepository.create` — the
+ * downstream sink being gated, NOT the authorization logic under test.
+ *
+ * Self-skips if PGlite is unavailable (mirrors the sibling billing suites).
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, spyOn, test } from "bun:test";
+
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS ||= "1";
+
+const PGLITE_TIMEOUT = 60000;
+
+const ORG_A = "00000000-0000-0000-0000-0000000000a1";
+const ORG_B = "00000000-0000-0000-0000-0000000000b1";
+const USER_A = "00000000-0000-0000-0000-0000000000a2";
+const USER_B = "00000000-0000-0000-0000-0000000000b2";
+const CHAR_A = "00000000-0000-0000-0000-0000000000a3";
+const CHAR_B = "00000000-0000-0000-0000-0000000000b3";
+const ROOM_A = "00000000-0000-0000-0000-0000000000a4";
+const ROOM_B = "00000000-0000-0000-0000-0000000000b4";
+const AGENT_A = "00000000-0000-0000-0000-0000000000a5";
+const APP_ID = "00000000-0000-0000-0000-00000000ff01";
+const CHARGE_ID = "00000000-0000-0000-0000-00000000ff02";
+const UNMAPPED_ROOM = "00000000-0000-0000-0000-00000000dead";
+
+let dbWrite: typeof import("../../../db/client").dbWrite;
+let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
+let appChargeCallbacksService: typeof import("../app-charge-callbacks").appChargeCallbacksService;
+let callbackRoomBelongsToOrganization: typeof import("../callback-channel-authz").callbackRoomBelongsToOrganization;
+let memoriesRepository: typeof import("../../../db/repositories/agents/memories").memoriesRepository;
+let createSpy: ReturnType<typeof spyOn> | undefined;
+let pgliteReady = true;
+
+async function seedCharge(creatorOrg: string, roomId: string): Promise<void> {
+  await dbWrite.execute(`DELETE FROM crypto_payments WHERE id = '${CHARGE_ID}';`);
+  const metadata = JSON.stringify({
+    kind: "app_charge_request",
+    app_id: APP_ID,
+    amount_usd: 5,
+    payment_context: "any_payer",
+    callback_channel: { roomId, agentId: AGENT_A, source: "payment" },
+  }).replace(/'/g, "''");
+  await dbWrite.execute(
+    `INSERT INTO crypto_payments
+       (id, organization_id, user_id, payment_address, token, network,
+        expected_amount, credits_to_add, status, expires_at, metadata)
+     VALUES
+       ('${CHARGE_ID}', '${creatorOrg}', '${USER_A}', 'addr', 'USDC', 'base',
+        '5', '5', 'confirmed', now() + interval '1 day', '${metadata}'::jsonb);`,
+  );
+}
+
+beforeAll(async () => {
+  try {
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
+    ({ appChargeCallbacksService } = await import("../app-charge-callbacks"));
+    ({ callbackRoomBelongsToOrganization } = await import("../callback-channel-authz"));
+    ({ memoriesRepository } = await import("../../../db/repositories/agents/memories"));
+
+    const ddl = [
+      `CREATE TABLE IF NOT EXISTS user_characters (
+        id uuid PRIMARY KEY,
+        organization_id uuid NOT NULL,
+        user_id uuid NOT NULL,
+        name text NOT NULL,
+        created_at timestamp NOT NULL DEFAULT now(),
+        updated_at timestamp NOT NULL DEFAULT now()
+      )`,
+      `CREATE TABLE IF NOT EXISTS eliza_room_characters (
+        room_id uuid PRIMARY KEY,
+        character_id uuid NOT NULL,
+        user_id uuid NOT NULL,
+        created_at timestamp NOT NULL DEFAULT now(),
+        updated_at timestamp NOT NULL DEFAULT now()
+      )`,
+      `CREATE TABLE IF NOT EXISTS crypto_payments (
+        id uuid PRIMARY KEY,
+        organization_id uuid NOT NULL,
+        user_id uuid,
+        payment_address text NOT NULL,
+        token_address text,
+        token text NOT NULL,
+        network text NOT NULL,
+        expected_amount text NOT NULL,
+        received_amount text,
+        credits_to_add text NOT NULL,
+        transaction_hash text,
+        block_number text,
+        status text NOT NULL,
+        created_at timestamp NOT NULL DEFAULT now(),
+        updated_at timestamp NOT NULL DEFAULT now(),
+        confirmed_at timestamp,
+        expires_at timestamp NOT NULL,
+        metadata jsonb DEFAULT '{}'
+      )`,
+    ];
+    for (const stmt of ddl) await dbWrite.execute(stmt);
+
+    // Two tenants: orgA owns charA in roomA; orgB owns charB in roomB.
+    await dbWrite.execute(`DELETE FROM user_characters;`);
+    await dbWrite.execute(`DELETE FROM eliza_room_characters;`);
+    await dbWrite.execute(
+      `INSERT INTO user_characters (id, organization_id, user_id, name) VALUES
+        ('${CHAR_A}', '${ORG_A}', '${USER_A}', 'Char A'),
+        ('${CHAR_B}', '${ORG_B}', '${USER_B}', 'Char B');`,
+    );
+    await dbWrite.execute(
+      `INSERT INTO eliza_room_characters (room_id, character_id, user_id) VALUES
+        ('${ROOM_A}', '${CHAR_A}', '${USER_A}'),
+        ('${ROOM_B}', '${CHAR_B}', '${USER_B}');`,
+    );
+  } catch (error) {
+    pgliteReady = false;
+    console.warn("[app-charge-callback-cross-tenant] PGlite unavailable, skipping:", error);
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  createSpy?.mockRestore();
+  if (closeDb) await closeDb();
+});
+
+describe("callbackRoomBelongsToOrganization — room→org authority", () => {
+  test("same-tenant (room owned by the charge org) → authorized", async () => {
+    if (!pgliteReady) return;
+    expect(
+      await callbackRoomBelongsToOrganization({
+        roomId: ROOM_A,
+        chargeOrganizationId: ORG_A,
+        logContext: "test",
+      }),
+    ).toBe(true);
+  });
+
+  test("cross-tenant (room owned by a different org) → refused", async () => {
+    if (!pgliteReady) return;
+    expect(
+      await callbackRoomBelongsToOrganization({
+        roomId: ROOM_A,
+        chargeOrganizationId: ORG_B,
+        logContext: "test",
+      }),
+    ).toBe(false);
+  });
+
+  test("unmapped room (no character mapping) → refused (fail-closed)", async () => {
+    if (!pgliteReady) return;
+    expect(
+      await callbackRoomBelongsToOrganization({
+        roomId: UNMAPPED_ROOM,
+        chargeOrganizationId: ORG_A,
+        logContext: "test",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("appChargeCallbacksService.dispatch — settlement memory write is gated", () => {
+  beforeEach(() => {
+    if (!pgliteReady) return;
+    createSpy?.mockRestore();
+    createSpy = spyOn(memoriesRepository, "create").mockImplementation(
+      async () => ({ id: "mem", roomId: ROOM_A }) as never,
+    );
+  });
+
+  test("same-tenant charge → settlement memory is written into the room", async () => {
+    if (!pgliteReady) return;
+    await seedCharge(ORG_A, ROOM_A);
+
+    const result = await appChargeCallbacksService.dispatch({
+      appId: APP_ID,
+      chargeRequestId: CHARGE_ID,
+      status: "paid",
+      provider: "stripe",
+      providerPaymentId: "pi_same",
+    });
+
+    expect(result.roomMessageCreated).toBe(true);
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    const [memory] = createSpy.mock.calls[0] as [{ roomId: string; agentId: string }];
+    expect(memory.roomId).toBe(ROOM_A);
+    expect(memory.agentId).toBe(AGENT_A);
+  });
+
+  test("cross-tenant charge → NO memory is written into the victim's room", async () => {
+    if (!pgliteReady) return;
+    // Attacker org B creates a charge whose channel points at org A's room.
+    await seedCharge(ORG_B, ROOM_A);
+
+    const result = await appChargeCallbacksService.dispatch({
+      appId: APP_ID,
+      chargeRequestId: CHARGE_ID,
+      status: "paid",
+      provider: "stripe",
+      providerPaymentId: "pi_cross",
+    });
+
+    expect(result.roomMessageCreated).toBe(false);
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  test("unmapped room → NO memory is written (fail-closed)", async () => {
+    if (!pgliteReady) return;
+    await seedCharge(ORG_A, UNMAPPED_ROOM);
+
+    const result = await appChargeCallbacksService.dispatch({
+      appId: APP_ID,
+      chargeRequestId: CHARGE_ID,
+      status: "paid",
+      provider: "stripe",
+      providerPaymentId: "pi_unmapped",
+    });
+
+    expect(result.roomMessageCreated).toBe(false);
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/app-charge-callbacks.ts
+++ b/packages/cloud/shared/src/lib/services/app-charge-callbacks.ts
@@ -6,6 +6,7 @@ import { memoriesRepository } from "../../db/repositories/agents/memories";
 import { cryptoPayments } from "../../db/schemas/crypto-payments";
 import type { DialogueMetadata } from "../types/message-content";
 import { logger } from "../utils/logger";
+import { callbackRoomBelongsToOrganization } from "./callback-channel-authz";
 
 export type AppChargeCallbackStatus = "paid" | "failed";
 export type AppChargeCallbackProvider = "stripe" | "oxapay";
@@ -226,7 +227,11 @@ export class AppChargeCallbacksService {
     const channel = callbackChannel(metadata);
     if (channel) {
       try {
-        result.roomMessageCreated = await this.createRoomMessage(payload, channel);
+        result.roomMessageCreated = await this.createRoomMessage(
+          payload,
+          channel,
+          chargeRequest.organization_id,
+        );
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         result.errors.push(message);
@@ -304,10 +309,23 @@ export class AppChargeCallbacksService {
   private async createRoomMessage(
     payload: AppChargeCallbackPayload,
     channel: AppChargeCallbackChannel,
+    chargeOrganizationId: string,
   ): Promise<boolean> {
     const roomId = roomIdFromChannel(channel);
     const agentId = agentIdFromChannel(channel);
     if (!roomId || !agentId) {
+      return false;
+    }
+
+    // The channel's roomId/agentId are attacker-controlled (set by the charge
+    // creator). Only write into the room if it belongs to the creator's org —
+    // otherwise a forged settlement message could be injected cross-tenant.
+    const authorized = await callbackRoomBelongsToOrganization({
+      roomId,
+      chargeOrganizationId,
+      logContext: "AppChargeCallbacks",
+    });
+    if (!authorized) {
       return false;
     }
 

--- a/packages/cloud/shared/src/lib/services/callback-channel-authz.ts
+++ b/packages/cloud/shared/src/lib/services/callback-channel-authz.ts
@@ -1,0 +1,47 @@
+import { elizaRoomCharactersRepository } from "../../db/repositories/eliza-room-characters";
+import { logger } from "../utils/logger";
+
+/**
+ * Confirms the room a payment-settlement callback would post into belongs to
+ * the organization that created the charge.
+ *
+ * A charge's `callback_channel.{roomId, agentId}` is attacker-controlled — it is
+ * supplied by whoever created the charge and stored verbatim. Without this check
+ * an attacker could create their own app + charge, point the channel at a victim
+ * org's room, self-pay, and have a forged `role:'agent'` settlement message
+ * ("Payment went through for $X.") injected into the victim's conversation,
+ * attributed to the victim's agent (#10253).
+ *
+ * `eliza_room_characters → user_characters.organization_id` is the room→org
+ * authority. A room with no character mapping cannot be attributed to an org, so
+ * it is rejected (fail-closed) — the legitimate callback path targets a
+ * cloud-managed character room, which always carries that mapping.
+ */
+export async function callbackRoomBelongsToOrganization(params: {
+  roomId: string;
+  chargeOrganizationId: string;
+  logContext: string;
+}): Promise<boolean> {
+  const { roomId, chargeOrganizationId, logContext } = params;
+
+  const roomOrganizationId = await elizaRoomCharactersRepository.findOrganizationIdByRoomId(roomId);
+
+  if (!roomOrganizationId) {
+    logger.warn(
+      `[${logContext}] refusing callback room-message: room has no organization mapping`,
+      { roomId, chargeOrganizationId },
+    );
+    return false;
+  }
+
+  if (roomOrganizationId !== chargeOrganizationId) {
+    logger.warn(`[${logContext}] refusing cross-tenant callback room-message`, {
+      roomId,
+      roomOrganizationId,
+      chargeOrganizationId,
+    });
+    return false;
+  }
+
+  return true;
+}

--- a/packages/cloud/shared/src/lib/services/x402-payment-requests.ts
+++ b/packages/cloud/shared/src/lib/services/x402-payment-requests.ts
@@ -22,6 +22,7 @@ import { apps } from "../../db/schemas/apps";
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 import { safeFetch } from "../security/safe-fetch";
 import { logger } from "../utils/logger";
+import { callbackRoomBelongsToOrganization } from "./callback-channel-authz";
 import { redeemableEarningsService } from "./redeemable-earnings";
 import { x402FacilitatorService } from "./x402-facilitator";
 
@@ -378,6 +379,16 @@ async function triggerChannelCallback(
   const roomId = stringValue(channel, "roomId") ?? stringValue(channel, "room_id");
   const agentId = stringValue(channel, "agentId") ?? stringValue(channel, "agent_id");
   if (!roomId || !agentId) return;
+
+  // The channel's roomId/agentId are attacker-controlled (set by the payment-
+  // request creator). Only write into the room if it belongs to the creator's
+  // org — otherwise a forged settlement message could be injected cross-tenant.
+  const authorized = await callbackRoomBelongsToOrganization({
+    roomId,
+    chargeOrganizationId: payment.organization_id,
+    logContext: "x402-payment-requests",
+  });
+  if (!authorized) return;
 
   const amountUsd = Number(metadata.amountUsd ?? payment.credits_to_add ?? 0);
   const source = stringValue(channel, "source") ?? "payment";


### PR DESCRIPTION
Closes the two adversarially-verified cross-tenant holes from the apps/Product-2 launch-readiness scan (#10253) and adds the refund/idempotency hardening tests for the domain-buy money path (#10247). The 402 `below_minimum`/`org_not_found` copy from #10247 already landed in #10248.

## #10253-1 — domain-buy orphan + cross-tenant free-domain takeover
`v1/apps/[id]/domains/buy/route.ts`

- **Orphan:** step-4 `persistAndAssignCloudflareDomain` (after register + debit succeed) was **not** wrapped. A throw hit the outer catch (release claim + 500) → the org was **charged**, the domain was **live on our Cloudflare account**, but there was **no `managed_domains` row**.
- **Takeover:** the unavailable-domain recovery branch then `persistAndAssign`ed that orphan to **whichever org called buy next**, with **no debit and no ownership check**.

**Fix**
- Wrap step 4 → a persist failure returns `502 persist_failed_recoverable` (no refund: the domain is genuinely bought), so it's *recoverable* instead of a silent charged orphan.
- Gate recovery on ownership: `creditTransactionsRepository.hasUnrefundedDomainPurchase(org, domain)` (domain_purchase debits outnumber refunds in the ledger) must hold before a registered-but-unrowed domain is assigned without a fresh debit. Any other org → 409 with the **same** copy as not-registered (no existence leak).

## #10253-2 — app-charge / x402 callback-channel cross-tenant injection
`lib/services/app-charge-callbacks.ts`, `lib/services/x402-payment-requests.ts`

A charge's `callback_channel.{roomId,agentId}` is attacker-controlled and was written verbatim into agent memory — a forged `role:'agent'` "Payment went through for \$X." could be injected into a **victim org's** room.

**Fix:** new shared guard `callback-channel-authz.ts` resolves the target room's org via `eliza_room_characters → user_characters` (new `elizaRoomCharactersRepository.findOrganizationIdByRoomId`) and only writes when it equals the charge creator's org. **Fail-closed** when the room has no mapping. Wired into both callback writers.

## #10247 — refund-on-failure + purchase idempotency
The route already refunds exactly once on registrar failure and single-flights via the idempotency claim; this PR adds the **missing tests** that pin those behaviors.

## Evidence (real paths, no mocked-subject)
All run locally against the real code; cloud-shared suites hit **in-process PGlite** (real SQL), route suite drives the **real Hono route** with only collaborators mocked.

```
# cloud-shared (real PGlite): cross-tenant guard + dispatch gate + ownership ledger
12 pass, 0 fail   (app-charge-callback-cross-tenant.test.ts, domain-purchase-ownership.test.ts)
# cloud-api (real route): debit-gate + refund-once + persist-recoverable + recovery-ownership + idempotency
10 pass, 0 fail   (domains-buy-credit-debit.test.ts)
```
Backend logs confirm the guard firing on the denied paths:
```
[AppChargeCallbacks] refusing cross-tenant callback room-message { roomId, roomOrganizationId: orgA, chargeOrganizationId: orgB }
[AppChargeCallbacks] refusing callback room-message: room has no organization mapping { roomId, chargeOrganizationId }
[Domains Buy] refusing to assign a registered domain with no prior purchase by this org { appId, domain, organizationId }
```

typecheck (cloud-api + cloud-shared): **0 errors** · biome: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)