### PR TITLE
fix(telegram): persist and pin task board (#8902)

### DIFF
--- a/.github/issue-evidence/8902-telegram-task-board/README.md
+++ b/.github/issue-evidence/8902-telegram-task-board/README.md
@@ -1,0 +1,48 @@
+# #8902 Telegram Task Board Evidence
+
+This evidence covers the local, credential-free acceptance work for #8902:
+
+- `/tasks` posts a board message,
+- the board message is pinned with `pinChatMessage`,
+- the board id is persisted in runtime memory keyed to the Telegram
+  chat/thread room,
+- a fresh board instance after restart edits the persisted message instead of
+  posting a duplicate.
+
+## Commands
+
+```bash
+bun run --cwd plugins/plugin-telegram test -- src/task-board.test.ts src/messageManager.edit-react.test.ts src/command-registration.test.ts
+bunx @biomejs/biome check plugins/plugin-telegram/src/task-board.ts plugins/plugin-telegram/src/task-board.test.ts plugins/plugin-telegram/src/service.ts plugins/plugin-telegram/src/command-registration.ts
+bun run --cwd plugins/plugin-telegram build
+```
+
+Results:
+
+- `telegram-task-board-tests.log`: 3 files, 30 tests passed.
+- `biome.log`: focused Biome check passed.
+- `build-attempt.log`: `tsup` succeeded; `tsc` failed on pre-existing
+  `SetupState` export drift in `src/account-setup-routes.ts` and
+  `src/setup-routes.ts`.
+
+## Mock Bot API Report
+
+`mock-bot-api-report.json` records the tested call sequence:
+
+1. `sendMessage` creates the board.
+2. `pinChatMessage` pins the created message.
+3. runtime `upsertMemory` persists the board id.
+4. a fresh `/tasks` command instance loads that persisted id and calls
+   `editMessage` for the same message id instead of posting again.
+
+## Live Scenario Status
+
+A live scenario-runner trajectory with an actual Telegram Bot API delivery still
+requires `TELEGRAM_BOT_TOKEN` and a target chat/thread. Those credentials are not
+available in this environment, so no live Telegram screenshot/recording is
+included here.
+
+Automatic task-status-change updates remain a separate integration gap because
+there is no current orchestrator task-change event exposed to this plugin; this
+PR fixes the pinned/restart-safe single-board behavior without inventing a new
+cross-plugin event contract.

--- a/.github/issue-evidence/8902-telegram-task-board/biome.log
+++ b/.github/issue-evidence/8902-telegram-task-board/biome.log
@@ -1,0 +1,1 @@
+Checked 4 files in 103ms. No fixes applied.

--- a/.github/issue-evidence/8902-telegram-task-board/build-attempt.log
+++ b/.github/issue-evidence/8902-telegram-task-board/build-attempt.log
@@ -1,0 +1,17 @@
+$ tsup && tsc --project tsconfig.build.json
+CLI Building entry: src/account-auth-service.ts, src/index.ts
+CLI Using tsconfig: tsconfig.build.json
+CLI tsup v8.5.1
+CLI Using tsup config: /home/shaw/milady/eliza-issue-8902/plugins/plugin-telegram/tsup.config.ts
+CLI Target: esnext
+CLI Cleaning output folder
+ESM Build start
+ESM dist/account-auth-service.js     787.00 B
+ESM dist/chunk-Q2XLH3NG.js           20.31 KB
+ESM dist/index.js                    191.28 KB
+ESM dist/account-auth-service.js.map 71.00 B
+ESM dist/chunk-Q2XLH3NG.js.map       38.52 KB
+ESM dist/index.js.map                382.09 KB
+ESM ⚡️ Build success in 54ms
+src/account-setup-routes.ts(27,3): error TS2724: '"@elizaos/core"' has no exported member named 'SetupState'. Did you mean 'SetupRpcState'?
+src/setup-routes.ts(25,8): error TS2724: '"@elizaos/core"' has no exported member named 'SetupState'. Did you mean 'SetupRpcState'?

--- a/.github/issue-evidence/8902-telegram-task-board/mock-bot-api-report.json
+++ b/.github/issue-evidence/8902-telegram-task-board/mock-bot-api-report.json
@@ -1,0 +1,45 @@
+{
+  "issue": 8902,
+  "scenario": "/tasks post, pin, persist, restart, edit",
+  "calls": [
+    {
+      "method": "sendMessage",
+      "chatId": 100,
+      "textContains": "Task board",
+      "result": {
+        "message_id": 42
+      }
+    },
+    {
+      "method": "pinChatMessage",
+      "chatId": 100,
+      "messageId": 42,
+      "extra": {
+        "disable_notification": true,
+        "message_thread_id": 7
+      }
+    },
+    {
+      "method": "upsertMemory",
+      "tableName": "messages",
+      "metadata": {
+        "type": "custom",
+        "kind": "telegram_task_board",
+        "accountId": "ops",
+        "chatId": "100",
+        "threadId": 7
+      },
+      "content": {
+        "messageId": 42
+      }
+    },
+    {
+      "method": "editMessage",
+      "chatId": 100,
+      "messageId": 42,
+      "textContains": "Task board",
+      "messageThreadId": 7
+    }
+  ],
+  "proof": "plugins/plugin-telegram/src/task-board.test.ts drives registerTelegramTaskBoardCommand twice against the same memory map; the second fresh instance edits message 42 instead of posting."
+}

--- a/.github/issue-evidence/8902-telegram-task-board/telegram-task-board-tests.log
+++ b/.github/issue-evidence/8902-telegram-task-board/telegram-task-board-tests.log
@@ -1,0 +1,10 @@
+$ vitest run src/task-board.test.ts src/messageManager.edit-react.test.ts src/command-registration.test.ts
+
+ RUN  v4.1.5 /home/shaw/milady/eliza-issue-8902/plugins/plugin-telegram
+
+
+ Test Files  3 passed (3)
+      Tests  30 passed (30)
+   Start at  23:47:16
+   Duration  7.10s (transform 11.22s, setup 239ms, import 17.67s, tests 63ms, environment 0ms)
+

--- a/plugins/plugin-telegram/src/command-registration.ts
+++ b/plugins/plugin-telegram/src/command-registration.ts
@@ -88,7 +88,7 @@ export interface TelegramCommandDescriptor {
  * id this bridge derives for role resolution is the same id the inbound message
  * pipeline assigns to the sender.
  */
-function scopedTelegramKey(key: string, accountId: string): string {
+export function scopedTelegramKey(key: string, accountId: string): string {
   return accountId === DEFAULT_ACCOUNT_ID ? key : `${accountId}:${key}`;
 }
 

--- a/plugins/plugin-telegram/src/service.ts
+++ b/plugins/plugin-telegram/src/service.ts
@@ -752,6 +752,7 @@ export class TelegramService extends Service {
         bot,
         this.runtime,
         commandMessageManager,
+        accountId,
       );
     }
 

--- a/plugins/plugin-telegram/src/task-board.test.ts
+++ b/plugins/plugin-telegram/src/task-board.test.ts
@@ -1,6 +1,8 @@
+import type { Memory, UUID } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import {
   composeTaskBoard,
+  registerTelegramTaskBoardCommand,
   type TaskBoardEntry,
   TelegramTaskBoard,
   taskBoardEmoji,
@@ -35,12 +37,16 @@ describe("TelegramTaskBoard (#8902)", () => {
   it("posts on first render, then edits the same message in place", async () => {
     const post = vi.fn(async () => ({ messageId: 42 }));
     const edit = vi.fn(async () => undefined);
-    const board = new TelegramTaskBoard({ post, edit });
+    const pin = vi.fn(async () => undefined);
+    const save = vi.fn(async () => undefined);
+    const board = new TelegramTaskBoard({ post, edit, pin, save });
 
     const id1 = await board.render(100, entries);
     expect(id1).toBe(42);
     expect(post).toHaveBeenCalledTimes(1);
     expect(edit).not.toHaveBeenCalled();
+    expect(pin).toHaveBeenCalledWith(100, 42, undefined);
+    expect(save).toHaveBeenCalledWith(100, { messageId: 42 }, undefined);
 
     // second render → edits message 42 (no new post = no flooding)
     const id2 = await board.render(100, [
@@ -69,10 +75,106 @@ describe("TelegramTaskBoard (#8902)", () => {
       .mockResolvedValueOnce({ messageId: 1 })
       .mockResolvedValueOnce({ messageId: 2 });
     const edit = vi.fn().mockRejectedValueOnce(new Error("message not found"));
-    const board = new TelegramTaskBoard({ post, edit });
+    const pin = vi.fn(async () => undefined);
+    const save = vi.fn(async () => undefined);
+    const board = new TelegramTaskBoard({ post, edit, pin, save });
     await board.render(100, entries); // posts msg 1
     const id = await board.render(100, entries); // edit fails → reposts msg 2
     expect(id).toBe(2);
     expect(post).toHaveBeenCalledTimes(2);
+    expect(pin).toHaveBeenCalledTimes(2);
+    expect(save).toHaveBeenLastCalledWith(100, { messageId: 2 }, undefined);
+  });
+
+  it("loads a persisted board id after restart and edits instead of posting", async () => {
+    const post = vi.fn(async () => ({ messageId: 99 }));
+    const edit = vi.fn(async () => undefined);
+    const load = vi.fn(async () => ({ messageId: 77 }));
+    const board = new TelegramTaskBoard({ post, edit, load });
+
+    const id = await board.render(100, entries, 7);
+
+    expect(id).toBe(77);
+    expect(load).toHaveBeenCalledWith(100, 7);
+    expect(edit).toHaveBeenCalledWith(100, 77, expect.any(String), 7);
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it("keeps rendering when pinning fails", async () => {
+    const post = vi.fn(async () => ({ messageId: 42 }));
+    const edit = vi.fn(async () => undefined);
+    const pin = vi.fn(async () => {
+      throw new Error("missing pin permission");
+    });
+    const board = new TelegramTaskBoard({ post, edit, pin });
+
+    await expect(board.render(100, entries)).resolves.toBe(42);
+    expect(pin).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("registerTelegramTaskBoardCommand (#8902)", () => {
+  it("pins and persists the board id, then a fresh command instance edits the persisted message", async () => {
+    const memories = new Map<string, Memory>();
+    let handler: ((ctx: unknown) => Promise<void>) | undefined;
+    const sendMessage = vi.fn(async () => ({ message_id: 42 }));
+    const pinChatMessage = vi.fn(async () => true);
+    const editMessage = vi.fn(async () => undefined);
+    const runtime = {
+      agentId: "00000000-0000-0000-0000-0000000000aa" as UUID,
+      getMemoryById: vi.fn(async (id: string) => memories.get(id) ?? null),
+      upsertMemory: vi.fn(async (memory: Memory) => {
+        if (!memory.id) throw new Error("missing memory id");
+        memories.set(memory.id, memory);
+      }),
+      getService: vi.fn(() => ({
+        listTasks: vi.fn(async () => [
+          { id: "1", title: "ship feature", status: "active" },
+        ]),
+      })),
+    };
+    const makeBot = () => ({
+      command: vi.fn((name: string, cb: (ctx: unknown) => Promise<void>) => {
+        expect(name).toBe("tasks");
+        handler = cb;
+      }),
+      telegram: { sendMessage, pinChatMessage },
+    });
+
+    registerTelegramTaskBoardCommand(
+      makeBot() as never,
+      runtime as never,
+      { editMessage } as never,
+      "ops",
+    );
+    await handler?.({ chat: { id: 100 }, message: { message_thread_id: 7 } });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(pinChatMessage).toHaveBeenCalledWith(100, 42, {
+      disable_notification: true,
+      message_thread_id: 7,
+    });
+    expect(runtime.upsertMemory).toHaveBeenCalledTimes(1);
+    const persisted = [...memories.values()][0];
+    expect(persisted.content.messageId).toBe(42);
+    expect(persisted.metadata).toMatchObject({
+      type: "custom",
+      kind: "telegram_task_board",
+      accountId: "ops",
+      chatId: "100",
+      threadId: 7,
+    });
+
+    handler = undefined;
+    registerTelegramTaskBoardCommand(
+      makeBot() as never,
+      runtime as never,
+      { editMessage } as never,
+      "ops",
+    );
+    await handler?.({ chat: { id: 100 }, message: { message_thread_id: 7 } });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(editMessage).toHaveBeenCalledWith(100, 42, expect.any(String), 7);
   });
 });

--- a/plugins/plugin-telegram/src/task-board.ts
+++ b/plugins/plugin-telegram/src/task-board.ts
@@ -11,8 +11,15 @@
  * post-or-edit manager takes injected `post`/`edit` so it tests with mocks.
  */
 
-import type { IAgentRuntime, Service } from "@elizaos/core";
-import { logger } from "@elizaos/core";
+import {
+  createUniqueUuid,
+  type IAgentRuntime,
+  logger,
+  type Memory,
+  type Service,
+  type UUID,
+} from "@elizaos/core";
+import { scopedTelegramKey } from "./command-registration";
 
 /** A task reduced to what a board line needs. */
 export interface TaskBoardEntry {
@@ -73,6 +80,10 @@ export interface TaskBoardPostResult {
   messageId: number;
 }
 
+export interface TaskBoardRecord {
+  messageId: number;
+}
+
 export interface TaskBoardDeps {
   /** Post a new board message; returns its message id. */
   post: (
@@ -85,6 +96,23 @@ export interface TaskBoardDeps {
     chatId: number | string,
     messageId: number,
     text: string,
+    threadId?: number,
+  ) => Promise<void>;
+  /** Pin a freshly-posted board message so Telegram users can find it. */
+  pin?: (
+    chatId: number | string,
+    messageId: number,
+    threadId?: number,
+  ) => Promise<void>;
+  /** Load a persisted board message id for this chat/thread. */
+  load?: (
+    chatId: number | string,
+    threadId?: number,
+  ) => Promise<TaskBoardRecord | null>;
+  /** Persist the board message id for this chat/thread. */
+  save?: (
+    chatId: number | string,
+    record: TaskBoardRecord,
     threadId?: number,
   ) => Promise<void>;
 }
@@ -111,8 +139,11 @@ export class TelegramTaskBoard {
   ): Promise<number> {
     const text = composeTaskBoard(entries);
     const key = this.key(chatId, threadId);
-    const existing = this.boardMsgByKey.get(key);
+    const existing =
+      this.boardMsgByKey.get(key) ??
+      (await this.deps.load?.(chatId, threadId))?.messageId;
     if (existing !== undefined) {
+      this.boardMsgByKey.set(key, existing);
       try {
         await this.deps.edit(chatId, existing, text, threadId);
         return existing;
@@ -128,7 +159,25 @@ export class TelegramTaskBoard {
     }
     const { messageId } = await this.deps.post(chatId, text, threadId);
     this.boardMsgByKey.set(key, messageId);
+    await this.deps.save?.(chatId, { messageId }, threadId);
+    await this.pinBestEffort(chatId, messageId, threadId);
     return messageId;
+  }
+
+  private async pinBestEffort(
+    chatId: number | string,
+    messageId: number,
+    threadId?: number,
+  ): Promise<void> {
+    try {
+      await this.deps.pin?.(chatId, messageId, threadId);
+    } catch (error) {
+      logger.warn(
+        `[TelegramTaskBoard] pin failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
   }
 
   /** Forget a stored board (e.g. when a chat is reset). */
@@ -158,6 +207,11 @@ interface TaskBoardBot {
       text: string,
       extra?: { message_thread_id?: number },
     ) => Promise<{ message_id: number }>;
+    pinChatMessage?: (
+      chatId: number | string,
+      messageId: number,
+      extra?: { disable_notification?: boolean; message_thread_id?: number },
+    ) => Promise<unknown>;
   };
 }
 
@@ -170,6 +224,112 @@ interface TaskBoardMessageManager {
   ) => Promise<void>;
 }
 
+const TASK_BOARD_MEMORY_TYPE = "telegram_task_board";
+
+function boardRoomKey(chatId: number | string, accountId: string): string {
+  return scopedTelegramKey(String(chatId), accountId);
+}
+
+function boardThreadRoomKey(
+  chatId: number | string,
+  threadId: number | undefined,
+  accountId: string,
+): string {
+  const roomKey = threadId !== undefined ? `${chatId}-${threadId}` : chatId;
+  return scopedTelegramKey(String(roomKey), accountId);
+}
+
+function boardMemoryId(
+  runtime: IAgentRuntime,
+  accountId: string,
+  chatId: number | string,
+  threadId?: number,
+): UUID {
+  return createUniqueUuid(
+    runtime,
+    `telegram-task-board:${boardThreadRoomKey(chatId, threadId, accountId)}`,
+  ) as UUID;
+}
+
+function boardRoomId(
+  runtime: IAgentRuntime,
+  accountId: string,
+  chatId: number | string,
+  threadId?: number,
+): UUID {
+  return createUniqueUuid(
+    runtime,
+    boardThreadRoomKey(chatId, threadId, accountId),
+  ) as UUID;
+}
+
+function boardWorldId(
+  runtime: IAgentRuntime,
+  accountId: string,
+  chatId: number | string,
+): UUID {
+  return createUniqueUuid(runtime, boardRoomKey(chatId, accountId)) as UUID;
+}
+
+function parseBoardRecord(memory: Memory | undefined): TaskBoardRecord | null {
+  const messageId = memory?.content.messageId;
+  return typeof messageId === "number" && Number.isInteger(messageId)
+    ? { messageId }
+    : null;
+}
+
+async function loadPersistedBoard(
+  runtime: IAgentRuntime,
+  accountId: string,
+  chatId: number | string,
+  threadId?: number,
+): Promise<TaskBoardRecord | null> {
+  const memory = await runtime.getMemoryById(
+    boardMemoryId(runtime, accountId, chatId, threadId),
+  );
+  return parseBoardRecord(memory ?? undefined);
+}
+
+async function savePersistedBoard(
+  runtime: IAgentRuntime,
+  accountId: string,
+  chatId: number | string,
+  record: TaskBoardRecord,
+  threadId?: number,
+): Promise<void> {
+  const now = Date.now();
+  const id = boardMemoryId(runtime, accountId, chatId, threadId);
+  const memory: Memory = {
+    id,
+    entityId: runtime.agentId,
+    agentId: runtime.agentId,
+    roomId: boardRoomId(runtime, accountId, chatId, threadId),
+    worldId: boardWorldId(runtime, accountId, chatId),
+    createdAt: now,
+    unique: true,
+    content: {
+      text: `Telegram task board message ${record.messageId}`,
+      source: "telegram",
+      messageId: record.messageId,
+    },
+    metadata: {
+      type: "custom",
+      kind: TASK_BOARD_MEMORY_TYPE,
+      source: "telegram",
+      accountId,
+      chatId: String(chatId),
+      ...(threadId !== undefined ? { threadId } : {}),
+      updatedAt: now,
+    },
+  };
+
+  if (typeof runtime.upsertMemory === "function") {
+    await runtime.upsertMemory(memory, "messages");
+    return;
+  }
+  await runtime.createMemory(memory, "messages", true);
+}
+
 /**
  * Register the `/tasks` command. Holds one {@link TelegramTaskBoard} for the
  * bot's lifetime so repeated `/tasks` edit the same message in place. Returns
@@ -179,6 +339,7 @@ export function registerTelegramTaskBoardCommand(
   bot: TaskBoardBot,
   runtime: IAgentRuntime,
   messageManager: TaskBoardMessageManager,
+  accountId = "default",
 ): TelegramTaskBoard {
   const board = new TelegramTaskBoard({
     post: async (chatId, text, threadId) => {
@@ -192,6 +353,16 @@ export function registerTelegramTaskBoardCommand(
     edit: async (chatId, messageId, text, threadId) => {
       await messageManager.editMessage(chatId, messageId, text, threadId);
     },
+    pin: async (chatId, messageId, threadId) => {
+      await bot.telegram.pinChatMessage?.(chatId, messageId, {
+        disable_notification: true,
+        ...(threadId !== undefined ? { message_thread_id: threadId } : {}),
+      });
+    },
+    load: (chatId, threadId) =>
+      loadPersistedBoard(runtime, accountId, chatId, threadId),
+    save: (chatId, record, threadId) =>
+      savePersistedBoard(runtime, accountId, chatId, record, threadId),
   });
   bot.command("tasks", async (ctx) => {
     const chatId = ctx.chat?.id;


### PR DESCRIPTION
Relates #8902.

## Summary
- Pins freshly-posted `/tasks` board messages with `pinChatMessage`.
- Persists the board message id in runtime memory keyed by the Telegram account/chat/thread room.
- Reloads the persisted board id after restart so a fresh `/tasks` command instance edits the existing board instead of posting a duplicate.
- Keeps repost-on-edit-failure behavior and persists/pins the replacement board.
- Adds issue evidence under `.github/issue-evidence/8902-telegram-task-board/`.

## Validation
- `bun run --cwd plugins/plugin-telegram test -- src/task-board.test.ts src/messageManager.edit-react.test.ts src/command-registration.test.ts` passed: 3 files, 30 tests.
- `bunx @biomejs/biome check plugins/plugin-telegram/src/task-board.ts plugins/plugin-telegram/src/task-board.test.ts plugins/plugin-telegram/src/service.ts plugins/plugin-telegram/src/command-registration.ts` passed.
- `git diff --check` passed.
- `bun run --cwd plugins/plugin-telegram build` was attempted: `tsup` succeeded, then `tsc` failed on pre-existing `SetupState` export drift in `src/account-setup-routes.ts` and `src/setup-routes.ts`.

## Evidence
Committed under `.github/issue-evidence/8902-telegram-task-board/`:
- `telegram-task-board-tests.log`
- `biome.log`
- `build-attempt.log`
- `mock-bot-api-report.json`

## Remaining Limitation
This PR fixes the pinned/restart-safe single-board behavior. A live Telegram Bot API scenario still requires `TELEGRAM_BOT_TOKEN` and a target chat/thread, which are not available in this environment. Automatic task-status-change updates also remain a separate integration gap because there is no current orchestrator task-change event exposed to this plugin; I did not invent a new cross-plugin event contract in this PR.