### PR TITLE
test(core): cover the restart/retry backoff math (#10203, #10197)

### DIFF
--- a/packages/core/src/utils/retry.backoff.test.ts
+++ b/packages/core/src/utils/retry.backoff.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { type BackoffPolicy, computeBackoff } from "./retry";
+
+/**
+ * Tests for the restart/retry backoff math (#10203 / #10197 stability, #8801).
+ * computeBackoff drives crash-recovery and retry delays; the exponential growth,
+ * the attempt clamp, the maxMs cap, and the jitter bounds were untested.
+ */
+const noJitter: BackoffPolicy = { initialMs: 100, maxMs: 10_000, factor: 2, jitter: 0 };
+
+describe("computeBackoff", () => {
+  it("grows exponentially by the factor (jitter 0)", () => {
+    expect(computeBackoff(noJitter, 1)).toBe(100); // 100 * 2^0
+    expect(computeBackoff(noJitter, 2)).toBe(200); // 100 * 2^1
+    expect(computeBackoff(noJitter, 3)).toBe(400);
+    expect(computeBackoff(noJitter, 4)).toBe(800);
+  });
+
+  it("treats attempt <= 1 as the first attempt (no negative exponent)", () => {
+    expect(computeBackoff(noJitter, 0)).toBe(100);
+    expect(computeBackoff(noJitter, -3)).toBe(100);
+  });
+
+  it("caps the delay at maxMs", () => {
+    expect(computeBackoff(noJitter, 30)).toBe(10_000); // 100*2^29 >> max
+  });
+
+  it("with jitter, stays within [base, base*(1+jitter)] across many samples", () => {
+    const j: BackoffPolicy = { initialMs: 100, maxMs: 1_000_000, factor: 2, jitter: 0.5 };
+    for (let i = 0; i < 300; i += 1) {
+      const v = computeBackoff(j, 3); // base = 400
+      expect(v).toBeGreaterThanOrEqual(400);
+      expect(v).toBeLessThanOrEqual(600); // 400 * 1.5
+    }
+  });
+});


### PR DESCRIPTION
`computeBackoff` drives crash-recovery and retry delays — the agent-stability restart machinery (#10203/#10197). The exponential growth, the attempt clamp, the `maxMs` cap, and the jitter bounds were untested.

**4 tests:**
- exponential growth by the factor (jitter 0): `100, 200, 400, 800`;
- `attempt ≤ 1` clamps to the first attempt (no negative exponent);
- the delay **caps at `maxMs`**;
- with jitter, the value stays within `[base, base*(1+jitter)]` across 300 samples.

Net-new coverage of the stability backoff (a non-colliding slice of #10203/#10197, whose fleet PR #10397 is the device-restart e2e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
