### PR TITLE
fix(chat): stream the reply on 404-conversation-recovery replay (#10231)

### DIFF
--- a/packages/ui/src/state/useChatSend.test.tsx
+++ b/packages/ui/src/state/useChatSend.test.tsx
@@ -340,14 +340,29 @@ describe("useChatSend 404 recovery", () => {
     ).toBe(false);
   });
 
-  it("recreates the conversation and replays when only the conversation was deleted", async () => {
+  it("recreates the conversation and replays as a token STREAM when only the conversation was deleted", async () => {
     // The normal recoverable case: the conversation row was deleted but the
-    // agent is fine. createConversation succeeds, the message is replayed.
-    mockStream404();
+    // agent is fine. createConversation succeeds, and the message is REPLAYED
+    // through the streaming endpoint (not the non-streaming one) so the reply
+    // tokens in rather than popping in all at once (#10231).
+    const replayTokens: Array<[string, string]> = [];
+    mocks.client.sendConversationMessageStream
+      .mockRejectedValueOnce(http404())
+      .mockImplementationOnce(
+        async (
+          _id: string,
+          _text: string,
+          onToken: (token: string, accumulatedText?: string) => void,
+        ) => {
+          onToken("hi", "hi");
+          onToken(" back", "hi back");
+          replayTokens.push(["hi", " back"]);
+          return { text: "hi back", completed: true };
+        },
+      );
     mocks.client.createConversation.mockResolvedValue({
       conversation: conversation("conv-new", "room-new"),
     });
-    mocks.client.sendConversationMessage.mockResolvedValue({ text: "hi back" });
     mocks.client.getBaseUrl.mockReturnValue(
       "https://api.elizacloud.ai/api/v1/eliza/agents/agent-123",
     );
@@ -366,7 +381,13 @@ describe("useChatSend 404 recovery", () => {
 
     expect(deps.setActionNotice).not.toHaveBeenCalled();
     expect(mocks.client.createConversation).toHaveBeenCalledTimes(1);
-    expect(mocks.client.sendConversationMessage).toHaveBeenCalledTimes(1);
+    // Original send (404) + streaming replay = two stream calls; the
+    // non-streaming endpoint is never used.
+    expect(mocks.client.sendConversationMessageStream).toHaveBeenCalledTimes(2);
+    expect(mocks.client.sendConversationMessage).not.toHaveBeenCalled();
+    // The replay actually streamed tokens.
+    expect(replayTokens).toEqual([["hi", " back"]]);
+    expect(deps.setChatFirstTokenReceived).toHaveBeenCalledWith(true);
     const remaining = deps.conversationMessagesRef.current;
     expect(
       remaining.some((m) => m.role === "user" && m.text === "hello there"),
@@ -437,7 +458,8 @@ describe("useChatSend always streams (#9174)", () => {
 
     // Happy path streams.
     expect(mocks.client.sendConversationMessageStream).toHaveBeenCalledTimes(1);
-    // The non-streaming endpoint is reserved for 404 recovery only.
+    // The non-streaming endpoint is never used — even 404 recovery streams now
+    // (#10231).
     expect(mocks.client.sendConversationMessage).not.toHaveBeenCalled();
     // Streaming context is active by default — the first-token signal fired as
     // tokens arrived through onToken.

--- a/packages/ui/src/state/useChatSend.ts
+++ b/packages/ui/src/state/useChatSend.ts
@@ -32,7 +32,6 @@ import { clearChatDraft } from "./ChatComposerContext.hooks";
 import { isConversationRecord } from "./chat-conversation-guards";
 import {
   applyStreamingTextModification,
-  filterRenderableConversationMessages,
   formatSearchBullet,
   type LoadConversationMessagesResult,
   mergeStreamingText,
@@ -1121,32 +1120,69 @@ export function useChatSend(deps: UseChatSendDeps) {
               conversationId: conversation.id,
             });
 
-            const retryData = await client.sendConversationMessage(
+            // Seed the recreated conversation with the user turn + an empty
+            // assistant placeholder, then REPLAY as a token stream — the 404
+            // recovery must stream like the primary send, not pop the whole
+            // reply in at once with the non-streaming endpoint (#10231).
+            const replayUserId = `temp-${Date.now()}`;
+            const replayAssistantId = `temp-resp-${Date.now()}`;
+            // Seed unfiltered (like the primary send path) — the empty assistant
+            // placeholder must survive so streamed tokens have a target;
+            // filterRenderableConversationMessages would drop an empty turn.
+            setConversationMessages([
+              { id: replayUserId, role: "user", text, timestamp: Date.now() },
+              {
+                id: replayAssistantId,
+                role: "assistant",
+                text: "",
+                timestamp: Date.now(),
+              },
+            ]);
+
+            let replayStreamedText = "";
+            const retryData = await client.sendConversationMessageStream(
               conversation.id,
               text,
+              (token, accumulatedText) => {
+                const nextText =
+                  typeof accumulatedText === "string"
+                    ? accumulatedText
+                    : mergeStreamingText(replayStreamedText, token);
+                if (nextText === replayStreamedText) return;
+                replayStreamedText = nextText;
+                setChatFirstTokenReceived(true);
+                scheduleStreamingText(replayAssistantId, nextText);
+              },
               channelType,
+              controller?.signal,
               imagesToSend,
               turn.metadata,
+              (serverStatus) => setServerTurnStatus(serverStatus),
             );
-            setConversationMessages(
-              filterRenderableConversationMessages([
-                {
-                  id: `temp-${Date.now()}`,
-                  role: "user",
-                  text,
-                  timestamp: Date.now(),
-                },
-                {
-                  id: `temp-resp-${Date.now()}`,
-                  role: "assistant",
-                  text: retryData.text,
-                  timestamp: Date.now(),
-                  ...(retryData.failureKind
-                    ? { failureKind: retryData.failureKind }
-                    : {}),
-                },
-              ]),
-            );
+
+            // Commit any throttle-parked token before the terminal modification.
+            flushStreamingText();
+
+            if (!retryData.text.trim()) {
+              applyStreamingTextModification(setConversationMessages, {
+                messageId: replayAssistantId,
+                ...(retryData.failureKind
+                  ? { mode: "fail", failureKind: retryData.failureKind }
+                  : { mode: "drop" }),
+              });
+            } else {
+              applyStreamingTextModification(setConversationMessages, {
+                messageId: replayAssistantId,
+                mode: "complete",
+                fullText: retryData.text,
+                ...(retryData.failureKind
+                  ? { failureKind: retryData.failureKind }
+                  : {}),
+                ...(retryData.reasoning
+                  ? { reasoning: retryData.reasoning }
+                  : {}),
+              });
+            }
           } catch {
             dropEmptyAssistantPlaceholder(assistantMsgId);
           }


### PR DESCRIPTION
The last open item from the app launch-readiness audit (#10231). On a chat send that 404s because the conversation row was deleted, the recovery path recreated the conversation and replayed via the **non-streaming** `sendConversationMessage`, so the reply popped in with no token streaming — inconsistent with the primary send path.

## Fix
Replay through `sendConversationMessageStream`:
- seed the recreated conversation with the user turn + an **empty assistant placeholder** (seeded *unfiltered*, mirroring the primary send — `filterRenderableConversationMessages` drops empty turns, which would leave the stream no target),
- stream tokens into it via the same `scheduleStreamingText` / `flushStreamingText` plumbing as the primary send (first-token signal + rich server-turn status),
- apply the terminal `drop` (empty) / `fail` (empty + failureKind) / `complete` modification.

The non-streaming endpoint is now unused in the hook (import removed).

## Evidence
`useChatSend.test.tsx` (the existing replay test, rewritten to drive the real path):
```
useChatSend 404 recovery
  ✓ keeps the user message + notifies when the agent is gone (cloud base createConversation 404)
  ✓ recreates the conversation and replays as a token STREAM when only the conversation was deleted
  ✓ does NOT notify on a non-cloud base when createConversation 404s
useChatSend always streams (#9174)
  ✓ uses the streaming endpoint on the happy path and never the non-streaming one
4 passed (matched), 13 skipped (filtered)
```
The rewritten replay test asserts: original send 404 + streaming replay = two stream calls, the non-streaming endpoint is never called, tokens actually stream (`["hi", " back"]`), the first-token signal fires, and the final assistant text lands. typecheck: 0 errors in touched files (the lone `steward-wallet-providers.tsx` wagmi `Config` error is pre-existing/unchanged). biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)