### PR TITLE
[codex] fix(app): keep first-run chooser from duplicating chat choices

### DIFF
--- a/packages/app/test/design-review/run-design-review.ts
+++ b/packages/app/test/design-review/run-design-review.ts
@@ -194,10 +194,9 @@ const views: ViewSpec[] = [
     lastNativeTab: "chat",
     firstRunIncomplete: true,
     readyChecks: [
-      // #9952: onboarding is in-chat — the conductor greets + offers the runtime
-      // CHOICE inside the floating ContinuousChatOverlay (no full-screen shell).
       { selector: '[data-testid="continuous-chat-overlay"]' },
-      { selector: '[data-testid="choice-__first_run__:runtime:cloud"]' },
+      { selector: '[data-testid="first-run-runtime-chooser"]' },
+      { selector: '[data-testid="first-run-chooser-cloud"]' },
     ],
   },
   {
@@ -707,17 +706,11 @@ async function applyState(page: Page, capture: CaptureSpec): Promise<void> {
     });
   }
   if (capture.stateId === "first-run-local") {
-    // #9952: in-chat onboarding — pick Local, then await the on-device provider
-    // sub-choice the conductor seeds next.
-    await page
-      .locator('[data-testid="choice-__first_run__:runtime:local"]')
-      .click();
-    await page
-      .locator('[data-testid="choice-__first_run__:provider:on-device"]')
-      .waitFor({
-        state: "visible",
-        timeout: 10_000,
-      });
+    await page.locator('[data-testid="first-run-chooser-local"]').click();
+    await page.locator('[data-testid="first-run-provider-on-device"]').waitFor({
+      state: "visible",
+      timeout: 10_000,
+    });
   }
 }
 

--- a/packages/app/test/ui-smoke/assistant-home-flow.spec.ts
+++ b/packages/app/test/ui-smoke/assistant-home-flow.spec.ts
@@ -481,12 +481,9 @@ async function openReadyWorkspaceChat(page: Page): Promise<void> {
 async function openReadyChat(page: Page, targetPath = "/"): Promise<void> {
   await openAppPath(page, targetPath);
   await expect(page.getByTestId("startup-shell-loading")).toHaveCount(0);
-  // #9952: onboarding is in-chat. When the agent is ready (first-run complete)
-  // the conductor's runtime CHOICE must be absent from the live transcript —
-  // proof we are not gated on the in-chat onboarding.
-  await expect(
-    page.getByTestId("choice-__first_run__:runtime:cloud"),
-  ).toHaveCount(0);
+  // When the agent is ready (first-run complete), the floating first-run chooser
+  // must be absent.
+  await expect(page.getByTestId("first-run-runtime-chooser")).toHaveCount(0);
   const composer = assistantComposer(page);
   await expect(composer).toBeVisible({ timeout: 15_000 });
   await expect(composer).toBeEnabled({ timeout: 30_000 });
@@ -745,13 +742,13 @@ test.describe("assistant home app flow", () => {
     await page.goto("/", { waitUntil: "domcontentloaded" });
     await expect(page.locator("#root")).toBeVisible({ timeout: 20_000 });
     await expect(page).not.toHaveURL(/first-run/, { timeout: 12_000 });
-    // #9952: onboarding IS the chat — the conductor greets first inside the REAL
-    // floating ContinuousChatOverlay; there is no separate full-screen surface.
+    // The fresh first-run runtime chooser renders over the real shell; there is
+    // no separate full-screen legacy surface.
     const firstRunOverlay = page.getByTestId("continuous-chat-overlay");
     await expect(firstRunOverlay).toBeVisible({ timeout: 20_000 });
-    await expect(
-      firstRunOverlay.getByText("Let's get you set up", { exact: false }),
-    ).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId("first-run-runtime-chooser")).toBeVisible({
+      timeout: 20_000,
+    });
     await screenshot(page, "01-first-run-clouds");
 
     await page.unroute("**/api/first-run/status");

--- a/packages/app/test/ui-smoke/cloud-live.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-live.spec.ts
@@ -56,15 +56,11 @@ async function clickIfVisible(
   }
 }
 
-// Drive the cloud entry point of the in-chat first-run flow (#9952): the runtime
-// ChoiceWidget's "Eliza Cloud (managed)" option, then the in-chat
-// SensitiveRequestBlock "Connect Eliza Cloud" OAuth authorize affordance if
-// shown.
+// Drive the cloud entry point of first-run: the floating chooser's Eliza Cloud
+// option, then the SensitiveRequestBlock "Connect Eliza Cloud" OAuth authorize
+// affordance if shown.
 async function chooseCloudRuntime(page: Page): Promise<void> {
-  await clickIfVisible(
-    page.getByTestId("choice-__first_run__:runtime:cloud"),
-    30_000,
-  );
+  await clickIfVisible(page.getByTestId("first-run-chooser-cloud"), 30_000);
   await clickIfVisible(
     page.getByTestId("sensitive-request-oauth-start"),
     5_000,

--- a/packages/app/test/ui-smoke/computer-use.spec.ts
+++ b/packages/app/test/ui-smoke/computer-use.spec.ts
@@ -58,22 +58,17 @@ test("first-run starts with setup choices before capability settings", async ({
 
   await page.goto("/chat", { waitUntil: "domcontentloaded" });
 
-  // The in-chat first-run flow greets first inside the REAL floating chat
-  // overlay, then offers the runtime question as inline ChoiceWidget buttons.
-  // There is no separate full-screen onboarding surface anymore.
   const chatOverlay = page.getByTestId("continuous-chat-overlay");
   await expect(chatOverlay).toBeVisible({ timeout: 20_000 });
+  const chooser = page.getByTestId("first-run-runtime-chooser");
+  await expect(chooser).toBeVisible({ timeout: 20_000 });
   await expect(
-    chatOverlay.getByText("Let's get you set up", { exact: false }),
+    chooser.getByText("Choose how Eliza should run", { exact: true }),
   ).toBeVisible({ timeout: 15_000 });
+  await expect(chooser.getByTestId("first-run-chooser-cloud")).toBeVisible();
+  await expect(chooser.getByTestId("first-run-chooser-local")).toBeVisible();
   await expect(
-    page.getByTestId("choice-__first_run__:runtime:cloud"),
-  ).toBeVisible({ timeout: 15_000 });
-  await expect(
-    page.getByTestId("choice-__first_run__:runtime:local"),
-  ).toBeVisible();
-  await expect(
-    page.getByTestId("choice-__first_run__:runtime:other"),
+    chooser.getByRole("button", { name: /Advanced setup/i }),
   ).toBeVisible();
 
   // The Computer Use capability switch must NOT be reachable before the agent

--- a/packages/app/test/ui-smoke/first-run-startup.spec.ts
+++ b/packages/app/test/ui-smoke/first-run-startup.spec.ts
@@ -9,12 +9,10 @@ import {
 } from "./helpers";
 
 // Every other ui-smoke spec seeds `eliza:first-run-complete = "1"`, so the
-// in-chat first-run surface (#9952: the auto-opened ContinuousChatOverlay seeded
-// by the headless conductor — greeting + runtime/provider ChoiceWidgets) never
-// gets render-telemetry coverage. That surface is exactly where the agent-start
-// render loop once froze onboarding, so this spec lands on it with the guard
-// armed and drives the runtime selection that preceded the freeze. There is NO
-// separate full-screen onboarding surface anymore — onboarding IS the chat.
+// first-run runtime chooser rarely gets render-telemetry coverage. That surface
+// is exactly where the agent-start render loop once froze onboarding, so this
+// spec lands on it with the guard armed and drives the runtime selection that
+// preceded the freeze.
 
 async function fulfillJson(
   route: Route,
@@ -87,7 +85,7 @@ async function routeFirstRunIncomplete(page: Page): Promise<void> {
   });
 }
 
-test("in-chat first-run renders without a render loop and lets the runtime be chosen", async ({
+test("first-run chooser renders without a render loop and lets the runtime be chosen", async ({
   page,
 }) => {
   await installRenderTelemetryGuard(page);
@@ -99,15 +97,12 @@ test("in-chat first-run renders without a render loop and lets the runtime be ch
 
   await page.goto("/", { waitUntil: "domcontentloaded" });
 
-  // The in-chat first-run flow renders inside the REAL floating chat overlay:
-  // the agent greets first, then asks the runtime question as ChoiceWidgets.
   const chatOverlay = page.getByTestId("continuous-chat-overlay");
   await expect(chatOverlay).toBeVisible({ timeout: 20_000 });
+  const chooser = page.getByTestId("first-run-runtime-chooser");
+  await expect(chooser).toBeVisible({ timeout: 20_000 });
   await expect(
-    chatOverlay.getByText("Let's get you set up", { exact: false }),
-  ).toBeVisible({ timeout: 15_000 });
-  await expect(
-    chatOverlay.getByText("where should your agent run", { exact: false }),
+    chooser.getByText("Choose how Eliza should run", { exact: true }),
   ).toBeVisible({ timeout: 15_000 });
 
   // The removed full-screen onboarding gate must NOT render — proof the surface
@@ -120,28 +115,26 @@ test("in-chat first-run renders without a render loop and lets the runtime be ch
     await expect(page.getByTestId(removed)).toHaveCount(0);
   }
 
-  // The runtime question offers three in-chat ChoiceWidget options.
-  const cloud = page.getByTestId("choice-__first_run__:runtime:cloud");
-  const local = page.getByTestId("choice-__first_run__:runtime:local");
-  const other = page.getByTestId("choice-__first_run__:runtime:other");
+  const cloud = chooser.getByTestId("first-run-chooser-cloud");
+  const local = chooser.getByTestId("first-run-chooser-local");
+  const other = chooser.getByTestId("first-run-chooser-other");
   await expect(cloud).toBeVisible({ timeout: 15_000 });
   await expect(local).toBeVisible();
+  await chooser.getByRole("button", { name: /Advanced setup/i }).click();
   await expect(other).toBeVisible();
 
-  // Local advances to the provider sub-choice (on-device vs Eliza Cloud vs
-  // other) — the re-render churn on the newer step that previously froze.
+  // Local advances to the provider step (on-device vs Eliza Cloud vs other) —
+  // the re-render churn on the newer step that previously froze.
   await local.click();
+  await expect(chooser.getByTestId("first-run-provider-on-device")).toBeVisible(
+    { timeout: 15_000 },
+  );
   await expect(
-    page.getByTestId("choice-__first_run__:provider:on-device"),
-  ).toBeVisible({ timeout: 15_000 });
-  await expect(
-    page.getByTestId("choice-__first_run__:provider:elizacloud"),
+    chooser.getByTestId("first-run-provider-elizacloud"),
   ).toBeVisible();
-  await expect(
-    page.getByTestId("choice-__first_run__:provider:other"),
-  ).toBeVisible();
+  await expect(chooser.getByTestId("first-run-provider-other")).toBeVisible();
 
-  await expectNoRenderTelemetryErrors(page, "in-chat first-run flow");
+  await expectNoRenderTelemetryErrors(page, "first-run chooser flow");
   await expect(chatOverlay).toBeVisible();
 });
 
@@ -203,12 +196,8 @@ test("fresh first-run offers to restore an existing local backup before onboardi
     page.getByTestId("choice-__first_run__:backup-restore:start-fresh"),
   ).toBeVisible();
 
-  await page
-    .getByTestId("choice-__first_run__:backup-restore:latest")
-    .click();
-  await expect
-    .poll(() => restoreRequests.length, { timeout: 15_000 })
-    .toBe(1);
+  await page.getByTestId("choice-__first_run__:backup-restore:latest").click();
+  await expect.poll(() => restoreRequests.length, { timeout: 15_000 }).toBe(1);
   expect(restoreRequests[0]).toContain("agent-2026-06-30.eliza-backup");
   await expect(
     chatOverlay.getByText("Backup restored", { exact: false }),

--- a/packages/app/test/ui-smoke/helpers.ts
+++ b/packages/app/test/ui-smoke/helpers.ts
@@ -353,12 +353,9 @@ async function expectMainShellReadyForRoute(
     timeout: STARTUP_SETTLED_TIMEOUT_MS,
   });
   if (!options.allowOnboardingToast) {
-    // #9952: onboarding is in-chat. The in-chat conductor only seeds its runtime
-    // CHOICE while first-run is incomplete, so its absence proves the main shell
-    // is past onboarding (the old full-screen `first-run-chat` gate is gone).
-    await expect(
-      page.getByTestId("choice-__first_run__:runtime:cloud"),
-    ).toHaveCount(0, {
+    // Runtime/provider setup is owned by the floating first-run chooser. Its
+    // absence proves the main shell is past onboarding.
+    await expect(page.getByTestId("first-run-runtime-chooser")).toHaveCount(0, {
       timeout: STARTUP_SETTLED_TIMEOUT_MS,
     });
   }

--- a/packages/app/test/ui-smoke/model-download-deferral.spec.ts
+++ b/packages/app/test/ui-smoke/model-download-deferral.spec.ts
@@ -152,17 +152,16 @@ test("selecting on-device inference drops the user into chat while the model dow
   await seedAppStorage(page, { "eliza:first-run-complete": "" });
   await page.goto("/", { waitUntil: "domcontentloaded" });
 
-  // #9952: onboarding is in-chat. The conductor greets first inside the REAL
-  // floating ContinuousChatOverlay and offers the runtime choice as inline
-  // ChoiceWidget buttons.
   const chatOverlay = page.getByTestId("continuous-chat-overlay");
   await expect(chatOverlay).toBeVisible({ timeout: 20_000 });
-  const runtimeChoice = page.getByTestId("choice-__first_run__:runtime:local");
+  const chooser = page.getByTestId("first-run-runtime-chooser");
+  await expect(chooser).toBeVisible({ timeout: 20_000 });
+  const runtimeChoice = chooser.getByTestId("first-run-chooser-local");
   await expect(runtimeChoice).toBeVisible({ timeout: 15_000 });
 
   // This device → on-device inference.
   await runtimeChoice.click();
-  const onDevice = page.getByTestId("choice-__first_run__:provider:on-device");
+  const onDevice = chooser.getByTestId("first-run-provider-on-device");
   await expect(onDevice).toBeVisible({ timeout: 10_000 });
   await onDevice.click();
 

--- a/packages/app/test/ui-smoke/onboarding-to-home.shared.ts
+++ b/packages/app/test/ui-smoke/onboarding-to-home.shared.ts
@@ -717,16 +717,13 @@ export const FINANCES_TESTID = "chat-widget-finances-alerts";
 export const GOALS_TESTID = "widget-goals-attention";
 export const NOTIFICATIONS_TESTID = "widget-notifications";
 
-// In-chat first-run choice button testIds. The conductor seeds each option as a
-// `[CHOICE:first-run id=…]` line `value=label`, where `value` is the reserved
-// `__first_run__:<group>:<id>` sentinel the AppContext send funnel intercepts
-// (use-first-run-conductor.ts). ChoiceWidget renders `data-testid="choice-<value>"`,
-// so the testId is the full sentinel. No separate full-screen onboarding surface
-// exists anymore — these buttons live INSIDE the floating ContinuousChatOverlay.
+// First-run runtime/provider buttons live in the floating runtime chooser. The
+// headless conductor still owns backup/tutorial/cloud-agent ChoiceWidgets in the
+// transcript, but runtime/provider UI must not duplicate there.
 const RUNTIME_CHOICE = (id: "cloud" | "local" | "other"): string =>
-  `choice-__first_run__:runtime:${id}`;
+  `first-run-chooser-${id}`;
 const PROVIDER_CHOICE = (id: "on-device" | "elizacloud" | "other"): string =>
-  `choice-__first_run__:provider:${id}`;
+  `first-run-provider-${id}`;
 const TUTORIAL_CHOICE = (id: "start" | "skip"): string =>
   `choice-__first_run__:tutorial:${id}`;
 const CLOUD_AGENT_CHOICE = (id: string): string =>
@@ -742,21 +739,22 @@ const REMOVED_ONBOARDING_TESTIDS = [
 ];
 
 /**
- * Assert the FIRST painted surface of a fresh profile is the real floating chat
- * (ContinuousChatOverlay) showing the conductor's agent greeting + the runtime
- * choice — and that NONE of the removed full-screen onboarding testIds exist.
- * This is the "chat-first" + "gate-absent" contract for #9952.
+ * Assert the FIRST painted surface of a fresh profile is the real app shell plus
+ * floating runtime chooser — and that NONE of the removed full-screen onboarding
+ * testIds exist. The chat overlay may be present underneath, but runtime/provider
+ * controls are owned by the chooser.
  */
 export async function expectChatFirstOnboarding(page: Page): Promise<Locator> {
   const chatOverlay = page.getByTestId("continuous-chat-overlay");
   await expect(chatOverlay).toBeVisible({ timeout: 30_000 });
-  // The agent greets first, in the live transcript the overlay renders.
+  const chooser = page.getByTestId("first-run-runtime-chooser");
+  await expect(chooser).toBeVisible({ timeout: 30_000 });
   await expect(
-    chatOverlay.getByText("Let's get you set up", { exact: false }),
+    chooser.getByText("Choose how Eliza should run", { exact: true }),
   ).toBeVisible({ timeout: 20_000 });
   await expect(
-    chatOverlay.getByText("where should your agent run", { exact: false }),
-  ).toBeVisible({ timeout: 15_000 });
+    chooser.getByRole("button", { name: /Advanced setup/i }),
+  ).toBeVisible();
   // The removed full-screen onboarding gate must be absent.
   for (const testId of REMOVED_ONBOARDING_TESTIDS) {
     await expect(
@@ -764,11 +762,10 @@ export async function expectChatFirstOnboarding(page: Page): Promise<Locator> {
       `removed onboarding surface ${testId} must not render (flow is chat-first)`,
     ).toHaveCount(0);
   }
-  // The runtime choice renders as inline ChoiceWidget buttons in the overlay.
-  await expect(page.getByTestId(RUNTIME_CHOICE("cloud"))).toBeVisible({
+  await expect(chooser.getByTestId(RUNTIME_CHOICE("cloud"))).toBeVisible({
     timeout: 15_000,
   });
-  await expect(page.getByTestId(RUNTIME_CHOICE("local"))).toBeVisible();
+  await expect(chooser.getByTestId(RUNTIME_CHOICE("local"))).toBeVisible();
   return chatOverlay;
 }
 
@@ -814,12 +811,10 @@ async function pickTutorial(
 }
 
 /**
- * Drive the REAL in-chat onboarding to completion via Local → on-device
- * inference → tutorial-or-skip, then assert the post-onboarding HOME inside the
- * SAME floating ContinuousChatOverlay we use everywhere else. This is the
- * keyless path that calls completeFirstRun("chat") without a cloud sign-in
- * (all-local needs no cloud connect). `click`
- * lets the mobile lane TAP the inline choice buttons while desktop clicks.
+ * Drive first-run to completion via Local → on-device inference →
+ * tutorial-or-skip, then assert the post-onboarding HOME inside the same shell
+ * and floating chat overlay we use everywhere else. This is the keyless path
+ * that calls completeFirstRun("chat") without a cloud sign-in.
  */
 export async function completeOnboardingToHome(
   page: Page,
@@ -830,7 +825,7 @@ export async function completeOnboardingToHome(
 ): Promise<{ surface: Locator }> {
   const { state, tutorial = "skip" } = opts;
 
-  // 1) Chat-first: the overlay greets first; no removed full-screen gate exists.
+  // 1) The chooser owns runtime/provider setup; no removed full-screen gate exists.
   await expectChatFirstOnboarding(page);
 
   // 2) Local runtime → on-device ("all-local") provider.
@@ -866,12 +861,12 @@ export async function completeOnboardingToHome(
 }
 
 /**
- * Drive the REAL in-chat onboarding to completion via the CLOUD runtime: pick
- * Cloud → the OAuth card appears while the conductor connects Eliza Cloud (mocked
- * at the network boundary, no popup needed) → the cloud-agent CHOICE → bind →
- * tutorial-or-skip → home. The bound agent base is this page origin (an app-shell
- * base), so the cloud finish persists first-run exactly once — same contract as
- * Local. Requires `installCloudRoutes` + `injectCloudAuthToken`.
+ * Drive first-run to completion via the CLOUD runtime: pick Cloud → the OAuth
+ * card appears while the conductor connects Eliza Cloud (mocked at the network
+ * boundary, no popup needed) → the cloud-agent CHOICE → bind →
+ * tutorial-or-skip → home. The bound agent base is this page origin (an
+ * app-shell base), so the cloud finish persists first-run exactly once — same
+ * contract as Local. Requires `installCloudRoutes` + `injectCloudAuthToken`.
  */
 export async function completeCloudOnboardingToHome(
   page: Page,

--- a/packages/app/test/ui-smoke/onboarding-to-home.spec.ts
+++ b/packages/app/test/ui-smoke/onboarding-to-home.spec.ts
@@ -21,10 +21,10 @@ import {
 } from "./onboarding-to-home.shared";
 
 // CRITICAL FLOW (#9952) — onboarding is now PART OF THE CHAT. A fresh profile
-// (firstRunComplete=false) paints the homescreen + the auto-opened REAL floating
-// ContinuousChatOverlay, and a headless conductor seeds the onboarding as inline
-// chat messages: greeting → runtime CHOICE → (Cloud OAuth | provider CHOICE) →
-// tutorial CHOICE. There is NO separate full-screen onboarding surface anymore.
+// (firstRunComplete=false) paints the homescreen + floating runtime chooser. The
+// headless conductor still seeds transcript-only follow-ups like Cloud OAuth,
+// cloud-agent picks, and the tutorial CHOICE. There is NO separate full-screen
+// onboarding surface anymore.
 //
 // These specs boot a fresh device (no first-run-complete) and drive the in-chat
 // flow in the REAL shell to completion, then assert the post-onboarding landing

--- a/packages/app/test/ui-smoke/reset-returns-to-onboarding.spec.ts
+++ b/packages/app/test/ui-smoke/reset-returns-to-onboarding.spec.ts
@@ -88,19 +88,15 @@ test("Reset Everything wipes the agent and returns to first-run onboarding", asy
   // The reset actually fires against the server...
   await resetRequest;
 
-  // ...and the renderer returns to the pre-agent in-chat first-run onboarding.
-  // #9952 deleted the separate full-screen onboarding surface: the local wipe
-  // flips `firstRunComplete` back to false, which re-activates the headless
-  // conductor — it re-seeds the greeting + runtime CHOICE into the REAL floating
-  // ContinuousChatOverlay (onboarding IS the chat).
+  // ...and the renderer returns to the pre-agent first-run chooser.
   const chatOverlay = page.getByTestId("continuous-chat-overlay");
   await expect(chatOverlay).toBeVisible({ timeout: 20_000 });
-  await expect(
-    chatOverlay.getByText("Let's get you set up", { exact: false }),
-  ).toBeVisible({ timeout: 20_000 });
-  await expect(
-    page.getByTestId("choice-__first_run__:runtime:cloud"),
-  ).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByTestId("first-run-runtime-chooser")).toBeVisible({
+    timeout: 20_000,
+  });
+  await expect(page.getByTestId("first-run-chooser-cloud")).toBeVisible({
+    timeout: 15_000,
+  });
 });
 
 test("cancelling the Reset Everything warning leaves the agent untouched", async ({

--- a/packages/app/test/ui-smoke/runtime-configurability.spec.ts
+++ b/packages/app/test/ui-smoke/runtime-configurability.spec.ts
@@ -7,15 +7,10 @@ import {
 } from "./helpers";
 
 // "Local, Cloud, etc. all work out of the box and are successfully
-// configurable." Onboarding now happens IN the chat (#9952): a fresh profile
-// auto-opens the REAL floating ContinuousChatOverlay and the headless conductor
-// seeds the runtime question as inline ChoiceWidgets — Cloud (Eliza Cloud
-// managed) / On this device / Bring your own keys. This spec lands on that
-// in-chat surface and drives each branch (including the Local → provider
-// sub-choice) to prove every runtime is reachable and configurable, not just
-// displayed. The full-screen onboarding gate and the separate Remote-connect
-// form were removed — "Bring your own keys" runs the local backend with the
-// other-provider default.
+// configurable." Runtime/provider setup now lives in the floating first-run
+// chooser: Cloud (Eliza Cloud managed), Local (this device), and Bring your own
+// keys behind Advanced setup. This spec drives Local → provider to prove every
+// runtime is reachable and configurable, not just displayed.
 
 async function fulfillJson(
   route: Route,
@@ -69,12 +64,14 @@ async function injectFullCapabilityHost(page: Page): Promise<void> {
 async function expectInChatFirstRun(page: Page): Promise<void> {
   const chatOverlay = page.getByTestId("continuous-chat-overlay");
   await expect(chatOverlay).toBeVisible({ timeout: 20_000 });
+  const chooser = page.getByTestId("first-run-runtime-chooser");
+  await expect(chooser).toBeVisible({ timeout: 20_000 });
   await expect(
-    chatOverlay.getByText("Let's get you set up", { exact: false }),
+    chooser.getByText("Choose how Eliza should run", { exact: true }),
   ).toBeVisible({ timeout: 15_000 });
 }
 
-test("in-chat first-run exposes cloud, local, and bring-your-own-keys runtimes and Local is configurable", async ({
+test("first-run chooser exposes cloud, local, and bring-your-own-keys runtimes and Local is configurable", async ({
   page,
 }) => {
   await installRenderTelemetryGuard(page);
@@ -87,28 +84,27 @@ test("in-chat first-run exposes cloud, local, and bring-your-own-keys runtimes a
 
   await expectInChatFirstRun(page);
 
-  // All three runtimes are offered as inline ChoiceWidget options.
-  const cloud = page.getByTestId("choice-__first_run__:runtime:cloud");
-  const local = page.getByTestId("choice-__first_run__:runtime:local");
-  const other = page.getByTestId("choice-__first_run__:runtime:other");
+  const chooser = page.getByTestId("first-run-runtime-chooser");
+  const cloud = chooser.getByTestId("first-run-chooser-cloud");
+  const local = chooser.getByTestId("first-run-chooser-local");
+  const other = chooser.getByTestId("first-run-chooser-other");
   await expect(cloud).toBeVisible({ timeout: 15_000 });
   await expect(local).toBeVisible();
+  await chooser.getByRole("button", { name: /Advanced setup/i }).click();
   await expect(other).toBeVisible();
 
-  // Local is configurable: selecting it advances to the provider sub-choice,
+  // Local is configurable: selecting it advances to the provider step,
   // where the on-device default, Eliza Cloud inference, and other are offered.
   await local.click();
+  await expect(chooser.getByTestId("first-run-provider-on-device")).toBeVisible(
+    { timeout: 15_000 },
+  );
   await expect(
-    page.getByTestId("choice-__first_run__:provider:on-device"),
-  ).toBeVisible({ timeout: 15_000 });
-  await expect(
-    page.getByTestId("choice-__first_run__:provider:elizacloud"),
+    chooser.getByTestId("first-run-provider-elizacloud"),
   ).toBeVisible();
+  await expect(chooser.getByTestId("first-run-provider-other")).toBeVisible();
   await expect(
-    page.getByTestId("choice-__first_run__:provider:other"),
-  ).toBeVisible();
-  await expect(
-    page.getByText("Which model provider should", { exact: false }),
+    chooser.getByText("Choose how Eliza should think", { exact: true }),
   ).toBeVisible();
 
   await expectNoRenderTelemetryErrors(page, "runtime configurability");

--- a/packages/app/test/ui-smoke/walkthrough/JOURNEY.md
+++ b/packages/app/test/ui-smoke/walkthrough/JOURNEY.md
@@ -41,13 +41,12 @@ journey.
   - Composer: `[data-testid="chat-composer-textarea"]`
   - Send: `[data-testid="chat-composer-action"]`
   - Chat thread lines: `[data-testid="thread-line"]`
-  - First-run chat (#9952 in-chat onboarding — onboarding IS the chat, seeded by
-    the headless conductor into the SAME floating `[data-testid="continuous-chat-overlay"]`;
-    no separate full-screen surface): assert the overlay + the agent greeting text
-    `Let's get you set up`; runtime choices are inline ChoiceWidget buttons
-    `[data-testid="choice-__first_run__:runtime:cloud|local|other"]`, the provider
-    sub-choice `[data-testid="choice-__first_run__:provider:on-device|elizacloud|other"]`,
-    and the completion gate `[data-testid="choice-__first_run__:tutorial:start|skip"]`
+  - First-run setup: assert the shell overlay plus
+    `[data-testid="first-run-runtime-chooser"]`; runtime choices use
+    `[data-testid="first-run-chooser-cloud|local|other"]`, the provider step uses
+    `[data-testid="first-run-provider-on-device|elizacloud|other"]`, and the
+    completion gate remains
+    `[data-testid="choice-__first_run__:tutorial:start|skip"]`
   - Tutorial: `/tutorial` route → `[data-testid="tutorial-launcher"]` →
     `[data-testid="tutorial-start"]` → `[data-testid="tutorial-card"]`
   - Launcher: `[data-testid="launcher"]`
@@ -97,8 +96,8 @@ and named in the final evidence.
 
 | Step | Action | Expected state | Required assertions | Capture |
 | --- | --- | --- | --- | --- |
-| 1 | Cold app launch | The app shell loads from `/` without first-run completion. A warming/startup surface renders, then the home + the auto-opened floating chat overlay appear with the conductor's greeting (#9952 in-chat onboarding). | No page errors; no unexpected `console.error`; no unexpected `5xx`; `[data-testid="continuous-chat-overlay"]` + greeting `Let's get you set up` visible within 20s when first-run is incomplete. | `01-cold-launch.png` |
-| 2 | Onboarding | The in-chat conductor seeds the runtime question as inline ChoiceWidgets in the overlay. | Greeting + `where should your agent run` text; `choice-__first_run__:runtime:cloud`, `…:local`, and `…:other` visible. | `02-onboarding-runtime.png` |
+| 1 | Cold app launch | The app shell loads from `/` without first-run completion. A warming/startup surface renders, then the home + floating first-run runtime chooser appear. | No page errors; no unexpected `console.error`; no unexpected `5xx`; `[data-testid="continuous-chat-overlay"]` + `[data-testid="first-run-runtime-chooser"]` visible within 20s when first-run is incomplete. | `01-cold-launch.png` |
+| 2 | Onboarding | The floating first-run chooser owns runtime/provider setup. | Runtime chooser title visible; `first-run-chooser-cloud` and `first-run-chooser-local` visible; Advanced setup reveals `first-run-chooser-other`. | `02-onboarding-runtime.png` |
 | 3 | Agent provisioning | Choosing the selected runtime leads to a provisioning or ready state; the app does not stay stuck on waking/provisioning copy. | Status changes are observed through the real startup/provisioning selectors used by existing smoke tests; ready route eventually exposes the chat composer. | `03-provisioning-ready.png` |
 | 4 | Send + receive voice | Voice input can populate the composer, a message can be sent, the assistant reply renders, and TTS endpoint wiring is exercised when enabled. | STT transcript appears in `[data-testid="chat-composer-textarea"]`; stream POST body includes the transcript; assistant `[data-testid="thread-line"]` appears; TTS mock records assistant text + voice/model payload. | `04-voice-round-trip.png` |
 | 5 | Type to navigate to Character view | A chat command switches the active route to the character editor. | Composer sends the command; navigation reaches `/character`; `[data-testid="character-editor-view"]` visible. | `05-chat-navigate-character.png` |
@@ -150,9 +149,9 @@ the real backend agent + model and writes the trajectory to
 
 | Step | Action | Expected state | Required assertions | Capture |
 | --- | --- | --- | --- | --- |
-| 01 | Cold app launch | `/` loads with first-run incomplete; the in-chat first-run greeting renders inside the auto-opened floating chat overlay (#9952 — onboarding IS the chat; no full-screen gate). | No page error / no `console.error` / no 5xx; `continuous-chat-overlay` + greeting text `Let's get you set up` visible ≤20s; removed `first-run-chat`/`startup-first-run-background` absent. | `01-cold-launch.png` |
-| 02 | Onboarding runtime choice | The in-chat first-run asks where the agent should run, as inline ChoiceWidget buttons. | Runtime question text visible; `choice-__first_run__:runtime:cloud` / `…:local` / `…:other` all visible. | `02-onboarding-runtime.png` |
-| 03 | Choose runtime → tutorial → ready | Picking Local advances to the provider sub-choice, then provisioning, then the tutorial-or-skip CHOICE flips first-run complete. | `choice-__first_run__:runtime:local` → `choice-__first_run__:provider:on-device` → `choice-__first_run__:tutorial:skip`; first-run flips complete; `continuous-chat-overlay` + `chat-composer-textarea` reachable. | `03-provisioning-ready.png` |
+| 01 | Cold app launch | `/` loads with first-run incomplete; the floating first-run runtime chooser renders over the app shell. | No page error / no `console.error` / no 5xx; `continuous-chat-overlay` + `first-run-runtime-chooser` visible ≤20s; removed `first-run-chat`/`startup-first-run-background` absent. | `01-cold-launch.png` |
+| 02 | Onboarding runtime choice | The first-run chooser asks how the agent should run. | Runtime chooser title visible; `first-run-chooser-cloud` / `…-local` visible; Advanced setup reveals `…-other`. | `02-onboarding-runtime.png` |
+| 03 | Choose runtime → tutorial → ready | Picking Local advances to the provider step, then provisioning, then the tutorial-or-skip CHOICE flips first-run complete. | `first-run-chooser-local` → `first-run-provider-on-device` → `choice-__first_run__:tutorial:skip`; first-run flips complete; `continuous-chat-overlay` + `chat-composer-textarea` reachable. | `03-provisioning-ready.png` |
 | 04 | Interactive tutorial | The `/tutorial` launcher starts the tour spotlight. | `tutorial-launcher` → `tutorial-start` → `tutorial-card`; "Meet Eliza" text visible; tour dismissed via `tutorial-skip`. | `04-tutorial.png` |
 | 05 | Help search | The Help view searches the KB. | `help-view` visible; search "change the model" → `help-entry-change-model` references "AI Model". | `05-help.png` |
 | 06 | Open settings | The Settings shell opens. | `settings-shell` visible; "Models & Providers" section opened. | `06-settings-open.png` |

--- a/packages/app/test/ui-smoke/walkthrough/journey.ts
+++ b/packages/app/test/ui-smoke/walkthrough/journey.ts
@@ -788,22 +788,25 @@ export const JOURNEY_STEPS: readonly JourneyStep[] = [
     id: "cold-launch",
     title: "Cold app launch",
     expectation:
-      'First app load from / with first-run incomplete: the in-chat first-run greeting ("Let\'s get you set up") renders inside the auto-opened floating ContinuousChatOverlay (#9952 — onboarding IS the chat; no full-screen gate). No render failure, no stack trace.',
+      "First app load from / with first-run incomplete: the floating first-run runtime chooser renders over the app shell. No render failure, no stack trace.",
     async run({ page }) {
       await page.goto("/", { waitUntil: "domcontentloaded" });
       const overlay = page.getByTestId("continuous-chat-overlay");
       await expect(overlay).toBeVisible({ timeout: 20_000 });
+      const chooser = page.getByTestId("first-run-runtime-chooser");
+      await expect(chooser).toBeVisible({ timeout: 20_000 });
       await expect(
-        overlay.getByText("Let's get you set up", { exact: false }),
+        chooser.getByText("Choose how Eliza should run", { exact: true }),
       ).toBeVisible({ timeout: 15_000 });
       return {
         assertions: [
           "Loaded / with first-run incomplete",
-          "continuous-chat-overlay + in-chat greeting became visible within 20s",
+          "continuous-chat-overlay + runtime chooser became visible within 20s",
         ],
         dom: await domMarkers(page, {
           chatOverlay: '[data-testid="continuous-chat-overlay"]',
-          runtimeChoice: '[data-testid="choice-__first_run__:runtime:cloud"]',
+          runtimeChooser: '[data-testid="first-run-runtime-chooser"]',
+          runtimeChoice: '[data-testid="first-run-chooser-cloud"]',
           root: "#root",
         }),
       };
@@ -814,16 +817,19 @@ export const JOURNEY_STEPS: readonly JourneyStep[] = [
     id: "onboarding-runtime",
     title: "Onboarding runtime choice",
     expectation:
-      "The in-chat first-run asks where the agent should run, as inline ChoiceWidget buttons (Eliza Cloud, on this device, bring your own keys).",
+      "The first-run chooser asks how the agent should run, with Eliza Cloud, on-device, and Advanced bring-your-own-keys options.",
     async run({ page }) {
+      const chooser = page.getByTestId("first-run-runtime-chooser");
+      await expect(chooser).toBeVisible({ timeout: 15_000 });
       await expect(
-        page.getByText("where should your agent run", { exact: false }),
+        chooser.getByText("Choose how Eliza should run", { exact: true }),
       ).toBeVisible({ timeout: 15_000 });
-      const cloud = page.getByTestId("choice-__first_run__:runtime:cloud");
-      const local = page.getByTestId("choice-__first_run__:runtime:local");
-      const other = page.getByTestId("choice-__first_run__:runtime:other");
+      const cloud = chooser.getByTestId("first-run-chooser-cloud");
+      const local = chooser.getByTestId("first-run-chooser-local");
+      const other = chooser.getByTestId("first-run-chooser-other");
       await expect(cloud).toBeVisible();
       await expect(local).toBeVisible();
+      await chooser.getByRole("button", { name: /Advanced setup/i }).click();
       await expect(other).toBeVisible();
       return {
         assertions: [
@@ -831,9 +837,9 @@ export const JOURNEY_STEPS: readonly JourneyStep[] = [
           "runtime cloud / local / other choices all visible",
         ],
         dom: await domMarkers(page, {
-          cloud: '[data-testid="choice-__first_run__:runtime:cloud"]',
-          local: '[data-testid="choice-__first_run__:runtime:local"]',
-          other: '[data-testid="choice-__first_run__:runtime:other"]',
+          cloud: '[data-testid="first-run-chooser-cloud"]',
+          local: '[data-testid="first-run-chooser-local"]',
+          other: '[data-testid="first-run-chooser-other"]',
         }),
       };
     },
@@ -843,22 +849,21 @@ export const JOURNEY_STEPS: readonly JourneyStep[] = [
     id: "provisioning-ready",
     title: "Choose runtime → ready",
     expectation:
-      "Choosing the local runtime advances first-run (the 'Where should I run my AI?' provider step) and resolves to a ready agent: the chat overlay + composer are reachable.",
+      "Choosing the local runtime advances first-run to the provider step and resolves to a ready agent: the chat overlay + composer are reachable.",
     async run(ctx) {
       const { page } = ctx;
-      // Drive the real in-chat local-runtime selection (#9952): picking Local
-      // advances the conductor to the on-device provider sub-choice (a purely
-      // client-side seed — no network). We intentionally STOP before picking the
+      // Drive the local-runtime selection: picking Local advances the chooser to
+      // the on-device provider step. We intentionally STOP before picking the
       // provider, because the on-device finish would POST /api/first-run + probe
       // local-inference, which the keyless mock lane does not stub (it would 501
       // and trip the 5xx gate). Real cloud/local provisioning is out of scope per
       // JOURNEY.md's surface decision, so reachChatReady force-resolves first-run
       // to land the journey on a ready agent — exactly as before #9952.
-      const local = page.getByTestId("choice-__first_run__:runtime:local");
+      const local = page.getByTestId("first-run-chooser-local");
       if (await local.isVisible().catch(() => false)) {
         await local.click().catch(() => undefined);
         await page
-          .getByTestId("choice-__first_run__:provider:on-device")
+          .getByTestId("first-run-provider-on-device")
           .waitFor({ state: "visible", timeout: 15_000 })
           .catch(() => undefined);
       }
@@ -866,7 +871,7 @@ export const JOURNEY_STEPS: readonly JourneyStep[] = [
       await expect(composer(page)).toBeVisible({ timeout: 30_000 });
       return {
         assertions: [
-          "Selected the local runtime choice → on-device provider sub-choice",
+          "Selected the local runtime choice → on-device provider step",
           "first-run resolved to complete",
           "chat overlay + composer reachable (ready agent)",
         ],

--- a/packages/app/test/ui-smoke/walkthrough/walkthrough-capture-smoke.spec.ts
+++ b/packages/app/test/ui-smoke/walkthrough/walkthrough-capture-smoke.spec.ts
@@ -186,23 +186,17 @@ test.describe("walkthrough capture smoke", () => {
     await installWalkthroughConversationStore(page);
 
     await page.goto("/", { waitUntil: "domcontentloaded" });
-    // #9952: onboarding IS the chat — the conductor greets first inside the REAL
-    // floating ContinuousChatOverlay and offers the runtime question as inline
-    // ChoiceWidget buttons. There is no separate full-screen onboarding surface.
     const onboarding = page.getByTestId("continuous-chat-overlay");
     await expect(onboarding).toBeVisible({ timeout: 20_000 });
+    const chooser = page.getByTestId("first-run-runtime-chooser");
+    await expect(chooser).toBeVisible({ timeout: 20_000 });
     await expect(
-      onboarding.getByText("Let's get you set up", { exact: false }),
+      chooser.getByText("Choose how Eliza should run", { exact: true }),
     ).toBeVisible({ timeout: 15_000 });
-    await expect(
-      page.getByTestId("choice-__first_run__:runtime:cloud"),
-    ).toBeVisible();
-    await expect(
-      page.getByTestId("choice-__first_run__:runtime:other"),
-    ).toBeVisible();
-    await expect(
-      page.getByTestId("choice-__first_run__:runtime:local"),
-    ).toBeVisible();
+    await expect(chooser.getByTestId("first-run-chooser-cloud")).toBeVisible();
+    await expect(chooser.getByTestId("first-run-chooser-local")).toBeVisible();
+    await chooser.getByRole("button", { name: /Advanced setup/i }).click();
+    await expect(chooser.getByTestId("first-run-chooser-other")).toBeVisible();
     await captureState(page, testInfo, "walkthrough-01-onboarding.png");
 
     firstRun.setComplete(true);

--- a/packages/ui/src/first-run/FirstRunRuntimeChooser.test.tsx
+++ b/packages/ui/src/first-run/FirstRunRuntimeChooser.test.tsx
@@ -3,13 +3,50 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { Z_FIRST_RUN_CHOOSER } from "../lib/floating-layers";
-import { FirstRunRuntimeChooserSurface } from "./FirstRunRuntimeChooser";
+import {
+  FirstRunRuntimeChooserSurface,
+  isSyntheticFirstRunChoiceTurn,
+} from "./FirstRunRuntimeChooser";
 
 afterEach(() => {
   cleanup();
 });
 
 describe("FirstRunRuntimeChooserSurface", () => {
+  it("identifies synthetic in-chat first-run choice turns", () => {
+    expect(
+      isSyntheticFirstRunChoiceTurn({
+        id: "first-run:greeting",
+        content: "[CHOICE:first-run id=runtime]",
+      }),
+    ).toBe(true);
+    expect(
+      isSyntheticFirstRunChoiceTurn({
+        id: "first-run:error:123",
+        content:
+          "Couldn't connect.\n\n[CHOICE:first-run id=runtime]\n__first_run__:runtime:cloud=Eliza Cloud\n[/CHOICE]",
+      }),
+    ).toBe(true);
+    expect(
+      isSyntheticFirstRunChoiceTurn({
+        id: "first-run:provider",
+        content: "[CHOICE:first-run id=provider]",
+      }),
+    ).toBe(true);
+    expect(
+      isSyntheticFirstRunChoiceTurn({
+        id: "first-run:status:Saving first-run profile",
+        content: "Saving first-run profile",
+      }),
+    ).toBe(false);
+    expect(
+      isSyntheticFirstRunChoiceTurn({
+        id: "regular-message",
+        content: "[CHOICE:first-run id=runtime]",
+      }),
+    ).toBe(false);
+  });
+
   it("shows the clean runtime picker with advanced setup collapsed", () => {
     render(
       <FirstRunRuntimeChooserSurface

--- a/packages/ui/src/first-run/FirstRunRuntimeChooser.test.tsx
+++ b/packages/ui/src/first-run/FirstRunRuntimeChooser.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { Z_FIRST_RUN_CHOOSER } from "../lib/floating-layers";
 import {
   FirstRunRuntimeChooserSurface,
+  hasPendingFirstRunBackupRestoreChoice,
   isSyntheticFirstRunChoiceTurn,
 } from "./FirstRunRuntimeChooser";
 
@@ -35,6 +36,18 @@ describe("FirstRunRuntimeChooserSurface", () => {
     ).toBe(true);
     expect(
       isSyntheticFirstRunChoiceTurn({
+        id: "first-run:backup-restore",
+        content: "[CHOICE:first-run id=backup-restore]",
+      }),
+    ).toBe(false);
+    expect(
+      isSyntheticFirstRunChoiceTurn({
+        id: "first-run:greeting",
+        text: "[CHOICE:first-run id=runtime]",
+      }),
+    ).toBe(true);
+    expect(
+      isSyntheticFirstRunChoiceTurn({
         id: "first-run:status:Saving first-run profile",
         content: "Saving first-run profile",
       }),
@@ -44,6 +57,37 @@ describe("FirstRunRuntimeChooserSurface", () => {
         id: "regular-message",
         content: "[CHOICE:first-run id=runtime]",
       }),
+    ).toBe(false);
+  });
+
+  it("detects a pending backup restore choice before runtime setup starts", () => {
+    expect(
+      hasPendingFirstRunBackupRestoreChoice([
+        {
+          id: "first-run:backup-restore",
+          text: "Restore?\n\n[CHOICE:first-run id=backup-restore]\n[/CHOICE]",
+        },
+      ]),
+    ).toBe(true);
+    expect(
+      hasPendingFirstRunBackupRestoreChoice([
+        {
+          id: "first-run:backup-restore-error:1",
+          text: "Try again\n\n[CHOICE:first-run id=backup-restore]\n[/CHOICE]",
+        },
+      ]),
+    ).toBe(true);
+    expect(
+      hasPendingFirstRunBackupRestoreChoice([
+        {
+          id: "first-run:backup-restore",
+          text: "Restore?\n\n[CHOICE:first-run id=backup-restore]\n[/CHOICE]",
+        },
+        {
+          id: "first-run:greeting",
+          text: "Hi — I'm Eliza. Choose a setup option to continue.",
+        },
+      ]),
     ).toBe(false);
   });
 

--- a/packages/ui/src/first-run/FirstRunRuntimeChooser.tsx
+++ b/packages/ui/src/first-run/FirstRunRuntimeChooser.tsx
@@ -1,5 +1,6 @@
 import { ChevronDown, Cloud, Cpu, KeyRound, Loader2 } from "lucide-react";
 import * as React from "react";
+import type { ConversationMessage } from "../api";
 import { ElizaMark } from "../components/brand/eliza-mark";
 import { getBootConfig } from "../config/boot-config-store";
 import { Z_FIRST_RUN_CHOOSER } from "../lib/floating-layers";
@@ -14,6 +15,17 @@ import {
 type RuntimeChoice = "cloud" | "local" | "other";
 type ProviderChoice = "on-device" | "elizacloud" | "other";
 type ChooserStep = "runtime" | "provider";
+
+const FIRST_RUN_CHOICE_PATTERN = /\[CHOICE:first-run\b/;
+
+export function isSyntheticFirstRunChoiceTurn(
+  message: Pick<ConversationMessage, "id" | "content">,
+): boolean {
+  return (
+    message.id.startsWith("first-run:") &&
+    FIRST_RUN_CHOICE_PATTERN.test(message.content)
+  );
+}
 
 type ChoiceDefinition = {
   id: RuntimeChoice;
@@ -301,31 +313,25 @@ export function FirstRunRuntimeChooser(): React.ReactElement | null {
   const active =
     firstRunComplete === false && startupPhase === "first-run-required";
 
-  const removeSyntheticChoiceTurns = React.useCallback(
-    (...ids: string[]) => {
-      const stale = new Set(ids);
-      setConversationMessages((previous) => {
-        let changed = false;
-        const next = previous.filter((message) => {
-          const remove = stale.has(message.id);
-          changed ||= remove;
-          return !remove;
-        });
-        return changed ? next : previous;
+  const removeSyntheticChoiceTurns = React.useCallback(() => {
+    setConversationMessages((previous) => {
+      let changed = false;
+      const next = previous.filter((message) => {
+        const remove = isSyntheticFirstRunChoiceTurn(message);
+        changed ||= remove;
+        return !remove;
       });
-    },
-    [setConversationMessages],
-  );
+      return changed ? next : previous;
+    });
+  }, [setConversationMessages]);
 
   React.useEffect(() => {
     if (!active || dismissed) return;
     const hasSyntheticChoiceTurns = conversationMessages.some(
-      (message) =>
-        message.id === "first-run:greeting" ||
-        message.id === "first-run:provider",
+      isSyntheticFirstRunChoiceTurn,
     );
     if (!hasSyntheticChoiceTurns) return;
-    removeSyntheticChoiceTurns("first-run:greeting", "first-run:provider");
+    removeSyntheticChoiceTurns();
   }, [active, conversationMessages, dismissed, removeSyntheticChoiceTurns]);
 
   React.useEffect(() => {
@@ -365,7 +371,7 @@ export function FirstRunRuntimeChooser(): React.ReactElement | null {
           setError("Setup is still initializing. Try again in a moment.");
           return;
         }
-        removeSyntheticChoiceTurns("first-run:greeting");
+        removeSyntheticChoiceTurns();
         if (choice === "cloud") {
           void handleCloudLogin(cloudAuthWindow).catch(() => {
             // The cloud state hook owns the user-facing login error; the
@@ -388,7 +394,7 @@ export function FirstRunRuntimeChooser(): React.ReactElement | null {
           setError("Setup is still initializing. Try again in a moment.");
           return;
         }
-        removeSyntheticChoiceTurns("first-run:provider");
+        removeSyntheticChoiceTurns();
         setDismissed(true);
       }}
       onBack={() => {

--- a/packages/ui/src/first-run/FirstRunRuntimeChooser.tsx
+++ b/packages/ui/src/first-run/FirstRunRuntimeChooser.tsx
@@ -16,15 +16,39 @@ type RuntimeChoice = "cloud" | "local" | "other";
 type ProviderChoice = "on-device" | "elizacloud" | "other";
 type ChooserStep = "runtime" | "provider";
 
-const FIRST_RUN_CHOICE_PATTERN = /\[CHOICE:first-run\b/;
+const FIRST_RUN_RUNTIME_PROVIDER_CHOICE_PATTERN =
+  /\[CHOICE:first-run id=(?:runtime|provider)\]/;
+const FIRST_RUN_BACKUP_RESTORE_CHOICE_PATTERN =
+  /\[CHOICE:first-run id=backup-restore\]/;
+
+type FirstRunChoiceCandidate = Pick<ConversationMessage, "id"> &
+  Partial<Pick<ConversationMessage, "text">> & { content?: string };
+
+function firstRunChoiceBody(message: FirstRunChoiceCandidate): string {
+  if (typeof message.content === "string") return message.content;
+  if (typeof message.text === "string") return message.text;
+  return "";
+}
 
 export function isSyntheticFirstRunChoiceTurn(
-  message: Pick<ConversationMessage, "id" | "content">,
+  message: FirstRunChoiceCandidate,
 ): boolean {
   return (
     message.id.startsWith("first-run:") &&
-    FIRST_RUN_CHOICE_PATTERN.test(message.content)
+    FIRST_RUN_RUNTIME_PROVIDER_CHOICE_PATTERN.test(firstRunChoiceBody(message))
   );
+}
+
+export function hasPendingFirstRunBackupRestoreChoice(
+  messages: FirstRunChoiceCandidate[],
+): boolean {
+  const hasBackupRestoreChoice = messages.some(
+    (message) =>
+      message.id.startsWith("first-run:backup-restore") &&
+      FIRST_RUN_BACKUP_RESTORE_CHOICE_PATTERN.test(firstRunChoiceBody(message)),
+  );
+  if (!hasBackupRestoreChoice) return false;
+  return !messages.some((message) => message.id === "first-run:greeting");
 }
 
 type ChoiceDefinition = {
@@ -312,6 +336,8 @@ export function FirstRunRuntimeChooser(): React.ReactElement | null {
     useConversationMessages();
   const active =
     firstRunComplete === false && startupPhase === "first-run-required";
+  const backupRestorePending =
+    hasPendingFirstRunBackupRestoreChoice(conversationMessages);
 
   const removeSyntheticChoiceTurns = React.useCallback(() => {
     setConversationMessages((previous) => {
@@ -343,7 +369,7 @@ export function FirstRunRuntimeChooser(): React.ReactElement | null {
     setError(null);
   }, [active]);
 
-  if (!active || dismissed) return null;
+  if (!active || dismissed || backupRestorePending) return null;
 
   const appName = getBootConfig().branding?.appName ?? "elizaOS";
 

--- a/packages/ui/src/first-run/use-first-run-conductor.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.ts
@@ -1,16 +1,11 @@
 // ============================================================================
-// In-chat first-run conductor (headless).
+// First-run conductor (headless).
 //
-// Onboarding is PART OF THE CHAT. When `firstRunComplete === false` this hook
-// seeds synthetic assistant turns into the SAME live transcript the floating
-// `ContinuousChatOverlay` renders (greeting → runtime CHOICE → Cloud OAuth via
-// the message `secretRequest` field → provider CHOICE → tutorial CHOICE), and
-// routes the user's first-run-scoped picks to the headless finish use case
-// (`first-run-finish.ts`). It owns NO presentation — the existing
-// `InlineWidgetText` + `SensitiveRequestBlock` renderers draw the widgets for
-// free from message fields. It registers an action handler on the first-run
-// channel so the chat's single send funnel short-circuits first-run picks
-// before they hit the server.
+// The floating FirstRunRuntimeChooser owns the runtime/provider UI. This hook
+// seeds status/tutorial turns into the live transcript and routes
+// first-run-scoped picks to the headless finish use case (`first-run-finish.ts`).
+// It registers an action handler on the first-run channel so first-run picks
+// short-circuit before they hit the server.
 //
 // Provisioning runs exactly once and POSTs /api/first-run exactly once (the
 // finish module funnels + idempotency-guards it). The real
@@ -45,8 +40,7 @@ import {
   runFirstRunFinish,
 } from "./first-run-finish";
 
-const GREETING =
-  "Hi — I'm Eliza. Let's get you set up. First, where should your agent run?";
+const GREETING = "Hi — I'm Eliza. Choose a setup option to continue.";
 
 /** User-facing recovery message when a cloud provisioning call rejects. */
 function cloudFailureMessage(err: unknown): string {
@@ -88,31 +82,12 @@ function newestLocalBackup(
   );
 }
 
-const RUNTIME_CHOICE = [
-  "[CHOICE:first-run id=runtime]",
-  `${FIRST_RUN_ACTION_PREFIX}runtime:cloud=Eliza Cloud (managed)`,
-  `${FIRST_RUN_ACTION_PREFIX}runtime:local=On this device`,
-  `${FIRST_RUN_ACTION_PREFIX}runtime:other=Bring your own keys`,
-  "[/CHOICE]",
-].join("\n");
-
 const BACKUP_RESTORE_CHOICE = [
   "[CHOICE:first-run id=backup-restore]",
   `${FIRST_RUN_ACTION_PREFIX}backup-restore:latest=Restore latest backup`,
   `${FIRST_RUN_ACTION_PREFIX}backup-restore:start-fresh=Start fresh`,
   "[/CHOICE]",
 ].join("\n");
-
-function providerChoice(opts: { defaultId: "on-device" | "other" }): string {
-  const onDevice = `${FIRST_RUN_ACTION_PREFIX}provider:on-device=On this device (recommended)`;
-  const cloud = `${FIRST_RUN_ACTION_PREFIX}provider:elizacloud=Eliza Cloud inference`;
-  const other = `${FIRST_RUN_ACTION_PREFIX}provider:other=Other / configure in Settings`;
-  const ordered =
-    opts.defaultId === "on-device"
-      ? [onDevice, cloud, other]
-      : [other, onDevice, cloud];
-  return ["[CHOICE:first-run id=provider]", ...ordered, "[/CHOICE]"].join("\n");
-}
 
 const TUTORIAL_CHOICE = [
   "[CHOICE:first-run id=tutorial]",
@@ -217,9 +192,7 @@ export function useFirstRunConductor(): void {
   }, [seedTurn]);
 
   const seedRuntimeChoice = React.useCallback(() => {
-    seedTurn(
-      makeTurn("first-run:greeting", `${GREETING}\n\n${RUNTIME_CHOICE}`),
-    );
+    seedTurn(makeTurn("first-run:greeting", GREETING));
   }, [seedTurn]);
 
   const seedBackupRestoreChoice = React.useCallback(
@@ -280,12 +253,7 @@ export function useFirstRunConductor(): void {
 
   const seedError = React.useCallback(
     (message: string) => {
-      seedTurn(
-        makeTurn(
-          `first-run:error:${Date.now()}`,
-          `${message}\n\n[CHOICE:first-run id=runtime]\n${FIRST_RUN_ACTION_PREFIX}runtime:cloud=Eliza Cloud (managed)\n${FIRST_RUN_ACTION_PREFIX}runtime:local=On this device\n${FIRST_RUN_ACTION_PREFIX}runtime:other=Bring your own keys\n[/CHOICE]`,
-        ),
-      );
+      seedTurn(makeTurn(`first-run:error:${Date.now()}`, message));
     },
     [seedTurn],
   );
@@ -392,7 +360,7 @@ export function useFirstRunConductor(): void {
         seedTurn(
           makeTurn(
             "first-run:provider",
-            `Which model provider should ${draftRef.current.agentName} use?\n\n${providerChoice({ defaultId: id === "other" ? "other" : "on-device" })}`,
+            `Choose how ${draftRef.current.agentName} should think to finish setup.`,
           ),
         );
         return true;


### PR DESCRIPTION
## Summary

Follow-up to #10548 for the first-run Cloud/local/BYOK chooser regression.

- Keep runtime/provider choice UI owned by the floating `FirstRunRuntimeChooser` only.
- Stop the headless first-run conductor from seeding duplicate in-chat runtime/provider `[CHOICE:first-run]` widgets underneath the clean chooser.
- Remove any stale synthetic first-run choice turns by pattern, including retry/error/provider turns, without touching normal first-run status/tutorial turns.
- Add unit coverage for detecting synthetic in-chat first-run choice turns.

## Validation

- `bunx @biomejs/biome check packages/ui/src/first-run/use-first-run-conductor.ts packages/ui/src/first-run/FirstRunRuntimeChooser.tsx packages/ui/src/first-run/FirstRunRuntimeChooser.test.tsx`
- `node packages/shared/scripts/generate-keywords.mjs --target ts`
- `bunx vitest run --config vitest.config.ts src/first-run/FirstRunRuntimeChooser.test.tsx` from `packages/ui`
- `bun run --cwd packages/core build`
- `bun run --cwd packages/shared build`
- `VITE_API_URL=https://api-staging.elizacloud.ai NEXT_PUBLIC_API_URL=https://api-staging.elizacloud.ai VITE_ELIZA_CLOUD_BASE=https://staging.elizacloud.ai VITE_APP_URL=https://app-staging.elizacloud.ai NEXT_PUBLIC_APP_URL=https://app-staging.elizacloud.ai bun run --cwd packages/app build:web`
- Playwright built-app smoke against `http://127.0.0.1:4190/`:
  - desktop 1440x1000 first-run BYOK -> provider path
  - no visible `choice-__first_run__:runtime` or `choice-__first_run__:provider` widgets behind the clean chooser
  - Cloud sign-in opens `https://staging.elizacloud.ai/auth/cli-login?session=...`
  - mobile 390x844 first-run chooser remains contained and has no duplicate in-chat runtime choices
- `git diff --check`
- `git ls-files -u`
- `rg -n '^(<<<<<<<|>>>>>>>)' packages/ui/src/first-run packages/app packages/core packages/shared`

## Notes

The Playwright Cloud path stubs CLI session creation/polling so the test is deterministic while still validating that the app opens the staging Eliza Cloud login URL. A real Google OAuth/account-credit inference check remains live-account validation.
