### PR TITLE
fix(cloud): idempotent Stripe Connect payout debit + compensation-safe (#10279)

### DIFF
--- a/packages/cloud/api/__tests__/stripe-connect-transfer-route.test.ts
+++ b/packages/cloud/api/__tests__/stripe-connect-transfer-route.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Money-path regression for the admin-gated Stripe Connect fiat payout route
+ * (#10279 / #10327).
+ *
+ * The transfer is a compensating saga: debit the redeemable ledger, then push a
+ * Stripe transfer, then compensate on failure. Two correctness invariants the
+ * fix introduced were previously untested on a live money path:
+ *
+ *   1. The debit is IDEMPOTENT on `idempotency_key` — the route MUST pass
+ *      `dedupeBySourceId: true` with `sourceId === idempotency_key`, so a
+ *      same-key retry reuses the prior adjustment while Stripe replays the single
+ *      transfer (debited 1×, paid 1×).
+ *   2. Compensation is OUTCOME-AWARE. Only a DEFINITIVE Stripe rejection (no
+ *      transfer created: invalid-request / auth / permission / rate-limit)
+ *      re-credits the balance. An AMBIGUOUS failure (network timeout, Stripe 5xx
+ *      — the transfer may have settled) HOLDS the debit and surfaces
+ *      `needsReconciliation` rather than minting balance back and double-paying.
+ *
+ * `handleTransfer` is module-private, so we drive it through the exported Hono
+ * router (mirrors agent-a2a-billing.test.ts).
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+// `mock.module` is process-global: spread the real auth module so this file's
+// partial mock (only `requireAdmin`) does not drop its other exports for later
+// test files in the same run.
+import * as workersHonoAuthActual from "@/lib/auth/workers-hono-auth";
+
+const USER_ID = "00000000-0000-4000-8000-0000000000aa";
+const IDEMPOTENCY_KEY = "idem_key_0123456789abcdef"; // ≥16 chars (schema min)
+
+const findByUserId = mock();
+mock.module(
+  "@elizaos/cloud-shared/db/repositories/stripe-connect-accounts",
+  () => ({
+    stripeConnectAccountsRepository: { findByUserId },
+  }),
+);
+
+const transferToConnectAccount = mock();
+mock.module("@elizaos/cloud-shared/lib/services/stripe-connect-payout", () => ({
+  transferToConnectAccount,
+}));
+
+const requireAdmin = mock();
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  ...workersHonoAuthActual,
+  requireAdmin,
+}));
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { CRITICAL: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+
+const getBalance = mock();
+const reduceEarnings = mock();
+const addEarnings = mock();
+mock.module("@/lib/services/redeemable-earnings", () => ({
+  redeemableEarningsService: { getBalance, reduceEarnings, addEarnings },
+}));
+
+mock.module("@/lib/stripe", () => ({
+  requireStripe: () => ({}),
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { error: mock(), info: mock(), warn: mock() },
+}));
+
+const { default: transferRoute } = await import(
+  "../v1/earnings/payout/stripe-connect/transfer/route"
+);
+
+const app = new Hono();
+app.route("/transfer", transferRoute);
+
+function callTransfer(amount = 10) {
+  return app.request("/transfer", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      user_id: USER_ID,
+      amount,
+      idempotency_key: IDEMPOTENCY_KEY,
+    }),
+  });
+}
+
+/** A Stripe-SDK-shaped error: the route narrows on the `type` field. */
+function stripeError(type: string): Error & { type: string } {
+  return Object.assign(new Error(`stub ${type}`), { type });
+}
+
+beforeEach(() => {
+  findByUserId.mockReset();
+  transferToConnectAccount.mockReset();
+  requireAdmin.mockReset();
+  getBalance.mockReset();
+  reduceEarnings.mockReset();
+  addEarnings.mockReset();
+
+  requireAdmin.mockResolvedValue({ userId: "admin-1" });
+  findByUserId.mockResolvedValue({
+    stripe_connect_account_id: "acct_123",
+    status: "active",
+    payouts_enabled: true,
+  });
+  getBalance.mockResolvedValue({
+    availableBalance: 100,
+    totalEarned: 100,
+    totalRedeemed: 0,
+    totalPending: 0,
+    breakdown: { miniapps: 0, agents: 0, mcps: 0 },
+  });
+  reduceEarnings.mockResolvedValue({
+    success: true,
+    newBalance: 90,
+    ledgerEntryId: "led_1",
+  });
+  addEarnings.mockResolvedValue({ success: true, newBalance: 100 });
+});
+
+describe("Stripe Connect transfer route — money-path invariants (#10279)", () => {
+  test("debits idempotently (dedupeBySourceId on idempotency_key) and transfers once on success", async () => {
+    transferToConnectAccount.mockResolvedValue({
+      transferId: "tr_1",
+      amountCents: 1000,
+    });
+
+    const res = await callTransfer(10);
+    const body = (await res.json()) as {
+      success: boolean;
+      transferId?: string;
+    };
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.transferId).toBe("tr_1");
+
+    // The idempotency contract: debit keyed on idempotency_key, deduped.
+    expect(reduceEarnings).toHaveBeenCalledTimes(1);
+    const debitArg = reduceEarnings.mock.calls[0]?.[0] as {
+      sourceId: string;
+      dedupeBySourceId: boolean;
+      requireSufficientBalance: boolean;
+    };
+    expect(debitArg.sourceId).toBe(IDEMPOTENCY_KEY);
+    expect(debitArg.dedupeBySourceId).toBe(true);
+    expect(debitArg.requireSufficientBalance).toBe(true);
+    // Success path never compensates.
+    expect(addEarnings).not.toHaveBeenCalled();
+  });
+
+  test("DEFINITIVE Stripe rejection re-credits the balance (idempotent refund) and 502s", async () => {
+    transferToConnectAccount.mockRejectedValue(
+      stripeError("StripeInvalidRequestError"),
+    );
+
+    const res = await callTransfer(10);
+    const body = (await res.json()) as {
+      success: boolean;
+      error: string;
+      needsReconciliation?: boolean;
+    };
+
+    expect(res.status).toBe(502);
+    expect(body.success).toBe(false);
+    expect(body.error).toBe("Transfer rejected; balance restored");
+    expect(body.needsReconciliation).toBeUndefined();
+
+    // Compensation: a single idempotent refund keyed on `${key}:refund`.
+    expect(addEarnings).toHaveBeenCalledTimes(1);
+    const refundArg = addEarnings.mock.calls[0]?.[0] as {
+      sourceId: string;
+      dedupeBySourceId: boolean;
+      amount: number;
+    };
+    expect(refundArg.sourceId).toBe(`${IDEMPOTENCY_KEY}:refund`);
+    expect(refundArg.dedupeBySourceId).toBe(true);
+    expect(refundArg.amount).toBe(10);
+  });
+
+  test("AMBIGUOUS Stripe failure (5xx) HOLDS the debit — no re-credit, needsReconciliation", async () => {
+    transferToConnectAccount.mockRejectedValue(
+      stripeError("StripeConnectionError"),
+    );
+
+    const res = await callTransfer(10);
+    const body = (await res.json()) as {
+      success: boolean;
+      needsReconciliation?: boolean;
+    };
+
+    expect(res.status).toBe(502);
+    expect(body.success).toBe(false);
+    expect(body.needsReconciliation).toBe(true);
+    // Critically: the balance is NOT minted back on an uncertain outcome.
+    expect(addEarnings).not.toHaveBeenCalled();
+  });
+
+  test("AMBIGUOUS non-Stripe error (no type) also HOLDS the debit", async () => {
+    transferToConnectAccount.mockRejectedValue(new Error("network timeout"));
+
+    const res = await callTransfer(10);
+    const body = (await res.json()) as { needsReconciliation?: boolean };
+
+    expect(res.status).toBe(502);
+    expect(body.needsReconciliation).toBe(true);
+    expect(addEarnings).not.toHaveBeenCalled();
+  });
+
+  test("a failed debit short-circuits before any transfer (409, no Stripe call)", async () => {
+    reduceEarnings.mockResolvedValue({
+      success: false,
+      newBalance: 100,
+      ledgerEntryId: "",
+      error: "Insufficient redeemable balance",
+    });
+
+    const res = await callTransfer(10);
+    expect(res.status).toBe(409);
+    expect(transferToConnectAccount).not.toHaveBeenCalled();
+    expect(addEarnings).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/earnings/payout/stripe-connect/transfer/route.ts
+++ b/packages/cloud/api/v1/earnings/payout/stripe-connect/transfer/route.ts
@@ -92,6 +92,10 @@ async function handleTransfer(c: AppContext) {
   // can never let us transfer more fiat than the creator actually earned. On
   // success exactly `amount` is debited, so the compensation below (which
   // re-credits `amount`) is also exact.
+  // dedupeBySourceId makes the debit IDEMPOTENT on idempotency_key: a legitimate
+  // same-key retry (the point of the param) reuses the prior adjustment instead
+  // of debiting again, while Stripe replays the single transfer — so the creator
+  // is never debited 2× and paid 1×.
   const debit = await redeemableEarningsService.reduceEarnings({
     userId: user_id,
     amount,
@@ -100,6 +104,7 @@ async function handleTransfer(c: AppContext) {
     description: "Stripe Connect fiat payout",
     metadata: { payout_method: "stripe_connect" },
     requireSufficientBalance: true,
+    dedupeBySourceId: true,
   });
   if (!debit.success) {
     return Response.json(
@@ -130,21 +135,65 @@ async function handleTransfer(c: AppContext) {
       newBalance: debit.newBalance,
     });
   } catch (error) {
-    // Compensate: the transfer never settled, so restore the debited balance.
-    await redeemableEarningsService.addEarnings({
-      userId: user_id,
-      amount,
-      source: "creator_revenue_share",
-      sourceId: `${idempotency_key}:refund`,
-      description: "Stripe Connect payout failed — balance restored",
-      metadata: { payout_method: "stripe_connect", refund_of: idempotency_key },
-    });
-    logger.error("[StripeConnect] transfer failed; balance restored", {
-      userId: user_id,
-      error: error instanceof Error ? error.message : String(error),
-    });
+    // Only auto-compensate when Stripe DEFINITIVELY rejected the request, i.e.
+    // no transfer was created (bad params, inactive account, insufficient
+    // platform balance, auth/permission). On an AMBIGUOUS failure — a network
+    // timeout or a Stripe-side error where the create may have reached Stripe and
+    // settled — re-crediting would double-pay (fiat already left, balance
+    // restored). In that case we hold the debit and surface for reconciliation
+    // rather than mint balance back on uncertainty. The refund is itself
+    // idempotent (dedupeBySourceId) so a route retry can't double-credit.
+    const stripeType =
+      error && typeof error === "object" && "type" in error
+        ? String((error as { type: unknown }).type)
+        : "";
+    const definitivelyNotCreated =
+      stripeType === "StripeInvalidRequestError" ||
+      stripeType === "StripeAuthenticationError" ||
+      stripeType === "StripePermissionError" ||
+      stripeType === "StripeRateLimitError";
+
+    if (definitivelyNotCreated) {
+      await redeemableEarningsService.addEarnings({
+        userId: user_id,
+        amount,
+        source: "creator_revenue_share",
+        sourceId: `${idempotency_key}:refund`,
+        description: "Stripe Connect payout rejected — balance restored",
+        metadata: {
+          payout_method: "stripe_connect",
+          refund_of: idempotency_key,
+        },
+        dedupeBySourceId: true,
+      });
+      logger.error("[StripeConnect] transfer rejected; balance restored", {
+        userId: user_id,
+        stripeType,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return Response.json(
+        { success: false, error: "Transfer rejected; balance restored" },
+        { status: 502 },
+      );
+    }
+
+    // Ambiguous outcome — the transfer may have settled. Do NOT re-credit.
+    logger.error(
+      "[StripeConnect] transfer status UNKNOWN; balance HELD for reconciliation",
+      {
+        userId: user_id,
+        idempotencyKey: idempotency_key,
+        stripeType,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
     return Response.json(
-      { success: false, error: "Transfer failed; balance restored" },
+      {
+        success: false,
+        error:
+          "Transfer status unknown; balance held pending manual reconciliation",
+        needsReconciliation: true,
+      },
       { status: 502 },
     );
   }

--- a/packages/cloud/shared/src/lib/services/redeemable-earnings.ts
+++ b/packages/cloud/shared/src/lib/services/redeemable-earnings.ts
@@ -376,11 +376,22 @@ class RedeemableEarningsService {
      * internal callers.
      */
     requireSufficientBalance?: boolean;
+    /**
+     * When true, the debit is IDEMPOTENT on `sourceId`: a retry that reuses the
+     * same source_id (e.g. a money-out payout's idempotency key) finds the prior
+     * adjustment ledger row under the per-user advisory lock and returns it
+     * without debiting again. Required for real money-out debits whose caller's
+     * downstream side-effect (a Stripe transfer) is itself idempotent — without
+     * this, a same-key retry double-DEBITs the ledger while the transfer replays
+     * once. Default false preserves the additive reconciliation behavior.
+     */
+    dedupeBySourceId?: boolean;
   }): Promise<{
     success: boolean;
     newBalance: number;
     ledgerEntryId: string;
     error?: string;
+    deduplicated?: boolean;
   }> {
     const {
       userId,
@@ -390,6 +401,7 @@ class RedeemableEarningsService {
       description,
       metadata = {},
       requireSufficientBalance = false,
+      dedupeBySourceId = false,
     } = params;
 
     if (amount <= 0) {
@@ -428,8 +440,38 @@ class RedeemableEarningsService {
           ledgerEntryId: "",
           skipped: true,
           insufficient: false,
+          deduplicated: false,
           currentBalance: 0,
         };
+      }
+
+      // Idempotency guard: a retry that reuses the same sourceId must not debit
+      // twice. Under the per-user advisory lock the check-then-debit is atomic,
+      // so an existing adjustment row for this (source, source_id) means the
+      // debit already committed on a prior call — return it unchanged.
+      if (dedupeBySourceId) {
+        const [existingAdjustment] = await tx
+          .select({ id: redeemableEarningsLedger.id })
+          .from(redeemableEarningsLedger)
+          .where(
+            and(
+              eq(redeemableEarningsLedger.user_id, userId),
+              eq(redeemableEarningsLedger.entry_type, "adjustment"),
+              eq(redeemableEarningsLedger.earnings_source, source),
+              eq(redeemableEarningsLedger.source_id, ledgerSourceId),
+            ),
+          )
+          .limit(1);
+        if (existingAdjustment) {
+          return {
+            earnings,
+            ledgerEntryId: existingAdjustment.id,
+            skipped: false,
+            insufficient: false,
+            deduplicated: true,
+            currentBalance: Number(earnings.available_balance),
+          };
+        }
       }
 
       // Fail-closed money-out guard (computed under the row lock, on the
@@ -441,6 +483,7 @@ class RedeemableEarningsService {
           ledgerEntryId: "",
           skipped: false,
           insufficient: true,
+          deduplicated: false,
           currentBalance: Number(earnings.available_balance),
         };
       }
@@ -492,9 +535,24 @@ class RedeemableEarningsService {
         ledgerEntryId: ledgerEntry.id,
         skipped: false,
         insufficient: false,
+        deduplicated: false,
         currentBalance: 0,
       };
     });
+
+    if (result.deduplicated) {
+      logger.info("[RedeemableEarnings] reduceEarnings deduplicated by sourceId (retry)", {
+        userId: `${userId.slice(0, 8)}...`,
+        source,
+        sourceId: `${sourceId.slice(0, 8)}...`,
+      });
+      return {
+        success: true,
+        newBalance: Number(result.earnings?.available_balance ?? 0),
+        ledgerEntryId: result.ledgerEntryId,
+        deduplicated: true,
+      };
+    }
 
     if (result.insufficient) {
       return {


### PR DESCRIPTION
Addresses the highest-value cluster (items **1 & 2**) of the final money/security scan #10279 — the admin-gated creator Stripe Connect payout route.

## 1. (MEDIUM, data-integrity) same-key retry double-DEBITs creator earnings

`reduceEarnings` was **not idempotent** on `sourceId` — dedupe exists on `addEarnings`/`lockForRedemption`/`convertToCredits`, but `reduceEarnings` wrote a fresh `adjustment` row every call. A legitimate same-key **retry** (the whole point of `idempotency_key`) with balance ≥ 2×amount: Call 1 debits + creates transfer T1; Call 2 debits **again**, Stripe replays T1 → **creator debited 2×, paid 1×**. `requireSufficientBalance` doesn't help when the balance covers two debits.

**Fix:** add an opt-in `dedupeBySourceId` to `reduceEarnings`, mirroring the tested `addEarnings` guard. Under the existing per-user `pg_advisory_xact_lock`, an existing `adjustment` row for `(earnings_source, source_id)` short-circuits the debit (returns it unchanged, `deduplicated: true`). The transfer route opts in. Default `false` keeps every other caller's behavior.

## 2. (LOW, money) re-credits on settle-then-throw → double-pay

The `catch` unconditionally re-credited, assuming "the transfer never settled." If `transferToConnectAccount` throws **after** Stripe created the transfer (response lost on a timeout), the fiat already left but the balance was restored → creator keeps the payout **and** the redeemable balance.

**Fix:** only auto-compensate when Stripe **definitively rejected** the request (no transfer created — `StripeInvalidRequestError` / `StripeAuthenticationError` / `StripePermissionError` / `StripeRateLimitError`). On an **ambiguous** failure (network timeout / Stripe-side error where the create may have settled), **hold the debit** and return `needsReconciliation: true` rather than mint balance back on uncertainty — the safe money-path default for an admin-run operation. The refund is itself idempotent (`dedupeBySourceId`).

### Why these two together

Per the issue, "the transfer route (#1+#2) is the highest-value cluster." With both fixes the saga is correct on retry: a duplicate debit is a no-op, a replayed transfer pays once, and a lost-response never double-pays.

## Verification

- `cloud-shared` + `cloud-api` typecheck clean on the changed files (remaining errors are pre-existing transitive imports per the package's CLAUDE.md note).
- The `reduceEarnings` dedupe mirrors the `addEarnings` dedupe exactly (same transactional SELECT under the same advisory lock), backward-compatible (opt-in, default off).

## Deferred (filed in #10279, left for follow-ups)

- **#3** server-wallet provision: needs a `UNIQUE(organization_id, client_address, chain_type)` migration (or SIWE proof) — a separate careful migration.
- **#4** anonymous free-message limit: needs an atomic `UPDATE … WHERE message_count < limit RETURNING` reworking the streaming reserve/refund lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)