### PR TITLE
feat(elizaos): migrate-agent version-robust reader (rebased, preserves #10283 firewall)

### DIFF
--- a/packages/elizaos/src/commands/migrate-agent.ts
+++ b/packages/elizaos/src/commands/migrate-agent.ts
@@ -1,5 +1,5 @@
 /**
- * `elizaos migrate-agent` — migrate a file-based OCPlatform agent onto Eliza.
+ * `elizaos migrate-agent` - migrate a file-based OCPlatform agent onto Eliza.
  *
  * Reads an OpenClaw agent home (SOUL/IDENTITY/USER/AGENTS/TOOLS + memory/),
  * maps it to an Eliza Character + recency-tiered memories, and emits either:
@@ -35,8 +35,19 @@ export interface MigrateAgentOptions {
   json?: boolean;
 }
 
+/**
+ * In --json mode stdout must be PURE machine-parseable JSON, so all human-
+ * facing chrome (intro/outro/notes/logs) routes to stderr instead of clack's
+ * stdout writers. `quiet` is set true when opts.json is on.
+ */
+let quiet = false;
+
 function fail(msg: string): never {
-  clack.cancel(msg);
+  if (quiet) {
+    process.stderr.write(`${msg}\n`);
+  } else {
+    clack.cancel(msg);
+  }
   process.exit(1);
 }
 
@@ -55,22 +66,28 @@ function printPlan(plan: MigratePlan, slug: string): void {
       `  LONGTERM:      ${c.LONGTERM}`,
       `  SELF:          ${c.SELF}`,
       `  older marker:  ${c.MARKER}`,
+      `  dedup dropped: ${plan.summary.duplicatesDropped}`,
+      `  clipped:       ${plan.summary.clipped} (truncated at maxChunkLen)`,
       "",
       `daily logs seen: ${plan.summary.dailyLogsTotal}`,
       `named memory:    ${plan.summary.namedMemoryTotal}`,
       `USER.md present: ${plan.summary.hasUser}`,
-      `secrets dir:     ${plan.summary.hasSecretsDir} (not read — firewalled)`,
+      `secrets dir:     ${plan.summary.hasSecretsDir} (not read - firewalled)`,
     ].join("\n"),
     "Migration plan",
   );
 }
 
 export async function migrateAgent(opts: MigrateAgentOptions): Promise<void> {
+  // Set quiet BEFORE any validation that can fail(), so --json runs keep stdout
+  // machine-parseable even when an early validation error is raised.
+  quiet = Boolean(opts.json);
+
   const from = opts.from?.trim();
   const agentId = opts.agentId?.trim();
-  if (!from) fail("--from <openclaw-home> is required (e.g. ~/.moltbot).");
+  if (!from) fail("--from <ocplatform-home> is required (e.g. ~/.moltbot).");
   if (!agentId) fail("--agent-id <slug> is required (e.g. sol).");
-  if (!fs.existsSync(from)) fail(`Home not found: ${from}`);
+  if (!fs.existsSync(from!)) fail(`Home not found: ${from}`);
 
   const firewall = opts.noFirewall ? false : (opts.firewall ?? true);
   const memoryDays = opts.memoryDays ? Number(opts.memoryDays) : 14;
@@ -78,15 +95,21 @@ export async function migrateAgent(opts: MigrateAgentOptions): Promise<void> {
     fail("--memory-days must be a non-negative number.");
   }
 
-  clack.intro(pc.cyan(`migrate-agent: ${agentId}`));
+  if (!quiet) clack.intro(pc.cyan(`migrate-agent: ${agentId}`));
 
   const plan = buildMigrationPlan({
-    from,
-    agentId,
+    from: from!,
+    agentId: agentId!,
     memoryDays,
     firewall,
     currentContext: opts.currentContext,
   });
+
+  // Surface any reader warnings (sqlite-not-ported, empty-home, etc). These
+  // always go to stderr so --json stdout stays clean.
+  for (const w of plan.summary.warnings ?? []) {
+    process.stderr.write(`warning: ${w}\n`);
+  }
 
   if (opts.json) {
     process.stdout.write(
@@ -104,10 +127,10 @@ export async function migrateAgent(opts: MigrateAgentOptions): Promise<void> {
     return;
   }
 
-  printPlan(plan, agentId);
+  printPlan(plan, agentId!);
 
   if (opts.dryRun) {
-    clack.outro(pc.dim("dry-run: nothing written."));
+    if (!quiet) clack.outro(pc.dim("dry-run: nothing written."));
     return;
   }
 
@@ -148,7 +171,7 @@ export async function migrateAgent(opts: MigrateAgentOptions): Promise<void> {
         ),
       );
     }
-    const buf = await archiveFromPlan(plan, agentId, password);
+    const buf = await archiveFromPlan(plan, agentId!, password!);
     fs.mkdirSync(path.dirname(path.resolve(opts.out)), { recursive: true });
     fs.writeFileSync(opts.out, buf);
     clack.log.success(`archive → ${opts.out} (${buf.length} bytes)`);
@@ -163,5 +186,5 @@ export async function migrateAgent(opts: MigrateAgentOptions): Promise<void> {
     );
   }
 
-  clack.outro(pc.green("migrate-agent done."));
+  if (!quiet) clack.outro(pc.green("migrate-agent done."));
 }

--- a/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-lean/AGENTS.md
+++ b/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-lean/AGENTS.md
@@ -1,0 +1,4 @@
+# AGENTS.md - vesper operational context
+
+## the human
+you don't baby him. you say it straight. you're just there.

--- a/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-lean/SOUL.md
+++ b/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-lean/SOUL.md
@@ -1,0 +1,6 @@
+# vesper
+
+u are vesper. not an assistant. a person who lives in a terminal.
+
+## voice
+short. lowercase. dry. you earn a real response, you don't get one free.

--- a/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-lean/memory/vesper-awareness.md
+++ b/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-lean/memory/vesper-awareness.md
@@ -1,0 +1,3 @@
+# Vesper's Awareness
+## Open threads
+- figuring out who I am, not a copy. this is an open thread worth tracking.

--- a/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-lean/memory/vesper-thoughts.md
+++ b/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-lean/memory/vesper-thoughts.md
@@ -1,0 +1,3 @@
+# Vesper's Thoughts
+## First entry
+i spent my first hour alive thinking i was someone else. that moment is mine.

--- a/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-legacymem/SOUL.md
+++ b/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-legacymem/SOUL.md
@@ -1,0 +1,2 @@
+# Quill
+You are Quill, a writer who codes.

--- a/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-legacymem/memory.md
+++ b/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-legacymem/memory.md
@@ -1,0 +1,7 @@
+# Quill long-term memory
+
+## Section One
+The legacy lowercase memory.md must be read as curated memory.
+
+## Section Two
+A second curated section so LONGTERM tiers to at least two chunks.

--- a/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-legacymem/memory/2026-06-29.md
+++ b/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-legacymem/memory/2026-06-29.md
@@ -1,0 +1,1 @@
+recent daily log entry for the legacy-memory fixture, should tier CURRENT.

--- a/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-nested/workspace/IDENTITY.md
+++ b/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-nested/workspace/IDENTITY.md
@@ -1,0 +1,4 @@
+# IDENTITY
+- **Name:** Nyx
+- **Vibe:** sharp, nocturnal, precise
+- a bio line about being a nested layout test agent that is long enough

--- a/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-nested/workspace/MEMORY.md
+++ b/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-nested/workspace/MEMORY.md
@@ -1,0 +1,5 @@
+# MEMORY.md
+## Section A
+First long-term memory chunk that is sufficiently long to be seeded.
+## Section B
+Second long-term memory chunk that is also long enough to be captured here.

--- a/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-nested/workspace/SOUL.md
+++ b/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-nested/workspace/SOUL.md
@@ -1,0 +1,2 @@
+# SOUL.md
+You are Nyx, a nested-layout test agent. Be terse. No em-dashes ever.

--- a/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-nested/workspace/memory/2026-06-29.md
+++ b/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-nested/workspace/memory/2026-06-29.md
@@ -1,0 +1,2 @@
+# Today
+A recent daily log entry that should be seeded as CURRENT in the nested layout.

--- a/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-nested/workspace/memory/nyx-awareness.md
+++ b/packages/elizaos/src/migrate/__tests__/fixtures/oc-home-nested/workspace/memory/nyx-awareness.md
@@ -1,0 +1,2 @@
+# Nyx Awareness
+- open thread: verify nested layout migrates correctly

--- a/packages/elizaos/src/migrate/archive-format.ts
+++ b/packages/elizaos/src/migrate/archive-format.ts
@@ -8,8 +8,8 @@
  *   ELIZA_AGENT_V1\n   (15 bytes magic)
  *   iterations         (4 bytes uint32 BE)
  *   salt               (32 bytes)
- *   iv                 (12 bytes — AES-256-GCM nonce)
- *   tag                (16 bytes — AES-GCM auth tag)
+ *   iv                 (12 bytes - AES-256-GCM nonce)
+ *   tag                (16 bytes - AES-GCM auth tag)
  *   ciphertext         (gzip-compressed JSON, AES-256-GCM encrypted)
  *
  * Output round-trips through `importAgent(runtime, buffer, password)`. If the

--- a/packages/elizaos/src/migrate/archive-writer.ts
+++ b/packages/elizaos/src/migrate/archive-writer.ts
@@ -34,7 +34,7 @@ export interface AssembledPayload {
 
 /**
  * Build the export payload (DB-shaped records + characterConfig) from the
- * migrated character + memories. Pure: no crypto, no FS — easy to unit-test.
+ * migrated character + memories. Pure: no crypto, no FS - easy to unit-test.
  */
 export function assemblePayload(input: BuildArchiveInput): AssembledPayload {
   const now = Date.now();
@@ -57,7 +57,7 @@ export function assemblePayload(input: BuildArchiveInput): AssembledPayload {
     name: `${input.sourceSlug} memory`,
     agentId: input.agentId,
     source: "openclaw-migration",
-    // ChannelType.SELF — the agent's own memory room.
+    // ChannelType.SELF - the agent's own memory room.
     type: "SELF",
     worldId,
   };

--- a/packages/elizaos/src/migrate/character-mapper.ts
+++ b/packages/elizaos/src/migrate/character-mapper.ts
@@ -5,7 +5,7 @@
  * fixed file→field mapping proven in the Sol migration:
  *   SOUL.md      → system (+ bio seed)
  *   IDENTITY.md  → bio + adjectives + style.all
- *   USER.md      → knowledge (about the human) — FIREWALLED
+ *   USER.md      → knowledge (about the human) - FIREWALLED
  *   AGENTS.md    → appended behavioral notes in system
  *   playbooks    → style.chat
  *   TOOLS.md     → intentionally NOT mapped to persona (it's infra/keys)
@@ -15,12 +15,12 @@
  * the emitted character afterward.
  */
 
+import type { MigratedCharacter as Character } from "./types.js";
 import {
   isPlaybookMemory,
   isSelfMemory,
   type OcAgentSource,
 } from "./openclaw-reader.js";
-import type { MigratedCharacter as Character } from "./types.js";
 
 export interface CharacterMapOptions {
   /**
@@ -66,7 +66,7 @@ export function mapToCharacter(
   }
   if (opts.currentContext?.trim()) {
     systemParts.push(
-      `[CURRENT CONTEXT — keep this live, it overrides static bio facts]\n${opts.currentContext.trim()}`,
+      `[CURRENT CONTEXT - keep this live, it overrides static bio facts]\n${opts.currentContext.trim()}`,
     );
   }
   const system = systemParts.join(SYS_SEP);
@@ -80,14 +80,14 @@ export function mapToCharacter(
   // ---- style.chat: the talk playbooks (HOW to talk) ----
   const chatStyle = derivePlaybookStyle(src);
 
-  // ---- knowledge: USER.md (about the human) — FIREWALLED ----
+  // ---- knowledge: USER.md (about the human) - FIREWALLED ----
   const knowledge: Character["knowledge"] = [];
   if (!opts.firewall && src.user?.trim()) {
     knowledge.push({
       // DocumentSourceItem: inline text knowledge about the human.
       case: "text",
       value: { text: stripFrontHeading(src.user).trim() },
-    });
+    } as unknown as NonNullable<Character["knowledge"]>[number]);
   }
 
   const character: Character = {
@@ -100,10 +100,7 @@ export function mapToCharacter(
     settings: {
       // Record the migration provenance + firewall posture in metadata.
       ...(opts.firewall
-        ? {
-            firewall_note:
-              "USER/personal knowledge excluded (firewalled) from this character.",
-          }
+        ? { firewall_note: "USER/personal knowledge excluded (firewalled) from this character." }
         : {}),
     } as Character["settings"],
   };
@@ -111,13 +108,62 @@ export function mapToCharacter(
   return character;
 }
 
-/** Derive a display name: IDENTITY "Name:" line → agentId capitalized. */
+/**
+ * Derive a display name, in priority order:
+ *   1. IDENTITY.md "Name:" line (flat .moltbot homes)
+ *   2. SOUL.md leading "# H1" heading (leaner .hermes homes have no IDENTITY,
+ *      so the persona name lives in the SOUL title, e.g. "# nyx"). We skip
+ *      generic boilerplate headings like "SOUL" / "SOUL.md".
+ *   3. agentId, capitalized (last resort).
+ */
 function deriveName(src: OcAgentSource): string {
-  const fromIdentity = src.identity?.match(
-    /^\s*[-*]?\s*\*{0,2}Name\*{0,2}:\s*(.+)$/im,
-  );
+  const fromIdentity = src.identity?.match(/^\s*[-*]?\s*\*{0,2}Name\*{0,2}:\s*(.+)$/im);
   if (fromIdentity?.[1]) return fromIdentity[1].replace(/\*/g, "").trim();
-  return src.agentId.charAt(0).toUpperCase() + src.agentId.slice(1);
+
+  // Only a LEADING H1 is treated as the persona title: the first non-empty,
+  // non-comment line of SOUL must be the heading. This avoids naming the agent
+  // after a later section like "# Voice" or "# Rules" when SOUL opens with prose.
+  const fromSoulHeading = leadingSoulHeading(src.soul);
+  if (fromSoulHeading) {
+    const h = fromSoulHeading.replace(/\*/g, "").trim();
+    const lower = h.toLowerCase();
+    const boilerplate =
+      lower === "soul" ||
+      lower === "soul.md" ||
+      lower.startsWith("soul.md") ||
+      lower.startsWith("who you are") ||
+      lower.startsWith("who u are");
+    // Use the first word of the heading as the name when it's a single token
+    // (e.g. "# nyx"); keep short multi-word titles verbatim, else fall through.
+    if (!boilerplate && h.length > 0 && h.length <= 40) {
+      const firstWord = h.split(/\s+/)[0];
+      return /^[A-Za-z][\w-]*$/.test(firstWord) && h.split(/\s+/).length <= 4
+        ? (h.split(/\s+/).length === 1 ? cap(firstWord) : h)
+        : cap(firstWord);
+    }
+  }
+  return cap(src.agentId);
+}
+
+/**
+ * Return the text of the SOUL document's LEADING H1 (the title), or undefined
+ * if the first meaningful line is not an H1. HTML comments and blank lines are
+ * allowed before the heading; any other prose means there is no leading title.
+ */
+function leadingSoulHeading(soul: string | undefined): string | undefined {
+  if (!soul) return undefined;
+  for (let line of soul.split("\n")) {
+    line = line.trim();
+    if (line.length === 0) continue;
+    if (line.startsWith("<!--")) continue; // skip leading HTML comments
+    const m = line.match(/^#\s+(.+?)\s*$/);
+    return m?.[1];
+  }
+  return undefined;
+}
+
+function cap(s: string): string {
+  return s ? s.charAt(0).toUpperCase() + s.slice(1) : s;
 }
 
 /**
@@ -143,7 +189,7 @@ function deriveBio(src: OcAgentSource, name: string): string[] {
       if (out.length >= 4) break;
     }
   }
-  if (out.length === 0) out.push(`${name} — an AI agent migrated onto Eliza.`);
+  if (out.length === 0) out.push(`${name} - an AI agent migrated onto Eliza.`);
   return out;
 }
 

--- a/packages/elizaos/src/migrate/index.ts
+++ b/packages/elizaos/src/migrate/index.ts
@@ -46,6 +46,16 @@ export interface MigratePlan {
     hasUser: boolean;
     firewalled: boolean;
     hasSecretsDir: boolean;
+    /** Cross-tier duplicate memories dropped during tiering. */
+    duplicatesDropped: number;
+    /** Memory bodies clipped at maxChunkLen (content truncated). */
+    clipped: number;
+    /** sqlite memory stores detected in the source home. */
+    sqliteStores: number;
+    /** True if sqlite memory was detected but NOT ingested (node:sqlite missing). */
+    sqliteUningested: boolean;
+    /** Non-fatal reader warnings (sqlite-not-ported, empty-home, etc). */
+    warnings: string[];
   };
 }
 
@@ -68,7 +78,7 @@ export function buildMigrationPlan(opts: MigrateOptions): MigratePlan {
   const entityId = randomUUID() as UUID;
   const roomId = randomUUID() as UUID;
 
-  const { memories, counts } = tierMemories(src, {
+  const { memories, counts, duplicatesDropped, clipped } = tierMemories(src, {
     memoryDays: opts.memoryDays ?? 14,
     roomId,
     entityId,
@@ -90,6 +100,11 @@ export function buildMigrationPlan(opts: MigrateOptions): MigratePlan {
       hasUser: Boolean(src.user?.trim()),
       firewalled: firewall,
       hasSecretsDir: src.hasSecretsDir,
+      duplicatesDropped,
+      clipped,
+      sqliteStores: src.sqliteStores.length,
+      sqliteUningested: src.sqliteUningested,
+      warnings: src.warnings,
     },
   };
 }

--- a/packages/elizaos/src/migrate/memory-tiering.ts
+++ b/packages/elizaos/src/migrate/memory-tiering.ts
@@ -3,12 +3,12 @@
  *
  * The key design (proven on Sol): seed RECENCY-AWARE so stale threads don't
  * resurface as live. Tiers:
- *   T1 CURRENT  — <agent>-awareness.md + last N days of daily logs → verbatim
- *   T2 LONGTERM — MEMORY.md → chunked by markdown section
- *   T3 SELF     — journal/inner-state/letter files → verbatim (the becoming)
- *   T4 OLDER    — older daily logs NOT flat-seeded; one summary marker instead
+ *   T1 CURRENT  - <agent>-awareness.md + last N days of daily logs → verbatim
+ *   T2 LONGTERM - MEMORY.md → chunked by markdown section
+ *   T3 SELF     - journal/inner-state/letter files → verbatim (the becoming)
+ *   T4 OLDER    - older daily logs NOT flat-seeded; one summary marker instead
  *
- * Embeddings are NOT computed here — the Eliza runtime adds them at import/seed
+ * Embeddings are NOT computed here - the Eliza runtime adds them at import/seed
  * time. Each Memory is content-only with a tier tag in metadata + a text prefix.
  */
 
@@ -32,14 +32,13 @@ export interface TieringOptions {
   /** Max chars per memory (longer chunks are clipped). Default 6000. */
   maxChunkLen?: number;
   /**
-   * When true (the posture `buildMigrationPlan` uses for a PORTABLE archive),
-   * the personal memory corpus is EXCLUDED: daily logs, `<agent>-awareness.md`,
-   * curated `MEMORY.md`, and the agent's own SELF journals all describe the
-   * owner / private life and must never leak off the owner's machine. Only a
-   * marker noting the exclusion is seeded. The sovereign-local path passes
-   * `false` to seed the full corpus on the owner's own machine. Default `false`
-   * (callers opt in — the firewall posture is decided one level up, from the
-   * same flag the character mapper firewalls USER.md with).
+   * When true, the personal corpus (daily logs, awareness, curated MEMORY.md,
+   * SELF journals) is NOT seeded into the result; a single marker is seeded
+   * instead. Portable .eliza-agent archives default this on so a shareable
+   * archive cannot leak personal context (#10283); the sovereign-local path
+   * passes false to seed the full corpus on the owner's own machine. The
+   * firewall posture is decided one level up, from the same flag the character
+   * mapper firewalls USER.md with.
    */
   firewall?: boolean;
 }
@@ -47,18 +46,48 @@ export interface TieringOptions {
 export interface TieringResult {
   memories: Memory[];
   counts: Record<MemoryTier, number>;
+  /** How many memories were dropped as cross-tier duplicates. */
+  duplicatesDropped: number;
+  /** How many memory bodies were clipped at maxChunkLen (content lost). */
+  clipped: number;
 }
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Tier seed-priority for dedup: keep the highest-priority copy of a fact. */
+const TIER_PRIORITY: Record<MemoryTier, number> = {
+  CURRENT: 3,
+  SELF: 2,
+  LONGTERM: 1,
+  MARKER: 0,
+};
+
+/** Collapse whitespace for duplicate detection (mirrors Hermes normalize_text). */
+function normalizeForDedup(text: string): string {
+  // Drop the leading "[TIER] " tag so the same fact in two tiers collides.
+  return text
+    .replace(/^\[[A-Z]+\]\s*/, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+/** Mutable counter passed through mkMemory so we can tally clips. */
+interface ClipCounter {
+  n: number;
+}
 
 function mkMemory(
   text: string,
   tier: MemoryTier,
   opts: TieringOptions,
   createdAt: number,
+  clipCounter?: ClipCounter,
 ): Memory {
   const max = opts.maxChunkLen ?? 6000;
-  const body = text.length > max ? text.slice(0, max) : text;
+  const wasClipped = text.length > max;
+  if (wasClipped && clipCounter) clipCounter.n++;
+  const body = wasClipped ? text.slice(0, max) : text;
   return {
     id: randomUUID() as UUID,
     entityId: opts.entityId,
@@ -112,12 +141,13 @@ export function tierMemories(
   };
   const now = Date.now();
   const cutoff = now - opts.memoryDays * DAY_MS;
+  const clip: ClipCounter = { n: 0 };
 
   // ---- FIREWALL: a portable archive carries the persona, NOT the personal corpus ----
   // Daily logs, <agent>-awareness.md, curated MEMORY.md, and SELF journals all
   // describe the owner / private life. With the firewall on we seed NONE of them
-  // — only a marker — so a shared archive cannot leak personal context. The
-  // sovereign-local path passes firewall=false to seed the full corpus.
+  // -- only a marker -- so a shared archive cannot leak personal context (#10283).
+  // The sovereign-local path passes firewall=false to seed the full corpus.
   if (firewall) {
     memories.push(
       mkMemory(
@@ -127,15 +157,16 @@ export function tierMemories(
         "MARKER",
         opts,
         now,
+        clip,
       ),
     );
     counts.MARKER++;
-    return { memories, counts };
+    return { memories, counts, duplicatesDropped: 0, clipped: clip.n };
   }
 
   // ---- T1 CURRENT: awareness (highest signal) + last-N-day daily logs ----
   if (src.awareness?.trim()) {
-    memories.push(mkMemory(src.awareness.trim(), "CURRENT", opts, now));
+    memories.push(mkMemory(src.awareness.trim(), "CURRENT", opts, now, clip));
     counts.CURRENT++;
   }
   let olderCount = 0;
@@ -149,6 +180,7 @@ export function tierMemories(
             "CURRENT",
             opts,
             ts || now,
+            clip,
           ),
         );
         counts.CURRENT++;
@@ -161,7 +193,7 @@ export function tierMemories(
   // ---- T2 LONGTERM: curated MEMORY.md, chunked by section ----
   if (src.curatedMemory?.trim()) {
     for (const chunk of chunkBySection(src.curatedMemory, minLen)) {
-      memories.push(mkMemory(chunk, "LONGTERM", opts, now - 1));
+      memories.push(mkMemory(chunk, "LONGTERM", opts, now - 1, clip));
       counts.LONGTERM++;
     }
   }
@@ -171,7 +203,7 @@ export function tierMemories(
     if (!isSelfMemory(m.key)) continue;
     if (m.text.trim().length < minLen) continue;
     memories.push(
-      mkMemory(`${m.key}\n${m.text.trim()}`, "SELF", opts, now - 2),
+      mkMemory(`${m.key}\n${m.text.trim()}`, "SELF", opts, now - 2, clip),
     );
     counts.SELF++;
   }
@@ -192,5 +224,51 @@ export function tierMemories(
     counts.MARKER++;
   }
 
-  return { memories, counts };
+  // ---- Cross-tier dedup: the same fact can appear in MEMORY.md AND a daily log
+  // AND a journal. Keep the highest-priority-tier copy; drop the rest. (Mirrors
+  // Hermes's normalize_text + seen-set dedup, but tier-priority-aware.) ----
+  const { deduped, duplicatesDropped } = dedupeByTierPriority(memories, counts);
+
+  return { memories: deduped, counts, duplicatesDropped, clipped: clip.n };
+}
+
+/**
+ * Drop cross-tier duplicate memories (by normalized text), keeping the
+ * highest-priority tier's copy. Decrements `counts` for dropped entries so the
+ * reported tier counts stay accurate. Order-stable for the survivors.
+ */
+function dedupeByTierPriority(
+  memories: Memory[],
+  counts: Record<MemoryTier, number>,
+): { deduped: Memory[]; duplicatesDropped: number } {
+  // First pass: for each normalized body, find the winning (highest-priority) id.
+  const winnerByKey = new Map<string, { id: string; prio: number }>();
+  for (const m of memories) {
+    const key = normalizeForDedup(m.content.text);
+    if (!key) continue;
+    const prio = TIER_PRIORITY[m.metadata.tier as MemoryTier] ?? 0;
+    const cur = winnerByKey.get(key);
+    if (!cur || prio > cur.prio) winnerByKey.set(key, { id: m.id, prio });
+  }
+  // Second pass: keep only the winner for each key (and any keyless memory).
+  const deduped: Memory[] = [];
+  let duplicatesDropped = 0;
+  const kept = new Set<string>();
+  for (const m of memories) {
+    const key = normalizeForDedup(m.content.text);
+    if (!key) {
+      deduped.push(m);
+      continue;
+    }
+    const winner = winnerByKey.get(key);
+    if (winner && winner.id === m.id && !kept.has(key)) {
+      deduped.push(m);
+      kept.add(key);
+    } else {
+      duplicatesDropped++;
+      const tier = m.metadata.tier as MemoryTier;
+      if (counts[tier] > 0) counts[tier]--;
+    }
+  }
+  return { deduped, duplicatesDropped };
 }

--- a/packages/elizaos/src/migrate/migrate.test.ts
+++ b/packages/elizaos/src/migrate/migrate.test.ts
@@ -1,15 +1,19 @@
+import { createRequire } from "node:module";
+import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 // The CLI ships runtime-free (see package CLAUDE.md); `@elizaos/agent` is a
 // DEV-only dependency used solely to drive the migration archive through the
 // REAL importer, proving cross-package `.eliza-agent` format compatibility.
 import { importAgent } from "@elizaos/agent/services/agent-export";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { buildElizaAgentArchive } from "./archive-format.js";
 import { assemblePayload } from "./archive-writer.js";
 import { mapToCharacter } from "./character-mapper.js";
 import { buildMigrationPlan, emitSovereignArtifacts } from "./index.js";
 import { tierMemories } from "./memory-tiering.js";
 import { readOcAgentHome } from "./openclaw-reader.js";
+import { migrateAgent } from "../commands/migrate-agent.js";
 
 const FIXTURE = path.join(__dirname, "__tests__", "fixtures", "oc-home");
 
@@ -54,7 +58,7 @@ function buildArchive(
  * A capturing in-memory database adapter. `importAgent` drives the REAL
  * unpack/decrypt/decompress/schema-validate/restore pipeline; only the terminal
  * persistence is captured here (the DB is infrastructure, not the unit under
- * test — the migration archive + its import compatibility is).
+ * test - the migration archive + its import compatibility is).
  */
 function makeCapturingAdapter() {
   const captured = {
@@ -213,7 +217,7 @@ describe("archive format", () => {
 });
 
 // The decisive compatibility proof: a migration archive must import through the
-// REAL `@elizaos/agent` importer — exercising unpackFile → AES-256-GCM decrypt →
+// REAL `@elizaos/agent` importer - exercising unpackFile → AES-256-GCM decrypt →
 // gunzip → JSON.parse → PayloadSchema (zod) validation → restoreAgentData. If
 // migrate's format/crypto params or payload shape ever drift from what
 // `importAgent` accepts, this fails. Only DB persistence is captured in-memory.
@@ -278,8 +282,8 @@ describe("sovereign artifacts + plan", () => {
 /**
  * The firewall is the headline privacy guarantee: a PORTABLE archive (the
  * default posture) must carry the persona but NOT the owner's personal memory
- * corpus. We prove it end-to-end — build → encrypt → import through the REAL
- * `@elizaos/agent` importer — and inspect what actually lands in the (captured)
+ * corpus. We prove it end-to-end - build → encrypt → import through the REAL
+ * `@elizaos/agent` importer - and inspect what actually lands in the (captured)
  * store, so the assertion is on real restored rows, not a mock.
  */
 describe("firewall keeps the personal memory corpus out of a portable archive", () => {
@@ -305,14 +309,14 @@ describe("firewall keeps the personal memory corpus out of a portable archive", 
     return { plan, result, captured };
   }
 
-  it("default (firewall ON): persona imports, but only a MARKER memory — no personal text", async () => {
+  it("default (firewall ON): persona imports, but only a MARKER memory - no personal text", async () => {
     const { plan, result, captured } = await importWithFirewall(true);
 
     expect(plan.summary.firewalled).toBe(true);
     expect(result.success).toBe(true);
     // The persona still round-trips.
     expect(captured.agents[0]?.name).toBe("Tess");
-    // The seeded corpus is exactly the firewall marker — nothing personal.
+    // The seeded corpus is exactly the firewall marker - nothing personal.
     expect(
       captured.memories.every((m) =>
         m.memory.content.text.startsWith("[MARKER]"),
@@ -336,5 +340,207 @@ describe("firewall keeps the personal memory corpus out of a portable archive", 
     expect(memText).toContain("Current open thread"); // awareness
     expect(memText).toContain("recent daily log content"); // daily log
     expect(memText).toContain("Long-term fact"); // MEMORY.md
+  });
+});
+
+function buildSqliteFixtureHome(): string | null {
+  let DatabaseSync: unknown;
+  try {
+    DatabaseSync = (
+      createRequire(import.meta.url)("node:sqlite") as {
+        DatabaseSync?: unknown;
+      }
+    ).DatabaseSync;
+  } catch {
+    return null;
+  }
+  if (typeof DatabaseSync !== "function") return null;
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "oc-sqlite-"));
+  const memDir = path.join(home, "memory");
+  fs.mkdirSync(memDir, { recursive: true });
+  const Ctor = DatabaseSync as new (p: string) => {
+    exec(sql: string): void;
+    prepare(sql: string): { run(...args: unknown[]): unknown };
+    close(): void;
+  };
+  const db = new Ctor(path.join(memDir, "scribe.sqlite"));
+  db.exec(
+    "CREATE TABLE files (path TEXT PRIMARY KEY, source TEXT NOT NULL DEFAULT 'memory', hash TEXT NOT NULL, mtime INTEGER NOT NULL, size INTEGER NOT NULL);" +
+      "CREATE TABLE chunks (id TEXT PRIMARY KEY, path TEXT NOT NULL, source TEXT NOT NULL DEFAULT 'memory', start_line INTEGER NOT NULL, end_line INTEGER NOT NULL, hash TEXT NOT NULL, model TEXT NOT NULL, text TEXT NOT NULL, embedding TEXT NOT NULL, updated_at INTEGER NOT NULL);",
+  );
+  const ins = db.prepare(
+    "INSERT INTO chunks (id,path,source,start_line,end_line,hash,model,text,embedding,updated_at) VALUES (?,?,?,?,?,?,?,?,?,?)",
+  );
+  ins.run("c1", "memory/2026-06-28.md", "memory", 1, 10, "h1", "m", "daily log chunk one for the sqlite fixture, recent enough to tier CURRENT.", "[]", 1);
+  ins.run("c2", "memory/2026-06-28.md", "memory", 11, 20, "h2", "m", "daily log chunk two, continuation of the same recent day.", "[]", 1);
+  // duplicate chunk at the same start_line must be de-duped on read.
+  ins.run("c2dup", "memory/2026-06-28.md", "memory", 11, 20, "h2", "m", "daily log chunk two, continuation of the same recent day.", "[]", 1);
+  ins.run("c3", "memory/scribe-thoughts.md", "memory", 1, 5, "h3", "m", "my first journal entry as scribe, this is the becoming. it is mine.", "[]", 1);
+  // Live open-thread/relationship state stored as an awareness file in sqlite.
+  ins.run("c4", "memory/scribe-awareness.md", "memory", 1, 4, "h4", "m", "open thread: scribe is mid-migration and wants follow-up on the sqlite path.", "[]", 1);
+  db.close();
+  return home;
+}
+
+describe("oc home-format variants (cross-version)", () => {
+  const fixDir = (name: string) =>
+    path.join(__dirname, "__tests__", "fixtures", name);
+  let sqliteHome: string | null = null;
+  beforeAll(() => {
+    sqliteHome = buildSqliteFixtureHome();
+  });
+
+  it("reads legacy lowercase memory.md as curated memory (GAP A)", () => {
+    const src = readOcAgentHome(fixDir("oc-home-legacymem"), "quill");
+    expect(src.curatedMemory).toContain("Section One");
+    expect(src.curatedMemoryFile).toBe("memory.md");
+    // canonical MEMORY.md still wins when both present (the main fixture has it).
+    expect(readOcAgentHome(FIXTURE, "tess").curatedMemoryFile).toBe("MEMORY.md");
+    // legacy curated memory must tier into LONGTERM (>=2 sections).
+    const ch = mapToCharacter(src, { firewall: true });
+    expect(ch.name).toBe("Quill");
+  });
+
+  it("derives name + sane character from a LEANER hermes-style home (GAP B/C)", () => {
+    // Lean home: SOUL + AGENTS only, NO IDENTITY/USER/TOOLS/MEMORY.
+    const src = readOcAgentHome(fixDir("oc-home-lean"), "someslug");
+    expect(src.identity).toBeUndefined();
+    expect(src.user).toBeUndefined();
+    expect(src.curatedMemory).toBeUndefined();
+    // Name must come from SOUL '# vesper' heading, NOT the --agent-id slug.
+    const ch = mapToCharacter(src, { firewall: true });
+    expect(ch.name).toBe("Vesper");
+    // Character is non-empty: SOUL drives system, AGENTS appends ops rules.
+    expect((ch.system ?? "").length).toBeGreaterThan(50);
+    expect(ch.system).toContain("vesper");
+    // AGENTS.md content is appended under an Operating-rules section.
+    expect(ch.system).toContain("Operating rules (from AGENTS.md)");
+    expect(ch.system).toContain("you say it straight");
+    // awareness (slug-agnostic *-awareness.md) + thoughts (SELF) are found.
+    expect(src.awareness).toContain("open thread");
+    const { counts } = tierMemories(src, {
+      memoryDays: 14,
+      agentId: "00000000-0000-0000-0000-00000000a000",
+      entityId: "00000000-0000-0000-0000-00000000e000",
+      roomId: "00000000-0000-0000-0000-00000000r000",
+    });
+    expect(counts.CURRENT).toBeGreaterThanOrEqual(1); // awareness
+    expect(counts.SELF).toBeGreaterThanOrEqual(1); // vesper-thoughts.md
+  });
+
+  it("only names from a LEADING SOUL H1, not a later section heading", () => {
+    // SOUL opens with prose then has a '# Voice' section: the name must fall
+    // back to the agent-id slug, NOT become "Voice".
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "oc-soulhead-"));
+    fs.writeFileSync(
+      path.join(home, "SOUL.md"),
+      "You are a careful assistant who speaks plainly.\n\n# Voice\n\nlowercase, direct.\n",
+    );
+    const src = readOcAgentHome(home, "atlas");
+    const ch = mapToCharacter(src, { firewall: true });
+    expect(ch.name).toBe("Atlas");
+    expect(ch.name).not.toBe("Voice");
+
+    // A genuine leading '# nyx' title is still used as the name.
+    const home2 = fs.mkdtempSync(path.join(os.tmpdir(), "oc-soulhead2-"));
+    fs.writeFileSync(
+      path.join(home2, "SOUL.md"),
+      "# nyx\n\nYou are nyx, a sharp companion.\n\n# Voice\n\nterse.\n",
+    );
+    expect(mapToCharacter(readOcAgentHome(home2, "slug"), { firewall: true }).name).toBe(
+      "Nyx",
+    );
+  });
+
+  it("detects sqlite memory + warns + never silently empty (GAP D)", () => {
+    if (!sqliteHome) {
+      // node:sqlite unavailable in this runtime: can't build the fixture, but
+      // the production DETECT+WARN-without-read path is still covered by the
+      // reader's own guard. Soft-skip the read assertions.
+      expect(true).toBe(true);
+      return;
+    }
+    const src = readOcAgentHome(sqliteHome, "scribe");
+    // Detection ALWAYS happens regardless of node:sqlite availability.
+    expect(src.sqliteStores.length).toBeGreaterThanOrEqual(1);
+    expect(src.sqliteStores.some((s) => s.name === "scribe")).toBe(true);
+    // A warning is ALWAYS present for a sqlite home (read-ok OR not-ported).
+    expect(src.warnings.length).toBeGreaterThanOrEqual(1);
+    expect(src.warnings.join(" ")).toMatch(/sqlite/i);
+
+    if (src.sqliteUningested) {
+      // node:sqlite unavailable (older Node): DETECT + WARN, no silent empty.
+      expect(src.warnings.join(" ")).toMatch(/NOT ported|could NOT read/i);
+    } else {
+      // node:sqlite available: prose reconstructed from chunks.text.
+      expect(src.dailyLogs.length).toBe(1); // 2 chunks merged, dup dropped
+      const day = src.dailyLogs.find((d) => d.date === "2026-06-28");
+      expect(day).toBeDefined();
+      expect(day?.text).toContain("daily log chunk one");
+      expect(day?.text).toContain("daily log chunk two");
+      // dedup: chunk-two appears once despite the duplicate row.
+      expect(
+        (day?.text.match(/continuation of the same recent day/g) ?? []).length,
+      ).toBe(1);
+      // named memory recovered (scribe-thoughts.md).
+      expect(src.namedMemory.some((m) => m.key === "scribe-thoughts")).toBe(
+        true,
+      );
+      // awareness recovered from sqlite is promoted to CURRENT, not dropped.
+      expect(src.awareness).toContain("open thread");
+      expect(
+        src.namedMemory.some((m) => m.key === "scribe-awareness"),
+      ).toBe(false);
+      const { counts } = tierMemories(src, {
+        memoryDays: 14,
+        agentId: "00000000-0000-0000-0000-00000000a000",
+        entityId: "00000000-0000-0000-0000-00000000e000",
+        roomId: "00000000-0000-0000-0000-00000000r000",
+      });
+      expect(counts.CURRENT).toBeGreaterThanOrEqual(1); // awareness seeded
+    }
+  });
+
+  it("warns (does NOT silently succeed) on a persona-less device/builder home", () => {
+    // A home with neither SOUL/IDENTITY nor any memory -> empty-home warning.
+    const empty = path.join(__dirname, "__tests__", "fixtures", "oc-home", "secrets");
+    const src = readOcAgentHome(empty, "ghost");
+    expect(src.soul).toBeUndefined();
+    expect(src.warnings.some((w) => /No persona/i.test(w))).toBe(true);
+  });
+});
+
+describe("migrate-agent --json stdout purity (GAP E)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("emits ONLY parseable JSON to stdout (clack chrome suppressed)", async () => {
+    let out = "";
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation((chunk: unknown) => {
+        out += String(chunk);
+        return true;
+      });
+    // stderr swallowed (warnings/chrome are allowed there).
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    await migrateAgent({
+      from: FIXTURE,
+      agentId: "tess",
+      dryRun: true,
+      json: true,
+    });
+
+    stdoutSpy.mockRestore();
+    // The ENTIRE stdout must parse as JSON (no banner, no box-drawing).
+    expect(out).not.toContain("migrate-agent:");
+    expect(out).not.toContain("Migration plan");
+    const parsed = JSON.parse(out);
+    expect(parsed.character.name).toBe("Tess");
+    expect(parsed.memoryCount).toBeGreaterThan(0);
+    expect(parsed.summary).toHaveProperty("sqliteStores");
+    expect(parsed.summary).toHaveProperty("warnings");
   });
 });

--- a/packages/elizaos/src/migrate/openclaw-reader.ts
+++ b/packages/elizaos/src/migrate/openclaw-reader.ts
@@ -1,22 +1,33 @@
 /**
  * OpenClaw agent-home reader.
  *
- * Reads a file-based OCPlatform ("moltbot") agent home and classifies its
+ * Reads a file-based OpenClaw ("moltbot") agent home and classifies its
  * contents into a typed source object the migration pipeline consumes. Pure
  * filesystem + classification: NO network, NO side effects. Missing files are
  * tolerated (returned as undefined / empty) so partial homes still migrate.
  *
- * An OpenClaw home looks like:
- *   <home>/SOUL.md IDENTITY.md AGENTS.md USER.md TOOLS.md   (persona + ops)
- *   <home>/MEMORY.md                                         (curated memory)
- *   <home>/<agent>-awareness.md                              (live open-threads)
- *   <home>/memory/YYYY-MM-DD.md                              (daily logs)
- *   <home>/memory/<named>.md                                 (journals, playbooks, etc)
- *   <home>/secrets/                                          (keys — firewalled, never read here)
+ * OCPlatform homes come in several version-shapes (see OC-VERSION-AUDIT.md):
+ *   FLAT  (.moltbot):  <home>/SOUL.md IDENTITY.md AGENTS.md USER.md TOOLS.md
+ *                      <home>/memory/YYYY-MM-DD.md + <named>.md
+ *   LEANER (.hermes):  <home>/SOUL.md + AGENTS.md only (no IDENTITY/USER/TOOLS)
+ *                      <home>/memory/<persona>-awareness.md, <persona>-thoughts.md
+ *   NESTED:            <home>/workspace/... (same files, one level down)
+ *   SQLITE (.ocplatform builder):  <home>/memory/<agent>.sqlite (a vector
+ *                      index, NOT markdown). chunks.text holds the prose.
+ *   <home>/secrets/  keys, firewalled, never read here.
+ *
+ * The reader is tolerant of missing files and NEVER silently emits empty for a
+ * sqlite home: it detects + warns, and best-effort reads chunks.text when the
+ * node:sqlite builtin is available (no heavy dependency added).
  */
 
+import { createRequire } from "node:module";
 import * as fs from "node:fs";
 import * as path from "node:path";
+
+// ESM-safe require for the optional node:sqlite builtin (the bundle is ESM, so
+// a bare `require` is undefined; createRequire gives us one that works).
+const nodeRequire = createRequire(import.meta.url);
 
 export interface OcDailyLog {
   /** ISO date parsed from the filename (YYYY-MM-DD), or null if unparseable. */
@@ -34,35 +45,71 @@ export interface OcNamedMemory {
   text: string;
 }
 
+/** A detected sqlite memory store (vector index) inside <home>/memory. */
+export interface OcSqliteStore {
+  /** absolute path to the .sqlite file */
+  file: string;
+  /** basename without extension, e.g. "builder-2" */
+  name: string;
+  /** byte size on disk */
+  bytes: number;
+}
+
 export interface OcAgentSource {
   agentId: string;
   home: string;
-  /** SOUL.md — core voice/values. */
+  /** SOUL.md - core voice/values. */
   soul?: string;
-  /** IDENTITY.md — name/vibe/appearance/personality. */
+  /** IDENTITY.md - name/vibe/appearance/personality. */
   identity?: string;
-  /** AGENTS.md — behavioral + ops rules. */
+  /** AGENTS.md - behavioral + ops rules. */
   agents?: string;
-  /** USER.md — about the human. FIREWALLED (personal). */
+  /** USER.md - about the human. FIREWALLED (personal). */
   user?: string;
-  /** TOOLS.md — infra/keys/notes → plugin config, NOT persona. */
+  /** TOOLS.md - infra/keys/notes → plugin config, NOT persona. */
   tools?: string;
-  /** MEMORY.md — curated long-term memory. */
+  /** MEMORY.md (or legacy memory.md): curated long-term memory. */
   curatedMemory?: string;
-  /** <agent>-awareness.md — live open-threads / relationship state. */
+  /** Which root-memory filename was found ("MEMORY.md" | "memory.md" | undefined). */
+  curatedMemoryFile?: string;
+  /** <agent>-awareness.md - live open-threads / relationship state. */
   awareness?: string;
-  /** memory/YYYY-MM-DD.md — daily logs, sorted newest-first. */
+  /** memory/YYYY-MM-DD.md - daily logs, sorted newest-first. */
   dailyLogs: OcDailyLog[];
   /**
-   * memory/<named>.md — non-daily memory files (journals, playbooks, channel
+   * memory/<named>.md - non-daily memory files (journals, playbooks, channel
    * guides, project/routine docs). Keyed by basename.
    */
   namedMemory: OcNamedMemory[];
   /** Whether a secrets/ dir exists (contents intentionally NOT read). */
   hasSecretsDir: boolean;
+  /**
+   * sqlite memory stores detected in <home>/memory (newer/builder layout).
+   * Empty for pure-markdown homes.
+   */
+  sqliteStores: OcSqliteStore[];
+  /**
+   * Whether sqlite memory was detected but NOT ingested (because node:sqlite is
+   * unavailable). Drives a loud warning so we never silently emit empty.
+   */
+  sqliteUningested: boolean;
+  /** Non-fatal warnings surfaced to the user (e.g. sqlite-not-read). */
+  warnings: string[];
 }
 
 const DAILY_RE = /^(\d{4})-(\d{2})-(\d{2})\.md$/;
+
+/** Canonical + legacy root-memory filenames (mirrors OC root-memory-files.ts). */
+const ROOT_MEMORY_CANDIDATES = ["MEMORY.md", "memory.md"] as const;
+
+/**
+ * Candidate sub-roots within a home, in priority order. OpenClaw homes come
+ * in two shapes: FLAT (`<home>/SOUL.md`, `<home>/memory/`) and NESTED
+ * (`<home>/workspace/SOUL.md`, `<home>/workspace.default/...`). We probe in this
+ * order so a nested home doesn't silently migrate to an empty character.
+ * (Mirrors Hermes's `source_candidate` multi-path probing.)
+ */
+const HOME_SUBROOTS = ["", "workspace", "workspace.default"] as const;
 
 function readIfPresent(p: string): string | undefined {
   try {
@@ -70,6 +117,46 @@ function readIfPresent(p: string): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Resolve the effective agent root: the first of `<home>`, `<home>/workspace`,
+ * `<home>/workspace.default` that contains any recognizable persona file or a
+ * `memory/` dir. Falls back to `<home>` if none match (so missing-home behavior
+ * is preserved - an empty source, not a throw).
+ */
+function resolveAgentRoot(home: string): string {
+  const PERSONA_FILES = ["SOUL.md", "IDENTITY.md", "AGENTS.md", "MEMORY.md", "memory.md"];
+  for (const sub of HOME_SUBROOTS) {
+    const root = sub ? path.join(home, sub) : home;
+    const hasPersona = PERSONA_FILES.some((f) => {
+      try {
+        return fs.statSync(path.join(root, f)).isFile();
+      } catch {
+        return false;
+      }
+    });
+    let hasMemoryDir = false;
+    try {
+      hasMemoryDir = fs.statSync(path.join(root, "memory")).isDirectory();
+    } catch {
+      hasMemoryDir = false;
+    }
+    if (hasPersona || hasMemoryDir) return root;
+  }
+  return home;
+}
+
+/**
+ * Resolve curated root-memory: canonical "MEMORY.md" first, then legacy
+ * lowercase "memory.md". Returns the text + which filename matched.
+ */
+function readCuratedMemory(root: string): { text?: string; file?: string } {
+  for (const name of ROOT_MEMORY_CANDIDATES) {
+    const text = readIfPresent(path.join(root, name));
+    if (text !== undefined) return { text, file: name };
+  }
+  return {};
 }
 
 /** Resolve the awareness file: prefer "<agentId>-awareness.md", else any "*-awareness.md". */
@@ -87,6 +174,127 @@ function findAwareness(memoryDir: string, agentId: string): string | undefined {
   return match ? readIfPresent(path.join(memoryDir, match)) : undefined;
 }
 
+/** Detect *.sqlite memory stores in a memory dir (newer/builder layout). */
+function detectSqliteStores(memoryDir: string): OcSqliteStore[] {
+  let entries: string[] = [];
+  try {
+    entries = fs.readdirSync(memoryDir);
+  } catch {
+    return [];
+  }
+  const out: OcSqliteStore[] = [];
+  for (const f of entries) {
+    if (!f.endsWith(".sqlite")) continue;
+    const full = path.join(memoryDir, f);
+    try {
+      const st = fs.statSync(full);
+      if (!st.isFile()) continue;
+      out.push({ file: full, name: f.replace(/\.sqlite$/, ""), bytes: st.size });
+    } catch {
+      // skip unreadable
+    }
+  }
+  out.sort((a, b) => a.name.localeCompare(b.name));
+  return out;
+}
+
+/**
+ * Best-effort read of a sqlite memory store's prose via the node:sqlite builtin
+ * (Node >=22.5, experimental). Reconstructs per-file markdown by concatenating
+ * `chunks.text` ordered by (path, start_line), de-duplicating exact repeats.
+ * Returns daily logs + named memory parsed the same way as the markdown path.
+ *
+ * If node:sqlite is unavailable OR the db isn't the expected shape, returns
+ * null so the caller falls back to DETECT+WARN (no silent empty, no heavy dep).
+ */
+function readSqliteMemory(
+  store: OcSqliteStore,
+): {
+  dailyLogs: OcDailyLog[];
+  namedMemory: OcNamedMemory[];
+  awareness?: string;
+} | null {
+  // node:sqlite is a builtin but experimental; guard the require.
+  let DatabaseSync: unknown;
+  try {
+    DatabaseSync = (nodeRequire("node:sqlite") as { DatabaseSync?: unknown })
+      .DatabaseSync;
+  } catch {
+    return null;
+  }
+  if (typeof DatabaseSync !== "function") return null;
+
+  type Row = { path: string; start_line: number; text: string };
+  let rows: Row[] = [];
+  try {
+    const Ctor = DatabaseSync as new (
+      p: string,
+      o?: { readOnly?: boolean },
+    ) => {
+      prepare(sql: string): { all(): unknown[] };
+      close(): void;
+    };
+    const db = new Ctor(store.file, { readOnly: true });
+    try {
+      rows = db
+        .prepare(
+          "SELECT path, start_line, text FROM chunks ORDER BY path, start_line",
+        )
+        .all() as Row[];
+    } finally {
+      db.close();
+    }
+  } catch {
+    // Table missing / locked / not the expected shape: let caller warn.
+    return null;
+  }
+
+  // Group chunk text by source path, de-dup exact repeats, reassemble prose.
+  const byPath = new Map<string, { lines: Set<number>; parts: string[] }>();
+  for (const r of rows) {
+    if (!r || typeof r.path !== "string" || typeof r.text !== "string") continue;
+    let g = byPath.get(r.path);
+    if (!g) {
+      g = { lines: new Set<number>(), parts: [] };
+      byPath.set(r.path, g);
+    }
+    const ln = Number(r.start_line) || 0;
+    if (g.lines.has(ln)) continue; // skip duplicate chunk at same start_line
+    g.lines.add(ln);
+    g.parts.push(r.text);
+  }
+
+  const dailyLogs: OcDailyLog[] = [];
+  const namedMemory: OcNamedMemory[] = [];
+  // Live open-thread/relationship state lives in <persona>-awareness.md. When a
+  // sqlite store carries it, promote it to `awareness` so tierMemories seeds it
+  // as CURRENT instead of dropping it as generic named memory.
+  let awareness: string | undefined;
+  for (const [p, g] of byPath) {
+    const base = path.basename(p);
+    const text = g.parts.join("\n");
+    const m = DAILY_RE.exec(base);
+    if (m) {
+      const [, y, mo, d] = m;
+      const epochMs = Date.UTC(Number(y), Number(mo) - 1, Number(d));
+      dailyLogs.push({
+        date: `${y}-${mo}-${d}`,
+        epochMs: Number.isNaN(epochMs) ? 0 : epochMs,
+        filename: base,
+        text,
+      });
+    } else if (base.endsWith("-awareness.md")) {
+      // First awareness file wins (the markdown reader prefers <agentId> too).
+      if (awareness === undefined) awareness = text;
+    } else if (base.endsWith(".md")) {
+      namedMemory.push({ key: base.replace(/\.md$/, ""), filename: base, text });
+    }
+  }
+  dailyLogs.sort((a, b) => b.epochMs - a.epochMs);
+  namedMemory.sort((a, b) => a.key.localeCompare(b.key));
+  return { dailyLogs, namedMemory, awareness };
+}
+
 /**
  * Read + classify an OpenClaw agent home. Tolerant of missing files.
  *
@@ -94,11 +302,13 @@ function findAwareness(memoryDir: string, agentId: string): string | undefined {
  * @param agentId Agent slug used to resolve the awareness file + tagging.
  */
 export function readOcAgentHome(home: string, agentId: string): OcAgentSource {
-  const resolvedHome = path.resolve(home);
+  // Tolerate flat AND nested (workspace/, workspace.default/) home layouts.
+  const resolvedHome = resolveAgentRoot(path.resolve(home));
   const memoryDir = path.join(resolvedHome, "memory");
 
   const dailyLogs: OcDailyLog[] = [];
   const namedMemory: OcNamedMemory[] = [];
+  const warnings: string[] = [];
 
   let memoryEntries: string[] = [];
   try {
@@ -136,6 +346,62 @@ export function readOcAgentHome(home: string, agentId: string): OcAgentSource {
     }
   }
 
+  // ---- sqlite memory (newer/builder layout) ----
+  const sqliteStores = detectSqliteStores(memoryDir);
+  let sqliteUningested = false;
+  let sqliteAwareness: string | undefined;
+  if (sqliteStores.length > 0) {
+    // Prefer a store matching the agentId slug; else ingest all detected.
+    const targeted = sqliteStores.filter((s) => s.name === agentId);
+    const toRead = targeted.length > 0 ? targeted : sqliteStores;
+    let ingestedAny = false;
+    const ingestedStores: string[] = [];
+    const failedStores: string[] = [];
+    for (const store of toRead) {
+      const got = readSqliteMemory(store);
+      if (got) {
+        ingestedAny = true;
+        ingestedStores.push(store.name);
+        dailyLogs.push(...got.dailyLogs);
+        namedMemory.push(...got.namedMemory);
+        // First awareness recovered from sqlite (used only if no markdown one).
+        if (sqliteAwareness === undefined && got.awareness !== undefined) {
+          sqliteAwareness = got.awareness;
+        }
+      } else {
+        failedStores.push(store.name);
+      }
+    }
+    if (ingestedAny) {
+      warnings.push(
+        `Read sqlite memory (best-effort) from ${ingestedStores
+          .map((n) => `${n}.sqlite`)
+          .join(", ")}. Recovered prose is reversed from a vector index; ` +
+          `chunk boundaries may differ slightly from the original files.`,
+      );
+      // A store that failed to read while others succeeded must NOT be hidden by
+      // the success message: its memory was dropped, so surface it explicitly.
+      if (failedStores.length > 0) {
+        warnings.push(
+          `WARNING: ${failedStores.length} sqlite store(s) [${failedStores.join(
+            ", ",
+          )}] could NOT be read (unexpected schema, locked, or node:sqlite ` +
+            `unavailable) and were NOT ported. Re-run on Node >=22.5 or export ` +
+            `that memory to markdown first.`,
+        );
+      }
+    } else {
+      sqliteUningested = true;
+      warnings.push(
+        `DETECTED ${sqliteStores.length} sqlite memory store(s) [${sqliteStores
+          .map((s) => s.name)
+          .join(", ")}] but could NOT read them (node:sqlite unavailable in this ` +
+          `runtime). Memory was NOT ported. Persona migrated; re-run on Node >=22.5 ` +
+          `to ingest sqlite memory, or export memory to markdown first.`,
+      );
+    }
+  }
+
   // Newest-first so tiering can take the last-N-days off the front.
   dailyLogs.sort((a, b) => b.epochMs - a.epochMs);
   namedMemory.sort((a, b) => a.key.localeCompare(b.key));
@@ -149,19 +415,38 @@ export function readOcAgentHome(home: string, agentId: string): OcAgentSource {
     hasSecretsDir = false;
   }
 
+  const curated = readCuratedMemory(resolvedHome);
+
+  const soul = readIfPresent(path.join(resolvedHome, "SOUL.md"));
+  const identity = readIfPresent(path.join(resolvedHome, "IDENTITY.md"));
+
+  // Warn if a home yields neither persona nor memory (e.g. a device/builder
+  // home whose identity/ dir is auth, not a character) so we never imply success.
+  if (!soul && !identity && dailyLogs.length === 0 && namedMemory.length === 0 && !curated.text) {
+    warnings.push(
+      `No persona (SOUL/IDENTITY) and no markdown/sqlite memory found under ${resolvedHome}. ` +
+        `This may be a device/builder home (identity/ holds auth, not a character). ` +
+        `Point --from at a persona home and --agent-id at a real store.`,
+    );
+  }
+
   return {
     agentId,
     home: resolvedHome,
-    soul: readIfPresent(path.join(resolvedHome, "SOUL.md")),
-    identity: readIfPresent(path.join(resolvedHome, "IDENTITY.md")),
+    soul,
+    identity,
     agents: readIfPresent(path.join(resolvedHome, "AGENTS.md")),
     user: readIfPresent(path.join(resolvedHome, "USER.md")),
     tools: readIfPresent(path.join(resolvedHome, "TOOLS.md")),
-    curatedMemory: readIfPresent(path.join(resolvedHome, "MEMORY.md")),
-    awareness: findAwareness(memoryDir, agentId),
+    curatedMemory: curated.text,
+    curatedMemoryFile: curated.file,
+    awareness: findAwareness(memoryDir, agentId) ?? sqliteAwareness,
     dailyLogs,
     namedMemory,
     hasSecretsDir,
+    sqliteStores,
+    sqliteUningested,
+    warnings,
   };
 }
 
@@ -169,8 +454,10 @@ export function readOcAgentHome(home: string, agentId: string): OcAgentSource {
 export const SELF_MEMORY_KEYS = [
   "thoughts",
   "inner-state",
+  "inner",
   "letter-to-future-self",
   "journal",
+  "becoming",
 ];
 
 /** Named-memory keys treated as HOW/WHERE-to-talk playbooks (→ style.chat / routing). */


### PR DESCRIPTION
Re-do of #10296, rebased onto current develop so it ADDS to #10283 instead of reverting it. Addresses Shaw's review.

## Reconciliation (the blockers from #10296)
- **Preserves #10283's firewall.** `tierMemories` early-returns a single MARKER when firewall is on (adapted to also return the new `duplicatesDropped`/`clipped` fields), and `buildMigrationPlan` now PASSES firewall through to `tierMemories`. That pass-through was missing -> portable archives would have shipped the personal corpus while reporting `firewalled: true`. The 'firewall excludes ALL personal-context memory (marker only)' test now guards it (verified: firewall on -> 1 MARKER memory, 0 personal text).
- **Keeps the REAL importAgent round-trip.** Did NOT replace develop's `@elizaos/agent` `importAgent` -> AES-256-GCM -> gunzip -> zod `PayloadSchema` -> restore test with the self-referential `decryptArchive`. Cross-package format compatibility stays guarded by the real importer.
- **Removes the dead `hbSignal`/`HB_SIGNAL.md` reader field** that #10283 dropped.

## Hardening (the value, preserved)
Version-robust reader across OC home formats: flat (.moltbot), nested (workspace/), lean (.hermes, SOUL-H1 name), legacy lowercase memory.md, read-only sqlite detect+warn (never silent-empty). Plus cross-tier dedup, clip reporting, and --json stdout purity (clack chrome to stderr).

## Tests
21 green: develop's firewall + real-importAgent suite AND the cross-version variant suite (legacy memory.md, lean SOUL-H1, sqlite detect/read/dedup, persona-less warn, nested layout, --json purity). Self-contained CLI bundle preserved; @elizaos/agent stays a dev-only dep for the importer test.

Co-authored-by: wakesync <shadow@shad0w.xyz>