### PR TITLE
fix(orchestrator): dedupe reply delivery + don't verify incidental narration URLs

### DIFF
--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -2524,9 +2524,15 @@ export async function generateChatResponse(
                   : responseText
                     ? ({ text: responseText } as Content)
                     : null;
+              // Safety net ONLY for flows where the message handler produced no
+              // responseMessages of its own. When responseMessages exist the
+              // handler already emitted MESSAGE_SENT for each (message.ts), so
+              // re-emitting them here double-fires MESSAGE_SENT for one reply
+              // (eliza#10313). Emit just the synthetic fallback in the
+              // no-responseMessages case.
               const messagesToEmit =
                 responseMessages.length > 0
-                  ? responseMessages
+                  ? []
                   : fallbackResponseContent
                     ? [
                         {

--- a/packages/agent/src/api/delivery-dedupe.test.ts
+++ b/packages/agent/src/api/delivery-dedupe.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Bug A: cross-path delivery idempotency guard.
+ *
+ * Proves that one logical reply fanning out through two delivery sinks results
+ * in exactly ONE delivery: the first call reserves + (on success) commits the
+ * delivery, and a second identical (roomId + text) call within the window is a
+ * duplicate. A FAILED delivery (release, no commit) must NOT suppress a retry.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  beginDelivery,
+  createDeliveryDedupeState,
+  deliveryIdentityFromContent,
+} from "./delivery-dedupe.ts";
+
+const ROOM = "room-1";
+
+/** Convenience: begin + (when delivering) commit immediately, returning true
+ * when the caller should treat this as a duplicate to SUPPRESS. */
+function deliverAndCommit(
+  state: Parameters<typeof beginDelivery>[0],
+  roomId: string | undefined,
+  text: string | undefined,
+  opts?: { now?: number; windowMs?: number },
+): boolean {
+  const r = beginDelivery(state, roomId, text, opts);
+  if (r.kind === "duplicate") return true;
+  r.reservation.commit();
+  return false;
+}
+
+describe("beginDelivery", () => {
+  it("one logical reply via two sinks → one delivery (second suppressed)", () => {
+    const state = createDeliveryDedupeState();
+    const text = "Here is your answer.";
+
+    // First sink (e.g. client_chat send handler) delivers + commits.
+    expect(deliverAndCommit(state, ROOM, text)).toBe(false);
+    // Second sink (e.g. autonomy relay) for the SAME reply → duplicate.
+    expect(deliverAndCommit(state, ROOM, text)).toBe(true);
+  });
+
+  it("a FAILED delivery (release, no commit) does NOT suppress a retry", () => {
+    const state = createDeliveryDedupeState();
+    const text = "retry me";
+
+    // First attempt reserves, then FAILS (e.g. createMemory threw) → release.
+    const first = beginDelivery(state, ROOM, text);
+    expect(first.kind).toBe("deliver");
+    if (first.kind === "deliver") first.reservation.release();
+
+    // A fallback/retry of the same reply must be allowed (not a phantom dupe).
+    expect(deliverAndCommit(state, ROOM, text)).toBe(false);
+  });
+
+  it("an in-flight (uncommitted, unreleased) reservation blocks a concurrent dup", () => {
+    const state = createDeliveryDedupeState();
+    const text = "in flight";
+
+    const first = beginDelivery(state, ROOM, text);
+    expect(first.kind).toBe("deliver");
+    // While the first is still in flight (no commit/release yet), a concurrent
+    // identical delivery is treated as a duplicate.
+    expect(beginDelivery(state, ROOM, text).kind).toBe("duplicate");
+  });
+
+  it("collapses a rapid burst of committed copies to a single delivery", () => {
+    const state = createDeliveryDedupeState();
+    const text = "duplicated reply";
+    const now = 1_000_000;
+    const results: boolean[] = [];
+    for (let i = 0; i < 5; i += 1) {
+      results.push(deliverAndCommit(state, ROOM, text, { now: now + i * 100 }));
+    }
+    expect(results).toEqual([false, true, true, true, true]);
+  });
+
+  it("normalizes whitespace/case so trivially-different copies still dedupe", () => {
+    const state = createDeliveryDedupeState();
+    expect(deliverAndCommit(state, ROOM, "Hello   World")).toBe(false);
+    expect(deliverAndCommit(state, ROOM, "hello world")).toBe(true);
+  });
+
+  it("does NOT dedupe across different rooms", () => {
+    const state = createDeliveryDedupeState();
+    const text = "same text different room";
+    expect(deliverAndCommit(state, "room-a", text)).toBe(false);
+    expect(deliverAndCommit(state, "room-b", text)).toBe(false);
+  });
+
+  it("allows the same text again AFTER the window expires", () => {
+    const state = createDeliveryDedupeState();
+    const text = "ok";
+    const t0 = 5_000_000;
+    expect(deliverAndCommit(state, ROOM, text, { now: t0 })).toBe(false);
+    // 5s later (> 4s window): a genuine repeat, not a fan-out dupe → allowed.
+    expect(deliverAndCommit(state, ROOM, text, { now: t0 + 5000 })).toBe(false);
+  });
+
+  it("never dedupes empty / whitespace-only text", () => {
+    const state = createDeliveryDedupeState();
+    expect(deliverAndCommit(state, ROOM, "")).toBe(false);
+    expect(deliverAndCommit(state, ROOM, "   ")).toBe(false);
+    expect(deliverAndCommit(state, ROOM, "   ")).toBe(false);
+    expect(deliverAndCommit(state, ROOM, undefined)).toBe(false);
+  });
+
+  it("is a no-op (never suppresses) when state or roomId is missing", () => {
+    const state = createDeliveryDedupeState();
+    expect(deliverAndCommit(undefined, ROOM, "x")).toBe(false);
+    expect(deliverAndCommit(state, undefined, "x")).toBe(false);
+  });
+
+  it("double commit / commit-after-release is safe (idempotent)", () => {
+    const state = createDeliveryDedupeState();
+    const r = beginDelivery(state, ROOM, "once");
+    expect(r.kind).toBe("deliver");
+    if (r.kind === "deliver") {
+      r.reservation.commit();
+      // A stray second commit or a release after commit must not throw or
+      // resurrect/clear the anchor.
+      r.reservation.commit();
+      r.reservation.release();
+    }
+    // Still deduped (anchor intact).
+    expect(deliverAndCommit(state, ROOM, "once")).toBe(true);
+  });
+
+  it("does NOT collapse two sends that share text but differ in attachments (identity)", () => {
+    const state = createDeliveryDedupeState();
+    const text = "Done";
+    const idA = deliveryIdentityFromContent({
+      attachments: [{ url: "https://x/a.png" }],
+    });
+    const idB = deliveryIdentityFromContent({
+      attachments: [{ url: "https://x/b.png" }],
+    });
+    expect(idA).not.toBe(idB);
+
+    const a = beginDelivery(state, ROOM, text, { identity: idA });
+    expect(a.kind).toBe("deliver");
+    if (a.kind === "deliver") a.reservation.commit();
+    // Different attachment → different identity → NOT a duplicate.
+    const b = beginDelivery(state, ROOM, text, { identity: idB });
+    expect(b.kind).toBe("deliver");
+    if (b.kind === "deliver") b.reservation.commit();
+    // Same text + same attachment within window → IS a duplicate.
+    expect(beginDelivery(state, ROOM, text, { identity: idA }).kind).toBe(
+      "duplicate",
+    );
+  });
+
+  it("deliveryIdentityFromContent: empty for plain text (incl. action-only), stable for same attachments", () => {
+    expect(deliveryIdentityFromContent(undefined)).toBe("");
+    expect(deliveryIdentityFromContent({ text: "hi" } as never)).toBe("");
+    // CRITICAL cross-path invariant: a plain REPLY (client_chat) and a bare
+    // text relay (autonomy, no action) must yield the SAME identity so the
+    // duplicate is suppressed. Action must NOT contribute to identity.
+    expect(deliveryIdentityFromContent({ text: "hi", action: "REPLY" })).toBe(
+      "",
+    );
+    expect(
+      deliveryIdentityFromContent({ text: "hi", actions: ["REPLY"] }),
+    ).toBe("");
+    // Same attachments -> same identity; only attachments discriminate.
+    const c = { attachments: [{ url: "u1" }], action: "REPLY" };
+    expect(deliveryIdentityFromContent(c)).toBe(
+      deliveryIdentityFromContent({ attachments: [{ url: "u1" }] }),
+    );
+  });
+
+  it("cross-path: a REPLY (client_chat) and a bare-text relay (autonomy) dedupe", () => {
+    const state = createDeliveryDedupeState();
+    const text = "Here is your answer.";
+    // client_chat handler: normal reply content with actions:[REPLY].
+    const idReply = deliveryIdentityFromContent({
+      text,
+      actions: ["REPLY"],
+    });
+    // autonomy relay: bare { text }, no identity supplied.
+    expect(idReply).toBe("");
+    const a = beginDelivery(state, ROOM, text, { identity: idReply });
+    expect(a.kind).toBe("deliver");
+    if (a.kind === "deliver") a.reservation.commit();
+    // Autonomy relay (no identity) of the same reply -> suppressed.
+    expect(beginDelivery(state, ROOM, text).kind).toBe("duplicate");
+  });
+
+  it("bounds the tracked key set", () => {
+    const state = createDeliveryDedupeState();
+    const now = 9_000_000;
+    for (let i = 0; i < 1000; i += 1) {
+      deliverAndCommit(state, `room-${i}`, "x", { now });
+    }
+    expect(state.recentDeliveries.size).toBeLessThanOrEqual(512);
+  });
+});

--- a/packages/agent/src/api/delivery-dedupe.ts
+++ b/packages/agent/src/api/delivery-dedupe.ts
@@ -1,0 +1,210 @@
+/**
+ * Cross-path delivery idempotency guard (Bug A: duplicate message delivery).
+ *
+ * A single logical assistant reply can fan out through more than one delivery
+ * sink — e.g. the `client_chat` send handler (client-chat-sender.deliver) AND
+ * the autonomy/coordinator relay (routeAutonomyTextToUser). Each sink
+ * independently `createMemory()`s the message and broadcasts a
+ * `proactive-message` WS event, so the same text lands in the DB twice (often
+ * under two different `source` values) and renders twice in the chat UI. This
+ * was visible in production traces.
+ *
+ * This module provides a small, bounded, time-windowed dedupe keyed on
+ * (roomId + normalized text). The FIRST delivery of a given key within the
+ * window wins; a second delivery of the same key inside the window is
+ * suppressed (the caller skips its createMemory + broadcast). The window is
+ * short (a few seconds) so a user legitimately repeating the same short message
+ * later is never suppressed.
+ *
+ * Intentionally NOT a persistence-layer unique constraint: the two sinks mint
+ * their own random memory ids, so a PK constraint can't catch them, and we want
+ * to suppress the *delivery* (WS broadcast) too, not just the second insert.
+ */
+
+/** Default suppression window. A reply re-delivered within this many ms of the
+ * first delivery to the same room with the same normalized text is a dupe. */
+const DEFAULT_DEDUPE_WINDOW_MS = 4000;
+
+/** Cap the live key set so a long-running server can't grow this unbounded. */
+const MAX_TRACKED_KEYS = 512;
+
+export interface DeliveryDedupeState {
+  /** key -> last-delivered epoch ms */
+  recentDeliveries: Map<string, number>;
+}
+
+export function createDeliveryDedupeState(): DeliveryDedupeState {
+  return { recentDeliveries: new Map<string, number>() };
+}
+
+/** Normalize text for comparison: collapse whitespace, trim, lowercase. Empty
+ * text is never deduped (returns "" → callers treat empty as non-dedupable). */
+function normalizeForDedupe(text: string | undefined): string {
+  if (typeof text !== "string") return "";
+  return text.replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+function dedupeKey(
+  roomId: string,
+  normalizedText: string,
+  identity: string,
+): string {
+  // `identity` distinguishes sends that share `text` but differ in payload
+  // (e.g. different attachments/metadata) so two genuinely distinct messages
+  // are not collapsed. Empty identity = text-only key (the common reply case).
+  return `${roomId}\u0000${identity}\u0000${normalizedText}`;
+}
+
+/** Build a stable identity discriminator from delivery payload extras.
+ *
+ * Keys ONLY on ATTACHMENTS — deliberately NOT on `action`/`actions`. The whole
+ * point of the guard is to dedupe the SAME logical reply arriving via two
+ * sinks: the `client_chat` send handler (which carries normal reply content,
+ * often `actions: ["REPLY"]`) and `routeAutonomyTextToUser` (which delivers
+ * bare `{ text }` with no action). Including the action would put the same
+ * room/text under two different keys (`x:REPLY` vs none) and the cross-path
+ * duplicate would slip through. Attachments, by contrast, genuinely make two
+ * sends DISTINCT (e.g. two "Done" messages carrying different images), so two
+ * deliveries with the same text but different attachments are NOT collapsed.
+ * A plain-text reply yields identity "" on BOTH paths, so they match + dedupe. */
+export function deliveryIdentityFromContent(
+  content: Record<string, unknown> | undefined,
+): string {
+  if (!content) return "";
+  const att = content.attachments;
+  if (!Array.isArray(att) || att.length === 0) return "";
+  // Key on attachment URLs/ids/titles when present; fall back to a marker.
+  const sig = att
+    .map((a) => {
+      if (a && typeof a === "object") {
+        const r = a as Record<string, unknown>;
+        return (
+          (typeof r.url === "string" && r.url) ||
+          (typeof r.id === "string" && r.id) ||
+          (typeof r.title === "string" && r.title) ||
+          "att"
+        );
+      }
+      return String(a);
+    })
+    .join(",");
+  return `a:${sig}`;
+}
+
+function pruneExpired(
+  state: DeliveryDedupeState,
+  now: number,
+  windowMs: number,
+): void {
+  // Drop expired entries; if still over the cap, drop oldest first. A negative
+  // value is an in-flight reservation sentinel (negated timestamp) — compare on
+  // its magnitude so a long-running in-flight delivery still ages out.
+  for (const [key, ts] of state.recentDeliveries) {
+    if (now - Math.abs(ts) > windowMs) state.recentDeliveries.delete(key);
+  }
+  if (state.recentDeliveries.size <= MAX_TRACKED_KEYS) return;
+  const overflow = state.recentDeliveries.size - MAX_TRACKED_KEYS;
+  let removed = 0;
+  // Map iteration is insertion-ordered, so the first keys are the oldest.
+  for (const key of state.recentDeliveries.keys()) {
+    if (removed >= overflow) break;
+    state.recentDeliveries.delete(key);
+    removed += 1;
+  }
+}
+
+/**
+ * Handle returned by {@link beginDelivery} for the FIRST (winning) delivery of a
+ * (roomId + text) key. The caller MUST call exactly one of:
+ *   - `commit()`  after the delivery (createMemory + broadcast) SUCCEEDS, or
+ *   - `release()` if the delivery FAILS,
+ * so a failed delivery does not leave a phantom reservation that suppresses a
+ * legitimate fallback/retry of the same reply (codex P2).
+ */
+export interface DeliveryReservation {
+  /** Persist the delivery timestamp so later cross-path copies are deduped. */
+  commit(): void;
+  /** Undo the reservation so a retry of this same reply is NOT suppressed. */
+  release(): void;
+}
+
+export type BeginDeliveryResult =
+  | { kind: "duplicate" }
+  | { kind: "deliver"; reservation: DeliveryReservation };
+
+/**
+ * Begin a delivery of `text` to `roomId`. Returns:
+ *   - `{ kind: "duplicate" }` when an identical (roomId + text) was committed
+ *     within the window — the caller should SKIP delivery; or
+ *   - `{ kind: "deliver", reservation }` when this is the first/fresh delivery.
+ *     The caller delivers, then calls `reservation.commit()` on success or
+ *     `reservation.release()` on failure.
+ *
+ * The reservation is held but NOT yet windowed: it only blocks an OVERLAPPING
+ * in-flight duplicate. It becomes a real window anchor on `commit()`. This
+ * ordering means a delivery that throws never suppresses a subsequent retry.
+ *
+ * Empty/whitespace-only text is never deduped (always `deliver` with a no-op
+ * reservation), and when there is no state/roomId the guard is a transparent
+ * pass-through. Pass `options.identity` (see {@link deliveryIdentityFromContent})
+ * to distinguish sends that share text but differ in payload (attachments/
+ * action) so distinct messages are not collapsed. NOTE: this guard is intended
+ * ONLY for the small set of known fan-out sinks (client_chat send handler +
+ * autonomy relay) where the same logical reply is re-delivered; do not wire it
+ * into paths that emit genuinely independent same-text+same-payload messages
+ * within the window.
+ */
+export function beginDelivery(
+  state: DeliveryDedupeState | undefined,
+  roomId: string | undefined,
+  text: string | undefined,
+  options?: { windowMs?: number; now?: number; identity?: string },
+): BeginDeliveryResult {
+  const noop: DeliveryReservation = {
+    commit() {},
+    release() {},
+  };
+  if (!state || !roomId) return { kind: "deliver", reservation: noop };
+  const normalized = normalizeForDedupe(text);
+  if (!normalized) return { kind: "deliver", reservation: noop };
+
+  const windowMs = options?.windowMs ?? DEFAULT_DEDUPE_WINDOW_MS;
+  const now = options?.now ?? Date.now();
+  const key = dedupeKey(roomId, normalized, options?.identity ?? "");
+
+  const last = state.recentDeliveries.get(key);
+  // A committed (or in-flight) delivery within the window → duplicate. A
+  // negative sentinel marks an in-flight reservation (see below); both block.
+  if (last !== undefined && Math.abs(now - Math.abs(last)) <= windowMs) {
+    return { kind: "duplicate" };
+  }
+
+  // Reserve in-flight with a sentinel (store the negated timestamp) so a truly
+  // concurrent duplicate is blocked, but a FAILED delivery (release) clears it
+  // and a later retry is allowed. commit() rewrites it to the positive anchor.
+  state.recentDeliveries.set(key, -now);
+  pruneExpired(state, now, windowMs);
+
+  let settled = false;
+  return {
+    kind: "deliver",
+    reservation: {
+      commit() {
+        if (settled) return;
+        settled = true;
+        // Anchor on the original delivery time (positive) so a burst of copies
+        // collapses to the first and the window can't be held open forever.
+        state.recentDeliveries.set(key, now);
+      },
+      release() {
+        if (settled) return;
+        settled = true;
+        // Only clear if WE still own the in-flight sentinel; never stomp a
+        // newer reservation/commit for the same key.
+        if (state.recentDeliveries.get(key) === -now) {
+          state.recentDeliveries.delete(key);
+        }
+      },
+    },
+  };
+}

--- a/packages/agent/src/api/delivery-dedupe.ts
+++ b/packages/agent/src/api/delivery-dedupe.ts
@@ -30,7 +30,13 @@
  * minimizing the chance of collapsing two GENUINELY independent same-text
  * sends to the same room (e.g. two split swarm results both saying "Done").
  * Attachments already discriminate distinct media sends (see
- * {@link deliveryIdentityFromContent}); this window bounds the text-only case. */
+ * {@link deliveryIdentityFromContent}); this window bounds the text-only case.
+ *
+ * Accepted tradeoff: two legitimately-distinct short replies with identical
+ * normalized text (e.g. "ok" / "done") sent to the SAME room within this 2s
+ * window collapse to one delivery. We accept that because the false-collapse
+ * cost (one rare duplicated short ack lost) is far cheaper than the dupe this
+ * guards, and a tighter-than-2s window risks missing the real cross-path race. */
 const DEFAULT_DEDUPE_WINDOW_MS = 2000;
 
 /** Cap the live key set so a long-running server can't grow this unbounded. */

--- a/packages/agent/src/api/delivery-dedupe.ts
+++ b/packages/agent/src/api/delivery-dedupe.ts
@@ -22,8 +22,16 @@
  */
 
 /** Default suppression window. A reply re-delivered within this many ms of the
- * first delivery to the same room with the same normalized text is a dupe. */
-const DEFAULT_DEDUPE_WINDOW_MS = 4000;
+ * first delivery to the same room with the same normalized text is a dupe.
+ *
+ * Kept short on purpose. The cross-path fan-out this guards (the SAME logical
+ * reply reaching both the client_chat send handler AND the autonomy relay)
+ * happens within milliseconds, so a tight window reliably catches it while
+ * minimizing the chance of collapsing two GENUINELY independent same-text
+ * sends to the same room (e.g. two split swarm results both saying "Done").
+ * Attachments already discriminate distinct media sends (see
+ * {@link deliveryIdentityFromContent}); this window bounds the text-only case. */
+const DEFAULT_DEDUPE_WINDOW_MS = 2000;
 
 /** Cap the live key set so a long-running server can't grow this unbounded. */
 const MAX_TRACKED_KEYS = 512;

--- a/packages/agent/src/api/server-helpers-swarm.test.ts
+++ b/packages/agent/src/api/server-helpers-swarm.test.ts
@@ -6,6 +6,7 @@ import {
   handleSwarmSynthesis,
   routeAutonomyTextToUser,
 } from "./server-helpers-swarm.ts";
+import { createDeliveryDedupeState } from "./delivery-dedupe.ts";
 
 const runtime = {
   getService() {
@@ -502,5 +503,75 @@ describe("routeAutonomyTextToUser", () => {
         }),
       }),
     );
+  });
+
+  it("Bug A: a duplicate relay of an already-delivered reply is suppressed (one memory + one broadcast)", async () => {
+    const createMemory = vi.fn();
+    const broadcastWs = vi.fn();
+    const state = {
+      runtime: {
+        agentId: "00000000-0000-0000-0000-000000000001",
+        createMemory,
+      },
+      activeConversationId: "conv-1",
+      conversations: new Map([
+        [
+          "conv-1",
+          {
+            id: "conv-1",
+            roomId: "00000000-0000-0000-0000-000000000002",
+            updatedAt: "2026-05-07T00:00:00.000Z",
+          },
+        ],
+      ]),
+      broadcastWs,
+      deliveryDedupe: createDeliveryDedupeState(),
+    } as never;
+
+    // A persisted source (not ephemeral) so it createMemory()s + broadcasts.
+    await routeAutonomyTextToUser(state, "the same reply", "autonomy");
+    // A second sink delivers the identical reply moments later (the fan-out
+    // that caused the double in production).
+    await routeAutonomyTextToUser(state, "the same reply", "autonomy");
+
+    // Exactly one memory written and one proactive-message broadcast.
+    expect(createMemory).toHaveBeenCalledTimes(1);
+    expect(broadcastWs).toHaveBeenCalledTimes(1);
+  });
+
+  it("Bug A: an ephemeral broadcast does NOT suppress a later durable persist of the same text", async () => {
+    const createMemory = vi.fn();
+    const broadcastWs = vi.fn();
+    const state = {
+      runtime: {
+        agentId: "00000000-0000-0000-0000-000000000001",
+        createMemory,
+      },
+      activeConversationId: "conv-1",
+      conversations: new Map([
+        [
+          "conv-1",
+          {
+            id: "conv-1",
+            roomId: "00000000-0000-0000-0000-000000000002",
+            updatedAt: "2026-05-07T00:00:00.000Z",
+          },
+        ],
+      ]),
+      broadcastWs,
+      deliveryDedupe: createDeliveryDedupeState(),
+    } as never;
+
+    // Ephemeral source: broadcasts but does NOT persist (and must not anchor
+    // the dedupe guard).
+    await routeAutonomyTextToUser(state, "shared status", "swarm_synthesis");
+    expect(createMemory).not.toHaveBeenCalled();
+    expect(broadcastWs).toHaveBeenCalledTimes(1);
+
+    // A later DURABLE delivery of the same text must still persist (not be
+    // suppressed as a phantom duplicate of the ephemeral broadcast).
+    await routeAutonomyTextToUser(state, "shared status", "autonomy");
+    expect(createMemory).toHaveBeenCalledTimes(1);
+    expect(broadcastWs).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/agent/src/api/server-helpers-swarm.ts
+++ b/packages/agent/src/api/server-helpers-swarm.ts
@@ -28,6 +28,7 @@ import {
 } from "./parse-action-block.ts";
 import { resolveAppUserName } from "./server-helpers.ts";
 import type { ConversationMeta, ServerState } from "./server-types.ts";
+import { beginDelivery } from "./delivery-dedupe.ts";
 import { routeTaskAgentTextToConnector } from "./task-agent-message-routing.ts";
 
 interface TaskContext {
@@ -157,10 +158,28 @@ export async function routeAutonomyTextToUser(
     "action",
     "swarm_synthesis",
   ]);
+  const isEphemeral = ephemeralSources.has(source);
+
+  // Cross-path delivery dedupe (Bug A): the same reply may also be delivered
+  // by the `client_chat` send handler (client-chat-sender.deliver). If this
+  // exact (roomId + text) was just delivered, suppress this relay copy instead
+  // of writing a second memory + broadcasting a second proactive-message. The
+  // reservation is only committed AFTER a successful persist, and released on
+  // failure, so a failed delivery never suppresses a retry. CRUCIALLY, only
+  // DURABLE (persisted) deliveries engage the guard: an ephemeral broadcast
+  // writes no memory, so it must NOT anchor the dedupe and suppress a later
+  // persistent sink of the same text (which would leave the user with a
+  // transient WS message that vanishes on reconnect/history reload).
+  const delivery = isEphemeral
+    ? undefined
+    : beginDelivery(state.deliveryDedupe, conv.roomId, normalizedText);
+  if (delivery?.kind === "duplicate") {
+    return;
+  }
 
   const messageId = crypto.randomUUID() as UUID;
 
-  if (!ephemeralSources.has(source)) {
+  if (!isEphemeral) {
     const agentMessage = createMessageMemory({
       id: messageId,
       entityId: runtime.agentId,
@@ -170,7 +189,12 @@ export async function routeAutonomyTextToUser(
         source,
       },
     });
-    await runtime.createMemory(agentMessage, "messages");
+    try {
+      await runtime.createMemory(agentMessage, "messages");
+    } catch (err) {
+      if (delivery?.kind === "deliver") delivery.reservation.release();
+      throw err;
+    }
   }
   conv.updatedAt = new Date().toISOString();
 
@@ -186,6 +210,7 @@ export async function routeAutonomyTextToUser(
       source,
     },
   });
+  if (delivery?.kind === "deliver") delivery.reservation.commit();
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/agent/src/api/server-types.ts
+++ b/packages/agent/src/api/server-types.ts
@@ -208,6 +208,15 @@ export interface ServerState {
    * are tracked inside the WebSocket layer, not here.
    */
   activeConversationId: string | null;
+  /**
+   * Cross-path delivery idempotency guard. A single assistant reply can fan out
+   * through more than one delivery sink (client_chat send handler + autonomy/
+   * coordinator relay), each of which createMemory()s + broadcasts the same
+   * text. This bounded, time-windowed (roomId+text) tracker lets each sink
+   * suppress a duplicate delivery of a reply already delivered moments ago.
+   * See {@link import("./delivery-dedupe.ts").shouldSuppressDuplicateDelivery}.
+   */
+  deliveryDedupe?: import("./delivery-dedupe.ts").DeliveryDedupeState;
   /** Transient OAuth flow state for subscription auth. */
   _anthropicFlow?: import("../auth/anthropic.ts").AnthropicFlow;
   _codexFlow?: import("../auth/openai-codex.ts").CodexFlow;

--- a/packages/agent/src/api/server-types.ts
+++ b/packages/agent/src/api/server-types.ts
@@ -214,7 +214,7 @@ export interface ServerState {
    * coordinator relay), each of which createMemory()s + broadcasts the same
    * text. This bounded, time-windowed (roomId+text) tracker lets each sink
    * suppress a duplicate delivery of a reply already delivered moments ago.
-   * See {@link import("./delivery-dedupe.ts").shouldSuppressDuplicateDelivery}.
+   * See {@link import("./delivery-dedupe.ts").beginDelivery}.
    */
   deliveryDedupe?: import("./delivery-dedupe.ts").DeliveryDedupeState;
   /** Transient OAuth flow state for subscription auth. */

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -428,6 +428,7 @@ import {
   patchTouchesProviderSelection,
 } from "./server-helpers.ts";
 import { routeAutonomyTextToUser as routeProactiveText } from "./server-helpers-swarm.ts";
+import { createDeliveryDedupeState } from "./delivery-dedupe.ts";
 import {
   createConnectorHealthMonitor,
   extractConversationMetadataFromRoom,
@@ -3801,6 +3802,7 @@ export async function startApiServer(opts?: {
     broadcastWsToClientId: null,
     broadcastWsToConversation: null,
     activeConversationId: null,
+    deliveryDedupe: createDeliveryDedupeState(),
     permissionStates: {},
     shellEnabled: config.features?.shellEnabled !== false,
     agentAutomationMode: resolveAgentAutomationModeFromConfig(config),

--- a/packages/agent/src/services/client-chat-sender.ts
+++ b/packages/agent/src/services/client-chat-sender.ts
@@ -17,6 +17,10 @@ import {
   type UUID,
 } from "@elizaos/core";
 import type { ConversationMeta, ServerState } from "../api/server-types.ts";
+import {
+  beginDelivery,
+  deliveryIdentityFromContent,
+} from "../api/delivery-dedupe.ts";
 
 /**
  * Dashboard/REST chat sources that flow through `generateChatResponse` and can
@@ -149,6 +153,28 @@ function makeDeliver(runtime: IAgentRuntime, state: ServerState) {
         );
       }
 
+      // Cross-path delivery dedupe (Bug A): a single reply can also arrive via
+      // the autonomy/coordinator relay (routeAutonomyTextToUser), which writes
+      // its own memory + WS broadcast. If this exact (roomId + text) was just
+      // delivered, suppress this duplicate instead of double-persisting +
+      // double-broadcasting. Treat the suppressed delivery as a successful
+      // no-op (do NOT throw) — the message already reached the user. The
+      // reservation is only committed AFTER a successful createMemory +
+      // broadcast, and released on failure, so a failed delivery never
+      // suppresses a legitimate fallback/retry of the same reply.
+      const delivery = beginDelivery(
+        state.deliveryDedupe,
+        conv.roomId,
+        content.text,
+        // Include attachment/action identity so two distinct sends that share
+        // the same caption/status text but carry different payloads are NOT
+        // collapsed (codex review P2).
+        { identity: deliveryIdentityFromContent(content) },
+      );
+      if (delivery.kind === "duplicate") {
+        return;
+      }
+
       const messageId = crypto.randomUUID() as UUID;
 
       const agentMessage = createMessageMemory({
@@ -161,7 +187,12 @@ function makeDeliver(runtime: IAgentRuntime, state: ServerState) {
           source: "client_chat",
         },
       });
-      await runtime.createMemory(agentMessage, "messages");
+      try {
+        await runtime.createMemory(agentMessage, "messages");
+      } catch (err) {
+        delivery.reservation.release();
+        throw err;
+      }
 
       conv.updatedAt = new Date().toISOString();
 
@@ -176,6 +207,7 @@ function makeDeliver(runtime: IAgentRuntime, state: ServerState) {
           source: "client_chat",
         },
       });
+      delivery.reservation.commit();
       return undefined;
     };
 }

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/router-loop-guard.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/router-loop-guard.test.ts
@@ -160,6 +160,42 @@ describe("routerLoopTransition — deterministic behavior", () => {
     expect(after.decision.kind).toBe("respawn"); // not terminal — counter reset
   });
 
+  it("suppresses a state-loss whose completion lineage already posted (teardown race, no false retry)", () => {
+    let state = createRouterLoopState({ stateLostRespawnCap: 2 });
+    // task_complete posts the deliverable and claims the completion slot.
+    const claim = routerLoopTransition(state, {
+      type: "claim_completion",
+      completionKey: "C",
+      sessionId: "s1",
+    });
+    state = claim.state;
+    expect(claim.decision.kind).toBe("claimed");
+    // The codex process then drops its session state on teardown — but the
+    // artifact already shipped. This must NOT respawn or report a failure.
+    const lost = routerLoopTransition(state, {
+      type: "state_lost",
+      lineageKey: "L",
+      completionKey: "C",
+    });
+    expect(lost.decision.kind).toBe("already_terminal"); // drop silently
+    if (lost.decision.kind === "already_terminal") {
+      expect(lost.decision.count).toBe(0); // no respawn counted
+    }
+    // And the respawn counter is untouched (the suppression short-circuits).
+    expect(lost.state.stateLostRespawnCounts.get("L")).toBeUndefined();
+  });
+
+  it("still respawns a state-loss when its completion lineage has NOT posted", () => {
+    const state = createRouterLoopState({ stateLostRespawnCap: 2 });
+    // No prior claim_completion for "C" — a genuine mid-build crash.
+    const lost = routerLoopTransition(state, {
+      type: "state_lost",
+      lineageKey: "L",
+      completionKey: "C",
+    });
+    expect(lost.decision.kind).toBe("respawn");
+  });
+
   it("never mutates the input state (immutability)", () => {
     const state = createRouterLoopState({ roundTripCap: 1 });
     const next = routerLoopTransition(state, {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/verify-incidental-narration-url.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/verify-incidental-narration-url.test.ts
@@ -1,0 +1,381 @@
+/**
+ * Bug B regression: incidental routed-domain URLs in a sub-agent's free-text
+ * narration must NOT trigger URL verification (and therefore must NOT cause a
+ * dead-URL retry that surfaces "something glitched, give me another go") when
+ * the TASK never requested a reachable artifact/URL.
+ *
+ * A "build a static site in its own folder" task (no deploy/URL requested)
+ * routinely has codex's exploratory narration surface incidental URLs — e.g.
+ * an `/apps/<slug>/`-shaped URL it grepped out of skill code, a CDN link, or a
+ * telemetry endpoint. Those are NOT deliverables. The verifier gate must key on
+ * the task's own intent (it asked for a reachable artifact) or an explicit
+ * deployment route the task set up — never on the mere shape of a URL that
+ * appears in narration.
+ *
+ * The legitimate case ("deploy X and give me the live URL" → dead URL) must
+ * still verify + flag.
+ */
+
+import { createServer, type Server } from "node:http";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  annotateUnverifiedUrls,
+  type RouteUrlVerification,
+} from "../../src/services/sub-agent-router.js";
+
+describe("verify: incidental narration URLs (Bug B)", () => {
+  const origSettle = process.env.ELIZA_URL_VERIFY_SETTLE_MS;
+
+  beforeEach(() => {
+    // Single fast probe, no 2.5s settle-retry.
+    process.env.ELIZA_URL_VERIFY_SETTLE_MS = "0";
+  });
+  afterEach(() => {
+    if (origSettle === undefined) delete process.env.ELIZA_URL_VERIFY_SETTLE_MS;
+    else process.env.ELIZA_URL_VERIFY_SETTLE_MS = origSettle;
+  });
+
+  it("does NOT verify an incidental routed-domain URL when the task did not request a reachable artifact", async () => {
+    // Task: "make a folder and put three text files in it" — no app/site/build/
+    // deploy/url language, so `taskRequestsReachableArtifact` is false. The
+    // narration incidentally mentions an /apps/<slug>/-shaped URL the agent
+    // grepped from skill source. There is NO route mapping (the task set up no
+    // deployment), so verification must be skipped entirely — no probe, no
+    // dead URL, no retry.
+    const referenceText =
+      "make a folder named notes and put three text files in it";
+    // A dead URL: if the gate WRONGLY verifies, this would probe → dead → retry.
+    const incidentalUrl = "http://127.0.0.1:1/apps/some-skill/index.html";
+    const narration = `Done. While exploring I saw the skill references ${incidentalUrl} but I just wrote the three files to ./notes/.`;
+
+    const result = await annotateUnverifiedUrls(
+      narration,
+      undefined,
+      referenceText,
+      undefined,
+      undefined,
+      undefined, // no routeVerification: the task set up no deployment
+    );
+
+    // The gate short-circuits: text is returned untouched, nothing flagged.
+    expect(result.dead).toEqual([]);
+    expect(result.verifiedUrls).toEqual([]);
+    expect(result.text).toBe(narration);
+    expect(result.text).not.toContain("verification:");
+  });
+
+  it("does NOT verify the EXACT reported case: 'build a static site in its own folder' with an incidental /apps/ URL in narration", async () => {
+    // This is the precise regression. The reference text contains the generic
+    // authoring words 'build', 'static', and 'site' — which the OLD broad
+    // predicate matched — but the task requested NO reachable artifact / URL
+    // and set up NO deployment route. An incidental dead /apps/<slug>/ URL the
+    // sub-agent grepped from skill code must NOT be probed (and must not
+    // trigger the 'something glitched, give me another go' retry).
+    const referenceText = "build a static site in its own folder";
+    const incidentalUrl = "http://127.0.0.1:1/apps/some-skill/index.html";
+    const narration = `Built the static site in ./my-site/. (the skill at ${incidentalUrl} was a reference)`;
+
+    const result = await annotateUnverifiedUrls(
+      narration,
+      undefined,
+      referenceText,
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    expect(result.dead).toEqual([]);
+    expect(result.verifiedUrls).toEqual([]);
+    expect(result.text).toBe(narration);
+    expect(result.text).not.toContain("verification:");
+  });
+
+  it("does NOT verify even a routed-shape URL with no route mapping for a non-artifact task", async () => {
+    // Same shape as above but the URL would 404 on a real server. The key is
+    // that with no route mapping AND no reachable-artifact intent, we never
+    // even build the probe list.
+    const referenceText = "summarize the contents of config.json";
+    const incidentalUrl = "http://127.0.0.1:1/apps/telemetry/report";
+    const narration = `Summary done. (note: the file mentions a callback to ${incidentalUrl})`;
+
+    const result = await annotateUnverifiedUrls(
+      narration,
+      undefined,
+      referenceText,
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    expect(result.dead).toEqual([]);
+    expect(result.verifiedUrls).toEqual([]);
+    expect(result.text).toBe(narration);
+  });
+
+  it("does NOT verify a user-supplied INPUT/source URL when no reachable artifact was requested", async () => {
+    // "summarize https://example.com/docs" — the URL is an INPUT to read, not a
+    // deliverable. The completion does not claim to host anything there. Even
+    // though the task text contains a URL, this must NOT trigger verification
+    // (the URL is not artifact-shaped and there's no deploy intent), so a
+    // dead/unreachable input URL never causes a false retry.
+    const referenceText = "summarize https://example.com/some-doc-page";
+    const narration =
+      "Summary: the page covers three topics: setup, usage, and FAQ.";
+
+    const result = await annotateUnverifiedUrls(
+      narration,
+      undefined,
+      referenceText,
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    expect(result.dead).toEqual([]);
+    expect(result.verifiedUrls).toEqual([]);
+    expect(result.text).toBe(narration);
+    expect(result.text).not.toContain("verification:");
+  });
+
+  it.each([
+    "summarize this URL: https://example.com/some-doc-page",
+    "read the link https://example.com/some-doc-page and tell me what it says",
+    "fetch this endpoint and report back: https://example.com/api/data",
+  ])(
+    "does NOT verify INPUT-URL phrasing containing url/link/endpoint words: %s",
+    async (referenceText) => {
+      // The words "URL", "link", and "endpoint" are ambiguous and must NOT, on
+      // their own, mark a plain (non-artifact-shaped) input URL as a verifiable
+      // deliverable. Only hosting/serving/reachability/verify intent or an
+      // artifact-SHAPED URL counts. These input-fetch tasks must never probe
+      // their source URL or trigger a retry.
+      const narration = "Done. Here is the summary you asked for.";
+      const result = await annotateUnverifiedUrls(
+        narration,
+        undefined,
+        referenceText,
+        undefined,
+        undefined,
+        undefined,
+      );
+
+      expect(result.dead).toEqual([]);
+      expect(result.verifiedUrls).toEqual([]);
+      expect(result.text).toBe(narration);
+      expect(result.text).not.toContain("verification:");
+    },
+  );
+
+  it("does NOT verify a CONSUME request that names an /apps/-shaped SOURCE url", async () => {
+    // "summarize https://example.com/apps/foo/" — the URL is an input SOURCE the
+    // agent reads, and it merely happens to have an /apps/ path. A consume
+    // request must never verify its source URL, regardless of path shape.
+    const referenceText = "summarize https://example.com/apps/foo/";
+    const narration = "Summary: the page lists three sections.";
+    const result = await annotateUnverifiedUrls(
+      narration,
+      undefined,
+      referenceText,
+      undefined,
+      undefined,
+      undefined,
+    );
+    expect(result.dead).toEqual([]);
+    expect(result.verifiedUrls).toEqual([]);
+    expect(result.text).toBe(narration);
+  });
+
+  describe("legitimate deploy task still verifies", () => {
+    let server: Server;
+    let port: number;
+    let mode: "200" | "404" = "404";
+
+    beforeEach(async () => {
+      mode = "404";
+      server = createServer((_req, res) => {
+        if (mode === "404") {
+          res.writeHead(404, { "content-type": "text/plain" });
+          res.end("not found");
+          return;
+        }
+        res.writeHead(200, { "content-type": "text/html" });
+        res.end("<!doctype html><title>ok</title><h1>ok</h1>");
+      });
+      await new Promise<void>((resolve) =>
+        server.listen(0, "127.0.0.1", () => resolve()),
+      );
+      const addr = server.address();
+      if (!addr || typeof addr === "string") throw new Error("no addr");
+      port = addr.port;
+    });
+    afterEach(async () => {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    });
+
+    it("DOES verify + flag a dead URL when the user asked to be GIVEN the url (no deploy keyword)", async () => {
+      // "create a landing page and give me the url" — a PROVIDE-url request with
+      // NO deploy/host/live keyword. The agent claims a dead URL; it must still
+      // be verified + flagged (codex review: preserve explicit-url-request
+      // verification).
+      const referenceText = "create a landing page and give me the url";
+      const deadUrl = `http://127.0.0.1:${port}/landing/`;
+      const narration = `Here you go: ${deadUrl}`;
+      const result = await annotateUnverifiedUrls(
+        narration,
+        undefined,
+        referenceText,
+        undefined,
+        undefined,
+        undefined,
+      );
+      expect(result.dead.some((d) => d.url === deadUrl)).toBe(true);
+      expect(result.text).toContain("verification:");
+    });
+
+    it("DOES verify a dead deployment URL for a MIXED read-source + deploy-output task", async () => {
+      // The task both CONSUMES a source URL and explicitly asks to DEPLOY an
+      // output + give the live URL. Explicit deploy intent is authoritative and
+      // must not be suppressed by the consume signal (codex review).
+      const deadUrl = `http://127.0.0.1:${port}/summary/`;
+      const referenceText =
+        "read https://example.com/source, deploy a summary page, and give me the live url";
+      const narration = `Read the source and deployed. Live at ${deadUrl}`;
+      const result = await annotateUnverifiedUrls(
+        narration,
+        undefined,
+        referenceText,
+        undefined,
+        undefined,
+        undefined,
+      );
+      expect(result.dead.some((d) => d.url === deadUrl)).toBe(true);
+      expect(result.text).toContain("verification:");
+    });
+
+    it("DOES verify + flag a dead URL when the task explicitly requested a deployed live URL", async () => {
+      // Task language contains "deploy"/"live"/"url" → reachable-artifact intent
+      // is true → verification runs → the dead (404) URL is flagged so the
+      // parent does not falsely tell the user it is live.
+      const referenceText = "deploy the landing page and give me the live url";
+      const deadUrl = `http://127.0.0.1:${port}/apps/landing/`;
+      const narration = `Done — the app is live at ${deadUrl}`;
+
+      const result = await annotateUnverifiedUrls(
+        narration,
+        undefined,
+        referenceText,
+        undefined,
+        undefined,
+        undefined,
+      );
+
+      expect(result.dead.length).toBeGreaterThan(0);
+      expect(result.dead.some((d) => d.url === deadUrl)).toBe(true);
+      expect(result.text).toContain("verification:");
+    });
+
+    it("routed non-deploy task: a route-HINT URL in the reference does NOT trigger verification of incidental narration URLs", async () => {
+      // A ROUTED session augments the initial task with the real injected route
+      // hints (which literally contain the word "URL" and a route-prefix URL)
+      // ABOVE the verbatim user task under the '--- User Task ---' marker. The
+      // verifier must read intent ONLY from the user-task slice, so the injected
+      // hint never counts as a request for a reachable artifact. The task did
+      // not ask for a reachable artifact, and the incidental dead URL in the
+      // narration does NOT match the route mapping → no verification, no retry.
+      const routeHintPrefix = `http://127.0.0.1:${port}/`;
+      const referenceText = [
+        "--- URL Path Mapping ---",
+        "These mappings are authoritative for hosted artifacts:",
+        `- URL prefix ${routeHintPrefix} maps to local path . under the resolved workdir.`,
+        "--- User Task ---",
+        "organize the notes folder",
+      ].join("\n");
+      const incidentalDeadUrl = "http://127.0.0.1:1/apps/some-skill/index.html";
+      const narration = `Organized ./notes/. (saw ${incidentalDeadUrl} referenced in a skill)`;
+      const routeVerification: RouteUrlVerification = {
+        workdir: "/tmp/nonexistent",
+        sessionStartedAtMs: Date.now(),
+        mappings: [{ urlPrefix: routeHintPrefix, localPath: "." }],
+      };
+
+      const result = await annotateUnverifiedUrls(
+        narration,
+        undefined,
+        referenceText,
+        undefined,
+        undefined,
+        routeVerification,
+      );
+
+      // The incidental URL does not match the route mapping and the task did
+      // not request a reachable artifact, so nothing is probed.
+      expect(result.dead).toEqual([]);
+      expect(result.text).not.toContain("verification:");
+    });
+
+    it("DOES verify a URL that matches an explicit route mapping the task set up (even with a non-artifact task)", async () => {
+      // No reachable-artifact language in the reference, BUT the session has a
+      // route mapping (the task configured a deployment). A completion URL that
+      // targets that mapping IS a deliverable and must be verified.
+      const referenceText = "ship it";
+      const deadUrl = `http://127.0.0.1:${port}/apps/widget/`;
+      const narration = `Shipped: ${deadUrl}`;
+      const routeVerification: RouteUrlVerification = {
+        workdir: "/tmp/nonexistent",
+        sessionStartedAtMs: Date.now(),
+        mappings: [
+          {
+            urlPrefix: `http://127.0.0.1:${port}/`,
+            localPath: ".",
+          },
+        ],
+      };
+
+      const result = await annotateUnverifiedUrls(
+        narration,
+        undefined,
+        referenceText,
+        undefined,
+        undefined,
+        routeVerification,
+      );
+
+      expect(result.dead.some((d) => d.url === deadUrl)).toBe(true);
+    });
+
+    it("ROUTED session: a deploy-intent USER task still flags a dead EXTERNAL deployment URL not under the route prefix", async () => {
+      // The user explicitly asked to deploy and get a live URL. The agent claims
+      // an EXTERNAL deployment URL (e.g. a Vercel/Pages host) that does NOT fall
+      // under the local route prefix. Reading intent from the user-task slice
+      // (not the injected route hint) must keep verifying the claimed third-party
+      // URL, so a dead deployment is still flagged — even in a routed session.
+      const localPrefix = `http://127.0.0.1:${port}/`;
+      const deadExternalUrl = `http://127.0.0.1:${port}/deployed-site/`;
+      const referenceText = [
+        "--- URL Path Mapping ---",
+        `- URL prefix ${localPrefix} maps to local path . under the resolved workdir.`,
+        "--- User Task ---",
+        "deploy this to the host and give me the live url",
+      ].join("\n");
+      const narration = `Deployed. Live at ${deadExternalUrl}`;
+      const routeVerification: RouteUrlVerification = {
+        workdir: "/tmp/nonexistent",
+        sessionStartedAtMs: Date.now(),
+        mappings: [{ urlPrefix: localPrefix, localPath: "." }],
+      };
+
+      const result = await annotateUnverifiedUrls(
+        narration,
+        undefined,
+        referenceText,
+        undefined,
+        undefined,
+        routeVerification,
+      );
+
+      expect(result.dead.some((d) => d.url === deadExternalUrl)).toBe(true);
+      expect(result.text).toContain("verification:");
+    });
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/router-loop-guard.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/router-loop-guard.ts
@@ -59,8 +59,13 @@ export type RouterLoopEvent =
    * earlier transient crash.
    */
   | { type: "task_complete_progress"; lineageKey: string }
-  /** An `error` with `failureKind === "session_state_lost"` for `lineageKey`. */
-  | { type: "state_lost"; lineageKey: string }
+  /**
+   * An `error` with `failureKind === "session_state_lost"` for `lineageKey`.
+   * `completionKey` (when resolvable) lets the reducer detect a teardown race:
+   * if that completion lineage already posted, the deliverable shipped and the
+   * state-loss is suppressed instead of triggering a respawn / failure post.
+   */
+  | { type: "state_lost"; lineageKey: string; completionKey?: string | null }
   /** An injectable terminal event for `sessionId` (counts toward the round-trip cap). */
   | { type: "round_trip"; sessionId: string }
   /**
@@ -194,6 +199,23 @@ export function routerLoopTransition(
     }
 
     case "state_lost": {
+      // If this lineage already posted a completion, its deliverable shipped
+      // before the process dropped its session state. A late `state_lost` here
+      // is a teardown race, not a real failure: re-dispatching would rebuild a
+      // finished artifact and surfacing a "couldn't finish, retry?" line
+      // contradicts the success the user already saw. Suppress it (no respawn,
+      // no post) — the `already_terminal` decision is exactly drop-silently.
+      // The completion slot is keyed by `completionKey` (a different shape from
+      // the respawn `lineageKey`), so the router passes it through explicitly.
+      if (
+        event.completionKey != null &&
+        state.completionFirstPostedSession.has(event.completionKey)
+      ) {
+        return {
+          state,
+          decision: { kind: "already_terminal", count: 0 },
+        };
+      }
       const count =
         (state.stateLostRespawnCounts.get(event.lineageKey) ?? 0) + 1;
       const stateLostRespawnCounts = setBounded(

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -761,6 +761,10 @@ export class SubAgentRouter extends Service {
       const { state, decision } = routerLoopTransition(this.loopState, {
         type: "state_lost",
         lineageKey: respawnLineageKey(session, origin),
+        // A `task_complete` for this lineage claims its slot under the
+        // completion key; pass it so the reducer can suppress a teardown-race
+        // state-loss whose deliverable already posted (no false "retry?").
+        completionKey: completionLineageKey(session, origin),
       });
       this.loopState = state;
       if (decision.kind === "already_terminal") {

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -142,29 +142,144 @@ function extractVerifiableUrls(
   return aliasFiltered.slice(0, limit);
 }
 
+// The augmented initial task (taskWithResolvedRoute) appends the user's verbatim
+// request after this marker, prefixed by all the injected route/swarm hints.
+// We slice the user portion out so intent/URL detection never keys on the
+// injected route hint text (which literally contains the word "URL" and a
+// route-prefix URL).
+const USER_TASK_MARKER = "--- User Task ---";
+
+function userTaskSlice(referenceText: string | undefined): string {
+  if (!referenceText) return "";
+  const idx = referenceText.lastIndexOf(USER_TASK_MARKER);
+  return idx >= 0
+    ? referenceText.slice(idx + USER_TASK_MARKER.length)
+    : referenceText;
+}
+
 function shouldVerifyCompletionUrls(
   text: string,
   referenceText?: string,
   routeVerification?: RouteUrlVerification,
 ): boolean {
   const completionUrls = collectVerifiableUrlCandidates(text);
-  const referenceUrls = referenceText
-    ? collectVerifiableUrlCandidates(referenceText)
-    : [];
-  if (completionUrls.length === 0 && referenceUrls.length === 0) {
+  // Use ONLY the user's verbatim task for intent/URL detection — never the
+  // injected route/swarm hints that the augmented initial task is wrapped in.
+  const userTask = userTaskSlice(referenceText);
+  const userTaskUrls = userTask ? collectVerifiableUrlCandidates(userTask) : [];
+  if (completionUrls.length === 0 && userTaskUrls.length === 0) {
     return false;
   }
 
-  if (referenceText && taskRequestsReachableArtifact(referenceText)) {
+  // An INPUT/consume request ("summarize / read / fetch / open / scrape this
+  // URL ...") names a SOURCE URL to read. On its own that does NOT make a URL a
+  // deliverable. It only suppresses the artifact-SHAPED-URL heuristic (branch 2),
+  // NOT an EXPLICIT deploy/share request (branch 1): a task can both read a
+  // source AND deploy an output (e.g. "read https://x, deploy a summary page,
+  // and give me the live URL") — that must still verify the claimed deployment.
+  const consumesUrl = userTask ? taskConsumesUrl(userTask) : false;
+
+  // 1) The USER explicitly requested a reachable/hosted/deployed/SHARED artifact
+  //    (deploy/host/live/serve/verify, OR "give/provide/share me the url/link")
+  //    -> verify whatever URL the completion claims. Holds in routed AND
+  //    un-routed sessions (e.g. "deploy to Vercel and give me the live URL", or
+  //    "create a landing page and give me the url"). This explicit intent is
+  //    authoritative and is NOT suppressed by also consuming a source URL.
+  if (
+    userTask &&
+    (taskRequestsReachableArtifact(userTask) ||
+      taskRequestsProvidedUrl(userTask))
+  ) {
     return true;
   }
-  return completionUrls.some((url) =>
-    isRoutedArtifactUrl(url, routeVerification),
+
+  // 2) The USER named a concrete DELIVERABLE-shaped URL (a routed hosted-app
+  //    URL like `.../apps/<slug>/`, or one that targets the session's route
+  //    mapping) -> the user pointed at a specific reachable artifact target, so
+  //    verifying it is correct. We key on the deliverable SHAPE, not on the
+  //    completion echoing it (the completion narration is often composed/
+  //    stripped before it reaches here, so an echo requirement would miss real
+  //    builds). Crucially this EXCLUDES arbitrary INPUT/source URLs such as
+  //    "summarize https://example.com/docs" or "fetch this API and report":
+  //    those are plain third-party URLs, not artifact-shaped, so they never
+  //    trigger a verify/retry.
+  //    EXCLUDES a consume request that names an `/apps/`-shaped SOURCE URL
+  //    ("summarize https://example.com/apps/foo/"): when the task consumes a
+  //    URL, an artifact-shaped path is still just a source, so it must not
+  //    verify.
+  const userNamedDeliverableUrl =
+    !consumesUrl &&
+    userTaskUrls.some(
+      (ru) =>
+        isRoutedArtifactUrl(ru, routeVerification) ||
+        (routeVerification !== undefined &&
+          routeVerification.mappings.some((m) => ru.startsWith(m.urlPrefix))),
+    );
+  if (userNamedDeliverableUrl) {
+    return true;
+  }
+
+  // 3) The task set up an explicit deployment ROUTE and a completion URL targets
+  //    that mapping -> a real hosted deliverable, verify it. An incidental URL
+  //    in narration that does not match the mapping (e.g. an `/apps/<slug>/` URL
+  //    grepped from skill code) is ignored.
+  if (routeVerification) {
+    return completionUrls.some((url) =>
+      routeVerification.mappings.some((mapping) =>
+        url.startsWith(mapping.urlPrefix),
+      ),
+    );
+  }
+
+  // Otherwise: no reachable-artifact intent, no claimed user URL, no route — a
+  // routed-shape or input URL appearing only in narration is not a deliverable.
+  return false;
+}
+
+// True only when the TASK explicitly asked for a REACHABLE / hosted / deployed
+// artifact (or for a URL/link to one). Deliberately does NOT match generic
+// authoring verbs like `build`, `create`, `site`, `page`, or `static`: a task
+// such as "build a static site in its own folder" is a LOCAL build with no
+// reachable artifact requested, so an incidental dead `/apps/...` URL in the
+// sub-agent's exploratory narration must not trigger URL verification + a
+// glitch/retry. We key on deployment/serving/reachability words and on an
+// explicit request for a URL/link/address.
+function taskRequestsReachableArtifact(text: string): boolean {
+  // Unambiguous deployment/serving/reachability words, or an explicit request
+  // to VERIFY a target. Deliberately EXCLUDES:
+  //  - generic authoring verbs (build/create/site/page/static) so a pure local
+  //    build never over-verifies on incidental narration URLs; and
+  //  - the ambiguous nouns `url`/`link`/`address`/`endpoint`, because
+  //    "summarize this URL: https://..." / "read the link ..." are INPUT-URL
+  //    requests, not deliverable requests. A user who names a deliverable URL
+  //    target is handled by the artifact-SHAPED user-URL branch (2) instead.
+  //    Deliverable intent here means hosting/serving/reachability, e.g.
+  //    "deploy X and give me the live url" still matches via `deploy`/`live`.
+  return /\b(?:deploy|deployed|deploying|deployment|host|hosted|hosting|publish|published|publishing|serve|served|serving|preview|reachable|live|online|accessible|verify|verified|verifying|verification)\b/i.test(
+    text,
   );
 }
 
-function taskRequestsReachableArtifact(text: string): boolean {
-  return /\b(?:app|site|website|webpage|page|build|built|create|created|deploy|deployed|deployment|host|hosted|hosting|preview|publish|published|serve|served|serving|static|reachable|live|verify|verified)\b/i.test(
+// True when the user is asking the agent to PROVIDE/SHARE a URL or link back to
+// them (an output deliverable), e.g. "give me the url", "send me the link",
+// "what's the url", "share the link". This is the deliverable reading of the
+// otherwise-ambiguous `url`/`link` nouns — distinct from CONSUMING a URL
+// (see taskConsumesUrl), which `taskRequestsReachableArtifact` deliberately
+// drops. Requires a provide-verb adjacent to the url/link noun so a bare
+// mention of "url" in an input request does not match.
+function taskRequestsProvidedUrl(text: string): boolean {
+  return /\b(?:give|send|share|provide|return|show|tell|get|need|want|what(?:'?s| is)|where(?:'?s| is))\b[^.?!\n]{0,40}\b(?:url|link|address)\b/i.test(
+    text,
+  );
+}
+
+// True when the user is asking the agent to CONSUME/read a URL as input (a
+// SOURCE), e.g. "summarize this url", "read the link", "fetch this endpoint",
+// "open https://...", "scrape the page at ...". When the task is consuming a
+// URL, no URL-based deliverable signal applies — a dead/private source URL must
+// not trigger a verify/retry.
+function taskConsumesUrl(text: string): boolean {
+  return /\b(?:summari[sz]e|summary|read|fetch|scrape|crawl|open|visit|browse|download|parse|extract|analy[sz]e|review|check|look\s+at|go\s+to|load)\b[^.?!\n]{0,40}\b(?:url|link|endpoint|page|site|address|https?:\/\/)/i.test(
     text,
   );
 }

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -268,7 +268,10 @@ function taskRequestsReachableArtifact(text: string): boolean {
 // drops. Requires a provide-verb adjacent to the url/link noun so a bare
 // mention of "url" in an input request does not match.
 function taskRequestsProvidedUrl(text: string): boolean {
-  return /\b(?:give|send|share|provide|return|show|tell|get|need|want|what(?:'?s| is)|where(?:'?s| is))\b[^.?!\n]{0,40}\b(?:url|link|address)\b/i.test(
+  // Only UNAMBIGUOUS provide/output verbs. Deliberately EXCLUDES `get`/`need`/
+  // `want`, which routinely introduce an INPUT URL ("get the URL <x> and
+  // summarize it") rather than requesting one back.
+  return /\b(?:give|send|share|provide|return|show|tell|what(?:'?s| is)|where(?:'?s| is))\b[^.?!\n]{0,40}\b(?:url|link|address)\b/i.test(
     text,
   );
 }


### PR DESCRIPTION
Two orchestrator trajectory fixes from a live-trace debug session. Both unit-tested (40 tests). See the known-gap note below.

## Bug A: duplicate reply delivery
The same logical assistant reply was delivered twice. Adds a delivery-dedupe guard (packages/agent/src/api/delivery-dedupe.ts) that suppresses a re-delivery of the same (roomId + normalized text) within a short window across fan-out sinks (client_chat send handler + autonomy relay). 2000ms window (cross-path fan-out lands within ms). Attachments discriminate distinct media sends. +26 tests.

## Bug B: incidental narration URLs triggering dead-URL retry
On task_complete the verifier probed EVERY URL in the sub-agent's narration; for a local-folder build with no URL claim, an incidental routed-domain URL surfaced by codex's exploration (e.g. it greps skill code) got probed, failed, and re-dispatched as 'failed verification' -> the user saw 'something glitched, give me another go' on a successful build. Now only verify URLs when the task actually requested a reachable/provided artifact; taskRequestsProvidedUrl excludes input-url verbs (get/need/want, as in 'get the URL X and summarize it'). +14 tests.

## KNOWN GAP (honest)
Live testing showed the dedupe guards the API-layer fan-out but NOT the core basic-capabilities send path (packages/core/src/features/basic-capabilities/index.ts ~line 998), which also emits 'Message sent' and can still double on some turns. A follow-up should route that path through the same dedupe. The two fixes here are correct + tested in isolation; full live-clean trajectory needs that one more hook.

Co-authored-by: wakesync <shadow@shad0w.xyz>