### PR TITLE
fix(cloud): inject app id into deployed app containers

### DIFF
--- a/.github/issue-evidence/10423-app-container-app-id/README.md
+++ b/.github/issue-evidence/10423-app-container-app-id/README.md
@@ -1,0 +1,56 @@
+# Issue #10423 - app container ELIZA_APP_ID injection
+
+Branch: `fix/10423-app-container-app-id`
+
+## What Changed
+
+- Treats `ELIZA_APP_ID` as app-deploy-reserved and strips any caller-supplied
+  value before deploy env construction.
+- Injects the platform-authoritative `req.appId` into every deployed app
+  container env, regardless of database mode.
+- Keeps isolated database injection unchanged: isolated apps still receive
+  `DATABASE_URL` and `POSTGRES_URL` from the tenant DB provisioner, while
+  stateless apps receive no DB vars.
+
+## Evidence
+
+```bash
+bun test src/lib/services/__tests__/app-deploy-orchestrator.test.ts src/lib/services/app-deploy-orchestrator.test.ts src/lib/services/reserved-env-keys.test.ts
+```
+
+Result from `packages/cloud/shared`: 17 tests passed across 3 files.
+
+```bash
+bun run --cwd packages/cloud/shared lint
+```
+
+Result: passed. Biome checked 1222 files with no fixes applied.
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+```bash
+bun run install:light
+bun run --cwd packages/cloud/shared typecheck
+```
+
+`install:light` completed successfully. Typecheck ran, but current `develop`
+fails through unrelated generated i18n modules outside this branch:
+
+- `packages/core/src/i18n/action-search-keywords.ts`
+- `packages/core/src/i18n/validation-keywords.ts`
+- `packages/shared/src/i18n/keyword-matching.ts`
+
+Each error is a missing `./generated/validation-keyword-data` module. No
+typecheck errors were reported for the changed app deploy or reserved env files.
+
+## Scope Note
+
+This PR proves the local deploy-spec wiring: provisioned app container rows now
+carry the authoritative app id and reject caller spoofing. The full cloud proof
+requested by the issue, deploy app -> app inference -> app-credit charge /
+creator earnings attribution, still requires staging or production cloud billing
+infrastructure and is not exercised in this local pass.

--- a/packages/cloud/shared/src/lib/services/__tests__/app-deploy-orchestrator.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-deploy-orchestrator.test.ts
@@ -54,6 +54,7 @@ describe("deployApp", () => {
     // (DATABASE_URL standard + POSTGRES_URL for plugin-sql/eliza images)
     expect(seen.row?.environmentVars.DATABASE_URL).toBe(TENANT_DSN);
     expect(seen.row?.environmentVars.POSTGRES_URL).toBe(TENANT_DSN);
+    expect(seen.row?.environmentVars.ELIZA_APP_ID).toBe(REQ.appId);
     expect(seen.row?.image).toBe(REQ.image);
     expect(seen.row?.port).toBe(3000);
     // provision was enqueued for the created container
@@ -82,13 +83,13 @@ describe("deployApp", () => {
     expect(seen.row?.port).toBe(8080);
   });
 
-  test("injects runtime env into a stateless app container", async () => {
+  test("injects platform-owned app id into a stateless app container", async () => {
     const { seen, deps: d } = deps();
     await deployApp(
       {
         ...REQ,
         env: {
-          ELIZA_APP_ID: REQ.appId,
+          ELIZA_APP_ID: "spoofed-app",
           ELIZA_CLOUD_URL: "https://www.elizacloud.ai",
         },
       },
@@ -108,7 +109,7 @@ describe("deployApp", () => {
         env: {
           DATABASE_URL: "postgresql://not-the-tenant-db",
           POSTGRES_URL: "postgresql://also-not-the-tenant-db",
-          ELIZA_APP_ID: REQ.appId,
+          ELIZA_APP_ID: "spoofed-app",
         },
       },
       d,
@@ -149,7 +150,7 @@ describe("deployApp", () => {
     expect(ensureCalled).toBe(false); // the tenant-DB cluster is never touched
     expect(seen.row?.environmentVars.DATABASE_URL).toBeUndefined();
     expect(seen.row?.environmentVars.POSTGRES_URL).toBeUndefined();
-    expect(seen.row?.environmentVars).toEqual({});
+    expect(seen.row?.environmentVars).toEqual({ ELIZA_APP_ID: REQ.appId });
     // everything else still happens — the app deploys + runs, just without a DB
     expect(result).toEqual({ containerId: "container-1", jobId: "job-1" });
     expect(seen.enqueued?.containerId).toBe("container-1");
@@ -166,6 +167,6 @@ describe("deployApp", () => {
     });
     await deployApp({ ...REQ, databaseMode: "none" }, d);
     expect(ensureCalled).toBe(false);
-    expect(seen.row?.environmentVars).toEqual({});
+    expect(seen.row?.environmentVars).toEqual({ ELIZA_APP_ID: REQ.appId });
   });
 });

--- a/packages/cloud/shared/src/lib/services/app-deploy-orchestrator.test.ts
+++ b/packages/cloud/shared/src/lib/services/app-deploy-orchestrator.test.ts
@@ -41,8 +41,12 @@ describe("deployApp env hardening", () => {
       deps,
     );
     // Reserved keys stripped; a stateless app gets NO DB var injected and can no
-    // longer smuggle one (or a managed identity key) in via caller env.
-    expect(captured.row?.environmentVars).toEqual({ APP_SETTING: "keep-me" });
+    // longer smuggle one (or a managed identity key) in via caller env. The app
+    // id is platform-owned and injected from the deploy request.
+    expect(captured.row?.environmentVars).toEqual({
+      APP_SETTING: "keep-me",
+      ELIZA_APP_ID: baseReq.appId,
+    });
   });
 
   test("platform isolated DSN wins over caller DATABASE_URL/POSTGRES_URL", async () => {
@@ -61,6 +65,7 @@ describe("deployApp env hardening", () => {
     );
     expect(captured.row?.environmentVars).toEqual({
       KEEP: "1",
+      ELIZA_APP_ID: baseReq.appId,
       DATABASE_URL: "postgres://tenant-dsn/app",
       POSTGRES_URL: "postgres://tenant-dsn/app",
     });
@@ -69,9 +74,17 @@ describe("deployApp env hardening", () => {
   test("non-reserved caller env passes through unchanged", async () => {
     const { deps, captured } = makeDeps();
     await deployApp(
-      { ...baseReq, databaseMode: "none", env: { FOO: "bar", LOG_LEVEL: "debug" } },
+      {
+        ...baseReq,
+        databaseMode: "none",
+        env: { FOO: "bar", ELIZA_APP_ID: "spoofed-app", LOG_LEVEL: "debug" },
+      },
       deps,
     );
-    expect(captured.row?.environmentVars).toEqual({ FOO: "bar", LOG_LEVEL: "debug" });
+    expect(captured.row?.environmentVars).toEqual({
+      FOO: "bar",
+      ELIZA_APP_ID: baseReq.appId,
+      LOG_LEVEL: "debug",
+    });
   });
 });

--- a/packages/cloud/shared/src/lib/services/app-deploy-orchestrator.ts
+++ b/packages/cloud/shared/src/lib/services/app-deploy-orchestrator.ts
@@ -99,18 +99,23 @@ export async function deployApp(
   const mode = req.databaseMode ?? DEFAULT_APP_DATABASE_MODE;
   const dsn = mode === "isolated" ? await deps.ensureTenantDb(req.appId) : undefined;
   // Strip caller-supplied platform-reserved keys (managed DB DSN, cloud API
-  // token, metered-identity keys) BEFORE injecting platform values. Without this
-  // a stateless ("none"-mode) app could set DATABASE_URL/POSTGRES_URL to point at
-  // an arbitrary DB, or pre-empt a managed identity key. The agent path already
-  // enforces this denylist (findReservedManagedElizaEnvKeys); the app path must
-  // too. POSTGRES_URL is added to the shared platform list because it is the
-  // app-container DB var (DATABASE_URL is already reserved).
+  // token, metered-identity keys, app attribution id) BEFORE injecting platform
+  // values. Without this a stateless ("none"-mode) app could set
+  // DATABASE_URL/POSTGRES_URL to point at an arbitrary DB, pre-empt a managed
+  // identity key, or spoof the app id used for monetization attribution. The
+  // agent path already enforces this denylist (findReservedManagedElizaEnvKeys);
+  // the app path must too. POSTGRES_URL is added to the shared platform list
+  // because it is the app-container DB var (DATABASE_URL is already reserved).
   const safeCallerEnv = stripReservedEnvKeys(req.env ?? {}, [
     ...RESERVED_PLATFORM_ENV_KEYS,
+    "ELIZA_APP_ID",
     "POSTGRES_URL",
   ]);
   const environmentVars = {
     ...safeCallerEnv,
+    // Platform-owned app attribution. Injected for both stateless and isolated
+    // apps so in-container SDK calls can identify the deployed app.
+    ELIZA_APP_ID: req.appId,
     // Platform-owned DB values are injected last so they always win for isolated
     // apps; stateless apps get neither var (and can no longer inject one).
     ...(dsn ? { DATABASE_URL: dsn, POSTGRES_URL: dsn } : {}),
@@ -123,11 +128,12 @@ export async function deployApp(
     containerName: req.containerName,
     image: req.image,
     port: req.port ?? 3000,
-    // Isolated apps get their OWN per-tenant DSN under BOTH `DATABASE_URL` (the
-    // de-facto standard most apps read) and `POSTGRES_URL` (what plugin-sql /
-    // eliza-based images read) — never the shared agent DATABASE_URL, and never a
-    // silent fallback to a throwaway local/PGlite store. Stateless ("none") apps
-    // get neither var.
+    // Every app gets the platform-owned ELIZA_APP_ID for attribution. Isolated
+    // apps additionally get their OWN per-tenant DSN under BOTH `DATABASE_URL`
+    // (the de-facto standard most apps read) and `POSTGRES_URL` (what plugin-sql
+    // / eliza-based images read) — never the shared agent DATABASE_URL, and
+    // never a silent fallback to a throwaway local/PGlite store. Stateless
+    // ("none") apps get no DB vars.
     environmentVars,
   });
 


### PR DESCRIPTION
## Summary

Refs #10423.

- Treat `ELIZA_APP_ID` as app-deploy-reserved and strip caller-supplied values in the app container deploy path.
- Inject the platform-authoritative `req.appId` into every deployed app container env, for both stateless and isolated database modes.
- Keep isolated DB behavior unchanged: isolated apps still receive tenant `DATABASE_URL` and `POSTGRES_URL`; stateless apps receive no DB vars.
- Add regression coverage proving caller spoofing is ignored and the created container row carries the deploy request app id.

## Evidence

- `packages/cloud/shared`: `bun test src/lib/services/__tests__/app-deploy-orchestrator.test.ts src/lib/services/app-deploy-orchestrator.test.ts src/lib/services/reserved-env-keys.test.ts` -> 17 tests passed across 3 files.
- `bun run --cwd packages/cloud/shared lint` -> passed, Biome checked 1222 files with no fixes applied.
- `git diff --check` -> passed.
- `bun run install:light` -> completed successfully.

## Typecheck caveat

`bun run --cwd packages/cloud/shared typecheck` was attempted after `install:light`. It runs, but current `develop` fails through unrelated generated i18n modules outside this branch:

- `packages/core/src/i18n/action-search-keywords.ts`
- `packages/core/src/i18n/validation-keywords.ts`
- `packages/shared/src/i18n/keyword-matching.ts`

The errors are missing `./generated/validation-keyword-data` imports. No typecheck errors were reported for the changed app deploy files.

## Scope note

This PR proves the local deploy-spec wiring: provisioned app container rows now carry the authoritative app id and reject caller spoofing. The full issue-level proof, deploy app -> app inference -> app-credit charge / creator earnings attribution, still requires staging or production cloud billing infrastructure.
