### PR TITLE
test(core): cover the ACTION_ROLE_POLICY authorization gate (#8801)

### DIFF
--- a/packages/core/src/runtime/action-role-policy.test.ts
+++ b/packages/core/src/runtime/action-role-policy.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	_resetActionRolePolicyCacheForTests,
+	isActionAllowedByRolePolicy,
+	readActionRolePolicy,
+	resolveActionRolePolicyRole,
+} from "./action-role-policy.ts";
+
+/**
+ * `ACTION_ROLE_POLICY` is an operator override that decides whether a caller may
+ * run a given action by role (#8801 — it gates real capabilities like SHELL /
+ * BROWSER but shipped untested). A regression that mis-parses the policy, fails
+ * to drop an invalid role, or admits a below-threshold caller is a privilege
+ * escalation, so the parse/lookup/authorization paths are pinned here.
+ */
+function setPolicy(json?: string): void {
+	if (json === undefined) {
+		delete process.env.ACTION_ROLE_POLICY;
+	} else {
+		process.env.ACTION_ROLE_POLICY = json;
+	}
+	_resetActionRolePolicyCacheForTests();
+}
+
+afterEach(() => setPolicy(undefined));
+
+describe("readActionRolePolicy", () => {
+	it("is empty when the env var is unset", () => {
+		setPolicy(undefined);
+		expect(readActionRolePolicy()).toEqual({});
+	});
+
+	it("parses + normalizes roles and drops invalid ones", () => {
+		setPolicy(
+			JSON.stringify({ SHELL: "guest", BROWSER: "MEMBER", EVIL: "superuser" }),
+		);
+		// roles uppercased/normalized; the unknown "superuser" role is dropped
+		expect(readActionRolePolicy()).toEqual({
+			SHELL: "GUEST",
+			BROWSER: "MEMBER",
+		});
+	});
+
+	it("is empty for malformed JSON or a non-object", () => {
+		setPolicy("not json");
+		expect(readActionRolePolicy()).toEqual({});
+		setPolicy("[1,2,3]");
+		expect(readActionRolePolicy()).toEqual({});
+	});
+
+	it("caches the parse until explicitly reset", () => {
+		setPolicy(JSON.stringify({ SHELL: "GUEST" }));
+		expect(readActionRolePolicy().SHELL).toBe("GUEST");
+		// change the env WITHOUT resetting → still the cached value
+		process.env.ACTION_ROLE_POLICY = JSON.stringify({ SHELL: "OWNER" });
+		expect(readActionRolePolicy().SHELL).toBe("GUEST");
+		_resetActionRolePolicyCacheForTests();
+		expect(readActionRolePolicy().SHELL).toBe("OWNER");
+	});
+});
+
+describe("resolveActionRolePolicyRole", () => {
+	it("resolves a string action, undefined when absent", () => {
+		setPolicy(JSON.stringify({ SHELL: "GUEST" }));
+		expect(resolveActionRolePolicyRole("SHELL")).toBe("GUEST");
+		expect(resolveActionRolePolicyRole("UNLISTED")).toBeUndefined();
+	});
+
+	it("resolves an object action by name, then falls back to a simile", () => {
+		setPolicy(JSON.stringify({ RUN_SHELL: "MEMBER" }));
+		expect(resolveActionRolePolicyRole({ name: "RUN_SHELL" })).toBe("MEMBER");
+		// name not in policy, but a simile is
+		expect(
+			resolveActionRolePolicyRole({ name: "EXEC", similes: ["RUN_SHELL"] }),
+		).toBe("MEMBER");
+		// nothing matches
+		expect(
+			resolveActionRolePolicyRole({ name: "EXEC", similes: ["NOPE"] }),
+		).toBeUndefined();
+	});
+});
+
+describe("isActionAllowedByRolePolicy (authorization)", () => {
+	it("denies an action the policy does not whitelist", () => {
+		setPolicy(JSON.stringify({ SHELL: "MEMBER" }));
+		expect(isActionAllowedByRolePolicy("BROWSER", ["OWNER"])).toBe(false);
+	});
+
+	it("allows a whitelisted action when the caller satisfies the role", () => {
+		setPolicy(JSON.stringify({ SHELL: "MEMBER" }));
+		expect(isActionAllowedByRolePolicy("SHELL", ["ADMIN"])).toBe(true);
+	});
+
+	it("denies a whitelisted action when the caller is below the role", () => {
+		setPolicy(JSON.stringify({ SHELL: "ADMIN" }));
+		expect(isActionAllowedByRolePolicy("SHELL", ["GUEST"])).toBe(false);
+		expect(isActionAllowedByRolePolicy("SHELL", undefined)).toBe(false);
+	});
+});


### PR DESCRIPTION
`ACTION_ROLE_POLICY` decides whether a caller may run a capability (SHELL/BROWSER) by role but shipped untested. Pins the parse/normalize/drop-invalid, name+simile lookup, and the authorization (allow/deny by role) paths so a mis-parse or below-threshold admit can't escalate privilege. 9 tests, all green. Test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)