### PR TITLE
fix(ui): restore clean first-run runtime chooser

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -77,6 +77,7 @@ import {
   FOCUS_CONNECTOR_EVENT,
   type FocusConnectorEventDetail,
 } from "./events";
+import { FirstRunRuntimeChooser } from "./first-run/FirstRunRuntimeChooser";
 import { FirstRunConductorMount } from "./first-run/use-first-run-conductor";
 import { BugReportProvider, useBugReportState, useContextMenu } from "./hooks";
 import { useAuthStatus } from "./hooks/useAuthStatus";
@@ -2300,6 +2301,7 @@ export function App() {
             transcript the overlay renders and routes first-run picks to the
             headless finish use case. Renders null. */}
         <FirstRunConductorMount />
+        <FirstRunRuntimeChooser />
         {/* Interactive tutorial: a persistent spotlight overlay that survives
             navigation (it sends the user to Settings, back home, …). Renders
             only when the tutorial is active (launched from the home Tutorial

--- a/packages/ui/src/first-run/FirstRunRuntimeChooser.test.tsx
+++ b/packages/ui/src/first-run/FirstRunRuntimeChooser.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Z_FIRST_RUN_CHOOSER } from "../lib/floating-layers";
+import { FirstRunRuntimeChooserSurface } from "./FirstRunRuntimeChooser";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("FirstRunRuntimeChooserSurface", () => {
+  it("shows the clean runtime picker with advanced setup collapsed", () => {
+    render(
+      <FirstRunRuntimeChooserSurface
+        appName="elizaOS"
+        step="runtime"
+        advancedOpen={false}
+        busyChoice={null}
+        error={null}
+        onSelect={vi.fn()}
+        onProviderSelect={vi.fn()}
+        onToggleAdvanced={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("dialog", { name: "Choose how Eliza should run" }),
+    ).toBeTruthy();
+    expect(screen.getByText("Sign in with Eliza Cloud")).toBeTruthy();
+    expect(screen.getByText("Run on this device")).toBeTruthy();
+    expect(screen.getByText("Advanced setup")).toBeTruthy();
+    expect(screen.queryByText("Bring your own keys")).toBeNull();
+    expect(screen.getByTestId("first-run-runtime-chooser").style.zIndex).toBe(
+      String(Z_FIRST_RUN_CHOOSER),
+    );
+  });
+
+  it("routes primary and advanced choices through callbacks", () => {
+    const onSelect = vi.fn();
+    const onToggleAdvanced = vi.fn();
+    render(
+      <FirstRunRuntimeChooserSurface
+        appName="elizaOS"
+        step="runtime"
+        advancedOpen
+        busyChoice={null}
+        error={null}
+        onSelect={onSelect}
+        onProviderSelect={vi.fn()}
+        onToggleAdvanced={onToggleAdvanced}
+        onBack={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("first-run-chooser-cloud"));
+    expect(onSelect).toHaveBeenCalledWith("cloud");
+
+    fireEvent.click(screen.getByText("Advanced setup"));
+    expect(onToggleAdvanced).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByTestId("first-run-chooser-other"));
+    expect(onSelect).toHaveBeenCalledWith("other");
+  });
+
+  it("keeps provider selection in the clean chooser surface", () => {
+    const onProviderSelect = vi.fn();
+    const onBack = vi.fn();
+    render(
+      <FirstRunRuntimeChooserSurface
+        appName="elizaOS"
+        step="provider"
+        advancedOpen={false}
+        busyChoice={null}
+        error={null}
+        onSelect={vi.fn()}
+        onProviderSelect={onProviderSelect}
+        onToggleAdvanced={vi.fn()}
+        onBack={onBack}
+      />,
+    );
+
+    expect(screen.getByText("Choose how Eliza should think")).toBeTruthy();
+    fireEvent.click(screen.getByTestId("first-run-provider-on-device"));
+    expect(onProviderSelect).toHaveBeenCalledWith("on-device");
+
+    fireEvent.click(screen.getByText("Back"));
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/first-run/FirstRunRuntimeChooser.tsx
+++ b/packages/ui/src/first-run/FirstRunRuntimeChooser.tsx
@@ -1,0 +1,401 @@
+import { ChevronDown, Cloud, Cpu, KeyRound, Loader2 } from "lucide-react";
+import * as React from "react";
+import { ElizaMark } from "../components/brand/eliza-mark";
+import { getBootConfig } from "../config/boot-config-store";
+import { Z_FIRST_RUN_CHOOSER } from "../lib/floating-layers";
+import { useAppSelectorShallow } from "../state";
+import { useConversationMessages } from "../state/ConversationMessagesContext.hooks";
+import { preOpenWindow } from "../utils";
+import {
+  FIRST_RUN_ACTION_PREFIX,
+  tryHandleFirstRunAction,
+} from "./first-run-action-channel";
+
+type RuntimeChoice = "cloud" | "local" | "other";
+type ProviderChoice = "on-device" | "elizacloud" | "other";
+type ChooserStep = "runtime" | "provider";
+
+type ChoiceDefinition = {
+  id: RuntimeChoice;
+  title: string;
+  description: string;
+  Icon: typeof Cloud;
+  testId: string;
+};
+
+const PRIMARY_CHOICES: ChoiceDefinition[] = [
+  {
+    id: "cloud",
+    title: "Sign in with Eliza Cloud",
+    description:
+      "Use the managed runtime, sync, and hosted agent from your account.",
+    Icon: Cloud,
+    testId: "first-run-chooser-cloud",
+  },
+  {
+    id: "local",
+    title: "Run on this device",
+    description:
+      "Start a local agent and choose on-device or cloud inference next.",
+    Icon: Cpu,
+    testId: "first-run-chooser-local",
+  },
+];
+
+const ADVANCED_CHOICE: ChoiceDefinition = {
+  id: "other",
+  title: "Bring your own keys",
+  description:
+    "Run locally and configure your preferred model provider in Settings.",
+  Icon: KeyRound,
+  testId: "first-run-chooser-other",
+};
+
+export type FirstRunRuntimeChooserSurfaceProps = {
+  appName: string;
+  step: ChooserStep;
+  busyChoice: RuntimeChoice | ProviderChoice | null;
+  error: string | null;
+  advancedOpen: boolean;
+  onToggleAdvanced: () => void;
+  onSelect: (choice: RuntimeChoice) => void;
+  onProviderSelect: (choice: ProviderChoice) => void;
+  onBack: () => void;
+};
+
+export function FirstRunRuntimeChooserSurface({
+  appName,
+  step,
+  busyChoice,
+  error,
+  advancedOpen,
+  onToggleAdvanced,
+  onSelect,
+  onProviderSelect,
+  onBack,
+}: FirstRunRuntimeChooserSurfaceProps): React.ReactElement {
+  const onProviderStep = step === "provider";
+  return (
+    <div
+      className="fixed inset-0 flex items-start justify-center overflow-y-auto bg-black/60 px-5 py-[calc(var(--safe-area-top,0px)+3rem)] text-white backdrop-blur-xl sm:items-center sm:py-8"
+      data-testid="first-run-runtime-chooser"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="first-run-runtime-chooser-title"
+      style={{ zIndex: Z_FIRST_RUN_CHOOSER }}
+    >
+      <div className="flex w-full max-w-[27rem] flex-col gap-7">
+        <div className="flex items-center justify-center gap-3">
+          <ElizaMark className="h-11 w-11" />
+          <span className="text-3xl font-medium leading-none tracking-normal">
+            {appName}
+          </span>
+        </div>
+
+        <div className="flex flex-col gap-3 text-center">
+          <h1
+            id="first-run-runtime-chooser-title"
+            className="text-[22px] font-semibold tracking-normal"
+          >
+            {onProviderStep
+              ? "Choose how Eliza should think"
+              : "Choose how Eliza should run"}
+          </h1>
+          <p className="text-sm leading-6 text-white/70">
+            {onProviderStep
+              ? "Use the on-device default, Eliza Cloud inference, or configure your own provider."
+              : "Pick the clean default now. Advanced provider setup stays one tap away."}
+          </p>
+        </div>
+
+        {onProviderStep ? (
+          <div className="flex flex-col gap-3">
+            <ProviderChoiceButton
+              id="on-device"
+              title="On this device"
+              description="Download and run the recommended local model."
+              Icon={Cpu}
+              busy={busyChoice === "on-device"}
+              disabled={busyChoice !== null}
+              onSelect={onProviderSelect}
+            />
+            <ProviderChoiceButton
+              id="elizacloud"
+              title="Eliza Cloud inference"
+              description="Keep the agent local, but use cloud-hosted model inference."
+              Icon={Cloud}
+              busy={busyChoice === "elizacloud"}
+              disabled={busyChoice !== null}
+              onSelect={onProviderSelect}
+            />
+            <ProviderChoiceButton
+              id="other"
+              title="Other provider"
+              description="Continue locally and configure keys in Settings."
+              Icon={KeyRound}
+              busy={busyChoice === "other"}
+              disabled={busyChoice !== null}
+              onSelect={onProviderSelect}
+            />
+            <button
+              type="button"
+              className="min-h-11 rounded-md px-3 text-sm font-medium text-white/70 transition-colors hover:bg-white/[0.06] hover:text-white disabled:opacity-60"
+              disabled={busyChoice !== null}
+              onClick={onBack}
+            >
+              Back
+            </button>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {PRIMARY_CHOICES.map((choice) => (
+              <RuntimeChoiceButton
+                key={choice.id}
+                choice={choice}
+                busy={busyChoice === choice.id}
+                disabled={busyChoice !== null}
+                onSelect={onSelect}
+              />
+            ))}
+
+            <div className="rounded-lg border border-white/12 bg-white/[0.06]">
+              <button
+                type="button"
+                className="flex min-h-12 w-full items-center justify-between gap-3 px-4 text-left text-sm font-medium text-white/80 transition-colors hover:bg-white/[0.06] disabled:opacity-60"
+                aria-expanded={advancedOpen}
+                onClick={onToggleAdvanced}
+                disabled={busyChoice !== null}
+              >
+                <span>Advanced setup</span>
+                <ChevronDown
+                  className={`h-4 w-4 transition-transform ${advancedOpen ? "rotate-180" : ""}`}
+                  aria-hidden
+                />
+              </button>
+              {advancedOpen ? (
+                <div className="border-t border-white/10 p-3">
+                  <RuntimeChoiceButton
+                    choice={ADVANCED_CHOICE}
+                    busy={busyChoice === ADVANCED_CHOICE.id}
+                    disabled={busyChoice !== null}
+                    onSelect={onSelect}
+                  />
+                </div>
+              ) : null}
+            </div>
+          </div>
+        )}
+
+        {error ? (
+          <div
+            className="rounded-md border border-red-300/30 bg-red-950/35 px-3 py-2 text-sm leading-5 text-red-100"
+            role="status"
+          >
+            {error}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function ProviderChoiceButton({
+  id,
+  title,
+  description,
+  Icon,
+  busy,
+  disabled,
+  onSelect,
+}: {
+  id: ProviderChoice;
+  title: string;
+  description: string;
+  Icon: typeof Cloud;
+  busy: boolean;
+  disabled: boolean;
+  onSelect: (choice: ProviderChoice) => void;
+}): React.ReactElement {
+  return (
+    <button
+      type="button"
+      data-testid={`first-run-provider-${id}`}
+      disabled={disabled}
+      onClick={() => onSelect(id)}
+      className="group flex min-h-[5.75rem] w-full items-center gap-4 rounded-lg border border-white/14 bg-white/[0.08] px-4 py-3 text-left transition-[border-color,background-color,transform] hover:border-white/32 hover:bg-white/[0.12] active:scale-[0.99] disabled:pointer-events-none disabled:opacity-70"
+    >
+      <span className="grid h-11 w-11 shrink-0 place-items-center rounded-md border border-white/12 bg-black/25 text-white/90">
+        {busy ? (
+          <Loader2 className="h-5 w-5 animate-spin" aria-hidden />
+        ) : (
+          <Icon className="h-5 w-5" aria-hidden />
+        )}
+      </span>
+      <span className="min-w-0">
+        <span className="block text-[15px] font-semibold leading-5 tracking-normal text-white">
+          {title}
+        </span>
+        <span className="mt-1 block text-sm leading-5 text-white/62">
+          {description}
+        </span>
+      </span>
+    </button>
+  );
+}
+
+function RuntimeChoiceButton({
+  choice,
+  busy,
+  disabled,
+  onSelect,
+}: {
+  choice: ChoiceDefinition;
+  busy: boolean;
+  disabled: boolean;
+  onSelect: (choice: RuntimeChoice) => void;
+}): React.ReactElement {
+  const { Icon } = choice;
+  return (
+    <button
+      type="button"
+      data-testid={choice.testId}
+      disabled={disabled}
+      onClick={() => onSelect(choice.id)}
+      className="group flex min-h-[5.75rem] w-full items-center gap-4 rounded-lg border border-white/14 bg-white/[0.08] px-4 py-3 text-left transition-[border-color,background-color,transform] hover:border-white/32 hover:bg-white/[0.12] active:scale-[0.99] disabled:pointer-events-none disabled:opacity-70"
+    >
+      <span className="grid h-11 w-11 shrink-0 place-items-center rounded-md border border-white/12 bg-black/25 text-white/90">
+        {busy ? (
+          <Loader2 className="h-5 w-5 animate-spin" aria-hidden />
+        ) : (
+          <Icon className="h-5 w-5" aria-hidden />
+        )}
+      </span>
+      <span className="min-w-0">
+        <span className="block text-[15px] font-semibold leading-5 tracking-normal text-white">
+          {choice.title}
+        </span>
+        <span className="mt-1 block text-sm leading-5 text-white/62">
+          {choice.description}
+        </span>
+      </span>
+    </button>
+  );
+}
+
+export function FirstRunRuntimeChooser(): React.ReactElement | null {
+  const { firstRunComplete, handleCloudLogin, startupPhase } =
+    useAppSelectorShallow((state) => ({
+      firstRunComplete: state.firstRunComplete,
+      handleCloudLogin: state.handleCloudLogin,
+      startupPhase: state.startupCoordinator.phase,
+    }));
+  const [dismissed, setDismissed] = React.useState(false);
+  const [advancedOpen, setAdvancedOpen] = React.useState(false);
+  const [step, setStep] = React.useState<ChooserStep>("runtime");
+  const [busyChoice, setBusyChoice] = React.useState<
+    RuntimeChoice | ProviderChoice | null
+  >(null);
+  const [error, setError] = React.useState<string | null>(null);
+  const { conversationMessages, setConversationMessages } =
+    useConversationMessages();
+  const active =
+    firstRunComplete === false && startupPhase === "first-run-required";
+
+  const removeSyntheticChoiceTurns = React.useCallback(
+    (...ids: string[]) => {
+      const stale = new Set(ids);
+      setConversationMessages((previous) => {
+        let changed = false;
+        const next = previous.filter((message) => {
+          const remove = stale.has(message.id);
+          changed ||= remove;
+          return !remove;
+        });
+        return changed ? next : previous;
+      });
+    },
+    [setConversationMessages],
+  );
+
+  React.useEffect(() => {
+    if (!active || dismissed) return;
+    const hasSyntheticChoiceTurns = conversationMessages.some(
+      (message) =>
+        message.id === "first-run:greeting" ||
+        message.id === "first-run:provider",
+    );
+    if (!hasSyntheticChoiceTurns) return;
+    removeSyntheticChoiceTurns("first-run:greeting", "first-run:provider");
+  }, [active, conversationMessages, dismissed, removeSyntheticChoiceTurns]);
+
+  React.useEffect(() => {
+    if (active) return;
+    setDismissed(false);
+    setAdvancedOpen(false);
+    setStep("runtime");
+    setBusyChoice(null);
+    setError(null);
+  }, [active]);
+
+  if (!active || dismissed) return null;
+
+  const appName = getBootConfig().branding?.appName ?? "elizaOS";
+
+  return (
+    <FirstRunRuntimeChooserSurface
+      appName={appName}
+      step={step}
+      advancedOpen={advancedOpen}
+      busyChoice={busyChoice}
+      error={error}
+      onToggleAdvanced={() => {
+        setAdvancedOpen((value) => !value);
+        setError(null);
+      }}
+      onSelect={(choice) => {
+        setBusyChoice(choice);
+        setError(null);
+        const cloudAuthWindow = choice === "cloud" ? preOpenWindow() : null;
+        const handled = tryHandleFirstRunAction(
+          `${FIRST_RUN_ACTION_PREFIX}runtime:${choice}`,
+        );
+        if (!handled) {
+          cloudAuthWindow?.close();
+          setBusyChoice(null);
+          setError("Setup is still initializing. Try again in a moment.");
+          return;
+        }
+        removeSyntheticChoiceTurns("first-run:greeting");
+        if (choice === "cloud") {
+          void handleCloudLogin(cloudAuthWindow).catch(() => {
+            // The cloud state hook owns the user-facing login error; the
+            // conductor also reports provisioning failures in the transcript.
+          });
+          setDismissed(true);
+          return;
+        }
+        setBusyChoice(null);
+        setStep("provider");
+      }}
+      onProviderSelect={(choice) => {
+        setBusyChoice(choice);
+        setError(null);
+        const handled = tryHandleFirstRunAction(
+          `${FIRST_RUN_ACTION_PREFIX}provider:${choice}`,
+        );
+        if (!handled) {
+          setBusyChoice(null);
+          setError("Setup is still initializing. Try again in a moment.");
+          return;
+        }
+        removeSyntheticChoiceTurns("first-run:provider");
+        setDismissed(true);
+      }}
+      onBack={() => {
+        setStep("runtime");
+        setBusyChoice(null);
+        setError(null);
+      }}
+    />
+  );
+}

--- a/packages/ui/src/lib/floating-layers.ts
+++ b/packages/ui/src/lib/floating-layers.ts
@@ -12,6 +12,7 @@ export const Z_DIALOG = 170;
 export const Z_OVERLAY = 200;
 export const Z_TOOLTIP = 300;
 export const Z_SHELL_OVERLAY = 9000;
+export const Z_FIRST_RUN_CHOOSER = 9400;
 // The interactive tutorial spotlight: sits above the chat/shell overlay so its
 // glow + card always read over an expanded chat, but stays BELOW the
 // system-critical band so a fatal banner can never be painted over by the tour.


### PR DESCRIPTION
## Summary
- Restores a clean first-run runtime chooser as the visible entry point while keeping the existing headless first-run conductor/provisioning path.
- Routes Cloud, local, and advanced/BYOK choices through the existing first-run action channel instead of adding a second provisioning path.
- Gives the chooser its own z-index above the shell overlay and removes stale synthetic chat-choice turns after selection.

## Why
The chat-style first-run surface could leave stale choice pills visible and the shell overlay could intercept the first-run chooser. This puts the clean chooser back in front of the user while preserving the newer conductor work underneath.

## Validation
- `bunx biome check packages/ui/src/App.tsx packages/ui/src/lib/floating-layers.ts packages/ui/src/first-run/FirstRunRuntimeChooser.tsx packages/ui/src/first-run/FirstRunRuntimeChooser.test.tsx`
- `bunx vitest run packages/ui/src/first-run/FirstRunRuntimeChooser.test.tsx packages/ui/src/first-run/first-run-action-channel.test.ts --environment jsdom`
- `VITE_API_URL=https://api-staging.elizacloud.ai NEXT_PUBLIC_API_URL=https://api-staging.elizacloud.ai VITE_APP_URL=https://staging.elizacloud.ai NEXT_PUBLIC_APP_URL=https://app-staging.elizacloud.ai VITE_ELIZA_APP_URL=https://app-staging.elizacloud.ai NEXT_PUBLIC_STEWARD_TENANT_ID=elizacloud-staging VITE_ENVIRONMENT=staging bun run --cwd packages/app build:web`
- Playwright smoke on local preview `http://127.0.0.1:4174/?runtime=first-run&reset=1`: chooser visible, z-index 9400, advanced toggle works, local path reaches provider step, Cloud click opens `https://elizacloud.ai/auth/cli-login?...`, no stale runtime choices remain, no relevant console errors.

Note: local static preview still returns expected 502s for `/api/*` because no backend proxy is running on the preview port; those were ignored only after confirming no non-generic app console errors.