### PR TITLE
feat(browser): add external dataset benchmark lane

### DIFF
--- a/.github/issue-evidence/10333-browser-external-dataset/README.md
+++ b/.github/issue-evidence/10333-browser-external-dataset/README.md
@@ -1,0 +1,44 @@
+# Issue #10333 - plugin-browser external dataset benchmark
+
+Branch: `feat/10333-browser-external-dataset-benchmark`
+
+## What changed
+
+- Added a committed Mind2Web/WebArena-style fixture adapter in `plugins/plugin-browser/src/benchmark/external-dataset.ts`.
+- The fixture compiles external dataset rows into the existing `BenchmarkTask` contract.
+- The runner still drives actions through `BrowserBenchmarkAdapter`, which dispatches real plugin-browser `BROWSER` workspace commands via `executeBrowserWorkspaceCommand`.
+- Added `bun run --cwd plugins/plugin-browser bench:external`.
+
+## Evidence
+
+```bash
+bunx vitest run src/benchmark/__tests__/external-dataset.test.ts src/benchmark/__tests__/miniwob-adapter.test.ts
+```
+
+Result: 2 test files passed, 8 tests passed.
+
+```bash
+bun run typecheck
+```
+
+Result: passed in `plugins/plugin-browser`.
+
+```bash
+bun run test
+```
+
+Result: 25 test files passed, 132 tests passed in `plugins/plugin-browser`.
+
+```bash
+bun run bench:external -- --out ../../.github/issue-evidence/10333-browser-external-dataset/external-dataset-oracle-run.json
+```
+
+Result: oracle solved 3/3 external dataset fixture episodes on `jsdom-web`.
+
+Primary artifact:
+
+- `external-dataset-oracle-run.json`
+
+## Scope note
+
+This lands the CI-safe external-dataset lane using committed Mind2Web/WebArena-style fixtures. It does not vendor the full public Mind2Web or WebArena corpora; larger corpus downloads and long-running CI gates remain separate infrastructure work.

--- a/.github/issue-evidence/10333-browser-external-dataset/external-dataset-oracle-run.json
+++ b/.github/issue-evidence/10333-browser-external-dataset/external-dataset-oracle-run.json
@@ -1,0 +1,216 @@
+{
+  "generatedAt": "2026-06-30T08:23:59.465Z",
+  "benchmark": "external-web-dataset",
+  "engine": "jsdom-web",
+  "policy": "oracle",
+  "seedsPerTask": 1,
+  "episodes": [
+    {
+      "taskId": "mind2web-travel-search",
+      "family": "mind2web-lite",
+      "seed": 0,
+      "utterance": "Search for a flight from SFO to JFK on 2026-07-14 and include flexible dates.",
+      "engine": "jsdom-web",
+      "policy": "oracle",
+      "reward": 1,
+      "success": true,
+      "steps": 6,
+      "trajectory": [
+        {
+          "action": {
+            "type": "fill",
+            "selector": "#from",
+            "value": "SFO",
+            "note": "origin"
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "fill",
+            "selector": "#to",
+            "value": "JFK",
+            "note": "destination"
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "fill",
+            "selector": "#date",
+            "value": "2026-07-14",
+            "note": "date"
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "check",
+            "selector": "#flexible",
+            "note": "flexible dates"
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "click",
+            "selector": "#search",
+            "note": "submit search"
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "oracle plan exhausted"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "mind2web-support-return",
+      "family": "mind2web-lite",
+      "seed": 0,
+      "utterance": "Open returns, enter order A-1042, and confirm the prepaid label request.",
+      "engine": "jsdom-web",
+      "policy": "oracle",
+      "reward": 1,
+      "success": true,
+      "steps": 5,
+      "trajectory": [
+        {
+          "action": {
+            "type": "click",
+            "selector": "#returns-link",
+            "note": "open returns"
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "fill",
+            "selector": "#order-id",
+            "value": "A-1042",
+            "note": "order id"
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "check",
+            "selector": "#prepaid-label",
+            "note": "prepaid label"
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "click",
+            "selector": "#submit-return",
+            "note": "submit return"
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "oracle plan exhausted"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    },
+    {
+      "taskId": "webarena-admin-invite",
+      "family": "webarena-lite",
+      "seed": 0,
+      "utterance": "Invite robin@example.com as an administrator and send the welcome email.",
+      "engine": "jsdom-web",
+      "policy": "oracle",
+      "reward": 1,
+      "success": true,
+      "steps": 5,
+      "trajectory": [
+        {
+          "action": {
+            "type": "fill",
+            "selector": "#invite-email",
+            "value": "robin@example.com",
+            "note": "invite email"
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "check",
+            "selector": "#admin-role",
+            "note": "admin role"
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "check",
+            "selector": "#send-welcome",
+            "note": "welcome email"
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "click",
+            "selector": "#invite",
+            "note": "send invite"
+          },
+          "resultMode": "web",
+          "error": null
+        },
+        {
+          "action": {
+            "type": "done",
+            "note": "oracle plan exhausted"
+          },
+          "resultMode": null,
+          "error": null
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "total": 3,
+    "solved": 3,
+    "successRate": 1,
+    "byTask": [
+      {
+        "taskId": "mind2web-travel-search",
+        "solved": 1,
+        "total": 1
+      },
+      {
+        "taskId": "mind2web-support-return",
+        "solved": 1,
+        "total": 1
+      },
+      {
+        "taskId": "webarena-admin-invite",
+        "solved": 1,
+        "total": 1
+      }
+    ]
+  }
+}

--- a/plugins/plugin-browser/package.json
+++ b/plugins/plugin-browser/package.json
@@ -38,6 +38,7 @@
     "bench:miniwob:chromium:capture": "bun scripts/capture-miniwob-chromium-evidence.mjs",
     "bench:miniwob:chromium:record": "bun scripts/capture-miniwob-chromium-recording.mjs",
     "bench:grounding:chromium": "bun scripts/capture-web-grounding-evidence.mjs",
+    "bench:external": "bun scripts/run-external-dataset-benchmark.mjs",
     "build": "bun run build:js && bun run build:types",
     "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist",
     "build:js": "tsup --config ../tsup.plugin-packages.shared.ts",

--- a/plugins/plugin-browser/scripts/run-external-dataset-benchmark.mjs
+++ b/plugins/plugin-browser/scripts/run-external-dataset-benchmark.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env bun
+/**
+ * External browser dataset benchmark runner (#10333).
+ *
+ * Runs committed Mind2Web/WebArena-style fixtures through the real
+ * plugin-browser BROWSER command router and writes an issue-evidence artifact.
+ */
+
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  EXTERNAL_WEB_DATASET_TASKS,
+  NoopPolicy,
+  OraclePolicy,
+  runBenchmarkSuite,
+  WrongPolicy,
+} from "../src/benchmark/index.ts";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "../../..");
+
+function parseArgs(argv) {
+  const opts = { policy: "oracle", out: null };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--policy") opts.policy = argv[++i];
+    else if (arg === "--out") opts.out = argv[++i];
+  }
+  return opts;
+}
+
+function makePolicy(name) {
+  if (name === "noop") return new NoopPolicy();
+  if (name === "wrong") return new WrongPolicy();
+  return new OraclePolicy();
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const outPath =
+    opts.out ??
+    path.join(
+      repoRoot,
+      ".github/issue-evidence/10333-browser-external-dataset",
+      `external-dataset-${opts.policy}-run.json`,
+    );
+
+  const report = await runBenchmarkSuite({
+    benchmarkName: "external-web-dataset",
+    tasks: EXTERNAL_WEB_DATASET_TASKS,
+    seeds: [0],
+    policy: makePolicy(opts.policy),
+  });
+  const stamped = { generatedAt: new Date().toISOString(), ...report };
+
+  await mkdir(path.dirname(outPath), { recursive: true });
+  await writeFile(outPath, `${JSON.stringify(stamped, null, 2)}\n`);
+
+  console.log(
+    `\nExternal dataset benchmark - engine=${report.engine} policy=${report.policy}`,
+  );
+  console.log("-".repeat(64));
+  for (const task of report.summary.byTask) {
+    const mark = task.solved === task.total ? "PASS" : "FAIL";
+    console.log(
+      `  ${mark} ${task.taskId.padEnd(28)} ${task.solved}/${task.total}`,
+    );
+  }
+  console.log("-".repeat(64));
+  console.log(
+    `  TOTAL solved ${report.summary.solved}/${report.summary.total} ` +
+      `(success rate ${(report.summary.successRate * 100).toFixed(1)}%)`,
+  );
+  console.log(`\n  artifact -> ${path.relative(repoRoot, outPath)}\n`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/plugins/plugin-browser/src/benchmark/__tests__/external-dataset.test.ts
+++ b/plugins/plugin-browser/src/benchmark/__tests__/external-dataset.test.ts
@@ -1,0 +1,84 @@
+/**
+ * External-dataset benchmark lane (#10333).
+ *
+ * The committed fixture is small, but it preserves the integration property
+ * the issue needs: dataset rows compile into benchmark tasks, and every oracle
+ * action is dispatched through real plugin-browser BROWSER commands.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  EXTERNAL_WEB_DATASET_FIXTURE,
+  EXTERNAL_WEB_DATASET_TASKS,
+} from "../external-dataset.js";
+import { NoopPolicy, OraclePolicy, WrongPolicy } from "../policy.js";
+import { runBenchmarkSuite } from "../runner.js";
+
+const fixedClock = () => 0;
+
+describe("external dataset benchmark wired through real plugin-browser", () => {
+  it("converts committed Mind2Web/WebArena-style records into benchmark tasks", () => {
+    expect(EXTERNAL_WEB_DATASET_FIXTURE).toHaveLength(3);
+    expect(EXTERNAL_WEB_DATASET_TASKS.map((task) => task.id)).toEqual(
+      EXTERNAL_WEB_DATASET_FIXTURE.map((record) => record.id),
+    );
+    expect(
+      new Set(
+        EXTERNAL_WEB_DATASET_FIXTURE.map((record) => record.sourceDataset),
+      ),
+    ).toEqual(new Set(["Mind2Web", "WebArena"]));
+
+    for (const record of EXTERNAL_WEB_DATASET_FIXTURE) {
+      expect(record.routes.length, record.id).toBeGreaterThan(0);
+      expect(record.trace.length, record.id).toBeGreaterThan(0);
+      expect(record.reward.length, record.id).toBeGreaterThan(0);
+    }
+  });
+
+  it("oracle policy solves the external dataset fixture through the real router", async () => {
+    const report = await runBenchmarkSuite({
+      benchmarkName: "external-web-dataset",
+      tasks: EXTERNAL_WEB_DATASET_TASKS,
+      seeds: [0],
+      policy: new OraclePolicy(),
+      timestampSource: fixedClock,
+    });
+
+    expect(report.benchmark).toBe("external-web-dataset");
+    expect(report.engine).toBe("jsdom-web");
+    expect(report.summary.total).toBe(EXTERNAL_WEB_DATASET_TASKS.length);
+    expect(report.summary.solved).toBe(report.summary.total);
+    expect(report.summary.successRate).toBe(1);
+
+    for (const ep of report.episodes) {
+      expect(ep.reward, ep.taskId).toBe(1);
+      expect(ep.error, ep.taskId).toBeUndefined();
+      for (const step of ep.trajectory.filter(
+        (s) => s.action.type !== "done",
+      )) {
+        expect(step.resultMode, `${ep.taskId} ${step.action.type}`).toBe("web");
+        expect(step.error, `${ep.taskId} ${step.action.type}`).toBeNull();
+      }
+    }
+  });
+
+  it("negative baselines fail the external dataset fixture", async () => {
+    const noop = await runBenchmarkSuite({
+      benchmarkName: "external-web-dataset",
+      tasks: EXTERNAL_WEB_DATASET_TASKS,
+      seeds: [0],
+      policy: new NoopPolicy(),
+      timestampSource: fixedClock,
+    });
+    expect(noop.summary.solved).toBe(0);
+
+    const wrong = await runBenchmarkSuite({
+      benchmarkName: "external-web-dataset",
+      tasks: EXTERNAL_WEB_DATASET_TASKS,
+      seeds: [0],
+      policy: new WrongPolicy(),
+      timestampSource: fixedClock,
+    });
+    expect(wrong.summary.solved).toBe(0);
+  });
+});

--- a/plugins/plugin-browser/src/benchmark/external-dataset.ts
+++ b/plugins/plugin-browser/src/benchmark/external-dataset.ts
@@ -1,0 +1,242 @@
+/**
+ * External-dataset benchmark fixtures for #10333.
+ *
+ * This is intentionally small and committed in-repo: CI can gate the adapter
+ * without downloading the full Mind2Web/WebArena corpora. Each row mirrors the
+ * external benchmark shape (site, start URL, natural-language goal, DOM routes,
+ * action trace, and observable reward checks), then compiles into the same
+ * BenchmarkTask contract used by the MiniWoB lane. Execution still goes through
+ * BrowserBenchmarkAdapter -> real BROWSER commands.
+ */
+
+import type {
+  BenchmarkAction,
+  BenchmarkRewardContext,
+  BenchmarkTask,
+} from "./types.js";
+
+export const EXTERNAL_DATASET_ORIGIN = "https://external-benchmark.test";
+
+export type ExternalDatasetFamily = "mind2web-lite" | "webarena-lite";
+
+export interface ExternalDatasetRoute {
+  url: string;
+  html: string;
+}
+
+export interface ExternalDatasetRewardCheck {
+  type: "url" | "value" | "checked" | "text";
+  selector?: string;
+  equals: string | boolean;
+}
+
+export interface ExternalDatasetRecord {
+  id: string;
+  family: ExternalDatasetFamily;
+  sourceDataset: "Mind2Web" | "WebArena";
+  site: string;
+  description: string;
+  goal: string;
+  startUrl: string;
+  routes: readonly ExternalDatasetRoute[];
+  trace: readonly BenchmarkAction[];
+  reward: readonly ExternalDatasetRewardCheck[];
+  maxSteps: number;
+}
+
+function page(title: string, body: string): string {
+  return `<!doctype html>
+<html>
+  <head><title>${escapeHtml(title)}</title></head>
+  <body>${body}</body>
+</html>`;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+const travelStart = `${EXTERNAL_DATASET_ORIGIN}/travel/search`;
+const supportStart = `${EXTERNAL_DATASET_ORIGIN}/support`;
+const supportReturns = `${EXTERNAL_DATASET_ORIGIN}/support/returns`;
+const adminStart = `${EXTERNAL_DATASET_ORIGIN}/admin`;
+
+export const EXTERNAL_WEB_DATASET_FIXTURE: readonly ExternalDatasetRecord[] = [
+  {
+    id: "mind2web-travel-search",
+    family: "mind2web-lite",
+    sourceDataset: "Mind2Web",
+    site: "travel",
+    description: "Fill a travel search form from a natural-language goal.",
+    goal: "Search for a flight from SFO to JFK on 2026-07-14 and include flexible dates.",
+    startUrl: travelStart,
+    routes: [
+      {
+        url: travelStart,
+        html: page(
+          "Travel Search",
+          `<div id="task">Search for a flight from SFO to JFK on 2026-07-14 and include flexible dates.</div>
+<label>From <input id="from" name="from" value="" /></label>
+<label>To <input id="to" name="to" value="" /></label>
+<label>Date <input id="date" name="date" value="" /></label>
+<label><input id="flexible" type="checkbox" /> Flexible dates</label>
+<button id="search" type="button">Search</button>`,
+        ),
+      },
+    ],
+    trace: [
+      { type: "fill", selector: "#from", value: "SFO", note: "origin" },
+      { type: "fill", selector: "#to", value: "JFK", note: "destination" },
+      { type: "fill", selector: "#date", value: "2026-07-14", note: "date" },
+      { type: "check", selector: "#flexible", note: "flexible dates" },
+      { type: "click", selector: "#search", note: "submit search" },
+    ],
+    reward: [
+      { type: "value", selector: "#from", equals: "SFO" },
+      { type: "value", selector: "#to", equals: "JFK" },
+      { type: "value", selector: "#date", equals: "2026-07-14" },
+      { type: "checked", selector: "#flexible", equals: true },
+    ],
+    maxSteps: 7,
+  },
+  {
+    id: "mind2web-support-return",
+    family: "mind2web-lite",
+    sourceDataset: "Mind2Web",
+    site: "support",
+    description:
+      "Navigate to a support return form and complete required fields.",
+    goal: "Open returns, enter order A-1042, and confirm the prepaid label request.",
+    startUrl: supportStart,
+    routes: [
+      {
+        url: supportStart,
+        html: page(
+          "Support Home",
+          `<div id="task">Open returns, enter order A-1042, and confirm the prepaid label request.</div>
+<a id="returns-link" href="/support/returns">Returns</a>
+<a id="warranty-link" href="/support/warranty">Warranty</a>`,
+        ),
+      },
+      {
+        url: supportReturns,
+        html: page(
+          "Returns",
+          `<label>Order <input id="order-id" value="" /></label>
+<label><input id="prepaid-label" type="checkbox" /> Request prepaid label</label>
+<button id="submit-return" type="button">Submit</button>`,
+        ),
+      },
+    ],
+    trace: [
+      { type: "click", selector: "#returns-link", note: "open returns" },
+      {
+        type: "fill",
+        selector: "#order-id",
+        value: "A-1042",
+        note: "order id",
+      },
+      { type: "check", selector: "#prepaid-label", note: "prepaid label" },
+      { type: "click", selector: "#submit-return", note: "submit return" },
+    ],
+    reward: [
+      { type: "url", equals: supportReturns },
+      { type: "value", selector: "#order-id", equals: "A-1042" },
+      { type: "checked", selector: "#prepaid-label", equals: true },
+    ],
+    maxSteps: 6,
+  },
+  {
+    id: "webarena-admin-invite",
+    family: "webarena-lite",
+    sourceDataset: "WebArena",
+    site: "admin",
+    description: "Complete a realistic admin invitation workflow.",
+    goal: "Invite robin@example.com as an administrator and send the welcome email.",
+    startUrl: adminStart,
+    routes: [
+      {
+        url: adminStart,
+        html: page(
+          "Admin Users",
+          `<div id="task">Invite robin@example.com as an administrator and send the welcome email.</div>
+<label>Email <input id="invite-email" value="" /></label>
+<label><input id="admin-role" type="checkbox" /> Administrator</label>
+<label><input id="send-welcome" type="checkbox" /> Send welcome email</label>
+<button id="invite" type="button">Invite</button>`,
+        ),
+      },
+    ],
+    trace: [
+      {
+        type: "fill",
+        selector: "#invite-email",
+        value: "robin@example.com",
+        note: "invite email",
+      },
+      { type: "check", selector: "#admin-role", note: "admin role" },
+      { type: "check", selector: "#send-welcome", note: "welcome email" },
+      { type: "click", selector: "#invite", note: "send invite" },
+    ],
+    reward: [
+      { type: "value", selector: "#invite-email", equals: "robin@example.com" },
+      { type: "checked", selector: "#admin-role", equals: true },
+      { type: "checked", selector: "#send-welcome", equals: true },
+    ],
+    maxSteps: 6,
+  },
+];
+
+export function externalDatasetRecordToTask(
+  record: ExternalDatasetRecord,
+): BenchmarkTask {
+  return {
+    id: record.id,
+    family: record.family,
+    description: `${record.sourceDataset} fixture: ${record.description}`,
+    maxSteps: record.maxSteps,
+    utterance() {
+      return record.goal;
+    },
+    build() {
+      return {
+        startUrl: record.startUrl,
+        routes: record.routes,
+      };
+    },
+    oracle() {
+      return [...record.trace];
+    },
+    reward(ctx) {
+      return scoreExternalReward(ctx, record.reward);
+    },
+  };
+}
+
+async function scoreExternalReward(
+  ctx: BenchmarkRewardContext,
+  checks: readonly ExternalDatasetRewardCheck[],
+): Promise<number> {
+  for (const check of checks) {
+    if (check.type === "url") {
+      if ((await ctx.getUrl()) !== check.equals) return 0;
+      continue;
+    }
+    if (!check.selector) return 0;
+    if (check.type === "value") {
+      if ((await ctx.getValue(check.selector)) !== check.equals) return 0;
+    } else if (check.type === "checked") {
+      if ((await ctx.getChecked(check.selector)) !== check.equals) return 0;
+    } else if ((await ctx.getText(check.selector)) !== check.equals) {
+      return 0;
+    }
+  }
+  return 1;
+}
+
+export const EXTERNAL_WEB_DATASET_TASKS: readonly BenchmarkTask[] =
+  EXTERNAL_WEB_DATASET_FIXTURE.map(externalDatasetRecordToTask);

--- a/plugins/plugin-browser/src/benchmark/index.ts
+++ b/plugins/plugin-browser/src/benchmark/index.ts
@@ -29,6 +29,16 @@ export {
   runBenchmarkSuite,
   runEpisode,
 } from "./runner.js";
+export {
+  EXTERNAL_DATASET_ORIGIN,
+  EXTERNAL_WEB_DATASET_FIXTURE,
+  EXTERNAL_WEB_DATASET_TASKS,
+  externalDatasetRecordToTask,
+  type ExternalDatasetFamily,
+  type ExternalDatasetRecord,
+  type ExternalDatasetRewardCheck,
+  type ExternalDatasetRoute,
+} from "./external-dataset.js";
 export { getTaskById, MINIWOB_TASKS, WOB_ORIGIN } from "./tasks.js";
 export type {
   BenchmarkAction,

--- a/plugins/plugin-browser/src/benchmark/runner.ts
+++ b/plugins/plugin-browser/src/benchmark/runner.ts
@@ -22,6 +22,7 @@ import type {
 
 export interface BenchmarkRunOptions {
   tasks?: readonly BenchmarkTask[];
+  benchmarkName?: string;
   seeds?: readonly number[];
   policy?: BenchmarkPolicy;
   /** Fresh executor (and its disposer) per episode. */
@@ -139,7 +140,7 @@ export async function runBenchmarkSuite(
   const solved = episodes.filter((e) => e.success).length;
 
   return {
-    benchmark: "miniwob++",
+    benchmark: options.benchmarkName ?? "miniwob++",
     engine,
     policy: policy.name,
     seedsPerTask: seeds.length,


### PR DESCRIPTION
## Summary

Adds a CI-safe external-dataset benchmark lane for `@elizaos/plugin-browser` as a follow-up slice for #10333.

- Adds committed Mind2Web/WebArena-style fixture records that compile into the existing `BenchmarkTask` interface.
- Reuses `BrowserBenchmarkAdapter`, so oracle actions still dispatch through real plugin-browser `BROWSER` workspace commands via `executeBrowserWorkspaceCommand`.
- Adds `bench:external` plus an evidence artifact under `.github/issue-evidence/10333-browser-external-dataset/`.
- Lets `runBenchmarkSuite` report an explicit `benchmarkName` for non-MiniWoB suites while preserving the existing MiniWoB default.

## Evidence

- `bunx vitest run src/benchmark/__tests__/external-dataset.test.ts src/benchmark/__tests__/miniwob-adapter.test.ts` from `plugins/plugin-browser` - passed, 2 files / 8 tests.
- `bun run typecheck` from `plugins/plugin-browser` - passed.
- `bun run test` from `plugins/plugin-browser` - passed, 25 files / 132 tests.
- `bun run bench:external -- --out ../../.github/issue-evidence/10333-browser-external-dataset/external-dataset-oracle-run.json` - passed, oracle solved 3/3 on `jsdom-web`.
- `git diff --check` - passed.

Root `bun run verify` was attempted after rebasing onto `origin/develop`; it exited nonzero on an unrelated existing lint error in `packages/agent/src/runtime/eliza.ts` import ordering (`assist/source/organizeImports`) from the crash-injection import block. No tracked files were modified by the verify run.

## Scope note

This lands the deterministic external-dataset lane with committed fixtures. It does not vendor or download the full public Mind2Web/WebArena corpora; larger corpus ingestion and long-running CI gating remain separate infrastructure work.

Part of #10333.

---
_Review note: this slice delivers only the external-dataset item of #10333 (4 checklist items total); de-scoped the auto-close so the remaining real-Chromium / grounding / CI-gating items stay tracked._