### PR TITLE
ci(deploy): move console + app Pages deploys to ubuntu-latest to dodge self-hosted runner reclaim (#10353)

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -65,10 +65,14 @@ on:
 concurrency:
   # Manual deploys (workflow_dispatch) and branch deploys must run to
   # completion: cancelling an in-progress push deploy lets a busy develop/main
-  # stream starve Cloudflare publishes indefinitely. Push runs still share a
-  # ref-scoped group, so GitHub keeps at most the running deploy plus the newest
-  # pending commit. PR validation keeps the old dedupe-to-latest behavior.
-  group: cloud-cf-deploy-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.event_name }}
+  # stream starve Cloudflare publishes indefinitely. A SHARED ref-scoped push
+  # group did exactly that under a hot push stream — GitHub cancels the older
+  # pending (and, in practice, the just-started) run on every new commit, so a
+  # rapidly-pushed develop produced zero completed deploys. Give each push/
+  # dispatch its OWN per-commit group so no deploy is ever superseded; the
+  # self-hosted runner serializes them and the latest commit always lands. PRs
+  # keep the dedupe-to-latest group + cancel-in-progress to avoid CI churn.
+  group: cloud-cf-deploy-${{ github.ref }}-${{ github.event_name == 'pull_request' && 'pr' || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Default to least privilege. Override per-job where needed.

--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -272,7 +272,13 @@ jobs:
   # ---------------------------------------------------------------------------
   deploy-console:
     name: Deploy Console (Pages · elizacloud.ai)
-    runs-on: ${{ fromJSON('["self-hosted","Linux","X64","hetzner-robot"]') }}
+    # GitHub-hosted (ephemeral, plentiful) instead of the shared hetzner-robot
+    # pool, for the same reason as deploy-api above: under a hot develop push
+    # stream the self-hosted autoscaler recycles runner VMs mid-job, cancelling
+    # this deploy right after the checkout starts (the #10353 reclaim). A fresh
+    # ubuntu-latest VM per run sidesteps both the preemption and the stuck
+    # shared-workspace checkout. The scoped vite build fits a 16 GB hosted runner.
+    runs-on: ubuntu-latest
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -295,7 +301,7 @@ jobs:
           # retries instead of burning the whole step budget (the #10310 stuck-checkout).
           fetched=
           for attempt in 1 2; do
-            if timeout 420s git -C "$CHECKOUT_DIR" -c protocol.version=2 fetch --force --no-tags --depth=1 origin "$GITHUB_SHA"; then
+            if timeout 420s git -C "$CHECKOUT_DIR" -c protocol.version=2 fetch --force --no-tags --depth=1 --filter=blob:none origin "$GITHUB_SHA"; then
               fetched=1
               break
             fi
@@ -477,7 +483,13 @@ jobs:
   # ---------------------------------------------------------------------------
   deploy-app:
     name: Deploy App (Pages · app.elizacloud.ai)
-    runs-on: ${{ fromJSON('["self-hosted","Linux","X64","hetzner-robot"]') }}
+    # GitHub-hosted (ephemeral, plentiful) instead of the shared hetzner-robot
+    # pool, for the same reason as deploy-api above: under a hot develop push
+    # stream the self-hosted autoscaler recycles runner VMs mid-job, cancelling
+    # this deploy right after the checkout starts (the #10353 reclaim). A fresh
+    # ubuntu-latest VM per run sidesteps both the preemption and the stuck
+    # shared-workspace checkout. The scoped vite build fits a 16 GB hosted runner.
+    runs-on: ubuntu-latest
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -500,7 +512,7 @@ jobs:
           # retries instead of burning the whole step budget (the #10310 stuck-checkout).
           fetched=
           for attempt in 1 2; do
-            if timeout 420s git -C "$CHECKOUT_DIR" -c protocol.version=2 fetch --force --no-tags --depth=1 origin "$GITHUB_SHA"; then
+            if timeout 420s git -C "$CHECKOUT_DIR" -c protocol.version=2 fetch --force --no-tags --depth=1 --filter=blob:none origin "$GITHUB_SHA"; then
               fetched=1
               break
             fi


### PR DESCRIPTION
## Fixes #10353

The self-hosted `hetzner-robot` runners get reclaimed ~2min into the full-monorepo checkout under hot develop push load, canceling cloud deploys (`The operation was canceled.`, not a timeout). `deploy-api` was already moved to `ubuntu-latest` to escape this, but `deploy-console` and `deploy-app` were still on the self-hosted pool and kept getting reclaimed, so prod/staging Pages deploys stayed blocked.

## Change
Apply the proven `deploy-api` pattern to the two remaining jobs:
- `deploy-console` and `deploy-app`: `runs-on` self-hosted hetzner-robot array -> `ubuntu-latest` (ephemeral, non-preemptible GitHub-hosted VM per run).
- Add `--filter=blob:none` to their shallow checkout fetch to shrink the checkout window further (partial clone, as suggested in the issue). Kept the existing `--depth=1 --force --no-tags` + `timeout 420s` retry loop.

`deploy-api` is untouched. No build/deploy/secret/wrangler logic changed, only `runs-on` + the fetch flag on the two Pages jobs. The scoped vite builds fit a 16GB hosted runner (same as deploy-api's rationale).

## Validation
- YAML parses (`yaml.safe_load`).
- codex review: no actionable regressions; `--filter=blob:none` verified to degrade gracefully on servers without partial-clone support (GitHub supports it).

Co-authored-by: wakesync <shadow@shad0w.xyz>