### PR TITLE
fix(cloud): default raw app creates to no repo

### DIFF
--- a/.github/issue-evidence/10450-app-create-repo-default.md
+++ b/.github/issue-evidence/10450-app-create-repo-default.md
@@ -1,0 +1,58 @@
+# Issue #10450 - raw app create repo default
+
+## What changed
+
+- `POST /api/v1/apps` now provisions a GitHub repo only when the request
+  explicitly sends `skipGitHubRepo: false`.
+- Omitting `skipGitHubRepo` now follows the no-repo/template-image path, matching
+  the dashboard and agent front doors and avoiding accidental first-party private
+  repository creation from raw API callers.
+- The explicit repo-backed path remains available for callers that opt in with
+  `skipGitHubRepo: false`.
+
+This PR addresses the locally testable raw app-create hardening slice from issue
+#10450. The X-App-Id org-scope rule and per-org app creation cap still need a
+product/auth policy decision before implementation.
+
+## Validation
+
+Base commit: `8e5d7797f0 test(screencapture): extract + device-test the recording config resolver (#9967) (#10453)`
+
+Commands run from `/home/shaw/milady/eliza-issue-10450`:
+
+```bash
+bun run install:light
+node packages/shared/scripts/generate-keywords.mjs --target ts
+bun run --cwd packages/contracts build
+bun run --cwd packages/core build:node
+git diff --check
+bunx @biomejs/biome check packages/cloud/api/v1/apps/route.ts packages/cloud/api/__tests__/apps-crud.integration.test.ts packages/cloud/shared/src/lib/services/__tests__/app-factory.test.ts
+bun test packages/cloud/api/__tests__/apps-crud.integration.test.ts --reporter=dot
+bun test packages/cloud/shared/src/lib/services/__tests__/app-factory.test.ts --reporter=dot
+```
+
+Observed results:
+
+- `git diff --check`: passed.
+- Biome focused check: `Checked 3 files in 64ms. No fixes applied.`
+- API integration suite: passed with `39 pass`, `0 fail`, `111 expect() calls`.
+- Shared app factory suite: passed with exit code 0; dot reporter showed 10
+  passing tests before the repository coverage table.
+
+The two test files were run separately. Running them in one Bun invocation caused
+test-module mock state from the API integration suite to contaminate the shared
+factory suite, so the separate runs are the valid signal for these focused files.
+
+## Human-verifiable behavior
+
+- Raw API body with no `skipGitHubRepo` now calls the app factory with
+  `createGitHubRepo: false` and returns no `githubRepo`.
+- Raw API body with `skipGitHubRepo: true` continues to return no `githubRepo`.
+- Raw API body with `skipGitHubRepo: false` calls the app factory with
+  `createGitHubRepo: true` and returns the created repo name.
+- Factory-level deploy resolution confirms the default raw body stamps the
+  template image and resolves, while explicit repo opt-in still follows the
+  repo-backed build-from-repo-disabled failure path.
+
+Screenshots/video/Android capture: N/A. This is a cloud backend route-contract
+change with no UI, native, or device surface.

--- a/packages/cloud/api/__tests__/apps-crud.integration.test.ts
+++ b/packages/cloud/api/__tests__/apps-crud.integration.test.ts
@@ -481,7 +481,7 @@ describe("POST /api/v1/apps (create)", () => {
     expect(json.suggestedName).toBe("My Cool App-a1b2");
   });
 
-  test("200 happy path → success + app + eliza_ apiKey", async () => {
+  test("200 happy path defaults to no GitHub repo", async () => {
     const { status, json } = await req("POST", "/api/v1/apps", {
       key: KEY_A,
       body: VALID_CREATE,
@@ -493,11 +493,30 @@ describe("POST /api/v1/apps (create)", () => {
     expect(created.organization_id).toBe(ORG_A);
     expect(typeof json.apiKey).toBe("string");
     expect(json.apiKey as string).toMatch(/^eliza_/);
-    // githubRepo present when not skipped.
-    expect(json.githubRepo).toBe("elizaOS-apps/my-cool-app");
+    expect(json.githubRepo).toBeUndefined();
+    expect(createApp.mock.calls[0][1]).toMatchObject({
+      createGitHubRepo: false,
+    });
     // Persisted: a follow-up list sees it.
     const list = await req("GET", "/api/v1/apps", { key: KEY_A });
     expect((list.json.apps as App[]).map((a) => a.id)).toContain(created.id);
+  });
+
+  test("200 skipGitHubRepo:false explicitly creates a GitHub repo", async () => {
+    const { status, json } = await req("POST", "/api/v1/apps", {
+      key: KEY_A,
+      body: {
+        ...VALID_CREATE,
+        name: "Repo App",
+        skipGitHubRepo: false,
+      },
+    });
+    expect(status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.githubRepo).toBe("elizaOS-apps/repo-app");
+    expect(createApp.mock.calls[0][1]).toMatchObject({
+      createGitHubRepo: true,
+    });
   });
 
   test("200 skipGitHubRepo:true → no githubRepo in response", async () => {

--- a/packages/cloud/api/v1/apps/route.ts
+++ b/packages/cloud/api/v1/apps/route.ts
@@ -77,7 +77,7 @@ app.post("/", async (c) => {
           allowed_origins: data.allowed_origins,
           logo_url: data.logo_url,
         },
-        { createGitHubRepo: !data.skipGitHubRepo },
+        { createGitHubRepo: data.skipGitHubRepo === false },
       );
 
       logger.info(`[Apps API] Created app: ${result.app.name}`, {

--- a/packages/cloud/shared/src/lib/services/__tests__/app-factory.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-factory.test.ts
@@ -177,16 +177,15 @@ describe("create -> deploy linkage: resolveImageRef on the created app", () => {
  * FRONT-DOOR end-to-end: prove that a real create request body — exactly what
  * the agent CREATE_APP action and the dashboard Create App dialog now POST to
  * `POST /api/v1/apps` — flows through the server route's `createGitHubRepo:
- * !skipGitHubRepo` mapping, the real factory, and the real `resolveImageRef`
- * to a deployable image (does NOT throw). The contrasting "pre-fix" body (no
- * `skipGitHubRepo`) is what shipped broken: it makes a repo-backed app whose
- * deploy throws build-from-repo-disabled — so the `skipGitHubRepo: true` the
- * front doors now send is load-bearing, not cosmetic.
+ * skipGitHubRepo === false` mapping, the real factory, and the real `resolveImageRef`
+ * to a deployable image (does NOT throw). `skipGitHubRepo: false` remains the
+ * explicit repo-backed opt-in path and still throws under the build-from-repo
+ * disabled gate.
  */
 describe("front-door create -> deploy resolves (POST /api/v1/apps body)", () => {
   // Mirrors the server route (`packages/cloud/api/v1/apps/route.ts`): the create
-  // route maps the request body's `skipGitHubRepo` to the factory option
-  // `createGitHubRepo: !skipGitHubRepo`. Keep this in lockstep with the route.
+  // route only provisions a GitHub repo when the request explicitly opts in with
+  // `skipGitHubRepo: false`. Keep this in lockstep with the route.
   const createFromFrontDoorBody = (body: {
     name: string;
     app_url: string;
@@ -199,7 +198,7 @@ describe("front-door create -> deploy resolves (POST /api/v1/apps body)", () => 
         created_by_user_id: DATA.created_by_user_id,
         app_url: body.app_url,
       },
-      { createGitHubRepo: !body.skipGitHubRepo },
+      { createGitHubRepo: body.skipGitHubRepo === false },
     );
 
   test("the fixed front-door body (skipGitHubRepo:true) stamps a template image and RESOLVES", async () => {
@@ -225,11 +224,30 @@ describe("front-door create -> deploy resolves (POST /api/v1/apps body)", () => 
     expect(img).toBe(DEFAULT_TEMPLATE_IMAGE);
   });
 
-  test("REGRESSION: the pre-fix front-door body (no skipGitHubRepo) makes a repo app whose deploy THROWS", async () => {
+  test("default raw create body (no skipGitHubRepo) stamps a template image and RESOLVES", async () => {
     const result = await createFromFrontDoorBody({
       name: "Acme Bot",
       app_url: "https://placeholder.invalid",
-      // skipGitHubRepo omitted — the bug: createGitHubRepo defaults true.
+      // skipGitHubRepo omitted — raw API default must not provision a repo.
+    });
+
+    expect(result.githubRepoCreated).toBe(false);
+    expect(metaImageTag(result.app.metadata)).toBe(DEFAULT_TEMPLATE_IMAGE);
+
+    const img = await resolveImageRef(buildOff, {
+      id: result.app.id,
+      name: result.app.name,
+      metadata: (result.app.metadata as Record<string, unknown>) ?? {},
+      repoUrl: result.app.github_repo ?? undefined,
+    });
+    expect(img).toBe(DEFAULT_TEMPLATE_IMAGE);
+  });
+
+  test("explicit repo opt-in (skipGitHubRepo:false) makes a repo app whose deploy THROWS while build-from-repo is disabled", async () => {
+    const result = await createFromFrontDoorBody({
+      name: "Repo Bot",
+      app_url: "https://placeholder.invalid",
+      skipGitHubRepo: false,
     });
 
     expect(result.githubRepoCreated).toBe(true);


### PR DESCRIPTION
## Summary
- default raw `POST /api/v1/apps` calls to the no-repo path unless the caller explicitly sends `skipGitHubRepo: false`
- keep explicit repo-backed app creation available for opt-in callers
- add API and factory coverage for omitted, true, and false `skipGitHubRepo` behavior

Addresses the locally testable raw app-create hardening slice of #10450. The X-App-Id org-scope rule and per-org app creation cap still need product/auth policy decisions.

## Evidence
- `.github/issue-evidence/10450-app-create-repo-default.md`

## Validation
- `bun run install:light`
- `node packages/shared/scripts/generate-keywords.mjs --target ts`
- `bun run --cwd packages/contracts build`
- `bun run --cwd packages/core build:node`
- `git diff --check origin/develop...HEAD`
- `bunx @biomejs/biome check packages/cloud/api/v1/apps/route.ts packages/cloud/api/__tests__/apps-crud.integration.test.ts packages/cloud/shared/src/lib/services/__tests__/app-factory.test.ts`
- `bun test packages/cloud/api/__tests__/apps-crud.integration.test.ts --reporter=dot` — 39 pass, 0 fail
- `bun test packages/cloud/shared/src/lib/services/__tests__/app-factory.test.ts --reporter=dot` — passed, exit 0

Screenshots/video/Android capture: N/A for this backend route-contract change.