### PR TITLE
chore(scripts): add run-all-tests plan inventory

### DIFF
--- a/.github/issue-evidence/10200-test-orchestration-plan/README.md
+++ b/.github/issue-evidence/10200-test-orchestration-plan/README.md
@@ -1,0 +1,50 @@
+# Issue #10200 evidence: run-all-tests plan inventory
+
+## Scope
+
+- Issue: https://github.com/elizaOS/eliza/issues/10200
+- Slice: residual `run-all-tests.mjs` auditability / orchestration consolidation.
+- PR scope is intentionally local to `packages/scripts`: add a non-executing test-plan inventory mode and pin shard determinism under Bun.
+
+## Change
+
+- Added `node packages/scripts/run-all-tests.mjs --plan[=text|json]`.
+- Plan mode performs the same workspace/script discovery, filters, sharding, parallel/serial classification, and cloud-step decision as the real runner, then exits before:
+  - preparing local PostgreSQL,
+  - spawning package test scripts,
+  - running `bun run test:cloud`.
+- JSON output includes:
+  - summary counts,
+  - package/script task rows,
+  - parallel-safe classification,
+  - structured skip reasons,
+  - cloud-step metadata.
+- Text output gives a compact human-readable plan.
+- The JSON plan self-test strips `PATH` to prove plan mode does not prepare PostgreSQL or spawn package test commands.
+- Replaced shard bucket conversion with `digest.readUInt32BE(0)` so the existing partition/balance invariants pass under Bun's test runtime.
+
+## Validation
+
+Commands run from `/home/shaw/milady/eliza-wt-10200-test-orchestration`:
+
+```bash
+bun test packages/scripts/__tests__/test-task-pool.test.ts
+bunx @biomejs/biome check packages/scripts/run-all-tests.mjs packages/scripts/lib/test-task-pool.mjs packages/scripts/__tests__/test-task-pool.test.ts
+node packages/scripts/run-all-tests.mjs --plan=json --only=test --no-cloud --filter=packages/core
+node packages/scripts/run-all-tests.mjs --plan --only=test --filter=packages/core
+git diff --check
+```
+
+Results:
+
+- `test-task-pool.test.ts`: 27 pass, 0 fail, 1892 expectations.
+- Biome check: exit 0. It emitted pre-existing `noUndeclaredEnvVars` warnings for `run-all-tests.mjs`; no errors.
+- `git diff --check`: passed.
+- JSON plan artifact: `core-test-plan.json`.
+- Text plan artifact: `core-test-plan.txt`.
+
+## Evidence N/A
+
+- Android capture: N/A. This is a repository script/test-orchestration change; no Android, app, native, UI, or runtime behavior changed.
+- Screenshot/screen recording: N/A for the same reason.
+- Live model trajectory: N/A. No agent, prompt, model, or action behavior changed.

--- a/.github/issue-evidence/10200-test-orchestration-plan/core-test-plan.json
+++ b/.github/issue-evidence/10200-test-orchestration-plan/core-test-plan.json
@@ -1,0 +1,43 @@
+{
+  "summary": {
+    "lane": "pr",
+    "only": "test",
+    "noCloud": true,
+    "shard": null,
+    "filters": [
+      "packages\\/core"
+    ],
+    "scriptFilter": null,
+    "startAt": null,
+    "concurrency": 1,
+    "packageCount": 1,
+    "taskCount": 1,
+    "parallelSafeTaskCount": 1,
+    "serialTaskCount": 0,
+    "cloudStep": false,
+    "byScript": {
+      "test": 1
+    },
+    "byPackage": {
+      "@elizaos/core": 1
+    }
+  },
+  "tasks": [
+    {
+      "packageName": "@elizaos/core",
+      "relativeDir": "packages/core",
+      "scriptName": "test",
+      "label": "@elizaos/core (packages/core)#test",
+      "parallelSafe": true
+    }
+  ],
+  "skipped": [
+    {
+      "label": "@elizaos/cloud-e2e (packages/test/cloud-e2e)",
+      "packageName": "@elizaos/cloud-e2e",
+      "relativeDir": "packages/test/cloud-e2e",
+      "reason": "cloud package skipped by --no-cloud"
+    }
+  ],
+  "cloudStep": null
+}

--- a/.github/issue-evidence/10200-test-orchestration-plan/core-test-plan.txt
+++ b/.github/issue-evidence/10200-test-orchestration-plan/core-test-plan.txt
@@ -1,0 +1,4 @@
+[eliza-test] PLAN lane=pr only=test tasks=1 packages=1
+[eliza-test] PLAN parallel-safe=1 serial=0 concurrency=1
+[eliza-test] PLAN cloud-step=yes
+[eliza-test] PLAN parallel @elizaos/core (packages/core)#test

--- a/packages/scripts/__tests__/test-task-pool.test.ts
+++ b/packages/scripts/__tests__/test-task-pool.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 
 import {
@@ -309,5 +310,78 @@ describe("CI plugin sharding contract", () => {
     expect(qualityWorkflow).not.toMatch(
       /develop-static-gate:[\s\S]*?Run lint[\s\S]*?bun run lint[\s\S]*?develop-lint-gate:/,
     );
+  });
+});
+
+describe("run-all-tests plan mode", () => {
+  const runnerPath = new URL("../run-all-tests.mjs", import.meta.url);
+
+  function runPlan(args: string[], env: Record<string, string> = {}) {
+    return spawnSync(process.execPath, [runnerPath.pathname, ...args], {
+      cwd: new URL("../../..", import.meta.url).pathname,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        TEST_LANE: "pr",
+        TEST_PACKAGE_FILTER: "",
+        TEST_SCRIPT_FILTER: "",
+        TEST_SHARD: "",
+        TEST_START_AT: "",
+        ...env,
+      },
+    });
+  }
+
+  test("prints a JSON inventory without preparing services or starting package tests", () => {
+    const result = runPlan(
+      [
+        "--plan=json",
+        "--only=test",
+        "--no-cloud",
+        "--filter=^@elizaos/core \\(packages/core\\)#test$",
+      ],
+      // If plan mode regresses and prepares PostgreSQL or spawns package
+      // scripts, this stripped PATH makes the side effect visible.
+      { PATH: "" },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).not.toContain("[eliza-test] START");
+    expect(result.stdout).not.toContain("PostgreSQL");
+    const plan = JSON.parse(result.stdout);
+    expect(plan.summary).toMatchObject({
+      lane: "pr",
+      only: "test",
+      noCloud: true,
+      taskCount: 1,
+      cloudStep: false,
+    });
+    expect(plan.tasks).toEqual([
+      {
+        packageName: "@elizaos/core",
+        relativeDir: "packages/core",
+        scriptName: "test",
+        label: "@elizaos/core (packages/core)#test",
+        parallelSafe: true,
+      },
+    ]);
+    expect(plan.cloudStep).toBeNull();
+  });
+
+  test("bare --plan prints text and keeps the cloud step visible", () => {
+    const result = runPlan([
+      "--plan",
+      "--only=test",
+      "--filter=^@elizaos/core \\(packages/core\\)#test$",
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("[eliza-test] PLAN lane=pr only=test");
+    expect(result.stdout).toContain("[eliza-test] PLAN cloud-step=yes");
+    expect(result.stdout).toContain(
+      "[eliza-test] PLAN parallel @elizaos/core (packages/core)#test",
+    );
+    expect(result.stdout).not.toContain("[eliza-test] START");
   });
 });

--- a/packages/scripts/lib/test-task-pool.mjs
+++ b/packages/scripts/lib/test-task-pool.mjs
@@ -193,7 +193,7 @@ export function taskBelongsToShard(taskKey, shardCfg) {
   if (!shardCfg) {
     return true;
   }
-  const hash = crypto.createHash("sha1").update(taskKey).digest("hex");
-  const bucket = Number.parseInt(hash.slice(0, 8), 16) % shardCfg.total;
+  const digest = crypto.createHash("sha1").update(taskKey).digest();
+  const bucket = digest.readUInt32BE(0) % shardCfg.total;
   return bucket === shardCfg.index - 1;
 }

--- a/packages/scripts/run-all-tests.mjs
+++ b/packages/scripts/run-all-tests.mjs
@@ -59,6 +59,10 @@
  *     lanes and any post-merge lane always serialize. Default 1 preserves the
  *     historical fully-serial behaviour, so existing callers are unaffected.
  *
+ *   --plan[=text|json]
+ *     Discover and print the test plan without spawning package tests or
+ *     preparing local services. This is the audit/inventory path for #10200.
+ *
  * Companion env knobs (legacy, still honoured):
  *   TEST_PACKAGE_FILTER  — same surface as --filter
  *   TEST_SCRIPT_FILTER   — regex over script name (test, test:e2e, ...)
@@ -73,6 +77,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
+  isParallelSafeTask,
   normalizeConcurrency,
   parseShardSpec,
   partitionTasks,
@@ -153,21 +158,26 @@ function failUsage(message) {
 
 const noCloud = parseFlag("--no-cloud");
 const helpFlag = parseFlag("--help") || parseFlag("-h");
+const barePlanFlag = parseFlag("--plan");
 let filterFlag;
 let patternFlag;
 let onlyFlag;
 let excludeFlags;
 let concurrencyFlag;
+let planFlag;
 try {
   filterFlag = parseFlagValue("--filter");
   patternFlag = parseFlagValue("--pattern");
   onlyFlag = parseFlagValue("--only"); // "e2e" | "test"
   excludeFlags = parseRepeatedFlagValue("--exclude");
   concurrencyFlag = parseFlagValue("--concurrency");
+  planFlag = parseFlagValue("--plan");
 } catch (error) {
   failUsage(error.message);
 }
 const allFlag = parseFlag("--all");
+const planEnabled = planFlag !== null || barePlanFlag;
+const planFormat = planFlag || "text";
 
 if (helpFlag) {
   process.stdout.write(
@@ -183,6 +193,7 @@ if (helpFlag) {
       "  --exclude=<path>     Exclude a repo-relative test path from this lane.",
       "  --concurrency=<n>    Run parallel-safe `test` tasks through an n-worker",
       "                       pool (pr lane only; default 1 = fully serial).",
+      "  --plan[=text|json]   Print the discovered test plan without running it.",
       "",
       "Env vars:",
       "  TEST_LANE=pr|post-merge        Lane select (default: pr).",
@@ -204,6 +215,9 @@ if (allFlag && onlyFlag) {
 }
 if (onlyFlag && !["e2e", "test"].includes(onlyFlag)) {
   failUsage(`--only must be "e2e" or "test", got "${onlyFlag}"`);
+}
+if (!["text", "json"].includes(planFormat)) {
+  failUsage(`--plan must be "text" or "json", got "${planFormat}"`);
 }
 if (argv.length > 0) {
   failUsage(`unknown argument(s): ${argv.join(" ")}`);
@@ -765,6 +779,85 @@ function buildLaneEnv() {
   return extra;
 }
 
+function buildPlanSummary(tasks) {
+  const { parallel, serial } = partitionTasks(tasks, TEST_LANE);
+  const byScript = {};
+  const byPackage = {};
+  for (const task of tasks) {
+    byScript[task.scriptName] = (byScript[task.scriptName] ?? 0) + 1;
+    byPackage[task.packageName] = (byPackage[task.packageName] ?? 0) + 1;
+  }
+  return {
+    lane: TEST_LANE,
+    only: onlyFlag || "all",
+    noCloud,
+    shard: shardConfig,
+    filters: packageFilters.map((rx) => rx.source),
+    scriptFilter: scriptFilter?.source ?? null,
+    startAt: startAt || null,
+    concurrency,
+    packageCount: new Set(tasks.map((task) => task.packageName)).size,
+    taskCount: tasks.length,
+    parallelSafeTaskCount: parallel.length,
+    serialTaskCount: serial.length,
+    cloudStep: !noCloud,
+    byScript,
+    byPackage,
+  };
+}
+
+function printableTask(task) {
+  return {
+    packageName: task.packageName,
+    relativeDir: path.relative(repoRoot, task.cwd) || ".",
+    scriptName: task.scriptName,
+    label: task.label,
+    parallelSafe: isParallelSafeTask({
+      scriptName: task.scriptName,
+      lane: TEST_LANE,
+      packageName: task.packageName,
+    }),
+  };
+}
+
+function printPlan(tasks) {
+  const summary = buildPlanSummary(tasks);
+  const taskRows = tasks.map(printableTask);
+  if (planFormat === "json") {
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          summary,
+          tasks: taskRows,
+          skipped: skippedPlanEntries,
+          cloudStep: summary.cloudStep
+            ? { label: "cloud#test", command: "bun run test:cloud" }
+            : null,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    return;
+  }
+
+  process.stdout.write(
+    [
+      `[eliza-test] PLAN lane=${summary.lane} only=${summary.only} tasks=${summary.taskCount} packages=${summary.packageCount}`,
+      `[eliza-test] PLAN parallel-safe=${summary.parallelSafeTaskCount} serial=${summary.serialTaskCount} concurrency=${summary.concurrency}`,
+      `[eliza-test] PLAN cloud-step=${summary.cloudStep ? "yes" : "no"}`,
+      ...taskRows.map(
+        (task) =>
+          `[eliza-test] PLAN ${task.parallelSafe ? "parallel" : "serial"} ${task.label}`,
+      ),
+      ...skippedPlanEntries.map(
+        (entry) => `[eliza-test] PLAN skip ${entry.label} (${entry.reason})`,
+      ),
+      "",
+    ].join("\n"),
+  );
+}
+
 function buildForwardedScriptArgs(scriptName, scripts) {
   if (excludeFlags.length === 0) {
     return [];
@@ -930,8 +1023,6 @@ function runCloudTests() {
 // Main
 // ---------------------------------------------------------------------------
 
-ensurePluginSqlPostgresEnv();
-
 const packageJsonPaths = collectPackageJsonPaths();
 
 let started = startAt.length === 0;
@@ -940,6 +1031,7 @@ let started = startAt.length === 0;
 // filters/skips. Collecting up front lets the runner dispatch the parallel-safe
 // subset through a worker pool instead of the historical strictly-serial loop.
 const tasks = [];
+const skippedPlanEntries = [];
 
 for (const packageJsonPath of packageJsonPaths) {
   const cwd = path.dirname(packageJsonPath);
@@ -952,9 +1044,19 @@ for (const packageJsonPath of packageJsonPaths) {
     continue;
   }
   if (noCloud && NO_CLOUD_PACKAGE_DIRS.has(relativeDir)) {
-    console.log(
-      `[eliza-test] SKIP ${packageJson.name || relativeDir} (${relativeDir}) (cloud package skipped by --no-cloud)`,
-    );
+    const label = `${packageJson.name || relativeDir} (${relativeDir})`;
+    if (planEnabled) {
+      skippedPlanEntries.push({
+        label,
+        packageName: packageJson.name || relativeDir,
+        relativeDir,
+        reason: "cloud package skipped by --no-cloud",
+      });
+    } else {
+      console.log(
+        `[eliza-test] SKIP ${label} (cloud package skipped by --no-cloud)`,
+      );
+    }
     continue;
   }
 
@@ -980,9 +1082,19 @@ for (const packageJsonPath of packageJsonPaths) {
       continue;
     }
     if (shouldSkipEmptyVitestScript(cwd, scriptName, scripts)) {
-      console.log(
-        `[eliza-test] SKIP ${label} (no local test files for vitest script)`,
-      );
+      if (planEnabled) {
+        skippedPlanEntries.push({
+          label,
+          packageName,
+          relativeDir,
+          scriptName,
+          reason: "no local test files for vitest script",
+        });
+      } else {
+        console.log(
+          `[eliza-test] SKIP ${label} (no local test files for vitest script)`,
+        );
+      }
       continue;
     }
 
@@ -991,6 +1103,13 @@ for (const packageJsonPath of packageJsonPaths) {
 }
 
 const laneEnv = buildLaneEnv();
+
+if (planEnabled) {
+  printPlan(tasks);
+  process.exit(0);
+}
+
+ensurePluginSqlPostgresEnv();
 
 // Run one task, logging START/PASS/SKIP/FAIL. `stream` echoes child output live
 // (serial path); when false the output is buffered and flushed only on failure


### PR DESCRIPTION
## Summary

- Adds `node packages/scripts/run-all-tests.mjs --plan[=text|json]` so #10200's remaining test-orchestration surface can be inventoried without spawning package tests or preparing local services.
- Plan mode uses the same discovery/filter/shard/parallel-safe/cloud-step decisions as the real runner, then exits before PostgreSQL setup, package test spawns, or `bun run test:cloud`.
- Pins the existing shard partition invariants under Bun by reading the SHA digest with `readUInt32BE(0)` instead of hex parsing.

## Evidence

Tracked evidence: `.github/issue-evidence/10200-test-orchestration-plan/`

Validation after rebasing onto current `origin/develop`:

```bash
bun test packages/scripts/__tests__/test-task-pool.test.ts
bunx @biomejs/biome check packages/scripts/run-all-tests.mjs packages/scripts/lib/test-task-pool.mjs packages/scripts/__tests__/test-task-pool.test.ts
node packages/scripts/run-all-tests.mjs --plan=json --only=test --no-cloud --filter=packages/core
node packages/scripts/run-all-tests.mjs --plan --only=test --filter=packages/core
git diff --check origin/develop...HEAD
```

Results:
- `test-task-pool.test.ts`: 27 pass, 0 fail, 1891 expectations.
- Biome check: exit 0; it reports existing `noUndeclaredEnvVars` warnings in `run-all-tests.mjs`.
- Plan artifacts committed: `core-test-plan.json`, `core-test-plan.txt`.

## N/A

- Android capture / screenshots / screen recording: N/A. This is a repo script orchestration change only; no app, Android, native, UI, or runtime surface changed.
- Live model trajectory: N/A. No agent/model/action behavior changed.

Relates to #10200
