### PR TITLE
[codex] ci(cloud): bound deploy dependency installs

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -126,6 +126,7 @@ jobs:
           bun-version: "canary"
 
       - name: Install dependencies
+        timeout-minutes: 20
         working-directory: ${{ env.CHECKOUT_DIR }}
         run: bun install --no-save --ignore-scripts && git diff --exit-code -- bun.lock
 
@@ -298,6 +299,7 @@ jobs:
           bun-version: "canary"
 
       - name: Install dependencies
+        timeout-minutes: 20
         working-directory: ${{ env.CHECKOUT_DIR }}
         run: bun install --no-save --ignore-scripts && git diff --exit-code -- bun.lock
 
@@ -492,6 +494,7 @@ jobs:
           bun-version: "canary"
 
       - name: Install dependencies
+        timeout-minutes: 20
         working-directory: ${{ env.CHECKOUT_DIR }}
         run: bun install --no-save --ignore-scripts && git diff --exit-code -- bun.lock
 


### PR DESCRIPTION
## Summary

Adds explicit `timeout-minutes: 20` bounds to the Cloud CF Deploy dependency install step in all three deploy jobs:

- `deploy-api`
- `deploy-console`
- `deploy-app`

## Why

The final production deploy for `main` run `28419290349` got past checkout, then `Deploy App` sat in `Install dependencies` without live log blobs while `Deploy Console` had already completed the same step. The install command had no step timeout, so a stuck `bun install` could hold a self-hosted deploy runner indefinitely and delay production deploys.

This keeps the existing install command unchanged, but makes hangs explicit and bounded.

## Validation

- `actionlint .github/workflows/cloud-cf-deploy.yml`
- `git diff --check`

## Notes

This does not touch product code or onboarding behavior. It is deploy-pipeline hardening only.
