### PR TITLE
fix(vision): route VISION by structured op/mode/name, not keyword text (#10471)

### DIFF
--- a/plugins/plugin-vision/README.md
+++ b/plugins/plugin-vision/README.md
@@ -62,18 +62,18 @@ All settings can also be prefixed with `VISION_` (e.g. `VISION_CAMERA_NAME`).
 
 ## Actions
 
-The plugin registers a single `VISION` action that routes to one of these sub-operations based on explicit `action` parameter or natural-language inference:
+The plugin registers a single `VISION` action that routes to one of these sub-operations from the structured `action` / `subaction` / `op` parameter. Mode changes use the structured `mode` parameter, and entity naming uses the structured `name` parameter.
 
-| Sub-operation | Trigger examples | What it does |
+| Sub-operation | Structured parameter example | What it does |
 |--------------|-----------------|-------------|
-| `describe` | "what do you see?", "describe the scene" | Returns the current VLM scene description |
-| `capture` | "take a photo", "screenshot" | Captures a frame and returns it as a base64 image attachment |
-| `set_mode` | "set vision mode to screen" | Switches between `OFF`, `CAMERA`, `SCREEN`, `BOTH` |
-| `enable_camera` / `disable_camera` | "turn on the camera" | Toggles camera input |
-| `enable_screen` / `disable_screen` | "enable screen capture" | Toggles screen input |
-| `name_entity` | "the person is named Alice" | Assigns a display name to the most prominent tracked entity |
-| `identify_person` | "who is that?" | Lists tracked people with names and presence duration |
-| `track_entity` | "track the person in the red shirt" | Refreshes entity tracking and reports statistics |
+| `describe` | `action: "describe"` | Returns the current VLM scene description |
+| `capture` | `action: "capture"` | Captures a frame and returns it as a base64 image attachment |
+| `set_mode` | `action: "set_mode", mode: "SCREEN"` | Switches between `OFF`, `CAMERA`, `SCREEN`, `BOTH` |
+| `enable_camera` / `disable_camera` | `action: "enable_camera"` | Toggles camera input |
+| `enable_screen` / `disable_screen` | `action: "enable_screen"` | Toggles screen input |
+| `name_entity` | `action: "name_entity", name: "Alice"` | Assigns a display name to the most prominent tracked entity |
+| `identify_person` | `action: "identify_person"` | Lists tracked people with names and presence duration |
+| `track_entity` | `action: "track_entity"` | Refreshes entity tracking and reports statistics |
 
 ## Vision Provider
 

--- a/plugins/plugin-vision/src/action-params.ts
+++ b/plugins/plugin-vision/src/action-params.ts
@@ -1,0 +1,98 @@
+/**
+ * Structured parameter resolvers for the VISION action (#10471).
+ *
+ * These are pure, dependency-light helpers deliberately kept out of `action.ts`
+ * (which pulls in the image/OCR/sharp stack) so the operation + mode resolution
+ * — the part that must NOT keyword-match raw message text — is independently
+ * testable. The planner supplies the operation and mode as structured params;
+ * these normalize them, never inferring intent from free text.
+ */
+
+import { VisionMode } from "./types";
+
+export const VISION_OPS = [
+  "describe",
+  "capture",
+  "get_screen",
+  "set_mode",
+  "enable_camera",
+  "disable_camera",
+  "enable_screen",
+  "disable_screen",
+  "name_entity",
+  "identify_person",
+  "track_entity",
+] as const;
+
+export type VisionOp = (typeof VISION_OPS)[number];
+
+/**
+ * Normalize a structured operation discriminator (`action`/`subaction`/`op`) to
+ * a canonical `VisionOp`, accepting a documented alias set. Returns `null` for
+ * anything unrecognized — including free-text sentences, so a raw message can
+ * never be coerced into an op.
+ */
+export function normalizeOp(value: unknown): VisionOp | null {
+  if (typeof value !== "string") return null;
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_");
+  if (!normalized) return null;
+  const aliases: Record<string, VisionOp> = {
+    describe_scene: "describe",
+    scene: "describe",
+    capture_image: "capture",
+    image: "capture",
+    photo: "capture",
+    snapshot: "capture",
+    screenshot: "capture",
+    set_vision_mode: "set_mode",
+    mode: "set_mode",
+    vision_mode: "set_mode",
+    camera_on: "enable_camera",
+    turn_on_camera: "enable_camera",
+    start_camera: "enable_camera",
+    camera_off: "disable_camera",
+    turn_off_camera: "disable_camera",
+    stop_camera: "disable_camera",
+    screen_on: "enable_screen",
+    turn_on_screen: "enable_screen",
+    start_screen: "enable_screen",
+    screen_off: "disable_screen",
+    turn_off_screen: "disable_screen",
+    stop_screen: "disable_screen",
+    name: "name_entity",
+    identify: "identify_person",
+    recognize: "identify_person",
+    track: "track_entity",
+    follow: "track_entity",
+  };
+  if (aliases[normalized]) return aliases[normalized];
+  return (VISION_OPS as readonly string[]).includes(normalized)
+    ? (normalized as VisionOp)
+    : null;
+}
+
+/**
+ * Normalize a structured vision mode value (`set_mode` op) to a `VisionMode`.
+ * Accepts the enum values + a small alias set; returns `null` for anything
+ * unrecognized. Exact-match only — never a substring test on free text (#10471),
+ * which previously let "coffee" match `.includes("off")` and disable vision.
+ */
+export function normalizeVisionMode(value: unknown): VisionMode | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  const aliases: Record<string, VisionMode> = {
+    off: VisionMode.OFF,
+    disable: VisionMode.OFF,
+    disabled: VisionMode.OFF,
+    none: VisionMode.OFF,
+    stop: VisionMode.OFF,
+    camera: VisionMode.CAMERA,
+    screen: VisionMode.SCREEN,
+    both: VisionMode.BOTH,
+    all: VisionMode.BOTH,
+  };
+  return aliases[normalized] ?? null;
+}

--- a/plugins/plugin-vision/src/action.structured.test.ts
+++ b/plugins/plugin-vision/src/action.structured.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { normalizeOp, normalizeVisionMode } from "./action-params";
+import { VisionMode } from "./types";
+
+/**
+ * #10471 — the VISION action resolves its operation and mode from the planner's
+ * STRUCTURED params, never from English keyword-matching the raw message text.
+ * These pin that the removed keyword banks / substring parsing stay gone (and
+ * that the old `"coffee".includes("off")` → OFF substring bug cannot recur).
+ */
+
+describe("normalizeOp (structured op only)", () => {
+  it("accepts canonical ops", () => {
+    expect(normalizeOp("describe")).toBe("describe");
+    expect(normalizeOp("set_mode")).toBe("set_mode");
+    expect(normalizeOp("track_entity")).toBe("track_entity");
+  });
+
+  it("accepts documented aliases", () => {
+    expect(normalizeOp("screenshot")).toBe("capture");
+    expect(normalizeOp("photo")).toBe("capture");
+    expect(normalizeOp("scene")).toBe("describe");
+    expect(normalizeOp("turn_on_camera")).toBe("enable_camera");
+    expect(normalizeOp("identify")).toBe("identify_person");
+  });
+
+  it("normalizes spacing/casing/hyphens", () => {
+    expect(normalizeOp(" Set-Mode ")).toBe("set_mode");
+    expect(normalizeOp("TURN OFF CAMERA")).toBe("disable_camera");
+  });
+
+  it("rejects free-text sentences (no keyword inference)", () => {
+    expect(normalizeOp("please describe what you see on my screen")).toBeNull();
+    expect(normalizeOp("can you take a photo?")).toBeNull();
+    expect(normalizeOp("")).toBeNull();
+    expect(normalizeOp(undefined)).toBeNull();
+    expect(normalizeOp(42)).toBeNull();
+  });
+});
+
+describe("normalizeVisionMode (exact enum match, no substring bug)", () => {
+  it("maps enum values and aliases", () => {
+    expect(normalizeVisionMode("OFF")).toBe(VisionMode.OFF);
+    expect(normalizeVisionMode("disable")).toBe(VisionMode.OFF);
+    expect(normalizeVisionMode("camera")).toBe(VisionMode.CAMERA);
+    expect(normalizeVisionMode("screen")).toBe(VisionMode.SCREEN);
+    expect(normalizeVisionMode("both")).toBe(VisionMode.BOTH);
+    expect(normalizeVisionMode(" Both ")).toBe(VisionMode.BOTH);
+  });
+
+  it("does NOT match a substring — the old bug where 'coffee'→OFF is gone", () => {
+    // "coffee" contains the substring "off"; exact-match must reject it.
+    expect(normalizeVisionMode("coffee")).toBeNull();
+    expect(normalizeVisionMode("turn off the lights and set alarm")).toBeNull();
+    expect(normalizeVisionMode("screenshot please")).toBeNull();
+    expect(normalizeVisionMode("")).toBeNull();
+    expect(normalizeVisionMode(undefined)).toBeNull();
+  });
+});

--- a/plugins/plugin-vision/src/action.ts
+++ b/plugins/plugin-vision/src/action.ts
@@ -12,6 +12,7 @@ import {
   type Memory,
   type State,
 } from "@elizaos/core";
+import { normalizeOp, normalizeVisionMode, VISION_OPS } from "./action-params";
 import { buildGetScreen, summarizeGetScreen } from "./get-screen";
 import { assertValidVisionImageBuffer } from "./image-input";
 import {
@@ -25,22 +26,6 @@ const VISION_ACTION_TIMEOUT_MS = 10_000;
 const MAX_VISION_TEXT_LENGTH = 4000;
 const MAX_VISION_ENTITIES = 25;
 
-const VISION_OPS = [
-  "describe",
-  "capture",
-  "get_screen",
-  "set_mode",
-  "enable_camera",
-  "disable_camera",
-  "enable_screen",
-  "disable_screen",
-  "name_entity",
-  "identify_person",
-  "track_entity",
-] as const;
-
-type VisionOp = (typeof VISION_OPS)[number];
-
 const ALL_VISION_CONTEXTS = [
   "media",
   "screen_time",
@@ -48,197 +33,6 @@ const ALL_VISION_CONTEXTS = [
   "memory",
   "settings",
 ] as const;
-
-const GET_SCREEN_KEYWORDS = [
-  "get_screen",
-  "get screen",
-  "read the screen",
-  "read screen",
-  "screen text",
-  "text on screen",
-  "what's on my screen",
-  "whats on my screen",
-  "what is on my screen",
-  "screen contents",
-  "ocr",
-  "extract text",
-];
-
-const DESCRIBE_KEYWORDS = [
-  "describe",
-  "scene",
-  "see",
-  "look",
-  "camera",
-  "screen",
-  "object",
-  "person",
-  "escena",
-  "ver",
-  "camara",
-  "décrire",
-  "scène",
-  "voir",
-  "beschreiben",
-  "szene",
-  "sehen",
-  "descrivi",
-  "scena",
-  "vedi",
-  "説明",
-  "見える",
-  "场景",
-  "描述",
-  "看见",
-  "장면",
-  "설명",
-  "보여",
-];
-
-const CAPTURE_KEYWORDS = [
-  "capture",
-  "image",
-  "photo",
-  "picture",
-  "snapshot",
-  "screenshot",
-  "camera",
-  "captura",
-  "foto",
-  "imagen",
-  "capturer",
-  "photo",
-  "bild",
-  "foto",
-  "capturare",
-  "写真",
-  "画像",
-  "スクリーンショット",
-  "拍照",
-  "截图",
-  "이미지",
-  "사진",
-  "스크린샷",
-];
-
-const SET_MODE_KEYWORDS = [
-  "vision",
-  "mode",
-  "camera",
-  "screen",
-  "both",
-  "disable",
-  "enable",
-  "off",
-  "visión",
-  "camara",
-  "pantalla",
-  "écran",
-  "kamera",
-  "bildschirm",
-  "schermo",
-  "ビジョン",
-  "カメラ",
-  "画面",
-  "视觉",
-  "相机",
-  "屏幕",
-  "비전",
-  "카메라",
-  "화면",
-];
-
-const NAME_ENTITY_KEYWORDS = [
-  "name",
-  "named",
-  "call",
-  "person",
-  "entity",
-  "remember",
-  "object",
-  "nombre",
-  "llama",
-  "persona",
-  "nom",
-  "appelle",
-  "personne",
-  "name",
-  "nenne",
-  "person",
-  "nome",
-  "chiama",
-  "persona",
-  "名前",
-  "呼ぶ",
-  "人",
-  "命名",
-  "叫",
-  "人",
-  "이름",
-  "불러",
-  "사람",
-];
-
-const IDENTIFY_PERSON_KEYWORDS = [
-  "identify",
-  "recognize",
-  "who is",
-  "person",
-  "face",
-  "seen before",
-  "identificar",
-  "reconoces",
-  "persona",
-  "visage",
-  "reconnais",
-  "personne",
-  "erkennen",
-  "gesicht",
-  "person",
-  "riconosci",
-  "persona",
-  "識別",
-  "誰",
-  "顔",
-  "识别",
-  "是谁",
-  "人",
-  "식별",
-  "누구",
-  "얼굴",
-];
-
-const TRACK_ENTITY_KEYWORDS = [
-  "track",
-  "follow",
-  "watch",
-  "keep an eye",
-  "entity",
-  "person",
-  "object",
-  "rastrear",
-  "seguir",
-  "vigilar",
-  "persona",
-  "suivre",
-  "surveiller",
-  "personne",
-  "verfolgen",
-  "beobachten",
-  "person",
-  "traccia",
-  "segui",
-  "persona",
-  "追跡",
-  "見張",
-  "人",
-  "跟踪",
-  "关注",
-  "人",
-  "추적",
-  "지켜봐",
-  "사람",
-];
 
 function withVisionTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
   return Promise.race([
@@ -323,86 +117,6 @@ function selectedContextMatches(
 function visionServiceIsActive(runtime: IAgentRuntime): boolean {
   const visionService = runtime.getService<VisionService>("VISION");
   return Boolean(visionService?.isActive());
-}
-
-function normalizeOp(value: unknown): VisionOp | null {
-  if (typeof value !== "string") return null;
-  const normalized = value
-    .trim()
-    .toLowerCase()
-    .replace(/[\s-]+/g, "_");
-  if (!normalized) return null;
-  const aliases: Record<string, VisionOp> = {
-    describe_scene: "describe",
-    scene: "describe",
-    capture_image: "capture",
-    image: "capture",
-    photo: "capture",
-    snapshot: "capture",
-    screenshot: "capture",
-    set_vision_mode: "set_mode",
-    mode: "set_mode",
-    vision_mode: "set_mode",
-    camera_on: "enable_camera",
-    turn_on_camera: "enable_camera",
-    start_camera: "enable_camera",
-    camera_off: "disable_camera",
-    turn_off_camera: "disable_camera",
-    stop_camera: "disable_camera",
-    screen_on: "enable_screen",
-    turn_on_screen: "enable_screen",
-    start_screen: "enable_screen",
-    screen_off: "disable_screen",
-    turn_off_screen: "disable_screen",
-    stop_screen: "disable_screen",
-    name: "name_entity",
-    identify: "identify_person",
-    recognize: "identify_person",
-    track: "track_entity",
-    follow: "track_entity",
-  };
-  if (aliases[normalized]) return aliases[normalized];
-  return (VISION_OPS as readonly string[]).includes(normalized)
-    ? (normalized as VisionOp)
-    : null;
-}
-
-function inferOpFromMessage(text: string): VisionOp | null {
-  const lower = text.toLowerCase();
-  if (
-    NAME_ENTITY_KEYWORDS.some((k) => lower.includes(k.toLowerCase())) &&
-    /\b(call|name|named)\b/.test(lower)
-  ) {
-    return "name_entity";
-  }
-  if (
-    IDENTIFY_PERSON_KEYWORDS.some((k) => lower.includes(k.toLowerCase())) &&
-    /\b(who|identify|recognize)\b/.test(lower)
-  ) {
-    return "identify_person";
-  }
-  if (
-    TRACK_ENTITY_KEYWORDS.some((k) => lower.includes(k.toLowerCase())) &&
-    /\b(track|follow|watch|keep an eye)\b/.test(lower)
-  ) {
-    return "track_entity";
-  }
-  if (
-    SET_MODE_KEYWORDS.some((k) => lower.includes(k.toLowerCase())) &&
-    /\b(mode|enable|disable|turn off|turn on)\b/.test(lower)
-  ) {
-    return "set_mode";
-  }
-  if (GET_SCREEN_KEYWORDS.some((k) => lower.includes(k.toLowerCase()))) {
-    return "get_screen";
-  }
-  if (CAPTURE_KEYWORDS.some((k) => lower.includes(k.toLowerCase()))) {
-    return "capture";
-  }
-  if (DESCRIBE_KEYWORDS.some((k) => lower.includes(k.toLowerCase()))) {
-    return "describe";
-  }
-  return null;
 }
 
 /** Structural view of plugin-computeruse's screenshot capability (no hard dep). */
@@ -976,21 +690,9 @@ async function runSetMode(
   }
 
   try {
-    const explicitMode =
-      typeof options.mode === "string" ? options.mode.toLowerCase() : "";
-    const messageText =
-      explicitMode || message.content.text?.toLowerCase() || "";
-    let newMode: VisionMode | null = null;
-
-    if (messageText.includes("off") || messageText.includes("disable")) {
-      newMode = VisionMode.OFF;
-    } else if (messageText.includes("both")) {
-      newMode = VisionMode.BOTH;
-    } else if (messageText.includes("screen")) {
-      newMode = VisionMode.SCREEN;
-    } else if (messageText.includes("camera")) {
-      newMode = VisionMode.CAMERA;
-    }
+    // #10471: the mode comes from the structured `mode` param, matched exactly
+    // against the VisionMode enum — never a substring test on message text.
+    const newMode = normalizeVisionMode(options.mode);
 
     if (!newMode) {
       const thought =
@@ -1112,17 +814,14 @@ async function runNameEntity(
       };
     }
 
-    const messageText = message.content.text?.toLowerCase() || "";
-    const explicitName =
-      typeof options.name === "string" ? options.name.trim() : "";
-    const nameMatch = explicitName
-      ? [explicitName, explicitName]
-      : messageText.match(/(?:named?|call(?:ed)?|is)\s+(\w+)/i);
+    // #10471: the entity name comes from the structured `name` param, not a
+    // regex over the raw message text.
+    const name = typeof options.name === "string" ? options.name.trim() : "";
 
-    if (!nameMatch) {
-      const thought = "Could not extract name from message.";
+    if (!name) {
+      const thought = "No structured name parameter was provided.";
       const text =
-        'I couldn\'t understand what name to assign. Please say something like "The person is named Alice".';
+        'I couldn\'t understand what name to assign. Provide a "name" parameter (e.g. name: "Alice").';
       await saveExecutionRecord(runtime, message, thought, text, ["VISION"]);
       if (callback) {
         await callback({ thought, text, actions: ["VISION"] });
@@ -1134,7 +833,6 @@ async function runNameEntity(
       };
     }
 
-    const name = nameMatch[1];
     const entityTracker = visionService.getEntityTracker();
 
     await entityTracker.updateEntities(
@@ -1635,11 +1333,11 @@ export const visionAction: Action = {
     _responses?: Memory[],
   ): Promise<ActionResult> => {
     const params = readActionParams(_options);
-    const explicitOp = normalizeOp(
+    // #10471: the operation comes from the planner's structured discriminator,
+    // never from English keyword-matching the raw message text.
+    const inferredOp = normalizeOp(
       params.action ?? params.subaction ?? params.op,
     );
-    const inferredOp =
-      explicitOp ?? inferOpFromMessage(message.content?.text ?? "");
 
     if (!inferredOp) {
       const text = `VISION could not determine the operation. Specify one of: ${VISION_OPS.join(", ")}.`;

--- a/plugins/plugin-vision/src/service.ts
+++ b/plugins/plugin-vision/src/service.ts
@@ -212,7 +212,8 @@ interface CameraDevice {
 }
 
 export class VisionService extends Service {
-  static override serviceType: ServiceTypeName = VisionServiceType.VISION;
+  static override serviceType: ServiceTypeName =
+    VisionServiceType.VISION as ServiceTypeName;
   override capabilityDescription =
     "Provides visual perception through camera integration and scene analysis.";
 


### PR DESCRIPTION
## Summary

Refs #10471. Removes the i18n-hostile string-match smells from `@elizaos/plugin-vision`'s `VISION` action — an untouched plugin in the sweep, and one hiding a genuine bug.

The action routed intent by keyword-matching raw `message.content.text`:
- **`inferOpFromMessage`** fed by **seven multilingual keyword banks** (`GET_SCREEN_KEYWORDS`, `CAPTURE_KEYWORDS`, `DESCRIBE_KEYWORDS`, `SET_MODE_KEYWORDS`, `NAME_ENTITY_KEYWORDS`, `IDENTIFY_PERSON_KEYWORDS`, `TRACK_ENTITY_KEYWORDS`, ~190 lines) — routed the operation.
- **`runSetMode`** parsed the mode with `messageText.includes("off")` etc. — a **substring** test, so `"coffee"` (contains `off`) would set `VisionMode.OFF` and disable vision. Real bug.
- **`runNameEntity`** parsed the entity name with a regex over message text.

## Changes

- New **`action-params.ts`** — pure, dependency-light resolvers so the op/mode logic is testable without the image/OCR/`sharp` stack: `normalizeOp` (structured discriminator + documented aliases; rejects free text) and `normalizeVisionMode` (exact enum/alias match).
- **Handler** resolves the op from the structured `action`/`subaction`/`op` param only; `inferOpFromMessage` + all seven keyword banks deleted. Unknown op → the existing `MISSING` error (the planner supplies the op).
- **`runSetMode`** → `normalizeVisionMode(options.mode)` (kills the substring bug).
- **`runNameEntity`** → structured `options.name` only.

## Tests

`bun run --cwd plugins/plugin-vision test src/action.structured.test.ts` → **6 passed**. biome 2.5.1 clean on all touched files.

Coverage: op canonical + aliases + spacing/casing, and **free-text sentences rejected** (no keyword inference); mode enum/alias mapping and the **`"coffee"`→OFF substring regression** explicitly pinned closed.

## Verification note (env-gated typecheck)

`bun run --cwd plugins/plugin-vision typecheck` cannot complete in a fresh worktree: `jimp` (a declared dep) is not hoisted into the shared node_modules, so `image/sharp-compat.ts` fails to resolve it and that **cascades** to `service.ts` (which imports the image stack). Both errors are in files this PR does **not** touch — there are **zero** type errors in `action.ts` / `action-params.ts`. CI installs `jimp` and typechecks the package clean.

## Evidence

- **Real-LLM trajectory / on-device run** — N/A: deterministic routing/param-resolution refactor; the VLM/OCR/service paths (`runDescribe`/`runCapture`/`getScreen`) are unchanged. The behavior change (structured-only op/mode/name) is covered by platform-independent unit tests.
