### PR TITLE
test(cloud): green up #10554 — fix a2a/billing/credit-gate tests + add IDOR/leak regression coverage

### DIFF
--- a/packages/cloud/api/__tests__/a2a-agent-card.test.ts
+++ b/packages/cloud/api/__tests__/a2a-agent-card.test.ts
@@ -137,16 +137,17 @@ describe("generateAgentCard", () => {
     }
   });
 
-  test("exposes contact ids and a single bearer auth scheme", () => {
+  test("omits internal contact ids and exposes a single bearer auth scheme", () => {
     const character = buildCharacter({
       user_id: "11111111-1111-1111-1111-111111111111",
       organization_id: "22222222-2222-2222-2222-222222222222",
     });
     const card = generateAgentCard(character, BASE_URL);
-    expect(card.contact).toEqual({
-      creatorId: "11111111-1111-1111-1111-111111111111",
-      organizationId: "22222222-2222-2222-2222-222222222222",
-    });
+    // SECURITY: this card is served UNAUTHENTICATED with CORS *, so the
+    // creator's internal user_id/organization_id MUST NOT appear on it
+    // (deanonymization/correlation of which org owns which agents). The field
+    // was dropped from the card type entirely — assert it is absent at runtime.
+    expect((card as { contact?: unknown }).contact).toBeUndefined();
     expect(card.authentication.schemes).toHaveLength(1);
     expect(card.authentication.schemes[0]?.scheme).toBe("bearer");
   });

--- a/packages/cloud/api/agents/[id]/a2a/route.ts
+++ b/packages/cloud/api/agents/[id]/a2a/route.ts
@@ -103,10 +103,10 @@ export function generateAgentCard(character: UserCharacter, baseUrl: string) {
       paymentMethods: ["api_key_credits"],
       minimumPayment: 0.001,
     },
-    contact: {
-      creatorId: character.user_id,
-      organizationId: character.organization_id,
-    },
+    // SECURITY: this card is served UNAUTHENTICATED (public /api/agents prefix)
+    // with CORS *. Do NOT expose the creator's internal user_id/organization_id
+    // here (deanonymization/correlation of which org owns which agents). The MCP
+    // card omits these too — keep parity.
   };
 }
 

--- a/packages/cloud/api/my-agents/characters/[id]/clone/route.test.ts
+++ b/packages/cloud/api/my-agents/characters/[id]/clone/route.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Cross-tenant IDOR regression for POST /api/my-agents/characters/:id/clone
+ * (#10554, finding 1).
+ *
+ * `charactersService.getById` is NOT org/visibility-scoped, so the route must
+ * gate clonability: a caller may clone a character only if they own it, or it is
+ * public/template. Cloning another org's PRIVATE character would copy back its
+ * system prompt / knowledge / settings (cross-tenant IP disclosure), so that
+ * case must 404 (a 404, not 403, to avoid an existence oracle). These tests drive
+ * the REAL route handler; only the data/auth boundaries are mocked.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+import type { UserCharacter } from "@/db/repositories/characters";
+
+const CALLER_ID = "00000000-0000-0000-0000-0000000000c1";
+const OTHER_OWNER_ID = "00000000-0000-0000-0000-0000000000ff";
+
+const requireUserOrApiKeyWithOrg = mock(async () => ({
+  id: CALLER_ID,
+  organization_id: "00000000-0000-0000-0000-0000000000a1",
+}));
+const getById = mock(async (): Promise<UserCharacter | undefined> => undefined);
+const create = mock(async (input: Record<string, unknown>) => ({
+  ...buildCharacter(),
+  id: "00000000-0000-0000-0000-0000000000cc",
+  username: "clone-1",
+  ...input,
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+}));
+
+mock.module("@/lib/services/characters/characters", () => ({
+  charactersService: { getById, create },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    debug: mock(() => undefined),
+    error: mock(() => undefined),
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+  },
+}));
+
+function buildCharacter(overrides: Partial<UserCharacter> = {}): UserCharacter {
+  return {
+    id: "00000000-0000-0000-0000-000000000001",
+    organization_id: "00000000-0000-0000-0000-0000000000b9",
+    user_id: OTHER_OWNER_ID,
+    name: "Private Agent",
+    username: "private-agent",
+    system: "PROPRIETARY SYSTEM PROMPT — do not leak.",
+    bio: "I am a private agent.",
+    message_examples: [],
+    post_examples: [],
+    topics: [],
+    adjectives: [],
+    knowledge: [],
+    plugins: [],
+    settings: {},
+    secrets: {},
+    style: {},
+    character_data: {},
+    is_template: false,
+    is_public: false,
+    avatar_url: null,
+    category: null,
+    tags: [],
+    featured: false,
+    view_count: 0,
+    interaction_count: 0,
+    popularity_score: 0,
+    source: "cloud",
+    token_address: null,
+    token_chain: null,
+    token_name: null,
+    token_ticker: null,
+    erc8004_registered: false,
+    erc8004_network: null,
+    erc8004_agent_id: null,
+    erc8004_agent_uri: null,
+    erc8004_tx_hash: null,
+    erc8004_registered_at: null,
+    monetization_enabled: false,
+    inference_markup_percentage: "0.00",
+    payout_wallet_address: null,
+    total_inference_requests: 0,
+    total_creator_earnings: "0.0000",
+    total_platform_revenue: "0.0000",
+    a2a_enabled: true,
+    mcp_enabled: true,
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  };
+}
+
+const { default: cloneRoute } = await import("./route");
+
+const app = new Hono();
+app.route("/characters/:id/clone", cloneRoute);
+
+async function postClone(characterId: string): Promise<Response> {
+  return app.fetch(
+    new Request(`https://api.example.test/characters/${characterId}/clone`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "X-API-Key": "test-key",
+      },
+      body: JSON.stringify({}),
+    }),
+  );
+}
+
+describe("clone character route — cross-tenant IDOR guard", () => {
+  beforeEach(() => {
+    requireUserOrApiKeyWithOrg.mockClear();
+    getById.mockClear();
+    create.mockClear();
+  });
+
+  test("404s when cloning another org's PRIVATE character (IDOR closed)", async () => {
+    getById.mockResolvedValueOnce(
+      buildCharacter({
+        user_id: OTHER_OWNER_ID,
+        is_public: false,
+        is_template: false,
+      }),
+    );
+
+    const response = await postClone("00000000-0000-0000-0000-000000000001");
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      success: false,
+      error: "Character not found",
+    });
+    // Critically: the private config is never copied into the caller's namespace.
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  test("404s when the character does not exist", async () => {
+    getById.mockResolvedValueOnce(undefined);
+
+    const response = await postClone("00000000-0000-0000-0000-000000000001");
+
+    expect(response.status).toBe(404);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  test("clones a PUBLIC character owned by another org", async () => {
+    getById.mockResolvedValueOnce(
+      buildCharacter({
+        user_id: OTHER_OWNER_ID,
+        is_public: true,
+        is_template: false,
+      }),
+    );
+
+    const response = await postClone("00000000-0000-0000-0000-000000000001");
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ success: true });
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ user_id: CALLER_ID }),
+    );
+  });
+
+  test("clones a TEMPLATE character owned by another org", async () => {
+    getById.mockResolvedValueOnce(
+      buildCharacter({
+        user_id: OTHER_OWNER_ID,
+        is_public: false,
+        is_template: true,
+      }),
+    );
+
+    const response = await postClone("00000000-0000-0000-0000-000000000001");
+
+    expect(response.status).toBe(200);
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  test("clones the caller's OWN private character", async () => {
+    getById.mockResolvedValueOnce(
+      buildCharacter({
+        user_id: CALLER_ID,
+        is_public: false,
+        is_template: false,
+      }),
+    );
+
+    const response = await postClone("00000000-0000-0000-0000-000000000001");
+
+    expect(response.status).toBe(200);
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ user_id: CALLER_ID }),
+    );
+  });
+});

--- a/packages/cloud/api/my-agents/characters/[id]/clone/route.ts
+++ b/packages/cloud/api/my-agents/characters/[id]/clone/route.ts
@@ -38,6 +38,20 @@ app.post("/", async (c) => {
       return c.json({ success: false, error: "Character not found" }, 404);
     }
 
+    // SECURITY: charactersService.getById is NOT org/visibility-scoped, so gate
+    // clonability — a caller may only clone a character they own, or one that is
+    // public/template. Otherwise any authenticated user could clone (and read
+    // back) another org's PRIVATE character config (system prompt, knowledge,
+    // settings) — cross-tenant IP disclosure. 404 (not 403) to avoid an
+    // existence oracle. Mirrors the app-link route's guard.
+    if (
+      original.user_id !== user.id &&
+      !original.is_public &&
+      !original.is_template
+    ) {
+      return c.json({ success: false, error: "Character not found" }, 404);
+    }
+
     const cloneName = body.name || `${original.name} (Copy)`;
 
     const clonedCharacter = await charactersService.create({

--- a/packages/cloud/api/v1/coding-containers/route.test.ts
+++ b/packages/cloud/api/v1/coding-containers/route.test.ts
@@ -4,6 +4,10 @@ const requireUserOrApiKeyWithOrg = mock(async () => ({
   id: "user-1",
   organization_id: "org-1",
 }));
+type CreditGateResult = { allowed: boolean; balance: number; error?: string };
+const checkAgentCreditGate = mock(
+  async (): Promise<CreditGateResult> => ({ allowed: true, balance: 5 }),
+);
 const checkProvisioningWorkerHealth = mock(async () => ({ ok: true }));
 const createCodingContainerAgent = mock(async () => ({
   idempotent: true,
@@ -27,6 +31,10 @@ const triggerImmediate = mock(async () => undefined);
 
 mock.module("@/lib/auth/workers-hono-auth", () => ({
   requireUserOrApiKeyWithOrg,
+}));
+
+mock.module("@/lib/services/agent-billing-gate", () => ({
+  checkAgentCreditGate,
 }));
 
 mock.module("@/lib/eliza-agent-web-ui", () => ({
@@ -95,6 +103,8 @@ async function postCodingContainer(image: string): Promise<Response> {
 describe("coding containers route", () => {
   beforeEach(() => {
     requireUserOrApiKeyWithOrg.mockClear();
+    checkAgentCreditGate.mockClear();
+    checkAgentCreditGate.mockResolvedValue({ allowed: true, balance: 5 });
     checkProvisioningWorkerHealth.mockClear();
     createCodingContainerAgent.mockClear();
     updateAgentEnvironment.mockClear();
@@ -176,6 +186,43 @@ describe("coding containers route", () => {
     );
 
     expect(response.status).toBe(200);
+    expect(createCodingContainerAgent).toHaveBeenCalledTimes(1);
+  });
+
+  // Regression for the free-compute leak (#10554, finding 3): a metered coding
+  // container is paid compute, so a $0/negative org must be blocked at the same
+  // credit gate every sibling provision route enforces — the route's downstream
+  // 402 poll branch is dead, so this gate is the only real block.
+  test("blocks provisioning with 402 when the org has insufficient credits", async () => {
+    checkAgentCreditGate.mockResolvedValueOnce({
+      allowed: false,
+      balance: 0,
+      error: "Insufficient credits",
+    });
+
+    const response = await postCodingContainer("ghcr.io/dexploarer/bnancy:latest");
+
+    expect(response.status).toBe(402);
+    expect(await response.json()).toEqual(
+      expect.objectContaining({
+        success: false,
+        code: "insufficient_credits",
+        currentBalance: 0,
+        requiredBalance: 0.1,
+      }),
+    );
+    expect(checkAgentCreditGate).toHaveBeenCalledWith("org-1");
+    // The gate must short-circuit BEFORE any paid compute is provisioned.
+    expect(createCodingContainerAgent).not.toHaveBeenCalled();
+  });
+
+  test("provisions when the org is funded (passes the credit gate)", async () => {
+    checkAgentCreditGate.mockResolvedValueOnce({ allowed: true, balance: 12.5 });
+
+    const response = await postCodingContainer("ghcr.io/dexploarer/bnancy:latest");
+
+    expect(response.status).toBe(200);
+    expect(checkAgentCreditGate).toHaveBeenCalledWith("org-1");
     expect(createCodingContainerAgent).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cloud/api/v1/coding-containers/route.ts
+++ b/packages/cloud/api/v1/coding-containers/route.ts
@@ -54,6 +54,8 @@ import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { containersEnv } from "@/lib/config/containers-env";
+import { AGENT_PRICING } from "@/lib/constants/agent-pricing";
+import { checkAgentCreditGate } from "@/lib/services/agent-billing-gate";
 import { getElizaAgentPublicWebUiUrl } from "@/lib/eliza-agent-web-ui";
 import {
   buildCodingContainerCreatePayload,
@@ -199,6 +201,31 @@ async function createCodingContainer(
           `are not accepted while CONTAINER_IMAGE_REQUIRE_DIGEST is enabled.`,
       },
       403,
+    );
+  }
+
+  // ── Credit gate: require the minimum deposit before provisioning paid
+  // compute (same as every sibling provision route). Without this, a $0/negative
+  // org could launch a metered coding container and get free compute until the
+  // hourly cron's warning + 48h grace expires. The route's downstream 402
+  // "insufficient_credit" poll branch is dead — provision() has no credit gate —
+  // so this is the only real gate. ──
+  const creditCheck = await checkAgentCreditGate(user.organization_id);
+  if (!creditCheck.allowed) {
+    logger.warn("[CodingContainers API] provision blocked: insufficient credits", {
+      orgId: user.organization_id,
+      balance: creditCheck.balance,
+      required: AGENT_PRICING.MINIMUM_DEPOSIT,
+    });
+    return c.json(
+      {
+        success: false,
+        code: "insufficient_credits",
+        error: creditCheck.error,
+        requiredBalance: AGENT_PRICING.MINIMUM_DEPOSIT,
+        currentBalance: creditCheck.balance,
+      },
+      402,
     );
   }
 

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-billing-reactivation.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-billing-reactivation.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Free-compute leak regression at the data layer (#10554, finding 2).
+ *
+ * When a credit-suspended agent is topped up and resumed, `provision()` calls
+ * `agentBillingRepository.reactivateSandboxBillingAfterFunding`. If that did not
+ * flip `billing_status` back to a billable value, the agent would run
+ * (status='running') permanently EXCLUDED from `listBillableSandboxes` — free
+ * dedicated compute forever. This suite proves the writer actually re-enters the
+ * billable set, against the REAL Drizzle schema on an in-process PGlite.
+ *
+ * Harness mirrors `repositories/__tests__/apps.test.ts`: drizzle-kit `pushSchema`
+ * generates the EXACT DDL from the real schema objects and applies it to the same
+ * PGlite connection the repository queries through. Self-skips LOUDLY (never
+ * silently passes) when a shared non-PGlite Postgres is the ambient DATABASE_URL.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { eq } from "drizzle-orm";
+
+const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
+const CAN_USE_ISOLATED_PGLITE =
+  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { pushSchema } from "drizzle-kit/api";
+import { closeDatabaseConnectionsForTests, dbWrite } from "../../client";
+import { agentSandboxes } from "../../schemas/agent-sandboxes";
+import { organizations } from "../../schemas/organizations";
+import { userCharacters } from "../../schemas/user-characters";
+import { users } from "../../schemas/users";
+import { agentBillingRepository } from "../agent-billing";
+
+const PGLITE_TIMEOUT = 60_000;
+let pgliteReady = true;
+
+let seq = 0;
+function uniq(prefix: string): string {
+  seq += 1;
+  return `${prefix}-${seq}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function seedOrgAndUser(): Promise<{ organizationId: string; userId: string }> {
+  const [org] = await dbWrite
+    .insert(organizations)
+    .values({ name: "Billing Org", slug: uniq("org") })
+    .returning();
+  const [user] = await dbWrite
+    .insert(users)
+    .values({ steward_user_id: uniq("steward"), organization_id: org.id })
+    .returning();
+  return { organizationId: org.id, userId: user.id };
+}
+
+/** Insert a dedicated, running sandbox and return its id. */
+async function seedSandbox(
+  organizationId: string,
+  userId: string,
+  billingStatus: "suspended" | "exempt" | "active",
+): Promise<string> {
+  const [row] = await dbWrite
+    .insert(agentSandboxes)
+    .values({
+      organization_id: organizationId,
+      user_id: userId,
+      agent_name: uniq("agent"),
+      status: "running",
+      execution_tier: "dedicated-always",
+      billing_status: billingStatus,
+      // A suspended/shutdown row may carry a pending-shutdown schedule; reactivate
+      // must clear it on the way back to billable.
+      shutdown_warning_sent_at: new Date("2026-06-01T00:00:00.000Z"),
+      scheduled_shutdown_at: new Date("2026-06-02T00:00:00.000Z"),
+    })
+    .returning();
+  return row.id;
+}
+
+async function billingStatusOf(id: string): Promise<string> {
+  const [row] = await dbWrite
+    .select({ billing_status: agentSandboxes.billing_status })
+    .from(agentSandboxes)
+    .where(eq(agentSandboxes.id, id));
+  return row.billing_status;
+}
+
+async function billableIds(): Promise<string[]> {
+  const now = new Date();
+  const rebillCutoff = new Date(now.getTime() - 60 * 60 * 1000);
+  const { runningSandboxes } = await agentBillingRepository.listBillableSandboxes(now, rebillCutoff);
+  return runningSandboxes.map((s) => s.id);
+}
+
+beforeAll(async () => {
+  if (!CAN_USE_ISOLATED_PGLITE) {
+    pgliteReady = false;
+    console.warn(
+      "[agent-billing-reactivation.test] DATABASE_URL is a non-PGlite Postgres (shared CI DB); this in-process-PGlite isolation suite self-skips — drizzle-kit pushSchema against a shared connection crashes the bun runner and would mutate the shared schema.",
+    );
+    return;
+  }
+  try {
+    const schema = { organizations, users, userCharacters, agentSandboxes };
+    const { apply } = await pushSchema(schema as never, dbWrite as never);
+    await apply();
+  } catch (error) {
+    pgliteReady = false;
+    console.error(
+      "[agent-billing-reactivation.test] PGlite/pushSchema unavailable — cannot drive AgentBillingRepository against a real DB. Skipping all cases.",
+      error,
+    );
+  }
+}, PGLITE_TIMEOUT);
+
+beforeEach(async () => {
+  if (!pgliteReady) return;
+  await dbWrite.delete(agentSandboxes);
+  await dbWrite.delete(userCharacters);
+  await dbWrite.delete(users);
+  await dbWrite.delete(organizations);
+});
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests();
+});
+
+describe("AgentBillingRepository.reactivateSandboxBillingAfterFunding", () => {
+  test("a suspended running agent is EXCLUDED from the billable set until reactivated", async () => {
+    if (!pgliteReady) return;
+    const { organizationId, userId } = await seedOrgAndUser();
+    const sandboxId = await seedSandbox(organizationId, userId, "suspended");
+
+    // Free-compute leak: suspended → not billed.
+    expect(await billingStatusOf(sandboxId)).toBe("suspended");
+    expect(await billableIds()).not.toContain(sandboxId);
+
+    await agentBillingRepository.reactivateSandboxBillingAfterFunding(sandboxId, new Date());
+
+    // Leak closed: active + back in the billable set, with the pending shutdown cleared.
+    expect(await billingStatusOf(sandboxId)).toBe("active");
+    expect(await billableIds()).toContain(sandboxId);
+
+    const [row] = await dbWrite
+      .select({
+        shutdown_warning_sent_at: agentSandboxes.shutdown_warning_sent_at,
+        scheduled_shutdown_at: agentSandboxes.scheduled_shutdown_at,
+      })
+      .from(agentSandboxes)
+      .where(eq(agentSandboxes.id, sandboxId));
+    expect(row.shutdown_warning_sent_at).toBeNull();
+    expect(row.scheduled_shutdown_at).toBeNull();
+  });
+
+  test("an EXEMPT agent is never forced into billing by reactivation", async () => {
+    if (!pgliteReady) return;
+    const { organizationId, userId } = await seedOrgAndUser();
+    const sandboxId = await seedSandbox(organizationId, userId, "exempt");
+
+    await agentBillingRepository.reactivateSandboxBillingAfterFunding(sandboxId, new Date());
+
+    // The `ne(billing_status, 'exempt')` guard means the row is untouched, and
+    // exempt is not a billable status, so it stays out of the billable set.
+    expect(await billingStatusOf(sandboxId)).toBe("exempt");
+    expect(await billableIds()).not.toContain(sandboxId);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -3,6 +3,7 @@ import type { SQL } from "drizzle-orm";
 import { PgDialect } from "drizzle-orm/pg-core";
 
 import * as realHelpersNs from "../../db/helpers";
+import { agentBillingRepository } from "../../db/repositories/agent-billing";
 import type { AgentSandbox, AgentSandboxBackup } from "../../db/repositories/agent-sandboxes";
 import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
 import type { DockerNode } from "../../db/repositories/docker-nodes";
@@ -44,6 +45,17 @@ mock.module("../../db/helpers", () => ({
 afterAll(() => {
   mock.module("../../db/helpers", () => realHelpers);
 });
+
+// provision()'s success path now re-enters the billable set via
+// agentBillingRepository.reactivateSandboxBillingAfterFunding (#10554) — a
+// dbWrite.update. This file swaps dbWrite for a transaction-only stub with no
+// `.update`, so stub the reactivation writer here (the singleton is shared with
+// eliza-sandbox.ts's import). The dedicated "re-enters billing" suite below
+// clears + asserts that provision() DOES invoke it on a successful provision.
+const reactivateBillingSpy = spyOn(
+  agentBillingRepository,
+  "reactivateSandboxBillingAfterFunding",
+).mockResolvedValue(undefined);
 
 const originalFetch = globalThis.fetch;
 const originalWebSocketPair = Object.getOwnPropertyDescriptor(globalThis, "WebSocketPair");
@@ -1515,6 +1527,97 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       markErrorSpy.mockRestore();
       ensureStartedSpy.mockRestore();
       getProviderSpy.mockRestore();
+    }
+  });
+
+  // #10554 finding 2 — free-compute leak. A successful provision MUST re-enter
+  // the billable set so a credit-suspended agent that a user tops up + resumes
+  // (via the user-facing routes that don't reactivate themselves) cannot run
+  // (status='running') permanently excluded from listBillableSandboxes = free
+  // dedicated compute. This drives the REAL provision() success path; the writer
+  // itself is proven against a real DB in agent-billing-reactivation.test.ts.
+  test("(6) a successful provision re-enters the billable set", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const row = provisioningReadyRow();
+    const finalRow: AgentSandbox = { ...row, status: "running" };
+    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
+    const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue({
+      ...row,
+      status: "provisioning",
+    });
+    const backupSpy = spyOn(agentSandboxesRepository, "getLatestBackup").mockResolvedValue(
+      undefined,
+    );
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
+      async (_id, data) => (data.status === "running" ? finalRow : { ...row, ...data }),
+    );
+    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
+      id: "22222222-2222-4222-8222-222222222222",
+      plainKey: "eliza_test_agent_key",
+      prefix: "eliza_test",
+    });
+    const svc = new ElizaSandboxService();
+    const ensureStartedSpy = spyOn(
+      svc as unknown as { ensureRuntimeAgentStarted: () => Promise<unknown> },
+      "ensureRuntimeAgentStarted",
+    ).mockResolvedValue(null);
+    const create = mock(async () => providerHandle());
+    const stop = mock(async () => {});
+    const getProviderSpy = spyOn(
+      svc as unknown as { getProvider: () => Promise<SandboxProvider> },
+      "getProvider",
+    ).mockResolvedValue({ create, stop, checkHealth: async () => true } as SandboxProvider);
+    reactivateBillingSpy.mockClear();
+    try {
+      const res = await svc.provision(AGENT, ORG);
+      expect(res.success).toBe(true);
+      expect(res.sandboxRecord).toBe(finalRow);
+      // The fix: provision() re-enters billing for the just-provisioned agent.
+      expect(reactivateBillingSpy).toHaveBeenCalledTimes(1);
+      expect(reactivateBillingSpy).toHaveBeenCalledWith(AGENT, expect.any(Date));
+      expect(create).toHaveBeenCalledTimes(1);
+    } finally {
+      findSpy.mockRestore();
+      lockSpy.mockRestore();
+      backupSpy.mockRestore();
+      updateSpy.mockRestore();
+      apiKeySpy.mockRestore();
+      ensureStartedSpy.mockRestore();
+      getProviderSpy.mockRestore();
+    }
+  });
+
+  test("(7) a provision that never reaches running does NOT re-enter billing", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    // Lock lost AND row not running → bails ("already being provisioned") before
+    // the success block, so billing is NOT (re)activated for a non-provisioned agent.
+    const provisioningRow: AgentSandbox = {
+      ...customSandbox(),
+      id: AGENT,
+      organization_id: ORG,
+      status: "provisioning",
+      bridge_url: null,
+      health_url: null,
+    };
+    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(
+      provisioningRow,
+    );
+    const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue(
+      undefined,
+    );
+    const provider: SandboxProvider = {
+      create: mock(async () => providerHandle()),
+      stop: mock(async () => {}),
+      checkHealth: mock(async () => true),
+    };
+    reactivateBillingSpy.mockClear();
+    try {
+      const res = await new ElizaSandboxService(provider).provision(AGENT, ORG);
+      expect(res.success).toBe(false);
+      expect(reactivateBillingSpy).not.toHaveBeenCalled();
+    } finally {
+      findSpy.mockRestore();
+      lockSpy.mockRestore();
     }
   });
 });

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -16,6 +16,7 @@ import {
   agentSandboxesRepository,
   prepareAgentBackupInsertData,
 } from "../../db/repositories/agent-sandboxes";
+import { agentBillingRepository } from "../../db/repositories/agent-billing";
 import { userCharactersRepository } from "../../db/repositories/characters";
 import { dockerNodesRepository } from "../../db/repositories/docker-nodes";
 import { sharedRuntimeHistoryRepository } from "../../db/repositories/shared-runtime-history";
@@ -1253,6 +1254,18 @@ export class ElizaSandboxService {
         }
 
         const updated = await agentSandboxesRepository.update(rec.id, updateData);
+
+        // Re-enter the billable set on every successful provision. A
+        // credit-suspended agent (billing_status='suspended') that a user tops
+        // up and resumes/wakes via the user-facing routes would otherwise run
+        // (status='running') permanently EXCLUDED from listBillableSandboxes =
+        // free dedicated compute forever. The service-key resume/restart routes
+        // already reactivate; do it here so ALL provision paths re-enter billing.
+        // Idempotent + exempt-guarded (ne billing_status 'exempt').
+        await agentBillingRepository.reactivateSandboxBillingAfterFunding(
+          rec.id,
+          new Date(),
+        );
 
         logger.info("[agent-sandbox] Provisioned", {
           agentId: rec.id,


### PR DESCRIPTION
## Why

PR #10554 (agent-provisioning launch hardening) was **squash-merged to develop** with only its 4 production fixes — **no test updates**. That left `develop` red on the test files those fixes touched, and shipped a security PR with **zero regression coverage**. This greens develop and adds the missing tests.

> The 4 production files in this diff are **byte-identical to what is already on develop** (verified), so they merge as a no-op; the real change is the 5 test files.

## Currently broken on develop (this fixes)

- `a2a-agent-card.test.ts` — still asserts `card.contact` exposes creator/org ids; fix #4 dropped that block → **fails**.
- `v1/coding-containers/route.test.ts` — fix #3 added `checkAgentCreditGate`, unmocked in the test → two happy-paths now **402**.
- `eliza-sandbox.test.ts` — fix #2 added `reactivateSandboxBillingAfterFunding` (a `dbWrite.update`) to `provision()`'s success path; the file stubs `dbWrite` without `.update`, so the provision-retry + wake tests **throw**.

## Changes

**Green-ups**
- a2a test: assert `card.contact` is **undefined** (renamed to "omits internal contact ids…"); bearer-scheme assertions kept.
- coding-containers test: mock `agent-billing-gate` (allowed by default).
- eliza-sandbox test: stub the reactivation writer (singleton, shared across the `?actual` import).

**New regression tests (one per fix)**
1. **IDOR** — `clone/route.test.ts` (new): another org's PRIVATE character → **404**; public / template / own → **200** + clone proceeds. Drives the real route handler.
2. **Free-compute leak (data layer)** — `agent-billing-reactivation.test.ts` (new): real in-process PGlite (`pushSchema`) proving a suspended running agent is **excluded** from `listBillableSandboxes`, then reactivation flips it to `active`, **re-includes** it, and clears the pending shutdown; an `exempt` agent is never forced into billing.
3. **Free-compute leak (wiring)** — `eliza-sandbox.test.ts`: drives the **real `provision()`** success path and asserts it invokes `reactivateSandboxBillingAfterFunding(agentId, Date)`; a provision that never reaches `running` does **not** re-enter billing.
4. **Credit gate** — `coding-containers/route.test.ts`: insufficient credits → **402 `insufficient_credits`** (no compute provisioned); funded org passes the gate and provisions.

## Verification

- `bun test` (cloud/api): a2a + coding-containers + clone → **18 pass / 0 fail**.
- `bun test --isolate` (cloud/shared): eliza-sandbox + agent-billing-reactivation → **54 pass / 0 fail**.
- `typecheck`: all five touched files type-clean (remaining repo typecheck noise is pre-existing — unbuilt i18n generated files, a Stripe API-version string, a hono version dup in the worktree store — none in these files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)