### PR TITLE
fix(orchestrator): cap forwarded screenshots by total bytes, not just count (#8904)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/screenshot-delivery.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/screenshot-delivery.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  capScreenshotPathsByBudget,
   collectScreenshotPaths,
   deliverScreenshots,
   MAX_SCREENSHOTS,
@@ -93,5 +94,49 @@ describe("deliverScreenshots (#8904)", () => {
         "/tmp/a.png",
       ]),
     ).toBe(0);
+  });
+
+  it("forwards only the screenshots that fit the byte budget (#8904)", async () => {
+    const send = vi.fn(async () => undefined);
+    // a,b,c are 4 bytes each; budget 10 → a(4)+b(8) fit, c(12) is dropped.
+    const n = await deliverScreenshots(
+      send,
+      { source: "telegram", roomId: ROOM },
+      ["/x/a.png", "/x/b.png", "/x/c.png"],
+      undefined,
+      { sizeOf: () => 4, maxTotalBytes: 10 },
+    );
+    expect(n).toBe(2);
+    expect((send.mock.calls[0][1] as { attachments: unknown[] }).attachments).toHaveLength(2);
+  });
+});
+
+describe("capScreenshotPathsByBudget (#8904)", () => {
+  const paths = ["/a.png", "/b.png", "/c.png", "/d.png"];
+
+  it("caps by count", () => {
+    const many = Array.from({ length: 7 }, (_, i) => `/${i}.png`);
+    expect(capScreenshotPathsByBudget(many, { sizeOf: () => 1 })).toHaveLength(
+      MAX_SCREENSHOTS,
+    );
+  });
+
+  it("stops once the cumulative byte budget would be exceeded", () => {
+    // 4 bytes each, budget 10 → keep a(4) + b(8); c would be 12 > 10 → stop.
+    expect(
+      capScreenshotPathsByBudget(paths, { sizeOf: () => 4, maxTotalBytes: 10 }),
+    ).toEqual(["/a.png", "/b.png"]);
+  });
+
+  it("always keeps the first path even if it alone exceeds the budget", () => {
+    expect(
+      capScreenshotPathsByBudget(paths, { sizeOf: () => 100, maxTotalBytes: 10 }),
+    ).toEqual(["/a.png"]);
+  });
+
+  it("treats unreadable files (size 0) as free, keeping up to the count cap", () => {
+    expect(
+      capScreenshotPathsByBudget(paths, { sizeOf: () => 0, maxTotalBytes: 10 }),
+    ).toEqual(paths);
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/screenshot-delivery.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/screenshot-delivery.ts
@@ -10,6 +10,7 @@
  * Telegram user sees what a Claude-Code user sees in-terminal.
  */
 
+import { statSync } from "node:fs";
 import type { Content, Media, UUID } from "@elizaos/core";
 import { ContentType, logger } from "@elizaos/core";
 import { parseCompletionEnvelope } from "./completion-envelope.js";
@@ -17,6 +18,59 @@ import { parseCompletionEnvelope } from "./completion-envelope.js";
 const IMAGE_EXT_RE = /\.(png|jpe?g|gif|webp|bmp)$/i;
 /** Cap how many screenshots we forward so a chatty task can't flood the chat. */
 export const MAX_SCREENSHOTS = 5;
+
+/**
+ * Cap the cumulative BYTES forwarded (in addition to the count cap) so a task
+ * with a few very large images can't blow the connector's upload limit or flood
+ * the chat with megabytes — the second half of #8904's "cap count AND total
+ * size". Overridable via `ELIZA_ORCHESTRATOR_SCREENSHOT_MAX_BYTES`; default 10 MB.
+ */
+export const MAX_SCREENSHOT_TOTAL_BYTES = (() => {
+  const raw = process.env.ELIZA_ORCHESTRATOR_SCREENSHOT_MAX_BYTES;
+  const n = raw ? Number.parseInt(raw, 10) : Number.NaN;
+  return Number.isFinite(n) && n > 0 ? n : 10 * 1024 * 1024;
+})();
+
+/** Default byte-size probe for a local screenshot path; 0 if unreadable. */
+function fileSizeBytes(p: string): number {
+  try {
+    return statSync(p).size;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Pure: cap screenshot paths by BOTH count and a cumulative byte budget (#8904).
+ * The first path is always kept (so a single oversized shot is still delivered
+ * rather than nothing); each subsequent path is dropped once the running total
+ * would exceed `maxTotalBytes`. `sizeOf` is injectable so this is unit-testable
+ * without real files; production uses `statSync`.
+ */
+export function capScreenshotPathsByBudget(
+  paths: string[],
+  {
+    maxCount = MAX_SCREENSHOTS,
+    maxTotalBytes = MAX_SCREENSHOT_TOTAL_BYTES,
+    sizeOf = fileSizeBytes,
+  }: {
+    maxCount?: number;
+    maxTotalBytes?: number;
+    sizeOf?: (p: string) => number;
+  } = {},
+): string[] {
+  const out: string[] = [];
+  let total = 0;
+  for (const p of paths) {
+    if (out.length >= maxCount) break;
+    let size = sizeOf(p);
+    if (!Number.isFinite(size) || size < 0) size = 0;
+    if (out.length > 0 && total + size > maxTotalBytes) break;
+    total += size;
+    out.push(p);
+  }
+  return out;
+}
 
 /**
  * Pure: collect candidate screenshot paths for a completion. Prefers the
@@ -85,8 +139,15 @@ export async function deliverScreenshots(
   target: { source: string; roomId: UUID },
   paths: string[],
   label?: string,
+  opts?: { sizeOf?: (p: string) => number; maxTotalBytes?: number },
 ): Promise<number> {
-  const attachments = screenshotsToAttachments(paths);
+  // Cap by count AND cumulative byte budget before building attachments (#8904),
+  // so a few huge screenshots can't exceed the connector's upload limit.
+  const budgeted = capScreenshotPathsByBudget(paths, {
+    sizeOf: opts?.sizeOf,
+    maxTotalBytes: opts?.maxTotalBytes,
+  });
+  const attachments = screenshotsToAttachments(budgeted);
   if (attachments.length === 0) return 0;
   const who = label ? ` from ${label}` : "";
   try {


### PR DESCRIPTION
## What

Closes the unmet half of #8904's acceptance criterion — "cap count **AND total size**". Screenshot delivery capped only the count (`MAX_SCREENSHOTS=5`), so five multi-MB screenshots could still exceed a connector's upload limit or flood the chat.

## Change
- `capScreenshotPathsByBudget(paths, {maxCount, maxTotalBytes, sizeOf})` — pure; caps by count **and** a cumulative byte budget. Always keeps the first path (a single oversized shot still delivers) and drops subsequent paths once the running total would exceed the budget. `sizeOf` is injectable for tests; production uses `statSync`.
- `MAX_SCREENSHOT_TOTAL_BYTES` (default 10 MB; override `ELIZA_ORCHESTRATOR_SCREENSHOT_MAX_BYTES`).
- `deliverScreenshots` gains an optional `{sizeOf, maxTotalBytes}` and budgets before building attachments. Backward-compatible — unreadable paths count as 0 bytes, so existing behavior is unchanged when files are absent.

## Tests (deterministic, Windows-local)
`screenshot-delivery.test.ts` → **13 pass / 0 fail** (8 existing + 5 new: count cap, byte-budget stop, always-keep-first, unreadable-as-free, and `deliverScreenshots` honoring an injected budget). Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)