### PR TITLE
test(cloud-shared): cover the invite-token security primitives (#8801, #9943)

### DIFF
--- a/packages/cloud/shared/src/lib/utils/invite-tokens.test.ts
+++ b/packages/cloud/shared/src/lib/utils/invite-tokens.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest";
+import {
+  generateInviteToken,
+  hashInviteToken,
+  verifyInviteToken,
+} from "./invite-tokens";
+
+/**
+ * Tests for the invite-token security primitives (#8801 / #9943). These were
+ * untested: generation must be unique + unguessable, the stored value must be a
+ * hash (never the raw token), and verification must accept only the exact
+ * token/hash pair.
+ */
+describe("invite tokens", () => {
+  test("generateInviteToken returns a unique 64-char hex string", () => {
+    const a = generateInviteToken();
+    const b = generateInviteToken();
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+    expect(b).toMatch(/^[0-9a-f]{64}$/);
+    expect(a).not.toBe(b);
+  });
+
+  test("hashInviteToken is a deterministic SHA-256 hex (known-answer)", () => {
+    expect(hashInviteToken("token-abc")).toBe(hashInviteToken("token-abc"));
+    expect(hashInviteToken("token-abc")).toMatch(/^[0-9a-f]{64}$/);
+    // NIST SHA-256("abc") — proves it is really SHA-256, not some other digest.
+    expect(hashInviteToken("abc")).toBe(
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+    );
+  });
+
+  test("distinct tokens hash differently", () => {
+    expect(hashInviteToken("one")).not.toBe(hashInviteToken("two"));
+  });
+
+  test("verifyInviteToken accepts the exact pair and rejects mismatches", () => {
+    const token = generateInviteToken();
+    const hash = hashInviteToken(token);
+    expect(verifyInviteToken(token, hash)).toBe(true);
+    expect(verifyInviteToken("wrong-token", hash)).toBe(false);
+    expect(verifyInviteToken(token, hashInviteToken("other"))).toBe(false);
+  });
+});


### PR DESCRIPTION
`generateInviteToken` / `hashInviteToken` / `verifyInviteToken` were untested. They guard invites: generation must be unique + unguessable, the stored value must be a **hash** (never the raw token), and verification must accept only the exact pair.

**4 tests** (run under the package's `bun test`):
- `generateInviteToken`: unique 64-char hex across calls;
- `hashInviteToken`: deterministic, and a **NIST known-answer vector** (`SHA-256("abc")`) proving it is really SHA-256;
- distinct tokens hash differently;
- `verifyInviteToken`: accepts the exact token+hash, rejects a wrong token and a wrong hash.

Net-new, security-relevant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
