### PR TITLE
test(agent): cover the EVM JSON-RPC URL validator (#8801, #9943)

### DIFF
--- a/packages/agent/src/api/tx-service.normalize-url.test.ts
+++ b/packages/agent/src/api/tx-service.normalize-url.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { normalizeJsonRpcUrl } from "./tx-service";
+
+/**
+ * Tests for the EVM JSON-RPC URL validator (#8801 / #9943). normalizeJsonRpcUrl
+ * gates the endpoint a wallet transaction talks to; it must reject empty,
+ * unparseable, and non-http(s) URLs (e.g. ws://, ftp://) — and was untested.
+ */
+describe("normalizeJsonRpcUrl", () => {
+  it("accepts and normalizes an http(s) URL", () => {
+    expect(normalizeJsonRpcUrl("https://eth.example.com/rpc")).toBe("https://eth.example.com/rpc");
+    expect(normalizeJsonRpcUrl("  http://localhost:8545  ")).toBe("http://localhost:8545/");
+  });
+
+  it("throws on an empty / whitespace URL", () => {
+    expect(() => normalizeJsonRpcUrl("")).toThrow(/required/);
+    expect(() => normalizeJsonRpcUrl("   ")).toThrow(/required/);
+  });
+
+  it("throws on an unparseable URL", () => {
+    expect(() => normalizeJsonRpcUrl("not a url")).toThrow(/expected an http\(s\) URL/);
+  });
+
+  it("throws on a non-http(s) scheme", () => {
+    expect(() => normalizeJsonRpcUrl("ws://eth.example.com")).toThrow(/expected http: or https:/);
+    expect(() => normalizeJsonRpcUrl("ftp://x.com/")).toThrow(/expected http: or https:/);
+  });
+});


### PR DESCRIPTION
`normalizeJsonRpcUrl` gates the endpoint a wallet transaction talks to. It must reject empty, unparseable, and non-`http(s)` URLs (`ws://`, `ftp://`), and was untested.

**4 tests:**
- accepts + normalizes an http(s) URL (trims; adds the canonical trailing slash);
- throws on empty/whitespace (`required`);
- throws on an unparseable URL;
- throws on a non-http(s) scheme.

Net-new, validation-relevant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
