### PR TITLE
feat(apps): wire first-party template image + de-personalize apps-deploy allowlist (open-to-everyone launch wiring)

### DIFF
--- a/packages/cloud/api/__tests__/apps-crud.integration.test.ts
+++ b/packages/cloud/api/__tests__/apps-crud.integration.test.ts
@@ -219,9 +219,6 @@ const createApp = mock(
       apiKey: `eliza_test_${app.id.replace(/-/g, "").slice(0, 24)}`,
       githubRepo: githubRepoCreated ? `elizaOS-apps/${slug}` : undefined,
       githubRepoCreated,
-      subdomain: undefined,
-      productionUrl: undefined,
-      subdomainAssigned: false,
       errors: [] as string[],
     };
   },

--- a/packages/cloud/shared/src/lib/config/containers-env.ts
+++ b/packages/cloud/shared/src/lib/config/containers-env.ts
@@ -180,6 +180,28 @@ export const containersEnv = {
   },
 
   /**
+   * First-party TEMPLATE image stamped onto a template app (one created WITHOUT a
+   * user repo) at create time, so create -> deploy resolves to a prebuilt,
+   * allowlisted image instead of failing with "no image to deploy".
+   *
+   * Defaults to the published example-app image at the `:showcase` tag that
+   * `.github/workflows/build-example-app-images.yml` publishes (and gates on a
+   * working container before pushing). It sits under `ghcr.io/elizaos/*`, so the
+   * apps-deploy allowlist permits it unchanged. Override the whole ref via
+   * `APP_DEFAULT_TEMPLATE_IMAGE`.
+   *
+   * TODO(ops, digest-pin): `:showcase` is a MUTABLE tag — the registry could
+   * re-point it after the deploy-time allowlist check. Once a stable showcase
+   * digest is published, pin this default to
+   * `ghcr.io/elizaos/example-edad@sha256:<64hex>` so a future digest-pin gate
+   * (`CONTAINER_IMAGE_REQUIRE_DIGEST`) accepts the template default unchanged.
+   */
+  appDefaultTemplateImage(): string {
+    const env = getCloudAwareEnv();
+    return pick(env.APP_DEFAULT_TEMPLATE_IMAGE) ?? "ghcr.io/elizaos/example-edad:showcase";
+  },
+
+  /**
    * Whether image refs must be pinned to a full `@sha256:<64hex>` digest to be
    * accepted by the container image gate (in addition to the allowlist).
    *

--- a/packages/cloud/shared/src/lib/config/containers-env.ts
+++ b/packages/cloud/shared/src/lib/config/containers-env.ts
@@ -149,6 +149,37 @@ export const containersEnv = {
   },
 
   /**
+   * Allowlist of image refs/prefixes permitted for APPS-DEPLOY (Product 2) image
+   * deploys — DELIBERATELY SEPARATE from {@link codingContainerImageAllowlist}.
+   *
+   * Apps-deploy ships ONLY first-party template/app images under
+   * `ghcr.io/elizaos/*`, so its default allowlist is `ghcr.io/elizaos/*` and
+   * nothing else — no personal (`ghcr.io/dexploarer/*`) or side-product
+   * (`ghcr.io/waifufun/*`) namespaces. Those stay on the coding-container
+   * allowlist (its BYO-image path), and an operator can opt them back in for
+   * apps-deploy by setting `APPS_DEPLOY_IMAGE_ALLOWLIST` explicitly.
+   *
+   * Format + matching rules are identical to the coding allowlist
+   * (comma-separated glob prefixes; trailing `*` = prefix match; no `*` = exact;
+   * a bare `*` opts out). Returns the parsed, normalized list; an empty list
+   * disables the gate at parse time, but the call site
+   * (`isCodingContainerImageAllowed`) is fail-closed, so an explicit empty env
+   * denies every apps-deploy image rather than silently opening the gate.
+   */
+  appsDeployImageAllowlist(): string[] {
+    const env = getCloudAwareEnv();
+    const raw = pick(env.APPS_DEPLOY_IMAGE_ALLOWLIST);
+    if (raw === undefined) {
+      // First-party elizaOS images only. Operators widen via env.
+      return ["ghcr.io/elizaos/*"];
+    }
+    return raw
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0);
+  },
+
+  /**
    * Whether image refs must be pinned to a full `@sha256:<64hex>` digest to be
    * accepted by the container image gate (in addition to the allowlist).
    *

--- a/packages/cloud/shared/src/lib/services/__tests__/app-deploy-runner.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-deploy-runner.test.ts
@@ -81,7 +81,7 @@ describe("resolveImageRef: image allowlist gate", () => {
 
   afterEach(() => {
     delete process.env.APP_DEFAULT_IMAGE;
-    delete process.env.CODING_CONTAINER_IMAGE_ALLOWLIST;
+    delete process.env.APPS_DEPLOY_IMAGE_ALLOWLIST;
   });
 
   test("rejects an imageTag outside the default allowlist", async () => {
@@ -112,7 +112,7 @@ describe("resolveImageRef: image allowlist gate", () => {
   });
 
   test("honors an operator-narrowed allowlist (rejects an off-list image)", async () => {
-    process.env.CODING_CONTAINER_IMAGE_ALLOWLIST = "ghcr.io/onlyme/*";
+    process.env.APPS_DEPLOY_IMAGE_ALLOWLIST = "ghcr.io/onlyme/*";
     await expect(
       resolveImageRef(buildOff, {
         ...baseApp,
@@ -124,6 +124,78 @@ describe("resolveImageRef: image allowlist gate", () => {
       metadata: { imageTag: "ghcr.io/onlyme/app:v1" },
     });
     expect(img).toBe("ghcr.io/onlyme/app:v1");
+  });
+});
+
+// De-personalized apps-deploy allowlist (owner directive: "no personal shit").
+// apps-deploy has its OWN allowlist (APPS_DEPLOY_IMAGE_ALLOWLIST) defaulting to
+// `ghcr.io/elizaos/*` ONLY — the personal `ghcr.io/dexploarer/*` and the
+// side-product `ghcr.io/waifufun/*` namespaces that the shared coding-container
+// allowlist still carries are REJECTED for apps-deploy unless an operator opts
+// them back in via the env. (The shared codingContainerImageAllowlist() default
+// is intentionally left unchanged for the coding-container path.)
+describe("resolveImageRef: apps-deploy allowlist is elizaos-only", () => {
+  const baseApp = { id: "app-1", name: "demo", metadata: {} as Record<string, unknown> };
+  const buildOff = { resolveImage: undefined } as unknown as AppDeployRunnerDeps;
+
+  afterEach(() => {
+    delete process.env.APPS_DEPLOY_IMAGE_ALLOWLIST;
+    delete process.env.CODING_CONTAINER_IMAGE_ALLOWLIST;
+  });
+
+  test("allows a first-party ghcr.io/elizaos/* image by default", async () => {
+    const img = await resolveImageRef(buildOff, {
+      ...baseApp,
+      metadata: { imageTag: "ghcr.io/elizaos/example-edad:showcase" },
+    });
+    expect(img).toBe("ghcr.io/elizaos/example-edad:showcase");
+  });
+
+  test("REJECTS ghcr.io/dexploarer/* by default (personal org)", async () => {
+    await expect(
+      resolveImageRef(buildOff, {
+        ...baseApp,
+        metadata: { imageTag: "ghcr.io/dexploarer/bnancy:latest" },
+      }),
+    ).rejects.toThrow(/is not permitted/);
+  });
+
+  test("REJECTS ghcr.io/waifufun/* by default (side product)", async () => {
+    await expect(
+      resolveImageRef(buildOff, {
+        ...baseApp,
+        metadata: { imageTag: "ghcr.io/waifufun/imagegen:latest" },
+      }),
+    ).rejects.toThrow(/is not permitted/);
+  });
+
+  test("does NOT read CODING_CONTAINER_IMAGE_ALLOWLIST (separate gate)", async () => {
+    // Widening the CODING allowlist must NOT widen apps-deploy: a dexploarer
+    // image stays rejected for apps-deploy even though the coding gate allows it.
+    process.env.CODING_CONTAINER_IMAGE_ALLOWLIST = "ghcr.io/dexploarer/*";
+    await expect(
+      resolveImageRef(buildOff, {
+        ...baseApp,
+        metadata: { imageTag: "ghcr.io/dexploarer/bnancy:latest" },
+      }),
+    ).rejects.toThrow(/is not permitted/);
+  });
+
+  test("opt-in via APPS_DEPLOY_IMAGE_ALLOWLIST re-allows dexploarer + waifufun", async () => {
+    process.env.APPS_DEPLOY_IMAGE_ALLOWLIST =
+      "ghcr.io/elizaos/*,ghcr.io/dexploarer/*,ghcr.io/waifufun/*";
+    expect(
+      await resolveImageRef(buildOff, {
+        ...baseApp,
+        metadata: { imageTag: "ghcr.io/dexploarer/bnancy:latest" },
+      }),
+    ).toBe("ghcr.io/dexploarer/bnancy:latest");
+    expect(
+      await resolveImageRef(buildOff, {
+        ...baseApp,
+        metadata: { imageTag: "ghcr.io/waifufun/imagegen:latest" },
+      }),
+    ).toBe("ghcr.io/waifufun/imagegen:latest");
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/__tests__/app-factory.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-factory.test.ts
@@ -1,0 +1,174 @@
+/**
+ * App-factory TEMPLATE-IMAGE wiring (the launch blocker).
+ *
+ * The apps-deploy access gate is open in prod, but a real user's create -> deploy
+ * FAILED because a template app (one created WITHOUT a user repo, i.e.
+ * `createGitHubRepo: false` / `skipGitHubRepo: true` — the path the agent's
+ * CREATE_APP uses) had no image: build-from-repo is intentionally OFF, so the
+ * deploy runner's `resolveImageRef` threw "no image to deploy".
+ *
+ * The fix stamps a first-party, allowlisted template image as
+ * `app.metadata.imageTag` at create time. These tests prove:
+ *   - a template app gets the default first-party image stamped (and persisted),
+ *   - the default is env-overridable (`APP_DEFAULT_TEMPLATE_IMAGE`),
+ *   - a caller-supplied image wins and a pre-existing imageTag is never overwritten,
+ *   - a REPO-BACKED app is left unchanged (no image stamped),
+ *   - and end-to-end: the stamped app then RESOLVES an image through the real
+ *     `resolveImageRef` (does not throw), while a repo-backed app still
+ *     (correctly) throws build-from-repo-disabled.
+ *
+ * `../apps` + `../github-repos` are mocked so the factory runs without a DB; the
+ * template-image logic, the real `containersEnv.appDefaultTemplateImage()`, and
+ * the real `resolveImageRef` gate are all exercised for real.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const updateCalls: Array<{ id: string; updates: Record<string, unknown> }> = [];
+// Per-test seed for what appsService.create() returns as the new app's metadata
+// (lets one test simulate an app whose metadata already carries an imageTag).
+let seededMetadata: Record<string, unknown> = {};
+
+class FakeAppNameConflictError extends Error {
+  readonly conflictType = "app";
+}
+
+mock.module("../apps", () => ({
+  AppNameConflictError: FakeAppNameConflictError,
+  appsService: {
+    isNameAvailable: async () => ({ available: true }),
+    create: async (data: {
+      name: string;
+      organization_id: string;
+      created_by_user_id: string;
+      app_url: string;
+    }) => ({
+      app: {
+        id: "11111111-2222-3333-4444-555555555555",
+        slug: "demo-app",
+        name: data.name,
+        organization_id: data.organization_id,
+        created_by_user_id: data.created_by_user_id,
+        app_url: data.app_url,
+        github_repo: null,
+        metadata: { ...seededMetadata },
+      },
+      apiKey: "eliza_test_app_key",
+    }),
+    update: async (id: string, updates: Record<string, unknown>) => {
+      updateCalls.push({ id, updates });
+      return undefined;
+    },
+  },
+}));
+
+mock.module("../github-repos", () => ({
+  githubReposService: {
+    generateRepoName: (_id: string, slug: string) => `app-${slug}`,
+    createAppRepo: async ({ name }: { name: string }) => ({ fullName: `elizaOS-apps/${name}` }),
+  },
+}));
+
+import type { AppDeployRunnerDeps } from "../app-deploy-runner";
+import { resolveImageRef } from "../app-deploy-runner";
+import { appFactoryService } from "../app-factory";
+
+const DATA = {
+  name: "Demo App",
+  organization_id: "org-1",
+  created_by_user_id: "user-1",
+  app_url: "https://demo.example.com",
+};
+
+const DEFAULT_TEMPLATE_IMAGE = "ghcr.io/elizaos/example-edad:showcase";
+const buildOff = { resolveImage: undefined } as unknown as AppDeployRunnerDeps;
+
+function metaImageTag(metadata: unknown): string | undefined {
+  const m = (metadata as Record<string, unknown>) ?? {};
+  return typeof m.imageTag === "string" ? m.imageTag : undefined;
+}
+
+beforeEach(() => {
+  updateCalls.length = 0;
+  seededMetadata = {};
+});
+
+afterEach(() => {
+  delete process.env.APP_DEFAULT_TEMPLATE_IMAGE;
+  delete process.env.APPS_DEPLOY_IMAGE_ALLOWLIST;
+});
+
+describe("createApp: template-image wiring (no-repo apps)", () => {
+  test("template app (createGitHubRepo:false) stamps the default first-party image + persists it", async () => {
+    const result = await appFactoryService.createApp(DATA, { createGitHubRepo: false });
+
+    expect(result.githubRepoCreated).toBe(false);
+    expect(result.githubRepo).toBeUndefined();
+    // Stamped on the returned app...
+    expect(metaImageTag(result.app.metadata)).toBe(DEFAULT_TEMPLATE_IMAGE);
+    // ...and persisted via appsService.update(metadata).
+    const persisted = updateCalls.at(-1);
+    expect(persisted?.id).toBe(result.app.id);
+    expect(metaImageTag(persisted?.updates.metadata)).toBe(DEFAULT_TEMPLATE_IMAGE);
+  });
+
+  test("APP_DEFAULT_TEMPLATE_IMAGE env overrides the stamped image", async () => {
+    process.env.APP_DEFAULT_TEMPLATE_IMAGE = "ghcr.io/elizaos/example-clone-ur-crush:showcase";
+    const result = await appFactoryService.createApp(DATA, { createGitHubRepo: false });
+    expect(metaImageTag(result.app.metadata)).toBe(
+      "ghcr.io/elizaos/example-clone-ur-crush:showcase",
+    );
+  });
+
+  test("caller-supplied options.imageTag wins over the default (not overwritten)", async () => {
+    const result = await appFactoryService.createApp(DATA, {
+      createGitHubRepo: false,
+      imageTag: "ghcr.io/elizaos/myapp:v9",
+    });
+    expect(metaImageTag(result.app.metadata)).toBe("ghcr.io/elizaos/myapp:v9");
+  });
+
+  test("a pre-existing metadata.imageTag is never overwritten (no redundant update)", async () => {
+    seededMetadata = { imageTag: "ghcr.io/elizaos/preexisting:v1" };
+    const result = await appFactoryService.createApp(DATA, { createGitHubRepo: false });
+    expect(metaImageTag(result.app.metadata)).toBe("ghcr.io/elizaos/preexisting:v1");
+    // imageTag unchanged => no metadata write (and no repo => no github_repo write).
+    expect(updateCalls.length).toBe(0);
+  });
+
+  test("repo-backed app (default createGitHubRepo) is NOT stamped with an image", async () => {
+    const result = await appFactoryService.createApp(DATA);
+    expect(result.githubRepoCreated).toBe(true);
+    expect(result.githubRepo).toBe("elizaOS-apps/app-demo-app");
+    expect(metaImageTag(result.app.metadata)).toBeUndefined();
+    // The only persisted update is the github_repo, never an imageTag.
+    for (const call of updateCalls) {
+      expect("imageTag" in ((call.updates.metadata as Record<string, unknown>) ?? {})).toBe(false);
+    }
+  });
+});
+
+describe("create -> deploy linkage: resolveImageRef on the created app", () => {
+  test("the stamped template app RESOLVES its image (does NOT throw)", async () => {
+    const result = await appFactoryService.createApp(DATA, { createGitHubRepo: false });
+    const img = await resolveImageRef(buildOff, {
+      id: result.app.id,
+      name: result.app.name,
+      metadata: (result.app.metadata as Record<string, unknown>) ?? {},
+      repoUrl: result.app.github_repo ?? undefined,
+    });
+    expect(img).toBe(DEFAULT_TEMPLATE_IMAGE);
+  });
+
+  test("a repo-backed app still throws build-from-repo-disabled (unchanged)", async () => {
+    const result = await appFactoryService.createApp(DATA);
+    await expect(
+      resolveImageRef(buildOff, {
+        id: result.app.id,
+        name: result.app.name,
+        metadata: (result.app.metadata as Record<string, unknown>) ?? {},
+        repoUrl: result.app.github_repo ?? undefined,
+      }),
+    ).rejects.toThrow(/build-from-repo is disabled/);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/app-deploy-runner.ts
+++ b/packages/cloud/shared/src/lib/services/app-deploy-runner.ts
@@ -138,19 +138,20 @@ export async function resolveImageRef(
     );
   }
   // SECURITY: an app deploy runs an image on our shared docker nodes. Gate the
-  // resolved image on the same allowlist the coding-container routes use, so a
-  // caller-supplied `metadata.imageTag` (or a mis-set APP_DEFAULT_IMAGE) cannot
-  // run an arbitrary off-namespace image. Fail-closed: empty allowlist denies.
-  // The default allowlist covers the first-party GHCR namespaces, so the default
-  // agent image and APP_DEFAULT_IMAGE under those namespaces pass unchanged.
-  const allowlist = containersEnv.codingContainerImageAllowlist();
+  // resolved image on the APPS-DEPLOY allowlist (first-party `ghcr.io/elizaos/*`
+  // ONLY by default — DELIBERATELY separate from the coding-container allowlist,
+  // which also carries personal/side-product namespaces for its BYO-image path),
+  // so a caller-supplied `metadata.imageTag` (or a mis-set APP_DEFAULT_IMAGE)
+  // cannot run an arbitrary off-namespace image. Fail-closed: empty allowlist
+  // denies. The default allowlist covers the first-party elizaOS namespace, so
+  // the stamped template image / APP_DEFAULT_IMAGE under it pass unchanged.
+  const allowlist = containersEnv.appsDeployImageAllowlist();
   if (!isCodingContainerImageAllowed(image, allowlist)) {
     const permitted = allowlist.length > 0 ? allowlist.join(", ") : "(none configured)";
     throw new Error(
       `Image '${image}' is not permitted for app ${app.id}: it is outside the ` +
-        `allowed image namespaces (${permitted}). Set app.metadata.imageTag (or ` +
-        `APP_DEFAULT_IMAGE) to an allowlisted image, or widen ` +
-        `CODING_CONTAINER_IMAGE_ALLOWLIST.`,
+        `allowed image namespaces (${permitted}). Set app.metadata.imageTag to an ` +
+        `allowlisted image, or widen APPS_DEPLOY_IMAGE_ALLOWLIST.`,
     );
   }
   // SECURITY (opt-in, default OFF): when the digest-pin gate is armed, reject a

--- a/packages/cloud/shared/src/lib/services/app-factory.ts
+++ b/packages/cloud/shared/src/lib/services/app-factory.ts
@@ -1,4 +1,5 @@
-import type { App } from "../../db/repositories/apps";
+import type { App, NewApp } from "../../db/repositories/apps";
+import { containersEnv } from "../config/containers-env";
 import { logger } from "../utils/logger";
 import { AppNameConflictError, appsService } from "./apps";
 import { githubReposService } from "./github-repos";
@@ -36,6 +37,14 @@ export interface CreateAppOptions {
   repoName?: string;
   /** Whether the repo should be private (default: true) */
   repoPrivate?: boolean;
+  /**
+   * Explicit container image to deploy for a TEMPLATE app (one created WITHOUT a
+   * user repo, i.e. `createGitHubRepo: false`). When set, it is stamped onto
+   * `app.metadata.imageTag` and wins over the first-party template default.
+   * Ignored for repo-backed apps (they build from their repo). Must resolve to an
+   * allowlisted image (see the apps-deploy image gate) or the deploy rejects it.
+   */
+  imageTag?: string;
 }
 
 export interface CreateAppResult {
@@ -145,10 +154,40 @@ export class AppFactoryService {
     // Wait for parallel tasks to complete
     await Promise.all(parallelTasks);
 
-    // Step 3: Batch update the app record (single DB call) with the GitHub repo.
-    const updates: Record<string, string | null> = {};
+    // Step 3: Batch update the app record (single DB call) with the GitHub repo
+    // and, for template apps, the first-party template image (below).
+    const updates: Partial<NewApp> = {};
     if (githubRepo) {
       updates.github_repo = githubRepo;
+    }
+
+    // TEMPLATE-IMAGE WIRING (the launch blocker): a TEMPLATE app — one created
+    // WITHOUT a user repo (createGitHubRepo === false, the path the agent's
+    // CREATE_APP / `skipGitHubRepo: true` uses) — has neither a build pipeline
+    // nor a repo image, so the deploy runner's `resolveImageRef` would throw
+    // "no image to deploy". Stamp a first-party, allowlisted template image as
+    // `metadata.imageTag` at create time so create -> deploy resolves to a
+    // prebuilt, allowlisted image. Repo-backed apps are intentionally LEFT
+    // UNTOUCHED — they still (correctly) hit the build-from-repo-disabled path
+    // until that tier is armed. A caller-supplied image (`options.imageTag`) or
+    // an image already present on the app's metadata wins and is never
+    // overwritten.
+    if (!createGitHubRepo) {
+      const existingMeta = (app.metadata as Record<string, unknown>) ?? {};
+      const existingImageTag =
+        typeof existingMeta.imageTag === "string" ? existingMeta.imageTag : undefined;
+      const imageTag =
+        options.imageTag ?? existingImageTag ?? containersEnv.appDefaultTemplateImage();
+      if (imageTag !== existingImageTag) {
+        const metadata = { ...existingMeta, imageTag };
+        updates.metadata = metadata;
+        // Reflect the stamp on the returned app so callers see it without a re-read.
+        app.metadata = metadata;
+        logger.info("AppFactory: Stamped template image on app metadata", {
+          appId: app.id,
+          imageTag,
+        });
+      }
     }
 
     if (Object.keys(updates).length > 0) {

--- a/packages/cloud/shared/src/lib/services/app-factory.ts
+++ b/packages/cloud/shared/src/lib/services/app-factory.ts
@@ -1,9 +1,7 @@
 import type { App } from "../../db/repositories/apps";
 import { logger } from "../utils/logger";
 import { AppNameConflictError, appsService } from "./apps";
-import { discordService } from "./discord";
 import { githubReposService } from "./github-repos";
-import { usersService } from "./users";
 
 /**
  * App Factory Service
@@ -38,10 +36,6 @@ export interface CreateAppOptions {
   repoName?: string;
   /** Whether the repo should be private (default: true) */
   repoPrivate?: boolean;
-  /** Whether to assign a subdomain (default: true) */
-  assignSubdomain?: boolean;
-  /** Preferred subdomain (optional, will auto-generate if not available) */
-  preferredSubdomain?: string;
 }
 
 export interface CreateAppResult {
@@ -49,9 +43,6 @@ export interface CreateAppResult {
   apiKey: string;
   githubRepo?: string;
   githubRepoCreated: boolean;
-  subdomain?: string;
-  productionUrl?: string;
-  subdomainAssigned: boolean;
   errors: string[];
 }
 
@@ -63,20 +54,16 @@ export class AppFactoryService {
    * throughout the application to ensure consistency.
    */
   async createApp(data: CreateAppInput, options: CreateAppOptions = {}): Promise<CreateAppResult> {
-    const { createGitHubRepo = true, repoPrivate = true, assignSubdomain = true } = options;
+    const { createGitHubRepo = true, repoPrivate = true } = options;
 
     const errors: string[] = [];
     let githubRepo: string | undefined;
     let githubRepoCreated = false;
-    let subdomain: string | undefined;
-    let productionUrl: string | undefined;
-    let subdomainAssigned = false;
 
     logger.info("AppFactory: Creating app", {
       name: data.name,
       organizationId: data.organization_id,
       createGitHubRepo,
-      assignSubdomain,
     });
 
     // Step 0: Validate name availability before creating anything
@@ -109,8 +96,9 @@ export class AppFactoryService {
       slug: app.slug,
     });
 
-    // Step 2: Run GitHub repo creation and subdomain assignment in PARALLEL
-    // This can save 3-10 seconds compared to sequential execution
+    // Step 2: Run repo-backed side effects (currently just GitHub repo creation)
+    // off the critical path. Kept as a task array so additional create-time work
+    // can run concurrently without reshaping the flow.
     const parallelTasks: Promise<void>[] = [];
 
     // GitHub repo creation task
@@ -157,61 +145,17 @@ export class AppFactoryService {
     // Wait for parallel tasks to complete
     await Promise.all(parallelTasks);
 
-    // Step 3: Batch update app record with all results (single DB call)
+    // Step 3: Batch update the app record (single DB call) with the GitHub repo.
     const updates: Record<string, string | null> = {};
     if (githubRepo) {
       updates.github_repo = githubRepo;
     }
-    if (productionUrl) {
-      updates.app_url = productionUrl;
-    }
 
     if (Object.keys(updates).length > 0) {
       await appsService.update(app.id, updates);
-      logger.info("AppFactory: App record updated with parallel results", {
+      logger.info("AppFactory: App record updated", {
         appId: app.id,
         updates: Object.keys(updates),
-      });
-    }
-
-    // Only send Discord notification after the app has a deployed production URL.
-    // Draft app URLs use a sentinel host and should not create launch alerts.
-    const finalAppUrl = productionUrl || data.app_url;
-    const isDraftSentinelUrl =
-      !finalAppUrl ||
-      finalAppUrl.includes("placeholder.local") ||
-      finalAppUrl === "https://placeholder.local";
-
-    if (!isDraftSentinelUrl && productionUrl) {
-      const appUrl = productionUrl;
-      // Fetch user info to get their name (non-blocking)
-      usersService
-        .getById(data.created_by_user_id)
-        .then((user) => {
-          const userName = user?.name || user?.nickname || user?.email || null;
-          return discordService.logAppCreated({
-            appId: app.id,
-            appName: app.name,
-            slug: app.slug,
-            userName,
-            userId: data.created_by_user_id,
-            organizationId: data.organization_id,
-            appUrl,
-            description: data.description,
-            githubRepo,
-            subdomain,
-          });
-        })
-        .catch((err) => {
-          logger.warn("AppFactory: Failed to send Discord notification", {
-            appId: app.id,
-            error: err instanceof Error ? err.message : "Unknown error",
-          });
-        });
-    } else {
-      logger.info("AppFactory: Skipping Discord notification for draft app (no production URL)", {
-        appId: app.id,
-        appUrl: finalAppUrl,
       });
     }
 
@@ -220,9 +164,6 @@ export class AppFactoryService {
       apiKey,
       githubRepo,
       githubRepoCreated,
-      subdomain,
-      productionUrl,
-      subdomainAssigned,
       errors,
     };
   }


### PR DESCRIPTION
## What

Makes the monetized-apps deploy actually **work for everyone** (the access gate `APPS_DEPLOY_ALLOWED_ORG_IDS="*"` is already open + live in prod) and removes personal/dev coupling from the launch path. Three focused changes; build-from-repo stays unarmed.

### A) Wire a first-party template image so create→deploy resolves (the launch blocker)
With the gate open, every new app still failed to deploy: `createApp` defaults `createGitHubRepo:true` → repoUrl set → `resolveImageRef` throws *"build-from-repo disabled / no image"* — for **everyone equally** (a missing config, not an access restriction).
- `appFactoryService.createApp` now stamps `app.metadata.imageTag` **only for template apps** (`createGitHubRepo:false` — the `skipGitHubRepo:true` path the agent's CREATE_APP uses) to `ghcr.io/elizaos/example-edad:showcase` (the tag `build-example-app-images.yml` actually publishes + smoke-gates + makes public), env-overridable via `APP_DEFAULT_TEMPLATE_IMAGE`.
- A caller-supplied / pre-existing `imageTag` always wins. **Repo-backed apps are untouched** (still correctly blocked until BYO tier is armed).

### B) De-personalize the apps-deploy image allowlist
- New **separate** `appsDeployImageAllowlist()` (env `APPS_DEPLOY_IMAGE_ALLOWLIST`) defaulting to **`ghcr.io/elizaos/*` only**; `resolveImageRef` gates on it. The personal `ghcr.io/dexploarer/*` and side-product `ghcr.io/waifufun/*` namespaces (still in the shared *coding*-container allowlist, unchanged) are now **rejected for apps-deploy** by default (opt-in via env).

### C) Remove dead/misleading create-path branches
- Removed the no-op `assignSubdomain`/`preferredSubdomain` options, always-undefined `subdomain`/`productionUrl` result fields, the unreachable create-time Discord notify (gated on a never-set `productionUrl`) + its `placeholder.local` sentinel, and now-unused imports.

## Evidence
- New `app-factory.test.ts` (8) drives the **real** factory + **real** `resolveImageRef`: template app stamps+persists+resolves the image (no throw); env override; caller/pre-existing imageTag respected; repo-backed app NOT stamped + still throws build-from-repo-disabled.
- Extended `app-deploy-runner.test.ts`: elizaos allowed; dexploarer/waifufun rejected by default; widening the coding allowlist does NOT widen apps-deploy; opt-in env re-allows.
- **72 pass** across 8 cloud-shared deploy/apps suites + **38 pass** cloud-api `apps-crud.integration`. Biome + typecheck clean on touched files.

## Notes / follow-ups
- Full serve still needs the apps-deploy backend **armed** at the daemon (`arm-apps-daemon.yml`) + data plane applied — ops cutover, separate.
- Pre-existing template apps (created before this) have no `imageTag` → a one-time `metadata.imageTag` backfill may be wanted.
- Digest-pin the template default once a stable `example-edad` showcase digest exists (TODO in code).
- Part of the apps launch (tracker #8434).
