### PR TITLE
fix(orchestrator): cap screenshot delivery bytes

### DIFF
--- a/.github/issue-evidence/8904-screenshot-byte-cap.md
+++ b/.github/issue-evidence/8904-screenshot-byte-cap.md
@@ -1,0 +1,37 @@
+# #8904 screenshot byte cap evidence
+
+## Change
+
+`screenshotsToAttachments` now enforces both:
+
+- count cap: `MAX_SCREENSHOTS`
+- total known byte cap: `MAX_SCREENSHOT_TOTAL_BYTES`
+
+The real router already filters to existing paths before calling delivery, so
+normal task-completion screenshot forwarding has file sizes available through
+`statSync`.
+
+## Validation
+
+```text
+bunx vitest run --config vitest.config.ts __tests__/unit/screenshot-delivery.test.ts
+Test Files  1 passed (1)
+Tests       10 passed (10)
+```
+
+```text
+bun run --cwd plugins/plugin-agent-orchestrator lint:check
+Checked 241 files. No fixes applied.
+```
+
+```text
+bun run --cwd plugins/plugin-agent-orchestrator typecheck
+tsgo --noEmit -p tsconfig.json
+```
+
+## Remaining Evidence Gap
+
+The live Telegram scenario from the original issue still requires a Telegram
+Bot API/mock-platform scenario lane and delivered-image artifact. This PR closes
+the missing total-size cap acceptance criterion; it does not claim full issue
+closure.

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/screenshot-delivery.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/screenshot-delivery.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   collectScreenshotPaths,
   deliverScreenshots,
+  MAX_SCREENSHOT_TOTAL_BYTES,
   MAX_SCREENSHOTS,
   screenshotsToAttachments,
 } from "../../src/services/screenshot-delivery.js";
@@ -57,6 +58,29 @@ describe("screenshotsToAttachments (#8904)", () => {
     expect(atts).toHaveLength(MAX_SCREENSHOTS);
     expect(atts[0]).toMatchObject({ url: "/tmp/0.png", contentType: "image" });
     expect(atts[0].title).toBe("0.png");
+  });
+
+  it("caps total known bytes across the forwarded screenshots", () => {
+    const atts = screenshotsToAttachments(
+      ["/tmp/a.png", "/tmp/b.png", "/tmp/c.png"],
+      {
+        maxCount: 5,
+        maxTotalBytes: 10,
+        getSize: (path) => (path.endsWith("b.png") ? 7 : 4),
+      },
+    );
+    expect(atts.map((att) => att.url)).toEqual(["/tmp/a.png", "/tmp/c.png"]);
+  });
+
+  it("skips a single screenshot larger than the total byte budget", () => {
+    const atts = screenshotsToAttachments(["/tmp/huge.png", "/tmp/small.png"], {
+      maxTotalBytes: MAX_SCREENSHOT_TOTAL_BYTES,
+      getSize: (path) =>
+        path.includes("huge")
+          ? MAX_SCREENSHOT_TOTAL_BYTES + 1
+          : MAX_SCREENSHOT_TOTAL_BYTES,
+    });
+    expect(atts.map((att) => att.url)).toEqual(["/tmp/small.png"]);
   });
 });
 

--- a/plugins/plugin-agent-orchestrator/src/services/screenshot-delivery.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/screenshot-delivery.ts
@@ -10,6 +10,7 @@
  * Telegram user sees what a Claude-Code user sees in-terminal.
  */
 
+import { statSync } from "node:fs";
 import type { Content, Media, UUID } from "@elizaos/core";
 import { ContentType, logger } from "@elizaos/core";
 import { parseCompletionEnvelope } from "./completion-envelope.js";
@@ -17,6 +18,8 @@ import { parseCompletionEnvelope } from "./completion-envelope.js";
 const IMAGE_EXT_RE = /\.(png|jpe?g|gif|webp|bmp)$/i;
 /** Cap how many screenshots we forward so a chatty task can't flood the chat. */
 export const MAX_SCREENSHOTS = 5;
+/** Cap the total known screenshot bytes in one completion delivery. */
+export const MAX_SCREENSHOT_TOTAL_BYTES = 20 * 1024 * 1024;
 
 /**
  * Pure: collect candidate screenshot paths for a completion. Prefers the
@@ -56,12 +59,57 @@ export function collectScreenshotPaths(
   return out;
 }
 
-/** Pure: turn screenshot paths into capped image `Media[]` for `Content.attachments`. */
+type ScreenshotAttachmentOptions = {
+  maxCount?: number;
+  maxTotalBytes?: number;
+  getSize?: (path: string) => number | undefined;
+};
+
+function getFileSize(path: string): number | undefined {
+  try {
+    return statSync(path).size;
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeAttachmentOptions(
+  maxCountOrOptions: number | ScreenshotAttachmentOptions,
+): Required<ScreenshotAttachmentOptions> {
+  if (typeof maxCountOrOptions === "number") {
+    return {
+      maxCount: maxCountOrOptions,
+      maxTotalBytes: MAX_SCREENSHOT_TOTAL_BYTES,
+      getSize: getFileSize,
+    };
+  }
+  return {
+    maxCount: maxCountOrOptions.maxCount ?? MAX_SCREENSHOTS,
+    maxTotalBytes:
+      maxCountOrOptions.maxTotalBytes ?? MAX_SCREENSHOT_TOTAL_BYTES,
+    getSize: maxCountOrOptions.getSize ?? getFileSize,
+  };
+}
+
+/** Turn screenshot paths into capped image `Media[]` for `Content.attachments`. */
 export function screenshotsToAttachments(
   paths: string[],
-  maxCount = MAX_SCREENSHOTS,
+  maxCountOrOptions: number | ScreenshotAttachmentOptions = MAX_SCREENSHOTS,
 ): Media[] {
-  return paths.slice(0, maxCount).map((p, i) => ({
+  const { maxCount, maxTotalBytes, getSize } =
+    normalizeAttachmentOptions(maxCountOrOptions);
+  const selected: string[] = [];
+  let totalBytes = 0;
+  for (const path of paths) {
+    if (selected.length >= maxCount) break;
+    const size = getSize(path);
+    if (typeof size === "number" && Number.isFinite(size)) {
+      if (size > maxTotalBytes || totalBytes + size > maxTotalBytes) continue;
+      totalBytes += size;
+    }
+    selected.push(path);
+  }
+  return selected.map((p, i) => ({
     id: `screenshot-${i}` as UUID,
     url: p,
     title: p.split("/").pop() || `screenshot-${i}`,


### PR DESCRIPTION
Relates #8904.

## Summary
- Adds a total known-byte budget for sub-agent screenshot forwarding in addition to the existing count cap.
- Keeps current count-cap and best-effort delivery behavior intact.
- Adds unit coverage for aggregate byte trimming and skipping a single screenshot larger than the byte budget.
- Adds issue evidence under `.github/issue-evidence/8904-screenshot-byte-cap.md`.

## Root Cause
The original #8904 implementation capped forwarded screenshot count, but did not account for total file size. A completion with several large screenshots could still try to upload an unbounded media payload to the origin connector.

## Evidence
- `bunx vitest run --config vitest.config.ts __tests__/unit/screenshot-delivery.test.ts` in `plugins/plugin-agent-orchestrator` — 10 passed.
- `bun run --cwd plugins/plugin-agent-orchestrator lint:check` — passed.
- `bun run --cwd plugins/plugin-agent-orchestrator typecheck` — passed.
- `git diff --check` — passed.

## Scope Notes
- This closes the missing "total size capped" acceptance criterion called out in the reopened issue comment.
- The live Telegram scenario / delivered-image artifact remains a separate environment-gated evidence gap; this PR does not claim full issue closure.
- Android evidence is N/A for this server-side orchestrator/Telegram forwarding helper; no Android runtime or app UI code changed.
