### PR TITLE
[codex] Expose playlist add and delete in music umbrella

### DIFF
--- a/plugins/plugin-music/AGENTS.md
+++ b/plugins/plugin-music/AGENTS.md
@@ -9,7 +9,7 @@ Adds comprehensive music capability to an Eliza agent: playback of YouTube and d
 ## Plugin Surface
 
 ### Actions
-- **`MUSIC`** (`src/actions/music.ts`) — Umbrella action. Dispatches all music operations via a verb-shaped `action` parameter: `play`, `pause`, `resume`, `skip`, `stop`, `queue_view`, `queue_add`, `queue_clear`, `playlist_play`, `playlist_save`, `search`, `play_query`, `download`, `play_audio`, `set_routing`, `set_zone`, `generate`, `extend`, `custom_generate`. Legacy aliases are accepted (e.g. `playlist`, `search_youtube`, `routing`, `zones`).
+- **`MUSIC`** (`src/actions/music.ts`) — Umbrella action. Dispatches all music operations via a verb-shaped `action` parameter: `play`, `pause`, `resume`, `skip`, `stop`, `queue_view`, `queue_add`, `queue_clear`, `playlist_play`, `playlist_save`, `playlist_delete`, `playlist_add`, `search`, `play_query`, `download`, `play_audio`, `set_routing`, `set_zone`, `generate`, `extend`, `custom_generate`. Legacy aliases are accepted (e.g. `playlist`, `search_youtube`, `routing`, `zones`).
 
 ### Services
 - **`MusicService`** (`src/service.ts`, serviceType: `"music"`) — Core playback engine. Manages per-guild queues, audio broadcasting, Discord voice wiring, audio routing, and the `AudioCacheService`.
@@ -201,7 +201,7 @@ bun run --cwd plugins/plugin-music test:e2e       # live smoke (requires running
 - **ffmpeg/ffprobe required.** Bundled via `ffmpeg-static`/`ffprobe-static` deps; paths overridden by `FFMPEG_PATH`/`FFPROBE_PATH`.
 - **Discord wiring is deferred.** The plugin init waits for the `discord` service load promise before wiring the voice manager. Music works web-only if Discord is absent.
 - **`@elizaos/plugin-suno` is a hard dep.** Generation subactions (`generate`, `extend`, `custom_generate`) delegate to `sunoGenerateMusicHandler` from that package; they are skipped/unreachable if `SUNO_API_KEY` is absent.
-- **Confirmation required for destructive ops.** `skip`, `stop`, `queue_add`, `queue_clear`, `playlist_save`, and `download` require `confirmed: true` in the action options (gated via `requireMusicConfirmation` in `src/actions/confirmation.ts`).
+- **Confirmation required for destructive ops.** `skip`, `stop`, `queue_add`, `queue_clear`, `playlist_save`, `playlist_delete`, `playlist_add`, and `download` require confirmation through `requireMusicConfirmation` in `src/actions/confirmation.ts`.
 - **MusicBrainz is the zero-config metadata source.** All other metadata APIs (Last.fm, Genius, TheAudioDB) are optional enhancements.
 - **MusicStorageService is a standalone exported utility.** It is not registered as a plugin service or auto-wired into `MusicLibraryService`; it is exported from `src/index.ts` for callers that want a permanent high-quality archive. Storage dir (`<cwd>/storage/music`) and quality mode are constructor arguments, not env vars.
 - **`@elizaos/plugin-sql` is expected for persistence.** Library, playlists, preferences, and analytics components write to the agent's database via runtime memory/cache APIs.

--- a/plugins/plugin-music/CLAUDE.md
+++ b/plugins/plugin-music/CLAUDE.md
@@ -9,7 +9,7 @@ Adds comprehensive music capability to an Eliza agent: playback of YouTube and d
 ## Plugin Surface
 
 ### Actions
-- **`MUSIC`** (`src/actions/music.ts`) — Umbrella action. Dispatches all music operations via a verb-shaped `action` parameter: `play`, `pause`, `resume`, `skip`, `stop`, `queue_view`, `queue_add`, `queue_clear`, `playlist_play`, `playlist_save`, `search`, `play_query`, `download`, `play_audio`, `set_routing`, `set_zone`, `generate`, `extend`, `custom_generate`. Legacy aliases are accepted (e.g. `playlist`, `search_youtube`, `routing`, `zones`).
+- **`MUSIC`** (`src/actions/music.ts`) — Umbrella action. Dispatches all music operations via a verb-shaped `action` parameter: `play`, `pause`, `resume`, `skip`, `stop`, `queue_view`, `queue_add`, `queue_clear`, `playlist_play`, `playlist_save`, `playlist_delete`, `playlist_add`, `search`, `play_query`, `download`, `play_audio`, `set_routing`, `set_zone`, `generate`, `extend`, `custom_generate`. Legacy aliases are accepted (e.g. `playlist`, `search_youtube`, `routing`, `zones`).
 
 ### Services
 - **`MusicService`** (`src/service.ts`, serviceType: `"music"`) — Core playback engine. Manages per-guild queues, audio broadcasting, Discord voice wiring, audio routing, and the `AudioCacheService`.
@@ -201,7 +201,7 @@ bun run --cwd plugins/plugin-music test:e2e       # live smoke (requires running
 - **ffmpeg/ffprobe required.** Bundled via `ffmpeg-static`/`ffprobe-static` deps; paths overridden by `FFMPEG_PATH`/`FFPROBE_PATH`.
 - **Discord wiring is deferred.** The plugin init waits for the `discord` service load promise before wiring the voice manager. Music works web-only if Discord is absent.
 - **`@elizaos/plugin-suno` is a hard dep.** Generation subactions (`generate`, `extend`, `custom_generate`) delegate to `sunoGenerateMusicHandler` from that package; they are skipped/unreachable if `SUNO_API_KEY` is absent.
-- **Confirmation required for destructive ops.** `skip`, `stop`, `queue_add`, `queue_clear`, `playlist_save`, and `download` require `confirmed: true` in the action options (gated via `requireMusicConfirmation` in `src/actions/confirmation.ts`).
+- **Confirmation required for destructive ops.** `skip`, `stop`, `queue_add`, `queue_clear`, `playlist_save`, `playlist_delete`, `playlist_add`, and `download` require confirmation through `requireMusicConfirmation` in `src/actions/confirmation.ts`.
 - **MusicBrainz is the zero-config metadata source.** All other metadata APIs (Last.fm, Genius, TheAudioDB) are optional enhancements.
 - **MusicStorageService is a standalone exported utility.** It is not registered as a plugin service or auto-wired into `MusicLibraryService`; it is exported from `src/index.ts` for callers that want a permanent high-quality archive. Storage dir (`<cwd>/storage/music`) and quality mode are constructor arguments, not env vars.
 - **`@elizaos/plugin-sql` is expected for persistence.** Library, playlists, preferences, and analytics components write to the agent's database via runtime memory/cache APIs.

--- a/plugins/plugin-music/README.md
+++ b/plugins/plugin-music/README.md
@@ -129,6 +129,8 @@ All music operations route through a single **`MUSIC`** action with a verb-shape
 | `queue_clear` | Clear the queue (requires `confirmed: true`) |
 | `playlist_play` | Load and play a saved playlist |
 | `playlist_save` | Save current queue as a playlist (requires `confirmed: true`) |
+| `playlist_delete` | Delete a saved playlist (requires confirmation) |
+| `playlist_add` | Add a song to a playlist (requires confirmation) |
 | `search` | Search YouTube for music |
 | `play_query` | Smart natural-language music query (search + play) |
 | `download` | Download a track to the local library (requires `confirmed: true`) |
@@ -172,4 +174,3 @@ This plugin works alongside:
 - **`@elizaos/plugin-discord`** — Provides voice channel playback (wired automatically on init)
 - **`@elizaos/plugin-sql`** — Required for persistent library and playlist storage
 - **`@elizaos/plugin-suno`** — Required for AI generation subactions
-

--- a/plugins/plugin-music/src/__tests__/core-test-mock.ts
+++ b/plugins/plugin-music/src/__tests__/core-test-mock.ts
@@ -27,6 +27,13 @@ vi.mock("@elizaos/core", () => {
       TEXT_LARGE: "TEXT_LARGE",
       TEXT_SMALL: "TEXT_SMALL",
     },
+    gateDestructiveConfirmation: vi.fn(async (args) => {
+      await args.callback?.({
+        text: args.prompt,
+        source: args.message?.content?.source,
+      });
+      return { status: "pending" };
+    }),
     getActiveRoutingContextsForTurn: vi.fn(() => []),
     parseKeyValueXml: (xml: string) => {
       const result: Record<string, string> = {};

--- a/plugins/plugin-music/src/actions/music.ts
+++ b/plugins/plugin-music/src/actions/music.ts
@@ -49,6 +49,8 @@ const MUSIC_SUBACTIONS = [
   // library
   "playlist_play",
   "playlist_save",
+  "playlist_delete",
+  "playlist_add",
   "search",
   "play_query",
   "download",
@@ -79,7 +81,7 @@ type DispatchKind =
     };
 
 type LibraryOp = "playlist" | "play_query" | "search_youtube" | "download";
-type PlaylistOp = "save" | "load";
+type PlaylistOp = "save" | "load" | "delete" | "add";
 
 /**
  * Legacy alias → canonical verb. Both the old MUSIC ops (e.g. `playlist`,
@@ -105,6 +107,10 @@ const SUBACTION_ALIASES: Record<string, MusicSubaction> = {
   play_playlist: "playlist_play",
   load_playlist: "playlist_play",
   save_playlist: "playlist_save",
+  create_playlist: "playlist_save",
+  delete_playlist: "playlist_delete",
+  remove_playlist: "playlist_delete",
+  add_to_playlist: "playlist_add",
   search_youtube: "search",
   youtube_search: "search",
   find: "search",
@@ -166,6 +172,16 @@ const PLAYLIST_SAVE_TOKENS = new Set([
   "playlist_save",
   "playlist_create",
 ]);
+
+const PLAYLIST_DELETE_TOKENS = new Set([
+  "delete",
+  "remove",
+  "playlist_delete",
+  "delete_playlist",
+  "remove_playlist",
+]);
+
+const PLAYLIST_ADD_TOKENS = new Set(["add", "playlist_add", "add_to_playlist"]);
 
 function normalizeToken(value: unknown): string | null {
   if (typeof value !== "string") return null;
@@ -297,6 +313,8 @@ Allowed actions:
 - queue_clear: clear the queue
 - playlist_play: load or play a saved playlist
 - playlist_save: save the current queue or songs as a playlist
+- playlist_delete: delete or remove a saved playlist
+- playlist_add: add a requested song to a saved playlist
 - search: search YouTube/music results without necessarily playing
 - play_query: research/find music and play or queue the best match
 - download: download/fetch music into the local library
@@ -311,7 +329,7 @@ Request:
 ${text}
 
 Return ONLY:
-<response><action>play|pause|resume|skip|stop|queue_view|queue_add|queue_clear|playlist_play|playlist_save|search|play_query|download|play_audio|set_routing|set_zone|generate|extend|custom_generate</action></response>`;
+<response><action>play|pause|resume|skip|stop|queue_view|queue_add|queue_clear|playlist_play|playlist_save|playlist_delete|playlist_add|search|play_query|download|play_audio|set_routing|set_zone|generate|extend|custom_generate</action></response>`;
 
   try {
     const raw = await runtime.useModel(ModelType.TEXT_SMALL, { prompt });
@@ -337,12 +355,16 @@ function resolvePlaylistOpFromOptions(
 ): PlaylistOp | null {
   if (subaction === "playlist_save") return "save";
   if (subaction === "playlist_play") return "load";
+  if (subaction === "playlist_delete") return "delete";
+  if (subaction === "playlist_add") return "add";
   const tokens = [merged.playlistOp, merged.subaction, merged.action, merged.op]
     .map((value) => normalizeToken(value))
     .filter((value): value is string => Boolean(value));
   for (const token of tokens) {
     if (PLAYLIST_LOAD_TOKENS.has(token)) return "load";
     if (PLAYLIST_SAVE_TOKENS.has(token)) return "save";
+    if (PLAYLIST_DELETE_TOKENS.has(token)) return "delete";
+    if (PLAYLIST_ADD_TOKENS.has(token)) return "add";
   }
   return null;
 }
@@ -378,6 +400,18 @@ function dispatchKindFor(
         kind: "library",
         libraryOp: "playlist",
         playlistOp: "save",
+      };
+    case "playlist_delete":
+      return {
+        kind: "library",
+        libraryOp: "playlist",
+        playlistOp: "delete",
+      };
+    case "playlist_add":
+      return {
+        kind: "library",
+        libraryOp: "playlist",
+        playlistOp: "add",
       };
     case "search":
       return { kind: "library", libraryOp: "search_youtube" };
@@ -541,19 +575,19 @@ export const musicAction: Action = {
   description:
     "Music action. Use verb-shaped action for everything: " +
     "playback (play, pause, resume, skip, stop), queue (queue_view, queue_add, queue_clear), " +
-    "library (playlist_play, playlist_save, search, play_query, download, play_audio), " +
+    "library (playlist_play, playlist_save, playlist_delete, playlist_add, search, play_query, download, play_audio), " +
     "routing/zones (set_routing, set_zone), " +
     "generation (generate, extend, custom_generate — Suno-backed, requires SUNO_API_KEY). " +
-    "skip, stop, queue_add, queue_clear, playlist_save, and download require confirmed:true.",
+    "skip, stop, queue_add, queue_clear, playlist_save, playlist_delete, playlist_add, and download require confirmation.",
   descriptionCompressed:
-    "Verb-shaped: play/pause/resume/skip/stop, queue_view/queue_add/queue_clear, playlist_play/playlist_save, search/play_query/download/play_audio, set_routing/set_zone, generate/extend/custom_generate.",
+    "Verb-shaped: play/pause/resume/skip/stop, queue_view/queue_add/queue_clear, playlist_play/playlist_save/playlist_delete/playlist_add, search/play_query/download/play_audio, set_routing/set_zone, generate/extend/custom_generate.",
   parameters: [
     {
       name: "action",
       description:
         "Verb-shaped subaction. Playback: play, pause, resume, skip, stop. " +
         "Queue: queue_view, queue_add, queue_clear. " +
-        "Library: playlist_play, playlist_save, search, play_query, download, play_audio. " +
+        "Library: playlist_play, playlist_save, playlist_delete, playlist_add, search, play_query, download, play_audio. " +
         "Routing/zones: set_routing, set_zone. " +
         "Generation (Suno): generate, extend, custom_generate. " +
         "Legacy aliases (e.g. queue, playlist, search_youtube, routing, zones, custom) are still accepted.",
@@ -577,7 +611,8 @@ export const musicAction: Action = {
     },
     {
       name: "playlistName",
-      description: "Playlist name for playlist_play / playlist_save.",
+      description:
+        "Playlist name for playlist_play / playlist_save / playlist_delete / playlist_add.",
       required: false,
       schema: { type: "string" },
     },

--- a/plugins/plugin-music/src/plugin-compression.test.ts
+++ b/plugins/plugin-music/src/plugin-compression.test.ts
@@ -1,5 +1,23 @@
+import type { HandlerCallback, IAgentRuntime, Memory } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import musicPlugin from "./index";
+
+function musicAction() {
+  const action = musicPlugin.actions?.find((a) => a.name === "MUSIC");
+  expect(action).toBeDefined();
+  if (!action) throw new Error("MUSIC action not registered");
+  return action;
+}
+
+function message(text = ""): Memory {
+  return {
+    id: "00000000-0000-0000-0000-000000000001",
+    entityId: "00000000-0000-0000-0000-000000000002",
+    agentId: "00000000-0000-0000-0000-000000000003",
+    roomId: "00000000-0000-0000-0000-000000000004",
+    content: { text, source: "test" },
+  } as Memory;
+}
 
 describe("music plugin compression", () => {
   it("registers library + playback providers", () => {
@@ -19,7 +37,7 @@ describe("music plugin compression", () => {
   });
 
   it("declares MUSIC subactions structurally on the action parameter", () => {
-    const action = musicPlugin.actions?.find((a) => a.name === "MUSIC");
+    const action = musicAction();
     const actionParameter = action?.parameters?.find(
       (parameter) => parameter.name === "action",
     );
@@ -36,6 +54,8 @@ describe("music plugin compression", () => {
         "queue_clear",
         "playlist_play",
         "playlist_save",
+        "playlist_delete",
+        "playlist_add",
         "search",
         "play_query",
         "download",
@@ -50,9 +70,68 @@ describe("music plugin compression", () => {
   });
 
   it("exposes MUSIC descriptionCompressed", () => {
-    const action = musicPlugin.actions?.find((a) => a.name === "MUSIC");
+    const action = musicAction();
     expect(action?.descriptionCompressed).toBe(
-      "Verb-shaped: play/pause/resume/skip/stop, queue_view/queue_add/queue_clear, playlist_play/playlist_save, search/play_query/download/play_audio, set_routing/set_zone, generate/extend/custom_generate.",
+      "Verb-shaped: play/pause/resume/skip/stop, queue_view/queue_add/queue_clear, playlist_play/playlist_save/playlist_delete/playlist_add, search/play_query/download/play_audio, set_routing/set_zone, generate/extend/custom_generate.",
+    );
+  });
+
+  it("routes playlist_delete through the MUSIC umbrella", async () => {
+    const action = musicAction();
+    const callbacks: string[] = [];
+    const callback: HandlerCallback = async ({ text }) => {
+      callbacks.push(text ?? "");
+      return [];
+    };
+    const runtime = {
+      getService: (name: string) =>
+        name === "musicLibrary" ? { loadPlaylists: async () => [] } : null,
+    } as unknown as IAgentRuntime;
+
+    const result = await action.handler?.(
+      runtime,
+      message(),
+      undefined,
+      { action: "playlist_delete", playlistName: "Focus" },
+      callback,
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      error: "No playlists available",
+    });
+    expect(callbacks).toEqual([
+      "You don't have any saved playlists to delete.",
+    ]);
+  });
+
+  it("routes playlist_add through the MUSIC umbrella", async () => {
+    const action = musicAction();
+    const callbacks: string[] = [];
+    const callback: HandlerCallback = async ({ text }) => {
+      callbacks.push(text ?? "");
+      return [];
+    };
+    const runtime = {} as unknown as IAgentRuntime;
+
+    const result = await action.handler?.(
+      runtime,
+      message(),
+      undefined,
+      {
+        action: "playlist_add",
+        playlistName: "Focus",
+        song: "Aphex Twin Avril 14th",
+      },
+      callback,
+    );
+
+    expect(result?.data).toMatchObject({
+      requiresConfirmation: true,
+      awaitingUserInput: true,
+    });
+    expect(callbacks[0]).toContain(
+      'Confirmation required before adding "Aphex Twin Avril 14th" to playlist "Focus".',
     );
   });
 });


### PR DESCRIPTION
## Summary

Expose `playlist_delete` and `playlist_add` as first-class `MUSIC` umbrella subactions.

## Why

The lower playlist handler already supports `save`, `load`, `delete`, and `add`, but the compressed `MUSIC` action only exposed `playlist_play` and `playlist_save`. After the recent plugin-music cleanup removed prose fallback inference, delete/add became unreachable through the planner-facing umbrella action.

## What Changed

- Adds canonical `playlist_delete` and `playlist_add` verbs to `MUSIC`.
- Maps legacy aliases such as `delete_playlist`, `remove_playlist`, and `add_to_playlist`.
- Routes the new verbs into `MUSIC_LIBRARY` with `playlistOp=delete` / `playlistOp=add`.
- Updates MUSIC action descriptions, extraction prompt enum, README, and package-local agent docs.
- Extends plugin-music tests to verify delete/add route through the umbrella.
- Updates the plugin-music core test mock for `gateDestructiveConfirmation`, which the playlist confirmation path imports from core.

## Validation

- `bun run --cwd plugins/plugin-music test src/plugin-compression.test.ts`
- `bun run --cwd plugins/plugin-music typecheck`
- `bun run --cwd plugins/plugin-music lint:check`
