### PR TITLE
test(workflow): cover WORKFLOW context-gate firing + ?q= search route (#8913)

### DIFF
--- a/plugins/plugin-workflow/__tests__/helpers/mockService.ts
+++ b/plugins/plugin-workflow/__tests__/helpers/mockService.ts
@@ -104,6 +104,17 @@ export function createMockService(
         }),
       ])
     ),
+    // Distinct from listWorkflows so a route test can prove the `?q=` ranked-search
+    // branch was taken (and not a plain list). #8913.
+    searchWorkflows: mock(() =>
+      Promise.resolve([
+        createWorkflowResponse({
+          id: 'wf-match',
+          name: 'Matched Workflow',
+          active: true,
+        }),
+      ])
+    ),
     activateWorkflow: mock(() => Promise.resolve()),
     deactivateWorkflow: mock(() => Promise.resolve()),
     deleteWorkflow: mock(() => Promise.resolve()),

--- a/plugins/plugin-workflow/__tests__/unit/routes/workflows.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/routes/workflows.test.ts
@@ -96,6 +96,39 @@ describe('GET /workflows', () => {
 
     expect((service.listWorkflows as ReturnType<typeof mock>).mock.calls[0][0]).toBe('user-42');
   });
+
+  // #8913: `?q=` routes through the ranked free-text search, not the plain list.
+  test('?q= performs a ranked search (searchWorkflows, not listWorkflows)', async () => {
+    const { runtime, service } = runtimeWithService();
+    const req = createRouteRequest({ query: { q: 'deploy gmail', userId: 'user-42' } });
+    const { res, getResult } = createRouteResponse();
+
+    await listHandler(req, res, runtime);
+
+    const search = service.searchWorkflows as ReturnType<typeof mock>;
+    expect(search.mock.calls.length).toBe(1);
+    expect(search.mock.calls[0][0]).toBe('deploy gmail');
+    expect(search.mock.calls[0][1]).toBe('user-42');
+    // The plain-list path must NOT be taken when a query is present.
+    expect((service.listWorkflows as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+
+    const { body } = getResult();
+    const data = body as { success: boolean; data: Array<{ id: string }> };
+    expect(data.success).toBe(true);
+    expect(data.data[0].id).toBe('wf-match');
+  });
+
+  // A blank/whitespace-only `q` falls through to the plain list (the `q?.trim()` guard).
+  test('blank ?q= falls through to listWorkflows', async () => {
+    const { runtime, service } = runtimeWithService();
+    const req = createRouteRequest({ query: { q: '   ' } });
+    const { res } = createRouteResponse();
+
+    await listHandler(req, res, runtime);
+
+    expect((service.searchWorkflows as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+    expect((service.listWorkflows as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+  });
 });
 
 describe('POST /workflows', () => {

--- a/plugins/plugin-workflow/__tests__/unit/workflow-context-gate.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/workflow-context-gate.test.ts
@@ -1,0 +1,50 @@
+/**
+ * #8913 — verify the WORKFLOW action's chat-context gating.
+ *
+ * The issue asked that the WORKFLOW action be reachable from an ordinary
+ * chat/Telegram turn (which seeds the `general` context) while staying gated out
+ * of unrelated contexts. #9014 implemented this by declaring
+ * `contexts/contextGate = ['general','automation','tasks','agent_internal']`
+ * (the `chat` literal in the issue text is an inert alias; a plain chat turn
+ * actually seeds `general`). That correctness argument previously lived only in
+ * code comments + the PR body — no test exercised the gate itself. This locks it
+ * in by evaluating the action's real `contextGate` through core's
+ * `satisfiesContextGate` (the same predicate the planner uses to admit an
+ * action).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { satisfiesContextGate } from '@elizaos/core';
+import { workflowAction } from '../../src/actions/workflow';
+
+describe('WORKFLOW context gating (#8913)', () => {
+  const gate = workflowAction.contextGate;
+  const ALLOWED = ['general', 'automation', 'tasks', 'agent_internal'] as const;
+
+  test('declares the intended allow-set on both contexts and contextGate', () => {
+    expect(gate).toBeDefined();
+    expect(workflowAction.contexts).toEqual(expect.arrayContaining([...ALLOWED]));
+    expect(gate?.anyOf).toEqual(expect.arrayContaining([...ALLOWED]));
+  });
+
+  test('fires under "general" — the context a plain chat/Telegram turn seeds', () => {
+    expect(satisfiesContextGate(['general'], gate)).toBe(true);
+  });
+
+  test('fires under every allowed context', () => {
+    for (const ctx of ALLOWED) {
+      expect(satisfiesContextGate([ctx], gate)).toBe(true);
+    }
+  });
+
+  test('is gated OUT of contexts outside the allow-set', () => {
+    expect(satisfiesContextGate(['contacts'], gate)).toBe(false);
+    expect(satisfiesContextGate(['settings'], gate)).toBe(false);
+    expect(satisfiesContextGate(['admin'], gate)).toBe(false);
+  });
+
+  test('does not fire when no context is active', () => {
+    expect(satisfiesContextGate([], gate)).toBe(false);
+    expect(satisfiesContextGate(undefined, gate)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Closes the two untested pieces of #8913. The `search` op + `general`-context gating shipped via #9014, but the issue's "How to test" items — *that the gate actually fires under a chat/`general` context and is gated out otherwise*, and *that `?q=` performs a ranked search* — had no assertions; the correctness argument lived only in code comments / the #9014 PR body.

## Tests added (deterministic, no live model)

- **`__tests__/unit/workflow-context-gate.test.ts`** — evaluates the WORKFLOW action's real `contextGate` through core's `satisfiesContextGate` (the same predicate the planner uses to admit an action):
  - fires under `general` (the context a plain chat/Telegram turn seeds) and every allowed context (`general`, `automation`, `tasks`, `agent_internal`);
  - is gated **out** of contexts outside the allow-set (`contacts`, `settings`, `admin`) and when no context is active.
- **`__tests__/unit/routes/workflows.test.ts`** — the `GET /workflows?q=` branch routes through `searchWorkflows` (not `listWorkflows`) with the query + userId, and a blank/whitespace `q` falls through to the plain list (the `q?.trim()` guard). Adds `searchWorkflows` to the mock service.

## Evidence

Run on Windows 11 (`bun test`):

```
bun test __tests__/unit/workflow-context-gate.test.ts __tests__/unit/routes/workflows.test.ts
 26 pass
 0 fail
 53 expect() calls
```

Biome clean. No source changes — test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)