### PR TITLE
fix(cloud): cap app creation per organization

### DIFF
--- a/.github/issue-evidence/10450-app-creation-cap.md
+++ b/.github/issue-evidence/10450-app-creation-cap.md
@@ -1,0 +1,72 @@
+# Issue #10450: per-organization app creation cap
+
+## Scope
+
+This slice covers the remaining local code hardening item from #10450: a
+per-organization app creation cap.
+
+Implemented behavior:
+
+- App creation is limited per organization by `ELIZA_CLOUD_MAX_APPS_PER_ORG`.
+- Invalid or unset `ELIZA_CLOUD_MAX_APPS_PER_ORG` falls back to a conservative
+  default of `25`.
+- `AppsService.create()` checks the cap before creating the one-time app API key.
+- The repository insert path also enforces the cap inside a transaction after
+  locking the organization row, so concurrent creates for the same org serialize
+  before counting and inserting.
+- If a transaction-level cap rejection or insert failure happens after an API key
+  was created, the service deletes that key before returning/throwing.
+- `POST /api/v1/apps` maps the typed cap error to HTTP `429` with
+  `code: "app_creation_limit_reached"` and the configured `limit`.
+
+## Validation
+
+Base commit: `01b3ca36a9 test(bun-runtime): extract + device-test the agent-service selection rule (#9967) (#10466)`
+
+Commands run from `/home/shaw/milady/eliza-issue-10450-app-cap`:
+
+```bash
+bun run install:light
+node packages/shared/scripts/generate-keywords.mjs --target ts
+bun run --cwd packages/contracts build
+bun run --cwd packages/core build:node
+git diff --check
+bunx @biomejs/biome check packages/cloud/shared/src/db/repositories/apps.ts packages/cloud/shared/src/lib/services/apps.ts packages/cloud/api/v1/apps/route.ts packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts packages/cloud/api/__tests__/apps-crud.integration.test.ts
+bun test packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts --reporter=dot
+bun test packages/cloud/api/__tests__/apps-crud.integration.test.ts -t "429 when the organization app creation cap is reached" --reporter=dot
+bun run --cwd packages/cloud/shared typecheck
+bun run --cwd packages/cloud/api typecheck
+```
+
+Observed results:
+
+- Focused Biome: `Checked 5 files in 90ms. No fixes applied.`
+- PGlite-backed apps repository/service suite: `17 pass`, `0 fail`,
+  `74 expect() calls`.
+- Targeted API route cap test: `1 pass`, `38 filtered out`, `0 fail`,
+  `5 expect() calls`.
+- `packages/cloud/shared` typecheck: passed.
+- `packages/cloud/api` typecheck: passed.
+
+## Full-suite note
+
+`bun test packages/cloud/api/__tests__/apps-crud.integration.test.ts --reporter=dot`
+was also attempted. The new cap route branch passed, then the suite failed later
+in the pre-existing `PUT /api/v1/apps/:id` linked-character update case because
+the test touches the real `user_characters` repository/table while this suite
+mocks app storage and does not create that table:
+
+```text
+error: relation "user_characters" does not exist
+Expected: 200
+Received: 500
+```
+
+This failure is unrelated to the app cap path; the targeted create-route test is
+included above for the changed branch.
+
+## Screenshots / Android
+
+N/A. This is Cloud API/backend quota and persistence logic with no app UI or
+native Android surface. The behavior is covered by real-schema PGlite tests, a
+route-level integration test for the HTTP response, and package typechecks.

--- a/packages/cloud/api/__tests__/apps-crud.integration.test.ts
+++ b/packages/cloud/api/__tests__/apps-crud.integration.test.ts
@@ -128,6 +128,7 @@ function makeApp(overrides: Partial<App>): App {
 // ---------------------------------------------------------------------------
 
 const store = new Map<string, App>();
+let createAppLimit: number | null = null;
 
 function slugFor(name: string): string {
   return name
@@ -196,6 +197,18 @@ const createApp = mock(
         `An app with the name "${data.name}" already exists. Please choose a different name.`,
         "app",
         `${data.name}-a1b2`,
+      );
+    }
+
+    if (
+      createAppLimit !== null &&
+      [...store.values()].filter(
+        (a) => a.organization_id === data.organization_id,
+      ).length >= createAppLimit
+    ) {
+      throw new realApps.AppCreationLimitError(
+        data.organization_id,
+        createAppLimit,
       );
     }
 
@@ -430,6 +443,7 @@ const VALID_CREATE = {
 beforeEach(() => {
   store.clear();
   cleanupErrors = [];
+  createAppLimit = null;
   createApp.mockClear();
   updateMonetizationSettings.mockClear();
   deleteAppWithCleanup.mockClear();
@@ -479,6 +493,24 @@ describe("POST /api/v1/apps (create)", () => {
     expect(json.success).toBe(false);
     expect(json.conflictType).toBe("app");
     expect(json.suggestedName).toBe("My Cool App-a1b2");
+  });
+
+  test("429 when the organization app creation cap is reached", async () => {
+    createAppLimit = 1;
+    seed({ name: "Existing", slug: "existing", organization_id: ORG_A });
+
+    const { status, json } = await req("POST", "/api/v1/apps", {
+      key: KEY_A,
+      body: { ...VALID_CREATE, name: "Second App" },
+    });
+
+    expect(status).toBe(429);
+    expect(json.success).toBe(false);
+    expect(json.code).toBe("app_creation_limit_reached");
+    expect(json.limit).toBe(1);
+    expect(
+      [...store.values()].filter((a) => a.organization_id === ORG_A),
+    ).toHaveLength(1);
   });
 
   test("200 happy path defaults to no GitHub repo", async () => {

--- a/packages/cloud/api/__tests__/apps-crud.integration.test.ts
+++ b/packages/cloud/api/__tests__/apps-crud.integration.test.ts
@@ -43,6 +43,7 @@ import * as realAppFactory from "@/lib/services/app-factory";
 // Keep the real modules so afterAll can restore them — bun's `mock.module` is
 // process-global and leaks across files otherwise.
 import * as realApps from "@/lib/services/apps";
+import * as realChars from "@/lib/services/characters/characters";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 import { authMiddleware } from "../src/middleware/auth";
 
@@ -329,6 +330,20 @@ mock.module("@/lib/services/apps", () => ({
   appsService: appsServiceMock,
 }));
 
+// The PUT /apps/:id route validates each linked_character_id via the real
+// charactersService.getById (a DB query) to block cross-tenant character
+// linking. This unit-style suite mocks the apps store, not the DB, so stub the
+// lookup: report every requested character as an owned, public character so the
+// route's existence + ownership guard passes for the happy-path link test. No
+// test asserts a character rejection, so this stays faithful to the route.
+mock.module("@/lib/services/characters/characters", () => ({
+  ...realChars,
+  charactersService: {
+    ...realChars.charactersService,
+    getById: async (id: string) => ({ id, user_id: USER_A, is_public: true }),
+  },
+}));
+
 mock.module("@/lib/services/app-factory", () => ({
   ...realAppFactory,
   appFactoryService: { ...realAppFactory.appFactoryService, createApp },
@@ -358,6 +373,7 @@ const checkNameRoute = (await import("../v1/apps/check-name/route")).default;
 afterAll(() => {
   mock.module("@/lib/auth/workers-hono-auth", () => realAuth);
   mock.module("@/lib/services/apps", () => realApps);
+  mock.module("@/lib/services/characters/characters", () => realChars);
   mock.module("@/lib/services/app-factory", () => realAppFactory);
   mock.module("@/lib/services/app-cleanup", () => realAppCleanup);
   mock.module("@/lib/services/app-credits", () => realAppCredits);

--- a/packages/cloud/api/v1/apps/route.ts
+++ b/packages/cloud/api/v1/apps/route.ts
@@ -11,7 +11,11 @@ import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { appCreditsService } from "@/lib/services/app-credits";
 import { appFactoryService } from "@/lib/services/app-factory";
-import { AppNameConflictError, appsService } from "@/lib/services/apps";
+import {
+  AppCreationLimitError,
+  AppNameConflictError,
+  appsService,
+} from "@/lib/services/apps";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -144,6 +148,21 @@ app.post("/", async (c) => {
             suggestedName: err.suggestedName,
           },
           409,
+        );
+      }
+      if (err instanceof AppCreationLimitError) {
+        logger.warn("[Apps API] App creation limit reached:", {
+          organizationId: err.organizationId,
+          limit: err.limit,
+        });
+        return c.json(
+          {
+            success: false,
+            error: err.message,
+            code: "app_creation_limit_reached",
+            limit: err.limit,
+          },
+          429,
         );
       }
       throw err;

--- a/packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts
@@ -591,6 +591,36 @@ describe("AppsService.isNameAvailable", () => {
 });
 
 describe("AppsService.create organization cap", () => {
+  test("treats malformed cap values as invalid and falls back to the default", async () => {
+    if (!pgliteReady) return;
+    const previousLimit = process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG;
+    process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG = "1abc";
+    try {
+      const { organizationId, userId } = await seedOrgAndUser();
+      await createApp({
+        name: "Existing App",
+        organization_id: organizationId,
+        created_by_user_id: userId,
+      });
+
+      const result = await appsService.create({
+        name: "Allowed By Default Cap",
+        organization_id: organizationId,
+        created_by_user_id: userId,
+        app_url: "https://default-cap.example",
+      });
+
+      expect(result.app.organization_id).toBe(organizationId);
+      expect(await appsRepository.countByOrganization(organizationId)).toBe(2);
+    } finally {
+      if (previousLimit === undefined) {
+        delete process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG;
+      } else {
+        process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG = previousLimit;
+      }
+    }
+  });
+
   test("rejects before API key creation when the org is already at the configured app cap", async () => {
     if (!pgliteReady) return;
     const previousLimit = process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG;
@@ -652,6 +682,42 @@ describe("AppsService.create organization cap", () => {
       expect(apiKey?.organization_id).toBe(organizationId);
       expect(apiKey?.user_id).toBe(userId);
     } finally {
+      if (previousLimit === undefined) {
+        delete process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG;
+      } else {
+        process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG = previousLimit;
+      }
+    }
+  });
+
+  test("cleans up the generated API key when the transactional cap check rejects", async () => {
+    if (!pgliteReady) return;
+    const previousLimit = process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG;
+    const originalCreateIfBelowLimit = appsRepository.createIfOrganizationBelowLimit;
+    process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG = "25";
+    try {
+      const { organizationId, userId } = await seedOrgAndUser();
+      appsRepository.createIfOrganizationBelowLimit = async () => undefined;
+
+      await expect(
+        appsService.create({
+          name: "Race Rejected App",
+          organization_id: organizationId,
+          created_by_user_id: userId,
+          app_url: "https://race-rejected.example",
+        }),
+      ).rejects.toMatchObject({
+        name: "AppCreationLimitError",
+        organizationId,
+        limit: 25,
+      });
+
+      expect(
+        await apiKeysRepository.findByUserAndName(userId, "Race Rejected App - App API Key"),
+      ).toEqual([]);
+      expect(await appsRepository.countByOrganization(organizationId)).toBe(0);
+    } finally {
+      appsRepository.createIfOrganizationBelowLimit = originalCreateIfBelowLimit;
       if (previousLimit === undefined) {
         delete process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG;
       } else {

--- a/packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts
@@ -35,6 +35,7 @@ process.env.MOCK_REDIS = "1";
 import { pushSchema } from "drizzle-kit/api";
 import { eq } from "drizzle-orm";
 import { closeDatabaseConnectionsForTests, dbWrite } from "../../client";
+import { apiKeys } from "../../schemas/api-keys";
 import { appConfig } from "../../schemas/app-config";
 import { appDomains } from "../../schemas/app-domains";
 import {
@@ -47,6 +48,7 @@ import {
 } from "../../schemas/apps";
 import { organizations } from "../../schemas/organizations";
 import { users } from "../../schemas/users";
+import { apiKeysRepository } from "../api-keys";
 import { type App, appsRepository } from "../apps";
 
 const PGLITE_TIMEOUT = 60_000;
@@ -106,6 +108,7 @@ beforeAll(async () => {
     const schema = {
       organizations,
       users,
+      apiKeys,
       apps,
       appUsers,
       appAnalytics,
@@ -584,5 +587,76 @@ describe("AppsService.isNameAvailable", () => {
     const result = await appsService.isNameAvailable(uniq("Service Fresh Name"));
     expect(result.available).toBe(true);
     expect(result.suggestedName).toBeUndefined();
+  });
+});
+
+describe("AppsService.create organization cap", () => {
+  test("rejects before API key creation when the org is already at the configured app cap", async () => {
+    if (!pgliteReady) return;
+    const previousLimit = process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG;
+    process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG = "1";
+    try {
+      const { organizationId, userId } = await seedOrgAndUser();
+      await createApp({
+        name: "Existing App",
+        organization_id: organizationId,
+        created_by_user_id: userId,
+      });
+
+      await expect(
+        appsService.create({
+          name: "Blocked App",
+          organization_id: organizationId,
+          created_by_user_id: userId,
+          app_url: "https://blocked.example",
+        }),
+      ).rejects.toMatchObject({
+        name: "AppCreationLimitError",
+        organizationId,
+        limit: 1,
+      });
+
+      expect(await appsRepository.countByOrganization(organizationId)).toBe(1);
+      expect(
+        await apiKeysRepository.findByUserAndName(userId, "Blocked App - App API Key"),
+      ).toEqual([]);
+    } finally {
+      if (previousLimit === undefined) {
+        delete process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG;
+      } else {
+        process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG = previousLimit;
+      }
+    }
+  });
+
+  test("allows creation below the configured cap and persists the generated API key", async () => {
+    if (!pgliteReady) return;
+    const previousLimit = process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG;
+    process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG = "2";
+    try {
+      const { organizationId, userId } = await seedOrgAndUser();
+
+      const result = await appsService.create({
+        name: "Allowed App",
+        organization_id: organizationId,
+        created_by_user_id: userId,
+        app_url: "https://allowed.example",
+      });
+
+      expect(result.app.organization_id).toBe(organizationId);
+      expect(result.app.api_key_id).toBeTruthy();
+      expect(result.apiKey).toMatch(/^eliza_/);
+      expect(await appsRepository.countByOrganization(organizationId)).toBe(1);
+
+      const apiKey = await apiKeysRepository.findById(result.app.api_key_id ?? "");
+      expect(apiKey?.organization_id).toBe(organizationId);
+      expect(apiKey?.user_id).toBe(userId);
+    } finally {
+      if (previousLimit === undefined) {
+        delete process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG;
+      } else {
+        process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG = previousLimit;
+      }
+    }
   });
 });

--- a/packages/cloud/shared/src/db/repositories/apps.ts
+++ b/packages/cloud/shared/src/db/repositories/apps.ts
@@ -19,6 +19,7 @@ import {
 } from "../schemas";
 import { appConfig } from "../schemas/app-config";
 import { appDomains } from "../schemas/app-domains";
+import { organizations } from "../schemas/organizations";
 
 /**
  * Evict all cache keys derived from the apps table for this row.
@@ -248,6 +249,14 @@ export class AppsRepository {
     });
   }
 
+  async countByOrganization(organizationId: string): Promise<number> {
+    const [row] = await dbRead
+      .select({ count: count() })
+      .from(apps)
+      .where(eq(apps.organization_id, organizationId));
+    return row?.count ?? 0;
+  }
+
   /**
    * Finds an app user by app ID and user ID.
    */
@@ -406,6 +415,32 @@ export class AppsRepository {
   async create(data: NewApp): Promise<App> {
     const [app] = await dbWrite.insert(apps).values(data).returning();
     return app;
+  }
+
+  /**
+   * Creates a new app only if the owning organization is still under its app cap.
+   *
+   * The organization row lock serializes concurrent app creates for one org in
+   * Postgres, so parallel requests cannot all observe the same pre-insert count.
+   */
+  async createIfOrganizationBelowLimit(data: NewApp, maxApps: number): Promise<App | undefined> {
+    return dbWrite.transaction(async (tx) => {
+      await tx.execute(
+        sql`SELECT ${organizations.id} FROM ${organizations} WHERE ${organizations.id} = ${data.organization_id} FOR UPDATE`,
+      );
+
+      const [row] = await tx
+        .select({ count: count() })
+        .from(apps)
+        .where(eq(apps.organization_id, data.organization_id));
+
+      if ((row?.count ?? 0) >= maxApps) {
+        return undefined;
+      }
+
+      const [app] = await tx.insert(apps).values(data).returning();
+      return app;
+    });
   }
 
   /**

--- a/packages/cloud/shared/src/lib/services/apps.ts
+++ b/packages/cloud/shared/src/lib/services/apps.ts
@@ -16,6 +16,24 @@ import { logger } from "../utils/logger";
 import { apiKeysService } from "./api-keys";
 import { managedDomainsService } from "./managed-domains";
 
+const DEFAULT_MAX_APPS_PER_ORG = 25;
+
+function resolveMaxAppsPerOrg(): number {
+  const raw = process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG;
+  if (!raw) return DEFAULT_MAX_APPS_PER_ORG;
+
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    logger.warn("[Apps] Invalid ELIZA_CLOUD_MAX_APPS_PER_ORG; using default", {
+      value: raw,
+      defaultValue: DEFAULT_MAX_APPS_PER_ORG,
+    });
+    return DEFAULT_MAX_APPS_PER_ORG;
+  }
+
+  return parsed;
+}
+
 export class AppNameConflictError extends Error {
   constructor(
     message: string,
@@ -24,6 +42,16 @@ export class AppNameConflictError extends Error {
   ) {
     super(message);
     this.name = "AppNameConflictError";
+  }
+}
+
+export class AppCreationLimitError extends Error {
+  constructor(
+    public readonly organizationId: string,
+    public readonly limit: number,
+  ) {
+    super(`Organization has reached the app creation limit of ${limit}`);
+    this.name = "AppCreationLimitError";
   }
 }
 
@@ -251,6 +279,26 @@ export class AppsService {
     return await appsRepository.listAll(filters);
   }
 
+  async countByOrganization(organizationId: string): Promise<number> {
+    return await appsRepository.countByOrganization(organizationId);
+  }
+
+  async assertCanCreateForOrganization(organizationId: string): Promise<{ limit: number }> {
+    const limit = resolveMaxAppsPerOrg();
+    const currentCount = await appsRepository.countByOrganization(organizationId);
+
+    if (currentCount >= limit) {
+      logger.warn("[Apps] Rejected app create at organization cap", {
+        organizationId,
+        currentCount,
+        limit,
+      });
+      throw new AppCreationLimitError(organizationId, limit);
+    }
+
+    return { limit };
+  }
+
   async create(data: {
     name: string;
     description?: string;
@@ -276,6 +324,8 @@ export class AppsService {
       throw new Error("Failed to generate unique slug");
     }
 
+    const { limit } = await this.assertCanCreateForOrganization(data.organization_id);
+
     const { apiKey, plainKey } = await apiKeysService.create({
       name: `${data.name} - App API Key`,
       description: `API key for app: ${data.name}`,
@@ -284,19 +334,43 @@ export class AppsService {
       rate_limit: 10000,
     });
 
-    const app = await appsRepository.create({
-      name: data.name,
-      description: data.description,
-      slug,
-      organization_id: data.organization_id,
-      created_by_user_id: data.created_by_user_id,
-      app_url: data.app_url,
-      allowed_origins: data.allowed_origins || [data.app_url],
-      api_key_id: apiKey.id,
-      logo_url: data.logo_url,
-      website_url: data.website_url,
-      contact_email: data.contact_email,
-    });
+    let app: App | undefined;
+    try {
+      app = await appsRepository.createIfOrganizationBelowLimit(
+        {
+          name: data.name,
+          description: data.description,
+          slug,
+          organization_id: data.organization_id,
+          created_by_user_id: data.created_by_user_id,
+          app_url: data.app_url,
+          allowed_origins: data.allowed_origins || [data.app_url],
+          api_key_id: apiKey.id,
+          logo_url: data.logo_url,
+          website_url: data.website_url,
+          contact_email: data.contact_email,
+        },
+        limit,
+      );
+    } catch (error) {
+      await apiKeysService.delete(apiKey.id).catch((cleanupError) => {
+        logger.warn("[Apps] Failed to clean up API key after app create failure", {
+          apiKeyId: apiKey.id,
+          error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+        });
+      });
+      throw error;
+    }
+
+    if (!app) {
+      await apiKeysService.delete(apiKey.id).catch((cleanupError) => {
+        logger.warn("[Apps] Failed to clean up API key after app cap rejection", {
+          apiKeyId: apiKey.id,
+          error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+        });
+      });
+      throw new AppCreationLimitError(data.organization_id, limit);
+    }
 
     logger.info(`Created app: ${app.name} (${app.id})`, {
       appId: app.id,

--- a/packages/cloud/shared/src/lib/services/apps.ts
+++ b/packages/cloud/shared/src/lib/services/apps.ts
@@ -22,8 +22,8 @@ function resolveMaxAppsPerOrg(): number {
   const raw = process.env.ELIZA_CLOUD_MAX_APPS_PER_ORG;
   if (!raw) return DEFAULT_MAX_APPS_PER_ORG;
 
-  const parsed = Number.parseInt(raw, 10);
-  if (!Number.isFinite(parsed) || parsed < 1) {
+  const value = raw.trim();
+  if (!/^[1-9]\d*$/.test(value)) {
     logger.warn("[Apps] Invalid ELIZA_CLOUD_MAX_APPS_PER_ORG; using default", {
       value: raw,
       defaultValue: DEFAULT_MAX_APPS_PER_ORG,
@@ -31,7 +31,7 @@ function resolveMaxAppsPerOrg(): number {
     return DEFAULT_MAX_APPS_PER_ORG;
   }
 
-  return parsed;
+  return Number.parseInt(value, 10);
 }
 
 export class AppNameConflictError extends Error {


### PR DESCRIPTION
## Summary
- adds a per-organization app creation cap controlled by `ELIZA_CLOUD_MAX_APPS_PER_ORG` with a default of 25
- checks the cap before creating the app API key, and enforces the insert under an organization row lock to serialize concurrent creates
- cleans up the one-time app API key if a transaction-level cap rejection or insert failure happens after key creation
- maps cap rejections from `POST /api/v1/apps` to HTTP 429 with `code: app_creation_limit_reached`

Covers the per-org app creation cap slice from #10450. Related #10450 slices are still split across PR #10455 for raw app-create repo defaulting and PR #10461 for X-App-Id attribution authorization.

## Evidence
- `.github/issue-evidence/10450-app-creation-cap.md`

## Validation
- `bun run install:light`
- `node packages/shared/scripts/generate-keywords.mjs --target ts`
- `bun run --cwd packages/contracts build`
- `bun run --cwd packages/core build:node`
- `git diff --check`
- focused Biome check over touched files
- `bun test packages/cloud/shared/src/db/repositories/__tests__/apps.test.ts --reporter=dot` (17 pass, 0 fail, 74 assertions)
- `bun test packages/cloud/api/__tests__/apps-crud.integration.test.ts -t "429 when the organization app creation cap is reached" --reporter=dot` (1 pass, 38 filtered, 0 fail, 5 assertions)
- `bun run --cwd packages/cloud/shared typecheck`
- `bun run --cwd packages/cloud/api typecheck`

## Notes
Full `apps-crud.integration.test.ts` was attempted. The new cap route branch passed, then the suite hit an unrelated existing harness failure in the linked-character update case because it queries the real `user_characters` table while this suite mocks app storage and does not create that table. Details are recorded in the evidence note.

Android/screenshots/video are N/A: this is backend Cloud API quota/persistence logic with no app UI or native Android surface.