### PR TITLE
fix(ui): launch resilience — surface active-server persist failures + retryable SSE idle stall

### DIFF
--- a/packages/ui/src/api/client-agent-stream.test.ts
+++ b/packages/ui/src/api/client-agent-stream.test.ts
@@ -401,4 +401,52 @@ describe("ElizaClient chat-turn status SSE (#8813)", () => {
     });
     expect(onToken).toHaveBeenCalledWith("hi", "hi");
   });
+
+  it("marks a 60s idle stall as a retryable provider_issue, keeping partial text", async () => {
+    vi.useFakeTimers();
+    try {
+      const encoder = new TextEncoder();
+      const read = vi
+        .fn()
+        // First read delivers a partial token, then the provider hangs — the
+        // second read never resolves, so only the 60s idle timer can settle it.
+        .mockResolvedValueOnce({
+          done: false,
+          value: encoder.encode(
+            'data: {"type":"token","text":"par","fullText":"par"}\n\n',
+          ),
+        })
+        .mockReturnValueOnce(new Promise(() => {}));
+      const cancel = vi.fn(async () => {});
+      const request = vi.fn(
+        async () =>
+          ({
+            ok: true,
+            status: 200,
+            body: { getReader: () => ({ read, cancel }) },
+          }) as unknown as Response,
+      );
+      const client = new ElizaClient("http://agent.example:31337", "token");
+      client.setRequestTransport({ request });
+
+      const resultPromise = client.streamChatEndpoint(
+        "/api/conversations/conversation-id/messages/stream",
+        "hello",
+        vi.fn(),
+      );
+
+      // Process the partial token, then trip the 60s idle timeout on the hang.
+      await vi.advanceTimersByTimeAsync(60_000);
+      const result = await resultPromise;
+
+      // The stall is now a retryable provider issue (renderer shows Retry)
+      // instead of an ambiguous interrupt, and the partial text is retained.
+      expect(result.completed).toBe(false);
+      expect(result.failureKind).toBe("provider_issue");
+      expect(result.text).toContain("par");
+      expect(cancel).toHaveBeenCalledWith("elizaos-sse-idle-timeout");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -1559,18 +1559,29 @@ export class ElizaClient {
     while (true) {
       let done = false;
       let value: Uint8Array | undefined;
+      let idleTimedOut = false;
       try {
         const readPromise = reader.read();
         const timeoutPromise = new Promise<never>((_, reject) => {
-          const id = setTimeout(
-            () => reject(new Error("SSE idle timeout — no data for 60s")),
-            SSE_IDLE_TIMEOUT_MS,
-          );
+          const id = setTimeout(() => {
+            idleTimedOut = true;
+            reject(new Error("SSE idle timeout — no data for 60s"));
+          }, SSE_IDLE_TIMEOUT_MS);
           // Clear timeout if the read resolves first
           void readPromise.finally(() => clearTimeout(id));
         });
         ({ done, value } = await Promise.race([readPromise, timeoutPromise]));
       } catch {
+        // Only the 60s idle timeout sets `idleTimedOut`; a user abort or a
+        // mid-stream network drop rejects the read without it. Stamp the stall
+        // as a transient provider issue so the consumer carries `failureKind`
+        // onto the turn and the renderer shows a Retry affordance instead of a
+        // bare, ambiguous "interrupted" badge that locks the partial text.
+        // User-stop / network-drop stay failureKind-less (genuine interrupt).
+        if (idleTimedOut) {
+          streamState.doneFailureKind =
+            streamState.doneFailureKind ?? "provider_issue";
+        }
         void reader.cancel("elizaos-sse-idle-timeout").catch(() => {});
         break;
       }

--- a/packages/ui/src/state/persistence-cloud-active-server.test.ts
+++ b/packages/ui/src/state/persistence-cloud-active-server.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 
+import { logger } from "@elizaos/logger";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createPersistedActiveServer,
@@ -196,5 +197,35 @@ describe("Cloud active server persistence", () => {
       label: "On-device agent",
       apiBase: "eliza-local-agent://ipc",
     });
+  });
+
+  it("logs a warning instead of silently swallowing a failed active-server persist", () => {
+    const server = createPersistedActiveServer({
+      id: "cloud:agent-warn",
+      kind: "cloud",
+      label: "Demo Agent",
+      apiBase: "https://agent-runtime.example.test",
+      accessToken: "cloud-token",
+    });
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    const setItemSpy = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new DOMException("quota exceeded", "QuotaExceededError");
+      });
+
+    try {
+      // A failed persist must not throw (callers treat it as best-effort) but
+      // must surface a diagnostic — previously this was swallowed silently, so
+      // a lost freshly-recovered apiBase re-triggered backfill on every boot.
+      expect(() => savePersistedActiveServer(server)).not.toThrow();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0]?.[0]).toMatch(
+        /\[persistence\] failed to save active server/,
+      );
+    } finally {
+      setItemSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/packages/ui/src/state/persistence.ts
+++ b/packages/ui/src/state/persistence.ts
@@ -1146,9 +1146,23 @@ export function loadPersistedActiveServer(): PersistedActiveServer | null {
 }
 
 export function savePersistedActiveServer(server: PersistedActiveServer): void {
-  tryLocalStorage(() => {
+  if (typeof localStorage === "undefined") {
+    return;
+  }
+
+  // The active-server record carries the sign-in state (kind/apiBase/token) and
+  // the backend the app reconnects to. A swallowed persist failure (quota,
+  // private-mode SecurityError) silently loses a freshly-recovered apiBase, so
+  // backfillCloudApiBase re-runs every boot with no diagnostic. Mirror
+  // savePersistedFirstRunComplete: still no-throw + no-op when unavailable, but
+  // surface the failure instead of swallowing it.
+  try {
     localStorage.setItem(ACTIVE_SERVER_STORAGE_KEY, JSON.stringify(server));
-  }, undefined);
+  } catch (err) {
+    logger.warn(
+      `[persistence] failed to save active server: ${describePersistenceError(err)}`,
+    );
+  }
 }
 
 export function clearPersistedActiveServer(): void {

--- a/packages/ui/src/state/useChatSend.test.tsx
+++ b/packages/ui/src/state/useChatSend.test.tsx
@@ -515,6 +515,61 @@ describe("useChatSend non-404 send failures", () => {
     ).toBe(false);
   });
 
+  it("distinguishes a first-token timeout from a network drop in the notice copy", async () => {
+    // A timeout means the agent WAS reached but did not respond in time, so
+    // "check your connection" is the wrong remedy. Timeout → slow-response copy;
+    // a genuine network drop keeps the connection copy.
+    mocks.client.sendConversationMessageStream.mockRejectedValue(
+      Object.assign(new Error("Request timed out"), { kind: "timeout" }),
+    );
+
+    const deps = makeDeps({
+      activeConversationId: "conv-1",
+      conversations: [conversation("conv-1", "room-1")],
+    });
+    const { result } = renderHook(() => useChatSend(deps));
+
+    await act(async () => {
+      await result.current.sendChatText("are you there", {
+        conversationId: "conv-1",
+      });
+    });
+
+    expect(deps.setActionNotice).toHaveBeenCalledWith(
+      expect.stringContaining("took too long"),
+      "error",
+      expect.any(Number),
+    );
+    // Must NOT show the misleading network/connection copy for a timeout.
+    expect(deps.setActionNotice).not.toHaveBeenCalledWith(
+      expect.stringContaining("check your connection"),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it("keeps the connection copy for a genuine network drop", async () => {
+    mocks.client.sendConversationMessageStream.mockRejectedValue(
+      Object.assign(new Error("Failed to fetch"), { kind: "network" }),
+    );
+
+    const deps = makeDeps({
+      activeConversationId: "conv-1",
+      conversations: [conversation("conv-1", "room-1")],
+    });
+    const { result } = renderHook(() => useChatSend(deps));
+
+    await act(async () => {
+      await result.current.sendChatText("hi", { conversationId: "conv-1" });
+    });
+
+    expect(deps.setActionNotice).toHaveBeenCalledWith(
+      expect.stringContaining("check your connection"),
+      "error",
+      expect.any(Number),
+    );
+  });
+
   it("does not reload (which could re-fail) on an auth-failure send error, and notifies", async () => {
     mocks.client.sendConversationMessageStream.mockRejectedValue(
       httpStatusError(401, "Unauthorized"),

--- a/packages/ui/src/state/useChatSend.ts
+++ b/packages/ui/src/state/useChatSend.ts
@@ -1202,9 +1202,11 @@ export function useChatSend(deps: UseChatSendDeps) {
               ? "The agent is busy right now — wait a few seconds and resend."
               : status === 503 || status === 502
                 ? "The agent is still waking up — give it a moment and resend."
-                : kind === "network" || kind === "timeout"
-                  ? "Couldn't reach the agent — check your connection and resend."
-                  : "That message didn't go through — please resend.";
+                : kind === "timeout"
+                  ? "The agent took too long to respond — give it a moment and resend."
+                  : kind === "network"
+                    ? "Couldn't reach the agent — check your connection and resend."
+                    : "That message didn't go through — please resend.";
           setActionNotice(notice, "error", 8_000);
           // Reconcile from the server for non-auth errors — loadConversationMessages
           // no longer wipes the thread on transient failures (404-only clear), so


### PR DESCRIPTION
Salvages the two genuine, well-tested resilience fixes from the closed #10229 (`nubs/app-launch-hardening`, closed on a CI/bot error, not on merit) and lands them clean on current `develop`. Both were found via the launch-readiness audit (#10231). Authorship preserved (@NubsCarson).

The third commit from that branch (`AgentPicker.tsx` inline bind-error) is intentionally **dropped** — `packages/ui/src/first-run/AgentPicker.tsx` no longer exists on develop; the component picker was replaced by the in-chat onboarding flow (#9952/#10302). That UX concern would be new work against the new flow, not a port.

## What lands

**1. Surface a failed active-server persist instead of swallowing it** (`persistence.ts`)
`savePersistedActiveServer` used `tryLocalStorage`'s bare catch, so a failed `localStorage.setItem` (quota / private-mode `SecurityError`) was silently swallowed. That record carries sign-in state + the backend the app reconnects to; when `backfillCloudApiBase` recovers a missing cloud apiBase and persists it, a silent failure loses the recovery and re-fires every boot with no diagnostic. Now mirrors `savePersistedFirstRunComplete` exactly: explicit localStorage-undefined guard + `try/catch` that `logger.warn(describePersistenceError(err))`. Behavior preserved (still no-throw, still no-op when storage unavailable) — the only change is the previously-silent failure now surfaces a warning.

**2. Clearer timeout copy + retryable SSE idle stall** (`client-base.ts`, `useChatSend.ts`)
- A first-token timeout (agent reached but slow) showed the network "check your connection" copy. Split the conflated `network||timeout` branch so a timeout gets a slow-response message and a genuine network drop keeps the connection copy.
- A 60s SSE idle stall rejected with no cause, so the turn returned `completed:false` with no `failureKind` — indistinguishable from a user stop / network drop, leaving an ambiguous "interrupted" badge that locks partial text. Bind the cause via an `idleTimedOut` flag (set only in the timer callback) and stamp `doneFailureKind='provider_issue'` (an existing `ChatFailureKind`) so the renderer shows a Retry affordance. Reuses existing `failureKind` plumbing — no new type, no render changes. User-stop / network-drop stay `failureKind`-less.

## Evidence

Real unit tests drive the error paths (not mocks of the unit under test):
- `persistence-cloud-active-server.test.ts` — a thrown `setItem` is caught (no throw) and `logger.warn` fires once.
- `client-agent-stream.test.ts` — fake-timer-driven idle stall asserts `failureKind === 'provider_issue'`, partial text retained, retryable.
- `useChatSend.test.tsx` — timeout vs network copy split.

```
$ bunx vitest run src/state/persistence-cloud-active-server.test.ts src/api/client-agent-stream.test.ts src/state/useChatSend.test.tsx
 Test Files  3 passed (3)
      Tests  40 passed (40)
```

`audit:app` visual review: **N/A** — no render changes (failure-kind stamping reuses existing badge/Retry plumbing; persistence + copy changes are non-visual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)