### PR TITLE
ci: run keyless plugin harness proofs

### DIFF
--- a/.github/issue-evidence/8801-keyless-plugin-harness-ci/README.md
+++ b/.github/issue-evidence/8801-keyless-plugin-harness-ci/README.md
@@ -1,0 +1,36 @@
+# Issue #8801 - keyless per-plugin harness CI
+
+Branch: `fix/8801-keyless-plugin-harness-ci`
+
+## What changed
+
+The existing `keyless-harness-e2e.yml` workflow already ran the central deterministic mock-LLM and recorded-fixture self-suite. This slice adds a representative model-provider and connector adoption proof to the same keyless PR lane:
+
+- `bun run --cwd plugins/plugin-anthropic test:harness`
+- `bun run --cwd plugins/plugin-discord test:harness`
+
+All provider credentials remain blanked by the workflow env.
+
+## Evidence
+
+```bash
+bun run --cwd plugins/plugin-anthropic test:harness
+```
+
+Result: 1 file passed, 2 tests passed.
+
+```bash
+bun run --cwd plugins/plugin-discord test:harness
+```
+
+Result: 1 file passed, 1 test passed.
+
+```bash
+bunx vitest run --config test/mocks/vitest.config.ts test/mocks/__tests__/
+```
+
+Result: run from `packages/`; 3 files passed, 57 tests passed.
+
+## Scope note
+
+This intentionally wires a minimal non-live plugin harness slice into PR CI. Broader per-plugin adoption and corpus widening remain separate ratchet work.

--- a/.github/workflows/keyless-harness-e2e.yml
+++ b/.github/workflows/keyless-harness-e2e.yml
@@ -14,7 +14,8 @@ name: Keyless Harness E2E
 #
 # This is intentionally a NEW, additive lane (not an edit to the load-bearing
 # scenario-pr / test workflows) so a change here can never red-X the broader PR
-# gate. It runs in seconds: install with scripts skipped, then the vitest config.
+# gate. It runs in seconds: install with scripts skipped, then the central
+# vitest config plus a small set of per-plugin harness adoption proofs.
 
 on:
   pull_request:
@@ -79,3 +80,13 @@ jobs:
       - name: Keyless harness e2e (mock-LLM + recorded fixtures)
         working-directory: packages
         run: bunx vitest run --config test/mocks/vitest.config.ts test/mocks/__tests__/
+
+      # Issue #8801 follow-up: the central harness proves the substrate, but the
+      # per-plugin adoption proofs are excluded from default vitest runs. Keep a
+      # representative model-provider and connector harness in this keyless PR
+      # lane so those proofs cannot drift while still avoiding live provider
+      # credentials.
+      - name: Per-plugin keyless harness adoption proofs
+        run: |
+          bun run --cwd plugins/plugin-anthropic test:harness
+          bun run --cwd plugins/plugin-discord test:harness


### PR DESCRIPTION
## Summary

Closes a concrete #8801 follow-up: the central keyless harness workflow was running only the `packages/test/mocks` self-suite, while the per-plugin `*.harness.test.ts` adoption proofs were excluded from default Vitest and not run in any PR lane.

This adds a small representative per-plugin slice to `.github/workflows/keyless-harness-e2e.yml`:

- `bun run --cwd plugins/plugin-anthropic test:harness` (model-provider harness)
- `bun run --cwd plugins/plugin-discord test:harness` (connector harness)

The workflow still blanks provider credentials, so these stay deterministic and keyless.

## Evidence

- `actionlint .github/workflows/keyless-harness-e2e.yml` - passed.
- From `packages/`: `bunx vitest run --config test/mocks/vitest.config.ts test/mocks/__tests__/` - passed, 3 files / 57 tests.
- `bun run --cwd plugins/plugin-anthropic test:harness` - passed, 1 file / 2 tests.
- `bun run --cwd plugins/plugin-discord test:harness` - passed, 1 file / 1 test.
- `git diff --check` - passed.

Root `bun run verify` is not clean on current `develop`: it fails on an unrelated `packages/agent/src/runtime/eliza.ts` import-order lint (`assist/source/organizeImports`) from the crash-injection import block. This PR only changes the keyless harness workflow and evidence note.

## Scope note

This intentionally wires the minimal deterministic per-plugin harness proof requested in the #8801 re-open thread. Broader plugin adoption and scenario-corpus widening remain ratchet/follow-up work.

Refs #8801.
