### PR TITLE
fix(training): rm -rf cleanup in ci_smoke_e2e (no node in python container)

### DIFF
--- a/packages/training/scripts/ci_smoke_e2e.sh
+++ b/packages/training/scripts/ci_smoke_e2e.sh
@@ -12,11 +12,13 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-REPO_ROOT="$(cd ../.. && pwd)"
-RM_PATH_RECURSIVE="$REPO_ROOT/packages/scripts/rm-path-recursive.mjs"
 PY=${PY:-python3}
 WORK=$(mktemp -d -t eliza-ci-XXXXXX)
-trap 'node "$RM_PATH_RECURSIVE" "$WORK"' EXIT
+# This smoke runs in a python-only container with no node on PATH, so clean the
+# mktemp scratch dir with rm -rf (repo convention) instead of the node helper —
+# otherwise the EXIT trap fails with `node: command not found` (exit 127) even
+# after every smoke phase passes.
+trap 'rm -rf "$WORK"' EXIT
 
 step() { echo; echo "[ci-smoke] $*"; }
 fail() { echo "[ci-smoke] FAIL: $*" >&2; exit 1; }


### PR DESCRIPTION
## Problem

The **Training Stack** workflow (`.github/workflows/training-stack.yml`) has been red on develop across its last runs (e.g. commit `0dae6d06f`, and `13e86ad54` on 06-29 — so this predates the biome bump). The failing job is *CPU smoke (lint + import)* → *Corpus-quality chain end-to-end smoke*.

Root cause: the smoke itself **passes** —
```
[ci-smoke] OK — all smoke phases of the corpus-quality chain passed
```
— but `packages/training/scripts/ci_smoke_e2e.sh` then runs its `EXIT` trap:
```bash
trap 'node "$RM_PATH_RECURSIVE" "$WORK"' EXIT
```
The smoke runs inside a **python-only Docker container** (per `training-stack.yml:121-123`) with **no `node` on PATH**. So the trap fails with `node: command not found` → exit **127**, turning a passing run into a failure.

## Fix

Clean the `mktemp` scratch dir with `rm -rf "$WORK"` — the repo's own convention across many shell scripts (`packages/research/chip/...`, `packages/homepage/public/install.sh`, etc.). The node `rm-path-recursive.mjs` helper is only appropriate in node-having build contexts; this script is explicitly *"Designed to need NO external network and NO GPU"* and is invoked only by the python container. Dead `REPO_ROOT`/`RM_PATH_RECURSIVE` vars removed.

## Verification

```
$ bash scripts/ci_smoke_e2e.sh ; echo $?
[ci-smoke] OK — all smoke phases of the corpus-quality chain passed
0
```
Exit 0, no `node: command not found`. `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)