### PR TITLE
test(plugin-browser): wire a MiniWoB++ benchmark through the real BROWSER command surface (#9476)

### DIFF
--- a/.github/issue-evidence/9476-browser-benchmark/README.md
+++ b/.github/issue-evidence/9476-browser-benchmark/README.md
@@ -1,0 +1,75 @@
+# #9476 — a benchmark wired through real plugin-browser
+
+This is the evidence bundle for the one Definition-of-Done deliverable that was
+[verifiably missing on `develop`](https://github.com/elizaOS/eliza/issues/9476#issuecomment-4830133507):
+
+> **≥1 benchmark wired through `plugin-browser`** (mirror
+> `plugin-computeruse/src/osworld/adapter.ts`), with a committed run artifact.
+
+The other three DoD items (CI-asserted parity matrix, a real-code JSDOM lane, a
+typed error contract) already landed. The web benchmarks (Mind2Web, WebShop,
+VisualWebBench) all **bypass** plugin-browser via the inference layer — no
+benchmark actually drove the BROWSER command surface end-to-end. This closes
+that gap.
+
+## What it is
+
+A **MiniWoB++-style** web-interaction benchmark (the canonical web-agent
+benchmark — Shi et al. 2017, Liu et al. 2018) whose every action is dispatched
+through the **real** `executeBrowserWorkspaceCommand` router — the same
+mock-free path the `browser-workspace-web-real-code` lane drives — and whose
+reward is computed from **observable DOM state read back through real BROWSER
+`get` commands**. No mock service stands in for the browser.
+
+Code: `plugins/plugin-browser/src/benchmark/`
+(`adapter.ts` mirrors `plugin-computeruse/src/osworld/adapter.ts`).
+
+| File | Role |
+|------|------|
+| `types.ts`   | Action / observation / task / report contracts + the engine-agnostic `BrowserCommandExecutor` seam |
+| `tasks.ts`   | 6 MiniWoB++ tasks (pure markup, no page scripts) with deterministic per-seed instances + oracle solutions |
+| `adapter.ts` | `BrowserBenchmarkAdapter` — `loadTask` / `getObservation` / `executeAction` / `step` / `rewardContext` |
+| `policy.ts`  | `OraclePolicy` (deterministic solver) + `NoopPolicy` / `WrongPolicy` (negative baselines) |
+| `runner.ts`  | `runBenchmarkSuite` — drives every task×seed episode, scores it, aggregates the report |
+| `__tests__/miniwob-adapter.test.ts` | CI-asserted real-code lane (runs in the default `vitest run`) |
+
+## How to reproduce
+
+```bash
+# the CI-asserted lane (runs through the real router, no mock):
+bun run --cwd plugins/plugin-browser test -- src/benchmark
+
+# the runnable harness → writes a JSON artifact + prints a summary table:
+bun run --cwd plugins/plugin-browser bench:miniwob                 # oracle policy
+bun run --cwd plugins/plugin-browser bench:miniwob -- --policy noop
+bun run --cwd plugins/plugin-browser bench:miniwob -- --policy wrong
+```
+
+## Artifacts in this folder (host: Windows 11 Pro, engine `jsdom-web`)
+
+| Artifact | Policy | Result | What it proves |
+|----------|--------|--------|----------------|
+| `miniwob-oracle-run.json` | oracle | **18/18 solved (100%)** | the suite is solvable end-to-end through real BROWSER commands; every action step records `resultMode: "web"` |
+| `miniwob-noop-run.json`   | noop   | **0/18 solved** | doing nothing scores 0 — the reward is grounded in real DOM state, not hard-coded to pass |
+| `miniwob-wrong-run.json`  | wrong  | **0/18 solved** | wrong-target / wrong-text near-misses score 0 — the reward discriminates |
+
+Each episode's `trajectory` lists the real commands the adapter dispatched
+(`resultMode: "web"` = the live `executeBrowserWorkspaceCommand` router ran it;
+a non-null `error` is a real workspace error code, e.g. on a missing element).
+
+The oracle's perfect score next to the noop/wrong zeros is the key signal: the
+benchmark exercises the real path **and** the reward function is honest.
+
+## Why JSDOM web mode (not real Chromium) here
+
+Web mode IS plugin-browser's canonical mock-free execution path — the re-open
+comment itself credits the JSDOM `browser-workspace-web-real-code` lane as
+legitimate "real (non-mock) code". It is deterministic, dependency-free, and
+CI-safe, so the committed artifact is reproducible. Reward is read from real DOM
+(`get value` / `get checked` / `get url` / `get title`); page scripts are
+**not** used (web mode hard-blocks script execution, GHSA-mhhr-9ph9-64j7), so
+nothing about the scoring relies on in-page JS.
+
+A **real-Chromium** engine lane, a web-element grounding benchmark, and CI
+gating of those heavier lanes are the deferred "Needs CI infra" items — tracked
+in the linked follow-up issue so no DoD deliverable is silently dropped.

--- a/.github/issue-evidence/9476-browser-benchmark/miniwob-noop-run.json
+++ b/.github/issue-evidence/9476-browser-benchmark/miniwob-noop-run.json
@@ -1,0 +1,424 @@
+{
+  "generatedAt": "2026-06-30T01:22:49.618Z",
+  "benchmark": "miniwob++",
+  "engine": "jsdom-web",
+  "policy": "noop",
+  "seedsPerTask": 3,
+  "episodes": [
+    {
+      "taskId": "click-button",
+      "family": "miniwob++",
+      "seed": 0,
+      "utterance": "Click the button labelled \"THREE\".",
+      "engine": "jsdom-web",
+      "policy": "noop",
+      "reward": 0,
+      "success": false,
+      "steps": 1,
+      "trajectory": [
+        {
+          "action": {
+            "type": "done",
+            "note": "noop"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "click-button",
+      "family": "miniwob++",
+      "seed": 1,
+      "utterance": "Click the button labelled \"cancel\".",
+      "engine": "jsdom-web",
+      "policy": "noop",
+      "reward": 0,
+      "success": false,
+      "steps": 1,
+      "trajectory": [
+        {
+          "action": {
+            "type": "done",
+            "note": "noop"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "click-button",
+      "family": "miniwob++",
+      "seed": 2,
+      "utterance": "Click the button labelled \"cancel\".",
+      "engine": "jsdom-web",
+      "policy": "noop",
+      "reward": 0,
+      "success": false,
+      "steps": 1,
+      "trajectory": [
+        {
+          "action": {
+            "type": "done",
+            "note": "noop"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "click-link",
+      "family": "miniwob++",
+      "seed": 0,
+      "utterance": "Click the link \"Home\".",
+      "engine": "jsdom-web",
+      "policy": "noop",
+      "reward": 0,
+      "success": false,
+      "steps": 1,
+      "trajectory": [
+        {
+          "action": {
+            "type": "done",
+            "note": "noop"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "click-link",
+      "family": "miniwob++",
+      "seed": 1,
+      "utterance": "Click the link \"Contact\".",
+      "engine": "jsdom-web",
+      "policy": "noop",
+      "reward": 0,
+      "success": false,
+      "steps": 1,
+      "trajectory": [
+        {
+          "action": {
+            "type": "done",
+            "note": "noop"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "click-link",
+      "family": "miniwob++",
+      "seed": 2,
+      "utterance": "Click the link \"Docs\".",
+      "engine": "jsdom-web",
+      "policy": "noop",
+      "reward": 0,
+      "success": false,
+      "steps": 1,
+      "trajectory": [
+        {
+          "action": {
+            "type": "done",
+            "note": "noop"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "enter-text",
+      "family": "miniwob++",
+      "seed": 0,
+      "utterance": "Enter \"Tobias\" into the text field and press Submit.",
+      "engine": "jsdom-web",
+      "policy": "noop",
+      "reward": 0,
+      "success": false,
+      "steps": 1,
+      "trajectory": [
+        {
+          "action": {
+            "type": "done",
+            "note": "noop"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "enter-text",
+      "family": "miniwob++",
+      "seed": 1,
+      "utterance": "Enter \"vivid\" into the text field and press Submit.",
+      "engine": "jsdom-web",
+      "policy": "noop",
+      "reward": 0,
+      "success": false,
+      "steps": 1,
+      "trajectory": [
+        {
+          "action": {
+            "type": "done",
+            "note": "noop"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "enter-text",
+      "family": "miniwob++",
+      "seed": 2,
+      "utterance": "Enter \"lantern\" into the text field and press Submit.",
+      "engine": "jsdom-web",
+      "policy": "noop",
+      "reward": 0,
+      "success": false,
+      "steps": 1,
+      "trajectory": [
+        {
+          "action": {
+            "type": "done",
+            "note": "noop"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "enter-text-dynamic",
+      "family": "miniwob++",
+      "seed": 0,
+      "utterance": "Enter \"Tobias100\" into the text field and press Submit.",
+      "engine": "jsdom-web",
+      "policy": "noop",
+      "reward": 0,
+      "success": false,
+      "steps": 1,
+      "trajectory": [
+        {
+          "action": {
+            "type": "done",
+            "note": "noop"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "enter-text-dynamic",
+      "family": "miniwob++",
+      "seed": 1,
+      "utterance": "Enter \"harbor513\" into the text field and press Submit.",
+      "engine": "jsdom-web",
+      "policy": "noop",
+      "reward": 0,
+      "success": false,
+      "steps": 1,
+      "trajectory": [
+        {
+          "action": {
+            "type": "done",
+            "note": "noop"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "enter-text-dynamic",
+      "family": "miniwob++",
+      "seed": 2,
+      "utterance": "Enter \"quartz591\" into the text field and press Submit.",
+      "engine": "jsdom-web",
+      "policy": "noop",
+      "reward": 0,
+      "success": false,
+      "steps": 1,
+      "trajectory": [
+        {
+          "action": {
+            "type": "done",
+            "note": "noop"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "click-checkboxes",
+      "family": "miniwob++",
+      "seed": 0,
+      "utterance": "Select lemon. Leave the rest unchecked.",
+      "engine": "jsdom-web",
+      "policy": "noop",
+      "reward": 0,
+      "success": false,
+      "steps": 1,
+      "trajectory": [
+        {
+          "action": {
+            "type": "done",
+            "note": "noop"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "click-checkboxes",
+      "family": "miniwob++",
+      "seed": 1,
+      "utterance": "Select peach. Leave the rest unchecked.",
+      "engine": "jsdom-web",
+      "policy": "noop",
+      "reward": 0,
+      "success": false,
+      "steps": 1,
+      "trajectory": [
+        {
+          "action": {
+            "type": "done",
+            "note": "noop"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "click-checkboxes",
+      "family": "miniwob++",
+      "seed": 2,
+      "utterance": "Select peach. Leave the rest unchecked.",
+      "engine": "jsdom-web",
+      "policy": "noop",
+      "reward": 0,
+      "success": false,
+      "steps": 1,
+      "trajectory": [
+        {
+          "action": {
+            "type": "done",
+            "note": "noop"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "multistep-purchase",
+      "family": "miniwob++",
+      "seed": 0,
+      "utterance": "Open the catalog, then buy the featured item.",
+      "engine": "jsdom-web",
+      "policy": "noop",
+      "reward": 0,
+      "success": false,
+      "steps": 1,
+      "trajectory": [
+        {
+          "action": {
+            "type": "done",
+            "note": "noop"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "multistep-purchase",
+      "family": "miniwob++",
+      "seed": 1,
+      "utterance": "Open the catalog, then buy the featured item.",
+      "engine": "jsdom-web",
+      "policy": "noop",
+      "reward": 0,
+      "success": false,
+      "steps": 1,
+      "trajectory": [
+        {
+          "action": {
+            "type": "done",
+            "note": "noop"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "multistep-purchase",
+      "family": "miniwob++",
+      "seed": 2,
+      "utterance": "Open the catalog, then buy the featured item.",
+      "engine": "jsdom-web",
+      "policy": "noop",
+      "reward": 0,
+      "success": false,
+      "steps": 1,
+      "trajectory": [
+        {
+          "action": {
+            "type": "done",
+            "note": "noop"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "total": 18,
+    "solved": 0,
+    "successRate": 0,
+    "byTask": [
+      {
+        "taskId": "click-button",
+        "solved": 0,
+        "total": 3
+      },
+      {
+        "taskId": "click-link",
+        "solved": 0,
+        "total": 3
+      },
+      {
+        "taskId": "enter-text",
+        "solved": 0,
+        "total": 3
+      },
+      {
+        "taskId": "enter-text-dynamic",
+        "solved": 0,
+        "total": 3
+      },
+      {
+        "taskId": "click-checkboxes",
+        "solved": 0,
+        "total": 3
+      },
+      {
+        "taskId": "multistep-purchase",
+        "solved": 0,
+        "total": 3
+      }
+    ]
+  }
+}

--- a/.github/issue-evidence/9476-browser-benchmark/miniwob-oracle-run.json
+++ b/.github/issue-evidence/9476-browser-benchmark/miniwob-oracle-run.json
@@ -1,0 +1,673 @@
+{
+  "generatedAt": "2026-06-30T01:22:29.803Z",
+  "benchmark": "miniwob++",
+  "engine": "jsdom-web",
+  "policy": "oracle",
+  "seedsPerTask": 3,
+  "episodes": [
+    {
+      "taskId": "click-button",
+      "family": "miniwob++",
+      "seed": 0,
+      "utterance": "Click the button labelled \"THREE\".",
+      "engine": "jsdom-web",
+      "policy": "oracle",
+      "reward": 1,
+      "success": true,
+      "steps": 2,
+      "trajectory": [
+        {
+          "action": {
+            "type": "click",
+            "selector": "#btn-0",
+            "note": "button \"THREE\""
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "oracle plan exhausted"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "click-button",
+      "family": "miniwob++",
+      "seed": 1,
+      "utterance": "Click the button labelled \"cancel\".",
+      "engine": "jsdom-web",
+      "policy": "oracle",
+      "reward": 1,
+      "success": true,
+      "steps": 2,
+      "trajectory": [
+        {
+          "action": {
+            "type": "click",
+            "selector": "#btn-0",
+            "note": "button \"cancel\""
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "oracle plan exhausted"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "click-button",
+      "family": "miniwob++",
+      "seed": 2,
+      "utterance": "Click the button labelled \"cancel\".",
+      "engine": "jsdom-web",
+      "policy": "oracle",
+      "reward": 1,
+      "success": true,
+      "steps": 2,
+      "trajectory": [
+        {
+          "action": {
+            "type": "click",
+            "selector": "#btn-0",
+            "note": "button \"cancel\""
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "oracle plan exhausted"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "click-link",
+      "family": "miniwob++",
+      "seed": 0,
+      "utterance": "Click the link \"Home\".",
+      "engine": "jsdom-web",
+      "policy": "oracle",
+      "reward": 1,
+      "success": true,
+      "steps": 2,
+      "trajectory": [
+        {
+          "action": {
+            "type": "click",
+            "selector": "#lnk-0",
+            "note": "link \"Home\""
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "oracle plan exhausted"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "click-link",
+      "family": "miniwob++",
+      "seed": 1,
+      "utterance": "Click the link \"Contact\".",
+      "engine": "jsdom-web",
+      "policy": "oracle",
+      "reward": 1,
+      "success": true,
+      "steps": 2,
+      "trajectory": [
+        {
+          "action": {
+            "type": "click",
+            "selector": "#lnk-0",
+            "note": "link \"Contact\""
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "oracle plan exhausted"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "click-link",
+      "family": "miniwob++",
+      "seed": 2,
+      "utterance": "Click the link \"Docs\".",
+      "engine": "jsdom-web",
+      "policy": "oracle",
+      "reward": 1,
+      "success": true,
+      "steps": 2,
+      "trajectory": [
+        {
+          "action": {
+            "type": "click",
+            "selector": "#lnk-0",
+            "note": "link \"Docs\""
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "oracle plan exhausted"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "enter-text",
+      "family": "miniwob++",
+      "seed": 0,
+      "utterance": "Enter \"Tobias\" into the text field and press Submit.",
+      "engine": "jsdom-web",
+      "policy": "oracle",
+      "reward": 1,
+      "success": true,
+      "steps": 3,
+      "trajectory": [
+        {
+          "action": {
+            "type": "type",
+            "selector": "#tt",
+            "value": "Tobias",
+            "note": "enter \"Tobias\""
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "click",
+            "selector": "#submit",
+            "note": "submit"
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "oracle plan exhausted"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "enter-text",
+      "family": "miniwob++",
+      "seed": 1,
+      "utterance": "Enter \"vivid\" into the text field and press Submit.",
+      "engine": "jsdom-web",
+      "policy": "oracle",
+      "reward": 1,
+      "success": true,
+      "steps": 3,
+      "trajectory": [
+        {
+          "action": {
+            "type": "type",
+            "selector": "#tt",
+            "value": "vivid",
+            "note": "enter \"vivid\""
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "click",
+            "selector": "#submit",
+            "note": "submit"
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "oracle plan exhausted"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "enter-text",
+      "family": "miniwob++",
+      "seed": 2,
+      "utterance": "Enter \"lantern\" into the text field and press Submit.",
+      "engine": "jsdom-web",
+      "policy": "oracle",
+      "reward": 1,
+      "success": true,
+      "steps": 3,
+      "trajectory": [
+        {
+          "action": {
+            "type": "type",
+            "selector": "#tt",
+            "value": "lantern",
+            "note": "enter \"lantern\""
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "click",
+            "selector": "#submit",
+            "note": "submit"
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "oracle plan exhausted"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "enter-text-dynamic",
+      "family": "miniwob++",
+      "seed": 0,
+      "utterance": "Enter \"Tobias100\" into the text field and press Submit.",
+      "engine": "jsdom-web",
+      "policy": "oracle",
+      "reward": 1,
+      "success": true,
+      "steps": 3,
+      "trajectory": [
+        {
+          "action": {
+            "type": "type",
+            "selector": "#tt",
+            "value": "Tobias100",
+            "note": "enter \"Tobias100\""
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "click",
+            "selector": "#submit",
+            "note": "submit"
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "oracle plan exhausted"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "enter-text-dynamic",
+      "family": "miniwob++",
+      "seed": 1,
+      "utterance": "Enter \"harbor513\" into the text field and press Submit.",
+      "engine": "jsdom-web",
+      "policy": "oracle",
+      "reward": 1,
+      "success": true,
+      "steps": 3,
+      "trajectory": [
+        {
+          "action": {
+            "type": "type",
+            "selector": "#tt",
+            "value": "harbor513",
+            "note": "enter \"harbor513\""
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "click",
+            "selector": "#submit",
+            "note": "submit"
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "oracle plan exhausted"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "enter-text-dynamic",
+      "family": "miniwob++",
+      "seed": 2,
+      "utterance": "Enter \"quartz591\" into the text field and press Submit.",
+      "engine": "jsdom-web",
+      "policy": "oracle",
+      "reward": 1,
+      "success": true,
+      "steps": 3,
+      "trajectory": [
+        {
+          "action": {
+            "type": "type",
+            "selector": "#tt",
+            "value": "quartz591",
+            "note": "enter \"quartz591\""
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "click",
+            "selector": "#submit",
+            "note": "submit"
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "oracle plan exhausted"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "click-checkboxes",
+      "family": "miniwob++",
+      "seed": 0,
+      "utterance": "Select lemon. Leave the rest unchecked.",
+      "engine": "jsdom-web",
+      "policy": "oracle",
+      "reward": 1,
+      "success": true,
+      "steps": 2,
+      "trajectory": [
+        {
+          "action": {
+            "type": "check",
+            "selector": "#cb-2",
+            "note": "check lemon"
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "oracle plan exhausted"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "click-checkboxes",
+      "family": "miniwob++",
+      "seed": 1,
+      "utterance": "Select peach. Leave the rest unchecked.",
+      "engine": "jsdom-web",
+      "policy": "oracle",
+      "reward": 1,
+      "success": true,
+      "steps": 2,
+      "trajectory": [
+        {
+          "action": {
+            "type": "check",
+            "selector": "#cb-5",
+            "note": "check peach"
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "oracle plan exhausted"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "click-checkboxes",
+      "family": "miniwob++",
+      "seed": 2,
+      "utterance": "Select peach. Leave the rest unchecked.",
+      "engine": "jsdom-web",
+      "policy": "oracle",
+      "reward": 1,
+      "success": true,
+      "steps": 2,
+      "trajectory": [
+        {
+          "action": {
+            "type": "check",
+            "selector": "#cb-5",
+            "note": "check peach"
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "oracle plan exhausted"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "multistep-purchase",
+      "family": "miniwob++",
+      "seed": 0,
+      "utterance": "Open the catalog, then buy the featured item.",
+      "engine": "jsdom-web",
+      "policy": "oracle",
+      "reward": 1,
+      "success": true,
+      "steps": 3,
+      "trajectory": [
+        {
+          "action": {
+            "type": "click",
+            "selector": "#go-catalog",
+            "note": "open catalog"
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "click",
+            "selector": "#buy",
+            "note": "buy featured item"
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "oracle plan exhausted"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "multistep-purchase",
+      "family": "miniwob++",
+      "seed": 1,
+      "utterance": "Open the catalog, then buy the featured item.",
+      "engine": "jsdom-web",
+      "policy": "oracle",
+      "reward": 1,
+      "success": true,
+      "steps": 3,
+      "trajectory": [
+        {
+          "action": {
+            "type": "click",
+            "selector": "#go-catalog",
+            "note": "open catalog"
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "click",
+            "selector": "#buy",
+            "note": "buy featured item"
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "oracle plan exhausted"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "multistep-purchase",
+      "family": "miniwob++",
+      "seed": 2,
+      "utterance": "Open the catalog, then buy the featured item.",
+      "engine": "jsdom-web",
+      "policy": "oracle",
+      "reward": 1,
+      "success": true,
+      "steps": 3,
+      "trajectory": [
+        {
+          "action": {
+            "type": "click",
+            "selector": "#go-catalog",
+            "note": "open catalog"
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "click",
+            "selector": "#buy",
+            "note": "buy featured item"
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "oracle plan exhausted"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "total": 18,
+    "solved": 18,
+    "successRate": 1,
+    "byTask": [
+      {
+        "taskId": "click-button",
+        "solved": 3,
+        "total": 3
+      },
+      {
+        "taskId": "click-link",
+        "solved": 3,
+        "total": 3
+      },
+      {
+        "taskId": "enter-text",
+        "solved": 3,
+        "total": 3
+      },
+      {
+        "taskId": "enter-text-dynamic",
+        "solved": 3,
+        "total": 3
+      },
+      {
+        "taskId": "click-checkboxes",
+        "solved": 3,
+        "total": 3
+      },
+      {
+        "taskId": "multistep-purchase",
+        "solved": 3,
+        "total": 3
+      }
+    ]
+  }
+}

--- a/.github/issue-evidence/9476-browser-benchmark/miniwob-wrong-run.json
+++ b/.github/issue-evidence/9476-browser-benchmark/miniwob-wrong-run.json
@@ -1,0 +1,592 @@
+{
+  "generatedAt": "2026-06-30T01:23:09.130Z",
+  "benchmark": "miniwob++",
+  "engine": "jsdom-web",
+  "policy": "wrong",
+  "seedsPerTask": 3,
+  "episodes": [
+    {
+      "taskId": "click-button",
+      "family": "miniwob++",
+      "seed": 0,
+      "utterance": "Click the button labelled \"THREE\".",
+      "engine": "jsdom-web",
+      "policy": "wrong",
+      "reward": 0,
+      "success": false,
+      "steps": 2,
+      "trajectory": [
+        {
+          "action": {
+            "type": "click",
+            "selector": "#wob-nonexistent",
+            "note": "wrong-target"
+          },
+          "resultMode": null,
+          "error": "command_failed: Target element was not found."
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "wrong-done"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "click-button",
+      "family": "miniwob++",
+      "seed": 1,
+      "utterance": "Click the button labelled \"cancel\".",
+      "engine": "jsdom-web",
+      "policy": "wrong",
+      "reward": 0,
+      "success": false,
+      "steps": 2,
+      "trajectory": [
+        {
+          "action": {
+            "type": "click",
+            "selector": "#wob-nonexistent",
+            "note": "wrong-target"
+          },
+          "resultMode": null,
+          "error": "command_failed: Target element was not found."
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "wrong-done"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "click-button",
+      "family": "miniwob++",
+      "seed": 2,
+      "utterance": "Click the button labelled \"cancel\".",
+      "engine": "jsdom-web",
+      "policy": "wrong",
+      "reward": 0,
+      "success": false,
+      "steps": 2,
+      "trajectory": [
+        {
+          "action": {
+            "type": "click",
+            "selector": "#wob-nonexistent",
+            "note": "wrong-target"
+          },
+          "resultMode": null,
+          "error": "command_failed: Target element was not found."
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "wrong-done"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "click-link",
+      "family": "miniwob++",
+      "seed": 0,
+      "utterance": "Click the link \"Home\".",
+      "engine": "jsdom-web",
+      "policy": "wrong",
+      "reward": 0,
+      "success": false,
+      "steps": 2,
+      "trajectory": [
+        {
+          "action": {
+            "type": "click",
+            "selector": "#wob-nonexistent",
+            "note": "wrong-target"
+          },
+          "resultMode": null,
+          "error": "command_failed: Target element was not found."
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "wrong-done"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "click-link",
+      "family": "miniwob++",
+      "seed": 1,
+      "utterance": "Click the link \"Contact\".",
+      "engine": "jsdom-web",
+      "policy": "wrong",
+      "reward": 0,
+      "success": false,
+      "steps": 2,
+      "trajectory": [
+        {
+          "action": {
+            "type": "click",
+            "selector": "#wob-nonexistent",
+            "note": "wrong-target"
+          },
+          "resultMode": null,
+          "error": "command_failed: Target element was not found."
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "wrong-done"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "click-link",
+      "family": "miniwob++",
+      "seed": 2,
+      "utterance": "Click the link \"Docs\".",
+      "engine": "jsdom-web",
+      "policy": "wrong",
+      "reward": 0,
+      "success": false,
+      "steps": 2,
+      "trajectory": [
+        {
+          "action": {
+            "type": "click",
+            "selector": "#wob-nonexistent",
+            "note": "wrong-target"
+          },
+          "resultMode": null,
+          "error": "command_failed: Target element was not found."
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "wrong-done"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "enter-text",
+      "family": "miniwob++",
+      "seed": 0,
+      "utterance": "Enter \"Tobias\" into the text field and press Submit.",
+      "engine": "jsdom-web",
+      "policy": "wrong",
+      "reward": 0,
+      "success": false,
+      "steps": 2,
+      "trajectory": [
+        {
+          "action": {
+            "type": "type",
+            "selector": "#tt",
+            "value": "Tobias-WRONG",
+            "note": "wrong-text"
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "wrong-done"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "enter-text",
+      "family": "miniwob++",
+      "seed": 1,
+      "utterance": "Enter \"vivid\" into the text field and press Submit.",
+      "engine": "jsdom-web",
+      "policy": "wrong",
+      "reward": 0,
+      "success": false,
+      "steps": 2,
+      "trajectory": [
+        {
+          "action": {
+            "type": "type",
+            "selector": "#tt",
+            "value": "vivid-WRONG",
+            "note": "wrong-text"
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "wrong-done"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "enter-text",
+      "family": "miniwob++",
+      "seed": 2,
+      "utterance": "Enter \"lantern\" into the text field and press Submit.",
+      "engine": "jsdom-web",
+      "policy": "wrong",
+      "reward": 0,
+      "success": false,
+      "steps": 2,
+      "trajectory": [
+        {
+          "action": {
+            "type": "type",
+            "selector": "#tt",
+            "value": "lantern-WRONG",
+            "note": "wrong-text"
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "wrong-done"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "enter-text-dynamic",
+      "family": "miniwob++",
+      "seed": 0,
+      "utterance": "Enter \"Tobias100\" into the text field and press Submit.",
+      "engine": "jsdom-web",
+      "policy": "wrong",
+      "reward": 0,
+      "success": false,
+      "steps": 2,
+      "trajectory": [
+        {
+          "action": {
+            "type": "type",
+            "selector": "#tt",
+            "value": "Tobias100-WRONG",
+            "note": "wrong-text"
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "wrong-done"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "enter-text-dynamic",
+      "family": "miniwob++",
+      "seed": 1,
+      "utterance": "Enter \"harbor513\" into the text field and press Submit.",
+      "engine": "jsdom-web",
+      "policy": "wrong",
+      "reward": 0,
+      "success": false,
+      "steps": 2,
+      "trajectory": [
+        {
+          "action": {
+            "type": "type",
+            "selector": "#tt",
+            "value": "harbor513-WRONG",
+            "note": "wrong-text"
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "wrong-done"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "enter-text-dynamic",
+      "family": "miniwob++",
+      "seed": 2,
+      "utterance": "Enter \"quartz591\" into the text field and press Submit.",
+      "engine": "jsdom-web",
+      "policy": "wrong",
+      "reward": 0,
+      "success": false,
+      "steps": 2,
+      "trajectory": [
+        {
+          "action": {
+            "type": "type",
+            "selector": "#tt",
+            "value": "quartz591-WRONG",
+            "note": "wrong-text"
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "wrong-done"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "click-checkboxes",
+      "family": "miniwob++",
+      "seed": 0,
+      "utterance": "Select lemon. Leave the rest unchecked.",
+      "engine": "jsdom-web",
+      "policy": "wrong",
+      "reward": 0,
+      "success": false,
+      "steps": 2,
+      "trajectory": [
+        {
+          "action": {
+            "type": "check",
+            "selector": "#wob-nonexistent",
+            "note": "wrong-target"
+          },
+          "resultMode": null,
+          "error": "command_failed: Target element was not found."
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "wrong-done"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "click-checkboxes",
+      "family": "miniwob++",
+      "seed": 1,
+      "utterance": "Select peach. Leave the rest unchecked.",
+      "engine": "jsdom-web",
+      "policy": "wrong",
+      "reward": 0,
+      "success": false,
+      "steps": 2,
+      "trajectory": [
+        {
+          "action": {
+            "type": "check",
+            "selector": "#wob-nonexistent",
+            "note": "wrong-target"
+          },
+          "resultMode": null,
+          "error": "command_failed: Target element was not found."
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "wrong-done"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "click-checkboxes",
+      "family": "miniwob++",
+      "seed": 2,
+      "utterance": "Select peach. Leave the rest unchecked.",
+      "engine": "jsdom-web",
+      "policy": "wrong",
+      "reward": 0,
+      "success": false,
+      "steps": 2,
+      "trajectory": [
+        {
+          "action": {
+            "type": "check",
+            "selector": "#wob-nonexistent",
+            "note": "wrong-target"
+          },
+          "resultMode": null,
+          "error": "command_failed: Target element was not found."
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "wrong-done"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "multistep-purchase",
+      "family": "miniwob++",
+      "seed": 0,
+      "utterance": "Open the catalog, then buy the featured item.",
+      "engine": "jsdom-web",
+      "policy": "wrong",
+      "reward": 0,
+      "success": false,
+      "steps": 2,
+      "trajectory": [
+        {
+          "action": {
+            "type": "click",
+            "selector": "#wob-nonexistent",
+            "note": "wrong-target"
+          },
+          "resultMode": null,
+          "error": "command_failed: Target element was not found."
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "wrong-done"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "multistep-purchase",
+      "family": "miniwob++",
+      "seed": 1,
+      "utterance": "Open the catalog, then buy the featured item.",
+      "engine": "jsdom-web",
+      "policy": "wrong",
+      "reward": 0,
+      "success": false,
+      "steps": 2,
+      "trajectory": [
+        {
+          "action": {
+            "type": "click",
+            "selector": "#wob-nonexistent",
+            "note": "wrong-target"
+          },
+          "resultMode": null,
+          "error": "command_failed: Target element was not found."
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "wrong-done"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "multistep-purchase",
+      "family": "miniwob++",
+      "seed": 2,
+      "utterance": "Open the catalog, then buy the featured item.",
+      "engine": "jsdom-web",
+      "policy": "wrong",
+      "reward": 0,
+      "success": false,
+      "steps": 2,
+      "trajectory": [
+        {
+          "action": {
+            "type": "click",
+            "selector": "#wob-nonexistent",
+            "note": "wrong-target"
+          },
+          "resultMode": null,
+          "error": "command_failed: Target element was not found."
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "wrong-done"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "total": 18,
+    "solved": 0,
+    "successRate": 0,
+    "byTask": [
+      {
+        "taskId": "click-button",
+        "solved": 0,
+        "total": 3
+      },
+      {
+        "taskId": "click-link",
+        "solved": 0,
+        "total": 3
+      },
+      {
+        "taskId": "enter-text",
+        "solved": 0,
+        "total": 3
+      },
+      {
+        "taskId": "enter-text-dynamic",
+        "solved": 0,
+        "total": 3
+      },
+      {
+        "taskId": "click-checkboxes",
+        "solved": 0,
+        "total": 3
+      },
+      {
+        "taskId": "multistep-purchase",
+        "solved": 0,
+        "total": 3
+      }
+    ]
+  }
+}

--- a/plugins/plugin-browser/package.json
+++ b/plugins/plugin-browser/package.json
@@ -31,6 +31,7 @@
   "scripts": {
     "typecheck": "tsgo --noEmit -p tsconfig.json",
     "test": "vitest run",
+    "bench:miniwob": "bun scripts/run-miniwob-benchmark.mjs",
     "build": "bun run build:js && bun run build:types",
     "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist",
     "build:js": "tsup --config ../tsup.plugin-packages.shared.ts",

--- a/plugins/plugin-browser/scripts/run-miniwob-benchmark.mjs
+++ b/plugins/plugin-browser/scripts/run-miniwob-benchmark.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env bun
+/**
+ * MiniWoB++ browser benchmark runner (#9476).
+ *
+ * Runs the MiniWoB++ task suite through the REAL plugin-browser command router
+ * (`executeBrowserWorkspaceCommand`, web mode) and writes a run-report artifact.
+ * This is the plugin-browser analog of plugin-computeruse's OSWorld benchmark
+ * runner — proof that a web-interaction benchmark is wired end-to-end through
+ * plugin-browser BROWSER actions, not bypassing it via the inference layer.
+ *
+ * Usage:
+ *   bun scripts/run-miniwob-benchmark.mjs [--policy oracle|noop|wrong]
+ *                                         [--seeds N] [--out <file>]
+ */
+
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  NoopPolicy,
+  OraclePolicy,
+  runBenchmarkSuite,
+  WrongPolicy,
+} from "../src/benchmark/index.ts";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "../../..");
+
+function parseArgs(argv) {
+  const opts = { policy: "oracle", seeds: 3, out: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--policy") opts.policy = argv[++i];
+    else if (a === "--seeds") opts.seeds = Number(argv[++i]);
+    else if (a === "--out") opts.out = argv[++i];
+  }
+  return opts;
+}
+
+function makePolicy(name) {
+  if (name === "noop") return new NoopPolicy();
+  if (name === "wrong") return new WrongPolicy();
+  return new OraclePolicy();
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const seeds = Array.from({ length: Math.max(1, opts.seeds) }, (_, i) => i);
+  const outPath =
+    opts.out ??
+    path.join(
+      repoRoot,
+      ".github/issue-evidence/9476-browser-benchmark",
+      `miniwob-${opts.policy}-run.json`,
+    );
+
+  const report = await runBenchmarkSuite({
+    seeds,
+    policy: makePolicy(opts.policy),
+  });
+
+  // Stamp the artifact after the deterministic run (clock is not part of the run).
+  const stamped = { generatedAt: new Date().toISOString(), ...report };
+
+  await mkdir(path.dirname(outPath), { recursive: true });
+  await writeFile(outPath, `${JSON.stringify(stamped, null, 2)}\n`);
+
+  // Human-readable summary.
+  console.log(
+    `\nMiniWoB++ benchmark — engine=${report.engine} policy=${report.policy}`,
+  );
+  console.log("─".repeat(64));
+  for (const t of report.summary.byTask) {
+    const bar = t.solved === t.total ? "✓" : "✗";
+    console.log(`  ${bar} ${t.taskId.padEnd(24)} ${t.solved}/${t.total}`);
+  }
+  console.log("─".repeat(64));
+  console.log(
+    `  TOTAL solved ${report.summary.solved}/${report.summary.total} ` +
+      `(success rate ${(report.summary.successRate * 100).toFixed(1)}%)`,
+  );
+
+  const failures = report.episodes.filter((e) => !e.success);
+  if (failures.length > 0) {
+    console.log("\n  failing episodes:");
+    for (const f of failures) {
+      const steps = f.trajectory
+        .map((s) => `${s.action.type}${s.error ? `!${s.error}` : ""}`)
+        .join(" → ");
+      console.log(
+        `   - ${f.taskId}#${f.seed} reward=${f.reward} steps=[${steps}]` +
+          `${f.error ? ` err=${f.error}` : ""}`,
+      );
+    }
+  }
+  console.log(`\n  artifact → ${path.relative(repoRoot, outPath)}\n`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/plugins/plugin-browser/src/benchmark/__tests__/miniwob-adapter.test.ts
+++ b/plugins/plugin-browser/src/benchmark/__tests__/miniwob-adapter.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Real-code benchmark lane (#9476).
+ *
+ * Drives the MiniWoB++ suite through the REAL `executeBrowserWorkspaceCommand`
+ * router (web mode) via {@link createWorkspaceBenchmarkExecutor} — no mock
+ * service stands in for the browser. This is the plugin-browser analog of
+ * plugin-computeruse's OSWorld `*.real.test.ts` lanes, and the CI-asserted proof
+ * that a benchmark is wired end-to-end through plugin-browser.
+ *
+ * It asserts both directions: the oracle policy SOLVES every task (reward 1),
+ * and the noop/adversarial baselines FAIL every task (reward 0) — so the reward
+ * is grounded in real DOM state, not hard-coded to pass.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  BrowserBenchmarkAdapter,
+  createWorkspaceBenchmarkExecutor,
+} from "../adapter.js";
+import { NoopPolicy, OraclePolicy, WrongPolicy } from "../policy.js";
+import { runBenchmarkSuite } from "../runner.js";
+import { getTaskById, MINIWOB_TASKS } from "../tasks.js";
+
+const fixedClock = () => 0;
+const SEEDS = [0, 1, 2];
+
+describe("MiniWoB++ benchmark wired through real plugin-browser", () => {
+  it("oracle policy solves every task on every seed (reward 1) through the real router", async () => {
+    const report = await runBenchmarkSuite({
+      seeds: SEEDS,
+      policy: new OraclePolicy(),
+      timestampSource: fixedClock,
+    });
+
+    expect(report.engine).toBe("jsdom-web");
+    expect(report.benchmark).toBe("miniwob++");
+    expect(report.summary.total).toBe(MINIWOB_TASKS.length * SEEDS.length);
+    expect(report.summary.solved).toBe(report.summary.total);
+    expect(report.summary.successRate).toBe(1);
+
+    for (const ep of report.episodes) {
+      expect(ep.reward, `${ep.taskId}#${ep.seed}`).toBe(1);
+      expect(ep.success, `${ep.taskId}#${ep.seed}`).toBe(true);
+      expect(ep.error, `${ep.taskId}#${ep.seed}`).toBeUndefined();
+      // every non-terminal step actually executed a real web-mode command
+      const actionSteps = ep.trajectory.filter((s) => s.action.type !== "done");
+      expect(
+        actionSteps.length,
+        `${ep.taskId}#${ep.seed} has steps`,
+      ).toBeGreaterThan(0);
+      for (const s of actionSteps) {
+        expect(s.resultMode, `${ep.taskId}#${ep.seed} ${s.action.type}`).toBe(
+          "web",
+        );
+        expect(s.error).toBeNull();
+      }
+    }
+
+    // every task is represented and fully solved
+    expect(report.summary.byTask).toHaveLength(MINIWOB_TASKS.length);
+    for (const t of report.summary.byTask) {
+      expect(t.solved, t.taskId).toBe(t.total);
+    }
+  });
+
+  it("noop baseline scores 0 on every task — reward discriminates, never auto-passes", async () => {
+    const report = await runBenchmarkSuite({
+      seeds: SEEDS,
+      policy: new NoopPolicy(),
+      timestampSource: fixedClock,
+    });
+    expect(report.summary.solved).toBe(0);
+    expect(report.summary.successRate).toBe(0);
+    for (const ep of report.episodes) {
+      expect(ep.reward, `${ep.taskId}#${ep.seed}`).toBe(0);
+    }
+  });
+
+  it("adversarial (wrong-target / wrong-text) baseline scores 0 on every task", async () => {
+    const report = await runBenchmarkSuite({
+      seeds: [0, 1],
+      policy: new WrongPolicy(),
+      timestampSource: fixedClock,
+    });
+    expect(report.summary.solved).toBe(0);
+    for (const ep of report.episodes) {
+      expect(ep.reward, `${ep.taskId}#${ep.seed}`).toBe(0);
+    }
+  });
+
+  it("surfaces a real workspace error when an action targets a missing element", async () => {
+    const { executor, dispose } = await createWorkspaceBenchmarkExecutor({});
+    try {
+      const adapter = new BrowserBenchmarkAdapter(executor);
+      const task = getTaskById("click-button");
+      expect(task).toBeDefined();
+      if (!task) return;
+      await adapter.loadTask(task, 0);
+
+      const res = await adapter.executeAction({
+        type: "click",
+        selector: "#wob-does-not-exist",
+      });
+      expect(res.commandResult).toBeNull();
+      expect(res.error).toBeDefined();
+      expect(res.error?.message ?? "").toMatch(/not found|target/i);
+    } finally {
+      await dispose();
+    }
+  });
+
+  it("observation reads the live #wob-query goal back through real BROWSER get", async () => {
+    const { executor, dispose } = await createWorkspaceBenchmarkExecutor({});
+    try {
+      const adapter = new BrowserBenchmarkAdapter(executor);
+      const task = getTaskById("enter-text");
+      if (!task) throw new Error("enter-text task missing");
+      const obs = await adapter.loadTask(task, 1);
+      expect(obs.url).toContain("enter-text");
+      expect(obs.title).toBe("Enter Text");
+      // the natural-language goal is observable in the live DOM, MiniWoB-style
+      expect(obs.bodyText.toLowerCase()).toContain("text field");
+    } finally {
+      await dispose();
+    }
+  });
+});

--- a/plugins/plugin-browser/src/benchmark/adapter.ts
+++ b/plugins/plugin-browser/src/benchmark/adapter.ts
@@ -1,0 +1,298 @@
+/**
+ * Browser benchmark adapter (#9476).
+ *
+ * The plugin-browser analog of `plugin-computeruse/src/osworld/adapter.ts`:
+ * bridges a web-interaction benchmark to the real BROWSER command surface.
+ *
+ *   1. loadTask()       — register the task's routed pages, navigate to start
+ *   2. getObservation() — read url/title/body through real `snapshot`/`get`
+ *   3. executeAction()  — map a benchmark action to a BROWSER command + dispatch
+ *   4. step()           — execute + observe (gymnasium-style), record trajectory
+ *   5. rewardContext()  — a read seam the task scores against (real `get`s)
+ *
+ * Engine-agnostic: it dispatches through any {@link BrowserCommandExecutor}, so
+ * the same suite runs against JSDOM web mode (deterministic, CI-safe) or a real
+ * Chromium target, exactly like the OSWorld adapter accepts any
+ * `ComputerUseService`.
+ */
+
+import {
+  __resetBrowserWorkspaceStateForTests,
+  closeBrowserWorkspaceTab,
+  executeBrowserWorkspaceCommand,
+  openBrowserWorkspaceTab,
+} from "../workspace/browser-workspace.js";
+import type {
+  BrowserWorkspaceCommand,
+  BrowserWorkspaceCommandResult,
+  BrowserWorkspaceGetMode,
+} from "../workspace/browser-workspace-types.js";
+import type {
+  BenchmarkAction,
+  BenchmarkObservation,
+  BenchmarkRewardContext,
+  BenchmarkStepResult,
+  BenchmarkTask,
+  BrowserCommandExecutor,
+} from "./types.js";
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function asString(value: unknown): string {
+  return typeof value === "string" ? value : value == null ? "" : String(value);
+}
+
+export interface BrowserBenchmarkAdapterConfig {
+  /** Step budget cap independent of a task's own `maxSteps`. */
+  maxTrajectoryLength: number;
+}
+
+export class BrowserBenchmarkAdapter {
+  private readonly executor: BrowserCommandExecutor;
+  private readonly config: BrowserBenchmarkAdapterConfig;
+  private stepCount = 0;
+  private terminated = false;
+  private trajectory: BenchmarkStepResult[] = [];
+  private timestampSource: () => number;
+
+  constructor(
+    executor: BrowserCommandExecutor,
+    config?: Partial<BrowserBenchmarkAdapterConfig> & {
+      timestampSource?: () => number;
+    },
+  ) {
+    this.executor = executor;
+    this.config = {
+      maxTrajectoryLength: config?.maxTrajectoryLength ?? 20,
+    };
+    this.timestampSource = config?.timestampSource ?? (() => Date.now());
+  }
+
+  get engine(): string {
+    return this.executor.engine;
+  }
+
+  // ── Task setup ──────────────────────────────────────────────────────
+  /**
+   * Reset the episode, register the task's routed pages, and navigate to the
+   * start URL — the benchmark "env reset". Returns the first observation.
+   */
+  async loadTask(
+    task: BenchmarkTask,
+    seed: number,
+  ): Promise<BenchmarkObservation> {
+    this.reset();
+    const { startUrl, routes } = task.build(seed);
+    for (const route of routes) {
+      await this.executor.execute({
+        subaction: "network",
+        networkAction: "route",
+        url: route.url,
+        responseBody: route.html,
+      });
+    }
+    await this.executor.execute({ subaction: "navigate", url: startUrl });
+    return this.getObservation();
+  }
+
+  // ── Observation ─────────────────────────────────────────────────────
+  async getObservation(): Promise<BenchmarkObservation> {
+    let url = "";
+    let title = "";
+    let bodyText = "";
+    try {
+      const snap = await this.executor.execute({ subaction: "snapshot" });
+      const value = asRecord(snap.value);
+      url = asString(value.url);
+      title = asString(value.title);
+      bodyText = asString(value.bodyText);
+    } catch {
+      // Observation best-effort: a failed snapshot yields an empty frame, the
+      // same contract OSWorldAdapter uses for a failed screenshot.
+    }
+    return {
+      url,
+      title,
+      bodyText,
+      step: this.stepCount,
+      done: this.terminated,
+    };
+  }
+
+  // ── Action execution ────────────────────────────────────────────────
+  /**
+   * Map a benchmark action to a BROWSER command and dispatch it through the
+   * real router. Control actions (`done`) terminate without a command.
+   */
+  async executeAction(action: BenchmarkAction): Promise<{
+    done: boolean;
+    error?: { code: string; message: string };
+    commandResult: BrowserWorkspaceCommandResult | null;
+  }> {
+    if (action.type === "done") {
+      this.terminated = true;
+      return { done: true, commandResult: null };
+    }
+
+    const command = this.toCommand(action);
+    if (!command) {
+      return {
+        done: false,
+        commandResult: null,
+        error: {
+          code: "unmapped_action",
+          message: `Unmapped action: ${action.type}`,
+        },
+      };
+    }
+
+    try {
+      const commandResult = await this.executor.execute(command);
+      return { done: false, commandResult };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const code =
+        error &&
+        typeof error === "object" &&
+        "browserWorkspaceErrorCode" in error
+          ? asString(
+              (error as { browserWorkspaceErrorCode?: unknown })
+                .browserWorkspaceErrorCode,
+            )
+          : "command_failed";
+      return { done: false, commandResult: null, error: { code, message } };
+    }
+  }
+
+  private toCommand(action: BenchmarkAction): BrowserWorkspaceCommand | null {
+    switch (action.type) {
+      case "click":
+        return { subaction: "click", selector: action.selector };
+      case "type":
+        return {
+          subaction: "type",
+          selector: action.selector,
+          value: action.value,
+        };
+      case "fill":
+        return {
+          subaction: "fill",
+          selector: action.selector,
+          value: action.value,
+        };
+      case "check":
+        return { subaction: "check", selector: action.selector };
+      case "uncheck":
+        return { subaction: "uncheck", selector: action.selector };
+      case "press":
+        return {
+          subaction: "press",
+          selector: action.selector,
+          key: action.key,
+        };
+      case "navigate":
+        return { subaction: "navigate", url: action.url };
+      default:
+        return null;
+    }
+  }
+
+  // ── Gymnasium-style step ────────────────────────────────────────────
+  async step(action: BenchmarkAction): Promise<BenchmarkStepResult> {
+    this.stepCount++;
+    const result = await this.executeAction(action);
+    const trajectoryExceeded =
+      this.stepCount >= this.config.maxTrajectoryLength;
+    const observation = await this.getObservation();
+    const stepResult: BenchmarkStepResult = {
+      action,
+      observation,
+      commandResult: result.commandResult,
+      error: result.error,
+      done: result.done || trajectoryExceeded,
+      timestamp: this.timestampSource(),
+    };
+    this.trajectory.push(stepResult);
+    return stepResult;
+  }
+
+  // ── Reward seam ─────────────────────────────────────────────────────
+  rewardContext(): BenchmarkRewardContext {
+    const get = async (
+      getMode: BrowserWorkspaceGetMode,
+      selector?: string,
+    ): Promise<unknown> => {
+      const command: BrowserWorkspaceCommand = selector
+        ? { subaction: "get", getMode, selector }
+        : { subaction: "get", getMode };
+      const result = await this.executor.execute(command);
+      return result.value;
+    };
+    return {
+      getValue: async (selector) => asString(await get("value", selector)),
+      getChecked: async (selector) => Boolean(await get("checked", selector)),
+      getText: async (selector) => asString(await get("text", selector)),
+      getCount: async (selector) => Number(await get("count", selector)) || 0,
+      getTitle: async () => asString(await get("title")),
+      getUrl: async () => asString(await get("url")),
+    };
+  }
+
+  // ── State ───────────────────────────────────────────────────────────
+  reset(): void {
+    this.stepCount = 0;
+    this.terminated = false;
+    this.trajectory = [];
+  }
+
+  getTrajectory(): BenchmarkStepResult[] {
+    return [...this.trajectory];
+  }
+
+  getStepCount(): number {
+    return this.stepCount;
+  }
+
+  isTerminated(): boolean {
+    return this.terminated;
+  }
+}
+
+/**
+ * Build a {@link BrowserCommandExecutor} backed by the real
+ * `executeBrowserWorkspaceCommand` router in JSDOM web mode — the same mock-free
+ * path the `browser-workspace-web-real-code` lane drives. Each executor owns one
+ * fresh tab; `dispose()` closes it.
+ */
+export async function createWorkspaceBenchmarkExecutor(
+  env: NodeJS.ProcessEnv = {},
+): Promise<{
+  executor: BrowserCommandExecutor;
+  tabId: string;
+  dispose: () => Promise<void>;
+}> {
+  await __resetBrowserWorkspaceStateForTests();
+  const tab = await openBrowserWorkspaceTab(
+    { show: true, url: "about:blank" },
+    env,
+  );
+  const executor: BrowserCommandExecutor = {
+    engine: "jsdom-web",
+    execute: (command) =>
+      executeBrowserWorkspaceCommand(
+        command.id ? command : { ...command, id: tab.id },
+        env,
+      ),
+  };
+  return {
+    executor,
+    tabId: tab.id,
+    dispose: async () => {
+      await closeBrowserWorkspaceTab(tab.id, env);
+    },
+  };
+}

--- a/plugins/plugin-browser/src/benchmark/index.ts
+++ b/plugins/plugin-browser/src/benchmark/index.ts
@@ -1,0 +1,35 @@
+/**
+ * Browser benchmark harness (#9476) — a MiniWoB++-style web-interaction
+ * benchmark wired through the real BROWSER command surface. This is the
+ * plugin-browser analog of `plugin-computeruse/src/osworld/`.
+ */
+
+export {
+  BrowserBenchmarkAdapter,
+  type BrowserBenchmarkAdapterConfig,
+  createWorkspaceBenchmarkExecutor,
+} from "./adapter.js";
+export {
+  type BenchmarkPolicy,
+  type BenchmarkPolicyInput,
+  NoopPolicy,
+  OraclePolicy,
+  WrongPolicy,
+} from "./policy.js";
+export {
+  type BenchmarkRunOptions,
+  runBenchmarkSuite,
+  runEpisode,
+} from "./runner.js";
+export { getTaskById, MINIWOB_TASKS, WOB_ORIGIN } from "./tasks.js";
+export type {
+  BenchmarkAction,
+  BenchmarkActionType,
+  BenchmarkEpisodeResult,
+  BenchmarkObservation,
+  BenchmarkRewardContext,
+  BenchmarkStepResult,
+  BenchmarkSuiteReport,
+  BenchmarkTask,
+  BrowserCommandExecutor,
+} from "./types.js";

--- a/plugins/plugin-browser/src/benchmark/policy.ts
+++ b/plugins/plugin-browser/src/benchmark/policy.ts
@@ -1,0 +1,81 @@
+/**
+ * Benchmark policies (#9476).
+ *
+ * A policy maps an observation to the next action — the "agent" half of the
+ * benchmark loop. The harness is policy-agnostic: the committed run uses the
+ * deterministic {@link OraclePolicy} (reproducible, zero model cost), while the
+ * same seam accepts an LLM-backed policy (read the `#wob-query` goal from the
+ * observation, choose an action) so the suite can later gate on a live model —
+ * mirroring how OSWorld's `*.real.test.ts` drives the adapter with a live model.
+ *
+ * {@link NoopPolicy} is the negative baseline: it does nothing, so a working
+ * reward function must score every task 0 under it. That proves the reward
+ * discriminates rather than always returning 1.
+ */
+
+import type {
+  BenchmarkAction,
+  BenchmarkObservation,
+  BenchmarkStepResult,
+  BenchmarkTask,
+} from "./types.js";
+
+export interface BenchmarkPolicyInput {
+  observation: BenchmarkObservation;
+  task: BenchmarkTask;
+  seed: number;
+  history: BenchmarkStepResult[];
+}
+
+export interface BenchmarkPolicy {
+  readonly name: string;
+  act(input: BenchmarkPolicyInput): Promise<BenchmarkAction>;
+}
+
+/** Replays the task's known-correct action sequence, then signals `done`. */
+export class OraclePolicy implements BenchmarkPolicy {
+  readonly name = "oracle";
+  async act({
+    task,
+    seed,
+    history,
+  }: BenchmarkPolicyInput): Promise<BenchmarkAction> {
+    const plan = task.oracle(seed);
+    const next = plan[history.length];
+    return next ?? { type: "done", note: "oracle plan exhausted" };
+  }
+}
+
+/** Negative baseline: terminates immediately without acting. */
+export class NoopPolicy implements BenchmarkPolicy {
+  readonly name = "noop";
+  async act(): Promise<BenchmarkAction> {
+    return { type: "done", note: "noop" };
+  }
+}
+
+/**
+ * Adversarial baseline: takes the oracle's first action but inverts its intent
+ * (wrong selector / wrong text) to confirm the reward rejects near-misses.
+ */
+export class WrongPolicy implements BenchmarkPolicy {
+  readonly name = "wrong";
+  async act({
+    task,
+    seed,
+    history,
+  }: BenchmarkPolicyInput): Promise<BenchmarkAction> {
+    if (history.length > 0) return { type: "done", note: "wrong-done" };
+    const first = task.oracle(seed)[0];
+    if (!first) return { type: "done", note: "wrong-empty" };
+    if (first.type === "type" || first.type === "fill") {
+      return {
+        ...first,
+        value: `${first.value ?? ""}-WRONG`,
+        note: "wrong-text",
+      };
+    }
+    // For click/check, point at a selector that does not exist → no effect.
+    return { ...first, selector: "#wob-nonexistent", note: "wrong-target" };
+  }
+}

--- a/plugins/plugin-browser/src/benchmark/runner.ts
+++ b/plugins/plugin-browser/src/benchmark/runner.ts
@@ -1,0 +1,158 @@
+/**
+ * Benchmark suite runner (#9476).
+ *
+ * Drives every task×seed episode through a {@link BrowserBenchmarkAdapter} and
+ * the chosen {@link BenchmarkPolicy}, scoring each with the task's reward
+ * function (computed from real DOM reads). Returns a {@link BenchmarkSuiteReport}
+ * — the shape committed as the run artifact.
+ */
+
+import {
+  BrowserBenchmarkAdapter,
+  createWorkspaceBenchmarkExecutor,
+} from "./adapter.js";
+import { type BenchmarkPolicy, OraclePolicy } from "./policy.js";
+import { MINIWOB_TASKS } from "./tasks.js";
+import type {
+  BenchmarkEpisodeResult,
+  BenchmarkSuiteReport,
+  BenchmarkTask,
+  BrowserCommandExecutor,
+} from "./types.js";
+
+export interface BenchmarkRunOptions {
+  tasks?: readonly BenchmarkTask[];
+  seeds?: readonly number[];
+  policy?: BenchmarkPolicy;
+  /** Fresh executor (and its disposer) per episode. */
+  makeExecutor?: () => Promise<{
+    executor: BrowserCommandExecutor;
+    dispose: () => Promise<void>;
+  }>;
+  /** Injectable clock for deterministic trajectory timestamps in tests. */
+  timestampSource?: () => number;
+}
+
+export async function runEpisode(
+  task: BenchmarkTask,
+  seed: number,
+  policy: BenchmarkPolicy,
+  executor: BrowserCommandExecutor,
+  timestampSource?: () => number,
+): Promise<BenchmarkEpisodeResult> {
+  const adapter = new BrowserBenchmarkAdapter(executor, {
+    maxTrajectoryLength: task.maxSteps,
+    timestampSource,
+  });
+  const base: Omit<
+    BenchmarkEpisodeResult,
+    "reward" | "success" | "steps" | "trajectory"
+  > = {
+    taskId: task.id,
+    family: task.family,
+    seed,
+    utterance: task.utterance(seed),
+    engine: executor.engine,
+    policy: policy.name,
+  };
+
+  try {
+    await adapter.loadTask(task, seed);
+    for (let i = 0; i < task.maxSteps && !adapter.isTerminated(); i++) {
+      const observation = await adapter.getObservation();
+      const action = await policy.act({
+        observation,
+        task,
+        seed,
+        history: adapter.getTrajectory(),
+      });
+      const result = await adapter.step(action);
+      if (result.done) break;
+    }
+    const reward = await task.reward(adapter.rewardContext(), seed);
+    return {
+      ...base,
+      reward,
+      success: reward >= 1,
+      steps: adapter.getStepCount(),
+      trajectory: adapter.getTrajectory().map((s) => ({
+        action: s.action,
+        resultMode: s.commandResult?.mode ?? null,
+        error: s.error ? `${s.error.code}: ${s.error.message}` : null,
+      })),
+    };
+  } catch (error) {
+    return {
+      ...base,
+      reward: 0,
+      success: false,
+      steps: adapter.getStepCount(),
+      trajectory: adapter.getTrajectory().map((s) => ({
+        action: s.action,
+        resultMode: s.commandResult?.mode ?? null,
+        error: s.error ? `${s.error.code}: ${s.error.message}` : null,
+      })),
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export async function runBenchmarkSuite(
+  options: BenchmarkRunOptions = {},
+): Promise<BenchmarkSuiteReport> {
+  const tasks = options.tasks ?? MINIWOB_TASKS;
+  const seeds = options.seeds ?? [0, 1, 2];
+  const policy = options.policy ?? new OraclePolicy();
+  const makeExecutor =
+    options.makeExecutor ?? (() => createWorkspaceBenchmarkExecutor({}));
+
+  const episodes: BenchmarkEpisodeResult[] = [];
+  let engine = "unknown";
+
+  for (const task of tasks) {
+    for (const seed of seeds) {
+      const { executor, dispose } = await makeExecutor();
+      engine = executor.engine;
+      try {
+        episodes.push(
+          await runEpisode(
+            task,
+            seed,
+            policy,
+            executor,
+            options.timestampSource,
+          ),
+        );
+      } finally {
+        await dispose();
+      }
+    }
+  }
+
+  const byTaskMap = new Map<string, { solved: number; total: number }>();
+  for (const ep of episodes) {
+    const entry = byTaskMap.get(ep.taskId) ?? { solved: 0, total: 0 };
+    entry.total += 1;
+    if (ep.success) entry.solved += 1;
+    byTaskMap.set(ep.taskId, entry);
+  }
+  const solved = episodes.filter((e) => e.success).length;
+
+  return {
+    benchmark: "miniwob++",
+    engine,
+    policy: policy.name,
+    seedsPerTask: seeds.length,
+    episodes,
+    summary: {
+      total: episodes.length,
+      solved,
+      successRate: episodes.length === 0 ? 0 : solved / episodes.length,
+      byTask: [...byTaskMap.entries()].map(([taskId, v]) => ({
+        taskId,
+        solved: v.solved,
+        total: v.total,
+      })),
+    },
+  };
+}

--- a/plugins/plugin-browser/src/benchmark/tasks.ts
+++ b/plugins/plugin-browser/src/benchmark/tasks.ts
@@ -1,0 +1,447 @@
+/**
+ * MiniWoB++-style task suite for the plugin-browser benchmark (#9476).
+ *
+ * MiniWoB / MiniWoB++ (Shi et al. 2017, "World of Bits"; Liu et al. 2018) is the
+ * canonical web-interaction agent benchmark. Each task here is faithful to that
+ * format — a short natural-language `utterance` plus a self-contained DOM the
+ * agent must manipulate — but rendered as **pure markup with no page scripts**,
+ * because plugin-browser's web mode hard-blocks script execution
+ * (GHSA-mhhr-9ph9-64j7). Reward is therefore computed from *observable* DOM
+ * state (resulting URL/title, field values, checkbox states) read back through
+ * real BROWSER `get` commands — never from in-page JS.
+ *
+ * Determinism: every task is parameterised by an integer `seed` via a small
+ * splitmix/mulberry PRNG, so a suite run is fully reproducible (the committed
+ * artifact is stable) while still varying targets across seeds.
+ */
+
+import type { BenchmarkAction, BenchmarkTask } from "./types.js";
+
+/** Origin all task pages are served from (via the `network route` interceptor). */
+export const WOB_ORIGIN = "https://wob.test";
+
+/** Deterministic PRNG so a given seed always yields the same task instance. */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function pick<T>(rng: () => number, items: readonly T[]): T {
+  return items[Math.floor(rng() * items.length) % items.length];
+}
+
+/** Render the shared task chrome: the `#wob-query` goal banner MiniWoB exposes. */
+function page(title: string, query: string, body: string): string {
+  return `<!doctype html>
+<html>
+  <head><title>${escapeHtml(title)}</title></head>
+  <body>
+    <div id="wob-query" data-role="query">${escapeHtml(query)}</div>
+    <main id="area">${body}</main>
+  </body>
+</html>`;
+}
+
+function terminalPage(kind: "done" | "fail"): string {
+  const title = kind === "done" ? "WOB SUCCESS" : "WOB FAIL";
+  return page(
+    title,
+    title,
+    `<h1 id="wob-${kind}">${title}</h1><p>episode reward = ${kind === "done" ? "1" : "0"}</p>`,
+  );
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+const BUTTON_LABELS = [
+  "ONE",
+  "TWO",
+  "THREE",
+  "submit",
+  "next",
+  "cancel",
+  "ok",
+  "no",
+] as const;
+const LINK_LABELS = [
+  "Details",
+  "Home",
+  "Pricing",
+  "Contact",
+  "Docs",
+  "Blog",
+] as const;
+const WORDS = [
+  "Kanon",
+  "Lindsay",
+  "Tobias",
+  "Marlena",
+  "orange",
+  "harbor",
+  "vivid",
+  "lantern",
+  "quartz",
+  "meadow",
+] as const;
+const FRUITS = ["apple", "cherry", "lemon", "grape", "melon", "peach"] as const;
+
+const DONE_URL = `${WOB_ORIGIN}/wob/done`;
+const FAIL_URL = `${WOB_ORIGIN}/wob/fail`;
+
+/** Terminal routes every navigation-scored task shares. */
+function terminalRoutes(): ReadonlyArray<{ url: string; html: string }> {
+  return [
+    { url: DONE_URL, html: terminalPage("done") },
+    { url: FAIL_URL, html: terminalPage("fail") },
+  ];
+}
+
+// ── click-button ──────────────────────────────────────────────────────────
+// Click the button with the target label. Implemented as anchor "buttons" so a
+// click is observable through navigation (web mode has no JS to fire handlers).
+const clickButton: BenchmarkTask = {
+  id: "click-button",
+  family: "miniwob++",
+  description: "Click the button carrying the labelled text.",
+  maxSteps: 4,
+  utterance(seed) {
+    const rng = mulberry32(seed);
+    return `Click the button labelled "${pick(rng, BUTTON_LABELS)}".`;
+  },
+  build(seed) {
+    const rng = mulberry32(seed);
+    const target = pick(rng, BUTTON_LABELS);
+    const labels = Array.from(new Set([target, ...BUTTON_LABELS])).slice(0, 4);
+    const buttons = labels
+      .map((label, i) => {
+        const href = label === target ? "/wob/done" : "/wob/fail";
+        return `<a id="btn-${i}" role="button" class="wob-btn" href="${href}">${escapeHtml(label)}</a>`;
+      })
+      .join("\n      ");
+    return {
+      startUrl: `${WOB_ORIGIN}/click-button`,
+      routes: [
+        {
+          url: `${WOB_ORIGIN}/click-button`,
+          html: page(
+            "Click Button",
+            `Click the button labelled "${target}".`,
+            buttons,
+          ),
+        },
+        ...terminalRoutes(),
+      ],
+    };
+  },
+  oracle(seed) {
+    const rng = mulberry32(seed);
+    const target = pick(rng, BUTTON_LABELS);
+    const labels = Array.from(new Set([target, ...BUTTON_LABELS])).slice(0, 4);
+    const idx = labels.indexOf(target);
+    return [
+      { type: "click", selector: `#btn-${idx}`, note: `button "${target}"` },
+    ];
+  },
+  async reward(ctx) {
+    return (await ctx.getUrl()) === DONE_URL ? 1 : 0;
+  },
+};
+
+// ── click-link ──────────────────────────────────────────────────────────
+const clickLink: BenchmarkTask = {
+  id: "click-link",
+  family: "miniwob++",
+  description: "Click the hyperlink with the target text.",
+  maxSteps: 4,
+  utterance(seed) {
+    const rng = mulberry32(seed);
+    return `Click the link "${pick(rng, LINK_LABELS)}".`;
+  },
+  build(seed) {
+    const rng = mulberry32(seed);
+    const target = pick(rng, LINK_LABELS);
+    const labels = Array.from(new Set([target, ...LINK_LABELS])).slice(0, 4);
+    const links = labels
+      .map((label, i) => {
+        const href = label === target ? "/wob/done" : "/wob/fail";
+        return `<a id="lnk-${i}" href="${href}">${escapeHtml(label)}</a>`;
+      })
+      .join(" · ");
+    return {
+      startUrl: `${WOB_ORIGIN}/click-link`,
+      routes: [
+        {
+          url: `${WOB_ORIGIN}/click-link`,
+          html: page(
+            "Click Link",
+            `Click the link "${target}".`,
+            `<p id="copy">Pick the right one: ${links}</p>`,
+          ),
+        },
+        ...terminalRoutes(),
+      ],
+    };
+  },
+  oracle(seed) {
+    const rng = mulberry32(seed);
+    const target = pick(rng, LINK_LABELS);
+    const labels = Array.from(new Set([target, ...LINK_LABELS])).slice(0, 4);
+    return [
+      {
+        type: "click",
+        selector: `#lnk-${labels.indexOf(target)}`,
+        note: `link "${target}"`,
+      },
+    ];
+  },
+  async reward(ctx) {
+    return (await ctx.getUrl()) === DONE_URL ? 1 : 0;
+  },
+};
+
+// ── enter-text ──────────────────────────────────────────────────────────
+// Type a fixed target string into the field; reward = field value matches.
+const enterText: BenchmarkTask = {
+  id: "enter-text",
+  family: "miniwob++",
+  description: "Enter the requested text into the field and submit.",
+  maxSteps: 4,
+  utterance(seed) {
+    const rng = mulberry32(seed);
+    return `Enter "${pick(rng, WORDS)}" into the text field and press Submit.`;
+  },
+  build(seed) {
+    const rng = mulberry32(seed);
+    const target = pick(rng, WORDS);
+    return {
+      startUrl: `${WOB_ORIGIN}/enter-text`,
+      // Submit is a non-navigating button (no JS, no action) so the field
+      // persists for reward inspection — MiniWoB scores the entered value.
+      routes: [
+        {
+          url: `${WOB_ORIGIN}/enter-text`,
+          html: page(
+            "Enter Text",
+            `Enter "${target}" into the text field and press Submit.`,
+            // No <form> wrapper: web mode submits (and reloads, wiping the
+            // field) on ANY button click inside a form, even type="button".
+            // MiniWoB scores the entered value, so the field must persist.
+            `<input id="tt" name="tt" type="text" value="" />
+      <button id="submit" type="button">Submit</button>`,
+          ),
+        },
+      ],
+    };
+  },
+  oracle(seed) {
+    const rng = mulberry32(seed);
+    const target = pick(rng, WORDS);
+    return [
+      {
+        type: "type",
+        selector: "#tt",
+        value: target,
+        note: `enter "${target}"`,
+      },
+      { type: "click", selector: "#submit", note: "submit" },
+    ];
+  },
+  async reward(ctx, seed) {
+    const rng = mulberry32(seed);
+    const target = pick(rng, WORDS);
+    return (await ctx.getValue("#tt")) === target ? 1 : 0;
+  },
+};
+
+// ── enter-text-dynamic ────────────────────────────────────────────────────
+// Target string is generated per-seed (MiniWoB enter-text-dynamic): the agent
+// must read it from the page, not memorise a fixed answer.
+const enterTextDynamic: BenchmarkTask = {
+  id: "enter-text-dynamic",
+  family: "miniwob++",
+  description: "Enter the dynamically-generated token shown in the prompt.",
+  maxSteps: 4,
+  utterance(seed) {
+    return `Enter "${dynamicToken(seed)}" into the text field and press Submit.`;
+  },
+  build(seed) {
+    const target = dynamicToken(seed);
+    return {
+      startUrl: `${WOB_ORIGIN}/enter-text-dynamic`,
+      routes: [
+        {
+          url: `${WOB_ORIGIN}/enter-text-dynamic`,
+          html: page(
+            "Enter Text Dynamic",
+            `Enter "${target}" into the text field and press Submit.`,
+            // See enter-text: keep the field outside a <form> so the Submit
+            // click does not reload and wipe the entered value.
+            `<input id="tt" name="tt" type="text" value="" />
+      <button id="submit" type="button">Submit</button>`,
+          ),
+        },
+      ],
+    };
+  },
+  oracle(seed) {
+    const target = dynamicToken(seed);
+    return [
+      {
+        type: "type",
+        selector: "#tt",
+        value: target,
+        note: `enter "${target}"`,
+      },
+      { type: "click", selector: "#submit", note: "submit" },
+    ];
+  },
+  async reward(ctx, seed) {
+    return (await ctx.getValue("#tt")) === dynamicToken(seed) ? 1 : 0;
+  },
+};
+
+function dynamicToken(seed: number): string {
+  const rng = mulberry32(seed * 2654435761);
+  const word = pick(rng, WORDS);
+  const num = Math.floor(rng() * 900 + 100);
+  return `${word}${num}`;
+}
+
+// ── click-checkboxes ──────────────────────────────────────────────────────
+// Check exactly the target subset; leave the rest unchecked.
+const clickCheckboxes: BenchmarkTask = {
+  id: "click-checkboxes",
+  family: "miniwob++",
+  description: "Select exactly the requested checkboxes and no others.",
+  maxSteps: 8,
+  utterance(seed) {
+    return `Select ${checkboxTargets(seed).join(", ")}. Leave the rest unchecked.`;
+  },
+  build(seed) {
+    const targets = new Set(checkboxTargets(seed));
+    const boxes = FRUITS.map(
+      (label, i) =>
+        `<label><input id="cb-${i}" type="checkbox" /> ${escapeHtml(label)}</label>`,
+    ).join("<br/>\n      ");
+    return {
+      startUrl: `${WOB_ORIGIN}/click-checkboxes`,
+      routes: [
+        {
+          url: `${WOB_ORIGIN}/click-checkboxes`,
+          html: page(
+            "Click Checkboxes",
+            `Select ${[...targets].join(", ")}. Leave the rest unchecked.`,
+            `<form id="form">${boxes}</form>`,
+          ),
+        },
+      ],
+    };
+  },
+  oracle(seed) {
+    const targets = new Set(checkboxTargets(seed));
+    const actions: BenchmarkAction[] = [];
+    FRUITS.forEach((label, i) => {
+      if (targets.has(label)) {
+        actions.push({
+          type: "check",
+          selector: `#cb-${i}`,
+          note: `check ${label}`,
+        });
+      }
+    });
+    return actions;
+  },
+  async reward(ctx, seed) {
+    const targets = new Set(checkboxTargets(seed));
+    for (let i = 0; i < FRUITS.length; i++) {
+      const want = targets.has(FRUITS[i]);
+      const got = await ctx.getChecked(`#cb-${i}`);
+      if (got !== want) return 0;
+    }
+    return 1;
+  },
+};
+
+function checkboxTargets(seed: number): string[] {
+  const rng = mulberry32(seed * 40503);
+  const count = 1 + Math.floor(rng() * 2); // 1..2 targets
+  const shuffled = [...FRUITS].sort(() => rng() - 0.5);
+  return shuffled.slice(0, count).sort();
+}
+
+// ── multistep-purchase ────────────────────────────────────────────────────
+// A genuine multi-page flow: home → catalog → buy. Proves the harness drives
+// navigation end-to-end through real BROWSER commands, not a single click.
+const multistepPurchase: BenchmarkTask = {
+  id: "multistep-purchase",
+  family: "miniwob++",
+  description: "Navigate home → catalog → buy across multiple routed pages.",
+  maxSteps: 6,
+  utterance() {
+    return "Open the catalog, then buy the featured item.";
+  },
+  build(seed) {
+    const rng = mulberry32(seed * 19349663);
+    const distractors = Array.from({ length: 3 }, (_, i) => {
+      const label = pick(rng, LINK_LABELS);
+      return `<a id="cat-${i}" href="/wob/fail">${escapeHtml(label)}</a>`;
+    }).join(" · ");
+    return {
+      startUrl: `${WOB_ORIGIN}/shop`,
+      routes: [
+        {
+          url: `${WOB_ORIGIN}/shop`,
+          html: page(
+            "Shop Home",
+            "Open the catalog, then buy the featured item.",
+            `<a id="go-catalog" href="/catalog">Open catalog</a>`,
+          ),
+        },
+        {
+          url: `${WOB_ORIGIN}/catalog`,
+          html: page(
+            "Catalog",
+            "Buy the featured item.",
+            `<p>${distractors}</p><a id="buy" href="/wob/done">Buy featured item</a>`,
+          ),
+        },
+        ...terminalRoutes(),
+      ],
+    };
+  },
+  oracle() {
+    return [
+      { type: "click", selector: "#go-catalog", note: "open catalog" },
+      { type: "click", selector: "#buy", note: "buy featured item" },
+    ];
+  },
+  async reward(ctx) {
+    return (await ctx.getUrl()) === DONE_URL ? 1 : 0;
+  },
+};
+
+/** The MiniWoB++ subset wired through plugin-browser. */
+export const MINIWOB_TASKS: readonly BenchmarkTask[] = [
+  clickButton,
+  clickLink,
+  enterText,
+  enterTextDynamic,
+  clickCheckboxes,
+  multistepPurchase,
+];
+
+export function getTaskById(id: string): BenchmarkTask | undefined {
+  return MINIWOB_TASKS.find((t) => t.id === id);
+}

--- a/plugins/plugin-browser/src/benchmark/types.ts
+++ b/plugins/plugin-browser/src/benchmark/types.ts
@@ -1,0 +1,169 @@
+/**
+ * Browser benchmark harness types (#9476).
+ *
+ * The plugin-computeruse side has a real benchmark wired through the live
+ * computer-use action surface (`src/osworld/adapter.ts` + the OSWorld
+ * `*.real.test.ts` lanes). plugin-browser had a CI-asserted parity matrix, a
+ * JSDOM real-code lane, and a typed error contract — but **no benchmark wired
+ * through the real BROWSER command path**. The web benchmarks (Mind2Web,
+ * WebShop, VisualWebBench) all bypass plugin-browser via the inference layer.
+ *
+ * This module closes that gap: a MiniWoB++-style web-interaction benchmark
+ * whose every action is dispatched through the real
+ * `executeBrowserWorkspaceCommand` router (the same mock-free path the
+ * `browser-workspace-web-real-code` lane drives) and whose reward is computed
+ * from observable DOM state read back through real BROWSER `get`/`state`
+ * commands. No mock service stands in for the thing under test.
+ *
+ * Engine-agnostic by design (mirrors how `OSWorldAdapter` takes a
+ * `ComputerUseService`): the adapter drives any {@link BrowserCommandExecutor},
+ * so the same task suite can run against the JSDOM web mode (deterministic,
+ * CI-safe, zero-dependency) or — once the deferred CI infra lands — a real
+ * Chromium-backed target.
+ */
+
+import type {
+  BrowserWorkspaceCommand,
+  BrowserWorkspaceCommandResult,
+} from "../workspace/browser-workspace-types.js";
+
+/**
+ * The seam the adapter dispatches through. A JSDOM-web executor binds
+ * {@link executeBrowserWorkspaceCommand} to a tab; a future Chromium executor
+ * would wrap a real `BrowserService` target. The adapter never imports a
+ * concrete backend, exactly like the OSWorld adapter never imports a concrete
+ * OS driver.
+ */
+export interface BrowserCommandExecutor {
+  /** Short id of the backing engine, e.g. `"jsdom-web"` or `"chromium"`. */
+  readonly engine: string;
+  /** Execute a single BROWSER workspace command through the real router. */
+  execute(
+    command: BrowserWorkspaceCommand,
+  ): Promise<BrowserWorkspaceCommandResult>;
+}
+
+/** A benchmark-level action a policy chooses; mapped to a BROWSER command. */
+export type BenchmarkActionType =
+  | "click"
+  | "type"
+  | "fill"
+  | "check"
+  | "uncheck"
+  | "press"
+  | "navigate"
+  | "done";
+
+export interface BenchmarkAction {
+  type: BenchmarkActionType;
+  /** CSS selector for element-targeted actions. */
+  selector?: string;
+  /** Text to enter for `type`/`fill`. */
+  value?: string;
+  /** Key name for `press`. */
+  key?: string;
+  /** Destination for `navigate`. */
+  url?: string;
+  /** Human-readable rationale (oracle label / policy reasoning). */
+  note?: string;
+}
+
+/** What a policy observes each step — read from the live DOM, never faked. */
+export interface BenchmarkObservation {
+  url: string;
+  title: string;
+  /** Visible body text of the active tab (includes the task `#wob-query`). */
+  bodyText: string;
+  /** 0-based index of the step that produced this observation. */
+  step: number;
+  /** True once the episode has terminated (policy emitted `done`). */
+  done: boolean;
+}
+
+/** One executed step: the action, the real command result, and any error. */
+export interface BenchmarkStepResult {
+  action: BenchmarkAction;
+  observation: BenchmarkObservation;
+  commandResult: BrowserWorkspaceCommandResult | null;
+  error?: { code: string; message: string };
+  done: boolean;
+  timestamp: number;
+}
+
+/**
+ * Reward seam handed to a task's `reward()` — every read goes through a real
+ * BROWSER `get`/`state` command against the live tab. A task computes its
+ * success criterion from these observations; it cannot inspect adapter
+ * internals or fabricate state.
+ */
+export interface BenchmarkRewardContext {
+  getValue(selector: string): Promise<string>;
+  getChecked(selector: string): Promise<boolean>;
+  getText(selector: string): Promise<string>;
+  getCount(selector: string): Promise<number>;
+  getTitle(): Promise<string>;
+  getUrl(): Promise<string>;
+}
+
+/**
+ * A self-contained MiniWoB++-style task. The HTML is pure markup served via the
+ * BROWSER `network route` interceptor (no external network, no page scripts —
+ * web mode hard-blocks script execution, GHSA-mhhr-9ph9-64j7), so the reward is
+ * computed entirely from observable DOM state.
+ */
+export interface BenchmarkTask {
+  /** MiniWoB task id, e.g. `"click-button"`. */
+  id: string;
+  /** Benchmark family, e.g. `"miniwob++"`. */
+  family: string;
+  /** One-line description of the task family. */
+  description: string;
+  /** The natural-language goal for `seed` (also rendered into the page). */
+  utterance(seed: number): string;
+  /** Deterministic environment for `seed`: routes to register + the start URL. */
+  build(seed: number): {
+    startUrl: string;
+    routes: ReadonlyArray<{ url: string; html: string }>;
+  };
+  /** The known-correct action sequence for `seed` (oracle policy / success path). */
+  oracle(seed: number): BenchmarkAction[];
+  /** Reward in `[0, 1]` from observable DOM state. 1 = solved. */
+  reward(ctx: BenchmarkRewardContext, seed: number): Promise<number>;
+  /** Step budget before the episode is force-terminated. */
+  maxSteps: number;
+}
+
+/** Result of a single task×seed episode. */
+export interface BenchmarkEpisodeResult {
+  taskId: string;
+  family: string;
+  seed: number;
+  utterance: string;
+  engine: string;
+  policy: string;
+  reward: number;
+  success: boolean;
+  steps: number;
+  /** Per-step record of the real commands the adapter dispatched. */
+  trajectory: Array<{
+    action: BenchmarkAction;
+    resultMode: string | null;
+    error: string | null;
+  }>;
+  error?: string;
+}
+
+/** Aggregate report for a whole suite run — the committed artifact shape. */
+export interface BenchmarkSuiteReport {
+  benchmark: string;
+  engine: string;
+  policy: string;
+  seedsPerTask: number;
+  episodes: BenchmarkEpisodeResult[];
+  summary: {
+    total: number;
+    solved: number;
+    successRate: number;
+    byTask: Array<{ taskId: string; solved: number; total: number }>;
+  };
+}


### PR DESCRIPTION
## What

Closes the one Definition-of-Done deliverable [verified missing on `develop`](https://github.com/elizaOS/eliza/issues/9476#issuecomment-4830133507) for #9476:

> **≥1 benchmark wired through `plugin-browser`** (mirror `plugin-computeruse/src/osworld/adapter.ts`), with a committed run artifact.

The other three DoD items already landed (CI-asserted parity matrix, JSDOM real-code lane, typed error contract). The web benchmarks (Mind2Web, WebShop, VisualWebBench) all **bypass** plugin-browser via the inference layer — no benchmark drove the BROWSER command surface end-to-end. This adds one that does.

## How

A **MiniWoB++-style** web-interaction benchmark (the canonical web-agent benchmark) under `plugins/plugin-browser/src/benchmark/`, the plugin-browser analog of `plugin-computeruse/src/osworld/`:

- **`adapter.ts`** — `BrowserBenchmarkAdapter` with the same observation/action/step seam as `OSWorldAdapter`, driving an engine-agnostic `BrowserCommandExecutor`. The workspace executor binds the **real** `executeBrowserWorkspaceCommand` router (the same mock-free path the `browser-workspace-web-real-code` lane uses) — no mock service stands in for the browser.
- **`tasks.ts`** — 6 tasks (`click-button`, `click-link`, `enter-text`, `enter-text-dynamic`, `click-checkboxes`, `multistep-purchase`). Pure markup, **no page scripts** (web mode hard-blocks script exec, GHSA-mhhr-9ph9-64j7); deterministic per seed; reward computed from **observable DOM state** read back through real BROWSER `get` commands (`value`/`checked`/`url`/`title`).
- **`policy.ts`** — `OraclePolicy` (deterministic solver) + `NoopPolicy`/`WrongPolicy` negative baselines.
- **`runner.ts`** — `runBenchmarkSuite` drives every task×seed episode, scores it, aggregates.
- **`__tests__/miniwob-adapter.test.ts`** — CI-asserted real-code lane (runs in the default `vitest run`).
- **`scripts/run-miniwob-benchmark.mjs`** + `bench:miniwob` — runnable harness that writes a JSON run report.

## Evidence (real, on a Windows 11 host) — see `.github/issue-evidence/9476-browser-benchmark/`

| Policy | Result | Proves |
|--------|--------|--------|
| oracle | **18/18 solved (100%)** | the suite is solvable end-to-end through real BROWSER commands; every action step records `resultMode: "web"` (the live router ran it) |
| noop   | **0/18** | doing nothing scores 0 — reward is grounded in real DOM state, not hard-coded |
| wrong  | **0/18** | wrong-target / wrong-text near-misses score 0 — reward discriminates |

Test lane locally: **5/5 passing**. Benchmark sources type-check clean (verified with a resolvable `@types/node`; the package's default `typecheck` hits a pre-existing worktree `typeRoots` quirk unrelated to this change). The broader plugin-browser suite's 8 core-barrel-dependent suites can't load under this box's light-install (a pre-existing `uuid`→`drizzle-orm`→`yaml`→`@noble/*` cascade, identical before this change); all 80 runnable tests pass, including the new lane.

## Reproduce

```bash
bun run --cwd plugins/plugin-browser test -- src/benchmark   # CI lane
bun run --cwd plugins/plugin-browser bench:miniwob           # oracle (writes artifact)
bun run --cwd plugins/plugin-browser bench:miniwob -- --policy noop
bun run --cwd plugins/plugin-browser bench:miniwob -- --policy wrong
```

## Deferred (tracked, not dropped)

The remaining #9476 "Needs CI infra" items — a real-Chromium engine lane, an external-dataset benchmark (Mind2Web/WebArena) through plugin-browser, a web-element grounding benchmark, and CI gating — are tracked in follow-up #10333. The adapter is already engine-agnostic, so the real-Chromium lane is a new executor + gated lane, not a rewrite.

Closes #9476.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
