### PR TITLE
fix(agent): green develop — replace memory-soak ?? 0 empty-guards with explicit handling

### DIFF
--- a/packages/agent/src/runtime/memory-soak.ts
+++ b/packages/agent/src/runtime/memory-soak.ts
@@ -115,10 +115,26 @@ export async function runSoak(options: SoakOptions): Promise<SoakResult> {
     });
   }
 
+  // A zero-iteration soak yields no samples — there is no baseline/growth to
+  // report, so return an explicit all-zero result rather than coalescing
+  // missing data to 0 downstream. Narrowing first/last to a defined sample lets
+  // the slope math run on a guaranteed-non-empty series.
+  const first = samples[0];
+  const last = samples.at(-1);
+  if (!first || !last) {
+    return {
+      samples,
+      baselineHeapMb: 0,
+      peakHeapMb: 0,
+      growthMb: 0,
+      slopeMbPerIter: 0,
+    };
+  }
+
   const heapSeries = samples.map((s) => s.heapUsedMb);
-  const baselineHeapMb = heapSeries[0] ?? 0;
-  const peakHeapMb = heapSeries.length ? Math.max(...heapSeries) : 0;
-  const growthMb = (heapSeries.at(-1) ?? 0) - baselineHeapMb;
+  const baselineHeapMb = first.heapUsedMb;
+  const peakHeapMb = Math.max(...heapSeries);
+  const growthMb = last.heapUsedMb - baselineHeapMb;
 
   return {
     samples,


### PR DESCRIPTION
## Problem
#10375's `packages/agent/src/runtime/memory-soak.ts` added two `?? 0` nullish fallbacks (`heapSeries[0] ?? 0`, `heapSeries.at(-1) ?? 0`), pushing the core/agent/app-core `?? 0` ratchet **381 → 383**. The type-safety ratchet runs in `verify` + the `quality`/`quality-fork` CI lanes, so develop went **red**, failing the gate for every open PR.

## Fix (code, not baseline)
The `?? 0`s were empty-`heapSeries` guards (only reachable at `iterations === 0`). Replaced with an explicit zero-sample guard up front that narrows `samples[0]`/`samples.at(-1)` to a defined `SoakSample` — so the baseline/growth math runs on a guaranteed-non-empty series with **no `?? 0` and no non-null `!`**.

Behavior-preserving: a zero-iteration soak still returns the same all-zero result; a real soak computes identically. The 2 soak tests pass unchanged.

## Verification
- `node packages/scripts/type-safety-ratchet.mjs` → **exit 0** (`?? 0` back to 381/381)
- `bun run --cwd packages/agent test src/runtime/__tests__/memory-soak.test.ts` → 2/2 pass
- biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)