### PR TITLE
fix(ui): persist-failure logging + retryable SSE idle stall

### DIFF
--- a/packages/ui/src/api/client-agent-stream.test.ts
+++ b/packages/ui/src/api/client-agent-stream.test.ts
@@ -401,4 +401,52 @@ describe("ElizaClient chat-turn status SSE (#8813)", () => {
     });
     expect(onToken).toHaveBeenCalledWith("hi", "hi");
   });
+
+  it("marks a 60s idle stall as a retryable provider_issue, keeping partial text", async () => {
+    vi.useFakeTimers();
+    try {
+      const encoder = new TextEncoder();
+      const read = vi
+        .fn()
+        // First read delivers a partial token, then the provider hangs — the
+        // second read never resolves, so only the 60s idle timer can settle it.
+        .mockResolvedValueOnce({
+          done: false,
+          value: encoder.encode(
+            'data: {"type":"token","text":"par","fullText":"par"}\n\n',
+          ),
+        })
+        .mockReturnValueOnce(new Promise(() => {}));
+      const cancel = vi.fn(async () => {});
+      const request = vi.fn(
+        async () =>
+          ({
+            ok: true,
+            status: 200,
+            body: { getReader: () => ({ read, cancel }) },
+          }) as unknown as Response,
+      );
+      const client = new ElizaClient("http://agent.example:31337", "token");
+      client.setRequestTransport({ request });
+
+      const resultPromise = client.streamChatEndpoint(
+        "/api/conversations/conversation-id/messages/stream",
+        "hello",
+        vi.fn(),
+      );
+
+      // Process the partial token, then trip the 60s idle timeout on the hang.
+      await vi.advanceTimersByTimeAsync(60_000);
+      const result = await resultPromise;
+
+      // The stall is now a retryable provider issue (renderer shows Retry)
+      // instead of an ambiguous interrupt, and the partial text is retained.
+      expect(result.completed).toBe(false);
+      expect(result.failureKind).toBe("provider_issue");
+      expect(result.text).toContain("par");
+      expect(cancel).toHaveBeenCalledWith("elizaos-sse-idle-timeout");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -1559,18 +1559,29 @@ export class ElizaClient {
     while (true) {
       let done = false;
       let value: Uint8Array | undefined;
+      let idleTimedOut = false;
       try {
         const readPromise = reader.read();
         const timeoutPromise = new Promise<never>((_, reject) => {
-          const id = setTimeout(
-            () => reject(new Error("SSE idle timeout — no data for 60s")),
-            SSE_IDLE_TIMEOUT_MS,
-          );
+          const id = setTimeout(() => {
+            idleTimedOut = true;
+            reject(new Error("SSE idle timeout — no data for 60s"));
+          }, SSE_IDLE_TIMEOUT_MS);
           // Clear timeout if the read resolves first
           void readPromise.finally(() => clearTimeout(id));
         });
         ({ done, value } = await Promise.race([readPromise, timeoutPromise]));
       } catch {
+        // Only the 60s idle timeout sets `idleTimedOut`; a user abort or a
+        // mid-stream network drop rejects the read without it. Stamp the stall
+        // as a transient provider issue so the consumer carries `failureKind`
+        // onto the turn and the renderer shows a Retry affordance instead of a
+        // bare, ambiguous "interrupted" badge that locks the partial text.
+        // User-stop / network-drop stay failureKind-less (genuine interrupt).
+        if (idleTimedOut) {
+          streamState.doneFailureKind =
+            streamState.doneFailureKind ?? "provider_issue";
+        }
         void reader.cancel("elizaos-sse-idle-timeout").catch(() => {});
         break;
       }

--- a/packages/ui/src/state/persistence-cloud-active-server.test.ts
+++ b/packages/ui/src/state/persistence-cloud-active-server.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 
+import { logger } from "@elizaos/logger";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createPersistedActiveServer,
@@ -196,5 +197,35 @@ describe("Cloud active server persistence", () => {
       label: "On-device agent",
       apiBase: "eliza-local-agent://ipc",
     });
+  });
+
+  it("logs a warning instead of silently swallowing a failed active-server persist", () => {
+    const server = createPersistedActiveServer({
+      id: "cloud:agent-warn",
+      kind: "cloud",
+      label: "Demo Agent",
+      apiBase: "https://agent-runtime.example.test",
+      accessToken: "cloud-token",
+    });
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    const setItemSpy = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new DOMException("quota exceeded", "QuotaExceededError");
+      });
+
+    try {
+      // A failed persist must not throw (callers treat it as best-effort) but
+      // must surface a diagnostic — previously this was swallowed silently, so
+      // a lost freshly-recovered apiBase re-triggered backfill on every boot.
+      expect(() => savePersistedActiveServer(server)).not.toThrow();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0]?.[0]).toMatch(
+        /\[persistence\] failed to save active server/,
+      );
+    } finally {
+      setItemSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/packages/ui/src/state/persistence.ts
+++ b/packages/ui/src/state/persistence.ts
@@ -1146,9 +1146,23 @@ export function loadPersistedActiveServer(): PersistedActiveServer | null {
 }
 
 export function savePersistedActiveServer(server: PersistedActiveServer): void {
-  tryLocalStorage(() => {
+  if (typeof localStorage === "undefined") {
+    return;
+  }
+
+  // The active-server record carries the sign-in state (kind/apiBase/token) and
+  // the backend the app reconnects to. A swallowed persist failure (quota,
+  // private-mode SecurityError) silently loses a freshly-recovered apiBase, so
+  // backfillCloudApiBase re-runs every boot with no diagnostic. Mirror
+  // savePersistedFirstRunComplete: still no-throw + no-op when unavailable, but
+  // surface the failure instead of swallowing it.
+  try {
     localStorage.setItem(ACTIVE_SERVER_STORAGE_KEY, JSON.stringify(server));
-  }, undefined);
+  } catch (err) {
+    logger.warn(
+      `[persistence] failed to save active server: ${describePersistenceError(err)}`,
+    );
+  }
 }
 
 export function clearPersistedActiveServer(): void {

--- a/packages/ui/src/state/useChatSend.test.tsx
+++ b/packages/ui/src/state/useChatSend.test.tsx
@@ -515,6 +515,61 @@ describe("useChatSend non-404 send failures", () => {
     ).toBe(false);
   });
 
+  it("distinguishes a first-token timeout from a network drop in the notice copy", async () => {
+    // A timeout means the agent WAS reached but did not respond in time, so
+    // "check your connection" is the wrong remedy. Timeout → slow-response copy;
+    // a genuine network drop keeps the connection copy.
+    mocks.client.sendConversationMessageStream.mockRejectedValue(
+      Object.assign(new Error("Request timed out"), { kind: "timeout" }),
+    );
+
+    const deps = makeDeps({
+      activeConversationId: "conv-1",
+      conversations: [conversation("conv-1", "room-1")],
+    });
+    const { result } = renderHook(() => useChatSend(deps));
+
+    await act(async () => {
+      await result.current.sendChatText("are you there", {
+        conversationId: "conv-1",
+      });
+    });
+
+    expect(deps.setActionNotice).toHaveBeenCalledWith(
+      expect.stringContaining("took too long"),
+      "error",
+      expect.any(Number),
+    );
+    // Must NOT show the misleading network/connection copy for a timeout.
+    expect(deps.setActionNotice).not.toHaveBeenCalledWith(
+      expect.stringContaining("check your connection"),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it("keeps the connection copy for a genuine network drop", async () => {
+    mocks.client.sendConversationMessageStream.mockRejectedValue(
+      Object.assign(new Error("Failed to fetch"), { kind: "network" }),
+    );
+
+    const deps = makeDeps({
+      activeConversationId: "conv-1",
+      conversations: [conversation("conv-1", "room-1")],
+    });
+    const { result } = renderHook(() => useChatSend(deps));
+
+    await act(async () => {
+      await result.current.sendChatText("hi", { conversationId: "conv-1" });
+    });
+
+    expect(deps.setActionNotice).toHaveBeenCalledWith(
+      expect.stringContaining("check your connection"),
+      "error",
+      expect.any(Number),
+    );
+  });
+
   it("does not reload (which could re-fail) on an auth-failure send error, and notifies", async () => {
     mocks.client.sendConversationMessageStream.mockRejectedValue(
       httpStatusError(401, "Unauthorized"),

--- a/packages/ui/src/state/useChatSend.ts
+++ b/packages/ui/src/state/useChatSend.ts
@@ -1202,9 +1202,11 @@ export function useChatSend(deps: UseChatSendDeps) {
               ? "The agent is busy right now — wait a few seconds and resend."
               : status === 503 || status === 502
                 ? "The agent is still waking up — give it a moment and resend."
-                : kind === "network" || kind === "timeout"
-                  ? "Couldn't reach the agent — check your connection and resend."
-                  : "That message didn't go through — please resend.";
+                : kind === "timeout"
+                  ? "The agent took too long to respond — give it a moment and resend."
+                  : kind === "network"
+                    ? "Couldn't reach the agent — check your connection and resend."
+                    : "That message didn't go through — please resend.";
           setActionNotice(notice, "error", 8_000);
           // Reconcile from the server for non-auth errors — loadConversationMessages
           // no longer wipes the thread on transient failures (404-only clear), so


### PR DESCRIPTION
Two small, independent UI launch-hardening fixes (both verified on current develop, 40/40 unit tests green, biome clean).

### 1. Log instead of silently swallowing a failed active-server persist
`savePersistedActiveServer` swallowed any `localStorage.setItem` failure, so a quota/serialization error left the active-server silently un-persisted (user looks signed-in, but a reload drops them). Now logs via the same `describePersistenceError` helper every other persist in this file already uses. (`packages/ui/src/state/persistence.ts`)

### 2. Retryable SSE idle stall + clearer timeout copy
- A 60s SSE idle timeout previously left the turn in a non-retryable state. Now binds the idle-timeout to `streamState.doneFailureKind = "provider_issue"` so the turn is retryable instead of a dead end. (`packages/ui/src/api/client-base.ts`)
- Timeout copy split so a true timeout reads "The agent took too long to respond — give it a moment and resend." vs the connection-loss copy. (`packages/ui/src/state/useChatSend.ts`)

### Provenance
These are the **still-novel** subset of #10229 (closed by a maintainer when that branch had gone stale + messy). Rebased fresh onto current develop; confirmed neither fix is already in develop. The third fix from #10229 (AgentPicker bind-error inline) was **dropped as obsolete** — `AgentPicker.tsx` has since been removed from develop.

### Tests
- `persistence-cloud-active-server.test.ts` — covers the new persist-failure log path.
- `client-agent-stream.test.ts` — covers the idle-timeout → retryable `provider_issue`.
- `useChatSend.test.tsx` — covers the split timeout/connection copy.
All green (40/40).