### PR TITLE
refactor(config): adopt core resolveSetting across remaining plugins + precedence docs (#10166)

### DIFF
--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -112,6 +112,39 @@ Read by the runtime (see README for the full WHY of each):
 
 Prefer the canonical env reader in `utils/read-env.ts` over raw `process.env` (it handles legacy aliases).
 
+### Setting / env resolution — precedence & the multi-tenant rule
+
+Two canonical helpers own all setting/env resolution; everything else delegates:
+
+| Helper | Source order | Use when |
+| --- | --- | --- |
+| `runtime.getSetting(key)` (`runtime.ts`) | character secrets → character settings → `settings.extra` → `settings.secrets` → `character.env.vars` → the constructor-provided `settings` map. **Never `process.env`.** | Inside the runtime / framework code. |
+| `readEnv(key, opts)` (`utils/read-env.ts`) | `process.env[key]` (trimmed; empty string treated as unset) → `defaultValue`. | Reading an env var with no runtime in scope. |
+| `resolveSetting(runtime, key, opts)` (`utils/resolve-setting.ts`) | `runtime.getSetting(key)` (coerced to string) → `readEnv(key)` → `defaultValue`. | Single-tenant / headless plugins that still want a dotenv fallback. |
+
+**Resolution order:** runtime/character setting → env alias → default. The
+per-agent runtime value always wins; the env fallback is the deployment default.
+
+**WHY core `getSetting()` deliberately does NOT read `process.env`:** in a
+multi-tenant process many agents share one OS environment. If `getSetting()`
+fell through to `process.env`, a host secret (`OPENAI_API_KEY`,
+`POSTGRES_URL`, …) set for the *box* would silently leak into *every* agent,
+including ones the operator never granted it to. Keeping `getSetting()`
+per-agent makes each agent's config explicit and isolated. `resolveSetting`
+re-adds an opt-in env fallback for single-tenant/headless plugins **without**
+changing `getSetting()` semantics — multi-tenant hosts that never call it are
+unaffected.
+
+**Host obligation (how to make dotenv values visible to `getSetting()`):**
+because `getSetting()` reads the constructor-provided `settings` map and not
+`process.env`, a host that wants `.env` / `process.env` values honored must fold
+them into the runtime's settings at construction. `getBasicCapabilitiesSettings(character, env)`
+(`runtime-composition.ts`) does exactly this — it flattens `character.settings`,
+`character.secrets`, and `env` into the `Record<string,string>` handed to
+adapter factories and the `AgentRuntime` constructor. Construct the runtime with
+those settings and dotenv is honored; skip it and only character config is
+visible.
+
 ## How to extend
 
 - **Add an action/provider/evaluator/service to the built-in bundle:** implement against the `Action`/`Provider`/`Evaluator`/`Service` types in `types/`, then add it to the relevant array in `src/features/basic-capabilities/index.ts` (`basicActions`, `basicProviders`, `basicEvaluators`, `basicServices`). Most new capabilities should live in their own plugin package instead of here.

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -112,6 +112,39 @@ Read by the runtime (see README for the full WHY of each):
 
 Prefer the canonical env reader in `utils/read-env.ts` over raw `process.env` (it handles legacy aliases).
 
+### Setting / env resolution — precedence & the multi-tenant rule
+
+Two canonical helpers own all setting/env resolution; everything else delegates:
+
+| Helper | Source order | Use when |
+| --- | --- | --- |
+| `runtime.getSetting(key)` (`runtime.ts`) | character secrets → character settings → `settings.extra` → `settings.secrets` → `character.env.vars` → the constructor-provided `settings` map. **Never `process.env`.** | Inside the runtime / framework code. |
+| `readEnv(key, opts)` (`utils/read-env.ts`) | `process.env[key]` (trimmed; empty string treated as unset) → `defaultValue`. | Reading an env var with no runtime in scope. |
+| `resolveSetting(runtime, key, opts)` (`utils/resolve-setting.ts`) | `runtime.getSetting(key)` (coerced to string) → `readEnv(key)` → `defaultValue`. | Single-tenant / headless plugins that still want a dotenv fallback. |
+
+**Resolution order:** runtime/character setting → env alias → default. The
+per-agent runtime value always wins; the env fallback is the deployment default.
+
+**WHY core `getSetting()` deliberately does NOT read `process.env`:** in a
+multi-tenant process many agents share one OS environment. If `getSetting()`
+fell through to `process.env`, a host secret (`OPENAI_API_KEY`,
+`POSTGRES_URL`, …) set for the *box* would silently leak into *every* agent,
+including ones the operator never granted it to. Keeping `getSetting()`
+per-agent makes each agent's config explicit and isolated. `resolveSetting`
+re-adds an opt-in env fallback for single-tenant/headless plugins **without**
+changing `getSetting()` semantics — multi-tenant hosts that never call it are
+unaffected.
+
+**Host obligation (how to make dotenv values visible to `getSetting()`):**
+because `getSetting()` reads the constructor-provided `settings` map and not
+`process.env`, a host that wants `.env` / `process.env` values honored must fold
+them into the runtime's settings at construction. `getBasicCapabilitiesSettings(character, env)`
+(`runtime-composition.ts`) does exactly this — it flattens `character.settings`,
+`character.secrets`, and `env` into the `Record<string,string>` handed to
+adapter factories and the `AgentRuntime` constructor. Construct the runtime with
+those settings and dotenv is honored; skip it and only character config is
+visible.
+
 ## How to extend
 
 - **Add an action/provider/evaluator/service to the built-in bundle:** implement against the `Action`/`Provider`/`Evaluator`/`Service` types in `types/`, then add it to the relevant array in `src/features/basic-capabilities/index.ts` (`basicActions`, `basicProviders`, `basicEvaluators`, `basicServices`). Most new capabilities should live in their own plugin package instead of here.

--- a/plugins/plugin-edge-tts/__tests__/core-test-mock.ts
+++ b/plugins/plugin-edge-tts/__tests__/core-test-mock.ts
@@ -1,5 +1,23 @@
 import { vi } from "vitest";
 
+// Faithful re-implementation of core `resolveSetting` (runtime per-agent setting
+// first, then `process.env` with dotenv semantics: trimmed, empty-as-unset, then
+// default). Kept inline so the lightweight core mock does not load real core.
+function resolveSetting(
+	runtime: { getSetting(key: string): unknown } | null | undefined,
+	key: string,
+	options: { env?: Record<string, string | undefined>; defaultValue?: string } = {},
+): string | undefined {
+	const fromRuntime = runtime?.getSetting(key);
+	if (fromRuntime !== undefined && fromRuntime !== null) {
+		return String(fromRuntime);
+	}
+	const env = options.env ?? (typeof process !== "undefined" ? process.env : {});
+	const raw = env[key];
+	const trimmed = typeof raw === "string" ? raw.trim() : "";
+	return trimmed.length > 0 ? trimmed : options.defaultValue;
+}
+
 vi.mock("@elizaos/core", () => ({
 	ModelType: {
 		TEXT_TO_SPEECH: "TEXT_TO_SPEECH",
@@ -12,4 +30,5 @@ vi.mock("@elizaos/core", () => ({
 		success: vi.fn(),
 		warn: vi.fn(),
 	},
+	resolveSetting,
 }));

--- a/plugins/plugin-edge-tts/src/index.ts
+++ b/plugins/plugin-edge-tts/src/index.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, readFileSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { type IAgentRuntime, logger, ModelType, type Plugin } from "@elizaos/core";
+import { type IAgentRuntime, logger, ModelType, type Plugin, resolveSetting } from "@elizaos/core";
 import { EdgeTTS } from "node-edge-tts";
 
 /**
@@ -68,6 +68,10 @@ const VOICE_PRESETS: Record<string, string> = {
   // Direct Edge TTS voice names pass through
 };
 
+// Runtime per-agent setting first, then `process.env`, then the fallback.
+// Thin wrapper over core `resolveSetting` so the precedence lives in one
+// canonical place; the env fallback uses dotenv semantics (trimmed; empty
+// strings treated as unset).
 function getSetting(runtime: IAgentRuntime | null, key: string): string | undefined;
 function getSetting(runtime: IAgentRuntime | null, key: string, fallback: string): string;
 function getSetting(
@@ -75,11 +79,7 @@ function getSetting(
   key: string,
   fallback?: string
 ): string | undefined {
-  const envValue =
-    typeof process !== "undefined" && (process as { env?: Record<string, string> }).env
-      ? (process as { env: Record<string, string> }).env[key]
-      : undefined;
-  return (runtime?.getSetting(key) as string | undefined) ?? envValue ?? fallback;
+  return resolveSetting(runtime, key, { defaultValue: fallback });
 }
 
 function getEdgeTTSSettings(runtime: IAgentRuntime | null): EdgeTTSSettings {

--- a/plugins/plugin-elevenlabs/src/index.ts
+++ b/plugins/plugin-elevenlabs/src/index.ts
@@ -18,6 +18,7 @@ import {
   ModelType,
   type Plugin,
   parseBooleanFromText,
+  resolveSetting,
 } from "@elizaos/core";
 
 function parseTtsOutputFormat(
@@ -151,6 +152,10 @@ function isBrowser(): boolean {
   return typeof globalThis.document !== "undefined";
 }
 
+// Runtime per-agent setting first, then `process.env`, then the fallback.
+// Thin wrapper over core `resolveSetting` so the precedence lives in one
+// canonical place; the env fallback uses dotenv semantics (trimmed; empty
+// strings treated as unset).
 function getSetting(runtime: IAgentRuntime, key: string): string | undefined;
 function getSetting(
   runtime: IAgentRuntime,
@@ -162,20 +167,7 @@ function getSetting(
   key: string,
   fallback?: string,
 ): string | undefined {
-  const rawRuntime = runtime.getSetting(key);
-  const fromRuntime =
-    rawRuntime === null || rawRuntime === undefined
-      ? undefined
-      : String(rawRuntime);
-
-  const envValue =
-    typeof process !== "undefined" &&
-    process.env &&
-    typeof process.env[key] === "string"
-      ? process.env[key]
-      : undefined;
-
-  return fromRuntime ?? envValue ?? fallback;
+  return resolveSetting(runtime, key, { defaultValue: fallback });
 }
 
 function getBaseURL(runtime: IAgentRuntime): string {
@@ -189,16 +181,7 @@ function getBaseURL(runtime: IAgentRuntime): string {
 }
 
 function getApiKey(runtime: IAgentRuntime): string | undefined {
-  const raw = runtime.getSetting("ELEVENLABS_API_KEY");
-  const fromRuntime =
-    raw === null || raw === undefined ? undefined : String(raw);
-  const fromEnv =
-    typeof process !== "undefined" &&
-    process.env &&
-    typeof process.env.ELEVENLABS_API_KEY === "string"
-      ? process.env.ELEVENLABS_API_KEY
-      : undefined;
-  return fromRuntime ?? fromEnv;
+  return getSetting(runtime, "ELEVENLABS_API_KEY");
 }
 
 function getElevenLabsClientConfig(runtime: IAgentRuntime): {

--- a/plugins/plugin-elizacloud/src/utils/config.ts
+++ b/plugins/plugin-elizacloud/src/utils/config.ts
@@ -1,27 +1,22 @@
 import type { IAgentRuntime } from "@elizaos/core";
-import { logger } from "@elizaos/core";
+import { logger, resolveSetting } from "@elizaos/core";
 import { DEFAULT_ELIZA_CLOUD_TEXT_MODEL } from "@elizaos/core";
 
 export const DEFAULT_ELIZA_CLOUD_LARGE_MODEL = "zai-glm-4.7";
 
-function getEnvValue(key: string): string | undefined {
-  if (typeof process === "undefined") {
-    return undefined;
-  }
-  const value = process.env[key];
-  return value === undefined ? undefined : String(value);
-}
-
+/**
+ * Runtime config first, then `process.env`, then the supplied default.
+ *
+ * Thin wrapper over core `resolveSetting` so the precedence lives in one
+ * canonical place. The env fallback uses dotenv semantics (trimmed; empty
+ * strings treated as unset).
+ */
 export function getSetting(
   runtime: IAgentRuntime,
   key: string,
   defaultValue?: string
 ): string | undefined {
-  const value = runtime.getSetting(key);
-  if (value !== undefined && value !== null) {
-    return String(value);
-  }
-  return getEnvValue(key) ?? defaultValue;
+  return resolveSetting(runtime, key, { defaultValue });
 }
 
 export function isBrowser(): boolean {

--- a/plugins/plugin-embeddings/src/utils/config.ts
+++ b/plugins/plugin-embeddings/src/utils/config.ts
@@ -11,30 +11,22 @@
  */
 
 import type { IAgentRuntime } from "@elizaos/core";
-import { logger } from "@elizaos/core";
-
-function getEnvValue(key: string): string | undefined {
-  if (typeof process === "undefined" || !process.env) {
-    return undefined;
-  }
-  const value = process.env[key];
-  return value === undefined ? undefined : String(value);
-}
+import { logger, resolveSetting } from "@elizaos/core";
 
 /**
  * Runtime config first, then `process.env`, then the supplied default.
  * Returns `undefined` when unset and no default is given.
+ *
+ * Thin wrapper over core `resolveSetting` so the precedence lives in one
+ * canonical place. The env fallback uses dotenv semantics (trimmed; empty
+ * strings treated as unset).
  */
 export function getSetting(
   runtime: IAgentRuntime,
   key: string,
   defaultValue?: string
 ): string | undefined {
-  const value = runtime.getSetting(key);
-  if (value !== undefined && value !== null) {
-    return String(value);
-  }
-  return getEnvValue(key) ?? defaultValue;
+  return resolveSetting(runtime, key, { defaultValue });
 }
 
 export function getNumericSetting(


### PR DESCRIPTION
## Summary

Finishes the tractable, mechanical residual of #10166 ("Unify setting and environment variable resolution"). PR #10287 added the canonical core seam `resolveSetting` (`packages/core/src/utils/resolve-setting.ts`: runtime per-agent setting → `readEnv` → default) and migrated only `plugin-x`. This PR migrates the remaining plugins that still hand-rolled their own `runtime → process.env → default` chain to delegate to that seam, and adds a precedence-table doc to core.

## Plugins migrated (precedence preserved: runtime setting → env → default)

| Plugin | File | Change |
| --- | --- | --- |
| `plugin-embeddings` | `src/utils/config.ts` | Removed local `getEnvValue`; `getSetting()` now delegates to `resolveSetting`. Public API + all getters unchanged. |
| `plugin-elizacloud` | `src/utils/config.ts` | Removed local `getEnvValue`; `getSetting()` delegates to `resolveSetting`. |
| `plugin-elevenlabs` | `src/index.ts` | `getSetting()` overloads delegate to `resolveSetting`; `getApiKey()` folded onto the local `getSetting` (it was a second copy of the same runtime→env chain). |
| `plugin-edge-tts` | `src/index.ts` | `getSetting()` overloads delegate to `resolveSetting`; the test's `@elizaos/core` mock (`__tests__/core-test-mock.ts`) gains a faithful inline `resolveSetting`. |

`plugin-x` was already migrated in #10287 and mirrors this exact pattern.

## Behavior note (documented, not silent)

The env *fallback* now uses core `readEnv`/dotenv semantics: env values are **trimmed** and an **empty/whitespace env var is treated as unset** (falls through to the default) instead of being returned verbatim. This is the canonical seam's behavior and only affects empty/whitespace env-var edge cases — the precedence order is unchanged and every public getter behaves identically for real (non-empty) values. Runtime-setting values are still returned as-is (only coerced to string). No existing test relied on the old untrimmed/empty-as-set behavior.

## Docs added

`packages/core/CLAUDE.md` (+ identical `AGENTS.md`, per repo convention) gain a **setting/env resolution precedence** section under *Config / env vars*:
- A table contrasting `runtime.getSetting()` vs `readEnv()` vs `resolveSetting()` and their source order.
- The resolution order (runtime/character setting → env alias → default).
- **WHY core `getSetting()` deliberately does NOT read `process.env`:** in a multi-tenant process a host secret set for the box would otherwise leak into every agent. `resolveSetting` re-adds an opt-in env fallback for single-tenant/headless plugins without changing `getSetting()` semantics.
- The **host obligation**: because `getSetting()` reads the constructor-provided `settings` map (not `process.env`), a host must fold env into runtime settings via `getBasicCapabilitiesSettings(character, env)` (`runtime-composition.ts`) for dotenv to be honored.

## Skipped / deferred

- **`DATABASE_URL` → `POSTGRES_URL` bridge consolidation** (the heavier residual item) is left as a follow-up. That bridge is duplicated across `packages/app-core/src/entry.ts` (global `process.env` mutation), the electrobun database-mode helper, and several `packages/cloud/shared` deploy paths — a cross-package change with deploy-path behavior that isn't mechanical and can't be exercised in this lane. Noted here so it isn't lost.

## Test evidence

```
plugin-embeddings   3 files, 27/27 pass
plugin-elevenlabs   27/27 pass
plugin-edge-tts     8/8 pass
plugin-elizacloud   250 pass, 3 skipped, 1 fail
```

The single `plugin-elizacloud` failure (`cloud-coding-container-routes.test.ts` — a coding-agent-kind zod enum expecting `claude|codex|opencode` while the runtime now also accepts `elizaos`) is a **pre-existing develop drift**, reproduced on clean `origin/develop` with none of this PR's edits present, and is unrelated to setting resolution (the test references zero config/`getSetting` code). All four touched plugins + `@elizaos/core` build clean.

Closes part of #10166.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
