### PR TITLE
fix(cloud): harden #9899 DB billing ledger (real overdraw bound + crash-safety)

### DIFF
--- a/.github/issue-evidence/9899-db-ledger-overdraw-measurement.json
+++ b/.github/issue-evidence/9899-db-ledger-overdraw-measurement.json
@@ -1,5 +1,5 @@
 {
-  "measuredAt": "2026-06-30T05:54:28.126Z",
+  "measuredAt": "2026-06-30T06:45:00.529Z",
   "scenarios": [
     {
       "burst": 50,

--- a/.github/issue-evidence/9899-db-ledger.md
+++ b/.github/issue-evidence/9899-db-ledger.md
@@ -63,14 +63,30 @@ under-bills one request. Documented as a tracked follow-up, not a regression.
 7 findings were adversarially **refuted** (e.g. sub-µ$ rounding, a markUncollected
 race) and correctly dropped. Full reasoning archived in the workflow transcript.
 
-## Test evidence — 97 pass / 0 fail (real DB, no larp)
+A **second** review pass over the *revised* code confirmed the runtime money-safety
+is correct (no new bugs from the transaction/advisory-lock rewrite) and surfaced
+two quality gaps, both now fixed:
+
+- **Advisory-lock bound was untested** (the behavioral suite passes identically with
+  or without the lock because single-connection PGlite serializes anyway). Added
+  `inference-billing-ledger-advisory-lock.test.ts` — mirroring `signup-grant-guard.test.ts`,
+  it asserts the per-org `pg_advisory_xact_lock` is acquired BEFORE the in-flight
+  `SUM`; **proven to fail** when the lock SQL is dropped/neutralized.
+- **Notification divergence** — the ledger debit skipped the low-credit email +
+  auto-top-up + waifu (hosted-agent pause) notifications that `deductCredits` fires.
+  Extracted `creditsService.notifyBalanceDecrease` and call it from both the
+  synchronous reserve and the ledger settle → full parity, with tests asserting it
+  fires on a debit and not on `settle(0)`.
+
+## Test evidence — 101 pass / 0 fail (real DB, no larp)
 
 Every test drives the **real SQL against in-process PGlite** (same pattern as the
 audited `credits-deduct-guard.test.ts`); only fire-and-forget non-billing
 side-effects (email/webhook/auto-top-up) are stubbed.
 
 ```
-inference-billing-ledger.test.ts              18 pass   (admission/settle/sweep/concurrency/recovery/GC)
+inference-billing-ledger.test.ts              20 pass   (admission/settle/sweep/concurrency/recovery/GC/notify-parity)
+inference-billing-ledger-advisory-lock.test.ts 2 pass   (lock acquired before SUM — fails if the lock is dropped)
 inference-pending-charges-migration.test.ts    6 pass   (journal reg + real-DB apply + idempotent)
 cron/sweep-inference-charges/route.test.ts     4 pass   (sweeps both backends)
 inference-billing-fast-path.test.ts           28 pass   (KV path — no regression)
@@ -78,10 +94,10 @@ inference-billing-cache-failure.test.ts        2 pass
 inference-auth-context.test.ts                12 pass
 inference-auth-lifecycle.test.ts               7 pass
 inference-hot-path-benchmark.test.ts           3 pass
-credits-deduct-guard.test.ts                   9 pass   (credit mutation — no regression)
+credits-deduct-guard.test.ts                   9 pass   (credit mutation + notifyBalanceDecrease — no regression)
 credits-reconcile.test.ts                      8 pass
 ------------------------------------------------------------
-TOTAL                                         97 pass / 0 fail
+TOTAL                                        101 pass / 0 fail
 ```
 
 New-file typecheck: clean (only pre-existing i18n/hono-dup/stripe-version noise).

--- a/.github/issue-evidence/9899-db-ledger.md
+++ b/.github/issue-evidence/9899-db-ledger.md
@@ -22,28 +22,57 @@ discipline the issue itself prescribed.
 
 ## Residuals closed (each point-for-point)
 
-1. **Hard concurrent-overdraw bound** — admission is one atomic `FOR UPDATE` +
-   `SUM(pending)` statement; a same-org burst serializes and cannot collectively
-   overdraw (was: KV soft bound via threshold only).
-2. **True exactly-once settlement** — `request_id` PK + atomic
-   `UPDATE … WHERE status='pending'` claim; inline settler and cron sweep can
-   never both charge (was: KV near-atomic get-then-delete → rare double-bill). No
-   single-flight lock needed anymore.
-3. **Age-ordered sweep drain** — `ORDER BY enqueued_at LIMIT batch` loop over a
-   partial index, no silent `maxKeys` cap (was: unordered bounded prefix scan).
+1. **Hard concurrent-overdraw bound** — admission runs in a transaction behind a
+   per-org `pg_advisory_xact_lock`, then reads the in-flight `SUM` of `pending`
+   rows; the lock serializes admissions so each reads the SUM only after the prior
+   commits → a same-org burst cannot collectively overdraw (was: KV soft bound).
+2. **True exactly-once, crash-safe settlement** — `request_id` PK + an atomic
+   `UPDATE … WHERE status='pending'` claim that runs in the SAME transaction as the
+   debit; a crash between them rolls back (row stays `pending`, sweep recovers) and
+   no over-admit window is ever visible (was: KV near-atomic get-then-delete → rare
+   double-bill; a first cut also had a claim→debit crash window). No single-flight
+   lock needed.
+3. **Age-ordered sweep drain + bounded growth** — `ORDER BY enqueued_at LIMIT
+   batch` loop over a partial index with an in-SQL (timezone-safe) cutoff, no
+   silent cap; GCs terminal rows past retention (was: unordered bounded prefix
+   scan). The cron sweeps both backends so a flag flip can't orphan rows.
 
 Plus `uncollected` becomes a first-class auditable row state; the org self-heals
 onto the synchronous-reserve path on a refused debit.
 
-## Test evidence — 90 pass / 0 fail (real DB, no larp)
+## Adversarial hardening (5-lens review, 3-vote verify)
+
+After the first cut, a multi-agent adversarial review (5 money-safety lenses; each
+finding confirmed/refuted by 3 independent skeptics) was run over the ledger — the
+same discipline the Tier 1/2 design received. It confirmed 11 of 18 findings; the
+material ones were **fixed**, and the design above is the corrected version:
+
+| # | Confirmed defect | Fix |
+|---|---|---|
+| 3 / 10 (HIGH) | Admission `SUM` reads a stale MVCC snapshot under READ COMMITTED — `FOR UPDATE` on the org row does NOT serialize a cross-table SUM, so a same-org burst over-admits on real Postgres (the headline "hard bound" was false; PGlite's single connection hid it) | Admission now runs in a transaction behind a per-org `pg_advisory_xact_lock`, so the in-flight `SUM` is read only after concurrent admissions commit |
+| 1 (HIGH) | claim and debit were separate auto-commit statements; a crash between them stranded the row `settled` with no debit, unrecoverable by the sweep (lost charge) | claim + debit now run in **one transaction** — a crash rolls back the claim, the row stays `pending`, the sweep recovers it |
+| 6 (MED) | settle-window: between claim and debit a charge was out of `pending_sum` and not yet in balance → transient over-admit | closed by the same single-transaction settle (no intermediate state is ever visible) |
+| 7 / 11 (HIGH/LOW) | sweep cutoff built as a client-side UTC `toISOString()` string vs a `timestamp`-without-tz column → skew under non-UTC session tz | cutoff computed **in SQL** (`enqueued_at < NOW() − interval`) — timezone-consistent |
+| 9 (MED) | a flag flip between admit-time and sweep-time orphaned rows on the inactive backend | cron now sweeps **both** backends every run (idempotent) |
+| 2 (LOW) | rows never GC'd → unbounded growth + a reused `request_id` pins an immortal row | sweep GCs terminal rows past a 24h retention window |
+| 4 / 8 (MED/LOW) | tests asserted a bound PGlite can't prove; lost-charge path untested | concurrency test now documents the PGlite limitation; added dropped-inline-recovery + GC tests |
+
+Confirmed parity residual **not** changed (it is a product-semantics call, shared
+with the KV backstop): `billUsage` throwing after billable output → `settle(0)`
+under-bills one request. Documented as a tracked follow-up, not a regression.
+7 findings were adversarially **refuted** (e.g. sub-µ$ rounding, a markUncollected
+race) and correctly dropped. Full reasoning archived in the workflow transcript.
+
+## Test evidence — 97 pass / 0 fail (real DB, no larp)
 
 Every test drives the **real SQL against in-process PGlite** (same pattern as the
 audited `credits-deduct-guard.test.ts`); only fire-and-forget non-billing
 side-effects (email/webhook/auto-top-up) are stubbed.
 
 ```
-inference-billing-ledger.test.ts              15 pass   (admission/settle/sweep/concurrency)
+inference-billing-ledger.test.ts              18 pass   (admission/settle/sweep/concurrency/recovery/GC)
 inference-pending-charges-migration.test.ts    6 pass   (journal reg + real-DB apply + idempotent)
+cron/sweep-inference-charges/route.test.ts     4 pass   (sweeps both backends)
 inference-billing-fast-path.test.ts           28 pass   (KV path — no regression)
 inference-billing-cache-failure.test.ts        2 pass
 inference-auth-context.test.ts                12 pass
@@ -52,7 +81,7 @@ inference-hot-path-benchmark.test.ts           3 pass
 credits-deduct-guard.test.ts                   9 pass   (credit mutation — no regression)
 credits-reconcile.test.ts                      8 pass
 ------------------------------------------------------------
-TOTAL                                         90 pass / 0 fail
+TOTAL                                         97 pass / 0 fail
 ```
 
 New-file typecheck: clean (only pre-existing i18n/hono-dup/stripe-version noise).

--- a/packages/cloud/api/cron/sweep-inference-charges/route.test.ts
+++ b/packages/cloud/api/cron/sweep-inference-charges/route.test.ts
@@ -1,7 +1,8 @@
 /**
  * Regression tests for the Tier-2 pending-charge sweep cron route (#9899).
  * Asserts cron-secret enforcement, the optimistic-billing-disabled no-op, and
- * that an authorized run delegates to sweepStalePendingInferenceCharges.
+ * that an authorized run sweeps BOTH backends (DB ledger + KV) every run so a
+ * flag flip between admit-time and sweep-time can't orphan pending charges.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -13,10 +14,22 @@ const sweep = mock(async () => ({
   uncollectedOrStale: 1,
   skippedYoung: 0,
 }));
+const sweepDb = mock(async () => ({
+  scanned: 5,
+  settled: 4,
+  skipped: 1,
+  batches: 1,
+  gcDeleted: 2,
+  capHit: false,
+}));
 
 mock.module("@/lib/services/inference-billing-fast-path", () => ({
   isOptimisticBillingEnabled: () => optimisticEnabled,
   sweepStalePendingInferenceCharges: sweep,
+}));
+
+mock.module("@/lib/services/inference-billing-ledger", () => ({
+  sweepStalePendingInferenceChargesDb: sweepDb,
 }));
 
 mock.module("@/lib/utils/logger", () => ({
@@ -44,6 +57,7 @@ describe("sweep-inference-charges cron route", () => {
   beforeEach(() => {
     optimisticEnabled = false;
     sweep.mockClear();
+    sweepDb.mockClear();
   });
 
   test("403 when no cron secret is configured", async () => {
@@ -67,19 +81,27 @@ describe("sweep-inference-charges cron route", () => {
       skipped: "optimistic_billing_disabled",
     });
     expect(sweep).not.toHaveBeenCalled();
+    expect(sweepDb).not.toHaveBeenCalled();
   });
 
-  test("runs the sweep and returns stats when optimistic billing is enabled", async () => {
+  test("sweeps BOTH backends and returns their stats when optimistic billing is enabled", async () => {
     optimisticEnabled = true;
     const res = await call({ secret: "cron-secret" });
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toEqual({
       success: true,
-      scanned: 3,
-      settled: 2,
-      uncollectedOrStale: 1,
-      skippedYoung: 0,
+      db: {
+        scanned: 5,
+        settled: 4,
+        skipped: 1,
+        batches: 1,
+        gcDeleted: 2,
+        capHit: false,
+      },
+      kv: { scanned: 3, settled: 2, uncollectedOrStale: 1, skippedYoung: 0 },
     });
+    // BOTH backends are swept every run (orphan-window closure), regardless of flag.
+    expect(sweepDb).toHaveBeenCalledTimes(1);
     expect(sweep).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cloud/api/cron/sweep-inference-charges/route.ts
+++ b/packages/cloud/api/cron/sweep-inference-charges/route.ts
@@ -6,10 +6,7 @@ import {
   isOptimisticBillingEnabled,
   sweepStalePendingInferenceCharges,
 } from "@/lib/services/inference-billing-fast-path";
-import {
-  resolveInferenceBillingLedger,
-  sweepStalePendingInferenceChargesDb,
-} from "@/lib/services/inference-billing-ledger";
+import { sweepStalePendingInferenceChargesDb } from "@/lib/services/inference-billing-ledger";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -28,21 +25,20 @@ async function handleSweepInferenceCharges(c: Context<AppEnv>) {
       return c.json({ success: true, skipped: "optimistic_billing_disabled" });
     }
 
-    // Sweep the backstop the route writes to: the DB ledger drains oldest-first in
-    // age-ordered batches (exactly-once via the row claim), the KV backstop scans
-    // its pending prefix. Selected by INFERENCE_BILLING_LEDGER (#9899).
-    if (resolveInferenceBillingLedger() === "db") {
-      const stats = await sweepStalePendingInferenceChargesDb();
-      logger.info(
-        "[Inference Billing] DB-ledger pending-charge sweep complete",
-        stats,
-      );
-      return c.json({ success: true, backend: "db", ...stats });
-    }
-
-    const stats = await sweepStalePendingInferenceCharges();
-    logger.info("[Inference Billing] pending-charge sweep complete", stats);
-    return c.json({ success: true, backend: "kv", ...stats });
+    // Sweep BOTH backstops every run, regardless of INFERENCE_BILLING_LEDGER. Each
+    // is exactly-once/idempotent and a cheap no-op when its store is empty, so
+    // sweeping the currently-inactive backend closes the orphan window where a flag
+    // flip (or rollback) between a charge's admit-time and the next sweep would
+    // otherwise strand its pending row on the no-longer-selected backend (#9899).
+    const [db, kv] = await Promise.all([
+      sweepStalePendingInferenceChargesDb(),
+      sweepStalePendingInferenceCharges(),
+    ]);
+    logger.info("[Inference Billing] pending-charge sweep complete", {
+      db,
+      kv,
+    });
+    return c.json({ success: true, db, kv });
   } catch (error) {
     logger.error("[Inference Billing] pending-charge sweep failed", { error });
     return failureResponse(c, error);

--- a/packages/cloud/api/docs/inference-hot-path.md
+++ b/packages/cloud/api/docs/inference-hot-path.md
@@ -304,46 +304,79 @@ replacement for the KV pending-charge backstop. It is selected by
 `INFERENCE_BILLING_LEDGER="db"` (default `kv` = the KV backstop). Code lives in
 `@/lib/services/inference-billing-ledger` (`admitInferenceChargeViaLedger`,
 `createLedgerDebitSettler`, `sweepStalePendingInferenceChargesDb`,
-`resolveInferenceBillingLedger`); the chat + embeddings routes and the
-`sweep-inference-charges` cron dispatch to it when the flag is `db`.
+`resolveInferenceBillingLedger`); the chat + embeddings routes admit through it
+when the flag is `db`, and the `sweep-inference-charges` cron sweeps BOTH backends
+every run.
+
+> This design — like Tier 1/2 — was hardened by an adversarial review (5-lens,
+> 3-vote verify). It surfaced that a first cut (single `FOR UPDATE` admission +
+> non-transactional claim-then-debit) did **not** actually bound overdraw on real
+> Postgres and could lose a charge on a crash between claim and debit. The
+> mechanisms below are the corrected design; the review's confirmed findings and
+> their fixes are catalogued in `.github/issue-evidence/9899-db-ledger.md`.
 
 It closes the three KV-inherent residuals point-for-point:
 
-1. **Hard concurrent-overdraw bound (was BILL-2 redux).** Admission is ONE atomic
-   statement that locks the org row (`SELECT … FOR UPDATE`), subtracts the SUM of
-   the org's still-`pending` charges from its balance, and inserts a `pending`
-   row ONLY when `balance > threshold` AND `balance − in-flight ≥ estimate`.
-   Concurrent admissions for one org serialize on the row lock, so a burst can
-   never *collectively* overdraw — the gate is the admission, not a stale hint.
-   (Residual window: between an inline settle's atomic claim and its `deductCredits`
-   commit a charge is briefly out of `pending_sum` but not yet in the balance, a
-   sub-RTT transient over-admit that the `CHECK(>=0)` still backstops — strictly
-   tighter than the KV soft bound.)
-2. **True exactly-once settlement.** `request_id` is the table PK and the settle
-   is an atomic `UPDATE … SET status='settled' WHERE status='pending' RETURNING`.
-   Only one of {inline settler, cron sweep} can ever transition a row, so they can
-   never both charge a request — removing the KV double-bill possibility. The
-   actual debit then funnels through the single audited `creditsService.deductCredits`
-   (atomic balance guard + all notifications), so there is one credit-mutation
-   codepath. This also means the cron needs **no** KV-style single-flight lock —
-   overlapping sweeps are safe.
-3. **Age-ordered sweep drain.** The sweep selects `status='pending' AND
-   enqueued_at < cutoff ORDER BY enqueued_at ASC LIMIT batch` over a partial index
-   and loops batches until the backlog is empty (bounded by `maxBatches`, which is
-   `log`-surfaced when hit) — no silent `maxKeys` cap.
+1. **Hard concurrent-overdraw bound (was BILL-2 redux).** Admission runs inside a
+   transaction that FIRST takes a per-org `pg_advisory_xact_lock`, THEN reads the
+   org balance + the `SUM` of its still-`pending` charges and inserts a `pending`
+   row only when `balance > threshold` AND `balance − in-flight ≥ estimate`. The
+   advisory lock serializes admissions for one org, so each reads the in-flight
+   `SUM` only after any concurrent admission has **committed** (READ COMMITTED
+   takes a fresh snapshot per statement). A bare `SELECT … FOR UPDATE` on the org
+   row is **not** sufficient — the in-flight `SUM` scans a *different* table and
+   would read a stale MVCC snapshot, so two concurrent admissions both see the same
+   pre-insert `SUM` and both admit. (Single-connection PGlite serializes and hides
+   this; real multi-connection Postgres does not — which is why the lock is
+   load-bearing.) In-flight is the live `SUM` of `pending` rows themselves, so it
+   is self-correcting: a crashed/dropped settle leaves its row `pending` and still
+   counted until the sweep settles it — no separate counter to drift.
+2. **Exactly-once settlement, crash-safe.** The claim (`UPDATE … SET
+   status='settled' WHERE request_id=$ AND status='pending' RETURNING`) and the
+   actual debit run in **one transaction**. The `request_id` PK + the `pending`
+   guard make the claim exactly-once (only one of {inline settler, cron sweep} can
+   win), and because claim+debit commit together: (a) a crash between them ROLLS
+   BACK the claim, leaving the row `pending` for the sweep to recover — **no lost
+   charge**; and (b) no concurrent admission ever observes a claimed-but-undebited
+   state — **no over-admit window**. The debit replicates the same atomic `FOR
+   UPDATE` balance guard + `credit_transactions` row as `reserveAndDeductCredits`
+   (so it can run inside the claim transaction — `deductCredits` cannot take an
+   external transaction); cache invalidation fires post-commit. Because the claim
+   is a true DB transition the cron needs **no** KV-style single-flight lock —
+   overlapping sweeps and a racing inline settler are all safe.
+3. **Age-ordered sweep drain + bounded growth.** The sweep selects `status='pending'
+   AND enqueued_at < NOW() − interval(grace) ORDER BY enqueued_at ASC LIMIT batch`
+   over a partial index and loops batches until empty (bounded by `maxBatches`,
+   `log`-surfaced when hit) — no silent cap. The cutoff is computed **in SQL**
+   against `NOW()` so it is timezone-consistent with the `NOW()`-written
+   `enqueued_at` (a client-side ISO-`Z` string would skew under a non-UTC session
+   timezone). The sweep also GCs terminal (`settled`/`uncollected`) rows older than
+   a retention window, so a caller-supplied `request_id` cannot pin an immortal row
+   and the table stays bounded.
 
-`uncollected` becomes a first-class row state (auditable) instead of log-only: a
-debit the DB refuses (would overdraw) marks the row `uncollected`, drops the
-org-balance hint, and the org's NEXT admission reads the now-depleted balance and
-self-heals onto the synchronous-reserve path (402). Bounded over-spend, never
-free-forever.
+`uncollected` is a first-class row state (auditable) instead of log-only: a debit
+the DB refuses (would overdraw) marks the row `uncollected`, drops the org-balance
+hint, and the org's NEXT admission reads the now-depleted balance and self-heals
+onto the synchronous-reserve path (402) — which re-engages the low-credit /
+auto-top-up / waifu notifications that the optimistic debit deliberately does not
+fire. Bounded over-spend, never free-forever.
+
+The cron sweeps **both** backends (`db` + `kv`) on every run regardless of the
+flag — each is idempotent and a cheap no-op when empty — so a flag flip (or
+rollback) between a charge's admit-time and the next sweep cannot orphan its
+pending row on the no-longer-selected backend.
 
 What the ledger does NOT change: pricing lookups remain per-request, and the
-admission still reads a balance (now under a lock, fresh) — the Tier-2 caveat that
-"zero DB reads pre-forward" holds for AUTH+MODERATION (Tier 1) and not for the
-billing gate still stands. The win is correctness-at-scale, not a further latency
-cut; the admission's single locked round-trip is comparable to the synchronous
-reserve it replaces while additionally bounding overdraw.
+admission still reads a balance — the Tier-2 caveat that "zero DB reads pre-forward"
+holds for AUTH+MODERATION (Tier 1) and not for the billing gate still stands. The
+win is correctness-at-scale, not a further latency cut.
+
+> Known parity residual (shared with the KV backstop, NOT fixed here because it is
+> a product-semantics question): when `billUsage` throws *after* the model produced
+> billable output, the route's error path calls `settle(0)`, which claims the row
+> and charges nothing — a bounded single-request under-bill. Fixing it (charge the
+> estimate vs. leave for the sweep vs. treat as a free abort) needs a decision on
+> abort billing; tracked as a follow-up, not a regression.
 
 ### Rollout (Tier 3)
 
@@ -364,9 +397,16 @@ in prod, the KV pending-charge path can be retired.
 drives the REAL SQL against in-process PGlite (the same honest pattern as
 `credits-deduct-guard.test.ts`): admission (affordable / threshold gate / **hard
 overdraw bound** via seeded in-flight rows / unknown org / `+Inf` threshold /
-idempotent re-delivery / a concurrent burst that cannot collectively overdraw);
-settle (actual debit / **exactly-once** double-settle no-op / `settle(0)` /
-**uncollected** under `CHECK(>=0)`); sweep (stale-vs-young / inline-then-sweep no
-double-charge / age-ordered multi-batch drain). The migration file itself is
-applied to PGlite and asserted (`inference-pending-charges-migration.test.ts`):
-table + PK + both partial indexes exist, and re-applying is idempotent.
+idempotent re-delivery / a concurrent burst that cannot collectively overdraw /
+in-flight self-correction once a charge settles); settle (actual debit /
+**exactly-once** double-settle no-op / `settle(0)` / **uncollected** under
+`CHECK(>=0)`); sweep (stale-vs-young / inline-then-sweep no double-charge /
+age-ordered multi-batch drain / **dropped-inline recovery** — a never-settled row
+stays `pending` and the sweep recovers the estimate / **GC** of terminal rows past
+retention). Because single-connection PGlite serializes, the burst test asserts the
+*accounting* (in-flight ≤ balance); the HARD bound under multi-connection Postgres
+is provided by the per-org advisory lock (a property of Postgres locking the unit
+test documents but cannot exercise in PGlite). The migration file itself is applied
+to PGlite and asserted (`inference-pending-charges-migration.test.ts`): table + PK
++ both partial indexes exist, and re-applying is idempotent. The cron route test
+(`cron/sweep-inference-charges/route.test.ts`) asserts it sweeps **both** backends.

--- a/packages/cloud/api/docs/inference-hot-path.md
+++ b/packages/cloud/api/docs/inference-hot-path.md
@@ -354,12 +354,16 @@ It closes the three KV-inherent residuals point-for-point:
    a retention window, so a caller-supplied `request_id` cannot pin an immortal row
    and the table stays bounded.
 
-`uncollected` is a first-class row state (auditable) instead of log-only: a debit
-the DB refuses (would overdraw) marks the row `uncollected`, drops the org-balance
-hint, and the org's NEXT admission reads the now-depleted balance and self-heals
-onto the synchronous-reserve path (402) — which re-engages the low-credit /
-auto-top-up / waifu notifications that the optimistic debit deliberately does not
-fire. Bounded over-spend, never free-forever.
+A successful debit fires the SAME post-debit notifications every other billing
+path does — low-credits email, auto-top-up check, and the waifu hosted-agent pause
+webhook — via the shared `creditsService.notifyBalanceDecrease`, so an org draining
+through optimistic inference still gets low-balance warnings (the ledger mutates
+the balance with its own transactional SQL rather than through `deductCredits`, so
+this parity is explicit, not inherited). `uncollected` is a first-class row state
+(auditable) instead of log-only: a debit the DB refuses (would overdraw) marks the
+row `uncollected`, drops the org-balance hint, and the org's NEXT admission reads
+the now-depleted balance and self-heals onto the synchronous-reserve path (402).
+Bounded over-spend, never free-forever.
 
 The cron sweeps **both** backends (`db` + `kv`) on every run regardless of the
 flag — each is idempotent and a cheap no-op when empty — so a flag flip (or

--- a/packages/cloud/shared/src/lib/services/__tests__/inference-billing-ledger.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/inference-billing-ledger.test.ts
@@ -335,6 +335,14 @@ describe("admitInferenceChargeViaLedger — atomic admission gate", () => {
       if (!pgliteReady) return;
       // Balance $10, threshold $1, three concurrent $6 charges. At most one can be
       // admitted ($6 ≤ $10; the next sees available $4 < $6).
+      //
+      // NOTE: single-connection PGlite serializes these `Promise.all` admissions,
+      // so this asserts the ACCOUNTING (in-flight ≤ balance), not true parallel
+      // locking. The HARD bound under real multi-connection Postgres comes from the
+      // per-org `pg_advisory_xact_lock` in admitInferenceChargeViaLedger, which
+      // makes each admission read the in-flight SUM only after the prior one
+      // commits — see the module header. A bare cross-table SUM under FOR UPDATE
+      // would read a stale snapshot and over-admit.
       const results = await Promise.all(
         [0, 1, 2].map(() =>
           ledger.admitInferenceChargeViaLedger({
@@ -350,6 +358,36 @@ describe("admitInferenceChargeViaLedger — atomic admission gate", () => {
         .filter((r) => r.status === "pending")
         .reduce((s, r) => s + r.estimated, 0);
       expect(inflight).toBeLessThanOrEqual(10);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "admission accounts for in-flight via the pending rows themselves (self-correcting, no separate counter)",
+    async () => {
+      if (!pgliteReady) return;
+      // Admit $4 (in-flight $4 of $10). A second $7 is refused (10-4=6 < 7)...
+      await ledger.admitInferenceChargeViaLedger({
+        charge: charge(nextRequestId()),
+        estimatedCostUsd: 4,
+        thresholdUsd: 1,
+      });
+      const refused = await ledger.admitInferenceChargeViaLedger({
+        charge: charge(nextRequestId()),
+        estimatedCostUsd: 7,
+        thresholdUsd: 1,
+      });
+      expect(refused.admitted).toBe(false);
+      // ...but once the first SETTLES (leaves the pending set), headroom returns and
+      // the $7 is admitted — proving in-flight is the live SUM of pending rows.
+      const firstId = (await pendingRows())[0].request_id;
+      await ledger.createLedgerDebitSettler({ ...charge(firstId) })(4);
+      const nowOk = await ledger.admitInferenceChargeViaLedger({
+        charge: charge(nextRequestId()),
+        estimatedCostUsd: 5, // balance is now $6 after the $4 debit; 5 ≤ 6
+        thresholdUsd: 1,
+      });
+      expect(nowOk.admitted).toBe(true);
     },
     PGLITE_TIMEOUT,
   );
@@ -508,6 +546,57 @@ describe("sweepStalePendingInferenceChargesDb — cron backstop", () => {
       expect(stats.batches).toBeGreaterThanOrEqual(3);
       expect(await readBalance()).toBeCloseTo(95, 6);
       expect((await pendingRows()).every((r) => r.status === "settled")).toBe(true);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a dropped inline settle (row left pending) is recovered by the sweep — no lost charge",
+    async () => {
+      if (!pgliteReady) return;
+      // Admit but NEVER call the inline settler (simulates an evicted isolate /
+      // dropped waitUntil). With the OLD non-transactional code a crash could strand
+      // the row 'settled' with no debit; here the row stays 'pending' and is
+      // recoverable — the sweep charges the estimate once it ages past the grace.
+      const reqId = nextRequestId();
+      await ledger.admitInferenceChargeViaLedger({
+        charge: charge(reqId),
+        estimatedCostUsd: 5,
+        thresholdUsd: 1,
+      });
+      await dbWrite.execute(
+        `UPDATE inference_pending_charges SET enqueued_at = NOW() - INTERVAL '30 minutes' WHERE request_id = '${reqId}';`,
+      );
+      const stats = await ledger.sweepStalePendingInferenceChargesDb({ graceMs: 20 * 60 * 1000 });
+      expect(stats.settled).toBe(1);
+      expect(await readBalance()).toBeCloseTo(95, 6); // the $5 estimate recovered
+      expect(await debitCount()).toBe(1);
+      expect((await pendingRows())[0].status).toBe("settled");
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "GCs terminal rows older than the retention window; keeps recent terminal + all pending",
+    async () => {
+      if (!pgliteReady) return;
+      // Two settled rows: one ancient, one fresh; plus a still-pending (young) row.
+      await insertPending(nextRequestId(), "1.000000", 60 * 1000); // young pending — keep
+      const oldSettled = nextRequestId();
+      const newSettled = nextRequestId();
+      await dbWrite.execute(
+        `INSERT INTO inference_pending_charges (request_id, organization_id, model, provider, billing_source, estimated_cost_usd, status, enqueued_at, settled_at)
+         VALUES ('${oldSettled}', '${ORG_ID}', 'm', 'p', 'platform', '1', 'settled', NOW() - INTERVAL '50 hours', NOW() - INTERVAL '49 hours'),
+                ('${newSettled}', '${ORG_ID}', 'm', 'p', 'platform', '1', 'uncollected', NOW() - INTERVAL '2 hours', NOW() - INTERVAL '1 hour');`,
+      );
+      const stats = await ledger.sweepStalePendingInferenceChargesDb({
+        graceMs: 20 * 60 * 1000,
+        retentionMs: 24 * 60 * 60 * 1000,
+      });
+      expect(stats.gcDeleted).toBe(1); // only the 49h-old terminal row
+      const ids = (await pendingRows()).map((r) => r.request_id);
+      expect(ids).not.toContain(oldSettled); // GC'd
+      expect(ids).toContain(newSettled); // within retention → kept
     },
     PGLITE_TIMEOUT,
   );

--- a/packages/cloud/shared/src/lib/services/__tests__/inference-billing-ledger.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/inference-billing-ledger.test.ts
@@ -23,7 +23,7 @@
  * Self-skips if PGlite is unavailable (mirrors the sibling suite).
  */
 
-import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 
 process.env.DATABASE_URL ||= "pglite://memory";
 process.env.NODE_ENV ||= "test";
@@ -51,6 +51,7 @@ const USER_ID = "00000000-0000-0000-0000-00000000ce02";
 let dbWrite: typeof import("../../../db/client").dbWrite;
 let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
 let ledger: typeof import("../inference-billing-ledger");
+let creditsService: typeof import("../credits").creditsService;
 let pgliteReady = true;
 
 let chargeSeq = 0;
@@ -130,6 +131,7 @@ beforeAll(async () => {
   try {
     ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
     ledger = await import("../inference-billing-ledger");
+    ({ creditsService } = await import("../credits"));
 
     const ddl = [
       `CREATE TABLE IF NOT EXISTS organizations (
@@ -455,6 +457,53 @@ describe("createLedgerDebitSettler — exactly-once inline settlement", () => {
       expect(await readBalance()).toBeCloseTo(10, 6);
       expect(await debitCount()).toBe(0);
       expect((await pendingRows())[0]).toMatchObject({ status: "settled", actual: 0 });
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "fires the low-credit/auto-top-up/waifu notifications on a successful debit (parity with deductCredits)",
+    async () => {
+      if (!pgliteReady) return;
+      const notify = spyOn(creditsService, "notifyBalanceDecrease");
+      try {
+        const reqId = nextRequestId();
+        await ledger.admitInferenceChargeViaLedger({
+          charge: charge(reqId),
+          estimatedCostUsd: 3,
+          thresholdUsd: 1,
+        });
+        await ledger.createLedgerDebitSettler(charge(reqId))(2);
+        // The org drained $2 → it must get the same low-balance notifications every
+        // other billing path fires (so a hosted agent is told to pause, etc.).
+        expect(notify).toHaveBeenCalledTimes(1);
+        const [org, newBalance] = notify.mock.calls[0];
+        expect(org).toBe(ORG_ID);
+        expect(newBalance).toBeCloseTo(8, 6);
+      } finally {
+        notify.mockRestore();
+      }
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "does NOT fire balance-decrease notifications when nothing was debited (settle(0) / uncollected)",
+    async () => {
+      if (!pgliteReady) return;
+      const notify = spyOn(creditsService, "notifyBalanceDecrease");
+      try {
+        const reqId = nextRequestId();
+        await ledger.admitInferenceChargeViaLedger({
+          charge: charge(reqId),
+          estimatedCostUsd: 3,
+          thresholdUsd: 1,
+        });
+        await ledger.createLedgerDebitSettler(charge(reqId))(0); // claims, charges nothing
+        expect(notify).not.toHaveBeenCalled();
+      } finally {
+        notify.mockRestore();
+      }
     },
     PGLITE_TIMEOUT,
   );

--- a/packages/cloud/shared/src/lib/services/credits.ts
+++ b/packages/cloud/shared/src/lib/services/credits.ts
@@ -592,24 +592,35 @@ export class CreditsService {
             });
         }
 
-        // Check if auto top-up should be triggered
-        this.checkAndTriggerAutoTopUp(organizationId, result.newBalance).catch((error) => {
-          logger.error("[CreditsService] Failed to check auto top-up:", error);
-        });
-
-        // Queue low credits email
-        this.queueLowCreditsEmail(organizationId, result.newBalance).catch((error) => {
-          logger.error("[CreditsService] Failed to queue low credits email:", error);
-        });
-
-        // Notify waifu so a hosted agent can downgrade or pause itself when it
-        // runs low / out of credits. Fire-and-forget: a webhook delivery
-        // problem must never block the billing path.
-        this.notifyWaifuCredits(organizationId, result.newBalance, metadata).catch((error) => {
-          logger.error("[CreditsService] Failed to notify waifu credit webhook:", error);
-        });
+        this.notifyBalanceDecrease(organizationId, result.newBalance, metadata);
       }
       return result;
+    });
+  }
+
+  /**
+   * Fire the post-debit notifications a balance decrease triggers: auto-top-up
+   * check, low-credits email, and the waifu webhook that lets a hosted agent
+   * downgrade/pause itself when it runs low. Fire-and-forget — a notification
+   * failure must never block the billing path. Exposed (not inlined) so EVERY
+   * debit path stays at parity: the synchronous reserve calls it here, and the
+   * optimistic inference ledger (`inference-billing-ledger.ts`), which mutates the
+   * balance with its own transactional SQL rather than through `deductCredits`,
+   * calls it after a successful debit so its orgs still get low-balance warnings.
+   */
+  notifyBalanceDecrease(
+    organizationId: string,
+    newBalance: number,
+    metadata?: Record<string, unknown>,
+  ): void {
+    this.checkAndTriggerAutoTopUp(organizationId, newBalance).catch((error) => {
+      logger.error("[CreditsService] Failed to check auto top-up:", error);
+    });
+    this.queueLowCreditsEmail(organizationId, newBalance).catch((error) => {
+      logger.error("[CreditsService] Failed to queue low credits email:", error);
+    });
+    this.notifyWaifuCredits(organizationId, newBalance, metadata).catch((error) => {
+      logger.error("[CreditsService] Failed to notify waifu credit webhook:", error);
     });
   }
 

--- a/packages/cloud/shared/src/lib/services/inference-billing-ledger-advisory-lock.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-ledger-advisory-lock.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Discriminating regression test for the admission advisory lock (#9899).
+ *
+ * The HARD concurrent-overdraw bound rests on `admitInferenceChargeViaLedger`
+ * taking a per-org `pg_advisory_xact_lock` BEFORE it reads the cross-table
+ * in-flight `SUM` (so each admission reads the SUM only after concurrent ones
+ * commit). Single-connection PGlite serializes every statement, so the behavioral
+ * suite in `inference-billing-ledger.test.ts` passes IDENTICALLY whether the lock
+ * is present, removed, or moved after the SUM — it cannot catch a regression that
+ * re-breaks the lock.
+ *
+ * This suite closes that gap WITHOUT a real multi-connection Postgres, the same
+ * way `signup-grant-guard.test.ts` does for its lock: it mocks the transaction,
+ * records the SQL each statement runs, and asserts the advisory lock is acquired
+ * with the correct per-org key and STRICTLY BEFORE the in-flight SUM read. Drop
+ * the lock, or move it after the `SELECT … SUM(estimated_cost_usd)`, and this
+ * fails.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import * as helpersActual from "../../db/helpers";
+
+const executedSql: string[] = [];
+
+function sqlText(query: unknown): string {
+  // drizzle `sql` templates carry their static text in `queryChunks`; stringifying
+  // is enough to recognize which statement ran and to scan bound params.
+  return JSON.stringify(query);
+}
+
+/** A transaction stand-in: records every statement and returns shapes the
+ * admission SQL consumer (`sqlRows`) accepts so the gate resolves to "admitted". */
+class FakeTx {
+  async execute(query: unknown): Promise<{ rows: Array<Record<string, unknown>> }> {
+    const text = sqlText(query);
+    executedSql.push(text);
+    if (text.includes("pg_advisory_xact_lock")) return { rows: [] };
+    // The admission's single WITH … SELECT — return an org that exists + an
+    // admitted request id so the function reports `admitted: true`.
+    return { rows: [{ org_exists: true, admitted_request_id: "req-lock-test" }] };
+  }
+}
+
+// Mock ONLY the transaction seam; `sqlRows` (execute-helpers) is left real and
+// just calls `tx.execute`. `dbWrite` is a stub — the sweep/settle aren't exercised.
+const writeTransaction = mock(async (fn: (tx: FakeTx) => Promise<unknown>) => fn(new FakeTx()));
+// Spread the real module so other named exports (dbRead, useReadDb, …) still
+// resolve — a partial mock.module throws "Export not found" (bun link error).
+mock.module("../../db/helpers", () => ({
+  ...helpersActual,
+  writeTransaction,
+  dbWrite: { execute: async () => ({ rows: [] }) },
+}));
+
+mock.module("../utils/logger", () => ({
+  logger: { warn: () => {}, info: () => {}, error: () => {}, debug: () => {} },
+}));
+
+const { admitInferenceChargeViaLedger } = await import("./inference-billing-ledger");
+
+afterEach(() => {
+  executedSql.length = 0;
+  writeTransaction.mockClear();
+});
+
+const ORG = "00000000-0000-0000-0000-00000000a10c";
+
+function admit() {
+  return admitInferenceChargeViaLedger({
+    charge: {
+      requestId: "req-lock-test",
+      organizationId: ORG,
+      userId: "00000000-0000-0000-0000-00000000a10d",
+      apiKeyId: null,
+      model: "gpt-oss-120b",
+      provider: "cerebras",
+      billingSource: "platform",
+    },
+    estimatedCostUsd: 1,
+    thresholdUsd: 0.5,
+  });
+}
+
+describe("admission advisory lock (#9899 — discriminates the overdraw-bound lock)", () => {
+  test("runs inside a transaction and acquires the per-org advisory lock BEFORE the in-flight SUM", async () => {
+    const res = await admit();
+    expect(res.admitted).toBe(true);
+
+    // It must use a transaction (where the xact lock lives) — not an auto-commit.
+    expect(writeTransaction).toHaveBeenCalledTimes(1);
+
+    const lockIdx = executedSql.findIndex((s) => s.includes("pg_advisory_xact_lock"));
+    const sumIdx = executedSql.findIndex((s) => s.includes("SUM(estimated_cost_usd)"));
+
+    // The lock is present...
+    expect(lockIdx).toBeGreaterThanOrEqual(0);
+    // ...the in-flight SUM is present...
+    expect(sumIdx).toBeGreaterThanOrEqual(0);
+    // ...and the lock is taken STRICTLY BEFORE the SUM (the load-bearing order:
+    // reading the SUM before the lock would re-open the stale-snapshot race).
+    expect(lockIdx).toBeLessThan(sumIdx);
+  });
+
+  test("scopes the advisory lock to THIS org (per-org serialization, not a global lock)", async () => {
+    await admit();
+    const lockStmt = executedSql.find((s) => s.includes("pg_advisory_xact_lock"));
+    expect(lockStmt).toBeDefined();
+    // The lock key embeds the org id so distinct orgs never serialize against
+    // each other (a global lock would needlessly serialize all inference).
+    expect(lockStmt).toContain("inference_admit:");
+    expect(lockStmt).toContain(ORG);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/inference-billing-ledger.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-ledger.ts
@@ -45,7 +45,7 @@ import { CacheInvalidation } from "../cache/invalidation";
 import { invalidateOrganizationCache } from "../cache/organizations-cache";
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 import { logger } from "../utils/logger";
-import type { CreditReconciliationResult } from "./credits";
+import { type CreditReconciliationResult, creditsService } from "./credits";
 import { invalidateOrgBalanceHint } from "./inference-auth-cache";
 
 export type InferenceBillingLedger = "db" | "kv";
@@ -289,6 +289,20 @@ async function settleLedgerCharge(
     await CacheInvalidation.onCreditMutation(ctx.organizationId).catch(() => {});
     invalidateOrganizationCache(ctx.organizationId).catch(() => {});
     invalidateOrgBalanceHint(ctx.organizationId).catch(() => {});
+    // Parity with deductCredits: fire low-credits email + auto-top-up + the waifu
+    // hosted-agent pause webhook so an org draining via optimistic inference still
+    // gets low-balance warnings (the ledger debits with its own SQL, not deductCredits).
+    if (outcome.newBalance !== undefined) {
+      creditsService.notifyBalanceDecrease(ctx.organizationId, outcome.newBalance, {
+        user_id: ctx.userId,
+        requestId: ctx.requestId,
+        model: ctx.model,
+        provider: ctx.provider,
+        billingSource: ctx.billingSource,
+        type: "inference_optimistic_ledger",
+        source,
+      });
+    }
   } else if (outcome.uncollected) {
     logger.error("[InferenceLedger] uncollected inference charge", {
       organizationId: ctx.organizationId,

--- a/packages/cloud/shared/src/lib/services/inference-billing-ledger.ts
+++ b/packages/cloud/shared/src/lib/services/inference-billing-ledger.ts
@@ -3,27 +3,35 @@
  * billing (#9899) — the documented "next step" that closes the at-scale residuals
  * a KV-only backstop cannot:
  *
- *   - **Hard concurrent-overdraw bound.** Admission runs ONE atomic statement
- *     that locks the org row (`FOR UPDATE`), subtracts the SUM of the org's
- *     still-pending charges from its balance, and only inserts a new pending row
- *     if `balance - in-flight >= estimate` (and `balance > threshold`). Concurrent
- *     admissions for one org serialize on the row lock, so a burst can never
- *     collectively overdraw — the KV gate could only bound this softly via the
- *     threshold.
- *   - **Exactly-once settlement.** `request_id` is the table PK and the settle is
- *     an atomic `UPDATE ... WHERE status = 'pending'` claim, so the inline settler
- *     and the cron sweep can never both charge one request. (KV's get-then-delete
- *     was only near-atomic ⇒ a rare double-bill; the row claim removes it.)
- *   - **Age-ordered sweep drain.** The cron drains oldest-pending-first through an
- *     indexed `ORDER BY enqueued_at` cursor and loops until empty — no silent cap.
+ *   - **Hard concurrent-overdraw bound.** Admission runs inside a transaction that
+ *     first takes a per-org advisory lock (`pg_advisory_xact_lock`), THEN reads the
+ *     org balance + the SUM of its still-`pending` charges and inserts a `pending`
+ *     row only if `balance > threshold AND balance - in-flight >= estimate`. The
+ *     advisory lock serializes admissions for one org, so each reads the in-flight
+ *     SUM only after any concurrent admission has COMMITTED (READ COMMITTED takes a
+ *     fresh snapshot per statement) — a burst can never collectively overdraw. A
+ *     bare `FOR UPDATE` on the org row is NOT enough: the in-flight SUM scans a
+ *     different table and would read a stale MVCC snapshot, so two admissions would
+ *     both see the same pre-insert SUM and both admit (the bug the advisory lock
+ *     fixes; single-connection PGlite masks it, real Postgres does not).
+ *   - **Exactly-once settlement, crash-safe.** The claim (`UPDATE … SET
+ *     status='settled' WHERE status='pending'`) and the actual debit run in ONE
+ *     transaction. Only one of {inline settler, cron sweep} can win the `pending`
+ *     transition (exactly-once), and because claim+debit commit together a crash
+ *     between them ROLLS BACK the claim — the row stays `pending` and the sweep
+ *     recovers it (no lost charge), and no other transaction ever observes a
+ *     "claimed-but-not-debited" state (no over-admit window).
+ *   - **Age-ordered sweep drain.** The cron drains oldest-pending-first via an
+ *     indexed `ORDER BY enqueued_at` cursor, looping batches until empty, and GCs
+ *     terminal rows past a retention window so the table cannot grow unbounded.
  *
- * Money flow mirrors the KV path: admit (reserve in-flight) → forward → settle the
- * ACTUAL cost off the response path (sweep settles the ESTIMATE for stragglers).
- * The actual debit goes through the single audited `creditsService.deductCredits`
- * mutation (atomic balance guard + `CHECK(credit_balance >= 0)` + all
- * notifications), so there is exactly ONE credit-mutation codepath. A debit the DB
- * refuses (would go negative) is recorded `uncollected` and the org self-heals onto
- * the safe synchronous-reserve path — bounded over-spend, never free-forever.
+ * The debit is replicated here (the same atomic `FOR UPDATE` balance guard +
+ * `credit_transactions` row as `creditsService.reserveAndDeductCredits`) so it can
+ * run INSIDE the claim transaction — `deductCredits` cannot take an external
+ * transaction. A debit the DB refuses (`credit_balance >= 0` CHECK) marks the row
+ * `uncollected` (auditable) and the org self-heals onto the synchronous-reserve
+ * path on its next admission (the slow path re-engages low-credit / auto-top-up
+ * notifications). Cache invalidation fires post-commit.
  *
  * Selected by `INFERENCE_BILLING_LEDGER="db"` (default `kv` = the existing backstop
  * in `inference-billing-fast-path.ts`); both are gated behind
@@ -32,10 +40,12 @@
 
 import { sql } from "drizzle-orm";
 import { sqlRows } from "../../db/execute-helpers";
-import { dbWrite } from "../../db/helpers";
+import { dbWrite, writeTransaction } from "../../db/helpers";
+import { CacheInvalidation } from "../cache/invalidation";
+import { invalidateOrganizationCache } from "../cache/organizations-cache";
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 import { logger } from "../utils/logger";
-import { type CreditReconciliationResult, creditsService } from "./credits";
+import type { CreditReconciliationResult } from "./credits";
 import { invalidateOrgBalanceHint } from "./inference-auth-cache";
 
 export type InferenceBillingLedger = "db" | "kv";
@@ -55,11 +65,13 @@ export function resolveInferenceBillingLedger(
 
 /** Default sweep grace: a pending row older than this with no inline settle is a straggler. */
 const DEFAULT_SWEEP_GRACE_MS = 20 * 60 * 1000; // 20 min (> max route duration)
+/** Terminal rows (settled/uncollected) older than this are GC'd so the table stays bounded. */
+const DEFAULT_RETENTION_MS = 24 * 60 * 60 * 1000; // 24h — well past the sweep grace
 
 export interface LedgerChargeContext {
   requestId: string;
   organizationId: string;
-  userId: string;
+  userId: string | null;
   apiKeyId: string | null;
   model: string;
   provider: string;
@@ -72,25 +84,25 @@ export interface LedgerAdmission {
   reason?: "ineligible" | "org_not_found" | "error";
 }
 
+function isPgTrue(value: boolean | "t" | "f" | number | string | null | undefined): boolean {
+  return value === true || value === "t" || value === 1 || value === "1" || value === "true";
+}
+
 interface AdmissionRow {
   org_exists: boolean | "t" | "f" | null;
   admitted_request_id: string | null;
 }
 
-function isPgTrue(value: boolean | "t" | "f" | null | undefined): boolean {
-  return value === true || value === "t";
-}
-
 /**
  * Atomically admit an optimistic charge against the org's available balance.
  *
- * One statement, one org-row lock: read the live balance, sum the org's
- * still-`pending` charges, and INSERT a pending row ONLY when the balance clears
- * the threshold AND `balance - in-flight >= estimate`. Returns `admitted:false`
- * (→ caller takes the synchronous reserve) when the gate fails, the org is
- * missing, or the row already exists (idempotent re-delivery). Never throws — a
- * DB error resolves to `admitted:false` so the request falls back to the safe
- * path rather than forwarding on an unrecorded charge.
+ * Serialized per org by a transaction-scoped advisory lock so the in-flight SUM is
+ * read only after any concurrent admission for the same org has committed — that
+ * is what makes the overdraw bound HARD. Returns `admitted:false` (→ caller takes
+ * the synchronous reserve) when the gate fails, the org is missing, or the row
+ * already exists (idempotent re-delivery). Never throws — a DB error resolves to
+ * `admitted:false` so the request falls back to the safe path rather than
+ * forwarding on an unrecorded charge.
  */
 export async function admitInferenceChargeViaLedger(params: {
   charge: LedgerChargeContext;
@@ -105,49 +117,55 @@ export async function admitInferenceChargeViaLedger(params: {
   if (!(estimatedCostUsd >= 0)) return { admitted: false, reason: "ineligible" };
 
   try {
-    const rows = await sqlRows<AdmissionRow>(
-      dbWrite,
-      sql`
-        WITH locked_org AS (
-          SELECT id, credit_balance::numeric AS balance
-          FROM organizations
-          WHERE id = ${charge.organizationId}
-          FOR UPDATE
-        ),
-        inflight AS (
-          SELECT COALESCE(SUM(estimated_cost_usd), 0)::numeric AS pending_sum
-          FROM inference_pending_charges
-          WHERE organization_id = ${charge.organizationId}
-            AND status = 'pending'
-        ),
-        gate AS (
-          SELECT locked_org.id
-          FROM locked_org, inflight
-          WHERE locked_org.balance > ${String(thresholdUsd)}::numeric
-            AND (locked_org.balance - inflight.pending_sum) >= ${String(estimatedCostUsd)}::numeric
-        ),
-        inserted AS (
-          INSERT INTO inference_pending_charges (
-            request_id, organization_id, user_id, api_key_id,
-            model, provider, billing_source, estimated_cost_usd, status, enqueued_at
+    return await writeTransaction(async (tx) => {
+      // Serialize admissions for THIS org. Held until commit, so the next admission
+      // reads the in-flight SUM below only after ours is durable.
+      await tx.execute(
+        sql`SELECT pg_advisory_xact_lock(hashtext(${`inference_admit:${charge.organizationId}`}))`,
+      );
+      const rows = await sqlRows<AdmissionRow>(
+        tx,
+        sql`
+          WITH org AS (
+            SELECT id, credit_balance::numeric AS balance
+            FROM organizations
+            WHERE id = ${charge.organizationId}
+          ),
+          inflight AS (
+            SELECT COALESCE(SUM(estimated_cost_usd), 0)::numeric AS pending_sum
+            FROM inference_pending_charges
+            WHERE organization_id = ${charge.organizationId}
+              AND status = 'pending'
+          ),
+          gate AS (
+            SELECT org.id
+            FROM org, inflight
+            WHERE org.balance > ${String(thresholdUsd)}::numeric
+              AND (org.balance - inflight.pending_sum) >= ${String(estimatedCostUsd)}::numeric
+          ),
+          inserted AS (
+            INSERT INTO inference_pending_charges (
+              request_id, organization_id, user_id, api_key_id,
+              model, provider, billing_source, estimated_cost_usd, status, enqueued_at
+            )
+            SELECT
+              ${charge.requestId}, gate.id, ${charge.userId}, ${charge.apiKeyId},
+              ${charge.model}, ${charge.provider}, ${charge.billingSource},
+              ${String(estimatedCostUsd)}::numeric, 'pending', NOW()
+            FROM gate
+            ON CONFLICT (request_id) DO NOTHING
+            RETURNING request_id
           )
           SELECT
-            ${charge.requestId}, gate.id, ${charge.userId}, ${charge.apiKeyId},
-            ${charge.model}, ${charge.provider}, ${charge.billingSource},
-            ${String(estimatedCostUsd)}::numeric, 'pending', NOW()
-          FROM gate
-          ON CONFLICT (request_id) DO NOTHING
-          RETURNING request_id
-        )
-        SELECT
-          EXISTS(SELECT 1 FROM locked_org) AS org_exists,
-          (SELECT request_id FROM inserted) AS admitted_request_id
-      `,
-    );
-    const row = rows[0];
-    if (!row || !isPgTrue(row.org_exists)) return { admitted: false, reason: "org_not_found" };
-    if (!row.admitted_request_id) return { admitted: false, reason: "ineligible" };
-    return { admitted: true };
+            EXISTS(SELECT 1 FROM org) AS org_exists,
+            (SELECT request_id FROM inserted) AS admitted_request_id
+        `,
+      );
+      const row = rows[0];
+      if (!row || !isPgTrue(row.org_exists)) return { admitted: false, reason: "org_not_found" };
+      if (!row.admitted_request_id) return { admitted: false, reason: "ineligible" };
+      return { admitted: true };
+    });
   } catch (error) {
     logger.error("[InferenceLedger] admission failed; falling back to synchronous reserve", {
       requestId: charge.requestId,
@@ -158,62 +176,51 @@ export async function admitInferenceChargeViaLedger(params: {
   }
 }
 
+interface SettleOutcome {
+  claimed: boolean;
+  debited: boolean;
+  uncollected: boolean;
+  newBalance?: number;
+}
+
 interface ClaimRow {
   organization_id: string | null;
 }
-
-/**
- * Atomically CLAIM a pending charge: flip `pending → settled` for this request and
- * stamp the cost. Returns the org id when THIS caller won the claim, or null when
- * the row was already settled (the sweep got there first, or a duplicate settle).
- * This `WHERE status = 'pending'` transition is the exactly-once gate — only one of
- * {inline settler, sweep} can ever own a given request.
- */
-async function claimPendingCharge(requestId: string, costUsd: number): Promise<string | null> {
-  const rows = await sqlRows<ClaimRow>(
-    dbWrite,
-    sql`
-      UPDATE inference_pending_charges
-      SET status = 'settled', settled_at = NOW(), actual_cost_usd = ${String(costUsd)}::numeric
-      WHERE request_id = ${requestId} AND status = 'pending'
-      RETURNING organization_id
-    `,
-  );
-  return rows[0]?.organization_id ?? null;
-}
-
-/** Mark a claimed row `uncollected` for audit when its debit was refused. Best-effort. */
-async function markUncollected(requestId: string): Promise<void> {
-  try {
-    await dbWrite.execute(
-      sql`UPDATE inference_pending_charges SET status = 'uncollected' WHERE request_id = ${requestId}`,
-    );
-  } catch (error) {
-    logger.warn("[InferenceLedger] failed to mark charge uncollected", {
-      requestId,
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
+interface DebitRow {
+  debited: boolean | "t" | "f" | null;
+  new_balance: string | number | null;
 }
 
 /**
- * Debit a claimed charge through the single audited credit mutation. On a refused
- * debit (balance would go negative — the DB forbids it) record the uncollected
- * amount, drop the org-balance hint, and mark the row; the org's next admission
- * reads the now-depleted balance and self-heals onto the synchronous-reserve path.
- * Never throws.
+ * Settle a pending charge in ONE transaction: atomically claim it
+ * (`pending → settled`, the exactly-once gate) and, when the cost is > 0, debit it
+ * with the same atomic balance guard (`FOR UPDATE` + `credit_balance >= amount`)
+ * and `credit_transactions` row that `reserveAndDeductCredits` uses. Because both
+ * happen in one transaction, a crash rolls back the claim (the sweep re-finds a
+ * `pending` row) and no concurrent admission ever sees a claimed-but-undebited
+ * state. A refused debit (would overdraw) marks the row `uncollected`. Never throws.
  */
-async function debitClaimedCharge(
+async function settleLedgerCharge(
   ctx: LedgerChargeContext,
   amountUsd: number,
   source: "inline" | "sweep",
-): Promise<void> {
+): Promise<SettleOutcome> {
+  let outcome: SettleOutcome = { claimed: false, debited: false, uncollected: false };
   try {
-    const result = await creditsService.deductCredits({
-      organizationId: ctx.organizationId,
-      amount: amountUsd,
-      description: `Inference (ledger ${source}): ${ctx.model}`,
-      metadata: {
+    outcome = await writeTransaction(async (tx) => {
+      const claimed = await sqlRows<ClaimRow>(
+        tx,
+        sql`
+          UPDATE inference_pending_charges
+          SET status = 'settled', settled_at = NOW(), actual_cost_usd = ${String(Math.max(amountUsd, 0))}::numeric
+          WHERE request_id = ${ctx.requestId} AND status = 'pending'
+          RETURNING organization_id
+        `,
+      );
+      if (claimed.length === 0) return { claimed: false, debited: false, uncollected: false };
+      if (!(amountUsd > 0)) return { claimed: true, debited: false, uncollected: false };
+
+      const metadataJson = JSON.stringify({
         user_id: ctx.userId,
         requestId: ctx.requestId,
         model: ctx.model,
@@ -221,46 +228,91 @@ async function debitClaimedCharge(
         billingSource: ctx.billingSource,
         type: "inference_optimistic_ledger",
         source,
-      },
+      });
+      const debit = await sqlRows<DebitRow>(
+        tx,
+        sql`
+          WITH locked AS (
+            SELECT id, credit_balance::numeric AS bal
+            FROM organizations
+            WHERE id = ${ctx.organizationId}
+            FOR UPDATE
+          ),
+          upd AS (
+            UPDATE organizations o
+            SET credit_balance = o.credit_balance - ${String(amountUsd)}::numeric, updated_at = NOW()
+            FROM locked
+            WHERE o.id = locked.id AND locked.bal >= ${String(amountUsd)}::numeric
+            RETURNING o.credit_balance AS new_balance
+          ),
+          ins AS (
+            INSERT INTO credit_transactions (organization_id, amount, type, description, metadata, created_at)
+            SELECT ${ctx.organizationId}, ${String(-amountUsd)}::numeric, 'debit',
+              ${`Inference (ledger ${source}): ${ctx.model}`}, ${metadataJson}::jsonb, NOW()
+            WHERE EXISTS (SELECT 1 FROM upd)
+            RETURNING id
+          )
+          SELECT EXISTS(SELECT 1 FROM upd) AS debited, (SELECT new_balance FROM upd) AS new_balance
+        `,
+      );
+      const debited = isPgTrue(debit[0]?.debited);
+      if (!debited) {
+        await tx.execute(
+          sql`UPDATE inference_pending_charges SET status = 'uncollected' WHERE request_id = ${ctx.requestId}`,
+        );
+        return { claimed: true, debited: false, uncollected: true };
+      }
+      const nb = debit[0]?.new_balance;
+      return {
+        claimed: true,
+        debited: true,
+        uncollected: false,
+        newBalance: nb === null || nb === undefined ? undefined : Number(nb),
+      };
     });
-    if (result.success) return;
+  } catch (error) {
+    // The transaction rolled back (the row stays `pending` for the sweep). Surface
+    // it; never swallow into a false "settled".
+    logger.error("[InferenceLedger] settle transaction failed; charge left pending for sweep", {
+      requestId: ctx.requestId,
+      organizationId: ctx.organizationId,
+      amountUsd,
+      source,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { claimed: false, debited: false, uncollected: false };
+  }
+
+  // Post-commit side-effects (cache freshness; alerting). Outside the transaction.
+  if (!outcome.claimed) return outcome;
+  if (outcome.debited) {
+    await CacheInvalidation.onCreditMutation(ctx.organizationId).catch(() => {});
+    invalidateOrganizationCache(ctx.organizationId).catch(() => {});
+    invalidateOrgBalanceHint(ctx.organizationId).catch(() => {});
+  } else if (outcome.uncollected) {
     logger.error("[InferenceLedger] uncollected inference charge", {
       organizationId: ctx.organizationId,
       userId: ctx.userId,
       requestId: ctx.requestId,
       amountUsd,
       source,
-      reason: result.reason,
     });
-    await invalidateOrgBalanceHint(ctx.organizationId);
-    await markUncollected(ctx.requestId);
-  } catch (error) {
-    logger.error("[InferenceLedger] inference debit threw", {
-      organizationId: ctx.organizationId,
-      requestId: ctx.requestId,
-      amountUsd,
-      source,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    await invalidateOrgBalanceHint(ctx.organizationId);
+    invalidateOrgBalanceHint(ctx.organizationId).catch(() => {});
   }
+  return outcome;
 }
 
 /**
  * Build the post-response settler. Same `(actualCost) => Promise<...>` shape as the
- * reservation/KV settlers, so the route's single settle chain is unchanged. It
- * CLAIMS the pending row (exactly-once) then debits the actual cost; called with 0
- * on error/abort, which still claims (clearing the row) but charges nothing.
+ * reservation/KV settlers, so the route's single settle chain is unchanged. Claims
+ * + debits the actual cost atomically; called with 0 on error/abort, which still
+ * claims (clearing the row) but charges nothing.
  */
 export function createLedgerDebitSettler(
   ctx: LedgerChargeContext,
 ): (actualCostUsd: number) => Promise<CreditReconciliationResult | null> {
   return async (actualCostUsd: number) => {
-    const claimedOrg = await claimPendingCharge(ctx.requestId, Math.max(actualCostUsd, 0));
-    if (!claimedOrg) return null; // already settled by the sweep / a prior call
-    if (actualCostUsd > 0) {
-      await debitClaimedCharge(ctx, actualCostUsd, "inline");
-    }
+    await settleLedgerCharge(ctx, actualCostUsd, "inline");
     return null;
   };
 }
@@ -270,6 +322,7 @@ export interface LedgerSweepStats {
   settled: number;
   skipped: number;
   batches: number;
+  gcDeleted: number;
   /** true when the sweep hit its batch ceiling — a backlog larger than one run can drain. */
   capHit: boolean;
 }
@@ -288,28 +341,33 @@ interface SweepRow {
  * Cron backstop: settle pending rows whose inline settle never ran (isolate
  * eviction / dropped waitUntil). Drains oldest-pending-first in age-ordered
  * batches until empty (cursor by `enqueued_at`), bounded by `maxBatches`. Each row
- * is settled through the SAME atomic claim, so overlapping cron runs and a racing
- * inline settler can never double-charge — which is why this needs no KV-style
- * single-flight lock. Charges the ESTIMATE (the actual is unknown once the inline
- * path is lost).
+ * is settled through the SAME atomic transactional claim, so overlapping cron runs
+ * and a racing inline settler can never double-charge — which is why this needs no
+ * KV-style single-flight lock. Charges the ESTIMATE (the actual is unknown once the
+ * inline path is lost). Finally GCs terminal rows older than the retention window
+ * so the table cannot grow unbounded.
+ *
+ * The staleness cutoff is computed IN SQL (`enqueued_at < NOW() - interval`) so it
+ * is timezone-consistent with the `NOW()`-written `enqueued_at` — a client-side ISO
+ * string would skew under any non-UTC DB session timezone.
  */
 export async function sweepStalePendingInferenceChargesDb(opts?: {
   graceMs?: number;
   batchSize?: number;
   maxBatches?: number;
-  now?: number;
+  retentionMs?: number;
 }): Promise<LedgerSweepStats> {
   const graceMs = opts?.graceMs ?? DEFAULT_SWEEP_GRACE_MS;
   const batchSize = opts?.batchSize ?? 200;
   const maxBatches = opts?.maxBatches ?? 50;
-  const now = opts?.now ?? Date.now();
-  const cutoff = new Date(now - graceMs);
+  const retentionMs = opts?.retentionMs ?? DEFAULT_RETENTION_MS;
 
   const stats: LedgerSweepStats = {
     scanned: 0,
     settled: 0,
     skipped: 0,
     batches: 0,
+    gcDeleted: 0,
     capHit: false,
   };
 
@@ -319,7 +377,8 @@ export async function sweepStalePendingInferenceChargesDb(opts?: {
       sql`
         SELECT request_id, organization_id, user_id, model, provider, billing_source, estimated_cost_usd
         FROM inference_pending_charges
-        WHERE status = 'pending' AND enqueued_at < ${cutoff.toISOString()}
+        WHERE status = 'pending'
+          AND enqueued_at < NOW() - (${String(graceMs)} || ' milliseconds')::interval
         ORDER BY enqueued_at ASC
         LIMIT ${batchSize}
       `,
@@ -330,35 +389,46 @@ export async function sweepStalePendingInferenceChargesDb(opts?: {
 
     for (const row of rows) {
       const estimate = Number(row.estimated_cost_usd);
-      const claimedOrg = await claimPendingCharge(
-        row.request_id,
+      const outcome = await settleLedgerCharge(
+        {
+          requestId: row.request_id,
+          organizationId: row.organization_id,
+          userId: row.user_id,
+          apiKeyId: null,
+          model: row.model,
+          provider: row.provider,
+          billingSource: row.billing_source,
+        },
         Number.isFinite(estimate) ? estimate : 0,
+        "sweep",
       );
-      if (!claimedOrg) {
-        // Lost the claim to a concurrent inline settle — counts as handled, not work.
-        stats.skipped++;
-        continue;
-      }
-      if (Number.isFinite(estimate) && estimate > 0) {
-        await debitClaimedCharge(
-          {
-            requestId: row.request_id,
-            organizationId: row.organization_id,
-            userId: row.user_id ?? "",
-            apiKeyId: null,
-            model: row.model,
-            provider: row.provider,
-            billingSource: row.billing_source,
-          },
-          estimate,
-          "sweep",
-        );
-      }
-      stats.settled++;
+      if (outcome.claimed) stats.settled++;
+      else stats.skipped++; // lost the claim to a concurrent inline settle — already handled
     }
 
     if (rows.length < batchSize) break;
     if (batch === maxBatches - 1) stats.capHit = true;
+  }
+
+  // GC terminal rows so a caller-supplied request_id can't pin an immortal row and
+  // the table stays bounded. Idempotent; runs every sweep. RETURNING + row count is
+  // driver-portable (PGlite's result does not expose a reliable `rowCount`).
+  try {
+    const deleted = await sqlRows<{ request_id: string }>(
+      dbWrite,
+      sql`
+        DELETE FROM inference_pending_charges
+        WHERE status IN ('settled', 'uncollected')
+          AND settled_at IS NOT NULL
+          AND settled_at < NOW() - (${String(retentionMs)} || ' milliseconds')::interval
+        RETURNING request_id
+      `,
+    );
+    stats.gcDeleted = deleted.length;
+  } catch (error) {
+    logger.warn("[InferenceLedger] pending-charge GC failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
   }
 
   if (stats.capHit) {
@@ -368,7 +438,7 @@ export async function sweepStalePendingInferenceChargesDb(opts?: {
       scanned: stats.scanned,
     });
   }
-  if (stats.settled > 0 || stats.skipped > 0) {
+  if (stats.settled > 0 || stats.skipped > 0 || stats.gcDeleted > 0) {
     logger.warn("[InferenceLedger] swept stale pending charges (dropped inline settles)", stats);
   }
   return stats;


### PR DESCRIPTION
Follow-up to **#10380** (DB-backed inference pending-charge ledger), which merged to `develop`. After that merge I ran a **5-lens / 3-vote adversarial review** over the new money-critical ledger; it found the first cut's headline guarantees were **not actually held on real Postgres**. This PR fixes them. The ledger is dormant behind the default-off `INFERENCE_BILLING_LEDGER` flag, so `develop` was never at risk — but these must land before any cutover.

## What the review found, and the fix

| Confirmed defect (votes) | Fix |
|---|---|
| **Overdraw bound was FALSE (HIGH, 3/3 ×2 lenses).** The admission's in-flight `SUM` reads a stale MVCC snapshot under READ COMMITTED — `FOR UPDATE` on the org row does **not** serialize a cross-table `SUM`, so a same-org burst over-admits. (Single-connection PGlite masked it.) | Admission now runs in `writeTransaction` behind a per-org `pg_advisory_xact_lock` (the idiomatic pattern here — see `affiliates.ts`, `redeemable-earnings.ts`), so each admission reads the `SUM` only after concurrent ones **commit**. |
| **Lost charge on crash (HIGH, 3/3).** claim + debit were separate auto-commit statements; a crash between them stranded the row `settled` with no debit, unrecoverable by the sweep. | claim + debit now run in **one transaction** — a crash rolls back the claim, the row stays `pending`, the sweep recovers it. Also closes the settle-window transient over-admit. |
| **Timezone skew (HIGH/LOW, 3/3).** sweep cutoff was a client UTC ISO string vs a `timestamp`-without-tz column. | cutoff computed **in SQL** (`enqueued_at < NOW() − interval`). |
| **Flag-flip orphan (MED, 3/3).** | cron sweeps **both** backends every run (idempotent). |
| **Unbounded growth / immortal `request_id` (LOW, 3/3).** | sweep GCs terminal rows past a 24h retention window. |

The debit is replicated from `reserveAndDeductCredits` (same atomic `FOR UPDATE` guard + `credit_transactions` row) so it can run inside the claim transaction — `deductCredits` can't take an external tx; cache invalidation fires post-commit. A confirmed **parity residual** (shared with the KV backstop — `billUsage` throwing after output → `settle(0)` under-bills one request) is a product-semantics call on abort billing and is documented, not silently changed.

## Evidence

- **97 pass / 0 fail** across touched + related suites (all real-DB PGlite), incl. **+3 new** tests: in-flight self-correction, dropped-inline → sweep recovery (the lost-charge path), and GC retention; the cron test now asserts both-backend sweep.
- **Overdraw bound re-measured** (`.github/issue-evidence/9899-db-ledger-overdraw-measurement.json`): bursts of 50×\$3 / 20×\$10 / 100×\$1 prevent **\$50 / \$100 / \$75** of overdraw; in-flight ≤ balance; final balance ≥ 0 in every case.
- Typecheck + Biome clean on changed files. Review findings + fixes catalogued in `.github/issue-evidence/9899-db-ledger.md`; corrected design + a Tier-3 hardening note in `docs/inference-hot-path.md`.

> Note: a separate `develop` issue surfaced during rebase — a concurrent PR's `0153_agent_server_wallets_org_scoped_client_address.sql` is on `develop` but **missing from the Drizzle journal** (orphaned, will never run). It is unrelated to this PR (my migration won the `0153` slot via #10380) and is being tracked for a focused renumber-to-0154 fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)