### PR TITLE
fix(cloud): scope X-App-Id attribution + cap app creation (apps launch hardening, #10450)

### DIFF
--- a/packages/cloud/api/v1/apps/route.ts
+++ b/packages/cloud/api/v1/apps/route.ts
@@ -11,7 +11,11 @@ import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { appCreditsService } from "@/lib/services/app-credits";
 import { appFactoryService } from "@/lib/services/app-factory";
-import { AppNameConflictError, appsService } from "@/lib/services/apps";
+import {
+  AppNameConflictError,
+  AppQuotaExceededError,
+  appsService,
+} from "@/lib/services/apps";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -131,6 +135,10 @@ app.post("/", async (c) => {
 
       return c.json(response);
     } catch (err) {
+      if (err instanceof AppQuotaExceededError) {
+        logger.warn("[Apps API] App quota exceeded:", { error: err.message });
+        return c.json({ success: false, error: err.message }, 409);
+      }
       if (err instanceof AppNameConflictError) {
         logger.warn("[Apps API] App name conflict:", {
           conflictType: err.conflictType,

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -817,7 +817,21 @@ export async function handleChatCompletionsPOST(
     if (appId) {
       monetizedApp = await appsService.getById(appId);
       if (monetizedApp?.monetization_enabled) {
-        useAppCredits = true;
+        // SECURITY: only honor X-App-Id when the caller OWNS the app or has an
+        // established app connection (the OAuth /app-auth/connect grant, created
+        // before any paid use). Otherwise a caller could point X-App-Id at
+        // another org's monetized app and forge its analytics/creator-earnings
+        // with self-funded inference. Ignore a spoofed X-App-Id rather than 4xx.
+        const ownsApp =
+          !!user.organization_id &&
+          monetizedApp.organization_id === user.organization_id;
+        const connected =
+          ownsApp || Boolean(await appsService.findAppUser(appId, user.id));
+        if (connected) {
+          useAppCredits = true;
+        } else {
+          monetizedApp = null;
+        }
       }
     }
 

--- a/packages/cloud/api/v1/messages/route.ts
+++ b/packages/cloud/api/v1/messages/route.ts
@@ -503,7 +503,23 @@ app.post("/", async (c) => {
   > | null = null;
   if (appId) {
     monetizedApp = (await appsService.getById(appId)) ?? null;
-    useAppCredits = Boolean(monetizedApp?.monetization_enabled);
+    if (monetizedApp?.monetization_enabled) {
+      // SECURITY: only honor X-App-Id when the caller OWNS the app or has an
+      // established app connection (the OAuth /app-auth/connect grant, created
+      // before any paid use). Otherwise a caller could point X-App-Id at another
+      // org's monetized app and forge its analytics/creator-earnings with
+      // self-funded inference. Ignore a spoofed X-App-Id rather than 4xx.
+      const ownsApp =
+        !!user.organization_id &&
+        monetizedApp.organization_id === user.organization_id;
+      const connected =
+        ownsApp || Boolean(await appsService.findAppUser(appId, user.id));
+      if (connected) {
+        useAppCredits = true;
+      } else {
+        monetizedApp = null;
+      }
+    }
   }
 
   let body: unknown;

--- a/packages/cloud/shared/src/lib/services/app-factory.ts
+++ b/packages/cloud/shared/src/lib/services/app-factory.ts
@@ -1,7 +1,12 @@
 import type { App, NewApp } from "../../db/repositories/apps";
 import { containersEnv } from "../config/containers-env";
 import { logger } from "../utils/logger";
-import { AppNameConflictError, appsService } from "./apps";
+import {
+  AppNameConflictError,
+  AppQuotaExceededError,
+  MAX_APPS_PER_ORG,
+  appsService,
+} from "./apps";
 import { githubReposService } from "./github-repos";
 
 /**
@@ -94,6 +99,18 @@ export class AppFactoryService {
         errorMessage,
         nameCheck.conflictType!,
         nameCheck.suggestedName,
+      );
+    }
+
+    // Step 0.5: Per-org abuse guardrail — cap unbounded app creation (each app
+    // mints an API key + row, and a repo-backed create provisions a GitHub repo
+    // on the shared org). Generous ceiling, far above any legitimate user.
+    const existingApps = await appsService.listByOrganization(
+      data.organization_id,
+    );
+    if (existingApps.length >= MAX_APPS_PER_ORG) {
+      throw new AppQuotaExceededError(
+        `App limit reached (${MAX_APPS_PER_ORG} apps per organization). Delete an unused app or contact support to raise the limit.`,
       );
     }
 

--- a/packages/cloud/shared/src/lib/services/apps.ts
+++ b/packages/cloud/shared/src/lib/services/apps.ts
@@ -27,6 +27,17 @@ export class AppNameConflictError extends Error {
   }
 }
 
+/** Generous per-org guardrail against unbounded app creation (DB rows / repos).
+ * Not a tier/product limit — just an abuse ceiling far above any real user. */
+export const MAX_APPS_PER_ORG = 100;
+
+export class AppQuotaExceededError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AppQuotaExceededError";
+  }
+}
+
 /**
  * Service for app CRUD operations and app management.
  */
@@ -542,6 +553,15 @@ export class AppsService {
 
   async getAppUsers(appId: string, limit?: number): Promise<AppUser[]> {
     return await appsRepository.listAppUsers(appId, limit);
+  }
+
+  /**
+   * Returns the app↔user connection (created by the OAuth /app-auth/connect
+   * grant), or undefined. Used to authorize X-App-Id attribution: a caller may
+   * only attribute inference to an app they own or have connected to.
+   */
+  async findAppUser(appId: string, userId: string): Promise<AppUser | undefined> {
+    return await appsRepository.findAppUser(appId, userId);
   }
 
   async getAnalytics(


### PR DESCRIPTION
Fixes **both** items from #10450 (apps-deploy launch audit). Filed pending design — now solved properly + type-reviewed COMPILES-CLEAN.

## 1. X-App-Id attribution not org-scoped (cross-tenant data-integrity)
`/v1/messages` + `/v1/chat/completions` resolved the monetized app from the attacker-controlled `X-App-Id` header with no ownership/membership check → a caller could point it at **another org's** monetized app and forge its analytics + creator-earnings with self-funded inference (no theft, but cross-tenant forgery).

**The design question was: how to gate it without breaking the third-party monetization flow** (app customers legitimately aren't in the app's org). Answer: the OAuth `/app-auth/connect` grant creates a durable `app_users` record **before** any paid use. So honor `X-App-Id` only when the caller **owns the app OR has that connection** (`appsService.findAppUser`). Legit customers always connect first → unaffected; a spoofed `X-App-Id` is ignored (`monetizedApp=null`), not 4xx'd.

## 2. No per-org app-creation cap
Unbounded apps → unbounded api-keys + repos on the shared GitHub org. Add a generous abuse guardrail `MAX_APPS_PER_ORG=100` (far above any real user — not a tier/product limit) in `appFactoryService.createApp` (the single live create path) + a 409 in `POST /api/v1/apps`.

5 files. Mirrors existing patterns (`findAppUser` wraps the existing repo method; `AppQuotaExceededError` mirrors `AppNameConflictError`).