### PR TITLE
fix(core/suno): route ATTACHMENT + Suno subaction by enum/params, not English text (#10471)

### DIFF
--- a/packages/core/src/features/advanced-capabilities/personality/actions/character.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/actions/character.ts
@@ -1306,22 +1306,6 @@ function parseEvolutionData(
 	}
 }
 
-function inferPreferenceCategory(text: string): string {
-	if (/\b(verbose|concise|brief|shorter|detailed)\b/i.test(text))
-		return "verbosity";
-	if (/\b(formal|casual|professional|polite)\b/i.test(text)) return "formality";
-	if (/\b(warm|direct|skeptical|encouraging|supportive|friendly)\b/i.test(text))
-		return "tone";
-	if (
-		/\b(chime|jump in|follow-up question|emoji|language|mentioned|directly addressed|messaged directly)\b/i.test(
-			text,
-		)
-	) {
-		return "style";
-	}
-	return "other";
-}
-
 async function parseUserPreference(
 	runtime: IAgentRuntime,
 	message: Memory,
@@ -1374,10 +1358,13 @@ Set action: none only if the request truly does not specify any interaction pref
 		if (typeof raw.text !== "string") return null;
 		const text = raw.text.trim();
 		if (!text) return null;
+		// #10471: the category comes from the model's structured `category`
+		// field; no English-keyword inference fallback (it was i18n-hostile and
+		// the stored category is not read for behavior). Default to "other".
 		const category =
 			typeof raw.category === "string" && raw.category.trim().length > 0
 				? raw.category.trim()
-				: inferPreferenceCategory(text);
+				: "other";
 		return { text, category, action };
 	} catch {
 		return null;

--- a/packages/core/src/features/working-memory/readAttachmentAction.i18n.test.ts
+++ b/packages/core/src/features/working-memory/readAttachmentAction.i18n.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { readAttachmentActionKind } from "./readAttachmentAction.ts";
+
+/**
+ * #10471 — ATTACHMENT action kind must come from the planner-emitted `action`
+ * enum, never from English keywords in the user text. The old fallback
+ * (`/\bsave\b…\b(document|doc|note|knowledge)\b/i`) silently failed for every
+ * non-English request.
+ */
+describe("readAttachmentActionKind is i18n-safe (#10471)", () => {
+	it("routes by the planner action enum (+ aliases)", () => {
+		expect(readAttachmentActionKind({ action: "save_as_document" })).toBe(
+			"save_as_document",
+		);
+		expect(readAttachmentActionKind({ action: "save-as-document" })).toBe(
+			"save_as_document",
+		);
+		expect(readAttachmentActionKind({ subaction: "read" })).toBe("read");
+	});
+
+	it("defaults to the non-destructive `read`, never inferring from text", () => {
+		// No structured action: must be `read` regardless of message text in any
+		// language. The old English regex would have returned save_as_document for
+		// "save this as a document"; that English-only behavior is gone.
+		expect(readAttachmentActionKind({})).toBe("read");
+		expect(readAttachmentActionKind({ action: "not-a-real-op" })).toBe("read");
+	});
+});

--- a/packages/core/src/features/working-memory/readAttachmentAction.ts
+++ b/packages/core/src/features/working-memory/readAttachmentAction.ts
@@ -193,9 +193,8 @@ function readAttachmentId(params: Record<string, unknown>): string | null {
 	return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
-function readAttachmentActionKind(
+export function readAttachmentActionKind(
 	params: Record<string, unknown>,
-	message: Memory,
 ): AttachmentAction {
 	const raw = params.action ?? params.subaction ?? params.op;
 	if (typeof raw === "string") {
@@ -207,11 +206,10 @@ function readAttachmentActionKind(
 			return normalized as AttachmentAction;
 		}
 	}
-	const text =
-		typeof message.content.text === "string" ? message.content.text : "";
-	return /\bsave\b[\s\S]{0,60}\b(?:document|doc|note|knowledge)\b/i.test(text)
-		? "save_as_document"
-		: "read";
+	// #10471: no English NL keyword inference — the planner emits the `action`
+	// enum (declared in the param schema) for any language. Default to the
+	// non-destructive `read`; `save_as_document` is selected via the enum.
+	return "read";
 }
 
 function readStringParam(
@@ -358,7 +356,7 @@ export const readAttachmentAction: Action = {
 	) => {
 		try {
 			const params = getActionParams(_options);
-			const action = readAttachmentActionKind(params, message);
+			const action = readAttachmentActionKind(params);
 			const messageWithParams: Memory = {
 				...message,
 				content: {

--- a/plugins/plugin-suno/src/actions/musicGeneration.i18n.test.ts
+++ b/plugins/plugin-suno/src/actions/musicGeneration.i18n.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { inferSubaction } from './musicGeneration';
+
+/**
+ * #10471 — the Suno subaction must come from the planner-emitted enum or the
+ * structured params, never from English keywords in the user text. The old
+ * `/\b(extend|lengthen|longer)\b/` / `/\b(custom|style|bpm)\b/` regexes silently
+ * failed for every non-English request.
+ */
+describe('suno inferSubaction is i18n-safe (#10471)', () => {
+    it('routes by the explicit subaction enum (+ aliases)', () => {
+        expect(inferSubaction({ action: 'extend' })).toBe('extend');
+        expect(inferSubaction({ action: 'custom-generate' })).toBe('custom_generate');
+        expect(inferSubaction({ subaction: 'generate' })).toBe('generate');
+    });
+
+    it('routes by structured params, not text', () => {
+        expect(inferSubaction({ audio_id: 'abc' })).toBe('extend');
+        expect(inferSubaction({ style: 'lofi' })).toBe('custom_generate');
+        expect(inferSubaction({ bpm: 120 })).toBe('custom_generate');
+    });
+
+    it('defaults to generate without inferring from natural-language text', () => {
+        // The params carry no structured signal; the result is `generate` in any
+        // language. The old English regexes would have mis-fired on the text.
+        expect(inferSubaction({})).toBe('generate');
+        expect(inferSubaction({ prompt: 'haz una canción más larga' })).toBe('generate');
+    });
+});

--- a/plugins/plugin-suno/src/actions/musicGeneration.ts
+++ b/plugins/plugin-suno/src/actions/musicGeneration.ts
@@ -53,20 +53,20 @@ function normalizeSubaction(value: unknown): SunoMusicSubaction | null {
     return null;
 }
 
-function inferSubaction(message: Memory, params: SunoMusicGenerationParams): SunoMusicSubaction {
+export function inferSubaction(params: SunoMusicGenerationParams): SunoMusicSubaction {
     const explicit = normalizeSubaction(params.action ?? params.subaction ?? params.operation);
     if (explicit) return explicit;
-    const text = (message.content?.text ?? '').toLowerCase();
-    if (params.audio_id || /\b(extend|lengthen|longer|add \d+.*seconds?)\b/.test(text)) {
-        return 'extend';
-    }
+    // #10471: no English NL keyword inference. 'extend' requires a specific
+    // audio_id and 'custom_generate' is driven by the custom params (style/bpm/
+    // key/mode/reference_audio) — both structured signals the planner emits in
+    // any language. Default 'generate'.
+    if (params.audio_id) return 'extend';
     if (
         params.reference_audio ||
         params.style ||
         params.bpm ||
         params.key ||
-        params.mode ||
-        /\b(custom|style|bpm|key|mode|reference)\b/.test(text)
+        params.mode
     ) {
         return 'custom_generate';
     }
@@ -115,7 +115,7 @@ export const sunoGenerateMusicHandler = async (
     callback?: HandlerCallback
 ): Promise<ActionResult> => {
     const params = paramsFromMessageAndOptions(message, options);
-    const subaction = inferSubaction(message, params);
+    const subaction = inferSubaction(params);
 
     let provider: SunoProvider;
     try {


### PR DESCRIPTION
## What

Round 2 of the #10471 op-inference conversions (after the merged #10550). Two more `infer*` helpers that read the user's `message.content.text` to pick an op:

- **`working-memory/readAttachmentAction.readAttachmentActionKind`** — dropped `/\bsave\b…\b(document|doc|note|knowledge)\b/i`. Resolves from the declared `action` enum (`ATTACHMENT_ACTIONS = [read, save_as_document]`), defaulting to the **non-destructive `read`** (`save_as_document` is selected via the enum).
- **`plugin-suno musicGeneration.inferSubaction`** — dropped `/\b(extend|lengthen|longer)\b/` and `/\b(custom|style|bpm|key|mode)\b/`. Resolves from the subaction enum plus the structured signals that actually drive it (`audio_id` ⇒ extend; `style`/`bpm`/`key`/`mode`/`reference_audio` ⇒ custom_generate); default `generate`.

## Why / evidence

Same pattern as the merged POST/GENERATE_MEDIA/MESSAGE conversions (#10550), where a live `gpt-oss-120b` was shown to emit these enums correctly across JA/DE/FR/KO/ZH/ES. The removed regexes only matched English, so non-English requests silently misrouted. New regression tests (`*.i18n.test.ts`) assert enum/param routing and that NL text no longer selects the op in any language (5 tests, green); scoped `tsc` + `biome` clean.

## Scope note — `role.ts` left unchanged (verified KEEP)

The audit flagged `role.ts`, but inspecting it directly: its op/role come from **structured params** (`params.action`/`role`/`label`), never from `message.content.text`. The English synonym maps (`normalizeOp`, `NATURAL_ROLE_MAP`) normalize the *planner's* English-enum output, not user text. A live probe confirmed the planner emits the correct, **non-over-privileging** role enum across languages (`boss`→ADMIN not OWNER, `invité`→GUEST). So it is not a user-text i18n smell — left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
