### PR TITLE
chore(build): consolidate the pure-tsc plugins onto buildPlugin (#10078)

### DIFF
--- a/plugins/plugin-bluebubbles/build.ts
+++ b/plugins/plugin-bluebubbles/build.ts
@@ -1,34 +1,15 @@
-import { execSync, spawnSync } from "node:child_process";
-import { join } from "node:path";
+#!/usr/bin/env bun
+/**
+ * Build script for @elizaos/plugin-bluebubbles.
+ * tsc-only (non-bundled) plugin: no Bun.build step — the shared driver cleans
+ * dist then runs `tsc --project tsconfig.json --noCheck` via the empty-targets
+ * path.
+ */
+import { buildPlugin } from "../plugin-build";
 
-const distDir = join(import.meta.dirname, "dist");
-const rmRecursiveScript = join(
-	import.meta.dirname,
-	"..",
-	"..",
-	"packages",
-	"scripts",
-	"rm-path-recursive.mjs",
-);
-
-function rmRecursive(targetPath: string) {
-	const result = spawnSync(process.execPath, [rmRecursiveScript, targetPath], {
-		stdio: "inherit",
-	});
-	if (result.status !== 0) {
-		throw new Error(
-			`failed to remove generated BlueBubbles build output ${targetPath}`,
-		);
-	}
-}
-
-// Clean
-rmRecursive(distDir);
-
-// Build
-execSync("bunx tsc -p tsconfig.json --noCheck", {
-	cwd: import.meta.dirname,
-	stdio: "inherit",
+await buildPlugin({
+  name: "@elizaos/plugin-bluebubbles",
+  clean: true,
+  targets: [],
+  dtsProject: "tsconfig.json",
 });
-
-console.log("Build complete: plugin-bluebubbles");

--- a/plugins/plugin-google-chat/build.ts
+++ b/plugins/plugin-google-chat/build.ts
@@ -1,5 +1,13 @@
-import { execSync } from "node:child_process";
+#!/usr/bin/env bun
+/**
+ * Build script for @elizaos/plugin-google-chat.
+ * tsc-only (non-bundled) plugin: no Bun.build step — the shared driver runs
+ * `tsc --project tsconfig.json --noCheck` via the empty-targets path.
+ */
+import { buildPlugin } from "../plugin-build";
 
-console.log("Building Google Chat plugin (TypeScript)...");
-execSync("bunx tsc -p tsconfig.json --noCheck", { stdio: "inherit" });
-console.log("Build complete.");
+await buildPlugin({
+  name: "@elizaos/plugin-google-chat",
+  targets: [],
+  dtsProject: "tsconfig.json",
+});

--- a/plugins/plugin-google/build.ts
+++ b/plugins/plugin-google/build.ts
@@ -1,25 +1,15 @@
-import { execSync, spawnSync } from "node:child_process";
-import { join } from "node:path";
+#!/usr/bin/env bun
+/**
+ * Build script for @elizaos/plugin-google.
+ * tsc-only (non-bundled) plugin: no Bun.build step — the shared driver cleans
+ * dist then runs `tsc --project tsconfig.json --noCheck` via the empty-targets
+ * path.
+ */
+import { buildPlugin } from "../plugin-build";
 
-const rmRecursiveScript = join(
-  import.meta.dirname,
-  "..",
-  "..",
-  "packages",
-  "scripts",
-  "rm-path-recursive.mjs"
-);
-
-function rmRecursive(targetPath: string) {
-  const result = spawnSync(process.execPath, [rmRecursiveScript, targetPath], {
-    stdio: "inherit",
-  });
-  if (result.status !== 0) {
-    throw new Error(`failed to remove generated Google plugin build output ${targetPath}`);
-  }
-}
-
-console.log("Building Google plugin (TypeScript)...");
-rmRecursive("dist");
-execSync("bunx tsc -p tsconfig.json --noCheck", { stdio: "inherit" });
-console.log("Build complete.");
+await buildPlugin({
+  name: "@elizaos/plugin-google",
+  clean: true,
+  targets: [],
+  dtsProject: "tsconfig.json",
+});

--- a/plugins/plugin-imessage/build.ts
+++ b/plugins/plugin-imessage/build.ts
@@ -1,30 +1,15 @@
-import { execSync, spawnSync } from "node:child_process";
-import { join } from "node:path";
-import { fileURLToPath } from "node:url";
+#!/usr/bin/env bun
+/**
+ * Build script for @elizaos/plugin-imessage.
+ * tsc-only (non-bundled) plugin: no Bun.build step — the shared driver cleans
+ * dist then runs `tsc --project tsconfig.json --noCheck` via the empty-targets
+ * path.
+ */
+import { buildPlugin } from "../plugin-build";
 
-const distDir = join(import.meta.dirname, "dist");
-const RM_RECURSIVE_SCRIPT = fileURLToPath(
-  new URL("../../packages/scripts/rm-path-recursive.mjs", import.meta.url)
-);
-
-function rmRecursive(target: string) {
-  const result = spawnSync(process.execPath, [RM_RECURSIVE_SCRIPT, target], {
-    stdio: "inherit",
-  });
-  if (result.error) throw result.error;
-  if (result.status !== 0) {
-    throw new Error(`rm-path-recursive failed for ${target} with status ${result.status}`);
-  }
-}
-
-// Clean
-rmRecursive(distDir);
-
-// Build with Bun's bundled TypeScript runner so Windows CI does not fall back
-// to the unrelated `tsc` npm package via `npx`.
-execSync("bun x tsc -p tsconfig.json --noCheck", {
-  cwd: import.meta.dirname,
-  stdio: "inherit",
+await buildPlugin({
+  name: "@elizaos/plugin-imessage",
+  clean: true,
+  targets: [],
+  dtsProject: "tsconfig.json",
 });
-
-console.log("Build complete: plugin-imessage");

--- a/plugins/plugin-line/build.ts
+++ b/plugins/plugin-line/build.ts
@@ -1,29 +1,15 @@
-import { execSync, spawnSync } from "node:child_process";
-import { join } from "node:path";
-import { fileURLToPath } from "node:url";
+#!/usr/bin/env bun
+/**
+ * Build script for @elizaos/plugin-line.
+ * tsc-only (non-bundled) plugin: no Bun.build step — the shared driver cleans
+ * dist then runs `tsc --project tsconfig.json --noCheck` via the empty-targets
+ * path.
+ */
+import { buildPlugin } from "../plugin-build";
 
-const distDir = join(import.meta.dirname, "dist");
-const RM_RECURSIVE_SCRIPT = fileURLToPath(
-  new URL("../../packages/scripts/rm-path-recursive.mjs", import.meta.url)
-);
-
-function rmRecursive(target: string) {
-  const result = spawnSync(process.execPath, [RM_RECURSIVE_SCRIPT, target], {
-    stdio: "inherit",
-  });
-  if (result.error) throw result.error;
-  if (result.status !== 0) {
-    throw new Error(`rm-path-recursive failed for ${target} with status ${result.status}`);
-  }
-}
-
-// Clean
-rmRecursive(distDir);
-
-// Build
-execSync("bunx tsc -p tsconfig.json --noCheck", {
-  cwd: import.meta.dirname,
-  stdio: "inherit",
+await buildPlugin({
+  name: "@elizaos/plugin-line",
+  clean: true,
+  targets: [],
+  dtsProject: "tsconfig.json",
 });
-
-console.log("Build complete: plugin-line");

--- a/plugins/plugin-nostr/build.ts
+++ b/plugins/plugin-nostr/build.ts
@@ -1,5 +1,13 @@
-import { execSync } from "node:child_process";
+#!/usr/bin/env bun
+/**
+ * Build script for @elizaos/plugin-nostr.
+ * tsc-only (non-bundled) plugin: no Bun.build step — the shared driver runs
+ * `tsc --project tsconfig.json --noCheck` via the empty-targets path.
+ */
+import { buildPlugin } from "../plugin-build";
 
-console.log("Building Nostr plugin (TypeScript)...");
-execSync("bunx tsc -p tsconfig.json --noCheck", { stdio: "inherit" });
-console.log("Build complete.");
+await buildPlugin({
+  name: "@elizaos/plugin-nostr",
+  targets: [],
+  dtsProject: "tsconfig.json",
+});


### PR DESCRIPTION
Continues **#10078** ("consolidate ~58 build.ts onto one helper") into the **pure-tsc** cohort — plugins whose `build.ts` just runs `tsc -p tsconfig.json --noCheck` (optionally after an rm-recursive clean), with no `Bun.build`. These weren't bundlers, but they're still hand-rolled build orchestration the shared driver can own — **byte-identically**.

The driver already supports this with **no change**: `buildPlugin({ name, clean, targets: [], dtsProject: "tsconfig.json" })` → the empty `targets` loop is a no-op and the `dtsProject` step (non-emitDeclarationOnly) runs `tsc --project tsconfig.json --noCheck`, identical to the originals (`-p` ≡ `--project`; both resolve the same workspace `tsc`).

| plugin | dist files | clean |
|---|---|---|
| plugin-nostr | 28 | no |
| plugin-google-chat | 36 | no |
| plugin-google | 56 | yes |
| plugin-bluebubbles | 56 | yes |
| plugin-imessage | 56 | yes |
| plugin-line | 36 | yes |

All six **byte-identical** (sorted per-file sha256, original vs migrated; nostr verified deterministic across 2 builds). `bun run build` exit 0; each shim typechecks. Net **−42 lines**.

`plugin-todos` was attempted and **skipped** — its `build.ts` turned out to be a `Bun.build` dev-only script; its production `build` is `tsup + vite + tsc`, so the empty-targets pure-tsc form doesn't apply.

With this, **zero pure-tsc holdouts remain** — every plugin that builds via `tsc`-only or `Bun.build` is now (or is in-flight to be) on the shared driver. The only off-driver builds left are native (`local-inference`) and a separate **tsup/vite** cohort (`commands`/`todos`/github/music/… — a different bundler, not byte-identical-migratable). Refs #10078.

🤖 Generated with [Claude Code](https://claude.com/claude-code)