### PR TITLE
ci(cloud): run production deploy on github-hosted runners

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -81,7 +81,7 @@ jobs:
   # ---------------------------------------------------------------------------
   deploy-api:
     name: Deploy API Worker
-    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON((github.ref == 'refs/heads/main' || github.event_name == 'pull_request') && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     if: github.event_name != 'pull_request'
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -225,7 +225,7 @@ jobs:
   # ---------------------------------------------------------------------------
   deploy-console:
     name: Deploy Console (Pages · elizacloud.ai)
-    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON((github.ref == 'refs/heads/main' || github.event_name == 'pull_request') && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -391,7 +391,7 @@ jobs:
   # ---------------------------------------------------------------------------
   deploy-app:
     name: Deploy App (Pages · app.elizacloud.ai)
-    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
+    runs-on: ${{ fromJSON((github.ref == 'refs/heads/main' || github.event_name == 'pull_request') && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}


### PR DESCRIPTION
## Summary
- route `main` Cloud CF Deploy jobs to `ubuntu-latest` instead of the self-hosted `hetzner-robot` pool
- keep PR deploy checks on GitHub-hosted runners and leave non-main deploys on the existing self-hosted pool
- no app/onboarding/runtime code changes

## Why
The production deploy for the Cloud onboarding fix was blocked after #10295 merged: two attempts on `main` reached the self-hosted deploy pool, then all three jobs stayed in `actions/checkout` for several minutes before I cancelled them. This keeps the normal production deploy workflow path, but avoids the unhealthy runner pool for launch-critical production deploys.

## Validation
- `actionlint .github/workflows/cloud-cf-deploy.yml`
- `git diff --check`

After merge I will watch the new `main` deploy and run the production onboarding/auth smoke against `https://app.elizacloud.ai`.
