### PR TITLE
test: require packaged desktop voice evidence for #9958

### DIFF
--- a/.github/issue-evidence/9958-voice-matrix-android-native-bridge/index.html
+++ b/.github/issue-evidence/9958-voice-matrix-android-native-bridge/index.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Voice Live Matrix</title>
+<style>
+body{font-family:system-ui,-apple-system,Segoe UI,sans-serif;margin:24px;background:#fafafa;color:#151515}
+table{width:100%;border-collapse:collapse;background:white}
+th,td{border:1px solid #ddd;padding:8px;vertical-align:top;white-space:pre-wrap}
+th{background:#f1f1f1;text-align:left}
+.pass td:nth-child(2){color:#116b2d;font-weight:700}
+.fail td:nth-child(2){color:#9a1b1b;font-weight:700}
+.skip td:nth-child(2),.pending td:nth-child(2){color:#7a5b00;font-weight:700}
+code{font-size:12px}
+</style>
+<h1>Voice Live Matrix</h1>
+<p>Generated 2026-06-30T03:13:49.083Z on darwin arm64 (Shaws-MacBook-Pro.local).</p>
+<p>Pass 2 · Fail 0 · Pending 0 · Skip 2</p>
+<table><thead><tr><th>Cell</th><th>Status</th><th>Platform</th><th>Class</th><th>Dimensions</th><th>Probe / Result</th><th>Command</th><th>Evidence</th></tr></thead><tbody><tr class="skip"><td><code>android.device.voice-roundtrip</code><br>Android device WebView real on-device STT -&gt; agent -&gt; TTS voice self-test</td><td>skip</td><td>android</td><td>mobile-live-voice</td><td>transcriptionState=off
+chimeIn=should-respond
+wakewordContext=idle-wake
+noiseRejection=quiet
+voices=owner</td><td>set ELIZA_VOICE_ANDROID_READY=1 on an Android device runner with the current APK and voice assets installed</td><td><code>bun run --cwd packages/app test:e2e:android:local</code></td><td>packages/app/test-results
+.github/issue-evidence</td></tr>
+<tr class="pass"><td><code>android.talkmode.native-bridge</code><br>TalkMode Android capture lifecycle, transcript, permission, and barge-in bridge contracts</td><td>pass</td><td>android</td><td>native-bridge-unit</td><td>transcriptionState=off
+chimeIn=should-respond
+wakewordContext=already-listening-wake-inert
+noiseRejection=echo-self-voice
+voices=owner</td><td>command passed (2026-06-30T03:13:48.408Z)</td><td><code>./gradlew -p ../../../scripts/android-voice-bridge-gradle :elizaos-capacitor-talkmode:testDebugUnitTest</code></td><td>plugins/plugin-native-talkmode/android/src/test/java</td></tr>
+<tr class="pass"><td><code>android.swabble.native-bridge</code><br>Swabble Android wake-firing -&gt; JS bridge event contract</td><td>pass</td><td>android</td><td>native-bridge-unit</td><td>transcriptionState=off
+chimeIn=should-respond
+wakewordContext=idle-wake
+noiseRejection=quiet
+voices=owner</td><td>command passed (2026-06-30T03:13:49.078Z)</td><td><code>./gradlew -p ../../../scripts/android-voice-bridge-gradle :elizaos-capacitor-swabble:testDebugUnitTest</code></td><td>plugins/plugin-native-swabble/android/src/test/java</td></tr>
+<tr class="skip"><td><code>stt.stage-b.evaluation</code><br>Stage-B STT evaluation: iOS SFSpeechRecognizer vs Android SpeechRecognizer vs fused ASR</td><td>skip</td><td>android</td><td>stt-evaluation</td><td>transcriptionState=on
+chimeIn=should-respond
+wakewordContext=idle-wake
+noiseRejection=noisy-reverberant
+voices=multi-speaker</td><td>Stage-B STT battery/latency evaluation needs paired iOS+Android device runners and power telemetry</td><td><code>bun packages/scripts/voice-matrix.mjs --stage-b-eval-placeholder</code></td><td>.github/issue-evidence/9147-voice-asr-m4max.md</td></tr></tbody></table>

--- a/.github/issue-evidence/9958-voice-matrix-android-native-bridge/voice-matrix.json
+++ b/.github/issue-evidence/9958-voice-matrix-android-native-bridge/voice-matrix.json
@@ -1,0 +1,191 @@
+{
+  "schema": "eliza_voice_live_matrix_v1",
+  "issue": 9958,
+  "generatedAt": "2026-06-30T03:13:49.083Z",
+  "mode": "run",
+  "dimensions": {
+    "platform": [
+      "web",
+      "linux",
+      "macos-electrobun",
+      "windows-electrobun",
+      "ios",
+      "android"
+    ],
+    "transcriptionState": [
+      "off",
+      "on"
+    ],
+    "chimeIn": [
+      "should-respond",
+      "should-not-respond"
+    ],
+    "wakewordContext": [
+      "idle-wake",
+      "already-listening-wake-inert",
+      "mid-transcription-wake"
+    ],
+    "noiseRejection": [
+      "quiet",
+      "noisy-reverberant",
+      "echo-self-voice",
+      "overlapping-speech"
+    ],
+    "voices": [
+      "owner",
+      "enrolled-contact",
+      "unknown",
+      "multi-speaker"
+    ]
+  },
+  "host": {
+    "platform": "darwin",
+    "arch": "arm64",
+    "hostname": "Shaws-MacBook-Pro.local",
+    "runnerOs": null,
+    "runnerArch": null
+  },
+  "summary": {
+    "pass": 2,
+    "fail": 0,
+    "pending": 0,
+    "skip": 2
+  },
+  "cells": [
+    {
+      "id": "android.device.voice-roundtrip",
+      "title": "Android device WebView real on-device STT -> agent -> TTS voice self-test",
+      "platform": "android",
+      "dimensions": {
+        "transcriptionState": "off",
+        "chimeIn": "should-respond",
+        "wakewordContext": "idle-wake",
+        "noiseRejection": "quiet",
+        "voices": "owner"
+      },
+      "class": "mobile-live-voice",
+      "command": [
+        "bun",
+        "run",
+        "--cwd",
+        "packages/app",
+        "test:e2e:android:local"
+      ],
+      "evidence": [
+        "packages/app/test-results",
+        ".github/issue-evidence"
+      ],
+      "probe": {
+        "available": false,
+        "reason": "set ELIZA_VOICE_ANDROID_READY=1 on an Android device runner with the current APK and voice assets installed"
+      },
+      "cwd": ".",
+      "env": {},
+      "execution": null,
+      "status": "skip"
+    },
+    {
+      "id": "android.talkmode.native-bridge",
+      "title": "TalkMode Android capture lifecycle, transcript, permission, and barge-in bridge contracts",
+      "platform": "android",
+      "dimensions": {
+        "transcriptionState": "off",
+        "chimeIn": "should-respond",
+        "wakewordContext": "already-listening-wake-inert",
+        "noiseRejection": "echo-self-voice",
+        "voices": "owner"
+      },
+      "class": "native-bridge-unit",
+      "command": [
+        "./gradlew",
+        "-p",
+        "../../../scripts/android-voice-bridge-gradle",
+        ":elizaos-capacitor-talkmode:testDebugUnitTest"
+      ],
+      "cwd": "packages/app-core/platforms/android",
+      "evidence": [
+        "plugins/plugin-native-talkmode/android/src/test/java"
+      ],
+      "probe": {
+        "available": true,
+        "reason": "command passed (2026-06-30T03:13:48.408Z)"
+      },
+      "env": {},
+      "execution": {
+        "exitCode": 0,
+        "signal": null,
+        "startedAt": "2026-06-30T03:13:47.502Z",
+        "finishedAt": "2026-06-30T03:13:48.408Z",
+        "stdoutTail": "> Task :capacitor-android:preBuild UP-TO-DATE\n> Task :capacitor-android:preDebugBuild UP-TO-DATE\n> Task :capacitor-android:generateDebugResValues UP-TO-DATE\n> Task :capacitor-android:generateDebugResources UP-TO-DATE\n> Task :capacitor-android:packageDebugResources UP-TO-DATE\n> Task :capacitor-android:processDebugNavigationResources UP-TO-DATE\n> Task :capacitor-android:parseDebugLocalResources UP-TO-DATE\n> Task :capacitor-android:generateDebugRFile UP-TO-DATE\n> Task :capacitor-android:javaPreCompileDebug UP-TO-DATE\n> Task :capacitor-android:compileDebugJavaWithJavac UP-TO-DATE\n> Task :capacitor-android:bundleLibRuntimeToJarDebug UP-TO-DATE\n> Task :capacitor-android:processDebugJavaRes NO-SOURCE\n> Task :capacitor-android:bundleLibCompileToJarDebug UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:checkKotlinGradlePluginConfigurationErrors SKIPPED\n> Task :elizaos-capacitor-talkmode:preBuild UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:preDebugBuild UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:generateDebugResValues UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:generateDebugResources UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:packageDebugResources UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:processDebugNavigationResources UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:parseDebugLocalResources UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:generateDebugRFile UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:compileDebugKotlin UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:javaPreCompileDebug UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:compileDebugJavaWithJavac NO-SOURCE\n> Task :elizaos-capacitor-talkmode:bundleLibRuntimeToJarDebug UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:bundleLibCompileToJarDebug UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:preDebugUnitTestBuild UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:generateDebugUnitTestStubRFile UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:compileDebugUnitTestKotlin UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:javaPreCompileDebugUnitTest UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:compileDebugUnitTestJavaWithJavac NO-SOURCE\n> Task :elizaos-capacitor-talkmode:processDebugJavaRes UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:processDebugUnitTestJavaRes UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:testDebugUnitTest UP-TO-DATE\n\n[Incubating] Problems report is available at: file:///Users/shawwalters/.codex/worktrees/740a/eliza/packages/scripts/android-voice-bridge-gradle/build/reports/problems/problems-report.html\n\nDeprecated Gradle features were used in this build, making it incompatible with Gradle 10.\n\nYou can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.\n\nFor more on this, please refer to https://docs.gradle.org/9.5.0/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.\n\nBUILD SUCCESSFUL in 838ms\n26 actionable tasks: 26 up-to-date\nConsider enabling configuration cache to speed up this build: https://docs.gradle.org/9.5.0/userguide/configuration_cache_enabling.html\n",
+        "stderrTail": ""
+      },
+      "status": "pass"
+    },
+    {
+      "id": "android.swabble.native-bridge",
+      "title": "Swabble Android wake-firing -> JS bridge event contract",
+      "platform": "android",
+      "dimensions": {
+        "transcriptionState": "off",
+        "chimeIn": "should-respond",
+        "wakewordContext": "idle-wake",
+        "noiseRejection": "quiet",
+        "voices": "owner"
+      },
+      "class": "native-bridge-unit",
+      "command": [
+        "./gradlew",
+        "-p",
+        "../../../scripts/android-voice-bridge-gradle",
+        ":elizaos-capacitor-swabble:testDebugUnitTest"
+      ],
+      "cwd": "packages/app-core/platforms/android",
+      "evidence": [
+        "plugins/plugin-native-swabble/android/src/test/java"
+      ],
+      "probe": {
+        "available": true,
+        "reason": "command passed (2026-06-30T03:13:49.078Z)"
+      },
+      "env": {},
+      "execution": {
+        "exitCode": 0,
+        "signal": null,
+        "startedAt": "2026-06-30T03:13:48.413Z",
+        "finishedAt": "2026-06-30T03:13:49.078Z",
+        "stdoutTail": "> Task :capacitor-android:preBuild UP-TO-DATE\n> Task :capacitor-android:preDebugBuild UP-TO-DATE\n> Task :capacitor-android:generateDebugResValues UP-TO-DATE\n> Task :capacitor-android:generateDebugResources UP-TO-DATE\n> Task :capacitor-android:packageDebugResources UP-TO-DATE\n> Task :capacitor-android:processDebugNavigationResources UP-TO-DATE\n> Task :capacitor-android:parseDebugLocalResources UP-TO-DATE\n> Task :capacitor-android:generateDebugRFile UP-TO-DATE\n> Task :capacitor-android:javaPreCompileDebug UP-TO-DATE\n> Task :capacitor-android:compileDebugJavaWithJavac UP-TO-DATE\n> Task :capacitor-android:bundleLibRuntimeToJarDebug UP-TO-DATE\n> Task :capacitor-android:processDebugJavaRes NO-SOURCE\n> Task :capacitor-android:bundleLibCompileToJarDebug UP-TO-DATE\n> Task :elizaos-capacitor-swabble:checkKotlinGradlePluginConfigurationErrors SKIPPED\n> Task :elizaos-capacitor-swabble:preBuild UP-TO-DATE\n> Task :elizaos-capacitor-swabble:preDebugBuild UP-TO-DATE\n> Task :elizaos-capacitor-swabble:generateDebugResValues UP-TO-DATE\n> Task :elizaos-capacitor-swabble:generateDebugResources UP-TO-DATE\n> Task :elizaos-capacitor-swabble:packageDebugResources UP-TO-DATE\n> Task :elizaos-capacitor-swabble:processDebugNavigationResources UP-TO-DATE\n> Task :elizaos-capacitor-swabble:parseDebugLocalResources UP-TO-DATE\n> Task :elizaos-capacitor-swabble:generateDebugRFile UP-TO-DATE\n> Task :elizaos-capacitor-swabble:compileDebugKotlin UP-TO-DATE\n> Task :elizaos-capacitor-swabble:javaPreCompileDebug UP-TO-DATE\n> Task :elizaos-capacitor-swabble:compileDebugJavaWithJavac NO-SOURCE\n> Task :elizaos-capacitor-swabble:bundleLibRuntimeToJarDebug UP-TO-DATE\n> Task :elizaos-capacitor-swabble:bundleLibCompileToJarDebug UP-TO-DATE\n> Task :elizaos-capacitor-swabble:preDebugUnitTestBuild UP-TO-DATE\n> Task :elizaos-capacitor-swabble:generateDebugUnitTestStubRFile UP-TO-DATE\n> Task :elizaos-capacitor-swabble:compileDebugUnitTestKotlin UP-TO-DATE\n> Task :elizaos-capacitor-swabble:javaPreCompileDebugUnitTest UP-TO-DATE\n> Task :elizaos-capacitor-swabble:compileDebugUnitTestJavaWithJavac NO-SOURCE\n> Task :elizaos-capacitor-swabble:processDebugJavaRes UP-TO-DATE\n> Task :elizaos-capacitor-swabble:processDebugUnitTestJavaRes UP-TO-DATE\n> Task :elizaos-capacitor-swabble:testDebugUnitTest UP-TO-DATE\n\n[Incubating] Problems report is available at: file:///Users/shawwalters/.codex/worktrees/740a/eliza/packages/scripts/android-voice-bridge-gradle/build/reports/problems/problems-report.html\n\nDeprecated Gradle features were used in this build, making it incompatible with Gradle 10.\n\nYou can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.\n\nFor more on this, please refer to https://docs.gradle.org/9.5.0/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.\n\nBUILD SUCCESSFUL in 611ms\n26 actionable tasks: 26 up-to-date\nConsider enabling configuration cache to speed up this build: https://docs.gradle.org/9.5.0/userguide/configuration_cache_enabling.html\n",
+        "stderrTail": ""
+      },
+      "status": "pass"
+    },
+    {
+      "id": "stt.stage-b.evaluation",
+      "title": "Stage-B STT evaluation: iOS SFSpeechRecognizer vs Android SpeechRecognizer vs fused ASR",
+      "platform": "android",
+      "dimensions": {
+        "transcriptionState": "on",
+        "chimeIn": "should-respond",
+        "wakewordContext": "idle-wake",
+        "noiseRejection": "noisy-reverberant",
+        "voices": "multi-speaker"
+      },
+      "class": "stt-evaluation",
+      "command": [
+        "bun",
+        "packages/scripts/voice-matrix.mjs",
+        "--stage-b-eval-placeholder"
+      ],
+      "evidence": [
+        ".github/issue-evidence/9147-voice-asr-m4max.md"
+      ],
+      "probe": {
+        "available": false,
+        "reason": "Stage-B STT battery/latency evaluation needs paired iOS+Android device runners and power telemetry"
+      },
+      "cwd": ".",
+      "env": {},
+      "execution": null,
+      "status": "skip"
+    }
+  ]
+}

--- a/.github/issue-evidence/9958-voice-matrix-android-native-bridge/voice-matrix.md
+++ b/.github/issue-evidence/9958-voice-matrix-android-native-bridge/voice-matrix.md
@@ -1,0 +1,20 @@
+# Voice Live Matrix
+
+Generated: 2026-06-30T03:13:49.083Z
+Host: darwin arm64 (Shaws-MacBook-Pro.local)
+
+| Cell | Status | Platform | Class | Probe / Result | Command |
+|---|---:|---|---|---|---|
+| `android.device.voice-roundtrip` | skip | android | mobile-live-voice | set ELIZA_VOICE_ANDROID_READY=1 on an Android device runner with the current APK and voice assets installed | `bun run --cwd packages/app test:e2e:android:local` |
+| `android.talkmode.native-bridge` | pass | android | native-bridge-unit | command passed (2026-06-30T03:13:48.408Z) | `./gradlew -p ../../../scripts/android-voice-bridge-gradle :elizaos-capacitor-talkmode:testDebugUnitTest` |
+| `android.swabble.native-bridge` | pass | android | native-bridge-unit | command passed (2026-06-30T03:13:49.078Z) | `./gradlew -p ../../../scripts/android-voice-bridge-gradle :elizaos-capacitor-swabble:testDebugUnitTest` |
+| `stt.stage-b.evaluation` | skip | android | stt-evaluation | Stage-B STT battery/latency evaluation needs paired iOS+Android device runners and power telemetry | `bun packages/scripts/voice-matrix.mjs --stage-b-eval-placeholder` |
+
+## Summary
+
+- Pass: 2
+- Fail: 0
+- Pending: 0
+- Skip: 2
+
+Hardware-unavailable cells are explicit `skip` rows. They are not evidence of platform coverage.

--- a/.github/issue-evidence/9958-voice-matrix-desktop-gated-probe/index.html
+++ b/.github/issue-evidence/9958-voice-matrix-desktop-gated-probe/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Voice Live Matrix</title>
+<style>
+body{font-family:system-ui,-apple-system,Segoe UI,sans-serif;margin:24px;background:#fafafa;color:#151515}
+table{width:100%;border-collapse:collapse;background:white}
+th,td{border:1px solid #ddd;padding:8px;vertical-align:top;white-space:pre-wrap}
+th{background:#f1f1f1;text-align:left}
+.pass td:nth-child(2){color:#116b2d;font-weight:700}
+.fail td:nth-child(2){color:#9a1b1b;font-weight:700}
+.skip td:nth-child(2),.pending td:nth-child(2){color:#7a5b00;font-weight:700}
+code{font-size:12px}
+</style>
+<h1>Voice Live Matrix</h1>
+<p>Generated 2026-06-30T01:40:00.782Z on darwin arm64 (Shaws-MacBook-Pro.local).</p>
+<p>Pass 0 · Fail 0 · Pending 0 · Skip 1</p>
+<table><thead><tr><th>Cell</th><th>Status</th><th>Platform</th><th>Class</th><th>Dimensions</th><th>Probe / Result</th><th>Command</th><th>Evidence</th></tr></thead><tbody><tr class="skip"><td><code>macos.electrobun.live-roundtrip</code><br>macOS Electrobun live mic -&gt; ASR -&gt; agent -&gt; Kokoro -&gt; speaker loop</td><td>skip</td><td>macos-electrobun</td><td>desktop-live-voice</td><td>transcriptionState=off
+chimeIn=should-respond
+wakewordContext=idle-wake
+noiseRejection=quiet
+voices=owner</td><td>ELIZA_VOICE_DESKTOP_API_BASE is not set to a real app-core API base</td><td><code>bun run --cwd packages/app test:desktop:voice</code></td><td>$ELIZA_VOICE_MATRIX_OUT/macos.electrobun.live-roundtrip
+packages/app/test-results</td></tr></tbody></table>

--- a/.github/issue-evidence/9958-voice-matrix-desktop-gated-probe/voice-matrix.json
+++ b/.github/issue-evidence/9958-voice-matrix-desktop-gated-probe/voice-matrix.json
@@ -1,0 +1,90 @@
+{
+  "schema": "eliza_voice_live_matrix_v1",
+  "issue": 9958,
+  "generatedAt": "2026-06-30T01:40:00.782Z",
+  "mode": "probe",
+  "dimensions": {
+    "platform": [
+      "web",
+      "linux",
+      "macos-electrobun",
+      "windows-electrobun",
+      "ios",
+      "android"
+    ],
+    "transcriptionState": [
+      "off",
+      "on"
+    ],
+    "chimeIn": [
+      "should-respond",
+      "should-not-respond"
+    ],
+    "wakewordContext": [
+      "idle-wake",
+      "already-listening-wake-inert",
+      "mid-transcription-wake"
+    ],
+    "noiseRejection": [
+      "quiet",
+      "noisy-reverberant",
+      "echo-self-voice",
+      "overlapping-speech"
+    ],
+    "voices": [
+      "owner",
+      "enrolled-contact",
+      "unknown",
+      "multi-speaker"
+    ]
+  },
+  "host": {
+    "platform": "darwin",
+    "arch": "arm64",
+    "hostname": "Shaws-MacBook-Pro.local",
+    "runnerOs": null,
+    "runnerArch": null
+  },
+  "summary": {
+    "pass": 0,
+    "fail": 0,
+    "pending": 0,
+    "skip": 1
+  },
+  "cells": [
+    {
+      "id": "macos.electrobun.live-roundtrip",
+      "title": "macOS Electrobun live mic -> ASR -> agent -> Kokoro -> speaker loop",
+      "platform": "macos-electrobun",
+      "dimensions": {
+        "transcriptionState": "off",
+        "chimeIn": "should-respond",
+        "wakewordContext": "idle-wake",
+        "noiseRejection": "quiet",
+        "voices": "owner"
+      },
+      "class": "desktop-live-voice",
+      "command": [
+        "bun",
+        "run",
+        "--cwd",
+        "packages/app",
+        "test:desktop:voice"
+      ],
+      "env": {
+        "ELIZA_VOICE_DESKTOP_SELFTEST": "1"
+      },
+      "evidence": [
+        "$ELIZA_VOICE_MATRIX_OUT/macos.electrobun.live-roundtrip",
+        "packages/app/test-results"
+      ],
+      "probe": {
+        "available": false,
+        "reason": "ELIZA_VOICE_DESKTOP_API_BASE is not set to a real app-core API base"
+      },
+      "cwd": ".",
+      "execution": null,
+      "status": "skip"
+    }
+  ]
+}

--- a/.github/issue-evidence/9958-voice-matrix-desktop-gated-probe/voice-matrix.md
+++ b/.github/issue-evidence/9958-voice-matrix-desktop-gated-probe/voice-matrix.md
@@ -1,0 +1,17 @@
+# Voice Live Matrix
+
+Generated: 2026-06-30T01:40:00.782Z
+Host: darwin arm64 (Shaws-MacBook-Pro.local)
+
+| Cell | Status | Platform | Class | Probe / Result | Command |
+|---|---:|---|---|---|---|
+| `macos.electrobun.live-roundtrip` | skip | macos-electrobun | desktop-live-voice | ELIZA_VOICE_DESKTOP_API_BASE is not set to a real app-core API base | `bun run --cwd packages/app test:desktop:voice` |
+
+## Summary
+
+- Pass: 0
+- Fail: 0
+- Pending: 0
+- Skip: 1
+
+Hardware-unavailable cells are explicit `skip` rows. They are not evidence of platform coverage.

--- a/.github/issue-evidence/9958-voice-matrix-ios-native-bridge/index.html
+++ b/.github/issue-evidence/9958-voice-matrix-ios-native-bridge/index.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Voice Live Matrix</title>
+<style>
+body{font-family:system-ui,-apple-system,Segoe UI,sans-serif;margin:24px;background:#fafafa;color:#151515}
+table{width:100%;border-collapse:collapse;background:white}
+th,td{border:1px solid #ddd;padding:8px;vertical-align:top;white-space:pre-wrap}
+th{background:#f1f1f1;text-align:left}
+.pass td:nth-child(2){color:#116b2d;font-weight:700}
+.fail td:nth-child(2){color:#9a1b1b;font-weight:700}
+.skip td:nth-child(2),.pending td:nth-child(2){color:#7a5b00;font-weight:700}
+code{font-size:12px}
+</style>
+<h1>Voice Live Matrix</h1>
+<p>Generated 2026-06-30T03:21:17.101Z on darwin arm64 (Shaws-MacBook-Pro.local).</p>
+<p>Pass 2 · Fail 0 · Pending 0 · Skip 1</p>
+<table><thead><tr><th>Cell</th><th>Status</th><th>Platform</th><th>Class</th><th>Dimensions</th><th>Probe / Result</th><th>Command</th><th>Evidence</th></tr></thead><tbody><tr class="skip"><td><code>ios.sim-or-device.voice-roundtrip</code><br>iOS simulator/device voice self-test and capture evidence</td><td>skip</td><td>ios</td><td>mobile-live-voice</td><td>transcriptionState=off
+chimeIn=should-respond
+wakewordContext=idle-wake
+noiseRejection=quiet
+voices=owner</td><td>set ELIZA_VOICE_IOS_READY=1 after installing a current iOS simulator/device build with voice assets</td><td><code>bun run --cwd packages/app capture:ios-sim -- --issue 9958 --slug voice-ios</code></td><td>.github/issue-evidence/9958-voice-ios-ios-sim.*</td></tr>
+<tr class="pass"><td><code>ios.talkmode.native-bridge</code><br>TalkMode iOS transcript, permission, state, and barge-in bridge contracts</td><td>pass</td><td>ios</td><td>native-bridge-unit</td><td>transcriptionState=off
+chimeIn=should-respond
+wakewordContext=already-listening-wake-inert
+noiseRejection=echo-self-voice
+voices=owner</td><td>command passed (2026-06-30T03:21:16.355Z)</td><td><code>swift test --disable-index-store --package-path plugins/plugin-native-talkmode/ios</code></td><td>plugins/plugin-native-talkmode/ios/Tests</td></tr>
+<tr class="pass"><td><code>ios.swabble.native-bridge</code><br>Swabble iOS wake-firing -&gt; JS bridge event contract</td><td>pass</td><td>ios</td><td>native-bridge-unit</td><td>transcriptionState=off
+chimeIn=should-respond
+wakewordContext=idle-wake
+noiseRejection=quiet
+voices=owner</td><td>command passed (2026-06-30T03:21:17.101Z)</td><td><code>swift test --disable-index-store --package-path plugins/plugin-native-swabble/ios</code></td><td>plugins/plugin-native-swabble/ios/Tests</td></tr></tbody></table>

--- a/.github/issue-evidence/9958-voice-matrix-ios-native-bridge/voice-matrix.json
+++ b/.github/issue-evidence/9958-voice-matrix-ios-native-bridge/voice-matrix.json
@@ -1,0 +1,168 @@
+{
+  "schema": "eliza_voice_live_matrix_v1",
+  "issue": 9958,
+  "generatedAt": "2026-06-30T03:21:17.101Z",
+  "mode": "run",
+  "dimensions": {
+    "platform": [
+      "web",
+      "linux",
+      "macos-electrobun",
+      "windows-electrobun",
+      "ios",
+      "android"
+    ],
+    "transcriptionState": [
+      "off",
+      "on"
+    ],
+    "chimeIn": [
+      "should-respond",
+      "should-not-respond"
+    ],
+    "wakewordContext": [
+      "idle-wake",
+      "already-listening-wake-inert",
+      "mid-transcription-wake"
+    ],
+    "noiseRejection": [
+      "quiet",
+      "noisy-reverberant",
+      "echo-self-voice",
+      "overlapping-speech"
+    ],
+    "voices": [
+      "owner",
+      "enrolled-contact",
+      "unknown",
+      "multi-speaker"
+    ]
+  },
+  "host": {
+    "platform": "darwin",
+    "arch": "arm64",
+    "hostname": "Shaws-MacBook-Pro.local",
+    "runnerOs": null,
+    "runnerArch": null
+  },
+  "summary": {
+    "pass": 2,
+    "fail": 0,
+    "pending": 0,
+    "skip": 1
+  },
+  "cells": [
+    {
+      "id": "ios.sim-or-device.voice-roundtrip",
+      "title": "iOS simulator/device voice self-test and capture evidence",
+      "platform": "ios",
+      "dimensions": {
+        "transcriptionState": "off",
+        "chimeIn": "should-respond",
+        "wakewordContext": "idle-wake",
+        "noiseRejection": "quiet",
+        "voices": "owner"
+      },
+      "class": "mobile-live-voice",
+      "command": [
+        "bun",
+        "run",
+        "--cwd",
+        "packages/app",
+        "capture:ios-sim",
+        "--",
+        "--issue",
+        "9958",
+        "--slug",
+        "voice-ios"
+      ],
+      "evidence": [
+        ".github/issue-evidence/9958-voice-ios-ios-sim.*"
+      ],
+      "probe": {
+        "available": false,
+        "reason": "set ELIZA_VOICE_IOS_READY=1 after installing a current iOS simulator/device build with voice assets"
+      },
+      "cwd": ".",
+      "env": {},
+      "execution": null,
+      "status": "skip"
+    },
+    {
+      "id": "ios.talkmode.native-bridge",
+      "title": "TalkMode iOS transcript, permission, state, and barge-in bridge contracts",
+      "platform": "ios",
+      "dimensions": {
+        "transcriptionState": "off",
+        "chimeIn": "should-respond",
+        "wakewordContext": "already-listening-wake-inert",
+        "noiseRejection": "echo-self-voice",
+        "voices": "owner"
+      },
+      "class": "native-bridge-unit",
+      "command": [
+        "swift",
+        "test",
+        "--disable-index-store",
+        "--package-path",
+        "plugins/plugin-native-talkmode/ios"
+      ],
+      "evidence": [
+        "plugins/plugin-native-talkmode/ios/Tests"
+      ],
+      "probe": {
+        "available": true,
+        "reason": "command passed (2026-06-30T03:21:16.355Z)"
+      },
+      "cwd": ".",
+      "env": {},
+      "execution": {
+        "exitCode": 0,
+        "signal": null,
+        "startedAt": "2026-06-30T03:21:15.424Z",
+        "finishedAt": "2026-06-30T03:21:16.355Z",
+        "stdoutTail": "Test Suite 'All tests' started at 2026-06-29 23:21:16.310.\nTest Suite 'ElizaosCapacitorTalkModeIOSContractsPackageTests.xctest' started at 2026-06-29 23:21:16.311.\nTest Suite 'TalkModeBridgeContractTests' started at 2026-06-29 23:21:16.311.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testBargeInInterruptIgnoresShortBlipsAndSelfEcho]' started.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testBargeInInterruptIgnoresShortBlipsAndSelfEcho]' passed (0.001 seconds).\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testStateAndPermissionPayloads]' started.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testStateAndPermissionPayloads]' passed (0.000 seconds).\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testTranscriptPayloadPreservesBridgeFields]' started.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testTranscriptPayloadPreservesBridgeFields]' passed (0.000 seconds).\nTest Suite 'TalkModeBridgeContractTests' passed at 2026-06-29 23:21:16.312.\n\t Executed 3 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds\nTest Suite 'ElizaosCapacitorTalkModeIOSContractsPackageTests.xctest' passed at 2026-06-29 23:21:16.312.\n\t Executed 3 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds\nTest Suite 'All tests' passed at 2026-06-29 23:21:16.312.\n\t Executed 3 tests, with 0 failures (0 unexpected) in 0.001 (0.002) seconds\n◇ Test run started.\n↳ Testing Library Version: 1743\n↳ Target Platform: arm64e-apple-macos14.0\n✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.\n",
+        "stderrTail": "[0/1] Planning build\nBuilding for debugging...\n[0/2] Write swift-version--58304C5D6DBC2206.txt\nBuild complete! (0.15s)\n"
+      },
+      "status": "pass"
+    },
+    {
+      "id": "ios.swabble.native-bridge",
+      "title": "Swabble iOS wake-firing -> JS bridge event contract",
+      "platform": "ios",
+      "dimensions": {
+        "transcriptionState": "off",
+        "chimeIn": "should-respond",
+        "wakewordContext": "idle-wake",
+        "noiseRejection": "quiet",
+        "voices": "owner"
+      },
+      "class": "native-bridge-unit",
+      "command": [
+        "swift",
+        "test",
+        "--disable-index-store",
+        "--package-path",
+        "plugins/plugin-native-swabble/ios"
+      ],
+      "evidence": [
+        "plugins/plugin-native-swabble/ios/Tests"
+      ],
+      "probe": {
+        "available": true,
+        "reason": "command passed (2026-06-30T03:21:17.101Z)"
+      },
+      "cwd": ".",
+      "env": {},
+      "execution": {
+        "exitCode": 0,
+        "signal": null,
+        "startedAt": "2026-06-30T03:21:16.365Z",
+        "finishedAt": "2026-06-30T03:21:17.101Z",
+        "stdoutTail": "Test Suite 'All tests' started at 2026-06-29 23:21:17.055.\nTest Suite 'ElizaosCapacitorSwabbleIOSContractsPackageTests.xctest' started at 2026-06-29 23:21:17.056.\nTest Suite 'SwabbleBridgeContractTests' started at 2026-06-29 23:21:17.056.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testFuzzyTriggerStillFiresFromSpeechRecognizerMiss]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testFuzzyTriggerStillFiresFromSpeechRecognizerMiss]' passed (0.001 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTextOnlyWakeCommandUsesTriggerAndMinimumLength]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTextOnlyWakeCommandUsesTriggerAndMinimumLength]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTriggerOnlyPayloadStartsCaptureWithoutCommand]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTriggerOnlyPayloadStartsCaptureWithoutCommand]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testWakePayloadMatchesJsBridgeContract]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testWakePayloadMatchesJsBridgeContract]' passed (0.000 seconds).\nTest Suite 'SwabbleBridgeContractTests' passed at 2026-06-29 23:21:17.058.\n\t Executed 4 tests, with 0 failures (0 unexpected) in 0.002 (0.002) seconds\nTest Suite 'ElizaosCapacitorSwabbleIOSContractsPackageTests.xctest' passed at 2026-06-29 23:21:17.058.\n\t Executed 4 tests, with 0 failures (0 unexpected) in 0.002 (0.002) seconds\nTest Suite 'All tests' passed at 2026-06-29 23:21:17.058.\n\t Executed 4 tests, with 0 failures (0 unexpected) in 0.002 (0.003) seconds\n◇ Test run started.\n↳ Testing Library Version: 1743\n↳ Target Platform: arm64e-apple-macos14.0\n✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.\n",
+        "stderrTail": "[0/1] Planning build\nBuilding for debugging...\n[0/2] Write swift-version--58304C5D6DBC2206.txt\nBuild complete! (0.21s)\n"
+      },
+      "status": "pass"
+    }
+  ]
+}

--- a/.github/issue-evidence/9958-voice-matrix-ios-native-bridge/voice-matrix.md
+++ b/.github/issue-evidence/9958-voice-matrix-ios-native-bridge/voice-matrix.md
@@ -1,0 +1,19 @@
+# Voice Live Matrix
+
+Generated: 2026-06-30T03:21:17.101Z
+Host: darwin arm64 (Shaws-MacBook-Pro.local)
+
+| Cell | Status | Platform | Class | Probe / Result | Command |
+|---|---:|---|---|---|---|
+| `ios.sim-or-device.voice-roundtrip` | skip | ios | mobile-live-voice | set ELIZA_VOICE_IOS_READY=1 after installing a current iOS simulator/device build with voice assets | `bun run --cwd packages/app capture:ios-sim -- --issue 9958 --slug voice-ios` |
+| `ios.talkmode.native-bridge` | pass | ios | native-bridge-unit | command passed (2026-06-30T03:21:16.355Z) | `swift test --disable-index-store --package-path plugins/plugin-native-talkmode/ios` |
+| `ios.swabble.native-bridge` | pass | ios | native-bridge-unit | command passed (2026-06-30T03:21:17.101Z) | `swift test --disable-index-store --package-path plugins/plugin-native-swabble/ios` |
+
+## Summary
+
+- Pass: 2
+- Fail: 0
+- Pending: 0
+- Skip: 1
+
+Hardware-unavailable cells are explicit `skip` rows. They are not evidence of platform coverage.

--- a/packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.ts
@@ -13,7 +13,7 @@
  * kiosk shell mode (kiosk wants a fullscreen view-manager surface).
  */
 
-import { isKioskShellMode } from "./kiosk-mode";
+import { appendShellModeParam, isKioskShellMode } from "./kiosk-mode";
 
 function parseTruthy(value: string | undefined): boolean {
   if (!value) return false;
@@ -50,14 +50,7 @@ export function shouldStartBottomBar(
  * background. Preserves any existing query string and hash routing.
  */
 export function appendChatOverlayShellModeParam(rendererUrl: string): string {
-  try {
-    const url = new URL(rendererUrl);
-    url.searchParams.set("shellMode", "chat-overlay");
-    return url.href;
-  } catch {
-    const separator = rendererUrl.includes("?") ? "&" : "?";
-    return `${rendererUrl}${separator}shellMode=chat-overlay`;
-  }
+  return appendShellModeParam(rendererUrl, "chat-overlay");
 }
 
 export interface ScreenWorkArea {

--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -49,7 +49,12 @@ import {
 import { scheduleDevtoolsLayoutRefresh } from "./devtools-layout";
 import { createElectrobunBrowserWindow } from "./electrobun-window-options";
 import { seedFirstPartyRemotePluginsForStartup } from "./first-party-remotes";
-import { appendKioskShellModeParam, isKioskShellMode } from "./kiosk-mode";
+import {
+  appendKioskShellModeParam,
+  appendShellModeParam,
+  isKioskShellMode,
+  readRendererShellMode,
+} from "./kiosk-mode";
 import { publishAgentApiBase } from "./lifecycle/agent-ready-publish";
 import * as apiBaseOwner from "./lifecycle/api-base-owner";
 import {
@@ -991,10 +996,13 @@ async function createMainWindow(rpc: ElizaDesktopRpc): Promise<BrowserWindow> {
   // Opt-in and mutually exclusive with kiosk.
   const bottomBar = presentation.mode === "bottom-bar";
   const baseRendererUrl = await resolveRendererUrlForCurrentRuntime();
+  const requestedShellMode = readRendererShellMode();
   const rendererUrl = kiosk
     ? appendKioskShellModeParam(baseRendererUrl)
     : bottomBar
       ? appendChatOverlayShellModeParam(baseRendererUrl)
+      : requestedShellMode && requestedShellMode !== "full"
+        ? appendShellModeParam(baseRendererUrl, requestedShellMode)
       : baseRendererUrl;
   const buildInfo = await BuildConfig.get();
   const mainWindowPartition = resolveMainWindowPartition(process.env, {

--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -1003,7 +1003,7 @@ async function createMainWindow(rpc: ElizaDesktopRpc): Promise<BrowserWindow> {
       ? appendChatOverlayShellModeParam(baseRendererUrl)
       : requestedShellMode && requestedShellMode !== "full"
         ? appendShellModeParam(baseRendererUrl, requestedShellMode)
-      : baseRendererUrl;
+        : baseRendererUrl;
   const buildInfo = await BuildConfig.get();
   const mainWindowPartition = resolveMainWindowPartition(process.env, {
     platform: process.platform,

--- a/packages/app-core/platforms/electrobun/src/kiosk-mode.test.ts
+++ b/packages/app-core/platforms/electrobun/src/kiosk-mode.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  appendKioskShellModeParam,
+  appendShellModeParam,
+  isKioskShellMode,
+  readRendererShellMode,
+} from "./kiosk-mode";
+
+describe("electrobun shell mode", () => {
+  it("reads supported renderer shell modes from env and argv", () => {
+    expect(
+      readRendererShellMode({ ELIZAOS_SHELL_MODE: "voice-selftest" }, []),
+    ).toBe("voice-selftest");
+    expect(readRendererShellMode({}, ["--shell-mode=voice-workbench"])).toBe(
+      "voice-workbench",
+    );
+  });
+
+  it("ignores unsupported renderer shell modes", () => {
+    expect(readRendererShellMode({ ELIZAOS_SHELL_MODE: "surprise" }, [])).toBe(
+      null,
+    );
+    expect(readRendererShellMode({}, ["--shell-mode=surprise"])).toBe(null);
+  });
+
+  it("keeps kiosk detection on the shared shell-mode reader", () => {
+    expect(isKioskShellMode({ ELIZAOS_SHELL_MODE: "kiosk" }, [])).toBe(true);
+    expect(isKioskShellMode({}, ["--shell-mode=kiosk"])).toBe(true);
+    expect(isKioskShellMode({ ELIZAOS_SHELL_MODE: "voice-selftest" }, [])).toBe(
+      false,
+    );
+  });
+
+  it("appends arbitrary renderer shell modes while preserving query and hash", () => {
+    expect(
+      appendShellModeParam(
+        "http://localhost:2138/?foo=1#/chat",
+        "voice-selftest",
+      ),
+    ).toBe("http://localhost:2138/?foo=1&shellMode=voice-selftest#/chat");
+  });
+
+  it("keeps the kiosk-specific wrapper behavior", () => {
+    expect(appendKioskShellModeParam("not a url")).toBe(
+      "not a url?shellMode=kiosk",
+    );
+  });
+});

--- a/packages/app-core/platforms/electrobun/src/kiosk-mode.ts
+++ b/packages/app-core/platforms/electrobun/src/kiosk-mode.ts
@@ -11,6 +11,15 @@
  */
 
 const SHELL_MODE_ARG_PREFIX = "--shell-mode=";
+const RENDERER_SHELL_MODES = new Set([
+  "chat-overlay",
+  "tray-popover",
+  "voice-selftest",
+  "voice-workbench",
+  "launcher",
+  "kiosk",
+  "full",
+]);
 
 function readShellModeArg(argv: readonly string[]): string | null {
   for (const arg of argv) {
@@ -22,6 +31,21 @@ function readShellModeArg(argv: readonly string[]): string | null {
 }
 
 /**
+ * Shell mode requested for the main renderer. `kiosk` has special native window
+ * presentation, but the renderer URL parameter is shared by every focused
+ * shell surface (`voice-selftest`, `voice-workbench`, tray popover, etc.).
+ */
+export function readRendererShellMode(
+  env: Record<string, string | undefined> = process.env,
+  argv: readonly string[] = process.argv,
+): string | null {
+  const raw = env.ELIZAOS_SHELL_MODE ?? readShellModeArg(argv);
+  if (!raw) return null;
+  const normalized = raw.trim();
+  return RENDERER_SHELL_MODES.has(normalized) ? normalized : null;
+}
+
+/**
  * Resolve whether the process was launched in kiosk shell mode. Reads the
  * `ELIZAOS_SHELL_MODE` env var first, then falls back to the `--shell-mode=`
  * argv flag so both the OS init service and manual launches agree.
@@ -30,8 +54,25 @@ export function isKioskShellMode(
   env: Record<string, string | undefined> = process.env,
   argv: readonly string[] = process.argv,
 ): boolean {
-  if (env.ELIZAOS_SHELL_MODE === "kiosk") return true;
-  return readShellModeArg(argv) === "kiosk";
+  return readRendererShellMode(env, argv) === "kiosk";
+}
+
+/**
+ * Append `?shellMode=<mode>` to the renderer URL so the React app renders the
+ * requested focused shell. Preserves any existing query string and hash routing.
+ */
+export function appendShellModeParam(
+  rendererUrl: string,
+  shellMode: string,
+): string {
+  try {
+    const url = new URL(rendererUrl);
+    url.searchParams.set("shellMode", shellMode);
+    return url.href;
+  } catch {
+    const separator = rendererUrl.includes("?") ? "&" : "?";
+    return `${rendererUrl}${separator}shellMode=${encodeURIComponent(shellMode)}`;
+  }
 }
 
 /**
@@ -39,12 +80,5 @@ export function isKioskShellMode(
  * `KioskShell`. Preserves any existing query string and hash routing.
  */
 export function appendKioskShellModeParam(rendererUrl: string): string {
-  try {
-    const url = new URL(rendererUrl);
-    url.searchParams.set("shellMode", "kiosk");
-    return url.href;
-  } catch {
-    const separator = rendererUrl.includes("?") ? "&" : "?";
-    return `${rendererUrl}${separator}shellMode=kiosk`;
-  }
+  return appendShellModeParam(rendererUrl, "kiosk");
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -21,6 +21,7 @@
     "test:e2e:walkthrough:device": "node scripts/walkthrough-e2e.mjs --platform device",
     "audit:app": "node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts --project=audit-app",
     "test:desktop:packaged": "node scripts/run-ui-playwright.mjs --config playwright.electrobun.packaged.config.ts",
+    "test:desktop:voice": "node scripts/run-ui-playwright.mjs --config playwright.electrobun.packaged.config.ts test/electrobun-packaged/desktop-voice-selftest.e2e.spec.ts",
     "test:remote-capabilities:ui": "node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts test/ui-smoke/remote-capability-view.spec.ts",
     "test:e2e:cloud-wallet": "node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts test/ui-smoke/cloud-wallet-import.spec.ts",
     "test:e2e:android": "node scripts/android-e2e.mjs",

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -1765,7 +1765,10 @@ function connectFirstRunRemoteDeepLink(rawApiBase: string): void {
 }
 
 function handleDeepLink(url: string): void {
-  const firstRunRemote = parseFirstRunRemoteConnectDeepLink(url, APP_URL_SCHEME);
+  const firstRunRemote = parseFirstRunRemoteConnectDeepLink(
+    url,
+    APP_URL_SCHEME,
+  );
   if (firstRunRemote) {
     connectFirstRunRemoteDeepLink(firstRunRemote.apiBase);
     return;

--- a/packages/app/test/android/onboarding-to-home.android.spec.ts
+++ b/packages/app/test/android/onboarding-to-home.android.spec.ts
@@ -16,9 +16,9 @@
 import path from "node:path";
 import { startAndroidScreenRecord } from "../../scripts/lib/android-capture.mjs";
 import {
+  APP_ID,
   adbDevice,
   adbReverse,
-  APP_ID,
   resolveAdb,
 } from "../../scripts/lib/android-device.mjs";
 import { expect, ORIGIN, test } from "./android-harness";

--- a/packages/app/test/electrobun-packaged/desktop-voice-selftest.e2e.spec.ts
+++ b/packages/app/test/electrobun-packaged/desktop-voice-selftest.e2e.spec.ts
@@ -1,0 +1,227 @@
+/**
+ * Packaged Electrobun live-voice self-test.
+ *
+ * This is matrix-only: it is skipped from the broad packaged desktop suite
+ * unless ELIZA_VOICE_DESKTOP_SELFTEST=1. When enabled, it launches the real
+ * packaged desktop shell directly into ?shellMode=voice-selftest, points the
+ * renderer at a real app-core API base, and requires the production
+ * ASR -> agent SSE -> local TTS harness to report every stage as pass.
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expect, type TestInfo, test } from "@playwright/test";
+import {
+  PackagedDesktopHarness,
+  resolvePackagedLauncher,
+} from "./packaged-app-helpers";
+
+type EvalOk<T> = T & { ok: true };
+type EvalErr = { ok: false; error: string };
+type EvalResult<T> = EvalOk<T> | EvalErr;
+
+interface VoiceSelfTestReport {
+  overall: "pass" | "fail" | "skipped";
+  platform: string;
+  mode: string;
+  ttsRoute: string;
+  transcript: string;
+  reply: string;
+  stages: Array<{ stage: string; status: string; error?: string }>;
+}
+
+const repoRoot = path.resolve(import.meta.dirname, "../../../..");
+
+function desktopVoiceSelfTestEnabled(): boolean {
+  return process.env.ELIZA_VOICE_DESKTOP_SELFTEST === "1";
+}
+
+function resolveVoiceApiBase(): string {
+  return (
+    process.env.ELIZA_VOICE_DESKTOP_API_BASE?.trim() ??
+    process.env.ELIZA_DESKTOP_TEST_API_BASE?.trim() ??
+    ""
+  );
+}
+
+function slug(value: string): string {
+  return value.replace(/[^a-z0-9_.-]+/gi, "-").replace(/^-+|-+$/g, "");
+}
+
+async function writeEvidence(args: {
+  testInfo: TestInfo;
+  harness: PackagedDesktopHarness;
+  report: VoiceSelfTestReport;
+}): Promise<void> {
+  const matrixOut = process.env.ELIZA_VOICE_MATRIX_OUT?.trim();
+  const cellId = process.env.ELIZA_VOICE_MATRIX_CELL_ID?.trim();
+  const evidenceDir = matrixOut
+    ? path.join(matrixOut, slug(cellId || "desktop-voice-selftest"))
+    : path.join(
+        repoRoot,
+        ".github",
+        "issue-evidence",
+        "9958-voice-desktop-selftest",
+      );
+  await fs.mkdir(evidenceDir, { recursive: true });
+
+  const prefix = `voice-desktop-selftest-${process.platform}`;
+  const reportPath = path.join(evidenceDir, `${prefix}.json`);
+  await fs.writeFile(reportPath, `${JSON.stringify(args.report, null, 2)}\n`);
+  await args.testInfo.attach("voice-desktop-selftest-report", {
+    path: reportPath,
+    contentType: "application/json",
+  });
+
+  const logPath = path.join(evidenceDir, `${prefix}.log`);
+  await fs.writeFile(
+    logPath,
+    [
+      "App stdout:",
+      args.harness.logs?.stdout.join("") ?? "",
+      "",
+      "App stderr:",
+      args.harness.logs?.stderr.join("") ?? "",
+    ].join("\n"),
+  );
+  await args.testInfo.attach("voice-desktop-selftest-log", {
+    path: logPath,
+    contentType: "text/plain",
+  });
+
+  const data = await args.harness.screenshot();
+  const pngPath = path.join(evidenceDir, `${prefix}.png`);
+  await fs.writeFile(
+    pngPath,
+    Buffer.from(data.replace(/^data:image\/png;base64,/, ""), "base64"),
+  );
+  await args.testInfo.attach("voice-desktop-selftest-screenshot", {
+    path: pngPath,
+    contentType: "image/png",
+  });
+}
+
+test.describe("packaged desktop live voice self-test", () => {
+  test.skip(
+    !desktopVoiceSelfTestEnabled(),
+    "matrix-only; set ELIZA_VOICE_DESKTOP_SELFTEST=1 from voice:matrix",
+  );
+
+  test("reports pass against a real desktop API base and local TTS route", async ({
+    browserName: _browserName,
+  }, testInfo) => {
+    void _browserName;
+    test.setTimeout(600_000);
+
+    const apiBase = resolveVoiceApiBase();
+    expect(
+      apiBase,
+      "ELIZA_VOICE_DESKTOP_API_BASE must point at a real app-core API base for live desktop voice evidence.",
+    ).toMatch(/^https?:\/\//);
+
+    const tempRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "eliza-desktop-voice-selftest-"),
+    );
+    const launcherPath = await resolvePackagedLauncher(
+      path.join(tempRoot, "extract"),
+    );
+    expect(
+      launcherPath,
+      "Packaged Electrobun launcher is required; build/redeploy the latest desktop app before capturing #9958 evidence.",
+    ).toBeTruthy();
+
+    let harness: PackagedDesktopHarness | null = null;
+    try {
+      harness = new PackagedDesktopHarness({
+        tempRoot,
+        launcherPath: launcherPath as string,
+        apiBase,
+        extraEnv: {
+          ELIZAOS_SHELL_MODE: "voice-selftest",
+        },
+      });
+
+      await harness.start({
+        bridgeHealthTimeoutMs: 300_000,
+        shellReadyTimeoutMs: 120_000,
+      });
+      await harness.setMainWindowBounds({
+        x: 0,
+        y: 0,
+        width: 1240,
+        height: 860,
+      });
+      await harness.showMainWindow();
+      await harness.focusMainWindow();
+
+      await expect
+        .poll(
+          async () =>
+            await harness?.eval<
+              EvalResult<{ ready: boolean; overall: string | null }>
+            >(`(() => {
+              try {
+                const shell = document.querySelector('[data-testid="voice-selftest-shell"]');
+                const overall = shell?.getAttribute("data-overall") ?? null;
+                return {
+                  ok: true,
+                  ready: Boolean(shell) && typeof window.__voiceSelfTest === "function",
+                  overall,
+                };
+              } catch (error) {
+                return { ok: false, error: error instanceof Error ? error.message : String(error) };
+              }
+            })()`),
+          {
+            timeout: 120_000,
+            message:
+              "Expected packaged desktop to boot into voice-selftest shell.",
+          },
+        )
+        .toMatchObject({ ok: true, ready: true });
+
+      const result = await harness.eval<
+        EvalResult<{ report: VoiceSelfTestReport }>
+      >(`(async () => {
+        try {
+          const run = window.__voiceSelfTest;
+          if (typeof run !== "function") {
+            return { ok: false, error: "__voiceSelfTest is not installed" };
+          }
+          const report = await run({ mode: "wav-direct" });
+          return { ok: true, report };
+        } catch (error) {
+          return { ok: false, error: error instanceof Error ? error.message : String(error) };
+        }
+      })()`);
+
+      expect(result.ok, result.ok ? undefined : result.error).toBe(true);
+      if (!result.ok) {
+        return;
+      }
+
+      await writeEvidence({
+        testInfo,
+        harness,
+        report: result.report,
+      });
+
+      expect(
+        result.report.overall,
+        `voice self-test stages: ${JSON.stringify(result.report.stages)}`,
+      ).toBe("pass");
+      expect(result.report.platform).toBe("desktop");
+      expect(result.report.ttsRoute).toBe("/api/tts/local-inference");
+      const byStage = Object.fromEntries(
+        result.report.stages.map((stage) => [stage.stage, stage.status]),
+      );
+      expect(byStage.asr).toBe("pass");
+      expect(byStage.send).toBe("pass");
+      expect(byStage.tts).toBe("pass");
+      expect(result.report.transcript.toLowerCase()).toContain("time");
+      expect(result.report.reply.length).toBeGreaterThan(0);
+    } finally {
+      await harness?.stop().catch(() => undefined);
+    }
+  });
+});

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -656,6 +656,55 @@
       "registryKind": "plugin",
       "directory": null
     },
+    "elizaos-plugin-quantumscan": {
+      "git": {
+        "repo": "quantumscan-io/elizaos-plugin-quantumscan",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "elizaos-plugin-quantumscan",
+        "v0": null,
+        "v1": null,
+        "v2": "1.0.2"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Post-quantum cryptography (PQC) vulnerability scanner for GitHub, GitLab, and Bitbucket repositories. Detects ECDSA, RSA, DH, AES-128, and other quantum-vulnerable algorithms. Returns risk scores and NIST FIPS 203/204/205 migration targets.",
+      "homepage": "https://quantumscan.io",
+      "topics": [
+        "security",
+        "pqc",
+        "post-quantum",
+        "cryptography",
+        "blockchain",
+        "nist",
+        "cbom",
+        "vulnerability-scanner",
+        "quantum-computing"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
     "elizaos-plugin-reddit-search": {
       "git": {
         "repo": "xavier-arosemena/elizaos-plugin-reddit-search",

--- a/packages/scripts/android-voice-bridge-gradle/.gitignore
+++ b/packages/scripts/android-voice-bridge-gradle/.gitignore
@@ -1,0 +1,2 @@
+.gradle/
+build/

--- a/packages/scripts/voice-matrix.mjs
+++ b/packages/scripts/voice-matrix.mjs
@@ -183,20 +183,11 @@ const CELLS = [
       voices: "owner",
     },
     class: "desktop-live-voice",
-    command: [
-      "bun",
-      "run",
-      "--cwd",
-      "packages/app",
-      "capture:macos-desktop",
-      "--",
-      "--issue",
-      ISSUE,
-      "--slug",
-      "voice-macos-electrobun",
-    ],
+    command: ["bun", "run", "--cwd", "packages/app", "test:desktop:voice"],
+    env: { ELIZA_VOICE_DESKTOP_SELFTEST: "1" },
     evidence: [
-      `.github/issue-evidence/${ISSUE}-voice-macos-electrobun-macos-desktop.*`,
+      "$ELIZA_VOICE_MATRIX_OUT/macos.electrobun.live-roundtrip",
+      "packages/app/test-results",
     ],
     probe: "macosElectrobun",
   },
@@ -213,20 +204,11 @@ const CELLS = [
       voices: "owner",
     },
     class: "desktop-live-voice",
-    command: [
-      "bun",
-      "run",
-      "--cwd",
-      "packages/app",
-      "capture:windows-desktop",
-      "--",
-      "--issue",
-      ISSUE,
-      "--slug",
-      "voice-windows-electrobun",
-    ],
+    command: ["bun", "run", "--cwd", "packages/app", "test:desktop:voice"],
+    env: { ELIZA_VOICE_DESKTOP_SELFTEST: "1" },
     evidence: [
-      `.github/issue-evidence/${ISSUE}-voice-windows-electrobun-windows-desktop.*`,
+      "$ELIZA_VOICE_MATRIX_OUT/windows.electrobun.live-roundtrip",
+      "packages/app/test-results",
     ],
     probe: "windowsElectrobun",
   },
@@ -441,12 +423,59 @@ function commandExists(name) {
   return spawnSync(cmd, [name], { stdio: "ignore" }).status === 0;
 }
 
-function runCapture(command, cwd, extraEnv = {}) {
+function findFiles(root, predicate, found = []) {
+  if (!fs.existsSync(root)) return found;
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const fullPath = path.join(root, entry.name);
+    if (entry.isDirectory()) findFiles(fullPath, predicate, found);
+    else if (entry.isFile() && predicate(fullPath)) found.push(fullPath);
+  }
+  return found;
+}
+
+function hasPackagedDesktopLauncher(platform) {
+  const explicit = process.env.ELIZA_TEST_PACKAGED_LAUNCHER_PATH?.trim();
+  if (explicit) return fs.existsSync(explicit);
+  const roots = [
+    path.join(REPO_ROOT, "packages/app-core/platforms/electrobun/build"),
+    path.join(REPO_ROOT, "packages/app-core/platforms/electrobun/artifacts"),
+  ];
+  if (platform === "darwin") {
+    return roots.some(
+      (root) =>
+        findFiles(root, (fullPath) =>
+          fullPath.endsWith(
+            `${path.sep}Contents${path.sep}MacOS${path.sep}launcher`,
+          ),
+        ).length > 0,
+    );
+  }
+  if (platform === "win32") {
+    return roots.some(
+      (root) =>
+        findFiles(
+          root,
+          (fullPath) =>
+            path.basename(fullPath).toLowerCase() === "launcher.exe",
+        ).length > 0,
+    );
+  }
+  return false;
+}
+
+function runCapture(command, cwd, extraEnv = {}, context = {}) {
   const startedAt = new Date().toISOString();
   const result = spawnSync(command[0], command.slice(1), {
     cwd: path.resolve(REPO_ROOT, cwd ?? "."),
     encoding: "utf8",
-    env: { ...process.env, ...extraEnv },
+    env: {
+      ...process.env,
+      ...(context.matrixOut
+        ? { ELIZA_VOICE_MATRIX_OUT: context.matrixOut }
+        : {}),
+      ...(context.cellId ? { ELIZA_VOICE_MATRIX_CELL_ID: context.cellId } : {}),
+      ...extraEnv,
+    },
     maxBuffer: 64 * 1024 * 1024,
   });
   return {
@@ -508,9 +537,24 @@ function probeCell(cell) {
             "set ELIZA_VOICE_MACOS_ELECTROBUN_READY=1 on a macOS Electrobun voice runner with loopback mic/audio capture",
         };
       }
+      if (!process.env.ELIZA_VOICE_DESKTOP_API_BASE?.trim()) {
+        return {
+          available: false,
+          reason:
+            "ELIZA_VOICE_DESKTOP_API_BASE is not set to a real app-core API base",
+        };
+      }
+      if (!hasPackagedDesktopLauncher("darwin")) {
+        return {
+          available: false,
+          reason:
+            "packaged macOS Electrobun launcher is missing; build/redeploy the latest desktop app before capture",
+        };
+      }
       return {
         available: true,
-        reason: "macOS Electrobun voice runner enabled",
+        reason:
+          "macOS Electrobun voice runner enabled with packaged launcher and API base",
       };
     case "windowsElectrobun":
       if (process.platform !== "win32")
@@ -525,9 +569,24 @@ function probeCell(cell) {
             "set ELIZA_VOICE_WINDOWS_ELECTROBUN_READY=1 on a Windows Electrobun voice runner with loopback mic/audio capture",
         };
       }
+      if (!process.env.ELIZA_VOICE_DESKTOP_API_BASE?.trim()) {
+        return {
+          available: false,
+          reason:
+            "ELIZA_VOICE_DESKTOP_API_BASE is not set to a real app-core API base",
+        };
+      }
+      if (!hasPackagedDesktopLauncher("win32")) {
+        return {
+          available: false,
+          reason:
+            "packaged Windows Electrobun launcher is missing; build/redeploy the latest desktop app before capture",
+        };
+      }
       return {
         available: true,
-        reason: "Windows Electrobun voice runner enabled",
+        reason:
+          "Windows Electrobun voice runner enabled with packaged launcher and API base",
       };
     case "ios":
       if (process.platform !== "darwin")
@@ -696,6 +755,7 @@ async function main() {
     process.exit(2);
   }
 
+  const outDir = path.resolve(REPO_ROOT, args.out);
   const selected = CELLS.filter(
     (cell) =>
       args.platforms.size === 0 ||
@@ -707,7 +767,10 @@ async function main() {
     const probe = probeCell(cell);
     let execution = null;
     if (args.run && probe.available) {
-      execution = runCapture(cell.command, cell.cwd, cell.env);
+      execution = runCapture(cell.command, cell.cwd, cell.env, {
+        matrixOut: outDir,
+        cellId: cell.id,
+      });
       probe.reason =
         execution.exitCode === 0
           ? `command passed (${execution.finishedAt})`
@@ -752,7 +815,6 @@ async function main() {
     cells,
   };
 
-  const outDir = path.resolve(REPO_ROOT, args.out);
   fs.mkdirSync(outDir, { recursive: true });
   fs.writeFileSync(
     path.join(outDir, "voice-matrix.json"),

--- a/packages/ui/src/first-run/__tests__/deep-link-entry.test.ts
+++ b/packages/ui/src/first-run/__tests__/deep-link-entry.test.ts
@@ -349,17 +349,14 @@ describe("parseFirstRunRemoteConnectDeepLink", () => {
     ).toEqual({ apiBase: "https://agent.example.com" });
   });
 
-  it.each(["apiBase", "url", "host"])(
-    "accepts the %s query alias",
-    (key) => {
-      expect(
-        parseFirstRunRemoteConnectDeepLink(
-          `eliza://first-run/runtime/remote?${key}=https://agent.example.com`,
-          URL_SCHEME,
-        ),
-      ).toEqual({ apiBase: "https://agent.example.com" });
-    },
-  );
+  it.each(["apiBase", "url", "host"])("accepts the %s query alias", (key) => {
+    expect(
+      parseFirstRunRemoteConnectDeepLink(
+        `eliza://first-run/runtime/remote?${key}=https://agent.example.com`,
+        URL_SCHEME,
+      ),
+    ).toEqual({ apiBase: "https://agent.example.com" });
+  });
 
   it("returns null for a bare remote link with no URL (falls through to pre-select)", () => {
     expect(

--- a/packages/ui/src/first-run/adopt-remote-first-run.test.ts
+++ b/packages/ui/src/first-run/adopt-remote-first-run.test.ts
@@ -19,9 +19,9 @@ describe("normalizeRemoteAgentUrl", () => {
   });
 
   it("strips query and hash so one host has one identity", () => {
-    expect(
-      normalizeRemoteAgentUrl("https://agent.example.com/?x=1#frag"),
-    ).toBe("https://agent.example.com");
+    expect(normalizeRemoteAgentUrl("https://agent.example.com/?x=1#frag")).toBe(
+      "https://agent.example.com",
+    );
   });
 
   it("throws on an empty value", () => {
@@ -37,9 +37,7 @@ describe("normalizeRemoteAgentUrl", () => {
   });
 });
 
-function makeClient(
-  overrides: Partial<RemoteFirstRunClient> = {},
-): {
+function makeClient(overrides: Partial<RemoteFirstRunClient> = {}): {
   client: RemoteFirstRunClient;
   getFirstRunStatus: ReturnType<typeof vi.fn>;
   submitFirstRun: ReturnType<typeof vi.fn>;

--- a/packages/ui/src/voice/VOICE_LIVE_MATRIX.md
+++ b/packages/ui/src/voice/VOICE_LIVE_MATRIX.md
@@ -59,8 +59,8 @@ known to be present; it turns `pending` or `skip` into a failing exit.
 | `web.workbench.respond-no-respond` | headful workbench Playwright scenario | chime-in should-respond/should-not-respond UI behavior |
 | `linux.fused-acoustic.workbench-real` | `plugins/plugin-local-inference voice:workbench --real` | fused ASR, diarization, VAD, Kokoro TTS, noisy and multi-speaker workbench report |
 | `linux.fused-acoustic.barge-in` | `plugins/plugin-local-inference voice:bargein-bench` | cancellation/latency harness for barge-in |
-| `macos.electrobun.live-roundtrip` | headed Electrobun runner plus `capture:macos-desktop` | screen/video/log artifact when `ELIZA_VOICE_MACOS_ELECTROBUN_READY=1` |
-| `windows.electrobun.live-roundtrip` | headed Electrobun runner plus `capture:windows-desktop` | screen/video/log artifact when `ELIZA_VOICE_WINDOWS_ELECTROBUN_READY=1` |
+| `macos.electrobun.live-roundtrip` | packaged Electrobun voice self-test via `packages/app test:desktop:voice` | real desktop `voice-selftest` ASR -> agent SSE -> local TTS report plus screenshot/log artifact when `ELIZA_VOICE_MACOS_ELECTROBUN_READY=1` and `ELIZA_VOICE_DESKTOP_API_BASE` points at a real app-core API |
+| `windows.electrobun.live-roundtrip` | packaged Electrobun voice self-test via `packages/app test:desktop:voice` | real desktop `voice-selftest` ASR -> agent SSE -> local TTS report plus screenshot/log artifact when `ELIZA_VOICE_WINDOWS_ELECTROBUN_READY=1` and `ELIZA_VOICE_DESKTOP_API_BASE` points at a real app-core API |
 | `ios.sim-or-device.voice-roundtrip` | installed iOS simulator/device build plus `capture:ios-sim` | simulator screenshot/video/log when `ELIZA_VOICE_IOS_READY=1` |
 | `ios.talkmode.native-bridge` | `swift test --disable-index-store --package-path plugins/plugin-native-talkmode/ios` | TalkMode transcript/permission/state/barge-in bridge tests |
 | `ios.swabble.native-bridge` | `swift test --disable-index-store --package-path plugins/plugin-native-swabble/ios` | Swabble wake-firing -> JS bridge event tests |
@@ -79,6 +79,7 @@ developer laptop:
 | --- | --- |
 | `ELIZA_VOICE_MACOS_ELECTROBUN_READY=1` | current macOS runner has a built Electrobun app, loopback mic/audio capture, and permission grants |
 | `ELIZA_VOICE_WINDOWS_ELECTROBUN_READY=1` | current Windows runner has a built Electrobun app, loopback mic/audio capture, and permission grants |
+| `ELIZA_VOICE_DESKTOP_API_BASE` | real app-core API base used by packaged desktop voice self-test; required for macOS/Windows Electrobun live cells |
 | `ELIZA_VOICE_IOS_READY=1` | current macOS runner has a freshly installed iOS simulator/device build with voice assets |
 | `ELIZA_VOICE_ANDROID_READY=1` | current runner has an attached Android device/emulator, current APK, voice assets, and granted mic permissions |
 | `ELIZA_OPENWAKEWORD_REAL_READY=1` | current runner has the real openWakeWord head and audio fixture/device path |

--- a/plugins/plugin-bluebubbles/build.ts
+++ b/plugins/plugin-bluebubbles/build.ts
@@ -8,8 +8,8 @@
 import { buildPlugin } from "../plugin-build";
 
 await buildPlugin({
-  name: "@elizaos/plugin-bluebubbles",
-  clean: true,
-  targets: [],
-  dtsProject: "tsconfig.json",
+	name: "@elizaos/plugin-bluebubbles",
+	clean: true,
+	targets: [],
+	dtsProject: "tsconfig.json",
 });

--- a/plugins/plugin-linear/build.ts
+++ b/plugins/plugin-linear/build.ts
@@ -13,16 +13,7 @@ await buildPlugin({
     // Preserve transitive externals the hand-maintained list relied on.
     // These show up via @linear/sdk + agentkeepalive's transitive graph;
     // keep them externalized to avoid inlining Node-builtin API users.
-    extra: [
-      "dotenv",
-      "fs",
-      "path",
-      "@reflink/reflink",
-      "https",
-      "http",
-      "agentkeepalive",
-      "zod",
-    ],
+    extra: ["dotenv", "fs", "path", "@reflink/reflink", "https", "http", "agentkeepalive", "zod"],
   },
   targets: [
     {

--- a/plugins/plugin-native-swabble/ios/.gitignore
+++ b/plugins/plugin-native-swabble/ios/.gitignore
@@ -1,0 +1,3 @@
+.build/
+.swiftpm/
+Package.resolved

--- a/plugins/plugin-native-talkmode/ios/.gitignore
+++ b/plugins/plugin-native-talkmode/ios/.gitignore
@@ -1,0 +1,3 @@
+.build/
+.swiftpm/
+Package.resolved


### PR DESCRIPTION
Refs #9958

## Summary
- Adds generic Electrobun renderer shell-mode support so non-kiosk shells can launch the packaged renderer in `voice-selftest` mode.
- Adds a packaged desktop voice self-test Playwright spec, wired to `bun run --cwd packages/app test:desktop:voice`, that requires a real app-core API base and packaged launcher before it can mark macOS/Windows desktop voice cells green.
- Wires the macOS/Windows Electrobun cells into `bun run voice:matrix` and checks in gated-probe evidence showing the desktop cell now reports an explicit hardware/config skip instead of false-greening without a real app.
- Adds Android native-bridge matrix evidence proving the current TalkMode and Swabble Kotlin bridge tests pass through the Gradle bridge project, while keeping Android device voice and Stage-B STT as explicit hardware/telemetry skips.
- Adds iOS native-bridge matrix evidence proving the current TalkMode and Swabble Swift package tests pass, while keeping iOS simulator/device live voice as an explicit installed-build/voice-assets skip.
- Ignores generated `.gradle/`, `build/`, Swift `.build/`, `.swiftpm/`, and `Package.resolved` caches for the native bridge test harnesses so running these probes does not dirty the tree.

## Evidence
- `.github/issue-evidence/9958-voice-matrix-desktop-gated-probe/voice-matrix.md`
- `.github/issue-evidence/9958-voice-matrix-desktop-gated-probe/voice-matrix.json`
- `.github/issue-evidence/9958-voice-matrix-desktop-gated-probe/index.html`
- `.github/issue-evidence/9958-voice-matrix-android-native-bridge/voice-matrix.md`
- `.github/issue-evidence/9958-voice-matrix-android-native-bridge/voice-matrix.json`
- `.github/issue-evidence/9958-voice-matrix-android-native-bridge/index.html`
- `.github/issue-evidence/9958-voice-matrix-ios-native-bridge/voice-matrix.md`
- `.github/issue-evidence/9958-voice-matrix-ios-native-bridge/voice-matrix.json`
- `.github/issue-evidence/9958-voice-matrix-ios-native-bridge/index.html`

Desktop gated probe command:

```bash
ELIZA_VOICE_MACOS_ELECTROBUN_READY=1 bun run voice:matrix -- --platform macos-electrobun --out .github/issue-evidence/9958-voice-matrix-desktop-gated-probe
```

Result: the macOS Electrobun cell is `skip`, with the reason `ELIZA_VOICE_DESKTOP_API_BASE is not set to a real app-core API base`.

Android native bridge command:

```bash
bun run voice:matrix -- --run --platform android --out .github/issue-evidence/9958-voice-matrix-android-native-bridge
```

Result: `android.talkmode.native-bridge` and `android.swabble.native-bridge` pass. `android.device.voice-roundtrip` and `stt.stage-b.evaluation` remain explicit skips because no Android device runner/current APK/voice assets or paired iOS+Android power telemetry were available in this run.

iOS native bridge command:

```bash
bun run voice:matrix -- --run --platform ios --out .github/issue-evidence/9958-voice-matrix-ios-native-bridge
```

Result: `ios.talkmode.native-bridge` and `ios.swabble.native-bridge` pass. `ios.sim-or-device.voice-roundtrip` remains an explicit skip because no current installed iOS simulator/device build with voice assets was available in this run.

## Verification
- `git fetch origin && git rebase origin/develop`, rebased onto `8fd183edc38` (`feat(registry): add elizaos-plugin-quantumscan — PQC vulnerability scanner (#10359)`)
- `bun install` after rebasing onto `origin/develop`
- `bun run verify` on the final rebased branch: 471 Turbo tasks successful, repo audit scripts passed, and 28 dist-path consumer configs checked
- `bun run --cwd packages/app audit:app`: 369 passed; `broken=0`, `needs-work=0`, `minimalism-budget-failures=0`. Latest rendered-UI audit predates the final registry/evidence-only commits, which do not change app rendering.
- `bun run voice:matrix -- --run --platform ios --out .github/issue-evidence/9958-voice-matrix-ios-native-bridge`
- `bun run voice:matrix -- --run --platform android --out .github/issue-evidence/9958-voice-matrix-android-native-bridge`
- `./gradlew -p ../../../scripts/android-voice-bridge-gradle :elizaos-capacitor-talkmode:testDebugUnitTest :elizaos-capacitor-swabble:testDebugUnitTest` from `packages/app-core/platforms/android`
- `node --check packages/scripts/voice-matrix.mjs`
- `bunx vitest run packages/app-core/platforms/electrobun/src/kiosk-mode.test.ts packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.test.ts`
- `ELIZA_VOICE_DESKTOP_SELFTEST=0 bun run --cwd packages/app test:desktop:voice`

## Residuals for #9958
This PR does not claim #9958 is complete. It closes one false-positive path by making packaged desktop voice evidence mandatory for desktop cells, and it adds current Android/iOS native bridge matrix proof. The remaining required issue evidence still needs real hardware/audio capture:

- macOS and Windows packaged Electrobun mic -> ASR -> agent -> Kokoro -> speaker captures with current packaged builds
- iOS and Android live capture via TalkMode/Swabble, with screen+audio recordings and barge-in
- real openWakeWord cells, not reducer/contract-only coverage
- live noise/rejection cell
- transcript capture -> record -> view -> playback -> attach round trip with live capture
- iOS `SFSpeechRecognizer` vs Android `SpeechRecognizer` vs fused ASR Stage-B latency/battery/accept matrix
