### PR TITLE
fix(snap): keep + build @elizaos/plugin-commands in snap closure

### DIFF
--- a/packages/app-core/packaging/snap/snapcraft.yaml
+++ b/packages/app-core/packaging/snap/snapcraft.yaml
@@ -131,6 +131,7 @@ parts:
           "plugin-aosp-local-inference",
           "plugin-browser",
           "plugin-capacitor-bridge",
+          "plugin-commands",
           "plugin-elizacloud",
           "plugin-imessage",
           "plugin-personal-assistant",
@@ -491,6 +492,7 @@ parts:
         --filter=@elizaos/plugin-agent-skills \
         --filter=@elizaos/plugin-aosp-local-inference \
         --filter=@elizaos/plugin-browser \
+        --filter=@elizaos/plugin-commands \
         --filter=@elizaos/plugin-imessage \
         --filter=@elizaos/plugin-personal-assistant \
         --filter=@elizaos/plugin-local-inference \


### PR DESCRIPTION
## Problem

The **Snap Build & Test** workflow (`Build Snap (amd64)` / `(arm64)`) fails on `develop`. Inside the snapcraft container's `override-build` (which runs the workspace turbo build), esbuild fails:

```
@elizaos/plugin-telegram:build: src/command-registration.ts:55:7: ERROR: Could not resolve "@elizaos/plugin-commands"
@elizaos/plugin-telegram#build: command (.../plugins/plugin-telegram) bun run build exited (1)
'override-build' in part 'elizaos-app' failed with code 1.
```

The import is **valid in the normal workspace** — `@elizaos/plugin-commands` is a declared `workspace:*` dep of `plugin-telegram`, the package exists, and a normal `turbo` build resolves it. The failure is **snap-specific**.

## Root cause

`packages/app-core/packaging/snap/snapcraft.yaml`'s `elizaos-app` `override-build`:

1. Runs a destructive **"snap rewrite"** that deletes every `plugins/*` directory **not** in an inline `keep` set (line ~128).
2. Then strips the now-dangling `workspace:*` deps from every surviving manifest.
3. Then builds an explicit turbo `--filter` closure (line ~483).

`plugin-commands` was in **neither** the `keep` set **nor** the `--filter` list. So the rewrite:
- **deleted `plugins/plugin-commands/` from disk**, and
- **removed `@elizaos/plugin-commands` from `plugin-telegram`'s `dependencies`** (and dropped the turbo `^build` edge with it).

Most plugins build with the shared tsup config (`plugins/tsup.plugin-packages.shared.ts`), which sets `external: [/^@elizaos\//, /^node:/]` + `packages: "external"` — so their `@elizaos/*` deps are never bundled and a stripped dep is harmless. **`plugin-telegram` uses its own `tsup.config.ts` with no `@elizaos/*` externalization**, so esbuild tries to **bundle** `@elizaos/plugin-commands` — which no longer exists on disk. That's the resolution failure.

`plugin-task-coordinator` also depends on `plugin-commands` (resolved at runtime as an external via the shared config), so `plugin-commands` must ship in the snap payload regardless.

## Fix

Add `plugin-commands` to:
- the **`keep` set** — so the package survives the rewrite, `plugin-telegram`'s `workspace:*` dep + turbo `^build` edge are preserved, and its `dist` is available for both the bundling consumer (telegram) and the runtime-external consumer (task-coordinator);
- the **turbo `--filter` build list** — matching the established pattern for every other runtime plugin, guaranteeing it's built.

`plugin-commands` depends only on `@elizaos/core`, so it builds cleanly and self-contained before its consumers.

```diff
           "plugin-capacitor-bridge",
+          "plugin-commands",
           "plugin-elizacloud",
...
         --filter=@elizaos/plugin-browser \
+        --filter=@elizaos/plugin-commands \
         --filter=@elizaos/plugin-imessage \
```

## Verification

- `turbo run build --filter=@elizaos/plugin-telegram --dry-run=json` on the normal graph shows `@elizaos/plugin-commands#build` as a **direct dependency** of `@elizaos/plugin-telegram#build` (turbo builds it first via `^build`). The snap rewrite is what severed that edge.
- Audited **every** kept plugin that uses its own (bundling) tsup config — `plugin-agent-skills`, `plugin-capacitor-bridge`, `plugin-telegram`, `plugin-video`, `plugin-wechat`. After this change, **none** bundle a `plugins/`-located `@elizaos/*` workspace dep that isn't in the available runtime set. `plugin-telegram → plugin-commands` was the only such case.
- Cannot run `snapcraft` locally (needs Linux/multipass) — but this PR touches `packages/app-core/packaging/snap/**`, which **path-triggers the Snap Build & Test lane on `pull_request`**, so the real end-to-end verifier runs on this PR. (amd64 is the gating job; arm64 is `experimental: true`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)