### PR TITLE
fix(orchestrator): resolve default agent type from process.env

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -164,6 +164,16 @@ function configuredDefaultAgentType(runtime: {
     const raw = runtime.getSetting?.(key);
     if (typeof raw === "string" && raw.trim().length > 0) return raw.trim();
   }
+  // Fall back to process.env. runtime.getSetting reads character
+  // settings/secrets, not raw env, so a deployment that configures the default
+  // agent purely via an env var (e.g. ELIZA_ACP_DEFAULT_AGENT=codex on a
+  // container) would otherwise be ignored and the spawn would fall through to
+  // the "opencode" fallback, which may not be installed. This mirrors the env
+  // resolution the spawn-workdir path already does.
+  for (const key of ["ELIZA_ACP_DEFAULT_AGENT", "ELIZA_DEFAULT_AGENT_TYPE"]) {
+    const raw = process.env[key];
+    if (typeof raw === "string" && raw.trim().length > 0) return raw.trim();
+  }
   return undefined;
 }
 


### PR DESCRIPTION
## Problem

`configuredDefaultAgentType` only reads `ELIZA_ACP_DEFAULT_AGENT` / `ELIZA_DEFAULT_AGENT_TYPE` via `runtime.getSetting`, which resolves character settings and secrets but not raw `process.env`.

A headless deployment that configures the default coding agent purely through an env var (the normal way to configure a container, e.g. `ELIZA_ACP_DEFAULT_AGENT=codex`) is therefore ignored: `spawnAgentForTask` falls through to the `"opencode"` fallback. If opencode is not installed (e.g. a container that ships codex only), every task-agent spawn fails with `spawn opencode ENOENT`, even though the operator explicitly set the default to an installed agent.

Repro: container with `ELIZA_ACP_DEFAULT_AGENT=codex` set in the environment (not in character settings) and only `codex-acp` installed. `POST /api/orchestrator/tasks/:id/agents` spawns `opencode` and ENOENTs.

## Fix

Add a `process.env` fallback after the `getSetting` lookup, mirroring the env resolution `resolveDefaultSpawnWorkdir` already performs for workspace roots. No change when the setting is present or no env var is configured.

## Verification

With the fix deployed and `ELIZA_ACP_DEFAULT_AGENT=codex` set via env, a task-agent spawn now logs `defaultAgent: 'codex'` and starts a codex session (task goes `active`, `sessionCount: 1`) instead of ENOENTing on opencode.

Co-authored-by: wakesync <shadow@shad0w.xyz>