### PR TITLE
feat(app-core): wire production Discord OAuth2 exchange into embed launch (#9947)

### DIFF
--- a/packages/app-core/src/api/auth/discord-exchange.test.ts
+++ b/packages/app-core/src/api/auth/discord-exchange.test.ts
@@ -1,0 +1,221 @@
+import { logger } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  type DiscordExchangeDeps,
+  resolveDiscordExchange,
+} from "./discord-exchange";
+
+const CLIENT_ID = "app-123";
+const CLIENT_SECRET = "super-secret-value-never-logged";
+const TOKEN_URL = "https://discord.test/oauth2/token";
+const USER_URL = "https://discord.test/users/@me";
+
+function runtimeWith(settings: Record<string, string>) {
+  return {
+    getSetting: (key: string): unknown => settings[key],
+  };
+}
+
+function jsonResponse(
+  status: number,
+  body: unknown,
+): Pick<Response, "ok" | "status" | "json"> {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  };
+}
+
+/** A fetch stub that returns the token response then the user response. */
+function sequencedFetch(
+  responses: Array<Pick<Response, "ok" | "status" | "json"> | Error>,
+) {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  let i = 0;
+  const fetchImpl: DiscordExchangeDeps["fetch"] = async (url, init) => {
+    calls.push({ url, init });
+    const next = responses[i++];
+    if (next instanceof Error) throw next;
+    if (!next) throw new Error(`unexpected fetch call #${i} to ${url}`);
+    return next;
+  };
+  return { fetchImpl, calls };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("resolveDiscordExchange", () => {
+  it("returns undefined when the client id is unconfigured (fail closed)", () => {
+    const exchange = resolveDiscordExchange(
+      runtimeWith({ DISCORD_CLIENT_SECRET: CLIENT_SECRET }),
+    );
+    expect(exchange).toBeUndefined();
+  });
+
+  it("returns undefined when the client secret is unconfigured (fail closed)", () => {
+    const exchange = resolveDiscordExchange(
+      runtimeWith({ DISCORD_APPLICATION_ID: CLIENT_ID }),
+    );
+    expect(exchange).toBeUndefined();
+  });
+
+  it("accepts DISCORD_CLIENT_ID as a fallback client id", () => {
+    const exchange = resolveDiscordExchange(
+      runtimeWith({
+        DISCORD_CLIENT_ID: CLIENT_ID,
+        DISCORD_CLIENT_SECRET: CLIENT_SECRET,
+      }),
+    );
+    expect(exchange).toBeTypeOf("function");
+  });
+
+  it("verifies a valid Activity code → user id via the two-step exchange", async () => {
+    const { fetchImpl, calls } = sequencedFetch([
+      jsonResponse(200, { access_token: "access-abc", token_type: "Bearer" }),
+      jsonResponse(200, { id: "discord-user-77", username: "owner" }),
+    ]);
+    const exchange = resolveDiscordExchange(
+      runtimeWith({
+        DISCORD_APPLICATION_ID: CLIENT_ID,
+        DISCORD_CLIENT_SECRET: CLIENT_SECRET,
+      }),
+      { fetch: fetchImpl, tokenUrl: TOKEN_URL, userUrl: USER_URL },
+    );
+    expect(exchange).toBeTypeOf("function");
+
+    const user = await exchange?.("oauth2-code-xyz");
+    expect(user).toEqual({ id: "discord-user-77" });
+
+    // Token request: POST form-encoded, carries the authorization-code grant.
+    expect(calls[0].url).toBe(TOKEN_URL);
+    expect(calls[0].init?.method).toBe("POST");
+    const body = String(calls[0].init?.body);
+    expect(body).toContain("grant_type=authorization_code");
+    expect(body).toContain("code=oauth2-code-xyz");
+    expect(body).toContain(`client_id=${CLIENT_ID}`);
+    // The secret IS sent to Discord (that is the whole point of the exchange)…
+    expect(body).toContain("client_secret=");
+
+    // User request: bearer the freshly minted access token, never the secret.
+    expect(calls[1].url).toBe(USER_URL);
+    const authHeader = (calls[1].init?.headers as Record<string, string>)
+      .Authorization;
+    expect(authHeader).toBe("Bearer access-abc");
+  });
+
+  it("fails closed (null) when the token endpoint rejects", async () => {
+    const { fetchImpl } = sequencedFetch([jsonResponse(401, { error: "bad" })]);
+    const exchange = resolveDiscordExchange(
+      runtimeWith({
+        DISCORD_APPLICATION_ID: CLIENT_ID,
+        DISCORD_CLIENT_SECRET: CLIENT_SECRET,
+      }),
+      { fetch: fetchImpl, tokenUrl: TOKEN_URL, userUrl: USER_URL },
+    );
+    expect(await exchange?.("code")).toBeNull();
+  });
+
+  it("fails closed when the token response has no access_token", async () => {
+    const { fetchImpl } = sequencedFetch([
+      jsonResponse(200, { scope: "identify" }),
+    ]);
+    const exchange = resolveDiscordExchange(
+      runtimeWith({
+        DISCORD_APPLICATION_ID: CLIENT_ID,
+        DISCORD_CLIENT_SECRET: CLIENT_SECRET,
+      }),
+      { fetch: fetchImpl, tokenUrl: TOKEN_URL, userUrl: USER_URL },
+    );
+    expect(await exchange?.("code")).toBeNull();
+  });
+
+  it("fails closed when the user lookup rejects", async () => {
+    const { fetchImpl } = sequencedFetch([
+      jsonResponse(200, { access_token: "access-abc" }),
+      jsonResponse(403, { message: "forbidden" }),
+    ]);
+    const exchange = resolveDiscordExchange(
+      runtimeWith({
+        DISCORD_APPLICATION_ID: CLIENT_ID,
+        DISCORD_CLIENT_SECRET: CLIENT_SECRET,
+      }),
+      { fetch: fetchImpl, tokenUrl: TOKEN_URL, userUrl: USER_URL },
+    );
+    expect(await exchange?.("code")).toBeNull();
+  });
+
+  it("fails closed when the user payload has no id", async () => {
+    const { fetchImpl } = sequencedFetch([
+      jsonResponse(200, { access_token: "access-abc" }),
+      jsonResponse(200, { username: "no-id-here" }),
+    ]);
+    const exchange = resolveDiscordExchange(
+      runtimeWith({
+        DISCORD_APPLICATION_ID: CLIENT_ID,
+        DISCORD_CLIENT_SECRET: CLIENT_SECRET,
+      }),
+      { fetch: fetchImpl, tokenUrl: TOKEN_URL, userUrl: USER_URL },
+    );
+    expect(await exchange?.("code")).toBeNull();
+  });
+
+  it("fails closed when the token request throws", async () => {
+    const { fetchImpl } = sequencedFetch([new Error("network down")]);
+    const exchange = resolveDiscordExchange(
+      runtimeWith({
+        DISCORD_APPLICATION_ID: CLIENT_ID,
+        DISCORD_CLIENT_SECRET: CLIENT_SECRET,
+      }),
+      { fetch: fetchImpl, tokenUrl: TOKEN_URL, userUrl: USER_URL },
+    );
+    expect(await exchange?.("code")).toBeNull();
+  });
+
+  it("fails closed when the user request throws", async () => {
+    const { fetchImpl } = sequencedFetch([
+      jsonResponse(200, { access_token: "access-abc" }),
+      new Error("socket reset"),
+    ]);
+    const exchange = resolveDiscordExchange(
+      runtimeWith({
+        DISCORD_APPLICATION_ID: CLIENT_ID,
+        DISCORD_CLIENT_SECRET: CLIENT_SECRET,
+      }),
+      { fetch: fetchImpl, tokenUrl: TOKEN_URL, userUrl: USER_URL },
+    );
+    expect(await exchange?.("code")).toBeNull();
+  });
+
+  it("fails closed for an empty code without calling Discord", async () => {
+    const { fetchImpl, calls } = sequencedFetch([]);
+    const exchange = resolveDiscordExchange(
+      runtimeWith({
+        DISCORD_APPLICATION_ID: CLIENT_ID,
+        DISCORD_CLIENT_SECRET: CLIENT_SECRET,
+      }),
+      { fetch: fetchImpl, tokenUrl: TOKEN_URL, userUrl: USER_URL },
+    );
+    expect(await exchange?.("")).toBeNull();
+    expect(calls).toHaveLength(0);
+  });
+
+  it("never logs the client secret on any failure path", async () => {
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    const { fetchImpl } = sequencedFetch([
+      jsonResponse(500, { error: `leak-check ${CLIENT_SECRET}` }),
+    ]);
+    const exchange = resolveDiscordExchange(
+      runtimeWith({
+        DISCORD_APPLICATION_ID: CLIENT_ID,
+        DISCORD_CLIENT_SECRET: CLIENT_SECRET,
+      }),
+      { fetch: fetchImpl, tokenUrl: TOKEN_URL, userUrl: USER_URL },
+    );
+    await exchange?.("code");
+    const logged = JSON.stringify(warnSpy.mock.calls);
+    expect(logged).not.toContain(CLIENT_SECRET);
+  });
+});

--- a/packages/app-core/src/api/auth/discord-exchange.ts
+++ b/packages/app-core/src/api/auth/discord-exchange.ts
@@ -1,0 +1,137 @@
+/**
+ * Production Discord Activity token exchange (#9947).
+ *
+ * The embed-launch handshake (`verifyEmbedLaunch`) verifies a Discord Activity
+ * by exchanging its OAuth2 authorization `code` for an access token server-side
+ * and reading the authenticated user id. The exchange is dependency-injected so
+ * the handshake stays pure and unit-testable; this module supplies the real
+ * implementation the HTTP route wires in.
+ *
+ * Flow (Discord Embedded App SDK): the Activity iframe calls
+ * `discordSdk.commands.authorize()` which returns a `code`; the client POSTs it
+ * to `/api/embed/auth`; this exchange turns `code` → access token → `/users/@me`.
+ * No `redirect_uri` is required for the Activity authorization-code grant.
+ *
+ * SECURITY: `DISCORD_CLIENT_SECRET` is used only in the token-exchange request
+ * body. It is never logged, never returned, and never attached to an error. The
+ * exchange fails closed (returns `null`) on every failure path so the handshake
+ * rejects the launch with a coarse 403.
+ */
+
+import { logger } from "@elizaos/core";
+import type { DiscordExchange, DiscordVerifiedUser } from "./embed-handshake";
+
+const DISCORD_TOKEN_URL = "https://discord.com/api/v10/oauth2/token";
+const DISCORD_USER_URL = "https://discord.com/api/v10/users/@me";
+
+type FetchLike = (
+  url: string,
+  init?: RequestInit,
+) => Promise<Pick<Response, "ok" | "status" | "json">>;
+
+export interface DiscordExchangeDeps {
+  /** Injectable fetch (defaults to the Node global) for deterministic tests. */
+  fetch?: FetchLike;
+  /** Overridable endpoints for tests; default to the real Discord API. */
+  tokenUrl?: string;
+  userUrl?: string;
+}
+
+function readSetting(
+  runtime: { getSetting?: (key: string) => unknown },
+  key: string,
+): string {
+  const value = runtime.getSetting?.(key);
+  return typeof value === "string" ? value.trim() : "";
+}
+
+/**
+ * Resolve the production Discord exchange from the runtime's configured
+ * credentials, or `undefined` when they are not set — in which case the
+ * handshake fails closed with `discord_exchange_unconfigured` rather than
+ * attempting an unauthenticated exchange.
+ *
+ * `client_id` comes from `DISCORD_APPLICATION_ID` (the same id the connector
+ * uses to build its install URL), falling back to `DISCORD_CLIENT_ID`.
+ */
+export function resolveDiscordExchange(
+  runtime: { getSetting?: (key: string) => unknown },
+  deps: DiscordExchangeDeps = {},
+): DiscordExchange | undefined {
+  const clientId =
+    readSetting(runtime, "DISCORD_APPLICATION_ID") ||
+    readSetting(runtime, "DISCORD_CLIENT_ID");
+  const clientSecret = readSetting(runtime, "DISCORD_CLIENT_SECRET");
+  if (!clientId || !clientSecret) {
+    return undefined;
+  }
+
+  const doFetch: FetchLike = deps.fetch ?? (fetch as unknown as FetchLike);
+  const tokenUrl = deps.tokenUrl ?? DISCORD_TOKEN_URL;
+  const userUrl = deps.userUrl ?? DISCORD_USER_URL;
+
+  return async (code: string): Promise<DiscordVerifiedUser | null> => {
+    if (!code) {
+      return null;
+    }
+
+    let accessToken: string;
+    try {
+      const tokenRes = await doFetch(tokenUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          client_id: clientId,
+          client_secret: clientSecret,
+          grant_type: "authorization_code",
+          code,
+        }).toString(),
+      });
+      if (!tokenRes.ok) {
+        logger.warn(
+          { status: tokenRes.status },
+          "[DiscordEmbedExchange] token exchange rejected (fail closed)",
+        );
+        return null;
+      }
+      const tokenData = (await tokenRes.json()) as { access_token?: unknown };
+      if (
+        typeof tokenData.access_token !== "string" ||
+        tokenData.access_token.length === 0
+      ) {
+        return null;
+      }
+      accessToken = tokenData.access_token;
+    } catch (err) {
+      logger.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "[DiscordEmbedExchange] token request failed (fail closed)",
+      );
+      return null;
+    }
+
+    try {
+      const userRes = await doFetch(userUrl, {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      if (!userRes.ok) {
+        logger.warn(
+          { status: userRes.status },
+          "[DiscordEmbedExchange] user lookup rejected (fail closed)",
+        );
+        return null;
+      }
+      const user = (await userRes.json()) as { id?: unknown };
+      if (typeof user.id !== "string" || user.id.length === 0) {
+        return null;
+      }
+      return { id: user.id };
+    } catch (err) {
+      logger.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        "[DiscordEmbedExchange] user request failed (fail closed)",
+      );
+      return null;
+    }
+  };
+}

--- a/packages/app-core/src/api/embed-auth-routes.test.ts
+++ b/packages/app-core/src/api/embed-auth-routes.test.ts
@@ -303,4 +303,97 @@ describe("handleEmbedAuthRoutes", () => {
     );
     expect(ok).toBe(true);
   });
+
+  it("wires the resolved Discord exchange into the handshake for discord", async () => {
+    verifyEmbedLaunch.mockResolvedValue({
+      ok: false,
+      status: 403,
+      reason: "x",
+    });
+    const exchangeFn = vi.fn();
+    const resolveDiscordExchange = vi.fn(() => exchangeFn);
+    const runtime = { agentId: "agent", getSetting: () => undefined };
+    const r = fakeRes();
+    await handleEmbedAuthRoutes(
+      fakeReq("POST", "/api/embed/auth", {
+        platform: "discord",
+        signedLaunchPayload: "oauth2-code",
+        accountId: "acct-9",
+      }),
+      r.res,
+      runtimeState(runtime),
+      {
+        verifyEmbedLaunch: verifyEmbedLaunch as never,
+        resolveDiscordExchange: resolveDiscordExchange as never,
+      },
+    );
+    expect(resolveDiscordExchange).toHaveBeenCalledWith(runtime);
+    expect(verifyEmbedLaunch).toHaveBeenCalledWith(
+      {
+        platform: "discord",
+        signedLaunchPayload: "oauth2-code",
+        accountId: "acct-9",
+        discordExchange: exchangeFn,
+      },
+      runtime,
+    );
+  });
+
+  it("passes an undefined exchange for discord when credentials are unconfigured", async () => {
+    verifyEmbedLaunch.mockResolvedValue({
+      ok: false,
+      status: 403,
+      reason: "x",
+    });
+    const resolveDiscordExchange = vi.fn(() => undefined);
+    const runtime = { agentId: "agent", getSetting: () => undefined };
+    const r = fakeRes();
+    await handleEmbedAuthRoutes(
+      fakeReq("POST", "/api/embed/auth", {
+        platform: "discord",
+        signedLaunchPayload: "oauth2-code",
+      }),
+      r.res,
+      runtimeState(runtime),
+      {
+        verifyEmbedLaunch: verifyEmbedLaunch as never,
+        resolveDiscordExchange: resolveDiscordExchange as never,
+      },
+    );
+    const input = verifyEmbedLaunch.mock.calls[0]?.[0] as {
+      platform: string;
+      discordExchange: unknown;
+    };
+    expect(input.platform).toBe("discord");
+    expect(input.discordExchange).toBeUndefined();
+  });
+
+  it("never resolves a Discord exchange for a telegram launch", async () => {
+    verifyEmbedLaunch.mockResolvedValue({
+      ok: false,
+      status: 403,
+      reason: "x",
+    });
+    const resolveDiscordExchange = vi.fn(() => vi.fn());
+    const runtime = { agentId: "agent", getSetting: () => undefined };
+    const r = fakeRes();
+    await handleEmbedAuthRoutes(
+      fakeReq("POST", "/api/embed/auth", {
+        platform: "telegram",
+        signedLaunchPayload: "initData",
+      }),
+      r.res,
+      runtimeState(runtime),
+      {
+        verifyEmbedLaunch: verifyEmbedLaunch as never,
+        resolveDiscordExchange: resolveDiscordExchange as never,
+      },
+    );
+    expect(resolveDiscordExchange).not.toHaveBeenCalled();
+    const input = verifyEmbedLaunch.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(input).not.toHaveProperty("discordExchange");
+  });
 });

--- a/packages/app-core/src/api/embed-auth-routes.ts
+++ b/packages/app-core/src/api/embed-auth-routes.ts
@@ -16,6 +16,7 @@
  */
 
 import type http from "node:http";
+import { resolveDiscordExchange } from "./auth/discord-exchange";
 import { type EmbedPlatform, verifyEmbedLaunch } from "./auth/embed-handshake";
 import {
   DEFAULT_EMBED_TOKEN_TTL_MS,
@@ -40,10 +41,15 @@ export async function handleEmbedAuthRoutes(
   res: http.ServerResponse,
   state: CompatRuntimeState,
   // Injectable so tests exercise the route without a module mock for the
-  // handshake — module mocks race under vmForks parallel load. Defaults to the
-  // real verifier in production.
-  deps: { verifyEmbedLaunch: typeof verifyEmbedLaunch } = { verifyEmbedLaunch },
+  // handshake — module mocks race under vmForks parallel load. Each field
+  // defaults to the real implementation in production.
+  deps: {
+    verifyEmbedLaunch?: typeof verifyEmbedLaunch;
+    resolveDiscordExchange?: typeof resolveDiscordExchange;
+  } = {},
 ): Promise<boolean> {
+  const verify = deps.verifyEmbedLaunch ?? verifyEmbedLaunch;
+  const resolveExchange = deps.resolveDiscordExchange ?? resolveDiscordExchange;
   const method = (req.method ?? "GET").toUpperCase();
   const url = new URL(req.url ?? "/", "http://localhost");
 
@@ -75,10 +81,22 @@ export async function handleEmbedAuthRoutes(
   const accountId =
     typeof body.accountId === "string" ? body.accountId : undefined;
 
-  const result = await deps.verifyEmbedLaunch(
-    { platform, signedLaunchPayload, accountId },
-    runtime,
-  );
+  // Discord verification exchanges the Activity OAuth2 code server-side; resolve
+  // the production exchange from the runtime's configured credentials. When the
+  // credentials are unset this is `undefined` and the handshake fails closed
+  // with `discord_exchange_unconfigured`. Telegram never needs an exchange, so
+  // its input is left untouched.
+  const input =
+    platform === "discord"
+      ? {
+          platform,
+          signedLaunchPayload,
+          accountId,
+          discordExchange: resolveExchange(runtime),
+        }
+      : { platform, signedLaunchPayload, accountId };
+
+  const result = await verify(input, runtime);
 
   if (!result.ok) {
     // Fail closed: never echo the raw reason in a way that leaks why the


### PR DESCRIPTION
## Summary

Refs #9947 (role-gated embedded-app launch surface — Discord Activities / Telegram Mini Apps).

While auditing #9947 I found that the embed backend is much further along than the
issue/kanban reflect: the shared handshake (`verifyEmbedLaunch`), the scoped session
token (`mintEmbedSessionToken`/`verifyEmbedSessionToken`), the `/api/embed/auth` route,
the per-platform `frame-ancestors` CSP middleware, the consolidated single `hasRoleAccess`,
and the Telegram `web_app` launch button all already landed on `develop`
(`377a0ebbac2`, `3c8f5bf63f1`). The issue body's "grep returns zero hits" is stale.

**The concrete gap this PR closes:** the handshake verifies a Discord Activity via an
*injected* `DiscordExchange`, but `handleEmbedAuthRoutes` never supplied a production
one — so in production every Discord launch failed closed with
`discord_exchange_unconfigured`, leaving the Discord half of the embed surface
non-functional (only Telegram worked end to end).

## What changed

- **`packages/app-core/src/api/auth/discord-exchange.ts`** — `resolveDiscordExchange(runtime)`:
  the real server-side OAuth2 exchange for a Discord Activity code. Two-step, mirroring the
  existing feed reference (`packages/feed/.../discord/activity/route.ts`):
  `POST https://discord.com/api/v10/oauth2/token` (authorization-code grant with
  `DISCORD_APPLICATION_ID`/`DISCORD_CLIENT_ID` + `DISCORD_CLIENT_SECRET`) →
  `GET /users/@me` with the bearer access token → `{ id }`.
  - Returns `undefined` when credentials are unset (so the handshake fails closed with
    `discord_exchange_unconfigured` rather than attempting an unauthenticated exchange).
  - Returns `null` on **every** failure path (non-200 token/user response, missing
    `access_token`, missing user `id`, thrown fetch, empty code).
  - **Security:** `DISCORD_CLIENT_SECRET` is only ever placed in the token-request body —
    never logged, returned, or attached to an error (covered by a test).
  - `fetch` + endpoints are dependency-injected for deterministic tests.
- **`packages/app-core/src/api/embed-auth-routes.ts`** — resolve and pass the exchange into
  `verifyEmbedLaunch` **only** for the `discord` platform; the telegram input path is
  byte-identical to before. Both collaborators stay dependency-injected.

## Tests (real, no network)

`bun run --cwd packages/app-core test src/api/auth/discord-exchange.test.ts src/api/embed-auth-routes.test.ts` — **all green**, plus the pre-existing `embed-handshake.test.ts` 9/9.

- `discord-exchange.test.ts` — full fail-closed matrix: unconfigured client id / secret →
  `undefined`; `DISCORD_CLIENT_ID` fallback; valid code → `{ id }` with the exact token/user
  requests asserted (POST form body carries `grant_type=authorization_code` + the code + the
  client id; user call bears `Bearer <access_token>`, never the secret); token 401 → null;
  no `access_token` → null; user 403 → null; no user id → null; token/user fetch throws →
  null; empty code short-circuits without any fetch; **secret never appears in any log line**.
- `embed-auth-routes.test.ts` — new wiring assertions: discord passes the resolved exchange
  to the handshake; unconfigured → `discordExchange: undefined`; telegram never resolves an
  exchange and its input carries no `discordExchange` key.

Verification: `bun run --cwd packages/app-core typecheck` (exit 0) and biome 2.5.1 `check`
(clean). Note: app-core's vitest runs `isolate: false`; running this trio of files as an
*explicit* 3-file subset can trip the pre-existing `vi.mock("@elizaos/core")` race in
`embed-handshake.test.ts` (documented in `embed-auth-routes.test.ts`'s header). It passes
deterministically (`--no-file-parallelism`) and in every pairwise combination; this PR adds
no `vi.mock` of core.

## Evidence (per PR_EVIDENCE.md)

- **Backend logs / real-LLM trajectory** — N/A: this is a distribution/auth-verification
  seam, not an agent/prompt/model path.
- **Live Discord Activity walkthrough** — GATED, not attached: a real end-to-end Discord
  Activity render requires a Discord application configured as an Activity + a provisioned
  `DISCORD_CLIENT_SECRET` + an OWNER/ADMIN Discord identity, none of which exist in this
  environment. The exchange is proven by the deterministic fail-closed test matrix above;
  the positive live path is unblocked the moment `DISCORD_CLIENT_SECRET` is provisioned.

## Remaining #9947 work (explicitly not in this PR)

This completes the **Discord verification backend**. To finish #9947 end-to-end:
1. **`/embed` SPA page** in `packages/app` (both platforms need it): read the launch payload
   (Telegram `window.Telegram.WebApp.initData` / Discord Activity `code`), POST to
   `/api/embed/auth`, store the returned token, boot the app authenticated. The CSP middleware
   exists; the page does not.
2. **Accept the embed session token in the API auth path** — `verifyEmbedSessionToken` is
   currently only exercised in tests; nothing in `ensureCompatApiAuthorizedAsync` /
   auth-context consumes it, so the minted token is not yet an accepted credential. (Security-
   critical; needs a boundary-role mapping decision for embed `ADMIN`.)
3. **Discord `/app` slash command** emitting the role-gated Activity/launch link.
4. **`DISCORD_CLIENT_SECRET`** provisioning + a live Discord/Telegram embedded-iframe
   walkthrough for closing evidence.

I'll post this corrected state assessment on #9947 and update the kanban (#10561).
