### PR TITLE
fix(cloud): close the broadcast→persist double-pay window in payout recovery (#10588)

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/payout-stale-lock-recovery.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/payout-stale-lock-recovery.test.ts
@@ -11,10 +11,12 @@
  *
  * The fix adds a SEPARATE recovery pass over stuck `processing` rows that
  * re-approves a row ONLY when it provably never broadcast a transaction
- * (`broadcast_tx_hash IS NULL`). The broadcast hash is persisted the instant the
- * transaction is broadcast — before confirmation — so recovery can tell
+ * (`broadcast_tx_hash IS NULL`). The broadcast hash is persisted BEFORE the
+ * transaction is broadcast (#10588: EVM signs locally then sends a raw tx; Solana
+ * records the deterministic signature before the raw send) — so recovery can tell
  * "never broadcast" (safe to retry) from "broadcast, awaiting confirmation"
- * (must reconcile on-chain; re-broadcasting would DOUBLE-PAY).
+ * (must reconcile on-chain; re-broadcasting would DOUBLE-PAY). The previous flow
+ * recorded the hash AFTER the broadcast, leaving a sub-second double-pay window.
  *
  * These tests run the REAL `PayoutProcessorService.processBatch` against
  * in-process PGlite. Only the chain clients (viem) and the RPC/env helpers are
@@ -38,9 +40,30 @@ const FAIL_ADDRESS = "0x000000000000000000000000000000000000fa11";
 const OK_ADDRESS = "0x0000000000000000000000000000000000000111";
 
 // --- Chain client stubs (the only things that hit the network) ----------------
-const writeContractMock = mock(async (_args: { args: [string, bigint] }) => `0x${"b".repeat(64)}`);
+// #10588: executeEvmPayout now signs LOCALLY (prepare → sign → keccak256),
+// persists the hash, and only THEN broadcasts (sendRawTransaction). The recipient
+// is encoded in the signed calldata, so we decode it to let a test fail one
+// specific payout. The broadcast hash is keccak256 of the (fixed, valid-hex)
+// signed tx, computed with real viem so the DB value is deterministic.
+const TRANSFER_ABI = realViem.parseAbi([
+  "function transfer(address to, uint256 amount) returns (bool)",
+]);
+const SIGNED_TX = `0x${"ab".repeat(120)}` as const;
+const BROADCAST_HASH = realViem.keccak256(SIGNED_TX);
+
+const prepareTxMock = mock(async (args: { data: `0x${string}` }) => ({ ...args, nonce: 0 }));
+const signTxMock = mock(async () => SIGNED_TX);
+const sendRawTxMock = mock(
+  async (_args: { serializedTransaction: `0x${string}` }) => BROADCAST_HASH,
+);
 const waitReceiptMock = mock(async (_args: { hash: string }) => ({ status: "success" as const }));
 const readContractMock = mock(async () => 10n ** 30n); // hot-wallet balance: always sufficient
+
+/** Decode the ERC-20 transfer recipient from prepared calldata (real viem). */
+function recipientOf(data: `0x${string}`): string {
+  const decoded = realViem.decodeFunctionData({ abi: TRANSFER_ABI, data });
+  return (decoded.args[0] as string).toLowerCase();
+}
 
 // Keep the real env (so the db client still resolves DATABASE_URL=pglite://memory)
 // and only inject the EVM hot-wallet key. Solana stays unconfigured.
@@ -54,14 +77,18 @@ mock.module("../../config/evm-rpc", () => ({
 }));
 
 // Spread the real viem module (token-constants pulls parseAbi, parseUnits, …
-// from it) and override only the two client factories so no RPC is hit.
+// from it) and override only the client factories so no RPC is hit.
 mock.module("viem", () => ({
   ...realViem,
   createPublicClient: () => ({
     readContract: readContractMock,
     waitForTransactionReceipt: waitReceiptMock,
   }),
-  createWalletClient: () => ({ writeContract: writeContractMock }),
+  createWalletClient: () => ({
+    prepareTransactionRequest: prepareTxMock,
+    signTransaction: signTxMock,
+    sendRawTransaction: sendRawTxMock,
+  }),
 }));
 
 mock.module("viem/accounts", () => ({
@@ -239,11 +266,18 @@ beforeEach(async () => {
   await dbWrite.execute(`DELETE FROM redeemable_earnings_ledger;`);
   await dbWrite.execute(`DELETE FROM redeemable_earnings;`);
 
-  writeContractMock.mockReset();
+  prepareTxMock.mockReset();
+  signTxMock.mockReset();
+  sendRawTxMock.mockReset();
   waitReceiptMock.mockReset();
   readContractMock.mockReset();
   sendAlertMock.mockReset();
-  writeContractMock.mockImplementation(async () => `0x${"b".repeat(64)}`);
+  prepareTxMock.mockImplementation(async (args: { data: `0x${string}` }) => ({
+    ...args,
+    nonce: 0,
+  }));
+  signTxMock.mockImplementation(async () => SIGNED_TX);
+  sendRawTxMock.mockImplementation(async () => BROADCAST_HASH);
   waitReceiptMock.mockImplementation(async () => ({ status: "success" as const }));
   readContractMock.mockImplementation(async () => 10n ** 30n);
   sendAlertMock.mockImplementation(async () => undefined);
@@ -268,12 +302,12 @@ describe("payout stale-lock recovery (#10553)", () => {
       // reaching 'completed' proves recovery re-approved it and the batch then
       // paid it out.
       expect(row.status).toBe("completed");
-      expect(row.tx_hash).toBe(`0x${"b".repeat(64)}`);
-      expect(row.broadcast_tx_hash).toBe(`0x${"b".repeat(64)}`);
+      expect(row.tx_hash).toBe(BROADCAST_HASH);
+      expect(row.broadcast_tx_hash).toBe(BROADCAST_HASH);
       // recovery incremented retry_count on the way back to 'approved'.
       expect(Number(row.retry_count)).toBe(1);
       // A real transaction was broadcast exactly once.
-      expect(writeContractMock.mock.calls.length).toBe(1);
+      expect(sendRawTxMock.mock.calls.length).toBe(1);
     },
     PGLITE_TIMEOUT,
   );
@@ -298,7 +332,7 @@ describe("payout stale-lock recovery (#10553)", () => {
       expect(row.broadcast_tx_hash).toBe(broadcastHash);
       expect(row.tx_hash).toBeNull();
       // The load-bearing assertion: NO new transaction was broadcast.
-      expect(writeContractMock.mock.calls.length).toBe(0);
+      expect(sendRawTxMock.mock.calls.length).toBe(0);
       // It is surfaced for on-chain reconciliation.
       expect(sendAlertMock.mock.calls.length).toBe(1);
     },
@@ -309,13 +343,16 @@ describe("payout stale-lock recovery (#10553)", () => {
     "(c) a throw in one redemption does not abort the batch",
     async () => {
       if (!pgliteReady) return;
-      // r1 will throw at broadcast (before any tx is sent); r2 must still pay out.
+      // r1 throws at PREPARE (before signing/recording/sending — genuinely
+      // pre-broadcast); r2 must still pay out.
       const r1 = await seedRedemption({ status: "approved", payoutAddress: FAIL_ADDRESS });
       const r2 = await seedRedemption({ status: "approved", payoutAddress: OK_ADDRESS });
 
-      writeContractMock.mockImplementation(async (call: { args: [string, bigint] }) => {
-        if (call.args[0] === FAIL_ADDRESS) throw new Error("RPC connection reset");
-        return `0x${"b".repeat(64)}`;
+      prepareTxMock.mockImplementation(async (args: { data: `0x${string}` }) => {
+        if (recipientOf(args.data) === FAIL_ADDRESS.toLowerCase()) {
+          throw new Error("RPC connection reset");
+        }
+        return { ...args, nonce: 0 };
       });
 
       // Must not throw out of processBatch.
@@ -329,20 +366,18 @@ describe("payout stale-lock recovery (#10553)", () => {
       expect(Number(row1.retry_count)).toBe(1);
       // r2 was reached despite r1 throwing → paid out.
       expect(row2.status).toBe("completed");
-      expect(row2.tx_hash).toBe(`0x${"b".repeat(64)}`);
+      expect(row2.tx_hash).toBe(BROADCAST_HASH);
       expect(stats.processed).toBe(2);
     },
     PGLITE_TIMEOUT,
   );
 
   test(
-    "(d) the tx hash is persisted at BROADCAST time, before confirmation",
+    "(d) the tx hash is persisted BEFORE broadcast; an eviction during confirm leaves it for reconciliation",
     async () => {
       if (!pgliteReady) return;
-      const broadcastHash = `0x${"e".repeat(64)}`;
       const id = await seedRedemption({ status: "approved" });
 
-      writeContractMock.mockImplementation(async () => broadcastHash);
       // Simulate a worker eviction / RPC failure DURING the confirmation wait,
       // i.e. AFTER the transaction was already broadcast.
       waitReceiptMock.mockImplementation(async () => {
@@ -352,13 +387,39 @@ describe("payout stale-lock recovery (#10553)", () => {
       await service.processBatch();
 
       const row = await readRedemption(id);
-      // The broadcast hash was persisted the moment writeContract returned,
-      // BEFORE waitForTransactionReceipt threw.
-      expect(row.broadcast_tx_hash).toBe(broadcastHash);
+      // The broadcast hash was persisted before the raw send, so it is set even
+      // though confirmation threw.
+      expect(row.broadcast_tx_hash).toBe(BROADCAST_HASH);
       // It never confirmed, so it is not completed and not re-approved — it is
       // left in 'processing' for on-chain reconciliation (never re-broadcast).
       expect(row.tx_hash).toBeNull();
       expect(row.status).toBe("processing");
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "(d2) #10588: the broadcast hash is persisted BEFORE the raw send (window closed)",
+    async () => {
+      if (!pgliteReady) return;
+      const id = await seedRedemption({ status: "approved" });
+
+      // Capture the DB state at the EXACT moment the raw transaction is sent. If
+      // the hash is already persisted then, a worker death anywhere in the
+      // broadcast→persist gap can never leave a NULL-hash row that recovery would
+      // re-broadcast → the double-pay window is closed.
+      let hashAtSendTime: string | null | "UNSET" = "UNSET";
+      sendRawTxMock.mockImplementation(async () => {
+        hashAtSendTime = (await readRedemption(id)).broadcast_tx_hash;
+        return BROADCAST_HASH;
+      });
+
+      await service.processBatch();
+
+      // The hash was already committed when sendRawTransaction ran (not after it).
+      expect(hashAtSendTime).toBe(BROADCAST_HASH);
+      const row = await readRedemption(id);
+      expect(row.status).toBe("completed");
     },
     PGLITE_TIMEOUT,
   );
@@ -380,7 +441,7 @@ describe("payout stale-lock recovery (#10553)", () => {
       // Recovery must not steal a row from a worker still inside the timeout.
       expect(row.status).toBe("processing");
       expect(Number(row.retry_count)).toBe(0);
-      expect(writeContractMock.mock.calls.length).toBe(0);
+      expect(sendRawTxMock.mock.calls.length).toBe(0);
     },
     PGLITE_TIMEOUT,
   );
@@ -402,7 +463,7 @@ describe("payout stale-lock recovery (#10553)", () => {
       expect(row.status).toBe("failed");
       expect(row.broadcast_tx_hash).toBeNull();
       // Never silently re-broadcast.
-      expect(writeContractMock.mock.calls.length).toBe(0);
+      expect(sendRawTxMock.mock.calls.length).toBe(0);
     },
     PGLITE_TIMEOUT,
   );

--- a/packages/cloud/shared/src/lib/services/payout-processor.ts
+++ b/packages/cloud/shared/src/lib/services/payout-processor.ts
@@ -34,7 +34,15 @@
 
 import bs58 from "bs58";
 import { and, eq, gte, isNotNull, isNull, lt, sql } from "drizzle-orm";
-import { type Address, createPublicClient, createWalletClient, http, parseUnits } from "viem";
+import {
+  type Address,
+  createPublicClient,
+  createWalletClient,
+  encodeFunctionData,
+  http,
+  keccak256,
+  parseUnits,
+} from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { dbRead, dbWrite } from "../../db/client";
 import { redeemableEarnings, redeemableEarningsLedger } from "../../db/schemas/redeemable-earnings";
@@ -545,19 +553,41 @@ export class PayoutProcessorService {
       };
     }
 
-    // Execute transfer
-    const txHash = await walletClient.writeContract({
-      address: tokenAddress,
+    // Sign the transfer LOCALLY first so its hash is known BEFORE it is
+    // broadcast, then persist that hash BEFORE the raw send. This closes the
+    // residual double-pay window (#10588): the previous flow used
+    // `writeContract`, which broadcasts the tx and only THEN returns the hash, so
+    // a worker death in the gap between the broadcast and the recordBroadcast
+    // commit left a NULL-hash row that recovery re-approved → re-broadcast →
+    // double-pay. With sign → record → send, a NULL `broadcast_tx_hash` provably
+    // means the tx was never submitted (safe to re-approve), and anything from
+    // the send onward leaves the hash set (reconciled, never re-broadcast). The
+    // nonce is pinned by prepareTransactionRequest, so the recorded hash is the
+    // exact — and only — transaction that can reach the chain.
+    const data = encodeFunctionData({
       abi: ERC20_ABI,
       functionName: "transfer",
       args: [toAddress, amount],
     });
+    const preparedRequest = await walletClient.prepareTransactionRequest({
+      account,
+      to: tokenAddress,
+      data,
+      chain,
+    });
+    const serializedTransaction = await walletClient.signTransaction(
+      preparedRequest as Parameters<typeof walletClient.signTransaction>[0],
+    );
+    const txHash = keccak256(serializedTransaction);
 
-    // Persist the broadcast hash the INSTANT it is known — before waiting for
-    // confirmation. If this worker dies during the confirmation wait, recovery
-    // sees a non-NULL broadcast hash and will NOT re-approve (no double-pay);
-    // the redemption is reconciled on-chain instead.
+    // Persist BEFORE broadcasting. A crash before this commit means the tx was
+    // never sent (sendRawTransaction is below) → recovery safely re-approves.
     await this.recordBroadcast(redemption.id, txHash);
+
+    // Broadcast the pre-signed transaction. A throw here routes through
+    // handleProcessingThrow, which sees the persisted hash and reconciles rather
+    // than re-broadcasting.
+    await walletClient.sendRawTransaction({ serializedTransaction });
 
     // Wait for confirmation
     const receipt = await publicClient.waitForTransactionReceipt({
@@ -658,14 +688,29 @@ export class PayoutProcessorService {
     transaction.feePayer = this.solanaKeypair.publicKey;
     transaction.sign(this.solanaKeypair);
 
-    // Broadcast, then persist the signature BEFORE confirming — the same
-    // crash-recovery invariant as the EVM path. A recorded broadcast hash means
-    // recovery must never re-broadcast this payout (no double-pay); an expired
-    // blockhash / eviction during confirmation throws into processBatch's
-    // try/catch, which leaves the broadcast row in 'processing' for on-chain
-    // reconciliation rather than re-approving it.
-    const signature = await this.solanaConnection.sendRawTransaction(transaction.serialize());
+    // The signature (= the txid) is deterministic the INSTANT the transaction is
+    // signed — before it is sent — so persist it BEFORE the raw broadcast, the
+    // same as the EVM sign→record→send order (#10588). The previous flow sent
+    // first and recorded after, leaving the identical broadcast→persist window: a
+    // crash in that gap left a NULL-hash row that recovery re-approved and
+    // re-broadcast → double-pay. A recorded broadcast hash means recovery must
+    // never re-broadcast (no double-pay); an expired blockhash / eviction during
+    // confirmation throws into processBatch's try/catch, which leaves the
+    // broadcast row in 'processing' for on-chain reconciliation.
+    const serializedTransaction = transaction.serialize();
+    const signatureBytes = transaction.signature;
+    if (!signatureBytes) {
+      // Signing did not populate a signature — nothing was broadcast, safe to retry.
+      return {
+        success: false,
+        error: "Solana transaction has no signature after signing",
+        retryable: true,
+      };
+    }
+    const signature = bs58.encode(signatureBytes);
     await this.recordBroadcast(redemption.id, signature);
+
+    await this.solanaConnection.sendRawTransaction(serializedTransaction);
 
     const confirmation = await this.solanaConnection.confirmTransaction(
       { signature, blockhash, lastValidBlockHeight },


### PR DESCRIPTION
Closes #10588.

#10553 was fixed by #10571, which records `broadcast_tx_hash` and reconciles broadcast rows on-chain. #10588 flagged the one **residual double-pay window** the merged design leaves open, and (correctly) noted it's launch-bound money code where "a wrong fix double-pays."

## The window
In `executeEvmPayout` the merged flow broadcasts with `writeContract` and persists the hash **after** it returns:
```
const txHash = await walletClient.writeContract({...});  // tx is in the mempool (BROADCAST)
await this.recordBroadcast(redemption.id, txHash);        // persisted AFTER
```
A worker death in the sub-second gap between `writeContract` returning and the `recordBroadcast` UPDATE committing leaves a `status='processing'`, `broadcast_tx_hash=NULL` row. ~5 min later the recovery selector re-approves it (`broadcast_tx_hash IS NULL`) and the retry broadcasts a **second** transfer with the next nonce → **double-pay**. `executeSolanaPayout` had the identical shape (`sendRawTransaction` then `recordBroadcast`).

## Fix — Option A (the issue's recommended approach; keeps the merged auto-retry)
Persist the hash **before** the network send, so `broadcast_tx_hash IS NULL ⇒ never broadcast` is airtight:
- **EVM**: `encodeFunctionData` → `prepareTransactionRequest` (pins the nonce) → `signTransaction` → `keccak256(serialized)` → `recordBroadcast(hash)` → `sendRawTransaction`. A crash before the `recordBroadcast` commit means the tx was never sent (the raw send is after it) → recovery safely re-approves; anything from the send onward leaves the hash set → reconciled, never re-broadcast.
- **Solana**: the signature is deterministic the instant `transaction.sign()` runs, so record it (`bs58.encode(transaction.signature)`) **before** `sendRawTransaction` — same order as EVM.

This is a pure **ordering** hardening — the merged `recoverStaleProcessing` / `handleProcessingThrow` already route a hash-set row to reconciliation, so no new selectors or states.

## Evidence
- **7/7 pass against real PGlite** (`payout-stale-lock-recovery.test.ts`): all existing recovery cases updated to the sign→record→send flow (only the chain client mocked; the recovery SQL, lock, and persistence run for real), **plus a new case `(d2)`** that reads the DB row at the exact moment `sendRawTransaction` is invoked and asserts `broadcast_tx_hash` is **already** persisted — directly proving the window is closed.
- **Real viem validated against a local anvil node**: `keccak256(signedSerializedTx)` (the value we persist before broadcasting) == `sendRawTransaction`'s return == the mined `transactionHash` — so the recorded-before-broadcast hash *is* the real on-chain hash, and reconciliation can always match it.
- `bun run --cwd packages/cloud/shared typecheck` → exit 0; Biome clean.

## Note for the maintainer
#10588's author has **Option B** (escalate ambiguous null-hash stale rows to `requires_review` instead of auto-retrying) implemented as an alternative. This PR is **Option A** (recommended in the issue, keeps auto-retry, no manual-review burden on the rare ambiguous case). Only one should land — pick whichever you prefer; happy to defer. cc @lalalune

> ⚠️ Money-path change — **not self-merged.** Tracked on the coordination board #10561.