### PR TITLE
fix(core): gate secrets info by selected context (#10471)

### DIFF
--- a/.github/issue-evidence/10471-secrets-info-context-gate/README.md
+++ b/.github/issue-evidence/10471-secrets-info-context-gate/README.md
@@ -1,0 +1,35 @@
+# Issue #10471 - SECRETS_INFO context gate
+
+## Change
+
+- Branch: `fix/10471-secrets-info-context-gate`
+- Removed the raw English keyword regex from `SECRETS_INFO`.
+- Provider selection now relies on the existing structured provider metadata:
+  `contexts: ["secrets", "settings"]`, `contextGate`, and `roleGate`.
+- Added a regression test proving selected secrets/settings context returns
+  secrets info for a non-English user message.
+
+## Validation
+
+- `bun test packages/core/src/features/secrets/providers/secrets-status.test.ts`
+  - PASS, see `focused-secrets-provider-test.log`
+- `bun run --cwd packages/core typecheck`
+  - PASS, see `core-typecheck.log`
+- `bun run --cwd packages/core lint:check`
+  - PASS, see `core-lint-check.log`
+- `bun run --cwd packages/core build`
+  - PASS, see `core-build.log`
+- `bun install`
+  - PASS after rebasing on `origin/develop`, see `install-after-rebase.log`
+- `PATH="/Users/shawwalters/.bun/bin:$PATH" bun run verify`
+  - PASS, see `root-verify.log`
+
+## Additional checks
+
+- `bun run --cwd packages/core test`
+  - Attempted; blocked by unrelated existing `src/plugin.test.ts` failure that
+    assigns `globalThis.Bun` where the property is readonly in this runtime.
+    The failure is captured in `full-core-test.log`.
+- Live model trajectory: N/A. This change is a deterministic provider-context
+  gate, not model/action generation.
+- Screenshots/video/audio: N/A. No UI, visual, or audio surface changed.

--- a/.github/issue-evidence/10471-secrets-info-context-gate/core-build.log
+++ b/.github/issue-evidence/10471-secrets-info-context-gate/core-build.log
@@ -1,0 +1,56 @@
+$ bun run --cwd ../logger build && bun run --cwd ../contracts build && ([ -f src/i18n/generated/validation-keyword-data.ts ] || node ../shared/scripts/generate-keywords.mjs --target ts)
+$ bun run build:dist
+$ node ../scripts/rm-path-recursive.mjs dist && tsc --noCheck -p tsconfig.build.json && node ../scripts/prepare-package-dist.mjs packages/logger
+$ tsc --noCheck -p tsconfig.build.json
+$ bun run build.ts
+🚀 Starting dual build process for @elizaos/core
+🔨 Building for Node.js...
+🚀 Building @elizaos/core...
+
+🌐 Building for Browser...
+🚀 Building @elizaos/core...
+
+⚡ Building for Edge...
+🚀 Building @elizaos/core...
+
+🧪 Building testing module...
+🚀 Building @elizaos/core...
+
+✓ Configuration prepared (0.91ms)
+
+Bundling with Bun...
+✓ Configuration prepared (0.65ms)
+
+Bundling with Bun...
+✓ Configuration prepared (0.60ms)
+
+Bundling with Bun...
+✓ Configuration prepared (0.51ms)
+
+Bundling with Bun...
+✓ Built 4 file(s) - 28.77MB (625.10ms)
+
+✅ @elizaos/core build complete!
+⏱️  Total build time: 626.10ms
+✅ Node.js build complete in 0.63s
+✓ Built 4 file(s) - 21.34MB (843.03ms)
+
+✅ @elizaos/core build complete!
+⏱️  Total build time: 843.75ms
+✅ Browser build complete in 0.84s
+✓ Built 2 file(s) - 18.52MB (1203.78ms)
+
+✅ @elizaos/core build complete!
+⏱️  Total build time: 1204.44ms
+✅ Edge build complete in 1.21s
+✓ Built 4 file(s) - 0.02MB (1207.29ms)
+
+✅ @elizaos/core build complete!
+⏱️  Total build time: 1207.86ms
+✅ Testing module build complete in 1.21s
+📝 Generating TypeScript declarations...
+   Compiling TypeScript declarations...
+   Rewrote 1504 relative specifier(s) in 465 .d.ts file(s) for NodeNext ESM
+✅ TypeScript declarations generated in 27.18s
+
+🎉 All builds complete in 28.39s

--- a/.github/issue-evidence/10471-secrets-info-context-gate/core-lint-check.log
+++ b/.github/issue-evidence/10471-secrets-info-context-gate/core-lint-check.log
@@ -1,0 +1,2 @@
+$ bunx @biomejs/biome check ./src
+Checked 913 files in 2s. No fixes applied.

--- a/.github/issue-evidence/10471-secrets-info-context-gate/core-typecheck.log
+++ b/.github/issue-evidence/10471-secrets-info-context-gate/core-typecheck.log
@@ -1,0 +1,1 @@
+$ tsgo --noEmit -p ./tsconfig.json

--- a/.github/issue-evidence/10471-secrets-info-context-gate/focused-secrets-provider-test.log
+++ b/.github/issue-evidence/10471-secrets-info-context-gate/focused-secrets-provider-test.log
@@ -1,0 +1,9 @@
+$ node ../scripts/run-vitest.mjs run src/features/secrets/providers/secrets-status.test.ts
+
+ RUN  v4.1.5 /Users/shawwalters/.codex/worktrees/36cd/eliza/packages/core
+
+
+ Test Files  1 passed (1)
+      Tests  2 passed (2)
+   Start at  22:12:47
+   Duration  725ms (transform 463ms, setup 0ms, import 624ms, tests 5ms, environment 0ms)

--- a/.github/issue-evidence/10471-secrets-info-context-gate/full-core-test.log
+++ b/.github/issue-evidence/10471-secrets-info-context-gate/full-core-test.log
@@ -1,0 +1,7 @@
+$ node ../scripts/run-vitest.mjs run
+
+ RUN  v4.1.5 /Users/shawwalters/.codex/worktrees/36cd/eliza/packages/core
+
+ ❯ src/plugin.test.ts (2 tests | 2 failed) 24ms
+     × honors the legacy plugin auto-install opt-out alias 12ms
+     × reaches Bun when no auto-install opt-out env is set 10ms

--- a/.github/issue-evidence/10471-secrets-info-context-gate/git-diff-check.log
+++ b/.github/issue-evidence/10471-secrets-info-context-gate/git-diff-check.log
@@ -1,0 +1,1 @@
+git diff --cached --check: PASS

--- a/.github/issue-evidence/10471-secrets-info-context-gate/install-after-rebase.log
+++ b/.github/issue-evidence/10471-secrets-info-context-gate/install-after-rebase.log
@@ -1,0 +1,39 @@
+bun install v1.3.14 (0d9b296a)
+Resolving dependencies
+Resolved, downloaded and extracted [432]
+Saved lockfile
+
+$ bun packages/scripts/patch-nested-core-dist.mjs && bun packages/scripts/patch-punycode-deprecation.mjs && bun packages/scripts/patch-llama-cpp-capacitor.mjs && bun packages/scripts/ensure-workspace-symlinks.mjs && bun packages/scripts/build-private-workspace-packages.mjs && bun packages/scripts/sync-artifacts.mjs
+[patch-llama-cpp-capacitor] patched=0 already-applied=1 repaired=0 failed=0
+[ensure-workspace-symlinks] created=0 skipped=436 hoisted=0 missing-roots=0
+[build-private-workspace-packages] skip packages/logger (already built: dist/index.js)
+[build-private-workspace-packages] skip packages/security (already built: dist/index.js)
+[build-private-workspace-packages] skip packages/plugin-remote-manifest (already built: dist/index.js)
+[build-private-workspace-packages] skip packages/plugin-worker-runtime (already built: dist/error.js)
+[sync-artifacts] downloading https://github.com/elizaOS/eliza-archive/releases/download/dev-artifacts/eliza-dev-artifacts.tar.gz (attempt 1/4)
+[sync-artifacts] artifact bundle size: 971 MiB across 638 files
+[sync-artifacts] downloaded 50 MiB of 971 MiB (5.1%) eta 1m 33s at 9.9 MiB/s
+[sync-artifacts] downloaded 95 MiB of 971 MiB (9.8%) eta 1m 33s at 9.5 MiB/s
+[sync-artifacts] downloaded 174 MiB of 971 MiB (17.9%) eta 1m 9s at 12 MiB/s
+[sync-artifacts] downloaded 251 MiB of 971 MiB (25.9%) eta 58s at 13 MiB/s
+[sync-artifacts] downloaded 319 MiB of 971 MiB (32.9%) eta 52s at 13 MiB/s
+[sync-artifacts] downloaded 362 MiB of 971 MiB (37.3%) eta 51s at 12 MiB/s
+[sync-artifacts] downloaded 375 MiB of 971 MiB (38.7%) eta 56s at 11 MiB/s
+[sync-artifacts] downloaded 389 MiB of 971 MiB (40.0%) eta 1m 1s at 9.7 MiB/s
+[sync-artifacts] downloaded 399 MiB of 971 MiB (41.1%) eta 1m 5s at 8.8 MiB/s
+[sync-artifacts] downloaded 411 MiB of 971 MiB (42.3%) eta 1m 9s at 8.2 MiB/s
+[sync-artifacts] downloaded 440 MiB of 971 MiB (45.3%) eta 1m 7s at 8.0 MiB/s
+[sync-artifacts] downloaded 520 MiB of 971 MiB (53.5%) eta 53s at 8.6 MiB/s
+[sync-artifacts] downloaded 582 MiB of 971 MiB (59.9%) eta 44s at 8.9 MiB/s
+[sync-artifacts] downloaded 630 MiB of 971 MiB (64.9%) eta 38s at 9.0 MiB/s
+[sync-artifacts] downloaded 659 MiB of 971 MiB (67.8%) eta 36s at 8.7 MiB/s
+[sync-artifacts] downloaded 718 MiB of 971 MiB (74.0%) eta 29s at 8.9 MiB/s
+[sync-artifacts] downloaded 788 MiB of 971 MiB (81.1%) eta 20s at 9.2 MiB/s
+[sync-artifacts] downloaded 836 MiB of 971 MiB (86.1%) eta 15s at 9.3 MiB/s
+[sync-artifacts] downloaded 904 MiB of 971 MiB (93.1%) eta 8s at 9.5 MiB/s
+[sync-artifacts] download complete: downloaded 971 MiB of 971 MiB (100.0%) eta 0s at 9.7 MiB/s
+[sync-artifacts] verifying sha256 for 971 MiB artifact bundle
+[sync-artifacts] extracting artifact bundle at repo root (638 files)…
+[sync-artifacts] done — artifacts synced to 2026-06-18.1
+
+Checked 4839 installs across 5073 packages (no changes) [127.76s]

--- a/.github/issue-evidence/10471-secrets-info-context-gate/root-verify.log
+++ b/.github/issue-evidence/10471-secrets-info-context-gate/root-verify.log
@@ -1,0 +1,3647 @@
+$ bun run audit:type-safety-ratchet && NODE_OPTIONS='--max-old-space-size=8192' node packages/scripts/run-turbo.mjs run typecheck lint --concurrency=8 --filter='!@elizaos/example-code' && bun run audit:build-model && bun run audit:turbo-build-deps && bun run audit:tee-secret-leak && bun run audit:scripts && bun run typecheck:dist
+$ node packages/scripts/type-safety-ratchet.mjs
+[type-safety-ratchet] scanned 9894 tracked production source files
+[type-safety-ratchet] as unknown as: 75 / 77
+[type-safety-ratchet] as any: 0 / 0
+[type-safety-ratchet] explicit `: any` annotation: 124 / 124
+[type-safety-ratchet] @ts-expect-error / @ts-ignore: 0 / 0
+[type-safety-ratchet] non-null assertion (!): 544 / 547
+[type-safety-ratchet] `?? ""` (core/agent/app-core): 611 / 620
+[type-safety-ratchet] `?? []` (core/agent/app-core): 573 / 588
+[type-safety-ratchet] `?? {}` (core/agent/app-core): 376 / 377
+[type-safety-ratchet] `?? 0` (core/agent/app-core): 376 / 380
+[type-safety-ratchet] baseline can shrink: as unknown as 77 -> 75, non-null assertion (!) 547 -> 544, `?? ""` (core/agent/app-core) 620 -> 611, `?? []` (core/agent/app-core) 588 -> 573, `?? {}` (core/agent/app-core) 377 -> 376, `?? 0` (core/agent/app-core) 380 -> 376
+• turbo 2.10.0
+
+   • Packages in scope: @elizaos-benchmarks/lib, @elizaos-examples/html-eliza, @elizaos/agent, @elizaos/agent-server, @elizaos/app, @elizaos/app-core, @elizaos/app-model-tester, @elizaos/aws-examples, @elizaos/bench-eliza-1, @elizaos/bench-eliza-1-vision-cua-e2e, @elizaos/browser-extension, @elizaos/bun-ios-runtime, @elizaos/capacitor-agent, @elizaos/capacitor-appblocker, @elizaos/capacitor-bun-runtime, @elizaos/capacitor-calendar, @elizaos/capacitor-camera, @elizaos/capacitor-canvas, @elizaos/capacitor-contacts, @elizaos/capacitor-desktop, @elizaos/capacitor-eliza-tasks, @elizaos/capacitor-gateway, @elizaos/capacitor-llama, @elizaos/capacitor-location, @elizaos/capacitor-messages, @elizaos/capacitor-mobile-agent-bridge, @elizaos/capacitor-mobile-signals, @elizaos/capacitor-network-policy, @elizaos/capacitor-phone, @elizaos/capacitor-screencapture, @elizaos/capacitor-swabble, @elizaos/capacitor-system, @elizaos/capacitor-talkmode, @elizaos/capacitor-websiteblocker, @elizaos/capacitor-wifi, @elizaos/cloud-api, @elizaos/cloud-e2e, @elizaos/cloud-infra, @elizaos/cloud-routing, @elizaos/cloud-sdk, @elizaos/cloud-services-common, @elizaos/cloud-shared, @elizaos/cloud-test-mocks, @elizaos/coding-remote-runner, @elizaos/container-control-plane, @elizaos/contracts, @elizaos/core, @elizaos/distro-os, @elizaos/docs, @elizaos/docs-elizacloud-redirect, @elizaos/electrobun, @elizaos/example-a2a-server, @elizaos/example-agent-console, @elizaos/example-app-capacitor, @elizaos/example-app-capacitor-backend, @elizaos/example-app-capacitor-frontend, @elizaos/example-app-electron, @elizaos/example-app-electron-renderer, @elizaos/example-app-electron-workspace, @elizaos/example-autonomous, @elizaos/example-bluesky, @elizaos/example-browser-extension, @elizaos/example-browser-extension-chrome, @elizaos/example-browser-extension-safari, @elizaos/example-chat, @elizaos/example-clone-ur-crush, @elizaos/example-convex, @elizaos/example-discord, @elizaos/example-edad, @elizaos/example-farcaster, @elizaos/example-form, @elizaos/example-game-of-life, @elizaos/example-lp-manager, @elizaos/example-mcp-server, @elizaos/example-rest-api-elysia, @elizaos/example-rest-api-express, @elizaos/example-rest-api-hono, @elizaos/example-smartglasses, @elizaos/example-telegram, @elizaos/example-text-adventure, @elizaos/example-tic-tac-toe, @elizaos/example-trader-ts, @elizaos/example-x402-image-gen, @elizaos/example-xai-x, @elizaos/gateway-discord, @elizaos/gateway-webhook, @elizaos/gcp-examples, @elizaos/interrupt-bench, @elizaos/ios-native-deps, @elizaos/logger, @elizaos/macosalarm, @elizaos/macosreminders, @elizaos/native-activity-tracker, @elizaos/native-plugin-shared-types, @elizaos/operator, @elizaos/os-android-system-ui, @elizaos/os-homepage, @elizaos/os-shared-system, @elizaos/os-usb-installer, @elizaos/plugin-agent-orchestrator, @elizaos/plugin-agent-skills, @elizaos/plugin-ainex, @elizaos/plugin-anthropic, @elizaos/plugin-anthropic-proxy, @elizaos/plugin-aosp-local-inference, @elizaos/plugin-app-control, @elizaos/plugin-app-manager, @elizaos/plugin-background-runner, @elizaos/plugin-benchmarks, @elizaos/plugin-blocker, @elizaos/plugin-bluebubbles, @elizaos/plugin-bluesky, @elizaos/plugin-browser, @elizaos/plugin-calendar, @elizaos/plugin-calendly, @elizaos/plugin-capacitor-bridge, @elizaos/plugin-cli, @elizaos/plugin-cli-inference, @elizaos/plugin-cloud-apps, @elizaos/plugin-codex-cli, @elizaos/plugin-coding-tools, @elizaos/plugin-commands, @elizaos/plugin-computeruse, @elizaos/plugin-contacts, @elizaos/plugin-discord, @elizaos/plugin-discord-local, @elizaos/plugin-documents, @elizaos/plugin-edge-tts, @elizaos/plugin-elevenlabs, @elizaos/plugin-elizacloud, @elizaos/plugin-embeddings, @elizaos/plugin-facewear, @elizaos/plugin-farcaster, @elizaos/plugin-feed, @elizaos/plugin-feishu, @elizaos/plugin-finances, @elizaos/plugin-form, @elizaos/plugin-github, @elizaos/plugin-gitpathologist, @elizaos/plugin-goals, @elizaos/plugin-google, @elizaos/plugin-google-chat, @elizaos/plugin-google-genai, @elizaos/plugin-groq, @elizaos/plugin-health, @elizaos/plugin-hyperliquid, @elizaos/plugin-imessage, @elizaos/plugin-inbox, @elizaos/plugin-inmemorydb, @elizaos/plugin-instagram, @elizaos/plugin-line, @elizaos/plugin-linear, @elizaos/plugin-lmstudio, @elizaos/plugin-local-inference, @elizaos/plugin-local-storage, @elizaos/plugin-localdb, @elizaos/plugin-matrix, @elizaos/plugin-mcp, @elizaos/plugin-messages, @elizaos/plugin-music, @elizaos/plugin-native-filesystem, @elizaos/plugin-native-settings, @elizaos/plugin-nearai, @elizaos/plugin-ngrok, @elizaos/plugin-nostr, @elizaos/plugin-ollama, @elizaos/plugin-openai, @elizaos/plugin-openrouter, @elizaos/plugin-pdf, @elizaos/plugin-personal-assistant, @elizaos/plugin-phone, @elizaos/plugin-polymarket, @elizaos/plugin-registry, @elizaos/plugin-relationships, @elizaos/plugin-reminders, @elizaos/plugin-remote-desktop, @elizaos/plugin-remote-manifest, @elizaos/plugin-scheduling, @elizaos/plugin-screenshare, @elizaos/plugin-shell, @elizaos/plugin-shopify, @elizaos/plugin-signal, @elizaos/plugin-slack, @elizaos/plugin-social-alpha, @elizaos/plugin-sql, @elizaos/plugin-starter, @elizaos/plugin-streaming, @elizaos/plugin-sub-agent-claude-code, @elizaos/plugin-suno, @elizaos/plugin-tailscale, @elizaos/plugin-task-coordinator, @elizaos/plugin-tee, @elizaos/plugin-telegram, @elizaos/plugin-todos, @elizaos/plugin-training, @elizaos/plugin-trajectory-logger, @elizaos/plugin-tunnel, @elizaos/plugin-twitch, @elizaos/plugin-vector-browser, @elizaos/plugin-video, @elizaos/plugin-vision, @elizaos/plugin-wallet, @elizaos/plugin-wallet-ui, @elizaos/plugin-web-search, @elizaos/plugin-wechat, @elizaos/plugin-whatsapp, @elizaos/plugin-wifi, @elizaos/plugin-worker-runtime, @elizaos/plugin-workflow, @elizaos/plugin-x, @elizaos/plugin-x402, @elizaos/plugin-xai, @elizaos/plugin-xr, @elizaos/plugin-zai, @elizaos/prompts, @elizaos/registry, @elizaos/robot, @elizaos/scenario-runner, @elizaos/security, @elizaos/setup, @elizaos/shared, @elizaos/skills, @elizaos/soc2-verify, @elizaos/test-harness, @elizaos/three-agent-dialogue, @elizaos/tui, @elizaos/ui, @elizaos/vault, @elizaos/vercel-edge-examples, @moltbook/eliza-agent, bags-claimer, cloud-mcp-smoke, eliza-app, eliza-cloud-agent, eliza-multichain-miniapp, eliza-next-example, eliza-react-example, elizagotchi, elizaos, elizaos-cloudflare-worker, elizaos-plugin-echo, trajectory-viewer
+   • Running typecheck, lint in 242 packages
+   • Remote caching disabled, using shared worktree cache
+
+@elizaos/logger:build: cache hit, replaying logs 0e948b0cc5911425
+@elizaos/logger:build: $ bun run build:dist
+@elizaos/logger:build: $ node ../scripts/rm-path-recursive.mjs dist && tsc --noCheck -p tsconfig.build.json && node ../scripts/prepare-package-dist.mjs packages/logger
+@elizaos/contracts:build: cache hit, replaying logs 3b9021bdf5886898
+@elizaos/contracts:build: $ tsc --noCheck -p tsconfig.build.json
+@elizaos/core:build: cache hit, replaying logs b195ab779458799f
+@elizaos/core:build: $ bun run --cwd ../logger build && bun run --cwd ../contracts build && ([ -f src/i18n/generated/validation-keyword-data.ts ] || node ../shared/scripts/generate-keywords.mjs --target ts)
+@elizaos/core:build: $ bun run build:dist
+@elizaos/core:build: $ node ../scripts/rm-path-recursive.mjs dist && tsc --noCheck -p tsconfig.build.json && node ../scripts/prepare-package-dist.mjs packages/logger
+@elizaos/core:build: $ tsc --noCheck -p tsconfig.build.json
+@elizaos/core:build: $ bun run build.ts
+@elizaos/core:build: 🚀 Starting dual build process for @elizaos/core
+@elizaos/core:build: 🔨 Building for Node.js...
+@elizaos/core:build: 🚀 Building @elizaos/core...
+@elizaos/core:build:
+@elizaos/core:build: 🌐 Building for Browser...
+@elizaos/core:build: 🚀 Building @elizaos/core...
+@elizaos/core:build:
+@elizaos/core:build: ⚡ Building for Edge...
+@elizaos/core:build: 🚀 Building @elizaos/core...
+@elizaos/core:build:
+@elizaos/core:build: 🧪 Building testing module...
+@elizaos/core:build: 🚀 Building @elizaos/core...
+@elizaos/core:build:
+@elizaos/core:build: ✓ Configuration prepared (1.33ms)
+@elizaos/core:build:
+@elizaos/core:build: Bundling with Bun...
+@elizaos/core:build: ✓ Configuration prepared (0.93ms)
+@elizaos/core:build:
+@elizaos/core:build: Bundling with Bun...
+@elizaos/core:build: ✓ Configuration prepared (0.77ms)
+@elizaos/core:build:
+@elizaos/core:build: Bundling with Bun...
+@elizaos/core:build: ✓ Configuration prepared (0.53ms)
+@elizaos/core:build:
+@elizaos/core:build: Bundling with Bun...
+@elizaos/core:build: ✓ Built 4 file(s) - 28.78MB (358.62ms)
+@elizaos/core:build:
+@elizaos/core:build: ✅ @elizaos/core build complete!
+@elizaos/core:build: ⏱️  Total build time: 360.05ms
+@elizaos/core:build: ✅ Node.js build complete in 0.36s
+@elizaos/core:build: ✓ Built 4 file(s) - 21.35MB (606.84ms)
+@elizaos/core:build:
+@elizaos/core:build: ✅ @elizaos/core build complete!
+@elizaos/core:build: ⏱️  Total build time: 607.84ms
+@elizaos/core:build: ✅ Browser build complete in 0.61s
+@elizaos/core:build: ✓ Built 2 file(s) - 18.52MB (835.35ms)
+@elizaos/core:build:
+@elizaos/core:build: ✅ @elizaos/core build complete!
+@elizaos/core:build: ⏱️  Total build time: 836.17ms
+@elizaos/core:build: ✅ Edge build complete in 0.84s
+@elizaos/core:build: ✓ Built 4 file(s) - 0.02MB (880.20ms)
+@elizaos/core:build:
+@elizaos/core:build: ✅ @elizaos/core build complete!
+@elizaos/core:build: ⏱️  Total build time: 880.81ms
+@elizaos/core:build: ✅ Testing module build complete in 0.88s
+@elizaos/core:build: 📝 Generating TypeScript declarations...
+@elizaos/core:build:    Compiling TypeScript declarations...
+@elizaos/core:build:    Rewrote 1504 relative specifier(s) in 465 .d.ts file(s) for NodeNext ESM
+@elizaos/core:build: ✅ TypeScript declarations generated in 49.63s
+@elizaos/core:build:
+@elizaos/core:build: 🎉 All builds complete in 50.51s
+@elizaos/capacitor-wifi:build: cache miss, executing 5704ae787fe499eb
+@elizaos/plugin-bluesky:build: cache miss, executing 7a1c3b214e0df0ff
+@elizaos/plugin-native-filesystem:build: cache miss, executing b9e7cc67c4f86c3c
+@elizaos/plugin-sql:build: cache miss, executing 1a5528a09d6da2c5
+@elizaos/plugin-capacitor-bridge:build: cache miss, executing bd0e21ed8383750e
+@elizaos/plugin-video:build: cache miss, executing 01dbf548f90458e8
+@elizaos/plugin-gitpathologist:build: cache miss, executing d238202402ab5ebc
+@elizaos/plugin-github:build: cache miss, executing f0f16109eee5f616
+@elizaos/plugin-capacitor-bridge:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist && bun run check:android-manifest && NODE_OPTIONS='--max-old-space-size=8192' tsup && tsc --declaration --emitDeclarationOnly --noEmit false --noCheck -p tsconfig.build.json && node ../../packages/scripts/rewrite-dist-relative-imports-node-esm.mjs plugins/plugin-capacitor-bridge
+@elizaos/plugin-sql:build: $ cd src && bun run build.ts
+@elizaos/capacitor-wifi:build: $ node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-wifi -- bun run build:unlocked
+@elizaos/plugin-github:build: $ tsup src/index.ts src/register-routes.ts --format esm --dts --clean
+@elizaos/plugin-gitpathologist:build: $ bun run build.ts
+@elizaos/plugin-video:build: $ bun run build.ts
+@elizaos/plugin-bluesky:build: $ bun run build.ts
+@elizaos/plugin-native-filesystem:build: $ bun run build.ts
+@elizaos/plugin-video:build: 🔨 Building @elizaos/plugin-video (Node)…
+@elizaos/plugin-video:build: ✅ Node complete in 0.01s
+@elizaos/plugin-video:build: 📝 Generating TypeScript declarations…
+@elizaos/capacitor-wifi:build: $ bun run clean && tsc && bunx rollup -c rollup.config.mjs
+@elizaos/plugin-capacitor-bridge:build: $ node scripts/check-android-manifest.mjs
+@elizaos/plugin-native-filesystem:build: 🔨 Building @elizaos/plugin-native-filesystem (Node)…
+@elizaos/capacitor-wifi:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/plugin-native-filesystem:build: ✅ Node complete in 0.05s
+@elizaos/plugin-native-filesystem:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-bluesky:build: 🔨 Building @elizaos/plugin-bluesky (Node)…
+@elizaos/plugin-gitpathologist:build: 🔨 Building @elizaos/plugin-gitpathologist (Node (ESM))…
+@elizaos/plugin-gitpathologist:build: ✅ Node (ESM) complete in 0.06s
+@elizaos/plugin-gitpathologist:build: 🔨 Building @elizaos/plugin-gitpathologist (Node (CJS))…
+@elizaos/plugin-bluesky:build: ✅ Node complete in 0.06s
+@elizaos/plugin-bluesky:build: 🔨 Building @elizaos/plugin-bluesky (Browser)…
+@elizaos/plugin-bluesky:build: ✅ Browser complete in 0.04s
+@elizaos/plugin-bluesky:build: 🔨 Building @elizaos/plugin-bluesky (Node (CJS))…
+@elizaos/plugin-gitpathologist:build: ✅ Node (CJS) complete in 0.05s
+@elizaos/plugin-gitpathologist:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-sql:build: Building Node.js ESM bundle...
+@elizaos/plugin-bluesky:build: ✅ Node (CJS) complete in 0.06s
+@elizaos/plugin-bluesky:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-sql:build: Building Browser ESM bundle...
+@elizaos/plugin-sql:build: Building CJS bundle...
+@elizaos/plugin-sql:build: Generating TypeScript declarations...
+@elizaos/plugin-github:build: CLI Building entry: src/register-routes.ts, src/index.ts
+@elizaos/plugin-github:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-github:build: CLI tsup v8.5.1
+@elizaos/plugin-github:build: CLI Target: es2022
+@elizaos/plugin-github:build: CLI Cleaning output folder
+@elizaos/plugin-github:build: ESM Build start
+@elizaos/plugin-github:build: ESM dist/register-routes.js 239.00 B
+@elizaos/plugin-github:build: ESM dist/index.js           73.49 KB
+@elizaos/plugin-github:build: ESM ⚡️ Build success in 657ms
+@elizaos/plugin-capacitor-bridge:build: CLI Building entry: {"index":"src/index.ts","android/bridge":"src/android/bridge.ts","ios/bridge":"src/ios/bridge.ts","mobile-device-bridge-bootstrap":"src/mobile-device-bridge-bootstrap.ts","shared/fs-shim":"src/shared/fs-shim.ts"}
+@elizaos/plugin-capacitor-bridge:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-capacitor-bridge:build: CLI tsup v8.5.1
+@elizaos/plugin-capacitor-bridge:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/plugin-capacitor-bridge/tsup.config.ts
+@elizaos/plugin-capacitor-bridge:build: CLI Target: es2022
+@elizaos/plugin-capacitor-bridge:build: CLI Cleaning output folder
+@elizaos/plugin-capacitor-bridge:build: ESM Build start
+@elizaos/plugin-capacitor-bridge:build: ESM dist/index.js                          1.05 KB
+@elizaos/plugin-capacitor-bridge:build: ESM dist/mobile-device-bridge-bootstrap.js 595.00 B
+@elizaos/plugin-capacitor-bridge:build: ESM dist/chunk-E7Y447TQ.js                 19.47 KB
+@elizaos/plugin-capacitor-bridge:build: ESM dist/android/bridge.js                 5.14 KB
+@elizaos/plugin-capacitor-bridge:build: ESM dist/chunk-MLKGABMK.js                 191.00 B
+@elizaos/plugin-capacitor-bridge:build: ESM dist/ios/bridge.js                     101.17 KB
+@elizaos/plugin-capacitor-bridge:build: ESM dist/shared/fs-shim.js                 267.00 B
+@elizaos/plugin-capacitor-bridge:build: ESM dist/chunk-2L4MX4DP.js                 42.48 KB
+@elizaos/plugin-capacitor-bridge:build: ESM ⚡️ Build success in 271ms
+@elizaos/plugin-github:build: DTS Build start
+@elizaos/capacitor-wifi:build:
+@elizaos/capacitor-wifi:build: dist/esm/index.js → dist/plugin.js, dist/plugin.cjs.js...
+@elizaos/plugin-video:build: 🎉 @elizaos/plugin-video build finished in 14.97s
+@elizaos/plugin-workflow:build: cache miss, executing 78ab0ce7f984640d
+@elizaos/plugin-workflow:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist && tsc --noCheck -p tsconfig.json
+@elizaos/capacitor-wifi:build: created dist/plugin.js, dist/plugin.cjs.js in 1.9s
+@elizaos/plugin-commands:build: cache miss, executing 72e97a2c3bb50764
+@elizaos/plugin-commands:build: $ bun run build.ts
+@elizaos/plugin-commands:build: 🔨 Building @elizaos/plugin-commands (Node (ESM))…
+@elizaos/plugin-commands:build: ✅ Node (ESM) complete in 0.02s
+@elizaos/plugin-commands:build: 🔨 Building @elizaos/plugin-commands (Node (CJS))…
+@elizaos/plugin-commands:build: ✅ Node (CJS) complete in 0.01s
+@elizaos/plugin-commands:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-native-filesystem:build: 🎉 @elizaos/plugin-native-filesystem build finished in 18.84s
+@elizaos/vault:build: cache miss, executing 157290fe4141d50a
+@elizaos/vault:build: $ node ../scripts/rm-path-recursive.mjs dist && tsc --noCheck -p tsconfig.build.json && node ../scripts/prepare-package-dist.mjs packages/vault
+@elizaos/plugin-gitpathologist:build: 🎉 @elizaos/plugin-gitpathologist build finished in 19.00s
+@elizaos/capacitor-mobile-agent-bridge:build: cache miss, executing 5990bc72a32f6edf
+@elizaos/capacitor-mobile-agent-bridge:build: $ node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-mobile-agent-bridge -- bun run build:unlocked
+@elizaos/capacitor-mobile-agent-bridge:build: $ bun run clean && tsc && bunx rollup -c rollup.config.mjs
+@elizaos/capacitor-mobile-agent-bridge:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/plugin-bluesky:build: 🎉 @elizaos/plugin-bluesky build finished in 26.55s
+@elizaos/capacitor-location:build: cache miss, executing 59f71f5e140a8c45
+@elizaos/capacitor-location:build: $ node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-location -- bun run build:unlocked
+@elizaos/capacitor-location:build: $ bun run clean && tsc && bunx rollup -c rollup.config.mjs
+@elizaos/capacitor-location:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/plugin-capacitor-bridge:build: [rewrite-dist-relative-imports] rewrote 2 file(s)
+@elizaos/capacitor-camera:build: cache miss, executing e5e02d983222b186
+@elizaos/capacitor-camera:build: $ node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-camera -- bun run build:unlocked
+@elizaos/capacitor-camera:build: $ bun run clean && tsc && bunx rollup -c rollup.config.mjs
+@elizaos/capacitor-camera:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/capacitor-mobile-agent-bridge:build:
+@elizaos/capacitor-mobile-agent-bridge:build: dist/esm/index.js → dist/plugin.js, dist/plugin.cjs.js...
+@elizaos/capacitor-mobile-agent-bridge:build: created dist/plugin.js, dist/plugin.cjs.js in 1.4s
+@elizaos/capacitor-phone:build: cache miss, executing c836f2e1a4c946b8
+@elizaos/capacitor-phone:build: $ node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-phone -- bun run build:unlocked
+@elizaos/capacitor-phone:build: $ bun run clean && tsc && bunx rollup -c rollup.config.mjs
+@elizaos/capacitor-phone:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/plugin-commands:build: 🎉 @elizaos/plugin-commands build finished in 20.37s
+@elizaos/capacitor-gateway:build: cache miss, executing 78aec37b14646b87
+@elizaos/capacitor-gateway:build: $ node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-gateway -- bun run build:unlocked
+@elizaos/capacitor-gateway:build: $ bun run clean && tsc && bunx rollup -c rollup.config.mjs
+@elizaos/capacitor-gateway:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/capacitor-location:build:
+@elizaos/capacitor-location:build: dist/esm/index.js → dist/plugin.js, dist/plugin.cjs.js...
+@elizaos/plugin-wechat:build: cache miss, executing 31f4a2ed374a280a
+@elizaos/plugin-wechat:build: $ tsup --config tsup.config.ts && tsc --declaration --emitDeclarationOnly --noEmit false --noCheck --outDir dist --rootDir src
+@elizaos/capacitor-location:build: created dist/plugin.js, dist/plugin.cjs.js in 2.2s
+@elizaos/capacitor-appblocker:build: cache miss, executing 86eb9c83552c23d9
+@elizaos/capacitor-appblocker:build: $ node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-appblocker -- bun run build:unlocked
+@elizaos/capacitor-appblocker:build: $ bun run clean && tsc && bunx rollup -c rollup.config.mjs
+@elizaos/capacitor-appblocker:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/capacitor-camera:build:
+@elizaos/capacitor-camera:build: dist/esm/index.js → dist/plugin.js, dist/plugin.cjs.js...
+@elizaos/plugin-wechat:build: CLI Building entry: src/index.ts
+@elizaos/plugin-wechat:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-wechat:build: CLI tsup v8.5.1
+@elizaos/plugin-wechat:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/plugin-wechat/tsup.config.ts
+@elizaos/plugin-wechat:build: CLI Target: es2022
+@elizaos/plugin-wechat:build: CLI Cleaning output folder
+@elizaos/plugin-wechat:build: ESM Build start
+@elizaos/plugin-wechat:build: ESM dist/index.js     39.54 KB
+@elizaos/plugin-wechat:build: ESM dist/index.js.map 80.60 KB
+@elizaos/plugin-wechat:build: ESM ⚡️ Build success in 521ms
+@elizaos/capacitor-camera:build: created dist/plugin.js, dist/plugin.cjs.js in 2.3s
+@elizaos/plugin-edge-tts:build: cache miss, executing 9104dd46c18a7026
+@elizaos/plugin-edge-tts:build: $ bun run build.ts
+@elizaos/capacitor-phone:build:
+@elizaos/capacitor-phone:build: dist/esm/index.js → dist/plugin.js, dist/plugin.cjs.js...
+@elizaos/plugin-edge-tts:build: 🔨 Building @elizaos/plugin-edge-tts (Node)…
+@elizaos/plugin-edge-tts:build: ✅ Node complete in 0.05s
+@elizaos/plugin-edge-tts:build: 🔨 Building @elizaos/plugin-edge-tts (Browser)…
+@elizaos/plugin-edge-tts:build: ✅ Browser complete in 0.03s
+@elizaos/plugin-edge-tts:build: 🔨 Building @elizaos/plugin-edge-tts (Node (CJS))…
+@elizaos/plugin-edge-tts:build: ✅ Node (CJS) complete in 0.03s
+@elizaos/plugin-edge-tts:build: 📝 Generating TypeScript declarations…
+@elizaos/capacitor-phone:build: created dist/plugin.js, dist/plugin.cjs.js in 968ms
+@elizaos/registry:build: cache miss, executing 3bd7914eb3c8b0d4
+@elizaos/registry:build: $ bun run src/generate.ts && bun run src/first-party/generate.ts
+@elizaos/registry:build: Generated /Users/shawwalters/.codex/worktrees/36cd/eliza/packages/registry/generated-registry.json (20 third-party entries)
+@elizaos/capacitor-gateway:build:
+@elizaos/capacitor-gateway:build: dist/esm/index.js → dist/plugin.js, dist/plugin.cjs.js...
+@elizaos/plugin-sql:build: Build complete!
+@elizaos/capacitor-mobile-signals:build: cache miss, executing 82cc147b196974e2
+@elizaos/capacitor-mobile-signals:build: $ node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-mobile-signals -- bun run build:unlocked
+@elizaos/capacitor-mobile-signals:build: $ bun run clean && bunx tsc -p tsconfig.json && bunx rollup -c rollup.config.mjs
+@elizaos/capacitor-gateway:build: created dist/plugin.js, dist/plugin.cjs.js in 2.6s
+@elizaos/capacitor-mobile-signals:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/registry:build: [registry/generate] wrote 115 entries + 9 curated-app definitions
+@elizaos/capacitor-messages:build: cache miss, executing 30e3c47053ea34b3
+@elizaos/capacitor-messages:build: $ node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-messages -- bun run build:unlocked
+@elizaos/capacitor-websiteblocker:build: cache miss, executing 81e824d7d97fbadd
+@elizaos/capacitor-websiteblocker:build: $ node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-websiteblocker -- bun run build:unlocked
+@elizaos/capacitor-messages:build: $ bun run clean && tsc && bunx rollup -c rollup.config.mjs
+@elizaos/capacitor-messages:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/capacitor-websiteblocker:build: $ bun run clean && tsc && bunx rollup -c rollup.config.mjs
+@elizaos/capacitor-websiteblocker:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/plugin-github:build: DTS ⚡️ Build success in 49871ms
+@elizaos/plugin-github:build: DTS dist/register-routes.d.ts 13.00 B
+@elizaos/plugin-github:build: DTS dist/index.d.ts           10.45 KB
+@elizaos/capacitor-appblocker:build:
+@elizaos/capacitor-appblocker:build: dist/esm/index.js → dist/plugin.js, dist/plugin.cjs.js...
+@elizaos/capacitor-appblocker:build: created dist/plugin.js, dist/plugin.cjs.js in 797ms
+@elizaos/capacitor-screencapture:build: cache miss, executing b9e9c12813f1d69a
+@elizaos/capacitor-screencapture:build: $ node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-screencapture -- bun run build:unlocked
+@elizaos/capacitor-screencapture:build: $ bun run clean && tsc && bunx rollup -c rollup.config.mjs
+@elizaos/capacitor-screencapture:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/capacitor-system:build: cache miss, executing 880df340f3aaf86e
+@elizaos/capacitor-system:build: $ node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-system -- bun run build:unlocked
+@elizaos/capacitor-system:build: $ bun run clean && tsc && bunx rollup -c rollup.config.mjs
+@elizaos/capacitor-system:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/skills:build: cache miss, executing f2e4cfb36a9a3c2a
+@elizaos/skills:build: $ tsc --noCheck -p tsconfig.build.json
+@elizaos/capacitor-canvas:build: cache miss, executing 6e2dbd9210e879ce
+@elizaos/capacitor-canvas:build: $ node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-canvas -- bun run build:unlocked
+@elizaos/capacitor-canvas:build: $ bun run clean && tsc && bunx rollup -c rollup.config.mjs
+@elizaos/capacitor-canvas:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/plugin-edge-tts:build: 🎉 @elizaos/plugin-edge-tts build finished in 19.91s
+@elizaos/plugin-inmemorydb:build: cache miss, executing df50131092710621
+@elizaos/plugin-inmemorydb:build: $ bun run build.ts
+@elizaos/plugin-inmemorydb:build: 🔨 Building @elizaos/plugin-inmemorydb (Node)…
+@elizaos/plugin-inmemorydb:build: ✅ Node complete in 0.09s
+@elizaos/plugin-inmemorydb:build: 🔨 Building @elizaos/plugin-inmemorydb (Browser)…
+@elizaos/plugin-inmemorydb:build: ✅ Browser complete in 0.33s
+@elizaos/plugin-inmemorydb:build: 📝 Generating TypeScript declarations…
+@elizaos/capacitor-messages:build:
+@elizaos/capacitor-messages:build: dist/esm/index.js → dist/plugin.js, dist/plugin.cjs.js...
+@elizaos/capacitor-messages:build: created dist/plugin.js, dist/plugin.cjs.js in 980ms
+@elizaos/plugin-calendly:build: cache miss, executing fac7ede394cdb0ee
+@elizaos/plugin-calendly:build: $ tsup src/index.ts --format esm --clean && tsc --declaration --emitDeclarationOnly --noEmit false --noCheck
+@elizaos/capacitor-mobile-signals:build:
+@elizaos/capacitor-mobile-signals:build: dist/esm/index.js → dist/plugin.js, dist/plugin.cjs.js...
+@elizaos/capacitor-websiteblocker:build:
+@elizaos/capacitor-websiteblocker:build: dist/esm/index.js → dist/plugin.js, dist/plugin.cjs.js...
+@elizaos/capacitor-mobile-signals:build: created dist/plugin.js, dist/plugin.cjs.js in 2.2s
+@elizaos/plugin-remote-desktop:build: cache miss, executing 64437159b6995771
+@elizaos/plugin-remote-desktop:build: $ bun run build.ts
+@elizaos/capacitor-websiteblocker:build: created dist/plugin.js, dist/plugin.cjs.js in 1.5s
+@elizaos/capacitor-system:build:
+@elizaos/capacitor-system:build: dist/esm/index.js → dist/plugin.js, dist/plugin.cjs.js...
+@elizaos/plugin-remote-desktop:build: 🔨 Building @elizaos/plugin-remote-desktop (Node)…
+@elizaos/plugin-google:build: cache miss, executing 23a9c23b3a44bd08
+@elizaos/plugin-google:build: $ bun run build.ts
+@elizaos/plugin-remote-desktop:build: ✅ Node complete in 0.08s
+@elizaos/plugin-remote-desktop:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-google:build: 📝 Generating TypeScript declarations…
+@elizaos/capacitor-system:build: created dist/plugin.js, dist/plugin.cjs.js in 1.3s
+@elizaos/plugin-whatsapp:build: cache miss, executing 73fd0d2cb69602cb
+@elizaos/plugin-whatsapp:build: $ bun run build.ts
+@elizaos/plugin-calendly:build: CLI Building entry: src/index.ts
+@elizaos/plugin-calendly:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-calendly:build: CLI tsup v8.5.1
+@elizaos/plugin-calendly:build: CLI Target: es2022
+@elizaos/plugin-calendly:build: CLI Cleaning output folder
+@elizaos/plugin-calendly:build: ESM Build start
+@elizaos/plugin-whatsapp:build: 🔨 Building @elizaos/plugin-whatsapp (Node)…
+@elizaos/plugin-whatsapp:build: ✅ Node complete in 0.11s
+@elizaos/plugin-whatsapp:build: 📝 Generating TypeScript declarations…
+@elizaos/capacitor-screencapture:build:
+@elizaos/capacitor-screencapture:build: dist/esm/index.js → dist/plugin.js, dist/plugin.cjs.js...
+@elizaos/plugin-calendly:build: ESM dist/index.js 50.60 KB
+@elizaos/plugin-calendly:build: ESM ⚡️ Build success in 613ms
+@elizaos/capacitor-screencapture:build: created dist/plugin.js, dist/plugin.cjs.js in 2.3s
+@elizaos/capacitor-calendar:build: cache miss, executing 13effe303adad85c
+@elizaos/capacitor-calendar:build: $ node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-calendar -- bun run build:unlocked
+@elizaos/capacitor-calendar:build: $ bun run clean && tsc && bunx rollup -c rollup.config.mjs
+@elizaos/capacitor-calendar:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/macosreminders:build: cache miss, executing 6bf18e97cdcdc9e7
+@elizaos/macosreminders:build: $ tsc --noCheck -p tsconfig.json
+@elizaos/capacitor-canvas:build:
+@elizaos/capacitor-canvas:build: dist/esm/index.js → dist/plugin.js, dist/plugin.cjs.js...
+@elizaos/tui:build: cache miss, executing dd257bb0533784bd
+@elizaos/tui:build: $ tsc -p tsconfig.build.json --noCheck
+@elizaos/capacitor-canvas:build: created dist/plugin.js, dist/plugin.cjs.js in 2.4s
+@elizaos/native-activity-tracker:build: cache miss, executing 851fe87e4a2929a8
+@elizaos/native-activity-tracker:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist && tsc -p tsconfig.json --noCheck
+@elizaos/capacitor-calendar:build:
+@elizaos/capacitor-calendar:build: dist/esm/index.js → dist/plugin.js, dist/plugin.cjs.js...
+@elizaos/plugin-inmemorydb:build: 🎉 @elizaos/plugin-inmemorydb build finished in 19.02s
+@elizaos/security:build: cache miss, executing 20bbd9c10695cfd6
+@elizaos/security:build: $ node ../scripts/rm-path-recursive.mjs dist && tsc --noCheck -p tsconfig.build.json && node ../scripts/prepare-package-dist.mjs packages/security
+@elizaos/capacitor-calendar:build: created dist/plugin.js, dist/plugin.cjs.js in 776ms
+@elizaos/cloud-routing:build: cache miss, executing 606cf6f53c606607
+@elizaos/cloud-routing:build: $ tsc --noCheck -p tsconfig.json && node ../../scripts/prepare-package-dist.mjs packages/cloud/routing
+@elizaos/plugin-remote-desktop:build: 🎉 @elizaos/plugin-remote-desktop build finished in 15.27s
+@elizaos/plugin-x402:build: cache miss, executing 5811a05524e5b88a
+@elizaos/plugin-x402:build: $ bun run build.ts
+@elizaos/plugin-x402:build: 🔨 Building @elizaos/plugin-x402 (Node)…
+@elizaos/plugin-x402:build: ✅ Node complete in 0.10s
+@elizaos/plugin-x402:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-imessage:build: cache miss, executing b6007cbee66172ef
+@elizaos/plugin-imessage:build: $ bun run build.ts
+@elizaos/plugin-imessage:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-whatsapp:build: 🎉 @elizaos/plugin-whatsapp build finished in 18.06s
+@elizaos/plugin-background-runner:build: cache miss, executing d87f36259310bdce
+@elizaos/plugin-background-runner:build: $ tsc --noCheck -p tsconfig.json
+@elizaos/plugin-signal:build: cache miss, executing d142c1200c34e3c6
+@elizaos/plugin-signal:build: $ bun run build.ts
+@elizaos/plugin-signal:build: 🔨 Building @elizaos/plugin-signal (Node)…
+@elizaos/plugin-signal:build: ✅ Node complete in 0.08s
+@elizaos/plugin-signal:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-ollama:build: cache miss, executing 0fbe8a72d755ebff
+@elizaos/plugin-ollama:build: $ bun run build.ts
+@elizaos/plugin-ollama:build: 🔨 Building @elizaos/plugin-ollama (Node ESM)…
+@elizaos/plugin-ollama:build: ✅ Node ESM complete in 0.04s
+@elizaos/plugin-ollama:build: 🔨 Building @elizaos/plugin-ollama (Browser ESM)…
+@elizaos/plugin-ollama:build: ✅ Browser ESM complete in 0.03s
+@elizaos/plugin-ollama:build: 🔨 Building @elizaos/plugin-ollama (CJS)…
+@elizaos/plugin-ollama:build: ✅ CJS complete in 0.01s
+@elizaos/plugin-ollama:build: 📝 Generating TypeScript declarations…
+@elizaos/cloud-sdk:build: cache miss, executing dba4a0487e28ecb9
+@elizaos/cloud-sdk:build: $ bun run build.ts
+@elizaos/capacitor-contacts:build: cache miss, executing 9e151de87be66f3f
+@elizaos/capacitor-contacts:build: $ node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-contacts -- bun run build:unlocked
+@elizaos/capacitor-contacts:build: $ bun run clean && tsc && bunx rollup -c rollup.config.mjs
+@elizaos/capacitor-contacts:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/plugin-imessage:build: 🎉 @elizaos/plugin-imessage build finished in 13.50s
+@elizaos/plugin-xai:build: cache miss, executing aeffb03f0dadb517
+@elizaos/plugin-xai:build: $ bun run build.ts
+@elizaos/plugin-xai:build: 🔨 Building @elizaos/plugin-xai (Node (ESM))…
+@elizaos/plugin-xai:build: ✅ Node (ESM) complete in 0.01s
+@elizaos/plugin-xai:build: 🔨 Building @elizaos/plugin-xai (Browser)…
+@elizaos/plugin-xai:build: ✅ Browser complete in 0.01s
+@elizaos/plugin-xai:build: 🔨 Building @elizaos/plugin-xai (Node (CJS))…
+@elizaos/plugin-xai:build: ✅ Node (CJS) complete in 0.02s
+@elizaos/plugin-xai:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-x:build: cache miss, executing f08bc8790a656e80
+@elizaos/plugin-x:build: $ tsup
+@elizaos/plugin-x402:build: 🎉 @elizaos/plugin-x402 build finished in 16.24s
+@elizaos/plugin-computeruse:build: cache miss, executing 4b55e73a781be2ed
+@elizaos/plugin-computeruse:build: $ bun run build.ts
+@elizaos/plugin-computeruse:build: 🔨 Building plugin-computeruse (index)…
+@elizaos/plugin-computeruse:build: ✅ index complete in 0.07s
+@elizaos/plugin-computeruse:build: 🔨 Building plugin-computeruse (register-routes)…
+@elizaos/plugin-computeruse:build: ✅ register-routes complete in 0.09s
+@elizaos/plugin-computeruse:build: 🔨 Building plugin-computeruse (mobile/ocr-provider)…
+@elizaos/plugin-computeruse:build: ✅ mobile/ocr-provider complete in 0.04s
+@elizaos/plugin-computeruse:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-x:build: CLI Building entry: src/index.ts, src/lifeops-message-adapter.ts
+@elizaos/plugin-x:build: CLI Using tsconfig: tsconfig.build.json
+@elizaos/plugin-x:build: CLI tsup v8.5.1
+@elizaos/plugin-x:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/plugin-x/tsup.config.ts
+@elizaos/plugin-x:build: CLI Target: es2020
+@elizaos/plugin-x:build: CLI Cleaning output folder
+@elizaos/plugin-x:build: ESM Build start
+@elizaos/capacitor-contacts:build:
+@elizaos/capacitor-contacts:build: dist/esm/index.js → dist/plugin.js, dist/plugin.cjs.js...
+@elizaos/plugin-x:build: ESM dist/chunk-VU26ZOMZ.js              5.42 KB
+@elizaos/plugin-x:build: ESM dist/lifeops-message-adapter.js     128.00 B
+@elizaos/plugin-x:build: ESM dist/index.js                       418.32 KB
+@elizaos/plugin-x:build: ESM dist/chunk-VU26ZOMZ.js.map          10.55 KB
+@elizaos/plugin-x:build: ESM dist/lifeops-message-adapter.js.map 71.00 B
+@elizaos/plugin-x:build: ESM dist/index.js.map                   990.67 KB
+@elizaos/plugin-x:build: ESM ⚡️ Build success in 598ms
+@elizaos/capacitor-contacts:build: created dist/plugin.js, dist/plugin.cjs.js in 900ms
+@elizaos/plugin-tunnel:build: cache miss, executing 4ea4f758552b32ff
+@elizaos/plugin-tunnel:build: $ tsc --noCheck -p tsconfig.json
+@elizaos/plugin-signal:build: 🎉 @elizaos/plugin-signal build finished in 11.72s
+@elizaos/capacitor-bun-runtime:build: cache miss, executing 962e9ea617ce2120
+@elizaos/capacitor-bun-runtime:build: $ node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-bun-runtime -- bun run build:unlocked
+@elizaos/capacitor-bun-runtime:build: $ bun run clean && tsc && bunx rollup -c rollup.config.mjs
+@elizaos/capacitor-bun-runtime:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/plugin-x:build: DTS Build start
+@elizaos/plugin-ollama:build: 🎉 @elizaos/plugin-ollama build finished in 14.55s
+@elizaos/capacitor-swabble:build: cache miss, executing c8410ac4126bc0a6
+@elizaos/capacitor-swabble:build: $ node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-swabble -- bun run build:unlocked
+@elizaos/capacitor-swabble:build: $ bun run clean && tsc && bunx rollup -c rollup.config.mjs
+@elizaos/capacitor-swabble:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/plugin-xai:build: 🎉 @elizaos/plugin-xai build finished in 10.94s
+@elizaos/capacitor-talkmode:build: cache miss, executing 6f75a20f886f41b5
+@elizaos/capacitor-talkmode:build: $ node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-talkmode -- bun run build:unlocked
+@elizaos/capacitor-talkmode:build: $ bun run clean && tsc && bunx rollup -c rollup.config.mjs
+@elizaos/capacitor-talkmode:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/plugin-anthropic:build: cache miss, executing 1cf3fd9a8ed02f95
+@elizaos/plugin-anthropic:build: $ bun run build.ts
+@elizaos/plugin-anthropic:build: 🔨 Building @elizaos/plugin-anthropic (Node)…
+@elizaos/plugin-anthropic:build: ✅ Node complete in 0.01s
+@elizaos/plugin-anthropic:build: 🔨 Building @elizaos/plugin-anthropic (Browser)…
+@elizaos/plugin-anthropic:build: ✅ Browser complete in 0.02s
+@elizaos/plugin-anthropic:build: 🔨 Building @elizaos/plugin-anthropic (Node (CJS))…
+@elizaos/plugin-anthropic:build: ✅ Node (CJS) complete in 0.02s
+@elizaos/plugin-anthropic:build: 📝 Generating TypeScript declarations…
+@elizaos/capacitor-bun-runtime:build:
+@elizaos/capacitor-bun-runtime:build: dist/esm/index.js → dist/plugin.js, dist/plugin.cjs.js...
+@elizaos/capacitor-bun-runtime:build: created dist/plugin.js, dist/plugin.cjs.js in 650ms
+@elizaos/plugin-openrouter:build: cache miss, executing 7b93a3f999c88ba2
+@elizaos/plugin-openrouter:build: $ bun run build.ts
+@elizaos/plugin-openrouter:build: 🔨 Building @elizaos/plugin-openrouter (Node ESM)…
+@elizaos/plugin-openrouter:build: ✅ Node ESM complete in 0.03s
+@elizaos/plugin-openrouter:build: 🔨 Building @elizaos/plugin-openrouter (Browser ESM)…
+@elizaos/plugin-openrouter:build: ✅ Browser ESM complete in 0.04s
+@elizaos/plugin-openrouter:build: 🔨 Building @elizaos/plugin-openrouter (CJS)…
+@elizaos/plugin-openrouter:build: ✅ CJS complete in 0.01s
+@elizaos/plugin-openrouter:build: 🎉 @elizaos/plugin-openrouter build finished in 0.15s
+@elizaos/plugin-openai:build: cache miss, executing 0c640a96123a3eb4
+@elizaos/plugin-openai:build: $ bun run build.ts
+@elizaos/plugin-openai:build: 🔨 Building @elizaos/plugin-openai (Node)…
+@elizaos/plugin-openai:build: ✅ Node complete in 0.03s
+@elizaos/plugin-openai:build: 🔨 Building @elizaos/plugin-openai (Browser)…
+@elizaos/plugin-openai:build: ✅ Browser complete in 0.01s
+@elizaos/plugin-openai:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-computeruse:build: 🎉 plugin-computeruse build finished in 15.71s
+@elizaos/plugin-groq:build: cache miss, executing ff20bd327e18fc27
+@elizaos/plugin-groq:build: $ bun run build.ts
+@elizaos/plugin-groq:build: 🔨 Building @elizaos/plugin-groq (Node)…
+@elizaos/plugin-groq:build: ✅ Node complete in 0.01s
+@elizaos/plugin-groq:build: 🔨 Building @elizaos/plugin-groq (Browser)…
+@elizaos/plugin-groq:build: ✅ Browser complete in 0.01s
+@elizaos/plugin-groq:build: 🔨 Building @elizaos/plugin-groq (Node (CJS))…
+@elizaos/plugin-groq:build: ✅ Node (CJS) complete in 0.00s
+@elizaos/plugin-groq:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-google-genai:build: cache miss, executing b9b2bf47668d707b
+@elizaos/plugin-google-genai:build: $ bun run build.ts
+@elizaos/plugin-google-genai:build: 🔨 Building @elizaos/plugin-google-genai (Node)…
+@elizaos/plugin-google-genai:build: ✅ Node complete in 0.01s
+@elizaos/plugin-google-genai:build: 🔨 Building @elizaos/plugin-google-genai (Browser)…
+@elizaos/plugin-google-genai:build: ✅ Browser complete in 0.01s
+@elizaos/plugin-google-genai:build: 🔨 Building @elizaos/plugin-google-genai (Node (CJS))…
+@elizaos/plugin-google-genai:build: ✅ Node (CJS) complete in 0.01s
+@elizaos/plugin-google-genai:build: 📝 Generating TypeScript declarations…
+@elizaos/capacitor-talkmode:build:
+@elizaos/capacitor-talkmode:build: dist/esm/index.js → dist/plugin.js, dist/plugin.cjs.js...
+@elizaos/capacitor-swabble:build:
+@elizaos/capacitor-swabble:build: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/plugin-native-swabble/dist/esm/index.js → dist/plugin.js, dist/plugin.cjs.js...
+@elizaos/plugin-google:build: 🎉 @elizaos/plugin-google build finished in 48.47s
+@elizaos/plugin-telegram:build: cache miss, executing 99b3e59d95ce6992
+@elizaos/plugin-telegram:build: $ tsup && tsc --project tsconfig.build.json
+@elizaos/capacitor-talkmode:build: created dist/plugin.js, dist/plugin.cjs.js in 685ms
+@elizaos/plugin-browser:build: cache miss, executing 4b8c689c4af6948c
+@elizaos/plugin-browser:build: $ bun run build:js && bun run build:types
+@elizaos/plugin-browser:build: $ tsup --config ../tsup.plugin-packages.shared.ts
+@elizaos/capacitor-swabble:build: created dist/plugin.js, dist/plugin.cjs.js in 694ms
+@elizaos/example-chat:typecheck: cache miss, executing 0250dc4584d5b8d4
+@elizaos/example-chat:typecheck: $ tsgo --noEmit
+@elizaos/shared:build: cache miss, executing a97bb3e6f4aa2d6e
+@elizaos/shared:build: $ bun run build:i18n && bun run build:dist
+@elizaos/shared:build: $ node scripts/generate-keywords.mjs --target ts
+@elizaos/shared:build: Generating keyword code from JSON...
+@elizaos/shared:build:
+@elizaos/shared:build:   Loaded action-search.generated.keywords.json: 114 entries
+@elizaos/shared:build:   Loaded context-search.keywords.json: 38 entries
+@elizaos/shared:build:   Loaded shared.keywords.json: 71 entries
+@elizaos/shared:build:   Loaded typescript.keywords.json: 16 entries
+@elizaos/shared:build:   Loaded validate.keywords.json: 2 entries
+@elizaos/shared:build:
+@elizaos/shared:build: Total: 239 entries, 6 locales
+@elizaos/shared:build:
+@elizaos/shared:build:   TypeScript (shared): /Users/shawwalters/.codex/worktrees/36cd/eliza/packages/shared/src/i18n/generated/validation-keyword-data.ts
+@elizaos/shared:build:   JavaScript (shared): /Users/shawwalters/.codex/worktrees/36cd/eliza/packages/shared/src/i18n/generated/validation-keyword-data.js
+@elizaos/shared:build:   TypeScript (core):   /Users/shawwalters/.codex/worktrees/36cd/eliza/packages/core/src/i18n/generated/validation-keyword-data.ts
+@elizaos/shared:build:
+@elizaos/shared:build: Done!
+@elizaos/shared:build: $ node ../scripts/rm-path-recursive.mjs dist && tsc --noCheck -p tsconfig.build.json && node ../scripts/prepare-package-dist.mjs packages/shared && node ../scripts/rewrite-dist-relative-imports-node-esm.mjs packages/shared && node ../scripts/copy-package-assets.mjs packages/shared src/brand/brand.css src/brand-classic/brand.css
+@elizaos/plugin-telegram:build: CLI Building entry: src/index.ts, src/account-auth-service.ts
+@elizaos/plugin-telegram:build: CLI Using tsconfig: tsconfig.build.json
+@elizaos/plugin-telegram:build: CLI tsup v8.5.1
+@elizaos/plugin-telegram:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/plugin-telegram/tsup.config.ts
+@elizaos/plugin-telegram:build: CLI Target: esnext
+@elizaos/plugin-telegram:build: CLI Cleaning output folder
+@elizaos/plugin-telegram:build: ESM Build start
+@elizaos/plugin-telegram:build: ESM dist/chunk-Q2XLH3NG.js           20.31 KB
+@elizaos/plugin-telegram:build: ESM dist/index.js                    193.32 KB
+@elizaos/plugin-telegram:build: ESM dist/account-auth-service.js     787.00 B
+@elizaos/plugin-telegram:build: ESM dist/chunk-Q2XLH3NG.js.map       38.52 KB
+@elizaos/plugin-telegram:build: ESM dist/index.js.map                387.58 KB
+@elizaos/plugin-telegram:build: ESM dist/account-auth-service.js.map 71.00 B
+@elizaos/plugin-telegram:build: ESM ⚡️ Build success in 137ms
+@elizaos/plugin-browser:build: CLI Building entry: src/schema.ts, src/companion-auth.ts, src/lifeops-session-contracts.ts, src/browser-capture-hooks.ts, src/workspace.ts, src/bridge-policy.ts, src/contracts.ts, src/browser-workspace-hooks.ts, src/plugin.ts, src/packaging.ts, src/password-manager-bridge.ts, src/message-adapter.ts, src/bridge-records.ts, src/bridge-readiness.ts, src/index.ts, src/service.ts, src/browser-service.ts, src/benchmark/web-grounding.ts, src/benchmark/chromium-executor.ts, src/benchmark/external-dataset.ts, src/benchmark/types.ts, src/benchmark/policy.ts, src/benchmark/adapter.ts, src/benchmark/index.ts, src/benchmark/tasks.ts, src/benchmark/runner.ts, src/targets/stagehand-target.ts, src/targets/bridge-target.ts, src/routes/workspace-account-gate.ts, src/routes/workspace-setup.ts, src/routes/workspace.ts, src/routes/bridge.ts, src/actions/browser-autofill-login.ts, src/actions/wait-for-url-predicate.ts, src/actions/manage-browser-bridge.ts, src/actions/wait-for-url.ts, src/actions/browser.ts, src/parity/browser-matrix.ts, src/parity/index.ts, src/workspace/browser-workspace-desktop.ts, src/workspace/browser-workspace-helpers.ts, src/workspace/browser-workspace-types.ts, src/workspace/browser-workspace-errors.ts, src/workspace/browser-workspace-network.ts, src/workspace/browser-workspace-elements.ts, src/workspace/browser-workspace-web.ts, src/workspace/browser-capture.ts, src/workspace/browser-workspace-jsdom.ts, src/workspace/browser-workspace-state.ts, src/workspace/browser-workspace-snapshots.ts, src/workspace/index.ts, src/workspace/browser-workspace-forms.ts, src/workspace/browser-workspace.ts, src/providers/workspace.ts
+@elizaos/plugin-browser:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-browser:build: CLI tsup v8.5.1
+@elizaos/plugin-browser:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/tsup.plugin-packages.shared.ts
+@elizaos/plugin-browser:build: CLI Target: es2022
+@elizaos/plugin-browser:build: ESM Build start
+@elizaos/plugin-browser:build: ESM dist/lifeops-session-contracts.js                 53.00 B
+@elizaos/plugin-browser:build: ESM dist/companion-auth.js                            2.83 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-capture.js                 5.24 KB
+@elizaos/plugin-browser:build: ESM dist/routes/workspace.js                          10.36 KB
+@elizaos/plugin-browser:build: ESM dist/packaging.js                                 17.54 KB
+@elizaos/plugin-browser:build: ESM dist/parity/index.js                              286.00 B
+@elizaos/plugin-browser:build: ESM dist/browser-workspace-hooks.js                   463.00 B
+@elizaos/plugin-browser:build: ESM dist/plugin.js                                    5.64 KB
+@elizaos/plugin-browser:build: ESM dist/benchmark/policy.js                          960.00 B
+@elizaos/plugin-browser:build: ESM dist/targets/bridge-target.js                     2.93 KB
+@elizaos/plugin-browser:build: ESM dist/browser-capture-hooks.js                     445.00 B
+@elizaos/plugin-browser:build: ESM dist/password-manager-bridge.js                   12.34 KB
+@elizaos/plugin-browser:build: ESM dist/message-adapter.js                           2.98 KB
+@elizaos/plugin-browser:build: ESM dist/bridge-records.js                            941.00 B
+@elizaos/plugin-browser:build: ESM dist/bridge-readiness.js                          3.01 KB
+@elizaos/plugin-browser:build: ESM dist/index.js                                     3.71 KB
+@elizaos/plugin-browser:build: ESM dist/contracts.js                                 1.28 KB
+@elizaos/plugin-browser:build: ESM dist/benchmark/index.js                           1.38 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-jsdom.js         6.72 KB
+@elizaos/plugin-browser:build: ESM dist/benchmark/runner.js                          3.26 KB
+@elizaos/plugin-browser:build: ESM dist/providers/workspace.js                       1.64 KB
+@elizaos/plugin-browser:build: ESM dist/benchmark/external-dataset.js                6.30 KB
+@elizaos/plugin-browser:build: ESM dist/benchmark/web-grounding.js                   5.63 KB
+@elizaos/plugin-browser:build: ESM dist/schema.js                                    4.88 KB
+@elizaos/plugin-browser:build: ESM dist/benchmark/tasks.js                           10.68 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-snapshots.js     5.68 KB
+@elizaos/plugin-browser:build: ESM dist/parity/browser-matrix.js                     8.70 KB
+@elizaos/plugin-browser:build: ESM dist/actions/browser-autofill-login.js            8.31 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/index.js                           158.00 B
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-web.js           45.14 KB
+@elizaos/plugin-browser:build: ESM dist/routes/bridge.js                             24.03 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-state.js         4.36 KB
+@elizaos/plugin-browser:build: ESM dist/targets/stagehand-target.js                  6.15 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-elements.js      17.56 KB
+@elizaos/plugin-browser:build: ESM dist/workspace.js                                 75.00 B
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace.js               30.90 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-helpers.js       9.61 KB
+@elizaos/plugin-browser:build: ESM dist/actions/browser.js                           20.26 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-forms.js         9.36 KB
+@elizaos/plugin-browser:build: ESM dist/actions/manage-browser-bridge.js             11.27 KB
+@elizaos/plugin-browser:build: ESM dist/targets/bridge-target.js.map                 7.00 KB
+@elizaos/plugin-browser:build: ESM dist/actions/wait-for-url.js                      2.92 KB
+@elizaos/plugin-browser:build: ESM dist/benchmark/policy.js.map                      3.55 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-types.js         237.00 B
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-capture.js.map             11.46 KB
+@elizaos/plugin-browser:build: ESM dist/parity/index.js.map                          540.00 B
+@elizaos/plugin-browser:build: ESM dist/packaging.js.map                             31.76 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-errors.js        2.25 KB
+@elizaos/plugin-browser:build: ESM dist/browser-workspace-hooks.js.map               2.00 KB
+@elizaos/plugin-browser:build: ESM dist/benchmark/adapter.js                         6.18 KB
+@elizaos/plugin-browser:build: ESM dist/browser-capture-hooks.js.map                 1.08 KB
+@elizaos/plugin-browser:build: ESM dist/bridge-policy.js                             1.33 KB
+@elizaos/plugin-browser:build: ESM dist/benchmark/chromium-executor.js               12.42 KB
+@elizaos/plugin-browser:build: ESM dist/routes/workspace-setup.js                    1.81 KB
+@elizaos/plugin-browser:build: ESM dist/service.js                                   151.00 B
+@elizaos/plugin-browser:build: ESM dist/companion-auth.js.map                        5.88 KB
+@elizaos/plugin-browser:build: ESM dist/password-manager-bridge.js.map               27.10 KB
+@elizaos/plugin-browser:build: ESM dist/benchmark/tasks.js.map                       21.67 KB
+@elizaos/plugin-browser:build: ESM dist/actions/wait-for-url-predicate.js            822.00 B
+@elizaos/plugin-browser:build: ESM dist/routes/workspace-account-gate.js             4.48 KB
+@elizaos/plugin-browser:build: ESM dist/routes/workspace.js.map                      19.02 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-network.js       4.43 KB
+@elizaos/plugin-browser:build: ESM dist/browser-service.js                           6.56 KB
+@elizaos/plugin-browser:build: ESM dist/benchmark/types.js                           33.00 B
+@elizaos/plugin-browser:build: ESM dist/workspace/index.js.map                       1.52 KB
+@elizaos/plugin-browser:build: ESM dist/benchmark/external-dataset.js.map            11.67 KB
+@elizaos/plugin-browser:build: ESM dist/lifeops-session-contracts.js.map             71.00 B
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-web.js.map       75.75 KB
+@elizaos/plugin-browser:build: ESM dist/bridge-readiness.js.map                      5.99 KB
+@elizaos/plugin-browser:build: ESM dist/message-adapter.js.map                       6.19 KB
+@elizaos/plugin-browser:build: ESM dist/routes/bridge.js.map                         45.55 KB
+@elizaos/plugin-browser:build: ESM dist/plugin.js.map                                10.91 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-snapshots.js.map 10.43 KB
+@elizaos/plugin-browser:build: ESM dist/index.js.map                                 5.78 KB
+@elizaos/plugin-browser:build: ESM dist/bridge-records.js.map                        2.08 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-desktop.js       55.49 KB
+@elizaos/plugin-browser:build: ESM dist/targets/stagehand-target.js.map              11.48 KB
+@elizaos/plugin-browser:build: ESM dist/contracts.js.map                             10.39 KB
+@elizaos/plugin-browser:build: ESM dist/workspace.js.map                             145.00 B
+@elizaos/plugin-browser:build: ESM dist/providers/workspace.js.map                   3.16 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace.js.map           56.36 KB
+@elizaos/plugin-browser:build: ESM dist/benchmark/runner.js.map                      7.10 KB
+@elizaos/plugin-browser:build: ESM dist/parity/browser-matrix.js.map                 16.58 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-state.js.map     7.87 KB
+@elizaos/plugin-browser:build: ESM dist/actions/browser-autofill-login.js.map        15.93 KB
+@elizaos/plugin-browser:build: ESM dist/actions/wait-for-url.js.map                  7.55 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-jsdom.js.map     12.78 KB
+@elizaos/plugin-browser:build: ESM dist/bridge-policy.js.map                         2.17 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-helpers.js.map   15.11 KB
+@elizaos/plugin-browser:build: ESM dist/benchmark/chromium-executor.js.map           27.96 KB
+@elizaos/plugin-browser:build: ESM dist/benchmark/index.js.map                       2.15 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-errors.js.map    6.81 KB
+@elizaos/plugin-browser:build: ESM dist/browser-service.js.map                       14.93 KB
+@elizaos/plugin-browser:build: ESM dist/schema.js.map                                9.92 KB
+@elizaos/plugin-browser:build: ESM dist/routes/workspace-setup.js.map                3.95 KB
+@elizaos/plugin-browser:build: ESM dist/routes/workspace-account-gate.js.map         8.28 KB
+@elizaos/plugin-browser:build: ESM dist/actions/wait-for-url-predicate.js.map        3.02 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-desktop.js.map   71.67 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-types.js.map     13.78 KB
+@elizaos/plugin-browser:build: ESM dist/benchmark/web-grounding.js.map               13.03 KB
+@elizaos/plugin-browser:build: ESM dist/actions/manage-browser-bridge.js.map         21.51 KB
+@elizaos/plugin-browser:build: ESM dist/actions/browser.js.map                       40.50 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-forms.js.map     16.36 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-elements.js.map  31.44 KB
+@elizaos/plugin-browser:build: ESM dist/benchmark/adapter.js.map                     13.35 KB
+@elizaos/plugin-browser:build: ESM dist/service.js.map                               4.07 KB
+@elizaos/plugin-browser:build: ESM dist/benchmark/types.js.map                       71.00 B
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-network.js.map   8.33 KB
+@elizaos/plugin-browser:build: ESM ⚡️ Build success in 302ms
+@elizaos/plugin-browser:build: $ tsc --noCheck -p tsconfig.build.json
+@elizaos/plugin-anthropic:build: 🎉 @elizaos/plugin-anthropic build finished in 9.05s
+@elizaos/plugin-localdb:build: cache miss, executing 3d5fdd34569e1509
+@elizaos/plugin-localdb:build: $ tsup --config tsup.config.ts
+@elizaos/plugin-openai:build: 🎉 @elizaos/plugin-openai build finished in 8.29s
+@elizaos/plugin-remote-manifest:build: cache miss, executing 35103077f4f432e6
+@elizaos/plugin-remote-manifest:build: $ node ../scripts/rm-path-recursive.mjs dist tsconfig.build.tsbuildinfo && tsc --noCheck -p tsconfig.build.json
+@elizaos/plugin-localdb:build: CLI Building entry: {"index":"index.ts","index.browser":"index.browser.ts"}
+@elizaos/plugin-localdb:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-localdb:build: CLI tsup v8.5.1
+@elizaos/plugin-localdb:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/plugin-localdb/tsup.config.ts
+@elizaos/plugin-localdb:build: CLI Target: es2022
+@elizaos/plugin-localdb:build: CLI Cleaning output folder
+@elizaos/plugin-localdb:build: ESM Build start
+@elizaos/plugin-localdb:build: ESM dist/index.js             4.16 KB
+@elizaos/plugin-localdb:build: ESM dist/index.browser.js     3.16 KB
+@elizaos/plugin-localdb:build: ESM dist/index.js.map         9.34 KB
+@elizaos/plugin-localdb:build: ESM dist/index.browser.js.map 6.74 KB
+@elizaos/plugin-localdb:build: ESM ⚡️ Build success in 18ms
+@elizaos/plugin-groq:build: 🎉 @elizaos/plugin-groq build finished in 7.38s
+@elizaos/plugin-mcp:build: cache miss, executing 101955bf2dcb6eba
+@elizaos/plugin-mcp:build: $ bun run build.ts
+@elizaos/plugin-mcp:build: 🔨 Building @elizaos/plugin-mcp (Node (ESM))…
+@elizaos/plugin-mcp:build: ✅ Node (ESM) complete in 0.01s
+@elizaos/plugin-mcp:build: 🔨 Building @elizaos/plugin-mcp (Node (CJS))…
+@elizaos/plugin-mcp:build: ✅ Node (CJS) complete in 0.01s
+@elizaos/plugin-mcp:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-localdb:build: DTS Build start
+@elizaos/plugin-google-genai:build: 🎉 @elizaos/plugin-google-genai build finished in 12.05s
+@elizaos/plugin-cloud-apps:build: cache miss, executing c58201ca610e805d
+@elizaos/plugin-cloud-apps:build: $ bun run build.ts
+@elizaos/plugin-cloud-apps:build: 🔨 Building @elizaos/plugin-cloud-apps (Node)…
+@elizaos/plugin-cloud-apps:build: ✅ Node complete in 0.04s
+@elizaos/plugin-cloud-apps:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-x:build: DTS ⚡️ Build success in 23262ms
+@elizaos/plugin-x:build: DTS dist/index.d.ts                   860.00 B
+@elizaos/plugin-x:build: DTS dist/lifeops-message-adapter.d.ts 963.00 B
+@elizaos/example-edad:typecheck: cache miss, executing 9bda1a6e032f4746
+@elizaos/example-edad:typecheck: $ tsgo --noEmit
+@elizaos/plugin-vision:build: cache miss, executing 47b86359868e2dca
+@elizaos/plugin-vision:build: $ bun run build.ts
+@elizaos/plugin-vision:build: 🔨 Building @elizaos/plugin-vision (Node)…
+@elizaos/plugin-vision:build: ✅ Node complete in 0.03s
+@elizaos/plugin-vision:build: 🔨 Building @elizaos/plugin-vision (Workers)…
+@elizaos/plugin-vision:build: ✅ Workers complete in 0.02s
+@elizaos/plugin-vision:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-mcp:build: 🎉 @elizaos/plugin-mcp build finished in 9.98s
+@elizaos/plugin-tailscale:typecheck: cache miss, executing a2b1345be6d3a7c7
+@elizaos/plugin-tailscale:typecheck: $ tsgo --noEmit
+@elizaos/gcp-examples:typecheck: cache miss, executing 3a552571c95edc5e
+@elizaos/gcp-examples:typecheck: $ tsgo --noEmit
+@elizaos/example-bluesky:typecheck: cache miss, executing 0cb0a25e2639965d
+@elizaos/example-convex:typecheck: cache miss, executing 64e44fa82f3ee6b4
+@elizaos/example-bluesky:typecheck: $ tsgo --noEmit
+@elizaos/example-convex:typecheck: $ tsgo --noEmit
+@elizaos/example-xai-x:typecheck: cache miss, executing 9e73597cf14767d1
+@elizaos/example-xai-x:typecheck: $ tsgo --noEmit
+@elizaos/plugin-worker-runtime:build: cache miss, executing afc452995c7b1550
+@elizaos/plugin-worker-runtime:build: $ node ../scripts/rm-path-recursive.mjs dist tsconfig.build.tsbuildinfo && tsc --noCheck -p tsconfig.build.json
+@elizaos/plugin-discord:build: cache miss, executing a99d21b788c2a8d4
+@elizaos/plugin-discord:build: $ bun run build.ts
+@elizaos/plugin-streaming:build: cache miss, executing d460072456a7b67e
+@elizaos/plugin-streaming:build: $ tsup && tsc --declaration --emitDeclarationOnly --noEmit false --noCheck
+@elizaos/plugin-discord:build: 🔨 Building @elizaos/plugin-discord (Node)…
+@elizaos/plugin-discord:build: ✅ Node complete in 0.04s
+@elizaos/plugin-discord:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-cloud-apps:build: 🎉 @elizaos/plugin-cloud-apps build finished in 7.16s
+@elizaos/plugin-discord:typecheck: cache miss, executing c78af0de713a7fa1
+@elizaos/plugin-discord:typecheck: $ tsgo --noEmit
+@elizaos/plugin-localdb:build: DTS ⚡️ Build success in 11886ms
+@elizaos/plugin-localdb:build: DTS dist/index.d.ts         306.00 B
+@elizaos/plugin-localdb:build: DTS dist/index.browser.d.ts 289.00 B
+@elizaos/cloud-shared:typecheck: cache miss, executing d9347b293cd0b9b1
+@elizaos/cloud-shared:typecheck: $ tsgo --noEmit
+@elizaos/cloud-api:typecheck: cache miss, executing 4ede9fa513530ade
+@elizaos/cloud-api:typecheck: $ tsgo --noEmit
+@elizaos/plugin-streaming:build: CLI Building entry: src/core.ts, src/index.ts, src/api/stream-route-state.ts, src/api/streaming-text.ts, src/api/stream-persistence.ts, src/api/stream-routes.ts, src/api/tts-routes.ts, src/api/streaming-types.ts, src/services/tts-stream-bridge.ts, src/services/stream-manager.ts
+@elizaos/plugin-streaming:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-streaming:build: CLI tsup v8.5.1
+@elizaos/plugin-streaming:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/plugin-streaming/tsup.config.ts
+@elizaos/plugin-streaming:build: CLI Target: esnext
+@elizaos/plugin-streaming:build: ESM Build start
+@elizaos/plugin-streaming:build: ESM dist/core.js                           16.43 KB
+@elizaos/plugin-streaming:build: ESM dist/index.js                          3.89 KB
+@elizaos/plugin-streaming:build: ESM dist/api/stream-routes.js              18.59 KB
+@elizaos/plugin-streaming:build: ESM dist/api/stream-route-state.js         46.00 B
+@elizaos/plugin-streaming:build: ESM dist/api/streaming-text.js             2.65 KB
+@elizaos/plugin-streaming:build: ESM dist/api/stream-persistence.js         5.69 KB
+@elizaos/plugin-streaming:build: ESM dist/api/streaming-types.js            43.00 B
+@elizaos/plugin-streaming:build: ESM dist/api/tts-routes.js                 11.60 KB
+@elizaos/plugin-streaming:build: ESM dist/services/tts-stream-bridge.js     13.19 KB
+@elizaos/plugin-streaming:build: ESM dist/services/stream-manager.js        15.39 KB
+@elizaos/plugin-streaming:build: ESM dist/index.js.map                      6.54 KB
+@elizaos/plugin-streaming:build: ESM dist/api/stream-routes.js.map          41.12 KB
+@elizaos/plugin-streaming:build: ESM dist/api/streaming-types.js.map        71.00 B
+@elizaos/plugin-streaming:build: ESM dist/api/streaming-text.js.map         5.00 KB
+@elizaos/plugin-streaming:build: ESM dist/api/stream-persistence.js.map     13.18 KB
+@elizaos/plugin-streaming:build: ESM dist/services/tts-stream-bridge.js.map 26.61 KB
+@elizaos/plugin-streaming:build: ESM dist/services/stream-manager.js.map    32.22 KB
+@elizaos/plugin-streaming:build: ESM dist/api/tts-routes.js.map             24.45 KB
+@elizaos/plugin-streaming:build: ESM dist/api/stream-route-state.js.map     71.00 B
+@elizaos/plugin-streaming:build: ESM dist/core.js.map                       36.92 KB
+@elizaos/plugin-streaming:build: ESM ⚡️ Build success in 92ms
+@elizaos/example-telegram:typecheck: cache miss, executing 0e56bdc3460ea39c
+@elizaos/example-telegram:typecheck: $ tsgo --noEmit
+@elizaos/plugin-sub-agent-claude-code:typecheck: cache miss, executing 6d1b2c5b19ad9c98
+@elizaos/plugin-sub-agent-claude-code:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-vision:build: 🎉 @elizaos/plugin-vision build finished in 12.40s
+@elizaos/shared:build: [rewrite-dist-relative-imports] rewrote 5 file(s)
+@elizaos/plugin-coding-tools:build: cache miss, executing ac5e89a11c4a1c2e
+@elizaos/plugin-agent-skills:build: cache miss, executing ec92872f971bff9e
+@elizaos/ui:build: cache miss, executing 1cc8046ec99f525f
+@elizaos/plugin-scheduling:build: cache miss, executing c0b65be20e24c03e
+@elizaos/plugin-elizacloud:build: cache miss, executing 6e51f8f2e840b451
+@elizaos/plugin-wallet:build: cache miss, executing 9dde1c139996cfa5
+@elizaos/plugin-coding-tools:build: $ bun run build.ts
+@elizaos/plugin-scheduling:build: $ bun run build:js && bun run build:types
+@elizaos/plugin-agent-skills:build: $ tsup && tsc --declaration --emitDeclarationOnly --noEmit false --noCheck
+@elizaos/ui:build: $ bun run build:dist
+@elizaos/plugin-elizacloud:build: $ bun run build.ts
+@elizaos/plugin-wallet:build: $ bun run build.ts
+@elizaos/ui:build: $ node ../scripts/with-package-build-lock.mjs packages/ui -- bun run build:dist:unlocked
+@elizaos/plugin-scheduling:build: $ tsup --config ../tsup.plugin-packages.shared.ts
+@elizaos/ui:build: $ bun run clean && bun run generate:css-strings && node ../scripts/ensure-tsc-nested-output-dir.mjs packages/ui && tsc --noCheck -p tsconfig.build.json && node ../scripts/flatten-tsc-package-output.mjs packages/ui && node ../scripts/copy-package-assets.mjs packages/ui src/styles src/cloud-ui/index.css && node ../scripts/prepare-package-dist.mjs packages/ui && node ../scripts/rewrite-dist-relative-imports-node-esm.mjs packages/ui && node ../scripts/verify-package-runtime-exports.mjs packages/ui
+@elizaos/ui:build: $ node ../scripts/rm-path-recursive.mjs dist
+@elizaos/plugin-coding-tools:build: 🔨 Building @elizaos/plugin-coding-tools (Node)…
+@elizaos/plugin-coding-tools:build: ✅ Node complete in 0.05s
+@elizaos/plugin-coding-tools:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-elizacloud:build: 🔨 Building @elizaos/plugin-elizacloud (Node)…
+@elizaos/plugin-elizacloud:build: ✅ Node complete in 0.02s
+@elizaos/plugin-elizacloud:build: 🔨 Building @elizaos/plugin-elizacloud (Browser)…
+@elizaos/plugin-elizacloud:build: ✅ Browser complete in 0.01s
+@elizaos/plugin-elizacloud:build: 🔨 Building @elizaos/plugin-elizacloud (Node (CJS))…
+@elizaos/plugin-elizacloud:build: ✅ Node (CJS) complete in 0.04s
+@elizaos/plugin-elizacloud:build: 🔨 Building @elizaos/plugin-elizacloud (Exported subpaths)…
+@elizaos/plugin-wallet:build: 🔨 Building @elizaos/plugin-wallet (Node)…
+@elizaos/plugin-wallet:build: ✅ Node complete in 0.07s
+@elizaos/plugin-wallet:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-elizacloud:build: ✅ Exported subpaths complete in 0.15s
+@elizaos/plugin-elizacloud:build: 📂 Flattening dist/src → dist/.…
+@elizaos/plugin-elizacloud:build: 📝 Generating TypeScript declarations…
+@elizaos/ui:build: $ node ../scripts/generate-css-strings.mjs
+@elizaos/ui:build: [generate-css-strings] processed 0 target(s), updated 0
+@elizaos/plugin-agent-skills:build: CLI Building entry: src/index.ts
+@elizaos/plugin-agent-skills:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-agent-skills:build: CLI tsup v8.5.1
+@elizaos/plugin-agent-skills:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/plugin-agent-skills/tsup.config.ts
+@elizaos/plugin-agent-skills:build: CLI Target: es2022
+@elizaos/plugin-agent-skills:build: CLI Cleaning output folder
+@elizaos/plugin-agent-skills:build: ESM Build start
+@elizaos/plugin-agent-skills:build: ESM dist/security-EG7TNDRO.js                 18.02 KB
+@elizaos/plugin-agent-skills:build: ESM dist/skill-catalog-client-XD3KGK7O.js     308.00 B
+@elizaos/plugin-agent-skills:build: ESM dist/index.js                             205.57 KB
+@elizaos/plugin-agent-skills:build: ESM dist/skill-marketplace-GLSNT3NB.js        337.00 B
+@elizaos/plugin-agent-skills:build: ESM dist/chunk-ZTFKIHLT.js                    3.64 KB
+@elizaos/plugin-agent-skills:build: ESM dist/chunk-JMKUEEPA.js                    20.54 KB
+@elizaos/plugin-agent-skills:build: ESM dist/skill-catalog-client-XD3KGK7O.js.map 71.00 B
+@elizaos/plugin-agent-skills:build: ESM dist/security-EG7TNDRO.js.map             34.87 KB
+@elizaos/plugin-agent-skills:build: ESM dist/skill-marketplace-GLSNT3NB.js.map    71.00 B
+@elizaos/plugin-agent-skills:build: ESM dist/chunk-ZTFKIHLT.js.map                7.92 KB
+@elizaos/plugin-agent-skills:build: ESM dist/index.js.map                         441.52 KB
+@elizaos/plugin-agent-skills:build: ESM dist/chunk-JMKUEEPA.js.map                41.94 KB
+@elizaos/plugin-agent-skills:build: ESM ⚡️ Build success in 150ms
+@elizaos/plugin-scheduling:build: CLI Building entry: src/dispatch-types.ts, src/plugin.ts, src/index.ts, src/scheduled-task/schema.ts, src/scheduled-task/runner-service.ts, src/scheduled-task/gate-registry.ts, src/scheduled-task/state-log.ts, src/scheduled-task/due.ts, src/scheduled-task/next-fire-at.ts, src/scheduled-task/types.ts, src/scheduled-task/completion-check-registry.ts, src/scheduled-task/escalation.ts, src/scheduled-task/default-pack.ts, src/scheduled-task/index.ts, src/scheduled-task/runner.ts, src/scheduled-task/consolidation-policy.ts, src/scheduled-task/seed-registry.ts, src/anchors/anchor-registry.ts, src/routes/scheduled-tasks.ts, src/routes/plugin-routes.ts
+@elizaos/plugin-scheduling:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-scheduling:build: CLI tsup v8.5.1
+@elizaos/plugin-scheduling:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/tsup.plugin-packages.shared.ts
+@elizaos/plugin-scheduling:build: CLI Target: es2022
+@elizaos/plugin-scheduling:build: ESM Build start
+@elizaos/plugin-discord:build: 🔧 Rewriting dist relative imports for NodeNext…
+@elizaos/plugin-discord:build: [rewrite-dist-relative-imports] rewrote 25 file(s)
+@elizaos/plugin-discord:build: 🎉 @elizaos/plugin-discord build finished in 15.86s
+@elizaos/plugin-shell:build: cache miss, executing 3ab8bafe79167136
+@elizaos/plugin-scheduling:build: ESM dist/dispatch-types.js                               42.00 B
+@elizaos/plugin-scheduling:build: ESM dist/plugin.js                                       1.87 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/types.js                         358.00 B
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/default-pack.js                  1.87 KB
+@elizaos/plugin-scheduling:build: ESM dist/index.js                                        734.00 B
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/next-fire-at.js                  6.81 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/state-log.js                     2.97 KB
+@elizaos/plugin-scheduling:build: ESM dist/anchors/anchor-registry.js                      3.93 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/completion-check-registry.js     3.35 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/schema.js                        6.30 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/runner-service.js                6.97 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/consolidation-policy.js          4.68 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/escalation.js                    2.90 KB
+@elizaos/plugin-scheduling:build: ESM dist/routes/plugin-routes.js                         2.24 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/index.js                         3.24 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/gate-registry.js                 7.49 KB
+@elizaos/plugin-scheduling:build: ESM dist/routes/scheduled-tasks.js                       7.42 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/seed-registry.js                 2.21 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/due.js                           12.66 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/runner.js                        23.87 KB
+@elizaos/plugin-scheduling:build: ESM dist/dispatch-types.js.map                           71.00 B
+@elizaos/plugin-scheduling:build: ESM dist/plugin.js.map                                   5.44 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/types.js.map                     14.98 KB
+@elizaos/plugin-scheduling:build: ESM dist/index.js.map                                    1.01 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/default-pack.js.map              5.18 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/state-log.js.map                 7.36 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/next-fire-at.js.map              14.68 KB
+@elizaos/plugin-scheduling:build: ESM dist/anchors/anchor-registry.js.map                  9.38 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/completion-check-registry.js.map 7.42 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/schema.js.map                    12.85 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/runner-service.js.map            17.78 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/consolidation-policy.js.map      11.60 KB
+@elizaos/plugin-scheduling:build: ESM dist/routes/plugin-routes.js.map                     5.17 KB
+@elizaos/plugin-scheduling:build: ESM dist/routes/scheduled-tasks.js.map                   15.44 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/due.js.map                       24.70 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/escalation.js.map                6.75 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/gate-registry.js.map             16.34 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/index.js.map                     4.99 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/seed-registry.js.map             6.50 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/runner.js.map                    60.38 KB
+@elizaos/plugin-scheduling:build: ESM ⚡️ Build success in 143ms
+@elizaos/plugin-shell:build: $ bun run build.ts
+@elizaos/plugin-scheduling:build: $ bunx tsc --noCheck -p tsconfig.build.json && node ../../packages/scripts/rewrite-dist-relative-imports-node-esm.mjs
+@elizaos/plugin-shell:build: 🔨 Building @elizaos/plugin-shell (Node)…
+@elizaos/plugin-shell:build: ✅ Node complete in 0.01s
+@elizaos/plugin-shell:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-coding-tools:build: 🎉 @elizaos/plugin-coding-tools build finished in 12.79s
+@elizaos/plugin-registry:build: cache miss, executing 37774f2dd100b650
+@elizaos/plugin-registry:build: $ bun run build:js && bun run build:types
+@elizaos/plugin-registry:build: $ tsup --config ../tsup.plugin-packages.shared.ts
+@elizaos/plugin-scheduling:build: [rewrite-dist-relative-imports] rewrote 1 file(s)
+@elizaos/plugin-aosp-local-inference:build: cache miss, executing 92e64da121a27e2f
+@elizaos/plugin-aosp-local-inference:build: $ tsc --noCheck -p tsconfig.json --noEmit
+@elizaos/plugin-agent-orchestrator:build: cache miss, executing bcf334f0b514eb83
+@elizaos/plugin-agent-orchestrator:build: $ bun run build.ts
+@elizaos/plugin-agent-orchestrator:build: 🔨 Building @elizaos/plugin-agent-orchestrator (Node)…
+@elizaos/plugin-agent-orchestrator:build: ✅ Node complete in 0.07s
+@elizaos/plugin-agent-orchestrator:build: 🔨 Building @elizaos/plugin-agent-orchestrator (Node (CJS))…
+@elizaos/plugin-agent-orchestrator:build: ✅ Node (CJS) complete in 0.05s
+@elizaos/plugin-agent-orchestrator:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-registry:build: CLI Building entry: src/index.ts, src/api/app-plugins-routes.ts, src/api/plugin-routes.ts, src/services/plugin-installer.ts
+@elizaos/plugin-registry:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-registry:build: CLI tsup v8.5.1
+@elizaos/plugin-registry:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/tsup.plugin-packages.shared.ts
+@elizaos/plugin-registry:build: CLI Target: es2022
+@elizaos/plugin-registry:build: ESM Build start
+@elizaos/plugin-shell:build: 🎉 @elizaos/plugin-shell build finished in 13.19s
+@elizaos/plugin-registry:build: ESM dist/api/plugin-routes.js             50.13 KB
+@elizaos/plugin-registry:build: ESM dist/services/plugin-installer.js     866.00 B
+@elizaos/plugin-registry:build: ESM dist/api/app-plugins-routes.js        37.85 KB
+@elizaos/plugin-registry:build: ESM dist/index.js                         542.00 B
+@elizaos/plugin-registry:build: ESM dist/api/app-plugins-routes.js.map    75.86 KB
+@elizaos/plugin-registry:build: ESM dist/services/plugin-installer.js.map 3.18 KB
+@elizaos/plugin-registry:build: ESM dist/index.js.map                     1.71 KB
+@elizaos/plugin-registry:build: ESM dist/api/plugin-routes.js.map         97.23 KB
+@elizaos/plugin-registry:build: ESM ⚡️ Build success in 186ms
+@elizaos/plugin-registry:build: $ tsc --noCheck -p tsconfig.build.json && node ../../packages/scripts/rewrite-dist-relative-imports-node-esm.mjs
+@elizaos/plugin-elizacloud:build: 🎉 @elizaos/plugin-elizacloud build finished in 16.76s
+@elizaos/example-browser-extension-chrome:typecheck: cache miss, executing e6d8d34c1546f5fc
+@elizaos/example-app-electron:typecheck: cache miss, executing 197fbeea305162f0
+@elizaos/example-browser-extension-chrome:typecheck: $ tsgo --noEmit
+@elizaos/example-app-electron:typecheck: $ tsc --noEmit
+@elizaos/example-rest-api-hono:typecheck: cache miss, executing a152e821ed14b898
+@elizaos/example-rest-api-hono:typecheck: $ tsgo --noEmit
+@elizaos/example-rest-api-express:typecheck: cache miss, executing 9631cdaa2b06e775
+@elizaos/example-rest-api-express:typecheck: $ tsgo --noEmit
+eliza-react-example:typecheck: cache miss, executing 4c7f6dd1a3777c4c
+eliza-react-example:typecheck: $ tsgo --noEmit
+@elizaos/example-rest-api-elysia:typecheck: cache miss, executing ceb6af7aff3d2326
+@elizaos/example-rest-api-elysia:typecheck: $ tsgo --noEmit
+@elizaos/example-a2a-server:typecheck: cache miss, executing 3cdf60092a34b10b
+@elizaos/example-a2a-server:typecheck: $ tsgo --noEmit
+@elizaos/plugin-local-inference:build: cache miss, executing ea980ccd4f1a4e91
+@elizaos/plugin-local-inference:build: $ bun run build.ts
+@elizaos/plugin-local-inference:build: 🔨 Building @elizaos/plugin-local-inference...
+@elizaos/plugin-local-inference:build: 📝 Generating TypeScript declarations...
+@elizaos/plugin-agent-orchestrator:build: 🎉 @elizaos/plugin-agent-orchestrator build finished in 11.44s
+@elizaos/plugin-registry:build: [rewrite-dist-relative-imports] rewrote 1 file(s)
+@elizaos/plugin-app-manager:build: cache miss, executing ef43825e83887543
+@elizaos/plugin-app-manager:build: $ bun run build.ts
+@elizaos/plugin-app-manager:build: 🔨 Building @elizaos/plugin-app-manager (Node)…
+@elizaos/plugin-app-manager:build: ✅ Node complete in 0.01s
+@elizaos/plugin-app-manager:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-wallet:build: 🎉 @elizaos/plugin-wallet build finished in 55.44s
+@elizaos/example-trader-ts:typecheck: cache miss, executing 2866971d3dab8b8d
+@elizaos/example-trader-ts:typecheck: $ tsgo --noEmit
+@elizaos/plugin-app-manager:build: 🔧 Rewriting dist relative imports for NodeNext…
+@elizaos/plugin-app-manager:build: [rewrite-dist-relative-imports] rewrote 1 file(s)
+@elizaos/plugin-app-manager:build: 🎉 @elizaos/plugin-app-manager build finished in 36.63s
+@elizaos/example-form:lint: cache miss, executing b8784555947e8ded
+@elizaos/example-browser-extension:lint: cache miss, executing bfba342204855efc
+@elizaos/example-mcp-server:lint: cache miss, executing 43b2226084d0ccd2
+elizagotchi:lint: cache miss, executing 82a157afabc767de
+@elizaos/plugin-web-search:lint: cache miss, executing 5968b451e52e3744
+@elizaos/plugin-local-inference:lint: cache miss, executing b52ac2a80f88144c
+@elizaos/example-form:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-mcp-server:lint: $ bunx @biomejs/biome check --write --unsafe .
+elizagotchi:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-local-inference:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-web-search:lint: $ bunx @biomejs/biome check src/
+@elizaos/example-browser-extension:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-form:lint: Checked 1 file in 188ms. No fixes applied.
+@elizaos/example-mcp-server:lint: Checked 4 files in 249ms. No fixes applied.
+@elizaos/plugin-web-search:lint: Checked 6 files in 253ms. No fixes applied.
+@elizaos/plugin-streaming:lint: cache miss, executing df444dff252c0816
+@elizaos/plugin-local-storage:lint: cache miss, executing dd55b3b37dce92ca
+@elizaos/plugin-streaming:lint: $ bunx @biomejs/biome check --write --unsafe src
+@elizaos/plugin-feishu:lint: cache miss, executing 9dca9792e0bd1b87
+elizagotchi:lint: Checked 18 files in 345ms. No fixes applied.
+@elizaos/plugin-local-storage:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-feishu:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-anthropic:lint: cache miss, executing 50a3d6a8eb10877b
+@elizaos/plugin-anthropic:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-browser-extension:lint: Checked 26 files in 569ms. No fixes applied.
+@elizaos/example-tic-tac-toe:lint: cache miss, executing 38b608679d24c51d
+@elizaos/example-tic-tac-toe:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-streaming:lint: Checked 12 files in 469ms. No fixes applied.
+@elizaos/plugin-feishu:lint: Checked 20 files in 225ms. No fixes applied.
+@elizaos/plugin-local-storage:lint: Checked 8 files in 157ms. No fixes applied.
+@elizaos/capacitor-gateway:lint: cache miss, executing ca2287320ed54349
+@elizaos/example-app-electron:lint: cache miss, executing e5fc103c1a94524f
+@elizaos/capacitor-gateway:lint: $ bunx @biomejs/biome check . && bash -c 'if command -v swiftlint >/dev/null 2>&1; then bun run swiftlint -- lint; fi'
+@elizaos/plugin-suno:lint: cache miss, executing ac998b962f560588
+@elizaos/example-app-electron:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-suno:lint: $ bunx @biomejs/biome check .
+@elizaos/plugin-anthropic:lint: Checked 22 files in 199ms. No fixes applied.
+@elizaos/example-tic-tac-toe:lint: Checked 3 files in 137ms. No fixes applied.
+@elizaos/plugin-cloud-apps:lint: cache miss, executing c74909e314e2787c
+@elizaos/plugin-tee:lint: cache miss, executing 2950ce54e1fe3617
+@elizaos/plugin-cloud-apps:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-tee:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-suno:lint: Checked 13 files in 119ms. No fixes applied.
+@elizaos/plugin-mcp:lint: cache miss, executing 3d790a6af3a5a471
+@elizaos/capacitor-gateway:lint: Checked 7 files in 103ms. No fixes applied.
+@elizaos/plugin-mcp:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-app-electron:lint: Checked 9 files in 190ms. No fixes applied.
+@elizaos/plugin-social-alpha:lint: cache miss, executing 3c4734331ecb1b55
+@elizaos/example-app-capacitor-frontend:lint: cache miss, executing 3650d44bfb3941f5
+@elizaos/plugin-social-alpha:lint: $ bunx @biomejs/biome check src
+@elizaos/example-app-capacitor-frontend:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-tee:lint: Checked 22 files in 176ms. No fixes applied.
+@elizaos/plugin-telegram:lint: cache miss, executing b78e1df8f9dcb214
+@elizaos/plugin-telegram:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-cloud-apps:lint: Checked 36 files in 324ms. No fixes applied.
+@elizaos/gateway-discord:lint: cache miss, executing 864adf62a8566eb0
+@elizaos/gateway-discord:lint: $ bunx @biomejs/biome check .
+@elizaos/plugin-mcp:lint: Checked 45 files in 192ms. No fixes applied.
+@elizaos/vercel-edge-examples:lint: cache miss, executing 37a258d5b3490fd9
+@elizaos/vercel-edge-examples:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-app-capacitor-frontend:lint: Checked 11 files in 209ms. No fixes applied.
+@elizaos/plugin-social-alpha:lint: Checked 33 files in 284ms. No fixes applied.
+@elizaos/plugin-farcaster:lint: cache miss, executing e49396226e341fe1
+@elizaos/plugin-farcaster:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-tailscale:lint: cache miss, executing bb22d9764095f401
+@elizaos/plugin-tailscale:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-local-inference:build: ✅ Build complete in 44.25s
+@elizaos/plugin-starter:lint: cache miss, executing a0d2e5241a6b00a5
+@elizaos/plugin-starter:lint: $ bunx @biomejs/biome check --write --unsafe ./src
+@elizaos/gateway-discord:lint: Checked 13 files in 446ms. No fixes applied.
+@elizaos/plugin-finances:lint: cache miss, executing 539dcd8cfbe2d5c3
+@elizaos/vercel-edge-examples:lint: Checked 6 files in 247ms. No fixes applied.
+@elizaos/plugin-finances:lint: $ bunx @biomejs/biome check src/
+@elizaos/example-browser-extension-safari:lint: cache miss, executing c504fded4b3fb323
+@elizaos/example-browser-extension-safari:lint: $ node scripts/fix-generated-safari.mjs && bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-starter:lint: Checked 9 files in 216ms. No fixes applied.
+@elizaos/example-chat:lint: cache miss, executing 35992fce383e5645
+@elizaos/example-chat:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-farcaster:lint: Checked 39 files in 370ms. No fixes applied.
+@elizaos/plugin-local-inference:lint: Checked 424 files in 3s. No fixes applied.
+@elizaos/skills:lint: cache miss, executing 4e5a8e3386c86bed
+@elizaos/skills:lint: $ bunx @biomejs/biome check --write ./src
+@elizaos/plugin-tailscale:lint: Checked 19 files in 264ms. No fixes applied.
+@elizaos/plugin-background-runner:lint: cache miss, executing a04bc4d0e9d60063
+@elizaos/app:lint: cache miss, executing f4856bfb18a8d213
+@elizaos/plugin-background-runner:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/app:lint: $ bunx @biomejs/biome check src scripts vite.config.ts vitest.config.ts vitest.e2e.config.ts playwright.dev-smoke.config.ts playwright.ui-smoke.config.ts playwright.ui-packaged.config.ts playwright.electrobun.packaged.config.ts playwright.web-views.config.ts playwright.android.config.ts test/android package.json capacitor.config.ts
+@elizaos/example-chat:lint: Checked 4 files in 245ms. No fixes applied.
+@elizaos/plugin-finances:lint: Checked 34 files in 529ms. No fixes applied.
+@elizaos/plugin-pdf:lint: cache miss, executing 34cab46f928afb4b
+@elizaos/plugin-pdf:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-inmemorydb:lint: cache miss, executing a709ee2e55353cbe
+@elizaos/plugin-inmemorydb:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-browser-extension-safari:lint: Checked 5 files in 195ms. No fixes applied.
+@elizaos/plugin-telegram:lint: Checked 40 files in 1762ms. No fixes applied.
+@elizaos/plugin-discord:lint: cache miss, executing 2d8ac903b01e3c2c
+@elizaos/plugin-feed:lint: cache miss, executing 34e016d58f69f3dc
+@elizaos/plugin-discord:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-feed:lint: $ bunx @biomejs/biome check src
+@elizaos/plugin-background-runner:lint: Checked 8 files in 157ms. No fixes applied.
+@elizaos/skills:lint: Checked 6 files in 312ms. No fixes applied.
+@elizaos/plugin-x:lint: cache miss, executing 2b01570cecac6d99
+@elizaos/plugin-x:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-nearai:lint: cache miss, executing a2e2f505f24dbb0e
+@elizaos/plugin-nearai:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-pdf:lint: Checked 8 files in 273ms. No fixes applied.
+@elizaos/plugin-inbox:lint: cache miss, executing b1089c747453d7bf
+@elizaos/plugin-inbox:lint: $ bunx @biomejs/biome check src/
+@elizaos/plugin-feed:lint: Checked 16 files in 289ms. No fixes applied.
+@elizaos/app:lint: Checked 120 files in 1301ms. No fixes applied.
+@elizaos/example-rest-api-hono:lint: cache miss, executing 6a377b0efcae315f
+@elizaos/ui:lint: cache miss, executing 7391d46708d81449
+@elizaos/ui:lint: $ bunx @biomejs/biome check src
+@elizaos/example-rest-api-hono:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-nearai:lint: Checked 17 files in 277ms. No fixes applied.
+@elizaos/gcp-examples:lint: cache miss, executing 1771dcf7ab0ade65
+@elizaos/gcp-examples:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-inbox:lint: Checked 34 files in 445ms. No fixes applied.
+@elizaos/plugin-inmemorydb:lint: Checked 17 files in 1281ms. No fixes applied.
+@elizaos/example-bluesky:lint: cache miss, executing a9c49627adfc45fc
+@elizaos/plugin-relationships:lint: cache miss, executing eaebaa4fca4065cd
+@elizaos/example-bluesky:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-relationships:lint: $ bunx @biomejs/biome check src/
+@elizaos/example-rest-api-hono:lint: Checked 4 files in 188ms. No fixes applied.
+@elizaos/plugin-ollama:lint: cache miss, executing b1ee7727bec643c8
+@elizaos/gcp-examples:lint: Checked 4 files in 197ms. No fixes applied.
+@elizaos/plugin-ollama:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-remote-desktop:lint: cache miss, executing 3b416166bf639314
+@elizaos/plugin-remote-desktop:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-x:lint: Checked 73 files in 1212ms. No fixes applied.
+@elizaos/cloud-routing:lint: cache miss, executing fe9ac84f48621cd5
+@elizaos/cloud-routing:lint: $ bunx @biomejs/biome check src
+@elizaos/example-bluesky:lint: Checked 6 files in 167ms. No fixes applied.
+@elizaos/plugin-todos:lint: cache miss, executing 4dbc8ec686efa8be
+@elizaos/plugin-todos:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-relationships:lint: Checked 15 files in 284ms. No fixes applied.
+@elizaos/plugin-linear:lint: cache miss, executing 269f55336052d103
+@elizaos/plugin-linear:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-remote-desktop:lint: Checked 12 files in 354ms. No fixes applied.
+@elizaos/plugin-blocker:lint: cache miss, executing 57e5cd10030ebe15
+@elizaos/plugin-ollama:lint: Checked 28 files in 312ms. No fixes applied.
+@elizaos/plugin-blocker:lint: $ bunx @biomejs/biome check src/
+@elizaos/plugin-phone:lint: cache miss, executing 94cbc402f0bfbaad
+@elizaos/plugin-phone:lint: $ bunx @biomejs/biome check src
+@elizaos/plugin-discord:lint: Checked 87 files in 2s. No fixes applied.
+@elizaos/plugin-instagram:lint: cache miss, executing 7d60ea5ef28e3376
+@elizaos/plugin-instagram:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/cloud-routing:lint: Checked 5 files in 129ms. No fixes applied.
+@elizaos/cloud-api:lint: cache miss, executing ed8bba57c444f92d
+@elizaos/cloud-api:lint: $ bunx @biomejs/biome check .
+@elizaos/plugin-linear:lint: Checked 37 files in 398ms. No fixes applied.
+@elizaos/plugin-tunnel:lint: cache miss, executing 0d6ed165f1a3169f
+@elizaos/plugin-tunnel:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-blocker:lint: Checked 27 files in 405ms. No fixes applied.
+@elizaos/plugin-todos:lint: Checked 24 files in 651ms. No fixes applied.
+@elizaos/example-lp-manager:lint: cache miss, executing 29b49178b9e75e33
+@elizaos/example-clone-ur-crush:lint: cache miss, executing 884d6869f82b18d6
+@elizaos/example-lp-manager:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-clone-ur-crush:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-phone:lint: Checked 40 files in 335ms. No fixes applied.
+@elizaos/agent-server:lint: cache miss, executing 569d5ce2391d71bf
+@elizaos/agent-server:lint: $ bunx @biomejs/biome check .
+@elizaos/plugin-instagram:lint: Checked 21 files in 570ms. No fixes applied.
+@elizaos/example-app-electron-workspace:lint: cache miss, executing 564806911850fa7a
+@elizaos/example-app-electron-workspace:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-tunnel:lint: Checked 11 files in 259ms. No fixes applied.
+@elizaos/plugin-slack:lint: cache miss, executing 1c9a1b5ba88ff5aa
+@elizaos/plugin-slack:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-lp-manager:lint: Checked 8 files in 508ms. No fixes applied.
+@elizaos/robot:lint: cache miss, executing ce81030a2159f599
+@elizaos/robot:lint: $ bunx @biomejs/biome check --write ./src
+@elizaos/agent-server:lint: Checked 13 files in 181ms. No fixes applied.
+@elizaos/example-clone-ur-crush:lint: Checked 22 files in 550ms. No fixes applied.
+@elizaos/plugin-matrix:lint: cache miss, executing 6b83f6e7bbb446f1
+@elizaos/example-game-of-life:lint: cache miss, executing 9d2fc91e47fd8659
+@elizaos/example-game-of-life:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-matrix:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/robot:lint: Checked 2 files in 190ms. No fixes applied.
+@elizaos/plugin-sub-agent-claude-code:lint: cache miss, executing 2cfaa7dc19836d51
+@elizaos/plugin-sub-agent-claude-code:lint: $ bunx @biomejs/biome check src
+@elizaos/example-app-electron-workspace:lint: Checked 22 files in 556ms. No fixes applied.
+@elizaos/plugin-groq:lint: cache miss, executing f018dd01d9963c5f
+@elizaos/plugin-groq:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-game-of-life:lint: Checked 3 files in 361ms. No fixes applied.
+@elizaos/logger:lint: cache miss, executing 8c564150171e8c14
+@elizaos/logger:lint: $ find src -name '*.ts' ! -name '*.d.ts' -print0 | xargs -0 bunx @biomejs/biome check
+@elizaos/plugin-matrix:lint: Checked 20 files in 731ms. No fixes applied.
+@elizaos/example-rest-api-elysia:lint: cache miss, executing 3a4e0fa294a54736
+@elizaos/example-rest-api-elysia:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-sub-agent-claude-code:lint: Checked 5 files in 184ms. No fixes applied.
+@elizaos/example-text-adventure:lint: cache miss, executing 008220c2d6cba695
+@elizaos/plugin-groq:lint: Checked 11 files in 221ms. No fixes applied.
+@elizaos/example-text-adventure:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-discord-local:lint: cache miss, executing f452dd00adac15f6
+@elizaos/plugin-discord-local:lint: $ bunx @biomejs/biome check --write --config-path ./biome.json .
+@elizaos/plugin-slack:lint: Checked 21 files in 1437ms. No fixes applied.
+@elizaos/capacitor-mobile-agent-bridge:lint: cache miss, executing d17cb94085130d2c
+@elizaos/example-rest-api-elysia:lint: Checked 4 files in 147ms. No fixes applied.
+@elizaos/capacitor-mobile-agent-bridge:lint: $ bunx @biomejs/biome check .
+@elizaos/logger:lint: Checked 4 files in 149ms. No fixes applied.
+@elizaos/example-text-adventure:lint: Checked 4 files in 166ms. No fixes applied.
+@elizaos/example-a2a-server:lint: cache miss, executing fb700a4cd6748e23
+@elizaos/example-a2a-server:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-openai:lint: cache miss, executing 7e79e4102a7e9431
+@elizaos/plugin-openai:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-imessage:lint: cache miss, executing f8274d0dc944e3cd
+@elizaos/plugin-imessage:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/capacitor-mobile-agent-bridge:lint: Checked 4 files in 138ms. No fixes applied.
+@elizaos/plugin-discord-local:lint: Checked 7 files in 638ms. No fixes applied.
+@elizaos/plugin-xai:lint: cache miss, executing bab76b2b8173d115
+@elizaos/plugin-xai:lint: $ bunx @biomejs/biome check .
+@elizaos/example-discord:lint: cache miss, executing 4517b68c115c94a6
+@elizaos/example-discord:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-a2a-server:lint: Checked 5 files in 235ms. No fixes applied.
+@elizaos/app-core:lint: cache miss, executing 7ded65867f65225a
+@elizaos/app-core:lint: $ bunx @biomejs/biome check src
+@elizaos/cloud-api:lint: Checked 740 files in 3s. No fixes applied.
+@elizaos/plugin-openai:lint: models/text.ts:1015:3 suppressions/unused ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+@elizaos/plugin-openai:lint:
+@elizaos/plugin-openai:lint:   ! Suppression comment has no effect. Remove the suppression or make sure you are suppressing the correct rule.
+@elizaos/plugin-openai:lint: Checked 35 files in 538ms. No fixes applied.
+@elizaos/plugin-openai:lint: Found 1 warning.
+@elizaos/plugin-openai:lint:
+@elizaos/plugin-openai:lint:     1013 │ ): Promise<Awaited<ReturnType<typeof generateText<ToolSet>>>> {
+@elizaos/plugin-openai:lint:     1014 │   let attempt = 0;
+@elizaos/plugin-openai:lint:   > 1015 │   // biome-ignore lint/suspicious/noExplicitAny: AI SDK's generateText overloads can't infer our NativeGenerateTextParams across the generic boundary.
+@elizaos/plugin-openai:lint:          │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+@elizaos/plugin-openai:lint:     1016 │   for (;;) {
+@elizaos/plugin-openai:lint:     1017 │     try {
+@elizaos/plugin-openai:lint:
+@elizaos/plugin-openai:lint:
+@elizaos/contracts:lint: cache miss, executing 5dd10a7f809e01bc
+@elizaos/example-autonomous:lint: cache miss, executing c9335b6556313ab0
+@elizaos/example-autonomous:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/contracts:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-xai:lint: Checked 14 files in 205ms. No fixes applied.
+@elizaos/plugin-wallet:lint: cache miss, executing 7b167c3dc87a9899
+@elizaos/plugin-wallet:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-discord:lint: Checked 5 files in 100ms. No fixes applied.
+@elizaos/example-app-capacitor-backend:lint: cache miss, executing 77dd20db4a5913c6
+@elizaos/example-app-capacitor-backend:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-imessage:lint: Checked 22 files in 1014ms. No fixes applied.
+@elizaos/plugin-workflow:lint: cache miss, executing 5ff1e304f4fd8158
+@elizaos/plugin-workflow:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-autonomous:lint: Checked 6 files in 316ms. No fixes applied.
+@elizaos/contracts:lint: Checked 9 files in 206ms. No fixes applied.
+@elizaos/plugin-scheduling:lint: cache miss, executing 0672fb3584ec7fc7
+@elizaos/shared:lint: cache miss, executing 153170d110e12386
+@elizaos/plugin-scheduling:lint: $ bunx @biomejs/biome check src/
+@elizaos/shared:lint: $ bunx @biomejs/biome check src
+@elizaos/example-app-capacitor-backend:lint: Checked 6 files in 225ms. No fixes applied.
+@elizaos/example-smartglasses:lint: cache miss, executing 82ac30593a4fd8f2
+@elizaos/example-smartglasses:lint: $ bunx @biomejs/biome check .
+@elizaos/app-core:lint: Checked 301 files in 1406ms. No fixes applied.
+@elizaos/plugin-whatsapp:lint: cache miss, executing 7d73db014a867471
+@elizaos/plugin-whatsapp:lint: $ bunx @biomejs/biome check --write --config-path ./biome.json .
+@elizaos/example-smartglasses:lint: Checked 23 files in 577ms. No fixes applied.
+@elizaos/cloud-shared:lint: cache miss, executing 98867b0dd7b31bc7
+@elizaos/cloud-shared:lint: $ bunx @biomejs/biome check .
+@elizaos/plugin-scheduling:lint: Checked 31 files in 717ms. No fixes applied.
+eliza-app:lint: cache miss, executing 3360fea60035ab7b
+eliza-app:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-whatsapp:lint: Checked 32 files in 1150ms. No fixes applied.
+@elizaos/plugin-bluesky:lint: cache miss, executing 0bb2d8b0160fb24b
+@elizaos/plugin-bluesky:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-workflow:lint: Checked 97 files in 2s. No fixes applied.
+@elizaos/plugin-twitch:lint: cache miss, executing 426595c500081692
+@elizaos/plugin-twitch:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/ui:lint: Checked 2204 files in 9s. No fixes applied.
+@elizaos/plugin-wallet:lint: Checked 224 files in 3s. No fixes applied.
+@elizaos/plugin-bluesky:lint: Checked 20 files in 228ms. No fixes applied.
+@elizaos/plugin-commands:lint: cache miss, executing c328be3da47d74b3
+@elizaos/plugin-commands:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-app-capacitor:lint: cache miss, executing 8f286fe3043f1573
+@elizaos/plugin-native-settings:lint: cache miss, executing e5b2098f723fc0c7
+@elizaos/example-app-capacitor:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-native-settings:lint: $ bunx @biomejs/biome check src
+eliza-app:lint: Checked 64 files in 1544ms. No fixes applied.
+@elizaos/plugin-coding-tools:lint: cache miss, executing 034dcad6af948610
+@elizaos/plugin-coding-tools:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/shared:lint: Checked 293 files in 3s. No fixes applied.
+@elizaos/plugin-xr:lint: cache miss, executing d80a1759c01cb8dc
+@elizaos/plugin-xr:lint: $ bunx @biomejs/biome check src
+@elizaos/plugin-commands:lint: Checked 29 files in 229ms. No fixes applied.
+@elizaos/plugin-twitch:lint: Checked 12 files in 469ms. No fixes applied.
+@elizaos/plugin-wifi:lint: cache miss, executing cf27049bd3abf50d
+@elizaos/plugin-cli:lint: cache miss, executing 59d5e9f35200a076
+@elizaos/plugin-wifi:lint: $ bunx @biomejs/biome check src
+@elizaos/plugin-cli:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-native-settings:lint: Checked 10 files in 270ms. No fixes applied.
+@elizaos/plugin-bluebubbles:lint: cache miss, executing 37bb376889761ae4
+@elizaos/plugin-bluebubbles:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-app-capacitor:lint: Checked 20 files in 656ms. No fixes applied.
+@elizaos/example-app-electron-renderer:lint: cache miss, executing 166fb7f7c9ed4795
+@elizaos/example-app-electron-renderer:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-xr:lint: Checked 22 files in 324ms. No fixes applied.
+@elizaos/plugin-worker-runtime:lint: cache miss, executing 993606a0c36705a4
+@elizaos/plugin-worker-runtime:lint: $ bunx @biomejs/biome check src
+@elizaos/plugin-cli:lint: Checked 8 files in 202ms. No fixes applied.
+@elizaos/plugin-wifi:lint: Checked 12 files in 387ms. No fixes applied.
+eliza-multichain-miniapp:lint: cache miss, executing ad2615923c42c43f
+@elizaos/plugin-agent-orchestrator:lint: cache miss, executing b0d355ba5227712b
+eliza-multichain-miniapp:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-agent-orchestrator:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-bluebubbles:lint: Checked 20 files in 694ms. No fixes applied.
+elizaos-plugin-echo:lint: cache miss, executing 4ddeb1a24ab86471
+elizaos-plugin-echo:lint: $ bunx @biomejs/biome check src
+@elizaos/plugin-worker-runtime:lint: Checked 7 files in 121ms. No fixes applied.
+@elizaos/plugin-coding-tools:lint: Checked 55 files in 1179ms. No fixes applied.
+@elizaos/plugin-elizacloud:lint: cache miss, executing 1833921a9ecd4f58
+@elizaos/plugin-line:lint: cache miss, executing d389e12fb263ceed
+@elizaos/plugin-elizacloud:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-line:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-app-electron-renderer:lint: Checked 11 files in 412ms. No fixes applied.
+eliza-multichain-miniapp:lint: Checked 17 files in 223ms. No fixes applied.
+@elizaos/plugin-vision:lint: cache miss, executing c1b5540a676e5aef
+@elizaos/plugin-vision:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-reminders:lint: cache miss, executing 38bcb2993e464159
+@elizaos/plugin-reminders:lint: $ bunx @biomejs/biome check src/
+elizaos-plugin-echo:lint: Checked 3 files in 156ms. No fixes applied.
+@elizaos/example-browser-extension-chrome:lint: cache miss, executing 2b0df5a84d65bc42
+@elizaos/example-browser-extension-chrome:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-reminders:lint: Checked 6 files in 172ms. No fixes applied.
+@elizaos/plugin-google-chat:lint: cache miss, executing d349f10d136e019b
+@elizaos/plugin-google-chat:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-browser-extension-chrome:lint: Checked 17 files in 197ms. No fixes applied.
+@elizaos/plugin-line:lint: Checked 15 files in 191ms. No fixes applied.
+@elizaos/plugin-elizacloud:lint: Checked 33 files in 368ms. No fixes applied.
+@elizaos/plugin-gitpathologist:lint: cache miss, executing ab3f78cdc1120ce9
+@elizaos/plugin-x402:lint: cache miss, executing a7b8747a7ef15c75
+@elizaos/plugin-x402:lint: $ bun run typecheck
+@elizaos/plugin-gitpathologist:lint: $ bunx @biomejs/biome check --write --unsafe .
+elizaos-cloudflare-worker:lint: cache miss, executing 7aefc40721f54cae
+@elizaos/plugin-x402:lint: $ tsgo --noEmit
+elizaos-cloudflare-worker:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/cloud-shared:lint: Checked 1238 files in 4s. No fixes applied.
+@elizaos/cloud-sdk:lint: cache miss, executing 4dfa5a1e3b5badb4
+@elizaos/cloud-sdk:lint: $ bunx @biomejs/biome check .
+@elizaos/plugin-gitpathologist:lint: Checked 28 files in 188ms. No fixes applied.
+@elizaos/plugin-contacts:lint: cache miss, executing b2bbe6f5963cbdef
+@elizaos/plugin-google-chat:lint: Checked 13 files in 531ms. No fixes applied.
+@elizaos/plugin-contacts:lint: $ bunx @biomejs/biome check src/
+@elizaos/setup:lint: cache miss, executing 0311a5b58cd32360
+elizaos-cloudflare-worker:lint: Checked 4 files in 161ms. No fixes applied.
+@elizaos/setup:lint: $ bunx @biomejs/biome check src vite.config.ts vitest.config.ts
+@elizaos/example-xai-x:lint: cache miss, executing 55cb85c5c448222e
+@elizaos/example-xai-x:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-vision:lint: Checked 104 files in 1277ms. No fixes applied.
+@elizaos/plugin-ngrok:lint: cache miss, executing eff1a9a9df398e85
+@elizaos/plugin-ngrok:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-contacts:lint: Checked 19 files in 89ms. No fixes applied.
+@elizaos/plugin-agent-skills:lint: cache miss, executing 9c3a22d409a7b370
+@elizaos/plugin-agent-skills:lint: $ bunx @biomejs/biome check --write --unsafe --config-path ./biome.json .
+@elizaos/example-xai-x:lint: Checked 5 files in 130ms. No fixes applied.
+@elizaos/plugin-zai:lint: cache miss, executing 0c26cac473f2c1fb
+@elizaos/plugin-zai:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/setup:lint: Checked 28 files in 229ms. No fixes applied.
+@elizaos/plugin-aosp-local-inference:lint: cache miss, executing ddf031ab02fe2ca2
+@elizaos/plugin-ngrok:lint: Checked 13 files in 92ms. No fixes applied.
+@elizaos/plugin-aosp-local-inference:lint: $ bunx @biomejs/biome check --write --unsafe .
+elizaos:lint: cache miss, executing e41da6641fad8895
+elizaos:lint: $ bunx @biomejs/biome check --write README.md build.ts package.json scripts src templates-manifest.json templates/min-plugin templates/min-project templates/project/.env.example templates/project/.gitignore templates/project/README.md templates/project/bunfig.toml templates/project/package.json templates/project/scripts templates/project/template.json templates/project/test tsconfig.json vitest.config.ts && cd templates/plugin && bunx @biomejs/biome check --write --unsafe . --config-path ./biome.json --vcs-enabled=false && cd ../project/apps/app && bunx @biomejs/biome check --write --unsafe . --config-path ./biome.json --vcs-enabled=false
+@elizaos/plugin-zai:lint: Checked 18 files in 74ms. No fixes applied.
+@elizaos/plugin-messages:lint: cache miss, executing c4e3b9ead60b2c18
+@elizaos/plugin-messages:lint: $ bunx @biomejs/biome check src
+@elizaos/cloud-sdk:lint: Checked 29 files in 931ms. No fixes applied.
+@elizaos/example-convex:lint: cache miss, executing fbadea30bea0a07a
+@elizaos/example-convex:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-agent-skills:lint: Checked 39 files in 314ms. No fixes applied.
+@elizaos/plugin-ainex:lint: cache miss, executing 61b922cce01f3156
+@elizaos/plugin-ainex:lint: $ bunx @biomejs/biome check --write --unsafe .
+elizaos:lint: Checked 40 files in 300ms. No fixes applied.
+@elizaos/plugin-messages:lint: Checked 15 files in 61ms. No fixes applied.
+@elizaos/plugin-shell:lint: cache miss, executing 13581bbc867b2b08
+@elizaos/plugin-shell:lint: $ bunx @biomejs/biome check .
+@elizaos/example-convex:lint: Checked 11 files in 108ms. No fixes applied.
+@elizaos/example-trader-ts:lint: cache miss, executing 54e7e56f425f3e5c
+@elizaos/example-trader-ts:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-ainex:lint: Checked 37 files in 196ms. No fixes applied.
+@elizaos/plugin-capacitor-bridge:lint: cache miss, executing f07b571159b91593
+elizaos:lint: Checked 11 files in 28ms. No fixes applied.
+@elizaos/plugin-capacitor-bridge:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-aosp-local-inference:lint: Checked 12 files in 582ms. No fixes applied.
+@elizaos/plugin-nostr:lint: cache miss, executing 0e5306761fe03699
+@elizaos/plugin-nostr:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-trader-ts:lint: Checked 18 files in 102ms. No fixes applied.
+@elizaos/plugin-shell:lint: Checked 37 files in 125ms. No fixes applied.
+@elizaos/plugin-openrouter:lint: cache miss, executing 5dd14ecf40e4869d
+@elizaos/plugin-openrouter:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/bench-eliza-1:lint: cache miss, executing 20281e1a465ed9d6
+@elizaos/bench-eliza-1:lint: $ bunx @biomejs/biome check .
+@elizaos/plugin-agent-orchestrator:lint: Checked 242 files in 3s. No fixes applied.
+@elizaos/plugin-benchmarks:lint: cache miss, executing 46c9612b0e0fb899
+@elizaos/plugin-benchmarks:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-trajectory-logger:lint: cache miss, executing ede9090f93d92d0a
+@elizaos/plugin-trajectory-logger:lint: $ bunx @biomejs/biome check src
+elizaos:lint: Checked 63 files in 286ms. No fixes applied.
+trajectory-viewer:lint: cache miss, executing e9ff93c922a7a475
+@elizaos/plugin-openrouter:lint: Checked 30 files in 126ms. No fixes applied.
+trajectory-viewer:lint: $ bunx @biomejs/biome check --write --unsafe src package.json --vcs-enabled=false
+@elizaos/example-rest-api-express:lint: cache miss, executing 7bbaadc6f8acb5c8
+@elizaos/example-rest-api-express:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-nostr:lint: Checked 17 files in 285ms. No fixes applied.
+@elizaos/bench-eliza-1:lint: Checked 42 files in 155ms. No fixes applied.
+@elizaos/plugin-google-genai:lint: cache miss, executing f126354e729a98b6
+@elizaos/app-model-tester:lint: cache miss, executing 1a0577ad41ed1582
+@elizaos/plugin-benchmarks:lint: Checked 14 files in 59ms. No fixes applied.
+@elizaos/plugin-google-genai:lint: $ bunx @biomejs/biome check --write --unsafe build.ts index.ts index.browser.ts index.node.ts init.ts __tests__ generated models types utils
+@elizaos/app-model-tester:lint: $ bunx @biomejs/biome check src
+@elizaos/plugin-google:lint: cache miss, executing 06307a88c8f13863
+@elizaos/plugin-google:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-trajectory-logger:lint: Checked 18 files in 89ms. No fixes applied.
+@elizaos/plugin-sql:lint: cache miss, executing 8e46c7faaa8cdde4
+@elizaos/plugin-sql:lint: $ cd src && bun run lint
+@elizaos/plugin-sql:lint: $ bunx @biomejs/biome check --write --config-path ./biome.json .
+trajectory-viewer:lint: Checked 12 files in 54ms. No fixes applied.
+@elizaos/container-control-plane:lint: cache miss, executing f6d3aceee46ec4b8
+@elizaos/example-rest-api-express:lint: Checked 4 files in 52ms. No fixes applied.
+@elizaos/container-control-plane:lint: $ bunx @biomejs/biome check .
+@elizaos/plugin-codex-cli:lint: cache miss, executing 55cd51166a7cef4d
+@elizaos/plugin-codex-cli:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-google-genai:lint: Checked 21 files in 148ms. No fixes applied.
+@elizaos/app-model-tester:lint: Checked 19 files in 136ms. No fixes applied.
+@elizaos/core:lint: cache miss, executing 0523c903f5f7f333
+eliza-react-example:lint: cache miss, executing 63636d237e6e2400
+@elizaos/core:lint: $ bunx @biomejs/biome check --write ./src
+@elizaos/plugin-google:lint: Checked 18 files in 148ms. No fixes applied.
+eliza-react-example:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-health:lint: cache miss, executing 3eed94e15a45de77
+@elizaos/plugin-capacitor-bridge:lint: Checked 24 files in 669ms. No fixes applied.
+@elizaos/plugin-health:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/operator:lint: cache miss, executing 50e0551db97a8a9b
+@elizaos/operator:lint: $ bunx @biomejs/biome check .
+@elizaos/container-control-plane:lint: Checked 3 files in 113ms. No fixes applied.
+@elizaos/plugin-goals:lint: cache miss, executing f1b2a943743722b5
+@elizaos/plugin-goals:lint: $ bunx @biomejs/biome check src/
+@elizaos/plugin-codex-cli:lint: Checked 5 files in 115ms. No fixes applied.
+@elizaos/plugin-elevenlabs:lint: cache miss, executing 333766f94aff5fb4
+@elizaos/plugin-elevenlabs:lint: $ bunx @biomejs/biome check --write --unsafe .
+eliza-react-example:lint: Checked 15 files in 196ms. No fixes applied.
+@moltbook/eliza-agent:lint: cache miss, executing ee02b5429388c0b7
+@elizaos/operator:lint: Checked 14 files in 99ms. No fixes applied.
+@moltbook/eliza-agent:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/os-usb-installer:lint: cache miss, executing 78840f0ecf8f45ac
+@elizaos/os-usb-installer:lint: $ bunx @biomejs/biome check src tests server.ts vite.config.ts vitest.config.ts playwright.config.ts
+@elizaos/plugin-goals:lint: Checked 24 files in 272ms. No fixes applied.
+@elizaos/plugin-edge-tts:lint: cache miss, executing b6ef9995ab073767
+@elizaos/plugin-edge-tts:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-elevenlabs:lint: Checked 9 files in 217ms. No fixes applied.
+@elizaos/cloud-services-common:lint: cache miss, executing a0f8012b32ac214f
+@elizaos/cloud-services-common:lint: $ bunx @biomejs/biome check .
+@moltbook/eliza-agent:lint: Checked 9 files in 149ms. No fixes applied.
+@elizaos/registry:lint: cache miss, executing 0ced5880e1efce18
+@elizaos/os-usb-installer:lint: Checked 33 files in 176ms. No fixes applied.
+@elizaos/registry:lint: $ bunx @biomejs/biome check src
+@elizaos/plugin-embeddings:lint: cache miss, executing bdaab792ed5e88a0
+@elizaos/plugin-embeddings:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-edge-tts:lint: Checked 10 files in 74ms. No fixes applied.
+@elizaos/plugin-app-control:lint: cache miss, executing 55e62e0facc189f5
+@elizaos/plugin-app-control:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/cloud-services-common:lint: Checked 5 files in 64ms. No fixes applied.
+@elizaos/plugin-facewear:lint: cache miss, executing c5f5b77c75757269
+@elizaos/plugin-facewear:lint: $ bunx @biomejs/biome check src
+@elizaos/plugin-embeddings:lint: Checked 20 files in 115ms. No fixes applied.
+@elizaos/registry:lint: Checked 57 files in 184ms. No fixes applied.
+bags-claimer:lint: cache miss, executing de7decd646f04b1f
+bags-claimer:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/electrobun:lint: cache miss, executing 321fade99394e93e
+@elizaos/electrobun:lint: $ bunx @biomejs/biome check $(find src -type f \( -name '*.ts' -o -name '*.tsx' \) ! -name '*.d.ts' -print)
+@elizaos/plugin-health:lint: Checked 113 files in 1305ms. No fixes applied.
+@elizaos/agent:lint: cache miss, executing 593c872b520071d1
+@elizaos/agent:lint: $ bunx @biomejs/biome check ./src/actions ./src/api ./src/auth ./src/awareness ./src/bin.ts ./src/cli ./src/config ./src/contracts ./src/diagnostics ./src/hooks ./src/index.ts ./src/providers ./src/runtime ./src/security ./src/services ./src/shared ./src/triggers ./src/utils ./src/version-resolver.ts
+bags-claimer:lint: Checked 3 files in 86ms. No fixes applied.
+@elizaos/plugin-localdb:lint: cache miss, executing d33092586865d7ba
+@elizaos/plugin-localdb:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-facewear:lint: Checked 83 files in 510ms. No fixes applied.
+@elizaos/example-telegram:lint: cache miss, executing f06d63a399f62d57
+@elizaos/plugin-sql:lint: Checked 178 files in 1948ms. No fixes applied.
+@elizaos/example-telegram:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/os-homepage:lint: cache miss, executing 2e5a2f264481e9b4
+@elizaos/os-homepage:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-localdb:lint: Checked 9 files in 94ms. No fixes applied.
+eliza-next-example:lint: cache miss, executing a3a6b70140cf37f3
+eliza-next-example:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-telegram:lint: Checked 5 files in 105ms. No fixes applied.
+@elizaos/plugin-signal:lint: cache miss, executing 06b4cd55ba1a89da
+@elizaos/plugin-app-control:lint: Checked 93 files in 1057ms. No fixes applied.
+@elizaos/plugin-signal:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-farcaster:lint: cache miss, executing 0a89b425acf4f872
+@elizaos/example-farcaster:lint: $ bunx @biomejs/biome check --write --unsafe .
+eliza-next-example:lint: Checked 18 files in 223ms. No fixes applied.
+@elizaos/os-homepage:lint: Checked 36 files in 384ms. No fixes applied.
+@elizaos/plugin-cli-inference:lint: cache miss, executing e9453806481423c5
+@elizaos/aws-examples:lint: cache miss, executing bfed842e4140dd1c
+@elizaos/plugin-cli-inference:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/aws-examples:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/electrobun:lint: Checked 190 files in 1050ms. No fixes applied.
+@elizaos/plugin-native-filesystem:lint: cache miss, executing 30c2d2d232225c40
+@elizaos/example-farcaster:lint: Checked 5 files in 83ms. No fixes applied.
+@elizaos/plugin-native-filesystem:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/three-agent-dialogue:lint: cache miss, executing 63016693b4f2b34b
+@elizaos/three-agent-dialogue:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-cli-inference:lint: Checked 15 files in 104ms. No fixes applied.
+@elizaos-examples/html-eliza:lint: cache miss, executing dd348355a4258f78
+@elizaos/aws-examples:lint: Checked 8 files in 82ms. No fixes applied.
+@elizaos-examples/html-eliza:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-lmstudio:lint: cache miss, executing 1446393164e202eb
+@elizaos/plugin-lmstudio:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos-examples/html-eliza:lint: Checked 3 files in 102ms. No fixes applied.
+@elizaos/gateway-webhook:lint: cache miss, executing 5ffa5f31ae706689
+@elizaos/plugin-native-filesystem:lint: Checked 13 files in 177ms. No fixes applied.
+@elizaos/plugin-lmstudio:lint: Checked 25 files in 140ms. No fixes applied.
+@elizaos/gateway-webhook:lint: $ bunx @biomejs/biome check .
+@elizaos/plugin-music:lint: cache miss, executing 6f4dc416e7c2e00b
+@elizaos/plugin-remote-manifest:lint: cache miss, executing 554b503d36389405
+@elizaos/plugin-music:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-signal:lint: Checked 23 files in 574ms. No fixes applied.
+@elizaos/plugin-remote-manifest:lint: $ bunx @biomejs/biome check src
+@elizaos/prompts:lint: cache miss, executing 2414f6c4a9a8abc3
+@elizaos/prompts:lint: $ bunx @biomejs/biome check --write .
+@elizaos/three-agent-dialogue:lint: Checked 13 files in 305ms. No fixes applied.
+@elizaos/gateway-webhook:lint: Checked 24 files in 271ms. No fixes applied.
+@elizaos/plugin-remote-manifest:lint: Checked 47 files in 327ms. No fixes applied.
+@elizaos/prompts:lint: Checked 12 files in 523ms. No fixes applied.
+@elizaos/plugin-music:lint: Checked 96 files in 914ms. No fixes applied.
+@elizaos/agent:lint: Checked 616 files in 2s. No fixes applied.
+@elizaos/core:lint: Checked 913 files in 4s. No fixes applied.
+@elizaos/ui:build: [rewrite-dist-relative-imports] rewrote 1618 file(s)
+@elizaos/ui:build: [verify-package-runtime-exports] verified 40 runtime export(s) for @elizaos/ui
+@elizaos/plugin-task-coordinator:build: cache miss, executing 59d1da6948f33264
+@elizaos/plugin-app-control:build: cache miss, executing ee3e3812f122b6f6
+@elizaos/plugin-health:build: cache miss, executing 82a880d9109e36d1
+@elizaos/plugin-contacts:typecheck: cache miss, executing 64f3e04bd004bcf2
+@elizaos/plugin-capacitor-bridge:typecheck: cache miss, executing 102720826410189a
+@elizaos/plugin-wifi:build: cache miss, executing cb12625d195c5ca1
+@elizaos/plugin-phone:build: cache miss, executing bddfde15df57225f
+@elizaos/plugin-contacts:build: cache miss, executing ec27abff8e55c6a0
+@elizaos/plugin-task-coordinator:build: $ bun run build:js && bun run build:views && bun run build:types
+@elizaos/plugin-phone:build: $ bun run build:js && bun run build:views && bun run build:types
+@elizaos/plugin-health:build: $ bun run build:js && bun run build:views && bun run build:types
+@elizaos/plugin-capacitor-bridge:typecheck: $ tsgo --noEmit
+@elizaos/plugin-app-control:build: $ node ../../packages/scripts/remove-source-build-artifacts.mjs src && tsup src/index.ts src/workers/app-worker-entry.ts --format esm --clean && tsc --declaration --emitDeclarationOnly --noEmit false --noCheck -p tsconfig.json && node ../../packages/scripts/flatten-tsc-package-output.mjs plugins/plugin-app-control && bun run build:views
+@elizaos/plugin-wifi:build: $ bun run build:js && bun run build:types
+@elizaos/plugin-contacts:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-phone:build: $ tsup --config ../tsup.plugin-packages.shared.ts
+@elizaos/plugin-contacts:build: $ bun run build:js && bun run build:views && bun run build:types
+@elizaos/plugin-task-coordinator:build: $ tsup --config ../tsup.plugin-packages.shared.ts
+@elizaos/plugin-health:build: $ tsup --config ../tsup.plugin-packages.shared.ts
+@elizaos/plugin-wifi:build: $ tsup --config ../tsup.plugin-packages.shared.ts
+@elizaos/plugin-contacts:build: $ tsup --config ../tsup.plugin-packages.shared.ts
+@elizaos/plugin-app-control:build: CLI Building entry: src/index.ts, src/workers/app-worker-entry.ts
+@elizaos/plugin-app-control:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-app-control:build: CLI tsup v8.5.1
+@elizaos/plugin-app-control:build: CLI Target: es2022
+@elizaos/plugin-app-control:build: CLI Cleaning output folder
+@elizaos/plugin-app-control:build: ESM Build start
+@elizaos/plugin-task-coordinator:build: CLI Building entry: src/orchestrator-plan.tsx, src/session-hydration.ts, src/CodingAgentTasksPanel.interact.ts, src/orchestrator-stream.tsx, src/orchestrator-reasoning.tsx, src/view-format.ts, src/PtyConsoleDrawer.tsx, src/TaskCardList.tsx, src/ModelConfigSection.tsx, src/CockpitRoute.tsx, src/orchestrator-markdown.helpers.ts, src/coding-agent-settings-shared.ts, src/orchestrator-params.ts, src/LlmProviderSection.tsx, src/orchestrator-stream.helpers.ts, src/orchestrator-capabilities.ts, src/PtyConsoleBase.tsx, src/task-coordinator-view-bundle.ts, src/CodingAgentControlChip.tsx, src/OrchestratorAccountHealthPanel.tsx, src/register-slots.ts, src/PtyConsoleSidePanel.tsx, src/pty-status-dots.ts, src/CodingAgentSettingsSection.tsx, src/orchestrator-command.ts, src/CockpitTerminalPanel.tsx, src/PtyTerminalPane.tsx, src/GitHubConnectionCard.tsx, src/OrchestratorView.tsx, src/register-terminal-view.tsx, src/use-orchestrator-data.ts, src/orchestrator-workbench-glyphs.tsx, src/CockpitSessionPane.tsx, src/GlobalPrefsSection.tsx, src/orchestrator-diff.helpers.ts, src/ui.ts, src/orchestrator-diff.tsx, src/TaskCoordinatorView.tsx, src/index.ts, src/register.ts, src/CodingAgentTasksPanel.tsx, src/OrchestratorWorkbench.tsx, src/orchestrator-markdown.tsx, src/AgentTabsSection.tsx, src/__e2e__/dashboard-fixture.tsx, src/api/coding-agents-auth-sanitize.ts, src/api/coding-agents-preflight-normalize.ts, src/components/OrchestratorSpatialView.tsx, src/components/TaskCoordinatorSpatialView.tsx
+@elizaos/plugin-task-coordinator:build: CLI Using tsconfig: ../../tsconfig.json
+@elizaos/plugin-task-coordinator:build: CLI tsup v8.5.1
+@elizaos/plugin-task-coordinator:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/tsup.plugin-packages.shared.ts
+@elizaos/plugin-wifi:build: CLI Building entry: src/plugin.ts, src/ui.ts, src/index.ts, src/register.ts, src/providers/networks.ts, src/components/WifiAppView.tsx, src/components/wifi-app.ts
+@elizaos/plugin-wifi:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-wifi:build: CLI tsup v8.5.1
+@elizaos/plugin-wifi:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/tsup.plugin-packages.shared.ts
+@elizaos/plugin-task-coordinator:build: CLI Target: es2022
+@elizaos/plugin-task-coordinator:build: ESM Build start
+@elizaos/plugin-phone:build: CLI Building entry: src/twilio.ts, src/plugin.ts, src/register-companion-page.ts, src/register-terminal-view.tsx, src/ui.ts, src/index.ts, src/register.ts, src/providers/call-log.ts, src/companion/index.ts, src/components/phone-view-helpers.ts, src/components/phone-view-bundle.ts, src/components/PhoneSpatialView.tsx, src/components/PhoneView.tsx, src/components/phone-interact.ts, src/companion/components/PhoneCompanionApp.tsx, src/companion/components/RemoteSession.tsx, src/companion/components/Pairing.tsx, src/companion/components/index.ts, src/companion/components/Chat.tsx, src/companion/services/push.ts, src/companion/services/navigation.ts, src/companion/services/intent-bridge.ts, src/companion/services/eliza-intent.ts, src/companion/services/logger.ts, src/companion/services/session-client.ts, src/companion/services/index.ts, src/companion/services/env.ts
+@elizaos/plugin-phone:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-phone:build: CLI tsup v8.5.1
+@elizaos/plugin-phone:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/tsup.plugin-packages.shared.ts
+@elizaos/plugin-wifi:build: CLI Target: es2022
+@elizaos/plugin-wifi:build: ESM Build start
+@elizaos/plugin-phone:build: CLI Target: es2022
+@elizaos/plugin-phone:build: ESM Build start
+@elizaos/plugin-contacts:build: CLI Building entry: src/plugin.ts, src/register-terminal-view.tsx, src/ui.ts, src/index.ts, src/register.ts, src/providers/contacts.ts, src/components/ContactsView.tsx, src/components/ContactsSpatialView.tsx, src/components/contacts-view-bundle.ts, src/components/ContactsAppView.interact.ts, src/components/ContactsAppView.tsx, src/components/ContactsAppView.helpers.ts, src/components/contacts-app.ts
+@elizaos/plugin-contacts:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-contacts:build: CLI tsup v8.5.1
+@elizaos/plugin-contacts:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/tsup.plugin-packages.shared.ts
+@elizaos/plugin-contacts:build: CLI Target: es2022
+@elizaos/plugin-contacts:build: ESM Build start
+@elizaos/plugin-phone:build: ESM dist/twilio.js                                     6.74 KB
+@elizaos/plugin-phone:build: ESM dist/plugin.js                                     1.80 KB
+@elizaos/plugin-phone:build: ESM dist/register-companion-page.js                    423.00 B
+@elizaos/plugin-phone:build: ESM dist/register-terminal-view.js                     603.00 B
+@elizaos/plugin-phone:build: ESM dist/ui.js                                         514.00 B
+@elizaos/plugin-phone:build: ESM dist/index.js                                      626.00 B
+@elizaos/plugin-phone:build: ESM dist/register.js                                   222.00 B
+@elizaos/plugin-phone:build: ESM dist/providers/call-log.js                         1.81 KB
+@elizaos/plugin-phone:build: ESM dist/companion/index.js                            368.00 B
+@elizaos/plugin-phone:build: ESM dist/components/phone-view-helpers.js              1.31 KB
+@elizaos/plugin-phone:build: ESM dist/components/phone-view-bundle.js               173.00 B
+@elizaos/plugin-phone:build: ESM dist/components/PhoneSpatialView.js                5.08 KB
+@elizaos/plugin-phone:build: ESM dist/components/PhoneView.js                       6.56 KB
+@elizaos/plugin-phone:build: ESM dist/components/phone-interact.js                  2.16 KB
+@elizaos/plugin-phone:build: ESM dist/companion/components/PhoneCompanionApp.js     4.82 KB
+@elizaos/plugin-phone:build: ESM dist/companion/components/RemoteSession.js         11.81 KB
+@elizaos/plugin-phone:build: ESM dist/companion/services/intent-bridge.js           355.00 B
+@elizaos/plugin-phone:build: ESM dist/companion/services/env.js                     419.00 B
+@elizaos/plugin-phone:build: ESM dist/companion/services/index.js                   565.00 B
+@elizaos/plugin-phone:build: ESM dist/companion/services/push.js                    3.07 KB
+@elizaos/plugin-phone:build: ESM dist/companion/services/navigation.js              3.14 KB
+@elizaos/plugin-phone:build: ESM dist/companion/components/index.js                 287.00 B
+@elizaos/plugin-phone:build: ESM dist/companion/components/Chat.js                  5.21 KB
+@elizaos/plugin-phone:build: ESM dist/companion/components/Pairing.js               5.57 KB
+@elizaos/plugin-phone:build: ESM dist/companion/services/logger.js                  1.13 KB
+@elizaos/plugin-phone:build: ESM dist/companion/services/eliza-intent.js            1.41 KB
+@elizaos/plugin-phone:build: ESM dist/companion/services/session-client.js          5.98 KB
+@elizaos/plugin-phone:build: ESM dist/twilio.js.map                                 13.04 KB
+@elizaos/plugin-phone:build: ESM dist/register-companion-page.js.map                1.19 KB
+@elizaos/plugin-phone:build: ESM dist/components/PhoneSpatialView.js.map            10.19 KB
+@elizaos/plugin-phone:build: ESM dist/register.js.map                               1.04 KB
+@elizaos/plugin-phone:build: ESM dist/companion/services/env.js.map                 1.25 KB
+@elizaos/plugin-phone:build: ESM dist/companion/index.js.map                        814.00 B
+@elizaos/plugin-phone:build: ESM dist/companion/components/RemoteSession.js.map     22.41 KB
+@elizaos/plugin-phone:build: ESM dist/plugin.js.map                                 3.17 KB
+@elizaos/plugin-phone:build: ESM dist/providers/call-log.js.map                     3.89 KB
+@elizaos/plugin-phone:build: ESM dist/components/phone-view-bundle.js.map           616.00 B
+@elizaos/plugin-phone:build: ESM dist/components/phone-interact.js.map              4.03 KB
+@elizaos/plugin-phone:build: ESM dist/components/PhoneView.js.map                   12.35 KB
+@elizaos/plugin-phone:build: ESM dist/ui.js.map                                     595.00 B
+@elizaos/plugin-phone:build: ESM dist/register-terminal-view.js.map                 1.58 KB
+@elizaos/plugin-phone:build: ESM dist/companion/components/index.js.map             382.00 B
+@elizaos/plugin-phone:build: ESM dist/index.js.map                                  1.26 KB
+@elizaos/plugin-phone:build: ESM dist/companion/components/PhoneCompanionApp.js.map 8.87 KB
+@elizaos/plugin-phone:build: ESM dist/companion/services/index.js.map               1.42 KB
+@elizaos/plugin-phone:build: ESM dist/components/phone-view-helpers.js.map          2.94 KB
+@elizaos/plugin-phone:build: ESM dist/companion/services/push.js.map                6.27 KB
+@elizaos/plugin-phone:build: ESM dist/companion/services/navigation.js.map          6.28 KB
+@elizaos/plugin-phone:build: ESM dist/companion/components/Pairing.js.map           9.52 KB
+@elizaos/plugin-phone:build: ESM dist/companion/services/intent-bridge.js.map       1.09 KB
+@elizaos/plugin-phone:build: ESM dist/companion/services/eliza-intent.js.map        4.44 KB
+@elizaos/plugin-phone:build: ESM dist/companion/services/logger.js.map              2.83 KB
+@elizaos/plugin-phone:build: ESM dist/companion/services/session-client.js.map      14.46 KB
+@elizaos/plugin-phone:build: ESM dist/companion/components/Chat.js.map              8.56 KB
+@elizaos/plugin-phone:build: ESM ⚡️ Build success in 159ms
+@elizaos/plugin-phone:build: $ bunx --bun vite build --config vite.config.views.ts
+@elizaos/plugin-wifi:build: ESM dist/plugin.js                     650.00 B
+@elizaos/plugin-wifi:build: ESM dist/ui.js                         252.00 B
+@elizaos/plugin-wifi:build: ESM dist/index.js                      505.00 B
+@elizaos/plugin-wifi:build: ESM dist/register.js                   179.00 B
+@elizaos/plugin-wifi:build: ESM dist/providers/networks.js         1.70 KB
+@elizaos/plugin-wifi:build: ESM dist/components/WifiAppView.js     13.53 KB
+@elizaos/plugin-wifi:build: ESM dist/components/wifi-app.js        531.00 B
+@elizaos/plugin-wifi:build: ESM dist/plugin.js.map                 1.16 KB
+@elizaos/plugin-wifi:build: ESM dist/ui.js.map                     310.00 B
+@elizaos/plugin-wifi:build: ESM dist/index.js.map                  980.00 B
+@elizaos/plugin-wifi:build: ESM dist/providers/networks.js.map     3.58 KB
+@elizaos/plugin-wifi:build: ESM dist/components/WifiAppView.js.map 19.90 KB
+@elizaos/plugin-wifi:build: ESM dist/components/wifi-app.js.map    1.20 KB
+@elizaos/plugin-wifi:build: ESM dist/register.js.map               549.00 B
+@elizaos/plugin-wifi:build: ESM ⚡️ Build success in 253ms
+@elizaos/plugin-wifi:build: $ tsc --noCheck -p tsconfig.build.json
+@elizaos/plugin-health:build: CLI Building entry: src/register-terminal-view.tsx, src/index.ts, src/register.ts, src/connectors/contract-types.ts, src/connectors/index.ts, src/providers/health.ts, src/providers/index.ts, src/contracts/permissions.ts, src/contracts/circadian.ts, src/contracts/circadian-default.ts, src/contracts/health.ts, src/contracts/lifeops.ts, src/contracts/lifeops-connector-degradation.ts, src/sleep/sleep-episode-store.ts, src/sleep/source-reliability.ts, src/sleep/circadian-rules.ts, src/sleep/sleep-recap.ts, src/sleep/sleep-wake-events.ts, src/sleep/sleep-episode-types.ts, src/sleep/sleep-cycle.ts, src/sleep/sleep-regularity.ts, src/sleep/sleep-service.ts, src/sleep/index.ts, src/sleep/sleep-cycle-dispatch.ts, src/sleep/awake-probability.ts, src/health-bridge/health-oauth.ts, src/health-bridge/health-provider-registry.ts, src/health-bridge/service-normalize-health.ts, src/health-bridge/health-connectors.ts, src/health-bridge/health-bridge.ts, src/health-bridge/index.ts, src/health-bridge/health-records.ts, src/util/token-encryption.ts, src/util/time-util.ts, src/util/normalize.ts, src/util/index.ts, src/util/time.ts, src/screen-time/mobile-signals.ts, src/screen-time/mobile-signal-setup.ts, src/screen-time/social-taxonomy.ts, src/screen-time/ranges.ts, src/screen-time/system-inactivity-apps.ts, src/screen-time/index.ts, src/screen-time/builders.ts, src/ui/assistant-commands.ts, src/ui/index.ts, src/actions/screen-time.ts, src/actions/optimized-prompt-instructions.ts, src/actions/health.ts, src/actions/index.ts, src/components/health/HealthSpatialView.tsx, src/components/health/health-view-bundle.ts, src/components/health/HealthView.tsx, src/default-packs/contract-types.ts, src/default-packs/sleep-recap.ts, src/default-packs/wake-up.ts, src/default-packs/index.ts, src/default-packs/bedtime.ts, src/anchors/index.ts, src/routes/sleep.ts, src/routes/index.ts
+@elizaos/plugin-health:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-health:build: CLI tsup v8.5.1
+@elizaos/plugin-health:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/tsup.plugin-packages.shared.ts
+@elizaos/plugin-health:build: CLI Target: es2022
+@elizaos/plugin-health:build: ESM Build start
+@elizaos/plugin-contacts:build: ESM dist/plugin.js                                  1.27 KB
+@elizaos/plugin-contacts:build: ESM dist/register-terminal-view.js                  625.00 B
+@elizaos/plugin-contacts:build: ESM dist/ui.js                                      369.00 B
+@elizaos/plugin-contacts:build: ESM dist/index.js                                   536.00 B
+@elizaos/plugin-contacts:build: ESM dist/register.js                                341.00 B
+@elizaos/plugin-contacts:build: ESM dist/providers/contacts.js                      1.90 KB
+@elizaos/plugin-contacts:build: ESM dist/components/ContactsView.js                 4.65 KB
+@elizaos/plugin-contacts:build: ESM dist/components/contacts-view-bundle.js         195.00 B
+@elizaos/plugin-contacts:build: ESM dist/components/ContactsAppView.helpers.js      1.21 KB
+@elizaos/plugin-contacts:build: ESM dist/components/ContactsAppView.interact.js     2.25 KB
+@elizaos/plugin-contacts:build: ESM dist/components/ContactsAppView.js              24.09 KB
+@elizaos/plugin-contacts:build: ESM dist/components/ContactsSpatialView.js          7.97 KB
+@elizaos/plugin-contacts:build: ESM dist/plugin.js.map                              2.19 KB
+@elizaos/plugin-contacts:build: ESM dist/register-terminal-view.js.map              1.61 KB
+@elizaos/plugin-contacts:build: ESM dist/ui.js.map                                  416.00 B
+@elizaos/plugin-contacts:build: ESM dist/index.js.map                               596.00 B
+@elizaos/plugin-contacts:build: ESM dist/providers/contacts.js.map                  3.91 KB
+@elizaos/plugin-contacts:build: ESM dist/components/ContactsView.js.map             9.45 KB
+@elizaos/plugin-contacts:build: ESM dist/components/contacts-app.js                 583.00 B
+@elizaos/plugin-contacts:build: ESM dist/register.js.map                            1.23 KB
+@elizaos/plugin-contacts:build: ESM dist/components/contacts-view-bundle.js.map     641.00 B
+@elizaos/plugin-contacts:build: ESM dist/components/ContactsAppView.helpers.js.map  2.63 KB
+@elizaos/plugin-contacts:build: ESM dist/components/ContactsAppView.interact.js.map 4.26 KB
+@elizaos/plugin-contacts:build: ESM dist/components/ContactsSpatialView.js.map      15.12 KB
+@elizaos/plugin-contacts:build: ESM dist/components/contacts-app.js.map             1.24 KB
+@elizaos/plugin-contacts:build: ESM dist/components/ContactsAppView.js.map          39.62 KB
+@elizaos/plugin-contacts:build: ESM ⚡️ Build success in 236ms
+@elizaos/plugin-contacts:build: $ bunx --bun vite build --config vite.config.views.ts
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-plan.js                         3.40 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/session-hydration.js                         184.00 B
+@elizaos/plugin-task-coordinator:build: ESM dist/CodingAgentTasksPanel.interact.js            1.59 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-stream.js                       10.27 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-reasoning.js                    3.29 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/view-format.js                               2.04 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/PtyConsoleDrawer.js                          3.43 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/TaskCardList.js                              8.31 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/OrchestratorView.js                          643.00 B
+@elizaos/plugin-task-coordinator:build: ESM dist/ModelConfigSection.js                        3.44 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/CockpitRoute.js                              1.95 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/ModelConfigSection.js.map                    5.49 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/OrchestratorView.js.map                      1.45 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/CockpitRoute.js.map                          4.64 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-plan.js.map                     6.36 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/session-hydration.js.map                     243.00 B
+@elizaos/plugin-task-coordinator:build: ESM dist/CodingAgentTasksPanel.interact.js.map        3.14 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-stream.js.map                   19.79 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-reasoning.js.map                7.05 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/register-terminal-view.js                    1.19 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/view-format.js.map                           4.76 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/use-orchestrator-data.js                     7.54 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/PtyConsoleDrawer.js.map                      4.85 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/CodingAgentTasksPanel.js                     28.09 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/OrchestratorWorkbench.js                     102.42 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-markdown.helpers.js             614.00 B
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-diff.helpers.js                 1.83 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-markdown.js                     7.80 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/register.js                                  276.00 B
+@elizaos/plugin-task-coordinator:build: ESM dist/CockpitSessionPane.js                        12.33 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/api/coding-agents-auth-sanitize.js           658.00 B
+@elizaos/plugin-task-coordinator:build: ESM dist/ui.js                                        277.00 B
+@elizaos/plugin-task-coordinator:build: ESM dist/TaskCardList.js.map                          14.71 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/index.js                                     10.36 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/GlobalPrefsSection.js                        7.07 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/TaskCoordinatorView.js                       4.33 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/OrchestratorAccountHealthPanel.js            3.06 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/register-terminal-view.js.map                2.59 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/CodingAgentTasksPanel.js.map                 47.33 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-capabilities.js                 4.95 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-workbench-glyphs.js             6.77 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/LlmProviderSection.js                        5.67 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/api/coding-agents-preflight-normalize.js     653.00 B
+@elizaos/plugin-task-coordinator:build: ESM dist/use-orchestrator-data.js.map                 17.05 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/__e2e__/dashboard-fixture.js                 4.06 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-diff.js                         3.84 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/AgentTabsSection.js                          6.55 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/OrchestratorWorkbench.js.map                 165.45 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/CodingAgentControlChip.js                    2.36 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/CockpitTerminalPanel.js                      3.75 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-command.js                      1.81 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/components/OrchestratorSpatialView.js        16.75 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/task-coordinator-view-bundle.js              371.00 B
+@elizaos/plugin-task-coordinator:build: ESM dist/pty-status-dots.js                           144.00 B
+@elizaos/plugin-task-coordinator:build: ESM dist/components/TaskCoordinatorSpatialView.js     10.66 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/register-slots.js                            1.28 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-stream.helpers.js               11.81 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/ui.js.map                                    288.00 B
+@elizaos/plugin-task-coordinator:build: ESM dist/GlobalPrefsSection.js.map                    11.26 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/PtyConsoleSidePanel.js                       299.00 B
+@elizaos/plugin-task-coordinator:build: ESM dist/coding-agent-settings-shared.js              2.95 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/PtyConsoleBase.js                            5.95 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-params.js                       850.00 B
+@elizaos/plugin-task-coordinator:build: ESM dist/GitHubConnectionCard.js                      6.59 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/api/coding-agents-auth-sanitize.js.map       2.12 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/PtyTerminalPane.js                           4.06 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/index.js.map                                 15.80 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-markdown.helpers.js.map         1.47 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-workbench-glyphs.js.map         13.76 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/CockpitSessionPane.js.map                    22.83 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/api/coding-agents-preflight-normalize.js.map 2.61 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/CockpitTerminalPanel.js.map                  6.27 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-capabilities.js.map             8.45 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/AgentTabsSection.js.map                      10.72 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/coding-agent-settings-shared.js.map          6.12 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/PtyConsoleSidePanel.js.map                   594.00 B
+@elizaos/plugin-task-coordinator:build: ESM dist/TaskCoordinatorView.js.map                   8.93 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-command.js.map                  4.49 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/CodingAgentSettingsSection.js                13.60 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/PtyConsoleBase.js.map                        8.77 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/CodingAgentControlChip.js.map                3.59 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-stream.helpers.js.map           29.78 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/OrchestratorAccountHealthPanel.js.map        6.92 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/LlmProviderSection.js.map                    9.22 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/pty-status-dots.js.map                       185.00 B
+@elizaos/plugin-task-coordinator:build: ESM dist/register.js.map                              838.00 B
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-diff.js.map                     8.34 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/components/TaskCoordinatorSpatialView.js.map 21.18 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/__e2e__/dashboard-fixture.js.map             6.53 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/register-slots.js.map                        3.43 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-diff.helpers.js.map             4.90 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/components/OrchestratorSpatialView.js.map    31.64 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/task-coordinator-view-bundle.js.map          1.17 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-markdown.js.map                 14.64 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/GitHubConnectionCard.js.map                  10.54 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-params.js.map                   1.98 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/PtyTerminalPane.js.map                       7.74 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/CodingAgentSettingsSection.js.map            25.07 KB
+@elizaos/plugin-task-coordinator:build: ESM ⚡️ Build success in 401ms
+@elizaos/plugin-task-coordinator:build: $ bunx --bun vite build --config vite.config.views.ts
+@elizaos/plugin-app-control:build: ESM dist/workers/app-worker-entry.js        8.72 KB
+@elizaos/plugin-app-control:build: ESM dist/register-terminal-view-AWQ5Y2CU.js 9.11 KB
+@elizaos/plugin-app-control:build: ESM dist/index.js                           353.62 KB
+@elizaos/plugin-app-control:build: ESM ⚡️ Build success in 669ms
+@elizaos/plugin-health:build: ESM dist/health-bridge/index.js                         275.00 B
+@elizaos/plugin-health:build: ESM dist/index.js                                       3.05 KB
+@elizaos/plugin-health:build: ESM dist/register.js                                    184.00 B
+@elizaos/plugin-health:build: ESM dist/connectors/contract-types.js                   42.00 B
+@elizaos/plugin-health:build: ESM dist/register-terminal-view.js                      600.00 B
+@elizaos/plugin-health:build: ESM dist/connectors/index.js                            5.65 KB
+@elizaos/plugin-health:build: ESM dist/ui/index.js                                    144.00 B
+@elizaos/plugin-health:build: ESM dist/providers/health.js                            3.23 KB
+@elizaos/plugin-health:build: ESM dist/actions/screen-time.js                         21.64 KB
+@elizaos/plugin-health:build: ESM dist/providers/index.js                             260.00 B
+@elizaos/plugin-health:build: ESM dist/contracts/permissions.js                       39.00 B
+@elizaos/plugin-health:build: ESM dist/screen-time/mobile-signal-setup.js             1.23 KB
+@elizaos/plugin-health:build: ESM dist/contracts/circadian.js                         442.00 B
+@elizaos/plugin-health:build: ESM dist/health-bridge/health-records.js                1005.00 B
+@elizaos/plugin-health:build: ESM dist/actions/optimized-prompt-instructions.js       1.79 KB
+@elizaos/plugin-health:build: ESM dist/util/token-encryption.js                       3.05 KB
+@elizaos/plugin-health:build: ESM dist/screen-time/social-taxonomy.js                 6.60 KB
+@elizaos/plugin-health:build: ESM dist/actions/health.js                              18.75 KB
+@elizaos/plugin-health:build: ESM dist/default-packs/wake-up.js                       1.83 KB
+@elizaos/plugin-health:build: ESM dist/default-packs/index.js                         1.08 KB
+@elizaos/plugin-health:build: ESM dist/default-packs/bedtime.js                       1.50 KB
+@elizaos/plugin-health:build: ESM dist/anchors/index.js                               171.00 B
+@elizaos/plugin-health:build: ESM dist/connectors/index.js.map                        12.52 KB
+@elizaos/plugin-health:build: ESM dist/index.js.map                                   6.57 KB
+@elizaos/plugin-health:build: ESM dist/default-packs/sleep-recap.js                   1.65 KB
+@elizaos/plugin-health:build: ESM dist/screen-time/ranges.js                          2.12 KB
+@elizaos/plugin-health:build: ESM dist/register.js.map                                863.00 B
+@elizaos/plugin-health:build: ESM dist/ui/index.js.map                                262.00 B
+@elizaos/plugin-health:build: ESM dist/screen-time/system-inactivity-apps.js          2.19 KB
+@elizaos/plugin-health:build: ESM dist/util/time-util.js                              416.00 B
+@elizaos/plugin-health:build: ESM dist/providers/health.js.map                        6.42 KB
+@elizaos/plugin-health:build: ESM dist/routes/sleep.js                                4.15 KB
+@elizaos/plugin-health:build: ESM dist/util/normalize.js                              1.91 KB
+@elizaos/plugin-health:build: ESM dist/contracts/circadian-default.js                 704.00 B
+@elizaos/plugin-health:build: ESM dist/register-terminal-view.js.map                  1.48 KB
+@elizaos/plugin-health:build: ESM dist/routes/index.js                                61.00 B
+@elizaos/plugin-health:build: ESM dist/components/health/health-view-bundle.js        117.00 B
+@elizaos/plugin-health:build: ESM dist/contracts/health.js                            596.00 B
+@elizaos/plugin-health:build: ESM dist/components/health/HealthSpatialView.js         3.30 KB
+@elizaos/plugin-health:build: ESM dist/contracts/lifeops.js                           12.88 KB
+@elizaos/plugin-health:build: ESM dist/util/time.js                                   4.79 KB
+@elizaos/plugin-health:build: ESM dist/health-bridge/index.js.map                     1.18 KB
+@elizaos/plugin-health:build: ESM dist/actions/index.js                               242.00 B
+@elizaos/plugin-health:build: ESM dist/connectors/contract-types.js.map               71.00 B
+@elizaos/plugin-health:build: ESM dist/sleep/sleep-regularity.js                      7.47 KB
+@elizaos/plugin-health:build: ESM dist/default-packs/contract-types.js                42.00 B
+@elizaos/plugin-health:build: ESM dist/sleep/circadian-rules.js                       9.03 KB
+@elizaos/plugin-health:build: ESM dist/screen-time/index.js                           213.00 B
+@elizaos/plugin-health:build: ESM dist/sleep/sleep-episode-store.js                   1.90 KB
+@elizaos/plugin-health:build: ESM dist/components/health/HealthView.js                6.79 KB
+@elizaos/plugin-health:build: ESM dist/util/index.js                                  92.00 B
+@elizaos/plugin-health:build: ESM dist/screen-time/mobile-signals.js                  5.63 KB
+@elizaos/plugin-health:build: ESM dist/screen-time/builders.js                        9.35 KB
+@elizaos/plugin-health:build: ESM dist/sleep/sleep-recap.js                           39.00 B
+@elizaos/plugin-health:build: ESM dist/health-bridge/health-connectors.js             32.44 KB
+@elizaos/plugin-health:build: ESM dist/health-bridge/service-normalize-health.js      3.30 KB
+@elizaos/plugin-health:build: ESM dist/health-bridge/health-oauth.js                  14.91 KB
+@elizaos/plugin-health:build: ESM dist/sleep/sleep-episode-types.js                   343.00 B
+@elizaos/plugin-health:build: ESM dist/sleep/sleep-cycle.js                           16.40 KB
+@elizaos/plugin-health:build: ESM dist/contracts/lifeops-connector-degradation.js     378.00 B
+@elizaos/plugin-health:build: ESM dist/sleep/source-reliability.js                    1.99 KB
+@elizaos/plugin-health:build: ESM dist/sleep/sleep-service.js                         4.91 KB
+@elizaos/plugin-health:build: ESM dist/health-bridge/health-provider-registry.js      3.91 KB
+@elizaos/plugin-health:build: ESM dist/sleep/awake-probability.js                     5.84 KB
+@elizaos/plugin-health:build: ESM dist/health-bridge/health-records.js.map            2.45 KB
+@elizaos/plugin-health:build: ESM dist/actions/optimized-prompt-instructions.js.map   2.16 KB
+@elizaos/plugin-health:build: ESM dist/contracts/permissions.js.map                   71.00 B
+@elizaos/plugin-health:build: ESM dist/screen-time/mobile-signal-setup.js.map         2.75 KB
+@elizaos/plugin-health:build: ESM dist/sleep/sleep-wake-events.js                     4.42 KB
+@elizaos/plugin-health:build: ESM dist/providers/index.js.map                         388.00 B
+@elizaos/plugin-health:build: ESM dist/ui/assistant-commands.js                       1.96 KB
+@elizaos/plugin-health:build: ESM dist/util/token-encryption.js.map                   6.94 KB
+@elizaos/plugin-health:build: ESM dist/sleep/index.js                                 462.00 B
+@elizaos/plugin-health:build: ESM dist/sleep/sleep-cycle-dispatch.js                  3.58 KB
+@elizaos/plugin-health:build: ESM dist/screen-time/social-taxonomy.js.map             13.79 KB
+@elizaos/plugin-health:build: ESM dist/health-bridge/health-bridge.js                 16.64 KB
+@elizaos/plugin-health:build: ESM dist/default-packs/wake-up.js.map                   3.54 KB
+@elizaos/plugin-health:build: ESM dist/contracts/circadian.js.map                     5.11 KB
+@elizaos/plugin-health:build: ESM dist/actions/health.js.map                          35.77 KB
+@elizaos/plugin-health:build: ESM dist/util/index.js.map                              462.00 B
+@elizaos/plugin-health:build: ESM dist/default-packs/sleep-recap.js.map               3.13 KB
+@elizaos/plugin-health:build: ESM dist/actions/screen-time.js.map                     41.61 KB
+@elizaos/plugin-health:build: ESM dist/util/normalize.js.map                          3.93 KB
+@elizaos/plugin-health:build: ESM dist/default-packs/bedtime.js.map                   2.94 KB
+@elizaos/plugin-health:build: ESM dist/screen-time/mobile-signals.js.map              11.01 KB
+@elizaos/plugin-health:build: ESM dist/routes/index.js.map                            141.00 B
+@elizaos/plugin-health:build: ESM dist/contracts/health.js.map                        3.22 KB
+@elizaos/plugin-health:build: ESM dist/routes/sleep.js.map                            8.49 KB
+@elizaos/plugin-health:build: ESM dist/sleep/sleep-recap.js.map                       71.00 B
+@elizaos/plugin-health:build: ESM dist/components/health/HealthSpatialView.js.map     7.90 KB
+@elizaos/plugin-health:build: ESM dist/util/time-util.js.map                          1.15 KB
+@elizaos/plugin-health:build: ESM dist/sleep/awake-probability.js.map                 11.16 KB
+@elizaos/plugin-health:build: ESM dist/health-bridge/health-connectors.js.map         61.42 KB
+@elizaos/plugin-health:build: ESM dist/screen-time/ranges.js.map                      4.30 KB
+@elizaos/plugin-health:build: ESM dist/sleep/index.js.map                             1.12 KB
+@elizaos/plugin-health:build: ESM dist/components/health/health-view-bundle.js.map    479.00 B
+@elizaos/plugin-health:build: ESM dist/default-packs/contract-types.js.map            71.00 B
+@elizaos/plugin-health:build: ESM dist/sleep/circadian-rules.js.map                   17.66 KB
+@elizaos/plugin-health:build: ESM dist/util/time.js.map                               9.32 KB
+@elizaos/plugin-health:build: ESM dist/contracts/lifeops-connector-degradation.js.map 844.00 B
+@elizaos/plugin-health:build: ESM dist/default-packs/index.js.map                     2.26 KB
+@elizaos/plugin-health:build: ESM dist/anchors/index.js.map                           1.12 KB
+@elizaos/plugin-health:build: ESM dist/components/health/HealthView.js.map            16.66 KB
+@elizaos/plugin-health:build: ESM dist/sleep/sleep-cycle.js.map                       32.18 KB
+@elizaos/plugin-health:build: ESM dist/sleep/sleep-episode-store.js.map               4.18 KB
+@elizaos/plugin-health:build: ESM dist/sleep/sleep-cycle-dispatch.js.map              9.94 KB
+@elizaos/plugin-health:build: ESM dist/screen-time/index.js.map                       1.53 KB
+@elizaos/plugin-health:build: ESM dist/ui/assistant-commands.js.map                   3.32 KB
+@elizaos/plugin-health:build: ESM dist/contracts/lifeops.js.map                       122.19 KB
+@elizaos/plugin-health:build: ESM dist/sleep/sleep-regularity.js.map                  14.33 KB
+@elizaos/plugin-health:build: ESM dist/contracts/circadian-default.js.map             1.90 KB
+@elizaos/plugin-health:build: ESM dist/screen-time/system-inactivity-apps.js.map      4.08 KB
+@elizaos/plugin-health:build: ESM dist/screen-time/builders.js.map                    17.58 KB
+@elizaos/plugin-health:build: ESM dist/health-bridge/health-bridge.js.map             35.20 KB
+@elizaos/plugin-health:build: ESM dist/sleep/source-reliability.js.map                4.71 KB
+@elizaos/plugin-health:build: ESM dist/actions/index.js.map                           788.00 B
+@elizaos/plugin-health:build: ESM dist/sleep/sleep-wake-events.js.map                 10.84 KB
+@elizaos/plugin-health:build: ESM dist/health-bridge/health-oauth.js.map              30.40 KB
+@elizaos/plugin-health:build: ESM dist/sleep/sleep-episode-types.js.map               2.20 KB
+@elizaos/plugin-health:build: ESM dist/health-bridge/service-normalize-health.js.map  5.76 KB
+@elizaos/plugin-health:build: ESM dist/sleep/sleep-service.js.map                     9.58 KB
+@elizaos/plugin-health:build: ESM dist/health-bridge/health-provider-registry.js.map  10.09 KB
+@elizaos/plugin-health:build: ESM ⚡️ Build success in 409ms
+@elizaos/plugin-health:build: $ bunx --bun vite build --config vite.config.views.ts
+@elizaos/plugin-phone:build: vite v8.0.16 building client environment for production...
+@elizaos/plugin-task-coordinator:build: vite v8.0.16 building client environment for production...
+@elizaos/plugin-phone:build: [2K@elizaos/plugin-phone:build: transforming...✓ 10 modules transformed.
+@elizaos/plugin-contacts:build: vite v8.0.16 building client environment for production...
+@elizaos/plugin-phone:build: rendering chunks...
+@elizaos/plugin-task-coordinator:build: [2K@elizaos/plugin-task-coordinator:build: transforming...✓ 30 modules transformed.
+@elizaos/plugin-phone:build: computing gzip size...
+@elizaos/plugin-phone:build: dist/views/web-TGRkTsa8.js    1.69 kB │ gzip: 0.70 kB │ map:  4.29 kB
+@elizaos/plugin-phone:build: dist/views/dist-Cd2YtKy4.js   9.78 kB │ gzip: 3.56 kB │ map: 34.19 kB
+@elizaos/plugin-phone:build: dist/views/bundle.js         10.98 kB │ gzip: 3.50 kB │ map: 28.51 kB
+@elizaos/plugin-phone:build:
+@elizaos/plugin-phone:build: ✓ built in 502ms
+@elizaos/plugin-health:build: vite v8.0.16 building client environment for production...
+@elizaos/plugin-phone:build: $ tsc --noCheck -p tsconfig.build.json
+@elizaos/plugin-contacts:build: [2K@elizaos/plugin-contacts:build: transforming...✓ 10 modules transformed.
+@elizaos/plugin-task-coordinator:build: rendering chunks...
+@elizaos/plugin-contacts:build: rendering chunks...
+@elizaos/plugin-health:build: [2K@elizaos/plugin-health:build: transforming...✓ 4 modules transformed.
+@elizaos/plugin-task-coordinator:build: computing gzip size...
+@elizaos/plugin-task-coordinator:build: dist/views/addon-fit-m6I4VupF.js    1.98 kB │ gzip:  0.86 kB │ map:   3.18 kB
+@elizaos/plugin-task-coordinator:build: dist/views/bundle.js              218.30 kB │ gzip: 51.54 kB │ map: 503.28 kB
+@elizaos/plugin-task-coordinator:build: dist/views/xterm-CSb1Gh9p.js      369.18 kB │ gzip: 74.91 kB │ map: 574.82 kB
+@elizaos/plugin-task-coordinator:build:
+@elizaos/plugin-task-coordinator:build: ✓ built in 814ms
+@elizaos/plugin-contacts:build: computing gzip size...
+@elizaos/plugin-contacts:build: dist/views/web-DMSWpoWr.js    1.07 kB │ gzip: 0.51 kB │ map:  3.14 kB
+@elizaos/plugin-contacts:build: dist/views/dist-Cd2YtKy4.js   9.78 kB │ gzip: 3.56 kB │ map: 34.19 kB
+@elizaos/plugin-contacts:build: dist/views/bundle.js         11.78 kB │ gzip: 3.40 kB │ map: 30.70 kB
+@elizaos/plugin-contacts:build:
+@elizaos/plugin-contacts:build: ✓ built in 681ms
+@elizaos/plugin-health:build: rendering chunks...
+@elizaos/plugin-contacts:build: $ bunx tsc --noCheck -p tsconfig.build.json
+@elizaos/plugin-task-coordinator:build: $ tsc --noCheck -p tsconfig.build.json
+@elizaos/plugin-health:build: computing gzip size...
+@elizaos/plugin-health:build: dist/views/bundle.js  7.76 kB │ gzip: 2.55 kB │ map: 23.96 kB
+@elizaos/plugin-health:build:
+@elizaos/plugin-health:build: ✓ built in 584ms
+@elizaos/plugin-health:build: $ tsc --noCheck -p tsconfig.build.json
+@elizaos/plugin-calendar:typecheck: cache miss, executing cb667498563c29bd
+@elizaos/plugin-calendar:typecheck: $ tsgo --noEmit
+@elizaos/plugin-app-control:build: $ bunx --bun vite build --config vite.config.views.ts
+@elizaos/plugin-app-control:build: vite v8.0.16 building client environment for production...
+@elizaos/plugin-app-control:build: [2K@elizaos/plugin-app-control:build: transforming...✓ 5 modules transformed.
+@elizaos/plugin-app-control:build: rendering chunks...
+@elizaos/plugin-app-control:build: computing gzip size...
+@elizaos/plugin-app-control:build: dist/views/bundle.js  5.76 kB │ gzip: 2.23 kB │ map: 16.92 kB
+@elizaos/plugin-app-control:build:
+@elizaos/plugin-app-control:build: ✓ built in 453ms
+@elizaos/agent:build: cache miss, executing 0ea641eec3b2d345
+@elizaos/agent:build: $ bun run build:dist
+@elizaos/agent:build: $ node ../scripts/rm-path-recursive.mjs dist && tsc --noCheck -p tsconfig.build.json && node ../scripts/prepare-package-dist.mjs packages/agent && node ../scripts/copy-package-assets.mjs packages/agent assets && node ../scripts/rewrite-dist-relative-imports-node-esm.mjs packages/agent
+@elizaos/agent:build: [rewrite-dist-relative-imports] rewrote 173 file(s)
+@elizaos/app-core:build: cache miss, executing 0938cf6b63695bca
+@elizaos/plugin-xr:build: cache miss, executing 8f8aea5ba9f95058
+@elizaos/plugin-reminders:build: cache miss, executing 5299ea9985ae6186
+@elizaos/plugin-local-inference:typecheck: cache miss, executing 366c58960e622531
+@elizaos/app-core:typecheck: cache miss, executing 953e8a38f6b64b91
+@elizaos/plugin-xr:build: $ bun run build:js && bun run build:types
+@elizaos/app-core:build: $ bun run build:dist
+@elizaos/plugin-local-inference:typecheck: $ tsgo --noEmit
+@elizaos/app-core:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-reminders:build: $ bun run build:js && bun run build:types
+@elizaos/plugin-xr:build: $ tsup --config ../tsup.plugin-packages.shared.ts
+@elizaos/app-core:build: $ node ../scripts/rm-path-recursive.mjs dist && tsc --noCheck -p tsconfig.build.json && node ../scripts/flatten-tsc-package-output.mjs packages/app-core && node ../scripts/copy-package-assets.mjs packages/app-core src/styles scripts platforms packaging patches test/scripts test/helpers && node ../scripts/prepare-package-dist.mjs packages/app-core && node ../scripts/rewrite-dist-relative-imports-node-esm.mjs packages/app-core
+@elizaos/plugin-reminders:build: $ tsup --config ../tsup.plugin-packages.shared.ts
+@elizaos/plugin-reminders:build: CLI Building entry: src/plugin.ts, src/index.ts, src/db/schema.ts, src/db/index.ts, src/services/migration.ts
+@elizaos/plugin-reminders:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-reminders:build: CLI tsup v8.5.1
+@elizaos/plugin-reminders:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/tsup.plugin-packages.shared.ts
+@elizaos/plugin-reminders:build: CLI Target: es2022
+@elizaos/plugin-reminders:build: ESM Build start
+@elizaos/plugin-reminders:build: ESM dist/db/schema.js              3.13 KB
+@elizaos/plugin-reminders:build: ESM dist/db/index.js               62.00 B
+@elizaos/plugin-reminders:build: ESM dist/index.js                  468.00 B
+@elizaos/plugin-reminders:build: ESM dist/plugin.js                 568.00 B
+@elizaos/plugin-reminders:build: ESM dist/services/migration.js     3.73 KB
+@elizaos/plugin-reminders:build: ESM dist/db/index.js.map           138.00 B
+@elizaos/plugin-reminders:build: ESM dist/plugin.js.map             1.42 KB
+@elizaos/plugin-reminders:build: ESM dist/index.js.map              544.00 B
+@elizaos/plugin-reminders:build: ESM dist/services/migration.js.map 8.38 KB
+@elizaos/plugin-reminders:build: ESM dist/db/schema.js.map          6.35 KB
+@elizaos/plugin-reminders:build: ESM ⚡️ Build success in 81ms
+@elizaos/plugin-xr:build: CLI Building entry: src/protocol.ts, src/index.ts, src/providers/xr-context.ts, src/actions/xr-query-vision.ts, src/actions/xr-view-actions.ts, src/routes/xr-status.ts, src/routes/xr-simulator-route.ts, src/routes/xr-views.ts, src/routes/xr-connect.ts, src/routes/xr-view-host.ts, src/services/audio-pipeline.ts, src/services/xr-session-service.ts, src/services/vision-pipeline.ts
+@elizaos/plugin-xr:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-xr:build: CLI tsup v8.5.1
+@elizaos/plugin-xr:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/tsup.plugin-packages.shared.ts
+@elizaos/plugin-xr:build: CLI Target: es2022
+@elizaos/plugin-xr:build: ESM Build start
+@elizaos/plugin-reminders:build: $ bunx tsc --noCheck -p tsconfig.build.json && node ../../packages/scripts/rewrite-dist-relative-imports-node-esm.mjs
+@elizaos/plugin-xr:build: ESM dist/routes/xr-views.js                 952.00 B
+@elizaos/plugin-xr:build: ESM dist/services/audio-pipeline.js         2.65 KB
+@elizaos/plugin-xr:build: ESM dist/providers/xr-context.js            1.16 KB
+@elizaos/plugin-xr:build: ESM dist/routes/xr-connect.js               3.37 KB
+@elizaos/plugin-xr:build: ESM dist/routes/xr-status.js                838.00 B
+@elizaos/plugin-xr:build: ESM dist/routes/xr-simulator-route.js       1.03 KB
+@elizaos/plugin-xr:build: ESM dist/protocol.js                        613.00 B
+@elizaos/plugin-xr:build: ESM dist/index.js                           1.66 KB
+@elizaos/plugin-xr:build: ESM dist/routes/xr-view-host.js             11.07 KB
+@elizaos/plugin-xr:build: ESM dist/actions/xr-query-vision.js         1.37 KB
+@elizaos/plugin-xr:build: ESM dist/actions/xr-view-actions.js         11.03 KB
+@elizaos/plugin-xr:build: ESM dist/services/vision-pipeline.js        1.28 KB
+@elizaos/plugin-xr:build: ESM dist/services/xr-session-service.js     8.89 KB
+@elizaos/plugin-xr:build: ESM dist/routes/xr-view-host.js.map         14.00 KB
+@elizaos/plugin-xr:build: ESM dist/routes/xr-simulator-route.js.map   1.91 KB
+@elizaos/plugin-xr:build: ESM dist/index.js.map                       2.34 KB
+@elizaos/plugin-xr:build: ESM dist/routes/xr-status.js.map            1.55 KB
+@elizaos/plugin-xr:build: ESM dist/routes/xr-views.js.map             1.96 KB
+@elizaos/plugin-xr:build: ESM dist/providers/xr-context.js.map        2.13 KB
+@elizaos/plugin-xr:build: ESM dist/services/audio-pipeline.js.map     5.75 KB
+@elizaos/plugin-xr:build: ESM dist/services/xr-session-service.js.map 17.34 KB
+@elizaos/plugin-xr:build: ESM dist/actions/xr-view-actions.js.map     21.08 KB
+@elizaos/plugin-xr:build: ESM dist/actions/xr-query-vision.js.map     2.70 KB
+@elizaos/plugin-xr:build: ESM dist/services/vision-pipeline.js.map    2.68 KB
+@elizaos/plugin-xr:build: ESM dist/routes/xr-connect.js.map           4.61 KB
+@elizaos/plugin-xr:build: ESM dist/protocol.js.map                    4.56 KB
+@elizaos/plugin-xr:build: ESM ⚡️ Build success in 61ms
+@elizaos/plugin-xr:build: $ tsc --noCheck -p tsconfig.build.json
+@elizaos/plugin-reminders:build: [rewrite-dist-relative-imports] rewrote 2 file(s)
+@elizaos/app-core:build: [rewrite-dist-relative-imports] rewrote 118 file(s)
+@elizaos/plugin-google-chat:typecheck: cache miss, executing 5d1cfd577905b604
+@elizaos/plugin-gitpathologist:typecheck: cache miss, executing c683566b79118496
+@elizaos/plugin-browser:typecheck: cache miss, executing ae3026091b321057
+@elizaos/plugin-x402:typecheck: cache miss, executing 0c34c8b883e1f762
+@elizaos/coding-remote-runner:typecheck: cache miss, executing 7b28de54aa20a68e
+elizaos-cloudflare-worker:typecheck: cache miss, executing 3bbad7399446307b
+@elizaos/setup:typecheck: cache miss, executing 9ca05285b03a74b5
+@elizaos/cloud-sdk:typecheck: cache miss, executing e680a898cdcea03f
+@elizaos/plugin-google-chat:typecheck: $ tsgo --noEmit
+@elizaos/plugin-gitpathologist:typecheck: $ tsgo --noEmit
+@elizaos/plugin-x402:typecheck: $ tsgo --noEmit
+@elizaos/coding-remote-runner:typecheck: $ tsgo --noEmit
+@elizaos/plugin-browser:typecheck: $ tsgo --noEmit -p tsconfig.json
+elizaos-cloudflare-worker:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/setup:typecheck: $ tsgo --noEmit -p tsconfig.json&& tsgo --noEmit -p tsconfig.main.json
+@elizaos/cloud-sdk:typecheck: $ tsgo --noEmit
+@elizaos/plugin-ngrok:typecheck: cache miss, executing b0c45b8aac5f6804
+@elizaos/plugin-ngrok:typecheck: $ tsgo --noEmit
+@elizaos/plugin-agent-skills:typecheck: cache miss, executing d13410c3b24c2a6b
+@elizaos/plugin-agent-skills:typecheck: $ tsgo --noEmit
+@elizaos/plugin-video:typecheck: cache miss, executing 2a05de60867d5722
+@elizaos/plugin-video:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-aosp-local-inference:typecheck: cache miss, executing 9e5b61aa7419baa9
+@elizaos/plugin-aosp-local-inference:typecheck: $ tsgo -p tsconfig.json --noEmit
+elizaos:typecheck: cache miss, executing e2b3a3d2034cd484
+elizaos:typecheck: $ tsgo --noEmit
+@elizaos-benchmarks/lib:typecheck: cache miss, executing fb3a551557d50c2f
+@elizaos-benchmarks/lib:typecheck: $ tsgo --noEmit
+@elizaos/plugin-messages:typecheck: cache miss, executing ef7bb60b4b2f3160
+@elizaos/plugin-messages:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-zai:typecheck: cache miss, executing 522d22bbb9cd48fb
+@elizaos/plugin-zai:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-ainex:typecheck: cache miss, executing 5691ae3d58d6600e
+@elizaos/plugin-ainex:typecheck: $ tsgo --noEmit
+@elizaos/plugin-shell:typecheck: cache miss, executing 82f7de28feffc615
+@elizaos/plugin-shell:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/macosalarm:typecheck: cache miss, executing cb5b2015c5b23248
+@elizaos/macosalarm:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-nostr:typecheck: cache miss, executing f761e310cfc61845
+@elizaos/plugin-nostr:typecheck: $ tsgo --noEmit
+@elizaos/plugin-openrouter:typecheck: cache miss, executing eec89bdd7825f429
+@elizaos/plugin-openrouter:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/bench-eliza-1:typecheck: cache miss, executing e4dd616118ae6d0b
+@elizaos/plugin-benchmarks:typecheck: cache miss, executing 2d80cfb87afb0487
+@elizaos/plugin-trajectory-logger:typecheck: cache miss, executing ef5fd47a48a7add9
+@elizaos/bench-eliza-1:typecheck: $ tsgo --noEmit
+@elizaos/plugin-benchmarks:typecheck: $ tsgo --noEmit
+@elizaos/plugin-trajectory-logger:typecheck: $ tsgo --noEmit -p tsconfig.json
+trajectory-viewer:typecheck: cache miss, executing 1aaafe450cb74588
+trajectory-viewer:typecheck: $ tsc --noEmit
+@elizaos/plugin-google-genai:typecheck: cache miss, executing 8618ae44654d6e8e
+@elizaos/plugin-google-genai:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/app-model-tester:typecheck: cache miss, executing 1857ceb21f8d9782
+@elizaos/app-model-tester:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/core:typecheck: cache miss, executing 9b271227eae9ebc9
+@elizaos/core:typecheck: $ tsgo --noEmit -p ./tsconfig.json
+@elizaos/plugin-health:typecheck: cache miss, executing 805fc2d7c3bde6b8
+@elizaos/plugin-health:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/operator:typecheck: cache miss, executing 07f625d514f51d85
+@elizaos/operator:typecheck: $ tsgo --noEmit
+@elizaos/plugin-goals:typecheck: cache miss, executing c99b26913ffc7fb3
+@elizaos/macosreminders:typecheck: cache miss, executing 393e47d42569c23d
+@elizaos/plugin-goals:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/macosreminders:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-elevenlabs:typecheck: cache miss, executing d2625571422fb53b
+@elizaos/plugin-elevenlabs:typecheck: $ tsgo --project tsconfig.json --noEmit
+@elizaos/soc2-verify:typecheck: cache miss, executing 322fd1a44be734e4
+@elizaos/soc2-verify:typecheck: $ tsgo --noEmit -p tsconfig.json
+@moltbook/eliza-agent:typecheck: cache miss, executing c7de9e1cbc4e691f
+@moltbook/eliza-agent:typecheck: $ tsgo --noEmit
+@elizaos/os-usb-installer:typecheck: cache miss, executing 5b2dc3c638534a93
+@elizaos/os-usb-installer:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-edge-tts:typecheck: cache miss, executing a70d98cd17d2f55e
+@elizaos/plugin-edge-tts:typecheck: $ tsgo --noEmit
+@elizaos/cloud-services-common:typecheck: cache miss, executing 78f68cc5d1d1c56a
+@elizaos/cloud-services-common:typecheck: $ tsgo --noEmit
+@elizaos/registry:typecheck: cache miss, executing 504a504342919a05
+@elizaos/registry:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-embeddings:typecheck: cache miss, executing 04460c9f40d87490
+@elizaos/plugin-embeddings:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-calendly:typecheck: cache miss, executing a43a1a5c2dd05dc0
+@elizaos/plugin-app-control:typecheck: cache miss, executing eb6769e59a002455
+@elizaos/plugin-calendly:typecheck: $ tsgo --noEmit
+@elizaos/plugin-app-control:typecheck: $ tsgo --noEmit
+@elizaos/plugin-facewear:typecheck: cache miss, executing 0466fdeaedfcd780
+@elizaos/plugin-facewear:typecheck: $ tsgo --noEmit -p tsconfig.json
+bags-claimer:typecheck: cache miss, executing 5827322b31d9753b
+bags-claimer:typecheck: $ echo 'No TypeScript config; skipping typecheck'
+bags-claimer:typecheck: No TypeScript config; skipping typecheck
+@elizaos/electrobun:typecheck: cache miss, executing ead89514c5cb08ee
+@elizaos/electrobun:typecheck: $ tsgo --noEmit
+@elizaos/agent:typecheck: cache miss, executing 13f152a22b43d860
+@elizaos/agent:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-localdb:typecheck: cache miss, executing 7227f88b5eb2ea87
+@elizaos/plugin-localdb:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/tui:typecheck: cache miss, executing 712b49becba160f5
+@elizaos/tui:typecheck: $ tsgo --noEmit -p tsconfig.build.json
+@elizaos/os-homepage:typecheck: cache miss, executing c761868d4e592f7e
+@elizaos/os-homepage:typecheck: $ tsc -b
+eliza-next-example:typecheck: cache miss, executing 284eba6011f4084a
+eliza-next-example:typecheck: $ tsgo --noEmit
+@elizaos/plugin-signal:typecheck: cache miss, executing 42adcb642fcd7ff4
+@elizaos/plugin-signal:typecheck: $ tsgo --noEmit
+@elizaos/example-farcaster:typecheck: cache miss, executing 232c9238a96c99e9
+@elizaos/example-farcaster:typecheck: $ tsgo --noEmit
+@elizaos/plugin-cli-inference:typecheck: cache miss, executing c1d76e59f3f61f75
+@elizaos/plugin-cli-inference:typecheck: $ tsgo --noEmit
+@elizaos/aws-examples:typecheck: cache miss, executing cfc85216d309403e
+@elizaos/aws-examples:typecheck: $ tsgo --noEmit
+@elizaos/plugin-native-filesystem:typecheck: cache miss, executing afa95f01b490428e
+@elizaos/plugin-native-filesystem:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/three-agent-dialogue:typecheck: cache miss, executing 96b17d0cf4aa0387
+@elizaos/three-agent-dialogue:typecheck: $ tsgo --noEmit
+@elizaos-examples/html-eliza:typecheck: cache miss, executing 9ff3682751db339e
+@elizaos-examples/html-eliza:typecheck: $ echo 'No TypeScript config; skipping typecheck'
+@elizaos-examples/html-eliza:typecheck: No TypeScript config; skipping typecheck
+@elizaos/plugin-lmstudio:typecheck: cache miss, executing aceb63fef0e547f7
+@elizaos/plugin-lmstudio:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/gateway-webhook:typecheck: cache miss, executing 081b32d285cb9a33
+@elizaos/gateway-webhook:typecheck: $ tsgo --noEmit
+@elizaos/plugin-music:typecheck: cache miss, executing 55aedbe33dc6ff3b
+@elizaos/plugin-music:typecheck: $ tsgo --noEmit -p tsconfig.typecheck.json
+@elizaos/plugin-form:typecheck: cache miss, executing 9e9278c9bf5fbe29
+@elizaos/plugin-form:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-remote-manifest:typecheck: cache miss, executing 74093872764b7504
+@elizaos/plugin-remote-manifest:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/prompts:typecheck: cache miss, executing a363aa620a515c32
+@elizaos/prompts:typecheck: $ echo 'No TypeScript source files to check'
+@elizaos/prompts:typecheck: No TypeScript source files to check
+@elizaos/plugin-screenshare:typecheck: cache miss, executing 8fd1345758f41eef
+@elizaos/plugin-screenshare:typecheck: $ tsgo --noEmit -p tsconfig.json
+elizagotchi:typecheck: cache miss, executing 5f162e081226c154
+elizagotchi:typecheck: $ tsgo --noEmit
+@elizaos/plugin-local-storage:typecheck: cache miss, executing e9dfa4bc34f660ec
+@elizaos/plugin-local-storage:typecheck: $ tsgo --noEmit
+@elizaos/plugin-feishu:typecheck: cache miss, executing 4871516e4018d7b9
+@elizaos/plugin-feishu:typecheck: $ tsgo --noEmit
+@elizaos/plugin-wallet-ui:typecheck: cache miss, executing c90adbee0348a7c6
+@elizaos/plugin-wallet-ui:typecheck: $ tsgo --noEmit -p tsconfig.build.json
+@elizaos/example-game-of-life:typecheck: cache miss, executing 162f2b820e5f63b6
+@elizaos/example-game-of-life:typecheck: $ tsgo --noEmit
+@elizaos/plugin-slack:typecheck: cache miss, executing c8ddacfe01586e01
+@elizaos/plugin-slack:typecheck: $ tsgo --noEmit
+@elizaos/plugin-suno:typecheck: cache miss, executing d5ef8d537f09e3e8
+@elizaos/plugin-suno:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/cloud-e2e:typecheck: cache miss, executing 468f39e62394f8d0
+@elizaos/cloud-e2e:typecheck: $ tsc --noEmit
+@elizaos/bench-eliza-1-vision-cua-e2e:typecheck: cache miss, executing 7f7fcd3da90880c3
+@elizaos/bench-eliza-1-vision-cua-e2e:typecheck: $ tsgo --noEmit
+@elizaos/plugin-tee:typecheck: cache miss, executing 0aabfd617e675da9
+@elizaos/plugin-tee:typecheck: $ tsgo --noEmit
+@elizaos/plugin-mcp:typecheck: cache miss, executing a62a83f99421a787
+@elizaos/plugin-mcp:typecheck: $ tsgo --noEmit
+@elizaos/plugin-social-alpha:typecheck: cache miss, executing 5fe1d231f908871b
+@elizaos/plugin-social-alpha:typecheck: $ node ../../packages/scripts/with-package-build-lock.mjs packages/ui -- tsgo --noEmit -p tsconfig.build.json
+@elizaos/gateway-discord:typecheck: cache miss, executing e9708920cea3e815
+@elizaos/gateway-discord:typecheck: $ tsgo --noEmit
+@elizaos/vercel-edge-examples:typecheck: cache miss, executing 71e28368a130e834
+@elizaos/vercel-edge-examples:typecheck: $ tsgo --noEmit
+@elizaos/plugin-vector-browser:typecheck: cache miss, executing f4579463cec9b47a
+@elizaos/plugin-vector-browser:typecheck: $ tsgo --noEmit -p tsconfig.build.json
+@elizaos/plugin-starter:typecheck: cache miss, executing 037f0816ce0e5c9b
+@elizaos/plugin-starter:typecheck: $ tsgo --noEmit
+@elizaos/plugin-finances:typecheck: cache miss, executing 38f9cd69525fed57
+@elizaos/plugin-finances:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/os-android-system-ui:typecheck: cache miss, executing 960e8f6b3394c1ae
+@elizaos/os-android-system-ui:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-documents:typecheck: cache miss, executing 1d93bd668a278095
+@elizaos/plugin-documents:typecheck: $ tsgo --noEmit -p tsconfig.build.json
+@elizaos/skills:typecheck: cache miss, executing c36148bb301e10bb
+@elizaos/skills:typecheck: $ tsgo --noEmit -p tsconfig.build.json
+@elizaos/plugin-background-runner:typecheck: cache miss, executing 83b26a2191770dc2
+@elizaos/plugin-background-runner:typecheck: $ tsgo --noEmit
+@elizaos/plugin-pdf:typecheck: cache miss, executing 210d76d6292f86ae
+@elizaos/plugin-pdf:typecheck: $ tsgo --noEmit
+@elizaos/plugin-inmemorydb:typecheck: cache miss, executing 1338a1f4a70fa8ff
+@elizaos/plugin-inmemorydb:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-feed:typecheck: cache miss, executing fb4f321e38d6b6fb
+@elizaos/plugin-feed:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-x:typecheck: cache miss, executing 1e403ad96bd9acf4
+@elizaos/plugin-x:typecheck: $ tsgo --noEmit
+@elizaos/plugin-computeruse:typecheck: cache miss, executing ee7b1e684d494afb
+@elizaos/plugin-computeruse:typecheck: $ tsgo --noEmit
+@elizaos/plugin-nearai:typecheck: cache miss, executing c606063a9cdd3c99
+@elizaos/plugin-nearai:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-app-manager:typecheck: cache miss, executing 5a05f53ea8b2c1c9
+@elizaos/plugin-app-manager:typecheck: $ tsgo --noEmit --rootDir ../..
+@elizaos/plugin-inbox:typecheck: cache miss, executing 789e12481d6893d4
+@elizaos/plugin-inbox:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/ui:typecheck: cache miss, executing 5108f8a59f6bf567
+@elizaos/ui:typecheck: $ bun run generate:css-strings && tsgo --noEmit -p tsconfig.json
+@elizaos/ui:typecheck: $ node ../scripts/generate-css-strings.mjs
+@elizaos/ui:typecheck: [generate-css-strings] processed 0 target(s), updated 0
+@elizaos/plugin-relationships:typecheck: cache miss, executing 20e45342c2dda69a
+@elizaos/plugin-relationships:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-ollama:typecheck: cache miss, executing 122a50443d5ef40c
+@elizaos/plugin-ollama:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-remote-desktop:typecheck: cache miss, executing 36e9312e03240e15
+@elizaos/plugin-remote-desktop:typecheck: $ tsgo --noEmit -p tsconfig.json --rootDir ../..
+@elizaos/cloud-routing:typecheck: cache miss, executing 69cd87051f15d8fa
+@elizaos/cloud-routing:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-todos:typecheck: cache miss, executing c060990c327034c2
+@elizaos/plugin-todos:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-linear:typecheck: cache miss, executing d9e1fa528b33cf39
+@elizaos/plugin-linear:typecheck: $ tsgo --noEmit
+@elizaos/plugin-blocker:typecheck: cache miss, executing bf8d39455a99fb00
+@elizaos/plugin-blocker:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-phone:typecheck: cache miss, executing 9a6e96e843bb420f
+@elizaos/plugin-phone:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-instagram:typecheck: cache miss, executing 46b6a5683cc65afb
+@elizaos/plugin-instagram:typecheck: $ tsgo --noEmit
+@elizaos/plugin-github:typecheck: cache miss, executing b35c45a94350974c
+@elizaos/plugin-github:typecheck: $ tsgo --noEmit
+@elizaos/example-agent-console:typecheck: cache miss, executing a37459597e927868
+@elizaos/plugin-tunnel:typecheck: cache miss, executing f742806fcda9c041
+@elizaos/example-agent-console:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-tunnel:typecheck: $ tsgo --noEmit
+@elizaos/example-lp-manager:typecheck: cache miss, executing 46016cd02d01ef65
+@elizaos/example-lp-manager:typecheck: $ tsgo --noEmit
+@elizaos/example-clone-ur-crush:typecheck: cache miss, executing f32fedfb38b318a6
+@elizaos/example-clone-ur-crush:typecheck: $ tsgo --noEmit
+@elizaos/example-x402-image-gen:typecheck: cache miss, executing 8e3507a91336e907
+@elizaos/example-x402-image-gen:typecheck: $ tsgo --noEmit
+@elizaos/agent-server:typecheck: cache miss, executing 4b9a72691a829781
+@elizaos/agent-server:typecheck: $ tsgo --noEmit
+@elizaos/example-app-electron-workspace:typecheck: cache miss, executing a672cbb6b278fc7e
+@elizaos/example-app-electron-workspace:typecheck: $ echo 'No TypeScript config; skipping typecheck'
+@elizaos/example-app-electron-workspace:typecheck: No TypeScript config; skipping typecheck
+@elizaos/robot:typecheck: cache miss, executing fa8eb8aa3057b79f
+@elizaos/robot:typecheck: $ tsgo --noEmit
+@elizaos/plugin-matrix:typecheck: cache miss, executing 7be77f2ae8f18dca
+@elizaos/plugin-matrix:typecheck: $ tsgo --noEmit
+@elizaos/plugin-hyperliquid:typecheck: cache miss, executing a5f611feb0af486c
+@elizaos/plugin-hyperliquid:typecheck: $ tsgo --noEmit -p tsconfig.build.json
+@elizaos/plugin-groq:typecheck: cache miss, executing cad815565f689eba
+@elizaos/plugin-groq:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/logger:typecheck: cache miss, executing c2a3dc9ef4871f21
+@elizaos/logger:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/vault:typecheck: cache miss, executing 357c14d8e177c4cc
+@elizaos/vault:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/example-text-adventure:typecheck: cache miss, executing 3c0d43cfc5976683
+@elizaos/example-text-adventure:typecheck: $ tsgo --noEmit
+@elizaos/plugin-discord-local:typecheck: cache miss, executing b0619778ad138714
+@elizaos/plugin-discord-local:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-openai:typecheck: cache miss, executing 970744d12aa5873c
+@elizaos/plugin-openai:typecheck: $ tsgo --noEmit
+@elizaos/plugin-imessage:typecheck: cache miss, executing d66c4a79daa34b9d
+@elizaos/plugin-imessage:typecheck: $ tsgo --noEmit
+@elizaos/plugin-xai:typecheck: cache miss, executing 423be3e951c3278e
+@elizaos/plugin-xai:typecheck: $ tsgo --noEmit
+@elizaos/example-discord:typecheck: cache miss, executing 9bf24634a7fd47ef
+@elizaos/example-discord:typecheck: $ tsgo --noEmit
+@elizaos/plugin-shopify:typecheck: cache miss, executing d13228f71d2bbe08
+@elizaos/plugin-shopify:typecheck: $ tsgo --noEmit -p tsconfig.build.json
+@elizaos/plugin-registry:typecheck: cache miss, executing bc2ff55c39ce33ba
+@elizaos/plugin-registry:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/contracts:typecheck: cache miss, executing f9e4affc4f038f31
+@elizaos/contracts:typecheck: $ tsgo --noEmit
+@elizaos/example-autonomous:typecheck: cache miss, executing 8fa3d2f36b2d1ad4
+@elizaos/example-autonomous:typecheck: $ tsgo --noEmit
+@elizaos/example-app-capacitor-backend:typecheck: cache miss, executing a20396aa172a4dea
+@elizaos/example-app-capacitor-backend:typecheck: $ tsc --noEmit
+@elizaos/plugin-workflow:typecheck: cache miss, executing 61f1541fd3ad595d
+@elizaos/plugin-workflow:typecheck: $ tsgo --noEmit -p tsconfig.typecheck.json
+@elizaos/plugin-scheduling:typecheck: cache miss, executing de344f2930bf5687
+@elizaos/plugin-scheduling:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/shared:typecheck: cache miss, executing fbb78b69d91458ff
+@elizaos/shared:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/example-smartglasses:typecheck: cache miss, executing 4d7c7534988db586
+@elizaos/example-smartglasses:typecheck: $ bun run --cwd ../../../plugins/plugin-facewear build && node ../../../packages/scripts/ensure-workspace-symlinks.mjs && BUN_INSTALL_CACHE_DIR=/tmp/eliza-bun-cache-clean bunx --package typescript@6.0.3 tsc --noEmit -p tsconfig.json
+@elizaos/example-smartglasses:typecheck: $ bun run build:js && bun run build:views && bun run build:types
+@elizaos/example-smartglasses:typecheck: $ tsup --config ../tsup.plugin-packages.shared.ts
+@elizaos/example-smartglasses:typecheck: CLI Building entry: src/register-terminal-view.tsx, src/status-format.ts, src/index.ts, src/register.ts, src/ui/SmartglassesView.helpers.ts, src/ui/facewear-view-bundle.ts, src/ui/SmartglassesView.tsx, src/components/SmartglassesSpatialView.tsx, src/components/facewear-profiles.ts, src/components/SmartglassesPanelView.tsx, src/components/WearablesSettingsSection.tsx, src/components/FacewearView.tsx, src/components/FacewearSpatialView.tsx, src/protocol/xr.ts, src/protocol/smartglasses.ts, src/runtime/node-probe.ts, src/runtime/openxr-runtime.ts, src/providers/smartglasses-status.ts, src/providers/facewear-context.ts, src/transport/mock.ts, src/transport/even-bridge.ts, src/transport/web-bluetooth.ts, src/transport/types.ts, src/transport/noble.ts, src/actions/vision-query.ts, src/actions/microphone.ts, src/actions/xr-runtime-setup.ts, src/actions/facewear-control.ts, src/actions/facewear-connect.ts, src/actions/display-text.ts, src/actions/xr-view-actions.ts, src/actions/facewear-status.ts, src/actions/view-actions.ts, src/actions/facewear-debug.ts, src/routes/status.ts, src/routes/views.ts, src/routes/view-host.ts, src/routes/simulator-route.ts, src/routes/device-config.ts, src/routes/connect.ts, src/routes/xr-runtime.ts, src/services/smartglasses-service.ts, src/services/facewear-service.ts, src/services/audio-pipeline.ts, src/services/xr-session-service.ts, src/services/vision-pipeline.ts, src/devices/meta-quest.ts, src/devices/even-realities.ts, src/devices/registry.ts, src/devices/apple-vision-pro.ts, src/devices/xreal.ts
+@elizaos/example-smartglasses:typecheck: CLI Using tsconfig: tsconfig.json
+@elizaos/example-smartglasses:typecheck: CLI tsup v8.5.1
+@elizaos/example-smartglasses:typecheck: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/tsup.plugin-packages.shared.ts
+@elizaos/example-smartglasses:typecheck: CLI Target: es2022
+@elizaos/example-smartglasses:typecheck: ESM Build start
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/microphone.js                      2.37 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/status-format.js                           3.17 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/protocol/xr.js                             607.00 B
+@elizaos/example-smartglasses:typecheck: ESM dist/register-terminal-view.js                  1.88 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/index.js                                   9.88 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/runtime/openxr-runtime.js                  7.39 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/register.js                                804.00 B
+@elizaos/example-smartglasses:typecheck: ESM dist/ui/SmartglassesView.helpers.js             9.39 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/transport/types.js                         33.00 B
+@elizaos/example-smartglasses:typecheck: ESM dist/transport/even-bridge.js                   18.27 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/ui/facewear-view-bundle.js                 242.00 B
+@elizaos/example-smartglasses:typecheck: ESM dist/transport/web-bluetooth.js                 4.97 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/ui/SmartglassesView.js                     41.98 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/status-format.js.map                       5.94 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/protocol/smartglasses.js                   43.80 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/providers/smartglasses-status.js           2.08 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/microphone.js.map                  4.16 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/vision-query.js                    1.45 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/components/WearablesSettingsSection.js     2.03 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/components/FacewearView.js                 3.18 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/components/facewear-profiles.js            1.04 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/routes/device-config.js                    1.47 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/components/SmartglassesPanelView.js        3.86 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/transport/mock.js                          3.15 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/view-actions.js                    11.41 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/providers/facewear-context.js              2.12 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/display-text.js                    3.20 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/xr-view-actions.js                 892.00 B
+@elizaos/example-smartglasses:typecheck: ESM dist/components/FacewearSpatialView.js          5.81 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/facewear-connect.js                2.72 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/facewear-status.js                 2.72 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/register.js.map                            1.97 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/components/SmartglassesSpatialView.js      8.44 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/runtime/node-probe.js                      1.63 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/transport/noble.js                         7.85 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/facewear-control.js                22.98 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/ui/SmartglassesView.helpers.js.map         20.44 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/transport/types.js.map                     71.00 B
+@elizaos/example-smartglasses:typecheck: ESM dist/devices/even-realities.js                  491.00 B
+@elizaos/example-smartglasses:typecheck: ESM dist/services/xr-session-service.js             11.17 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/services/vision-pipeline.js                1.29 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/runtime/openxr-runtime.js.map              16.76 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/services/facewear-service.js               1.36 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/ui/facewear-view-bundle.js.map             843.00 B
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/xr-runtime-setup.js                2.45 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/services/smartglasses-service.js           27.81 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/routes/views.js                            945.00 B
+@elizaos/example-smartglasses:typecheck: ESM dist/devices/registry.js                        2.41 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/index.js.map                               13.12 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/routes/status.js                           831.00 B
+@elizaos/example-smartglasses:typecheck: ESM dist/routes/view-host.js                        11.79 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/routes/xr-runtime.js                       561.00 B
+@elizaos/example-smartglasses:typecheck: ESM dist/transport/even-bridge.js.map               36.73 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/devices/meta-quest.js                      398.00 B
+@elizaos/example-smartglasses:typecheck: ESM dist/transport/web-bluetooth.js.map             11.25 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/xr-view-actions.js.map             1.27 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/transport/mock.js.map                      7.34 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/display-text.js.map                5.89 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/components/facewear-profiles.js.map        2.97 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/vision-query.js.map                2.80 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/ui/SmartglassesView.js.map                 67.09 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/components/WearablesSettingsSection.js.map 3.83 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/view-actions.js.map                21.53 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/providers/facewear-context.js.map          3.76 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/components/SmartglassesPanelView.js.map    8.60 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/providers/smartglasses-status.js.map       3.67 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/facewear-debug.js                  1.86 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/routes/simulator-route.js                  1.08 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/facewear-control.js.map            42.18 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/components/SmartglassesSpatialView.js.map  15.82 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/facewear-connect.js.map            4.62 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/facewear-status.js.map             4.48 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/components/FacewearSpatialView.js.map      11.55 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/runtime/node-probe.js.map                  3.44 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/protocol/xr.js.map                         4.91 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/protocol/smartglasses.js.map               75.46 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/register-terminal-view.js.map              4.04 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/services/audio-pipeline.js                 2.66 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/devices/xreal.js                           501.00 B
+@elizaos/example-smartglasses:typecheck: ESM dist/transport/noble.js.map                     17.48 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/routes/connect.js                          3.36 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/routes/device-config.js.map                2.67 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/components/FacewearView.js.map             7.30 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/devices/apple-vision-pro.js                532.00 B
+@elizaos/example-smartglasses:typecheck: ESM dist/devices/even-realities.js.map              667.00 B
+@elizaos/example-smartglasses:typecheck: ESM dist/services/xr-session-service.js.map         21.86 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/xr-runtime-setup.js.map            4.62 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/routes/views.js.map                        1.96 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/services/smartglasses-service.js.map       54.51 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/services/facewear-service.js.map           2.95 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/facewear-debug.js.map              3.44 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/routes/connect.js.map                      4.60 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/services/vision-pipeline.js.map            2.70 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/routes/status.js.map                       1.54 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/devices/meta-quest.js.map                  683.00 B
+@elizaos/example-smartglasses:typecheck: ESM dist/routes/simulator-route.js.map              2.00 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/devices/xreal.js.map                       817.00 B
+@elizaos/example-smartglasses:typecheck: ESM dist/routes/view-host.js.map                    14.82 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/routes/xr-runtime.js.map                   1.19 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/services/audio-pipeline.js.map             5.76 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/devices/apple-vision-pro.js.map            817.00 B
+@elizaos/example-smartglasses:typecheck: ESM dist/devices/registry.js.map                    4.62 KB
+@elizaos/example-smartglasses:typecheck: ESM ⚡️ Build success in 167ms
+@elizaos/example-smartglasses:typecheck: $ bunx --bun vite build --config vite.config.views.ts
+@elizaos/example-smartglasses:typecheck: vite v8.0.16 building client environment for production...
+@elizaos/example-smartglasses:typecheck: [2K@elizaos/example-smartglasses:typecheck: transforming...✓ 9 modules transformed.
+@elizaos/example-smartglasses:typecheck: rendering chunks...
+@elizaos/example-smartglasses:typecheck: computing gzip size...
+@elizaos/example-smartglasses:typecheck: dist/views/bundle.js  19.35 kB │ gzip: 5.08 kB │ map: 109.04 kB
+@elizaos/example-smartglasses:typecheck:
+@elizaos/example-smartglasses:typecheck: ✓ built in 162ms
+@elizaos/example-smartglasses:typecheck: $ bunx tsc --noCheck -p tsconfig.build.json && node ../../packages/scripts/rewrite-dist-relative-imports-node-esm.mjs
+@elizaos/plugin-whatsapp:typecheck: cache miss, executing 6cc13df5b702dc39
+@elizaos/plugin-whatsapp:typecheck: $ tsgo --noEmit -p tsconfig.json
+eliza-app:typecheck: cache miss, executing 3736a86484b616e2
+eliza-app:typecheck: $ node ../app-core/scripts/write-homepage-release-data.mjs && tsc -b
+eliza-app:typecheck: homepage release data: stable=v2.0.3-beta.7, canary=v2.0.3-beta.7, osArtifacts=10
+@elizaos/plugin-bluesky:typecheck: cache miss, executing 0f6d814207c38ca8
+@elizaos/plugin-bluesky:typecheck: $ tsgo --noEmit
+@elizaos/plugin-anthropic-proxy:typecheck: cache miss, executing d38ca075eaa522b1
+@elizaos/plugin-anthropic-proxy:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-twitch:typecheck: cache miss, executing d5885c4ef2a707ff
+@elizaos/plugin-twitch:typecheck: $ tsgo --noEmit
+@elizaos/example-tic-tac-toe:typecheck: cache miss, executing e24b1a699df7b434
+@elizaos/example-tic-tac-toe:typecheck: $ tsgo --noEmit
+@elizaos/native-activity-tracker:typecheck: cache miss, executing 193edff959133d28
+@elizaos/native-activity-tracker:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-google:typecheck: cache miss, executing 7404ebc8a4054d89
+@elizaos/plugin-google:typecheck: $ tsgo --noEmit
+@elizaos/plugin-sql:typecheck: cache miss, executing 4e722abd19763c84
+@elizaos/plugin-sql:typecheck: $ tsgo --noEmit -p src/tsconfig.json
+@elizaos/container-control-plane:typecheck: cache miss, executing 4fa157ee610a5dc3
+@elizaos/container-control-plane:typecheck: $ tsgo --noEmit
+@elizaos/plugin-codex-cli:typecheck: cache miss, executing d5b20f633332a98b
+@elizaos/plugin-codex-cli:typecheck: $ tsgo --noEmit
+@elizaos/example-app-capacitor:typecheck: cache miss, executing a97b46448d60131c
+@elizaos/example-app-capacitor:typecheck: $ echo 'No TypeScript config; skipping typecheck'
+@elizaos/example-app-capacitor:typecheck: No TypeScript config; skipping typecheck
+@elizaos/example-browser-extension:typecheck: cache miss, executing d0c384ff86c19f8e
+@elizaos/example-browser-extension:typecheck: $ echo 'No TypeScript config; skipping typecheck'
+@elizaos/example-browser-extension:typecheck: No TypeScript config; skipping typecheck
+@elizaos/example-form:typecheck: cache miss, executing 615cd72056e3a8e1
+@elizaos/example-form:typecheck: $ bun run --cwd ../chat typecheck
+@elizaos/example-form:typecheck: $ tsgo --noEmit
+@elizaos/plugin-web-search:typecheck: cache miss, executing 6860ce3ba3d0e151
+@elizaos/plugin-web-search:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/example-mcp-server:typecheck: cache miss, executing 572968c85cde896c
+@elizaos/example-mcp-server:typecheck: $ tsgo --noEmit
+@elizaos/plugin-streaming:typecheck: cache miss, executing d9a673c18b49f9bd
+@elizaos/plugin-streaming:typecheck: $ tsgo --noEmit
+@elizaos/plugin-anthropic:typecheck: cache miss, executing 3eabd56badd456aa
+@elizaos/plugin-anthropic:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/interrupt-bench:typecheck: cache miss, executing c6d70f723b298f8c
+@elizaos/interrupt-bench:typecheck: $ tsgo --noEmit
+@elizaos/plugin-blocker:build: cache miss, executing 8c609ef6d4083376
+@elizaos/plugin-blocker:build: $ bun run build:js && bun run build:views && bun run build:types
+@elizaos/plugin-blocker:build: $ tsup --config ../tsup.plugin-packages.shared.ts
+@elizaos/plugin-todos:build: cache miss, executing a7e41bf7f4fb4779
+@elizaos/plugin-todos:build: $ bun run build:js && bun run build:views && bun run build:types
+@elizaos/plugin-todos:build: $ tsup --config ../tsup.plugin-packages.shared.ts
+@elizaos/example-smartglasses:typecheck: [rewrite-dist-relative-imports] rewrote 25 file(s)
+@elizaos/plugin-blocker:build: CLI Building entry: src/plugin.ts, src/types.ts, src/register-terminal-view.tsx, src/index.ts, src/register.ts, src/providers/app-blocker.ts, src/providers/website-blocker.ts, src/db/schema.ts, src/db/index.ts, src/components/focus/FocusView.tsx, src/components/focus/FocusSpatialView.tsx, src/components/focus/focus-view-bundle.ts, src/services/website-blocker/permissions.ts, src/services/website-blocker/engine.ts, src/services/website-blocker/access.ts, src/services/website-blocker/roles.ts, src/services/website-blocker/index.ts, src/services/website-blocker/service.ts, src/services/app-blocker/engine.ts, src/services/app-blocker/types.ts, src/services/app-blocker/access.ts, src/services/app-blocker/index.ts, src/services/app-blocker/service.ts
+@elizaos/plugin-blocker:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-blocker:build: CLI tsup v8.5.1
+@elizaos/plugin-blocker:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/tsup.plugin-packages.shared.ts
+@elizaos/example-smartglasses:typecheck: [ensure-workspace-symlinks] created=0 skipped=436 hoisted=0 missing-roots=0
+@elizaos/plugin-blocker:build: CLI Target: es2022
+@elizaos/plugin-blocker:build: ESM Build start
+@elizaos/example-smartglasses:typecheck: Saved lockfile
+@elizaos/plugin-blocker:build: ESM dist/plugin.js                                   2.46 KB
+@elizaos/plugin-blocker:build: ESM dist/services/app-blocker/engine.js              2.07 KB
+@elizaos/plugin-blocker:build: ESM dist/services/website-blocker/access.js          1.30 KB
+@elizaos/plugin-blocker:build: ESM dist/services/app-blocker/types.js               33.00 B
+@elizaos/plugin-blocker:build: ESM dist/services/app-blocker/index.js               793.00 B
+@elizaos/plugin-blocker:build: ESM dist/services/app-blocker/access.js              1.31 KB
+@elizaos/plugin-blocker:build: ESM dist/register-terminal-view.js                   590.00 B
+@elizaos/plugin-blocker:build: ESM dist/services/app-blocker/service.js             769.00 B
+@elizaos/plugin-blocker:build: ESM dist/types.js                                    638.00 B
+@elizaos/plugin-blocker:build: ESM dist/services/website-blocker/roles.js           586.00 B
+@elizaos/plugin-blocker:build: ESM dist/services/website-blocker/service.js         9.95 KB
+@elizaos/plugin-blocker:build: ESM dist/services/website-blocker/index.js           2.03 KB
+@elizaos/plugin-blocker:build: ESM dist/services/website-blocker/permissions.js     39.00 B
+@elizaos/plugin-blocker:build: ESM dist/components/focus/focus-view-bundle.js       113.00 B
+@elizaos/plugin-blocker:build: ESM dist/components/focus/FocusSpatialView.js        3.71 KB
+@elizaos/plugin-blocker:build: ESM dist/index.js                                    848.00 B
+@elizaos/plugin-blocker:build: ESM dist/db/index.js                                 62.00 B
+@elizaos/plugin-blocker:build: ESM dist/providers/app-blocker.js                    3.60 KB
+@elizaos/plugin-blocker:build: ESM dist/components/focus/FocusView.js               3.67 KB
+@elizaos/plugin-blocker:build: ESM dist/db/schema.js                                2.40 KB
+@elizaos/plugin-blocker:build: ESM dist/register.js                                 183.00 B
+@elizaos/plugin-blocker:build: ESM dist/services/website-blocker/engine.js          40.53 KB
+@elizaos/plugin-blocker:build: ESM dist/providers/website-blocker.js                5.89 KB
+@elizaos/plugin-blocker:build: ESM dist/services/app-blocker/types.js.map           71.00 B
+@elizaos/plugin-blocker:build: ESM dist/plugin.js.map                               4.72 KB
+@elizaos/plugin-blocker:build: ESM dist/services/app-blocker/engine.js.map          4.96 KB
+@elizaos/plugin-blocker:build: ESM dist/services/website-blocker/roles.js.map       1.39 KB
+@elizaos/plugin-blocker:build: ESM dist/types.js.map                                2.07 KB
+@elizaos/plugin-blocker:build: ESM dist/db/index.js.map                             138.00 B
+@elizaos/plugin-blocker:build: ESM dist/services/app-blocker/service.js.map         1.55 KB
+@elizaos/plugin-blocker:build: ESM dist/services/app-blocker/index.js.map           1.00 KB
+@elizaos/plugin-blocker:build: ESM dist/services/app-blocker/access.js.map          2.58 KB
+@elizaos/plugin-blocker:build: ESM dist/db/schema.js.map                            5.15 KB
+@elizaos/plugin-blocker:build: ESM dist/index.js.map                                1.08 KB
+@elizaos/plugin-blocker:build: ESM dist/components/focus/FocusView.js.map           8.70 KB
+@elizaos/plugin-blocker:build: ESM dist/services/website-blocker/access.js.map      2.83 KB
+@elizaos/plugin-blocker:build: ESM dist/providers/website-blocker.js.map            8.96 KB
+@elizaos/plugin-blocker:build: ESM dist/register.js.map                             872.00 B
+@elizaos/plugin-blocker:build: ESM dist/register-terminal-view.js.map               1.54 KB
+@elizaos/plugin-blocker:build: ESM dist/components/focus/focus-view-bundle.js.map   492.00 B
+@elizaos/plugin-blocker:build: ESM dist/services/website-blocker/engine.js.map      76.12 KB
+@elizaos/plugin-blocker:build: ESM dist/providers/app-blocker.js.map                6.04 KB
+@elizaos/plugin-blocker:build: ESM dist/services/website-blocker/service.js.map     18.17 KB
+@elizaos/plugin-blocker:build: ESM dist/components/focus/FocusSpatialView.js.map    8.09 KB
+@elizaos/plugin-blocker:build: ESM dist/services/website-blocker/permissions.js.map 71.00 B
+@elizaos/plugin-blocker:build: ESM dist/services/website-blocker/index.js.map       1.98 KB
+@elizaos/plugin-blocker:build: ESM ⚡️ Build success in 289ms
+@elizaos/plugin-blocker:build: $ bunx --bun vite build --config vite.config.views.ts
+@elizaos/plugin-todos:build: CLI Building entry: src/types.ts, src/register-terminal-view.tsx, src/index.ts, src/register.ts, src/service.ts, src/providers/current-todos.ts, src/db/schema.ts, src/db/index.ts, src/actions/todo.ts, src/components/todos/todos-view-bundle.ts, src/components/todos/TodosView.tsx, src/components/todos/TodosSpatialView.tsx
+@elizaos/plugin-todos:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-todos:build: CLI tsup v8.5.1
+@elizaos/plugin-todos:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/tsup.plugin-packages.shared.ts
+@elizaos/plugin-todos:build: CLI Target: es2022
+@elizaos/plugin-todos:build: ESM Build start
+@elizaos/plugin-todos:build: ESM dist/types.js                                  586.00 B
+@elizaos/plugin-todos:build: ESM dist/components/todos/TodosSpatialView.js      3.03 KB
+@elizaos/plugin-todos:build: ESM dist/register-terminal-view.js                 639.00 B
+@elizaos/plugin-todos:build: ESM dist/db/schema.js                              1.23 KB
+@elizaos/plugin-todos:build: ESM dist/db/index.js                               62.00 B
+@elizaos/plugin-todos:build: ESM dist/components/todos/todos-view-bundle.js     113.00 B
+@elizaos/plugin-todos:build: ESM dist/components/todos/TodosView.js             4.44 KB
+@elizaos/plugin-todos:build: ESM dist/index.js                                  2.19 KB
+@elizaos/plugin-todos:build: ESM dist/register.js                               183.00 B
+@elizaos/plugin-todos:build: ESM dist/actions/todo.js                           15.60 KB
+@elizaos/plugin-todos:build: ESM dist/service.js                                6.74 KB
+@elizaos/plugin-todos:build: ESM dist/providers/current-todos.js                1.25 KB
+@elizaos/plugin-todos:build: ESM dist/types.js.map                              1.63 KB
+@elizaos/plugin-todos:build: ESM dist/service.js.map                            13.90 KB
+@elizaos/plugin-todos:build: ESM dist/actions/todo.js.map                       30.91 KB
+@elizaos/plugin-todos:build: ESM dist/register.js.map                           860.00 B
+@elizaos/plugin-todos:build: ESM dist/db/index.js.map                           138.00 B
+@elizaos/plugin-todos:build: ESM dist/index.js.map                              3.31 KB
+@elizaos/plugin-todos:build: ESM dist/components/todos/TodosView.js.map         12.39 KB
+@elizaos/plugin-todos:build: ESM dist/register-terminal-view.js.map             1.60 KB
+@elizaos/plugin-todos:build: ESM dist/db/schema.js.map                          2.36 KB
+@elizaos/plugin-todos:build: ESM dist/providers/current-todos.js.map            2.97 KB
+@elizaos/plugin-todos:build: ESM dist/components/todos/TodosSpatialView.js.map  7.19 KB
+@elizaos/plugin-todos:build: ESM dist/components/todos/todos-view-bundle.js.map 473.00 B
+@elizaos/plugin-todos:build: ESM ⚡️ Build success in 251ms
+@elizaos/plugin-todos:build: $ bunx --bun vite build --config vite.config.views.ts
+@elizaos/plugin-blocker:build: vite v8.0.16 building client environment for production...
+@elizaos/plugin-blocker:build: [2K@elizaos/plugin-blocker:build: transforming...✓ 4 modules transformed.
+@elizaos/plugin-todos:build: vite v8.0.16 building client environment for production...
+@elizaos/plugin-blocker:build: rendering chunks...
+@elizaos/plugin-blocker:build: computing gzip size...
+@elizaos/plugin-blocker:build: dist/views/bundle.js  5.86 kB │ gzip: 1.87 kB │ map: 16.56 kB
+@elizaos/plugin-blocker:build:
+@elizaos/plugin-blocker:build: ✓ built in 643ms
+@elizaos/plugin-todos:build: [2K@elizaos/plugin-todos:build: transforming...✓ 4 modules transformed.
+@elizaos/plugin-blocker:build: $ bunx tsc --noCheck -p tsconfig.build.json && node ../../packages/scripts/rewrite-dist-relative-imports-node-esm.mjs
+@elizaos/plugin-todos:build: rendering chunks...
+@elizaos/plugin-todos:build: computing gzip size...
+@elizaos/plugin-todos:build: dist/views/bundle.js  5.85 kB │ gzip: 2.09 kB │ map: 19.33 kB
+@elizaos/plugin-todos:build:
+@elizaos/plugin-todos:build: ✓ built in 316ms
+@elizaos/plugin-todos:build: $ tsc --noCheck -p tsconfig.build.json
+@elizaos/plugin-calendar:build: cache miss, executing 2c0dee6d57cc2285
+@elizaos/plugin-calendar:build: $ bun run build:js && bun run build:views && bun run build:types
+@elizaos/plugin-calendar:build: $ bun run clean && tsup --config tsup.config.ts
+@elizaos/plugin-calendar:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist .turbo
+@elizaos/plugin-calendar:build: CLI Building entry: src/plugin.ts, src/apple-calendar.ts, src/register-terminal-view.tsx, src/ui.ts, src/index.ts, src/register.ts, src/internal/sql.ts, src/internal/errors.ts, src/internal/detail.ts, src/internal/format.ts, src/internal/constants.ts, src/internal/normalize.ts, src/internal/google-delegates.ts, src/internal/calendar-normalize.ts, src/internal/time.ts, src/components/EventEditorDrawer.tsx, src/components/CalendarSection.tsx, src/hooks/useCalendarWeek.ts, src/api/client-calendar.ts, src/actions/conflict-detect.ts, src/actions/calendar.ts, src/actions/optimized-prompt-instructions.ts, src/actions/index.ts, src/actions/deps.ts, src/actions/calendar-handler.ts, src/service/schema.ts, src/service/CalendarService.ts, src/service/migration.ts, src/service/gate.ts, src/service/feed-preferences.ts, src/service/index.ts, src/service/CalendarRepository.ts, src/routes/calendar-routes.ts, src/routes/plugin-routes.ts, src/components/calendar/calendar-view-bundle.ts, src/components/calendar/CalendarView.tsx, src/components/calendar/CalendarSpatialView.tsx
+@elizaos/plugin-calendar:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-calendar:build: CLI tsup v8.5.1
+@elizaos/plugin-calendar:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/plugin-calendar/tsup.config.ts
+@elizaos/plugin-calendar:build: CLI Target: es2022
+@elizaos/plugin-calendar:build: ESM Build start
+@elizaos/plugin-calendar:build: ESM dist/plugin.js                                       1.58 KB
+@elizaos/plugin-calendar:build: ESM dist/api/client-calendar.js                          3.28 KB
+@elizaos/plugin-calendar:build: ESM dist/actions/calendar.js                             3.89 KB
+@elizaos/plugin-calendar:build: ESM dist/actions/optimized-prompt-instructions.js        5.12 KB
+@elizaos/plugin-calendar:build: ESM dist/components/calendar/calendar-view-bundle.js     125.00 B
+@elizaos/plugin-calendar:build: ESM dist/components/calendar/CalendarView.js             3.59 KB
+@elizaos/plugin-calendar:build: ESM dist/internal/sql.js                                 3.39 KB
+@elizaos/plugin-calendar:build: ESM dist/register-terminal-view.js                       652.00 B
+@elizaos/plugin-calendar:build: ESM dist/index.js                                        1.44 KB
+@elizaos/plugin-calendar:build: ESM dist/internal/normalize.js                           4.41 KB
+@elizaos/plugin-calendar:build: ESM dist/internal/constants.js                           1.39 KB
+@elizaos/plugin-calendar:build: ESM dist/internal/errors.js                              389.00 B
+@elizaos/plugin-calendar:build: ESM dist/apple-calendar.js                               14.93 KB
+@elizaos/plugin-calendar:build: ESM dist/ui.js                                           306.00 B
+@elizaos/plugin-calendar:build: ESM dist/routes/plugin-routes.js                         7.47 KB
+@elizaos/plugin-calendar:build: ESM dist/register.js                                     186.00 B
+@elizaos/plugin-calendar:build: ESM dist/actions/index.js                                264.00 B
+@elizaos/plugin-calendar:build: ESM dist/internal/format.js                              4.43 KB
+@elizaos/plugin-calendar:build: ESM dist/actions/conflict-detect.js                      2.56 KB
+@elizaos/plugin-calendar:build: ESM dist/actions/deps.js                                 32.00 B
+@elizaos/plugin-calendar:build: ESM dist/hooks/useCalendarWeek.js                        3.75 KB
+@elizaos/plugin-calendar:build: ESM dist/routes/calendar-routes.js                       4.77 KB
+@elizaos/plugin-calendar:build: ESM dist/internal/detail.js                              1.84 KB
+@elizaos/plugin-calendar:build: ESM dist/components/CalendarSection.js                   36.39 KB
+@elizaos/plugin-calendar:build: ESM dist/internal/time.js                                3.56 KB
+@elizaos/plugin-calendar:build: ESM dist/components/EventEditorDrawer.js                 29.93 KB
+@elizaos/plugin-calendar:build: ESM dist/service/CalendarService.js                      26.04 KB
+@elizaos/plugin-calendar:build: ESM dist/service/schema.js                               2.47 KB
+@elizaos/plugin-calendar:build: ESM dist/internal/google-delegates.js                    13.62 KB
+@elizaos/plugin-calendar:build: ESM dist/internal/calendar-normalize.js                  9.73 KB
+@elizaos/plugin-calendar:build: ESM dist/service/feed-preferences.js                     3.35 KB
+@elizaos/plugin-calendar:build: ESM dist/service/migration.js                            3.74 KB
+@elizaos/plugin-calendar:build: ESM dist/service/gate.js                                 3.19 KB
+@elizaos/plugin-calendar:build: ESM dist/components/calendar/CalendarSpatialView.js      3.63 KB
+@elizaos/plugin-calendar:build: ESM dist/service/index.js                                1.14 KB
+@elizaos/plugin-calendar:build: ESM dist/service/CalendarRepository.js                   9.84 KB
+@elizaos/plugin-calendar:build: ESM dist/actions/calendar-handler.js                     116.71 KB
+@elizaos/plugin-calendar:build: ESM dist/actions/calendar.js.map                         8.66 KB
+@elizaos/plugin-calendar:build: ESM dist/api/client-calendar.js.map                      8.77 KB
+@elizaos/plugin-calendar:build: ESM dist/plugin.js.map                                   2.66 KB
+@elizaos/plugin-calendar:build: ESM dist/service/migration.js.map                        8.52 KB
+@elizaos/plugin-calendar:build: ESM dist/internal/constants.js.map                       2.20 KB
+@elizaos/plugin-calendar:build: ESM dist/service/gate.js.map                             7.78 KB
+@elizaos/plugin-calendar:build: ESM dist/actions/index.js.map                            539.00 B
+@elizaos/plugin-calendar:build: ESM dist/internal/detail.js.map                          4.09 KB
+@elizaos/plugin-calendar:build: ESM dist/internal/errors.js.map                          917.00 B
+@elizaos/plugin-calendar:build: ESM dist/hooks/useCalendarWeek.js.map                    8.03 KB
+@elizaos/plugin-calendar:build: ESM dist/components/CalendarSection.js.map               63.79 KB
+@elizaos/plugin-calendar:build: ESM dist/apple-calendar.js.map                           30.46 KB
+@elizaos/plugin-calendar:build: ESM dist/components/calendar/CalendarSpatialView.js.map  7.94 KB
+@elizaos/plugin-calendar:build: ESM dist/ui.js.map                                       984.00 B
+@elizaos/plugin-calendar:build: ESM dist/actions/deps.js.map                             71.00 B
+@elizaos/plugin-calendar:build: ESM dist/service/index.js.map                            1.18 KB
+@elizaos/plugin-calendar:build: ESM dist/routes/plugin-routes.js.map                     15.10 KB
+@elizaos/plugin-calendar:build: ESM dist/internal/format.js.map                          8.49 KB
+@elizaos/plugin-calendar:build: ESM dist/service/CalendarRepository.js.map               18.06 KB
+@elizaos/plugin-calendar:build: ESM dist/register.js.map                                 792.00 B
+@elizaos/plugin-calendar:build: ESM dist/components/calendar/CalendarView.js.map         7.48 KB
+@elizaos/plugin-calendar:build: ESM dist/internal/sql.js.map                             7.16 KB
+@elizaos/plugin-calendar:build: ESM dist/internal/normalize.js.map                       8.06 KB
+@elizaos/plugin-calendar:build: ESM dist/index.js.map                                    2.03 KB
+@elizaos/plugin-calendar:build: ESM dist/register-terminal-view.js.map                   1.65 KB
+@elizaos/plugin-calendar:build: ESM dist/internal/time.js.map                            6.83 KB
+@elizaos/plugin-calendar:build: ESM dist/actions/conflict-detect.js.map                  5.74 KB
+@elizaos/plugin-calendar:build: ESM dist/actions/optimized-prompt-instructions.js.map    5.98 KB
+@elizaos/plugin-calendar:build: ESM dist/routes/calendar-routes.js.map                   11.95 KB
+@elizaos/plugin-calendar:build: ESM dist/components/EventEditorDrawer.js.map             49.41 KB
+@elizaos/plugin-calendar:build: ESM dist/components/calendar/calendar-view-bundle.js.map 491.00 B
+@elizaos/plugin-calendar:build: ESM dist/service/feed-preferences.js.map                 7.29 KB
+@elizaos/plugin-calendar:build: ESM dist/internal/calendar-normalize.js.map              17.80 KB
+@elizaos/plugin-calendar:build: ESM dist/actions/calendar-handler.js.map                 209.52 KB
+@elizaos/plugin-calendar:build: ESM dist/service/schema.js.map                           5.19 KB
+@elizaos/plugin-calendar:build: ESM dist/service/CalendarService.js.map                  48.50 KB
+@elizaos/plugin-calendar:build: ESM dist/internal/google-delegates.js.map                26.08 KB
+@elizaos/plugin-calendar:build: ESM ⚡️ Build success in 426ms
+@elizaos/plugin-calendar:build: $ bunx --bun vite build --config vite.config.views.ts
+@elizaos/plugin-calendar:build: vite v8.0.16 building client environment for production...
+@elizaos/plugin-calendar:build: [2K@elizaos/plugin-calendar:build: transforming...✓ 6 modules transformed.
+@elizaos/plugin-calendar:build: rendering chunks...
+@elizaos/plugin-calendar:build: computing gzip size...
+@elizaos/plugin-calendar:build: dist/views/bundle.js  9.82 kB │ gzip: 3.12 kB │ map: 30.92 kB
+@elizaos/plugin-calendar:build:
+@elizaos/plugin-calendar:build: ✓ built in 606ms
+@elizaos/plugin-calendar:build: $ tsc --noCheck -p tsconfig.build.json
+@elizaos/plugin-goals:build: cache miss, executing fa69a50f163b523e
+@elizaos/plugin-goals:build: $ bun run build:js && bun run build:views && bun run build:types
+@elizaos/plugin-goals:build: $ tsup --config ../tsup.plugin-packages.shared.ts
+@elizaos/plugin-inbox:build: cache miss, executing 0247deb5987f69d5
+@elizaos/plugin-inbox:build: $ bun run build:js && bun run build:views && bun run build:types
+@elizaos/plugin-inbox:build: $ tsup --config ../tsup.plugin-packages.shared.ts
+@elizaos/plugin-goals:build: CLI Building entry: src/goals-runtime.ts, src/goal-grounding.ts, src/plugin.ts, src/goals-service.ts, src/types.ts, src/register-terminal-view.tsx, src/goal-semantic-evaluator.ts, src/goal-normalize.ts, src/index.ts, src/register.ts, src/actions/goals.ts, src/components/goals/GoalsSpatialView.tsx, src/components/goals/goals-view-bundle.ts, src/components/goals/GoalsView.tsx, src/services/migration.ts, src/services/checkin.ts, src/db/schema.ts, src/db/sql.ts, src/db/goals-repository.ts, src/db/index.ts
+@elizaos/plugin-goals:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-goals:build: CLI tsup v8.5.1
+@elizaos/plugin-goals:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/tsup.plugin-packages.shared.ts
+@elizaos/plugin-goals:build: CLI Target: es2022
+@elizaos/plugin-goals:build: ESM Build start
+@elizaos/plugin-inbox:build: CLI Building entry: src/plugin.ts, src/types.ts, src/register-terminal-view.tsx, src/index.ts, src/register.ts, src/inbox/unsubscribe-repository.ts, src/inbox/repository.ts, src/inbox/migration.ts, src/inbox/message-fetcher.ts, src/inbox/triage-classifier.ts, src/inbox/email-unsubscribe-types.ts, src/inbox/email-curation.ts, src/inbox/unsubscribe-service.ts, src/inbox/types.ts, src/inbox/gmail-normalize.ts, src/inbox/reflection.ts, src/inbox/google-gmail-seam.ts, src/inbox/config.ts, src/inbox/channel-deep-links.ts, src/inbox/service.ts, src/db/schema.ts, src/db/sql.ts, src/db/index.ts, src/actions/inbox.ts, src/providers/inbox-triage.ts, src/providers/cross-channel-context.ts, src/components/inbox/InboxView.tsx, src/components/inbox/inbox-view-bundle.ts, src/components/inbox/InboxSpatialView.tsx
+@elizaos/plugin-inbox:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-inbox:build: CLI tsup v8.5.1
+@elizaos/plugin-inbox:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/tsup.plugin-packages.shared.ts
+@elizaos/plugin-goals:build: ESM dist/goals-runtime.js                          1.29 KB
+@elizaos/plugin-goals:build: ESM dist/goal-grounding.js                         4.86 KB
+@elizaos/plugin-goals:build: ESM dist/register-terminal-view.js                 622.00 B
+@elizaos/plugin-goals:build: ESM dist/db/index.js                               62.00 B
+@elizaos/plugin-goals:build: ESM dist/db/sql.js                                 3.85 KB
+@elizaos/plugin-goals:build: ESM dist/goal-normalize.js                         2.63 KB
+@elizaos/plugin-goals:build: ESM dist/db/goals-repository.js                    7.89 KB
+@elizaos/plugin-goals:build: ESM dist/services/migration.js                     3.63 KB
+@elizaos/plugin-goals:build: ESM dist/goal-semantic-evaluator.js                7.59 KB
+@elizaos/plugin-goals:build: ESM dist/db/schema.js                              2.07 KB
+@elizaos/plugin-goals:build: ESM dist/components/goals/GoalsView.js             4.35 KB
+@elizaos/plugin-goals:build: ESM dist/goals-service.js                          8.98 KB
+@elizaos/plugin-goals:build: ESM dist/components/goals/goals-view-bundle.js     113.00 B
+@elizaos/plugin-goals:build: ESM dist/services/checkin.js                       1.23 KB
+@elizaos/plugin-goals:build: ESM dist/plugin.js                                 1.88 KB
+@elizaos/plugin-goals:build: ESM dist/components/goals/GoalsSpatialView.js      5.20 KB
+@elizaos/plugin-goals:build: ESM dist/types.js                                  915.00 B
+@elizaos/plugin-goals:build: ESM dist/register.js                               183.00 B
+@elizaos/plugin-goals:build: ESM dist/actions/goals.js                          4.85 KB
+@elizaos/plugin-goals:build: ESM dist/index.js                                  1.32 KB
+@elizaos/plugin-goals:build: ESM dist/goal-grounding.js.map                     10.63 KB
+@elizaos/plugin-goals:build: ESM dist/goals-runtime.js.map                      3.68 KB
+@elizaos/plugin-goals:build: ESM dist/db/goals-repository.js.map                15.34 KB
+@elizaos/plugin-goals:build: ESM dist/goal-semantic-evaluator.js.map            13.67 KB
+@elizaos/plugin-goals:build: ESM dist/components/goals/GoalsView.js.map         12.17 KB
+@elizaos/plugin-goals:build: ESM dist/db/sql.js.map                             8.28 KB
+@elizaos/plugin-goals:build: ESM dist/goal-normalize.js.map                     5.62 KB
+@elizaos/plugin-goals:build: ESM dist/services/migration.js.map                 8.50 KB
+@elizaos/plugin-goals:build: ESM dist/db/schema.js.map                          4.39 KB
+@elizaos/plugin-goals:build: ESM dist/register-terminal-view.js.map             1.58 KB
+@elizaos/plugin-goals:build: ESM dist/db/index.js.map                           138.00 B
+@elizaos/plugin-goals:build: ESM dist/goals-service.js.map                      19.27 KB
+@elizaos/plugin-goals:build: ESM dist/register.js.map                           846.00 B
+@elizaos/plugin-goals:build: ESM dist/components/goals/GoalsSpatialView.js.map  11.45 KB
+@elizaos/plugin-goals:build: ESM dist/actions/goals.js.map                      9.57 KB
+@elizaos/plugin-goals:build: ESM dist/index.js.map                              1.81 KB
+@elizaos/plugin-goals:build: ESM dist/services/checkin.js.map                   2.56 KB
+@elizaos/plugin-goals:build: ESM dist/types.js.map                              4.19 KB
+@elizaos/plugin-goals:build: ESM dist/components/goals/goals-view-bundle.js.map 473.00 B
+@elizaos/plugin-goals:build: ESM dist/plugin.js.map                             3.14 KB
+@elizaos/plugin-goals:build: ESM ⚡️ Build success in 275ms
+@elizaos/plugin-goals:build: $ bunx --bun vite build --config vite.config.views.ts
+@elizaos/plugin-inbox:build: CLI Target: es2022
+@elizaos/plugin-inbox:build: ESM Build start
+@elizaos/plugin-inbox:build: ESM dist/types.js                                  402.00 B
+@elizaos/plugin-inbox:build: ESM dist/plugin.js                                 1.82 KB
+@elizaos/plugin-inbox:build: ESM dist/register-terminal-view.js                 589.00 B
+@elizaos/plugin-inbox:build: ESM dist/inbox/message-fetcher.js                  16.01 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/reflection.js                       4.88 KB
+@elizaos/plugin-inbox:build: ESM dist/register.js                               183.00 B
+@elizaos/plugin-inbox:build: ESM dist/inbox/gmail-normalize.js                  33.78 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/repository.js                       12.45 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/types.js                            33.00 B
+@elizaos/plugin-inbox:build: ESM dist/inbox/unsubscribe-repository.js           3.64 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/triage-classifier.js                10.66 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/unsubscribe-service.js              11.98 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/email-unsubscribe-types.js          51.00 B
+@elizaos/plugin-inbox:build: ESM dist/inbox/email-curation.js                   35.62 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/migration.js                        3.69 KB
+@elizaos/plugin-inbox:build: ESM dist/index.js                                  1.80 KB
+@elizaos/plugin-inbox:build: ESM dist/components/inbox/InboxSpatialView.js      5.48 KB
+@elizaos/plugin-inbox:build: ESM dist/components/inbox/inbox-view-bundle.js     113.00 B
+@elizaos/plugin-inbox:build: ESM dist/db/sql.js                                 3.85 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/google-gmail-seam.js                8.84 KB
+@elizaos/plugin-inbox:build: ESM dist/db/schema.js                              2.92 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/service.js                          9.78 KB
+@elizaos/plugin-inbox:build: ESM dist/providers/cross-channel-context.js        3.88 KB
+@elizaos/plugin-inbox:build: ESM dist/providers/inbox-triage.js                 3.48 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/channel-deep-links.js               3.24 KB
+@elizaos/plugin-inbox:build: ESM dist/actions/inbox.js                          10.53 KB
+@elizaos/plugin-inbox:build: ESM dist/db/index.js                               88.00 B
+@elizaos/plugin-inbox:build: ESM dist/components/inbox/InboxView.js             5.15 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/config.js                           1.25 KB
+@elizaos/plugin-inbox:build: ESM dist/types.js.map                              2.40 KB
+@elizaos/plugin-inbox:build: ESM dist/plugin.js.map                             2.54 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/unsubscribe-repository.js.map       7.06 KB
+@elizaos/plugin-inbox:build: ESM dist/register.js.map                           845.00 B
+@elizaos/plugin-inbox:build: ESM dist/inbox/types.js.map                        71.00 B
+@elizaos/plugin-inbox:build: ESM dist/inbox/repository.js.map                   23.59 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/reflection.js.map                   9.33 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/message-fetcher.js.map              31.70 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/gmail-normalize.js.map              63.16 KB
+@elizaos/plugin-inbox:build: ESM dist/register-terminal-view.js.map             1.48 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/triage-classifier.js.map            20.03 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/unsubscribe-service.js.map          23.24 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/email-unsubscribe-types.js.map      71.00 B
+@elizaos/plugin-inbox:build: ESM dist/index.js.map                              3.30 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/migration.js.map                    8.50 KB
+@elizaos/plugin-inbox:build: ESM dist/components/inbox/InboxSpatialView.js.map  11.72 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/email-curation.js.map               70.76 KB
+@elizaos/plugin-inbox:build: ESM dist/components/inbox/InboxView.js.map         15.20 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/service.js.map                      21.59 KB
+@elizaos/plugin-inbox:build: ESM dist/db/index.js.map                           177.00 B
+@elizaos/plugin-inbox:build: ESM dist/providers/inbox-triage.js.map             6.44 KB
+@elizaos/plugin-inbox:build: ESM dist/providers/cross-channel-context.js.map    8.08 KB
+@elizaos/plugin-inbox:build: ESM dist/actions/inbox.js.map                      22.60 KB
+@elizaos/plugin-inbox:build: ESM dist/db/schema.js.map                          6.12 KB
+@elizaos/plugin-inbox:build: ESM dist/components/inbox/inbox-view-bundle.js.map 473.00 B
+@elizaos/plugin-inbox:build: ESM dist/inbox/channel-deep-links.js.map           6.33 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/google-gmail-seam.js.map            19.46 KB
+@elizaos/plugin-inbox:build: ESM dist/db/sql.js.map                             8.28 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/config.js.map                       2.85 KB
+@elizaos/plugin-inbox:build: ESM ⚡️ Build success in 335ms
+@elizaos/plugin-inbox:build: $ bunx --bun vite build --config vite.config.views.ts
+@elizaos/plugin-goals:build: vite v8.0.16 building client environment for production...
+@elizaos/plugin-goals:build: [2K@elizaos/plugin-goals:build: transforming...✓ 5 modules transformed.
+@elizaos/plugin-goals:build: rendering chunks...
+@elizaos/plugin-goals:build: computing gzip size...
+@elizaos/plugin-inbox:build: vite v8.0.16 building client environment for production...
+@elizaos/plugin-goals:build: dist/views/bundle.js  7.16 kB │ gzip: 2.43 kB │ map: 26.91 kB
+@elizaos/plugin-goals:build:
+@elizaos/plugin-goals:build: ✓ built in 662ms
+@elizaos/plugin-goals:build: $ tsc --noCheck -p tsconfig.build.json && node ../../packages/scripts/rewrite-dist-relative-imports-node-esm.mjs
+@elizaos/plugin-inbox:build: [2K@elizaos/plugin-inbox:build: transforming...✓ 5 modules transformed.
+@elizaos/plugin-inbox:build: rendering chunks...
+@elizaos/plugin-inbox:build: computing gzip size...
+@elizaos/plugin-inbox:build: dist/views/bundle.js  7.40 kB │ gzip: 2.70 kB │ map: 28.44 kB
+@elizaos/plugin-inbox:build:
+@elizaos/plugin-inbox:build: ✓ built in 718ms
+@elizaos/plugin-inbox:build: $ tsc --noCheck -p tsconfig.build.json && node ../../packages/scripts/rewrite-dist-relative-imports-node-esm.mjs
+@elizaos/plugin-finances:build: cache miss, executing 3622dfac5d165e2c
+@elizaos/plugin-finances:build: $ bun run build:js && bun run build:views && bun run build:types
+@elizaos/plugin-finances:build: $ tsup --config ../tsup.plugin-packages.shared.ts
+@elizaos/plugin-finances:build: CLI Building entry: src/subscriptions-types.ts, src/payment-recurrence.ts, src/token-encryption.ts, src/plugin.ts, src/payment-types.ts, src/types.ts, src/finance-normalize.ts, src/payment-csv-import.ts, src/register-terminal-view.tsx, src/finances-service.ts, src/subscriptions-playbooks.ts, src/index.ts, src/register.ts, src/actions/finances.ts, src/db/schema.ts, src/db/finances-repository.ts, src/db/sql.ts, src/db/index.ts, src/services/migration.ts, src/services/gmail-seam.ts, src/services/subscriptions-service.ts, src/services/browser-bridge-seam.ts, src/components/finances/FinancesView.tsx, src/components/finances/finances-view-bundle.ts, src/components/finances/FinancesSpatialView.tsx
+@elizaos/plugin-finances:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-finances:build: CLI tsup v8.5.1
+@elizaos/plugin-finances:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/tsup.plugin-packages.shared.ts
+@elizaos/plugin-finances:build: CLI Target: es2022
+@elizaos/plugin-finances:build: ESM Build start
+@elizaos/plugin-finances:build: ESM dist/subscriptions-types.js                          47.00 B
+@elizaos/plugin-finances:build: ESM dist/components/finances/FinancesSpatialView.js      5.60 KB
+@elizaos/plugin-finances:build: ESM dist/components/finances/finances-view-bundle.js     125.00 B
+@elizaos/plugin-finances:build: ESM dist/components/finances/FinancesView.js             7.00 KB
+@elizaos/plugin-finances:build: ESM dist/index.js                                        2.82 KB
+@elizaos/plugin-finances:build: ESM dist/subscriptions-playbooks.js                      30.35 KB
+@elizaos/plugin-finances:build: ESM dist/db/index.js                                     152.00 B
+@elizaos/plugin-finances:build: ESM dist/db/sql.js                                       5.34 KB
+@elizaos/plugin-finances:build: ESM dist/payment-recurrence.js                           6.11 KB
+@elizaos/plugin-finances:build: ESM dist/actions/finances.js                             9.92 KB
+@elizaos/plugin-finances:build: ESM dist/db/schema.js                                    4.89 KB
+@elizaos/plugin-finances:build: ESM dist/services/gmail-seam.js                          7.32 KB
+@elizaos/plugin-finances:build: ESM dist/register-terminal-view.js                       622.00 B
+@elizaos/plugin-finances:build: ESM dist/finances-service.js                             38.52 KB
+@elizaos/plugin-finances:build: ESM dist/payment-csv-import.js                           7.12 KB
+@elizaos/plugin-finances:build: ESM dist/subscriptions-types.js.map                      71.00 B
+@elizaos/plugin-finances:build: ESM dist/payment-types.js                                41.00 B
+@elizaos/plugin-finances:build: ESM dist/types.js                                        266.00 B
+@elizaos/plugin-finances:build: ESM dist/plugin.js                                       1.39 KB
+@elizaos/plugin-finances:build: ESM dist/services/subscriptions-service.js               35.66 KB
+@elizaos/plugin-finances:build: ESM dist/token-encryption.js                             3.05 KB
+@elizaos/plugin-finances:build: ESM dist/register.js                                     186.00 B
+@elizaos/plugin-finances:build: ESM dist/db/finances-repository.js                       18.88 KB
+@elizaos/plugin-finances:build: ESM dist/components/finances/FinancesView.js.map         19.61 KB
+@elizaos/plugin-finances:build: ESM dist/index.js.map                                    4.07 KB
+@elizaos/plugin-finances:build: ESM dist/subscriptions-playbooks.js.map                  54.77 KB
+@elizaos/plugin-finances:build: ESM dist/actions/finances.js.map                         19.67 KB
+@elizaos/plugin-finances:build: ESM dist/services/browser-bridge-seam.js                 1.13 KB
+@elizaos/plugin-finances:build: ESM dist/payment-recurrence.js.map                       12.71 KB
+@elizaos/plugin-finances:build: ESM dist/db/sql.js.map                                   13.04 KB
+@elizaos/plugin-finances:build: ESM dist/finance-normalize.js                            1.70 KB
+@elizaos/plugin-finances:build: ESM dist/db/index.js.map                                 217.00 B
+@elizaos/plugin-finances:build: ESM dist/components/finances/FinancesSpatialView.js.map  12.37 KB
+@elizaos/plugin-finances:build: ESM dist/components/finances/finances-view-bundle.js.map 565.00 B
+@elizaos/plugin-finances:build: ESM dist/services/gmail-seam.js.map                      15.58 KB
+@elizaos/plugin-finances:build: ESM dist/finances-service.js.map                         70.41 KB
+@elizaos/plugin-finances:build: ESM dist/register-terminal-view.js.map                   1.51 KB
+@elizaos/plugin-finances:build: ESM dist/payment-csv-import.js.map                       14.39 KB
+@elizaos/plugin-finances:build: ESM dist/services/migration.js                           3.78 KB
+@elizaos/plugin-finances:build: ESM dist/db/schema.js.map                                10.32 KB
+@elizaos/plugin-finances:build: ESM dist/services/subscriptions-service.js.map           66.84 KB
+@elizaos/plugin-finances:build: ESM dist/plugin.js.map                                   2.42 KB
+@elizaos/plugin-finances:build: ESM dist/db/finances-repository.js.map                   34.76 KB
+@elizaos/plugin-finances:build: ESM dist/types.js.map                                    2.31 KB
+@elizaos/plugin-finances:build: ESM dist/payment-types.js.map                            71.00 B
+@elizaos/plugin-finances:build: ESM dist/register.js.map                                 869.00 B
+@elizaos/plugin-finances:build: ESM dist/token-encryption.js.map                         6.93 KB
+@elizaos/plugin-finances:build: ESM dist/finance-normalize.js.map                        3.60 KB
+@elizaos/plugin-finances:build: ESM dist/services/browser-bridge-seam.js.map             4.17 KB
+@elizaos/plugin-finances:build: ESM dist/services/migration.js.map                       9.79 KB
+@elizaos/plugin-finances:build: ESM ⚡️ Build success in 256ms
+@elizaos/plugin-finances:build: $ bunx --bun vite build --config vite.config.views.ts
+@elizaos/plugin-blocker:build: [rewrite-dist-relative-imports] rewrote 11 file(s)
+@elizaos/plugin-cloud-apps:typecheck: cache miss, executing 4bea1342613ae68a
+@elizaos/plugin-cloud-apps:typecheck: $ tsgo --noEmit
+@elizaos/example-app-capacitor-frontend:typecheck: cache miss, executing 0107bdb042c714a8
+@elizaos/example-app-capacitor-frontend:typecheck: $ tsc --noEmit
+@elizaos/plugin-farcaster:typecheck: cache miss, executing 0ee38dc15cc52df4
+@elizaos/plugin-farcaster:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-finances:build: vite v8.0.16 building client environment for production...
+@elizaos/plugin-finances:build: [2K@elizaos/plugin-finances:build: transforming...✓ 4 modules transformed.
+@elizaos/plugin-finances:build: rendering chunks...
+@elizaos/plugin-finances:build: computing gzip size...
+@elizaos/plugin-finances:build: dist/views/bundle.js  9.58 kB │ gzip: 2.86 kB │ map: 31.59 kB
+@elizaos/plugin-finances:build:
+@elizaos/plugin-finances:build: ✓ built in 685ms
+@elizaos/plugin-finances:build: $ bunx tsc --noCheck -p tsconfig.build.json && node ../../packages/scripts/rewrite-dist-relative-imports-node-esm.mjs
+@elizaos/plugin-polymarket:typecheck: cache miss, executing 00c4669c5c0574ee
+@elizaos/plugin-polymarket:typecheck: $ tsgo --noEmit -p tsconfig.build.json
+@elizaos/plugin-commands:typecheck: cache miss, executing f32865348aa15467
+@elizaos/plugin-commands:typecheck: $ tsgo --noEmit
+@elizaos/example-browser-extension-safari:typecheck: cache miss, executing 974be3f23cb6c8d5
+@elizaos/example-browser-extension-safari:typecheck: $ echo 'No TypeScript config; skipping typecheck'
+@elizaos/example-browser-extension-safari:typecheck: No TypeScript config; skipping typecheck
+@elizaos/plugin-worker-runtime:typecheck: cache miss, executing cc422ce93e6a19e0
+@elizaos/plugin-worker-runtime:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-native-settings:typecheck: cache miss, executing d57a9130b3258082
+@elizaos/plugin-native-settings:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-coding-tools:typecheck: cache miss, executing 008b3c0353800e23
+@elizaos/plugin-coding-tools:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-xr:typecheck: cache miss, executing 4a3c672d4ea22ce3
+@elizaos/plugin-xr:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-wifi:typecheck: cache miss, executing 08bda329eab840a6
+@elizaos/plugin-wifi:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-cli:typecheck: cache miss, executing 7cd135a2f6318ecf
+@elizaos/plugin-cli:typecheck: $ tsgo --noEmit
+@elizaos/plugin-bluebubbles:typecheck: cache miss, executing af5aa40148f98cb3
+@elizaos/plugin-bluebubbles:typecheck: $ tsgo --noEmit
+@elizaos/security:typecheck: cache miss, executing d1ad7f4af2de352e
+@elizaos/security:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-task-coordinator:typecheck: cache miss, executing 48187f6f1ffb1e11
+@elizaos/plugin-task-coordinator:typecheck: $ tsgo --noEmit -p tsconfig.build.json
+@elizaos/plugin-elizacloud:typecheck: cache miss, executing 1af58e91d468c5d5
+@elizaos/plugin-elizacloud:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-goals:build: [rewrite-dist-relative-imports] rewrote 8 file(s)
+eliza-multichain-miniapp:typecheck: cache miss, executing be61c846ebf1d98f
+eliza-multichain-miniapp:typecheck: $ tsgo --noEmit
+@elizaos/example-app-electron-renderer:typecheck: cache miss, executing 9fce1ccfe8bff675
+@elizaos/example-app-electron-renderer:typecheck: $ tsc --noEmit
+@elizaos/plugin-agent-orchestrator:typecheck: cache miss, executing 1682b4c195fe4ce7
+@elizaos/plugin-agent-orchestrator:typecheck: $ tsgo --noEmit -p tsconfig.json
+elizaos-plugin-echo:typecheck: cache miss, executing 372b5c892e8e6dd8
+elizaos-plugin-echo:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-vision:typecheck: cache miss, executing 4fc5b944226dbcf8
+@elizaos/plugin-vision:typecheck: $ tsgo --noEmit
+@elizaos/scenario-runner:build: cache miss, executing a223d05d65d7caa9
+@elizaos/scenario-runner:build: $ tsc --noCheck -p tsconfig.build.json
+@elizaos/plugin-line:typecheck: cache miss, executing d5a2123e0a30a813
+@elizaos/plugin-line:typecheck: $ tsgo --noEmit
+@elizaos/plugin-reminders:typecheck: cache miss, executing f9b3ee5c5cac6af2
+@elizaos/plugin-reminders:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-inbox:build: [rewrite-dist-relative-imports] rewrote 10 file(s)
+@elizaos/plugin-finances:build: [rewrite-dist-relative-imports] rewrote 8 file(s)
+@elizaos/plugin-personal-assistant:build: cache miss, executing c269fd61dd9bc5fa
+@elizaos/plugin-personal-assistant:typecheck: cache miss, executing 8f340d35a1da9d35
+@elizaos/plugin-personal-assistant:build: $ bun run build:js && bun run build:types
+@elizaos/plugin-personal-assistant:typecheck: $ tsc --noEmit -p tsconfig.build.json
+@elizaos/plugin-personal-assistant:build: $ bun run clean && tsup --config tsup.config.ts
+@elizaos/plugin-personal-assistant:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/plugin-personal-assistant:build: CLI Building entry: src/plugin.ts, src/automation-node-contributor.ts, src/agent-lifeops.ts, src/client.ts, src/ui.ts, src/index.ts, src/provider.ts, src/service.ts, src/public.ts, src/travel-time/service.ts, src/travel-time/calendar-create.ts, src/lifeops/feature-flags.ts, src/lifeops/calendar-gate.ts, src/lifeops/schema.ts, src/lifeops/schedule-state.ts, src/lifeops/privacy.ts, src/lifeops/bulk-review.ts, src/lifeops/escalation-ladders.ts, src/lifeops/service-mixin-drive.ts, src/lifeops/service-mixin-discord.ts, src/lifeops/notifications-push.ts, src/lifeops/background-planner.ts, src/lifeops/privacy-egress.ts, src/lifeops/google-plugin-delegates.ts, src/lifeops/service-mixin-calendar.ts, src/lifeops/google-scopes.ts, src/lifeops/cross-channel-search.ts, src/lifeops/repository.ts, src/lifeops/runtime-service-delegates.ts, src/lifeops/service-helpers-browser.ts, src/lifeops/continuity-probe.ts, src/lifeops/browser-session-lifecycle.ts, src/lifeops/service-mixin-relationships.ts, src/lifeops/fda-probe.ts, src/lifeops/service-mixin-reminders.ts, src/lifeops/service-normalize-gmail.ts, src/lifeops/screen-context.ts, src/lifeops/sql.ts, src/lifeops/schedule-insight.ts, src/lifeops/background-planner-dispatch.ts, src/lifeops/goal-grounding.ts, src/lifeops/bill-extraction.ts, src/lifeops/device-identity.ts, src/lifeops/travel-booking.types.ts, src/lifeops/defaults.ts, src/lifeops/time-util.ts, src/lifeops/service-helpers-misc.ts, src/lifeops/browser-constants.ts, src/lifeops/email-classifier.ts, src/lifeops/service-mixin-x.ts, src/lifeops/feature-flags.types.ts, src/lifeops/policy-memory.ts, src/lifeops/service-mixin-screentime.ts, src/lifeops/service-helpers-occurrence.ts, src/lifeops/intent-sync.ts, src/lifeops/service-mixin-inbox.ts, src/lifeops/email-unsubscribe-types.ts, src/lifeops/email-curation.ts, src/lifeops/lifeops-context.ts, src/lifeops/owner-profile.ts, src/lifeops/engine.ts, src/lifeops/service-mixin-status.ts, src/lifeops/seed-routines.ts, src/lifeops/relative-schedule-resolver.ts, src/lifeops/approval-queue.ts, src/lifeops/voice-affect.ts, src/lifeops/service-mixin-gmail.ts, src/lifeops/wave1-types.ts, src/lifeops/service-mixin-subscriptions.ts, src/lifeops/runtime.ts, src/lifeops/service-normalize-task.ts, src/lifeops/runtime-cache.ts, src/lifeops/optimized-prompt-instructions.ts, src/lifeops/approval-queue.types.ts, src/lifeops/browser-extension-store.ts, src/lifeops/service-mixin-core.ts, src/lifeops/contact-route-policy.ts, src/lifeops/service-mixin-definitions.ts, src/lifeops/enforcement-windows.ts, src/lifeops/service-types.ts, src/lifeops/access.ts, src/lifeops/device-bus-service.ts, src/lifeops/service-constants.ts, src/lifeops/service-mixin-whatsapp.ts, src/lifeops/goal-semantic-evaluator.ts, src/lifeops/service-normalize.ts, src/lifeops/redact-sensitive-data.ts, src/lifeops/service-mixin-goals.ts, src/lifeops/priority-scoring.ts, src/lifeops/imessage-outbound-probe.ts, src/lifeops/service-mixin-signal.ts, src/lifeops/service-mixin-travel.ts, src/lifeops/app-state.ts, src/lifeops/service-normalize-connector.ts, src/lifeops/telemetry-mapping.ts, src/lifeops/apple-reminders.ts, src/lifeops/sensitive-request-delivery.ts, src/lifeops/service-mixin-email-unsubscribe.ts, src/lifeops/relative-time.ts, src/lifeops/index.ts, src/lifeops/service-mixin-browser.ts, src/lifeops/telemetry-retention.ts, src/lifeops/document-review.ts, src/lifeops/schedule-sync-config.ts, src/lifeops/scheduler-task.ts, src/lifeops/stretch-decider.ts, src/lifeops/service-mixin-telegram.ts, src/lifeops/schedule-sync-contracts.ts, src/lifeops/service-mixin-health.ts, src/lifeops/service-mixin-scheduling.ts, src/lifeops/autofill-whitelist.ts, src/lifeops/service.ts, src/lifeops/service-mixin-x-read.ts, src/lifeops/service-mixin-google.ts, src/lifeops/service-helpers-reminder.ts, src/lifeops/service-mixin-imessage.ts, src/lifeops/time.ts, src/lifeops/signal-runtime-config.ts, src/lifeops/service-mixin-workflows.ts, src/security/action-confirmation.ts, src/inbox/repository.ts, src/inbox/message-fetcher.ts, src/inbox/types.ts, src/types/website-blocker-settings-card.ts, src/types/briefing.ts, src/types/app-blocker-settings-card.ts, src/types/document-request.ts, src/types/index.ts, src/followup/followup-tracker.ts, src/followup/index.ts, src/contracts/lifeops.ts, src/contracts/index.ts, src/providers/work-threads.ts, src/providers/inbox-triage.ts, src/providers/recent-task-states.ts, src/providers/activity-profile.ts, src/providers/room-policy.ts, src/providers/first-run.ts, src/providers/health.ts, src/providers/cross-channel-context.ts, src/providers/lifeops.ts, src/providers/pending-prompts.ts, src/platform/lifeops-github.ts, src/platform/host.ts, src/platform/index.ts, src/utils/index.ts, src/utils/format-duration.ts, src/utils/lifeops-url.ts, src/components/WebsiteBlockerSettingsCard.tsx, src/components/AppBlockerSettingsCard.tsx, src/hooks/useInbox.ts, src/hooks/connector-error.ts, src/hooks/useDiscordConnector.ts, src/hooks/useIMessageConnector.ts, src/hooks/useLifeOpsXConnector.ts, src/hooks/useWhatsAppConnector.ts, src/hooks/useLifeOpsActivitySignals.ts, src/hooks/useLifeOpsAppState.ts, src/hooks/useGoogleLifeOpsConnector.ts, src/hooks/useSignalConnector.ts, src/hooks/useTelegramConnector.ts, src/hooks/useLifeOpsCapabilitiesStatus.ts, src/actions/work-thread.ts, src/actions/conflict-detect.ts, src/actions/remote-desktop.ts, src/actions/block.ts, src/actions/schedule.ts, src/actions/website-block.ts, src/actions/screen-time.ts, src/actions/inbox.ts, src/actions/entity.ts, src/actions/connector.ts, src/actions/owner-surfaces.ts, src/actions/document.ts, src/actions/life.ts, src/actions/resolve-request.ts, src/actions/password-manager.ts, src/actions/calendar.ts, src/actions/money.ts, src/actions/prioritize.ts, src/actions/app-block.ts, src/actions/scheduled-task.ts, src/actions/book-travel.ts, src/actions/autofill.ts, src/actions/brief.ts, src/actions/subscriptions.ts, src/actions/health.ts, src/actions/voice-call.ts, src/actions/credentials.ts, src/actions/payments.ts, src/api/client-lifeops.ts, src/activity-profile/presence-signal-bridge-service.ts, src/activity-profile/activity-tracker-service.ts, src/activity-profile/proactive-planner.ts, src/activity-profile/activity-tracker-repo.ts, src/activity-profile/proactive-worker.ts, src/activity-profile/activity-tracker-reporting.ts, src/activity-profile/types.ts, src/activity-profile/proactive-inbox-digest.ts, src/activity-profile/analyzer.ts, src/activity-profile/profile-metadata.ts, src/activity-profile/redactor.ts, src/activity-profile/focus-session.ts, src/activity-profile/service.ts, src/website-blocker/proactive-block-bridge.ts, src/website-blocker/public.ts, src/events/index.ts, src/routes/relationships.ts, src/routes/travel-provider-relay-routes.ts, src/routes/website-blocker-routes.ts, src/routes/lifeops-routes.ts, src/routes/scheduled-tasks.ts, src/routes/entities.ts, src/routes/plugin.ts, src/routes/sleep-routes.ts, src/routes/cloud-features-routes.ts, src/default-packs/autofill-whitelist-pack.ts, src/default-packs/lint.ts, src/default-packs/escalation-ladders.ts, src/default-packs/morning-brief.ts, src/default-packs/contract-types.ts, src/default-packs/followup-starter.ts, src/default-packs/habit-starters.ts, src/default-packs/consolidation-policies.ts, src/default-packs/inbox-triage-starter.ts, src/default-packs/task-definitions.ts, src/default-packs/quiet-user-watcher.ts, src/default-packs/registry-types.ts, src/default-packs/executive-assistant.ts, src/default-packs/index.ts, src/default-packs/daily-rhythm.ts, src/lifeops/connectors/_helpers.ts, src/lifeops/connectors/twilio.ts, src/lifeops/connectors/contract.ts, src/lifeops/connectors/mockoon-redirect.ts, src/lifeops/connectors/duffel.ts, src/lifeops/connectors/x.ts, src/lifeops/connectors/google.ts, src/lifeops/connectors/imessage.ts, src/lifeops/connectors/discord.ts, src/lifeops/connectors/telegram.ts, src/lifeops/connectors/registry.ts, src/lifeops/connectors/default-pack.ts, src/lifeops/connectors/whatsapp.ts, src/lifeops/connectors/index.ts, src/lifeops/connectors/dispatch-policy.ts, src/lifeops/connectors/signal.ts, src/lifeops/connectors/calendly.ts, src/lifeops/validate/coding-task-request.ts, src/lifeops/work-threads/types.ts, src/lifeops/work-threads/field-evaluator-thread-ops.ts, src/lifeops/work-threads/index.ts, src/lifeops/work-threads/store.ts, src/lifeops/domains/workflows-service.ts, src/lifeops/domains/google-service.ts, src/lifeops/domains/gmail-service.ts, src/lifeops/domains/drive-service.ts, src/lifeops/domains/signal-service.ts, src/lifeops/domains/telegram-service.ts, src/lifeops/domains/goals-service.ts, src/lifeops/domains/subscriptions-service.ts, src/lifeops/domains/whatsapp-service.ts, src/lifeops/domains/email-unsubscribe-service.ts, src/lifeops/domains/screentime-service.ts, src/lifeops/domains/discord-service.ts, src/lifeops/domains/relationships-service.ts, src/lifeops/domains/definitions-service.ts, src/lifeops/domains/scheduling-service.ts, src/lifeops/domains/health-service.ts, src/lifeops/domains/sleep-service.ts, src/lifeops/domains/calendar-service.ts, src/lifeops/domains/status-service.ts, src/lifeops/domains/travel-service.ts, src/lifeops/domains/reminders-service.ts, src/lifeops/domains/inbox-service.ts, src/lifeops/domains/x-service.ts, src/lifeops/domains/browser-service.ts, src/lifeops/domains/imessage-service.ts, src/lifeops/domains/x-read-service.ts, src/lifeops/registries/feature-flag-registry.ts, src/lifeops/registries/workflow-step-registry.ts, src/lifeops/registries/website-blocker-contribution.ts, src/lifeops/registries/event-kind-registry.ts, src/lifeops/registries/index.ts, src/lifeops/registries/app-blocker-contribution.ts, src/lifeops/registries/blocker-registry.ts, src/lifeops/registries/feature-flag-default-pack.ts, src/lifeops/registries/family-registry.ts, src/lifeops/registries/workflow-step-default-pack.ts, src/lifeops/send-policy/contract.ts, src/lifeops/send-policy/registry.ts, src/lifeops/send-policy/index.ts, src/lifeops/pending-prompts/store.ts, src/lifeops/owner/fact-store.ts, src/lifeops/owner/profile-extraction-evaluator.ts, src/lifeops/triggers/schedule-once.ts, src/lifeops/global-pause/store.ts, src/lifeops/handoff/store.ts, src/lifeops/google/format-helpers.ts, src/lifeops/signals/bus.ts, src/lifeops/seed-routine-migration/migrator.ts, src/lifeops/scheduled-task/runtime-wiring.ts, src/lifeops/scheduled-task/scheduler.ts, src/lifeops/scheduled-task/index.ts, src/lifeops/scheduled-task/service.ts, src/lifeops/time/timezone.ts, src/lifeops/voice/grounded-reply.ts, src/lifeops/first-run/state.ts, src/lifeops/first-run/defaults.ts, src/lifeops/first-run/replay.ts, src/lifeops/first-run/questions.ts, src/lifeops/first-run/service.ts, src/lifeops/checkin/checkin-service.ts, src/lifeops/checkin/schedule-resolver.ts, src/lifeops/checkin/types.ts, src/lifeops/i18n/localized-examples-resolver.ts, src/lifeops/i18n/prompt-registry.ts, src/lifeops/i18n/localized-examples-provider.ts, src/lifeops/messaging/owner-send-policy.ts, src/lifeops/messaging/index.ts, src/lifeops/relationships/mapping.ts, src/lifeops/relationships/extraction.ts, src/lifeops/relationships/types.ts, src/lifeops/relationships/index.ts, src/lifeops/relationships/store.ts, src/lifeops/entities/voice-attribution.ts, src/lifeops/entities/types.ts, src/lifeops/entities/voice-observer-bridge.ts, src/lifeops/entities/voice-observer.ts, src/lifeops/entities/index.ts, src/lifeops/entities/merge.ts, src/lifeops/entities/store.ts, src/lifeops/channels/priority-posture.ts, src/lifeops/channels/contract.ts, src/lifeops/channels/registry.ts, src/lifeops/channels/default-pack.ts, src/lifeops/channels/index.ts, src/followup/actions/listOverdueFollowups.ts, src/followup/actions/markFollowupDone.ts, src/followup/actions/setFollowupThreshold.ts, src/actions/lib/extract-life-operation.ts, src/actions/lib/extract-update-fields.ts, src/actions/lib/extract-task-plan.ts, src/actions/lib/extract-goal-plan.ts, src/actions/lib/lifeops-deferred-draft.ts, src/actions/lib/messaging-helpers.ts, src/actions/lib/scheduling-handler.ts, src/actions/lib/calendly-handler.ts, src/actions/lib/prompt-format.ts, src/actions/lib/owner-policy-writes.ts, src/website-blocker/chat-integration/block-rule-reconciler.ts, src/website-blocker/chat-integration/block-rule-schema.ts, src/website-blocker/chat-integration/block-activator.ts, src/website-blocker/chat-integration/harsh-mode-check.ts, src/website-blocker/chat-integration/index.ts, src/website-blocker/chat-integration/block-rule-service.ts
+@elizaos/plugin-personal-assistant:build: CLI Using tsconfig: ../../tsconfig.json
+@elizaos/plugin-personal-assistant:build: CLI tsup v8.5.1
+@elizaos/plugin-personal-assistant:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/plugin-personal-assistant/tsup.config.ts
+@elizaos/plugin-personal-assistant:build: CLI Target: es2022
+@elizaos/plugin-personal-assistant:build: ESM Build start
+@elizaos/plugin-personal-assistant:build: ESM dist/plugin.js                                                     38.55 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useWhatsAppConnector.js                                 1.47 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/feature-flags.types.js                                4.32 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/schedule-sync-config.js                               1.02 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useLifeOpsActivitySignals.js                            12.61 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/policy-memory.js                                      30.84 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/scheduler-task.js                                     6.42 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useLifeOpsAppState.js                                   1.93 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useLifeOpsCapabilitiesStatus.js                         1.48 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/stretch-decider.js                                    2.03 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-screentime.js                           52.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useGoogleLifeOpsConnector.js                            20.56 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-telegram.js                             50.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-helpers-occurrence.js                         8.24 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useSignalConnector.js                                   2.67 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useTelegramConnector.js                                 2.99 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/intent-sync.js                                        10.89 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/repository.js                                         241.16 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/schedule-sync-contracts.js                            133.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/telemetry-mapping.js                                  4.08 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/browser-session-lifecycle.js                          9.45 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useIMessageConnector.js                                 1.47 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/google-plugin-delegates.js                            13.79 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-relationships.js                        55.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-calendar.js                             50.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/google-scopes.js                                      4.32 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/time-util.js                                          416.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/document-review.js                                    28.14 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/bill-extraction.js                                    10.61 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/relative-time.js                                      7.17 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/routes/travel-provider-relay-routes.js                        216.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/routes/entities.js                                            6.91 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/apple-reminders.js                                    11.07 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/device-identity.js                                    2.66 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/routes/website-blocker-routes.js                              6.29 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/sensitive-request-delivery.js                         3.08 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/travel-booking.types.js                               48.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/routes/lifeops-routes.js                                      77.47 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/routes/sleep-routes.js                                        889.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/cross-channel-search.js                               25.11 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/index.js                                              839.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/telemetry-retention.js                                390.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/email-classifier.js                                   361.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useLifeOpsXConnector.js                                 2.21 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-x.js                                    43.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-signal.js                               48.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/fda-probe.js                                          1.81 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-goals.js                                47.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-reminders.js                            290.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/priority-scoring.js                                   10.17 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-normalize-gmail.js                            2.51 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/redact-sensitive-data.js                              2.71 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/imessage-outbound-probe.js                            2.23 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-helpers-misc.js                               17.02 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/sql.js                                                5.33 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/browser-constants.js                                  643.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-normalize-connector.js                        24.08 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-browser.js                              49.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/goal-grounding.js                                     544.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/routes/relationships.js                                       6.97 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/routes/plugin.js                                              21.32 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/defaults.js                                           5.77 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-travel.js                               151.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/schedule-insight.js                                   23.30 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/app-state.js                                          2.13 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/routes/scheduled-tasks.js                                     3.87 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/screen-context.js                                     9.75 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/background-planner-dispatch.js                        3.47 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-email-unsubscribe.js                    59.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/privacy-egress.js                                     7.49 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useDiscordConnector.js                                  2.59 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/continuity-probe.js                                   5.75 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/proactive-worker.js                          26.30 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/utils/index.js                                                105.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/agent-lifeops.js                                              77.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/first-run.js                                        4.10 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/calendar.js                                           27.85 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/inbox.js                                              290.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/room-policy.js                                      2.17 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/utils/format-duration.js                                      382.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/activity-tracker-reporting.js                4.76 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/client.js                                                     1.35 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/utils/lifeops-url.js                                          975.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/types.js                                     706.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/ui.js                                                         939.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/proactive-inbox-digest.js                    750.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/enforcement-windows.js                                2.44 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/index.js                                                      5.63 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/analyzer.js                                  19.74 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/provider.js                                                   4.07 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/profile-metadata.js                          597.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/service.js                                                    3.70 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/redactor.js                                  786.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/public.js                                                     577.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/focus-session.js                             1.74 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/travel-time/service.js                                        6.82 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/service.js                                   9.30 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/screen-time.js                                        1.54 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/travel-time/calendar-create.js                                830.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/password-manager.js                                   6.90 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/components/WebsiteBlockerSettingsCard.js                      5.36 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/website-blocker/proactive-block-bridge.js                     4.61 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-core.js                                 16.49 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/contact-route-policy.js                               5.00 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/components/AppBlockerSettingsCard.js                          20.83 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-definitions.js                          53.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/feature-flags.js                                      8.46 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service.js                                            43.19 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/goal-semantic-evaluator.js                            188.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/health.js                                           463.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-types.js                                      130.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-inbox.js                                381.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/schema.js                                             54.70 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/access.js                                             2.50 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/entity.js                                             27.87 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/cross-channel-context.js                            6.65 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/email-unsubscribe-types.js                            51.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/scheduled-task.js                                     20.54 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/schedule-state.js                                     24.08 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/book-travel.js                                        15.82 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/calendar-gate.js                                      1.33 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-x-read.js                               48.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-drive.js                                331.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/connector.js                                          41.80 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/device-bus-service.js                                 572.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/subscriptions-service.js                      1.35 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/privacy.js                                            1.82 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/whatsapp-service.js                           6.64 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-constants.js                                  4.78 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/email-unsubscribe-service.js                  879.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/browser-extension-store.js                            6.08 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/relative-schedule-resolver.js                         3.43 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/website-blocker/public.js                                     1.58 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/runtime-cache.js                                      125.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/bulk-review.js                                        34.31 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/approval-queue.types.js                               686.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-whatsapp.js                             50.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/goals-service.js                              31.45 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/escalation-ladders.js                                 536.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/scheduled-task/service.js                             203.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/activity-tracker-service.js                  5.88 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/voice-affect.js                                       8.34 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/google/format-helpers.js                              20.80 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-gmail.js                                47.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/seed-routine-migration/migrator.js                    4.21 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/wave1-types.js                                        39.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/presence-signal-bridge-service.js            5.22 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/activity-profile.js                                 9.57 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-subscriptions.js                        55.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-normalize-task.js                             17.14 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-imessage.js                             50.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/subscriptions.js                                      11.32 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/lifeops.js                                          27.75 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/screentime-service.js                         16.60 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/owner-surfaces.js                                     16.54 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-google.js                               48.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/approval-queue.js                                     18.94 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/discord-service.js                            44.56 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/platform/lifeops-github.js                                    4.44 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/types/website-blocker-settings-card.js                        57.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/seed-routines.js                                      3.91 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-status.js                               48.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/email-curation.js                                     102.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/extract-goal-plan.js                              18.71 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-discord.js                              49.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/relationships-service.js                      4.93 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/signals/bus.js                                        3.69 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/types/briefing.js                                             36.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/proactive-planner.js                         19.65 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/automation-node-contributor.js                                5.81 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/types/document-request.js                                     44.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/lifeops-deferred-draft.js                         10.87 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/scheduled-task/scheduler.js                           6.28 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/types/app-blocker-settings-card.js                            53.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/time.js                                               4.79 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/health.js                                             1.11 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/definitions-service.js                        14.85 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/brief.js                                              15.47 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/owner-profile.js                                      13.89 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/platform/index.js                                             97.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/api/client-lifeops.js                                         26.15 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/activity-tracker-repo.js                     1.94 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/optimized-prompt-instructions.js                      2.97 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/inbox/types.js                                                84.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/scheduled-task/index.js                               320.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/runtime.js                                            3.55 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/prioritize.js                                         16.47 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-helpers-reminder.js                           38.69 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/inbox/message-fetcher.js                                      282.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-normalize.js                                  1.32 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/work-threads.js                                     3.58 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/scheduled-task/runtime-wiring.js                      13.04 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/messaging-helpers.js                              2.95 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/autofill.js                                           10.96 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/schedule.js                                           5.95 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/contracts/index.js                                            66.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/runtime-service-delegates.js                          25.15 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/lifeops-context.js                                    43.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/scheduling-service.js                         12.78 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/app-blocker-contribution.js                1.86 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/resolve-request.js                                    12.43 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/scheduling-handler.js                             31.22 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/platform/host.js                                              618.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/life.js                                               87.12 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/engine.js                                             17.81 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/imessage-service.js                           10.01 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/pending-prompts.js                                  2.64 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/inbox-triage.js                                     4.71 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/types/index.js                                                33.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/voice-call.js                                         22.76 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/app-block.js                                          12.72 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/calendly-handler.js                               16.97 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/x-read-service.js                             7.97 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/website-block.js                                      27.33 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/money.js                                              1.39 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/blocker-registry.js                        1003.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/x-service.js                                  17.56 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/travel-service.js                             8.44 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/recent-task-states.js                               5.30 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/reminders-service.js                          147.62 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/messaging/owner-send-policy.js                        2.85 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/prompt-format.js                                  1.39 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/events/index.js                                               1.09 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/inbox-service.js                              21.12 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/remote-desktop.js                                     290.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/inbox/repository.js                                           167.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/i18n/localized-examples-provider.js                   1.03 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/entities/store.js                                     207.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/browser-service.js                            35.05 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/block.js                                              10.03 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-workflows.js                            181.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-helpers-browser.js                            10.50 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/document.js                                           19.42 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-health.js                               48.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/signal-runtime-config.js                              1.16 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/feature-flag-registry.js                   1.89 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/health-service.js                             21.28 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/followup/actions/listOverdueFollowups.js                      2.75 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/owner-policy-writes.js                            5.15 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/entities/merge.js                                     368.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/notifications-push.js                                 3.17 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/followup/actions/markFollowupDone.js                          5.51 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/sleep-service.js                              1.26 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/conflict-detect.js                                    9.46 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/connector-error.js                                      284.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/messaging/index.js                                    133.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/workflow-step-registry.js                  1.56 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/feature-flag-default-pack.js               1.03 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/calendar-service.js                           1.70 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/channels/registry.js                                  1.28 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/credentials.js                                        5.54 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/website-blocker/chat-integration/block-rule-reconciler.js     4.00 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/status-service.js                             14.07 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useInbox.js                                             3.11 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/work-thread.js                                        20.64 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/extract-update-fields.js                          6.14 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/background-planner.js                                 12.38 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/extract-life-operation.js                         12.00 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/followup/actions/setFollowupThreshold.js                      5.75 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/channels/default-pack.js                              5.42 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/family-registry.js                         2.81 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/website-blocker/chat-integration/block-rule-schema.js         4.13 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/channels/priority-posture.js                          531.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/payments.js                                           149.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/relationships/mapping.js                              2.82 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/channels/index.js                                     522.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/extract-task-plan.js                              14.72 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/channels/contract.js                                  36.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/website-blocker-contribution.js            2.18 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/mockoon-redirect.js                        1.90 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/first-run/state.js                                    5.31 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/calendly.js                                1.86 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/relationships/types.js                                266.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/followup/index.js                                             1.21 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/entities/voice-attribution.js                         3.44 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-scheduling.js                           52.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/first-run/service.js                                  18.13 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/workflows-service.js                          25.30 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/signal.js                                  1.66 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/entities/types.js                                     266.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/checkin/checkin-service.js                            38.23 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/validate/coding-task-request.js                       448.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/drive-service.js                              6.24 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/contracts/lifeops.js                                          68.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/event-kind-registry.js                     2.16 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/duffel.js                                  1.96 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/signal-service.js                             7.38 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/website-blocker/chat-integration/block-activator.js           964.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/checkin/types.js                                      33.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/relationships/extraction.js                           4.41 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/routes/cloud-features-routes.js                               5.38 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/relationships/index.js                                454.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/workflow-step-default-pack.js              9.63 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/x.js                                       1.74 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/work-threads/types.js                                 33.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/entities/voice-observer-bridge.js                     2.14 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/followup/followup-tracker.js                                  10.43 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/relationships/store.js                                117.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/owner/fact-store.js                                   14.40 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/autofill-whitelist.js                                 1.96 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/first-run/defaults.js                                 7.08 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/google-service.js                             12.02 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/telegram-service.js                           10.31 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/google.js                                  2.39 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/i18n/localized-examples-resolver.js                   710.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/work-threads/field-evaluator-thread-ops.js            8.27 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/entities/voice-observer.js                            3.27 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/checkin/schedule-resolver.js                          1.00 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/website-blocker/chat-integration/harsh-mode-check.js          669.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/owner/profile-extraction-evaluator.js                 8.30 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/first-run/replay.js                                   993.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/time/timezone.js                                      4.80 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/security/action-confirmation.js                               955.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/entities/index.js                                     581.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/first-run/questions.js                                5.41 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/handoff/store.js                                      521.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/gmail-service.js                              22.66 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/send-policy/registry.js                               1.73 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/imessage.js                                1.50 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/work-threads/index.js                                 123.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useTelegramConnector.js.map                             5.35 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/scheduler-task.js.map                                 12.00 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/voice/grounded-reply.js                               654.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/website-blocker/chat-integration/index.js                     700.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/i18n/prompt-registry.js                               7.94 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/global-pause/store.js                                 523.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useGoogleLifeOpsConnector.js.map                        38.10 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/discord.js                                 1.50 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-helpers-occurrence.js.map                     14.99 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/stretch-decider.js.map                                6.62 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/whatsapp.js                                1.59 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/registry.js                                1.42 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/default-pack.js                            1.42 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/index.js                                   547.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/send-policy/index.js                                  316.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/morning-brief.js                                2.71 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/index.js                                   3.41 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/autofill-whitelist-pack.js                      1006.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/send-policy/contract.js                               36.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useLifeOpsActivitySignals.js.map                        23.05 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useLifeOpsCapabilitiesStatus.js.map                     2.72 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-telegram.js.map                         71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-screentime.js.map                       71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/index.js                                        4.00 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/intent-sync.js.map                                    21.43 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/work-threads/store.js                                 8.81 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/triggers/schedule-once.js                             2.79 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useLifeOpsAppState.js.map                               3.45 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/_helpers.js                                2.56 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/dispatch-policy.js                         1021.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/pending-prompts/store.js                              501.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/contract.js                                36.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/lint.js                                         5.39 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/website-blocker/chat-integration/block-rule-service.js        7.17 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/quiet-user-watcher.js                           3.54 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/followup-starter.js                             4.29 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/executive-assistant.js                          29.75 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/feature-flags.types.js.map                            13.71 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useWhatsAppConnector.js.map                             2.61 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/contract-types.js                               42.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/plugin.js.map                                                 66.19 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/policy-memory.js.map                                  65.50 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/habit-starters.js                               8.48 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/inbox-triage-starter.js                         2.33 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useSignalConnector.js.map                               4.86 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/task-definitions.js                             3.34 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/escalation-ladders.js                           536.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/telegram.js                                1.78 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/consolidation-policies.js                       378.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/twilio.js                                  3.48 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/daily-rhythm.js                                 4.61 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/registry-types.js                               42.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/schedule-sync-config.js.map                           1.76 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/repository.js.map                                     420.26 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/schedule-sync-contracts.js.map                        214.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/telemetry-mapping.js.map                              7.86 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/browser-session-lifecycle.js.map                      19.27 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useIMessageConnector.js.map                             2.87 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-calendar.js.map                         71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/google-scopes.js.map                                  7.04 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/time-util.js.map                                      1.16 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/google-plugin-delegates.js.map                        25.78 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-relationships.js.map                    71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/document-review.js.map                                61.77 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-inbox.js.map                            523.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/schema.js.map                                         104.18 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/access.js.map                                         4.74 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/bill-extraction.js.map                                21.18 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/scheduled-task.js.map                                 41.36 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/email-unsubscribe-types.js.map                        71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/goal-semantic-evaluator.js.map                        599.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/cross-channel-context.js.map                        13.32 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-types.js.map                                  3.33 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/health.js.map                                       734.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/entity.js.map                                         49.39 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service.js.map                                        106.38 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/screen-time.js.map                                    2.19 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/travel-time/calendar-create.js.map                            1.99 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-definitions.js.map                      71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/website-blocker/proactive-block-bridge.js.map                 11.60 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/password-manager.js.map                               12.89 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/components/AppBlockerSettingsCard.js.map                      32.02 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/components/WebsiteBlockerSettingsCard.js.map                  8.79 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/feature-flags.js.map                                  17.75 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/contact-route-policy.js.map                           10.65 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/service.js.map                               17.46 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-core.js.map                             31.21 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/first-run.js.map                                    7.80 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/browser-constants.js.map                              1.18 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/proactive-inbox-digest.js.map                1.18 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-imessage.js.map                         71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-normalize-connector.js.map                    42.36 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-browser.js.map                          71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/subscriptions.js.map                                  20.72 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/goal-grounding.js.map                                 999.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/routes/relationships.js.map                                   14.27 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/analyzer.js.map                              40.08 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/scheduled-task/service.js.map                         922.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/background-planner-dispatch.js.map                    8.55 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-normalize-task.js.map                         30.17 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/service.js.map                                                8.96 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/redactor.js.map                              2.06 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/public.js.map                                                 589.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/focus-session.js.map                         5.29 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/travel-time/service.js.map                                    15.30 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/lifeops.js.map                                      41.71 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/prompt-format.js.map                              2.82 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/index.js.map                                                  5.65 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/routes/plugin.js.map                                          39.91 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/seed-routine-migration/migrator.js.map                11.65 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/profile-metadata.js.map                      1.57 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/reminders-service.js.map                      269.58 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/screentime-service.js.map                     32.36 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/discord-service.js.map                        82.68 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/calendar.js.map                                       49.27 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/wave1-types.js.map                                    71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useDiscordConnector.js.map                              4.71 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/continuity-probe.js.map                               13.64 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/schedule-insight.js.map                               48.68 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/provider.js.map                                               7.49 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/proactive-worker.js.map                      48.57 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/routes/scheduled-tasks.js.map                                 9.90 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/routes/sleep-routes.js.map                                    2.32 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/telemetry-retention.js.map                            1.27 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/messaging/owner-send-policy.js.map                    5.77 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/privacy-egress.js.map                                 15.77 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/screen-context.js.map                                 19.95 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/enforcement-windows.js.map                            5.62 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/travel-booking.types.js.map                           71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/fda-probe.js.map                                      3.96 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/agent-lifeops.js.map                                          147.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/inbox.js.map                                          847.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/index.js.map                                          1.18 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/email-classifier.js.map                               775.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-normalize-gmail.js.map                        2.35 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-x.js.map                                71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-reminders.js.map                        404.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/utils/format-duration.js.map                                  995.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/imessage-outbound-probe.js.map                        4.32 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/room-policy.js.map                                  4.37 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/redact-sensitive-data.js.map                          6.51 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/app-state.js.map                                      4.80 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/defaults.js.map                                       12.13 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useLifeOpsXConnector.js.map                             4.10 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/sql.js.map                                            13.04 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/routes/lifeops-routes.js.map                                  146.39 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/types.js.map                                 5.04 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/cross-channel-search.js.map                           57.84 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-email-unsubscribe.js.map                71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/priority-scoring.js.map                               21.29 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-signal.js.map                           71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/ui.js.map                                                     2.05 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/client.js.map                                                 3.13 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/activity-tracker-reporting.js.map            10.67 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/utils/lifeops-url.js.map                                      1.65 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-goals.js.map                            71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/routes/entities.js.map                                        14.25 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-helpers-misc.js.map                           32.16 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/schedule-state.js.map                                 44.84 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-x-read.js.map                           71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/utils/index.js.map                                            197.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/relative-time.js.map                                  15.26 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/approval-queue.js.map                                 36.91 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/sensitive-request-delivery.js.map                     7.18 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-travel.js.map                           1.84 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/device-identity.js.map                                5.78 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/connector.js.map                                      77.08 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/apple-reminders.js.map                                21.78 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-google.js.map                           71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-drive.js.map                            3.19 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/routes/website-blocker-routes.js.map                          11.67 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/calendar-gate.js.map                                  4.30 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/owner-surfaces.js.map                                 28.73 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/routes/travel-provider-relay-routes.js.map                    308.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/book-travel.js.map                                    31.01 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/recent-task-states.js.map                           11.67 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/money.js.map                                          3.90 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/blocker-registry.js.map                    5.55 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/x-service.js.map                              34.03 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/travel-service.js.map                         18.66 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/website-block.js.map                                  48.48 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/activity-profile.js.map                             16.80 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/device-bus-service.js.map                             1.31 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/subscriptions-service.js.map                  4.17 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/privacy.js.map                                        4.64 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/whatsapp-service.js.map                       12.94 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/brief.js.map                                          33.16 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/presence-signal-bridge-service.js.map        9.28 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/credentials.js.map                                    10.25 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/payments.js.map                                       585.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/channels/priority-posture.js.map                      2.49 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/work-thread.js.map                                    36.37 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/escalation-ladders.js.map                             2.01 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-constants.js.map                              3.56 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/feature-flag-registry.js.map               6.80 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/voice-affect.js.map                                   17.09 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/owner-profile.js.map                                  26.92 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/sleep-service.js.map                          2.56 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/calendly-handler.js.map                           30.68 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/entities/store.js.map                                 674.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/lifeops-deferred-draft.js.map                     22.97 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/engine.js.map                                         31.39 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-status.js.map                           71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/pending-prompts.js.map                              5.91 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/extract-task-plan.js.map                          26.61 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/scheduled-task/scheduler.js.map                       14.20 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/owner-policy-writes.js.map                        11.59 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/i18n/localized-examples-provider.js.map               2.42 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/channels/index.js.map                                 735.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/relationships/mapping.js.map                          6.56 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/extract-update-fields.js.map                      11.64 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/types/app-blocker-settings-card.js.map                        71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/extract-goal-plan.js.map                          31.88 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-health.js.map                           71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/types/document-request.js.map                                 71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/types/website-blocker-settings-card.js.map                    71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/events/index.js.map                                           2.63 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/app-block.js.map                                      23.27 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/life.js.map                                           162.89 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/platform/index.js.map                                         192.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/signal-runtime-config.js.map                          2.51 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/platform/host.js.map                                          1.48 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/email-unsubscribe-service.js.map              2.58 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/inbox-triage.js.map                                 8.34 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/conflict-detect.js.map                                20.02 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/health-service.js.map                         39.49 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/workflow-step-registry.js.map              7.95 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/types/briefing.js.map                                         71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/imessage-service.js.map                       21.31 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-gmail.js.map                            71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/entities/merge.js.map                                 716.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/time.js.map                                           9.32 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/browser-service.js.map                        63.38 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/connector-error.js.map                                  511.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/types/index.js.map                                            71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/automation-node-contributor.js.map                            10.36 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/followup/actions/markFollowupDone.js.map                      9.86 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/voice-call.js.map                                     40.54 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/channels/default-pack.js.map                          11.18 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/extract-life-operation.js.map                     19.78 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/definitions-service.js.map                    27.92 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/background-planner.js.map                             31.16 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/document.js.map                                       39.08 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/browser-extension-store.js.map                        12.93 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/followup/actions/setFollowupThreshold.js.map                  10.01 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/work-threads.js.map                                 6.57 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-discord.js.map                          71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/relative-schedule-resolver.js.map                     7.35 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-workflows.js.map                        974.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/notifications-push.js.map                             7.33 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/website-blocker/public.js.map                                 1.96 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/followup/actions/listOverdueFollowups.js.map                  4.86 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/platform/lifeops-github.js.map                                7.71 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/proactive-planner.js.map                     45.03 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/health.js.map                                         1.65 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/x-read-service.js.map                         16.28 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/family-registry.js.map                     7.85 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/seed-routines.js.map                                  7.39 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/google/format-helpers.js.map                          39.88 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-helpers-browser.js.map                        20.34 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/calendar-service.js.map                       5.36 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/email-curation.js.map                                 697.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/block.js.map                                          19.55 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/runtime-cache.js.map                                  412.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/website-blocker/chat-integration/block-rule-reconciler.js.map 7.29 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/api/client-lifeops.js.map                                     68.43 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/autofill.js.map                                       20.63 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/signals/bus.js.map                                    10.59 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/inbox/message-fetcher.js.map                                  780.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/runtime-service-delegates.js.map                      53.11 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/website-blocker/chat-integration/block-rule-schema.js.map     8.32 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/scheduled-task/index.js.map                           954.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/schedule.js.map                                       11.16 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/messaging/index.js.map                                361.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/feature-flag-default-pack.js.map           3.02 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/scheduled-task/runtime-wiring.js.map                  26.21 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/channels/registry.js.map                              2.89 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/runtime.js.map                                        6.31 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/inbox/repository.js.map                                       645.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/relationships-service.js.map                  10.38 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/prioritize.js.map                                     33.47 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-subscriptions.js.map                    71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-helpers-reminder.js.map                       77.02 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/app-blocker-contribution.js.map            3.92 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/inbox/types.js.map                                            516.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/inbox-service.js.map                          42.78 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/contracts/index.js.map                                        149.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/status-service.js.map                         27.67 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-normalize.js.map                              1.36 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/activity-tracker-repo.js.map                 4.20 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/activity-tracker-service.js.map              11.41 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/bulk-review.js.map                                    76.20 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/scheduling-handler.js.map                         58.99 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/lifeops-context.js.map                                71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useInbox.js.map                                         7.45 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/optimized-prompt-instructions.js.map                  3.50 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/scheduling-service.js.map                     26.75 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/remote-desktop.js.map                                 891.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/resolve-request.js.map                                22.71 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/messaging-helpers.js.map                          6.82 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/goals-service.js.map                          59.88 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-whatsapp.js.map                         71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/approval-queue.types.js.map                           7.45 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/google-service.js.map                         22.57 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/checkin/checkin-service.js.map                        71.20 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/entities/voice-observer-bridge.js.map                 5.43 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/validate/coding-task-request.js.map                   1.52 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/autofill-whitelist.js.map                             4.16 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/first-run/defaults.js.map                             14.70 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/drive-service.js.map                          13.40 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/contracts/lifeops.js.map                                      151.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/owner/fact-store.js.map                               34.35 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/event-kind-registry.js.map                 5.81 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/duffel.js.map                              3.87 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/signal-service.js.map                         14.48 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/website-blocker/chat-integration/block-activator.js.map       2.71 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/checkin/types.js.map                                  71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/workflows-service.js.map                      47.23 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/mockoon-redirect.js.map                    5.11 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/telegram-service.js.map                       20.56 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/first-run/state.js.map                                13.02 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/calendly.js.map                            3.57 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/relationships/types.js.map                            806.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/followup/index.js.map                                         1.11 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/entities/voice-attribution.js.map                     9.79 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-scheduling.js.map                       71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/dispatch-policy.js.map                     5.57 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/relationships/store.js.map                            615.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/first-run/service.js.map                              35.58 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/pending-prompts/store.js.map                          1.85 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/signal.js.map                              3.28 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/entities/types.js.map                                 822.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/morning-brief.js.map                            5.62 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/website-blocker/chat-integration/block-rule-service.js.map    13.15 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/_helpers.js.map                            6.38 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/channels/contract.js.map                              71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/triggers/schedule-once.js.map                         5.37 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/index.js.map                               826.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/send-policy/index.js.map                              498.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/website-blocker-contribution.js.map        4.63 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/gmail-service.js.map                          43.10 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/work-threads/index.js.map                             453.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/voice/grounded-reply.js.map                           2.67 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/imessage.js.map                            3.15 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/work-threads/store.js.map                             19.53 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/contract.js.map                            71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/registry.js.map                            3.38 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/task-definitions.js.map                         9.21 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/index.js.map                               4.45 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/relationships/extraction.js.map                       11.06 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/autofill-whitelist-pack.js.map                  2.33 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/consolidation-policies.js.map                   1.25 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/send-policy/registry.js.map                           4.29 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/send-policy/contract.js.map                           71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/escalation-ladders.js.map                       1.64 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/twilio.js.map                              6.90 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/followup-starter.js.map                         7.90 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/inbox-triage-starter.js.map                     3.99 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/telegram.js.map                            3.74 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/quiet-user-watcher.js.map                       7.32 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/x.js.map                                   3.32 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/website-blocker/chat-integration/index.js.map                 900.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/routes/cloud-features-routes.js.map                           10.93 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/work-threads/field-evaluator-thread-ops.js.map        18.40 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/followup/followup-tracker.js.map                              20.77 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/lint.js.map                                     13.62 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/checkin/schedule-resolver.js.map                      2.64 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/default-pack.js.map                        3.55 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/work-threads/types.js.map                             71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/workflow-step-default-pack.js.map          19.92 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/website-blocker/chat-integration/harsh-mode-check.js.map      1.70 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/first-run/replay.js.map                               3.32 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/contract-types.js.map                           71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/habit-starters.js.map                           15.54 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/whatsapp.js.map                            3.31 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/security/action-confirmation.js.map                           1.98 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/first-run/questions.js.map                            12.14 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/discord.js.map                             2.91 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/relationships/index.js.map                            758.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/i18n/localized-examples-resolver.js.map               2.80 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/entities/voice-observer.js.map                        7.83 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/global-pause/store.js.map                             1.70 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/entities/index.js.map                                 852.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/time/timezone.js.map                                  8.51 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/owner/profile-extraction-evaluator.js.map             14.58 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/i18n/prompt-registry.js.map                           16.03 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/executive-assistant.js.map                      45.73 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/index.js.map                                    7.94 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/handoff/store.js.map                                  1.80 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/google.js.map                              5.22 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/daily-rhythm.js.map                             8.19 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/registry-types.js.map                           71.00 B
+@elizaos/plugin-personal-assistant:build: ESM ⚡️ Build success in 1867ms
+@elizaos/plugin-personal-assistant:build: $ tsc --noCheck -p tsconfig.build.json
+@elizaos/plugin-training:typecheck: cache miss, executing 1a91d4af675007b6
+@elizaos/plugin-training:typecheck: $ tsgo --noEmit -p tsconfig.typecheck.json
+@elizaos/scenario-runner:typecheck: cache miss, executing 17943746de37e2df
+@elizaos/app:typecheck: cache miss, executing 866dc2535af27fea
+@elizaos/scenario-runner:typecheck: $ tsgo --noEmit
+@elizaos/app:typecheck: $ tsgo --noEmit -p tsconfig.typecheck.json
+
+ Tasks:    474 successful, 474 total
+Cached:    3 cached, 474 total
+  Time:    13m42.451s
+
+$ node packages/scripts/audit-build-typecheck.mjs
+[audit-build-typecheck] ✓ build/typecheck compiler model is consistent
+$ node packages/scripts/audit-turbo-build-deps.mjs
+[audit-turbo-build-deps] ✓ no phantom #build dependency edges
+$ node packages/scripts/audit-tee-secret-leak.mjs
+audit-tee-secret-leak: PASS — 3 confidential module(s) + 2 off-device serializer(s) clean.
+$ node packages/scripts/audit-scripts.mjs
+[audit-scripts] OK — no orphan/no-op/broken scripts.
+$ node packages/scripts/generate-dist-paths-config.mjs --check && node packages/scripts/prepare-dist-path-declarations.mjs && node packages/scripts/typecheck-dist-path-consumers.mjs
+[generate-dist-paths-config] ✓ 194 path aliases are current
+[prepare-dist-path-declarations] @elizaos/prompts
+[prepare-dist-path-declarations] prepared 1 declaration emit(s)
+
+[typecheck:dist] packages/examples/_plugin/tsconfig.json
+
+[typecheck:dist] packages/examples/a2a/tsconfig.json
+
+[typecheck:dist] packages/examples/agent-console/tsconfig.json
+
+[typecheck:dist] packages/examples/app/electron/backend/tsconfig.json
+
+[typecheck:dist] packages/examples/autonomous/tsconfig.json
+
+[typecheck:dist] packages/examples/bluesky/tsconfig.json
+
+[typecheck:dist] packages/examples/chat/tsconfig.json
+
+[typecheck:dist] packages/examples/cloudflare/tsconfig.json
+
+[typecheck:dist] packages/examples/code/tsconfig.json
+
+[typecheck:dist] packages/examples/convex/tsconfig.json
+
+[typecheck:dist] packages/examples/discord/tsconfig.json
+
+[typecheck:dist] packages/examples/elizagotchi/tsconfig.json
+
+[typecheck:dist] packages/examples/farcaster-miniapp/tsconfig.json
+
+[typecheck:dist] packages/examples/farcaster/tsconfig.json
+
+[typecheck:dist] packages/examples/game-of-life/tsconfig.json
+
+[typecheck:dist] packages/examples/lp-manager/tsconfig.json
+
+[typecheck:dist] packages/examples/moltbook/tsconfig.json
+
+[typecheck:dist] packages/examples/plugin-echo/tsconfig.json
+
+[typecheck:dist] packages/examples/react/tsconfig.json
+
+[typecheck:dist] packages/examples/rest-api/elysia/tsconfig.json
+
+[typecheck:dist] packages/examples/rest-api/express/tsconfig.json
+
+[typecheck:dist] packages/examples/rest-api/hono/tsconfig.json
+
+[typecheck:dist] packages/examples/smartglasses/tsconfig.json
+
+[typecheck:dist] packages/examples/text-adventure/tsconfig.json
+
+[typecheck:dist] packages/examples/tic-tac-toe/tsconfig.json
+
+[typecheck:dist] packages/examples/trader/tsconfig.json
+
+[typecheck:dist] packages/examples/twitter-xai/tsconfig.json
+
+[typecheck:dist] packages/examples/vercel/tsconfig.json
+
+[typecheck:dist] checked 28 dist-path consumer config(s)

--- a/packages/core/src/features/secrets/providers/secrets-status.test.ts
+++ b/packages/core/src/features/secrets/providers/secrets-status.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "vitest";
+import type { IAgentRuntime, Memory } from "../../../types/index.ts";
+import {
+	SECRETS_SERVICE_TYPE,
+	type SecretsService,
+} from "../services/secrets.ts";
+import { secretsInfoProvider } from "./secrets-status.ts";
+
+function runtimeWithSecrets(
+	globalSecrets: Record<string, unknown>,
+): IAgentRuntime {
+	return {
+		agentId: "agent-1",
+		getService: (name: string) => {
+			if (name === SECRETS_SERVICE_TYPE) {
+				return {
+					list: async () => globalSecrets,
+				} satisfies Partial<SecretsService>;
+			}
+			return null;
+		},
+	} as unknown as IAgentRuntime;
+}
+
+function message(text: string): Memory {
+	return {
+		agentId: "agent-1",
+		entityId: "user-1",
+		roomId: "room-1",
+		content: { text },
+	} as Memory;
+}
+
+describe("SECRETS_INFO provider", () => {
+	test("does not gate selected provider context on English secret keywords", async () => {
+		const result = await secretsInfoProvider.get(
+			runtimeWithSecrets({
+				OPENAI_API_KEY: { status: "valid", type: "api_key" },
+				DISCORD_BOT_TOKEN: { status: "valid", type: "bot_token" },
+			}),
+			message("configura mis credenciales"),
+		);
+
+		expect(result.text).toContain("[Secrets Info]");
+		expect(result.text).toContain("Total configured secrets: 2");
+		expect(result.text).toContain("api_key: OPENAI_API_KEY");
+		expect(result.values).toEqual({ secretCount: 2 });
+	});
+
+	test("returns empty text only when the secrets service is unavailable", async () => {
+		const result = await secretsInfoProvider.get(
+			{ getService: () => null } as unknown as IAgentRuntime,
+			message("secret status"),
+		);
+
+		expect(result).toEqual({ text: "" });
+	});
+});

--- a/packages/core/src/features/secrets/providers/secrets-status.ts
+++ b/packages/core/src/features/secrets/providers/secrets-status.ts
@@ -179,21 +179,12 @@ export const secretsInfoProvider: Provider = {
 
 	get: async (
 		runtime: IAgentRuntime,
-		message: Memory,
+		_message: Memory,
 		_state?: State,
 	): Promise<ProviderResult> => {
 		const secretsService =
 			runtime.getService<SecretsService>(SECRETS_SERVICE_TYPE);
 		if (!secretsService) {
-			return { text: "" };
-		}
-
-		const text = message.content.text?.toLowerCase() ?? "";
-
-		// Check if message is about secrets
-		const isAboutSecrets =
-			/\b(secret|key|token|credential|api|password|configure)\b/i.test(text);
-		if (!isAboutSecrets) {
 			return { text: "" };
 		}
 


### PR DESCRIPTION
## Summary

Refs #10471.

- Removes the raw English keyword regex from `SECRETS_INFO`.
- Leaves provider selection on the structured provider metadata: `contexts`, `contextGate`, and `roleGate`.
- Adds a regression test proving selected secrets/settings context returns secrets info for non-English user text.

## Evidence

Evidence is in `.github/issue-evidence/10471-secrets-info-context-gate/`.

- `bun test packages/core/src/features/secrets/providers/secrets-status.test.ts` PASS
- `bun run --cwd packages/core typecheck` PASS
- `bun run --cwd packages/core lint:check` PASS
- `bun run --cwd packages/core build` PASS
- `git fetch origin && git rebase origin/develop` PASS
- `bun install` PASS after rebase
- `PATH="/Users/shawwalters/.bun/bin:$PATH" bun run verify` PASS after rebase
- `git diff --check origin/develop...HEAD` PASS

## Notes

- `bun run --cwd packages/core test` was attempted and is captured in `full-core-test.log`; it is blocked by an unrelated existing `src/plugin.test.ts` failure assigning `globalThis.Bun` where the property is readonly in this runtime.
- Screenshots/video/audio are N/A because this is a deterministic backend provider-context gate with no UI, visual, or audio surface change.
