### PR TITLE
ci(voice): make voice-live-e2e lane provisionable + keyless (#9454)

### DIFF
--- a/.github/issue-evidence/9454-gpu-runner-provisioning.md
+++ b/.github/issue-evidence/9454-gpu-runner-provisioning.md
@@ -1,0 +1,242 @@
+# #9454 — Voice live E2E runner provisioning handoff
+
+**Issue:** [elizaOS/eliza#9454](https://github.com/elizaOS/eliza/issues/9454) — *ops(voice): provision the real-audio GPU CI lane for #9147's merge-gating DER/WER/echo/owner/impostor evidence.*
+
+**Status:** code/config side is done and the lane is now keyless and self-staging.
+The only remaining work is **physical**: register one self-hosted Linux x86‑64
+runner with the voice models staged on it. Everything below is the exact recipe.
+
+This issue **cannot be closed from a code session** — it needs a registered
+runner that runs `voice-live-e2e.yml` to `conclusion=success` and uploads real
+metrics. The PR that ships these config fixes references #9454 but does **not**
+`Closes` it.
+
+---
+
+## 1. What changed in this PR (config side)
+
+The lane previously could not go green **even on a fully provisioned runner**,
+because of three checked-in config bugs in `.github/workflows/voice-live-e2e.yml`.
+All three are fixed here:
+
+1. **Keyless contradiction.** The acoustic job's `Probe provisioned voice runner`
+   step did `exit 1` whenever `ELEVENLABS_API_KEY` was empty — directly
+   contradicting #9577, which made the matrix keyless (owner/impostor turns are
+   synthesized locally with distinct fused Kokoro presets). This was the exact
+   step the nightly runs failed at. The hard requirement is removed; the key is
+   now optional (it only upgrades the human-turn rows to real ElevenLabs voices).
+
+2. **Phantom Kokoro GGUF.** The lane downloaded
+   `bundles/2b/tts/kokoro/kokoro-82m-v1_0-Q4_K_M.gguf` with sha
+   `cb5440c3…`. That filename **404s on Hugging Face** (only the canonical
+   `kokoro-82m-v1_0.gguf` is published), and the pinned sha matched nothing. So
+   the `Stage published acoustic GGUFs` step would hard-fail at the Kokoro
+   download regardless of runner. Repointed to the published
+   `kokoro-82m-v1_0.gguf` with its real sha `25521c1a…`. The Kokoro engine
+   discovery treats the no-suffix name as canonical, and the lane's consuming
+   scripts glob `kokoro-82m-v1_0*.gguf`, so this is fully compatible.
+
+3. **Stale `af_bella.bin` sha.** The pinned `f69d8362…` no longer matched the
+   published voice pack (`63d24d0e…`), so `download_sha` would also fail there.
+   Repointed to the current sha (verified by downloading the 522 KB file and
+   `sha256sum`-ing it).
+
+Plus two operability changes:
+
+- **Single point of runner config.** Both real jobs now use
+  `runs-on: ${{ fromJSON(vars.VOICE_LIVE_RUNNER_LABELS || '["self-hosted","Linux","X64","eliza"]') }}`.
+  Default targets the already-online `eliza` runners. To repoint at a dedicated
+  GPU box, set **one** repo variable `VOICE_LIVE_RUNNER_LABELS` — no workflow edit.
+- **Actionable hard-fail + lib-path alignment.** The acoustic job now fails with
+  a clear "fused lib not staged — see this doc" message instead of a bare
+  non-zero, and the fused-lib search list now includes the canonical
+  `~/.eliza/local-inference/lib/libelizainference.so` output of
+  `stage-desktop-fused-lib.mjs`, so staging is one command with no env wiring.
+
+The other four pinned GGUFs (wespeaker, pyannote, both silero VAD files) were
+verified against HF and are **correct** — unchanged.
+
+---
+
+## 2. Current runner target
+
+| | |
+|---|---|
+| Jobs that need it | `voice-roundtrip` (non-blocking) and `voice-acoustic-matrix` (the gate) |
+| Default labels | `[self-hosted, Linux, X64, eliza]` |
+| Single config point | repo variable `VOICE_LIVE_RUNNER_LABELS` (JSON array of labels) |
+| Currently online with this label | `odi-100-25-1` … `odi-100-25-5` (5 runners) |
+
+The label `gpu-cuda-12.6` named in the original issue **does not exist** on the
+org; the lane was already repointed off it to `eliza`. The 5 `eliza`-labeled
+runners are online but do **not** have the voice models/lib staged — that is the
+remaining work.
+
+**A GPU is recommended (for speed) but not required.** The fused
+`libelizainference.so` builds with `GGML_CPU` always on and has no CUDA
+`DT_NEEDED`, so the acoustic forward passes run on CPU. They were proven on real
+hardware on both an RTX 5080 box (CPU-fused lib, no CUDA rebuild) and an Apple
+M4 Max (Metal). A CUDA 12.6+ box just runs the matrix faster.
+
+---
+
+## 3. Provisioning steps (the physical handoff)
+
+Pick the host: either stage the models on one of the existing `eliza` runners,
+or stand up a dedicated GPU box and point the lane at it via
+`VOICE_LIVE_RUNNER_LABELS`.
+
+**3.1 Register the runner** (skip if using an existing `eliza` runner)
+
+```bash
+# On the target Linux x86-64 box, register a repo/org self-hosted runner with
+# the labels you want the lane to match. Default expects: self-hosted Linux X64 eliza
+./config.sh --url https://github.com/elizaOS/eliza \
+  --token <RUNNER_TOKEN> --labels self-hosted,Linux,X64,eliza
+./run.sh    # or install as a service
+```
+
+If you use a different label set (e.g. a real GPU box labeled `gpu-cuda-12.6`),
+register with those labels and set the repo variable:
+
+```bash
+gh variable set VOICE_LIVE_RUNNER_LABELS \
+  --repo elizaOS/eliza --body '["self-hosted","Linux","X64","gpu-cuda-12.6"]'
+```
+
+**3.2 Host tooling**
+
+- **ffmpeg** (`apt-get install -y ffmpeg`) — round-trip resample step.
+- **Node 24** and **Bun canary** are installed by the workflow itself (setup-node
+  / setup-bun), so they don't need pre-staging. Build toolchain for the fused lib:
+  `build-essential`, `cmake`, and **CUDA Toolkit 12.6+** (`nvcc`) if you want the
+  GPU build; without `nvcc` the script falls back to Vulkan/HIP/CPU automatically.
+
+**3.3 Stage the fused `libelizainference.so`** (one command)
+
+```bash
+# From a checkout of this repo on the runner:
+node packages/app-core/scripts/stage-desktop-fused-lib.mjs --variant auto
+# Outputs ~/.eliza/local-inference/lib/libelizainference.so
+# (--variant cuda forces the CUDA build; auto detects nvcc → CUDA, else CPU)
+```
+
+The lane now searches `~/.eliza/local-inference/lib/libelizainference.so`
+directly, so no env var is needed. To use a lib at a custom path instead, set the
+runner env `ELIZA_INFERENCE_LIBRARY=/abs/path/libelizainference.so`.
+
+**3.4 Stage the eliza-1-2b ASR bundle**
+
+The lane requires a source bundle with an `asr/` region at
+`~/.eliza/local-inference/models/eliza-1-2b.bundle` (override with
+`ELIZA_ASR_BUNDLE`). Any box that has run the Eliza desktop app with local
+inference already has it. To stage it manually, fetch the ASR region from HF:
+
+```bash
+B=~/.eliza/local-inference/models/eliza-1-2b.bundle/asr
+mkdir -p "$B"
+base=https://huggingface.co/elizaos/eliza-1/resolve/main/bundles/2b/asr
+curl -fL "$base/eliza-1-asr.gguf"        -o "$B/eliza-1-asr.gguf"
+curl -fL "$base/eliza-1-asr-mmproj.gguf" -o "$B/eliza-1-asr-mmproj.gguf"
+curl -fL "$base/mmproj-audio-2b-bf16.gguf" -o "$B/mmproj-audio-2b-bf16.gguf"
+```
+
+| ASR file (under `asr/`) | size | sha256 |
+|---|---|---|
+| `eliza-1-asr.gguf` | 804.7 MB | `bca259818b50ca7c4c05e9bdb35a5dc04fa039653a6d6f3f0f331f96f6aa1971` |
+| `eliza-1-asr-mmproj.gguf` | 214.4 MB | `41a342b5e4c514e968cb756de6cd1b7be39eff43c44c57a2ef5fc6522e36603d` |
+| `mmproj-audio-2b-bf16.gguf` | 986.8 MB | `e42083b71a9e31e0f722171d551f6d92b101544001c4dde040306a8f2160fe8c` |
+
+That is **all** the runner needs. Every other GGUF (speaker / diarizer / VAD /
+Kokoro TTS) is fetched fresh from HF with a pinned sha256 by the lane itself.
+
+---
+
+## 4. Voice GGUFs the lane downloads (no manual staging needed)
+
+All verified present on `https://huggingface.co/elizaos/eliza-1/resolve/main`
+with the shas now pinned in the workflow:
+
+| HF path | dest in overlay bundle | sha256 |
+|---|---|---|
+| `voice/speaker-encoder/wespeaker-resnet34-lm.gguf` | `speaker/…` | `ad066730b125f61a305c949f7f196d23681f387f3e3f916be7a4cd003aae6ae3` |
+| `voice/diarizer/pyannote-segmentation-3.0.gguf` | `diariz/…` | `30983eba41c0a99ab7eada564739ae8be74faeb21a31da759c870b5173cbd8a5` |
+| `voice/vad/silero-vad-v5.1.2.ggml.bin` | `vad/…` | `29940d98d42b91fbd05ce489f3ecf7c72f0a42f027e4875919a28fb4c04ea2cf` |
+| `bundles/2b/vad/silero-vad-v5.gguf` | `vad/…` | `d348cd6d87ea53dcd3e6680698c88be326082e27dae899adef653d090bee4995` |
+| `bundles/2b/tts/kokoro/kokoro-82m-v1_0.gguf` | `tts/kokoro/…` | `25521c1aa35218d03630bf5239e70d8b5acd0e54c6e92543accfb3ebf9cff9d2` |
+| `bundles/2b/tts/kokoro/voices/af_bella.bin` | `tts/kokoro/voices/…` | `63d24d0e5d91cb6cf3bca294a3b8c0b4428aa54ac9b5de42e5ba07f6bd110ea8` |
+
+**No wakeword GGUF is required by this lane.** The acoustic matrix exercises
+VAD + speaker-encoder (WeSpeaker) + diarizer (pyannote) + Kokoro TTS + ASR; it
+does not load a wakeword model, so the wake-word asset filenames mentioned in
+older issue comments do not gate any row here. All VAD/speaker/diariz/Kokoro
+assets are present on HF — there are **no absent assets** blocking this lane.
+
+---
+
+## 5. Secrets / env
+
+| Name | Required? | Effect |
+|---|---|---|
+| `ELEVENLABS_API_KEY` | **No** (keyless, #9577) | If set, the human-turn rows use real ElevenLabs voices instead of local Kokoro presets. The gate passes without it. |
+| `CEREBRAS_API_KEY` | No | Only enables the optional mixed cloud round-trip in `voice-roundtrip` (non-blocking job). |
+| `VOICE_LIVE_RUNNER_LABELS` (repo var) | No | Override the runner labels (single config point). |
+
+There are **no required secrets** after #9577. Provisioning is the only blocker.
+
+---
+
+## 6. What the lane runs and the gate it enforces
+
+Trigger on demand:
+
+```bash
+gh workflow run voice-live-e2e.yml --repo elizaOS/eliza --ref develop
+```
+
+The blocking `voice-acoustic-matrix` job runs, in `--require-real` mode (a missing
+model/ABI is a hard failure, never a green skip), and uploads logs to the
+`voice-real-acoustic-matrix` artifact:
+
+1. `test:kokoro:real` — real Kokoro GGUF synthesizes audible PCM.
+2. `voice-attribution-smoke.ts --require-real` — VAD / WeSpeaker / diarizer /
+   enrollment / bystander / streaming + live self-voice echo suppression.
+3. `voicestack:real`, `agentvoice:real`, `robustness:real`.
+4. `voice:workbench --real`.
+5. **`packages/benchmarks/voice/voice-real-ci-matrix.mjs`** — the DER / WER /
+   echo / owner / impostor gate (below).
+6. Real fused FFI vitest lanes (encoder / diarizer / asr-timed / kokoro bridge).
+
+### Acceptance thresholds (`voice-real-ci-matrix.mjs`, all env-overridable)
+
+| Metric | Gate | Env override |
+|---|---|---|
+| DER | ≤ `0.6` | `ELIZA_VOICE_REAL_MAX_DER` |
+| WER (mean) | ≤ `0.35` | `ELIZA_VOICE_REAL_MAX_WER` |
+| Owner accuracy | ≥ `1.0` (100%) | `ELIZA_VOICE_REAL_MIN_OWNER_ACCURACY` |
+| Impostor accept rate (FAR) | ≤ `0` | `ELIZA_VOICE_REAL_MAX_IMPOSTOR_ACCEPT_RATE` |
+| Owner accept threshold (cosine) | `0.78` | `ELIZA_VOICE_OWNER_ACCEPT_THRESHOLD` |
+| Self-voice margin | ≥ `0.1` | `ELIZA_VOICE_REAL_MIN_SELF_MARGIN` |
+| Echo rejection | must be `1` (agent echo suppressed) | — |
+
+> Note on DER: local self-validating runs reproduced the pyannote over-detection
+> tracked in **#9460** (DER ≈ 0.57 on a clean 2-speaker clip). If the provisioned
+> run trips the DER gate, that is the #9460 diarizer bug surfacing, not a lane
+> defect — it must be fixed (or the runner must carry a fused lib built past the
+> diarizer-submodule fix `a359942d30`) before the gate goes green. The lane is
+> doing its job by failing hard on it.
+
+---
+
+## 7. Definition of done for #9454 (close criteria)
+
+- [ ] `voice-live-e2e.yml` run with `conclusion=success` on the provisioned
+      runner (link the `gh run`), real-matrix steps green, no skip-pass.
+- [ ] That run uploads real DER/WER/echo/owner/impostor numbers as lane outputs
+      to `.github/issue-evidence/9147-*`.
+- [ ] Numbers meet the thresholds in §6.
+
+**Remaining work = exactly one physical step:** stage §3.3 (fused lib) + §3.4
+(ASR bundle) on a Linux x86‑64 runner carrying the `eliza` label (or a dedicated
+GPU box pointed to via `VOICE_LIVE_RUNNER_LABELS`), then dispatch the lane. No
+code or secret work remains.

--- a/.github/workflows/voice-live-e2e.yml
+++ b/.github/workflows/voice-live-e2e.yml
@@ -18,6 +18,18 @@ name: Voice Live E2E
 # libelizainference build. Its scripts run in require-real mode so a missing
 # model/ABI/credential is a hard failure rather than green skip evidence.
 #
+# Runner provisioning (full handoff: .github/issue-evidence/9454-gpu-runner-provisioning.md):
+#   The two real jobs default to the online [self-hosted, Linux, X64, eliza]
+#   runners. To repoint at a dedicated GPU box without editing this file, set the
+#   repo variable VOICE_LIVE_RUNNER_LABELS to a JSON array of labels, e.g.
+#   ["self-hosted","Linux","X64","gpu-cuda-12.6"] — this is the single point of
+#   runner configuration. The chosen runner must have ffmpeg, a fused
+#   libelizainference.so, and the eliza-1-2b ASR bundle staged; every voice GGUF
+#   is fetched fresh from Hugging Face with a pinned sha256 by this lane. The
+#   matrix is keyless (#9577): owner/impostor turns are synthesized locally with
+#   distinct fused Kokoro presets, so ELEVENLABS_API_KEY is optional and only
+#   upgrades the human-turn rows to real ElevenLabs voices.
+#
 # Runs nightly (offset from app-live-e2e) + on-demand; never on pull_request.
 
 on:
@@ -91,7 +103,8 @@ jobs:
 
   voice-roundtrip:
     name: Real fused ASR + optional mixed round-trip (self-hosted)
-    runs-on: [self-hosted, Linux, X64, eliza]
+    # Single point of runner config — override with repo var VOICE_LIVE_RUNNER_LABELS.
+    runs-on: ${{ fromJSON(vars.VOICE_LIVE_RUNNER_LABELS || '["self-hosted","Linux","X64","eliza"]') }}
     timeout-minutes: 90
     env:
       ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
@@ -142,6 +155,7 @@ jobs:
           FUSED_LIB="$(first_existing_file \
             "${ELIZA_INFERENCE_LIBRARY:-}" \
             "$BUNDLE/lib/libelizainference.so" \
+            "$HOME/.eliza/local-inference/lib/libelizainference.so" \
             "$HOME/.eliza/local-inference/bin/mtp/linux-x64-cuda-fused/libelizainference.so" \
             "$HOME/.eliza/local-inference/bin/mtp/linux-x64-cpu-fused/libelizainference.so" \
             || true)"
@@ -170,7 +184,8 @@ jobs:
 
   voice-acoustic-matrix:
     name: Real acoustic VAD + diarization + self-voice matrix (self-hosted)
-    runs-on: [self-hosted, Linux, X64, eliza]
+    # Single point of runner config — override with repo var VOICE_LIVE_RUNNER_LABELS.
+    runs-on: ${{ fromJSON(vars.VOICE_LIVE_RUNNER_LABELS || '["self-hosted","Linux","X64","eliza"]') }}
     timeout-minutes: 120
     env:
       ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
@@ -194,9 +209,13 @@ jobs:
             nvcc --version || true
             nvidia-smi || true
             ffmpeg -version | head -1 || true
+            # Keyless by design (#9577): the owner/impostor corpus is synthesized
+            # locally with distinct fused Kokoro presets, so no ElevenLabs secret
+            # is required. The key only upgrades the human-turn rows to real voices.
             if [ -z "${ELEVENLABS_API_KEY:-}" ]; then
-              echo "ELEVENLABS_API_KEY is required for real generated-speech lanes"
-              exit 1
+              echo "ELEVENLABS_API_KEY not set — keyless local-Kokoro corpus (#9577)"
+            else
+              echo "ELEVENLABS_API_KEY present — human-turn rows use real ElevenLabs voices"
             fi
           } 2>&1 | tee "$VOICE_REAL_MATRIX_OUT/probe.log"
 
@@ -279,8 +298,16 @@ jobs:
           FUSED_LIB="$(first_existing_file \
             "${ELIZA_INFERENCE_LIBRARY:-}" \
             "$SRC_BUNDLE/lib/libelizainference.so" \
+            "$HOME/.eliza/local-inference/lib/libelizainference.so" \
             "$HOME/.eliza/local-inference/bin/mtp/linux-x64-cuda-fused/libelizainference.so" \
-            "$HOME/.eliza/local-inference/bin/mtp/linux-x64-cpu-fused/libelizainference.so")"
+            "$HOME/.eliza/local-inference/bin/mtp/linux-x64-cpu-fused/libelizainference.so" \
+            || true)"
+          if [ -z "$FUSED_LIB" ]; then
+            echo "FATAL: fused libelizainference.so is not staged on this runner."
+            echo "Provision the lane per .github/issue-evidence/9454-gpu-runner-provisioning.md"
+            echo "(stage the fused libelizainference.so + the eliza-1-2b ASR bundle)."
+            exit 1
+          fi
 
           BUNDLE="$RUNNER_TEMP/eliza-voice-real.bundle"
           node packages/scripts/rm-path-recursive.mjs "$BUNDLE"
@@ -306,12 +333,12 @@ jobs:
           download_sha "$base/bundles/2b/vad/silero-vad-v5.gguf" \
             "$BUNDLE/vad/silero-vad-v5.gguf" \
             "d348cd6d87ea53dcd3e6680698c88be326082e27dae899adef653d090bee4995"
-          download_sha "$base/bundles/2b/tts/kokoro/kokoro-82m-v1_0-Q4_K_M.gguf" \
-            "$BUNDLE/tts/kokoro/kokoro-82m-v1_0-Q4_K_M.gguf" \
-            "cb5440c3e2eadccae635ff5089cbe07082697910a611f323dc5278b9f6659c1e"
+          download_sha "$base/bundles/2b/tts/kokoro/kokoro-82m-v1_0.gguf" \
+            "$BUNDLE/tts/kokoro/kokoro-82m-v1_0.gguf" \
+            "25521c1aa35218d03630bf5239e70d8b5acd0e54c6e92543accfb3ebf9cff9d2"
           download_sha "$base/bundles/2b/tts/kokoro/voices/af_bella.bin" \
             "$BUNDLE/tts/kokoro/voices/af_bella.bin" \
-            "f69d836209b78eb8c66e75e3cda491e26ea838a3674257e9d4e5703cbaf55c8b"
+            "63d24d0e5d91cb6cf3bca294a3b8c0b4428aa54ac9b5de42e5ba07f6bd110ea8"
 
           {
             echo "ELIZA_ASR_BUNDLE=$BUNDLE"


### PR DESCRIPTION
## Summary

Gets the real-audio voice CI lane (`voice-live-e2e.yml`) to a one-step physical handoff for #9454. The code side of #9454 was done, but the lane could not reach a green run **even on a fully provisioned runner** because of three checked-in config bugs. This fixes all three and makes runner provisioning a single point of configuration.

Refs #9454 — does **not** `Closes` it: the remaining acceptance is physical (register a Linux x86-64 runner with the voice models staged and run the lane to `conclusion=success` with uploaded metrics).

## The three blockers fixed

1. **Keyless contradiction.** The acoustic job's `Probe provisioned voice runner` step did `exit 1` whenever `ELEVENLABS_API_KEY` was empty — contradicting #9577, which made the matrix keyless (owner/impostor turns synthesize locally via distinct fused Kokoro presets). This was the exact step the nightly runs failed at. The key is now optional (only upgrades human-turn rows to real ElevenLabs voices).
2. **Phantom Kokoro GGUF.** The lane downloaded `bundles/2b/tts/kokoro/kokoro-82m-v1_0-Q4_K_M.gguf` (sha `cb5440c3…`). That filename **404s on Hugging Face** (only the canonical `kokoro-82m-v1_0.gguf` is published) and the sha matched nothing — so the staging step hard-failed regardless of runner. Repointed to the published file + its real sha `25521c1a…`. Compatible with the engine discovery (no-suffix name is canonical) and the lane's `kokoro-82m-v1_0*.gguf` glob.
3. **Stale `af_bella.bin` sha.** Pinned `f69d8362…` no longer matched the published voice pack (`63d24d0e…`). Repointed; verified by downloading the 522 KB file and `sha256sum`-ing it.

The other four pinned GGUFs (wespeaker, pyannote, both silero VAD) were verified against HF and are correct — unchanged.

## Operability

- **Single point of runner config.** Both real jobs now use `runs-on: ${{ fromJSON(vars.VOICE_LIVE_RUNNER_LABELS || '["self-hosted","Linux","X64","eliza"]') }}` (same pattern as `cloud-cf-deploy.yml` / `codeql.yml`). Default targets the already-online `eliza` runners; set repo var `VOICE_LIVE_RUNNER_LABELS` to repoint at a dedicated GPU box without editing the file.
- **Lib-path alignment + actionable hard-fail.** The fused-lib search now includes `~/.eliza/local-inference/lib/libelizainference.so` (the canonical output of `stage-desktop-fused-lib.mjs`), and a missing lib fails hard with a message pointing at the provisioning doc.

## Handoff doc

`.github/issue-evidence/9454-gpu-runner-provisioning.md` documents the exact recipe: runner label/override, fused-lib build (`stage-desktop-fused-lib.mjs --variant auto`), ASR-bundle staging (with HF paths + shas), the published voice GGUFs the lane self-fetches, confirmation that **no secrets are required** post-#9577, the gate command, and the DER/WER/echo/owner/impostor thresholds.

## What remains (physical only)

Stage the fused `libelizainference.so` + the eliza-1-2b ASR bundle on a Linux x86-64 runner carrying the `eliza` label (or a dedicated GPU box via `VOICE_LIVE_RUNNER_LABELS`), then dispatch the lane. A GPU is recommended for speed but not required — the fused lib has no CUDA `DT_NEEDED` and runs the forward passes on CPU. No code or secret work remains.

## Verification

- `actionlint .github/workflows/voice-live-e2e.yml` — clean.
- YAML parse — clean.
- All 6 voice GGUF shas + the 3 ASR shas checked against the HF tree API; the af_bella sha verified end-to-end (download + sha256sum). The two fixed pins were proven stale by the same method.
- `bun run verify` — N/A (no TypeScript touched; workflow YAML + markdown only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)