### PR TITLE
[codex] ci(cloud): give deploy checkout more time

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -94,7 +94,7 @@ jobs:
       CHECKOUT_DIR: /tmp/eliza-checkout-${{ github.run_id }}-${{ github.run_attempt }}-deploy-api
     steps:
       - name: Checkout repository
-        timeout-minutes: 5
+        timeout-minutes: 15
         env:
           CHECKOUT_TOKEN: ${{ github.token }}
         run: |
@@ -262,7 +262,7 @@ jobs:
       CHECKOUT_DIR: /tmp/eliza-checkout-${{ github.run_id }}-${{ github.run_attempt }}-deploy-console
     steps:
       - name: Checkout repository
-        timeout-minutes: 5
+        timeout-minutes: 15
         env:
           CHECKOUT_TOKEN: ${{ github.token }}
         run: |
@@ -452,7 +452,7 @@ jobs:
       CHECKOUT_DIR: /tmp/eliza-checkout-${{ github.run_id }}-${{ github.run_attempt }}-deploy-app
     steps:
       - name: Checkout repository
-        timeout-minutes: 5
+        timeout-minutes: 15
         env:
           CHECKOUT_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
## Summary
- Increase the Cloud CF Deploy manual checkout timeout from 5 minutes to 15 minutes for API, Console, and App deploy jobs.

## Root cause
The latest `main` production deploy (`28411818426`, `f930589e46`) failed before any product build/test/deploy work could run. Logs show the temp-dir checkout did fetch and start checking out the correct SHA, but the self-hosted deploy runners exceeded the 5-minute step timeout under load:

- App: fetch finished, checkout/reset reached `f930589e46`, then the step timed out after 5 minutes.
- Console/API: cancelled in the same checkout phase; API also showed the existing self-hosted runner diagnostic-file collision.

The temp checkout isolation from #10314 is still the right shape; the timeout was just too aggressive for the current runner behavior.

## Validation
- `actionlint .github/workflows/cloud-cf-deploy.yml`
- `git diff --check`
