### PR TITLE
fix(first-run): device remote-connect-at-URL onboarding via deep link + Settings (#10322)

### DIFF
--- a/.github/issue-evidence/10322-device-remote-connect-onboarding.md
+++ b/.github/issue-evidence/10322-device-remote-connect-onboarding.md
@@ -1,0 +1,94 @@
+# 10322 — Device remote-connect-at-URL onboarding (deep link + Settings)
+
+Closes #10322. Follow-up to #9952 / #10302 (the in-chat onboarding redesign that
+removed the remote-connect-at-URL surface and quarantined the two device lanes).
+
+## What changed
+
+Device/desktop "connect to a remote agent at a URL" onboarding is restored as a
+first-class capability that is **decoupled from the onboarding surface**, so it
+works whether onboarding is the old full-screen flow or the new in-chat
+conductor — and survives future onboarding redesigns.
+
+| Surface | Before (#9952/#10302) | After |
+| --- | --- | --- |
+| Deep link | `<scheme>://first-run/runtime/remote` only **pre-selected** the runtime; the URL had to be typed into a now-deleted DOM field | `<scheme>://first-run/runtime/remote?api=<url>` **carries the URL** and connects + completes first-run |
+| Settings → Runtime → Remote | `reloadIntoFirstRunRuntime("remote")` → dead-ends in the conductor (no remote URL capture) | Opens a **"Connect a remote agent"** URL + optional-token form |
+| `finishRemote` | unreachable in `first-run-finish.ts` | capability **relocated** to the reusable headless `adopt-remote-first-run.ts` |
+| Android lane | quarantined (`test.skip`) | **live**, drives the real `adb` VIEW-intent deep link |
+| iOS lane | self-skips (`phase: "skipped"`) | **live**, harness fires `simctl openurl`; in-app verifier proves home |
+
+Both the deep link and the Settings entry funnel through the existing,
+security-hardened `CONNECT_EVENT` path (`applyLaunchConnection` +
+`url-trust-policy`); a bearer token is **never** accepted from an OS-delivered
+deep link.
+
+### Completion semantics (the lynchpin)
+
+`applyLaunchConnection({ kind: "remote" })` only points the client at the remote;
+it does **not** complete first-run. `adopt-remote-first-run.ts` PROBES the
+remote's `GET /api/first-run/status` and only `POST`s `/api/first-run` when the
+host has not finished its own first-run — an improvement over the legacy
+unconditional `finishRemote` POST, which could clobber an already-configured
+host's deployment target. `retryStartup()` then re-polls and lands on home.
+
+## Verification done locally (this branch, rebased onto post-#10302 develop)
+
+- **Unit tests — `bun run --cwd packages/ui test` (filtered): 36 passed.**
+  - `src/first-run/__tests__/deep-link-entry.test.ts` — `parseFirstRunRemoteConnectDeepLink`:
+    api/apiBase/url/host aliases, percent-decoding, bare-remote → null (falls
+    through to pre-select), local/cloud → null, foreign scheme/host → null,
+    malformed → null, empty `api` → null.
+  - `src/first-run/adopt-remote-first-run.test.ts` — `normalizeRemoteAgentUrl`
+    (trailing-slash/query/hash strip, bare-host → https, empty/non-http reject)
+    and `adoptRemoteAgentFirstRun` (fresh host → POST `{deploymentTarget.runtime:"remote"}`,
+    already-complete → no POST/no clobber, unreachable probe → still POSTs,
+    POST failure → propagates, token forwarded).
+- **No regressions** — `packages/ui` first-run + shell suite: 143 passed (13
+  files); `packages/app` deep-link suite: 19 passed.
+- **Typecheck** — `packages/ui` and `packages/app` clean for every touched file.
+  (Only pre-existing, unrelated `src/cloud/billing/wallet/steward-wallet-providers.tsx`
+  viem `Config` generic error remains; that file is unmodified by this branch
+  and errors identically on `develop`.)
+- **Lint** — Biome could not run locally: the repo pins `@biomejs/biome@2.5.0`
+  but this worktree's shared store has only 2.4.x, which rejects the root
+  `biome.json` `css.parser.tailwindDirectives` key. Code follows Biome defaults
+  (double quotes, 2-space, trailing commas, import sort); CI runs 2.5.0.
+
+## Device e2e — real OS deep link (runs in CI / on device hardware)
+
+These lanes need a booted emulator/simulator + the deterministic host agent
+(`serve-real-local-agent.ts`), so they execute in CI, not in this sandbox. They
+were rewritten to drive the **real** path and produce the screenshots + video:
+
+- **iOS** — `.github/workflows/mobile-build-smoke.yml` → `node packages/app/scripts/ios-onboarding-smoke.mjs`.
+  Harness fires `simctl openurl <scheme>://first-run/runtime/remote?api=http://127.0.0.1:31337`;
+  the in-app verifier asserts `home-launcher-surface[data-page=home]` +
+  `chat-composer-textarea` + persisted `elizaos:active-server`. Artifacts:
+  `fresh-onboarding.png`, `home-landing.png`, `onboarding-to-home.mp4`,
+  `result.json` (uploaded as the `ios-onboarding-to-home` artifact).
+- **Android** — `bun run --cwd packages/app test:e2e:android:onboarding`.
+  Fires `adb am start -a VIEW -c BROWSABLE -d <scheme>://first-run/runtime/remote?api=…`;
+  asserts the same home surface + `"kind":"remote"` active-server. Artifacts:
+  `home-landing.png`, `onboarding-to-home.mp4`.
+
+## Aesthetic review — Settings → Runtime → "Connect a remote agent"
+
+- Reuses canonical primitives only: `SettingsRow` (stacked), `Input`,
+  `SettingsActionButton`. No new base elements.
+- Brand-compliant: no blue; error text uses the established `text-destructive`
+  token; the Connect button is the standard accent action button; the form is a
+  neutral stacked row under the Remote runtime card.
+- States covered: empty (Connect disabled until a URL is entered), invalid URL
+  (inline `role="alert"` message from `normalizeRemoteAgentUrl`), optional token
+  field (password input). Desktop + mobile share the `SettingsRow stacked`
+  layout.
+- Full-page rest/hover screenshots for this row are produced by
+  `bun run --cwd packages/app audit:app` (Settings → Runtime), which boots the
+  real shell — run in the app visual-audit lane.
+
+## Trajectory / audio — N/A
+
+This is shell/first-run UX wiring (deep-link routing + a connect form), not an
+agent action / prompt / model change, so there is no model trajectory or
+voice round-trip to capture (consistent with the #9952 evidence section).

--- a/packages/app/scripts/ios-onboarding-smoke.mjs
+++ b/packages/app/scripts/ios-onboarding-smoke.mjs
@@ -1,7 +1,11 @@
 #!/usr/bin/env node
-// iOS Simulator first-run smoke. WKWebView is not CDP-drivable like Android,
-// so the harness writes a Capacitor Preferences request, launches the installed
-// app, and lets the WebView click/fill the real onboarding DOM internally.
+// iOS Simulator first-run REMOTE-CONNECT smoke. WKWebView is not CDP-drivable
+// like Android, so the harness writes a Capacitor Preferences request (which
+// arms the in-app verifier), launches the installed app, then fires the real
+// `<scheme>://first-run/runtime/remote?api=<url>` deep link via `simctl
+// openurl`. The app connects to the remote + completes first-run on its own;
+// the in-app verifier proves it landed on home and reports back via Preferences.
+// No onboarding DOM is driven, so the lane survives the in-chat redesign.
 import { execFileSync, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
@@ -358,10 +362,6 @@ async function pollResult(udid, appId) {
       } catch {
         parsed = null;
       }
-      // Quarantined (#10322): the in-app smoke skips cleanly because the
-      // remote-connect-at-URL onboarding surface it drove was removed by #9952.
-      if (parsed?.skipped === true || parsed?.phase === "skipped")
-        return parsed;
       if (parsed?.ok === true) return parsed;
       if (parsed?.phase === "failed" || parsed?.error) {
         throw new Error(`iOS onboarding smoke failed: ${lastRaw}`);
@@ -406,31 +406,16 @@ async function main() {
     log(`launching ${appId} on ${udid}`);
     simctl(["launch", udid, appId]);
     await sleep(1500);
-    if (has("--use-deeplink")) {
-      tryRun("xcrun", [
-        "simctl",
-        "openurl",
-        udid,
-        `${urlScheme}://first-run/runtime/remote`,
-      ]);
-    }
+    // Fire the real OS deep link that carries the remote agent URL. The app's
+    // CONNECT_EVENT path connects + completes first-run; the in-app verifier
+    // (runIosOnboardingSmokeIfRequested) then proves it landed on home.
+    const deepLink = `${urlScheme}://first-run/runtime/remote?api=${encodeURIComponent(apiBase)}`;
+    log(`opening first-run remote deep link: ${deepLink}`);
+    simctl(["openurl", udid, deepLink]);
     takeScreenshot(udid, "fresh-onboarding");
     const result = await pollResult(udid, appId);
     const screenshot = takeScreenshot(udid, "home-landing");
     const video = await stopVideo(recording);
-    if (result.skipped === true || result.phase === "skipped") {
-      // Quarantined (#10322): remote-connect-at-URL onboarding was removed by
-      // #9952; the in-app smoke skips cleanly until device onboarding is
-      // redesigned. Treated as a pass so mobile-build-smoke.yml stays green.
-      fs.writeFileSync(
-        path.join(resultDir, "result.json"),
-        `${JSON.stringify({ ...result, screenshot, video }, null, 2)}\n`,
-      );
-      log(
-        `SKIP (#10322): ${result.reason ?? "remote-connect-at-URL onboarding pending device redesign"}`,
-      );
-      return;
-    }
     if (result.homeVisible !== true || result.composerVisible !== true) {
       throw new Error(
         `iOS onboarding smoke result lacked home/composer: ${JSON.stringify(result)}`,

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -74,7 +74,10 @@ import {
   SHARE_TARGET_EVENT,
   TRAY_ACTION_EVENT,
 } from "@elizaos/ui/events";
-import { routeFirstRunDeepLink } from "@elizaos/ui/first-run/deep-link-handler";
+import {
+  parseFirstRunRemoteConnectDeepLink,
+  routeFirstRunDeepLink,
+} from "@elizaos/ui/first-run/deep-link-handler";
 import {
   IOS_LOCAL_AGENT_IPC_BASE,
   MOBILE_LOCAL_AGENT_API_BASE,
@@ -407,6 +410,7 @@ const IOS_FULL_BUN_SMOKE_REQUEST_KEY = "eliza:ios-full-bun-smoke:request";
 const IOS_FULL_BUN_SMOKE_RESULT_KEY = "eliza:ios-full-bun-smoke:result";
 const IOS_ONBOARDING_SMOKE_REQUEST_KEY = "eliza:ios-onboarding-smoke:request";
 const IOS_ONBOARDING_SMOKE_RESULT_KEY = "eliza:ios-onboarding-smoke:result";
+const IOS_ONBOARDING_SMOKE_TIMEOUT_MS = 120_000;
 const IOS_FULL_BUN_SMOKE_ROUTE_TIMEOUT_MS = 300_000;
 const IOS_FULL_BUN_SMOKE_MESSAGE_TIMEOUT_MS = 600_000;
 const IOS_FULL_BUN_SMOKE_CHAT_TEXT =
@@ -823,6 +827,29 @@ function parseIosOnboardingSmokeRequest(raw: string | null): {
   }
 }
 
+async function waitForIosOnboardingElement<T extends Element>(
+  selector: string,
+  options?: { timeoutMs?: number; visible?: boolean },
+): Promise<T> {
+  const timeoutMs = options?.timeoutMs ?? IOS_ONBOARDING_SMOKE_TIMEOUT_MS;
+  const deadline = Date.now() + timeoutMs;
+  let lastElement: Element | null = null;
+  while (Date.now() < deadline) {
+    lastElement = document.querySelector(selector);
+    if (lastElement) {
+      const visible =
+        !options?.visible ||
+        (lastElement instanceof HTMLElement &&
+          lastElement.offsetParent !== null);
+      if (visible) return lastElement as T;
+    }
+    await new Promise((resolve) => window.setTimeout(resolve, 250));
+  }
+  throw new Error(
+    `Timed out waiting for iOS onboarding selector ${selector}${lastElement ? " to become visible" : ""}`,
+  );
+}
+
 function readIosOnboardingSmokeStorageSnapshot(): Record<
   string,
   string | null
@@ -859,22 +886,48 @@ async function runIosOnboardingSmokeIfRequested(): Promise<boolean> {
 
   iosOnboardingSmokeStarted = true;
   const request = parseIosOnboardingSmokeRequest(rawRequest);
-  // QUARANTINED (#10322): #9952 moved onboarding into the in-chat
-  // ContinuousChatOverlay and removed the remote-connect-at-URL surface this
-  // smoke drove (first-run-remote-address / choice-remote / choice-connect /
-  // first-run-chat). Device remote-connect onboarding needs a product redesign
-  // before this lane can be rewritten, so skip cleanly — the harness treats a
-  // `phase: "skipped"` result as a pass — instead of timing out against
-  // selectors that no longer exist.
+  await writeIosOnboardingSmokeResult({
+    ok: false,
+    phase: "running",
+    startedAt: new Date().toISOString(),
+    apiBase: request.apiBase,
+  });
   try {
+    // The harness fires the `<scheme>://first-run/runtime/remote?api=…` deep
+    // link after launch; the app connects to the remote and completes first-run
+    // on its own (CONNECT_EVENT → adopt → startup re-poll). This verifier only
+    // proves the post-connect surface, so it is decoupled from the onboarding
+    // DOM — no remote-address field to fill, resilient to the in-chat redesign.
+    const home = await waitForIosOnboardingElement<HTMLElement>(
+      '[data-testid="home-launcher-surface"][data-page="home"]',
+      { visible: true },
+    );
+    const composer = await waitForIosOnboardingElement<HTMLElement>(
+      '[data-testid="chat-composer-textarea"]',
+      { visible: true },
+    );
+
+    const onboardingHidden = !document.querySelector(
+      '[data-testid="first-run-chat"], [data-testid="startup-first-run-background"]',
+    );
+
     await writeIosOnboardingSmokeResult({
-      ok: false,
-      skipped: true,
-      phase: "skipped",
+      ok: true,
+      phase: "complete",
       finishedAt: new Date().toISOString(),
       apiBase: request.apiBase,
-      reason:
-        "remote-connect-at-URL onboarding removed by #9952; device redesign pending — see https://github.com/elizaOS/eliza/issues/10322",
+      homeVisible: Boolean(home),
+      composerVisible: Boolean(composer),
+      onboardingHidden,
+      storage: readIosOnboardingSmokeStorageSnapshot(),
+    });
+  } catch (error) {
+    await writeIosOnboardingSmokeResult({
+      ok: false,
+      phase: "failed",
+      finishedAt: new Date().toISOString(),
+      apiBase: request.apiBase,
+      error: error instanceof Error ? error.message : String(error),
       storage: readIosOnboardingSmokeStorageSnapshot(),
     });
   } finally {
@@ -1674,7 +1727,49 @@ async function initializeNetworkListener(): Promise<void> {
 // `assetlinks.json` + `apple-app-site-association` served from eliza.app).
 const APP_LINK_HOSTS = ["eliza.app"];
 
+// Device/desktop "connect to a remote agent at a URL" first-run onboarding:
+// `<scheme>://first-run/runtime/remote?api=<url>`. The host (a desktop/cloud
+// agent) emits this as a link/QR; opening it on a fresh device connects to that
+// remote and lands on home. Routed through the same hardened CONNECT_EVENT path
+// as `<scheme>://connect?url=` (trust-policy gated, token never accepted from a
+// deep link) but with `completeFirstRun` so it also finishes onboarding.
+function connectFirstRunRemoteDeepLink(rawApiBase: string): void {
+  let validatedUrl: URL;
+  try {
+    validatedUrl = new URL(rawApiBase);
+  } catch {
+    console.error(`${APP_LOG_PREFIX} Invalid first-run remote URL format`);
+    return;
+  }
+  if (validatedUrl.protocol !== "https:" && validatedUrl.protocol !== "http:") {
+    console.error(
+      `${APP_LOG_PREFIX} Invalid first-run remote URL protocol:`,
+      validatedUrl.protocol,
+    );
+    return;
+  }
+  if (!isTrustedDeepLinkApiBaseUrl(validatedUrl)) {
+    console.warn(
+      `${APP_LOG_PREFIX} Rejected untrusted first-run remote host:`,
+      validatedUrl.hostname,
+    );
+    return;
+  }
+  // SECURITY: never accept a bearer token from an OS-delivered deep link (see
+  // the `connect` case below). A pairing-disabled remote that needs a token is
+  // connected via the trusted in-app Settings entry instead.
+  dispatchAppEvent(CONNECT_EVENT, {
+    gatewayUrl: validatedUrl.href,
+    completeFirstRun: true,
+  });
+}
+
 function handleDeepLink(url: string): void {
+  const firstRunRemote = parseFirstRunRemoteConnectDeepLink(url, APP_URL_SCHEME);
+  if (firstRunRemote) {
+    connectFirstRunRemoteDeepLink(firstRunRemote.apiBase);
+    return;
+  }
   if (routeFirstRunDeepLink(url, APP_URL_SCHEME)) {
     return;
   }

--- a/packages/app/test/android/onboarding-to-home.android.spec.ts
+++ b/packages/app/test/android/onboarding-to-home.android.spec.ts
@@ -1,26 +1,126 @@
-// Fresh first-run onboarding on the real Android Capacitor WebView.
+// Fresh first-run REMOTE-CONNECT onboarding on the real Android Capacitor
+// WebView, driven by the OS deep link.
 //
-// QUARANTINED (#10322). #9952 moved onboarding INTO the floating
-// ContinuousChatOverlay and deleted the separate full-screen onboarding
-// surface, including the remote-connect-at-URL flow this lane drove: the
-// `choice-remote` card, the `first-run-remote-address` input, and the
-// `choice-connect` button no longer exist. The in-chat conductor only offers
-// runtime cloud/local/other; `runtime:other` ("bring your own keys") now runs
-// the LOCAL backend, and there is no in-chat "connect to a remote host agent at
-// a URL" step (`finishRemote` exists in first-run-finish.ts but is unreachable).
+// The host (a desktop/cloud agent) emits a
+// `<scheme>://first-run/runtime/remote?api=<url>` link/QR. Opening it on a fresh
+// device connects to that remote and lands on home. This spec resets the
+// installed app into first-run, fires the real deep link via `adb am start`
+// (delivered to Capacitor's `appUrlOpen`), and asserts the post-onboarding home
+// surface — no onboarding DOM is touched, so the lane survives the in-chat
+// onboarding redesign (#9952/#10302) instead of binding to deleted testids
+// (the original `choice-remote` / `first-run-remote-address` / `choice-connect`
+// flow). Replaces the lane quarantined in #10322.
 //
-// Device remote-connect onboarding needs a product redesign before this lane can
-// be rewritten to drive the new surface — tracked in
-// https://github.com/elizaOS/eliza/issues/10322. Skipped (NOT deleted) so the
-// coverage gap stays visible and tracked rather than silently dropped.
-import { test } from "./android-harness";
+// The deterministic host agent is reachable at 127.0.0.1:31337 through
+// `adb reverse`; 127.0.0.1 is loopback, so the connect needs no confirm prompt.
+import path from "node:path";
+import { startAndroidScreenRecord } from "../../scripts/lib/android-capture.mjs";
+import {
+  adbDevice,
+  adbReverse,
+  APP_ID,
+  resolveAdb,
+} from "../../scripts/lib/android-device.mjs";
+import { expect, ORIGIN, test } from "./android-harness";
+
+const HOST_AGENT_BASE = "http://127.0.0.1:31337";
+// app.config.ts `desktop.urlScheme`; the Android manifest registers it as the
+// BROWSABLE `@string/custom_url_scheme` intent-filter.
+const URL_SCHEME = "elizaos";
+const FIRST_RUN_REMOTE_DEEPLINK = `${URL_SCHEME}://first-run/runtime/remote?api=${encodeURIComponent(
+  HOST_AGENT_BASE,
+)}`;
+const ARTIFACT_DIR = path.join(
+  process.cwd(),
+  "test-results",
+  "android-onboarding-to-home",
+);
 
 test.describe
-  .serial("android onboarding to home (real Capacitor WebView)", () => {
-    test("fresh first-run connects to a host agent and lands on home", () => {
-      test.skip(
-        true,
-        "remote-connect-at-URL onboarding removed by #9952; device redesign pending — see https://github.com/elizaOS/eliza/issues/10322",
-      );
+  .serial("android remote-connect onboarding via deep link (real WebView)", () => {
+    test("fresh first-run deep link connects to a host agent and lands on home", async ({
+      page,
+      device,
+    }, testInfo) => {
+      test.setTimeout(180_000);
+
+      const adbBin = resolveAdb();
+      const serial = device.serial();
+      // The device's 127.0.0.1:31337 must reach the host's deterministic agent.
+      adbReverse(adbBin, serial, 31337);
+
+      const recording = await startAndroidScreenRecord({
+        serial,
+        artifactDir: ARTIFACT_DIR,
+        filename: "onboarding-to-home.mp4",
+        remotePath: "/sdcard/eliza-onboarding-to-home.mp4",
+      });
+
+      try {
+        // Force a fresh first-run: drop any seeded active-server / completion so
+        // the app boots into onboarding before the deep link arrives.
+        await page.evaluate(() => {
+          localStorage.removeItem("elizaos:active-server");
+          localStorage.removeItem("eliza:onboarding-complete");
+          localStorage.removeItem("eliza:first-run-complete");
+          localStorage.removeItem("eliza:setup:step");
+          localStorage.removeItem("eliza:mobile-runtime-mode");
+        });
+        await page.goto(`${ORIGIN}/?reset`, {
+          waitUntil: "domcontentloaded",
+          timeout: 60_000,
+        });
+
+        // The agent must be the gate before the deep link lands.
+        await expect(page.getByTestId("home-launcher-surface")).toHaveCount(0, {
+          timeout: 30_000,
+        });
+
+        // Fire the real OS deep link. `am start` delivers it to the running
+        // WebView via Capacitor `appUrlOpen` (singleTask onNewIntent), so the
+        // CDP page survives and observes the connect → home transition.
+        adbDevice(adbBin, serial, [
+          "shell",
+          "am",
+          "start",
+          "-a",
+          "android.intent.action.VIEW",
+          "-c",
+          "android.intent.category.BROWSABLE",
+          "-d",
+          FIRST_RUN_REMOTE_DEEPLINK,
+          APP_ID,
+        ]);
+
+        const surface = page.getByTestId("home-launcher-surface");
+        await expect(surface).toBeVisible({ timeout: 90_000 });
+        await expect(surface).toHaveAttribute("data-page", "home");
+        await expect(page.getByTestId("chat-composer-textarea")).toBeVisible({
+          timeout: 60_000,
+        });
+
+        // The connect must have persisted the remote as the active server.
+        const activeServer = await page.evaluate(() =>
+          localStorage.getItem("elizaos:active-server"),
+        );
+        expect(activeServer, "active-server persisted").toBeTruthy();
+        expect(activeServer).toContain("127.0.0.1:31337");
+        expect(activeServer).toContain('"kind":"remote"');
+
+        const screenshotPath = path.join(ARTIFACT_DIR, "home-landing.png");
+        await page.screenshot({ path: screenshotPath, fullPage: true });
+        await testInfo.attach("home landing screenshot", {
+          path: screenshotPath,
+          contentType: "image/png",
+        });
+      } finally {
+        const videoPath = await recording.stop();
+        if (videoPath) {
+          await testInfo.attach("onboarding walkthrough video", {
+            path: videoPath,
+            contentType: "video/mp4",
+          });
+        }
+      }
     });
   });

--- a/packages/ui/src/components/settings/RuntimeSettingsSection.tsx
+++ b/packages/ui/src/components/settings/RuntimeSettingsSection.tsx
@@ -8,6 +8,8 @@ import {
 } from "../../bridge/electrobun-rpc";
 import { isElectrobunRuntime } from "../../bridge/electrobun-runtime";
 import { isStoreBuild } from "../../build-variant";
+import { CONNECT_EVENT, dispatchAppEvent } from "../../events";
+import { normalizeRemoteAgentUrl } from "../../first-run/adopt-remote-first-run";
 import { readPersistedMobileRuntimeMode } from "../../first-run/mobile-runtime-mode";
 import {
   type FirstRunReloadTarget,
@@ -23,6 +25,7 @@ import {
 import { loadPersistedActiveServer } from "../../state/persistence";
 import { AdvancedToggle } from "./AdvancedToggle";
 import { useAdvancedSettingsEnabled } from "./AdvancedToggle.hooks";
+import { Input } from "../ui/input";
 import { SettingsActionButton } from "./settings-agent-rows";
 import { SettingsGroup, SettingsRow, SettingsStack } from "./settings-layout";
 
@@ -83,6 +86,10 @@ export function RuntimeSettingsSection() {
   const advancedEnabled = useAdvancedSettingsEnabled();
   const [migrationMessage, setMigrationMessage] = useState<string | null>(null);
   const [migrationBusy, setMigrationBusy] = useState(false);
+  const [remoteFormOpen, setRemoteFormOpen] = useState(false);
+  const [remoteUrl, setRemoteUrl] = useState("");
+  const [remoteToken, setRemoteToken] = useState("");
+  const [remoteError, setRemoteError] = useState<string | null>(null);
 
   // Prefer the authoritative server snapshot (`GET /api/runtime/mode`); fall
   // back to the local heuristic when it is loading or unreachable.
@@ -141,8 +148,43 @@ export function RuntimeSettingsSection() {
   }, [t, cloudOnly, storeBuild, localDisabledReason]);
 
   const handleSwitch = useCallback((target: FirstRunReloadTarget) => {
+    // Cloud/local re-enter the first-run runtime picker. Remote no longer routes
+    // through first-run (post-#9952 there is no remote URL capture there);
+    // instead it reveals an inline "connect a remote agent" form that points the
+    // app straight at a host via the hardened CONNECT_EVENT path.
+    if (target === "remote") {
+      setRemoteError(null);
+      setRemoteFormOpen((open) => !open);
+      return;
+    }
     reloadIntoFirstRunRuntime(target);
   }, []);
+
+  const handleConnectRemote = useCallback(() => {
+    let normalized: string;
+    try {
+      normalized = normalizeRemoteAgentUrl(remoteUrl);
+    } catch (error) {
+      setRemoteError(
+        error instanceof Error
+          ? error.message
+          : t("settings.runtime.remoteInvalidUrl", {
+              defaultValue: "Enter a valid remote agent URL.",
+            }),
+      );
+      return;
+    }
+    setRemoteError(null);
+    // skipConfirm: the user explicitly typed this URL in trusted Settings, so the
+    // OS-deep-link confirmation prompt is redundant. completeFirstRun: adopt the
+    // remote as the active runtime and land on home.
+    dispatchAppEvent(CONNECT_EVENT, {
+      gatewayUrl: normalized,
+      token: remoteToken.trim() || undefined,
+      completeFirstRun: true,
+      skipConfirm: true,
+    });
+  }, [remoteUrl, remoteToken, t]);
 
   const handleImportDirectState = useCallback(async () => {
     setMigrationBusy(true);
@@ -233,6 +275,75 @@ export function RuntimeSettingsSection() {
             />
           );
         })}
+
+        {remoteFormOpen ? (
+          <SettingsRow
+            label={t("settings.runtime.remoteConnectLabel", {
+              defaultValue: "Connect a remote agent",
+            })}
+            description={t("settings.runtime.remoteConnectHelp", {
+              defaultValue:
+                "Enter the agent's URL — add an access token only if the host requires one.",
+            })}
+            stacked
+          >
+            <div className="flex flex-col gap-2">
+              <Input
+                type="url"
+                inputMode="url"
+                autoCapitalize="none"
+                autoCorrect="off"
+                spellCheck={false}
+                value={remoteUrl}
+                onChange={(event) => {
+                  setRemoteUrl(event.target.value);
+                  setRemoteError(null);
+                }}
+                placeholder="https://agent.example.com"
+                hasError={Boolean(remoteError)}
+                data-testid="settings-remote-address"
+                aria-label={t("settings.runtime.remoteConnectLabel", {
+                  defaultValue: "Connect a remote agent",
+                })}
+              />
+              <Input
+                type="password"
+                autoCapitalize="none"
+                autoCorrect="off"
+                spellCheck={false}
+                value={remoteToken}
+                onChange={(event) => setRemoteToken(event.target.value)}
+                placeholder={t("settings.runtime.remoteTokenPlaceholder", {
+                  defaultValue: "Access token (optional)",
+                })}
+                data-testid="settings-remote-token"
+                aria-label={t("settings.runtime.remoteTokenPlaceholder", {
+                  defaultValue: "Access token (optional)",
+                })}
+              />
+              {remoteError ? (
+                <p className="text-xs text-destructive" role="alert">
+                  {remoteError}
+                </p>
+              ) : null}
+              <SettingsActionButton
+                agentId="runtime-connect-remote"
+                agentLabel={t("settings.runtime.remoteConnectAction", {
+                  defaultValue: "Connect",
+                })}
+                type="button"
+                onClick={handleConnectRemote}
+                disabled={!remoteUrl.trim()}
+                className="h-11 w-fit rounded-md px-4 text-sm"
+                data-testid="settings-remote-connect"
+              >
+                {t("settings.runtime.remoteConnectAction", {
+                  defaultValue: "Connect",
+                })}
+              </SettingsActionButton>
+            </div>
+          </SettingsRow>
+        ) : null}
       </SettingsGroup>
 
       {/* The default surface is the runtime-mode picker above. The one-time

--- a/packages/ui/src/components/settings/RuntimeSettingsSection.tsx
+++ b/packages/ui/src/components/settings/RuntimeSettingsSection.tsx
@@ -23,9 +23,9 @@ import {
   inferAgentRuntimeTarget,
 } from "../../state/agent-runtime-target";
 import { loadPersistedActiveServer } from "../../state/persistence";
+import { Input } from "../ui/input";
 import { AdvancedToggle } from "./AdvancedToggle";
 import { useAdvancedSettingsEnabled } from "./AdvancedToggle.hooks";
-import { Input } from "../ui/input";
 import { SettingsActionButton } from "./settings-agent-rows";
 import { SettingsGroup, SettingsRow, SettingsStack } from "./settings-layout";
 

--- a/packages/ui/src/first-run/__tests__/deep-link-entry.test.ts
+++ b/packages/ui/src/first-run/__tests__/deep-link-entry.test.ts
@@ -62,6 +62,7 @@ vi.mock("@capacitor/app", () => ({
 
 import {
   installFirstRunDeepLinkListener,
+  parseFirstRunRemoteConnectDeepLink,
   routeFirstRunDeepLink,
 } from "../deep-link-handler";
 import {
@@ -326,5 +327,91 @@ describe("installFirstRunDeepLinkListener", () => {
 
     await cleanup();
     expect(removeMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("parseFirstRunRemoteConnectDeepLink", () => {
+  it("captures the remote agent URL from the api param", () => {
+    expect(
+      parseFirstRunRemoteConnectDeepLink(
+        "eliza://first-run/runtime/remote?api=http://127.0.0.1:31337",
+        URL_SCHEME,
+      ),
+    ).toEqual({ apiBase: "http://127.0.0.1:31337" });
+  });
+
+  it("decodes a percent-encoded URL (how the OS delivers it)", () => {
+    expect(
+      parseFirstRunRemoteConnectDeepLink(
+        "eliza://first-run/runtime/remote?api=https%3A%2F%2Fagent.example.com",
+        URL_SCHEME,
+      ),
+    ).toEqual({ apiBase: "https://agent.example.com" });
+  });
+
+  it.each(["apiBase", "url", "host"])(
+    "accepts the %s query alias",
+    (key) => {
+      expect(
+        parseFirstRunRemoteConnectDeepLink(
+          `eliza://first-run/runtime/remote?${key}=https://agent.example.com`,
+          URL_SCHEME,
+        ),
+      ).toEqual({ apiBase: "https://agent.example.com" });
+    },
+  );
+
+  it("returns null for a bare remote link with no URL (falls through to pre-select)", () => {
+    expect(
+      parseFirstRunRemoteConnectDeepLink(
+        "eliza://first-run/runtime/remote",
+        URL_SCHEME,
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null for the local/cloud runtime targets", () => {
+    expect(
+      parseFirstRunRemoteConnectDeepLink(
+        "eliza://first-run/runtime/local?api=http://127.0.0.1:31337",
+        URL_SCHEME,
+      ),
+    ).toBeNull();
+    expect(
+      parseFirstRunRemoteConnectDeepLink(
+        "eliza://first-run/runtime/cloud?api=http://127.0.0.1:31337",
+        URL_SCHEME,
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null for a foreign scheme or non-first-run host", () => {
+    expect(
+      parseFirstRunRemoteConnectDeepLink(
+        "evil://first-run/runtime/remote?api=http://127.0.0.1:31337",
+        URL_SCHEME,
+      ),
+    ).toBeNull();
+    expect(
+      parseFirstRunRemoteConnectDeepLink(
+        "eliza://connect/runtime/remote?api=http://127.0.0.1:31337",
+        URL_SCHEME,
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null for a malformed URL", () => {
+    expect(
+      parseFirstRunRemoteConnectDeepLink("not a url", URL_SCHEME),
+    ).toBeNull();
+  });
+
+  it("ignores an empty api param", () => {
+    expect(
+      parseFirstRunRemoteConnectDeepLink(
+        "eliza://first-run/runtime/remote?api=",
+        URL_SCHEME,
+      ),
+    ).toBeNull();
   });
 });

--- a/packages/ui/src/first-run/adopt-remote-first-run.test.ts
+++ b/packages/ui/src/first-run/adopt-remote-first-run.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  adoptRemoteAgentFirstRun,
+  normalizeRemoteAgentUrl,
+  type RemoteFirstRunClient,
+} from "./adopt-remote-first-run";
+
+describe("normalizeRemoteAgentUrl", () => {
+  it("keeps a valid http URL and strips the trailing slash", () => {
+    expect(normalizeRemoteAgentUrl("http://127.0.0.1:31337/")).toBe(
+      "http://127.0.0.1:31337",
+    );
+  });
+
+  it("upgrades a bare host to https", () => {
+    expect(normalizeRemoteAgentUrl("agent.example.com")).toBe(
+      "https://agent.example.com",
+    );
+  });
+
+  it("strips query and hash so one host has one identity", () => {
+    expect(
+      normalizeRemoteAgentUrl("https://agent.example.com/?x=1#frag"),
+    ).toBe("https://agent.example.com");
+  });
+
+  it("throws on an empty value", () => {
+    expect(() => normalizeRemoteAgentUrl("   ")).toThrow(
+      /enter a remote agent url/i,
+    );
+  });
+
+  it("rejects a non-http(s) protocol", () => {
+    expect(() => normalizeRemoteAgentUrl("ftp://agent.example.com")).toThrow(
+      /http or https/i,
+    );
+  });
+});
+
+function makeClient(
+  overrides: Partial<RemoteFirstRunClient> = {},
+): {
+  client: RemoteFirstRunClient;
+  getFirstRunStatus: ReturnType<typeof vi.fn>;
+  submitFirstRun: ReturnType<typeof vi.fn>;
+} {
+  const getFirstRunStatus = vi.fn(async () => ({ complete: false }));
+  const submitFirstRun = vi.fn(async () => undefined);
+  const client: RemoteFirstRunClient = {
+    getFirstRunStatus,
+    submitFirstRun,
+    ...overrides,
+  };
+  return { client, getFirstRunStatus, submitFirstRun };
+}
+
+describe("adoptRemoteAgentFirstRun", () => {
+  it("adopts a fresh remote: probes then POSTs the remote deployment target", async () => {
+    const { client, submitFirstRun } = makeClient({
+      getFirstRunStatus: vi.fn(async () => ({ complete: false })),
+    });
+
+    const result = await adoptRemoteAgentFirstRun(client, {
+      apiBase: "http://127.0.0.1:31337",
+    });
+
+    expect(result).toEqual({ alreadyComplete: false });
+    expect(submitFirstRun).toHaveBeenCalledTimes(1);
+    const payload = submitFirstRun.mock.calls[0][0] as {
+      deploymentTarget?: { runtime?: string; remoteApiBase?: string };
+    };
+    expect(payload.deploymentTarget?.runtime).toBe("remote");
+    expect(payload.deploymentTarget?.remoteApiBase).toBe(
+      "http://127.0.0.1:31337",
+    );
+  });
+
+  it("does NOT clobber a host that already finished first-run", async () => {
+    const { client, submitFirstRun } = makeClient({
+      getFirstRunStatus: vi.fn(async () => ({ complete: true })),
+    });
+
+    const result = await adoptRemoteAgentFirstRun(client, {
+      apiBase: "https://agent.example.com",
+    });
+
+    expect(result).toEqual({ alreadyComplete: true });
+    expect(submitFirstRun).not.toHaveBeenCalled();
+  });
+
+  it("treats an unreachable status probe as 'needs adoption' and still POSTs", async () => {
+    const { client, submitFirstRun } = makeClient({
+      getFirstRunStatus: vi.fn(async () => {
+        throw new Error("network down");
+      }),
+    });
+
+    await adoptRemoteAgentFirstRun(client, {
+      apiBase: "http://127.0.0.1:31337",
+    });
+
+    expect(submitFirstRun).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates a completion-write failure instead of faking success", async () => {
+    const { client } = makeClient({
+      getFirstRunStatus: vi.fn(async () => ({ complete: false })),
+      submitFirstRun: vi.fn(async () => {
+        throw new Error("remote unreachable");
+      }),
+    });
+
+    await expect(
+      adoptRemoteAgentFirstRun(client, { apiBase: "http://127.0.0.1:31337" }),
+    ).rejects.toThrow(/remote unreachable/);
+  });
+
+  it("forwards an access token in the submitted plan", async () => {
+    const { client, submitFirstRun } = makeClient();
+
+    await adoptRemoteAgentFirstRun(client, {
+      apiBase: "https://agent.example.com",
+      token: "secret-key",
+    });
+
+    const payload = submitFirstRun.mock.calls[0][0] as {
+      deploymentTarget?: { remoteAccessToken?: string };
+    };
+    expect(payload.deploymentTarget?.remoteAccessToken).toBe("secret-key");
+  });
+});

--- a/packages/ui/src/first-run/adopt-remote-first-run.ts
+++ b/packages/ui/src/first-run/adopt-remote-first-run.ts
@@ -1,0 +1,112 @@
+/**
+ * Headless "adopt a remote agent during first-run" use case.
+ *
+ * Device + desktop remote-connect-at-URL onboarding (deep link and the Settings
+ * "Connect a remote agent" entry) funnels through here AFTER the client base has
+ * been pointed at the remote (`applyLaunchConnection({ kind: "remote" })`). It
+ * makes the connected remote the device's completed first-run target so the
+ * startup poll lands on home instead of re-showing onboarding on the next launch.
+ *
+ * This is the headless equivalent of the legacy `finishRemote` step that used to
+ * live in the full-screen onboarding controller, with one deliberate
+ * improvement: it PROBES the remote's first-run status first and only writes
+ * when the host has not finished its own first-run. Connecting to an
+ * already-configured host therefore adopts it as-is instead of clobbering its
+ * deployment target — the destructive overwrite the unconditional legacy POST
+ * could cause.
+ *
+ * It is intentionally dependency-injected (the client surface is the only
+ * dependency) so it can be unit-tested without the React shell or a live server.
+ */
+
+import type { UiLanguage } from "../i18n";
+import { buildFirstRunSubmitPlan } from "./first-run";
+
+/**
+ * Normalizes a user- or link-supplied remote agent address into a canonical
+ * `http(s)://host[:port]` URL, throwing a friendly message on anything invalid.
+ * A bare `host:port` is upgraded to `https://`. Trailing slashes, query, and
+ * hash are stripped so the same host always yields one identity.
+ */
+export function normalizeRemoteAgentUrl(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) throw new Error("Enter a remote agent URL.");
+  const candidate = /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(trimmed)
+    ? trimmed
+    : `https://${trimmed}`;
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate);
+  } catch {
+    throw new Error("Enter a valid remote agent URL.");
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("Remote agents must use HTTP or HTTPS.");
+  }
+  parsed.pathname = parsed.pathname.replace(/\/+$/, "");
+  parsed.search = "";
+  parsed.hash = "";
+  return parsed.toString().replace(/\/+$/, "");
+}
+
+/** The minimal client surface this use case needs (a subset of `ElizaClient`). */
+export interface RemoteFirstRunClient {
+  getFirstRunStatus(): Promise<{ complete: boolean }>;
+  submitFirstRun(data: Record<string, unknown>): Promise<void>;
+}
+
+export interface AdoptRemoteAgentFirstRunInput {
+  /** The remote agent URL — already normalized/applied by the caller. */
+  apiBase: string;
+  /** Optional pre-shared access token for a pairing-disabled remote. */
+  token?: string | null;
+  /** Drives the default character preset language; defaults to English. */
+  uiLanguage?: UiLanguage;
+}
+
+export interface AdoptRemoteAgentFirstRunResult {
+  /** True when the remote already reported a completed first-run (no write). */
+  alreadyComplete: boolean;
+}
+
+/**
+ * Ensures the connected remote is recorded as the device's completed first-run
+ * target. Returns whether the remote was already complete (so callers can skip
+ * a redundant "configured" notice).
+ *
+ * Throws if the remote cannot be reached for the completion write — surfacing a
+ * real connection failure rather than silently landing the user on a dead shell.
+ */
+export async function adoptRemoteAgentFirstRun(
+  client: RemoteFirstRunClient,
+  input: AdoptRemoteAgentFirstRunInput,
+): Promise<AdoptRemoteAgentFirstRunResult> {
+  let alreadyComplete = false;
+  try {
+    alreadyComplete = (await client.getFirstRunStatus()).complete === true;
+  } catch {
+    // A fresh host with no persisted first-run state, or one whose build
+    // predates the status route, is the expected "needs adoption" shape — fall
+    // through to the completion write below. A genuinely unreachable remote
+    // re-fails there, so the failure still surfaces; it is not hidden here.
+    alreadyComplete = false;
+  }
+
+  if (alreadyComplete) {
+    return { alreadyComplete: true };
+  }
+
+  const plan = buildFirstRunSubmitPlan({
+    draft: {
+      agentName: "",
+      runtime: "remote",
+      localInference: "all-local",
+      remoteApiBase: input.apiBase,
+      remoteToken: input.token ?? "",
+    },
+    uiLanguage: input.uiLanguage ?? "en",
+  });
+
+  await client.submitFirstRun(plan.payload);
+  return { alreadyComplete: false };
+}

--- a/packages/ui/src/first-run/deep-link-handler.ts
+++ b/packages/ui/src/first-run/deep-link-handler.ts
@@ -55,6 +55,62 @@ function isFirstRunPathTarget(value: string): value is FirstRunPathTarget {
 }
 
 /**
+ * Query-parameter aliases that carry the remote agent URL on a
+ * `<scheme>://first-run/runtime/remote?api=<url>` deep link. `api` is the
+ * documented form; the others are accepted so a host that already emits a
+ * `connect`-style `url=`/`apiBase=` link does not silently drop the address.
+ */
+const REMOTE_CONNECT_QUERY_KEYS = ["api", "apiBase", "url", "host"] as const;
+
+export interface FirstRunRemoteConnectDeepLink {
+  /** The raw remote agent URL captured from the deep link (not yet trusted). */
+  apiBase: string;
+}
+
+/**
+ * Parses a device "connect to a remote agent at a URL" first-run deep link:
+ * `<scheme>://first-run/runtime/remote?api=<url>`. Returns the captured URL
+ * when the link targets the remote runtime AND carries an address; returns
+ * `null` for every other shape (wrong scheme/host, a non-remote target, or a
+ * bare `remote` link with no URL — that case still flows through
+ * {@link routeFirstRunDeepLink} as a runtime pre-selection).
+ *
+ * This parser is intentionally pure: it does NOT validate trust or connect.
+ * The app shell owns the trust policy (`isTrustedDeepLinkApiBaseUrl`) and the
+ * connect dispatch, so the same hardened path serves both this link and the
+ * existing `<scheme>://connect?url=` link.
+ */
+export function parseFirstRunRemoteConnectDeepLink(
+  url: string,
+  urlScheme: string,
+): FirstRunRemoteConnectDeepLink | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+
+  if (parsed.protocol !== `${urlScheme}:`) return null;
+  if (parsed.host !== FIRST_RUN_HOST) return null;
+
+  const pathSegments = parsed.pathname
+    .split("/")
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0);
+
+  if (pathSegments[0] !== RUNTIME_SEGMENT) return null;
+  if (pathSegments[1] !== STEP_TO_FIRST_RUN_TARGET.remote) return null;
+
+  for (const key of REMOTE_CONNECT_QUERY_KEYS) {
+    const value = parsed.searchParams.get(key)?.trim();
+    if (value) return { apiBase: value };
+  }
+
+  return null;
+}
+
+/**
  * Parses `eliza://first-run/runtime/<id>` (or any scheme matching `urlScheme`)
  * and writes the matching first-run runtime query
  * params to the current location. Returns `true` when the URL matched the

--- a/packages/ui/src/state/use-startup-shell-controller.ts
+++ b/packages/ui/src/state/use-startup-shell-controller.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { client } from "../api";
 import type { StartupShellView } from "../components/shell/startup-shell-types";
 import { CONNECT_EVENT } from "../events";
+import { adoptRemoteAgentFirstRun } from "../first-run/adopt-remote-first-run";
 import { ensureStoreBuildWorkspaceFolder } from "../first-run/ensure-store-build-workspace-folder";
 import { persistMobileRuntimeModeForServerTarget } from "../first-run/mobile-runtime-mode";
 import { applyLaunchConnection } from "../platform";
@@ -85,6 +86,7 @@ export function useStartupShellController(): StartupShellController {
     setActionNotice,
     setState,
     t,
+    uiLanguage,
   } = useAppSelectorShallow((s) => ({
     startupCoordinator: s.startupCoordinator,
     startupError: s.startupError,
@@ -94,6 +96,7 @@ export function useStartupShellController(): StartupShellController {
     setActionNotice: s.setActionNotice,
     setState: s.setState,
     t: s.t,
+    uiLanguage: s.uiLanguage,
   }));
   const phase = startupCoordinator.phase;
   const [showBootstrap, setShowBootstrap] = useState(false);
@@ -109,18 +112,33 @@ export function useStartupShellController(): StartupShellController {
       const detail = (event as CustomEvent<unknown>).detail;
       const payload =
         detail && typeof detail === "object" && !Array.isArray(detail)
-          ? (detail as { gatewayUrl?: unknown; token?: unknown })
+          ? (detail as {
+              gatewayUrl?: unknown;
+              token?: unknown;
+              completeFirstRun?: unknown;
+              skipConfirm?: unknown;
+            })
           : null;
       if (typeof payload?.gatewayUrl !== "string") {
         return;
       }
 
-      // CONNECT_EVENT is only ever dispatched from an OS-delivered `connect`
-      // deep link (attacker-reachable). Repointing the agent API base to a
-      // non-loopback host is security-sensitive, so require explicit user
-      // confirmation for any remote target; the local-agent (loopback) connect
-      // stays frictionless.
-      if (!isLoopbackGatewayHost(payload.gatewayUrl)) {
+      // `completeFirstRun` marks the connected remote as this device's finished
+      // first-run target (device/desktop remote-connect-at-URL onboarding), so
+      // it lands on home instead of re-showing onboarding on the next launch.
+      const completeFirstRun = payload.completeFirstRun === true;
+      // `skipConfirm` is set ONLY by trusted in-app callers (the Settings
+      // "Connect a remote agent" entry, where the user just typed the URL).
+      // OS-delivered deep links never set it, so they keep the confirmation.
+      const skipConfirm = payload.skipConfirm === true;
+
+      // CONNECT_EVENT is dispatched from an OS-delivered `connect`/`first-run`
+      // deep link (attacker-reachable) as well as the trusted Settings entry.
+      // Repointing the agent API base to a non-loopback host is
+      // security-sensitive, so require explicit user confirmation for any remote
+      // target from an untrusted source; the local-agent (loopback) connect and
+      // the trusted in-app entry stay frictionless.
+      if (!skipConfirm && !isLoopbackGatewayHost(payload.gatewayUrl)) {
         const approved = await confirmDesktopAction({
           type: "warning",
           title: "Connect to this server?",
@@ -149,6 +167,17 @@ export function useStartupShellController(): StartupShellController {
         setState("firstRunRemoteToken", connection.token ?? "");
         setState("firstRunRemoteConnected", true);
         setState("firstRunRemoteError", null);
+        if (completeFirstRun) {
+          // Adopt the remote as this device's completed first-run target. Probes
+          // first, so an already-configured host is used as-is (no clobber) and
+          // a fresh host is marked complete — either way the startup re-poll
+          // below lands on home rather than onboarding.
+          await adoptRemoteAgentFirstRun(client, {
+            apiBase: connection.apiBase,
+            token: connection.token,
+            uiLanguage,
+          });
+        }
         setActionNotice("Connected to remote backend.", "success", 4200);
         retryStartup();
       } catch (err) {
@@ -164,7 +193,7 @@ export function useStartupShellController(): StartupShellController {
 
     document.addEventListener(CONNECT_EVENT, handleConnect);
     return () => document.removeEventListener(CONNECT_EVENT, handleConnect);
-  }, [retryStartup, setActionNotice, setState]);
+  }, [retryStartup, setActionNotice, setState, uiLanguage]);
 
   useEffect(() => {
     void ensureStoreBuildWorkspaceFolder();


### PR DESCRIPTION
Closes #10322. Follow-up to #9952 / #10302 (the in-chat onboarding redesign that deleted the remote-connect-at-URL surface and quarantined the two device lanes).

## Problem

After #10302, the in-chat conductor only offers `runtime:cloud | local | other`. There is **no remote-connect-at-URL path**: `finishRemote` exists in `first-run-finish.ts` but is unreachable, the device deep link only pre-selected the runtime (the URL had to be typed into a now-deleted DOM field), and `Settings → Runtime → Remote` dead-ends by reloading into a conductor that can't capture a URL. The Android + iOS device lanes that drove the old flow were skipped.

## Approach — deep link + Settings, decoupled from the onboarding surface

Per the product decision, remote-connect becomes a first-class capability that does **not** depend on which onboarding surface is active, so it works today and survives future redesigns. Both entry points funnel through the existing, security-hardened `CONNECT_EVENT` path (`applyLaunchConnection` + `url-trust-policy`; a bearer token is **never** accepted from an OS-delivered deep link).

- **Deep link carries the URL** — `parseFirstRunRemoteConnectDeepLink` recognizes `<scheme>://first-run/runtime/remote?api=<url>` (pure parser; `api`/`apiBase`/`url`/`host` aliases) and routes it through `connectFirstRunRemoteDeepLink` in `main.tsx` (trust-policy gated) → `CONNECT_EVENT { completeFirstRun: true }`. A bare `…/remote` link still falls through to the existing runtime pre-select.
- **Headless `adopt-remote-first-run.ts`** — the reachable, reusable successor to `finishRemote`. PROBES the remote's `GET /api/first-run/status` and only `POST`s `/api/first-run` when the host hasn't finished its own first-run — an improvement over the legacy unconditional POST, which could clobber an already-configured host. `retryStartup()` re-polls → lands on home.
- **`CONNECT_EVENT` handler** gains `completeFirstRun` (adopt the remote) + `skipConfirm` (trusted in-app callers); OS deep links keep the non-loopback confirmation prompt.
- **Settings → Runtime → Remote** now opens a "Connect a remote agent" URL + optional-token form (reusing `SettingsRow`/`Input`/`SettingsActionButton`) that dispatches the same `CONNECT_EVENT { completeFirstRun, skipConfirm }`.
- **Device lanes un-quarantined + rewritten to the real OS deep link** — Android fires an `adb` VIEW intent; the iOS smoke fires `simctl openurl` and the in-app verifier proves the post-connect home surface (no onboarding DOM driven, so the lanes survive the in-chat redesign). Removed the now-dead iOS DOM-driver helpers + the harness skip-handling.

## Verification

- **Unit — 36 passed**: `deep-link-entry.test.ts` (parser: aliases, decoding, negative cases) + `adopt-remote-first-run.test.ts` (`normalizeRemoteAgentUrl` + adopt: fresh→POST, already-complete→no-clobber, unreachable→still-POST, failure→propagates, token forwarded).
- **No regressions** — `packages/ui` first-run + shell suite 143 passed; `packages/app` deep-link suite 19 passed.
- **Typecheck** — `packages/ui` + `packages/app` clean for every touched file (only the pre-existing, unmodified `steward-wallet-providers.tsx` viem error remains, identical on `develop`).
- **Device e2e (real deep link)** runs in CI / on device hardware — iOS via `mobile-build-smoke.yml` (`ios-onboarding-smoke.mjs`), Android via `test:e2e:android:onboarding`; both produce `home-landing.png` + `onboarding-to-home.mp4` + `result.json`.
- Full evidence + aesthetic review: [`.github/issue-evidence/10322-device-remote-connect-onboarding.md`](https://github.com/elizaOS/eliza/blob/shaw/frosty-elbakyan-54c6ef/.github/issue-evidence/10322-device-remote-connect-onboarding.md).
- **Trajectory / audio: N/A** — shell/first-run UX wiring, not an agent/model change (consistent with the #9952 evidence section).

## Notes / follow-up

- `finishRemote` (+ its remote helpers) in `first-run-finish.ts` is now superseded by `adopt-remote-first-run.ts` and remains unreachable; left in place to avoid touching freshly-landed #10302 internals — safe to delete in a follow-up.
- Biome could not run locally (worktree has `@biomejs/biome` 2.4.x; root config needs the pinned 2.5.0's `css.parser.tailwindDirectives`); CI runs 2.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)