### PR TITLE
fix(scripts): add run-all-tests plan mode

### DIFF
--- a/.github/issue-evidence/10200-run-all-tests-plan.md
+++ b/.github/issue-evidence/10200-run-all-tests-plan.md
@@ -1,0 +1,83 @@
+# Issue #10200: run-all-tests plan mode
+
+## Change
+
+- Added `node packages/scripts/run-all-tests.mjs --list` / `--dry-run`.
+- The mode prints the discovered runnable task plan after lane/filter/shard/skip handling.
+- It exits before PostgreSQL preparation and before any test child process is spawned.
+
+## Validation
+
+```bash
+~/.bun/bin/bun test packages/scripts/__tests__/run-all-tests-plan.test.ts packages/scripts/__tests__/test-task-pool.test.ts
+```
+
+Result: passed, 28 tests.
+
+```bash
+~/.bun/bin/bun test packages/scripts/__tests__/run-all-tests-plan.test.ts
+```
+
+Result: passed, 3 tests.
+
+```bash
+node packages/scripts/run-all-tests.mjs --list --filter=packages/core --only=test --no-cloud --concurrency=3
+```
+
+Reviewed output:
+
+```text
+[eliza-test] plan
+  lane: pr
+  scripts: test
+  cloud: disabled
+  shard: none
+  concurrency: 3
+  package filters: packages/core
+  script filter: none
+  start at: none
+  excludes: 0
+  runnable tasks: 1
+  parallel task(s): 1
+  serial task(s): 0
+  skipped during discovery: 1
+  parallel @elizaos/core (packages/core)#test
+  skip @elizaos/cloud-e2e (packages/test/cloud-e2e) (cloud package skipped by --no-cloud)
+```
+
+```bash
+~/.bun/bin/bunx @biomejs/biome@2.5.1 check --write packages/scripts/run-all-tests.mjs packages/scripts/__tests__/run-all-tests-plan.test.ts
+```
+
+Result: passed with no fixes applied. Biome reported existing `noUndeclaredEnvVars` warnings in `run-all-tests.mjs` for pre-existing environment variables used by the runner.
+
+```bash
+bun run --cwd packages/benchmarks/solana/solana-gym-env/docs/trajectory-viewer lint
+```
+
+Result: passed. This was added after the first full verify attempt exposed two ambiguous-link lint failures in the generated trajectory viewer docs page.
+
+```bash
+bun run typecheck:dist
+```
+
+Result: passed after regenerating `tsconfig.dist-paths.json`.
+
+```bash
+bun run verify
+```
+
+Result: passed.
+
+- Turbo typecheck/lint: 474 successful, 474 total.
+- `audit-build-typecheck`: passed.
+- `audit-turbo-build-deps`: passed.
+- `audit-tee-secret-leak`: passed.
+- `audit-scripts`: passed.
+- `typecheck:dist`: checked 28 dist-path consumer configs.
+
+## Artifact matrix
+
+- Screenshots/video: N/A. This is a CLI runner change with no app UI surface.
+- Live model trajectory: N/A. This does not change agent/model/prompt behavior.
+- Domain artifacts: the reviewed CLI plan output above.

--- a/packages/benchmarks/solana/solana-gym-env/docs/trajectory-viewer/src/components/LandingPage.tsx
+++ b/packages/benchmarks/solana/solana-gym-env/docs/trajectory-viewer/src/components/LandingPage.tsx
@@ -597,7 +597,7 @@ const LandingPage: React.FC = () => {
               target="_blank"
               rel="noopener noreferrer"
             >
-              here.
+              in this swap benchmark analysis thread.
             </a>{" "}
             In this environment, LLMs are prompted to construct swap
             transactions across different DEXes. SDKs to Jupiter, Orca, Meteora,
@@ -705,7 +705,7 @@ const LandingPage: React.FC = () => {
               rel="noopener noreferrer"
               style={{ textDecoration: "underline" }}
             >
-              here
+              through the Solana benchmark funding form
             </a>
             .
           </p>

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -26,7 +26,13 @@
       },
       "description": "HSM-backed secrets + multi-chain signing for elizaOS agents via 1Claw — vault access and EVM/Solana/BTC/XRP/Cardano/Tron signing without the agent ever holding private keys; optional Shroud TEE LLM proxy.",
       "homepage": "https://github.com/1clawAI/1claw-elizaos-plugin",
-      "topics": ["security", "secrets", "vault", "signing", "multi-chain"],
+      "topics": [
+        "security",
+        "secrets",
+        "vault",
+        "signing",
+        "multi-chain"
+      ],
       "stargazers_count": 0,
       "language": "TypeScript",
       "origin": "third-party",
@@ -112,7 +118,14 @@
       },
       "description": "WaaP wallet plugin for ElizaOS — 2-of-2 MPC signing for EVM and Sui, with native 2FA and server-enforced spending policies; the agent never holds private keys.",
       "homepage": "https://github.com/holonym-foundation/eliza-plugin-waap",
-      "topics": ["wallet", "mpc", "2pc", "evm", "sui", "2fa"],
+      "topics": [
+        "wallet",
+        "mpc",
+        "2pc",
+        "evm",
+        "sui",
+        "2fa"
+      ],
       "stargazers_count": 0,
       "language": "TypeScript",
       "origin": "third-party",
@@ -582,7 +595,11 @@
       },
       "description": "Reference third-party elizaOS plugin: an ECHO action that repeats a message back.",
       "homepage": "https://github.com/elizaOS/eliza/tree/main/packages/examples/plugin-echo",
-      "topics": ["example", "utility", "reference"],
+      "topics": [
+        "example",
+        "utility",
+        "reference"
+      ],
       "stargazers_count": 0,
       "language": "TypeScript",
       "origin": "third-party",
@@ -621,7 +638,12 @@
       },
       "description": "Farcaster engagement discovery, like, reply, and follow/unfollow actions via Neynar REST API for ElizaOS agents",
       "homepage": null,
-      "topics": ["farcaster", "neynar", "social", "discovery"],
+      "topics": [
+        "farcaster",
+        "neynar",
+        "social",
+        "discovery"
+      ],
       "stargazers_count": 0,
       "language": "TypeScript",
       "origin": "third-party",
@@ -709,7 +731,11 @@
       },
       "description": "ElizaOS plugin for Reddit integration — search, engage, and manage Reddit interactions autonomously",
       "homepage": null,
-      "topics": ["reddit", "social", "discovery"],
+      "topics": [
+        "reddit",
+        "social",
+        "discovery"
+      ],
       "stargazers_count": 0,
       "language": "TypeScript",
       "origin": "third-party",

--- a/packages/scripts/__tests__/run-all-tests-plan.test.ts
+++ b/packages/scripts/__tests__/run-all-tests-plan.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(SCRIPT_DIR, "..", "..", "..");
+const RUNNER = path.join(REPO_ROOT, "packages", "scripts", "run-all-tests.mjs");
+
+function runRunner(args: string[], env: Record<string, string> = {}) {
+  const result = spawnSync(process.execPath, [RUNNER, ...args], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      TEST_LANE: "pr",
+      TEST_PACKAGE_FILTER: "",
+      TEST_SCRIPT_FILTER: "",
+      TEST_SHARD: "",
+      ...env,
+    },
+    encoding: "utf8",
+  });
+
+  return {
+    ...result,
+    output: `${result.stdout ?? ""}${result.stderr ?? ""}`,
+  };
+}
+
+describe("run-all-tests task plan mode", () => {
+  test("help documents the list/dry-run option", () => {
+    const result = runRunner(["--help"]);
+    expect(result.status).toBe(0);
+    expect(result.output).toContain("--list, --dry-run");
+    expect(result.output).toContain("Print the discovered task plan");
+  });
+
+  test("--list prints discovered tasks without spawning test commands", () => {
+    const result = runRunner(
+      [
+        "--list",
+        "--filter=packages/core",
+        "--only=test",
+        "--no-cloud",
+        "--concurrency=3",
+      ],
+      // If --list ever regresses and tries to prepare Postgres or spawn bun,
+      // this stripped PATH makes the failure immediate and obvious.
+      { PATH: "" },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.output).toContain("[eliza-test] plan");
+    expect(result.output).toContain("lane: pr");
+    expect(result.output).toContain("scripts: test");
+    expect(result.output).toContain("cloud: disabled");
+    expect(result.output).toContain("concurrency: 3");
+    expect(result.output).toContain("parallel task(s):");
+    expect(result.output).toContain("serial task(s):");
+    expect(result.output).toMatch(/@elizaos\/core \(packages\/core\)#test/);
+    expect(result.output).not.toContain("[eliza-test] START");
+    expect(result.output).not.toContain("[eliza-test] PASS");
+  });
+
+  test("--dry-run is an alias for the task plan path", () => {
+    const result = runRunner([
+      "--dry-run",
+      "--filter=packages/core",
+      "--only=test",
+      "--no-cloud",
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(result.output).toContain("[eliza-test] plan");
+    expect(result.output).not.toContain("[eliza-test] START");
+  });
+});

--- a/packages/scripts/run-all-tests.mjs
+++ b/packages/scripts/run-all-tests.mjs
@@ -59,6 +59,10 @@
  *     lanes and any post-merge lane always serialize. Default 1 preserves the
  *     historical fully-serial behaviour, so existing callers are unaffected.
  *
+ *   --list | --dry-run
+ *     Print the exact discovered task plan (after lane/filter/shard/skip
+ *     handling) and exit before preparing databases or spawning tests.
+ *
  * Companion env knobs (legacy, still honoured):
  *   TEST_PACKAGE_FILTER  — same surface as --filter
  *   TEST_SCRIPT_FILTER   — regex over script name (test, test:e2e, ...)
@@ -153,6 +157,7 @@ function failUsage(message) {
 
 const noCloud = parseFlag("--no-cloud");
 const helpFlag = parseFlag("--help") || parseFlag("-h");
+const listFlag = parseFlag("--list") || parseFlag("--dry-run");
 let filterFlag;
 let patternFlag;
 let onlyFlag;
@@ -183,6 +188,8 @@ if (helpFlag) {
       "  --exclude=<path>     Exclude a repo-relative test path from this lane.",
       "  --concurrency=<n>    Run parallel-safe `test` tasks through an n-worker",
       "                       pool (pr lane only; default 1 = fully serial).",
+      "  --list, --dry-run    Print the discovered task plan and exit without",
+      "                       preparing databases or spawning tests.",
       "",
       "Env vars:",
       "  TEST_LANE=pr|post-merge        Lane select (default: pr).",
@@ -301,17 +308,18 @@ const NO_CLOUD_PACKAGE_DIRS = new Set([
 // must match a task's label for it to run — they intersect rather than
 // override each other so callers can stack a package filter (--filter) and a
 // per-test filter (--pattern) on top of one another.
-const packageFilters = [
+const packageFilterInputs = [
   filterFlag,
   patternFlag,
   process.env.TEST_PACKAGE_FILTER,
-]
-  .filter((value) => typeof value === "string" && value.length > 0)
-  .map((value) => new RegExp(value));
+].filter((value) => typeof value === "string" && value.length > 0);
+
+const packageFilters = packageFilterInputs.map((value) => new RegExp(value));
 
 const scriptFilter = process.env.TEST_SCRIPT_FILTER
   ? new RegExp(process.env.TEST_SCRIPT_FILTER)
   : null;
+const scriptFilterInput = process.env.TEST_SCRIPT_FILTER?.trim() || "";
 const startAt = process.env.TEST_START_AT?.trim() || "";
 const DEFAULT_POSTGRES_URL =
   "postgresql://eliza_test:test123@localhost:5432/eliza_test";
@@ -930,8 +938,6 @@ function runCloudTests() {
 // Main
 // ---------------------------------------------------------------------------
 
-ensurePluginSqlPostgresEnv();
-
 const packageJsonPaths = collectPackageJsonPaths();
 
 let started = startAt.length === 0;
@@ -940,6 +946,7 @@ let started = startAt.length === 0;
 // filters/skips. Collecting up front lets the runner dispatch the parallel-safe
 // subset through a worker pool instead of the historical strictly-serial loop.
 const tasks = [];
+const discoverySkips = [];
 
 for (const packageJsonPath of packageJsonPaths) {
   const cwd = path.dirname(packageJsonPath);
@@ -952,9 +959,12 @@ for (const packageJsonPath of packageJsonPaths) {
     continue;
   }
   if (noCloud && NO_CLOUD_PACKAGE_DIRS.has(relativeDir)) {
-    console.log(
-      `[eliza-test] SKIP ${packageJson.name || relativeDir} (${relativeDir}) (cloud package skipped by --no-cloud)`,
-    );
+    const label = `${packageJson.name || relativeDir} (${relativeDir})`;
+    const reason = "cloud package skipped by --no-cloud";
+    discoverySkips.push({ label, reason });
+    if (!listFlag) {
+      console.log(`[eliza-test] SKIP ${label} (${reason})`);
+    }
     continue;
   }
 
@@ -980,15 +990,60 @@ for (const packageJsonPath of packageJsonPaths) {
       continue;
     }
     if (shouldSkipEmptyVitestScript(cwd, scriptName, scripts)) {
-      console.log(
-        `[eliza-test] SKIP ${label} (no local test files for vitest script)`,
-      );
+      const reason = "no local test files for vitest script";
+      discoverySkips.push({ label, reason });
+      if (!listFlag) {
+        console.log(`[eliza-test] SKIP ${label} (${reason})`);
+      }
       continue;
     }
 
     tasks.push({ cwd, scriptName, label, scripts, packageName });
   }
 }
+
+function printTaskPlan() {
+  const { parallel, serial } =
+    concurrency > 1
+      ? partitionTasks(tasks, TEST_LANE)
+      : { parallel: [], serial: tasks };
+  const parallelLabels = new Set(parallel.map((task) => task.label));
+  const scriptMode = onlyFlag ?? "all";
+  console.log("[eliza-test] plan");
+  console.log(`  lane: ${TEST_LANE}`);
+  console.log(`  scripts: ${scriptMode}`);
+  console.log(`  cloud: ${noCloud ? "disabled" : "enabled"}`);
+  console.log(`  shard: ${TEST_SHARD || "none"}`);
+  console.log(`  concurrency: ${concurrency}`);
+  console.log(
+    `  package filters: ${packageFilterInputs.length ? packageFilterInputs.join(" && ") : "none"}`,
+  );
+  console.log(`  script filter: ${scriptFilterInput || "none"}`);
+  console.log(`  start at: ${startAt || "none"}`);
+  console.log(`  excludes: ${excludeFlags.length}`);
+  console.log(`  runnable tasks: ${tasks.length}`);
+  console.log(`  parallel task(s): ${parallel.length}`);
+  console.log(`  serial task(s): ${serial.length + (noCloud ? 0 : 1)}`);
+  console.log(`  skipped during discovery: ${discoverySkips.length}`);
+
+  for (const task of tasks) {
+    const mode = parallelLabels.has(task.label) ? "parallel" : "serial";
+    console.log(`  ${mode} ${task.label}`);
+  }
+  if (!noCloud) {
+    console.log("  serial cloud#test");
+  }
+  for (const { label, reason } of discoverySkips) {
+    console.log(`  skip ${label} (${reason})`);
+  }
+}
+
+if (listFlag) {
+  printTaskPlan();
+  process.exit(0);
+}
+
+ensurePluginSqlPostgresEnv();
 
 const laneEnv = buildLaneEnv();
 

--- a/tsconfig.dist-paths.json
+++ b/tsconfig.dist-paths.json
@@ -6,14 +6,24 @@
     "declaration": false,
     "declarationMap": false,
     "paths": {
-      "@elizaos-benchmarks/lib": ["./packages/benchmarks/lib/src/index.ts"],
-      "@elizaos/agent": ["./packages/agent/dist/index.d.ts"],
-      "@elizaos/agent/*": ["./packages/agent/dist/*.d.ts"],
-      "@elizaos/app-core": ["./packages/app-core/dist/index.d.ts"],
+      "@elizaos-benchmarks/lib": [
+        "./packages/benchmarks/lib/src/index.ts"
+      ],
+      "@elizaos/agent": [
+        "./packages/agent/dist/index.d.ts"
+      ],
+      "@elizaos/agent/*": [
+        "./packages/agent/dist/*.d.ts"
+      ],
+      "@elizaos/app-core": [
+        "./packages/app-core/dist/index.d.ts"
+      ],
       "@elizaos/app-model-tester": [
         "./plugins/app-model-tester/dist/index.d.ts"
       ],
-      "@elizaos/bench-eliza-1": ["./packages/benchmarks/eliza-1/src/index.ts"],
+      "@elizaos/bench-eliza-1": [
+        "./packages/benchmarks/eliza-1/src/index.ts"
+      ],
       "@elizaos/bench-eliza-1-vision-cua-e2e": [
         "./packages/benchmarks/eliza-1/vision-cua-e2e/src/pipeline.ts"
       ],
@@ -89,20 +99,30 @@
       "@elizaos/capacitor-wifi": [
         "./plugins/plugin-native-wifi/dist/esm/index.d.ts"
       ],
-      "@elizaos/cloud-routing": ["./packages/cloud/routing/dist/index.d.ts"],
-      "@elizaos/cloud-sdk": ["./packages/cloud/sdk/dist/index.d.ts"],
+      "@elizaos/cloud-routing": [
+        "./packages/cloud/routing/dist/index.d.ts"
+      ],
+      "@elizaos/cloud-sdk": [
+        "./packages/cloud/sdk/dist/index.d.ts"
+      ],
       "@elizaos/cloud-services-common": [
         "./packages/cloud/services/_common/src/index.ts"
       ],
       "@elizaos/configbench": [
         "./packages/benchmarks/configbench/dist/index.d.ts"
       ],
-      "@elizaos/contracts": ["./packages/contracts/dist/index.d.ts"],
-      "@elizaos/core": ["./packages/core/dist/index.d.ts"],
+      "@elizaos/contracts": [
+        "./packages/contracts/dist/index.d.ts"
+      ],
+      "@elizaos/core": [
+        "./packages/core/dist/index.d.ts"
+      ],
       "@elizaos/interrupt-bench": [
         "./packages/benchmarks/interrupt-bench/src/index.ts"
       ],
-      "@elizaos/logger": ["./packages/logger/dist/index.d.ts"],
+      "@elizaos/logger": [
+        "./packages/logger/dist/index.d.ts"
+      ],
       "@elizaos/macosalarm": [
         "./plugins/plugin-native-macosalarm/dist/index.d.ts"
       ],
@@ -115,15 +135,21 @@
       "@elizaos/os-android-system-ui": [
         "./packages/os/android/system-ui/src/index.ts"
       ],
-      "@elizaos/os-shared-system": ["./packages/os/shared-system/src/index.ts"],
-      "@elizaos/os-usb-installer": ["./packages/os/usb-installer/src/index.ts"],
+      "@elizaos/os-shared-system": [
+        "./packages/os/shared-system/src/index.ts"
+      ],
+      "@elizaos/os-usb-installer": [
+        "./packages/os/usb-installer/src/index.ts"
+      ],
       "@elizaos/plugin-agent-orchestrator": [
         "./plugins/plugin-agent-orchestrator/dist/index.d.ts"
       ],
       "@elizaos/plugin-agent-skills": [
         "./plugins/plugin-agent-skills/dist/index.d.ts"
       ],
-      "@elizaos/plugin-ainex": ["./plugins/plugin-ainex/dist/index.d.ts"],
+      "@elizaos/plugin-ainex": [
+        "./plugins/plugin-ainex/dist/index.d.ts"
+      ],
       "@elizaos/plugin-anthropic": [
         "./plugins/plugin-anthropic/dist/index.d.ts"
       ],
@@ -145,20 +171,30 @@
       "@elizaos/plugin-benchmarks": [
         "./plugins/plugin-benchmarks/dist/index.d.ts"
       ],
-      "@elizaos/plugin-blocker": ["./plugins/plugin-blocker/dist/index.d.ts"],
+      "@elizaos/plugin-blocker": [
+        "./plugins/plugin-blocker/dist/index.d.ts"
+      ],
       "@elizaos/plugin-bluebubbles": [
         "./plugins/plugin-bluebubbles/dist/index.d.ts"
       ],
       "@elizaos/plugin-bluesky": [
         "./plugins/plugin-bluesky/dist/node/index.d.ts"
       ],
-      "@elizaos/plugin-browser": ["./plugins/plugin-browser/dist/index.d.ts"],
-      "@elizaos/plugin-calendar": ["./plugins/plugin-calendar/dist/index.d.ts"],
-      "@elizaos/plugin-calendly": ["./plugins/plugin-calendly/dist/index.d.ts"],
+      "@elizaos/plugin-browser": [
+        "./plugins/plugin-browser/dist/index.d.ts"
+      ],
+      "@elizaos/plugin-calendar": [
+        "./plugins/plugin-calendar/dist/index.d.ts"
+      ],
+      "@elizaos/plugin-calendly": [
+        "./plugins/plugin-calendly/dist/index.d.ts"
+      ],
       "@elizaos/plugin-capacitor-bridge": [
         "./plugins/plugin-capacitor-bridge/dist/index.d.ts"
       ],
-      "@elizaos/plugin-cli": ["./plugins/plugin-cli/dist/index.d.ts"],
+      "@elizaos/plugin-cli": [
+        "./plugins/plugin-cli/dist/index.d.ts"
+      ],
       "@elizaos/plugin-cli-inference": [
         "./plugins/plugin-cli-inference/dist/index.d.ts"
       ],
@@ -171,19 +207,27 @@
       "@elizaos/plugin-coding-tools": [
         "./plugins/plugin-coding-tools/dist/index.d.ts"
       ],
-      "@elizaos/plugin-commands": ["./plugins/plugin-commands/dist/index.d.ts"],
+      "@elizaos/plugin-commands": [
+        "./plugins/plugin-commands/dist/index.d.ts"
+      ],
       "@elizaos/plugin-computeruse": [
         "./plugins/plugin-computeruse/dist/index.d.ts"
       ],
-      "@elizaos/plugin-contacts": ["./plugins/plugin-contacts/dist/index.d.ts"],
-      "@elizaos/plugin-discord": ["./plugins/plugin-discord/dist/index.d.ts"],
+      "@elizaos/plugin-contacts": [
+        "./plugins/plugin-contacts/dist/index.d.ts"
+      ],
+      "@elizaos/plugin-discord": [
+        "./plugins/plugin-discord/dist/index.d.ts"
+      ],
       "@elizaos/plugin-discord-local": [
         "./plugins/plugin-discord-local/dist/src/index.d.ts"
       ],
       "@elizaos/plugin-documents": [
         "./plugins/plugin-documents/dist/index.d.ts"
       ],
-      "@elizaos/plugin-edge-tts": ["./plugins/plugin-edge-tts/dist/index.d.ts"],
+      "@elizaos/plugin-edge-tts": [
+        "./plugins/plugin-edge-tts/dist/index.d.ts"
+      ],
       "@elizaos/plugin-elevenlabs": [
         "./plugins/plugin-elevenlabs/dist/index.d.ts"
       ],
@@ -193,42 +237,72 @@
       "@elizaos/plugin-embeddings": [
         "./plugins/plugin-embeddings/dist/node/index.d.ts"
       ],
-      "@elizaos/plugin-facewear": ["./plugins/plugin-facewear/dist/index.d.ts"],
-      "@elizaos/plugin-facewear/*": ["./plugins/plugin-facewear/dist/*.d.ts"],
+      "@elizaos/plugin-facewear": [
+        "./plugins/plugin-facewear/dist/index.d.ts"
+      ],
+      "@elizaos/plugin-facewear/*": [
+        "./plugins/plugin-facewear/dist/*.d.ts"
+      ],
       "@elizaos/plugin-farcaster": [
         "./plugins/plugin-farcaster/dist/node/index.d.ts"
       ],
-      "@elizaos/plugin-feed": ["./plugins/plugin-feed/dist/index.d.ts"],
-      "@elizaos/plugin-feishu": ["./plugins/plugin-feishu/dist/index.d.ts"],
-      "@elizaos/plugin-finances": ["./plugins/plugin-finances/dist/index.d.ts"],
-      "@elizaos/plugin-form": ["./plugins/plugin-form/dist/index.d.ts"],
-      "@elizaos/plugin-github": ["./plugins/plugin-github/dist/index.d.ts"],
+      "@elizaos/plugin-feed": [
+        "./plugins/plugin-feed/dist/index.d.ts"
+      ],
+      "@elizaos/plugin-feishu": [
+        "./plugins/plugin-feishu/dist/index.d.ts"
+      ],
+      "@elizaos/plugin-finances": [
+        "./plugins/plugin-finances/dist/index.d.ts"
+      ],
+      "@elizaos/plugin-form": [
+        "./plugins/plugin-form/dist/index.d.ts"
+      ],
+      "@elizaos/plugin-github": [
+        "./plugins/plugin-github/dist/index.d.ts"
+      ],
       "@elizaos/plugin-gitpathologist": [
         "./plugins/plugin-gitpathologist/dist/index.d.ts"
       ],
-      "@elizaos/plugin-goals": ["./plugins/plugin-goals/dist/index.d.ts"],
-      "@elizaos/plugin-google": ["./plugins/plugin-google/dist/index.d.ts"],
+      "@elizaos/plugin-goals": [
+        "./plugins/plugin-goals/dist/index.d.ts"
+      ],
+      "@elizaos/plugin-google": [
+        "./plugins/plugin-google/dist/index.d.ts"
+      ],
       "@elizaos/plugin-google-chat": [
         "./plugins/plugin-google-chat/dist/index.d.ts"
       ],
       "@elizaos/plugin-google-genai": [
         "./plugins/plugin-google-genai/dist/index.d.ts"
       ],
-      "@elizaos/plugin-groq": ["./plugins/plugin-groq/dist/index.d.ts"],
-      "@elizaos/plugin-health": ["./plugins/plugin-health/dist/index.d.ts"],
+      "@elizaos/plugin-groq": [
+        "./plugins/plugin-groq/dist/index.d.ts"
+      ],
+      "@elizaos/plugin-health": [
+        "./plugins/plugin-health/dist/index.d.ts"
+      ],
       "@elizaos/plugin-hyperliquid": [
         "./plugins/plugin-hyperliquid/dist/index.d.ts"
       ],
-      "@elizaos/plugin-imessage": ["./plugins/plugin-imessage/dist/index.d.ts"],
-      "@elizaos/plugin-inbox": ["./plugins/plugin-inbox/dist/index.d.ts"],
+      "@elizaos/plugin-imessage": [
+        "./plugins/plugin-imessage/dist/index.d.ts"
+      ],
+      "@elizaos/plugin-inbox": [
+        "./plugins/plugin-inbox/dist/index.d.ts"
+      ],
       "@elizaos/plugin-inmemorydb": [
         "./plugins/plugin-inmemorydb/dist/index.d.ts"
       ],
       "@elizaos/plugin-instagram": [
         "./plugins/plugin-instagram/dist/index.d.ts"
       ],
-      "@elizaos/plugin-line": ["./plugins/plugin-line/dist/index.d.ts"],
-      "@elizaos/plugin-linear": ["./plugins/plugin-linear/dist/index.d.ts"],
+      "@elizaos/plugin-line": [
+        "./plugins/plugin-line/dist/index.d.ts"
+      ],
+      "@elizaos/plugin-linear": [
+        "./plugins/plugin-linear/dist/index.d.ts"
+      ],
       "@elizaos/plugin-lmstudio": [
         "./plugins/plugin-lmstudio/dist/node/index.d.ts"
       ],
@@ -247,11 +321,21 @@
       "@elizaos/plugin-local-storage": [
         "./plugins/plugin-local-storage/dist/index.d.ts"
       ],
-      "@elizaos/plugin-localdb": ["./plugins/plugin-localdb/dist/index.d.ts"],
-      "@elizaos/plugin-matrix": ["./plugins/plugin-matrix/dist/index.d.ts"],
-      "@elizaos/plugin-mcp": ["./plugins/plugin-mcp/dist/index.d.ts"],
-      "@elizaos/plugin-messages": ["./plugins/plugin-messages/dist/index.d.ts"],
-      "@elizaos/plugin-music": ["./plugins/plugin-music/dist/index.d.ts"],
+      "@elizaos/plugin-localdb": [
+        "./plugins/plugin-localdb/dist/index.d.ts"
+      ],
+      "@elizaos/plugin-matrix": [
+        "./plugins/plugin-matrix/dist/index.d.ts"
+      ],
+      "@elizaos/plugin-mcp": [
+        "./plugins/plugin-mcp/dist/index.d.ts"
+      ],
+      "@elizaos/plugin-messages": [
+        "./plugins/plugin-messages/dist/index.d.ts"
+      ],
+      "@elizaos/plugin-music": [
+        "./plugins/plugin-music/dist/index.d.ts"
+      ],
       "@elizaos/plugin-music-library": [
         "./plugins/plugin-music/dist/index.d.ts"
       ],
@@ -267,24 +351,36 @@
       "@elizaos/plugin-nearai": [
         "./plugins/plugin-nearai/dist/node/index.d.ts"
       ],
-      "@elizaos/plugin-ngrok": ["./plugins/plugin-ngrok/dist/index.d.ts"],
-      "@elizaos/plugin-nostr": ["./plugins/plugin-nostr/dist/index.d.ts"],
+      "@elizaos/plugin-ngrok": [
+        "./plugins/plugin-ngrok/dist/index.d.ts"
+      ],
+      "@elizaos/plugin-nostr": [
+        "./plugins/plugin-nostr/dist/index.d.ts"
+      ],
       "@elizaos/plugin-ollama": [
         "./plugins/plugin-ollama/dist/node/index.d.ts"
       ],
-      "@elizaos/plugin-openai": ["./plugins/plugin-openai/dist/index.d.ts"],
+      "@elizaos/plugin-openai": [
+        "./plugins/plugin-openai/dist/index.d.ts"
+      ],
       "@elizaos/plugin-openrouter": [
         "./plugins/plugin-openrouter/dist/index.d.ts"
       ],
-      "@elizaos/plugin-pdf": ["./plugins/plugin-pdf/dist/index.d.ts"],
+      "@elizaos/plugin-pdf": [
+        "./plugins/plugin-pdf/dist/index.d.ts"
+      ],
       "@elizaos/plugin-personal-assistant": [
         "./plugins/plugin-personal-assistant/dist/index.d.ts"
       ],
-      "@elizaos/plugin-phone": ["./plugins/plugin-phone/dist/index.d.ts"],
+      "@elizaos/plugin-phone": [
+        "./plugins/plugin-phone/dist/index.d.ts"
+      ],
       "@elizaos/plugin-polymarket": [
         "./plugins/plugin-polymarket/dist/index.d.ts"
       ],
-      "@elizaos/plugin-registry": ["./plugins/plugin-registry/dist/index.d.ts"],
+      "@elizaos/plugin-registry": [
+        "./plugins/plugin-registry/dist/index.d.ts"
+      ],
       "@elizaos/plugin-relationships": [
         "./plugins/plugin-relationships/dist/index.d.ts"
       ],
@@ -303,14 +399,24 @@
       "@elizaos/plugin-screenshare": [
         "./plugins/plugin-screenshare/dist/index.d.ts"
       ],
-      "@elizaos/plugin-shell": ["./plugins/plugin-shell/dist/index.d.ts"],
-      "@elizaos/plugin-shopify": ["./plugins/plugin-shopify/dist/index.d.ts"],
-      "@elizaos/plugin-signal": ["./plugins/plugin-signal/dist/index.d.ts"],
-      "@elizaos/plugin-slack": ["./plugins/plugin-slack/dist/index.d.ts"],
+      "@elizaos/plugin-shell": [
+        "./plugins/plugin-shell/dist/index.d.ts"
+      ],
+      "@elizaos/plugin-shopify": [
+        "./plugins/plugin-shopify/dist/index.d.ts"
+      ],
+      "@elizaos/plugin-signal": [
+        "./plugins/plugin-signal/dist/index.d.ts"
+      ],
+      "@elizaos/plugin-slack": [
+        "./plugins/plugin-slack/dist/index.d.ts"
+      ],
       "@elizaos/plugin-social-alpha": [
         "./plugins/plugin-social-alpha/dist/index.d.ts"
       ],
-      "@elizaos/plugin-sql": ["./plugins/plugin-sql/src/dist/index.node.d.ts"],
+      "@elizaos/plugin-sql": [
+        "./plugins/plugin-sql/src/dist/index.node.d.ts"
+      ],
       "@elizaos/plugin-starter": [
         "./packages/examples/_plugin/dist/index.d.ts"
       ],
@@ -320,84 +426,168 @@
       "@elizaos/plugin-sub-agent-claude-code": [
         "./packages/plugin-sub-agent-claude-code/dist/plugin.d.ts"
       ],
-      "@elizaos/plugin-suno": ["./plugins/plugin-suno/dist/index.d.ts"],
+      "@elizaos/plugin-suno": [
+        "./plugins/plugin-suno/dist/index.d.ts"
+      ],
       "@elizaos/plugin-tailscale": [
         "./plugins/plugin-tailscale/dist/index.d.ts"
       ],
       "@elizaos/plugin-task-coordinator": [
         "./plugins/plugin-task-coordinator/dist/index.d.ts"
       ],
-      "@elizaos/plugin-tee": ["./plugins/plugin-tee/dist/node/index.d.ts"],
-      "@elizaos/plugin-telegram": ["./plugins/plugin-telegram/dist/index.d.ts"],
-      "@elizaos/plugin-todos": ["./plugins/plugin-todos/dist/index.d.ts"],
-      "@elizaos/plugin-training": ["./plugins/plugin-training/dist/index.d.ts"],
+      "@elizaos/plugin-tee": [
+        "./plugins/plugin-tee/dist/node/index.d.ts"
+      ],
+      "@elizaos/plugin-telegram": [
+        "./plugins/plugin-telegram/dist/index.d.ts"
+      ],
+      "@elizaos/plugin-todos": [
+        "./plugins/plugin-todos/dist/index.d.ts"
+      ],
+      "@elizaos/plugin-training": [
+        "./plugins/plugin-training/dist/index.d.ts"
+      ],
       "@elizaos/plugin-trajectory-logger": [
         "./plugins/plugin-trajectory-logger/dist/index.d.ts"
       ],
-      "@elizaos/plugin-tunnel": ["./plugins/plugin-tunnel/dist/index.d.ts"],
-      "@elizaos/plugin-twitch": ["./plugins/plugin-twitch/dist/index.d.ts"],
+      "@elizaos/plugin-tunnel": [
+        "./plugins/plugin-tunnel/dist/index.d.ts"
+      ],
+      "@elizaos/plugin-twitch": [
+        "./plugins/plugin-twitch/dist/index.d.ts"
+      ],
       "@elizaos/plugin-vector-browser": [
         "./plugins/plugin-vector-browser/dist/index.d.ts"
       ],
-      "@elizaos/plugin-video": ["./plugins/plugin-video/dist/index.d.ts"],
-      "@elizaos/plugin-vision": ["./plugins/plugin-vision/dist/index.d.ts"],
-      "@elizaos/plugin-wallet": ["./plugins/plugin-wallet/dist/index.d.ts"],
+      "@elizaos/plugin-video": [
+        "./plugins/plugin-video/dist/index.d.ts"
+      ],
+      "@elizaos/plugin-vision": [
+        "./plugins/plugin-vision/dist/index.d.ts"
+      ],
+      "@elizaos/plugin-wallet": [
+        "./plugins/plugin-wallet/dist/index.d.ts"
+      ],
       "@elizaos/plugin-wallet-ui": [
         "./plugins/plugin-wallet-ui/dist/index.d.ts"
       ],
       "@elizaos/plugin-web-search": [
         "./plugins/plugin-web-search/dist/index.d.ts"
       ],
-      "@elizaos/plugin-wechat": ["./plugins/plugin-wechat/dist/index.d.ts"],
-      "@elizaos/plugin-whatsapp": ["./plugins/plugin-whatsapp/dist/index.d.ts"],
-      "@elizaos/plugin-wifi": ["./plugins/plugin-wifi/dist/index.d.ts"],
+      "@elizaos/plugin-wechat": [
+        "./plugins/plugin-wechat/dist/index.d.ts"
+      ],
+      "@elizaos/plugin-whatsapp": [
+        "./plugins/plugin-whatsapp/dist/index.d.ts"
+      ],
+      "@elizaos/plugin-wifi": [
+        "./plugins/plugin-wifi/dist/index.d.ts"
+      ],
       "@elizaos/plugin-worker-runtime": [
         "./packages/plugin-worker-runtime/dist/index.d.ts"
       ],
-      "@elizaos/plugin-workflow": ["./plugins/plugin-workflow/dist/index.d.ts"],
-      "@elizaos/plugin-x": ["./plugins/plugin-x/dist/index.d.ts"],
-      "@elizaos/plugin-x402": ["./plugins/plugin-x402/dist/index.d.ts"],
-      "@elizaos/plugin-xai": ["./plugins/plugin-xai/dist/index.d.ts"],
-      "@elizaos/plugin-xai/*": ["./plugins/plugin-xai/*"],
-      "@elizaos/plugin-xr": ["./plugins/plugin-xr/dist/index.d.ts"],
-      "@elizaos/plugin-zai": ["./plugins/plugin-zai/dist/node/index.d.ts"],
-      "@elizaos/prompts": ["./packages/prompts/dist/index.d.ts"],
-      "@elizaos/registry": ["./packages/registry/src/index.ts"],
-      "@elizaos/robot": ["./packages/research/robot/dist/index.d.ts"],
+      "@elizaos/plugin-workflow": [
+        "./plugins/plugin-workflow/dist/index.d.ts"
+      ],
+      "@elizaos/plugin-x": [
+        "./plugins/plugin-x/dist/index.d.ts"
+      ],
+      "@elizaos/plugin-x402": [
+        "./plugins/plugin-x402/dist/index.d.ts"
+      ],
+      "@elizaos/plugin-xai": [
+        "./plugins/plugin-xai/dist/index.d.ts"
+      ],
+      "@elizaos/plugin-xai/*": [
+        "./plugins/plugin-xai/*"
+      ],
+      "@elizaos/plugin-xr": [
+        "./plugins/plugin-xr/dist/index.d.ts"
+      ],
+      "@elizaos/plugin-zai": [
+        "./plugins/plugin-zai/dist/node/index.d.ts"
+      ],
+      "@elizaos/prompts": [
+        "./packages/prompts/dist/index.d.ts"
+      ],
+      "@elizaos/registry": [
+        "./packages/registry/src/index.ts"
+      ],
+      "@elizaos/robot": [
+        "./packages/research/robot/dist/index.d.ts"
+      ],
       "@elizaos/scenario-runner": [
         "./packages/scenario-runner/dist/index.d.ts"
       ],
-      "@elizaos/security": ["./packages/security/dist/index.d.ts"],
-      "@elizaos/shared": ["./packages/shared/dist/index.d.ts"],
+      "@elizaos/security": [
+        "./packages/security/dist/index.d.ts"
+      ],
+      "@elizaos/shared": [
+        "./packages/shared/dist/index.d.ts"
+      ],
       "@elizaos/shared/local-inference": [
         "./packages/shared/src/local-inference/index.ts"
       ],
-      "@elizaos/skills": ["./packages/skills/dist/index.d.ts"],
+      "@elizaos/skills": [
+        "./packages/skills/dist/index.d.ts"
+      ],
       "@elizaos/three-agent-dialogue": [
         "./packages/benchmarks/three-agent-dialogue/runner/run-dialogue.ts"
       ],
-      "@elizaos/tui": ["./packages/tui/dist/index.d.ts"],
-      "@elizaos/ui": ["./packages/ui/dist/index.d.ts"],
-      "@elizaos/vault": ["./packages/vault/dist/index.d.ts"],
-      "@feed/a2a": ["./packages/feed/packages/a2a/src/index.ts"],
-      "@feed/agents": ["./packages/feed/packages/agents/src/index.ts"],
-      "@feed/api": ["./packages/feed/packages/api/src/index.ts"],
-      "@feed/contracts": ["./packages/feed/packages/contracts/src/index.ts"],
-      "@feed/core": ["./packages/feed/packages/core/markets/index.ts"],
-      "@feed/db": ["./packages/feed/packages/db/src/index.ts"],
-      "@feed/engine": ["./packages/feed/packages/engine/src/index.ts"],
-      "@feed/mcp": ["./packages/feed/packages/mcp/src/index.ts"],
+      "@elizaos/tui": [
+        "./packages/tui/dist/index.d.ts"
+      ],
+      "@elizaos/ui": [
+        "./packages/ui/dist/index.d.ts"
+      ],
+      "@elizaos/vault": [
+        "./packages/vault/dist/index.d.ts"
+      ],
+      "@feed/a2a": [
+        "./packages/feed/packages/a2a/src/index.ts"
+      ],
+      "@feed/agents": [
+        "./packages/feed/packages/agents/src/index.ts"
+      ],
+      "@feed/api": [
+        "./packages/feed/packages/api/src/index.ts"
+      ],
+      "@feed/contracts": [
+        "./packages/feed/packages/contracts/src/index.ts"
+      ],
+      "@feed/core": [
+        "./packages/feed/packages/core/markets/index.ts"
+      ],
+      "@feed/db": [
+        "./packages/feed/packages/db/src/index.ts"
+      ],
+      "@feed/engine": [
+        "./packages/feed/packages/engine/src/index.ts"
+      ],
+      "@feed/mcp": [
+        "./packages/feed/packages/mcp/src/index.ts"
+      ],
       "@feed/pack-corporate-30-under-30": [
         "./packages/feed/packages/pack-corporate-30-under-30/src/index.ts"
       ],
       "@feed/pack-default": [
         "./packages/feed/packages/pack-default/src/index.ts"
       ],
-      "@feed/shared": ["./packages/feed/packages/shared/src/index.ts"],
-      "@feed/sim": ["./packages/feed/packages/sim/core/index.ts"],
-      "@feed/testing": ["./packages/feed/packages/testing/src/index.ts"],
-      "elizaos": ["./packages/elizaos/dist/index.d.ts"],
-      "elizaos-plugin-echo": ["./packages/examples/plugin-echo/dist/index.d.ts"]
+      "@feed/shared": [
+        "./packages/feed/packages/shared/src/index.ts"
+      ],
+      "@feed/sim": [
+        "./packages/feed/packages/sim/core/index.ts"
+      ],
+      "@feed/testing": [
+        "./packages/feed/packages/testing/src/index.ts"
+      ],
+      "elizaos": [
+        "./packages/elizaos/dist/index.d.ts"
+      ],
+      "elizaos-plugin-echo": [
+        "./packages/examples/plugin-echo/dist/index.d.ts"
+      ]
     }
   },
   "include": [


### PR DESCRIPTION
## Summary

- Add `--list` / `--dry-run` to `packages/scripts/run-all-tests.mjs` so maintainers can inspect the exact task plan after lane/filter/shard/skip handling without preparing Postgres or spawning tests.
- Add a focused runner-plan self-test, including a stripped-`PATH` assertion that the plan path stays side-effect free.
- Refresh generated dist-path metadata and the registry generated output required by the current toolchain.
- Fix two ambiguous anchor labels in the Solana trajectory viewer that blocked repo-wide verify.

Refs #10200.

## Evidence

Evidence file: `.github/issue-evidence/10200-run-all-tests-plan.md`

Validation run locally on the branch:

- `bun run install:light`
- `bun test packages/scripts/__tests__/run-all-tests-plan.test.ts packages/scripts/__tests__/test-task-pool.test.ts` (28 pass)
- `node packages/scripts/run-all-tests.mjs --list --filter=packages/core --only=test --no-cloud --concurrency=3` (output manually reviewed)
- `bun run --cwd packages/benchmarks/solana/solana-gym-env/docs/trajectory-viewer lint`
- `bun run typecheck:dist`
- `bun run verify` (passed: 474/474 Turbo tasks, all post-Turbo audits, 28 dist-path consumers)

## N/A

- Screenshots/video: CLI runner + docs lint/generated metadata only; no app UI behavior changed.
- Live model trajectory: no agent/model/prompt/action behavior changed.