### PR TITLE
fix(cloud): mount StewardAuthProvider on the email magic-link callback

### DIFF
--- a/packages/ui/src/cloud/public-pages/pages/auth/email-callback-page.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/email-callback-page.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// A never-resolving verify keeps the page in its "verifying" state — we only
+// need to observe the verify was REACHED, not its outcome.
+const { verifyEmailCallback } = vi.hoisted(() => ({
+  verifyEmailCallback: vi.fn(
+    (_token: string, _email: string) => new Promise(() => {}),
+  ),
+}));
+
+// Stub StewardAuthProvider with a marker that ALSO supplies the Steward context
+// — what the real provider does once its runtime mounts. This lets us assert
+// both halves of the fix: (a) the callback renders INSIDE the self-mounted
+// provider, and (b) the context reaches it so the magic-link verify runs,
+// instead of the "Sign-in is unavailable" dead-end a first-time visitor hit
+// when this public route had no provider at all (#9881-class).
+vi.mock("../../../shell/StewardProvider", async () => {
+  const { createContext } = await import("react");
+  const LocalStewardAuthContext = createContext<unknown>(null);
+  return {
+    LocalStewardAuthContext,
+    StewardAuthProvider: ({ children }: { children: ReactNode }) => (
+      <div data-testid="steward-auth-provider">
+        <LocalStewardAuthContext.Provider
+          value={{
+            isAuthenticated: false,
+            isLoading: false,
+            user: null,
+            session: null,
+            signOut: () => {},
+            getToken: () => "",
+            verifyEmailCallback,
+          }}
+        >
+          {children}
+        </LocalStewardAuthContext.Provider>
+      </div>
+    ),
+  };
+});
+
+vi.mock("../../../shell/CloudI18nProvider", () => ({
+  useCloudT: () => (_key: string, opts?: { defaultValue?: string }) =>
+    opts?.defaultValue ?? _key,
+}));
+vi.mock("../../lib/use-page-title", () => ({ usePageTitle: () => {} }));
+vi.mock("../../lib/steward-session", () => ({
+  syncStewardSessionCookie: vi.fn(),
+}));
+vi.mock("../../../../cloud-ui/components/auth/authorize-return", () => ({
+  readStoredAppAuthorizeReturnTo: () => null,
+  clearStoredAppAuthorizeReturnTo: () => {},
+}));
+vi.mock("../../../../cloud-ui/components/brand/brand-button", () => ({
+  BrandButton: ({ children }: { children: ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+}));
+
+import EmailCallbackPage from "./email-callback-page";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("EmailCallbackPage", () => {
+  it("mounts the callback inside StewardAuthProvider so the magic-link verify runs (not the 'unavailable' dead-end)", async () => {
+    render(
+      <MemoryRouter
+        initialEntries={["/auth/callback/email?token=tok&email=a%40b.co"]}
+      >
+        <EmailCallbackPage />
+      </MemoryRouter>,
+    );
+
+    // (a) the callback renders inside the self-mounted provider — drop the
+    // wrapper and this marker is never rendered, so getByTestId throws.
+    expect(screen.getByTestId("steward-auth-provider")).toBeTruthy();
+
+    // (b) the Steward context reaches the page, so verify runs with the URL
+    // token/email. Without the wrapper `auth` is null and this never fires —
+    // the page dead-ends on "Sign-in is unavailable".
+    await waitFor(() =>
+      expect(verifyEmailCallback).toHaveBeenCalledWith("tok", "a@b.co"),
+    );
+  });
+});

--- a/packages/ui/src/cloud/public-pages/pages/auth/email-callback-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/email-callback-page.tsx
@@ -15,13 +15,31 @@ import {
 } from "../../../../cloud-ui/components/auth/authorize-return";
 import { BrandButton } from "../../../../cloud-ui/components/brand/brand-button";
 import { useCloudT } from "../../../shell/CloudI18nProvider";
-import { LocalStewardAuthContext } from "../../../shell/StewardProvider";
+import {
+  LocalStewardAuthContext,
+  StewardAuthProvider,
+} from "../../../shell/StewardProvider";
 import { syncStewardSessionCookie } from "../../lib/steward-session";
 import { usePageTitle } from "../../lib/use-page-title";
 
 type CallbackStatus = "verifying" | "success" | "error";
 
+// `public: true` routes render WITHOUT the per-route Steward wrapper (see
+// `CloudRouteElement` / `app-authorize-page` #9881), so this page must mount the
+// shell's `StewardAuthProvider` itself. Otherwise the magic-link verify has no
+// Steward context, `auth` is null, and a first-time signed-out visitor (no
+// stored token, cold browser) just gets "Sign-in is unavailable". `/auth` is
+// already in `StewardAuthProvider`'s runtime route patterns, so the Steward
+// runtime mounts even for that visitor.
 export default function EmailCallbackPage() {
+  return (
+    <StewardAuthProvider>
+      <EmailCallbackContent />
+    </StewardAuthProvider>
+  );
+}
+
+function EmailCallbackContent() {
   const t = useCloudT();
   const [searchParams] = useSearchParams();
   const auth = useContext(LocalStewardAuthContext);


### PR DESCRIPTION
## What
The email magic-link callback (`/auth/callback/email`) is a `public: true` route, so it renders WITHOUT the per-route Steward wrapper. It reads `useContext(LocalStewardAuthContext)` but nothing provides it → `auth` is null → the page bails with **"Sign-in is unavailable. Start sign-in again from the app."** before any verify runs.

Same gap app-authorize hit in #9881 — that page self-mounts `StewardAuthProvider`; the email callback was missed.

## Repro
Fresh browser (no stored token), open the magic-link URL directly:
`/auth/callback/email?token=…&email=…&tenantId=…` → "Sign-in is unavailable", and **zero** `…/steward` network calls (the runtime never mounts). Reproduces on **prod too** (elizacloud.ai), not only staging — returning users dodge it because a stored token loads the runtime via `readStoredToken()`.

## Fix
Wrap the page in `StewardAuthProvider`, exactly like app-authorize. `/auth` is already in `StewardAuthProvider`'s runtime route patterns, so the Steward runtime mounts even for a signed-out first-time visitor → `verifyEmailCallback` runs.

## Test
- `bun run --cwd packages/ui typecheck` green.
- Broken state reproduced on staging **and** prod via Playwright (auth null, no steward calls).
- Post-deploy: a real magic link in a fresh browser lands authenticated instead of "unavailable".