### PR TITLE
chore(build): remove the dead `harness` root script (dup of `start`) (#10200)

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "publish:eliza1": "cd packages/training && node ../scripts/run-python.mjs -m scripts.publish.publish_eliza1_all",
     "publish:eliza1:dry-run": "cd packages/training && node ../scripts/run-python.mjs -m scripts.publish.publish_eliza1_all --dry-run",
     "dev:agent": "bun run --cwd packages/agent dev",
-    "harness": "bun run --cwd packages/agent start",
     "dev:core": "bun run --cwd packages/core dev",
     "start:debug": "NODE_NO_WARNINGS=1 LOG_LEVEL=debug bun run --cwd packages/agent start",
     "build": "node packages/scripts/run-turbo.mjs run build --concurrency=8 --filter='!@elizaos/electrobun' --cache=local:r,remote:r --output-logs=errors-only && bun run --cwd packages/app-core/platforms/electrobun build && bun run check:view-bundles",


### PR DESCRIPTION
First concrete declutter from the **#10200** script inventory (#10360). `harness` is a 100% byte-identical duplicate of `start` (both `bun run --cwd packages/agent start`) with **no CI/script/doc/test caller** — per #10200's keep-criterion (retain aliases only where truly used, documented, and tested), it's removable dead weight.

**Migration:** `bun run start` (canonical, unchanged, 30 doc refs).

Independently re-verified the inventory's other two duplicate candidates are NOT safe to remove and are intentionally kept: `test:cloud:playwright` is pinned by a `scenario-pr-workflow.test.ts` assertion, and `dev:web:ui` is a documented dev alias referenced in e2e run-instructions. Conservative, evidence-based — one proven-dead duplicate removed.

Refs #10200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)