### PR TITLE
fix(agent): integrity-gate restored media against its content hash (#9963)

### DIFF
--- a/packages/agent/src/api/media-store.ts
+++ b/packages/agent/src/api/media-store.ts
@@ -342,6 +342,26 @@ export function writeStoredMediaFile(fileName: string, bytes: Buffer): boolean {
   }
 }
 
+/**
+ * Content-integrity check for a stored media file: the store is content-addressed
+ * (`<sha256>.<ext>`, the sha256 of the bytes — see how filenames are minted
+ * above), so the bytes MUST hash back to the name. Returns true only when
+ * `fileName` is a strict content-addressed name AND `sha256(bytes)` equals its
+ * 64-hex hash. Used at the restore/import boundary (#9963) to reject corrupt or
+ * tampered backup media instead of silently writing bytes under a hash that
+ * doesn't match their content — which would poison the dedup/capability
+ * invariant the whole store relies on.
+ */
+export function storedMediaContentMatchesName(
+  fileName: string,
+  bytes: Buffer,
+): boolean {
+  if (!MEDIA_FILE_NAME.test(fileName)) return false;
+  const expected = fileName.slice(0, 64);
+  const actual = crypto.createHash("sha256").update(bytes).digest("hex");
+  return actual === expected;
+}
+
 const DATA_URL_RE = /^data:([^;,]*)(;base64)?,([\s\S]*)$/;
 
 /** Persist a `data:` URL's bytes to the store; returns null for non-data URLs. */

--- a/packages/agent/src/services/agent-export.media.test.ts
+++ b/packages/agent/src/services/agent-export.media.test.ts
@@ -4,6 +4,7 @@
  * a restored agent keeps its message images/attachments (the DB rows alone point
  * at media that wouldn't exist on the target).
  */
+import { createHash } from "node:crypto";
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -11,9 +12,18 @@ import type { Content, Memory, UUID } from "@elizaos/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   readStoredMediaBytes,
+  storedMediaContentMatchesName,
   writeStoredMediaFile,
 } from "../api/media-store.ts";
-import { collectReferencedMediaFileNames } from "./agent-export.ts";
+import {
+  collectReferencedMediaFileNames,
+  restoreMedia,
+} from "./agent-export.ts";
+
+/** Build the content-addressed `<sha256>.<ext>` name for some bytes. */
+function nameFor(bytes: Buffer, ext = "png"): string {
+  return `${createHash("sha256").update(bytes).digest("hex")}.${ext}`;
+}
 
 const SHA_A = "a".repeat(64);
 const SHA_B = "b".repeat(64);
@@ -77,5 +87,67 @@ describe("media-store read/write round-trip", () => {
     expect(writeStoredMediaFile("../escape.bin", Buffer.from("x"))).toBe(false);
     expect(readStoredMediaBytes("../../etc/passwd")).toBeNull();
     expect(existsSync(join(dir, "..", "escape.bin"))).toBe(false);
+  });
+});
+
+describe("storedMediaContentMatchesName (restore integrity primitive #9963)", () => {
+  it("accepts bytes whose sha256 matches the content-addressed name", () => {
+    const bytes = Buffer.from("agent backup media payload");
+    expect(storedMediaContentMatchesName(nameFor(bytes), bytes)).toBe(true);
+  });
+
+  it("rejects tampered bytes (content no longer hashes to the name)", () => {
+    const original = Buffer.from("original media");
+    const tampered = Buffer.from("tampered media");
+    // Name minted from the ORIGINAL bytes, but the TAMPERED bytes are supplied.
+    expect(storedMediaContentMatchesName(nameFor(original), tampered)).toBe(
+      false,
+    );
+  });
+
+  it("rejects non-content-addressed / malformed names", () => {
+    const bytes = Buffer.from("x");
+    expect(storedMediaContentMatchesName("not-a-hash.png", bytes)).toBe(false);
+    expect(storedMediaContentMatchesName("../escape.png", bytes)).toBe(false);
+    // 64 hex but no extension → not a valid stored name.
+    expect(storedMediaContentMatchesName("a".repeat(64), bytes)).toBe(false);
+  });
+});
+
+describe("restoreMedia content-integrity gate (#9963)", () => {
+  let dir: string;
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "restore-media-test-"));
+    process.env.ELIZA_STATE_DIR = dir;
+    process.env.MILADY_STATE_DIR = dir;
+  });
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("restores valid media but SKIPS entries whose bytes don't match their name", () => {
+    const good = Buffer.from("good restored image");
+    const goodName = nameFor(good);
+    // A valid-format name (minted from OTHER content) fed TAMPERED bytes — a
+    // corrupt/tampered backup. The gate must refuse to write it.
+    const tamperedName = nameFor(Buffer.from("the-real-content"));
+    const tamperedBytes = Buffer.from(
+      "smuggled bytes that do not hash to the name",
+    );
+
+    const restored = restoreMedia([
+      { fileName: goodName, base64: good.toString("base64") },
+      { fileName: tamperedName, base64: tamperedBytes.toString("base64") },
+    ]);
+
+    expect(restored).toBe(1); // only the valid entry counts
+    expect(readStoredMediaBytes(goodName)?.equals(good)).toBe(true);
+    // The tampered entry must NOT have been written under its (mismatched) name.
+    expect(readStoredMediaBytes(tamperedName)).toBeNull();
+  });
+
+  it("handles an empty/undefined media list", () => {
+    expect(restoreMedia(undefined)).toBe(0);
+    expect(restoreMedia([])).toBe(0);
   });
 });

--- a/packages/agent/src/services/agent-export.ts
+++ b/packages/agent/src/services/agent-export.ts
@@ -41,6 +41,7 @@ import {
   isStoredMediaUrl,
   mediaFileNameFromUrl,
   readStoredMediaBytes,
+  storedMediaContentMatchesName,
   writeStoredMediaFile,
 } from "../api/media-store.ts";
 
@@ -282,15 +283,34 @@ function captureReferencedMedia(
 }
 
 /** Rehydrate the content-addressed store from the export's media entries. */
-function restoreMedia(
+export function restoreMedia(
   media: Array<{ fileName: string; base64: string }> | undefined,
 ): number {
   let restored = 0;
+  let rejected = 0;
   if (!media) return restored;
   for (const { fileName, base64 } of media) {
-    if (writeStoredMediaFile(fileName, Buffer.from(base64, "base64"))) {
+    const bytes = Buffer.from(base64, "base64");
+    // Content-addressed integrity gate (#9963): the bytes MUST hash back to their
+    // `<sha256>` name. A mismatch means a corrupt or tampered backup — skip it,
+    // loudly, rather than poison the content-addressed store with bytes filed
+    // under a hash that doesn't match their content (the dedup + unguessable-
+    // capability invariant the store relies on).
+    if (!storedMediaContentMatchesName(fileName, bytes)) {
+      rejected++;
+      logger.warn(
+        `[agent-export] Skipping restored media ${fileName}: sha256 content-hash mismatch (corrupt or tampered backup)`,
+      );
+      continue;
+    }
+    if (writeStoredMediaFile(fileName, bytes)) {
       restored++;
     }
+  }
+  if (rejected > 0) {
+    logger.warn(
+      `[agent-export] Rejected ${rejected} media file(s) on restore for content-hash mismatch`,
+    );
   }
   return restored;
 }


### PR DESCRIPTION
## What

A bounded slice of #9963. The local agent backup/restore (DB + content-addressed media, landed in #10165) restored media bytes straight to their `<sha256>.<ext>` names **without verifying the bytes actually hash to that name**. A corrupt or tampered backup could therefore write content under a mismatched hash, poisoning the content-addressed store's core invariant (filename == `sha256(bytes)`, which the dedup + unguessable-capability serving both rely on).

## Change

- **`media-store.ts`** — `storedMediaContentMatchesName(fileName, bytes)`: returns true only when `fileName` is a strict `<64-hex sha256>.<ext>` **and** `sha256(bytes)` equals that hash.
- **`agent-export.ts` `restoreMedia`** — runs every restored entry through the gate before writing; mismatches are **skipped (never written)** and logged loudly, with a rejected-count summary warning. (Exported so the gate is directly testable.)

## Tests (deterministic, Windows-local)

`agent-export.media.test.ts` → **9 pass / 0 fail** (4 existing + 5 new):
- the primitive accepts matching bytes, rejects tampered bytes, rejects malformed/non-content-addressed names;
- `restoreMedia` restores a valid entry but **skips a tampered one — asserting the bad bytes are not written to disk** — and handles empty/undefined input.

```
vitest run agent-export.media
 Test Files  1 passed (1)
      Tests  9 passed (9)
```
Biome clean.

## Scope note

The issue frames it as "DB + media + **vault**". Secrets/vault are *intentionally* stripped from the portable archive today (a portable backup of all secrets is itself a security risk), so I did **not** add a vault leg — that's a maintainer security decision. The full export→import round-trip e2e (needs a real PGlite-backed `AgentRuntime`, which the agent tests deliberately don't stand up) is also left for a follow-up. This PR closes the concrete integrity gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)