### PR TITLE
chore(build): migrate linear + tee onto buildPlugin — last raw Bun.build bundlers (#10078)

### DIFF
--- a/plugins/plugin-linear/build.ts
+++ b/plugins/plugin-linear/build.ts
@@ -1,71 +1,37 @@
 #!/usr/bin/env bun
+/**
+ * Build script for @elizaos/plugin-linear (Node). Orchestration lives in the
+ * shared driver (plugins/plugin-build.ts); this lists only what differs.
+ */
+import { buildPlugin } from "../plugin-build";
 
-import { spawnSync } from "node:child_process";
-import { dirname, join, resolve } from "node:path";
-import { externalsFromPackageJson } from "../plugin-build-externals.ts";
-
-const ROOT = resolve(dirname(import.meta.path));
-const DIST = join(ROOT, "dist");
-const RM_RECURSIVE_SCRIPT = join(ROOT, "..", "..", "packages", "scripts", "rm-path-recursive.mjs");
-
-function rmRecursive(targetPath: string) {
-  const result = spawnSync(process.execPath, [RM_RECURSIVE_SCRIPT, targetPath], {
-    stdio: "inherit",
-  });
-  if (result.status !== 0) {
-    throw new Error(`failed to remove generated plugin-linear build output ${targetPath}`);
-  }
-}
-
-const externalDeps = await externalsFromPackageJson("./package.json", {
-  // Preserve transitive externals the hand-maintained list relied on.
-  // These show up via @linear/sdk + agentkeepalive's transitive graph;
-  // keep them externalized to avoid inlining Node-builtin API users.
-  extra: ["dotenv", "fs", "path", "@reflink/reflink", "https", "http", "agentkeepalive", "zod"],
-});
-
-async function buildPlugin() {
-  console.log("🔨 Building @elizaos/plugin-linear...\n");
-
-  rmRecursive(DIST);
-
-  console.log("📦 Bundling with Bun...");
-  const buildResult = await Bun.build({
-    entrypoints: ["src/index.ts"],
-    outdir: "dist",
-    target: "node",
-    format: "esm",
-    sourcemap: "external",
-    minify: false,
-    external: externalDeps,
-  });
-
-  if (!buildResult.success) {
-    console.error("Build failed:");
-    for (const log of buildResult.logs) {
-      console.error(log);
-    }
-    process.exit(1);
-  }
-
-  console.log(`✅ Built ${buildResult.outputs.length} file(s)`);
-
-  console.log("📝 Generating type declarations...");
-  const tscProcess = Bun.spawn(["bunx", "tsc", "-p", "tsconfig.build.json", "--noCheck"], {
-    stdout: "inherit",
-    stderr: "inherit",
-  });
-  await tscProcess.exited;
-
-  if (tscProcess.exitCode !== 0) {
-    console.error("TypeScript declaration generation failed");
-    process.exit(1);
-  }
-
-  console.log("\n✅ Build complete!");
-}
-
-buildPlugin().catch((error) => {
-  console.error("Build failed:", error);
-  process.exit(1);
+await buildPlugin({
+  name: "@elizaos/plugin-linear",
+  clean: true,
+  externals: "auto",
+  externalsOptions: {
+    // Preserve transitive externals the hand-maintained list relied on.
+    // These show up via @linear/sdk + agentkeepalive's transitive graph;
+    // keep them externalized to avoid inlining Node-builtin API users.
+    extra: [
+      "dotenv",
+      "fs",
+      "path",
+      "@reflink/reflink",
+      "https",
+      "http",
+      "agentkeepalive",
+      "zod",
+    ],
+  },
+  targets: [
+    {
+      label: "Node",
+      entry: "src/index.ts",
+      outSubdir: "",
+      target: "node",
+      format: "esm",
+    },
+  ],
+  dtsProject: "tsconfig.build.json",
 });

--- a/plugins/plugin-tee/build.ts
+++ b/plugins/plugin-tee/build.ts
@@ -1,94 +1,44 @@
 #!/usr/bin/env bun
+/**
+ * Build script for @elizaos/plugin-tee (Node). Orchestration lives in the shared
+ * driver (plugins/plugin-build.ts); this lists only what differs.
+ */
+import { buildPlugin } from "../plugin-build";
 
-import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { externalsFromPackageJson } from "../plugin-build-externals.ts";
-
-const RM_RECURSIVE_SCRIPT = fileURLToPath(
-  new URL("../../packages/scripts/rm-path-recursive.mjs", import.meta.url),
-);
-
-function rmRecursive(target: string) {
-  const result = spawnSync(process.execPath, [RM_RECURSIVE_SCRIPT, target], {
-    stdio: "inherit",
-  });
-  if (result.error) throw result.error;
-  if (result.status !== 0) {
-    throw new Error(
-      `rm-path-recursive failed for ${target} with status ${result.status}`,
-    );
-  }
-}
-
-const externalDeps = await externalsFromPackageJson("./package.json", {
-  // Preserve transitive packages + bare-string node builtins the hand-list
-  // relied on. Most of these are pulled in via @solana/web3.js and viem.
-  extra: [
-    "dotenv",
-    "fs",
-    "path",
-    "@reflink/reflink",
-    "@node-llama-cpp",
-    "https",
-    "http",
-    "agentkeepalive",
-    "safe-buffer",
-    "base-x",
-    "bs58",
-    "borsh",
-    "stream",
-    "buffer",
-    "undici",
-    "zod",
-  ],
-});
-
-async function buildPlugin() {
-  console.log("Building @elizaos/plugin-tee...\n");
-
-  if (existsSync("dist")) {
-    rmRecursive("dist");
-  }
-
-  const buildResult = await Bun.build({
-    entrypoints: ["src/index.ts"],
-    outdir: "dist",
-    target: "node",
-    format: "esm",
-    sourcemap: "external",
-    minify: false,
-    external: externalDeps,
-  });
-
-  if (!buildResult.success) {
-    console.error("Build failed:");
-    for (const log of buildResult.logs) {
-      console.error(log);
-    }
-    process.exit(1);
-  }
-
-  console.log(`Built ${buildResult.outputs.length} file(s)`);
-
-  const tscProcess = Bun.spawn(
-    ["bunx", "tsc", "-p", "tsconfig.build.json", "--noCheck"],
+await buildPlugin({
+  name: "@elizaos/plugin-tee",
+  clean: true,
+  externals: "auto",
+  externalsOptions: {
+    // Preserve transitive packages + bare-string node builtins the hand-list
+    // relied on. Most of these are pulled in via @solana/web3.js and viem.
+    extra: [
+      "dotenv",
+      "fs",
+      "path",
+      "@reflink/reflink",
+      "@node-llama-cpp",
+      "https",
+      "http",
+      "agentkeepalive",
+      "safe-buffer",
+      "base-x",
+      "bs58",
+      "borsh",
+      "stream",
+      "buffer",
+      "undici",
+      "zod",
+    ],
+  },
+  targets: [
     {
-      stdout: "inherit",
-      stderr: "inherit",
+      label: "Node",
+      entry: "src/index.ts",
+      outSubdir: "",
+      target: "node",
+      format: "esm",
     },
-  );
-  await tscProcess.exited;
-
-  if (tscProcess.exitCode !== 0) {
-    console.error("TypeScript declaration generation failed");
-    process.exit(1);
-  }
-
-  console.log("\nBuild complete!");
-}
-
-buildPlugin().catch((error) => {
-  console.error("Build failed:", error);
-  process.exit(1);
+  ],
+  dtsProject: "tsconfig.build.json",
 });


### PR DESCRIPTION
Completes the **#10078** raw-`Bun.build` bundler migration — `plugin-linear` and `plugin-tee` were the last two plugins still hand-rolling `Bun.build` (via local functions coincidentally named `buildPlugin`). Both migrated onto the shared driver, byte-identical.

| plugin | dist files | shape |
|---|---|---|
| plugin-linear | 62 | single Node ESM, `clean`, `externals:"auto"` + 8-entry `extra`, `dtsProject` (emitDeclarationOnly) |
| plugin-tee | 38 | single Node ESM → `dist/node`, `clean`, 16-entry `extra`, `dtsProject` |

Both originals verified deterministic (2 clean builds, no `.tsbuildinfo` leakage); migrated dist sha256-identical (62/62, 38/38). `bun run build` exit 0; shims typecheck.

## #10078 raw-`Bun.build` migration now complete
With this + the in-flight batches (#10331/#10338/#10341/#10343), **every plugin that bundles via `Bun.build` is on the shared `buildPlugin` driver** — the only remaining direct `Bun.build` caller is native `plugin-local-inference` (llama.cpp, out of scope). Remaining custom builds are **pure-tsc** (nostr/line/imessage/google/google-chat/bluebubbles/commands/todos — `tsc`-only, not a bundle the driver orchestrates) and a separate **tsup** cohort (github/music/localdb/calendly/agent-skills — a different bundler, separate consolidation scope).

Refs #10078.

🤖 Generated with [Claude Code](https://claude.com/claude-code)