### PR TITLE
fix(scenarios): harden keyless plugin scenarios (#8801)

### DIFF
--- a/packages/scenario-runner/schema/index.d.ts
+++ b/packages/scenario-runner/schema/index.d.ts
@@ -139,6 +139,14 @@ export type ScenarioCleanupStep =
       name?: string;
       profile?: string;
       [key: string]: unknown;
+    }
+  | {
+      type: "custom";
+      name?: string;
+      apply?: (
+        ctx: ScenarioContext,
+      ) => ScenarioCheckResult | Promise<ScenarioCheckResult>;
+      [key: string]: unknown;
     };
 
 export type ScenarioJudgeRubric = {

--- a/packages/scenario-runner/src/executor-cleanup.test.ts
+++ b/packages/scenario-runner/src/executor-cleanup.test.ts
@@ -141,4 +141,43 @@ describe("scenario cleanup", () => {
       "selfControlClearBlocks failed",
     );
   });
+
+  it("runs custom cleanup even when scenario execution throws", async () => {
+    let cleanedUp = false;
+
+    const report = await runScenario(
+      {
+        id: "custom-cleanup-after-throw",
+        title: "Custom cleanup after throw",
+        domain: "executor",
+        turns: [
+          {
+            kind: "message",
+            name: "missing-message-service",
+            text: "This turn should throw before normal completion.",
+          },
+        ],
+        cleanup: [
+          {
+            type: "custom",
+            name: "mark-cleaned",
+            apply: () => {
+              cleanedUp = true;
+              return undefined;
+            },
+          },
+        ],
+      },
+      createRuntime(),
+      {
+        minJudgeScore: 0.8,
+        providerName: "unit-test",
+        turnTimeoutMs: 1_000,
+      },
+    );
+
+    expect(report.status).toBe("failed");
+    expect(report.error).toContain("runtime.messageService is not initialized");
+    expect(cleanedUp).toBe(true);
+  });
 });

--- a/packages/scenario-runner/src/executor.ts
+++ b/packages/scenario-runner/src/executor.ts
@@ -449,6 +449,14 @@ async function loadRequiredPlugin(pkg: string): Promise<Plugin | null> {
       actions: [mod.appAction, mod.backgroundAction, mod.viewsAction],
     };
   }
+  if (pkg === "@elizaos/plugin-hyperliquid") {
+    const mod = (await import(
+      "../../../plugins/plugin-hyperliquid/src/plugin.ts"
+    )) as {
+      hyperliquidPlugin?: Plugin;
+    };
+    return mod.hyperliquidPlugin ?? null;
+  }
 
   const mod = (await import(pkg)) as Record<string, unknown>;
   const isPlugin = (value: unknown): value is Plugin => {
@@ -1162,6 +1170,8 @@ async function clearSelfControlBlocks(): Promise<string | undefined> {
 
 async function runScenarioCleanups(
   scenario: ScenarioDefinition,
+  runtime: AgentRuntime,
+  ctx: RunnerContext,
 ): Promise<string[]> {
   const cleanups = (scenario as { cleanup?: unknown }).cleanup;
   if (!Array.isArray(cleanups)) {
@@ -1172,13 +1182,29 @@ async function runScenarioCleanups(
     if (!cleanup || typeof cleanup !== "object") {
       continue;
     }
-    const step = cleanup as { type?: unknown; name?: unknown };
+    const step = cleanup as {
+      type?: unknown;
+      name?: unknown;
+      apply?: unknown;
+    };
     let result: string | undefined;
     try {
       if (step.type === "gmailDeleteDrafts") {
         result = await deleteMockGmailDrafts();
       } else if (step.type === "selfControlClearBlocks") {
         result = await clearSelfControlBlocks();
+      } else if (step.type === "custom" && typeof step.apply === "function") {
+        const scenarioCtx: ScenarioContext = {
+          ...ctx,
+          runtime,
+        };
+        const customResult = await (
+          step.apply as (c: ScenarioContext) => unknown
+        )(scenarioCtx);
+        result =
+          typeof customResult === "string" && customResult.length > 0
+            ? customResult
+            : undefined;
       } else {
         continue;
       }
@@ -2144,19 +2170,18 @@ export async function runScenario(
         detail: fixtureFailure,
       });
     }
-
-    const cleanupFailures = await runScenarioCleanups(scenario);
+  } catch (err) {
+    report.status = "failed";
+    report.error = err instanceof Error ? err.message : String(err);
+    logger.warn(`[scenario-runner] ${scenario.id} threw: ${report.error}`);
+  } finally {
+    const cleanupFailures = await runScenarioCleanups(scenario, runtime, ctx);
     if (cleanupFailures.length > 0) {
       report.status = "failed";
       for (const detail of cleanupFailures) {
         report.failedAssertions.push({ label: "cleanup", detail });
       }
     }
-  } catch (err) {
-    report.status = "failed";
-    report.error = err instanceof Error ? err.message : String(err);
-    logger.warn(`[scenario-runner] ${scenario.id} threw: ${report.error}`);
-  } finally {
     (
       runtime as {
         getService: AgentRuntime["getService"];

--- a/packages/test/scenarios/hyperliquid/perpetual-market-status.scenario.ts
+++ b/packages/test/scenarios/hyperliquid/perpetual-market-status.scenario.ts
@@ -19,6 +19,8 @@ type R = AgentRuntime & {
   };
 };
 
+let restoreFetch: (() => void) | undefined;
+
 const STATUS_RESPONSE = {
   publicReadReady: true,
   signerReady: false,
@@ -57,11 +59,22 @@ export default scenario({
       apply: async (ctx) => {
         const runtime = ctx.runtime as R;
         const realFetch = globalThis.fetch;
-        globalThis.fetch = (async (
+        restoreFetch = () => {
+          if (globalThis.fetch === hyperliquidMockFetch) {
+            globalThis.fetch = realFetch;
+          }
+          restoreFetch = undefined;
+        };
+        const hyperliquidMockFetch = (async (
           input: RequestInfo | URL,
           init?: RequestInit,
         ) => {
-          const url = typeof input === "string" ? input : input.toString();
+          const url =
+            typeof input === "string"
+              ? input
+              : input instanceof Request
+                ? input.url
+                : input.toString();
           if (url.includes("/api/hyperliquid/status")) {
             return new Response(JSON.stringify(STATUS_RESPONSE), {
               headers: { "Content-Type": "application/json" },
@@ -69,6 +82,7 @@ export default scenario({
           }
           return realFetch(input, init);
         }) as typeof fetch;
+        globalThis.fetch = hyperliquidMockFetch;
 
         runtime.scenarioLlmFixtures?.register(
           {
@@ -79,7 +93,7 @@ export default scenario({
               toolName: "HANDLE_RESPONSE",
             },
             response: {
-              contexts: ["connectors"],
+              contexts: ["finance", "connectors"],
               intents: ["read hyperliquid status"],
               replyText: "",
               threadOps: [],
@@ -89,11 +103,9 @@ export default scenario({
           },
           {
             name: "hyperliquid-planner",
-            match: {
-              modelType: ModelType.ACTION_PLANNER,
-              input: (v: string) => v.includes("Hyperliquid"),
-              toolName: PERPETUAL_MARKET,
-            },
+            match: (call: { modelType: string; toolNames: string[] }) =>
+              call.modelType === ModelType.ACTION_PLANNER &&
+              call.toolNames.includes(PERPETUAL_MARKET),
             response: {
               text: "",
               thought: "Read Hyperliquid market status.",
@@ -129,6 +141,16 @@ export default scenario({
             times: 1,
           },
         );
+        return undefined;
+      },
+    },
+  ],
+  cleanup: [
+    {
+      type: "custom",
+      name: "restore-hyperliquid-fetch",
+      apply: () => {
+        restoreFetch?.();
         return undefined;
       },
     },

--- a/packages/test/scenarios/linear/search-issues.scenario.ts
+++ b/packages/test/scenarios/linear/search-issues.scenario.ts
@@ -19,6 +19,8 @@ type R = AgentRuntime & {
   };
 };
 
+let restoreFetch: (() => void) | undefined;
+
 export default scenario({
   lane: "pr-deterministic",
   id: "linear.search-issues",
@@ -39,11 +41,22 @@ export default scenario({
         const runtime = ctx.runtime as R;
         // Scoped fetch interceptor: redirect @linear/sdk's calls to a mock.
         const realFetch = globalThis.fetch;
-        globalThis.fetch = (async (
+        restoreFetch = () => {
+          if (globalThis.fetch === linearMockFetch) {
+            globalThis.fetch = realFetch;
+          }
+          restoreFetch = undefined;
+        };
+        const linearMockFetch = (async (
           input: RequestInfo | URL,
           init?: RequestInit,
         ) => {
-          const url = typeof input === "string" ? input : input.toString();
+          const url =
+            typeof input === "string"
+              ? input
+              : input instanceof Request
+                ? input.url
+                : input.toString();
           if (url.includes("api.linear.app")) {
             let query = "";
             try {
@@ -68,6 +81,7 @@ export default scenario({
           }
           return realFetch(input, init);
         }) as typeof fetch;
+        globalThis.fetch = linearMockFetch;
 
         process.env.LINEAR_API_KEY = "lin_api_test_dummy";
         runtime.setSetting?.("LINEAR_API_KEY", "lin_api_test_dummy");
@@ -142,6 +156,16 @@ export default scenario({
             times: 1,
           },
         );
+        return undefined;
+      },
+    },
+  ],
+  cleanup: [
+    {
+      type: "custom",
+      name: "restore-linear-fetch",
+      apply: () => {
+        restoreFetch?.();
         return undefined;
       },
     },

--- a/plugins/plugin-hyperliquid/src/actions/perpetual-market.ts
+++ b/plugins/plugin-hyperliquid/src/actions/perpetual-market.ts
@@ -5,9 +5,7 @@ import type {
   HandlerCallback,
   HandlerOptions,
   IAgentRuntime,
-  Memory,
   ProviderDataRecord,
-  State,
 } from "@elizaos/core";
 import { Service } from "@elizaos/core";
 import { resolveApiToken, resolveDesktopApiPort } from "@elizaos/shared";
@@ -174,35 +172,6 @@ function readOp(
     return "place_order";
   }
   return null;
-}
-
-function hasSelectedContext(
-  state: State | undefined,
-  contexts: readonly string[] = HYPERLIQUID_ACTION_CONTEXTS,
-): boolean {
-  const selected = new Set<string>();
-  const collect = (value: unknown) => {
-    if (!Array.isArray(value)) return;
-    for (const item of value) {
-      if (typeof item === "string") selected.add(item);
-    }
-  };
-  collect(
-    (state?.values as Record<string, unknown> | undefined)?.selectedContexts,
-  );
-  collect(
-    (state?.data as Record<string, unknown> | undefined)?.selectedContexts,
-  );
-  const contextObject = (state?.data as Record<string, unknown> | undefined)
-    ?.contextObject as
-    | {
-        trajectoryPrefix?: { selectedContexts?: unknown };
-        metadata?: { selectedContexts?: unknown };
-      }
-    | undefined;
-  collect(contextObject?.trajectoryPrefix?.selectedContexts);
-  collect(contextObject?.metadata?.selectedContexts);
-  return contexts.some((context) => selected.has(context));
 }
 
 async function fetchHyperliquidJson<T>(path: string): Promise<T> {
@@ -758,12 +727,9 @@ export const perpetualMarketAction: Action = {
       schema: { type: "number" },
     },
   ],
-  // Applicability = the finance/crypto/trading/payments context is active. Whether
-  // the user wants a perpetual-market read is the model's call (offered via the
-  // action description + semantic retrieval, in any language), not a hardcoded
-  // multilingual keyword list on the message text (#10470).
-  validate: async (_runtime, _message: Memory, state?: State) =>
-    hasSelectedContext(state),
+  // Applicability is enforced by contextGate. Keep validate non-semantic so
+  // planner state-shape drift cannot hide the action after routing selected it.
+  validate: async () => true,
   handler: async (runtime, _message, _state, options, callback) => {
     const op = readOp(options);
     if (!op) {


### PR DESCRIPTION
## Summary

Follow-up to #10569 for issue #8801. After the Linear and Hyperliquid keyless scenarios merged, I found two issues while validating on current `develop`:

- scenario-level `fetch` interceptors could leak after a scenario, and cleanup did not run if scenario execution threw before normal completion
- the Hyperliquid keyless path could miss the `PERPETUAL_MARKET` planner tool because the package-root auto-load pulled UI/dist dependencies and the action validate duplicated context gating against a planner state shape that did not carry the selected contexts consistently

This PR:

- adds typed custom cleanup support in the scenario runner and runs cleanup from `finally`
- restores the Linear and Hyperliquid scenario `fetch` interceptors after each scenario
- loads the Hyperliquid plugin object directly for required-plugin scenario auto-loading
- lets Hyperliquid action applicability come from its existing `contextGate`, so planner state-shape drift does not hide the selected action
- aligns the Hyperliquid deterministic fixture with the routed finance/connectors context and available planner tool list

## Validation

- `bun run --cwd packages/scenario-runner test src/executor-cleanup.test.ts` - pass, 3 tests
- `bun test packages/scripts/e2e-coverage/check-e2e-coverage.test.ts` - pass, 10 tests
- `SCENARIO_USE_LLM_PROXY=1 SCENARIO_LLM_PROXY_STRICT=1 bun --conditions eliza-source --tsconfig-override ../../tsconfig.json src/cli.ts run ../test/scenarios/linear/search-issues.scenario.ts --lane pr-deterministic` - pass, `linear.search-issues`, 1 passed / 0 failed
- `SCENARIO_USE_LLM_PROXY=1 SCENARIO_LLM_PROXY_STRICT=1 bun --conditions eliza-source --tsconfig-override ../../tsconfig.json src/cli.ts run ../test/scenarios/hyperliquid/perpetual-market-status.scenario.ts --lane pr-deterministic` - pass, `hyperliquid.perpetual-market-status`, 1 passed / 0 failed
- `bunx @biomejs/biome check packages/scenario-runner/src/executor.ts packages/scenario-runner/src/executor-cleanup.test.ts packages/scenario-runner/schema/index.d.ts packages/test/scenarios/linear/search-issues.scenario.ts packages/test/scenarios/hyperliquid/perpetual-market-status.scenario.ts plugins/plugin-hyperliquid/src/actions/perpetual-market.ts` - pass
- `git diff --check && git diff --check origin/develop...HEAD` - pass

Note: Bun prints `Internal error: directory mismatch...` after the successful scenario runs, but both commands exit `0` after reporting the scenario totals as passed.

Fixes #8801.