### PR TITLE
ci(cloud): checkout deploy jobs in temp dirs

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -87,6 +87,7 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       TURBO_CACHE: remote:rw
+      CHECKOUT_DIR: /tmp/eliza-checkout-${{ github.run_id }}-${{ github.run_attempt }}-deploy-api
     steps:
       - name: Checkout repository
         timeout-minutes: 5
@@ -94,13 +95,13 @@ jobs:
           CHECKOUT_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          shopt -s dotglob nullglob
-          rm -rf "${GITHUB_WORKSPACE:?}/"*
-          git init "$GITHUB_WORKSPACE"
-          git -C "$GITHUB_WORKSPACE" remote add origin "https://x-access-token:${CHECKOUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git -C "$GITHUB_WORKSPACE" -c protocol.version=2 fetch --no-tags --depth=1 origin "$GITHUB_SHA"
-          git -C "$GITHUB_WORKSPACE" checkout --force FETCH_HEAD
-          git -C "$GITHUB_WORKSPACE" clean -ffdx
+          mkdir -p "$CHECKOUT_DIR"
+          git init "$CHECKOUT_DIR"
+          git -C "$CHECKOUT_DIR" remote set-url origin "https://x-access-token:${CHECKOUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" 2>/dev/null \
+            || git -C "$CHECKOUT_DIR" remote add origin "https://x-access-token:${CHECKOUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git -C "$CHECKOUT_DIR" -c protocol.version=2 fetch --force --no-tags --depth=1 origin "$GITHUB_SHA"
+          git -C "$CHECKOUT_DIR" checkout --force --detach FETCH_HEAD
+          git -C "$CHECKOUT_DIR" reset --hard FETCH_HEAD
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
@@ -111,15 +112,19 @@ jobs:
           bun-version: "canary"
 
       - name: Install dependencies
+        working-directory: ${{ env.CHECKOUT_DIR }}
         run: bun install --no-save --ignore-scripts && git diff --exit-code -- bun.lock
 
       - name: Build linked elizaOS workspaces
+        working-directory: ${{ env.CHECKOUT_DIR }}
         run: bun run build:core
 
       - name: Verify Worker
+        working-directory: ${{ env.CHECKOUT_DIR }}
         run: bun run --cwd packages/cloud/api typecheck
 
       - name: Run Worker e2e
+        working-directory: ${{ env.CHECKOUT_DIR }}
         run: bun run --cwd packages/cloud/api test:e2e
         env:
           # The deploy runner is a shared self-hosted box running wrangler dev,
@@ -129,10 +134,12 @@ jobs:
           RUN_STEWARD_WALLET_E2E: "0"
 
       - name: Build
+        working-directory: ${{ env.CHECKOUT_DIR }}
         run: bun run --cwd packages/cloud/api build
 
       - name: Resolve deploy environment
         id: env
+        working-directory: ${{ env.CHECKOUT_DIR }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.environment }}" = "production" ]; then
             echo "wrangler_args=--env production" >> "$GITHUB_OUTPUT"
@@ -150,6 +157,7 @@ jobs:
 
       - name: Check Cloudflare credentials
         id: cf
+        working-directory: ${{ env.CHECKOUT_DIR }}
         env:
           HAS_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN != '' }}
           HAS_ACCOUNT: ${{ secrets.CLOUDFLARE_ACCOUNT_ID != '' }}
@@ -172,7 +180,7 @@ jobs:
 
       - name: Publish Worker AI secrets
         if: steps.cf.outputs.configured == 'true'
-        working-directory: packages/cloud/api
+        working-directory: ${{ env.CHECKOUT_DIR }}/packages/cloud/api
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -222,11 +230,16 @@ jobs:
 
       - name: Deploy to Cloudflare Workers
         if: steps.cf.outputs.configured == 'true'
-        working-directory: packages/cloud/api
+        working-directory: ${{ env.CHECKOUT_DIR }}/packages/cloud/api
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: bunx wrangler deploy ${{ steps.env.outputs.wrangler_args }}
+
+      - name: Clean temp checkout
+        if: always()
+        working-directory: /tmp
+        run: timeout 120s rm -rf "$CHECKOUT_DIR" || echo "::warning::Timed out cleaning $CHECKOUT_DIR"
 
   # ---------------------------------------------------------------------------
   # Console frontend (Cloudflare Pages) — packages/app at the elizacloud.ai apex.
@@ -242,6 +255,7 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       TURBO_CACHE: remote:rw
+      CHECKOUT_DIR: /tmp/eliza-checkout-${{ github.run_id }}-${{ github.run_attempt }}-deploy-console
     steps:
       - name: Checkout repository
         timeout-minutes: 5
@@ -249,13 +263,13 @@ jobs:
           CHECKOUT_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          shopt -s dotglob nullglob
-          rm -rf "${GITHUB_WORKSPACE:?}/"*
-          git init "$GITHUB_WORKSPACE"
-          git -C "$GITHUB_WORKSPACE" remote add origin "https://x-access-token:${CHECKOUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git -C "$GITHUB_WORKSPACE" -c protocol.version=2 fetch --no-tags --depth=1 origin "$GITHUB_SHA"
-          git -C "$GITHUB_WORKSPACE" checkout --force FETCH_HEAD
-          git -C "$GITHUB_WORKSPACE" clean -ffdx
+          mkdir -p "$CHECKOUT_DIR"
+          git init "$CHECKOUT_DIR"
+          git -C "$CHECKOUT_DIR" remote set-url origin "https://x-access-token:${CHECKOUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" 2>/dev/null \
+            || git -C "$CHECKOUT_DIR" remote add origin "https://x-access-token:${CHECKOUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git -C "$CHECKOUT_DIR" -c protocol.version=2 fetch --force --no-tags --depth=1 origin "$GITHUB_SHA"
+          git -C "$CHECKOUT_DIR" checkout --force --detach FETCH_HEAD
+          git -C "$CHECKOUT_DIR" reset --hard FETCH_HEAD
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
@@ -266,9 +280,11 @@ jobs:
           bun-version: "canary"
 
       - name: Install dependencies
+        working-directory: ${{ env.CHECKOUT_DIR }}
         run: bun install --no-save --ignore-scripts && git diff --exit-code -- bun.lock
 
       - name: Build linked elizaOS core workspace
+        working-directory: ${{ env.CHECKOUT_DIR }}
         run: bun run build:core
 
       # The cloud console origin, built from packages/app. The vite build is the
@@ -276,6 +292,7 @@ jobs:
       # separate verify workflow, not here. Identical build to deploy-app — only
       # the canonical-origin env below differs (apex vs app.* subdomain).
       - name: Build console (packages/app)
+        working-directory: ${{ env.CHECKOUT_DIR }}
         run: bun run --cwd packages/app build:web
         env:
           VITE_API_URL: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'https://api.elizacloud.ai' || 'https://api-staging.elizacloud.ai' }}
@@ -306,11 +323,12 @@ jobs:
       # the crypto/wallet/solana graph into one lazy `vendor-crypto` chunk, so a
       # clean build passes and any future eager-chunk regression fails the deploy.
       - name: Verify bundle chunk safety
-        working-directory: packages/app
+        working-directory: ${{ env.CHECKOUT_DIR }}/packages/app
         run: bun run verify:chunks
 
       - name: Resolve Pages branch
         id: pages
+        working-directory: ${{ env.CHECKOUT_DIR }}
         env:
           PR_HEAD_REF: ${{ github.head_ref }}
           EVENT_NAME: ${{ github.event_name }}
@@ -327,6 +345,7 @@ jobs:
 
       - name: Check Cloudflare credentials
         id: cf
+        working-directory: ${{ env.CHECKOUT_DIR }}
         env:
           HAS_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN != '' }}
           HAS_ACCOUNT: ${{ secrets.CLOUDFLARE_ACCOUNT_ID != '' }}
@@ -349,7 +368,7 @@ jobs:
 
       - name: Deploy to Cloudflare Pages
         if: steps.cf.outputs.configured == 'true'
-        working-directory: packages/app
+        working-directory: ${{ env.CHECKOUT_DIR }}/packages/app
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -365,6 +384,7 @@ jobs:
       # freshly-deployed Cloudflare API Worker directly instead.
       - name: Verify API Worker health
         if: steps.cf.outputs.configured == 'true' && github.event_name != 'pull_request'
+        working-directory: ${{ env.CHECKOUT_DIR }}
         env:
           API_URL: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'https://api.elizacloud.ai' || 'https://api-staging.elizacloud.ai' }}
         run: |
@@ -406,6 +426,11 @@ jobs:
             echo "⚠️ Steward providers (DB-backed) health check failed post-deploy — likely a downstream DB incident, not this deploy." >> "$GITHUB_STEP_SUMMARY"
           fi
 
+      - name: Clean temp checkout
+        if: always()
+        working-directory: /tmp
+        run: timeout 120s rm -rf "$CHECKOUT_DIR" || echo "::warning::Timed out cleaning $CHECKOUT_DIR"
+
   # ---------------------------------------------------------------------------
   # App frontend (Cloudflare Pages) — packages/app (the Eliza agent app) at
   # app.elizacloud.ai. The same web UI as `bun run dev`. Deploys to the
@@ -420,6 +445,7 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       TURBO_CACHE: remote:rw
+      CHECKOUT_DIR: /tmp/eliza-checkout-${{ github.run_id }}-${{ github.run_attempt }}-deploy-app
     steps:
       - name: Checkout repository
         timeout-minutes: 5
@@ -427,13 +453,13 @@ jobs:
           CHECKOUT_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          shopt -s dotglob nullglob
-          rm -rf "${GITHUB_WORKSPACE:?}/"*
-          git init "$GITHUB_WORKSPACE"
-          git -C "$GITHUB_WORKSPACE" remote add origin "https://x-access-token:${CHECKOUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git -C "$GITHUB_WORKSPACE" -c protocol.version=2 fetch --no-tags --depth=1 origin "$GITHUB_SHA"
-          git -C "$GITHUB_WORKSPACE" checkout --force FETCH_HEAD
-          git -C "$GITHUB_WORKSPACE" clean -ffdx
+          mkdir -p "$CHECKOUT_DIR"
+          git init "$CHECKOUT_DIR"
+          git -C "$CHECKOUT_DIR" remote set-url origin "https://x-access-token:${CHECKOUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" 2>/dev/null \
+            || git -C "$CHECKOUT_DIR" remote add origin "https://x-access-token:${CHECKOUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git -C "$CHECKOUT_DIR" -c protocol.version=2 fetch --force --no-tags --depth=1 origin "$GITHUB_SHA"
+          git -C "$CHECKOUT_DIR" checkout --force --detach FETCH_HEAD
+          git -C "$CHECKOUT_DIR" reset --hard FETCH_HEAD
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
@@ -444,14 +470,17 @@ jobs:
           bun-version: "canary"
 
       - name: Install dependencies
+        working-directory: ${{ env.CHECKOUT_DIR }}
         run: bun install --no-save --ignore-scripts && git diff --exit-code -- bun.lock
 
       - name: Build linked elizaOS core workspace
+        working-directory: ${{ env.CHECKOUT_DIR }}
         run: bun run build:core
 
       # The Eliza agent app. The vite build is the gate (it resolves @elizaos/*
       # to source); typecheck is enforced by the separate verify workflow.
       - name: Build app
+        working-directory: ${{ env.CHECKOUT_DIR }}
         run: bun run --cwd packages/app build:web
         env:
           VITE_API_URL: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'https://api.elizacloud.ai' || 'https://api-staging.elizacloud.ai' }}
@@ -473,11 +502,12 @@ jobs:
       # the crypto/wallet/solana graph into one lazy `vendor-crypto` chunk, so a
       # clean build passes and any future eager-chunk regression fails the deploy.
       - name: Verify bundle chunk safety
-        working-directory: packages/app
+        working-directory: ${{ env.CHECKOUT_DIR }}/packages/app
         run: bun run verify:chunks
 
       - name: Resolve Pages branch
         id: pages
+        working-directory: ${{ env.CHECKOUT_DIR }}
         env:
           PR_HEAD_REF: ${{ github.head_ref }}
           EVENT_NAME: ${{ github.event_name }}
@@ -494,6 +524,7 @@ jobs:
 
       - name: Check Cloudflare credentials
         id: cf
+        working-directory: ${{ env.CHECKOUT_DIR }}
         env:
           HAS_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN != '' }}
           HAS_ACCOUNT: ${{ secrets.CLOUDFLARE_ACCOUNT_ID != '' }}
@@ -520,6 +551,7 @@ jobs:
       # docs/cloud-into-eliza/CUTOVER-RUNBOOK.md.
       - name: Ensure eliza-app Pages project exists
         if: steps.cf.outputs.configured == 'true'
+        working-directory: ${{ env.CHECKOUT_DIR }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -527,7 +559,7 @@ jobs:
 
       - name: Deploy to Cloudflare Pages
         if: steps.cf.outputs.configured == 'true'
-        working-directory: packages/app
+        working-directory: ${{ env.CHECKOUT_DIR }}/packages/app
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -535,3 +567,8 @@ jobs:
         # `pages_build_output_dir = "./dist"`, and passing both makes wrangler
         # ignore wrangler.toml — which silently drops the `functions/` upload.
         run: bunx wrangler pages deploy --project-name=eliza-app --branch=${{ steps.pages.outputs.branch }}
+
+      - name: Clean temp checkout
+        if: always()
+        working-directory: /tmp
+        run: timeout 120s rm -rf "$CHECKOUT_DIR" || echo "::warning::Timed out cleaning $CHECKOUT_DIR"


### PR DESCRIPTION
## Summary
- check out Cloud CF Deploy jobs into unique /tmp directories instead of deleting the self-hosted runner workspace
- run all repo-dependent deploy steps from CHECKOUT_DIR
- add bounded non-blocking cleanup for the temp checkout

## Why
Production Cloud CF Deploy run 28410867949 proved that the deploy jobs start on the self-hosted hetzner-robot pool, but all three jobs time out in checkout before app code runs. The logs show the timeout is caused by the pre-checkout workspace deletion: Console/App orphaned `rm`, and API spent almost the full timeout before reaching `git init`.

This keeps the self-hosted runner path that actually starts jobs, but avoids recursive deletion of dirty runner workspaces on the critical deploy path.

## Validation
- `actionlint .github/workflows/cloud-cf-deploy.yml`
- `git diff --check`