### PR TITLE
fix(cloud): /v1/chat rejects org-less authed users (no free inference)

### DIFF
--- a/packages/cloud/api/v1/chat/route.ts
+++ b/packages/cloud/api/v1/chat/route.ts
@@ -143,6 +143,18 @@ app.post("/", async (c) => {
     if (authedUser) {
       user = authedUser;
       apiKey = await getRequestApiKey(c);
+      // SECURITY: a NON-anonymous authed user must belong to an org. Without this
+      // guard an org-less authed user (legacy/edge data) would fall through to the
+      // no-op anonymous reservation (createAnonymousReservation) and be billed to
+      // org "anonymous" = free inference on any model, exempt from the anon
+      // free-tier cap. Every sibling inference route enforces org via
+      // requireUserOrApiKeyWithOrg; reject here too rather than serve free.
+      if (!user.organization_id) {
+        return c.json(
+          { error: "No organization associated with this account" },
+          403,
+        );
+      }
     } else {
       const anonData = await getAnonymousUser(c.req.raw);
       if (!anonData) {


### PR DESCRIPTION
Closes the `/v1/chat` org-parity item from #10557 (the *safe* one). `/v1/chat` uses bare `getCurrentUser` (required for the anonymous free-tier path) but never enforced that a **non-anonymous** authed user has an org — an org-less authed user would fall through to the no-op anonymous reservation + be billed to org `anonymous` = free inference on any model, exempt from the anon cap. Every sibling route enforces org via `requireUserOrApiKeyWithOrg`; this adds the equivalent guard (403) without touching the anonymous path. Latent today (no path nulls a user's org), cheap defense-in-depth.

The other two filed items genuinely need careful design and are NOT force-fixed (doing so risks worse money bugs): #10557's embeddings reconcile (a documented single-charge-site dual-path invariant — a restructure risks double-charge/free-embeddings) and #10553's payout stale-lock (recovery needs tx-hash-aware on-chain reconciliation — a naive fix re-broadcasts a settled payout = double-pay).