### PR TITLE
[codex] test(app): align cloud startup smoke with first-run chooser

### DIFF
--- a/.github/issue-evidence/8434-cloud-onboarding-qa/README.md
+++ b/.github/issue-evidence/8434-cloud-onboarding-qa/README.md
@@ -1,0 +1,34 @@
+# #8434 cloud onboarding QA evidence
+
+PR: #10627
+
+Validated code commit: `daafb53fc0e3b309ee75a6feb02b7e8d2c3b1d78`
+
+The final PR head adds this evidence README only; the smoke-test code validated above is unchanged.
+
+Scope:
+- Test-only update to `packages/app/test/ui-smoke/cloud-provisioning-startup.spec.ts`.
+- Aligns the cloud provisioning startup smoke with the current floating first-run Cloud runtime chooser.
+- Keeps the startup fixture fresh by returning `firstRunComplete: false`, no agents, and no defaults from `/api/config`.
+- Falls back to the accessible `Create a new agent` button name when the older `onboarding-agent-create` test id is absent.
+
+Validation run on 2026-07-01:
+- `git diff --check origin/develop...HEAD` -> pass.
+- `bunx biome check packages/app/test/ui-smoke/cloud-provisioning-startup.spec.ts` -> pass.
+- `bun run --cwd packages/shared build:i18n` -> generated the local shared i18n artifact required by the focused unit test.
+- `bun test packages/ui/src/api/app-shell-capabilities.test.ts` -> pass, 4 tests.
+- `bun run --cwd packages/core build` -> pass.
+- `bun run --cwd packages/shared build` -> pass.
+- `ELIZA_UI_SMOKE_PORT=42138 ELIZA_UI_SMOKE_API_PORT=42137 ELIZA_UI_SMOKE_DISABLE_VIDEO=1 bunx playwright test --config playwright.ui-smoke.config.ts test/ui-smoke/first-run-startup.spec.ts test/ui-smoke/cloud-provisioning-startup.spec.ts --project=chromium` -> pass, 6 Chromium tests.
+
+Playwright coverage:
+- `cloud provisioning reaches chat from startup on mobile`
+- `cloud provisioning reaches chat from startup on desktop`
+- `cloud provisioning reaches chat from startup on wide-web`
+- `new cloud agent provisions through direct cloud sandbox and reaches chat`
+- `first-run chooser renders without a render loop and lets the runtime be chosen`
+- `fresh first-run offers to restore an existing local backup before onboarding`
+
+Artifacts not applicable:
+- Full app aesthetic audit: N/A, this PR changes only a Playwright smoke test, not app UI implementation or styling.
+- Live OAuth/Google sign-in: N/A for this deterministic startup compatibility smoke; live private-account staging sign-in remains an operator/manual account proof.

--- a/.github/issue-evidence/8434-cloud-onboarding-qa/README.md
+++ b/.github/issue-evidence/8434-cloud-onboarding-qa/README.md
@@ -2,9 +2,11 @@
 
 PR: #10627
 
-Validated code commit: `daafb53fc0e3b309ee75a6feb02b7e8d2c3b1d78`
+Validated smoke-test code commit: `5a8687bd0b1487702fed6515c77c848269bd6197`
 
-The final PR head adds this evidence README only; the smoke-test code validated above is unchanged.
+Evidence README commit: `d07d444e03747a7733b2c9d32f48f4b7a5ecef6b`
+
+The final PR head adds this evidence README plus evidence-only corrections; the smoke-test code validated above is unchanged from `5a8687bd0b1487702fed6515c77c848269bd6197`.
 
 Scope:
 - Test-only update to `packages/app/test/ui-smoke/cloud-provisioning-startup.spec.ts`.

--- a/packages/app/test/ui-smoke/cloud-provisioning-startup.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-provisioning-startup.spec.ts
@@ -120,19 +120,23 @@ async function clickIfVisible(
 }
 
 async function startCloudRuntime(page: Page): Promise<void> {
-  // For an already-authenticated user, first-run onboarding skips the "How should
-  // Eliza run?" runtime choice and goes straight to the "Choose your agent"
-  // picker, fetching the account's existing cloud agents. Driving "Create new"
-  // provisions a fresh agent through the local cloud proxy. A brand-new account
-  // with zero agents skips the picker entirely and auto-creates — both paths land
-  // on the same create route, so absence of the picker is fine.
-  const createNew = page.getByTestId("onboarding-agent-create");
-  await createNew.waitFor({ state: "visible", timeout: 30_000 }).catch(() => {
-    /* no picker: zero-agent account auto-creates without a picker step */
-  });
-  if (await createNew.isVisible().catch(() => false)) {
-    await createNew.click();
-  }
+  const cloudRuntime = page.getByTestId("first-run-chooser-cloud");
+  if (await clickIfVisible(cloudRuntime, 10_000)) return;
+
+  // Some authenticated recovery paths can still hydrate directly at the agent
+  // picker before the floating runtime chooser paints.
+  const createNew = page
+    .getByTestId("onboarding-agent-create")
+    .or(page.getByRole("button", { name: /create a new agent/i }));
+  await clickIfVisible(createNew, 2_000);
+}
+
+async function chooseNewCloudAgent(page: Page): Promise<void> {
+  const createNew = page
+    .getByTestId("onboarding-agent-create")
+    .or(page.getByRole("button", { name: /create a new agent/i }));
+  await createNew.waitFor({ state: "visible", timeout: 30_000 });
+  await createNew.click();
 }
 
 async function installCloudConnectionRoutes(
@@ -165,6 +169,22 @@ async function installCloudConnectionRoutes(
       low: false,
       critical: false,
       authRejected: false,
+    });
+  });
+}
+
+async function installFreshFirstRunConfigRoute(page: Page): Promise<void> {
+  await page.route("**/api/config", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    await fulfillJson(route, 200, {
+      meta: { firstRunComplete: false },
+      agents: {
+        list: [],
+        defaults: {},
+      },
     });
   });
 }
@@ -414,6 +434,7 @@ for (const viewport of VIEWPORTS) {
     );
 
     await installDefaultAppRoutes(page);
+    await installFreshFirstRunConfigRoute(page);
     await installCloudConnectionRoutes(page, "cloud-provisioning-smoke-user");
     await installDirectCloudLoginRoutes(page, "cloud-provisioning-smoke-user");
     await installDirectCloudSandboxRoutes(page, {
@@ -665,6 +686,7 @@ for (const viewport of VIEWPORTS) {
     await clickIfVisible(
       page.getByRole("button", { name: /sign in with eliza cloud/i }),
     );
+    await chooseNewCloudAgent(page);
 
     // "Create new" in the picker provisions a fresh dedicated cloud agent via the
     // local cloud proxy, then writes the first-run profile.


### PR DESCRIPTION
## Summary

- Updates the cloud provisioning startup smoke to drive the current floating first-run Cloud runtime chooser before the Eliza Cloud agent picker.
- Keeps the startup fixture genuinely fresh by overriding `/api/config` to report `firstRunComplete: false` with no existing agents/defaults.
- Uses the accessible `Create a new agent` button label as a fallback because the current picker no longer exposes the old `onboarding-agent-create` test id.

## Root Cause

After the first-run chooser follow-up merged, this compat smoke still assumed the old flow: an authenticated user would land directly on the agent picker and the picker create button carried `onboarding-agent-create`. On current `develop`, the fresh Cloud path goes through the floating runtime chooser and the visible create button is only role/name-addressable, so the test stopped creating the agent even though the product UI was showing the right prompt.

## Validation

- `bunx biome check packages/app/test/ui-smoke/cloud-provisioning-startup.spec.ts`
- `bun test packages/ui/src/api/app-shell-capabilities.test.ts`
- `ELIZA_UI_SMOKE_PORT=42138 ELIZA_UI_SMOKE_API_PORT=42137 ELIZA_UI_SMOKE_DISABLE_VIDEO=1 bunx playwright test --config playwright.ui-smoke.config.ts test/ui-smoke/first-run-startup.spec.ts test/ui-smoke/cloud-provisioning-startup.spec.ts --project=chromium`