### PR TITLE
fix(ratchet): green develop — fix 7 of 8 post-merge type-safety regressions

### DIFF
--- a/packages/elizaos/src/commands/migrate-agent.ts
+++ b/packages/elizaos/src/commands/migrate-agent.ts
@@ -87,7 +87,7 @@ export async function migrateAgent(opts: MigrateAgentOptions): Promise<void> {
   const agentId = opts.agentId?.trim();
   if (!from) fail("--from <ocplatform-home> is required (e.g. ~/.moltbot).");
   if (!agentId) fail("--agent-id <slug> is required (e.g. sol).");
-  if (!fs.existsSync(from!)) fail(`Home not found: ${from}`);
+  if (!fs.existsSync(from)) fail(`Home not found: ${from}`);
 
   const firewall = opts.noFirewall ? false : (opts.firewall ?? true);
   const memoryDays = opts.memoryDays ? Number(opts.memoryDays) : 14;
@@ -98,8 +98,8 @@ export async function migrateAgent(opts: MigrateAgentOptions): Promise<void> {
   if (!quiet) clack.intro(pc.cyan(`migrate-agent: ${agentId}`));
 
   const plan = buildMigrationPlan({
-    from: from!,
-    agentId: agentId!,
+    from,
+    agentId,
     memoryDays,
     firewall,
     currentContext: opts.currentContext,
@@ -127,7 +127,7 @@ export async function migrateAgent(opts: MigrateAgentOptions): Promise<void> {
     return;
   }
 
-  printPlan(plan, agentId!);
+  printPlan(plan, agentId);
 
   if (opts.dryRun) {
     if (!quiet) clack.outro(pc.dim("dry-run: nothing written."));
@@ -171,7 +171,7 @@ export async function migrateAgent(opts: MigrateAgentOptions): Promise<void> {
         ),
       );
     }
-    const buf = await archiveFromPlan(plan, agentId!, password!);
+    const buf = await archiveFromPlan(plan, agentId, password);
     fs.mkdirSync(path.dirname(path.resolve(opts.out)), { recursive: true });
     fs.writeFileSync(opts.out, buf);
     clack.log.success(`archive → ${opts.out} (${buf.length} bytes)`);

--- a/packages/elizaos/src/migrate/character-mapper.ts
+++ b/packages/elizaos/src/migrate/character-mapper.ts
@@ -83,8 +83,13 @@ export function mapToCharacter(
   // ---- knowledge: USER.md (about the human) - FIREWALLED ----
   const knowledge: Character["knowledge"] = [];
   if (!opts.firewall && src.user?.trim()) {
+    // NOTE(#10326): the runtime ingests an inline-text knowledge item
+    // ({ case: "text", value: { text } }), but core's `DocumentSourceItem`
+    // type currently models only path/directory/empty cases — no inline-text
+    // member — so this requires a double cast. The correct fix is to widen
+    // `DocumentSourceItem` (or the migrate-knowledge representation) so this
+    // shape is type-expressible; tracked as a follow-up on #10326.
     knowledge.push({
-      // DocumentSourceItem: inline text knowledge about the human.
       case: "text",
       value: { text: stripFrontHeading(src.user).trim() },
     } as unknown as NonNullable<Character["knowledge"]>[number]);

--- a/packages/scripts/type-safety-ratchet-baseline.json
+++ b/packages/scripts/type-safety-ratchet-baseline.json
@@ -1,6 +1,6 @@
 {
   "schema": "eliza_type_safety_ratchet_v1",
-  "updatedAt": "2026-06-29T19:40:12.279Z",
+  "updatedAt": "2026-06-30T01:35:02.105Z",
   "scope": {
     "trackedOnly": true,
     "enumeration": "git ls-files",
@@ -43,15 +43,15 @@
     ]
   },
   "limits": {
-    "asUnknownAs": 82,
+    "asUnknownAs": 83,
     "asAny": 0,
     "explicitAny": 126,
     "tsSuppress": 0,
     "nonNullAssertion": 565,
-    "nullishEmptyString": 636,
+    "nullishEmptyString": 627,
     "nullishEmptyArray": 588,
-    "nullishEmptyObject": 379,
-    "nullishZero": 406
+    "nullishEmptyObject": 377,
+    "nullishZero": 386
   },
-  "filesScanned": 9888
+  "filesScanned": 9924
 }

--- a/plugins/plugin-cloud-apps/src/reachability.ts
+++ b/plugins/plugin-cloud-apps/src/reachability.ts
@@ -55,7 +55,7 @@ export async function probeReachable(
   options: ProbeOptions = {},
 ): Promise<ReachabilityResult> {
   const fetchImpl =
-    options.fetchImpl ?? (globalThis.fetch as unknown as FetchLike | undefined);
+    options.fetchImpl ?? (globalThis.fetch as FetchLike | undefined);
   if (typeof fetchImpl !== "function") {
     return { ok: false, error: "no_fetch" };
   }


### PR DESCRIPTION
## Problem

Concurrent merges since the baseline was last set (#10259) pushed the type-safety ratchet **RED** on develop:
- `as unknown as`: **84 > 82** baseline
- non-null assertion `!`: **571 > 565** baseline

The ratchet runs in `bun run verify` **and** the `quality` / `quality-fork` CI lanes (`audit:type-safety-ratchet`), so develop being red fails the quality gate for **every open PR**.

## Root cause (exact, via AST diff)

Pinpointed the 8 new escapes to 3 freshly-merged files:
| file | delta | source |
|---|---|---|
| `packages/elizaos/src/commands/migrate-agent.ts` | +6 `!` | migrate-agent |
| `plugins/plugin-cloud-apps/src/reachability.ts` | +1 `as unknown as` | #10335 |
| `packages/elizaos/src/migrate/character-mapper.ts` | +1 `as unknown as` | #10326 |

## Fix — code, not baseline (7 of 8)

- **migrate-agent.ts** — removed all 6 redundant non-null assertions. `fail()` returns `never`, so the preceding `if (!from) fail(...)` / `if (!agentId) …` / `if (!password …) …` guards already narrow these to `string`. `bun run --cwd packages/elizaos typecheck` passes → **non-null back to 565 (= baseline), fully fixed in code.**
- **reachability.ts** — `globalThis.fetch as unknown as FetchLike` → single `as FetchLike`. `typeof fetch` is structurally assignable to the narrower `FetchLike` (wider params; `Response ⊇ {ok,status}`), so the double cast was never needed.

## The 1 remaining cast (documented follow-up)

`character-mapper.ts` pushes an inline-text knowledge item `{ case: "text", value: { text } }`, but core's `DocumentSourceItem` models only `path`/`directory`/empty cases — **no inline-text member** — so it genuinely requires a cast. Fixing it properly means widening the core type, which is out of scope here and entangled with #10326's runtime semantics. It's now documented inline as a #10326 follow-up, and the baseline reflects it (`asUnknownAs` 82→83).

## Baseline regen also captured legitimate shrinks

`?? ""` 636→627, `?? {}` 379→377, `?? 0` 406→386 — three nullish categories **tightened**.

## Verification
- `node packages/scripts/type-safety-ratchet.mjs` → **exit 0** (green)
- `--self-test` → passed
- `packages/elizaos typecheck` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)