### PR TITLE
feat(ui): feed live JS heap into view-cache pruning (#10196)

### DIFF
--- a/packages/ui/src/cache-telemetry.ts
+++ b/packages/ui/src/cache-telemetry.ts
@@ -1,3 +1,5 @@
+import { readJsHeapUsedSize } from "./state/bounded-view-lru";
+
 export const MODULE_CACHE_TELEMETRY_EVENT = "eliza:module-cache-telemetry";
 
 export type ModuleCacheTelemetrySource =
@@ -19,6 +21,9 @@ export interface ModuleCacheTelemetryEvent {
     | "ttl"
     | "lru"
     | "memorypressure"
+    // Live `usedJSHeapSize` crossed HEAP_PRESSURE_RATIO (#10196) — the real
+    // heap-driven eviction, as opposed to the never-fired `memorypressure`.
+    | "heap-pressure"
     | "visibility-hidden"
     | "app-pause"
     | "invalidate"
@@ -29,6 +34,12 @@ export interface ModuleCacheTelemetryEvent {
   activeCount: number;
   idleCount: number;
   cacheSize: number;
+  /**
+   * Live `performance.memory.usedJSHeapSize` (bytes) at emit time, or omitted
+   * when the Chromium-only heap API is unavailable. Lets the views soak assert
+   * heap growth/eviction directly off the module-cache ring (#10196).
+   */
+  jsHeapUsedSize?: number;
   at: number;
   route?: string;
 }
@@ -46,8 +57,10 @@ function currentRoute(): string | undefined {
 export function emitModuleCacheTelemetry(
   event: Omit<ModuleCacheTelemetryEvent, "at" | "route">,
 ): void {
+  const jsHeapUsedSize = readJsHeapUsedSize();
   const detail: ModuleCacheTelemetryEvent = {
     ...event,
+    ...(jsHeapUsedSize !== undefined ? { jsHeapUsedSize } : {}),
     at: Date.now(),
     route: currentRoute(),
   };

--- a/packages/ui/src/components/views/DynamicViewLoader.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.tsx
@@ -60,7 +60,12 @@ import {
   useAppSelector,
   useAppSelectorShallow,
 } from "../../state/app-store.ts";
-import { isLowMemoryDevice } from "../../state/bounded-view-lru";
+import {
+  getBundleModuleMaxEntries,
+  getBundleModuleTtlMs,
+  HEAP_PRESSURE_EVENT,
+} from "../../state/bounded-view-lru";
+import { installHeapPressureMonitor } from "../../state/heap-pressure-monitor";
 import { useTranslation } from "../../state/TranslationContext.hooks";
 import { useApp } from "../../state/useApp.ts";
 import { registerDetailExtension } from "../apps/extensions/registry.ts";
@@ -110,13 +115,12 @@ interface ViewBundleCacheEntry {
 // cleanup hook. Keep a tiny LRU of recently used views so quick tab switches are
 // instant, then drop idle/heavy views automatically.
 const bundleModuleCache = new Map<string, ViewBundleCacheEntry>();
-const DEFAULT_BUNDLE_CACHE_TTL_MS = 5 * 60_000;
-const LOW_MEMORY_BUNDLE_CACHE_TTL_MS = 60_000;
-const DEFAULT_BUNDLE_CACHE_MAX_ENTRIES = 6;
-const LOW_MEMORY_BUNDLE_CACHE_MAX_ENTRIES = 2;
+// TTL/LRU caps live in bounded-view-lru (single home for all bounded caches,
+// heap-pressure aware). See getBundleModule{TtlMs,MaxEntries}.
 
 let bundleCacheLifecycleInstalled = false;
 let pruneBundleCacheOnPressure: (() => void) | null = null;
+let pruneBundleCacheOnHeapPressure: (() => void) | null = null;
 let pruneBundleCacheOnVisibilityHidden: (() => void) | null = null;
 let pruneBundleCacheOnAppPause: (() => void) | null = null;
 
@@ -147,18 +151,6 @@ function emitBundleTelemetry(
     ...patch,
     ...bundleCacheStats(),
   });
-}
-
-function getBundleCacheMaxEntries(): number {
-  if (isLowMemoryDevice()) {
-    return LOW_MEMORY_BUNDLE_CACHE_MAX_ENTRIES;
-  }
-  return DEFAULT_BUNDLE_CACHE_MAX_ENTRIES;
-}
-
-function getBundleCacheTtlMs(): number {
-  if (isLowMemoryDevice()) return LOW_MEMORY_BUNDLE_CACHE_TTL_MS;
-  return DEFAULT_BUNDLE_CACHE_TTL_MS;
 }
 
 function scheduleIdleWork(work: () => void): void {
@@ -217,14 +209,14 @@ function armBundleEntryRetentionTimer(entry: ViewBundleCacheEntry): void {
   entry.retentionTimer = setTimeout(() => {
     entry.retentionTimer = null;
     scheduleIdleWork(() => pruneBundleModuleCache());
-  }, getBundleCacheTtlMs() + 50);
+  }, getBundleModuleTtlMs() + 50);
 }
 
 function pruneBundleModuleCache(
   options: { force?: boolean; reason?: EvictReason } = {},
 ): void {
   const now = Date.now();
-  const ttlMs = options.force ? 0 : getBundleCacheTtlMs();
+  const ttlMs = options.force ? 0 : getBundleModuleTtlMs();
   const reason = options.reason ?? (options.force ? "memorypressure" : "ttl");
   const idleEntries = [...bundleModuleCache.values()]
     .filter((entry) => entry.refCount === 0)
@@ -236,7 +228,7 @@ function pruneBundleModuleCache(
     }
   }
 
-  const maxEntries = options.force ? 0 : getBundleCacheMaxEntries();
+  const maxEntries = options.force ? 0 : getBundleModuleMaxEntries();
   let retained = [...bundleModuleCache.values()].filter(
     (entry) => entry.refCount === 0,
   );
@@ -251,6 +243,7 @@ function pruneBundleModuleCache(
 function installBundleCacheLifecycle(): void {
   if (bundleCacheLifecycleInstalled || typeof window === "undefined") return;
   bundleCacheLifecycleInstalled = true;
+  installHeapPressureMonitor();
   pruneBundleCacheOnPressure = () => {
     scheduleIdleWork(() =>
       pruneBundleModuleCache({ force: true, reason: "memorypressure" }),
@@ -268,7 +261,20 @@ function installBundleCacheLifecycle(): void {
       pruneBundleModuleCache({ force: true, reason: "app-pause" }),
     );
   };
+  // Real heap-driven eviction (#10196): ViewTelemetryProfiler dispatches this
+  // when live usedJSHeapSize crosses HEAP_PRESSURE_RATIO. Unlike the
+  // never-fired `memorypressure` window event, this actually feeds live heap
+  // into the cache.
+  pruneBundleCacheOnHeapPressure = () => {
+    scheduleIdleWork(() =>
+      pruneBundleModuleCache({ force: true, reason: "heap-pressure" }),
+    );
+  };
   window.addEventListener("memorypressure", pruneBundleCacheOnPressure);
+  document.addEventListener(
+    HEAP_PRESSURE_EVENT,
+    pruneBundleCacheOnHeapPressure,
+  );
   document.addEventListener(
     "visibilitychange",
     pruneBundleCacheOnVisibilityHidden,
@@ -290,6 +296,12 @@ export function __resetDynamicViewLoaderCacheForTests(): void {
   if (typeof window !== "undefined" && pruneBundleCacheOnPressure) {
     window.removeEventListener("memorypressure", pruneBundleCacheOnPressure);
   }
+  if (typeof document !== "undefined" && pruneBundleCacheOnHeapPressure) {
+    document.removeEventListener(
+      HEAP_PRESSURE_EVENT,
+      pruneBundleCacheOnHeapPressure,
+    );
+  }
   if (typeof document !== "undefined" && pruneBundleCacheOnVisibilityHidden) {
     document.removeEventListener(
       "visibilitychange",
@@ -300,6 +312,7 @@ export function __resetDynamicViewLoaderCacheForTests(): void {
     document.removeEventListener(APP_PAUSE_EVENT, pruneBundleCacheOnAppPause);
   }
   pruneBundleCacheOnPressure = null;
+  pruneBundleCacheOnHeapPressure = null;
   pruneBundleCacheOnVisibilityHidden = null;
   pruneBundleCacheOnAppPause = null;
   bundleCacheLifecycleInstalled = false;

--- a/packages/ui/src/components/views/DynamicViewLoader.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.tsx
@@ -261,10 +261,10 @@ function installBundleCacheLifecycle(): void {
       pruneBundleModuleCache({ force: true, reason: "app-pause" }),
     );
   };
-  // Real heap-driven eviction (#10196): ViewTelemetryProfiler dispatches this
-  // when live usedJSHeapSize crosses HEAP_PRESSURE_RATIO. Unlike the
-  // never-fired `memorypressure` window event, this actually feeds live heap
-  // into the cache.
+  // Real heap-driven eviction (#10196): the shared heap-pressure monitor
+  // (installHeapPressureMonitor) dispatches this when live usedJSHeapSize
+  // crosses HEAP_PRESSURE_RATIO. Unlike the never-fired `memorypressure`
+  // window event, this actually feeds live heap into the cache.
   pruneBundleCacheOnHeapPressure = () => {
     scheduleIdleWork(() =>
       pruneBundleModuleCache({ force: true, reason: "heap-pressure" }),

--- a/packages/ui/src/components/views/ViewTelemetryProfiler.tsx
+++ b/packages/ui/src/components/views/ViewTelemetryProfiler.tsx
@@ -36,6 +36,7 @@ import {
   WINDOW_MS,
 } from "../../hooks/useRenderGuard";
 import { snapshotResourceCounters } from "../../perf/resource-counters";
+import { readJsHeap } from "../../state/bounded-view-lru";
 import { useViewLifecycle } from "../../state/useViewLifecycle";
 import type { ViewLifecyclePhase } from "../../state/view-lifecycle-types";
 import {
@@ -43,17 +44,6 @@ import {
   installViewRuntimeTelemetryRing,
   type ViewRuntimeTelemetryReason,
 } from "../../view-runtime-telemetry";
-
-interface PerfMemory {
-  usedJSHeapSize?: number;
-}
-
-function readJsHeapUsedSize(): number | undefined {
-  if (typeof performance === "undefined") return undefined;
-  const memory = (performance as Performance & { memory?: PerfMemory }).memory;
-  const used = memory?.usedJSHeapSize;
-  return typeof used === "number" && Number.isFinite(used) ? used : undefined;
-}
 
 export interface ViewTelemetryProfilerProps {
   viewId: string;
@@ -133,7 +123,7 @@ export function ViewTelemetryProfiler({
         renderCount: renderCount.current,
         lastCommitMs: lastCommitMs.current,
         commitDurationP95Ms: percentile(commitDurations.current, 95),
-        jsHeapUsedSize: readJsHeapUsedSize(),
+        jsHeapUsedSize: readJsHeap()?.usedJSHeapSize,
         activeSubscriptions: snap.activeSubscriptions,
         pendingTimers: snap.pendingTimers,
         heavyResources: snap.heavyResources,

--- a/packages/ui/src/retained-lazy.test.tsx
+++ b/packages/ui/src/retained-lazy.test.tsx
@@ -12,6 +12,7 @@ import {
   RetainedLazyComponent,
   type RetainedLazyModule,
 } from "./retained-lazy";
+import { __resetHeapPressureMonitorForTests } from "./state/heap-pressure-monitor";
 
 interface TestProps {
   label: string;
@@ -36,6 +37,7 @@ describe("RetainedLazyComponent", () => {
   afterEach(() => {
     cleanup();
     __resetRetainedLazyModulesForTests();
+    __resetHeapPressureMonitorForTests();
     delete (window as Partial<Window>).requestIdleCallback;
   });
 

--- a/packages/ui/src/retained-lazy.test.tsx
+++ b/packages/ui/src/retained-lazy.test.tsx
@@ -176,4 +176,54 @@ describe("RetainedLazyComponent", () => {
       ]),
     );
   });
+
+  it("evicts inactive modules on live heap pressure and emits the heap value (#10196)", async () => {
+    Object.defineProperty(performance, "memory", {
+      configurable: true,
+      value: { usedJSHeapSize: 950, jsHeapSizeLimit: 1000 },
+    });
+    const events: ModuleCacheTelemetryEvent[] = [];
+    const onTelemetry = (event: Event) => {
+      events.push((event as CustomEvent<ModuleCacheTelemetryEvent>).detail);
+    };
+    window.addEventListener(MODULE_CACHE_TELEMETRY_EVENT, onTelemetry);
+    const cleanupModule = vi.fn();
+    const loader = vi.fn(
+      async (): Promise<RetainedLazyModule<TestProps>> => ({
+        default: function TestPanel({ label }: TestProps) {
+          return <div>{label}</div>;
+        },
+        cleanup: cleanupModule,
+      }),
+    );
+
+    const rendered = render(
+      <RetainedLazyComponent
+        loader={loader}
+        componentProps={{ label: "heap panel" }}
+      />,
+    );
+    await screen.findByText("heap panel");
+    rendered.unmount();
+
+    // The real heap-driven signal (the never-fired `memorypressure` is replaced
+    // by HEAP_PRESSURE_EVENT, sourced from the heap monitor).
+    document.dispatchEvent(new CustomEvent("eliza:heap-pressure"));
+    await waitFor(() => expect(cleanupModule).toHaveBeenCalledTimes(1));
+    window.removeEventListener(MODULE_CACHE_TELEMETRY_EVENT, onTelemetry);
+
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "retained-lazy",
+          action: "evict",
+          reason: "heap-pressure",
+          // Every cache event now carries the live heap reading.
+          jsHeapUsedSize: 950,
+        }),
+      ]),
+    );
+    // biome-ignore lint/performance/noDelete: test cleanup of the mock field
+    delete (performance as { memory?: unknown }).memory;
+  });
 });

--- a/packages/ui/src/retained-lazy.tsx
+++ b/packages/ui/src/retained-lazy.tsx
@@ -14,7 +14,9 @@ import { APP_PAUSE_EVENT } from "./events";
 import {
   getRetainedModuleMaxEntries,
   getRetainedModuleTtlMs,
+  HEAP_PRESSURE_EVENT,
 } from "./state/bounded-view-lru";
+import { installHeapPressureMonitor } from "./state/heap-pressure-monitor";
 
 type RetainedCleanup = () => void | Promise<void>;
 
@@ -44,6 +46,7 @@ const retainedModuleCache = new Map<
 
 let retainedModuleLifecycleInstalled = false;
 let pruneOnPressure: (() => void) | null = null;
+let pruneOnHeapPressure: (() => void) | null = null;
 let pruneOnVisibilityHidden: (() => void) | null = null;
 let pruneOnAppPause: (() => void) | null = null;
 
@@ -168,6 +171,7 @@ function installRetainedModuleLifecycle(): void {
     return;
   }
   retainedModuleLifecycleInstalled = true;
+  installHeapPressureMonitor();
   pruneOnPressure = () => {
     scheduleIdleWork(() =>
       pruneRetainedLazyModules({ force: true, reason: "memorypressure" }),
@@ -185,7 +189,14 @@ function installRetainedModuleLifecycle(): void {
       pruneRetainedLazyModules({ force: true, reason: "app-pause" }),
     );
   };
+  // Real heap-driven eviction (#10196) — see DynamicViewLoader for rationale.
+  pruneOnHeapPressure = () => {
+    scheduleIdleWork(() =>
+      pruneRetainedLazyModules({ force: true, reason: "heap-pressure" }),
+    );
+  };
   window.addEventListener("memorypressure", pruneOnPressure);
+  document.addEventListener(HEAP_PRESSURE_EVENT, pruneOnHeapPressure);
   document.addEventListener("visibilitychange", pruneOnVisibilityHidden);
   document.addEventListener(APP_PAUSE_EVENT, pruneOnAppPause);
 }
@@ -317,6 +328,9 @@ export function __resetRetainedLazyModulesForTests(): void {
   if (typeof window !== "undefined" && pruneOnPressure) {
     window.removeEventListener("memorypressure", pruneOnPressure);
   }
+  if (typeof document !== "undefined" && pruneOnHeapPressure) {
+    document.removeEventListener(HEAP_PRESSURE_EVENT, pruneOnHeapPressure);
+  }
   if (typeof document !== "undefined" && pruneOnVisibilityHidden) {
     document.removeEventListener("visibilitychange", pruneOnVisibilityHidden);
   }
@@ -324,6 +338,7 @@ export function __resetRetainedLazyModulesForTests(): void {
     document.removeEventListener(APP_PAUSE_EVENT, pruneOnAppPause);
   }
   pruneOnPressure = null;
+  pruneOnHeapPressure = null;
   pruneOnVisibilityHidden = null;
   pruneOnAppPause = null;
   retainedModuleLifecycleInstalled = false;

--- a/packages/ui/src/state/bounded-view-lru.heap.test.ts
+++ b/packages/ui/src/state/bounded-view-lru.heap.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_BUNDLE_MODULE_MAX_ENTRIES,
+  DEFAULT_RETAINED_MODULE_MAX_ENTRIES,
+  getBundleModuleMaxEntries,
+  getKeepAliveMaxViews,
+  getRetainedModuleMaxEntries,
+  HEAP_PRESSURE_EVENT,
+  HEAP_PRESSURE_RATIO,
+  isCacheMemoryConstrained,
+  isHeapUnderPressure,
+  LOW_MEMORY_BUNDLE_MODULE_MAX_ENTRIES,
+  LOW_MEMORY_KEEP_ALIVE_MAX_VIEWS,
+  LOW_MEMORY_RETAINED_MODULE_MAX_ENTRIES,
+  readJsHeap,
+  readJsHeapUsedSize,
+} from "./bounded-view-lru";
+import {
+  __resetHeapPressureMonitorForTests,
+  checkHeapPressureOnce,
+} from "./heap-pressure-monitor";
+
+const LIMIT = 1_000_000;
+
+function setHeap(used: number | null): void {
+  if (used === null) {
+    // biome-ignore lint/performance/noDelete: test cleanup of the mock field
+    delete (performance as { memory?: unknown }).memory;
+    return;
+  }
+  Object.defineProperty(performance, "memory", {
+    configurable: true,
+    value: { usedJSHeapSize: used, jsHeapSizeLimit: LIMIT },
+  });
+}
+
+function setDeviceMemory(gb: number | null): void {
+  Object.defineProperty(navigator, "deviceMemory", {
+    configurable: true,
+    value: gb === null ? undefined : gb,
+  });
+}
+
+describe("bounded-view-lru live heap accounting (#10196)", () => {
+  beforeEach(() => {
+    setHeap(null);
+    setDeviceMemory(16); // a healthy, non-low-memory device by default
+  });
+  afterEach(() => {
+    setHeap(null);
+    __resetHeapPressureMonitorForTests();
+    vi.restoreAllMocks();
+  });
+
+  it("readJsHeap returns null without the API and a reading with it", () => {
+    expect(readJsHeap()).toBeNull();
+    expect(readJsHeapUsedSize()).toBeUndefined();
+    setHeap(0.5 * LIMIT);
+    expect(readJsHeap()).toEqual({
+      usedJSHeapSize: 0.5 * LIMIT,
+      jsHeapSizeLimit: LIMIT,
+    });
+    expect(readJsHeapUsedSize()).toBe(0.5 * LIMIT);
+  });
+
+  it("isHeapUnderPressure trips at the ratio, is false below and without the API", () => {
+    expect(isHeapUnderPressure()).toBe(false); // no API
+    setHeap((HEAP_PRESSURE_RATIO - 0.05) * LIMIT);
+    expect(isHeapUnderPressure()).toBe(false);
+    setHeap(HEAP_PRESSURE_RATIO * LIMIT);
+    expect(isHeapUnderPressure()).toBe(true);
+    setHeap(0.95 * LIMIT);
+    expect(isHeapUnderPressure()).toBe(true);
+  });
+
+  it("live heap pressure constrains the caps even on a healthy device", () => {
+    // Healthy device, low heap → default (large) caps.
+    setHeap(0.2 * LIMIT);
+    expect(isCacheMemoryConstrained()).toBe(false);
+    expect(getRetainedModuleMaxEntries()).toBe(
+      DEFAULT_RETAINED_MODULE_MAX_ENTRIES,
+    );
+    expect(getBundleModuleMaxEntries()).toBe(DEFAULT_BUNDLE_MODULE_MAX_ENTRIES);
+
+    // Same healthy device, but live heap is now under pressure → low-memory caps.
+    setHeap(0.9 * LIMIT);
+    expect(isCacheMemoryConstrained()).toBe(true);
+    expect(getRetainedModuleMaxEntries()).toBe(
+      LOW_MEMORY_RETAINED_MODULE_MAX_ENTRIES,
+    );
+    expect(getBundleModuleMaxEntries()).toBe(
+      LOW_MEMORY_BUNDLE_MODULE_MAX_ENTRIES,
+    );
+    expect(getKeepAliveMaxViews()).toBe(LOW_MEMORY_KEEP_ALIVE_MAX_VIEWS);
+  });
+
+  it("checkHeapPressureOnce dispatches the heap-pressure event only under pressure", () => {
+    const fired: Event[] = [];
+    const handler = (e: Event) => fired.push(e);
+    document.addEventListener(HEAP_PRESSURE_EVENT, handler);
+    try {
+      setHeap(0.2 * LIMIT);
+      expect(checkHeapPressureOnce()).toBe(false);
+      expect(fired).toHaveLength(0);
+
+      setHeap(0.95 * LIMIT);
+      expect(checkHeapPressureOnce()).toBe(true);
+      expect(fired).toHaveLength(1);
+    } finally {
+      document.removeEventListener(HEAP_PRESSURE_EVENT, handler);
+    }
+  });
+});

--- a/packages/ui/src/state/bounded-view-lru.ts
+++ b/packages/ui/src/state/bounded-view-lru.ts
@@ -34,6 +34,34 @@ export const LOW_MEMORY_KEEP_ALIVE_MAX_VIEWS = 1;
 export const DEFAULT_KEEP_ALIVE_TTL_MS = 5 * 60_000;
 export const LOW_MEMORY_KEEP_ALIVE_TTL_MS = 60_000;
 
+// Remote-bundle module-cache tiers (centralized here, previously hardcoded in
+// DynamicViewLoader.tsx where they had silently diverged from the retained-lazy
+// caps). A remote view bundle is heavier than a route chunk, so the normal cap
+// is smaller than the retained-module cap but the low-memory floor matches.
+export const DEFAULT_BUNDLE_MODULE_TTL_MS = 5 * 60_000;
+export const LOW_MEMORY_BUNDLE_MODULE_TTL_MS = 60_000;
+export const DEFAULT_BUNDLE_MODULE_MAX_ENTRIES = 6;
+export const LOW_MEMORY_BUNDLE_MODULE_MAX_ENTRIES = 2;
+
+/**
+ * Live-heap pressure threshold: when `usedJSHeapSize / jsHeapSizeLimit` reaches
+ * this fraction, every bounded cache drops to its low-memory tier and a forced
+ * idle-eviction pass is requested (via {@link HEAP_PRESSURE_EVENT}). 0.8 leaves
+ * headroom before the engine's own GC/OOM kicks in.
+ */
+export const HEAP_PRESSURE_RATIO = 0.8;
+
+/**
+ * Document event dispatched when live heap crosses {@link HEAP_PRESSURE_RATIO}.
+ * This is the REAL memory-pressure signal for the caches: the non-standard
+ * `memorypressure` window event Chromium never fires, so before this the caches
+ * had no live-heap input at all. The heap-pressure-monitor polls
+ * `performance.memory` while the tab is visible and dispatches this when usage
+ * crosses {@link HEAP_PRESSURE_RATIO}; the module caches listen for it and
+ * force-evict idle entries.
+ */
+export const HEAP_PRESSURE_EVENT = "eliza:heap-pressure";
+
 /**
  * Reported device RAM in GB, or `null` when the (Chromium-only) hint is absent.
  * `null` is treated as "not low memory" by {@link isLowMemoryDevice} so engines
@@ -52,16 +80,91 @@ export function isLowMemoryDevice(): boolean {
   return memoryGb !== null && memoryGb <= LOW_MEMORY_DEVICE_GB;
 }
 
+/** Live JS-heap reading from the (Chromium-only) `performance.memory` API. */
+export interface JsHeapReading {
+  usedJSHeapSize: number;
+  jsHeapSizeLimit: number;
+}
+
+/**
+ * Live heap usage from `performance.memory`, or `null` when the (Chromium-only)
+ * API is absent (Safari/Firefox) or reports non-finite values. Shared by the
+ * cache prune path, the cache-telemetry emitter, and {@link ViewTelemetryProfiler}
+ * so there is exactly one heap read implementation in the shell.
+ */
+export function readJsHeap(): JsHeapReading | null {
+  if (typeof performance === "undefined") return null;
+  const memory = (
+    performance as Performance & {
+      memory?: { usedJSHeapSize?: unknown; jsHeapSizeLimit?: unknown };
+    }
+  ).memory;
+  if (!memory) return null;
+  const used = memory.usedJSHeapSize;
+  const limit = memory.jsHeapSizeLimit;
+  if (
+    typeof used !== "number" ||
+    !Number.isFinite(used) ||
+    typeof limit !== "number" ||
+    !Number.isFinite(limit) ||
+    limit <= 0
+  ) {
+    return null;
+  }
+  return { usedJSHeapSize: used, jsHeapSizeLimit: limit };
+}
+
+/** Just the live used-heap bytes (or `undefined`), for telemetry payloads. */
+export function readJsHeapUsedSize(): number | undefined {
+  return readJsHeap()?.usedJSHeapSize;
+}
+
+/**
+ * True when live heap usage is at or above {@link HEAP_PRESSURE_RATIO} of the
+ * engine limit. Returns `false` (not "constrained") when the heap API is absent,
+ * so non-Chromium engines keep the larger caps and rely on TTL/visibility/pause.
+ */
+export function isHeapUnderPressure(
+  reading: JsHeapReading | null = readJsHeap(),
+): boolean {
+  if (!reading) return false;
+  return (
+    reading.usedJSHeapSize / reading.jsHeapSizeLimit >= HEAP_PRESSURE_RATIO
+  );
+}
+
+/**
+ * Single predicate the bounded caches size off: a device is treated as
+ * memory-constrained when it is a static low-memory device OR live heap is
+ * under pressure right now. This is the seam that finally feeds `usedJSHeapSize`
+ * into the prune decision — every cap/TTL getter below routes through it.
+ */
+export function isCacheMemoryConstrained(): boolean {
+  return isLowMemoryDevice() || isHeapUnderPressure();
+}
+
 export function getRetainedModuleTtlMs(): number {
-  return isLowMemoryDevice()
+  return isCacheMemoryConstrained()
     ? LOW_MEMORY_RETAINED_MODULE_TTL_MS
     : DEFAULT_RETAINED_MODULE_TTL_MS;
 }
 
 export function getRetainedModuleMaxEntries(): number {
-  return isLowMemoryDevice()
+  return isCacheMemoryConstrained()
     ? LOW_MEMORY_RETAINED_MODULE_MAX_ENTRIES
     : DEFAULT_RETAINED_MODULE_MAX_ENTRIES;
+}
+
+export function getBundleModuleTtlMs(): number {
+  return isCacheMemoryConstrained()
+    ? LOW_MEMORY_BUNDLE_MODULE_TTL_MS
+    : DEFAULT_BUNDLE_MODULE_TTL_MS;
+}
+
+export function getBundleModuleMaxEntries(): number {
+  return isCacheMemoryConstrained()
+    ? LOW_MEMORY_BUNDLE_MODULE_MAX_ENTRIES
+    : DEFAULT_BUNDLE_MODULE_MAX_ENTRIES;
 }
 
 /**
@@ -70,14 +173,14 @@ export function getRetainedModuleMaxEntries(): number {
  * least-recently-active retained view beyond this cap.
  */
 export function getKeepAliveMaxViews(): number {
-  return isLowMemoryDevice()
+  return isCacheMemoryConstrained()
     ? LOW_MEMORY_KEEP_ALIVE_MAX_VIEWS
     : DEFAULT_KEEP_ALIVE_MAX_VIEWS;
 }
 
 /** Idle TTL after which a retained-but-hidden keep-alive view is evicted. */
 export function getKeepAliveTtlMs(): number {
-  return isLowMemoryDevice()
+  return isCacheMemoryConstrained()
     ? LOW_MEMORY_KEEP_ALIVE_TTL_MS
     : DEFAULT_KEEP_ALIVE_TTL_MS;
 }

--- a/packages/ui/src/state/heap-pressure-monitor.ts
+++ b/packages/ui/src/state/heap-pressure-monitor.ts
@@ -1,0 +1,90 @@
+/**
+ * Live-heap pressure monitor (#10196).
+ *
+ * The bounded module/view caches size off `isCacheMemoryConstrained()`, which
+ * now folds in live heap via {@link isHeapUnderPressure}. But the caps only take
+ * effect when a prune actually runs, and the only memory-driven prune trigger
+ * the shell had — the non-standard `memorypressure` window event — is never
+ * fired by Chromium. So before this, live heap had no path into eviction at all.
+ *
+ * This monitor closes that loop: while the document is visible it polls
+ * `performance.memory` on a low-frequency interval and, when usage crosses
+ * {@link HEAP_PRESSURE_RATIO}, dispatches {@link HEAP_PRESSURE_EVENT}. The
+ * `DynamicViewLoader` + `retained-lazy` caches listen for it and force-evict
+ * idle entries. It is a no-op on engines without `performance.memory`
+ * (Safari/Firefox), which keep relying on TTL/visibility/app-pause.
+ *
+ * The poll loop is intentionally tiny (one timer, a single property read per
+ * tick) and edge-triggered logging is left to the cache telemetry; the dispatch
+ * itself is idempotent because the caches' prune is.
+ */
+
+import { HEAP_PRESSURE_EVENT, isHeapUnderPressure } from "./bounded-view-lru";
+
+/** How often to sample heap while the tab is visible. */
+export const HEAP_PRESSURE_POLL_MS = 10_000;
+
+let heapMonitorTimer: ReturnType<typeof setInterval> | null = null;
+let heapMonitorVisibilityHandler: (() => void) | null = null;
+let heapMonitorInstalled = false;
+
+/**
+ * Read heap once and dispatch {@link HEAP_PRESSURE_EVENT} when under pressure.
+ * Exported (and pure aside from the dispatch) so tests can drive a tick without
+ * waiting on the interval. Returns whether pressure was signalled.
+ */
+export function checkHeapPressureOnce(): boolean {
+  if (typeof document === "undefined") return false;
+  if (!isHeapUnderPressure()) return false;
+  document.dispatchEvent(new CustomEvent(HEAP_PRESSURE_EVENT));
+  return true;
+}
+
+function startPolling(): void {
+  if (heapMonitorTimer !== null || typeof window === "undefined") return;
+  heapMonitorTimer = setInterval(checkHeapPressureOnce, HEAP_PRESSURE_POLL_MS);
+}
+
+function stopPolling(): void {
+  if (heapMonitorTimer === null) return;
+  clearInterval(heapMonitorTimer);
+  heapMonitorTimer = null;
+}
+
+/**
+ * Install the heap monitor once. Idempotent — both cache lifecycles call it, so
+ * there is a single shared poll loop regardless of how many caches are active.
+ * Polling pauses while the document is hidden (no point evicting a backgrounded
+ * tab off heap — visibility-hidden already prunes it) and resumes on show.
+ */
+export function installHeapPressureMonitor(): void {
+  if (heapMonitorInstalled || typeof window === "undefined") return;
+  heapMonitorInstalled = true;
+  heapMonitorVisibilityHandler = () => {
+    if (document.visibilityState === "hidden") {
+      stopPolling();
+    } else {
+      checkHeapPressureOnce();
+      startPolling();
+    }
+  };
+  document.addEventListener("visibilitychange", heapMonitorVisibilityHandler);
+  if (
+    typeof document === "undefined" ||
+    document.visibilityState !== "hidden"
+  ) {
+    startPolling();
+  }
+}
+
+export function __resetHeapPressureMonitorForTests(): void {
+  stopPolling();
+  if (typeof document !== "undefined" && heapMonitorVisibilityHandler) {
+    document.removeEventListener(
+      "visibilitychange",
+      heapMonitorVisibilityHandler,
+    );
+  }
+  heapMonitorVisibilityHandler = null;
+  heapMonitorInstalled = false;
+}


### PR DESCRIPTION
Closes #10196. Salvaged from `feat/10196-view-heap-soak` (no PR), with the three review nits fixed.

## Problem

The bounded module/view caches already size off `isCacheMemoryConstrained()`, but the caps only take effect when a prune actually runs — and the **only** memory-driven prune trigger the shell had was the non-standard `memorypressure` window event, which **Chromium never fires**. So live heap had no path into eviction at all.

## What lands

- `heap-pressure-monitor.ts` — a single shared poll (`installHeapPressureMonitor`, one `setInterval` at 10s, paused while the tab is hidden) that reads `performance.memory` and, when `usedJSHeapSize` crosses `HEAP_PRESSURE_RATIO` (0.8 of `jsHeapSizeLimit`), dispatches `eliza:heap-pressure`. `DynamicViewLoader` + `retained-lazy` force-evict idle entries on it. No-op on Safari/Firefox (no `performance.memory`) — those keep relying on TTL/visibility/app-pause.
- `readJsHeap()` in `bounded-view-lru.ts` — the single boundary read (non-standard `performance.memory` validated, not `any`), routed through the existing `isCacheMemoryConstrained()` seam via `isHeapUnderPressure()`.
- Centralizes the remote-bundle caps (6/2) that had silently diverged from retained-lazy.
- `jsHeapUsedSize` added to cache telemetry.

## Review fixes (second commit)

- **Actually consolidated the heap reader** — `ViewTelemetryProfiler` now uses the shared `readJsHeap()` instead of its own private `readJsHeapUsedSize()`. (The bounded-view-lru doc claimed "exactly one heap read implementation"; now it's true.)
- Corrected the `DynamicViewLoader` comment that wrongly credited `ViewTelemetryProfiler` with dispatching the event — the shared monitor dispatches it.
- `retained-lazy.test.tsx` `afterEach` now calls `__resetHeapPressureMonitorForTests()` so the poll interval + `visibilitychange` listener don't leak across the suite.

## Safety

Graceful degradation: `readJsHeap()` returns `null` on SSR/Safari/Firefox → larger caps retained, never falsely starved. A hard `refCount > 0` floor protects the active view (only idle `refCount === 0` entries evict — no thrash). Shared `setInterval`, no busy-poll.

## Evidence

```
$ bunx vitest run src/retained-lazy.test.tsx src/state/bounded-view-lru.heap.test.ts
 Test Files  2 passed (2)
      Tests  9 passed (9)
```
Tests drive the real LRU + event path (not mocked units): the heap-pressure test stubs `performance.memory` to 950/1000, dispatches `eliza:heap-pressure`, asserts the idle module is evicted with `reason: "heap-pressure"` and the live `jsHeapUsedSize: 950` rides the telemetry event.

Typecheck: clean for all touched files.

`audit:app` visual review: **N/A** — this is view-cache eviction + telemetry plumbing; zero rendered-output change (no component renders differently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)