### PR TITLE
feat(cloud): DB-backed inference pending-charge ledger (#9899 Tier 3)

### DIFF
--- a/.github/issue-evidence/9899-db-ledger-overdraw-measurement.json
+++ b/.github/issue-evidence/9899-db-ledger-overdraw-measurement.json
@@ -1,0 +1,47 @@
+{
+  "measuredAt": "2026-06-30T05:54:28.126Z",
+  "scenarios": [
+    {
+      "burst": 50,
+      "estimate": 3,
+      "startBalance": 100,
+      "threshold": 1,
+      "admitted": 33,
+      "rejected": 17,
+      "inflightReserved": 99,
+      "naiveUnboundedInflight": 150,
+      "overdrawPreventedUsd": 50,
+      "inflightWithinBalance": true,
+      "finalBalance": 1,
+      "finalBalanceNonNegative": true
+    },
+    {
+      "burst": 20,
+      "estimate": 10,
+      "startBalance": 100,
+      "threshold": 5,
+      "admitted": 10,
+      "rejected": 10,
+      "inflightReserved": 100,
+      "naiveUnboundedInflight": 200,
+      "overdrawPreventedUsd": 100,
+      "inflightWithinBalance": true,
+      "finalBalance": 0,
+      "finalBalanceNonNegative": true
+    },
+    {
+      "burst": 100,
+      "estimate": 1,
+      "startBalance": 25,
+      "threshold": 0.5,
+      "admitted": 25,
+      "rejected": 75,
+      "inflightReserved": 25,
+      "naiveUnboundedInflight": 100,
+      "overdrawPreventedUsd": 75,
+      "inflightWithinBalance": true,
+      "finalBalance": 0,
+      "finalBalanceNonNegative": true
+    }
+  ]
+}

--- a/.github/issue-evidence/9899-db-ledger.md
+++ b/.github/issue-evidence/9899-db-ledger.md
@@ -1,0 +1,79 @@
+# #9899 — DB-backed pending-charge + settlement ledger (Tier 3)
+
+The pre-forward TTFT root cause in #9899 was fixed and shipped (Tier 1 auth cache +
+Tier 2 optimistic billing, live in prod). The only remaining **code** work the
+issue + `docs/inference-hot-path.md` named was the **DB-backed pending-charge +
+settlement ledger** that closes the three at-scale residuals a KV-only backstop
+cannot. This change implements it, flag-gated `INFERENCE_BILLING_LEDGER="db"`
+(default `""`/`kv` = no behavior change), matching the soak-then-cutover rollout
+discipline the issue itself prescribed.
+
+## What landed
+
+| File | Change |
+|---|---|
+| `packages/cloud/shared/src/db/schemas/inference-pending-charges.ts` | New table schema (PK `request_id`, partial indexes) |
+| `packages/cloud/shared/src/db/migrations/0153_inference_pending_charges.sql` + journal | Additive, idempotent migration |
+| `packages/cloud/shared/src/lib/services/inference-billing-ledger.ts` | `admitInferenceChargeViaLedger`, `createLedgerDebitSettler`, `sweepStalePendingInferenceChargesDb`, `resolveInferenceBillingLedger` |
+| `packages/cloud/api/v1/chat/completions/route.ts` · `v1/embeddings/route.ts` | DB-ledger admission branch (KV path byte-identical when flag unset) |
+| `packages/cloud/api/cron/sweep-inference-charges/route.ts` | Dispatch to DB sweep when selected |
+| `packages/cloud/api/wrangler.toml` · `types/cloud-worker-env.ts` | `INFERENCE_BILLING_LEDGER` flag (off in all envs) |
+| `packages/cloud/api/docs/inference-hot-path.md` | Tier-3 section + cutover plan |
+
+## Residuals closed (each point-for-point)
+
+1. **Hard concurrent-overdraw bound** — admission is one atomic `FOR UPDATE` +
+   `SUM(pending)` statement; a same-org burst serializes and cannot collectively
+   overdraw (was: KV soft bound via threshold only).
+2. **True exactly-once settlement** — `request_id` PK + atomic
+   `UPDATE … WHERE status='pending'` claim; inline settler and cron sweep can
+   never both charge (was: KV near-atomic get-then-delete → rare double-bill). No
+   single-flight lock needed anymore.
+3. **Age-ordered sweep drain** — `ORDER BY enqueued_at LIMIT batch` loop over a
+   partial index, no silent `maxKeys` cap (was: unordered bounded prefix scan).
+
+Plus `uncollected` becomes a first-class auditable row state; the org self-heals
+onto the synchronous-reserve path on a refused debit.
+
+## Test evidence — 90 pass / 0 fail (real DB, no larp)
+
+Every test drives the **real SQL against in-process PGlite** (same pattern as the
+audited `credits-deduct-guard.test.ts`); only fire-and-forget non-billing
+side-effects (email/webhook/auto-top-up) are stubbed.
+
+```
+inference-billing-ledger.test.ts              15 pass   (admission/settle/sweep/concurrency)
+inference-pending-charges-migration.test.ts    6 pass   (journal reg + real-DB apply + idempotent)
+inference-billing-fast-path.test.ts           28 pass   (KV path — no regression)
+inference-billing-cache-failure.test.ts        2 pass
+inference-auth-context.test.ts                12 pass
+inference-auth-lifecycle.test.ts               7 pass
+inference-hot-path-benchmark.test.ts           3 pass
+credits-deduct-guard.test.ts                   9 pass   (credit mutation — no regression)
+credits-reconcile.test.ts                      8 pass
+------------------------------------------------------------
+TOTAL                                         90 pass / 0 fail
+```
+
+New-file typecheck: clean (only pre-existing i18n/hono-dup/stripe-version noise).
+Biome: clean on all changed files. The route-level runtime tests
+(`chat-completions-optimistic-billing.test.ts`) need a built `@elizaos/core`
+dist, which cannot be generated in this worktree (`tsc` can't resolve
+`@types/bun`/`@types/node` — the shared-parent-`node_modules` limitation); they
+run in CI. The DB-ledger route branch is type-checked clean and the KV path is
+structurally unchanged when `INFERENCE_BILLING_LEDGER` is unset.
+
+## Measurement — the hard overdraw bound, quantified
+
+`9899-db-ledger-overdraw-measurement.json` — concurrent bursts of optimistic
+admissions against a fixed balance:
+
+| Burst × estimate | Balance | Threshold | Admitted | Rejected | In-flight reserved | Naive (unbounded) | **Overdraw prevented** | Final balance ≥ 0 |
+|---|---|---|---|---|---|---|---|---|
+| 50 × $3 | $100 | $1 | 33 | 17 | $99 | $150 | **$50** | $1 ✓ |
+| 20 × $10 | $100 | $5 | 10 | 10 | $100 | $200 | **$100** | $0 ✓ |
+| 100 × $1 | $25 | $0.50 | 25 | 75 | $25 | $100 | **$75** | $0 ✓ |
+
+In every scenario the total in-flight reserved is `≤` the balance and the
+post-settle balance never goes negative — the guarantee the KV soft-bound cannot
+provide (it would have admitted the full naive in-flight).

--- a/packages/cloud/api/cron/sweep-inference-charges/route.ts
+++ b/packages/cloud/api/cron/sweep-inference-charges/route.ts
@@ -6,6 +6,10 @@ import {
   isOptimisticBillingEnabled,
   sweepStalePendingInferenceCharges,
 } from "@/lib/services/inference-billing-fast-path";
+import {
+  resolveInferenceBillingLedger,
+  sweepStalePendingInferenceChargesDb,
+} from "@/lib/services/inference-billing-ledger";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -24,9 +28,21 @@ async function handleSweepInferenceCharges(c: Context<AppEnv>) {
       return c.json({ success: true, skipped: "optimistic_billing_disabled" });
     }
 
+    // Sweep the backstop the route writes to: the DB ledger drains oldest-first in
+    // age-ordered batches (exactly-once via the row claim), the KV backstop scans
+    // its pending prefix. Selected by INFERENCE_BILLING_LEDGER (#9899).
+    if (resolveInferenceBillingLedger() === "db") {
+      const stats = await sweepStalePendingInferenceChargesDb();
+      logger.info(
+        "[Inference Billing] DB-ledger pending-charge sweep complete",
+        stats,
+      );
+      return c.json({ success: true, backend: "db", ...stats });
+    }
+
     const stats = await sweepStalePendingInferenceCharges();
     logger.info("[Inference Billing] pending-charge sweep complete", stats);
-    return c.json({ success: true, ...stats });
+    return c.json({ success: true, backend: "kv", ...stats });
   } catch (error) {
     logger.error("[Inference Billing] pending-charge sweep failed", { error });
     return failureResponse(c, error);

--- a/packages/cloud/api/docs/inference-hot-path.md
+++ b/packages/cloud/api/docs/inference-hot-path.md
@@ -293,3 +293,80 @@ The money-safety invariants (no double-charge under an atomic backend, no
 free-forever on cache failure, fail-safe `+Inf` threshold, uncollected→slow-path)
 are unit-tested; the residuals above are the explicit boundary of what unit tests
 on the in-memory adapter can prove about the production KV backend.
+
+---
+
+## Tier 3 — DB-backed pending-charge + settlement ledger (IMPLEMENTED — flag-gated, default OFF)
+
+The "documented next step" above is now built: a real database table
+(`inference_pending_charges`, migration `0153`) that is the durable, exactly-once
+replacement for the KV pending-charge backstop. It is selected by
+`INFERENCE_BILLING_LEDGER="db"` (default `kv` = the KV backstop). Code lives in
+`@/lib/services/inference-billing-ledger` (`admitInferenceChargeViaLedger`,
+`createLedgerDebitSettler`, `sweepStalePendingInferenceChargesDb`,
+`resolveInferenceBillingLedger`); the chat + embeddings routes and the
+`sweep-inference-charges` cron dispatch to it when the flag is `db`.
+
+It closes the three KV-inherent residuals point-for-point:
+
+1. **Hard concurrent-overdraw bound (was BILL-2 redux).** Admission is ONE atomic
+   statement that locks the org row (`SELECT … FOR UPDATE`), subtracts the SUM of
+   the org's still-`pending` charges from its balance, and inserts a `pending`
+   row ONLY when `balance > threshold` AND `balance − in-flight ≥ estimate`.
+   Concurrent admissions for one org serialize on the row lock, so a burst can
+   never *collectively* overdraw — the gate is the admission, not a stale hint.
+   (Residual window: between an inline settle's atomic claim and its `deductCredits`
+   commit a charge is briefly out of `pending_sum` but not yet in the balance, a
+   sub-RTT transient over-admit that the `CHECK(>=0)` still backstops — strictly
+   tighter than the KV soft bound.)
+2. **True exactly-once settlement.** `request_id` is the table PK and the settle
+   is an atomic `UPDATE … SET status='settled' WHERE status='pending' RETURNING`.
+   Only one of {inline settler, cron sweep} can ever transition a row, so they can
+   never both charge a request — removing the KV double-bill possibility. The
+   actual debit then funnels through the single audited `creditsService.deductCredits`
+   (atomic balance guard + all notifications), so there is one credit-mutation
+   codepath. This also means the cron needs **no** KV-style single-flight lock —
+   overlapping sweeps are safe.
+3. **Age-ordered sweep drain.** The sweep selects `status='pending' AND
+   enqueued_at < cutoff ORDER BY enqueued_at ASC LIMIT batch` over a partial index
+   and loops batches until the backlog is empty (bounded by `maxBatches`, which is
+   `log`-surfaced when hit) — no silent `maxKeys` cap.
+
+`uncollected` becomes a first-class row state (auditable) instead of log-only: a
+debit the DB refuses (would overdraw) marks the row `uncollected`, drops the
+org-balance hint, and the org's NEXT admission reads the now-depleted balance and
+self-heals onto the synchronous-reserve path (402). Bounded over-spend, never
+free-forever.
+
+What the ledger does NOT change: pricing lookups remain per-request, and the
+admission still reads a balance (now under a lock, fresh) — the Tier-2 caveat that
+"zero DB reads pre-forward" holds for AUTH+MODERATION (Tier 1) and not for the
+billing gate still stands. The win is correctness-at-scale, not a further latency
+cut; the admission's single locked round-trip is comparable to the synchronous
+reserve it replaces while additionally bounding overdraw.
+
+### Rollout (Tier 3)
+
+Same soak-then-cutover discipline as Tier 1/2, and orthogonal to them
+(`INFERENCE_BILLING_LEDGER` is independent of `INFERENCE_HOT_PATH_CACHE` and
+`INFERENCE_OPTIMISTIC_BILLING`; the ledger still requires
+`INFERENCE_OPTIMISTIC_BILLING="true"`). Default `""`/`kv` everywhere = no behavior
+change. To cut over: ship migration `0153`, flip `INFERENCE_BILLING_LEDGER="db"`
+in staging, drive load, watch `[InferenceLedger] uncollected inference charge`
+and the sweep stats (`settled`/`skipped`/`capHit`), then flip prod. Revert =
+flag back to `""` (the KV backstop is unchanged and still wired). The KV backstop
+stays as the rollback target during the migration; once the DB ledger is soaked
+in prod, the KV pending-charge path can be retired.
+
+### Tests (Tier 3)
+
+`packages/cloud/shared/src/lib/services/__tests__/inference-billing-ledger.test.ts`
+drives the REAL SQL against in-process PGlite (the same honest pattern as
+`credits-deduct-guard.test.ts`): admission (affordable / threshold gate / **hard
+overdraw bound** via seeded in-flight rows / unknown org / `+Inf` threshold /
+idempotent re-delivery / a concurrent burst that cannot collectively overdraw);
+settle (actual debit / **exactly-once** double-settle no-op / `settle(0)` /
+**uncollected** under `CHECK(>=0)`); sweep (stale-vs-young / inline-then-sweep no
+double-charge / age-ordered multi-batch drain). The migration file itself is
+applied to PGlite and asserted (`inference-pending-charges-migration.test.ts`):
+table + PK + both partial indexes exist, and re-applying is idempotent.

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -80,6 +80,11 @@ import {
   resolveSafeBalanceThresholdUsd,
   writePendingInferenceCharge,
 } from "@/lib/services/inference-billing-fast-path";
+import {
+  admitInferenceChargeViaLedger,
+  createLedgerDebitSettler,
+  resolveInferenceBillingLedger,
+} from "@/lib/services/inference-billing-ledger";
 import { getCachedGatewayModelById } from "@/lib/services/model-catalog";
 import { createCreditReservationSettler } from "@/lib/utils/credit-reservation";
 import { logger } from "@/lib/utils/logger";
@@ -1035,15 +1040,68 @@ export async function handleChatCompletionsPOST(
     } else {
       // Organization credits path. #9899 Tier-2: when optimistic billing is
       // enabled AND this org's balance comfortably clears SAFE_BALANCE_THRESHOLD,
-      // skip the synchronous reserve write — instead persist a durable
-      // pending-charge backstop and defer the FULL actual-cost debit to the
-      // post-response settler. Otherwise take the existing synchronous reserve.
-      // Only consider the optimistic path when the durable backstop is writable
-      // (cache available) — otherwise a forwarded request would have no recorded
-      // charge (free inference). Mirrors the IAC resolver's cache-health guard.
+      // skip the synchronous reserve write — instead reserve the charge against a
+      // durable backstop and defer the FULL actual-cost debit to the post-response
+      // settler. Otherwise take the existing synchronous reserve.
+      //
+      // The durable backstop is selected by INFERENCE_BILLING_LEDGER: "db" uses
+      // the inference_pending_charges ledger (atomic overdraw bound + exactly-once
+      // settle + age-ordered sweep), otherwise the KV backstop. The ledger's
+      // admission is itself the gate (it reads a fresh balance under a row lock),
+      // so it does not need the KV org-balance hint or a writable cache.
+      let optimisticReady = false;
+      const optimisticBillingEnabled = isOptimisticBillingEnabled();
+      const useDbLedger =
+        optimisticBillingEnabled && resolveInferenceBillingLedger() === "db";
+
+      if (useDbLedger) {
+        const { totalCost } = await calculateCost(
+          normalizedModel,
+          provider,
+          estimatedInputTokens,
+          estimatedOutputTokens,
+          billingSource,
+        );
+        const admission = await admitInferenceChargeViaLedger({
+          charge: {
+            requestId,
+            organizationId: user.organization_id,
+            userId: user.id,
+            apiKeyId: apiKey?.id ?? null,
+            model,
+            provider,
+            billingSource,
+          },
+          estimatedCostUsd: totalCost,
+          thresholdUsd: resolveSafeBalanceThresholdUsd(),
+        });
+        if (admission.admitted) {
+          reservation = creditsService.createAnonymousReservation();
+          optimisticSettler = createLedgerDebitSettler({
+            requestId,
+            organizationId: user.organization_id,
+            userId: user.id,
+            apiKeyId: apiKey?.id ?? null,
+            model,
+            provider,
+            billingSource,
+          });
+          optimisticReady = true;
+        }
+      }
+
+      // KV backstop path (unchanged). Only consider it when the DB ledger is not
+      // selected and the cache is writable — otherwise a forwarded request would
+      // have no recorded charge (free inference). Mirrors the IAC resolver's
+      // cache-health guard.
       let useOptimistic = false;
       let estimatedCostUsd = 0;
-      if (isOptimisticBillingEnabled() && isOptimisticBackstopAvailable()) {
+      if (
+        !optimisticReady &&
+        optimisticBillingEnabled &&
+        !useDbLedger &&
+        isOptimisticBackstopAvailable()
+      ) {
         const { totalCost } = await calculateCost(
           normalizedModel,
           provider,
@@ -1065,7 +1123,6 @@ export async function handleChatCompletionsPOST(
       // Optimistic path is taken ONLY if the durable pending-charge actually
       // persisted; a non-durable backstop falls through to the synchronous
       // reserve so we never forward on an un-recorded charge (#9899).
-      let optimisticReady = false;
       if (useOptimistic) {
         const persisted = await writePendingInferenceCharge(
           {

--- a/packages/cloud/api/v1/embeddings/route.ts
+++ b/packages/cloud/api/v1/embeddings/route.ts
@@ -42,6 +42,11 @@ import {
   resolveSafeBalanceThresholdUsd,
   writePendingInferenceCharge,
 } from "@/lib/services/inference-billing-fast-path";
+import {
+  admitInferenceChargeViaLedger,
+  createLedgerDebitSettler,
+  resolveInferenceBillingLedger,
+} from "@/lib/services/inference-billing-ledger";
 import { usageService } from "@/lib/services/usage";
 import { createCreditReservationSettler } from "@/lib/utils/credit-reservation";
 import { logger } from "@/lib/utils/logger";
@@ -210,9 +215,61 @@ app.post("/", async (c) => {
     let reservation: Awaited<ReturnType<typeof reserveCredits>> | undefined;
     let optimisticReady = false;
 
+    // Durable backstop selected by INFERENCE_BILLING_LEDGER (see chat route). The
+    // DB ledger's atomic admission is itself the gate and needs no writable cache.
+    const optimisticBillingEnabled = isOptimisticBillingEnabled();
+    const useDbLedger =
+      !!orgId &&
+      optimisticBillingEnabled &&
+      resolveInferenceBillingLedger() === "db";
+
+    if (useDbLedger) {
+      const { totalCost: backstopEstimateUsd } = await calculateCost(
+        model,
+        provider,
+        estimatedInputTokens,
+        0,
+        billingSource,
+      );
+      const admission = await admitInferenceChargeViaLedger({
+        charge: {
+          requestId,
+          organizationId: orgId,
+          userId: user.id,
+          apiKeyId,
+          model,
+          provider,
+          billingSource: billingSource ?? "",
+        },
+        estimatedCostUsd: backstopEstimateUsd,
+        thresholdUsd: resolveSafeBalanceThresholdUsd(),
+      });
+      if (admission.admitted) {
+        const ledgerSettler = createLedgerDebitSettler({
+          requestId,
+          organizationId: orgId,
+          userId: user.id,
+          apiKeyId,
+          model,
+          provider,
+          billingSource: billingSource ?? "",
+        });
+        reservation = {
+          reservedAmount: 0,
+          reservationTransactionId: null,
+          reconcile: async (actualCost: number) => {
+            await ledgerSettler(actualCost);
+          },
+        };
+        optimisticReady = true;
+      }
+    }
+
     if (
+      !optimisticReady &&
       orgId &&
-      isOptimisticBillingEnabled() &&
+      optimisticBillingEnabled &&
+      !useDbLedger &&
       isOptimisticBackstopAvailable()
     ) {
       // Embeddings cost ~$0, so SAFE_BALANCE_THRESHOLD is the real guard: the

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -150,6 +150,10 @@ REDIS_RATE_LIMITING = "false"
 # (no flag); a cache miss falls back to the authoritative slow path.
 INFERENCE_OPTIMISTIC_BILLING = "false"
 SAFE_BALANCE_THRESHOLD = ""
+# Optimistic-billing durable backstop: "db" = inference_pending_charges ledger
+# (atomic overdraw bound + exactly-once settle + age-ordered sweep); "" = KV
+# backstop (current). Off until soaked; cutover is an ops flip (#9899).
+INFERENCE_BILLING_LEDGER = ""
 FORCE_REDIS_EVENTS = "false"
 R2_PUBLIC_HOST = "blob.elizacloud.ai"
 SQL_HEAVY_PAYLOAD_STORAGE = "r2"
@@ -325,6 +329,10 @@ REDIS_RATE_LIMITING = "false"
 # (no flag); a cache miss falls back to the authoritative slow path.
 INFERENCE_OPTIMISTIC_BILLING = "false"
 SAFE_BALANCE_THRESHOLD = ""
+# Optimistic-billing durable backstop: "db" = inference_pending_charges ledger
+# (atomic overdraw bound + exactly-once settle + age-ordered sweep); "" = KV
+# backstop (current). Off until soaked; cutover is an ops flip (#9899).
+INFERENCE_BILLING_LEDGER = ""
 FORCE_REDIS_EVENTS = "false"
 R2_PUBLIC_HOST = "blob.elizacloud.ai"
 SQL_HEAVY_PAYLOAD_STORAGE = "r2"
@@ -457,6 +465,10 @@ REDIS_RATE_LIMITING = "false"
 # (no flag); a cache miss falls back to the authoritative slow path.
 INFERENCE_OPTIMISTIC_BILLING = "true"
 SAFE_BALANCE_THRESHOLD = "5.00"
+# Optimistic-billing durable backstop: "db" = inference_pending_charges ledger
+# (atomic overdraw bound + exactly-once settle + age-ordered sweep); "" = KV
+# backstop (current). Off until soaked; cutover is an ops flip (#9899).
+INFERENCE_BILLING_LEDGER = ""
 FORCE_REDIS_EVENTS = "false"
 R2_PUBLIC_HOST = "blob.elizacloud.ai"
 SQL_HEAVY_PAYLOAD_STORAGE = "r2"

--- a/packages/cloud/shared/src/db/inference-pending-charges-migration.test.ts
+++ b/packages/cloud/shared/src/db/inference-pending-charges-migration.test.ts
@@ -1,0 +1,139 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS ||= "1";
+
+/**
+ * #9899 — the migration that creates the `inference_pending_charges` DB ledger
+ * (the durable, exactly-once optimistic-billing backstop) must (a) exist and be
+ * registered in the Drizzle journal so it actually runs in prod, (b) be additive
+ * + idempotent (CREATE ... IF NOT EXISTS, guarded FKs) so re-running is safe, and
+ * (c) carry the partial indexes the admission gate + sweep rely on. The schema
+ * source-of-truth must be exported from the barrel so the Drizzle client and
+ * future generations see it. These checks need no live DB.
+ */
+const migrationsDir = join(import.meta.dirname, "migrations");
+const schemasDir = join(import.meta.dirname, "schemas");
+
+describe("inference_pending_charges migration (#9899)", () => {
+  const sqlPath = join(migrationsDir, "0153_inference_pending_charges.sql");
+
+  it("migration file exists and is registered in the journal", () => {
+    expect(existsSync(sqlPath)).toBe(true);
+    const journal = JSON.parse(
+      readFileSync(join(migrationsDir, "meta", "_journal.json"), "utf8"),
+    ) as { entries: Array<{ tag: string }> };
+    expect(journal.entries.some((e) => e.tag === "0153_inference_pending_charges")).toBe(true);
+  });
+
+  it("creates the table additively + idempotently with the exactly-once PK", () => {
+    const sql = readFileSync(sqlPath, "utf8");
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS "inference_pending_charges"/i);
+    // request_id PK is the exactly-once idempotency key.
+    expect(sql).toMatch(/"request_id" text PRIMARY KEY/i);
+    // Guarded, idempotent FK adds (re-run safe).
+    expect(sql).toMatch(/WHEN duplicate_object THEN null/i);
+    expect(sql).toMatch(/REFERENCES "public"\."organizations"/i);
+  });
+
+  it("carries the partial indexes the admission gate + sweep depend on", () => {
+    const sql = readFileSync(sqlPath, "utf8");
+    // Age-ordered sweep cursor.
+    expect(sql).toMatch(
+      /inference_pending_charges_pending_age_idx[\s\S]*\("enqueued_at"\)\s*WHERE status = 'pending'/i,
+    );
+    // Per-org in-flight SUM for the atomic admission gate.
+    expect(sql).toMatch(
+      /inference_pending_charges_org_pending_idx[\s\S]*\("organization_id"\)\s*WHERE status = 'pending'/i,
+    );
+  });
+
+  it("the schema source is exported from the barrel (Drizzle client + future gen)", () => {
+    expect(existsSync(join(schemasDir, "inference-pending-charges.ts"))).toBe(true);
+    const barrel = readFileSync(join(schemasDir, "index.ts"), "utf8");
+    expect(barrel).toContain("./inference-pending-charges");
+  });
+});
+
+/**
+ * Apply the REAL migration-file bytes against in-process PGlite (real Postgres in
+ * WASM) and prove the resulting table + partial indexes exist and that re-running
+ * the file is idempotent — so the SQL is valid DDL, not just regex-matched text.
+ * Self-skips if PGlite is unavailable.
+ */
+describe("inference_pending_charges migration applies to a real DB (#9899)", () => {
+  const sqlPath = join(migrationsDir, "0153_inference_pending_charges.sql");
+  let dbWrite: typeof import("./client").dbWrite;
+  let closeDb: typeof import("./client").closeDatabaseConnectionsForTests | undefined;
+  let pgliteReady = true;
+
+  async function applyMigration(): Promise<void> {
+    const file = readFileSync(sqlPath, "utf8");
+    for (const stmt of file.split("--> statement-breakpoint")) {
+      const trimmed = stmt.trim();
+      if (trimmed.length > 0) await dbWrite.execute(trimmed);
+    }
+  }
+
+  beforeAll(async () => {
+    try {
+      ({ dbWrite, closeDatabaseConnectionsForTests: closeDb } = await import("./client"));
+      // FK targets the migration references must pre-exist.
+      await dbWrite.execute(`CREATE TABLE IF NOT EXISTS organizations (id uuid PRIMARY KEY)`);
+      await dbWrite.execute(`CREATE TABLE IF NOT EXISTS users (id uuid PRIMARY KEY)`);
+      await dbWrite.execute(`DROP TABLE IF EXISTS inference_pending_charges`);
+    } catch (error) {
+      pgliteReady = false;
+      console.warn("[migration] PGlite unavailable, skipping DB apply:", error);
+    }
+  }, 60000);
+
+  afterAll(async () => {
+    if (closeDb) await closeDb();
+  });
+
+  it("applies cleanly and creates the table, PK, and both partial indexes", async () => {
+    if (!pgliteReady) return;
+    await applyMigration();
+
+    const cols = await dbWrite.execute(
+      `SELECT column_name FROM information_schema.columns WHERE table_name = 'inference_pending_charges' ORDER BY column_name`,
+    );
+    const names = (cols.rows as { column_name: string }[]).map((r) => r.column_name);
+    expect(names).toEqual(
+      [
+        "actual_cost_usd",
+        "api_key_id",
+        "billing_source",
+        "enqueued_at",
+        "estimated_cost_usd",
+        "model",
+        "organization_id",
+        "provider",
+        "request_id",
+        "settled_at",
+        "status",
+        "user_id",
+      ].sort(),
+    );
+
+    const idx = await dbWrite.execute(
+      `SELECT indexname FROM pg_indexes WHERE tablename = 'inference_pending_charges' ORDER BY indexname`,
+    );
+    const idxNames = (idx.rows as { indexname: string }[]).map((r) => r.indexname);
+    expect(idxNames).toContain("inference_pending_charges_pending_age_idx");
+    expect(idxNames).toContain("inference_pending_charges_org_pending_idx");
+  }, 60000);
+
+  it("is idempotent — re-applying the same file is a no-op (no duplicate-object error)", async () => {
+    if (!pgliteReady) return;
+    await applyMigration(); // second time
+    const t = await dbWrite.execute(
+      `SELECT count(*)::int AS n FROM information_schema.tables WHERE table_name = 'inference_pending_charges'`,
+    );
+    expect(Number((t.rows[0] as { n: number }).n)).toBe(1);
+  }, 60000);
+});

--- a/packages/cloud/shared/src/db/migrations/0153_inference_pending_charges.sql
+++ b/packages/cloud/shared/src/db/migrations/0153_inference_pending_charges.sql
@@ -1,0 +1,44 @@
+-- DB-backed pending-charge + settlement ledger for Tier-2 optimistic inference
+-- billing (#9899). The durable, exactly-once replacement for the KV pending-charge
+-- backstop — it closes the at-scale residuals KV cannot:
+--   * hard concurrent-overdraw bound  (atomic admission under an org row lock),
+--   * exactly-once settlement          (request_id PK + `WHERE status='pending'` claim),
+--   * age-ordered sweep drain          (partial index on enqueued_at).
+--
+-- See packages/cloud/api/docs/inference-hot-path.md and
+-- packages/cloud/shared/src/lib/services/inference-billing-ledger.ts.
+--
+-- Additive + idempotent: CREATE TABLE / INDEX IF NOT EXISTS, guarded FKs, no
+-- backfill, no drops. Selected at runtime by INFERENCE_BILLING_LEDGER="db"
+-- (default "kv") so creating the table changes no behavior until the flag flips.
+
+CREATE TABLE IF NOT EXISTS "inference_pending_charges" (
+	"request_id" text PRIMARY KEY NOT NULL,
+	"organization_id" uuid NOT NULL,
+	"user_id" uuid,
+	"api_key_id" uuid,
+	"model" text NOT NULL,
+	"provider" text NOT NULL,
+	"billing_source" text NOT NULL,
+	"estimated_cost_usd" numeric(12, 6) NOT NULL,
+	"actual_cost_usd" numeric(12, 6),
+	"status" text DEFAULT 'pending' NOT NULL,
+	"enqueued_at" timestamp DEFAULT now() NOT NULL,
+	"settled_at" timestamp
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "inference_pending_charges" ADD CONSTRAINT "inference_pending_charges_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "inference_pending_charges" ADD CONSTRAINT "inference_pending_charges_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "inference_pending_charges_pending_age_idx" ON "inference_pending_charges" USING btree ("enqueued_at") WHERE status = 'pending';
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "inference_pending_charges_org_pending_idx" ON "inference_pending_charges" USING btree ("organization_id") WHERE status = 'pending';

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1058,6 +1058,13 @@
       "when": 1780100400000,
       "tag": "0152_agent_sandboxes_previous_image",
       "breakpoints": true
+    },
+    {
+      "idx": 151,
+      "version": "7",
+      "when": 1780186800000,
+      "tag": "0153_inference_pending_charges",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/schemas/index.ts
+++ b/packages/cloud/shared/src/db/schemas/index.ts
@@ -50,6 +50,7 @@ export * from "./eliza-room-characters";
 export * from "./entity-settings";
 export * from "./generations";
 export * from "./idempotency-keys";
+export * from "./inference-pending-charges";
 export * from "./invoices";
 export * from "./jobs";
 export * from "./llm-trajectories";

--- a/packages/cloud/shared/src/db/schemas/inference-pending-charges.ts
+++ b/packages/cloud/shared/src/db/schemas/inference-pending-charges.ts
@@ -1,0 +1,73 @@
+import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+import { index, numeric, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { organizations } from "./organizations";
+import { users } from "./users";
+
+/**
+ * DB-backed pending-charge + settlement ledger for Tier-2 optimistic inference
+ * billing (#9899).
+ *
+ * This is the durable, exactly-once replacement for the KV pending-charge
+ * backstop (`iac:pending:<requestId>`). It exists to close the at-scale residuals
+ * that a KV-only backstop cannot — they require a real database:
+ *
+ *   1. Hard concurrent-overdraw bound — admission accounts for every in-flight
+ *      pending charge of the org under a row lock, so a burst can't collectively
+ *      overdraw. KV has no per-org atomic accounting.
+ *   2. Exactly-once settlement — `request_id` is the primary key and the settle
+ *      is an atomic `UPDATE ... WHERE status = 'pending'` claim, so the inline
+ *      settler and the cron sweep can never both charge one request. KV's
+ *      get-then-delete is only near-atomic.
+ *   3. Age-ordered sweep drain — the cron drains oldest-pending-first via an
+ *      indexed `ORDER BY enqueued_at` cursor with no silent cap. KV scan is an
+ *      unordered, bounded prefix scan.
+ *
+ * Lifecycle of a row:
+ *   - `pending`     — admitted on the hot path; counted against the org balance.
+ *   - `settled`     — the inline settler (or sweep) claimed it and the actual
+ *                     (or estimated) cost was debited.
+ *   - `uncollected` — claimed, but the debit was refused (balance would go
+ *                     negative; the DB `CHECK(credit_balance >= 0)` forbids it).
+ *                     Bounded over-spend, recorded for alerting/audit, never a
+ *                     free-forever loop (the org drops to the safe path).
+ *
+ * See `packages/cloud/api/docs/inference-hot-path.md` and
+ * `lib/services/inference-billing-ledger.ts`.
+ */
+export const inferencePendingCharges = pgTable(
+  "inference_pending_charges",
+  {
+    /** The request id — the idempotency key. PK ⇒ exactly-once settlement. */
+    request_id: text("request_id").primaryKey(),
+    organization_id: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    user_id: uuid("user_id").references(() => users.id, { onDelete: "set null" }),
+    /** Informational; not FK-constrained so a key rotation can't orphan a row. */
+    api_key_id: uuid("api_key_id"),
+    model: text("model").notNull(),
+    provider: text("provider").notNull(),
+    billing_source: text("billing_source").notNull(),
+    /** Pre-forward cost estimate; the in-flight amount the admission gate reserves. */
+    estimated_cost_usd: numeric("estimated_cost_usd", { precision: 12, scale: 6 }).notNull(),
+    /** The amount actually charged at settle (actual inline, estimate via sweep). */
+    actual_cost_usd: numeric("actual_cost_usd", { precision: 12, scale: 6 }),
+    status: text("status").notNull().default("pending"),
+    enqueued_at: timestamp("enqueued_at").notNull().defaultNow(),
+    settled_at: timestamp("settled_at"),
+  },
+  (table) => ({
+    /** Age-ordered sweep over still-pending rows (oldest-first cursor, no cap). */
+    pending_age_idx: index("inference_pending_charges_pending_age_idx")
+      .on(table.enqueued_at)
+      .where(sql`status = 'pending'`),
+    /** Per-org in-flight SUM for the atomic admission gate. */
+    org_pending_idx: index("inference_pending_charges_org_pending_idx")
+      .on(table.organization_id)
+      .where(sql`status = 'pending'`),
+  }),
+);
+
+export type InferencePendingChargeRow = InferSelectModel<typeof inferencePendingCharges>;
+export type NewInferencePendingChargeRow = InferInsertModel<typeof inferencePendingCharges>;

--- a/packages/cloud/shared/src/lib/services/__tests__/inference-billing-ledger.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/inference-billing-ledger.test.ts
@@ -1,0 +1,524 @@
+/**
+ * Real-DB coverage for the DB-backed pending-charge + settlement ledger (#9899).
+ *
+ * The ledger is the durable, exactly-once replacement for the KV optimistic
+ * backstop, and it is BILLING-CRITICAL: it decides who may skip the synchronous
+ * reserve (admission) and how the deferred cost is collected (settle / sweep). A
+ * regression here is either a free-inference leak or a double charge, so every
+ * test drives the REAL SQL against in-process PGlite — the same honest pattern as
+ * `credits-deduct-guard.test.ts`. Only the fire-and-forget, non-billing
+ * side-effects on the deduct success path (email / webhook / auto-top-up) are
+ * stubbed; the admission accounting, the atomic claim, and the debit run real.
+ *
+ * What is pinned:
+ *   - Admission: affordable → admitted; threshold gate; HARD overdraw bound
+ *     (balance − in-flight); unknown org; +Inf threshold; idempotent re-delivery.
+ *   - Settle: inline claims + debits the ACTUAL; EXACTLY-ONCE (a second settle and
+ *     the sweep cannot re-charge); settle(0) claims but charges nothing;
+ *     uncollected (debit refused by CHECK(>=0)) → row marked, balance intact.
+ *   - Sweep: drains stale pending charging the ESTIMATE; skips young rows;
+ *     age-ordered across batches; inline-then-sweep never double-charges.
+ *   - Concurrency: a same-org burst cannot collectively overdraw.
+ *
+ * Self-skips if PGlite is unavailable (mirrors the sibling suite).
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS ||= "1";
+
+// Stub the non-billing fire-and-forget side-effects the deduct success path kicks
+// off — NOT the code under test. The deduct + guard SQL runs real against PGlite.
+mock.module("../email", () => ({
+  emailService: { sendLowCreditsEmail: mock(async () => false) },
+}));
+mock.module("../waifu-webhook", () => ({
+  resolveWaifuWebhookTarget: mock(() => null),
+  classifyCreditBalance: mock(() => null),
+  emitWaifuCreditWebhook: mock(async () => undefined),
+}));
+mock.module("../auto-top-up", () => ({
+  autoTopUpService: { executeAutoTopUp: mock(async () => undefined) },
+}));
+
+const PGLITE_TIMEOUT = 60000;
+
+const ORG_ID = "00000000-0000-0000-0000-00000000ce01";
+const USER_ID = "00000000-0000-0000-0000-00000000ce02";
+
+let dbWrite: typeof import("../../../db/client").dbWrite;
+let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
+let ledger: typeof import("../inference-billing-ledger");
+let pgliteReady = true;
+
+let chargeSeq = 0;
+function nextRequestId(): string {
+  chargeSeq += 1;
+  return `req-ledger-${chargeSeq}`;
+}
+
+function charge(requestId: string) {
+  return {
+    requestId,
+    organizationId: ORG_ID,
+    userId: USER_ID,
+    apiKeyId: null,
+    model: "gpt-oss-120b",
+    provider: "cerebras",
+    billingSource: "platform" as const,
+  };
+}
+
+async function seedOrg(balance: string): Promise<void> {
+  await dbWrite.execute(`DELETE FROM inference_pending_charges;`);
+  await dbWrite.execute(`DELETE FROM credit_transactions;`);
+  await dbWrite.execute(`DELETE FROM organizations;`);
+  await dbWrite.execute(
+    `INSERT INTO organizations (id, name, slug, credit_balance, pay_as_you_go_from_earnings, is_active)
+     VALUES ('${ORG_ID}', 'Acme', 'acme-${ORG_ID}', '${balance}', true, true);`,
+  );
+}
+
+async function readBalance(): Promise<number> {
+  const rows = await dbWrite.execute(
+    `SELECT credit_balance FROM organizations WHERE id = '${ORG_ID}';`,
+  );
+  return Number((rows.rows[0] as { credit_balance: string }).credit_balance);
+}
+
+async function pendingRows(): Promise<
+  { request_id: string; status: string; estimated: number; actual: number | null }[]
+> {
+  const rows = await dbWrite.execute(
+    `SELECT request_id, status, estimated_cost_usd, actual_cost_usd
+     FROM inference_pending_charges ORDER BY enqueued_at ASC;`,
+  );
+  return (
+    rows.rows as {
+      request_id: string;
+      status: string;
+      estimated_cost_usd: string;
+      actual_cost_usd: string | null;
+    }[]
+  ).map((r) => ({
+    request_id: r.request_id,
+    status: r.status,
+    estimated: Number(r.estimated_cost_usd),
+    actual: r.actual_cost_usd === null ? null : Number(r.actual_cost_usd),
+  }));
+}
+
+async function debitCount(): Promise<number> {
+  const rows = await dbWrite.execute(
+    `SELECT count(*)::int AS n FROM credit_transactions WHERE organization_id = '${ORG_ID}' AND type = 'debit';`,
+  );
+  return Number((rows.rows[0] as { n: number }).n);
+}
+
+/** Insert a pending row directly with a controlled age (for sweep/uncollected setup). */
+async function insertPending(requestId: string, estimate: string, ageMs: number): Promise<void> {
+  await dbWrite.execute(
+    `INSERT INTO inference_pending_charges
+       (request_id, organization_id, user_id, api_key_id, model, provider, billing_source, estimated_cost_usd, status, enqueued_at)
+     VALUES ('${requestId}', '${ORG_ID}', '${USER_ID}', NULL, 'gpt-oss-120b', 'cerebras', 'platform', '${estimate}', 'pending', NOW() - INTERVAL '${ageMs} milliseconds');`,
+  );
+}
+
+beforeAll(async () => {
+  try {
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
+    ledger = await import("../inference-billing-ledger");
+
+    const ddl = [
+      `CREATE TABLE IF NOT EXISTS organizations (
+        id uuid PRIMARY KEY,
+        name text NOT NULL,
+        slug text NOT NULL,
+        credit_balance numeric(12,6) NOT NULL DEFAULT '0' CHECK (credit_balance >= 0),
+        settings jsonb DEFAULT '{}',
+        stripe_customer_id text,
+        billing_email text,
+        stripe_payment_method_id text,
+        stripe_default_payment_method text,
+        auto_top_up_enabled boolean DEFAULT false,
+        auto_top_up_threshold numeric(10,2),
+        auto_top_up_amount numeric(10,2),
+        pay_as_you_go_from_earnings boolean NOT NULL DEFAULT true,
+        steward_tenant_id text,
+        steward_tenant_api_key text,
+        is_active boolean NOT NULL DEFAULT true,
+        created_at timestamp NOT NULL DEFAULT now(),
+        updated_at timestamp NOT NULL DEFAULT now()
+      )`,
+      `CREATE TABLE IF NOT EXISTS credit_transactions (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        organization_id uuid NOT NULL,
+        user_id uuid,
+        amount numeric(12,6) NOT NULL,
+        type text NOT NULL,
+        description text,
+        metadata jsonb NOT NULL DEFAULT '{}',
+        stripe_payment_intent_id text,
+        created_at timestamp NOT NULL DEFAULT now()
+      )`,
+      `CREATE UNIQUE INDEX IF NOT EXISTS credit_transactions_stripe_payment_intent_idx
+        ON credit_transactions (stripe_payment_intent_id)`,
+      // The table under test — matches migration 0153 + the schema.
+      `CREATE TABLE IF NOT EXISTS inference_pending_charges (
+        request_id text PRIMARY KEY,
+        organization_id uuid NOT NULL,
+        user_id uuid,
+        api_key_id uuid,
+        model text NOT NULL,
+        provider text NOT NULL,
+        billing_source text NOT NULL,
+        estimated_cost_usd numeric(12,6) NOT NULL,
+        actual_cost_usd numeric(12,6),
+        status text NOT NULL DEFAULT 'pending',
+        enqueued_at timestamp NOT NULL DEFAULT now(),
+        settled_at timestamp
+      )`,
+      `CREATE INDEX IF NOT EXISTS inference_pending_charges_pending_age_idx
+        ON inference_pending_charges (enqueued_at) WHERE status = 'pending'`,
+      `CREATE INDEX IF NOT EXISTS inference_pending_charges_org_pending_idx
+        ON inference_pending_charges (organization_id) WHERE status = 'pending'`,
+    ];
+    for (const stmt of ddl) await dbWrite.execute(stmt);
+  } catch (error) {
+    pgliteReady = false;
+    console.warn("[inference-billing-ledger] PGlite unavailable, skipping DB cases:", error);
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
+describe("admitInferenceChargeViaLedger — atomic admission gate", () => {
+  beforeEach(async () => {
+    if (!pgliteReady) return;
+    await seedOrg("10.000000");
+  });
+
+  test(
+    "admits an affordable charge and writes exactly one pending row at the estimate",
+    async () => {
+      if (!pgliteReady) return;
+      const reqId = nextRequestId();
+      const res = await ledger.admitInferenceChargeViaLedger({
+        charge: charge(reqId),
+        estimatedCostUsd: 3,
+        thresholdUsd: 1,
+      });
+      expect(res.admitted).toBe(true);
+      const rows = await pendingRows();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({ request_id: reqId, status: "pending", estimated: 3 });
+      // Admission reserves in-flight only — it must NOT move the balance yet.
+      expect(await readBalance()).toBeCloseTo(10, 6);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "rejects when the balance does not clear the threshold (no row written)",
+    async () => {
+      if (!pgliteReady) return;
+      const res = await ledger.admitInferenceChargeViaLedger({
+        charge: charge(nextRequestId()),
+        estimatedCostUsd: 1,
+        thresholdUsd: 10, // balance 10 is NOT > 10
+      });
+      expect(res.admitted).toBe(false);
+      expect(res.reason).toBe("ineligible");
+      expect(await pendingRows()).toHaveLength(0);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "HARD overdraw bound: admission accounts for in-flight pending charges",
+    async () => {
+      if (!pgliteReady) return;
+      // $8 already in-flight against a $10 balance, threshold $1.
+      await insertPending(nextRequestId(), "5.000000", 1000);
+      await insertPending(nextRequestId(), "3.000000", 1000);
+
+      // available = 10 - 8 = 2. A $3 charge must be REFUSED (would overdraw)...
+      const tooBig = await ledger.admitInferenceChargeViaLedger({
+        charge: charge(nextRequestId()),
+        estimatedCostUsd: 3,
+        thresholdUsd: 1,
+      });
+      expect(tooBig.admitted).toBe(false);
+      expect(tooBig.reason).toBe("ineligible");
+
+      // ...but a $2 charge sits exactly on the boundary and is admitted.
+      const onBoundary = await ledger.admitInferenceChargeViaLedger({
+        charge: charge(nextRequestId()),
+        estimatedCostUsd: 2,
+        thresholdUsd: 1,
+      });
+      expect(onBoundary.admitted).toBe(true);
+
+      // Total in-flight now exactly equals the balance — never more.
+      const inflight = (await pendingRows())
+        .filter((r) => r.status === "pending")
+        .reduce((s, r) => s + r.estimated, 0);
+      expect(inflight).toBeCloseTo(10, 6);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "rejects an unknown organization with reason org_not_found",
+    async () => {
+      if (!pgliteReady) return;
+      const res = await ledger.admitInferenceChargeViaLedger({
+        charge: {
+          ...charge(nextRequestId()),
+          organizationId: "00000000-0000-0000-0000-00000000dead",
+        },
+        estimatedCostUsd: 1,
+        thresholdUsd: 1,
+      });
+      expect(res.admitted).toBe(false);
+      expect(res.reason).toBe("org_not_found");
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "fails SAFE on a +Infinity threshold (misconfigured SAFE_BALANCE_THRESHOLD) without touching the DB",
+    async () => {
+      if (!pgliteReady) return;
+      const res = await ledger.admitInferenceChargeViaLedger({
+        charge: charge(nextRequestId()),
+        estimatedCostUsd: 1,
+        thresholdUsd: Number.POSITIVE_INFINITY,
+      });
+      expect(res.admitted).toBe(false);
+      expect(await pendingRows()).toHaveLength(0);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "idempotent re-delivery: the same request id never writes a second pending row",
+    async () => {
+      if (!pgliteReady) return;
+      const reqId = nextRequestId();
+      const first = await ledger.admitInferenceChargeViaLedger({
+        charge: charge(reqId),
+        estimatedCostUsd: 2,
+        thresholdUsd: 1,
+      });
+      expect(first.admitted).toBe(true);
+      // Re-admitting the same id is an ON CONFLICT DO NOTHING → not admitted, so
+      // the route falls to the safe synchronous reserve (matches the KV backstop).
+      const second = await ledger.admitInferenceChargeViaLedger({
+        charge: charge(reqId),
+        estimatedCostUsd: 2,
+        thresholdUsd: 1,
+      });
+      expect(second.admitted).toBe(false);
+      expect(await pendingRows()).toHaveLength(1);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a same-org concurrent burst cannot collectively overdraw",
+    async () => {
+      if (!pgliteReady) return;
+      // Balance $10, threshold $1, three concurrent $6 charges. At most one can be
+      // admitted ($6 ≤ $10; the next sees available $4 < $6).
+      const results = await Promise.all(
+        [0, 1, 2].map(() =>
+          ledger.admitInferenceChargeViaLedger({
+            charge: charge(nextRequestId()),
+            estimatedCostUsd: 6,
+            thresholdUsd: 1,
+          }),
+        ),
+      );
+      const admitted = results.filter((r) => r.admitted).length;
+      expect(admitted).toBe(1);
+      const inflight = (await pendingRows())
+        .filter((r) => r.status === "pending")
+        .reduce((s, r) => s + r.estimated, 0);
+      expect(inflight).toBeLessThanOrEqual(10);
+    },
+    PGLITE_TIMEOUT,
+  );
+});
+
+describe("createLedgerDebitSettler — exactly-once inline settlement", () => {
+  beforeEach(async () => {
+    if (!pgliteReady) return;
+    await seedOrg("10.000000");
+  });
+
+  test(
+    "settles the ACTUAL cost: claims the row, debits once, moves the balance by -actual",
+    async () => {
+      if (!pgliteReady) return;
+      const reqId = nextRequestId();
+      await ledger.admitInferenceChargeViaLedger({
+        charge: charge(reqId),
+        estimatedCostUsd: 3,
+        thresholdUsd: 1,
+      });
+      const settle = ledger.createLedgerDebitSettler(charge(reqId));
+      await settle(2.5);
+
+      expect(await readBalance()).toBeCloseTo(7.5, 6);
+      expect(await debitCount()).toBe(1);
+      const row = (await pendingRows())[0];
+      expect(row).toMatchObject({ status: "settled", actual: 2.5 });
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "EXACTLY-ONCE: a second settle of the same request charges nothing more",
+    async () => {
+      if (!pgliteReady) return;
+      const reqId = nextRequestId();
+      await ledger.admitInferenceChargeViaLedger({
+        charge: charge(reqId),
+        estimatedCostUsd: 3,
+        thresholdUsd: 1,
+      });
+      const settle = ledger.createLedgerDebitSettler(charge(reqId));
+      await settle(2.5);
+      await settle(2.5); // duplicate (retry / double waitUntil)
+
+      expect(await readBalance()).toBeCloseTo(7.5, 6); // not 5.0
+      expect(await debitCount()).toBe(1);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "settle(0) (error/abort) claims the row but charges nothing",
+    async () => {
+      if (!pgliteReady) return;
+      const reqId = nextRequestId();
+      await ledger.admitInferenceChargeViaLedger({
+        charge: charge(reqId),
+        estimatedCostUsd: 3,
+        thresholdUsd: 1,
+      });
+      await ledger.createLedgerDebitSettler(charge(reqId))(0);
+
+      expect(await readBalance()).toBeCloseTo(10, 6);
+      expect(await debitCount()).toBe(0);
+      expect((await pendingRows())[0]).toMatchObject({ status: "settled", actual: 0 });
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "uncollected: a debit the DB refuses (would overdraw) marks the row, leaves the balance intact",
+    async () => {
+      if (!pgliteReady) return;
+      const reqId = nextRequestId();
+      await ledger.admitInferenceChargeViaLedger({
+        charge: charge(reqId),
+        estimatedCostUsd: 1,
+        thresholdUsd: 0.5,
+      });
+      // Drain the org to $0.50 out-of-band, then settle an actual that exceeds it.
+      await dbWrite.execute(
+        `UPDATE organizations SET credit_balance = '0.500000' WHERE id = '${ORG_ID}';`,
+      );
+      await ledger.createLedgerDebitSettler(charge(reqId))(5);
+
+      // CHECK(credit_balance >= 0) refused the debit → balance untouched, no debit row.
+      expect(await readBalance()).toBeCloseTo(0.5, 6);
+      expect(await debitCount()).toBe(0);
+      // The charge is recorded uncollected (auditable), not left pending forever.
+      expect((await pendingRows())[0]).toMatchObject({ status: "uncollected" });
+    },
+    PGLITE_TIMEOUT,
+  );
+});
+
+describe("sweepStalePendingInferenceChargesDb — cron backstop", () => {
+  beforeEach(async () => {
+    if (!pgliteReady) return;
+    await seedOrg("100.000000");
+  });
+
+  test(
+    "settles stale pending rows charging the ESTIMATE; skips young ones",
+    async () => {
+      if (!pgliteReady) return;
+      const stale = nextRequestId();
+      const young = nextRequestId();
+      await insertPending(stale, "4.000000", 30 * 60 * 1000); // 30 min old → stale
+      await insertPending(young, "2.000000", 60 * 1000); // 1 min old → in-flight
+
+      const stats = await ledger.sweepStalePendingInferenceChargesDb({ graceMs: 20 * 60 * 1000 });
+
+      expect(stats.settled).toBe(1);
+      expect(await readBalance()).toBeCloseTo(96, 6); // only the $4 stale charge
+      const rows = await pendingRows();
+      expect(rows.find((r) => r.request_id === stale)?.status).toBe("settled");
+      expect(rows.find((r) => r.request_id === young)?.status).toBe("pending");
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "inline-then-sweep never double-charges (the inline settle already claimed it)",
+    async () => {
+      if (!pgliteReady) return;
+      const reqId = nextRequestId();
+      await ledger.admitInferenceChargeViaLedger({
+        charge: charge(reqId),
+        estimatedCostUsd: 4,
+        thresholdUsd: 1,
+      });
+      await ledger.createLedgerDebitSettler(charge(reqId))(3); // inline: balance 100 → 97
+      // Even though the row is now old, the sweep finds nothing pending to charge.
+      const stats = await ledger.sweepStalePendingInferenceChargesDb({ graceMs: 0 });
+      expect(stats.settled).toBe(0);
+      expect(await readBalance()).toBeCloseTo(97, 6);
+      expect(await debitCount()).toBe(1);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "drains the whole stale backlog oldest-first across multiple batches (no silent cap)",
+    async () => {
+      if (!pgliteReady) return;
+      for (let i = 0; i < 5; i++) {
+        await insertPending(nextRequestId(), "1.000000", (40 + i) * 60 * 1000);
+      }
+      const stats = await ledger.sweepStalePendingInferenceChargesDb({
+        graceMs: 20 * 60 * 1000,
+        batchSize: 2, // force multiple batches
+      });
+      expect(stats.settled).toBe(5);
+      expect(stats.batches).toBeGreaterThanOrEqual(3);
+      expect(await readBalance()).toBeCloseTo(95, 6);
+      expect((await pendingRows()).every((r) => r.status === "settled")).toBe(true);
+    },
+    PGLITE_TIMEOUT,
+  );
+});
+
+describe("resolveInferenceBillingLedger — backstop selector", () => {
+  test("only 'db' (case/space-insensitive) selects the DB ledger; everything else is 'kv'", () => {
+    expect(ledger.resolveInferenceBillingLedger({ INFERENCE_BILLING_LEDGER: "db" })).toBe("db");
+    expect(ledger.resolveInferenceBillingLedger({ INFERENCE_BILLING_LEDGER: " DB " })).toBe("db");
+    expect(ledger.resolveInferenceBillingLedger({ INFERENCE_BILLING_LEDGER: "kv" })).toBe("kv");
+    expect(ledger.resolveInferenceBillingLedger({ INFERENCE_BILLING_LEDGER: "" })).toBe("kv");
+    expect(ledger.resolveInferenceBillingLedger({})).toBe("kv");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/inference-billing-ledger.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-ledger.ts
@@ -1,0 +1,375 @@
+/**
+ * DB-backed pending-charge + settlement ledger for Tier-2 optimistic inference
+ * billing (#9899) — the documented "next step" that closes the at-scale residuals
+ * a KV-only backstop cannot:
+ *
+ *   - **Hard concurrent-overdraw bound.** Admission runs ONE atomic statement
+ *     that locks the org row (`FOR UPDATE`), subtracts the SUM of the org's
+ *     still-pending charges from its balance, and only inserts a new pending row
+ *     if `balance - in-flight >= estimate` (and `balance > threshold`). Concurrent
+ *     admissions for one org serialize on the row lock, so a burst can never
+ *     collectively overdraw — the KV gate could only bound this softly via the
+ *     threshold.
+ *   - **Exactly-once settlement.** `request_id` is the table PK and the settle is
+ *     an atomic `UPDATE ... WHERE status = 'pending'` claim, so the inline settler
+ *     and the cron sweep can never both charge one request. (KV's get-then-delete
+ *     was only near-atomic ⇒ a rare double-bill; the row claim removes it.)
+ *   - **Age-ordered sweep drain.** The cron drains oldest-pending-first through an
+ *     indexed `ORDER BY enqueued_at` cursor and loops until empty — no silent cap.
+ *
+ * Money flow mirrors the KV path: admit (reserve in-flight) → forward → settle the
+ * ACTUAL cost off the response path (sweep settles the ESTIMATE for stragglers).
+ * The actual debit goes through the single audited `creditsService.deductCredits`
+ * mutation (atomic balance guard + `CHECK(credit_balance >= 0)` + all
+ * notifications), so there is exactly ONE credit-mutation codepath. A debit the DB
+ * refuses (would go negative) is recorded `uncollected` and the org self-heals onto
+ * the safe synchronous-reserve path — bounded over-spend, never free-forever.
+ *
+ * Selected by `INFERENCE_BILLING_LEDGER="db"` (default `kv` = the existing backstop
+ * in `inference-billing-fast-path.ts`); both are gated behind
+ * `INFERENCE_OPTIMISTIC_BILLING`. See `packages/cloud/api/docs/inference-hot-path.md`.
+ */
+
+import { sql } from "drizzle-orm";
+import { sqlRows } from "../../db/execute-helpers";
+import { dbWrite } from "../../db/helpers";
+import { getCloudAwareEnv } from "../runtime/cloud-bindings";
+import { logger } from "../utils/logger";
+import { type CreditReconciliationResult, creditsService } from "./credits";
+import { invalidateOrgBalanceHint } from "./inference-auth-cache";
+
+export type InferenceBillingLedger = "db" | "kv";
+
+type StringEnv = Record<string, string | undefined>;
+
+/**
+ * Which durable backstop the optimistic path uses. Default `kv` (the shipped
+ * backstop) so flipping `INFERENCE_BILLING_LEDGER` is the only thing that moves an
+ * environment onto the DB ledger — a deliberate, soak-then-cutover migration.
+ */
+export function resolveInferenceBillingLedger(
+  env: StringEnv = getCloudAwareEnv(),
+): InferenceBillingLedger {
+  return (env.INFERENCE_BILLING_LEDGER ?? "").trim().toLowerCase() === "db" ? "db" : "kv";
+}
+
+/** Default sweep grace: a pending row older than this with no inline settle is a straggler. */
+const DEFAULT_SWEEP_GRACE_MS = 20 * 60 * 1000; // 20 min (> max route duration)
+
+export interface LedgerChargeContext {
+  requestId: string;
+  organizationId: string;
+  userId: string;
+  apiKeyId: string | null;
+  model: string;
+  provider: string;
+  billingSource: string;
+}
+
+export interface LedgerAdmission {
+  admitted: boolean;
+  /** Why admission was refused — for the `[preforward]` log / fallback decision. */
+  reason?: "ineligible" | "org_not_found" | "error";
+}
+
+interface AdmissionRow {
+  org_exists: boolean | "t" | "f" | null;
+  admitted_request_id: string | null;
+}
+
+function isPgTrue(value: boolean | "t" | "f" | null | undefined): boolean {
+  return value === true || value === "t";
+}
+
+/**
+ * Atomically admit an optimistic charge against the org's available balance.
+ *
+ * One statement, one org-row lock: read the live balance, sum the org's
+ * still-`pending` charges, and INSERT a pending row ONLY when the balance clears
+ * the threshold AND `balance - in-flight >= estimate`. Returns `admitted:false`
+ * (→ caller takes the synchronous reserve) when the gate fails, the org is
+ * missing, or the row already exists (idempotent re-delivery). Never throws — a
+ * DB error resolves to `admitted:false` so the request falls back to the safe
+ * path rather than forwarding on an unrecorded charge.
+ */
+export async function admitInferenceChargeViaLedger(params: {
+  charge: LedgerChargeContext;
+  estimatedCostUsd: number;
+  thresholdUsd: number;
+}): Promise<LedgerAdmission> {
+  const { charge, estimatedCostUsd, thresholdUsd } = params;
+
+  // +Inf threshold (misconfig / unset SAFE_BALANCE_THRESHOLD) ⇒ no org is ever
+  // fast-pathed. Mirror the fast-path gate's fail-safe so the two backends agree.
+  if (!Number.isFinite(thresholdUsd)) return { admitted: false, reason: "ineligible" };
+  if (!(estimatedCostUsd >= 0)) return { admitted: false, reason: "ineligible" };
+
+  try {
+    const rows = await sqlRows<AdmissionRow>(
+      dbWrite,
+      sql`
+        WITH locked_org AS (
+          SELECT id, credit_balance::numeric AS balance
+          FROM organizations
+          WHERE id = ${charge.organizationId}
+          FOR UPDATE
+        ),
+        inflight AS (
+          SELECT COALESCE(SUM(estimated_cost_usd), 0)::numeric AS pending_sum
+          FROM inference_pending_charges
+          WHERE organization_id = ${charge.organizationId}
+            AND status = 'pending'
+        ),
+        gate AS (
+          SELECT locked_org.id
+          FROM locked_org, inflight
+          WHERE locked_org.balance > ${String(thresholdUsd)}::numeric
+            AND (locked_org.balance - inflight.pending_sum) >= ${String(estimatedCostUsd)}::numeric
+        ),
+        inserted AS (
+          INSERT INTO inference_pending_charges (
+            request_id, organization_id, user_id, api_key_id,
+            model, provider, billing_source, estimated_cost_usd, status, enqueued_at
+          )
+          SELECT
+            ${charge.requestId}, gate.id, ${charge.userId}, ${charge.apiKeyId},
+            ${charge.model}, ${charge.provider}, ${charge.billingSource},
+            ${String(estimatedCostUsd)}::numeric, 'pending', NOW()
+          FROM gate
+          ON CONFLICT (request_id) DO NOTHING
+          RETURNING request_id
+        )
+        SELECT
+          EXISTS(SELECT 1 FROM locked_org) AS org_exists,
+          (SELECT request_id FROM inserted) AS admitted_request_id
+      `,
+    );
+    const row = rows[0];
+    if (!row || !isPgTrue(row.org_exists)) return { admitted: false, reason: "org_not_found" };
+    if (!row.admitted_request_id) return { admitted: false, reason: "ineligible" };
+    return { admitted: true };
+  } catch (error) {
+    logger.error("[InferenceLedger] admission failed; falling back to synchronous reserve", {
+      requestId: charge.requestId,
+      organizationId: charge.organizationId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { admitted: false, reason: "error" };
+  }
+}
+
+interface ClaimRow {
+  organization_id: string | null;
+}
+
+/**
+ * Atomically CLAIM a pending charge: flip `pending → settled` for this request and
+ * stamp the cost. Returns the org id when THIS caller won the claim, or null when
+ * the row was already settled (the sweep got there first, or a duplicate settle).
+ * This `WHERE status = 'pending'` transition is the exactly-once gate — only one of
+ * {inline settler, sweep} can ever own a given request.
+ */
+async function claimPendingCharge(requestId: string, costUsd: number): Promise<string | null> {
+  const rows = await sqlRows<ClaimRow>(
+    dbWrite,
+    sql`
+      UPDATE inference_pending_charges
+      SET status = 'settled', settled_at = NOW(), actual_cost_usd = ${String(costUsd)}::numeric
+      WHERE request_id = ${requestId} AND status = 'pending'
+      RETURNING organization_id
+    `,
+  );
+  return rows[0]?.organization_id ?? null;
+}
+
+/** Mark a claimed row `uncollected` for audit when its debit was refused. Best-effort. */
+async function markUncollected(requestId: string): Promise<void> {
+  try {
+    await dbWrite.execute(
+      sql`UPDATE inference_pending_charges SET status = 'uncollected' WHERE request_id = ${requestId}`,
+    );
+  } catch (error) {
+    logger.warn("[InferenceLedger] failed to mark charge uncollected", {
+      requestId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/**
+ * Debit a claimed charge through the single audited credit mutation. On a refused
+ * debit (balance would go negative — the DB forbids it) record the uncollected
+ * amount, drop the org-balance hint, and mark the row; the org's next admission
+ * reads the now-depleted balance and self-heals onto the synchronous-reserve path.
+ * Never throws.
+ */
+async function debitClaimedCharge(
+  ctx: LedgerChargeContext,
+  amountUsd: number,
+  source: "inline" | "sweep",
+): Promise<void> {
+  try {
+    const result = await creditsService.deductCredits({
+      organizationId: ctx.organizationId,
+      amount: amountUsd,
+      description: `Inference (ledger ${source}): ${ctx.model}`,
+      metadata: {
+        user_id: ctx.userId,
+        requestId: ctx.requestId,
+        model: ctx.model,
+        provider: ctx.provider,
+        billingSource: ctx.billingSource,
+        type: "inference_optimistic_ledger",
+        source,
+      },
+    });
+    if (result.success) return;
+    logger.error("[InferenceLedger] uncollected inference charge", {
+      organizationId: ctx.organizationId,
+      userId: ctx.userId,
+      requestId: ctx.requestId,
+      amountUsd,
+      source,
+      reason: result.reason,
+    });
+    await invalidateOrgBalanceHint(ctx.organizationId);
+    await markUncollected(ctx.requestId);
+  } catch (error) {
+    logger.error("[InferenceLedger] inference debit threw", {
+      organizationId: ctx.organizationId,
+      requestId: ctx.requestId,
+      amountUsd,
+      source,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    await invalidateOrgBalanceHint(ctx.organizationId);
+  }
+}
+
+/**
+ * Build the post-response settler. Same `(actualCost) => Promise<...>` shape as the
+ * reservation/KV settlers, so the route's single settle chain is unchanged. It
+ * CLAIMS the pending row (exactly-once) then debits the actual cost; called with 0
+ * on error/abort, which still claims (clearing the row) but charges nothing.
+ */
+export function createLedgerDebitSettler(
+  ctx: LedgerChargeContext,
+): (actualCostUsd: number) => Promise<CreditReconciliationResult | null> {
+  return async (actualCostUsd: number) => {
+    const claimedOrg = await claimPendingCharge(ctx.requestId, Math.max(actualCostUsd, 0));
+    if (!claimedOrg) return null; // already settled by the sweep / a prior call
+    if (actualCostUsd > 0) {
+      await debitClaimedCharge(ctx, actualCostUsd, "inline");
+    }
+    return null;
+  };
+}
+
+export interface LedgerSweepStats {
+  scanned: number;
+  settled: number;
+  skipped: number;
+  batches: number;
+  /** true when the sweep hit its batch ceiling — a backlog larger than one run can drain. */
+  capHit: boolean;
+}
+
+interface SweepRow {
+  request_id: string;
+  organization_id: string;
+  user_id: string | null;
+  model: string;
+  provider: string;
+  billing_source: string;
+  estimated_cost_usd: string;
+}
+
+/**
+ * Cron backstop: settle pending rows whose inline settle never ran (isolate
+ * eviction / dropped waitUntil). Drains oldest-pending-first in age-ordered
+ * batches until empty (cursor by `enqueued_at`), bounded by `maxBatches`. Each row
+ * is settled through the SAME atomic claim, so overlapping cron runs and a racing
+ * inline settler can never double-charge — which is why this needs no KV-style
+ * single-flight lock. Charges the ESTIMATE (the actual is unknown once the inline
+ * path is lost).
+ */
+export async function sweepStalePendingInferenceChargesDb(opts?: {
+  graceMs?: number;
+  batchSize?: number;
+  maxBatches?: number;
+  now?: number;
+}): Promise<LedgerSweepStats> {
+  const graceMs = opts?.graceMs ?? DEFAULT_SWEEP_GRACE_MS;
+  const batchSize = opts?.batchSize ?? 200;
+  const maxBatches = opts?.maxBatches ?? 50;
+  const now = opts?.now ?? Date.now();
+  const cutoff = new Date(now - graceMs);
+
+  const stats: LedgerSweepStats = {
+    scanned: 0,
+    settled: 0,
+    skipped: 0,
+    batches: 0,
+    capHit: false,
+  };
+
+  for (let batch = 0; batch < maxBatches; batch++) {
+    const rows = await sqlRows<SweepRow>(
+      dbWrite,
+      sql`
+        SELECT request_id, organization_id, user_id, model, provider, billing_source, estimated_cost_usd
+        FROM inference_pending_charges
+        WHERE status = 'pending' AND enqueued_at < ${cutoff.toISOString()}
+        ORDER BY enqueued_at ASC
+        LIMIT ${batchSize}
+      `,
+    );
+    if (rows.length === 0) break;
+    stats.batches++;
+    stats.scanned += rows.length;
+
+    for (const row of rows) {
+      const estimate = Number(row.estimated_cost_usd);
+      const claimedOrg = await claimPendingCharge(
+        row.request_id,
+        Number.isFinite(estimate) ? estimate : 0,
+      );
+      if (!claimedOrg) {
+        // Lost the claim to a concurrent inline settle — counts as handled, not work.
+        stats.skipped++;
+        continue;
+      }
+      if (Number.isFinite(estimate) && estimate > 0) {
+        await debitClaimedCharge(
+          {
+            requestId: row.request_id,
+            organizationId: row.organization_id,
+            userId: row.user_id ?? "",
+            apiKeyId: null,
+            model: row.model,
+            provider: row.provider,
+            billingSource: row.billing_source,
+          },
+          estimate,
+          "sweep",
+        );
+      }
+      stats.settled++;
+    }
+
+    if (rows.length < batchSize) break;
+    if (batch === maxBatches - 1) stats.capHit = true;
+  }
+
+  if (stats.capHit) {
+    logger.warn("[InferenceLedger] pending-charge sweep hit its batch ceiling — backlog growing", {
+      maxBatches,
+      batchSize,
+      scanned: stats.scanned,
+    });
+  }
+  if (stats.settled > 0 || stats.skipped > 0) {
+    logger.warn("[InferenceLedger] swept stale pending charges (dropped inline settles)", stats);
+  }
+  return stats;
+}

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -166,6 +166,11 @@ export interface Bindings {
   // safe synchronous-reserve path).
   INFERENCE_OPTIMISTIC_BILLING?: string;
   SAFE_BALANCE_THRESHOLD?: string;
+  // Optimistic-billing durable backstop selector. "db" routes the pending-charge
+  // + settlement through the inference_pending_charges DB ledger (atomic
+  // overdraw bound + exactly-once settle + age-ordered sweep); anything else
+  // (default) keeps the KV backstop. Both still require INFERENCE_OPTIMISTIC_BILLING.
+  INFERENCE_BILLING_LEDGER?: string;
   RATE_LIMIT_DISABLED?: string;
   RATE_LIMIT_MULTIPLIER?: string;
   PLAYWRIGHT_TEST_AUTH?: string;


### PR DESCRIPTION
## What & why

Closes the remaining **code** work on #9899. The pre-forward TTFT root cause is fixed and live (Tier 1 auth cache + Tier 2 optimistic billing). The issue + `packages/cloud/api/docs/inference-hot-path.md` named one remaining step: the **DB-backed pending-charge + settlement ledger** that closes the three at-scale residuals a KV-only backstop *cannot*. This implements it behind `INFERENCE_BILLING_LEDGER="db"` (default `""`/`kv` ⇒ **no behavior change** anywhere until ops flips it), matching the soak-then-cutover discipline the issue itself prescribed.

## Residuals closed (point-for-point)

1. **Hard concurrent-overdraw bound** — admission is ONE atomic `SELECT … FOR UPDATE` + `SUM(pending)` statement; a same-org burst serializes on the row lock and cannot collectively overdraw (was: KV soft bound via threshold only).
2. **True exactly-once settlement** — `request_id` PK + atomic `UPDATE … WHERE status='pending'` claim ⇒ inline settler and cron sweep can never both charge; the debit funnels through the single audited `creditsService.deductCredits`. No more KV single-flight lock (was: near-atomic get-then-delete ⇒ rare double-bill).
3. **Age-ordered sweep drain** — `ORDER BY enqueued_at LIMIT batch` loop over a partial index, no silent `maxKeys` cap.

Plus `uncollected` is now a first-class auditable row state; the org self-heals onto the synchronous-reserve path on a refused debit.

## Rollout (default OFF, no prod change)

`INFERENCE_BILLING_LEDGER` is `""` in every env block (still requires `INFERENCE_OPTIMISTIC_BILLING="true"`). The KV path is **byte-identical** when the flag is unset and stays as the rollback target. Cutover = ship migration `0153`, flip to `"db"` in staging, watch `[InferenceLedger] uncollected …` + sweep stats, then prod.

## Evidence (real path, no larp)

**90 pass / 0 fail** across the touched + related suites, every test driving the **real SQL against in-process PGlite** (same pattern as the audited `credits-deduct-guard.test.ts`):

| Suite | |
|---|---|
| `inference-billing-ledger.test.ts` | 15 — admission (overdraw bound, threshold, unknown org, +Inf, idempotent, concurrency) · settle (actual, **exactly-once**, settle(0), uncollected) · sweep (stale/young, inline-then-sweep, age-ordered multi-batch) |
| `inference-pending-charges-migration.test.ts` | 6 — journal registration + **real migration-file apply to PGlite** + idempotent re-apply |
| `inference-billing-fast-path` / `auth-context` / `auth-lifecycle` / `cache-failure` / benchmark | 52 — KV path, no regression |
| `credits-deduct-guard` / `credits-reconcile` | 17 — credit mutation, no regression |

**Measured hard overdraw bound** (`.github/issue-evidence/9899-db-ledger-overdraw-measurement.json`):

| Burst × est | Balance | Threshold | Admitted | In-flight | Naive unbounded | **Overdraw prevented** | Final ≥ 0 |
|---|---|---|---|---|---|---|---|
| 50 × \$3 | \$100 | \$1 | 33 | \$99 | \$150 | **\$50** | ✓ \$1 |
| 20 × \$10 | \$100 | \$5 | 10 | \$100 | \$200 | **\$100** | ✓ \$0 |
| 100 × \$1 | \$25 | \$0.50 | 25 | \$25 | \$100 | **\$75** | ✓ \$0 |

Typecheck (cloud-shared + cloud-api): my files clean (only pre-existing i18n/hono-dup/stripe-version noise). Biome: clean on all changed files. Route-level *runtime* tests need a built `@elizaos/core` dist that can't be generated in this worktree (shared-parent-`node_modules` ⇒ `tsc` can't resolve `@types/bun`/`node`); they run in CI. The DB-ledger route branch is type-checked clean and the KV path is structurally unchanged when the flag is unset.

Full write-up: `.github/issue-evidence/9899-db-ledger.md`. Doc: Tier-3 section + cutover plan in `packages/cloud/api/docs/inference-hot-path.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)