### PR TITLE
fix(cloud): allow CLI auth from local and staging app origins

### DIFF
--- a/packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.test.ts
+++ b/packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.test.ts
@@ -41,6 +41,8 @@ describe("isFirstPartyOrigin", () => {
     // The Eliza agent app on its own subdomain is first-party.
     expect(isFirstPartyOrigin("https://app.elizacloud.ai")).toBe(true);
     expect(isFirstPartyOrigin("https://app-staging.elizacloud.ai")).toBe(true);
+    expect(isFirstPartyOrigin("https://develop.eliza-app.pages.dev")).toBe(true);
+    expect(isFirstPartyOrigin("https://random.eliza-app.pages.dev")).toBe(false);
     expect(isFirstPartyOrigin("http://localhost:5173")).toBe(true);
     expect(isFirstPartyOrigin("https://supakan.nubs.site")).toBe(false);
     expect(isFirstPartyOrigin("https://evil.example.com")).toBe(false);

--- a/packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.ts
+++ b/packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.ts
@@ -45,6 +45,9 @@ const STATIC_ALLOWED_ORIGINS = new Set<string>([
   // `Access-Control-Allow-Credentials`.
   "https://app.elizacloud.ai",
   "https://app-staging.elizacloud.ai",
+  // Exact develop branch alias for staging QA. Do not add a broad *.pages.dev
+  // wildcard here; session-capable routes must remain first-party-only.
+  "https://develop.eliza-app.pages.dev",
   "https://elizaos.ai",
   "https://www.elizaos.ai",
   "https://os.elizacloud.ai",

--- a/packages/cloud/shared/src/lib/utils/cors.test.ts
+++ b/packages/cloud/shared/src/lib/utils/cors.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "vitest";
+import { getCorsHeaders } from "./cors";
+
+describe("getCorsHeaders", () => {
+  test("reflects first-party app origins for credentialed auth routes", () => {
+    const headers = getCorsHeaders("https://app-staging.elizacloud.ai");
+
+    expect(headers["Access-Control-Allow-Origin"]).toBe("https://app-staging.elizacloud.ai");
+    expect(headers["Access-Control-Allow-Credentials"]).toBe("true");
+  });
+
+  test("reflects local dev origins with ports", () => {
+    const headers = getCorsHeaders("http://localhost:2138");
+
+    expect(headers["Access-Control-Allow-Origin"]).toBe("http://localhost:2138");
+    expect(headers["Access-Control-Allow-Credentials"]).toBe("true");
+  });
+
+  test("reflects native app scheme origins", () => {
+    const headers = getCorsHeaders("capacitor://localhost");
+
+    expect(headers["Access-Control-Allow-Origin"]).toBe("capacitor://localhost");
+    expect(headers["Access-Control-Allow-Credentials"]).toBe("true");
+  });
+
+  test("reflects the exact develop Pages staging alias only", () => {
+    const headers = getCorsHeaders("https://develop.eliza-app.pages.dev");
+
+    expect(headers["Access-Control-Allow-Origin"]).toBe("https://develop.eliza-app.pages.dev");
+    expect(getCorsHeaders("https://random.eliza-app.pages.dev")).not.toHaveProperty(
+      "Access-Control-Allow-Origin",
+    );
+  });
+
+  test("does not reflect untrusted origins", () => {
+    const headers = getCorsHeaders("https://attacker.example");
+
+    expect(headers).not.toHaveProperty("Access-Control-Allow-Origin");
+    expect(headers).not.toHaveProperty("Access-Control-Allow-Credentials");
+  });
+});

--- a/packages/cloud/shared/src/lib/utils/cors.ts
+++ b/packages/cloud/shared/src/lib/utils/cors.ts
@@ -1,4 +1,4 @@
-import { CORS_ALLOW_HEADERS } from "../cors-constants";
+import { APP_LOCAL_ORIGIN_RE, APP_SCHEME_ORIGIN_RE, CORS_ALLOW_HEADERS } from "../cors-constants";
 
 const ALLOWED_ORIGINS = [
   process.env.NEXT_PUBLIC_APP_URL,
@@ -10,6 +10,9 @@ const ALLOWED_ORIGINS = [
   // The Eliza agent app on its own subdomain (Pages project `eliza-app`).
   "https://app.elizacloud.ai",
   "https://app-staging.elizacloud.ai",
+  // Exact develop branch alias for staging QA. Do not add a broad *.pages.dev
+  // wildcard here; these auth routes can return API keys after login.
+  "https://develop.eliza-app.pages.dev",
   "https://eliza.ai",
   "https://www.eliza.ai",
   // Capacitor native shells (iOS WKWebView / Android WebView). The
@@ -19,15 +22,24 @@ const ALLOWED_ORIGINS = [
   "http://localhost",
 ].filter(Boolean) as string[];
 
+function isAllowedOrigin(origin: string): boolean {
+  return (
+    ALLOWED_ORIGINS.includes(origin) ||
+    APP_LOCAL_ORIGIN_RE.test(origin) ||
+    APP_SCHEME_ORIGIN_RE.test(origin)
+  );
+}
+
 export function getCorsHeaders(origin: string | null): Record<string, string> {
   // Only reflect origin if it's in the allowlist; otherwise use first allowed origin or reject
   // Only set origin header for allowed origins, otherwise omit it entirely
-  const allowedOrigin = origin && ALLOWED_ORIGINS.includes(origin) ? origin : undefined; // Omit header for non-allowed origins
+  const allowedOrigin = origin && isAllowedOrigin(origin) ? origin : undefined; // Omit header for non-allowed origins
 
   const headers: Record<string, string> = {
     "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
     "Access-Control-Allow-Headers": CORS_ALLOW_HEADERS,
     "Access-Control-Max-Age": "86400",
+    Vary: "Origin",
   };
 
   if (allowedOrigin) {


### PR DESCRIPTION
## Summary
- Updates both credentialed CORS layers used by Cloud login/session endpoints: the route helper and the global Cloud API Hono middleware.
- Reflects local app origins with ports via the existing app-origin regexes, so `http://localhost:2138` can start/poll Cloud login without browser CORS failure.
- Allows the exact `https://develop.eliza-app.pages.dev` staging QA alias without adding a broad `*.pages.dev` wildcard.
- Adds focused coverage for first-party app origins, local dev, native schemes, the exact staging alias, and untrusted Pages aliases.

## Validation
- `bun test packages/cloud/shared/src/lib/utils/cors.test.ts packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.test.ts`
- `bunx @biomejs/biome check packages/cloud/shared/src/lib/utils/cors.ts packages/cloud/shared/src/lib/utils/cors.test.ts packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.ts packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.test.ts`
- `bun run --cwd packages/cloud/shared typecheck`

## Live staging proof
Manually deployed the staging API Worker from this branch because Cloud CF Deploy is still queued: `eliza-cloud-api-staging` version `c7dedd7d-3114-42df-ba52-db8b72013aba`.

Preflight checks after deploy:
- `Origin: https://develop.eliza-app.pages.dev` -> reflected with credentials.
- `Origin: http://localhost:2138` -> reflected with credentials.
- `Origin: https://random.eliza-app.pages.dev` -> no `Access-Control-Allow-Origin`.

Playwright live smoke after deploy:
- `https://develop.eliza-app.pages.dev/?reset=1&runtime=first-run` -> chooser rendered, Cloud click `POST /api/auth/cli-session` returned 201, popup reached `https://staging.elizacloud.ai/auth/cli-login?...`, no CORS/502/ERR_FAILED console issues.
- `https://app-staging.elizacloud.ai/?reset=1&runtime=first-run` -> same pass.

## Context
This came out of the first-run chooser live QA. The clean chooser fix (#10558) is merged and staging app deploy is live, but the raw Pages alias and local dev origin exposed the older auth CORS helper drift. This PR keeps the policy narrow: exact first-party hosts, loopback/dev origins, native app schemes, and the exact develop alias only.