### PR TITLE
fix(feed): import EmbeddedAppViewer from the @elizaos/ui barrel (view-bundle guard fix)

### DIFF
--- a/plugins/plugin-feed/src/components/FeedView.tsx
+++ b/plugins/plugin-feed/src/components/FeedView.tsx
@@ -24,8 +24,8 @@ import {
   selectLatestRunForApp,
 } from "@elizaos/app-core/ui-compat";
 
+import { EmbeddedAppViewer } from "@elizaos/ui";
 import { useAgentElement } from "@elizaos/ui/agent-surface";
-import { EmbeddedAppViewer } from "@elizaos/ui/components/apps/EmbeddedAppViewer";
 import { Button } from "@elizaos/ui/components/ui/button";
 import { getActiveViewModality } from "@elizaos/ui/platform";
 import { useAppSelector } from "@elizaos/ui/state";


### PR DESCRIPTION
## What

Fixes a **build-breaking bug on `develop`** found while reviewing the recently-landed view-architecture PRs: `plugins/plugin-feed/src/components/FeedView.tsx` imports `EmbeddedAppViewer` from the deep subpath `@elizaos/ui/components/apps/EmbeddedAppViewer`.

The view-bundle import guard (`packages/scripts/view-bundle-import-guard.mjs`) only allows specifiers that are **keys in `DynamicViewLoader`'s `HOST_EXTERNAL_IMPORTERS` map**. That deep subpath is **not** a key, so plugin-feed's built `dist/views/bundle.js` externalises an import the host can never rewrite → the view fails to load in the browser (`Failed to resolve module specifier`) and `build-views` fails the guard.

## Fix

One line: import from the bare `@elizaos/ui` barrel, which **is** an allowed key. Both barrels re-export the symbol, so it resolves in **both** build paths:
- view-bundle runtime → `importUiRootCompat` → `index.ts:159` (`export * from "./components/apps/EmbeddedAppViewer"`)
- app-renderer alias → `browser.ts:34` (`export * from "./components/apps/EmbeddedAppViewer.tsx"`)

This matches the plugin's own documented contract ("EmbeddedAppViewer (from `@elizaos/ui`)" in `plugins/plugin-feed/CLAUDE.md`).

## Evidence

```
# before: bundle imports the deep subpath -> guard fails
# after fix, rebuilt dist/views/bundle.js:
$ rg -o 'from "@elizaos/ui[^"]*"' plugins/plugin-feed/dist/views/bundle.js | sort -u
from "@elizaos/ui"               # <- bare barrel (allowed key)
from "@elizaos/ui/agent-surface"
from "@elizaos/ui/components/ui/button"
from "@elizaos/ui/platform"
from "@elizaos/ui/spatial"
from "@elizaos/ui/state"
# deep subpath GONE; biome check clean
```

## Context

Surfaced during an adversarial sub-agent review of this session's landed/competing PRs (#10366 deploy, #10412 camera/wearables, #10434 companion, steward removal, #10333 benchmark lanes, #10408 external-dataset). All others verified **good**; notably the views review's claimed "wearables Settings section never registers" was **refuted** — facewear is auto-loaded via the `elizaos.appRegister` vite discovery (CI-asserted in `plugin-registrations.test.ts`). This feed import is the one real, build-breaking bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
