### PR TITLE
perf(cloud): port #9899 IAC fast-path to /v1/messages — the eliza-code path (~2.5s → ~0.9s)

### DIFF
--- a/packages/cloud/api/__tests__/messages-iac-fast-path.test.ts
+++ b/packages/cloud/api/__tests__/messages-iac-fast-path.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Route-level regression coverage for the /v1/messages IAC fast path.
+ *
+ * The route should use the shared inference-auth resolver for API-key requests,
+ * skip the serial Hono auth/API-key lookup and synchronous moderation read on
+ * authorized hits, and still return Anthropic-compatible 403s for suspended
+ * users before any provider or billing work.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const aiActual = require("ai") as Record<string, unknown>;
+
+const ORG = "00000000-0000-4000-8000-0000000000aa";
+const USER = "00000000-0000-4000-8000-0000000000bb";
+const API_KEY_ID = "00000000-0000-4000-8000-0000000000cc";
+
+mock.module("@/lib/pricing", () => ({
+  calculateCost: async () => ({
+    inputCost: 0.001,
+    outputCost: 0.001,
+    totalCost: 0.002,
+  }),
+  getProviderFromModel: () => "anthropic",
+  getSafeModelParams: () => ({}),
+  normalizeModelName: (model: string) => model,
+}));
+
+mock.module("@/lib/providers/anthropic-thinking", () => ({
+  mergeAnthropicCotProviderOptions: () => ({}),
+  resolveAnthropicThinkingBudgetTokens: () => null,
+}));
+
+const resolveInferenceAuthContext = mock();
+mock.module("@/lib/services/inference-auth-context", () => ({
+  resolveInferenceAuthContext,
+}));
+
+const requireUserOrApiKeyWithOrg = mock();
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+}));
+
+const validateApiKey = mock();
+mock.module("@/lib/services/api-keys", () => ({
+  apiKeysService: {
+    validateApiKey,
+  },
+}));
+
+const shouldBlockUser = mock();
+const moderateInBackground = mock();
+mock.module("@/lib/services/content-moderation", () => ({
+  contentModerationService: {
+    shouldBlockUser,
+    moderateInBackground,
+  },
+}));
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { RELAXED: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => {
+    await next();
+  },
+}));
+
+mock.module("@/lib/providers/language-model", () => ({
+  canonicalizeCerebrasModelId: (model: string) => model,
+  getLanguageModel: () => ({}) as never,
+  resolveAiProviderSource: () => "bitrouter",
+}));
+
+class TestInsufficientCreditsError extends Error {
+  required: number;
+
+  constructor(required: number) {
+    super("Insufficient credits");
+    this.required = required;
+  }
+}
+
+const reserveCredits = mock();
+const billUsage = mock();
+const estimateInputTokens = mock();
+const recordUsageAnalytics = mock();
+mock.module("@/lib/services/ai-billing", () => ({
+  InsufficientCreditsError: TestInsufficientCreditsError,
+  billUsage,
+  estimateInputTokens,
+  recordUsageAnalytics,
+  reserveCredits,
+}));
+
+mock.module("@/lib/services/credits", () => ({
+  creditsService: {
+    createAnonymousReservation: () => ({
+      reservedAmount: 0,
+      reconcile: async () => null,
+    }),
+  },
+}));
+
+mock.module("@/lib/services/app-credits", () => ({
+  appCreditsService: {
+    calculateCostWithMarkup: async () => ({ totalCost: 0.002 }),
+    checkBalance: async () => ({ sufficient: true }),
+    recordUsage: async () => undefined,
+  },
+}));
+
+mock.module("@/lib/services/apps", () => ({
+  appsService: {
+    getAuthorizedMonetizedAppForUser: async () => null,
+    getById: async () => null,
+  },
+}));
+
+const createCreditReservationSettler = mock();
+mock.module("@/lib/utils/credit-reservation", () => ({
+  createCreditReservationSettler,
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    error: mock(),
+    info: mock(),
+    warn: mock(),
+  },
+}));
+
+mock.module("@/lib/utils/request-timeout", () => ({
+  getRouteTimeoutMs: () => 30_000,
+}));
+
+const generateText = mock();
+mock.module("ai", () => ({
+  ...aiActual,
+  generateText,
+}));
+
+const messagesRoute = (await import("../v1/messages/route")).default;
+
+afterAll(() => {
+  mock.restore();
+});
+
+beforeEach(() => {
+  resolveInferenceAuthContext.mockReset();
+  requireUserOrApiKeyWithOrg.mockReset();
+  validateApiKey.mockReset();
+  shouldBlockUser.mockReset();
+  moderateInBackground.mockReset();
+  reserveCredits.mockReset();
+  billUsage.mockReset();
+  estimateInputTokens.mockReset();
+  recordUsageAnalytics.mockReset();
+  createCreditReservationSettler.mockReset();
+  generateText.mockReset();
+
+  resolveInferenceAuthContext.mockResolvedValue({
+    kind: "authorized",
+    ctx: { userId: USER, orgId: ORG, apiKeyId: API_KEY_ID },
+    source: "cache",
+  });
+  requireUserOrApiKeyWithOrg.mockResolvedValue({
+    id: USER,
+    organization_id: ORG,
+  });
+  validateApiKey.mockResolvedValue({ id: API_KEY_ID });
+  shouldBlockUser.mockResolvedValue(false);
+  estimateInputTokens.mockReturnValue(8);
+  reserveCredits.mockResolvedValue({
+    reservedAmount: 0.01,
+    reconcile: async () => null,
+  });
+  createCreditReservationSettler.mockReturnValue(async () => null);
+  generateText.mockImplementation(() => {
+    throw new Error("model-call-stub");
+  });
+});
+
+function postMessages() {
+  return messagesRoute.request("/", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-api-key": "eliza_test_key",
+    },
+    body: JSON.stringify({
+      model: "claude-3-5-sonnet-20241022",
+      max_tokens: 16,
+      messages: [{ role: "user", content: "hello" }],
+    }),
+  });
+}
+
+describe("/v1/messages IAC fast path", () => {
+  test("authorized resolver result skips serial auth, api-key lookup, and sync moderation", async () => {
+    const response = await postMessages();
+
+    expect(response.status).toBe(500);
+    expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(1);
+    expect(requireUserOrApiKeyWithOrg).not.toHaveBeenCalled();
+    expect(validateApiKey).not.toHaveBeenCalled();
+    expect(shouldBlockUser).not.toHaveBeenCalled();
+    expect(reserveCredits).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: ORG,
+        userId: USER,
+      }),
+      expect.any(Number),
+      16,
+    );
+    expect(generateText).toHaveBeenCalledTimes(1);
+  });
+
+  test("suspended resolver result returns Anthropic 403 before billing or provider work", async () => {
+    resolveInferenceAuthContext.mockResolvedValueOnce({
+      kind: "suspended",
+      userId: USER,
+    });
+
+    const response = await postMessages();
+
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as {
+      error?: { type?: string; message?: string };
+    };
+    expect(body.error?.type).toBe("permission_error");
+    expect(body.error?.message).toContain("suspended");
+    expect(requireUserOrApiKeyWithOrg).not.toHaveBeenCalled();
+    expect(validateApiKey).not.toHaveBeenCalled();
+    expect(shouldBlockUser).not.toHaveBeenCalled();
+    expect(reserveCredits).not.toHaveBeenCalled();
+    expect(generateText).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/messages/route.ts
+++ b/packages/cloud/api/v1/messages/route.ts
@@ -59,6 +59,7 @@ import {
   type CreditReservation,
   creditsService,
 } from "@/lib/services/credits";
+import { resolveInferenceAuthContext } from "@/lib/services/inference-auth-context";
 import { createCreditReservationSettler } from "@/lib/utils/credit-reservation";
 import { logger } from "@/lib/utils/logger";
 import { getRouteTimeoutMs } from "@/lib/utils/request-timeout";
@@ -485,12 +486,38 @@ app.post("/", async (c) => {
 
   let user: { id: string; organization_id: string };
   let apiKey: { id: string } | null = null;
+  // #9899 fast-path: collapse auth + org + suspension into ONE KV read for the
+  // API-key inference path (this is the eliza-code / anthropic-proxy route, which
+  // previously did serial auth + a separate apiKeyId lookup + an uncached
+  // moderation Postgres read = ~2.5x slower than /v1/chat/completions). Mirrors
+  // that route's resolver; falls to the authoritative serial path for
+  // JWT/cookie/wallet creds or a cold cache.
+  let moderationAlreadyChecked = false;
   try {
-    const auth = await requireUserOrApiKeyWithOrg(c);
-    user = { id: auth.id, organization_id: auth.organization_id };
-    // Workers auth shim does not surface the apiKey row; attribution by
-    // apiKey id requires a separate lookup.
-    apiKey = await getRequestApiKeyId(c);
+    const resolution = await resolveInferenceAuthContext(c.req.raw);
+    if (resolution.kind === "suspended") {
+      return anthropicError(
+        "permission_error",
+        "Your account has been suspended due to policy violations.",
+        403,
+      );
+    }
+    if (resolution.kind === "authorized") {
+      user = {
+        id: resolution.ctx.userId,
+        organization_id: resolution.ctx.orgId,
+      };
+      apiKey = { id: resolution.ctx.apiKeyId };
+      // The resolver already verified not-suspended (cache hit = at populate;
+      // origin miss = just now), so the synchronous moderation read is skipped.
+      moderationAlreadyChecked = true;
+    } else {
+      const auth = await requireUserOrApiKeyWithOrg(c);
+      user = { id: auth.id, organization_id: auth.organization_id };
+      // Workers auth shim does not surface the apiKey row; attribution by
+      // apiKey id requires a separate lookup.
+      apiKey = await getRequestApiKeyId(c);
+    }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     return anthropicError("authentication_error", message, 401);
@@ -541,7 +568,10 @@ app.post("/", async (c) => {
   const normalizedModel = normalizeModelName(model);
   const systemPrompt = normalizeSystemPrompt(request.system);
 
-  if (await contentModerationService.shouldBlockUser(user.id)) {
+  if (
+    !moderationAlreadyChecked &&
+    (await contentModerationService.shouldBlockUser(user.id))
+  ) {
     return anthropicError(
       "permission_error",
       "Your account has been suspended due to policy violations.",


### PR DESCRIPTION
## The real eliza-code latency fix

Measured live through prod (`api.elizacloud.ai`, temp test key, same model). The `#9899` inference auth fast-path was applied to `/v1/chat/completions` + `/v1/embeddings` but **NOT `/v1/messages`** — which is the Anthropic Messages API that the app's **eliza-code / anthropic-proxy** coding mode actually uses:

| Route | Warm | Cold |
|---|---|---|
| `/v1/chat/completions` (has fast-path) | ~0.8–0.96s | ~1.4s |
| **`/v1/messages`** (eliza-code, NO fast-path) | **~2.2–3.1s** | **~5.7s** |

`/v1/messages` did serial `requireUserOrApiKeyWithOrg` + a separate `getRequestApiKeyId` lookup + an **uncached** `shouldBlockUser` Postgres read on every request — ~2.5–3× slower.

## Change
Replace that block with `resolveInferenceAuthContext(c.req.raw)`: one KV read collapses auth+org+suspension for the API-key path, and the synchronous moderation read is skipped when the resolver already verified not-suspended. Falls back to the **verbatim original** serial path for JWT/cookie/wallet creds or a cold cache. Mirrors the chat/completions + embeddings pattern exactly. **Expected: eliza-code → ~0.9s (matching chat/completions).**

## Verification (auth path — verified before shipping)
- **Auth-correctness (adversarial): AUTH-CORRECT — no bypass/regression.** Every credential path traced: valid key (cache hit/miss) → authorized w/ correct user/org/apiKeyId; invalid/expired/org-less → 401; suspended → 403; JWT/cookie/wallet → unchanged slow path. Moderation not weakened — `moderationAlreadyChecked` set only on `authorized` (which provably implies not-suspended), and the IAC is invalidated in the authoritative `recordViolation`/`banUser` mutations regardless of route. Billing attribution byte-identical.
- **Type-check: COMPILES-CLEAN** (tsc-verified `user` definite-assignment).

Auth-path change → **PR'd for review, not self-deployed.** Combined with the pricing-cache PR (#10583) this closes the remaining inference-latency gaps. cc @lalalune