### PR TITLE
test(mcp): cover the JSON extraction + schema validation utils (#8801, #9943)

### DIFF
--- a/plugins/plugin-mcp/src/utils/__tests__/json.test.ts
+++ b/plugins/plugin-mcp/src/utils/__tests__/json.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseJSON,
+  parseStructuredModelOutput,
+  validateJsonSchema,
+} from "../json";
+
+/**
+ * Tests for the MCP JSON utilities (#8801 / #9943). `parseJSON` /
+ * `parseStructuredModelOutput` extract a JSON object out of raw model output
+ * (fences, surrounding prose, JSON5 leniency) and `validateJsonSchema` gates
+ * tool-call arguments — both brittle, security/correctness-relevant, and
+ * previously untested.
+ */
+describe("parseJSON", () => {
+  it("parses a plain JSON object", () => {
+    expect(parseJSON("{\"a\":1}")).toEqual({ a: 1 });
+  });
+
+  it("strips a ```json markdown fence", () => {
+    expect(parseJSON("```json\n{\"a\":1,\"b\":2}\n```")).toEqual({ a: 1, b: 2 });
+  });
+
+  it("extracts the object from surrounding prose (first { to last })", () => {
+    expect(parseJSON('Sure, here it is: {"ok":true} — done')).toEqual({ ok: true });
+  });
+
+  it("accepts JSON5 leniency (unquoted keys, single quotes, trailing comma)", () => {
+    expect(parseJSON("{ a: 1, b: 'two', }")).toEqual({ a: 1, b: "two" });
+  });
+
+  it("parses a nested object", () => {
+    expect(parseJSON('{"a":{"b":2}}')).toEqual({ a: { b: 2 } });
+  });
+
+  it("throws when there is no JSON object", () => {
+    expect(() => parseJSON("no json here")).toThrow(/No valid JSON object/);
+  });
+});
+
+describe("parseStructuredModelOutput", () => {
+  it("returns the parsed object for valid (fenced) output", () => {
+    expect(parseStructuredModelOutput("```\n{\"x\":42}\n```")).toEqual({ x: 42 });
+  });
+  it("throws a descriptive error when nothing parses", () => {
+    expect(() => parseStructuredModelOutput("nope")).toThrow(/No valid JSON object found/);
+  });
+});
+
+describe("validateJsonSchema", () => {
+  const schema = {
+    type: "object",
+    properties: { name: { type: "string" } },
+    required: ["name"],
+    additionalProperties: false,
+  } as const;
+
+  it("accepts data that satisfies the schema", () => {
+    const result = validateJsonSchema<{ name: string }>({ name: "tool" }, schema);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.name).toBe("tool");
+  });
+
+  it("rejects data missing a required field, with an error message", () => {
+    const result = validateJsonSchema({}, schema);
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.length).toBeGreaterThan(0);
+  });
+
+  it("rejects a wrong-typed field", () => {
+    const result = validateJsonSchema({ name: 123 }, schema);
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
`plugin-mcp`'s `src/utils/json.ts` was untested: `parseJSON` / `parseStructuredModelOutput` pull a JSON object out of **raw model output**, and `validateJsonSchema` gates **MCP tool-call arguments** — both brittle and security/correctness-relevant.

**11 tests**, placed under `src/utils/__tests__/` so the plugin's CI `vitest run` actually runs them:
- `parseJSON`: plain object, ` ```json ` fence stripping, extraction from surrounding prose (first `{` … last `}`), JSON5 leniency (unquoted keys / single quotes / trailing comma), nested objects, throw when no object present;
- `parseStructuredModelOutput`: fenced happy path + descriptive throw;
- `validateJsonSchema`: accepts valid data, rejects a missing required field (with a non-empty error) and a wrong-typed field.

**Verified:** plugin CI lane now **6 files / 35 tests, 0 fail** (was 5/24). Net-new, non-redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
