### PR TITLE
chore(build): migrate 5 more plugin build.ts onto shared buildPlugin (#10078)

### DIFF
--- a/plugins/plugin-benchmarks/build.ts
+++ b/plugins/plugin-benchmarks/build.ts
@@ -1,78 +1,34 @@
 #!/usr/bin/env bun
-import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
-import { join } from "node:path";
-import { fileURLToPath } from "node:url";
-import { externalsFromPackageJson } from "../plugin-build-externals.ts";
+/**
+ * Build script for @elizaos/plugin-benchmarks (Node). Orchestration lives in the
+ * shared driver (plugins/plugin-build.ts); this lists only what differs.
+ *
+ * The single `index.ts` entry is bundled for Node with an external sourcemap.
+ * Declarations are emitted via tsconfig.build.json (tolerated on failure), and
+ * the root `index.d.ts` alias is written as a hand-rolled re-export. The emitted
+ * `dist/` is byte-identical to the previous hand-rolled build.
+ */
+import { buildPlugin } from "../plugin-build";
 
-const RM_RECURSIVE_SCRIPT = fileURLToPath(
-  new URL("../../packages/scripts/rm-path-recursive.mjs", import.meta.url)
-);
-
-function rmRecursive(target: string) {
-  const result = spawnSync(process.execPath, [RM_RECURSIVE_SCRIPT, target], {
-    stdio: "inherit",
-  });
-  if (result.error) throw result.error;
-  if (result.status !== 0) {
-    throw new Error(`rm-path-recursive failed for ${target} with status ${result.status}`);
-  }
-}
-
-async function build() {
-  const totalStart = Date.now();
-  const externalDeps = await externalsFromPackageJson("./package.json");
-
-  console.log("Cleaning...");
-  if (existsSync("dist")) rmRecursive("dist");
-
-  const buildStart = Date.now();
-  console.log("Building @elizaos/plugin-benchmarks...");
-  const result = await Bun.build({
-    entrypoints: ["index.ts"],
-    outdir: "dist",
-    target: "node",
-    format: "esm",
-    sourcemap: "external",
-    minify: false,
-    external: externalDeps,
-  });
-
-  if (!result.success) {
-    console.error(result.logs);
-    throw new Error("Build failed");
-  }
-  console.log(`Build complete in ${((Date.now() - buildStart) / 1000).toFixed(2)}s`);
-
-  const dtsStart = Date.now();
-  console.log("Generating TypeScript declarations...");
-  const { $ } = await import("bun");
-  try {
-    if (existsSync("tsconfig.build.json"))
-      await $`tsc --project tsconfig.build.json --noCheck`.quiet();
-    console.log(`Declarations generated in ${((Date.now() - dtsStart) / 1000).toFixed(2)}s`);
-  } catch (_error) {
-    console.warn(
-      `Declaration generation had errors (${((Date.now() - dtsStart) / 1000).toFixed(2)}s)`
-    );
-  }
-
-  const distDir = join(process.cwd(), "dist");
-  if (!existsSync(distDir)) await mkdir(distDir, { recursive: true });
-  const rootIndexDtsPath = join(distDir, "index.d.ts");
-  if (!existsSync(rootIndexDtsPath)) {
-    await writeFile(
-      rootIndexDtsPath,
-      'export * from "./index";\nexport { default } from "./index";\n',
-      "utf8"
-    );
-  }
-
-  console.log(`All builds finished in ${((Date.now() - totalStart) / 1000).toFixed(2)}s`);
-}
-
-build().catch((err) => {
-  console.error("Build failed:", err);
-  process.exit(1);
+await buildPlugin({
+  name: "@elizaos/plugin-benchmarks",
+  clean: true,
+  targets: [
+    {
+      label: "Node",
+      entry: "index.ts",
+      outSubdir: "",
+      target: "node",
+      format: "esm",
+      sourcemap: "external",
+    },
+  ],
+  dtsProject: "tsconfig.build.json",
+  dtsTolerant: true,
+  dtsShims: [
+    {
+      path: "index.d.ts",
+      content: 'export * from "./index";\nexport { default } from "./index";\n',
+    },
+  ],
 });

--- a/plugins/plugin-cli-inference/build.ts
+++ b/plugins/plugin-cli-inference/build.ts
@@ -1,63 +1,37 @@
 #!/usr/bin/env bun
-/** Build script for @elizaos/plugin-cli-inference. */
+/**
+ * Build script for @elizaos/plugin-cli-inference (Node + Browser).
+ * Orchestration lives in the shared driver (plugins/plugin-build.ts); this lists
+ * only what differs. The emitted `dist/` is byte-identical to the previous
+ * hand-rolled build.
+ */
+import { buildPlugin } from "../plugin-build";
 
-import { externalsFromPackageJson } from "../plugin-build-externals.ts";
+// Single-quoted re-export to keep the emitted .d.ts byte-stable.
+const reexport = "export * from '../index';\nexport { default } from '../index';\n";
 
-const externalDeps = await externalsFromPackageJson("./package.json");
-
-async function build(): Promise<void> {
-  const totalStart = Date.now();
-
-  const nodeStart = Date.now();
-  console.log("🔨 Building @elizaos/plugin-cli-inference for Node (ESM)...");
-  const nodeResult = await Bun.build({
-    entrypoints: ["index.node.ts"],
-    outdir: "dist/node",
-    target: "node",
-    format: "esm",
-    sourcemap: "external",
-    minify: false,
-    external: externalDeps,
-  });
-  if (!nodeResult.success) {
-    console.error("Node ESM build failed:", nodeResult.logs);
-    throw new Error("Node ESM build failed");
-  }
-  console.log(`✅ Node ESM build complete in ${((Date.now() - nodeStart) / 1000).toFixed(2)}s`);
-
-  const browserStart = Date.now();
-  console.log("🌐 Building @elizaos/plugin-cli-inference for Browser...");
-  const browserResult = await Bun.build({
-    entrypoints: ["index.browser.ts"],
-    outdir: "dist/browser",
-    target: "browser",
-    format: "esm",
-    sourcemap: "external",
-    minify: true,
-    external: externalDeps,
-  });
-  if (!browserResult.success) {
-    console.error("Browser build failed:", browserResult.logs);
-    throw new Error("Browser build failed");
-  }
-  console.log(`✅ Browser build complete in ${((Date.now() - browserStart) / 1000).toFixed(2)}s`);
-
-  const dtsStart = Date.now();
-  console.log("📝 Generating TypeScript declarations...");
-  const { mkdir, writeFile } = await import("node:fs/promises");
-  await Bun.$`tsc --project tsconfig.build.json --noCheck`;
-  await mkdir("dist/node", { recursive: true });
-  await mkdir("dist/browser", { recursive: true });
-  const reexportDeclaration = `export * from '../index';\nexport { default } from '../index';\n`;
-  await writeFile("dist/node/index.d.ts", reexportDeclaration);
-  await writeFile("dist/browser/index.d.ts", reexportDeclaration);
-  console.log(`✅ Declarations generated in ${((Date.now() - dtsStart) / 1000).toFixed(2)}s`);
-
-  const totalTime = ((Date.now() - totalStart) / 1000).toFixed(2);
-  console.log(`🎉 All builds finished in ${totalTime}s`);
-}
-
-build().catch((err) => {
-  console.error("Build failed:", err);
-  process.exit(1);
+await buildPlugin({
+  name: "@elizaos/plugin-cli-inference",
+  targets: [
+    {
+      label: "Node",
+      entry: "index.node.ts",
+      outSubdir: "node",
+      target: "node",
+      format: "esm",
+    },
+    {
+      label: "Browser",
+      entry: "index.browser.ts",
+      outSubdir: "browser",
+      target: "browser",
+      format: "esm",
+      minify: true,
+    },
+  ],
+  dtsProject: "tsconfig.build.json",
+  dtsShims: [
+    { path: "node/index.d.ts", content: reexport },
+    { path: "browser/index.d.ts", content: reexport },
+  ],
 });

--- a/plugins/plugin-codex-cli/build.ts
+++ b/plugins/plugin-codex-cli/build.ts
@@ -1,63 +1,37 @@
 #!/usr/bin/env bun
-/** Build script for @elizaos/plugin-codex-cli. */
+/**
+ * Build script for @elizaos/plugin-codex-cli (Node + Browser).
+ * Orchestration lives in the shared driver (plugins/plugin-build.ts); this lists
+ * only what differs. The emitted `dist/` is byte-identical to the previous
+ * hand-rolled build.
+ */
+import { buildPlugin } from "../plugin-build";
 
-import { externalsFromPackageJson } from "../plugin-build-externals.ts";
+// Single-quoted re-export to keep the emitted .d.ts byte-stable.
+const reexport = "export * from '../index';\nexport { default } from '../index';\n";
 
-const externalDeps = await externalsFromPackageJson("./package.json");
-
-async function build(): Promise<void> {
-  const totalStart = Date.now();
-
-  const nodeStart = Date.now();
-  console.log("🔨 Building @elizaos/plugin-codex-cli for Node (ESM)...");
-  const nodeResult = await Bun.build({
-    entrypoints: ["index.node.ts"],
-    outdir: "dist/node",
-    target: "node",
-    format: "esm",
-    sourcemap: "external",
-    minify: false,
-    external: externalDeps,
-  });
-  if (!nodeResult.success) {
-    console.error("Node ESM build failed:", nodeResult.logs);
-    throw new Error("Node ESM build failed");
-  }
-  console.log(`✅ Node ESM build complete in ${((Date.now() - nodeStart) / 1000).toFixed(2)}s`);
-
-  const browserStart = Date.now();
-  console.log("🌐 Building @elizaos/plugin-codex-cli for Browser...");
-  const browserResult = await Bun.build({
-    entrypoints: ["index.browser.ts"],
-    outdir: "dist/browser",
-    target: "browser",
-    format: "esm",
-    sourcemap: "external",
-    minify: true,
-    external: externalDeps,
-  });
-  if (!browserResult.success) {
-    console.error("Browser build failed:", browserResult.logs);
-    throw new Error("Browser build failed");
-  }
-  console.log(`✅ Browser build complete in ${((Date.now() - browserStart) / 1000).toFixed(2)}s`);
-
-  const dtsStart = Date.now();
-  console.log("📝 Generating TypeScript declarations...");
-  const { mkdir, writeFile } = await import("node:fs/promises");
-  await Bun.$`tsc --project tsconfig.build.json --noCheck`;
-  await mkdir("dist/node", { recursive: true });
-  await mkdir("dist/browser", { recursive: true });
-  const reexportDeclaration = `export * from '../index';\nexport { default } from '../index';\n`;
-  await writeFile("dist/node/index.d.ts", reexportDeclaration);
-  await writeFile("dist/browser/index.d.ts", reexportDeclaration);
-  console.log(`✅ Declarations generated in ${((Date.now() - dtsStart) / 1000).toFixed(2)}s`);
-
-  const totalTime = ((Date.now() - totalStart) / 1000).toFixed(2);
-  console.log(`🎉 All builds finished in ${totalTime}s`);
-}
-
-build().catch((err) => {
-  console.error("Build failed:", err);
-  process.exit(1);
+await buildPlugin({
+  name: "@elizaos/plugin-codex-cli",
+  targets: [
+    {
+      label: "Node",
+      entry: "index.node.ts",
+      outSubdir: "node",
+      target: "node",
+      format: "esm",
+    },
+    {
+      label: "Browser",
+      entry: "index.browser.ts",
+      outSubdir: "browser",
+      target: "browser",
+      format: "esm",
+      minify: true,
+    },
+  ],
+  dtsProject: "tsconfig.build.json",
+  dtsShims: [
+    { path: "node/index.d.ts", content: reexport },
+    { path: "browser/index.d.ts", content: reexport },
+  ],
 });

--- a/plugins/plugin-computeruse/build.ts
+++ b/plugins/plugin-computeruse/build.ts
@@ -1,114 +1,51 @@
 #!/usr/bin/env bun
 /**
- * Build script for plugin-computeruse
+ * Build script for @elizaos/plugin-computeruse. Orchestration lives in the
+ * shared driver (plugins/plugin-build.ts); this lists only what differs.
+ *
+ * Three Node/ESM entrypoints are bundled with linked sourcemaps and flat
+ * `[name].[ext]` naming (index + register-routes at the dist root, the mobile
+ * OCR provider under dist/mobile). Declarations are emitted declaration-only
+ * from tsconfig.build.json. The emitted `dist/` is byte-identical to the
+ * previous hand-rolled build.
  */
+import { buildPlugin } from "../plugin-build";
 
-import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { rm } from "node:fs/promises";
-import { fileURLToPath } from "node:url";
-import { $ } from "bun";
-import { externalsFromPackageJson } from "../plugin-build-externals.ts";
+const naming = { entry: "[name].[ext]" };
 
-const RM_RECURSIVE_SCRIPT = fileURLToPath(
-  new URL("../../packages/scripts/rm-path-recursive.mjs", import.meta.url),
-);
-
-const externalDeps = await externalsFromPackageJson("./package.json", {
-  extra: ["node:*"],
+await buildPlugin({
+  name: "plugin-computeruse",
+  clean: true,
+  externalsOptions: { extra: ["node:*"] },
+  targets: [
+    {
+      label: "index",
+      entry: "./src/index.ts",
+      outSubdir: "",
+      target: "node",
+      format: "esm",
+      sourcemap: "linked",
+      naming,
+    },
+    {
+      label: "register-routes",
+      entry: "./src/register-routes.ts",
+      outSubdir: "",
+      target: "node",
+      format: "esm",
+      sourcemap: "linked",
+      naming,
+    },
+    {
+      label: "mobile/ocr-provider",
+      entry: "./src/mobile/ocr-provider.ts",
+      outSubdir: "mobile",
+      target: "node",
+      format: "esm",
+      sourcemap: "linked",
+      naming,
+    },
+  ],
+  dtsProject: "tsconfig.build.json",
+  dtsEmitDeclarationOnly: true,
 });
-
-function rmRecursive(target: string) {
-  const result = spawnSync(process.execPath, [RM_RECURSIVE_SCRIPT, target], {
-    stdio: "inherit",
-  });
-  if (result.error) throw result.error;
-  if (result.status !== 0) {
-    throw new Error(
-      `rm-path-recursive failed for ${target} with status ${result.status}`,
-    );
-  }
-}
-
-async function cleanBuild(outdir = "dist") {
-  if (existsSync(outdir)) {
-    rmRecursive(outdir);
-    console.log(`Cleaned ${outdir} directory`);
-  }
-  if (existsSync("tsconfig.build.tsbuildinfo")) {
-    await rm("tsconfig.build.tsbuildinfo", { force: true });
-  }
-}
-
-async function build() {
-  const start = performance.now();
-  console.log("Building plugin-computeruse...");
-
-  try {
-    await cleanBuild("dist");
-
-    const [buildResult, declResult] = await Promise.all([
-      (async () => {
-        console.log("Bundling with Bun...");
-        const outputs: BuildArtifact[] = [];
-        for (const { entrypoint, outdir } of [
-          { entrypoint: "./src/index.ts", outdir: "./dist" },
-          { entrypoint: "./src/register-routes.ts", outdir: "./dist" },
-          {
-            entrypoint: "./src/mobile/ocr-provider.ts",
-            outdir: "./dist/mobile",
-          },
-        ]) {
-          const result = await Bun.build({
-            entrypoints: [entrypoint],
-            outdir,
-            target: "node",
-            format: "esm",
-            sourcemap: "linked",
-            minify: false,
-            external: externalDeps,
-            naming: {
-              entry: "[name].[ext]",
-            },
-          });
-
-          if (!result.success) {
-            console.error("Build failed:", result.logs);
-            return { success: false, outputs };
-          }
-          outputs.push(...result.outputs);
-        }
-
-        const totalSize = outputs.reduce((sum, output) => sum + output.size, 0);
-        const sizeMB = (totalSize / 1024 / 1024).toFixed(2);
-        console.log(`Built ${outputs.length} file(s) - ${sizeMB}MB`);
-
-        return { success: true, outputs };
-      })(),
-
-      (async () => {
-        console.log("Generating TypeScript declarations...");
-        try {
-          await $`bunx tsc --noCheck --emitDeclarationOnly --incremental --project ./tsconfig.build.json`;
-          console.log("TypeScript declarations generated");
-          return { success: true };
-        } catch (e) {
-          console.error("TypeScript declaration generation failed", e);
-          return { success: false };
-        }
-      })(),
-    ]);
-
-    if (!buildResult.success || !declResult.success) {
-      process.exit(1);
-    }
-
-    const elapsed = ((performance.now() - start) / 1000).toFixed(2);
-    console.log(`Build complete! (${elapsed}s)`);
-  } catch (error) {
-    console.error("Build error:", error);
-    process.exit(1);
-  }
-}
-
-build();

--- a/plugins/plugin-pdf/build.ts
+++ b/plugins/plugin-pdf/build.ts
@@ -1,80 +1,40 @@
 #!/usr/bin/env bun
+/**
+ * Build script for @elizaos/plugin-pdf (Node + Browser). Orchestration lives in
+ * the shared driver (plugins/plugin-build.ts); this lists only what differs.
+ *
+ * pdfjs-dist is a transitive dep (via unpdf); keep it externalized so the worker
+ * entry inside pdfjs-dist isn't inlined. The emitted `dist/` is byte-identical
+ * to the previous hand-rolled build.
+ */
+import { buildPlugin } from "../plugin-build";
 
-import { externalsFromPackageJson } from "../plugin-build-externals.ts";
+// Single-quoted re-export to keep the emitted .d.ts byte-stable.
+const reexport = "export * from '../index';\nexport { default } from '../index';\n";
 
-const externalDeps = await externalsFromPackageJson("./package.json", {
-  // pdfjs-dist is a transitive dep (via unpdf); keep externalized so the
-  // worker entry inside pdfjs-dist isn't inlined.
-  extra: ["pdfjs-dist"],
-});
-
-async function build(): Promise<void> {
-  const totalStart = Date.now();
-
-  const nodeStart = Date.now();
-  console.log("🔨 Building @elizaos/plugin-pdf for Node (ESM)...");
-
-  const nodeResult = await Bun.build({
-    entrypoints: ["index.node.ts"],
-    outdir: "dist/node",
-    target: "node",
-    format: "esm",
-    sourcemap: "external",
-    minify: false,
-    external: externalDeps,
-  });
-
-  if (!nodeResult.success) {
-    console.error("Node ESM build failed:", nodeResult.logs);
-    throw new Error("Node ESM build failed");
-  }
-
-  console.log(`✅ Node ESM build complete in ${((Date.now() - nodeStart) / 1000).toFixed(2)}s`);
-
-  const browserStart = Date.now();
-  console.log("🌐 Building @elizaos/plugin-pdf for Browser...");
-
-  const browserResult = await Bun.build({
-    entrypoints: ["index.browser.ts"],
-    outdir: "dist/browser",
-    target: "browser",
-    format: "esm",
-    sourcemap: "external",
-    minify: true,
-    external: externalDeps,
-  });
-
-  if (!browserResult.success) {
-    console.error("Browser build failed:", browserResult.logs);
-    throw new Error("Browser build failed");
-  }
-
-  console.log(`✅ Browser build complete in ${((Date.now() - browserStart) / 1000).toFixed(2)}s`);
-
-  const dtsStart = Date.now();
-  console.log("📝 Generating TypeScript declarations...");
-
-  const { mkdir, writeFile } = await import("node:fs/promises");
-  const { $ } = await import("bun");
-  await $`bunx tsc --project tsconfig.build.json --noCheck`;
-
-  await mkdir("dist/node", { recursive: true });
-  await mkdir("dist/browser", { recursive: true });
-
-  const reexportDeclaration = `export * from '../index';
-export { default } from '../index';
-`;
-
-  await writeFile("dist/node/index.d.ts", reexportDeclaration);
-  await writeFile("dist/browser/index.d.ts", reexportDeclaration);
-
-  console.log(`✅ Declarations generated in ${((Date.now() - dtsStart) / 1000).toFixed(2)}s`);
-
-  const totalTime = ((Date.now() - totalStart) / 1000).toFixed(2);
-  console.log(`🎉 All builds finished in ${totalTime}s`);
-}
-
-build().catch((err) => {
-  console.error("Build failed:", err);
-  process.exit(1);
+await buildPlugin({
+  name: "@elizaos/plugin-pdf",
+  externalsOptions: { extra: ["pdfjs-dist"] },
+  targets: [
+    {
+      label: "Node",
+      entry: "index.node.ts",
+      outSubdir: "node",
+      target: "node",
+      format: "esm",
+    },
+    {
+      label: "Browser",
+      entry: "index.browser.ts",
+      outSubdir: "browser",
+      target: "browser",
+      format: "esm",
+      minify: true,
+    },
+  ],
+  dtsProject: "tsconfig.build.json",
+  dtsShims: [
+    { path: "node/index.d.ts", content: reexport },
+    { path: "browser/index.d.ts", content: reexport },
+  ],
 });


### PR DESCRIPTION
Continues **#10078** — migrates five more plugins' hand-rolled `build.ts` onto the shared `buildPlugin` driver, all **byte-identical** (sorted per-file sha256, BEFORE vs AFTER, zero diff; reproduced on a single pass — no nondeterminism).

| plugin | dist files | targets |
|---|---|---|
| plugin-computeruse | 188 | 3 Node/ESM entrypoints, `sourcemap:"linked"`, flat `naming`, `clean`, `externalsOptions.extra:["node:*"]`, `dtsEmitDeclarationOnly` |
| plugin-benchmarks | 3 | single Node, `dtsTolerant`, root `dtsShims` |
| plugin-cli-inference | 26 | Node + minified Browser |
| plugin-codex-cli | 20 | Node + minified Browser |
| plugin-pdf | 20 | Node + minified Browser, `externalsOptions.extra:["pdfjs-dist"]` |

Net **−199 lines** of duplicated orchestration. **No driver gaps** — every plugin's needs were covered by existing `BuildPluginConfig` fields.

Notable discovery (`plugin-benchmarks`): its tsconfig `outDir:"../dist"` makes `tsc` emit into a gitignored `plugins/dist` stray that's discarded — the real `dist/index.d.ts` is a 60-byte reexport shim, faithfully reproduced via `dtsShims` (not tsc), matching the original output exactly.

Verification: each `bun run --cwd plugins/plugin-<p> build` exits 0 (dist counts match the manifests above); all five shims typecheck against the driver. Byte-identical-or-skip — all five passed. Refs #10078.

🤖 Generated with [Claude Code](https://claude.com/claude-code)