### PR TITLE
test(core): cover the LLM-output JSON parser (#8801, #9943)

### DIFF
--- a/packages/core/src/utils/json-llm.test.ts
+++ b/packages/core/src/utils/json-llm.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { extractAndParseJSONObjectFromText } from "./json-llm";
+
+/**
+ * Tests for the core LLM-output JSON parser (#8801 / #9943). This is used across
+ * the runtime to turn a model's text into a structured object; a regression
+ * breaks every structured output. It was untested.
+ */
+describe("extractAndParseJSONObjectFromText", () => {
+  it("parses a plain JSON object", () => {
+    expect(extractAndParseJSONObjectFromText('{"a":1,"b":"two"}')).toEqual({ a: 1, b: "two" });
+  });
+
+  it("parses a JSON array", () => {
+    expect(extractAndParseJSONObjectFromText("[1, 2, 3]")).toEqual([1, 2, 3]);
+  });
+
+  it("extracts JSON from a ```json fenced block surrounded by prose", () => {
+    expect(
+      extractAndParseJSONObjectFromText("here you go:\n```json\n{\"ok\":true}\n```\nthanks"),
+    ).toEqual({ ok: true });
+  });
+
+  it("accepts JSON5 leniency (unquoted keys, single quotes, trailing comma)", () => {
+    expect(extractAndParseJSONObjectFromText("{ a: 1, b: 'two', }")).toEqual({ a: 1, b: "two" });
+  });
+
+  it("throws on empty / non-string input", () => {
+    expect(() => extractAndParseJSONObjectFromText("")).toThrow(/non-empty string/);
+  });
+
+  it("throws on unparseable text", () => {
+    expect(() => extractAndParseJSONObjectFromText("this is not json at all")).toThrow(/Failed to parse/);
+  });
+});


### PR DESCRIPTION
`extractAndParseJSONObjectFromText` turns a model's text into a structured object **across the whole runtime** — a regression breaks every structured output. It was untested.

**6 tests:**
- plain object and array;
- extraction from a ` ```json ` fenced block surrounded by prose;
- JSON5 leniency (unquoted keys / single quotes / trailing comma);
- throws on empty/non-string input;
- throws on unparseable text.

Net-new, runtime-critical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
