### PR TITLE
fix(ui): cloud dashboard routes self-provide PageHeaderProvider (#10319)

### DIFF
--- a/packages/ui/src/cloud-ui/components/layout/dashboard-route-page.test.tsx
+++ b/packages/ui/src/cloud-ui/components/layout/dashboard-route-page.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+
+/**
+ * Regression tests for #10319: dashboard routes (apps/containers/instances/...)
+ * threw `usePageHeader must be used within a PageHeaderProvider` when mounted
+ * without an ancestor provider (CloudRouterShell mounts them standalone, and the
+ * app mounts them natively).
+ *
+ * Two invariants are covered:
+ *  1. `useSetPageHeader` requires a `PageHeaderProvider` — the throw the bug hit,
+ *     and the no-throw every route entry now guarantees by supplying a provider.
+ *  2. `DashboardRoutePage` is self-sufficient: it provides its own context when
+ *     none exists (so it never throws), but defers to an ancestor provider when
+ *     one is present (so a host's header chrome still sees the header it sets).
+ */
+
+import {
+  cleanup,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DashboardRoutePage } from "./dashboard-route-page";
+import { PageHeaderProvider } from "./page-header-context";
+import { usePageHeader, useSetPageHeader } from "./page-header-context.hooks";
+
+afterEach(cleanup);
+
+/** Reads the page header from the nearest provider so a test can assert on it. */
+function HeaderProbe() {
+  const { pageInfo } = usePageHeader();
+  return <span data-testid="probe">{pageInfo?.title ?? "none"}</span>;
+}
+
+describe("useSetPageHeader provider invariant", () => {
+  it("throws when no PageHeaderProvider ancestor is present", () => {
+    // React logs the render error; silence it so the suite output stays clean.
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => renderHook(() => useSetPageHeader({ title: "x" }))).toThrow(
+      /PageHeaderProvider/,
+    );
+    spy.mockRestore();
+  });
+
+  it("does not throw when wrapped in a PageHeaderProvider", () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <PageHeaderProvider>{children}</PageHeaderProvider>
+    );
+    expect(() =>
+      renderHook(() => useSetPageHeader({ title: "x" }), { wrapper }),
+    ).not.toThrow();
+  });
+});
+
+describe("DashboardRoutePage page-header self-sufficiency (#10319)", () => {
+  it("renders and sets its header without an ancestor PageHeaderProvider", async () => {
+    render(
+      <DashboardRoutePage title="Standalone">
+        <HeaderProbe />
+        <span data-testid="body">content</span>
+      </DashboardRoutePage>,
+    );
+
+    // The body renders (no "must be used within a PageHeaderProvider" throw)...
+    expect(screen.getByTestId("body").textContent).toBe("content");
+    // ...and the self-provided context receives the header it published.
+    await waitFor(() =>
+      expect(screen.getByTestId("probe").textContent).toBe("Standalone"),
+    );
+  });
+
+  it("defers to an ancestor PageHeaderProvider instead of shadowing it", async () => {
+    render(
+      <PageHeaderProvider>
+        <HeaderProbe />
+        <DashboardRoutePage title="FromHost">
+          <span>body</span>
+        </DashboardRoutePage>
+      </PageHeaderProvider>,
+    );
+
+    // The probe is a sibling reading the ANCESTOR provider. If DashboardRoutePage
+    // had created its own nested provider, the ancestor would never see the
+    // header and this would stay "none".
+    await waitFor(() =>
+      expect(screen.getByTestId("probe").textContent).toBe("FromHost"),
+    );
+  });
+});

--- a/packages/ui/src/cloud-ui/components/layout/dashboard-route-page.tsx
+++ b/packages/ui/src/cloud-ui/components/layout/dashboard-route-page.tsx
@@ -1,13 +1,18 @@
 "use client";
 
-import type {
-  ComponentPropsWithoutRef,
-  DependencyList,
-  ReactNode,
+import {
+  type ComponentPropsWithoutRef,
+  type DependencyList,
+  type ReactNode,
+  useContext,
 } from "react";
 import { cn } from "../../lib/utils";
 import { DashboardPageContainer, DashboardPageStack } from "./dashboard-page";
-import { useSetPageHeader } from "./page-header-context.hooks";
+import { PageHeaderProvider } from "./page-header-context";
+import {
+  PageHeaderContext,
+  useSetPageHeader,
+} from "./page-header-context.hooks";
 
 type DashboardRoutePageBannerTone = "info" | "success" | "warning" | "error";
 
@@ -51,7 +56,30 @@ function normalizeLayoutProps<T extends object>(
   return value;
 }
 
-export function DashboardRoutePage({
+/**
+ * A dashboard route body. Publishes its title/description/actions to the page
+ * header context and renders the standard container/stack/banner layout.
+ *
+ * Self-sufficient w.r.t. the page header context: dashboard routes are mounted
+ * standalone by `CloudRouterShell` — and natively inside the app — with no
+ * ancestor `PageHeaderProvider`, which would make {@link useSetPageHeader}
+ * throw. When no provider is present this component supplies its own; when a
+ * host already provides one (e.g. a dashboard shell that renders the header
+ * chrome), it defers to that provider so the header stays visible to the chrome.
+ */
+export function DashboardRoutePage(props: DashboardRoutePageProps) {
+  const hasAncestorProvider = useContext(PageHeaderContext) !== undefined;
+  if (hasAncestorProvider) {
+    return <DashboardRoutePageBody {...props} />;
+  }
+  return (
+    <PageHeaderProvider>
+      <DashboardRoutePageBody {...props} />
+    </PageHeaderProvider>
+  );
+}
+
+function DashboardRoutePageBody({
   title,
   description,
   actions,

--- a/packages/ui/src/cloud/analytics/Page.tsx
+++ b/packages/ui/src/cloud/analytics/Page.tsx
@@ -15,7 +15,11 @@
  */
 
 import { useSearchParams } from "react-router-dom";
-import { DashboardErrorState, DashboardLoadingState } from "../../cloud-ui";
+import {
+  DashboardErrorState,
+  DashboardLoadingState,
+  PageHeaderProvider,
+} from "../../cloud-ui";
 import { useCloudT } from "../shell/CloudI18nProvider";
 import { AnalyticsPageClient } from "./_components/analytics-page-client";
 import {
@@ -65,10 +69,14 @@ export default function AnalyticsPage() {
     );
   }
 
+  // AnalyticsPageClient sets the page header; this standalone route has no
+  // ancestor PageHeaderProvider, so supply one here.
   return (
-    <AnalyticsPageClient
-      data={breakdown.data}
-      projectionsData={projections.data}
-    />
+    <PageHeaderProvider>
+      <AnalyticsPageClient
+        data={breakdown.data}
+        projectionsData={projections.data}
+      />
+    </PageHeaderProvider>
   );
 }

--- a/packages/ui/src/cloud/instances/MyAgentsPage.tsx
+++ b/packages/ui/src/cloud/instances/MyAgentsPage.tsx
@@ -4,7 +4,10 @@
  * `@elizaos/cloud-frontend/src/dashboard/my-agents/Page.tsx`.
  */
 
-import { DashboardLoadingState } from "@elizaos/ui/cloud-ui";
+import {
+  DashboardLoadingState,
+  PageHeaderProvider,
+} from "@elizaos/ui/cloud-ui";
 import { useDocumentTitle } from "../lib/use-document-title";
 import { MyAgentsClient } from "./components/my-agents";
 import { useT } from "./lib/i18n";
@@ -26,5 +29,11 @@ export default function MyAgentsPage() {
     );
   }
 
-  return <MyAgentsClient />;
+  // MyAgentsClient sets the page header; this standalone route has no ancestor
+  // PageHeaderProvider, so supply one here.
+  return (
+    <PageHeaderProvider>
+      <MyAgentsClient />
+    </PageHeaderProvider>
+  );
 }

--- a/packages/ui/src/cloud/mcps/McpsRoute.tsx
+++ b/packages/ui/src/cloud/mcps/McpsRoute.tsx
@@ -4,9 +4,13 @@
  * Gates on the Steward session (the registry CRUD routes require auth), then
  * renders {@link McpsView}. The same {@link McpsSurface} backs both the
  * standalone route and the Settings-section wrapper, so they stay identical.
+ * `McpsView` sets the page header, so each entry point supplies a
+ * `PageHeaderProvider`: the standalone route wraps one here; the settings
+ * section gets it from `CloudSettingsSectionShell`.
  */
 
 import { useContext } from "react";
+import { PageHeaderProvider } from "../../cloud-ui";
 import { DashboardLoadingState } from "../../cloud-ui/components/dashboard/route-placeholders";
 import { useCloudT } from "../shell/CloudI18nProvider";
 import { LocalStewardAuthContext } from "../shell/StewardProvider";
@@ -32,5 +36,9 @@ export function McpsSurface() {
 
 /** Default export consumed by the cloud-route registry. */
 export default function McpsRoute() {
-  return <McpsSurface />;
+  return (
+    <PageHeaderProvider>
+      <McpsSurface />
+    </PageHeaderProvider>
+  );
 }


### PR DESCRIPTION
## What

Fixes #10319. Cloud dashboard routes threw `usePageHeader must be used within a PageHeaderProvider` when mounted without an ancestor `PageHeaderProvider` — which is exactly how `CloudRouterShell` mounts them (and how the app mounts them natively). The provider wrap was **inconsistent**: the `account-security/*` and `settings` routes self-wrap a `PageHeaderProvider`, but the dashboard routes did not.

## Root cause

`useSetPageHeader()` → `usePageHeader()` throws when no `PageHeaderContext` is present (`page-header-context.hooks.ts:35`). `CloudProviders` in `CloudRouterShell` supplies query + i18n + Steward auth, but intentionally **no** `PageHeaderProvider`. Every route below that calls `useSetPageHeader` without supplying its own therefore throws on first render.

An audit during review of #10309 surfaced this. Beyond the four routes named in the issue, two more standalone routes had the same latent crash (they call `useSetPageHeader` directly, bypassing `DashboardRoutePage`):

| Route | Header setter | Provider before | Provider after |
|---|---|---|---|
| `/dashboard/apps` (+ containers/instances/dashboard) | `DashboardRoutePage` | ❌ none | ✅ self-provided |
| `/dashboard/mcps` | `McpsView` | ❌ none | ✅ `McpsRoute` wrap |
| `/dashboard/my-agents` | `MyAgentsClient` | ❌ none | ✅ `MyAgentsPage` wrap |
| `/dashboard/analytics` | `AnalyticsPageClient` | ❌ none | ✅ `AnalyticsPage` wrap |
| `/dashboard/account` · `/security` · `/permissions` · settings sections | each surface | ✅ already wrapped | unchanged |

## Fix (issue's preferred option 1, made shadow-safe)

- **`DashboardRoutePage`** now provides its own `PageHeaderProvider` when none exists, and **defers to an ancestor when one is present** (reads `PageHeaderContext` first) — so it never throws *and* never shadows a host's header chrome that consumes the same context. This covers apps/containers/instances/dashboard and the native in-app mount in one place.
- **`McpsRoute` / `MyAgentsPage` / `AnalyticsPage`** wrap their header-setting body in `PageHeaderProvider`, matching the existing `account-security`/`settings` pattern. The embeddable settings sections (`McpsSection`, …) keep getting a provider from `CloudSettingsSectionShell`, so no double-wrap there.

This also removes the latent web-route crash that #10309's native mount had to work around — the native `NativeAppsStudio` provider becomes redundant (an ancestor `DashboardRoutePage` now defers to it).

## Verification

```
bun run --cwd packages/ui test -- --run src/cloud-ui/components/layout/dashboard-route-page.test.tsx
  ✓ 4/4  (provider-required throw, no-throw-when-wrapped, self-provide, defers-to-ancestor/no-shadow)
bun run --cwd packages/ui test -- --run src/cloud-ui/components/layout/ src/cloud/mcps/ src/cloud/instances/ src/cloud/analytics/
  ✓ 16/16
bun run --cwd packages/ui test -- --run src/cloud-ui/__tests__/cloud-ui-stories-smoke.test.tsx
  ✓ 367/367  (renders every cloud-ui story incl. dashboard-route-page)
biome check (5 touched files)  → clean
tsgo --noEmit (packages/ui)    → 0 errors in touched files (pre-existing unrelated: generated i18n data + a viem Config mismatch in steward-wallet-providers.tsx, neither in this diff)
```

New regression test `packages/ui/src/cloud-ui/components/layout/dashboard-route-page.test.tsx` reproduces the exact pre-fix throw and asserts the self-provide + no-shadow invariants.

**Visual audit:** N/A — this is a render-time crash guard in shared library code; the affected routes require a live Steward session/backend to render, and the regression test reproduces the precise throw the fix removes.
