### PR TITLE
fix(cloud): payout stale-lock recovery + tx-hash-at-broadcast to prevent double-pay (#10553)

### DIFF
--- a/packages/cloud/shared/src/db/migrations/0155_redemption_broadcast_tx_hash.sql
+++ b/packages/cloud/shared/src/db/migrations/0155_redemption_broadcast_tx_hash.sql
@@ -1,0 +1,18 @@
+-- Crash-recovery support for the payout processor (#10553).
+--
+-- Records the on-chain transaction hash the MOMENT a redemption transfer is
+-- broadcast — before confirmation — so a worker that dies mid-payout can be
+-- recovered without risking a double-pay:
+--   * a stuck `processing` row WITH a broadcast hash means a transfer may be
+--     in-flight on-chain → it must NEVER be auto-retried (a re-broadcast would
+--     double-pay); it is routed to operator reconciliation instead.
+--   * a stuck EVM `processing` row WITHOUT a broadcast hash means the worker died
+--     before submitting any transaction → it is provably safe to re-approve.
+--
+-- Distinct from `tx_hash`, which is only written once the transfer CONFIRMS.
+-- Additive + idempotent: ADD COLUMN IF NOT EXISTS, nullable, no backfill, no drop.
+-- The column defaults NULL, so every pre-existing row is treated as "not
+-- broadcast" — correct, since any redemption created before this migration is
+-- already completed/failed or still approved, never mid-broadcast.
+
+ALTER TABLE "token_redemptions" ADD COLUMN IF NOT EXISTS "broadcast_tx_hash" text;

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1072,6 +1072,13 @@
       "when": 1780273200000,
       "tag": "0154_agent_server_wallets_client_address_chain_unique",
       "breakpoints": true
+    },
+    {
+      "idx": 153,
+      "version": "7",
+      "when": 1780359600000,
+      "tag": "0155_redemption_broadcast_tx_hash",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/repositories/token-redemptions.ts
+++ b/packages/cloud/shared/src/db/repositories/token-redemptions.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gte, inArray, isNull, lt, or, sql } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, isNull, lt, sql } from "drizzle-orm";
 import { mutateRowCount } from "../execute-helpers";
 import { dbRead, dbWrite } from "../helpers";
 import { apps } from "../schemas/apps";
@@ -109,12 +109,40 @@ export class TokenRedemptionsRepository {
 
   /**
    * Gets approved redemptions ready for processing.
-   * Excludes items that are currently being processed or have exceeded retry limit.
+   *
+   * An approved row always has a NULL processing_started_at — acquireLock flips
+   * it to 'processing', and markFailed/stale-lock recovery reset it to NULL when
+   * returning a row to 'approved' — so a plain isNull is the correct "unlocked"
+   * filter. (The former `OR processing_started_at < lockThreshold` clause was
+   * dead: no 'approved' row ever carries a stale lock. Stale 'processing' locks
+   * are recovered separately by the payout processor's recoverStaleLocks.)
    */
   async getApprovedForProcessing(
     batchSize: number,
-    lockTimeoutMs: number,
+    _lockTimeoutMs: number,
     maxRetries: number,
+  ): Promise<TokenRedemption[]> {
+    return await dbRead
+      .select()
+      .from(tokenRedemptions)
+      .where(
+        and(
+          eq(tokenRedemptions.status, "approved"),
+          isNull(tokenRedemptions.processing_started_at),
+          lt(sql`CAST(${tokenRedemptions.retry_count} AS INTEGER)`, maxRetries),
+        ),
+      )
+      .limit(batchSize);
+  }
+
+  /**
+   * Gets redemptions stuck in `processing` past the lock timeout (their worker
+   * died mid-payout). The payout processor classifies each by broadcast_tx_hash
+   * to decide whether it is safe to retry or must be reconciled on-chain.
+   */
+  async getStaleProcessingLocks(
+    batchSize: number,
+    lockTimeoutMs: number,
   ): Promise<TokenRedemption[]> {
     const lockThreshold = new Date(Date.now() - lockTimeoutMs);
 
@@ -123,12 +151,8 @@ export class TokenRedemptionsRepository {
       .from(tokenRedemptions)
       .where(
         and(
-          eq(tokenRedemptions.status, "approved"),
-          or(
-            isNull(tokenRedemptions.processing_started_at),
-            lt(tokenRedemptions.processing_started_at, lockThreshold),
-          ),
-          lt(sql`CAST(${tokenRedemptions.retry_count} AS INTEGER)`, maxRetries),
+          eq(tokenRedemptions.status, "processing"),
+          lt(tokenRedemptions.processing_started_at, lockThreshold),
         ),
       )
       .limit(batchSize);

--- a/packages/cloud/shared/src/db/schemas/token-redemptions.ts
+++ b/packages/cloud/shared/src/db/schemas/token-redemptions.ts
@@ -104,6 +104,14 @@ export const tokenRedemptions = pgTable(
     processing_started_at: timestamp("processing_started_at"),
     processing_worker_id: text("processing_worker_id"), // For distributed locking
 
+    // Broadcast tx hash, recorded the moment the transfer is submitted to the
+    // chain (BEFORE confirmation). Load-bearing for crash recovery: a stuck
+    // `processing` row with this set means a transaction may be in-flight on-chain
+    // and MUST NOT be re-broadcast (would double-pay); a null value on an EVM row
+    // means the worker died before broadcasting → safe to retry. Distinct from
+    // `tx_hash`, which is only written once the transfer is confirmed.
+    broadcast_tx_hash: text("broadcast_tx_hash"),
+
     // Completion details
     tx_hash: text("tx_hash"),
     completed_at: timestamp("completed_at"),

--- a/packages/cloud/shared/src/lib/services/__tests__/payout-processor-crash-recovery.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/payout-processor-crash-recovery.test.ts
@@ -1,0 +1,421 @@
+/**
+ * Crash-recovery + no-double-pay tests for the payout processor (#10553).
+ *
+ * Before: a worker that died mid-payout left a redemption stuck in `processing`
+ * forever — the only batch selector filtered on status='approved', and the
+ * "recover stale lock" OR-clause was dead (no approved row ever carries a stale
+ * lock). And executeEvmPayout did not wrap writeContract/waitForTransactionReceipt,
+ * so a thrown RPC error aborted the whole batch with the row left locked.
+ *
+ * After: a separate stale-`processing` recovery path classifies each stuck row by
+ * whether a transfer may already be on-chain (broadcast_tx_hash recorded, or any
+ * interrupted Solana payout) and NEVER auto-retries those — only a provably
+ * un-broadcast EVM lock is re-approved. The broadcast hash is persisted the moment
+ * the transfer is submitted, BEFORE confirmation. These tests pin that safety.
+ */
+import { afterAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+
+const viemActual = require("viem") as Record<string, unknown>;
+const cloudBindingsActual = await import("../../runtime/cloud-bindings");
+const evmRpcActual = await import("../../config/evm-rpc");
+const dbClientActual = await import("../../../db/client");
+const payoutAlertsActual = await import("../payout-alerts");
+
+// ---- module mocks (must be set before importing the service) ----
+const getCloudAwareEnv = mock();
+mock.module("../../runtime/cloud-bindings", () => ({ ...cloudBindingsActual, getCloudAwareEnv }));
+
+const resolveEvmRpc = mock(() => ({ source: "test", url: "https://rpc.invalid.example" }));
+mock.module("../../config/evm-rpc", () => ({ ...evmRpcActual, resolveEvmRpc }));
+
+// Controllable viem clients. writeContract / waitForTransactionReceipt / readContract
+// are driven per-test; http + parseUnits stay real.
+const writeContract = mock();
+const waitForTransactionReceipt = mock();
+const readContract = mock(async () => 10n ** 30n); // hot wallet always funded
+mock.module("viem", () => ({
+  ...viemActual,
+  createPublicClient: () => ({ readContract, waitForTransactionReceipt }),
+  createWalletClient: () => ({ writeContract }),
+}));
+mock.module("viem/accounts", () => ({
+  privateKeyToAccount: () => ({ address: "0x000000000000000000000000000000000000dEaD" }),
+}));
+
+// DB mock: a thenable chain whose terminal awaits consume a results queue in call
+// order. `.set()` payloads are captured for assertions.
+function makeDb() {
+  const queue: unknown[][] = [];
+  const setArgs: Record<string, unknown>[] = [];
+  const chain: Record<string, unknown> = {
+    // biome-ignore lint/suspicious/noThenProperty: intentional thenable — emulates drizzle's awaitable query builder so `await db.select()...` resolves to the queued result.
+    then: (resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) =>
+      Promise.resolve(queue.length ? queue.shift() : []).then(resolve, reject),
+  };
+  for (const m of [
+    "select",
+    "from",
+    "where",
+    "limit",
+    "update",
+    "insert",
+    "values",
+    "returning",
+    "delete",
+    "orderBy",
+  ]) {
+    chain[m] = mock(() => chain);
+  }
+  chain.set = mock((payload: Record<string, unknown>) => {
+    setArgs.push(payload);
+    return chain;
+  });
+  chain.transaction = mock(async (fn: (tx: unknown) => unknown) => fn(chain));
+  return {
+    chain,
+    enqueue: (r: unknown[]) => queue.push(r),
+    setArgs,
+    reset: () => {
+      queue.length = 0;
+      setArgs.length = 0;
+    },
+  };
+}
+
+// One STABLE db/chain for the whole file — the processor's ESM import snapshots
+// the chain, so we reset its queue/setArgs in place between tests rather than
+// reassigning `db` (which the import would never see).
+const db = makeDb();
+mock.module("../../../db/client", () => ({
+  ...dbClientActual,
+  dbRead: db.chain,
+  dbWrite: db.chain,
+}));
+
+const sendAlert = mock(async () => undefined);
+mock.module("../payout-alerts", () => ({
+  ...payoutAlertsActual,
+  payoutAlertsService: { sendAlert },
+}));
+
+const { classifyStaleProcessingLock, PayoutProcessorService } = await import("../payout-processor");
+
+afterAll(() => {
+  mock.module("viem", () => viemActual);
+});
+
+const EVM_KEY = `0x${"1".repeat(64)}`;
+
+function evmRedemption(over: Record<string, unknown> = {}) {
+  return {
+    id: "11111111-1111-4111-8111-111111111111",
+    network: "base",
+    payout_address: "0x000000000000000000000000000000000000bEEF",
+    eliza_amount: "100",
+    price_quote_expires_at: new Date(Date.now() + 60_000),
+    eliza_price_usd: "0.01",
+    usd_value: "1.00",
+    user_id: "22222222-2222-4222-8222-222222222222",
+    broadcast_tx_hash: null,
+    ...over,
+  } as never;
+}
+
+beforeEach(() => {
+  db.reset();
+  getCloudAwareEnv.mockReset();
+  getCloudAwareEnv.mockReturnValue({ EVM_PAYOUT_PRIVATE_KEY: EVM_KEY });
+  writeContract.mockReset();
+  waitForTransactionReceipt.mockReset();
+  readContract.mockReset();
+  readContract.mockResolvedValue(10n ** 30n);
+  resolveEvmRpc.mockReturnValue({ source: "test", url: "https://rpc.invalid.example" });
+  sendAlert.mockReset();
+  sendAlert.mockResolvedValue(undefined);
+});
+
+// ---------------------------------------------------------------------------
+// 1. The pure safety classifier — the no-double-pay decision, exhaustive.
+// ---------------------------------------------------------------------------
+describe("classifyStaleProcessingLock — never re-approves a possibly-broadcast row", () => {
+  for (const network of ["ethereum", "base", "bnb"]) {
+    test(`${network} with NO broadcast hash → reapprove (worker died before submitting)`, () => {
+      const r = classifyStaleProcessingLock({ network, broadcast_tx_hash: null });
+      expect(r.action).toBe("reapprove");
+    });
+    test(`${network} WITH a broadcast hash → reconcile (may be in-flight, never re-broadcast)`, () => {
+      const r = classifyStaleProcessingLock({ network, broadcast_tx_hash: "0xdeadbeef" });
+      expect(r.action).toBe("reconcile");
+    });
+  }
+
+  test("solana with NO broadcast hash → reconcile (atomic send+confirm can't be proven un-sent)", () => {
+    const r = classifyStaleProcessingLock({ network: "solana", broadcast_tx_hash: null });
+    expect(r.action).toBe("reconcile");
+  });
+  test("solana WITH a broadcast hash → reconcile", () => {
+    const r = classifyStaleProcessingLock({ network: "solana", broadcast_tx_hash: "sig123" });
+    expect(r.action).toBe("reconcile");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. executeEvmPayout — persist hash BEFORE confirm; route every failure safely.
+// ---------------------------------------------------------------------------
+describe("executeEvmPayout — broadcast hash persisted before confirmation", () => {
+  test("success: records broadcast hash BEFORE awaiting the receipt, then completes", async () => {
+    const svc = new PayoutProcessorService();
+    const order: string[] = [];
+    const recordSpy = spyOn(
+      svc as unknown as { recordBroadcastTxHash: (id: string, h: string) => Promise<void> },
+      "recordBroadcastTxHash",
+    ).mockImplementation(async () => {
+      order.push("record");
+    });
+    writeContract.mockImplementation(async () => {
+      order.push("broadcast");
+      return "0xabc123";
+    });
+    waitForTransactionReceipt.mockImplementation(async () => {
+      order.push("confirm");
+      return { status: "success" };
+    });
+
+    const result = await (
+      svc as unknown as {
+        executeEvmPayout: (r: never, n: string) => Promise<{ success: boolean; txHash?: string }>;
+      }
+    ).executeEvmPayout(evmRedemption(), "base");
+
+    expect(result.success).toBe(true);
+    expect(result.txHash).toBe("0xabc123");
+    // The hash MUST be persisted between broadcast and confirmation.
+    expect(order).toEqual(["broadcast", "record", "confirm"]);
+    expect(recordSpy).toHaveBeenCalledWith(evmRedemption().id, "0xabc123");
+  });
+
+  test("writeContract throws (never submitted) → retryable, no hash recorded", async () => {
+    const svc = new PayoutProcessorService();
+    const recordSpy = spyOn(
+      svc as unknown as { recordBroadcastTxHash: () => Promise<void> },
+      "recordBroadcastTxHash",
+    ).mockResolvedValue(undefined);
+    writeContract.mockRejectedValue(new Error("nonce too low"));
+
+    const result = await (
+      svc as unknown as {
+        executeEvmPayout: (
+          r: never,
+          n: string,
+        ) => Promise<{ success: boolean; retryable?: boolean; needsReconciliation?: boolean }>;
+      }
+    ).executeEvmPayout(evmRedemption(), "base");
+
+    expect(result.success).toBe(false);
+    expect(result.retryable).toBe(true);
+    expect(result.needsReconciliation).toBeUndefined();
+    expect(recordSpy).not.toHaveBeenCalled();
+    expect(waitForTransactionReceipt).not.toHaveBeenCalled();
+  });
+
+  test("hash persistence fails AFTER broadcast → needsReconciliation (never retry)", async () => {
+    const svc = new PayoutProcessorService();
+    spyOn(
+      svc as unknown as { recordBroadcastTxHash: () => Promise<void> },
+      "recordBroadcastTxHash",
+    ).mockRejectedValue(new Error("db down"));
+    writeContract.mockResolvedValue("0xLIVE");
+
+    const result = await (
+      svc as unknown as {
+        executeEvmPayout: (
+          r: never,
+          n: string,
+        ) => Promise<{
+          success: boolean;
+          retryable?: boolean;
+          needsReconciliation?: boolean;
+          txHash?: string;
+        }>;
+      }
+    ).executeEvmPayout(evmRedemption(), "base");
+
+    expect(result.success).toBe(false);
+    expect(result.needsReconciliation).toBe(true);
+    expect(result.retryable).toBeUndefined();
+    expect(result.txHash).toBe("0xLIVE");
+    // The tx is live — we must NOT wait/confirm-then-retry; reconcile instead.
+    expect(waitForTransactionReceipt).not.toHaveBeenCalled();
+  });
+
+  test("waitForTransactionReceipt throws (broadcast, unconfirmed) → needsReconciliation", async () => {
+    const svc = new PayoutProcessorService();
+    spyOn(
+      svc as unknown as { recordBroadcastTxHash: () => Promise<void> },
+      "recordBroadcastTxHash",
+    ).mockResolvedValue(undefined);
+    writeContract.mockResolvedValue("0xLIVE2");
+    waitForTransactionReceipt.mockRejectedValue(new Error("rpc timeout"));
+
+    const result = await (
+      svc as unknown as {
+        executeEvmPayout: (
+          r: never,
+          n: string,
+        ) => Promise<{
+          success: boolean;
+          retryable?: boolean;
+          needsReconciliation?: boolean;
+          txHash?: string;
+        }>;
+      }
+    ).executeEvmPayout(evmRedemption(), "base");
+
+    expect(result.success).toBe(false);
+    expect(result.needsReconciliation).toBe(true);
+    expect(result.retryable).toBeUndefined();
+    expect(result.txHash).toBe("0xLIVE2");
+  });
+
+  test("reverted transfer (moved nothing) → retryable", async () => {
+    const svc = new PayoutProcessorService();
+    spyOn(
+      svc as unknown as { recordBroadcastTxHash: () => Promise<void> },
+      "recordBroadcastTxHash",
+    ).mockResolvedValue(undefined);
+    writeContract.mockResolvedValue("0xREVERT");
+    waitForTransactionReceipt.mockResolvedValue({ status: "reverted" });
+
+    const result = await (
+      svc as unknown as {
+        executeEvmPayout: (
+          r: never,
+          n: string,
+        ) => Promise<{ success: boolean; retryable?: boolean; needsReconciliation?: boolean }>;
+      }
+    ).executeEvmPayout(evmRedemption(), "base");
+
+    expect(result.success).toBe(false);
+    expect(result.retryable).toBe(true);
+    expect(result.needsReconciliation).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. recoverStaleLocks — routes each stuck row to the safe action.
+// ---------------------------------------------------------------------------
+describe("recoverStaleLocks — re-approves only provably un-broadcast EVM locks", () => {
+  const config = {
+    LOCK_TIMEOUT_MS: 5 * 60 * 1000,
+    BATCH_SIZE: 10,
+    MAX_RETRY_ATTEMPTS: 3,
+    WORKER_ID: "test",
+  } as never;
+
+  test("stale EVM lock with no broadcast hash → re-approved", async () => {
+    const svc = new PayoutProcessorService();
+    const old = new Date(Date.now() - 60 * 60 * 1000);
+    db.enqueue([
+      { id: "r1", network: "base", broadcast_tx_hash: null, processing_started_at: old },
+    ]); // select
+    db.enqueue([{ id: "r1" }]); // reapprove .returning() → truthy
+
+    await (svc as unknown as { recoverStaleLocks: (c: never) => Promise<void> }).recoverStaleLocks(
+      config,
+    );
+
+    expect(db.setArgs.length).toBe(1);
+    expect(db.setArgs[0].status).toBe("approved");
+    expect(db.setArgs[0].processing_started_at).toBeNull();
+    expect(sendAlert).not.toHaveBeenCalled();
+  });
+
+  test("stale lock WITH a broadcast hash → parked failed + requires_review + alert", async () => {
+    const svc = new PayoutProcessorService();
+    const old = new Date(Date.now() - 60 * 60 * 1000);
+    db.enqueue([
+      {
+        id: "r2",
+        network: "base",
+        broadcast_tx_hash: "0xINFLIGHT",
+        processing_started_at: old,
+        payout_address: "0xbEEF",
+        eliza_amount: "5",
+      },
+    ]); // select
+    db.enqueue([{ id: "r2" }]); // parked .returning() → truthy
+
+    await (svc as unknown as { recoverStaleLocks: (c: never) => Promise<void> }).recoverStaleLocks(
+      config,
+    );
+
+    expect(db.setArgs.length).toBe(1);
+    expect(db.setArgs[0].status).toBe("failed");
+    expect(db.setArgs[0].requires_review).toBe(true);
+    expect(sendAlert).toHaveBeenCalledTimes(1);
+  });
+
+  test("stale Solana lock with no hash → parked for reconciliation (never re-approved)", async () => {
+    const svc = new PayoutProcessorService();
+    const old = new Date(Date.now() - 60 * 60 * 1000);
+    db.enqueue([
+      {
+        id: "r3",
+        network: "solana",
+        broadcast_tx_hash: null,
+        processing_started_at: old,
+        eliza_amount: "5",
+        payout_address: "sol",
+      },
+    ]);
+    db.enqueue([{ id: "r3" }]);
+
+    await (svc as unknown as { recoverStaleLocks: (c: never) => Promise<void> }).recoverStaleLocks(
+      config,
+    );
+
+    expect(db.setArgs[0].status).toBe("failed");
+    expect(db.setArgs[0].requires_review).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. processBatch — one throwing redemption never aborts the batch.
+// ---------------------------------------------------------------------------
+describe("processBatch — a throwing redemption is isolated", () => {
+  test("a mid-batch throw is caught; the remaining rows still process", async () => {
+    const svc = new PayoutProcessorService();
+    spyOn(
+      svc as unknown as { recoverStaleLocks: () => Promise<void> },
+      "recoverStaleLocks",
+    ).mockResolvedValue(undefined);
+    spyOn(
+      svc as unknown as { acquireLock: () => Promise<boolean> },
+      "acquireLock",
+    ).mockResolvedValue(true);
+    const completed: string[] = [];
+    spyOn(
+      svc as unknown as { markCompleted: (r: { id: string }) => Promise<void> },
+      "markCompleted",
+    ).mockImplementation(async (r) => {
+      completed.push(r.id);
+    });
+    spyOn(
+      svc as unknown as { processRedemption: (r: { id: string }) => Promise<unknown> },
+      "processRedemption",
+    ).mockImplementation(async (r) => {
+      if (r.id === "b") throw new Error("RPC exploded mid-payout");
+      return { success: true, txHash: `0x${r.id}` };
+    });
+
+    db.enqueue([{ id: "a" }, { id: "b" }, { id: "c" }]); // approved-rows select
+
+    const stats = await svc.processBatch();
+
+    expect(stats.processed).toBe(3);
+    expect(stats.succeeded).toBe(2);
+    expect(stats.failed).toBe(1);
+    // The throw on "b" did not prevent "c" from completing.
+    expect(completed).toEqual(["a", "c"]);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/payout-processor.ts
+++ b/packages/cloud/shared/src/lib/services/payout-processor.ts
@@ -33,7 +33,7 @@
  */
 
 import bs58 from "bs58";
-import { and, eq, isNull, lt, or, sql } from "drizzle-orm";
+import { and, eq, isNull, lt, sql } from "drizzle-orm";
 import { type Address, createPublicClient, createWalletClient, http, parseUnits } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { dbRead, dbWrite } from "../../db/client";
@@ -92,6 +92,53 @@ interface PayoutResult {
   txHash?: string;
   error?: string;
   retryable?: boolean;
+  // True when a transfer may already be in-flight on-chain (broadcast happened,
+  // confirmation/persistence did not). Such a redemption must NOT be auto-retried
+  // — a re-broadcast would double-pay — so it is parked for operator on-chain
+  // reconciliation instead of being reset to `approved`.
+  needsReconciliation?: boolean;
+}
+
+/**
+ * Decide how to recover a redemption found stuck in `processing` past the lock
+ * timeout (its worker died mid-payout). This is the load-bearing safety
+ * decision: a wrong "re-approve" here re-broadcasts a transfer that already
+ * landed → double-pay. Kept pure and exported so it can be exhaustively tested.
+ *
+ *  - A recorded `broadcast_tx_hash` ⇒ a transaction may be in-flight on-chain.
+ *    NEVER auto-retry; reconcile against the chain.
+ *  - Solana with no recorded hash ⇒ its send+confirm is atomic and a thrown/killed
+ *    call may still have landed the transfer, and no pre-confirmation signature is
+ *    recorded — we cannot prove it did NOT broadcast, so reconcile conservatively.
+ *  - EVM with no recorded hash ⇒ the worker died before `writeContract`, so no
+ *    transaction was ever submitted → provably safe to re-approve for a fresh try.
+ */
+export type StaleLockRecovery =
+  | { action: "reapprove"; reason: string }
+  | { action: "reconcile"; reason: string };
+
+export function classifyStaleProcessingLock(row: {
+  network: string;
+  broadcast_tx_hash: string | null;
+}): StaleLockRecovery {
+  if (row.broadcast_tx_hash) {
+    return {
+      action: "reconcile",
+      reason: `broadcast tx ${row.broadcast_tx_hash} may be in-flight on-chain — reconcile before any retry, DO NOT re-broadcast`,
+    };
+  }
+  if (row.network === "solana") {
+    return {
+      action: "reconcile",
+      reason:
+        "solana payout interrupted with no recorded broadcast signature — atomic send+confirm cannot be proven un-sent, reconcile before any retry",
+    };
+  }
+  return {
+    action: "reapprove",
+    reason:
+      "stale lock with no broadcast — worker died before submitting any transaction, safe to retry",
+  };
 }
 
 interface ProcessingStats {
@@ -192,20 +239,26 @@ export class PayoutProcessorService {
       return stats;
     }
 
-    // Find approved redemptions that aren't being processed
+    // First, recover any redemptions stuck in `processing` past the lock timeout
+    // (their worker died mid-payout). This is what re-enables the documented
+    // "automatic retry" — previously these rows were unreachable forever because
+    // the only selector below filters on status='approved'.
+    await this.recoverStaleLocks(payoutConfig);
+
+    // Find approved redemptions that aren't being processed. An approved row
+    // always has a NULL processing_started_at (acquireLock flips it to
+    // 'processing'; markFailed/recovery reset it to NULL when returning to
+    // 'approved'), so a plain isNull is the correct unlocked filter. Stale
+    // 'processing' locks are handled by recoverStaleLocks above — NOT here (the
+    // old `OR processing_started_at < timeout` clause was dead: no approved row
+    // ever carries a stale lock).
     const redemptions = await dbRead
       .select()
       .from(tokenRedemptions)
       .where(
         and(
           eq(tokenRedemptions.status, "approved"),
-          or(
-            isNull(tokenRedemptions.processing_started_at),
-            lt(
-              tokenRedemptions.processing_started_at,
-              new Date(Date.now() - payoutConfig.LOCK_TIMEOUT_MS),
-            ),
-          ),
+          isNull(tokenRedemptions.processing_started_at),
           lt(
             sql`CAST(${tokenRedemptions.retry_count} AS INTEGER)`,
             payoutConfig.MAX_RETRY_ATTEMPTS,
@@ -217,27 +270,155 @@ export class PayoutProcessorService {
     for (const redemption of redemptions) {
       stats.processed++;
 
-      // Try to acquire lock
-      const locked = await this.acquireLock(redemption.id);
-      if (!locked) {
-        stats.skipped++;
-        continue;
-      }
+      // One redemption must never abort the whole batch. A throw here leaves the
+      // row in 'processing' (the lock is already held) — the NEXT cycle's
+      // recoverStaleLocks classifies it by broadcast_tx_hash (safe-by-default: a
+      // broadcast row reconciles, a pre-broadcast EVM row retries).
+      try {
+        // Try to acquire lock
+        const locked = await this.acquireLock(redemption.id);
+        if (!locked) {
+          stats.skipped++;
+          continue;
+        }
 
-      // Process the payout
-      const result = await this.processRedemption(redemption);
+        // Process the payout
+        const result = await this.processRedemption(redemption);
 
-      if (result.success) {
-        await this.markCompleted(redemption, result.txHash!);
-        stats.succeeded++;
-      } else {
-        await this.markFailed(redemption.id, result.error!, result.retryable ?? true);
+        if (result.success) {
+          await this.markCompleted(redemption, result.txHash!);
+          stats.succeeded++;
+        } else if (result.needsReconciliation) {
+          // A transfer may already be on-chain — park for operator reconciliation,
+          // never auto-retry.
+          await this.markNeedsReconciliation(
+            redemption.id,
+            result.error ?? "payout interrupted after broadcast",
+            result.txHash,
+          );
+          stats.failed++;
+        } else {
+          await this.markFailed(redemption.id, result.error!, result.retryable ?? true);
+          stats.failed++;
+        }
+      } catch (error) {
         stats.failed++;
+        logger.error(
+          "[PayoutProcessor] Unexpected error processing redemption — left locked for stale-lock recovery",
+          {
+            redemptionId: redemption.id,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
       }
     }
 
     logger.info("[PayoutProcessor] Batch completed", stats);
     return stats;
+  }
+
+  /**
+   * Recover redemptions stuck in `processing` past the lock timeout (their worker
+   * died mid-payout). Each is classified by {@link classifyStaleProcessingLock}:
+   * a pre-broadcast EVM lock is re-approved for a fresh attempt; anything that may
+   * have broadcast (a recorded hash, or any interrupted Solana payout) is parked
+   * in `failed` + `requires_review` for operator on-chain reconciliation — never
+   * auto-retried, so recovery can never cause a double-pay.
+   */
+  private async recoverStaleLocks(config: ReturnType<typeof getPayoutConfig>): Promise<void> {
+    const lockThreshold = new Date(Date.now() - config.LOCK_TIMEOUT_MS);
+
+    const stale = await dbRead
+      .select()
+      .from(tokenRedemptions)
+      .where(
+        and(
+          eq(tokenRedemptions.status, "processing"),
+          lt(tokenRedemptions.processing_started_at, lockThreshold),
+        ),
+      )
+      .limit(config.BATCH_SIZE);
+
+    for (const row of stale) {
+      const recovery = classifyStaleProcessingLock(row);
+
+      if (recovery.action === "reapprove") {
+        // Conditional reset, re-guarded against a concurrent worker that revived
+        // the row or broadcast in the meantime (status back to 'processing' only
+        // if still stale AND still un-broadcast). retry_count is bumped so a row
+        // that keeps dying pre-broadcast eventually exits the retry budget.
+        const [reapproved] = await dbWrite
+          .update(tokenRedemptions)
+          .set({
+            status: "approved",
+            processing_started_at: null,
+            processing_worker_id: null,
+            failure_reason: recovery.reason,
+            retry_count: sql`${tokenRedemptions.retry_count} + 1`,
+            updated_at: new Date(),
+          })
+          .where(
+            and(
+              eq(tokenRedemptions.id, row.id),
+              eq(tokenRedemptions.status, "processing"),
+              isNull(tokenRedemptions.broadcast_tx_hash),
+              lt(tokenRedemptions.processing_started_at, lockThreshold),
+            ),
+          )
+          .returning();
+
+        if (reapproved) {
+          logger.warn("[PayoutProcessor] Recovered stale pre-broadcast lock → approved", {
+            redemptionId: row.id,
+            network: row.network,
+            reason: recovery.reason,
+          });
+        }
+        continue;
+      }
+
+      // reconcile: park for operator review, preserving any broadcast hash.
+      const [parked] = await dbWrite
+        .update(tokenRedemptions)
+        .set({
+          status: "failed",
+          requires_review: true,
+          failure_reason: recovery.reason,
+          updated_at: new Date(),
+        })
+        .where(
+          and(
+            eq(tokenRedemptions.id, row.id),
+            eq(tokenRedemptions.status, "processing"),
+            lt(tokenRedemptions.processing_started_at, lockThreshold),
+          ),
+        )
+        .returning();
+
+      if (parked) {
+        logger.error(
+          "[PayoutProcessor] Stale lock may have broadcast — parked for reconciliation",
+          {
+            redemptionId: row.id,
+            network: row.network,
+            broadcastTxHash: row.broadcast_tx_hash,
+            reason: recovery.reason,
+          },
+        );
+        void payoutAlertsService.sendAlert({
+          severity: "high",
+          title: "Redemption needs on-chain reconciliation",
+          message: recovery.reason,
+          details: {
+            redemptionId: row.id,
+            network: row.network,
+            broadcastTxHash: row.broadcast_tx_hash ?? null,
+            payoutAddress: row.payout_address,
+            elizaAmount: row.eliza_amount,
+          },
+        });
+      }
+    }
   }
 
   /**
@@ -393,21 +574,68 @@ export class PayoutProcessorService {
       };
     }
 
-    // Execute transfer
-    const txHash = await walletClient.writeContract({
-      address: tokenAddress,
-      abi: ERC20_ABI,
-      functionName: "transfer",
-      args: [toAddress, amount],
-    });
+    // Broadcast the transfer. A throw HERE means the transaction was never
+    // submitted (RPC rejected / nonce / signing) → safe to retry.
+    let txHash: `0x${string}`;
+    try {
+      txHash = await walletClient.writeContract({
+        address: tokenAddress,
+        abi: ERC20_ABI,
+        functionName: "transfer",
+        args: [toAddress, amount],
+      });
+    } catch (error) {
+      return {
+        success: false,
+        error: `Broadcast failed: ${error instanceof Error ? error.message : String(error)}`,
+        retryable: true,
+      };
+    }
 
-    // Wait for confirmation
-    const receipt = await publicClient.waitForTransactionReceipt({
-      hash: txHash,
-      confirmations: 2,
-    });
+    // The transfer is now in the mempool. Persist the hash BEFORE awaiting
+    // confirmation so a crash during the wait can never be mistaken for
+    // "never broadcast" and re-tried (which would double-pay). If persistence
+    // itself fails, we still KNOW in-process the tx is live → reconcile, never
+    // retry.
+    try {
+      await this.recordBroadcastTxHash(redemption.id, txHash);
+    } catch (error) {
+      logger.error("[PayoutProcessor] Failed to persist broadcast tx hash", {
+        redemptionId: redemption.id,
+        network,
+        txHash,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return {
+        success: false,
+        error: `Broadcast ${txHash} but failed to persist hash: ${error instanceof Error ? error.message : String(error)}`,
+        needsReconciliation: true,
+        txHash,
+      };
+    }
+
+    // Wait for confirmation. A throw here (RPC timeout, dropped connection) does
+    // NOT mean the transfer failed — it may still confirm → reconcile, never
+    // auto-retry.
+    let receipt: Awaited<ReturnType<typeof publicClient.waitForTransactionReceipt>>;
+    try {
+      receipt = await publicClient.waitForTransactionReceipt({
+        hash: txHash,
+        confirmations: 2,
+      });
+    } catch (error) {
+      return {
+        success: false,
+        error: `Broadcast ${txHash}, confirmation failed: ${error instanceof Error ? error.message : String(error)}`,
+        needsReconciliation: true,
+        txHash,
+      };
+    }
 
     if (receipt.status === "reverted") {
+      // A reverted transfer moved no tokens, so a fresh attempt is safe. Mark
+      // retryable; markFailed clears the recorded broadcast hash so recovery
+      // won't later mistake this terminal revert for an in-flight transfer.
       return {
         success: false,
         error: "Transaction reverted",
@@ -491,13 +719,27 @@ export class PayoutProcessorService {
       createTransferInstruction(sourceAta, destinationAta, this.solanaKeypair.publicKey, amount),
     );
 
-    // Send and confirm transaction
-    const signature = await sendAndConfirmTransaction(
-      this.solanaConnection,
-      transaction,
-      [this.solanaKeypair],
-      { commitment: "confirmed" },
-    );
+    // Send and confirm transaction. sendAndConfirmTransaction couples broadcast
+    // and confirmation, so a throw is AMBIGUOUS — the transfer may already have
+    // landed. We cannot prove it did not broadcast, so on any failure we route to
+    // reconciliation rather than risk a double-pay on retry. (A future hardening
+    // could split sign → sendRawTransaction → confirmTransaction and persist the
+    // signature at broadcast time, mirroring the EVM path.)
+    let signature: string;
+    try {
+      signature = await sendAndConfirmTransaction(
+        this.solanaConnection,
+        transaction,
+        [this.solanaKeypair],
+        { commitment: "confirmed" },
+      );
+    } catch (error) {
+      return {
+        success: false,
+        error: `Solana payout failed (may have broadcast): ${error instanceof Error ? error.message : String(error)}`,
+        needsReconciliation: true,
+      };
+    }
 
     logger.info("[PayoutProcessor] Solana payout completed", {
       redemptionId: redemption.id,
@@ -564,6 +806,56 @@ export class PayoutProcessorService {
   }
 
   /**
+   * Persist the broadcast transaction hash the moment a transfer is submitted to
+   * the chain, BEFORE confirmation. This is the recovery signal that lets
+   * {@link classifyStaleProcessingLock} distinguish "never broadcast" (safe to
+   * retry) from "broadcast, unconfirmed" (must reconcile, never re-broadcast).
+   */
+  private async recordBroadcastTxHash(redemptionId: string, txHash: string): Promise<void> {
+    await dbWrite
+      .update(tokenRedemptions)
+      .set({ broadcast_tx_hash: txHash, updated_at: new Date() })
+      .where(eq(tokenRedemptions.id, redemptionId));
+  }
+
+  /**
+   * Park a redemption whose transfer may already be on-chain (broadcast happened,
+   * confirmation/persistence did not) for operator on-chain reconciliation. It is
+   * NEVER auto-retried — re-broadcasting would double-pay. The broadcast hash is
+   * preserved so an operator can verify the chain state.
+   */
+  private async markNeedsReconciliation(
+    redemptionId: string,
+    reason: string,
+    txHash?: string,
+  ): Promise<void> {
+    await dbWrite
+      .update(tokenRedemptions)
+      .set({
+        status: "failed",
+        requires_review: true,
+        failure_reason: `RECONCILE: ${reason}`,
+        // Record the hash if the caller has it and it wasn't already persisted.
+        ...(txHash ? { broadcast_tx_hash: txHash } : {}),
+        updated_at: new Date(),
+      })
+      .where(eq(tokenRedemptions.id, redemptionId));
+
+    logger.error("[PayoutProcessor] Redemption parked for reconciliation", {
+      redemptionId,
+      txHash,
+      reason,
+    });
+
+    void payoutAlertsService.sendAlert({
+      severity: "high",
+      title: "Redemption needs on-chain reconciliation",
+      message: reason,
+      details: { redemptionId, broadcastTxHash: txHash ?? null },
+    });
+  }
+
+  /**
    * Mark redemption as failed.
    */
   private async markFailed(
@@ -572,7 +864,11 @@ export class PayoutProcessorService {
     retryable: boolean,
   ): Promise<void> {
     if (retryable) {
-      // Increment retry count and reset to approved for retry
+      // Increment retry count and reset to approved for retry. Clear any recorded
+      // broadcast hash: a retryable failure means no transfer is in-flight (e.g.
+      // a reverted tx moved nothing, or the broadcast never happened), so a fresh
+      // attempt is safe and recovery must not later read a stale hash as
+      // "in-flight".
       await dbWrite
         .update(tokenRedemptions)
         .set({
@@ -581,6 +877,7 @@ export class PayoutProcessorService {
           retry_count: sql`${tokenRedemptions.retry_count} + 1`,
           processing_started_at: null,
           processing_worker_id: null,
+          broadcast_tx_hash: null,
           updated_at: new Date(),
         })
         .where(eq(tokenRedemptions.id, redemptionId));


### PR DESCRIPTION
Closes #10553.

A redemption whose worker died mid-payout was stuck in `status='processing'` forever with **no auto-recovery**, contradicting the file's documented "automatic retry."

## Root cause
- The batch selector filters `status='approved'`, and the intended stale-lock recovery clause (`processing_started_at < now-LOCK_TIMEOUT`) was **unreachable dead code**: it's ANDed with `status='approved'`, but a locked row is `processing`, and `markFailed(retryable)` always resets `processing_started_at` to NULL when returning a row to `approved` — so no approved row ever carries a stale lock. (Same dead pattern was duplicated in `repositories/token-redemptions.ts`.)
- The per-redemption loop had **no try/catch**, and `executeEvmPayout` didn't wrap `writeContract`/`waitForTransactionReceipt` — one RPC throw aborted the whole batch with the row left locked.

## The double-pay trap
A naive recovery selector that re-approves any stuck `processing` row would **double-pay** a transfer that was broadcast but not yet confirmed. The fix is designed entirely around making that impossible to do automatically.

## Fix
1. **`broadcast_tx_hash` column** (migration **0155**, additive/idempotent), persisted the **moment** a transfer is submitted — *before* confirmation — so recovery can tell "never broadcast" (safe to retry) from "broadcast, unconfirmed" (reconcile, never re-broadcast). EVM records it right after `writeContract`; if persistence or confirmation then fails, the in-process path returns `needsReconciliation`, never `retryable`.
2. **`classifyStaleProcessingLock`** — pure, exported, exhaustively tested. The load-bearing safety decision: recorded hash → **reconcile**; Solana w/ no hash → **reconcile** (atomic send+confirm can't be proven un-sent); EVM w/ no hash → **re-approve** (worker died before submitting). `recoverStaleLocks` runs each batch and re-approves *only* provably-un-broadcast EVM locks via a guarded conditional UPDATE; everything else is parked `failed` + `requires_review` + an ops alert — **never auto-retried**.
3. **Batch-loop try/catch** (one bad row no longer aborts the batch; it's left locked for next-cycle recovery). `markFailed(retryable)` clears `broadcast_tx_hash` (a reverted tx moved nothing → safe fresh attempt). Dead clause removed from processor + repo; repo gains `getStaleProcessingLocks`.

## Evidence — 17 pass / 0 fail
- **Classifier** exhaustive over every network × hash state (no possibly-broadcast row is ever re-approved).
- **executeEvmPayout** proves the hash is persisted **between** broadcast and confirm (ordering asserted), and routes every failure safely: `writeContract` throw → retryable (never submitted); persist throw → reconcile; confirm throw → reconcile (live, unconfirmed); revert → retryable (moved nothing).
- **recoverStaleLocks** routing (EVM-null→approved; hash→failed+review+alert; Solana-null→reconcile) and **batch-loop isolation** (a mid-batch throw doesn't stop later rows).
- Existing payout suites (`payout-status-resilience`, `payout-fork`, `stripe-connect-payout`) still green. `bun run --cwd packages/cloud/shared typecheck` → exit 0. Biome clean.

## Residual (documented, not hidden)
- A hard process-kill in the sub-ms window between `writeContract` resolving and the hash commit is unrecoverable without pre-broadcast idempotency keys — but that window is vastly smaller than today's "any crash never recovers."
- Solana is conservatively routed to reconciliation rather than refactored into sign→sendRawTransaction→confirm (which would let it persist a pre-confirmation signature like EVM); flagged as a follow-up.

> ⚠️ Money-path change — **not self-merged.** Maintainer review/merge per the launch protocol. Tracked on the coordination board #10561.