### PR TITLE
fix(core): route MANAGE_PLUGINS subactions via resolveActionArgs (#10471)

### DIFF
--- a/packages/core/src/features/plugin-manager/actions/plugin.ts
+++ b/packages/core/src/features/plugin-manager/actions/plugin.ts
@@ -5,19 +5,28 @@
  * `sync`, `reinject`, `list`, `list_ejected`, `search`, `details`,
  * `status`, `enable`, `disable`, `core_status`, `create`).
  *
- * Validate gates on owner role + a keyword heuristic + a lookup against
- * any pending PLUGIN_CREATE intent task in the same room (so the
+ * Validate gates on owner role + structured/context selection + a lookup
+ * against any pending PLUGIN_CREATE intent task in the same room (so the
  * multi-turn choice reply still resolves).
  *
  * Handler is pure dispatch — sub-handlers live under ./plugin-handlers/.
+ * Subaction routing goes through the shared `resolveActionArgs` substrate:
+ * structured planner/programmatic `action` enum first, then a single LLM
+ * extraction pass over the registered subactions for free-form requests.
  */
 
 import path from "node:path";
+import {
+	resolveActionArgs,
+	type SubactionsMap,
+} from "../../../actions/resolve-action-args.ts";
 import { logger } from "../../../logger.ts";
 import type {
 	Action,
+	ActionParameters,
 	ActionResult,
 	HandlerCallback,
+	HandlerOptions,
 } from "../../../types/components.ts";
 import type { Memory } from "../../../types/memory.ts";
 import type { IAgentRuntime } from "../../../types/runtime.ts";
@@ -75,22 +84,93 @@ const SUBACTIONS: readonly PluginSubaction[] = [
 	"create",
 ] as const;
 
-const INSTALL_VERBS = /\binstall\b/i;
-const EJECT_VERBS = /\beject\b/i;
-const SYNC_VERBS = /\bsync\b/i;
-const REINJECT_VERBS = /\b(reinject|re-inject|unject)\b/i;
-const SEARCH_VERBS = /\b(search|find|look\s+for|discover)\b/i;
-const LIST_VERBS = /\b(list|show)\b/i;
-const DETAILS_VERBS =
-	/\b(details?|info|information|tell\s+me\s+more|more\s+about|describe)\b/i;
-const ENABLE_VERBS = /\b(enable|activate|turn\s+on|load)\b/i;
-const DISABLE_VERBS = /\b(disable|deactivate|turn\s+off|unload)\b/i;
-const CREATE_VERBS = /\b(create|build|make|new|scaffold|generate)\b/i;
-const PLUGIN_NOUN = /\bplugins?\b/i;
-const EJECTED_NOUN = /\bejected\b/i;
-const CORE_NOUN = /\bcore\b/i;
-const STATUS_NOUN = /\bstatus\b/i;
-const MANAGE_VERBS = /\b(manage|build|create|build|fix|update|edit)\b/i;
+interface PluginActionParams {
+	name?: string;
+	source?: "npm" | "git";
+	url?: string;
+	version?: string;
+	query?: string;
+	intent?: string;
+}
+
+/**
+ * Subaction contract surfaced to `resolveActionArgs`. Required keys gate
+ * extraction; the resolver picks the subaction from the structured `action`
+ * enum (planner) or a single LLM pass, then we fill machine-parsed plugin
+ * identifiers / queries below before dispatch.
+ */
+const PLUGIN_SUBACTIONS: SubactionsMap<PluginSubaction> = {
+	install: {
+		description: "Install a plugin from the registry by canonical name.",
+		descriptionCompressed: "install plugin from registry by name",
+		required: ["name"],
+		optional: ["source", "url", "version"],
+	},
+	eject: {
+		description: "Clone a registry plugin into the local plugins directory.",
+		descriptionCompressed: "eject (clone) registry plugin locally",
+		required: ["name"],
+	},
+	sync: {
+		description: "Pull upstream changes into an ejected (local) plugin.",
+		descriptionCompressed: "sync upstream into ejected plugin",
+		required: ["name"],
+	},
+	reinject: {
+		description: "Remove the local copy of an ejected plugin (re-inject).",
+		descriptionCompressed: "reinject (remove local copy of) ejected plugin",
+		required: ["name"],
+	},
+	list: {
+		description: "List the loaded / installed plugins.",
+		descriptionCompressed: "list loaded/installed plugins",
+		required: [],
+	},
+	list_ejected: {
+		description: "List the ejected (locally cloned) plugins.",
+		descriptionCompressed: "list ejected plugins",
+		required: [],
+	},
+	search: {
+		description: "Search the plugin registry for a free-form capability.",
+		descriptionCompressed: "search registry for plugins matching query",
+		required: ["query"],
+	},
+	details: {
+		description: "Show registry / runtime details for one plugin.",
+		descriptionCompressed: "show details for one plugin",
+		required: ["name"],
+	},
+	status: {
+		description:
+			"Report plugin runtime state (all plugins, or one when a name is given).",
+		descriptionCompressed: "report plugin runtime status",
+		required: [],
+		optional: ["name"],
+	},
+	enable: {
+		description: "Load (enable) a runtime-registered plugin.",
+		descriptionCompressed: "enable runtime plugin by name",
+		required: ["name"],
+	},
+	disable: {
+		description: "Unload (disable) a runtime-registered plugin.",
+		descriptionCompressed: "disable runtime plugin by name",
+		required: ["name"],
+	},
+	core_status: {
+		description: "Report the @elizaos/core ejection state.",
+		descriptionCompressed: "report @elizaos/core ejection status",
+		required: [],
+	},
+	create: {
+		description:
+			"Run the multi-turn create-or-edit flow that scaffolds a new plugin or edits an existing one.",
+		descriptionCompressed: "create/edit a plugin via the scaffold flow",
+		required: [],
+		optional: ["intent"],
+	},
+};
 
 type OwnerAccessFn = (
 	runtime: IAgentRuntime,
@@ -146,6 +226,12 @@ function readStringOption(
 	return trimmed.length > 0 ? trimmed : undefined;
 }
 
+/**
+ * Normalize a structured subaction value supplied by the planner / a
+ * programmatic caller (the `action` / `subaction` / `mode` enum, including
+ * legacy aliases). This matches the model's structured English-enum output,
+ * not the user's free-form text.
+ */
 function normalizeSubaction(value: string): PluginSubaction | null {
 	const normalized = value.trim().toLowerCase().replace(/-/g, "_");
 	switch (normalized) {
@@ -178,6 +264,23 @@ function normalizeSubaction(value: string): PluginSubaction | null {
 	}
 }
 
+/**
+ * Read an explicit structured subaction from the call options. Covers the
+ * planner-supplied `action` enum, the legacy `mode` alias, and direct
+ * programmatic callers (top-level or nested under `parameters`). Returns
+ * `null` when the caller supplied no structured subaction — natural-language
+ * routing then falls through to `resolveActionArgs`.
+ */
+function readExplicitSubaction(
+	options: ActionOptions | undefined,
+): PluginSubaction | null {
+	const explicit =
+		readStringOption(options, "action") ??
+		readStringOption(options, "subaction") ??
+		readStringOption(options, "mode");
+	return explicit ? normalizeSubaction(explicit) : null;
+}
+
 function readSourceOption(
 	options: ActionOptions | undefined,
 ): "npm" | "git" | undefined {
@@ -186,48 +289,11 @@ function readSourceOption(
 	return undefined;
 }
 
-function inferMode(
-	text: string,
-	options?: Record<string, unknown>,
-): PluginSubaction | null {
-	const explicit =
-		readStringOption(options, "action") ??
-		readStringOption(options, "subaction") ??
-		readStringOption(options, "mode");
-	if (explicit) return normalizeSubaction(explicit);
-
-	const trimmed = text.trim();
-	if (!trimmed) return null;
-
-	if (CORE_NOUN.test(trimmed) && STATUS_NOUN.test(trimmed))
-		return "core_status";
-
-	if (LIST_VERBS.test(trimmed) && EJECTED_NOUN.test(trimmed))
-		return "list_ejected";
-	if (LIST_VERBS.test(trimmed) && PLUGIN_NOUN.test(trimmed)) return "list";
-
-	if (
-		DETAILS_VERBS.test(trimmed) &&
-		(PLUGIN_NOUN.test(trimmed) || extractNameFromText(trimmed))
-	)
-		return "details";
-	if (STATUS_NOUN.test(trimmed) && PLUGIN_NOUN.test(trimmed)) return "status";
-	if (ENABLE_VERBS.test(trimmed) && PLUGIN_NOUN.test(trimmed)) return "enable";
-	if (DISABLE_VERBS.test(trimmed) && PLUGIN_NOUN.test(trimmed))
-		return "disable";
-	if (REINJECT_VERBS.test(trimmed)) return "reinject";
-	if (EJECT_VERBS.test(trimmed)) return "eject";
-	if (SYNC_VERBS.test(trimmed) && PLUGIN_NOUN.test(trimmed)) return "sync";
-	if (INSTALL_VERBS.test(trimmed) && PLUGIN_NOUN.test(trimmed))
-		return "install";
-	if (SEARCH_VERBS.test(trimmed) && PLUGIN_NOUN.test(trimmed)) return "search";
-
-	if (CREATE_VERBS.test(trimmed) && PLUGIN_NOUN.test(trimmed)) return "create";
-	if (MANAGE_VERBS.test(trimmed) && PLUGIN_NOUN.test(trimmed)) return "create";
-
-	return null;
-}
-
+/**
+ * Machine extractor: pull a plugin package identifier (`@scope/plugin-x`,
+ * `plugin-x`, or a bare name after an operation verb) out of free-form text.
+ * Operates on plugin-identifier token shapes, not behavior-deciding NL.
+ */
 function extractNameFromText(text: string): string | undefined {
 	const scoped = text.match(/@[\w-]+\/(plugin-[\w.-]+)/);
 	if (scoped) return scoped[0];
@@ -300,6 +366,44 @@ function hasAccessContext(runtime: IAgentRuntime, message: Memory): boolean {
 	);
 }
 
+/**
+ * Seed `options.parameters` with machine-parsed plugin identifiers / query /
+ * source so `resolveActionArgs` can satisfy required params even when the LLM
+ * extraction does not surface them verbatim. Resolver-extracted values still
+ * win for any key the LLM does fill, since the seeded values are merged as
+ * planner params only when present.
+ */
+function buildResolverOptions(
+	options: Record<string, unknown> | undefined,
+	text: string,
+): HandlerOptions {
+	const nested = readNestedParameters(options);
+	const seeded: ActionParameters =
+		nested && !Array.isArray(nested)
+			? { ...(nested as ActionParameters) }
+			: {};
+
+	const name = normalizePluginNameInput(
+		readStringOption(options, "name") ??
+			readStringOption(options, "pluginId") ??
+			extractNameFromText(text),
+	);
+	const source = readSourceOption(options);
+	const url = readStringOption(options, "url");
+	const version = readStringOption(options, "version");
+	const query = readStringOption(options, "query") ?? extractQueryFromText(text);
+	const intent = readStringOption(options, "intent");
+
+	if (name !== undefined) seeded.name = name;
+	if (source !== undefined) seeded.source = source;
+	if (url !== undefined) seeded.url = url;
+	if (version !== undefined) seeded.version = version;
+	if (query !== undefined) seeded.query = query;
+	if (intent !== undefined) seeded.intent = intent;
+
+	return { ...(options as HandlerOptions), parameters: seeded };
+}
+
 export function createPluginAction(deps: PluginActionDeps = {}): Action {
 	const ownerCheck = deps.hasOwnerAccess ?? defaultOwnerAccessFn;
 	const repoRoot = deps.repoRoot ?? defaultRepoRoot();
@@ -310,6 +414,66 @@ export function createPluginAction(deps: PluginActionDeps = {}): Action {
 	): Promise<boolean> => {
 		if (!hasAccessContext(runtime, message)) return false;
 		return ownerCheck(runtime, message);
+	};
+
+	const dispatch = async (
+		runtime: IAgentRuntime,
+		message: Memory,
+		options: Record<string, unknown> | undefined,
+		callback: HandlerCallback | undefined,
+		subaction: PluginSubaction,
+		params: PluginActionParams,
+	): Promise<ActionResult> => {
+		logger.info(`[plugin-manager] MANAGE_PLUGINS mode=${subaction}`);
+		const text = message.content.text ?? "";
+		const name = params.name;
+
+		switch (subaction) {
+			case "install":
+				return runInstall({
+					runtime,
+					name: name ?? "",
+					source: params.source,
+					callback,
+				});
+			case "eject":
+				return runEject({ runtime, name: name ?? "", callback });
+			case "sync":
+				return runSync({ runtime, name: name ?? "", callback });
+			case "reinject":
+				return runReinject({ runtime, name: name ?? "", callback });
+			case "list":
+				return runList({ runtime, callback });
+			case "list_ejected":
+				return runListEjected({ runtime, callback });
+			case "search":
+				return runSearch({
+					runtime,
+					query: params.query ?? text,
+					callback,
+				});
+			case "details":
+				return runPluginDetails({ runtime, name: name ?? "", callback });
+			case "status":
+				return runPluginStatus({ runtime, name, callback });
+			case "enable":
+				return runEnablePlugin({ runtime, name: name ?? "", callback });
+			case "disable":
+				return runDisablePlugin({ runtime, name: name ?? "", callback });
+			case "core_status":
+				return runCoreStatus({ runtime, callback });
+			case "create":
+				return runCreate({
+					runtime,
+					message,
+					options,
+					callback,
+					intent: params.intent ?? readStringOption(options, "intent"),
+					choice: readStringOption(options, "choice"),
+					editTarget: readStringOption(options, "editTarget"),
+					repoRoot,
+				});
+		}
 	};
 
 	return {
@@ -432,7 +596,7 @@ export function createPluginAction(deps: PluginActionDeps = {}): Action {
 		handler: async (
 			runtime: IAgentRuntime,
 			message: Memory,
-			_state?: State,
+			state?: State,
 			options?: Record<string, unknown>,
 			callback?: HandlerCallback,
 		): Promise<ActionResult> => {
@@ -459,64 +623,55 @@ export function createPluginAction(deps: PluginActionDeps = {}): Action {
 				}
 			}
 
-			const mode = inferMode(text, options);
-			if (!mode) {
+			// Structured planner/programmatic subaction (incl. legacy `mode`
+			// alias + normalization aliases) routes directly; machine-parsed
+			// params are filled below. This is the planner-trust fast path.
+			const explicit = readExplicitSubaction(options);
+			const resolverOptions = buildResolverOptions(options, text);
+			if (explicit) {
+				const seededParams = (resolverOptions.parameters ??
+					{}) as PluginActionParams;
+				return dispatch(
+					runtime,
+					message,
+					options,
+					callback,
+					explicit,
+					seededParams,
+				);
+			}
+
+			const resolved = await resolveActionArgs<
+				PluginSubaction,
+				PluginActionParams
+			>({
+				runtime,
+				message,
+				state,
+				options: resolverOptions,
+				actionName: "MANAGE_PLUGINS",
+				subactions: PLUGIN_SUBACTIONS,
+			});
+
+			if (!resolved.ok) {
 				const reply =
 					'Tell me which plugin operation to run. Try: "install @elizaos/plugin-discord", "list ejected plugins", "search for plugins for blockchain", "create a new plugin for X".';
 				await callback?.({ text: reply });
-				return { success: false, text: reply };
+				return {
+					success: false,
+					text: reply,
+					data: { action: "clarify", missing: resolved.missing },
+				};
 			}
 
-			logger.info(`[plugin-manager] MANAGE_PLUGINS mode=${mode}`);
-
-			const name = normalizePluginNameInput(
-				readStringOption(options, "name") ??
-					readStringOption(options, "pluginId") ??
-					extractNameFromText(text),
+			return dispatch(
+				runtime,
+				message,
+				options,
+				callback,
+				resolved.subaction,
+				resolved.params,
 			);
-			const source = readSourceOption(options);
-			const query =
-				readStringOption(options, "query") ??
-				extractQueryFromText(text) ??
-				text;
-
-			switch (mode) {
-				case "install":
-					return runInstall({ runtime, name: name ?? "", source, callback });
-				case "eject":
-					return runEject({ runtime, name: name ?? "", callback });
-				case "sync":
-					return runSync({ runtime, name: name ?? "", callback });
-				case "reinject":
-					return runReinject({ runtime, name: name ?? "", callback });
-				case "list":
-					return runList({ runtime, callback });
-				case "list_ejected":
-					return runListEjected({ runtime, callback });
-				case "search":
-					return runSearch({ runtime, query, callback });
-				case "details":
-					return runPluginDetails({ runtime, name: name ?? "", callback });
-				case "status":
-					return runPluginStatus({ runtime, name, callback });
-				case "enable":
-					return runEnablePlugin({ runtime, name: name ?? "", callback });
-				case "disable":
-					return runDisablePlugin({ runtime, name: name ?? "", callback });
-				case "core_status":
-					return runCoreStatus({ runtime, callback });
-				case "create":
-					return runCreate({
-						runtime,
-						message,
-						options,
-						callback,
-						intent: readStringOption(options, "intent"),
-						choice: readStringOption(options, "choice"),
-						editTarget: readStringOption(options, "editTarget"),
-						repoRoot,
-					});
-			}
 		},
 
 		examples: [

--- a/packages/core/src/features/plugin-manager/plugin-manager-routing.test.ts
+++ b/packages/core/src/features/plugin-manager/plugin-manager-routing.test.ts
@@ -1,0 +1,189 @@
+/**
+ * MANAGE_PLUGINS subaction routing (post-`resolveActionArgs` migration).
+ *
+ * The umbrella action used to pick its subaction by regex-matching the user's
+ * natural-language `message.content.text` (the `inferMode` keyword heuristic).
+ * That decided agent behavior off free-form English — the i18n smell. Routing
+ * now goes through the shared `resolveActionArgs` substrate:
+ *
+ *   1. Structured planner/programmatic `action` enum (incl. the legacy `mode`
+ *      alias + normalization aliases) → dispatch directly, no model call.
+ *   2. Otherwise a single `TEXT_LARGE` extraction pass over the registered
+ *      subactions, with machine-parsed plugin identifiers / queries seeded into
+ *      the resolver params so the required fields resolve.
+ *
+ * These tests drive the real handler with a stubbed `plugin_manager` service
+ * and a deterministic mock `useModel`, asserting both paths route correctly and
+ * that the no-match case degrades to a structured clarification.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type { HandlerCallback } from "../../types/components.ts";
+import type { Memory } from "../../types/memory.ts";
+import type { IAgentRuntime } from "../../types/runtime.ts";
+import { createPluginAction } from "./actions/plugin.ts";
+
+interface StubServiceCalls {
+	installed: string[];
+}
+
+function createStubPluginManager(calls: StubServiceCalls) {
+	return {
+		getAllPlugins: () => [{ name: "plugin-manager", status: "LOADED" }],
+		listInstalledPlugins: async () => [],
+		listEjectedPlugins: async () => [],
+		installPlugin: async (name: string) => {
+			calls.installed.push(name);
+			return {
+				success: true,
+				pluginName: name,
+				version: "1.0.0",
+				installPath: `/plugins/installed/${name}`,
+				requiresRestart: true,
+			};
+		},
+	};
+}
+
+function createRuntime(opts: {
+	calls: StubServiceCalls;
+	useModel?: ReturnType<typeof vi.fn>;
+}): IAgentRuntime {
+	const service = createStubPluginManager(opts.calls);
+	return {
+		agentId: "agent-id",
+		getService: (name: string) =>
+			name === "plugin_manager" ? service : null,
+		useModel: opts.useModel ?? vi.fn(),
+		logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() },
+	} as unknown as IAgentRuntime;
+}
+
+function createMessage(text: string): Memory {
+	return {
+		id: "message-id",
+		agentId: "agent-id",
+		entityId: "user-id",
+		roomId: "room-id",
+		content: { text },
+	} as Memory;
+}
+
+// Owner gate is exercised elsewhere; bypass it so these tests isolate routing.
+const action = createPluginAction({
+	hasOwnerAccess: async () => true,
+	repoRoot: "/repo",
+});
+
+describe("MANAGE_PLUGINS subaction routing", () => {
+	it("routes a structured planner `action` enum directly without a model call", async () => {
+		const calls: StubServiceCalls = { installed: [] };
+		const useModel = vi.fn();
+		const runtime = createRuntime({ calls, useModel });
+		const replies: string[] = [];
+		const callback: HandlerCallback = async (content) => {
+			if (typeof content.text === "string") replies.push(content.text);
+			return [];
+		};
+
+		const result = await action.handler?.(
+			runtime,
+			createMessage("(structured call)"),
+			undefined,
+			{ parameters: { action: "list" } },
+			callback,
+		);
+
+		expect(result?.success).toBe(true);
+		expect(useModel).not.toHaveBeenCalled();
+		expect(replies.join("\n")).toContain("Loaded plugins");
+	});
+
+	it("normalizes the legacy `mode` alias (installed -> list) with no model call", async () => {
+		const calls: StubServiceCalls = { installed: [] };
+		const useModel = vi.fn();
+		const runtime = createRuntime({ calls, useModel });
+		const replies: string[] = [];
+		const callback: HandlerCallback = async (content) => {
+			if (typeof content.text === "string") replies.push(content.text);
+			return [];
+		};
+
+		const result = await action.handler?.(
+			runtime,
+			createMessage("(structured call)"),
+			undefined,
+			{ parameters: { mode: "installed" } },
+			callback,
+		);
+
+		expect(result?.success).toBe(true);
+		expect(useModel).not.toHaveBeenCalled();
+		expect(replies.join("\n")).toContain("Loaded plugins");
+	});
+
+	it("routes a natural-language install via the LLM extraction pass, seeding the parsed plugin name", async () => {
+		const calls: StubServiceCalls = { installed: [] };
+		// The single TEXT_LARGE extraction call chooses `install`; the resolver
+		// already received the machine-parsed `name` seeded from the text, so the
+		// model only needs to pick the subaction.
+		const useModel = vi.fn(async () =>
+			JSON.stringify({
+				action: "install",
+				params: {},
+				missing: [],
+				confidence: 0.95,
+			}),
+		);
+		const runtime = createRuntime({ calls, useModel });
+		const replies: string[] = [];
+		const callback: HandlerCallback = async (content) => {
+			if (typeof content.text === "string") replies.push(content.text);
+			return [];
+		};
+
+		const result = await action.handler?.(
+			runtime,
+			createMessage("please install @elizaos/plugin-discord for me"),
+			undefined,
+			undefined,
+			callback,
+		);
+
+		expect(result?.success, replies.join("\n")).toBe(true);
+		expect(useModel).toHaveBeenCalledTimes(1);
+		// The machine-parsed identifier reached the install handler.
+		expect(calls.installed).toEqual(["@elizaos/plugin-discord"]);
+	});
+
+	it("degrades to a structured clarification when the request matches no subaction", async () => {
+		const calls: StubServiceCalls = { installed: [] };
+		const useModel = vi.fn(async () =>
+			JSON.stringify({
+				action: null,
+				params: {},
+				missing: ["action"],
+				confidence: 0.1,
+			}),
+		);
+		const runtime = createRuntime({ calls, useModel });
+		const replies: string[] = [];
+		const callback: HandlerCallback = async (content) => {
+			if (typeof content.text === "string") replies.push(content.text);
+			return [];
+		};
+
+		const result = (await action.handler?.(
+			runtime,
+			createMessage("what is the weather today?"),
+			undefined,
+			undefined,
+			callback,
+		)) as { success: boolean; data?: { action?: string } };
+
+		expect(result?.success).toBe(false);
+		expect(result?.data?.action).toBe("clarify");
+		expect(calls.installed).toHaveLength(0);
+		expect(replies.join("\n")).toContain("which plugin operation");
+	});
+});


### PR DESCRIPTION
## What changed

`MANAGE_PLUGINS` (the plugin-manager umbrella action in `packages/core/src/features/plugin-manager/actions/plugin.ts`) used to pick its subaction by **regex-matching the user's natural-language `message.content.text`**. `inferMode` ran a battery of English keyword tables — `INSTALL_VERBS`, `EJECT_VERBS`, `LIST_VERBS`, `DETAILS_VERBS`, `ENABLE_VERBS`, `DISABLE_VERBS`, `CREATE_VERBS`, `PLUGIN_NOUN`, `MANAGE_VERBS`, … — to DECIDE which of the ~13 subactions (install / eject / sync / reinject / list / list_ejected / search / details / status / enable / disable / core_status / create) to run.

This migrates the whole `inferMode` block to the shared **`resolveActionArgs` + `SubactionsMap`** substrate (`packages/core/src/actions/resolve-action-args.ts`) — the canonical pattern already used by `plugin-goals`' `OWNER_GOALS`:

- Declares `PLUGIN_SUBACTIONS: SubactionsMap<PluginSubaction>` with each subaction's required/optional params.
- **Structured planner/programmatic `action` enum** (including the legacy `mode` alias and the `normalizeSubaction` aliases) routes directly with **no model call** — the planner-trust fast path.
- **Natural-language** requests now run a **single `TEXT_LARGE` extraction pass** that picks the subaction from the structured enum and pulls its params — instead of English keyword regexes.
- The **machine extractors are kept**: `extractNameFromText` / `extractQueryFromText` / `normalizePluginNameInput` / `readSourceOption` parse structured plugin identifiers (`@scope/plugin-x`, `plugin-x`), git URLs, and search queries — token-shape extraction, not behavior-deciding NL matching. Their results are **seeded into the resolver params** so required fields resolve even when the LLM does not surface them verbatim.
- No-match degrades to the same `"Tell me which plugin operation to run…"` clarification (no regression to a bare delete).
- The **create choice-reply multi-turn path** and the **owner/role validate gate** are untouched.

## Why (the i18n smell, #10471)

Per #10471: deciding agent behavior by matching the user's free-form `message.content.text` against English keywords is a smell. Matching the planner/model's structured English-enum **output** is a keep. `inferMode`'s `*_VERBS` / `*_NOUN` regex tables matched the **user's text** to decide behavior — exactly the smell. The structured-enum path (`action` / `mode` enum, with `normalizeSubaction` aliases) matched the **planner output** and is preserved as the fast path.

## Verification

- `bun x tsc --noEmit -p packages/core/tsconfig.json` — 0 errors for touched files.
- `bun x @biomejs/biome lint` on both files — clean.
- Tests (`packages/core`), green **8/8**:
  - `plugin-manager-umbrella.test.ts` (existing surface tests) — unchanged, still pass.
  - `plugin-manager-routing.test.ts` (**new**, drives the real handler with a stubbed `plugin_manager` service + deterministic mock `useModel`):
    - structured planner `action` enum → dispatch with **no** model call;
    - legacy `mode: "installed"` alias normalizes to `list`, no model call;
    - NL `"install @elizaos/plugin-discord"` → LLM picks `install`, the machine-parsed name `@elizaos/plugin-discord` reaches the install handler;
    - no-match request → structured `clarify` reply, no dispatch.

## Behavior change

Free-form plugin-management utterances are now routed by one structured LLM extraction pass rather than English keyword regexes. Structured/planner calls (the `action`/`mode` enum) behave identically and still skip the model. The clarification fallback message is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)