### PR TITLE
fix(apps): front doors create deployable template apps + audit cleanups (sentinel, log, docs)

### DIFF
--- a/packages/cloud/shared/src/lib/eliza/agent-loader.ts
+++ b/packages/cloud/shared/src/lib/eliza/agent-loader.ts
@@ -235,17 +235,21 @@ export class AgentLoader {
   ): Promise<Plugin[]> {
     const plugins: Plugin[] = [cloudModelProviderPlugin];
 
-    // Eliza Cloud Apps read-core (#10218 apps launch). Added as a FULL plugin
+    // Eliza Cloud Apps (#10218 apps launch). Added as a FULL plugin
     // (NOT via AVAILABLE_PLUGINS, which strips to models-only) so its actions +
-    // provider reach cloud-hosted agents. Gated OFF by default — see
-    // isCloudAppsPluginEnabled — because it loads on every dedicated prod agent.
+    // provider reach cloud-hosted agents. This is the FULL action set
+    // (list/get/create/deploy/manage incl. delete/withdraw/rotate-key), not just
+    // read. Gated OFF by default — see isCloudAppsPluginEnabled — because it
+    // loads on every dedicated prod agent and includes destructive/money actions.
     if (isCloudAppsPluginEnabled(characterSettings)) {
       // Lazy-load so the default-OFF gate actually avoids the import cost: a
       // static top-level import would pull @elizaos/plugin-cloud-apps (+ the
       // cloud SDK) into every dedicated prod agent regardless of the flag.
       const { cloudAppsPlugin } = await import("@elizaos/plugin-cloud-apps");
       plugins.push(asPlugin(cloudAppsPlugin));
-      logger.info("[AgentLoader] Cloud Apps plugin enabled (read-core)");
+      logger.info(
+        "[AgentLoader] Cloud Apps plugin enabled (full: list/create/deploy/manage incl. delete/withdraw/rotate-key)",
+      );
     }
 
     const conditionalPlugins = getConditionalPlugins(characterSettings);

--- a/packages/cloud/shared/src/lib/services/__tests__/app-factory.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-factory.test.ts
@@ -172,3 +172,76 @@ describe("create -> deploy linkage: resolveImageRef on the created app", () => {
     ).rejects.toThrow(/build-from-repo is disabled/);
   });
 });
+
+/**
+ * FRONT-DOOR end-to-end: prove that a real create request body — exactly what
+ * the agent CREATE_APP action and the dashboard Create App dialog now POST to
+ * `POST /api/v1/apps` — flows through the server route's `createGitHubRepo:
+ * !skipGitHubRepo` mapping, the real factory, and the real `resolveImageRef`
+ * to a deployable image (does NOT throw). The contrasting "pre-fix" body (no
+ * `skipGitHubRepo`) is what shipped broken: it makes a repo-backed app whose
+ * deploy throws build-from-repo-disabled — so the `skipGitHubRepo: true` the
+ * front doors now send is load-bearing, not cosmetic.
+ */
+describe("front-door create -> deploy resolves (POST /api/v1/apps body)", () => {
+  // Mirrors the server route (`packages/cloud/api/v1/apps/route.ts`): the create
+  // route maps the request body's `skipGitHubRepo` to the factory option
+  // `createGitHubRepo: !skipGitHubRepo`. Keep this in lockstep with the route.
+  const createFromFrontDoorBody = (body: {
+    name: string;
+    app_url: string;
+    skipGitHubRepo?: boolean;
+  }) =>
+    appFactoryService.createApp(
+      {
+        name: body.name,
+        organization_id: DATA.organization_id,
+        created_by_user_id: DATA.created_by_user_id,
+        app_url: body.app_url,
+      },
+      { createGitHubRepo: !body.skipGitHubRepo },
+    );
+
+  test("the fixed front-door body (skipGitHubRepo:true) stamps a template image and RESOLVES", async () => {
+    // The exact body the front doors send: a draft-sentinel URL + skipGitHubRepo.
+    const result = await createFromFrontDoorBody({
+      name: "Acme Bot",
+      app_url: "https://placeholder.invalid",
+      skipGitHubRepo: true,
+    });
+
+    // No repo was created, and a deployable template image was stamped.
+    expect(result.githubRepoCreated).toBe(false);
+    expect(metaImageTag(result.app.metadata)).toBe(DEFAULT_TEMPLATE_IMAGE);
+
+    // The created app RESOLVES an image through the real deploy-runner gate —
+    // the create -> deploy loop the audit found broken now completes.
+    const img = await resolveImageRef(buildOff, {
+      id: result.app.id,
+      name: result.app.name,
+      metadata: (result.app.metadata as Record<string, unknown>) ?? {},
+      repoUrl: result.app.github_repo ?? undefined,
+    });
+    expect(img).toBe(DEFAULT_TEMPLATE_IMAGE);
+  });
+
+  test("REGRESSION: the pre-fix front-door body (no skipGitHubRepo) makes a repo app whose deploy THROWS", async () => {
+    const result = await createFromFrontDoorBody({
+      name: "Acme Bot",
+      app_url: "https://placeholder.invalid",
+      // skipGitHubRepo omitted — the bug: createGitHubRepo defaults true.
+    });
+
+    expect(result.githubRepoCreated).toBe(true);
+    expect(metaImageTag(result.app.metadata)).toBeUndefined();
+
+    await expect(
+      resolveImageRef(buildOff, {
+        id: result.app.id,
+        name: result.app.name,
+        metadata: (result.app.metadata as Record<string, unknown>) ?? {},
+        repoUrl: result.app.github_repo ?? undefined,
+      }),
+    ).rejects.toThrow(/build-from-repo is disabled/);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/app-factory.ts
+++ b/packages/cloud/shared/src/lib/services/app-factory.ts
@@ -162,9 +162,10 @@ export class AppFactoryService {
     }
 
     // TEMPLATE-IMAGE WIRING (the launch blocker): a TEMPLATE app — one created
-    // WITHOUT a user repo (createGitHubRepo === false, the path the agent's
-    // CREATE_APP / `skipGitHubRepo: true` uses) — has neither a build pipeline
-    // nor a repo image, so the deploy runner's `resolveImageRef` would throw
+    // WITHOUT a user repo (createGitHubRepo === false, which is what both front
+    // doors send as `skipGitHubRepo: true`: the agent's CREATE_APP action and the
+    // dashboard Create App dialog) — has neither a build pipeline nor a repo
+    // image, so the deploy runner's `resolveImageRef` would throw
     // "no image to deploy". Stamp a first-party, allowlisted template image as
     // `metadata.imageTag` at create time so create -> deploy resolves to a
     // prebuilt, allowlisted image. Repo-backed apps are intentionally LEFT

--- a/packages/docs/cloud/api/containers.mdx
+++ b/packages/docs/cloud/api/containers.mdx
@@ -53,17 +53,18 @@ Deploy a new container. Returns a container record and polling instructions.
 
 ### Request
 
+The request body is **camelCase** — the server validates with a strict schema that **silently drops unknown keys**, so a snake_case key (e.g. `environment_vars`) is discarded and your `ELIZA_APP_ID` never reaches the container.
+
 ```json
 {
   "name": "My App",
-  "project_name": "my-app",
-  "image": "ghcr.io/acme/my-app:latest",
+  "projectName": "my-app",
+  "image": "ghcr.io/elizaos/example-edad:showcase",
   "port": 3000,
   "cpu": 256,
-  "memory": 512,
-  "desired_count": 1,
-  "health_check_path": "/health",
-  "environment_vars": {
+  "memoryMb": 512,
+  "healthCheckPath": "/health",
+  "environmentVars": {
     "PORT": "3000",
     "ELIZA_APP_ID": "uuid-abc123"
   }
@@ -75,16 +76,15 @@ Deploy a new container. Returns a container record and polling instructions.
 | Parameter | Type | Required | Description |
 | --------- | ---- | -------- | ----------- |
 | `name` | string | yes | Display name. |
-| `project_name` | string | yes | Stable project identifier. |
+| `projectName` | string | no | Stable project identifier. |
 | `image` | string | yes | Full image reference, for example `ghcr.io/owner/repo:tag`. |
 | `port` | integer | no | Container port. Default: 3000. |
 | `cpu` | integer | no | CPU units. Default: 256. |
-| `memory` | integer | no | Memory in MB. Default: 512. |
-| `desired_count` | integer | no | Must be 1 on the current shared Docker pool. |
-| `health_check_path` | string | no | Health check endpoint. Default: `/health`. |
-| `environment_vars` | object | no | String environment variables. |
-| `persist_volume` | boolean | no | Mount project-scoped persistent storage at `/data`. |
-| `use_hetzner_volume` | boolean | no | Use a Hetzner Cloud volume when persistent volumes are enabled and configured. |
+| `memoryMb` | integer | no | Memory in MB. Default: 512. |
+| `healthCheckPath` | string | no | Health check endpoint. Default: `/health`. |
+| `environmentVars` | object | no | String environment variables (this is where `ELIZA_APP_ID` belongs). |
+| `persistVolume` | boolean | no | Mount project-scoped persistent storage at `/data`. |
+| `useHetznerVolume` | boolean | no | Use a Hetzner Cloud volume when persistent volumes are enabled and configured. |
 | `volume_size_gb` | integer | no | Declared volume size in GiB. Default: 10. |
 
 ### Response

--- a/packages/docs/cloud/apps.mdx
+++ b/packages/docs/cloud/apps.mdx
@@ -17,7 +17,7 @@ An Eliza Cloud app provides:
 - **Monetization**: Creator markup for app-scoped chat usage.
 - **Domains and hosting metadata**: App URL, managed app domains, and custom domains.
 
-Use a **project** for deployable product workspace state and container `project_name`. Use the **Cloud app** `id` when calling `/api/v1/apps/{id}/chat`.
+Use a **project** for deployable product workspace state and container `projectName`. Use the **Cloud app** `id` when calling `/api/v1/apps/{id}/chat`.
 
 ## Launch Readiness
 
@@ -95,7 +95,7 @@ curl -X PUT "https://www.elizacloud.ai/api/v1/apps/$APP_ID/monetization" \
 
 <Step title="Deploy your project">
 
-Deploy your project as a container with `POST /api/v1/containers` or the SDK `createContainer()` helper. Use `project_name` for the deployment identifier and pass the Cloud app ID through environment variables.
+Deploy your project as a container with `POST /api/v1/containers` or the SDK `createContainer()` helper. Use `projectName` for the deployment identifier and pass the Cloud app ID through environment variables.
 
 </Step>
 
@@ -159,7 +159,7 @@ Redeem available earnings for elizaOS tokens from [Dashboard -> Earnings](https:
 
 - Keep admin API keys on the server.
 - Forward user bearer tokens for user-facing app-scoped chat.
-- Store the Cloud app `id` separately from container `project_name`.
+- Store the Cloud app `id` separately from container `projectName`.
 - Patch `app_url` and `allowed_origins` after container deployment.
 - Treat `databaseMode: "isolated"` as the production default for apps that need
   persistence; verify the deployed image reads the injected `DATABASE_URL`.

--- a/packages/ui/src/cloud/applications/components/create-app-dialog.tsx
+++ b/packages/ui/src/cloud/applications/components/create-app-dialog.tsx
@@ -107,6 +107,10 @@ export function CreateAppDialog({ open, onOpenChange }: CreateAppDialogProps) {
         name: name.trim(),
         app_url: appUrl.trim(),
         allowed_origins: [appUrl.trim()],
+        // Template app (no repo): the server stamps a first-party template image
+        // so the created app is deployable. Without this, DEPLOY throws
+        // "build-from-repo is disabled / no image to deploy".
+        skipGitHubRepo: true,
       });
       setCreatedApp({ appId: data.app.id, apiKey: data.apiKey });
       await queryClient.invalidateQueries({ queryKey: APPS_QUERY_KEY });

--- a/packages/ui/src/cloud/applications/lib/apps.deploy.test.ts
+++ b/packages/ui/src/cloud/applications/lib/apps.deploy.test.ts
@@ -67,7 +67,7 @@ describe("apps lib mutations (#9145)", () => {
     await expect(checkAppNameAvailable("x")).resolves.toBe(false);
   });
 
-  it("createApp POSTs the input and returns the record + one-time key", async () => {
+  it("createApp POSTs the input with skipGitHubRepo:true (deployable template app) and returns the record + one-time key", async () => {
     apiMock.mockResolvedValue({ app: { id: "a" }, apiKey: "k" });
     const input = {
       name: "n",
@@ -78,9 +78,27 @@ describe("apps lib mutations (#9145)", () => {
       app: { id: "a" },
       apiKey: "k",
     });
+    // The dashboard front door MUST request a template app so the server stamps
+    // a deployable image — otherwise the created app has no image and DEPLOY
+    // throws "build-from-repo is disabled / no image to deploy".
     expect(apiMock).toHaveBeenCalledWith("/api/v1/apps", {
       method: "POST",
-      json: input,
+      json: { skipGitHubRepo: true, ...input },
+    });
+  });
+
+  it("createApp leaves an explicit skipGitHubRepo:false intact (caller override)", async () => {
+    apiMock.mockResolvedValue({ app: { id: "a" }, apiKey: "k" });
+    const input = {
+      name: "n",
+      app_url: "https://x",
+      allowed_origins: [],
+      skipGitHubRepo: false,
+    };
+    await createApp(input);
+    expect(apiMock).toHaveBeenCalledWith("/api/v1/apps", {
+      method: "POST",
+      json: { skipGitHubRepo: false, name: "n", app_url: "https://x", allowed_origins: [] },
     });
   });
 

--- a/packages/ui/src/cloud/applications/lib/apps.ts
+++ b/packages/ui/src/cloud/applications/lib/apps.ts
@@ -91,10 +91,19 @@ export async function createApp(input: {
   name: string;
   app_url: string;
   allowed_origins: string[];
+  /**
+   * Create a TEMPLATE app (no GitHub repo). The dashboard has no
+   * build-from-repo flow, and build-from-repo is intentionally OFF, so a
+   * repo-backed app would have no image and DEPLOY would throw "build-from-repo
+   * is disabled / no image to deploy". With skipGitHubRepo the server stamps a
+   * first-party template image so the create -> deploy loop resolves. Defaults
+   * to true so a dashboard-created app is always deployable.
+   */
+  skipGitHubRepo?: boolean;
 }): Promise<{ app: App; apiKey: string }> {
   return api<{ app: App; apiKey: string }>("/api/v1/apps", {
     method: "POST",
-    json: input,
+    json: { skipGitHubRepo: true, ...input },
   });
 }
 

--- a/plugins/plugin-cloud-apps/__tests__/create-app.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/create-app.test.ts
@@ -92,6 +92,10 @@ describe("CREATE_APP", () => {
     expect(received).not.toBeNull();
     expect((received as unknown as CreateAppInput).name).toBe("Acme Bot");
     expect((received as unknown as CreateAppInput).app_url).toBe(DRAFT_APP_URL);
+    // The front door MUST request a template app (skipGitHubRepo) so the server
+    // stamps a deployable image — without this the create -> deploy loop throws
+    // "build-from-repo is disabled / no image to deploy".
+    expect((received as unknown as CreateAppInput).skipGitHubRepo).toBe(true);
     const reply = cb.calls[0]?.text ?? "";
     expect(reply).toContain("Acme Bot");
     expect(reply.toLowerCase()).toContain("deploy");

--- a/plugins/plugin-cloud-apps/src/actions/create-app.ts
+++ b/plugins/plugin-cloud-apps/src/actions/create-app.ts
@@ -178,6 +178,13 @@ function buildCreateBody(intent: CreateAppIntent): CreateAppInput {
   const body: CreateAppInput = {
     name: intent.name as string,
     app_url: DRAFT_APP_URL,
+    // Create a TEMPLATE app (no GitHub repo). The agent has no build-from-repo
+    // flow, and build-from-repo is intentionally OFF, so a repo-backed app would
+    // have no image and DEPLOY_APP would throw "build-from-repo is disabled / no
+    // image to deploy". With skipGitHubRepo the server stamps a first-party,
+    // allowlisted template image onto metadata.imageTag at create time, so the
+    // create -> deploy loop resolves a real image instead of failing.
+    skipGitHubRepo: true,
   };
   if (intent.description) body.description = intent.description;
   if (intent.monetization) body.monetization_enabled = true;

--- a/plugins/plugin-cloud-apps/src/actions/create-app.ts
+++ b/plugins/plugin-cloud-apps/src/actions/create-app.ts
@@ -26,8 +26,13 @@ import type {
 import { logger } from "@elizaos/core";
 import { getCloudClient, resolveCloudApiKey } from "../client.js";
 
-/** Draft sentinel URL the server treats as "not yet deployed" (no launch alert). */
-export const DRAFT_APP_URL = "https://placeholder.local";
+/**
+ * Draft sentinel URL the server recognizes as "not yet deployed" (suppresses the
+ * launch alert + the custom-domain DNS exact-match guard skips it). Must match
+ * the server/fixtures sentinel exactly — `https://placeholder.invalid` — or a
+ * draft app surfaces a fake URL and a pre-deploy domain buy would CNAME to it.
+ */
+export const DRAFT_APP_URL = "https://placeholder.invalid";
 
 const NO_KEY_MESSAGE =
   "I can't reach Eliza Cloud yet — no Cloud API key is configured. Add your ELIZAOS_CLOUD_API_KEY and I can create apps for you.";

--- a/plugins/plugin-cloud-apps/src/client.ts
+++ b/plugins/plugin-cloud-apps/src/client.ts
@@ -91,9 +91,26 @@ function toNumber(value: string | number | null | undefined): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
-/** A live, reachable URL for an app: prefer its production deploy, else its app URL. */
+/**
+ * Draft/placeholder sentinel hosts the cloud uses for "not yet deployed" apps —
+ * never surfaced to the user as a real URL.
+ */
+function isPlaceholderUrl(url: string): boolean {
+  try {
+    const host = new URL(url).hostname.toLowerCase();
+    return host === "placeholder.invalid" || host === "placeholder.local";
+  } catch {
+    return false;
+  }
+}
+
+/** A live, reachable URL for an app: prefer its production deploy, else its app URL — never a draft sentinel. */
 export function appUrl(app: AppDto): string | null {
-  return normalizeSecret(app.production_url) ?? normalizeSecret(app.app_url);
+  const prod = normalizeSecret(app.production_url);
+  if (prod && !isPlaceholderUrl(prod)) return prod;
+  const declared = normalizeSecret(app.app_url);
+  if (declared && !isPlaceholderUrl(declared)) return declared;
+  return null;
 }
 
 /** Short human status combining deployment + active flags. */


### PR DESCRIPTION
## What

Closes the launch-defeating gap an adversarial audit found in the merged apps launch, plus the smaller correctness items it surfaced.

### 1. Front doors now create DEPLOYABLE template apps (the launch-defeating bug)
The agent's `CREATE_APP` and the dashboard "Create App" dialog both created **repo-backed** apps (`createGitHubRepo` defaulted true), but build-from-repo is OFF and the first-party template image is stamped only for non-repo apps — so **every** front-door app would throw `"build-from-repo is disabled / no image to deploy"` the instant `APPS_DEPLOY_ENABLED` flips (masked today only because deploy is gated off; no test caught it because the e2e bypasses the front doors). This was an unreconciled seam between #10290 and #10298 (merged 9s apart).
- Send `skipGitHubRepo: true` from all three front doors (agent `create-app.ts`, GUI `lib/apps.ts` + `create-app-dialog.tsx`) → server stamps the allowlisted template image → `resolveImageRef` resolves.
- Fixed the false `app-factory.ts` comment that claimed CREATE_APP already did this.
- **Added front-door tests** (plugin + cloud-shared + ui) proving the created app gets the template `imageTag` — the test that was missing.

### 2. Correctness cleanups
- **Draft sentinel:** `DRAFT_APP_URL` `placeholder.local` → `placeholder.invalid` (the sentinel the server/fixtures actually recognize; the old value surfaced a fake URL and would mis-CNAME a pre-deploy domain buy). `appUrl()` now suppresses placeholder sentinels.
- **Agent-loader log/comment:** now state the cloud-hosted plugin is the FULL action set (incl. delete/withdraw/rotate-key), not "read-core" — honest blast radius.
- **Docs:** `containers.mdx` POST body + params → camelCase (with a note that the schema strips unknown keys → snake_case silently drops `ELIZA_APP_ID`, the #10267 bug); `apps.mdx` prose `project_name` → `projectName`.

## Evidence
- `plugins/plugin-cloud-apps` **116/0**; `cloud-shared` app-factory **9/0**; `packages/docs` **15/0**; biome clean.

## Follow-up (filed separately, NOT in this PR)
The audit also flagged that the managed deploy path injects `DATABASE_URL` but **no `ELIZA_APP_ID` / app-scoped cloud credential** into the deployed container — so per-app monetization attribution for *deployed* apps is unverified. That's core cloud-monetization architecture that needs the owning lane + real-infra verification, so it's filed as an issue rather than patched blind here.

Part of the apps launch (tracker #8434).
