### PR TITLE
[codex] fix staging cloud auth base for app bundle

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -349,6 +349,7 @@ jobs:
         env:
           VITE_API_URL: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'https://api.elizacloud.ai' || 'https://api-staging.elizacloud.ai' }}
           NEXT_PUBLIC_API_URL: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'https://api.elizacloud.ai' || 'https://api-staging.elizacloud.ai' }}
+          VITE_ELIZA_CLOUD_BASE: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'https://www.elizacloud.ai' || 'https://staging.elizacloud.ai' }}
           # The console's own canonical origin (OG/canonical tags, returnTo base).
           VITE_APP_URL: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'https://elizacloud.ai' || 'https://staging.elizacloud.ai' }}
           NEXT_PUBLIC_APP_URL: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'https://elizacloud.ai' || 'https://staging.elizacloud.ai' }}
@@ -558,6 +559,7 @@ jobs:
         env:
           VITE_API_URL: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'https://api.elizacloud.ai' || 'https://api-staging.elizacloud.ai' }}
           NEXT_PUBLIC_API_URL: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'https://api.elizacloud.ai' || 'https://api-staging.elizacloud.ai' }}
+          VITE_ELIZA_CLOUD_BASE: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'https://www.elizacloud.ai' || 'https://staging.elizacloud.ai' }}
           # The app's own canonical origin — its own subdomain, NOT the apex.
           NEXT_PUBLIC_APP_URL: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'https://app.elizacloud.ai' || 'https://app-staging.elizacloud.ai' }}
           # Steward tenant pin (same tenant as the console; one identity across

--- a/packages/app/wrangler.toml
+++ b/packages/app/wrangler.toml
@@ -21,12 +21,14 @@ compatibility_date = "2026-04-29"
 
 [vars]
 API_UPSTREAM = "https://api.elizacloud.ai"
+VITE_ELIZA_CLOUD_BASE = "https://www.elizacloud.ai"
 # Per-env signal consumed by isomorphic code so the SPA can branch on
 # deployment env. Mirrors the cloud-frontend convention.
 VITE_ENVIRONMENT = "production"
 
 [env.preview.vars]
 API_UPSTREAM = "https://api-staging.elizacloud.ai"
+VITE_ELIZA_CLOUD_BASE = "https://staging.elizacloud.ai"
 # Pin the Steward tenant for the staging build so the SPA initialises the SDK
 # with tenantId=elizacloud-staging and OAuth /authorize carries
 # tenant_id=elizacloud-staging (Steward resolves the OAuth tenant from the

--- a/packages/ui/src/api/client-cloud-direct-auth.test.ts
+++ b/packages/ui/src/api/client-cloud-direct-auth.test.ts
@@ -81,6 +81,55 @@ describe("ElizaClient direct Cloud auth on native", () => {
     expectNoLocalPersistOrStatusProbe();
   });
 
+  it("creates staging CLI sessions through the staging API host and opens the staging web auth host", async () => {
+    capacitorMocks.post.mockResolvedValue({ status: 200, data: {} });
+
+    const client = new ElizaClient("https://staging.elizacloud.ai");
+    const result = await client.cloudLoginDirect(
+      "https://staging.elizacloud.ai",
+    );
+
+    expect(capacitorMocks.post).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://api-staging.elizacloud.ai/api/auth/cli-session",
+        data: expect.objectContaining({ sessionId: expect.any(String) }),
+      }),
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        ok: true,
+        apiBase: "https://api-staging.elizacloud.ai",
+        browserUrl: expect.stringMatching(
+          /^https:\/\/staging\.elizacloud\.ai\/auth\/cli-login\?session=/,
+        ),
+      }),
+    );
+  });
+
+  it("maps staging API bases back to the staging web auth host", async () => {
+    capacitorMocks.post.mockResolvedValue({ status: 200, data: {} });
+
+    const client = new ElizaClient("https://api-staging.elizacloud.ai");
+    const result = await client.cloudLoginDirect(
+      "https://api-staging.elizacloud.ai",
+    );
+
+    expect(capacitorMocks.post).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://api-staging.elizacloud.ai/api/auth/cli-session",
+      }),
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        ok: true,
+        apiBase: "https://api-staging.elizacloud.ai",
+        browserUrl: expect.stringMatching(
+          /^https:\/\/staging\.elizacloud\.ai\/auth\/cli-login\?session=/,
+        ),
+      }),
+    );
+  });
+
   it("polls native CLI sessions through the Cloud API host", async () => {
     capacitorMocks.get.mockResolvedValue({
       status: 200,

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -63,13 +63,21 @@ import type {
 const AGENT_TRANSFER_MIN_PASSWORD_LENGTH = 4;
 const DEFAULT_DIRECT_CLOUD_BASE_URL = "https://www.elizacloud.ai";
 const DEFAULT_DIRECT_CLOUD_API_BASE_URL = "https://api.elizacloud.ai";
+const STAGING_DIRECT_CLOUD_BASE_URL = "https://staging.elizacloud.ai";
+const STAGING_DIRECT_CLOUD_API_BASE_URL = "https://api-staging.elizacloud.ai";
 const DIRECT_CLOUD_HTTP_TIMEOUT_MS = 15_000;
-const DIRECT_ELIZA_CLOUD_WEB_HOSTS = new Set([
-  "elizacloud.ai",
-  "www.elizacloud.ai",
-  "dev.elizacloud.ai",
+const DIRECT_ELIZA_CLOUD_API_BY_HOST = new Map([
+  ["api.elizacloud.ai", DEFAULT_DIRECT_CLOUD_API_BASE_URL],
+  ["elizacloud.ai", DEFAULT_DIRECT_CLOUD_API_BASE_URL],
+  ["www.elizacloud.ai", DEFAULT_DIRECT_CLOUD_API_BASE_URL],
+  ["dev.elizacloud.ai", DEFAULT_DIRECT_CLOUD_API_BASE_URL],
+  ["api-staging.elizacloud.ai", STAGING_DIRECT_CLOUD_API_BASE_URL],
+  ["staging.elizacloud.ai", STAGING_DIRECT_CLOUD_API_BASE_URL],
 ]);
-const DIRECT_ELIZA_CLOUD_API_HOST = "api.elizacloud.ai";
+const DIRECT_ELIZA_CLOUD_WEB_BY_API_HOST = new Map([
+  ["api.elizacloud.ai", DEFAULT_DIRECT_CLOUD_BASE_URL],
+  ["api-staging.elizacloud.ai", STAGING_DIRECT_CLOUD_BASE_URL],
+]);
 
 type DirectCloudAgent = {
   id?: string;
@@ -160,10 +168,7 @@ function isDirectCloudBase(client: ElizaClient): boolean {
 
   try {
     const host = new URL(baseUrl).hostname.toLowerCase();
-    return (
-      host === DIRECT_ELIZA_CLOUD_API_HOST ||
-      DIRECT_ELIZA_CLOUD_WEB_HOSTS.has(host)
-    );
+    return DIRECT_ELIZA_CLOUD_API_BY_HOST.has(host);
   } catch {
     return false;
   }
@@ -234,9 +239,7 @@ function resolveDirectCloudWebBase(cloudBase: string): string {
   const normalized = cloudBase.replace(/\/+$/, "");
   try {
     const host = new URL(normalized).hostname.toLowerCase();
-    if (host === DIRECT_ELIZA_CLOUD_API_HOST) {
-      return DEFAULT_DIRECT_CLOUD_BASE_URL;
-    }
+    return DIRECT_ELIZA_CLOUD_WEB_BY_API_HOST.get(host) ?? normalized;
   } catch {
     // Fall back to the provided base below.
   }
@@ -248,12 +251,7 @@ function resolveDirectCloudAuthApiBase(cloudBase: string): string {
   try {
     const url = new URL(normalized);
     const host = url.hostname.toLowerCase();
-    if (
-      host === DIRECT_ELIZA_CLOUD_API_HOST ||
-      DIRECT_ELIZA_CLOUD_WEB_HOSTS.has(host)
-    ) {
-      return DEFAULT_DIRECT_CLOUD_API_BASE_URL;
-    }
+    return DIRECT_ELIZA_CLOUD_API_BY_HOST.get(host) ?? normalized;
   } catch {
     // Fall back to the provided base below.
   }


### PR DESCRIPTION
## Summary
- pins the hosted app/console staging bundles to `https://staging.elizacloud.ai` for direct Cloud auth instead of falling back to prod
- teaches the shared Cloud client that staging web/API hosts are a matched pair: `staging.elizacloud.ai` <-> `api-staging.elizacloud.ai`
- adds direct-auth coverage so staging login creates CLI sessions against `api-staging` and opens the staging web auth host

## Validation
- `bunx vitest run packages/ui/src/api/client-cloud-direct-auth.test.ts` -> 29 pass
- `bun run --cwd packages/ui typecheck` -> pass
- `bun test packages/cloud/api/src/index.test.ts` -> 21 pass
- `bun run --cwd packages/cloud/api typecheck` -> pass
- `actionlint .github/workflows/cloud-cf-deploy.yml` -> pass
- `git diff --check origin/develop...HEAD` -> pass
- staging env `bun run --cwd packages/app build:web` -> pass; `verify-chunk-safety` OK
- built-output Playwright smoke on `127.0.0.1:2140`: first-run Cloud connect POSTs `https://api-staging.elizacloud.ai/api/auth/cli-session` and opens `https://staging.elizacloud.ai/auth/cli-login?session=...`

## Context
Shaw merged #10440 while I was validating this follow-up, so this PR is intentionally split to contain only the remaining staging auth-base fix on top of current `develop`.
