### PR TITLE
fix(cloud): payout recovery escalates ambiguous stale locks instead of re-paying (#10588)

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/payout-stale-lock-recovery.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/payout-stale-lock-recovery.test.ts
@@ -9,12 +9,16 @@
  * `status='approved'`, and approved rows always have a NULL
  * `processing_started_at`, so it was unreachable dead code.
  *
- * The fix adds a SEPARATE recovery pass over stuck `processing` rows that
- * re-approves a row ONLY when it provably never broadcast a transaction
- * (`broadcast_tx_hash IS NULL`). The broadcast hash is persisted the instant the
- * transaction is broadcast — before confirmation — so recovery can tell
- * "never broadcast" (safe to retry) from "broadcast, awaiting confirmation"
- * (must reconcile on-chain; re-broadcasting would DOUBLE-PAY).
+ * The fix adds a SEPARATE recovery pass over stuck `processing` rows. A row that
+ * already broadcast a transaction (`broadcast_tx_hash IS NOT NULL`) is surfaced
+ * for on-chain reconciliation, never re-broadcast.
+ *
+ * #10588 hardening: a row with NO recorded broadcast (`broadcast_tx_hash IS NULL`)
+ * is NO LONGER auto-re-approved for retry. A null hash does not prove the tx was
+ * never broadcast — a worker can die between broadcasting the transaction and
+ * persisting its hash — so re-approving would re-broadcast and DOUBLE-PAY. Such
+ * rows are now escalated to `failed` + `requires_review` for human / on-chain
+ * verification instead.
  *
  * These tests run the REAL `PayoutProcessorService.processBatch` against
  * in-process PGlite. Only the chain clients (viem) and the RPC/env helpers are
@@ -135,9 +139,11 @@ async function readRedemption(id: string): Promise<{
   tx_hash: string | null;
   retry_count: string;
   processing_started_at: string | null;
+  requires_review: number;
 }> {
   const rows = await dbWrite.execute(
-    `SELECT status, broadcast_tx_hash, tx_hash, retry_count, processing_started_at
+    `SELECT status, broadcast_tx_hash, tx_hash, retry_count, processing_started_at,
+            (requires_review)::int AS requires_review
      FROM token_redemptions WHERE id = '${id}';`,
   );
   return rows.rows[0] as {
@@ -146,6 +152,7 @@ async function readRedemption(id: string): Promise<{
     tx_hash: string | null;
     retry_count: string;
     processing_started_at: string | null;
+    requires_review: number;
   };
 }
 
@@ -251,7 +258,7 @@ beforeEach(async () => {
 
 describe("payout stale-lock recovery (#10553)", () => {
   test(
-    "(a) a stale 'processing' row with NO broadcast hash is recovered, re-approved, and paid out",
+    "(a) a stale 'processing' row with NO recorded broadcast is escalated for review, NOT auto-re-paid (double-pay guard, #10588)",
     async () => {
       if (!pgliteReady) return;
       const id = await seedRedemption({
@@ -264,16 +271,16 @@ describe("payout stale-lock recovery (#10553)", () => {
       await service.processBatch();
 
       const row = await readRedemption(id);
-      // It started in 'processing' (NOT selectable by the approved-select), so
-      // reaching 'completed' proves recovery re-approved it and the batch then
-      // paid it out.
-      expect(row.status).toBe("completed");
-      expect(row.tx_hash).toBe(`0x${"b".repeat(64)}`);
-      expect(row.broadcast_tx_hash).toBe(`0x${"b".repeat(64)}`);
-      // recovery incremented retry_count on the way back to 'approved'.
-      expect(Number(row.retry_count)).toBe(1);
-      // A real transaction was broadcast exactly once.
-      expect(writeContractMock.mock.calls.length).toBe(1);
+      // A null broadcast hash does NOT prove the tx was never broadcast — the
+      // worker may have died between broadcasting and persisting the hash. So
+      // recovery must never auto-re-pay it (that would re-broadcast and
+      // double-pay); it is surfaced for human / on-chain review instead.
+      expect(row.status).toBe("failed");
+      expect(Number(row.requires_review)).toBe(1);
+      expect(row.broadcast_tx_hash).toBeNull();
+      expect(row.tx_hash).toBeNull();
+      // The load-bearing assertion: NO transaction was (re-)broadcast.
+      expect(writeContractMock.mock.calls.length).toBe(0);
     },
     PGLITE_TIMEOUT,
   );
@@ -386,20 +393,21 @@ describe("payout stale-lock recovery (#10553)", () => {
   );
 
   test(
-    "(f) a provably-safe stale row with retries exhausted is failed for manual intervention",
+    "(f) a stale 'processing' row with no broadcast is escalated regardless of retry_count",
     async () => {
       if (!pgliteReady) return;
       const id = await seedRedemption({
         status: "processing",
         broadcastTxHash: null,
         startedMinutesAgo: 10,
-        retryCount: 3, // == MAX_RETRY_ATTEMPTS
+        retryCount: 3, // recovery no longer keys off retry_count — all null-broadcast escalate
       });
 
       await service.processBatch();
 
       const row = await readRedemption(id);
       expect(row.status).toBe("failed");
+      expect(Number(row.requires_review)).toBe(1);
       expect(row.broadcast_tx_hash).toBeNull();
       // Never silently re-broadcast.
       expect(writeContractMock.mock.calls.length).toBe(0);

--- a/packages/cloud/shared/src/lib/services/payout-processor.ts
+++ b/packages/cloud/shared/src/lib/services/payout-processor.ts
@@ -33,7 +33,7 @@
  */
 
 import bs58 from "bs58";
-import { and, eq, gte, isNotNull, isNull, lt, sql } from "drizzle-orm";
+import { and, eq, isNotNull, isNull, lt, sql } from "drizzle-orm";
 import { type Address, createPublicClient, createWalletClient, http, parseUnits } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { dbRead, dbWrite } from "../../db/client";
@@ -269,33 +269,21 @@ export class PayoutProcessorService {
     const config = getPayoutConfig();
     const staleThreshold = new Date(Date.now() - config.LOCK_TIMEOUT_MS);
 
-    // (1) Provably-safe, retries remaining → re-approve for retry.
-    const reapproved = await dbWrite
-      .update(tokenRedemptions)
-      .set({
-        status: "approved",
-        processing_started_at: null,
-        processing_worker_id: null,
-        failure_reason: "Recovered stale processing lock (no broadcast detected)",
-        retry_count: sql`${tokenRedemptions.retry_count} + 1`,
-        updated_at: new Date(),
-      })
-      .where(
-        and(
-          eq(tokenRedemptions.status, "processing"),
-          lt(tokenRedemptions.processing_started_at, staleThreshold),
-          isNull(tokenRedemptions.broadcast_tx_hash),
-          lt(sql`CAST(${tokenRedemptions.retry_count} AS INTEGER)`, config.MAX_RETRY_ATTEMPTS),
-        ),
-      )
-      .returning({ id: tokenRedemptions.id });
-
-    // (2) Provably-safe, retries exhausted → fail (manual intervention).
-    const exhausted = await dbWrite
+    // (1) No broadcast hash recorded → do NOT auto-retry. A null broadcast hash
+    // usually means the worker died before broadcasting, but it can ALSO mean it
+    // died in the window between the transaction being broadcast (writeContract /
+    // sendRawTransaction returning) and the hash being persisted by
+    // recordBroadcast. Re-approving such a row would re-broadcast and DOUBLE-PAY
+    // (#10588). Because we cannot prove it never broadcast, surface it for human /
+    // on-chain review instead of auto-retrying — the same fail-safe posture
+    // already applied to broadcast-but-unconfirmed rows in (2).
+    const escalated = await dbWrite
       .update(tokenRedemptions)
       .set({
         status: "failed",
-        failure_reason: "Stale processing lock exceeded MAX_RETRY_ATTEMPTS (no broadcast detected)",
+        failure_reason:
+          "Stale processing lock with no recorded broadcast — a payout may have been broadcast before the worker died; verify on-chain before resolving (not auto-retried to avoid double-pay)",
+        requires_review: true,
         processing_started_at: null,
         processing_worker_id: null,
         updated_at: new Date(),
@@ -305,12 +293,11 @@ export class PayoutProcessorService {
           eq(tokenRedemptions.status, "processing"),
           lt(tokenRedemptions.processing_started_at, staleThreshold),
           isNull(tokenRedemptions.broadcast_tx_hash),
-          gte(sql`CAST(${tokenRedemptions.retry_count} AS INTEGER)`, config.MAX_RETRY_ATTEMPTS),
         ),
       )
       .returning({ id: tokenRedemptions.id });
 
-    // (3) Broadcast-but-unconfirmed → NEVER re-approve. Surface for reconciliation.
+    // (2) Broadcast-but-unconfirmed → NEVER re-approve. Surface for reconciliation.
     const stuck = await dbWrite
       .select({
         id: tokenRedemptions.id,
@@ -326,16 +313,16 @@ export class PayoutProcessorService {
         ),
       );
 
-    if (reapproved.length > 0) {
-      logger.warn("[PayoutProcessor] Recovered stale processing locks for retry", {
-        count: reapproved.length,
-        redemptionIds: reapproved.map((r) => r.id),
-      });
-    }
-    if (exhausted.length > 0) {
-      logger.error("[PayoutProcessor] Stale processing locks exhausted retries; marked failed", {
-        count: exhausted.length,
-        redemptionIds: exhausted.map((r) => r.id),
+    if (escalated.length > 0) {
+      logger.error(
+        "[PayoutProcessor] Stale processing locks with no recorded broadcast escalated for review (NOT auto-retried to avoid double-pay)",
+        { count: escalated.length, redemptionIds: escalated.map((r) => r.id) },
+      );
+      void payoutAlertsService.sendAlert({
+        severity: "high",
+        title: "Payout stuck — stale lock, no recorded broadcast",
+        message: `${escalated.length} redemption(s) held a processing lock past the timeout with no recorded broadcast hash. They are NOT auto-retried — a transaction may have been broadcast before the worker died. Verify on-chain and resolve manually.`,
+        details: { redemptionIds: escalated.map((r) => r.id) },
       });
     }
     if (stuck.length > 0) {


### PR DESCRIPTION
## What

Closes the residual double-pay window described in #10588 (follow-up to #10553 / #10571).

#10571 added payout stale-lock recovery that re-approves a stuck `processing` row for retry when it "provably never broadcast" (`broadcast_tx_hash IS NULL`). But a null broadcast hash does **not** prove the transaction was never broadcast: `executeEvmPayout` broadcasts at `writeContract` (the tx is in the mempool) and only *then* persists the hash via `recordBroadcast` — two separate awaits. A worker SIGKILLed/evicted **in that gap** leaves `broadcast_tx_hash` NULL though the tx was already broadcast. Recovery then re-approves it → the retry re-broadcasts (next nonce; the first tx has since mined) → **a second on-chain transfer of the same redemption.** Same shape on Solana (`sendRawTransaction` → `recordBroadcast`).

## The fix (surgical — the live payout path is untouched)

In `recoverStaleProcessing`, a stale `processing` row with **no recorded broadcast** is **no longer auto-re-approved**. Because we cannot prove it never broadcast, it is escalated to `status='failed'` + `requires_review=true` (with a clear `failure_reason`) and an ops alert, for human / on-chain verification — the same fail-safe posture the merged code already applies to broadcast-but-unconfirmed rows. Recovery therefore **never re-broadcasts an ambiguous row**, which closes the window.

This intentionally touches **only the recovery branch** — `executeEvmPayout` / `executeSolanaPayout` (the path that moves real money) are not modified, so there is **zero regression risk to the happy payout path**. Stuck rows are still recovered out of the dead `processing` state (the #10553 bug); they're routed to review instead of auto-retried.

The trade-off: a worker that dies mid-payout before broadcasting (rare) now needs an operator to confirm-and-resolve rather than auto-retrying. Given how rare mid-payout worker death is, and that the alternative is a real (if narrow) double-pay, the conservative posture is the right default for money movement.

### Alternative considered (not taken here)
**Sign-then-send** would keep the auto-retry: derive the EVM tx hash from the locally-signed tx (`signTransaction` → `keccak256(serialized)`) and persist it *before* `sendRawTransaction` (Solana: the signature is deterministic pre-send), making `broadcast_tx_hash IS NULL ⇒ never broadcast` airtight. It's the "complete" fix but it rewrites the live broadcast path (nonce/gas management, new failure modes) — more regression risk on just-merged money code. Happy to switch this PR to that approach if maintainers prefer to preserve auto-retry; flagged in #10588.

## Tests — real DB, no larp

Updates the existing `__tests__/payout-stale-lock-recovery.test.ts` (real in-process PGlite; only the chain client mocked):
- **(a)** rewritten: a stale row with no recorded broadcast is now **escalated for review, NOT auto-re-paid** (`status='failed'`, `requires_review=1`, `writeContract` never called) — the direct window-closure assertion.
- **(f)** updated: null-broadcast stale rows escalate **regardless of `retry_count`**.
- (b) broadcast-row-not-re-approved, (c) batch-isolation, (d) hash-persisted-at-broadcast, (e) fresh-lock-left-alone — unchanged and still green (the broadcast/in-batch/fresh paths aren't touched).

`bun test`: all green (real PGlite). `tsgo` typecheck + biome: clean.

Money-path change — **not self-merged; requesting maintainer review.** This came out of a 9-agent adversarial review of #10571.
