### PR TITLE
fix(cloud): authorize X-App-Id attribution

### DIFF
--- a/.github/issue-evidence/10450-x-app-id-attribution.md
+++ b/.github/issue-evidence/10450-x-app-id-attribution.md
@@ -1,0 +1,61 @@
+# Issue #10450 - X-App-Id attribution hardening
+
+## What changed
+
+- `POST /api/v1/messages` and `POST /api/v1/chat/completions` no longer trust
+  an arbitrary `X-App-Id` header for app-credit/creator-earnings attribution.
+- A monetized app id is honored only when:
+  - the caller belongs to the app's owning organization, or
+  - the caller has a durable app-auth connection to that app.
+- Durable app-auth connections are represented by `app_users.signup_source =
+  "oauth"`. Plain inference analytics may still create `app_users` rows, but
+  those rows do not authorize future attribution.
+- `/api/v1/app-auth/connect` now upgrades an existing analytics-created
+  `app_users` row to the OAuth grant state, so legitimate users are not blocked
+  if an analytics row already existed.
+
+This addresses finding 1 from issue #10450. Finding 2's per-org app creation cap
+still needs a product/tier cap value. Draft PR #10455 separately covers the raw
+app-create GitHub repo default.
+
+## Validation
+
+Base commit: `426a1676f4 fix(cloud): proof-of-control wallet provisioning; revert #10382 org-scoped RPC regression (#10279) (#10438)`
+
+Commands run from `/home/shaw/milady/eliza-issue-10450-xappid`:
+
+```bash
+bun run install:light
+node packages/shared/scripts/generate-keywords.mjs --target ts
+bun run --cwd packages/contracts build
+bun run --cwd packages/core build:node
+git diff --check
+bunx @biomejs/biome check packages/cloud/shared/src/db/repositories/apps.ts packages/cloud/shared/src/lib/services/apps.ts packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts packages/cloud/api/v1/messages/route.ts packages/cloud/api/v1/chat/completions/route.ts
+bun test packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts --reporter=dot
+bun run --cwd packages/cloud/shared typecheck
+bun run --cwd packages/cloud/api typecheck
+```
+
+Observed results:
+
+- `git diff --check`: passed.
+- Focused Biome check: passed, `Checked 5 files`.
+- Apps repository/service PGlite suite: passed with `17 pass`, `0 fail`, `74
+  expect() calls`.
+- `packages/cloud/shared` typecheck: passed.
+- `packages/cloud/api` typecheck: passed.
+
+## Human-verifiable behavior
+
+- Same-org callers can still use a monetized app id for app-credit attribution.
+- Cross-org callers with no app-auth connection cannot attribute inference to
+  another org's app.
+- A cross-org analytics-created `app_users` row is not sufficient to authorize
+  attribution.
+- A later app-auth connect call upgrades that existing row to `signup_source:
+  "oauth"`, after which the cross-org user can legitimately attribute to the app.
+- Unauthorized app ids are dropped before app-credit reconciliation and before
+  downstream chat-completion metadata receives an app id.
+
+Screenshots/video/Android capture: N/A. This is a cloud backend authorization
+and accounting-boundary change with no UI, native, or attached-Android surface.

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -809,16 +809,20 @@ export async function handleChatCompletionsPOST(
     }
 
     // 2. Check for app monetization
-    const appId = req.headers.get("X-App-Id");
+    const requestedAppId = req.headers.get("X-App-Id");
+    let appId: string | null = null;
     let useAppCredits = false;
     let monetizedApp: Awaited<ReturnType<typeof appsService.getById>> | null =
       null;
 
-    if (appId) {
-      monetizedApp = await appsService.getById(appId);
-      if (monetizedApp?.monetization_enabled) {
-        useAppCredits = true;
-      }
+    if (requestedAppId) {
+      monetizedApp =
+        (await appsService.getAuthorizedMonetizedAppForUser(
+          requestedAppId,
+          user,
+        )) ?? null;
+      appId = monetizedApp?.id ?? null;
+      useAppCredits = Boolean(monetizedApp);
     }
 
     // 3. Parse request — guard a malformed/empty body to a 400 instead of a 500.

--- a/packages/cloud/api/v1/messages/route.ts
+++ b/packages/cloud/api/v1/messages/route.ts
@@ -496,13 +496,19 @@ app.post("/", async (c) => {
     return anthropicError("authentication_error", message, 401);
   }
 
-  const appId = c.req.header("X-App-Id");
+  const requestedAppId = c.req.header("X-App-Id");
+  let appId: string | null = null;
   let useAppCredits = false;
   let monetizedApp: NonNullable<
     Awaited<ReturnType<typeof appsService.getById>>
   > | null = null;
-  if (appId) {
-    monetizedApp = (await appsService.getById(appId)) ?? null;
+  if (requestedAppId) {
+    monetizedApp =
+      (await appsService.getAuthorizedMonetizedAppForUser(
+        requestedAppId,
+        user,
+      )) ?? null;
+    appId = monetizedApp?.id ?? null;
     useAppCredits = Boolean(monetizedApp?.monetization_enabled);
   }
 

--- a/packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts
@@ -339,6 +339,88 @@ describe("AppsRepository.listByOrganization", () => {
   });
 });
 
+describe("App-auth attribution grants", () => {
+  test("connectUser upgrades an existing analytics-created app user to an OAuth grant", async () => {
+    if (!pgliteReady) return;
+    const appOrg = await seedOrg();
+    const callerOrg = await seedOrg();
+    const appOwner = await seedUser(appOrg);
+    const caller = await seedUser(callerOrg);
+    const app = await createApp({
+      name: "OAuth Upgrade",
+      organization_id: appOrg,
+      created_by_user_id: appOwner,
+    });
+
+    await appsRepository.trackAppUserActivity(app.id, caller, "0.01", {
+      route: "messages",
+    });
+    const before = await appsRepository.findAppUser(app.id, caller);
+    expect(before?.signup_source).toBeNull();
+
+    const action = await appsRepository.connectUser({
+      appId: app.id,
+      userId: caller,
+      signupSource: "oauth",
+      ipAddress: "203.0.113.10",
+      userAgent: "test-agent",
+    });
+
+    expect(action).toBe("updated");
+    const after = await appsRepository.findAppUser(app.id, caller);
+    expect(after?.signup_source).toBe("oauth");
+    expect(after?.ip_address).toBe("203.0.113.10");
+    expect(after?.user_agent).toBe("test-agent");
+  });
+
+  test("X-App-Id attribution requires same org or an OAuth app-auth grant", async () => {
+    if (!pgliteReady) return;
+    const appOrg = await seedOrg();
+    const callerOrg = await seedOrg();
+    const appOwner = await seedUser(appOrg);
+    const sameOrgUser = await seedUser(appOrg);
+    const caller = await seedUser(callerOrg);
+    const app = await createApp({
+      name: "Monetized App",
+      organization_id: appOrg,
+      created_by_user_id: appOwner,
+      monetization_enabled: true,
+    });
+
+    const sameOrg = await appsService.getAuthorizedMonetizedAppForUser(app.id, {
+      id: sameOrgUser,
+      organization_id: appOrg,
+    });
+    expect(sameOrg?.id).toBe(app.id);
+
+    const crossOrgBefore = await appsService.getAuthorizedMonetizedAppForUser(app.id, {
+      id: caller,
+      organization_id: callerOrg,
+    });
+    expect(crossOrgBefore).toBeUndefined();
+
+    await appsRepository.trackAppUserActivity(app.id, caller, "0.01", {
+      route: "messages",
+    });
+    const analyticsOnly = await appsService.getAuthorizedMonetizedAppForUser(app.id, {
+      id: caller,
+      organization_id: callerOrg,
+    });
+    expect(analyticsOnly).toBeUndefined();
+
+    await appsRepository.connectUser({
+      appId: app.id,
+      userId: caller,
+      signupSource: "oauth",
+    });
+    const oauthGranted = await appsService.getAuthorizedMonetizedAppForUser(app.id, {
+      id: caller,
+      organization_id: callerOrg,
+    });
+    expect(oauthGranted?.id).toBe(app.id);
+  });
+});
+
 describe("AppsRepository.listAll", () => {
   test("filters by is_active / is_approved", async () => {
     if (!pgliteReady) return;

--- a/packages/cloud/shared/src/db/repositories/apps.ts
+++ b/packages/cloud/shared/src/db/repositories/apps.ts
@@ -270,7 +270,12 @@ export class AppsRepository {
     if (existingConnection) {
       await dbWrite
         .update(appUsers)
-        .set({ last_seen_at: new Date() })
+        .set({
+          last_seen_at: new Date(),
+          signup_source: input.signupSource,
+          ip_address: input.ipAddress ?? existingConnection.ip_address,
+          user_agent: input.userAgent ?? existingConnection.user_agent,
+        })
         .where(eq(appUsers.id, existingConnection.id));
       return "updated";
     }

--- a/packages/cloud/shared/src/lib/services/apps.ts
+++ b/packages/cloud/shared/src/lib/services/apps.ts
@@ -140,6 +140,44 @@ export class AppsService {
   }
 
   /**
+   * Resolve a monetized app id only when the caller may attribute inference to it.
+   *
+   * Same-org callers are app owners/operators. Cross-org callers must have gone
+   * through the app-auth connect flow, which persists an app_users row with
+   * signup_source="oauth". Plain inference tracking also creates app_users rows,
+   * but without that OAuth source, so first-touch analytics cannot bootstrap its
+   * own authorization.
+   */
+  async getAuthorizedMonetizedAppForUser(
+    appId: string,
+    user: { id: string; organization_id: string },
+  ): Promise<App | undefined> {
+    const app = await this.getById(appId);
+    if (!app?.monetization_enabled) {
+      return undefined;
+    }
+
+    if (app.organization_id === user.organization_id) {
+      return app;
+    }
+
+    const appUser = await appsRepository.findAppUser(app.id, user.id);
+    if (appUser?.signup_source === "oauth") {
+      return app;
+    }
+
+    logger.warn("[Apps] Rejected unauthorized X-App-Id attribution", {
+      appId: app.id,
+      userId: user.id,
+      userOrganizationId: user.organization_id,
+      appOrganizationId: app.organization_id,
+      hasAppUser: Boolean(appUser),
+      appUserSignupSource: appUser?.signup_source ?? null,
+    });
+    return undefined;
+  }
+
+  /**
    * Get app by its associated API key ID with Redis caching.
    * This is the primary method for app auth - avoids fetching all org apps.
    *


### PR DESCRIPTION
## Summary
- hardens `X-App-Id` attribution so monetized app credits/earnings are only used for same-org apps or cross-org apps with a durable app-auth OAuth grant
- stops analytics-created `app_users` rows from authorizing cross-org attribution by themselves
- upgrades existing analytics-created app-user rows to `signup_source = oauth` when `/app-auth/connect` grants access
- applies the authorized app id to both `/v1/messages` and `/v1/chat/completions` so rejected headers cannot flow into accounting metadata

Fixes the first finding in #10450. The raw HTTP app-create repo default is handled separately in draft PR #10455. The per-org app cap still needs a product/tier decision before implementation.

## Evidence
- `.github/issue-evidence/10450-x-app-id-attribution.md`

## Validation
- `bun run install:light`
- `node packages/shared/scripts/generate-keywords.mjs --target ts`
- `bun run --cwd packages/contracts build`
- `bun run --cwd packages/core build:node`
- `git diff --check`
- `bunx @biomejs/biome check packages/cloud/shared/src/db/repositories/apps.ts packages/cloud/shared/src/lib/services/apps.ts packages/cloud/api/v1/messages/route.ts packages/cloud/api/v1/chat/completions/route.ts packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts`
- `bun test packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts --reporter=dot` (17 pass, 0 fail, 74 assertions)
- `bun run --cwd packages/cloud/shared typecheck`
- `bun run --cwd packages/cloud/api typecheck`

## Screenshots / Android
N/A: this is a Cloud API/backend authorization and accounting boundary change with no UI or native Android surface. The behavior is covered by repository-level PGlite tests and package typechecks.