### PR TITLE
test(shell): cover the auto-approval guard isSafeBinUsage (#8801, #9943)

### DIFF
--- a/plugins/plugin-shell/__tests__/isSafeBinUsage.test.ts
+++ b/plugins/plugin-shell/__tests__/isSafeBinUsage.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { isSafeBinUsage, normalizeSafeBins } from "../approvals/analysis";
+import type { CommandResolution } from "../approvals/types";
+
+/**
+ * Tests for the shell auto-approval guard (#8801 / #9943). isSafeBinUsage decides
+ * whether a command may be auto-approved: only an allowlisted executable with NO
+ * path-like / existing-file arguments (so it can't quietly read or mutate files).
+ * It's a security boundary and was untested; `fileExists` is injected for
+ * determinism.
+ */
+const res = (
+  executableName: string,
+  resolvedPath: string | undefined = `/usr/bin/${executableName}`,
+): CommandResolution => ({ rawExecutable: executableName, resolvedPath, executableName });
+const noFiles = () => false;
+
+describe("normalizeSafeBins", () => {
+  it("trims, lowercases, drops empties, and dedups", () => {
+    expect([...normalizeSafeBins([" LS ", "ls", "", "  ", "Cat"])].sort()).toEqual(["cat", "ls"]);
+  });
+  it("returns an empty set for non-array input", () => {
+    expect(normalizeSafeBins(undefined).size).toBe(0);
+  });
+});
+
+describe("isSafeBinUsage", () => {
+  const safeBins = normalizeSafeBins(["ls", "cat"]);
+
+  it("refuses when the safe-bin set is empty", () => {
+    expect(isSafeBinUsage({ argv: ["ls"], resolution: res("ls"), safeBins: new Set(), fileExists: noFiles })).toBe(false);
+  });
+
+  it("refuses a non-allowlisted executable", () => {
+    expect(isSafeBinUsage({ argv: ["rm", "-rf"], resolution: res("rm"), safeBins, fileExists: noFiles })).toBe(false);
+  });
+
+  it("refuses when the executable has no resolved path", () => {
+    const unresolved: CommandResolution = { rawExecutable: "ls", executableName: "ls" };
+    expect(isSafeBinUsage({ argv: ["ls"], resolution: unresolved, safeBins, fileExists: noFiles })).toBe(false);
+  });
+
+  it("approves an allowlisted bin with only flags", () => {
+    expect(isSafeBinUsage({ argv: ["ls", "-la", "--color"], resolution: res("ls"), safeBins, fileExists: noFiles })).toBe(true);
+  });
+
+  it("refuses a path-like positional argument", () => {
+    expect(isSafeBinUsage({ argv: ["cat", "/etc/passwd"], resolution: res("cat"), safeBins, fileExists: noFiles })).toBe(false);
+  });
+
+  it("refuses a positional that names an existing file", () => {
+    expect(isSafeBinUsage({ argv: ["cat", "secrets"], resolution: res("cat"), safeBins, cwd: "/work", fileExists: () => true })).toBe(false);
+  });
+
+  it("refuses a --flag=<path> value", () => {
+    expect(isSafeBinUsage({ argv: ["ls", "--width=/etc/passwd"], resolution: res("ls"), safeBins, fileExists: noFiles })).toBe(false);
+  });
+
+  it("approves a non-path positional that does not exist", () => {
+    expect(isSafeBinUsage({ argv: ["ls", "subcmd"], resolution: res("ls"), safeBins, fileExists: noFiles })).toBe(true);
+  });
+});


### PR DESCRIPTION
`isSafeBinUsage` decides whether a shell command may be **auto-approved** — only an allowlisted executable with **no** path-like / existing-file arguments (so it can't quietly read or mutate files). A security boundary, previously untested. `fileExists` is injected for determinism.

**10 tests (+ `normalizeSafeBins`):**
- refuses empty allowlist, non-allowlisted bin, and a bin with no resolved path;
- approves an allowlisted bin with only flags;
- refuses a path-like positional, a positional naming an existing file, and a `--flag=<path>` value;
- approves a non-path positional that does not exist;
- `normalizeSafeBins` trims/lowercases/dedups and rejects non-array input.

Net-new, security-relevant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
