### PR TITLE
[codex] ci(cloud): harden deploy checkout and core build

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -94,7 +94,7 @@ jobs:
       CHECKOUT_DIR: /tmp/eliza-checkout-${{ github.run_id }}-${{ github.run_attempt }}-deploy-api
     steps:
       - name: Checkout repository
-        timeout-minutes: 15
+        timeout-minutes: 30
         env:
           CHECKOUT_TOKEN: ${{ github.token }}
         run: |
@@ -104,8 +104,11 @@ jobs:
           git -C "$CHECKOUT_DIR" remote set-url origin "https://x-access-token:${CHECKOUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" 2>/dev/null \
             || git -C "$CHECKOUT_DIR" remote add origin "https://x-access-token:${CHECKOUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git -C "$CHECKOUT_DIR" -c protocol.version=2 fetch --force --no-tags --depth=1 origin "$GITHUB_SHA"
-          git -C "$CHECKOUT_DIR" checkout --force --detach FETCH_HEAD
-          git -C "$CHECKOUT_DIR" reset --hard FETCH_HEAD
+          git -C "$CHECKOUT_DIR" \
+            -c advice.detachedHead=false \
+            -c checkout.workers=8 \
+            -c checkout.thresholdForParallelism=100 \
+            checkout --force --detach FETCH_HEAD
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
@@ -120,8 +123,9 @@ jobs:
         run: bun install --no-save --ignore-scripts && git diff --exit-code -- bun.lock
 
       - name: Build linked elizaOS workspaces
+        timeout-minutes: 45
         working-directory: ${{ env.CHECKOUT_DIR }}
-        run: bun run build:core
+        run: bun run build:core -- --concurrency=4
 
       - name: Verify Worker
         working-directory: ${{ env.CHECKOUT_DIR }}
@@ -262,7 +266,7 @@ jobs:
       CHECKOUT_DIR: /tmp/eliza-checkout-${{ github.run_id }}-${{ github.run_attempt }}-deploy-console
     steps:
       - name: Checkout repository
-        timeout-minutes: 15
+        timeout-minutes: 30
         env:
           CHECKOUT_TOKEN: ${{ github.token }}
         run: |
@@ -272,8 +276,11 @@ jobs:
           git -C "$CHECKOUT_DIR" remote set-url origin "https://x-access-token:${CHECKOUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" 2>/dev/null \
             || git -C "$CHECKOUT_DIR" remote add origin "https://x-access-token:${CHECKOUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git -C "$CHECKOUT_DIR" -c protocol.version=2 fetch --force --no-tags --depth=1 origin "$GITHUB_SHA"
-          git -C "$CHECKOUT_DIR" checkout --force --detach FETCH_HEAD
-          git -C "$CHECKOUT_DIR" reset --hard FETCH_HEAD
+          git -C "$CHECKOUT_DIR" \
+            -c advice.detachedHead=false \
+            -c checkout.workers=8 \
+            -c checkout.thresholdForParallelism=100 \
+            checkout --force --detach FETCH_HEAD
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
@@ -288,8 +295,9 @@ jobs:
         run: bun install --no-save --ignore-scripts && git diff --exit-code -- bun.lock
 
       - name: Build linked elizaOS core workspace
+        timeout-minutes: 45
         working-directory: ${{ env.CHECKOUT_DIR }}
-        run: bun run build:core
+        run: bun run build:core -- --concurrency=4
 
       # The cloud console origin, built from packages/app. The vite build is the
       # gate (it resolves @elizaos/* to source); typecheck is enforced by the
@@ -452,7 +460,7 @@ jobs:
       CHECKOUT_DIR: /tmp/eliza-checkout-${{ github.run_id }}-${{ github.run_attempt }}-deploy-app
     steps:
       - name: Checkout repository
-        timeout-minutes: 15
+        timeout-minutes: 30
         env:
           CHECKOUT_TOKEN: ${{ github.token }}
         run: |
@@ -462,8 +470,11 @@ jobs:
           git -C "$CHECKOUT_DIR" remote set-url origin "https://x-access-token:${CHECKOUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" 2>/dev/null \
             || git -C "$CHECKOUT_DIR" remote add origin "https://x-access-token:${CHECKOUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git -C "$CHECKOUT_DIR" -c protocol.version=2 fetch --force --no-tags --depth=1 origin "$GITHUB_SHA"
-          git -C "$CHECKOUT_DIR" checkout --force --detach FETCH_HEAD
-          git -C "$CHECKOUT_DIR" reset --hard FETCH_HEAD
+          git -C "$CHECKOUT_DIR" \
+            -c advice.detachedHead=false \
+            -c checkout.workers=8 \
+            -c checkout.thresholdForParallelism=100 \
+            checkout --force --detach FETCH_HEAD
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
@@ -478,8 +489,9 @@ jobs:
         run: bun install --no-save --ignore-scripts && git diff --exit-code -- bun.lock
 
       - name: Build linked elizaOS core workspace
+        timeout-minutes: 45
         working-directory: ${{ env.CHECKOUT_DIR }}
-        run: bun run build:core
+        run: bun run build:core -- --concurrency=4
 
       # The Eliza agent app. The vite build is the gate (it resolves @elizaos/*
       # to source); typecheck is enforced by the separate verify workflow.


### PR DESCRIPTION
## Summary
- Increase deploy checkout timeout from 15 to 30 minutes.
- Use Git parallel checkout workers and remove the redundant `git reset --hard` after forced detached checkout.
- Add a 45-minute bound to `build:core` deploy steps.
- Run deploy `build:core` with `--concurrency=4` so self-hosted runners do not thrash on duplicate high-concurrency core builds.

## Root cause / evidence
#10324 proved the previous 5-minute checkout cap was too low, but the latest production deploy still failed on current runner variance:

- Production deploy `28413808545` on `main` / `151d05c3ba` fetched successfully, then timed out inside `git checkout`:
  - App runner `eliza-robot-12`: fetch completed at `01:28:30Z`, checkout timed out at `01:42:24Z`.
  - Console runner `eliza-robot-6`: fetch completed at `01:31:14Z`, checkout timed out at `01:42:37Z`.
- API runner `eliza-robot-1` failed before app code while downloading setup actions, which is consistent with the ongoing runner instability seen in earlier deploy attempts.
- Local `bun run build:core` on this SHA passed: 64 successful tasks in about 4m13s, so the source build path is not the immediate blocker.

This keeps the temp checkout isolation from #10314/#10324, but makes checkout faster/less redundant and prevents build-core from hanging forever on deploy runners.

## Validation
- `actionlint .github/workflows/cloud-cf-deploy.yml`
- `git diff --check`
- `bun run build:core -- --dry=json --concurrency=4` confirmed Bun forwards the concurrency flag to turbo.
- `timeout 1800s bun run build:core` passed locally.
