### PR TITLE
revert: #10542 X-App-Id/app-cap — defer to @lalalune's better-designed slices (#10461/#10468/#10455)

### DIFF
--- a/packages/cloud/api/v1/apps/route.ts
+++ b/packages/cloud/api/v1/apps/route.ts
@@ -11,11 +11,7 @@ import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { appCreditsService } from "@/lib/services/app-credits";
 import { appFactoryService } from "@/lib/services/app-factory";
-import {
-  AppNameConflictError,
-  AppQuotaExceededError,
-  appsService,
-} from "@/lib/services/apps";
+import { AppNameConflictError, appsService } from "@/lib/services/apps";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -135,10 +131,6 @@ app.post("/", async (c) => {
 
       return c.json(response);
     } catch (err) {
-      if (err instanceof AppQuotaExceededError) {
-        logger.warn("[Apps API] App quota exceeded:", { error: err.message });
-        return c.json({ success: false, error: err.message }, 409);
-      }
       if (err instanceof AppNameConflictError) {
         logger.warn("[Apps API] App name conflict:", {
           conflictType: err.conflictType,

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -817,21 +817,7 @@ export async function handleChatCompletionsPOST(
     if (appId) {
       monetizedApp = await appsService.getById(appId);
       if (monetizedApp?.monetization_enabled) {
-        // SECURITY: only honor X-App-Id when the caller OWNS the app or has an
-        // established app connection (the OAuth /app-auth/connect grant, created
-        // before any paid use). Otherwise a caller could point X-App-Id at
-        // another org's monetized app and forge its analytics/creator-earnings
-        // with self-funded inference. Ignore a spoofed X-App-Id rather than 4xx.
-        const ownsApp =
-          !!user.organization_id &&
-          monetizedApp.organization_id === user.organization_id;
-        const connected =
-          ownsApp || Boolean(await appsService.findAppUser(appId, user.id));
-        if (connected) {
-          useAppCredits = true;
-        } else {
-          monetizedApp = null;
-        }
+        useAppCredits = true;
       }
     }
 

--- a/packages/cloud/api/v1/messages/route.ts
+++ b/packages/cloud/api/v1/messages/route.ts
@@ -503,23 +503,7 @@ app.post("/", async (c) => {
   > | null = null;
   if (appId) {
     monetizedApp = (await appsService.getById(appId)) ?? null;
-    if (monetizedApp?.monetization_enabled) {
-      // SECURITY: only honor X-App-Id when the caller OWNS the app or has an
-      // established app connection (the OAuth /app-auth/connect grant, created
-      // before any paid use). Otherwise a caller could point X-App-Id at another
-      // org's monetized app and forge its analytics/creator-earnings with
-      // self-funded inference. Ignore a spoofed X-App-Id rather than 4xx.
-      const ownsApp =
-        !!user.organization_id &&
-        monetizedApp.organization_id === user.organization_id;
-      const connected =
-        ownsApp || Boolean(await appsService.findAppUser(appId, user.id));
-      if (connected) {
-        useAppCredits = true;
-      } else {
-        monetizedApp = null;
-      }
-    }
+    useAppCredits = Boolean(monetizedApp?.monetization_enabled);
   }
 
   let body: unknown;

--- a/packages/cloud/shared/src/lib/services/app-factory.ts
+++ b/packages/cloud/shared/src/lib/services/app-factory.ts
@@ -1,12 +1,7 @@
 import type { App, NewApp } from "../../db/repositories/apps";
 import { containersEnv } from "../config/containers-env";
 import { logger } from "../utils/logger";
-import {
-  AppNameConflictError,
-  AppQuotaExceededError,
-  MAX_APPS_PER_ORG,
-  appsService,
-} from "./apps";
+import { AppNameConflictError, appsService } from "./apps";
 import { githubReposService } from "./github-repos";
 
 /**
@@ -99,18 +94,6 @@ export class AppFactoryService {
         errorMessage,
         nameCheck.conflictType!,
         nameCheck.suggestedName,
-      );
-    }
-
-    // Step 0.5: Per-org abuse guardrail — cap unbounded app creation (each app
-    // mints an API key + row, and a repo-backed create provisions a GitHub repo
-    // on the shared org). Generous ceiling, far above any legitimate user.
-    const existingApps = await appsService.listByOrganization(
-      data.organization_id,
-    );
-    if (existingApps.length >= MAX_APPS_PER_ORG) {
-      throw new AppQuotaExceededError(
-        `App limit reached (${MAX_APPS_PER_ORG} apps per organization). Delete an unused app or contact support to raise the limit.`,
       );
     }
 

--- a/packages/cloud/shared/src/lib/services/apps.ts
+++ b/packages/cloud/shared/src/lib/services/apps.ts
@@ -27,17 +27,6 @@ export class AppNameConflictError extends Error {
   }
 }
 
-/** Generous per-org guardrail against unbounded app creation (DB rows / repos).
- * Not a tier/product limit — just an abuse ceiling far above any real user. */
-export const MAX_APPS_PER_ORG = 100;
-
-export class AppQuotaExceededError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "AppQuotaExceededError";
-  }
-}
-
 /**
  * Service for app CRUD operations and app management.
  */
@@ -553,15 +542,6 @@ export class AppsService {
 
   async getAppUsers(appId: string, limit?: number): Promise<AppUser[]> {
     return await appsRepository.listAppUsers(appId, limit);
-  }
-
-  /**
-   * Returns the app↔user connection (created by the OAuth /app-auth/connect
-   * grant), or undefined. Used to authorize X-App-Id attribution: a caller may
-   * only attribute inference to an app they own or have connected to.
-   */
-  async findAppUser(appId: string, userId: string): Promise<AppUser | undefined> {
-    return await appsRepository.findAppUser(appId, userId);
   }
 
   async getAnalytics(


### PR DESCRIPTION
Reverting my #10542. @lalalune had in-flight draft slices for the same #10450 items, and **his design is better**: he extracted a centralized `appsService.getAuthorizedMonetizedAppForUser(requestedAppId, user)` (vs my inline duplication across messages + chat/completions) and properly nulls the spoofed `appId` downstream (mine left it set) — plus his slices carry tests + evidence.

My #10542 merging first made his #10461/#10468 `dirty`. This revert unblocks them so his tested, cleaner versions land. My coordination miss — deferring to the maintainer. (Low-severity items; brief gap on develop is fine, and they only reach prod via the release.)