### PR TITLE
feat(plugin-build): additive dtsCopies hook + migrate wallet & video (#10078)

### DIFF
--- a/plugins/plugin-build.ts
+++ b/plugins/plugin-build.ts
@@ -9,7 +9,7 @@
  * on. The emitted `dist/` is byte-identical to the previous hand-rolled build.
  */
 import { existsSync } from "node:fs";
-import { mkdir, readdir, rename, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, readdir, rename, writeFile } from "node:fs/promises";
 import { dirname, join, relative, resolve } from "node:path";
 import {
   type ExternalsFromPackageJsonOptions,
@@ -89,6 +89,16 @@ export interface BuildPluginConfig {
    * single-/multi-target adopters that don't set it are unaffected.
    */
   flatten?: ReadonlyArray<{ from: string; to?: string }>;
+  /**
+   * After declaration emit (+ any `dtsShims`), copy an emitted file under
+   * `dist/<from>` to `dist/<to>`. Reproduces the hand-rolled
+   * `copyFileSync("dist/index.d.ts", "dist/index.d.mts")` step some plugins use
+   * to publish a `.d.mts` sibling of a `tsc`-generated `.d.ts`. Unlike a
+   * `dtsShim` (a frozen literal that would silently diverge from generated
+   * output on any source change), this copies the real emitted file. Off by
+   * default; adopters that don't set it are unaffected.
+   */
+  dtsCopies?: ReadonlyArray<{ from: string; to: string }>;
 }
 
 const RM_RECURSIVE = resolve(
@@ -213,6 +223,12 @@ export async function buildPlugin(config: BuildPluginConfig): Promise<void> {
     const target = join(distDir, shim.path);
     await mkdir(dirname(target), { recursive: true });
     await writeFile(target, shim.content, "utf8");
+  }
+
+  for (const { from, to } of config.dtsCopies ?? []) {
+    const dest = join(distDir, to);
+    await mkdir(dirname(dest), { recursive: true });
+    await copyFile(join(distDir, from), dest);
   }
 
   if (config.rewriteDistImports) {

--- a/plugins/plugin-video/build.ts
+++ b/plugins/plugin-video/build.ts
@@ -1,54 +1,31 @@
 #!/usr/bin/env bun
-import { spawnSync } from "node:child_process";
-import { fileURLToPath } from "node:url";
-import { $ } from "bun";
-import { externalsFromPackageJson } from "../plugin-build-externals.ts";
+/**
+ * Build script for @elizaos/plugin-video (Node). Orchestration lives in the
+ * shared driver (plugins/plugin-build.ts); this lists only what differs. The
+ * emitted `dist/` is byte-identical to the previous hand-rolled build.
+ *
+ * Declarations are emitted straight from the package `tsconfig.json`, which
+ * already sets `declaration`/`emitDeclarationOnly`/`outDir: dist`/`rootDir: src`
+ * — the previous CLI's `--declaration`/`--declarationDir dist` overrides were
+ * redundant with those settings.
+ */
+import { buildPlugin } from "../plugin-build";
 
-const RM_RECURSIVE_SCRIPT = fileURLToPath(
-  new URL("../../packages/scripts/rm-path-recursive.mjs", import.meta.url),
-);
-
-const external = await externalsFromPackageJson("./package.json", {
-  extra: ["node:*", "bun:*"],
+await buildPlugin({
+  name: "@elizaos/plugin-video",
+  clean: true,
+  externals: "auto",
+  externalsOptions: { extra: ["node:*", "bun:*"] },
+  targets: [
+    {
+      label: "Node",
+      entry: "src/index.ts",
+      outSubdir: "",
+      target: "node",
+      format: "esm",
+      sourcemap: "external",
+    },
+  ],
+  dtsProject: "tsconfig.json",
+  dtsEmitDeclarationOnly: true,
 });
-
-function rmRecursive(target: string) {
-  const result = spawnSync(process.execPath, [RM_RECURSIVE_SCRIPT, target], {
-    stdio: "inherit",
-  });
-  if (result.error) throw result.error;
-  if (result.status !== 0) {
-    throw new Error(
-      `rm-path-recursive failed for ${target} with status ${result.status}`,
-    );
-  }
-}
-
-console.log("🔨 Building @elizaos/plugin-video...");
-const start = Date.now();
-
-rmRecursive("dist");
-
-const result = await Bun.build({
-  entrypoints: ["src/index.ts"],
-  outdir: "dist",
-  target: "node",
-  format: "esm",
-  sourcemap: "external",
-  external,
-  minify: false,
-});
-
-if (!result.success) {
-  for (const log of result.logs) {
-    console.error(log);
-  }
-  process.exit(1);
-}
-
-console.log("📝 Generating TypeScript declarations...");
-await $`tsc --emitDeclarationOnly --declaration --declarationDir dist --noCheck -p tsconfig.json`.quiet();
-
-console.log(
-  `✅ Build complete in ${((Date.now() - start) / 1000).toFixed(2)}s`,
-);

--- a/plugins/plugin-wallet/build.ts
+++ b/plugins/plugin-wallet/build.ts
@@ -1,92 +1,51 @@
 #!/usr/bin/env bun
-import { spawnSync } from "node:child_process";
-import { copyFileSync, existsSync, renameSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { $ } from "bun";
+/**
+ * Build script for @elizaos/plugin-wallet (Node, multi-entrypoint).
+ * Orchestration lives in the shared driver (plugins/plugin-build.ts); this
+ * lists only what differs. The emitted `dist/` is byte-identical to the
+ * previous hand-rolled build.
+ *
+ * Notable specifics reproduced here:
+ * - Four entrypoints are bundled together under `dist/` with Bun's default
+ *   `[dir]/[name].[ext]` naming, so `src/sdk/index.ts` etc. keep their tree.
+ * - Only the primary `index.js`/`index.js.map` are renamed to `.mjs`/`.mjs.map`
+ *   (the package `main`/`exports` point at `dist/index.mjs`); the secondary
+ *   entrypoints keep their `.js` names.
+ * - Declarations are emitted via `tsconfig.build.json` (the package
+ *   `tsconfig.json` is `noEmit: true` and carries no `outDir`/`rootDir`), which
+ *   turns emit back on and pins `outDir`/`rootDir` to mirror the previous
+ *   `tsc --noEmit false --outDir dist --rootDir src --declaration` CLI override.
+ * - `dist/index.d.mts` is a byte-copy of the generated `dist/index.d.ts`
+ *   (publishes a NodeNext `.d.mts` sibling for the `.mjs` entry), expressed via
+ *   the driver's `dtsCopies` hook rather than a frozen `dtsShim`.
+ */
+import { buildPlugin } from "../plugin-build";
 
-// Externalize everything in `dependencies` + `peerDependencies` so transitive
-// Node-internal API users (undici, ws, etc.) aren't inlined, and so workspace
-// `@elizaos/*` packages stay external regardless of how Bun.build resolves
-// them (string vs. workspace-relative path). This replaces the previous
-// `[/^@elizaos\//, "undici"]` regex, which missed @elizaos/plugin-elizacloud
-// when resolved via a relative path and thus inlined undici@8.x — whose
-// `CacheStorage` constructor calls Node-internal `webidl.util.markAsUncloneable`
-// (absent on Bun), crashing at top-level import.
-import { externalsFromPackageJson } from "../plugin-build-externals.ts";
-
-const external = await externalsFromPackageJson("./package.json");
-const RM_RECURSIVE_SCRIPT = fileURLToPath(
-  new URL("../../packages/scripts/rm-path-recursive.mjs", import.meta.url),
-);
-
-function rmRecursive(target: string) {
-  const result = spawnSync(process.execPath, [RM_RECURSIVE_SCRIPT, target], {
-    stdio: "inherit",
-  });
-  if (result.error) throw result.error;
-  if (result.status !== 0) {
-    throw new Error(
-      `rm-path-recursive failed for ${target} with status ${result.status}`,
-    );
-  }
-}
-
-console.log("🔨 Building @elizaos/plugin-wallet...");
-const start = Date.now();
-
-rmRecursive("dist");
-
-// Build all entrypoints together
-const result = await Bun.build({
-  entrypoints: [
-    "src/index.ts",
-    "src/sdk/index.ts",
-    "src/wallet-action.ts",
-    "src/lib/server-wallet-trade.ts",
+await buildPlugin({
+  name: "@elizaos/plugin-wallet",
+  clean: true,
+  externals: "auto",
+  targets: [
+    {
+      label: "Node",
+      entry: [
+        "src/index.ts",
+        "src/sdk/index.ts",
+        "src/wallet-action.ts",
+        "src/lib/server-wallet-trade.ts",
+      ],
+      outSubdir: "",
+      target: "node",
+      format: "esm",
+      sourcemap: "external",
+      naming: { entry: "[dir]/[name].[ext]" },
+      renames: [
+        ["index.js", "index.mjs"],
+        ["index.js.map", "index.mjs.map"],
+      ],
+    },
   ],
-  outdir: "dist",
-  target: "node",
-  format: "esm",
-  sourcemap: "external",
-  external,
-  minify: false,
-  splitting: false,
-  naming: "[dir]/[name].[ext]",
+  dtsProject: "tsconfig.build.json",
+  dtsEmitDeclarationOnly: true,
+  dtsCopies: [{ from: "index.d.ts", to: "index.d.mts" }],
 });
-
-if (!result.success) {
-  for (const log of result.logs) {
-    console.error(log);
-  }
-  process.exit(1);
-}
-
-// The primary export expects dist/index.mjs — rename it.
-// Bun outputs dist/index.js; rename to dist/index.mjs.
-renameSync("dist/index.js", "dist/index.mjs");
-if (
-  await Bun.file("dist/index.js.map")
-    .exists()
-    .catch(() => false)
-) {
-  renameSync("dist/index.js.map", "dist/index.mjs.map");
-}
-
-console.log("📝 Generating TypeScript declarations...");
-// wallet tsconfig has noEmit: true — override with --noEmit false, set outDir + rootDir explicitly
-await $`tsc --emitDeclarationOnly --declaration --noEmit false --outDir dist --rootDir src --noCheck --skipLibCheck -p tsconfig.json`.quiet();
-
-// The runtime entry is dist/index.mjs. Keep the legacy .d.ts file for tooling
-// that reads package-level "types", and also emit the NodeNext-matching .d.mts
-// declaration so resolvers that pair .mjs with .d.mts do not fall back to any.
-copyFileSync("dist/index.d.ts", "dist/index.d.mts");
-
-for (const declarationPath of ["dist/index.d.ts", "dist/index.d.mts"]) {
-  if (!existsSync(declarationPath)) {
-    throw new Error(`Missing wallet declaration artifact: ${declarationPath}`);
-  }
-}
-
-console.log(
-  `✅ Build complete in ${((Date.now() - start) / 1000).toFixed(2)}s`,
-);

--- a/plugins/plugin-wallet/tsconfig.build.json
+++ b/plugins/plugin-wallet/tsconfig.build.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": [
+    "**/__tests__/**",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.e2e.test.ts",
+    "build.ts"
+  ]
+}


### PR DESCRIPTION
Extends the shared `buildPlugin` driver (**#10078**) with the last capability the remaining bundling plugins needed, and migrates its two consumers — completing the migratable-bundling-plugin set.

## The hook (additive, off-by-default)
`dtsCopies?: ReadonlyArray<{ from: string; to: string }>` — after declaration emit (+ any `dtsShims`), copy an **emitted** file `dist/<from>` → `dist/<to>`. Reproduces the hand-rolled `copyFileSync("dist/index.d.ts","dist/index.d.mts")` step that publishes a `.d.mts` sibling of a `tsc`-generated `.d.ts`. Unlike a `dtsShim` (a frozen literal that would silently diverge from generated output on any source change), this copies the real emitted file.

**Purely additive — adopters can't regress:** the diff only adds the field + a `for (… of config.dtsCopies ?? [])` loop (no-op when unset); the common path (targets/d.ts/shims/flatten/rewrite) is untouched.

### Regression check (NEW vs OLD driver, empirical)
- **plugin-openai** (Node+Browser): 42 files — **byte-identical**
- **plugin-mcp** (Node+CJS+renames+dtsShims): 66 files — **byte-identical**

## Consumers migrated (byte-identical)
- **plugin-wallet** — **204/204**. `dtsCopies:[{from:"index.d.ts",to:"index.d.mts"}]` for the `.d.mts` sibling; renames `index.js`→`index.mjs` (+ `.map`); new build-only `tsconfig.build.json` to encode the original's `--noEmit false --declaration --outDir dist --rootDir src` CLI overrides (its `tsconfig.json` is `noEmit:true`).
- **plugin-video** — **5/5**. No tsconfig needed — its existing `tsconfig.json` already carries `declaration`/`emitDeclarationOnly`/`outDir`/`rootDir`, so the old CLI flags were redundant; `dtsProject` straight at it reproduces the output.

Each `bun run --cwd plugins/plugin-<p> build` exits 0 (dist counts match).

With this, the genuinely-migratable **bundling** plugins are done; what remains is **pure-tsc** (nostr/line/imessage/google/google-chat/bluebubbles/commands/local-storage/todos — `tsc`-only, not a Bun.build bundle the driver orchestrates) and **native** (local-inference). Refs #10078.

🤖 Generated with [Claude Code](https://claude.com/claude-code)