### PR TITLE
ci(ui): storybook play-coverage ratchet (#9943 — interaction-test floor)

### DIFF
--- a/.github/workflows/ui-story-gate.yml
+++ b/.github/workflows/ui-story-gate.yml
@@ -58,6 +58,12 @@ jobs:
           skip-avatar-clone: "true"
           no-vision-deps: "true"
 
+      # Source-static ratchet (#9943): fails fast — before the heavy catalog build
+      # + browser install — if any story that had a `play` interaction test lost
+      # it, or play-coverage fell below the committed floor.
+      - name: Story `play`-coverage ratchet
+        run: node packages/ui/test/story-gate/play-coverage-gate.mjs
+
       - name: Install Playwright Chromium
         run: bunx playwright install --with-deps chromium
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -62,6 +62,8 @@
     "audit:stories": "node test/story-gate/run-story-gate.mjs",
     "audit:stories:build": "bun run build-storybook --output-dir storybook-static --quiet && node test/story-gate/run-story-gate.mjs",
     "audit:stories:update-baseline": "node test/story-gate/run-story-gate.mjs --update-baseline",
+    "audit:stories:play": "node test/story-gate/play-coverage-gate.mjs",
+    "audit:stories:play:update-baseline": "node test/story-gate/play-coverage-gate.mjs --update-baseline",
     "build:dist:unlocked": "bun run clean && bun run generate:css-strings && node ../scripts/ensure-tsc-nested-output-dir.mjs packages/ui && tsc --noCheck -p tsconfig.build.json && node ../scripts/flatten-tsc-package-output.mjs packages/ui && node ../scripts/copy-package-assets.mjs packages/ui src/styles src/cloud-ui/index.css && node ../scripts/prepare-package-dist.mjs packages/ui && node ../scripts/rewrite-dist-relative-imports-node-esm.mjs packages/ui && node ../scripts/verify-package-runtime-exports.mjs packages/ui",
     "test:orchestrator-accounts-e2e": "bun run --cwd ../.. packages/ui/src/components/chat/widgets/__e2e__/run-orchestrator-accounts-e2e.mjs",
     "test:ftu-home-e2e": "bun run --cwd ../.. packages/ui/src/components/chat/widgets/__e2e__/run-ftu-home-e2e.mjs"

--- a/packages/ui/test/story-gate/baseline/play-baseline.json
+++ b/packages/ui/test/story-gate/baseline/play-baseline.json
@@ -1,0 +1,19 @@
+{
+  "description": "Story files with a Storybook `play` interaction test (#9943 ratchet floor). Regenerate with: bun run --cwd packages/ui audit:stories:play -- --update-baseline",
+  "files": [
+    "packages/ui/src/components/chat/widgets/agent-provisioning.stories.tsx",
+    "packages/ui/src/components/chat/widgets/calendar-upcoming.stories.tsx",
+    "packages/ui/src/components/chat/widgets/finances-alerts.stories.tsx",
+    "packages/ui/src/components/chat/widgets/goals-attention.stories.tsx",
+    "packages/ui/src/components/chat/widgets/health-sleep.stories.tsx",
+    "packages/ui/src/components/chat/widgets/home-widget-card.stories.tsx",
+    "packages/ui/src/components/chat/widgets/inbox-unread.stories.tsx",
+    "packages/ui/src/components/chat/widgets/model-download.stories.tsx",
+    "packages/ui/src/components/chat/widgets/needs-attention.stories.tsx",
+    "packages/ui/src/components/chat/widgets/relationships-attention.stories.tsx",
+    "packages/ui/src/components/composites/chat/chat-message-actions.stories.tsx",
+    "packages/ui/src/components/pages/Launcher.stories.tsx",
+    "packages/ui/src/components/shell/RestartBanner.stories.tsx",
+    "packages/ui/src/components/shell/ShortcutsOverlay.stories.tsx"
+  ]
+}

--- a/packages/ui/test/story-gate/play-coverage-gate.mjs
+++ b/packages/ui/test/story-gate/play-coverage-gate.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+/**
+ * Storybook `play`-coverage ratchet (issue #9943).
+ *
+ * The story gate (`run-story-gate.mjs`) proves every story MOUNTS; it does not
+ * prove component interactions work. Most stories are render-only — only a small
+ * set export a `play` (Storybook's interaction-test hook). A naive "require `play`
+ * on every story" would red ~300 stories at once, so this is an eslint-style
+ * RATCHET instead: the set of stories that currently have a `play` is the
+ * committed floor, and the gate fails when any of them LOSES its `play` (an
+ * interaction-test regression) or the total count drops below the floor. New
+ * `play`s are encouraged (ratchet up via `--update-baseline`), never required.
+ *
+ * Source-static (scans `*.stories.tsx`) — no Storybook build or browser needed,
+ * so it runs fast on every PR.
+ *
+ * Usage:
+ *   node test/story-gate/play-coverage-gate.mjs [--update-baseline]
+ *
+ * Exit codes: 0 clean · 1 regression (a tracked story lost `play`, or count fell).
+ */
+import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "../../../..");
+const baselinePath = join(here, "baseline", "play-baseline.json");
+
+/** Roots scanned for `*.stories.tsx`. */
+const SCAN_ROOTS = ["packages/ui/src", "plugins/plugin-companion/src"];
+
+/** A `play` is `play:` (CSF3 object) or `.play =` (CSF2 assignment); `\bplay\b`
+ * avoids matching `display`/`replay`. */
+const PLAY_RE = /\bplay\b\s*[:=]/;
+
+function walk(dir, out) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const e of entries) {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) {
+      if (
+        e.name === "node_modules" ||
+        e.name === "dist" ||
+        e.name === "storybook-static"
+      )
+        continue;
+      walk(full, out);
+    } else if (e.isFile() && e.name.endsWith(".stories.tsx")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function storyFilesWithPlay() {
+  const withPlay = [];
+  for (const root of SCAN_ROOTS) {
+    const abs = join(repoRoot, root);
+    try {
+      statSync(abs);
+    } catch {
+      continue;
+    }
+    for (const file of walk(abs, [])) {
+      const src = readFileSync(file, "utf8");
+      if (PLAY_RE.test(src))
+        withPlay.push(relative(repoRoot, file).replaceAll("\\", "/"));
+    }
+  }
+  return withPlay.sort();
+}
+
+function loadBaseline() {
+  try {
+    const parsed = JSON.parse(readFileSync(baselinePath, "utf8"));
+    return Array.isArray(parsed.files) ? parsed.files : [];
+  } catch {
+    return [];
+  }
+}
+
+const updateBaseline = process.argv.includes("--update-baseline");
+const current = storyFilesWithPlay();
+
+if (updateBaseline) {
+  writeFileSync(
+    baselinePath,
+    `${JSON.stringify({ description: "Story files with a Storybook `play` interaction test (#9943 ratchet floor). Regenerate with: bun run --cwd packages/ui audit:stories:play -- --update-baseline", files: current }, null, 2)}\n`,
+  );
+  console.log(
+    `[play-gate] baseline updated: ${current.length} stories with a play`,
+  );
+  process.exit(0);
+}
+
+const baseline = loadBaseline();
+const currentSet = new Set(current);
+const lost = baseline.filter((f) => !currentSet.has(f));
+
+if (lost.length > 0) {
+  console.error(
+    `[play-gate] REGRESSION: ${lost.length} story file(s) that had a \`play\` interaction test lost it:\n` +
+      lost.map((f) => `  - ${f}`).join("\n") +
+      `\nAdd the \`play\` back, or (if intentional) regenerate the baseline with:\n` +
+      `  bun run --cwd packages/ui audit:stories:play -- --update-baseline`,
+  );
+  process.exit(1);
+}
+
+if (current.length < baseline.length) {
+  console.error(
+    `[play-gate] REGRESSION: play-coverage fell from ${baseline.length} to ${current.length} stories.`,
+  );
+  process.exit(1);
+}
+
+const added = current.filter((f) => !baseline.includes(f));
+console.log(
+  `[play-gate] OK — ${current.length} stories have a play (floor ${baseline.length})` +
+    (added.length
+      ? `; ${added.length} new (run --update-baseline to lock them in)`
+      : ""),
+);
+process.exit(0);


### PR DESCRIPTION
## What & why

One slice of the #9943 umbrella (item B5): the story gate proves every story **mounts**, but not that component **interactions** work — only ~14 of 330 stories export a Storybook `play`. A naive "require `play` on every story" would red ~300 stories at once, so this adds an **eslint-style ratchet** instead.

`play-coverage-gate.mjs` (source-static — scans `*.stories.tsx`, **no** storybook build or browser):
- The 14 stories that currently have a `play` are the committed floor (`baseline/play-baseline.json`).
- Fails when any tracked story **loses** its `play` (an interaction-test regression) or the count drops below the floor.
- New `play`s are encouraged (`audit:stories:play:update-baseline`), never required.
- Wired as the **first, fast-fail step** of `ui-story-gate.yml` (before the heavy catalog build + chromium install).

## Verification (local, real)

```
bun run --cwd packages/ui audit:stories:play
[play-gate] OK — 14 stories have a play (floor 14)
```

Proved it guards regressions (no-larp): stripping the `play` from one tracked story (`agent-provisioning.stories.tsx`) turns it **red** — `REGRESSION: 1 story file ... lost it` (exit 1) — and restoring goes green.

## Context: most of #9943 already landed

Re-verifying the umbrella against current `develop`, almost every original claim is already fixed: the **feed lane** (`feed-test.yml`, #9991/#10055), **directory-driven ui-smoke gate**, **coverage gate `ENFORCE=1` + thresholds**, **group-g2 auth/validation un-skip**, and the **zero-test plugins** are all done. This `play`-ratchet closes one of the few remaining non-hardware enforcement gaps. Remaining items (feed `test:ci` E2E promotion, the iOS device smoke `continue-on-error`, device/gesture lanes) are deliberate-defer or hardware-gated. See the issue comment for the full re-verified matrix.

Evidence: local gate output + red-on-regression proof above. Screenshots/device/LLM: N/A (CI-config + source-static script).

Advances #9943.

🤖 Generated with [Claude Code](https://claude.com/claude-code)