### PR TITLE
fix(build): complete the typecheck #build-dep scoping — fix 11 packages' cold typecheck (#10078)

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -381,7 +381,8 @@
         "@elizaos/plugin-capacitor-bridge#build",
         "@elizaos/plugin-coding-tools#build",
         "@elizaos/plugin-registry#build",
-        "@elizaos/plugin-remote-manifest#build"
+        "@elizaos/plugin-remote-manifest#build",
+        "@elizaos/plugin-task-coordinator#build"
       ],
       "outputs": []
     },
@@ -459,6 +460,46 @@
     },
     "@elizaos/example-trader-ts#typecheck": {
       "dependsOn": ["@elizaos/plugin-wallet#build"],
+      "outputs": []
+    },
+    "@elizaos/example-a2a-server#typecheck": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
+    "@elizaos/example-app-electron#typecheck": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
+    "@elizaos/example-browser-extension-chrome#typecheck": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
+    "@elizaos/example-convex#typecheck": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
+    "@elizaos/example-rest-api-elysia#typecheck": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
+    "@elizaos/example-rest-api-express#typecheck": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
+    "@elizaos/example-rest-api-hono#typecheck": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
+    "@elizaos/example-xai-x#typecheck": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
+    "eliza-react-example#typecheck": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
+    "@elizaos/plugin-training#typecheck": {
+      "dependsOn": ["^build"],
       "outputs": []
     },
     "@elizaos/plugin-sub-agent-claude-code#typecheck": {


### PR DESCRIPTION
Completes the **#10078** "drop blanket `^build` from typecheck" inner-loop win. The blanket drop landed in **#10347** (root `typecheck`/`lint` no longer rebuild the whole graph — the win), but it left the **per-package `#typecheck` override set incomplete**: 11 dist-resolving packages (which resolve `@elizaos/*` → `dist/*.d.ts` via `tsconfig.dist-paths.json` / `tsconfig.build.shared.json`) have a missing or insufficient override, so their **cold/isolated `typecheck` fails** (`TS2307: Cannot find module '@elizaos/…'`). CI doesn't catch it because CI runs `bun run build` before `typecheck` (dist always warm) — but `turbo run typecheck` from cold, and the inner-loop the win was meant to enable, break for these packages.

## The fix (turbo.json, +42/−1, purely additive build edges)
- New `#typecheck: { dependsOn: ["^build"] }` overrides for 9 examples + `plugin-training`: `example-a2a-server`, `example-app-electron`, `example-browser-extension-chrome`, `example-convex`, `example-rest-api-{elysia,express,hono}`, `example-xai-x`, `eliza-react-example`, `plugin-training` — they need their model-plugin/scenario-runner deps built but were treated as source-resolvers.
- `plugin-calendar#typecheck`: added `plugin-task-coordinator#build` (calendar source-maps `@elizaos/agent`→src; agent's source imports the dist-resolved `plugin-task-coordinator`).
- `lint` needs none (biome doesn't do cross-package type resolution).

## A/B verification (cold, full workspace)
- **A (develop unchanged):** 11 cold `typecheck` failures — exactly the regression set above.
- **B (this change):** **305/305 pass, 0 fail**; each fixed package's deps were genuinely *built* (cache-miss/executed), not just cached.
- **B ⊆ A:** the change only *adds* build edges → it can only remove failures, never add. Win preserved: `plugin-openai#typecheck` (a source-resolver) dry-run shows **no `^build`/whole-graph** dependency. Gating audits pass (`audit-turbo-build-deps`, `audit-build-typecheck`).

**Caveat:** validated locally (tsgo + turbo); CI is the authoritative check, and since this is additive + CI builds before typecheck, it cannot regress CI. Follows up #10347. Refs #10078.

🤖 Generated with [Claude Code](https://claude.com/claude-code)