### PR TITLE
test(plugin-native-appblocker): on-device androidTest for the installed-apps read (#9967)

### DIFF
--- a/.github/issue-evidence/9967-system-plugin-androidtest/appblocker-emulator-am-instrument.txt
+++ b/.github/issue-evidence/9967-system-plugin-androidtest/appblocker-emulator-am-instrument.txt
@@ -1,0 +1,25 @@
+INSTRUMENTATION_STATUS: class=ai.eliza.plugins.appblocker.InstalledAppsReaderInstrumentedTest
+INSTRUMENTATION_STATUS: current=1
+ai.eliza.plugins.appblocker.InstalledAppsReaderInstrumentedTest:
+INSTRUMENTATION_STATUS: test=listLaunchableApps_returnsRealWellFormedApps
+INSTRUMENTATION_STATUS_CODE: 1
+INSTRUMENTATION_STATUS: class=ai.eliza.plugins.appblocker.InstalledAppsReaderInstrumentedTest
+INSTRUMENTATION_STATUS: current=1
+INSTRUMENTATION_STATUS: test=listLaunchableApps_returnsRealWellFormedApps
+INSTRUMENTATION_STATUS_CODE: 0
+INSTRUMENTATION_STATUS: class=ai.eliza.plugins.appblocker.InstalledAppsReaderInstrumentedTest
+INSTRUMENTATION_STATUS: current=2
+INSTRUMENTATION_STATUS: test=listLaunchableApps_includesAKnownLauncherApp
+INSTRUMENTATION_STATUS_CODE: 1
+INSTRUMENTATION_STATUS: class=ai.eliza.plugins.appblocker.InstalledAppsReaderInstrumentedTest
+INSTRUMENTATION_STATUS: current=2
+INSTRUMENTATION_STATUS: test=listLaunchableApps_includesAKnownLauncherApp
+INSTRUMENTATION_STATUS_CODE: 0
+INSTRUMENTATION_RESULT: stream=
+
+Time: 0.037
+
+OK (2 tests)
+
+
+INSTRUMENTATION_CODE: -1

--- a/plugins/plugin-native-appblocker/AGENTS.md
+++ b/plugins/plugin-native-appblocker/AGENTS.md
@@ -82,6 +82,7 @@ This plugin reads no environment variables. It requires OS-level permissions gra
 
 ## Conventions / gotchas
 
+- **Instrumented test (issue #9967).** The launchable-app enumeration (`PackageManager.queryIntentActivities(MAIN/LAUNCHER)`) lives in `InstalledAppsReader`; `getInstalledApps` delegates to it (JS shape unchanged) so an on-device `androidTest` drives the real `PackageManager` (permission-free positive read). Complements the `AppBlockerStateStore` block-state device test.
 - **Capacitor plugin, not elizaOS plugin**: this has no `Plugin` object shaped for `AgentRuntime`. Do not wire it into elizaOS plugin loading. The consuming app imports and uses `AppBlocker` from JS.
 - **Android blocking engine**: a foreground service (`AppBlockerForegroundService`) polls `UsageStatsManager.queryEvents` every 500 ms and shows a full-screen system overlay when a blocked app moves to foreground. The service is `START_STICKY`; it self-terminates if the block state is cleared or the timer expires.
 - **iOS engine**: uses `ManagedSettingsStore` to set `store.shield.applications`. No polling; the OS enforces the shield. `getInstalledApps` always returns `[]` on iOS because Family Controls does not expose an app list — use `selectApps` to let the user pick via `FamilyActivityPicker`.

--- a/plugins/plugin-native-appblocker/CLAUDE.md
+++ b/plugins/plugin-native-appblocker/CLAUDE.md
@@ -82,6 +82,7 @@ This plugin reads no environment variables. It requires OS-level permissions gra
 
 ## Conventions / gotchas
 
+- **Instrumented test (issue #9967).** The launchable-app enumeration (`PackageManager.queryIntentActivities(MAIN/LAUNCHER)`) lives in `InstalledAppsReader`; `getInstalledApps` delegates to it (JS shape unchanged) so an on-device `androidTest` drives the real `PackageManager` (permission-free positive read). Complements the `AppBlockerStateStore` block-state device test.
 - **Capacitor plugin, not elizaOS plugin**: this has no `Plugin` object shaped for `AgentRuntime`. Do not wire it into elizaOS plugin loading. The consuming app imports and uses `AppBlocker` from JS.
 - **Android blocking engine**: a foreground service (`AppBlockerForegroundService`) polls `UsageStatsManager.queryEvents` every 500 ms and shows a full-screen system overlay when a blocked app moves to foreground. The service is `START_STICKY`; it self-terminates if the block state is cleared or the timer expires.
 - **iOS engine**: uses `ManagedSettingsStore` to set `store.shield.applications`. No polling; the OS enforces the shield. `getInstalledApps` always returns `[]` on iOS because Family Controls does not expose an app list — use `selectApps` to let the user pick via `FamilyActivityPicker`.

--- a/plugins/plugin-native-appblocker/android/build.gradle
+++ b/plugins/plugin-native-appblocker/android/build.gradle
@@ -55,5 +55,8 @@ dependencies {
 
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
+    // core + runner for the on-device installed-apps read test (issue #9967).
+    androidTestImplementation "androidx.test:core:1.5.0"
+    androidTestImplementation "androidx.test:runner:1.5.2"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
 }

--- a/plugins/plugin-native-appblocker/android/src/androidTest/java/ai/eliza/plugins/appblocker/InstalledAppsReaderInstrumentedTest.kt
+++ b/plugins/plugin-native-appblocker/android/src/androidTest/java/ai/eliza/plugins/appblocker/InstalledAppsReaderInstrumentedTest.kt
@@ -1,0 +1,62 @@
+package ai.eliza.plugins.appblocker
+
+import android.content.Context
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * On-device read test for the launchable-app enumeration (issue #9967).
+ *
+ * Drives the real [android.content.pm.PackageManager] query via
+ * [InstalledAppsReader] — the same read [AppBlockerPlugin.getInstalledApps]
+ * exposes — and asserts the result is real, well-formed, de-duplicated, and
+ * sorted. Permission-free, so it asserts positively on any device/emulator.
+ */
+@RunWith(AndroidJUnit4::class)
+class InstalledAppsReaderInstrumentedTest {
+
+    private val context: Context
+        get() = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Test
+    fun listLaunchableApps_returnsRealWellFormedApps() {
+        val apps = InstalledAppsReader(context).listLaunchableApps()
+
+        // Every Android device/emulator ships launchable system apps.
+        assertTrue("device has at least one launchable app", apps.isNotEmpty())
+
+        for (app in apps) {
+            assertTrue("package name is non-empty", app.packageName.isNotEmpty())
+            assertTrue("display name is non-empty for ${app.packageName}", app.displayName.isNotEmpty())
+        }
+
+        // De-duplicated by package name.
+        assertEquals(
+            "no duplicate packages",
+            apps.map { it.packageName }.distinct().size,
+            apps.size,
+        )
+
+        // Sorted case-insensitively by display name (the plugin's contract).
+        val names = apps.map { it.displayName.lowercase() }
+        assertEquals("sorted by display name", names.sortedBy { it }, names)
+    }
+
+    @Test
+    fun listLaunchableApps_includesAKnownLauncherApp() {
+        val apps = InstalledAppsReader(context).listLaunchableApps()
+        // The Settings app is launchable on every standard Android image — a
+        // concrete cross-check that the real PackageManager query ran (not a stub).
+        assertTrue(
+            "a known launchable system app (Settings or a launcher) is present",
+            apps.any {
+                it.packageName == "com.android.settings" ||
+                    it.packageName.contains("launcher")
+            },
+        )
+    }
+}

--- a/plugins/plugin-native-appblocker/android/src/main/java/ai/eliza/plugins/appblocker/AppBlockerPlugin.kt
+++ b/plugins/plugin-native-appblocker/android/src/main/java/ai/eliza/plugins/appblocker/AppBlockerPlugin.kt
@@ -2,7 +2,6 @@ package ai.eliza.plugins.appblocker
 
 import android.app.AppOpsManager
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.os.Process
@@ -18,6 +17,11 @@ import java.time.Instant
 
 @CapacitorPlugin(name = "ElizaAppBlocker")
 class AppBlockerPlugin : Plugin() {
+    // The PackageManager launchable-app enumeration lives in InstalledAppsReader
+    // so it is exercisable by an instrumented androidTest without a Capacitor
+    // Bridge (issue #9967).
+    private val installedAppsReader by lazy { InstalledAppsReader(context) }
+
     @PluginMethod
     override fun checkPermissions(call: PluginCall) {
         call.resolve(buildPermissionResult())
@@ -38,38 +42,16 @@ class AppBlockerPlugin : Plugin() {
 
     @PluginMethod
     fun getInstalledApps(call: PluginCall) {
-        val launcherIntent = Intent(Intent.ACTION_MAIN).addCategory(Intent.CATEGORY_LAUNCHER)
-        val matches = if (Build.VERSION.SDK_INT >= 33) {
-            context.packageManager.queryIntentActivities(
-                launcherIntent,
-                PackageManager.ResolveInfoFlags.of(0),
-            )
-        } else {
-            @Suppress("DEPRECATION")
-            context.packageManager.queryIntentActivities(launcherIntent, 0)
-        }
-
-        val ownPackageName = context.packageName
-        val apps = matches
-            .asSequence()
-            .mapNotNull { resolveInfo ->
-                val packageName = resolveInfo.activityInfo?.packageName?.trim().orEmpty()
-                if (packageName.isEmpty() || packageName == ownPackageName) {
-                    return@mapNotNull null
-                }
-                val displayName = resolveInfo.loadLabel(context.packageManager)
-                    ?.toString()
-                    ?.trim()
-                    .takeUnless { it.isNullOrEmpty() }
-                    ?: packageName
-                JSObject().apply {
-                    put("packageName", packageName)
-                    put("displayName", displayName)
-                }
+        // The PackageManager launchable-app query is delegated to
+        // InstalledAppsReader so it can be exercised by an instrumented
+        // androidTest without a Capacitor Bridge (issue #9967); the JS shape
+        // below is unchanged.
+        val apps = installedAppsReader.listLaunchableApps().map { app ->
+            JSObject().apply {
+                put("packageName", app.packageName)
+                put("displayName", app.displayName)
             }
-            .distinctBy { it.getString("packageName") }
-            .sortedBy { it.getString("displayName")?.lowercase() ?: "" }
-            .toList()
+        }
 
         call.resolve(
             JSObject().apply {

--- a/plugins/plugin-native-appblocker/android/src/main/java/ai/eliza/plugins/appblocker/InstalledAppsReader.kt
+++ b/plugins/plugin-native-appblocker/android/src/main/java/ai/eliza/plugins/appblocker/InstalledAppsReader.kt
@@ -1,0 +1,57 @@
+package ai.eliza.plugins.appblocker
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+
+/**
+ * [Context]-backed reader for the launchable-app enumeration that
+ * [AppBlockerPlugin.getInstalledApps] exposes — the
+ * `PackageManager.queryIntentActivities(ACTION_MAIN/CATEGORY_LAUNCHER)` read.
+ *
+ * Extracted from the Capacitor plugin so the real [PackageManager] query can be
+ * exercised by an instrumented `androidTest` without a Capacitor `Bridge`/WebView
+ * (issue #9967). The plugin delegates to it and marshals each record into the
+ * unchanged `{ packageName, displayName }` JS shape. Permission-free.
+ */
+class InstalledAppsReader(context: Context) {
+
+    private val appContext: Context = context.applicationContext
+
+    data class LaunchableApp(val packageName: String, val displayName: String)
+
+    /**
+     * Home-screen-launchable apps, excluding this app, de-duplicated by package
+     * and sorted case-insensitively by display name.
+     */
+    fun listLaunchableApps(): List<LaunchableApp> {
+        val launcherIntent = Intent(Intent.ACTION_MAIN).addCategory(Intent.CATEGORY_LAUNCHER)
+        val pm = appContext.packageManager
+        val matches = if (Build.VERSION.SDK_INT >= 33) {
+            pm.queryIntentActivities(launcherIntent, PackageManager.ResolveInfoFlags.of(0))
+        } else {
+            @Suppress("DEPRECATION")
+            pm.queryIntentActivities(launcherIntent, 0)
+        }
+
+        val ownPackageName = appContext.packageName
+        return matches
+            .asSequence()
+            .mapNotNull { resolveInfo ->
+                val packageName = resolveInfo.activityInfo?.packageName?.trim().orEmpty()
+                if (packageName.isEmpty() || packageName == ownPackageName) {
+                    return@mapNotNull null
+                }
+                val displayName = resolveInfo.loadLabel(pm)
+                    ?.toString()
+                    ?.trim()
+                    .takeUnless { it.isNullOrEmpty() }
+                    ?: packageName
+                LaunchableApp(packageName, displayName)
+            }
+            .distinctBy { it.packageName }
+            .sortedBy { it.displayName.lowercase() }
+            .toList()
+    }
+}


### PR DESCRIPTION
## What

Adds on-device `androidTest` coverage for `@elizaos/capacitor-appblocker`'s **`getInstalledApps`** — the `PackageManager.queryIntentActivities(ACTION_MAIN/CATEGORY_LAUNCHER)` launchable-app enumeration. Same root-cause #9967 fix: extract a `Context`-backed `InstalledAppsReader` from the Capacitor `Bridge` coupling, delegate from the plugin (**JS wire shape unchanged**, net −15 lines), then drive the real `PackageManager` from `src/androidTest`.

This **complements** #10447 (merged), which device-tested the *block-state/expiry* path (`AppBlockerStateStore`). That left `getInstalledApps` — the other real device read on this plugin — untested; this closes it. Permission-free, so it asserts positively on any device.

## Verified on-device

`OK (2 tests)` on **Pixel 6a (Android 16)** *and* an **API-34 emulator**:
- `listLaunchableApps_returnsRealWellFormedApps` — the real query returns a non-empty list; every entry has a non-empty package + display name; de-duplicated by package; sorted case-insensitively by display name (the plugin's contract).
- `listLaunchableApps_includesAKnownLauncherApp` — cross-checks a known launchable system app (Settings / a launcher) is present, proving the real `PackageManager` ran (not a stub).

Evidence: `.github/issue-evidence/9967-system-plugin-androidtest/appblocker-emulator-am-instrument.txt`.

## Test plan
- `:elizaos-capacitor-appblocker:assembleDebug` / `connectedDebugAndroidTest` — green on Pixel 6a + emulator.
- Web parity: appblocker 15/15 unchanged.
- The existing `AppBlockerStateStoreInstrumentedTest` (#10447) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)