### PR TITLE
test: require real openWakeWord evidence for #9958

### DIFF
--- a/.github/issue-evidence/9958-stt-stage-b-eval/stage-b-stt-eval.md
+++ b/.github/issue-evidence/9958-stt-stage-b-eval/stage-b-stt-eval.md
@@ -50,15 +50,22 @@ Speech source: on-device Apple TTS (`say -v Samantha`) at 16000 Hz mono; noisy c
 - **iOS / Apple Silicon:** the measured on-device `SFSpeechRecognizer` arm confirms the §7 claim —
   real-time-factor < 1 (faster than real time) and exact accept on clean speech — so the
   ANE-capable `SFSpeechRecognizer` is the cheapest-correct Stage-B confirm recognizer on Apple.
-  Kokoro TTS is unchanged. Remaining device handoff: per-frame battery/energy telemetry on a real
-  iOS device (Instruments Energy Log), which a Mac cannot measure.
-- **Android:** `SpeechRecognizer` (NNAPI) latency/battery/accept must be measured on a real Android
-  device — not reachable from this host. Handoff.
+  Kokoro TTS is unchanged. iOS device energy telemetry is not counted as covered by this
+  Apple-Silicon-only artifact; it must be supplied through the strict Stage-B report gate.
+- **Android:** `SpeechRecognizer` (NNAPI) latency/battery/accept is not counted as covered by
+  this host artifact; it must be supplied through the strict Stage-B report gate.
 - **Linux/desktop fused:** the fused libelizainference ASR latency/RTF on the identical corpus is a
-  runtime handoff (needs the provisioned `libelizainference` bundle; see
-  `.github/issue-evidence/9147-voice-asr-m4max.md` for the qualitative on-device transcription proof).
+  required report input when the provisioned `libelizainference` bundle is available.
+  Historical qualitative ASR artifacts are not accepted as Stage-B coverage; use
+  `ELIZA_VOICE_STAGE_B_REPORT` with `packages/scripts/voice-stage-b-eval.mjs`.
 
-## Device handoff (not measurable on this host)
+## Strict report gate (not measured by this Apple-only host artifact)
+
+The complete #9958 Stage-B decision is green only when `voice-stage-b-eval.mjs`
+validates a reviewed JSON report covering iOS `SFSpeechRecognizer`, Android
+`SpeechRecognizer`, and fused ASR with real hardware, latency, WER, and power telemetry.
+
+## Required external measurements
 
 | Arm | Needs | Run |
 |---|---|---|

--- a/.github/issue-evidence/9958-voice-android-ready-gated-probe/README.md
+++ b/.github/issue-evidence/9958-voice-android-ready-gated-probe/README.md
@@ -1,0 +1,15 @@
+# #9958 Android Ready Gate Probe
+
+Generated on 2026-06-30 after tightening the Android voice matrix probe. Command:
+
+```bash
+ELIZA_VOICE_ANDROID_READY=1 \
+  bun run voice:matrix -- --platform android.device.voice-roundtrip \
+  --out .github/issue-evidence/9958-voice-android-ready-gated-probe
+```
+
+Manual review:
+
+- `voice-matrix.json`, `voice-matrix.md`, and `index.html` were opened after generation.
+- The selected Android live voice cell is `skip`, not `pass`, because this host has no Android device/emulator attached in `device` state.
+- A separate local assertion ran the same selected cell with `--require-green`; it exited with code `1`, proving an opted-in hardware lane cannot green-pass this missing device/app state.

--- a/.github/issue-evidence/9958-voice-android-ready-gated-probe/index.html
+++ b/.github/issue-evidence/9958-voice-android-ready-gated-probe/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Voice Live Matrix</title>
+<style>
+body{font-family:system-ui,-apple-system,Segoe UI,sans-serif;margin:24px;background:#fafafa;color:#151515}
+table{width:100%;border-collapse:collapse;background:white}
+th,td{border:1px solid #ddd;padding:8px;vertical-align:top;white-space:pre-wrap}
+th{background:#f1f1f1;text-align:left}
+.pass td:nth-child(2){color:#116b2d;font-weight:700}
+.fail td:nth-child(2){color:#9a1b1b;font-weight:700}
+.skip td:nth-child(2),.pending td:nth-child(2){color:#7a5b00;font-weight:700}
+code{font-size:12px}
+</style>
+<h1>Voice Live Matrix</h1>
+<p>Generated 2026-06-30T07:21:10.264Z on darwin arm64 (Shaws-MacBook-Pro.local).</p>
+<p>Pass 0 · Fail 0 · Pending 0 · Skip 1</p>
+<table><thead><tr><th>Cell</th><th>Status</th><th>Platform</th><th>Class</th><th>Dimensions</th><th>Probe / Result</th><th>Command</th><th>Evidence</th></tr></thead><tbody><tr class="skip"><td><code>android.device.voice-roundtrip</code><br>Android device WebView real on-device STT -&gt; agent -&gt; TTS voice self-test</td><td>skip</td><td>android</td><td>mobile-live-voice</td><td>transcriptionState=off
+chimeIn=should-respond
+wakewordContext=idle-wake
+noiseRejection=quiet
+voices=owner</td><td>ELIZA_VOICE_ANDROID_READY=1 but no Android device/emulator is attached in device state; attach a device/emulator and install the current app before capture</td><td><code>bun run --cwd packages/app test:e2e:android:local</code></td><td>packages/app/test-results
+.github/issue-evidence</td></tr></tbody></table>

--- a/.github/issue-evidence/9958-voice-android-ready-gated-probe/voice-matrix.json
+++ b/.github/issue-evidence/9958-voice-android-ready-gated-probe/voice-matrix.json
@@ -1,0 +1,88 @@
+{
+  "schema": "eliza_voice_live_matrix_v1",
+  "issue": 9958,
+  "generatedAt": "2026-06-30T07:21:10.264Z",
+  "mode": "probe",
+  "dimensions": {
+    "platform": [
+      "web",
+      "linux",
+      "macos-electrobun",
+      "windows-electrobun",
+      "ios",
+      "android"
+    ],
+    "transcriptionState": [
+      "off",
+      "on"
+    ],
+    "chimeIn": [
+      "should-respond",
+      "should-not-respond"
+    ],
+    "wakewordContext": [
+      "idle-wake",
+      "already-listening-wake-inert",
+      "mid-transcription-wake"
+    ],
+    "noiseRejection": [
+      "quiet",
+      "noisy-reverberant",
+      "echo-self-voice",
+      "overlapping-speech"
+    ],
+    "voices": [
+      "owner",
+      "enrolled-contact",
+      "unknown",
+      "multi-speaker"
+    ]
+  },
+  "host": {
+    "platform": "darwin",
+    "arch": "arm64",
+    "hostname": "Shaws-MacBook-Pro.local",
+    "runnerOs": null,
+    "runnerArch": null
+  },
+  "summary": {
+    "pass": 0,
+    "fail": 0,
+    "pending": 0,
+    "skip": 1
+  },
+  "cells": [
+    {
+      "id": "android.device.voice-roundtrip",
+      "title": "Android device WebView real on-device STT -> agent -> TTS voice self-test",
+      "platform": "android",
+      "dimensions": {
+        "transcriptionState": "off",
+        "chimeIn": "should-respond",
+        "wakewordContext": "idle-wake",
+        "noiseRejection": "quiet",
+        "voices": "owner"
+      },
+      "class": "mobile-live-voice",
+      "command": [
+        "bun",
+        "run",
+        "--cwd",
+        "packages/app",
+        "test:e2e:android:local"
+      ],
+      "evidence": [
+        "packages/app/test-results",
+        ".github/issue-evidence"
+      ],
+      "probe": {
+        "available": false,
+        "reason": "ELIZA_VOICE_ANDROID_READY=1 but no Android device/emulator is attached in device state; attach a device/emulator and install the current app before capture"
+      },
+      "cwd": ".",
+      "env": {},
+      "execution": null,
+      "status": "skip"
+    }
+  ]
+}

--- a/.github/issue-evidence/9958-voice-android-ready-gated-probe/voice-matrix.md
+++ b/.github/issue-evidence/9958-voice-android-ready-gated-probe/voice-matrix.md
@@ -1,0 +1,17 @@
+# Voice Live Matrix
+
+Generated: 2026-06-30T07:21:10.264Z
+Host: darwin arm64 (Shaws-MacBook-Pro.local)
+
+| Cell | Status | Platform | Class | Probe / Result | Command |
+|---|---:|---|---|---|---|
+| `android.device.voice-roundtrip` | skip | android | mobile-live-voice | ELIZA_VOICE_ANDROID_READY=1 but no Android device/emulator is attached in device state; attach a device/emulator and install the current app before capture | `bun run --cwd packages/app test:e2e:android:local` |
+
+## Summary
+
+- Pass: 0
+- Fail: 0
+- Pending: 0
+- Skip: 1
+
+Hardware-unavailable cells are explicit `skip` rows. They are not evidence of platform coverage.

--- a/.github/issue-evidence/9958-voice-ios-ready-gated-probe/README.md
+++ b/.github/issue-evidence/9958-voice-ios-ready-gated-probe/README.md
@@ -1,0 +1,15 @@
+# #9958 iOS Ready Gate Probe
+
+Generated on 2026-06-30 after tightening the iOS voice matrix probe. Command:
+
+```bash
+ELIZA_VOICE_IOS_READY=1 \
+  bun run voice:matrix -- --platform ios.sim-or-device.voice-roundtrip \
+  --out .github/issue-evidence/9958-voice-ios-ready-gated-probe
+```
+
+Manual review:
+
+- `voice-matrix.json`, `voice-matrix.md`, and `index.html` were opened after generation.
+- The selected iOS live voice cell is `skip`, not `pass`, because this Mac has no booted iOS simulator.
+- A separate local assertion ran the same selected cell with `--require-green`; it exited with code `1`, proving an opted-in hardware lane cannot green-pass this missing simulator/app state.

--- a/.github/issue-evidence/9958-voice-ios-ready-gated-probe/index.html
+++ b/.github/issue-evidence/9958-voice-ios-ready-gated-probe/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Voice Live Matrix</title>
+<style>
+body{font-family:system-ui,-apple-system,Segoe UI,sans-serif;margin:24px;background:#fafafa;color:#151515}
+table{width:100%;border-collapse:collapse;background:white}
+th,td{border:1px solid #ddd;padding:8px;vertical-align:top;white-space:pre-wrap}
+th{background:#f1f1f1;text-align:left}
+.pass td:nth-child(2){color:#116b2d;font-weight:700}
+.fail td:nth-child(2){color:#9a1b1b;font-weight:700}
+.skip td:nth-child(2),.pending td:nth-child(2){color:#7a5b00;font-weight:700}
+code{font-size:12px}
+</style>
+<h1>Voice Live Matrix</h1>
+<p>Generated 2026-06-30T07:01:48.954Z on darwin arm64 (Shaws-MacBook-Pro.local).</p>
+<p>Pass 0 · Fail 0 · Pending 0 · Skip 1</p>
+<table><thead><tr><th>Cell</th><th>Status</th><th>Platform</th><th>Class</th><th>Dimensions</th><th>Probe / Result</th><th>Command</th><th>Evidence</th></tr></thead><tbody><tr class="skip"><td><code>ios.sim-or-device.voice-roundtrip</code><br>iOS simulator/device voice self-test and capture evidence</td><td>skip</td><td>ios</td><td>mobile-live-voice</td><td>transcriptionState=off
+chimeIn=should-respond
+wakewordContext=idle-wake
+noiseRejection=quiet
+voices=owner</td><td>ELIZA_VOICE_IOS_READY=1 but no booted iOS simulator is available; boot a simulator and install the current app before capture</td><td><code>bun run --cwd packages/app capture:ios-sim -- --issue 9958 --slug voice-ios</code></td><td>.github/issue-evidence/9958-voice-ios-ios-sim.*</td></tr></tbody></table>

--- a/.github/issue-evidence/9958-voice-ios-ready-gated-probe/voice-matrix.json
+++ b/.github/issue-evidence/9958-voice-ios-ready-gated-probe/voice-matrix.json
@@ -1,0 +1,92 @@
+{
+  "schema": "eliza_voice_live_matrix_v1",
+  "issue": 9958,
+  "generatedAt": "2026-06-30T07:01:48.954Z",
+  "mode": "probe",
+  "dimensions": {
+    "platform": [
+      "web",
+      "linux",
+      "macos-electrobun",
+      "windows-electrobun",
+      "ios",
+      "android"
+    ],
+    "transcriptionState": [
+      "off",
+      "on"
+    ],
+    "chimeIn": [
+      "should-respond",
+      "should-not-respond"
+    ],
+    "wakewordContext": [
+      "idle-wake",
+      "already-listening-wake-inert",
+      "mid-transcription-wake"
+    ],
+    "noiseRejection": [
+      "quiet",
+      "noisy-reverberant",
+      "echo-self-voice",
+      "overlapping-speech"
+    ],
+    "voices": [
+      "owner",
+      "enrolled-contact",
+      "unknown",
+      "multi-speaker"
+    ]
+  },
+  "host": {
+    "platform": "darwin",
+    "arch": "arm64",
+    "hostname": "Shaws-MacBook-Pro.local",
+    "runnerOs": null,
+    "runnerArch": null
+  },
+  "summary": {
+    "pass": 0,
+    "fail": 0,
+    "pending": 0,
+    "skip": 1
+  },
+  "cells": [
+    {
+      "id": "ios.sim-or-device.voice-roundtrip",
+      "title": "iOS simulator/device voice self-test and capture evidence",
+      "platform": "ios",
+      "dimensions": {
+        "transcriptionState": "off",
+        "chimeIn": "should-respond",
+        "wakewordContext": "idle-wake",
+        "noiseRejection": "quiet",
+        "voices": "owner"
+      },
+      "class": "mobile-live-voice",
+      "command": [
+        "bun",
+        "run",
+        "--cwd",
+        "packages/app",
+        "capture:ios-sim",
+        "--",
+        "--issue",
+        "9958",
+        "--slug",
+        "voice-ios"
+      ],
+      "evidence": [
+        ".github/issue-evidence/9958-voice-ios-ios-sim.*"
+      ],
+      "probe": {
+        "available": false,
+        "reason": "ELIZA_VOICE_IOS_READY=1 but no booted iOS simulator is available; boot a simulator and install the current app before capture"
+      },
+      "cwd": ".",
+      "env": {},
+      "execution": null,
+      "status": "skip"
+    }
+  ]
+}

--- a/.github/issue-evidence/9958-voice-ios-ready-gated-probe/voice-matrix.md
+++ b/.github/issue-evidence/9958-voice-ios-ready-gated-probe/voice-matrix.md
@@ -1,0 +1,17 @@
+# Voice Live Matrix
+
+Generated: 2026-06-30T07:01:48.954Z
+Host: darwin arm64 (Shaws-MacBook-Pro.local)
+
+| Cell | Status | Platform | Class | Probe / Result | Command |
+|---|---:|---|---|---|---|
+| `ios.sim-or-device.voice-roundtrip` | skip | ios | mobile-live-voice | ELIZA_VOICE_IOS_READY=1 but no booted iOS simulator is available; boot a simulator and install the current app before capture | `bun run --cwd packages/app capture:ios-sim -- --issue 9958 --slug voice-ios` |
+
+## Summary
+
+- Pass: 0
+- Fail: 0
+- Pending: 0
+- Skip: 1
+
+Hardware-unavailable cells are explicit `skip` rows. They are not evidence of platform coverage.

--- a/.github/issue-evidence/9958-voice-matrix-android-native-bridge/index.html
+++ b/.github/issue-evidence/9958-voice-matrix-android-native-bridge/index.html
@@ -12,7 +12,7 @@ th{background:#f1f1f1;text-align:left}
 code{font-size:12px}
 </style>
 <h1>Voice Live Matrix</h1>
-<p>Generated 2026-06-30T03:13:49.083Z on darwin arm64 (Shaws-MacBook-Pro.local).</p>
+<p>Generated 2026-06-30T07:13:49.529Z on darwin arm64 (Shaws-MacBook-Pro.local).</p>
 <p>Pass 2 · Fail 0 · Pending 0 · Skip 2</p>
 <table><thead><tr><th>Cell</th><th>Status</th><th>Platform</th><th>Class</th><th>Dimensions</th><th>Probe / Result</th><th>Command</th><th>Evidence</th></tr></thead><tbody><tr class="skip"><td><code>android.device.voice-roundtrip</code><br>Android device WebView real on-device STT -&gt; agent -&gt; TTS voice self-test</td><td>skip</td><td>android</td><td>mobile-live-voice</td><td>transcriptionState=off
 chimeIn=should-respond
@@ -24,14 +24,15 @@ voices=owner</td><td>set ELIZA_VOICE_ANDROID_READY=1 on an Android device runner
 chimeIn=should-respond
 wakewordContext=already-listening-wake-inert
 noiseRejection=echo-self-voice
-voices=owner</td><td>command passed (2026-06-30T03:13:48.408Z)</td><td><code>./gradlew -p ../../../scripts/android-voice-bridge-gradle :elizaos-capacitor-talkmode:testDebugUnitTest</code></td><td>plugins/plugin-native-talkmode/android/src/test/java</td></tr>
+voices=owner</td><td>command passed (2026-06-30T07:13:48.985Z)</td><td><code>./gradlew -p ../../../scripts/android-voice-bridge-gradle :elizaos-capacitor-talkmode:testDebugUnitTest</code></td><td>plugins/plugin-native-talkmode/android/src/test/java</td></tr>
 <tr class="pass"><td><code>android.swabble.native-bridge</code><br>Swabble Android wake-firing -&gt; JS bridge event contract</td><td>pass</td><td>android</td><td>native-bridge-unit</td><td>transcriptionState=off
 chimeIn=should-respond
 wakewordContext=idle-wake
 noiseRejection=quiet
-voices=owner</td><td>command passed (2026-06-30T03:13:49.078Z)</td><td><code>./gradlew -p ../../../scripts/android-voice-bridge-gradle :elizaos-capacitor-swabble:testDebugUnitTest</code></td><td>plugins/plugin-native-swabble/android/src/test/java</td></tr>
-<tr class="skip"><td><code>stt.stage-b.evaluation</code><br>Stage-B STT evaluation: iOS SFSpeechRecognizer vs Android SpeechRecognizer vs fused ASR</td><td>skip</td><td>android</td><td>stt-evaluation</td><td>transcriptionState=on
+voices=owner</td><td>command passed (2026-06-30T07:13:49.525Z)</td><td><code>./gradlew -p ../../../scripts/android-voice-bridge-gradle :elizaos-capacitor-swabble:testDebugUnitTest</code></td><td>plugins/plugin-native-swabble/android/src/test/java</td></tr>
+<tr class="skip"><td><code>stt.stage-b.evaluation</code><br>Stage-B STT evaluation: iOS battery/energy + Android SpeechRecognizer (NNAPI) vs fused ASR</td><td>skip</td><td>android</td><td>stt-evaluation</td><td>transcriptionState=on
 chimeIn=should-respond
 wakewordContext=idle-wake
 noiseRejection=noisy-reverberant
-voices=multi-speaker</td><td>Stage-B STT battery/latency evaluation needs paired iOS+Android device runners and power telemetry</td><td><code>bun packages/scripts/voice-matrix.mjs --stage-b-eval-placeholder</code></td><td>.github/issue-evidence/9147-voice-asr-m4max.md</td></tr></tbody></table>
+voices=multi-speaker</td><td>ELIZA_VOICE_STAGE_B_REPORT is not set to a reviewed iOS+Android+fused ASR Stage-B JSON report</td><td><code>node packages/scripts/voice-stage-b-eval.mjs</code></td><td>$ELIZA_VOICE_MATRIX_OUT/stt.stage-b.evaluation/stage-b-eval.json
+$ELIZA_VOICE_STAGE_B_REPORT</td></tr></tbody></table>

--- a/.github/issue-evidence/9958-voice-matrix-android-native-bridge/voice-matrix.json
+++ b/.github/issue-evidence/9958-voice-matrix-android-native-bridge/voice-matrix.json
@@ -1,7 +1,7 @@
 {
   "schema": "eliza_voice_live_matrix_v1",
   "issue": 9958,
-  "generatedAt": "2026-06-30T03:13:49.083Z",
+  "generatedAt": "2026-06-30T07:13:49.529Z",
   "mode": "run",
   "dimensions": {
     "platform": [
@@ -108,15 +108,15 @@
       ],
       "probe": {
         "available": true,
-        "reason": "command passed (2026-06-30T03:13:48.408Z)"
+        "reason": "command passed (2026-06-30T07:13:48.985Z)"
       },
       "env": {},
       "execution": {
         "exitCode": 0,
         "signal": null,
-        "startedAt": "2026-06-30T03:13:47.502Z",
-        "finishedAt": "2026-06-30T03:13:48.408Z",
-        "stdoutTail": "> Task :capacitor-android:preBuild UP-TO-DATE\n> Task :capacitor-android:preDebugBuild UP-TO-DATE\n> Task :capacitor-android:generateDebugResValues UP-TO-DATE\n> Task :capacitor-android:generateDebugResources UP-TO-DATE\n> Task :capacitor-android:packageDebugResources UP-TO-DATE\n> Task :capacitor-android:processDebugNavigationResources UP-TO-DATE\n> Task :capacitor-android:parseDebugLocalResources UP-TO-DATE\n> Task :capacitor-android:generateDebugRFile UP-TO-DATE\n> Task :capacitor-android:javaPreCompileDebug UP-TO-DATE\n> Task :capacitor-android:compileDebugJavaWithJavac UP-TO-DATE\n> Task :capacitor-android:bundleLibRuntimeToJarDebug UP-TO-DATE\n> Task :capacitor-android:processDebugJavaRes NO-SOURCE\n> Task :capacitor-android:bundleLibCompileToJarDebug UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:checkKotlinGradlePluginConfigurationErrors SKIPPED\n> Task :elizaos-capacitor-talkmode:preBuild UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:preDebugBuild UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:generateDebugResValues UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:generateDebugResources UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:packageDebugResources UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:processDebugNavigationResources UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:parseDebugLocalResources UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:generateDebugRFile UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:compileDebugKotlin UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:javaPreCompileDebug UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:compileDebugJavaWithJavac NO-SOURCE\n> Task :elizaos-capacitor-talkmode:bundleLibRuntimeToJarDebug UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:bundleLibCompileToJarDebug UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:preDebugUnitTestBuild UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:generateDebugUnitTestStubRFile UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:compileDebugUnitTestKotlin UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:javaPreCompileDebugUnitTest UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:compileDebugUnitTestJavaWithJavac NO-SOURCE\n> Task :elizaos-capacitor-talkmode:processDebugJavaRes UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:processDebugUnitTestJavaRes UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:testDebugUnitTest UP-TO-DATE\n\n[Incubating] Problems report is available at: file:///Users/shawwalters/.codex/worktrees/740a/eliza/packages/scripts/android-voice-bridge-gradle/build/reports/problems/problems-report.html\n\nDeprecated Gradle features were used in this build, making it incompatible with Gradle 10.\n\nYou can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.\n\nFor more on this, please refer to https://docs.gradle.org/9.5.0/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.\n\nBUILD SUCCESSFUL in 838ms\n26 actionable tasks: 26 up-to-date\nConsider enabling configuration cache to speed up this build: https://docs.gradle.org/9.5.0/userguide/configuration_cache_enabling.html\n",
+        "startedAt": "2026-06-30T07:13:48.136Z",
+        "finishedAt": "2026-06-30T07:13:48.985Z",
+        "stdoutTail": "> Task :capacitor-android:preBuild UP-TO-DATE\n> Task :capacitor-android:preDebugBuild UP-TO-DATE\n> Task :capacitor-android:generateDebugResValues UP-TO-DATE\n> Task :capacitor-android:generateDebugResources UP-TO-DATE\n> Task :capacitor-android:packageDebugResources UP-TO-DATE\n> Task :capacitor-android:processDebugNavigationResources UP-TO-DATE\n> Task :capacitor-android:parseDebugLocalResources UP-TO-DATE\n> Task :capacitor-android:generateDebugRFile UP-TO-DATE\n> Task :capacitor-android:javaPreCompileDebug UP-TO-DATE\n> Task :capacitor-android:compileDebugJavaWithJavac UP-TO-DATE\n> Task :capacitor-android:bundleLibRuntimeToJarDebug UP-TO-DATE\n> Task :capacitor-android:processDebugJavaRes NO-SOURCE\n> Task :capacitor-android:bundleLibCompileToJarDebug UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:checkKotlinGradlePluginConfigurationErrors SKIPPED\n> Task :elizaos-capacitor-talkmode:preBuild UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:preDebugBuild UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:generateDebugResValues UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:generateDebugResources UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:packageDebugResources UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:processDebugNavigationResources UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:parseDebugLocalResources UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:generateDebugRFile UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:compileDebugKotlin UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:javaPreCompileDebug UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:compileDebugJavaWithJavac NO-SOURCE\n> Task :elizaos-capacitor-talkmode:bundleLibRuntimeToJarDebug UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:bundleLibCompileToJarDebug UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:preDebugUnitTestBuild UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:generateDebugUnitTestStubRFile UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:compileDebugUnitTestKotlin UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:javaPreCompileDebugUnitTest UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:compileDebugUnitTestJavaWithJavac NO-SOURCE\n> Task :elizaos-capacitor-talkmode:processDebugJavaRes UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:processDebugUnitTestJavaRes UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:testDebugUnitTest UP-TO-DATE\n\n[Incubating] Problems report is available at: file:///Users/shawwalters/.codex/worktrees/740a/eliza/packages/scripts/android-voice-bridge-gradle/build/reports/problems/problems-report.html\n\nDeprecated Gradle features were used in this build, making it incompatible with Gradle 10.\n\nYou can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.\n\nFor more on this, please refer to https://docs.gradle.org/9.5.0/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.\n\nBUILD SUCCESSFUL in 789ms\n26 actionable tasks: 26 up-to-date\nConsider enabling configuration cache to speed up this build: https://docs.gradle.org/9.5.0/userguide/configuration_cache_enabling.html\n",
         "stderrTail": ""
       },
       "status": "pass"
@@ -145,22 +145,22 @@
       ],
       "probe": {
         "available": true,
-        "reason": "command passed (2026-06-30T03:13:49.078Z)"
+        "reason": "command passed (2026-06-30T07:13:49.525Z)"
       },
       "env": {},
       "execution": {
         "exitCode": 0,
         "signal": null,
-        "startedAt": "2026-06-30T03:13:48.413Z",
-        "finishedAt": "2026-06-30T03:13:49.078Z",
-        "stdoutTail": "> Task :capacitor-android:preBuild UP-TO-DATE\n> Task :capacitor-android:preDebugBuild UP-TO-DATE\n> Task :capacitor-android:generateDebugResValues UP-TO-DATE\n> Task :capacitor-android:generateDebugResources UP-TO-DATE\n> Task :capacitor-android:packageDebugResources UP-TO-DATE\n> Task :capacitor-android:processDebugNavigationResources UP-TO-DATE\n> Task :capacitor-android:parseDebugLocalResources UP-TO-DATE\n> Task :capacitor-android:generateDebugRFile UP-TO-DATE\n> Task :capacitor-android:javaPreCompileDebug UP-TO-DATE\n> Task :capacitor-android:compileDebugJavaWithJavac UP-TO-DATE\n> Task :capacitor-android:bundleLibRuntimeToJarDebug UP-TO-DATE\n> Task :capacitor-android:processDebugJavaRes NO-SOURCE\n> Task :capacitor-android:bundleLibCompileToJarDebug UP-TO-DATE\n> Task :elizaos-capacitor-swabble:checkKotlinGradlePluginConfigurationErrors SKIPPED\n> Task :elizaos-capacitor-swabble:preBuild UP-TO-DATE\n> Task :elizaos-capacitor-swabble:preDebugBuild UP-TO-DATE\n> Task :elizaos-capacitor-swabble:generateDebugResValues UP-TO-DATE\n> Task :elizaos-capacitor-swabble:generateDebugResources UP-TO-DATE\n> Task :elizaos-capacitor-swabble:packageDebugResources UP-TO-DATE\n> Task :elizaos-capacitor-swabble:processDebugNavigationResources UP-TO-DATE\n> Task :elizaos-capacitor-swabble:parseDebugLocalResources UP-TO-DATE\n> Task :elizaos-capacitor-swabble:generateDebugRFile UP-TO-DATE\n> Task :elizaos-capacitor-swabble:compileDebugKotlin UP-TO-DATE\n> Task :elizaos-capacitor-swabble:javaPreCompileDebug UP-TO-DATE\n> Task :elizaos-capacitor-swabble:compileDebugJavaWithJavac NO-SOURCE\n> Task :elizaos-capacitor-swabble:bundleLibRuntimeToJarDebug UP-TO-DATE\n> Task :elizaos-capacitor-swabble:bundleLibCompileToJarDebug UP-TO-DATE\n> Task :elizaos-capacitor-swabble:preDebugUnitTestBuild UP-TO-DATE\n> Task :elizaos-capacitor-swabble:generateDebugUnitTestStubRFile UP-TO-DATE\n> Task :elizaos-capacitor-swabble:compileDebugUnitTestKotlin UP-TO-DATE\n> Task :elizaos-capacitor-swabble:javaPreCompileDebugUnitTest UP-TO-DATE\n> Task :elizaos-capacitor-swabble:compileDebugUnitTestJavaWithJavac NO-SOURCE\n> Task :elizaos-capacitor-swabble:processDebugJavaRes UP-TO-DATE\n> Task :elizaos-capacitor-swabble:processDebugUnitTestJavaRes UP-TO-DATE\n> Task :elizaos-capacitor-swabble:testDebugUnitTest UP-TO-DATE\n\n[Incubating] Problems report is available at: file:///Users/shawwalters/.codex/worktrees/740a/eliza/packages/scripts/android-voice-bridge-gradle/build/reports/problems/problems-report.html\n\nDeprecated Gradle features were used in this build, making it incompatible with Gradle 10.\n\nYou can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.\n\nFor more on this, please refer to https://docs.gradle.org/9.5.0/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.\n\nBUILD SUCCESSFUL in 611ms\n26 actionable tasks: 26 up-to-date\nConsider enabling configuration cache to speed up this build: https://docs.gradle.org/9.5.0/userguide/configuration_cache_enabling.html\n",
+        "startedAt": "2026-06-30T07:13:48.989Z",
+        "finishedAt": "2026-06-30T07:13:49.525Z",
+        "stdoutTail": "> Task :capacitor-android:preBuild UP-TO-DATE\n> Task :capacitor-android:preDebugBuild UP-TO-DATE\n> Task :capacitor-android:generateDebugResValues UP-TO-DATE\n> Task :capacitor-android:generateDebugResources UP-TO-DATE\n> Task :capacitor-android:packageDebugResources UP-TO-DATE\n> Task :capacitor-android:processDebugNavigationResources UP-TO-DATE\n> Task :capacitor-android:parseDebugLocalResources UP-TO-DATE\n> Task :capacitor-android:generateDebugRFile UP-TO-DATE\n> Task :capacitor-android:javaPreCompileDebug UP-TO-DATE\n> Task :capacitor-android:compileDebugJavaWithJavac UP-TO-DATE\n> Task :capacitor-android:bundleLibRuntimeToJarDebug UP-TO-DATE\n> Task :capacitor-android:processDebugJavaRes NO-SOURCE\n> Task :capacitor-android:bundleLibCompileToJarDebug UP-TO-DATE\n> Task :elizaos-capacitor-swabble:checkKotlinGradlePluginConfigurationErrors SKIPPED\n> Task :elizaos-capacitor-swabble:preBuild UP-TO-DATE\n> Task :elizaos-capacitor-swabble:preDebugBuild UP-TO-DATE\n> Task :elizaos-capacitor-swabble:generateDebugResValues UP-TO-DATE\n> Task :elizaos-capacitor-swabble:generateDebugResources UP-TO-DATE\n> Task :elizaos-capacitor-swabble:packageDebugResources UP-TO-DATE\n> Task :elizaos-capacitor-swabble:processDebugNavigationResources UP-TO-DATE\n> Task :elizaos-capacitor-swabble:parseDebugLocalResources UP-TO-DATE\n> Task :elizaos-capacitor-swabble:generateDebugRFile UP-TO-DATE\n> Task :elizaos-capacitor-swabble:compileDebugKotlin UP-TO-DATE\n> Task :elizaos-capacitor-swabble:javaPreCompileDebug UP-TO-DATE\n> Task :elizaos-capacitor-swabble:compileDebugJavaWithJavac NO-SOURCE\n> Task :elizaos-capacitor-swabble:bundleLibRuntimeToJarDebug UP-TO-DATE\n> Task :elizaos-capacitor-swabble:bundleLibCompileToJarDebug UP-TO-DATE\n> Task :elizaos-capacitor-swabble:preDebugUnitTestBuild UP-TO-DATE\n> Task :elizaos-capacitor-swabble:generateDebugUnitTestStubRFile UP-TO-DATE\n> Task :elizaos-capacitor-swabble:compileDebugUnitTestKotlin UP-TO-DATE\n> Task :elizaos-capacitor-swabble:javaPreCompileDebugUnitTest UP-TO-DATE\n> Task :elizaos-capacitor-swabble:compileDebugUnitTestJavaWithJavac NO-SOURCE\n> Task :elizaos-capacitor-swabble:processDebugJavaRes UP-TO-DATE\n> Task :elizaos-capacitor-swabble:processDebugUnitTestJavaRes UP-TO-DATE\n> Task :elizaos-capacitor-swabble:testDebugUnitTest UP-TO-DATE\n\n[Incubating] Problems report is available at: file:///Users/shawwalters/.codex/worktrees/740a/eliza/packages/scripts/android-voice-bridge-gradle/build/reports/problems/problems-report.html\n\nDeprecated Gradle features were used in this build, making it incompatible with Gradle 10.\n\nYou can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.\n\nFor more on this, please refer to https://docs.gradle.org/9.5.0/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.\n\nBUILD SUCCESSFUL in 476ms\n26 actionable tasks: 26 up-to-date\nConsider enabling configuration cache to speed up this build: https://docs.gradle.org/9.5.0/userguide/configuration_cache_enabling.html\n",
         "stderrTail": ""
       },
       "status": "pass"
     },
     {
       "id": "stt.stage-b.evaluation",
-      "title": "Stage-B STT evaluation: iOS SFSpeechRecognizer vs Android SpeechRecognizer vs fused ASR",
+      "title": "Stage-B STT evaluation: iOS battery/energy + Android SpeechRecognizer (NNAPI) vs fused ASR",
       "platform": "android",
       "dimensions": {
         "transcriptionState": "on",
@@ -171,16 +171,16 @@
       },
       "class": "stt-evaluation",
       "command": [
-        "bun",
-        "packages/scripts/voice-matrix.mjs",
-        "--stage-b-eval-placeholder"
+        "node",
+        "packages/scripts/voice-stage-b-eval.mjs"
       ],
       "evidence": [
-        ".github/issue-evidence/9147-voice-asr-m4max.md"
+        "$ELIZA_VOICE_MATRIX_OUT/stt.stage-b.evaluation/stage-b-eval.json",
+        "$ELIZA_VOICE_STAGE_B_REPORT"
       ],
       "probe": {
         "available": false,
-        "reason": "Stage-B STT battery/latency evaluation needs paired iOS+Android device runners and power telemetry"
+        "reason": "ELIZA_VOICE_STAGE_B_REPORT is not set to a reviewed iOS+Android+fused ASR Stage-B JSON report"
       },
       "cwd": ".",
       "env": {},

--- a/.github/issue-evidence/9958-voice-matrix-android-native-bridge/voice-matrix.md
+++ b/.github/issue-evidence/9958-voice-matrix-android-native-bridge/voice-matrix.md
@@ -1,14 +1,14 @@
 # Voice Live Matrix
 
-Generated: 2026-06-30T03:13:49.083Z
+Generated: 2026-06-30T07:13:49.529Z
 Host: darwin arm64 (Shaws-MacBook-Pro.local)
 
 | Cell | Status | Platform | Class | Probe / Result | Command |
 |---|---:|---|---|---|---|
 | `android.device.voice-roundtrip` | skip | android | mobile-live-voice | set ELIZA_VOICE_ANDROID_READY=1 on an Android device runner with the current APK and voice assets installed | `bun run --cwd packages/app test:e2e:android:local` |
-| `android.talkmode.native-bridge` | pass | android | native-bridge-unit | command passed (2026-06-30T03:13:48.408Z) | `./gradlew -p ../../../scripts/android-voice-bridge-gradle :elizaos-capacitor-talkmode:testDebugUnitTest` |
-| `android.swabble.native-bridge` | pass | android | native-bridge-unit | command passed (2026-06-30T03:13:49.078Z) | `./gradlew -p ../../../scripts/android-voice-bridge-gradle :elizaos-capacitor-swabble:testDebugUnitTest` |
-| `stt.stage-b.evaluation` | skip | android | stt-evaluation | Stage-B STT battery/latency evaluation needs paired iOS+Android device runners and power telemetry | `bun packages/scripts/voice-matrix.mjs --stage-b-eval-placeholder` |
+| `android.talkmode.native-bridge` | pass | android | native-bridge-unit | command passed (2026-06-30T07:13:48.985Z) | `./gradlew -p ../../../scripts/android-voice-bridge-gradle :elizaos-capacitor-talkmode:testDebugUnitTest` |
+| `android.swabble.native-bridge` | pass | android | native-bridge-unit | command passed (2026-06-30T07:13:49.525Z) | `./gradlew -p ../../../scripts/android-voice-bridge-gradle :elizaos-capacitor-swabble:testDebugUnitTest` |
+| `stt.stage-b.evaluation` | skip | android | stt-evaluation | ELIZA_VOICE_STAGE_B_REPORT is not set to a reviewed iOS+Android+fused ASR Stage-B JSON report | `node packages/scripts/voice-stage-b-eval.mjs` |
 
 ## Summary
 

--- a/.github/issue-evidence/9958-voice-matrix-android-native-run/README.md
+++ b/.github/issue-evidence/9958-voice-matrix-android-native-run/README.md
@@ -1,0 +1,27 @@
+# #9958 Android Native Bridge Matrix Refresh
+
+Command:
+
+```bash
+bun run voice:matrix -- --run --platform android --out .github/issue-evidence/9958-voice-matrix-android-native-run
+```
+
+Result:
+
+- `pass=2`
+- `fail=0`
+- `pending=0`
+- `skip=2`
+
+Manual review:
+
+- Reviewed `voice-matrix.json`; Android TalkMode and Swabble native bridge
+  Gradle contracts passed, with both command executions exiting 0.
+- Reviewed `voice-matrix.md`; the selected Android bridge rows match the JSON
+  pass counts.
+- Reviewed `index.html`; it renders the same bridge pass rows and the refreshed
+  strict Stage-B missing-report skip.
+
+This is native bridge contract evidence, not Android device voice-roundtrip
+coverage. `android.device.voice-roundtrip` remains an explicit hardware skip
+until a current APK/device runner is available.

--- a/.github/issue-evidence/9958-voice-matrix-android-native-run/index.html
+++ b/.github/issue-evidence/9958-voice-matrix-android-native-run/index.html
@@ -12,7 +12,7 @@ th{background:#f1f1f1;text-align:left}
 code{font-size:12px}
 </style>
 <h1>Voice Live Matrix</h1>
-<p>Generated 2026-06-30T00:38:51.994Z on darwin arm64 (Shaws-MacBook-Pro.local).</p>
+<p>Generated 2026-06-30T06:47:00.567Z on darwin arm64 (Shaws-MacBook-Pro.local).</p>
 <p>Pass 2 · Fail 0 · Pending 0 · Skip 2</p>
 <table><thead><tr><th>Cell</th><th>Status</th><th>Platform</th><th>Class</th><th>Dimensions</th><th>Probe / Result</th><th>Command</th><th>Evidence</th></tr></thead><tbody><tr class="skip"><td><code>android.device.voice-roundtrip</code><br>Android device WebView real on-device STT -&gt; agent -&gt; TTS voice self-test</td><td>skip</td><td>android</td><td>mobile-live-voice</td><td>transcriptionState=off
 chimeIn=should-respond
@@ -24,14 +24,15 @@ voices=owner</td><td>set ELIZA_VOICE_ANDROID_READY=1 on an Android device runner
 chimeIn=should-respond
 wakewordContext=already-listening-wake-inert
 noiseRejection=echo-self-voice
-voices=owner</td><td>command passed (2026-06-30T00:38:10.190Z)</td><td><code>./gradlew -p ../../../scripts/android-voice-bridge-gradle :elizaos-capacitor-talkmode:testDebugUnitTest</code></td><td>plugins/plugin-native-talkmode/android/src/test/java</td></tr>
+voices=owner</td><td>command passed (2026-06-30T06:46:59.048Z)</td><td><code>./gradlew -p ../../../scripts/android-voice-bridge-gradle :elizaos-capacitor-talkmode:testDebugUnitTest</code></td><td>plugins/plugin-native-talkmode/android/src/test/java</td></tr>
 <tr class="pass"><td><code>android.swabble.native-bridge</code><br>Swabble Android wake-firing -&gt; JS bridge event contract</td><td>pass</td><td>android</td><td>native-bridge-unit</td><td>transcriptionState=off
 chimeIn=should-respond
 wakewordContext=idle-wake
 noiseRejection=quiet
-voices=owner</td><td>command passed (2026-06-30T00:38:51.752Z)</td><td><code>./gradlew -p ../../../scripts/android-voice-bridge-gradle :elizaos-capacitor-swabble:testDebugUnitTest</code></td><td>plugins/plugin-native-swabble/android/src/test/java</td></tr>
-<tr class="skip"><td><code>stt.stage-b.evaluation</code><br>Stage-B STT evaluation: iOS SFSpeechRecognizer vs Android SpeechRecognizer vs fused ASR</td><td>skip</td><td>android</td><td>stt-evaluation</td><td>transcriptionState=on
+voices=owner</td><td>command passed (2026-06-30T06:47:00.561Z)</td><td><code>./gradlew -p ../../../scripts/android-voice-bridge-gradle :elizaos-capacitor-swabble:testDebugUnitTest</code></td><td>plugins/plugin-native-swabble/android/src/test/java</td></tr>
+<tr class="skip"><td><code>stt.stage-b.evaluation</code><br>Stage-B STT evaluation: iOS battery/energy + Android SpeechRecognizer (NNAPI) vs fused ASR</td><td>skip</td><td>android</td><td>stt-evaluation</td><td>transcriptionState=on
 chimeIn=should-respond
 wakewordContext=idle-wake
 noiseRejection=noisy-reverberant
-voices=multi-speaker</td><td>Stage-B STT battery/latency evaluation needs paired iOS+Android device runners and power telemetry</td><td><code>bun packages/scripts/voice-matrix.mjs --stage-b-eval-placeholder</code></td><td>.github/issue-evidence/9147-voice-asr-m4max.md</td></tr></tbody></table>
+voices=multi-speaker</td><td>ELIZA_VOICE_STAGE_B_REPORT is not set to a reviewed iOS+Android+fused ASR Stage-B JSON report</td><td><code>node packages/scripts/voice-stage-b-eval.mjs</code></td><td>$ELIZA_VOICE_MATRIX_OUT/stt.stage-b.evaluation/stage-b-eval.json
+$ELIZA_VOICE_STAGE_B_REPORT</td></tr></tbody></table>

--- a/.github/issue-evidence/9958-voice-matrix-android-native-run/voice-matrix.json
+++ b/.github/issue-evidence/9958-voice-matrix-android-native-run/voice-matrix.json
@@ -1,7 +1,7 @@
 {
   "schema": "eliza_voice_live_matrix_v1",
   "issue": 9958,
-  "generatedAt": "2026-06-30T00:38:51.994Z",
+  "generatedAt": "2026-06-30T06:47:00.567Z",
   "mode": "run",
   "dimensions": {
     "platform": [
@@ -108,15 +108,15 @@
       ],
       "probe": {
         "available": true,
-        "reason": "command passed (2026-06-30T00:38:10.190Z)"
+        "reason": "command passed (2026-06-30T06:46:59.048Z)"
       },
       "env": {},
       "execution": {
         "exitCode": 0,
         "signal": null,
-        "startedAt": "2026-06-30T00:37:38.501Z",
-        "finishedAt": "2026-06-30T00:38:10.190Z",
-        "stdoutTail": "> Task :capacitor-android:preBuild UP-TO-DATE\n> Task :capacitor-android:preDebugBuild UP-TO-DATE\n> Task :capacitor-android:generateDebugResValues UP-TO-DATE\n> Task :capacitor-android:generateDebugResources UP-TO-DATE\n> Task :capacitor-android:packageDebugResources UP-TO-DATE\n> Task :capacitor-android:processDebugNavigationResources UP-TO-DATE\n> Task :capacitor-android:parseDebugLocalResources UP-TO-DATE\n> Task :capacitor-android:generateDebugRFile UP-TO-DATE\n> Task :capacitor-android:javaPreCompileDebug UP-TO-DATE\n> Task :capacitor-android:compileDebugJavaWithJavac UP-TO-DATE\n> Task :capacitor-android:bundleLibRuntimeToJarDebug UP-TO-DATE\n> Task :capacitor-android:processDebugJavaRes NO-SOURCE\n> Task :capacitor-android:bundleLibCompileToJarDebug UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:checkKotlinGradlePluginConfigurationErrors SKIPPED\n> Task :elizaos-capacitor-talkmode:preBuild UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:preDebugBuild UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:generateDebugResValues UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:generateDebugResources UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:packageDebugResources UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:processDebugNavigationResources UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:parseDebugLocalResources UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:generateDebugRFile UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:compileDebugKotlin UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:javaPreCompileDebug UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:compileDebugJavaWithJavac NO-SOURCE\n> Task :elizaos-capacitor-talkmode:bundleLibRuntimeToJarDebug UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:bundleLibCompileToJarDebug UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:preDebugUnitTestBuild UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:generateDebugUnitTestStubRFile UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:compileDebugUnitTestKotlin UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:javaPreCompileDebugUnitTest UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:compileDebugUnitTestJavaWithJavac NO-SOURCE\n> Task :elizaos-capacitor-talkmode:processDebugJavaRes UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:processDebugUnitTestJavaRes UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:testDebugUnitTest UP-TO-DATE\n\n[Incubating] Problems report is available at: file:///Users/shawwalters/.codex/worktrees/740a/eliza/packages/scripts/android-voice-bridge-gradle/build/reports/problems/problems-report.html\n\nDeprecated Gradle features were used in this build, making it incompatible with Gradle 10.\n\nYou can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.\n\nFor more on this, please refer to https://docs.gradle.org/9.5.0/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.\n\nBUILD SUCCESSFUL in 30s\n26 actionable tasks: 26 up-to-date\nConsider enabling configuration cache to speed up this build: https://docs.gradle.org/9.5.0/userguide/configuration_cache_enabling.html\n",
+        "startedAt": "2026-06-30T06:46:54.340Z",
+        "finishedAt": "2026-06-30T06:46:59.048Z",
+        "stdoutTail": "> Task :capacitor-android:preBuild UP-TO-DATE\n> Task :capacitor-android:preDebugBuild UP-TO-DATE\n> Task :capacitor-android:generateDebugResValues UP-TO-DATE\n> Task :capacitor-android:generateDebugResources UP-TO-DATE\n> Task :capacitor-android:packageDebugResources UP-TO-DATE\n> Task :capacitor-android:processDebugNavigationResources UP-TO-DATE\n> Task :capacitor-android:parseDebugLocalResources UP-TO-DATE\n> Task :capacitor-android:generateDebugRFile UP-TO-DATE\n> Task :capacitor-android:javaPreCompileDebug UP-TO-DATE\n> Task :capacitor-android:compileDebugJavaWithJavac UP-TO-DATE\n> Task :capacitor-android:bundleLibRuntimeToJarDebug UP-TO-DATE\n> Task :capacitor-android:processDebugJavaRes NO-SOURCE\n> Task :capacitor-android:bundleLibCompileToJarDebug UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:checkKotlinGradlePluginConfigurationErrors SKIPPED\n> Task :elizaos-capacitor-talkmode:preBuild UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:preDebugBuild UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:generateDebugResValues UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:generateDebugResources UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:packageDebugResources UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:processDebugNavigationResources UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:parseDebugLocalResources UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:generateDebugRFile UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:compileDebugKotlin UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:javaPreCompileDebug UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:compileDebugJavaWithJavac NO-SOURCE\n> Task :elizaos-capacitor-talkmode:bundleLibRuntimeToJarDebug UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:bundleLibCompileToJarDebug UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:preDebugUnitTestBuild UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:generateDebugUnitTestStubRFile UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:compileDebugUnitTestKotlin UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:javaPreCompileDebugUnitTest UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:compileDebugUnitTestJavaWithJavac NO-SOURCE\n> Task :elizaos-capacitor-talkmode:processDebugJavaRes UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:processDebugUnitTestJavaRes UP-TO-DATE\n> Task :elizaos-capacitor-talkmode:testDebugUnitTest UP-TO-DATE\n\n[Incubating] Problems report is available at: file:///Users/shawwalters/.codex/worktrees/740a/eliza/packages/scripts/android-voice-bridge-gradle/build/reports/problems/problems-report.html\n\nDeprecated Gradle features were used in this build, making it incompatible with Gradle 10.\n\nYou can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.\n\nFor more on this, please refer to https://docs.gradle.org/9.5.0/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.\n\nBUILD SUCCESSFUL in 4s\n26 actionable tasks: 26 up-to-date\nConsider enabling configuration cache to speed up this build: https://docs.gradle.org/9.5.0/userguide/configuration_cache_enabling.html\n",
         "stderrTail": ""
       },
       "status": "pass"
@@ -145,22 +145,22 @@
       ],
       "probe": {
         "available": true,
-        "reason": "command passed (2026-06-30T00:38:51.752Z)"
+        "reason": "command passed (2026-06-30T06:47:00.561Z)"
       },
       "env": {},
       "execution": {
         "exitCode": 0,
         "signal": null,
-        "startedAt": "2026-06-30T00:38:10.318Z",
-        "finishedAt": "2026-06-30T00:38:51.752Z",
-        "stdoutTail": "> Task :capacitor-android:preBuild UP-TO-DATE\n> Task :capacitor-android:preDebugBuild UP-TO-DATE\n> Task :capacitor-android:generateDebugResValues UP-TO-DATE\n> Task :capacitor-android:generateDebugResources UP-TO-DATE\n> Task :capacitor-android:packageDebugResources UP-TO-DATE\n> Task :capacitor-android:processDebugNavigationResources UP-TO-DATE\n> Task :capacitor-android:parseDebugLocalResources UP-TO-DATE\n> Task :capacitor-android:generateDebugRFile UP-TO-DATE\n> Task :capacitor-android:javaPreCompileDebug UP-TO-DATE\n> Task :capacitor-android:compileDebugJavaWithJavac UP-TO-DATE\n> Task :capacitor-android:bundleLibRuntimeToJarDebug UP-TO-DATE\n> Task :capacitor-android:processDebugJavaRes NO-SOURCE\n> Task :capacitor-android:bundleLibCompileToJarDebug UP-TO-DATE\n> Task :elizaos-capacitor-swabble:checkKotlinGradlePluginConfigurationErrors SKIPPED\n> Task :elizaos-capacitor-swabble:preBuild UP-TO-DATE\n> Task :elizaos-capacitor-swabble:preDebugBuild UP-TO-DATE\n> Task :elizaos-capacitor-swabble:generateDebugResValues UP-TO-DATE\n> Task :elizaos-capacitor-swabble:generateDebugResources UP-TO-DATE\n> Task :elizaos-capacitor-swabble:packageDebugResources UP-TO-DATE\n> Task :elizaos-capacitor-swabble:processDebugNavigationResources UP-TO-DATE\n> Task :elizaos-capacitor-swabble:parseDebugLocalResources UP-TO-DATE\n> Task :elizaos-capacitor-swabble:generateDebugRFile UP-TO-DATE\n> Task :elizaos-capacitor-swabble:compileDebugKotlin UP-TO-DATE\n> Task :elizaos-capacitor-swabble:javaPreCompileDebug UP-TO-DATE\n> Task :elizaos-capacitor-swabble:compileDebugJavaWithJavac NO-SOURCE\n> Task :elizaos-capacitor-swabble:bundleLibRuntimeToJarDebug UP-TO-DATE\n> Task :elizaos-capacitor-swabble:bundleLibCompileToJarDebug UP-TO-DATE\n> Task :elizaos-capacitor-swabble:preDebugUnitTestBuild UP-TO-DATE\n> Task :elizaos-capacitor-swabble:generateDebugUnitTestStubRFile UP-TO-DATE\n> Task :elizaos-capacitor-swabble:compileDebugUnitTestKotlin UP-TO-DATE\n> Task :elizaos-capacitor-swabble:javaPreCompileDebugUnitTest UP-TO-DATE\n> Task :elizaos-capacitor-swabble:compileDebugUnitTestJavaWithJavac NO-SOURCE\n> Task :elizaos-capacitor-swabble:processDebugJavaRes UP-TO-DATE\n> Task :elizaos-capacitor-swabble:processDebugUnitTestJavaRes UP-TO-DATE\n> Task :elizaos-capacitor-swabble:testDebugUnitTest UP-TO-DATE\n\n[Incubating] Problems report is available at: file:///Users/shawwalters/.codex/worktrees/740a/eliza/packages/scripts/android-voice-bridge-gradle/build/reports/problems/problems-report.html\n\nDeprecated Gradle features were used in this build, making it incompatible with Gradle 10.\n\nYou can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.\n\nFor more on this, please refer to https://docs.gradle.org/9.5.0/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.\n\nBUILD SUCCESSFUL in 39s\n26 actionable tasks: 26 up-to-date\nConsider enabling configuration cache to speed up this build: https://docs.gradle.org/9.5.0/userguide/configuration_cache_enabling.html\n",
+        "startedAt": "2026-06-30T06:46:59.060Z",
+        "finishedAt": "2026-06-30T06:47:00.561Z",
+        "stdoutTail": "> Task :capacitor-android:preBuild UP-TO-DATE\n> Task :capacitor-android:preDebugBuild UP-TO-DATE\n> Task :capacitor-android:generateDebugResValues UP-TO-DATE\n> Task :capacitor-android:generateDebugResources UP-TO-DATE\n> Task :capacitor-android:packageDebugResources UP-TO-DATE\n> Task :capacitor-android:processDebugNavigationResources UP-TO-DATE\n> Task :capacitor-android:parseDebugLocalResources UP-TO-DATE\n> Task :capacitor-android:generateDebugRFile UP-TO-DATE\n> Task :capacitor-android:javaPreCompileDebug UP-TO-DATE\n> Task :capacitor-android:compileDebugJavaWithJavac UP-TO-DATE\n> Task :capacitor-android:bundleLibRuntimeToJarDebug UP-TO-DATE\n> Task :capacitor-android:processDebugJavaRes NO-SOURCE\n> Task :capacitor-android:bundleLibCompileToJarDebug UP-TO-DATE\n> Task :elizaos-capacitor-swabble:checkKotlinGradlePluginConfigurationErrors SKIPPED\n> Task :elizaos-capacitor-swabble:preBuild UP-TO-DATE\n> Task :elizaos-capacitor-swabble:preDebugBuild UP-TO-DATE\n> Task :elizaos-capacitor-swabble:generateDebugResValues UP-TO-DATE\n> Task :elizaos-capacitor-swabble:generateDebugResources UP-TO-DATE\n> Task :elizaos-capacitor-swabble:packageDebugResources UP-TO-DATE\n> Task :elizaos-capacitor-swabble:processDebugNavigationResources UP-TO-DATE\n> Task :elizaos-capacitor-swabble:parseDebugLocalResources UP-TO-DATE\n> Task :elizaos-capacitor-swabble:generateDebugRFile UP-TO-DATE\n> Task :elizaos-capacitor-swabble:compileDebugKotlin UP-TO-DATE\n> Task :elizaos-capacitor-swabble:javaPreCompileDebug UP-TO-DATE\n> Task :elizaos-capacitor-swabble:compileDebugJavaWithJavac NO-SOURCE\n> Task :elizaos-capacitor-swabble:bundleLibRuntimeToJarDebug UP-TO-DATE\n> Task :elizaos-capacitor-swabble:bundleLibCompileToJarDebug UP-TO-DATE\n> Task :elizaos-capacitor-swabble:preDebugUnitTestBuild UP-TO-DATE\n> Task :elizaos-capacitor-swabble:generateDebugUnitTestStubRFile UP-TO-DATE\n> Task :elizaos-capacitor-swabble:compileDebugUnitTestKotlin UP-TO-DATE\n> Task :elizaos-capacitor-swabble:javaPreCompileDebugUnitTest UP-TO-DATE\n> Task :elizaos-capacitor-swabble:compileDebugUnitTestJavaWithJavac NO-SOURCE\n> Task :elizaos-capacitor-swabble:processDebugJavaRes UP-TO-DATE\n> Task :elizaos-capacitor-swabble:processDebugUnitTestJavaRes UP-TO-DATE\n> Task :elizaos-capacitor-swabble:testDebugUnitTest UP-TO-DATE\n\n[Incubating] Problems report is available at: file:///Users/shawwalters/.codex/worktrees/740a/eliza/packages/scripts/android-voice-bridge-gradle/build/reports/problems/problems-report.html\n\nDeprecated Gradle features were used in this build, making it incompatible with Gradle 10.\n\nYou can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.\n\nFor more on this, please refer to https://docs.gradle.org/9.5.0/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.\n\nBUILD SUCCESSFUL in 1s\n26 actionable tasks: 26 up-to-date\nConsider enabling configuration cache to speed up this build: https://docs.gradle.org/9.5.0/userguide/configuration_cache_enabling.html\n",
         "stderrTail": ""
       },
       "status": "pass"
     },
     {
       "id": "stt.stage-b.evaluation",
-      "title": "Stage-B STT evaluation: iOS SFSpeechRecognizer vs Android SpeechRecognizer vs fused ASR",
+      "title": "Stage-B STT evaluation: iOS battery/energy + Android SpeechRecognizer (NNAPI) vs fused ASR",
       "platform": "android",
       "dimensions": {
         "transcriptionState": "on",
@@ -171,16 +171,16 @@
       },
       "class": "stt-evaluation",
       "command": [
-        "bun",
-        "packages/scripts/voice-matrix.mjs",
-        "--stage-b-eval-placeholder"
+        "node",
+        "packages/scripts/voice-stage-b-eval.mjs"
       ],
       "evidence": [
-        ".github/issue-evidence/9147-voice-asr-m4max.md"
+        "$ELIZA_VOICE_MATRIX_OUT/stt.stage-b.evaluation/stage-b-eval.json",
+        "$ELIZA_VOICE_STAGE_B_REPORT"
       ],
       "probe": {
         "available": false,
-        "reason": "Stage-B STT battery/latency evaluation needs paired iOS+Android device runners and power telemetry"
+        "reason": "ELIZA_VOICE_STAGE_B_REPORT is not set to a reviewed iOS+Android+fused ASR Stage-B JSON report"
       },
       "cwd": ".",
       "env": {},

--- a/.github/issue-evidence/9958-voice-matrix-android-native-run/voice-matrix.md
+++ b/.github/issue-evidence/9958-voice-matrix-android-native-run/voice-matrix.md
@@ -1,14 +1,14 @@
 # Voice Live Matrix
 
-Generated: 2026-06-30T00:38:51.994Z
+Generated: 2026-06-30T06:47:00.567Z
 Host: darwin arm64 (Shaws-MacBook-Pro.local)
 
 | Cell | Status | Platform | Class | Probe / Result | Command |
 |---|---:|---|---|---|---|
 | `android.device.voice-roundtrip` | skip | android | mobile-live-voice | set ELIZA_VOICE_ANDROID_READY=1 on an Android device runner with the current APK and voice assets installed | `bun run --cwd packages/app test:e2e:android:local` |
-| `android.talkmode.native-bridge` | pass | android | native-bridge-unit | command passed (2026-06-30T00:38:10.190Z) | `./gradlew -p ../../../scripts/android-voice-bridge-gradle :elizaos-capacitor-talkmode:testDebugUnitTest` |
-| `android.swabble.native-bridge` | pass | android | native-bridge-unit | command passed (2026-06-30T00:38:51.752Z) | `./gradlew -p ../../../scripts/android-voice-bridge-gradle :elizaos-capacitor-swabble:testDebugUnitTest` |
-| `stt.stage-b.evaluation` | skip | android | stt-evaluation | Stage-B STT battery/latency evaluation needs paired iOS+Android device runners and power telemetry | `bun packages/scripts/voice-matrix.mjs --stage-b-eval-placeholder` |
+| `android.talkmode.native-bridge` | pass | android | native-bridge-unit | command passed (2026-06-30T06:46:59.048Z) | `./gradlew -p ../../../scripts/android-voice-bridge-gradle :elizaos-capacitor-talkmode:testDebugUnitTest` |
+| `android.swabble.native-bridge` | pass | android | native-bridge-unit | command passed (2026-06-30T06:47:00.561Z) | `./gradlew -p ../../../scripts/android-voice-bridge-gradle :elizaos-capacitor-swabble:testDebugUnitTest` |
+| `stt.stage-b.evaluation` | skip | android | stt-evaluation | ELIZA_VOICE_STAGE_B_REPORT is not set to a reviewed iOS+Android+fused ASR Stage-B JSON report | `node packages/scripts/voice-stage-b-eval.mjs` |
 
 ## Summary
 

--- a/.github/issue-evidence/9958-voice-matrix-full-probe/README.md
+++ b/.github/issue-evidence/9958-voice-matrix-full-probe/README.md
@@ -1,0 +1,27 @@
+# #9958 Voice Matrix Full Probe Refresh
+
+Command:
+
+```bash
+bun run voice:matrix -- --out .github/issue-evidence/9958-voice-matrix-full-probe
+```
+
+Result:
+
+- `pass=0`
+- `fail=0`
+- `pending=8`
+- `skip=8`
+
+Manual review:
+
+- Reviewed `voice-matrix.json`; the full probe now records the strict
+  `wake.openwakeword.real-head` validator command and the
+  `ELIZA_VOICE_OPENWAKEWORD_REPORT` missing-report skip reason.
+- Reviewed `voice-matrix.md`; the rendered table matches the JSON and no longer
+  shows the old broad workbench placeholder for openWakeWord.
+- Reviewed `index.html`; it renders the same refreshed validator commands and
+  explicit missing-report reasons for openWakeWord and Stage-B.
+
+Hardware-unavailable cells remain explicit skips. They are not platform
+coverage.

--- a/.github/issue-evidence/9958-voice-matrix-full-probe/README.md
+++ b/.github/issue-evidence/9958-voice-matrix-full-probe/README.md
@@ -22,6 +22,9 @@ Manual review:
   shows the old broad workbench placeholder for openWakeWord.
 - Reviewed `index.html`; it renders the same refreshed validator commands and
   explicit missing-report reasons for openWakeWord and Stage-B.
+- Reviewed the iOS live row; without `ELIZA_VOICE_IOS_READY=1`, it now says the
+  runner must boot an iOS simulator and install the current app build with voice
+  assets before capture.
 
 Hardware-unavailable cells remain explicit skips. They are not platform
 coverage.

--- a/.github/issue-evidence/9958-voice-matrix-full-probe/index.html
+++ b/.github/issue-evidence/9958-voice-matrix-full-probe/index.html
@@ -12,7 +12,7 @@ th{background:#f1f1f1;text-align:left}
 code{font-size:12px}
 </style>
 <h1>Voice Live Matrix</h1>
-<p>Generated 2026-06-30T05:06:04.844Z on darwin arm64 (Mac.localdomain).</p>
+<p>Generated 2026-06-30T06:45:47.854Z on darwin arm64 (Shaws-MacBook-Pro.local).</p>
 <p>Pass 0 · Fail 0 · Pending 8 · Skip 8</p>
 <table><thead><tr><th>Cell</th><th>Status</th><th>Platform</th><th>Class</th><th>Dimensions</th><th>Probe / Result</th><th>Command</th><th>Evidence</th></tr></thead><tbody><tr class="pending"><td><code>web.fake-mic.roundtrip</code><br>Web fake-device mic capture -&gt; ASR -&gt; agent -&gt; local TTS + barge-in</td><td>pending</td><td>web</td><td>live-client-audio-barge-in</td><td>transcriptionState=off
 chimeIn=should-respond
@@ -90,7 +90,8 @@ voices=owner</td><td>Android voice bridge Gradle project exists</td><td><code>./
 chimeIn=should-not-respond
 wakewordContext=mid-transcription-wake
 noiseRejection=overlapping-speech
-voices=multi-speaker</td><td>ELIZA_OPENWAKEWORD_REAL_READY is not set for a real wake-word head run</td><td><code>bun run --cwd plugins/plugin-local-inference voice:workbench --real</code></td><td>$VOICE_REAL_MATRIX_OUT/voice-workbench-real</td></tr>
+voices=multi-speaker</td><td>ELIZA_VOICE_OPENWAKEWORD_REPORT is not set to a reviewed real-head openWakeWord JSON report</td><td><code>node packages/scripts/voice-openwakeword-eval.mjs</code></td><td>$ELIZA_VOICE_MATRIX_OUT/wake.openwakeword.real-head/openwakeword-eval.json
+$ELIZA_VOICE_OPENWAKEWORD_REPORT</td></tr>
 <tr class="pending"><td><code>stt.stage-b.apple-sfspeech</code><br>Stage-B STT Apple arm: real on-device SFSpeechRecognizer latency/WER over synthesised speech (quiet + 10dB noise)</td><td>pending</td><td>macos-electrobun</td><td>stt-evaluation</td><td>transcriptionState=on
 chimeIn=should-respond
 wakewordContext=idle-wake
@@ -100,4 +101,5 @@ voices=owner</td><td>macOS on-device SFSpeechRecognizer + say/afconvert availabl
 chimeIn=should-respond
 wakewordContext=idle-wake
 noiseRejection=noisy-reverberant
-voices=multi-speaker</td><td>iOS battery/energy telemetry and the Android SpeechRecognizer (NNAPI) arm need paired device runners with power telemetry (the Apple latency/WER arm is covered by stt.stage-b.apple-sfspeech)</td><td><code>bun packages/scripts/voice-matrix.mjs --stage-b-eval-placeholder</code></td><td>.github/issue-evidence/9147-voice-asr-m4max.md</td></tr></tbody></table>
+voices=multi-speaker</td><td>ELIZA_VOICE_STAGE_B_REPORT is not set to a reviewed iOS+Android+fused ASR Stage-B JSON report</td><td><code>node packages/scripts/voice-stage-b-eval.mjs</code></td><td>$ELIZA_VOICE_MATRIX_OUT/stt.stage-b.evaluation/stage-b-eval.json
+$ELIZA_VOICE_STAGE_B_REPORT</td></tr></tbody></table>

--- a/.github/issue-evidence/9958-voice-matrix-full-probe/index.html
+++ b/.github/issue-evidence/9958-voice-matrix-full-probe/index.html
@@ -12,7 +12,7 @@ th{background:#f1f1f1;text-align:left}
 code{font-size:12px}
 </style>
 <h1>Voice Live Matrix</h1>
-<p>Generated 2026-06-30T06:45:47.854Z on darwin arm64 (Shaws-MacBook-Pro.local).</p>
+<p>Generated 2026-06-30T06:57:29.880Z on darwin arm64 (Shaws-MacBook-Pro.local).</p>
 <p>Pass 0 · Fail 0 · Pending 8 · Skip 8</p>
 <table><thead><tr><th>Cell</th><th>Status</th><th>Platform</th><th>Class</th><th>Dimensions</th><th>Probe / Result</th><th>Command</th><th>Evidence</th></tr></thead><tbody><tr class="pending"><td><code>web.fake-mic.roundtrip</code><br>Web fake-device mic capture -&gt; ASR -&gt; agent -&gt; local TTS + barge-in</td><td>pending</td><td>web</td><td>live-client-audio-barge-in</td><td>transcriptionState=off
 chimeIn=should-respond
@@ -59,7 +59,7 @@ packages/app/test-results</td></tr>
 chimeIn=should-respond
 wakewordContext=idle-wake
 noiseRejection=quiet
-voices=owner</td><td>set ELIZA_VOICE_IOS_READY=1 after installing a current iOS simulator/device build with voice assets</td><td><code>bun run --cwd packages/app capture:ios-sim -- --issue 9958 --slug voice-ios</code></td><td>.github/issue-evidence/9958-voice-ios-ios-sim.*</td></tr>
+voices=owner</td><td>set ELIZA_VOICE_IOS_READY=1 after booting an iOS simulator and installing the current app build with voice assets</td><td><code>bun run --cwd packages/app capture:ios-sim -- --issue 9958 --slug voice-ios</code></td><td>.github/issue-evidence/9958-voice-ios-ios-sim.*</td></tr>
 <tr class="pending"><td><code>ios.talkmode.native-bridge</code><br>TalkMode iOS transcript, permission, state, and barge-in bridge contracts</td><td>pending</td><td>ios</td><td>native-bridge-unit</td><td>transcriptionState=off
 chimeIn=should-respond
 wakewordContext=already-listening-wake-inert

--- a/.github/issue-evidence/9958-voice-matrix-full-probe/voice-matrix.json
+++ b/.github/issue-evidence/9958-voice-matrix-full-probe/voice-matrix.json
@@ -1,7 +1,7 @@
 {
   "schema": "eliza_voice_live_matrix_v1",
   "issue": 9958,
-  "generatedAt": "2026-06-30T05:06:04.844Z",
+  "generatedAt": "2026-06-30T06:45:47.854Z",
   "mode": "probe",
   "dimensions": {
     "platform": [
@@ -41,7 +41,7 @@
   "host": {
     "platform": "darwin",
     "arch": "arm64",
-    "hostname": "Mac.localdomain",
+    "hostname": "Shaws-MacBook-Pro.local",
     "runnerOs": null,
     "runnerArch": null
   },
@@ -498,19 +498,16 @@
       },
       "class": "wakeword-device-gap",
       "command": [
-        "bun",
-        "run",
-        "--cwd",
-        "plugins/plugin-local-inference",
-        "voice:workbench",
-        "--real"
+        "node",
+        "packages/scripts/voice-openwakeword-eval.mjs"
       ],
       "evidence": [
-        "$VOICE_REAL_MATRIX_OUT/voice-workbench-real"
+        "$ELIZA_VOICE_MATRIX_OUT/wake.openwakeword.real-head/openwakeword-eval.json",
+        "$ELIZA_VOICE_OPENWAKEWORD_REPORT"
       ],
       "probe": {
         "available": false,
-        "reason": "ELIZA_OPENWAKEWORD_REAL_READY is not set for a real wake-word head run"
+        "reason": "ELIZA_VOICE_OPENWAKEWORD_REPORT is not set to a reviewed real-head openWakeWord JSON report"
       },
       "cwd": ".",
       "env": {},
@@ -558,16 +555,16 @@
       },
       "class": "stt-evaluation",
       "command": [
-        "bun",
-        "packages/scripts/voice-matrix.mjs",
-        "--stage-b-eval-placeholder"
+        "node",
+        "packages/scripts/voice-stage-b-eval.mjs"
       ],
       "evidence": [
-        ".github/issue-evidence/9147-voice-asr-m4max.md"
+        "$ELIZA_VOICE_MATRIX_OUT/stt.stage-b.evaluation/stage-b-eval.json",
+        "$ELIZA_VOICE_STAGE_B_REPORT"
       ],
       "probe": {
         "available": false,
-        "reason": "iOS battery/energy telemetry and the Android SpeechRecognizer (NNAPI) arm need paired device runners with power telemetry (the Apple latency/WER arm is covered by stt.stage-b.apple-sfspeech)"
+        "reason": "ELIZA_VOICE_STAGE_B_REPORT is not set to a reviewed iOS+Android+fused ASR Stage-B JSON report"
       },
       "cwd": ".",
       "env": {},

--- a/.github/issue-evidence/9958-voice-matrix-full-probe/voice-matrix.json
+++ b/.github/issue-evidence/9958-voice-matrix-full-probe/voice-matrix.json
@@ -1,7 +1,7 @@
 {
   "schema": "eliza_voice_live_matrix_v1",
   "issue": 9958,
-  "generatedAt": "2026-06-30T06:45:47.854Z",
+  "generatedAt": "2026-06-30T06:57:29.880Z",
   "mode": "probe",
   "dimensions": {
     "platform": [
@@ -324,7 +324,7 @@
       ],
       "probe": {
         "available": false,
-        "reason": "set ELIZA_VOICE_IOS_READY=1 after installing a current iOS simulator/device build with voice assets"
+        "reason": "set ELIZA_VOICE_IOS_READY=1 after booting an iOS simulator and installing the current app build with voice assets"
       },
       "cwd": ".",
       "env": {},

--- a/.github/issue-evidence/9958-voice-matrix-full-probe/voice-matrix.md
+++ b/.github/issue-evidence/9958-voice-matrix-full-probe/voice-matrix.md
@@ -1,7 +1,7 @@
 # Voice Live Matrix
 
-Generated: 2026-06-30T05:06:04.844Z
-Host: darwin arm64 (Mac.localdomain)
+Generated: 2026-06-30T06:45:47.854Z
+Host: darwin arm64 (Shaws-MacBook-Pro.local)
 
 | Cell | Status | Platform | Class | Probe / Result | Command |
 |---|---:|---|---|---|---|
@@ -18,9 +18,9 @@ Host: darwin arm64 (Mac.localdomain)
 | `android.device.voice-roundtrip` | skip | android | mobile-live-voice | set ELIZA_VOICE_ANDROID_READY=1 on an Android device runner with the current APK and voice assets installed | `bun run --cwd packages/app test:e2e:android:local` |
 | `android.talkmode.native-bridge` | pending | android | native-bridge-unit | Android voice bridge Gradle project exists | `./gradlew -p ../../../scripts/android-voice-bridge-gradle :elizaos-capacitor-talkmode:testDebugUnitTest` |
 | `android.swabble.native-bridge` | pending | android | native-bridge-unit | Android voice bridge Gradle project exists | `./gradlew -p ../../../scripts/android-voice-bridge-gradle :elizaos-capacitor-swabble:testDebugUnitTest` |
-| `wake.openwakeword.real-head` | skip | linux | wakeword-device-gap | ELIZA_OPENWAKEWORD_REAL_READY is not set for a real wake-word head run | `bun run --cwd plugins/plugin-local-inference voice:workbench --real` |
+| `wake.openwakeword.real-head` | skip | linux | wakeword-device-gap | ELIZA_VOICE_OPENWAKEWORD_REPORT is not set to a reviewed real-head openWakeWord JSON report | `node packages/scripts/voice-openwakeword-eval.mjs` |
 | `stt.stage-b.apple-sfspeech` | pending | macos-electrobun | stt-evaluation | macOS on-device SFSpeechRecognizer + say/afconvert available for a real Stage-B latency/WER measurement | `node packages/scripts/stage-b-stt-bench.mjs` |
-| `stt.stage-b.evaluation` | skip | android | stt-evaluation | iOS battery/energy telemetry and the Android SpeechRecognizer (NNAPI) arm need paired device runners with power telemetry (the Apple latency/WER arm is covered by stt.stage-b.apple-sfspeech) | `bun packages/scripts/voice-matrix.mjs --stage-b-eval-placeholder` |
+| `stt.stage-b.evaluation` | skip | android | stt-evaluation | ELIZA_VOICE_STAGE_B_REPORT is not set to a reviewed iOS+Android+fused ASR Stage-B JSON report | `node packages/scripts/voice-stage-b-eval.mjs` |
 
 ## Summary
 

--- a/.github/issue-evidence/9958-voice-matrix-full-probe/voice-matrix.md
+++ b/.github/issue-evidence/9958-voice-matrix-full-probe/voice-matrix.md
@@ -1,6 +1,6 @@
 # Voice Live Matrix
 
-Generated: 2026-06-30T06:45:47.854Z
+Generated: 2026-06-30T06:57:29.880Z
 Host: darwin arm64 (Shaws-MacBook-Pro.local)
 
 | Cell | Status | Platform | Class | Probe / Result | Command |
@@ -12,7 +12,7 @@ Host: darwin arm64 (Shaws-MacBook-Pro.local)
 | `linux.fused-acoustic.barge-in` | skip | linux | barge-in | requires Linux runner; current=darwin | `bun run --cwd plugins/plugin-local-inference voice:bargein-bench` |
 | `macos.electrobun.live-roundtrip` | skip | macos-electrobun | desktop-live-voice | set ELIZA_VOICE_MACOS_ELECTROBUN_READY=1 on a macOS Electrobun voice runner with loopback mic/audio capture | `bun run --cwd packages/app test:desktop:voice` |
 | `windows.electrobun.live-roundtrip` | skip | windows-electrobun | desktop-live-voice | requires Windows runner; current=darwin | `bun run --cwd packages/app test:desktop:voice` |
-| `ios.sim-or-device.voice-roundtrip` | skip | ios | mobile-live-voice | set ELIZA_VOICE_IOS_READY=1 after installing a current iOS simulator/device build with voice assets | `bun run --cwd packages/app capture:ios-sim -- --issue 9958 --slug voice-ios` |
+| `ios.sim-or-device.voice-roundtrip` | skip | ios | mobile-live-voice | set ELIZA_VOICE_IOS_READY=1 after booting an iOS simulator and installing the current app build with voice assets | `bun run --cwd packages/app capture:ios-sim -- --issue 9958 --slug voice-ios` |
 | `ios.talkmode.native-bridge` | pending | ios | native-bridge-unit | macOS Swift Package test toolchain is available | `swift test --disable-index-store --package-path plugins/plugin-native-talkmode/ios` |
 | `ios.swabble.native-bridge` | pending | ios | native-bridge-unit | macOS Swift Package test toolchain is available | `swift test --disable-index-store --package-path plugins/plugin-native-swabble/ios` |
 | `android.device.voice-roundtrip` | skip | android | mobile-live-voice | set ELIZA_VOICE_ANDROID_READY=1 on an Android device runner with the current APK and voice assets installed | `bun run --cwd packages/app test:e2e:android:local` |

--- a/.github/issue-evidence/9958-voice-matrix-ios-native-bridge/index.html
+++ b/.github/issue-evidence/9958-voice-matrix-ios-native-bridge/index.html
@@ -12,20 +12,20 @@ th{background:#f1f1f1;text-align:left}
 code{font-size:12px}
 </style>
 <h1>Voice Live Matrix</h1>
-<p>Generated 2026-06-30T03:21:17.101Z on darwin arm64 (Shaws-MacBook-Pro.local).</p>
+<p>Generated 2026-06-30T07:14:08.572Z on darwin arm64 (Shaws-MacBook-Pro.local).</p>
 <p>Pass 2 · Fail 0 · Pending 0 · Skip 1</p>
 <table><thead><tr><th>Cell</th><th>Status</th><th>Platform</th><th>Class</th><th>Dimensions</th><th>Probe / Result</th><th>Command</th><th>Evidence</th></tr></thead><tbody><tr class="skip"><td><code>ios.sim-or-device.voice-roundtrip</code><br>iOS simulator/device voice self-test and capture evidence</td><td>skip</td><td>ios</td><td>mobile-live-voice</td><td>transcriptionState=off
 chimeIn=should-respond
 wakewordContext=idle-wake
 noiseRejection=quiet
-voices=owner</td><td>set ELIZA_VOICE_IOS_READY=1 after installing a current iOS simulator/device build with voice assets</td><td><code>bun run --cwd packages/app capture:ios-sim -- --issue 9958 --slug voice-ios</code></td><td>.github/issue-evidence/9958-voice-ios-ios-sim.*</td></tr>
+voices=owner</td><td>set ELIZA_VOICE_IOS_READY=1 after booting an iOS simulator and installing the current app build with voice assets</td><td><code>bun run --cwd packages/app capture:ios-sim -- --issue 9958 --slug voice-ios</code></td><td>.github/issue-evidence/9958-voice-ios-ios-sim.*</td></tr>
 <tr class="pass"><td><code>ios.talkmode.native-bridge</code><br>TalkMode iOS transcript, permission, state, and barge-in bridge contracts</td><td>pass</td><td>ios</td><td>native-bridge-unit</td><td>transcriptionState=off
 chimeIn=should-respond
 wakewordContext=already-listening-wake-inert
 noiseRejection=echo-self-voice
-voices=owner</td><td>command passed (2026-06-30T03:21:16.355Z)</td><td><code>swift test --disable-index-store --package-path plugins/plugin-native-talkmode/ios</code></td><td>plugins/plugin-native-talkmode/ios/Tests</td></tr>
+voices=owner</td><td>command passed (2026-06-30T07:14:07.267Z)</td><td><code>swift test --disable-index-store --package-path plugins/plugin-native-talkmode/ios</code></td><td>plugins/plugin-native-talkmode/ios/Tests</td></tr>
 <tr class="pass"><td><code>ios.swabble.native-bridge</code><br>Swabble iOS wake-firing -&gt; JS bridge event contract</td><td>pass</td><td>ios</td><td>native-bridge-unit</td><td>transcriptionState=off
 chimeIn=should-respond
 wakewordContext=idle-wake
 noiseRejection=quiet
-voices=owner</td><td>command passed (2026-06-30T03:21:17.101Z)</td><td><code>swift test --disable-index-store --package-path plugins/plugin-native-swabble/ios</code></td><td>plugins/plugin-native-swabble/ios/Tests</td></tr></tbody></table>
+voices=owner</td><td>command passed (2026-06-30T07:14:08.572Z)</td><td><code>swift test --disable-index-store --package-path plugins/plugin-native-swabble/ios</code></td><td>plugins/plugin-native-swabble/ios/Tests</td></tr></tbody></table>

--- a/.github/issue-evidence/9958-voice-matrix-ios-native-bridge/voice-matrix.json
+++ b/.github/issue-evidence/9958-voice-matrix-ios-native-bridge/voice-matrix.json
@@ -1,7 +1,7 @@
 {
   "schema": "eliza_voice_live_matrix_v1",
   "issue": 9958,
-  "generatedAt": "2026-06-30T03:21:17.101Z",
+  "generatedAt": "2026-06-30T07:14:08.572Z",
   "mode": "run",
   "dimensions": {
     "platform": [
@@ -81,7 +81,7 @@
       ],
       "probe": {
         "available": false,
-        "reason": "set ELIZA_VOICE_IOS_READY=1 after installing a current iOS simulator/device build with voice assets"
+        "reason": "set ELIZA_VOICE_IOS_READY=1 after booting an iOS simulator and installing the current app build with voice assets"
       },
       "cwd": ".",
       "env": {},
@@ -112,17 +112,17 @@
       ],
       "probe": {
         "available": true,
-        "reason": "command passed (2026-06-30T03:21:16.355Z)"
+        "reason": "command passed (2026-06-30T07:14:07.267Z)"
       },
       "cwd": ".",
       "env": {},
       "execution": {
         "exitCode": 0,
         "signal": null,
-        "startedAt": "2026-06-30T03:21:15.424Z",
-        "finishedAt": "2026-06-30T03:21:16.355Z",
-        "stdoutTail": "Test Suite 'All tests' started at 2026-06-29 23:21:16.310.\nTest Suite 'ElizaosCapacitorTalkModeIOSContractsPackageTests.xctest' started at 2026-06-29 23:21:16.311.\nTest Suite 'TalkModeBridgeContractTests' started at 2026-06-29 23:21:16.311.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testBargeInInterruptIgnoresShortBlipsAndSelfEcho]' started.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testBargeInInterruptIgnoresShortBlipsAndSelfEcho]' passed (0.001 seconds).\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testStateAndPermissionPayloads]' started.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testStateAndPermissionPayloads]' passed (0.000 seconds).\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testTranscriptPayloadPreservesBridgeFields]' started.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testTranscriptPayloadPreservesBridgeFields]' passed (0.000 seconds).\nTest Suite 'TalkModeBridgeContractTests' passed at 2026-06-29 23:21:16.312.\n\t Executed 3 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds\nTest Suite 'ElizaosCapacitorTalkModeIOSContractsPackageTests.xctest' passed at 2026-06-29 23:21:16.312.\n\t Executed 3 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds\nTest Suite 'All tests' passed at 2026-06-29 23:21:16.312.\n\t Executed 3 tests, with 0 failures (0 unexpected) in 0.001 (0.002) seconds\n◇ Test run started.\n↳ Testing Library Version: 1743\n↳ Target Platform: arm64e-apple-macos14.0\n✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.\n",
-        "stderrTail": "[0/1] Planning build\nBuilding for debugging...\n[0/2] Write swift-version--58304C5D6DBC2206.txt\nBuild complete! (0.15s)\n"
+        "startedAt": "2026-06-30T07:14:05.952Z",
+        "finishedAt": "2026-06-30T07:14:07.267Z",
+        "stdoutTail": "Test Suite 'All tests' started at 2026-06-30 03:14:07.232.\nTest Suite 'ElizaosCapacitorTalkModeIOSContractsPackageTests.xctest' started at 2026-06-30 03:14:07.233.\nTest Suite 'TalkModeBridgeContractTests' started at 2026-06-30 03:14:07.233.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testBargeInInterruptIgnoresShortBlipsAndSelfEcho]' started.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testBargeInInterruptIgnoresShortBlipsAndSelfEcho]' passed (0.000 seconds).\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testStateAndPermissionPayloads]' started.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testStateAndPermissionPayloads]' passed (0.000 seconds).\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testTranscriptPayloadPreservesBridgeFields]' started.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testTranscriptPayloadPreservesBridgeFields]' passed (0.000 seconds).\nTest Suite 'TalkModeBridgeContractTests' passed at 2026-06-30 03:14:07.234.\n\t Executed 3 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds\nTest Suite 'ElizaosCapacitorTalkModeIOSContractsPackageTests.xctest' passed at 2026-06-30 03:14:07.234.\n\t Executed 3 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds\nTest Suite 'All tests' passed at 2026-06-30 03:14:07.234.\n\t Executed 3 tests, with 0 failures (0 unexpected) in 0.001 (0.002) seconds\n◇ Test run started.\n↳ Testing Library Version: 1743\n↳ Target Platform: arm64e-apple-macos14.0\n✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.\n",
+        "stderrTail": "[0/1] Planning build\nBuilding for debugging...\n[0/2] Write swift-version--58304C5D6DBC2206.txt\nBuild complete! (0.11s)\n"
       },
       "status": "pass"
     },
@@ -150,17 +150,17 @@
       ],
       "probe": {
         "available": true,
-        "reason": "command passed (2026-06-30T03:21:17.101Z)"
+        "reason": "command passed (2026-06-30T07:14:08.572Z)"
       },
       "cwd": ".",
       "env": {},
       "execution": {
         "exitCode": 0,
         "signal": null,
-        "startedAt": "2026-06-30T03:21:16.365Z",
-        "finishedAt": "2026-06-30T03:21:17.101Z",
-        "stdoutTail": "Test Suite 'All tests' started at 2026-06-29 23:21:17.055.\nTest Suite 'ElizaosCapacitorSwabbleIOSContractsPackageTests.xctest' started at 2026-06-29 23:21:17.056.\nTest Suite 'SwabbleBridgeContractTests' started at 2026-06-29 23:21:17.056.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testFuzzyTriggerStillFiresFromSpeechRecognizerMiss]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testFuzzyTriggerStillFiresFromSpeechRecognizerMiss]' passed (0.001 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTextOnlyWakeCommandUsesTriggerAndMinimumLength]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTextOnlyWakeCommandUsesTriggerAndMinimumLength]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTriggerOnlyPayloadStartsCaptureWithoutCommand]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTriggerOnlyPayloadStartsCaptureWithoutCommand]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testWakePayloadMatchesJsBridgeContract]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testWakePayloadMatchesJsBridgeContract]' passed (0.000 seconds).\nTest Suite 'SwabbleBridgeContractTests' passed at 2026-06-29 23:21:17.058.\n\t Executed 4 tests, with 0 failures (0 unexpected) in 0.002 (0.002) seconds\nTest Suite 'ElizaosCapacitorSwabbleIOSContractsPackageTests.xctest' passed at 2026-06-29 23:21:17.058.\n\t Executed 4 tests, with 0 failures (0 unexpected) in 0.002 (0.002) seconds\nTest Suite 'All tests' passed at 2026-06-29 23:21:17.058.\n\t Executed 4 tests, with 0 failures (0 unexpected) in 0.002 (0.003) seconds\n◇ Test run started.\n↳ Testing Library Version: 1743\n↳ Target Platform: arm64e-apple-macos14.0\n✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.\n",
-        "stderrTail": "[0/1] Planning build\nBuilding for debugging...\n[0/2] Write swift-version--58304C5D6DBC2206.txt\nBuild complete! (0.21s)\n"
+        "startedAt": "2026-06-30T07:14:07.275Z",
+        "finishedAt": "2026-06-30T07:14:08.572Z",
+        "stdoutTail": "Test Suite 'All tests' started at 2026-06-30 03:14:08.536.\nTest Suite 'ElizaosCapacitorSwabbleIOSContractsPackageTests.xctest' started at 2026-06-30 03:14:08.537.\nTest Suite 'SwabbleBridgeContractTests' started at 2026-06-30 03:14:08.537.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testFuzzyTriggerStillFiresFromSpeechRecognizerMiss]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testFuzzyTriggerStillFiresFromSpeechRecognizerMiss]' passed (0.001 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTextOnlyWakeCommandUsesTriggerAndMinimumLength]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTextOnlyWakeCommandUsesTriggerAndMinimumLength]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTriggerOnlyPayloadStartsCaptureWithoutCommand]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTriggerOnlyPayloadStartsCaptureWithoutCommand]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testWakePayloadMatchesJsBridgeContract]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testWakePayloadMatchesJsBridgeContract]' passed (0.000 seconds).\nTest Suite 'SwabbleBridgeContractTests' passed at 2026-06-30 03:14:08.538.\n\t Executed 4 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds\nTest Suite 'SwabbleTriggerGateTests' started at 2026-06-30 03:14:08.538.\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testBareTriggerIsTriggerOnly]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testBareTriggerIsTriggerOnly]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testEmptyTranscriptIsNotTriggerOnly]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testEmptyTranscriptIsNotTriggerOnly]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testFuzzyMisheardTriggerStillCountsAsTriggerOnly]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testFuzzyMisheardTriggerStillCountsAsTriggerOnly]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testNonTriggerSpeechIsNotTriggerOnly]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testNonTriggerSpeechIsNotTriggerOnly]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testTriggerWithTrailingCommandIsNotTriggerOnly]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testTriggerWithTrailingCommandIsNotTriggerOnly]' passed (0.000 seconds).\nTest Suite 'SwabbleTriggerGateTests' passed at 2026-06-30 03:14:08.539.\n\t Executed 5 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds\nTest Suite 'ElizaosCapacitorSwabbleIOSContractsPackageTests.xctest' passed at 2026-06-30 03:14:08.539.\n\t Executed 9 tests, with 0 failures (0 unexpected) in 0.001 (0.002) seconds\nTest Suite 'All tests' passed at 2026-06-30 03:14:08.539.\n\t Executed 9 tests, with 0 failures (0 unexpected) in 0.001 (0.003) seconds\n◇ Test run started.\n↳ Testing Library Version: 1743\n↳ Target Platform: arm64e-apple-macos14.0\n✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.\n",
+        "stderrTail": "[0/1] Planning build\nBuilding for debugging...\n[0/2] Write swift-version--58304C5D6DBC2206.txt\nBuild complete! (0.11s)\n"
       },
       "status": "pass"
     }

--- a/.github/issue-evidence/9958-voice-matrix-ios-native-bridge/voice-matrix.md
+++ b/.github/issue-evidence/9958-voice-matrix-ios-native-bridge/voice-matrix.md
@@ -1,13 +1,13 @@
 # Voice Live Matrix
 
-Generated: 2026-06-30T03:21:17.101Z
+Generated: 2026-06-30T07:14:08.572Z
 Host: darwin arm64 (Shaws-MacBook-Pro.local)
 
 | Cell | Status | Platform | Class | Probe / Result | Command |
 |---|---:|---|---|---|---|
-| `ios.sim-or-device.voice-roundtrip` | skip | ios | mobile-live-voice | set ELIZA_VOICE_IOS_READY=1 after installing a current iOS simulator/device build with voice assets | `bun run --cwd packages/app capture:ios-sim -- --issue 9958 --slug voice-ios` |
-| `ios.talkmode.native-bridge` | pass | ios | native-bridge-unit | command passed (2026-06-30T03:21:16.355Z) | `swift test --disable-index-store --package-path plugins/plugin-native-talkmode/ios` |
-| `ios.swabble.native-bridge` | pass | ios | native-bridge-unit | command passed (2026-06-30T03:21:17.101Z) | `swift test --disable-index-store --package-path plugins/plugin-native-swabble/ios` |
+| `ios.sim-or-device.voice-roundtrip` | skip | ios | mobile-live-voice | set ELIZA_VOICE_IOS_READY=1 after booting an iOS simulator and installing the current app build with voice assets | `bun run --cwd packages/app capture:ios-sim -- --issue 9958 --slug voice-ios` |
+| `ios.talkmode.native-bridge` | pass | ios | native-bridge-unit | command passed (2026-06-30T07:14:07.267Z) | `swift test --disable-index-store --package-path plugins/plugin-native-talkmode/ios` |
+| `ios.swabble.native-bridge` | pass | ios | native-bridge-unit | command passed (2026-06-30T07:14:08.572Z) | `swift test --disable-index-store --package-path plugins/plugin-native-swabble/ios` |
 
 ## Summary
 

--- a/.github/issue-evidence/9958-voice-matrix-ios-native-run/index.html
+++ b/.github/issue-evidence/9958-voice-matrix-ios-native-run/index.html
@@ -12,20 +12,20 @@ th{background:#f1f1f1;text-align:left}
 code{font-size:12px}
 </style>
 <h1>Voice Live Matrix</h1>
-<p>Generated 2026-06-30T00:02:44.522Z on darwin arm64 (Shaws-MacBook-Pro.local).</p>
+<p>Generated 2026-06-30T07:14:11.972Z on darwin arm64 (Shaws-MacBook-Pro.local).</p>
 <p>Pass 2 · Fail 0 · Pending 0 · Skip 1</p>
 <table><thead><tr><th>Cell</th><th>Status</th><th>Platform</th><th>Class</th><th>Dimensions</th><th>Probe / Result</th><th>Command</th><th>Evidence</th></tr></thead><tbody><tr class="skip"><td><code>ios.sim-or-device.voice-roundtrip</code><br>iOS simulator/device voice self-test and capture evidence</td><td>skip</td><td>ios</td><td>mobile-live-voice</td><td>transcriptionState=off
 chimeIn=should-respond
 wakewordContext=idle-wake
 noiseRejection=quiet
-voices=owner</td><td>set ELIZA_VOICE_IOS_READY=1 after installing a current iOS simulator/device build with voice assets</td><td><code>bun run --cwd packages/app capture:ios-sim -- --issue 9958 --slug voice-ios</code></td><td>.github/issue-evidence/9958-voice-ios-ios-sim.*</td></tr>
+voices=owner</td><td>set ELIZA_VOICE_IOS_READY=1 after booting an iOS simulator and installing the current app build with voice assets</td><td><code>bun run --cwd packages/app capture:ios-sim -- --issue 9958 --slug voice-ios</code></td><td>.github/issue-evidence/9958-voice-ios-ios-sim.*</td></tr>
 <tr class="pass"><td><code>ios.talkmode.native-bridge</code><br>TalkMode iOS transcript, permission, state, and barge-in bridge contracts</td><td>pass</td><td>ios</td><td>native-bridge-unit</td><td>transcriptionState=off
 chimeIn=should-respond
 wakewordContext=already-listening-wake-inert
 noiseRejection=echo-self-voice
-voices=owner</td><td>command passed (2026-06-30T00:00:35.231Z)</td><td><code>swift test --disable-index-store --package-path plugins/plugin-native-talkmode/ios</code></td><td>plugins/plugin-native-talkmode/ios/Tests</td></tr>
+voices=owner</td><td>command passed (2026-06-30T07:14:10.286Z)</td><td><code>swift test --disable-index-store --package-path plugins/plugin-native-talkmode/ios</code></td><td>plugins/plugin-native-talkmode/ios/Tests</td></tr>
 <tr class="pass"><td><code>ios.swabble.native-bridge</code><br>Swabble iOS wake-firing -&gt; JS bridge event contract</td><td>pass</td><td>ios</td><td>native-bridge-unit</td><td>transcriptionState=off
 chimeIn=should-respond
 wakewordContext=idle-wake
 noiseRejection=quiet
-voices=owner</td><td>command passed (2026-06-30T00:02:44.522Z)</td><td><code>swift test --disable-index-store --package-path plugins/plugin-native-swabble/ios</code></td><td>plugins/plugin-native-swabble/ios/Tests</td></tr></tbody></table>
+voices=owner</td><td>command passed (2026-06-30T07:14:11.972Z)</td><td><code>swift test --disable-index-store --package-path plugins/plugin-native-swabble/ios</code></td><td>plugins/plugin-native-swabble/ios/Tests</td></tr></tbody></table>

--- a/.github/issue-evidence/9958-voice-matrix-ios-native-run/voice-matrix.json
+++ b/.github/issue-evidence/9958-voice-matrix-ios-native-run/voice-matrix.json
@@ -1,7 +1,7 @@
 {
   "schema": "eliza_voice_live_matrix_v1",
   "issue": 9958,
-  "generatedAt": "2026-06-30T00:02:44.522Z",
+  "generatedAt": "2026-06-30T07:14:11.972Z",
   "mode": "run",
   "dimensions": {
     "platform": [
@@ -81,7 +81,7 @@
       ],
       "probe": {
         "available": false,
-        "reason": "set ELIZA_VOICE_IOS_READY=1 after installing a current iOS simulator/device build with voice assets"
+        "reason": "set ELIZA_VOICE_IOS_READY=1 after booting an iOS simulator and installing the current app build with voice assets"
       },
       "cwd": ".",
       "env": {},
@@ -112,17 +112,17 @@
       ],
       "probe": {
         "available": true,
-        "reason": "command passed (2026-06-30T00:00:35.231Z)"
+        "reason": "command passed (2026-06-30T07:14:10.286Z)"
       },
       "cwd": ".",
       "env": {},
       "execution": {
         "exitCode": 0,
         "signal": null,
-        "startedAt": "2026-06-29T23:59:16.223Z",
-        "finishedAt": "2026-06-30T00:00:35.231Z",
-        "stdoutTail": "Test Suite 'All tests' started at 2026-06-29 20:00:32.965.\nTest Suite 'ElizaosCapacitorTalkModeIOSContractsPackageTests.xctest' started at 2026-06-29 20:00:32.984.\nTest Suite 'TalkModeBridgeContractTests' started at 2026-06-29 20:00:32.984.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testBargeInInterruptIgnoresShortBlipsAndSelfEcho]' started.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testBargeInInterruptIgnoresShortBlipsAndSelfEcho]' passed (0.027 seconds).\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testStateAndPermissionPayloads]' started.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testStateAndPermissionPayloads]' passed (0.001 seconds).\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testTranscriptPayloadPreservesBridgeFields]' started.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testTranscriptPayloadPreservesBridgeFields]' passed (0.009 seconds).\nTest Suite 'TalkModeBridgeContractTests' passed at 2026-06-29 20:00:33.027.\n\t Executed 3 tests, with 0 failures (0 unexpected) in 0.038 (0.043) seconds\nTest Suite 'ElizaosCapacitorTalkModeIOSContractsPackageTests.xctest' passed at 2026-06-29 20:00:33.028.\n\t Executed 3 tests, with 0 failures (0 unexpected) in 0.038 (0.043) seconds\nTest Suite 'All tests' passed at 2026-06-29 20:00:33.031.\n\t Executed 3 tests, with 0 failures (0 unexpected) in 0.038 (0.066) seconds\n◇ Test run started.\n↳ Testing Library Version: 1743\n↳ Target Platform: arm64e-apple-macos14.0\n✔ Test run with 0 tests in 0 suites passed after 0.005 seconds.\n",
-        "stderrTail": "[0/1] Planning build\nBuilding for debugging...\n[0/2] Write swift-version--58304C5D6DBC2206.txt\n[2/4] Emitting module TalkModeIOSContracts\n[3/4] Compiling TalkModeIOSContracts TalkModeBridgeContract.swift\n[4/6] Emitting module TalkModeBridgeContractTests\n[5/6] Compiling TalkModeBridgeContractTests TalkModeBridgeContractTests.swift\n[6/8] Compiling ElizaosCapacitorTalkModeIOSContractsPackageTests runner.swift\n[7/8] Emitting module ElizaosCapacitorTalkModeIOSContractsPackageTests\nBuild complete! (52.45s)\n"
+        "startedAt": "2026-06-30T07:14:08.712Z",
+        "finishedAt": "2026-06-30T07:14:10.286Z",
+        "stdoutTail": "Test Suite 'All tests' started at 2026-06-30 03:14:10.240.\nTest Suite 'ElizaosCapacitorTalkModeIOSContractsPackageTests.xctest' started at 2026-06-30 03:14:10.241.\nTest Suite 'TalkModeBridgeContractTests' started at 2026-06-30 03:14:10.241.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testBargeInInterruptIgnoresShortBlipsAndSelfEcho]' started.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testBargeInInterruptIgnoresShortBlipsAndSelfEcho]' passed (0.000 seconds).\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testStateAndPermissionPayloads]' started.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testStateAndPermissionPayloads]' passed (0.000 seconds).\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testTranscriptPayloadPreservesBridgeFields]' started.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testTranscriptPayloadPreservesBridgeFields]' passed (0.000 seconds).\nTest Suite 'TalkModeBridgeContractTests' passed at 2026-06-30 03:14:10.242.\n\t Executed 3 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds\nTest Suite 'ElizaosCapacitorTalkModeIOSContractsPackageTests.xctest' passed at 2026-06-30 03:14:10.242.\n\t Executed 3 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds\nTest Suite 'All tests' passed at 2026-06-30 03:14:10.242.\n\t Executed 3 tests, with 0 failures (0 unexpected) in 0.001 (0.002) seconds\n◇ Test run started.\n↳ Testing Library Version: 1743\n↳ Target Platform: arm64e-apple-macos14.0\n✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.\n",
+        "stderrTail": "[0/1] Planning build\nBuilding for debugging...\n[0/2] Write swift-version--58304C5D6DBC2206.txt\nBuild complete! (0.11s)\n"
       },
       "status": "pass"
     },
@@ -150,17 +150,17 @@
       ],
       "probe": {
         "available": true,
-        "reason": "command passed (2026-06-30T00:02:44.522Z)"
+        "reason": "command passed (2026-06-30T07:14:11.972Z)"
       },
       "cwd": ".",
       "env": {},
       "execution": {
         "exitCode": 0,
         "signal": null,
-        "startedAt": "2026-06-30T00:00:35.587Z",
-        "finishedAt": "2026-06-30T00:02:44.522Z",
-        "stdoutTail": "Test Suite 'All tests' started at 2026-06-29 20:02:43.435.\nTest Suite 'ElizaosCapacitorSwabbleIOSContractsPackageTests.xctest' started at 2026-06-29 20:02:43.441.\nTest Suite 'SwabbleBridgeContractTests' started at 2026-06-29 20:02:43.441.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testFuzzyTriggerStillFiresFromSpeechRecognizerMiss]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testFuzzyTriggerStillFiresFromSpeechRecognizerMiss]' passed (0.025 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTextOnlyWakeCommandUsesTriggerAndMinimumLength]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTextOnlyWakeCommandUsesTriggerAndMinimumLength]' passed (0.009 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTriggerOnlyPayloadStartsCaptureWithoutCommand]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTriggerOnlyPayloadStartsCaptureWithoutCommand]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testWakePayloadMatchesJsBridgeContract]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testWakePayloadMatchesJsBridgeContract]' passed (0.000 seconds).\nTest Suite 'SwabbleBridgeContractTests' passed at 2026-06-29 20:02:43.496.\n\t Executed 4 tests, with 0 failures (0 unexpected) in 0.034 (0.054) seconds\nTest Suite 'ElizaosCapacitorSwabbleIOSContractsPackageTests.xctest' passed at 2026-06-29 20:02:43.496.\n\t Executed 4 tests, with 0 failures (0 unexpected) in 0.034 (0.054) seconds\nTest Suite 'All tests' passed at 2026-06-29 20:02:43.496.\n\t Executed 4 tests, with 0 failures (0 unexpected) in 0.034 (0.061) seconds\n◇ Test run started.\n↳ Testing Library Version: 1743\n↳ Target Platform: arm64e-apple-macos14.0\n✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.\n",
-        "stderrTail": "[0/1] Planning build\nBuilding for debugging...\n[0/7] Write sources\n[0/7] /Users/shawwalters/.codex/worktrees/740a/eliza/plugins/plugin-native-swabble/ios/.build/arm64-apple-macosx/debug/ElizaosCapacitorSwabbleIOSContractsPackageTests.derived/runner.swift\n[3/7] Write sources\n[4/7] Write swift-version--58304C5D6DBC2206.txt\n[6/9] Emitting module SwabbleIOSContracts\n[7/9] Compiling SwabbleIOSContracts SwabbleBridgeContract.swift\n[8/11] Emitting module SwabbleBridgeContractTests\n[9/11] Compiling SwabbleBridgeContractTests SwabbleBridgeContractTests.swift\n[10/13] Emitting module ElizaosCapacitorSwabbleIOSContractsPackageTests\n[11/13] Compiling ElizaosCapacitorSwabbleIOSContractsPackageTests runner.swift\n[11/13] Write Objects.LinkFileList\n[12/13] Linking ElizaosCapacitorSwabbleIOSContractsPackageTests\nBuild complete! (111.48s)\n"
+        "startedAt": "2026-06-30T07:14:10.299Z",
+        "finishedAt": "2026-06-30T07:14:11.972Z",
+        "stdoutTail": "Test Suite 'All tests' started at 2026-06-30 03:14:11.923.\nTest Suite 'ElizaosCapacitorSwabbleIOSContractsPackageTests.xctest' started at 2026-06-30 03:14:11.924.\nTest Suite 'SwabbleBridgeContractTests' started at 2026-06-30 03:14:11.924.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testFuzzyTriggerStillFiresFromSpeechRecognizerMiss]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testFuzzyTriggerStillFiresFromSpeechRecognizerMiss]' passed (0.001 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTextOnlyWakeCommandUsesTriggerAndMinimumLength]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTextOnlyWakeCommandUsesTriggerAndMinimumLength]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTriggerOnlyPayloadStartsCaptureWithoutCommand]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTriggerOnlyPayloadStartsCaptureWithoutCommand]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testWakePayloadMatchesJsBridgeContract]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testWakePayloadMatchesJsBridgeContract]' passed (0.000 seconds).\nTest Suite 'SwabbleBridgeContractTests' passed at 2026-06-30 03:14:11.925.\n\t Executed 4 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds\nTest Suite 'SwabbleTriggerGateTests' started at 2026-06-30 03:14:11.925.\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testBareTriggerIsTriggerOnly]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testBareTriggerIsTriggerOnly]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testEmptyTranscriptIsNotTriggerOnly]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testEmptyTranscriptIsNotTriggerOnly]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testFuzzyMisheardTriggerStillCountsAsTriggerOnly]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testFuzzyMisheardTriggerStillCountsAsTriggerOnly]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testNonTriggerSpeechIsNotTriggerOnly]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testNonTriggerSpeechIsNotTriggerOnly]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testTriggerWithTrailingCommandIsNotTriggerOnly]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testTriggerWithTrailingCommandIsNotTriggerOnly]' passed (0.000 seconds).\nTest Suite 'SwabbleTriggerGateTests' passed at 2026-06-30 03:14:11.926.\n\t Executed 5 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds\nTest Suite 'ElizaosCapacitorSwabbleIOSContractsPackageTests.xctest' passed at 2026-06-30 03:14:11.926.\n\t Executed 9 tests, with 0 failures (0 unexpected) in 0.002 (0.002) seconds\nTest Suite 'All tests' passed at 2026-06-30 03:14:11.926.\n\t Executed 9 tests, with 0 failures (0 unexpected) in 0.002 (0.003) seconds\n◇ Test run started.\n↳ Testing Library Version: 1743\n↳ Target Platform: arm64e-apple-macos14.0\n✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.\n",
+        "stderrTail": "[0/1] Planning build\nBuilding for debugging...\n[0/2] Write swift-version--58304C5D6DBC2206.txt\nBuild complete! (0.12s)\n"
       },
       "status": "pass"
     }

--- a/.github/issue-evidence/9958-voice-matrix-ios-native-run/voice-matrix.md
+++ b/.github/issue-evidence/9958-voice-matrix-ios-native-run/voice-matrix.md
@@ -1,13 +1,13 @@
 # Voice Live Matrix
 
-Generated: 2026-06-30T00:02:44.522Z
+Generated: 2026-06-30T07:14:11.972Z
 Host: darwin arm64 (Shaws-MacBook-Pro.local)
 
 | Cell | Status | Platform | Class | Probe / Result | Command |
 |---|---:|---|---|---|---|
-| `ios.sim-or-device.voice-roundtrip` | skip | ios | mobile-live-voice | set ELIZA_VOICE_IOS_READY=1 after installing a current iOS simulator/device build with voice assets | `bun run --cwd packages/app capture:ios-sim -- --issue 9958 --slug voice-ios` |
-| `ios.talkmode.native-bridge` | pass | ios | native-bridge-unit | command passed (2026-06-30T00:00:35.231Z) | `swift test --disable-index-store --package-path plugins/plugin-native-talkmode/ios` |
-| `ios.swabble.native-bridge` | pass | ios | native-bridge-unit | command passed (2026-06-30T00:02:44.522Z) | `swift test --disable-index-store --package-path plugins/plugin-native-swabble/ios` |
+| `ios.sim-or-device.voice-roundtrip` | skip | ios | mobile-live-voice | set ELIZA_VOICE_IOS_READY=1 after booting an iOS simulator and installing the current app build with voice assets | `bun run --cwd packages/app capture:ios-sim -- --issue 9958 --slug voice-ios` |
+| `ios.talkmode.native-bridge` | pass | ios | native-bridge-unit | command passed (2026-06-30T07:14:10.286Z) | `swift test --disable-index-store --package-path plugins/plugin-native-talkmode/ios` |
+| `ios.swabble.native-bridge` | pass | ios | native-bridge-unit | command passed (2026-06-30T07:14:11.972Z) | `swift test --disable-index-store --package-path plugins/plugin-native-swabble/ios` |
 
 ## Summary
 

--- a/.github/issue-evidence/9958-voice-matrix-ios-run/index.html
+++ b/.github/issue-evidence/9958-voice-matrix-ios-run/index.html
@@ -12,20 +12,20 @@ th{background:#f1f1f1;text-align:left}
 code{font-size:12px}
 </style>
 <h1>Voice Live Matrix</h1>
-<p>Generated 2026-06-29T20:52:27.019Z on darwin arm64 (Shaws-MacBook-Pro.local).</p>
+<p>Generated 2026-06-30T07:14:02.754Z on darwin arm64 (Shaws-MacBook-Pro.local).</p>
 <p>Pass 2 · Fail 0 · Pending 0 · Skip 1</p>
 <table><thead><tr><th>Cell</th><th>Status</th><th>Platform</th><th>Class</th><th>Dimensions</th><th>Probe / Result</th><th>Command</th><th>Evidence</th></tr></thead><tbody><tr class="skip"><td><code>ios.sim-or-device.voice-roundtrip</code><br>iOS simulator/device voice self-test and capture evidence</td><td>skip</td><td>ios</td><td>mobile-live-voice</td><td>transcriptionState=off
 chimeIn=should-respond
 wakewordContext=idle-wake
 noiseRejection=quiet
-voices=owner</td><td>set ELIZA_VOICE_IOS_READY=1 after installing a current iOS simulator/device build with voice assets</td><td><code>bun run --cwd packages/app capture:ios-sim -- --issue 9958 --slug voice-ios</code></td><td>.github/issue-evidence/9958-voice-ios-ios-sim.*</td></tr>
+voices=owner</td><td>set ELIZA_VOICE_IOS_READY=1 after booting an iOS simulator and installing the current app build with voice assets</td><td><code>bun run --cwd packages/app capture:ios-sim -- --issue 9958 --slug voice-ios</code></td><td>.github/issue-evidence/9958-voice-ios-ios-sim.*</td></tr>
 <tr class="pass"><td><code>ios.talkmode.native-bridge</code><br>TalkMode iOS transcript, permission, state, and barge-in bridge contracts</td><td>pass</td><td>ios</td><td>native-bridge-unit</td><td>transcriptionState=off
 chimeIn=should-respond
 wakewordContext=already-listening-wake-inert
 noiseRejection=echo-self-voice
-voices=owner</td><td>command passed (2026-06-29T20:52:26.366Z)</td><td><code>swift test --package-path plugins/plugin-native-talkmode/ios</code></td><td>plugins/plugin-native-talkmode/ios/Tests</td></tr>
+voices=owner</td><td>command passed (2026-06-30T07:14:00.171Z)</td><td><code>swift test --disable-index-store --package-path plugins/plugin-native-talkmode/ios</code></td><td>plugins/plugin-native-talkmode/ios/Tests</td></tr>
 <tr class="pass"><td><code>ios.swabble.native-bridge</code><br>Swabble iOS wake-firing -&gt; JS bridge event contract</td><td>pass</td><td>ios</td><td>native-bridge-unit</td><td>transcriptionState=off
 chimeIn=should-respond
 wakewordContext=idle-wake
 noiseRejection=quiet
-voices=owner</td><td>command passed (2026-06-29T20:52:27.019Z)</td><td><code>swift test --package-path plugins/plugin-native-swabble/ios</code></td><td>plugins/plugin-native-swabble/ios/Tests</td></tr></tbody></table>
+voices=owner</td><td>command passed (2026-06-30T07:14:02.754Z)</td><td><code>swift test --disable-index-store --package-path plugins/plugin-native-swabble/ios</code></td><td>plugins/plugin-native-swabble/ios/Tests</td></tr></tbody></table>

--- a/.github/issue-evidence/9958-voice-matrix-ios-run/voice-matrix.json
+++ b/.github/issue-evidence/9958-voice-matrix-ios-run/voice-matrix.json
@@ -1,7 +1,7 @@
 {
   "schema": "eliza_voice_live_matrix_v1",
   "issue": 9958,
-  "generatedAt": "2026-06-29T20:52:27.019Z",
+  "generatedAt": "2026-06-30T07:14:02.754Z",
   "mode": "run",
   "dimensions": {
     "platform": [
@@ -81,7 +81,7 @@
       ],
       "probe": {
         "available": false,
-        "reason": "set ELIZA_VOICE_IOS_READY=1 after installing a current iOS simulator/device build with voice assets"
+        "reason": "set ELIZA_VOICE_IOS_READY=1 after booting an iOS simulator and installing the current app build with voice assets"
       },
       "cwd": ".",
       "env": {},
@@ -103,6 +103,7 @@
       "command": [
         "swift",
         "test",
+        "--disable-index-store",
         "--package-path",
         "plugins/plugin-native-talkmode/ios"
       ],
@@ -111,17 +112,17 @@
       ],
       "probe": {
         "available": true,
-        "reason": "command passed (2026-06-29T20:52:26.366Z)"
+        "reason": "command passed (2026-06-30T07:14:00.171Z)"
       },
       "cwd": ".",
       "env": {},
       "execution": {
         "exitCode": 0,
         "signal": null,
-        "startedAt": "2026-06-29T20:52:25.347Z",
-        "finishedAt": "2026-06-29T20:52:26.366Z",
-        "stdoutTail": "Test Suite 'All tests' started at 2026-06-29 16:52:26.323.\nTest Suite 'ElizaosCapacitorTalkModeIOSContractsPackageTests.xctest' started at 2026-06-29 16:52:26.324.\nTest Suite 'TalkModeBridgeContractTests' started at 2026-06-29 16:52:26.324.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testBargeInInterruptIgnoresShortBlipsAndSelfEcho]' started.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testBargeInInterruptIgnoresShortBlipsAndSelfEcho]' passed (0.000 seconds).\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testStateAndPermissionPayloads]' started.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testStateAndPermissionPayloads]' passed (0.000 seconds).\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testTranscriptPayloadPreservesBridgeFields]' started.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testTranscriptPayloadPreservesBridgeFields]' passed (0.000 seconds).\nTest Suite 'TalkModeBridgeContractTests' passed at 2026-06-29 16:52:26.326.\n\t Executed 3 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds\nTest Suite 'ElizaosCapacitorTalkModeIOSContractsPackageTests.xctest' passed at 2026-06-29 16:52:26.326.\n\t Executed 3 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds\nTest Suite 'All tests' passed at 2026-06-29 16:52:26.326.\n\t Executed 3 tests, with 0 failures (0 unexpected) in 0.001 (0.002) seconds\n◇ Test run started.\n↳ Testing Library Version: 1743\n↳ Target Platform: arm64e-apple-macos14.0\n✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.\n",
-        "stderrTail": "[0/1] Planning build\nBuilding for debugging...\n[0/2] Write swift-version--58304C5D6DBC2206.txt\nBuild complete! (0.18s)\n"
+        "startedAt": "2026-06-30T07:13:57.341Z",
+        "finishedAt": "2026-06-30T07:14:00.171Z",
+        "stdoutTail": "Test Suite 'All tests' started at 2026-06-30 03:14:00.132.\nTest Suite 'ElizaosCapacitorTalkModeIOSContractsPackageTests.xctest' started at 2026-06-30 03:14:00.133.\nTest Suite 'TalkModeBridgeContractTests' started at 2026-06-30 03:14:00.133.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testBargeInInterruptIgnoresShortBlipsAndSelfEcho]' started.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testBargeInInterruptIgnoresShortBlipsAndSelfEcho]' passed (0.001 seconds).\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testStateAndPermissionPayloads]' started.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testStateAndPermissionPayloads]' passed (0.000 seconds).\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testTranscriptPayloadPreservesBridgeFields]' started.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testTranscriptPayloadPreservesBridgeFields]' passed (0.000 seconds).\nTest Suite 'TalkModeBridgeContractTests' passed at 2026-06-30 03:14:00.134.\n\t Executed 3 tests, with 0 failures (0 unexpected) in 0.001 (0.002) seconds\nTest Suite 'ElizaosCapacitorTalkModeIOSContractsPackageTests.xctest' passed at 2026-06-30 03:14:00.134.\n\t Executed 3 tests, with 0 failures (0 unexpected) in 0.001 (0.002) seconds\nTest Suite 'All tests' passed at 2026-06-30 03:14:00.134.\n\t Executed 3 tests, with 0 failures (0 unexpected) in 0.001 (0.003) seconds\n◇ Test run started.\n↳ Testing Library Version: 1743\n↳ Target Platform: arm64e-apple-macos14.0\n✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.\n",
+        "stderrTail": "[0/1] Planning build\nBuilding for debugging...\n[0/2] Write swift-version--58304C5D6DBC2206.txt\nBuild complete! (0.13s)\n"
       },
       "status": "pass"
     },
@@ -140,6 +141,7 @@
       "command": [
         "swift",
         "test",
+        "--disable-index-store",
         "--package-path",
         "plugins/plugin-native-swabble/ios"
       ],
@@ -148,17 +150,17 @@
       ],
       "probe": {
         "available": true,
-        "reason": "command passed (2026-06-29T20:52:27.019Z)"
+        "reason": "command passed (2026-06-30T07:14:02.754Z)"
       },
       "cwd": ".",
       "env": {},
       "execution": {
         "exitCode": 0,
         "signal": null,
-        "startedAt": "2026-06-29T20:52:26.373Z",
-        "finishedAt": "2026-06-29T20:52:27.019Z",
-        "stdoutTail": "Test Suite 'All tests' started at 2026-06-29 16:52:26.973.\nTest Suite 'ElizaosCapacitorSwabbleIOSContractsPackageTests.xctest' started at 2026-06-29 16:52:26.974.\nTest Suite 'SwabbleBridgeContractTests' started at 2026-06-29 16:52:26.974.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testFuzzyTriggerStillFiresFromSpeechRecognizerMiss]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testFuzzyTriggerStillFiresFromSpeechRecognizerMiss]' passed (0.001 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTextOnlyWakeCommandUsesTriggerAndMinimumLength]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTextOnlyWakeCommandUsesTriggerAndMinimumLength]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTriggerOnlyPayloadStartsCaptureWithoutCommand]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTriggerOnlyPayloadStartsCaptureWithoutCommand]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testWakePayloadMatchesJsBridgeContract]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testWakePayloadMatchesJsBridgeContract]' passed (0.000 seconds).\nTest Suite 'SwabbleBridgeContractTests' passed at 2026-06-29 16:52:26.976.\n\t Executed 4 tests, with 0 failures (0 unexpected) in 0.001 (0.002) seconds\nTest Suite 'ElizaosCapacitorSwabbleIOSContractsPackageTests.xctest' passed at 2026-06-29 16:52:26.976.\n\t Executed 4 tests, with 0 failures (0 unexpected) in 0.001 (0.002) seconds\nTest Suite 'All tests' passed at 2026-06-29 16:52:26.976.\n\t Executed 4 tests, with 0 failures (0 unexpected) in 0.001 (0.003) seconds\n◇ Test run started.\n↳ Testing Library Version: 1743\n↳ Target Platform: arm64e-apple-macos14.0\n✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.\n",
-        "stderrTail": "[0/1] Planning build\nBuilding for debugging...\n[0/2] Write swift-version--58304C5D6DBC2206.txt\nBuild complete! (0.16s)\n"
+        "startedAt": "2026-06-30T07:14:00.179Z",
+        "finishedAt": "2026-06-30T07:14:02.754Z",
+        "stdoutTail": "Test Suite 'All tests' started at 2026-06-30 03:14:02.716.\nTest Suite 'ElizaosCapacitorSwabbleIOSContractsPackageTests.xctest' started at 2026-06-30 03:14:02.717.\nTest Suite 'SwabbleBridgeContractTests' started at 2026-06-30 03:14:02.717.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testFuzzyTriggerStillFiresFromSpeechRecognizerMiss]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testFuzzyTriggerStillFiresFromSpeechRecognizerMiss]' passed (0.001 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTextOnlyWakeCommandUsesTriggerAndMinimumLength]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTextOnlyWakeCommandUsesTriggerAndMinimumLength]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTriggerOnlyPayloadStartsCaptureWithoutCommand]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTriggerOnlyPayloadStartsCaptureWithoutCommand]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testWakePayloadMatchesJsBridgeContract]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testWakePayloadMatchesJsBridgeContract]' passed (0.000 seconds).\nTest Suite 'SwabbleBridgeContractTests' passed at 2026-06-30 03:14:02.718.\n\t Executed 4 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds\nTest Suite 'SwabbleTriggerGateTests' started at 2026-06-30 03:14:02.718.\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testBareTriggerIsTriggerOnly]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testBareTriggerIsTriggerOnly]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testEmptyTranscriptIsNotTriggerOnly]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testEmptyTranscriptIsNotTriggerOnly]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testFuzzyMisheardTriggerStillCountsAsTriggerOnly]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testFuzzyMisheardTriggerStillCountsAsTriggerOnly]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testNonTriggerSpeechIsNotTriggerOnly]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testNonTriggerSpeechIsNotTriggerOnly]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testTriggerWithTrailingCommandIsNotTriggerOnly]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testTriggerWithTrailingCommandIsNotTriggerOnly]' passed (0.000 seconds).\nTest Suite 'SwabbleTriggerGateTests' passed at 2026-06-30 03:14:02.719.\n\t Executed 5 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds\nTest Suite 'ElizaosCapacitorSwabbleIOSContractsPackageTests.xctest' passed at 2026-06-30 03:14:02.719.\n\t Executed 9 tests, with 0 failures (0 unexpected) in 0.001 (0.002) seconds\nTest Suite 'All tests' passed at 2026-06-30 03:14:02.719.\n\t Executed 9 tests, with 0 failures (0 unexpected) in 0.001 (0.003) seconds\n◇ Test run started.\n↳ Testing Library Version: 1743\n↳ Target Platform: arm64e-apple-macos14.0\n✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.\n",
+        "stderrTail": "[0/1] Planning build\nBuilding for debugging...\n[0/4] Write sources\n[1/4] Write swift-version--58304C5D6DBC2206.txt\n[3/6] Emitting module SwabbleBridgeContractTests\n[4/6] Compiling SwabbleBridgeContractTests SwabbleTriggerGateTests.swift\n[4/6] Write Objects.LinkFileList\n[5/6] Linking ElizaosCapacitorSwabbleIOSContractsPackageTests\nBuild complete! (1.18s)\n"
       },
       "status": "pass"
     }

--- a/.github/issue-evidence/9958-voice-matrix-ios-run/voice-matrix.md
+++ b/.github/issue-evidence/9958-voice-matrix-ios-run/voice-matrix.md
@@ -1,13 +1,13 @@
 # Voice Live Matrix
 
-Generated: 2026-06-29T20:52:27.019Z
+Generated: 2026-06-30T07:14:02.754Z
 Host: darwin arm64 (Shaws-MacBook-Pro.local)
 
 | Cell | Status | Platform | Class | Probe / Result | Command |
 |---|---:|---|---|---|---|
-| `ios.sim-or-device.voice-roundtrip` | skip | ios | mobile-live-voice | set ELIZA_VOICE_IOS_READY=1 after installing a current iOS simulator/device build with voice assets | `bun run --cwd packages/app capture:ios-sim -- --issue 9958 --slug voice-ios` |
-| `ios.talkmode.native-bridge` | pass | ios | native-bridge-unit | command passed (2026-06-29T20:52:26.366Z) | `swift test --package-path plugins/plugin-native-talkmode/ios` |
-| `ios.swabble.native-bridge` | pass | ios | native-bridge-unit | command passed (2026-06-29T20:52:27.019Z) | `swift test --package-path plugins/plugin-native-swabble/ios` |
+| `ios.sim-or-device.voice-roundtrip` | skip | ios | mobile-live-voice | set ELIZA_VOICE_IOS_READY=1 after booting an iOS simulator and installing the current app build with voice assets | `bun run --cwd packages/app capture:ios-sim -- --issue 9958 --slug voice-ios` |
+| `ios.talkmode.native-bridge` | pass | ios | native-bridge-unit | command passed (2026-06-30T07:14:00.171Z) | `swift test --disable-index-store --package-path plugins/plugin-native-talkmode/ios` |
+| `ios.swabble.native-bridge` | pass | ios | native-bridge-unit | command passed (2026-06-30T07:14:02.754Z) | `swift test --disable-index-store --package-path plugins/plugin-native-swabble/ios` |
 
 ## Summary
 

--- a/.github/issue-evidence/9958-voice-matrix-ios-swift-run/index.html
+++ b/.github/issue-evidence/9958-voice-matrix-ios-swift-run/index.html
@@ -12,20 +12,20 @@ th{background:#f1f1f1;text-align:left}
 code{font-size:12px}
 </style>
 <h1>Voice Live Matrix</h1>
-<p>Generated 2026-06-30T05:06:02.224Z on darwin arm64 (Mac.localdomain).</p>
+<p>Generated 2026-06-30T07:14:05.903Z on darwin arm64 (Shaws-MacBook-Pro.local).</p>
 <p>Pass 2 · Fail 0 · Pending 0 · Skip 1</p>
 <table><thead><tr><th>Cell</th><th>Status</th><th>Platform</th><th>Class</th><th>Dimensions</th><th>Probe / Result</th><th>Command</th><th>Evidence</th></tr></thead><tbody><tr class="skip"><td><code>ios.sim-or-device.voice-roundtrip</code><br>iOS simulator/device voice self-test and capture evidence</td><td>skip</td><td>ios</td><td>mobile-live-voice</td><td>transcriptionState=off
 chimeIn=should-respond
 wakewordContext=idle-wake
 noiseRejection=quiet
-voices=owner</td><td>set ELIZA_VOICE_IOS_READY=1 after installing a current iOS simulator/device build with voice assets</td><td><code>bun run --cwd packages/app capture:ios-sim -- --issue 9958 --slug voice-ios</code></td><td>.github/issue-evidence/9958-voice-ios-ios-sim.*</td></tr>
+voices=owner</td><td>set ELIZA_VOICE_IOS_READY=1 after booting an iOS simulator and installing the current app build with voice assets</td><td><code>bun run --cwd packages/app capture:ios-sim -- --issue 9958 --slug voice-ios</code></td><td>.github/issue-evidence/9958-voice-ios-ios-sim.*</td></tr>
 <tr class="pass"><td><code>ios.talkmode.native-bridge</code><br>TalkMode iOS transcript, permission, state, and barge-in bridge contracts</td><td>pass</td><td>ios</td><td>native-bridge-unit</td><td>transcriptionState=off
 chimeIn=should-respond
 wakewordContext=already-listening-wake-inert
 noiseRejection=echo-self-voice
-voices=owner</td><td>command passed (2026-06-30T05:05:29.063Z)</td><td><code>swift test --disable-index-store --package-path plugins/plugin-native-talkmode/ios</code></td><td>plugins/plugin-native-talkmode/ios/Tests</td></tr>
+voices=owner</td><td>command passed (2026-06-30T07:14:04.272Z)</td><td><code>swift test --disable-index-store --package-path plugins/plugin-native-talkmode/ios</code></td><td>plugins/plugin-native-talkmode/ios/Tests</td></tr>
 <tr class="pass"><td><code>ios.swabble.native-bridge</code><br>Swabble iOS wake-firing -&gt; JS bridge event contract</td><td>pass</td><td>ios</td><td>native-bridge-unit</td><td>transcriptionState=off
 chimeIn=should-respond
 wakewordContext=idle-wake
 noiseRejection=quiet
-voices=owner</td><td>command passed (2026-06-30T05:06:02.224Z)</td><td><code>swift test --disable-index-store --package-path plugins/plugin-native-swabble/ios</code></td><td>plugins/plugin-native-swabble/ios/Tests</td></tr></tbody></table>
+voices=owner</td><td>command passed (2026-06-30T07:14:05.903Z)</td><td><code>swift test --disable-index-store --package-path plugins/plugin-native-swabble/ios</code></td><td>plugins/plugin-native-swabble/ios/Tests</td></tr></tbody></table>

--- a/.github/issue-evidence/9958-voice-matrix-ios-swift-run/voice-matrix.json
+++ b/.github/issue-evidence/9958-voice-matrix-ios-swift-run/voice-matrix.json
@@ -1,7 +1,7 @@
 {
   "schema": "eliza_voice_live_matrix_v1",
   "issue": 9958,
-  "generatedAt": "2026-06-30T05:06:02.224Z",
+  "generatedAt": "2026-06-30T07:14:05.903Z",
   "mode": "run",
   "dimensions": {
     "platform": [
@@ -41,7 +41,7 @@
   "host": {
     "platform": "darwin",
     "arch": "arm64",
-    "hostname": "Mac.localdomain",
+    "hostname": "Shaws-MacBook-Pro.local",
     "runnerOs": null,
     "runnerArch": null
   },
@@ -81,7 +81,7 @@
       ],
       "probe": {
         "available": false,
-        "reason": "set ELIZA_VOICE_IOS_READY=1 after installing a current iOS simulator/device build with voice assets"
+        "reason": "set ELIZA_VOICE_IOS_READY=1 after booting an iOS simulator and installing the current app build with voice assets"
       },
       "cwd": ".",
       "env": {},
@@ -112,17 +112,17 @@
       ],
       "probe": {
         "available": true,
-        "reason": "command passed (2026-06-30T05:05:29.063Z)"
+        "reason": "command passed (2026-06-30T07:14:04.272Z)"
       },
       "cwd": ".",
       "env": {},
       "execution": {
         "exitCode": 0,
         "signal": null,
-        "startedAt": "2026-06-30T05:05:04.808Z",
-        "finishedAt": "2026-06-30T05:05:29.063Z",
-        "stdoutTail": "Test Suite 'All tests' started at 2026-06-30 01:05:28.799.\nTest Suite 'ElizaosCapacitorTalkModeIOSContractsPackageTests.xctest' started at 2026-06-30 01:05:28.810.\nTest Suite 'TalkModeBridgeContractTests' started at 2026-06-30 01:05:28.810.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testBargeInInterruptIgnoresShortBlipsAndSelfEcho]' started.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testBargeInInterruptIgnoresShortBlipsAndSelfEcho]' passed (0.009 seconds).\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testStateAndPermissionPayloads]' started.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testStateAndPermissionPayloads]' passed (0.001 seconds).\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testTranscriptPayloadPreservesBridgeFields]' started.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testTranscriptPayloadPreservesBridgeFields]' passed (0.000 seconds).\nTest Suite 'TalkModeBridgeContractTests' passed at 2026-06-30 01:05:28.821.\n\t Executed 3 tests, with 0 failures (0 unexpected) in 0.010 (0.011) seconds\nTest Suite 'ElizaosCapacitorTalkModeIOSContractsPackageTests.xctest' passed at 2026-06-30 01:05:28.821.\n\t Executed 3 tests, with 0 failures (0 unexpected) in 0.010 (0.011) seconds\nTest Suite 'All tests' passed at 2026-06-30 01:05:28.821.\n\t Executed 3 tests, with 0 failures (0 unexpected) in 0.010 (0.022) seconds\n◇ Test run started.\n↳ Testing Library Version: 1743\n↳ Target Platform: arm64e-apple-macos14.0\n✔ Test run with 0 tests in 0 suites passed after 0.003 seconds.\n",
-        "stderrTail": "[0/1] Planning build\nBuilding for debugging...\n[0/2] Write swift-version--58304C5D6DBC2206.txt\nBuild complete! (1.52s)\n"
+        "startedAt": "2026-06-30T07:14:02.799Z",
+        "finishedAt": "2026-06-30T07:14:04.272Z",
+        "stdoutTail": "Test Suite 'All tests' started at 2026-06-30 03:14:04.239.\nTest Suite 'ElizaosCapacitorTalkModeIOSContractsPackageTests.xctest' started at 2026-06-30 03:14:04.240.\nTest Suite 'TalkModeBridgeContractTests' started at 2026-06-30 03:14:04.240.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testBargeInInterruptIgnoresShortBlipsAndSelfEcho]' started.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testBargeInInterruptIgnoresShortBlipsAndSelfEcho]' passed (0.000 seconds).\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testStateAndPermissionPayloads]' started.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testStateAndPermissionPayloads]' passed (0.000 seconds).\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testTranscriptPayloadPreservesBridgeFields]' started.\nTest Case '-[TalkModeBridgeContractTests.TalkModeBridgeContractTests testTranscriptPayloadPreservesBridgeFields]' passed (0.000 seconds).\nTest Suite 'TalkModeBridgeContractTests' passed at 2026-06-30 03:14:04.241.\n\t Executed 3 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds\nTest Suite 'ElizaosCapacitorTalkModeIOSContractsPackageTests.xctest' passed at 2026-06-30 03:14:04.241.\n\t Executed 3 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds\nTest Suite 'All tests' passed at 2026-06-30 03:14:04.241.\n\t Executed 3 tests, with 0 failures (0 unexpected) in 0.001 (0.002) seconds\n◇ Test run started.\n↳ Testing Library Version: 1743\n↳ Target Platform: arm64e-apple-macos14.0\n✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.\n",
+        "stderrTail": "[0/1] Planning build\nBuilding for debugging...\n[0/2] Write swift-version--58304C5D6DBC2206.txt\nBuild complete! (0.12s)\n"
       },
       "status": "pass"
     },
@@ -150,17 +150,17 @@
       ],
       "probe": {
         "available": true,
-        "reason": "command passed (2026-06-30T05:06:02.224Z)"
+        "reason": "command passed (2026-06-30T07:14:05.903Z)"
       },
       "cwd": ".",
       "env": {},
       "execution": {
         "exitCode": 0,
         "signal": null,
-        "startedAt": "2026-06-30T05:05:29.179Z",
-        "finishedAt": "2026-06-30T05:06:02.224Z",
-        "stdoutTail": "Test Suite 'All tests' started at 2026-06-30 01:06:01.203.\nTest Suite 'ElizaosCapacitorSwabbleIOSContractsPackageTests.xctest' started at 2026-06-30 01:06:01.244.\nTest Suite 'SwabbleBridgeContractTests' started at 2026-06-30 01:06:01.245.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testFuzzyTriggerStillFiresFromSpeechRecognizerMiss]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testFuzzyTriggerStillFiresFromSpeechRecognizerMiss]' passed (0.013 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTextOnlyWakeCommandUsesTriggerAndMinimumLength]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTextOnlyWakeCommandUsesTriggerAndMinimumLength]' passed (0.001 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTriggerOnlyPayloadStartsCaptureWithoutCommand]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTriggerOnlyPayloadStartsCaptureWithoutCommand]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testWakePayloadMatchesJsBridgeContract]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testWakePayloadMatchesJsBridgeContract]' passed (0.000 seconds).\nTest Suite 'SwabbleBridgeContractTests' passed at 2026-06-30 01:06:01.260.\n\t Executed 4 tests, with 0 failures (0 unexpected) in 0.014 (0.015) seconds\nTest Suite 'SwabbleTriggerGateTests' started at 2026-06-30 01:06:01.260.\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testBareTriggerIsTriggerOnly]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testBareTriggerIsTriggerOnly]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testEmptyTranscriptIsNotTriggerOnly]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testEmptyTranscriptIsNotTriggerOnly]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testFuzzyMisheardTriggerStillCountsAsTriggerOnly]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testFuzzyMisheardTriggerStillCountsAsTriggerOnly]' passed (0.001 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testNonTriggerSpeechIsNotTriggerOnly]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testNonTriggerSpeechIsNotTriggerOnly]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testTriggerWithTrailingCommandIsNotTriggerOnly]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testTriggerWithTrailingCommandIsNotTriggerOnly]' passed (0.000 seconds).\nTest Suite 'SwabbleTriggerGateTests' passed at 2026-06-30 01:06:01.263.\n\t Executed 5 tests, with 0 failures (0 unexpected) in 0.002 (0.003) seconds\nTest Suite 'ElizaosCapacitorSwabbleIOSContractsPackageTests.xctest' passed at 2026-06-30 01:06:01.263.\n\t Executed 9 tests, with 0 failures (0 unexpected) in 0.016 (0.018) seconds\nTest Suite 'All tests' passed at 2026-06-30 01:06:01.263.\n\t Executed 9 tests, with 0 failures (0 unexpected) in 0.016 (0.060) seconds\n◇ Test run started.\n↳ Testing Library Version: 1743\n↳ Target Platform: arm64e-apple-macos14.0\n✔ Test run with 0 tests in 0 suites passed after 0.009 seconds.\n",
-        "stderrTail": "[0/1] Planning build\nBuilding for debugging...\n[0/2] Write swift-version--58304C5D6DBC2206.txt\nBuild complete! (5.16s)\n"
+        "startedAt": "2026-06-30T07:14:04.280Z",
+        "finishedAt": "2026-06-30T07:14:05.903Z",
+        "stdoutTail": "Test Suite 'All tests' started at 2026-06-30 03:14:05.864.\nTest Suite 'ElizaosCapacitorSwabbleIOSContractsPackageTests.xctest' started at 2026-06-30 03:14:05.865.\nTest Suite 'SwabbleBridgeContractTests' started at 2026-06-30 03:14:05.865.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testFuzzyTriggerStillFiresFromSpeechRecognizerMiss]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testFuzzyTriggerStillFiresFromSpeechRecognizerMiss]' passed (0.001 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTextOnlyWakeCommandUsesTriggerAndMinimumLength]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTextOnlyWakeCommandUsesTriggerAndMinimumLength]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTriggerOnlyPayloadStartsCaptureWithoutCommand]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testTriggerOnlyPayloadStartsCaptureWithoutCommand]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testWakePayloadMatchesJsBridgeContract]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleBridgeContractTests testWakePayloadMatchesJsBridgeContract]' passed (0.000 seconds).\nTest Suite 'SwabbleBridgeContractTests' passed at 2026-06-30 03:14:05.866.\n\t Executed 4 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds\nTest Suite 'SwabbleTriggerGateTests' started at 2026-06-30 03:14:05.866.\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testBareTriggerIsTriggerOnly]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testBareTriggerIsTriggerOnly]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testEmptyTranscriptIsNotTriggerOnly]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testEmptyTranscriptIsNotTriggerOnly]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testFuzzyMisheardTriggerStillCountsAsTriggerOnly]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testFuzzyMisheardTriggerStillCountsAsTriggerOnly]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testNonTriggerSpeechIsNotTriggerOnly]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testNonTriggerSpeechIsNotTriggerOnly]' passed (0.000 seconds).\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testTriggerWithTrailingCommandIsNotTriggerOnly]' started.\nTest Case '-[SwabbleBridgeContractTests.SwabbleTriggerGateTests testTriggerWithTrailingCommandIsNotTriggerOnly]' passed (0.000 seconds).\nTest Suite 'SwabbleTriggerGateTests' passed at 2026-06-30 03:14:05.867.\n\t Executed 5 tests, with 0 failures (0 unexpected) in 0.001 (0.001) seconds\nTest Suite 'ElizaosCapacitorSwabbleIOSContractsPackageTests.xctest' passed at 2026-06-30 03:14:05.867.\n\t Executed 9 tests, with 0 failures (0 unexpected) in 0.002 (0.002) seconds\nTest Suite 'All tests' passed at 2026-06-30 03:14:05.867.\n\t Executed 9 tests, with 0 failures (0 unexpected) in 0.002 (0.003) seconds\n◇ Test run started.\n↳ Testing Library Version: 1743\n↳ Target Platform: arm64e-apple-macos14.0\n✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.\n",
+        "stderrTail": "[0/1] Planning build\nBuilding for debugging...\n[0/2] Write swift-version--58304C5D6DBC2206.txt\nBuild complete! (0.12s)\n"
       },
       "status": "pass"
     }

--- a/.github/issue-evidence/9958-voice-matrix-ios-swift-run/voice-matrix.md
+++ b/.github/issue-evidence/9958-voice-matrix-ios-swift-run/voice-matrix.md
@@ -1,13 +1,13 @@
 # Voice Live Matrix
 
-Generated: 2026-06-30T05:06:02.224Z
-Host: darwin arm64 (Mac.localdomain)
+Generated: 2026-06-30T07:14:05.903Z
+Host: darwin arm64 (Shaws-MacBook-Pro.local)
 
 | Cell | Status | Platform | Class | Probe / Result | Command |
 |---|---:|---|---|---|---|
-| `ios.sim-or-device.voice-roundtrip` | skip | ios | mobile-live-voice | set ELIZA_VOICE_IOS_READY=1 after installing a current iOS simulator/device build with voice assets | `bun run --cwd packages/app capture:ios-sim -- --issue 9958 --slug voice-ios` |
-| `ios.talkmode.native-bridge` | pass | ios | native-bridge-unit | command passed (2026-06-30T05:05:29.063Z) | `swift test --disable-index-store --package-path plugins/plugin-native-talkmode/ios` |
-| `ios.swabble.native-bridge` | pass | ios | native-bridge-unit | command passed (2026-06-30T05:06:02.224Z) | `swift test --disable-index-store --package-path plugins/plugin-native-swabble/ios` |
+| `ios.sim-or-device.voice-roundtrip` | skip | ios | mobile-live-voice | set ELIZA_VOICE_IOS_READY=1 after booting an iOS simulator and installing the current app build with voice assets | `bun run --cwd packages/app capture:ios-sim -- --issue 9958 --slug voice-ios` |
+| `ios.talkmode.native-bridge` | pass | ios | native-bridge-unit | command passed (2026-06-30T07:14:04.272Z) | `swift test --disable-index-store --package-path plugins/plugin-native-talkmode/ios` |
+| `ios.swabble.native-bridge` | pass | ios | native-bridge-unit | command passed (2026-06-30T07:14:05.903Z) | `swift test --disable-index-store --package-path plugins/plugin-native-swabble/ios` |
 
 ## Summary
 

--- a/.github/issue-evidence/9958-voice-matrix/index.html
+++ b/.github/issue-evidence/9958-voice-matrix/index.html
@@ -12,8 +12,8 @@ th{background:#f1f1f1;text-align:left}
 code{font-size:12px}
 </style>
 <h1>Voice Live Matrix</h1>
-<p>Generated 2026-06-30T00:39:27.069Z on darwin arm64 (Shaws-MacBook-Pro.local).</p>
-<p>Pass 0 · Fail 0 · Pending 7 · Skip 8</p>
+<p>Generated 2026-06-30T07:13:48.071Z on darwin arm64 (Shaws-MacBook-Pro.local).</p>
+<p>Pass 0 · Fail 0 · Pending 8 · Skip 8</p>
 <table><thead><tr><th>Cell</th><th>Status</th><th>Platform</th><th>Class</th><th>Dimensions</th><th>Probe / Result</th><th>Command</th><th>Evidence</th></tr></thead><tbody><tr class="pending"><td><code>web.fake-mic.roundtrip</code><br>Web fake-device mic capture -&gt; ASR -&gt; agent -&gt; local TTS + barge-in</td><td>pending</td><td>web</td><td>live-client-audio-barge-in</td><td>transcriptionState=off
 chimeIn=should-respond
 wakewordContext=idle-wake
@@ -47,17 +47,19 @@ voices=owner</td><td>requires Linux runner; current=darwin</td><td><code>bun run
 chimeIn=should-respond
 wakewordContext=idle-wake
 noiseRejection=quiet
-voices=owner</td><td>set ELIZA_VOICE_MACOS_ELECTROBUN_READY=1 on a macOS Electrobun voice runner with loopback mic/audio capture</td><td><code>bun run --cwd packages/app capture:macos-desktop -- --issue 9958 --slug voice-macos-electrobun</code></td><td>.github/issue-evidence/9958-voice-macos-electrobun-macos-desktop.*</td></tr>
+voices=owner</td><td>set ELIZA_VOICE_MACOS_ELECTROBUN_READY=1 on a macOS Electrobun voice runner with loopback mic/audio capture</td><td><code>bun run --cwd packages/app test:desktop:voice</code></td><td>$ELIZA_VOICE_MATRIX_OUT/macos.electrobun.live-roundtrip
+packages/app/test-results</td></tr>
 <tr class="skip"><td><code>windows.electrobun.live-roundtrip</code><br>Windows Electrobun live mic -&gt; ASR -&gt; agent -&gt; Kokoro -&gt; speaker loop</td><td>skip</td><td>windows-electrobun</td><td>desktop-live-voice</td><td>transcriptionState=off
 chimeIn=should-respond
 wakewordContext=idle-wake
 noiseRejection=quiet
-voices=owner</td><td>requires Windows runner; current=darwin</td><td><code>bun run --cwd packages/app capture:windows-desktop -- --issue 9958 --slug voice-windows-electrobun</code></td><td>.github/issue-evidence/9958-voice-windows-electrobun-windows-desktop.*</td></tr>
+voices=owner</td><td>requires Windows runner; current=darwin</td><td><code>bun run --cwd packages/app test:desktop:voice</code></td><td>$ELIZA_VOICE_MATRIX_OUT/windows.electrobun.live-roundtrip
+packages/app/test-results</td></tr>
 <tr class="skip"><td><code>ios.sim-or-device.voice-roundtrip</code><br>iOS simulator/device voice self-test and capture evidence</td><td>skip</td><td>ios</td><td>mobile-live-voice</td><td>transcriptionState=off
 chimeIn=should-respond
 wakewordContext=idle-wake
 noiseRejection=quiet
-voices=owner</td><td>set ELIZA_VOICE_IOS_READY=1 after installing a current iOS simulator/device build with voice assets</td><td><code>bun run --cwd packages/app capture:ios-sim -- --issue 9958 --slug voice-ios</code></td><td>.github/issue-evidence/9958-voice-ios-ios-sim.*</td></tr>
+voices=owner</td><td>set ELIZA_VOICE_IOS_READY=1 after booting an iOS simulator and installing the current app build with voice assets</td><td><code>bun run --cwd packages/app capture:ios-sim -- --issue 9958 --slug voice-ios</code></td><td>.github/issue-evidence/9958-voice-ios-ios-sim.*</td></tr>
 <tr class="pending"><td><code>ios.talkmode.native-bridge</code><br>TalkMode iOS transcript, permission, state, and barge-in bridge contracts</td><td>pending</td><td>ios</td><td>native-bridge-unit</td><td>transcriptionState=off
 chimeIn=should-respond
 wakewordContext=already-listening-wake-inert
@@ -88,9 +90,16 @@ voices=owner</td><td>Android voice bridge Gradle project exists</td><td><code>./
 chimeIn=should-not-respond
 wakewordContext=mid-transcription-wake
 noiseRejection=overlapping-speech
-voices=multi-speaker</td><td>ELIZA_OPENWAKEWORD_REAL_READY is not set for a real wake-word head run</td><td><code>bun run --cwd plugins/plugin-local-inference voice:workbench --real</code></td><td>$VOICE_REAL_MATRIX_OUT/voice-workbench-real</td></tr>
-<tr class="skip"><td><code>stt.stage-b.evaluation</code><br>Stage-B STT evaluation: iOS SFSpeechRecognizer vs Android SpeechRecognizer vs fused ASR</td><td>skip</td><td>android</td><td>stt-evaluation</td><td>transcriptionState=on
+voices=multi-speaker</td><td>ELIZA_VOICE_OPENWAKEWORD_REPORT is not set to a reviewed real-head openWakeWord JSON report</td><td><code>node packages/scripts/voice-openwakeword-eval.mjs</code></td><td>$ELIZA_VOICE_MATRIX_OUT/wake.openwakeword.real-head/openwakeword-eval.json
+$ELIZA_VOICE_OPENWAKEWORD_REPORT</td></tr>
+<tr class="pending"><td><code>stt.stage-b.apple-sfspeech</code><br>Stage-B STT Apple arm: real on-device SFSpeechRecognizer latency/WER over synthesised speech (quiet + 10dB noise)</td><td>pending</td><td>macos-electrobun</td><td>stt-evaluation</td><td>transcriptionState=on
 chimeIn=should-respond
 wakewordContext=idle-wake
 noiseRejection=noisy-reverberant
-voices=multi-speaker</td><td>Stage-B STT battery/latency evaluation needs paired iOS+Android device runners and power telemetry</td><td><code>bun packages/scripts/voice-matrix.mjs --stage-b-eval-placeholder</code></td><td>.github/issue-evidence/9147-voice-asr-m4max.md</td></tr></tbody></table>
+voices=owner</td><td>macOS on-device SFSpeechRecognizer + say/afconvert available for a real Stage-B latency/WER measurement</td><td><code>node packages/scripts/stage-b-stt-bench.mjs</code></td><td>.github/issue-evidence/9958-stt-stage-b-eval</td></tr>
+<tr class="skip"><td><code>stt.stage-b.evaluation</code><br>Stage-B STT evaluation: iOS battery/energy + Android SpeechRecognizer (NNAPI) vs fused ASR</td><td>skip</td><td>android</td><td>stt-evaluation</td><td>transcriptionState=on
+chimeIn=should-respond
+wakewordContext=idle-wake
+noiseRejection=noisy-reverberant
+voices=multi-speaker</td><td>ELIZA_VOICE_STAGE_B_REPORT is not set to a reviewed iOS+Android+fused ASR Stage-B JSON report</td><td><code>node packages/scripts/voice-stage-b-eval.mjs</code></td><td>$ELIZA_VOICE_MATRIX_OUT/stt.stage-b.evaluation/stage-b-eval.json
+$ELIZA_VOICE_STAGE_B_REPORT</td></tr></tbody></table>

--- a/.github/issue-evidence/9958-voice-matrix/voice-matrix.json
+++ b/.github/issue-evidence/9958-voice-matrix/voice-matrix.json
@@ -1,7 +1,7 @@
 {
   "schema": "eliza_voice_live_matrix_v1",
   "issue": 9958,
-  "generatedAt": "2026-06-30T00:39:27.069Z",
+  "generatedAt": "2026-06-30T07:13:48.071Z",
   "mode": "probe",
   "dimensions": {
     "platform": [
@@ -48,7 +48,7 @@
   "summary": {
     "pass": 0,
     "fail": 0,
-    "pending": 7,
+    "pending": 8,
     "skip": 8
   },
   "cells": [
@@ -244,22 +244,20 @@
         "run",
         "--cwd",
         "packages/app",
-        "capture:macos-desktop",
-        "--",
-        "--issue",
-        "9958",
-        "--slug",
-        "voice-macos-electrobun"
+        "test:desktop:voice"
       ],
+      "env": {
+        "ELIZA_VOICE_DESKTOP_SELFTEST": "1"
+      },
       "evidence": [
-        ".github/issue-evidence/9958-voice-macos-electrobun-macos-desktop.*"
+        "$ELIZA_VOICE_MATRIX_OUT/macos.electrobun.live-roundtrip",
+        "packages/app/test-results"
       ],
       "probe": {
         "available": false,
         "reason": "set ELIZA_VOICE_MACOS_ELECTROBUN_READY=1 on a macOS Electrobun voice runner with loopback mic/audio capture"
       },
       "cwd": ".",
-      "env": {},
       "execution": null,
       "status": "skip"
     },
@@ -280,22 +278,20 @@
         "run",
         "--cwd",
         "packages/app",
-        "capture:windows-desktop",
-        "--",
-        "--issue",
-        "9958",
-        "--slug",
-        "voice-windows-electrobun"
+        "test:desktop:voice"
       ],
+      "env": {
+        "ELIZA_VOICE_DESKTOP_SELFTEST": "1"
+      },
       "evidence": [
-        ".github/issue-evidence/9958-voice-windows-electrobun-windows-desktop.*"
+        "$ELIZA_VOICE_MATRIX_OUT/windows.electrobun.live-roundtrip",
+        "packages/app/test-results"
       ],
       "probe": {
         "available": false,
         "reason": "requires Windows runner; current=darwin"
       },
       "cwd": ".",
-      "env": {},
       "execution": null,
       "status": "skip"
     },
@@ -328,7 +324,7 @@
       ],
       "probe": {
         "available": false,
-        "reason": "set ELIZA_VOICE_IOS_READY=1 after installing a current iOS simulator/device build with voice assets"
+        "reason": "set ELIZA_VOICE_IOS_READY=1 after booting an iOS simulator and installing the current app build with voice assets"
       },
       "cwd": ".",
       "env": {},
@@ -502,19 +498,16 @@
       },
       "class": "wakeword-device-gap",
       "command": [
-        "bun",
-        "run",
-        "--cwd",
-        "plugins/plugin-local-inference",
-        "voice:workbench",
-        "--real"
+        "node",
+        "packages/scripts/voice-openwakeword-eval.mjs"
       ],
       "evidence": [
-        "$VOICE_REAL_MATRIX_OUT/voice-workbench-real"
+        "$ELIZA_VOICE_MATRIX_OUT/wake.openwakeword.real-head/openwakeword-eval.json",
+        "$ELIZA_VOICE_OPENWAKEWORD_REPORT"
       ],
       "probe": {
         "available": false,
-        "reason": "ELIZA_OPENWAKEWORD_REAL_READY is not set for a real wake-word head run"
+        "reason": "ELIZA_VOICE_OPENWAKEWORD_REPORT is not set to a reviewed real-head openWakeWord JSON report"
       },
       "cwd": ".",
       "env": {},
@@ -522,8 +515,36 @@
       "status": "skip"
     },
     {
+      "id": "stt.stage-b.apple-sfspeech",
+      "title": "Stage-B STT Apple arm: real on-device SFSpeechRecognizer latency/WER over synthesised speech (quiet + 10dB noise)",
+      "platform": "macos-electrobun",
+      "dimensions": {
+        "transcriptionState": "on",
+        "chimeIn": "should-respond",
+        "wakewordContext": "idle-wake",
+        "noiseRejection": "noisy-reverberant",
+        "voices": "owner"
+      },
+      "class": "stt-evaluation",
+      "command": [
+        "node",
+        "packages/scripts/stage-b-stt-bench.mjs"
+      ],
+      "evidence": [
+        ".github/issue-evidence/9958-stt-stage-b-eval"
+      ],
+      "probe": {
+        "available": true,
+        "reason": "macOS on-device SFSpeechRecognizer + say/afconvert available for a real Stage-B latency/WER measurement"
+      },
+      "cwd": ".",
+      "env": {},
+      "execution": null,
+      "status": "pending"
+    },
+    {
       "id": "stt.stage-b.evaluation",
-      "title": "Stage-B STT evaluation: iOS SFSpeechRecognizer vs Android SpeechRecognizer vs fused ASR",
+      "title": "Stage-B STT evaluation: iOS battery/energy + Android SpeechRecognizer (NNAPI) vs fused ASR",
       "platform": "android",
       "dimensions": {
         "transcriptionState": "on",
@@ -534,16 +555,16 @@
       },
       "class": "stt-evaluation",
       "command": [
-        "bun",
-        "packages/scripts/voice-matrix.mjs",
-        "--stage-b-eval-placeholder"
+        "node",
+        "packages/scripts/voice-stage-b-eval.mjs"
       ],
       "evidence": [
-        ".github/issue-evidence/9147-voice-asr-m4max.md"
+        "$ELIZA_VOICE_MATRIX_OUT/stt.stage-b.evaluation/stage-b-eval.json",
+        "$ELIZA_VOICE_STAGE_B_REPORT"
       ],
       "probe": {
         "available": false,
-        "reason": "Stage-B STT battery/latency evaluation needs paired iOS+Android device runners and power telemetry"
+        "reason": "ELIZA_VOICE_STAGE_B_REPORT is not set to a reviewed iOS+Android+fused ASR Stage-B JSON report"
       },
       "cwd": ".",
       "env": {},

--- a/.github/issue-evidence/9958-voice-matrix/voice-matrix.md
+++ b/.github/issue-evidence/9958-voice-matrix/voice-matrix.md
@@ -1,31 +1,32 @@
 # Voice Live Matrix
 
-Generated: 2026-06-30T00:39:27.069Z
+Generated: 2026-06-30T07:13:48.071Z
 Host: darwin arm64 (Shaws-MacBook-Pro.local)
 
 | Cell | Status | Platform | Class | Probe / Result | Command |
 |---|---:|---|---|---|---|
 | `web.fake-mic.roundtrip` | pending | web | live-client-audio-barge-in | Chromium fake-device mic lane is host-runnable | `bun run --cwd packages/app test:e2e test/ui-smoke/voice-realaudio.spec.ts` |
-| `web.fake-mic.transcript-roundtrip` | pending | web | transcripts-roundtrip-agent-action-parity | Chromium fake-device mic lane is host-runnable | `bun run --cwd packages/app test:e2e test/ui-smoke/transcript-realaudio.spec.ts` |
+| `web.fake-mic.transcript-roundtrip` | pending | web | transcripts-roundtrip-voice-control-bridge-parity | Chromium fake-device mic lane is host-runnable | `bun run --cwd packages/app test:e2e test/ui-smoke/transcript-realaudio.spec.ts` |
 | `web.workbench.respond-no-respond` | pending | web | chime-in-matrix | Chromium fake-device mic lane is host-runnable | `bun run --cwd packages/app test:e2e test/ui-smoke/voice-workbench-respond-no-respond.spec.ts` |
 | `linux.fused-acoustic.workbench-real` | skip | linux | real-acoustic-workbench | requires Linux runner; current=darwin | `bun run --cwd plugins/plugin-local-inference voice:workbench --real` |
 | `linux.fused-acoustic.barge-in` | skip | linux | barge-in | requires Linux runner; current=darwin | `bun run --cwd plugins/plugin-local-inference voice:bargein-bench` |
-| `macos.electrobun.live-roundtrip` | skip | macos-electrobun | desktop-live-voice | set ELIZA_VOICE_MACOS_ELECTROBUN_READY=1 on a macOS Electrobun voice runner with loopback mic/audio capture | `bun run --cwd packages/app capture:macos-desktop -- --issue 9958 --slug voice-macos-electrobun` |
-| `windows.electrobun.live-roundtrip` | skip | windows-electrobun | desktop-live-voice | requires Windows runner; current=darwin | `bun run --cwd packages/app capture:windows-desktop -- --issue 9958 --slug voice-windows-electrobun` |
-| `ios.sim-or-device.voice-roundtrip` | skip | ios | mobile-live-voice | set ELIZA_VOICE_IOS_READY=1 after installing a current iOS simulator/device build with voice assets | `bun run --cwd packages/app capture:ios-sim -- --issue 9958 --slug voice-ios` |
+| `macos.electrobun.live-roundtrip` | skip | macos-electrobun | desktop-live-voice | set ELIZA_VOICE_MACOS_ELECTROBUN_READY=1 on a macOS Electrobun voice runner with loopback mic/audio capture | `bun run --cwd packages/app test:desktop:voice` |
+| `windows.electrobun.live-roundtrip` | skip | windows-electrobun | desktop-live-voice | requires Windows runner; current=darwin | `bun run --cwd packages/app test:desktop:voice` |
+| `ios.sim-or-device.voice-roundtrip` | skip | ios | mobile-live-voice | set ELIZA_VOICE_IOS_READY=1 after booting an iOS simulator and installing the current app build with voice assets | `bun run --cwd packages/app capture:ios-sim -- --issue 9958 --slug voice-ios` |
 | `ios.talkmode.native-bridge` | pending | ios | native-bridge-unit | macOS Swift Package test toolchain is available | `swift test --disable-index-store --package-path plugins/plugin-native-talkmode/ios` |
 | `ios.swabble.native-bridge` | pending | ios | native-bridge-unit | macOS Swift Package test toolchain is available | `swift test --disable-index-store --package-path plugins/plugin-native-swabble/ios` |
 | `android.device.voice-roundtrip` | skip | android | mobile-live-voice | set ELIZA_VOICE_ANDROID_READY=1 on an Android device runner with the current APK and voice assets installed | `bun run --cwd packages/app test:e2e:android:local` |
 | `android.talkmode.native-bridge` | pending | android | native-bridge-unit | Android voice bridge Gradle project exists | `./gradlew -p ../../../scripts/android-voice-bridge-gradle :elizaos-capacitor-talkmode:testDebugUnitTest` |
 | `android.swabble.native-bridge` | pending | android | native-bridge-unit | Android voice bridge Gradle project exists | `./gradlew -p ../../../scripts/android-voice-bridge-gradle :elizaos-capacitor-swabble:testDebugUnitTest` |
-| `wake.openwakeword.real-head` | skip | linux | wakeword-device-gap | ELIZA_OPENWAKEWORD_REAL_READY is not set for a real wake-word head run | `bun run --cwd plugins/plugin-local-inference voice:workbench --real` |
-| `stt.stage-b.evaluation` | skip | android | stt-evaluation | Stage-B STT battery/latency evaluation needs paired iOS+Android device runners and power telemetry | `bun packages/scripts/voice-matrix.mjs --stage-b-eval-placeholder` |
+| `wake.openwakeword.real-head` | skip | linux | wakeword-device-gap | ELIZA_VOICE_OPENWAKEWORD_REPORT is not set to a reviewed real-head openWakeWord JSON report | `node packages/scripts/voice-openwakeword-eval.mjs` |
+| `stt.stage-b.apple-sfspeech` | pending | macos-electrobun | stt-evaluation | macOS on-device SFSpeechRecognizer + say/afconvert available for a real Stage-B latency/WER measurement | `node packages/scripts/stage-b-stt-bench.mjs` |
+| `stt.stage-b.evaluation` | skip | android | stt-evaluation | ELIZA_VOICE_STAGE_B_REPORT is not set to a reviewed iOS+Android+fused ASR Stage-B JSON report | `node packages/scripts/voice-stage-b-eval.mjs` |
 
 ## Summary
 
 - Pass: 0
 - Fail: 0
-- Pending: 7
+- Pending: 8
 - Skip: 8
 
 Hardware-unavailable cells are explicit `skip` rows. They are not evidence of platform coverage.

--- a/.github/issue-evidence/9958-voice-openwakeword-contract/README.md
+++ b/.github/issue-evidence/9958-voice-openwakeword-contract/README.md
@@ -1,0 +1,37 @@
+# Issue 9958 openWakeWord Evidence Contract
+
+This bundle proves the `wake.openwakeword.real-head` matrix cell no longer runs a
+broad workbench command as a stand-in for real wake-context evidence.
+
+Command:
+
+```bash
+bun run voice:matrix -- --run --platform wake.openwakeword.real-head --out .github/issue-evidence/9958-voice-openwakeword-contract
+```
+
+Result:
+
+- `pass=0`
+- `fail=0`
+- `pending=0`
+- `skip=1`
+
+The skip is expected on this host because `ELIZA_VOICE_OPENWAKEWORD_REPORT` is
+not set. A future hardware run must provide a reviewed report using schema
+`eliza_voice_openwakeword_eval_v1` and covering:
+
+- `idle-wake`
+- `already-listening-wake-inert`
+- `mid-transcription-wake`
+
+Manual review:
+
+- Reviewed `voice-matrix.json`; the selected cell is a skip with the explicit
+  missing-report reason and points at `packages/scripts/voice-openwakeword-eval.mjs`.
+- Reviewed `voice-matrix.md`; the rendered summary matches the JSON counts.
+- Reviewed `index.html`; it renders the same selected cell, dimensions, command,
+  and missing-report reason.
+
+This is not live openWakeWord hardware coverage. It is the contract evidence
+that prevents the wakeword residual in #9958 from going green without reviewed
+real-head artifacts.

--- a/.github/issue-evidence/9958-voice-openwakeword-contract/index.html
+++ b/.github/issue-evidence/9958-voice-openwakeword-contract/index.html
@@ -12,7 +12,7 @@ th{background:#f1f1f1;text-align:left}
 code{font-size:12px}
 </style>
 <h1>Voice Live Matrix</h1>
-<p>Generated 2026-06-30T05:19:32.582Z on darwin arm64 (Mac.localdomain).</p>
+<p>Generated 2026-06-30T05:28:35.152Z on darwin arm64 (Mac.localdomain).</p>
 <p>Pass 0 · Fail 0 · Pending 0 · Skip 1</p>
 <table><thead><tr><th>Cell</th><th>Status</th><th>Platform</th><th>Class</th><th>Dimensions</th><th>Probe / Result</th><th>Command</th><th>Evidence</th></tr></thead><tbody><tr class="skip"><td><code>wake.openwakeword.real-head</code><br>Real openWakeWord head wake-context cells</td><td>skip</td><td>linux</td><td>wakeword-device-gap</td><td>transcriptionState=on
 chimeIn=should-not-respond

--- a/.github/issue-evidence/9958-voice-openwakeword-contract/index.html
+++ b/.github/issue-evidence/9958-voice-openwakeword-contract/index.html
@@ -12,7 +12,7 @@ th{background:#f1f1f1;text-align:left}
 code{font-size:12px}
 </style>
 <h1>Voice Live Matrix</h1>
-<p>Generated 2026-06-30T05:28:35.152Z on darwin arm64 (Mac.localdomain).</p>
+<p>Generated 2026-06-30T06:23:37.951Z on darwin arm64 (Shaws-MacBook-Pro.local).</p>
 <p>Pass 0 · Fail 0 · Pending 0 · Skip 1</p>
 <table><thead><tr><th>Cell</th><th>Status</th><th>Platform</th><th>Class</th><th>Dimensions</th><th>Probe / Result</th><th>Command</th><th>Evidence</th></tr></thead><tbody><tr class="skip"><td><code>wake.openwakeword.real-head</code><br>Real openWakeWord head wake-context cells</td><td>skip</td><td>linux</td><td>wakeword-device-gap</td><td>transcriptionState=on
 chimeIn=should-not-respond

--- a/.github/issue-evidence/9958-voice-openwakeword-contract/index.html
+++ b/.github/issue-evidence/9958-voice-openwakeword-contract/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Voice Live Matrix</title>
+<style>
+body{font-family:system-ui,-apple-system,Segoe UI,sans-serif;margin:24px;background:#fafafa;color:#151515}
+table{width:100%;border-collapse:collapse;background:white}
+th,td{border:1px solid #ddd;padding:8px;vertical-align:top;white-space:pre-wrap}
+th{background:#f1f1f1;text-align:left}
+.pass td:nth-child(2){color:#116b2d;font-weight:700}
+.fail td:nth-child(2){color:#9a1b1b;font-weight:700}
+.skip td:nth-child(2),.pending td:nth-child(2){color:#7a5b00;font-weight:700}
+code{font-size:12px}
+</style>
+<h1>Voice Live Matrix</h1>
+<p>Generated 2026-06-30T05:19:32.582Z on darwin arm64 (Mac.localdomain).</p>
+<p>Pass 0 · Fail 0 · Pending 0 · Skip 1</p>
+<table><thead><tr><th>Cell</th><th>Status</th><th>Platform</th><th>Class</th><th>Dimensions</th><th>Probe / Result</th><th>Command</th><th>Evidence</th></tr></thead><tbody><tr class="skip"><td><code>wake.openwakeword.real-head</code><br>Real openWakeWord head wake-context cells</td><td>skip</td><td>linux</td><td>wakeword-device-gap</td><td>transcriptionState=on
+chimeIn=should-not-respond
+wakewordContext=mid-transcription-wake
+noiseRejection=overlapping-speech
+voices=multi-speaker</td><td>ELIZA_VOICE_OPENWAKEWORD_REPORT is not set to a reviewed real-head openWakeWord JSON report</td><td><code>node packages/scripts/voice-openwakeword-eval.mjs</code></td><td>$ELIZA_VOICE_MATRIX_OUT/wake.openwakeword.real-head/openwakeword-eval.json
+$ELIZA_VOICE_OPENWAKEWORD_REPORT</td></tr></tbody></table>

--- a/.github/issue-evidence/9958-voice-openwakeword-contract/voice-matrix.json
+++ b/.github/issue-evidence/9958-voice-openwakeword-contract/voice-matrix.json
@@ -1,0 +1,85 @@
+{
+  "schema": "eliza_voice_live_matrix_v1",
+  "issue": 9958,
+  "generatedAt": "2026-06-30T05:19:32.582Z",
+  "mode": "run",
+  "dimensions": {
+    "platform": [
+      "web",
+      "linux",
+      "macos-electrobun",
+      "windows-electrobun",
+      "ios",
+      "android"
+    ],
+    "transcriptionState": [
+      "off",
+      "on"
+    ],
+    "chimeIn": [
+      "should-respond",
+      "should-not-respond"
+    ],
+    "wakewordContext": [
+      "idle-wake",
+      "already-listening-wake-inert",
+      "mid-transcription-wake"
+    ],
+    "noiseRejection": [
+      "quiet",
+      "noisy-reverberant",
+      "echo-self-voice",
+      "overlapping-speech"
+    ],
+    "voices": [
+      "owner",
+      "enrolled-contact",
+      "unknown",
+      "multi-speaker"
+    ]
+  },
+  "host": {
+    "platform": "darwin",
+    "arch": "arm64",
+    "hostname": "Mac.localdomain",
+    "runnerOs": null,
+    "runnerArch": null
+  },
+  "summary": {
+    "pass": 0,
+    "fail": 0,
+    "pending": 0,
+    "skip": 1
+  },
+  "cells": [
+    {
+      "id": "wake.openwakeword.real-head",
+      "title": "Real openWakeWord head wake-context cells",
+      "platform": "linux",
+      "dimensions": {
+        "transcriptionState": "on",
+        "chimeIn": "should-not-respond",
+        "wakewordContext": "mid-transcription-wake",
+        "noiseRejection": "overlapping-speech",
+        "voices": "multi-speaker"
+      },
+      "class": "wakeword-device-gap",
+      "command": [
+        "node",
+        "packages/scripts/voice-openwakeword-eval.mjs"
+      ],
+      "evidence": [
+        "$ELIZA_VOICE_MATRIX_OUT/wake.openwakeword.real-head/openwakeword-eval.json",
+        "$ELIZA_VOICE_OPENWAKEWORD_REPORT"
+      ],
+      "probe": {
+        "available": false,
+        "reason": "ELIZA_VOICE_OPENWAKEWORD_REPORT is not set to a reviewed real-head openWakeWord JSON report"
+      },
+      "cwd": ".",
+      "env": {},
+      "execution": null,
+      "status": "skip"
+    }
+  ]
+}

--- a/.github/issue-evidence/9958-voice-openwakeword-contract/voice-matrix.json
+++ b/.github/issue-evidence/9958-voice-openwakeword-contract/voice-matrix.json
@@ -1,7 +1,7 @@
 {
   "schema": "eliza_voice_live_matrix_v1",
   "issue": 9958,
-  "generatedAt": "2026-06-30T05:28:35.152Z",
+  "generatedAt": "2026-06-30T06:23:37.951Z",
   "mode": "run",
   "dimensions": {
     "platform": [
@@ -41,7 +41,7 @@
   "host": {
     "platform": "darwin",
     "arch": "arm64",
-    "hostname": "Mac.localdomain",
+    "hostname": "Shaws-MacBook-Pro.local",
     "runnerOs": null,
     "runnerArch": null
   },

--- a/.github/issue-evidence/9958-voice-openwakeword-contract/voice-matrix.json
+++ b/.github/issue-evidence/9958-voice-openwakeword-contract/voice-matrix.json
@@ -1,7 +1,7 @@
 {
   "schema": "eliza_voice_live_matrix_v1",
   "issue": 9958,
-  "generatedAt": "2026-06-30T05:19:32.582Z",
+  "generatedAt": "2026-06-30T05:28:35.152Z",
   "mode": "run",
   "dimensions": {
     "platform": [

--- a/.github/issue-evidence/9958-voice-openwakeword-contract/voice-matrix.md
+++ b/.github/issue-evidence/9958-voice-openwakeword-contract/voice-matrix.md
@@ -1,0 +1,17 @@
+# Voice Live Matrix
+
+Generated: 2026-06-30T05:19:32.582Z
+Host: darwin arm64 (Mac.localdomain)
+
+| Cell | Status | Platform | Class | Probe / Result | Command |
+|---|---:|---|---|---|---|
+| `wake.openwakeword.real-head` | skip | linux | wakeword-device-gap | ELIZA_VOICE_OPENWAKEWORD_REPORT is not set to a reviewed real-head openWakeWord JSON report | `node packages/scripts/voice-openwakeword-eval.mjs` |
+
+## Summary
+
+- Pass: 0
+- Fail: 0
+- Pending: 0
+- Skip: 1
+
+Hardware-unavailable cells are explicit `skip` rows. They are not evidence of platform coverage.

--- a/.github/issue-evidence/9958-voice-openwakeword-contract/voice-matrix.md
+++ b/.github/issue-evidence/9958-voice-openwakeword-contract/voice-matrix.md
@@ -1,7 +1,7 @@
 # Voice Live Matrix
 
-Generated: 2026-06-30T05:28:35.152Z
-Host: darwin arm64 (Mac.localdomain)
+Generated: 2026-06-30T06:23:37.951Z
+Host: darwin arm64 (Shaws-MacBook-Pro.local)
 
 | Cell | Status | Platform | Class | Probe / Result | Command |
 |---|---:|---|---|---|---|

--- a/.github/issue-evidence/9958-voice-openwakeword-contract/voice-matrix.md
+++ b/.github/issue-evidence/9958-voice-openwakeword-contract/voice-matrix.md
@@ -1,6 +1,6 @@
 # Voice Live Matrix
 
-Generated: 2026-06-30T05:19:32.582Z
+Generated: 2026-06-30T05:28:35.152Z
 Host: darwin arm64 (Mac.localdomain)
 
 | Cell | Status | Platform | Class | Probe / Result | Command |

--- a/.github/issue-evidence/9958-voice-stage-b-contract/index.html
+++ b/.github/issue-evidence/9958-voice-stage-b-contract/index.html
@@ -12,7 +12,7 @@ th{background:#f1f1f1;text-align:left}
 code{font-size:12px}
 </style>
 <h1>Voice Live Matrix</h1>
-<p>Generated 2026-06-30T05:28:35.152Z on darwin arm64 (Mac.localdomain).</p>
+<p>Generated 2026-06-30T06:23:38.110Z on darwin arm64 (Shaws-MacBook-Pro.local).</p>
 <p>Pass 0 · Fail 0 · Pending 0 · Skip 1</p>
 <table><thead><tr><th>Cell</th><th>Status</th><th>Platform</th><th>Class</th><th>Dimensions</th><th>Probe / Result</th><th>Command</th><th>Evidence</th></tr></thead><tbody><tr class="skip"><td><code>stt.stage-b.evaluation</code><br>Stage-B STT evaluation: iOS battery/energy + Android SpeechRecognizer (NNAPI) vs fused ASR</td><td>skip</td><td>android</td><td>stt-evaluation</td><td>transcriptionState=on
 chimeIn=should-respond

--- a/.github/issue-evidence/9958-voice-stage-b-contract/index.html
+++ b/.github/issue-evidence/9958-voice-stage-b-contract/index.html
@@ -12,9 +12,9 @@ th{background:#f1f1f1;text-align:left}
 code{font-size:12px}
 </style>
 <h1>Voice Live Matrix</h1>
-<p>Generated 2026-06-30T04:18:57.849Z on darwin arm64 (Mac.localdomain).</p>
+<p>Generated 2026-06-30T05:28:35.152Z on darwin arm64 (Mac.localdomain).</p>
 <p>Pass 0 · Fail 0 · Pending 0 · Skip 1</p>
-<table><thead><tr><th>Cell</th><th>Status</th><th>Platform</th><th>Class</th><th>Dimensions</th><th>Probe / Result</th><th>Command</th><th>Evidence</th></tr></thead><tbody><tr class="skip"><td><code>stt.stage-b.evaluation</code><br>Stage-B STT evaluation: iOS SFSpeechRecognizer vs Android SpeechRecognizer vs fused ASR</td><td>skip</td><td>android</td><td>stt-evaluation</td><td>transcriptionState=on
+<table><thead><tr><th>Cell</th><th>Status</th><th>Platform</th><th>Class</th><th>Dimensions</th><th>Probe / Result</th><th>Command</th><th>Evidence</th></tr></thead><tbody><tr class="skip"><td><code>stt.stage-b.evaluation</code><br>Stage-B STT evaluation: iOS battery/energy + Android SpeechRecognizer (NNAPI) vs fused ASR</td><td>skip</td><td>android</td><td>stt-evaluation</td><td>transcriptionState=on
 chimeIn=should-respond
 wakewordContext=idle-wake
 noiseRejection=noisy-reverberant

--- a/.github/issue-evidence/9958-voice-stage-b-contract/voice-matrix.json
+++ b/.github/issue-evidence/9958-voice-stage-b-contract/voice-matrix.json
@@ -1,7 +1,7 @@
 {
   "schema": "eliza_voice_live_matrix_v1",
   "issue": 9958,
-  "generatedAt": "2026-06-30T05:28:35.152Z",
+  "generatedAt": "2026-06-30T06:23:38.110Z",
   "mode": "run",
   "dimensions": {
     "platform": [
@@ -41,7 +41,7 @@
   "host": {
     "platform": "darwin",
     "arch": "arm64",
-    "hostname": "Mac.localdomain",
+    "hostname": "Shaws-MacBook-Pro.local",
     "runnerOs": null,
     "runnerArch": null
   },

--- a/.github/issue-evidence/9958-voice-stage-b-contract/voice-matrix.json
+++ b/.github/issue-evidence/9958-voice-stage-b-contract/voice-matrix.json
@@ -1,7 +1,7 @@
 {
   "schema": "eliza_voice_live_matrix_v1",
   "issue": 9958,
-  "generatedAt": "2026-06-30T04:18:57.849Z",
+  "generatedAt": "2026-06-30T05:28:35.152Z",
   "mode": "run",
   "dimensions": {
     "platform": [
@@ -54,7 +54,7 @@
   "cells": [
     {
       "id": "stt.stage-b.evaluation",
-      "title": "Stage-B STT evaluation: iOS SFSpeechRecognizer vs Android SpeechRecognizer vs fused ASR",
+      "title": "Stage-B STT evaluation: iOS battery/energy + Android SpeechRecognizer (NNAPI) vs fused ASR",
       "platform": "android",
       "dimensions": {
         "transcriptionState": "on",

--- a/.github/issue-evidence/9958-voice-stage-b-contract/voice-matrix.md
+++ b/.github/issue-evidence/9958-voice-stage-b-contract/voice-matrix.md
@@ -1,6 +1,6 @@
 # Voice Live Matrix
 
-Generated: 2026-06-30T04:18:57.849Z
+Generated: 2026-06-30T05:28:35.152Z
 Host: darwin arm64 (Mac.localdomain)
 
 | Cell | Status | Platform | Class | Probe / Result | Command |

--- a/.github/issue-evidence/9958-voice-stage-b-contract/voice-matrix.md
+++ b/.github/issue-evidence/9958-voice-stage-b-contract/voice-matrix.md
@@ -1,7 +1,7 @@
 # Voice Live Matrix
 
-Generated: 2026-06-30T05:28:35.152Z
-Host: darwin arm64 (Mac.localdomain)
+Generated: 2026-06-30T06:23:38.110Z
+Host: darwin arm64 (Shaws-MacBook-Pro.local)
 
 | Cell | Status | Platform | Class | Probe / Result | Command |
 |---|---:|---|---|---|---|

--- a/.github/workflows/voice-live-e2e.yml
+++ b/.github/workflows/voice-live-e2e.yml
@@ -423,6 +423,8 @@ jobs:
     timeout-minutes: 90
     env:
       ELIZA_VOICE_MACOS_ELECTROBUN_READY: ${{ vars.ELIZA_VOICE_MACOS_ELECTROBUN_READY }}
+      ELIZA_TEST_PACKAGED_LAUNCHER_PATH: ${{ vars.ELIZA_TEST_PACKAGED_LAUNCHER_PATH }}
+      ELIZA_VOICE_DESKTOP_API_BASE: ${{ vars.ELIZA_VOICE_DESKTOP_API_BASE }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -446,7 +448,7 @@ jobs:
       - name: Run macOS Electrobun matrix
         run: |
           set -euo pipefail
-          bun run voice:matrix -- --run --platform macos-electrobun --out "$RUNNER_TEMP/voice-macos-electrobun-matrix"
+          bun run voice:matrix -- --run --require-green --platform macos-electrobun --out "$RUNNER_TEMP/voice-macos-electrobun-matrix"
 
       - name: Upload macOS Electrobun matrix
         if: always()
@@ -463,6 +465,8 @@ jobs:
     timeout-minutes: 90
     env:
       ELIZA_VOICE_WINDOWS_ELECTROBUN_READY: ${{ vars.ELIZA_VOICE_WINDOWS_ELECTROBUN_READY }}
+      ELIZA_TEST_PACKAGED_LAUNCHER_PATH: ${{ vars.ELIZA_TEST_PACKAGED_LAUNCHER_PATH }}
+      ELIZA_VOICE_DESKTOP_API_BASE: ${{ vars.ELIZA_VOICE_DESKTOP_API_BASE }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -487,7 +491,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          bun run voice:matrix -- --run --platform windows-electrobun --out "$RUNNER_TEMP/voice-windows-electrobun-matrix"
+          bun run voice:matrix -- --run --require-green --platform windows-electrobun --out "$RUNNER_TEMP/voice-windows-electrobun-matrix"
 
       - name: Upload Windows Electrobun matrix
         if: always()
@@ -504,6 +508,8 @@ jobs:
     timeout-minutes: 90
     env:
       ELIZA_VOICE_IOS_READY: ${{ vars.ELIZA_VOICE_IOS_READY }}
+      ELIZA_IOS_APP_ID: ${{ vars.ELIZA_IOS_APP_ID }}
+      ELIZA_VOICE_IOS_APP_ID: ${{ vars.ELIZA_VOICE_IOS_APP_ID }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -527,7 +533,7 @@ jobs:
       - name: Run iOS matrix
         run: |
           set -euo pipefail
-          bun run voice:matrix -- --run --platform ios --out "$RUNNER_TEMP/voice-ios-matrix"
+          bun run voice:matrix -- --run --require-green --platform ios --out "$RUNNER_TEMP/voice-ios-matrix"
 
       - name: Upload iOS matrix
         if: always()
@@ -544,6 +550,7 @@ jobs:
     timeout-minutes: 120
     env:
       ELIZA_VOICE_ANDROID_READY: ${{ vars.ELIZA_VOICE_ANDROID_READY }}
+      ELIZA_VOICE_STAGE_B_REPORT: ${{ vars.ELIZA_VOICE_STAGE_B_REPORT }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -570,7 +577,7 @@ jobs:
       - name: Run Android matrix
         run: |
           set -euo pipefail
-          bun run voice:matrix -- --run --platform android --out "$RUNNER_TEMP/voice-android-matrix"
+          bun run voice:matrix -- --run --require-green --platform android --out "$RUNNER_TEMP/voice-android-matrix"
 
       - name: Upload Android matrix
         if: always()

--- a/.github/workflows/voice-live-e2e.yml
+++ b/.github/workflows/voice-live-e2e.yml
@@ -550,6 +550,8 @@ jobs:
     timeout-minutes: 120
     env:
       ELIZA_VOICE_ANDROID_READY: ${{ vars.ELIZA_VOICE_ANDROID_READY }}
+      ELIZA_ANDROID_APP_ID: ${{ vars.ELIZA_ANDROID_APP_ID }}
+      ELIZA_VOICE_ANDROID_APP_ID: ${{ vars.ELIZA_VOICE_ANDROID_APP_ID }}
       ELIZA_VOICE_STAGE_B_REPORT: ${{ vars.ELIZA_VOICE_STAGE_B_REPORT }}
     steps:
       - name: Checkout

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -31,11 +31,11 @@ import {
   startMemorySampler,
 } from "./boot-telemetry.ts";
 import { BootTimer } from "./boot-timer.ts";
-import { startMemoryWatchdog } from "./memory-watchdog.ts";
 // Dev/test-only crash/hang injection (#10203). No-op unless ELIZA_CRASH_INJECT
 // is armed, and it refuses to arm in production — see crash-injection.ts.
 import { maybeInjectFault } from "./crash-injection.ts";
 import { runFirstTimeSetup } from "./first-time-setup.ts";
+import { startMemoryWatchdog } from "./memory-watchdog.ts";
 import { resolveConfigEnvForProcess } from "./operations/vault-bridge.ts";
 import {
   type PluginResolutionPhase,

--- a/packages/scripts/__tests__/voice-openwakeword-eval.test.ts
+++ b/packages/scripts/__tests__/voice-openwakeword-eval.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  OPENWAKEWORD_SCHEMA,
+  validateOpenWakeWordReport,
+} from "../lib/voice-openwakeword-eval.mjs";
+
+async function makeArtifact(root: string, caseId: string, name: string) {
+  const artifactPath = path.join(root, "artifacts", caseId, name);
+  await fs.mkdir(path.dirname(artifactPath), { recursive: true });
+  await fs.writeFile(artifactPath, `${caseId} ${name}\n`);
+  return path.relative(root, artifactPath);
+}
+
+async function validRun(
+  root: string,
+  caseId: string,
+  observations: Record<string, unknown>,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    case: caseId,
+    platform: "android",
+    realHardware: true,
+    realHead: true,
+    device: { name: "Pixel voice device", osVersion: "Android test" },
+    build: { gitSha: "0123456789abcdef" },
+    openWakeWord: { model: "hey-eliza", threshold: 0.62 },
+    audio: { source: "speaker-to-mic", durationSeconds: 45 },
+    observations,
+    artifacts: [
+      {
+        kind: "log",
+        path: await makeArtifact(root, caseId, "run.log"),
+        reviewed: true,
+      },
+      {
+        kind: "recording",
+        path: await makeArtifact(root, caseId, "screen-audio.txt"),
+        reviewed: true,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+async function validReport(root: string) {
+  return {
+    schema: OPENWAKEWORD_SCHEMA,
+    issue: 9958,
+    capturedAt: "2026-06-30T05:00:00.000Z",
+    realHardware: true,
+    realHead: true,
+    build: { gitSha: "0123456789abcdef" },
+    runs: [
+      await validRun(root, "idle-wake", {
+        wakeEvents: 1,
+        listenWindowOpened: true,
+        latencyMs: 320,
+      }),
+      await validRun(root, "already-listening-wake-inert", {
+        wakeEvents: 1,
+        listenWindowOpened: false,
+        duplicateWindowCount: 0,
+      }),
+      await validRun(root, "mid-transcription-wake", {
+        wakeEvents: 1,
+        transcriptCorrupted: false,
+        droppedTokens: 0,
+      }),
+    ],
+  };
+}
+
+describe("voice openWakeWord real-head validator", () => {
+  test("accepts a reviewed real three-case report", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openwakeword-ok-"));
+    const report = await validReport(root);
+    const result = validateOpenWakeWordReport(report, {
+      reportPath: path.join(root, "report.json"),
+      repoRoot: root,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.summary.checkedCases).toEqual([
+      "idle-wake",
+      "already-listening-wake-inert",
+      "mid-transcription-wake",
+    ]);
+  });
+
+  test("rejects mock reports and missing wake-context cases", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openwakeword-mock-"));
+    const report = await validReport(root);
+    report.mocked = true;
+    report.runs = report.runs.filter((run) => run.case !== "idle-wake");
+
+    const result = validateOpenWakeWordReport(report, {
+      reportPath: path.join(root, "report.json"),
+      repoRoot: root,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain(
+      "report must not be marked mocked/synthetic",
+    );
+    expect(result.errors).toContain(
+      "missing required openWakeWord case idle-wake (idle wake opens the listen window)",
+    );
+  });
+
+  test("rejects unreviewed artifacts and contradictory observations", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openwakeword-bad-"));
+    const report = await validReport(root);
+    const inertRun = report.runs[1];
+    inertRun.observations.listenWindowOpened = true;
+    inertRun.observations.duplicateWindowCount = 1;
+    inertRun.artifacts[0].reviewed = false;
+
+    const result = validateOpenWakeWordReport(report, {
+      reportPath: path.join(root, "report.json"),
+      repoRoot: root,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain(
+      "runs[1] already-listening-wake-inert.observations.listenWindowOpened must be false",
+    );
+    expect(result.errors).toContain(
+      "runs[1] already-listening-wake-inert.observations.duplicateWindowCount must be 0",
+    );
+    expect(result.errors).toContain(
+      "runs[1] already-listening-wake-inert.artifacts[0].reviewed must be true after manual review",
+    );
+  });
+});

--- a/packages/scripts/lib/voice-openwakeword-eval.mjs
+++ b/packages/scripts/lib/voice-openwakeword-eval.mjs
@@ -1,0 +1,435 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export const OPENWAKEWORD_SCHEMA = "eliza_voice_openwakeword_eval_v1";
+export const OPENWAKEWORD_ISSUE = "9958";
+
+export const REQUIRED_OPENWAKEWORD_CASES = [
+  {
+    caseId: "idle-wake",
+    label: "idle wake opens the listen window",
+    checks: ["wakeEvents", "listenWindowOpened", "latencyMs"],
+  },
+  {
+    caseId: "already-listening-wake-inert",
+    label: "wake while already listening is inert",
+    checks: ["wakeEvents", "listenWindowOpenedFalse", "duplicateWindowCount"],
+  },
+  {
+    caseId: "mid-transcription-wake",
+    label: "wake during transcription does not corrupt transcript",
+    checks: ["wakeEvents", "transcriptCorruptedFalse", "droppedTokens"],
+  },
+];
+
+const ALLOWED_PLATFORMS = new Set([
+  "android",
+  "linux",
+  "macos",
+  "macos-electrobun",
+]);
+const AUDIO_SOURCES = new Set([
+  "device-mic",
+  "speaker-to-mic",
+  "hardware-loopback",
+  "real-fixture-replay",
+]);
+
+function isObject(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function getNumber(source, keys) {
+  if (!isObject(source)) return undefined;
+  for (const key of keys) {
+    const value = source[key];
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+    if (typeof value === "string" && value.trim()) {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed)) return parsed;
+    }
+  }
+  return undefined;
+}
+
+function getString(source, keys) {
+  if (!isObject(source)) return undefined;
+  for (const key of keys) {
+    const value = source[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return undefined;
+}
+
+function pushNumberError(errors, label, value, predicate, hint) {
+  if (
+    typeof value !== "number" ||
+    !Number.isFinite(value) ||
+    !predicate(value)
+  ) {
+    errors.push(`${label} must be ${hint}`);
+  }
+}
+
+function isUrl(value) {
+  return /^https?:\/\//i.test(value);
+}
+
+function artifactPathExists(artifactPath, reportPath, repoRoot) {
+  if (isUrl(artifactPath)) return true;
+  const candidates = [];
+  if (path.isAbsolute(artifactPath)) candidates.push(artifactPath);
+  else {
+    if (reportPath)
+      candidates.push(path.resolve(path.dirname(reportPath), artifactPath));
+    if (repoRoot) candidates.push(path.resolve(repoRoot, artifactPath));
+    candidates.push(path.resolve(process.cwd(), artifactPath));
+  }
+  return candidates.some((candidate) => fs.existsSync(candidate));
+}
+
+function validateIsoTimestamp(errors, label, value) {
+  if (typeof value !== "string" || Number.isNaN(Date.parse(value))) {
+    errors.push(`${label} must be an ISO timestamp`);
+  }
+}
+
+function validateArtifact(errors, artifact, context) {
+  if (!isObject(artifact)) {
+    errors.push(
+      `${context.label}.artifacts[${context.index}] must be an object`,
+    );
+    return;
+  }
+  const artifactKind = getString(artifact, ["kind", "type"]);
+  const artifactPath = getString(artifact, ["path", "href", "url"]);
+  if (!artifactKind) {
+    errors.push(
+      `${context.label}.artifacts[${context.index}].kind is required`,
+    );
+  }
+  if (!artifactPath) {
+    errors.push(
+      `${context.label}.artifacts[${context.index}].path is required`,
+    );
+  } else if (
+    !artifactPathExists(artifactPath, context.reportPath, context.repoRoot)
+  ) {
+    errors.push(
+      `${context.label}.artifacts[${context.index}].path does not exist: ${artifactPath}`,
+    );
+  }
+  if (artifact.reviewed !== true) {
+    errors.push(
+      `${context.label}.artifacts[${context.index}].reviewed must be true after manual review`,
+    );
+  }
+}
+
+function validateCommonRun(errors, run, requirement, context) {
+  const label = `runs[${context.index}] ${requirement.caseId}`;
+  if (!isObject(run)) {
+    errors.push(`${label} must be an object`);
+    return null;
+  }
+  if (run.realHardware !== true) {
+    errors.push(`${label}.realHardware must be true`);
+  }
+  if (run.realHead !== true && run.realOpenWakeWordHead !== true) {
+    errors.push(`${label}.realHead must be true`);
+  }
+  if (run.mocked === true || run.synthetic === true) {
+    errors.push(`${label} must not be marked mocked/synthetic`);
+  }
+  if (!ALLOWED_PLATFORMS.has(String(run.platform ?? ""))) {
+    errors.push(
+      `${label}.platform must be one of ${Array.from(ALLOWED_PLATFORMS).join(", ")}`,
+    );
+  }
+
+  const device = isObject(run.device) ? run.device : {};
+  if (!getString(device, ["name", "model", "hardwareModel"])) {
+    errors.push(`${label}.device.name or model is required`);
+  }
+  if (!getString(device, ["osVersion", "runtime", "kernel"])) {
+    errors.push(`${label}.device.osVersion/runtime/kernel is required`);
+  }
+
+  const build = isObject(run.build) ? run.build : context.reportBuild;
+  if (!getString(build, ["gitSha", "sha", "revision"])) {
+    errors.push(`${label}.build.gitSha is required`);
+  }
+
+  const head = isObject(run.openWakeWord)
+    ? run.openWakeWord
+    : isObject(run.wakeHead)
+      ? run.wakeHead
+      : {};
+  if (!getString(head, ["model", "modelName", "head"])) {
+    errors.push(`${label}.openWakeWord.model is required`);
+  }
+  pushNumberError(
+    errors,
+    `${label}.openWakeWord.threshold`,
+    getNumber(head, ["threshold", "scoreThreshold"]),
+    (value) => value > 0 && value <= 1,
+    "between 0 and 1",
+  );
+
+  const audio = isObject(run.audio) ? run.audio : {};
+  const source = getString(audio, ["source"]);
+  if (!source || !AUDIO_SOURCES.has(source)) {
+    errors.push(
+      `${label}.audio.source must be one of ${Array.from(AUDIO_SOURCES).join(", ")}`,
+    );
+  }
+  pushNumberError(
+    errors,
+    `${label}.audio.durationSeconds`,
+    getNumber(audio, ["durationSeconds", "seconds"]),
+    (value) => value > 0,
+    "greater than 0",
+  );
+
+  if (!Array.isArray(run.artifacts) || run.artifacts.length === 0) {
+    errors.push(`${label}.artifacts must list manually reviewed evidence`);
+  } else {
+    run.artifacts.forEach((artifact, artifactIndex) => {
+      validateArtifact(errors, artifact, {
+        index: artifactIndex,
+        label,
+        reportPath: context.reportPath,
+        repoRoot: context.repoRoot,
+      });
+    });
+  }
+
+  return label;
+}
+
+function observationsFor(run) {
+  if (isObject(run.observations)) return run.observations;
+  if (isObject(run.metrics)) return run.metrics;
+  return {};
+}
+
+function validateCaseObservations(errors, run, requirement, context) {
+  const label = validateCommonRun(errors, run, requirement, context);
+  if (!label) return;
+  const observations = observationsFor(run);
+  const wakeEvents = getNumber(observations, [
+    "wakeEvents",
+    "wakeEventCount",
+    "detections",
+  ]);
+  pushNumberError(
+    errors,
+    `${label}.observations.wakeEvents`,
+    wakeEvents,
+    (value) => value >= 1,
+    "at least 1",
+  );
+
+  if (requirement.caseId === "idle-wake") {
+    if (observations.listenWindowOpened !== true) {
+      errors.push(`${label}.observations.listenWindowOpened must be true`);
+    }
+    pushNumberError(
+      errors,
+      `${label}.observations.latencyMs`,
+      getNumber(observations, ["latencyMs", "wakeToListenWindowMs"]),
+      (value) => value > 0,
+      "greater than 0",
+    );
+    return;
+  }
+
+  if (requirement.caseId === "already-listening-wake-inert") {
+    if (observations.listenWindowOpened !== false) {
+      errors.push(`${label}.observations.listenWindowOpened must be false`);
+    }
+    pushNumberError(
+      errors,
+      `${label}.observations.duplicateWindowCount`,
+      getNumber(observations, ["duplicateWindowCount", "extraWindows"]),
+      (value) => value === 0,
+      "0",
+    );
+    return;
+  }
+
+  if (requirement.caseId === "mid-transcription-wake") {
+    if (observations.transcriptCorrupted !== false) {
+      errors.push(`${label}.observations.transcriptCorrupted must be false`);
+    }
+    pushNumberError(
+      errors,
+      `${label}.observations.droppedTokens`,
+      getNumber(observations, ["droppedTokens", "droppedTokenCount"]),
+      (value) => value === 0,
+      "0",
+    );
+  }
+}
+
+export function resolveOpenWakeWordReportPath(env = process.env) {
+  const value = env.ELIZA_VOICE_OPENWAKEWORD_REPORT?.trim();
+  return value ? path.resolve(value) : null;
+}
+
+export function defaultOpenWakeWordOutputDir(
+  env = process.env,
+  repoRoot = process.cwd(),
+) {
+  if (env.ELIZA_VOICE_OPENWAKEWORD_OUT?.trim()) {
+    return path.resolve(env.ELIZA_VOICE_OPENWAKEWORD_OUT.trim());
+  }
+  if (env.ELIZA_VOICE_MATRIX_OUT?.trim()) {
+    return path.resolve(
+      env.ELIZA_VOICE_MATRIX_OUT.trim(),
+      env.ELIZA_VOICE_MATRIX_CELL_ID?.trim() || "wake.openwakeword.real-head",
+    );
+  }
+  return path.resolve(
+    repoRoot,
+    ".github",
+    "issue-evidence",
+    `${OPENWAKEWORD_ISSUE}-voice-openwakeword-evaluation`,
+  );
+}
+
+export function readOpenWakeWordReport(reportPath) {
+  return JSON.parse(fs.readFileSync(reportPath, "utf8"));
+}
+
+export function validateOpenWakeWordReport(report, options = {}) {
+  const errors = [];
+  const warnings = [];
+  const reportPath = options.reportPath
+    ? path.resolve(options.reportPath)
+    : null;
+  const repoRoot = options.repoRoot
+    ? path.resolve(options.repoRoot)
+    : process.cwd();
+
+  if (!isObject(report)) {
+    return {
+      ok: false,
+      errors: ["report must be a JSON object"],
+      warnings,
+      summary: {
+        runCount: 0,
+        requiredCases: REQUIRED_OPENWAKEWORD_CASES.length,
+      },
+    };
+  }
+
+  if (report.schema !== OPENWAKEWORD_SCHEMA) {
+    errors.push(`schema must be ${OPENWAKEWORD_SCHEMA}`);
+  }
+  if (String(report.issue ?? "") !== OPENWAKEWORD_ISSUE) {
+    errors.push(`issue must be ${OPENWAKEWORD_ISSUE}`);
+  }
+  validateIsoTimestamp(errors, "capturedAt", report.capturedAt);
+  if (report.realHardware !== true) errors.push("realHardware must be true");
+  if (report.realHead !== true && report.realOpenWakeWordHead !== true) {
+    errors.push("realHead must be true");
+  }
+  if (report.mocked === true || report.synthetic === true) {
+    errors.push("report must not be marked mocked/synthetic");
+  }
+
+  const runs = Array.isArray(report.runs) ? report.runs : [];
+  if (runs.length === 0) errors.push("runs must contain openWakeWord cases");
+  const runsByCase = new Map();
+  for (const [index, run] of runs.entries()) {
+    const caseId = isObject(run)
+      ? getString(run, ["case", "caseId", "id"])
+      : null;
+    if (!caseId) {
+      errors.push(`runs[${index}].case is required`);
+      continue;
+    }
+    if (runsByCase.has(caseId))
+      errors.push(`runs contains duplicate case ${caseId}`);
+    runsByCase.set(caseId, { run, index });
+  }
+
+  const reportBuild = isObject(report.build) ? report.build : {};
+  for (const requirement of REQUIRED_OPENWAKEWORD_CASES) {
+    const entry = runsByCase.get(requirement.caseId);
+    if (!entry) {
+      errors.push(
+        `missing required openWakeWord case ${requirement.caseId} (${requirement.label})`,
+      );
+      continue;
+    }
+    validateCaseObservations(errors, entry.run, requirement, {
+      index: entry.index,
+      reportPath,
+      repoRoot,
+      reportBuild,
+    });
+  }
+
+  for (const caseId of runsByCase.keys()) {
+    if (
+      !REQUIRED_OPENWAKEWORD_CASES.some(
+        (requirement) => requirement.caseId === caseId,
+      )
+    ) {
+      warnings.push(`ignoring non-required openWakeWord case ${caseId}`);
+    }
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    warnings,
+    summary: {
+      runCount: runs.length,
+      requiredCases: REQUIRED_OPENWAKEWORD_CASES.length,
+      checkedCases: REQUIRED_OPENWAKEWORD_CASES.map(
+        (requirement) => requirement.caseId,
+      ),
+    },
+  };
+}
+
+export function renderOpenWakeWordValidationMarkdown(result, options = {}) {
+  const status = result.ok ? "PASS" : "FAIL";
+  const lines = [
+    "# openWakeWord Real-Head Validation",
+    "",
+    `Status: ${status}`,
+    options.reportPath ? `Report: ${options.reportPath}` : null,
+    "",
+    "## Required Cases",
+    "",
+    "| Case | Expected proof |",
+    "| --- | --- |",
+    ...REQUIRED_OPENWAKEWORD_CASES.map(
+      (item) => `| \`${item.caseId}\` | ${item.label} |`,
+    ),
+    "",
+    "## Result",
+    "",
+    `- Runs checked: ${result.summary.runCount}`,
+    `- Required cases: ${result.summary.requiredCases}`,
+  ].filter((line) => line !== null);
+
+  if (result.errors.length > 0) {
+    lines.push("", "## Errors", "");
+    for (const error of result.errors) lines.push(`- ${error}`);
+  }
+  if (result.warnings.length > 0) {
+    lines.push("", "## Warnings", "");
+    for (const warning of result.warnings) lines.push(`- ${warning}`);
+  }
+  lines.push(
+    "",
+    "A passing report proves only the openWakeWord evidence artifact contract. The referenced recordings, logs, and transcripts still need reviewer inspection.",
+    "",
+  );
+  return lines.join("\n");
+}

--- a/packages/scripts/stage-b-stt-bench.mjs
+++ b/packages/scripts/stage-b-stt-bench.mjs
@@ -344,26 +344,45 @@ function renderMarkdown(report) {
     "  ANE-capable `SFSpeechRecognizer` is the cheapest-correct Stage-B confirm recognizer on Apple.",
   );
   lines.push(
-    "  Kokoro TTS is unchanged. Remaining device handoff: per-frame battery/energy telemetry on a real",
+    "  Kokoro TTS is unchanged. iOS device energy telemetry is not counted as covered by this",
   );
   lines.push(
-    "  iOS device (Instruments Energy Log), which a Mac cannot measure.",
+    "  Apple-Silicon-only artifact; it must be supplied through the strict Stage-B report gate.",
   );
   lines.push(
-    "- **Android:** `SpeechRecognizer` (NNAPI) latency/battery/accept must be measured on a real Android",
+    "- **Android:** `SpeechRecognizer` (NNAPI) latency/battery/accept is not counted as covered by",
   );
-  lines.push("  device — not reachable from this host. Handoff.");
+  lines.push(
+    "  this host artifact; it must be supplied through the strict Stage-B report gate.",
+  );
   lines.push(
     "- **Linux/desktop fused:** the fused libelizainference ASR latency/RTF on the identical corpus is a",
   );
   lines.push(
-    "  runtime handoff (needs the provisioned `libelizainference` bundle; see",
+    "  required report input when the provisioned `libelizainference` bundle is available.",
   );
   lines.push(
-    "  `.github/issue-evidence/9147-voice-asr-m4max.md` for the qualitative on-device transcription proof).",
+    "  Historical qualitative ASR artifacts are not accepted as Stage-B coverage; use",
+  );
+  lines.push(
+    "  `ELIZA_VOICE_STAGE_B_REPORT` with `packages/scripts/voice-stage-b-eval.mjs`.",
   );
   lines.push("");
-  lines.push("## Device handoff (not measurable on this host)");
+  lines.push(
+    "## Strict report gate (not measured by this Apple-only host artifact)",
+  );
+  lines.push("");
+  lines.push(
+    "The complete #9958 Stage-B decision is green only when `voice-stage-b-eval.mjs`",
+  );
+  lines.push(
+    "validates a reviewed JSON report covering iOS `SFSpeechRecognizer`, Android",
+  );
+  lines.push(
+    "`SpeechRecognizer`, and fused ASR with real hardware, latency, WER, and power telemetry.",
+  );
+  lines.push("");
+  lines.push("## Required external measurements");
   lines.push("");
   lines.push("| Arm | Needs | Run |");
   lines.push("|---|---|---|");

--- a/packages/scripts/voice-matrix.mjs
+++ b/packages/scripts/voice-matrix.mjs
@@ -472,6 +472,90 @@ function hasPackagedDesktopLauncher(platform) {
   return false;
 }
 
+function oneLine(text) {
+  return String(text ?? "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function readDefaultIosAppId() {
+  const fromEnv =
+    process.env.ELIZA_VOICE_IOS_APP_ID?.trim() ||
+    process.env.ELIZA_IOS_APP_ID?.trim();
+  if (fromEnv) return fromEnv;
+
+  const appConfigPath = path.join(REPO_ROOT, "packages/app/app.config.ts");
+  try {
+    const source = fs.readFileSync(appConfigPath, "utf8");
+    return source.match(/\bappId:\s*["']([^"']+)["']/)?.[1] ?? "ai.elizaos.app";
+  } catch {
+    return "ai.elizaos.app";
+  }
+}
+
+function simctl(args) {
+  return spawnSync("xcrun", ["simctl", ...args], {
+    encoding: "utf8",
+    maxBuffer: 8 * 1024 * 1024,
+  });
+}
+
+function bootedIosSimulator() {
+  const result = simctl(["list", "devices", "booted", "--json"]);
+  if (result.status !== 0) {
+    const detail = oneLine(result.stderr || result.stdout);
+    return {
+      device: null,
+      reason: `xcrun simctl list devices booted failed${detail ? `: ${detail}` : ""}`,
+    };
+  }
+
+  let json;
+  try {
+    json = JSON.parse(result.stdout || "{}");
+  } catch (error) {
+    return {
+      device: null,
+      reason: `xcrun simctl list devices booted returned invalid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+
+  for (const [runtime, devices] of Object.entries(json.devices ?? {})) {
+    if (!String(runtime).toLowerCase().includes("ios")) continue;
+    for (const device of Array.isArray(devices) ? devices : []) {
+      if (device?.state === "Booted" && device?.udid) {
+        return {
+          device: {
+            udid: device.udid,
+            name: device.name ?? device.udid,
+            runtime,
+          },
+          reason: null,
+        };
+      }
+    }
+  }
+
+  return {
+    device: null,
+    reason:
+      "ELIZA_VOICE_IOS_READY=1 but no booted iOS simulator is available; boot a simulator and install the current app before capture",
+  };
+}
+
+function installedIosAppContainer(udid, appId) {
+  const result = simctl(["get_app_container", udid, appId, "data"]);
+  const containerPath = oneLine(result.stdout);
+  if (result.status === 0 && containerPath) {
+    return { path: containerPath, reason: null };
+  }
+  const detail = oneLine(result.stderr || result.stdout);
+  return {
+    path: null,
+    reason: `ELIZA_VOICE_IOS_READY=1 but ${appId} is not installed on booted simulator ${udid}; build/redeploy the current iOS app before capture${detail ? ` (${detail})` : ""}`,
+  };
+}
+
 function runCapture(command, cwd, extraEnv = {}, context = {}) {
   const startedAt = new Date().toISOString();
   const result = spawnSync(command[0], command.slice(1), {
@@ -622,10 +706,24 @@ function probeCell(cell) {
         return {
           available: false,
           reason:
-            "set ELIZA_VOICE_IOS_READY=1 after installing a current iOS simulator/device build with voice assets",
+            "set ELIZA_VOICE_IOS_READY=1 after booting an iOS simulator and installing the current app build with voice assets",
         };
       }
-      return { available: true, reason: "iOS voice capture runner enabled" };
+      {
+        const booted = bootedIosSimulator();
+        if (!booted.device) {
+          return { available: false, reason: booted.reason };
+        }
+        const appId = readDefaultIosAppId();
+        const container = installedIosAppContainer(booted.device.udid, appId);
+        if (!container.path) {
+          return { available: false, reason: container.reason };
+        }
+        return {
+          available: true,
+          reason: `iOS voice capture runner enabled for ${appId} on ${booted.device.name} (${booted.device.udid})`,
+        };
+      }
     case "swiftPackage":
       if (process.platform !== "darwin")
         return {

--- a/packages/scripts/voice-matrix.mjs
+++ b/packages/scripts/voice-matrix.mjs
@@ -493,11 +493,79 @@ function readDefaultIosAppId() {
   }
 }
 
+function readDefaultAndroidAppId() {
+  const fromEnv =
+    process.env.ELIZA_VOICE_ANDROID_APP_ID?.trim() ||
+    process.env.ELIZA_ANDROID_APP_ID?.trim() ||
+    process.env.ELIZA_APP_ID?.trim();
+  if (fromEnv) return fromEnv;
+
+  const appConfigPath = path.join(REPO_ROOT, "packages/app/app.config.ts");
+  try {
+    const source = fs.readFileSync(appConfigPath, "utf8");
+    return source.match(/\bappId:\s*["']([^"']+)["']/)?.[1] ?? "ai.elizaos.app";
+  } catch {
+    return "ai.elizaos.app";
+  }
+}
+
 function simctl(args) {
   return spawnSync("xcrun", ["simctl", ...args], {
     encoding: "utf8",
     maxBuffer: 8 * 1024 * 1024,
   });
+}
+
+function adb(args) {
+  return spawnSync("adb", args, {
+    encoding: "utf8",
+    maxBuffer: 8 * 1024 * 1024,
+  });
+}
+
+function attachedAndroidDevice() {
+  const result = adb(["devices"]);
+  if (result.status !== 0) {
+    const detail = oneLine(result.stderr || result.stdout);
+    return {
+      serial: null,
+      reason: `adb devices failed${detail ? `: ${detail}` : ""}`,
+    };
+  }
+
+  const rows = String(result.stdout ?? "")
+    .split(/\r?\n/)
+    .map((line) => line.trim().split(/\s+/))
+    .filter(([serial]) => serial && serial !== "List");
+  const requested = process.env.ANDROID_SERIAL?.trim();
+  if (requested) {
+    const row = rows.find(([serial]) => serial === requested);
+    if (row?.[1] === "device") return { serial: requested, reason: null };
+    return {
+      serial: null,
+      reason: `ELIZA_VOICE_ANDROID_READY=1 but ANDROID_SERIAL=${requested} is not attached in device state`,
+    };
+  }
+
+  const device = rows.find(([, state]) => state === "device");
+  if (device?.[0]) return { serial: device[0], reason: null };
+  return {
+    serial: null,
+    reason:
+      "ELIZA_VOICE_ANDROID_READY=1 but no Android device/emulator is attached in device state; attach a device/emulator and install the current app before capture",
+  };
+}
+
+function installedAndroidApp(serial, appId) {
+  const result = adb(["-s", serial, "shell", "pm", "path", appId]);
+  if (result.status === 0 && /^package:/m.test(result.stdout ?? "")) {
+    return { installed: true, reason: null };
+  }
+  const detail = oneLine(result.stderr || result.stdout);
+  return {
+    installed: false,
+    reason: `ELIZA_VOICE_ANDROID_READY=1 but ${appId} is not installed on Android device ${serial}; build/redeploy the current APK before capture${detail ? ` (${detail})` : ""}`,
+  };
 }
 
 function bootedIosSimulator() {
@@ -746,7 +814,17 @@ function probeCell(cell) {
             "set ELIZA_VOICE_ANDROID_READY=1 on an Android device runner with the current APK and voice assets installed",
         };
       }
-      return { available: true, reason: "Android voice runner enabled" };
+      {
+        const device = attachedAndroidDevice();
+        if (!device.serial) return { available: false, reason: device.reason };
+        const appId = readDefaultAndroidAppId();
+        const app = installedAndroidApp(device.serial, appId);
+        if (!app.installed) return { available: false, reason: app.reason };
+        return {
+          available: true,
+          reason: `Android voice runner enabled for ${appId} on ${device.serial}`,
+        };
+      }
     case "androidGradle": {
       const androidDir = path.join(
         REPO_ROOT,

--- a/packages/scripts/voice-matrix.mjs
+++ b/packages/scripts/voice-matrix.mjs
@@ -358,15 +358,11 @@ const CELLS = [
       voices: "multi-speaker",
     },
     class: "wakeword-device-gap",
-    command: [
-      "bun",
-      "run",
-      "--cwd",
-      "plugins/plugin-local-inference",
-      "voice:workbench",
-      "--real",
+    command: ["node", "packages/scripts/voice-openwakeword-eval.mjs"],
+    evidence: [
+      "$ELIZA_VOICE_MATRIX_OUT/wake.openwakeword.real-head/openwakeword-eval.json",
+      "$ELIZA_VOICE_OPENWAKEWORD_REPORT",
     ],
-    evidence: ["$VOICE_REAL_MATRIX_OUT/voice-workbench-real"],
     probe: "openWakeWord",
   },
   {
@@ -529,14 +525,27 @@ function probeCell(cell) {
         reason: "Linux fused voice environment is provisioned",
       };
     case "openWakeWord":
-      if (!process.env.ELIZA_OPENWAKEWORD_REAL_READY) {
+      if (!process.env.ELIZA_VOICE_OPENWAKEWORD_REPORT?.trim()) {
         return {
           available: false,
           reason:
-            "ELIZA_OPENWAKEWORD_REAL_READY is not set for a real wake-word head run",
+            "ELIZA_VOICE_OPENWAKEWORD_REPORT is not set to a reviewed real-head openWakeWord JSON report",
         };
       }
-      return { available: true, reason: "real openWakeWord head gate enabled" };
+      if (
+        !fs.existsSync(
+          path.resolve(REPO_ROOT, process.env.ELIZA_VOICE_OPENWAKEWORD_REPORT),
+        )
+      ) {
+        return {
+          available: true,
+          reason: `openWakeWord report configured but missing: ${process.env.ELIZA_VOICE_OPENWAKEWORD_REPORT}`,
+        };
+      }
+      return {
+        available: true,
+        reason: `openWakeWord report configured: ${process.env.ELIZA_VOICE_OPENWAKEWORD_REPORT}`,
+      };
     case "macosElectrobun":
       if (process.platform !== "darwin")
         return {

--- a/packages/scripts/voice-openwakeword-eval.mjs
+++ b/packages/scripts/voice-openwakeword-eval.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  defaultOpenWakeWordOutputDir,
+  OPENWAKEWORD_SCHEMA,
+  readOpenWakeWordReport,
+  renderOpenWakeWordValidationMarkdown,
+  resolveOpenWakeWordReportPath,
+  validateOpenWakeWordReport,
+} from "./lib/voice-openwakeword-eval.mjs";
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+);
+
+function parseArgs(argv) {
+  const args = {
+    report: null,
+    out: null,
+    help: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i];
+    if (token === "--help" || token === "-h") args.help = true;
+    else if (token === "--report") args.report = argv[++i] ?? null;
+    else if (token === "--out") args.out = argv[++i] ?? null;
+  }
+  return args;
+}
+
+function printHelp() {
+  console.log(`Usage: node packages/scripts/voice-openwakeword-eval.mjs [--report path] [--out dir]
+
+Validates real openWakeWord wake-context evidence for issue #9958.
+
+Required report schema: ${OPENWAKEWORD_SCHEMA}
+Default report: ELIZA_VOICE_OPENWAKEWORD_REPORT
+Default output: ELIZA_VOICE_OPENWAKEWORD_OUT, or ELIZA_VOICE_MATRIX_OUT/<cell>, or .github/issue-evidence/9958-voice-openwakeword-evaluation
+`);
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    return;
+  }
+
+  const reportPath = args.report
+    ? path.resolve(args.report)
+    : resolveOpenWakeWordReportPath(process.env);
+  if (!reportPath) {
+    console.error(
+      "[voice:openwakeword] set ELIZA_VOICE_OPENWAKEWORD_REPORT or pass --report with a real openWakeWord JSON report",
+    );
+    process.exit(2);
+  }
+  if (!fs.existsSync(reportPath)) {
+    console.error(`[voice:openwakeword] report does not exist: ${reportPath}`);
+    process.exit(2);
+  }
+
+  const outDir = args.out
+    ? path.resolve(args.out)
+    : defaultOpenWakeWordOutputDir(process.env, REPO_ROOT);
+  const report = readOpenWakeWordReport(reportPath);
+  const result = validateOpenWakeWordReport(report, {
+    reportPath,
+    repoRoot: REPO_ROOT,
+  });
+
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(outDir, "openwakeword-eval.json"),
+    JSON.stringify(
+      {
+        schema: "eliza_voice_openwakeword_validation_v1",
+        issue: 9958,
+        generatedAt: new Date().toISOString(),
+        reportPath,
+        ...result,
+      },
+      null,
+      2,
+    ),
+  );
+  fs.writeFileSync(
+    path.join(outDir, "openwakeword-eval.md"),
+    renderOpenWakeWordValidationMarkdown(result, { reportPath }),
+  );
+
+  console.log(
+    `[voice:openwakeword] wrote ${path.relative(REPO_ROOT, outDir)}/openwakeword-eval.json`,
+  );
+  if (!result.ok) {
+    for (const error of result.errors) {
+      console.error(`[voice:openwakeword] ${error}`);
+    }
+    process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  console.error(
+    `[voice:openwakeword] ${error instanceof Error ? error.stack : String(error)}`,
+  );
+  process.exit(1);
+});

--- a/packages/ui/src/state/startup-phase-hydrate.voice-control.test.ts
+++ b/packages/ui/src/state/startup-phase-hydrate.voice-control.test.ts
@@ -61,13 +61,15 @@ function makeDeps(): ReadyPhaseDeps {
 }
 
 describe("bindReadyPhase voice-control agent-event bridge", () => {
-  let voiceHandler: ReturnType<typeof vi.fn>;
+  let voiceHandler: EventListener;
+  let voiceHandlerMock: ReturnType<typeof vi.fn<(event: Event) => void>>;
 
   beforeEach(() => {
     clientMock.handlers.clear();
     clientMock.onWsEvent.mockClear();
     clientMock.disconnectWs.mockClear();
-    voiceHandler = vi.fn();
+    voiceHandlerMock = vi.fn();
+    voiceHandler = (event) => voiceHandlerMock(event);
     window.addEventListener(VOICE_CONTROL_EVENT, voiceHandler);
   });
 
@@ -84,8 +86,8 @@ describe("bindReadyPhase voice-control agent-event bridge", () => {
       payload: { command: "start" },
     });
 
-    expect(voiceHandler).toHaveBeenCalledTimes(1);
-    const event = voiceHandler.mock.calls[0][0] as CustomEvent;
+    expect(voiceHandlerMock).toHaveBeenCalledTimes(1);
+    const event = voiceHandlerMock.mock.calls[0][0] as CustomEvent;
     expect(event.detail).toEqual({ command: "start" });
 
     teardown(cleanup);
@@ -99,8 +101,8 @@ describe("bindReadyPhase voice-control agent-event bridge", () => {
       payload: { command: "stop" },
     });
 
-    expect(voiceHandler).toHaveBeenCalledTimes(1);
-    const event = voiceHandler.mock.calls[0][0] as CustomEvent;
+    expect(voiceHandlerMock).toHaveBeenCalledTimes(1);
+    const event = voiceHandlerMock.mock.calls[0][0] as CustomEvent;
     expect(event.detail).toEqual({ command: "stop" });
 
     teardown(cleanup);
@@ -118,7 +120,7 @@ describe("bindReadyPhase voice-control agent-event bridge", () => {
       payload: {},
     });
 
-    expect(voiceHandler).not.toHaveBeenCalled();
+    expect(voiceHandlerMock).not.toHaveBeenCalled();
 
     teardown(cleanup);
   });
@@ -132,7 +134,7 @@ describe("bindReadyPhase voice-control agent-event bridge", () => {
       payload: { command: "start" },
     });
 
-    expect(voiceHandler).not.toHaveBeenCalled();
+    expect(voiceHandlerMock).not.toHaveBeenCalled();
 
     teardown(cleanup);
   });

--- a/packages/ui/src/voice/VOICE_LIVE_MATRIX.md
+++ b/packages/ui/src/voice/VOICE_LIVE_MATRIX.md
@@ -47,8 +47,9 @@ bun run voice:matrix -- --run --platform android
 bun run voice:matrix -- --run --platform linux
 ```
 
-Use `--require-green` only on a lane where every selected hardware dependency is
-known to be present; it turns `pending` or `skip` into a failing exit.
+Use `--require-green` on any opted-in hardware lane; it turns `pending` or
+`skip` into a failing exit so a readiness variable cannot produce green evidence
+while a device, app install, model, or reviewed report is missing.
 
 To validate the Stage-B STT benchmark cell, point the matrix at the reviewed
 report:
@@ -77,7 +78,7 @@ ELIZA_VOICE_OPENWAKEWORD_REPORT=.github/issue-evidence/9958-openwakeword/report.
 | `linux.fused-acoustic.barge-in` | `plugins/plugin-local-inference voice:bargein-bench` | cancellation/latency harness for barge-in |
 | `macos.electrobun.live-roundtrip` | packaged Electrobun voice self-test via `packages/app test:desktop:voice` | real desktop `voice-selftest` ASR -> agent SSE -> local TTS report plus screenshot/log artifact when `ELIZA_VOICE_MACOS_ELECTROBUN_READY=1` and `ELIZA_VOICE_DESKTOP_API_BASE` points at a real app-core API |
 | `windows.electrobun.live-roundtrip` | packaged Electrobun voice self-test via `packages/app test:desktop:voice` | real desktop `voice-selftest` ASR -> agent SSE -> local TTS report plus screenshot/log artifact when `ELIZA_VOICE_WINDOWS_ELECTROBUN_READY=1` and `ELIZA_VOICE_DESKTOP_API_BASE` points at a real app-core API |
-| `ios.sim-or-device.voice-roundtrip` | installed iOS simulator/device build plus `capture:ios-sim` | simulator screenshot/video/log when `ELIZA_VOICE_IOS_READY=1` |
+| `ios.sim-or-device.voice-roundtrip` | installed iOS simulator build plus `capture:ios-sim` | simulator screenshot/video/log when `ELIZA_VOICE_IOS_READY=1`, a booted iOS simulator exists, and the current app ID is installed |
 | `ios.talkmode.native-bridge` | `swift test --disable-index-store --package-path plugins/plugin-native-talkmode/ios` | TalkMode transcript/permission/state/barge-in bridge tests |
 | `ios.swabble.native-bridge` | `swift test --disable-index-store --package-path plugins/plugin-native-swabble/ios` | Swabble wake-firing -> JS bridge event tests |
 | `android.device.voice-roundtrip` | `packages/app test:e2e:android:local` | real WebView on-device STT -> agent -> TTS self-test |
@@ -97,7 +98,8 @@ developer laptop:
 | `ELIZA_VOICE_MACOS_ELECTROBUN_READY=1` | current macOS runner has a built Electrobun app, loopback mic/audio capture, and permission grants |
 | `ELIZA_VOICE_WINDOWS_ELECTROBUN_READY=1` | current Windows runner has a built Electrobun app, loopback mic/audio capture, and permission grants |
 | `ELIZA_VOICE_DESKTOP_API_BASE` | real app-core API base used by packaged desktop voice self-test; required for macOS/Windows Electrobun live cells |
-| `ELIZA_VOICE_IOS_READY=1` | current macOS runner has a freshly installed iOS simulator/device build with voice assets |
+| `ELIZA_VOICE_IOS_READY=1` | current macOS runner has a booted iOS simulator with the current app build and voice assets installed; the matrix verifies the booted simulator and installed app ID before capture |
+| `ELIZA_VOICE_IOS_APP_ID` / `ELIZA_IOS_APP_ID` | optional app ID override for the iOS install check; defaults to `packages/app/app.config.ts` (`ai.elizaos.app`) |
 | `ELIZA_VOICE_ANDROID_READY=1` | current runner has an attached Android device/emulator, current APK, voice assets, and granted mic permissions |
 | `ELIZA_VOICE_OPENWAKEWORD_REPORT` | reviewed openWakeWord real-head JSON report using schema `eliza_voice_openwakeword_eval_v1`; required cases are `idle-wake`, `already-listening-wake-inert`, and `mid-transcription-wake` |
 | `ELIZA_INFERENCE_LIBRARY` + `ELIZA_ASR_BUNDLE` | Linux fused real-service runner has the provisioned local-inference bundle |

--- a/packages/ui/src/voice/VOICE_LIVE_MATRIX.md
+++ b/packages/ui/src/voice/VOICE_LIVE_MATRIX.md
@@ -58,6 +58,14 @@ ELIZA_VOICE_STAGE_B_REPORT=.github/issue-evidence/9958-stage-b/report.json \
   bun run voice:matrix -- --run --platform stt.stage-b.evaluation
 ```
 
+To validate the real openWakeWord head wake-context cell, point the matrix at the
+reviewed report:
+
+```bash
+ELIZA_VOICE_OPENWAKEWORD_REPORT=.github/issue-evidence/9958-openwakeword/report.json \
+  bun run voice:matrix -- --run --platform wake.openwakeword.real-head
+```
+
 ## Cells
 
 | Cell | Existing runner | Evidence |
@@ -75,7 +83,7 @@ ELIZA_VOICE_STAGE_B_REPORT=.github/issue-evidence/9958-stage-b/report.json \
 | `android.device.voice-roundtrip` | `packages/app test:e2e:android:local` | real WebView on-device STT -> agent -> TTS self-test |
 | `android.talkmode.native-bridge` | `./gradlew -p ../../../scripts/android-voice-bridge-gradle :elizaos-capacitor-talkmode:testDebugUnitTest` | TalkMode capture lifecycle/transcript/permission/barge-in bridge tests |
 | `android.swabble.native-bridge` | `./gradlew -p ../../../scripts/android-voice-bridge-gradle :elizaos-capacitor-swabble:testDebugUnitTest` | Swabble wake-firing -> JS bridge event tests |
-| `wake.openwakeword.real-head` | gated real openWakeWord head run | idle wake, always-on inert wake, and mid-transcription non-corruption evidence |
+| `wake.openwakeword.real-head` | `packages/scripts/voice-openwakeword-eval.mjs` validating a reviewed real-head report | idle wake opens the listen window, always-on wake is inert, and mid-transcription wake does not corrupt the transcript |
 | `stt.stage-b.apple-sfspeech` | `node packages/scripts/stage-b-stt-bench.mjs` (macOS) | **measured** on-device `SFSpeechRecognizer` latency/RTF/WER over on-device-synthesised speech (quiet + 10 dB noise), `.github/issue-evidence/9958-stt-stage-b-eval/` |
 | `stt.stage-b.evaluation` | `packages/scripts/voice-stage-b-eval.mjs` validating a paired device benchmark report | iOS `SFSpeechRecognizer`, Android `SpeechRecognizer`, and fused ASR latency/battery/accept matrix with reviewed artifacts |
 
@@ -91,12 +99,19 @@ developer laptop:
 | `ELIZA_VOICE_DESKTOP_API_BASE` | real app-core API base used by packaged desktop voice self-test; required for macOS/Windows Electrobun live cells |
 | `ELIZA_VOICE_IOS_READY=1` | current macOS runner has a freshly installed iOS simulator/device build with voice assets |
 | `ELIZA_VOICE_ANDROID_READY=1` | current runner has an attached Android device/emulator, current APK, voice assets, and granted mic permissions |
-| `ELIZA_OPENWAKEWORD_REAL_READY=1` | current runner has the real openWakeWord head and audio fixture/device path |
+| `ELIZA_VOICE_OPENWAKEWORD_REPORT` | reviewed openWakeWord real-head JSON report using schema `eliza_voice_openwakeword_eval_v1`; required cases are `idle-wake`, `already-listening-wake-inert`, and `mid-transcription-wake` |
 | `ELIZA_INFERENCE_LIBRARY` + `ELIZA_ASR_BUNDLE` | Linux fused real-service runner has the provisioned local-inference bundle |
 | `ELIZA_VOICE_STAGE_B_REPORT` | reviewed Stage-B JSON report using schema `eliza_voice_stage_b_stt_eval_v1`; required backends are `ios-sfspeechrecognizer`, `android-speechrecognizer`, and `fused-asr` |
 
 The matrix report records these gates in the `probe.reason` field. This keeps
 Linux green separate from missing macOS/iOS/Android evidence.
+
+The openWakeWord report must mark `realHardware: true` and `realHead: true`.
+Each required case must identify the device/build/openWakeWord model, record the
+real audio source and duration, include manually reviewed artifacts, and prove
+the case-specific observation: idle wake opened the listen window, wake while
+already listening did not open a duplicate window, and wake during transcription
+did not corrupt or drop transcript tokens.
 
 The Stage-B report is intentionally stricter than a plain benchmark dump. Each
 backend run must mark `realHardware: true`, identify the build and device, record

--- a/packages/ui/src/voice/VOICE_LIVE_MATRIX.md
+++ b/packages/ui/src/voice/VOICE_LIVE_MATRIX.md
@@ -81,7 +81,7 @@ ELIZA_VOICE_OPENWAKEWORD_REPORT=.github/issue-evidence/9958-openwakeword/report.
 | `ios.sim-or-device.voice-roundtrip` | installed iOS simulator build plus `capture:ios-sim` | simulator screenshot/video/log when `ELIZA_VOICE_IOS_READY=1`, a booted iOS simulator exists, and the current app ID is installed |
 | `ios.talkmode.native-bridge` | `swift test --disable-index-store --package-path plugins/plugin-native-talkmode/ios` | TalkMode transcript/permission/state/barge-in bridge tests |
 | `ios.swabble.native-bridge` | `swift test --disable-index-store --package-path plugins/plugin-native-swabble/ios` | Swabble wake-firing -> JS bridge event tests |
-| `android.device.voice-roundtrip` | `packages/app test:e2e:android:local` | real WebView on-device STT -> agent -> TTS self-test |
+| `android.device.voice-roundtrip` | `packages/app test:e2e:android:local` | real WebView on-device STT -> agent -> TTS self-test when `ELIZA_VOICE_ANDROID_READY=1`, an Android target is attached in `device` state, and the current app ID is installed |
 | `android.talkmode.native-bridge` | `./gradlew -p ../../../scripts/android-voice-bridge-gradle :elizaos-capacitor-talkmode:testDebugUnitTest` | TalkMode capture lifecycle/transcript/permission/barge-in bridge tests |
 | `android.swabble.native-bridge` | `./gradlew -p ../../../scripts/android-voice-bridge-gradle :elizaos-capacitor-swabble:testDebugUnitTest` | Swabble wake-firing -> JS bridge event tests |
 | `wake.openwakeword.real-head` | `packages/scripts/voice-openwakeword-eval.mjs` validating a reviewed real-head report | idle wake opens the listen window, always-on wake is inert, and mid-transcription wake does not corrupt the transcript |
@@ -100,7 +100,8 @@ developer laptop:
 | `ELIZA_VOICE_DESKTOP_API_BASE` | real app-core API base used by packaged desktop voice self-test; required for macOS/Windows Electrobun live cells |
 | `ELIZA_VOICE_IOS_READY=1` | current macOS runner has a booted iOS simulator with the current app build and voice assets installed; the matrix verifies the booted simulator and installed app ID before capture |
 | `ELIZA_VOICE_IOS_APP_ID` / `ELIZA_IOS_APP_ID` | optional app ID override for the iOS install check; defaults to `packages/app/app.config.ts` (`ai.elizaos.app`) |
-| `ELIZA_VOICE_ANDROID_READY=1` | current runner has an attached Android device/emulator, current APK, voice assets, and granted mic permissions |
+| `ELIZA_VOICE_ANDROID_READY=1` | current runner has an attached Android device/emulator in `device` state, current APK, voice assets, and granted mic permissions; the matrix verifies the attached target and installed app ID before capture |
+| `ELIZA_VOICE_ANDROID_APP_ID` / `ELIZA_ANDROID_APP_ID` / `ELIZA_APP_ID` | optional app ID override for the Android install check; defaults to `packages/app/app.config.ts` (`ai.elizaos.app`) |
 | `ELIZA_VOICE_OPENWAKEWORD_REPORT` | reviewed openWakeWord real-head JSON report using schema `eliza_voice_openwakeword_eval_v1`; required cases are `idle-wake`, `already-listening-wake-inert`, and `mid-transcription-wake` |
 | `ELIZA_INFERENCE_LIBRARY` + `ELIZA_ASR_BUNDLE` | Linux fused real-service runner has the provisioned local-inference bundle |
 | `ELIZA_VOICE_STAGE_B_REPORT` | reviewed Stage-B JSON report using schema `eliza_voice_stage_b_stt_eval_v1`; required backends are `ios-sfspeechrecognizer`, `android-speechrecognizer`, and `fused-asr` |

--- a/plugins/plugin-polymarket/tsconfig.build.json
+++ b/plugins/plugin-polymarket/tsconfig.build.json
@@ -2,7 +2,8 @@
   "extends": "../tsconfig.build.shared.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "types": ["node"]
   },
   "include": ["src"],
   "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/**/__tests__/**"]


### PR DESCRIPTION
## Summary
- Add a strict openWakeWord real-head evidence validator and wire it into `voice:matrix` via `ELIZA_VOICE_OPENWAKEWORD_REPORT`.
- Require reviewed real hardware/head metadata, real audio, build/model details, artifacts, and the three #9958 wake cases before the matrix can pass.
- Harden the optional hardware workflow lanes so opted-in macOS Electrobun, Windows Electrobun, iOS, and Android voice matrix jobs run with `--require-green` instead of passing with skipped/pending cells.
- Tighten the iOS voice probe: `ELIZA_VOICE_IOS_READY=1` now also requires a booted iOS simulator and an installed current app ID before `capture:ios-sim` can count as runnable.
- Tighten the Android voice probe: `ELIZA_VOICE_ANDROID_READY=1` now also requires an attached Android target in `device` state and an installed current app ID before the on-device voice roundtrip can count as runnable.
- Replace stale Stage-B handoff/qualitative-ASR wording with the strict `ELIZA_VOICE_STAGE_B_REPORT` / `voice-stage-b-eval.mjs` report gate.
- Refresh legacy #9958 evidence bundles so older checked-in matrix artifacts no longer contain the old `ELIZA_OPENWAKEWORD_REAL_READY`, `stage-b-eval-placeholder`, old iOS readiness wording, or desktop capture placeholder commands.
- Carry current-`develop` verification repairs found while proving the branch: typed UI voice-control event listener, sorted agent runtime imports, and Node ambient types for the Polymarket build typecheck path.

## Evidence
- `.github/issue-evidence/9958-voice-openwakeword-contract/` records the openWakeWord contract run: no false green without `ELIZA_VOICE_OPENWAKEWORD_REPORT`.
- `.github/issue-evidence/9958-voice-stage-b-contract/` refreshes the Stage-B matrix contract output.
- `.github/issue-evidence/9958-voice-matrix-full-probe/` records the current full probe with strict openWakeWord, Stage-B, and mobile readiness wording.
- `.github/issue-evidence/9958-voice-matrix/` was refreshed as the legacy full matrix bundle and now matches the current strict gates.
- `.github/issue-evidence/9958-voice-matrix-android-native-run/` and `.github/issue-evidence/9958-voice-matrix-android-native-bridge/` both show the Android native bridge slice: TalkMode and Swabble bridge contracts pass; Android device roundtrip and full Stage-B remain explicit hardware/report skips.
- `.github/issue-evidence/9958-voice-android-ready-gated-probe/` forces `ELIZA_VOICE_ANDROID_READY=1` on this Mac with no attached Android target and records the selected Android live cell as `skip`, not `pass`; the same selected cell exits `1` with `--require-green`.
- `.github/issue-evidence/9958-voice-matrix-ios-run/`, `.github/issue-evidence/9958-voice-matrix-ios-swift-run/`, `.github/issue-evidence/9958-voice-matrix-ios-native-bridge/`, and `.github/issue-evidence/9958-voice-matrix-ios-native-run/` all show the iOS Swift bridge slice: TalkMode and Swabble bridge suites pass; live iOS capture remains an explicit current-build simulator/device skip.
- `.github/issue-evidence/9958-voice-ios-ready-gated-probe/` forces `ELIZA_VOICE_IOS_READY=1` on this Mac with no booted simulator and records the selected iOS live cell as `skip`, not `pass`; the same selected cell exits `1` with `--require-green`.
- `.github/issue-evidence/9958-stt-stage-b-eval/stage-b-stt-eval.md` now explicitly says iOS energy, Android SpeechRecognizer, and fused-ASR measurements are not covered by the Apple-only host artifact and must come through the strict Stage-B report gate.

## Verification
- `git fetch origin` and confirmed `origin/develop` is an ancestor of the branch head (`8681dc7cf8aed1339077df31d2286cfd9c4e8897`).
- `bun install` (no dependency changes; lockfile ordering churn discarded earlier on this branch).
- `bun test packages/scripts/__tests__/voice-openwakeword-eval.test.ts packages/scripts/__tests__/voice-stage-b-eval.test.ts`
- `node packages/scripts/voice-openwakeword-eval.mjs --help`
- `node packages/scripts/voice-stage-b-eval.mjs --help`
- `bun run voice:matrix -- --run --platform wake.openwakeword.real-head --out .github/issue-evidence/9958-voice-openwakeword-contract`
- `bun run voice:matrix -- --run --platform stt.stage-b.evaluation --out .github/issue-evidence/9958-voice-stage-b-contract`
- `bun run voice:matrix -- --out .github/issue-evidence/9958-voice-matrix-full-probe`
- `bun run voice:matrix -- --out .github/issue-evidence/9958-voice-matrix`
- `bun run voice:matrix -- --run --platform android --out .github/issue-evidence/9958-voice-matrix-android-native-run`
- `bun run voice:matrix -- --run --platform android --out .github/issue-evidence/9958-voice-matrix-android-native-bridge`
- `bun run voice:matrix -- --run --platform ios --out .github/issue-evidence/9958-voice-matrix-ios-run`
- `bun run voice:matrix -- --run --platform ios --out .github/issue-evidence/9958-voice-matrix-ios-swift-run`
- `bun run voice:matrix -- --run --platform ios --out .github/issue-evidence/9958-voice-matrix-ios-native-bridge`
- `bun run voice:matrix -- --run --platform ios --out .github/issue-evidence/9958-voice-matrix-ios-native-run`
- `ELIZA_VOICE_IOS_READY=1 bun run voice:matrix -- --platform ios.sim-or-device.voice-roundtrip --out .github/issue-evidence/9958-voice-ios-ready-gated-probe`
- `ELIZA_VOICE_IOS_READY=1 bun run voice:matrix -- --platform ios.sim-or-device.voice-roundtrip --require-green --out /tmp/9958-ios-ready-gated-require-green` (expected exit `1`)
- `ELIZA_VOICE_ANDROID_READY=1 bun run voice:matrix -- --platform android.device.voice-roundtrip --out .github/issue-evidence/9958-voice-android-ready-gated-probe`
- `ELIZA_VOICE_ANDROID_READY=1 bun run voice:matrix -- --platform android.device.voice-roundtrip --require-green --out /tmp/9958-android-ready-gated-require-green` (expected exit `1`)
- JSON parse/summary assertions over refreshed #9958 matrix evidence.
- stale-marker scan for old `ELIZA_OPENWAKEWORD_REAL_READY`, Stage-B placeholder, old iOS readiness text, old desktop capture commands, and legacy qualitative ASR proof strings.
- `git diff --check`
- `bun run --cwd packages/ui typecheck`
- `bun run --cwd packages/ui test -- src/state/startup-phase-hydrate.voice-control.test.ts`
- `bunx @biomejs/biome check packages/scripts/lib/voice-openwakeword-eval.mjs packages/scripts/voice-openwakeword-eval.mjs packages/scripts/voice-matrix.mjs packages/scripts/stage-b-stt-bench.mjs packages/scripts/__tests__/voice-openwakeword-eval.test.ts packages/ui/src/voice/VOICE_LIVE_MATRIX.md packages/ui/src/state/startup-phase-hydrate.voice-control.test.ts packages/agent/src/runtime/eliza.ts`
- `bunx @biomejs/biome check packages/scripts/voice-matrix.mjs packages/ui/src/voice/VOICE_LIVE_MATRIX.md .github/workflows/voice-live-e2e.yml .github/issue-evidence/9958-voice-android-ready-gated-probe/README.md`
- `bun run --cwd packages/agent lint`
- `bun run --cwd plugins/plugin-polymarket typecheck`
- `bun run --cwd plugins/plugin-polymarket build:types`
- `NODE_OPTIONS='--max-old-space-size=8192' node packages/scripts/run-turbo.mjs run typecheck lint --concurrency=4 --filter='!@elizaos/example-code'` (`476 successful, 476 total`)
- `bun run verify` before the latest residual hardening (`476 successful, 476 total`; final dist-path consumer check passed)
- `bun run verify` after the hardware-gate/Stage-B wording hardening and rebase (`476 successful, 476 total`; final dist-path consumer check passed)
- `bun run verify` after the legacy evidence refresh (`476 successful, 476 total`; final dist-path consumer check passed)
- `bun run verify` after the Android ready-gate follow-up (`476 successful, 476 total`; repo audits passed; 28 dist-path consumer configs checked)

Refs #9958.