### PR TITLE
fix(workflow): search active workflow context

### DIFF
--- a/.github/issue-evidence/8913-active-workflows-search.md
+++ b/.github/issue-evidence/8913-active-workflows-search.md
@@ -1,0 +1,57 @@
+# Issue #8913 evidence — ACTIVE_WORKFLOWS search context
+
+Date: 2026-06-30
+
+## Change summary
+
+- `ACTIVE_WORKFLOWS` now runs in the same chat-facing context family as the
+  `WORKFLOW` action: `general`, `automation`, `tasks`, and `connectors`.
+- Workflow-related user messages call `WorkflowService.searchWorkflows(query,
+  userId)` and return only matching workflows to the prompt context.
+- Free-text workflow search now tokenizes sentence queries and ignores generic
+  workflow/search boilerplate, so a prompt like "find the workflow that posts to
+  Slack" matches Slack workflows instead of treating the whole sentence as one
+  substring.
+- Non-workflow chat text still uses the full `listWorkflows(userId)` context.
+- Provider cache scope is `turn` so one searched result cannot be reused for a
+  later unrelated message.
+
+## Validation
+
+```bash
+bun run install:light
+bun run --cwd packages/core build
+bun test __tests__/integration/providers/providers.test.ts
+bun test __tests__/unit/workflow-search.test.ts __tests__/unit/routes/workflows.test.ts
+bun run --cwd plugins/plugin-workflow typecheck
+bun run --cwd plugins/plugin-workflow lint:check
+bun run --cwd plugins/plugin-workflow test
+bun run verify
+```
+
+Results:
+
+- Focused provider + search suites:
+  `bun test __tests__/unit/workflow-search.test.ts __tests__/integration/providers/providers.test.ts`
+  — 29 pass, 0 fail.
+- Provider regression now drives `ACTIVE_WORKFLOWS` with sentence text through
+  the real `WorkflowService.searchWorkflows` / `rankWorkflowsByQuery` path, not
+  a mocked `searchWorkflows` result.
+- Plugin typecheck: pass.
+- Plugin lint: pass.
+- Full `@elizaos/plugin-workflow` suite: 362 pass, 0 fail.
+- Root `bun run verify`: fails before workspace typecheck/lint in
+  `audit:type-safety-ratchet` on existing unrelated baseline drift. Current
+  2026-06-30 rebase result:
+  - `?? []` is 590 current vs 588 baseline.
+  - `?? {}` is 379 current vs 377 baseline.
+  - `?? 0` is 381 current vs 380 baseline.
+  The reported files are outside `plugins/plugin-workflow`.
+
+## Manual evidence notes
+
+- Screenshots/video: N/A. This change is in the workflow context provider and
+  does not alter `packages/app/`, visual UI, or a mobile/native surface.
+- Live LLM trajectory: N/A. This update addresses deterministic provider/search
+  behavior: query selection, real service ranking, context gate, cache scope,
+  and serialized provider output.

--- a/plugins/plugin-workflow/AGENTS.md
+++ b/plugins/plugin-workflow/AGENTS.md
@@ -12,14 +12,14 @@ Adds workflow automation capabilities to an Eliza agent. Given a natural-languag
 
 | Name | Description |
 |---|---|
-| `WORKFLOW` | Umbrella action for all workflow lifecycle ops. Dispatches on `action` parameter: `create`, `modify`, `activate`, `deactivate`, `toggle_active`, `delete`, `executions`. Requires `minRole: OWNER`. Active in contexts `automation`, `tasks`, `agent_internal`. |
+| `WORKFLOW` | Umbrella action for all workflow lifecycle ops. Dispatches on `action` parameter: `create`, `modify`, `activate`, `deactivate`, `toggle_active`, `delete`, `executions`. Requires `minRole: OWNER`. Active in contexts `general`, `automation`, `tasks`, `agent_internal`. |
 
 ### Providers
 
 | Name | Description |
 |---|---|
 | `workflow_status` | Lists each user's workflows with last execution status. Contexts: `automation`, `connectors`. `minRole: ADMIN`. Cache scope: `turn`. |
-| `ACTIVE_WORKFLOWS` | Lists active/inactive workflows for LLM context (IDs, names, node counts). Contexts: `automation`, `connectors`. `minRole: ADMIN`. Cache scope: `agent`. |
+| `ACTIVE_WORKFLOWS` | Lists active/inactive workflows for LLM context (IDs, names, node counts), or searches the user's workflows when the current message is workflow-related. Contexts: `general`, `automation`, `tasks`, `connectors`. `minRole: ADMIN`. Cache scope: `turn`. |
 | `PENDING_WORKFLOW_DRAFT` | Surfaces an in-flight draft so the agent routes confirmation/cancellation messages to `WORKFLOW` instead of `REPLY`. Contexts: `automation`, `connectors`. `minRole: ADMIN`. Cache scope: `conversation`. |
 
 ### Services

--- a/plugins/plugin-workflow/CLAUDE.md
+++ b/plugins/plugin-workflow/CLAUDE.md
@@ -12,14 +12,14 @@ Adds workflow automation capabilities to an Eliza agent. Given a natural-languag
 
 | Name | Description |
 |---|---|
-| `WORKFLOW` | Umbrella action for all workflow lifecycle ops. Dispatches on `action` parameter: `create`, `modify`, `activate`, `deactivate`, `toggle_active`, `delete`, `executions`. Requires `minRole: OWNER`. Active in contexts `automation`, `tasks`, `agent_internal`. |
+| `WORKFLOW` | Umbrella action for all workflow lifecycle ops. Dispatches on `action` parameter: `create`, `modify`, `activate`, `deactivate`, `toggle_active`, `delete`, `executions`. Requires `minRole: OWNER`. Active in contexts `general`, `automation`, `tasks`, `agent_internal`. |
 
 ### Providers
 
 | Name | Description |
 |---|---|
 | `workflow_status` | Lists each user's workflows with last execution status. Contexts: `automation`, `connectors`. `minRole: ADMIN`. Cache scope: `turn`. |
-| `ACTIVE_WORKFLOWS` | Lists active/inactive workflows for LLM context (IDs, names, node counts). Contexts: `automation`, `connectors`. `minRole: ADMIN`. Cache scope: `agent`. |
+| `ACTIVE_WORKFLOWS` | Lists active/inactive workflows for LLM context (IDs, names, node counts), or searches the user's workflows when the current message is workflow-related. Contexts: `general`, `automation`, `tasks`, `connectors`. `minRole: ADMIN`. Cache scope: `turn`. |
 | `PENDING_WORKFLOW_DRAFT` | Surfaces an in-flight draft so the agent routes confirmation/cancellation messages to `WORKFLOW` instead of `REPLY`. Contexts: `automation`, `connectors`. `minRole: ADMIN`. Cache scope: `conversation`. |
 
 ### Services

--- a/plugins/plugin-workflow/__tests__/integration/providers/providers.test.ts
+++ b/plugins/plugin-workflow/__tests__/integration/providers/providers.test.ts
@@ -2,9 +2,10 @@ import { describe, expect, mock, test } from 'bun:test';
 import { activeWorkflowsProvider } from '../../../src/providers/activeWorkflows';
 import { pendingDraftProvider } from '../../../src/providers/pendingDraft';
 import { workflowStatusProvider } from '../../../src/providers/workflowStatus';
-import { WORKFLOW_SERVICE_TYPE } from '../../../src/services/workflow-service';
+import { WORKFLOW_SERVICE_TYPE, WorkflowService } from '../../../src/services/workflow-service';
 import {
   createExecution,
+  createSlackNode,
   createTriggerNode,
   createWorkflowResponse,
 } from '../../fixtures/workflows';
@@ -16,6 +17,19 @@ import { createMockService } from '../../helpers/mockService';
 // ============================================================================
 
 describe('activeWorkflowsProvider', () => {
+  test('matches WORKFLOW action chat contexts and uses turn cache', () => {
+    expect(activeWorkflowsProvider.contexts).toEqual([
+      'general',
+      'automation',
+      'tasks',
+      'connectors',
+    ]);
+    expect(activeWorkflowsProvider.contextGate).toEqual({
+      anyOf: ['general', 'automation', 'tasks', 'connectors'],
+    });
+    expect(activeWorkflowsProvider.cacheScope).toBe('turn');
+  });
+
   test('returns empty when service not available', async () => {
     const runtime = createMockRuntime();
     const result = await activeWorkflowsProvider.get(
@@ -90,6 +104,151 @@ describe('activeWorkflowsProvider', () => {
       name: 'Stripe Payments',
       active: true,
       nodeCount: 3,
+    });
+  });
+
+  test('searches workflows from workflow-related message text', async () => {
+    const searchQuery = 'Find the workflow that posts to Slack';
+    const mockService = createMockService({
+      listWorkflows: mock(() => Promise.resolve([])),
+      searchWorkflows: mock(() =>
+        Promise.resolve([
+          createWorkflowResponse({
+            id: 'wf-slack',
+            name: 'Slack Alerts',
+            active: true,
+            nodes: [createTriggerNode({ name: 'Slack', position: [0, 0] })],
+          }),
+        ])
+      ),
+    });
+    const runtime = createMockRuntime({
+      services: { [WORKFLOW_SERVICE_TYPE]: mockService },
+    });
+    const message = createMockMessage({
+      entityId: 'user-123',
+      content: { text: searchQuery },
+    });
+
+    const result = await activeWorkflowsProvider.get(runtime, message, createMockState());
+
+    expect(mockService.searchWorkflows).toHaveBeenCalledWith(searchQuery, 'user-123');
+    expect(mockService.listWorkflows).not.toHaveBeenCalled();
+    expect(result.text).toContain('# Matching Workflows');
+    expect(result.text).toContain('Slack Alerts');
+    expect(result.data).toEqual({
+      workflows: [
+        {
+          id: 'wf-slack',
+          name: 'Slack Alerts',
+          active: true,
+          nodeCount: 1,
+        },
+      ],
+      searchQuery,
+    });
+    expect(result.values).toEqual({
+      hasWorkflows: true,
+      workflowCount: 1,
+      workflowSearchQuery: searchQuery,
+    });
+  });
+
+  test('searches sentence text through the real workflow ranking path', async () => {
+    const service = Object.assign(Object.create(WorkflowService.prototype), {
+      serviceType: WORKFLOW_SERVICE_TYPE,
+      listWorkflows: mock(() =>
+        Promise.resolve([
+          createWorkflowResponse({
+            id: 'wf-gmail',
+            name: 'Gmail digest',
+          }),
+          createWorkflowResponse({
+            id: 'wf-slack',
+            name: 'Team notifications',
+            nodes: [createTriggerNode(), createSlackNode()],
+          }),
+        ])
+      ),
+    }) as WorkflowService;
+    const runtime = createMockRuntime({
+      services: { [WORKFLOW_SERVICE_TYPE]: service },
+    });
+    const message = createMockMessage({
+      entityId: 'user-123',
+      content: { text: 'find the workflow that posts to Slack' },
+    });
+
+    const result = await activeWorkflowsProvider.get(runtime, message, createMockState());
+
+    expect(service.listWorkflows).toHaveBeenCalledWith('user-123');
+    expect(result.text).toContain('# Matching Workflows');
+    expect(result.text).toContain('Team notifications');
+    expect(result.text).not.toContain('Gmail digest');
+    expect(result.data).toEqual({
+      workflows: [
+        {
+          id: 'wf-slack',
+          name: 'Team notifications',
+          active: false,
+          nodeCount: 2,
+        },
+      ],
+      searchQuery: 'find the workflow that posts to Slack',
+    });
+  });
+
+  test('uses full workflow list for non-workflow chat text', async () => {
+    const mockService = createMockService({
+      listWorkflows: mock(() =>
+        Promise.resolve([createWorkflowResponse({ id: 'wf-1', name: 'Daily Summary' })])
+      ),
+      searchWorkflows: mock(() => Promise.resolve([])),
+    });
+    const runtime = createMockRuntime({
+      services: { [WORKFLOW_SERVICE_TYPE]: mockService },
+    });
+    const message = createMockMessage({
+      content: { text: 'What happened this morning?' },
+    });
+
+    const result = await activeWorkflowsProvider.get(runtime, message, createMockState());
+
+    expect(mockService.listWorkflows).toHaveBeenCalledWith('user-001');
+    expect(mockService.searchWorkflows).not.toHaveBeenCalled();
+    expect(result.text).toContain('# Available Workflows');
+    expect(result.data).toEqual({
+      workflows: [
+        {
+          id: 'wf-1',
+          name: 'Daily Summary',
+          active: false,
+          nodeCount: 2,
+        },
+      ],
+    });
+  });
+
+  test('returns explicit empty result when workflow search has no matches', async () => {
+    const searchQuery = 'search workflows for calendar cleanup';
+    const mockService = createMockService({
+      searchWorkflows: mock(() => Promise.resolve([])),
+    });
+    const runtime = createMockRuntime({
+      services: { [WORKFLOW_SERVICE_TYPE]: mockService },
+    });
+    const message = createMockMessage({
+      content: { text: searchQuery },
+    });
+
+    const result = await activeWorkflowsProvider.get(runtime, message, createMockState());
+
+    expect(result.text).toContain(`No workflows match "${searchQuery}".`);
+    expect(result.data).toEqual({ workflows: [], searchQuery });
+    expect(result.values).toEqual({
+      hasWorkflows: false,
+      workflowCount: 0,
+      workflowSearchQuery: searchQuery,
     });
   });
 

--- a/plugins/plugin-workflow/__tests__/unit/workflow-search.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/workflow-search.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from 'bun:test';
-import { rankWorkflowsByQuery, scoreWorkflowMatch } from '../../src/services/workflow-service';
+import {
+  rankWorkflowsByQuery,
+  scoreWorkflowMatch,
+  tokenizeWorkflowSearchQuery,
+} from '../../src/services/workflow-service';
 
 /**
  * Unit coverage for the WORKFLOW `search` op ranking (#8913).
@@ -41,6 +45,18 @@ describe('scoreWorkflowMatch', () => {
   test('no match scores zero', () => {
     expect(scoreWorkflowMatch(wf({ name: 'gmail digest' }), 'slack')).toBe(0);
   });
+
+  test('matches a sentence query by meaningful tokens', () => {
+    const score = scoreWorkflowMatch(
+      wf({
+        name: 'Team notifications',
+        nodes: [{ type: 'workflows-nodes-base.slack', name: 'Slack' }],
+      }),
+      'find the workflow that posts to Slack'
+    );
+
+    expect(score).toBeGreaterThan(0);
+  });
 });
 
 describe('rankWorkflowsByQuery', () => {
@@ -55,8 +71,27 @@ describe('rankWorkflowsByQuery', () => {
     expect(ranked.map((w) => w.id)).toEqual(['b', 'c']);
   });
 
+  test('sentence query uses per-token OR scoring', () => {
+    const ranked = rankWorkflowsByQuery(workflows, 'find the workflow that posts to Slack');
+    expect(ranked.map((w) => w.id)).toEqual(['b', 'c']);
+  });
+
+  test('generic workflow query returns the input unchanged', () => {
+    const ranked = rankWorkflowsByQuery(workflows, 'what workflows do I have?');
+    expect(ranked.map((w) => w.id)).toEqual(['a', 'b', 'c']);
+  });
+
   test('empty query returns the input unchanged', () => {
     const ranked = rankWorkflowsByQuery(workflows, '   ');
     expect(ranked.map((w) => w.id)).toEqual(['a', 'b', 'c']);
+  });
+});
+
+describe('tokenizeWorkflowSearchQuery', () => {
+  test('keeps useful terms and drops workflow/search boilerplate', () => {
+    expect(tokenizeWorkflowSearchQuery('find the workflow that posts to Slack')).toEqual([
+      'post',
+      'slack',
+    ]);
   });
 });

--- a/plugins/plugin-workflow/src/providers/activeWorkflows.ts
+++ b/plugins/plugin-workflow/src/providers/activeWorkflows.ts
@@ -1,6 +1,13 @@
 import { type IAgentRuntime, logger, type Memory, type Provider, type State } from '@elizaos/core';
 import { WORKFLOW_SERVICE_TYPE, type WorkflowService } from '../services/index';
 
+function getWorkflowSearchQuery(message: Memory): string | null {
+  const text = typeof message.content.text === 'string' ? message.content.text.trim() : '';
+  if (!text) return null;
+
+  return /\b(workflow|workflows|automation|automations)\b/i.test(text) ? text : null;
+}
+
 /**
  * Provider that enriches state with user's active workflows
  *
@@ -12,9 +19,9 @@ import { WORKFLOW_SERVICE_TYPE, type WorkflowService } from '../services/index';
 export const activeWorkflowsProvider: Provider = {
   name: 'ACTIVE_WORKFLOWS',
   description: "User's active workflows with IDs and descriptions",
-  contexts: ['automation', 'connectors'],
-  contextGate: { anyOf: ['automation', 'connectors'] },
-  cacheScope: 'agent',
+  contexts: ['general', 'automation', 'tasks', 'connectors'],
+  contextGate: { anyOf: ['general', 'automation', 'tasks', 'connectors'] },
+  cacheScope: 'turn',
   roleGate: { minRole: 'ADMIN' },
 
   get: async (runtime: IAgentRuntime, _message: Memory, _state: State) => {
@@ -30,13 +37,18 @@ export const activeWorkflowsProvider: Provider = {
       }
 
       const userId = _message.entityId;
-      const workflows = await service.listWorkflows(userId);
+      const searchQuery = getWorkflowSearchQuery(_message);
+      const workflows = searchQuery
+        ? await service.searchWorkflows(searchQuery, userId)
+        : await service.listWorkflows(userId);
 
       if (workflows.length === 0) {
         return {
-          text: '',
-          data: { workflows: [] },
-          values: { hasWorkflows: false },
+          text: searchQuery ? `# Matching Workflows\n\nNo workflows match "${searchQuery}".` : '',
+          data: searchQuery ? { workflows: [], searchQuery } : { workflows: [] },
+          values: searchQuery
+            ? { hasWorkflows: false, workflowCount: 0, workflowSearchQuery: searchQuery }
+            : { hasWorkflows: false },
         };
       }
 
@@ -49,7 +61,7 @@ export const activeWorkflowsProvider: Provider = {
         })
         .join('\n');
 
-      const text = `# Available Workflows\n\n${workflowList}`;
+      const text = `${searchQuery ? '# Matching Workflows' : '# Available Workflows'}\n\n${workflowList}`;
 
       return {
         text,
@@ -60,10 +72,12 @@ export const activeWorkflowsProvider: Provider = {
             active: wf.active || false,
             nodeCount: wf.nodes.length || 0,
           })),
+          ...(searchQuery ? { searchQuery } : {}),
         },
         values: {
           hasWorkflows: true,
           workflowCount: workflows.length,
+          ...(searchQuery ? { workflowSearchQuery: searchQuery } : {}),
         },
       };
     } catch (error) {

--- a/plugins/plugin-workflow/src/services/workflow-service.ts
+++ b/plugins/plugin-workflow/src/services/workflow-service.ts
@@ -108,6 +108,34 @@ const FIELD_TRANSFORM_TARGET_PATTERN =
   /\b(field|fields|value|values|data|item|items|metadata|json|property|properties)\b/;
 const NETWORK_REQUEST_PATTERN =
   /\b(http|https|url|api|request|fetch|call|post|get|put|patch|delete|webhook)\b/;
+const WORKFLOW_SEARCH_STOPWORDS = new Set([
+  'a',
+  'an',
+  'and',
+  'are',
+  'automation',
+  'automations',
+  'can',
+  'do',
+  'find',
+  'for',
+  'have',
+  'i',
+  'list',
+  'me',
+  'my',
+  'of',
+  'please',
+  'search',
+  'show',
+  'that',
+  'the',
+  'to',
+  'what',
+  'which',
+  'workflow',
+  'workflows',
+]);
 
 function buildWorkflowSearchKeywords(prompt: string, keywords: string[]): string[] {
   const normalized = new Set(keywords.map((keyword) => keyword.toLowerCase()));
@@ -151,14 +179,25 @@ function normalizeGeneratedNodeParameterShapes(
   }
 }
 
-/**
- * Score a workflow against a lowercased query: name beats node type beats
- * description, and an exact/prefix name match beats a substring. Returns 0 for
- * no match. Pure + exported so the ranking is unit-testable without a DB.
- */
-export function scoreWorkflowMatch(workflow: WorkflowDefinitionResponse, query: string): number {
-  const q = query.trim().toLowerCase();
-  if (!q) return 0;
+function normalizeWorkflowSearchToken(token: string): string {
+  return token.length > 3 && token.endsWith('s') ? token.slice(0, -1) : token;
+}
+
+export function tokenizeWorkflowSearchQuery(query: string): string[] {
+  const normalized = query
+    .toLowerCase()
+    .split(/[^a-z0-9]+/u)
+    .map((token) => normalizeWorkflowSearchToken(token.trim()))
+    .filter(
+      (token, index, tokens) =>
+        token.length >= 2 &&
+        !WORKFLOW_SEARCH_STOPWORDS.has(token) &&
+        tokens.indexOf(token) === index
+    );
+  return normalized;
+}
+
+function scoreWorkflowMatchTerm(workflow: WorkflowDefinitionResponse, q: string): number {
   const name = String(workflow.name ?? '').toLowerCase();
   let score = 0;
   if (name === q) score += 100;
@@ -186,14 +225,35 @@ export function scoreWorkflowMatch(workflow: WorkflowDefinitionResponse, query: 
 }
 
 /**
+ * Score a workflow against a free-text query: name beats node type beats
+ * description, and an exact/prefix name match beats a substring. Sentence
+ * queries are tokenized with generic workflow/search words ignored. Returns 0
+ * for no match. Pure + exported so the ranking is unit-testable without a DB.
+ */
+export function scoreWorkflowMatch(workflow: WorkflowDefinitionResponse, query: string): number {
+  const q = query.trim().toLowerCase();
+  if (!q) return 0;
+
+  const phraseScore = scoreWorkflowMatchTerm(workflow, q);
+  const tokenScore = tokenizeWorkflowSearchQuery(q).reduce(
+    (total, token) => total + scoreWorkflowMatchTerm(workflow, token),
+    0
+  );
+
+  return Math.max(phraseScore, tokenScore);
+}
+
+/**
  * Rank workflows best-match-first for a free-text query, dropping non-matches.
- * An empty query returns the input order unchanged. Pure + exported (#8913).
+ * An empty or generic query returns the input order unchanged. Pure + exported
+ * (#8913).
  */
 export function rankWorkflowsByQuery(
   workflows: WorkflowDefinitionResponse[],
   query: string
 ): WorkflowDefinitionResponse[] {
   if (!query.trim()) return workflows;
+  if (tokenizeWorkflowSearchQuery(query).length === 0) return workflows;
   return workflows
     .map((workflow) => ({ workflow, score: scoreWorkflowMatch(workflow, query) }))
     .filter((entry) => entry.score > 0)


### PR DESCRIPTION
## Summary

- make `ACTIVE_WORKFLOWS` available in the same chat-facing contexts as the `WORKFLOW` action
- use `WorkflowService.searchWorkflows(query, userId)` for workflow-related user messages
- keep ordinary chat messages on the existing full `listWorkflows(userId)` path
- switch provider cache scope to `turn` so search results cannot bleed into later messages

Fixes #8913.

## Evidence

See `.github/issue-evidence/8913-active-workflows-search.md`.

Validation run locally:

- `bun run install:light`
- `bun run --cwd packages/core build`
- `bun test __tests__/integration/providers/providers.test.ts` from `plugins/plugin-workflow`
- `bun test __tests__/unit/workflow-search.test.ts __tests__/unit/routes/workflows.test.ts` from `plugins/plugin-workflow`
- `bun run --cwd plugins/plugin-workflow typecheck`
- `bun run --cwd plugins/plugin-workflow lint:check`
- `bun run --cwd plugins/plugin-workflow test` — 350 pass, 0 fail

Root `bun run verify` currently fails before workspace typecheck/lint in `audit:type-safety-ratchet` on unrelated baseline drift outside `plugins/plugin-workflow`; details are recorded in the evidence file.

## Screenshots / recordings

N/A: provider/runtime context change only; no `packages/app/`, visual UI, mobile, native, or device-facing surface changed.

## 2026-06-30 needs-work follow-up

Addressed the review blocker from the board/PR comment: `ACTIVE_WORKFLOWS` no longer relies on whole-sentence substring matching. `rankWorkflowsByQuery` now tokenizes free-text queries, drops generic workflow/search boilerplate, and scores any meaningful token, so `find the workflow that posts to Slack` matches Slack workflows. Added a provider regression that calls `ACTIVE_WORKFLOWS` with sentence text through the real `WorkflowService.searchWorkflows` / `rankWorkflowsByQuery` path rather than a mocked search result.

Final pushed commit: `4d47d063b1` rebased onto current `origin/develop`.

Validation after final rebase:
- `bun test __tests__/unit/workflow-search.test.ts __tests__/integration/providers/providers.test.ts` from `plugins/plugin-workflow` — 29 pass / 0 fail
- `bun run --cwd plugins/plugin-workflow lint:check` — pass
- `bun run --cwd plugins/plugin-workflow typecheck` — pass
- `bun run --cwd plugins/plugin-workflow test` — 362 pass / 0 fail
- `git diff --check` — pass
- `bun run verify` — still blocked at unrelated `audit:type-safety-ratchet` baseline drift outside `plugins/plugin-workflow` (`?? []`, `?? {}`, `?? 0` counts exceed baseline); evidence file updated.
