### PR TITLE
ci(android): wire touch-gesture + view-runtime-soak into pr-device-smoke

### DIFF
--- a/.github/workflows/android-device-e2e.yml
+++ b/.github/workflows/android-device-e2e.yml
@@ -236,6 +236,23 @@ jobs:
             ELIZA_ANDROID_REQUIRE_AGENT=1 \
               bun run --cwd packages/app test:e2e:android:native-plugin-view || true
 
+            # Real OS-level touch swipe on the chat-sheet grabber (#9943): proves
+            # the home→launcher pager gesture fires with real Android touch input
+            # (pointerMouseCount===0), not desktop mouse emulation. Signal-only on
+            # the PR lane for the same reason as above — flip to a hard gate once
+            # emulator-green evidence is attached.
+            ELIZA_ANDROID_BACKEND=host \
+            ELIZA_ANDROID_REQUIRE_AGENT=1 \
+            ELIZA_ANDROID_CLEAR_APP_DATA=1 \
+              bun run --cwd packages/app test:e2e:android:touch-gesture || true
+
+            # View-runtime telemetry soak (#10196): activates every registered
+            # view through the real eliza:navigate:view channel and asserts
+            # bounded render/heap/cache behavior. Signal-only on the PR lane.
+            ELIZA_ANDROID_BACKEND=host \
+            ELIZA_ANDROID_REQUIRE_AGENT=1 \
+              bun run --cwd packages/app test:e2e:android:view-runtime-soak || true
+
       - uses: actions/upload-artifact@v7
         if: always()
         with:


### PR DESCRIPTION
## Summary

Follow-up to the reviews of #10622 (touch-gesture, merged) and #10603 (view-runtime-soak, merged). Both PRs added real on-device Android specs (`test:e2e:android:touch-gesture`, `test:e2e:android:view-runtime-soak`) but **neither was wired into any CI lane** — they only ran manually. That's the exact "on-device never gates a PR" gap called out in #9943.

This wires both into the existing `pr-device-smoke` job (label-gated on `ci:device`) as **signal-only (`|| true`) steps**, matching the established `native-plugin-view` precedent, so they run on the device lane and can be promoted to hard gates once emulator-green.

No new workflow, no change to the `workflow_dispatch` matrix, no runner burned on ordinary PRs (still `ci:device`-gated).

## Evidence

- Both specs already exist on `develop` (`packages/app/package.json`) from the merged #10622/#10603; this only adds the CI invocation.
- Diff is 17 lines in `.github/workflows/android-device-e2e.yml`, all inside the `pr-device-smoke` step, mirroring the existing `native-plugin-view || true` line.
- N/A: no runtime/UI/model behavior changes; this is CI orchestration only.

Refs #9943, #10622, #10603.
