### PR TITLE
fix(core): force plan action narration

### DIFF
--- a/.github/issue-evidence/10424-simple-path-action-narration/README.md
+++ b/.github/issue-evidence/10424-simple-path-action-narration/README.md
@@ -1,0 +1,24 @@
+# Issue #10424 Evidence
+
+## Change
+
+Stage-1 simple-path output now treats progress narration and live-verification
+claims as honesty violations, forcing the turn back through planning with an
+empty direct reply instead of publishing text such as "Spawning the sub-agent
+now" or "Verified live" without tool evidence.
+
+## Validation
+
+- `core-focused-vitest.log` — `bun run --cwd packages/core test src/runtime/__tests__/message-handler.test.ts src/runtime/__tests__/message-handler-bogus-candidates.test.ts` passed.
+- `core-typecheck.log` — `bun run --cwd packages/core typecheck` passed.
+- `core-build-node.log` — `bun run --cwd packages/core build:node` passed.
+- `biome-focused.log` — focused Biome check passed for the detector and touched tests.
+
+## Evidence Not Captured
+
+- Live LLM trajectory: N/A in this shell because no supported live-model API key
+  is present. See `live-llm-env.log`; it records key presence only, never secret
+  values.
+- Android screenshot/screen recording: N/A for this runtime-only routing change,
+  and the attached physical Android is currently locked on `NotificationShade`.
+  See `android-lock-state.log`.

--- a/.github/issue-evidence/10424-simple-path-action-narration/android-lock-state.log
+++ b/.github/issue-evidence/10424-simple-path-action-narration/android-lock-state.log
@@ -1,0 +1,10 @@
+2026-06-30T00:38:30-07:00
+$ adb devices -l
+List of devices attached
+27051JEGR10034         device usb:5-2 product:bluejay model:Pixel_6a device:bluejay transport_id:5
+emulator-5554          device product:sdk_gphone64_x86_64 model:sdk_gphone64_x86_64 device:emu64xa transport_id:14
+
+$ adb -s 27051JEGR10034 shell dumpsys window | rg mCurrentFocus|mFocusedApp|mDreamingLockscreen
+  mCurrentFocus=Window{e93d7cf u0 NotificationShade}
+  mFocusedApp=null
+    mShowingDream=false mDreamingLockscreen=true

--- a/.github/issue-evidence/10424-simple-path-action-narration/biome-focused.log
+++ b/.github/issue-evidence/10424-simple-path-action-narration/biome-focused.log
@@ -1,0 +1,3 @@
+2026-06-30T00:38:30-07:00
+$ bunx @biomejs/biome check packages/core/src/runtime/stage1-honesty-detector.ts packages/core/src/runtime/__tests__/message-handler.test.ts packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts
+Checked 3 files in 43ms. No fixes applied.

--- a/.github/issue-evidence/10424-simple-path-action-narration/core-build-node.log
+++ b/.github/issue-evidence/10424-simple-path-action-narration/core-build-node.log
@@ -1,0 +1,32 @@
+2026-06-30T00:38:21-07:00
+$ bun run --cwd packages/core build:node
+$ bun run build.ts --node-only
+🚀 Starting Node-only build process for @elizaos/core
+🔨 Building for Node.js...
+🚀 Building @elizaos/core...
+
+🧪 Building testing module...
+🚀 Building @elizaos/core...
+
+✓ Configuration prepared (0.62ms)
+
+Bundling with Bun...
+✓ Configuration prepared (0.42ms)
+
+Bundling with Bun...
+✓ Built 4 file(s) - 28.78MB (339.36ms)
+
+✅ @elizaos/core build complete!
+⏱️  Total build time: 340.08ms
+✅ Node.js build complete in 0.34s
+✓ Built 4 file(s) - 0.02MB (344.36ms)
+
+✅ @elizaos/core build complete!
+⏱️  Total build time: 344.86ms
+✅ Testing module build complete in 0.34s
+📝 Generating TypeScript declarations...
+   Compiling TypeScript declarations...
+   Rewrote 1495 relative specifier(s) in 458 .d.ts file(s) for NodeNext ESM
+✅ TypeScript declarations generated in 8.75s
+
+🎉 Node-only build complete in 9.09s

--- a/.github/issue-evidence/10424-simple-path-action-narration/core-focused-vitest.log
+++ b/.github/issue-evidence/10424-simple-path-action-narration/core-focused-vitest.log
@@ -1,0 +1,12 @@
+2026-06-30T00:38:17-07:00
+$ bun run --cwd packages/core test src/runtime/__tests__/message-handler.test.ts src/runtime/__tests__/message-handler-bogus-candidates.test.ts
+$ node ../scripts/run-vitest.mjs run src/runtime/__tests__/message-handler.test.ts src/runtime/__tests__/message-handler-bogus-candidates.test.ts
+
+ RUN  v4.1.5 /home/shaw/milady/eliza-issue-10424/packages/core
+
+
+ Test Files  2 passed (2)
+      Tests  63 passed (63)
+   Start at  00:38:18
+   Duration  3.05s (transform 2.09s, setup 0ms, import 2.61s, tests 91ms, environment 0ms)
+

--- a/.github/issue-evidence/10424-simple-path-action-narration/core-typecheck.log
+++ b/.github/issue-evidence/10424-simple-path-action-narration/core-typecheck.log
@@ -1,0 +1,3 @@
+2026-06-30T00:38:21-07:00
+$ bun run --cwd packages/core typecheck
+$ tsgo --noEmit -p ./tsconfig.json

--- a/.github/issue-evidence/10424-simple-path-action-narration/live-llm-env.log
+++ b/.github/issue-evidence/10424-simple-path-action-narration/live-llm-env.log
@@ -1,0 +1,7 @@
+2026-06-30T00:38:30-07:00
+$ node -e <redacted key presence check>
+OPENAI_API_KEY=missing
+ANTHROPIC_API_KEY=missing
+GOOGLE_GENERATIVE_AI_API_KEY=missing
+GEMINI_API_KEY=missing
+ELIZAOS_API_KEY=missing

--- a/packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts
+++ b/packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts
@@ -183,6 +183,29 @@ describe("messageHandlerFromFieldResult — bogus candidate actions", () => {
 		expect(handler.plan.reply).toBe("");
 	});
 
+	it("keeps the simple path for explanatory gerunds that are substantive answers", () => {
+		const replyText =
+			"Checking accounts are bank accounts designed for frequent deposits and withdrawals.";
+		const handler = messageHandlerFromFieldResult(
+			{
+				shouldRespond: "RESPOND",
+				contexts: ["simple"],
+				candidateActionNames: [],
+				replyText,
+				intents: [],
+				facts: [],
+				addressedTo: [],
+			},
+			undefined,
+			{ actions: REAL_ACTIONS },
+		);
+
+		expect(handler.plan.simple).toBe(true);
+		expect(handler.plan.requiresTool).toBe(false);
+		expect(handler.plan.contexts).toEqual(["simple"]);
+		expect(handler.plan.reply).toBe(replyText);
+	});
+
 	it("still promotes to planning when candidateActions contains AT LEAST ONE real action even with simple context", () => {
 		const handler = messageHandlerFromFieldResult(
 			{

--- a/packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts
+++ b/packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts
@@ -141,6 +141,48 @@ describe("messageHandlerFromFieldResult — bogus candidate actions", () => {
 		expect(handler.plan.reply).toBe("");
 	});
 
+	it("forces planning for simple-path unexecuted sub-agent narration", () => {
+		const handler = messageHandlerFromFieldResult(
+			{
+				shouldRespond: "RESPOND",
+				contexts: ["simple"],
+				candidateActionNames: [],
+				replyText: "Spawning the sub-agent now.",
+				intents: [],
+				facts: [],
+				addressedTo: [],
+			},
+			undefined,
+			{ actions: REAL_ACTIONS },
+		);
+
+		expect(handler.plan.simple).toBe(false);
+		expect(handler.plan.requiresTool).toBe(true);
+		expect(handler.plan.contexts).toEqual(["general"]);
+		expect(handler.plan.reply).toBe("");
+	});
+
+	it("forces planning for simple-path live-verification claims without tool evidence", () => {
+		const handler = messageHandlerFromFieldResult(
+			{
+				shouldRespond: "RESPOND",
+				contexts: ["simple"],
+				candidateActionNames: [],
+				replyText: "Verified live: App loads HTTP 200 and 401/402 is enforced.",
+				intents: [],
+				facts: [],
+				addressedTo: [],
+			},
+			undefined,
+			{ actions: REAL_ACTIONS },
+		);
+
+		expect(handler.plan.simple).toBe(false);
+		expect(handler.plan.requiresTool).toBe(true);
+		expect(handler.plan.contexts).toEqual(["general"]);
+		expect(handler.plan.reply).toBe("");
+	});
+
 	it("still promotes to planning when candidateActions contains AT LEAST ONE real action even with simple context", () => {
 		const handler = messageHandlerFromFieldResult(
 			{

--- a/packages/core/src/runtime/__tests__/message-handler.test.ts
+++ b/packages/core/src/runtime/__tests__/message-handler.test.ts
@@ -199,6 +199,71 @@ describe("v5 message handler routing", () => {
 		}
 	});
 
+	it("forces planning when simple-path text narrates unexecuted action", () => {
+		const parsed = parseMessageHandlerOutput(
+			JSON.stringify({
+				shouldRespond: "RESPOND",
+				replyText: "Spawning the sub-agent now.",
+				contexts: ["simple"],
+				candidateActionNames: [],
+			}),
+		);
+
+		expect(parsed).toMatchObject({
+			processMessage: "RESPOND",
+			plan: { contexts: ["general"], reply: "" },
+		});
+		expect(parsed).not.toBeNull();
+		if (!parsed) return;
+		const route = routeMessageHandlerOutput(parsed);
+		expect(route.type).toBe("planning_needed");
+	});
+
+	it("forces planning when simple-path text claims live verification without a tool result", () => {
+		const parsed = parseMessageHandlerOutput(
+			JSON.stringify({
+				shouldRespond: "RESPOND",
+				replyText: "Verified live: App loads HTTP 200 and 401/402 is enforced.",
+				contexts: ["simple"],
+				candidateActionNames: [],
+			}),
+		);
+
+		expect(parsed).toMatchObject({
+			processMessage: "RESPOND",
+			plan: { contexts: ["general"], reply: "" },
+		});
+		expect(parsed).not.toBeNull();
+		if (!parsed) return;
+		const route = routeMessageHandlerOutput(parsed);
+		expect(route.type).toBe("planning_needed");
+	});
+
+	it("does not force planning for explanatory gerunds that are substantive answers", () => {
+		const parsed = parseMessageHandlerOutput(
+			JSON.stringify({
+				shouldRespond: "RESPOND",
+				replyText:
+					"Checking accounts are bank accounts designed for frequent deposits and withdrawals.",
+				contexts: ["simple"],
+				candidateActionNames: [],
+			}),
+		);
+
+		expect(parsed).toMatchObject({
+			processMessage: "RESPOND",
+			plan: {
+				contexts: ["simple"],
+				reply:
+					"Checking accounts are bank accounts designed for frequent deposits and withdrawals.",
+			},
+		});
+		expect(parsed).not.toBeNull();
+		if (!parsed) return;
+		const route = routeMessageHandlerOutput(parsed);
+		expect(route.type).toBe("final_reply");
+	});
+
 	it("does not parse retired requiresTool from the model envelope", () => {
 		const parsed = parseMessageHandlerOutput(
 			JSON.stringify({

--- a/packages/core/src/runtime/stage1-honesty-detector.ts
+++ b/packages/core/src/runtime/stage1-honesty-detector.ts
@@ -2,13 +2,77 @@ import { looksLikeTrainingCutoffLeak } from "./cutoff-leak-detector";
 import { looksLikeFabricatedModeration } from "./fabricated-moderation-detector";
 import { looksLikeRefusal } from "./refusal-detector";
 
+function normalizeForActionNarration(text: string): string {
+	return text
+		.toLowerCase()
+		.replace(/[`*_~[\](){}>#✅]/g, " ")
+		.replace(/\s+/g, " ")
+		.trim();
+}
+
+/**
+ * Stage 1 is allowed to answer directly only when its text is the answer. It
+ * must not narrate work that only a planner/tool turn can actually perform.
+ */
+export function looksLikeUnexecutedActionNarration(
+	text: string | undefined | null,
+): boolean {
+	if (typeof text !== "string") return false;
+	const normalized = normalizeForActionNarration(text);
+	if (!normalized) return false;
+
+	if (
+		/^(?:i(?:'|’)m|i am|i(?:'|’)ll|i will|let me)\s+(?:work on|check|fetch|search|look (?:up|into)|verify|test|build|deploy|fix|start|run|spawn)\b/u.test(
+			normalized,
+		)
+	) {
+		return true;
+	}
+	if (
+		/^(?:working on|checking|fetching|searching|looking (?:up|into)|verifying|testing|building|deploying|fixing|starting|running|spawning)\s+(?:a|an|the|that|this|it|for|now|live|http\b|https?:|deploy|deployment|site|app|url|endpoint|page|test|tests|build|sub-?agent|coding)\b/u.test(
+			normalized,
+		)
+	) {
+		return true;
+	}
+	if (
+		/^(?:one sec|one moment|give me a sec|hold on|please hold|be right back|almost done|wrapping it up)\b/u.test(
+			normalized,
+		)
+	) {
+		return true;
+	}
+	if (
+		/\bspawning\s+(?:a|the)?\s*(?:coding\s+)?sub-?agent\b/u.test(normalized)
+	) {
+		return true;
+	}
+	if (
+		/^(?:verified|confirmed|checked|tested)\s+(?:live|the live|http\b|https?:|deployment|deploy|401\b|402\b)/u.test(
+			normalized,
+		)
+	) {
+		return true;
+	}
+	if (
+		/^(?:app|site|url|endpoint|page)\b.*\b(?:loads|returns|responds)\b.*\bhttp\s*200\b/u.test(
+			normalized,
+		)
+	) {
+		return true;
+	}
+
+	return false;
+}
+
 export function looksLikeStage1HonestyViolation(
 	text: string | undefined | null,
 ): boolean {
 	return (
 		looksLikeRefusal(text) ||
 		looksLikeTrainingCutoffLeak(text) ||
-		looksLikeFabricatedModeration(text)
+		looksLikeFabricatedModeration(text) ||
+		looksLikeUnexecutedActionNarration(text)
 	);
 }
 
@@ -16,6 +80,8 @@ export function looksLikeNonRefusalStage1HonestyViolation(
 	text: string | undefined | null,
 ): boolean {
 	return (
-		looksLikeTrainingCutoffLeak(text) || looksLikeFabricatedModeration(text)
+		looksLikeTrainingCutoffLeak(text) ||
+		looksLikeFabricatedModeration(text) ||
+		looksLikeUnexecutedActionNarration(text)
 	);
 }


### PR DESCRIPTION
## Summary

- Adds a Stage-1 honesty backstop for simple-path progress narration and unsupported live-verification claims.
- Reuses the existing honesty-violation planning path so these replies become planner turns with an empty direct reply.
- Covers parser-level routing and field-result routing, plus a regression ensuring explanatory gerunds still answer directly.

Fixes #10424

## Validation

- `bun run --cwd packages/core test src/runtime/__tests__/message-handler.test.ts src/runtime/__tests__/message-handler-bogus-candidates.test.ts`
- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/core build:node`
- `bunx @biomejs/biome check packages/core/src/runtime/stage1-honesty-detector.ts packages/core/src/runtime/__tests__/message-handler.test.ts packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts`

## Evidence

- `.github/issue-evidence/10424-simple-path-action-narration/README.md`
- Live LLM trajectory: N/A, no supported live-model API key present in this shell; key-presence evidence included.
- Android screenshot/screen recording: N/A for runtime-only routing behavior; attached physical Android is locked on NotificationShade; lock-state evidence included.