### PR TITLE
[codex] ci(cloud): run API deploy on hosted runner

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -85,7 +85,14 @@ jobs:
   # ---------------------------------------------------------------------------
   deploy-api:
     name: Deploy API Worker
-    runs-on: ${{ fromJSON('["self-hosted","Linux","X64","hetzner-robot"]') }}
+    # GitHub-hosted (ephemeral, plentiful) instead of the shared hetzner-robot
+    # pool: under a hot develop push stream the self-hosted autoscaler recycles
+    # runner VMs mid-job, cancelling deploy-api right after "Set up job" (verified
+    # on an unsuperseded workflow_dispatch run; not concurrency, not checkout).
+    # A fresh ubuntu-latest VM per run sidesteps both the preemption and the
+    # stuck shared-workspace checkout. The Worker build/deploy are scoped to
+    # @elizaos/core + packages/cloud/api and fit a standard 16 GB hosted runner.
+    runs-on: ubuntu-latest
     if: github.event_name != 'pull_request'
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}


### PR DESCRIPTION
## Summary

- moves only the Cloud CF Deploy `Deploy API Worker` job from the self-hosted `hetzner-robot` pool to `ubuntu-latest`
- keeps Console/App on the existing self-hosted pool
- cherry-picks Shaw's focused develop-side fix without promoting the rest of develop or the in-chat onboarding work

## Why

Production deploys are repeatedly losing the API job on self-hosted runners before app code runs: action setup/download or `git fetch` gets cancelled on `eliza-robot-*`. The current main production run on #10342 (`28418005860`) shows App/Console progressing after checkout while API failed on `eliza-robot-7` during checkout with `The operation was canceled`.

The Worker build/deploy is smaller than the Pages builds and should fit a standard GitHub-hosted runner. Using an ephemeral hosted runner avoids the shared self-hosted workspace/preemption path for API while preserving the existing Pages runner behavior.

## Validation

- `actionlint .github/workflows/cloud-cf-deploy.yml`
- `git diff --check HEAD~1..HEAD`
- current #10342 production deploy evidence: App/Console passed setup+checkout; API failed on self-hosted runner preemption/fetch cancellation
