### PR TITLE
fix(plugin-sql): scope PGlite managers by agent

### DIFF
--- a/plugins/plugin-sql/src/__tests__/unit/pglite-manager-reuse.test.ts
+++ b/plugins/plugin-sql/src/__tests__/unit/pglite-manager-reuse.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  getActivePgliteManager,
+  getOrCreatePgliteManagerForAgent,
+  type PgliteManagerCache,
+} from "../../pglite/manager-cache";
+
+class FakeManager {
+  constructor(readonly label: string) {}
+
+  shuttingDown = false;
+
+  isShuttingDown(): boolean {
+    return this.shuttingDown;
+  }
+}
+
+describe("PGlite manager reuse", () => {
+  let cache: PgliteManagerCache<FakeManager> = {};
+  const created: FakeManager[] = [];
+
+  beforeEach(() => {
+    cache = {};
+    created.length = 0;
+  });
+
+  function getManager(dataDir: string | undefined, agentId: string): FakeManager {
+    return getOrCreatePgliteManagerForAgent(cache, dataDir, agentId, () => {
+      const manager = new FakeManager(`${dataDir ?? "memory"}:${agentId}`);
+      created.push(manager);
+      return manager;
+    });
+  }
+
+  it("reuses the manager for the same PGlite data dir and agent id", () => {
+    const agentId = "00000000-0000-4000-8000-000000000001";
+
+    const first = getManager(":memory:", agentId);
+    const second = getManager(":memory:", agentId);
+
+    expect(second).toBe(first);
+    expect(created).toHaveLength(1);
+  });
+
+  it("does not reuse a manager across agent ids", () => {
+    const first = getManager(":memory:", "00000000-0000-4000-8000-000000000001");
+    const second = getManager(":memory:", "00000000-0000-4000-8000-000000000002");
+
+    expect(second).not.toBe(first);
+    expect(second.label).toBe(":memory::00000000-0000-4000-8000-000000000002");
+    expect(getActivePgliteManager(cache)).toBe(second);
+    expect(created).toHaveLength(2);
+  });
+
+  it("replaces a closed manager for the same data dir and agent id", () => {
+    const agentId = "00000000-0000-4000-8000-000000000001";
+    const first = getManager("/tmp/eliza-agent", agentId);
+    first.shuttingDown = true;
+
+    const second = getManager("/tmp/eliza-agent", agentId);
+
+    expect(second).not.toBe(first);
+    expect(getActivePgliteManager(cache)).toBe(second);
+    expect(created).toHaveLength(2);
+  });
+});

--- a/plugins/plugin-sql/src/index.browser.ts
+++ b/plugins/plugin-sql/src/index.browser.ts
@@ -7,14 +7,13 @@ import {
 } from "@elizaos/core";
 import { PgliteDatabaseAdapter } from "./pglite/adapter";
 import { PGliteClientManager } from "./pglite/manager";
+import { getOrCreatePgliteManagerForAgent, type PgliteManagerCache } from "./pglite/manager-cache";
 import * as schema from "./schema";
 import { AdvancedMemoryStorageService } from "./services/advanced-memory-storage";
 
 const GLOBAL_SINGLETONS = Symbol.for("elizaos.plugin-sql.global-singletons");
 
-interface GlobalSingletons {
-  pgLiteClientManager?: PGliteClientManager;
-}
+type GlobalSingletons = PgliteManagerCache<PGliteClientManager>;
 
 interface RuntimeWithAdapterRegistrar {
   registerDatabaseAdapter: (adapter: IDatabaseAdapter) => void;
@@ -26,14 +25,17 @@ if (!globalSymbols[GLOBAL_SINGLETONS]) {
 }
 const globalSingletons = globalSymbols[GLOBAL_SINGLETONS];
 
+function getOrCreatePgliteManager(agentId: UUID): PGliteClientManager {
+  return getOrCreatePgliteManagerForAgent(globalSingletons, undefined, agentId, () => {
+    return new PGliteClientManager({ agentId });
+  });
+}
+
 export function createDatabaseAdapter(
   _config: { dataDir?: string },
   agentId: UUID
 ): IDatabaseAdapter {
-  if (!globalSingletons.pgLiteClientManager) {
-    globalSingletons.pgLiteClientManager = new PGliteClientManager({});
-  }
-  return new PgliteDatabaseAdapter(agentId, globalSingletons.pgLiteClientManager);
+  return new PgliteDatabaseAdapter(agentId, getOrCreatePgliteManager(agentId));
 }
 
 export const plugin: Plugin = {

--- a/plugins/plugin-sql/src/index.node.ts
+++ b/plugins/plugin-sql/src/index.node.ts
@@ -29,6 +29,11 @@ import {
   type PgliteSyncStatus,
   type PgliteSyncTableStatus,
 } from "./pglite/manager";
+import {
+  getActivePgliteManager,
+  getOrCreatePgliteManagerForAgent,
+  type PgliteManagerCache,
+} from "./pglite/manager-cache";
 import * as schema from "./schema";
 import { AdvancedMemoryStorageService } from "./services/advanced-memory-storage";
 import { stringToUuid } from "./utils/string-to-uuid";
@@ -60,8 +65,7 @@ export type { DrizzleDatabase } from "./types";
 
 const GLOBAL_SINGLETONS = Symbol.for("elizaos.plugin-sql.global-singletons");
 
-interface GlobalSingletons {
-  pgLiteClientManager?: PGliteClientManager;
+interface GlobalSingletons extends PgliteManagerCache<PGliteClientManager> {
   postgresConnectionManagers?: Map<string, PostgresConnectionManager>;
 }
 
@@ -74,14 +78,6 @@ if (!globalSymbols[GLOBAL_SINGLETONS]) {
   globalSymbols[GLOBAL_SINGLETONS] = {};
 }
 const globalSingletons = globalSymbols[GLOBAL_SINGLETONS];
-
-function shouldReusePgliteManager(manager: PGliteClientManager | undefined): boolean {
-  if (!manager) {
-    return false;
-  }
-
-  return !manager.isShuttingDown();
-}
 
 function shouldReusePostgresManager(
   manager: PostgresConnectionManager | undefined
@@ -152,13 +148,9 @@ export function createDatabaseAdapter(
     mkdirSync(dataDir, { recursive: true });
   }
 
-  if (!shouldReusePgliteManager(globalSingletons.pgLiteClientManager)) {
-    globalSingletons.pgLiteClientManager = new PGliteClientManager({ dataDir, agentId });
-  }
-  const manager = globalSingletons.pgLiteClientManager;
-  if (!manager) {
-    throw new Error("[plugin-sql] pgLiteClientManager not initialized before adapter creation");
-  }
+  const manager = getOrCreatePgliteManagerForAgent(globalSingletons, dataDir, agentId, () => {
+    return new PGliteClientManager({ dataDir, agentId });
+  });
   return new PgliteDatabaseAdapter(agentId, manager);
 }
 
@@ -252,7 +244,7 @@ export function getPgliteSyncStatus(): {
   tables: PgliteSyncTableStatus;
   synced: string[];
 } {
-  const manager = globalSingletons.pgLiteClientManager;
+  const manager = getActivePgliteManager(globalSingletons);
   if (!manager) {
     return { status: "disabled", error: null, tables: {}, synced: [] };
   }

--- a/plugins/plugin-sql/src/index.ts
+++ b/plugins/plugin-sql/src/index.ts
@@ -29,6 +29,11 @@ import {
   type PgliteSyncStatus,
   type PgliteSyncTableStatus,
 } from "./pglite/manager";
+import {
+  getActivePgliteManager,
+  getOrCreatePgliteManagerForAgent,
+  type PgliteManagerCache,
+} from "./pglite/manager-cache";
 import * as schema from "./schema";
 import { AdvancedMemoryStorageService } from "./services/advanced-memory-storage";
 import { resolvePgliteDir } from "./utils";
@@ -60,8 +65,7 @@ export type { DrizzleDatabase } from "./types";
 
 const GLOBAL_SINGLETONS = Symbol.for("elizaos.plugin-sql.global-singletons");
 
-interface GlobalSingletons {
-  pgLiteClientManager?: PGliteClientManager;
+interface GlobalSingletons extends PgliteManagerCache<PGliteClientManager> {
   postgresConnectionManager?: PostgresConnectionManager;
 }
 
@@ -80,14 +84,6 @@ if (!globalSymbols[GLOBAL_SINGLETONS]) {
 }
 
 const globalSingletons = globalSymbols[GLOBAL_SINGLETONS];
-
-function shouldReusePgliteManager(manager: PGliteClientManager | undefined): boolean {
-  if (!manager) {
-    return false;
-  }
-
-  return !manager.isShuttingDown();
-}
 
 function shouldReusePostgresManager(
   manager: PostgresConnectionManager | undefined
@@ -144,14 +140,9 @@ export function createDatabaseAdapter(
     mkdirSync(dataDir, { recursive: true });
   }
 
-  if (!shouldReusePgliteManager(globalSingletons.pgLiteClientManager)) {
-    globalSingletons.pgLiteClientManager = new PGliteClientManager({ dataDir, agentId });
-  }
-
-  const manager = globalSingletons.pgLiteClientManager;
-  if (!manager) {
-    throw new Error("[plugin-sql] pgLiteClientManager not initialized before adapter creation");
-  }
+  const manager = getOrCreatePgliteManagerForAgent(globalSingletons, dataDir, agentId, () => {
+    return new PGliteClientManager({ dataDir, agentId });
+  });
 
   return new PgliteDatabaseAdapter(agentId, manager);
 }
@@ -251,7 +242,7 @@ export function getPgliteSyncStatus(): {
   tables: PgliteSyncTableStatus;
   synced: string[];
 } {
-  const manager = globalSingletons.pgLiteClientManager;
+  const manager = getActivePgliteManager(globalSingletons);
   if (!manager) {
     return { status: "disabled", error: null, tables: {}, synced: [] };
   }

--- a/plugins/plugin-sql/src/pglite/manager-cache.ts
+++ b/plugins/plugin-sql/src/pglite/manager-cache.ts
@@ -1,0 +1,46 @@
+export interface ReusablePgliteManager {
+  isShuttingDown(): boolean;
+}
+
+export interface PgliteManagerCache<TManager extends ReusablePgliteManager> {
+  pgLiteClientManager?: TManager;
+  pgLiteClientManagers?: Map<string, TManager>;
+  activePgliteManagerKey?: string;
+}
+
+export function pgliteManagerCacheKey(dataDir: string | undefined, agentId: string): string {
+  return JSON.stringify({ dataDir: dataDir ?? null, agentId });
+}
+
+export function getOrCreatePgliteManagerForAgent<TManager extends ReusablePgliteManager>(
+  cache: PgliteManagerCache<TManager>,
+  dataDir: string | undefined,
+  agentId: string,
+  createManager: () => TManager
+): TManager {
+  const key = pgliteManagerCacheKey(dataDir, agentId);
+  cache.pgLiteClientManagers ??= new Map();
+
+  const existing = cache.pgLiteClientManagers.get(key);
+  if (existing && !existing.isShuttingDown()) {
+    cache.pgLiteClientManager = existing;
+    cache.activePgliteManagerKey = key;
+    return existing;
+  }
+
+  const manager = createManager();
+  cache.pgLiteClientManagers.set(key, manager);
+  cache.pgLiteClientManager = manager;
+  cache.activePgliteManagerKey = key;
+  return manager;
+}
+
+export function getActivePgliteManager<TManager extends ReusablePgliteManager>(
+  cache: PgliteManagerCache<TManager>
+): TManager | undefined {
+  if (cache.activePgliteManagerKey && cache.pgLiteClientManagers) {
+    return cache.pgLiteClientManagers.get(cache.activePgliteManagerKey);
+  }
+
+  return cache.pgLiteClientManager;
+}


### PR DESCRIPTION
# Relates to

N/A - follow-up reliability fix.

# Sync with develop

- Created from latest `origin/develop` at `caacfd052`.

# Risks

Low. This is limited to plugin-sql PGlite manager reuse. Adapters for the same PGlite data dir and agent id still reuse the existing manager; adapters for a different agent id get a separate manager so they do not inherit another agent's sync/write-back state.

# Background

## What does this PR do?

Scopes the process-global PGlite manager cache by local data directory and agent id, and adds a focused regression for that reuse boundary.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

## Why are we doing this? Any context or related work?

`PGliteClientManager` captures the agent id used by Electric sync filtering and by `WriteBackService` when constructing the cloud write-back URL. Before this change, a second runtime in the same process could receive an adapter for agent B while reusing the manager that was created for agent A. Local writes from agent B could then be forwarded through agent A's write-back endpoint, or the sync status helper could report the stale manager. The new cache keeps reuse for the same local agent but prevents cross-agent manager reuse.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Start with `plugins/plugin-sql/src/pglite/manager-cache.ts` and `plugins/plugin-sql/src/__tests__/unit/pglite-manager-reuse.test.ts`, then the three plugin-sql entrypoints that create PGlite adapters.

## Detailed testing steps

- `bunx vitest run --config plugins/plugin-sql/src/vitest.config.ts plugins/plugin-sql/src/__tests__/unit/pglite-manager-reuse.test.ts`
- `bunx @biomejs/biome check plugins/plugin-sql/src/index.browser.ts plugins/plugin-sql/src/index.node.ts plugins/plugin-sql/src/index.ts plugins/plugin-sql/src/pglite/manager-cache.ts plugins/plugin-sql/src/__tests__/unit/pglite-manager-reuse.test.ts`
- `git diff --check`
- Direct source-mode repro: create two PGlite adapters with different agent ids and write-back enabled; verified the second adapter now owns a distinct manager and its write URL ends in `/agents/00000000-0000-4000-8000-000000000002/write`.

Local note: `bun run --cwd plugins/plugin-sql/src typecheck` could not run in this worktree because the partial dependency install does not link `tsgo` (`/bin/bash: tsgo: command not found`).

# Evidence (prove the real thing happened - see PR_EVIDENCE.md)

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model behavior changed.

## Backend + frontend logs

N/A - focused plugin-sql manager cache fix covered by unit regression and source-mode repro.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice change.
