### PR TITLE
fix(computeruse): floor legacy-driver PowerShell spawn timeouts on Windows (#9581 tail)

### DIFF
--- a/plugins/plugin-computeruse/src/__tests__/helpers-ps-timeout-floor.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/helpers-ps-timeout-floor.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Behavioral guard for the central PowerShell spawn-timeout floor in
+ * `helpers.ts#runCommand` / `runCommandBuffer`.
+ *
+ * Regression coverage for #9581: the legacy-driver desktop paths in
+ * `desktop.ts` spawn `powershell` through `runCommand` with small hardcoded
+ * budgets (e.g. the 5s `System.Windows.Forms.Cursor` position query that
+ * `driverGetCursorPosition` always uses on Windows). On a Defender-heavy host a
+ * cold `powershell.exe` spawn pays a ~10-16s AV-scan tax, so 5s ETIMEDOUTs and
+ * the capability false-fails (`cua-parity-input.real` died at
+ * `legacyGetCursorPosition`). #10100 floored the `windows-list.ts` spawns but
+ * not these; flooring `runCommand` centrally covers every legacy-driver
+ * PowerShell spawn at once. The mock keeps this a normal cross-platform unit
+ * test (no real spawn), so it fails loudly if the floor is ever dropped.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { execFileSyncMock } = vi.hoisted(() => ({
+  execFileSyncMock: vi.fn(() => ""),
+}));
+
+vi.mock("node:child_process", () => ({
+  execFileSync: execFileSyncMock,
+  execSync: vi.fn(() => ""),
+}));
+
+import { runCommand, runCommandBuffer } from "../platform/helpers.js";
+
+const ENV = "ELIZA_COMPUTERUSE_PS_TIMEOUT_MS";
+
+afterEach(() => {
+  delete process.env[ENV];
+  execFileSyncMock.mockClear();
+});
+
+function lastTimeout(): number {
+  const call = execFileSyncMock.mock.calls.at(-1);
+  return (call?.[2] as { timeout: number }).timeout;
+}
+
+describe("runCommand PowerShell spawn-timeout floor", () => {
+  it("raises a powershell timeout to the ELIZA_COMPUTERUSE_PS_TIMEOUT_MS floor", () => {
+    process.env[ENV] = "30000";
+    runCommand("powershell", ["-Command", "x"], 5000);
+    expect(lastTimeout()).toBe(30000);
+  });
+
+  it("also raises pwsh spawns", () => {
+    process.env[ENV] = "30000";
+    runCommand("pwsh", ["-Command", "x"], 5000);
+    expect(lastTimeout()).toBe(30000);
+  });
+
+  it("only ever raises — never lowers a base above the floor", () => {
+    process.env[ENV] = "1000";
+    runCommand("powershell", ["-Command", "x"], 5000);
+    expect(lastTimeout()).toBe(5000);
+  });
+
+  it("does not touch non-powershell commands", () => {
+    process.env[ENV] = "30000";
+    runCommand("cliclick", ["p:."], 5000);
+    expect(lastTimeout()).toBe(5000);
+  });
+
+  it("is a no-op when the env var is unset", () => {
+    runCommand("powershell", ["-Command", "x"], 5000);
+    expect(lastTimeout()).toBe(5000);
+  });
+
+  it("floors runCommandBuffer powershell spawns too", () => {
+    process.env[ENV] = "30000";
+    runCommandBuffer("powershell", ["-Command", "x"], 5000);
+    expect(lastTimeout()).toBe(30000);
+  });
+});

--- a/plugins/plugin-computeruse/src/platform/helpers.ts
+++ b/plugins/plugin-computeruse/src/platform/helpers.ts
@@ -7,6 +7,7 @@
 
 import { execFileSync, execSync } from "node:child_process";
 import { platform } from "node:os";
+import { psSpawnTimeoutMs } from "./windows-timeouts.js";
 
 // ── Command Execution ───────────────────────────────────────────────────────
 
@@ -41,6 +42,20 @@ export function clearCommandExistsCache(): void {
 }
 
 /**
+ * Resolve the effective spawn timeout for a command. PowerShell spawns pay the
+ * Defender cold-spawn tax on Windows (~10-16s, #9581); raise their budget to the
+ * `ELIZA_COMPUTERUSE_PS_TIMEOUT_MS` floor so a legacy-driver call site's small
+ * hardcoded timeout (e.g. the 5s WinForms cursor-position query in `desktop.ts`)
+ * can't false-fail with `ETIMEDOUT` on an extreme host. Non-PowerShell commands
+ * (cliclick/xdotool/osascript/…) and the unset env var are no-ops.
+ */
+function effectiveSpawnTimeout(command: string, timeout: number): number {
+  return command === "powershell" || command === "pwsh"
+    ? psSpawnTimeoutMs(timeout)
+    : timeout;
+}
+
+/**
  * Run a command via execFileSync (no shell) with timeout.
  * Throws on non-zero exit or timeout.
  */
@@ -50,7 +65,7 @@ export function runCommand(
   timeout: number,
 ): string {
   const result = execFileSync(command, args, {
-    timeout,
+    timeout: effectiveSpawnTimeout(command, timeout),
     stdio: ["ignore", "pipe", "pipe"],
     encoding: "utf-8",
   });
@@ -66,7 +81,7 @@ export function runCommandBuffer(
   timeout: number,
 ): void {
   execFileSync(command, args, {
-    timeout,
+    timeout: effectiveSpawnTimeout(command, timeout),
     stdio: ["ignore", "pipe", "pipe"],
   });
 }


### PR DESCRIPTION
## Problem

`plugin-computeruse`'s legacy-shell driver (`platform/desktop.ts`) spawns `powershell` through `runCommand` at ~20 sites with small **hardcoded** budgets (`5000`/`10000`ms), **none** floored by `psSpawnTimeoutMs`. That includes the `System.Windows.Forms.Cursor` position query in `legacyGetCursorPosition()`, which `driverGetCursorPosition` **always** uses on Windows — even under the default nutjs driver, because nutjs `mouse.getPosition()` returns a stale value (see `docs/TEST_LANES_COMPUTERUSE_VISION.md`).

On a Defender-heavy Windows host a **cold `powershell.exe` spawn pays a ~10–16s real-time-AV-scan tax** (the #9581 root cause). So the 5s cursor-read budget `ETIMEDOUT`s and the capability false-fails while it's actually fine:

```
Error: spawnSync powershell ETIMEDOUT
 ❯ runCommand src/platform/helpers.ts
 ❯ legacyGetCursorPosition src/platform/desktop.ts:181
 ❯ driverGetCursorPosition src/platform/driver.ts:159
 ❯ cua-parity-input.real.test.ts:84
```

#10100 / #10163 floored the `windows-list.ts` spawns, but **missed this legacy-driver class** — even though `windows-timeouts.ts`'s own contract says `ELIZA_COMPUTERUSE_PS_TIMEOUT_MS` should raise **every** PowerShell spawn budget at once.

## Fix

Floor `runCommand` / `runCommandBuffer` **centrally** for `powershell`/`pwsh` via `psSpawnTimeoutMs` (a single `effectiveSpawnTimeout` gate). `psSpawnTimeoutMs` only ever **raises** a budget and is a no-op when the env var is unset, so normal hosts are unaffected; non-PowerShell commands (cliclick/xdotool/osascript/…) are never touched. One env var now covers every legacy-driver spawn **and** any future `runCommand("powershell", …)` caller — no per-site whack-a-mole.

## Evidence (Windows 11 Pro, interactive desktop)

- **The bug, real-driver:** `cua-parity-input.real.test.ts` (real cursor move → `get_cursor_position` round-trip, via the real config) — **before: 1 failed** (`ETIMEDOUT` @ `legacyGetCursorPosition`) → **after: 6/6 passed** with `ELIZA_COMPUTERUSE_PS_TIMEOUT_MS=30000`.
- **New behavioral guard** `helpers-ps-timeout-floor.test.ts` (mocked `execFileSync`, runs cross-platform in the normal unit lane): **6/6** — asserts powershell + pwsh are floored, the floor only raises (never lowers a higher base), non-PS commands are untouched, and it's a no-op when the env var is unset.

Found by running the win32-gated `plugin-computeruse` real lanes on a real Windows box (no CI runs them — computeruse isn't in `windows-ci.yml`). Continues the #9581 "Windows robustness/input tail."

Refs #9581.
