### PR TITLE
chore(cloud): arm rate limiting in staging + production (#9853 P1.1)

### DIFF
--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -320,7 +320,7 @@ CACHE_ENABLED = "true"
 # (Railway TCP) is set, else the legacy Upstash REST fallback. "redis-rest"
 # would force the dead Upstash path and skip Railway Redis (client.ts:235).
 CACHE_BACKEND = "auto"
-REDIS_RATE_LIMITING = "false"
+REDIS_RATE_LIMITING = "true"
 # Tier-2 optimistic off-path billing (#9899). INFERENCE_OPTIMISTIC_BILLING
 # enables it; when "true" with a writable KV backstop, an org clearing
 # SAFE_BALANCE_THRESHOLD skips the sync reserve and debits actual cost off the
@@ -456,7 +456,7 @@ CACHE_ENABLED = "true"
 # (Railway TCP) is set, else the legacy Upstash REST fallback. "redis-rest"
 # would force the dead Upstash path and skip Railway Redis (client.ts:235).
 CACHE_BACKEND = "auto"
-REDIS_RATE_LIMITING = "false"
+REDIS_RATE_LIMITING = "true"
 # Tier-2 optimistic off-path billing (#9899). INFERENCE_OPTIMISTIC_BILLING
 # enables it; when "true" with a writable KV backstop, an org clearing
 # SAFE_BALANCE_THRESHOLD skips the sync reserve and debits actual cost off the


### PR DESCRIPTION
Flips `REDIS_RATE_LIMITING` false→true in staging + production Worker vars (base stays false for local dev). Both envs already have the `REDIS_URL` secret, and #10609's fail-closed guard protects a misconfigured deploy.

**Verified LIVE on staging** (deployed `eliza-cloud-api-staging` version `c5822bec`): the anon-session-mint CRITICAL limiter (5/5min per IP) returns **429 after the 5th request** — Redis-backed enforcement is on. Staging cutover done.

Production arms on the next develop→main release (the flag is now in config; Redis + guard are ready). Refs #9853 (P1.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)