### PR TITLE
ci(#9142): wire the frame-glitch transient harness into CI

### DIFF
--- a/.github/workflows/chat-shell-gestures.yml
+++ b/.github/workflows/chat-shell-gestures.yml
@@ -109,6 +109,21 @@ jobs:
       - name: Chat overlay perf gate
         run: bun run --cwd packages/ui test:chat-perf-gate
 
+      # #9142 Part 2: capture a dense CDP frame burst across the pill→open spring
+      # (animations ON) and run the single-frame-flash + two-pills-crossfade
+      # detectors. The harness was merged (#10356/#10374) but ran in NO workflow,
+      # so a transient glitch could still ship. Run under bun (resolves the
+      # esbuild/pixelmatch/pngjs deps directly, regardless of the node-run
+      # portability fallback in #10400).
+      - name: Frame-glitch (transient) e2e
+        run: bun packages/ui/src/components/shell/__e2e__/run-chat-sheet-frame-glitch-e2e.mjs
+
+      # Self-test: --canary injects a one-frame wrong state and asserts the
+      # detectors FIRE on it; the harness exits 0 iff they do (and non-zero if it
+      # has gone blind). This guards against the detectors silently degrading.
+      - name: Frame-glitch canary self-test
+        run: bun packages/ui/src/components/shell/__e2e__/run-chat-sheet-frame-glitch-e2e.mjs --canary
+
       - name: Upload gesture videos + screenshots
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
@@ -119,5 +134,6 @@ jobs:
             packages/ui/src/components/shell/__e2e__/output/
             packages/ui/src/components/shell/__e2e__/output-chatux/
             packages/ui/src/components/shell/__e2e__/output-perf-gate/
+            packages/ui/src/components/shell/__e2e__/output-frame-glitch/
           if-no-files-found: warn
           retention-days: 14


### PR DESCRIPTION
Closes the last open AC of #9142 Part 2.

## Why
The single-frame-flash + two-pills-crossfade harness `run-chat-sheet-frame-glitch-e2e.mjs` was built and merged (#10356/#10374) but **ran in no workflow** — so a transient one-frame glitch in the chat overlay could still ship undetected. #9142's checklist explicitly asks to "wire into CI on packages/ui shell-component changes (mirror ui-story-gate.yml)."

## What
Two steps added to the existing, packages/ui-path-gated `chat-shell-gestures` lane (which already runs the sibling chat e2e harnesses):
- **Frame-glitch (transient) e2e** — drives the pill→open spring with animations ON, captures a dense CDP frame burst, runs the flash + crossfade detectors.
- **Frame-glitch canary self-test** — `--canary` injects a one-frame wrong state and the harness asserts the detectors **fire** on it (exits 0 iff they do), guarding against the detectors silently going blind.

Plus the `output-frame-glitch/` artifacts are uploaded with the other gesture artifacts.

## Notes
- Runs the harness directly under **bun**, which resolves `esbuild`/`pixelmatch`/`pngjs` without needing the node-run portability fallback in #10400 — so this lane is green today, independent of that PR.
- Verified locally on this branch: normal mode **PASS** (34 frames, 0 single-frame flashes, worst two-pills overlap 0.000); `--canary` fires the flash detector **3/3 runs**.
- Caught while wiring: the merged harness's `--canary` mode asserts-and-exits-0-on-success (inversion is internal), so the step is a plain run — an external `if/invert` would have failed CI on every successful canary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)