### PR TITLE
fix(cloud): embeddings reservation-leak on billUsage throw + /v1/chat org parity (#10557)

### DIFF
--- a/packages/cloud/api/__tests__/chat-stream-credit-leak.test.ts
+++ b/packages/cloud/api/__tests__/chat-stream-credit-leak.test.ts
@@ -28,14 +28,33 @@ mock.module("ai", () => ({
   streamText,
 }));
 
+// Controllable auth seam so tests can drive authed / authed-org-less / anonymous.
+let currentUserImpl: () => Promise<{
+  id: string;
+  organization_id?: string | null;
+} | null> = async () => ({ id: USER, organization_id: ORG });
 mock.module("@/lib/auth/workers-hono-auth", () => ({
-  getCurrentUser: mock(async () => ({ id: USER, organization_id: ORG })),
+  getCurrentUser: mock(() => currentUserImpl()),
 }));
 
+let anonymousUserImpl: (() => Promise<unknown>) | null = null;
 mock.module("@/lib/auth-anonymous", () => ({
   checkAnonymousLimit: mock(),
-  getAnonymousUser: mock(),
-  reserveAnonymousMessageSlot: mock(),
+  getAnonymousUser: mock(() =>
+    anonymousUserImpl ? anonymousUserImpl() : null,
+  ),
+  reserveAnonymousMessageSlot: mock(async () => ({
+    allowed: true,
+    remaining: 5,
+    limit: 10,
+  })),
+}));
+
+mock.module("@/lib/services/anonymous-sessions", () => ({
+  anonymousSessionsService: {
+    addTokenUsage: mock(async () => undefined),
+    refundMessageSlot: mock(async () => undefined),
+  },
 }));
 
 mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
@@ -117,6 +136,8 @@ beforeEach(() => {
   ledger = makeLedgerReservation(100, 0.015);
   streamText.mockClear();
   streamTextImpl = null;
+  currentUserImpl = async () => ({ id: USER, organization_id: ORG });
+  anonymousUserImpl = null;
 });
 
 describe("/v1/chat streaming credit reservation", () => {
@@ -158,5 +179,71 @@ describe("/v1/chat streaming credit reservation", () => {
     await onAbort?.();
     expect(ledger.reconcileCalls).toBe(1);
     expect(ledger.balance).toBeCloseTo(ledger.startBalance, 10);
+  });
+});
+
+describe("/v1/chat org-membership parity (#10557 part 2)", () => {
+  test("authenticated caller with NO organization is rejected 403, never reaches the model", async () => {
+    // The defense-in-depth gap: a null-org authenticated user would previously
+    // fall through to the anonymous no-op reservation and get unbounded free
+    // inference, exempt from the anon cap. Now mirror the sibling routes' org
+    // guard and 403 before any provider call.
+    currentUserImpl = async () => ({ id: USER, organization_id: null });
+    streamTextImpl = () => {
+      throw new Error("must not reach the model for an org-less authed user");
+    };
+
+    const response = await chatRoute.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ messages: [{ role: "user", content: "hello" }] }),
+    });
+
+    expect(response.status).toBe(403);
+    expect(streamText).not.toHaveBeenCalled();
+    // No reservation was settled — the caller was rejected before any hold.
+    expect(ledger.reconcileCalls).toBe(0);
+  });
+
+  test("authenticated caller WITH an organization still streams normally (no regression)", async () => {
+    currentUserImpl = async () => ({ id: USER, organization_id: ORG });
+    streamTextImpl = () => ({
+      toUIMessageStreamResponse: () => new Response("stream-started"),
+    });
+
+    const response = await chatRoute.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ messages: [{ role: "user", content: "hello" }] }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(streamText).toHaveBeenCalledTimes(1);
+  });
+
+  test("genuine anonymous caller is NOT rejected by the org guard (free tier preserved)", async () => {
+    // No authed user → anonymous path. The org guard must not touch this caller;
+    // anonymous inference still works via the anonymous reservation.
+    currentUserImpl = async () => null;
+    anonymousUserImpl = async () => ({
+      user: { id: "anon-user", organization_id: undefined },
+      session: {
+        id: "anon-session",
+        session_token: "anon-token",
+        message_count: 0,
+      },
+    });
+    streamTextImpl = () => ({
+      toUIMessageStreamResponse: () => new Response("stream-started"),
+    });
+
+    const response = await chatRoute.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ messages: [{ role: "user", content: "hello" }] }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(streamText).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cloud/api/__tests__/embeddings-credit-leak.test.ts
+++ b/packages/cloud/api/__tests__/embeddings-credit-leak.test.ts
@@ -245,28 +245,34 @@ describe("embeddings — reserve() failure does not crash the release path", () 
   });
 });
 
+function makeBilling(actual: number) {
+  return {
+    inputCost: actual,
+    outputCost: 0,
+    totalCost: actual,
+    baseInputCost: actual,
+    baseOutputCost: 0,
+    baseTotalCost: actual,
+    platformMarkup: 0,
+    inputTokens: 5,
+    outputTokens: 0,
+    totalTokens: 5,
+    markupApplied: true,
+  };
+}
+
 describe("embeddings — success settles to actual usage exactly once", () => {
-  test("success path reconciles via billUsage once; the catch never double-refunds", async () => {
+  test("success path settles via the route settler once; the catch never double-refunds", async () => {
     const ledger = makeLedgerReservation(100, 0.01);
     const ACTUAL = 0.003;
     reserveCredits.mockResolvedValue(ledger.reservation);
     embed.mockResolvedValue({ embedding: [0.1, 0.2], usage: { tokens: 5 } });
-    // Model reality: billUsage reconciles the reservation to actual cost.
-    billUsage.mockImplementation(async (_ctx, _usage) => {
-      await ledger.reservation.reconcile(ACTUAL);
-      return {
-        inputCost: ACTUAL,
-        outputCost: 0,
-        totalCost: ACTUAL,
-        baseInputCost: ACTUAL,
-        baseOutputCost: 0,
-        baseTotalCost: ACTUAL,
-        platformMarkup: 0,
-        inputTokens: 5,
-        outputTokens: 0,
-        totalTokens: 5,
-        markupApplied: true,
-      };
+    // #10557: billUsage is now called WITHOUT the reservation, so it does NOT
+    // reconcile internally (mirrors the real adapter's `if (reservation)`
+    // guard). The route reconciles via the single first-call-wins settler.
+    billUsage.mockImplementation(async (_ctx, _usage, reservationArg) => {
+      expect(reservationArg).toBeUndefined();
+      return makeBilling(ACTUAL);
     });
 
     const { ctx, scheduled } = makeExecutionCtx();
@@ -277,7 +283,66 @@ describe("embeddings — success settles to actual usage exactly once", () => {
     expect(res.status).toBe(200);
 
     await Promise.all(scheduled);
-    // Reconciled exactly once (by billUsage); the catch release never fired.
+    // Reconciled exactly once (by the route settler); the catch release never fired.
+    expect(ledger.reconcileCalls).toBe(1);
+    expect(ledger.balance).toBeCloseTo(ledger.startBalance - ACTUAL, 10);
+  });
+});
+
+describe("embeddings — billUsage internal throw releases the hold (#10557)", () => {
+  test("billUsage throws AFTER embedding (e.g. calculateCost/affiliate lookup): hold released to 0, no double-refund", async () => {
+    // The original leak: the embedding succeeded and the reservation hold was
+    // taken, but billUsage threw before its internal reconcile (calculateCost or
+    // the affiliate-code lookup throwing). The deferred settleBilling only logged
+    // → the ~1.5x hold leaked permanently. After the fix, settleBilling's catch
+    // releases the hold via the settler.
+    const ledger = makeLedgerReservation(100, 0.01);
+    reserveCredits.mockResolvedValue(ledger.reservation);
+    embed.mockResolvedValue({ embedding: [0.1], usage: { tokens: 5 } });
+    billUsage.mockRejectedValue(new Error("calculateCost exploded"));
+
+    const { ctx, scheduled } = makeExecutionCtx();
+    const res = await post(
+      // X-Affiliate-Code present → exercises the affiliate-lookup branch too.
+      { model: "text-embedding-3-small", input: "hi" },
+      ctx,
+    );
+
+    // Billing is deferred, so the vectors still returned 200.
+    expect(res.status).toBe(200);
+    expect(scheduled.length).toBe(1);
+    // The deferred task swallows its own error after releasing the hold.
+    await Promise.all(scheduled);
+
+    expect(billUsage).toHaveBeenCalledTimes(1);
+    // Hold released exactly once → balance back to pre-request (no permanent over-debit).
+    expect(ledger.reconcileCalls).toBe(1);
+    expect(ledger.balance).toBeCloseTo(ledger.startBalance, 10);
+    // usage record never written because billUsage threw first.
+    expect(usageCreate).not.toHaveBeenCalled();
+  });
+
+  test("billUsage succeeds then usage-record write throws: actual cost stays settled, NOT refunded to 0", async () => {
+    // Defense of the idempotency guarantee: if settlement already happened and a
+    // later step (usageService.create) throws, the catch's settleReservation(0)
+    // must be a no-op (first-call-wins) — the customer stays billed the real
+    // cost, never refunded for inference they received.
+    const ledger = makeLedgerReservation(100, 0.01);
+    const ACTUAL = 0.004;
+    reserveCredits.mockResolvedValue(ledger.reservation);
+    embed.mockResolvedValue({ embedding: [0.1], usage: { tokens: 5 } });
+    billUsage.mockResolvedValue(makeBilling(ACTUAL));
+    usageCreate.mockRejectedValue(new Error("usage table write failed"));
+
+    const { ctx, scheduled } = makeExecutionCtx();
+    const res = await post(
+      { model: "text-embedding-3-small", input: "hi" },
+      ctx,
+    );
+    expect(res.status).toBe(200);
+    await Promise.all(scheduled);
+
+    // Settled once to the ACTUAL cost; the post-settle throw did NOT refund it.
     expect(ledger.reconcileCalls).toBe(1);
     expect(ledger.balance).toBeCloseTo(ledger.startBalance - ACTUAL, 10);
   });

--- a/packages/cloud/api/v1/embeddings/route.ts
+++ b/packages/cloud/api/v1/embeddings/route.ts
@@ -75,8 +75,8 @@ app.post("/", async (c) => {
   let settleReservation:
     | ReturnType<typeof createCreditReservationSettler>
     | undefined;
-  // True once settleBilling() (which runs billUsage → reservation.reconcile) has
-  // been invoked, so the catch never double-applies a release on the success path.
+  // True once settleBilling() has taken ownership of settling/releasing the
+  // reservation, so the outer catch never double-applies a release.
   let billed = false;
   try {
     // Resolve auth (+ org + moderation) in a SINGLE cache read for API-key
@@ -203,13 +203,12 @@ app.post("/", async (c) => {
     // enabled AND this org's balance comfortably clears SAFE_BALANCE_THRESHOLD,
     // SKIP the synchronous reserve write (~0.8-1.7s of serial credit DB on every
     // memory-backed reply) and defer the ACTUAL-cost debit to the post-response
-    // settle, backed by a durable KV pending-charge. Gated + fail-SAFE: flag off
+    // settle, backed by a durable pending-charge. Gated + fail-SAFE: flag off
     // / null org / low balance / cache down / non-durable backstop all fall
     // through to the synchronous reserve below, VERBATIM (same try/catch/402 as
-    // today). The success-path settleBilling and the catch are left byte-for-byte
-    // unchanged: on the optimistic path the reservation we hand billUsage is one
-    // whose `reconcile` IS the actual-cost debit, so there is exactly one charge
-    // site (billUsage's `reservation.reconcile(totalCost)`) on either path.
+    // today). On the optimistic path the reservation's `reconcile` IS the
+    // actual-cost debit, and settleBilling invokes it through the single
+    // first-call-wins settler.
     const requestId = c.req.header("x-request-id") || crypto.randomUUID();
     const orgId = user.organization_id;
     let reservation: Awaited<ReturnType<typeof reserveCredits>> | undefined;
@@ -320,11 +319,11 @@ app.post("/", async (c) => {
           // Build a reservation whose `reconcile` IS the optimistic debit
           // settler. We deliberately do NOT use
           // creditsService.createAnonymousReservation() here — its reconcile is
-          // a no-op (`async () => {}`), which would make billUsage charge
+          // a no-op (`async () => {}`), which would make settleReservation charge
           // NOTHING (free embeddings — the known trap). When settleBilling calls
-          // billUsage(..., reservation) → reservation.reconcile(totalCost), the
-          // settler atomically claims the KV backstop (so the cron sweep can't
-          // also charge) and debits the ACTUAL marked-up cost via deductCredits.
+          // settleReservation(totalCost), the settler atomically claims the
+          // pending backstop (so the sweep can't also charge) and debits the
+          // ACTUAL marked-up cost via deductCredits.
           const optimisticSettler = createOptimisticDebitSettler({
             requestId,
             organizationId: orgId,
@@ -383,9 +382,8 @@ app.post("/", async (c) => {
       }
     }
 
-    // Idempotent settler over whatever reservation we built. Used only by the
-    // catch below to release on a provider failure; the success path settles via
-    // billUsage(reservation) instead (see settleBilling). For the optimistic
+    // Idempotent settler over whatever reservation we built. The success path
+    // settles the actual cost; failure paths release to zero. For the optimistic
     // reservation, settleReservation(0) → reconcile(0) → optimisticSettler(0):
     // it claims (removes) the pending entry and debits nothing.
     if (!reservation) {
@@ -422,53 +420,76 @@ app.post("/", async (c) => {
 
     // Defer billing off the response path: reconciliation + usage recording add
     // serial DB round-trips that need not block the vector return. We still RUN
-    // billUsage (it reconciles the reservation), just after the response is sent
-    // via waitUntil. The terminal insufficient-credits guard already fired above
+    // billUsage + settle the reservation, just after the response is sent via
+    // waitUntil. The terminal insufficient-credits guard already fired above
     // (reserveCredits), so a caller with no balance was rejected before embedding;
     // the only residual risk is an under-bill if the Worker dies before the
-    // deferred task completes — an accepted trade-off (never a double- or
-    // dropped-bill, since billUsage runs exactly once).
+    // deferred task completes — an accepted trade-off for this route. The settler
+    // prevents double-settlement inside the task.
     const affiliateCode = c.req.header("X-Affiliate-Code") ?? null;
     const settleBilling = async () => {
-      const billing = await billUsage(
-        {
-          organizationId: user.organization_id,
-          userId: user.id,
-          apiKeyId,
+      try {
+        // #10557: bill WITHOUT handing billUsage the reservation, then settle
+        // explicitly below — making `settleReservation` the SINGLE idempotent
+        // reconcile owner (mirrors /v1/messages and /v1/chat/completions).
+        // Previously billUsage was given the reservation and reconciled it at the
+        // very END, AFTER two unguarded awaits (calculateCost + the affiliate-code
+        // lookup). If either threw, that internal reconcile never ran and the
+        // ~1.5x upfront hold leaked permanently (the outer catch is gated by
+        // `billed`, and this deferred task only logged its failure). Settling via
+        // the first-call-wins settler lets the catch release the hold without any
+        // double-refund risk.
+        const billing = await billUsage(
+          {
+            organizationId: user.organization_id,
+            userId: user.id,
+            apiKeyId,
+            model,
+            provider,
+            billingSource,
+            // Affiliate revenue-share: when the calling app sets X-Affiliate-Code,
+            // activate the existing billUsage affiliate branch (same as /v1/messages).
+            affiliateCode,
+          },
+          { inputTokens: actualTokens, outputTokens: 0 },
+        );
+
+        // Single reconcile site. The settler is first-call-wins idempotent, so
+        // this actual-cost charge can never be double-applied with the catch's
+        // settleReservation(0).
+        await settleReservation?.(billing.totalCost);
+
+        logger.info("[Embeddings] Complete", {
           model,
+          actualTokens,
+          totalCost: billing.totalCost,
+        });
+
+        await usageService.create({
+          organization_id: user.organization_id,
+          user_id: user.id,
+          api_key_id: apiKeyId,
+          type: "embeddings",
+          model: normalizedModel,
           provider,
-          billingSource,
-          // Affiliate revenue-share: when the calling app sets X-Affiliate-Code,
-          // activate the existing billUsage affiliate branch (same as /v1/messages).
-          affiliateCode,
-        },
-        { inputTokens: actualTokens, outputTokens: 0 },
-        reservation,
-      );
-
-      logger.info("[Embeddings] Complete", {
-        model,
-        actualTokens,
-        totalCost: billing.totalCost,
-      });
-
-      await usageService.create({
-        organization_id: user.organization_id,
-        user_id: user.id,
-        api_key_id: apiKeyId,
-        type: "embeddings",
-        model: normalizedModel,
-        provider,
-        input_tokens: actualTokens,
-        output_tokens: 0,
-        input_cost: String(billing.inputCost),
-        output_cost: String(0),
-        is_successful: true,
-      });
+          input_tokens: actualTokens,
+          output_tokens: 0,
+          input_cost: String(billing.inputCost),
+          output_cost: String(0),
+          is_successful: true,
+        });
+      } catch (err) {
+        // billUsage / calculateCost / affiliate lookup threw before the hold was
+        // reconciled → release it. Idempotent: a no-op if we already settled the
+        // actual cost above. Rethrow so the waitUntil .catch logs it.
+        await settleReservation?.(0);
+        throw err;
+      }
     };
 
-    // Past this point billing (which reconciles the reservation) owns the hold,
-    // so the catch must NOT also release it — that would double-refund.
+    // Past this point the deferred settleBilling owns the hold (it settles the
+    // actual cost on success and releases it on its own failure), so the outer
+    // catch must NOT also release it.
     billed = true;
     const billedPromise = settleBilling().catch((err) => {
       logger.error("[Embeddings] Failed to settle billing", {


### PR DESCRIPTION
Closes #10557.

Two items from the inference-billing lifecycle audit (both LOW), each filed because a naive fix gets it wrong.

## Part 1 (money) — embeddings reservation leak
`packages/cloud/api/v1/embeddings/route.ts`. The synchronous-reserve path debits a ~1.5× hold whose **only** refund was `billUsage`'s internal `reservation.reconcile`, run at the END of `billUsage` after two unguarded awaits (`calculateCost` + the affiliate-code lookup). If either threw, that reconcile never ran — and since `billed=true` was already set and the deferred `settleBilling().catch` only **logged**, nothing released the hold → permanent over-debit against the customer (always errs against the customer; sub-cent; narrow trigger).

**The double-refund trap:** a naive `settleReservation(0)` in the catch is NOT safe here the way it is on the messages/completions routes, because embeddings let `billUsage` call `reservation.reconcile` directly, *bypassing* the settler's first-call-wins guard. If reconcile ran and then something threw after it, that release would double-refund.

**Fix (mirrors `/v1/messages` and `/v1/chat/completions`):** stop passing the reservation into `billUsage`, and make the first-call-wins settler the **single reconcile owner** — `settleReservation(billing.totalCost)` on success, `settleReservation(0)` in `settleBilling`'s catch. Idempotent and safe.

## Part 2 (defense-in-depth) — `/v1/chat` org parity
`packages/cloud/api/v1/chat/route.ts` used bare `getCurrentUser` and fell back to the no-op anonymous reservation + org `"anonymous"` for an authenticated user with a null `organization_id`. Not a live leak today (no flow nulls `organization_id`), but a real parity gap: such a caller would get **unbounded free inference on an arbitrary model**, exempt from the anon cap. Mirror the siblings' `requireUserOrApiKeyWithOrg`: **403 an authenticated org-less caller** before any provider call. Genuine anonymous callers are unaffected.

## Evidence
- `embeddings-credit-leak.test.ts`: new cases — billUsage **internal throw** releases the hold exactly once (balance restored, no double-refund); a **post-settle** usage-write throw does NOT refund the real charge (idempotency). Updated the existing success test so the `billUsage` mock no longer reconciles internally (matches the real adapter now that the reservation isn't passed).
- `chat-stream-credit-leak.test.ts`: authed **org-less → 403**, never reaches the model, no hold; authed-**with-org** and **genuine-anonymous** still stream normally.
- **11 pass / 0 fail.** `bun run --cwd packages/cloud/api typecheck` → exit 0. Biome clean.

> ⚠️ Money-path change — **not self-merged.** Maintainer review/merge per the launch protocol. Tracked on the coordination board #10561.