### PR TITLE
feat(cloud): domain search + buy UI in the Applications domains tab (#10246)

### DIFF
--- a/packages/cloud/api/v1/apps/[id]/domains/check/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/check/route.ts
@@ -46,6 +46,9 @@ app.post("/", async (c) => {
       return c.json({ success: true, domain, available: false });
     }
     const price = computeDomainPrice(availability.priceUsdCents);
+    const renewal = computeDomainPrice(
+      availability.renewalUsdCents ?? availability.priceUsdCents,
+    );
     return c.json({
       success: true,
       domain,
@@ -57,6 +60,10 @@ app.post("/", async (c) => {
         marginUsdCents: price.marginUsdCents,
         totalUsdCents: price.totalUsdCents,
         marginBps: price.marginBps,
+      },
+      // Annual renewal price the org will be re-charged for by the renewal cron.
+      renewal: {
+        totalUsdCents: renewal.totalUsdCents,
       },
     });
   } catch (error) {

--- a/packages/ui/src/cloud/applications/components/BuyDomainCard.test.tsx
+++ b/packages/ui/src/cloud/applications/components/BuyDomainCard.test.tsx
@@ -1,0 +1,192 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// --- collaborator doubles (hoisted so vi.mock factories can close over them) ---
+const apiMock = vi.hoisted(() => vi.fn());
+const openExternalUrlMock = vi.hoisted(() => vi.fn());
+const toastSuccessMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../lib/api-client", async () => {
+  const actual = await vi.importActual<typeof import("../../lib/api-client")>(
+    "../../lib/api-client",
+  );
+  return { ...actual, api: (...args: unknown[]) => apiMock(...args) };
+});
+vi.mock("../../../utils/openExternalUrl", () => ({
+  openExternalUrl: (...args: unknown[]) => openExternalUrlMock(...args),
+}));
+vi.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccessMock(...args),
+    error: vi.fn(),
+  },
+}));
+// t() returns the defaultValue with {{vars}} interpolated so assertions read real copy.
+vi.mock("../../shell/CloudI18nProvider", () => ({
+  useCloudT:
+    () =>
+    (_k: string, o?: Record<string, unknown> & { defaultValue?: string }) => {
+      let s = o?.defaultValue ?? _k;
+      if (o) {
+        for (const [key, val] of Object.entries(o)) {
+          if (key !== "defaultValue") {
+            s = s.replace(new RegExp(`\\{\\{${key}\\}\\}`, "g"), String(val));
+          }
+        }
+      }
+      return s;
+    },
+}));
+
+import { ApiError } from "../../lib/api-client";
+import { BuyDomainCard } from "./BuyDomainCard";
+
+afterEach(() => {
+  cleanup();
+  apiMock.mockReset();
+  openExternalUrlMock.mockReset();
+  toastSuccessMock.mockReset();
+});
+
+async function checkDomain(
+  user: ReturnType<typeof userEvent.setup>,
+  domain: string,
+) {
+  await user.type(screen.getByLabelText("Domain to buy"), domain);
+  await user.click(screen.getByRole("button", { name: /Check/i }));
+}
+
+describe("BuyDomainCard (#10246)", () => {
+  const checkBtn = () =>
+    screen.getByRole("button", { name: /Check/i }) as HTMLButtonElement;
+
+  it("disables Check until the input looks like a domain", async () => {
+    const user = userEvent.setup({ delay: null });
+    render(<BuyDomainCard appId="app_1" onPurchased={vi.fn()} />);
+
+    expect(checkBtn().disabled).toBe(true);
+    await user.type(screen.getByLabelText("Domain to buy"), "not-a-domain");
+    expect(checkBtn().disabled).toBe(true);
+    await user.type(screen.getByLabelText("Domain to buy"), ".com");
+    expect(checkBtn().disabled).toBe(false);
+  });
+
+  it("checks availability and shows the price + renewal quote", async () => {
+    apiMock.mockResolvedValueOnce({
+      success: true,
+      domain: "yourbrand.com",
+      available: true,
+      currency: "USD",
+      price: { totalUsdCents: 1495 },
+      renewal: { totalUsdCents: 1599 },
+    });
+    const user = userEvent.setup({ delay: null });
+    render(<BuyDomainCard appId="app_1" onPurchased={vi.fn()} />);
+
+    await checkDomain(user, "yourbrand.com");
+
+    await waitFor(() =>
+      expect(apiMock).toHaveBeenCalledWith("/api/v1/apps/app_1/domains/check", {
+        method: "POST",
+        json: { domain: "yourbrand.com" },
+      }),
+    );
+    expect(await screen.findByText(/\$14\.95\/yr/)).toBeTruthy();
+    expect(screen.getByText(/renews \$15\.99\/yr/)).toBeTruthy();
+  });
+
+  it("shows 'not available' for a taken domain, with no Buy button", async () => {
+    apiMock.mockResolvedValueOnce({
+      success: true,
+      domain: "taken.com",
+      available: false,
+    });
+    const user = userEvent.setup({ delay: null });
+    render(<BuyDomainCard appId="app_1" onPurchased={vi.fn()} />);
+
+    await checkDomain(user, "taken.com");
+
+    expect(await screen.findByText(/taken\.com is not available/)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Buy \$/ })).toBeNull();
+  });
+
+  it("buys after explicit confirm and refreshes the domain list", async () => {
+    apiMock
+      .mockResolvedValueOnce({
+        success: true,
+        domain: "yourbrand.com",
+        available: true,
+        price: { totalUsdCents: 1495 },
+        renewal: { totalUsdCents: 1495 },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        domain: "yourbrand.com",
+        status: "active",
+        pendingZoneProvisioning: false,
+      });
+    const onPurchased = vi.fn();
+    const user = userEvent.setup({ delay: null });
+    render(<BuyDomainCard appId="app_1" onPurchased={onPurchased} />);
+
+    await checkDomain(user, "yourbrand.com");
+    await user.click(
+      await screen.findByRole("button", { name: /Buy \$14\.95/ }),
+    );
+    // Confirm dialog
+    await user.click(
+      await screen.findByRole("button", { name: /^Buy domain$/ }),
+    );
+
+    await waitFor(() =>
+      expect(apiMock).toHaveBeenCalledWith("/api/v1/apps/app_1/domains/buy", {
+        method: "POST",
+        json: { domain: "yourbrand.com" },
+      }),
+    );
+    expect(onPurchased).toHaveBeenCalledTimes(1);
+    expect(toastSuccessMock).toHaveBeenCalled();
+  });
+
+  it("on 402 surfaces an insufficient-credits error and an Add-credits CTA to the system browser", async () => {
+    apiMock
+      .mockResolvedValueOnce({
+        success: true,
+        domain: "yourbrand.com",
+        available: true,
+        price: { totalUsdCents: 1495 },
+        renewal: { totalUsdCents: 1495 },
+      })
+      .mockRejectedValueOnce(
+        new ApiError(
+          402,
+          "insufficient_balance",
+          "Insufficient credit balance for this domain",
+        ),
+      );
+    const user = userEvent.setup({ delay: null });
+    render(<BuyDomainCard appId="app_1" onPurchased={vi.fn()} />);
+
+    await checkDomain(user, "yourbrand.com");
+    await user.click(
+      await screen.findByRole("button", { name: /Buy \$14\.95/ }),
+    );
+    await user.click(
+      await screen.findByRole("button", { name: /^Buy domain$/ }),
+    );
+
+    expect(
+      await screen.findByText(/Insufficient credit balance for this domain/),
+    ).toBeTruthy();
+    const addCredits = await screen.findByRole("button", {
+      name: /Add credits/i,
+    });
+    await user.click(addCredits);
+    expect(openExternalUrlMock).toHaveBeenCalledWith(
+      expect.stringContaining("/dashboard/billing"),
+    );
+  });
+});

--- a/packages/ui/src/cloud/applications/components/BuyDomainCard.tsx
+++ b/packages/ui/src/cloud/applications/components/BuyDomainCard.tsx
@@ -1,0 +1,336 @@
+/**
+ * Application detail — Domains tab: search + price-quote + buy a domain through
+ * Cloudflare (#10246).
+ *
+ * Calls `POST /api/v1/apps/:id/domains/check` for an availability + price quote,
+ * then `POST /api/v1/apps/:id/domains/buy` behind an explicit confirm. The buy is
+ * charged from the org's credit balance; a 402 surfaces a top-up CTA routed to
+ * the system browser via `openExternalUrl` (never an in-webview checkout). The
+ * quote shows the annual renewal price the renewal cron will re-charge.
+ */
+
+import {
+  AlertTriangle,
+  CheckCircle2,
+  CreditCard,
+  Loader2,
+  Search,
+  ShoppingCart,
+  XCircle,
+} from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "../../../components/ui/alert-dialog";
+import { Button } from "../../../components/ui/button";
+import { Input } from "../../../components/ui/input";
+import { openExternalUrl } from "../../../utils/openExternalUrl";
+import { ApiError, api } from "../../lib/api-client";
+import { useCloudT } from "../../shell/CloudI18nProvider";
+
+interface DomainCheckResponse {
+  success: boolean;
+  domain: string;
+  available: boolean;
+  currency?: string;
+  price?: { totalUsdCents: number };
+  renewal?: { totalUsdCents: number };
+}
+
+interface DomainBuyResponse {
+  success: boolean;
+  domain: string;
+  status?: string;
+  pendingZoneProvisioning?: boolean;
+}
+
+const DOMAIN_RE = /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/;
+
+function formatUsd(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+export interface BuyDomainCardProps {
+  appId: string;
+  onPurchased: () => void | Promise<void>;
+}
+
+export function BuyDomainCard({ appId, onPurchased }: BuyDomainCardProps) {
+  const t = useCloudT();
+  const [query, setQuery] = useState("");
+  const [checking, setChecking] = useState(false);
+  const [result, setResult] = useState<DomainCheckResponse | null>(null);
+  const [buying, setBuying] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [needsCredits, setNeedsCredits] = useState(false);
+
+  const normalized = query.trim().toLowerCase().replace(/\.$/, "");
+  const isValid = DOMAIN_RE.test(normalized);
+
+  async function handleCheck() {
+    if (!isValid || checking) return;
+    setChecking(true);
+    setError(null);
+    setResult(null);
+    setNeedsCredits(false);
+    try {
+      const data = await api<DomainCheckResponse>(
+        `/api/v1/apps/${appId}/domains/check`,
+        { method: "POST", json: { domain: normalized } },
+      );
+      setResult(data);
+    } catch (e) {
+      setError(
+        e instanceof Error
+          ? e.message
+          : t("cloud.appDomains.buyCheckFailed", {
+              defaultValue: "Could not check that domain. Try again.",
+            }),
+      );
+    } finally {
+      setChecking(false);
+    }
+  }
+
+  async function handleBuy() {
+    if (!result?.available || buying) return;
+    setBuying(true);
+    setError(null);
+    setNeedsCredits(false);
+    try {
+      const data = await api<DomainBuyResponse>(
+        `/api/v1/apps/${appId}/domains/buy`,
+        { method: "POST", json: { domain: normalized } },
+      );
+      toast.success(
+        t("cloud.appDomains.buySuccess", { defaultValue: "Domain purchased" }),
+        {
+          description: data.pendingZoneProvisioning
+            ? t("cloud.appDomains.buyProvisioning", {
+                defaultValue:
+                  "Setting up DNS — it may take a few minutes to go live.",
+              })
+            : t("cloud.appDomains.buyLive", {
+                defaultValue: "Connecting it to your app now.",
+              }),
+        },
+      );
+      setQuery("");
+      setResult(null);
+      await onPurchased();
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 402) {
+        setNeedsCredits(true);
+        setError(
+          e.message ||
+            t("cloud.appDomains.buyInsufficient", {
+              defaultValue: "Not enough credits to buy this domain.",
+            }),
+        );
+      } else if (e instanceof ApiError && e.status === 409) {
+        setResult(null);
+        setError(
+          e.message ||
+            t("cloud.appDomains.buyUnavailable", {
+              defaultValue: "That domain is no longer available.",
+            }),
+        );
+      } else {
+        setError(
+          e instanceof Error
+            ? e.message
+            : t("cloud.appDomains.buyFailed", {
+                defaultValue: "Purchase failed. You were not charged.",
+              }),
+        );
+      }
+    } finally {
+      setBuying(false);
+    }
+  }
+
+  function openBilling() {
+    void openExternalUrl(`${window.location.origin}/dashboard/billing`);
+  }
+
+  return (
+    <div className="bg-neutral-900 rounded-sm p-4 space-y-4">
+      <div>
+        <h3 className="text-sm font-medium text-white flex items-center gap-2">
+          <ShoppingCart className="h-4 w-4 text-[#FF5800]" />
+          {t("cloud.appDomains.buyTitle", { defaultValue: "Buy a Domain" })}
+        </h3>
+        <p className="text-xs text-neutral-500 mt-1">
+          {t("cloud.appDomains.buySubtitle", {
+            defaultValue:
+              "Register a new domain through Cloudflare and connect it to this app.",
+          })}
+        </p>
+      </div>
+
+      <form
+        className="flex flex-col sm:flex-row gap-2"
+        onSubmit={(e) => {
+          e.preventDefault();
+          void handleCheck();
+        }}
+      >
+        <Input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={t("cloud.appDomains.buyPlaceholder", {
+            defaultValue: "yourbrand.com",
+          })}
+          aria-label={t("cloud.appDomains.buyInputLabel", {
+            defaultValue: "Domain to buy",
+          })}
+          className="bg-black/40 border-neutral-800 text-white"
+          autoCapitalize="none"
+          autoCorrect="off"
+          spellCheck={false}
+        />
+        <Button
+          type="submit"
+          size="sm"
+          disabled={!isValid || checking}
+          className="bg-[#FF5800] hover:bg-[#e54f00] text-white rounded-sm shrink-0"
+        >
+          {checking ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Search className="h-4 w-4" />
+          )}
+          <span className="ml-1.5">
+            {t("cloud.appDomains.buyCheck", { defaultValue: "Check" })}
+          </span>
+        </Button>
+      </form>
+
+      {result && !result.available && (
+        <div className="flex items-center gap-2 p-3 rounded-sm bg-black/40 text-sm text-neutral-300">
+          <XCircle className="h-4 w-4 text-neutral-500 shrink-0" />
+          <span>
+            {t("cloud.appDomains.buyTaken", {
+              defaultValue: "{{domain}} is not available.",
+              domain: result.domain,
+            })}
+          </span>
+        </div>
+      )}
+
+      {result?.available && result.price && (
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 p-3 rounded-sm bg-black/40">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <CheckCircle2 className="h-4 w-4 text-[#FF5800] shrink-0" />
+              <span className="text-sm font-medium text-white truncate">
+                {result.domain}
+              </span>
+            </div>
+            <p className="text-xs text-neutral-400 mt-1">
+              {t("cloud.appDomains.buyPriceLine", {
+                defaultValue: "{{price}}/yr",
+                price: formatUsd(result.price.totalUsdCents),
+              })}
+              {result.renewal && (
+                <span className="text-neutral-500">
+                  {" · "}
+                  {t("cloud.appDomains.buyRenewsLine", {
+                    defaultValue: "renews {{price}}/yr",
+                    price: formatUsd(result.renewal.totalUsdCents),
+                  })}
+                </span>
+              )}
+            </p>
+          </div>
+
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button
+                size="sm"
+                disabled={buying}
+                className="bg-[#FF5800] hover:bg-[#e54f00] text-white rounded-sm shrink-0"
+              >
+                {buying ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <ShoppingCart className="h-4 w-4" />
+                )}
+                <span className="ml-1.5">
+                  {t("cloud.appDomains.buyAction", {
+                    defaultValue: "Buy {{price}}",
+                    price: formatUsd(result.price.totalUsdCents),
+                  })}
+                </span>
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>
+                  {t("cloud.appDomains.buyConfirmTitle", {
+                    defaultValue: "Buy {{domain}}?",
+                    domain: result.domain,
+                  })}
+                </AlertDialogTitle>
+                <AlertDialogDescription>
+                  {t("cloud.appDomains.buyConfirmBody", {
+                    defaultValue:
+                      "{{price}} will be charged from your credit balance now. The domain renews automatically each year at {{renewal}} unless you cancel.",
+                    price: formatUsd(result.price.totalUsdCents),
+                    renewal: formatUsd(
+                      (result.renewal ?? result.price).totalUsdCents,
+                    ),
+                  })}
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>
+                  {t("common.cancel", { defaultValue: "Cancel" })}
+                </AlertDialogCancel>
+                <AlertDialogAction
+                  onClick={() => void handleBuy()}
+                  className="bg-[#FF5800] hover:bg-[#e54f00] text-white"
+                >
+                  {t("cloud.appDomains.buyConfirmAction", {
+                    defaultValue: "Buy domain",
+                  })}
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </div>
+      )}
+
+      {error && (
+        <div className="flex flex-col gap-2 p-3 rounded-sm bg-red-500/10 border border-red-500/20">
+          <div className="flex items-center gap-2 text-sm text-red-300">
+            <AlertTriangle className="h-4 w-4 shrink-0" />
+            <span>{error}</span>
+          </div>
+          {needsCredits && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={openBilling}
+              className="self-start border-neutral-700 hover:bg-white/5"
+            >
+              <CreditCard className="h-4 w-4 mr-1.5" />
+              {t("cloud.appDomains.buyAddCredits", {
+                defaultValue: "Add credits",
+              })}
+            </Button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/cloud/applications/components/app-domains.tsx
+++ b/packages/ui/src/cloud/applications/components/app-domains.tsx
@@ -47,6 +47,7 @@ import {
 } from "../../../components/ui/tooltip";
 import { api } from "../../lib/api-client";
 import { useCloudT } from "../../shell/CloudI18nProvider";
+import { BuyDomainCard } from "./BuyDomainCard";
 
 interface DomainInfo {
   id: string;
@@ -558,6 +559,11 @@ export function AppDomains({ appId }: AppDomainsProps) {
             </div>
           )}
         </div>
+
+        {/* Buy a domain through Cloudflare (#10246) */}
+        {primaryDomain && !hasCustomDomain && !isLoading && (
+          <BuyDomainCard appId={appId} onPurchased={fetchDomains} />
+        )}
 
         {/* DNS Configuration Panel */}
         <AnimatePresence>


### PR DESCRIPTION
Today the domains tab is attach-BYO + DNS-verify only; the only buy surface was the agent `BUY_APP_DOMAIN` action. This adds a domain-search → price-quote → buy flow in the GUI, on top of the now-hardened buy money path (#10248 / #10297) and the renewal cron (#10303).

## What
- **`BuyDomainCard`** — search a domain → `POST /api/v1/apps/:id/domains/check` for an availability + price quote (now including the annual **renewal** price), then buy behind an **explicit confirm** via `POST /api/v1/apps/:id/domains/buy`.
- The buy is charged from the org credit balance:
  - **402** → insufficient-credits message + an **"Add credits"** CTA routed to the **system browser** via `openExternalUrl` (never an in-webview checkout, per the native rule),
  - **409** → "no longer available",
  - other failures → "Purchase failed. You were not charged."
- **Renewal price** shown in the quote + confirm body (pairs with the renewal cron) so the user sees the annual re-charge before buying.
- Rendered in `app-domains.tsx` when the app is deployed and has no custom domain attached yet. Matches the tab's visual system (orange `#FF5800` → `#e54f00` hover, neutral-900 cards, shared primitives).
- `domains/check` route now returns `renewal.totalUsdCents` alongside the registration price.

## Evidence
`BuyDomainCard.test.tsx` — 5 tests (jsdom, real `api-client` contract, mocked transport):
```
✓ disables Check until the input looks like a domain
✓ checks availability and shows the price + renewal quote
✓ shows 'not available' for a taken domain, with no Buy button
✓ buys after explicit confirm and refreshes the domain list
✓ on 402 surfaces an insufficient-credits error and an Add-credits CTA to the system browser
5 passed
```
typecheck: 0 errors in touched files (the single `steward-wallet-providers.tsx` wagmi `Config` error is pre-existing — unchanged vs develop). biome clean.

**Visual:** the domains tab lives in the authenticated cloud dashboard (`/dashboard/apps/:id?tab=domains`) and needs a deployed app + a CF-registrar-configured stack to render live; a faithful state mockup of the card (quote / confirm / 402) is attached to the task thread. Full `audit:cloud` of the live tab is a deploy-time verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)