### PR TITLE
fix: post-#10302 develop greening (linux static-smoke first-run grep)

### DIFF
--- a/packages/os/linux/scripts/static-smoke.sh
+++ b/packages/os/linux/scripts/static-smoke.sh
@@ -270,13 +270,17 @@ grep -q 'text-txt' \
     "${REPO_ROOT}/packages/ui/src/components/shell/StartupFailureView.tsx"
 grep -q 'text-destructive' \
     "${REPO_ROOT}/packages/ui/src/components/shell/StartupFailureView.tsx"
-first_run_shell="${REPO_ROOT}/packages/ui/src/first-run/FirstRunChat.tsx"
-grep -q 'first-run-chat' "${first_run_shell}"
+# First-run onboarding now renders inline in the real floating chat overlay:
+# #10302 deleted the dedicated FirstRunChat.tsx surface and seeds the onboarding
+# greeting/choices as the same inline widgets the live chat uses. Gate that
+# overlay against the stale dark/gradient/glow styling from the pre-redesign
+# first-run shell (mirrors the #10167 repoint when CompactOnboarding was removed).
+first_run_shell="${REPO_ROOT}/packages/ui/src/components/shell/ContinuousChatOverlay.tsx"
 grep -q 'text-white' "${first_run_shell}"
 if rg -n 'bg-\[#08080a\]|bg-\[#0a0a0a\]|radial-gradient|blur-\[' \
     "${first_run_shell}"
 then
-    echo "First-run onboarding must not reintroduce the old dark/gradient shell." >&2
+    echo "First-run onboarding (in-chat overlay) must not reintroduce the old dark/gradient shell." >&2
     exit 1
 fi
 onboarding_states_css="${REPO_ROOT}/packages/ui/src/components/onboarding/states/onboarding.css"


### PR DESCRIPTION
## What was broken

PR #10302 (the −23k-LOC onboarding inversion) deleted `packages/ui/src/first-run/FirstRunChat.tsx` and moved onboarding into the real floating chat overlay. But `packages/os/linux/scripts/static-smoke.sh` still hard-references the deleted file:

```sh
first_run_shell="${REPO_ROOT}/packages/ui/src/first-run/FirstRunChat.tsx"
grep -q 'first-run-chat' "${first_run_shell}"   # file no longer exists
```

The script runs under `set -euo pipefail`; `grep -q` on a missing file exits 2 and aborts the whole elizaOS Linux ISO static-smoke gate. That gate is wired into `build-linux-iso.yml` / `elizaos-os-release.yml`, which trigger on the **nightly schedule + release**, not on PR — so #10302 merged (with ~51 checks still pending) without this surfacing.

This was found during a post-merge validation sweep of `develop` after #10302. Everything else came back green (see below).

## The fix

Repoint the first-run dark/gradient regression guard at the current onboarding surface — `packages/ui/src/components/shell/ContinuousChatOverlay.tsx` (where onboarding now renders inline) — and drop the stale `first-run-chat` testid assertion (that DOM marker no longer exists). This mirrors the earlier #10167 repoint done when `CompactOnboarding` was removed. The dark/gradient negative guard still fires; `ContinuousChatOverlay` is clean of those patterns.

## Verification

- `bash -n static-smoke.sh` -> OK; `shellcheck -S error` -> clean.
- `ELIZAOS_STATIC_SOURCE_ONLY=1 bash ./scripts/static-smoke.sh` -> **`static smoke passed`** (exit 0). Before: aborts at the FirstRunChat grep.

## Rest of the post-#10302 `develop` sweep (all green, no other fix needed)

- Typecheck (`tsgo --noEmit`): `packages/ui`, `packages/app`, `packages/app-core`, `packages/agent` — all **PASS**, no errors. (These cross-package typechecks were the #1 risk since #10302's CI never confirmed them.)
- Lint: `packages/ui` biome (2197 files) clean; biome check on the 18 changed `packages/app` files clean.
- `packages/ui` first-run unit tests: **141 passed / 12 files**.
- No dangling code imports of the deleted symbols (CompactOnboarding / FirstRunChat / AgentPicker / StartupFirstRunBackground / first-run-tts-route / voice-readiness / runFirstRunChatHandoff / handleCloudFirstRunFinish) — only docs/comments + this one shell-script ref.

Reviewed as part of the open-PR / post-merge greening sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)