### PR TITLE
test(ui): drop dead window test-hooks from bottom-bar fixture (#9953 follow-up)

### DIFF
--- a/packages/ui/src/components/shell/__e2e__/bottombar-fixture.tsx
+++ b/packages/ui/src/components/shell/__e2e__/bottombar-fixture.tsx
@@ -81,24 +81,6 @@ function BottomBarShell() {
     setTimeout(() => setVisionActive(false), 1200);
   }, [send]);
 
-  // Test hooks so the runner can force a state deterministically (same typed
-  // `window as {…}` idiom the sibling chat-sheet fixture uses).
-  React.useEffect(() => {
-    const w = window as {
-      __setPhase?: (p: ShellPhase) => void;
-      __setRecording?: (r: boolean) => void;
-      __captureVision?: () => void;
-    };
-    w.__setPhase = (p) => setPhase(p);
-    w.__setRecording = (r) => setRecording(r);
-    w.__captureVision = () => captureVision();
-    return () => {
-      w.__setPhase = undefined;
-      w.__setRecording = undefined;
-      w.__captureVision = undefined;
-    };
-  }, [captureVision]);
-
   return (
     <>
       {/* Desktop-like wallpaper behind the transparent chromeless bar, so the


### PR DESCRIPTION
Follow-up to #10352 (merged). The bottom-bar e2e runner drives the bar entirely through real DOM interaction — `HomePill` click, input fill/Enter, VISION button by role, Escape — so the `window.__setPhase`/`__setRecording`/`__captureVision` hooks it never calls were dead code, and the comment claiming "the runner can force a state" was misleading. Removing them also drops a needless `window as {…}` type-assertion.

The e2e lane still passes (13/13) after the removal (re-run locally on Windows under Node). No behavior or evidence change.

Follow-up to #9953.