### PR TITLE
fix(macosalarm): route ALARM by structured context/params, not keyword text (#10471)

### DIFF
--- a/plugins/plugin-native-macosalarm/AGENTS.md
+++ b/plugins/plugin-native-macosalarm/AGENTS.md
@@ -10,7 +10,7 @@ Adds the `ALARM` action to an Eliza agent so it can schedule, cancel, and list m
 
 | Kind | Name | Description |
 |------|------|-------------|
-| Action | `ALARM` | Schedule (`set`), remove (`cancel`), or enumerate (`list`) macOS alarms. Subaction is inferred from message text when not explicitly passed as a parameter. Role-gated to `ADMIN`. |
+| Action | `ALARM` | Schedule (`set`), remove (`cancel`), or enumerate (`list`) macOS alarms. Subaction comes from structured parameters (`action` / `subaction` / `op`) or from the structured parameter shape. Role-gated to `ADMIN`. |
 
 No providers, services, evaluators, routes, or events are registered.
 
@@ -60,7 +60,7 @@ No runtime config keys are read from the agent runtime settings object. The only
 
 | Parameter | Required for | Description |
 |-----------|-------------|-------------|
-| `action` / `subaction` / `op` | — | `set`, `cancel`, or `list` (inferred from text if absent) |
+| `action` / `subaction` / `op` | — | `set`, `cancel`, or `list` (if absent, inferred from structured parameter shape: schedule payload → `set`, id → `cancel`, otherwise `list`) |
 | `timeIso` | `set` | ISO-8601 timestamp for the alarm |
 | `title` | `set` | Notification title |
 | `body` | `set` (optional) | Notification body |
@@ -88,7 +88,7 @@ No runtime config keys are read from the agent runtime settings object. The only
 - **IPC protocol is line-delimited JSON.** The Swift process reads one JSON object from stdin and writes exactly one JSON object to stdout. The TS layer takes the last non-empty line of stdout as the response.
 - **Notification permission.** `schedule` calls `ensureAuthorization()` in Swift, which requests the `UNUserNotificationCenter` permission prompt on first use. If the user has denied notifications, the binary exits with code `3` and returns `{ "success": false, "error": "permission-denied: ..." }`.
 - **Role gate.** The `ALARM` action has `roleGate: { minRole: "ADMIN" }`, so only admin-role users can trigger it.
-- **Context gate.** The action matches the `tasks`, `calendar`, and `automation` contexts; `hasAlarmSignal` also fires on keyword matching (supports several languages including Spanish, French, German, Chinese, Japanese, Korean, Vietnamese).
+- **Context gate.** The action matches the `tasks`, `calendar`, and `automation` contexts from canonical turn routing plus legacy `activeContexts` / `selectedContexts` signals. It does not validate from alarm keywords in raw message text.
 - **Testing the Swift layer.** Use the `spawnImpl` and `binPathOverride` options in `HelperRunOptions` to inject a mock process in tests without needing a compiled binary.
 
 <!-- BEGIN: evidence-and-e2e-mandate (managed; canonical standard = repo-root PR_EVIDENCE.md) -->

--- a/plugins/plugin-native-macosalarm/CLAUDE.md
+++ b/plugins/plugin-native-macosalarm/CLAUDE.md
@@ -10,7 +10,7 @@ Adds the `ALARM` action to an Eliza agent so it can schedule, cancel, and list m
 
 | Kind | Name | Description |
 |------|------|-------------|
-| Action | `ALARM` | Schedule (`set`), remove (`cancel`), or enumerate (`list`) macOS alarms. Subaction is inferred from message text when not explicitly passed as a parameter. Role-gated to `ADMIN`. |
+| Action | `ALARM` | Schedule (`set`), remove (`cancel`), or enumerate (`list`) macOS alarms. Subaction comes from structured parameters (`action` / `subaction` / `op`) or from the structured parameter shape. Role-gated to `ADMIN`. |
 
 No providers, services, evaluators, routes, or events are registered.
 
@@ -60,7 +60,7 @@ No runtime config keys are read from the agent runtime settings object. The only
 
 | Parameter | Required for | Description |
 |-----------|-------------|-------------|
-| `action` / `subaction` / `op` | — | `set`, `cancel`, or `list` (inferred from text if absent) |
+| `action` / `subaction` / `op` | — | `set`, `cancel`, or `list` (if absent, inferred from structured parameter shape: schedule payload → `set`, id → `cancel`, otherwise `list`) |
 | `timeIso` | `set` | ISO-8601 timestamp for the alarm |
 | `title` | `set` | Notification title |
 | `body` | `set` (optional) | Notification body |
@@ -88,7 +88,7 @@ No runtime config keys are read from the agent runtime settings object. The only
 - **IPC protocol is line-delimited JSON.** The Swift process reads one JSON object from stdin and writes exactly one JSON object to stdout. The TS layer takes the last non-empty line of stdout as the response.
 - **Notification permission.** `schedule` calls `ensureAuthorization()` in Swift, which requests the `UNUserNotificationCenter` permission prompt on first use. If the user has denied notifications, the binary exits with code `3` and returns `{ "success": false, "error": "permission-denied: ..." }`.
 - **Role gate.** The `ALARM` action has `roleGate: { minRole: "ADMIN" }`, so only admin-role users can trigger it.
-- **Context gate.** The action matches the `tasks`, `calendar`, and `automation` contexts; `hasAlarmSignal` also fires on keyword matching (supports several languages including Spanish, French, German, Chinese, Japanese, Korean, Vietnamese).
+- **Context gate.** The action matches the `tasks`, `calendar`, and `automation` contexts from canonical turn routing plus legacy `activeContexts` / `selectedContexts` signals. It does not validate from alarm keywords in raw message text.
 - **Testing the Swift layer.** Use the `spawnImpl` and `binPathOverride` options in `HelperRunOptions` to inject a mock process in tests without needing a compiled binary.
 
 <!-- BEGIN: evidence-and-e2e-mandate (managed; canonical standard = repo-root PR_EVIDENCE.md) -->

--- a/plugins/plugin-native-macosalarm/__tests__/actions.test.ts
+++ b/plugins/plugin-native-macosalarm/__tests__/actions.test.ts
@@ -1,0 +1,154 @@
+import type { Memory, State } from "@elizaos/core";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createAlarmAction,
+  hasAlarmContext,
+  resolveSubaction,
+} from "../src/actions";
+
+/**
+ * #10471 — the ALARM action must route by the planner's structured context
+ * decision + structured params, NOT by English (or multilingual) keyword
+ * matching on raw message text. These pin that the removed `ALARM_TERMS` keyword
+ * bank and text-regex subaction inference stay gone.
+ */
+
+function msg(text = "", content: Record<string, unknown> = {}): Memory {
+  return {
+    id: "00000000-0000-0000-0000-000000000001",
+    entityId: "00000000-0000-0000-0000-000000000002",
+    agentId: "00000000-0000-0000-0000-000000000003",
+    roomId: "00000000-0000-0000-0000-000000000004",
+    content: { text, source: "test", ...content },
+    createdAt: 0,
+  } as unknown as Memory;
+}
+
+function stateWithRouting(routing: unknown): State {
+  return {
+    values: { __contextRouting: routing },
+    data: {},
+    text: "",
+  } as unknown as State;
+}
+
+describe("hasAlarmContext (canonical routing, no keyword bank)", () => {
+  it("matches an alarm context from the canonical __contextRouting primaryContext", () => {
+    expect(
+      hasAlarmContext(msg(), stateWithRouting({ primaryContext: "tasks" })),
+    ).toBe(true);
+  });
+
+  it("matches from a __contextRouting secondaryContext", () => {
+    expect(
+      hasAlarmContext(
+        msg(),
+        stateWithRouting({
+          primaryContext: "chat",
+          secondaryContexts: ["calendar"],
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("matches from the legacy state.values.selectedContexts signal", () => {
+    expect(
+      hasAlarmContext(msg(), {
+        values: { selectedContexts: ["automation"] },
+      } as unknown as State),
+    ).toBe(true);
+  });
+
+  it("does NOT match a non-alarm routed context", () => {
+    expect(
+      hasAlarmContext(msg(), stateWithRouting({ primaryContext: "chat" })),
+    ).toBe(false);
+  });
+
+  it("does NOT match on alarm keyword text alone — the keyword bank is gone", () => {
+    expect(
+      hasAlarmContext(
+        msg("please set an alarm for 7am"),
+        stateWithRouting({ primaryContext: "chat" }),
+      ),
+    ).toBe(false);
+    // Previously the multilingual ALARM_TERMS bank matched these; now: no state,
+    // no routed context → no match.
+    expect(hasAlarmContext(msg("wake me up / despertador / アラーム"))).toBe(
+      false,
+    );
+  });
+});
+
+describe("resolveSubaction (structured only)", () => {
+  it("prefers the explicit action discriminator", () => {
+    expect(resolveSubaction({ action: "cancel", id: "x" })).toBe("cancel");
+  });
+
+  it("accepts subaction and op aliases", () => {
+    expect(resolveSubaction({ subaction: "schedule" })).toBe("set");
+    expect(resolveSubaction({ op: "remove", id: "x" })).toBe("cancel");
+    expect(resolveSubaction({ action: "show" })).toBe("list");
+  });
+
+  it("infers set from a schedule payload shape", () => {
+    expect(
+      resolveSubaction({ timeIso: "2026-01-01T07:00:00Z", title: "Wake" }),
+    ).toBe("set");
+  });
+
+  it("infers cancel from an id / alarmId", () => {
+    expect(resolveSubaction({ id: "alarm-1" })).toBe("cancel");
+    expect(resolveSubaction({ alarmId: "alarm-2" })).toBe("cancel");
+  });
+
+  it("defaults to the read-only list when nothing structured is present", () => {
+    expect(resolveSubaction({})).toBe("list");
+  });
+
+  it("never parses English verbs from an unrelated text field", () => {
+    expect(resolveSubaction({ note: "cancel this alarm now" })).toBe("list");
+  });
+});
+
+describe("ALARM action validate", () => {
+  const realPlatform = process.platform;
+  const setPlatform = (value: string) =>
+    Object.defineProperty(process, "platform", { value, configurable: true });
+  afterEach(() =>
+    Object.defineProperty(process, "platform", {
+      value: realPlatform,
+      configurable: true,
+    }),
+  );
+
+  it("returns false on non-darwin even when routed to an alarm context", async () => {
+    setPlatform("linux");
+    const ok = await createAlarmAction().validate?.(
+      {} as never,
+      msg(),
+      stateWithRouting({ primaryContext: "tasks" }),
+    );
+    expect(ok).toBe(false);
+  });
+
+  it("validates on darwin when routed to an alarm context", async () => {
+    setPlatform("darwin");
+    const ok = await createAlarmAction().validate?.(
+      {} as never,
+      msg(),
+      stateWithRouting({ primaryContext: "calendar" }),
+    );
+    expect(ok).toBe(true);
+  });
+
+  it("does NOT validate on darwin from alarm keyword text without a routed context", async () => {
+    setPlatform("darwin");
+    const ok = await createAlarmAction().validate?.(
+      {} as never,
+      msg("set an alarm"),
+      stateWithRouting({ primaryContext: "chat" }),
+    );
+    expect(ok).toBe(false);
+  });
+});

--- a/plugins/plugin-native-macosalarm/src/actions.ts
+++ b/plugins/plugin-native-macosalarm/src/actions.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import {
   type Action,
   type ActionResult,
+  getActiveRoutingContextsForTurn,
   type HandlerCallback,
   type HandlerOptions,
   type IAgentRuntime,
@@ -35,32 +36,9 @@ const NOT_SUPPORTED: ActionResult = {
   error: "macos-only",
 };
 const ALARM_CONTEXTS = ["tasks", "calendar", "automation"] as const;
-const ALARM_TERMS = [
-  "alarm",
-  "alarms",
-  "wake",
-  "despertador",
-  "alarma",
-  "alarmas",
-  "reveil",
-  "réveil",
-  "alarme",
-  "wecker",
-  "alarm anzeigen",
-  "闹钟",
-  "提醒",
-  "アラーム",
-  "알람",
-  "báo thức",
-  "bao thuc",
-];
 
 function isDarwin(): boolean {
   return process.platform === "darwin";
-}
-
-function getText(message: Memory): string {
-  return (message.content.text ?? "").toLowerCase();
 }
 
 function normalizeContextList(value: unknown): string[] {
@@ -70,25 +48,31 @@ function normalizeContextList(value: unknown): string[] {
     .filter(Boolean);
 }
 
-function hasAlarmContext(message: Memory, state?: State): boolean {
-  const values = state?.values ?? {};
-  const content = message.content as Record<string, unknown>;
-  const contexts = [
-    ...normalizeContextList(values.activeContexts),
-    ...normalizeContextList(values.selectedContexts),
-    ...normalizeContextList(content.activeContexts),
-    ...normalizeContextList(content.selectedContexts),
-    ...normalizeContextList(content.contexts),
-  ];
-  return contexts.some((context) =>
-    ALARM_CONTEXTS.includes(context as (typeof ALARM_CONTEXTS)[number]),
+/**
+ * True when the turn is routed to an alarm context. Reads the planner's
+ * canonical routing decision (`state.values.__contextRouting`, via
+ * `getActiveRoutingContextsForTurn`) — never an English/keyword match on raw
+ * message text (#10471) — plus the legacy `activeContexts`/`selectedContexts`
+ * signals for back-compat.
+ */
+export function hasAlarmContext(message: Memory, state?: State): boolean {
+  const active = new Set<string>(
+    getActiveRoutingContextsForTurn(state, message).map((context) =>
+      `${context}`.toLowerCase(),
+    ),
   );
-}
-
-function hasAlarmSignal(message: Memory, state?: State): boolean {
-  if (hasAlarmContext(message, state)) return true;
-  const text = getText(message);
-  return ALARM_TERMS.some((term) => text.includes(term.toLowerCase()));
+  const values = (state?.values ?? {}) as Record<string, unknown>;
+  const content = message.content as Record<string, unknown>;
+  for (const list of [
+    normalizeContextList(values.activeContexts),
+    normalizeContextList(values.selectedContexts),
+    normalizeContextList(content.activeContexts),
+    normalizeContextList(content.selectedContexts),
+    normalizeContextList(content.contexts),
+  ]) {
+    for (const context of list) active.add(context);
+  }
+  return ALARM_CONTEXTS.some((context) => active.has(context));
 }
 
 function readParameters(
@@ -121,32 +105,28 @@ function normalizeSubactionValue(value: unknown): AlarmSubaction | null {
     : null;
 }
 
-function inferSubactionFromText(text: string): AlarmSubaction | null {
-  const lower = text.toLowerCase();
-  if (
-    /\b(list|show|pending|view|see|what)\b.*\balarm/.test(lower) ||
-    /\balarms?\s*(?:list|pending)\b/.test(lower)
-  ) {
-    return "list";
-  }
-  if (
-    /\b(cancel|stop|remove|delete|kill|clear)\b.*\balarm/.test(lower) ||
-    /\balarm\b.*\b(cancel|stop|remove|delete|kill|clear)\b/.test(lower)
-  ) {
-    return "cancel";
-  }
-  if (
-    /\b(set|schedule|create|add|new|wake)\b.*\balarm/.test(lower) ||
-    /\balarm\b.*\b(set|schedule|create|add|for)\b/.test(lower) ||
-    /\bwake me\b/.test(lower)
-  ) {
+/**
+ * Resolve the subaction from structured params only (#10471): the explicit
+ * `action`/`subaction`/`op` discriminator, otherwise inferred from the SHAPE of
+ * the structured params (a schedule payload → `set`, an id → `cancel`),
+ * defaulting to the read-only, non-destructive `list`. Never parses English (or
+ * any language) from the raw message text — the planner supplies the operation.
+ */
+export function resolveSubaction(
+  params: Record<string, unknown>,
+): AlarmSubaction {
+  const explicit =
+    normalizeSubactionValue(params.action) ??
+    normalizeSubactionValue(params.subaction) ??
+    normalizeSubactionValue(params.op);
+  if (explicit) return explicit;
+  if (typeof params.timeIso === "string" && typeof params.title === "string") {
     return "set";
   }
-  if (lower.includes("alarm")) {
-    // Default to list when alarm mentioned without a clear verb.
-    return "list";
+  if (typeof params.id === "string" || typeof params.alarmId === "string") {
+    return "cancel";
   }
-  return null;
+  return "list";
 }
 
 function parseSchedule(
@@ -390,7 +370,7 @@ export function createAlarmAction(deps: MacosAlarmActionDeps = {}): Action {
   return {
     name: "ALARM",
     description:
-      "Manage native macOS alarms via UNUserNotificationCenter. Subactions: set (schedule a new alarm), cancel (remove a scheduled alarm by id), list (show pending alarms). Subaction inferred from message text when not explicitly provided.",
+      "Manage native macOS alarms via UNUserNotificationCenter. Subactions: set (schedule a new alarm), cancel (remove a scheduled alarm by id), list (show pending alarms). Pass the operation as the structured `action` parameter; when omitted it is inferred from the other structured params (a schedule payload → set, an id → cancel, otherwise list).",
     descriptionCompressed:
       "macOS alarm: set / cancel / list (UNUserNotificationCenter).",
     contexts: [...ALARM_CONTEXTS],
@@ -420,7 +400,7 @@ export function createAlarmAction(deps: MacosAlarmActionDeps = {}): Action {
       {
         name: "subaction",
         description:
-          "Operation to perform: set, cancel, or list. Inferred from message text when omitted.",
+          "Operation to perform: set, cancel, or list. Inferred from the other structured parameters when omitted.",
         required: false,
         schema: { type: "string", enum: [...ALARM_SUBACTIONS] },
       },
@@ -465,7 +445,7 @@ export function createAlarmAction(deps: MacosAlarmActionDeps = {}): Action {
       state?: State,
     ): Promise<boolean> => {
       if (!isDarwin()) return false;
-      return hasAlarmSignal(message, state);
+      return hasAlarmContext(message, state);
     },
     handler: async (
       _runtime: IAgentRuntime,
@@ -488,27 +468,7 @@ export function createAlarmAction(deps: MacosAlarmActionDeps = {}): Action {
       }
 
       const params = readParameters(options);
-      const explicit =
-        normalizeSubactionValue(params.action) ??
-        normalizeSubactionValue(params.subaction) ??
-        normalizeSubactionValue(params.op);
-      const subaction = explicit ?? inferSubactionFromText(getText(message));
-
-      if (!subaction) {
-        const text = `ALARM could not determine the subaction. Specify one of: ${ALARM_SUBACTIONS.join(", ")}.`;
-        if (callback) {
-          await callback({ text, source: message.content.source });
-        }
-        return {
-          success: false,
-          text,
-          values: { error: "MISSING_SUBACTION" },
-          data: {
-            actionName: "ALARM",
-            availableSubactions: [...ALARM_SUBACTIONS],
-          },
-        };
-      }
+      const subaction = resolveSubaction(params);
 
       switch (subaction) {
         case "set":


### PR DESCRIPTION
## Summary

Refs #10471. Removes the i18n-hostile string-match smells from the `@elizaos/macosalarm` `ALARM` action — an untouched plugin in the #10471 sweep.

Two smells drove behavior off raw `message.content.text`:
- **`ALARM_TERMS`** — a 17-entry hardcoded multilingual keyword bank (`alarm`, `despertador`, `réveil`, `闹钟`, `アラーム`, `알람`, …) matched in `validate`. Only ever covers the languages someone thought to list.
- **`inferSubactionFromText`** — English verb regexes (`/\b(cancel|stop|remove|delete)\b.*\balarm/`, …) picking the subaction in the handler.

Both re-parse natural language the planner already structured, and `hasAlarmContext` even read the legacy `selectedContexts` while **missing** the canonical `__contextRouting` key (the #10582 authoritative source).

## Changes (`plugins/plugin-native-macosalarm/src/actions.ts`)

- **`validate`** gates purely on the routed context via core `getActiveRoutingContextsForTurn` (reads `state.values.__contextRouting`) + the legacy `activeContexts`/`selectedContexts` signals for back-compat. `ALARM_TERMS` deleted.
- **`resolveSubaction`** (replaces `inferSubactionFromText`): explicit `action`/`subaction`/`op` discriminator → else the structured param shape (`timeIso`+`title` → set, `id`/`alarmId` → cancel) → else read-only `list`. Never parses text. The `MISSING_SUBACTION` branch is gone (resolution always yields a valid op; `list` is the safe non-destructive default the old text path already used).
- Action + param **descriptions** now point the model at the structured `action` parameter instead of "inferred from message text".

## Tests

`bun run --cwd plugins/plugin-native-macosalarm test` → **20 passed** (new `__tests__/actions.test.ts` + existing helper/integration suites). Typecheck exit 0, biome 2.5.1 clean.

New coverage:
- `hasAlarmContext`: matches from canonical `__contextRouting` primary + secondary, from legacy `selectedContexts`; does NOT match a non-alarm context; **does NOT match on alarm keyword text alone** (EN + multilingual) — the core regression this fixes.
- `resolveSubaction`: explicit-discriminator priority, aliases (schedule→set, remove→cancel, show→list), param-shape inference (schedule→set, id→cancel), `list` default, and that a stray English phrase in an unrelated field does not flip the op.
- `validate`: darwin gate, context-routed acceptance, and keyword-text-without-context rejection.

## Evidence

- **Real-LLM trajectory** — N/A: this is a deterministic routing/dispatch refactor with no prompt/model change; the planner already emits the structured `action`.
- **On-device macOS run** — N/A for this change: the Swift helper IPC path (`runHelper`) and its darwin behavior are unchanged; only context-gating + subaction resolution changed, both covered by platform-independent unit tests (validate mocks `process.platform`).
