### PR TITLE
[codex] fix cloud app staging frontend alias

### DIFF
--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -63,9 +63,39 @@ describe("cloud-api worker entrypoint", () => {
     );
   });
 
+  test("proxies app frontend aliases to the app Pages project", () => {
+    const target = getFrontendAliasProxyTarget(
+      new URL("https://app.elizacloud.ai/?runtime=first-run"),
+    );
+
+    expect(target?.toString()).toBe(
+      "https://eliza-app.pages.dev/?runtime=first-run",
+    );
+  });
+
+  test("proxies staging app frontend aliases to the app Pages develop branch", () => {
+    const target = getFrontendAliasProxyTarget(
+      new URL("https://app-staging.elizacloud.ai/?runtime=first-run"),
+    );
+
+    expect(target?.toString()).toBe(
+      "https://develop.eliza-app.pages.dev/?runtime=first-run",
+    );
+  });
+
   test("proxies staging API aliases to the staging API worker", () => {
     const target = getFrontendAliasProxyTarget(
       new URL("https://staging.elizacloud.ai/api/health"),
+    );
+
+    expect(target?.toString()).toBe(
+      "https://api-staging.elizacloud.ai/api/health",
+    );
+  });
+
+  test("proxies staging app API aliases to the staging API worker", () => {
+    const target = getFrontendAliasProxyTarget(
+      new URL("https://app-staging.elizacloud.ai/api/health"),
     );
 
     expect(target?.toString()).toBe(

--- a/packages/cloud/api/src/index.ts
+++ b/packages/cloud/api/src/index.ts
@@ -24,6 +24,14 @@ const FRONTEND_ALIAS_TARGETS: Record<
   string,
   { appHost: string; apiHost: string }
 > = {
+  "app.elizacloud.ai": {
+    appHost: "eliza-app.pages.dev",
+    apiHost: "api.elizacloud.ai",
+  },
+  "app-staging.elizacloud.ai": {
+    appHost: "develop.eliza-app.pages.dev",
+    apiHost: "api-staging.elizacloud.ai",
+  },
   "staging.elizacloud.ai": {
     appHost: "develop.eliza-cloud-enq.pages.dev",
     apiHost: "api-staging.elizacloud.ai",


### PR DESCRIPTION
## Summary

Adds Cloud API frontend-alias targets for the Eliza app hostnames:

- `app.elizacloud.ai` -> `eliza-app.pages.dev`
- `app-staging.elizacloud.ai` -> `develop.eliza-app.pages.dev`

`/api/*` and `/steward/*` on those aliases continue to route to the matching Cloud API Worker host.

## Why

During the desktop/web cloud first-run smoke, production `app.elizacloud.ai` served the app shell correctly, but staging `app-staging.elizacloud.ai/?reset=1&runtime=first-run` returned the Cloud API root JSON instead of the app shell. That means the request is currently reaching the Cloud API Worker and falling through instead of being served by the app Pages custom domain.

The Worker already has this safety-net alias pattern for `staging.elizacloud.ai`; this extends the same pattern to the app subdomains so staging app requests that hit the Worker proxy to the app Pages project instead of returning API JSON.

## Validation

- `curl https://app-staging.elizacloud.ai/?reset=1&runtime=first-run` currently returns API JSON before this fix is deployed.
- `curl https://develop.eliza-app.pages.dev/?reset=1&runtime=first-run` returns the Eliza app HTML shell.
- `bun test packages/cloud/api/src/index.test.ts` -> 18 pass / 0 fail.

