### PR TITLE
chore(build): migrate local-storage + vision onto buildPlugin (#10078)

### DIFF
--- a/plugins/plugin-local-storage/build.ts
+++ b/plugins/plugin-local-storage/build.ts
@@ -1,45 +1,24 @@
 #!/usr/bin/env bun
 /**
- * Build script for @elizaos/plugin-local-storage (Node ESM only)
+ * Build script for @elizaos/plugin-local-storage (Node ESM only).
+ * Orchestration lives in the shared driver (plugins/plugin-build.ts);
+ * this lists only what differs.
  */
+import { buildPlugin } from "../plugin-build";
 
-import { externalsFromPackageJson } from "../plugin-build-externals.ts";
-
-const externalDeps = await externalsFromPackageJson("./package.json");
-
-async function build(): Promise<void> {
-  const totalStart = Date.now();
-
-  const nodeStart = Date.now();
-  console.log("🔨 Building @elizaos/plugin-local-storage for Node...");
-  const nodeResult = await Bun.build({
-    entrypoints: ["src/index.ts"],
-    outdir: "dist",
-    target: "node",
-    format: "esm",
-    sourcemap: "external",
-    minify: false,
-    external: externalDeps,
-    naming: {
-      entry: "index.js",
+await buildPlugin({
+  name: "@elizaos/plugin-local-storage",
+  targets: [
+    {
+      label: "Node",
+      entry: "src/index.ts",
+      outSubdir: "",
+      target: "node",
+      format: "esm",
+      sourcemap: "external",
+      minify: false,
+      naming: { entry: "index.js" },
     },
-  });
-  if (!nodeResult.success) {
-    console.error(nodeResult.logs);
-    throw new Error("Node build failed");
-  }
-  console.log(`✅ Node build complete in ${((Date.now() - nodeStart) / 1000).toFixed(2)}s`);
-
-  const dtsStart = Date.now();
-  console.log("📝 Generating TypeScript declarations...");
-  const { $ } = await import("bun");
-  await $`tsc --project tsconfig.build.json --noCheck`;
-  console.log(`✅ Declarations generated in ${((Date.now() - dtsStart) / 1000).toFixed(2)}s`);
-
-  console.log(`🎉 All builds finished in ${((Date.now() - totalStart) / 1000).toFixed(2)}s`);
-}
-
-build().catch((err) => {
-  console.error("Build failed:", err);
-  process.exit(1);
+  ],
+  dtsProject: "tsconfig.build.json",
 });

--- a/plugins/plugin-vision/build.ts
+++ b/plugins/plugin-vision/build.ts
@@ -1,12 +1,13 @@
 #!/usr/bin/env bun
-
 /**
- * Build script using bun build
- * Uses Bun.build for bundling
+ * Build script for @elizaos/plugin-vision (Node ESM main + CJS workers).
+ * Orchestration lives in the shared driver (plugins/plugin-build.ts); this
+ * lists only what differs.
+ *
+ * Note: `build:native` (native/yolo.cpp/build.mjs) is a separate script and is
+ * NOT part of this `build` step.
  */
-
-import { $ } from "bun";
-import { externalsFromPackageJson } from "../plugin-build-externals.ts";
+import { buildPlugin } from "../plugin-build";
 
 const NODE_BUILTINS = [
   "fs",
@@ -26,103 +27,60 @@ const NODE_BUILTINS = [
   "node:url",
 ] as const;
 
-async function build() {
-  console.log("🏗️  Building package...");
+// Externalize plugin-computeruse even though it is NOT a package.json
+// dependency: plugin-vision dynamically imports its OCR seam
+// (`@elizaos/plugin-computeruse/mobile/ocr-provider`) at boot via a
+// best-effort import. It MUST stay external so the registry singleton is the
+// one runtime instance computeruse reads — bundling a copy would split the
+// registry and the registration would be invisible to computeruse.
+const OPTIONAL_PEERS = ["@elizaos/plugin-computeruse"] as const;
 
-  // Clean dist directory
-  await $`node ../../packages/scripts/rm-path-recursive.mjs dist`;
+// Worker-only externals (sharp's native/optional transitive deps). The main
+// entrypoints never reference these, so folding them into the single shared
+// external set leaves the main bundle byte-identical while keeping the worker
+// bundles externalizing them exactly as before.
+const WORKER_EXTRAS = [
+  "@mapbox/node-pre-gyp",
+  "mock-aws-s3",
+  "aws-sdk",
+  "nock",
+] as const;
 
-  // Externalize plugin-computeruse even though it is NOT a package.json
-  // dependency: plugin-vision dynamically imports its OCR seam
-  // (`@elizaos/plugin-computeruse/mobile/ocr-provider`) at boot via a
-  // best-effort import. It MUST stay external so the registry singleton is the
-  // one runtime instance computeruse reads — bundling a copy would split the
-  // registry and the registration would be invisible to computeruse.
-  const OPTIONAL_PEERS = ["@elizaos/plugin-computeruse"] as const;
-  const external = await externalsFromPackageJson("./package.json", {
-    extra: [...NODE_BUILTINS, ...OPTIONAL_PEERS],
-  });
-
-  // Build main package
-  console.log("📦 Building main package...");
-  const mainResult = await Bun.build({
-    // index.ts is the package entry; som.ts is also a published subpath
-    // (`@elizaos/plugin-vision/som`, #9170 M9) consumed by computeruse's
-    // detect_elements/grounding, so emit it as its own dist entrypoint.
-    entrypoints: ["./src/index.ts", "./src/som.ts"],
-    outdir: "./dist",
-    target: "node",
-    format: "esm",
-    splitting: false,
-    sourcemap: "external",
-    external,
-    naming: "[dir]/[name].[ext]",
-  });
-
-  if (!mainResult.success) {
-    console.error("❌ Main build failed:");
-    for (const message of mainResult.logs) {
-      console.error(message);
-    }
-    process.exit(1);
-  }
-
-  console.log(`✅ Built ${mainResult.outputs.length} main files`);
-
-  // Check if workers exist before building them
-  const { existsSync, readdirSync } = await import("node:fs");
-  const workersDir = "src/workers";
-  if (existsSync(workersDir)) {
-    const files = readdirSync(workersDir);
-    const workerFiles = files.filter((f) => f.endsWith(".ts"));
-    if (workerFiles.length > 0) {
-      console.log("👷 Building workers...");
-      const workersResult = await Bun.build({
-        entrypoints: [
-          "./src/workers/screen-capture-worker.ts",
-          "./src/workers/ocr-worker.ts",
-        ],
-        outdir: "./dist/workers",
-        target: "node",
-        format: "cjs", // Workers need CommonJS format
-        splitting: false,
-        sourcemap: true,
-        external: [
-          ...external,
-          "@mapbox/node-pre-gyp",
-          "mock-aws-s3",
-          "aws-sdk",
-          "nock",
-        ],
-        naming: "[name].[ext]",
-      });
-
-      if (!workersResult.success) {
-        console.error("❌ Workers build failed:");
-        for (const message of workersResult.logs) {
-          console.error(message);
-        }
-        process.exit(1);
-      }
-
-      console.log(`✅ Built ${workersResult.outputs.length} worker files`);
-    }
-  }
-
-  // Generate TypeScript declarations
-  console.log("📝 Generating TypeScript declarations...");
-  const dtsResult =
-    await $`tsc --project tsconfig.build.json --noCheck`.nothrow();
-  if (dtsResult.exitCode !== 0) {
-    console.error("❌ TypeScript declarations failed");
-    process.exit(dtsResult.exitCode);
-  }
-  console.log("✅ TypeScript declarations generated");
-
-  console.log("✅ Build complete!");
-}
-
-build().catch((error) => {
-  console.error(error);
-  process.exit(1);
+await buildPlugin({
+  name: "@elizaos/plugin-vision",
+  clean: true,
+  externals: "auto",
+  externalsOptions: {
+    extra: [...NODE_BUILTINS, ...OPTIONAL_PEERS, ...WORKER_EXTRAS],
+  },
+  targets: [
+    {
+      // index.ts is the package entry; som.ts is also a published subpath
+      // (`@elizaos/plugin-vision/som`, #9170 M9) consumed by computeruse's
+      // detect_elements/grounding, so emit it as its own dist entrypoint.
+      label: "Node",
+      entry: ["./src/index.ts", "./src/som.ts"],
+      outSubdir: "",
+      target: "node",
+      format: "esm",
+      splitting: false,
+      sourcemap: "external",
+      naming: { entry: "[dir]/[name].[ext]" },
+    },
+    {
+      // Workers need CommonJS format.
+      label: "Workers",
+      entry: [
+        "./src/workers/screen-capture-worker.ts",
+        "./src/workers/ocr-worker.ts",
+      ],
+      outSubdir: "workers",
+      target: "node",
+      format: "cjs",
+      splitting: false,
+      sourcemap: "linked",
+      naming: { entry: "[name].[ext]" },
+    },
+  ],
+  dtsProject: "tsconfig.build.json",
 });


### PR DESCRIPTION
Continues **#10078** — migrates two more onto the shared `buildPlugin` driver, byte-identical.

| plugin | dist files | shape |
|---|---|---|
| plugin-local-storage | 5 | single Node ESM, `dtsProject` |
| plugin-vision | 100 | Node ESM (2 entries) + CJS workers (`outSubdir:"workers"`, `sourcemap:"linked"`), `clean` |

- **vision**: its "native" `build:native` (yolo.cpp) is a *separate* script the `build` script never invokes — out of scope; `build.ts` is just 2 `Bun.build` + tsc. Folded the workers' per-target externals (`@mapbox/node-pre-gyp`, `mock-aws-s3`, `aws-sdk`, `nock`) into the shared `externalsOptions.extra` — verified the main entrypoints never reference them, so the main bundle stays byte-identical and workers externalize exactly as before.

Both `bun run build` exit 0; dist byte-identical (5/5, 100/100); shims typecheck. Refs #10078.

Note: `plugin-linear` and `plugin-tee` turned out to still be raw-`Bun.build` bundlers (local functions coincidentally named `buildPlugin`, not the shared import) — migrating those next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)