### PR TITLE
chore(post-swarm): billing/privesc regression tests + 2 cleanups (follow-up to #10260–#10277)

### DIFF
--- a/packages/cloud/api/__tests__/agent-a2a-billing.test.ts
+++ b/packages/cloud/api/__tests__/agent-a2a-billing.test.ts
@@ -1,12 +1,22 @@
 /**
- * Agent MCP billing invariants for monetized agents.
+ * Agent A2A billing invariants for monetized agents — companion to
+ * agent-mcp-billing.test.ts.
  *
- * The route must reserve the marked-up estimate up front and must not credit
- * creator earnings unless final reconciliation confirms the consumer charge was
- * collected.
+ * Regression for #10266: the A2A chat path settles the consumer org with
+ * reservation.reconcile(actualTotal), THEN records creator earnings in the same
+ * try. recordCreatorEarnings can throw on a transient DB error; the pre-fix code
+ * let it reach the outer catch, which ran the NON-idempotent reconcile(0) —
+ * double-refunding the WHOLE reservation (free inference + a net credit grant)
+ * and returning a -32000 error. The fix swallows the earnings error so reconcile
+ * fires exactly once and the already-correct settlement response is returned.
+ *
+ * `handleChat` is module-private, so we drive it through the exported Hono app's
+ * POST handler (method "chat"), mounted under `/agents/:id/a2a` so the `:id`
+ * param resolves (mirrors app-charge-public-route.test.ts).
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
 // `mock.module` is process-global: spread the real auth module so this file's
 // partial mock (only `requireUserOrApiKeyWithOrg`) does not drop the other auth
 // exports (e.g. `requireUserOrApiKey`) for later test files in the same run.
@@ -47,6 +57,7 @@ mock.module("@/lib/services/agent-monetization", () => ({
 }));
 
 const reserve = mock();
+const charactersGetById = mock();
 class InsufficientCreditsError extends Error {
   constructor(
     public readonly required: number,
@@ -62,12 +73,13 @@ mock.module("@/lib/services/credits", () => ({
 }));
 
 mock.module("@/lib/services/characters/characters", () => ({
-  charactersService: { getById: mock() },
+  charactersService: { getById: charactersGetById },
 }));
 
+const requireUserOrApiKeyWithOrg = mock();
 mock.module("@/lib/auth/workers-hono-auth", () => ({
   ...workersHonoAuthActual,
-  requireUserOrApiKeyWithOrg: mock(),
+  requireUserOrApiKeyWithOrg,
 }));
 
 mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
@@ -83,20 +95,15 @@ mock.module("@/lib/utils/logger", () => ({
   },
 }));
 
-const { handleToolCall } = await import("../agents/[id]/mcp/route");
+const { default: a2aRoute } = await import("../agents/[id]/a2a/route");
+
+const app = new Hono();
+app.route("/agents/:id/a2a", a2aRoute);
 
 function textStream(text: string) {
   return (async function* stream() {
     yield text;
   })();
-}
-
-function makeContext() {
-  return {
-    env: {},
-    json: (body: unknown, status?: number) =>
-      Response.json(body, { status: status ?? 200 }),
-  };
 }
 
 function makeCharacter() {
@@ -105,10 +112,14 @@ function makeCharacter() {
     name: "Markup Agent",
     user_id: "owner-1",
     organization_id: "creator-org",
+    is_public: true,
+    a2a_enabled: true,
     monetization_enabled: true,
     inference_markup_percentage: "500",
     system: null,
     bio: "Helpful.",
+    category: null,
+    tags: [],
     settings: {},
   };
 }
@@ -131,16 +142,24 @@ function makeReservation(reconcileResult: {
   return reconcile;
 }
 
-async function callChat() {
-  return handleToolCall(
-    makeContext() as never,
-    makeCharacter(),
+function callChat() {
+  return app.request(
+    "/agents/agent-1/a2a",
     {
-      name: "chat",
-      arguments: { message: "hello", model: "gpt-5-mini" },
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        method: "chat",
+        params: {
+          model: "gpt-5-mini",
+          messages: [{ role: "user", content: "hello" }],
+        },
+        id: "rpc-1",
+      }),
     },
-    "rpc-1",
-    { id: USER_ID, organization_id: ORG_ID },
+    // Worker Bindings (c.env): the route reads ANTHROPIC_COT_* off it.
+    {},
   );
 }
 
@@ -152,7 +171,14 @@ beforeEach(() => {
   getProviderFromModel.mockClear();
   recordCreatorEarnings.mockReset();
   reserve.mockReset();
+  charactersGetById.mockReset();
+  requireUserOrApiKeyWithOrg.mockReset();
 
+  charactersGetById.mockResolvedValue(makeCharacter());
+  requireUserOrApiKeyWithOrg.mockResolvedValue({
+    id: USER_ID,
+    organization_id: ORG_ID,
+  });
   estimateRequestCost.mockResolvedValue(0.01);
   calculateCost.mockResolvedValue({ totalCost: 0.01 });
   streamText.mockResolvedValue({
@@ -166,25 +192,17 @@ beforeEach(() => {
   recordCreatorEarnings.mockResolvedValue(undefined);
 });
 
-describe("Agent MCP billing", () => {
-  test("reserves the marked-up estimate before invoking the model", async () => {
+describe("Agent A2A billing", () => {
+  test("settles once and records creator earnings on the happy path", async () => {
     const reconcile = makeReservation({ adjustmentType: "none" });
 
     const response = await callChat();
+    const body = (await response.json()) as {
+      result?: { content: string };
+      error?: { code: number };
+    };
 
     expect(response.status).toBe(200);
-    expect(reserve).toHaveBeenCalledTimes(1);
-    const reserveParams = reserve.mock.calls[0]?.[0] as { amount: number };
-    expect(reserveParams).toMatchObject({
-      organizationId: ORG_ID,
-      userId: USER_ID,
-      description: "Agent MCP: Markup Agent (gpt-5-mini)",
-    });
-    expect(reserveParams.amount).toBeCloseTo(0.06, 12);
-    expect(streamText).toHaveBeenCalledTimes(1);
-    expect(reserve.mock.invocationCallOrder[0]).toBeLessThan(
-      streamText.mock.invocationCallOrder[0],
-    );
     expect(reconcile).toHaveBeenCalledTimes(1);
     expect(reconcile.mock.calls[0]?.[0]).toBeCloseTo(0.06, 12);
     expect(recordCreatorEarnings).toHaveBeenCalledWith(
@@ -192,38 +210,14 @@ describe("Agent MCP billing", () => {
         agentId: "agent-1",
         earnings: 0.05,
         consumerOrgId: ORG_ID,
-        protocol: "mcp",
+        protocol: "a2a",
       }),
     );
-    expect(reconcile.mock.invocationCallOrder[0]).toBeLessThan(
-      recordCreatorEarnings.mock.invocationCallOrder[0],
-    );
+    expect(body.error).toBeUndefined();
+    expect(body.result?.content).toBe("hello from model");
   });
 
-  test("does not record creator earnings when final overage is uncollected", async () => {
-    makeReservation({ adjustmentType: "uncollected_overage" });
-    calculateCost.mockResolvedValue({ totalCost: 0.02 });
-
-    const response = await callChat();
-    const body = (await response.json()) as {
-      error?: { code: number; message: string };
-    };
-
-    expect(response.status).toBe(200);
-    expect(body.error).toEqual({
-      code: -32003,
-      message: "Insufficient credits for final usage cost",
-    });
-    expect(recordCreatorEarnings).not.toHaveBeenCalled();
-  });
-
-  // Regression for #10266: a post-settlement earnings failure must NOT trigger a
-  // second reconcile. The consumer is settled with reconcile(actualTotal); if
-  // recordCreatorEarnings throws, the pre-fix code let it reach the outer catch,
-  // which ran the NON-idempotent reconcile(0) — double-refunding the WHOLE
-  // reservation (free inference + a net credit grant) and returning an error.
-  // The fix swallows the earnings error so reconcile fires exactly once and the
-  // already-correct settlement response is returned.
+  // Regression for #10266 (A2A side).
   test("post-settlement earnings failure does not double-refund the reservation", async () => {
     const reconcile = makeReservation({ adjustmentType: "none" });
     recordCreatorEarnings.mockRejectedValue(
@@ -232,21 +226,21 @@ describe("Agent MCP billing", () => {
 
     const response = await callChat();
     const body = (await response.json()) as {
-      result?: { content: Array<{ type: string; text: string }> };
+      result?: { content: string };
       error?: { code: number; message: string };
     };
 
     expect(response.status).toBe(200);
 
-    // The reservation is reconciled EXACTLY ONCE, with the real settled total
-    // (not the double-refund reconcile(0) from the outer catch).
+    // Reconciled EXACTLY ONCE with the real settled total — never the outer
+    // catch's double-refund reconcile(0).
     expect(reconcile).toHaveBeenCalledTimes(1);
     expect(reconcile.mock.calls[0]?.[0]).toBeCloseTo(0.06, 12);
 
-    // The earnings step was attempted (and failed) — but the request still
-    // returns the successful settlement, never the -32000 outer-catch error.
+    // Earnings attempted (and failed) but the request still returns the
+    // successful settlement, not the -32000 outer-catch error.
     expect(recordCreatorEarnings).toHaveBeenCalledTimes(1);
     expect(body.error).toBeUndefined();
-    expect(body.result?.content?.[0]?.text).toBe("hello from model");
+    expect(body.result?.content).toBe("hello from model");
   });
 });

--- a/packages/cloud/api/__tests__/user-email-route.test.ts
+++ b/packages/cloud/api/__tests__/user-email-route.test.ts
@@ -1,0 +1,143 @@
+/**
+ * PATCH /api/v1/user/email — defense-in-depth gate (#10272).
+ *
+ * This self-service route sets `email_verified = false` with NO ownership proof,
+ * so it must NOT accept a privileged-domain (`@elizalabs.ai`) address: an
+ * unverified admin-domain email is a super_admin grant vector. The route calls
+ * `isElizaLabsAdminEmail` and returns 403 before touching the users table.
+ *
+ * The admin-grant logic itself (`isElizaLabsAdminEmail`, the verified-email
+ * super_admin gate) is covered by
+ * `packages/cloud/shared/src/lib/services/__tests__/admin-email.test.ts` — this
+ * file asserts the ROUTE-level rejection, which did not exist before the fix.
+ *
+ * `bun:test`'s `mock.module` is hoisted-import-aware and process-global: register
+ * mocks BEFORE importing the route module, and spread real modules so only the
+ * exports this file shadows are replaced.
+ */
+
+import { afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
+// `mock.module` is process-global in Bun's single-process run: a PARTIAL mock of
+// a shared module drops its other real exports for every later importer in the
+// run. Spread the real modules so only the exports this file shadows are
+// replaced (cf. users-me-wallet-attach.test.ts).
+import * as workersHonoAuthActual from "@/lib/auth/workers-hono-auth";
+
+const requireUserOrApiKey =
+  mock<(c: unknown) => Promise<{ id: string }>>();
+const getById =
+  mock<(id: string) => Promise<{ email: string | null } | undefined>>();
+const getByEmail =
+  mock<(email: string) => Promise<{ id: string } | undefined>>();
+const update =
+  mock<(id: string, data: Record<string, unknown>) => Promise<unknown>>();
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  ...workersHonoAuthActual,
+  requireUserOrApiKey,
+}));
+
+mock.module("@/lib/services/users", () => ({
+  usersService: { getById, getByEmail, update },
+}));
+
+// `@/lib/services/admin` is mocked to avoid pulling its DB-client graph (a real
+// import hangs on connect at module load). `isElizaLabsAdminEmail` is a faithful
+// copy of the real one-liner (admin.ts:
+// `email?.trim().toLowerCase().endsWith("@elizalabs.ai")`); the real function and
+// the super_admin grant gate are unit-tested in admin-email.test.ts. This keeps
+// the route's WIRING (does it call the gate and return 403?) as the unit under
+// test. Each cloud-api test file runs in its own process (test/run-unit-isolated.mjs),
+// so this partial module override cannot leak into other files.
+mock.module("@/lib/services/admin", () => ({
+  isElizaLabsAdminEmail: (email?: string | null): boolean =>
+    Boolean(email?.trim().toLowerCase().endsWith("@elizalabs.ai")),
+}));
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => {
+    await next();
+  },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+    debug: () => undefined,
+  },
+}));
+
+let emailRoute: { default: { fetch: (req: Request) => Promise<Response> } };
+
+beforeAll(async () => {
+  emailRoute = (await import(
+    "../v1/user/email/route"
+  )) as typeof emailRoute;
+});
+
+function patchEmail(email: string) {
+  return new Request("http://test.local/", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email }),
+  });
+}
+
+afterEach(() => {
+  requireUserOrApiKey.mockReset();
+  getById.mockReset();
+  getByEmail.mockReset();
+  update.mockReset();
+});
+
+describe("PATCH /api/v1/user/email — privileged-domain rejection", () => {
+  test("rejects an @elizalabs.ai address with 403 and never writes it", async () => {
+    requireUserOrApiKey.mockResolvedValue({ id: "user-1" });
+    // User has no email yet (the only state where the route would otherwise set one).
+    getById.mockResolvedValue({ email: null });
+
+    const res = await emailRoute.default.fetch(
+      patchEmail("attacker@elizalabs.ai"),
+    );
+
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toContain("cannot be set here");
+    // The gate must fire BEFORE the uniqueness check and the write.
+    expect(getByEmail).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  test("rejects @elizalabs.ai case-insensitively (mixed case + padding)", async () => {
+    requireUserOrApiKey.mockResolvedValue({ id: "user-1" });
+    getById.mockResolvedValue({ email: null });
+
+    const res = await emailRoute.default.fetch(
+      patchEmail("ATTACKER@ELIZALABS.AI"),
+    );
+
+    expect(res.status).toBe(403);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  test("still allows a normal address through to the write", async () => {
+    requireUserOrApiKey.mockResolvedValue({ id: "user-1" });
+    getById.mockResolvedValue({ email: null });
+    getByEmail.mockResolvedValue(undefined);
+    update.mockResolvedValue(undefined);
+
+    const res = await emailRoute.default.fetch(patchEmail("user@gmail.com"));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { success: boolean };
+    expect(body.success).toBe(true);
+    expect(update).toHaveBeenCalledWith("user-1", {
+      email: "user@gmail.com",
+      email_verified: false,
+    });
+  });
+});

--- a/packages/cloud/shared/src/lib/eliza/agent-loader.ts
+++ b/packages/cloud/shared/src/lib/eliza/agent-loader.ts
@@ -6,7 +6,6 @@ import {
   type Provider,
   parseCharacter,
 } from "@elizaos/core";
-import { cloudAppsPlugin } from "@elizaos/plugin-cloud-apps";
 import { memoriesRepository } from "../../db/repositories/agents/memories";
 import { charactersService } from "../services/characters/characters";
 import type { ElizaCharacter } from "../types/eliza-character";
@@ -241,6 +240,10 @@ export class AgentLoader {
     // provider reach cloud-hosted agents. Gated OFF by default — see
     // isCloudAppsPluginEnabled — because it loads on every dedicated prod agent.
     if (isCloudAppsPluginEnabled(characterSettings)) {
+      // Lazy-load so the default-OFF gate actually avoids the import cost: a
+      // static top-level import would pull @elizaos/plugin-cloud-apps (+ the
+      // cloud SDK) into every dedicated prod agent regardless of the flag.
+      const { cloudAppsPlugin } = await import("@elizaos/plugin-cloud-apps");
       plugins.push(asPlugin(cloudAppsPlugin));
       logger.info("[AgentLoader] Cloud Apps plugin enabled (read-core)");
     }

--- a/packages/cloud/shared/src/lib/services/__tests__/ad-campaign-credit-reconciliation.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/ad-campaign-credit-reconciliation.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Ad-campaign budget credit reconciliation on update + delete (#10265).
+ *
+ * createCampaign charges budget*markup up front (stored as credits_allocated).
+ * Two money leaks were fixed:
+ *
+ *  - deleteCampaign refunded `credits_allocated - credits_spent`, but
+ *    credits_spent is never written, so every delete refunded 100% of the
+ *    prepaid budget + markup regardless of real ad spend ("free advertising").
+ *    The fix refunds only the UNUSED fraction, derived from the real recorded
+ *    spend (total_spend / budget_amount) scaled by credits_allocated.
+ *
+ *  - updateCampaign pushed a new budget LIVE to the ad platform but charged
+ *    nothing for an increase and refunded nothing for a decrease. The fix
+ *    charges the credit delta BEFORE pushing an increase live (fail-CLOSED on
+ *    insufficient balance — never calls the platform), refunds the delta if the
+ *    platform then rejects the increase, and refunds a decrease after the
+ *    platform accepts it. A name-only change charges/refunds nothing.
+ *
+ * Tests the REAL advertisingService; only the repository, credentials, provider,
+ * and creditsService boundaries are spied (no `mock.module`, so nothing leaks).
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  spyOn,
+  test,
+} from "bun:test";
+import {
+  adAccountsRepository,
+  adCampaignsRepository,
+  adTransactionsRepository,
+} from "../../../db/repositories";
+import { creditsService } from "../credits";
+import type { AdProvider } from "../advertising/types";
+import { advertisingService } from "../advertising";
+
+const ORG_ID = "org-1";
+const CAMPAIGN_ID = "campaign-1";
+
+const spies: Array<{ mockRestore: () => void }> = [];
+function track<T extends { mockRestore: () => void }>(s: T): T {
+  spies.push(s);
+  return s;
+}
+
+/** Base campaign row; override per test. credits_allocated = budget * 1.1. */
+function makeCampaign(over: Record<string, unknown> = {}) {
+  return {
+    id: CAMPAIGN_ID,
+    organization_id: ORG_ID,
+    ad_account_id: "acct-1",
+    name: "My Campaign",
+    external_campaign_id: null as string | null,
+    budget_amount: "100",
+    budget_currency: "USD",
+    credits_allocated: "110",
+    credits_spent: "0",
+    total_spend: "0",
+    total_impressions: 0,
+    total_clicks: 0,
+    total_conversions: 0,
+    ...over,
+  };
+}
+
+function stubProvider(over: Partial<AdProvider> = {}): AdProvider {
+  return {
+    platform: "meta",
+    updateCampaign: async () => ({ success: true }),
+    deleteCampaign: async () => ({ success: true }),
+    ...over,
+  } as unknown as AdProvider;
+}
+
+afterEach(() => {
+  for (const s of spies.splice(0)) s.mockRestore();
+});
+
+describe("deleteCampaign — refunds only the UNUSED budget fraction", () => {
+  beforeEach(() => {
+    // Not synced to a platform → no platform delete, no metrics refresh; the
+    // stored total_spend is used directly (the simplest path through the fix).
+    track(spyOn(adCampaignsRepository, "delete").mockResolvedValue(undefined));
+  });
+
+  test("budget 100 / allocated 110 / spent 40 → refunds 66, not the full 110", async () => {
+    track(
+      spyOn(adCampaignsRepository, "findById").mockResolvedValue(
+        makeCampaign({ total_spend: "40" }) as never,
+      ),
+    );
+    const refund = track(
+      spyOn(creditsService, "refundCredits").mockResolvedValue({
+        success: true,
+      } as never),
+    );
+    track(
+      spyOn(adTransactionsRepository, "create").mockResolvedValue({} as never),
+    );
+
+    await advertisingService.deleteCampaign(CAMPAIGN_ID, ORG_ID);
+
+    expect(refund).toHaveBeenCalledTimes(1);
+    const arg = refund.mock.calls[0]?.[0] as { amount: number };
+    // 110 * (1 - 40/100) = 66 — NOT 110 (the old over-refund).
+    expect(arg.amount).toBeCloseTo(66, 9);
+  });
+
+  test("fully-spent budget refunds nothing (no over-refund)", async () => {
+    track(
+      spyOn(adCampaignsRepository, "findById").mockResolvedValue(
+        makeCampaign({ total_spend: "100" }) as never,
+      ),
+    );
+    const refund = track(
+      spyOn(creditsService, "refundCredits").mockResolvedValue({
+        success: true,
+      } as never),
+    );
+    track(
+      spyOn(adTransactionsRepository, "create").mockResolvedValue({} as never),
+    );
+
+    await advertisingService.deleteCampaign(CAMPAIGN_ID, ORG_ID);
+
+    // fractionSpent clamps to 1 → creditsRemaining 0 → no refund call.
+    expect(refund).not.toHaveBeenCalled();
+  });
+});
+
+describe("updateCampaign — reconciles the credit hold on a budget change", () => {
+  beforeEach(() => {
+    track(
+      spyOn(adAccountsRepository, "findById").mockResolvedValue({
+        id: "acct-1",
+        organization_id: ORG_ID,
+        platform: "meta",
+      } as never),
+    );
+    // getCredentials is private + hits the secrets vault; stub it out.
+    track(
+      spyOn(
+        advertisingService as unknown as {
+          getCredentials: () => Promise<unknown>;
+        },
+        "getCredentials",
+      ).mockResolvedValue({} as never),
+    );
+  });
+
+  test("budget INCREASE fails CLOSED on insufficient balance (platform never called)", async () => {
+    track(
+      spyOn(adCampaignsRepository, "findById").mockResolvedValue(
+        makeCampaign({ external_campaign_id: "ext-1" }) as never,
+      ),
+    );
+    const deduct = track(
+      spyOn(creditsService, "deductCredits").mockResolvedValue({
+        success: false,
+      } as never),
+    );
+    const provider = stubProvider();
+    const providerUpdate = track(spyOn(provider, "updateCampaign"));
+    track(
+      spyOn(advertisingService, "getProvider").mockReturnValue(provider),
+    );
+
+    await expect(
+      // 100 → 200 budget: delta = 220 - 110 = 110 credits.
+      advertisingService.updateCampaign(CAMPAIGN_ID, ORG_ID, {
+        budgetAmount: 200,
+      }),
+    ).rejects.toThrow("Insufficient credit balance for the budget increase");
+
+    expect(deduct).toHaveBeenCalledTimes(1);
+    expect((deduct.mock.calls[0]?.[0] as { amount: number }).amount).toBeCloseTo(
+      110,
+      9,
+    );
+    // Fail-closed: the increase is charged BEFORE the platform push, so the
+    // platform must never have been called.
+    expect(providerUpdate).not.toHaveBeenCalled();
+  });
+
+  test("budget INCREASE refunds the delta if the platform rejects it", async () => {
+    track(
+      spyOn(adCampaignsRepository, "findById").mockResolvedValue(
+        makeCampaign({ external_campaign_id: "ext-1" }) as never,
+      ),
+    );
+    const deduct = track(
+      spyOn(creditsService, "deductCredits").mockResolvedValue({
+        success: true,
+      } as never),
+    );
+    const refund = track(
+      spyOn(creditsService, "refundCredits").mockResolvedValue({
+        success: true,
+      } as never),
+    );
+    track(
+      spyOn(advertisingService, "getProvider").mockReturnValue(
+        stubProvider({
+          updateCampaign: async () => ({
+            success: false,
+            error: "platform rejected",
+          }),
+        }),
+      ),
+    );
+
+    await expect(
+      advertisingService.updateCampaign(CAMPAIGN_ID, ORG_ID, {
+        budgetAmount: 200,
+      }),
+    ).rejects.toThrow("platform rejected");
+
+    // Charged the increase, then refunded the SAME delta when the platform
+    // rejected — net zero, no leak.
+    expect(deduct).toHaveBeenCalledTimes(1);
+    expect(refund).toHaveBeenCalledTimes(1);
+    expect((deduct.mock.calls[0]?.[0] as { amount: number }).amount).toBeCloseTo(
+      110,
+      9,
+    );
+    expect((refund.mock.calls[0]?.[0] as { amount: number }).amount).toBeCloseTo(
+      110,
+      9,
+    );
+  });
+
+  test("a name-only update charges and refunds nothing", async () => {
+    track(
+      spyOn(adCampaignsRepository, "findById").mockResolvedValue(
+        makeCampaign({ external_campaign_id: "ext-1" }) as never,
+      ),
+    );
+    const deduct = track(
+      spyOn(creditsService, "deductCredits").mockResolvedValue({
+        success: true,
+      } as never),
+    );
+    const refund = track(
+      spyOn(creditsService, "refundCredits").mockResolvedValue({
+        success: true,
+      } as never),
+    );
+    track(
+      spyOn(advertisingService, "getProvider").mockReturnValue(stubProvider()),
+    );
+    track(
+      spyOn(adCampaignsRepository, "update").mockResolvedValue(
+        makeCampaign({
+          external_campaign_id: "ext-1",
+          name: "Renamed",
+        }) as never,
+      ),
+    );
+
+    const updated = await advertisingService.updateCampaign(
+      CAMPAIGN_ID,
+      ORG_ID,
+      { name: "Renamed" },
+    );
+
+    expect(updated.name).toBe("Renamed");
+    // No budgetAmount in the input → no budget delta → no credit movement.
+    expect(deduct).not.toHaveBeenCalled();
+    expect(refund).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/proxy/pricing-fallback.test.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/pricing-fallback.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Proxy pricing fallback behavior (#10269).
+ *
+ * When a service's DB pricing rows are missing (a partially-seeded DB or a new
+ * serviceId shipped without a seed), `getServiceMethodCost` must:
+ *   (1) return a fail-safe sub-cent FALLBACK_COST of $0.001 — NOT the old
+ *       $1.00/call (~1,000–20,000x the real price); and
+ *   (2) NOT cache the empty pricing map, so a transient/partial-seed miss
+ *       self-heals on the next call once the rows land (caching it would pin the
+ *       fallback for the whole TTL, up to 5 min).
+ *
+ * Tests the REAL pricing module: only the DB repository read and the cache I/O
+ * (the two runtime boundaries) are spied.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  spyOn,
+  test,
+} from "bun:test";
+import { servicePricingRepository } from "../../../db/repositories";
+import { cache } from "../../cache/client";
+import {
+  getServiceMethodCost,
+  invalidateServicePricingCache,
+} from "./pricing";
+
+const SERVICE_ID = "pricing-fallback-test-service";
+
+let listByServiceSpy: ReturnType<typeof spyOn>;
+let cacheGetSpy: ReturnType<typeof spyOn>;
+let cacheSetSpy: ReturnType<typeof spyOn>;
+
+beforeEach(async () => {
+  // Start every test from a cold cache + no inflight load for this serviceId.
+  await invalidateServicePricingCache(SERVICE_ID);
+  // Cache is always a cold miss here so the repository read path runs.
+  cacheGetSpy = spyOn(cache, "get").mockResolvedValue(null);
+  cacheSetSpy = spyOn(cache, "set").mockResolvedValue(undefined);
+  listByServiceSpy = spyOn(servicePricingRepository, "listByService");
+});
+
+afterEach(async () => {
+  cacheGetSpy.mockRestore();
+  cacheSetSpy.mockRestore();
+  listByServiceSpy.mockRestore();
+  await invalidateServicePricingCache(SERVICE_ID);
+});
+
+describe("getServiceMethodCost — missing-pricing fallback", () => {
+  test("returns the $0.001 fail-safe fallback when no DB rows exist", async () => {
+    listByServiceSpy.mockResolvedValue([]);
+
+    const cost = await getServiceMethodCost(SERVICE_ID, "getPrice");
+
+    expect(cost).toBe(0.001);
+    // Sanity: the fallback is well under a cent (not the old $1.00 over-charge).
+    expect(cost).toBeLessThan(0.01);
+  });
+
+  test("does NOT cache the empty pricing map (so a partial-seed miss self-heals)", async () => {
+    listByServiceSpy.mockResolvedValue([]);
+
+    await getServiceMethodCost(SERVICE_ID, "getPrice");
+
+    // The empty map must never be written to the cache.
+    expect(cacheSetSpy).not.toHaveBeenCalled();
+  });
+
+  test("self-heals once the pricing rows land (no stale empty-map cache)", async () => {
+    // First call: rows are missing → fallback, nothing cached.
+    listByServiceSpy.mockResolvedValueOnce([]);
+    const first = await getServiceMethodCost(SERVICE_ID, "getPrice");
+    expect(first).toBe(0.001);
+
+    // Rows are seeded before the next call. Because the empty map was not
+    // cached, the next read hits the DB again and picks up the real price.
+    listByServiceSpy.mockResolvedValueOnce([
+      { method: "getPrice", cost: "0.0003" },
+    ] as never);
+    const second = await getServiceMethodCost(SERVICE_ID, "getPrice");
+
+    expect(second).toBeCloseTo(0.0003, 12);
+    // A non-empty map IS cached for the TTL.
+    expect(cacheSetSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/proxy/refund-on-failure.test.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/refund-on-failure.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Direct API-proxy refund-on-failure (#10269).
+ *
+ * The birdeye + dexscreener direct handlers debit the per-call cost up front,
+ * then return the upstream response. They must mirror the engine routes' refund
+ * policy so the same failure isn't charged here while being refunded there:
+ *   - birdeye (PAID upstream): refund on >=500 (server outage, no usable
+ *     response), but KEEP the charge on 4xx (the customer's own bad request
+ *     still consumed our Birdeye quota);
+ *   - dexscreener (FREE upstream): refund on ANY non-ok (the failed call cost us
+ *     nothing).
+ *
+ * The refund must happen EXACTLY ONCE for the cost that was debited. Only the
+ * credits, pricing, auth, and `fetch` boundaries are mocked; the handlers'
+ * branching logic is the unit under test.
+ *
+ * `mock.module` is process-global in Bun's single-process run, so the real
+ * modules are restored in `afterAll` to avoid leaking into later files.
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import type { Context } from "hono";
+import type { AppEnv } from "../../../types/cloud-worker-env";
+import * as creditsActual from "../credits";
+import * as pricingActual from "./pricing";
+import * as authActual from "../../auth/workers-hono-auth";
+
+const realCredits = { ...creditsActual };
+const realPricing = { ...pricingActual };
+const realAuth = { ...authActual };
+
+const ORG_ID = "00000000-0000-4000-8000-0000000000aa";
+const COST = 0.0003;
+
+const deductCredits = mock<(args: unknown) => Promise<{ success: boolean }>>();
+const refundCredits = mock<(args: unknown) => Promise<{ success: boolean }>>();
+
+mock.module("../credits", () => ({
+  ...realCredits,
+  creditsService: {
+    ...realCredits.creditsService,
+    deductCredits,
+    refundCredits,
+  },
+}));
+
+mock.module("./pricing", () => ({
+  ...realPricing,
+  getServiceMethodCost: async () => COST,
+}));
+
+mock.module("../../auth/workers-hono-auth", () => ({
+  ...realAuth,
+  requireUserOrApiKeyWithOrg: async () => ({ organization_id: ORG_ID }),
+}));
+
+const { handleBirdeyeMarketDataProxyGet } = await import("./birdeye-handler");
+const { handleDexscreenerProxyGet } = await import("./dexscreener-handler");
+
+const originalFetch = globalThis.fetch;
+
+/** Minimal Hono Context stub covering exactly what the handlers read. */
+function makeContext(path: string, env: Record<string, unknown> = {}): Context<AppEnv> {
+  const url = `https://api.elizacloud.ai/proxy/${path}`;
+  return {
+    env,
+    req: {
+      param: (key: string) => (key === "*" ? path : undefined),
+      url,
+      header: (_name: string) => undefined,
+    },
+    json: (body: unknown, status?: number) =>
+      Response.json(body, { status: status ?? 200 }),
+  } as unknown as Context<AppEnv>;
+}
+
+function mockUpstream(status: number, body = "{}") {
+  globalThis.fetch = mock(async () =>
+    new Response(body, {
+      status,
+      headers: { "Content-Type": "application/json" },
+    }),
+  ) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  deductCredits.mockReset();
+  refundCredits.mockReset();
+  deductCredits.mockResolvedValue({ success: true });
+  refundCredits.mockResolvedValue({ success: true });
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+afterAll(() => {
+  mock.module("../credits", () => realCredits);
+  mock.module("./pricing", () => realPricing);
+  mock.module("../../auth/workers-hono-auth", () => realAuth);
+});
+
+describe("birdeye proxy refund-on-failure", () => {
+  test("upstream 500 refunds the upfront cost exactly once", async () => {
+    mockUpstream(500, '{"error":"upstream down"}');
+
+    const res = await handleBirdeyeMarketDataProxyGet(
+      makeContext("defi/price", { BIRDEYE_API_KEY: "key" }),
+    );
+
+    // Status is passed through (the customer sees the upstream failure).
+    expect(res.status).toBe(500);
+    expect(deductCredits).toHaveBeenCalledTimes(1);
+    expect(refundCredits).toHaveBeenCalledTimes(1);
+    const refundArg = refundCredits.mock.calls[0]?.[0] as {
+      organizationId: string;
+      amount: number;
+    };
+    expect(refundArg.organizationId).toBe(ORG_ID);
+    expect(refundArg.amount).toBeCloseTo(COST, 12);
+  });
+
+  test("upstream 4xx does NOT refund (paid API, customer's bad request)", async () => {
+    mockUpstream(400, '{"error":"bad request"}');
+
+    const res = await handleBirdeyeMarketDataProxyGet(
+      makeContext("defi/price", { BIRDEYE_API_KEY: "key" }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(deductCredits).toHaveBeenCalledTimes(1);
+    expect(refundCredits).not.toHaveBeenCalled();
+  });
+
+  test("upstream 200 does NOT refund (successful call)", async () => {
+    mockUpstream(200, '{"data":{"value":1}}');
+
+    const res = await handleBirdeyeMarketDataProxyGet(
+      makeContext("defi/price", { BIRDEYE_API_KEY: "key" }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(deductCredits).toHaveBeenCalledTimes(1);
+    expect(refundCredits).not.toHaveBeenCalled();
+  });
+});
+
+describe("dexscreener proxy refund-on-failure", () => {
+  test("non-ok upstream refunds the upfront cost exactly once (free upstream)", async () => {
+    mockUpstream(429, '{"error":"rate limited"}');
+
+    const res = await handleDexscreenerProxyGet(makeContext("latest/dex/pairs/x"));
+
+    expect(res.status).toBe(429);
+    expect(deductCredits).toHaveBeenCalledTimes(1);
+    expect(refundCredits).toHaveBeenCalledTimes(1);
+    const refundArg = refundCredits.mock.calls[0]?.[0] as {
+      organizationId: string;
+      amount: number;
+    };
+    expect(refundArg.organizationId).toBe(ORG_ID);
+    expect(refundArg.amount).toBeCloseTo(COST, 12);
+  });
+
+  test("a 500 upstream also refunds (any non-ok)", async () => {
+    mockUpstream(500, '{"error":"upstream down"}');
+
+    const res = await handleDexscreenerProxyGet(makeContext("latest/dex/pairs/x"));
+
+    expect(res.status).toBe(500);
+    expect(refundCredits).toHaveBeenCalledTimes(1);
+  });
+
+  test("ok upstream does NOT refund", async () => {
+    mockUpstream(200, '{"pairs":[]}');
+
+    const res = await handleDexscreenerProxyGet(makeContext("latest/dex/pairs/x"));
+
+    expect(res.status).toBe(200);
+    expect(deductCredits).toHaveBeenCalledTimes(1);
+    expect(refundCredits).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-discord/discord-events.ts
+++ b/plugins/plugin-discord/discord-events.ts
@@ -100,7 +100,6 @@ export interface DiscordServiceInternals {
  */
 interface EventListenerConfig {
 	listenCids: string[];
-	debounceMs: number;
 	channelDebounceMs: number;
 	responseCooldownMs: number;
 	recentContextTtlMs: number;
@@ -126,17 +125,6 @@ function parseEventListenerConfig(
 						.map((s) => s.trim())
 						.filter((s) => s.length > 0)
 				: [];
-
-	const debounceMsSetting = service.runtime.getSetting("DISCORD_DEBOUNCE_MS") as
-		| string
-		| number
-		| undefined;
-	const debounceMs =
-		typeof debounceMsSetting === "number"
-			? debounceMsSetting
-			: typeof debounceMsSetting === "string" && debounceMsSetting.trim()
-				? Number.parseInt(debounceMsSetting, 10) || 400
-				: 400;
 
 	const channelDebounceMsSetting = service.runtime.getSetting(
 		"DISCORD_CHANNEL_DEBOUNCE_MS",
@@ -179,7 +167,6 @@ function parseEventListenerConfig(
 
 	return {
 		listenCids,
-		debounceMs,
 		channelDebounceMs,
 		responseCooldownMs,
 		recentContextTtlMs,


### PR DESCRIPTION
Follow-ups to the PR-review swarm that landed #10260–#10277 on develop. Keeps the test additions off develop until CI validates them.

## Code cleanups
- **#10277 nit:** `agent-loader.ts` now lazy-loads `@elizaos/plugin-cloud-apps` (`await import` inside the `CLOUD_APPS_PLUGIN_ENABLED` branch) so the default-OFF gate actually avoids pulling the plugin + cloud SDK into every dedicated prod agent.
- **#10270 nit:** removed the now-dead `DISCORD_DEBOUNCE_MS` / `parseEventListenerConfig.debounceMs` (no consumer after the message-debouncer removal).

## Regression tests (the gap the authors flagged on the merged PRs)
- **#10269** `proxy/refund-on-failure.test.ts` (birdeye 500→refund once, birdeye 4xx→no refund, dexscreener non-ok→refund) + `proxy/pricing-fallback.test.ts` (empty pricing map not cached; FALLBACK_COST 0.001).
- **#10266** `agent-mcp-billing.test.ts` (+) and new `agent-a2a-billing.test.ts`: earnings-recording throw after `reconcile(actualTotal)` must NOT trigger the outer `reconcile(0)` double-refund.
- **#10265** `ad-campaign-credit-reconciliation.test.ts`: delete refunds only the unused fraction; budget increase charges the delta and fails closed; refund on platform rejection; name-only update is credit-neutral.
- **#10272** `user-email-route.test.ts`: `PATCH /api/v1/user/email` rejects `@elizalabs.ai` (defense-in-depth; the admin-gate test already landed with #10272).

Note: authored against the merged fixes; imports verified against the tree. Local run was not possible in the build env (native-dep OOM) — relying on this PR's CI as the runtime validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)