### PR TITLE
test(training): cover the HTML/JSON XSS escapers (#8801, #9943)

### DIFF
--- a/plugins/plugin-training/src/core/html-escape.test.ts
+++ b/plugins/plugin-training/src/core/html-escape.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { escapeHtml, escapeScriptJson } from "./html-escape";
+
+/**
+ * Tests for the HTML/JSON escapers (#8801 / #9943). These are XSS boundaries:
+ * escapeHtml entity-encodes user text rendered into markup, and escapeScriptJson
+ * escapes `<` so embedded JSON can't break out of an inline <script>. Both were
+ * untested; a regression here is a cross-site-scripting hole.
+ */
+describe("escapeHtml", () => {
+  it("escapes the four HTML-significant characters", () => {
+    expect(escapeHtml("<script>")).toBe("&lt;script&gt;");
+    expect(escapeHtml('a & "b"')).toBe("a &amp; &quot;b&quot;");
+  });
+
+  it("escapes & first so an existing entity double-encodes (no under-escaping)", () => {
+    expect(escapeHtml("&lt;")).toBe("&amp;lt;");
+  });
+
+  it("escapes a full tag with attributes", () => {
+    expect(escapeHtml('<a href="x">')).toBe("&lt;a href=&quot;x&quot;&gt;");
+  });
+});
+
+describe("escapeScriptJson", () => {
+  it("serializes a value to JSON", () => {
+    expect(escapeScriptJson({ a: 1, b: "two" })).toBe('{"a":1,"b":"two"}');
+  });
+
+  it("escapes < as \\u003c to prevent a </script> breakout", () => {
+    expect(escapeScriptJson("</script>")).toBe('"\\u003c/script>"');
+    expect(escapeScriptJson({ html: "<b>" })).toBe('{"html":"\\u003cb>"}');
+  });
+
+  it("leaves no raw < that could open or close a tag", () => {
+    const out = escapeScriptJson({ payload: "<svg onload=alert(1)>" });
+    expect(out).not.toContain("<");
+  });
+});


### PR DESCRIPTION
`escapeHtml` + `escapeScriptJson` are **XSS boundaries** (entity-encode user text rendered into markup; escape `<` so embedded JSON can't break out of an inline `<script>`), and were untested. A regression here is a cross-site-scripting hole.

**6 tests:**
- `escapeHtml`: the four significant chars, **&-first ordering** (no under-escaping), a full attributed tag;
- `escapeScriptJson`: plain JSON, `</script>` → `</script>`, and that **no raw `<` survives** that could open/close a tag.

Verified via plugin-training's vitest. Net-new, security-relevant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
