### PR TITLE
test(app-core): cover the dev-console-log path guard (#8801, #9943)

### DIFF
--- a/packages/app-core/src/api/dev-console-log.guard.test.ts
+++ b/packages/app-core/src/api/dev-console-log.guard.test.ts
@@ -1,0 +1,44 @@
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { isAllowedDevConsoleLogPath } from "./dev-console-log";
+
+/**
+ * Tests for the dev-console-log path guard (#8801 / #9943). isAllowedDevConsole
+ * LogPath gates a file READ exposed over the dev API; without it a traversal
+ * could read arbitrary files. It must allow only `desktop-dev-console.log` UNDER
+ * the state dir. It was untested.
+ */
+describe("isAllowedDevConsoleLogPath", () => {
+  let stateDir: string;
+  const prev = process.env.ELIZA_STATE_DIR;
+
+  beforeAll(() => {
+    stateDir = realpathSync(mkdtempSync(join(tmpdir(), "devconsole-state-")));
+    process.env.ELIZA_STATE_DIR = stateDir;
+  });
+  afterAll(() => {
+    if (prev === undefined) delete process.env.ELIZA_STATE_DIR;
+    else process.env.ELIZA_STATE_DIR = prev;
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("allows the dev-console log under the state dir (incl. nested)", () => {
+    expect(isAllowedDevConsoleLogPath(join(stateDir, "desktop-dev-console.log"))).toBe(true);
+    expect(isAllowedDevConsoleLogPath(join(stateDir, "logs", "desktop-dev-console.log"))).toBe(true);
+  });
+
+  it("rejects a wrong basename", () => {
+    expect(isAllowedDevConsoleLogPath(join(stateDir, "secrets.log"))).toBe(false);
+    expect(isAllowedDevConsoleLogPath(join(stateDir, "desktop-dev-console.log.bak"))).toBe(false);
+  });
+
+  it("rejects a path outside the state dir", () => {
+    expect(isAllowedDevConsoleLogPath("/etc/desktop-dev-console.log")).toBe(false);
+  });
+
+  it("rejects a traversal that escapes the state dir", () => {
+    expect(isAllowedDevConsoleLogPath(join(stateDir, "..", "desktop-dev-console.log"))).toBe(false);
+  });
+});


### PR DESCRIPTION
`isAllowedDevConsoleLogPath` gates a file **READ** exposed over the dev API; without it a traversal could read arbitrary files. It must allow only `desktop-dev-console.log` **under** the state dir. It was untested.

**4 tests** (`ELIZA_STATE_DIR` pointed at a temp dir, restored after):
- allows `desktop-dev-console.log` directly under and nested in the state dir;
- rejects a wrong basename (`secrets.log`, `*.log.bak`);
- rejects a path outside the state dir (`/etc/…`);
- rejects a traversal that escapes the state dir.

Net-new, path-traversal-prevention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
