### PR TITLE
fix(cloud): enforce character ownership on generic PATCH /apps/:id (cross-tenant IDOR)

### DIFF
--- a/packages/cloud/api/v1/apps/[id]/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/route.ts
@@ -13,6 +13,7 @@ import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { appCleanupService } from "@/lib/services/app-cleanup";
 import { appsService } from "@/lib/services/apps";
+import { charactersService } from "@/lib/services/characters/characters";
 import { logger } from "@/lib/utils/logger";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
@@ -80,6 +81,31 @@ async function updateApp(c: AppContext, verb: "PUT" | "PATCH") {
       },
       400,
     );
+  }
+
+  // SECURITY: linked_character_ids on the generic update path must enforce the
+  // SAME ownership guard the dedicated PUT /apps/:id/characters route does —
+  // otherwise a caller can link another org's PRIVATE character id and read its
+  // metadata back via GET /apps/:id/characters (cross-tenant disclosure).
+  if (validationResult.data.linked_character_ids) {
+    for (const characterId of validationResult.data.linked_character_ids) {
+      const character = await charactersService.getById(characterId);
+      if (!character) {
+        return c.json(
+          { success: false, error: `Character not found: ${characterId}` },
+          404,
+        );
+      }
+      if (character.user_id !== user.id && !character.is_public) {
+        return c.json(
+          {
+            success: false,
+            error: `Not authorized to link character: ${characterId}`,
+          },
+          403,
+        );
+      }
+    }
   }
 
   const updateData = {


### PR DESCRIPTION
Found by an adversarial audit of the **apps-deploy launch surface** (newly opened to all orgs via #9789), verified real+reachable.

## Bug (cross-tenant isolation / IDOR)
The dedicated `PUT /api/v1/apps/:id/characters` route validates every linked character is owned-by-caller or public (403 otherwise). The **generic** `PATCH/PUT /api/v1/apps/:id` route accepts the same `linked_character_ids` field but persisted it with **only an app-ownership check, no character-ownership check**. Since `GET /api/v1/apps/:id/characters` re-hydrates linked ids via the non-org-scoped `charactersService.getById`:

```
PATCH /apps/{own-app} { linked_character_ids: [<victim-private-uuid>] }   // passed — no guard
GET   /apps/{own-app}/characters                                          // returns victim's private character
```

→ org A reads org B's **private** character metadata (name, username, avatar, bio). Bounded (needs the victim's v4 UUID, metadata only — no secrets/money), but an unambiguous cross-tenant read on a launch surface.

## Fix
Mirror the dedicated route's guard inside `updateApp`: reject any linked character the caller doesn't own and isn't public, before persisting. Single route, no API shape change for legitimate use.

Two related lower-severity findings from the same audit (X-App-Id analytics-attribution org-scope; unbounded app creation) are filed separately — both need design/product decisions (the X-App-Id fix must not break the third-party-app monetization flow; the app-cap value is a product call).