### PR TITLE
ci(cloud): use plain ubuntu runner for deploy workflow

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -81,7 +81,7 @@ jobs:
   # ---------------------------------------------------------------------------
   deploy-api:
     name: Deploy API Worker
-    runs-on: ${{ fromJSON((github.ref == 'refs/heads/main' || github.event_name == 'pull_request') && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
+    runs-on: ubuntu-latest
     if: github.event_name != 'pull_request'
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -225,7 +225,7 @@ jobs:
   # ---------------------------------------------------------------------------
   deploy-console:
     name: Deploy Console (Pages · elizacloud.ai)
-    runs-on: ${{ fromJSON((github.ref == 'refs/heads/main' || github.event_name == 'pull_request') && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
+    runs-on: ubuntu-latest
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -391,7 +391,7 @@ jobs:
   # ---------------------------------------------------------------------------
   deploy-app:
     name: Deploy App (Pages · app.elizacloud.ai)
-    runs-on: ${{ fromJSON((github.ref == 'refs/heads/main' || github.event_name == 'pull_request') && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
+    runs-on: ubuntu-latest
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}


### PR DESCRIPTION
## Summary
- change Cloud CF Deploy jobs to plain `runs-on: ubuntu-latest`
- removes the conditional `fromJSON(["ubuntu-latest"])` form that left deploy jobs queued without runner assignment
- workflow-only change; no app/onboarding/runtime code changes

## Why
#10299 correctly moved production deploys away from the unhealthy self-hosted pool, but the resulting jobs were still queued with the label array form. The follow-up uses the standard string form for GitHub-hosted runners.

## Validation
- `actionlint .github/workflows/cloud-cf-deploy.yml`
- `git diff --check`

After merge I will watch the Cloud CF Deploy run and rerun the production onboarding/auth smoke.
