### PR TITLE
test(agent): cover the destructive reset-state-dir guard (#8801, #9943)

### DIFF
--- a/packages/agent/src/api/server-helpers-config.test.ts
+++ b/packages/agent/src/api/server-helpers-config.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { isSafeResetStateDir } from "./server-helpers-config";
+
+/**
+ * Tests for the destructive-reset guard (#8801 / #9943). isSafeResetStateDir
+ * decides whether a path may be wiped by the "reset state" operation. A bug here
+ * could erase the filesystem root, $HOME, or an unrelated directory — so the
+ * guard (under-home AND contains an "eliza" segment, never root/home itself) is
+ * pinned. It was untested.
+ */
+describe("isSafeResetStateDir", () => {
+  const home = "/home/user";
+
+  it("allows a state dir under home that carries an 'eliza' segment", () => {
+    expect(isSafeResetStateDir("/home/user/.local/state/eliza", home)).toBe(true);
+    expect(isSafeResetStateDir("/home/user/eliza", home)).toBe(true);
+  });
+
+  it("refuses the filesystem root", () => {
+    expect(isSafeResetStateDir("/", home)).toBe(false);
+  });
+
+  it("refuses the home directory itself", () => {
+    expect(isSafeResetStateDir(home, home)).toBe(false);
+  });
+
+  it("refuses any directory outside home (even with an eliza segment)", () => {
+    expect(isSafeResetStateDir("/tmp/eliza", home)).toBe(false);
+    expect(isSafeResetStateDir("/var/lib/eliza", home)).toBe(false);
+  });
+
+  it("refuses a traversal that escapes home", () => {
+    expect(isSafeResetStateDir("/home/user/../etc/eliza", home)).toBe(false);
+  });
+
+  it("refuses a dir under home that lacks the allowed segment", () => {
+    expect(isSafeResetStateDir("/home/user/Documents", home)).toBe(false);
+    expect(isSafeResetStateDir("/home/user/.local/state/milady", home)).toBe(false);
+  });
+});


### PR DESCRIPTION
`isSafeResetStateDir` decides whether a path may be **wiped** by the "reset state" operation. A bug here could erase the filesystem **root**, **`$HOME`**, or an unrelated directory — so the guard (under-home **and** contains an `eliza` segment, never root/home itself) is worth pinning. It was untested.

**6 tests:**
- allows a dir under home that carries an `eliza` segment;
- refuses the filesystem root and `$HOME` itself;
- refuses any dir outside home (even with an `eliza` segment);
- refuses a traversal that escapes home (`../etc/eliza`);
- refuses a dir under home lacking the allowed segment.

Net-new, safety-critical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
