### PR TITLE
fix(cloud): release the sync-reserve hold when embeddings billUsage throws pre-reconcile (#10557)

### DIFF
--- a/packages/cloud/api/__tests__/embeddings-credit-leak.test.ts
+++ b/packages/cloud/api/__tests__/embeddings-credit-leak.test.ts
@@ -282,3 +282,30 @@ describe("embeddings — success settles to actual usage exactly once", () => {
     expect(ledger.balance).toBeCloseTo(ledger.startBalance - ACTUAL, 10);
   });
 });
+
+describe("embeddings — sync billUsage failure releases the upfront hold", () => {
+  test("billUsage throwing before its reconcile (sync reserve) refunds the hold exactly once", async () => {
+    const ledger = makeLedgerReservation(100, 0.01);
+    reserveCredits.mockResolvedValue(ledger.reservation);
+    embed.mockResolvedValue({ embedding: [0.1, 0.2], usage: { tokens: 5 } });
+    // billUsage throws BEFORE its internal reconcile (e.g. calculateCost or the
+    // affiliate lookup fails) — reconcile never runs, so on the SYNC-reserve path
+    // the upfront hold must be released by the route's inner catch (not leaked).
+    billUsage.mockRejectedValue(new Error("billing pipeline error"));
+
+    const { ctx, scheduled } = makeExecutionCtx();
+    // The vectors were already returned; billing is deferred via waitUntil, so the
+    // request still succeeds even though the deferred billing throws.
+    const res = await post(
+      { model: "text-embedding-3-small", input: "hi" },
+      ctx,
+    );
+    expect(res.status).toBe(200);
+
+    await Promise.all(scheduled);
+    // The inner catch released the hold exactly once (reconcile(0)); balance fully
+    // restored — no permanent overcharge, and not double-refunded.
+    expect(ledger.reconcileCalls).toBe(1);
+    expect(ledger.balance).toBeCloseTo(ledger.startBalance, 10);
+  });
+});

--- a/packages/cloud/api/v1/embeddings/route.ts
+++ b/packages/cloud/api/v1/embeddings/route.ts
@@ -430,21 +430,38 @@ app.post("/", async (c) => {
     // dropped-bill, since billUsage runs exactly once).
     const affiliateCode = c.req.header("X-Affiliate-Code") ?? null;
     const settleBilling = async () => {
-      const billing = await billUsage(
-        {
-          organizationId: user.organization_id,
-          userId: user.id,
-          apiKeyId,
-          model,
-          provider,
-          billingSource,
-          // Affiliate revenue-share: when the calling app sets X-Affiliate-Code,
-          // activate the existing billUsage affiliate branch (same as /v1/messages).
-          affiliateCode,
-        },
-        { inputTokens: actualTokens, outputTokens: 0 },
-        reservation,
-      );
+      let billing: Awaited<ReturnType<typeof billUsage>>;
+      try {
+        billing = await billUsage(
+          {
+            organizationId: user.organization_id,
+            userId: user.id,
+            apiKeyId,
+            model,
+            provider,
+            billingSource,
+            // Affiliate revenue-share: when the calling app sets X-Affiliate-Code,
+            // activate the existing billUsage affiliate branch (same as /v1/messages).
+            affiliateCode,
+          },
+          { inputTokens: actualTokens, outputTokens: 0 },
+          reservation,
+        );
+      } catch (err) {
+        // billUsage throws BEFORE its reconcile (reconcile is its last meaningful
+        // step — only a logger.info + the return follow it), so on the SYNC-reserve
+        // path the upfront ~1.5x hold was never released → a permanent overcharge.
+        // Release it via the idempotent settler. Do NOT release on the OPTIMISTIC
+        // path: there reservedAmount=0 (no upfront hold) and the cron settles the
+        // KV pending-charge, so settleReservation(0) → ledgerSettler(0) would
+        // settle that charge at zero = a free embedding. usageService.create runs
+        // AFTER this (outside the try), so its failure can't reach here and
+        // double-refund an already-reconciled hold.
+        if (!optimisticReady && settleReservation) {
+          await settleReservation(0);
+        }
+        throw err;
+      }
 
       logger.info("[Embeddings] Complete", {
         model,
@@ -467,8 +484,11 @@ app.post("/", async (c) => {
       });
     };
 
-    // Past this point billing (which reconciles the reservation) owns the hold,
-    // so the catch must NOT also release it — that would double-refund.
+    // Past this point billing owns the hold. The ONLY safe release is the inner
+    // billUsage catch above (reconcile provably didn't run there). The .catch
+    // below logs whatever settleBilling rejects with — a usageService.create
+    // failure (reconcile already ran) or the inner catch's re-throw (hold already
+    // released) — and must NOT release again, or it would double-refund.
     billed = true;
     const billedPromise = settleBilling().catch((err) => {
       logger.error("[Embeddings] Failed to settle billing", {


### PR DESCRIPTION
Closes the **embeddings reservation-leak** item of #10557 — the one I'd filed as "needs careful design." I did the careful design + **adversarially verified it on all 5 paths** before shipping.

## The bug
The embeddings **sync-reserve** path takes a ~1.5× upfront credit hold (`reserveCredits`) whose only release is `reservation.reconcile()` — which runs at the **end** of `billUsage()`. If `billUsage` throws **before** that (`calculateCost`, or the affiliate lookup when `X-Affiliate-Code` is set), reconcile never runs and the hold is **never released → permanent overcharge**. The route set `billed=true` + fire-and-forgot `settleBilling().catch(log)`, and the outer catch was gated by `!billed`, so nothing released it.

## Why the naive fix was wrong (and what I did instead)
A bare `settleReservation(0)` in the catch would **double-refund** (a `usageService.create` failure *after* reconcile would also hit it) and **break the optimistic path** (there `reservedAmount=0` and the cron settles the KV pending-charge — a 0-cost settle would claim that entry → **free embedding**).

The fix:
- wrap **only** `billUsage` in an inner try/catch (so the `usageService.create` *after* it can't trigger a release of an already-reconciled hold),
- release **only on the sync path** (`!optimisticReady`), leaving the optimistic pending-charge intact for the cron.

This is provably safe: `billUsage`'s reconcile is its last meaningful step (only `logger.info`+`return` follow), so a `billUsage` throw guarantees reconcile didn't run; the sync reconcile never partially-runs (it returns instead of throwing).

## Verification
- **Adversarial money-correctness agent** traced all 5 paths → **CONFIRMED-CORRECT**: no double-refund, no double-charge, no free-embedding, no leak.
- **Type-check agent** → COMPILES-CLEAN.
- **Added a regression test** (`embeddings-credit-leak.test.ts`): sync `billUsage`-throw → `reconcileCalls===1`, balance restored. (Mirrors the existing passing tests; runs in CI — local run blocked on uninstalled deps, not test logic.)

Low severity (sub-cent, narrow trigger, errs against the customer) but a real money-correctness fix done right, not slopped.