### PR TITLE
[codex] ci(cloud): run Pages deploys on hosted runners

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -266,7 +266,9 @@ jobs:
   # ---------------------------------------------------------------------------
   deploy-console:
     name: Deploy Console (Pages · elizacloud.ai)
-    runs-on: ${{ fromJSON('["self-hosted","Linux","X64","hetzner-robot"]') }}
+    # Match deploy-api: the shared hetzner-robot pool is cancelling Pages
+    # checkouts mid-fetch before any build/deploy code runs.
+    runs-on: ubuntu-latest
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -461,7 +463,9 @@ jobs:
   # ---------------------------------------------------------------------------
   deploy-app:
     name: Deploy App (Pages · app.elizacloud.ai)
-    runs-on: ${{ fromJSON('["self-hosted","Linux","X64","hetzner-robot"]') }}
+    # Match deploy-api: the shared hetzner-robot pool is cancelling Pages
+    # checkouts mid-fetch before any build/deploy code runs.
+    runs-on: ubuntu-latest
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}


### PR DESCRIPTION
## Summary

Moves the two Cloudflare Pages deploy jobs to GitHub-hosted runners:

- `deploy-console`
- `deploy-app`

`deploy-api` was already moved to hosted in #10362.

## Why

Production deploy run `28420116996` failed before any Console build/deploy logic ran. The `Deploy Console (Pages · elizacloud.ai)` job was assigned to `eliza-robot-16` and was canceled during manual checkout/fetch:

```text
Initialized empty Git repository in /tmp/eliza-checkout-28420116996-1-deploy-console/.git/
##[error]The operation was canceled.
```

This is the same self-hosted runner preemption/cancellation class that previously broke the API deploy and earlier preview Console attempts. Moving Pages deploys to hosted runners removes the flaky shared `hetzner-robot` pool from production deploy publication.

## Validation

- `actionlint .github/workflows/cloud-cf-deploy.yml`
- `git diff --check`

## Scope

Workflow-only. No product code, onboarding code, Cloud API code, or deploy commands changed.
