### PR TITLE
fix(cockpit): land 6 stranded correctness fixes (incl. credential leak) missed by #10544's squash

### DIFF
--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -9,7 +9,7 @@ export function getSegmenter(): Intl.Segmenter {
 
 /**
  * Check if a grapheme cluster (after segmentation) could possibly be an RGI emoji.
- * This is a fast heuristic to avoid the expensive rgiEmojiRegex test.
+ * This is a fast heuristic to avoid expensive exact emoji classification.
  * The tested Unicode blocks are deliberately broad so newer Unicode versions
  * keep matching likely emoji ranges.
  */
@@ -30,7 +30,13 @@ const zeroWidthRegex =
   /^(?:\p{Default_Ignorable_Code_Point}|\p{Control}|\p{Mark}|\p{Surrogate})+$/u;
 const leadingNonPrintingRegex =
   /^[\p{Default_Ignorable_Code_Point}\p{Control}\p{Format}\p{Mark}\p{Surrogate}]+/u;
-const rgiEmojiRegex = /^\p{RGI_Emoji}$/v;
+const sgrAndCursorRegex = new RegExp("\\x1b\\[[0-9;]*[mGKHJ]", "g");
+const osc8HyperlinkRegex = new RegExp("\\x1b\\]8;;[^\\x07]*\\x07", "g");
+const apcSequenceRegex = new RegExp(
+  "\\x1b_[^\\x07\\x1b]*(?:\\x07|\\x1b\\\\)",
+  "g",
+);
+const ansiSgrParamsRegex = new RegExp("\\x1b\\[([\\d;]*)m");
 
 // Cache for non-ASCII strings
 const WIDTH_CACHE_SIZE = 512;
@@ -39,7 +45,7 @@ const widthCache = new Map<string, number>();
 /**
  * Calculate the terminal width of a single grapheme cluster.
  * Based on code from the string-width library, but includes a possible-emoji
- * check to avoid running the RGI_Emoji regex unnecessarily.
+ * check to avoid exact emoji classification unnecessarily.
  */
 function graphemeWidth(segment: string): number {
   // Zero-width clusters
@@ -108,11 +114,11 @@ export function visibleWidth(str: string): number {
   }
   if (clean.includes("\x1b")) {
     // Strip SGR codes (\x1b[...m) and cursor codes (\x1b[...G/K/H/J)
-    clean = clean.replace(/\x1b\[[0-9;]*[mGKHJ]/g, "");
+    clean = clean.replace(sgrAndCursorRegex, "");
     // Strip OSC 8 hyperlinks: \x1b]8;;URL\x07 and \x1b]8;;\x07
-    clean = clean.replace(/\x1b\]8;;[^\x07]*\x07/g, "");
+    clean = clean.replace(osc8HyperlinkRegex, "");
     // Strip APC sequences: \x1b_...\x07 or \x1b_...\x1b\\ (used for cursor marker)
-    clean = clean.replace(/\x1b_[^\x07\x1b]*(?:\x07|\x1b\\)/g, "");
+    clean = clean.replace(apcSequenceRegex, "");
   }
 
   // Calculate width
@@ -206,7 +212,7 @@ class AnsiCodeTracker {
     }
 
     // Extract the parameters between \x1b[ and m
-    const match = ansiCode.match(/\x1b\[([\d;]*)m/);
+    const match = ansiCode.match(ansiSgrParamsRegex);
     if (!match) return;
 
     const params = match[1];

--- a/packages/ui/src/components/cockpit/CockpitView.tsx
+++ b/packages/ui/src/components/cockpit/CockpitView.tsx
@@ -39,8 +39,8 @@ export interface CockpitViewProps {
  *   - the **new-session** form (mode picker → create-task `providerPolicy`).
  *
  * The driver bubble (host chat) manages these rooms; tapping a room drills into
- * its focused session pane (transcript + `TaskInspector` controls + a real-CLI
- * terminal toggle + Fast/Smart tier toggle), and the bubble then drives THAT
+ * its focused session pane (transcript + `TaskInspector` controls + a terminal-
+ * output watch toggle + Fast/Smart tier toggle), and the bubble then drives THAT
  * task — all wired by the container (`CockpitRoute`). The "My Runtimes" switcher
  * lives in Settings.
  */

--- a/packages/ui/src/components/cockpit/MyRuntimesContainer.test.tsx
+++ b/packages/ui/src/components/cockpit/MyRuntimesContainer.test.tsx
@@ -82,17 +82,34 @@ describe("MyRuntimesContainer", () => {
     expect(screen.getByTestId("runtime-local-1-active")).toBeTruthy();
   });
 
-  it("hides the local runtime on an android-cloud build (phone gating)", () => {
+  it("hides a NON-active local runtime on an android-cloud build (phone gating)", () => {
     mocks.isAndroidCloudBuild.mockReturnValue(true);
+    mocks.loadAgentProfileRegistry.mockReturnValue({
+      ...REG,
+      activeProfileId: "vps-1",
+    });
     render(<MyRuntimesContainer />);
     expect(screen.queryByTestId("runtime-local-1")).toBeNull();
     expect(screen.getByTestId("runtime-vps-1")).toBeTruthy();
   });
 
-  it("hides the local runtime on a store build too", () => {
+  it("hides a non-active local runtime on a store build too", () => {
     mocks.isStoreBuild.mockReturnValue(true);
+    mocks.loadAgentProfileRegistry.mockReturnValue({
+      ...REG,
+      activeProfileId: "vps-1",
+    });
     render(<MyRuntimesContainer />);
     expect(screen.queryByTestId("runtime-local-1")).toBeNull();
+  });
+
+  it("keeps the ACTIVE local visible with its Active badge even when gated", () => {
+    // default REG: local-1 is the active profile. Under hideLocal it must stay
+    // visible (with the Active badge), else the UI shows no active runtime.
+    mocks.isAndroidCloudBuild.mockReturnValue(true);
+    render(<MyRuntimesContainer />);
+    expect(screen.getByTestId("runtime-local-1")).toBeTruthy();
+    expect(screen.getByTestId("runtime-local-1-active")).toBeTruthy();
   });
 
   it("refuses switching to local when gated, and does not call the switch", async () => {

--- a/packages/ui/src/components/cockpit/MyRuntimesContainer.tsx
+++ b/packages/ui/src/components/cockpit/MyRuntimesContainer.tsx
@@ -32,7 +32,12 @@ export function MyRuntimesContainer({ className }: MyRuntimesContainerProps) {
   // phone users only ever drive a cloud/remote runtime.
   const hideLocal = isAndroidCloudBuild() || isStoreBuild();
   const visibleProfiles = hideLocal
-    ? registry.profiles.filter((p) => p.kind !== "local")
+    ? // Hide local runtimes — but keep the one that's CURRENTLY active visible,
+      // else the Active badge would vanish on a store build whose persisted
+      // active profile is local (onSwitch still refuses switching TO a local).
+      registry.profiles.filter(
+        (p) => p.kind !== "local" || p.id === registry.activeProfileId,
+      )
     : registry.profiles;
 
   const refresh = useCallback(() => {

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -39,6 +39,7 @@ import {
   getShellSurface,
   resetShellSurfaceForTests,
 } from "../../state/shell-surface-store";
+import { setViewChatBinding } from "../../state/view-chat-binding";
 import { copyTextToClipboard } from "../../utils/clipboard";
 import { ContinuousChatOverlay } from "./ContinuousChatOverlay";
 import {
@@ -55,6 +56,7 @@ beforeAll(() => {
 afterEach(() => {
   cleanup();
   resetShellSurfaceForTests();
+  setViewChatBinding(null);
 });
 
 function makeController(
@@ -746,6 +748,38 @@ describe("ContinuousChatOverlay", () => {
       expect.objectContaining({
         images: expect.arrayContaining([
           expect.objectContaining({ name: "pic.png", mimeType: "image/png" }),
+        ]),
+      }),
+    );
+  });
+
+  it("a view-binding does NOT claim an image-bearing turn (images must not be lost)", async () => {
+    // A focused cockpit session registers a text-only onSubmit binding. A turn
+    // that also carries an image must fall through to the host agent (which can
+    // send images), not be claimed by the binding — else the image vanishes.
+    const onSubmit = vi.fn(() => true);
+    setViewChatBinding({ onSubmit });
+    const controller = makeController({ messages: [] });
+    render(<ContinuousChatOverlay controller={controller} />);
+
+    const fileInput = document.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    const file = new File(["x"], "pic.png", { type: "image/png" });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+    await screen.findByLabelText("send");
+    fireEvent.change(screen.getByLabelText("message"), {
+      target: { value: "analyze this" },
+    });
+
+    fireEvent.click(screen.getByLabelText("send"));
+    // binding must NOT have claimed it; host agent gets the text + image.
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(controller.send).toHaveBeenCalledWith(
+      "analyze this",
+      expect.objectContaining({
+        images: expect.arrayContaining([
+          expect.objectContaining({ name: "pic.png" }),
         ]),
       }),
     );

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -1573,7 +1573,14 @@ export function ContinuousChatOverlay({
       // claim the send to drive its OWN target instead of the host agent. If it
       // consumes the text, clear the composer and stop — do not fall through to
       // controller.send. Returns false/undefined → driver mode (host agent).
-      if (trimmed && viewChatBinding?.onSubmit?.(trimmed)) {
+      // ONLY claim a text-only turn: the binding's onSubmit is text-only, so a
+      // turn carrying images must fall through to the host agent (which can send
+      // images) rather than have the images silently dropped.
+      if (
+        trimmed &&
+        images.length === 0 &&
+        viewChatBinding?.onSubmit?.(trimmed)
+      ) {
         setDraft("");
         setSlashDismissed(false);
         setPendingImages([]);

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -58,6 +58,10 @@ export {
   getInjectedCharacters,
 } from "./character-catalog";
 export * from "./chat/index";
+export {
+  useRegisterViewChatBinding,
+  type ViewChatBinding,
+} from "./state/view-chat-binding";
 // App-hosted Eliza Cloud surfaces (API client, query client, steward-session
 // glue, cloud-route registry). Namespaced to avoid colliding with the many
 // generic names (`api`, `ApiError`, `queryClient`, …) in the root barrel.

--- a/packages/ui/src/state/switch-runtime.test.ts
+++ b/packages/ui/src/state/switch-runtime.test.ts
@@ -158,6 +158,23 @@ describe("switchRuntimeNonDestructive", () => {
     expect(mocks.setToken).toHaveBeenCalledWith("tok-vps");
   });
 
+  it("switching to a TOKENLESS remote CLEARS the token (no inherited bearer)", () => {
+    mocks.isTrustedRestoreApiBaseUrl.mockReturnValue(true);
+    const tokenless: AgentProfile = {
+      id: "vps-2",
+      label: "Tokenless VPS",
+      kind: "remote",
+      apiBase: "http://100.72.1.9:3000",
+      createdAt: "2026-06-04T00:00:00.000Z",
+    };
+    withRegistry([CLOUD, tokenless]);
+    const res = switchRuntimeNonDestructive("vps-2");
+    expect(res.ok).toBe(true);
+    expect(mocks.repointBaseUrl).toHaveBeenCalledWith("http://100.72.1.9:3000");
+    // must CLEAR — not keep the prior cloud bearer (cross-backend leak guard).
+    expect(mocks.setToken).toHaveBeenCalledWith(null);
+  });
+
   it("clears chat drafts on a switch (no cross-runtime draft bleed)", () => {
     withRegistry([LOCAL, CLOUD]);
     switchRuntimeNonDestructive("cloud-1");

--- a/packages/ui/src/state/switch-runtime.ts
+++ b/packages/ui/src/state/switch-runtime.ts
@@ -64,7 +64,11 @@ export function switchRuntimeNonDestructive(
   // the live client stuck on the stale remote base + token for the rest of the
   // session (it only self-heals on reboot).
   if (profile.apiBase) {
-    if (profile.accessToken) client.setToken(profile.accessToken);
+    // Set THIS profile's own token, clearing when it has none — never inherit
+    // the prior runtime's bearer. A tokenless remote (e.g. a VPS added in My
+    // Runtimes) would otherwise keep the cloud token and send it to that backend
+    // (silent cross-backend credential leak / auth failure).
+    client.setToken(profile.accessToken ?? null);
     client.repointBaseUrl(profile.apiBase);
   } else if (typeof window !== "undefined") {
     client.setToken(null);

--- a/plugins/plugin-task-coordinator/src/CockpitSessionPane.test.tsx
+++ b/plugins/plugin-task-coordinator/src/CockpitSessionPane.test.tsx
@@ -43,6 +43,7 @@ const calls = {
   getCodingAgentStatus: vi.fn(),
   updateOrchestratorTask: vi.fn(),
   addOrchestratorAgent: vi.fn(),
+  restartOrchestratorTask: vi.fn(),
 };
 
 // TaskInspector wires a couple of agent elements (close button + priority
@@ -76,6 +77,8 @@ vi.mock("@elizaos/ui", async (importOriginal) => {
         calls.updateOrchestratorTask(id, patch),
       addOrchestratorAgent: (id: string, input: unknown) =>
         calls.addOrchestratorAgent(id, input),
+      restartOrchestratorTask: (id: string, input: unknown) =>
+        calls.restartOrchestratorTask(id, input),
     },
   };
 });
@@ -289,6 +292,7 @@ beforeEach(() => {
   calls.getCodingAgentStatus.mockResolvedValue({ tasks: [] });
   calls.updateOrchestratorTask.mockResolvedValue(detailFixture);
   calls.addOrchestratorAgent.mockResolvedValue(detailFixture);
+  calls.restartOrchestratorTask.mockResolvedValue(detailFixture);
 });
 
 afterEach(() => {
@@ -370,7 +374,7 @@ describe("CockpitSessionPane — drill-in (client mocked at the boundary)", () =
     expect(screen.queryByTestId("cockpit-session-transcript")).toBeNull();
   });
 
-  it("Eliza Cloud: flipping the tier persists policy + respawns on the new model", async () => {
+  it("Eliza Cloud: flipping the tier persists policy + RESTARTS (stops old worker, no agent accumulation)", async () => {
     calls.getCodingAgentTaskThread.mockResolvedValue({
       ...detailFixture,
       providerPolicy: {
@@ -382,6 +386,7 @@ describe("CockpitSessionPane — drill-in (client mocked at the boundary)", () =
     renderPane();
     const smart = await screen.findByTestId("cockpit-tier-large");
     fireEvent.click(smart);
+    // 1. persist the new tier's model on the task policy
     await waitFor(() =>
       expect(calls.updateOrchestratorTask).toHaveBeenCalledWith(
         "task-1",
@@ -390,10 +395,30 @@ describe("CockpitSessionPane — drill-in (client mocked at the boundary)", () =
         }),
       ),
     );
+    // 2. RESTART with stopActive (replaces the worker) — NOT addOrchestratorAgent
+    // (which would accumulate live agents on repeated flips — Shaw's review).
     await waitFor(() =>
-      expect(calls.addOrchestratorAgent).toHaveBeenCalledWith(
+      expect(calls.restartOrchestratorTask).toHaveBeenCalledWith(
         "task-1",
-        expect.objectContaining({ model: "zai-glm-4.7" }),
+        expect.objectContaining({ stopActive: true }),
+      ),
+    );
+    expect(calls.addOrchestratorAgent).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an error when a composer-driven message fails to deliver", async () => {
+    calls.postOrchestratorTaskMessage.mockRejectedValue(new Error("offline"));
+    renderPane();
+    await waitFor(() =>
+      expect(screen.getByTestId("orchestrator-user-message")).toBeTruthy(),
+    );
+    const binding = getViewChatBinding();
+    // onSubmit still consumes the send (returns true) — but a failed delivery
+    // must surface, not vanish silently (Shaw's review).
+    expect(binding?.onSubmit?.("hi")).toBe(true);
+    await waitFor(() =>
+      expect(screen.getByTestId("cockpit-session-error").textContent).toMatch(
+        /deliver/i,
       ),
     );
   });

--- a/plugins/plugin-task-coordinator/src/CockpitSessionPane.tsx
+++ b/plugins/plugin-task-coordinator/src/CockpitSessionPane.tsx
@@ -263,9 +263,8 @@ export function CockpitSessionPane({
             className="shrink-0"
           />
         ) : null}
-        <div
-          className="flex shrink-0 items-center gap-1"
-          role="group"
+        <fieldset
+          className="flex shrink-0 items-center gap-1 border-0 p-0"
           aria-label={t("cockpit.session.viewMode", {
             defaultValue: "View mode",
           })}
@@ -302,7 +301,7 @@ export function CockpitSessionPane({
           >
             <SquareTerminal className="h-4 w-4" aria-hidden />
           </button>
-        </div>
+        </fieldset>
       </header>
 
       {composerError ? (

--- a/plugins/plugin-task-coordinator/src/CockpitSessionPane.tsx
+++ b/plugins/plugin-task-coordinator/src/CockpitSessionPane.tsx
@@ -34,7 +34,7 @@ import {
   useRegisterViewChatBinding,
 } from "@elizaos/ui";
 import { ArrowLeft, ScrollText, SquareTerminal } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CockpitTerminalPanel } from "./CockpitTerminalPanel";
 import { TaskInspector } from "./OrchestratorWorkbench";
 import { ConversationBlockView } from "./orchestrator-stream";
@@ -78,21 +78,35 @@ export function CockpitSessionPane({
   // so the inspector's "Add agent" affordance works end to end.
   const [addAgentOpen, setAddAgentOpen] = useState(false);
 
-  // CLI face: "transcript" (pretty) ⇄ "terminal" (real-CLI / PTY watch view).
+  // CLI face: "transcript" (pretty) ⇄ "terminal" (a read-mostly PTY-output WATCH
+  // view — ACP sessions run --no-terminal, so it's not an interactive shell
+  // until a PTY_SERVICE-backed build exists; see CockpitTerminalPanel).
   const [view, setView] = useState<"transcript" | "terminal">("transcript");
 
   // The PTY session feed (CodingAgentSession[]) is a separate source from the
   // task detail; poll it and narrow to THIS task's sessions by matching
   // sessionId against the task's session records.
   const [ptySessions, setPtySessions] = useState<CodingAgentSession[]>([]);
+  const ptyPollFailedRef = useRef(false);
   useEffect(() => {
     let alive = true;
     const pull = async () => {
       try {
         const status = await client.getCodingAgentStatus();
-        if (alive) setPtySessions(status?.tasks ?? []);
-      } catch {
-        // best-effort; the terminal shows its empty state if unavailable.
+        if (!alive) return;
+        setPtySessions(status?.tasks ?? []);
+        ptyPollFailedRef.current = false;
+      } catch (e) {
+        // Don't silently swallow a persistently-broken status endpoint (Shaw's
+        // review): warn once per failure streak (not every 3s), and the terminal
+        // shows its empty state meanwhile.
+        if (!ptyPollFailedRef.current) {
+          ptyPollFailedRef.current = true;
+          console.warn(
+            "[cockpit] coding-agent status poll failed; terminal sessions unavailable",
+            e,
+          );
+        }
       }
     };
     void pull();
@@ -143,13 +157,11 @@ export function CockpitSessionPane({
             model,
           },
         });
-        // Re-spawn so the next turn actually runs on the new tier's model.
-        await client.addOrchestratorAgent(taskId, {
-          framework: "elizaos",
-          providerSource: "eliza-cloud",
-          model,
-          task: "Continue on the selected tier.",
-        });
+        // RESTART (stopActive) rather than add-agent: restartTask stops the
+        // worker(s) running on the OLD model, then respawns a single fresh one
+        // from the just-updated providerPolicy. Adding a worker would accumulate
+        // live agents on the task with each tier flip (Shaw's review of #10544).
+        await client.restartOrchestratorTask(taskId, { stopActive: true });
       });
     },
     [taskId, runMutation],
@@ -197,9 +209,20 @@ export function CockpitSessionPane({
   // Claim the floating composer's SEND while this pane is open: route it to THIS
   // task's room. Stable identity (only `taskId` matters) so the binding does not
   // needlessly re-register on every transcript tick.
+  const [composerError, setComposerError] = useState<string | null>(null);
   const onComposerSubmit = useCallback(
     (text: string): boolean => {
-      void client.postOrchestratorTaskMessage(taskId, text);
+      setComposerError(null);
+      // Surface a delivery failure: the composer has already cleared by the time
+      // this resolves, so a silently-dropped post would lose the user's message
+      // (Shaw's review of #10544). Still return true — the send WAS claimed.
+      client.postOrchestratorTaskMessage(taskId, text).catch((e: unknown) => {
+        setComposerError(
+          e instanceof Error
+            ? `Couldn't deliver your message: ${e.message}`
+            : "Couldn't deliver your message.",
+        );
+      });
       return true;
     },
     [taskId],
@@ -268,7 +291,9 @@ export function CockpitSessionPane({
             onClick={() => setView("terminal")}
             aria-pressed={view === "terminal"}
             data-testid="cockpit-view-terminal"
-            title={t("cockpit.session.terminal", { defaultValue: "Terminal" })}
+            title={t("cockpit.session.watch", {
+              defaultValue: "Watch (terminal output)",
+            })}
             className={`inline-flex h-8 w-8 items-center justify-center rounded-md transition-colors ${
               view === "terminal"
                 ? "bg-accent/15 text-accent"
@@ -279,6 +304,16 @@ export function CockpitSessionPane({
           </button>
         </div>
       </header>
+
+      {composerError ? (
+        <div
+          role="alert"
+          data-testid="cockpit-session-error"
+          className="shrink-0 border-destructive/40 border-b bg-destructive/10 px-3 py-2 text-xs text-destructive"
+        >
+          {composerError}
+        </div>
+      ) : null}
 
       <div className="flex min-h-0 flex-1 overflow-hidden">
         {view === "terminal" ? (

--- a/plugins/plugin-task-coordinator/src/components/TaskCoordinatorSpatialView.tsx
+++ b/plugins/plugin-task-coordinator/src/components/TaskCoordinatorSpatialView.tsx
@@ -35,6 +35,7 @@ import {
   Field,
   HStack,
   List,
+  Spacer,
   type SpatialTone,
   Text,
   VStack,
@@ -188,6 +189,7 @@ function TaskList({
   const doneCount = threads.filter((t) => t.status === "done").length;
   return (
     <Card gap={1} padding={1}>
+      <Spacer size={8} />
       <HStack gap={1} align="center" wrap>
         <Text style="caption" tone="muted" grow={1}>
           {loading ? "loading" : `${threads.length} total`}


### PR DESCRIPTION
## What + why

PR #10544 (the coding cockpit) was **squash-merged at the state *before* two follow-up fix commits landed** — so develop + main (prod) are running known-buggy cockpit code whose fixes were already written but stranded on `nubs/paseo-coding-cockpit`. This PR cherry-picks those two commits (`878ac48838` + `85e98a9aff`) onto current develop. Verified by content that prod lacks each fix below.

## Fixes (all already test-covered; cherry-picked clean, no conflicts)

- 🔴 **MED — cross-runtime credential leak** (`switch-runtime.ts`): switching to a tokenless remote kept the prior bearer → an Eliza Cloud token gets sent to a VPS. Now `setToken(profile.accessToken ?? null)`.
- 🔴 **MED — image silently dropped** (`ContinuousChatOverlay.tsx`): when a cockpit binding claims a send, attached images vanished (the binding's `onSubmit` is text-only). Now only text-only turns are claimed; image turns fall through to the host agent.
- **Tier toggle accumulated agents** (`CockpitSessionPane.tsx`): `onTierChange` now `restartOrchestratorTask({stopActive})` instead of `addOrchestratorAgent` (which piled up live workers per flip — Shaw's review).
- **Composer-driven sends failed silently** → now surface a `cockpit-session-error` banner.
- **PTY status-poll** no longer swallows errors (warns once per streak).
- **Active local "Active" badge** no longer vanishes under `hideLocal` (store/phone builds).
- Honest framing: "real-CLI terminal" → terminal-output **watch** view.

## Tests

Each fix ships its covering test (tokenless-remote→`setToken(null)`; image-bearing claim→host send w/ image; tier→restart not add; composer-fail→banner; active-local→badge). These passed when authored; cherry-picked unchanged. CI runs the full suite here.

Closes the prod gap flagged in the cockpit completion audit. cc @lalalune
