### PR TITLE
fix(cloud): settle reservation in /v1/messages stream catch (leak backstop)

### DIFF
--- a/packages/cloud/api/v1/messages/route.ts
+++ b/packages/cloud/api/v1/messages/route.ts
@@ -1228,6 +1228,14 @@ async function handleStream(
 
         controller.enqueue(sse("message_stop", { type: "message_stop" }));
       } catch (error) {
+        // Backstop: this catch can run even when the AI SDK never invokes (or
+        // doesn't await) onError — e.g. a fullStream `error` part re-thrown here,
+        // or a controller.enqueue throw on client disconnect racing ahead of
+        // onAbort. Settle the reservation here too so the upfront hold is never
+        // leaked (a permanent overcharge). The settler is first-call-wins
+        // idempotent, so this cannot double-refund if onError already won the
+        // race. Mirrors the /v1/chat/completions backstop.
+        await settleReservation(0);
         const message = error instanceof Error ? error.message : String(error);
         logger.error("[Messages API] Stream error", { error: message });
         controller.enqueue(


### PR DESCRIPTION
From the inference-billing lifecycle audit (highest-volume money path), adversarially verified.

`/v1/messages` streaming reserves credits upfront (real debit) and relies on the AI SDK `onError` to settle the hold. The in-stream `catch` (fullStream error part re-thrown, or `controller.enqueue` throw on client disconnect) only logged + emitted an SSE error — **never settling the reservation.** When `onError` doesn't fire/await (SDK race, CF-Worker isolate teardown after `controller.close()`, disconnect racing `onAbort`), the hold stays permanently debited → **overcharge** on the paid Anthropic-Messages path (Claude Code sends large max_tokens → hold up to ~$0.5–0.7).

Fix: `await settleReservation(0)` at the top of the catch — the exact backstop the sibling `/v1/chat/completions` already has (with the same rationale comment). First-call-wins idempotent → no double-refund.

Low severity (narrow race/teardown window), but a real money-correctness backstop + one-line fix mirroring an established sibling. (A related embeddings reservation-leak is filed separately — it needs a single-reconcile-owner restructure to avoid a double-refund trap, not slopped here.)