### PR TITLE
test(agent-skills): cover the security manifest builder (#8801, #9943)

### DIFF
--- a/plugins/plugin-agent-skills/src/security/manifest-scanner.test.ts
+++ b/plugins/plugin-agent-skills/src/security/manifest-scanner.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { buildManifestEntriesFromMemory } from "./manifest-scanner";
+
+/**
+ * Tests for the in-memory skill-manifest builder (#8801 / #9943). The manifest
+ * feeds the security scanner / integrity check, so the per-file size must be the
+ * UTF-8 BYTE length (not the character count) — otherwise non-ASCII files report
+ * a wrong size. It was untested.
+ */
+describe("buildManifestEntriesFromMemory", () => {
+  it("returns an empty manifest for no files", () => {
+    expect(buildManifestEntriesFromMemory(new Map())).toEqual([]);
+  });
+
+  it("measures text size in UTF-8 bytes, not characters", () => {
+    const files = new Map([
+      ["a.txt", { content: "hello", isText: true }], // 5 ASCII bytes
+      ["u.txt", { content: "café", isText: true }], // é = 2 bytes -> 5
+      ["e.txt", { content: "🎉", isText: true }], // 1 char, 4 bytes
+    ]);
+    const size = Object.fromEntries(
+      buildManifestEntriesFromMemory(files).map((e) => [e.relativePath, e.sizeBytes]),
+    );
+    expect(size["a.txt"]).toBe(5);
+    expect(size["u.txt"]).toBe(5);
+    expect(size["e.txt"]).toBe(4);
+  });
+
+  it("uses byteLength for binary content and preserves the path", () => {
+    const files = new Map([
+      ["b.bin", { content: new Uint8Array([1, 2, 3, 4, 5, 6, 7]), isText: false }],
+    ]);
+    const [entry] = buildManifestEntriesFromMemory(files);
+    expect(entry.sizeBytes).toBe(7);
+    expect(entry.relativePath).toBe("b.bin");
+  });
+
+  it("marks every entry as a non-symlink", () => {
+    const files = new Map([["x", { content: "y", isText: true }]]);
+    expect(buildManifestEntriesFromMemory(files).every((e) => e.isSymlink === false)).toBe(true);
+  });
+});


### PR DESCRIPTION
`buildManifestEntriesFromMemory` feeds the skill **security scanner / integrity check**. Per-file size must be the **UTF-8 byte length**, not the character count, or non-ASCII files report a wrong size. It was untested.

**4 tests:**
- empty map → empty manifest;
- text size measured in **UTF-8 bytes** (`café` → 5, `🎉` → 4, `hello` → 5);
- binary content uses `byteLength`, path preserved;
- every entry marked `isSymlink: false`.

Net-new, integrity-relevant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
