### PR TITLE
refactor(ui): centralize the bounded module-cache eviction policy (#10196)

### DIFF
--- a/packages/ui/src/components/views/DynamicViewLoader.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.tsx
@@ -63,6 +63,7 @@ import {
 import {
   HEAP_PRESSURE_EVENT,
   isUnderMemoryPressure,
+  planModuleCacheEvictions,
 } from "../../state/bounded-view-lru";
 import { installHeapPressureMonitor } from "../../state/heap-pressure-monitor";
 import { useTranslation } from "../../state/TranslationContext.hooks";
@@ -228,28 +229,18 @@ function armBundleEntryRetentionTimer(entry: ViewBundleCacheEntry): void {
 function pruneBundleModuleCache(
   options: { force?: boolean; reason?: EvictReason } = {},
 ): void {
-  const now = Date.now();
-  const ttlMs = options.force ? 0 : getBundleCacheTtlMs();
-  const reason = options.reason ?? (options.force ? "memorypressure" : "ttl");
-  const idleEntries = [...bundleModuleCache.values()]
-    .filter((entry) => entry.refCount === 0)
-    .sort((a, b) => a.lastUsedAt - b.lastUsedAt);
-
-  for (const entry of idleEntries) {
-    if (options.force || now - entry.lastUsedAt >= ttlMs) {
-      cleanupBundleEntry(entry, reason);
-    }
-  }
-
-  const maxEntries = options.force ? 0 : getBundleCacheMaxEntries();
-  let retained = [...bundleModuleCache.values()].filter(
-    (entry) => entry.refCount === 0,
-  );
-  retained = retained.sort((a, b) => a.lastUsedAt - b.lastUsedAt);
-  while (bundleModuleCache.size > maxEntries && retained.length > 0) {
-    const entry = retained.shift();
-    if (!entry) break;
-    cleanupBundleEntry(entry, options.reason ?? "lru");
+  const ttlReason =
+    options.reason ?? (options.force ? "memorypressure" : "ttl");
+  const lruReason = options.reason ?? "lru";
+  const plan = planModuleCacheEvictions([...bundleModuleCache.values()], {
+    now: Date.now(),
+    ttlMs: options.force ? 0 : getBundleCacheTtlMs(),
+    maxEntries: options.force ? 0 : getBundleCacheMaxEntries(),
+    force: options.force ?? false,
+    totalSize: bundleModuleCache.size,
+  });
+  for (const { entry, phase } of plan) {
+    cleanupBundleEntry(entry, phase === "ttl" ? ttlReason : lruReason);
   }
 }
 

--- a/packages/ui/src/retained-lazy.tsx
+++ b/packages/ui/src/retained-lazy.tsx
@@ -15,6 +15,7 @@ import {
   getRetainedModuleMaxEntries,
   getRetainedModuleTtlMs,
   HEAP_PRESSURE_EVENT,
+  planModuleCacheEvictions,
 } from "./state/bounded-view-lru";
 import { installHeapPressureMonitor } from "./state/heap-pressure-monitor";
 
@@ -141,28 +142,18 @@ function armRetentionTimer(entry: RetainedModuleEntry<object>): void {
 export function pruneRetainedLazyModules(
   options: { force?: boolean; reason?: EvictReason } = {},
 ): void {
-  const now = Date.now();
-  const ttlMs = options.force ? 0 : getRetainedModuleTtlMs();
-  const reason = options.reason ?? (options.force ? "memorypressure" : "ttl");
-  const idleEntries = [...retainedModuleCache.values()]
-    .filter((entry) => entry.refCount === 0)
-    .sort((a, b) => a.lastUsedAt - b.lastUsedAt);
-
-  for (const entry of idleEntries) {
-    if (options.force || now - entry.lastUsedAt >= ttlMs) {
-      cleanupEntry(entry, reason);
-    }
-  }
-
-  const maxEntries = options.force ? 0 : getRetainedModuleMaxEntries();
-  let retained = [...retainedModuleCache.values()].filter(
-    (entry) => entry.refCount === 0,
-  );
-  retained = retained.sort((a, b) => a.lastUsedAt - b.lastUsedAt);
-  while (retainedModuleCache.size > maxEntries && retained.length > 0) {
-    const entry = retained.shift();
-    if (!entry) break;
-    cleanupEntry(entry, options.reason ?? "lru");
+  const ttlReason =
+    options.reason ?? (options.force ? "memorypressure" : "ttl");
+  const lruReason = options.reason ?? "lru";
+  const plan = planModuleCacheEvictions([...retainedModuleCache.values()], {
+    now: Date.now(),
+    ttlMs: options.force ? 0 : getRetainedModuleTtlMs(),
+    maxEntries: options.force ? 0 : getRetainedModuleMaxEntries(),
+    force: options.force ?? false,
+    totalSize: retainedModuleCache.size,
+  });
+  for (const { entry, phase } of plan) {
+    cleanupEntry(entry, phase === "ttl" ? ttlReason : lruReason);
   }
 }
 

--- a/packages/ui/src/state/bounded-view-lru.evictions.test.ts
+++ b/packages/ui/src/state/bounded-view-lru.evictions.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Pure module-cache eviction planner (#10196 item 3 — "the eviction policy is
+ * not centralized or independently testable"). `retained-lazy.tsx` and
+ * `components/views/DynamicViewLoader.tsx` previously each carried a byte-
+ * identical TTL-sweep + LRU-cap loop; both now call `planModuleCacheEvictions`,
+ * so this is the single place the policy is asserted. The cases pin the exact
+ * behavior the duplicated loops had: idle-only, oldest-first, TTL-then-LRU,
+ * `force` evicts all idle, and active (`refCount > 0`) entries are never chosen.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  type ModuleCacheEntryLike,
+  type ModuleCacheEvictionPhase,
+  planModuleCacheEvictions,
+} from "./bounded-view-lru";
+
+interface TestEntry extends ModuleCacheEntryLike {
+  id: string;
+}
+
+const e = (id: string, lastUsedAt: number, refCount = 0): TestEntry => ({
+  id,
+  lastUsedAt,
+  refCount,
+});
+
+/** Flatten a plan to `[id, phase]` pairs for order-sensitive assertions. */
+const pairs = (
+  plan: { entry: TestEntry; phase: ModuleCacheEvictionPhase }[],
+): [string, ModuleCacheEvictionPhase][] =>
+  plan.map(({ entry, phase }) => [entry.id, phase]);
+
+const NOW = 1_000_000;
+const TTL = 5 * 60_000;
+
+describe("planModuleCacheEvictions", () => {
+  it("evicts nothing when every idle entry is fresh and within the cap", () => {
+    const entries = [e("a", NOW - 1_000), e("b", NOW - 2_000)];
+    const plan = planModuleCacheEvictions(entries, {
+      now: NOW,
+      ttlMs: TTL,
+      maxEntries: 6,
+      force: false,
+      totalSize: entries.length,
+    });
+    expect(plan).toEqual([]);
+  });
+
+  it("TTL-evicts only idle entries past the TTL, oldest first", () => {
+    const fresh = e("fresh", NOW - 1_000);
+    const stale1 = e("stale1", NOW - (TTL + 10_000));
+    const stale2 = e("stale2", NOW - (TTL + 1)); // just over the line, newer than stale1
+    const plan = planModuleCacheEvictions([fresh, stale2, stale1], {
+      now: NOW,
+      ttlMs: TTL,
+      maxEntries: 6,
+      force: false,
+      totalSize: 3,
+    });
+    // oldest-first: stale1 (older) before stale2; fresh is untouched.
+    expect(pairs(plan)).toEqual([
+      ["stale1", "ttl"],
+      ["stale2", "ttl"],
+    ]);
+  });
+
+  it("never selects an active (refCount > 0) entry, even when stale", () => {
+    const pinnedStale = e("pinned", NOW - 10 * TTL, 2);
+    const idleStale = e("idle", NOW - 10 * TTL, 0);
+    const plan = planModuleCacheEvictions([pinnedStale, idleStale], {
+      now: NOW,
+      ttlMs: TTL,
+      maxEntries: 0,
+      force: false,
+      totalSize: 2,
+    });
+    expect(pairs(plan)).toEqual([["idle", "ttl"]]);
+  });
+
+  it("LRU-evicts the oldest idle entries down to the cap when all are fresh", () => {
+    // 4 fresh idle entries, cap of 2 → evict the 2 oldest as LRU.
+    const entries = [
+      e("newest", NOW - 1_000),
+      e("older", NOW - 3_000),
+      e("oldest", NOW - 4_000),
+      e("mid", NOW - 2_000),
+    ];
+    const plan = planModuleCacheEvictions(entries, {
+      now: NOW,
+      ttlMs: TTL,
+      maxEntries: 2,
+      force: false,
+      totalSize: 4,
+    });
+    expect(pairs(plan)).toEqual([
+      ["oldest", "lru"],
+      ["older", "lru"],
+    ]);
+  });
+
+  it("applies the TTL sweep first, then LRU on the survivors, with no double-eviction", () => {
+    // stale (past TTL) → ttl; remaining 3 fresh idle with cap 1 → 2 LRU evictions.
+    const entries = [
+      e("stale", NOW - (TTL + 5_000)),
+      e("f-newest", NOW - 1_000),
+      e("f-oldest", NOW - 3_500),
+      e("f-mid", NOW - 2_000),
+    ];
+    const plan = planModuleCacheEvictions(entries, {
+      now: NOW,
+      ttlMs: TTL,
+      maxEntries: 1,
+      force: false,
+      totalSize: 4,
+    });
+    expect(pairs(plan)).toEqual([
+      ["stale", "ttl"],
+      ["f-oldest", "lru"],
+      ["f-mid", "lru"],
+    ]);
+    // every entry appears at most once
+    const ids = plan.map((p) => p.entry.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("force-evicts every idle entry as TTL, regardless of freshness", () => {
+    const entries = [e("a", NOW), e("b", NOW - 1), e("pinned", NOW, 1)];
+    const plan = planModuleCacheEvictions(entries, {
+      now: NOW,
+      ttlMs: 0,
+      maxEntries: 0,
+      force: true,
+      totalSize: 3,
+    });
+    // both idle entries evicted (oldest-first), the pinned one survives
+    expect(pairs(plan)).toEqual([
+      ["b", "ttl"],
+      ["a", "ttl"],
+    ]);
+  });
+
+  it("measures the cap against post-TTL size, not the original size", () => {
+    // 5 entries, 3 stale (past TTL), cap 3. After the 3 TTL evictions only 2
+    // remain (≤ cap) so the LRU phase must add nothing.
+    const entries = [
+      e("s1", NOW - (TTL + 1)),
+      e("s2", NOW - (TTL + 2)),
+      e("s3", NOW - (TTL + 3)),
+      e("fresh1", NOW - 1_000),
+      e("fresh2", NOW - 2_000),
+    ];
+    const plan = planModuleCacheEvictions(entries, {
+      now: NOW,
+      ttlMs: TTL,
+      maxEntries: 3,
+      force: false,
+      totalSize: 5,
+    });
+    expect(plan.every((p) => p.phase === "ttl")).toBe(true);
+    expect(plan).toHaveLength(3);
+  });
+
+  it("counts active entries toward the cap but never evicts them", () => {
+    // 2 active + 2 idle, cap 1. Active entries occupy size but can't be evicted,
+    // so both idle are LRU-evicted (size 4 → 2, still > cap, but nothing idle left).
+    const entries = [
+      e("act1", NOW, 1),
+      e("act2", NOW, 1),
+      e("idle-old", NOW - 3_000),
+      e("idle-new", NOW - 1_000),
+    ];
+    const plan = planModuleCacheEvictions(entries, {
+      now: NOW,
+      ttlMs: TTL,
+      maxEntries: 1,
+      force: false,
+      totalSize: 4,
+    });
+    expect(pairs(plan)).toEqual([
+      ["idle-old", "lru"],
+      ["idle-new", "lru"],
+    ]);
+  });
+
+  it("returns an empty plan for an empty cache", () => {
+    expect(
+      planModuleCacheEvictions<TestEntry>([], {
+        now: NOW,
+        ttlMs: TTL,
+        maxEntries: 0,
+        force: true,
+        totalSize: 0,
+      }),
+    ).toEqual([]);
+  });
+});

--- a/packages/ui/src/state/bounded-view-lru.ts
+++ b/packages/ui/src/state/bounded-view-lru.ts
@@ -184,3 +184,72 @@ export function selectLruEvictions(
   });
   return ordered.slice(0, Math.min(overflow, ordered.length));
 }
+
+/** Minimal shape of a bounded module-cache entry the eviction planner reads. */
+export interface ModuleCacheEntryLike {
+  /** >0 while at least one mounted view holds the module; such entries are pinned. */
+  refCount: number;
+  /** `Date.now()` of the last acquire/release; the LRU + TTL ordering key. */
+  lastUsedAt: number;
+}
+
+/** Which phase of the prune selected an entry — drives the telemetry reason. */
+export type ModuleCacheEvictionPhase = "ttl" | "lru";
+
+export interface ModuleCacheEvictionPlanOptions {
+  /** Wall-clock reference (`Date.now()`); injected so the planner stays pure. */
+  now: number;
+  /** Idle TTL in ms; an idle entry past this is TTL-evicted. `0` evicts all idle. */
+  ttlMs: number;
+  /** Cap on total retained entries after the TTL sweep; overflow is LRU-evicted. */
+  maxEntries: number;
+  /** Force-evict every idle entry regardless of TTL (memory-pressure / app-pause). */
+  force: boolean;
+  /** Current `cache.size` (active + idle) the cap is measured against. */
+  totalSize: number;
+}
+
+/**
+ * Pure eviction planner shared by the two bounded module caches
+ * (`retained-lazy.tsx`, `components/views/DynamicViewLoader.tsx`), which
+ * previously each carried a byte-identical copy of this TTL-sweep + LRU-cap loop
+ * (#10196 — "the eviction policy is not centralized or independently testable").
+ *
+ * It reproduces that loop exactly: first every idle (`refCount === 0`) entry
+ * older than `ttlMs` (all of them when `force`) is selected oldest-first as a
+ * `"ttl"` eviction; then, if the cache would still exceed `maxEntries` after
+ * those, additional idle entries are selected oldest-first as `"lru"` evictions
+ * until the total is within the cap. Active (`refCount > 0`) entries are never
+ * selected. The caller maps each phase to its telemetry reason and runs its own
+ * `cleanup`, so behavior — including emit order — is unchanged.
+ */
+export function planModuleCacheEvictions<E extends ModuleCacheEntryLike>(
+  entries: readonly E[],
+  options: ModuleCacheEvictionPlanOptions,
+): { entry: E; phase: ModuleCacheEvictionPhase }[] {
+  const { now, ttlMs, maxEntries, force, totalSize } = options;
+  const idleOldestFirst = entries
+    .filter((entry) => entry.refCount === 0)
+    .sort((a, b) => a.lastUsedAt - b.lastUsedAt);
+
+  const plan: { entry: E; phase: ModuleCacheEvictionPhase }[] = [];
+  const ttlEvicted = new Set<E>();
+  for (const entry of idleOldestFirst) {
+    if (force || now - entry.lastUsedAt >= ttlMs) {
+      plan.push({ entry, phase: "ttl" });
+      ttlEvicted.add(entry);
+    }
+  }
+
+  // The original LRU phase re-reads `cache.size` AFTER the TTL deletes, then
+  // evicts the oldest still-idle entries until within the cap. Mirror that by
+  // shrinking the measured size by the TTL evictions and skipping them here.
+  let retainedSize = totalSize - ttlEvicted.size;
+  for (const entry of idleOldestFirst) {
+    if (retainedSize <= maxEntries) break;
+    if (ttlEvicted.has(entry)) continue;
+    plan.push({ entry, phase: "lru" });
+    retainedSize -= 1;
+  }
+  return plan;
+}


### PR DESCRIPTION
## What

The two bounded view-module caches each carried a **byte-identical** TTL-sweep + LRU-cap prune loop:

- `packages/ui/src/retained-lazy.tsx` — route-chunk module cache
- `packages/ui/src/components/views/DynamicViewLoader.tsx` — remote-bundle module cache

#10196 flags this directly: *"the eviction policy + thresholds are not centralized or independently testable."* (The thresholds were already centralized in `state/bounded-view-lru.ts` by earlier #10196 work; the **algorithm** was still duplicated.)

This extracts the loop into a pure `planModuleCacheEvictions()` in `state/bounded-view-lru.ts` — the module that already owns the caches' device-memory + heap-pressure tiering — and has both prune functions call it.

## Behavior-preserving

The planner reproduces the original loop exactly:
- only idle (`refCount === 0`) entries are eligible; active entries are never evicted;
- TTL phase first (oldest-first), then LRU phase measured against the **post-TTL** size;
- `force` evicts every idle entry; same per-phase telemetry `reason` and the same emit order.

Net effect: **no behavior change, one source of truth** (–44 duplicated lines across the two caches, replaced by one tested function).

## Tests

New `packages/ui/src/state/bounded-view-lru.evictions.test.ts` (9 cases) pins the policy independently: no-op within cap, TTL sweep oldest-first, active-entry pinning, LRU cap, combined TTL→LRU with no double-eviction, post-TTL cap measurement, force-evict-all-idle, empty cache.

```
✓ bounded-view-lru.evictions.test.ts  (9)
✓ bounded-view-lru.heap.test.ts + cache-telemetry.test.ts  (unchanged)
✓ DynamicViewLoader.test.tsx + AppWindowRenderer.helpers.test.tsx (21, unchanged)
```

## Verification

- `bun run --cwd packages/ui typecheck` → exit 0, 0 errors
- `bunx biome check` on the 4 touched files → clean
- vitest: all listed suites green

Part of #10196 (views/state OS-grade discipline). Deliverable: *consolidate the two module caches behind one independently-testable eviction policy.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
