### PR TITLE
fix(app-auth): fail loud on invalid Steward URL

### DIFF
--- a/.github/issue-evidence/10416-app-auth-steward-config/README.md
+++ b/.github/issue-evidence/10416-app-auth-steward-config/README.md
@@ -1,0 +1,37 @@
+# Issue #10416 evidence
+
+## Scope
+
+- `packages/ui/src/cloud/shell/StewardProvider.tsx` now separates "route does
+  not need Steward" from "route needs Steward but the Steward URL is invalid".
+- `packages/cloud/sdk/src/app-auth.ts` exports `buildAppAuthorizeUrl()` for the
+  canonical `/app-auth/authorize` URL.
+- `packages/cloud/sdk/README.md` documents the helper and explicitly warns
+  against bare `/authorize`.
+
+## Validation
+
+- `bun run --cwd packages/ui test src/cloud/shell/StewardProvider.test.tsx src/cloud/public-pages/pages/app-auth/app-authorize-page.test.tsx`
+- `bun test packages/cloud/sdk/src/app-auth.test.ts`
+- `bun run --cwd packages/cloud/sdk test`
+- `bun run --cwd packages/cloud/sdk typecheck`
+- `bun run --cwd packages/cloud/sdk build`
+- `bunx @biomejs/biome check packages/ui/src/cloud/shell/StewardProvider.tsx packages/ui/src/cloud/shell/StewardProvider.test.tsx packages/cloud/sdk/src/app-auth.ts packages/cloud/sdk/src/app-auth.test.ts packages/cloud/sdk/src/index.ts packages/cloud/sdk/README.md`
+
+## Known unrelated blockers
+
+- `bun run --cwd packages/ui typecheck` fails on pre-existing unrelated
+  workspace type issues and missing generated files under `packages/core` /
+  `packages/shared`.
+- `bun run --cwd packages/app dev` in a fresh worktree fails before startup
+  because `@elizaos/core` package exports are not built.
+- Attached physical Android `27051JEGR10034` is connected but locked
+  (`NotificationShade`, `mDreamingLockscreen=true`), so Android screenshot and
+  recording are N/A for this web auth-route hardening slice.
+
+## Visual capture
+
+No Android visual capture is attached for this issue. The touched route is a web
+Cloud app-auth route, and the attached physical Android remained locked during
+validation. The UI branch is covered by the focused jsdom/Vitest route tests
+listed above.

--- a/.github/issue-evidence/10416-app-auth-steward-config/android-lock-state.log
+++ b/.github/issue-evidence/10416-app-auth-steward-config/android-lock-state.log
@@ -1,0 +1,8 @@
+Tue Jun 30 00:30:45 PDT 2026
+List of devices attached
+27051JEGR10034	device
+emulator-5554	device
+
+115:  mCurrentFocus=Window{e93d7cf u0 NotificationShade}
+116:  mFocusedApp=null
+217:    mShowingDream=false mDreamingLockscreen=true

--- a/.github/issue-evidence/10416-app-auth-steward-config/app-dev-unrelated-startup-failure.log
+++ b/.github/issue-evidence/10416-app-auth-steward-config/app-dev-unrelated-startup-failure.log
@@ -1,0 +1,34 @@
+Tue Jun 30 00:30:53 PDT 2026
+$ node ../shared/scripts/sync-to-public.mjs ./public --logos --favicons --concepts --banners --background --background-videos
+[shared-brand] synced into /home/shaw/milady/eliza-issue-10416/packages/app/public: logos, favicons, banners, concepts, background+videos
+$ bun --bun vite --host "127.0.0.1"
+failed to load config from /home/shaw/milady/eliza-issue-10416/packages/app/vite.config.ts
+error when starting dev server:
+Error: Build failed with 2 errors:
+
+[plugin externalize-deps]
+Error: Failed to resolve entry for package "@elizaos/core". The package may have incorrect main/module/exports specified in its package.json.
+    at packageEntryFailure (/home/shaw/milady/eliza-issue-10416/node_modules/.bun/vite@8.0.16+1f4de08050f1f556/node_modules/vite/dist/node/chunks/node.js:32596:34)
+    at resolvePackageEntry (/home/shaw/milady/eliza-issue-10416/node_modules/.bun/vite@8.0.16+1f4de08050f1f556/node_modules/vite/dist/node/chunks/node.js:32593:2)
+    at tryNodeResolve (/home/shaw/milady/eliza-issue-10416/node_modules/.bun/vite@8.0.16+1f4de08050f1f556/node_modules/vite/dist/node/chunks/node.js:32492:50)
+    at nodeResolveWithVite (/home/shaw/milady/eliza-issue-10416/node_modules/.bun/vite@8.0.16+1f4de08050f1f556/node_modules/vite/dist/node/chunks/node.js:32701:9)
+    at handler (/home/shaw/milady/eliza-issue-10416/node_modules/.bun/vite@8.0.16+1f4de08050f1f556/node_modules/vite/dist/node/chunks/node.js:34912:18)
+    at <anonymous> (/home/shaw/milady/eliza-issue-10416/node_modules/.bun/rolldown@1.0.3/node_modules/rolldown/dist/shared/bindingify-input-options-ClrST5Xx.mjs:1092:30)
+    at <anonymous> (/home/shaw/milady/eliza-issue-10416/node_modules/.bun/rolldown@1.0.3/node_modules/rolldown/dist/shared/bindingify-input-options-ClrST5Xx.mjs:1625:18)
+[plugin externalize-deps]
+Error: Failed to resolve entry for package "@elizaos/core". The package may have incorrect main/module/exports specified in its package.json.
+    at packageEntryFailure (/home/shaw/milady/eliza-issue-10416/node_modules/.bun/vite@8.0.16+1f4de08050f1f556/node_modules/vite/dist/node/chunks/node.js:32596:34)
+    at resolvePackageEntry (/home/shaw/milady/eliza-issue-10416/node_modules/.bun/vite@8.0.16+1f4de08050f1f556/node_modules/vite/dist/node/chunks/node.js:32593:2)
+    at tryNodeResolve (/home/shaw/milady/eliza-issue-10416/node_modules/.bun/vite@8.0.16+1f4de08050f1f556/node_modules/vite/dist/node/chunks/node.js:32492:50)
+    at nodeResolveWithVite (/home/shaw/milady/eliza-issue-10416/node_modules/.bun/vite@8.0.16+1f4de08050f1f556/node_modules/vite/dist/node/chunks/node.js:32701:9)
+    at handler (/home/shaw/milady/eliza-issue-10416/node_modules/.bun/vite@8.0.16+1f4de08050f1f556/node_modules/vite/dist/node/chunks/node.js:34912:18)
+    at <anonymous> (/home/shaw/milady/eliza-issue-10416/node_modules/.bun/rolldown@1.0.3/node_modules/rolldown/dist/shared/bindingify-input-options-ClrST5Xx.mjs:1092:30)
+    at <anonymous> (/home/shaw/milady/eliza-issue-10416/node_modules/.bun/rolldown@1.0.3/node_modules/rolldown/dist/shared/bindingify-input-options-ClrST5Xx.mjs:1625:18)
+    at aggregateBindingErrorsIntoJsError (/home/shaw/milady/eliza-issue-10416/node_modules/.bun/rolldown@1.0.3/node_modules/rolldown/dist/shared/error-BuvQYXuZ.mjs:48:22)
+    at unwrapBindingResult (/home/shaw/milady/eliza-issue-10416/node_modules/.bun/rolldown@1.0.3/node_modules/rolldown/dist/shared/error-BuvQYXuZ.mjs:18:128)
+    at #build (/home/shaw/milady/eliza-issue-10416/node_modules/.bun/rolldown@1.0.3/node_modules/rolldown/dist/shared/rolldown-build-CrPk_lZe.mjs:3246:34)
+    at processTicksAndRejections (native:7:39) {
+  errors: [Getter/Setter]
+}
+error: "vite" exited with code 1
+error: script "dev" exited with code 1

--- a/.github/issue-evidence/10416-app-auth-steward-config/biome.log
+++ b/.github/issue-evidence/10416-app-auth-steward-config/biome.log
@@ -1,0 +1,2 @@
+Tue Jun 30 00:30:45 PDT 2026
+Checked 5 files in 43ms. No fixes applied.

--- a/.github/issue-evidence/10416-app-auth-steward-config/sdk-app-auth-test.log
+++ b/.github/issue-evidence/10416-app-auth-steward-config/sdk-app-auth-test.log
@@ -1,0 +1,17 @@
+Tue Jun 30 00:30:42 PDT 2026
+bun test v1.4.0-canary.1 (64ae83c2f)
+
+packages/cloud/sdk/src/app-auth.test.ts:
+(pass) buildAppAuthorizeUrl > builds the canonical third-party app authorize URL [0.67ms]
+------------------------------------|---------|---------|-------------------
+File                                | % Funcs | % Lines | Uncovered Line #s
+------------------------------------|---------|---------|-------------------
+All files                           |  100.00 |  100.00 |
+ packages/cloud/sdk/src/app-auth.ts |  100.00 |  100.00 | 
+ packages/cloud/sdk/src/types.ts    |  100.00 |  100.00 | 
+------------------------------------|---------|---------|-------------------
+
+ 1 pass
+ 0 fail
+ 5 expect() calls
+Ran 1 test across 1 file. [247.00ms]

--- a/.github/issue-evidence/10416-app-auth-steward-config/sdk-build.log
+++ b/.github/issue-evidence/10416-app-auth-steward-config/sdk-build.log
@@ -1,0 +1,2 @@
+Tue Jun 30 00:30:43 PDT 2026
+$ bun run build.ts

--- a/.github/issue-evidence/10416-app-auth-steward-config/sdk-test.log
+++ b/.github/issue-evidence/10416-app-auth-steward-config/sdk-test.log
@@ -1,0 +1,117 @@
+Tue Jun 30 00:30:42 PDT 2026
+$ bun test src
+bun test v1.4.0-canary.1 (64ae83c2f)
+
+src/live.e2e.test.ts:
+(skip) ElizaCloudClient real API e2e: public, auth bootstrap, and raw access > fetches the live OpenAPI document through getOpenApiSpec, request, and requestRaw
+(skip) ElizaCloudClient real API e2e: public, auth bootstrap, and raw access > starts a CLI login session and polls it with direct and templated endpoint calls
+(skip) ElizaCloudClient real API e2e: public, auth bootstrap, and raw access > lists public models through the high-level client and compatibility client
+(skip) ElizaCloudClient real API e2e: pairing token exchange > pairs with a supplied one-time pairing token
+(skip) ElizaCloudClient real API e2e: API-key read paths > sets credentials after construction and gets the authenticated profile
+(skip) ElizaCloudClient real API e2e: API-key read paths > gets credit balance and summary
+(skip) ElizaCloudClient real API e2e: container read paths (requires containers scope) > lists containers and container quota
+(skip) ElizaCloudClient real API e2e: Eliza agent read paths (requires agents scope) > lists Eliza agents
+(skip) ElizaCloudClient real API e2e: paid generation paths > creates a responses API completion
+(skip) ElizaCloudClient real API e2e: paid generation paths > creates a chat completion
+(skip) ElizaCloudClient real API e2e: paid generation paths > creates embeddings
+(skip) ElizaCloudClient real API e2e: paid generation paths > generates an image
+(skip) ElizaCloudClient real API e2e: gateway relay lifecycle > registers, polls, optionally responds, and disconnects a relay session
+(skip) ElizaCloudClient real API e2e: job status > gets and polls a supplied job id
+(skip) ElizaCloudClient real API e2e: container lifecycle > creates, inspects, updates, reads operational endpoints, and deletes a container
+(skip) ElizaCloudClient real API e2e: Eliza agent lifecycle > creates, updates, snapshots, controls, inspects backups, and deletes an agent
+(skip) ElizaCloudClient real API e2e: session-only API key management > lists API keys with a browser session bearer token
+(skip) ElizaCloudClient real API e2e: session-only API key management > creates, regenerates, updates, and deletes an API key
+(skip) ElizaCloudClient real API e2e: profile write path > patches a caller-supplied profile field
+
+src/apps.client.test.ts:
+(pass) ElizaCloudClient typed app methods > listApps GETs /api/v1/apps and returns a typed ListAppsResponse [2.97ms]
+(pass) ElizaCloudClient typed app methods > getApp GETs /api/v1/apps/:id with the id encoded into the path [0.42ms]
+(pass) ElizaCloudClient typed app methods > createApp POSTs /api/v1/apps with the snake_case create body [0.33ms]
+(pass) ElizaCloudClient typed app methods > updateApp PATCHes /api/v1/apps/:id with the patch body [0.28ms]
+(pass) ElizaCloudClient typed app methods > updateMonetization PUTs /api/v1/apps/:id/monetization with camelCase settings [0.28ms]
+(pass) ElizaCloudClient typed app methods > deployApp POSTs /api/v1/apps/:id/deploy (empty body by default) [0.23ms]
+(pass) ElizaCloudClient typed app methods > getAppDeployStatus GETs /api/v1/apps/:id/deploy/status [0.20ms]
+(pass) ElizaCloudClient typed app methods > deleteApp DELETEs /api/v1/apps/:id [0.19ms]
+(pass) ElizaCloudClient typed app methods > regenerateAppApiKey POSTs /api/v1/apps/:id/regenerate-api-key and returns the new key [0.41ms]
+(pass) ElizaCloudClient typed app methods > buyAppDomain (deferred stub) POSTs /api/v1/apps/:id/domains/buy with { domain } [0.21ms]
+
+src/client.test.ts:
+(pass) ElizaCloudClient payment and monetization helpers > normalizes origin-only apiBaseUrl inputs to the Cloud API v1 base [0.54ms]
+(pass) ElizaCloudClient payment and monetization helpers > rejects apiBaseUrl values that already include a resource path or URL components [0.16ms]
+(pass) ElizaCloudClient payment and monetization helpers > creates durable x402 payment requests with callback channel metadata [0.45ms]
+(pass) ElizaCloudClient payment and monetization helpers > uses public x402 settlement routes without sending stored credentials [0.28ms]
+(pass) ElizaCloudClient payment and monetization helpers > creates app charges and payer checkouts on the app money routes [0.50ms]
+(pass) ElizaCloudClient payment and monetization helpers > routes affiliates, earnings, and token redemptions through typed helpers [0.35ms]
+(pass) ElizaCloudClient.getContainerLogs > requests text logs with tail and returns the raw body on a 2xx response [0.61ms]
+(pass) ElizaCloudClient.getContainerLogs > throws CloudApiError carrying status and body on a non-ok response [0.73ms]
+(pass) ElizaCloudClient.createContainer wire contract > serializes a camelCase body so projectName and environmentVars.ELIZA_APP_ID survive (per-app monetization) [0.43ms]
+(pass) ElizaCloudClient.createContainer wire contract > sends the action-discriminated PATCH body verbatim for updateContainer [0.23ms]
+(pass) ElizaCloudClient path parameter encoding > percent-encodes path parameters that contain slashes, query markers, and fragments [0.28ms]
+(pass) ElizaCloudClient path parameter encoding > fails fast when templated endpoint calls omit a required path parameter [0.25ms]
+(pass) ElizaCloudClient CLI login > uses the API host for session creation but the web host for browser auth [0.39ms]
+(pass) ElizaCloudClient web sign-in + app-credits affordances > sends X-App-Id when an appId is passed to createChatCompletion [0.33ms]
+(pass) ElizaCloudClient web sign-in + app-credits affordances > omits X-App-Id when no appId is given [0.16ms]
+(pass) ElizaCloudClient web sign-in + app-credits affordances > waitForCliLogin polls until authenticated and returns the key [4.00ms]
+(pass) ElizaCloudClient web sign-in + app-credits affordances > waitForCliLogin throws on an expired session [0.34ms]
+(pass) ElizaCloudClient.transcribeAudio > POSTs multipart audio to /api/v1/voice/stt with X-App-Id [0.91ms]
+
+src/public-routes.test.ts:
+(pass) ElizaCloudPublicRoutesClient path building > preserves meaningful empty middle segments for catch-all string params [0.43ms]
+(pass) ElizaCloudPublicRoutesClient path building > encodes catch-all array params one segment at a time [0.19ms]
+(pass) ElizaCloudPublicRoutesClient path building > rejects unexpected params and arrays for non-catch-all params [0.29ms]
+(pass) ElizaCloudPublicRoutesClient path building > rejects catch-all values with empty leading or trailing segments [0.19ms]
+
+src/http.test.ts:
+(pass) ElizaCloudHttpClient auth headers > serializes hostile query values without dropping falsey values or inventing path segments [0.51ms]
+(pass) ElizaCloudHttpClient auth headers > appends URLSearchParams repeatedly without mutating the caller-owned params [0.36ms]
+(pass) ElizaCloudHttpClient auth headers > sends API keys as bearer authorization and x-api-key [0.17ms]
+(pass) ElizaCloudHttpClient auth headers > uses bearer token for Authorization while retaining x-api-key [0.15ms]
+(pass) ElizaCloudHttpClient auth headers > removes auth headers on skipAuth, including caller/default auth headers [0.19ms]
+(pass) ElizaCloudHttpClient auth headers > merges default and per-request headers before applying auth [0.17ms]
+(pass) ElizaCloudHttpClient errors > preserves structured API error code, type, details, and original body [0.38ms]
+(pass) ElizaCloudHttpClient errors > throws InsufficientCreditsError with billing fields intact [0.27ms]
+(pass) ElizaCloudHttpClient errors > falls back safely when JSON content is malformed [0.28ms]
+
+src/app-auth.test.ts:
+(pass) buildAppAuthorizeUrl > builds the canonical third-party app authorize URL [0.22ms]
+
+src/cloud-setup-session/__tests__/mock-service.test.ts:
+(pass) MockCloudSetupSessionService > starts a session in the provisioning state with an opening message [0.40ms]
+(pass) MockCloudSetupSessionService > returns canned replies and extracts owner facts on early turns [0.37ms]
+(pass) MockCloudSetupSessionService > flips container status to ready after the configured number of polls [0.17ms]
+(pass) MockCloudSetupSessionService > finalizes a handoff envelope that mirrors the transcript and facts [0.30ms]
+(pass) MockCloudSetupSessionService > refuses to finalize while the container is still provisioning [0.23ms]
+(pass) MockCloudSetupSessionService > cancels and forgets the session [0.20ms]
+
+src/cloud-setup-session/__tests__/policy.test.ts:
+(pass) DEFAULT_SETUP_POLICY > permits the documented setup-only actions [0.10ms]
+(pass) DEFAULT_SETUP_POLICY > rejects unrelated actions [0.03ms]
+(pass) DEFAULT_SETUP_POLICY > caps budgets to keep the pre-container agent cheap [0.03ms]
+(pass) isActionAllowed with custom policy > honors the supplied allow-list [0.04ms]
+
+19 tests skipped:
+(skip) ElizaCloudClient real API e2e: public, auth bootstrap, and raw access > fetches the live OpenAPI document through getOpenApiSpec, request, and requestRaw
+(skip) ElizaCloudClient real API e2e: public, auth bootstrap, and raw access > starts a CLI login session and polls it with direct and templated endpoint calls
+(skip) ElizaCloudClient real API e2e: public, auth bootstrap, and raw access > lists public models through the high-level client and compatibility client
+(skip) ElizaCloudClient real API e2e: pairing token exchange > pairs with a supplied one-time pairing token
+(skip) ElizaCloudClient real API e2e: API-key read paths > sets credentials after construction and gets the authenticated profile
+(skip) ElizaCloudClient real API e2e: API-key read paths > gets credit balance and summary
+(skip) ElizaCloudClient real API e2e: container read paths (requires containers scope) > lists containers and container quota
+(skip) ElizaCloudClient real API e2e: Eliza agent read paths (requires agents scope) > lists Eliza agents
+(skip) ElizaCloudClient real API e2e: paid generation paths > creates a responses API completion
+(skip) ElizaCloudClient real API e2e: paid generation paths > creates a chat completion
+(skip) ElizaCloudClient real API e2e: paid generation paths > creates embeddings
+(skip) ElizaCloudClient real API e2e: paid generation paths > generates an image
+(skip) ElizaCloudClient real API e2e: gateway relay lifecycle > registers, polls, optionally responds, and disconnects a relay session
+(skip) ElizaCloudClient real API e2e: job status > gets and polls a supplied job id
+(skip) ElizaCloudClient real API e2e: container lifecycle > creates, inspects, updates, reads operational endpoints, and deletes a container
+(skip) ElizaCloudClient real API e2e: Eliza agent lifecycle > creates, updates, snapshots, controls, inspects backups, and deletes an agent
+(skip) ElizaCloudClient real API e2e: session-only API key management > lists API keys with a browser session bearer token
+(skip) ElizaCloudClient real API e2e: session-only API key management > creates, regenerates, updates, and deletes an API key
+(skip) ElizaCloudClient real API e2e: profile write path > patches a caller-supplied profile field
+
+ 52 pass
+ 19 skip
+ 0 fail
+ 122 expect() calls
+Ran 71 tests across 8 files. [72.00ms]

--- a/.github/issue-evidence/10416-app-auth-steward-config/sdk-typecheck.log
+++ b/.github/issue-evidence/10416-app-auth-steward-config/sdk-typecheck.log
@@ -1,0 +1,2 @@
+Tue Jun 30 00:30:42 PDT 2026
+$ tsgo --noEmit

--- a/.github/issue-evidence/10416-app-auth-steward-config/ui-typecheck-unrelated-failure.log
+++ b/.github/issue-evidence/10416-app-auth-steward-config/ui-typecheck-unrelated-failure.log
@@ -1,0 +1,75 @@
+Tue Jun 30 00:30:45 PDT 2026
+$ bun run generate:css-strings && tsgo --noEmit -p tsconfig.json
+$ node ../scripts/generate-css-strings.mjs
+[generate-css-strings] processed 0 target(s), updated 0
+../core/src/contracts/service-routing.ts(20,8): error TS2307: Cannot find module '@elizaos/contracts' or its corresponding type declarations.
+../core/src/contracts/wallet.ts(96,8): error TS2307: Cannot find module '@elizaos/contracts' or its corresponding type declarations.
+../core/src/i18n/action-search-keywords.ts(9,41): error TS2307: Cannot find module './generated/validation-keyword-data.ts' or its corresponding type declarations.
+../core/src/i18n/validation-keywords.ts(16,8): error TS2307: Cannot find module './generated/validation-keyword-data.ts' or its corresponding type declarations.
+../core/src/i18n/validation-keywords.ts(18,46): error TS2307: Cannot find module './generated/validation-keyword-data.ts' or its corresponding type declarations.
+../shared/src/contracts/service-routing.ts(25,8): error TS2307: Cannot find module '@elizaos/contracts' or its corresponding type declarations.
+../shared/src/contracts/service-routing.ts(45,8): error TS2307: Cannot find module '@elizaos/contracts' or its corresponding type declarations.
+../shared/src/contracts/wallet.ts(14,8): error TS2307: Cannot find module '@elizaos/contracts' or its corresponding type declarations.
+../shared/src/contracts/wallet.ts(103,8): error TS2307: Cannot find module '@elizaos/contracts' or its corresponding type declarations.
+../shared/src/i18n/keyword-matching.ts(17,41): error TS2307: Cannot find module './generated/validation-keyword-data.js' or its corresponding type declarations.
+src/components/accounts/AccountCard.tsx(124,19): error TS2339: Property 'health' does not exist on type 'AccountWithCredentialFlag'.
+src/components/accounts/AccountCard.tsx(131,45): error TS2339: Property 'healthDetail' does not exist on type 'AccountWithCredentialFlag'.
+src/components/accounts/AccountCard.tsx(190,31): error TS2339: Property 'providerId' does not exist on type 'AccountWithCredentialFlag'.
+src/components/accounts/AccountCard.tsx(191,27): error TS2339: Property 'providerId' does not exist on type 'AccountWithCredentialFlag'.
+src/components/accounts/AccountCard.tsx(193,13): error TS2339: Property 'providerId' does not exist on type 'AccountWithCredentialFlag'.
+src/components/accounts/AccountCard.tsx(193,52): error TS2339: Property 'providerId' does not exist on type 'AccountWithCredentialFlag'.
+src/components/accounts/AccountCard.tsx(194,25): error TS2339: Property 'usage' does not exist on type 'AccountWithCredentialFlag'.
+src/components/accounts/AccountCard.tsx(195,47): error TS2339: Property 'lastUsedAt' does not exist on type 'AccountWithCredentialFlag'.
+src/components/accounts/AccountCard.tsx(201,18): error TS2339: Property 'enabled' does not exist on type 'AccountWithCredentialFlag'.
+src/components/accounts/AccountCard.tsx(208,28): error TS2339: Property 'label' does not exist on type 'AccountWithCredentialFlag'.
+src/components/accounts/AccountCard.tsx(223,25): error TS2339: Property 'source' does not exist on type 'AccountWithCredentialFlag'.
+src/components/accounts/AccountCard.tsx(233,23): error TS2339: Property 'priority' does not exist on type 'AccountWithCredentialFlag'.
+src/components/accounts/AccountCard.tsx(270,32): error TS2339: Property 'enabled' does not exist on type 'AccountWithCredentialFlag'.
+src/components/accounts/AccountList.tsx(39,56): error TS2339: Property 'priority' does not exist on type 'AccountWithCredentialFlag'.
+src/components/accounts/AccountList.tsx(39,69): error TS2339: Property 'priority' does not exist on type 'AccountWithCredentialFlag'.
+src/components/accounts/AccountList.tsx(46,47): error TS2339: Property 'id' does not exist on type 'AccountWithCredentialFlag'.
+src/components/accounts/AccountList.tsx(52,39): error TS2339: Property 'priority' does not exist on type 'AccountWithCredentialFlag'.
+src/components/accounts/AccountList.tsx(52,62): error TS2339: Property 'priority' does not exist on type 'AccountWithCredentialFlag'.
+src/components/accounts/AccountList.tsx(53,33): error TS2339: Property 'priority' does not exist on type 'AccountWithCredentialFlag'.
+src/components/accounts/AccountList.tsx(54,43): error TS2339: Property 'priority' does not exist on type 'AccountWithCredentialFlag'.
+src/components/accounts/AccountList.tsx(60,45): error TS2339: Property 'id' does not exist on type 'AccountWithCredentialFlag'.
+src/components/accounts/AccountList.tsx(64,52): error TS2339: Property 'id' does not exist on type 'AccountWithCredentialFlag'.
+src/components/accounts/AccountList.tsx(69,49): error TS2339: Property 'id' does not exist on type 'AccountWithCredentialFlag'.
+src/components/accounts/AccountList.tsx(135,28): error TS2339: Property 'id' does not exist on type 'AccountWithCredentialFlag'.
+src/components/accounts/AccountList.tsx(139,51): error TS2339: Property 'id' does not exist on type 'AccountWithCredentialFlag'.
+src/components/accounts/AccountList.tsx(140,61): error TS2339: Property 'id' does not exist on type 'AccountWithCredentialFlag'.
+src/components/accounts/AccountList.tsx(141,65): error TS2339: Property 'id' does not exist on type 'AccountWithCredentialFlag'.
+src/components/accounts/AccountList.tsx(142,69): error TS2339: Property 'id' does not exist on type 'AccountWithCredentialFlag'.
+src/components/accounts/AccountList.tsx(143,50): error TS2339: Property 'id' does not exist on type 'AccountWithCredentialFlag'.
+src/components/accounts/AccountList.tsx(144,52): error TS2339: Property 'id' does not exist on type 'AccountWithCredentialFlag'.
+src/components/accounts/AccountList.tsx(146,57): error TS2339: Property 'id' does not exist on type 'AccountWithCredentialFlag'.
+src/components/accounts/AccountList.tsx(149,59): error TS2339: Property 'id' does not exist on type 'AccountWithCredentialFlag'.
+src/components/accounts/AccountList.tsx(151,67): error TS2339: Property 'id' does not exist on type 'AccountWithCredentialFlag'.
+src/components/chat/widgets/__e2e__/orchestrator-accounts-fixture.tsx(21,43): error TS2339: Property 'providerId' does not exist on type 'AccountWithCredentialFlag'.
+src/components/chat/widgets/__e2e__/orchestrator-accounts-fixture.tsx(46,11): error TS2353: Object literal may only specify known properties, and 'usage' does not exist in type 'Partial<AccountWithCredentialFlag> & { id: string; providerId: any; label: string; }'.
+src/components/chat/widgets/__e2e__/orchestrator-accounts-fixture.tsx(52,11): error TS2353: Object literal may only specify known properties, and 'usage' does not exist in type 'Partial<AccountWithCredentialFlag> & { id: string; providerId: any; label: string; }'.
+src/components/chat/widgets/__e2e__/orchestrator-accounts-fixture.tsx(64,11): error TS2353: Object literal may only specify known properties, and 'usage' does not exist in type 'Partial<AccountWithCredentialFlag> & { id: string; providerId: any; label: string; }'.
+src/components/chat/widgets/agent-orchestrator-accounts-view.tsx(187,62): error TS2339: Property 'id' does not exist on type 'AccountWithCredentialFlag'.
+src/components/chat/widgets/agent-orchestrator-accounts-view.tsx(190,31): error TS2339: Property 'providerId' does not exist on type 'AccountWithCredentialFlag'.
+src/components/chat/widgets/agent-orchestrator-accounts-view.tsx(190,53): error TS2339: Property 'id' does not exist on type 'AccountWithCredentialFlag'.
+src/components/chat/widgets/agent-orchestrator-accounts-view.tsx(195,87): error TS2339: Property 'health' does not exist on type 'AccountWithCredentialFlag'.
+src/components/chat/widgets/agent-orchestrator-accounts-view.tsx(198,28): error TS2339: Property 'label' does not exist on type 'AccountWithCredentialFlag'.
+src/components/chat/widgets/agent-orchestrator-accounts-view.tsx(201,28): error TS2339: Property 'providerId' does not exist on type 'AccountWithCredentialFlag'.
+src/components/chat/widgets/agent-orchestrator-accounts-view.tsx(214,30): error TS2339: Property 'usage' does not exist on type 'AccountWithCredentialFlag'.
+src/components/chat/widgets/agent-orchestrator-accounts-view.tsx(218,30): error TS2339: Property 'usage' does not exist on type 'AccountWithCredentialFlag'.
+src/hooks/useAccounts.ts(84,49): error TS2339: Property 'id' does not exist on type 'AccountWithCredentialFlag'.
+src/hooks/useAccounts.ts(91,26): error TS2339: Property 'id' does not exist on type 'AccountWithCredentialFlag'.
+src/hooks/useAccounts.ts(179,32): error TS2339: Property 'id' does not exist on type 'AccountWithCredentialFlag'.
+src/hooks/useAccounts.ts(180,35): error TS2339: Property 'priority' does not exist on type 'AccountWithCredentialFlag'.
+src/hooks/useAccounts.ts(180,48): error TS2339: Property 'priority' does not exist on type 'AccountWithCredentialFlag'.
+src/hooks/useAccounts.ts(211,58): error TS2339: Property 'id' does not exist on type 'AccountWithCredentialFlag'.
+src/state/startup-phase-hydrate.voice-control.test.ts(71,50): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Argument of type 'Mock<Constructable | Procedure>' is not assignable to parameter of type 'EventListenerOrEventListenerObject'.
+      Type 'MockInstance<Constructable | Procedure> & (new (...args: any[]) => any) & {}' is not assignable to type 'EventListenerOrEventListenerObject'.
+src/state/startup-phase-hydrate.voice-control.test.ts(76,53): error TS2769: No overload matches this call.
+  The last overload gave the following error.
+    Argument of type 'Mock<Constructable | Procedure>' is not assignable to parameter of type 'EventListenerOrEventListenerObject'.
+      Type 'MockInstance<Constructable | Procedure> & (new (...args: any[]) => any) & {}' is not assignable to type 'EventListenerOrEventListenerObject'.
+src/state/useWalletState.ts(232,10): error TS7006: Parameter 'wallet' implicitly has an 'any' type.
+error: script "typecheck" exited with code 1

--- a/.github/issue-evidence/10416-app-auth-steward-config/ui-vitest.log
+++ b/.github/issue-evidence/10416-app-auth-steward-config/ui-vitest.log
@@ -1,0 +1,11 @@
+Tue Jun 30 00:30:40 PDT 2026
+$ NODE_OPTIONS="${NODE_OPTIONS:-} --no-experimental-webstorage --disable-warning=ExperimentalWarning" vitest run --config ./vitest.config.ts src/cloud/shell/StewardProvider.test.tsx src/cloud/public-pages/pages/app-auth/app-authorize-page.test.tsx
+
+ RUN  v4.1.5 /home/shaw/milady/eliza-issue-10416/packages/ui
+
+
+ Test Files  2 passed (2)
+      Tests  4 passed (4)
+   Start at  00:30:40
+   Duration  1.90s (transform 271ms, setup 125ms, import 461ms, tests 479ms, environment 1.87s)
+

--- a/packages/cloud/sdk/README.md
+++ b/packages/cloud/sdk/README.md
@@ -57,6 +57,26 @@ const reply = await cloud.createChatCompletion(
 );
 ```
 
+For a third-party OAuth-style app sign-in, send the user to the canonical
+Eliza Cloud app authorization route. Use the SDK helper so your app does not
+accidentally link to bare `/authorize`, which is not a Cloud app-auth route:
+
+```ts
+import { buildAppAuthorizeUrl } from "@elizaos/cloud-sdk";
+
+const authorizeUrl = buildAppAuthorizeUrl({
+  appId: "app_123",
+  redirectUri: "https://example.app/auth/eliza/callback",
+  state: crypto.randomUUID(),
+});
+
+window.location.assign(authorizeUrl);
+```
+
+The generated URL is
+`https://www.elizacloud.ai/app-auth/authorize?app_id=...&redirect_uri=...&state=...`.
+Use `/app-auth/authorize`; do not use `/authorize`.
+
 `waitForCliLogin(sessionId, { timeoutMs?, intervalMs?, signal? })` and the
 `{ appId }` option on `createChatCompletion` / `createResponse` /
 `createEmbeddings` / `generateImage` exist so browser apps don't have to

--- a/packages/cloud/sdk/src/app-auth.test.ts
+++ b/packages/cloud/sdk/src/app-auth.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { APP_AUTHORIZE_PATH, buildAppAuthorizeUrl } from "./app-auth.js";
+
+describe("buildAppAuthorizeUrl", () => {
+  it("builds the canonical third-party app authorize URL", () => {
+    const url = new URL(
+      buildAppAuthorizeUrl({
+        appId: "app_123",
+        redirectUri: "https://example.app/auth/callback",
+        state: "csrf-value",
+        baseUrl: "https://www.elizacloud.ai/",
+      }),
+    );
+
+    expect(url.origin).toBe("https://www.elizacloud.ai");
+    expect(url.pathname).toBe(APP_AUTHORIZE_PATH);
+    expect(url.searchParams.get("app_id")).toBe("app_123");
+    expect(url.searchParams.get("redirect_uri")).toBe(
+      "https://example.app/auth/callback",
+    );
+    expect(url.searchParams.get("state")).toBe("csrf-value");
+  });
+});

--- a/packages/cloud/sdk/src/app-auth.ts
+++ b/packages/cloud/sdk/src/app-auth.ts
@@ -1,0 +1,29 @@
+import { DEFAULT_ELIZA_CLOUD_BASE_URL } from "./types.js";
+
+export const APP_AUTHORIZE_PATH = "/app-auth/authorize";
+
+export interface BuildAppAuthorizeUrlOptions {
+  appId: string;
+  redirectUri: string;
+  state?: string;
+  baseUrl?: string;
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+export function buildAppAuthorizeUrl({
+  appId,
+  redirectUri,
+  state,
+  baseUrl = DEFAULT_ELIZA_CLOUD_BASE_URL,
+}: BuildAppAuthorizeUrlOptions): string {
+  const url = new URL(APP_AUTHORIZE_PATH, `${trimTrailingSlash(baseUrl)}/`);
+  url.searchParams.set("app_id", appId);
+  url.searchParams.set("redirect_uri", redirectUri);
+  if (state) {
+    url.searchParams.set("state", state);
+  }
+  return url.toString();
+}

--- a/packages/cloud/sdk/src/index.ts
+++ b/packages/cloud/sdk/src/index.ts
@@ -1,3 +1,8 @@
+export {
+  APP_AUTHORIZE_PATH,
+  type BuildAppAuthorizeUrlOptions,
+  buildAppAuthorizeUrl,
+} from "./app-auth.js";
 export { createElizaCloudClient, ElizaCloudClient } from "./client.js";
 export {
   CloudApiClient,

--- a/packages/ui/src/cloud/shell/StewardProvider.test.tsx
+++ b/packages/ui/src/cloud/shell/StewardProvider.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const resolveBrowserStewardApiUrl = vi.fn(() => "placeholder-steward-url");
+
+vi.mock("./steward-url", () => ({
+  resolveBrowserStewardApiUrl: () => resolveBrowserStewardApiUrl(),
+}));
+
+vi.mock("./StewardProviderRuntime", () => ({
+  default: ({ children }: { children: ReactNode }) => (
+    <div data-testid="steward-runtime">{children}</div>
+  ),
+}));
+
+import { StewardAuthProvider } from "./StewardProvider";
+
+afterEach(() => {
+  cleanup();
+  resolveBrowserStewardApiUrl.mockReturnValue("placeholder-steward-url");
+});
+
+function renderAt(pathname: string) {
+  return render(
+    <MemoryRouter initialEntries={[pathname]}>
+      <StewardAuthProvider>
+        <div data-testid="protected-child" />
+      </StewardAuthProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("StewardAuthProvider", () => {
+  it("renders a fail-loud auth configuration error on app-auth routes with an invalid Steward URL", () => {
+    renderAt("/app-auth/authorize?app_id=app_123");
+
+    expect(
+      screen.getByRole("alert", { name: /sign-in temporarily unavailable/i }),
+    ).toBeTruthy();
+    expect(screen.queryByTestId("protected-child")).toBeNull();
+  });
+
+  it("keeps bypassing Steward runtime on routes that do not need auth", () => {
+    renderAt("/docs");
+
+    expect(screen.getByTestId("protected-child")).toBeTruthy();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("loads the Steward runtime on app-auth routes with a valid Steward URL", async () => {
+    resolveBrowserStewardApiUrl.mockReturnValue(
+      "https://api.elizacloud.ai/steward",
+    );
+
+    renderAt("/app-auth/authorize?app_id=app_123");
+
+    expect(await screen.findByTestId("steward-runtime")).toBeTruthy();
+    expect(screen.getByTestId("protected-child")).toBeTruthy();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});

--- a/packages/ui/src/cloud/shell/StewardProvider.tsx
+++ b/packages/ui/src/cloud/shell/StewardProvider.tsx
@@ -73,6 +73,48 @@ function shouldLoadStewardRuntime(pathname: string): boolean {
   );
 }
 
+function StewardConfigError() {
+  return (
+    <main
+      aria-labelledby="steward-config-error-title"
+      role="alert"
+      style={{
+        alignItems: "center",
+        background: "#f8f4ef",
+        color: "#2f261f",
+        display: "flex",
+        minHeight: "100vh",
+        padding: "24px",
+      }}
+    >
+      <section
+        style={{
+          border: "1px solid #d8c7b8",
+          borderRadius: 8,
+          margin: "0 auto",
+          maxWidth: 560,
+          padding: "24px",
+        }}
+      >
+        <h1
+          id="steward-config-error-title"
+          style={{
+            fontSize: 24,
+            lineHeight: 1.2,
+            margin: "0 0 12px",
+          }}
+        >
+          Sign-in temporarily unavailable
+        </h1>
+        <p style={{ fontSize: 16, lineHeight: 1.5, margin: 0 }}>
+          Eliza Cloud authentication is not configured for this environment. Set
+          a valid Steward API URL and reload this page.
+        </p>
+      </section>
+    </main>
+  );
+}
+
 /**
  * Outer Steward provider. Cheap on routes that don't need auth (no token, not
  * an auth surface) — it renders children directly without loading the heavy
@@ -109,8 +151,14 @@ export function StewardAuthProvider({ children }: { children: ReactNode }) {
     return <>{children}</>;
   }
 
-  if (!hasValidUrl || !shouldLoadStewardRuntime(location.pathname)) {
+  const needsStewardRuntime = shouldLoadStewardRuntime(location.pathname);
+
+  if (!needsStewardRuntime) {
     return <>{children}</>;
+  }
+
+  if (!hasValidUrl) {
+    return <StewardConfigError />;
   }
 
   return (


### PR DESCRIPTION
## Summary
- render a clear Steward auth configuration error on routes like `/app-auth/authorize` when the Steward API URL is invalid instead of bypassing the provider and letting `useAuth()` crash
- keep non-auth routes on the cheap bypass path and keep valid app-auth routes loading the Steward runtime
- add `buildAppAuthorizeUrl()` / `APP_AUTHORIZE_PATH` to `@elizaos/cloud-sdk` and document the canonical `/app-auth/authorize` URL

Fixes #10416.

## Validation
- `bun run --cwd packages/ui test src/cloud/shell/StewardProvider.test.tsx src/cloud/public-pages/pages/app-auth/app-authorize-page.test.tsx`
- `bun test packages/cloud/sdk/src/app-auth.test.ts`
- `bun run --cwd packages/cloud/sdk test`
- `bun run --cwd packages/cloud/sdk typecheck`
- `bun run --cwd packages/cloud/sdk build`
- `bunx @biomejs/biome check packages/ui/src/cloud/shell/StewardProvider.tsx packages/ui/src/cloud/shell/StewardProvider.test.tsx packages/cloud/sdk/src/app-auth.ts packages/cloud/sdk/src/app-auth.test.ts packages/cloud/sdk/src/index.ts packages/cloud/sdk/README.md`

## Evidence
- `.github/issue-evidence/10416-app-auth-steward-config/` contains the command logs and Android lock-state capture.
- Android screenshot/recording: N/A for this web app-auth route; physical device `27051JEGR10034` was connected but locked (`NotificationShade`, `mDreamingLockscreen=true`).
- `packages/ui typecheck` and `packages/app dev` were attempted and logs are included; both fail on unrelated existing fresh-worktree/build-state blockers documented in the evidence README.