### PR TITLE
perf(cloud): cache persisted pricing reads on the inference hot path (~300ms/req)

### DIFF
--- a/packages/cloud/shared/src/lib/services/ai-pricing/cache.test.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/cache.test.ts
@@ -5,7 +5,12 @@
  * latency issue where the failing fetch ran 2x per chat request.
  */
 import { expect, test } from "bun:test";
-import { getCachedExternalEntries } from "./cache";
+import type { AiPricingEntry } from "../../../db/schemas/ai-pricing";
+import {
+  __clearPersistedPricingCache,
+  getCachedExternalEntries,
+  getCachedPersistedEntries,
+} from "./cache";
 import type { PreparedPricingEntry } from "./types";
 
 test("negative-caches a failing loader — subsequent lookups skip the re-fetch", async () => {
@@ -38,4 +43,41 @@ test("caches a successful loader result — loader runs once", async () => {
   expect(await getCachedExternalEntries("test:pos", loader)).toEqual([entry]);
   expect(await getCachedExternalEntries("test:pos", loader)).toEqual([entry]);
   expect(calls).toBe(1);
+});
+
+test("persisted: caches a successful DB read — loader runs once within TTL", async () => {
+  __clearPersistedPricingCache();
+  let calls = 0;
+  const row = { model: "gpt-oss-120b", provider: "cerebras" } as unknown as AiPricingEntry;
+  const loader = async (): Promise<AiPricingEntry[]> => {
+    calls++;
+    return [row];
+  };
+  expect(await getCachedPersistedEntries("k1", loader)).toEqual([row]);
+  expect(await getCachedPersistedEntries("k1", loader)).toEqual([row]);
+  expect(calls).toBe(1);
+});
+
+test("persisted: does NOT negative-cache a DB error — the next call retries", async () => {
+  __clearPersistedPricingCache();
+  let calls = 0;
+  const loader = async (): Promise<AiPricingEntry[]> => {
+    calls++;
+    throw new Error("db transient");
+  };
+  // Unlike the external catalog (permanent 404 → negative-cache), a DB error is
+  // transient and must re-run on the next request.
+  await expect(getCachedPersistedEntries("k2", loader)).rejects.toThrow("db transient");
+  await expect(getCachedPersistedEntries("k2", loader)).rejects.toThrow("db transient");
+  expect(calls).toBe(2);
+});
+
+test("persisted: distinct keys cache independently (no cross-key bleed)", async () => {
+  __clearPersistedPricingCache();
+  const a = { model: "a" } as unknown as AiPricingEntry;
+  const b = { model: "b" } as unknown as AiPricingEntry;
+  expect(await getCachedPersistedEntries("ka", async () => [a])).toEqual([a]);
+  expect(await getCachedPersistedEntries("kb", async () => [b])).toEqual([b]);
+  // 'ka' stays cached as [a] even though this loader would return [b].
+  expect(await getCachedPersistedEntries("ka", async () => [b])).toEqual([a]);
 });

--- a/packages/cloud/shared/src/lib/services/ai-pricing/cache.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/cache.ts
@@ -1,3 +1,4 @@
+import type { AiPricingEntry } from "../../../db/schemas/ai-pricing";
 import {
   EXTERNAL_CACHE_TTL_MS,
   type ExternalCacheValue,
@@ -49,4 +50,53 @@ export async function getCachedExternalEntries(
     expiresAt: Date.now() + EXTERNAL_CACHE_TTL_MS,
   });
   return entries;
+}
+
+// ── Persisted (DB) active-pricing read cache ────────────────────────────────
+// Unlike the external catalog above, these come from
+// `aiPricingRepository.listActiveEntriesForProviderModelPairs` and run on EVERY
+// inference inside `calculateTextCostFromCatalog` — which is part of the
+// synchronous credit-reserve and was measured at ~2 cross-region Postgres
+// round-trips (~300ms) of the pre-forward latency. Pricing is operator-refreshed
+// and near-static, so a short TTL is billing-correct: a change propagates within
+// PERSISTED_PRICING_CACHE_TTL_MS — a few seconds of negligible over/under-bill on
+// a rare change. Cached only on this billing hot path (the repository itself
+// stays uncached, so admin/refresh readers see fresh data). DB read errors are
+// NOT cached (transient → retry next request), unlike the external-catalog 404.
+const PERSISTED_PRICING_CACHE_TTL_MS = 60 * 1000;
+
+const persistedPricingCache = new Map<string, { entries: AiPricingEntry[]; expiresAt: number }>();
+
+function evictExpiredPersistedEntries(): void {
+  const now = Date.now();
+  for (const [key, value] of persistedPricingCache) {
+    if (value.expiresAt <= now) {
+      persistedPricingCache.delete(key);
+    }
+  }
+}
+
+export async function getCachedPersistedEntries(
+  cacheKey: string,
+  loader: () => Promise<AiPricingEntry[]>,
+): Promise<AiPricingEntry[]> {
+  const cached = persistedPricingCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.entries;
+  }
+
+  evictExpiredPersistedEntries();
+  // Do NOT cache a failure: a DB read error is transient (unlike a permanently
+  // dead external catalog), so let the next request retry against the DB.
+  const entries = await loader();
+  persistedPricingCache.set(cacheKey, {
+    entries,
+    expiresAt: Date.now() + PERSISTED_PRICING_CACHE_TTL_MS,
+  });
+  return entries;
+}
+
+/** Test hook: reset the persisted-pricing cache between tests. */
+export function __clearPersistedPricingCache(): void {
+  persistedPricingCache.clear();
 }

--- a/packages/cloud/shared/src/lib/services/ai-pricing/lookup.ts
+++ b/packages/cloud/shared/src/lib/services/ai-pricing/lookup.ts
@@ -10,6 +10,7 @@ import {
   type PricingChargeUnit,
   type PricingProductFamily,
 } from "../ai-pricing-definitions";
+import { getCachedPersistedEntries } from "./cache";
 import {
   chooseBestCandidatePricingEntry,
   expandPricingCatalogModelCandidates,
@@ -65,12 +66,21 @@ async function resolvePreparedPricingEntry(params: {
       }));
     });
 
-    const allPersisted = await aiPricingRepository.listActiveEntriesForProviderModelPairs({
-      billingSource: source,
-      productFamily: params.productFamily,
-      chargeType: params.chargeType,
-      pairs: providerModelPairs,
-    });
+    // Cache the per-request active-pricing read (~2 cross-region Postgres trips on
+    // every inference). Key fully captures the query inputs; pairs sorted for a
+    // stable key. Short TTL (see cache.ts) keeps billing correct.
+    const persistedCacheKey = `persisted|${source ?? ""}|${params.productFamily ?? ""}|${params.chargeType ?? ""}|${providerModelPairs
+      .map((p) => `${p.provider}:${p.model}`)
+      .sort()
+      .join(",")}`;
+    const allPersisted = await getCachedPersistedEntries(persistedCacheKey, () =>
+      aiPricingRepository.listActiveEntriesForProviderModelPairs({
+        billingSource: source,
+        productFamily: params.productFamily,
+        chargeType: params.chargeType,
+        pairs: providerModelPairs,
+      }),
+    );
 
     const persistedCandidates = modelCandidates.flatMap(
       (modelId): CandidatePreparedPricingEntry[] => {


### PR DESCRIPTION
## Context — measured live through prod
I measured end-to-end inference latency on `api.elizacloud.ai` (temp test key, read the `X-Eliza-Preforward-Ms` telemetry header). **Warm streaming TTFT is now ~0.9s** (gpt-oss-120b / zai-glm-4.7), down from the old 6-9s. Breakdown of a warm request:
- auth+org+moderation: **~4ms** (already collapsed to 1 KV read ✅)
- rate-limit/app/catalog/moderation: **0ms** (no-op ✅)
- **credit reserve: ~500-700ms** ← the remaining hotspot
- cerebras first-token+net: ~200-300ms (cerebras-direct ✅)

~2 of the reserve's cross-region Postgres round-trips (~300ms) are the **uncached** active-pricing read in `calculateTextCostFromCatalog` — it runs on *every* inference. The external pricing catalog was already cached; the persisted DB read wasn't.

## Change
`getCachedPersistedEntries` (mirrors the existing `getCachedExternalEntries`, same module), 60s TTL, wraps the lookup's `listActiveEntriesForProviderModelPairs`.

**Billing-correct:** short TTL bounds staleness to ~60s on a rare operator pricing change (well inside the existing 15-min external-catalog tolerance); cached **only** on the billing hot path (the repository stays uncached → admin/refresh readers fresh); DB errors **not** negative-cached (transient → retry).

**Tests (5 pass):** hit-within-TTL, no-negative-cache-on-DB-error, no cross-key bleed. Existing lookup tests don't collide (static mock + distinct model ids); `__clearPersistedPricingCache` hook exported for future tests.

It's a **billing-path perf change** so I'm PR'ing for a second set of eyes on the staleness/correctness rather than self-deploying. Complementary to (and independent of) the optimistic-billing flag — both reduce the reserve, this one helps both billing paths. cc @lalalune