### PR TITLE
fix(scripts): harden #10200 build helpers after adversarial review

### DIFF
--- a/.github/issue-evidence/10200-script-declutter-followup.md
+++ b/.github/issue-evidence/10200-script-declutter-followup.md
@@ -1,0 +1,74 @@
+# Script declutter — review-driven hardening (issue #10200, follow-up)
+
+Follow-up to the merged #10384 (`07b769e4e02`). An adversarial multi-agent
+review of that diff surfaced one CI blocker + three real quality gaps; a
+maintainer already fixed the blocker on `develop` (the `TSC_BIN` resolution), so
+this PR (a) makes that fix robust and (b) lands the three remaining quality
+items the review confirmed.
+
+## What this PR changes
+
+### 1. `TSC_BIN` resolution made layout-independent
+`develop` resolves `tsc` as `resolve(import.meta.dir, "..", "node_modules",
+"typescript", "bin", "tsc")` — a fixed offset that holds in a fresh CI checkout
+but **breaks in a git worktree** (no sibling `node_modules`) or any non-hoisted
+layout. Replaced with `createRequire(import.meta.url).resolve("typescript/bin/tsc")`
+(with the old path as a fallback), which follows real node module resolution and
+works in CI, in a worktree, and standalone. The invocation (`node ${TSC_BIN}`) is
+unchanged, so the 57 production plugin builds are unaffected.
+
+### 2. `externals` self-test now *proves* externalization (was tautological)
+The merged test declared `node-fetch` as a dep and asserted the bundle
+`toContain("node-fetch")` — but the dep is never installed, so the only outcomes
+were "import specifier survives" (pass) or "build throws" (error); it could never
+observe an inlined module, and would pass even if externalization were deleted
+from `buildPlugin`. Replaced with a **real installed marker dependency**: under
+`externals:"auto"` the bundle must contain the bare import but **not** the marker
+body (externalized); under `externals:[]` it must contain the marker body
+(inlined). That distinguishes externalized from bundled.
+
+### 3. Stronger declaration-emit coverage
+- `dtsTolerant` test now provokes a **genuine** `tsc` failure (real compiler,
+  TS5058 missing project) and asserts the tolerant **warning fired** (spy on
+  `console.warn`) — not just that output files are absent (which also held when
+  `tsc` simply never ran).
+- Added `dtsEmitDeclarationOnly` (the one behavior-selecting branch with no
+  coverage; used by 10+ real plugins), a tsc-free `renames`+`flatten` case (so a
+  `moveTreeContents`/rename regression is caught without a compiler), and a
+  strict-default `dtsProject`-rejects case. 12 `buildPlugin` cases + 2
+  `externalsFromPackageJson`; 100 % function coverage of `plugin-build.ts`.
+
+### 4. `turboFanoutTasks` parses Turbo dependency selectors correctly
+The inventory tool's positive-filter regex `(@elizaos\/[a-z0-9.-]+)` swallowed
+the trailing `...` of `--filter=@elizaos/app...` and missed the leading `...` of
+`--filter=...@elizaos/core` — both Turbo selectors that *include* the named
+package. Now strips a leading/trailing `...` before the equality check. (Latent:
+no wrong output today, but the classifier was objectively wrong.)
+
+### 5. `build-core.mjs` actionable output
+Prints the package count on start and, on a turbo failure, the exact
+`bun run build:core` re-run command (+ a `bun install` hint on spawn failure) —
+the issue's "what ran / why blocked / exact next command" AC for the script this
+work introduced.
+
+## Verification
+
+Run under a stripped CI-shape PATH (`env -i PATH=<node>:<bun>:/usr/bin:/bin`, no
+`node_modules/.bin`) to prove the `TSC_BIN` resolution holds on a clean runner
+and in this worktree:
+
+```
+$ bun test packages/scripts/__tests__/plugin-build.test.ts            # 12 pass, 100% func cov
+$ bun test packages/scripts/__tests__/build-core.test.ts              # 6 pass
+$ bun test packages/scripts/__tests__/audit-scripts-inventory.test.ts # 6 pass
+                                                                      # → 24 pass / 0 fail
+$ node packages/scripts/audit-scripts.mjs           # OK
+$ node packages/scripts/audit-build-typecheck.mjs   # compiler model consistent
+$ biome check <changed files>                        # clean
+# turboFanoutTasks: @elizaos/app... → [@elizaos/app]; ...@elizaos/core →
+#   [@elizaos/core]; !@elizaos/electrobun → []   (negative filters excluded)
+```
+
+The review itself: 5 parallel reviewers → per-finding adversarial verification →
+synthesis; 16 raw findings, 10 confirmed (1 blocker since fixed on develop, 3
+acted on here, the rest nits/skips with recorded rationale).

--- a/packages/scripts/__tests__/plugin-build.test.ts
+++ b/packages/scripts/__tests__/plugin-build.test.ts
@@ -8,6 +8,10 @@
  *
  * Lives in packages/scripts/__tests__ (not a workspace member), so a workflow
  * must invoke it explicitly via `bun test packages/scripts/__tests__/plugin-build.test.ts`.
+ *
+ * The driver resolves `tsc` to an absolute path (`TSC_BIN`, via node module
+ * resolution) and runs it as `node ${TSC_BIN}`, so the declaration-emit cases run
+ * without `node_modules/.bin` on PATH — exactly the bare `bun test` CI shape.
  */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
@@ -51,6 +55,11 @@ function makeFixture(opts: {
   pkg?: Record<string, unknown>;
   src?: string;
   tsconfig?: boolean;
+  /** Real dependency packages to drop into the fixture's node_modules. */
+  deps?: Record<
+    string,
+    { packageJson?: Record<string, unknown>; index: string }
+  >;
 }) {
   fixtureDir = mkdtempSync(path.join(tmpdir(), "plugin-build-"));
   writeFileSync(
@@ -76,6 +85,21 @@ function makeFixture(opts: {
       path.join(fixtureDir, "tsconfig.json"),
       JSON.stringify(TS_CONFIG, null, 2),
     );
+  }
+  for (const [name, dep] of Object.entries(opts.deps ?? {})) {
+    const depDir = path.join(fixtureDir, "node_modules", name);
+    mkdirSync(depDir, { recursive: true });
+    writeFileSync(
+      path.join(depDir, "package.json"),
+      JSON.stringify({
+        name,
+        version: "1.0.0",
+        type: "module",
+        main: "index.js",
+        ...dep.packageJson,
+      }),
+    );
+    writeFileSync(path.join(depDir, "index.js"), dep.index);
   }
   process.chdir(fixtureDir);
   return fixtureDir;
@@ -105,6 +129,35 @@ describe("buildPlugin (shared driver, issue #10200)", () => {
     expect(existsSync(distPath("index.d.ts"))).toBe(true);
     expect(readFileSync(distPath("index.d.ts"), "utf8")).toContain("add");
     // No JS bundle on the tsc-only path.
+    expect(existsSync(distPath("index.js"))).toBe(false);
+  });
+
+  test("dtsEmitDeclarationOnly passes --emitDeclarationOnly (tsconfig that also emits JS)", async () => {
+    // tsconfig WITHOUT emitDeclarationOnly: only --emitDeclarationOnly on the CLI
+    // keeps this from emitting index.js alongside the declarations.
+    makeFixture({ tsconfig: false });
+    writeFileSync(
+      path.join(fixtureDir, "tsconfig.json"),
+      JSON.stringify(
+        {
+          compilerOptions: {
+            ...TS_CONFIG.compilerOptions,
+            emitDeclarationOnly: false,
+          },
+          include: ["src"],
+        },
+        null,
+        2,
+      ),
+    );
+    await buildPlugin({
+      name: "@elizaos/fixture-plugin",
+      targets: [],
+      dtsProject: "tsconfig.json",
+      dtsEmitDeclarationOnly: true,
+    });
+    expect(existsSync(distPath("index.d.ts"))).toBe(true);
+    // --emitDeclarationOnly suppressed the JS the tsconfig would otherwise emit.
     expect(existsSync(distPath("index.js"))).toBe(false);
   });
 
@@ -171,28 +224,68 @@ describe("buildPlugin (shared driver, issue #10200)", () => {
     );
   });
 
-  test("externals:auto keeps a declared dependency un-inlined in the bundle", async () => {
-    makeFixture({
-      pkg: { dependencies: { "node-fetch": "^3.0.0" } },
-      src: 'import fetch from "node-fetch";\nexport const f = fetch;\n',
-    });
+  test("renames + flatten work with no tsc (pure-fs orchestration, no dtsProject)", async () => {
+    // Decoupled from the compiler so a moveTreeContents/rename regression is
+    // caught even where tsc is unavailable.
+    makeFixture({ tsconfig: false });
     await buildPlugin({
       name: "@elizaos/fixture-plugin",
-      externals: "auto",
       targets: [
         {
           label: "Node",
           entry: "src/index.ts",
-          outSubdir: ".",
+          outSubdir: "node",
           target: "node",
           format: "esm",
+          renames: [["index.js", "index.node.js"]],
         },
       ],
+      flatten: [{ from: "node", to: "." }],
     });
-    const bundle = readFileSync(distPath("index.js"), "utf8");
-    // The dep is externalized: a bare `from "node-fetch"` import survives rather
-    // than the module being inlined into the bundle.
-    expect(bundle).toContain("node-fetch");
+    expect(existsSync(distPath("index.node.js"))).toBe(true);
+    expect(existsSync(distPath("node"))).toBe(false);
+    expect(readFileSync(distPath("index.node.js"), "utf8")).toContain("add");
+  });
+
+  test("externals:auto externalizes a declared dep; externals:[] inlines it", async () => {
+    // The marker body proves externalization: an externalized dep keeps only the
+    // bare import (no marker bytes), an inlined dep carries the marker into the
+    // bundle. Asserting the import *specifier* alone would be tautological.
+    const MARKER = "INLINED_MARKER_9f3a2b";
+    const depIndex = `export const m = "${MARKER}";\nexport default m;\n`;
+    const fixtureOpts = {
+      pkg: { dependencies: { "fixture-marker-dep": "1.0.0" } },
+      src: 'import m from "fixture-marker-dep";\nexport const v = m;\n',
+      deps: { "fixture-marker-dep": { index: depIndex } },
+    };
+    const target = {
+      label: "Node",
+      entry: "src/index.ts",
+      outSubdir: ".",
+      target: "node" as const,
+      format: "esm" as const,
+    };
+
+    makeFixture(fixtureOpts);
+    await buildPlugin({
+      name: "@elizaos/fixture-plugin",
+      externals: "auto",
+      targets: [target],
+    });
+    const autoBundle = readFileSync(distPath("index.js"), "utf8");
+    expect(autoBundle).toContain("fixture-marker-dep"); // bare import survives
+    expect(autoBundle).not.toContain(MARKER); // body NOT inlined → externalized
+    process.chdir(originalCwd);
+    rmSync(fixtureDir, { recursive: true, force: true });
+
+    makeFixture(fixtureOpts);
+    await buildPlugin({
+      name: "@elizaos/fixture-plugin",
+      externals: [],
+      targets: [target],
+    });
+    const inlinedBundle = readFileSync(distPath("index.js"), "utf8");
+    expect(inlinedBundle).toContain(MARKER); // body inlined → NOT externalized
   });
 
   test("a failing Bun.build aborts with a thrown error (no silent success)", async () => {
@@ -213,26 +306,52 @@ describe("buildPlugin (shared driver, issue #10200)", () => {
     ).rejects.toThrow();
   });
 
-  test("dtsTolerant swallows a failed declaration emit and keeps JS outputs", async () => {
-    // No tsconfig present → tsc invocation fails; tolerant mode warns + continues.
+  test("dtsTolerant swallows a failed declaration emit and warns, keeping JS outputs", async () => {
+    // No tsconfig present → tsc fails (TS5058, missing project) → tolerant mode
+    // must warn + continue rather than abort. Spy on console.warn to prove the
+    // tolerant branch actually fired (not that tsc silently never ran).
     makeFixture({ tsconfig: false });
-    await buildPlugin({
-      name: "@elizaos/fixture-plugin",
-      targets: [
-        {
-          label: "Node",
-          entry: "src/index.ts",
-          outSubdir: ".",
-          target: "node",
-          format: "esm",
-        },
-      ],
-      dtsProject: "tsconfig.json",
-      dtsTolerant: true,
-    });
+    const warnings: string[] = [];
+    const realWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    };
+    try {
+      await buildPlugin({
+        name: "@elizaos/fixture-plugin",
+        targets: [
+          {
+            label: "Node",
+            entry: "src/index.ts",
+            outSubdir: ".",
+            target: "node",
+            format: "esm",
+          },
+        ],
+        dtsProject: "tsconfig.json",
+        dtsTolerant: true,
+      });
+    } finally {
+      console.warn = realWarn;
+    }
     // JS target survived even though declaration emit failed.
     expect(existsSync(distPath("index.js"))).toBe(true);
     expect(existsSync(distPath("index.d.ts"))).toBe(false);
+    // The tolerant branch logged the specific warning.
+    expect(warnings.some((w) => /declaration generation failed/i.test(w))).toBe(
+      true,
+    );
+  });
+
+  test("dtsProject failure WITHOUT dtsTolerant rejects (the strict default)", async () => {
+    makeFixture({ tsconfig: false });
+    await expect(
+      buildPlugin({
+        name: "@elizaos/fixture-plugin",
+        targets: [],
+        dtsProject: "tsconfig.json",
+      }),
+    ).rejects.toThrow();
   });
 });
 

--- a/packages/scripts/audit-scripts-inventory.mjs
+++ b/packages/scripts/audit-scripts-inventory.mjs
@@ -194,11 +194,15 @@ function filesFromRootScripts(reachedRoots, rootScripts, fileUniverse) {
  * every workspace package, so a fan-out task reaches packages/app's same-named
  * script — unless the invocation carries a positive `--filter=@elizaos/<pkg>`
  * allowlist that omits app (e.g. `build:core`). Negative `--filter=!…` filters
- * still include app.
+ * still include app, and Turbo's dependency selectors `<pkg>...` (with-deps) /
+ * `...<pkg>` (with-dependents) both include the named package, so the leading/
+ * trailing `...` is stripped before the equality check.
  */
 function turboFanoutTasks(body) {
   const positiveElizaFilters = [
-    ...body.matchAll(/--filter=['"]?(@elizaos\/[a-z0-9.-]+)/g),
+    ...body.matchAll(
+      /--filter=['"]?(?:\.\.\.)?(@elizaos\/[a-z0-9-]+)(?:\.\.\.)?/g,
+    ),
   ].map((m) => m[1]);
   if (
     positiveElizaFilters.length &&

--- a/packages/scripts/build-core.mjs
+++ b/packages/scripts/build-core.mjs
@@ -37,6 +37,10 @@ export function buildCoreTurboArgs(extra = []) {
 
 function main() {
   const extra = process.argv.slice(2);
+  console.log(
+    `[build-core] building ${CORE_BUILD_PACKAGES.length} core packages via turbo` +
+      (extra.length ? ` (extra args: ${extra.join(" ")})` : ""),
+  );
   const result = spawnSync(
     process.execPath,
     [RUN_TURBO, ...buildCoreTurboArgs(extra)],
@@ -44,9 +48,17 @@ function main() {
   );
   if (result.error) {
     console.error(
-      `[build-core] failed to start turbo: ${result.error.message}`,
+      `[build-core] could not start turbo: ${result.error.message}\n` +
+        `[build-core] re-run after \`bun install\`: bun run build:core`,
     );
     process.exit(1);
+  }
+  if (result.status !== 0) {
+    console.error(
+      `[build-core] turbo failed (exit ${result.status ?? "signal"}) building ` +
+        `the ${CORE_BUILD_PACKAGES.length} core packages. The failing package + ` +
+        `error are in turbo's output above. Re-run: bun run build:core`,
+    );
   }
   process.exit(result.status ?? 1);
 }

--- a/plugins/plugin-build.ts
+++ b/plugins/plugin-build.ts
@@ -10,6 +10,7 @@
  */
 import { existsSync } from "node:fs";
 import { copyFile, mkdir, readdir, rename, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { dirname, join, relative, resolve } from "node:path";
 import {
   type ExternalsFromPackageJsonOptions,
@@ -117,14 +118,30 @@ const REWRITE_DIST_IMPORTS = resolve(
   "rewrite-dist-relative-imports-node-esm.mjs",
 );
 
-const TSC_BIN = resolve(
-  import.meta.dir,
-  "..",
-  "node_modules",
-  "typescript",
-  "bin",
-  "tsc",
-);
+/**
+ * Absolute path to the workspace `tsc` JS entry. Resolved via node module
+ * resolution so it works regardless of the node_modules layout — a fresh CI
+ * checkout, a hoisted/symlinked install, or a git worktree that borrows a
+ * parent's node_modules — instead of assuming a fixed `../node_modules/...`
+ * offset (which is absent in a worktree). `buildPlugin` runs it as
+ * `node ${TSC_BIN}`, so it needs no `node_modules/.bin` on PATH: `Bun.$`
+ * resolves commands from the bun process's startup PATH, which a bare
+ * `bun test` step does not extend (only `bun run` does).
+ */
+const TSC_BIN = (() => {
+  try {
+    return createRequire(import.meta.url).resolve("typescript/bin/tsc");
+  } catch {
+    return resolve(
+      import.meta.dir,
+      "..",
+      "node_modules",
+      "typescript",
+      "bin",
+      "tsc",
+    );
+  }
+})();
 
 /**
  * Recursively move every file under `fromDir` into `toDir`, preserving the


### PR DESCRIPTION
Follow-up to the merged [#10384](https://github.com/elizaOS/eliza/pull/10384) (`07b769e`). After it merged, I ran an adversarial multi-agent review of the diff (5 parallel reviewers → per-finding verification → synthesis; 16 raw findings, 10 confirmed). It surfaced **one CI blocker** plus three real quality gaps. The blocker was independently fixed on `develop` by a maintainer (the `TSC_BIN` resolution); this PR makes that fix robust and lands the three confirmed quality items.

## Changes

### 1. `TSC_BIN` resolution made layout-independent
`develop` resolves `tsc` at a fixed `resolve(import.meta.dir, "..", "node_modules", "typescript", "bin", "tsc")` offset — correct in a fresh CI checkout, but **broken in a git worktree** (no sibling `node_modules`) or any non-hoisted layout. Now resolved via `createRequire(import.meta.url).resolve("typescript/bin/tsc")` (old path kept as fallback). The `node ${TSC_BIN}` invocation is unchanged → the 57 production plugin builds are byte-for-byte unaffected.

### 2. `externals` self-test now *proves* externalization (was tautological)
The merged test declared `node-fetch` as a dep (never installed) and asserted `bundle.toContain("node-fetch")` — which holds even if externalization were deleted from `buildPlugin`. Replaced with a **real installed marker dependency**: under `externals:"auto"` the bundle keeps the bare import but **not** the marker body (externalized); under `externals:[]` it contains the marker body (inlined).

### 3. Stronger declaration-emit coverage
`dtsTolerant` now provokes a genuine `tsc` failure and asserts the tolerant **warning fired** (not just that output files are absent). Added `dtsEmitDeclarationOnly` (the one behavior-selecting branch with no coverage, used by 10+ plugins), a tsc-free `renames`+`flatten` case, and a strict-default-rejects case. 12 `buildPlugin` cases + 2 `externalsFromPackageJson`; **100% function coverage** of `plugin-build.ts`.

### 4. `turboFanoutTasks` parses Turbo dependency selectors
The inventory regex swallowed the trailing `...` of `--filter=@elizaos/app...` and missed the leading `...` of `--filter=...@elizaos/core` (both *include* the named package). Now strips `...` before the equality check. Latent (no wrong output today), now correct.

### 5. `build-core.mjs` actionable output
Prints the package count on start + the exact `bun run build:core` re-run command on failure — the issue's "what ran / why blocked / next command" AC for the script this work introduced.

## Verification
Run under a stripped CI-shape PATH (`env -i PATH=<node>:<bun>:/usr/bin:/bin`, **no** `node_modules/.bin`) to prove the `TSC_BIN` resolution holds on a clean runner:
- `bun test` the 3 self-tests → **24 pass / 0 fail** (plugin-build: 12 cases, 100% func cov).
- `audit:scripts`, `audit:scripts:self-test`, `audit:build-model` → pass.
- `biome check` on all changed files → clean.
- `turboFanoutTasks`: `@elizaos/app...` → `[@elizaos/app]`; `...@elizaos/core` → `[@elizaos/core]`; `!@elizaos/electrobun` → `[]`.

Evidence: `.github/issue-evidence/10200-script-declutter-followup.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)