### PR TITLE
fix(documents): route DOCUMENT subaction via structured args, not NL keywords

### DIFF
--- a/packages/core/src/features/documents/__tests__/actions-routing.test.ts
+++ b/packages/core/src/features/documents/__tests__/actions-routing.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+	HandlerOptions,
+	IAgentRuntime,
+	Memory,
+	SearchCategoryRegistration,
+	UUID,
+} from "../../../types";
+import { documentAction } from "../actions";
+import { DocumentService } from "../service";
+
+// ── Structured-routing tests ───────────────────────────────────────────────
+//
+// The DOCUMENT umbrella action selects its subaction from the planner's
+// structured English-enum `action` parameter (via `resolveActionArgs`), NOT
+// from natural-language keywords in the user's `message.content.text`. The
+// planner-trust path in `resolveActionArgs` resolves a valid `action` value
+// with zero required fields synchronously — no model call — so these tests are
+// fully deterministic.
+
+const AGENT_ID = "00000000-0000-0000-0000-00000000a9e7" as UUID;
+const USER_ID = "00000000-0000-0000-0000-00000000c0de" as UUID;
+const ROOM_ID = "00000000-0000-0000-0000-00000000d00d" as UUID;
+const DOC_ID = "11111111-2222-3333-4444-555555555555" as UUID;
+
+function makeMessage(text: string): Memory {
+	return {
+		id: "00000000-0000-0000-0000-0000000000aa" as UUID,
+		entityId: USER_ID,
+		agentId: AGENT_ID,
+		roomId: ROOM_ID,
+		content: { text },
+		createdAt: Date.now(),
+	} as Memory;
+}
+
+function makeService() {
+	return {
+		listDocuments: vi.fn(async () => []),
+		searchDocuments: vi.fn(async () => []),
+		getDocumentById: vi.fn(async () => null),
+		addDocument: vi.fn(async () => ({
+			clientDocumentId: DOC_ID,
+			fragmentCount: 1,
+		})),
+		updateDocument: vi.fn(async () => ({
+			documentId: DOC_ID,
+			fragmentCount: 1,
+		})),
+		deleteDocument: vi.fn(async () => undefined),
+	};
+}
+
+function makeRuntime(service: ReturnType<typeof makeService>): {
+	runtime: IAgentRuntime;
+	useModel: ReturnType<typeof vi.fn>;
+} {
+	const categories = new Map<string, SearchCategoryRegistration>();
+	const useModel = vi.fn(async () => {
+		throw new Error("useModel must not be called on the planner-trust path");
+	});
+	const runtime = {
+		agentId: AGENT_ID,
+		getService: vi.fn(<T>(type: string): T | null =>
+			type === DocumentService.serviceType ? (service as unknown as T) : null,
+		),
+		registerSearchCategory: vi.fn((reg: SearchCategoryRegistration) => {
+			categories.set(reg.category, reg);
+		}),
+		getSearchCategory: vi.fn((category: string) => {
+			const found = categories.get(category);
+			if (!found) {
+				throw new Error(`unknown category ${category}`);
+			}
+			return found;
+		}),
+		getSetting: vi.fn(() => undefined),
+		useModel,
+	} as unknown as IAgentRuntime;
+	return { runtime, useModel };
+}
+
+function options(parameters: Record<string, unknown>): HandlerOptions {
+	return { parameters } as HandlerOptions;
+}
+
+describe("documentAction.validate", () => {
+	it("is service-presence only — true when the service is registered", async () => {
+		const service = makeService();
+		const { runtime } = makeRuntime(service);
+		await expect(
+			documentAction.validate?.(runtime, makeMessage("anything"), undefined),
+		).resolves.toBe(true);
+	});
+
+	it("registers the documents search category as a side effect", async () => {
+		const service = makeService();
+		const { runtime } = makeRuntime(service);
+		await documentAction.validate?.(runtime, makeMessage("hi"), undefined);
+		expect(runtime.registerSearchCategory).toHaveBeenCalledTimes(1);
+		expect(runtime.getSearchCategory("documents")).toMatchObject({
+			category: "documents",
+			serviceType: DocumentService.serviceType,
+		});
+	});
+
+	it("is false when no documents service is present (no NL inference)", async () => {
+		const { runtime } = makeRuntime(makeService());
+		(runtime.getService as ReturnType<typeof vi.fn>).mockReturnValue(null);
+		await expect(
+			documentAction.validate?.(
+				runtime,
+				makeMessage("please search my documents for launch notes"),
+				undefined,
+			),
+		).resolves.toBe(false);
+	});
+});
+
+describe("documentAction.handler structured routing", () => {
+	it("routes on the planner action value, ignoring conflicting NL keywords", async () => {
+		const service = makeService();
+		const { runtime, useModel } = makeRuntime(service);
+		// Text screams "delete"; the structured action says "list" — list wins.
+		const res = await documentAction.handler?.(
+			runtime,
+			makeMessage("delete remove drop forget everything"),
+			undefined,
+			options({ action: "list" }),
+		);
+		expect(useModel).not.toHaveBeenCalled();
+		expect(service.listDocuments).toHaveBeenCalledTimes(1);
+		expect(service.deleteDocument).not.toHaveBeenCalled();
+		expect(res?.data).toMatchObject({ actionName: "DOCUMENT", subaction: "list" });
+	});
+
+	it.each([
+		["search", "searchDocuments"],
+		["list", "listDocuments"],
+	] as const)(
+		"routes the %s subaction to the matching service call",
+		async (action, method) => {
+			const service = makeService();
+			const { runtime } = makeRuntime(service);
+			await documentAction.handler?.(
+				runtime,
+				makeMessage("placeholder text"),
+				undefined,
+				options(
+					action === "search"
+						? { action, query: "launch notes" }
+						: { action },
+				),
+			);
+			expect(service[method]).toHaveBeenCalledTimes(1);
+		},
+	);
+
+	it("forwards a structured documentId to read without scanning the text", async () => {
+		const service = makeService();
+		service.getDocumentById.mockResolvedValueOnce({
+			content: { text: "hello doc" },
+		} as never);
+		const { runtime } = makeRuntime(service);
+		const res = await documentAction.handler?.(
+			runtime,
+			makeMessage("no uuid in this text"),
+			undefined,
+			options({ action: "read", documentId: DOC_ID }),
+		);
+		expect(service.getDocumentById).toHaveBeenCalledWith(
+			DOC_ID,
+			expect.anything(),
+		);
+		expect(res?.data).toMatchObject({ subaction: "read" });
+	});
+
+	it("returns service-unavailable when the service disappears at dispatch", async () => {
+		const { runtime } = makeRuntime(makeService());
+		(runtime.getService as ReturnType<typeof vi.fn>).mockReturnValue(null);
+		const res = await documentAction.handler?.(
+			runtime,
+			makeMessage("list documents"),
+			undefined,
+			options({ action: "list" }),
+		);
+		expect(res?.success).toBe(false);
+		expect(res?.values).toMatchObject({ error: "service_unavailable" });
+	});
+});

--- a/packages/core/src/features/documents/actions.ts
+++ b/packages/core/src/features/documents/actions.ts
@@ -1,5 +1,9 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import {
+	resolveActionArgs,
+	type SubactionsMap,
+} from "../../actions/resolve-action-args";
 import { logger } from "../../logger";
 import { checkSenderRole, hasRoleAccess, isAgentSelf } from "../../roles";
 import type {
@@ -59,16 +63,91 @@ type DocumentActionParameters = {
 	timeRangeEnd?: string | number;
 };
 
-const DOCUMENT_SUB_ACTIONS = new Set<DocumentSubAction>([
-	"list",
-	"search",
-	"read",
-	"write",
-	"edit",
-	"delete",
-	"import_file",
-	"import_url",
-]);
+/**
+ * Route-only subaction map: the planner selects the DOCUMENT subaction by
+ * emitting a structured English-enum `action`/`subaction` value, and
+ * {@link resolveActionArgs} routes on it. Every subaction declares
+ * `required: []` because the per-subaction presence/invariant checks (a valid
+ * document id, non-empty text, a resolvable source) are enforced inside the
+ * individual handlers, which can also recover those values from machine
+ * extractors (UUID / file-path / URL patterns). The `optional` lists mirror the
+ * {@link DocumentActionParameters} keys each handler reads so the resolver
+ * forwards them through.
+ */
+const DOCUMENT_SUBACTIONS: SubactionsMap<DocumentSubAction> = {
+	list: {
+		description: "List available stored documents, optionally filtered.",
+		descriptionCompressed: "list stored documents w/ filters",
+		required: [],
+		optional: [
+			"query",
+			"limit",
+			"offset",
+			"scope",
+			"scopedToEntityId",
+			"addedBy",
+			"timeRangeStart",
+			"timeRangeEnd",
+			"tags",
+		],
+	},
+	search: {
+		description: "Semantic + keyword search over stored document fragments.",
+		descriptionCompressed: "search document fragments by query",
+		required: [],
+		optional: [
+			"query",
+			"limit",
+			"searchMode",
+			"scope",
+			"scopedToEntityId",
+			"addedBy",
+			"timeRangeStart",
+			"timeRangeEnd",
+			"tags",
+		],
+	},
+	read: {
+		description: "Read the full text of one stored document by id.",
+		descriptionCompressed: "read document by id",
+		required: [],
+		optional: ["id", "documentId"],
+	},
+	write: {
+		description: "Create a new text-backed document from supplied content.",
+		descriptionCompressed: "create text document",
+		required: [],
+		optional: ["text", "content", "title", "tags", "scope", "scopedToEntityId"],
+	},
+	edit: {
+		description: "Replace the content of an existing document by id.",
+		descriptionCompressed: "edit document content by id",
+		required: [],
+		optional: ["id", "documentId", "text", "content"],
+	},
+	delete: {
+		description: "Delete a stored document by id.",
+		descriptionCompressed: "delete document by id",
+		required: [],
+		optional: ["id", "documentId"],
+	},
+	import_file: {
+		description: "Import a document from a local file path or text content.",
+		descriptionCompressed: "import document from file path",
+		required: [],
+		optional: ["filePath", "content", "title", "scope", "scopedToEntityId"],
+	},
+	import_url: {
+		description: "Import a document from an HTTP or HTTPS URL.",
+		descriptionCompressed: "import document from url",
+		required: [],
+		optional: ["url", "includeImageDescriptions", "scope", "scopedToEntityId"],
+	},
+};
+
+const DOCUMENT_SUB_ACTION_KEYS = Object.keys(
+	DOCUMENT_SUBACTIONS,
+) as DocumentSubAction[];
 
 const DOCUMENT_SCOPES = new Set<DocumentVisibilityScope>([
 	"global",
@@ -120,54 +199,6 @@ export function registerDocumentsSearchCategory(runtime: IAgentRuntime): void {
 	if (!hasSearchCategory(runtime, DOCUMENTS_SEARCH_CATEGORY.category)) {
 		runtime.registerSearchCategory(DOCUMENTS_SEARCH_CATEGORY);
 	}
-}
-
-function getParams(
-	options?: HandlerOptions | unknown,
-): DocumentActionParameters {
-	const maybeOptions = options as HandlerOptions | undefined;
-	const params = maybeOptions?.parameters;
-	return params && typeof params === "object"
-		? (params as DocumentActionParameters)
-		: {};
-}
-
-function normalizeSubAction(value: unknown): DocumentSubAction | null {
-	if (typeof value !== "string") return null;
-	const normalized = value.trim().toLowerCase().replace(/-/g, "_");
-	return DOCUMENT_SUB_ACTIONS.has(normalized as DocumentSubAction)
-		? (normalized as DocumentSubAction)
-		: null;
-}
-
-function inferSubAction(
-	params: DocumentActionParameters,
-	message: Memory,
-): DocumentSubAction | null {
-	const explicit =
-		normalizeSubAction(params.action) ?? normalizeSubAction(params.subaction);
-	if (explicit) return explicit;
-
-	const text = message.content.text ?? "";
-	if (
-		(params.url || URL_PATTERN.test(text)) &&
-		/\b(add|import|save)\b/i.test(text)
-	) {
-		return "import_url";
-	}
-	if (
-		(params.filePath || DOCUMENT_PATH_PATTERN.test(text)) &&
-		/\b(add|import|process|save)\b/i.test(text)
-	) {
-		return "import_file";
-	}
-	if (/\b(read|open|show)\b/i.test(text)) return "read";
-	if (/\b(list|recent|available)\b/i.test(text)) return "list";
-	if (/\b(delete|remove|drop|forget)\b/i.test(text)) return "delete";
-	if (/\b(edit|update|replace|rewrite)\b/i.test(text)) return "edit";
-	if (/\b(save|store|write|create|remember|add)\b/i.test(text)) return "write";
-	if (/\b(search|find|lookup|look up|query)\b/i.test(text)) return "search";
-	return null;
 }
 
 function isUuid(value: string): value is UUID {
@@ -1011,7 +1042,7 @@ export const documentAction: Action = {
 			required: true,
 			schema: {
 				type: "string",
-				enum: [...DOCUMENT_SUB_ACTIONS],
+				enum: [...DOCUMENT_SUB_ACTION_KEYS],
 			},
 		},
 		{
@@ -1173,20 +1204,16 @@ export const documentAction: Action = {
 
 	validate: async (
 		runtime: IAgentRuntime,
-		message: Memory,
-		_state?: State,
-		options?: unknown,
+		_message: Memory,
 	): Promise<boolean> => {
 		registerDocumentsSearchCategory(runtime);
-		if (!runtime.getService(DocumentService.serviceType)) return false;
-		const params = getParams(options);
-		return Boolean(inferSubAction(params, message));
+		return Boolean(runtime.getService(DocumentService.serviceType));
 	},
 
 	handler: async (
 		runtime: IAgentRuntime,
 		message: Memory,
-		_state?: State,
+		state?: State,
 		options?: HandlerOptions,
 		callback?: HandlerCallback,
 	): Promise<ActionResult> => {
@@ -1194,23 +1221,34 @@ export const documentAction: Action = {
 		const service = runtime.getService<DocumentService>(
 			DocumentService.serviceType,
 		);
-		const params = getParams(options);
-		const subaction = inferSubAction(params, message);
 
 		if (!service) {
 			const text = "Documents service not available.";
 			await emit(callback, { text });
-			return result(false, text, subaction ?? "search", {
+			return result(false, text, "search", {
 				values: { error: "service_unavailable" },
 			});
 		}
-		if (!subaction) {
-			const text = "I need a document subaction to perform.";
-			await emit(callback, { text });
-			return result(false, text, "search", {
-				values: { error: "missing_sub_action" },
+
+		const resolved = await resolveActionArgs<
+			DocumentSubAction,
+			DocumentActionParameters
+		>({
+			runtime,
+			message,
+			state,
+			options,
+			actionName: "DOCUMENT",
+			subactions: DOCUMENT_SUBACTIONS,
+		});
+		if (!resolved.ok) {
+			await emit(callback, { text: resolved.clarification });
+			return result(false, resolved.clarification, "search", {
+				values: { error: "missing_sub_action", missing: resolved.missing },
 			});
 		}
+
+		const { subaction, params } = resolved;
 
 		try {
 			switch (subaction) {


### PR DESCRIPTION
## What changed

The core `DOCUMENT` umbrella action (`packages/core/src/features/documents/actions.ts`) picked its subaction — `list | search | read | write | edit | delete | import_file | import_url` — by regex-matching English keywords in the **user's** `message.content.text` via `inferSubAction` / `normalizeSubAction`:

```ts
if (/\b(read|open|show)\b/i.test(text)) return "read";
if (/\b(delete|remove|drop|forget)\b/i.test(text)) return "delete";
if (/\b(save|store|write|create|remember|add)\b/i.test(text)) return "write";
// …
```

This is the #10471 smell — **deciding behavior off the user's natural-language text** rather than the planner/model's structured English-enum output. It also made `validate()` return `false` (so the action was **unselectable**) whenever the user's phrasing happened to lack a recognized verb.

It now routes through the shared `resolveActionArgs` + `SubactionsMap` substrate — the same path `plugins/plugin-goals/src/actions/goals.ts` already uses:

- Added `DOCUMENT_SUBACTIONS: SubactionsMap<DocumentSubAction>` — **route-only**, `required: []` everywhere. Per-subaction presence/invariant checks (valid id, non-empty text, resolvable source) stay in the individual handlers, which can recover values from the machine extractors. Each subaction's `optional` list mirrors the `DocumentActionParameters` keys its handler reads, so the resolver forwards them through.
- `validate` is now **service-presence only**: registers the documents search category, then `Boolean(runtime.getService(DocumentService.serviceType))`. Selection is already scoped by the declarative `contextGate { anyOf: ['documents'] }` + `roleGate`, so the action is no longer silently unselectable on phrasing.
- The handler resolves `{ subaction, params }` via `resolveActionArgs({ runtime, message, state, options, actionName: 'DOCUMENT', subactions: DOCUMENT_SUBACTIONS })` (planner-trust path first, single LLM extraction fallback), emits the standard clarification error on `!resolved.ok`, then branches on the resolved subaction.
- Deleted `inferSubAction`, `normalizeSubAction`, the `DOCUMENT_SUB_ACTIONS` `Set`, and the now-unused `getParams` helper (verified no external references repo-wide).

**Kept** the machine extractors — `getDocumentId` (UUID), `getFilePath`, `getUrl`, `URL_PATTERN`, `DOCUMENT_PATH_PATTERN`. Those extract *values* from text; they do not *decide* the subaction (#10471 KEEPs). The action's `parameters` schema enum is now derived from the subaction map keys.

## Why (the i18n / #10471 smell)

Matching the user's free-form text to choose which operation to run causes drift: phrasing decides behavior, the LLM's structured `action` value is ignored, and a missing verb makes the whole umbrella action disappear from candidate selection. Structured routing trusts the planner's enum output and falls back to a single explicit extraction pass.

## Behavior change

- A `DOCUMENT` invocation is now selected purely by the declarative gates; it is **no longer suppressed** when the user text lacks a recognized verb.
- The subaction is taken from the structured `action` parameter (planner-trust path, synchronous, no model call) or a single bounded extraction pass — never from keyword regexes over the user message.
- Conflicting NL keywords (e.g. text saying "delete" while `action: "list"`) no longer override the structured choice.

## Verification

- `bun x tsc --noEmit -p packages/core/tsconfig.json` — clean for touched files (only the pre-existing worktree-env `../ui/` + `validation-keyword-data` artifacts remain, unrelated to this change).
- `bun x @biomejs/biome lint` on both changed files — clean.
- `bun x vitest run src/features/documents/` — **56/56 pass**, including 8 new tests in `__tests__/actions-routing.test.ts` asserting: `validate` is service-presence only (and registers the search category); the handler routes on the structured `action` value while ignoring conflicting NL keywords with **no model call** on the planner-trust path; structured `documentId` is forwarded to `read`; and service-unavailable surfaces correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)