### PR TITLE
test(core): cover the role-gate normalizer (#8801, #9943)

### DIFF
--- a/packages/core/src/runtime/context-gates.test.ts
+++ b/packages/core/src/runtime/context-gates.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { normalizeGateRole } from "./context-gates";
+import type { RoleGateRole } from "./context-gates";
+
+/**
+ * Tests for the role-gate normalizer (#8801 / #9943). normalizeGateRole canon-
+ * icalizes a role before a gate check; the USER->MEMBER alias and the case/trim
+ * handling must be consistent or role gating silently diverges. It was untested.
+ */
+const norm = (r: string) => normalizeGateRole(r as RoleGateRole);
+
+describe("normalizeGateRole", () => {
+  it("aliases USER to MEMBER", () => {
+    expect(norm("USER")).toBe("MEMBER");
+    expect(norm("user")).toBe("MEMBER");
+  });
+
+  it("uppercases and trims", () => {
+    expect(norm("  admin  ")).toBe("ADMIN");
+    expect(norm("owner")).toBe("OWNER");
+  });
+
+  it("leaves an already-canonical role unchanged", () => {
+    expect(norm("MEMBER")).toBe("MEMBER");
+    expect(norm("OWNER")).toBe("OWNER");
+  });
+});


### PR DESCRIPTION
`normalizeGateRole` canonicalizes a role before a gate check; the **USER→MEMBER** alias and the case/trim handling must be consistent or role gating silently diverges. It was untested.

**3 tests:** USER→MEMBER aliasing (any case), uppercase+trim, and that an already-canonical role is unchanged.

Net-new, auth-relevant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
