### PR TITLE
fix(cloud/security): fail closed when prod rate limiting is misconfigured (#9853 P1.1)

### DIFF
--- a/packages/cloud/api/src/bootstrap-app.ts
+++ b/packages/cloud/api/src/bootstrap-app.ts
@@ -11,11 +11,13 @@ import { requestId } from "hono/request-id";
 import { secureHeaders } from "hono/secure-headers";
 import { runWithDbCacheAsync } from "@/db/client";
 import { ApiError, failureResponse } from "@/lib/api/cloud-worker-errors";
+import { buildRedisClient } from "@/lib/cache/redis-factory";
 import { corsMiddleware } from "@/lib/cors/cloud-api-hono-cors";
 import {
   getIpKey,
   getRequestIp,
   rateLimit,
+  rateLimitConfigVerdict,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { observeCloudRequest } from "@/lib/observability/cloud-backend-observability";
 import { runWithCloudBindingsAsync } from "@/lib/runtime/cloud-bindings";
@@ -257,6 +259,48 @@ export function createApp(): Hono<AppEnv> {
     );
   });
   app.route("/.well-known/jwks.json", jwksRoute);
+
+  // Rate-limit config guard (#9853 P1.1) — never let production silently serve
+  // with rate limiting OFF. The limiters fall open whenever REDIS_RATE_LIMITING
+  // is not "true" or no Redis client is reachable, which would leave the
+  // anon-mint / metered-inference paths unbounded. This evaluates once per
+  // isolate against the request-scoped env (the Worker has no boot-time env):
+  //   - prod + REDIS_RATE_LIMITING="true" but NO reachable Redis  → fail CLOSED
+  //     (503) — a deploy misconfiguration; surface it loudly instead of running
+  //     with limiters silently disabled.
+  //   - prod + REDIS_RATE_LIMITING!="true"  → loud WARN once (limiters disabled;
+  //     the documented #9853 ops cutover is: set REDIS_URL, flip the flag true).
+  let rateLimitConfigLogged = false;
+  app.use("*", async (c, next) => {
+    const env = c.env as { ENVIRONMENT?: string; REDIS_RATE_LIMITING?: string };
+    const verdict = rateLimitConfigVerdict({
+      environment: env.ENVIRONMENT,
+      redisRateLimiting: env.REDIS_RATE_LIMITING,
+      hasRedisClient: Boolean(buildRedisClient(c.env)),
+    });
+    if (!rateLimitConfigLogged) {
+      rateLimitConfigLogged = true;
+      if (verdict === "fail-closed") {
+        logger.error(
+          "[bootstrap-app] FATAL: REDIS_RATE_LIMITING=true in production but no Redis client is reachable (set the REDIS_URL secret). Failing closed — refusing traffic rather than serving with rate limiting silently disabled.",
+        );
+      } else if (verdict === "warn-disabled") {
+        logger.warn(
+          '[bootstrap-app] Rate limiting is DISABLED in production (REDIS_RATE_LIMITING!="true") — limiters fall open. Cutover (#9853 P1.1): provision Redis, set REDIS_URL, then set REDIS_RATE_LIMITING="true" and redeploy.',
+        );
+      }
+    }
+    if (verdict === "fail-closed") {
+      return c.json(
+        {
+          error: "Rate limiting misconfigured",
+          code: "RATE_LIMIT_UNAVAILABLE",
+        },
+        503,
+      );
+    }
+    await next();
+  });
 
   // Global IP-keyed backstop limiter. Routes with their own (tighter) limiter
   // still enforce it; this only guarantees that a route which forgot to add one

--- a/packages/cloud/shared/src/lib/middleware/rate-limit-config-verdict.test.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-config-verdict.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { rateLimitConfigVerdict } from "./rate-limit-hono-cloudflare";
+
+// #9853 P1.1 — production must never silently serve with rate limiting OFF.
+describe("rateLimitConfigVerdict", () => {
+  test("non-production is always ok (local/dev/staging may fall open)", () => {
+    for (const environment of [undefined, "staging", "development", "test"]) {
+      expect(
+        rateLimitConfigVerdict({
+          environment,
+          redisRateLimiting: "false",
+          hasRedisClient: false,
+        }),
+      ).toBe("ok");
+      expect(
+        rateLimitConfigVerdict({
+          environment,
+          redisRateLimiting: "true",
+          hasRedisClient: false,
+        }),
+      ).toBe("ok");
+    }
+  });
+
+  test("prod + limiting enabled + Redis reachable → ok", () => {
+    expect(
+      rateLimitConfigVerdict({
+        environment: "production",
+        redisRateLimiting: "true",
+        hasRedisClient: true,
+      }),
+    ).toBe("ok");
+  });
+
+  test("prod + REDIS_RATE_LIMITING=true but NO Redis → fail-closed (the deploy footgun)", () => {
+    expect(
+      rateLimitConfigVerdict({
+        environment: "production",
+        redisRateLimiting: "true",
+        hasRedisClient: false,
+      }),
+    ).toBe("fail-closed");
+  });
+
+  test("prod + limiting not enabled → warn-disabled (falls open today; ops cutover pending)", () => {
+    for (const redisRateLimiting of [undefined, "false", "0", "no"]) {
+      expect(
+        rateLimitConfigVerdict({
+          environment: "production",
+          redisRateLimiting,
+          hasRedisClient: false,
+        }),
+      ).toBe("warn-disabled");
+      // even with a reachable client, an un-flipped flag means limiting is off
+      expect(
+        rateLimitConfigVerdict({
+          environment: "production",
+          redisRateLimiting,
+          hasRedisClient: true,
+        }),
+      ).toBe("warn-disabled");
+    }
+  });
+});

--- a/packages/cloud/shared/src/lib/middleware/rate-limit-hono-cloudflare.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-hono-cloudflare.ts
@@ -27,6 +27,29 @@ function getRedis(env: Bindings): CompatibleRedis | null {
 }
 
 /**
+ * Verdict for the production rate-limit config guard (#9853 P1.1). The limiters
+ * fall open whenever Redis is unreachable, so production must never silently run
+ * with limiting disabled:
+ *   - `ok`            — limiting is on and Redis is reachable (or not production).
+ *   - `fail-closed`   — prod + REDIS_RATE_LIMITING="true" but no reachable Redis:
+ *                       a deploy misconfiguration — reject traffic + alert loudly.
+ *   - `warn-disabled` — prod + limiting not enabled: falls open; warn loudly so
+ *                       the ops cutover (provision Redis, flip the flag) is visible.
+ * Pure (takes a resolved `hasRedisClient`) so it is unit-testable without booting
+ * the Worker or a live Redis.
+ */
+export type RateLimitConfigVerdict = "ok" | "fail-closed" | "warn-disabled";
+export function rateLimitConfigVerdict(opts: {
+  environment?: string;
+  redisRateLimiting?: string;
+  hasRedisClient: boolean;
+}): RateLimitConfigVerdict {
+  if (opts.environment !== "production") return "ok";
+  if (opts.redisRateLimiting !== "true") return "warn-disabled";
+  return opts.hasRedisClient ? "ok" : "fail-closed";
+}
+
+/**
  * Resolve the client IP, preferring `cf-connecting-ip` (set by Cloudflare and
  * not spoofable by the client) over `x-forwarded-for` so a forged XFF header
  * cannot evade IP-keyed limits. Returns `undefined` when no IP is known.


### PR DESCRIPTION
Hardening for #9853 P1 item 1. The rate-limit **code** is fully implemented + unit-tested, but every limiter **falls open** when Redis is unreachable, and `REDIS_RATE_LIMITING` is `"false"` in deployed envs — so production can silently serve the anon-mint + metered-inference paths with **no limiting** (the unbounded-cost vuln the item targets). Worse, a future flip of the flag to `true` without provisioning Redis would degrade silently rather than fail.

**This PR makes that impossible to do silently.** Adds `rateLimitConfigVerdict()` (pure, unit-tested) + an early once-per-isolate guard in `bootstrap-app`:
- **prod + `REDIS_RATE_LIMITING="true"` but no reachable Redis → `503` fail-closed** + loud `[FATAL]` log. A deploy misconfiguration surfaces immediately instead of running with limiting silently off.
- **prod + limiting not enabled → loud `[WARN]` once** — it falls open today; the documented ops cutover is logged.
- Non-production unaffected (local/staging may fall open).

**Deliberately does NOT flip the committed `REDIS_RATE_LIMITING` flag.** Flipping it without a provisioned Redis would hard-503 the live API on the next deploy. The flag flip is the coordinated **ops cutover**, and this guard makes that flip *safe* (it can no longer silently fall open).

**Remaining ops step (not code):** provision Railway TCP Redis, set the `REDIS_URL` Wrangler secret in staging+prod, set `REDIS_RATE_LIMITING="true"`, redeploy, and verify anon-mint/inference return `429` past the cap.

**Verification:** `rateLimitConfigVerdict` test 4/4; `cloud/api` + `cloud/shared` typecheck clean; biome clean.

Refs #9853 (P1 item 1). Security PR — for maintainer review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)