### PR TITLE
chore(build): migrate discord-local + mcp + gitpathologist onto buildPlugin (#10078)

### DIFF
--- a/plugins/plugin-discord-local/build.ts
+++ b/plugins/plugin-discord-local/build.ts
@@ -3,59 +3,54 @@
 /**
  * Standalone build script for @elizaos/plugin-discord-local.
  * Uses Bun's native bundler — no monorepo build-utils dependency.
+ *
+ * Migrated onto the shared `buildPlugin` driver (issue #10078). Emits the
+ * same single Node ESM bundle (`dist/index.js` + linked sourcemap) and the
+ * tolerant `tsc` declaration pass to `dist/src/`, byte-identical to the prior
+ * hand-rolled build.
  */
 
-import { execSync } from "node:child_process";
-import { externalsFromPackageJson } from "../plugin-build-externals.ts";
+import { buildPlugin } from "../plugin-build.ts";
 
-const external = await externalsFromPackageJson("./package.json", {
-  // Preserve the bare-string node builtins the prior hand-list included so
-  // any source that imports them without the `node:` prefix still resolves
-  // externally under Bun.build.
-  extra: [
-    "fs",
-    "path",
-    "os",
-    "http",
-    "https",
-    "crypto",
-    "stream",
-    "events",
-    "util",
-    "url",
-    "net",
-    "tls",
-    "zlib",
-    "buffer",
-    "child_process",
-    "readline",
+await buildPlugin({
+  name: "@elizaos/plugin-discord-local",
+  externals: "auto",
+  externalsOptions: {
+    // Preserve the bare-string node builtins the prior hand-list included so
+    // any source that imports them without the `node:` prefix still resolves
+    // externally under Bun.build.
+    extra: [
+      "fs",
+      "path",
+      "os",
+      "http",
+      "https",
+      "crypto",
+      "stream",
+      "events",
+      "util",
+      "url",
+      "net",
+      "tls",
+      "zlib",
+      "buffer",
+      "child_process",
+      "readline",
+    ],
+  },
+  targets: [
+    {
+      label: "Node",
+      entry: "src/index.ts",
+      outSubdir: "",
+      target: "node",
+      format: "esm",
+      sourcemap: "linked",
+      minify: false,
+    },
   ],
+  // Emit real declaration files via tsc; non-fatal — the plugin works at
+  // runtime without .d.ts files.
+  dtsProject: "tsconfig.build.json",
+  dtsTolerant: true,
 });
-
-const result = await Bun.build({
-  entrypoints: ["src/index.ts"],
-  outdir: "dist",
-  target: "node",
-  format: "esm",
-  external,
-  sourcemap: "linked",
-  minify: false,
-});
-
-if (!result.success) {
-  console.error("Build failed:");
-  for (const log of result.logs) {
-    console.error(log);
-  }
-  process.exit(1);
-}
-
-// Emit real declaration files via tsc
-try {
-  execSync("bunx tsc -p tsconfig.build.json --noCheck", { stdio: "inherit" });
-} catch {
-  // Non-fatal — plugin works at runtime without .d.ts files
-  console.warn("[plugin-discord-local] tsc declaration emit failed (non-fatal)");
-}
-
-console.log("[plugin-discord-local] Build complete");

--- a/plugins/plugin-gitpathologist/build.ts
+++ b/plugins/plugin-gitpathologist/build.ts
@@ -1,93 +1,63 @@
 #!/usr/bin/env bun
 
-import { spawnSync } from "node:child_process";
-import { fileURLToPath } from "node:url";
-import { externalsFromPackageJson } from "../plugin-build-externals.ts";
+/**
+ * Build script for @elizaos/plugin-gitpathologist.
+ *
+ * Outputs:
+ * - ESM (Node): dist/node/index.js
+ * - CJS (Node): dist/cjs/index.cjs
+ * - Types: dist/index.d.ts + dist/node/index.d.ts + dist/cjs/index.d.ts
+ *
+ * Migrated onto the shared `buildPlugin` driver (issue #10078). The CJS bundle
+ * is renamed `index.js` -> `index.cjs` with a plain rename (its sibling
+ * `index.js.map` is intentionally left unrenamed so the emitted
+ * `//# sourceMappingURL=index.js.map` reference stays valid), byte-identical to
+ * the prior hand-rolled build.
+ */
 
-const RM_RECURSIVE_SCRIPT = fileURLToPath(
-  new URL("../../packages/scripts/rm-path-recursive.mjs", import.meta.url)
-);
+import { buildPlugin } from "../plugin-build.ts";
 
-function rmRecursive(target: string) {
-  const result = spawnSync(process.execPath, [RM_RECURSIVE_SCRIPT, target], {
-    stdio: "inherit",
-  });
-  if (result.error) throw result.error;
-  if (result.status !== 0) {
-    throw new Error(`rm-path-recursive failed for ${target} with status ${result.status}`);
-  }
-}
-
-const externalDeps = await externalsFromPackageJson("./package.json", {
-  extra: ["@elizaos/shared", "@elizaos/agent"],
-});
-
-async function build(): Promise<void> {
-  const totalStart = Date.now();
-  rmRecursive("dist");
-
-  const nodeStart = Date.now();
-  console.log("Building @elizaos/plugin-gitpathologist for Node (ESM)...");
-  const nodeResult = await Bun.build({
-    entrypoints: ["src/index.ts"],
-    outdir: "dist/node",
-    target: "node",
-    format: "esm",
-    sourcemap: "external",
-    minify: false,
-    external: externalDeps,
-  });
-  if (!nodeResult.success) {
-    console.error("Node ESM build failed:", nodeResult.logs);
-    throw new Error("Node ESM build failed");
-  }
-  console.log(`Node ESM build complete in ${((Date.now() - nodeStart) / 1000).toFixed(2)}s`);
-
-  const cjsStart = Date.now();
-  console.log("Building @elizaos/plugin-gitpathologist for Node (CJS)...");
-  const cjsResult = await Bun.build({
-    entrypoints: ["src/index.ts"],
-    outdir: "dist/cjs",
-    target: "node",
-    format: "cjs",
-    sourcemap: "external",
-    minify: false,
-    external: externalDeps,
-  });
-  if (!cjsResult.success) {
-    console.error("Node CJS build failed:", cjsResult.logs);
-    throw new Error("Node CJS build failed");
-  }
-
-  const { rename, access, mkdir, writeFile } = await import("node:fs/promises");
-  const { $ } = await import("bun");
-
-  await access("dist/cjs/index.js");
-  await rename("dist/cjs/index.js", "dist/cjs/index.cjs");
-  console.log(`Node CJS build complete in ${((Date.now() - cjsStart) / 1000).toFixed(2)}s`);
-
-  const dtsStart = Date.now();
-  console.log("Generating TypeScript declarations...");
-  await $`tsc --noCheck --project tsconfig.build.json`;
-
-  await mkdir("dist/node", { recursive: true });
-  await mkdir("dist/cjs", { recursive: true });
-
-  const rootReexport = `export * from "./node/index";
+await buildPlugin({
+  name: "@elizaos/plugin-gitpathologist",
+  clean: true,
+  externals: "auto",
+  externalsOptions: {
+    extra: ["@elizaos/shared", "@elizaos/agent"],
+  },
+  targets: [
+    {
+      label: "Node (ESM)",
+      entry: "src/index.ts",
+      outSubdir: "node",
+      target: "node",
+      format: "esm",
+      sourcemap: "external",
+      minify: false,
+    },
+    {
+      label: "Node (CJS)",
+      entry: "src/index.ts",
+      outSubdir: "cjs",
+      target: "node",
+      format: "cjs",
+      sourcemap: "external",
+      minify: false,
+      renames: [["index.js", "index.cjs"]],
+    },
+  ],
+  dtsProject: "tsconfig.build.json",
+  dtsShims: [
+    {
+      path: "index.d.ts",
+      content: `export * from "./node/index";
 export { default } from "./node/index";
-`;
-  const cjsReexport = `export * from "../node/index";
+`,
+    },
+    {
+      path: "cjs/index.d.ts",
+      content: `export * from "../node/index";
 export { default } from "../node/index";
-`;
-
-  await writeFile("dist/index.d.ts", rootReexport);
-  await writeFile("dist/cjs/index.d.ts", cjsReexport);
-
-  console.log(`Declarations generated in ${((Date.now() - dtsStart) / 1000).toFixed(2)}s`);
-  console.log(`All builds finished in ${((Date.now() - totalStart) / 1000).toFixed(2)}s`);
-}
-
-build().catch((err) => {
-  console.error("Build failed:", err);
-  process.exit(1);
+`,
+    },
+  ],
 });

--- a/plugins/plugin-mcp/build.ts
+++ b/plugins/plugin-mcp/build.ts
@@ -7,105 +7,68 @@
  * - ESM (Node): dist/node/index.js
  * - CJS (Node): dist/cjs/index.cjs
  * - Types: dist/index.d.ts + dist/node/index.d.ts + dist/cjs/index.d.ts
+ *
+ * Migrated onto the shared `buildPlugin` driver (issue #10078). The CJS bundle
+ * is renamed `index.js` -> `index.cjs` with a plain rename (its sibling
+ * `index.js.map` is intentionally left unrenamed so the emitted
+ * `//# sourceMappingURL=index.js.map` reference stays valid), byte-identical to
+ * the prior hand-rolled build.
  */
 
-import { spawnSync } from "node:child_process";
-import { fileURLToPath } from "node:url";
-import { externalsFromPackageJson } from "../plugin-build-externals.ts";
+import { buildPlugin } from "../plugin-build.ts";
 
-const RM_RECURSIVE_SCRIPT = fileURLToPath(
-  new URL("../../packages/scripts/rm-path-recursive.mjs", import.meta.url)
-);
-
-function rmRecursive(target: string) {
-  const result = spawnSync(process.execPath, [RM_RECURSIVE_SCRIPT, target], {
-    stdio: "inherit",
-  });
-  if (result.error) throw result.error;
-  if (result.status !== 0) {
-    throw new Error(`rm-path-recursive failed for ${target} with status ${result.status}`);
-  }
-}
-
-const externalDeps = await externalsFromPackageJson("./package.json", {
-  // Transitive workspace + native deps the hand-list relied on.
-  extra: ["@elizaos/shared", "@elizaos/agent", "@node-llama-cpp", "node-llama-cpp"],
-});
-
-async function build(): Promise<void> {
-  const totalStart = Date.now();
-
-  // Wipe dist first so leftover .d.ts files from prior runs don't get
-  // picked up by tsc as inputs (TS5055).
-  rmRecursive("dist");
-
-  const nodeStart = Date.now();
-  console.log("🔨 Building @elizaos/plugin-mcp for Node (ESM)...");
-  const nodeResult = await Bun.build({
-    entrypoints: ["src/index.ts"],
-    outdir: "dist/node",
-    target: "node",
-    format: "esm",
-    sourcemap: "external",
-    minify: false,
-    external: externalDeps,
-  });
-  if (!nodeResult.success) {
-    console.error("Node ESM build failed:", nodeResult.logs);
-    throw new Error("Node ESM build failed");
-  }
-  console.log(`✅ Node ESM build complete in ${((Date.now() - nodeStart) / 1000).toFixed(2)}s`);
-
-  const cjsStart = Date.now();
-  console.log("🧱 Building @elizaos/plugin-mcp for Node (CJS)...");
-  const cjsResult = await Bun.build({
-    entrypoints: ["src/index.ts"],
-    outdir: "dist/cjs",
-    target: "node",
-    format: "cjs",
-    sourcemap: "external",
-    minify: false,
-    external: externalDeps,
-  });
-  if (!cjsResult.success) {
-    console.error("Node CJS build failed:", cjsResult.logs);
-    throw new Error("Node CJS build failed");
-  }
-
-  const { rename, access, mkdir, writeFile } = await import("node:fs/promises");
-  const { $ } = await import("bun");
-
-  // Rename Bun's CJS output to .cjs to be loadable under "type": "module".
-  await access("dist/cjs/index.js");
-  await rename("dist/cjs/index.js", "dist/cjs/index.cjs");
-
-  console.log(`✅ Node CJS build complete in ${((Date.now() - cjsStart) / 1000).toFixed(2)}s`);
-
-  const dtsStart = Date.now();
-  console.log("📝 Generating TypeScript declarations...");
-  // --noCheck because plugin-mcp transitively imports @elizaos/agent
-  // which has pre-existing migration debt outside our scope.
-  await $`tsc --noCheck --project tsconfig.build.json`;
-
-  await mkdir("dist/node", { recursive: true });
-  await mkdir("dist/cjs", { recursive: true });
-
-  const rootReexport = `export * from "./node/index";
+await buildPlugin({
+  name: "@elizaos/plugin-mcp",
+  // Wipe dist first so leftover .d.ts files from prior runs don't get picked up
+  // by tsc as inputs (TS5055).
+  clean: true,
+  externals: "auto",
+  externalsOptions: {
+    // Transitive workspace + native deps the hand-list relied on.
+    extra: [
+      "@elizaos/shared",
+      "@elizaos/agent",
+      "@node-llama-cpp",
+      "node-llama-cpp",
+    ],
+  },
+  targets: [
+    {
+      label: "Node (ESM)",
+      entry: "src/index.ts",
+      outSubdir: "node",
+      target: "node",
+      format: "esm",
+      sourcemap: "external",
+      minify: false,
+    },
+    {
+      label: "Node (CJS)",
+      entry: "src/index.ts",
+      outSubdir: "cjs",
+      target: "node",
+      format: "cjs",
+      sourcemap: "external",
+      minify: false,
+      // Rename Bun's CJS output to .cjs to be loadable under "type": "module".
+      renames: [["index.js", "index.cjs"]],
+    },
+  ],
+  // --noCheck because plugin-mcp transitively imports @elizaos/agent which has
+  // pre-existing migration debt outside our scope.
+  dtsProject: "tsconfig.build.json",
+  dtsShims: [
+    {
+      path: "index.d.ts",
+      content: `export * from "./node/index";
 export { default } from "./node/index";
-`;
-  const cjsReexport = `export * from "../node/index";
+`,
+    },
+    {
+      path: "cjs/index.d.ts",
+      content: `export * from "../node/index";
 export { default } from "../node/index";
-`;
-
-  await writeFile("dist/index.d.ts", rootReexport);
-  await writeFile("dist/cjs/index.d.ts", cjsReexport);
-
-  console.log(`✅ Declarations generated in ${((Date.now() - dtsStart) / 1000).toFixed(2)}s`);
-
-  console.log(`🎉 All builds finished in ${((Date.now() - totalStart) / 1000).toFixed(2)}s`);
-}
-
-build().catch((err) => {
-  console.error("Build failed:", err);
-  process.exit(1);
+`,
+    },
+  ],
 });


### PR DESCRIPTION
Final bundling-plugin batch for **#10078** — migrates three more onto the shared `buildPlugin` driver, all **byte-identical** (sorted per-file sha256, zero diff; originals verified deterministic).

| plugin | dist files | shape |
|---|---|---|
| plugin-discord-local | 5 | single Node ESM, `sourcemap:"linked"`, `dtsTolerant` |
| plugin-mcp | 66 | Node ESM→`dist/node` + CJS→`dist/cjs` (`index.js`→`index.cjs` rename, sibling `.map` left unrenamed to preserve the inner `//# sourceMappingURL` ref), 2 `dtsShims` |
| plugin-gitpathologist | 30 | same Node+CJS+rename+dtsShims pattern |

Net **−72 lines**. Each `bun run --cwd plugins/plugin-<p> build` exits 0 (dist counts match); shims typecheck against the driver.

## `plugin-wallet` deferred (new driver gap)
Attempted and **reverted** (untouched vs develop): wallet reproduced byte-identical **except `dist/index.d.mts`** — its build ends with `copyFileSync("dist/index.d.ts", "dist/index.d.mts")`, duplicating a *generated* declaration into a `.d.mts` sibling. The driver has no hook to copy an emitted `.d.ts`, and faking it with a static `dtsShim` would freeze generated output (silently diverging on any source change) — so it's a true skip, not a hack.

**Suggested driver enhancement (follow-up):** a post-tsc `dtsCopies: [{from, to}]` hook (copy an emitted declaration to a sibling name) + a custom-tsc-flags path — would unblock `wallet` and `plugin-video`. I'll likely file that next, same as the `flatten` hook unblocked elizacloud.

After this, the genuinely-migratable bundling plugins are essentially done; the rest is pure-tsc (nostr/line/imessage/google/google-chat/bluebubbles — `tsc`-only, not a bundle the driver orchestrates) or native (local-inference/vision/video). Refs #10078.

🤖 Generated with [Claude Code](https://claude.com/claude-code)