### PR TITLE
fix(agent): honor ELIZA_FORCE_INJECT_TOKEN for UI token injection

### DIFF
--- a/packages/agent/src/api/static-file-server.ts
+++ b/packages/agent/src/api/static-file-server.ts
@@ -257,10 +257,15 @@ export function serveStaticUi(
   // When served behind a reverse proxy that rewrites the app under a path prefix,
   // inject the API base so the UI client sends requests to the correct path prefix.
   // For cloud-provisioned containers, also inject the API token so the browser
-  // client can authenticate without requiring a pairing flow.
-  const cloudToken = isCloudProvisionedContainer()
-    ? resolveApiToken(process.env)
-    : null;
+  // client can authenticate without requiring a pairing flow. Self-hosted
+  // operators who front the UI with their own auth gate (e.g. a reverse-proxy
+  // cookie wall) can opt into the same token injection with
+  // ELIZA_FORCE_INJECT_TOKEN=1 so the browser authenticates without pairing.
+  const cloudToken =
+    isCloudProvisionedContainer() ||
+    process.env.ELIZA_FORCE_INJECT_TOKEN === "1"
+      ? resolveApiToken(process.env)
+      : null;
   const html = injectApiBaseIntoHtml(
     uiIndexHtml,
     process.env.ELIZA_EXTERNAL_BASE_URL,


### PR DESCRIPTION
## Problem

`serveStaticUi` injects `window.__ELIZA_API_TOKEN__` into the dashboard `index.html` so the browser client authenticates without the device-pairing flow. That injection is gated only on `isCloudProvisionedContainer()`:

```ts
const cloudToken = isCloudProvisionedContainer()
  ? resolveApiToken(process.env)
  : null;
```

A self-hosted operator who fronts the dashboard with their own auth gate (for example a reverse-proxy cookie wall that injects the bearer token on API calls) gets no token in the HTML, so the UI falls back to a "pairing required" screen. `ELIZA_PAIRING_DISABLED=1` does not help here: it disables the pairing endpoint but does not hand the UI a token.

## Fix

Inject the token when the container is cloud-provisioned **or** `ELIZA_FORCE_INJECT_TOKEN=1`, letting self-hosters behind their own auth gate opt into the same token injection cloud already uses.

```ts
const cloudToken =
  isCloudProvisionedContainer() ||
  process.env.ELIZA_FORCE_INJECT_TOKEN === "1"
    ? resolveApiToken(process.env)
    : null;
```

Opt-in via env, no behavior change when the flag is unset.

## Verification

With `ELIZA_FORCE_INJECT_TOKEN=1`, the served `index.html` contains `window.__ELIZA_API_TOKEN__="..."` and the dashboard loads straight into chat with no pairing wall.

Co-authored-by: wakesync <shadow@shad0w.xyz>