### PR TITLE
fix(cloud): agent-provisioning launch hardening — cross-tenant IDOR + free-compute leaks + ID leak

### DIFF
--- a/packages/cloud/api/agents/[id]/a2a/route.ts
+++ b/packages/cloud/api/agents/[id]/a2a/route.ts
@@ -103,10 +103,10 @@ export function generateAgentCard(character: UserCharacter, baseUrl: string) {
       paymentMethods: ["api_key_credits"],
       minimumPayment: 0.001,
     },
-    contact: {
-      creatorId: character.user_id,
-      organizationId: character.organization_id,
-    },
+    // SECURITY: this card is served UNAUTHENTICATED (public /api/agents prefix)
+    // with CORS *. Do NOT expose the creator's internal user_id/organization_id
+    // here (deanonymization/correlation of which org owns which agents). The MCP
+    // card omits these too — keep parity.
   };
 }
 

--- a/packages/cloud/api/my-agents/characters/[id]/clone/route.ts
+++ b/packages/cloud/api/my-agents/characters/[id]/clone/route.ts
@@ -38,6 +38,20 @@ app.post("/", async (c) => {
       return c.json({ success: false, error: "Character not found" }, 404);
     }
 
+    // SECURITY: charactersService.getById is NOT org/visibility-scoped, so gate
+    // clonability — a caller may only clone a character they own, or one that is
+    // public/template. Otherwise any authenticated user could clone (and read
+    // back) another org's PRIVATE character config (system prompt, knowledge,
+    // settings) — cross-tenant IP disclosure. 404 (not 403) to avoid an
+    // existence oracle. Mirrors the app-link route's guard.
+    if (
+      original.user_id !== user.id &&
+      !original.is_public &&
+      !original.is_template
+    ) {
+      return c.json({ success: false, error: "Character not found" }, 404);
+    }
+
     const cloneName = body.name || `${original.name} (Copy)`;
 
     const clonedCharacter = await charactersService.create({

--- a/packages/cloud/api/v1/coding-containers/route.ts
+++ b/packages/cloud/api/v1/coding-containers/route.ts
@@ -54,6 +54,8 @@ import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { containersEnv } from "@/lib/config/containers-env";
+import { AGENT_PRICING } from "@/lib/constants/agent-pricing";
+import { checkAgentCreditGate } from "@/lib/services/agent-billing-gate";
 import { getElizaAgentPublicWebUiUrl } from "@/lib/eliza-agent-web-ui";
 import {
   buildCodingContainerCreatePayload,
@@ -199,6 +201,31 @@ async function createCodingContainer(
           `are not accepted while CONTAINER_IMAGE_REQUIRE_DIGEST is enabled.`,
       },
       403,
+    );
+  }
+
+  // ── Credit gate: require the minimum deposit before provisioning paid
+  // compute (same as every sibling provision route). Without this, a $0/negative
+  // org could launch a metered coding container and get free compute until the
+  // hourly cron's warning + 48h grace expires. The route's downstream 402
+  // "insufficient_credit" poll branch is dead — provision() has no credit gate —
+  // so this is the only real gate. ──
+  const creditCheck = await checkAgentCreditGate(user.organization_id);
+  if (!creditCheck.allowed) {
+    logger.warn("[CodingContainers API] provision blocked: insufficient credits", {
+      orgId: user.organization_id,
+      balance: creditCheck.balance,
+      required: AGENT_PRICING.MINIMUM_DEPOSIT,
+    });
+    return c.json(
+      {
+        success: false,
+        code: "insufficient_credits",
+        error: creditCheck.error,
+        requiredBalance: AGENT_PRICING.MINIMUM_DEPOSIT,
+        currentBalance: creditCheck.balance,
+      },
+      402,
     );
   }
 

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -16,6 +16,7 @@ import {
   agentSandboxesRepository,
   prepareAgentBackupInsertData,
 } from "../../db/repositories/agent-sandboxes";
+import { agentBillingRepository } from "../../db/repositories/agent-billing";
 import { userCharactersRepository } from "../../db/repositories/characters";
 import { dockerNodesRepository } from "../../db/repositories/docker-nodes";
 import { sharedRuntimeHistoryRepository } from "../../db/repositories/shared-runtime-history";
@@ -1253,6 +1254,18 @@ export class ElizaSandboxService {
         }
 
         const updated = await agentSandboxesRepository.update(rec.id, updateData);
+
+        // Re-enter the billable set on every successful provision. A
+        // credit-suspended agent (billing_status='suspended') that a user tops
+        // up and resumes/wakes via the user-facing routes would otherwise run
+        // (status='running') permanently EXCLUDED from listBillableSandboxes =
+        // free dedicated compute forever. The service-key resume/restart routes
+        // already reactivate; do it here so ALL provision paths re-enter billing.
+        // Idempotent + exempt-guarded (ne billing_status 'exempt').
+        await agentBillingRepository.reactivateSandboxBillingAfterFunding(
+          rec.id,
+          new Date(),
+        );
 
         logger.info("[agent-sandbox] Provisioned", {
           agentId: rec.id,


### PR DESCRIPTION
Four findings from an adversarial audit of the **agent-provisioning / container-lifecycle** surface (the core product — real \$/day compute + multi-tenancy), all verified real+reachable. Type-reviewed **COMPILES-CLEAN**.

### 1. [HIGH · isolation] Cross-tenant agent-config exfiltration via clone (IDOR)
`POST /api/my-agents/characters/:id/clone` loaded the source via the **unscoped** `charactersService.getById` (no user/org/visibility filter) and copied the full config into the caller's namespace, returning it. **Any authenticated user could clone — and read back — another org's PRIVATE character** (system prompt = customer IP, knowledge, settings). Char IDs are non-secret (exposed in share/app/a2a URLs). **Fix:** gate clonability to own-OR-public-OR-template, else 404 — mirrors the existing app-link route guard. (Clone was the lone outlier; siblings already gate via `getByIdForUser`.)

### 2. [HIGH · money] Resume/wake of a credit-suspended agent → free compute forever
The hourly billing cron only charges `billing_status ∈ {active,warning,shutdown_pending}`. Credit-suspension sets `suspended`. The **user-facing** resume/wake/provision routes top-up-gate + run `provision()`, which sets `status='running'` but **never resets `billing_status`** → the agent runs permanently excluded from `listBillableSandboxes` = indefinite free dedicated compute (~\$7.20/mo each, real Hetzner cost), deliberately triggerable. The service-key routes already reactivate; the user-facing ones didn't. **Fix:** call `reactivateSandboxBillingAfterFunding` in `provision()`'s success path so ALL paths re-enter billing (idempotent, exempt-guarded).

### 3. [MEDIUM · money] Coding-container provision has no credit gate
`POST /api/v1/coding-containers` provisioned a metered container with **no `checkAgentCreditGate`** (its downstream 402 branch is dead — `provision()` has no gate). A \$0 org got free compute until the 48h grace expired. **Fix:** add the same gate every sibling provision route uses (also revives the dead 402 branch).

### 4. [LOW · security] Public A2A card leaks creator's internal IDs
The unauthenticated (`/api/agents` public prefix, CORS *, cached) A2A agent card embedded `contact: { creatorId: user_id, organizationId: org_id }` → anonymous deanonymization/correlation. **Fix:** dropped the block (the MCP card already omits them).

(5th finding — payout-processor stale-lock recovery dead code — filed as #10553; needs careful on-chain-reconciliation design, a naive fix double-pays.)

Money/isolation paths — flagged for review, not self-merged.