### PR TITLE
feat(app): /embed SPA bootstrap — client half of the embed launch handshake (#9947)

### DIFF
--- a/packages/app/src/embed-bootstrap.test.ts
+++ b/packages/app/src/embed-bootstrap.test.ts
@@ -125,7 +125,10 @@ describe("runEmbedHandshake", () => {
       jsonResponse(200, { role: "ADMIN", adminMode: true, token: "t" }),
     );
     const outcome = await runEmbedHandshake({
-      win: fakeWin("/embed", "?platform=discord&code=oauth2-code"),
+      win: fakeWin(
+        "/embed",
+        "?platform=discord&code=oauth2-code&state=signed-state",
+      ),
       fetchImpl: fetchImpl as unknown as typeof fetch,
       client,
     });
@@ -133,6 +136,7 @@ describe("runEmbedHandshake", () => {
     expect(JSON.parse(String(fetchImpl.mock.calls[0][1]?.body))).toMatchObject({
       platform: "discord",
       signedLaunchPayload: "oauth2-code",
+      state: "signed-state",
     });
   });
 
@@ -161,7 +165,7 @@ describe("runEmbedHandshake", () => {
       jsonResponse(200, { role: "ADMIN", adminMode: true, token: "t" }),
     );
     const outcome = await runEmbedHandshake({
-      win: fakeWin("/embed", "?code=disc-code"),
+      win: fakeWin("/embed", "?code=disc-code&state=signed-state"),
       fetchImpl: fetchImpl as unknown as typeof fetch,
       client,
     });
@@ -169,7 +173,26 @@ describe("runEmbedHandshake", () => {
     expect(JSON.parse(String(fetchImpl.mock.calls[0][1]?.body))).toMatchObject({
       platform: "discord",
       signedLaunchPayload: "disc-code",
+      state: "signed-state",
     });
+  });
+
+  it("fails closed when a discord redirect has a code but omits OAuth state", async () => {
+    const { client, setToken } = fakeClient();
+    const fetchImpl = fakeFetch(
+      jsonResponse(200, { role: "ADMIN", adminMode: true, token: "t" }),
+    );
+    const outcome = await runEmbedHandshake({
+      win: fakeWin("/embed", "?code=disc-code"),
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      client,
+    });
+    expect(outcome).toEqual({
+      status: "failed",
+      reason: "missing_oauth_state",
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(setToken).not.toHaveBeenCalled();
   });
 
   it("fails closed on a bare /embed with no platform signal at all", async () => {

--- a/packages/app/src/embed-bootstrap.test.ts
+++ b/packages/app/src/embed-bootstrap.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  type EmbedClient,
+  isEmbedPath,
+  runEmbedHandshake,
+} from "./embed-bootstrap";
+
+const BASE = "https://agent.example";
+
+function fakeClient() {
+  const setToken = vi.fn<(token: string | null) => void>();
+  const client: EmbedClient = { getBaseUrl: () => BASE, setToken };
+  return { client, setToken };
+}
+
+function fakeFetch(response: Response | Error) {
+  return vi.fn((_url: string, _init?: RequestInit): Promise<Response> => {
+    if (response instanceof Error) return Promise.reject(response);
+    return Promise.resolve(response);
+  });
+}
+
+function fakeWin(
+  pathname: string,
+  search = "",
+  telegramInitData?: string,
+): Window {
+  return {
+    location: { pathname, search },
+    ...(telegramInitData !== undefined
+      ? { Telegram: { WebApp: { initData: telegramInitData, ready: vi.fn() } } }
+      : {}),
+  } as unknown as Window;
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe("isEmbedPath", () => {
+  it("matches /embed and subpaths only", () => {
+    expect(isEmbedPath("/embed")).toBe(true);
+    expect(isEmbedPath("/embed/telegram")).toBe(true);
+    expect(isEmbedPath("/")).toBe(false);
+    expect(isEmbedPath("/embedded")).toBe(false);
+  });
+});
+
+describe("runEmbedHandshake", () => {
+  it("is a no-op off the /embed route", async () => {
+    const fetchImpl = fakeFetch(jsonResponse(200, {}));
+    const { client, setToken } = fakeClient();
+    const outcome = await runEmbedHandshake({
+      win: fakeWin("/"),
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      client,
+    });
+    expect(outcome).toEqual({ status: "not-embed" });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(setToken).not.toHaveBeenCalled();
+  });
+
+  it("fails closed on an unknown platform", async () => {
+    const outcome = await runEmbedHandshake({
+      win: fakeWin("/embed", "?platform=slack"),
+      client: fakeClient().client,
+    });
+    expect(outcome).toEqual({ status: "failed", reason: "unknown_platform" });
+  });
+
+  it("fails when the telegram initData is missing", async () => {
+    const outcome = await runEmbedHandshake({
+      win: fakeWin("/embed", "?platform=telegram"),
+      client: fakeClient().client,
+    });
+    expect(outcome).toEqual({
+      status: "failed",
+      reason: "missing_launch_payload",
+    });
+  });
+
+  it("exchanges a telegram initData payload and installs the token", async () => {
+    const { client, setToken } = fakeClient();
+    const fetchImpl = fakeFetch(
+      jsonResponse(200, {
+        entityId: "e1",
+        role: "OWNER",
+        adminMode: true,
+        token: "embed-token-abc",
+      }),
+    );
+    const outcome = await runEmbedHandshake({
+      win: fakeWin(
+        "/embed",
+        "?platform=telegram&accountId=acct-1",
+        "tg-init-data",
+      ),
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      client,
+    });
+    expect(outcome).toEqual({
+      status: "authenticated",
+      role: "OWNER",
+      adminMode: true,
+    });
+    expect(setToken).toHaveBeenCalledWith("embed-token-abc");
+    // POSTs the verified launch to the agent's embed-auth route.
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(url).toBe(`${BASE}/api/embed/auth`);
+    expect(init?.method).toBe("POST");
+    expect(JSON.parse(String(init?.body))).toEqual({
+      platform: "telegram",
+      signedLaunchPayload: "tg-init-data",
+      accountId: "acct-1",
+    });
+  });
+
+  it("exchanges a discord Activity code from the query string", async () => {
+    const { client } = fakeClient();
+    const fetchImpl = fakeFetch(
+      jsonResponse(200, { role: "ADMIN", adminMode: true, token: "t" }),
+    );
+    const outcome = await runEmbedHandshake({
+      win: fakeWin("/embed", "?platform=discord&code=oauth2-code"),
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      client,
+    });
+    expect(outcome.status).toBe("authenticated");
+    expect(JSON.parse(String(fetchImpl.mock.calls[0][1]?.body))).toMatchObject({
+      platform: "discord",
+      signedLaunchPayload: "oauth2-code",
+    });
+  });
+
+  it("fails closed on a 403 without installing a token", async () => {
+    const { client, setToken } = fakeClient();
+    const fetchImpl = fakeFetch(jsonResponse(403, { error: "nope" }));
+    const outcome = await runEmbedHandshake({
+      win: fakeWin("/embed", "?platform=telegram", "tg"),
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      client,
+    });
+    expect(outcome).toEqual({ status: "failed", reason: "http_403" });
+    expect(setToken).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the response carries no token", async () => {
+    const { client, setToken } = fakeClient();
+    const fetchImpl = fakeFetch(jsonResponse(200, { role: "OWNER" }));
+    const outcome = await runEmbedHandshake({
+      win: fakeWin("/embed", "?platform=telegram", "tg"),
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      client,
+    });
+    expect(outcome).toEqual({ status: "failed", reason: "no_token" });
+    expect(setToken).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the fetch rejects", async () => {
+    const { client, setToken } = fakeClient();
+    const fetchImpl = fakeFetch(new Error("network down"));
+    const outcome = await runEmbedHandshake({
+      win: fakeWin("/embed", "?platform=telegram", "tg"),
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      client,
+    });
+    expect(outcome).toEqual({ status: "failed", reason: "network_error" });
+    expect(setToken).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/embed-bootstrap.test.ts
+++ b/packages/app/src/embed-bootstrap.test.ts
@@ -136,6 +136,51 @@ describe("runEmbedHandshake", () => {
     });
   });
 
+  it("auto-detects telegram from injected initData on a bare /embed URL", async () => {
+    // The Telegram web_app button links to a bare `<base>/embed` (no ?platform).
+    const { client, setToken } = fakeClient();
+    const fetchImpl = fakeFetch(
+      jsonResponse(200, { role: "OWNER", adminMode: true, token: "tok" }),
+    );
+    const outcome = await runEmbedHandshake({
+      win: fakeWin("/embed", "", "tg-init"),
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      client,
+    });
+    expect(outcome.status).toBe("authenticated");
+    expect(setToken).toHaveBeenCalledWith("tok");
+    expect(JSON.parse(String(fetchImpl.mock.calls[0][1]?.body))).toMatchObject({
+      platform: "telegram",
+      signedLaunchPayload: "tg-init",
+    });
+  });
+
+  it("auto-detects discord from a bare /embed?code= redirect", async () => {
+    const { client } = fakeClient();
+    const fetchImpl = fakeFetch(
+      jsonResponse(200, { role: "ADMIN", adminMode: true, token: "t" }),
+    );
+    const outcome = await runEmbedHandshake({
+      win: fakeWin("/embed", "?code=disc-code"),
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      client,
+    });
+    expect(outcome.status).toBe("authenticated");
+    expect(JSON.parse(String(fetchImpl.mock.calls[0][1]?.body))).toMatchObject({
+      platform: "discord",
+      signedLaunchPayload: "disc-code",
+    });
+  });
+
+  it("fails closed on a bare /embed with no platform signal at all", async () => {
+    const { client } = fakeClient();
+    const outcome = await runEmbedHandshake({
+      win: fakeWin("/embed"),
+      client,
+    });
+    expect(outcome).toEqual({ status: "failed", reason: "unknown_platform" });
+  });
+
   it("fails closed on a 403 without installing a token", async () => {
     const { client, setToken } = fakeClient();
     const fetchImpl = fakeFetch(jsonResponse(403, { error: "nope" }));

--- a/packages/app/src/embed-bootstrap.ts
+++ b/packages/app/src/embed-bootstrap.ts
@@ -92,6 +92,11 @@ function readLaunchPayload(
   return code ? code : null;
 }
 
+function readDiscordOAuthState(params: URLSearchParams): string | null {
+  const state = params.get("state")?.trim();
+  return state ? state : null;
+}
+
 /**
  * Run the embed-launch handshake if the current location is the `/embed` route.
  * Returns `{ status: "not-embed" }` (a no-op) otherwise so callers can invoke it
@@ -115,6 +120,11 @@ export async function runEmbedHandshake(
   if (!signedLaunchPayload) {
     return { status: "failed", reason: "missing_launch_payload" };
   }
+  const oauthState =
+    platform === "discord" ? readDiscordOAuthState(params) : undefined;
+  if (platform === "discord" && !oauthState) {
+    return { status: "failed", reason: "missing_oauth_state" };
+  }
 
   const embedClient = deps.client;
   if (!embedClient) {
@@ -129,7 +139,12 @@ export async function runEmbedHandshake(
     response = await fetchImpl(`${base}/api/embed/auth`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ platform, signedLaunchPayload, accountId }),
+      body: JSON.stringify({
+        platform,
+        signedLaunchPayload,
+        accountId,
+        ...(oauthState ? { state: oauthState } : {}),
+      }),
     });
   } catch {
     return { status: "failed", reason: "network_error" };

--- a/packages/app/src/embed-bootstrap.ts
+++ b/packages/app/src/embed-bootstrap.ts
@@ -50,9 +50,32 @@ export function isEmbedPath(pathname: string): boolean {
   return pathname === "/embed" || pathname.startsWith("/embed/");
 }
 
-function detectPlatform(params: URLSearchParams): EmbedPlatform | null {
-  const platform = params.get("platform");
-  return platform === "telegram" || platform === "discord" ? platform : null;
+function telegramInitData(win: Window): string | null {
+  const telegram = (win as Window & { Telegram?: { WebApp?: TelegramWebApp } })
+    .Telegram?.WebApp;
+  // The Mini App SDK wants `ready()` called once the app is prepared to be
+  // shown; it is also what makes `initData` reliably available.
+  telegram?.ready?.();
+  const initData = telegram?.initData?.trim();
+  return initData ? initData : null;
+}
+
+/**
+ * Detect the launch platform. The connector launch surfaces link to a bare
+ * `/embed` URL (no `?platform=`), so infer it from the runtime signals:
+ * a Telegram Mini App injects `Telegram.WebApp.initData`; a Discord Activity
+ * OAuth redirect lands with a `?code`. An explicit `?platform=` overrides both
+ * (useful for testing / non-standard launchers).
+ */
+function detectPlatform(
+  params: URLSearchParams,
+  win: Window,
+): EmbedPlatform | null {
+  const explicit = params.get("platform");
+  if (explicit === "telegram" || explicit === "discord") return explicit;
+  if (telegramInitData(win)) return "telegram";
+  if (params.get("code")?.trim()) return "discord";
+  return null;
 }
 
 function readLaunchPayload(
@@ -61,14 +84,7 @@ function readLaunchPayload(
   win: Window,
 ): string | null {
   if (platform === "telegram") {
-    const telegram = (
-      win as Window & { Telegram?: { WebApp?: TelegramWebApp } }
-    ).Telegram?.WebApp;
-    // The Mini App SDK wants `ready()` called once the app is prepared to be
-    // shown; it is also what makes `initData` reliably available.
-    telegram?.ready?.();
-    const initData = telegram?.initData?.trim();
-    return initData ? initData : null;
+    return telegramInitData(win);
   }
   // Discord Activity: the Embedded App SDK's `commands.authorize()` returns an
   // OAuth2 `code` the launch link carries through as a query param.
@@ -90,7 +106,7 @@ export async function runEmbedHandshake(
   }
 
   const params = new URLSearchParams(win.location.search);
-  const platform = detectPlatform(params);
+  const platform = detectPlatform(params, win);
   if (!platform) {
     return { status: "failed", reason: "unknown_platform" };
   }

--- a/packages/app/src/embed-bootstrap.ts
+++ b/packages/app/src/embed-bootstrap.ts
@@ -1,0 +1,143 @@
+/**
+ * Embedded-app launch bootstrap (#9947).
+ *
+ * When the SPA is served at `/embed` inside a Telegram Mini App or Discord
+ * Activity iframe, the first-party Steward session cookie does not cross into
+ * the third-party origin, so the app cannot authenticate the normal way. This
+ * runs the client half of the embed-launch handshake before the app mounts:
+ *
+ *   1. Read the platform's signed launch payload (Telegram `initData` from the
+ *      WebApp SDK; the Discord Activity OAuth2 `code` from the query string).
+ *   2. POST it to the agent's `POST /api/embed/auth`, which verifies it
+ *      server-side (`verifyEmbedLaunch`) and mints a scoped session token for
+ *      the verified OWNER/ADMIN principal.
+ *   3. Install that token on the ElizaClient (`client.setToken`) so every
+ *      subsequent agent API call carries it as a bearer — the credential the
+ *      auth boundary now accepts (see app-core embed-session-token wiring).
+ *
+ * The handshake is dependency-injected (window / fetch / client) so it is unit
+ * testable without the iframe runtime or the ElizaClient singleton. It never
+ * throws: a failure returns a `failed` outcome and the app still mounts (in its
+ * unauthenticated state) rather than white-screening.
+ */
+
+export type EmbedPlatform = "telegram" | "discord";
+
+export type EmbedAuthOutcome =
+  | { status: "not-embed" }
+  | { status: "authenticated"; role: string; adminMode: boolean }
+  | { status: "failed"; reason: string };
+
+/** The subset of the ElizaClient this bootstrap needs. */
+export interface EmbedClient {
+  getBaseUrl(): string;
+  setToken(token: string | null): void;
+}
+
+interface TelegramWebApp {
+  initData?: string;
+  ready?: () => void;
+  expand?: () => void;
+}
+
+interface EmbedHandshakeDeps {
+  win?: Window;
+  fetchImpl?: typeof fetch;
+  client?: EmbedClient;
+}
+
+export function isEmbedPath(pathname: string): boolean {
+  return pathname === "/embed" || pathname.startsWith("/embed/");
+}
+
+function detectPlatform(params: URLSearchParams): EmbedPlatform | null {
+  const platform = params.get("platform");
+  return platform === "telegram" || platform === "discord" ? platform : null;
+}
+
+function readLaunchPayload(
+  platform: EmbedPlatform,
+  params: URLSearchParams,
+  win: Window,
+): string | null {
+  if (platform === "telegram") {
+    const telegram = (
+      win as Window & { Telegram?: { WebApp?: TelegramWebApp } }
+    ).Telegram?.WebApp;
+    // The Mini App SDK wants `ready()` called once the app is prepared to be
+    // shown; it is also what makes `initData` reliably available.
+    telegram?.ready?.();
+    const initData = telegram?.initData?.trim();
+    return initData ? initData : null;
+  }
+  // Discord Activity: the Embedded App SDK's `commands.authorize()` returns an
+  // OAuth2 `code` the launch link carries through as a query param.
+  const code = params.get("code")?.trim();
+  return code ? code : null;
+}
+
+/**
+ * Run the embed-launch handshake if the current location is the `/embed` route.
+ * Returns `{ status: "not-embed" }` (a no-op) otherwise so callers can invoke it
+ * unconditionally at boot.
+ */
+export async function runEmbedHandshake(
+  deps: EmbedHandshakeDeps = {},
+): Promise<EmbedAuthOutcome> {
+  const win = deps.win ?? window;
+  if (!isEmbedPath(win.location.pathname)) {
+    return { status: "not-embed" };
+  }
+
+  const params = new URLSearchParams(win.location.search);
+  const platform = detectPlatform(params);
+  if (!platform) {
+    return { status: "failed", reason: "unknown_platform" };
+  }
+
+  const signedLaunchPayload = readLaunchPayload(platform, params, win);
+  if (!signedLaunchPayload) {
+    return { status: "failed", reason: "missing_launch_payload" };
+  }
+
+  const embedClient = deps.client;
+  if (!embedClient) {
+    return { status: "failed", reason: "client_unavailable" };
+  }
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const accountId = params.get("accountId") ?? undefined;
+  const base = embedClient.getBaseUrl().replace(/\/+$/, "");
+
+  let response: Response;
+  try {
+    response = await fetchImpl(`${base}/api/embed/auth`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ platform, signedLaunchPayload, accountId }),
+    });
+  } catch {
+    return { status: "failed", reason: "network_error" };
+  }
+
+  if (!response.ok) {
+    return { status: "failed", reason: `http_${response.status}` };
+  }
+
+  let body: { token?: unknown; role?: unknown; adminMode?: unknown };
+  try {
+    body = (await response.json()) as typeof body;
+  } catch {
+    return { status: "failed", reason: "bad_response" };
+  }
+
+  if (typeof body.token !== "string" || body.token.length === 0) {
+    return { status: "failed", reason: "no_token" };
+  }
+
+  embedClient.setToken(body.token);
+  return {
+    status: "authenticated",
+    role: typeof body.role === "string" ? body.role : "ADMIN",
+    adminMode: body.adminMode === true,
+  };
+}

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -135,6 +135,7 @@ import { APP_ENV_ALIASES, APP_ENV_PREFIX } from "./brand-env";
 import { APP_CHARACTER_CATALOG } from "./character-catalog";
 import { isTrustedAppLink } from "./deep-link-handler";
 import { buildAssistantLaunchHashRoute } from "./deep-link-routing";
+import { runEmbedHandshake } from "./embed-bootstrap";
 import {
   apiBaseToDeviceBridgeUrl,
   type IosRuntimeConfig,
@@ -2614,6 +2615,12 @@ function applyStoredDetachedShellTheme(): void {
 async function main(): Promise<void> {
   markStartup("main-start");
   registerViewServiceWorker();
+
+  // #9947: when served at /embed inside a Telegram Mini App / Discord Activity
+  // iframe, exchange the platform's signed launch payload for a scoped session
+  // token and install it on the ElizaClient BEFORE any authenticated agent API
+  // call is made. No-op (and never throws) off the /embed route.
+  await runEmbedHandshake({ client });
 
   const appWindowSlug = window.location.pathname.startsWith("/apps/")
     ? window.location.pathname.slice("/apps/".length).split("/")[0]

--- a/plugins/plugin-discord/__tests__/slash-commands.test.ts
+++ b/plugins/plugin-discord/__tests__/slash-commands.test.ts
@@ -21,6 +21,8 @@ import {
 
 const AGENT_ID = "11111111-1111-1111-1111-111111111111";
 const HTTPS_EMBED_URL = "https://app.eliza.example/embed";
+const HTTPS_DISCORD_EMBED_URL =
+	"https://app.eliza.example/embed?platform=discord";
 
 function makeRuntime(settings: Record<string, string> = {}): IAgentRuntime {
 	return {
@@ -82,7 +84,7 @@ describe("/app embedded-app launch command (#9947)", () => {
 		expect(payload.commands.some((c) => c.name === "app")).toBe(true);
 	});
 
-	it("returns the https /embed launch link for an elevated member", async () => {
+	it("returns the platform-tagged https /embed launch link for an elevated member", async () => {
 		hasRoleAccess.mockResolvedValue(true);
 		const interaction = makeInteraction();
 		await appCommand().execute(
@@ -92,7 +94,7 @@ describe("/app embedded-app launch command (#9947)", () => {
 
 		const reply = lastReply(interaction);
 		expect(reply.ephemeral).toBe(true);
-		expect(reply.content).toContain(HTTPS_EMBED_URL);
+		expect(reply.content).toContain(HTTPS_DISCORD_EMBED_URL);
 		// The gate was evaluated against the ADMIN role.
 		expect(hasRoleAccess).toHaveBeenCalled();
 		expect(hasRoleAccess.mock.calls[0][2]).toBe("ADMIN");
@@ -106,7 +108,7 @@ describe("/app embedded-app launch command (#9947)", () => {
 			makeRuntime({ ELIZA_APP_URL: "https://app.eliza.example/" }),
 		);
 
-		expect(lastReply(interaction).content).toContain(HTTPS_EMBED_URL);
+		expect(lastReply(interaction).content).toContain(HTTPS_DISCORD_EMBED_URL);
 	});
 
 	it("returns an ephemeral denial for a non-elevated member", async () => {

--- a/plugins/plugin-discord/slash-commands.ts
+++ b/plugins/plugin-discord/slash-commands.ts
@@ -426,26 +426,31 @@ const APP_LAUNCH_LABEL = "Open Eliza App";
 function resolveEmbedLaunchUrl(runtime: IAgentRuntime): string | undefined {
 	const direct = runtime.getSetting("ELIZA_EMBED_URL");
 	if (typeof direct === "string" && direct.trim().length > 0) {
-		return toHttpsUrl(direct.trim());
+		return toHttpsUrl(direct.trim(), "discord");
 	}
 	const base =
 		runtime.getSetting("ELIZA_APP_URL") ||
 		runtime.getSetting("ELIZA_CLOUD_URL");
 	if (typeof base === "string" && base.trim().length > 0) {
-		return toHttpsUrl(`${base.trim().replace(/\/+$/, "")}/embed`);
+		return toHttpsUrl(`${base.trim().replace(/\/+$/, "")}/embed`, "discord");
 	}
 	return undefined;
 }
 
 /** Return the URL only when it parses as absolute `https`, else `undefined`. */
-function toHttpsUrl(url: string): string | undefined {
+function toHttpsUrl(url: string, platform: "discord"): string | undefined {
 	let parsed: URL;
 	try {
 		parsed = new URL(url);
 	} catch {
 		return undefined;
 	}
-	return parsed.protocol === "https:" ? parsed.toString() : undefined;
+	if (parsed.protocol !== "https:") return undefined;
+	if (parsed.pathname === "/" || parsed.pathname === "") {
+		parsed.pathname = "/embed";
+	}
+	parsed.searchParams.set("platform", platform);
+	return parsed.toString();
 }
 
 /**

--- a/plugins/plugin-telegram/src/messageManager.embed-launch.test.ts
+++ b/plugins/plugin-telegram/src/messageManager.embed-launch.test.ts
@@ -18,6 +18,8 @@ vi.mock("@elizaos/core", async (importOriginal) => {
 import { MessageManager } from "./messageManager";
 
 const HTTPS_EMBED_URL = "https://app.eliza.example/embed";
+const HTTPS_TELEGRAM_EMBED_URL =
+  "https://app.eliza.example/embed?platform=telegram";
 
 function setup(settings: Record<string, string> = {}) {
   const runtime = {
@@ -77,7 +79,7 @@ describe("Telegram embedded-app launch button (#9947)", () => {
     hasRoleAccess.mockResolvedValue(true);
   });
 
-  it("emits a web_app button with the https /embed url for an OWNER sender", async () => {
+  it("emits a web_app button with the platform-tagged https /embed url for an OWNER sender", async () => {
     const { manager, ctx, sendMessage } = setup({
       ELIZA_EMBED_URL: HTTPS_EMBED_URL,
     });
@@ -86,7 +88,7 @@ describe("Telegram embedded-app launch button (#9947)", () => {
 
     const buttons = webAppButtons(lastKeyboard(sendMessage));
     expect(buttons).toHaveLength(1);
-    expect(buttons[0].web_app.url).toBe(HTTPS_EMBED_URL);
+    expect(buttons[0].web_app.url).toBe(HTTPS_TELEGRAM_EMBED_URL);
     expect(buttons[0].text.length).toBeGreaterThan(0);
   });
 
@@ -99,7 +101,7 @@ describe("Telegram embedded-app launch button (#9947)", () => {
 
     const buttons = webAppButtons(lastKeyboard(sendMessage));
     expect(buttons).toHaveLength(1);
-    expect(buttons[0].web_app.url).toBe(HTTPS_EMBED_URL);
+    expect(buttons[0].web_app.url).toBe(HTTPS_TELEGRAM_EMBED_URL);
   });
 
   it("emits NO web_app button for a non-elevated sender", async () => {

--- a/plugins/plugin-telegram/src/messageManager.ts
+++ b/plugins/plugin-telegram/src/messageManager.ts
@@ -256,26 +256,31 @@ const EMBED_LAUNCH_BUTTON_TEXT = "Open Eliza App";
 function resolveEmbedLaunchUrl(runtime: IAgentRuntime): string | undefined {
   const direct = runtime.getSetting("ELIZA_EMBED_URL");
   if (typeof direct === "string" && direct.trim().length > 0) {
-    return toHttpsUrl(direct.trim());
+    return toHttpsUrl(direct.trim(), "telegram");
   }
   const base =
     runtime.getSetting("ELIZA_APP_URL") ||
     runtime.getSetting("ELIZA_CLOUD_URL");
   if (typeof base === "string" && base.trim().length > 0) {
-    return toHttpsUrl(`${base.trim().replace(/\/+$/, "")}/embed`);
+    return toHttpsUrl(`${base.trim().replace(/\/+$/, "")}/embed`, "telegram");
   }
   return undefined;
 }
 
 /** Return the URL only when it parses as absolute `https`, else `undefined`. */
-function toHttpsUrl(url: string): string | undefined {
+function toHttpsUrl(url: string, platform: "telegram"): string | undefined {
   let parsed: URL;
   try {
     parsed = new URL(url);
   } catch {
     return undefined;
   }
-  return parsed.protocol === "https:" ? parsed.toString() : undefined;
+  if (parsed.protocol !== "https:") return undefined;
+  if (parsed.pathname === "/" || parsed.pathname === "") {
+    parsed.pathname = "/embed";
+  }
+  parsed.searchParams.set("platform", platform);
+  return parsed.toString();
 }
 
 /** Build the Telegram `web_app` inline-keyboard button for the `/embed` route. */


### PR DESCRIPTION
## Summary

Refs #9947. Completes the embedded-app launch flow **end to end**. The server side already landed — the shared handshake, the Discord OAuth2 exchange (#10638), and embed-token acceptance in the auth boundary (#10643) — but nothing on the client ever ran the handshake. So the `/embed` route (whose per-platform `frame-ancestors` CSP was already wired) just rendered the normal app, which cannot authenticate inside a cross-origin Telegram/Discord iframe (the first-party Steward cookie doesn't cross origins).

This adds the client half.

## Changes (`packages/app`)

- **`src/embed-bootstrap.ts`** — `runEmbedHandshake()`:
  1. On the `/embed` route, read the platform's signed launch payload — Telegram `window.Telegram.WebApp.initData` (calling `ready()` first) or the Discord Activity OAuth2 `code` from the query string.
  2. POST it to the agent's `POST /api/embed/auth` (at `client.getBaseUrl()`), which verifies it server-side and mints the scoped session token.
  3. Install the token via **`client.setToken()`** — which propagates it to boot config + the `setElizaApiToken` window global — so every subsequent agent API call carries the bearer the auth boundary now accepts (#10643).
  - Dependency-injected (`window` / `fetch` / `client`), **fail-closed**, and never throws: off `/embed` it returns `{status:"not-embed"}` so `main()` can call it unconditionally; on any failure the app still mounts.
- **`src/main.tsx`** — `await runEmbedHandshake({ client })` at the top of `main()`, before `mountReactApp()`, so the token is set before the first authenticated call.

## Tests

`bun run --cwd packages/app test src/embed-bootstrap.test.ts` → **9 passed**. biome 2.5.1 clean on all three touched files.

Coverage: `isEmbedPath`; no-op off `/embed`; fail-closed on unknown platform / missing payload / HTTP 403 / no-token / network error (none install a token); and the telegram + discord success paths asserting the exact POST body and the `client.setToken()` install.

## Verification note + evidence

- The app-package typecheck surfaces **one pre-existing** wagmi `Config` type error in `@elizaos/ui/cloud/billing/wallet` (a shared-node_modules version artifact) — unrelated to this change; there are **zero** type errors in the files this PR touches.
- **Live Telegram Mini App / Discord Activity iframe walkthrough** — GATED, not attached: requires a real Mini App/Activity registration + a provisioned `ELIZA_EMBED_SESSION_SECRET` + `DISCORD_CLIENT_SECRET` + a real OWNER/ADMIN identity, none available in this env. The client logic is proven by the fail-closed + success unit matrix; the CSP + server handshake are covered by their own suites.
- **`audit:app` visual** — N/A for behavior: `/embed` reuses the existing app shell unchanged; this PR adds only a pre-mount auth handshake, no new rendered surface/pixels.

With #10638 + #10643 + this, #9947 is functionally complete end to end (server verify → token mint → token acceptance → client handshake). The remaining items are the Discord `/app` launch command and the ops-gated live evidence.
