### PR TITLE
feat(orchestrator): #8895 envelope gate + #8898 independent read-only verifier wired into autoVerifyCompletion

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/auto-verify-completion-evidence.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/auto-verify-completion-evidence.test.ts
@@ -115,15 +115,25 @@ function changeSet(): WorkspaceChangeSet {
 
 describe("auto-verify completion evidence pipeline", () => {
   const prevFlag = process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY;
+  const prevIndependent = process.env.ELIZA_ORCHESTRATOR_INDEPENDENT_VERIFY;
 
   beforeEach(() => {
     process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY = "1";
+    // Isolate the TEXT-JUDGE evidence path: the #8898 independent verifier is a
+    // separate gate that precedes the judge for code-change tasks; turn it off
+    // here so these assertions exercise the evidence assembly the judge sees.
+    process.env.ELIZA_ORCHESTRATOR_INDEPENDENT_VERIFY = "0";
   });
   afterEach(() => {
     if (prevFlag === undefined) {
       delete process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY;
     } else {
       process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY = prevFlag;
+    }
+    if (prevIndependent === undefined) {
+      delete process.env.ELIZA_ORCHESTRATOR_INDEPENDENT_VERIFY;
+    } else {
+      process.env.ELIZA_ORCHESTRATOR_INDEPENDENT_VERIFY = prevIndependent;
     }
   });
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/completion-evidence-bundle.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/completion-evidence-bundle.test.ts
@@ -176,10 +176,15 @@ describe("classifyToolOutput", () => {
 
 describe("completion-evidence bundle assembly + trajectory persistence", () => {
   const prevFlag = process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY;
+  const prevIndependent = process.env.ELIZA_ORCHESTRATOR_INDEPENDENT_VERIFY;
   let workdir: string;
 
   beforeEach(async () => {
     process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY = "1";
+    // Isolate the TEXT-JUDGE evidence path: the #8898 independent verifier is a
+    // separate gate that precedes the judge for code-change tasks; turn it off
+    // here so these assertions exercise the evidence bundle the judge sees.
+    process.env.ELIZA_ORCHESTRATOR_INDEPENDENT_VERIFY = "0";
     workdir = await mkdtemp(join(tmpdir(), "evidence-bundle-"));
   });
   afterEach(() => {
@@ -187,6 +192,11 @@ describe("completion-evidence bundle assembly + trajectory persistence", () => {
       delete process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY;
     } else {
       process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY = prevFlag;
+    }
+    if (prevIndependent === undefined) {
+      delete process.env.ELIZA_ORCHESTRATOR_INDEPENDENT_VERIFY;
+    } else {
+      process.env.ELIZA_ORCHESTRATOR_INDEPENDENT_VERIFY = prevIndependent;
     }
   });
 

--- a/plugins/plugin-agent-orchestrator/src/__tests__/acp-native-transport.verifier.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/acp-native-transport.verifier.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { NativeAcpClient } from "../services/acp-native-transport";
+import type { ApprovalPreset } from "../services/types";
+
+/**
+ * AC4 (#8898): the independent verifier's read-only-but-executable capability is
+ * enforced at the native transport, not by prompt text.
+ *
+ * `isOperationApproved` is the single gate every dangerous client method consults:
+ * `writeTextFile` throws `PermissionDeniedError` when `!isOperationApproved("edit")`,
+ * `createTerminal` when `!isOperationApproved("execute")`, and `readTextFile` when
+ * `!isOperationApproved("read")`. The public `approvesPermissionRequest` mirrors
+ * that exact decision (`isOperationApproved(inferToolKind(toolCall))`), so asserting
+ * it proves the hard enforcement: under `verifier`, read/search/execute are approved
+ * (the verifier can run `bun test`, `git diff`, and read files) while edit/write/delete
+ * are denied (any write physically throws off the same gate).
+ */
+function makeClient(approvalPreset: ApprovalPreset): NativeAcpClient {
+  return new NativeAcpClient({
+    command: "true",
+    cwd: "/tmp",
+    approvalPreset,
+  });
+}
+
+const OPTIONS = [
+  { kind: "allow_once", optionId: "allow" },
+  { kind: "reject_once", optionId: "reject" },
+];
+
+function approves(client: NativeAcpClient, kind: string): boolean {
+  return client.approvesPermissionRequest({
+    toolCall: { kind },
+    options: OPTIONS,
+  });
+}
+
+describe("acp-native-transport approval preset 'verifier' (#8898 AC4)", () => {
+  it("approves read, search, and execute", () => {
+    const client = makeClient("verifier");
+    expect(approves(client, "read")).toBe(true);
+    expect(approves(client, "search")).toBe(true);
+    expect(approves(client, "execute")).toBe(true);
+  });
+
+  it("denies edit, write, and delete (read-only enforced at the transport)", () => {
+    const client = makeClient("verifier");
+    expect(approves(client, "edit")).toBe(false);
+    expect(approves(client, "write")).toBe(false);
+    expect(approves(client, "delete")).toBe(false);
+  });
+
+  it("differs from 'standard' (which denies execute) and 'readonly' (which denies all)", () => {
+    // Contrast: only `verifier` grants execute while still denying writes.
+    const standard = makeClient("standard");
+    expect(approves(standard, "execute")).toBe(false);
+    expect(approves(standard, "read")).toBe(true);
+    expect(approves(standard, "edit")).toBe(false);
+
+    const readonly = makeClient("readonly");
+    expect(approves(readonly, "read")).toBe(false);
+    expect(approves(readonly, "execute")).toBe(false);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/__tests__/auto-goal-verify.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/auto-goal-verify.test.ts
@@ -314,3 +314,412 @@ describe("auto goal verification on task_complete", () => {
     expect(useModel).not.toHaveBeenCalled();
   });
 });
+
+/** Runner-agnostic poll (Bun's vitest shim lacks `vi.waitFor`). */
+async function until(
+  predicate: () => boolean | Promise<boolean>,
+  { timeoutMs = 3000, stepMs = 10 }: { timeoutMs?: number; stepMs?: number } = {},
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (await predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, stepMs));
+  }
+  throw new Error("until: condition not met within timeout");
+}
+
+/** A runtime whose `useModel` spy is exposed so tests can assert call count and
+ *  inspect the prompt the text judge received. */
+function makeSpyRuntime(
+  acp: ReturnType<typeof makeFakeAcp>["service"],
+  modelResponse: () => string,
+): {
+  runtime: Record<string, unknown>;
+  useModel: ReturnType<typeof vi.fn>;
+} {
+  const useModel = vi.fn(async () => modelResponse());
+  return {
+    runtime: {
+      character: { name: "Tester" },
+      databaseAdapter: undefined,
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      getSetting: () => undefined,
+      useModel,
+      getService: (type: string) =>
+        type === AcpService.serviceType ? acp : undefined,
+    },
+    useModel,
+  };
+}
+
+const VALID_ENVELOPE = JSON.stringify(
+  {
+    diffSummary: "added the feature",
+    filesChanged: ["src/x.ts"],
+    testResults: [{ command: "bun test", exitCode: 0, summary: "all green" }],
+    screenshotPaths: [],
+    acceptanceCriteriaStatus: [
+      { criterion: "tests pass", met: true, evidence: "bun test exit 0" },
+    ],
+    residualRisks: [],
+  },
+  null,
+  2,
+);
+
+// Missing `testResults` → present-but-malformed.
+const MALFORMED_ENVELOPE = JSON.stringify(
+  {
+    diffSummary: "added the feature",
+    filesChanged: ["src/x.ts"],
+    screenshotPaths: [],
+    acceptanceCriteriaStatus: [
+      { criterion: "tests pass", met: true, evidence: "x" },
+    ],
+    residualRisks: [],
+  },
+  null,
+  2,
+);
+
+const fence = (json: string): string => `done.\n\n\`\`\`json\n${json}\n\`\`\``;
+
+describe("completion envelope gate (#8895)", () => {
+  let savedFlag: string | undefined;
+  beforeEach(() => {
+    savedFlag = process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY;
+    delete process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY;
+  });
+  afterEach(() => {
+    if (savedFlag === undefined)
+      delete process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY;
+    else process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY = savedFlag;
+  });
+
+  it("valid fenced envelope → metadata.completionEnvelope populated + judge grills the contract", async () => {
+    const fake = makeFakeAcp();
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const { taskId, sessionId } = await seedTaskWithSession(store, [
+      "tests pass",
+    ]);
+    const { runtime, useModel } = makeSpyRuntime(fake.service, () =>
+      JSON.stringify({ passed: true, summary: "confirmed", missing: [] }),
+    );
+    const service = new OrchestratorTaskService(runtime as never, { store });
+    await service.start();
+
+    fake.emit(sessionId, "task_complete", { response: fence(VALID_ENVELOPE) });
+    await until(async () => (await store.getTask(taskId))?.task.status === "done");
+
+    const doc = await store.getTask(taskId);
+    const envelope = doc?.task.metadata.completionEnvelope as
+      | { filesChanged: string[]; testResults: unknown[] }
+      | undefined;
+    expect(envelope?.filesChanged).toEqual(["src/x.ts"]);
+    expect(envelope?.testResults).toHaveLength(1);
+    // The judge received a summarizeEnvelope-grounded evidence string, not prose.
+    const judgePrompt = useModel.mock.calls[0]?.[1] as
+      | { prompt?: string }
+      | undefined;
+    expect(judgePrompt?.prompt).toContain("criteria: 1/1 met");
+  });
+
+  it("malformed envelope → structural block BEFORE the judge + re-prompt", async () => {
+    const fake = makeFakeAcp();
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const { taskId, sessionId } = await seedTaskWithSession(store, [
+      "tests pass",
+    ]);
+    const { runtime, useModel } = makeSpyRuntime(fake.service, () =>
+      JSON.stringify({ passed: true, summary: "n/a", missing: [] }),
+    );
+    const service = new OrchestratorTaskService(runtime as never, { store });
+    await service.start();
+
+    fake.emit(sessionId, "task_complete", {
+      response: fence(MALFORMED_ENVELOPE),
+    });
+    await until(() => fake.service.sendToSession.mock.calls.length > 0);
+
+    // The model judge was never consulted — the structural gate ran first.
+    expect(useModel).not.toHaveBeenCalled();
+    const doc = await store.getTask(taskId);
+    expect(doc?.events.some((e) => e.eventType === "envelope_invalid")).toBe(
+      true,
+    );
+    const lastSent = fake.sent.at(-1);
+    expect(lastSent?.text).toContain("did not include a valid CompletionEnvelope");
+    expect(lastSent?.text).toContain("testResults must be an array");
+    expect(doc?.task.status).toBe("active");
+    expect(doc?.task.metadata.autoVerifyAttempts).toBe(1);
+  });
+
+  it("absent envelope → back-compat fallback to the text judge", async () => {
+    const fake = makeFakeAcp();
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const { taskId, sessionId } = await seedTaskWithSession(store, [
+      "tests pass",
+    ]);
+    const { runtime, useModel } = makeSpyRuntime(fake.service, () =>
+      JSON.stringify({ passed: true, summary: "confirmed", missing: [] }),
+    );
+    const service = new OrchestratorTaskService(runtime as never, { store });
+    await service.start();
+
+    fake.emit(sessionId, "task_complete", {
+      response: "I finished the work and all tests pass.",
+    });
+    await until(async () => (await store.getTask(taskId))?.task.status === "done");
+
+    // No envelope present → the existing text-judge path still runs.
+    expect(useModel).toHaveBeenCalledTimes(1);
+    const doc = await store.getTask(taskId);
+    expect(doc?.task.metadata.completionEnvelope).toBeUndefined();
+  });
+
+  it("malformed envelope at the attempt cap → parks waiting_on_user (no infinite loop)", async () => {
+    const fake = makeFakeAcp();
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const { taskId, sessionId } = await seedTaskWithSession(store, [
+      "tests pass",
+    ]);
+    await store.updateTask(taskId, {
+      metadata: { autoVerifyAttempts: MAX_AUTO_VERIFY_ATTEMPTS },
+    });
+    const { runtime, useModel } = makeSpyRuntime(fake.service, () =>
+      JSON.stringify({ passed: true, summary: "n/a", missing: [] }),
+    );
+    const service = new OrchestratorTaskService(runtime as never, { store });
+    await service.start();
+
+    fake.emit(sessionId, "task_complete", {
+      response: fence(MALFORMED_ENVELOPE),
+    });
+    await until(
+      async () =>
+        (await store.getTask(taskId))?.task.status === "waiting_on_user",
+    );
+
+    expect(fake.service.sendToSession).not.toHaveBeenCalled();
+    expect(useModel).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * A richer fake ACP for the #8898 independent verifier: supports multiple event
+ * subscribers, records spawnSession calls, and pushes a configurable verifier
+ * `task_complete` for any session spawned with `metadata.source` of
+ * `independent-verifier`.
+ */
+function makeVerifierAcp(verifierResponse: () => string) {
+  type Handler = (sessionId: string, event: string, data: unknown) => void;
+  const handlers = new Set<Handler>();
+  const sent: Array<{ sessionId: string; text: string }> = [];
+  const spawned: Array<{
+    approvalPreset?: string;
+    metadata?: Record<string, unknown>;
+    workdir?: string;
+  }> = [];
+  const stopped: string[] = [];
+  let counter = 0;
+  const emit = (sessionId: string, event: string, data: unknown) => {
+    for (const handler of [...handlers]) handler(sessionId, event, data);
+  };
+  const service = {
+    onSessionEvent(cb: Handler) {
+      handlers.add(cb);
+      return () => {
+        handlers.delete(cb);
+      };
+    },
+    sendToSession: vi.fn(async (sessionId: string, text: string) => {
+      sent.push({ sessionId, text });
+      return { stopReason: "end_turn", finalText: "ok" };
+    }),
+    stopSession: vi.fn(async (sessionId: string) => {
+      stopped.push(sessionId);
+    }),
+    getSession: vi.fn(async () => undefined),
+    spawnSession: vi.fn(
+      async (opts: {
+        approvalPreset?: string;
+        metadata?: Record<string, unknown>;
+        workdir?: string;
+        initialTask?: string;
+      }) => {
+        spawned.push({
+          approvalPreset: opts.approvalPreset,
+          metadata: opts.metadata,
+          workdir: opts.workdir,
+        });
+        counter += 1;
+        const sessionId = `verifier-${counter}`;
+        if (opts.metadata?.source === "independent-verifier") {
+          // Emit AFTER spawnSession resolves and the caller subscribes.
+          setTimeout(() => {
+            emit(sessionId, "task_complete", { response: verifierResponse() });
+          }, 0);
+        }
+        return { sessionId, workdir: opts.workdir ?? "/tmp/x" };
+      },
+    ),
+  };
+  return { service, sent, spawned, stopped, emit };
+}
+
+const CHANGE_SET = {
+  changedFiles: ["src/x.ts"],
+  diffStat: "1 file changed",
+  diff: "diff --git a/src/x.ts b/src/x.ts",
+  truncated: false,
+  capturedAt: Date.now(),
+};
+
+async function seedCodeChangeTask(
+  store: OrchestratorTaskStore,
+  acceptanceCriteria: string[],
+): Promise<{ taskId: string; sessionId: string }> {
+  const seeded = await seedTaskWithSession(store, acceptanceCriteria);
+  // A real change set on the reporting session makes hasCodeChanges true so the
+  // independent verifier is gated ON.
+  await store.updateSession(seeded.sessionId, {
+    metadata: { lastChangeSet: CHANGE_SET },
+  });
+  return seeded;
+}
+
+const FAILING_VERIFIER_ENVELOPE = `verified.\n\n\`\`\`json\n${JSON.stringify({
+  diffSummary: "re-ran",
+  filesChanged: [],
+  testResults: [{ command: "bun test", exitCode: 1, summary: "2 failed" }],
+  screenshotPaths: [],
+  acceptanceCriteriaStatus: [
+    { criterion: "tests pass", met: false, evidence: "2 failed" },
+  ],
+  residualRisks: [],
+})}\n\`\`\``;
+
+const INCONCLUSIVE_VERIFIER_ENVELOPE = `verified.\n\n\`\`\`json\n${JSON.stringify(
+  {
+    diffSummary: "could not confirm",
+    filesChanged: [],
+    testResults: [],
+    screenshotPaths: [],
+    acceptanceCriteriaStatus: [],
+    residualRisks: [],
+  },
+)}\n\`\`\``;
+
+describe("independent read-only verifier (#8898)", () => {
+  let savedFlag: string | undefined;
+  beforeEach(() => {
+    savedFlag = process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY;
+    delete process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY;
+  });
+  afterEach(() => {
+    if (savedFlag === undefined)
+      delete process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY;
+    else process.env.ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY = savedFlag;
+  });
+
+  it("spawns a read-only verifier with approvalPreset 'verifier'; a falsely-green completion is BLOCKED", async () => {
+    const fake = makeVerifierAcp(() => FAILING_VERIFIER_ENVELOPE);
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const { taskId, sessionId } = await seedCodeChangeTask(store, ["tests pass"]);
+    const useModel = vi.fn(async () =>
+      JSON.stringify({ passed: true, summary: "should not be reached" }),
+    );
+    const runtime = {
+      character: { name: "Tester" },
+      databaseAdapter: undefined,
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      getSetting: () => undefined,
+      useModel,
+      getService: (type: string) =>
+        type === AcpService.serviceType ? fake.service : undefined,
+    };
+    const service = new OrchestratorTaskService(runtime as never, { store });
+    await service.start();
+
+    // Worker falsely claims green via a valid envelope.
+    fake.emit(sessionId, "task_complete", { response: fence(VALID_ENVELOPE) });
+    await until(() => fake.service.sendToSession.mock.calls.length > 0);
+
+    // AC1: the verifier was spawned read-only, ephemeral, and torn down.
+    expect(fake.spawned).toHaveLength(1);
+    expect(fake.spawned[0]?.approvalPreset).toBe("verifier");
+    expect(fake.spawned[0]?.metadata?.source).toBe("independent-verifier");
+    expect(fake.spawned[0]?.metadata?.keepAliveAfterComplete).toBe(false);
+    expect(fake.stopped).toContain("verifier-1");
+
+    // AC2/AC3: execution disproved the claim → blocked with distinct provenance.
+    const doc = await store.getTask(taskId);
+    expect(doc?.task.status).not.toBe("done");
+    const failure = doc?.events.find(
+      (e) => e.eventType === "validation_failed",
+    );
+    expect(failure?.data?.verifier).toBe("independent-acp-verifier");
+    // The cheap text judge was never reached — execution verdict is authoritative.
+    expect(useModel).not.toHaveBeenCalled();
+  });
+
+  it("an inconclusive verifier verdict keeps the task validating (no false promotion)", async () => {
+    const fake = makeVerifierAcp(() => INCONCLUSIVE_VERIFIER_ENVELOPE);
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const { taskId, sessionId } = await seedCodeChangeTask(store, ["tests pass"]);
+    const useModel = vi.fn(async () =>
+      JSON.stringify({ passed: true, summary: "should not be reached" }),
+    );
+    const runtime = {
+      character: { name: "Tester" },
+      databaseAdapter: undefined,
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      getSetting: () => undefined,
+      useModel,
+      getService: (type: string) =>
+        type === AcpService.serviceType ? fake.service : undefined,
+    };
+    const service = new OrchestratorTaskService(runtime as never, { store });
+    await service.start();
+
+    fake.emit(sessionId, "task_complete", { response: fence(VALID_ENVELOPE) });
+    await until(
+      async () =>
+        (await store.getTask(taskId))?.events.some(
+          (e) => e.eventType === "independent_verify_inconclusive",
+        ) === true,
+    );
+
+    const doc = await store.getTask(taskId);
+    expect(doc?.task.status).toBe("validating");
+    expect(doc?.task.status).not.toBe("done");
+    expect(useModel).not.toHaveBeenCalled();
+  });
+
+  it("does NOT spawn a verifier for a task with no code changes (gated)", async () => {
+    const fake = makeVerifierAcp(() => FAILING_VERIFIER_ENVELOPE);
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    // No lastChangeSet seeded → hasCodeChanges false → verifier gated off.
+    const { taskId, sessionId } = await seedTaskWithSession(store, ["tests pass"]);
+    const useModel = vi.fn(async () =>
+      JSON.stringify({ passed: true, summary: "confirmed", missing: [] }),
+    );
+    const runtime = {
+      character: { name: "Tester" },
+      databaseAdapter: undefined,
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      getSetting: () => undefined,
+      useModel,
+      getService: (type: string) =>
+        type === AcpService.serviceType ? fake.service : undefined,
+    };
+    const service = new OrchestratorTaskService(runtime as never, { store });
+    await service.start();
+
+    fake.emit(sessionId, "task_complete", { response: "done, all tests pass" });
+    await until(async () => (await store.getTask(taskId))?.task.status === "done");
+
+    expect(fake.spawned).toHaveLength(0);
+    expect(useModel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
@@ -559,6 +559,13 @@ export class NativeAcpClient {
     if (this.opts.approvalPreset === "standard") {
       return kind === "read" || kind === "search";
     }
+    // Independent verifier (#8898): may read, search, and EXECUTE (run tests /
+    // build / git diff) but is hard-blocked from edit/write/delete — writeTextFile
+    // throws PermissionDeniedError off this gate, so read-only is enforced at the
+    // transport, not by prompt text.
+    if (this.opts.approvalPreset === "verifier") {
+      return kind === "read" || kind === "search" || kind === "execute";
+    }
     return false;
   }
 

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -2360,6 +2360,13 @@ function approvalArgs(preset: ApprovalPreset): string[] {
       return ["--approve-all"];
     case "readonly":
       return ["--deny-all"];
+    case "verifier":
+      // Independent read-only verifier (#8898). acpx has no execute-approve flag,
+      // so on the CLI transport the verifier gets the reads-approved / deny-the-rest
+      // baseline (writes are denied — never over-permissioned). Execute approval is
+      // enforced on the NATIVE transport (isOperationApproved), which is the
+      // orchestrator default; CLI deny-writes is the safe floor.
+      return ["--approve-reads", "--non-interactive-permissions", "deny"];
     default:
       return ["--approve-reads", "--non-interactive-permissions", "deny"];
   }
@@ -2386,6 +2393,12 @@ function normalizeApprovalPreset(value: string | undefined): ApprovalPreset {
   )
     return "permissive";
   if (normalized === "autonomous") return "autonomous";
+  if (
+    normalized === "verifier" ||
+    normalized === "read-execute" ||
+    normalized === "read-only-execute"
+  )
+    return "verifier";
   return "autonomous";
 }
 

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -47,6 +47,11 @@ import {
   renderChangeSetBody,
 } from "./completion-evidence.js";
 import {
+  envelopeCorrection,
+  parseCompletionEnvelope,
+  summarizeEnvelope,
+} from "./completion-envelope.js";
+import {
   buildAutoVerifyCorrection,
   LLM_GOAL_VERIFIER_NAME,
   MAX_AUTO_VERIFY_ATTEMPTS,
@@ -59,6 +64,11 @@ import {
   coerceGoalCapabilityProfile,
   type GoalFollowUpReason,
 } from "./goal-prompt.js";
+import {
+  type IndependentVerifierVerdict,
+  runIndependentVerification,
+  shouldRunIndependentVerify,
+} from "./independent-verifier.js";
 import {
   summarizeUsage,
   summarizeUsageRows,
@@ -155,6 +165,33 @@ function configuredDefaultAgentType(runtime: {
     if (typeof raw === "string" && raw.trim().length > 0) return raw.trim();
   }
   return undefined;
+}
+
+/** Provenance stamped on the `validateTask` verdict produced by the independent
+ *  read-only execution verifier (#8898), distinct from the text judge's
+ *  `llm-goal-verifier`, so the validation event's origin is unambiguous. */
+const INDEPENDENT_ACP_VERIFIER_NAME = "independent-acp-verifier";
+
+/** Default upper bound on how long the independent verifier session may run
+ *  before its await is abandoned (treated as inconclusive). Overridable via
+ *  `ELIZA_ORCHESTRATOR_INDEPENDENT_VERIFY_TIMEOUT_MS`. */
+const DEFAULT_INDEPENDENT_VERIFY_TIMEOUT_MS = 600_000;
+
+function independentVerifyTimeoutMs(runtime: {
+  getSetting?: (key: string) => unknown;
+}): number {
+  const raw = runtime.getSetting?.(
+    "ELIZA_ORCHESTRATOR_INDEPENDENT_VERIFY_TIMEOUT_MS",
+  );
+  const value =
+    typeof raw === "string"
+      ? Number(raw)
+      : typeof raw === "number"
+        ? raw
+        : Number.NaN;
+  return Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : DEFAULT_INDEPENDENT_VERIFY_TIMEOUT_MS;
 }
 
 export interface SpawnAgentForTaskOptions {
@@ -772,7 +809,16 @@ export class OrchestratorTaskService extends Service {
           sessionId,
           summary ?? "",
         );
-        void this.autoVerifyCompletion(taskId, sessionId, completionEvidence);
+        // Thread the RAW final message (record.response) through alongside the
+        // reworded evidence bundle: the #8895 CompletionEnvelope lives verbatim in
+        // the sub-agent's last message, not in the prose evidence, so the structural
+        // parser must see the original text.
+        void this.autoVerifyCompletion(
+          taskId,
+          sessionId,
+          completionEvidence,
+          summary ?? "",
+        );
         break;
       }
       case "error": {
@@ -1606,23 +1652,30 @@ export class OrchestratorTaskService extends Service {
   }
 
   /**
-   * Automatically judge a freshly-`validating` task against its acceptance
-   * criteria (issue #8124): the orchestrator should always behave like `/goal`,
-   * confirming the sub-agent met every criterion before reporting done.
+   * Verify a freshly-`validating` task against its acceptance criteria before
+   * promoting it to `done` (issue #8124). One linear pipeline runs inside the
+   * re-entrancy guard:
    *
-   * Behavior:
-   * - **Gated.** No-op when {@link shouldAutoVerifyGoal} is off, when the task
-   *   has no acceptance criteria (so a criteria-free task incurs zero model
-   *   spend and behaves exactly as before), or when the task is no longer
-   *   `validating` (e.g. a human already validated it).
-   * - **Small model only.** Delegates to {@link verifyGoalCompletion}, which
-   *   uses `ModelType.TEXT_SMALL`.
-   * - **Pass →** forwards a passing verdict to {@link validateTask} (task → done).
-   * - **Fail, under cap →** sends a corrective follow-up to the active sub-agent
-   *   citing the unmet criteria (task returns to `active` via `sendToTaskAgent`),
-   *   and increments the per-task attempt counter.
-   * - **Fail, cap reached →** stops looping and parks the task on
-   *   `waiting_on_user` for a human, instead of re-prompting forever.
+   * 1. **Structural envelope gate (#8895).** {@link parseCompletionEnvelope} reads
+   *    the sub-agent's verbatim final message. A PRESENT-but-malformed envelope is
+   *    blocked *before* any model spend and the worker is re-prompted with
+   *    {@link envelopeCorrection}. An ABSENT envelope falls through unchanged
+   *    (back-compat). A VALID envelope is stamped onto `metadata.completionEnvelope`
+   *    and its {@link summarizeEnvelope} is prepended to the judge's evidence so the
+   *    judge grills the contract, not prose.
+   * 2. **Independent execution verifier (#8898).** For code-change tasks
+   *    ({@link shouldRunIndependentVerify}) a SEPARATE read-only ACP session re-runs
+   *    the tests/diff and returns an execution-grounded verdict. A failing verdict
+   *    BLOCKS (provenance `independent-acp-verifier`); an inconclusive verdict keeps
+   *    the task `validating` (never a false promotion on a verifier crash); a
+   *    passing/skipped verdict falls through.
+   * 3. **Text judge (fallback).** {@link verifyGoalCompletion} (`ModelType.TEXT_SMALL`)
+   *    judges the evidence and promotes (→ `done`) or re-prompts.
+   *
+   * All three failure paths share one {@link reEngageOrEscalate} helper, one
+   * `autoVerifyAttempts` counter, and one {@link MAX_AUTO_VERIFY_ATTEMPTS} cap, so a
+   * malformed/failing worker is re-prompted a bounded number of times and then
+   * parked on `waiting_on_user`.
    *
    * Fire-and-forget from the event bridge: failures here must never break the
    * session-event write path, so everything is wrapped and logged.
@@ -1631,6 +1684,7 @@ export class OrchestratorTaskService extends Service {
     taskId: string,
     sessionId: string,
     completionEvidence: string,
+    rawCompletion: string,
   ): Promise<void> {
     if (!shouldAutoVerifyGoal()) return;
     // Re-entrancy guard: drop a second overlapping run for the same task (the
@@ -1647,13 +1701,113 @@ export class OrchestratorTaskService extends Service {
       // Criteria-free tasks keep the prior behavior: stay `validating` for a
       // human/manual caller, no surprise model spend.
       if (acceptanceCriteria.length === 0) return;
+      const attempts = num(doc.task.metadata?.autoVerifyAttempts);
 
+      // 1. Structural envelope gate (#8895) — BEFORE any model spend.
+      const parse = parseCompletionEnvelope(rawCompletion);
+      let evidence = completionEvidence;
+      if (parse.present && !parse.ok) {
+        // Malformed contract: block the judge and re-prompt for a valid envelope.
+        await this.reEngageOrEscalate({
+          taskId,
+          sessionId,
+          correction: envelopeCorrection(parse.errors),
+          eventType: "envelope_invalid",
+          verifier: "completion-envelope",
+          summary: `Completion envelope was malformed: ${parse.errors.join("; ")}`,
+          missing: parse.errors,
+          attempt: attempts,
+        });
+        return;
+      }
+      if (parse.present && parse.ok) {
+        // Valid contract: stamp the structured fields and feed the judge a
+        // contract-grounded evidence string instead of raw prose.
+        await this.store.updateTask(taskId, {
+          metadata: {
+            ...doc.task.metadata,
+            completionEnvelope: {
+              diffSummary: parse.envelope.diffSummary,
+              filesChanged: parse.envelope.filesChanged,
+              testResults: parse.envelope.testResults,
+              acceptanceCriteriaStatus: parse.envelope.acceptanceCriteriaStatus,
+              residualRisks: parse.envelope.residualRisks,
+            },
+          },
+        });
+        evidence = `${summarizeEnvelope(parse.envelope)}\n\n${completionEvidence}`;
+      }
+
+      // 2. Independent read-only execution verifier (#8898).
+      const independent = await this.runIndependentVerify(taskId, doc, sessionId);
+      if (independent) {
+        if (independent.inconclusive) {
+          // A verifier crash/empty verdict is never a pass — keep validating.
+          await this.store.addEvent({
+            id: randomUUID(),
+            taskId,
+            sessionId,
+            eventType: "independent_verify_inconclusive",
+            summary: independent.summary,
+            data: {
+              verifier: INDEPENDENT_ACP_VERIFIER_NAME,
+              unmet: independent.unmet,
+              failedCommands: independent.failedCommands,
+            },
+            timestamp: Date.now(),
+            createdAt: nowIso(),
+          });
+          this.emitChange(taskId);
+          return;
+        }
+        if (!independent.passed) {
+          // Execution disproved the worker's claim — block with distinct
+          // provenance, then re-prompt with the concrete gaps.
+          const blockEvidence = [
+            independent.summary,
+            independent.unmet.length > 0
+              ? `Unmet criteria: ${independent.unmet.join("; ")}`
+              : "",
+            independent.failedCommands.length > 0
+              ? `Failing commands: ${independent.failedCommands.join("; ")}`
+              : "",
+          ]
+            .filter(Boolean)
+            .join("\n");
+          await this.validateTask(taskId, {
+            passed: false,
+            summary: independent.summary,
+            evidence: blockEvidence,
+            verifier: INDEPENDENT_ACP_VERIFIER_NAME,
+          });
+          const missing = [
+            ...independent.unmet,
+            ...independent.failedCommands.map((c) => `command failed: ${c}`),
+          ];
+          await this.reEngageOrEscalate({
+            taskId,
+            sessionId,
+            correction: buildAutoVerifyCorrection(
+              missing.length > 0 ? missing : [independent.summary],
+              attempts + 1,
+            ),
+            eventType: "independent_verify_failed",
+            verifier: INDEPENDENT_ACP_VERIFIER_NAME,
+            summary: independent.summary,
+            missing,
+            attempt: attempts,
+          });
+          return;
+        }
+      }
+
+      // 3. Text judge (fallback for non-code / criteria-light tasks).
       const verdict = await verifyGoalCompletion(
         this.runtime,
         {
           goal: doc.task.goal,
           acceptanceCriteria,
-          completionEvidence,
+          completionEvidence: evidence,
         },
         {
           recordTrajectory: {
@@ -1668,7 +1822,7 @@ export class OrchestratorTaskService extends Service {
         await this.validateTask(taskId, {
           passed: true,
           summary: verdict.summary,
-          evidence: verdict.rawResponse || completionEvidence,
+          evidence: verdict.rawResponse || evidence,
           verifier: LLM_GOAL_VERIFIER_NAME,
         });
         // Notify live subscribers (SSE/UI) — this is a fire-and-forget hook with
@@ -1678,103 +1832,18 @@ export class OrchestratorTaskService extends Service {
         return;
       }
 
-      const attempts = num(doc.task.metadata?.autoVerifyAttempts);
-      if (attempts >= MAX_AUTO_VERIFY_ATTEMPTS) {
-        // Stop the loop: park for a human rather than re-prompting forever.
-        await this.store.addEvent({
-          id: randomUUID(),
-          taskId,
-          sessionId,
-          eventType: "auto_verify_exhausted",
-          summary: `Automatic verification failed ${attempts} time(s); escalating to a human.`,
-          data: {
-            verifier: LLM_GOAL_VERIFIER_NAME,
-            missing: verdict.missing,
-            attempts,
-          },
-          timestamp: Date.now(),
-          createdAt: nowIso(),
-        });
-        await this.advanceTaskStatus(taskId, "waiting_on_user");
-        this.emitChange(taskId);
-        return;
-      }
-
-      // Under cap: re-send a corrective follow-up to the worker. The reporting
-      // session is now `completed` (terminal) but was spawned with
-      // `keepAliveAfterComplete`, so the ACP process is still attached and can
-      // take a follow-up. Persist the bumped attempt counter first so a
-      // redelivered task_complete can't double-count, then reactivate and steer.
-      // Reflexion (#8899): record a verbal post-mortem of this failed attempt so
-      // the next re-spawn of this task can replay it and avoid repeating the gap.
-      const attemptReflections = [
-        ...readAttemptReflections(doc.task.metadata),
-        {
-          attempt: attempts + 1,
-          missing: verdict.missing ?? [],
-          summary: verdict.summary ?? "",
-        },
-      ].slice(-MAX_ATTEMPT_REFLECTIONS);
-      await this.store.updateTask(taskId, {
-        metadata: {
-          ...doc.task.metadata,
-          autoVerifyAttempts: attempts + 1,
-          attemptReflections,
-        },
-      });
-      await this.store.addEvent({
-        id: randomUUID(),
+      await this.reEngageOrEscalate({
         taskId,
         sessionId,
+        // Escalate the grill per attempt: `attempts` is the count of prior
+        // failures, so `attempts + 1` is this correction's 1-based stage.
+        correction: buildAutoVerifyCorrection(verdict.missing, attempts + 1),
         eventType: "auto_verify_failed",
+        verifier: LLM_GOAL_VERIFIER_NAME,
         summary: verdict.summary,
-        data: {
-          verifier: LLM_GOAL_VERIFIER_NAME,
-          missing: verdict.missing,
-          attempt: attempts + 1,
-        },
-        timestamp: Date.now(),
-        createdAt: nowIso(),
+        missing: verdict.missing,
+        attempt: attempts,
       });
-      try {
-        // Reactivate the kept-alive session so the corrective turn lands on a
-        // non-terminal record, then re-dispatch through the goal envelope.
-        await this.store.updateSession(sessionId, {
-          status: "ready",
-          taskDelivered: false,
-          stoppedAt: undefined,
-        });
-        await this.sendToTaskAgent(
-          taskId,
-          sessionId,
-          // Escalate the grill per attempt: `attempts` is the count of prior
-          // failures, so `attempts + 1` is this correction's 1-based stage
-          // (matches the persisted autoVerifyAttempts bump above).
-          buildAutoVerifyCorrection(verdict.missing, attempts + 1),
-          "validation_failed",
-        );
-        await this.store.updateTask(taskId, { status: "active" });
-      } catch (sendErr) {
-        // The kept-alive session could not take the follow-up — escalate rather
-        // than silently leaving the task stuck in `validating`.
-        await this.store.addEvent({
-          id: randomUUID(),
-          taskId,
-          sessionId,
-          eventType: "auto_verify_resend_failed",
-          summary:
-            "Automatic verification failed and the corrective follow-up could not be delivered; escalating to a human.",
-          data: {
-            verifier: LLM_GOAL_VERIFIER_NAME,
-            missing: verdict.missing,
-            error: sendErr instanceof Error ? sendErr.message : String(sendErr),
-          },
-          timestamp: Date.now(),
-          createdAt: nowIso(),
-        });
-        await this.advanceTaskStatus(taskId, "waiting_on_user");
-      }
-      this.emitChange(taskId);
     } catch (err) {
       this.log("warn", "auto goal verification failed", {
         taskId,
@@ -1783,6 +1852,238 @@ export class OrchestratorTaskService extends Service {
       });
     } finally {
       this.autoVerifyInFlight.delete(taskId);
+    }
+  }
+
+  /**
+   * Shared re-prompt / escalation path for every failed completion verdict — the
+   * malformed-envelope gate (#8895), the independent-verify block (#8898), and the
+   * text judge. ONE `autoVerifyAttempts` counter and ONE
+   * {@link MAX_AUTO_VERIFY_ATTEMPTS} cap govern all three: under the cap the
+   * kept-alive worker is reactivated and re-prompted with `correction` (and a
+   * reflexion post-mortem is recorded for the next respawn, #8899); at the cap, or
+   * when the corrective send fails, the task is parked on `waiting_on_user` instead
+   * of looping forever.
+   *
+   * @param attempt the count of PRIOR failed attempts (0-based); the helper persists
+   *        `attempt + 1` as the new counter and uses it as the 1-based grill stage.
+   */
+  private async reEngageOrEscalate(args: {
+    taskId: string;
+    sessionId: string;
+    correction: string;
+    eventType: string;
+    verifier: string;
+    summary: string;
+    missing: string[];
+    attempt: number;
+  }): Promise<void> {
+    const {
+      taskId,
+      sessionId,
+      correction,
+      eventType,
+      verifier,
+      summary,
+      missing,
+      attempt,
+    } = args;
+    if (attempt >= MAX_AUTO_VERIFY_ATTEMPTS) {
+      // Stop the loop: park for a human rather than re-prompting forever.
+      await this.store.addEvent({
+        id: randomUUID(),
+        taskId,
+        sessionId,
+        eventType: "auto_verify_exhausted",
+        summary: `Automatic verification failed ${attempt} time(s); escalating to a human.`,
+        data: { verifier, missing, attempts: attempt },
+        timestamp: Date.now(),
+        createdAt: nowIso(),
+      });
+      await this.advanceTaskStatus(taskId, "waiting_on_user");
+      this.emitChange(taskId);
+      return;
+    }
+    // Persist the bumped attempt counter + a reflexion post-mortem first, so a
+    // redelivered task_complete can't double-count and the next respawn (#8899)
+    // can replay the gap. Re-read the doc so an upstream metadata write in this
+    // same pass (e.g. the valid-envelope stamp) is preserved.
+    const doc = await this.store.getTask(taskId);
+    const attemptReflections = [
+      ...readAttemptReflections(doc?.task.metadata),
+      { attempt: attempt + 1, missing, summary },
+    ].slice(-MAX_ATTEMPT_REFLECTIONS);
+    await this.store.updateTask(taskId, {
+      metadata: {
+        ...doc?.task.metadata,
+        autoVerifyAttempts: attempt + 1,
+        attemptReflections,
+      },
+    });
+    await this.store.addEvent({
+      id: randomUUID(),
+      taskId,
+      sessionId,
+      eventType,
+      summary,
+      data: { verifier, missing, attempt: attempt + 1 },
+      timestamp: Date.now(),
+      createdAt: nowIso(),
+    });
+    try {
+      // Reactivate the kept-alive session so the corrective turn lands on a
+      // non-terminal record, then re-dispatch through the goal envelope.
+      await this.store.updateSession(sessionId, {
+        status: "ready",
+        taskDelivered: false,
+        stoppedAt: undefined,
+      });
+      await this.sendToTaskAgent(
+        taskId,
+        sessionId,
+        correction,
+        "validation_failed",
+      );
+      await this.store.updateTask(taskId, { status: "active" });
+    } catch (sendErr) {
+      // The kept-alive session could not take the follow-up — escalate rather
+      // than silently leaving the task stuck in `validating`.
+      await this.store.addEvent({
+        id: randomUUID(),
+        taskId,
+        sessionId,
+        eventType: "auto_verify_resend_failed",
+        summary:
+          "Automatic verification failed and the corrective follow-up could not be delivered; escalating to a human.",
+        data: {
+          verifier,
+          missing,
+          error: sendErr instanceof Error ? sendErr.message : String(sendErr),
+        },
+        timestamp: Date.now(),
+        createdAt: nowIso(),
+      });
+      await this.advanceTaskStatus(taskId, "waiting_on_user");
+    }
+    this.emitChange(taskId);
+  }
+
+  /**
+   * Independent read-only execution verifier (#8898). For code-change tasks, spawn
+   * a SEPARATE read-only ACP session that re-runs the tests/diff and returns an
+   * execution-grounded verdict. Returns `null` when the verifier is gated off
+   * (non-code task, flag disabled, or no ACP / workdir available), so the caller
+   * falls through to the text judge.
+   */
+  private async runIndependentVerify(
+    taskId: string,
+    doc: OrchestratorTaskDocument,
+    sessionId: string,
+  ): Promise<IndependentVerifierVerdict | null> {
+    const changeSet = await this.resolveCompletionChangeSet(sessionId, doc);
+    const hasCodeChanges = (changeSet?.changedFiles.length ?? 0) > 0;
+    // shouldRunIndependentVerify wants (key) => string | undefined | null.
+    // Resolve from runtime settings, then fall back to process.env so the
+    // ELIZA_ORCHESTRATOR_INDEPENDENT_VERIFY flag is honored consistently with the
+    // env-driven shouldAutoVerifyGoal gate (runtime.getSetting may be absent).
+    const getSetting = (key: string): string | undefined => {
+      const value = this.runtime.getSetting?.(key);
+      if (typeof value === "string") return value;
+      const fromEnv = process.env[key];
+      return typeof fromEnv === "string" ? fromEnv : undefined;
+    };
+    if (!shouldRunIndependentVerify(getSetting, hasCodeChanges)) return null;
+    const acp = this.acp();
+    if (!acp) return null;
+    const session = doc.sessions.find((s) => s.sessionId === sessionId);
+    const workdir = session?.workdir;
+    if (!workdir) return null;
+    const diffSummary =
+      changeSet && changeSet.changedFiles.length > 0
+        ? renderChangeSetBody(changeSet)
+        : undefined;
+    return runIndependentVerification(
+      {
+        goal: doc.task.goal,
+        acceptanceCriteria: doc.task.acceptanceCriteria,
+        ...(diffSummary ? { diffSummary } : {}),
+      },
+      {
+        spawnAndAwait: (prompt) =>
+          this.spawnReadOnlyVerifier(acp, prompt, workdir, taskId, sessionId),
+      },
+    );
+  }
+
+  /**
+   * Spawn the #8898 read-only verifier as an EPHEMERAL ACP session and resolve its
+   * final completion text. The session runs under the `verifier` approval preset
+   * (read + search + execute; writes denied at the transport) in the completed
+   * worker's workdir and is torn down after its verdict. It is intentionally NOT
+   * registered with the task store, so the event bridge's `resolveTaskId` ignores
+   * its events and it never recurses into auto-verify.
+   */
+  private async spawnReadOnlyVerifier(
+    acp: AcpService,
+    prompt: string,
+    workdir: string,
+    taskId: string,
+    reportingSessionId: string,
+  ): Promise<string> {
+    const timeoutMs = independentVerifyTimeoutMs(this.runtime);
+    const live = await acp.getSession(reportingSessionId);
+    const meta = live?.metadata;
+    const parentDepth =
+      isRecord(meta) && typeof meta.nestingDepth === "number"
+        ? meta.nestingDepth
+        : 0;
+    const spawn = await acp.spawnSession({
+      agentType: configuredDefaultAgentType(this.runtime) ?? "opencode",
+      workdir,
+      initialTask: prompt,
+      approvalPreset: "verifier",
+      metadata: {
+        taskId,
+        source: "independent-verifier",
+        keepAliveAfterComplete: false,
+        nestingDepth: parentDepth + 1,
+      },
+    });
+    const verifierSessionId = spawn.sessionId;
+    let unsubscribe: (() => void) | undefined;
+    try {
+      return await new Promise<string>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          reject(
+            new Error(
+              `independent verifier session timed out after ${timeoutMs}ms`,
+            ),
+          );
+        }, timeoutMs);
+        timer.unref?.();
+        unsubscribe = acp.onSessionEvent((sid, event, data) => {
+          if (sid !== verifierSessionId) return;
+          if (event === "task_complete") {
+            clearTimeout(timer);
+            const response = isRecord(data) ? str(data.response) : undefined;
+            resolve(response ?? "");
+          } else if (event === "error") {
+            clearTimeout(timer);
+            const message = isRecord(data) ? str(data.message) : undefined;
+            reject(new Error(message ?? "independent verifier session errored"));
+          }
+        });
+      });
+    } finally {
+      unsubscribe?.();
+      try {
+        await acp.stopSession(verifierSessionId);
+      } catch (stopErr) {
+        this.log("warn", "failed to stop independent verifier session", {
+          sessionId: verifierSessionId,
+          error: stopErr instanceof Error ? stopErr.message : String(stopErr),
+        });
+      }
     }
   }
 

--- a/plugins/plugin-agent-orchestrator/src/services/types.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/types.ts
@@ -10,7 +10,12 @@ export type ApprovalPreset =
   | "readonly"
   | "standard"
   | "permissive"
-  | "autonomous";
+  | "autonomous"
+  // Read + search + EXECUTE allowed, edit/write/delete DENIED. The profile the
+  // independent read-only verifier (#8898) runs under: it must re-run tests
+  // (`execute`) and inspect files (`read`/`search`) but can never mutate the
+  // worktree it is verifying. `readonly` (`--deny-all`) cannot run the tests.
+  | "verifier";
 
 export type SessionStatus =
   | "running"


### PR DESCRIPTION
Closes **#8895** and **#8898**. Both shipped their primitives (#9020) but left the **enforcement dead** — no production caller. This wires both into the one live completion gate, `autoVerifyCompletion`, as a single linear pipeline (per the master design).

## The pipeline (orchestrator-task-service.ts)
1. **Structural envelope gate (#8895)** — `parseCompletionEnvelope` runs **before** the LLM judge. Malformed → `envelope_invalid` + `envelopeCorrection` re-prompt (**no model spend**); absent → fall through unchanged (back-compat); valid → stamp `metadata.completionEnvelope` + prepend `summarizeEnvelope` to the judge evidence.
2. **Independent read-only verifier (#8898)** — for code-change tasks (`shouldRunIndependentVerify`, gated `ELIZA_ORCHESTRATOR_INDEPENDENT_VERIFY`, default on) a **separate read-only ACP session** re-runs tests/build; its execution verdict feeds `validateTask` under a distinct id `independent-acp-verifier`. inconclusive → stay `validating`; !passed → block + re-prompt; passed → fall through.
3. **Text judge** fallback unchanged.

## Read-only enforcement (#8898 AC4)
New `"verifier"` ApprovalPreset: read+search+**execute** allowed, edit/write/delete **denied** at the native transport (`isOperationApproved` → `writeTextFile` throws `PermissionDeniedError`). The existing `readonly`=`--deny-all` couldn't run the verifier's own tests. One `reEngageOrEscalate` helper + one `autoVerifyAttempts`/`MAX` cap govern all three failure paths.

## The 6 formerly-dead primitives now have real production callers
`parseCompletionEnvelope` (L1707), `envelopeCorrection` (L1714), `summarizeEnvelope` (L1738), `shouldRunIndependentVerify` (L1995), `runIndependentVerification` (L2005), `spawnReadOnlyVerifier`+`approvalPreset:'verifier'` (L2013/L2026).

## Tests
- `auto-goal-verify` (4 envelope-gate + 3 independent-verifier cases via fake-ACP harness) + `acp-native-transport.verifier` (read-only enforcement) + `independent-verifier` → **25 pass / 0 fail** (re-verified locally via vitest).
- Full plugin suite green except one **unrelated pre-existing** `smithers-task-runner` load-timeout flake (passes 8/8 in isolation; references no touched code). Typecheck 0 errors.

The literal `writeTextFile`-rejects assertion is covered deterministically by `isOperationApproved`/`approvesPermissionRequest` here and exercised end-to-end (real `PermissionDeniedError` → `deny.log`) by the gated multi-account live e2e.

Closes #8895, #8898.

🤖 Generated with [Claude Code](https://claude.com/claude-code)