### PR TITLE
test(browser): cover the browser-workspace input helpers (#10333, #8801)

### DIFF
--- a/plugins/plugin-browser/src/workspace/browser-workspace-helpers.test.ts
+++ b/plugins/plugin-browser/src/workspace/browser-workspace-helpers.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeBrowserWorkspaceText,
+  parseBrowserWorkspaceNumberLike,
+} from "./browser-workspace-helpers";
+
+/**
+ * Tests for the browser-workspace input helpers (#10333 / #8801). These coerce
+ * untrusted command arguments (numbers, text) the browser bridge acts on, and
+ * were untested.
+ */
+describe("parseBrowserWorkspaceNumberLike", () => {
+  it("passes a finite number through", () => {
+    expect(parseBrowserWorkspaceNumberLike(42)).toBe(42);
+    expect(parseBrowserWorkspaceNumberLike(0)).toBe(0);
+    expect(parseBrowserWorkspaceNumberLike(-3.5)).toBe(-3.5);
+  });
+
+  it("parses a numeric string (trimmed) and a leading-number string", () => {
+    expect(parseBrowserWorkspaceNumberLike("  12.5 ")).toBe(12.5);
+    expect(parseBrowserWorkspaceNumberLike("100")).toBe(100);
+    expect(parseBrowserWorkspaceNumberLike("12px")).toBe(12); // parseFloat semantics
+  });
+
+  it("returns undefined for non-finite, non-numeric, or non-string/number input", () => {
+    expect(parseBrowserWorkspaceNumberLike(Number.NaN)).toBeUndefined();
+    expect(parseBrowserWorkspaceNumberLike(Number.POSITIVE_INFINITY)).toBeUndefined();
+    expect(parseBrowserWorkspaceNumberLike("abc")).toBeUndefined();
+    expect(parseBrowserWorkspaceNumberLike("")).toBeUndefined();
+    expect(parseBrowserWorkspaceNumberLike(null)).toBeUndefined();
+    expect(parseBrowserWorkspaceNumberLike({})).toBeUndefined();
+  });
+});
+
+describe("normalizeBrowserWorkspaceText", () => {
+  it("collapses whitespace runs to single spaces and trims", () => {
+    expect(normalizeBrowserWorkspaceText("  hello   world \n\t ")).toBe("hello world");
+  });
+
+  it("stringifies null/undefined to empty and coerces non-strings", () => {
+    expect(normalizeBrowserWorkspaceText(null)).toBe("");
+    expect(normalizeBrowserWorkspaceText(undefined)).toBe("");
+    expect(normalizeBrowserWorkspaceText(42)).toBe("42");
+  });
+});


### PR DESCRIPTION
`parseBrowserWorkspaceNumberLike` + `normalizeBrowserWorkspaceText` coerce untrusted command arguments the browser bridge acts on, and were untested — a non-colliding coverage slice of #10333 (whose fleet PR #10408 adds an external-dataset benchmark lane).

**5 tests:**
- `parseBrowserWorkspaceNumberLike`: passes finite numbers; parses numeric + leading-number strings (`12px`→`12`); `undefined` for NaN/Infinity/non-numeric/empty/null/object;
- `normalizeBrowserWorkspaceText`: collapses whitespace runs + trims; null/undefined→`""` and coerces non-strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
