### PR TITLE
feat(app-core): accept the embed session token as an API credential (#9947)

### DIFF
--- a/packages/app-core/src/api/auth.ts
+++ b/packages/app-core/src/api/auth.ts
@@ -13,6 +13,8 @@ import { resolveApiToken } from "@elizaos/shared";
 import { type AuthIdentityRow, AuthStore } from "../services/auth-store.js";
 import {
   type EmbedSessionClaims,
+  type EmbedSessionSecretRuntime,
+  readEmbedSessionSecretSetting,
   resolveEmbedSessionSecret,
   verifyEmbedSessionToken,
 } from "./auth/embed-session-token.js";
@@ -28,7 +30,9 @@ import { sendJsonError } from "./response.js";
 export { tokenMatches } from "./auth/tokens.js";
 
 interface CompatStateLike {
-  current: { adapter?: { db?: unknown } | null } | null;
+  current:
+    | (EmbedSessionSecretRuntime & { adapter?: { db?: unknown } | null })
+    | null;
 }
 
 /**
@@ -220,6 +224,7 @@ export async function ensureCompatApiAuthorizedAsync(
   options: {
     store: import("../services/auth-store").AuthStore;
     now?: number;
+    readSetting?: (key: string) => unknown;
     /**
      * Skip CSRF enforcement for routes that ALWAYS handle CSRF themselves
      * (e.g. login routes that mint the cookie, where there is no prior
@@ -288,7 +293,7 @@ export async function ensureCompatApiAuthorizedAsync(
     // Embed session token (cross-origin Mini App / Activity iframe): a valid,
     // unexpired token minted by /api/embed/auth authenticates the verified
     // OWNER/ADMIN principal. Bearer-only, so CSRF-exempt like the paths above.
-    if (resolveEmbedPrincipal(req, options.now)) {
+    if (resolveEmbedPrincipal(req, options.now, options.readSetting)) {
       return true;
     }
   }
@@ -556,7 +561,9 @@ async function resolveAuthorizedRouteRole(
     // Embed session token → its verified boundary role (OWNER→OWNER,
     // ADMIN→USER). Fails closed on a tampered/expired token or no secret.
     const embedRole = embedBoundaryRole(
-      resolveEmbedPrincipal(req, options.now),
+      resolveEmbedPrincipal(req, options.now, (key) =>
+        readEmbedSessionSecretSetting(state.current, key),
+      ),
     );
     if (embedRole) {
       return { ok: true, role: embedRole };
@@ -650,5 +657,6 @@ export async function ensureRouteAuthorized(
     store,
     now: options.now,
     skipCsrf: options.skipCsrf,
+    readSetting: (key) => readEmbedSessionSecretSetting(state.current, key),
   });
 }

--- a/packages/app-core/src/api/auth.ts
+++ b/packages/app-core/src/api/auth.ts
@@ -12,6 +12,11 @@ import { resolveApiToken } from "@elizaos/shared";
 // import below was INEFFECTIVE_DYNAMIC_IMPORT.
 import { type AuthIdentityRow, AuthStore } from "../services/auth-store.js";
 import {
+  type EmbedSessionClaims,
+  resolveEmbedSessionSecret,
+  verifyEmbedSessionToken,
+} from "./auth/embed-session-token.js";
+import {
   CSRF_HEADER_NAME,
   findActiveSession,
   verifyCsrfToken,
@@ -72,6 +77,41 @@ export function getProvidedApiToken(
     extractHeaderValue(req.headers["x-api-token"]);
 
   return headerToken?.trim() || null;
+}
+
+/**
+ * Resolve a request's embed session principal (#9947), or `null`.
+ *
+ * A cross-origin embedded surface (Telegram Mini App / Discord Activity iframe)
+ * cannot present the first-party session cookie, so after `/api/embed/auth`
+ * verifies its platform-signed launch it mints a scoped, HMAC-signed bearer.
+ * This resolves + verifies that bearer against the same configured secret,
+ * failing closed on a tampered/expired/malformed token or an unconfigured
+ * secret. `read` defaults to `process.env`; the sync boundary-role path passes
+ * its own env source.
+ */
+export function resolveEmbedPrincipal(
+  req: Pick<http.IncomingMessage, "headers">,
+  now?: number,
+  read: (key: string) => unknown = (key) => process.env[key],
+): EmbedSessionClaims | null {
+  const secret = resolveEmbedSessionSecret(read);
+  if (!secret) return null;
+  const provided = getProvidedApiToken(req);
+  if (!provided) return null;
+  return verifyEmbedSessionToken(provided, secret, now);
+}
+
+/**
+ * Map a verified embed principal to a boundary role. OWNER→OWNER; ADMIN→USER —
+ * non-escalating, because the HTTP boundary has no ADMIN tier and ADMIN ranks
+ * below OWNER. Returns `null` when there is no valid embed principal.
+ */
+export function embedBoundaryRole(
+  claims: EmbedSessionClaims | null,
+): RoleGateRole | null {
+  if (!claims) return null;
+  return claims.role === "OWNER" ? "OWNER" : "USER";
 }
 
 // ── Auth attempt rate limiter ─────────────────────────────────────────────────
@@ -242,6 +282,13 @@ export async function ensureCompatApiAuthorizedAsync(
       expectedToken &&
       tokenMatches(expectedToken, provided)
     ) {
+      return true;
+    }
+
+    // Embed session token (cross-origin Mini App / Activity iframe): a valid,
+    // unexpired token minted by /api/embed/auth authenticates the verified
+    // OWNER/ADMIN principal. Bearer-only, so CSRF-exempt like the paths above.
+    if (resolveEmbedPrincipal(req, options.now)) {
       return true;
     }
   }
@@ -504,6 +551,15 @@ async function resolveAuthorizedRouteRole(
       tokenMatches(expectedToken, provided)
     ) {
       return { ok: true, role: "OWNER" };
+    }
+
+    // Embed session token → its verified boundary role (OWNER→OWNER,
+    // ADMIN→USER). Fails closed on a tampered/expired token or no secret.
+    const embedRole = embedBoundaryRole(
+      resolveEmbedPrincipal(req, options.now),
+    );
+    if (embedRole) {
+      return { ok: true, role: embedRole };
     }
   }
 

--- a/packages/app-core/src/api/auth/embed-session-auth.test.ts
+++ b/packages/app-core/src/api/auth/embed-session-auth.test.ts
@@ -1,0 +1,264 @@
+/**
+ * #9947 keystone — the embed session token is accepted as an API credential.
+ *
+ * `/api/embed/auth` mints a scoped, HMAC-signed bearer for the verified
+ * OWNER/ADMIN principal of a cross-origin Telegram Mini App / Discord Activity
+ * iframe (which cannot present the first-party session cookie). These tests pin
+ * that the auth boundary now accepts that bearer — fail-closed on every bad
+ * path — and that it is deliberately kept OUT of the sync sensitive/secrets
+ * gate (`resolveBoundaryRole`), matching how normal sessions are excluded there.
+ */
+
+import * as http from "node:http";
+import { Socket } from "node:net";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AuthStore } from "../../services/auth-store";
+import {
+  _resetAuthRateLimiter,
+  embedBoundaryRole,
+  ensureCompatApiAuthorizedAsync,
+  resolveBoundaryRole,
+  resolveEmbedPrincipal,
+} from "../auth.ts";
+import {
+  mintEmbedSessionToken,
+  resolveEmbedSessionSecret,
+} from "./embed-session-token";
+
+const SECRET = "embed-secret-at-least-16-chars-long";
+const NOW = 1_000_000;
+const ENTITY = "11111111-1111-1111-1111-111111111111";
+
+// A store whose session lookups always miss, so the request falls through the
+// cookie/session-bearer paths to the embed check. No real DB needed.
+const noSessionStore = {
+  findSession: async () => null,
+  findIdentity: async () => null,
+} as unknown as AuthStore;
+
+// A remote (off-box) request — NOT trusted-local, so it must authenticate.
+function remoteReq(
+  headers: http.IncomingHttpHeaders = {},
+): http.IncomingMessage {
+  const req = new http.IncomingMessage(new Socket());
+  req.headers = {
+    host: "localhost:2138",
+    "x-forwarded-for": "203.0.113.9",
+    ...headers,
+  };
+  req.method = "GET";
+  Object.defineProperty(req.socket, "remoteAddress", {
+    value: "203.0.113.9",
+    configurable: true,
+  });
+  return req;
+}
+
+function bearer(token: string): http.IncomingHttpHeaders {
+  return { authorization: `Bearer ${token}` };
+}
+
+function fakeRes() {
+  const req = new http.IncomingMessage(new Socket());
+  const res = new http.ServerResponse(req);
+  res.setHeader = () => res;
+  res.end = (() => res) as typeof res.end;
+  return res;
+}
+
+function validToken(
+  overrides: Partial<Parameters<typeof mintEmbedSessionToken>[0]> = {},
+) {
+  return mintEmbedSessionToken(
+    {
+      entityId: ENTITY,
+      role: "OWNER",
+      adminMode: true,
+      exp: NOW + 60_000,
+      ...overrides,
+    },
+    SECRET,
+  );
+}
+
+const ENV = ["ELIZA_EMBED_SESSION_SECRET", "ELIZA_API_TOKEN"] as const;
+function clearEnv() {
+  for (const k of ENV) delete process.env[k];
+}
+
+beforeEach(() => {
+  clearEnv();
+  _resetAuthRateLimiter();
+});
+afterEach(() => {
+  clearEnv();
+  _resetAuthRateLimiter();
+  vi.restoreAllMocks();
+});
+
+describe("resolveEmbedSessionSecret", () => {
+  it("prefers ELIZA_EMBED_SESSION_SECRET", () => {
+    expect(
+      resolveEmbedSessionSecret((k) =>
+        k === "ELIZA_EMBED_SESSION_SECRET"
+          ? SECRET
+          : k === "ELIZA_API_TOKEN"
+            ? "other-api-token-16chars"
+            : undefined,
+      ),
+    ).toBe(SECRET);
+  });
+
+  it("falls back to ELIZA_API_TOKEN", () => {
+    expect(
+      resolveEmbedSessionSecret((k) =>
+        k === "ELIZA_API_TOKEN" ? SECRET : undefined,
+      ),
+    ).toBe(SECRET);
+  });
+
+  it("treats a too-short value as unconfigured", () => {
+    expect(resolveEmbedSessionSecret(() => "short")).toBeNull();
+  });
+
+  it("returns null when neither key is set", () => {
+    expect(resolveEmbedSessionSecret(() => undefined)).toBeNull();
+  });
+});
+
+describe("resolveEmbedPrincipal", () => {
+  it("resolves a valid, unexpired token to its claims", () => {
+    const claims = resolveEmbedPrincipal(
+      remoteReq(bearer(validToken())),
+      NOW,
+      () => SECRET,
+    );
+    expect(claims).toMatchObject({ entityId: ENTITY, role: "OWNER" });
+  });
+
+  it("fails closed on a tampered token", () => {
+    const token = `${validToken()}tamper`;
+    expect(
+      resolveEmbedPrincipal(remoteReq(bearer(token)), NOW, () => SECRET),
+    ).toBeNull();
+  });
+
+  it("fails closed on an expired token", () => {
+    const token = validToken({ exp: NOW - 1 });
+    expect(
+      resolveEmbedPrincipal(remoteReq(bearer(token)), NOW, () => SECRET),
+    ).toBeNull();
+  });
+
+  it("fails closed when the secret is unconfigured", () => {
+    expect(
+      resolveEmbedPrincipal(
+        remoteReq(bearer(validToken())),
+        NOW,
+        () => undefined,
+      ),
+    ).toBeNull();
+  });
+
+  it("fails closed when the token was signed with a different secret", () => {
+    const token = mintEmbedSessionToken(
+      { entityId: ENTITY, role: "OWNER", adminMode: true, exp: NOW + 60_000 },
+      "a-totally-different-secret-16c",
+    );
+    expect(
+      resolveEmbedPrincipal(remoteReq(bearer(token)), NOW, () => SECRET),
+    ).toBeNull();
+  });
+
+  it("returns null when no bearer is present", () => {
+    expect(resolveEmbedPrincipal(remoteReq(), NOW, () => SECRET)).toBeNull();
+  });
+});
+
+describe("embedBoundaryRole", () => {
+  it("maps OWNER→OWNER (no escalation)", () => {
+    expect(
+      embedBoundaryRole({
+        entityId: ENTITY,
+        role: "OWNER",
+        adminMode: true,
+        exp: NOW,
+      }),
+    ).toBe("OWNER");
+  });
+  it("maps ADMIN→USER (non-escalating; boundary has no ADMIN tier)", () => {
+    expect(
+      embedBoundaryRole({
+        entityId: ENTITY,
+        role: "ADMIN",
+        adminMode: true,
+        exp: NOW,
+      }),
+    ).toBe("USER");
+  });
+  it("returns null for no principal", () => {
+    expect(embedBoundaryRole(null)).toBeNull();
+  });
+});
+
+describe("ensureCompatApiAuthorizedAsync — embed token", () => {
+  it("authorizes a remote request bearing a valid embed token", async () => {
+    process.env.ELIZA_EMBED_SESSION_SECRET = SECRET;
+    const ok = await ensureCompatApiAuthorizedAsync(
+      remoteReq(bearer(validToken())),
+      fakeRes(),
+      { store: noSessionStore, now: NOW },
+    );
+    expect(ok).toBe(true);
+  });
+
+  it("rejects a tampered embed token (401)", async () => {
+    process.env.ELIZA_EMBED_SESSION_SECRET = SECRET;
+    const ok = await ensureCompatApiAuthorizedAsync(
+      remoteReq(bearer(`${validToken()}x`)),
+      fakeRes(),
+      { store: noSessionStore, now: NOW },
+    );
+    expect(ok).toBe(false);
+  });
+
+  it("rejects an expired embed token (401)", async () => {
+    process.env.ELIZA_EMBED_SESSION_SECRET = SECRET;
+    const ok = await ensureCompatApiAuthorizedAsync(
+      remoteReq(bearer(validToken({ exp: NOW - 1 }))),
+      fakeRes(),
+      { store: noSessionStore, now: NOW },
+    );
+    expect(ok).toBe(false);
+  });
+
+  it("rejects a valid-looking token when no embed secret is configured", async () => {
+    // Token minted with SECRET, but the server has no secret set → cannot verify.
+    const ok = await ensureCompatApiAuthorizedAsync(
+      remoteReq(bearer(validToken())),
+      fakeRes(),
+      { store: noSessionStore, now: NOW },
+    );
+    expect(ok).toBe(false);
+  });
+
+  it("rejects an arbitrary non-embed bearer", async () => {
+    process.env.ELIZA_EMBED_SESSION_SECRET = SECRET;
+    const ok = await ensureCompatApiAuthorizedAsync(
+      remoteReq(bearer("not-an-embed-token")),
+      fakeRes(),
+      { store: noSessionStore, now: NOW },
+    );
+    expect(ok).toBe(false);
+  });
+});
+
+describe("resolveBoundaryRole — embed is excluded from the sensitive gate", () => {
+  it("does NOT grant a boundary role to an embed token (stays NONE)", () => {
+    process.env.ELIZA_EMBED_SESSION_SECRET = SECRET;
+    // Even a valid embed OWNER token must not satisfy the sync sensitive-route
+    // boundary — that gate is token-only, like it is for normal sessions.
+    const role = resolveBoundaryRole(remoteReq(bearer(validToken())));
+    expect(role).toBe("NONE");
+  });
+});

--- a/packages/app-core/src/api/auth/embed-session-token.ts
+++ b/packages/app-core/src/api/auth/embed-session-token.ts
@@ -31,6 +31,42 @@ export interface EmbedSessionClaims {
 /** Default token lifetime (1 hour) — short by design; the embed re-launches. */
 export const DEFAULT_EMBED_TOKEN_TTL_MS = 60 * 60 * 1000;
 
+/**
+ * Setting keys (in preference order) that supply the HMAC secret used to sign
+ * and verify embed session tokens. A dedicated `ELIZA_EMBED_SESSION_SECRET` is
+ * preferred; it falls back to the configured `ELIZA_API_TOKEN`.
+ */
+export const EMBED_SESSION_SECRET_KEYS = [
+  "ELIZA_EMBED_SESSION_SECRET",
+  "ELIZA_API_TOKEN",
+] as const;
+
+/** Minimum secret length; a shorter value is treated as unconfigured. */
+export const EMBED_SESSION_SECRET_MIN_LENGTH = 16;
+
+/**
+ * Resolve the embed-session HMAC secret from a settings reader (the runtime's
+ * `getSetting` at mint time, or `process.env` on the auth path). The mint and
+ * verify sides MUST resolve the same secret, so both go through here. Returns
+ * `null` when no key is set to a value of at least
+ * {@link EMBED_SESSION_SECRET_MIN_LENGTH} characters — the caller then treats
+ * embed tokens as unsupported (no minting, no acceptance).
+ */
+export function resolveEmbedSessionSecret(
+  read: (key: string) => unknown,
+): string | null {
+  for (const key of EMBED_SESSION_SECRET_KEYS) {
+    const value = read(key);
+    if (
+      typeof value === "string" &&
+      value.trim().length >= EMBED_SESSION_SECRET_MIN_LENGTH
+    ) {
+      return value.trim();
+    }
+  }
+  return null;
+}
+
 function base64url(input: Buffer | string): string {
   return Buffer.from(input).toString("base64url");
 }

--- a/packages/app-core/src/api/auth/embed-session-token.ts
+++ b/packages/app-core/src/api/auth/embed-session-token.ts
@@ -44,6 +44,10 @@ export const EMBED_SESSION_SECRET_KEYS = [
 /** Minimum secret length; a shorter value is treated as unconfigured. */
 export const EMBED_SESSION_SECRET_MIN_LENGTH = 16;
 
+export interface EmbedSessionSecretRuntime {
+  getSetting?: (key: string) => unknown;
+}
+
 /**
  * Resolve the embed-session HMAC secret from a settings reader (the runtime's
  * `getSetting` at mint time, or `process.env` on the auth path). The mint and
@@ -65,6 +69,37 @@ export function resolveEmbedSessionSecret(
     }
   }
   return null;
+}
+
+/**
+ * Read an embed-session secret key from the runtime first, then from the real
+ * process env. Runtime settings win when set, but env-only deployments also
+ * work for keys intentionally not forwarded into character settings.
+ */
+export function readEmbedSessionSecretSetting(
+  runtime: EmbedSessionSecretRuntime | null | undefined,
+  key: string,
+  env: Record<string, string | undefined> = process.env,
+): unknown {
+  const runtimeValue = runtime?.getSetting?.(key);
+  if (typeof runtimeValue === "string" && runtimeValue.trim()) {
+    return runtimeValue;
+  }
+  const envValue = env[key];
+  if (typeof envValue === "string" && envValue.trim()) {
+    return envValue;
+  }
+  return runtimeValue;
+}
+
+/** Resolve the shared mint/verify secret from runtime settings or process env. */
+export function resolveEmbedSessionSecretForRuntime(
+  runtime: EmbedSessionSecretRuntime | null | undefined,
+  env: Record<string, string | undefined> = process.env,
+): string | null {
+  return resolveEmbedSessionSecret((key) =>
+    readEmbedSessionSecretSetting(runtime, key, env),
+  );
 }
 
 function base64url(input: Buffer | string): string {

--- a/packages/app-core/src/api/embed-auth-routes.test.ts
+++ b/packages/app-core/src/api/embed-auth-routes.test.ts
@@ -1,11 +1,14 @@
 import * as http from "node:http";
 import { Socket } from "node:net";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AuthStore } from "../services/auth-store";
+import { ensureCompatApiAuthorizedAsync } from "./auth";
 import { verifyEmbedSessionToken } from "./auth/embed-session-token";
 import type { CompatRuntimeState } from "./compat-route-shared";
 import { handleEmbedAuthRoutes } from "./embed-auth-routes";
 
 const EMBED_SECRET = "embed-secret-at-least-16-chars";
+const EMBED_ENTITY_ID = "11111111-1111-1111-1111-111111111111";
 
 // No module mocks: both collaborators are supplied directly. The request body
 // is delivered as the pre-parsed `req.body` the rawPath plugin-route adapter
@@ -13,6 +16,11 @@ const EMBED_SECRET = "embed-secret-at-least-16-chars";
 // is dependency-injected. Module mocks (vi.mock) race under app-core's vmForks
 // pool at full-suite parallelism, which previously hung/failed this file.
 const verifyEmbedLaunch = vi.fn();
+
+const noSessionStore = {
+  findSession: async () => null,
+  findIdentity: async () => null,
+} as unknown as AuthStore;
 
 function fakeRes() {
   let bodyText = "";
@@ -47,6 +55,21 @@ function fakeReq(
   return req;
 }
 
+function authReq(token: string): http.IncomingMessage {
+  const req = new http.IncomingMessage(new Socket());
+  req.method = "GET";
+  req.headers = {
+    host: "localhost:2138",
+    "x-forwarded-for": "203.0.113.9",
+    authorization: `Bearer ${token}`,
+  };
+  Object.defineProperty(req.socket, "remoteAddress", {
+    value: "203.0.113.9",
+    configurable: true,
+  });
+  return req;
+}
+
 const runtimeState = (current: unknown): CompatRuntimeState =>
   ({
     current,
@@ -65,6 +88,13 @@ const call = (
 
 beforeEach(() => {
   verifyEmbedLaunch.mockReset();
+  delete process.env.ELIZA_EMBED_SESSION_SECRET;
+  delete process.env.ELIZA_API_TOKEN;
+});
+
+afterEach(() => {
+  delete process.env.ELIZA_EMBED_SESSION_SECRET;
+  delete process.env.ELIZA_API_TOKEN;
 });
 
 describe("handleEmbedAuthRoutes", () => {
@@ -138,7 +168,7 @@ describe("handleEmbedAuthRoutes", () => {
   it("200 with the verified principal on success", async () => {
     verifyEmbedLaunch.mockResolvedValue({
       ok: true,
-      entityId: "11111111-1111-1111-1111-111111111111",
+      entityId: EMBED_ENTITY_ID,
       role: "OWNER",
       adminMode: true,
     });
@@ -166,14 +196,14 @@ describe("handleEmbedAuthRoutes", () => {
       expiresAt: number;
     };
     expect(body).toMatchObject({
-      entityId: "11111111-1111-1111-1111-111111111111",
+      entityId: EMBED_ENTITY_ID,
       role: "OWNER",
       adminMode: true,
     });
     // The minted scoped token round-trips to the same verified principal.
     expect(typeof body.token).toBe("string");
     const decoded = verifyEmbedSessionToken(body.token, EMBED_SECRET);
-    expect(decoded?.entityId).toBe("11111111-1111-1111-1111-111111111111");
+    expect(decoded?.entityId).toBe(EMBED_ENTITY_ID);
     expect(decoded?.role).toBe("OWNER");
     // The handshake is called with the live runtime + the parsed input.
     expect(verifyEmbedLaunch).toHaveBeenCalledWith(
@@ -204,5 +234,73 @@ describe("handleEmbedAuthRoutes", () => {
     );
     expect(r.status()).toBe(200);
     expect((r.body() as { token: unknown }).token).toBeNull();
+  });
+
+  it("mints an env-only token that the API auth gate accepts", async () => {
+    process.env.ELIZA_EMBED_SESSION_SECRET = EMBED_SECRET;
+    verifyEmbedLaunch.mockResolvedValue({
+      ok: true,
+      entityId: EMBED_ENTITY_ID,
+      role: "OWNER",
+      adminMode: true,
+    });
+    const runtime = {
+      agentId: "agent",
+      getSetting: () => undefined,
+    };
+    const r = fakeRes();
+    await call(
+      fakeReq("POST", "/api/embed/auth", {
+        platform: "telegram",
+        signedLaunchPayload: "valid",
+      }),
+      r.res,
+      runtimeState(runtime),
+    );
+
+    const body = r.body() as { token: string; expiresAt: number };
+    expect(typeof body.token).toBe("string");
+    const ok = await ensureCompatApiAuthorizedAsync(
+      authReq(body.token),
+      fakeRes().res,
+      { store: noSessionStore, now: body.expiresAt - 1 },
+    );
+    expect(ok).toBe(true);
+  });
+
+  it("mints a runtime-only token that the API auth gate accepts through the same reader", async () => {
+    verifyEmbedLaunch.mockResolvedValue({
+      ok: true,
+      entityId: EMBED_ENTITY_ID,
+      role: "OWNER",
+      adminMode: true,
+    });
+    const runtime = {
+      agentId: "agent",
+      getSetting: (key: string) =>
+        key === "ELIZA_EMBED_SESSION_SECRET" ? EMBED_SECRET : undefined,
+    };
+    const r = fakeRes();
+    await call(
+      fakeReq("POST", "/api/embed/auth", {
+        platform: "telegram",
+        signedLaunchPayload: "valid",
+      }),
+      r.res,
+      runtimeState(runtime),
+    );
+
+    const body = r.body() as { token: string; expiresAt: number };
+    expect(typeof body.token).toBe("string");
+    const ok = await ensureCompatApiAuthorizedAsync(
+      authReq(body.token),
+      fakeRes().res,
+      {
+        store: noSessionStore,
+        now: body.expiresAt - 1,
+        readSetting: runtime.getSetting,
+      },
+    );
+    expect(ok).toBe(true);
   });
 });

--- a/packages/app-core/src/api/embed-auth-routes.ts
+++ b/packages/app-core/src/api/embed-auth-routes.ts
@@ -20,6 +20,7 @@ import { type EmbedPlatform, verifyEmbedLaunch } from "./auth/embed-handshake";
 import {
   DEFAULT_EMBED_TOKEN_TTL_MS,
   mintEmbedSessionToken,
+  resolveEmbedSessionSecretForRuntime,
 } from "./auth/embed-session-token";
 import {
   type CompatRuntimeState,
@@ -32,24 +33,6 @@ import {
 
 function isEmbedPlatform(value: unknown): value is EmbedPlatform {
   return value === "telegram" || value === "discord";
-}
-
-/**
- * Resolve the secret used to sign the scoped embed session token. Prefers a
- * dedicated `ELIZA_EMBED_SESSION_SECRET`, falling back to the configured
- * `ELIZA_API_TOKEN`. Returns `null` when neither is set — the route then returns
- * the verified principal without a token rather than minting one with no secret.
- */
-function resolveEmbedTokenSecret(runtime: {
-  getSetting?: (key: string) => unknown;
-}): string | null {
-  for (const key of ["ELIZA_EMBED_SESSION_SECRET", "ELIZA_API_TOKEN"]) {
-    const value = runtime.getSetting?.(key);
-    if (typeof value === "string" && value.trim().length >= 16) {
-      return value.trim();
-    }
-  }
-  return null;
 }
 
 export async function handleEmbedAuthRoutes(
@@ -106,7 +89,7 @@ export async function handleEmbedAuthRoutes(
 
   // Mint the scoped, short-lived embed session token the cross-origin SPA will
   // present back (first-party Steward cookies do not cross into the iframe).
-  const secret = resolveEmbedTokenSecret(runtime);
+  const secret = resolveEmbedSessionSecretForRuntime(runtime);
   const expiresAt = Date.now() + DEFAULT_EMBED_TOKEN_TTL_MS;
   const token = secret
     ? mintEmbedSessionToken(


### PR DESCRIPTION
## Summary

Refs #9947. Closes the keystone gap that made the whole embedded-app launch
surface non-functional: **the minted embed session token was never accepted as
a credential.** `verifyEmbedSessionToken` existed but was only ever called in
tests — so after `/api/embed/auth` handed the cross-origin iframe a token, the
SPA's subsequent `/api` calls had nothing that would honor it. The Telegram
`web_app` button and the Discord exchange (#10638) both dead-ended here.

This wires the token into the auth boundary, **fail-closed**, and non-escalating.

## What changed (`packages/app-core/src/api/`)

- **`auth/embed-session-token.ts`** — `resolveEmbedSessionSecret(read)`: the
  single source of the mint/verify HMAC secret (`ELIZA_EMBED_SESSION_SECRET` →
  `ELIZA_API_TOKEN`, ≥16 chars). Mint and verify now resolve the same secret
  the same way, so they cannot drift.
- **`auth.ts`**
  - `resolveEmbedPrincipal(req, now, read)` — verify the bearer as an embed
    token against the configured secret; `null` on tampered/expired/malformed/
    wrong-secret/no-secret/no-bearer.
  - `ensureCompatApiAuthorizedAsync` (the binary gate behind `ensureRouteAuthorized`,
    used by most routes): a valid embed bearer authenticates the request.
    Bearer-only ⇒ CSRF-exempt, like the sibling session/local-token bearer paths.
  - `resolveAuthorizedRouteRole` (behind `ensureRouteMinRole`, role-gated routes):
    maps the verified embed role to a boundary role — **OWNER→OWNER, ADMIN→USER**
    (non-escalating: the HTTP boundary has no ADMIN tier and ADMIN < OWNER).
  - **Deliberately NOT** wired into `resolveBoundaryRole`, so the sync
    sensitive/secrets/wallet gate stays token-only — exactly as it already is for
    normal sessions. A valid embed token resolves to `NONE` there (pinned by test).

## Safety properties

- **Zero behavior change when unconfigured.** If neither `ELIZA_EMBED_SESSION_SECRET`
  nor `ELIZA_API_TOKEN` is set, `resolveEmbedSessionSecret` returns `null` and the
  embed branch is skipped entirely.
- **Additive & fail-closed.** The embed check only runs after the cookie / session-
  bearer / local-token paths miss, and only for a bearer that HMAC-verifies against
  the configured secret with an unexpired `exp`. A raw API token or random bearer
  does not verify as an embed token.
- **Not an escalation.** The handshake only ever mints OWNER/ADMIN principals it
  already verified via core `hasRoleAccess`; accepting the token is that verified
  user authenticating, mapped down (ADMIN→USER), never up.

## Tests

`bun run --cwd packages/app-core test src/api/auth/embed-session-auth.test.ts src/api/auth/embed-session-token.test.ts` → **25 passed**; `src/api/__tests__/ensure-min-role.test.ts` → **9 passed** (no regression). Typecheck exit 0, biome 2.5.1 clean.

Coverage: secret resolution (preference, fallback, too-short, unset);
`resolveEmbedPrincipal` (valid / tampered / expired / wrong-secret / no-secret /
no-bearer); `embedBoundaryRole` (OWNER→OWNER, ADMIN→USER, null); the binary gate
(authorizes valid, rejects tampered/expired/no-secret/non-embed); and the
`resolveBoundaryRole` exclusion (embed ⇒ `NONE` at the sensitive gate).

## Evidence

- **Live cross-origin iframe walkthrough** — GATED, not attached: requires a real
  Telegram Mini App / Discord Activity + a provisioned `ELIZA_EMBED_SESSION_SECRET`
  + a real OWNER/ADMIN identity, none of which exist in this env. The auth
  behavior is proven by the deterministic fail-closed matrix above.
- **Real-LLM trajectory** — N/A (auth boundary, not an agent/model path).

## Note

`auth.ts` reads the embed secret from `process.env` (the stateless boundary has no
runtime), so the secret must be set as an **env var** for cross-origin embed auth.
The remaining #9947 work (the `/embed` SPA page that reads the launch payload,
POSTs to `/api/embed/auth`, and attaches this token to its `/api` calls; and the
Discord `/app` command) is tracked on the issue. Independent of #10638 (no file overlap).
