### PR TITLE
fix(orchestrator): allow configured workspace roots in workdir validation

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/workdir-validation.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/workdir-validation.test.ts
@@ -55,4 +55,36 @@ describe("ensureTaskWorkdir / resolveAllowedWorkdir", () => {
     const resolved = await resolveAllowedWorkdir(dir);
     expect(resolved.endsWith(path.basename(dir))).toBe(true);
   });
+
+  it("accepts a dir inside a configured workspace root (ELIZA_WORKSPACE_DIR)", async () => {
+    // A dir under the OS temp dir is normally rejected (it is neither the
+    // ~/.eliza/workspaces base nor cwd). Pointing a configured workspace root
+    // env var at it must make a child dir allowed, matching the spawn path.
+    const root = path.join(os.tmpdir(), `eliza-ws-root-${process.pid}`);
+    const child = path.join(root, "apps", "some-app");
+    await mkdir(child, { recursive: true });
+    created.push(root);
+    const prev = process.env.ELIZA_WORKSPACE_DIR;
+    process.env.ELIZA_WORKSPACE_DIR = root;
+    try {
+      const resolved = await resolveAllowedWorkdir(child);
+      expect(resolved.endsWith(path.join("apps", "some-app"))).toBe(true);
+    } finally {
+      if (prev === undefined) delete process.env.ELIZA_WORKSPACE_DIR;
+      else process.env.ELIZA_WORKSPACE_DIR = prev;
+    }
+  });
+
+  it("still rejects a dir outside the base, cwd, and any configured root", async () => {
+    // With no workspace-root env configured, the OS temp dir stays rejected.
+    const prev = process.env.ELIZA_WORKSPACE_DIR;
+    delete process.env.ELIZA_WORKSPACE_DIR;
+    try {
+      await expect(resolveAllowedWorkdir(os.tmpdir())).rejects.toThrow(
+        /within workspace base/,
+      );
+    } finally {
+      if (prev !== undefined) process.env.ELIZA_WORKSPACE_DIR = prev;
+    }
+  });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/workdir-validation.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workdir-validation.ts
@@ -21,6 +21,22 @@ export async function ensureTaskWorkdir(taskId: string): Promise<string> {
   return dir;
 }
 
+/**
+ * Configured workspace-root env keys, in the same precedence the spawn path
+ * (`resolveDefaultSpawnWorkdir` in task-agent-routing.ts) honors. An operator
+ * who points the runtime at a coding workspace (e.g. ELIZA_WORKSPACE_DIR or
+ * ELIZA_ACP_WORKSPACE_ROOT = /workspace) expects HTTP-spawned agents to be
+ * allowed to run THERE, not only under ~/.eliza/workspaces or process.cwd().
+ * Reading from process.env here keeps this validator runtime-handle-free.
+ */
+const WORKSPACE_ROOT_ENV_KEYS = [
+  "ELIZA_ACP_WORKSPACE_ROOT",
+  "ACPX_DEFAULT_CWD",
+  "ELIZA_WORKSPACE_DIR",
+  "ELIZA_CODING_WORKSPACE",
+  "ELIZA_CODING_DIRECTORY",
+] as const;
+
 export async function resolveAllowedWorkdir(
   rawWorkdir: string,
 ): Promise<string> {
@@ -37,11 +53,27 @@ export async function resolveAllowedWorkdir(
     () => workspaceBaseDirResolved,
   );
   const cwdReal = await realpath(cwdResolved).catch(() => cwdResolved);
-  if (
-    ![workspaceBaseDirReal, cwdReal].some((prefix) =>
-      isInside(prefix, resolvedReal),
-    )
-  ) {
+
+  // Also allow any explicitly-configured workspace root. This keeps the HTTP
+  // task-agent spawn path (which calls this validator) consistent with the
+  // chat-action spawn path, which already lands sessions under the configured
+  // root. Without this, a configured /workspace root is rejected as "not within
+  // workspace base directory or cwd" even though the operator set it.
+  const configuredRoots: string[] = [];
+  for (const key of WORKSPACE_ROOT_ENV_KEYS) {
+    const raw = process.env[key]?.trim();
+    if (!raw) continue;
+    const rootResolved = path.resolve(raw);
+    const rootReal = await realpath(rootResolved).catch(() => rootResolved);
+    configuredRoots.push(rootReal);
+  }
+
+  const allowedPrefixes = [
+    workspaceBaseDirReal,
+    cwdReal,
+    ...configuredRoots,
+  ];
+  if (!allowedPrefixes.some((prefix) => isInside(prefix, resolvedReal))) {
     throw new Error("workdir must be within workspace base directory or cwd");
   }
 


### PR DESCRIPTION
## Problem

`resolveAllowedWorkdir` (the sandbox boundary for HTTP-spawned coding agents via `POST /api/orchestrator/tasks/:taskId/agents`) only permitted workdirs under `~/.eliza/workspaces` or `process.cwd()`. It ignored the configured workspace-root env vars that the spawn path (`resolveDefaultSpawnWorkdir` in `task-agent-routing.ts`) already honors:
`ELIZA_ACP_WORKSPACE_ROOT`, `ACPX_DEFAULT_CWD`, `ELIZA_WORKSPACE_DIR`, `ELIZA_CODING_WORKSPACE`, `ELIZA_CODING_DIRECTORY`.

This produced an inconsistency: an operator who points the runtime at a coding workspace (for example `ELIZA_WORKSPACE_DIR=/workspace`) can spawn a session there from the chat action, but the HTTP task-agent endpoint rejects the same workdir with `workdir must be within workspace base directory or cwd`. That blocks attaching a coding agent to a task from the dashboard.

Repro: with `ELIZA_WORKSPACE_DIR=/workspace`, `POST /api/orchestrator/tasks/:id/agents` with `{"workdir":"/workspace/apps"}` returns `{"error":"workdir must be within workspace base directory or cwd"}` even though `/workspace/apps` is inside the configured root.

## Fix

Allow any explicitly-configured workspace root (read from `process.env`, in the same precedence as the spawn path) as an additional permitted prefix. No change when none is configured: the `~/.eliza/workspaces` and cwd bases still apply, and out-of-sandbox workdirs are still rejected.

Adds tests for the configured-root accept path and the no-config reject path (existing tests still pass, 6/6 locally).

## Verification

With the fix deployed and `ELIZA_WORKSPACE_DIR=/workspace`, the same `POST .../agents` request with `{"workdir":"/workspace/apps"}` now passes validation (it proceeds to spawn rather than 400ing on the workdir).

Co-authored-by: wakesync <shadow@shad0w.xyz>