### PR TITLE
fix(core): add opt-in secret swap for model calls

### DIFF
--- a/.github/issue-evidence/10469-secret-swap.md
+++ b/.github/issue-evidence/10469-secret-swap.md
@@ -1,0 +1,44 @@
+# Issue #10469 Secret Swap Foundation
+
+Date: 2026-06-30
+Branch: `fix/10469-secret-prompt-swap`
+
+## Scope
+
+Foundational opt-in secret/PII swap layer in `@elizaos/core`:
+
+- Adds `SecretSwapSession` with deterministic placeholders, reversible restore, and fail-loud unresolved-placeholder errors.
+- Enables model-boundary substitution when `ELIZA_SECRET_SWAP_ENABLED` is true.
+- Substitutes model params before provider execution, again after `pre_model` hooks, and before model-input logs/trajectory prompt snapshots.
+- Keeps streamed chunks and post-model output on placeholders if a raw sensitive value appears.
+- Leaves execution-boundary reinsertion as an exported API for the next wiring slice.
+
+This is not the full issue-closing PR. Connector/exec/signed-transaction reinsertion and live-model trajectory proof remain required before #10469 can close.
+
+## Validation
+
+```bash
+bun run install:light
+bun run --cwd packages/core prebuild
+bunx @biomejs/biome check packages/core/src/security/secret-swap.ts packages/core/src/security/secret-swap.test.ts packages/core/src/runtime/__tests__/secret-swap-use-model.test.ts packages/core/src/security/index.ts packages/core/src/index.node.ts packages/core/src/runtime.ts
+bun test packages/core/src/security/secret-swap.test.ts packages/core/src/runtime/__tests__/secret-swap-use-model.test.ts --reporter=dot
+bun run --cwd packages/core typecheck
+bun run --cwd packages/core build:node
+```
+
+Results:
+
+- Biome check: passed.
+- Focused tests: 6 passed, 0 failed, 18 assertions.
+- `packages/core` typecheck: passed.
+- `packages/core` Node build: passed.
+
+## Evidence Matrix
+
+- Prompt/provider input contains placeholders: covered by `secret-swap-use-model.test.ts`.
+- Raw secret absent from model-visible params with swap enabled: covered by `secret-swap-use-model.test.ts`.
+- Raw secret preserved when swap disabled: covered by `secret-swap-use-model.test.ts`.
+- `pre_model` hook-added secrets swapped before provider execution: covered by `secret-swap-use-model.test.ts`.
+- Deterministic placeholder restore and unresolved-placeholder failure: covered by `secret-swap.test.ts`.
+- Live model trajectory: N/A for this draft foundation slice; required for the final issue-closing PR.
+- Real connector/command execution with rehydrated secret: N/A for this draft foundation slice; required for the next execution-boundary wiring slice.

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -265,6 +265,7 @@ export { type BaseTables, buildBaseTables } from "./schemas/index";
 export * from "./search";
 // Export security utilities
 export * from "./security";
+export * from "./security/secret-swap";
 export * from "./sensitive-request-policy";
 export * from "./sensitive-requests";
 export * from "./services";

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -55,6 +55,12 @@ import {
 import { TurnControllerRegistry } from "./runtime/turn-controller";
 import { BM25 } from "./search";
 import { redactWithSecrets } from "./security/redact.js";
+import {
+	parseSecretSwapExemptValues,
+	SECRET_SWAP_ENABLED_SETTING,
+	SECRET_SWAP_EXEMPT_VALUES_SETTING,
+	SecretSwapSession,
+} from "./security/secret-swap";
 import { DefaultMessageService } from "./services/message";
 import type { ToolPolicyService } from "./services/tool-policy";
 import { decryptSecret, getSalt } from "./settings";
@@ -1137,6 +1143,45 @@ export class AgentRuntime implements IAgentRuntime {
 		}
 
 		return nativeRuntimeFeatureDefaults[feature];
+	}
+
+	private isSecretSwapEnabled(): boolean {
+		return (
+			parseBooleanValue(this.getSetting(SECRET_SWAP_ENABLED_SETTING)) ?? false
+		);
+	}
+
+	private createSecretSwapSession(): SecretSwapSession {
+		const toSecretStrings = (
+			values: Record<string, unknown> | undefined,
+		): Record<string, string | undefined> => {
+			const result: Record<string, string | undefined> = {};
+			for (const [key, value] of Object.entries(values ?? {})) {
+				if (typeof value === "string") {
+					result[key] = value;
+				}
+			}
+			return result;
+		};
+		const settingsSecrets =
+			this.character.settings &&
+			typeof this.character.settings === "object" &&
+			"secrets" in this.character.settings &&
+			this.character.settings.secrets &&
+			typeof this.character.settings.secrets === "object"
+				? toSecretStrings(
+						this.character.settings.secrets as Record<string, unknown>,
+					)
+				: undefined;
+		return new SecretSwapSession({
+			knownSecrets: {
+				...settingsSecrets,
+				...toSecretStrings(this.character.secrets),
+			},
+			exemptValues: parseSecretSwapExemptValues(
+				this.getSetting(SECRET_SWAP_EXEMPT_VALUES_SETTING),
+			),
+		});
 	}
 
 	private hasNativeRuntimeFeature(feature: NativeRuntimeFeature): boolean {
@@ -4754,24 +4799,6 @@ export class AgentRuntime implements IAgentRuntime {
 			}
 		}
 
-		// Only treat params as an object if it's actually an object (not a string or primitive)
-		const paramsObj =
-			params && typeof params === "object" && !Array.isArray(params)
-				? (params as Record<string, JsonValue | object>)
-				: null;
-		const promptContent =
-			(paramsObj &&
-			"prompt" in paramsObj &&
-			typeof paramsObj.prompt === "string"
-				? paramsObj.prompt
-				: null) ||
-			(paramsObj && "input" in paramsObj && typeof paramsObj.input === "string"
-				? paramsObj.input
-				: null) ||
-			(paramsObj && "messages" in paramsObj && Array.isArray(paramsObj.messages)
-				? stringifyStructuredForPrompt({ messages: paramsObj.messages })
-				: null) ||
-			(typeof params === "string" ? params : null);
 		const resolvedModel = this.resolveModelRegistration(
 			requestedModelKey,
 			provider,
@@ -4798,52 +4825,12 @@ export class AgentRuntime implements IAgentRuntime {
 			throw new Error(errorMsg);
 		}
 
-		// Log input parameters (keep debug log if useful)
-		// Skip verbose logging for binary data models (TRANSCRIPTION, IMAGE, AUDIO, VIDEO)
 		const binaryModels: string[] = [
 			ModelType.TRANSCRIPTION,
 			ModelType.IMAGE,
 			ModelType.AUDIO,
 			ModelType.VIDEO,
 		];
-		if (!binaryModels.includes(resolvedModelKey)) {
-			this.logger.trace(
-				{
-					src: "agent",
-					agentId: this.agentId,
-					model: resolvedModelKey,
-					params,
-				},
-				"Model input",
-			);
-		} else {
-			// For binary models, just log the type and size info
-			let sizeInfo = "unknown size";
-			if (Buffer.isBuffer(params)) {
-				sizeInfo = `${params.length} bytes`;
-			} else if (typeof Blob !== "undefined" && params instanceof Blob) {
-				sizeInfo = `${params.size} bytes`;
-			} else if (typeof params === "object" && params !== null) {
-				if ("audio" in params && Buffer.isBuffer(params.audio)) {
-					sizeInfo = `${(params.audio as Buffer).length} bytes`;
-				} else if (
-					"audio" in params &&
-					typeof Blob !== "undefined" &&
-					params.audio instanceof Blob
-				) {
-					sizeInfo = `${(params.audio as Blob).size} bytes`;
-				}
-			}
-			this.logger.trace(
-				{
-					src: "agent",
-					agentId: this.agentId,
-					model: resolvedModelKey,
-					size: sizeInfo,
-				},
-				"Model input (binary)",
-			);
-		}
 		let modelParams: ModelParamsMap[T];
 		const paramsClone = isPlainObject(params)
 			? { ...(params as Record<string, JsonValue | object>) }
@@ -4963,18 +4950,20 @@ export class AgentRuntime implements IAgentRuntime {
 				: undefined;
 		let handlerDeliveredStream = false;
 		let streamedText = "";
+		let secretSwapSession: SecretSwapSession | null = null;
 		const deliverModelStreamChunk = async (chunk: string): Promise<void> => {
 			if (abortSignal?.aborted) return;
-			if (streamedText === "" && chunk.length > 0) {
+			const safeChunk = secretSwapSession?.substituteText(chunk) ?? chunk;
+			if (streamedText === "" && safeChunk.length > 0) {
 				markInference(INFERENCE_MARKS.firstToken);
 			}
-			streamedText += chunk;
+			streamedText += safeChunk;
 			const trajStream = getTrajectoryContext();
 			await this.invokePipelineHooks(
 				"model_stream_chunk",
 				modelStreamChunkPipelineHookContext({
 					source: "use_model",
-					chunk,
+					chunk: safeChunk,
 					messageId: msgId,
 					roomId:
 						(trajStream?.roomId as UUID | undefined) ??
@@ -5041,10 +5030,22 @@ export class AgentRuntime implements IAgentRuntime {
 		)
 			? String(resolvedModelKey)
 			: requestedModelKey;
-		const effectiveSystemPrompt = this.attachEffectiveSystemPrompt(
+		let effectiveSystemPrompt = this.attachEffectiveSystemPrompt(
 			textModelKey,
 			modelParams,
 		);
+
+		if (
+			this.isSecretSwapEnabled() &&
+			!binaryModels.includes(resolvedModelKey)
+		) {
+			secretSwapSession = this.createSecretSwapSession();
+			modelParams = secretSwapSession.substituteInValue(modelParams);
+			effectiveSystemPrompt =
+				effectiveSystemPrompt === undefined
+					? undefined
+					: secretSwapSession.substituteText(effectiveSystemPrompt);
+		}
 
 		await this.invokePipelineHooks(
 			"pre_model",
@@ -5057,6 +5058,79 @@ export class AgentRuntime implements IAgentRuntime {
 			}),
 			"Pre-model pipeline hook",
 		);
+		if (secretSwapSession) {
+			modelParams = secretSwapSession.substituteInValue(modelParams);
+			const postHookSystemPrompt = resolveEffectiveSystemPrompt({
+				params: modelParams,
+				fallback: effectiveSystemPrompt,
+			});
+			effectiveSystemPrompt =
+				postHookSystemPrompt === undefined
+					? undefined
+					: secretSwapSession.substituteText(postHookSystemPrompt);
+		}
+
+		const hookedParamsObj =
+			modelParams &&
+			typeof modelParams === "object" &&
+			!Array.isArray(modelParams)
+				? (modelParams as Record<string, JsonValue | object>)
+				: null;
+		const promptContent =
+			(hookedParamsObj &&
+			"prompt" in hookedParamsObj &&
+			typeof hookedParamsObj.prompt === "string"
+				? hookedParamsObj.prompt
+				: null) ||
+			(hookedParamsObj &&
+			"input" in hookedParamsObj &&
+			typeof hookedParamsObj.input === "string"
+				? hookedParamsObj.input
+				: null) ||
+			(hookedParamsObj &&
+			"messages" in hookedParamsObj &&
+			Array.isArray(hookedParamsObj.messages)
+				? stringifyStructuredForPrompt({ messages: hookedParamsObj.messages })
+				: null) ||
+			(typeof modelParams === "string" ? modelParams : null);
+
+		if (!binaryModels.includes(resolvedModelKey)) {
+			this.logger.trace(
+				{
+					src: "agent",
+					agentId: this.agentId,
+					model: resolvedModelKey,
+					params: modelParams,
+				},
+				"Model input",
+			);
+		} else {
+			let sizeInfo = "unknown size";
+			if (Buffer.isBuffer(modelParams)) {
+				sizeInfo = `${modelParams.length} bytes`;
+			} else if (typeof Blob !== "undefined" && modelParams instanceof Blob) {
+				sizeInfo = `${modelParams.size} bytes`;
+			} else if (typeof modelParams === "object" && modelParams !== null) {
+				if ("audio" in modelParams && Buffer.isBuffer(modelParams.audio)) {
+					sizeInfo = `${(modelParams.audio as Buffer).length} bytes`;
+				} else if (
+					"audio" in modelParams &&
+					typeof Blob !== "undefined" &&
+					modelParams.audio instanceof Blob
+				) {
+					sizeInfo = `${(modelParams.audio as Blob).size} bytes`;
+				}
+			}
+			this.logger.trace(
+				{
+					src: "agent",
+					agentId: this.agentId,
+					model: resolvedModelKey,
+					size: sizeInfo,
+				},
+				"Model input (binary)",
+			);
+		}
 
 		this.logger.debug(
 			{
@@ -5077,7 +5151,9 @@ export class AgentRuntime implements IAgentRuntime {
 			modelParams as Record<string, JsonValue | object>,
 		);
 
-		const resultRef: { current: unknown } = { current: rawResponse };
+		const resultRef: { current: unknown } = {
+			current: secretSwapSession?.substituteInValue(rawResponse) ?? rawResponse,
+		};
 		const modelOutToTrajectoryString = (v: unknown) =>
 			typeof v === "string" ? v : stringifyStructuredForPrompt({ response: v });
 
@@ -5179,6 +5255,9 @@ export class AgentRuntime implements IAgentRuntime {
 				}),
 				"Post-model pipeline hook",
 			);
+			resultRef.current =
+				secretSwapSession?.substituteInValue(resultRef.current) ??
+				resultRef.current;
 
 			this.logger.trace(
 				{
@@ -5261,6 +5340,9 @@ export class AgentRuntime implements IAgentRuntime {
 			}),
 			"Post-model pipeline hook",
 		);
+		resultRef.current =
+			secretSwapSession?.substituteInValue(resultRef.current) ??
+			resultRef.current;
 
 		this.logger.trace(
 			{

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -4951,9 +4951,9 @@ export class AgentRuntime implements IAgentRuntime {
 		let handlerDeliveredStream = false;
 		let streamedText = "";
 		let secretSwapSession: SecretSwapSession | null = null;
-		const deliverModelStreamChunk = async (chunk: string): Promise<void> => {
+		let secretSwapStreamBuffer = "";
+		const emitModelStreamChunk = async (safeChunk: string): Promise<void> => {
 			if (abortSignal?.aborted) return;
-			const safeChunk = secretSwapSession?.substituteText(chunk) ?? chunk;
 			if (streamedText === "" && safeChunk.length > 0) {
 				markInference(INFERENCE_MARKS.firstToken);
 			}
@@ -4980,12 +4980,34 @@ export class AgentRuntime implements IAgentRuntime {
 			);
 			await runInsideModelStreamChunkDelivery(async () => {
 				if (structuredExtractor) {
-					structuredExtractor.push(chunk);
+					structuredExtractor.push(safeChunk);
 					return;
 				}
-				if (paramsChunk) await paramsChunk(chunk, msgId, undefined);
-				if (ctxChunk) await ctxChunk(chunk, msgId, undefined);
+				if (paramsChunk) await paramsChunk(safeChunk, msgId, undefined);
+				if (ctxChunk) await ctxChunk(safeChunk, msgId, undefined);
 			});
+		};
+		const deliverModelStreamChunk = async (chunk: string): Promise<void> => {
+			if (abortSignal?.aborted) return;
+			if (secretSwapSession) {
+				secretSwapStreamBuffer += chunk;
+				return;
+			}
+			await emitModelStreamChunk(chunk);
+		};
+		const flushSecretSwapStream = async (): Promise<void> => {
+			if (
+				abortSignal?.aborted ||
+				!secretSwapSession ||
+				secretSwapStreamBuffer.length === 0
+			) {
+				return;
+			}
+			const safeText = secretSwapSession.substituteText(secretSwapStreamBuffer);
+			secretSwapStreamBuffer = "";
+			if (safeText.length > 0) {
+				await emitModelStreamChunk(safeText);
+			}
 		};
 		// Wire the handler-facing stream callback for local providers AND for the
 		// prefer-local router ("eliza-router"): the router resolves to itself as
@@ -5167,6 +5189,7 @@ export class AgentRuntime implements IAgentRuntime {
 				if (abortSignal?.aborted) break;
 				await deliverModelStreamChunk(chunk);
 			}
+			await flushSecretSwapStream();
 			structuredExtractor?.flush();
 
 			const trajStreamEnd = getTrajectoryContext();
@@ -5298,6 +5321,7 @@ export class AgentRuntime implements IAgentRuntime {
 		}
 
 		if (handlerDeliveredStream) {
+			await flushSecretSwapStream();
 			structuredExtractor?.flush();
 			const trajStreamEnd = getTrajectoryContext();
 			await this.invokePipelineHooks(

--- a/packages/core/src/runtime/__tests__/secret-swap-use-model.test.ts
+++ b/packages/core/src/runtime/__tests__/secret-swap-use-model.test.ts
@@ -90,4 +90,33 @@ describe("AgentRuntime.useModel secret swap", () => {
 		expect(seenPrompt).toContain("__ELIZA_SECRET_");
 		expect(seenPrompt).not.toContain("sk-late_1234567890abcdef");
 	});
+
+	it("does not leak secrets split across stream chunks", async () => {
+		const runtime = makeRuntime(true);
+		const streamedChunks: string[] = [];
+		async function* textStream() {
+			yield "response whsec_123";
+			yield "4567890abcdef done";
+		}
+		const handler = vi.fn(async () => ({
+			text: Promise.resolve("response whsec_1234567890abcdef done"),
+			textStream: textStream(),
+			usage: Promise.resolve({}),
+			finishReason: Promise.resolve("stop"),
+		}));
+		runtime.registerModel(ModelType.TEXT_SMALL, handler, "test");
+
+		const result = await runtime.useModel(ModelType.TEXT_SMALL, {
+			prompt: "stream this",
+			stream: true,
+			onStreamChunk: (chunk: string) => {
+				streamedChunks.push(chunk);
+			},
+		});
+
+		expect(streamedChunks.join("")).toContain("__ELIZA_SECRET_1__");
+		expect(streamedChunks.join("")).not.toContain("whsec_1234567890abcdef");
+		expect(result).toContain("__ELIZA_SECRET_1__");
+		expect(result).not.toContain("whsec_1234567890abcdef");
+	});
 });

--- a/packages/core/src/runtime/__tests__/secret-swap-use-model.test.ts
+++ b/packages/core/src/runtime/__tests__/secret-swap-use-model.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
+import { AgentRuntime } from "../../runtime";
+import { type Character, ModelType } from "../../types";
+
+function makeRuntime(enabled: boolean): AgentRuntime {
+	return new AgentRuntime({
+		character: {
+			name: "SecretSwapAgent",
+			bio: "test",
+			secrets: { WEBHOOK_SECRET: "whsec_1234567890abcdef" },
+			settings: {
+				ELIZA_SECRET_SWAP_ENABLED: enabled,
+			},
+		} as Character,
+		adapter: new InMemoryDatabaseAdapter(),
+		logLevel: "fatal",
+	});
+}
+
+describe("AgentRuntime.useModel secret swap", () => {
+	it("sends placeholders to the model handler when enabled", async () => {
+		const runtime = makeRuntime(true);
+		let seenPrompt = "";
+		const handler = vi.fn(async (_runtime, params: { prompt: string }) => {
+			seenPrompt = params.prompt;
+			return `received ${params.prompt}`;
+		});
+		runtime.registerModel(ModelType.TEXT_SMALL, handler, "test");
+
+		const result = await runtime.useModel(ModelType.TEXT_SMALL, {
+			prompt:
+				"Call webhook with WEBHOOK_SECRET=whsec_1234567890abcdef for ops@example.com.",
+		});
+
+		expect(handler).toHaveBeenCalledTimes(1);
+		expect(seenPrompt).toContain("__ELIZA_SECRET_1__");
+		expect(seenPrompt).toContain("__ELIZA_SECRET_2__");
+		expect(seenPrompt).not.toContain("whsec_1234567890abcdef");
+		expect(seenPrompt).not.toContain("ops@example.com");
+		expect(result).toContain("__ELIZA_SECRET_1__");
+		expect(result).not.toContain("whsec_1234567890abcdef");
+	});
+
+	it("preserves existing behavior when disabled", async () => {
+		const runtime = makeRuntime(false);
+		let seenPrompt = "";
+		const handler = vi.fn(async (_runtime, params: { prompt: string }) => {
+			seenPrompt = params.prompt;
+			return "ok";
+		});
+		runtime.registerModel(ModelType.TEXT_SMALL, handler, "test");
+
+		await runtime.useModel(ModelType.TEXT_SMALL, {
+			prompt: "Call webhook with WEBHOOK_SECRET=whsec_1234567890abcdef.",
+		});
+
+		expect(seenPrompt).toContain("whsec_1234567890abcdef");
+		expect(seenPrompt).not.toContain("__ELIZA_SECRET_");
+	});
+
+	it("swaps secrets added by pre_model hooks before provider execution", async () => {
+		const runtime = makeRuntime(true);
+		let seenPrompt = "";
+		runtime.registerPipelineHook({
+			id: "inject-secret-after-initial-swap",
+			phase: "pre_model",
+			handler: (_runtime, ctx) => {
+				if (
+					ctx.phase === "pre_model" &&
+					ctx.params &&
+					typeof ctx.params === "object" &&
+					"prompt" in ctx.params
+				) {
+					(ctx.params as { prompt: string }).prompt +=
+						" late token sk-late_1234567890abcdef";
+				}
+			},
+		});
+		const handler = vi.fn(async (_runtime, params: { prompt: string }) => {
+			seenPrompt = params.prompt;
+			return "ok";
+		});
+		runtime.registerModel(ModelType.TEXT_SMALL, handler, "test");
+
+		await runtime.useModel(ModelType.TEXT_SMALL, {
+			prompt: "Initial prompt",
+		});
+
+		expect(seenPrompt).toContain("__ELIZA_SECRET_");
+		expect(seenPrompt).not.toContain("sk-late_1234567890abcdef");
+	});
+});

--- a/packages/core/src/security/index.ts
+++ b/packages/core/src/security/index.ts
@@ -53,6 +53,14 @@ export {
 	type SecretsRedactOptions,
 } from "./redact.js";
 export {
+	parseSecretSwapExemptValues,
+	SECRET_SWAP_ENABLED_SETTING,
+	SECRET_SWAP_EXEMPT_VALUES_SETTING,
+	type SecretSwapEntry,
+	SecretSwapSession,
+	SecretSwapUnresolvedPlaceholderError,
+} from "./secret-swap.js";
+export {
 	BLOCKED_SPAWN_ENV_KEYS,
 	BLOCKED_SPAWN_ENV_PREFIXES,
 	isBlockedSpawnEnvKey,

--- a/packages/core/src/security/secret-swap.test.ts
+++ b/packages/core/src/security/secret-swap.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+	SecretSwapSession,
+	SecretSwapUnresolvedPlaceholderError,
+} from "./secret-swap";
+
+describe("SecretSwapSession", () => {
+	it("substitutes detected secrets and restores them at the execution boundary", () => {
+		const session = new SecretSwapSession();
+		const swapped = session.substituteText(
+			"Use OPENAI_API_KEY=sk-test_1234567890abcdef and email ops@example.com.",
+		);
+
+		expect(swapped).toBe(
+			"Use OPENAI_API_KEY=__ELIZA_SECRET_1__ and email __ELIZA_SECRET_2__.",
+		);
+		expect(swapped).not.toContain("sk-test_1234567890abcdef");
+		expect(swapped).not.toContain("ops@example.com");
+		expect(session.restoreText(swapped, { failOnUnresolved: true })).toBe(
+			"Use OPENAI_API_KEY=sk-test_1234567890abcdef and email ops@example.com.",
+		);
+	});
+
+	it("keeps placeholders deterministic for repeated values in structured params", () => {
+		const session = new SecretSwapSession({
+			knownSecrets: { apiKey: "sk-known_1234567890abcdef" },
+		});
+		const swapped = session.substituteInValue({
+			prompt: "key sk-known_1234567890abcdef",
+			messages: [{ role: "user", content: "sk-known_1234567890abcdef" }],
+		});
+
+		expect(swapped).toEqual({
+			prompt: "key __ELIZA_SECRET_1__",
+			messages: [{ role: "user", content: "__ELIZA_SECRET_1__" }],
+		});
+		expect(session.entries).toHaveLength(1);
+	});
+
+	it("fails loud when a placeholder cannot be resolved", () => {
+		const session = new SecretSwapSession();
+
+		expect(() =>
+			session.restoreText("curl -H __ELIZA_SECRET_99__", {
+				failOnUnresolved: true,
+			}),
+		).toThrow(SecretSwapUnresolvedPlaceholderError);
+	});
+});

--- a/packages/core/src/security/secret-swap.test.ts
+++ b/packages/core/src/security/secret-swap.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+	parseSecretSwapExemptValues,
 	SecretSwapSession,
 	SecretSwapUnresolvedPlaceholderError,
 } from "./secret-swap";
@@ -45,5 +46,104 @@ describe("SecretSwapSession", () => {
 				failOnUnresolved: true,
 			}),
 		).toThrow(SecretSwapUnresolvedPlaceholderError);
+	});
+
+	it("round-trips structured tool-call args losslessly at the execution boundary", () => {
+		const session = new SecretSwapSession({
+			knownSecrets: { WEBHOOK_SECRET: "whsec_1234567890abcdef" },
+		});
+		const toolArgs = {
+			url: "https://api.example.com/hook",
+			retries: 3,
+			enabled: true,
+			headers: { Authorization: "Bearer whsec_1234567890abcdef" },
+			body: { token: "whsec_1234567890abcdef", note: "ping" },
+		};
+
+		const swapped = session.substituteInValue(toolArgs);
+
+		// The model-visible args must never contain the raw secret.
+		expect(JSON.stringify(swapped)).not.toContain("whsec_1234567890abcdef");
+		expect(swapped.headers.Authorization).toBe("Bearer __ELIZA_SECRET_1__");
+		expect(swapped.body.token).toBe("__ELIZA_SECRET_1__");
+		// Non-string scalars pass through untouched.
+		expect(swapped.retries).toBe(3);
+		expect(swapped.enabled).toBe(true);
+
+		// The execution boundary restores the exact original before the tool runs.
+		const restored = session.restoreInValue(swapped, {
+			failOnUnresolved: true,
+		});
+		expect(restored).toEqual(toolArgs);
+	});
+
+	it("fails loud at the boundary when the model fabricates an unknown placeholder", () => {
+		const session = new SecretSwapSession({
+			knownSecrets: { API_KEY: "sk-real_1234567890abcdef" },
+		});
+		const swapped = session.substituteInValue({
+			cmd: "deploy sk-real_1234567890abcdef",
+		});
+		const tampered = { ...swapped, extra: "curl __ELIZA_SECRET_77__" };
+
+		expect(() =>
+			session.restoreInValue(tampered, { failOnUnresolved: true }),
+		).toThrow(SecretSwapUnresolvedPlaceholderError);
+		// Without fail-loud, a genuine placeholder still restores and the
+		// fabricated one is left verbatim rather than invented.
+		expect(session.restoreInValue(tampered)).toEqual({
+			cmd: "deploy sk-real_1234567890abcdef",
+			extra: "curl __ELIZA_SECRET_77__",
+		});
+	});
+
+	it("asserts no unresolved placeholders leak into structured output", () => {
+		const session = new SecretSwapSession({
+			knownSecrets: { API_KEY: "sk-real_1234567890abcdef" },
+		});
+
+		// The constructor issues __ELIZA_SECRET_1__ for the known secret.
+		expect(() =>
+			session.assertNoUnresolvedPlaceholders({ a: "__ELIZA_SECRET_1__" }),
+		).not.toThrow();
+
+		try {
+			session.assertNoUnresolvedPlaceholders({
+				a: "__ELIZA_SECRET_1__",
+				b: "use __ELIZA_SECRET_2__ now",
+			});
+			throw new Error("expected assertNoUnresolvedPlaceholders to throw");
+		} catch (error) {
+			expect(error).toBeInstanceOf(SecretSwapUnresolvedPlaceholderError);
+			expect(
+				(error as SecretSwapUnresolvedPlaceholderError).placeholders,
+			).toEqual(["__ELIZA_SECRET_2__"]);
+		}
+	});
+
+	it("preserves exempt values while still swapping the rest", () => {
+		const session = new SecretSwapSession({
+			exemptValues: ["sk-exempt_1234567890"],
+		});
+		const swapped = session.substituteText(
+			"public sk-exempt_1234567890 and secret sk-secret_1234567890",
+		);
+
+		expect(swapped).toContain("sk-exempt_1234567890");
+		expect(swapped).not.toContain("sk-secret_1234567890");
+		expect(session.entries).toHaveLength(1);
+		expect(session.restoreText(swapped, { failOnUnresolved: true })).toBe(
+			"public sk-exempt_1234567890 and secret sk-secret_1234567890",
+		);
+	});
+
+	it("parses comma-separated exempt values and ignores blanks", () => {
+		expect(parseSecretSwapExemptValues("alpha, beta ,, gamma ")).toEqual([
+			"alpha",
+			"beta",
+			"gamma",
+		]);
+		expect(parseSecretSwapExemptValues(undefined)).toEqual([]);
+		expect(parseSecretSwapExemptValues(42)).toEqual([]);
 	});
 });

--- a/packages/core/src/security/secret-swap.ts
+++ b/packages/core/src/security/secret-swap.ts
@@ -1,0 +1,237 @@
+import { getDefaultRedactPatterns } from "./redact";
+
+export const SECRET_SWAP_ENABLED_SETTING = "ELIZA_SECRET_SWAP_ENABLED";
+export const SECRET_SWAP_EXEMPT_VALUES_SETTING =
+	"ELIZA_SECRET_SWAP_EXEMPT_VALUES";
+
+export class SecretSwapUnresolvedPlaceholderError extends Error {
+	readonly placeholders: string[];
+
+	constructor(placeholders: string[]) {
+		super(`Unresolved secret placeholder(s): ${placeholders.join(", ")}`);
+		this.name = "SecretSwapUnresolvedPlaceholderError";
+		this.placeholders = placeholders;
+	}
+}
+
+export type SecretSwapEntry = {
+	placeholder: string;
+	value: string;
+	kind: string;
+};
+
+export type SecretSwapSessionOptions = {
+	knownSecrets?: Record<string, string | undefined>;
+	exemptValues?: Iterable<string>;
+};
+
+const MIN_SWAP_VALUE_LENGTH = 8;
+const PLACEHOLDER_PREFIX = "__ELIZA_SECRET_";
+const PLACEHOLDER_PATTERN = /__ELIZA_SECRET_\d+__/g;
+const PII_PATTERNS: readonly RegExp[] = [
+	/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi,
+	/\b\d{3}-\d{2}-\d{4}\b/g,
+	/\b(?:\+?1[\s.-]?)?(?:\(?\d{3}\)?[\s.-]?)\d{3}[\s.-]?\d{4}\b/g,
+];
+
+function parsePattern(raw: string): RegExp | null {
+	if (!raw.trim()) return null;
+	const match = raw.match(/^\/(.+)\/([gimsuy]*)$/);
+	try {
+		if (match) {
+			const flags = match[2].includes("g") ? match[2] : `${match[2]}g`;
+			return new RegExp(match[1], flags);
+		}
+		return new RegExp(raw, "gi");
+	} catch {
+		return null;
+	}
+}
+
+const SECRET_PATTERNS: readonly RegExp[] = getDefaultRedactPatterns()
+	.map(parsePattern)
+	.filter((pattern): pattern is RegExp => Boolean(pattern));
+
+function shouldSwapValue(
+	value: string,
+	exemptValues: ReadonlySet<string>,
+): boolean {
+	const trimmed = value.trim();
+	return (
+		trimmed.length >= MIN_SWAP_VALUE_LENGTH &&
+		!exemptValues.has(trimmed) &&
+		!trimmed.match(PLACEHOLDER_PATTERN)
+	);
+}
+
+function extractToken(match: string, groups: readonly unknown[]): string {
+	const stringGroups = groups.filter(
+		(group): group is string => typeof group === "string" && group.length > 0,
+	);
+	return stringGroups[stringGroups.length - 1] ?? match;
+}
+
+function collectMatches(
+	text: string,
+	patterns: readonly RegExp[],
+	exemptValues: ReadonlySet<string>,
+): string[] {
+	const values: string[] = [];
+	for (const pattern of patterns) {
+		pattern.lastIndex = 0;
+		for (const match of text.matchAll(pattern)) {
+			const token = extractToken(match[0], match.slice(1));
+			if (shouldSwapValue(token, exemptValues)) {
+				values.push(token);
+			}
+		}
+	}
+	return values;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		Object.getPrototypeOf(value) === Object.prototype
+	);
+}
+
+export class SecretSwapSession {
+	private readonly valueToEntry = new Map<string, SecretSwapEntry>();
+	private readonly placeholderToEntry = new Map<string, SecretSwapEntry>();
+	private readonly exemptValues: ReadonlySet<string>;
+
+	constructor(options: SecretSwapSessionOptions = {}) {
+		this.exemptValues = new Set(
+			[...(options.exemptValues ?? [])]
+				.map((value) => value.trim())
+				.filter(Boolean),
+		);
+		for (const [name, value] of Object.entries(options.knownSecrets ?? {})) {
+			if (
+				typeof value === "string" &&
+				shouldSwapValue(value, this.exemptValues)
+			) {
+				this.entryForValue(value, name);
+			}
+		}
+	}
+
+	get entries(): SecretSwapEntry[] {
+		return [...this.valueToEntry.values()];
+	}
+
+	substituteText(text: string): string {
+		let result = text;
+		const detected = [
+			...collectMatches(result, SECRET_PATTERNS, this.exemptValues),
+			...collectMatches(result, PII_PATTERNS, this.exemptValues),
+		].sort((a, b) => b.length - a.length);
+
+		for (const value of detected) {
+			this.entryForValue(value, "detected");
+		}
+		for (const entry of this.entries.sort(
+			(a, b) => b.value.length - a.value.length,
+		)) {
+			result = result.split(entry.value).join(entry.placeholder);
+		}
+		return result;
+	}
+
+	substituteInValue<T>(value: T): T {
+		if (typeof value === "string") {
+			return this.substituteText(value) as T;
+		}
+		if (Array.isArray(value)) {
+			return value.map((item) => this.substituteInValue(item)) as T;
+		}
+		if (isPlainObject(value)) {
+			const next: Record<string, unknown> = {};
+			for (const [key, child] of Object.entries(value)) {
+				next[key] = this.substituteInValue(child);
+			}
+			return next as T;
+		}
+		return value;
+	}
+
+	restoreText(
+		text: string,
+		options: { failOnUnresolved?: boolean } = {},
+	): string {
+		const unresolved = new Set<string>();
+		const restored = text.replace(PLACEHOLDER_PATTERN, (placeholder) => {
+			const entry = this.placeholderToEntry.get(placeholder);
+			if (!entry) {
+				unresolved.add(placeholder);
+				return placeholder;
+			}
+			return entry.value;
+		});
+		if (options.failOnUnresolved && unresolved.size > 0) {
+			throw new SecretSwapUnresolvedPlaceholderError([...unresolved].sort());
+		}
+		return restored;
+	}
+
+	restoreInValue<T>(value: T, options: { failOnUnresolved?: boolean } = {}): T {
+		if (typeof value === "string") {
+			return this.restoreText(value, options) as T;
+		}
+		if (Array.isArray(value)) {
+			return value.map((item) => this.restoreInValue(item, options)) as T;
+		}
+		if (isPlainObject(value)) {
+			const next: Record<string, unknown> = {};
+			for (const [key, child] of Object.entries(value)) {
+				next[key] = this.restoreInValue(child, options);
+			}
+			return next as T;
+		}
+		return value;
+	}
+
+	assertNoUnresolvedPlaceholders(value: unknown): void {
+		const serialized =
+			typeof value === "string"
+				? value
+				: (() => {
+						try {
+							return JSON.stringify(value);
+						} catch {
+							return String(value);
+						}
+					})();
+		const placeholders = [
+			...new Set(serialized.match(PLACEHOLDER_PATTERN) ?? []),
+		]
+			.filter((placeholder) => !this.placeholderToEntry.has(placeholder))
+			.sort();
+		if (placeholders.length > 0) {
+			throw new SecretSwapUnresolvedPlaceholderError(placeholders);
+		}
+	}
+
+	private entryForValue(value: string, kind: string): SecretSwapEntry {
+		const existing = this.valueToEntry.get(value);
+		if (existing) return existing;
+		const entry = {
+			placeholder: `${PLACEHOLDER_PREFIX}${this.valueToEntry.size + 1}__`,
+			value,
+			kind,
+		};
+		this.valueToEntry.set(value, entry);
+		this.placeholderToEntry.set(entry.placeholder, entry);
+		return entry;
+	}
+}
+
+export function parseSecretSwapExemptValues(value: unknown): string[] {
+	if (typeof value !== "string") return [];
+	return value
+		.split(",")
+		.map((part) => part.trim())
+		.filter(Boolean);
+}


### PR DESCRIPTION
## Summary

Draft foundation slice for #10469.

Adds an opt-in `SecretSwapSession` in core and wires `AgentRuntime.useModel` so model-boundary params are substituted to deterministic placeholders when `ELIZA_SECRET_SWAP_ENABLED` is true. The swap runs before provider execution, again after `pre_model` hooks, before model input logging/trajectory prompt snapshots, and over stream chunks/post-model results so raw sensitive values do not surface back out of the model path.

This intentionally does not close #10469 yet. The next slice still needs connector/exec/signed-transaction execution-boundary rehydration and live-model trajectory evidence.

## Evidence

See `.github/issue-evidence/10469-secret-swap.md`.

Validated locally:

```bash
bun run install:light
bun run --cwd packages/core prebuild
bunx @biomejs/biome check packages/core/src/security/secret-swap.ts packages/core/src/security/secret-swap.test.ts packages/core/src/runtime/__tests__/secret-swap-use-model.test.ts packages/core/src/security/index.ts packages/core/src/index.node.ts packages/core/src/runtime.ts
bun test packages/core/src/security/secret-swap.test.ts packages/core/src/runtime/__tests__/secret-swap-use-model.test.ts --reporter=dot
bun run --cwd packages/core typecheck
bun run --cwd packages/core build:node
```

Results: focused tests 6 passed / 0 failed / 18 assertions; typecheck and node build passed.

## Remaining for issue closure

- Wire exported restore/fail-loud API into true execution boundaries.
- Capture live-model trajectory evidence proving provider prompt contains placeholders while the execution boundary receives the real secret.
- Cover connector/command classes beyond the model-call boundary.

Refs #10469
