### PR TITLE
fix(cloud): payout batch resilience — one redemption's throw no longer aborts the batch (#10553 safe half)

### DIFF
--- a/packages/cloud/shared/src/lib/services/payout-processor.ts
+++ b/packages/cloud/shared/src/lib/services/payout-processor.ts
@@ -217,22 +217,43 @@ export class PayoutProcessorService {
     for (const redemption of redemptions) {
       stats.processed++;
 
-      // Try to acquire lock
-      const locked = await this.acquireLock(redemption.id);
-      if (!locked) {
-        stats.skipped++;
-        continue;
-      }
+      try {
+        // Try to acquire lock
+        const locked = await this.acquireLock(redemption.id);
+        if (!locked) {
+          stats.skipped++;
+          continue;
+        }
 
-      // Process the payout
-      const result = await this.processRedemption(redemption);
+        // Process the payout
+        const result = await this.processRedemption(redemption);
 
-      if (result.success) {
-        await this.markCompleted(redemption, result.txHash!);
-        stats.succeeded++;
-      } else {
-        await this.markFailed(redemption.id, result.error!, result.retryable ?? true);
+        if (result.success) {
+          await this.markCompleted(redemption, result.txHash!);
+          stats.succeeded++;
+        } else {
+          await this.markFailed(
+            redemption.id,
+            result.error!,
+            result.retryable ?? true,
+          );
+          stats.failed++;
+        }
+      } catch (err) {
+        // A throw here (RPC/DB error mid-processRedemption, or a Worker eviction)
+        // must NOT abort the whole batch — keep processing the remaining
+        // redemptions. Crucially, do NOT markFailed/re-approve this row: the
+        // payout may already have been BROADCAST (writeContract succeeded) while
+        // markCompleted had not yet persisted its tx_hash, so re-queuing it would
+        // risk a DOUBLE-PAY. Leave it in 'processing' for operator/on-chain
+        // reconciliation. (Full auto-recovery of stuck rows needs persisting the
+        // tx hash at broadcast time so a recovery can tell never-broadcast from
+        // broadcast-pending — tracked in #10553.)
         stats.failed++;
+        logger.error("[PayoutProcessor] Redemption processing threw", {
+          redemptionId: redemption.id,
+          error: err instanceof Error ? err.message : String(err),
+        });
       }
     }
 


### PR DESCRIPTION
The safe half of #10553. `processBatch`'s per-redemption loop had **no try/catch**, so an unexpected throw (RPC/DB error mid-`processRedemption`, or a Worker eviction) aborted the whole batch.

Wrap each redemption: a throw is logged and the batch continues. **Deliberately does NOT markFailed/re-approve** the throwing row — its payout may already be BROADCAST (`writeContract` succeeded) while `markCompleted` hadn't persisted the `tx_hash`, so re-queuing would risk a **double-pay**. Left in `processing` for reconciliation = fail-safe.

The full stuck-row auto-recovery is intentionally **not** here — it's the dangerous part (see the #10553 blueprint). Additive error handling, no logic change.