### PR TITLE
fix(benchmarks): add inventory checklist

### DIFF
--- a/.github/issue-evidence/10199-benchmark-inventory.md
+++ b/.github/issue-evidence/10199-benchmark-inventory.md
@@ -1,0 +1,87 @@
+# Issue 10199 Evidence: Benchmark Inventory Slice
+
+## Scope
+
+Implemented the deterministic local slice for #10199: a static benchmark
+inventory checklist generated from the live registry and adapter discovery.
+
+This does not claim to replace the full live `gpt-oss-120b` graded rerun or HITL
+multi-Codex runner. Those remain gated on live model/accounts. This slice gives
+operators the missing preflight inventory that shows registry, adapter, directory,
+harness, environment, result-locator, and trajectory-expectation coverage before
+they run the expensive live suite.
+
+## Commands Run
+
+```bash
+bun install
+```
+
+Result: passed. Downloaded and synced the repo artifact bundle; generated
+untracked artifact residue was cleaned from this isolated worktree.
+
+```bash
+PYTHONPATH=packages python3 -m pytest packages/benchmarks/orchestrator/tests -q
+```
+
+Result: passed, 341 tests.
+
+```bash
+bun run --cwd packages/benchmarks/recall-bench test
+```
+
+Result: passed, 3 files / 30 tests.
+
+```bash
+bun run --cwd packages/shared build:i18n
+bun run --cwd packages/benchmarks/recall-bench bench
+```
+
+Result: passed. The real recall smoke drove PGlite + DocumentService +
+`searchMemories`; budgets passed 19/19.
+
+```bash
+PYTHONPATH=packages python3 -m benchmarks.orchestrator run \
+  --benchmarks recall_bench \
+  --agent perfect_v1 \
+  --provider cerebras \
+  --model gpt-oss-120b \
+  --force
+```
+
+Result: passed. `recall_bench` synthetic calibration succeeded with score `1.0`.
+
+```bash
+PYTHONPATH=packages python3 -m benchmarks.orchestrator run \
+  --benchmarks trajectory_replay \
+  --agent perfect_v1 \
+  --provider cerebras \
+  --model gpt-oss-120b \
+  --force
+```
+
+Result: passed. `trajectory_replay` synthetic calibration succeeded with score
+`1.0`.
+
+```bash
+PYTHONPATH=packages python3 -m benchmarks.orchestrator validate-matrix --format json
+```
+
+Result: passed. Adapter count `53`, command construction errors `0`,
+compatible cells `141`, incompatible cells `18`.
+
+```bash
+PYTHONPATH=packages python3 -m benchmarks.orchestrator inventory --format json
+```
+
+Result: passed. Adapter count `53`, registry entry count `44`, directory gaps
+`[]`, registry gaps `[]`.
+
+## Evidence Notes
+
+- Live model trajectory evidence: N/A for this local slice. The implemented
+  feature is a static inventory generator plus keyless recall-bench discovery and
+  synthetic calibration coverage. The full issue's live `gpt-oss-120b` rerun
+  remains out of scope for this machine without live model/accounts.
+- Screenshot/video: N/A. This is a CLI/operator benchmark harness change with no
+  UI surface.

--- a/packages/benchmarks/orchestrator/README.md
+++ b/packages/benchmarks/orchestrator/README.md
@@ -20,6 +20,19 @@ for consistent dependency versions across benchmark subprocesses.
 
 This verifies adapter coverage for all benchmark directories under `benchmarks/`.
 
+## Generate the static operator inventory
+
+```bash
+/opt/miniconda3/bin/python -m benchmarks.orchestrator inventory --format markdown
+/opt/miniconda3/bin/python -m benchmarks.orchestrator inventory --format json
+```
+
+`inventory` emits the registry/adapter checklist without running benchmarks:
+registry entries, discovered adapters, directory coverage, harness compatibility,
+required environment variables, result locators, and trajectory expectations. It
+exits with code `2` when static gaps exist so the drift is visible before a live
+`run --all` or `validate-matrix` pass.
+
 ## Run benchmarks idempotently
 
 Run one benchmark:

--- a/packages/benchmarks/orchestrator/adapters.py
+++ b/packages/benchmarks/orchestrator/adapters.py
@@ -2500,6 +2500,13 @@ def discover_adapters(workspace_root: Path) -> AdapterDiscovery:
             "limit": 2,
             "seeds": 1,
         },
+        "recall_bench": {
+            "tier": "smoke",
+        },
+        "trajectory_replay": {
+            "traj_set": str((benchmarks_root / "eliza-adapter" / "fixtures" / "replay").resolve()),
+            "baseline": "fixture-baseline",
+        },
     }
     registry_dir_map = {
         "context_bench": "context-bench",
@@ -2513,6 +2520,8 @@ def discover_adapters(workspace_root: Path) -> AdapterDiscovery:
         "lifeops_bench": "lifeops-bench",
         "voicebench_quality": "voicebench-quality",
         "vision_language": "vision-language",
+        "recall_bench": "recall-bench",
+        "trajectory_replay": "standard",
         "mmlu": "standard",
         "humaneval": "standard",
         "gsm8k": "standard",

--- a/packages/benchmarks/orchestrator/cli.py
+++ b/packages/benchmarks/orchestrator/cli.py
@@ -23,6 +23,11 @@ from .db import (
 from .latest_comparability import print_comparability_report, validate_latest_comparability
 from .latest_publishability import print_publishability_report, validate_latest_publishability
 from .latest_readiness import print_readiness_report, validate_latest_readiness
+from .inventory import (
+    build_inventory_report,
+    report_to_json as inventory_report_to_json,
+    report_to_markdown as inventory_report_to_markdown,
+)
 from .random_baseline_runner import CALIBRATION_HARNESSES, SYNTHETIC_HARNESSES
 from .runner import _rebuild_latest_result_snapshots, _repair_current_compatibility_statuses, run_benchmarks
 from .matrix_validation import build_cross_matrix_report, report_to_json, report_to_markdown
@@ -139,6 +144,16 @@ def _cmd_validate_matrix(args: argparse.Namespace) -> int:
     else:
         print(report_to_markdown(report))
     return 1 if report.error_count else 0
+
+
+def _cmd_inventory(args: argparse.Namespace) -> int:
+    workspace_root = _workspace_root_from_here()
+    report = build_inventory_report(workspace_root.parent)
+    if args.format == "json":
+        print(inventory_report_to_json(report))
+    else:
+        print(inventory_report_to_markdown(report))
+    return 2 if report.has_gaps else 0
 
 
 def _cmd_run(args: argparse.Namespace) -> int:
@@ -789,6 +804,13 @@ def build_parser() -> argparse.ArgumentParser:
     p_matrix.add_argument("--extra", default=None, help="JSON object merged into every dry-run request")
     p_matrix.add_argument("--format", choices=("markdown", "json"), default="markdown")
     p_matrix.set_defaults(func=_cmd_validate_matrix)
+
+    p_inventory = sub.add_parser(
+        "inventory",
+        help="Generate the static benchmark registry/adapter/operator checklist",
+    )
+    p_inventory.add_argument("--format", choices=("markdown", "json"), default="markdown")
+    p_inventory.set_defaults(func=_cmd_inventory)
 
     p_run = sub.add_parser("run", help="Run one or more benchmarks idempotently")
     p_run.add_argument("--all", action="store_true", help="Run all integrated benchmarks")

--- a/packages/benchmarks/orchestrator/inventory.py
+++ b/packages/benchmarks/orchestrator/inventory.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from benchmarks.registry import get_benchmark_registry
+
+from .adapters import discover_adapters
+from .matrix_validation import _result_patterns_for, _trajectory_expectations
+
+
+@dataclass(frozen=True)
+class BenchmarkInventoryRow:
+    benchmark_id: str
+    directory: str
+    source: str
+    display_name: str | None
+    description: str
+    harnesses: tuple[str, ...]
+    required_env: tuple[str, ...]
+    result_locator_patterns: tuple[str, ...]
+    trajectory_expectations: tuple[str, ...]
+    default_timeout_seconds: int
+    default_extra_config: dict[str, Any]
+    command_cwd: str
+    has_adapter: bool
+    has_registry_entry: bool
+
+
+@dataclass(frozen=True)
+class BenchmarkInventoryReport:
+    adapter_count: int
+    registry_entry_count: int
+    benchmark_directory_count: int
+    checklist_count: int
+    registry_entries_without_adapters: tuple[str, ...]
+    adapters_without_registry_entries: tuple[str, ...]
+    benchmark_directories_without_adapters: tuple[str, ...]
+    rows: list[BenchmarkInventoryRow]
+
+    @property
+    def has_gaps(self) -> bool:
+        return bool(
+            self.registry_entries_without_adapters
+            or self.benchmark_directories_without_adapters
+        )
+
+
+def _workspace_root_from_repo(repo_root: Path) -> Path:
+    packages_root = repo_root / "packages"
+    return packages_root if (packages_root / "benchmarks").is_dir() else repo_root
+
+
+def build_inventory_report(repo_root: Path) -> BenchmarkInventoryReport:
+    workspace_root = _workspace_root_from_repo(repo_root.resolve())
+    discovery = discover_adapters(workspace_root)
+    registry_entries = get_benchmark_registry(workspace_root)
+    registry_by_id = {entry.id: entry for entry in registry_entries}
+
+    rows: list[BenchmarkInventoryRow] = []
+    for benchmark_id in sorted(discovery.adapters):
+        adapter = discovery.adapters[benchmark_id]
+        registry_entry = registry_by_id.get(benchmark_id)
+        source = "registry" if registry_entry is not None else "adapter-only"
+        rows.append(
+            BenchmarkInventoryRow(
+                benchmark_id=benchmark_id,
+                directory=adapter.directory,
+                source=source,
+                display_name=registry_entry.display_name if registry_entry else None,
+                description=adapter.description,
+                harnesses=tuple(adapter.agent_compatibility),
+                required_env=tuple(adapter.required_env),
+                result_locator_patterns=tuple(
+                    _result_patterns_for(adapter.id, adapter.result_patterns)
+                ),
+                trajectory_expectations=tuple(_trajectory_expectations(adapter.id)),
+                default_timeout_seconds=adapter.default_timeout_seconds,
+                default_extra_config=dict(adapter.default_extra_config),
+                command_cwd=adapter.cwd,
+                has_adapter=True,
+                has_registry_entry=registry_entry is not None,
+            )
+        )
+
+    adapter_ids = set(discovery.adapters)
+    covered_dirs = {adapter.directory for adapter in discovery.adapters.values()}
+    registry_missing_adapters = tuple(
+        sorted(entry.id for entry in registry_entries if entry.id not in adapter_ids)
+    )
+    adapter_only = tuple(
+        sorted(benchmark_id for benchmark_id in adapter_ids if benchmark_id not in registry_by_id)
+    )
+    directory_gaps = tuple(
+        sorted(directory for directory in discovery.all_directories if directory not in covered_dirs)
+    )
+
+    return BenchmarkInventoryReport(
+        adapter_count=len(discovery.adapters),
+        registry_entry_count=len(registry_entries),
+        benchmark_directory_count=len(discovery.all_directories),
+        checklist_count=len(rows),
+        registry_entries_without_adapters=registry_missing_adapters,
+        adapters_without_registry_entries=adapter_only,
+        benchmark_directories_without_adapters=directory_gaps,
+        rows=rows,
+    )
+
+
+def report_to_json(report: BenchmarkInventoryReport) -> str:
+    return json.dumps(asdict(report), indent=2, sort_keys=True, ensure_ascii=True)
+
+
+def _csv(values: tuple[str, ...]) -> str:
+    return ", ".join(values) if values else "-"
+
+
+def report_to_markdown(report: BenchmarkInventoryReport) -> str:
+    lines = [
+        "# Benchmark Inventory Checklist",
+        "",
+        f"- adapters: `{report.adapter_count}`",
+        f"- registry entries: `{report.registry_entry_count}`",
+        f"- benchmark directories: `{report.benchmark_directory_count}`",
+        f"- checklist rows: `{report.checklist_count}`",
+        f"- registry entries without adapters: `{len(report.registry_entries_without_adapters)}`",
+        f"- adapter-only entries: `{len(report.adapters_without_registry_entries)}`",
+        f"- benchmark directories without adapters: `{len(report.benchmark_directories_without_adapters)}`",
+        "",
+    ]
+
+    if report.registry_entries_without_adapters:
+        lines.extend(
+            [
+                "## Registry Entries Without Adapters",
+                "",
+                ", ".join(report.registry_entries_without_adapters),
+                "",
+            ]
+        )
+    if report.benchmark_directories_without_adapters:
+        lines.extend(
+            [
+                "## Benchmark Directories Without Adapters",
+                "",
+                ", ".join(report.benchmark_directories_without_adapters),
+                "",
+            ]
+        )
+
+    lines.extend(
+        [
+            "| benchmark | source | directory | harnesses | required env | result locators | trajectories |",
+            "| --- | --- | --- | --- | --- | --- | --- |",
+        ]
+    )
+    for row in report.rows:
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    row.benchmark_id,
+                    row.source,
+                    row.directory,
+                    _csv(row.harnesses),
+                    _csv(row.required_env),
+                    _csv(row.result_locator_patterns),
+                    _csv(row.trajectory_expectations),
+                ]
+            )
+            + " |"
+        )
+    return "\n".join(lines)

--- a/packages/benchmarks/orchestrator/random_baseline_runner.py
+++ b/packages/benchmarks/orchestrator/random_baseline_runner.py
@@ -126,6 +126,27 @@ def _realm_payload(score: float) -> dict[str, Any]:
     }
 
 
+def _recall_bench_payload(score: float) -> dict[str, Any]:
+    return {
+        "benchmark": "recall-bench",
+        "tier": "synthetic-calibration",
+        "corpus": {
+            "documents": 2,
+            "facts": 2,
+            "queries": 2,
+        },
+        "metrics": {
+            "overall_recall_at_5": score,
+            "overall_ndcg_at_5": score,
+            "overall_p95_latency_ms": 1.0,
+        },
+        "failOpen": {
+            "recallDrop": score,
+            "observable": True,
+        },
+    }
+
+
 def _scambench_payload(score: float) -> dict[str, Any]:
     return {
         "metrics": {
@@ -690,6 +711,7 @@ _RESULT_TEMPLATES: dict[str, tuple[str, Any]] = {
     "orchestrator_lifecycle": ("orchestrator-lifecycle-results.json", lambda score: {"metrics": {"overall_score": score, "scenario_pass_rate": score, "clarification_success_rate": score, "interruption_handling_rate": score}}),
     "osworld": ("osworld-results.json", _osworld_payload),
     "personality_bench": ("report.json", _personality_payload),
+    "recall_bench": ("recall-bench-results.json", _recall_bench_payload),
     "rlm_bench": ("rlm-results.json", _rlm_payload),
     "social_alpha": ("benchmark_results_random_v1.json", _social_alpha_payload),
     "solana": ("eliza_random_v1_metrics.json", _solana_payload),
@@ -698,6 +720,7 @@ _RESULT_TEMPLATES: dict[str, tuple[str, Any]] = {
     "swe_bench_orchestrated": ("swe-bench-orchestrated-results.json", _swe_bench_orchestrated_payload),
     "tau_bench": ("tau-bench-results.json", _tau_bench_payload),
     "terminal_bench": ("terminal-bench-results.json", _terminal_bench_payload),
+    "trajectory_replay": ("trajectory-replay-results.json", _metrics_score_payload),
     "trust": ("trust-results.json", _trust_payload),
     "vending_bench": ("vending-bench-results.json", _vending_payload),
     "visualwebbench": ("visualwebbench-results.json", _visualwebbench_payload),

--- a/packages/benchmarks/orchestrator/tests/test_inventory.py
+++ b/packages/benchmarks/orchestrator/tests/test_inventory.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from benchmarks.orchestrator import inventory
+from benchmarks.orchestrator.inventory import (
+    build_inventory_report,
+    report_to_json,
+    report_to_markdown,
+)
+from benchmarks.orchestrator.types import AdapterDiscovery, BenchmarkAdapter, ExecutionContext
+
+
+def _workspace_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def test_inventory_report_lists_real_adapters_and_operator_contracts() -> None:
+    report = build_inventory_report(_workspace_root().parent)
+
+    assert report.adapter_count == len(report.rows)
+    assert report.registry_entry_count > 0
+    assert report.benchmark_directory_count > 0
+    assert isinstance(report.benchmark_directories_without_adapters, tuple)
+    assert isinstance(report.registry_entries_without_adapters, tuple)
+
+    bfcl = next(row for row in report.rows if row.benchmark_id == "bfcl")
+    assert bfcl.source == "registry"
+    assert bfcl.has_adapter is True
+    assert bfcl.has_registry_entry is True
+    assert "eliza" in bfcl.harnesses
+    assert bfcl.result_locator_patterns
+    assert bfcl.trajectory_expectations
+
+    payload = report_to_json(report)
+    assert '"benchmark_id": "bfcl"' in payload
+
+    markdown = report_to_markdown(report)
+    assert "# Benchmark Inventory Checklist" in markdown
+    assert "| bfcl | registry | bfcl |" in markdown
+
+
+def test_inventory_report_surfaces_registry_adapter_and_directory_gaps(monkeypatch) -> None:
+    def command_builder(ctx: ExecutionContext, adapter: BenchmarkAdapter) -> list[str]:
+        return ["python", "-m", adapter.id]
+
+    adapter = BenchmarkAdapter(
+        id="registered",
+        directory="registered-dir",
+        description="registered adapter",
+        cwd="/tmp/registered",
+        command_builder=command_builder,
+        result_locator=lambda _ctx, _adapter, _root: None,
+        score_extractor=lambda _path: SimpleNamespace(
+            score=None,
+            unit=None,
+            higher_is_better=None,
+            metrics={},
+        ),
+        required_env=("MODEL_API_KEY",),
+        result_patterns=("summary.json",),
+        agent_compatibility=("eliza", "hermes"),
+    )
+    adapter_only = BenchmarkAdapter(
+        id="adapter_only",
+        directory="adapter-only-dir",
+        description="adapter-only benchmark",
+        cwd="/tmp/adapter-only",
+        command_builder=command_builder,
+        result_locator=lambda _ctx, _adapter, _root: None,
+        score_extractor=lambda _path: SimpleNamespace(
+            score=None,
+            unit=None,
+            higher_is_better=None,
+            metrics={},
+        ),
+    )
+    discovery = AdapterDiscovery(
+        adapters={"registered": adapter, "adapter_only": adapter_only},
+        all_directories=("registered-dir", "adapter-only-dir", "uncovered-dir"),
+    )
+    registry_entries = (
+        SimpleNamespace(id="registered", display_name="Registered"),
+        SimpleNamespace(id="registry_only", display_name="Registry Only"),
+    )
+
+    monkeypatch.setattr(inventory, "discover_adapters", lambda _workspace_root: discovery)
+    monkeypatch.setattr(inventory, "get_benchmark_registry", lambda _workspace_root: registry_entries)
+
+    report = build_inventory_report(Path("/repo"))
+
+    assert report.has_gaps is True
+    assert report.registry_entries_without_adapters == ("registry_only",)
+    assert report.adapters_without_registry_entries == ("adapter_only",)
+    assert report.benchmark_directories_without_adapters == ("uncovered-dir",)
+
+    registered = next(row for row in report.rows if row.benchmark_id == "registered")
+    assert registered.source == "registry"
+    assert registered.required_env == ("MODEL_API_KEY",)
+    assert registered.result_locator_patterns == ("summary.json",)
+
+    adapter_only_row = next(row for row in report.rows if row.benchmark_id == "adapter_only")
+    assert adapter_only_row.source == "adapter-only"
+    assert adapter_only_row.has_registry_entry is False
+
+    markdown = report_to_markdown(report)
+    assert "registry_only" in markdown
+    assert "uncovered-dir" in markdown


### PR DESCRIPTION
## Summary

- add `benchmarks.orchestrator inventory` as a static registry/adapter/operator checklist in JSON or Markdown
- close discovered static coverage gaps by wiring `recall_bench` and `trajectory_replay` into adapter discovery
- add synthetic calibration result templates for `recall_bench` and `trajectory_replay`
- document the inventory command and attach issue evidence

## Why

#10199 needs an operator review layer before expensive live benchmark runs. The registry and adapter set could drift silently; this command surfaces registry-only, adapter-only, and directory coverage state plus harness/env/result/trajectory contracts before a full `run --all`.

## Validation

- `bun install`
- `PYTHONPATH=packages python3 -m pytest packages/benchmarks/orchestrator/tests -q` -> 341 passed
- `bun run --cwd packages/benchmarks/recall-bench test` -> 3 files / 30 tests passed
- `bun run --cwd packages/shared build:i18n`
- `bun run --cwd packages/benchmarks/recall-bench bench` -> budgets PASS 19/19
- `PYTHONPATH=packages python3 -m benchmarks.orchestrator run --benchmarks recall_bench --agent perfect_v1 --provider cerebras --model gpt-oss-120b --force` -> score 1.0
- `PYTHONPATH=packages python3 -m benchmarks.orchestrator run --benchmarks trajectory_replay --agent perfect_v1 --provider cerebras --model gpt-oss-120b --force` -> score 1.0
- `PYTHONPATH=packages python3 -m benchmarks.orchestrator validate-matrix --format json` -> adapter_count 53, error_count 0
- `PYTHONPATH=packages python3 -m benchmarks.orchestrator inventory --format json` -> adapter_count 53, registry gaps [], directory gaps []
- `git diff --check`
- `python3 -m compileall -q packages/benchmarks/orchestrator/inventory.py packages/benchmarks/orchestrator/tests/test_inventory.py`

Evidence: `.github/issue-evidence/10199-benchmark-inventory.md`

## N/A

Live `gpt-oss-120b` graded rerun and HITL multi-Codex/account trajectory review remain outside this deterministic local slice; this PR adds the static inventory and closes local discovery/calibration gaps needed before that live run.