### PR TITLE
fix(chip): sync ai_workload_manifest sha256 (fixes e1-chip docker-regression)

### DIFF
--- a/packages/research/chip/docs/spec-db/ai-eda/e1-ai-workload-manifest.yaml
+++ b/packages/research/chip/docs/spec-db/ai-eda/e1-ai-workload-manifest.yaml
@@ -185,7 +185,7 @@ workloads:
         sha256: 4309d2b3ef1d5237fde826ec4da23d26f7e274bb84e13a9f01a75e0647cee654
         role: gptq_calibrator
       - path: compiler/quantization/tests/test_awq_int4_mlp_e2e.py
-        sha256: 3a70d4cf8b50632b6e8f50d47b44446c2b1c0bfa321253859d7de215e707ee5f
+        sha256: b84f28765587d7769ae3238b441a4578d5bbda15d5bb819d826c4e6957fe00e2
         role: e2e_test
     input_shape:
       input: local_mlp_calibration_fixture


### PR DESCRIPTION
## Problem

The **e1-chip** workflow (`.github/workflows/e1-chip.yml`, job `docker-regression`) fails on `develop` at `Makefile:2161` (`ai-eda-ai-workload-manifest-check`):

```
STATUS: FAIL ai_eda.ai_workload_manifest workloads[6].artifacts[2].sha256 mismatch for compiler/quantization/tests/test_awq_int4_mlp_e2e.py: expected 3a70d4cf8b50632b6e8f50d47b44446c2b1c0bfa321253859d7de215e707ee5f, got b84f28765587d7769ae3238b441a4578d5bbda15d5bb819d826c4e6957fe00e2
make: *** [Makefile:2161: ai-eda-ai-workload-manifest-check] Error 1
```

## Root cause (manifest sha drift)

`packages/research/chip/scripts/ai_eda/check_ai_workload_manifest.py` hashes each artifact file and compares it to the `sha256` recorded in `packages/research/chip/docs/spec-db/ai-eda/e1-ai-workload-manifest.yaml`.

Commit `c865be65991` ("chore(repo): packages reorg + adaptive-view consolidation") edited the test file `compiler/quantization/tests/test_awq_int4_mlp_e2e.py` — a **one-line header-comment path fix** (`.../packages/chip/...` → `.../packages/research/chip/...`) to match the reorg — but did **not** update the file's recorded `sha256` in the manifest. So the manifest's `expected` hash still points at the pre-reorg content.

- `git show c865be65991 -- <test file>`: single-line comment change only (legitimate, intentional).
- The last commit touching the manifest is the earlier reorg `53ae4ec1a1a`, so the manifest was never regenerated after `c865be65991`.

## Fix

Update the recorded `sha256` for `test_awq_int4_mlp_e2e.py` in `e1-ai-workload-manifest.yaml` from the stale `3a70d4cf…707ee5f` to the current file content `b84f2876…57fe00e2`. The check script is validate-only (no `--write`/regen mode), so the manifest is hand-maintained; a one-line hash update is the canonical fix.

## Verification (macOS, local)

```
$ shasum -a 256 packages/research/chip/compiler/quantization/tests/test_awq_int4_mlp_e2e.py
b84f28765587d7769ae3238b441a4578d5bbda15d5bb819d826c4e6957fe00e2   # == CI "got"

$ python3 packages/research/chip/scripts/ai_eda/check_ai_workload_manifest.py
STATUS: PASS ai_eda.ai_workload_manifest workloads=8 categories=... claim_boundary=...
# exit 0  (this is exactly the Makefile:2161 target that was failing)
```

Stale hash `3a70d4cf…` no longer appears anywhere under `packages/research/chip`. Diff is a single line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)