### PR TITLE
test(core): cover character config validation (#8801, #9943)

### DIFF
--- a/packages/core/src/schemas/character.test.ts
+++ b/packages/core/src/schemas/character.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { isValidCharacter, parseAndValidateCharacter } from "./character";
+
+/**
+ * Tests for character config validation (#8801 / #9943). parseAndValidateCharacter
+ * and isValidCharacter gate whether an agent definition is accepted; they (and
+ * the underlying validateCharacter) were untested. The key behaviors: a valid
+ * character passes, malformed JSON is reported DISTINCTLY from schema errors, and
+ * non-objects / missing name are rejected.
+ */
+describe("parseAndValidateCharacter", () => {
+  it("accepts a minimal valid character", () => {
+    expect(parseAndValidateCharacter('{"name":"Aria"}').success).toBe(true);
+  });
+
+  it("reports invalid JSON distinctly (not as a schema error)", () => {
+    const result = parseAndValidateCharacter("{not valid json");
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.message).toMatch(/Invalid JSON/);
+  });
+
+  it("rejects well-formed JSON that fails the schema (missing name)", () => {
+    expect(parseAndValidateCharacter("{}").success).toBe(false);
+  });
+
+  it("rejects a non-object JSON value", () => {
+    expect(parseAndValidateCharacter('"just a string"').success).toBe(false);
+  });
+});
+
+describe("isValidCharacter", () => {
+  it("is a type guard — true only for a valid character object", () => {
+    expect(isValidCharacter({ name: "Aria" })).toBe(true);
+    expect(isValidCharacter({})).toBe(false);
+    expect(isValidCharacter(null)).toBe(false);
+    expect(isValidCharacter("nope")).toBe(false);
+    expect(isValidCharacter(42)).toBe(false);
+  });
+});


### PR DESCRIPTION
`parseAndValidateCharacter` / `isValidCharacter` (and the underlying `validateCharacter`) gate whether an agent definition is accepted, and were untested.

**5 tests:**
- a minimal valid character is accepted;
- **malformed JSON is reported distinctly** (`"Invalid JSON: …"`) rather than as a schema error;
- well-formed JSON that fails the schema (missing `name`) is rejected;
- a non-object JSON value is rejected;
- `isValidCharacter` is a proper type guard (true only for a valid object; false for `{}`, `null`, string, number).

Net-new, config-validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
