### PR TITLE
test(app-core): cover the password-strength guard (#8801, #9943)

### DIFF
--- a/packages/app-core/src/api/auth/passwords.test.ts
+++ b/packages/app-core/src/api/auth/passwords.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { PASSWORD_MIN_LENGTH, WeakPasswordError, assertPasswordStrong } from "./passwords";
+
+/**
+ * Tests for the password-strength guard (#8801 / #9943). assertPasswordStrong is
+ * the auth boundary that enforces a minimum strength on sign-up/reset; weakening
+ * it silently is a real risk, and it was untested.
+ */
+describe("assertPasswordStrong", () => {
+  it("accepts length + a letter + a digit OR a symbol", () => {
+    expect(() => assertPasswordStrong("abcdefgh1234")).not.toThrow();
+    expect(() => assertPasswordStrong("MyP@sswordXY")).not.toThrow(); // symbol satisfies the requirement
+  });
+
+  it("rejects a too-short password", () => {
+    expect(() => assertPasswordStrong("aB3".padEnd(PASSWORD_MIN_LENGTH - 1, "a"))).toThrow(/too_short/);
+  });
+
+  it("rejects a password with no letter", () => {
+    expect(() => assertPasswordStrong("1234567890!@")).toThrow(/missing_letter/);
+  });
+
+  it("rejects a password with no digit or symbol", () => {
+    expect(() => assertPasswordStrong("abcdefghijkl")).toThrow(/missing_digit_or_symbol/);
+  });
+
+  it("surfaces the failure reason on a WeakPasswordError", () => {
+    try {
+      assertPasswordStrong("short");
+      throw new Error("expected assertPasswordStrong to throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(WeakPasswordError);
+      expect((e as WeakPasswordError).reason).toBe("too_short");
+    }
+  });
+});


### PR DESCRIPTION
`assertPasswordStrong` is the auth boundary enforcing minimum password strength on sign-up/reset; silently weakening it is a real risk, and it was untested.

**5 tests:**
- accepts length(≥12) + a letter + a digit **or** a symbol;
- rejects too-short (`too_short`), no-letter (`missing_letter`), and no-digit-or-symbol (`missing_digit_or_symbol`);
- surfaces the typed failure `reason` on a `WeakPasswordError`.

Net-new, auth-critical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
