### PR TITLE
fix(telegram): persist task board message ids

### DIFF
--- a/.github/issue-evidence/8902-task-board-persistence.md
+++ b/.github/issue-evidence/8902-task-board-persistence.md
@@ -1,0 +1,35 @@
+# #8902 Telegram task board persistence evidence
+
+## Change
+
+The Telegram task board now:
+
+- pins a newly posted board message when the bot exposes `pinChatMessage`
+- persists the board message id in runtime memory keyed by chat/thread
+- loads the persisted id in a fresh `TelegramTaskBoard` instance so a restart can
+  edit the existing board instead of posting a duplicate
+- forgets persisted ids after an edit failure before reposting
+
+## Validation
+
+```text
+bunx vitest run src/task-board.test.ts
+Test Files  1 passed (1)
+Tests       6 passed (6)
+```
+
+```text
+bun run --cwd plugins/plugin-telegram lint:check
+Checked 39 files. No fixes applied.
+```
+
+```text
+bun run --cwd plugins/plugin-telegram build
+Build success
+```
+
+## Remaining Evidence Gap
+
+This PR covers the pinning and restart-safe message-id persistence gaps. The
+issue still needs a live/mock Telegram scenario that drives `/tasks` through a
+status change and captures the outbound Bot API calls before full closure.

--- a/plugins/plugin-telegram/src/task-board.test.ts
+++ b/plugins/plugin-telegram/src/task-board.test.ts
@@ -35,11 +35,15 @@ describe("TelegramTaskBoard (#8902)", () => {
   it("posts on first render, then edits the same message in place", async () => {
     const post = vi.fn(async () => ({ messageId: 42 }));
     const edit = vi.fn(async () => undefined);
-    const board = new TelegramTaskBoard({ post, edit });
+    const pin = vi.fn(async () => undefined);
+    const saveMessageId = vi.fn(async () => undefined);
+    const board = new TelegramTaskBoard({ post, edit, pin, saveMessageId });
 
     const id1 = await board.render(100, entries);
     expect(id1).toBe(42);
     expect(post).toHaveBeenCalledTimes(1);
+    expect(pin).toHaveBeenCalledWith(100, 42, undefined);
+    expect(saveMessageId).toHaveBeenCalledWith(100, 42, undefined);
     expect(edit).not.toHaveBeenCalled();
 
     // second render → edits message 42 (no new post = no flooding)
@@ -50,6 +54,20 @@ describe("TelegramTaskBoard (#8902)", () => {
     expect(post).toHaveBeenCalledTimes(1);
     expect(edit).toHaveBeenCalledTimes(1);
     expect(edit).toHaveBeenCalledWith(100, 42, expect.any(String), undefined);
+  });
+
+  it("loads a persisted board id so a fresh instance edits after restart", async () => {
+    const post = vi.fn(async () => ({ messageId: 99 }));
+    const edit = vi.fn(async () => undefined);
+    const loadMessageId = vi.fn(async () => 42);
+    const board = new TelegramTaskBoard({ post, edit, loadMessageId });
+
+    const id = await board.render(100, entries, 7);
+
+    expect(id).toBe(42);
+    expect(loadMessageId).toHaveBeenCalledWith(100, 7);
+    expect(edit).toHaveBeenCalledWith(100, 42, expect.any(String), 7);
+    expect(post).not.toHaveBeenCalled();
   });
 
   it("keeps separate boards per chat/thread", async () => {
@@ -69,10 +87,12 @@ describe("TelegramTaskBoard (#8902)", () => {
       .mockResolvedValueOnce({ messageId: 1 })
       .mockResolvedValueOnce({ messageId: 2 });
     const edit = vi.fn().mockRejectedValueOnce(new Error("message not found"));
-    const board = new TelegramTaskBoard({ post, edit });
+    const forgetMessageId = vi.fn(async () => undefined);
+    const board = new TelegramTaskBoard({ post, edit, forgetMessageId });
     await board.render(100, entries); // posts msg 1
     const id = await board.render(100, entries); // edit fails → reposts msg 2
     expect(id).toBe(2);
     expect(post).toHaveBeenCalledTimes(2);
+    expect(forgetMessageId).toHaveBeenCalledWith(100, undefined);
   });
 });

--- a/plugins/plugin-telegram/src/task-board.ts
+++ b/plugins/plugin-telegram/src/task-board.ts
@@ -11,8 +11,8 @@
  * post-or-edit manager takes injected `post`/`edit` so it tests with mocks.
  */
 
-import type { IAgentRuntime, Service } from "@elizaos/core";
-import { logger } from "@elizaos/core";
+import type { IAgentRuntime, Memory, Service, UUID } from "@elizaos/core";
+import { createUniqueUuid, logger } from "@elizaos/core";
 
 /** A task reduced to what a board line needs. */
 export interface TaskBoardEntry {
@@ -87,6 +87,28 @@ export interface TaskBoardDeps {
     text: string,
     threadId?: number,
   ) => Promise<void>;
+  /** Best-effort pin for a newly posted board message. */
+  pin?: (
+    chatId: number | string,
+    messageId: number,
+    threadId?: number,
+  ) => Promise<void>;
+  /** Load a persisted board message id for this chat/thread. */
+  loadMessageId?: (
+    chatId: number | string,
+    threadId?: number,
+  ) => Promise<number | undefined>;
+  /** Persist the board message id for this chat/thread. */
+  saveMessageId?: (
+    chatId: number | string,
+    messageId: number,
+    threadId?: number,
+  ) => Promise<void>;
+  /** Forget a persisted board message id after deletion/edit failure. */
+  forgetMessageId?: (
+    chatId: number | string,
+    threadId?: number,
+  ) => Promise<void>;
 }
 
 /**
@@ -111,7 +133,11 @@ export class TelegramTaskBoard {
   ): Promise<number> {
     const text = composeTaskBoard(entries);
     const key = this.key(chatId, threadId);
-    const existing = this.boardMsgByKey.get(key);
+    let existing = this.boardMsgByKey.get(key);
+    if (existing === undefined && this.deps.loadMessageId) {
+      existing = await this.deps.loadMessageId(chatId, threadId);
+      if (existing !== undefined) this.boardMsgByKey.set(key, existing);
+    }
     if (existing !== undefined) {
       try {
         await this.deps.edit(chatId, existing, text, threadId);
@@ -124,16 +150,28 @@ export class TelegramTaskBoard {
           }`,
         );
         this.boardMsgByKey.delete(key);
+        await this.deps.forgetMessageId?.(chatId, threadId);
       }
     }
     const { messageId } = await this.deps.post(chatId, text, threadId);
     this.boardMsgByKey.set(key, messageId);
+    await this.deps.saveMessageId?.(chatId, messageId, threadId);
+    try {
+      await this.deps.pin?.(chatId, messageId, threadId);
+    } catch (error) {
+      logger.warn(
+        `[TelegramTaskBoard] pin failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
     return messageId;
   }
 
   /** Forget a stored board (e.g. when a chat is reset). */
   forget(chatId: number | string, threadId?: number): void {
     this.boardMsgByKey.delete(this.key(chatId, threadId));
+    void this.deps.forgetMessageId?.(chatId, threadId);
   }
 }
 
@@ -158,6 +196,11 @@ interface TaskBoardBot {
       text: string,
       extra?: { message_thread_id?: number },
     ) => Promise<{ message_id: number }>;
+    pinChatMessage?: (
+      chatId: number | string,
+      messageId: number,
+      extra?: { disable_notification?: boolean },
+    ) => Promise<unknown>;
   };
 }
 
@@ -189,9 +232,22 @@ export function registerTelegramTaskBoardCommand(
       );
       return { messageId: sent.message_id };
     },
+    pin: bot.telegram.pinChatMessage
+      ? async (chatId, messageId) => {
+          await bot.telegram.pinChatMessage?.(chatId, messageId, {
+            disable_notification: true,
+          });
+        }
+      : undefined,
     edit: async (chatId, messageId, text, threadId) => {
       await messageManager.editMessage(chatId, messageId, text, threadId);
     },
+    loadMessageId: (chatId, threadId) =>
+      loadPersistedTaskBoardMessageId(runtime, chatId, threadId),
+    saveMessageId: (chatId, messageId, threadId) =>
+      savePersistedTaskBoardMessageId(runtime, chatId, messageId, threadId),
+    forgetMessageId: (chatId, threadId) =>
+      forgetPersistedTaskBoardMessageId(runtime, chatId, threadId),
   });
   bot.command("tasks", async (ctx) => {
     const chatId = ctx.chat?.id;
@@ -209,6 +265,84 @@ export function registerTelegramTaskBoardCommand(
     }
   });
   return board;
+}
+
+function taskBoardMemoryIds(
+  runtime: IAgentRuntime,
+  chatId: number | string,
+  threadId?: number,
+): { id: UUID; roomId: UUID; metadata: Record<string, unknown> } {
+  const key = `${chatId}:${threadId ?? ""}`;
+  return {
+    id: createUniqueUuid(runtime, `telegram-task-board-memory:${key}`) as UUID,
+    roomId: createUniqueUuid(
+      runtime,
+      `telegram-task-board-room:${key}`,
+    ) as UUID,
+    metadata: {
+      type: "telegram_task_board",
+      chatId: String(chatId),
+      threadId: threadId ?? null,
+    },
+  };
+}
+
+export async function loadPersistedTaskBoardMessageId(
+  runtime: IAgentRuntime,
+  chatId: number | string,
+  threadId?: number,
+): Promise<number | undefined> {
+  const { id } = taskBoardMemoryIds(runtime, chatId, threadId);
+  const memory = await runtime.getMemoryById(id).catch(() => null);
+  const metadata = memory?.metadata as Record<string, unknown> | undefined;
+  const messageId = metadata?.messageId;
+  return typeof messageId === "number" && Number.isFinite(messageId)
+    ? messageId
+    : undefined;
+}
+
+export async function savePersistedTaskBoardMessageId(
+  runtime: IAgentRuntime,
+  chatId: number | string,
+  messageId: number,
+  threadId?: number,
+): Promise<void> {
+  const { id, roomId, metadata } = taskBoardMemoryIds(
+    runtime,
+    chatId,
+    threadId,
+  );
+  const nextMetadata = { ...metadata, messageId };
+  const existing = await runtime.getMemoryById(id).catch(() => null);
+  if (existing) {
+    await runtime.updateMemory({ id, metadata: nextMetadata });
+    return;
+  }
+  await runtime.createMemory(
+    {
+      id,
+      entityId: runtime.agentId,
+      agentId: runtime.agentId,
+      roomId,
+      content: {
+        text: `Telegram task board ${chatId}${threadId ? `/${threadId}` : ""}`,
+        source: "telegram",
+        type: "telegram_task_board",
+      },
+      metadata: nextMetadata,
+    } as Memory,
+    "memories",
+    true,
+  );
+}
+
+export async function forgetPersistedTaskBoardMessageId(
+  runtime: IAgentRuntime,
+  chatId: number | string,
+  threadId?: number,
+): Promise<void> {
+  const { id } = taskBoardMemoryIds(runtime, chatId, threadId);
+  await runtime.deleteMemory(id).catch(() => undefined);
 }
 
 /**


### PR DESCRIPTION
Relates #8902.

## Summary
- Pins newly posted Telegram task-board messages when `pinChatMessage` is available.
- Persists the task-board message id in runtime memory keyed by chat/thread.
- Loads the persisted id in a fresh `TelegramTaskBoard` instance so an agent restart can edit the existing board instead of posting a duplicate.
- Forgets persisted ids after edit failure before reposting.
- Adds unit coverage for pinning, persistence save/load, restart-style fresh-instance edit, and stale-id cleanup.

## Root Cause
The task board core edited in place only while its in-process `Map` survived. After restart the board id was lost, so `/tasks` could post a duplicate board instead of editing the existing one. It also did not call Telegram's pin API despite the issue requiring a pinned board.

## Evidence
- `bunx vitest run src/task-board.test.ts` in `plugins/plugin-telegram` — 6 passed.
- `bun run --cwd plugins/plugin-telegram lint:check` — passed.
- `bun run --cwd plugins/plugin-telegram build` — passed.
- `git diff --check` — passed.
- Evidence note: `.github/issue-evidence/8902-task-board-persistence.md`.

## Scope Notes
- This closes the pinning and restart-safe message-id persistence gaps.
- The live/mock Telegram scenario that drives `/tasks` through a status change and captures outbound Bot API calls remains as a separate evidence gap; this PR does not claim full issue closure.
- Android evidence is N/A for this Telegram connector/server-side task-board change; no Android runtime or app UI code changed.
