### PR TITLE
ci(browser): gate remaining benchmark lanes

### DIFF
--- a/.github/workflows/browser-real-bench.yml
+++ b/.github/workflows/browser-real-bench.yml
@@ -1,13 +1,16 @@
-name: Browser Real-Chromium Benchmark
+name: Browser Benchmark Lanes
 
-# The deferred "Needs CI infra" lane of #9476, tracked by #10333: run the
-# plugin-browser MiniWoB++ benchmark suite against a REAL Chromium engine
-# (puppeteer-core) instead of JSDOM web mode. The `*.real.test.ts` lane is
-# excluded from the default `vitest run` and self-skips without a Chromium
-# binary, so it ONLY executes here, after `bunx playwright install chromium`
-# (mirroring scenario-pr.yml's `app-browser-core`). Gated like the other heavy
-# real lanes — nightly + on-demand + on changes to the benchmark/executor — not
-# on every PR.
+# Deferred "Needs CI infra" lanes of #9476, tracked by #10333:
+# - MiniWoB++ benchmark suite against a REAL Chromium engine (puppeteer-core)
+# - ScreenSpot-Web-style grounding against a REAL Chromium engine
+# - committed Mind2Web/WebArena-style external dataset fixtures through the
+#   plugin-browser BROWSER command router
+#
+# The `*.real.test.ts` lanes are excluded from the default `vitest run` and
+# self-skip without a Chromium binary, so they only execute here after
+# `bunx playwright install chromium` (mirroring scenario-pr.yml's
+# `app-browser-core`). Gated like the other heavy real lanes — nightly +
+# on-demand + on changes to the benchmark/executor — not on every PR.
 
 on:
   schedule:
@@ -17,7 +20,10 @@ on:
   pull_request:
     paths:
       - "plugins/plugin-browser/src/benchmark/**"
+      - "plugins/plugin-browser/vitest.real.config.ts"
       - "plugins/plugin-browser/scripts/run-miniwob-chromium-benchmark.mjs"
+      - "plugins/plugin-browser/scripts/capture-web-grounding-evidence.mjs"
+      - "plugins/plugin-browser/scripts/run-external-dataset-benchmark.mjs"
       - ".github/workflows/browser-real-bench.yml"
 
 concurrency:
@@ -64,7 +70,7 @@ jobs:
         run: bunx playwright install --with-deps chromium
 
       - name: Run MiniWoB++ on real Chromium (engine-parity lane)
-        run: bunx vitest run --config plugins/plugin-browser/vitest.real.config.ts plugins/plugin-browser/src/benchmark/__tests__/miniwob-chromium.real.test.ts
+        run: bun run --cwd plugins/plugin-browser test:real-chromium
 
       - name: Generate run-report artifacts (oracle + noop)
         run: |
@@ -77,4 +83,87 @@ jobs:
         with:
           name: miniwob-chromium-run
           path: .github/issue-evidence/10333-browser-real-chromium/*.json
+          if-no-files-found: warn
+
+  web-grounding-chromium:
+    name: Web grounding on real Chromium
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+          show-progress: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install Chromium
+        run: bunx playwright install --with-deps chromium
+
+      - name: Run web-element grounding on real Chromium
+        run: bun run --cwd plugins/plugin-browser test:real:grounding
+
+      - name: Generate grounding artifacts
+        run: bun run --cwd plugins/plugin-browser bench:grounding:chromium
+
+      - name: Upload grounding artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: web-grounding-chromium-run
+          path: .github/issue-evidence/10333-web-grounding/*
+          if-no-files-found: warn
+
+  external-dataset:
+    name: External dataset benchmark
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+          show-progress: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Assert external dataset benchmark contract
+        run: bunx vitest run src/benchmark/__tests__/external-dataset.test.ts
+        working-directory: plugins/plugin-browser
+
+      - name: Generate external dataset artifacts
+        run: |
+          bun run --cwd plugins/plugin-browser bench:external --policy oracle
+          bun run --cwd plugins/plugin-browser bench:external --policy noop
+          bun run --cwd plugins/plugin-browser bench:external --policy wrong
+
+      - name: Upload external dataset artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: external-dataset-run
+          path: .github/issue-evidence/10333-browser-external-dataset/*.json
           if-no-files-found: warn


### PR DESCRIPTION
## Summary

Completes the remaining #10333 CI-gating slice for the browser benchmark work. The existing workflow only ran MiniWoB++ on real Chromium, and its root-level Vitest command no longer matched `vitest.real.config.ts`'s `src/**/*.real.test.ts` include when reproduced locally.

This PR:
- fixes the MiniWoB++ real-Chromium workflow command to run through the plugin package script;
- adds a real-Chromium web-element grounding job;
- adds an external-dataset benchmark job for committed Mind2Web/WebArena-style fixtures;
- uploads artifacts for all three lanes.

## Validation

- `python3` + PyYAML parse of `.github/workflows/browser-real-bench.yml` — pass
- `bun run --cwd plugins/plugin-browser test:real-chromium` — pass, 1 file / 2 tests
- `bun run --cwd plugins/plugin-browser test:real:grounding` — pass, 1 file / 3 tests
- `(cd plugins/plugin-browser && bunx vitest run src/benchmark/__tests__/external-dataset.test.ts)` — pass, 1 file / 3 tests
- `bun run --cwd plugins/plugin-browser bench:external --policy oracle` — 3/3 solved
- `bun run --cwd plugins/plugin-browser bench:external --policy noop` — 0/3 solved
- `bun run --cwd plugins/plugin-browser bench:external --policy wrong` — 0/3 solved
- `bun run --cwd plugins/plugin-browser bench:grounding:chromium` — 3/3 grounded on local Chromium

## Notes

No app UI or Android surface is changed; screenshots/video are N/A for this workflow-only CI slice. Existing committed benchmark evidence remains unchanged; local regenerated artifacts were discarded.