### PR TITLE
fix(ui): complete the at-rest cloud-credential scrub on disconnect/sign-out

### DIFF
--- a/packages/ui/src/cloud/shell/StewardProviderShared.ts
+++ b/packages/ui/src/cloud/shell/StewardProviderShared.ts
@@ -5,6 +5,8 @@ import {
   STEWARD_TOKEN_KEY,
 } from "@elizaos/shared/steward-session-client";
 import { createContext } from "react";
+import { scrubPersistedAgentProfileTokens } from "../../state/agent-profiles";
+import { scrubPersistedActiveServerToken } from "../../state/persistence";
 import { decodeJwtPayload } from "../lib/jwt";
 
 export function isPlaceholderValue(value: string | undefined): boolean {
@@ -143,6 +145,12 @@ export function tokenSecsRemaining(token: string): number | null {
 export function clearStaleStewardSession(): void {
   if (typeof window === "undefined") return;
   clearStoredStewardToken();
+  // SECURITY: also scrub the persisted accessToken mirrors so the secondary
+  // sign-out / 401-self-heal paths that route through here (native apps-studio
+  // signOut, the authorize-content edge, StewardProviderRuntime 401 clears) don't
+  // leave a usable cloud bearer/API-key at rest in localStorage.
+  scrubPersistedActiveServerToken();
+  scrubPersistedAgentProfileTokens();
   clearServerStewardSessionCookies();
   try {
     window.dispatchEvent(new CustomEvent("steward-token-sync"));

--- a/packages/ui/src/state/useCloudState.ts
+++ b/packages/ui/src/state/useCloudState.ts
@@ -15,6 +15,7 @@
  */
 
 import {
+  clearStoredStewardToken,
   readStoredStewardToken,
   writeStoredStewardToken,
 } from "@elizaos/shared/steward-session-client";
@@ -44,6 +45,7 @@ import {
   hasStewardLoginLauncher,
   launchStewardLogin,
 } from "./cloud-steward-login";
+import { scrubPersistedAgentProfileTokens } from "./agent-profiles";
 import { scrubPersistedActiveServerToken } from "./persistence";
 import { isPrivateNetworkHost } from "./private-network-host";
 
@@ -900,6 +902,21 @@ export function useCloudState({
         // an at-rest JWT leak readable by XSS / plugin views. Keep the server
         // selection (kind/apiBase/label) so we know where to re-authenticate.
         scrubPersistedActiveServerToken();
+        // SECURITY: scrubbing active-server.accessToken alone is incomplete —
+        // the LIVE cloud bearer also lives in (a) localStorage steward_session_token
+        // (the JWT read on every /api/* call), (b) per-agent-profile accessToken
+        // copies, and (c) the in-memory __ELIZA_CLOUD_AUTH_TOKEN__ global. Clear
+        // all of them on an explicit disconnect so no usable credential survives
+        // at rest / in memory (XSS / same-origin plugin views).
+        clearStoredStewardToken();
+        scrubPersistedAgentProfileTokens();
+        try {
+          delete (globalThis as Record<string, unknown>)
+            .__ELIZA_CLOUD_AUTH_TOKEN__;
+        } catch {
+          (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__ =
+            undefined;
+        }
         if (wasConnected) {
           setActionNotice("Disconnected from Eliza Cloud.", "success");
         }


### PR DESCRIPTION
From the **eliza-app client-security audit** (the app half), adversarially verified. The existing 'scrub persisted JWT on cloud-disconnect' fix was **incomplete** — it cleared one secondary copy but left the LIVE cloud bearer at rest after an explicit disconnect/sign-out:
- **Steward JWT** in localStorage `steward_session_token` (read on every /api/* call)
- per-agent-profile `accessToken` copies
- the in-memory `__ELIZA_CLOUD_AUTH_TOKEN__` window global (the *sole* live credential for the device-code/Remote pairing flow)

All readable by same-origin code (XSS / embedded plugin/app views) → a user who 'disconnected' still has a usable token lingering.

**Fix:** `handleCloudDisconnect` now also clears the Steward JWT + agent-profile copies + the global; `clearStaleStewardSession` (the secondary sign-out / 401-self-heal path) now scrubs both accessToken mirrors too. Helpers are idempotent no-ops when already clear.

@lalalune — these touch the UI auth state (your active area), so PR'd for your review rather than self-merged. Credential-hygiene / defense-in-depth (the leak needs a secondary XSS/same-origin-plugin to exploit). Type-review clean.