### PR TITLE
test(agent-stability): prove memory-watchdog RSS breach drives supervised restart (#10197)

### DIFF
--- a/.github/issue-evidence/10197-memory-watchdog-e2e/README.md
+++ b/.github/issue-evidence/10197-memory-watchdog-e2e/README.md
@@ -1,0 +1,59 @@
+# #10197 — memory-watchdog → supervised-restart end-to-end proof
+
+## Gap closed
+
+The memory watchdog (`packages/agent/src/runtime/memory-watchdog.ts`) was
+covered in three disjoint pieces:
+- `memory-watchdog.test.ts` — unit test of `createMemoryWatchdog`'s
+  threshold/debounce/one-shot logic with **fake** deps.
+- `crash-restart-supervisor.test.ts` — real spawned-process proof that
+  `RESTART_EXIT_CODE=75` drives the supervisor's respawn/storm-guard contract,
+  but only via the `crash-injection` fixture.
+
+Nothing drove a **real process whose real RSS crosses the threshold through the
+real `requestRestart` seam**. Per PR_EVIDENCE ("real E2E, no larp"), that seam
+is now proven end to end.
+
+## What the new fixture + tests do
+
+`packages/agent/test/fixtures/memory-watchdog-child.ts` (spawned under `bun`):
+1. Registers the **same restart handler production uses**
+   (`app-core/src/cli/run-main.ts` → `setRestartHandler(() => process.exit(RESTART_EXIT_CODE))`).
+2. Holds `CRASH_CHILD_ALLOC_MB` of **page-touched** heap so
+   `process.memoryUsage().rss` genuinely climbs.
+3. Starts the real `startMemoryWatchdog()` (real RSS source + real
+   `requestRestart`).
+4. A ref'd guard timer fails loud (exit 2) if the watchdog never fires.
+
+Three gated e2e cases added to `crash-restart-supervisor.test.ts`
+(`RUN_CRASH_RESTART_E2E=1`, out of the fast unit lane):
+- **trips**: 400 MB held, 128 MB threshold, sustained=1 → real watchdog samples
+  RSS 570 MB ≥ 128 MB → `requestRestart` → `process.exit(75)`.
+- **stays quiet under threshold**: 64 GB threshold → no restart → guard exit 2.
+- **respects the opt-in gate**: `ELIZA_MEMORY_WATCHDOG` unset → `startMemoryWatchdog`
+  returns null → clean exit 0 even under 400 MB pressure.
+
+## Verification (host-only; no device/key/cluster)
+
+```
+# real child, breach case — actual log lines:
+ Info  [MemoryWatchdog] enabled (threshold 128MB, interval 1000ms, sustained 1 samples)
+ Warn  [MemoryWatchdog] memory-watchdog: RSS 570MB >= 128MB for 1 samples — requesting clean restart via supervisor
+ memory-watchdog-child: restart requested: ... — exiting 75
+ exit=75
+
+$ RUN_CRASH_RESTART_E2E=1 bun run --cwd packages/agent test -- crash-restart-supervisor
+ Test Files  1 passed (1)
+      Tests  10 passed (10)      # 7 existing + 3 new
+
+# fast unit lane still excludes the e2e (gate holds):
+$ bun run --cwd packages/agent test -- crash-restart-supervisor
+      Tests  10 skipped (10)
+```
+
+## N/A
+- **Live-LLM trajectory / screenshots / audio:** N/A — this is a process-lifecycle
+  stability test (spawned `bun` children under real memory pressure); no model,
+  UI, or audio path is involved.
+- **iOS device / k8s cluster:** out of scope for this seam — those device/cluster
+  lanes are the remaining #10197 work tracked in the (still-draft) #10616.

--- a/packages/agent/test/crash-restart-supervisor.test.ts
+++ b/packages/agent/test/crash-restart-supervisor.test.ts
@@ -18,6 +18,7 @@ import { afterAll, describe, expect, it } from "vitest";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const CHILD = path.join(HERE, "fixtures", "crash-injection-child.ts");
+const MEMORY_CHILD = path.join(HERE, "fixtures", "memory-watchdog-child.ts");
 
 // Spawns real `bun` child processes — gated like `test:tui-pty` so it stays out
 // of the fast unit lane and runs in the post-merge / on-demand lane with
@@ -36,16 +37,20 @@ afterAll(() => {
   for (const f of tmpFiles) fs.rmSync(f, { force: true });
 });
 
-function runChild(env: Record<string, string>): Promise<number> {
+function runChildAt(
+  childPath: string,
+  env: Record<string, string>,
+  timeoutMs = 15_000,
+): Promise<number> {
   return new Promise((resolve, reject) => {
-    const child = spawn("bun", [CHILD], {
+    const child = spawn("bun", [childPath], {
       env: { ...process.env, NODE_ENV: "test", ...env },
       stdio: ["ignore", "ignore", "ignore"],
     });
     const timer = setTimeout(() => {
       child.kill("SIGKILL");
-      reject(new Error("child did not exit within 15s"));
-    }, 15_000);
+      reject(new Error(`child did not exit within ${timeoutMs}ms`));
+    }, timeoutMs);
     child.on("exit", (code, signal) => {
       clearTimeout(timer);
       resolve(signal ? -1 : (code ?? -2));
@@ -53,6 +58,15 @@ function runChild(env: Record<string, string>): Promise<number> {
     child.on("error", reject);
   });
 }
+
+const runChild = (env: Record<string, string>): Promise<number> =>
+  runChildAt(CHILD, env);
+
+// The memory-watchdog child allocates real heap and waits at least one sample
+// interval before tripping, so it needs a longer ceiling than the fast
+// crash-injection child.
+const runMemoryChild = (env: Record<string, string>): Promise<number> =>
+  runChildAt(MEMORY_CHILD, env, 25_000);
 
 /** Supervisor mirroring run-node.mjs: respawn on 75, storm-guard, else propagate. */
 async function supervise(
@@ -151,4 +165,50 @@ describeE2E("supervisor restart contract (mirrors run-node.mjs)", () => {
     // spawned MAX+1 times, then the supervisor refuses to relaunch.
     expect(result.spawns).toBe(MAX_RESTARTS_IN_WINDOW + 1);
   }, 60_000);
+});
+
+// End-to-end proof for the memory watchdog (#10197): the unit test covers
+// createMemoryWatchdog's threshold/debounce logic and the block above covers the
+// supervisor's exit-75 respawn — but nothing drives a REAL process whose real
+// RSS crosses the threshold through the real requestRestart seam. These close
+// that gap with a spawned bun child under genuine memory pressure.
+describeE2E("memory watchdog -> supervised restart (real RSS pressure)", () => {
+  it("trips on sustained RSS over threshold and exits RESTART_EXIT_CODE", async () => {
+    const code = await runMemoryChild({
+      ELIZA_MEMORY_WATCHDOG: "1",
+      ELIZA_MEMORY_WATCHDOG_RSS_MB: "128", // floor; the child holds far more
+      ELIZA_MEMORY_WATCHDOG_INTERVAL_MS: "1000", // floor
+      ELIZA_MEMORY_WATCHDOG_SUSTAINED: "1",
+      CRASH_CHILD_ALLOC_MB: "400", // resident heap well above the threshold
+      CRASH_CHILD_WATCHDOG_TIMEOUT_MS: "12000",
+    });
+    expect(code).toBe(RESTART_EXIT_CODE);
+  }, 25_000);
+
+  it("does NOT restart while RSS stays under the threshold", async () => {
+    // Threshold far above anything the child allocates -> the watchdog samples,
+    // sees RSS below the line, never requests a restart, and the child times out
+    // to a deliberate non-75 exit.
+    const code = await runMemoryChild({
+      ELIZA_MEMORY_WATCHDOG: "1",
+      ELIZA_MEMORY_WATCHDOG_RSS_MB: "65536", // 64 GB — unreachable here
+      ELIZA_MEMORY_WATCHDOG_INTERVAL_MS: "1000",
+      ELIZA_MEMORY_WATCHDOG_SUSTAINED: "1",
+      CRASH_CHILD_ALLOC_MB: "64",
+      CRASH_CHILD_WATCHDOG_TIMEOUT_MS: "3000",
+    });
+    expect(code).not.toBe(RESTART_EXIT_CODE);
+    expect(code).toBe(2); // the child's "watchdog never fired" guard exit
+  }, 25_000);
+
+  it("does NOT restart when the watchdog is disabled, even under pressure", async () => {
+    // No ELIZA_MEMORY_WATCHDOG -> startMemoryWatchdog returns null -> clean exit 0
+    // regardless of RSS. Proves the opt-in gate holds.
+    const code = await runMemoryChild({
+      ELIZA_MEMORY_WATCHDOG_RSS_MB: "128",
+      ELIZA_MEMORY_WATCHDOG_SUSTAINED: "1",
+      CRASH_CHILD_ALLOC_MB: "400",
+    });
+    expect(code).toBe(0);
+  }, 25_000);
 });

--- a/packages/agent/test/fixtures/memory-watchdog-child.ts
+++ b/packages/agent/test/fixtures/memory-watchdog-child.ts
@@ -1,0 +1,64 @@
+/**
+ * Supervised child fixture for the memory-watchdog crash/restart e2e (#10197).
+ * Run under `bun`. It wires the REAL memory watchdog to the REAL
+ * `requestRestart` seam through the same restart handler production registers
+ * (`app-core/src/cli/run-main.ts` → exit `RESTART_EXIT_CODE`), then drives real
+ * RSS pressure so the e2e proves the whole chain end to end:
+ *
+ *   startMemoryWatchdog() → real `process.memoryUsage().rss` sample ≥ threshold
+ *   for the sustained window → `requestRestart()` → registered handler →
+ *   `process.exit(RESTART_EXIT_CODE=75)` → supervisor respawns.
+ *
+ * Env knobs (set by the e2e):
+ *   - `ELIZA_MEMORY_WATCHDOG*`        the real watchdog config (opt-in + thresholds)
+ *   - `CRASH_CHILD_ALLOC_MB`          MB of touched heap to hold (default 0 = no forced pressure)
+ *   - `CRASH_CHILD_WATCHDOG_TIMEOUT_MS` safety timeout; exit non-75 if the watchdog
+ *                                      never fires so the e2e fails loud instead of hanging
+ */
+import process from "node:process";
+
+import { RESTART_EXIT_CODE, setRestartHandler } from "@elizaos/shared";
+import { startMemoryWatchdog } from "../../src/runtime/memory-watchdog.ts";
+
+// Mirror the production restart handler (app-core/src/cli/run-main.ts): a
+// restart request exits with RESTART_EXIT_CODE so the supervisor relaunches.
+// This is the seam the watchdog depends on — the e2e proves it fires for real.
+setRestartHandler((reason) => {
+  console.error(
+    `memory-watchdog-child: restart requested: ${reason ?? "unspecified"} — exiting ${RESTART_EXIT_CODE}`,
+  );
+  process.exit(RESTART_EXIT_CODE);
+});
+
+// Hold real, page-touched memory so `process.memoryUsage().rss` actually climbs
+// (untouched Buffer.alloc pages may not be resident). A strong global ref keeps
+// it off the GC's reach until the process exits.
+const allocMb = Number(process.env.CRASH_CHILD_ALLOC_MB ?? "0");
+if (allocMb > 0) {
+  const blocks: Buffer[] = [];
+  for (let i = 0; i < allocMb; i++) {
+    const block = Buffer.alloc(1024 * 1024);
+    block.fill((i % 255) + 1); // touch every page so it becomes resident
+    blocks.push(block);
+  }
+  (globalThis as Record<string, unknown>).__eliza_watchdog_hold = blocks;
+}
+
+const started = startMemoryWatchdog();
+if (!started) {
+  // Watchdog disabled (no ELIZA_MEMORY_WATCHDOG): prove it does NOT restart even
+  // under memory pressure by exiting cleanly.
+  process.exit(0);
+}
+
+// The watchdog interval is unref()'d, so keep the event loop alive with a ref'd
+// guard timer. The watchdog should call requestRestart → exit(75) before it
+// fires; if it doesn't, exit non-75 so the e2e fails instead of hanging.
+const timeoutMs = Number(process.env.CRASH_CHILD_WATCHDOG_TIMEOUT_MS ?? "8000");
+const guard = setTimeout(() => {
+  console.error(
+    "memory-watchdog-child: watchdog did not request restart within the window",
+  );
+  process.exit(2);
+}, timeoutMs);
+guard.ref?.();


### PR DESCRIPTION
Relates to #10197.

## Summary

Closes a real-E2E gap in the memory-watchdog stability work. The watchdog (`packages/agent/src/runtime/memory-watchdog.ts`) was covered only in disjoint pieces:

- `memory-watchdog.test.ts` — unit test of `createMemoryWatchdog`'s threshold/debounce/one-shot logic with **fake** deps.
- `crash-restart-supervisor.test.ts` — real spawned-process proof of the supervisor's `RESTART_EXIT_CODE=75` respawn/storm-guard contract, but only via the `crash-injection` fixture.

Nothing drove **a real process whose real RSS crosses the threshold through the real `requestRestart` seam**. Per PR_EVIDENCE ("real E2E, no larp"), this proves that seam end to end.

## What's added

- `packages/agent/test/fixtures/memory-watchdog-child.ts` — a `bun` child that:
  1. registers the **same restart handler production uses** (`app-core/src/cli/run-main.ts` → `setRestartHandler(() => process.exit(RESTART_EXIT_CODE))`),
  2. holds `CRASH_CHILD_ALLOC_MB` of **page-touched** heap so `process.memoryUsage().rss` genuinely climbs,
  3. starts the real `startMemoryWatchdog()` (real RSS source + real `requestRestart`),
  4. fails loud (exit 2) via a ref'd guard if the watchdog never fires.
- Three `RUN_CRASH_RESTART_E2E=1`-gated cases in `crash-restart-supervisor.test.ts` (kept out of the fast unit lane, same gate as the existing crash-restart e2e):
  - **trips** — 400 MB held, 128 MB threshold, sustained=1 → real watchdog samples RSS 570 MB ≥ 128 MB → `requestRestart` → `process.exit(75)`.
  - **stays quiet under threshold** — 64 GB threshold → no restart → guard exit 2.
  - **respects the opt-in gate** — `ELIZA_MEMORY_WATCHDOG` unset → `startMemoryWatchdog` returns null → clean exit 0 even under 400 MB pressure.

## Evidence

`.github/issue-evidence/10197-memory-watchdog-e2e/README.md` — real child log lines + run output.

```
# breach case (real child):
 Warn  [MemoryWatchdog] memory-watchdog: RSS 570MB >= 128MB for 1 samples — requesting clean restart via supervisor
 memory-watchdog-child: restart requested: ... — exiting 75    exit=75

$ RUN_CRASH_RESTART_E2E=1 bun run --cwd packages/agent test -- crash-restart-supervisor
 Test Files  1 passed (1)   Tests  10 passed (10)   # 7 existing + 3 new

$ bun run --cwd packages/agent test -- crash-restart-supervisor
 Tests  10 skipped (10)   # gate holds; fast lane unaffected
```

### N/A
- **Live-LLM trajectory / screenshots / audio:** N/A — process-lifecycle stability test (spawned `bun` children under real memory pressure); no model/UI/audio path involved.
- **iOS device / k8s cluster:** out of scope here — those remaining #10197 lanes are tracked in the (still-draft) #10616.

🤖 Generated with [Claude Code](https://claude.com/claude-code)