### PR TITLE
fix(plugin-wallet): structured amountMode for EVM relative swaps (#10471)

### DIFF
--- a/plugins/plugin-wallet/src/chains/evm/__tests__/unit/swap-amount-mode.test.ts
+++ b/plugins/plugin-wallet/src/chains/evm/__tests__/unit/swap-amount-mode.test.ts
@@ -1,0 +1,225 @@
+import type { IAgentRuntime, Memory, State } from "@elizaos/core";
+import { base } from "viem/chains";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildSwapDetails } from "../../actions/swap";
+import type { WalletProvider } from "../../providers/wallet";
+
+// Control the raw LLM output so we can assert the structured amountMode →
+// absolute-amount resolution in isolation from any model call.
+const runIntentModel = vi.fn<(...args: unknown[]) => Promise<string>>();
+vi.mock("../../../../utils/intent-trajectory", () => ({
+  runIntentModel: (...args: unknown[]) => runIntentModel(...args),
+}));
+
+const WETH = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+const USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+
+// base mainnet native balance, as a decimal string (the shape getWalletBalances returns)
+const BASE_BALANCE = "2"; // 2.0 ETH
+
+function createWalletProvider(
+  balances: Record<string, string> = { base: BASE_BALANCE }
+): WalletProvider {
+  return {
+    chains: { base },
+    getSupportedChains: () => ["base"],
+    getChainConfigs: () => base,
+    getWalletBalances: async () => balances,
+  } as unknown as WalletProvider;
+}
+
+function createRuntime(): IAgentRuntime {
+  const state = {} as State;
+  return {
+    composeState: vi.fn(async () => state),
+  } as unknown as IAgentRuntime;
+}
+
+const message = { content: { text: "swap stuff" } } as Memory;
+
+function llmJson(obj: Record<string, unknown>): void {
+  runIntentModel.mockResolvedValue(JSON.stringify(obj));
+}
+
+describe("buildSwapDetails amountMode resolution", () => {
+  beforeEach(() => {
+    runIntentModel.mockReset();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("passes through an absolute amount unchanged", async () => {
+    llmJson({
+      inputToken: WETH,
+      outputToken: USDC,
+      amountMode: "absolute",
+      amount: "0.5",
+      chain: "base",
+    });
+
+    const details = await buildSwapDetails(
+      {} as State,
+      message,
+      createRuntime(),
+      createWalletProvider()
+    );
+
+    expect(details.amount).toBe("0.5");
+    expect(details.chain).toBe("base");
+    expect(details.fromToken).toBe(WETH);
+    expect(details.toToken).toBe(USDC);
+  });
+
+  it("treats a missing/unknown amountMode as absolute", async () => {
+    llmJson({
+      inputToken: WETH,
+      outputToken: USDC,
+      amount: "1.25",
+      chain: "base",
+    });
+
+    const details = await buildSwapDetails(
+      {} as State,
+      message,
+      createRuntime(),
+      createWalletProvider()
+    );
+
+    expect(details.amount).toBe("1.25");
+  });
+
+  it("resolves half to balance / 2", async () => {
+    llmJson({
+      inputToken: WETH,
+      outputToken: USDC,
+      amountMode: "half",
+      chain: "base",
+    });
+
+    const details = await buildSwapDetails(
+      {} as State,
+      message,
+      createRuntime(),
+      createWalletProvider({ base: "2" })
+    );
+
+    expect(details.amount).toBe("1"); // 2 / 2
+  });
+
+  it("resolves max to balance * 0.9 (gas reserve)", async () => {
+    llmJson({
+      inputToken: WETH,
+      outputToken: USDC,
+      amountMode: "max",
+      chain: "base",
+    });
+
+    const details = await buildSwapDetails(
+      {} as State,
+      message,
+      createRuntime(),
+      createWalletProvider({ base: "10" })
+    );
+
+    expect(details.amount).toBe("9"); // 10 * 0.9
+  });
+
+  it("resolves percent to balance * amountPercent / 100", async () => {
+    llmJson({
+      inputToken: WETH,
+      outputToken: USDC,
+      amountMode: "percent",
+      amountPercent: 30,
+      chain: "base",
+    });
+
+    const details = await buildSwapDetails(
+      {} as State,
+      message,
+      createRuntime(),
+      createWalletProvider({ base: "10" })
+    );
+
+    expect(details.amount).toBe("3"); // 10 * 30 / 100
+  });
+
+  it("accepts a numeric percent supplied as a string", async () => {
+    llmJson({
+      inputToken: WETH,
+      outputToken: USDC,
+      amountMode: "percent",
+      amountPercent: "25",
+      chain: "base",
+    });
+
+    const details = await buildSwapDetails(
+      {} as State,
+      message,
+      createRuntime(),
+      createWalletProvider({ base: "8" })
+    );
+
+    expect(details.amount).toBe("2"); // 8 * 25 / 100
+  });
+
+  it("throws INVALID_PARAMS when the chain balance is unknown for a relative mode", async () => {
+    llmJson({
+      inputToken: WETH,
+      outputToken: USDC,
+      amountMode: "half",
+      chain: "base",
+    });
+
+    await expect(
+      buildSwapDetails(
+        {} as State,
+        message,
+        createRuntime(),
+        // no balance entry for "base"
+        createWalletProvider({})
+      )
+    ).rejects.toThrow(/unknown balance/i);
+  });
+
+  it("throws INVALID_PARAMS when percent is out of range (0)", async () => {
+    llmJson({
+      inputToken: WETH,
+      outputToken: USDC,
+      amountMode: "percent",
+      amountPercent: 0,
+      chain: "base",
+    });
+
+    await expect(
+      buildSwapDetails({} as State, message, createRuntime(), createWalletProvider({ base: "5" }))
+    ).rejects.toThrow(/between 1 and 100/i);
+  });
+
+  it("throws INVALID_PARAMS when percent is out of range (150)", async () => {
+    llmJson({
+      inputToken: WETH,
+      outputToken: USDC,
+      amountMode: "percent",
+      amountPercent: 150,
+      chain: "base",
+    });
+
+    await expect(
+      buildSwapDetails({} as State, message, createRuntime(), createWalletProvider({ base: "5" }))
+    ).rejects.toThrow(/between 1 and 100/i);
+  });
+
+  it("throws INVALID_PARAMS when percent mode omits amountPercent", async () => {
+    llmJson({
+      inputToken: WETH,
+      outputToken: USDC,
+      amountMode: "percent",
+      chain: "base",
+    });
+
+    await expect(
+      buildSwapDetails({} as State, message, createRuntime(), createWalletProvider({ base: "5" }))
+    ).rejects.toThrow(/between 1 and 100/i);
+  });
+});

--- a/plugins/plugin-wallet/src/chains/evm/actions/swap.ts
+++ b/plugins/plugin-wallet/src/chains/evm/actions/swap.ts
@@ -777,14 +777,25 @@ export async function buildSwapDetails(
     );
   }
 
-  const rawParams = {
+  const chain = String(parsedResponse.chain ?? "").toLowerCase();
+  const amountMode = resolveAmountMode(parsedResponse.amountMode);
+
+  // `chain` is an arbitrary lowercased string from the model, so the balance
+  // lookup is honestly `string | undefined` (resolveRelativeAmount throws when
+  // it is undefined). Validation of the chain itself happens via parseSwapParams.
+  const chainBalance: string | undefined = (balances as Record<string, string | undefined>)[chain];
+
+  const amount =
+    amountMode === "absolute"
+      ? String(parsedResponse.amount ?? "")
+      : resolveRelativeAmount(amountMode, parsedResponse.amountPercent, chainBalance);
+
+  const swapDetails = parseSwapParams({
     fromToken: String(parsedResponse.inputToken ?? ""),
     toToken: String(parsedResponse.outputToken ?? ""),
-    amount: String(parsedResponse.amount ?? ""),
-    chain: String(parsedResponse.chain ?? "").toLowerCase(),
-  };
-
-  const swapDetails = parseSwapParams(rawParams);
+    amount,
+    chain,
+  });
 
   if (!wp.chains[swapDetails.chain]) {
     throw new EVMError(
@@ -793,35 +804,51 @@ export async function buildSwapDetails(
     );
   }
 
-  const messageText = (message.content.text ?? "").toLowerCase();
-  if (swapDetails.amount === "null") {
-    const balance = balances[swapDetails.chain];
-    if (balance) {
-      if (messageText.includes("half") || messageText.includes("50%")) {
-        return { ...swapDetails, amount: (parseFloat(balance) / 2).toString() };
-      }
-      if (
-        messageText.includes("all") ||
-        messageText.includes("100%") ||
-        messageText.includes("everything")
-      ) {
-        return {
-          ...swapDetails,
-          amount: (parseFloat(balance) * 0.9).toString(),
-        };
-      }
-      const percentMatch = messageText.match(/(\d+)%/);
-      if (percentMatch) {
-        const percentage = parseInt(percentMatch[1], 10) / 100;
-        return {
-          ...swapDetails,
-          amount: (parseFloat(balance) * percentage).toString(),
-        };
-      }
-    }
+  return swapDetails;
+}
+
+const AMOUNT_MODES = ["absolute", "half", "max", "percent"] as const;
+type AmountMode = (typeof AMOUNT_MODES)[number];
+
+function resolveAmountMode(value: unknown): AmountMode {
+  return AMOUNT_MODES.includes(value as AmountMode) ? (value as AmountMode) : "absolute";
+}
+
+/**
+ * Resolve a relative swap size ("half"/"max"/"percent") into an absolute,
+ * human-readable amount string from the connected chain's native balance.
+ * `max` keeps a 10% gas reserve (0.9 * balance). Throws INVALID_PARAMS when the
+ * balance for the chain is unknown or a percentage is out of the 1-100 range.
+ */
+function resolveRelativeAmount(
+  mode: Exclude<AmountMode, "absolute">,
+  rawPercent: unknown,
+  balance: string | undefined
+): string {
+  if (balance === undefined) {
+    throw new EVMError(
+      EVMErrorCode.INVALID_PARAMS,
+      `Cannot resolve a relative swap amount: unknown balance for the selected chain.`
+    );
   }
 
-  return swapDetails;
+  const balanceNum = parseFloat(balance);
+
+  if (mode === "half") {
+    return (balanceNum / 2).toString();
+  }
+  if (mode === "max") {
+    return (balanceNum * 0.9).toString();
+  }
+
+  const percent = Number(rawPercent);
+  if (!Number.isFinite(percent) || percent < 1 || percent > 100) {
+    throw new EVMError(
+      EVMErrorCode.INVALID_PARAMS,
+      `Swap percentage must be between 1 and 100, received: ${String(rawPercent)}`
+    );
+  }
+  return ((balanceNum * percent) / 100).toString();
 }
 
 export const swapAction = {

--- a/plugins/plugin-wallet/src/chains/evm/prompts.ts
+++ b/plugins/plugin-wallet/src/chains/evm/prompts.ts
@@ -118,13 +118,22 @@ export const swapTemplate = `Given the recent messages and wallet information be
 Extract the following information about the requested token swap:
 - Input token symbol or address (the token being sold)
 - Output token symbol or address (the token being bought)
-- Amount to swap: Must be a string representing the amount in ether (only number without coin symbol, e.g., "0.1")
+- How much to swap, expressed structurally:
+  - amountMode: one of "absolute", "half", "max", "percent"
+    - "absolute" when the user named a concrete amount (e.g. "swap 1.5 ETH")
+    - "half" when the user wants half of their balance (e.g. "half", "50%", "mitad")
+    - "max" when the user wants all of their balance (e.g. "all", "everything", "100%", "todo")
+    - "percent" when the user named a different percentage (e.g. "30%", "swap 30% of my ETH")
+  - amount: the concrete number as a string, only when amountMode is "absolute" (e.g. "0.1"); empty otherwise
+  - amountPercent: the integer percentage 1-100, only when amountMode is "percent"; empty otherwise
 - Chain to execute on
 
 Respond using plain key/value text like this:
 inputToken: token symbol or address being sold, or empty
 outputToken: token symbol or address being bought, or empty
-amount: amount as string (e.g. 0.1), or empty
+amountMode: one of absolute | half | max | percent
+amount: amount as string (e.g. 0.1) when amountMode is absolute, otherwise empty
+amountPercent: integer 1-100 when amountMode is percent, otherwise empty
 chain: chain from {{supportedChains}}, or empty
 
 IMPORTANT: Your response must ONLY contain the key/value fields above. No preamble or explanation.`;


### PR DESCRIPTION
## What changed

`buildSwapDetails` (EVM swap) previously resolved a *relative* swap size ("swap half my ETH for USDC") by scanning the **user's natural-language `message.content.text`** with `.includes("half" / "50%" / "all" / "everything")`. That is the exact #10471 smell — matching the user's NL text to decide behavior.

This PR replaces the text scan with a structured extraction enum on the **planner/model output** (a #10471 KEEP):

- **`swapTemplate`** (`prompts.ts`) now extracts:
  - `amountMode` — one of `absolute | half | max | percent`
  - `amount` — filled only when `amountMode === absolute`
  - `amountPercent` — integer `1-100`, only when `amountMode === percent`

  The template already injects `{{chainBalances}}`, so the model sees the balances.
- **`buildSwapDetails`** (`swap.ts`) now reads `amountMode` (default `absolute`, clamped to the 4-value union) and resolves the **absolute** amount from the connected chain's native balance **before** calling `parseSwapParams`:
  - `half` → `balance / 2`
  - `max` → `balance * 0.9` (keeps the existing 10% gas reserve)
  - `percent` → `balance * amountPercent / 100`
  - throws `EVMError(INVALID_PARAMS)` on an unknown chain balance or a percent outside `1-100`.
- The dead `messageText.includes(...)` ladder is **deleted**.

## Why (the i18n smell + a real bug)

Two problems with the old code:

1. **i18n-hostile.** The `.includes(...)` ladder only matched English substrings. "Intercambia la mitad…" (ES) or "把我全部的…" (ZH) never matched.
2. **Already dead / broken.** `parseSwapParams` uses `AmountSchema`, which requires `amount > 0`. When the model returned `amount === 'null'`/empty, `parseSwapParams` **threw** *before* the includes-ladder could run. So relative swaps were broken outright. Resolving the amount up-front and only then calling `parseSwapParams` is a **net fix** — relative swaps now actually work, in any language.

`amountMode` is the model's structured English-enum output, not the user's raw text, so this is a KEEP, not a new smell.

No `swapAction.parameters` schema was added (confirmed dead — the handler ignores `_options` and re-extracts via the template).

## Verification

- `bun x tsc --noEmit -p plugins/plugin-wallet/tsconfig.json` → clean.
- `biome lint` on `swap.ts`, `prompts.ts`, and the new test → clean.
- New unit tests (`swap-amount-mode.test.ts`, 10 cases) cover the resolution math (`half`/`max`/`percent` over a known balance, string-percent) and the error cases (unknown balance, percent `0`/`150`/missing). Ran with the existing `chain-handler` + `wallet-router` suites: **22/22 pass**.
- **Live model probe** (`gpt-oss-120b` @ Cerebras, `temp 0`) against the new template — it emits the correct `amountMode` across languages (the old English-substring ladder missed ES/ZH entirely):

  | input | amountMode | amount/percent |
  |---|---|---|
  | `swap half my ETH for USDC on base` | `half` | — |
  | `Intercambia la mitad de mis ETH por USDC en base` (ES) | `half` | — |
  | `把我全部的 ETH 换成 USDC，在 base 上` (ZH, "all") | `max` | — |
  | `Trade 30% of my ETH balance into USDC on base` | `percent` | `amountPercent: 30` |
  | `swap 1.5 ETH for USDC on base` | `absolute` | `amount: 1.5` |

## Behavior change

Relative-amount swaps (`half` / `max` / `percent`) now resolve correctly to an absolute amount and execute (previously they threw). Resolution is identical math to the old intended behavior (half=½, max=0.9×, percent=%), but now driven by a language-independent structured enum and gated on a known balance / valid percent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)