### PR TITLE
[codex] test(ui): allow onboarding e2e browser override

### DIFF
--- a/packages/ui/src/first-run/__e2e__/run-onboarding-e2e.mjs
+++ b/packages/ui/src/first-run/__e2e__/run-onboarding-e2e.mjs
@@ -122,7 +122,9 @@ const STATES = [
   { q: "?busy=Starting+your+agent%E2%80%A6", name: "busy", desktop: true },
 ];
 
-const browser = await chromium.launch();
+const browser = await chromium.launch({
+  executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH || undefined,
+});
 try {
   for (const view of [
     { w: 402, h: 874, tag: "mobile", scale: 2 },


### PR DESCRIPTION
## Summary

- Lets the first-run onboarding E2E honor `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` when set.
- Keeps the default Playwright Chromium behavior unchanged for CI and normal local runs.

## Why

The launch-smoke environment already had system Google Chrome available, but the repo harness failed before reaching app code because Playwright bundled Chromium was not installed. This gives agents and local maintainers a clean way to run the existing onboarding E2E without downloading another browser.

## Validation

- `bun run --cwd packages/ui test -- CompactOnboarding.test.tsx onboarding-intent.test.ts`
- `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/google-chrome bun run --cwd packages/ui test:onboarding-e2e`

The onboarding E2E verified Cloud, local runtime, Advanced remote setup, one first-run POST per terminal path, and no uncaught page errors.