### PR TITLE
fix(ios): unblock iOS device build — TalkModePlugin JSObject bridge + register AgentWatchdog.swift

### DIFF
--- a/packages/app-core/platforms/ios/App/App.xcodeproj/project.pbxproj
+++ b/packages/app-core/platforms/ios/App/App.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		A084ECDBA7D38E1E42DFC39D /* Pods_App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AF277DCFFFF123FFC6DF26C7 /* Pods_App.framework */; };
 		E1A5105A0000000000000001 /* ElizaAppIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A5105A0000000000000002 /* ElizaAppIntents.swift */; };
 		MIPL00010000000000000001 /* ElizaIntentPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = MIPL00010000000000000002 /* ElizaIntentPlugin.swift */; };
+		AWDG00010000000000000001 /* AgentWatchdog.swift in Sources */ = {isa = PBXBuildFile; fileRef = AWDG00010000000000000002 /* AgentWatchdog.swift */; };
 		PRIVACYAPP000000000000001 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = PRIVACYAPP000000000000002 /* PrivacyInfo.xcprivacy */; };
 		PRIVACYWBCB00000000000001 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = PRIVACYWBCB00000000000002 /* PrivacyInfo.xcprivacy */; };
 		SCENEDEL00000000000001 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = SCENEDEL00000000000002 /* SceneDelegate.swift */; };
@@ -86,6 +87,7 @@
 		E1A5105A0000000000000002 /* ElizaAppIntents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElizaAppIntents.swift; sourceTree = "<group>"; };
 		FC68EB0AF532CFC21C3344DD /* Pods-App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-App.debug.xcconfig"; path = "Pods/Target Support Files/Pods-App/Pods-App.debug.xcconfig"; sourceTree = "<group>"; };
 		MIPL00010000000000000002 /* ElizaIntentPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElizaIntentPlugin.swift; sourceTree = "<group>"; };
+		AWDG00010000000000000002 /* AgentWatchdog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentWatchdog.swift; sourceTree = "<group>"; };
 		PRIVACYAPP000000000000002 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		PRIVACYWBCB00000000000002 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		SCENEDEL00000000000002 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -175,6 +177,7 @@
 				SCENEDEL00000000000002 /* SceneDelegate.swift */,
 				E1A5105A0000000000000002 /* ElizaAppIntents.swift */,
 				MIPL00010000000000000002 /* ElizaIntentPlugin.swift */,
+				AWDG00010000000000000002 /* AgentWatchdog.swift */,
 				504EC30B1FED79650016851F /* Main.storyboard */,
 				504EC30E1FED79650016851F /* Assets.xcassets */,
 				504EC3101FED79650016851F /* LaunchScreen.storyboard */,
@@ -458,6 +461,7 @@
 				SCENEDEL00000000000001 /* SceneDelegate.swift in Sources */,
 				E1A5105A0000000000000001 /* ElizaAppIntents.swift in Sources */,
 				MIPL00010000000000000001 /* ElizaIntentPlugin.swift in Sources */,
+				AWDG00010000000000000001 /* AgentWatchdog.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/plugins/plugin-native-talkmode/ios/Sources/TalkModePlugin/TalkModePlugin.swift
+++ b/plugins/plugin-native-talkmode/ios/Sources/TalkModePlugin/TalkModePlugin.swift
@@ -1159,10 +1159,22 @@ public class TalkModePlugin: CAPPlugin, CAPBridgedPlugin {
         @unknown default: speechStatus = "prompt"
         }
 
-        return TalkModeBridgeContract.permissionPayload(
+        // TalkModeBridgeContract.permissionPayload defines the canonical shape
+        // ([String: Any] for parity with the other payloads + their tests). A
+        // Capacitor JSObject is [String: any JSValue], so bridge the contract's
+        // String fields explicitly rather than returning [String: Any] directly
+        // (Any does not conform to JSValue — the implicit conversion fails to
+        // type-check).
+        var result = JSObject()
+        for (key, value) in TalkModeBridgeContract.permissionPayload(
             microphone: micStatus,
             speechRecognition: speechStatus
-        )
+        ) {
+            if let stringValue = value as? String {
+                result[key] = stringValue
+            }
+        }
+        return result
     }
 
     // MARK: - Audio Session


### PR DESCRIPTION
Two real bugs that made **every** signed iOS device build fail — found by actually building + installing the current app to a physical iPhone 15 Pro (for the #9958/#10351 on-device voice verification). Both native additions had shipped without an on-device build ever being run, so the compile breaks went undetected.

## 1. `TalkModePlugin.swift` — `[String: Any]` returned as `JSObject`
`buildPermissionResult() -> JSObject` returned `TalkModeBridgeContract.permissionPayload(...)`, whose type is `[String: Any]`. A Capacitor `JSObject` is `[String: any JSValue]`, and `Any` does not conform to `JSValue` — so the implicit conversion fails to type-check, and the **Swift compiler crashed producing the diagnostic** (`error: failed to produce diagnostic for expression`) at `TalkModePlugin.swift:1162`. Fixed by bridging the contract's String fields into an explicit `JSObject`; the `TalkModeBridgeContract` + its `BridgeContractTests` are unchanged. (The BridgeContract pattern was introduced by the #9958/#10357 native-test work.)

## 2. `AgentWatchdog.swift` not registered in the Xcode project
The iOS local-agent watchdog (`AgentWatchdog.swift`, #10197) was added to `platforms/ios/App/App/` and wired from `AppDelegate.didFinishLaunching`, but **never added to `App.xcodeproj/project.pbxproj`** — no `PBXFileReference`, no `PBXBuildFile`, not in the App target's Sources phase. xcodebuild therefore never compiled it → `error: cannot find 'AgentWatchdog' in scope` at `AppDelegate.swift:21`. (`ElizaHomeIndicator` compiles only because it's defined *inside* `AppDelegate.swift`; the project uses an explicit file list, not an Xcode-16 synchronized group, so every standalone `App/App/*.swift` needs explicit registration.) Added the 4 pbxproj entries mirroring `ElizaIntentPlugin.swift`.

## Verification
With both fixes, `bun run build:ios:local:device:full-bun` (signed, Team `25877RY2EH`) reaches **`** BUILD SUCCEEDED **`**, and the resulting `App.app` was **installed and launched on a physical iPhone 15 Pro (iOS 26.5)** via `devicectl` — confirming the full on-device build path works end to end. (The on-device voice round-trip itself is human-gated: mic/speech permission grants + live speech.)

Refs #10197, #9958, #10351.

🤖 Generated with [Claude Code](https://claude.com/claude-code)