### PR TITLE
fix(cloud): route OAuth by structured op (#10471)

### DIFF
--- a/.github/issue-evidence/10471-cloud-oauth-structured-op/README.md
+++ b/.github/issue-evidence/10471-cloud-oauth-structured-op/README.md
@@ -1,0 +1,43 @@
+# Issue #10471 - cloud OAuth structured op evidence
+
+## Change
+
+- Branch: `fix/10471-cloud-oauth-structured-op`
+- Removed `OAUTH` operation inference from raw `message.content.text`.
+- `OAUTH` now resolves the operation only from structured fields:
+  `op`, `subaction`, `operation`, `action`, or legacy structured action metadata
+  such as `OAUTH_CONNECT` / `OAUTH_REVOKE`.
+- Updated the action description, parameter contract, and examples so the
+  planner is told to provide structured `op` data instead of relying on prose.
+- Added regression coverage proving English prose alone no longer routes and
+  non-English text works when paired with structured params.
+
+## Validation
+
+- `focused-oauth-test.log`
+  - PASS: 4 tests, including raw English `disconnect google` / `did it work?`
+    rejection and structured non-English / legacy metadata acceptance.
+- `cloud-shared-typecheck.log`
+  - PASS: `bun run --cwd packages/cloud/shared typecheck`.
+- `cloud-shared-lint.log`
+  - PASS: `bun run --cwd packages/cloud/shared lint`.
+- `install.log`
+  - PASS: `bun install` after confirming the branch head matched
+    `origin/develop`.
+- `root-verify.log`
+  - PASS: `bun run verify` (`Tasks: 474 successful, 474 total`, audits and
+    dist-path checks passed).
+- `git-diff-check.log`
+  - PASS: staged branch diff whitespace check.
+- `cloud-shared-test.log`
+  - Attempted full package lane: OAuth tests passed within the run, but the
+    package exited nonzero on an unrelated existing `x402-app-earnings.test.ts`
+    module error: `Export named 'dbRead' not found in .../src/db/helpers.ts`.
+
+## Evidence Notes
+
+- Live model trajectory: N/A for this deterministic handler routing change; the
+  planner contract is structured `op` extraction, and the handler no longer
+  inspects prose for operation intent.
+- Screenshots / screen recording / audio: N/A. No UI, visual, or audio surface
+  changed.

--- a/.github/issue-evidence/10471-cloud-oauth-structured-op/cloud-shared-lint.log
+++ b/.github/issue-evidence/10471-cloud-oauth-structured-op/cloud-shared-lint.log
@@ -1,0 +1,2 @@
+$ bunx @biomejs/biome check .
+Checked 1239 files in 514ms. No fixes applied.

--- a/.github/issue-evidence/10471-cloud-oauth-structured-op/cloud-shared-test.log
+++ b/.github/issue-evidence/10471-cloud-oauth-structured-op/cloud-shared-test.log
@@ -1,0 +1,3425 @@
+bun test v1.3.14 (0d9b296a)
+
+scripts/check-tenant-scope.test.ts:
+(pass) findUnscopedTenantReads — combinator-wrapped pk-only reads (FLAG) > bare eq(table.id, id) — the original case [5.67ms]
+(pass) findUnscopedTenantReads — combinator-wrapped pk-only reads (FLAG) > and(eq(table.id, id)) — single-operand combinator wrapper [0.73ms]
+(pass) findUnscopedTenantReads — combinator-wrapped pk-only reads (FLAG) > or(eq(table.id, a), eq(table.id, b)) — all operands pk predicates [0.55ms]
+(pass) findUnscopedTenantReads — combinator-wrapped pk-only reads (FLAG) > inArray(table.id, ids) — bulk pk read [0.45ms]
+(pass) findUnscopedTenantReads — combinator-wrapped pk-only reads (FLAG) > and(inArray(table.id, ids)) — combinator-wrapped bulk pk read [0.51ms]
+(pass) findUnscopedTenantReads — combinator-wrapped pk-only reads (FLAG) > and(...conditions) where conditions = [eq(table.id, id)] — dynamic spread idiom [0.95ms]
+(pass) findUnscopedTenantReads — combinator-wrapped pk-only reads (FLAG) > the .where() builder form is caught too [0.42ms]
+(pass) findUnscopedTenantReads — properly ownership-scoped reads (NO FLAG) > and(eq(table.id, id), eq(table.organization_id, orgId)) — org-scoped [0.38ms]
+(pass) findUnscopedTenantReads — properly ownership-scoped reads (NO FLAG) > and(...conditions) carrying an ownership predicate is not flagged [0.38ms]
+(pass) findUnscopedTenantReads — properly ownership-scoped reads (NO FLAG) > a non-pk ownership-only read (no id predicate) is not flagged [0.50ms]
+(pass) findUnscopedTenantReads — properly ownership-scoped reads (NO FLAG) > a pk read against a NON-tenant table is not flagged [0.35ms]
+(pass) findUnscopedTenantReads — properly ownership-scoped reads (NO FLAG) > a /* global-scope */ annotation opts the method out [0.43ms]
+(pass) findUnscopedTenantReads — reporting > reports the table and method name for an unscoped read [0.31ms]
+
+src/lib/steward-url.test.ts:
+(pass) resolveBrowserStewardApiUrl > routes staging cloud host to the staging API worker [0.09ms]
+(pass) resolveBrowserStewardApiUrl > routes production cloud host to the production API worker
+(pass) resolveBrowserStewardApiUrl > falls back to same-origin steward mount for unknown hosts [0.03ms]
+
+src/lib/promotion-pricing.test.ts:
+(pass) formatCost > Free / sub-cent / dollar formatting [0.02ms]
+(pass) getPostCost / getPreviewCost > returns the per-platform + per-preview cost [0.03ms]
+(pass) estimateAssetGenerationCost > defaults to 1 image + banner + copy [0.03ms]
+(pass) estimateAssetGenerationCost > excludes banner and copy when disabled [0.01ms]
+
+src/lib/signup-grant-amount.test.ts:
+(pass) #8427 signup-grant amount agreement > both signup paths default to $5 (no give-away drift) [0.02ms]
+(pass) #8427 signup-grant amount agreement > steward getInitialCredits honors the INITIAL_FREE_CREDITS override [0.02ms]
+(pass) #8427 signup-grant amount agreement > steward getInitialCredits rejects a negative override and falls back to the default
+(pass) #8427 signup-grant amount agreement > steward getInitialCredits falls back to the default on a non-numeric override
+
+src/lib/pricing-reasoning-detection.test.ts:
+(pass) modelUsesReasoningTokens > treats openai/o1 as a reasoning model [0.11ms]
+(pass) modelUsesReasoningTokens > treats openai/o1-mini as a reasoning model
+(pass) modelUsesReasoningTokens > treats openai/o3 as a reasoning model
+(pass) modelUsesReasoningTokens > treats openai/o3-mini as a reasoning model
+(pass) modelUsesReasoningTokens > treats openai/o4-mini as a reasoning model
+(pass) modelUsesReasoningTokens > treats anthropic/claude-opus-4.8 as a reasoning model [0.02ms]
+(pass) modelUsesReasoningTokens > treats anthropic/claude-sonnet-4.5 as a reasoning model
+(pass) modelUsesReasoningTokens > treats deepseek/deepseek-r1 as a reasoning model
+(pass) modelUsesReasoningTokens > treats deepseek/deepseek-reasoner as a reasoning model
+(pass) modelUsesReasoningTokens > treats minimax/minimax-m3 as a reasoning model [0.01ms]
+(pass) modelUsesReasoningTokens > treats minimax/minimax-m1 as a reasoning model [0.02ms]
+(pass) modelUsesReasoningTokens > treats qwen/qwq-32b as a reasoning model
+(pass) modelUsesReasoningTokens > treats qwen/qwen3.7-max as a reasoning model [0.01ms]
+(pass) modelUsesReasoningTokens > treats allenai/olmo-3-32b-think as a reasoning model [0.01ms]
+(pass) modelUsesReasoningTokens > treats nvidia/nemotron-3-super-120b-a12b-reasoning as a reasoning model
+(pass) modelUsesReasoningTokens > treats z-ai/glm-4.6-thinking as a reasoning model
+(pass) modelUsesReasoningTokens > treats moonshotai/kimi-k2.6-think as a reasoning model
+(pass) modelUsesReasoningTokens > treats x-ai/grok-4-reasoning as a reasoning model
+(pass) modelUsesReasoningTokens > treats gpt-oss-120b as a reasoning model [0.01ms]
+(pass) modelUsesReasoningTokens > treats openai/gpt-oss-120b as a reasoning model
+(pass) modelUsesReasoningTokens > treats cerebras:gpt-oss-120b as a reasoning model
+(pass) modelUsesReasoningTokens > treats openai/gpt-oss-120b:nitro as a reasoning model
+(pass) modelUsesReasoningTokens > treats zai-glm-4.7 as a reasoning model
+(pass) modelUsesReasoningTokens > treats cerebras:zai-glm-4.7 as a reasoning model
+(pass) modelUsesReasoningTokens > treats openai/gpt-4o-mini as a non-reasoning model [0.01ms]
+(pass) modelUsesReasoningTokens > treats openai/gpt-4.1-mini as a non-reasoning model
+(pass) modelUsesReasoningTokens > treats anthropic/claude-3.5-haiku as a non-reasoning model
+(pass) modelUsesReasoningTokens > treats google/gemini-2.5-flash as a non-reasoning model
+(pass) modelUsesReasoningTokens > treats meta-llama/llama-3.3-70b-instruct as a non-reasoning model
+(pass) modelUsesReasoningTokens > treats mistralai/mistral-small-latest as a non-reasoning model
+(pass) modelUsesReasoningTokens > treats deepseek/deepseek-chat as a non-reasoning model
+(pass) modelUsesReasoningTokens > treats minimax/minimax-text-01 as a non-reasoning model
+(pass) modelUsesReasoningTokens > matches a bare (provider-less) model name [0.02ms]
+(pass) modelUsesReasoningTokens > catalog supported_parameters signal (authoritative) > moonshotai/kimi-k2.6 is NOT caught by name pattern alone [0.01ms]
+(pass) modelUsesReasoningTokens > catalog supported_parameters signal (authoritative) > z-ai/glm-5.1 is NOT caught by name pattern alone
+(pass) modelUsesReasoningTokens > catalog supported_parameters signal (authoritative) > deepseek/deepseek-v4-pro is NOT caught by name pattern alone
+(pass) modelUsesReasoningTokens > catalog supported_parameters signal (authoritative) > moonshotai/kimi-k2.6 IS caught when the catalog advertises reasoning [0.02ms]
+(pass) modelUsesReasoningTokens > catalog supported_parameters signal (authoritative) > z-ai/glm-5.1 IS caught when the catalog advertises reasoning
+(pass) modelUsesReasoningTokens > catalog supported_parameters signal (authoritative) > deepseek/deepseek-v4-pro IS caught when the catalog advertises reasoning
+(pass) modelUsesReasoningTokens > catalog supported_parameters signal (authoritative) > reasoning_effort alone is enough
+(pass) modelUsesReasoningTokens > catalog supported_parameters signal (authoritative) > a non-reasoning catalog model stays false
+(pass) modelUsesReasoningTokens > catalog supported_parameters signal (authoritative) > empty/undefined supported_parameters falls back to name pattern [0.01ms]
+(pass) modelUsesReasoningTokens > is case-insensitive
+(pass) modelUsesReasoningTokens > the narrow isReasoningModel (temperature gate) stays narrow [0.03ms]
+
+src/lib/steward-sync-grant.test.ts:
+(pass) syncUserFromSteward — initial-credits grant fallback > happy path: addCredits succeeds → no fallback update, no error logged [59.18ms]
+(pass) syncUserFromSteward — initial-credits grant fallback > ledger failure: rolls back the org and does not write an unledgered balance [0.64ms]
+
+src/lib/pricing.test.ts:
+(pass) getProviderFromModel / normalizeModelName > resolves provider from prefix, slash-form, and bare names [0.08ms]
+(pass) getProviderFromModel / normalizeModelName > normalizeModelName strips provider prefixes [0.02ms]
+(pass) reasoning detection > isReasoningModel is narrow (temperature-stripping only) [0.01ms]
+(pass) reasoning detection > modelUsesReasoningTokens trusts catalog params, then name patterns [0.06ms]
+(pass) getSafeModelParams > Anthropic strips frequency/presence penalties, keeps temperature for non-reasoning [0.03ms]
+(pass) getSafeModelParams > reasoning model drops temperature [0.01ms]
+(pass) getSafeModelParams > non-Anthropic strips topK
+(pass) estimateTokens > ~4 chars per token, rounded up [0.01ms]
+
+src/db/drop-app-billing-migration.test.ts:
+(pass) drop app_billing migration (#8923) > migration file exists and is registered in the journal [0.20ms]
+(pass) drop app_billing migration (#8923) > asserts zero rows before dropping, then drops idempotently [1.01ms]
+(pass) drop app_billing migration (#8923) > removed the schema file and its barrel export [0.08ms]
+(pass) drop app_billing migration (#8923) > removed the apps.billing relation and the appBilling import [0.05ms]
+
+src/db/retry-transient.test.ts:
+(pass) isTransientDbError > classifies connection-class SQLSTATEs as transient [0.05ms]
+(pass) isTransientDbError > classifies node socket error codes as transient [0.01ms]
+(pass) isTransientDbError > classifies connection-failure messages as transient [0.06ms]
+(pass) isTransientDbError > walks the cause chain [0.02ms]
+(pass) isTransientDbError > does NOT classify query/constraint errors as transient [0.02ms]
+(pass) retryOnTransientDbError > returns immediately on success without retrying [0.16ms]
+(pass) retryOnTransientDbError > retries transient errors and succeeds within the attempt budget [0.08ms]
+(pass) retryOnTransientDbError > does NOT retry non-transient errors [0.05ms]
+(pass) retryOnTransientDbError > rethrows the last error after exhausting attempts [0.05ms]
+
+src/db/inference-pending-charges-migration.test.ts:
+(pass) inference_pending_charges migration (#9899) > migration file exists and is registered in the journal [0.15ms]
+(pass) inference_pending_charges migration (#9899) > creates the table additively + idempotently with the exactly-once PK [0.29ms]
+(pass) inference_pending_charges migration (#9899) > carries the partial indexes the admission gate + sweep depend on [0.12ms]
+(pass) inference_pending_charges migration (#9899) > the schema source is exported from the barrel (Drizzle client + future gen) [0.05ms]
+(pass) inference_pending_charges migration applies to a real DB (#9899) > applies cleanly and creates the table, PK, and both partial indexes [11.70ms]
+(pass) inference_pending_charges migration applies to a real DB (#9899) > is idempotent — re-applying the same file is a no-op (no duplicate-object error) [2.53ms]
+
+src/billing/credit-markup.test.ts:
+(pass) calculateCreditMarkup > applies basic creator markup with no platform fee [0.08ms]
+(pass) calculateCreditMarkup > zero markup leaves base unchanged
+(pass) calculateCreditMarkup > zero base produces zero on every field [0.01ms]
+(pass) calculateCreditMarkup > affiliate flow: markup + platform fee both apply to base
+(pass) calculateCreditMarkup > handles fractional markup percentages without rounding [0.01ms]
+(pass) calculateCreditMarkup > preserves precision: does not round, callers format at the boundary
+(pass) calculateCreditMarkup > rejects negative or non-finite inputs [0.09ms]
+(pass) calculateCreditMarkup > applies creator markup above 100%, up to the validated ceiling [0.02ms]
+(pass) calculateCreditMarkup > rejects values above documented markup and platform fee bounds [0.02ms]
+(pass) calculateCreditMarkup > exposes the canonical platform fee rate
+
+src/billing/markup.test.ts:
+(pass) markup helpers > rounds marked-up USD costs at the billing boundary [0.08ms]
+(pass) markup helpers > supports explicit sub-cent USD precision [0.01ms]
+(pass) markup helpers > handles zero and rejects negative or non-finite costs [0.06ms]
+(pass) Twilio SMS billing > estimates segment count at a boundary [0.01ms]
+(pass) Twilio SMS billing > estimates segment count at a boundary
+(pass) Twilio SMS billing > estimates segment count at a boundary
+(pass) Twilio SMS billing > estimates segment count at a boundary
+(pass) Twilio SMS billing > estimates segment count at a boundary
+(pass) Twilio SMS billing > estimates segment count at a boundary
+(pass) Twilio SMS billing > calculates provider cost and markup from shared segment rules [0.02ms]
+(pass) Twilio SMS billing > resolves configured SMS segment cost with a shared fallback [0.04ms]
+(pass) Twilio SMS billing > rejects negative or non-finite SMS costs [0.02ms]
+
+src/lib/middleware/rate-limit-config-verdict.test.ts:
+(pass) rateLimitConfigVerdict > non-production is always ok (local/dev/staging may fall open) [0.04ms]
+(pass) rateLimitConfigVerdict > prod + limiting enabled + Redis reachable → ok
+(pass) rateLimitConfigVerdict > prod + REDIS_RATE_LIMITING=true but NO Redis → fail-closed (the deploy footgun)
+(pass) rateLimitConfigVerdict > prod + limiting not enabled → warn-disabled (falls open today; ops cutover pending) [0.02ms]
+
+src/lib/eliza/config.allowed-models.test.ts:
+(pass) isAllowedChatModel > accepts every id on the explicit allowlist [0.04ms]
+(pass) isAllowedChatModel > rejects an unlisted model [0.01ms]
+(pass) isAllowedChatModel > rejects empty / whitespace ids
+(pass) expandBitRouterModelIdCandidates (cross-spelling) > offers both the legacy and BitRouter spelling for xAI / Mistral [0.02ms]
+(pass) expandBitRouterModelIdCandidates (cross-spelling) > returns the id itself for providers with one spelling
+(pass) expandBitRouterModelIdCandidates (cross-spelling) > returns nothing for an empty id (no false candidate)
+
+src/lib/types/social-media.credits.test.ts:
+(pass) calculatePostCredits > a single default-multiplier platform costs the base 10 [0.05ms]
+(pass) calculatePostCredits > applies the per-platform multiplier (tiktok 2x, instagram/linkedin 1.5x) [0.01ms]
+(pass) calculatePostCredits > adds 5 credits per media attachment to the base before the multiplier [0.03ms]
+(pass) calculatePostCredits > ceil-rounds the per-platform subtotal
+(pass) calculatePostCredits > sums across multiple platforms
+(pass) calculatePostCredits > an empty platform list costs nothing
+
+src/lib/cache/cache-scan-pagination.test.ts:
+(pass) MemoryCacheAdapter.scan paginates (no dropped keys, opaque cursor) > walks all keys across pages and only signals done with '0' [0.81ms]
+(pass) CacheClient SCAN over the memory backend (end-to-end cursor threading) > scanByPrefix returns ALL keys across multiple pages (>100) [4.27ms]
+(pass) CacheClient SCAN over the memory backend (end-to-end cursor threading) > delPattern deletes ALL matching keys across pages [26.00ms]
+(pass) CacheClient.delPattern empty SCAN page guard > counts empty non-terminal pages and warns when the iteration cap is exhausted [22.74ms]
+
+src/lib/config/evm-rpc.test.ts:
+(pass) resolveEvmRpc > uses CRYPTO_DIRECT_<NET>_RPC_URL first [0.11ms]
+(pass) resolveEvmRpc > falls back to <NET>_RPC_URL [0.01ms]
+(pass) resolveEvmRpc > constructs Alchemy URL when key set and no explicit URL [0.01ms]
+(pass) resolveEvmRpc > constructs Infura URL when only Infura key set [0.01ms]
+(pass) resolveEvmRpc > returns chain's public default URL when nothing configured [0.03ms]
+(pass) resolveEvmRpc > BNB has no Alchemy/Infura mapping, falls through to public [0.01ms]
+(pass) resolveEvmRpc > listEvmPayoutNetworks returns all three EVM networks [0.01ms]
+
+src/lib/config/containers-env-disk.test.ts:
+(pass) nodeDiskPruneThresholdPct > defaults to 80 when unset [0.12ms]
+(pass) nodeDiskPruneThresholdPct > reads a valid override [0.05ms]
+(pass) nodeDiskPruneThresholdPct > clamps to [50, 99] [0.02ms]
+(pass) nodeDiskUnhealthyThresholdPct > defaults to 92 when unset [0.02ms]
+(pass) nodeDiskUnhealthyThresholdPct > stays strictly above the prune threshold even if configured lower [0.01ms]
+(pass) nodeDiskPruneCooldownMs > defaults to 30 minutes when unset [0.02ms]
+(pass) nodeDiskPruneCooldownMs > clamps to [60s, 6h] [0.02ms]
+
+src/lib/config/deployment-environment.test.ts:
+(pass) isProductionDeployment > uses ENVIRONMENT when it is set [0.03ms]
+(pass) isProductionDeployment > falls back to NODE_ENV when ENVIRONMENT is unset [0.01ms]
+(pass) shouldBlockRegistrarStub > blocks the stub when it is enabled in a production deployment [0.02ms]
+(pass) shouldBlockRegistrarStub > allows the stub outside production (dev / test / staging)
+(pass) shouldBlockRegistrarStub > does not block when the stub flag is off
+
+src/lib/config/redemption-security.test.ts:
+(pass) calculateEffectiveTokens > applies the safety spread so the user receives below par [0.02ms]
+(pass) threshold gates > isLargeRedemption trips at the configured threshold [0.01ms]
+(pass) threshold gates > requiresAdminApproval trips at the configured threshold [0.01ms]
+(pass) isPriceSane > accepts prices within [MIN, MAX], rejects outside [0.02ms]
+
+src/lib/config/payout-networks.test.ts:
+(pass) mainnet ↔ testnet mapping > every mainnet round-trips through its testnet equivalent [0.04ms]
+(pass) mainnet ↔ testnet mapping > known testnet labels map to the expected mainnet
+(pass) isValidNetwork / assertValidNetwork > accepts configured networks, rejects unknown strings [0.01ms]
+(pass) isValidNetwork / assertValidNetwork > assertValidNetwork throws on an unknown network [0.05ms]
+
+src/lib/config/feature-flags.test.ts:
+(pass) isFeatureEnabled env override > returns the compiled default when no env override is set [0.09ms]
+(pass) isFeatureEnabled env override > FEATURE_FLAGS_DISABLED force-disables a flag (kill switch) [0.04ms]
+(pass) isFeatureEnabled env override > disabled list accepts multiple comma/space separated flags [0.02ms]
+(pass) isFeatureEnabled env override > FEATURE_FLAGS_ENABLED force-enables a flag
+(pass) isFeatureEnabled env override > disable wins over enable when a flag is in both lists
+(pass) isFeatureEnabled env override > getEnabledFeatures and getDisabledFeatures honor the override [0.05ms]
+(pass) isFeatureEnabled env override > isRouteEnabled honors the override for a mapped route [0.06ms]
+
+src/lib/config/crypto.test.ts:
+(pass) validatePaymentAmount > enforces the min/max bounds [0.13ms]
+(pass) validateReceivedAmount > accepts exact and overpayment, rejects underpayment [0.04ms]
+(pass) networks > getSupportedNetworks + getNetworkConfig, throw on unknown [0.05ms]
+(pass) networks > calculateTolerance never exceeds the amount [0.09ms]
+(pass) webhook timestamps > extractWebhookTimestamp normalizes seconds to ms, prefers header [0.03ms]
+(pass) webhook timestamps > validateWebhookTimestamp rejects stale + future, allows now + undefined [0.06ms]
+
+src/lib/config/deployment-environment.gates.test.ts:
+(pass) shouldBlockUnsafeWebhookSkip > blocks only when SKIP_WEBHOOK_VERIFICATION=true AND production [0.03ms]
+(pass) shouldBlockUnsafeWebhookSkip > allows the skip outside production
+(pass) shouldBlockUnsafeWebhookSkip > does not block when the flag is unset or not exactly 'true'
+(pass) shouldBlockDevnetBypass > blocks only when DEVNET=true AND production [0.01ms]
+(pass) shouldBlockDevnetBypass > allows devnet outside production, when unset, or not exactly 'true'
+(pass) shouldBlockDevnetBypass > honors ENVIRONMENT over NODE_ENV (staging is not production)
+
+src/lib/security/safe-fetch.test.ts:
+(pass) createPinnedLookup > returns the pinned address for the legacy (address, family) callback [0.18ms]
+(pass) createPinnedLookup > returns the pinned address as an array when `all` is requested [0.02ms]
+(pass) createPinnedLookup > rejects a pin that re-checks as a private/reserved address (169.254.169.254) [0.05ms]
+(pass) createPinnedLookup > rejects a pin that re-checks as a private/reserved address (127.0.0.1)
+(pass) createPinnedLookup > rejects a pin that re-checks as a private/reserved address (10.0.0.5)
+(pass) createPinnedLookup > rejects a pin that re-checks as a private/reserved address (::1) [0.16ms]
+(pass) resolveSafeOutboundTarget (connection pin) > pins to the first validated resolved address [0.17ms]
+(pass) resolveSafeOutboundTarget (connection pin) > pins an IP-literal target without a DNS round-trip [0.03ms]
+(pass) resolveSafeOutboundTarget (connection pin) > rejects when a host resolves to any private/reserved address [0.07ms]
+(pass) resolveSafeOutboundTarget (connection pin) > rejects a rebinding redirect host that now resolves to link-local metadata [0.03ms]
+(pass) safeFetch fail-closed > never connects when the target host resolves to a private address [0.13ms]
+(pass) safeFetch fail-closed > rejects credential-bearing and non-http targets before any lookup [0.04ms]
+
+src/lib/security/outbound-url.test.ts:
+(pass) outbound URL SSRF validation > classifies 0.0.0.0 as forbidden [0.04ms]
+(pass) outbound URL SSRF validation > classifies 10.0.0.1 as forbidden
+(pass) outbound URL SSRF validation > classifies 100.64.0.1 as forbidden
+(pass) outbound URL SSRF validation > classifies 127.0.0.1 as forbidden
+(pass) outbound URL SSRF validation > classifies 169.254.169.254 as forbidden
+(pass) outbound URL SSRF validation > classifies 172.16.0.1 as forbidden
+(pass) outbound URL SSRF validation > classifies 192.0.2.1 as forbidden
+(pass) outbound URL SSRF validation > classifies 192.168.0.1 as forbidden
+(pass) outbound URL SSRF validation > classifies 198.18.0.1 as forbidden
+(pass) outbound URL SSRF validation > classifies 203.0.113.1 as forbidden
+(pass) outbound URL SSRF validation > classifies 224.0.0.1 as forbidden
+(pass) outbound URL SSRF validation > classifies 255.255.255.255 as forbidden
+(pass) outbound URL SSRF validation > classifies :: as forbidden [0.02ms]
+(pass) outbound URL SSRF validation > classifies ::1 as forbidden
+(pass) outbound URL SSRF validation > classifies fc00::1 as forbidden
+(pass) outbound URL SSRF validation > classifies fd00::1 as forbidden
+(pass) outbound URL SSRF validation > classifies fe80::1 as forbidden
+(pass) outbound URL SSRF validation > classifies 2001:db8::1 as forbidden
+(pass) outbound URL SSRF validation > classifies ::ffff:127.0.0.1 as forbidden
+(pass) outbound URL SSRF validation > classifies ::ffff:7f00:1 as forbidden
+(pass) outbound URL SSRF validation > classifies 0:0:0:0:0:ffff:a00:1 as forbidden [0.01ms]
+(pass) outbound URL SSRF validation > classifies ::169.254.169.254 as forbidden
+(pass) outbound URL SSRF validation > classifies ::127.0.0.1 as forbidden
+(pass) outbound URL SSRF validation > classifies ::10.0.0.1 as forbidden
+(pass) outbound URL SSRF validation > classifies ::a9fe:a9fe as forbidden
+(pass) outbound URL SSRF validation > classifies ::7f00:1 as forbidden
+(pass) outbound URL SSRF validation > classifies 8.8.8.8 as public
+(pass) outbound URL SSRF validation > classifies 1.1.1.1 as public
+(pass) outbound URL SSRF validation > classifies 2606:4700:4700::1111 as public
+(pass) outbound URL SSRF validation > rejects unsafe URL syntax or direct host ftp://example.com/file [0.10ms]
+(pass) outbound URL SSRF validation > rejects unsafe URL syntax or direct host https://user:pass@example.com/
+(pass) outbound URL SSRF validation > rejects unsafe URL syntax or direct host http://localhost:3000/
+(pass) outbound URL SSRF validation > rejects unsafe URL syntax or direct host http://service.localhost/
+(pass) outbound URL SSRF validation > rejects unsafe URL syntax or direct host http://127.0.0.1/ [0.01ms]
+(pass) outbound URL SSRF validation > rejects unsafe URL syntax or direct host http://[::1]/
+(pass) outbound URL SSRF validation > rejects unsafe URL syntax or direct host http://[::ffff:127.0.0.1]/ [0.02ms]
+(pass) outbound URL SSRF validation > rejects unsafe URL syntax or direct host http://[::ffff:7f00:1]/
+(pass) outbound URL SSRF validation > rejects unsafe URL syntax or direct host http://169.254.169.254/latest/meta-data/
+(pass) outbound URL SSRF validation > accepts public hostnames resolving only to public addresses [0.05ms]
+(pass) outbound URL SSRF validation > rejects hostnames resolving to any private or reserved address [0.03ms]
+(pass) outbound URL SSRF validation > rejects DNS failures and empty DNS answers [0.04ms]
+
+src/lib/security/redirect-validation.test.ts:
+(pass) relative redirect paths > isSafeRelativeRedirectPath rejects protocol-relative + absolute [0.03ms]
+(pass) relative redirect paths > sanitizeRelativeRedirectPath falls back on unsafe/empty [0.02ms]
+(pass) absolute redirect URLs > only allows http(s), credential-free, allowlisted origins [0.14ms]
+(pass) absolute redirect URLs > assertAllowedAbsoluteRedirectUrl returns URL or throws [0.05ms]
+
+src/lib/auth/siwe-test-login.test.ts:
+(pass) siweTestLogin > completes a real SIWE handshake and returns a usable session [11.81ms]
+(pass) siweTestLogin > signs in deterministically when a private key is supplied [2.56ms]
+(pass) siweTestLogin > throws (does not return a dead key) when the signature is rejected [1.48ms]
+(skip) siweTestLogin (live) > creates a real free cloud account and authorizes a request
+
+src/lib/auth/cron.test.ts:
+(pass) timingSafeEqualSecret > returns true only for an exact match [0.03ms]
+(pass) timingSafeEqualSecret > returns false for a same-length mismatch
+(pass) timingSafeEqualSecret > returns false on any length mismatch (no prefix match)
+(pass) timingSafeEqualSecret > handles unicode/byte-length differences
+
+src/lib/auth/playwright-test-session.test.ts:
+(pass) playwright test session auth > round trips enabled test session tokens [0.20ms]
+(pass) playwright test session auth > is disabled unless the explicit test-auth flag is true [0.05ms]
+(pass) playwright test session auth > rejects weak secrets [0.02ms]
+(pass) playwright test session auth > rejects tampered, multi-part, and malformed tokens [0.03ms]
+(pass) playwright test session auth > rejects expired tokens and non-string required claims [0.04ms]
+
+src/lib/constants/agent-pricing-display.test.ts:
+(pass) formatters > formatUSD / formatHourlyRate / formatMonthlyEstimate shapes [0.06ms]
+(pass) formatters > formatDuration renders days + hours [0.02ms]
+(pass) estimateHoursRemaining > null when nothing is burning credits [0.01ms]
+(pass) estimateHoursRemaining > more running agents drain a fixed balance no slower [0.02ms]
+(pass) packSavingsPercent > computes discount, clamps non-savings to 0 [0.02ms]
+
+src/lib/providers/provider-keys.test.ts:
+(pass) getProviderKeys (multi-key provider rotation) > returns empty when nothing configured [0.13ms]
+(pass) getProviderKeys (multi-key provider rotation) > returns the singular key when only it is set [0.03ms]
+(pass) getProviderKeys (multi-key provider rotation) > parses a comma/whitespace list from the plural env [0.06ms]
+(pass) getProviderKeys (multi-key provider rotation) > merges plural list + singular + numbered suffixes, de-duped, in order [0.03ms]
+(pass) getProviderKeys (multi-key provider rotation) > filters placeholder + empty values [0.02ms]
+(pass) getProviderKeys (multi-key provider rotation) > de-dupes identical keys across sources [0.01ms]
+
+src/lib/providers/_http.test.ts:
+(pass) providerFetchWithTimeout retry > retries a transient 429 then succeeds [2.83ms]
+(pass) providerFetchWithTimeout retry > a recovered request returns REAL usable content, not just a 200 [2.38ms]
+(pass) providerFetchWithTimeout retry > retries a transient 502 (empty-content upstream) then succeeds [1.19ms]
+(pass) providerFetchWithTimeout retry > does NOT retry a non-retryable 400 [0.05ms]
+(pass) providerFetchWithTimeout retry > exhausts the retry budget and throws the last transient error [2.34ms]
+(pass) providerFetchWithTimeout retry > maxRetries: 0 disables retry (streaming path) [0.06ms]
+(pass) providerFetchWithTimeout retry > respects Retry-After header for backoff (still succeeds) [1.20ms]
+(pass) providerFetchWithTimeout retry > does not retry when body is a one-shot ReadableStream [0.23ms]
+
+src/lib/providers/vast.test.ts:
+(pass) VastProvider > forwards eliza_prefill_plan field to worker [0.30ms]
+(pass) VastProvider > forwards eliza_guided_decode field to worker [0.10ms]
+(pass) VastProvider > forwards eliza_planner_action_schemas field to worker [0.07ms]
+(pass) VastProvider > forwards multiple eliza fields together [0.07ms]
+(pass) VastProvider > omits eliza fields when providerOptions is undefined [0.06ms]
+(pass) VastProvider > omits eliza fields when no eliza options are provided [0.05ms]
+(pass) VastProvider > preserves standard OpenAI fields [0.07ms]
+
+src/lib/providers/language-model-cerebras-fallback.test.ts:
+(pass) getLanguageModel cerebras-direct (cerebras-only, no OpenRouter fallback) > a bare Cerebras id serves directly via cerebras.ai on the happy path [5.34ms]
+(pass) getLanguageModel cerebras-direct (cerebras-only, no OpenRouter fallback) > a 429 surfaces (cerebras-only) and is never routed to OpenRouter [1.19ms]
+(pass) getLanguageModel cerebras-direct (cerebras-only, no OpenRouter fallback) > a 429 FAILS FAST under default retries (one cerebras call, no ~50s backoff loop) [0.22ms]
+(pass) getLanguageModel cerebras-direct (cerebras-only, no OpenRouter fallback) > a non-retryable error (400) also surfaces via cerebras only [0.19ms]
+(pass) getLanguageModel cerebras-direct (cerebras-only, no OpenRouter fallback) > happy-path billing attributes to cerebras [0.03ms]
+
+src/lib/providers/language-model-openrouter-primary.test.ts:
+(pass) OpenRouter-only deployment (BitRouter unset) > getLanguageModel serves a catalog model directly via openrouter.ai [4.14ms]
+(pass) OpenRouter-only deployment (BitRouter unset) > getLanguageModel serves a :nitro routing-suffix model via openrouter.ai [0.27ms]
+(pass) OpenRouter-only deployment (BitRouter unset) > resolveAiProviderSource bills OpenRouter-served models to the bitrouter price catalog [0.03ms]
+(pass) OpenRouter-only deployment (BitRouter unset) > hasLanguageModelProviderConfigured is true when only OpenRouter is configured [0.04ms]
+
+src/lib/providers/openrouter.test.ts:
+(pass) OpenRouterProvider request shape > defaults to the OpenRouter BYOK endpoint with bearer + attribution headers [0.39ms]
+(pass) OpenRouterProvider request shape > normalizes a custom base URL and appends /v1 [0.06ms]
+(pass) OpenRouterProvider request shape > translates legacy xai/ ids to the OpenRouter x-ai/ catalog form [0.06ms]
+(pass) OpenRouterProvider routing-suffix failover > retries the base model when :nitro returns a retryable 503 [0.13ms]
+(pass) OpenRouterProvider routing-suffix failover > does not retry on a non-retryable error (400) [0.07ms]
+(pass) OpenRouterProvider routing-suffix failover > fails fast on the :nitro priority path, then exhausts transport retry on the base model [2.41ms]
+(pass) OpenRouterProvider routing-suffix failover > a suffix-less model is retried transiently but never fails over to another model [2.38ms]
+
+src/lib/providers/language-model-openrouter-fallback.test.ts:
+(pass) getLanguageModel native → OpenRouter fallback (AI SDK path) > falls over to OpenRouter when the native provider returns a retryable 503 [3.97ms]
+(pass) getLanguageModel native → OpenRouter fallback (AI SDK path) > does not fall over on a non-retryable error (400) [0.75ms]
+
+src/lib/providers/vercel-ai-gateway-tools.test.ts:
+(pass) toGatewayTools — tolerates flat ToolDefinition shape > does not throw on the exact flat shape that 500'd in prod [0.07ms]
+(pass) toGatewayTools — tolerates flat ToolDefinition shape > keys the gateway tool map by the flat tool name [0.02ms]
+(pass) toGatewayTools — tolerates flat ToolDefinition shape > still handles the nested OpenAI shape [0.01ms]
+(pass) toGatewayTools — tolerates flat ToolDefinition shape > drops nameless tools instead of throwing [0.01ms]
+(pass) normalizeToolFunction > reads name/parameters from the flat shape [0.01ms]
+(pass) normalizeToolFunction > reads name/parameters from the nested shape [0.01ms]
+(pass) normalizeToolFunction > returns undefined name for a nameless / non-object input
+
+src/lib/providers/provider-fallback-selection.test.ts:
+(pass) getProviderForModelWithFallback (native-first, OpenRouter backup) > openai/* → OpenAI direct primary, OpenRouter backup [0.21ms]
+(pass) getProviderForModelWithFallback (native-first, OpenRouter backup) > anthropic/* → Anthropic direct primary, OpenRouter backup [0.05ms]
+(pass) getProviderForModelWithFallback (native-first, OpenRouter backup) > Cerebras paid/default ids → Cerebras direct primary with no OpenRouter fallback [0.04ms]
+(pass) getProviderForModelWithFallback (native-first, OpenRouter backup) > Cerebras free ids stay on the gateway path, not OpenAI direct [0.01ms]
+(pass) getProviderForModelWithFallback (native-first, OpenRouter backup) > Cerebras ids fall back to OpenRouter when the Cerebras key is absent [0.02ms]
+(pass) getProviderForModelWithFallback (native-first, OpenRouter backup) > models with no native key (x-ai/*, google/*) → OpenRouter direct, no further fallback [0.03ms]
+
+src/lib/providers/model-id-translation.test.ts:
+(pass) stripOpenRouterRoutingSuffix > strips :nitro from a provider-prefixed model id [0.01ms]
+(pass) stripOpenRouterRoutingSuffix > strips :floor from a provider-prefixed model id
+(pass) stripOpenRouterRoutingSuffix > strips :nitro from a dashed bare model id
+(pass) stripOpenRouterRoutingSuffix > does not strip :free (distinct free-tier variant)
+(pass) stripOpenRouterRoutingSuffix > does not strip :online (changes behavior)
+(pass) stripOpenRouterRoutingSuffix > returns null when there is no routing suffix
+(pass) stripOpenRouterRoutingSuffix > does not mistake a forced-provider prefix for a suffix
+(pass) stripOpenRouterRoutingSuffix > strips only the trailing routing suffix, keeping a forced-provider prefix
+(pass) stripOpenRouterRoutingSuffix > returns null for an opaque provider:nitro with no model id shape
+(pass) stripOpenRouterRoutingSuffix > returns null for empty input
+
+src/lib/utils/agent-username.test.ts:
+(pass) validateUsername > rejects bad length / charset / hyphen placement [0.09ms]
+(pass) validateUsername > rejects reserved names, accepts + normalizes valid ones [0.02ms]
+(pass) slugify > produces URL-safe slugs [0.05ms]
+(pass) generateUsernameFromName > slugs and truncates to the max length [0.03ms]
+(pass) generateUniqueUsername > appends an incrementing suffix on collision [0.03ms]
+(pass) extractUsernameFromPath > extracts the @handle, else null [0.05ms]
+
+src/lib/utils/cors.test.ts:
+(pass) getCorsHeaders > reflects first-party app origins for credentialed auth routes [0.04ms]
+(pass) getCorsHeaders > reflects local dev origins with ports [0.02ms]
+(pass) getCorsHeaders > reflects native app scheme origins
+(pass) getCorsHeaders > reflects the exact develop Pages staging alias only [0.03ms]
+(pass) getCorsHeaders > does not reflect untrusted origins
+
+src/lib/utils/invite-tokens.test.ts:
+(pass) invite tokens > generateInviteToken returns a unique 64-char hex string [0.06ms]
+(pass) invite tokens > hashInviteToken is a deterministic SHA-256 hex (known-answer) [0.07ms]
+(pass) invite tokens > distinct tokens hash differently
+(pass) invite tokens > verifyInviteToken accepts the exact pair and rejects mismatches [0.02ms]
+
+src/lib/utils/whatsapp-api.test.ts:
+(pass) verifyWhatsAppSignature > accepts a genuine Meta signature [0.10ms]
+(pass) verifyWhatsAppSignature > rejects tampered body, wrong secret, and malformed headers [0.03ms]
+(pass) WhatsApp id ↔ E.164 > round-trips digits, stripping/adding the + and any separators [0.04ms]
+(pass) WhatsApp id ↔ E.164 > isValidWhatsAppId requires 7-15 digits, no symbols [0.02ms]
+
+src/lib/utils/telegram-helpers.test.ts:
+(pass) escapeMarkdownV2 / convertToTelegramMarkdown > escapes every reserved MarkdownV2 char [0.04ms]
+(pass) escapeMarkdownV2 / convertToTelegramMarkdown > converts **bold** / _italic_ / `code` back to Telegram syntax [0.04ms]
+(pass) splitMessage > returns one chunk under the cap, splits oversize lines [0.08ms]
+(pass) parseBotToken > valid token yields the bot id; malformed is rejected [0.02ms]
+(pass) maskChatId > redacts the middle of long ids, leaves short ones [0.03ms]
+(pass) message + command parsing > extractMessageText prefers text then caption [0.01ms]
+(pass) message + command parsing > isCommand + parseCommand strip @botname and split args [0.04ms]
+
+src/lib/utils/google-mcp-shared.test.ts:
+(pass) sanitizeHeaderValue > removes CR and LF (header-injection defense) [0.04ms]
+(pass) errMsg > uses an Error's message, else the fallback [0.02ms]
+(pass) extractBody > decodes a direct base64 body [0.10ms]
+(pass) extractBody > prefers text/plain among MIME parts [0.02ms]
+(pass) extractBody > returns empty string when no body is present
+(pass) mappers > mapGmailMessage flattens headers + converts internalDate [0.05ms]
+(pass) mappers > mapCalendarEvent prefers dateTime, falls back to date [0.02ms]
+(pass) mappers > mapContact picks the first name/email/phone and unwraps person [0.03ms]
+
+src/lib/utils/with-timeout.test.ts:
+(pass) withTimeout > resolves with the value when the promise settles before the deadline [0.08ms]
+(pass) withTimeout > rejects with a labelled timeout error when the deadline elapses [11.03ms]
+(pass) withTimeout > propagates the underlying rejection when it loses to the race [0.07ms]
+
+src/lib/utils/app-url.test.ts:
+(pass) getAppUrl > defaults to localhost when unset / empty / non-string [0.05ms]
+(pass) getAppUrl > uses a configured absolute URL and strips the trailing slash [0.01ms]
+(pass) getAppUrl > prepends https:// when the configured value has no scheme
+(pass) getAppHost > returns the host (with port) of the resolved app URL [0.03ms]
+
+src/lib/utils/discord-helpers.test.ts:
+(pass) splitMessage > returns chunks all within the limit, losing no content words [0.20ms]
+(pass) escapeMarkdown > backslash-escapes Discord formatting metacharacters [0.03ms]
+(pass) isValidSnowflake / maskId > validates 17-19 digit ids and masks for logs [0.03ms]
+(pass) channel + text helpers > channel type naming, text-channel check, mentions, truncate [0.05ms]
+
+src/lib/utils/settle-off-response-path.test.ts:
+(pass) settleOffResponsePath (#8759 defer-billing) > defers via waitUntil and resolves BEFORE the task settles [0.10ms]
+(pass) settleOffResponsePath (#8759 defer-billing) > runs the task INLINE (awaited) when there is no executionCtx [0.04ms]
+(pass) settleOffResponsePath (#8759 defer-billing) > runs inline when executionCtx has no waitUntil function [0.02ms]
+(pass) settleOffResponsePath (#8759 defer-billing) > inline mode propagates a task rejection to the caller [0.04ms]
+(pass) settleOffResponsePath (#8759 defer-billing) > deferred mode hands the (possibly rejecting) task promise to waitUntil, not the response path [0.05ms]
+
+src/lib/utils/credit-reservation.test.ts:
+(pass) createCreditReservationSettler > returns null immediately when no reservation is provided [0.07ms]
+(pass) createCreditReservationSettler > calls reconcile once and returns the result [0.04ms]
+(pass) createCreditReservationSettler > once-guard: second call returns cached result without re-running reconcile [0.04ms]
+(pass) createCreditReservationSettler > concurrent calls both return the same result with only one reconcile run [10.70ms]
+(pass) createCreditReservationSettler > allows retry after reconcile throws [0.14ms]
+(pass) createCreditReservationSettler > settle(0) releases without re-billing once a real cost is settled (onFinish-then-abort) [0.07ms]
+(pass) createCreditReservationSettler > abort-then-finish: first settlement wins, second is a no-op [0.04ms]
+(pass) createCreditReservationSettler > settle(0) on a no-op (anonymous) reservation releases without billing [0.04ms]
+
+src/lib/utils/phone-normalization.test.ts:
+(pass) isValidE164 / isValidEmail > E.164 requires a leading + and digits, no separators [0.03ms]
+(pass) isValidE164 / isValidEmail > email check accepts addr@host.tld, rejects malformed [0.02ms]
+(pass) normalizeToE164 > passes through valid +E.164 and infers +1 for NANP digits [0.03ms]
+(pass) normalizePhoneNumber > emails normalize to lowercase, phones to E.164 [1.07ms]
+
+src/lib/models/catalog.test.ts:
+(pass) #8426 text catalog recommendation invariants > the two healthy Cerebras defaults are recommended [0.04ms]
+(pass) #8426 text catalog recommendation invariants > the flaky :nitro gateway model is reachable but NOT recommended [0.02ms]
+(pass) #8426 text catalog recommendation invariants > annotateCatalogModel never re-badges :nitro as recommended [0.02ms]
+(pass) #8426 text catalog recommendation invariants > annotateCatalogModel DOES badge the Cerebras default ids by id alone [0.01ms]
+(pass) #8426 text catalog recommendation invariants > the selector list ranks the two Cerebras defaults first (no :nitro at the top) [0.02ms]
+
+src/lib/models/model-tiers.test.ts:
+(pass) #8426 model-tier PRO default > pro resolves to the Cerebras default and is flagged recommended [0.01ms]
+(pass) #8426 model-tier PRO default > resolveModel keeps Cerebras-native bare ids on Cerebras for billing [0.14ms]
+(pass) #8426 model-tier PRO default > no model tier defaults onto a :nitro gateway id [0.03ms]
+
+src/lib/cors/cloud-api-hono-cors.test.ts:
+(pass) isFirstPartyOrigin > recognizes the production SPA + localhost, rejects third-party [0.07ms]
+(pass) isFirstPartyOrigin — Eliza app WebView origins > recognizes the Capacitor/Electrobun app WebView origins [0.02ms]
+(pass) isPublicTokenApiPath > recognizes explicit public token API paths [0.03ms]
+(pass) corsMiddleware — first-party origins (credentialed) > reflects the origin and allows credentials [1.62ms]
+(pass) corsMiddleware — Eliza app WebView origin (credentialed SSE) > reflects https://localhost + allows credentials (not wildcard) [0.14ms]
+(pass) corsMiddleware — Eliza app WebView origin (credentialed SSE) > reflects capacitor://localhost + allows credentials [0.11ms]
+(pass) corsMiddleware — Eliza app WebView origin (credentialed SSE) > preflight names X-ElizaOS-Client-Id (+ UI-Language) in allow-headers [0.18ms]
+(pass) corsMiddleware — third-party app origins (open, NO credentials) > allows the origin (wildcard) WITHOUT credentials so the browser permits it [0.15ms]
+(pass) corsMiddleware — third-party app origins (open, NO credentials) > preflight (OPTIONS) returns wildcard origin + methods + headers [0.15ms]
+(pass) corsMiddleware — third-party app origins (open, NO credentials) > any third-party origin is allowed (open API) [0.14ms]
+(pass) corsMiddleware — third-party app origins (open, NO credentials) > does not allow wildcard CORS on session-capable non-public paths [0.09ms]
+(pass) corsMiddleware — no Origin (non-browser caller) > still sets Access-Control-Allow-Origin so c.res is touched (invariant) [0.10ms]
+(pass) corsMiddleware + secureHeaders chain on a raw Response.json passthrough > no-Origin (Bearer) request to a raw-Response route returns 200, not an immutable-headers 500 [0.24ms]
+(pass) corsMiddleware + secureHeaders chain on a raw Response.json passthrough > the same raw-Response route still works for a first-party Origin [0.10ms]
+
+src/lib/api/errors.test.ts:
+(pass) getErrorStatusCode > maps by error name [0.07ms]
+(pass) getErrorStatusCode > maps by message phrase, defaults to 500 [0.03ms]
+(pass) getSafeErrorMessage > redacts backend/DB internals [0.06ms]
+(pass) getSafeErrorMessage > passes safe client-error messages through [0.03ms]
+
+src/lib/api/compat-envelope.test.ts:
+(pass) toCompatStatus > includes service status aliases and wallet account metadata [0.29ms]
+
+src/lib/api/cloud-worker-errors.test.ts:
+(pass) failureResponse infrastructure-error sanitization > never leaks raw SQL from a Drizzle/postgres query failure [0.20ms]
+(pass) failureResponse infrastructure-error sanitization > forces 500 for postgres SQLSTATE-coded errors [0.04ms]
+(pass) failureResponse infrastructure-error sanitization > still surfaces genuine 4xx domain messages [0.03ms]
+
+src/lib/api/mobile-client.test.ts:
+(pass) MobileApiClient > preserves canonical API error codes from JSON error responses [0.28ms]
+(pass) MobileApiClient > uses text response bodies as non-JSON error messages [0.05ms]
+(pass) MobileApiClient > encodes query params and omits only undefined values [0.11ms]
+(pass) MobileApiClient > removes manual content-type for FormData bodies [0.05ms]
+(pass) MobileApiClient > authenticated client adds bearer token without dropping caller headers [0.06ms]
+
+src/lib/export/analytics.test.ts:
+(pass) generateCSV — formula-injection guard > prefixes dangerous leading chars with an apostrophe [0.12ms]
+(pass) generateCSV — formula-injection guard > RFC-4180 quotes values containing commas or quotes [0.04ms]
+(pass) generateCSV — formula-injection guard > null/undefined cells render as empty strings [0.01ms]
+(pass) generateJSON > wraps data under a data key; metadata only when requested [0.05ms]
+(pass) formatters degrade safely > formatCurrency converts cents and tolerates junk [0.02ms]
+(pass) formatters degrade safely > formatNumber adds K/M suffixes [0.02ms]
+(pass) formatters degrade safely > formatPercentage scales 0..1 to a percent [0.02ms]
+(pass) formatters degrade safely > formatDate emits ISO for Date/string, empty for junk [0.02ms]
+
+src/lib/client/api-keys.test.ts:
+(pass) getClientApiKeySecret > does not fetch old full keys from the API key list [0.09ms]
+
+src/lib/services/orphan-shared-bridge-reaper.test.ts:
+(pass) selectOrphanedSharedBridges (pure orphan rule) > reaps a stale shared bridge superseded by a live dedicated twin [0.08ms]
+(pass) selectOrphanedSharedBridges (pure orphan rule) > does NOT reap a shared bridge with NO dedicated twin (deliberate long-lived shared agent)
+(pass) selectOrphanedSharedBridges (pure orphan rule) > does NOT reap an in-flight handoff (younger than the floor) [0.01ms]
+(pass) selectOrphanedSharedBridges (pure orphan rule) > does NOT reap when the twin was created BEFORE the bridge (a different pre-existing agent) [0.01ms]
+(pass) selectOrphanedSharedBridges (pure orphan rule) > does NOT reap when the only twin has a different agent_name / user / org [0.02ms]
+(pass) selectOrphanedSharedBridges (pure orphan rule) > does NOT reap an unnamed bridge even with a matching-null twin (uncorrelatable)
+(pass) reapOrphanedSharedBridges (orchestration) > reaps only the orphans, via deleteAgent, and reports counts [0.25ms]
+[orphan-shared-reaper] failed to reap shared bridge {
+  agentId: "a",
+  organizationId: "org-1",
+  error: "node unreachable",
+}
+(pass) reapOrphanedSharedBridges (orchestration) > a delete failure is counted, not thrown, and does not abort the batch [0.14ms]
+(pass) reapOrphanedSharedBridges (orchestration) > no candidates → no twin lookup, no deletes [0.03ms]
+(pass) reapOrphanedSharedBridges (orchestration) > caps `max` at 50 even when a larger value is requested [0.03ms]
+
+src/lib/services/provisioning-worker-health-monitor.test.ts:
+(pass) isHeartbeatStale > treats a fresh heartbeat as not stale [0.03ms]
+(pass) isHeartbeatStale > treats a heartbeat older than the max age as stale [0.02ms]
+(pass) isHeartbeatStale > treats an absent heartbeat as stale
+(pass) isHeartbeatStale > treats an unparseable heartbeat as stale
+(pass) isHeartbeatStale > does not flag a heartbeat exactly at the max age
+(pass) monitorProvisioningWorkerHealth > is healthy and silent when the daemon is not required [6.11ms]
+(pass) monitorProvisioningWorkerHealth > is healthy and silent on a fresh heartbeat [0.10ms]
+(pass) monitorProvisioningWorkerHealth > is unhealthy and alerts when the heartbeat is absent (gate failed closed) [0.07ms]
+(pass) monitorProvisioningWorkerHealth > is unhealthy and alerts when a present heartbeat is stale [0.05ms]
+
+src/lib/services/eliza-sandbox.test.ts:
+(pass) resolveSandboxContainerLaunchConfig > maps stored waifu container hints to sandbox provider launch config [0.07ms]
+(pass) resolveSandboxContainerLaunchConfig > ignores invalid or absent container hints [0.02ms]
+(pass) ElizaSandboxService bridge status > reports web-only custom agents as running through the router origin in Workers [31.87ms]
+(pass) ElizaSandboxService shared runtime bridge > does not persist degraded shared-runtime turns [0.75ms]
+(pass) ElizaSandboxService wake > skips missing state restore endpoint for web-only custom images [1.37ms]
+(pass) ElizaSandboxService snapshot — endpoint capability > a 404 from /api/snapshot (V2 image) returns the unsupported sentinel, not a hard failure [0.21ms]
+(pass) ElizaSandboxService recoverDisconnected > recovers a reachable disconnected agent via guarded compare-and-set [0.18ms]
+(pass) ElizaSandboxService recoverDisconnected > does NOT revive when the row left disconnected mid-probe (CAS loses -> gone) [0.09ms]
+(pass) ElizaSandboxService recoverDisconnected > reports unreachable without writing when the bridge does not answer [4007.09ms]
+(pass) ElizaSandboxService recoverDisconnected > reports gone (and never probes) when the row is no longer disconnected [0.23ms]
+[agent-sandbox] Heartbeat miss within grace window, keeping running {
+  agentId: "e06bb509-6c52-4c33-a9f7-66addc43e8c8",
+  downForMs: 34005,
+}
+(pass) ElizaSandboxService heartbeat > probe miss inside the grace window keeps the agent running with no DB write [4005.66ms]
+[agent-sandbox] Heartbeat failed past grace window, marking disconnected {
+  agentId: "e06bb509-6c52-4c33-a9f7-66addc43e8c8",
+  downForMs: 204002,
+}
+(pass) ElizaSandboxService heartbeat > probe miss past the grace window marks disconnected without bumping heartbeat [4002.34ms]
+(pass) ElizaSandboxService heartbeat > probe that succeeds on a retry bumps last_heartbeat_at and leaves status alone [2001.08ms]
+(pass) ElizaSandboxService.executeResume > an already-running agent is a no-op — never re-provisioned [0.23ms]
+(pass) ElizaSandboxService.executeResume > a stopped agent is resumed by delegating to provision() [0.08ms]
+(pass) ElizaSandboxService.executeResume > an unknown agent returns not-found without provisioning [0.06ms]
+(pass) ElizaSandboxService.executeResume > a provision failure during resume is surfaced, not swallowed [0.05ms]
+(pass) ElizaSandboxService deletion-state guards (resume/wake/restart) > executeResume bails on deletion_pending (not-found, no provision) [0.05ms]
+(pass) ElizaSandboxService deletion-state guards (resume/wake/restart) > executeWake bails on deletion_pending (not-found, no provision) [0.04ms]
+(pass) ElizaSandboxService deletion-state guards (resume/wake/restart) > executeRestart bails on deletion_pending before shutdown/provision [0.10ms]
+(pass) ElizaSandboxService deletion-state guards (resume/wake/restart) > executeResume bails on deletion_failed (not-found, no provision) [0.01ms]
+(pass) ElizaSandboxService deletion-state guards (resume/wake/restart) > executeWake bails on deletion_failed (not-found, no provision)
+(pass) ElizaSandboxService deletion-state guards (resume/wake/restart) > executeRestart bails on deletion_failed before shutdown/provision
+(pass) ElizaSandboxService.deleteAgent teardown cap (#9066) > (a) teardown timeout → delete still proceeds (row deleted) + leak warning, no phantom 'handled' [0.28ms]
+(pass) ElizaSandboxService.deleteAgent teardown cap (#9066) > (b) a real stop failure on a reachable node → delete aborts (failure), row never deleted [0.08ms]
+(pass) ElizaSandboxService.deleteAgent teardown cap (#9066) > (c) an ignorable 'already gone' failure → info + delete proceeds (row deleted) [0.10ms]
+(pass) ElizaSandboxService.deleteAgent teardown cap (#9066) > the bounded teardown runs OUTSIDE the row-delete phase (sequenced, not nested) [0.09ms]
+(pass) ElizaSandboxService.deleteAgent teardown cap (#9066) > runBoundedSandboxStop returns null on a clean provider stop [0.12ms]
+(pass) ElizaSandboxService.deleteAgent teardown cap (#9066) > runBoundedSandboxStop captures a provider error as a value (not a timeout) [0.07ms]
+(pass) ElizaSandboxService.deleteAgent teardown cap (#9066) > runBoundedSandboxStop cuts off a never-settling provider stop with { error, timedOut } [0.10ms]
+(pass) computeManagedAgentDbEnv (#8696 local agent state) > local-state agent gets ELIZA_MANAGED_DATABASE_URL and NO DATABASE_URL [0.03ms]
+(pass) computeManagedAgentDbEnv (#8696 local agent state) > existing agent (no flag) keeps the shared DATABASE_URL injection [0.02ms]
+(pass) computeManagedAgentDbEnv (#8696 local agent state) > caller-supplied DATABASE_URL is preserved; managed exposed separately [0.03ms]
+(pass) computeManagedAgentDbEnv (#8696 local agent state) > create() merge: a caller DATABASE_URL survives while the shared DB rides ELIZA_MANAGED_DATABASE_URL [0.03ms]
+(pass) computeManagedAgentDbEnv (#8696 local agent state) > create() merge: a local-state agent ends with NO DATABASE_URL and the shared DB on the managed key [0.03ms]
+(pass) buildRuntimeBootstrapAgent persona seed > seeds a name-aware identity when agent_config has no system/bio [0.15ms]
+(pass) buildRuntimeBootstrapAgent persona seed > preserves a real persona supplied in agent_config [0.04ms]
+(pass) ElizaSandboxService.provision dedup + port-collision retry (LARP H2) > (1) lock lost but row already running+reachable → reuse, provider.create NEVER called [0.08ms]
+(pass) ElizaSandboxService.provision dedup + port-collision retry (LARP H2) > (2) lock lost AND not running → 'Agent is already being provisioned', no create [0.08ms]
+[agent-sandbox] Post-create failure, cleaning up container {
+  agentId: "e06bb509-6c52-4c33-a9f7-66addc43e8c8",
+  sandboxId: "sandbox-blue-1",
+  attempt: 1,
+  error: "duplicate key value violates unique constraint \"23505\"",
+}
+(pass) ElizaSandboxService.provision dedup + port-collision retry (LARP H2) > (3) UNIQUE (port TOCTOU) on attempt 1 → ghost stop + retry → attempt 2 succeeds [0.32ms]
+[agent-sandbox] Post-create failure, cleaning up container {
+  agentId: "e06bb509-6c52-4c33-a9f7-66addc43e8c8",
+  sandboxId: "sandbox-blue-1",
+  attempt: 1,
+  error: "connection terminated unexpectedly",
+}
+(pass) ElizaSandboxService.provision dedup + port-collision retry (LARP H2) > (4) a NON-unique post-create error → markError, NO retry (one create), failure [0.19ms]
+[agent-sandbox] Post-create failure, cleaning up container {
+  agentId: "e06bb509-6c52-4c33-a9f7-66addc43e8c8",
+  sandboxId: "sandbox-blue-1",
+  attempt: 1,
+  error: "duplicate key value violates unique constraint (port collision)",
+}
+[agent-sandbox] Post-create failure, cleaning up container {
+  agentId: "e06bb509-6c52-4c33-a9f7-66addc43e8c8",
+  sandboxId: "sandbox-blue-1",
+  attempt: 2,
+  error: "duplicate key value violates unique constraint (port collision)",
+}
+[agent-sandbox] Post-create failure, cleaning up container {
+  agentId: "e06bb509-6c52-4c33-a9f7-66addc43e8c8",
+  sandboxId: "sandbox-blue-1",
+  attempt: 3,
+  error: "duplicate key value violates unique constraint (port collision)",
+}
+(pass) ElizaSandboxService.provision dedup + port-collision retry (LARP H2) > (5) UNIQUE on every attempt → exhaustion → 'Provisioning failed after 3 attempts' [0.23ms]
+(pass) ElizaSandboxService.provision dedup + port-collision retry (LARP H2) > (6) a successful provision re-enters the billable set [0.15ms]
+(pass) ElizaSandboxService.provision dedup + port-collision retry (LARP H2) > (7) a provision that never reaches running does NOT re-enter billing [0.06ms]
+(pass) ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LARP H3) > (a) blue health-check FAILS → blue torn down, row stays on OLD, rolled-back error [50.05ms]
+(pass) ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LARP H3) > (b) blue digest MISMATCH → blue torn down, NO swap [0.15ms]
+(pass) ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LARP H3) > (b2) blue runtime readiness gate FAILS → blue torn down, NO snapshot or swap [0.33ms]
+(pass) ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LARP H3) > (c) happy path → atomic swap writes blue's node/container/bridge + image_digest=toDigest [0.56ms]
+(pass) ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LARP H3) > (c2) pre-upgrade snapshot failure → blue torn down, NO swap [0.21ms]
+[agent-sandbox] Atomic swap UPDATE failed; tearing down orphaned blue {
+  agentId: "e06bb509-6c52-4c33-a9f7-66addc43e8c8",
+  err: "Agent changed during upgrade; abandoned stale swap",
+}
+(pass) ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LARP H3) > (d) CAS guard: row moved under us → returns false → throws 'changed during upgrade', tears down orphaned blue [0.31ms]
+(pass) ElizaSandboxService.executeDowngrade rollback onto previous_image_digest (#9964) > no previous_image_digest → refuses, never touches the live agent [0.41ms]
+(pass) ElizaSandboxService.executeDowngrade rollback onto previous_image_digest (#9964) > happy path → restores pre-upgrade snapshot then swaps back onto PREV_DIGEST + clears prior columns [0.33ms]
+
+src/lib/services/docker-node-workloads.test.ts:
+(pass) agentIdFromContainerName > extracts the id from an agent-<id> name [0.03ms]
+(pass) agentIdFromContainerName > returns null for names without the agent- prefix [0.01ms]
+(pass) agentIdFromContainerName > returns null for a bare prefix with no id
+(pass) computeOrphanContainersToReap (agent diff) > reaps a container whose agent id has NO db row [0.07ms]
+(pass) computeOrphanContainersToReap (agent diff) > reaps a container whose db row is in a terminal state [0.03ms]
+(pass) computeOrphanContainersToReap (agent diff) > treats error / sleeping / deletion_failed rows as terminal [0.03ms]
+(pass) computeOrphanContainersToReap (agent diff) > does NOT reap a container with a live (running) db row [0.01ms]
+(pass) computeOrphanContainersToReap (agent diff) > does NOT reap a row in deletion_pending (delete job owns teardown) [0.01ms]
+(pass) computeOrphanContainersToReap (agent diff) > does NOT reap provisioning / pending / disconnected rows [0.03ms]
+(pass) computeOrphanContainersToReap (agent diff) > ignores containers that do not match the agent- pattern
+(pass) computeOrphanContainersToReap (agent diff) > mixed fleet: reaps only the orphans, leaves live + non-agent alone [0.03ms]
+(pass) reconcileOrphanContainers (agent orchestration) > force-removes every orphan on a healthy node [0.31ms]
+[orphan-reconciler] Skipping node: container listing failed {
+  nodeId: "node-1",
+  hostname: "host-1",
+}
+(pass) reconcileOrphanContainers (agent orchestration) > SKIPS a node whose container listing failed — never reaps on a blind node [0.07ms]
+(pass) reconcileOrphanContainers (agent orchestration) > SKIPS a non-healthy node (defensive: caller should pre-filter) [0.04ms]
+[orphan-reconciler] Failed to reap orphan container {
+  nodeId: "node-1",
+  hostname: "host-1",
+  containerName: "agent-a",
+  key: "a",
+  error: "ssh broke",
+}
+(pass) reconcileOrphanContainers (agent orchestration) > counts a failed removal as reapFailed without aborting the rest [0.14ms]
+(pass) reconcileOrphanContainers (agent orchestration) > does not query the DB when a node has no agent- containers [0.04ms]
+
+src/lib/services/provisioning-jobs-lanes.test.ts:
+(pass) processPendingJobs — lane scoping > apps lane claims + stale-recovers ONLY apps job types, never an agent type [0.44ms]
+(pass) processPendingJobs — lane scoping > default (no jobTypes) claims + recovers every JOB_TYPES entry — unchanged behavior [0.11ms]
+(pass) processPendingJobs — lane scoping > agent lane never claims an apps job type (no cross-lane leakage) [0.10ms]
+
+src/lib/services/reserved-env-keys.test.ts:
+(pass) reserved-env-keys > findReservedEnvKeys flags reserved keys case-insensitively, echoing caller casing [0.07ms]
+(pass) reserved-env-keys > findReservedEnvKeys returns [] when no reserved keys present [0.01ms]
+(pass) reserved-env-keys > POSTGRES_URL is not in the default platform list but can be added per-caller [0.02ms]
+(pass) reserved-env-keys > stripReservedEnvKeys removes reserved keys (case-insensitive) and keeps the rest [0.06ms]
+(pass) reserved-env-keys > stripReservedEnvKeys with an extended set also strips POSTGRES_URL [0.02ms]
+(pass) reserved-env-keys > stripReservedEnvKeys does not mutate its input [0.02ms]
+
+src/lib/services/eliza-sandbox-shared-billing.test.ts:
+(pass) ElizaSandboxService shared runtime billing > meters successful shared-runtime turns [2.09ms]
+
+src/lib/services/provisioning-job-types.test.ts:
+(pass) job lanes — completeness invariant > agent ∪ apps covers EVERY job type (none orphaned) [0.03ms]
+(pass) job lanes — completeness invariant > agent and apps lanes are DISJOINT (no type double-claimed) [0.02ms]
+(pass) job lanes — completeness invariant > apps lane is exactly the CONTAINER_* + APP_* rows [0.01ms]
+(pass) job lanes — completeness invariant > no AGENT_* type leaked into the apps lane [0.01ms]
+(pass) resolveJobTypesForLanes — fail-open to ALL > undefined → all types [0.03ms]
+(pass) resolveJobTypesForLanes — fail-open to ALL > null → all types
+(pass) resolveJobTypesForLanes — fail-open to ALL > "" → all types
+(pass) resolveJobTypesForLanes — fail-open to ALL > "   " → all types
+(pass) resolveJobTypesForLanes — fail-open to ALL > "," → all types
+(pass) resolveJobTypesForLanes — fail-open to ALL > " , " → all types
+(pass) resolveJobTypesForLanes — fail-open to ALL > an unrecognized lane name → all types (never claim nothing) [0.01ms]
+(pass) resolveJobTypesForLanes — fail-open to ALL > prototype-key-only spec "constructor" → all types (no throw)
+(pass) resolveJobTypesForLanes — fail-open to ALL > prototype-key-only spec "__proto__" → all types (no throw)
+(pass) resolveJobTypesForLanes — fail-open to ALL > prototype-key-only spec "valueof,hasownproperty" → all types (no throw)
+(pass) resolveJobTypesForLanes — fail-open to ALL > prototype-key-only spec "tostring" → all types (no throw)
+(pass) resolveJobTypesForLanes — fail-open to ALL > 'agent,constructor' → exactly the agent lane (proto key ignored) [0.02ms]
+(pass) resolveJobTypesForLanes — scoping > 'apps' → exactly the apps lane [0.02ms]
+(pass) resolveJobTypesForLanes — scoping > 'agent' → exactly the agent lane [0.01ms]
+(pass) resolveJobTypesForLanes — scoping > 'agent,apps' → all types (both lanes) [0.02ms]
+(pass) resolveJobTypesForLanes — scoping > case-insensitive + whitespace tolerant [0.02ms]
+(pass) resolveJobTypesForLanes — scoping > a recognized lane alongside garbage → just the recognized lane
+(pass) resolveJobTypesForLanes — scoping > preserves JOB_TYPES declaration order [0.02ms]
+
+src/lib/services/inference-billing-cache-failure.test.ts:
+(pass) optimistic billing with an unavailable cache backstop > isOptimisticBackstopAvailable() is false (forces the synchronous reserve) [0.02ms]
+[InferenceBilling] pending-charge backstop write failed; will reserve instead {
+  requestId: "req-cachedown",
+  organizationId: "org-cachedown",
+  error: "Cache unavailable for atomic set-if-not-exists",
+}
+(pass) optimistic billing with an unavailable cache backstop > writePendingInferenceCharge() reports false instead of silently no-op'ing [0.18ms]
+
+src/lib/services/coding-containers.test.ts:
+(pass) coding container payloads > uses the coding remote runner image when configured [0.27ms]
+(pass) coding container payloads > lets explicit coding container image override the default [0.02ms]
+(pass) request schema > defaults a missing agent to claude [0.54ms]
+(pass) request schema > still honors an explicit agent [0.03ms]
+(pass) request schema > accepts elizaos (the eliza-code cloud coding agent, #10059) [0.04ms]
+(pass) request schema > rejects an unknown coding agent [0.17ms]
+(pass) request schema > rejects dropped container fields instead of silently ignoring them [0.21ms]
+(pass) request schema > still accepts the supported container fields [0.02ms]
+(pass) coding container session response url > prefers the per-agent public HTTPS url over the internal bridge url [0.09ms]
+(pass) coding container session response url > falls back to the internal url when no public url is present [0.02ms]
+(pass) coding container image allowlist > allows images under an allowed prefix [0.03ms]
+(pass) coding container image allowlist > rejects images outside the allowlist [0.01ms]
+(pass) coding container image allowlist > is case-insensitive and trims whitespace
+(pass) coding container image allowlist > fails closed on an empty allowlist
+(pass) coding container image allowlist > supports an explicit wildcard opt-out
+(pass) coding container image allowlist > supports exact-match entries
+(pass) coding container image allowlist > env getter returns the secure default when unset [0.03ms]
+(pass) coding container image allowlist > env getter parses a comma-separated override [0.03ms]
+(pass) coding container digest-pin gate > never rejects when the flag is off (opt-in default) [0.01ms]
+(pass) coding container digest-pin gate > rejects mutable refs when the flag is on [0.05ms]
+(pass) coding container digest-pin gate > accepts a full sha256-digest-pinned ref when the flag is on
+(pass) coding container digest-pin gate > env getter defaults OFF and only 'true' enables it [0.04ms]
+
+src/lib/services/headscale-client.test.ts:
+(pass) resolvePreAuthTtlMs (headscale pre-auth key TTL) > defaults to 60 minutes (prod-verified; 10 min looped slow boots) [0.03ms]
+(pass) resolvePreAuthTtlMs (headscale pre-auth key TTL) > honors HEADSCALE_PREAUTH_TTL_MIN so the box override survives a redeploy [0.01ms]
+(pass) resolvePreAuthTtlMs (headscale pre-auth key TTL) > falls back to the 60-min default for non-positive / non-numeric values [0.03ms]
+
+src/lib/services/agent-gateway-router.test.ts:
+[PhoneNormalization] Using best-effort format {
+  phone: "+1 (555) 555-0100",
+  country: "US",
+}
+[PhoneNormalization] Using best-effort format {
+  phone: "+1 (555) 555-0100",
+  country: "US",
+}
+[PhoneNormalization] Using best-effort format {
+  phone: "+15555550100",
+  country: "US",
+}
+(pass) AgentGatewayRouterService phone routing > routes to the sender's own active agent before checking friend contacts [2.08ms]
+[PhoneNormalization] Using best-effort format {
+  phone: "+1 (555) 555-0100",
+  country: "US",
+}
+[PhoneNormalization] Using best-effort format {
+  phone: "+1 (555) 555-0100",
+  country: "US",
+}
+[PhoneNormalization] Using best-effort format {
+  phone: "+15555550100",
+  country: "US",
+}
+(pass) AgentGatewayRouterService phone routing > routes to the sender's own running Cloud agent before checking friend contacts [0.38ms]
+[PhoneNormalization] Using best-effort format {
+  phone: "+1 (555) 555-0100",
+  country: "US",
+}
+[PhoneNormalization] Using best-effort format {
+  phone: "+15555550100",
+  country: "US",
+}
+[PhoneNormalization] Using best-effort format {
+  phone: "+1 (555) 555-0100",
+  country: "US",
+}
+[PhoneNormalization] Using best-effort format {
+  phone: "+15555550100",
+  country: "US",
+}
+(pass) AgentGatewayRouterService phone routing > routes unknown senders to an agent that previously messaged them [0.68ms]
+[PhoneNormalization] Using best-effort format {
+  phone: "+1 (555) 555-0100",
+  country: "US",
+}
+[PhoneNormalization] Using best-effort format {
+  phone: "+15555550100",
+  country: "US",
+}
+[PhoneNormalization] Using best-effort format {
+  phone: "+1 (555) 555-0100",
+  country: "US",
+}
+[PhoneNormalization] Using best-effort format {
+  phone: "+15555550100",
+  country: "US",
+}
+(pass) AgentGatewayRouterService phone routing > falls back to outbound phone message log when no contact row exists [0.29ms]
+[PhoneNormalization] Using best-effort format {
+  phone: "+1 (555) 555-0100",
+  country: "US",
+}
+[PhoneNormalization] Using best-effort format {
+  phone: "+15555550100",
+  country: "US",
+}
+[AgentGatewayRouter] agent_phone_contacts table is not migrated yet
+[PhoneNormalization] Using best-effort format {
+  phone: "+1 (555) 555-0100",
+  country: "US",
+}
+[PhoneNormalization] Using best-effort format {
+  phone: "+15555550100",
+  country: "US",
+}
+(pass) AgentGatewayRouterService phone routing > falls back to outbound phone message log when contact table is not migrated [0.32ms]
+[PhoneNormalization] Using best-effort format {
+  phone: "+1 (555) 555-0100",
+  country: "US",
+}
+[PhoneNormalization] Using best-effort format {
+  phone: "+15555550100",
+  country: "US",
+}
+(pass) AgentGatewayRouterService phone routing > starts onboarding for phone numbers with no owner or contact relationship [0.12ms]
+[PhoneNormalization] Using best-effort format {
+  phone: "+1 (555) 555-0100",
+  country: "US",
+}
+[AgentGatewayRouter] Failed to resolve phone target {
+  provider: "blooio",
+  from: "+1 (555) 555-0100",
+  to: "+14159611510",
+  error: "lookup failed",
+}
+(pass) AgentGatewayRouterService phone routing > starts onboarding instead of throwing when phone target resolution fails [0.16ms]
+[PhoneNormalization] Using best-effort format {
+  phone: "+1 (555) 555-0100",
+  country: "US",
+}
+[AgentGatewayRouter] Failed to resolve phone sender's own runtime {
+  provider: "blooio",
+  userId: "known-user",
+  organizationId: "known-org",
+  error: "relay lookup failed",
+}
+[PhoneNormalization] Using best-effort format {
+  phone: "+15555550100",
+  country: "US",
+}
+(pass) AgentGatewayRouterService phone routing > falls back to authenticated onboarding when owner runtime lookup fails [0.19ms]
+[PhoneNormalization] Using best-effort format {
+  phone: "+1 (555) 555-0100",
+  country: "US",
+}
+[PhoneNormalization] Using best-effort format {
+  phone: "+15555550100",
+  country: "US",
+}
+[PhoneNormalization] Using best-effort format {
+  phone: "+1 (555) 555-0100",
+  country: "US",
+}
+[PhoneNormalization] Using best-effort format {
+  phone: "+15555550100",
+  country: "US",
+}
+(pass) AgentGatewayRouterService phone routing > routes known senders without an active own agent to their friend contact route [0.30ms]
+[PhoneNormalization] Using best-effort format {
+  phone: "+1 (555) 555-0100",
+  country: "US",
+}
+[PhoneNormalization] Using best-effort format {
+  phone: "+1 (555) 555-0100",
+  country: "US",
+}
+[PhoneNormalization] Using best-effort format {
+  phone: "+15555550100",
+  country: "US",
+}
+[AgentGatewayRouter] Phone target route threw {
+  provider: "blooio",
+  from: "+15555550100",
+  to: "+14159611510",
+  agentId: undefined,
+  userId: "known-user",
+  organizationId: "known-org",
+  source: "owner",
+  error: "relay unavailable",
+}
+(pass) AgentGatewayRouterService phone routing > falls back to authenticated onboarding when the sender's own agent route throws [0.19ms]
+[PhoneNormalization] Using best-effort format {
+  phone: "+1 (555) 555-0100",
+  country: "US",
+}
+[PhoneNormalization] Using best-effort format {
+  phone: "+15555550100",
+  country: "US",
+}
+[PhoneNormalization] Using best-effort format {
+  phone: "+1 (555) 555-0100",
+  country: "US",
+}
+[PhoneNormalization] Using best-effort format {
+  phone: "+15555550100",
+  country: "US",
+}
+[AgentGatewayRouter] Phone target route threw {
+  provider: "blooio",
+  from: "+15555550100",
+  to: "+14159611510",
+  agentId: "friend-agent",
+  userId: "owner-user",
+  organizationId: "owner-org",
+  source: "contact",
+  error: "sandbox unavailable",
+}
+(pass) AgentGatewayRouterService phone routing > returns bridge_failed instead of onboarding when a friend contact target throws [0.19ms]
+
+src/lib/services/waifu-webhook.test.ts:
+(pass) resolveWaifuWebhookTarget > returns null when not configured [0.05ms]
+(pass) resolveWaifuWebhookTarget > resolves from WAIFU_WEBHOOK_URL + WAIFU_WEBHOOK_SECRET and strips trailing slash [0.02ms]
+(pass) resolveWaifuWebhookTarget > resolves from the canonical ELIZA_CLOUD_WEBHOOK_URL + ELIZA_CLOUD_WEBHOOK_SECRET [0.02ms]
+(pass) resolveWaifuWebhookTarget > ELIZA_CLOUD_* takes precedence over the deprecated WAIFU_* aliases [0.02ms]
+(pass) emitWaifuWebhook signing + delivery > posts to the credits receiver with a waifu-verifiable signature [61.03ms]
+(pass) emitWaifuWebhook signing + delivery > routes inference events to the inference receiver [1.86ms]
+(pass) emitWaifuWebhook signing + delivery > credits-path target + inference kind re-derives the /inference receiver [1.23ms]
+(pass) emitWaifuWebhook signing + delivery > inference-path target + credits kind re-derives the /credits receiver [0.81ms]
+(pass) emitWaifuWebhook signing + delivery > credits-path target + credits kind is preserved (no spurious swap) [0.70ms]
+(pass) emitWaifuWebhook signing + delivery > no-ops cleanly when target is not configured [0.05ms]
+[waifu-webhook] delivery error {
+  kind: "credits",
+  idempotencyKey: "evt-3",
+  error: "connection reset",
+}
+(pass) emitWaifuWebhook signing + delivery > never throws on delivery error; returns delivered=false [0.97ms]
+(pass) emitWaifuWebhook signing + delivery > signWaifuWebhook matches waifu's scheme exactly [0.02ms]
+(pass) isWaifuWebhookTargetUrl (signed-envelope gating) > true when the callback origin matches the waifu target [0.03ms]
+(pass) isWaifuWebhookTargetUrl (signed-envelope gating) > false for a non-waifu callback url so its payload stays unsigned
+(pass) isWaifuWebhookTargetUrl (signed-envelope gating) > false for a malformed url [0.02ms]
+(pass) isWaifuWebhookTargetUrl (signed-envelope gating) > false for a same-origin url that is not a /v2/webhooks/ receiver
+(pass) isWaifuWebhookTargetUrl (signed-envelope gating) > true for a same-origin /v2/webhooks/ inference receiver
+(pass) classifyCreditBalance (money-path threshold mapping) > depleted at or below zero [0.01ms]
+(pass) classifyCreditBalance (money-path threshold mapping) > low between zero and the threshold
+(pass) classifyCreditBalance (money-path threshold mapping) > no signal above the threshold
+(pass) emitWaifuCreditWebhook > maps depleted balance to credits.depleted and carries ids [0.84ms]
+(pass) emitWaifuCreditWebhook > maps low balance to credits.low [0.76ms]
+(pass) emitWaifuInferenceWebhook > emits inference.spent with usd + tokens [1.14ms]
+
+src/lib/services/managed-eliza-config.test.ts:
+(pass) managed Eliza environment > sets public base url to the managed agent subdomain when missing [4.08ms]
+(pass) managed Eliza environment > replaces local and tunnel public base urls before provisioning [0.11ms]
+(pass) managed Eliza environment > preserves a caller-pinned custom public base url [0.05ms]
+(pass) managed Eliza environment > replaces unresolved public base url placeholders [0.05ms]
+(pass) managed Eliza environment > pins managed containers to their cloud agent id for waifu chat JWT scope [0.04ms]
+(pass) managed Eliza environment > preserves waifu-provided hosted UI enablement [0.04ms]
+(pass) managed Eliza environment > preserves waifu chat auth and frame env for hosted token pages [0.04ms]
+(pass) managed Eliza environment > pins embeddings to the elizacloud Worker base so /embeddings never 503s [0.04ms]
+(pass) managed Eliza environment > honors an explicit per-agent embedding URL override [0.03ms]
+(pass) managed Eliza environment > defaults new agents to local in-container state + lean chat plugins (#8696/#8434) [0.04ms]
+(pass) managed Eliza environment > honors escape hatches: shared DB + custom plugin set + custom pglite dir [0.04ms]
+(pass) managed Eliza environment > strips an inherited control-plane DATABASE_URL so a local-state agent stays off shared Postgres (#8783/#8696) [0.04ms]
+(pass) managed Eliza environment > pins both embedding dimensions to 1536 so the storage column and the cloud probe agree (#8769) [0.03ms]
+(pass) managed Eliza environment > honors explicit per-agent embedding-dimension overrides [0.03ms]
+(pass) applyManagedAgentInferenceEnvDefaults (#8434) > returns all 5 inference keys with 1536-d embedding defaults on an empty env [0.04ms]
+(pass) applyManagedAgentInferenceEnvDefaults (#8434) > preserves explicit per-agent overrides [0.03ms]
+(pass) applyManagedAgentInferenceEnvDefaults (#8434) > spreading the helper heals a stale upgrade env that lacks EMBEDDING_DIMENSION [0.06ms]
+
+src/lib/services/eliza-sandbox-bridge-ssrf.test.ts:
+(pass) ElizaSandboxService bridge SSRF guard (untrusted string bridge URL) > rejects an untrusted bridge URL pointing at a private IP [0.28ms]
+(pass) ElizaSandboxService bridge SSRF guard (untrusted string bridge URL) > rejects an untrusted bridge URL pointing at the cloud-metadata IP [0.04ms]
+(pass) ElizaSandboxService bridge SSRF guard (untrusted string bridge URL) > rejects an untrusted bridge URL pointing at localhost [0.03ms]
+(pass) ElizaSandboxService bridge SSRF guard (untrusted string bridge URL) > allows a trusted internal-mesh bridge URL to stay unguarded [0.03ms]
+
+src/lib/services/node-disk-manager.test.ts:
+(pass) parseDfUsedPercent > reads the Capacity column from a standard df -P output [0.11ms]
+(pass) parseDfUsedPercent > ignores [stderr]-prefixed lines from the SSH client [0.03ms]
+(pass) parseDfUsedPercent > returns null when no percentage field is present [0.02ms]
+(pass) parseDfUsedPercent > rejects an out-of-range percent
+(pass) decideDiskAction > below the threshold → skip_below_threshold (never prune) [0.03ms]
+(pass) decideDiskAction > at the threshold and never pruned → prune
+(pass) decideDiskAction > above the threshold but inside cooldown → skip_cooldown
+(pass) decideDiskAction > above the threshold and cooldown elapsed → prune [0.01ms]
+(pass) diskHealthVerdict > below the unhealthy mark → ok [0.01ms]
+(pass) diskHealthVerdict > at/above the unhealthy mark → critical
+(pass) diskHealthVerdict > a failed df read (null) is ok — disk never owns reachability
+(pass) buildReclaimCommand > prunes the docker system WITHOUT --volumes (agent volumes preserved)
+(pass) buildReclaimCommand > clears stuck containerd ingest (the actual failed-pull junk)
+(pass) buildReclaimCommand > prunes the buildkit cache too
+(pass) cleanupNodeDisks > prunes a healthy node above the threshold and reports reclaimed space [0.29ms]
+(pass) cleanupNodeDisks > does NOT prune a node below the threshold [0.04ms]
+(pass) cleanupNodeDisks > respects the cooldown: a node pruned recently is skipped even above threshold [0.04ms]
+(pass) cleanupNodeDisks > arms the cooldown after a prune so the next tick skips it [0.05ms]
+[node-disk-manager] Skipping node: disk usage read failed {
+  nodeId: "node-a",
+  hostname: "10.0.0.1",
+}
+(pass) cleanupNodeDisks > skips a node whose df read failed (never reclaim off a misread) [0.07ms]
+(pass) cleanupNodeDisks > never touches a non-healthy node [0.03ms]
+[node-disk-manager] Disk reclamation failed {
+  nodeId: "bad",
+  hostname: "10.0.0.1",
+  error: "reclaim failed over ssh",
+}
+(pass) cleanupNodeDisks > counts a reclaim that throws as pruneFailed and continues [0.11ms]
+
+src/lib/services/provisioning-jobs-stale-threshold.test.ts:
+(pass) recoverStaleJobs threshold by job type > cold-boot types outlast the ~11min cold provision; fast ops keep the 5min backstop [0.21ms]
+
+src/lib/services/payment-requests.test.ts:
+(pass) createPaymentRequestsService > rejects providers without a real adapter before creating a row [0.24ms]
+(pass) expirePastForOrg (least-privilege expire, #10117) > only sweeps the caller's org and never the global sweep [0.27ms]
+(pass) expirePastForOrg (least-privilege expire, #10117) > expirePast (cron) still uses the global sweep [0.07ms]
+
+src/lib/services/managed-eliza-lean-chat-boot.integration.test.ts:
+(pass) D10 lean-chat local-state cloud agent boot — end-to-end > managed env pins local state + lean chat + 1536-d embeddings (no DATABASE_URL) [1.19ms]
+(pass) D10 lean-chat local-state cloud agent boot — end-to-end > (1) DB adapter resolves to PGlite when the managed env has no DATABASE_URL [38.79ms]
+(pass) D10 lean-chat local-state cloud agent boot — end-to-end > (2) resolved lean-chat plugin set excludes local-inference/wallet/workflow, includes elizacloud [290.87ms]
+ Info       [Migration] Starting pre-1.6.5 → 1.6.5+ schema migration...
+ Info       [Migration] ✓ Migration complete - pre-1.6.5 → 1.6.5+ schema migration finished
+ Info       [PLUGIN:SQL] Initializing migration system
+ Info       [PLUGIN:SQL] Migration system initialized
+ Info       [PLUGIN:SQL] DatabaseMigrationService initialized
+ Info       [PLUGIN:SQL] Plugin schemas discovered (schemasDiscovered=1, totalPlugins=1)
+ Info       [PLUGIN:SQL] Starting migrations (environment=DEVELOPMENT, pluginCount=1, dryRun=false)
+ Info       [PLUGIN:SQL] Starting migration for plugin (pluginName=@elizaos/plugin-sql)
+ Info       [PLUGIN:SQL] Initializing migration system
+ Info       [PLUGIN:SQL] Migration system initialized
+ Info       [PLUGIN:SQL] Executing SQL statements (pluginName=@elizaos/plugin-sql, statementCount=167)
+ Info       [PLUGIN:SQL] Recorded migration (pluginName=@elizaos/plugin-sql, tag=0000_@elizaos/plugin-sql_mr1iyi8u)
+ Info       [PLUGIN:SQL] Migration completed successfully (pluginName=@elizaos/plugin-sql)
+ Info       [PLUGIN:SQL] Migration completed (pluginName=@elizaos/plugin-sql)
+ Info       [PLUGIN:SQL] All migrations completed successfully (successCount=1)
+ Info       [PLUGIN:SQL] Skipping RLS re-application (ENABLE_DATA_ISOLATION is not true)
+ Warn       [PLUGIN:SQL] Skipping embedding insert: dimension mismatch with configured column (expectedDimension=1536, receivedDimension=384, column=dim1536)
+(pass) D10 lean-chat local-state cloud agent boot — end-to-end > (3) a 1536-d memory insert lands in the dim1536 column (not 'dimension mismatch') [1396.09ms]
+
+src/lib/services/ai-pricing-variant-indexing.test.ts:
+(pass) stripVersionedSnapshotSuffix — dated and labelled suffixes > strips compact 8-digit date suffix [0.09ms]
+(pass) stripVersionedSnapshotSuffix — dated and labelled suffixes > strips ISO date suffix [0.02ms]
+(pass) stripVersionedSnapshotSuffix — dated and labelled suffixes > strips -latest label [0.01ms]
+(pass) stripVersionedSnapshotSuffix — dated and labelled suffixes > strips -preview label [0.01ms]
+(pass) stripVersionedSnapshotSuffix — dated and labelled suffixes > strips -beta label [0.01ms]
+(pass) stripVersionedSnapshotSuffix — dated and labelled suffixes > dated suffix bypasses the 2-segment safety check for short bases [0.01ms]
+(pass) stripVersionedSnapshotSuffix — numeric snapshot suffixes > strips -001 numeric snapshot [0.03ms]
+(pass) stripVersionedSnapshotSuffix — numeric snapshot suffixes > strips multi-digit numeric snapshot when two+ segments remain [0.06ms]
+(pass) stripVersionedSnapshotSuffix — numeric snapshot suffixes > does NOT strip when result would collapse to one segment after slash [0.02ms]
+(pass) stripVersionedSnapshotSuffix — must-not-strip cases > returns null when no suffix pattern matches [0.02ms]
+(pass) stripVersionedSnapshotSuffix — must-not-strip cases > returns null when stripping would empty the id
+(pass) stripVersionedSnapshotSuffix — must-not-strip cases > returns null when stripping would leave just a provider prefix
+(pass) stripVersionedSnapshotSuffix — must-not-strip cases > returns null for ids without dash-version markers
+(pass) stripVersionedSnapshotSuffix — must-not-strip cases > does NOT treat a non-date 8-digit run id as a date suffix
+(pass) stripVersionedSnapshotSuffix — must-not-strip cases > accepts realistic compact-date suffixes for both 19xx and 20xx years [0.01ms]
+(pass) buildBitRouterPreparedEntries — exact + stripped variants > emits both exact and stripped rows for prompt and completion [0.53ms]
+(pass) buildBitRouterPreparedEntries — exact + stripped variants > emits only exact rows when no suffix can be stripped [0.05ms]
+(pass) buildBitRouterPreparedEntries — exact + stripped variants > propagates provider, productFamily, billingSource on stripped row [0.04ms]
+(pass) buildBitRouterPreparedEntries — exact + stripped variants > does not emit stripped row when prices are missing [0.02ms]
+(pass) buildBitRouterPreparedEntries — exact + stripped variants > emits stripped row only for the priced direction (input-only) [0.03ms]
+(pass) forced provider route pricing ids > keeps forced route ids canonical before slash-prefixed aliases [0.03ms]
+(pass) forced provider route pricing ids > infers provider from forced route prefixes [0.01ms]
+(pass) forced provider route pricing ids > uses underlying catalog id as an alias for OpenRouter forced routes [0.18ms]
+(pass) forced provider route pricing ids > bridges the slash provider form to the colon-keyed Cerebras forced rows [0.04ms]
+(pass) forced provider route pricing ids > does not synthesize a colon route id for namespace prefixes or variant ids [0.03ms]
+(pass) forced provider route pricing ids > adds synthetic Cerebras pricing rows to the BitRouter catalog [0.48ms]
+(pass) forced provider route pricing ids > adds a synthetic openai/gpt-oss-120b row so :nitro / :free variants resolve [0.07ms]
+(pass) forced provider route pricing ids > emits forced embedding:input row for bare text-embedding-3-small id [0.05ms]
+(pass) forced provider route pricing ids > emits forced embedding:input row for prefixed openai/text-embedding-3-small id [0.05ms]
+(pass) canonicalModelId — OpenRouter routing variants on bare model ids > prepends provider for bare id with routing suffix [0.01ms]
+(pass) canonicalModelId — OpenRouter routing variants on bare model ids > prepends provider for bare id with no suffix
+(pass) canonicalModelId — OpenRouter routing variants on bare model ids > leaves already-canonical id unchanged
+(pass) canonicalModelId — OpenRouter routing variants on bare model ids > leaves already-canonical id with routing suffix unchanged
+(pass) canonicalModelId — OpenRouter routing variants on bare model ids > preserves forced-provider id (cerebras has no dash in prefix)
+(pass) canonicalModelId — OpenRouter routing variants on bare model ids > heuristic generalizes to anthropic + :floor on dashed bare id
+(pass) chooseBestCandidatePricingEntry — tie-break when stripped variants conflict > picks the higher unitPrice when two stripped snapshots collide [9.90ms]
+(pass) chooseBestCandidatePricingEntry — tie-break when stripped variants conflict > returns deterministic winner when both prices are equal [0.05ms]
+
+src/lib/services/stripe-connect-payout-flow.e2e.test.ts:
+(pass) Stripe Connect payout flow e2e — stub (#8922) > onboard → activate → transfer → webhook → balance decremented [0.52ms]
+(pass) Stripe Connect payout flow e2e — stub (#8922) > compensates the ledger when the Stripe transfer fails (no balance loss) [0.15ms]
+(pass) Stripe Connect payout flow e2e — stub (#8922) > rejects a transfer that exceeds the available balance before calling Stripe [0.02ms]
+
+src/lib/services/inference-billing-fast-path.test.ts:
+(pass) isOptimisticBillingEnabled > default OFF; ON only for exact 'true' [0.59ms]
+(pass) resolveSafeBalanceThresholdUsd (fail SAFE = +Inf) > unset / blank / non-finite / non-positive -> +Infinity [0.05ms]
+(pass) resolveSafeBalanceThresholdUsd (fail SAFE = +Inf) > valid positive parses [0.03ms]
+(pass) isOptimisticEligible > eligible when balance clears threshold and est cost [0.03ms]
+(pass) isOptimisticEligible > not eligible when disabled [0.02ms]
+(pass) isOptimisticEligible > not eligible for app-credits [0.01ms]
+(pass) isOptimisticEligible > not eligible when threshold is +Inf (misconfig fail-safe) [0.01ms]
+(pass) isOptimisticEligible > not eligible when balance does not clear threshold [0.02ms]
+(pass) isOptimisticEligible > not eligible when balance does not clear est cost (tiny balance, huge call) [0.02ms]
+(pass) isPendingInferenceCharge shape guard > accepts a full record, rejects partial / wrong version [0.05ms]
+(pass) getGateBalanceUsd > hint hit returns hint, no fresh DB read [0.41ms]
+(pass) getGateBalanceUsd > miss reads fresh, writes hint, second call served from hint [0.12ms]
+(pass) writePendingInferenceCharge + durable backstop > writes a readable, shape-valid pending entry [0.15ms]
+(pass) createOptimisticDebitSettler > claims the pending entry and debits the ACTUAL cost [0.36ms]
+(pass) createOptimisticDebitSettler > on debit success refreshes the org-balance hint [0.23ms]
+[InferenceBilling] uncollected inference charge {
+  organizationId: "org-16",
+  userId: "user-17",
+  requestId: "req-15",
+  amountUsd: 0.02,
+  source: "inline",
+  reason: "insufficient_balance",
+}
+(pass) createOptimisticDebitSettler > on FAILED debit (insufficient) forces org off the fast path [0.28ms]
+(pass) createOptimisticDebitSettler > actualCost 0 claims the entry but charges nothing [0.09ms]
+(pass) createOptimisticDebitSettler > second settle of an already-claimed request is a no-op (no double charge) [0.14ms]
+[InferenceBilling] swept stale pending charges (dropped inline settles) {
+  scanned: 1,
+  settled: 1,
+  uncollectedOrStale: 0,
+  skippedYoung: 0,
+  locked: false,
+  capHit: false,
+}
+(pass) sweepStalePendingInferenceCharges > settles stragglers older than grace via the ESTIMATE [2.38ms]
+(pass) sweepStalePendingInferenceCharges > skips young entries still in flight [0.13ms]
+[InferenceBilling] swept stale pending charges (dropped inline settles) {
+  scanned: 1,
+  settled: 0,
+  uncollectedOrStale: 1,
+  skippedYoung: 0,
+  locked: false,
+  capHit: false,
+}
+(pass) sweepStalePendingInferenceCharges > drops malformed entries under the prefix without charging [0.17ms]
+(pass) sweepStalePendingInferenceCharges > does not double-charge an entry the inline settler already claimed [0.11ms]
+(pass) sweepStalePendingInferenceCharges > a held single-flight lock makes the sweep a no-op (no overlapping claims) [0.09ms]
+(pass) #9899 hardening: backstop durability, lower-only hint, claim atomicity > writePendingInferenceCharge reports true when the backstop persists [0.05ms]
+(pass) #9899 hardening: backstop durability, lower-only hint, claim atomicity > isOptimisticBackstopAvailable is true when the cache is up [0.03ms]
+(pass) #9899 hardening: backstop durability, lower-only hint, claim atomicity > debit hint write is lower-only: a stale-high concurrent debit never raises the gate [0.11ms]
+(pass) #9899 hardening: backstop durability, lower-only hint, claim atomicity > two concurrent inline claims of one request charge exactly once (atomic getAndDelete) [0.07ms]
+(pass) #9899 hardening: backstop durability, lower-only hint, claim atomicity > concurrent inline settle + cron sweep on one request charge at most once [0.07ms]
+
+src/lib/services/ai-pricing-bitrouter-units.test.ts:
+(pass) BitRouter pricing units > structured per-million prices are normalized to per-token [0.72ms]
+(pass) BitRouter pricing units > a 1k-token request costs cents, not thousands of dollars [0.03ms]
+(pass) BitRouter pricing units > cheap models normalize too (gpt-oss-120b) [0.02ms]
+(pass) BitRouter pricing units > legacy flat per-token fields (OpenRouter form) are used as-is [0.02ms]
+(pass) BitRouter pricing units > flat field wins over structured when both are present [0.01ms]
+(pass) BitRouter pricing units > models without pricing produce no entries [0.02ms]
+
+src/lib/services/provisioning-jobs-agent-downgrade.test.ts:
+(pass) ProvisioningJobService agent_downgrade > executes rollback through the daemon job and persists the swap result [0.74ms]
+(pass) ProvisioningJobService agent_downgrade > treats rollback refusal as a failed attempt, not a silent no-op [0.20ms]
+
+src/lib/services/sensitive-requests.test.ts:
+(pass) SensitiveRequestsService — token-actor paths > getPublicByToken returns the redacted public view for a valid token [0.95ms]
+(pass) SensitiveRequestsService — token-actor paths > getPublicByToken rejects an invalid token [0.19ms]
+(pass) SensitiveRequestsService — token-actor paths > submit with a token and no actor succeeds when the link is not authenticated [0.48ms]
+(pass) SensitiveRequestsService — token-actor paths > submit with a token but no actor is rejected when the link requires authentication [0.12ms]
+
+src/lib/services/server-wallets-provision-proof.test.ts:
+(pass) provisionServerWallet — proof-of-control gate > accepts a valid proof and proceeds to provision [13.63ms]
+(pass) provisionServerWallet — proof-of-control gate > rejects a proof signed by a DIFFERENT key (the squatting case) [1.47ms]
+(pass) provisionServerWallet — proof-of-control gate > rejects an expired proof (timestamp outside the window) [0.46ms]
+(pass) provisionServerWallet — proof-of-control gate > rejects a far-future proof (timestamp outside the window) [0.41ms]
+(pass) provisionServerWallet — proof-of-control gate > rejects a replayed proof (same nonce twice) [1.98ms]
+(pass) provisionServerWallet — proof-of-control gate > rejects when the signed chainType differs from the requested one [1.54ms]
+
+src/lib/services/app-deploy-orchestrator.test.ts:
+(pass) deployApp env hardening > strips caller-supplied platform-reserved keys on a stateless (none) app [0.29ms]
+(pass) deployApp env hardening > platform isolated DSN wins over caller DATABASE_URL/POSTGRES_URL [0.06ms]
+(pass) deployApp env hardening > non-reserved caller env passes through unchanged [0.04ms]
+
+src/lib/services/headscale-integration.test.ts:
+(pass) Headscale identity inference > uses organization id before mutable agent identity [0.06ms]
+(pass) Headscale identity inference > falls back to user id, agent name, then configured default user [0.02ms]
+(pass) Headscale identity inference > keeps agent name only in the hostname and includes an id prefix [0.01ms]
+(pass) Headscale identity inference > hostname stays within the 63-char DNS label limit [0.02ms]
+(pass) Headscale identity inference > hostname never ends with a hyphen even when the 63-char slice cuts one [0.02ms]
+(pass) Headscale identity inference > hostname normalizes special chars to a valid DNS label and never empties [0.01ms]
+(pass) Headscale identity inference > inferHeadscaleUser reads HEADSCALE_USER for the all-empty fallback [0.04ms]
+(pass) Headscale node lookup is keyed on the node name (not the agentId) > waitForVPNRegistration polls getNodeByName with the node name [0.22ms]
+(pass) Headscale node lookup is keyed on the node name (not the agentId) > cleanupContainerVPN deletes the node found by the node name [0.10ms]
+(pass) normalizeHeadscaleSegment + registration-timeout default > lowercases, trims, replaces invalid chars, collapses + strips hyphens [0.02ms]
+(pass) normalizeHeadscaleSegment + registration-timeout default > returns null for empty / whitespace-only / undefined [0.01ms]
+(pass) normalizeHeadscaleSegment + registration-timeout default > DEFAULT_REGISTRATION_TIMEOUT_MS falls back to 180s when env is unset
+
+src/lib/services/inference-billing-ledger-advisory-lock.test.ts:
+(pass) admission advisory lock (#9899 — discriminates the overdraw-bound lock) > runs inside a transaction and acquires the per-org advisory lock BEFORE the in-flight SUM [0.51ms]
+(pass) admission advisory lock (#9899 — discriminates the overdraw-bound lock) > scopes the advisory lock to THIS org (per-org serialization, not a global lock) [10.59ms]
+
+src/lib/services/app-container-orphan-reconciler.test.ts:
+(pass) appContainerKeyOf > accepts an app-<slug> name and returns the name as the key [0.02ms]
+(pass) appContainerKeyOf > rejects names without the app- prefix [0.01ms]
+(pass) appContainerKeyOf > rejects a bare prefix with no slug
+(pass) computeOrphanContainersToReap (app diff) > reaps a container whose name has NO db row [0.09ms]
+(pass) computeOrphanContainersToReap (app diff) > reaps a container whose db row is in a terminal state (stopped/failed/deleted) [0.04ms]
+(pass) computeOrphanContainersToReap (app diff) > does NOT reap a container with a live (running) db row [0.01ms]
+(pass) computeOrphanContainersToReap (app diff) > does NOT reap deploying / building / pending rows [0.02ms]
+(pass) computeOrphanContainersToReap (app diff) > does NOT reap a row in 'deleting' (delete job owns teardown) [0.03ms]
+(pass) computeOrphanContainersToReap (app diff) > ignores containers that do not match the app- pattern [0.01ms]
+(pass) computeOrphanContainersToReap (app diff) > mixed fleet: reaps only the orphans, leaves live + non-app alone [0.03ms]
+(pass) computeOrphanContainersToReap (app diff) > does NOT reap a name with a running AND a stopped row — running order [0.01ms]
+(pass) computeOrphanContainersToReap (app diff) > does NOT reap a name with a stopped AND a running row — reversed order
+(pass) computeOrphanContainersToReap (app diff) > does NOT reap when ANY of several rows is non-terminal (running last) [0.02ms]
+(pass) computeOrphanContainersToReap (app diff) > reaps a name when EVERY row is terminal (multiple terminal rows) [0.01ms]
+(pass) computeOrphanContainersToReap (app diff) > reaps a name with NO rows as no_db_row [0.01ms]
+(pass) reconcileOrphanContainers (app orchestration) > force-removes every orphan on a healthy node — BY ID, not name [0.30ms]
+[app-orphan-reconciler] Skipping node: container listing failed {
+  nodeId: "node-1",
+  hostname: "host-1",
+}
+(pass) reconcileOrphanContainers (app orchestration) > SKIPS a node whose container listing failed — never reaps on a blind node [0.08ms]
+(pass) reconcileOrphanContainers (app orchestration) > SKIPS a non-healthy node (defensive: caller should pre-filter) [0.07ms]
+[app-orphan-reconciler] Failed to reap orphan container {
+  nodeId: "node-1",
+  hostname: "host-1",
+  containerName: "app-a",
+  key: "app-a",
+  error: "ssh broke",
+}
+(pass) reconcileOrphanContainers (app orchestration) > counts a failed removal as reapFailed without aborting the rest [0.16ms]
+(pass) reconcileOrphanContainers (app orchestration) > does not query the DB when a node has no app- containers [0.04ms]
+
+src/lib/services/provisioning-worker-health.test.ts:
+(pass) provisioning worker health (Redis heartbeat) > returns unhealthy when no heartbeat has been published [0.30ms]
+(pass) provisioning worker health (Redis heartbeat) > returns healthy after the daemon publishes a heartbeat [0.15ms]
+(pass) provisioning worker health (Redis heartbeat) > returns not-required when the env flag is off [0.10ms]
+(pass) provisioning worker health (Redis heartbeat) > publish returns false when redis is not configured [0.03ms]
+(pass) provisioning worker health (Redis heartbeat) > uses a stable redis key for observability
+
+src/lib/services/signup-grant-guard.test.ts:
+(pass) runWithSignupGrantIpCap (anti-sybil free-grant cap) > falls open and runs the grant without a transaction when no IP is known [0.07ms]
+(pass) runWithSignupGrantIpCap (anti-sybil free-grant cap) > acquires a per-IP advisory xact lock before counting [0.42ms]
+(pass) runWithSignupGrantIpCap (anti-sybil free-grant cap) > passes the lock-holding transaction to the grant callback for known IPs [0.06ms]
+(pass) runWithSignupGrantIpCap (anti-sybil free-grant cap) > grants below the cap and withholds once it is reached [0.19ms]
+(pass) runWithSignupGrantIpCap (anti-sybil free-grant cap) > two concurrent same-IP attempts cannot both pass the cap (TOCTOU) [0.12ms]
+(pass) runWithSignupGrantIpCap (anti-sybil free-grant cap) > a grant failure propagates (no swallow) and is not counted as committed [0.08ms]
+
+src/lib/services/provisioning-jobs-downgrade.test.ts:
+(pass) agent_downgrade job wiring (#9964) > AGENT_DOWNGRADE is registered and in the agent lane [0.70ms]
+(pass) agent_downgrade job wiring (#9964) > readAgentDowngradeJobData accepts well-formed data [0.07ms]
+(pass) agent_downgrade job wiring (#9964) > rejects missing/wrong-typed required fields [0.10ms]
+
+src/lib/services/eliza-agent-config.test.ts:
+(pass) stripReservedElizaConfigKeys > removes any __agent* key (case-insensitive), keeps the rest [0.09ms]
+(pass) character ownership > withReusedElizaCharacterOwnership strips forgeries then sets the flag [0.03ms]
+(pass) managed Discord binding round-trip > write then read returns the normalized binding [0.08ms]
+(pass) managed Discord binding round-trip > read returns null when required fields are missing [0.01ms]
+
+src/lib/services/user-mcps.test.ts:
+(pass) userMcpsService.create > creates a draft MCP with the supplied fields and computed shares [0.40ms]
+(pass) userMcpsService.create > rejects a duplicate slug within the same organization [0.09ms]
+(pass) userMcpsService.create > allows the same slug in a different organization [0.04ms]
+(pass) userMcpsService.getById > returns the row for an existing MCP [0.09ms]
+(pass) userMcpsService.getById > returns null for an unknown id [0.02ms]
+(pass) userMcpsService.listByOrganization > lists only the organization's own MCPs [0.11ms]
+(pass) userMcpsService.listByOrganization > filters by status [0.22ms]
+(pass) userMcpsService.listPublic > only returns live + public MCPs [0.10ms]
+(pass) userMcpsService.listPublic > filters by category and search term [0.10ms]
+(pass) userMcpsService.update > updates allowed fields and recomputes the share split [0.14ms]
+(pass) userMcpsService.update > rejects updates from a different organization [0.05ms]
+(pass) userMcpsService.update > throws for a missing MCP [0.02ms]
+(pass) userMcpsService.publish > moves a valid MCP to live and stamps published_at [0.03ms]
+(pass) userMcpsService.publish > rejects publishing an MCP with no tools [0.03ms]
+(pass) userMcpsService.publish > rejects publishing an external MCP without an endpoint [0.03ms]
+(pass) userMcpsService.publish > rejects publishing from a different organization [0.20ms]
+(pass) userMcpsService.unpublish > moves a live MCP back to draft (disabled in the registry) [0.13ms]
+(pass) userMcpsService.delete > removes the MCP [0.11ms]
+(pass) userMcpsService.delete > rejects deletion from a different organization [0.04ms]
+(pass) userMcpsService.delete > throws for a missing MCP [0.03ms]
+(pass) userMcpsService.toRegistryFormat > projects a live MCP into the public catalog shape [0.11ms]
+
+src/lib/services/stripe-connect-payout.test.ts:
+(pass) createConnectOnboarding (#8922) > creates an Express account + onboarding link on first onboard [0.16ms]
+(pass) createConnectOnboarding (#8922) > reuses an existing account (no new account created) [0.04ms]
+(pass) usdToStripeCents > rounds USD to integer cents [0.03ms]
+(pass) usdToStripeCents > rejects non-positive / non-finite amounts [0.04ms]
+(pass) transferToConnectAccount (#8922) > transfers cents to the connected account with an idempotency key [0.07ms]
+(pass) transferToConnectAccount (#8922) > rejects an invalid amount before calling Stripe [0.04ms]
+(pass) connectStatusFromCapabilities > maps capability flags to a status [0.02ms]
+(pass) mapConnectWebhookEvent (#8922) > advances payout status on transfer.created / payout.paid [0.03ms]
+(pass) mapConnectWebhookEvent (#8922) > refreshes account status on account.updated [0.01ms]
+(pass) mapConnectWebhookEvent (#8922) > ignores unrelated event types
+(pass) migration 0150 (#8922) > creates the table + enum and is registered in the journal [0.51ms]
+
+src/lib/services/admin-moderation-iac.test.ts:
+[Admin] Recorded moderation violation {
+  userId: "user-1",
+  categories: [ "spam" ],
+  action: "refused",
+}
+(pass) moderation auto-suspension invalidates IAC > crossing into a blocking state (4 -> 5 violations) drops the user's IAC [1.77ms]
+[Admin] Recorded moderation violation {
+  userId: "user-1",
+  categories: [ "spam" ],
+  action: "refused",
+}
+(pass) moderation auto-suspension invalidates IAC > an already-blocking user does not re-invalidate (transition-only) [0.06ms]
+[Admin] Recorded moderation violation {
+  userId: "user-1",
+  categories: [ "spam" ],
+  action: "refused",
+}
+(pass) moderation auto-suspension invalidates IAC > a violation below the blocking threshold does not invalidate [0.04ms]
+[Admin] Recorded moderation violation {
+  userId: "user-1",
+  categories: [ "spam" ],
+  action: "refused",
+}
+(pass) moderation auto-suspension invalidates IAC > a brand-new violator (no prior row) does not invalidate [0.03ms]
+
+src/lib/services/inference-auth-context.test.ts:
+(pass) extractApiKeyCredential > reads X-API-Key [0.65ms]
+(pass) extractApiKeyCredential > reads eliza_* bearer [0.03ms]
+(pass) extractApiKeyCredential > rejects non-eliza bearer (JWT) [0.02ms]
+(pass) extractApiKeyCredential > rejects when wallet headers present (fail-closed, not cacheable) [0.03ms]
+(pass) extractApiKeyCredential > returns null with no credential [0.02ms]
+(pass) resolveInferenceAuthContext > non-API-key request -> slow_path [0.14ms]
+(pass) resolveInferenceAuthContext > miss -> runs authoritative chain, authorizes, and caches [0.39ms]
+(pass) resolveInferenceAuthContext > warm hit -> served from cache, no authoritative chain call [0.09ms]
+(pass) resolveInferenceAuthContext > suspended user -> never cached, returns suspended [0.06ms]
+(pass) resolveInferenceAuthContext > auth failure propagates (never fail-open) [0.08ms]
+(pass) resolveInferenceAuthContext > invalidation clears the cached entry [0.06ms]
+(pass) isInferenceAuthContext shape guard > rejects wrong version / partial shapes [0.02ms]
+
+src/lib/services/eliza-sandbox-create-idempotency.test.ts:
+(pass) ElizaSandboxService.createAgent — opt-in org reuse guard > (a) two reuse-flagged creates for one org collapse to the same agent — 2nd is idempotent, no 2nd insert [31.41ms]
+(pass) ElizaSandboxService.createAgent — opt-in org reuse guard > (b) a create for a DIFFERENT org still mints a distinct agent [0.08ms]
+(pass) ElizaSandboxService.createAgent — opt-in org reuse guard > (c) an org whose only agent is terminal creates a fresh one (guard filters to non-terminal) [0.40ms]
+(pass) ElizaSandboxService.createAgent — opt-in org reuse guard > multi-agent path (flag unset) bypasses the guard and always inserts via the repository [0.08ms]
+
+src/lib/services/phone-gateway-devices.test.ts:
+(pass) registerPhoneGatewayDevice > upserts a shared gateway device by provider, phone number, and bridge id [13.47ms]
+(pass) registerPhoneGatewayDevice > repairs the gateway table on first use when the migration is missing [0.54ms]
+
+src/lib/services/orphan-container-reconciler.test.ts:
+(pass) shared diff — UNIQUE-key mode (agent, group-by-key ≡ last-write-wins) > status=undefined → matches single-status check [0.07ms]
+(pass) shared diff — UNIQUE-key mode (agent, group-by-key ≡ last-write-wins) > status=running → matches single-status check [0.02ms]
+(pass) shared diff — UNIQUE-key mode (agent, group-by-key ≡ last-write-wins) > status=stopped → matches single-status check
+(pass) shared diff — UNIQUE-key mode (agent, group-by-key ≡ last-write-wins) > status=error → matches single-status check
+(pass) shared diff — UNIQUE-key mode (agent, group-by-key ≡ last-write-wins) > status=pending → matches single-status check
+(pass) shared diff — UNIQUE-key mode (agent, group-by-key ≡ last-write-wins) > distinct unique keys are decided independently [0.03ms]
+(pass) shared diff — DUPLICATE-key mode (app, #9307 every-terminal fail-safe) > ANY non-terminal row among duplicates protects the key (both orders) [0.04ms]
+(pass) shared diff — DUPLICATE-key mode (app, #9307 every-terminal fail-safe) > reaps only when EVERY duplicate row is terminal [0.02ms]
+
+src/lib/services/inference-hot-path-benchmark.test.ts:
+(pass) inference hot-path benchmark > cold miss pays the authoritative chain exactly once, then caches [0.40ms]
+(pass) inference hot-path benchmark > WARM hit = exactly 1 cache read, 0 writes, 0 auth, 0 moderation [0.17ms]
+(pass) inference hot-path benchmark > N warm hits stay O(1) cache reads each (no per-request DB growth) [0.30ms]
+
+src/lib/services/pairing-token.test.ts:
+(pass) getAlternateDomainOrigins > returns every other suffix in the same alias group [0.18ms]
+(pass) getAlternateDomainOrigins > rewrites the suffix while keeping the agent UUID prefix intact [0.04ms]
+(pass) getAlternateDomainOrigins > rejects retired 0xSolace-era domains (example.ai, shad0w.xyz) [0.01ms]
+(pass) getAlternateDomainOrigins > preserves the URL port when an origin includes one [0.02ms]
+(pass) getAlternateDomainOrigins > rewrites only the suffix when the prefix is itself a multi-level subdomain [0.02ms]
+(pass) getAlternateDomainOrigins > returns an empty array when no aliased suffix matches [0.01ms]
+(pass) getAlternateDomainOrigins > returns an empty array for unparseable input rather than throwing [0.06ms]
+(pass) getAlternateDomainOrigins > matches uppercase hostnames (URL parser lowercases per WHATWG spec) [0.03ms]
+(pass) getAlternateDomainOrigins > matches the suffix on the right boundary (no partial-domain false positive)
+(pass) DOMAIN_ALIAS_GROUPS > declares the rebrand-target domain `.elizacloud.ai` so the suffix matches
+(pass) DOMAIN_ALIAS_GROUPS > uses leading-dot suffixes so subdomain matching is anchored [0.01ms]
+
+src/lib/services/provisioning-jobs-per-job-timeout.test.ts:
+(pass) PER_JOB_TIMEOUT_MS sizing (cold-pull orphaning fix) > outlasts a cold image pull and matches the leaf pull ceiling [0.08ms]
+(pass) PER_JOB_TIMEOUT_MS sizing (cold-pull orphaning fix) > a create/pull longer than the OLD ceiling completes without timing out under the new ceiling [161.64ms]
+(pass) PER_JOB_TIMEOUT_MS sizing (cold-pull orphaning fix) > a genuinely-hung create still times out [303.83ms]
+
+src/lib/services/app-credit-math.test.ts:
+(pass) computePurchaseSplit > applies platform fee then creator share when monetized [0.06ms]
+(pass) computePurchaseSplit > platform fee never exceeds the purchase [0.01ms]
+(pass) computePurchaseSplit > monetization off → no fee, no creator earnings, full credits [0.01ms]
+(pass) computeInferenceCharge > adds creator markup to base cost when monetized [0.02ms]
+(pass) computeInferenceCharge > monetization off → user pays base cost only, creator earns nothing
+(pass) computeReconciliation > scales an estimate→actual delta by the markup multiplier [0.02ms]
+(pass) computeReconciliation > a negative delta (over-charged) yields a signed refund
+(pass) computeReconciliation > monetization off → delta is base-cost only
+
+src/lib/services/agent-backup-diff.test.ts:
+(pass) diffBackupState / applyBackupDelta round-trip > identity [0.11ms]
+(pass) diffBackupState / applyBackupDelta round-trip > file added [0.02ms]
+(pass) diffBackupState / applyBackupDelta round-trip > file changed
+(pass) diffBackupState / applyBackupDelta round-trip > file removed
+(pass) diffBackupState / applyBackupDelta round-trip > config added/changed/removed [0.04ms]
+(pass) diffBackupState / applyBackupDelta round-trip > nested config value change [0.01ms]
+(pass) diffBackupState / applyBackupDelta round-trip > memory append
+(pass) diffBackupState / applyBackupDelta round-trip > memory rebase (prefix diverged)
+(pass) diffBackupState / applyBackupDelta round-trip > memory truncation
+(pass) diffBackupState / applyBackupDelta round-trip > everything at once
+(pass) diff structure > append uses base count + tail, not a rebase [0.02ms]
+(pass) diff structure > rebase carries full log with base count 0 [0.01ms]
+(pass) diff structure > identity diff is empty [0.02ms]
+(pass) diff structure > key insertion order does not produce a spurious config diff [0.01ms]
+(pass) reconstructFromChain > replays a base full backup + N incrementals exactly [0.06ms]
+(pass) reconstructFromChain > empty chain returns the base
+(pass) computeStateHash > is stable across key ordering [0.09ms]
+(pass) computeStateHash > changes when content changes [0.03ms]
+(pass) planIncrementalBackup > chooses incremental for a tiny change on a large base [0.08ms]
+(pass) planIncrementalBackup > chooses full when the change rewrites most of the state [0.03ms]
+(pass) planIncrementalBackup > forces full once the chain is too deep [0.01ms]
+(pass) planIncrementalBackup > forces full when a full-agent manifest is present [0.03ms]
+(pass) backup chains > resolveBackupChain returns base→target oldest-first [0.06ms]
+(pass) backup chains > incrementalChainDepth counts incrementals above the base [0.02ms]
+(pass) backup chains > resolveBackupChain throws on a broken chain [0.05ms]
+(pass) backup chains > resolveBackupChain throws on a cycle [0.02ms]
+(pass) backup chains > selectPrunableBackupIds keeps ancestors of a retained incremental [0.06ms]
+(pass) backup chains > selectPrunableBackupIds prunes an old standalone full a retained chain doesn't need [0.02ms]
+(pass) backup chains > selectPrunableBackupIds never strands an incremental's base
+(pass) backup chains > selectPrunableBackupIds returns nothing when under the keep count
+
+src/lib/services/provisioning-jobs-delete-enqueue.test.ts:
+(pass) enqueueAgentDeleteOnce.beforeInsert — cancels other pending jobs > marks the agent's non-delete pending/in_progress jobs cancelled [116.20ms]
+(pass) enqueueScheduledBackups — only reachable agents > query requires bridge_url IS NOT NULL (idle agents are never enqueued) [0.28ms]
+(pass) enqueueScheduledBackups — only reachable agents > a due, reachable agent is enqueued for an auto snapshot [0.08ms]
+(pass) reEnqueueFailedDeletions — recover stuck deletion_failed rows > re-enqueues agent_delete for each old deletion_failed row [0.26ms]
+[provisioning-jobs] re-enqueue of failed deletion failed {
+  agentId: "a1",
+  error: "node still down",
+}
+(pass) reEnqueueFailedDeletions — recover stuck deletion_failed rows > an enqueue throw on one row is counted, the rest still process [0.16ms]
+[provisioning-jobs] deletion abandoned — exceeded re-enqueue budget {
+  event: "deletion.abandoned_candidate",
+  agentId: "a2",
+  orgId: "o2",
+  errorCount: 5,
+  maxReEnqueues: 5,
+}
+(pass) reEnqueueFailedDeletions — recover stuck deletion_failed rows > circuit-breaker: a row past the re-enqueue budget is abandoned, not re-armed [0.08ms]
+[provisioning-jobs] deletion abandoned — exceeded re-enqueue budget {
+  event: "deletion.abandoned_candidate",
+  agentId: "a1",
+  orgId: "o1",
+  errorCount: 2,
+  maxReEnqueues: 2,
+}
+(pass) reEnqueueFailedDeletions — recover stuck deletion_failed rows > circuit-breaker threshold is configurable via maxReEnqueues [0.07ms]
+
+src/lib/services/provisioning-jobs-delete-lifecycle.test.ts:
+(pass) ProvisioningJobService — Agent-not-found is a terminal no-op > suspend: completes (no-op) and never increments attempts [0.86ms]
+(pass) ProvisioningJobService — Agent-not-found is a terminal no-op > resume: completes (no-op) and never increments attempts [0.11ms]
+(pass) ProvisioningJobService — Agent-not-found is a terminal no-op > sleep: completes (no-op) and never increments attempts [0.08ms]
+(pass) ProvisioningJobService — Agent-not-found is a terminal no-op > wake: completes (no-op) and never increments attempts [0.08ms]
+(pass) ProvisioningJobService — Agent-not-found is a terminal no-op > restart: completes (no-op) and never increments attempts [0.08ms]
+(pass) ProvisioningJobService — Agent-not-found is a terminal no-op > snapshot: completes (no-op) and never increments attempts [0.11ms]
+(pass) ProvisioningJobService — auto snapshot of an idle agent is a terminal SKIP > auto + 'Sandbox is not running' → completed-as-skipped, no retry [0.09ms]
+(pass) ProvisioningJobService — auto snapshot of an idle agent is a terminal SKIP > auto + snapshot-endpoint-unsupported (V2 image 404) → completed-as-skipped, no retry [0.06ms]
+(pass) ProvisioningJobService — auto snapshot of an idle agent is a terminal SKIP > manual + 'Sandbox is not running' → still errors (the user asked for it) [0.18ms]
+
+src/lib/services/cloudflare-registrar.test.ts:
+(pass) cloudflareRegistrarService production stub guard > refuses the stub in production before any registrar work happens [0.41ms]
+(pass) cloudflareRegistrarService production stub guard > still serves the stub outside production (dev/test) [0.10ms]
+
+src/lib/services/eliza-sandbox-dedicated-bootstrap.test.ts:
+(pass) ElizaSandboxService bridge — dedicated bootstrap window > serves message.send via the shared runtime while the container provisions [2.13ms]
+(pass) ElizaSandboxService bridge — dedicated bootstrap window > status.get reports ready during the bootstrap window [0.11ms]
+[agent-sandbox] Bridge call to non-running sandbox {
+  agentId: "e06bb509-6c52-4c33-a9f7-66addc43e8c8",
+  method: "message.send",
+}
+(pass) ElizaSandboxService bridge — dedicated bootstrap window > does NOT hijack an established dedicated agent that is merely stopped [0.10ms]
+
+src/lib/services/docker-sandbox-utils.test.ts:
+(pass) shellQuote > wraps in single quotes and neutralizes embedded quotes [11.77ms]
+(pass) validateAgentId / validateContainerName > rejects shell metacharacters, control chars, and overflow [0.26ms]
+(pass) validateAgentId / validateContainerName > container name must start alphanumeric and stay shell-safe [0.06ms]
+(pass) validateEnvKey / validateEnvValue > keys must be identifier-shaped [0.06ms]
+(pass) validateEnvKey / validateEnvValue > values reject control chars (newline-injected payloads) [0.11ms]
+(pass) validateVolumePath > requires absolute, normalized, traversal-free paths [0.11ms]
+(pass) getContainerName / getVolumePath > derive deterministic, validated names from agent id [0.03ms]
+(pass) architecture inference > normalizes arch aliases [0.03ms]
+(pass) architecture inference > Hetzner CAX → arm64, CX/CPX/CCX → amd64 [0.02ms]
+(pass) architecture inference > platform requirement + compatibility [0.03ms]
+(pass) dockerPlatformFlag > empty → no flag, valid → quoted flag, invalid → throws [0.05ms]
+(pass) extractDockerCreateContainerId > picks the hex id line, ignores warnings, truncates to 12 [0.12ms]
+(pass) steward url + host gateway routing > loopback host rewrites to host.docker.internal, override wins [0.12ms]
+(pass) steward url + host gateway routing > requiresDockerHostGateway only for host.docker.internal [0.02ms]
+(pass) port + metadata helpers > allocatePort stays in range and avoids the exclusion set [0.09ms]
+(pass) port + metadata helpers > readDockerHostPortFromMetadata returns positive ints only [0.03ms]
+
+src/lib/services/inference-auth-lifecycle.test.ts:
+(pass) UsersService — IAC invalidation on lifecycle > update with is_active=false evicts the user's cached key hashes [0.94ms]
+(pass) UsersService — IAC invalidation on lifecycle > update without an is_active=false transition does NOT invalidate [0.18ms]
+(pass) UsersService — IAC invalidation on lifecycle > delete resolves the key hashes BEFORE deleting the row [0.22ms]
+(pass) UsersService — IAC invalidation on lifecycle > delete invalidation is best-effort: a cache/db failure does not throw [0.19ms]
+(pass) OrganizationsService — IAC invalidation on lifecycle > update with is_active=false evicts the org's cached key hashes [0.23ms]
+(pass) OrganizationsService — IAC invalidation on lifecycle > update without an is_active=false transition does NOT invalidate [0.04ms]
+(pass) OrganizationsService — IAC invalidation on lifecycle > delete resolves the key hashes BEFORE the delete cascade [0.07ms]
+
+src/lib/services/provisioning-jobs-recovery.test.ts:
+(pass) processDisconnectedRecovery > reachable → recovered (no re-provision); unreachable → re-provision; gone → skipped [0.37ms]
+(pass) processDisconnectedRecovery > empty list → no work, no enqueue [0.06ms]
+[provisioning-jobs] disconnected recovery failed {
+  agentId: "a1",
+  error: "probe blew up",
+}
+(pass) processDisconnectedRecovery > a throw on one agent is counted failed; the rest still process [0.12ms]
+
+src/db/crypto/crypto.test.ts:
+(pass) field-crypto > encrypt/decrypt round-trips a UTF-8 string [0.82ms]
+(pass) field-crypto > AAD mismatch causes decrypt to fail [0.14ms]
+(pass) field-crypto > blindIndex is deterministic for the same input [0.13ms]
+(pass) field-crypto > blindIndex purposes are domain-separated [0.04ms]
+(pass) normalization > email is case- and whitespace-insensitive [0.02ms]
+(pass) normalization > phone strips formatting [0.03ms]
+(pass) normalization > wallet lowercases EVM but not Solana [0.02ms]
+(pass) blind-index lookups > email lookup matches across case/whitespace variants [0.03ms]
+(pass) blind-index lookups > phone lookup matches across formatting [0.06ms]
+(pass) blind-index lookups > wallet lookup is case-insensitive for EVM [0.04ms]
+(pass) api-keys crypto (D-1) > encrypt/decrypt round-trips the plaintext key [0.06ms]
+(pass) api-keys crypto (D-1) > a different row id cannot decrypt the ciphertext (AAD bound) [0.06ms]
+(pass) user-field crypto (D-3) > round-trips email and phone [0.08ms]
+(pass) user-field crypto (D-3) > cross-column decrypt fails (AAD bound) [0.05ms]
+(pass) platform-credentials crypto (D-3) > round-trips platform_user_id and platform_email [0.08ms]
+(pass) conversation crypto (D-3) > round-trips content with row-binding AAD [0.07ms]
+
+src/db/repositories/jobs.test.ts:
+(pass) prepareJobInsertData > preserves appId inline when job data is offloaded [1.24ms]
+
+src/db/repositories/anonymous-sessions.test.ts:
+(pass) AnonymousSessionsRepository free-message reservations > reserves a message slot atomically at the configured limit [7.48ms]
+(pass) AnonymousSessionsRepository free-message reservations > refunds a reserved slot without underflowing the counter [3.47ms]
+
+src/db/repositories/agent-sandboxes.test.ts:
+(pass) AgentSandboxesRepository > allows sleeping agents to take the provisioning lock for wake [29.40ms]
+(pass) AgentSandboxesRepository > provisioning lock admits a running row ONLY when it has no container (re-provision unblock) [0.20ms]
+(pass) AgentSandboxesRepository > heartbeat selection excludes shared-runtime agents (no container to dial) [0.18ms]
+(pass) AgentSandboxesRepository > marks only orphaned user-owned pending rows with no provision job as error [0.24ms]
+(pass) AgentSandboxesRepository > fleet-upgrade candidates exclude containerless (shared-runtime) agents [0.14ms]
+(pass) AgentSandboxesRepository > backup inserts encrypt state_data at rest and hydration returns plaintext [0.66ms]
+(pass) AgentSandboxesRepository > backup metadata listing does not hydrate encrypted state payloads [0.12ms]
+
+src/db/repositories/shared-runtime-history.test.ts:
+(pass) SharedRuntimeHistoryRepository.deleteByAgent > deletes every channel row for the agent and returns the count [1.01ms]
+
+src/db/schemas/organizations.test.ts:
+(pass) #8427 organizations zero-balance default > credit_balance defaults to 0, not a give-away [0.05ms]
+(pass) #8427 organizations zero-balance default > a non-negative credit_balance CHECK constraint is present [0.02ms]
+
+src/db/__tests__/client-tls.test.ts:
+(pass) shouldSkipTlsVerification > default (no flag, no sslmode) keeps strict verification [66.98ms]
+(pass) shouldSkipTlsVerification > ?sslmode=no-verify opts out of verification (e.g. Railway self-signed proxy) [0.06ms]
+(pass) shouldSkipTlsVerification > DATABASE_SSL_NO_VERIFY=true opts out regardless of URL [0.05ms]
+(pass) shouldSkipTlsVerification > any other DATABASE_SSL_NO_VERIFY value stays strict [0.01ms]
+(pass) enforceTlsForRemote > local connections run without TLS (ssl undefined, url untouched) [0.17ms]
+(pass) enforceTlsForRemote > remote default normalizes sslmode=require and verifies the cert [1.92ms]
+(pass) enforceTlsForRemote > remote ?sslmode=no-verify relaxes CA verification but keeps TLS [0.11ms]
+(pass) enforceTlsForRemote > DATABASE_SSL_NO_VERIFY=true relaxes verification on a bare remote URL [0.05ms]
+(pass) enforceTlsForRemote > fails closed on a remote URL that disables TLS [0.10ms]
+
+src/lib/eliza/runtime/stable-serialize.test.ts:
+(pass) stableSerialize > serializes object keys in deterministic order [107.09ms]
+(pass) stableSerialize > serializes nested arrays and objects while preserving array order [0.21ms]
+(pass) stableSerialize > omits undefined object fields but serializes array undefined slots as null [0.05ms]
+(pass) stableSerialize > serializes Date values explicitly instead of collapsing them to empty objects [0.02ms]
+(pass) stableSerialize > rejects non-plain objects that would otherwise collide [0.27ms]
+(pass) stableSerialize > rejects circular arrays and objects with a deterministic error [0.20ms]
+
+src/lib/cache/__tests__/client-mock.test.ts:
+(pass) CacheClient (MOCK_REDIS=1) > set + get round-trip via in-memory adapter [47.26ms]
+
+src/lib/cache/__tests__/client-worker-rest.test.ts:
+(pass) CacheClient in Worker envs > uses Upstash REST bindings for durable shared-runtime history [18.87ms]
+
+src/lib/cache/__tests__/redis-factory-mock.test.ts:
+(pass) buildRedisClient (MOCK_REDIS=1) > returns an in-memory MockSocketRedis that supports round-trip [1.59ms]
+(pass) hasRedisConfig > mirrors buildRedisClient resolution (incl. TCP REDIS_URL) [0.13ms]
+
+src/lib/email/utils/template-renderer.test.ts:
+(pass) email template renderer > renders the low-credits email with interpolated data (no fs access) [1.03ms]
+(pass) email template renderer > renders the welcome email (bundled template, no fs access) [0.09ms]
+(pass) email template renderer > every template id resolves to a non-empty bundled string [0.06ms]
+
+src/lib/services/erc8004/identity-client.test.ts:
+(pass) ERC8004IdentityClient > register returns agentId parsed from Registered event [16.77ms]
+(pass) ERC8004IdentityClient > reads ownerOf [0.08ms]
+(pass) ERC8004IdentityClient > URI read/write round-trip [0.08ms]
+
+src/lib/services/social-media/token-refresh.expiry.test.ts:
+(pass) isTokenExpired (5-min refresh buffer) > treats a token with no expiry as not expired [0.04ms]
+(pass) isTokenExpired (5-min refresh buffer) > is NOT expired comfortably outside the buffer window [0.02ms]
+(pass) isTokenExpired (5-min refresh buffer) > IS expired once inside the 5-min buffer (refresh early)
+(pass) isTokenExpired (5-min refresh buffer) > IS expired for an already-past expiry
+
+src/lib/services/oauth/provider-registry.test.ts:
+(pass) provider lookup > getProvider is case-insensitive; isValidProvider matches the registry [0.09ms]
+(pass) getAllowedScopes / resolveRequestedScopes > allowed scopes fall back default → allowed, normalized + deduped [0.09ms]
+(pass) getAllowedScopes / resolveRequestedScopes > empty request → default scopes; valid request passes; invalid THROWS [0.13ms]
+(pass) getCallbackUrl / getNestedValue > generic callback URL is built from the base + provider id [0.02ms]
+(pass) getCallbackUrl / getNestedValue > getNestedValue walks dot paths and is null-safe [0.05ms]
+
+src/lib/services/oauth/provider-alignment.test.ts:
+(pass) core OAuthProvider ⊆ cloud OAuth registry > every cloud-serviced core provider exists in the cloud registry [0.91ms]
+(pass) core OAuthProvider ⊆ cloud OAuth registry > github (the #8909 ask) is aligned across both layers [0.05ms]
+(pass) core OAuthProvider ⊆ cloud OAuth registry > the previously-missing providers (notion, slack) are aligned [0.09ms]
+(pass) core OAuthProvider ⊆ cloud OAuth registry > connector-native exceptions are a subset of the core enum [0.03ms]
+
+src/lib/services/ai-pricing/openrouter-fallback.test.ts:
+(pass) maps a language model's prices to per-token input/output fallback rows [13.45ms]
+(pass) excludes non-language models and unpriced models [0.03ms]
+(pass) fetchOpenRouterCatalogEntries parses a catalog payload (fetch mocked) [0.25ms]
+[AI Pricing] OpenRouter catalog fetch error (non-fatal) {
+  error: "network down",
+}
+(pass) fetchOpenRouterCatalogEntries is non-fatal when OpenRouter is unreachable [0.11ms]
+
+src/lib/services/ai-pricing/cache.test.ts:
+(pass) negative-caches a failing loader — subsequent lookups skip the re-fetch [12.82ms]
+(pass) caches a successful loader result — loader runs once [0.07ms]
+(pass) persisted: caches a successful DB read — loader runs once within TTL [0.09ms]
+(pass) persisted: does NOT negative-cache a DB error — the next call retries [0.05ms]
+(pass) persisted: distinct keys cache independently (no cross-key bleed) [0.06ms]
+
+src/lib/services/ai-pricing/lookup-missing-pricing.test.ts:
+ai-pricing: input pricing unavailable; billing input at $0 {
+  canonicalModel: "someprovider/totally-uncatalogued-model",
+  provider: "someprovider",
+  billingSource: undefined,
+}
+(pass) missing input pricing degrades to $0 instead of throwing a 500 [14.38ms]
+ai-pricing: input pricing unavailable; billing input at $0 {
+  canonicalModel: "someprovider/uncatalogued-embedding-model",
+  provider: "someprovider",
+  billingSource: undefined,
+}
+(pass) missing input pricing for an input-only embedding model does not throw [0.11ms]
+
+src/lib/services/ai-pricing/dimensions.test.ts:
+(pass) markup math > decimalToMoney rounds to 6 dp; applyPlatformMarkup adds the platform markup [12.81ms]
+(pass) dimensions > normalize is order-independent and drops undefined; key collapses empty to '*' [0.17ms]
+(pass) dimensions > subset check + source priority [0.05ms]
+(pass) canonical model id > keeps slashed ids, prepends provider, handles special providers [0.02ms]
+(pass) canonical model id > inferProviderFromCanonicalModel reads the prefix [0.02ms]
+
+src/lib/services/proxy/cors.test.ts:
+(pass) isAppOrigin > matches the app WebView + local-dev origins, rejects look-alikes [0.05ms]
+(pass) getCorsHeaders > app origin → reflected origin + credentials + Vary: Origin [0.06ms]
+(pass) getCorsHeaders > app origin → allow-headers includes the X-Eliza* client headers [0.06ms]
+(pass) getCorsHeaders > non-app origin → wildcard, NO credentials [0.02ms]
+(pass) getCorsHeaders > no origin → wildcard (non-browser / API-key caller)
+(pass) handleCorsOptions / applyCorsHeaders > preflight reflects the app origin with credentials [0.06ms]
+(pass) handleCorsOptions / applyCorsHeaders > applyCorsHeaders preserves the body + status and reflects the origin [0.14ms]
+
+src/lib/services/proxy/pricing-fallback.test.ts:
+[Pricing] No pricing records in DB, using fallback {
+  serviceId: "pricing-fallback-test-service",
+  fallback: 0.001,
+}
+[Pricing] Missing DB pricing, using fallback {
+  serviceId: "pricing-fallback-test-service",
+  method: "getPrice",
+  fallback: 0.001,
+}
+(pass) getServiceMethodCost — missing-pricing fallback > returns the $0.001 fail-safe fallback when no DB rows exist [229.50ms]
+[Pricing] No pricing records in DB, using fallback {
+  serviceId: "pricing-fallback-test-service",
+  fallback: 0.001,
+}
+[Pricing] Missing DB pricing, using fallback {
+  serviceId: "pricing-fallback-test-service",
+  method: "getPrice",
+  fallback: 0.001,
+}
+(pass) getServiceMethodCost — missing-pricing fallback > does NOT cache the empty pricing map (so a partial-seed miss self-heals) [0.26ms]
+[Pricing] No pricing records in DB, using fallback {
+  serviceId: "pricing-fallback-test-service",
+  fallback: 0.001,
+}
+[Pricing] Missing DB pricing, using fallback {
+  serviceId: "pricing-fallback-test-service",
+  method: "getPrice",
+  fallback: 0.001,
+}
+(pass) getServiceMethodCost — missing-pricing fallback > self-heals once the pricing rows land (no stale empty-map cache) [0.80ms]
+
+src/lib/services/proxy/engine.test.ts:
+(pass) resolveBillableCost > 2xx success without actualCost bills the full reserved cost [0.04ms]
+(pass) resolveBillableCost > 2xx success with a reported actualCost bills that amount [0.01ms]
+(pass) resolveBillableCost > 3xx (response.ok false but <500) bills the reserved cost
+(pass) resolveBillableCost > 502 upstream-down without actualCost refunds to 0 (the regression)
+(pass) resolveBillableCost > 503 circuit-open refunds to 0
+(pass) resolveBillableCost > 500 with an explicit partial actualCost bills only that partial cost [0.01ms]
+(pass) resolveBillableCost > 4xx client error still bills the reserved cost
+(pass) resolveBillableCost > 4xx with a reported actualCost bills that amount
+
+src/lib/services/proxy/refund-on-failure.test.ts:
+(pass) birdeye proxy refund-on-failure > upstream 500 refunds the upfront cost exactly once [0.40ms]
+(pass) birdeye proxy refund-on-failure > upstream 4xx does NOT refund (paid API, customer's bad request) [0.07ms]
+(pass) birdeye proxy refund-on-failure > upstream 200 does NOT refund (successful call) [0.05ms]
+[DexscreenerProxy] upstream non-OK {
+  status: 429,
+  path: "latest/dex/pairs/x",
+}
+(pass) dexscreener proxy refund-on-failure > non-ok upstream refunds the upfront cost exactly once (free upstream) [0.31ms]
+[DexscreenerProxy] upstream non-OK {
+  status: 500,
+  path: "latest/dex/pairs/x",
+}
+(pass) dexscreener proxy refund-on-failure > a 500 upstream also refunds (any non-ok) [0.08ms]
+(pass) dexscreener proxy refund-on-failure > ok upstream does NOT refund [0.05ms]
+
+src/lib/services/eliza-app/onboarding-chat.test.ts:
+(pass) runOnboardingChat > asks for a name before provisioning a trusted phone onboarding session [0.69ms]
+(pass) runOnboardingChat > sends a login link after a trusted phone user provides a preferred name [0.13ms]
+(pass) runOnboardingChat > forces the exact login URL when generated copy rewrites link punctuation [0.18ms]
+(pass) runOnboardingChat > removes markdown punctuation around generated login URLs [0.10ms]
+(pass) runOnboardingChat > removes orphaned markdown lines after replacing generated login URLs [0.06ms]
+(pass) runOnboardingChat > enforces exact starter credit copy before the login URL [0.07ms]
+(pass) runOnboardingChat > forces generated SMS onboarding replies to ASCII text [0.09ms]
+(pass) runOnboardingChat > sanitizes duplicated URL schemes from generated onboarding replies [0.07ms]
+(pass) runOnboardingChat > copies the onboarding transcript into memory once the provisioned agent is running [0.44ms]
+(pass) runOnboardingChat > continues an authenticated phone onboarding session without requiring another message [0.10ms]
+
+src/lib/services/eliza-app/provisioning.test.ts:
+(pass) ensureElizaAppProvisioning > grants starter credits before provisioning a new Eliza App agent [0.41ms]
+(pass) ensureElizaAppProvisioning > reuses an in-flight sandbox without enqueuing a second provision job [0.05ms]
+(pass) ensureElizaAppProvisioning > deletes the just-created sandbox when the provision enqueue throws [0.09ms]
+(pass) ensureElizaAppProvisioning > does not grant duplicate starter credits when an existing transaction is present [0.03ms]
+
+src/lib/services/__tests__/ai-billing-usage.test.ts:
+(pass) normalizeUsage > returns all-zeros for null/undefined [0.73ms]
+(pass) normalizeUsage > maps AI SDK v4 field names [0.02ms]
+(pass) normalizeUsage > maps legacy promptTokens/completionTokens + derives total [0.01ms]
+(pass) normalizeUsage > new field names win over legacy when both are present [0.01ms]
+(pass) normalizeUsage > normalizes both cache-token naming variants [0.02ms]
+
+src/lib/services/__tests__/app-deployments-helpers.test.ts:
+(pass) publicStatusFor > maps draft to DRAFT [0.01ms]
+(pass) publicStatusFor > collapses building and deploying to BUILDING
+(pass) publicStatusFor > maps deployed to READY
+(pass) publicStatusFor > maps failed to ERROR
+(pass) deploymentIdFor > uses ISO timestamp when last_deployed_at is set [0.03ms]
+(pass) deploymentIdFor > uses 0 sentinel when last_deployed_at is null
+(pass) deploymentIdFor > coerces an ISO-string last_deployed_at (cached read) without throwing
+(pass) assertDeployable > throws ApiError(409) when status is building [17.83ms]
+(pass) assertDeployable > does not throw for draft / deployed / failed / deploying [0.04ms]
+(pass) appKindFor / isLocalApp / isRemoteApp (#9145) > draft app with no production_url is local [0.03ms]
+(pass) appKindFor / isLocalApp / isRemoteApp (#9145) > deployed app is remote even if production_url is somehow null
+(pass) appKindFor / isLocalApp / isRemoteApp (#9145) > deployed app with production_url is remote
+(pass) appKindFor / isLocalApp / isRemoteApp (#9145) > building/deploying app with a production_url already assigned is remote
+(pass) appKindFor / isLocalApp / isRemoteApp (#9145) > building/deploying app without a production_url is still local
+(pass) appKindFor / isLocalApp / isRemoteApp (#9145) > failed app is local (no live container, even with a stale url)
+
+src/lib/services/__tests__/docker-port-allocation.test.ts:
+(pass) docker-port-allocation > defines the app container host port range [0.04ms]
+(pass) docker-port-allocation > allocateAppContainerHostPort skips ports already used on the node [0.17ms]
+
+src/lib/services/__tests__/direct-wallet-payments.integration.test.ts:
+(skip) DirectWalletPaymentsService (PGlite integration) > createPayment for BSC native BNB locks price quote and computes wei
+(skip) DirectWalletPaymentsService (PGlite integration) > createPayment for BSC USDT computes usd * 1e18 with no oracle call
+(skip) DirectWalletPaymentsService (PGlite integration) > attachTransaction flips pending -> broadcast and records hash
+(skip) DirectWalletPaymentsService (PGlite integration) > attachTransaction is idempotent on the same hash
+(skip) DirectWalletPaymentsService (PGlite integration) > attachTransaction rejects a different second hash on the same payment
+(skip) DirectWalletPaymentsService (PGlite integration) > confirmPayment (BSC USDT) credits the org and is idempotent on retry
+(skip) DirectWalletPaymentsService (PGlite integration) > confirmPayment rejects amount-too-low; status stays broadcast; no credits
+(skip) DirectWalletPaymentsService (PGlite integration) > BNB native verify accepts within ±2% slippage and rejects below floor
+(skip) DirectWalletPaymentsService (PGlite integration) > BNB native verify rejects below the slippage floor
+(skip) DirectWalletPaymentsService (PGlite integration) > BNB native verify rejects above the slippage ceiling (gross overpayment)
+(skip) DirectWalletPaymentsService (PGlite integration) > confirmPayment rejects a tampered quote_signature without touching the chain
+(skip) DirectWalletPaymentsService (PGlite integration) > processBroadcastBatch bumps verify_attempts and gives up at MAX_VERIFY_ATTEMPTS
+(skip) DirectWalletPaymentsService (PGlite integration) > Solana confirmPayment rejects when receiving ATA owner mismatches treasury
+(skip) DirectWalletPaymentsService (PGlite integration) > processBroadcastBatch confirms a broadcast row when verify succeeds
+(skip) DirectWalletPaymentsService (PGlite integration) > processBroadcastBatch marks failed_chain on terminal verify failure
+(skip) DirectWalletPaymentsService (PGlite integration) > processBroadcastBatch leaves payment in broadcast on transient (not-found) failure
+(skip) DirectWalletPaymentsService (PGlite integration) > BSC promo can only be redeemed once per organization
+(skip) DirectWalletPaymentsService (PGlite integration) > BSC promo guard is org-scoped and ignores non-promo purchases
+(skip) DirectWalletPaymentsService (PGlite integration) > getPaymentStatusForUser refuses to disclose to a different user
+
+src/lib/services/__tests__/payout-fork.integration.test.ts:
+(skip) payout transfer path against anvil forks > (unnamed)
+(skip) payout transfer path against anvil forks > base: ELIZA contract reachable via configured RPC
+(skip) payout transfer path against anvil forks > base: full payout sequence — impersonate holder → transfer → waitForReceipt(confirmations=2)
+(skip) payout transfer path against anvil forks > bnb: ELIZA contract reachable via configured RPC
+(skip) payout transfer path against anvil forks > bnb: full payout sequence — impersonate holder → transfer → waitForReceipt(confirmations=2)
+(skip) payout transfer path against anvil forks > (unnamed)
+
+src/lib/services/__tests__/admin-email.test.ts:
+(pass) isElizaLabsAdminEmail > accepts an @elizalabs.ai email (case-insensitive, trimmed) [0.04ms]
+(pass) isElizaLabsAdminEmail > rejects non-admin + empty inputs [0.01ms]
+(pass) isElizaLabsAdminEmail > rejects look-alike-domain spoofing [0.01ms]
+(pass) getAdminStatusForUser email verification gate > grants super_admin to verified @elizalabs.ai email [0.07ms]
+(pass) getAdminStatusForUser email verification gate > does not grant super_admin to unverified @elizalabs.ai email [0.03ms]
+
+src/lib/services/__tests__/app-deploy-runner-env-dsn-teardown.test.ts:
+Found unencrypted value where encrypted was expected
+(pass) env-DSN deploy mode — per-tenant DB teardown (#8342) > deploy persists app_databases row; delete DROPs the DB and releases the slot [1.72ms]
+(pass) env-DSN deploy mode — per-tenant DB teardown (#8342) > updateState failure after provision triggers a compensating deprovision (no leak) [0.15ms]
+
+src/lib/services/__tests__/container-job-types.test.ts:
+(pass) JOB_TYPES — CONTAINER_* lane > registers every container job type with its wire value [15.64ms]
+(pass) JOB_TYPES — CONTAINER_* lane > container wire values are unique and don't collide with agent values [0.13ms]
+(pass) JOB_TYPES — CONTAINER_* lane > container wire values are snake_case and container-namespaced [0.04ms]
+
+src/lib/services/__tests__/app-deployments.test.ts:
+(pass) AppDeploymentsService > persists deploy-body build hints before enqueueing APP_DEPLOY [0.48ms]
+(pass) AppDeploymentsService > returns startedAt from cached ISO-string deployment timestamps [0.10ms]
+
+src/lib/services/__tests__/provisioning-job-types.test.ts:
+(pass) JOB_TYPES > includes every registered job type [0.03ms]
+(pass) JOB_TYPES > wire values are unique (no two symbols share a string) [0.02ms]
+(pass) JOB_TYPES > wire values are snake_case (matches DB convention) [0.05ms]
+(pass) JOB_TYPES > ProvisioningJobType narrows to the registered set
+
+src/lib/services/__tests__/containers-slot-release-idempotency.test.ts:
+(pass) containersRepository.tryReleaseNodeSlot — idempotency > releases the slot exactly once across a re-run [7.83ms]
+(pass) containersRepository.tryReleaseNodeSlot — idempotency > clamps at 0 — never drives allocated_count negative [1.92ms]
+
+src/lib/services/__tests__/server-wallets.test.ts:
+(pass) server wallet RPC lookup > looks the wallet up globally by client_address + EVM chain, not org-scoped [15.51ms]
+
+src/lib/services/__tests__/app-deployments-options.test.ts:
+(pass) AppDeploymentsService deploy options > passes repo build options to the Worker APP_DEPLOY enqueuer [0.16ms]
+(pass) AppDeploymentsService deploy options > passes repo build options to the direct runner [0.07ms]
+
+src/lib/services/__tests__/user-database-deprovision.test.ts:
+(pass) cleanupDatabase — isolated tenant DB teardown enqueue > enqueues a deprovision job carrying the ENCRYPTED uri (survives cascade-delete) [0.12ms]
+(pass) cleanupDatabase — isolated tenant DB teardown enqueue > no enqueue when the app has no isolated DB [0.04ms]
+Isolated tenant DB not torn down — no backend/enqueuer wired {
+  appId: "app-3",
+  hasEnqueuer: true,
+  hasOrg: false,
+}
+(pass) cleanupDatabase — isolated tenant DB teardown enqueue > no enqueue when the owning org is unknown (can't form the job row) [0.06ms]
+(pass) cleanupDatabase — isolated tenant DB teardown enqueue > no-ops cleanly when there is no database row at all [0.03ms]
+
+src/lib/services/__tests__/analytics-overview.test.ts:
+(pass) AnalyticsService.getOverview > cached loader path returns only derived summary fields [0.42ms]
+(pass) AnalyticsService.getOverview > cache-miss fallback path returns only derived summary fields [0.07ms]
+
+src/lib/services/__tests__/app-container-store.test.ts:
+(pass) mapContainerRowToAppContainerRow > projects columns and carries the per-tenant DSN through env vars [0.08ms]
+(pass) mapContainerRowToAppContainerRow > prefers metadata.appId over project_name when present [0.01ms]
+(pass) mapContainerRowToAppContainerRow > null image_tag becomes empty string [0.01ms]
+(pass) mergeHostPlacementMetadata > preserves existing metadata (e.g. appId) and adds host placement [0.02ms]
+(pass) mergeHostPlacementMetadata > null/undefined existing → just the host placement [0.01ms]
+(pass) toNewContainer > the app's OWN DSN rides in environment_vars; project_name + metadata key off appId [0.02ms]
+
+src/lib/services/__tests__/app-db-ambassador.test.ts:
+(pass) ambassador naming > ambassadorName uses the same 12-char slug as the app container [0.02ms]
+(pass) ambassador naming > ambassadorNameForContainer derives from the app container name [0.02ms]
+(pass) parseDsnEndpoint > extracts host + port from a full DSN [0.06ms]
+(pass) parseDsnEndpoint > defaults the port to 5432 when absent [0.01ms]
+(pass) parseDsnEndpoint > is not fooled by an @ that isn't present (returns null)
+(pass) rewriteDsnToAmbassador > replaces only host:port, preserving user/pass/db/params [0.03ms]
+(pass) rewriteDsnToAmbassador > works when the original DSN omits the port [0.01ms]
+(pass) buildEnsureAmbassadorCmds > rm stale -> run socat to the tenant DB -> attach to the app net [0.07ms]
+(pass) buildEnsureAmbassadorCmds > honors a custom egress network + image [20.14ms]
+(pass) buildRemoveAmbassadorCmdForContainer > removes the ambassador derived from the container name (best-effort) [0.07ms]
+
+src/lib/services/__tests__/credits-reconcile.test.ts:
+(pass) CreditsService.reconcile > refund branch: reserved > actual increases balance by the difference [17.40ms]
+[Credits] Reconciled - charged overage {
+  organizationId: "00000000-0000-0000-0000-0000000000d4",
+  reserved: 0.4,
+  actual: 1,
+  overage: 0.6,
+}
+(pass) CreditsService.reconcile > overage branch (collectable): actual > reserved decreases balance by the overage [189.61ms]
+(pass) CreditsService.reconcile > epsilon/none branch: exact match is a no-op [1.58ms]
+(pass) CreditsService.reconcile > epsilon/none branch: a nonzero sub-EPSILON difference is a no-op (PINS the EPSILON tolerance band) [1.07ms]
+[Credits] Reconciled - overage uncollected {
+  organizationId: "00000000-0000-0000-0000-0000000000d4",
+  reserved: 0,
+  actual: 1,
+  overage: 1,
+  balance: 0.1,
+  reason: "insufficient_balance",
+}
+(pass) CreditsService.reconcile > overage uncollectable: balance below overage is reported explicitly and not charged [3.32ms]
+(pass) CreditsService.reconcile > refund branch: actualCost 0 refunds the ENTIRE reservation (request-failure path) [2.53ms]
+[Credits] Reconciliation retry {
+  attempt: 1,
+  organizationId: "00000000-0000-0000-0000-0000000000d4",
+  error: "simulated transient deduct failure",
+}
+[CreditsService] No billing email for organization {
+  organizationId: "00000000-0000-0000-0000-0000000000d4",
+}
+[Credits] Reconciliation retry {
+  attempt: 2,
+  organizationId: "00000000-0000-0000-0000-0000000000d4",
+  error: "simulated transient deduct failure",
+}
+[Credits] Reconciliation failed after retries {
+  organizationId: "00000000-0000-0000-0000-0000000000d4",
+  reserved: 0.4,
+  actual: 1,
+  difference: -0.6,
+  error: "simulated transient deduct failure",
+}
+(pass) CreditsService.reconcile > overage retry/catch fallback: deductCredits that always THROWS exhausts all retries and reports an uncollected overage without a debit [302.77ms]
+(pass) CreditsService.reconcile > NON-IDEMPOTENT double-settle hazard: settling then a second reconcile(0) refunds AGAIN (the free-generation bug #10278's chargeSettled guard prevents) [4.50ms]
+
+src/lib/services/__tests__/app-cleanup-container.test.ts:
+(pass) stopAppContainers — app-delete container teardown (Blocker #7) > stops metering AND enqueues CONTAINER_DELETE for an app with a container [0.28ms]
+(pass) stopAppContainers — app-delete container teardown (Blocker #7) > tears down every undeleted container row for the app [0.07ms]
+(pass) stopAppContainers — app-delete container teardown (Blocker #7) > is a clean no-op when the app never deployed a container [0.03ms]
+[AppCleanup] Failed to tear down container {
+  appId: "22222222-2222-2222-2222-222222222222",
+  containerId: "bad",
+  error: "db down",
+}
+(pass) stopAppContainers — app-delete container teardown (Blocker #7) > collects a per-container error without aborting the others [0.14ms]
+
+src/lib/services/__tests__/app-database-mode.test.ts:
+(pass) isAppDatabaseMode > accepts the two valid modes only [16.82ms]
+(pass) resolveAppDatabaseMode > defaults to 'none' for missing / empty / malformed metadata [0.09ms]
+(pass) resolveAppDatabaseMode > reads an explicit mode from metadata [0.02ms]
+
+src/lib/services/__tests__/container-billing-idempotency.test.ts:
+(pass) computeContainerBillingPeriod > normalizes to the UTC day regardless of time of day [0.14ms]
+(pass) computeContainerBillingPeriod > is stable across two timestamps on the same UTC day [0.02ms]
+(pass) computeContainerBillingPeriod > rolls to a new period across the UTC midnight boundary [0.01ms]
+(pass) convertToCredits idempotency > same idempotencyKey debits earnings exactly once [8.59ms]
+(pass) convertToCredits idempotency > a different key (next period) debits again [2.63ms]
+(pass) reduceEarnings money-out guard > requireSufficientBalance fails closed without writing when live balance is short [1.94ms]
+(pass) reduceEarnings money-out guard > default reconciliation mode keeps legacy floor-to-zero behavior [2.59ms]
+(pass) container billing gate + row-lock guard > gates by next_billing_at, records -fromCredits, and is idempotent on re-run [6.63ms]
+(pass) container billing gate + row-lock guard > atomic decrement preserves a concurrent debit that lands after the caller's read (no lost update) [2.86ms]
+
+src/lib/services/__tests__/container-jobs-data.test.ts:
+(pass) container-jobs-data codecs > provision round-trips through toRecord -> read [16.35ms]
+(pass) container-jobs-data codecs > delete + restart accept the minimal {containerId, organizationId} [0.07ms]
+(pass) container-jobs-data codecs > upgrade keeps an optional image, logs keeps an optional tail [0.06ms]
+(pass) container-jobs-data codecs > guards reject malformed data [0.02ms]
+(pass) container-jobs-data codecs > read* throws (with the job id) on invalid data [0.09ms]
+
+src/lib/services/__tests__/docker-sandbox-already-gone.test.ts:
+(pass) isAlreadyGoneMessage > recognizes "No such container" (Docker 24) [0.03ms]
+(pass) isAlreadyGoneMessage > recognizes "not found" (older Docker)
+(pass) isAlreadyGoneMessage > recognizes "already gone"
+(pass) isAlreadyGoneMessage > recognizes "no longer exists"
+(pass) isAlreadyGoneMessage > case-insensitive
+(pass) isAlreadyGoneMessage > returns false for SSH connection failure
+(pass) isAlreadyGoneMessage > returns false for Docker daemon down
+(pass) isAlreadyGoneMessage > returns false for permission denied
+(pass) isAlreadyGoneMessage > returns false for empty / unrelated text
+(pass) isAlreadyGoneMessage > stays false for SSH timeout (handled by isNodeUnreachableMessage instead)
+(pass) isNodeUnreachableMessage > recognizes SSH connect timeout [0.02ms]
+(pass) isNodeUnreachableMessage > does NOT classify a per-command timeout as unreachable (reachable-but-slow node)
+(pass) isNodeUnreachableMessage > still classifies a connect timeout as unreachable
+(pass) isNodeUnreachableMessage > recognizes ECONNREFUSED
+(pass) isNodeUnreachableMessage > recognizes no route to host
+(pass) isNodeUnreachableMessage > recognizes ENETUNREACH [0.02ms]
+(pass) isNodeUnreachableMessage > recognizes DNS failure (getaddrinfo)
+(pass) isNodeUnreachableMessage > recognizes generic connection error
+(pass) isNodeUnreachableMessage > is case-insensitive
+(pass) isNodeUnreachableMessage > returns false for a Docker daemon 'No such container' error
+(pass) isNodeUnreachableMessage > returns false for generic / empty text (no 'error'-only match)
+
+src/lib/services/__tests__/x402-app-earnings.test.ts:
+
+# Unhandled error between tests
+-------------------------------
+SyntaxError: Export named 'dbRead' not found in module '/Users/shawwalters/.codex/worktrees/36cd/eliza/packages/cloud/shared/src/db/helpers.ts'.
+-------------------------------
+
+
+src/lib/services/__tests__/container-job-service.test.ts:
+(pass) isContainerJobType > recognizes only the CONTAINER_* types [0.02ms]
+(pass) dispatchContainerJob > routes container_provision to provision [0.37ms]
+(pass) dispatchContainerJob > routes container_delete to delete [0.07ms]
+(pass) dispatchContainerJob > routes container_restart to restart [0.03ms]
+(pass) dispatchContainerJob > routes container_upgrade to provision [0.11ms]
+(pass) dispatchContainerJob > routes container_logs to logs [0.03ms]
+(pass) dispatchContainerJob > throws on a non-container job type [0.04ms]
+(pass) getContainerExecutorDeps / setContainerExecutorDeps > throws until the backend is wired, then returns it [0.04ms]
+(pass) ContainerJobEnqueuer > enqueues each lifecycle verb with the right type + data [0.10ms]
+
+src/lib/services/__tests__/app-firewall-utils.test.ts:
+(pass) buildAppNodeNftablesRules > default-drops the forward chain [0.01ms]
+(pass) buildAppNodeNftablesRules > blocks the cloud metadata endpoint and every RFC1918 range [0.03ms]
+(pass) buildAppNodeNftablesRules > allows established return traffic and the egress proxy
+(pass) buildAppNodeNftablesRules > omits the proxy allow when no proxy ip is given [0.02ms]
+(pass) buildHetznerAppFirewallRules > allows inbound to the host-port range only from control-plane CIDRs [0.04ms]
+
+src/lib/services/__tests__/registry-probe-edges.test.ts:
+(pass) parseImageRef — boundary inputs > whitespace-only tag is currently accepted by the parser [0.08ms]
+(pass) parseImageRef — boundary inputs > tag with leading and trailing dots is accepted as-is [0.02ms]
+(pass) parseImageRef — boundary inputs > repo with a leading slash (double-slash after registry) keeps the slash [0.01ms]
+(pass) parseImageRef — boundary inputs > empty registry host with port (`:8080/foo:bar`) parses without crashing [0.01ms]
+(pass) parseImageRef — boundary inputs > unicode characters in tag are preserved [0.01ms]
+(pass) parseImageRef — boundary inputs > trailing slash with no tag returns null
+(pass) parseImageRef — boundary inputs > digest-style ref (@sha256:...) is not a tag and returns null
+(pass) resolveImageDigest — pathological refs short-circuit safely > `:8080/foo:bar` resolves to null without hitting the network [0.18ms]
+(pass) resolveImageDigest — pathological refs short-circuit safely > whitespace tag on ghcr ref does attempt the fetch (parser is permissive) [0.31ms]
+(pass) clearRegistryProbeCache — multi-ref cache lifecycle > ghcr / docker.io / bare-name entries cache independently and clear together [0.17ms]
+(pass) clearRegistryProbeCache — multi-ref cache lifecycle > re-resolving an already-cached entry never invokes fetch [0.07ms]
+(pass) clearRegistryProbeCache — multi-ref cache lifecycle > negative cache for non-ghcr ref is honored across calls [0.04ms]
+
+src/lib/services/__tests__/docker-ensure-network.test.ts:
+(pass) buildEnsureNetworkCmd > inspects first, creates only if missing [0.07ms]
+(pass) buildEnsureNetworkCmd > re-inspects after create to survive a concurrent create race [0.04ms]
+(pass) buildEnsureNetworkCmd > only ever creates a plain bridge network (no implicit subnet) [0.01ms]
+(pass) buildEnsureNetworkCmd > shell-escapes the network name [0.01ms]
+
+src/lib/services/__tests__/app-factory.test.ts:
+(pass) createApp: template-image wiring (no-repo apps) > template app (createGitHubRepo:false) stamps the default first-party image + persists it [0.35ms]
+(pass) createApp: template-image wiring (no-repo apps) > APP_DEFAULT_TEMPLATE_IMAGE env overrides the stamped image [0.06ms]
+(pass) createApp: template-image wiring (no-repo apps) > caller-supplied options.imageTag wins over the default (not overwritten) [0.03ms]
+(pass) createApp: template-image wiring (no-repo apps) > a pre-existing metadata.imageTag is never overwritten (no redundant update) [0.03ms]
+(pass) createApp: template-image wiring (no-repo apps) > repo-backed app (default createGitHubRepo) is NOT stamped with an image [0.15ms]
+(pass) create -> deploy linkage: resolveImageRef on the created app > the stamped template app RESOLVES its image (does NOT throw) [0.55ms]
+(pass) create -> deploy linkage: resolveImageRef on the created app > a repo-backed app still throws build-from-repo-disabled (unchanged) [0.13ms]
+(pass) front-door create -> deploy resolves (POST /api/v1/apps body) > the fixed front-door body (skipGitHubRepo:true) stamps a template image and RESOLVES [0.10ms]
+(pass) front-door create -> deploy resolves (POST /api/v1/apps body) > default raw create body (no skipGitHubRepo) stamps a template image and RESOLVES [0.06ms]
+(pass) front-door create -> deploy resolves (POST /api/v1/apps body) > explicit repo opt-in (skipGitHubRepo:false) makes a repo app whose deploy THROWS while build-from-repo is disabled [0.07ms]
+
+src/lib/services/__tests__/app-deploy-runner-retire.test.ts:
+(pass) DefaultAppDeployRunner — redeploy retires the prior container row (Bug 1) > a redeploy flips the prior row to deleting, enqueues its delete, and keeps quota ≤1 [1.18ms]
+
+src/lib/services/__tests__/app-db-deprovision-job-service.test.ts:
+(pass) readAppDbDeprovisionJobData > extracts appId + dbUri [0.02ms]
+(pass) readAppDbDeprovisionJobData > throws when appId missing/blank [0.05ms]
+(pass) readAppDbDeprovisionJobData > throws when dbUri missing/blank [0.03ms]
+(pass) app db deprovisioner injection > getAppDbDeprovisioner throws before it is wired [0.02ms]
+Found unencrypted value where encrypted was expected
+(pass) app db deprovisioner injection > dispatch decrypts the carried URI and delegates to the injected deprovisioner [0.10ms]
+(pass) enqueueAppDbDeprovision > inserts an APP_DB_DEPROVISION job carrying appId + encrypted dbUri (pg-free writer) [0.05ms]
+
+src/lib/services/__tests__/app-credits-ledger.test.ts:
+(pass) processPurchase — funds the org ledger (#8253) > credits the purchasing user's org balance with the full purchase amount [0.69ms]
+(pass) processPurchase — funds the org ledger (#8253) > still records creator purchase-share revenue on the monetized app [0.08ms]
+(pass) processPurchase — funds the org ledger (#8253) > webhook retry dedup returns the org balance without re-crediting [0.06ms]
+(pass) deductCredits — debits the same org ledger > purchase and spend round-trip through one ledger [0.33ms]
+(pass) deductCredits — debits the same org ledger > insufficient org balance reports a cloud-credits message [0.04ms]
+[AppCredits] Post-debit accounting failed, compensating charge {
+  appId: "app-1",
+  userId: "user-1",
+  baseCost: 1,
+  creatorMarkup: 0.1,
+  totalCost: 1.1,
+  chargeTransactionId: "tx-2",
+  error: "accounting down",
+}
+(pass) deductCredits — debits the same org ledger > compensates the full charge and rethrows when post-debit accounting fails [0.15ms]
+(pass) reconcileCredits — charges/refunds the estimate↔actual delta (#9145) > no-ops when the difference is below the reconciliation threshold [0.26ms]
+(pass) reconcileCredits — charges/refunds the estimate↔actual delta (#9145) > charges the markup'd delta to the org when actual exceeds estimated [0.07ms]
+(pass) reconcileCredits — charges/refunds the estimate↔actual delta (#9145) > refunds the markup'd overcharge to the org when actual is below estimated [0.12ms]
+[AppCredits] User not found during reconciliation {
+  userId: "user-1",
+}
+(pass) reconcileCredits — charges/refunds the estimate↔actual delta (#9145) > does not reconcile when the user has no organization [0.04ms]
+[AppCredits] App not found during reconciliation {
+  appId: "app-1",
+}
+(pass) reconcileCredits — charges/refunds the estimate↔actual delta (#9145) > does not reconcile when the app is missing [0.03ms]
+[AppCredits] Reconciliation: Insufficient org balance for additional charge (platform absorbing loss) {
+  appId: "app-1",
+  userId: "user-1",
+  organizationId: "org-1",
+  additionalCharge: 1.1,
+  currentBalance: 0.05,
+  lossAmount: 1.1,
+}
+(pass) reconcileCredits — charges/refunds the estimate↔actual delta (#9145) > absorbs the loss without crediting the creator when the reconcile charge is uncollectable [0.04ms]
+(pass) checkBalance — reads the org ledger > gates on the org balance, not a per-app pool [0.07ms]
+(pass) calculateCostWithMarkup — quotes the inference price > monetized app marks the base cost up by its inference_markup_percentage [0.12ms]
+(pass) calculateCostWithMarkup — quotes the inference price > monetization disabled collapses to base cost with zero markup [0.03ms]
+(pass) calculateCostWithMarkup — quotes the inference price > missing app quotes zero markup AND negative-caches the __none marker [0.06ms]
+(pass) processPurchase — clamps an oversized platform offset > offset >= purchase is clamped to the purchase; creator earns 0, never negative [0.04ms]
+(pass) processPurchase — monetization-disabled dedup record > writes a zero-amount dedup transaction and records no creator earnings [0.06ms]
+(pass) deductCredits — validateMetadata size & depth guards > rejects metadata that serializes beyond the 10KB cap [0.05ms]
+(pass) deductCredits — validateMetadata size & depth guards > rejects metadata nested deeper than the max depth [0.07ms]
+(pass) deductCredits — validateMetadata size & depth guards > accepts small, shallow metadata and proceeds to the debit [0.05ms]
+
+src/lib/services/__tests__/docker-sandbox-unreachable-terminal.test.ts:
+[docker-sandbox] docker stop failed for agent-unreachable-test: [docker-ssh] Connection to 138.201.80.125:22 timed out after 10000ms
+[docker-sandbox] docker rm failed for agent-unreachable-test: [docker-ssh] Connection to 138.201.80.125:22 timed out after 10000ms
+[docker-sandbox] Node 138.201.80.125 unreachable during stop of agent-unreachable-test; completing delete and ABANDONING the container — it will LEAK until reclaimed (no automatic orphan-sweep / node-reconcile job exists yet) — docker stop -> [docker-ssh] Connection to 138.201.80.125:22 timed out after 10000ms; docker rm -f -> [docker-ssh] Connection to 138.201.80.125:22 timed out after 10000ms {
+  nodeId: "node-1",
+  containerName: "agent-unreachable-test",
+}
+[docker-sandbox] Failed to decrement allocated_count for node node-1: Failed query: update "docker_nodes" set "allocated_count" = GREATEST("docker_nodes"."allocated_count" - 1, 0), "updated_at" = $1 where "docker_nodes"."node_id" = $2 returning "allocated_count"
+params: 2026-07-01T03:37:36.562Z,node-1
+(pass) DockerSandboxProvider.stop() terminal policy on unreachable node > RESOLVES (no throw) when both stop and rm fail with an SSH timeout [4.93ms]
+[docker-sandbox] docker stop failed for agent-unreachable-test: Error response from daemon: cannot stop container: permission denied
+[docker-sandbox] docker rm failed for agent-unreachable-test: Error response from daemon: cannot stop container: permission denied
+(pass) DockerSandboxProvider.stop() terminal policy on unreachable node > still THROWS when both legs fail for a non-unreachable, non-gone reason [0.10ms]
+[docker-sandbox] docker stop failed for agent-unreachable-test: [docker-ssh] Command timed out after 25000ms on host: docker [redacted]
+[docker-sandbox] docker rm failed for agent-unreachable-test: [docker-ssh] Command timed out after 25000ms on host: docker [redacted]
+(pass) DockerSandboxProvider.stop() terminal policy on unreachable node > still THROWS on a per-command timeout (reachable-but-slow node, NOT terminal) [0.06ms]
+[docker-sandbox] docker stop failed for agent-unreachable-test: Error response from daemon: No such container: agent-x
+[docker-sandbox] docker rm failed for agent-unreachable-test: Error response from daemon: No such container: agent-x
+[docker-sandbox] Failed to decrement allocated_count for node node-1: Failed query: update "docker_nodes" set "allocated_count" = GREATEST("docker_nodes"."allocated_count" - 1, 0), "updated_at" = $1 where "docker_nodes"."node_id" = $2 returning "allocated_count"
+params: 2026-07-01T03:37:36.563Z,node-1
+(pass) DockerSandboxProvider.stop() terminal policy on unreachable node > RESOLVES when the container is already gone (existing behavior preserved) [0.26ms]
+
+src/lib/services/__tests__/provision-reachability-regression.test.ts:
+(pass) provision reachability — trusted Docker bridge route > a Headscale IP yields a reachable bridge URL and never needs the node lookup [0.20ms]
+(pass) provision reachability — trusted Docker bridge route > a missing Headscale IP falls back to the resolved node hostname [0.05ms]
+(pass) provision reachability — trusted Docker bridge route > CANARY: no Headscale IP and an unresolvable node => null (running-but-unreachable) [0.03ms]
+(pass) provision reachability — trusted Docker bridge route > no node signal at all => null (provision never landed a route) [0.03ms]
+(pass) provision reachability — trusted Docker web route > a stored health_url wins as the trusted web origin [0.08ms]
+(pass) provision reachability — trusted Docker web route > CANARY: no health_url, no Headscale IP, unresolvable node => null [0.04ms]
+
+src/lib/services/__tests__/node-builder-exec.test.ts:
+(pass) makeNodeBuilderExec — arming gate > returns null when no docker node is configured (→ prebuilt fallback) [0.89ms]
+(pass) makeNodeBuilderExec — arming gate > returns null when no SSH key is configured [0.03ms]
+(pass) makeNodeBuilderExec — arming gate > returns null when explicitly disabled even if node + key present [0.02ms]
+(pass) makeNodeBuilderExec — arming gate > returns null when build-from-repo is NOT armed (backend configured) [0.03ms]
+(pass) makeNodeBuilderExec — arming gate > returns null when only the image registry is configured [0.01ms]
+[container-executor-deps] build-from-repo armed but no isolated builder host — set APPS_BUILDS_HOST (dedicated) or APPS_BUILD_ON_RUNTIME_NODE=1 to opt into the runtime node; staying on prebuilt-image path
+(pass) makeNodeBuilderExec — arming gate > returns null when armed but no isolated builder host (no dedicated, no runtime opt-in) [0.09ms]
+(pass) makeNodeBuilderExec — arming gate > returns a BuildExec when armed + a DEDICATED builder host is set [0.09ms]
+(pass) makeNodeBuilderExec — arming gate > returns a BuildExec when armed + runtime-node opt-in (no dedicated host) [0.03ms]
+
+src/lib/services/__tests__/credits-deduct-guard.test.ts:
+[CreditsService] No billing email for organization {
+  organizationId: "00000000-0000-0000-0000-0000000000d1",
+}
+(pass) reserveAndDeductCredits — atomic debit > (a) a sufficient debit moves the balance by exactly -amount and writes ONE matching debit row [7.45ms]
+(pass) reserveAndDeductCredits — atomic debit > (b) amount > balance fails CLOSED: success:false, reason:insufficient_balance, balance + ledger untouched [2.21ms]
+(pass) reserveAndDeductCredits — atomic debit > (b2) a debit for exactly the full balance succeeds and lands at zero (boundary of the >= guard) [2.92ms]
+(pass) reserveAndDeductCredits — atomic debit > an unknown organization fails with reason:org_not_found and writes nothing [1.43ms]
+[Credits] Insufficient credits for reservation {
+  organizationId: "00000000-0000-0000-0000-0000000000d1",
+  required: 5,
+  available: 2,
+  reason: "insufficient_balance",
+}
+(pass) reserve() — high-level reservation gate > (c) reserve() throws InsufficientCreditsError when the reservation exceeds the balance (no debit) [2.08ms]
+[CreditsService] No billing email for organization {
+  organizationId: "00000000-0000-0000-0000-0000000000d1",
+}
+(pass) reserve() — high-level reservation gate > reserve() succeeds within budget, debiting the reserved amount once [2.60ms]
+[CreditsService] No billing email for organization {
+  organizationId: "00000000-0000-0000-0000-0000000000d1",
+}
+(pass) reconcile() — settle reserved vs actual > (d) actual < reserved → refunds the difference (credit_balance goes UP by the refund) [5.00ms]
+[CreditsService] No billing email for organization {
+  organizationId: "00000000-0000-0000-0000-0000000000d1",
+}
+[Credits] Reconciled - charged overage {
+  organizationId: "00000000-0000-0000-0000-0000000000d1",
+  reserved: 5,
+  actual: 8,
+  overage: 3,
+}
+[CreditsService] No billing email for organization {
+  organizationId: "00000000-0000-0000-0000-0000000000d1",
+}
+(pass) reconcile() — settle reserved vs actual > (d) actual > reserved → charges the overage (credit_balance goes DOWN by the overage) [4.86ms]
+[CreditsService] No billing email for organization {
+  organizationId: "00000000-0000-0000-0000-0000000000d1",
+}
+(pass) reconcile() — settle reserved vs actual > actual == reserved (within epsilon) → no-op, balance unchanged, no settlement rows [2.34ms]
+
+src/lib/services/__tests__/inference-billing-ledger.test.ts:
+(pass) admitInferenceChargeViaLedger — atomic admission gate > admits an affordable charge and writes exactly one pending row at the estimate [5.01ms]
+(pass) admitInferenceChargeViaLedger — atomic admission gate > rejects when the balance does not clear the threshold (no row written) [2.61ms]
+(pass) admitInferenceChargeViaLedger — atomic admission gate > HARD overdraw bound: admission accounts for in-flight pending charges [3.62ms]
+(pass) admitInferenceChargeViaLedger — atomic admission gate > rejects an unknown organization with reason org_not_found [2.02ms]
+(pass) admitInferenceChargeViaLedger — atomic admission gate > fails SAFE on a +Infinity threshold (misconfigured SAFE_BALANCE_THRESHOLD) without touching the DB [0.75ms]
+(pass) admitInferenceChargeViaLedger — atomic admission gate > idempotent re-delivery: the same request id never writes a second pending row [2.81ms]
+(pass) admitInferenceChargeViaLedger — atomic admission gate > a same-org concurrent burst cannot collectively overdraw [3.62ms]
+[CreditsService] No billing email for organization {
+  organizationId: "00000000-0000-0000-0000-00000000ce01",
+}
+(pass) admitInferenceChargeViaLedger — atomic admission gate > admission accounts for in-flight via the pending rows themselves (self-correcting, no separate counter) [7.66ms]
+[CreditsService] No billing email for organization {
+  organizationId: "00000000-0000-0000-0000-00000000ce01",
+}
+(pass) createLedgerDebitSettler — exactly-once inline settlement > settles the ACTUAL cost: claims the row, debits once, moves the balance by -actual [4.18ms]
+[CreditsService] No billing email for organization {
+  organizationId: "00000000-0000-0000-0000-00000000ce01",
+}
+(pass) createLedgerDebitSettler — exactly-once inline settlement > EXACTLY-ONCE: a second settle of the same request charges nothing more [3.62ms]
+(pass) createLedgerDebitSettler — exactly-once inline settlement > settle(0) (error/abort) claims the row but charges nothing [1.76ms]
+[CreditsService] No billing email for organization {
+  organizationId: "00000000-0000-0000-0000-00000000ce01",
+}
+(pass) createLedgerDebitSettler — exactly-once inline settlement > fires the low-credit/auto-top-up/waifu notifications on a successful debit (parity with deductCredits) [2.98ms]
+(pass) createLedgerDebitSettler — exactly-once inline settlement > does NOT fire balance-decrease notifications when nothing was debited (settle(0) / uncollected) [1.56ms]
+[InferenceLedger] uncollected inference charge {
+  organizationId: "00000000-0000-0000-0000-00000000ce01",
+  userId: "00000000-0000-0000-0000-00000000ce02",
+  requestId: "req-ledger-21",
+  amountUsd: 5,
+  source: "inline",
+}
+(pass) createLedgerDebitSettler — exactly-once inline settlement > uncollected: a debit the DB refuses (would overdraw) marks the row, leaves the balance intact [2.39ms]
+[InferenceLedger] swept stale pending charges (dropped inline settles) {
+  scanned: 1,
+  settled: 1,
+  skipped: 0,
+  batches: 1,
+  gcDeleted: 0,
+  capHit: false,
+}
+[CreditsService] No billing email for organization {
+  organizationId: "00000000-0000-0000-0000-00000000ce01",
+}
+(pass) sweepStalePendingInferenceChargesDb — cron backstop > settles stale pending rows charging the ESTIMATE; skips young ones [4.15ms]
+[CreditsService] No billing email for organization {
+  organizationId: "00000000-0000-0000-0000-00000000ce01",
+}
+(pass) sweepStalePendingInferenceChargesDb — cron backstop > inline-then-sweep never double-charges (the inline settle already claimed it) [3.31ms]
+[CreditsService] No billing email for organization {
+  organizationId: "00000000-0000-0000-0000-00000000ce01",
+}
+[CreditsService] No billing email for organization {
+  organizationId: "00000000-0000-0000-0000-00000000ce01",
+}
+[CreditsService] No billing email for organization {
+  organizationId: "00000000-0000-0000-0000-00000000ce01",
+}
+[CreditsService] No billing email for organization {
+  organizationId: "00000000-0000-0000-0000-00000000ce01",
+}
+[InferenceLedger] swept stale pending charges (dropped inline settles) {
+  scanned: 5,
+  settled: 5,
+  skipped: 0,
+  batches: 3,
+  gcDeleted: 0,
+  capHit: false,
+}
+[CreditsService] No billing email for organization {
+  organizationId: "00000000-0000-0000-0000-00000000ce01",
+}
+(pass) sweepStalePendingInferenceChargesDb — cron backstop > drains the whole stale backlog oldest-first across multiple batches (no silent cap) [9.30ms]
+[InferenceLedger] swept stale pending charges (dropped inline settles) {
+  scanned: 1,
+  settled: 1,
+  skipped: 0,
+  batches: 1,
+  gcDeleted: 0,
+  capHit: false,
+}
+[CreditsService] No billing email for organization {
+  organizationId: "00000000-0000-0000-0000-00000000ce01",
+}
+(pass) sweepStalePendingInferenceChargesDb — cron backstop > a dropped inline settle (row left pending) is recovered by the sweep — no lost charge [3.72ms]
+[InferenceLedger] swept stale pending charges (dropped inline settles) {
+  scanned: 0,
+  settled: 0,
+  skipped: 0,
+  batches: 0,
+  gcDeleted: 1,
+  capHit: false,
+}
+(pass) sweepStalePendingInferenceChargesDb — cron backstop > GCs terminal rows older than the retention window; keeps recent terminal + all pending [1.36ms]
+(pass) resolveInferenceBillingLedger — backstop selector > only 'db' (case/space-insensitive) selects the DB ledger; everything else is 'kv' [0.04ms]
+
+src/lib/services/__tests__/docker-sandbox-headscale-route.test.ts:
+(pass) requiresHeadscaleRoute > does not require Headscale routing when Headscale is not configured [0.15ms]
+(pass) requiresHeadscaleRoute > requires a persisted headscale route when Headscale is configured [0.02ms]
+(pass) requiresHeadscaleRoute > requires Headscale routing for public cloud agent ingress [0.01ms]
+(pass) requiresHeadscaleRoute > requires Headscale routing for deployed cloud environments [0.03ms]
+(pass) requiresHeadscaleRoute > requires Headscale routing when Headscale URL config is present [0.01ms]
+(pass) requiresHeadscaleRoute > allows explicit legacy bridge-host fallback [0.04ms]
+(pass) headscaleVpnEnabled > enabled when an API key is configured and no fallback is requested [0.02ms]
+(pass) headscaleVpnEnabled > disabled when no API key is configured [0.02ms]
+(pass) headscaleVpnEnabled > disabled when the operator opts into legacy bridge-host fallback [0.02ms]
+(pass) headscaleVpnEnabled > stays consistent with requiresHeadscaleRoute under the fallback flag [0.02ms]
+(pass) shouldCleanupHeadscaleVpn > cleans up only when VPN is enabled and a registered node name is present [0.03ms]
+(pass) shouldCleanupHeadscaleVpn > does not clean up fallback-mode containers even when an API key is configured [0.01ms]
+(pass) resolveDockerSandboxImage > prefers a per-agent image over the operator default image [0.02ms]
+(pass) resolveDockerSandboxImage > uses the operator default when no per-agent image is set
+(pass) buildManagedElizaRuntimeConfig > writes canonical cloud runtime + inference routing for managed containers [0.63ms]
+(pass) resolveContainerPort > uses HTTP_PORT when PORT is absent [0.03ms]
+(pass) resolveContainerPort > prefers PORT over HTTP_PORT [0.01ms]
+[docker-sandbox] Headscale routing is required for this cloud environment, but HEADSCALE_API_KEY is not configured. Refusing to mark the agent running without a routable internal ingress; set AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK=1 only for legacy public-host routing. {
+  agentId: "11111111-1111-4111-8111-111111111111",
+}
+(pass) DockerSandboxProvider Headscale route guard > rejects public cloud provisioning before a sandbox can be marked running without Headscale config [1.47ms]
+(pass) resolveSandboxRegistryEnv (#8756) > no backend configured → cannot self-register, no warning [0.07ms]
+(pass) resolveSandboxRegistryEnv (#8756) > a redis:// URL self-registers without a token (TCP carries auth) [0.02ms]
+(pass) resolveSandboxRegistryEnv (#8756) > rediss:// (TLS) is also TCP [0.01ms]
+(pass) resolveSandboxRegistryEnv (#8756) > an https Upstash URL needs a token to self-register [0.05ms]
+(pass) resolveSandboxRegistryEnv (#8756) > explicit SANDBOX_REGISTRY_* wins over legacy KV_REST_API_*, and does NOT borrow the legacy token [0.01ms]
+(pass) resolveSandboxRegistryEnv (#8756) > legacy KV_REST_API_URL + token self-registers [0.01ms]
+(pass) resolveSandboxRegistryEnv (#8756) > an unexpected scheme that still self-registers surfaces a warning [0.02ms]
+(pass) resolveSandboxRegistryEnv (#8756) > trims whitespace around the URL [0.01ms]
+
+src/lib/services/__tests__/apps-ingress-routes.test.ts:
+(pass) buildCaddyRouteId > derives a stable id from the host's first label (the shortid) [0.05ms]
+(pass) buildCaddyRouteId > sanitizes to [a-z0-9] and lowercases [0.01ms]
+(pass) buildCaddyRoute > host-match -> reverse_proxy to the node-local 127.0.0.1:hostPort, keyed by @id [0.08ms]
+(pass) buildCaddyRoute > folds verified custom domains into the same route's host-match (deduped + lowercased) [0.02ms]
+(pass) buildCaddyRoute > empty/omitted extraHostnames keeps the plain single-host route [0.01ms]
+(pass) admin-API urls > add-route URL targets a server's routes (default srv0) [0.02ms]
+(pass) admin-API urls > by-id URL addresses the route by @id (for DELETE)
+(pass) buildOnDemandAskUrl > points at the fixed apps-ingress ask endpoint (Caddy appends ?domain=) [0.01ms]
+
+src/lib/services/__tests__/x402-facilitator.test.ts:
+(pass) verify rejects when signed authorization.value is below the required amount [17.80ms]
+(pass) verify accepts matching signed authorization.value and continues to signature/balance checks [0.09ms]
+[x402-facilitator] Settlement TX failed: settlement_reverted
+(pass) settle rejects when the submitted EVM transaction reverts before crediting [0.61ms]
+[x402-facilitator] Settlement TX failed: settlement_amount_too_low
+(pass) settle rejects when the receipt does not contain the required token transfer [0.11ms]
+(pass) settle succeeds only after the EVM receipt proves the required transfer [0.07ms]
+
+src/lib/services/__tests__/app-deploy-orchestrator.test.ts:
+(pass) deployApp > provisions an isolated DB, creates the row with that DSN, enqueues, links [0.36ms]
+(pass) deployApp > the injected DSN is the per-tenant one, never a shared agent URL [0.06ms]
+(pass) deployApp > honors a custom container port [0.04ms]
+(pass) deployApp > injects platform-owned app id into a stateless app container [0.06ms]
+(pass) deployApp > platform DB env wins over caller-provided DB keys [0.03ms]
+(pass) deployApp > surfaces a DB-provisioning failure before creating any container [0.06ms]
+(pass) deployApp > a stateless app (mode 'none', the default) provisions NO DB and injects no DATABASE_URL [0.05ms]
+(pass) deployApp > explicit mode 'none' behaves like the default (no DB) [0.04ms]
+
+src/lib/services/__tests__/affiliate-images.test.ts:
+(pass) affiliate-images URL safety > extractSafeImageUrls keeps only http(s) string URLs [17.38ms]
+(pass) affiliate-images URL safety > hasValidReferenceImages reflects whether any safe URL remains [0.03ms]
+(pass) affiliate-images URL safety > buildAffiliateImageReferences marks the first url as the profile pic [0.06ms]
+
+src/lib/services/__tests__/analytics-derived.test.ts:
+(pass) deriveCostTrendingFields > returns zero when balance is zero [0.07ms]
+(pass) deriveCostTrendingFields > rounds percent to one decimal place
+(pass) deriveCostTrendingFields > clamps progress percent to 100
+(pass) deriveCostTrendingFields > burnAlertThresholdExceeded triggers at >80% of balance
+(pass) toSuccessRatePercent > converts rate to percent rounded to 1dp [0.02ms]
+(pass) toRatePercent > computes percent of denominator [0.01ms]
+(pass) toRatePercent > returns zero when denominator is zero
+(pass) toRatePercent > rounds to one decimal place
+(pass) toDistribution > sorts by count desc and computes percents [0.10ms]
+(pass) toDistribution > returns zero percent for empty input
+(pass) toRetentionRates > computes per-day retention percents and skips null retained [0.06ms]
+(pass) toRetentionRates > returns null retention when cohort size is zero [0.03ms]
+(pass) deriveQuotaUsage > returns null percent when no limit [0.02ms]
+(pass) deriveQuotaUsage > computes percent and clamps to 100
+
+src/lib/services/__tests__/app-image-resolver.test.ts:
+(pass) makeBuildFromRepoResolver > builds + pushes from app.github_repo and returns the ref [0.44ms]
+(pass) makeBuildFromRepoResolver > falls back to metadata.repoUrl when github_repo is absent [0.05ms]
+(pass) makeBuildFromRepoResolver > uses deploy metadata for repo, ref, and Dockerfile [0.05ms]
+(pass) makeBuildFromRepoResolver > returns undefined (no error) when the app has no repo [0.03ms]
+(pass) makePrebuiltImageMapResolver > returns undefined when no map is configured [0.04ms]
+(pass) makePrebuiltImageMapResolver > uses the longest matching app name prefix [0.11ms]
+[AppImageResolver] APP_PREBUILT_IMAGES is not valid JSON; ignoring the per-app prebuilt image map
+(pass) makePrebuiltImageMapResolver > ignores invalid JSON maps [0.05ms]
+(pass) composeImageResolvers > returns undefined when no resolver is active [0.02ms]
+(pass) composeImageResolvers > returns the first resolver image and falls through undefined results [0.08ms]
+
+src/lib/services/__tests__/tts-cache-key-parity.test.ts:
+(pass) hashCloudCacheKey parity — 200 randomised inputs > matches reference hash for all random inputs [2.77ms]
+(pass) hashCloudCacheKey parity — 200 randomised inputs > scope does NOT affect the hash (lookup-only dimension) [27.51ms]
+(pass) hashCloudCacheKey parity — 200 randomised inputs > cross-provider MISS: kokoro hash != elevenlabs hash for same text [0.08ms]
+(pass) hashCloudCacheKey parity — 200 randomised inputs > all 5 providers produce distinct hashes for the same text+settings [0.06ms]
+
+src/lib/services/__tests__/app-network-utils.test.ts:
+(pass) appNetworkName > derives a stable per-app network name [0.07ms]
+(pass) buildEnsureAppNetworkCmd — isolation is real (--internal) > creates an --internal bridge (the load-bearing flag) [0.01ms]
+(pass) buildEnsureAppNetworkCmd — isolation is real (--internal) > never references the shared agent network name
+(pass) buildAppContainerSecurityFlags — untrusted-image hardening > drops all caps, forbids privilege escalation, bounds pids
+(pass) buildAppContainerSecurityFlags — untrusted-image hardening > NEVER grants the agent-only network escapes [0.01ms]
+(pass) buildAppContainerSecurityFlags — untrusted-image hardening > honors a custom pids limit [0.01ms]
+(pass) buildAppEgressEnv > routes all HTTP(S) egress through the proxy, bypassing localhost [0.02ms]
+(pass) buildSquidAllowlistConf — default deny > allows only listed hosts and denies everything else [0.07ms]
+(pass) buildSquidAllowlistConf — default deny > an empty allowlist denies everything (no allow line) [0.01ms]
+(pass) buildSquidAllowlistConf — default deny > ignores malformed/injection-y host entries [0.01ms]
+
+src/lib/services/__tests__/app-deploy-runner.test.ts:
+(pass) containerNameForApp (#9145) > produces a lowercase app-<slug> name [0.03ms]
+(pass) containerNameForApp (#9145) > strips every non-alphanumeric character
+(pass) containerNameForApp (#9145) > truncates the slug to 12 chars (16 total) [0.01ms]
+(pass) containerNameForApp (#9145) > is deterministic for a UUID id [0.01ms]
+(pass) resolveImageRef: build-from-repo-disabled guard > repo app + build off + no imageTag -> throws, does NOT fall back to APP_DEFAULT_IMAGE [0.15ms]
+(pass) resolveImageRef: build-from-repo-disabled guard > repo app + build off + explicit imageTag -> uses the prebuilt image [0.22ms]
+(pass) resolveImageRef: build-from-repo-disabled guard > repo app + build on -> uses the built image [0.04ms]
+(pass) resolveImageRef: build-from-repo-disabled guard > non-repo app still falls back to APP_DEFAULT_IMAGE (unchanged) [0.03ms]
+(pass) resolveImageRef: image allowlist gate > rejects an imageTag outside the default allowlist [0.05ms]
+(pass) resolveImageRef: image allowlist gate > allows an imageTag inside the default first-party allowlist [0.02ms]
+(pass) resolveImageRef: image allowlist gate > the default agent image passes the default allowlist [0.04ms]
+(pass) resolveImageRef: image allowlist gate > a mis-set APP_DEFAULT_IMAGE outside the allowlist is rejected [0.03ms]
+(pass) resolveImageRef: image allowlist gate > honors an operator-narrowed allowlist (rejects an off-list image) [0.06ms]
+(pass) resolveImageRef: apps-deploy allowlist is elizaos-only > allows a first-party ghcr.io/elizaos/* image by default [0.03ms]
+(pass) resolveImageRef: apps-deploy allowlist is elizaos-only > REJECTS ghcr.io/dexploarer/* by default (personal org) [0.02ms]
+(pass) resolveImageRef: apps-deploy allowlist is elizaos-only > REJECTS ghcr.io/waifufun/* by default (side product) [0.02ms]
+(pass) resolveImageRef: apps-deploy allowlist is elizaos-only > does NOT read CODING_CONTAINER_IMAGE_ALLOWLIST (separate gate) [0.02ms]
+(pass) resolveImageRef: apps-deploy allowlist is elizaos-only > opt-in via APPS_DEPLOY_IMAGE_ALLOWLIST re-allows dexploarer + waifufun [0.04ms]
+(pass) resolveImageRef: digest-pin gate (#9853 follow-up) > flag ON: a mutable :tag app image is rejected [0.17ms]
+(pass) resolveImageRef: digest-pin gate (#9853 follow-up) > flag ON: an implicit-latest (untagged) app image is rejected [0.04ms]
+(pass) resolveImageRef: digest-pin gate (#9853 follow-up) > flag ON: a digest-pinned app image passes [0.05ms]
+(pass) resolveImageRef: digest-pin gate (#9853 follow-up) > flag OFF (default): a mutable :tag app image is unchanged (passes) [0.03ms]
+
+src/lib/services/__tests__/container-provider-input.test.ts:
+(pass) buildContainerProvisionInput > applies defaults for unset fields [0.05ms]
+(pass) buildContainerProvisionInput > overrides win over defaults and carry the core fields through [0.02ms]
+(pass) buildContainerProvisionInput > never auto-injects DATABASE_URL [0.04ms]
+(pass) buildContainerProvisionInput > with no env at all, no DATABASE_URL appears
+(pass) buildContainerProvisionInput > forwards a caller-supplied (per-tenant) DATABASE_URL verbatim
+(pass) buildContainerProvisionInput > does not let callers mutate the output env by reference [0.01ms]
+(pass) buildContainerProvisionInput > throws on missing required fields [0.03ms]
+
+src/lib/services/__tests__/app-reachability.test.ts:
+(pass) isReachableStatus > 2xx/3xx and auth gates (401/403) are reachable [0.06ms]
+(pass) isReachableStatus > bad-gateway family (502/503/504) is NOT reachable [0.01ms]
+(pass) probeUrlReachable > a completed 401 counts as reachable [0.14ms]
+(pass) probeUrlReachable > a 502 gateway error is NOT reachable [0.03ms]
+(pass) probeUrlReachable > a thrown request (connection refused / timeout) is NOT reachable [0.05ms]
+(pass) waitForUrlReachable > returns true as soon as the URL answers [0.10ms]
+(pass) waitForUrlReachable > recovers once the upstream starts answering after a few 502s [38.37ms]
+(pass) waitForUrlReachable > gives up after the bounded window when never reachable [56.98ms]
+
+src/lib/services/__tests__/app-build-cmd.test.ts:
+(pass) buildAppImageBuildCmd > plain docker build from a local context, no push [0.02ms]
+(pass) buildAppImageBuildCmd > git URL context builds natively (no clone step) [0.01ms]
+(pass) buildAppImageBuildCmd > push implies buildx + --push (no --load) [0.02ms]
+(pass) buildAppImageBuildCmd > buildx without push gets --load so the image lands locally [0.01ms]
+(pass) buildAppImageBuildCmd > dockerfile + build args are quoted [0.02ms]
+(pass) buildAppImageBuildCmd > shell-quotes a context with metacharacters (injection-safe) [0.04ms]
+(pass) buildAppImageBuildCmd > builderName pins --builder and implies buildx [0.01ms]
+(pass) buildAppImageBuildCmd > noCache adds --no-cache
+(pass) isolatedBuilderName > derives a DNS/Docker-safe name from appId + suffix [0.04ms]
+(pass) isolatedBuilderName > strips unsafe characters from both parts [0.01ms]
+(pass) buildIsolatedAppImageScript — throwaway isolated builder (BLOCKER #6) > creates a fresh docker-container BuildKit isolated from the host daemon
+(pass) buildIsolatedAppImageScript — throwaway isolated builder (BLOCKER #6) > guarantees teardown of the throwaway builder on EXIT
+(pass) buildIsolatedAppImageScript — throwaway isolated builder (BLOCKER #6) > aborts the build if the isolated builder cannot be created (set -e) [0.03ms]
+(pass) buildIsolatedAppImageScript — throwaway isolated builder (BLOCKER #6) > pins the build to the throwaway builder and pushes from inside it
+(pass) buildIsolatedAppImageScript — throwaway isolated builder (BLOCKER #6) > shell-quotes an injection-laced context (defense in depth) [0.01ms]
+(pass) buildAppImagePushCmd > quotes the ref [0.01ms]
+
+src/lib/services/__tests__/app-image-ref.test.ts:
+(pass) appImageSlug > strips to [a-z0-9], lowercases, caps at 24 [23.22ms]
+(pass) appImageSlug > throws on a too-short slug [0.14ms]
+(pass) deriveImageTag > absent/empty ref → latest [0.04ms]
+(pass) deriveImageTag > passes through a clean git sha
+(pass) deriveImageTag > collapses unsafe chars and strips a leading dot/dash [0.01ms]
+(pass) deriveImageTag > caps at 128 chars
+(pass) buildAppImageRef > composes <registry>/app-<slug>:<tag> [0.04ms]
+(pass) buildAppImageRef > defaults tag to latest and trims trailing slashes on the registry [0.03ms]
+(pass) buildAppImageRef > rejects an invalid registry [0.08ms]
+
+src/lib/services/__tests__/app-url.test.ts:
+(pass) deriveAppPublicUrl > derives <shortid>.<base> hostname + https url when a base domain is set [18.01ms]
+(pass) deriveAppPublicUrl > returns null when no public base domain is configured (e.g. local dev) [0.01ms]
+(pass) deriveAppPublicUrl > does NOT inherit the agent sandbox domain — null when only the agent domain is set [0.01ms]
+(pass) deriveAppPublicUrl > uses the apps base domain (apps.elizacloud.ai) when set, ignoring the agent domain [0.02ms]
+
+src/lib/services/__tests__/payout-stale-lock-recovery.test.ts:
+[PayoutProcessor] SOLANA_PAYOUT_PRIVATE_KEY not set - Solana payouts disabled
+[PayoutProcessor] Recovered stale processing locks for retry {
+  count: 1,
+  redemptionIds: [ "406e9c55-9c95-451d-9cd4-feaa7ecd118f" ],
+}
+(pass) payout stale-lock recovery (#10553) > (a) a stale 'processing' row with NO broadcast hash is recovered, re-approved, and paid out [14.20ms]
+[PayoutProcessor] Stale processing locks with a broadcast tx require on-chain reconciliation (NOT auto-retried to avoid double-pay) {
+  count: 1,
+  redemptions: [
+    {
+      id: "718f7d2a-778e-46c6-821b-3caef25bd1e3",
+      network: "base",
+      broadcast_tx_hash: "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    }
+  ],
+}
+(pass) payout stale-lock recovery (#10553) > (b) a stale 'processing' row WITH a broadcast hash is NOT re-approved (no double-pay) [3.02ms]
+[PayoutProcessor] Redemption threw before broadcast; marking failed-retryable {
+  redemptionId: "b429990e-82d0-43d9-8de5-1c5f996c506e",
+  reason: "RPC connection reset",
+}
+[PayoutProcessor] Payout failed {
+  redemptionId: "b429990e-82d0-43d9-8de5-1c5f996c506e",
+  reason: "RPC connection reset",
+  retryable: true,
+}
+(pass) payout stale-lock recovery (#10553) > (c) a throw in one redemption does not abort the batch [7.76ms]
+[PayoutProcessor] Redemption threw AFTER broadcast; leaving 'processing' for reconciliation (no auto-retry) {
+  redemptionId: "aca41b6c-7535-430e-b525-f1b6ae45ccab",
+  broadcastTxHash: "0x761d18c6e2e9111d60087f7747a1c35af2630956bbbff0111ca2154e11f8c743",
+  reason: "worker evicted while awaiting receipt",
+}
+(pass) payout stale-lock recovery (#10553) > (d) the tx hash is persisted BEFORE broadcast; an eviction during confirm leaves it for reconciliation [3.96ms]
+(pass) payout stale-lock recovery (#10553) > (d2) #10588: the broadcast hash is persisted BEFORE the raw send (window closed) [4.57ms]
+(pass) payout stale-lock recovery (#10553) > (e) a FRESH 'processing' row (within LOCK_TIMEOUT) is left alone for the live worker [2.63ms]
+[PayoutProcessor] Stale processing locks exhausted retries; marked failed {
+  count: 1,
+  redemptionIds: [ "8d3c0e04-72ec-4cf7-a424-cd6dd2741266" ],
+}
+(pass) payout stale-lock recovery (#10553) > (f) a provably-safe stale row with retries exhausted is failed for manual intervention [2.21ms]
+
+src/lib/services/__tests__/apps-ingress-provisioner.test.ts:
+(pass) addAppRoute > deletes any same-id route, then POSTs the built route to the server [0.43ms]
+(pass) addAppRoute > throws when Caddy rejects the POST (so the deploy fails fast, not a silent 502) [0.26ms]
+(pass) removeAppRoute > DELETEs the route by @id [0.08ms]
+(pass) removeAppRoute > treats 404 as success (route already gone) [0.03ms]
+(pass) removeAppRoute > throws on a non-404 failure [0.04ms]
+
+src/lib/services/__tests__/auto-top-up.test.ts:
+(pass) AutoTopUpService.executeAutoTopUp > persists successful auto top-up credits before returning success [18.60ms]
+(pass) AutoTopUpService.validateSettings > accepts in-range values incl. boundaries [0.05ms]
+(pass) AutoTopUpService.validateSettings > rejects amount below $1 [0.04ms]
+(pass) AutoTopUpService.validateSettings > rejects amount above $1000 [0.03ms]
+(pass) AutoTopUpService.validateSettings > rejects negative threshold [0.02ms]
+(pass) AutoTopUpService.validateSettings > rejects threshold above $1000 [0.01ms]
+
+src/lib/services/__tests__/provisioning-jobs-failure-writeback.test.ts:
+[provisioning-jobs] Marked app deployment as failed after container provision permanent failure {
+  jobId: "job-1",
+  containerId: "cccccccc-dddd-4eee-8fff-000000000000",
+  appId: "11111111-2222-4333-8444-555555555555",
+}
+(pass) buildPermanentFailureWriteback: CONTAINER_PROVISION > app container (UUID project_name) -> apps.deployment_status flipped to failed [0.53ms]
+(pass) buildPermanentFailureWriteback: CONTAINER_PROVISION > plain container (non-UUID project_name) -> no app update [0.04ms]
+(pass) buildPermanentFailureWriteback: CONTAINER_PROVISION > missing container row -> no app update [0.03ms]
+(pass) buildPermanentFailureWriteback: CONTAINER_PROVISION > 36-char non-UUID project_name (e.g. all dashes) -> no app update [0.04ms]
+
+src/lib/services/__tests__/app-image-builder.test.ts:
+(pass) AppImageBuilder > resolves the ref and execs the build inside a THROWAWAY isolated builder by default [0.44ms]
+(pass) AppImageBuilder > uses a unique throwaway builder name per build (no shared BuildKit) [0.12ms]
+(pass) AppImageBuilder > push runs --push from inside the isolated builder (never loads into host daemon) [0.04ms]
+(pass) AppImageBuilder > isolatedBuilder:false runs the plain host-daemon build (trusted/verification only) [0.05ms]
+(pass) AppImageBuilder > propagates a build failure [0.06ms]
+
+src/lib/services/__tests__/app-docker-cmd.test.ts:
+(pass) buildAppDockerCreateCmd > puts the container on its own --internal app network [0.34ms]
+(pass) buildAppDockerCreateCmd > hardens the container and NEVER uses the agent escapes [0.03ms]
+(pass) buildAppDockerCreateCmd > maps the host port, sets memory, and runs the requested image [0.03ms]
+(pass) buildAppDockerCreateCmd > publishes ONLY to loopback so the port is not reachable across the private network [0.03ms]
+(pass) buildAppDockerCreateCmd > caps CPU and pins swap to the memory limit (untrusted-tenant DoS guards) [0.04ms]
+(pass) buildAppDockerCreateCmd > never auto-injects DATABASE_URL, but forwards a caller-supplied one [0.03ms]
+(pass) buildAppDockerCreateCmd > routes egress through the proxy when one is given [0.03ms]
+(pass) buildAppDockerCreateCmd > honors a custom container port and health path [0.02ms]
+
+src/lib/services/__tests__/agent-github-return.test.ts:
+(pass) resolveAgentReturnUrl (open-redirect guard) > accepts the allow-listed agent:// deep links (trimmed) [0.09ms]
+(pass) resolveAgentReturnUrl (open-redirect guard) > rejects empty / unparseable inputs [0.06ms]
+(pass) resolveAgentReturnUrl (open-redirect guard) > rejects non-agent schemes (the open-redirect vectors) [0.02ms]
+(pass) resolveAgentReturnUrl (open-redirect guard) > rejects non-allow-listed agent paths [0.02ms]
+
+src/lib/services/__tests__/user-database-provision-fail-closed.test.ts:
+Database provisioning failed {
+  appId: "app-1",
+  error: "Isolated database requested but no tenant-DB provisioning backend is wired (the provisioning daemon is not armed). Refusing to fall back to the shared cloud DATABASE_URL — arm the daemon (configureAppsDeployBackend) and retry.",
+}
+(pass) provisionDatabase — fail closed without a tenant-DB backend > returns success:false and never the shared DATABASE_URL when no backend is wired [1.08ms]
+
+src/lib/services/__tests__/agent-backup-diff.test.ts:
+(pass) agent-backup-diff round-trip invariant > apply(base, diff(base, next)) deep-equals next: empty → empty [0.16ms]
+(pass) agent-backup-diff round-trip invariant > apply(base, diff(base, next)) deep-equals next: empty → populated [0.01ms]
+(pass) agent-backup-diff round-trip invariant > apply(base, diff(base, next)) deep-equals next: files + config changed/removed [0.06ms]
+(pass) agent-backup-diff round-trip invariant > apply(base, diff(base, next)) deep-equals next: memory append (common case) [0.01ms]
+(pass) agent-backup-diff round-trip invariant > apply(base, diff(base, next)) deep-equals next: memory rebase (prefix diverges)
+(pass) agent-backup-diff helpers > computeStateHash is key-order independent + content-sensitive [0.11ms]
+(pass) agent-backup-diff helpers > isEmptyDelta is true only for a no-op delta [0.03ms]
+(pass) agent-backup-diff helpers > emptyBackupState returns a fresh, non-shared object [0.01ms]
+(pass) agent-backup-diff chain reconstruction (restore path) > reconstructFromChain replays deltas to restore the final state [0.05ms]
+(pass) agent-backup-diff chain reconstruction (restore path) > resolveBackupChain walks parents from the full backup to the target [0.07ms]
+(pass) agent-backup-diff chain reconstruction (restore path) > resolveBackupChain throws on a broken chain (missing parent) [0.03ms]
+
+src/lib/services/__tests__/classify-container-health.test.ts:
+(pass) classifyContainerHealth > db error → failed/critical [0.25ms]
+(pass) classifyContainerHealth > stopped + no runtime → stopped/info (intentional) [0.02ms]
+(pass) classifyContainerHealth > pending/provisioning + no runtime → warming/info [0.03ms]
+(pass) classifyContainerHealth > active db but no runtime → missing/critical
+(pass) classifyContainerHealth > stopped db but runtime still present → degraded/warning [0.02ms]
+(pass) classifyContainerHealth > runtime dead/exited → failed/critical [0.05ms]
+(pass) classifyContainerHealth > runtime restarting → degraded; created → warming; unhealthy → failed [0.02ms]
+
+src/lib/services/__tests__/app-deploy-job-service.test.ts:
+(pass) readAppDeployJobData > extracts appId [0.09ms]
+(pass) readAppDeployJobData > extracts deploy options [0.03ms]
+(pass) readAppDeployJobData > throws when appId missing/blank [0.03ms]
+(pass) readAppDeployJobData > throws when deploy options are malformed [0.09ms]
+(pass) app deploy runner injection > getAppDeployRunner throws before it is wired [0.02ms]
+(pass) app deploy runner injection > dispatchAppDeployJob runs the injected runner with the appId and options [0.10ms]
+(pass) enqueueAppDeploy > inserts an APP_DEPLOY job carrying the appId (pg-free writer) [0.06ms]
+
+src/lib/services/__tests__/ad-campaign-credit-reconciliation.test.ts:
+(pass) deleteCampaign — refunds only the UNUSED budget fraction > budget 100 / allocated 110 / spent 40 → refunds 66, not the full 110 [0.40ms]
+(pass) deleteCampaign — refunds only the UNUSED budget fraction > fully-spent budget refunds nothing (no over-refund) [0.07ms]
+(pass) updateCampaign — reconciles the credit hold on a budget change > budget INCREASE fails CLOSED on insufficient balance (platform never called) [0.24ms]
+(pass) updateCampaign — reconciles the credit hold on a budget change > budget INCREASE refunds the delta if the platform rejects it [0.09ms]
+(pass) updateCampaign — reconciles the credit hold on a budget change > a name-only update charges and refunds nothing [0.07ms]
+
+src/lib/services/__tests__/autoscale-defaults.test.ts:
+(pass) defaultHcloudServerType > falls back to ccx33 (32 GB amd64, dedicated vCPU) when no env is set [18.60ms]
+(pass) defaultHcloudServerType > primary env wins over legacy alias [0.05ms]
+(pass) defaultHcloudServerType > honors legacy HCLOUD_SERVER_TYPE if only it is set [0.02ms]
+(pass) defaultAutoscaleNodeCapacity > defaults to 8 when env is unset [0.05ms]
+(pass) defaultAutoscaleNodeCapacity > reads a valid positive integer from env [0.02ms]
+(pass) defaultAutoscaleNodeCapacity > floors fractional values [0.02ms]
+(pass) defaultAutoscaleNodeCapacity > clamps an oversized value to 64 [0.01ms]
+(pass) defaultAutoscaleNodeCapacity > falls back to 8 on zero, negative, or non-numeric [0.03ms]
+
+src/lib/services/__tests__/registry-probe.test.ts:
+(pass) parseImageRef > parses a full ghcr.io reference [0.11ms]
+(pass) parseImageRef > parses a nested repo path [0.01ms]
+(pass) parseImageRef > returns null for bare image without registry
+(pass) parseImageRef > returns null when no tag
+(pass) parseImageRef > returns null when empty tag
+(pass) parseImageRef > handles port in registry (colon before slash is not a tag)
+(pass) parseImageRef > returns null for malformed input [0.01ms]
+(pass) resolveImageDigest > resolves ghcr.io reference to the manifest digest [0.46ms]
+(pass) resolveImageDigest > returns null for non-ghcr registries (only ghcr supported in MVP) [0.03ms]
+(pass) resolveImageDigest > returns null for bare image names (no registry) [0.02ms]
+(pass) resolveImageDigest > returns null on 404 manifest (tag never pushed) [0.05ms]
+[registry-probe] ghcr manifest fetch failed for elizaos/eliza:develop: 502
+(pass) resolveImageDigest > returns null on 5xx (transient registry failure) [0.06ms]
+[registry-probe] ghcr token fetch failed for elizaos/eliza: 403
+(pass) resolveImageDigest > returns null on token endpoint failure [0.05ms]
+[registry-probe] ghcr token network error for elizaos/eliza: ECONNREFUSED
+(pass) resolveImageDigest > returns null on network error [0.08ms]
+(pass) resolveImageDigest > caches successful results for 60s [0.08ms]
+(pass) resolveImageDigest > re-fetches after TTL expiry [0.07ms]
+(pass) resolveImageDigest > URL-encodes tag with special characters [0.06ms]
+(pass) resolveImageDigest > preserves `/` between repo segments while encoding each segment [0.05ms]
+(pass) resolveImageDigest > caches negative results too (don't hammer ghcr on 404) [0.06ms]
+
+src/lib/services/__tests__/content-safety.test.ts:
+(pass) contentSafetyService > skips when no moderation key is configured unless required [3.73ms]
+(pass) contentSafetyService > sends multimodal moderation payloads to OpenAI [18.37ms]
+(pass) contentSafetyService > blocks flagged public content in enforce mode [0.61ms]
+(pass) contentSafetyService > fails closed when moderation is configured but unavailable [0.37ms]
+
+src/lib/services/__tests__/payout-status-resilience.test.ts:
+[PayoutStatus] Invalid EVM payout private key; treating EVM as unconfigured {
+  error: "invalid private key, expected hex or 32 bytes, got string",
+}
+(pass) getStatus() does not throw on a malformed EVM payout key [1.53ms]
+[PayoutStatus] ethereum RPC setup failed {
+  error: "RPC not configured for network",
+}
+[PayoutStatus] base RPC setup failed {
+  error: "RPC not configured for network",
+}
+[PayoutStatus] bnb RPC setup failed {
+  error: "RPC not configured for network",
+}
+(pass) getStatus() degrades a network whose RPC setup throws (no 500) [31.40ms]
+(pass) isNetworkAvailable() reports unavailable instead of throwing [0.09ms]
+
+src/lib/services/__tests__/app-builder-host.test.ts:
+(pass) selectBuilderHost — dedicated-host preference > prefers the dedicated builder host over the runtime node [18.67ms]
+(pass) selectBuilderHost — dedicated-host preference > falls back to the runtime node only when explicitly opted in [0.03ms]
+(pass) selectBuilderHost — dedicated-host preference > returns null when no dedicated host and runtime build not opted in [0.01ms]
+(pass) decideBuilderArming — arming gate (BLOCKER #6) > not armed when the container backend is disabled [0.04ms]
+(pass) decideBuilderArming — arming gate (BLOCKER #6) > not armed when build-from-repo is not explicitly enabled [0.03ms]
+(pass) decideBuilderArming — arming gate (BLOCKER #6) > not armed when armed but no isolated builder host resolves [0.01ms]
+(pass) decideBuilderArming — arming gate (BLOCKER #6) > armed + dedicated when a dedicated builder host is configured [0.02ms]
+(pass) decideBuilderArming — arming gate (BLOCKER #6) > armed + NOT dedicated when only the runtime-node opt-in is set [0.02ms]
+
+src/lib/services/__tests__/quote-signature.test.ts:
+(pass) quote signing > signs and verifies a valid quote [0.47ms]
+(pass) quote signing > rejects a quote with tampered expectedTokenUnits [0.14ms]
+(pass) quote signing > rejects a quote with tampered receiveAddress [0.22ms]
+(pass) quote signing > rejects a signature produced with a different key [0.11ms]
+(pass) quote signing > identical inputs yield deterministic signatures [0.10ms]
+(pass) quote signing > canonical input format encodes all critical fields [0.06ms]
+(pass) quote signing > refuses to sign in production without env key [0.08ms]
+[DirectWalletPayments] CRYPTO_DIRECT_QUOTE_SIGNING_KEY missing — using DEV fallback. Set this env var for any non-dev environment.
+(pass) quote signing > dev environment without key uses the dev fallback (warning logged) [0.07ms]
+(pass) quote signing > token address vs token mint vs native are distinguished in the canonical string [0.11ms]
+
+src/lib/services/__tests__/app-charge-callback-cross-tenant.test.ts:
+(pass) callbackRoomBelongsToOrganization — room→org authority > same-tenant (room owned by the charge org) → authorized [2.33ms]
+[test] refusing cross-tenant callback room-message {
+  roomId: "00000000-0000-0000-0000-0000000000a4",
+  roomOrganizationId: "00000000-0000-0000-0000-0000000000a1",
+  chargeOrganizationId: "00000000-0000-0000-0000-0000000000b1",
+}
+(pass) callbackRoomBelongsToOrganization — room→org authority > cross-tenant (room owned by a different org) → refused [0.98ms]
+[test] refusing callback room-message: room has no organization mapping {
+  roomId: "00000000-0000-0000-0000-00000000dead",
+  chargeOrganizationId: "00000000-0000-0000-0000-0000000000a1",
+}
+(pass) callbackRoomBelongsToOrganization — room→org authority > unmapped room (no character mapping) → refused (fail-closed) [0.59ms]
+(pass) appChargeCallbacksService.dispatch — settlement memory write is gated > same-tenant charge → settlement memory is written into the room [3.84ms]
+[AppChargeCallbacks] refusing cross-tenant callback room-message {
+  roomId: "00000000-0000-0000-0000-0000000000a4",
+  roomOrganizationId: "00000000-0000-0000-0000-0000000000a1",
+  chargeOrganizationId: "00000000-0000-0000-0000-0000000000b1",
+}
+(pass) appChargeCallbacksService.dispatch — settlement memory write is gated > cross-tenant charge → NO memory is written into the victim's room [2.17ms]
+[AppChargeCallbacks] refusing callback room-message: room has no organization mapping {
+  roomId: "00000000-0000-0000-0000-00000000dead",
+  chargeOrganizationId: "00000000-0000-0000-0000-0000000000a1",
+}
+(pass) appChargeCallbacksService.dispatch — settlement memory write is gated > unmapped room → NO memory is written (fail-closed) [1.65ms]
+
+src/lib/services/__tests__/domain-maintenance.test.ts:
+[CreditsService] No billing email for organization {
+  organizationId: "00000000-0000-0000-0000-0000000000e1",
+}
+(pass) domain renewal billing (#10245) > due domain with funds → debited once, registrar renewed, expiry advanced [13.93ms]
+(pass) domain renewal billing (#10245) > idempotent: a period already charged is NOT re-debited [3.74ms]
+[Domain Renewals] renewal debit declined — domain will lapse {
+  domain: "renew-me.com",
+  organizationId: "00000000-0000-0000-0000-0000000000e1",
+  reason: "insufficient_balance",
+}
+(pass) domain renewal billing (#10245) > declined debit (insufficient funds) → domain lapses (auto_renew disabled), no charge [5.62ms]
+[CreditsService] No billing email for organization {
+  organizationId: "00000000-0000-0000-0000-0000000000e1",
+}
+[Domain Renewals] registrar renew failed; refunded {
+  domain: "fail-renew-x.com",
+  organizationId: "00000000-0000-0000-0000-0000000000e1",
+  error: "Cloudflare API error (status=400): [1300] stub: simulated renewal failure",
+}
+(pass) domain renewal billing (#10245) > registrar failure after debit → refunded exactly once (net zero) [6.14ms]
+(pass) domain renewal billing (#10245) > not due (expiry far in the future) → skipped [2.58ms]
+(pass) custom-domain health probe (#10244) > 2xx /health → is_live true, no error [3.75ms]
+(pass) custom-domain health probe (#10244) > 5xx /health → is_live false, error recorded [3.14ms]
+(pass) custom-domain health probe (#10244) > network error → is_live false, error recorded [2.75ms]
+(pass) custom-domain health probe (#10244) > already-live domains are not re-probed [1.33ms]
+
+src/lib/services/__tests__/tts-first-line-cache.test.ts:
+(pass) hashCloudCacheKey > is deterministic across calls [0.91ms]
+(pass) hashCloudCacheKey > changes when any key field changes (regression: F3 voice-swap safety) [0.08ms]
+(pass) hashCloudCacheKey > scope is NOT part of the manifest-key hash but is part of the lookup [0.02ms]
+(pass) fingerprintCloudVoiceSettings > is order-independent [0.02ms]
+(pass) fingerprintCloudVoiceSettings > differs when values differ [0.01ms]
+(pass) fingerprintCloudVoiceSettings > empty / null produce the same baseline fingerprint [0.02ms]
+(pass) shouldBypassCloudFirstLineCache > returns true on explicit forceBypass [0.02ms]
+(pass) shouldBypassCloudFirstLineCache > returns true for realtime models (non-deterministic output) [0.04ms]
+(pass) shouldBypassCloudFirstLineCache > returns false for default flash model [0.01ms]
+
+src/lib/services/__tests__/container-job-executors.test.ts:
+(pass) executeContainerProvision > builds input from the row, provisions, and marks running [0.63ms]
+(pass) executeContainerProvision > flips the linked app to deployed on success (#5: deploy reaches READY) [0.13ms]
+(pass) executeContainerProvision > does NOT mark the app deployed when provisioning fails [0.18ms]
+(pass) executeContainerProvision > marks error and rethrows when provisioning fails [0.09ms]
+(pass) executeContainerProvision > throws when the container row is missing [0.04ms]
+[ContainerExecutor] route-add/markAppDeployed failed after markRunning {
+  containerId: "container-1",
+  appId: "11111111-2222-3333-4444-555555555555",
+  error: "caddy unreachable",
+}
+(pass) executeContainerProvision > route-add failure AFTER markRunning keeps the row running, never failed [0.16ms]
+(pass) executeContainerProvision > #9853: marks deployed only after the public URL is reachable [0.11ms]
+[ContainerExecutor] route-add/markAppDeployed failed after markRunning {
+  containerId: "container-1",
+  appId: "11111111-2222-3333-4444-555555555555",
+  error: "App 11111111-2222-3333-4444-555555555555 container is running but its public URL https://containe.apps.elizacloud.ai is not HTTP-reachable — refusing to report deploy success.",
+}
+(pass) executeContainerProvision > #9853: an unreachable public URL throws and never marks deployed [0.13ms]
+(pass) executeContainerDelete / restart / logs > delete removes the container then marks it deleted [0.16ms]
+(pass) executeContainerDelete / restart / logs > restart restarts by container name [0.09ms]
+(pass) executeContainerDelete / restart / logs > logs returns the provider output for the requested tail [0.11ms]
+(pass) ingress route hooks > provision adds the route (host + hostPort, NO nodeHost in the dial) + threads nodeHost to markRunning [0.18ms]
+(pass) ingress route hooks > provision folds the app's verified custom domains into the route [0.09ms]
+(pass) ingress route hooks > a custom-domain lookup failure never fails the deploy (route still added, no extras) [0.11ms]
+(pass) ingress route hooks > delete removes the route (best-effort) [0.07ms]
+(pass) ingress route hooks > no base domain -> no route call (ingress not configured) [0.05ms]
+
+src/lib/services/__tests__/app-container-provider.test.ts:
+(pass) parseUsedHostPorts > extracts host ports from `docker ps` Ports output (ipv4 + ipv6 dedup) [0.29ms]
+(pass) parseUsedHostPorts > empty output -> empty set [0.02ms]
+(pass) AppContainerProvider.provision > ensures the --internal network, creates, starts, and returns the id [0.70ms]
+(pass) AppContainerProvider.provision > removes any stale container by name BEFORE docker create (redeploy self-heal) [0.10ms]
+(pass) AppContainerProvider.provision > a failing pre-clean rm does not abort the provision (best-effort) [0.09ms]
+(pass) AppContainerProvider.provision > picks a host port not already in use on the node (collision-safe) [0.31ms]
+(pass) AppContainerProvider.provision > provision with DATABASE_URL + POSTGRES_URL stands up the ambassador + rewrites BOTH [0.21ms]
+(pass) AppContainerProvider.provision > lifecycle verbs issue the expected docker commands [0.17ms]
+
+src/lib/services/tenant-db/tenant-db-placement-claimer.test.ts:
+(pass) tenant DB durable placement claimer > provisionForApp retry reuses the same real placement without claiming a second slot [11.94ms]
+
+src/lib/services/tenant-db/tenant-db-provisioning.integration.test.ts:
+[E6 tenant-db isolation] SKIPPED — no superuser Postgres available. This proves per-tenant DB CREATE + the cross-tenant CONNECT rejection (REVOKE CONNECT FROM PUBLIC), which need a REAL Postgres. Enable it with:
+  • docker present:   APPS_TENANT_DB_EPHEMERAL=1 bun test src/lib/services/tenant-db/tenant-db-provisioning.integration.test.ts
+  • or your own PG:   DATABASE_URL=<dsn> APPS_TENANT_DB_TEST_DSN=<same dsn> bun test …
+  • CI post-merge lane (TEST_LANE=post-merge) opts in automatically when docker exists.
+(skip) tenant-db provisioning over real Postgres > (unnamed)
+(skip) tenant-db provisioning over real Postgres > two concurrent claims on a one-slot cluster: exactly one wins
+(skip) tenant-db provisioning over real Postgres > provisionForApp gives an isolated DB reachable only by its own role
+(skip) tenant-db provisioning over real Postgres > SqlTenantDbProvisioner.provision() is DDL-idempotent against REAL Postgres: a re-run on the SAME cluster does not throw, rotates the DSN, and consumes NO cluster slot
+(skip) tenant-db provisioning over real Postgres > #9686: a deploy RETRY for the SAME app reuses its durable cluster placement — provisionForApp twice claims ONE slot, not two
+(skip) tenant-db provisioning over real Postgres > (unnamed)
+
+src/lib/services/containers/compute-rate-governor.test.ts:
+(pass) RateLimitGovernor — rate buckets > permits up to the per-minute budget without waiting [0.25ms]
+(pass) RateLimitGovernor — rate buckets > the 4th acquire in a minute blocks until a token refills [24.38ms]
+(pass) RateLimitGovernor — rate buckets > uses real DO defaults (250/min, 5000/hr, 10 concurrent) [0.01ms]
+(pass) RateLimitGovernor — concurrency > caps in-flight creates and wakes a waiter on release (not a timer) [0.08ms]
+(pass) RateLimitGovernor — concurrency > waiters are woken in FIFO order [0.07ms]
+(pass) RateLimitGovernor — concurrency > rate cap holds across the semaphore wait (TOCTOU: no over-consume) [0.10ms]
+(pass) RateLimitGovernor — header self-correction > clamps local budget DOWN to ratelimit-remaining [0.13ms]
+(pass) RateLimitGovernor — header self-correction > does NOT raise local budget above its own estimate [0.07ms]
+(pass) RateLimitGovernor — 429 backoff > a single 429 arms base backoff before the next acquire proceeds [0.09ms]
+(pass) RateLimitGovernor — 429 backoff > backoff grows exponentially across consecutive 429s [0.05ms]
+(pass) RateLimitGovernor — 429 backoff > backoff is capped at backoffMaxMs [0.05ms]
+(pass) RateLimitGovernor — 429 backoff > a clean observation resets the backoff ladder [0.18ms]
+(pass) RateLimitGovernor — 429 backoff > backoff honors ratelimit-reset (epoch seconds) when it exceeds the schedule [0.11ms]
+(pass) pollAction > resolves immediately when the action is already completed (no sleep) [0.28ms]
+(pass) pollAction > spec signature: (actionId, getAction, {timeoutMs, intervalMs}) with clock defaulted [0.05ms]
+(pass) pollAction > polls through in-progress until completed [0.07ms]
+(pass) pollAction > does NOT treat in-progress as terminal (the Hetzner-negation trap) [0.11ms]
+(pass) pollAction > throws PollActionError(reason: errored) on an errored action [0.06ms]
+(pass) pollAction > throws PollActionError(reason: timeout) when never terminal [0.05ms]
+(pass) pollAction > never overshoots timeoutMs (no sleep that breaches the deadline) [0.05ms]
+
+src/lib/services/containers/compute-provider-fake.test.ts:
+(pass) surface > exposes all ComputeProvider methods [0.11ms]
+(pass) server lifecycle > createServer returns a not-ready (new) server [0.18ms]
+(pass) server lifecycle > getServer is a PURE read: repeated calls never flip status without ticks [0.08ms]
+(pass) server lifecycle > getServer flips new → active exactly when ticks reach activateAfterTicks [0.06ms]
+(pass) server lifecycle > serverActivateAfterTicks=0 means active immediately [0.05ms]
+(pass) server lifecycle > getServer returns null for an unknown id [0.02ms]
+(pass) server lifecycle > listServers returns live servers and filters by labels [0.10ms]
+(pass) server lifecycle > ids and created timestamps are deterministic across instances [0.03ms]
+(pass) server delete > deleteServer makes subsequent getServer null [0.04ms]
+(pass) server delete > a second delete resolves void (404 == success), never throws [0.09ms]
+(pass) server delete > deleting an id that never existed is a no-op success [0.01ms]
+(pass) server delete > deleted servers drop out of listServers [0.02ms]
+(pass) volume lifecycle > createVolume is `creating` then `available` after ticks [0.09ms]
+(pass) volume lifecycle > volumeAvailableAfterTicks=0 means available immediately [0.03ms]
+(pass) volume lifecycle > getVolume returns null for unknown id; null after delete [0.03ms]
+(pass) volume lifecycle > listVolumes filters by location and label [0.07ms]
+(pass) actions > attachVolume returns an in-progress action; waitForAction completes it [0.11ms]
+(pass) actions > detachVolume clears the attachment and goes in-progress → completed [0.05ms]
+(pass) actions > powerOff / powerOn return in-progress actions that complete [0.05ms]
+(pass) actions > waitForAction resolves a poisoned id to `errored` WITHOUT throwing [0.05ms]
+(pass) actions > pre-seeded poisonedActionIds also resolve errored [0.06ms]
+(pass) actions > waitForAction on an unknown action id throws not_found [0.06ms]
+(pass) actions > waitForAction does not sleep (resolves synchronously fast) [0.05ms]
+(pass) actions > attach/detach/power against a missing server or volume throw not_found [0.05ms]
+(pass) capacity > createServer rejects with no_capacity once maxServers reached [0.05ms]
+(pass) capacity > deleting a server frees a capacity slot [0.04ms]
+(pass) capacity > createVolume rejects with no_capacity once maxVolumes reached [0.03ms]
+(pass) capacity > unbounded by default: many servers create fine [0.09ms]
+(pass) injected clock > startTick seeds the initial tick; tick(n) advances by n [0.01ms]
+(pass) injected clock > tick rejects non-integer / negative input [0.03ms]
+(pass) injected clock > full async lifecycle is reproducible end-to-end [0.08ms]
+
+src/lib/services/containers/compute-provider-characterization.test.ts:
+(pass) HetznerCloudClient public surface > pins the set of public methods [0.15ms]
+(pass) HetznerCloudClient public surface > static constructors and module accessors exist [0.02ms]
+(pass) HetznerCloudClient public surface > withToken rejects an empty token with missing_token [0.07ms]
+(pass) HetznerCloudClient transport > sends Bearer auth + JSON content-type to the default API base [0.40ms]
+(pass) HetznerCloudClient transport > a 204 No Content response maps to undefined (delete path) [0.10ms]
+(pass) HetznerCloudClient transport > a transport-level fetch rejection maps to transport_error [0.12ms]
+(pass) HetznerCloudClient servers > listServers without labels hits /servers with no query string [0.04ms]
+(pass) HetznerCloudClient servers > listServers encodes a label selector [0.07ms]
+(pass) HetznerCloudClient servers > getServer returns the server payload on 200 [0.08ms]
+(pass) HetznerCloudClient servers > getServer returns null on 404 (does not throw) [0.05ms]
+(pass) HetznerCloudClient servers > createServer remaps camelCase input to the Hetzner wire body [0.16ms]
+(pass) HetznerCloudClient servers > createServer omits ssh_keys/networks/labels when empty [0.05ms]
+(pass) HetznerCloudClient servers > createServer rejects userData >32KiB BEFORE any fetch [0.04ms]
+(pass) HetznerCloudClient servers > powerOff / powerOn POST to the action endpoints and return the action [0.10ms]
+(pass) HetznerCloudClient volumes > createVolume remaps sizeGb→size and defaults format to ext4 [0.08ms]
+(pass) HetznerCloudClient volumes > createVolume includes server/automount=false/labels when set [0.04ms]
+(pass) HetznerCloudClient volumes > attachVolume body is {server, automount} and defaults automount=false [0.06ms]
+(pass) HetznerCloudClient volumes > detachVolume POSTs to the detach action endpoint [0.04ms]
+(pass) HetznerCloudClient volumes > deleteVolume issues a DELETE and resolves undefined on 204 [0.05ms]
+(pass) HetznerCloudClient volumes > getVolume returns null on 404 [0.06ms]
+(pass) HetznerCloudClient volumes > listVolumes applies the location filter CLIENT-SIDE after the fetch [0.09ms]
+(pass) HetznerCloudClient waitForAction > returns immediately when the first poll reports success [0.08ms]
+(pass) HetznerCloudClient waitForAction > returns an error action without throwing (status !== running) [0.03ms]
+(pass) HetznerCloudClient catalog > listServerTypes / listLocations unwrap their envelopes [0.09ms]
+(pass) HetznerCloudClient catalog > listImages encodes type + architecture query params [0.06ms]
+(pass) HetznerCloudClient catalog > listImages with no filter hits /images with no query string [0.03ms]
+(pass) HetznerCloudClient error mapping > 403 with apiCode limit_reached → quota_exceeded (wins over auth fallback) [0.18ms]
+(pass) HetznerCloudClient error mapping > 403 with apiCode resource_limit_exceeded → quota_exceeded [0.08ms]
+(pass) HetznerCloudClient error mapping > plain 403 (no quota apiCode) → missing_token [0.06ms]
+(pass) HetznerCloudClient error mapping > 401 → missing_token [0.03ms]
+(pass) HetznerCloudClient error mapping > 404 (on a non-get-by-id call) → not_found [0.03ms]
+(pass) HetznerCloudClient error mapping > 422 → invalid_input [0.02ms]
+(pass) HetznerCloudClient error mapping > 400 → invalid_input [0.02ms]
+(pass) HetznerCloudClient error mapping > 429 → rate_limited [0.03ms]
+(pass) HetznerCloudClient error mapping > 500 → server_error [0.03ms]
+(pass) HetznerCloudClient error mapping > a non-JSON error body maps to server_error (parse precedes status mapping) [0.09ms]
+(pass) HetznerCloudClient env construction > isHetznerCloudConfigured is false with no token env [0.12ms]
+(pass) HetznerCloudClient env construction > isHetznerCloudConfigured is true once HCLOUD_TOKEN is set [0.04ms]
+(pass) HetznerCloudClient env construction > fromEnv throws missing_token when no token env is present [0.04ms]
+(pass) HetznerCloudClient env construction > fromEnv constructs a client when HCLOUD_TOKEN is set and uses it as Bearer [0.05ms]
+
+src/lib/services/containers/image-rollout-status.test.ts:
+(pass) describeImageReference — pinning + production safety > a full sha256 digest is production-safe with no warning [0.09ms]
+(pass) describeImageReference — pinning + production safety > a malformed digest is rejected as not production-safe [0.05ms]
+(pass) describeImageReference — pinning + production safety > an explicit mutable tag is not production-safe [0.02ms]
+(pass) describeImageReference — pinning + production safety > no tag and no digest resolves to implicit mutable latest [0.02ms]
+(pass) describeImageReference — pinning + production safety > a registry host:port is not mistaken for a tag [0.01ms]
+(pass) describeImageReference — pinning + production safety > a registry host:port WITH a tag parses repository and tag correctly [0.01ms]
+(pass) describeImageReference — pinning + production safety > digest pinning wins even when a tag is also present [0.01ms]
+(pass) describeImageReference — pinning + production safety > trims surrounding whitespace [0.01ms]
+(pass) imageMatchesDesired > a null current image never matches [0.02ms]
+(pass) imageMatchesDesired > digest-desired matches purely by digest (repository/tag noise ignored) [0.02ms]
+(pass) imageMatchesDesired > a tagged current image does not match a digest-desired image
+(pass) imageMatchesDesired > tag-desired matches by exact reference [0.01ms]
+(pass) summarizeImageRollout — status state machine > disabled pool short-circuits regardless of rows [0.16ms]
+(pass) summarizeImageRollout — status state machine > an unpinned desired image is blocked from rollout [0.02ms]
+(pass) summarizeImageRollout — status state machine > a pinned desired image with no ready rows needs replenish [0.01ms]
+(pass) summarizeImageRollout — status state machine > all rows on the desired image ⇒ current, no action [0.02ms]
+(pass) summarizeImageRollout — status state machine > a stale-image row triggers a rollout and is reported as stale [0.07ms]
+(pass) summarizeImageRollout — status state machine > a null-image row counts as unknown + stale [0.03ms]
+(pass) summarizeImageRollout — status state machine > currentImages aggregates duplicates and sorts by image name [0.06ms]
+(pass) summarizeImageRollout — status state machine > canary stays unsupported; rollback is an operator-gated supported action [0.03ms]
+
+src/lib/services/containers/node-bootstrap.test.ts:
+(pass) buildContainerNodeUserData — ghcr access > clears stale ghcr creds (logout) when no registry token is configured [19.74ms]
+(pass) buildContainerNodeUserData — ghcr access > logs in (no logout) when a registry token + username are configured [0.06ms]
+(pass) buildContainerNodeUserData — ghcr access > ghcr-access step runs after the bridge network and before the pre-pull [0.03ms]
+
+src/lib/services/containers/agent-warm-pool.test.ts:
+(pass) decideReplenish > creates up to the deficit when under target with headroom + burst room [0.87ms]
+(pass) decideReplenish > caps a large deficit at the burst limit and says so [0.03ms]
+(pass) decideReplenish > counts in-flight provisioning toward the total (won't over-create) [0.04ms]
+(pass) decideReplenish > limits creation by headroom to maxPoolSize [0.01ms]
+(pass) decideReplenish > defers when already at maxPoolSize with an over-cap target [0.01ms]
+(pass) decideReplenish > steady state creates nothing [0.01ms]
+(pass) decideReplenish > never returns a negative toCreate when over target
+(pass) decideDrain > never drains while demand keeps the target above the floor [0.05ms]
+(pass) decideDrain > never drains when at or below the floor [0.02ms]
+(pass) decideDrain > holds surplus rows that are still inside the idle window [0.05ms]
+(pass) decideDrain > drains the OLDEST surplus rows past the idle window, capped at the surplus [0.04ms]
+(pass) decideDrain > ignores rows with no pool_ready_at timestamp [0.02ms]
+(pass) decideRollout > replaces rows whose image differs from the current image [0.04ms]
+(pass) decideRollout > treats every row as current when all images match [0.02ms]
+(pass) decideRollout > does NOT replace rows with an unknown (null) image
+
+src/lib/services/containers/node-autoscaler.test.ts:
+(pass) NodeAutoscaler Hetzner provisioning > creates a Hetzner server and registers the autoscaled docker node [0.42ms]
+(pass) NodeAutoscaler Hetzner provisioning > passes configured Hetzner private network ids to new nodes [0.09ms]
+(pass) NodeAutoscaler Hetzner provisioning > fails before calling hcloud when Hetzner is not configured [0.08ms]
+(pass) NodeAutoscaler Hetzner provisioning > generates an eliza-core-<8hex> nodeId when none is supplied [0.42ms]
+(pass) NodeAutoscaler Hetzner provisioning > generated nodeIds are unique across repeated provisions [0.57ms]
+(pass) NodeAutoscaler Hetzner provisioning > scales up when there is no healthy compatible capacity [0.26ms]
+(pass) NodeAutoscaler Hetzner provisioning > provisions through an injected ComputeProvider without monkey-patching (#8919) [0.18ms]
+(pass) NodeAutoscaler full provision→healthy→drain loop (#8920) > drives provision → healthy → drain against an injected ComputeProvider + stateful docker_nodes [0.70ms]
+
+src/lib/services/containers/digitalocean-provider.test.ts:
+(pass) DigitalOceanComputeProvider public surface > exposes the full ComputeProvider method set [0.17ms]
+(pass) DigitalOceanComputeProvider public surface > withToken rejects an empty token with missing_token [0.13ms]
+(pass) DigitalOceanComputeProvider transport > sends Bearer auth + JSON content-type to the DO v2 base [0.42ms]
+(pass) DigitalOceanComputeProvider transport > a request fires missing_token (no fetch) when the token getter is empty [0.05ms]
+(pass) DigitalOceanComputeProvider transport > a transport-level fetch rejection maps to transport_error [0.12ms]
+(pass) DigitalOceanComputeProvider transport > a 204 No Content maps to undefined (delete path) [0.10ms]
+(pass) DigitalOceanComputeProvider servers > listServers sends per_page; first label value becomes tag_name; rest filtered client-side [0.18ms]
+(pass) DigitalOceanComputeProvider servers > getServer maps the droplet and normalizes status + IPs [0.12ms]
+(pass) DigitalOceanComputeProvider servers > getServer returns null on a 404 DO envelope (does not throw) [0.05ms]
+(pass) DigitalOceanComputeProvider servers > createServer remaps camelCase input to the DO wire body [0.15ms]
+(pass) DigitalOceanComputeProvider servers > createServer coerces an all-digits image string to a numeric id [0.04ms]
+(pass) DigitalOceanComputeProvider servers > createServer omits ssh_keys/tags/vpc_uuid when not provided [0.04ms]
+(pass) DigitalOceanComputeProvider servers > createServer rejects userData > 64 KiB BEFORE any fetch [0.04ms]
+(pass) DigitalOceanComputeProvider servers > deleteServer 404 == success (resolves undefined, never throws) [0.05ms]
+(pass) DigitalOceanComputeProvider servers > deleteServer rethrows non-404 errors [0.03ms]
+(pass) DigitalOceanComputeProvider servers > powerOff / powerOn POST a droplet action and map the action status [0.12ms]
+(pass) DigitalOceanComputeProvider volumes > createVolume remaps sizeGb → size_gigabytes and defaults filesystem_type ext4 [0.12ms]
+(pass) DigitalOceanComputeProvider volumes > createVolume honors format + labels (tags) [0.04ms]
+(pass) DigitalOceanComputeProvider volumes > listVolumes sends region server-side and filters labels client-side [0.18ms]
+(pass) DigitalOceanComputeProvider volumes > getVolume maps droplet_ids[0] → server and returns null on 404 [0.09ms]
+(pass) DigitalOceanComputeProvider volumes > attachVolume POSTs {type:attach, droplet_id} to the volume actions endpoint [0.07ms]
+(pass) DigitalOceanComputeProvider volumes > detachVolume looks up the current droplet, then POSTs detach [0.09ms]
+(pass) DigitalOceanComputeProvider volumes > detachVolume throws invalid_input when the volume is unattached [0.03ms]
+(pass) DigitalOceanComputeProvider volumes > deleteVolume 404 == success [0.07ms]
+(pass) DigitalOceanComputeProvider waitForAction > returns immediately when the first poll is completed [0.08ms]
+(pass) DigitalOceanComputeProvider waitForAction > polls until the action leaves in-progress (loop runs more than once) [0.06ms]
+(pass) DigitalOceanComputeProvider waitForAction > returns an errored action WITHOUT throwing [0.03ms]
+(pass) DigitalOceanComputeProvider waitForAction > throws transport_error when the deadline is already past (no fetch) [0.04ms]
+(pass) DigitalOceanComputeProvider catalog > listServerTypes unwraps sizes and surfaces vcpus/memoryMb [0.06ms]
+(pass) DigitalOceanComputeProvider catalog > listLocations unwraps regions to {id: slug, name} [0.33ms]
+(pass) DigitalOceanComputeProvider catalog > listImages encodes the type filter and ignores architecture [0.08ms]
+(pass) DigitalOceanComputeProvider catalog > listImages with no filter hits /images with only per_page [0.03ms]
+(pass) DigitalOceanComputeProvider error mapping > 422 limit_reached → quota_exceeded (wins over invalid_input fallback) [0.06ms]
+(pass) DigitalOceanComputeProvider error mapping > 422 too_many_requests_droplet_limit → quota_exceeded [0.03ms]
+(pass) DigitalOceanComputeProvider error mapping > 404 → not_found [0.02ms]
+(pass) DigitalOceanComputeProvider error mapping > 401 → missing_token [0.02ms]
+(pass) DigitalOceanComputeProvider error mapping > 403 → missing_token [0.03ms]
+(pass) DigitalOceanComputeProvider error mapping > 422 (no quota id) → invalid_input [0.02ms]
+(pass) DigitalOceanComputeProvider error mapping > 400 → invalid_input [0.02ms]
+(pass) DigitalOceanComputeProvider error mapping > 429 → rate_limited [0.02ms]
+(pass) DigitalOceanComputeProvider error mapping > 500 → server_error [0.03ms]
+(pass) DigitalOceanComputeProvider error mapping > a non-JSON error body maps to server_error (JSON parse fails before status mapping) [0.06ms]
+(pass) status mappers > mapDropletStatus normalizes the DO vocabulary to Hetzner vocabulary [0.01ms]
+(pass) status mappers > mapActionStatus normalizes the DO action vocabulary
+(pass) getComputeProvider / isComputeConfigured selection > COMPUTE_PROVIDER=digitalocean returns a DigitalOceanComputeProvider [0.12ms]
+(pass) getComputeProvider / isComputeConfigured selection > default (unset) returns the Hetzner client [0.08ms]
+(pass) getComputeProvider / isComputeConfigured selection > any non-digitalocean value falls back to Hetzner [0.01ms]
+(pass) getComputeProvider / isComputeConfigured selection > isComputeConfigured tracks the DO token when provider=digitalocean [0.04ms]
+(pass) getComputeProvider / isComputeConfigured selection > isComputeConfigured also honors DIGITALOCEAN_TOKEN for the DO provider [0.02ms]
+(pass) getComputeProvider / isComputeConfigured selection > isComputeConfigured tracks the Hetzner token when provider defaults to hetzner [0.03ms]
+(pass) getComputeProvider / isComputeConfigured selection > a DO token does NOT make the default (hetzner) provider configured [0.03ms]
+
+src/lib/services/containers/agent-warm-pool-forecast.test.ts:
+(pass) computeForecast — guards > throws when minPoolSize exceeds maxPoolSize [18.10ms]
+(pass) computeForecast — guards > throws when emaAlpha is out of (0, 1] [0.05ms]
+(pass) computeForecast — guards > accepts the boundary emaAlpha = 1 [0.04ms]
+(pass) computeForecast — guards > throws when leadTimeBuckets is negative [0.02ms]
+(pass) computeForecast — empty window > no buckets ⇒ rate 0, target floored at minPoolSize, observedBuckets 0 [0.02ms]
+(pass) computeForecast — EMA > a single bucket is honored (EMA seeded at the first observation) [0.01ms]
+(pass) computeForecast — EMA > alpha = 1 makes the forecast equal the most recent bucket [0.01ms]
+(pass) computeForecast — EMA > a steady rate forecasts to that rate [0.01ms]
+(pass) computeForecast — EMA > recent buckets dominate older ones under EMA [0.04ms]
+(pass) computeForecast — target sizing + clamp > target = ceil(rate × leadTime) + minPoolSize, then clamped [0.01ms]
+(pass) computeForecast — target sizing + clamp > a low non-zero rate still lifts target above the floor (ceil rounds up)
+(pass) computeForecast — target sizing + clamp > clamps up to maxPoolSize on a burst
+(pass) computeForecast — target sizing + clamp > a zero rate keeps target exactly at the floor
+(pass) computeForecast — target sizing + clamp > leadTimeBuckets = 0 pins target to the floor regardless of rate
+(pass) DEFAULT_WARM_POOL_POLICY > is internally consistent (floor ≤ ceiling, valid alpha, sane windows) [0.03ms]
+
+src/lib/services/message-router/index.test.ts:
+(pass) MessageRouterService contact recording > records a phone contact after a successful agent outbound message [1.80ms]
+(pass) MessageRouterService contact recording > does not record a contact when agent ownership metadata is missing [0.07ms]
+[MessageRouter] Blooio send error {
+  error: 170 |     expect(dbWrite.insert).not.toHaveBeenCalled();
+171 |   });
+172 |
+173 |   test("does not record a contact when provider send fails", async () => {
+174 |     secretsGet.mockResolvedValue("blooio-api-key");
+175 |     blooioApiRequest.mockRejectedValue(new Error("provider down"));
+                                                 ^
+error: provider down
+      at <anonymous> (/Users/shawwalters/.codex/worktrees/36cd/eliza/packages/cloud/shared/src/lib/services/message-router/index.test.ts:175:44)
+,
+}
+(pass) MessageRouterService contact recording > does not record a contact when provider send fails [0.19ms]
+
+src/lib/services/shared-runtime/agent-tier.test.ts:
+(pass) getAgentTier > defaults a plain agent to shared (no container) [0.18ms]
+(pass) getAgentTier > escalates a custom docker image to 'custom' [0.01ms]
+(pass) getAgentTier > escalates the always-on toggle / too-large model / stateful runtime to dedicated-always [0.01ms]
+(pass) getAgentTier > escalates persistent-connection plugins to dedicated-always [0.01ms]
+(pass) getAgentTier > custom image wins over always-on
+(pass) tier helpers > tierProvisionsEagerly only for always-on + custom [0.02ms]
+(pass) runSharedAgentTurn (degraded path — no model configured) > never throws and appends user+assistant to history when no shared model is set [0.40ms]
+
+src/lib/services/shared-runtime/shared-rest-adapter.test.ts:
+(pass) shared-rest-adapter — conversation surface > health is ok [0.03ms]
+(pass) shared-rest-adapter — conversation surface > list returns exactly one canonical conversation (id === agentId === roomId) [0.05ms]
+(pass) shared-rest-adapter — conversation surface > create is idempotent — same canonical conversation as list [0.02ms]
+(pass) shared-rest-adapter — conversation surface > create falls back to a title when the agent has no name [0.01ms]
+(pass) shared-rest-adapter — conversation surface > update accepts title patches for the canonical conversation [0.03ms]
+(pass) shared-rest-adapter — conversation surface > update falls back to the agent title for generate-only patches [0.01ms]
+(pass) shared-rest-adapter — conversation surface > delete is accepted as a canonical-conversation compatibility no-op [0.04ms]
+(pass) shared-rest-adapter — startup shell surface > status is the first gate: running + agent name [0.02ms]
+(pass) shared-rest-adapter — startup shell surface > status falls back to a name when the agent has none
+(pass) shared-rest-adapter — startup shell surface > first-run is always complete + cloud-provisioned (no onboarding) [0.02ms]
+(pass) shared-rest-adapter — startup shell surface > config declares no websocket + no streaming (client uses non-stream REST) [0.01ms]
+(pass) shared-rest-adapter — startup shell surface > views returns the builtin chat view by default [0.03ms]
+(pass) shared-rest-adapter — startup shell surface > views honors ?viewType=: gui matches, tui/xr return empty [0.01ms]
+(pass) shared-rest-adapter — startup shell surface > auth/me reports the authed machine identity (the app's hard gate) [0.02ms]
+(pass) shared-rest-adapter — startup shell surface > auth/me falls back to a display name when the agent has none
+(pass) shared-rest-adapter — character > returns the shared runtime character the turn answers as [0.10ms]
+(pass) shared-rest-adapter — character > falls back to an empty character object when the sandbox can't resolve [0.03ms]
+(pass) shared-rest-adapter — messages > GET maps bridge turn history → REST messages [0.16ms]
+(pass) shared-rest-adapter — messages > POST forwards to bridge message.send with roomId and returns the reply [0.17ms]
+(pass) shared-rest-adapter — messages > POST throws when the bridge returns an error (surfaced to the client) [0.07ms]
+
+src/lib/services/shared-runtime/dedicated-bootstrap.test.ts:
+(pass) isDedicatedBootstrapWindow > true for a freshly-created dedicated agent still provisioning [0.03ms]
+(pass) isDedicatedBootstrapWindow > true for any dedicated tier in the boot window [0.01ms]
+(pass) isDedicatedBootstrapWindow > false for a shared-tier agent (its own path serves it) [0.01ms]
+(pass) isDedicatedBootstrapWindow > false once the container is reachable (bridge_url set) — use the subdomain
+(pass) isDedicatedBootstrapWindow > false for a running agent — handoff already switched to the subdomain
+(pass) isDedicatedBootstrapWindow > false for an established agent that went down (proxy wakes it) [0.02ms]
+(pass) isDedicatedBootstrapWindow > false for an errored or deleting agent — surface the failure [0.01ms]
+
+src/db/repositories/__tests__/apps.test.ts:
+[⣷] Pulling schema from database...
+[2K[1G[⣯] Pulling schema from database...
+[2K[1G[⣟] Pulling schema from database...
+[2K[1G[⡿] Pulling schema from database...
+[2K[1G[⢿] Pulling schema from database...
+[2K[1G[✓] Pulling schema from database...
+(pass) AppsRepository.create + reads > create returns a persisted App with id/slug/api_key_id; reads find it [10.45ms]
+(pass) AppsRepository.create + reads > reads for non-existent identifiers return undefined [2.13ms]
+(pass) AppsRepository.update > update returns the merged App and a fresh read reflects the change [5.64ms]
+(pass) AppsRepository.update > update of a non-existent id returns undefined [0.81ms]
+(pass) AppsRepository.update > update evicts the service read-cache (fresh read returns NEW value, not stale) [5.24ms]
+(pass) AppsRepository.delete > delete removes the row (findById -> undefined) and evicts the cache [7.11ms]
+(pass) AppsRepository.listByOrganization > returns only that org's apps, ordered updated_at DESC, respecting limit/offset [11.29ms]
+(pass) App-auth attribution grants > connectUser upgrades an existing analytics-created app user to an OAuth grant [6.34ms]
+[Apps] Rejected unauthorized X-App-Id attribution {
+  appId: "a72ee707-3050-434b-a1d6-d82db21474a0",
+  userId: "a34251c5-622e-45cc-9fe0-228e189ee72b",
+  userOrganizationId: "b2046fb1-923b-4ecd-a42f-72f8ba47577c",
+  appOrganizationId: "03b3ba2b-34bb-48f0-928c-fb7e79d19fc6",
+  hasAppUser: false,
+  appUserSignupSource: null,
+}
+[Apps] Rejected unauthorized X-App-Id attribution {
+  appId: "a72ee707-3050-434b-a1d6-d82db21474a0",
+  userId: "a34251c5-622e-45cc-9fe0-228e189ee72b",
+  userOrganizationId: "b2046fb1-923b-4ecd-a42f-72f8ba47577c",
+  appOrganizationId: "03b3ba2b-34bb-48f0-928c-fb7e79d19fc6",
+  hasAppUser: true,
+  appUserSignupSource: null,
+}
+(pass) App-auth attribution grants > X-App-Id attribution requires same org or an OAuth app-auth grant [7.39ms]
+(pass) AppsRepository.listAll > filters by is_active / is_approved [4.84ms]
+(pass) AppsRepository.checkNameAvailability > available for a fresh name [0.86ms]
+(pass) AppsRepository.checkNameAvailability > taken (app slug) -> available:false + slug + conflictType 'app' [2.13ms]
+(pass) AppsRepository.checkNameAvailability > subdomain-collision path -> available:false + conflictType 'subdomain' [2.97ms]
+(pass) jsonb + scalar round-trips > metadata { viewKind, foo } persists and reads back through the jsonb column [3.50ms]
+(pass) jsonb + scalar round-trips > affiliate_code + app_url round-trip [3.51ms]
+(pass) AppsService.isNameAvailable > taken name -> available:false + a suggestedName [2.06ms]
+(pass) AppsService.isNameAvailable > available name -> available:true and no suggestedName [0.77ms]
+[Apps] Invalid ELIZA_CLOUD_MAX_APPS_PER_ORG; using default {
+  value: "1abc",
+  defaultValue: 25,
+}
+(pass) AppsService.create organization cap > treats malformed cap values as invalid and falls back to the default [7.28ms]
+[Apps] Rejected app create at organization cap {
+  organizationId: "fd346b41-7926-425e-99f0-dae12e3b7b3f",
+  currentCount: 1,
+  limit: 1,
+}
+(pass) AppsService.create organization cap > rejects before API key creation when the org is already at the configured app cap [3.26ms]
+(pass) AppsService.create organization cap > allows creation below the configured cap and persists the generated API key [5.08ms]
+(pass) AppsService.create organization cap > cleans up the generated API key when the transactional cap check rejects [3.59ms]
+
+src/db/repositories/__tests__/domain-purchase-ownership.test.ts:
+(pass) hasUnrefundedDomainPurchase > no transactions → false [2.22ms]
+(pass) hasUnrefundedDomainPurchase > an unrefunded domain_purchase debit → true [1.16ms]
+(pass) hasUnrefundedDomainPurchase > debit fully refunded → false [1.94ms]
+(pass) hasUnrefundedDomainPurchase > re-purchased after a refund (debits > refunds) → true [2.30ms]
+(pass) hasUnrefundedDomainPurchase > a different org's purchase does not grant ownership [1.12ms]
+(pass) hasUnrefundedDomainPurchase > a purchase of a different domain does not match [1.11ms]
+
+src/db/repositories/__tests__/agent-billing-reactivation.test.ts:
+[⣷] Pulling schema from database...
+[2K[1G[⣯] Pulling schema from database...
+[2K[1G[⣟] Pulling schema from database...
+[2K[1G[⡿] Pulling schema from database...
+[2K[1G[⢿] Pulling schema from database...
+[2K[1G[✓] Pulling schema from database...
+(pass) AgentBillingRepository.reactivateSandboxBillingAfterFunding > a suspended running agent is EXCLUDED from the billable set until reactivated [11.48ms]
+(pass) AgentBillingRepository.reactivateSandboxBillingAfterFunding > an EXEMPT agent is never forced into billing by reactivation [5.66ms]
+
+src/db/repositories/__tests__/tenant-scope-gate.test.ts:
+(pass) tenant-scope gate (#9853 P1.6) > flags a pk-only read against a tenant data-plane table [34.24ms]
+(pass) tenant-scope gate (#9853 P1.6) > passes when the read is annotated global-scope or carries an ownership predicate [2.71ms]
+
+src/lib/eliza/plugin-cloud-bootstrap/utils/context-routing.test.ts:
+(pass) parseContextList > splits, normalizes, dedupes, and drops unknown contexts [0.24ms]
+(pass) parseContextRoutingMetadata > derives primary + de-duplicated secondary contexts [0.07ms]
+(pass) parseContextRoutingMetadata > non-object input yields an empty decision
+(pass) getActiveRoutingContexts > always includes general plus primary + secondary [0.03ms]
+(pass) resolveActionContexts > declared contexts win, else map lookup, else general [0.03ms]
+(pass) deriveAvailableContexts > collects, includes general, and sorts [0.07ms]
+(pass) filterActionsByRouting > general-only routing keeps all actions [0.02ms]
+(pass) filterActionsByRouting > wallet routing keeps wallet + general actions, drops browser [0.04ms]
+
+src/lib/eliza/shared/utils/helpers.test.ts:
+(pass) AI-speak detection + removal > flags persona-breaking phrases [1.07ms]
+(pass) AI-speak detection + removal > removeAISpeak strips the offending sentence, keeps the rest [0.14ms]
+(pass) isRepetitiveGreeting > matches bare greetings, ignores substantive openers [0.07ms]
+(pass) cleanPrompt > collapses blank runs, trims leading newlines + trailing whitespace [0.04ms]
+(pass) isRepeatedOpening / trackOpening > a tracked opening is detected as repeated, per-room [0.06ms]
+(pass) extractAttachments > keeps http attachments, drops data: URLs / placeholders / empties [0.07ms]
+
+src/lib/eliza/plugin-oauth/actions/oauth.test.ts:
+(pass) OAUTH structured op routing (#10471) > does not infer revoke intent from raw English message text [0.22ms]
+(pass) OAUTH structured op routing (#10471) > does not infer status intent from raw English completion text [0.09ms]
+(pass) OAUTH structured op routing (#10471) > uses structured op params even when message text is non-English [0.38ms]
+(pass) OAUTH structured op routing (#10471) > uses legacy structured action metadata without parsing message text [0.16ms]
+
+src/lib/services/oauth/connection-adapters/secrets-adapter-utils.connid.test.ts:
+(pass) verifyConnectionId > derives a deterministic id from platform + org [0.74ms]
+(pass) verifyConnectionId > accepts the id that matches (platform, org) [0.04ms]
+(pass) verifyConnectionId > REJECTS another org's connection id (IDOR guard) [0.05ms]
+(pass) verifyConnectionId > REJECTS a different platform's id and an arbitrary id [0.03ms]
+
+src/lib/services/ai-pricing/providers/gateway.test.ts:
+(pass) fetchEntriesForSource — provider-outage resilience > returns [] and warns when a provider fetch throws (never 500s inference) [0.20ms]
+(pass) fetchEntriesForSource — provider-outage resilience > returns the provider's entries unchanged on success [0.03ms]
+
+src/lib/services/proxy/services/address-validation.test.ts:
+(pass) isValidSolanaAddress > accepts real base58 32-byte addresses [0.13ms]
+(pass) isValidSolanaAddress > rejects empty / non-string / wrong-length input [0.01ms]
+(pass) isValidSolanaAddress > rejects base58-forbidden characters (0, O, I, l)
+(pass) isValidAddress (multi-chain dispatch) > routes solana addresses (case-insensitive chain) [0.24ms]
+(pass) isValidAddress (multi-chain dispatch) > rejects an unknown chain outright
+
+src/lib/services/gateway-discord/__tests__/schemas.test.ts:
+(pass) DiscordEventTypeSchema > accepts valid event types [0.11ms]
+(pass) DiscordEventTypeSchema > rejects invalid event types [0.27ms]
+(pass) DiscordEventTypeSchema > rejects empty string [0.05ms]
+(pass) DiscordEventTypeSchema > rejects non-string values [0.04ms]
+(pass) DiscordAuthorSchema > accepts valid author with required fields [0.63ms]
+(pass) DiscordAuthorSchema > accepts valid author with all optional fields [0.05ms]
+(pass) DiscordAuthorSchema > accepts null avatar and global_name [0.02ms]
+(pass) DiscordAuthorSchema > rejects author without id [0.05ms]
+(pass) DiscordAuthorSchema > rejects author without username [0.03ms]
+(pass) DiscordAuthorSchema > rejects empty id [0.04ms]
+(pass) DiscordAuthorSchema > rejects empty username [0.02ms]
+(pass) DiscordMemberSchema > accepts valid member with nick [0.09ms]
+(pass) DiscordMemberSchema > accepts valid member with roles [0.06ms]
+(pass) DiscordMemberSchema > accepts null nick
+(pass) DiscordMemberSchema > accepts empty object
+(pass) DiscordAttachmentSchema > accepts valid attachment with required fields [0.22ms]
+(pass) DiscordAttachmentSchema > accepts valid attachment with all optional fields [0.08ms]
+(pass) DiscordAttachmentSchema > rejects invalid URL [0.07ms]
+(pass) DiscordAttachmentSchema > rejects negative size [0.04ms]
+(pass) DiscordAttachmentSchema > rejects zero size [0.06ms]
+(pass) DiscordAttachmentSchema > rejects empty id [0.03ms]
+(pass) VoiceAttachmentSchema > accepts valid voice attachment [0.24ms]
+(pass) VoiceAttachmentSchema > rejects invalid datetime format [0.04ms]
+(pass) VoiceAttachmentSchema > rejects missing required fields [0.05ms]
+(pass) VoiceAttachmentSchema > rejects negative size [0.03ms]
+(pass) MessageCreateDataSchema > accepts valid message with required fields [0.50ms]
+(pass) MessageCreateDataSchema > accepts valid message with guild_id [0.04ms]
+(pass) MessageCreateDataSchema > accepts null guild_id (DM) [0.02ms]
+(pass) MessageCreateDataSchema > accepts message with attachments [0.04ms]
+(pass) MessageCreateDataSchema > accepts message with embeds [0.15ms]
+(pass) MessageCreateDataSchema > accepts message with mentions [0.14ms]
+(pass) MessageCreateDataSchema > accepts message with referenced_message (reply) [0.07ms]
+(pass) MessageCreateDataSchema > accepts message with voice_attachments [0.04ms]
+(pass) MessageCreateDataSchema > accepts message with member data [0.02ms]
+(pass) MessageCreateDataSchema > rejects message without id [0.05ms]
+(pass) MessageCreateDataSchema > rejects message without channel_id [0.04ms]
+(pass) MessageCreateDataSchema > rejects message without author [0.03ms]
+(pass) DiscordEventPayloadSchema > validates connection_id as UUID [0.06ms]
+(pass) DiscordEventPayloadSchema > validates organization_id as UUID [0.03ms]
+(pass) DiscordEventPayloadSchema > validates event_type as enum [0.03ms]
+(pass) DiscordEventPayloadSchema > validates timestamp as datetime [0.02ms]
+(pass) DiscordEventPayloadSchema > validates event_id is non-empty [0.03ms]
+(pass) DiscordEventPayloadSchema > validates platform_connection_id is string
+(pass) DiscordEventPayloadSchema > validates guild_id is string
+(pass) DiscordEventPayloadSchema > validates channel_id is string
+(pass) ConnectionStatusUpdateSchema > accepts valid status update [0.20ms]
+(pass) ConnectionStatusUpdateSchema > accepts all valid statuses [0.04ms]
+(pass) ConnectionStatusUpdateSchema > accepts error_message with error status [0.01ms]
+(pass) ConnectionStatusUpdateSchema > accepts bot_user_id with connected status [0.01ms]
+(pass) ConnectionStatusUpdateSchema > rejects invalid pod_name with special characters [0.08ms]
+(pass) ConnectionStatusUpdateSchema > rejects pod_name over 253 characters [0.03ms]
+(pass) ConnectionStatusUpdateSchema > accepts pod_name at max 253 characters [0.01ms]
+(pass) ConnectionStatusUpdateSchema > rejects empty pod_name [0.02ms]
+(pass) ConnectionStatusUpdateSchema > rejects invalid status [0.03ms]
+(pass) ConnectionStatusUpdateSchema > rejects invalid connection_id [0.03ms]
+(pass) FailoverRequestSchema > accepts valid failover request [0.09ms]
+(pass) FailoverRequestSchema > accepts hyphenated pod names [0.01ms]
+(pass) FailoverRequestSchema > rejects invalid claiming_pod name [0.02ms]
+(pass) FailoverRequestSchema > rejects invalid dead_pod name [0.02ms]
+(pass) FailoverRequestSchema > rejects missing claiming_pod [0.03ms]
+(pass) FailoverRequestSchema > rejects missing dead_pod [0.02ms]
+
+src/lib/services/gateway-discord/__tests__/event-router.test.ts:
+(pass) sanitizeError logic > regex matches Discord token format [21.07ms]
+(pass) sanitizeError logic > redacts Discord bot tokens from error messages [0.11ms]
+(pass) sanitizeError logic > preserves non-token text in error messages [0.01ms]
+(pass) sanitizeError logic > token embedded in error message is redacted [0.02ms]
+(pass) sanitizeError logic > handles Error objects [0.03ms]
+(pass) sanitizeError logic > handles multiple tokens in one message [0.01ms]
+(pass) sanitizeError logic > handles non-Error objects [0.02ms]
+(pass) sanitizeError logic > regex does not match non-token strings [0.02ms]
+(pass) truncateUtf16Safe logic > does not truncate strings under limit [0.03ms]
+(pass) truncateUtf16Safe logic > truncates strings over limit [0.01ms]
+(pass) truncateUtf16Safe logic > handles surrogate pairs correctly [0.01ms]
+(pass) truncateUtf16Safe logic > preserves complete emoji when there is room [0.01ms]
+(pass) truncateUtf16Safe logic > removes emoji if truncation would split it
+(pass) channel filtering logic > enabledChannels empty allows all [0.01ms]
+(pass) channel filtering logic > enabledChannels with matching channel allows [0.01ms]
+(pass) channel filtering logic > enabledChannels without matching channel blocks
+(pass) channel filtering logic > disabledChannels blocks matching channel
+(pass) channel filtering logic > disabledChannels allows non-matching channel
+(pass) keyword matching logic > matches exact keyword [0.06ms]
+(pass) keyword matching logic > matches keyword with different case [0.02ms]
+(pass) keyword matching logic > does not match partial word [0.01ms]
+(pass) keyword matching logic > matches word at boundaries [0.02ms]
+(pass) keyword matching logic > matches multiple keywords
+(pass) keyword matching logic > returns false when no keywords match
+(pass) keyword matching logic > escapes regex special characters in keywords [0.02ms]
+(pass) mention mode logic > detects bot mention in mentions array [0.02ms]
+(pass) mention mode logic > detects when bot is not mentioned [0.02ms]
+(pass) mention mode logic > handles empty mentions array
+(pass) message processing - data transformation > MessageCreateDataSchema accepts attachments [0.70ms]
+(pass) message processing - data transformation > MessageCreateDataSchema accepts voice attachments [0.14ms]
+(pass) message processing - data transformation > MessageCreateDataSchema accepts combined attachments [0.05ms]
+(pass) bot message filtering > detects bot messages [0.01ms]
+(pass) bot message filtering > detects user messages
+(pass) bot message filtering > handles missing bot field
+
+src/lib/services/gateway-discord/__tests__/constants.test.ts:
+(pass) DEAD_POD_THRESHOLD_MS > has correct default value of 45 seconds [20.38ms]
+(pass) DEAD_POD_THRESHOLD_MS > is a positive number [0.04ms]
+(pass) DEAD_POD_THRESHOLD_MS > is at least 3x typical heartbeat interval (15s)
+(pass) DEAD_POD_THRESHOLD_MS > is less than pod state TTL (300s / 5 minutes)
+
+src/lib/services/tenant-db/__tests__/cluster-pool.test.ts:
+(pass) selectLeastLoadedCluster > picks the active cluster with the lowest database_count [0.12ms]
+(pass) selectLeastLoadedCluster > ties break deterministically by id [0.02ms]
+(pass) selectLeastLoadedCluster > skips full and inactive clusters [0.02ms]
+(pass) selectLeastLoadedCluster > returns null for an empty pool
+(pass) ClusterPool.allocate > allocates the least-loaded cluster and returns its admin handle [0.14ms]
+(pass) ClusterPool.allocate > retries on a lost claim race, then succeeds on the next candidate [0.06ms]
+(pass) ClusterPool.allocate > throws NoClusterCapacityError when nothing is claimable [0.11ms]
+(pass) ClusterPool.allocate > throws after exhausting attempts when every claim keeps racing [0.04ms]
+
+src/lib/services/tenant-db/__tests__/tenant-db-provisioner.test.ts:
+(pass) deriveTenantIdent > derives valid, stable db + role identifiers from an app id [0.06ms]
+(pass) deriveTenantIdent > rejects an app id with too little entropy [0.02ms]
+(pass) quoteIdent > double-quotes and escapes embedded quotes [0.01ms]
+(pass) buildIdempotentAdminDdl — the hard cross-tenant boundary as a contract > creates the role BEFORE the database owns it (order is load-bearing) [0.04ms]
+(pass) buildIdempotentAdminDdl — the hard cross-tenant boundary as a contract > REVOKEs CONNECT from PUBLIC and GRANTs it only to the tenant role [0.02ms]
+(pass) buildIdempotentAdminDdl — the hard cross-tenant boundary as a contract > the role is least-privilege (no superuser/createdb/createrole) [0.02ms]
+(pass) buildIdempotentAdminDdl — the hard cross-tenant boundary as a contract > idempotent CREATE ROLE: DO block that swallows duplicate_object [0.01ms]
+(pass) buildIdempotentAdminDdl — the hard cross-tenant boundary as a contract > ALWAYS sets the role password (escaped) so a retry's DSN stays current [0.01ms]
+(pass) buildIdempotentAdminDdl — the hard cross-tenant boundary as a contract > escapes a password containing a single quote in the ALTER ROLE literal [0.02ms]
+(pass) buildIdempotentAdminDdl — the hard cross-tenant boundary as a contract > emits CREATE DATABASE only when the database is absent [0.04ms]
+(pass) buildTenantDdl > locks the public schema to the tenant role only [0.02ms]
+(pass) buildDeprovisionDdl > drops the database WITH FORCE, then the role [0.02ms]
+(pass) buildDsn > builds an sslmode=require DSN with URL-encoded credentials [0.02ms]
+(pass) SqlTenantDbProvisioner > provisions: admin DDL first, then in-database DDL, returns the scoped DSN [0.44ms]
+(pass) SqlTenantDbProvisioner > provision() is DDL-idempotent: a retry (DB now present) succeeds, skips CREATE DATABASE, still rotates the password [0.12ms]
+(pass) SqlTenantDbProvisioner > provision() recovers a partial prior failure: role exists but database does not [0.07ms]
+(pass) SqlTenantDbProvisioner > deprovisions via admin DROP DATABASE/ROLE and reports the DB existed [0.09ms]
+(pass) SqlTenantDbProvisioner > deprovision reports existed:false when the DB is already gone (gates the slot release) [0.03ms]
+
+src/lib/services/tenant-db/__tests__/tenant-db-deprovision.test.ts:
+(pass) parseDsnHost > extracts the host from a full DSN (creds + port + query stripped) [0.18ms]
+(pass) parseDsnHost > returns null for an unparseable / hostless DSN [0.06ms]
+(pass) deprovisionTenantDbForApp > resolves the cluster, DROPs the DB, THEN releases the slot (order matters) [0.22ms]
+(pass) deprovisionTenantDbForApp > no-op when the DSN has no parseable host (nothing to drop) [0.04ms]
+(pass) deprovisionTenantDbForApp > no-op when no cluster owns the host (shared-mode / already-removed) [0.04ms]
+(pass) deprovisionTenantDbForApp > a failed DROP propagates and does NOT release the slot (DB still live) [0.07ms]
+(pass) deprovisionTenantDbForApp > does NOT release the slot when the DB was already gone (idempotent re-run, no double-free) [0.05ms]
+
+src/lib/services/tenant-db/__tests__/tenant-db-provisioning.test.ts:
+(pass) SqlTenantDbProvisioning > provisions on the allocated cluster and returns the real isolated DSN [0.31ms]
+(pass) SqlTenantDbProvisioning > reuses a durable app placement instead of allocating another cluster slot [0.06ms]
+(pass) SqlTenantDbProvisioning > the returned DSN is the per-tenant one, never the shared env DATABASE_URL [0.09ms]
+(pass) SqlTenantDbProvisioning > propagates a NoClusterCapacity failure from the pool [0.06ms]
+(pass) SqlTenantDbProvisioning > deprovisionForApp resolves the cluster by host, DROPs the DB, releases the slot [0.19ms]
+(pass) SqlTenantDbProvisioning > deprovisionForApp clears the recorded placement after teardown [0.07ms]
+(pass) SqlTenantDbProvisioning > deprovisionForApp does NOT release the slot when the DB was already gone (idempotent re-run) [0.05ms]
+(pass) SqlTenantDbProvisioning > deprovisionForApp throws a clear error when the teardown deps aren't wired [0.03ms]
+
+src/lib/services/containers/hetzner-client/paths.mount-path.test.ts:
+(pass) validateContainerMountPath > defaults an empty value to the standard mount path [20.31ms]
+(pass) validateContainerMountPath > accepts a normal absolute path [0.10ms]
+(pass) validateContainerMountPath > normalizes duplicate and trailing slashes [0.01ms]
+(pass) validateContainerMountPath > REJECTS mounting the host root [0.10ms]
+(pass) validateContainerMountPath > REJECTS a relative (non-absolute) path [0.02ms]
+(pass) validateContainerMountPath > REJECTS path-traversal and null bytes [0.02ms]
+
+src/lib/services/containers/hetzner-client/registry.test.ts:
+(pass) getImageRegistryHost > returns ghcr.io for fully qualified GHCR refs [0.04ms]
+(pass) getImageRegistryHost > returns null for implicit docker hub refs [0.01ms]
+[loginToImageRegistry] No registry credentials configured for ghcr.io; relying on anonymous pull (public images only — a private image will fail at docker pull)
+(pass) loginToImageRegistry > skips login for public GHCR pulls when credentials are not configured [0.21ms]
+(pass) loginToImageRegistry > logs in when registry credentials are configured [0.08ms]
+(pass) ensureRegistryAccess > logs out the registry host when NO token is configured (clears stale cred) [0.12ms]
+(pass) ensureRegistryAccess > logs in (no logout) when a registry token IS configured [0.05ms]
+(pass) ensureRegistryAccess > is a no-op for implicit docker-hub refs (no registry host) [0.02ms]
+[ensureRegistryAccess] docker logout ghcr.io failed; a stale cred may block the public pull {
+  error: "ssh boom",
+}
+(pass) ensureRegistryAccess > swallows a logout failure (best-effort, never blocks the pull) [0.07ms]
+[ensureRegistryAccess] docker login to ghcr.io failed; continuing {
+  error: "ssh boom",
+}
+(pass) ensureRegistryAccess > swallows a login failure when a token is configured [0.06ms]
+
+32 tests skipped:
+(skip) siweTestLogin (live) > creates a real free cloud account and authorizes a request
+(skip) DirectWalletPaymentsService (PGlite integration) > createPayment for BSC native BNB locks price quote and computes wei
+(skip) DirectWalletPaymentsService (PGlite integration) > createPayment for BSC USDT computes usd * 1e18 with no oracle call
+(skip) DirectWalletPaymentsService (PGlite integration) > attachTransaction flips pending -> broadcast and records hash
+(skip) DirectWalletPaymentsService (PGlite integration) > attachTransaction is idempotent on the same hash
+(skip) DirectWalletPaymentsService (PGlite integration) > attachTransaction rejects a different second hash on the same payment
+(skip) DirectWalletPaymentsService (PGlite integration) > confirmPayment (BSC USDT) credits the org and is idempotent on retry
+(skip) DirectWalletPaymentsService (PGlite integration) > confirmPayment rejects amount-too-low; status stays broadcast; no credits
+(skip) DirectWalletPaymentsService (PGlite integration) > BNB native verify accepts within ±2% slippage and rejects below floor
+(skip) DirectWalletPaymentsService (PGlite integration) > BNB native verify rejects below the slippage floor
+(skip) DirectWalletPaymentsService (PGlite integration) > BNB native verify rejects above the slippage ceiling (gross overpayment)
+(skip) DirectWalletPaymentsService (PGlite integration) > confirmPayment rejects a tampered quote_signature without touching the chain
+(skip) DirectWalletPaymentsService (PGlite integration) > processBroadcastBatch bumps verify_attempts and gives up at MAX_VERIFY_ATTEMPTS
+(skip) DirectWalletPaymentsService (PGlite integration) > Solana confirmPayment rejects when receiving ATA owner mismatches treasury
+(skip) DirectWalletPaymentsService (PGlite integration) > processBroadcastBatch confirms a broadcast row when verify succeeds
+(skip) DirectWalletPaymentsService (PGlite integration) > processBroadcastBatch marks failed_chain on terminal verify failure
+(skip) DirectWalletPaymentsService (PGlite integration) > processBroadcastBatch leaves payment in broadcast on transient (not-found) failure
+(skip) DirectWalletPaymentsService (PGlite integration) > BSC promo can only be redeemed once per organization
+(skip) DirectWalletPaymentsService (PGlite integration) > BSC promo guard is org-scoped and ignores non-promo purchases
+(skip) DirectWalletPaymentsService (PGlite integration) > getPaymentStatusForUser refuses to disclose to a different user
+(skip) payout transfer path against anvil forks > (unnamed)
+(skip) payout transfer path against anvil forks > base: ELIZA contract reachable via configured RPC
+(skip) payout transfer path against anvil forks > base: full payout sequence — impersonate holder → transfer → waitForReceipt(confirmations=2)
+(skip) payout transfer path against anvil forks > bnb: ELIZA contract reachable via configured RPC
+(skip) payout transfer path against anvil forks > bnb: full payout sequence — impersonate holder → transfer → waitForReceipt(confirmations=2)
+(skip) payout transfer path against anvil forks > (unnamed)
+(skip) tenant-db provisioning over real Postgres > (unnamed)
+(skip) tenant-db provisioning over real Postgres > two concurrent claims on a one-slot cluster: exactly one wins
+(skip) tenant-db provisioning over real Postgres > provisionForApp gives an isolated DB reachable only by its own role
+(skip) tenant-db provisioning over real Postgres > SqlTenantDbProvisioner.provision() is DDL-idempotent against REAL Postgres: a re-run on the SAME cluster does not throw, rotates the DSN, and consumes NO cluster slot
+(skip) tenant-db provisioning over real Postgres > #9686: a deploy RETRY for the SAME app reuses its durable cluster placement — provisionForApp twice claims ONE slot, not two
+(skip) tenant-db provisioning over real Postgres > (unnamed)
+
+
+1 tests failed:
+
+ 2091 pass
+ 32 skip
+ 1 fail
+ 1 error
+ 5216 expect() calls
+Ran 2124 tests across 250 files. [52.64s]

--- a/.github/issue-evidence/10471-cloud-oauth-structured-op/cloud-shared-typecheck.log
+++ b/.github/issue-evidence/10471-cloud-oauth-structured-op/cloud-shared-typecheck.log
@@ -1,0 +1,1 @@
+$ tsgo --noEmit

--- a/.github/issue-evidence/10471-cloud-oauth-structured-op/focused-oauth-test.log
+++ b/.github/issue-evidence/10471-cloud-oauth-structured-op/focused-oauth-test.log
@@ -1,0 +1,12 @@
+bun test v1.3.14 (0d9b296a)
+
+packages/cloud/shared/src/lib/eliza/plugin-oauth/actions/oauth.test.ts:
+(pass) OAUTH structured op routing (#10471) > does not infer revoke intent from raw English message text [0.18ms]
+(pass) OAUTH structured op routing (#10471) > does not infer status intent from raw English completion text [0.03ms]
+(pass) OAUTH structured op routing (#10471) > uses structured op params even when message text is non-English [0.35ms]
+(pass) OAUTH structured op routing (#10471) > uses legacy structured action metadata without parsing message text [0.14ms]
+
+ 4 pass
+ 0 fail
+ 12 expect() calls
+Ran 4 tests across 1 file. [21.92s]

--- a/.github/issue-evidence/10471-cloud-oauth-structured-op/git-diff-check.log
+++ b/.github/issue-evidence/10471-cloud-oauth-structured-op/git-diff-check.log
@@ -1,0 +1,1 @@
+git diff --cached --check: PASS

--- a/.github/issue-evidence/10471-cloud-oauth-structured-op/install.log
+++ b/.github/issue-evidence/10471-cloud-oauth-structured-op/install.log
@@ -1,0 +1,15 @@
+bun install v1.3.14 (0d9b296a)
+Resolving dependencies
+Resolved, downloaded and extracted [432]
+Saved lockfile
+
+$ bun packages/scripts/patch-nested-core-dist.mjs && bun packages/scripts/patch-punycode-deprecation.mjs && bun packages/scripts/patch-llama-cpp-capacitor.mjs && bun packages/scripts/ensure-workspace-symlinks.mjs && bun packages/scripts/build-private-workspace-packages.mjs && bun packages/scripts/sync-artifacts.mjs
+[patch-llama-cpp-capacitor] patched=0 already-applied=1 repaired=0 failed=0
+[ensure-workspace-symlinks] created=0 skipped=436 hoisted=0 missing-roots=0
+[build-private-workspace-packages] skip packages/logger (already built: dist/index.js)
+[build-private-workspace-packages] skip packages/security (already built: dist/index.js)
+[build-private-workspace-packages] skip packages/plugin-remote-manifest (already built: dist/index.js)
+[build-private-workspace-packages] skip packages/plugin-worker-runtime (already built: dist/error.js)
+[sync-artifacts] artifacts already at 2026-06-18.1; nothing to do
+
+Checked 4839 installs across 5073 packages (no changes) [4.35s]

--- a/.github/issue-evidence/10471-cloud-oauth-structured-op/root-verify.log
+++ b/.github/issue-evidence/10471-cloud-oauth-structured-op/root-verify.log
@@ -1,0 +1,3647 @@
+$ bun run audit:type-safety-ratchet && NODE_OPTIONS='--max-old-space-size=8192' node packages/scripts/run-turbo.mjs run typecheck lint --concurrency=8 --filter='!@elizaos/example-code' && bun run audit:build-model && bun run audit:turbo-build-deps && bun run audit:tee-secret-leak && bun run audit:scripts && bun run typecheck:dist
+$ node packages/scripts/type-safety-ratchet.mjs
+[type-safety-ratchet] scanned 9895 tracked production source files
+[type-safety-ratchet] as unknown as: 75 / 77
+[type-safety-ratchet] as any: 0 / 0
+[type-safety-ratchet] explicit `: any` annotation: 124 / 124
+[type-safety-ratchet] @ts-expect-error / @ts-ignore: 0 / 0
+[type-safety-ratchet] non-null assertion (!): 544 / 547
+[type-safety-ratchet] `?? ""` (core/agent/app-core): 612 / 620
+[type-safety-ratchet] `?? []` (core/agent/app-core): 573 / 588
+[type-safety-ratchet] `?? {}` (core/agent/app-core): 376 / 377
+[type-safety-ratchet] `?? 0` (core/agent/app-core): 376 / 380
+[type-safety-ratchet] baseline can shrink: as unknown as 77 -> 75, non-null assertion (!) 547 -> 544, `?? ""` (core/agent/app-core) 620 -> 612, `?? []` (core/agent/app-core) 588 -> 573, `?? {}` (core/agent/app-core) 377 -> 376, `?? 0` (core/agent/app-core) 380 -> 376
+• turbo 2.10.0
+
+   • Packages in scope: @elizaos-benchmarks/lib, @elizaos-examples/html-eliza, @elizaos/agent, @elizaos/agent-server, @elizaos/app, @elizaos/app-core, @elizaos/app-model-tester, @elizaos/aws-examples, @elizaos/bench-eliza-1, @elizaos/bench-eliza-1-vision-cua-e2e, @elizaos/browser-extension, @elizaos/bun-ios-runtime, @elizaos/capacitor-agent, @elizaos/capacitor-appblocker, @elizaos/capacitor-bun-runtime, @elizaos/capacitor-calendar, @elizaos/capacitor-camera, @elizaos/capacitor-canvas, @elizaos/capacitor-contacts, @elizaos/capacitor-desktop, @elizaos/capacitor-eliza-tasks, @elizaos/capacitor-gateway, @elizaos/capacitor-llama, @elizaos/capacitor-location, @elizaos/capacitor-messages, @elizaos/capacitor-mobile-agent-bridge, @elizaos/capacitor-mobile-signals, @elizaos/capacitor-network-policy, @elizaos/capacitor-phone, @elizaos/capacitor-screencapture, @elizaos/capacitor-swabble, @elizaos/capacitor-system, @elizaos/capacitor-talkmode, @elizaos/capacitor-websiteblocker, @elizaos/capacitor-wifi, @elizaos/cloud-api, @elizaos/cloud-e2e, @elizaos/cloud-infra, @elizaos/cloud-routing, @elizaos/cloud-sdk, @elizaos/cloud-services-common, @elizaos/cloud-shared, @elizaos/cloud-test-mocks, @elizaos/coding-remote-runner, @elizaos/container-control-plane, @elizaos/contracts, @elizaos/core, @elizaos/distro-os, @elizaos/docs, @elizaos/docs-elizacloud-redirect, @elizaos/electrobun, @elizaos/example-a2a-server, @elizaos/example-agent-console, @elizaos/example-app-capacitor, @elizaos/example-app-capacitor-backend, @elizaos/example-app-capacitor-frontend, @elizaos/example-app-electron, @elizaos/example-app-electron-renderer, @elizaos/example-app-electron-workspace, @elizaos/example-autonomous, @elizaos/example-bluesky, @elizaos/example-browser-extension, @elizaos/example-browser-extension-chrome, @elizaos/example-browser-extension-safari, @elizaos/example-chat, @elizaos/example-clone-ur-crush, @elizaos/example-convex, @elizaos/example-discord, @elizaos/example-edad, @elizaos/example-farcaster, @elizaos/example-form, @elizaos/example-game-of-life, @elizaos/example-lp-manager, @elizaos/example-mcp-server, @elizaos/example-rest-api-elysia, @elizaos/example-rest-api-express, @elizaos/example-rest-api-hono, @elizaos/example-smartglasses, @elizaos/example-telegram, @elizaos/example-text-adventure, @elizaos/example-tic-tac-toe, @elizaos/example-trader-ts, @elizaos/example-x402-image-gen, @elizaos/example-xai-x, @elizaos/gateway-discord, @elizaos/gateway-webhook, @elizaos/gcp-examples, @elizaos/interrupt-bench, @elizaos/ios-native-deps, @elizaos/logger, @elizaos/macosalarm, @elizaos/macosreminders, @elizaos/native-activity-tracker, @elizaos/native-plugin-shared-types, @elizaos/operator, @elizaos/os-android-system-ui, @elizaos/os-homepage, @elizaos/os-shared-system, @elizaos/os-usb-installer, @elizaos/plugin-agent-orchestrator, @elizaos/plugin-agent-skills, @elizaos/plugin-ainex, @elizaos/plugin-anthropic, @elizaos/plugin-anthropic-proxy, @elizaos/plugin-aosp-local-inference, @elizaos/plugin-app-control, @elizaos/plugin-app-manager, @elizaos/plugin-background-runner, @elizaos/plugin-benchmarks, @elizaos/plugin-blocker, @elizaos/plugin-bluebubbles, @elizaos/plugin-bluesky, @elizaos/plugin-browser, @elizaos/plugin-calendar, @elizaos/plugin-calendly, @elizaos/plugin-capacitor-bridge, @elizaos/plugin-cli, @elizaos/plugin-cli-inference, @elizaos/plugin-cloud-apps, @elizaos/plugin-codex-cli, @elizaos/plugin-coding-tools, @elizaos/plugin-commands, @elizaos/plugin-computeruse, @elizaos/plugin-contacts, @elizaos/plugin-discord, @elizaos/plugin-discord-local, @elizaos/plugin-documents, @elizaos/plugin-edge-tts, @elizaos/plugin-elevenlabs, @elizaos/plugin-elizacloud, @elizaos/plugin-embeddings, @elizaos/plugin-facewear, @elizaos/plugin-farcaster, @elizaos/plugin-feed, @elizaos/plugin-feishu, @elizaos/plugin-finances, @elizaos/plugin-form, @elizaos/plugin-github, @elizaos/plugin-gitpathologist, @elizaos/plugin-goals, @elizaos/plugin-google, @elizaos/plugin-google-chat, @elizaos/plugin-google-genai, @elizaos/plugin-groq, @elizaos/plugin-health, @elizaos/plugin-hyperliquid, @elizaos/plugin-imessage, @elizaos/plugin-inbox, @elizaos/plugin-inmemorydb, @elizaos/plugin-instagram, @elizaos/plugin-line, @elizaos/plugin-linear, @elizaos/plugin-lmstudio, @elizaos/plugin-local-inference, @elizaos/plugin-local-storage, @elizaos/plugin-localdb, @elizaos/plugin-matrix, @elizaos/plugin-mcp, @elizaos/plugin-messages, @elizaos/plugin-music, @elizaos/plugin-native-filesystem, @elizaos/plugin-native-settings, @elizaos/plugin-nearai, @elizaos/plugin-ngrok, @elizaos/plugin-nostr, @elizaos/plugin-ollama, @elizaos/plugin-openai, @elizaos/plugin-openrouter, @elizaos/plugin-pdf, @elizaos/plugin-personal-assistant, @elizaos/plugin-phone, @elizaos/plugin-polymarket, @elizaos/plugin-registry, @elizaos/plugin-relationships, @elizaos/plugin-reminders, @elizaos/plugin-remote-desktop, @elizaos/plugin-remote-manifest, @elizaos/plugin-scheduling, @elizaos/plugin-screenshare, @elizaos/plugin-shell, @elizaos/plugin-shopify, @elizaos/plugin-signal, @elizaos/plugin-slack, @elizaos/plugin-social-alpha, @elizaos/plugin-sql, @elizaos/plugin-starter, @elizaos/plugin-streaming, @elizaos/plugin-sub-agent-claude-code, @elizaos/plugin-suno, @elizaos/plugin-tailscale, @elizaos/plugin-task-coordinator, @elizaos/plugin-tee, @elizaos/plugin-telegram, @elizaos/plugin-todos, @elizaos/plugin-training, @elizaos/plugin-trajectory-logger, @elizaos/plugin-tunnel, @elizaos/plugin-twitch, @elizaos/plugin-vector-browser, @elizaos/plugin-video, @elizaos/plugin-vision, @elizaos/plugin-wallet, @elizaos/plugin-wallet-ui, @elizaos/plugin-web-search, @elizaos/plugin-wechat, @elizaos/plugin-whatsapp, @elizaos/plugin-wifi, @elizaos/plugin-worker-runtime, @elizaos/plugin-workflow, @elizaos/plugin-x, @elizaos/plugin-x402, @elizaos/plugin-xai, @elizaos/plugin-xr, @elizaos/plugin-zai, @elizaos/prompts, @elizaos/registry, @elizaos/robot, @elizaos/scenario-runner, @elizaos/security, @elizaos/setup, @elizaos/shared, @elizaos/skills, @elizaos/soc2-verify, @elizaos/test-harness, @elizaos/three-agent-dialogue, @elizaos/tui, @elizaos/ui, @elizaos/vault, @elizaos/vercel-edge-examples, @moltbook/eliza-agent, bags-claimer, cloud-mcp-smoke, eliza-app, eliza-cloud-agent, eliza-multichain-miniapp, eliza-next-example, eliza-react-example, elizagotchi, elizaos, elizaos-cloudflare-worker, elizaos-plugin-echo, trajectory-viewer
+   • Running typecheck, lint in 242 packages
+   • Remote caching disabled, using shared worktree cache
+
+@elizaos/contracts:build: cache miss, executing 14df36d0700382e1
+@elizaos/logger:build: cache miss, executing 669cecb69b5f9dc4
+@elizaos/logger:build: $ bun run build:dist
+@elizaos/contracts:build: $ tsc --noCheck -p tsconfig.build.json
+@elizaos/logger:build: $ node ../scripts/rm-path-recursive.mjs dist && tsc --noCheck -p tsconfig.build.json && node ../scripts/prepare-package-dist.mjs packages/logger
+@elizaos/core:build: cache miss, executing 15e84d9637d3c512
+@elizaos/core:build: $ bun run --cwd ../logger build && bun run --cwd ../contracts build && ([ -f src/i18n/generated/validation-keyword-data.ts ] || node ../shared/scripts/generate-keywords.mjs --target ts)
+@elizaos/core:build: $ bun run build:dist
+@elizaos/core:build: $ node ../scripts/rm-path-recursive.mjs dist && tsc --noCheck -p tsconfig.build.json && node ../scripts/prepare-package-dist.mjs packages/logger
+@elizaos/core:build: $ tsc --noCheck -p tsconfig.build.json
+@elizaos/core:build: $ bun run build.ts
+@elizaos/core:build: 🚀 Starting dual build process for @elizaos/core
+@elizaos/core:build: 🔨 Building for Node.js...
+@elizaos/core:build: 🚀 Building @elizaos/core...
+@elizaos/core:build:
+@elizaos/core:build: 🌐 Building for Browser...
+@elizaos/core:build: 🚀 Building @elizaos/core...
+@elizaos/core:build:
+@elizaos/core:build: ⚡ Building for Edge...
+@elizaos/core:build: 🚀 Building @elizaos/core...
+@elizaos/core:build:
+@elizaos/core:build: 🧪 Building testing module...
+@elizaos/core:build: 🚀 Building @elizaos/core...
+@elizaos/core:build:
+@elizaos/core:build: ✓ Configuration prepared (0.29ms)
+@elizaos/core:build:
+@elizaos/core:build: Bundling with Bun...
+@elizaos/core:build: ✓ Configuration prepared (0.24ms)
+@elizaos/core:build:
+@elizaos/core:build: Bundling with Bun...
+@elizaos/core:build: ✓ Configuration prepared (0.21ms)
+@elizaos/core:build:
+@elizaos/core:build: Bundling with Bun...
+@elizaos/core:build: ✓ Configuration prepared (0.18ms)
+@elizaos/core:build:
+@elizaos/core:build: Bundling with Bun...
+@elizaos/core:build: ✓ Built 4 file(s) - 28.78MB (121.23ms)
+@elizaos/core:build:
+@elizaos/core:build: ✅ @elizaos/core build complete!
+@elizaos/core:build: ⏱️  Total build time: 121.56ms
+@elizaos/core:build: ✅ Node.js build complete in 0.12s
+@elizaos/core:build: ✓ Built 4 file(s) - 21.35MB (167.36ms)
+@elizaos/core:build:
+@elizaos/core:build: ✅ @elizaos/core build complete!
+@elizaos/core:build: ⏱️  Total build time: 167.62ms
+@elizaos/core:build: ✅ Browser build complete in 0.17s
+@elizaos/core:build: ✓ Built 2 file(s) - 18.52MB (205.90ms)
+@elizaos/core:build:
+@elizaos/core:build: ✅ @elizaos/core build complete!
+@elizaos/core:build: ⏱️  Total build time: 206.14ms
+@elizaos/core:build: ✅ Edge build complete in 0.21s
+@elizaos/core:build: ✓ Built 4 file(s) - 0.02MB (206.74ms)
+@elizaos/core:build:
+@elizaos/core:build: ✅ @elizaos/core build complete!
+@elizaos/core:build: ⏱️  Total build time: 206.95ms
+@elizaos/core:build: ✅ Testing module build complete in 0.21s
+@elizaos/core:build: 📝 Generating TypeScript declarations...
+@elizaos/core:build:    Compiling TypeScript declarations...
+@elizaos/core:build:    Rewrote 1504 relative specifier(s) in 465 .d.ts file(s) for NodeNext ESM
+@elizaos/core:build: ✅ TypeScript declarations generated in 3.81s
+@elizaos/core:build:
+@elizaos/core:build: 🎉 All builds complete in 4.02s
+@elizaos/plugin-sql:build: cache miss, executing 9fc1572729c1923f
+@elizaos/plugin-commands:build: cache miss, executing d824d30405dd5fd9
+@elizaos/plugin-gitpathologist:build: cache miss, executing 0baafa8076d670d6
+@elizaos/plugin-workflow:build: cache miss, executing 74e2e2779a758d36
+@elizaos/plugin-video:build: cache miss, executing 125e20a724db4e69
+@elizaos/plugin-github:build: cache miss, executing e47a50fe67da6ec1
+@elizaos/plugin-native-filesystem:build: cache miss, executing c500371d1de76aa6
+@elizaos/plugin-capacitor-bridge:build: cache miss, executing 6fa8ed415597279b
+@elizaos/plugin-gitpathologist:build: $ bun run build.ts
+@elizaos/plugin-workflow:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist && tsc --noCheck -p tsconfig.json
+@elizaos/plugin-commands:build: $ bun run build.ts
+@elizaos/plugin-sql:build: $ cd src && bun run build.ts
+@elizaos/plugin-video:build: $ bun run build.ts
+@elizaos/plugin-github:build: $ tsup src/index.ts src/register-routes.ts --format esm --dts --clean
+@elizaos/plugin-native-filesystem:build: $ bun run build.ts
+@elizaos/plugin-capacitor-bridge:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist && bun run check:android-manifest && NODE_OPTIONS='--max-old-space-size=8192' tsup && tsc --declaration --emitDeclarationOnly --noEmit false --noCheck -p tsconfig.build.json && node ../../packages/scripts/rewrite-dist-relative-imports-node-esm.mjs plugins/plugin-capacitor-bridge
+@elizaos/plugin-video:build: 🔨 Building @elizaos/plugin-video (Node)…
+@elizaos/plugin-native-filesystem:build: 🔨 Building @elizaos/plugin-native-filesystem (Node)…
+@elizaos/plugin-native-filesystem:build: ✅ Node complete in 0.00s
+@elizaos/plugin-native-filesystem:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-video:build: ✅ Node complete in 0.00s
+@elizaos/plugin-video:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-commands:build: 🔨 Building @elizaos/plugin-commands (Node (ESM))…
+@elizaos/plugin-gitpathologist:build: 🔨 Building @elizaos/plugin-gitpathologist (Node (ESM))…
+@elizaos/plugin-capacitor-bridge:build: $ node scripts/check-android-manifest.mjs
+@elizaos/plugin-commands:build: ✅ Node (ESM) complete in 0.00s
+@elizaos/plugin-commands:build: 🔨 Building @elizaos/plugin-commands (Node (CJS))…
+@elizaos/plugin-gitpathologist:build: ✅ Node (ESM) complete in 0.00s
+@elizaos/plugin-gitpathologist:build: 🔨 Building @elizaos/plugin-gitpathologist (Node (CJS))…
+@elizaos/plugin-commands:build: ✅ Node (CJS) complete in 0.00s
+@elizaos/plugin-commands:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-gitpathologist:build: ✅ Node (CJS) complete in 0.00s
+@elizaos/plugin-gitpathologist:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-sql:build: Building Node.js ESM bundle...
+@elizaos/plugin-sql:build: Building Browser ESM bundle...
+@elizaos/plugin-sql:build: Building CJS bundle...
+@elizaos/plugin-sql:build: Generating TypeScript declarations...
+@elizaos/plugin-github:build: CLI Building entry: src/register-routes.ts, src/index.ts
+@elizaos/plugin-github:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-github:build: CLI tsup v8.5.1
+@elizaos/plugin-github:build: CLI Target: es2022
+@elizaos/plugin-github:build: CLI Cleaning output folder
+@elizaos/plugin-github:build: ESM Build start
+@elizaos/plugin-github:build: ESM dist/register-routes.js 239.00 B
+@elizaos/plugin-github:build: ESM dist/index.js           73.49 KB
+@elizaos/plugin-github:build: ESM ⚡️ Build success in 48ms
+@elizaos/plugin-capacitor-bridge:build: CLI Building entry: {"index":"src/index.ts","android/bridge":"src/android/bridge.ts","ios/bridge":"src/ios/bridge.ts","mobile-device-bridge-bootstrap":"src/mobile-device-bridge-bootstrap.ts","shared/fs-shim":"src/shared/fs-shim.ts"}
+@elizaos/plugin-capacitor-bridge:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-capacitor-bridge:build: CLI tsup v8.5.1
+@elizaos/plugin-capacitor-bridge:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/plugin-capacitor-bridge/tsup.config.ts
+@elizaos/plugin-capacitor-bridge:build: CLI Target: es2022
+@elizaos/plugin-capacitor-bridge:build: CLI Cleaning output folder
+@elizaos/plugin-capacitor-bridge:build: ESM Build start
+@elizaos/plugin-capacitor-bridge:build: ESM dist/chunk-MLKGABMK.js                 191.00 B
+@elizaos/plugin-capacitor-bridge:build: ESM dist/ios/bridge.js                     101.17 KB
+@elizaos/plugin-capacitor-bridge:build: ESM dist/index.js                          1.05 KB
+@elizaos/plugin-capacitor-bridge:build: ESM dist/chunk-2L4MX4DP.js                 42.48 KB
+@elizaos/plugin-capacitor-bridge:build: ESM dist/chunk-E7Y447TQ.js                 19.47 KB
+@elizaos/plugin-capacitor-bridge:build: ESM dist/mobile-device-bridge-bootstrap.js 595.00 B
+@elizaos/plugin-capacitor-bridge:build: ESM dist/android/bridge.js                 5.14 KB
+@elizaos/plugin-capacitor-bridge:build: ESM dist/shared/fs-shim.js                 267.00 B
+@elizaos/plugin-capacitor-bridge:build: ESM ⚡️ Build success in 32ms
+@elizaos/plugin-github:build: DTS Build start
+@elizaos/plugin-native-filesystem:build: 🎉 @elizaos/plugin-native-filesystem build finished in 1.05s
+@elizaos/plugin-gitpathologist:build: 🎉 @elizaos/plugin-gitpathologist build finished in 1.05s
+@elizaos/capacitor-contacts:build: cache miss, executing 5a2c56d1f76ccc26
+@elizaos/plugin-computeruse:build: cache miss, executing 35fe485192f8975b
+@elizaos/capacitor-contacts:build: $ node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-contacts -- bun run build:unlocked
+@elizaos/plugin-computeruse:build: $ bun run build.ts
+@elizaos/capacitor-contacts:build: $ bun run clean && tsc && bunx rollup -c rollup.config.mjs
+@elizaos/capacitor-contacts:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/plugin-video:build: 🎉 @elizaos/plugin-video build finished in 1.13s
+@elizaos/plugin-xai:build: cache miss, executing ec37060897ff1dbb
+@elizaos/plugin-computeruse:build: 🔨 Building plugin-computeruse (index)…
+@elizaos/plugin-xai:build: $ bun run build.ts
+@elizaos/plugin-computeruse:build: ✅ index complete in 0.01s
+@elizaos/plugin-computeruse:build: 🔨 Building plugin-computeruse (register-routes)…
+@elizaos/plugin-computeruse:build: ✅ register-routes complete in 0.01s
+@elizaos/plugin-computeruse:build: 🔨 Building plugin-computeruse (mobile/ocr-provider)…
+@elizaos/plugin-computeruse:build: ✅ mobile/ocr-provider complete in 0.00s
+@elizaos/plugin-computeruse:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-xai:build: 🔨 Building @elizaos/plugin-xai (Node (ESM))…
+@elizaos/plugin-xai:build: ✅ Node (ESM) complete in 0.01s
+@elizaos/plugin-xai:build: 🔨 Building @elizaos/plugin-xai (Browser)…
+@elizaos/plugin-xai:build: ✅ Browser complete in 0.00s
+@elizaos/plugin-xai:build: 🔨 Building @elizaos/plugin-xai (Node (CJS))…
+@elizaos/plugin-xai:build: ✅ Node (CJS) complete in 0.00s
+@elizaos/plugin-xai:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-commands:build: 🎉 @elizaos/plugin-commands build finished in 1.33s
+@elizaos/plugin-x:build: cache miss, executing 59606114f1602b0b
+@elizaos/plugin-x:build: $ tsup
+@elizaos/plugin-x:build: CLI Building entry: src/index.ts, src/lifeops-message-adapter.ts
+@elizaos/plugin-x:build: CLI Using tsconfig: tsconfig.build.json
+@elizaos/plugin-x:build: CLI tsup v8.5.1
+@elizaos/plugin-x:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/plugin-x/tsup.config.ts
+@elizaos/plugin-x:build: CLI Target: es2020
+@elizaos/plugin-x:build: CLI Cleaning output folder
+@elizaos/plugin-x:build: ESM Build start
+@elizaos/plugin-x:build: ESM dist/chunk-VU26ZOMZ.js              5.42 KB
+@elizaos/plugin-x:build: ESM dist/lifeops-message-adapter.js     128.00 B
+@elizaos/plugin-x:build: ESM dist/index.js                       418.32 KB
+@elizaos/plugin-x:build: ESM dist/chunk-VU26ZOMZ.js.map          10.55 KB
+@elizaos/plugin-x:build: ESM dist/lifeops-message-adapter.js.map 71.00 B
+@elizaos/plugin-x:build: ESM dist/index.js.map                   990.67 KB
+@elizaos/plugin-x:build: ESM ⚡️ Build success in 97ms
+@elizaos/plugin-x:build: DTS Build start
+@elizaos/capacitor-contacts:build:
+@elizaos/capacitor-contacts:build: dist/esm/index.js → dist/plugin.js, dist/plugin.cjs.js...
+@elizaos/capacitor-contacts:build: created dist/plugin.js, dist/plugin.cjs.js in 131ms
+@elizaos/plugin-ollama:build: cache miss, executing da94b3785b832758
+@elizaos/plugin-capacitor-bridge:build: [rewrite-dist-relative-imports] rewrote 2 file(s)
+@elizaos/plugin-ollama:build: $ bun run build.ts
+@elizaos/plugin-xai:build: 🎉 @elizaos/plugin-xai build finished in 0.97s
+@elizaos/plugin-tunnel:build: cache miss, executing eccc0ead21f69c3e
+@elizaos/plugin-tunnel:build: $ tsc --noCheck -p tsconfig.json
+@elizaos/plugin-x402:build: cache miss, executing f68f8fc48df1d4d1
+@elizaos/plugin-x402:build: $ bun run build.ts
+@elizaos/plugin-ollama:build: 🔨 Building @elizaos/plugin-ollama (Node ESM)…
+@elizaos/plugin-ollama:build: ✅ Node ESM complete in 0.01s
+@elizaos/plugin-ollama:build: 🔨 Building @elizaos/plugin-ollama (Browser ESM)…
+@elizaos/plugin-ollama:build: ✅ Browser ESM complete in 0.01s
+@elizaos/plugin-ollama:build: 🔨 Building @elizaos/plugin-ollama (CJS)…
+@elizaos/plugin-ollama:build: ✅ CJS complete in 0.00s
+@elizaos/plugin-ollama:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-x402:build: 🔨 Building @elizaos/plugin-x402 (Node)…
+@elizaos/plugin-x402:build: ✅ Node complete in 0.01s
+@elizaos/plugin-x402:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-computeruse:build: 🎉 plugin-computeruse build finished in 1.92s
+@elizaos/cloud-sdk:build: cache miss, executing 1389cd92f4b6a6a8
+@elizaos/cloud-sdk:build: $ bun run build.ts
+@elizaos/capacitor-calendar:build: cache miss, executing a9d0fdfc98c067d6
+@elizaos/capacitor-calendar:build: $ node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-calendar -- bun run build:unlocked
+@elizaos/capacitor-calendar:build: $ bun run clean && tsc && bunx rollup -c rollup.config.mjs
+@elizaos/capacitor-calendar:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/plugin-sql:build: Build complete!
+@elizaos/plugin-calendly:build: cache miss, executing 4f48a4ae73816a1b
+@elizaos/plugin-calendly:build: $ tsup src/index.ts --format esm --clean && tsc --declaration --emitDeclarationOnly --noEmit false --noCheck
+@elizaos/plugin-whatsapp:build: cache miss, executing 9231ce724c4b63f9
+@elizaos/plugin-whatsapp:build: $ bun run build.ts
+@elizaos/plugin-whatsapp:build: 🔨 Building @elizaos/plugin-whatsapp (Node)…
+@elizaos/plugin-whatsapp:build: ✅ Node complete in 0.01s
+@elizaos/plugin-whatsapp:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-github:build: DTS ⚡️ Build success in 3028ms
+@elizaos/plugin-github:build: DTS dist/register-routes.d.ts 13.00 B
+@elizaos/plugin-github:build: DTS dist/index.d.ts           10.45 KB
+@elizaos/plugin-calendly:build: CLI Building entry: src/index.ts
+@elizaos/plugin-calendly:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-calendly:build: CLI tsup v8.5.1
+@elizaos/plugin-calendly:build: CLI Target: es2022
+@elizaos/plugin-calendly:build: CLI Cleaning output folder
+@elizaos/plugin-calendly:build: ESM Build start
+@elizaos/plugin-ollama:build: 🎉 @elizaos/plugin-ollama build finished in 1.59s
+@elizaos/plugin-remote-desktop:build: cache miss, executing d1aad32e85de6773
+@elizaos/plugin-remote-desktop:build: $ bun run build.ts
+@elizaos/plugin-calendly:build: ESM dist/index.js 50.60 KB
+@elizaos/plugin-calendly:build: ESM ⚡️ Build success in 37ms
+@elizaos/capacitor-wifi:build: cache miss, executing 4f53570d603e7c42
+@elizaos/capacitor-wifi:build: $ node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-wifi -- bun run build:unlocked
+@elizaos/plugin-remote-desktop:build: 🔨 Building @elizaos/plugin-remote-desktop (Node)…
+@elizaos/plugin-remote-desktop:build: ✅ Node complete in 0.00s
+@elizaos/plugin-remote-desktop:build: 📝 Generating TypeScript declarations…
+@elizaos/capacitor-calendar:build:
+@elizaos/capacitor-calendar:build: dist/esm/index.js → dist/plugin.js, dist/plugin.cjs.js...
+@elizaos/capacitor-wifi:build: $ bun run clean && tsc && bunx rollup -c rollup.config.mjs
+@elizaos/capacitor-wifi:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/capacitor-calendar:build: created dist/plugin.js, dist/plugin.cjs.js in 81ms
+@elizaos/cloud-routing:build: cache miss, executing b942b3c3a675c85c
+@elizaos/cloud-routing:build: $ tsc --noCheck -p tsconfig.json && node ../../scripts/prepare-package-dist.mjs packages/cloud/routing
+@elizaos/plugin-x402:build: 🎉 @elizaos/plugin-x402 build finished in 2.59s
+@elizaos/native-activity-tracker:build: cache miss, executing b284644c123de793
+@elizaos/native-activity-tracker:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist && tsc -p tsconfig.json --noCheck
+@elizaos/capacitor-wifi:build:
+@elizaos/capacitor-wifi:build: dist/esm/index.js → dist/plugin.js, dist/plugin.cjs.js...
+@elizaos/plugin-google:build: cache miss, executing aa9a24ff78013eea
+@elizaos/plugin-google:build: $ bun run build.ts
+@elizaos/plugin-x:build: DTS ⚡️ Build success in 3034ms
+@elizaos/plugin-x:build: DTS dist/index.d.ts                   860.00 B
+@elizaos/plugin-x:build: DTS dist/lifeops-message-adapter.d.ts 963.00 B
+@elizaos/tui:build: cache miss, executing 6d4b6728f16eb46d
+@elizaos/tui:build: $ tsc -p tsconfig.build.json --noCheck
+@elizaos/capacitor-wifi:build: created dist/plugin.js, dist/plugin.cjs.js in 68ms
+@elizaos/plugin-google:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-remote-desktop:build: 🎉 @elizaos/plugin-remote-desktop build finished in 1.12s
+@elizaos/plugin-background-runner:build: cache miss, executing aa6c8be105e8c5b9
+@elizaos/security:build: cache miss, executing cc6dbdbe2717e82b
+@elizaos/plugin-background-runner:build: $ tsc --noCheck -p tsconfig.json
+@elizaos/security:build: $ node ../scripts/rm-path-recursive.mjs dist && tsc --noCheck -p tsconfig.build.json && node ../scripts/prepare-package-dist.mjs packages/security
+@elizaos/plugin-signal:build: cache miss, executing 785b44e613e88c1a
+@elizaos/plugin-signal:build: $ bun run build.ts
+@elizaos/plugin-signal:build: 🔨 Building @elizaos/plugin-signal (Node)…
+@elizaos/plugin-signal:build: ✅ Node complete in 0.02s
+@elizaos/plugin-signal:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-whatsapp:build: 🎉 @elizaos/plugin-whatsapp build finished in 1.35s
+@elizaos/macosreminders:build: cache miss, executing d248bf9d9eac4f4b
+@elizaos/macosreminders:build: $ tsc --noCheck -p tsconfig.json
+@elizaos/plugin-imessage:build: cache miss, executing 01b313c9af6ea2f3
+@elizaos/plugin-imessage:build: $ bun run build.ts
+@elizaos/plugin-inmemorydb:build: cache miss, executing fa2ed1e680d366fd
+@elizaos/plugin-inmemorydb:build: $ bun run build.ts
+@elizaos/plugin-imessage:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-inmemorydb:build: 🔨 Building @elizaos/plugin-inmemorydb (Node)…
+@elizaos/plugin-inmemorydb:build: ✅ Node complete in 0.00s
+@elizaos/plugin-inmemorydb:build: 🔨 Building @elizaos/plugin-inmemorydb (Browser)…
+@elizaos/plugin-inmemorydb:build: ✅ Browser complete in 0.03s
+@elizaos/plugin-inmemorydb:build: 📝 Generating TypeScript declarations…
+@elizaos/skills:build: cache miss, executing 2f31f0366242c5ba
+@elizaos/skills:build: $ tsc --noCheck -p tsconfig.build.json
+@elizaos/capacitor-mobile-agent-bridge:build: cache miss, executing 4d41a913f430a2e0
+@elizaos/capacitor-mobile-agent-bridge:build: $ node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-mobile-agent-bridge -- bun run build:unlocked
+@elizaos/capacitor-mobile-agent-bridge:build: $ bun run clean && tsc && bunx rollup -c rollup.config.mjs
+@elizaos/capacitor-mobile-agent-bridge:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/plugin-signal:build: 🎉 @elizaos/plugin-signal build finished in 1.36s
+@elizaos/capacitor-camera:build: cache miss, executing 91b726d953fba642
+@elizaos/capacitor-camera:build: $ node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-camera -- bun run build:unlocked
+@elizaos/capacitor-camera:build: $ bun run clean && tsc && bunx rollup -c rollup.config.mjs
+@elizaos/capacitor-camera:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/capacitor-websiteblocker:build: cache miss, executing 0176481aedaeb503
+@elizaos/capacitor-websiteblocker:build: $ node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-websiteblocker -- bun run build:unlocked
+@elizaos/capacitor-appblocker:build: cache miss, executing 1715d146b7c4d855
+@elizaos/capacitor-websiteblocker:build: $ bun run clean && tsc && bunx rollup -c rollup.config.mjs
+@elizaos/capacitor-appblocker:build: $ node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-appblocker -- bun run build:unlocked
+@elizaos/capacitor-websiteblocker:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/capacitor-appblocker:build: $ bun run clean && tsc && bunx rollup -c rollup.config.mjs
+@elizaos/capacitor-appblocker:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/plugin-inmemorydb:build: 🎉 @elizaos/plugin-inmemorydb build finished in 1.39s
+@elizaos/plugin-bluesky:build: cache miss, executing 39eafe3d717f229d
+@elizaos/plugin-bluesky:build: $ bun run build.ts
+@elizaos/plugin-bluesky:build: 🔨 Building @elizaos/plugin-bluesky (Node)…
+@elizaos/plugin-bluesky:build: ✅ Node complete in 0.01s
+@elizaos/plugin-bluesky:build: 🔨 Building @elizaos/plugin-bluesky (Browser)…
+@elizaos/plugin-bluesky:build: ✅ Browser complete in 0.00s
+@elizaos/plugin-bluesky:build: 🔨 Building @elizaos/plugin-bluesky (Node (CJS))…
+@elizaos/plugin-bluesky:build: ✅ Node (CJS) complete in 0.01s
+@elizaos/plugin-bluesky:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-imessage:build: 🎉 @elizaos/plugin-imessage build finished in 1.70s
+@elizaos/capacitor-system:build: cache miss, executing 42113b3c0809cc00
+@elizaos/capacitor-system:build: $ node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-system -- bun run build:unlocked
+@elizaos/capacitor-mobile-agent-bridge:build:
+@elizaos/capacitor-mobile-agent-bridge:build: dist/esm/index.js → dist/plugin.js, dist/plugin.cjs.js...
+@elizaos/capacitor-system:build: $ bun run clean && tsc && bunx rollup -c rollup.config.mjs
+@elizaos/capacitor-system:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/capacitor-mobile-agent-bridge:build: created dist/plugin.js, dist/plugin.cjs.js in 63ms
+@elizaos/plugin-edge-tts:build: cache miss, executing dc6495d9ac04c178
+@elizaos/plugin-edge-tts:build: $ bun run build.ts
+@elizaos/capacitor-camera:build:
+@elizaos/capacitor-camera:build: dist/esm/index.js → dist/plugin.js, dist/plugin.cjs.js...
+@elizaos/plugin-edge-tts:build: 🔨 Building @elizaos/plugin-edge-tts (Node)…
+@elizaos/plugin-edge-tts:build: ✅ Node complete in 0.01s
+@elizaos/plugin-edge-tts:build: 🔨 Building @elizaos/plugin-edge-tts (Browser)…
+@elizaos/capacitor-screencapture:build: cache miss, executing 316ffee72e2af8bf
+@elizaos/plugin-edge-tts:build: ✅ Browser complete in 0.01s
+@elizaos/plugin-edge-tts:build: 🔨 Building @elizaos/plugin-edge-tts (Node (CJS))…
+@elizaos/capacitor-screencapture:build: $ node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-screencapture -- bun run build:unlocked
+@elizaos/plugin-edge-tts:build: ✅ Node (CJS) complete in 0.01s
+@elizaos/plugin-edge-tts:build: 📝 Generating TypeScript declarations…
+@elizaos/capacitor-screencapture:build: $ bun run clean && tsc && bunx rollup -c rollup.config.mjs
+@elizaos/capacitor-screencapture:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/capacitor-appblocker:build:
+@elizaos/capacitor-appblocker:build: dist/esm/index.js → dist/plugin.js, dist/plugin.cjs.js...
+@elizaos/capacitor-camera:build: created dist/plugin.js, dist/plugin.cjs.js in 140ms
+@elizaos/capacitor-websiteblocker:build:
+@elizaos/capacitor-websiteblocker:build: dist/esm/index.js → dist/plugin.js, dist/plugin.cjs.js...
+@elizaos/capacitor-location:build: cache miss, executing 4b9b8473bb0b8e1a
+@elizaos/capacitor-location:build: $ node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-location -- bun run build:unlocked
+@elizaos/capacitor-location:build: $ bun run clean && tsc && bunx rollup -c rollup.config.mjs
+@elizaos/capacitor-location:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/capacitor-appblocker:build: created dist/plugin.js, dist/plugin.cjs.js in 188ms
+@elizaos/plugin-wechat:build: cache miss, executing cacd2aebbdddb736
+@elizaos/plugin-wechat:build: $ tsup --config tsup.config.ts && tsc --declaration --emitDeclarationOnly --noEmit false --noCheck --outDir dist --rootDir src
+@elizaos/capacitor-websiteblocker:build: created dist/plugin.js, dist/plugin.cjs.js in 182ms
+@elizaos/vault:build: cache miss, executing 4ce5e81a4d3a3b59
+@elizaos/vault:build: $ node ../scripts/rm-path-recursive.mjs dist && tsc --noCheck -p tsconfig.build.json && node ../scripts/prepare-package-dist.mjs packages/vault
+@elizaos/capacitor-system:build:
+@elizaos/capacitor-system:build: dist/esm/index.js → dist/plugin.js, dist/plugin.cjs.js...
+@elizaos/plugin-wechat:build: CLI Building entry: src/index.ts
+@elizaos/plugin-wechat:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-wechat:build: CLI tsup v8.5.1
+@elizaos/plugin-wechat:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/plugin-wechat/tsup.config.ts
+@elizaos/plugin-wechat:build: CLI Target: es2022
+@elizaos/capacitor-system:build: created dist/plugin.js, dist/plugin.cjs.js in 75ms
+@elizaos/plugin-wechat:build: CLI Cleaning output folder
+@elizaos/plugin-wechat:build: ESM Build start
+@elizaos/plugin-wechat:build: ESM dist/index.js     39.54 KB
+@elizaos/plugin-wechat:build: ESM dist/index.js.map 80.60 KB
+@elizaos/plugin-wechat:build: ESM ⚡️ Build success in 27ms
+@elizaos/capacitor-messages:build: cache miss, executing 53537c55754d0fc9
+@elizaos/capacitor-messages:build: $ node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-messages -- bun run build:unlocked
+@elizaos/capacitor-messages:build: $ bun run clean && tsc && bunx rollup -c rollup.config.mjs
+@elizaos/capacitor-messages:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/plugin-edge-tts:build: 🎉 @elizaos/plugin-edge-tts build finished in 1.15s
+@elizaos/capacitor-mobile-signals:build: cache miss, executing c24e6487428d0331
+@elizaos/capacitor-mobile-signals:build: $ node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-mobile-signals -- bun run build:unlocked
+@elizaos/capacitor-screencapture:build:
+@elizaos/capacitor-screencapture:build: dist/esm/index.js → dist/plugin.js, dist/plugin.cjs.js...
+@elizaos/capacitor-mobile-signals:build: $ bun run clean && bunx tsc -p tsconfig.json && bunx rollup -c rollup.config.mjs
+@elizaos/capacitor-mobile-signals:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/plugin-bluesky:build: 🎉 @elizaos/plugin-bluesky build finished in 1.64s
+@elizaos/capacitor-canvas:build: cache miss, executing 2ef3c26145452dd4
+@elizaos/capacitor-canvas:build: $ node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-canvas -- bun run build:unlocked
+@elizaos/capacitor-location:build:
+@elizaos/capacitor-location:build: dist/esm/index.js → dist/plugin.js, dist/plugin.cjs.js...
+@elizaos/capacitor-screencapture:build: created dist/plugin.js, dist/plugin.cjs.js in 107ms
+@elizaos/capacitor-canvas:build: $ bun run clean && tsc && bunx rollup -c rollup.config.mjs
+@elizaos/capacitor-canvas:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/registry:build: cache miss, executing d5a0f95cd0fde518
+@elizaos/registry:build: $ bun run src/generate.ts && bun run src/first-party/generate.ts
+@elizaos/capacitor-location:build: created dist/plugin.js, dist/plugin.cjs.js in 65ms
+@elizaos/registry:build: Generated /Users/shawwalters/.codex/worktrees/36cd/eliza/packages/registry/generated-registry.json (20 third-party entries)
+@elizaos/capacitor-gateway:build: cache miss, executing 4a6fda7f42bade53
+@elizaos/capacitor-gateway:build: $ node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-gateway -- bun run build:unlocked
+@elizaos/capacitor-gateway:build: $ bun run clean && tsc && bunx rollup -c rollup.config.mjs
+@elizaos/capacitor-bun-runtime:build: cache miss, executing 48fd004d46da46c6
+@elizaos/capacitor-gateway:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/capacitor-bun-runtime:build: $ node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-bun-runtime -- bun run build:unlocked
+@elizaos/capacitor-bun-runtime:build: $ bun run clean && tsc && bunx rollup -c rollup.config.mjs
+@elizaos/capacitor-messages:build:
+@elizaos/capacitor-messages:build: dist/esm/index.js → dist/plugin.js, dist/plugin.cjs.js...
+@elizaos/capacitor-bun-runtime:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/capacitor-messages:build: created dist/plugin.js, dist/plugin.cjs.js in 82ms
+@elizaos/capacitor-phone:build: cache miss, executing 0907dc903f7e7813
+@elizaos/capacitor-phone:build: $ node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-phone -- bun run build:unlocked
+@elizaos/plugin-openai:build: cache miss, executing 9a29809106bd4fdb
+@elizaos/plugin-openai:build: $ bun run build.ts
+@elizaos/capacitor-phone:build: $ bun run clean && tsc && bunx rollup -c rollup.config.mjs
+@elizaos/capacitor-phone:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/plugin-openai:build: 🔨 Building @elizaos/plugin-openai (Node)…
+@elizaos/plugin-openai:build: ✅ Node complete in 0.01s
+@elizaos/plugin-openai:build: 🔨 Building @elizaos/plugin-openai (Browser)…
+@elizaos/plugin-openai:build: ✅ Browser complete in 0.00s
+@elizaos/plugin-openai:build: 📝 Generating TypeScript declarations…
+@elizaos/registry:build: [registry/generate] wrote 115 entries + 9 curated-app definitions
+@elizaos/plugin-anthropic:build: cache miss, executing 5ceb1f3f6216682b
+@elizaos/plugin-anthropic:build: $ bun run build.ts
+@elizaos/plugin-anthropic:build: 🔨 Building @elizaos/plugin-anthropic (Node)…
+@elizaos/plugin-anthropic:build: ✅ Node complete in 0.02s
+@elizaos/plugin-anthropic:build: 🔨 Building @elizaos/plugin-anthropic (Browser)…
+@elizaos/plugin-anthropic:build: ✅ Browser complete in 0.01s
+@elizaos/plugin-anthropic:build: 🔨 Building @elizaos/plugin-anthropic (Node (CJS))…
+@elizaos/plugin-anthropic:build: ✅ Node (CJS) complete in 0.01s
+@elizaos/plugin-anthropic:build: 📝 Generating TypeScript declarations…
+@elizaos/capacitor-mobile-signals:build:
+@elizaos/capacitor-mobile-signals:build: dist/esm/index.js → dist/plugin.js, dist/plugin.cjs.js...
+@elizaos/capacitor-bun-runtime:build:
+@elizaos/capacitor-bun-runtime:build: dist/esm/index.js → dist/plugin.js, dist/plugin.cjs.js...
+@elizaos/capacitor-bun-runtime:build: created dist/plugin.js, dist/plugin.cjs.js in 70ms
+@elizaos/capacitor-mobile-signals:build: created dist/plugin.js, dist/plugin.cjs.js in 110ms
+@elizaos/plugin-google-genai:build: cache miss, executing 9df3d7d3a32efc22
+@elizaos/plugin-google-genai:build: $ bun run build.ts
+@elizaos/plugin-groq:build: cache miss, executing 4b7323e6917c75b8
+@elizaos/plugin-groq:build: $ bun run build.ts
+@elizaos/plugin-google-genai:build: 🔨 Building @elizaos/plugin-google-genai (Node)…
+@elizaos/plugin-google-genai:build: ✅ Node complete in 0.01s
+@elizaos/plugin-google-genai:build: 🔨 Building @elizaos/plugin-google-genai (Browser)…
+@elizaos/plugin-google-genai:build: ✅ Browser complete in 0.01s
+@elizaos/plugin-google-genai:build: 🔨 Building @elizaos/plugin-google-genai (Node (CJS))…
+@elizaos/plugin-google-genai:build: ✅ Node (CJS) complete in 0.00s
+@elizaos/plugin-google-genai:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-groq:build: 🔨 Building @elizaos/plugin-groq (Node)…
+@elizaos/plugin-groq:build: ✅ Node complete in 0.00s
+@elizaos/plugin-groq:build: 🔨 Building @elizaos/plugin-groq (Browser)…
+@elizaos/plugin-groq:build: ✅ Browser complete in 0.00s
+@elizaos/plugin-groq:build: 🔨 Building @elizaos/plugin-groq (Node (CJS))…
+@elizaos/plugin-groq:build: ✅ Node (CJS) complete in 0.01s
+@elizaos/plugin-groq:build: 📝 Generating TypeScript declarations…
+@elizaos/capacitor-gateway:build:
+@elizaos/capacitor-gateway:build: dist/esm/index.js → dist/plugin.js, dist/plugin.cjs.js...
+@elizaos/capacitor-canvas:build:
+@elizaos/capacitor-canvas:build: dist/esm/index.js → dist/plugin.js, dist/plugin.cjs.js...
+@elizaos/capacitor-phone:build:
+@elizaos/capacitor-phone:build: dist/esm/index.js → dist/plugin.js, dist/plugin.cjs.js...
+@elizaos/capacitor-phone:build: created dist/plugin.js, dist/plugin.cjs.js in 118ms
+@elizaos/capacitor-gateway:build: created dist/plugin.js, dist/plugin.cjs.js in 177ms
+@elizaos/plugin-openrouter:build: cache miss, executing 3c3e223ab9266dc7
+@elizaos/plugin-telegram:build: cache miss, executing e8db8d19e4a43d41
+@elizaos/plugin-openrouter:build: $ bun run build.ts
+@elizaos/plugin-telegram:build: $ tsup && tsc --project tsconfig.build.json
+@elizaos/plugin-openrouter:build: 🔨 Building @elizaos/plugin-openrouter (Node ESM)…
+@elizaos/capacitor-canvas:build: created dist/plugin.js, dist/plugin.cjs.js in 259ms
+@elizaos/plugin-openrouter:build: ✅ Node ESM complete in 0.01s
+@elizaos/plugin-openrouter:build: 🔨 Building @elizaos/plugin-openrouter (Browser ESM)…
+@elizaos/plugin-openrouter:build: ✅ Browser ESM complete in 0.00s
+@elizaos/plugin-openrouter:build: 🔨 Building @elizaos/plugin-openrouter (CJS)…
+@elizaos/plugin-openrouter:build: ✅ CJS complete in 0.00s
+@elizaos/plugin-openrouter:build: 🎉 @elizaos/plugin-openrouter build finished in 0.04s
+@elizaos/plugin-vision:build: cache miss, executing 4e44dd6aff295a1f
+@elizaos/plugin-vision:build: $ bun run build.ts
+@elizaos/example-chat:typecheck: cache miss, executing 8a4598fce510c6b1
+@elizaos/example-chat:typecheck: $ tsgo --noEmit
+@elizaos/plugin-vision:build: 🔨 Building @elizaos/plugin-vision (Node)…
+@elizaos/plugin-vision:build: ✅ Node complete in 0.01s
+@elizaos/plugin-vision:build: 🔨 Building @elizaos/plugin-vision (Workers)…
+@elizaos/plugin-vision:build: ✅ Workers complete in 0.01s
+@elizaos/plugin-vision:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-openai:build: 🎉 @elizaos/plugin-openai build finished in 1.18s
+@elizaos/plugin-tailscale:typecheck: cache miss, executing 017c96cc1d5546c1
+@elizaos/plugin-tailscale:typecheck: $ tsgo --noEmit
+@elizaos/plugin-telegram:build: CLI Building entry: src/index.ts, src/account-auth-service.ts
+@elizaos/plugin-telegram:build: CLI Using tsconfig: tsconfig.build.json
+@elizaos/plugin-telegram:build: CLI tsup v8.5.1
+@elizaos/plugin-telegram:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/plugin-telegram/tsup.config.ts
+@elizaos/plugin-telegram:build: CLI Target: esnext
+@elizaos/plugin-google:build: 🎉 @elizaos/plugin-google build finished in 5.28s
+@elizaos/capacitor-talkmode:build: cache miss, executing 5337ca5ab3601836
+@elizaos/capacitor-talkmode:build: $ node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-talkmode -- bun run build:unlocked
+@elizaos/plugin-telegram:build: CLI Cleaning output folder
+@elizaos/plugin-telegram:build: ESM Build start
+@elizaos/plugin-telegram:build: ESM dist/chunk-Q2XLH3NG.js           20.31 KB
+@elizaos/plugin-telegram:build: ESM dist/account-auth-service.js     787.00 B
+@elizaos/plugin-telegram:build: ESM dist/index.js                    193.32 KB
+@elizaos/plugin-telegram:build: ESM dist/account-auth-service.js.map 71.00 B
+@elizaos/plugin-telegram:build: ESM dist/chunk-Q2XLH3NG.js.map       38.52 KB
+@elizaos/plugin-telegram:build: ESM dist/index.js.map                387.58 KB
+@elizaos/plugin-telegram:build: ESM ⚡️ Build success in 33ms
+@elizaos/capacitor-talkmode:build: $ bun run clean && tsc && bunx rollup -c rollup.config.mjs
+@elizaos/capacitor-talkmode:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/plugin-anthropic:build: 🎉 @elizaos/plugin-anthropic build finished in 1.10s
+@elizaos/capacitor-swabble:build: cache miss, executing e4e6157ac50ed612
+@elizaos/capacitor-swabble:build: $ node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-swabble -- bun run build:unlocked
+@elizaos/capacitor-swabble:build: $ bun run clean && tsc && bunx rollup -c rollup.config.mjs
+@elizaos/capacitor-swabble:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/plugin-cloud-apps:build: cache miss, executing db5e0e088efd9ce4
+@elizaos/plugin-cloud-apps:build: $ bun run build.ts
+@elizaos/example-edad:typecheck: cache miss, executing af0fa81739183af0
+@elizaos/plugin-groq:build: 🎉 @elizaos/plugin-groq build finished in 0.89s
+@elizaos/example-edad:typecheck: $ tsgo --noEmit
+@elizaos/example-xai-x:typecheck: cache miss, executing 1d8ca1432a3605a7
+@elizaos/example-xai-x:typecheck: $ tsgo --noEmit
+@elizaos/plugin-cloud-apps:build: 🔨 Building @elizaos/plugin-cloud-apps (Node)…
+@elizaos/plugin-cloud-apps:build: ✅ Node complete in 0.01s
+@elizaos/plugin-cloud-apps:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-remote-manifest:build: cache miss, executing 692347b643ca85e1
+@elizaos/plugin-remote-manifest:build: $ node ../scripts/rm-path-recursive.mjs dist tsconfig.build.tsbuildinfo && tsc --noCheck -p tsconfig.build.json
+@elizaos/plugin-mcp:build: cache miss, executing 24d8e3956eea63a4
+@elizaos/plugin-mcp:build: $ bun run build.ts
+@elizaos/plugin-mcp:build: 🔨 Building @elizaos/plugin-mcp (Node (ESM))…
+@elizaos/plugin-mcp:build: ✅ Node (ESM) complete in 0.01s
+@elizaos/plugin-mcp:build: 🔨 Building @elizaos/plugin-mcp (Node (CJS))…
+@elizaos/plugin-mcp:build: ✅ Node (CJS) complete in 0.01s
+@elizaos/plugin-mcp:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-google-genai:build: 🎉 @elizaos/plugin-google-genai build finished in 1.82s
+@elizaos/plugin-localdb:build: cache miss, executing 8377054ba43a0540
+@elizaos/plugin-localdb:build: $ tsup --config tsup.config.ts
+@elizaos/capacitor-talkmode:build:
+@elizaos/capacitor-talkmode:build: dist/esm/index.js → dist/plugin.js, dist/plugin.cjs.js...
+@elizaos/plugin-cloud-apps:build: 🎉 @elizaos/plugin-cloud-apps build finished in 1.03s
+@elizaos/plugin-browser:build: cache miss, executing b5dd0b6142915486
+@elizaos/plugin-browser:build: $ bun run build:js && bun run build:types
+@elizaos/plugin-browser:build: $ tsup --config ../tsup.plugin-packages.shared.ts
+@elizaos/capacitor-talkmode:build: created dist/plugin.js, dist/plugin.cjs.js in 103ms
+@elizaos/shared:build: cache miss, executing 2e8a0175a2aeb803
+@elizaos/shared:build: $ bun run build:i18n && bun run build:dist
+@elizaos/shared:build: $ node scripts/generate-keywords.mjs --target ts
+@elizaos/plugin-vision:build: 🎉 @elizaos/plugin-vision build finished in 1.56s
+@elizaos/gcp-examples:typecheck: cache miss, executing 9efbd93fe1e6acb0
+@elizaos/gcp-examples:typecheck: $ tsgo --noEmit
+@elizaos/shared:build: Generating keyword code from JSON...
+@elizaos/shared:build:
+@elizaos/plugin-localdb:build: CLI Building entry: {"index":"index.ts","index.browser":"index.browser.ts"}
+@elizaos/plugin-localdb:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-localdb:build: CLI tsup v8.5.1
+@elizaos/plugin-localdb:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/plugin-localdb/tsup.config.ts
+@elizaos/shared:build:   Loaded action-search.generated.keywords.json: 114 entries
+@elizaos/shared:build:   Loaded context-search.keywords.json: 38 entries
+@elizaos/shared:build:   Loaded shared.keywords.json: 71 entries
+@elizaos/plugin-localdb:build: CLI Target: es2022
+@elizaos/shared:build:   Loaded typescript.keywords.json: 16 entries
+@elizaos/shared:build:   Loaded validate.keywords.json: 2 entries
+@elizaos/shared:build:
+@elizaos/shared:build: Total: 239 entries, 6 locales
+@elizaos/shared:build:
+@elizaos/plugin-localdb:build: CLI Cleaning output folder
+@elizaos/plugin-localdb:build: ESM Build start
+@elizaos/shared:build:   TypeScript (shared): /Users/shawwalters/.codex/worktrees/36cd/eliza/packages/shared/src/i18n/generated/validation-keyword-data.ts
+@elizaos/shared:build:   JavaScript (shared): /Users/shawwalters/.codex/worktrees/36cd/eliza/packages/shared/src/i18n/generated/validation-keyword-data.js
+@elizaos/shared:build:   TypeScript (core):   /Users/shawwalters/.codex/worktrees/36cd/eliza/packages/core/src/i18n/generated/validation-keyword-data.ts
+@elizaos/shared:build:
+@elizaos/shared:build: Done!
+@elizaos/plugin-localdb:build: ESM dist/index.js             4.16 KB
+@elizaos/plugin-localdb:build: ESM dist/index.browser.js     3.16 KB
+@elizaos/plugin-localdb:build: ESM dist/index.js.map         9.34 KB
+@elizaos/plugin-localdb:build: ESM dist/index.browser.js.map 6.74 KB
+@elizaos/plugin-localdb:build: ESM ⚡️ Build success in 10ms
+@elizaos/shared:build: $ node ../scripts/rm-path-recursive.mjs dist && tsc --noCheck -p tsconfig.build.json && node ../scripts/prepare-package-dist.mjs packages/shared && node ../scripts/rewrite-dist-relative-imports-node-esm.mjs packages/shared && node ../scripts/copy-package-assets.mjs packages/shared src/brand/brand.css src/brand-classic/brand.css
+@elizaos/capacitor-swabble:build:
+@elizaos/capacitor-swabble:build: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/plugin-native-swabble/dist/esm/index.js → dist/plugin.js, dist/plugin.cjs.js...
+@elizaos/example-bluesky:typecheck: cache miss, executing 073a547c56f153c1
+@elizaos/example-bluesky:typecheck: $ tsgo --noEmit
+@elizaos/capacitor-swabble:build: created dist/plugin.js, dist/plugin.cjs.js in 164ms
+@elizaos/plugin-localdb:build: DTS Build start
+@elizaos/plugin-browser:build: CLI Building entry: src/schema.ts, src/companion-auth.ts, src/lifeops-session-contracts.ts, src/browser-capture-hooks.ts, src/workspace.ts, src/bridge-policy.ts, src/contracts.ts, src/browser-workspace-hooks.ts, src/plugin.ts, src/packaging.ts, src/password-manager-bridge.ts, src/message-adapter.ts, src/bridge-records.ts, src/bridge-readiness.ts, src/index.ts, src/service.ts, src/browser-service.ts, src/benchmark/web-grounding.ts, src/benchmark/chromium-executor.ts, src/benchmark/external-dataset.ts, src/benchmark/types.ts, src/benchmark/policy.ts, src/benchmark/adapter.ts, src/benchmark/index.ts, src/benchmark/tasks.ts, src/benchmark/runner.ts, src/targets/stagehand-target.ts, src/targets/bridge-target.ts, src/routes/workspace-account-gate.ts, src/routes/workspace-setup.ts, src/routes/workspace.ts, src/routes/bridge.ts, src/workspace/browser-workspace-desktop.ts, src/workspace/browser-workspace-helpers.ts, src/workspace/browser-workspace-types.ts, src/workspace/browser-workspace-errors.ts, src/workspace/browser-workspace-network.ts, src/workspace/browser-workspace-elements.ts, src/workspace/browser-workspace-web.ts, src/workspace/browser-capture.ts, src/workspace/browser-workspace-jsdom.ts, src/workspace/browser-workspace-state.ts, src/workspace/browser-workspace-snapshots.ts, src/workspace/index.ts, src/workspace/browser-workspace-forms.ts, src/workspace/browser-workspace.ts, src/providers/workspace.ts, src/actions/browser-autofill-login.ts, src/actions/wait-for-url-predicate.ts, src/actions/manage-browser-bridge.ts, src/actions/wait-for-url.ts, src/actions/browser.ts, src/parity/browser-matrix.ts, src/parity/index.ts
+@elizaos/plugin-browser:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-browser:build: CLI tsup v8.5.1
+@elizaos/plugin-browser:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/tsup.plugin-packages.shared.ts
+@elizaos/plugin-browser:build: CLI Target: es2022
+@elizaos/plugin-browser:build: ESM Build start
+@elizaos/example-convex:typecheck: cache miss, executing fbda47778a510fa5
+@elizaos/example-convex:typecheck: $ tsgo --noEmit
+@elizaos/plugin-browser:build: ESM dist/targets/bridge-target.js                     2.93 KB
+@elizaos/plugin-browser:build: ESM dist/schema.js                                    4.88 KB
+@elizaos/plugin-browser:build: ESM dist/benchmark/types.js                           33.00 B
+@elizaos/plugin-browser:build: ESM dist/benchmark/runner.js                          3.26 KB
+@elizaos/plugin-browser:build: ESM dist/benchmark/policy.js                          960.00 B
+@elizaos/plugin-browser:build: ESM dist/benchmark/index.js                           1.38 KB
+@elizaos/plugin-browser:build: ESM dist/routes/bridge.js                             24.03 KB
+@elizaos/plugin-browser:build: ESM dist/benchmark/tasks.js                           10.68 KB
+@elizaos/plugin-browser:build: ESM dist/routes/workspace-setup.js                    1.81 KB
+@elizaos/plugin-browser:build: ESM dist/targets/stagehand-target.js                  6.15 KB
+@elizaos/plugin-browser:build: ESM dist/parity/browser-matrix.js                     8.70 KB
+@elizaos/plugin-browser:build: ESM dist/packaging.js                                 17.54 KB
+@elizaos/plugin-browser:build: ESM dist/password-manager-bridge.js                   12.34 KB
+@elizaos/plugin-browser:build: ESM dist/routes/workspace.js                          10.36 KB
+@elizaos/plugin-browser:build: ESM dist/parity/index.js                              286.00 B
+@elizaos/plugin-browser:build: ESM dist/message-adapter.js                           2.98 KB
+@elizaos/plugin-browser:build: ESM dist/routes/workspace-account-gate.js             4.48 KB
+@elizaos/plugin-browser:build: ESM dist/bridge-policy.js                             1.33 KB
+@elizaos/plugin-browser:build: ESM dist/bridge-records.js                            941.00 B
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-forms.js         9.36 KB
+@elizaos/plugin-browser:build: ESM dist/workspace.js                                 75.00 B
+@elizaos/plugin-browser:build: ESM dist/contracts.js                                 1.28 KB
+@elizaos/plugin-browser:build: ESM dist/bridge-readiness.js                          3.01 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-state.js         4.36 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-jsdom.js         6.72 KB
+@elizaos/plugin-browser:build: ESM dist/index.js                                     3.71 KB
+@elizaos/plugin-browser:build: ESM dist/browser-workspace-hooks.js                   463.00 B
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace.js               30.90 KB
+@elizaos/plugin-browser:build: ESM dist/benchmark/adapter.js                         6.18 KB
+@elizaos/plugin-browser:build: ESM dist/service.js                                   151.00 B
+@elizaos/plugin-browser:build: ESM dist/targets/bridge-target.js.map                 7.00 KB
+@elizaos/plugin-browser:build: ESM dist/plugin.js                                    5.64 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-snapshots.js     5.68 KB
+@elizaos/plugin-browser:build: ESM dist/actions/wait-for-url.js                      2.92 KB
+@elizaos/plugin-browser:build: ESM dist/benchmark/index.js.map                       2.15 KB
+@elizaos/plugin-browser:build: ESM dist/benchmark/runner.js.map                      7.10 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-desktop.js       55.49 KB
+@elizaos/plugin-browser:build: ESM dist/benchmark/types.js.map                       71.00 B
+@elizaos/plugin-browser:build: ESM dist/actions/wait-for-url-predicate.js            822.00 B
+@elizaos/plugin-browser:build: ESM dist/benchmark/policy.js.map                      3.55 KB
+@elizaos/plugin-browser:build: ESM dist/actions/browser.js                           20.26 KB
+@elizaos/plugin-browser:build: ESM dist/browser-service.js                           6.56 KB
+@elizaos/plugin-browser:build: ESM dist/actions/manage-browser-bridge.js             11.27 KB
+@elizaos/plugin-browser:build: ESM dist/providers/workspace.js                       1.64 KB
+@elizaos/plugin-browser:build: ESM dist/companion-auth.js                            2.83 KB
+@elizaos/plugin-browser:build: ESM dist/benchmark/web-grounding.js                   5.63 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-types.js         237.00 B
+@elizaos/plugin-browser:build: ESM dist/workspace/index.js                           158.00 B
+@elizaos/plugin-browser:build: ESM dist/lifeops-session-contracts.js                 53.00 B
+@elizaos/plugin-browser:build: ESM dist/browser-capture-hooks.js                     445.00 B
+@elizaos/plugin-browser:build: ESM dist/schema.js.map                                9.92 KB
+@elizaos/plugin-browser:build: ESM dist/actions/browser-autofill-login.js            8.31 KB
+@elizaos/plugin-browser:build: ESM dist/benchmark/external-dataset.js                6.30 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-capture.js                 5.24 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-errors.js        2.25 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-helpers.js       9.61 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-web.js           45.14 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-elements.js      17.56 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-network.js       4.43 KB
+@elizaos/plugin-browser:build: ESM dist/benchmark/chromium-executor.js               12.42 KB
+@elizaos/plugin-browser:build: ESM dist/routes/bridge.js.map                         45.55 KB
+@elizaos/plugin-browser:build: ESM dist/benchmark/tasks.js.map                       21.67 KB
+@elizaos/plugin-browser:build: ESM dist/targets/stagehand-target.js.map              11.48 KB
+@elizaos/plugin-browser:build: ESM dist/routes/workspace-setup.js.map                3.95 KB
+@elizaos/plugin-browser:build: ESM dist/parity/browser-matrix.js.map                 16.58 KB
+@elizaos/plugin-browser:build: ESM dist/bridge-policy.js.map                         2.17 KB
+@elizaos/plugin-browser:build: ESM dist/packaging.js.map                             31.76 KB
+@elizaos/plugin-browser:build: ESM dist/contracts.js.map                             10.39 KB
+@elizaos/plugin-browser:build: ESM dist/parity/index.js.map                          540.00 B
+@elizaos/plugin-browser:build: ESM dist/message-adapter.js.map                       6.19 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-forms.js.map     16.36 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-snapshots.js.map 10.43 KB
+@elizaos/plugin-browser:build: ESM dist/bridge-records.js.map                        2.08 KB
+@elizaos/plugin-browser:build: ESM dist/routes/workspace.js.map                      19.02 KB
+@elizaos/plugin-browser:build: ESM dist/bridge-readiness.js.map                      5.99 KB
+@elizaos/plugin-browser:build: ESM dist/password-manager-bridge.js.map               27.10 KB
+@elizaos/plugin-browser:build: ESM dist/service.js.map                               4.07 KB
+@elizaos/plugin-browser:build: ESM dist/workspace.js.map                             145.00 B
+@elizaos/plugin-browser:build: ESM dist/index.js.map                                 5.78 KB
+@elizaos/plugin-browser:build: ESM dist/benchmark/web-grounding.js.map               13.03 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-web.js.map       75.75 KB
+@elizaos/plugin-browser:build: ESM dist/actions/wait-for-url.js.map                  7.55 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-desktop.js.map   71.67 KB
+@elizaos/plugin-browser:build: ESM dist/routes/workspace-account-gate.js.map         8.28 KB
+@elizaos/plugin-browser:build: ESM dist/plugin.js.map                                10.91 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-jsdom.js.map     12.78 KB
+@elizaos/plugin-browser:build: ESM dist/benchmark/adapter.js.map                     13.35 KB
+@elizaos/plugin-browser:build: ESM dist/actions/browser-autofill-login.js.map        15.93 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace.js.map           56.36 KB
+@elizaos/plugin-browser:build: ESM dist/lifeops-session-contracts.js.map             71.00 B
+@elizaos/plugin-browser:build: ESM dist/benchmark/external-dataset.js.map            11.67 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-state.js.map     7.87 KB
+@elizaos/plugin-browser:build: ESM dist/actions/wait-for-url-predicate.js.map        3.02 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/index.js.map                       1.52 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-elements.js.map  31.44 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-capture.js.map             11.46 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-helpers.js.map   15.11 KB
+@elizaos/plugin-browser:build: ESM dist/companion-auth.js.map                        5.88 KB
+@elizaos/plugin-browser:build: ESM dist/actions/browser.js.map                       40.50 KB
+@elizaos/plugin-browser:build: ESM dist/browser-service.js.map                       14.93 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-types.js.map     13.78 KB
+@elizaos/plugin-browser:build: ESM dist/actions/manage-browser-bridge.js.map         21.51 KB
+@elizaos/plugin-browser:build: ESM dist/browser-capture-hooks.js.map                 1.08 KB
+@elizaos/plugin-browser:build: ESM dist/browser-workspace-hooks.js.map               2.00 KB
+@elizaos/plugin-browser:build: ESM dist/providers/workspace.js.map                   3.16 KB
+@elizaos/plugin-browser:build: ESM dist/benchmark/chromium-executor.js.map           27.96 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-errors.js.map    6.81 KB
+@elizaos/plugin-browser:build: ESM dist/workspace/browser-workspace-network.js.map   8.33 KB
+@elizaos/plugin-browser:build: ESM ⚡️ Build success in 77ms
+@elizaos/plugin-browser:build: $ tsc --noCheck -p tsconfig.build.json
+@elizaos/cloud-api:typecheck: cache miss, executing db57496897860779
+@elizaos/cloud-api:typecheck: $ tsgo --noEmit
+@elizaos/plugin-mcp:build: 🎉 @elizaos/plugin-mcp build finished in 1.35s
+@elizaos/cloud-shared:typecheck: cache miss, executing 4bce4ba202f44437
+@elizaos/cloud-shared:typecheck: $ tsgo --noEmit
+@elizaos/plugin-worker-runtime:build: cache miss, executing a827915b887deafc
+@elizaos/plugin-worker-runtime:build: $ node ../scripts/rm-path-recursive.mjs dist tsconfig.build.tsbuildinfo && tsc --noCheck -p tsconfig.build.json
+@elizaos/example-telegram:typecheck: cache miss, executing ffaa620484f02d2a
+@elizaos/example-telegram:typecheck: $ tsgo --noEmit
+@elizaos/plugin-sub-agent-claude-code:typecheck: cache miss, executing a951830a31947469
+@elizaos/plugin-sub-agent-claude-code:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-localdb:build: DTS ⚡️ Build success in 1721ms
+@elizaos/plugin-localdb:build: DTS dist/index.d.ts         306.00 B
+@elizaos/plugin-localdb:build: DTS dist/index.browser.d.ts 289.00 B
+@elizaos/plugin-streaming:build: cache miss, executing 3afc992fe5ee6e6c
+@elizaos/plugin-discord:build: cache miss, executing efe6042c2efbb0cd
+@elizaos/plugin-discord:typecheck: cache miss, executing 094c970b88be93bc
+@elizaos/plugin-streaming:build: $ tsup && tsc --declaration --emitDeclarationOnly --noEmit false --noCheck
+@elizaos/plugin-discord:build: $ bun run build.ts
+@elizaos/plugin-discord:typecheck: $ tsgo --noEmit
+@elizaos/plugin-discord:build: 🔨 Building @elizaos/plugin-discord (Node)…
+@elizaos/plugin-discord:build: ✅ Node complete in 0.07s
+@elizaos/plugin-discord:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-streaming:build: CLI Building entry: src/core.ts, src/index.ts, src/services/tts-stream-bridge.ts, src/services/stream-manager.ts, src/api/stream-route-state.ts, src/api/streaming-text.ts, src/api/stream-persistence.ts, src/api/stream-routes.ts, src/api/tts-routes.ts, src/api/streaming-types.ts
+@elizaos/plugin-streaming:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-streaming:build: CLI tsup v8.5.1
+@elizaos/plugin-streaming:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/plugin-streaming/tsup.config.ts
+@elizaos/plugin-streaming:build: CLI Target: esnext
+@elizaos/plugin-streaming:build: ESM Build start
+@elizaos/plugin-streaming:build: ESM dist/services/stream-manager.js        15.39 KB
+@elizaos/plugin-streaming:build: ESM dist/services/tts-stream-bridge.js     13.19 KB
+@elizaos/plugin-streaming:build: ESM dist/api/stream-routes.js              18.59 KB
+@elizaos/plugin-streaming:build: ESM dist/api/stream-persistence.js         5.69 KB
+@elizaos/plugin-streaming:build: ESM dist/api/streaming-text.js             2.65 KB
+@elizaos/plugin-streaming:build: ESM dist/api/tts-routes.js                 11.60 KB
+@elizaos/plugin-streaming:build: ESM dist/core.js                           16.43 KB
+@elizaos/plugin-streaming:build: ESM dist/api/stream-route-state.js         46.00 B
+@elizaos/plugin-streaming:build: ESM dist/index.js                          3.89 KB
+@elizaos/plugin-streaming:build: ESM dist/api/streaming-types.js            43.00 B
+@elizaos/plugin-streaming:build: ESM dist/api/stream-persistence.js.map     13.18 KB
+@elizaos/plugin-streaming:build: ESM dist/core.js.map                       36.92 KB
+@elizaos/plugin-streaming:build: ESM dist/services/stream-manager.js.map    32.22 KB
+@elizaos/plugin-streaming:build: ESM dist/index.js.map                      6.54 KB
+@elizaos/plugin-streaming:build: ESM dist/api/stream-routes.js.map          41.12 KB
+@elizaos/plugin-streaming:build: ESM dist/api/stream-route-state.js.map     71.00 B
+@elizaos/plugin-streaming:build: ESM dist/api/streaming-text.js.map         5.00 KB
+@elizaos/plugin-streaming:build: ESM dist/api/tts-routes.js.map             24.45 KB
+@elizaos/plugin-streaming:build: ESM dist/services/tts-stream-bridge.js.map 26.61 KB
+@elizaos/plugin-streaming:build: ESM dist/api/streaming-types.js.map        71.00 B
+@elizaos/plugin-streaming:build: ESM ⚡️ Build success in 38ms
+@elizaos/plugin-discord:build: 🔧 Rewriting dist relative imports for NodeNext…
+@elizaos/plugin-discord:build: [rewrite-dist-relative-imports] rewrote 25 file(s)
+@elizaos/plugin-discord:build: 🎉 @elizaos/plugin-discord build finished in 1.65s
+@elizaos/shared:build: [rewrite-dist-relative-imports] rewrote 5 file(s)
+@elizaos/ui:build: cache miss, executing b37d016a04d0dc6a
+@elizaos/plugin-scheduling:build: cache miss, executing dd22fc9f8df0c424
+@elizaos/plugin-agent-skills:build: cache miss, executing dbb8a6c737ea4a63
+@elizaos/plugin-coding-tools:build: cache miss, executing e974e4dfccd99dbe
+@elizaos/plugin-elizacloud:build: cache miss, executing 87f58d4c2e4d06b0
+@elizaos/plugin-registry:build: cache miss, executing 96b1edb7af5a441e
+@elizaos/plugin-shell:build: cache miss, executing 5eea103711521ea9
+@elizaos/plugin-scheduling:build: $ bun run build:js && bun run build:types
+@elizaos/ui:build: $ bun run build:dist
+@elizaos/plugin-coding-tools:build: $ bun run build.ts
+@elizaos/plugin-shell:build: $ bun run build.ts
+@elizaos/plugin-registry:build: $ bun run build:js && bun run build:types
+@elizaos/plugin-agent-skills:build: $ tsup && tsc --declaration --emitDeclarationOnly --noEmit false --noCheck
+@elizaos/plugin-elizacloud:build: $ bun run build.ts
+@elizaos/plugin-scheduling:build: $ tsup --config ../tsup.plugin-packages.shared.ts
+@elizaos/plugin-registry:build: $ tsup --config ../tsup.plugin-packages.shared.ts
+@elizaos/ui:build: $ node ../scripts/with-package-build-lock.mjs packages/ui -- bun run build:dist:unlocked
+@elizaos/ui:build: $ bun run clean && bun run generate:css-strings && node ../scripts/ensure-tsc-nested-output-dir.mjs packages/ui && tsc --noCheck -p tsconfig.build.json && node ../scripts/flatten-tsc-package-output.mjs packages/ui && node ../scripts/copy-package-assets.mjs packages/ui src/styles src/cloud-ui/index.css && node ../scripts/prepare-package-dist.mjs packages/ui && node ../scripts/rewrite-dist-relative-imports-node-esm.mjs packages/ui && node ../scripts/verify-package-runtime-exports.mjs packages/ui
+@elizaos/ui:build: $ node ../scripts/rm-path-recursive.mjs dist
+@elizaos/plugin-shell:build: 🔨 Building @elizaos/plugin-shell (Node)…
+@elizaos/plugin-coding-tools:build: 🔨 Building @elizaos/plugin-coding-tools (Node)…
+@elizaos/plugin-shell:build: ✅ Node complete in 0.01s
+@elizaos/plugin-shell:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-coding-tools:build: ✅ Node complete in 0.02s
+@elizaos/plugin-coding-tools:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-elizacloud:build: 🔨 Building @elizaos/plugin-elizacloud (Node)…
+@elizaos/plugin-elizacloud:build: ✅ Node complete in 0.01s
+@elizaos/plugin-elizacloud:build: 🔨 Building @elizaos/plugin-elizacloud (Browser)…
+@elizaos/plugin-elizacloud:build: ✅ Browser complete in 0.00s
+@elizaos/plugin-elizacloud:build: 🔨 Building @elizaos/plugin-elizacloud (Node (CJS))…
+@elizaos/plugin-elizacloud:build: ✅ Node (CJS) complete in 0.02s
+@elizaos/plugin-elizacloud:build: 🔨 Building @elizaos/plugin-elizacloud (Exported subpaths)…
+@elizaos/plugin-agent-skills:build: CLI Building entry: src/index.ts
+@elizaos/plugin-agent-skills:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-agent-skills:build: CLI tsup v8.5.1
+@elizaos/plugin-agent-skills:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/plugin-agent-skills/tsup.config.ts
+@elizaos/plugin-agent-skills:build: CLI Target: es2022
+@elizaos/plugin-registry:build: CLI Building entry: src/index.ts, src/api/app-plugins-routes.ts, src/api/plugin-routes.ts, src/services/plugin-installer.ts
+@elizaos/plugin-registry:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-registry:build: CLI tsup v8.5.1
+@elizaos/plugin-registry:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/tsup.plugin-packages.shared.ts
+@elizaos/plugin-registry:build: CLI Target: es2022
+@elizaos/plugin-registry:build: ESM Build start
+@elizaos/plugin-scheduling:build: CLI Building entry: src/dispatch-types.ts, src/plugin.ts, src/index.ts, src/scheduled-task/schema.ts, src/scheduled-task/runner-service.ts, src/scheduled-task/gate-registry.ts, src/scheduled-task/state-log.ts, src/scheduled-task/due.ts, src/scheduled-task/next-fire-at.ts, src/scheduled-task/types.ts, src/scheduled-task/completion-check-registry.ts, src/scheduled-task/escalation.ts, src/scheduled-task/default-pack.ts, src/scheduled-task/index.ts, src/scheduled-task/runner.ts, src/scheduled-task/consolidation-policy.ts, src/scheduled-task/seed-registry.ts, src/routes/scheduled-tasks.ts, src/routes/plugin-routes.ts, src/anchors/anchor-registry.ts
+@elizaos/plugin-scheduling:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-scheduling:build: CLI tsup v8.5.1
+@elizaos/plugin-scheduling:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/tsup.plugin-packages.shared.ts
+@elizaos/plugin-scheduling:build: CLI Target: es2022
+@elizaos/plugin-scheduling:build: ESM Build start
+@elizaos/plugin-elizacloud:build: ✅ Exported subpaths complete in 0.08s
+@elizaos/plugin-elizacloud:build: 📂 Flattening dist/src → dist/.…
+@elizaos/plugin-agent-skills:build: CLI Cleaning output folder
+@elizaos/plugin-agent-skills:build: ESM Build start
+@elizaos/plugin-registry:build: ESM dist/api/plugin-routes.js             50.13 KB
+@elizaos/plugin-registry:build: ESM dist/services/plugin-installer.js     866.00 B
+@elizaos/plugin-registry:build: ESM dist/index.js                         542.00 B
+@elizaos/plugin-registry:build: ESM dist/api/app-plugins-routes.js        37.85 KB
+@elizaos/plugin-registry:build: ESM dist/api/plugin-routes.js.map         97.23 KB
+@elizaos/plugin-registry:build: ESM dist/api/app-plugins-routes.js.map    75.86 KB
+@elizaos/plugin-registry:build: ESM dist/index.js.map                     1.71 KB
+@elizaos/plugin-registry:build: ESM dist/services/plugin-installer.js.map 3.18 KB
+@elizaos/plugin-registry:build: ESM ⚡️ Build success in 37ms
+@elizaos/plugin-scheduling:build: ESM dist/plugin.js                                       1.87 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/completion-check-registry.js     3.35 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/escalation.js                    2.90 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/gate-registry.js                 7.49 KB
+@elizaos/plugin-scheduling:build: ESM dist/anchors/anchor-registry.js                      3.93 KB
+@elizaos/plugin-scheduling:build: ESM dist/dispatch-types.js                               42.00 B
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/state-log.js                     2.97 KB
+@elizaos/plugin-scheduling:build: ESM dist/index.js                                        734.00 B
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/due.js                           12.66 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/runner-service.js                6.97 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/default-pack.js                  1.87 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/next-fire-at.js                  6.81 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/index.js                         3.24 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/seed-registry.js                 2.21 KB
+@elizaos/plugin-scheduling:build: ESM dist/routes/scheduled-tasks.js                       7.42 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/runner.js                        23.87 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/types.js                         358.00 B
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/consolidation-policy.js          4.68 KB
+@elizaos/plugin-scheduling:build: ESM dist/plugin.js.map                                   5.44 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/schema.js                        6.30 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/escalation.js.map                6.75 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/completion-check-registry.js.map 7.42 KB
+@elizaos/plugin-scheduling:build: ESM dist/routes/plugin-routes.js                         2.24 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/gate-registry.js.map             16.34 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/state-log.js.map                 7.36 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/runner-service.js.map            17.78 KB
+@elizaos/plugin-scheduling:build: ESM dist/index.js.map                                    1.01 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/due.js.map                       24.70 KB
+@elizaos/plugin-scheduling:build: ESM dist/dispatch-types.js.map                           71.00 B
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/default-pack.js.map              5.18 KB
+@elizaos/plugin-scheduling:build: ESM dist/anchors/anchor-registry.js.map                  9.38 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/types.js.map                     14.98 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/consolidation-policy.js.map      11.60 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/index.js.map                     4.99 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/schema.js.map                    12.85 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/runner.js.map                    60.38 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/seed-registry.js.map             6.50 KB
+@elizaos/plugin-scheduling:build: ESM dist/routes/scheduled-tasks.js.map                   15.44 KB
+@elizaos/plugin-scheduling:build: ESM dist/scheduled-task/next-fire-at.js.map              14.68 KB
+@elizaos/plugin-scheduling:build: ESM dist/routes/plugin-routes.js.map                     5.17 KB
+@elizaos/plugin-scheduling:build: ESM ⚡️ Build success in 36ms
+@elizaos/plugin-registry:build: $ tsc --noCheck -p tsconfig.build.json && node ../../packages/scripts/rewrite-dist-relative-imports-node-esm.mjs
+@elizaos/plugin-scheduling:build: $ bunx tsc --noCheck -p tsconfig.build.json && node ../../packages/scripts/rewrite-dist-relative-imports-node-esm.mjs
+@elizaos/plugin-agent-skills:build: ESM dist/security-EG7TNDRO.js                 18.02 KB
+@elizaos/plugin-agent-skills:build: ESM dist/index.js                             205.57 KB
+@elizaos/plugin-agent-skills:build: ESM dist/chunk-ZTFKIHLT.js                    3.64 KB
+@elizaos/plugin-agent-skills:build: ESM dist/skill-catalog-client-XD3KGK7O.js     308.00 B
+@elizaos/plugin-agent-skills:build: ESM dist/skill-marketplace-GLSNT3NB.js        337.00 B
+@elizaos/plugin-agent-skills:build: ESM dist/chunk-JMKUEEPA.js                    20.54 KB
+@elizaos/plugin-agent-skills:build: ESM dist/security-EG7TNDRO.js.map             34.87 KB
+@elizaos/plugin-agent-skills:build: ESM dist/skill-marketplace-GLSNT3NB.js.map    71.00 B
+@elizaos/plugin-agent-skills:build: ESM dist/index.js.map                         441.52 KB
+@elizaos/plugin-agent-skills:build: ESM dist/chunk-JMKUEEPA.js.map                41.94 KB
+@elizaos/plugin-agent-skills:build: ESM dist/chunk-ZTFKIHLT.js.map                7.92 KB
+@elizaos/plugin-agent-skills:build: ESM dist/skill-catalog-client-XD3KGK7O.js.map 71.00 B
+@elizaos/plugin-agent-skills:build: ESM ⚡️ Build success in 51ms
+@elizaos/plugin-elizacloud:build: 📝 Generating TypeScript declarations…
+@elizaos/ui:build: $ node ../scripts/generate-css-strings.mjs
+@elizaos/ui:build: [generate-css-strings] processed 0 target(s), updated 0
+@elizaos/plugin-wallet:build: cache miss, executing 808bf59010cbcdda
+@elizaos/plugin-wallet:build: $ bun run build.ts
+@elizaos/plugin-wallet:build: 🔨 Building @elizaos/plugin-wallet (Node)…
+@elizaos/plugin-wallet:build: ✅ Node complete in 0.02s
+@elizaos/plugin-wallet:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-coding-tools:build: 🎉 @elizaos/plugin-coding-tools build finished in 1.77s
+@elizaos/plugin-aosp-local-inference:build: cache miss, executing dc015445a1c7b437
+@elizaos/plugin-aosp-local-inference:build: $ tsc --noCheck -p tsconfig.json --noEmit
+@elizaos/plugin-shell:build: 🎉 @elizaos/plugin-shell build finished in 1.85s
+@elizaos/plugin-agent-orchestrator:build: cache miss, executing 4ebd313a7706a216
+@elizaos/plugin-agent-orchestrator:build: $ bun run build.ts
+@elizaos/plugin-scheduling:build: [rewrite-dist-relative-imports] rewrote 1 file(s)
+@elizaos/plugin-agent-orchestrator:build: 🔨 Building @elizaos/plugin-agent-orchestrator (Node)…
+@elizaos/plugin-agent-orchestrator:build: ✅ Node complete in 0.03s
+@elizaos/plugin-agent-orchestrator:build: 🔨 Building @elizaos/plugin-agent-orchestrator (Node (CJS))…
+@elizaos/plugin-agent-orchestrator:build: ✅ Node (CJS) complete in 0.02s
+@elizaos/plugin-agent-orchestrator:build: 📝 Generating TypeScript declarations…
+@elizaos/plugin-registry:build: [rewrite-dist-relative-imports] rewrote 1 file(s)
+@elizaos/plugin-app-manager:build: cache miss, executing 38418a08e6bf54b4
+@elizaos/plugin-app-manager:build: $ bun run build.ts
+@elizaos/plugin-elizacloud:build: 🎉 @elizaos/plugin-elizacloud build finished in 2.57s
+@elizaos/example-rest-api-elysia:typecheck: cache miss, executing e85bcc59d74d9564
+@elizaos/example-a2a-server:typecheck: cache miss, executing 8dc7033cba1f359f
+@elizaos/plugin-app-manager:build: 🔨 Building @elizaos/plugin-app-manager (Node)…
+@elizaos/example-browser-extension-chrome:typecheck: cache miss, executing 01185c163209799c
+@elizaos/example-rest-api-elysia:typecheck: $ tsgo --noEmit
+@elizaos/plugin-app-manager:build: ✅ Node complete in 0.01s
+@elizaos/plugin-app-manager:build: 📝 Generating TypeScript declarations…
+@elizaos/example-browser-extension-chrome:typecheck: $ tsgo --noEmit
+@elizaos/example-a2a-server:typecheck: $ tsgo --noEmit
+eliza-react-example:typecheck: cache miss, executing 6ddee35f85a947bf
+eliza-react-example:typecheck: $ tsgo --noEmit
+@elizaos/example-rest-api-hono:typecheck: cache miss, executing 8be58ab1f2f94931
+@elizaos/example-rest-api-hono:typecheck: $ tsgo --noEmit
+@elizaos/example-app-electron:typecheck: cache miss, executing 7c6f612c54eb8def
+@elizaos/example-rest-api-express:typecheck: cache miss, executing 1a5fc858f54fa5f4
+@elizaos/example-app-electron:typecheck: $ tsc --noEmit
+@elizaos/example-rest-api-express:typecheck: $ tsgo --noEmit
+@elizaos/plugin-local-inference:build: cache miss, executing 8b8b584adefca1b6
+@elizaos/plugin-local-inference:build: $ bun run build.ts
+@elizaos/plugin-local-inference:build: 🔨 Building @elizaos/plugin-local-inference...
+@elizaos/plugin-local-inference:build: 📝 Generating TypeScript declarations...
+@elizaos/plugin-agent-orchestrator:build: 🎉 @elizaos/plugin-agent-orchestrator build finished in 1.63s
+@elizaos/plugin-app-manager:build: 🔧 Rewriting dist relative imports for NodeNext…
+@elizaos/plugin-app-manager:build: [rewrite-dist-relative-imports] rewrote 1 file(s)
+@elizaos/plugin-app-manager:build: 🎉 @elizaos/plugin-app-manager build finished in 3.36s
+@elizaos/plugin-music:lint: cache miss, executing f63bd1d6b8ca946a
+@elizaos/plugin-coding-tools:lint: cache miss, executing abf2a19a5401b224
+@elizaos/plugin-linear:lint: cache miss, executing 95db930dc0e7b434
+@elizaos/example-text-adventure:lint: cache miss, executing c37dee7fe757827e
+@elizaos/plugin-feed:lint: cache miss, executing 570e98b6987a983b
+@elizaos/plugin-coding-tools:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-music:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-linear:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-text-adventure:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-feed:lint: $ bunx @biomejs/biome check src
+@elizaos/plugin-linear:lint: Checked 37 files in 70ms. No fixes applied.
+@elizaos/plugin-line:lint: cache miss, executing ba0e02b8528a24c7
+@elizaos/plugin-line:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-music:lint: Checked 97 files in 144ms. No fixes applied.
+@elizaos/contracts:lint: cache miss, executing e26c01571f30ad46
+@elizaos/plugin-feed:lint: Checked 16 files in 33ms. No fixes applied.
+@elizaos/contracts:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/gcp-examples:lint: cache miss, executing e62185ff8f2804b7
+@elizaos/example-text-adventure:lint: Checked 4 files in 63ms. No fixes applied.
+@elizaos/gcp-examples:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-nearai:lint: cache miss, executing 27815fb4cb870904
+@elizaos/plugin-coding-tools:lint: Checked 55 files in 91ms. No fixes applied.
+@elizaos/plugin-nearai:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/agent:lint: cache miss, executing 6aacb84b01658edb
+@elizaos/agent:lint: $ bunx @biomejs/biome check ./src/actions ./src/api ./src/auth ./src/awareness ./src/bin.ts ./src/cli ./src/config ./src/contracts ./src/diagnostics ./src/hooks ./src/index.ts ./src/providers ./src/runtime ./src/security ./src/services ./src/shared ./src/triggers ./src/utils ./src/version-resolver.ts
+@elizaos/plugin-line:lint: Checked 15 files in 44ms. No fixes applied.
+elizaos:lint: cache miss, executing f2c100c9c6a75833
+@elizaos/contracts:lint: Checked 9 files in 16ms. No fixes applied.
+elizaos:lint: $ bunx @biomejs/biome check --write README.md build.ts package.json scripts src templates-manifest.json templates/min-plugin templates/min-project templates/project/.env.example templates/project/.gitignore templates/project/README.md templates/project/bunfig.toml templates/project/package.json templates/project/scripts templates/project/template.json templates/project/test tsconfig.json vitest.config.ts && cd templates/plugin && bunx @biomejs/biome check --write --unsafe . --config-path ./biome.json --vcs-enabled=false && cd ../project/apps/app && bunx @biomejs/biome check --write --unsafe . --config-path ./biome.json --vcs-enabled=false
+@elizaos/plugin-remote-desktop:lint: cache miss, executing 063e29b34d2993c9
+@elizaos/plugin-remote-desktop:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/gcp-examples:lint: Checked 4 files in 24ms. No fixes applied.
+@elizaos/plugin-groq:lint: cache miss, executing e73e63a65e65d67b
+@elizaos/plugin-groq:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-nearai:lint: Checked 17 files in 27ms. No fixes applied.
+@elizaos/logger:lint: cache miss, executing 7cb082d2d0dbb835
+@elizaos/logger:lint: $ find src -name '*.ts' ! -name '*.d.ts' -print0 | xargs -0 bunx @biomejs/biome check
+@elizaos/plugin-remote-desktop:lint: Checked 12 files in 31ms. No fixes applied.
+@elizaos/plugin-elizacloud:lint: cache miss, executing 695c179eb00e0f67
+@elizaos/plugin-elizacloud:lint: $ bunx @biomejs/biome check --write --unsafe .
+elizaos:lint: Checked 40 files in 78ms. No fixes applied.
+@elizaos/plugin-groq:lint: Checked 11 files in 82ms. No fixes applied.
+@elizaos/plugin-gitpathologist:lint: cache miss, executing 0ecb9d27c38394cc
+@elizaos/logger:lint: Checked 4 files in 53ms. No fixes applied.
+@elizaos/plugin-gitpathologist:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos-examples/html-eliza:lint: cache miss, executing 63d8dc25a09f1f29
+@elizaos-examples/html-eliza:lint: $ bunx @biomejs/biome check --write --unsafe .
+elizaos:lint: Checked 11 files in 38ms. No fixes applied.
+@elizaos/plugin-gitpathologist:lint: Checked 28 files in 69ms. No fixes applied.
+@elizaos/plugin-elizacloud:lint: Checked 33 files in 97ms. No fixes applied.
+@elizaos/example-app-electron-renderer:lint: cache miss, executing e00840d5037d951c
+@elizaos/plugin-blocker:lint: cache miss, executing 332bc6d97e191339
+@elizaos/example-app-electron-renderer:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-blocker:lint: $ bunx @biomejs/biome check src/
+@elizaos-examples/html-eliza:lint: Checked 3 files in 73ms. No fixes applied.
+@elizaos/plugin-ainex:lint: cache miss, executing bf595c3776e170ff
+@elizaos/plugin-ainex:lint: $ bunx @biomejs/biome check --write --unsafe .
+elizaos:lint: Checked 63 files in 62ms. No fixes applied.
+@elizaos/plugin-app-control:lint: cache miss, executing 491eb564ecf0b3fa
+@elizaos/plugin-app-control:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-app-electron-renderer:lint: Checked 11 files in 57ms. No fixes applied.
+@elizaos/example-game-of-life:lint: cache miss, executing 7aacd9de76278735
+@elizaos/example-game-of-life:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-blocker:lint: Checked 27 files in 75ms. No fixes applied.
+@elizaos/plugin-vision:lint: cache miss, executing ce65166b0c7acfee
+@elizaos/plugin-vision:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-ainex:lint: Checked 37 files in 78ms. No fixes applied.
+@elizaos/plugin-mcp:lint: cache miss, executing 750eb0347ce46a3f
+@elizaos/plugin-mcp:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/agent:lint: Checked 616 files in 581ms. No fixes applied.
+@elizaos/plugin-streaming:lint: cache miss, executing 63653ac35f5afea6
+@elizaos/plugin-streaming:lint: $ bunx @biomejs/biome check --write --unsafe src
+@elizaos/plugin-app-control:lint: Checked 93 files in 107ms. No fixes applied.
+@elizaos/example-game-of-life:lint: Checked 3 files in 87ms. No fixes applied.
+@elizaos/plugin-messages:lint: cache miss, executing 2cfccd929d1c25d0
+@elizaos/plugin-bluebubbles:lint: cache miss, executing e5e81b38fe898dc2
+@elizaos/plugin-messages:lint: $ bunx @biomejs/biome check src
+@elizaos/plugin-bluebubbles:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-mcp:lint: Checked 45 files in 75ms. No fixes applied.
+@elizaos/plugin-cloud-apps:lint: cache miss, executing 1300678911cdbdd5
+@elizaos/plugin-cloud-apps:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-wallet:build: 🎉 @elizaos/plugin-wallet build finished in 5.59s
+@elizaos/plugin-tunnel:lint: cache miss, executing 3e30fde644fc4def
+@elizaos/plugin-streaming:lint: Checked 12 files in 38ms. No fixes applied.
+eliza-next-example:lint: cache miss, executing ab529cc1b0193ddb
+@elizaos/plugin-tunnel:lint: $ bunx @biomejs/biome check --write --unsafe .
+eliza-next-example:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-vision:lint: Checked 104 files in 199ms. No fixes applied.
+@elizaos/plugin-contacts:lint: cache miss, executing 97c13af71db8af05
+@elizaos/plugin-messages:lint: Checked 15 files in 31ms. No fixes applied.
+@elizaos/plugin-contacts:lint: $ bunx @biomejs/biome check src/
+@elizaos/example-lp-manager:lint: cache miss, executing 4bbe19940c258738
+@elizaos/example-lp-manager:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-local-inference:build: ✅ Build complete in 4.04s
+@elizaos/plugin-bluebubbles:lint: Checked 20 files in 45ms. No fixes applied.
+@elizaos/plugin-ollama:lint: cache miss, executing bba7a4e08dd7496f
+@elizaos/example-app-capacitor:lint: cache miss, executing 6836a4af03b37dfa
+@elizaos/plugin-cloud-apps:lint: Checked 36 files in 51ms. No fixes applied.
+@elizaos/plugin-ollama:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-app-capacitor:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-zai:lint: cache miss, executing 1a0bad2014f4d8ce
+@elizaos/plugin-tunnel:lint: Checked 11 files in 32ms. No fixes applied.
+@elizaos/plugin-zai:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-ngrok:lint: cache miss, executing ceeae104119a80a5
+@elizaos/plugin-ngrok:lint: $ bunx @biomejs/biome check --write --unsafe .
+eliza-next-example:lint: Checked 18 files in 23ms. No fixes applied.
+@elizaos/plugin-imessage:lint: cache miss, executing b9087f8a5ed33c1c
+@elizaos/plugin-contacts:lint: Checked 19 files in 41ms. No fixes applied.
+@elizaos/plugin-imessage:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-inmemorydb:lint: cache miss, executing 797ba293bb82b801
+@elizaos/plugin-inmemorydb:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-lp-manager:lint: Checked 8 files in 46ms. No fixes applied.
+@elizaos/plugin-workflow:lint: cache miss, executing a225cecdc7bd2688
+@elizaos/plugin-ollama:lint: Checked 28 files in 35ms. No fixes applied.
+@elizaos/plugin-workflow:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-app-capacitor:lint: Checked 20 files in 37ms. No fixes applied.
+@elizaos/plugin-zai:lint: Checked 18 files in 28ms. No fixes applied.
+@elizaos/container-control-plane:lint: cache miss, executing ad80bdebec05e9e2
+@elizaos/plugin-native-settings:lint: cache miss, executing 8820eebb9994a795
+@elizaos/plugin-wifi:lint: cache miss, executing ce2e90b7b1990b39
+@elizaos/container-control-plane:lint: $ bunx @biomejs/biome check .
+@elizaos/plugin-native-settings:lint: $ bunx @biomejs/biome check src
+@elizaos/plugin-wifi:lint: $ bunx @biomejs/biome check src
+@elizaos/plugin-ngrok:lint: Checked 13 files in 35ms. No fixes applied.
+@elizaos/plugin-discord-local:lint: cache miss, executing 57a76600faabbf29
+@elizaos/plugin-discord-local:lint: $ bunx @biomejs/biome check --write --config-path ./biome.json .
+@elizaos/plugin-imessage:lint: Checked 22 files in 52ms. No fixes applied.
+@elizaos/example-browser-extension-chrome:lint: cache miss, executing d2815ac7fe41109e
+@elizaos/container-control-plane:lint: Checked 3 files in 51ms. No fixes applied.
+@elizaos/plugin-wifi:lint: Checked 12 files in 63ms. No fixes applied.
+@elizaos/example-browser-extension-chrome:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-x402:lint: cache miss, executing 20008334b475136c
+@elizaos/plugin-native-settings:lint: Checked 10 files in 65ms. No fixes applied.
+@elizaos/plugin-inmemorydb:lint: Checked 17 files in 101ms. No fixes applied.
+@elizaos/plugin-x402:lint: $ bun run typecheck
+@elizaos/plugin-wallet:lint: cache miss, executing 7c3836579810b32a
+@elizaos/plugin-google-genai:lint: cache miss, executing fa78c49cecc1abfd
+@elizaos/plugin-tee:lint: cache miss, executing de5cdcd1eda0ad69
+@elizaos/plugin-discord-local:lint: Checked 7 files in 65ms. No fixes applied.
+@elizaos/plugin-wallet:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-x402:lint: $ tsgo --noEmit
+@elizaos/plugin-google-genai:lint: $ bunx @biomejs/biome check --write --unsafe build.ts index.ts index.browser.ts index.node.ts init.ts __tests__ generated models types utils
+@elizaos/plugin-tee:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-mcp-server:lint: cache miss, executing 1492707443e2f858
+@elizaos/example-mcp-server:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-workflow:lint: Checked 97 files in 141ms. No fixes applied.
+@elizaos/os-usb-installer:lint: cache miss, executing 4985df075153072a
+@elizaos/os-usb-installer:lint: $ bunx @biomejs/biome check src tests server.ts vite.config.ts vitest.config.ts playwright.config.ts
+@elizaos/example-mcp-server:lint: Checked 4 files in 33ms. No fixes applied.
+@elizaos/example-browser-extension-chrome:lint: Checked 17 files in 71ms. No fixes applied.
+elizagotchi:lint: cache miss, executing 834d1714c9688c02
+@elizaos/example-clone-ur-crush:lint: cache miss, executing 986440efe6a17570
+elizagotchi:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-clone-ur-crush:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-google-genai:lint: Checked 21 files in 83ms. No fixes applied.
+@elizaos/plugin-tee:lint: Checked 22 files in 84ms. No fixes applied.
+@elizaos/agent-server:lint: cache miss, executing f27f24ff05f12c17
+@elizaos/agent-server:lint: $ bunx @biomejs/biome check .
+@elizaos/plugin-feishu:lint: cache miss, executing efe5086e6df69fa1
+@elizaos/plugin-feishu:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/os-usb-installer:lint: Checked 33 files in 78ms. No fixes applied.
+@moltbook/eliza-agent:lint: cache miss, executing 617c6711e2b7369a
+@moltbook/eliza-agent:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/agent-server:lint: Checked 13 files in 45ms. No fixes applied.
+@elizaos/plugin-feishu:lint: Checked 20 files in 58ms. No fixes applied.
+@elizaos/plugin-embeddings:lint: cache miss, executing 259c97cddb6d2307
+@elizaos/setup:lint: cache miss, executing 9fb9698b08bafc4a
+@elizaos/plugin-embeddings:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/setup:lint: $ bunx @biomejs/biome check src vite.config.ts vitest.config.ts
+elizagotchi:lint: Checked 18 files in 84ms. No fixes applied.
+@elizaos/example-clone-ur-crush:lint: Checked 22 files in 90ms. No fixes applied.
+@elizaos/plugin-sql:lint: cache miss, executing d45edbe259fecfeb
+@elizaos/plugin-sql:lint: $ cd src && bun run lint
+@elizaos/plugin-slack:lint: cache miss, executing ad8d6f7663918f25
+@elizaos/plugin-slack:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-sql:lint: $ bunx @biomejs/biome check --write --config-path ./biome.json .
+@elizaos/plugin-wallet:lint: Checked 224 files in 323ms. No fixes applied.
+@moltbook/eliza-agent:lint: Checked 9 files in 24ms. No fixes applied.
+@elizaos/prompts:lint: cache miss, executing 99d8f99181e7dab4
+@elizaos/operator:lint: cache miss, executing 5ba7c59906aa7546
+@elizaos/example-telegram:lint: cache miss, executing e30e2d3a976c5199
+@elizaos/prompts:lint: $ bunx @biomejs/biome check --write .
+@elizaos/operator:lint: $ bunx @biomejs/biome check .
+@elizaos/example-telegram:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-embeddings:lint: Checked 20 files in 20ms. No fixes applied.
+@elizaos/plugin-x:lint: cache miss, executing dc48c1ddb83cff25
+@elizaos/plugin-x:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/setup:lint: Checked 28 files in 58ms. No fixes applied.
+@elizaos/plugin-instagram:lint: cache miss, executing ce9adec4a6db7a60
+@elizaos/plugin-instagram:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/prompts:lint: Checked 12 files in 56ms. No fixes applied.
+@elizaos/example-telegram:lint: Checked 5 files in 33ms. No fixes applied.
+@elizaos/operator:lint: Checked 14 files in 27ms. No fixes applied.
+@elizaos/plugin-slack:lint: Checked 21 files in 160ms. No fixes applied.
+@elizaos/robot:lint: cache miss, executing 961aba810f845e65
+@elizaos/example-discord:lint: cache miss, executing 7dcd2ea2aa57afab
+@elizaos/plugin-benchmarks:lint: cache miss, executing 6dab7b919eefd138
+@elizaos/plugin-trajectory-logger:lint: cache miss, executing 1754d4d3723904ed
+@elizaos/example-discord:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-instagram:lint: Checked 21 files in 36ms. No fixes applied.
+@elizaos/robot:lint: $ bunx @biomejs/biome check --write ./src
+@elizaos/plugin-benchmarks:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-trajectory-logger:lint: $ bunx @biomejs/biome check src
+@elizaos/plugin-codex-cli:lint: cache miss, executing b40b3e6fb6e43f13
+@elizaos/plugin-codex-cli:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-x:lint: Checked 73 files in 103ms. No fixes applied.
+@elizaos/plugin-nostr:lint: cache miss, executing 8275628c25e214c2
+@elizaos/plugin-nostr:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-sql:lint: Checked 180 files in 269ms. No fixes applied.
+@elizaos/robot:lint: Checked 2 files in 14ms. No fixes applied.
+@elizaos/plugin-benchmarks:lint: Checked 14 files in 16ms. No fixes applied.
+@elizaos/example-discord:lint: Checked 5 files in 20ms. No fixes applied.
+@elizaos/three-agent-dialogue:lint: cache miss, executing 0a2ba0c5a94b8357
+@elizaos/cloud-shared:lint: cache miss, executing e3b999b0eb6af7b7
+@elizaos/plugin-capacitor-bridge:lint: cache miss, executing 26b28f22af695f40
+@elizaos/plugin-capacitor-bridge:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/three-agent-dialogue:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/cloud-shared:lint: $ bunx @biomejs/biome check .
+trajectory-viewer:lint: cache miss, executing df7f8e14f150eb8f
+@elizaos/plugin-trajectory-logger:lint: Checked 18 files in 28ms. No fixes applied.
+trajectory-viewer:lint: $ bunx @biomejs/biome check --write --unsafe src package.json --vcs-enabled=false
+@elizaos/plugin-agent-orchestrator:lint: cache miss, executing e291f82d5e433b91
+@elizaos/plugin-codex-cli:lint: Checked 5 files in 27ms. No fixes applied.
+@elizaos/plugin-agent-orchestrator:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/aws-examples:lint: cache miss, executing 3ffe168ffc34f551
+@elizaos/aws-examples:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-nostr:lint: Checked 17 files in 34ms. No fixes applied.
+@elizaos/plugin-sub-agent-claude-code:lint: cache miss, executing 77d54f6b95fc2057
+trajectory-viewer:lint: Checked 12 files in 24ms. No fixes applied.
+@elizaos/plugin-sub-agent-claude-code:lint: $ bunx @biomejs/biome check src
+@elizaos/gateway-webhook:lint: cache miss, executing 7f73c1d90a671b52
+@elizaos/gateway-webhook:lint: $ bunx @biomejs/biome check .
+@elizaos/three-agent-dialogue:lint: Checked 13 files in 47ms. No fixes applied.
+@elizaos/gateway-discord:lint: cache miss, executing 934853e37fdfc94b
+@elizaos/aws-examples:lint: Checked 8 files in 47ms. No fixes applied.
+@elizaos/gateway-discord:lint: $ bunx @biomejs/biome check .
+@elizaos/os-homepage:lint: cache miss, executing 93f3f199ab9f509d
+@elizaos/os-homepage:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-capacitor-bridge:lint: Checked 24 files in 126ms. No fixes applied.
+@elizaos/example-convex:lint: cache miss, executing a445c257613f54dd
+@elizaos/example-convex:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-sub-agent-claude-code:lint: Checked 5 files in 86ms. No fixes applied.
+@elizaos/plugin-local-inference:lint: cache miss, executing e59ccfac9b424ecb
+@elizaos/plugin-local-inference:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/gateway-webhook:lint: Checked 24 files in 122ms. No fixes applied.
+@elizaos/plugin-remote-manifest:lint: cache miss, executing 59fcb938babe52dc
+@elizaos/plugin-remote-manifest:lint: $ bunx @biomejs/biome check src
+@elizaos/gateway-discord:lint: Checked 13 files in 77ms. No fixes applied.
+eliza-multichain-miniapp:lint: cache miss, executing 6fb9e8cb6db3dc4d
+eliza-multichain-miniapp:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/os-homepage:lint: Checked 36 files in 121ms. No fixes applied.
+@elizaos/app:lint: cache miss, executing 79f018b92d08380d
+@elizaos/app:lint: $ bunx @biomejs/biome check src scripts vite.config.ts vitest.config.ts vitest.e2e.config.ts playwright.dev-smoke.config.ts playwright.ui-smoke.config.ts playwright.ui-packaged.config.ts playwright.electrobun.packaged.config.ts playwright.web-views.config.ts playwright.android.config.ts test/android package.json capacitor.config.ts
+@elizaos/example-convex:lint: Checked 11 files in 45ms. No fixes applied.
+@elizaos/skills:lint: cache miss, executing 77e0d08e764ec26a
+@elizaos/skills:lint: $ bunx @biomejs/biome check --write ./src
+@elizaos/plugin-remote-manifest:lint: Checked 47 files in 134ms. No fixes applied.
+@elizaos/example-app-capacitor-backend:lint: cache miss, executing 843dda57c937b44e
+@elizaos/example-app-capacitor-backend:lint: $ bunx @biomejs/biome check --write --unsafe .
+eliza-multichain-miniapp:lint: Checked 17 files in 152ms. No fixes applied.
+@elizaos/example-xai-x:lint: cache miss, executing dfeba08678a81ec6
+@elizaos/example-xai-x:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/skills:lint: Checked 6 files in 113ms. No fixes applied.
+@elizaos/plugin-scheduling:lint: cache miss, executing df8bd2a93fd09177
+@elizaos/plugin-scheduling:lint: $ bunx @biomejs/biome check src/
+@elizaos/cloud-shared:lint: Checked 1239 files in 906ms. No fixes applied.
+@elizaos/example-app-capacitor-backend:lint: Checked 6 files in 47ms. No fixes applied.
+@elizaos/app:lint: Checked 121 files in 285ms. No fixes applied.
+@elizaos/plugin-openai:lint: cache miss, executing a9a7c512b948400a
+@elizaos/example-smartglasses:lint: cache miss, executing 26b361b8e9d3be91
+@elizaos/plugin-openai:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-farcaster:lint: cache miss, executing 5e40c2a0324e53d0
+@elizaos/plugin-agent-orchestrator:lint: Checked 242 files in 924ms. No fixes applied.
+@elizaos/example-smartglasses:lint: $ bunx @biomejs/biome check .
+@elizaos/example-farcaster:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-rest-api-hono:lint: cache miss, executing 0e22267a15e70c3c
+@elizaos/example-xai-x:lint: Checked 5 files in 54ms. No fixes applied.
+@elizaos/plugin-pdf:lint: cache miss, executing 42d145cae7105677
+@elizaos/example-rest-api-hono:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-pdf:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-local-inference:lint: Checked 424 files in 633ms. No fixes applied.
+@elizaos/cloud-routing:lint: cache miss, executing 4d8403d6bd0ed408
+@elizaos/plugin-scheduling:lint: Checked 31 files in 69ms. No fixes applied.
+@elizaos/cloud-routing:lint: $ bunx @biomejs/biome check src
+@elizaos/plugin-web-search:lint: cache miss, executing 91178ca5f7ef5219
+@elizaos/plugin-openai:lint: models/text.ts:1015:3 suppressions/unused ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+@elizaos/plugin-openai:lint:
+@elizaos/plugin-openai:lint:   ! Suppression comment has no effect. Remove the suppression or make sure you are suppressing the correct rule.
+@elizaos/plugin-openai:lint:
+@elizaos/plugin-openai:lint:     1013 │ ): Promise<Awaited<ReturnType<typeof generateText<ToolSet>>>> {
+@elizaos/plugin-openai:lint:     1014 │   let attempt = 0;
+@elizaos/plugin-web-search:lint: $ bunx @biomejs/biome check src/
+@elizaos/plugin-openai:lint: Checked 35 files in 61ms. No fixes applied.
+@elizaos/plugin-openai:lint: Found 1 warning.
+@elizaos/plugin-openai:lint:   > 1015 │   // biome-ignore lint/suspicious/noExplicitAny: AI SDK's generateText overloads can't infer our NativeGenerateTextParams across the generic boundary.
+@elizaos/plugin-openai:lint:          │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+@elizaos/plugin-openai:lint:     1016 │   for (;;) {
+@elizaos/plugin-openai:lint:     1017 │     try {
+@elizaos/plugin-openai:lint:
+@elizaos/plugin-openai:lint:
+@elizaos/example-farcaster:lint: Checked 5 files in 17ms. No fixes applied.
+@elizaos/example-rest-api-hono:lint: Checked 4 files in 18ms. No fixes applied.
+@elizaos/example-form:lint: cache miss, executing a1d4857d8b526bd8
+@elizaos/ui:lint: cache miss, executing 39a1fb2498b814bb
+@elizaos/plugin-bluesky:lint: cache miss, executing 0dd7130911f88ec1
+@elizaos/example-form:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-pdf:lint: Checked 8 files in 25ms. No fixes applied.
+@elizaos/ui:lint: $ bunx @biomejs/biome check src
+@elizaos/plugin-bluesky:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-localdb:lint: cache miss, executing 1a86ec5fc8c9a93d
+@elizaos/example-smartglasses:lint: Checked 23 files in 37ms. No fixes applied.
+@elizaos/plugin-localdb:lint: $ bunx @biomejs/biome check --write --unsafe .
+bags-claimer:lint: cache miss, executing 1c4add0d1b81bd20
+bags-claimer:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/cloud-routing:lint: Checked 5 files in 16ms. No fixes applied.
+@elizaos/example-a2a-server:lint: cache miss, executing 015e1871bc333a8b
+@elizaos/example-a2a-server:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-web-search:lint: Checked 6 files in 25ms. No fixes applied.
+@elizaos/example-form:lint: Checked 1 file in 19ms. No fixes applied.
+@elizaos/plugin-inbox:lint: cache miss, executing 7640694935222527
+@elizaos/plugin-inbox:lint: $ bunx @biomejs/biome check src/
+@elizaos/plugin-starter:lint: cache miss, executing bad0425d99b79404
+@elizaos/plugin-starter:lint: $ bunx @biomejs/biome check --write --unsafe ./src
+@elizaos/plugin-bluesky:lint: Checked 20 files in 47ms. No fixes applied.
+@elizaos/plugin-localdb:lint: Checked 9 files in 52ms. No fixes applied.
+@elizaos/plugin-finances:lint: cache miss, executing 16bff810ae228e92
+@elizaos/plugin-social-alpha:lint: cache miss, executing f75660f518ad4691
+@elizaos/plugin-finances:lint: $ bunx @biomejs/biome check src/
+bags-claimer:lint: Checked 3 files in 83ms. No fixes applied.
+@elizaos/plugin-social-alpha:lint: $ bunx @biomejs/biome check src
+@elizaos/plugin-cli:lint: cache miss, executing bc26e55773dc4a91
+@elizaos/plugin-cli:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-starter:lint: Checked 9 files in 31ms. No fixes applied.
+eliza-app:lint: cache miss, executing a8066d2642c824ec
+eliza-app:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-a2a-server:lint: Checked 5 files in 77ms. No fixes applied.
+eliza-react-example:lint: cache miss, executing ace44cde6eff5015
+eliza-react-example:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-inbox:lint: Checked 34 files in 127ms. No fixes applied.
+@elizaos/plugin-background-runner:lint: cache miss, executing bdd716a2f1d43cd4
+@elizaos/plugin-finances:lint: Checked 34 files in 111ms. No fixes applied.
+@elizaos/plugin-cli:lint: Checked 8 files in 47ms. No fixes applied.
+@elizaos/plugin-background-runner:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/app-model-tester:lint: cache miss, executing bdd25c7ed04bd6a2
+@elizaos/plugin-social-alpha:lint: Checked 33 files in 123ms. No fixes applied.
+@elizaos/plugin-xai:lint: cache miss, executing 07675819d2d7597e
+@elizaos/app-model-tester:lint: $ bunx @biomejs/biome check src
+@elizaos/plugin-xai:lint: $ bunx @biomejs/biome check .
+@elizaos/plugin-todos:lint: cache miss, executing 57c0197d088247a9
+@elizaos/plugin-todos:lint: $ bunx @biomejs/biome check --write --unsafe .
+eliza-react-example:lint: Checked 15 files in 79ms. No fixes applied.
+@elizaos/example-trader-ts:lint: cache miss, executing e0ac7debcb817689
+@elizaos/example-trader-ts:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-background-runner:lint: Checked 8 files in 91ms. No fixes applied.
+@elizaos/plugin-phone:lint: cache miss, executing d8b205d4c3cbd9ce
+eliza-app:lint: Checked 64 files in 145ms. No fixes applied.
+@elizaos/plugin-phone:lint: $ bunx @biomejs/biome check src
+@elizaos/plugin-google-chat:lint: cache miss, executing 59aedc3ba6a11502
+@elizaos/plugin-google-chat:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/app-model-tester:lint: Checked 19 files in 89ms. No fixes applied.
+elizaos-cloudflare-worker:lint: cache miss, executing 16094fa5b094d3d4
+@elizaos/plugin-todos:lint: Checked 24 files in 127ms. No fixes applied.
+elizaos-cloudflare-worker:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-xai:lint: Checked 14 files in 138ms. No fixes applied.
+@elizaos/plugin-aosp-local-inference:lint: cache miss, executing 3d8c28dc3ffafa16
+@elizaos/plugin-aosp-local-inference:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-app-capacitor-frontend:lint: cache miss, executing fc30ebbb8d7d9b11
+@elizaos/example-app-capacitor-frontend:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-trader-ts:lint: Checked 18 files in 54ms. No fixes applied.
+@elizaos/example-browser-extension:lint: cache miss, executing c20384f9d52d4415
+@elizaos/example-browser-extension:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-google-chat:lint: Checked 13 files in 102ms. No fixes applied.
+elizaos-cloudflare-worker:lint: Checked 4 files in 50ms. No fixes applied.
+@elizaos/plugin-agent-skills:lint: cache miss, executing 05a5c966a0c6a21a
+@elizaos/plugin-agent-skills:lint: $ bunx @biomejs/biome check --write --unsafe --config-path ./biome.json .
+@elizaos/plugin-phone:lint: Checked 40 files in 136ms. No fixes applied.
+@elizaos/plugin-relationships:lint: cache miss, executing 8dcf4555ad98dbd8
+@elizaos/vercel-edge-examples:lint: cache miss, executing 77c5fab174722da7
+@elizaos/example-app-capacitor-frontend:lint: Checked 11 files in 55ms. No fixes applied.
+@elizaos/plugin-relationships:lint: $ bunx @biomejs/biome check src/
+@elizaos/vercel-edge-examples:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-aosp-local-inference:lint: Checked 12 files in 92ms. No fixes applied.
+@elizaos/capacitor-gateway:lint: cache miss, executing d3f00c73fbb630b7
+@elizaos/example-autonomous:lint: cache miss, executing f25b7e9618650c7b
+@elizaos/example-autonomous:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/capacitor-gateway:lint: $ bunx @biomejs/biome check . && bash -c 'if command -v swiftlint >/dev/null 2>&1; then bun run swiftlint -- lint; fi'
+@elizaos/plugin-agent-skills:lint: Checked 39 files in 94ms. No fixes applied.
+@elizaos/example-browser-extension:lint: Checked 26 files in 103ms. No fixes applied.
+@elizaos/plugin-reminders:lint: cache miss, executing e3b5d5bd40edd402
+@elizaos/vercel-edge-examples:lint: Checked 6 files in 58ms. No fixes applied.
+@elizaos/plugin-reminders:lint: $ bunx @biomejs/biome check src/
+@elizaos/plugin-google:lint: cache miss, executing a2b117eda4d8a345
+@elizaos/plugin-whatsapp:lint: cache miss, executing 73170e928112b044
+@elizaos/plugin-relationships:lint: Checked 15 files in 83ms. No fixes applied.
+@elizaos/plugin-google:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-whatsapp:lint: $ bunx @biomejs/biome check --write --config-path ./biome.json .
+@elizaos/plugin-suno:lint: cache miss, executing e83cdd592d498d91
+@elizaos/plugin-suno:lint: $ bunx @biomejs/biome check .
+@elizaos/example-autonomous:lint: Checked 6 files in 63ms. No fixes applied.
+@elizaos/capacitor-gateway:lint: Checked 7 files in 68ms. No fixes applied.
+@elizaos/plugin-telegram:lint: cache miss, executing 8fae697e39b3a4ed
+@elizaos/plugin-telegram:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-chat:lint: cache miss, executing 1770e8caed5bda96
+@elizaos/example-chat:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-suno:lint: Checked 13 files in 32ms. No fixes applied.
+@elizaos/plugin-google:lint: Checked 18 files in 72ms. No fixes applied.
+@elizaos/plugin-whatsapp:lint: Checked 32 files in 84ms. No fixes applied.
+@elizaos/plugin-commands:lint: cache miss, executing eaccdaf0446ceef9
+@elizaos/cloud-services-common:lint: cache miss, executing 95b010fc5938e410
+@elizaos/plugin-commands:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-local-storage:lint: cache miss, executing 212ca00323c0cb4d
+@elizaos/cloud-services-common:lint: $ bunx @biomejs/biome check .
+@elizaos/plugin-local-storage:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-reminders:lint: Checked 6 files in 103ms. No fixes applied.
+@elizaos/example-app-electron:lint: cache miss, executing 189e961cd53567ef
+@elizaos/example-app-electron:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-chat:lint: Checked 4 files in 38ms. No fixes applied.
+@elizaos/plugin-anthropic:lint: cache miss, executing f701fc09d6864c64
+@elizaos/plugin-anthropic:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/cloud-services-common:lint: Checked 5 files in 37ms. No fixes applied.
+@elizaos/plugin-shell:lint: cache miss, executing 6fb9a03c61a1e7f5
+@elizaos/plugin-local-storage:lint: Checked 8 files in 59ms. No fixes applied.
+@elizaos/plugin-shell:lint: $ bunx @biomejs/biome check .
+@elizaos/example-app-electron-workspace:lint: cache miss, executing c9669c3e98d438a1
+@elizaos/plugin-telegram:lint: Checked 40 files in 143ms. No fixes applied.
+@elizaos/plugin-commands:lint: Checked 29 files in 29ms. No fixes applied.
+@elizaos/ui:lint: Checked 2204 files in 1306ms. No fixes applied.
+@elizaos/example-app-electron-workspace:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/capacitor-mobile-agent-bridge:lint: cache miss, executing 5e0df6642bed82e4
+@elizaos/plugin-health:lint: cache miss, executing b2f1ec452915767f
+@elizaos/capacitor-mobile-agent-bridge:lint: $ bunx @biomejs/biome check .
+@elizaos/example-app-electron:lint: Checked 9 files in 35ms. No fixes applied.
+@elizaos/plugin-health:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-matrix:lint: cache miss, executing 935733796778bc06
+@elizaos/plugin-facewear:lint: cache miss, executing 3152eea8c44734f0
+@elizaos/plugin-matrix:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-facewear:lint: $ bunx @biomejs/biome check src
+@elizaos/plugin-anthropic:lint: Checked 22 files in 34ms. No fixes applied.
+@elizaos/plugin-xr:lint: cache miss, executing 31ec00bb9d665922
+@elizaos/plugin-xr:lint: $ bunx @biomejs/biome check src
+@elizaos/plugin-shell:lint: Checked 37 files in 28ms. No fixes applied.
+@elizaos/capacitor-mobile-agent-bridge:lint: Checked 4 files in 33ms. No fixes applied.
+@elizaos/electrobun:lint: cache miss, executing 09b485eab615c9ea
+@elizaos/plugin-discord:lint: cache miss, executing aa9c075f6cf8b174
+@elizaos/electrobun:lint: $ bunx @biomejs/biome check $(find src -type f \( -name '*.ts' -o -name '*.tsx' \) ! -name '*.d.ts' -print)
+@elizaos/plugin-discord:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-app-electron-workspace:lint: Checked 22 files in 63ms. No fixes applied.
+@elizaos/example-tic-tac-toe:lint: cache miss, executing e62f7b5b13300db8
+@elizaos/example-tic-tac-toe:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-matrix:lint: Checked 20 files in 97ms. No fixes applied.
+@elizaos/example-browser-extension-safari:lint: cache miss, executing 5dfd969e67bf3106
+@elizaos/example-browser-extension-safari:lint: $ node scripts/fix-generated-safari.mjs && bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-xr:lint: Checked 22 files in 27ms. No fixes applied.
+@elizaos/plugin-facewear:lint: Checked 83 files in 153ms. No fixes applied.
+@elizaos/plugin-health:lint: Checked 113 files in 168ms. No fixes applied.
+@elizaos/shared:lint: cache miss, executing 75ed73cdba29576f
+elizaos-plugin-echo:lint: cache miss, executing 5615d9e47171672d
+@elizaos/plugin-lmstudio:lint: cache miss, executing f6687a87d498ab45
+@elizaos/shared:lint: $ bunx @biomejs/biome check src
+elizaos-plugin-echo:lint: $ bunx @biomejs/biome check src
+@elizaos/plugin-lmstudio:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-tic-tac-toe:lint: Checked 3 files in 49ms. No fixes applied.
+@elizaos/plugin-cli-inference:lint: cache miss, executing 40e415b12de8d49c
+@elizaos/plugin-cli-inference:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-browser-extension-safari:lint: Checked 5 files in 25ms. No fixes applied.
+@elizaos/plugin-lmstudio:lint: Checked 25 files in 30ms. No fixes applied.
+elizaos-plugin-echo:lint: Checked 3 files in 29ms. No fixes applied.
+@elizaos/cloud-sdk:lint: cache miss, executing 0555db7246f91aa2
+@elizaos/cloud-sdk:lint: $ bunx @biomejs/biome check .
+@elizaos/plugin-signal:lint: cache miss, executing 74a58865cc9670ef
+@elizaos/example-rest-api-elysia:lint: cache miss, executing 3bcfcfb63f258541
+@elizaos/plugin-signal:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-rest-api-elysia:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-cli-inference:lint: Checked 15 files in 29ms. No fixes applied.
+@elizaos/electrobun:lint: Checked 190 files in 174ms. No fixes applied.
+@elizaos/plugin-native-filesystem:lint: cache miss, executing b8d030632b9e2611
+@elizaos/plugin-native-filesystem:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/example-rest-api-express:lint: cache miss, executing dd9dd46074316635
+@elizaos/example-rest-api-express:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-discord:lint: Checked 87 files in 200ms. No fixes applied.
+@elizaos/cloud-api:lint: cache miss, executing 705a1a36d13fdf32
+@elizaos/cloud-api:lint: $ bunx @biomejs/biome check .
+@elizaos/example-rest-api-elysia:lint: Checked 4 files in 27ms. No fixes applied.
+@elizaos/example-bluesky:lint: cache miss, executing 234b085cdcf811cc
+@elizaos/example-bluesky:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-native-filesystem:lint: Checked 13 files in 25ms. No fixes applied.
+@elizaos/example-rest-api-express:lint: Checked 4 files in 19ms. No fixes applied.
+@elizaos/app-core:lint: cache miss, executing 1704daabe4a289cc
+@elizaos/plugin-worker-runtime:lint: cache miss, executing a005fecb78e25c94
+@elizaos/plugin-worker-runtime:lint: $ bunx @biomejs/biome check src
+@elizaos/app-core:lint: $ bunx @biomejs/biome check src
+@elizaos/plugin-signal:lint: Checked 23 files in 109ms. No fixes applied.
+@elizaos/registry:lint: cache miss, executing e81ce34e43659038
+@elizaos/registry:lint: $ bunx @biomejs/biome check src
+@elizaos/cloud-sdk:lint: Checked 29 files in 164ms. No fixes applied.
+@elizaos/plugin-edge-tts:lint: cache miss, executing 19bfad10c7613602
+@elizaos/plugin-worker-runtime:lint: Checked 7 files in 37ms. No fixes applied.
+@elizaos/example-bluesky:lint: Checked 6 files in 72ms. No fixes applied.
+@elizaos/plugin-edge-tts:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-elevenlabs:lint: cache miss, executing f5fc328442519af5
+@elizaos/plugin-openrouter:lint: cache miss, executing 1c24e6a5599f2e30
+@elizaos/plugin-elevenlabs:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-openrouter:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/shared:lint: Checked 293 files in 367ms. No fixes applied.
+@elizaos/bench-eliza-1:lint: cache miss, executing 6d3577e60d1e07e2
+@elizaos/bench-eliza-1:lint: $ bunx @biomejs/biome check .
+@elizaos/registry:lint: Checked 57 files in 129ms. No fixes applied.
+@elizaos/plugin-elevenlabs:lint: Checked 9 files in 69ms. No fixes applied.
+@elizaos/plugin-edge-tts:lint: Checked 10 files in 75ms. No fixes applied.
+@elizaos/plugin-farcaster:lint: cache miss, executing de6775dfc477fba6
+@elizaos/plugin-farcaster:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/core:lint: cache miss, executing 5522b8a947ec47da
+@elizaos/core:lint: $ bunx @biomejs/biome check --write ./src
+@elizaos/plugin-twitch:lint: cache miss, executing ff13059be3b49871
+@elizaos/plugin-openrouter:lint: Checked 30 files in 136ms. No fixes applied.
+@elizaos/plugin-twitch:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/plugin-goals:lint: cache miss, executing 0d0d7c0bb871bd73
+@elizaos/plugin-goals:lint: $ bunx @biomejs/biome check src/
+@elizaos/bench-eliza-1:lint: Checked 42 files in 87ms. No fixes applied.
+@elizaos/plugin-tailscale:lint: cache miss, executing 0eee6494ec138e1e
+@elizaos/plugin-tailscale:lint: $ bunx @biomejs/biome check --write --unsafe .
+@elizaos/app-core:lint: Checked 301 files in 341ms. No fixes applied.
+@elizaos/plugin-farcaster:lint: Checked 39 files in 96ms. No fixes applied.
+@elizaos/example-trader-ts:typecheck: cache miss, executing 4ea423e871e84001
+@elizaos/plugin-twitch:lint: Checked 12 files in 80ms. No fixes applied.
+@elizaos/example-trader-ts:typecheck: $ tsgo --noEmit
+@elizaos/plugin-goals:lint: Checked 24 files in 121ms. No fixes applied.
+@elizaos/cloud-api:lint: Checked 740 files in 659ms. No fixes applied.
+@elizaos/plugin-tailscale:lint: Checked 19 files in 180ms. No fixes applied.
+@elizaos/core:lint: Checked 912 files in 1016ms. No fixes applied.
+@elizaos/ui:build: [rewrite-dist-relative-imports] rewrote 1618 file(s)
+@elizaos/ui:build: [verify-package-runtime-exports] verified 40 runtime export(s) for @elizaos/ui
+@elizaos/plugin-task-coordinator:build: cache miss, executing e04d91ea6297eab0
+@elizaos/plugin-health:build: cache miss, executing 39274100e14331b7
+@elizaos/plugin-capacitor-bridge:typecheck: cache miss, executing c58940051780ea0d
+@elizaos/plugin-app-control:build: cache miss, executing ebbb6e643c3142b4
+@elizaos/plugin-phone:build: cache miss, executing d6aeea114dccd269
+@elizaos/plugin-contacts:build: cache miss, executing 823694187e0a1d4f
+@elizaos/plugin-wifi:build: cache miss, executing e58c1eaa4cf19fff
+@elizaos/plugin-contacts:typecheck: cache miss, executing a1c72eae0360b34a
+@elizaos/plugin-task-coordinator:build: $ bun run build:js && bun run build:views && bun run build:types
+@elizaos/plugin-contacts:build: $ bun run build:js && bun run build:views && bun run build:types
+@elizaos/plugin-capacitor-bridge:typecheck: $ tsgo --noEmit
+@elizaos/plugin-health:build: $ bun run build:js && bun run build:views && bun run build:types
+@elizaos/plugin-app-control:build: $ node ../../packages/scripts/remove-source-build-artifacts.mjs src && tsup src/index.ts src/workers/app-worker-entry.ts --format esm --clean && tsc --declaration --emitDeclarationOnly --noEmit false --noCheck -p tsconfig.json && node ../../packages/scripts/flatten-tsc-package-output.mjs plugins/plugin-app-control && bun run build:views
+@elizaos/plugin-phone:build: $ bun run build:js && bun run build:views && bun run build:types
+@elizaos/plugin-wifi:build: $ bun run build:js && bun run build:types
+@elizaos/plugin-contacts:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-task-coordinator:build: $ tsup --config ../tsup.plugin-packages.shared.ts
+@elizaos/plugin-contacts:build: $ tsup --config ../tsup.plugin-packages.shared.ts
+@elizaos/plugin-health:build: $ tsup --config ../tsup.plugin-packages.shared.ts
+@elizaos/plugin-phone:build: $ tsup --config ../tsup.plugin-packages.shared.ts
+@elizaos/plugin-wifi:build: $ tsup --config ../tsup.plugin-packages.shared.ts
+@elizaos/plugin-app-control:build: CLI Building entry: src/index.ts, src/workers/app-worker-entry.ts
+@elizaos/plugin-app-control:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-app-control:build: CLI tsup v8.5.1
+@elizaos/plugin-app-control:build: CLI Target: es2022
+@elizaos/plugin-app-control:build: CLI Cleaning output folder
+@elizaos/plugin-app-control:build: ESM Build start
+@elizaos/plugin-wifi:build: CLI Building entry: src/plugin.ts, src/ui.ts, src/index.ts, src/register.ts, src/providers/networks.ts, src/components/WifiAppView.tsx, src/components/wifi-app.ts
+@elizaos/plugin-wifi:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-wifi:build: CLI tsup v8.5.1
+@elizaos/plugin-wifi:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/tsup.plugin-packages.shared.ts
+@elizaos/plugin-wifi:build: CLI Target: es2022
+@elizaos/plugin-wifi:build: ESM Build start
+@elizaos/plugin-wifi:build: ESM dist/ui.js                         252.00 B
+@elizaos/plugin-wifi:build: ESM dist/register.js                   179.00 B
+@elizaos/plugin-wifi:build: ESM dist/providers/networks.js         1.70 KB
+@elizaos/plugin-wifi:build: ESM dist/plugin.js                     650.00 B
+@elizaos/plugin-wifi:build: ESM dist/components/WifiAppView.js     13.53 KB
+@elizaos/plugin-wifi:build: ESM dist/ui.js.map                     310.00 B
+@elizaos/plugin-wifi:build: ESM dist/index.js                      505.00 B
+@elizaos/plugin-wifi:build: ESM dist/components/wifi-app.js        531.00 B
+@elizaos/plugin-wifi:build: ESM dist/register.js.map               549.00 B
+@elizaos/plugin-wifi:build: ESM dist/providers/networks.js.map     3.58 KB
+@elizaos/plugin-wifi:build: ESM dist/components/wifi-app.js.map    1.20 KB
+@elizaos/plugin-wifi:build: ESM dist/plugin.js.map                 1.16 KB
+@elizaos/plugin-wifi:build: ESM dist/components/WifiAppView.js.map 19.90 KB
+@elizaos/plugin-wifi:build: ESM dist/index.js.map                  980.00 B
+@elizaos/plugin-wifi:build: ESM ⚡️ Build success in 28ms
+@elizaos/plugin-app-control:build: ESM dist/register-terminal-view-AWQ5Y2CU.js 9.11 KB
+@elizaos/plugin-app-control:build: ESM dist/workers/app-worker-entry.js        8.72 KB
+@elizaos/plugin-app-control:build: ESM dist/index.js                           353.62 KB
+@elizaos/plugin-app-control:build: ESM ⚡️ Build success in 57ms
+@elizaos/plugin-wifi:build: $ tsc --noCheck -p tsconfig.build.json
+@elizaos/plugin-contacts:build: CLI Building entry: src/plugin.ts, src/register-terminal-view.tsx, src/ui.ts, src/index.ts, src/register.ts, src/providers/contacts.ts, src/components/ContactsView.tsx, src/components/ContactsSpatialView.tsx, src/components/contacts-view-bundle.ts, src/components/ContactsAppView.interact.ts, src/components/ContactsAppView.tsx, src/components/ContactsAppView.helpers.ts, src/components/contacts-app.ts
+@elizaos/plugin-contacts:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-contacts:build: CLI tsup v8.5.1
+@elizaos/plugin-contacts:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/tsup.plugin-packages.shared.ts
+@elizaos/plugin-contacts:build: CLI Target: es2022
+@elizaos/plugin-contacts:build: ESM Build start
+@elizaos/plugin-contacts:build: ESM dist/register-terminal-view.js                  625.00 B
+@elizaos/plugin-contacts:build: ESM dist/components/ContactsAppView.helpers.js      1.21 KB
+@elizaos/plugin-contacts:build: ESM dist/plugin.js                                  1.27 KB
+@elizaos/plugin-contacts:build: ESM dist/register.js                                341.00 B
+@elizaos/plugin-contacts:build: ESM dist/components/ContactsAppView.interact.js     2.25 KB
+@elizaos/plugin-contacts:build: ESM dist/components/ContactsSpatialView.js          7.97 KB
+@elizaos/plugin-contacts:build: ESM dist/index.js                                   536.00 B
+@elizaos/plugin-contacts:build: ESM dist/ui.js                                      369.00 B
+@elizaos/plugin-contacts:build: ESM dist/components/ContactsAppView.js              24.09 KB
+@elizaos/plugin-contacts:build: ESM dist/components/ContactsView.js                 4.65 KB
+@elizaos/plugin-contacts:build: ESM dist/components/contacts-app.js                 583.00 B
+@elizaos/plugin-contacts:build: ESM dist/providers/contacts.js                      1.90 KB
+@elizaos/plugin-contacts:build: ESM dist/components/contacts-view-bundle.js         195.00 B
+@elizaos/plugin-contacts:build: ESM dist/plugin.js.map                              2.19 KB
+@elizaos/plugin-contacts:build: ESM dist/components/ContactsAppView.helpers.js.map  2.63 KB
+@elizaos/plugin-contacts:build: ESM dist/register.js.map                            1.23 KB
+@elizaos/plugin-contacts:build: ESM dist/index.js.map                               596.00 B
+@elizaos/plugin-contacts:build: ESM dist/register-terminal-view.js.map              1.61 KB
+@elizaos/plugin-contacts:build: ESM dist/components/ContactsSpatialView.js.map      15.12 KB
+@elizaos/plugin-contacts:build: ESM dist/components/ContactsAppView.interact.js.map 4.26 KB
+@elizaos/plugin-contacts:build: ESM dist/ui.js.map                                  416.00 B
+@elizaos/plugin-contacts:build: ESM dist/components/ContactsAppView.js.map          39.62 KB
+@elizaos/plugin-contacts:build: ESM dist/providers/contacts.js.map                  3.91 KB
+@elizaos/plugin-contacts:build: ESM dist/components/contacts-app.js.map             1.24 KB
+@elizaos/plugin-contacts:build: ESM dist/components/ContactsView.js.map             9.45 KB
+@elizaos/plugin-contacts:build: ESM dist/components/contacts-view-bundle.js.map     641.00 B
+@elizaos/plugin-contacts:build: ESM ⚡️ Build success in 15ms
+@elizaos/plugin-contacts:build: $ bunx --bun vite build --config vite.config.views.ts
+@elizaos/plugin-phone:build: CLI Building entry: src/twilio.ts, src/plugin.ts, src/register-companion-page.ts, src/register-terminal-view.tsx, src/ui.ts, src/index.ts, src/register.ts, src/providers/call-log.ts, src/components/phone-view-helpers.ts, src/components/phone-view-bundle.ts, src/components/PhoneSpatialView.tsx, src/components/PhoneView.tsx, src/components/phone-interact.ts, src/companion/index.ts, src/companion/components/PhoneCompanionApp.tsx, src/companion/components/RemoteSession.tsx, src/companion/components/Pairing.tsx, src/companion/components/index.ts, src/companion/components/Chat.tsx, src/companion/services/push.ts, src/companion/services/navigation.ts, src/companion/services/intent-bridge.ts, src/companion/services/eliza-intent.ts, src/companion/services/logger.ts, src/companion/services/session-client.ts, src/companion/services/index.ts, src/companion/services/env.ts
+@elizaos/plugin-phone:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-phone:build: CLI tsup v8.5.1
+@elizaos/plugin-phone:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/tsup.plugin-packages.shared.ts
+@elizaos/plugin-phone:build: CLI Target: es2022
+@elizaos/plugin-phone:build: ESM Build start
+@elizaos/plugin-phone:build: ESM dist/twilio.js                                     6.74 KB
+@elizaos/plugin-phone:build: ESM dist/components/PhoneView.js                       6.56 KB
+@elizaos/plugin-phone:build: ESM dist/plugin.js                                     1.80 KB
+@elizaos/plugin-phone:build: ESM dist/register-terminal-view.js                     603.00 B
+@elizaos/plugin-phone:build: ESM dist/register-companion-page.js                    423.00 B
+@elizaos/plugin-phone:build: ESM dist/index.js                                      626.00 B
+@elizaos/plugin-phone:build: ESM dist/components/phone-interact.js                  2.16 KB
+@elizaos/plugin-phone:build: ESM dist/companion/components/Pairing.js               5.57 KB
+@elizaos/plugin-phone:build: ESM dist/companion/components/Chat.js                  5.21 KB
+@elizaos/plugin-phone:build: ESM dist/register.js                                   222.00 B
+@elizaos/plugin-phone:build: ESM dist/companion/services/push.js                    3.07 KB
+@elizaos/plugin-phone:build: ESM dist/companion/components/PhoneCompanionApp.js     4.82 KB
+@elizaos/plugin-phone:build: ESM dist/index.js.map                                  1.26 KB
+@elizaos/plugin-phone:build: ESM dist/companion/services/logger.js                  1.13 KB
+@elizaos/plugin-phone:build: ESM dist/providers/call-log.js                         1.81 KB
+@elizaos/plugin-phone:build: ESM dist/register.js.map                               1.04 KB
+@elizaos/plugin-phone:build: ESM dist/components/PhoneView.js.map                   12.35 KB
+@elizaos/plugin-phone:build: ESM dist/twilio.js.map                                 13.04 KB
+@elizaos/plugin-phone:build: ESM dist/companion/services/env.js                     419.00 B
+@elizaos/plugin-phone:build: ESM dist/components/PhoneSpatialView.js                5.08 KB
+@elizaos/plugin-phone:build: ESM dist/companion/services/navigation.js              3.14 KB
+@elizaos/plugin-phone:build: ESM dist/companion/services/push.js.map                6.27 KB
+@elizaos/plugin-phone:build: ESM dist/companion/services/eliza-intent.js            1.41 KB
+@elizaos/plugin-phone:build: ESM dist/companion/components/RemoteSession.js         11.81 KB
+@elizaos/plugin-phone:build: ESM dist/components/phone-interact.js.map              4.03 KB
+@elizaos/plugin-phone:build: ESM dist/companion/services/index.js                   565.00 B
+@elizaos/plugin-phone:build: ESM dist/ui.js                                         514.00 B
+@elizaos/plugin-phone:build: ESM dist/components/phone-view-helpers.js              1.31 KB
+@elizaos/plugin-phone:build: ESM dist/register-terminal-view.js.map                 1.58 KB
+@elizaos/plugin-phone:build: ESM dist/register-companion-page.js.map                1.19 KB
+@elizaos/plugin-phone:build: ESM dist/companion/services/intent-bridge.js           355.00 B
+@elizaos/plugin-phone:build: ESM dist/components/phone-view-bundle.js               173.00 B
+@elizaos/plugin-phone:build: ESM dist/providers/call-log.js.map                     3.89 KB
+@elizaos/plugin-phone:build: ESM dist/companion/components/Pairing.js.map           9.52 KB
+@elizaos/plugin-phone:build: ESM dist/companion/components/PhoneCompanionApp.js.map 8.87 KB
+@elizaos/plugin-phone:build: ESM dist/plugin.js.map                                 3.17 KB
+@elizaos/plugin-phone:build: ESM dist/companion/components/index.js                 287.00 B
+@elizaos/plugin-phone:build: ESM dist/companion/services/session-client.js          5.98 KB
+@elizaos/plugin-phone:build: ESM dist/components/PhoneSpatialView.js.map            10.19 KB
+@elizaos/plugin-phone:build: ESM dist/companion/components/RemoteSession.js.map     22.41 KB
+@elizaos/plugin-phone:build: ESM dist/companion/services/eliza-intent.js.map        4.44 KB
+@elizaos/plugin-phone:build: ESM dist/companion/services/env.js.map                 1.25 KB
+@elizaos/plugin-phone:build: ESM dist/companion/components/Chat.js.map              8.56 KB
+@elizaos/plugin-phone:build: ESM dist/components/phone-view-helpers.js.map          2.94 KB
+@elizaos/plugin-phone:build: ESM dist/companion/index.js                            368.00 B
+@elizaos/plugin-phone:build: ESM dist/ui.js.map                                     595.00 B
+@elizaos/plugin-phone:build: ESM dist/companion/services/intent-bridge.js.map       1.09 KB
+@elizaos/plugin-phone:build: ESM dist/companion/services/navigation.js.map          6.28 KB
+@elizaos/plugin-phone:build: ESM dist/companion/services/index.js.map               1.42 KB
+@elizaos/plugin-phone:build: ESM dist/companion/services/logger.js.map              2.83 KB
+@elizaos/plugin-phone:build: ESM dist/companion/components/index.js.map             382.00 B
+@elizaos/plugin-phone:build: ESM dist/components/phone-view-bundle.js.map           616.00 B
+@elizaos/plugin-phone:build: ESM dist/companion/index.js.map                        814.00 B
+@elizaos/plugin-phone:build: ESM dist/companion/services/session-client.js.map      14.46 KB
+@elizaos/plugin-phone:build: ESM ⚡️ Build success in 23ms
+@elizaos/plugin-phone:build: $ bunx --bun vite build --config vite.config.views.ts
+@elizaos/plugin-health:build: CLI Building entry: src/register-terminal-view.tsx, src/index.ts, src/register.ts, src/ui/assistant-commands.ts, src/ui/index.ts, src/connectors/contract-types.ts, src/connectors/index.ts, src/health-bridge/health-oauth.ts, src/health-bridge/health-provider-registry.ts, src/health-bridge/service-normalize-health.ts, src/health-bridge/health-connectors.ts, src/health-bridge/health-bridge.ts, src/health-bridge/index.ts, src/health-bridge/health-records.ts, src/util/token-encryption.ts, src/util/time-util.ts, src/util/normalize.ts, src/util/index.ts, src/util/time.ts, src/sleep/sleep-episode-store.ts, src/sleep/source-reliability.ts, src/sleep/circadian-rules.ts, src/sleep/sleep-recap.ts, src/sleep/sleep-wake-events.ts, src/sleep/sleep-episode-types.ts, src/sleep/sleep-cycle.ts, src/sleep/sleep-regularity.ts, src/sleep/sleep-service.ts, src/sleep/index.ts, src/sleep/sleep-cycle-dispatch.ts, src/sleep/awake-probability.ts, src/screen-time/mobile-signals.ts, src/screen-time/mobile-signal-setup.ts, src/screen-time/social-taxonomy.ts, src/screen-time/ranges.ts, src/screen-time/system-inactivity-apps.ts, src/screen-time/index.ts, src/screen-time/builders.ts, src/contracts/permissions.ts, src/contracts/circadian.ts, src/contracts/circadian-default.ts, src/contracts/health.ts, src/contracts/lifeops.ts, src/contracts/lifeops-connector-degradation.ts, src/providers/health.ts, src/providers/index.ts, src/actions/screen-time.ts, src/actions/optimized-prompt-instructions.ts, src/actions/health.ts, src/actions/index.ts, src/routes/sleep.ts, src/routes/index.ts, src/anchors/index.ts, src/default-packs/contract-types.ts, src/default-packs/sleep-recap.ts, src/default-packs/wake-up.ts, src/default-packs/index.ts, src/default-packs/bedtime.ts, src/components/health/HealthSpatialView.tsx, src/components/health/health-view-bundle.ts, src/components/health/HealthView.tsx
+@elizaos/plugin-health:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-health:build: CLI tsup v8.5.1
+@elizaos/plugin-health:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/tsup.plugin-packages.shared.ts
+@elizaos/plugin-health:build: CLI Target: es2022
+@elizaos/plugin-health:build: ESM Build start
+@elizaos/plugin-task-coordinator:build: CLI Building entry: src/orchestrator-plan.tsx, src/session-hydration.ts, src/CodingAgentTasksPanel.interact.ts, src/orchestrator-stream.tsx, src/orchestrator-reasoning.tsx, src/view-format.ts, src/PtyConsoleDrawer.tsx, src/TaskCardList.tsx, src/ModelConfigSection.tsx, src/CockpitRoute.tsx, src/orchestrator-markdown.helpers.ts, src/coding-agent-settings-shared.ts, src/orchestrator-params.ts, src/LlmProviderSection.tsx, src/orchestrator-stream.helpers.ts, src/orchestrator-capabilities.ts, src/PtyConsoleBase.tsx, src/task-coordinator-view-bundle.ts, src/CodingAgentControlChip.tsx, src/OrchestratorAccountHealthPanel.tsx, src/register-slots.ts, src/PtyConsoleSidePanel.tsx, src/pty-status-dots.ts, src/CodingAgentSettingsSection.tsx, src/orchestrator-command.ts, src/CockpitTerminalPanel.tsx, src/PtyTerminalPane.tsx, src/GitHubConnectionCard.tsx, src/OrchestratorView.tsx, src/register-terminal-view.tsx, src/use-orchestrator-data.ts, src/orchestrator-workbench-glyphs.tsx, src/CockpitSessionPane.tsx, src/GlobalPrefsSection.tsx, src/orchestrator-diff.helpers.ts, src/ui.ts, src/orchestrator-diff.tsx, src/TaskCoordinatorView.tsx, src/index.ts, src/register.ts, src/CodingAgentTasksPanel.tsx, src/OrchestratorWorkbench.tsx, src/orchestrator-markdown.tsx, src/AgentTabsSection.tsx, src/__e2e__/dashboard-fixture.tsx, src/components/OrchestratorSpatialView.tsx, src/components/TaskCoordinatorSpatialView.tsx, src/api/coding-agents-auth-sanitize.ts, src/api/coding-agents-preflight-normalize.ts
+@elizaos/plugin-task-coordinator:build: CLI Using tsconfig: ../../tsconfig.json
+@elizaos/plugin-task-coordinator:build: CLI tsup v8.5.1
+@elizaos/plugin-task-coordinator:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/tsup.plugin-packages.shared.ts
+@elizaos/plugin-task-coordinator:build: CLI Target: es2022
+@elizaos/plugin-task-coordinator:build: ESM Build start
+@elizaos/plugin-health:build: ESM dist/providers/health.js                            3.23 KB
+@elizaos/plugin-health:build: ESM dist/providers/index.js                             260.00 B
+@elizaos/plugin-health:build: ESM dist/screen-time/social-taxonomy.js                 6.60 KB
+@elizaos/plugin-health:build: ESM dist/actions/screen-time.js                         21.64 KB
+@elizaos/plugin-health:build: ESM dist/register-terminal-view.js                      600.00 B
+@elizaos/plugin-health:build: ESM dist/sleep/sleep-episode-store.js                   1.90 KB
+@elizaos/plugin-health:build: ESM dist/screen-time/ranges.js                          2.12 KB
+@elizaos/plugin-health:build: ESM dist/screen-time/builders.js                        9.35 KB
+@elizaos/plugin-health:build: ESM dist/sleep/sleep-cycle.js                           16.40 KB
+@elizaos/plugin-health:build: ESM dist/components/health/HealthView.js                6.79 KB
+@elizaos/plugin-health:build: ESM dist/sleep/source-reliability.js                    1.99 KB
+@elizaos/plugin-health:build: ESM dist/sleep/sleep-regularity.js                      7.47 KB
+@elizaos/plugin-health:build: ESM dist/actions/screen-time.js.map                     41.61 KB
+@elizaos/plugin-health:build: ESM dist/screen-time/social-taxonomy.js.map             13.79 KB
+@elizaos/plugin-health:build: ESM dist/screen-time/system-inactivity-apps.js          2.19 KB
+@elizaos/plugin-health:build: ESM dist/routes/sleep.js                                4.15 KB
+@elizaos/plugin-health:build: ESM dist/screen-time/mobile-signals.js                  5.63 KB
+@elizaos/plugin-health:build: ESM dist/register.js                                    184.00 B
+@elizaos/plugin-health:build: ESM dist/actions/optimized-prompt-instructions.js       1.79 KB
+@elizaos/plugin-health:build: ESM dist/actions/health.js                              18.75 KB
+@elizaos/plugin-health:build: ESM dist/contracts/lifeops-connector-degradation.js     378.00 B
+@elizaos/plugin-health:build: ESM dist/actions/index.js                               242.00 B
+@elizaos/plugin-health:build: ESM dist/screen-time/mobile-signal-setup.js             1.23 KB
+@elizaos/plugin-health:build: ESM dist/contracts/permissions.js                       39.00 B
+@elizaos/plugin-health:build: ESM dist/sleep/sleep-recap.js                           39.00 B
+@elizaos/plugin-health:build: ESM dist/contracts/circadian.js                         442.00 B
+@elizaos/plugin-health:build: ESM dist/sleep/sleep-episode-types.js                   343.00 B
+@elizaos/plugin-health:build: ESM dist/contracts/circadian-default.js                 704.00 B
+@elizaos/plugin-health:build: ESM dist/contracts/health.js                            596.00 B
+@elizaos/plugin-health:build: ESM dist/contracts/lifeops.js                           12.88 KB
+@elizaos/plugin-health:build: ESM dist/default-packs/bedtime.js                       1.50 KB
+@elizaos/plugin-health:build: ESM dist/screen-time/index.js                           213.00 B
+@elizaos/plugin-health:build: ESM dist/components/health/HealthSpatialView.js         3.30 KB
+@elizaos/plugin-health:build: ESM dist/default-packs/index.js                         1.08 KB
+@elizaos/plugin-health:build: ESM dist/sleep/sleep-cycle-dispatch.js                  3.58 KB
+@elizaos/plugin-health:build: ESM dist/sleep/awake-probability.js                     5.84 KB
+@elizaos/plugin-health:build: ESM dist/index.js                                       3.05 KB
+@elizaos/plugin-health:build: ESM dist/sleep/index.js                                 462.00 B
+@elizaos/plugin-health:build: ESM dist/anchors/index.js                               171.00 B
+@elizaos/plugin-health:build: ESM dist/default-packs/wake-up.js                       1.83 KB
+@elizaos/plugin-health:build: ESM dist/components/health/health-view-bundle.js        117.00 B
+@elizaos/plugin-health:build: ESM dist/sleep/circadian-rules.js                       9.03 KB
+@elizaos/plugin-health:build: ESM dist/default-packs/contract-types.js                42.00 B
+@elizaos/plugin-health:build: ESM dist/sleep/sleep-service.js                         4.91 KB
+@elizaos/plugin-health:build: ESM dist/sleep/sleep-wake-events.js                     4.42 KB
+@elizaos/plugin-health:build: ESM dist/default-packs/sleep-recap.js                   1.65 KB
+@elizaos/plugin-health:build: ESM dist/routes/index.js                                61.00 B
+@elizaos/plugin-health:build: ESM dist/contracts/lifeops-connector-degradation.js.map 844.00 B
+@elizaos/plugin-health:build: ESM dist/components/health/HealthSpatialView.js.map     7.90 KB
+@elizaos/plugin-health:build: ESM dist/providers/index.js.map                         388.00 B
+@elizaos/plugin-health:build: ESM dist/default-packs/sleep-recap.js.map               3.13 KB
+@elizaos/plugin-health:build: ESM dist/util/time.js                                   4.79 KB
+@elizaos/plugin-health:build: ESM dist/sleep/sleep-cycle-dispatch.js.map              9.94 KB
+@elizaos/plugin-health:build: ESM dist/register.js.map                                863.00 B
+@elizaos/plugin-health:build: ESM dist/routes/sleep.js.map                            8.49 KB
+@elizaos/plugin-health:build: ESM dist/ui/assistant-commands.js                       1.96 KB
+@elizaos/plugin-health:build: ESM dist/screen-time/mobile-signals.js.map              11.01 KB
+@elizaos/plugin-health:build: ESM dist/contracts/circadian.js.map                     5.11 KB
+@elizaos/plugin-health:build: ESM dist/contracts/circadian-default.js.map             1.90 KB
+@elizaos/plugin-health:build: ESM dist/health-bridge/health-oauth.js                  14.91 KB
+@elizaos/plugin-health:build: ESM dist/screen-time/system-inactivity-apps.js.map      4.08 KB
+@elizaos/plugin-health:build: ESM dist/sleep/index.js.map                             1.12 KB
+@elizaos/plugin-health:build: ESM dist/sleep/sleep-regularity.js.map                  14.33 KB
+@elizaos/plugin-health:build: ESM dist/sleep/sleep-recap.js.map                       71.00 B
+@elizaos/plugin-health:build: ESM dist/providers/health.js.map                        6.42 KB
+@elizaos/plugin-health:build: ESM dist/health-bridge/health-provider-registry.js      3.91 KB
+@elizaos/plugin-health:build: ESM dist/contracts/health.js.map                        3.22 KB
+@elizaos/plugin-health:build: ESM dist/ui/assistant-commands.js.map                   3.32 KB
+@elizaos/plugin-health:build: ESM dist/util/time.js.map                               9.32 KB
+@elizaos/plugin-health:build: ESM dist/index.js.map                                   6.57 KB
+@elizaos/plugin-health:build: ESM dist/components/health/HealthView.js.map            16.66 KB
+@elizaos/plugin-health:build: ESM dist/actions/health.js.map                          35.77 KB
+@elizaos/plugin-health:build: ESM dist/health-bridge/index.js                         275.00 B
+@elizaos/plugin-health:build: ESM dist/default-packs/index.js.map                     2.26 KB
+@elizaos/plugin-health:build: ESM dist/routes/index.js.map                            141.00 B
+@elizaos/plugin-health:build: ESM dist/anchors/index.js.map                           1.12 KB
+@elizaos/plugin-health:build: ESM dist/actions/optimized-prompt-instructions.js.map   2.16 KB
+@elizaos/plugin-health:build: ESM dist/contracts/lifeops.js.map                       122.19 KB
+@elizaos/plugin-health:build: ESM dist/health-bridge/health-connectors.js             32.44 KB
+@elizaos/plugin-health:build: ESM dist/health-bridge/health-bridge.js                 16.64 KB
+@elizaos/plugin-health:build: ESM dist/health-bridge/health-oauth.js.map              30.40 KB
+@elizaos/plugin-health:build: ESM dist/sleep/sleep-service.js.map                     9.58 KB
+@elizaos/plugin-health:build: ESM dist/health-bridge/health-provider-registry.js.map  10.09 KB
+@elizaos/plugin-health:build: ESM dist/sleep/source-reliability.js.map                4.71 KB
+@elizaos/plugin-health:build: ESM dist/health-bridge/service-normalize-health.js      3.30 KB
+@elizaos/plugin-health:build: ESM dist/health-bridge/health-records.js                1005.00 B
+@elizaos/plugin-health:build: ESM dist/ui/index.js                                    144.00 B
+@elizaos/plugin-health:build: ESM dist/register-terminal-view.js.map                  1.48 KB
+@elizaos/plugin-health:build: ESM dist/actions/index.js.map                           788.00 B
+@elizaos/plugin-health:build: ESM dist/screen-time/builders.js.map                    17.58 KB
+@elizaos/plugin-health:build: ESM dist/connectors/contract-types.js                   42.00 B
+@elizaos/plugin-health:build: ESM dist/sleep/awake-probability.js.map                 11.16 KB
+@elizaos/plugin-health:build: ESM dist/health-bridge/index.js.map                     1.18 KB
+@elizaos/plugin-health:build: ESM dist/sleep/sleep-episode-store.js.map               4.18 KB
+@elizaos/plugin-health:build: ESM dist/util/token-encryption.js                       3.05 KB
+@elizaos/plugin-health:build: ESM dist/sleep/circadian-rules.js.map                   17.66 KB
+@elizaos/plugin-health:build: ESM dist/components/health/health-view-bundle.js.map    479.00 B
+@elizaos/plugin-health:build: ESM dist/default-packs/contract-types.js.map            71.00 B
+@elizaos/plugin-health:build: ESM dist/sleep/sleep-episode-types.js.map               2.20 KB
+@elizaos/plugin-health:build: ESM dist/sleep/sleep-cycle.js.map                       32.18 KB
+@elizaos/plugin-health:build: ESM dist/health-bridge/health-connectors.js.map         61.42 KB
+@elizaos/plugin-health:build: ESM dist/util/normalize.js                              1.91 KB
+@elizaos/plugin-health:build: ESM dist/default-packs/wake-up.js.map                   3.54 KB
+@elizaos/plugin-health:build: ESM dist/contracts/permissions.js.map                   71.00 B
+@elizaos/plugin-health:build: ESM dist/screen-time/ranges.js.map                      4.30 KB
+@elizaos/plugin-health:build: ESM dist/util/index.js                                  92.00 B
+@elizaos/plugin-health:build: ESM dist/sleep/sleep-wake-events.js.map                 10.84 KB
+@elizaos/plugin-health:build: ESM dist/connectors/contract-types.js.map               71.00 B
+@elizaos/plugin-health:build: ESM dist/connectors/index.js                            5.65 KB
+@elizaos/plugin-health:build: ESM dist/default-packs/bedtime.js.map                   2.94 KB
+@elizaos/plugin-health:build: ESM dist/health-bridge/health-records.js.map            2.45 KB
+@elizaos/plugin-health:build: ESM dist/ui/index.js.map                                262.00 B
+@elizaos/plugin-health:build: ESM dist/util/token-encryption.js.map                   6.94 KB
+@elizaos/plugin-health:build: ESM dist/util/time-util.js                              416.00 B
+@elizaos/plugin-health:build: ESM dist/screen-time/mobile-signal-setup.js.map         2.75 KB
+@elizaos/plugin-health:build: ESM dist/screen-time/index.js.map                       1.53 KB
+@elizaos/plugin-health:build: ESM dist/util/normalize.js.map                          3.93 KB
+@elizaos/plugin-health:build: ESM dist/health-bridge/service-normalize-health.js.map  5.76 KB
+@elizaos/plugin-health:build: ESM dist/health-bridge/health-bridge.js.map             35.20 KB
+@elizaos/plugin-health:build: ESM dist/connectors/index.js.map                        12.52 KB
+@elizaos/plugin-health:build: ESM dist/util/index.js.map                              462.00 B
+@elizaos/plugin-health:build: ESM dist/util/time-util.js.map                          1.15 KB
+@elizaos/plugin-health:build: ESM ⚡️ Build success in 59ms
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-plan.js                         3.40 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-stream.js                       10.27 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/use-orchestrator-data.js                     7.54 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/view-format.js                               2.04 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/TaskCardList.js                              8.31 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-diff.js                         3.84 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-reasoning.js                    3.29 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/CockpitTerminalPanel.js                      3.75 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/TaskCoordinatorView.js                       4.33 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/CodingAgentTasksPanel.interact.js            1.59 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/PtyConsoleDrawer.js                          3.43 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/components/TaskCoordinatorSpatialView.js     10.66 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/api/coding-agents-auth-sanitize.js           658.00 B
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-capabilities.js                 4.95 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-command.js                      1.81 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/session-hydration.js                         184.00 B
+@elizaos/plugin-task-coordinator:build: ESM dist/OrchestratorView.js                          643.00 B
+@elizaos/plugin-task-coordinator:build: ESM dist/LlmProviderSection.js                        5.67 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/__e2e__/dashboard-fixture.js                 4.06 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/PtyConsoleBase.js                            5.95 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/pty-status-dots.js                           144.00 B
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-workbench-glyphs.js             6.77 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/task-coordinator-view-bundle.js              371.00 B
+@elizaos/plugin-task-coordinator:build: ESM dist/GlobalPrefsSection.js                        7.07 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/index.js                                     10.36 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/OrchestratorAccountHealthPanel.js            3.06 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/components/OrchestratorSpatialView.js        16.75 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-diff.helpers.js                 1.83 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/ui.js                                        277.00 B
+@elizaos/plugin-task-coordinator:build: ESM dist/coding-agent-settings-shared.js              2.95 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-diff.js.map                     8.34 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/OrchestratorWorkbench.js                     102.42 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/CodingAgentSettingsSection.js                13.60 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/CockpitRoute.js                              1.95 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/CockpitSessionPane.js                        12.33 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/CodingAgentTasksPanel.js                     28.09 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-stream.helpers.js               11.81 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-reasoning.js.map                7.05 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/PtyConsoleSidePanel.js                       299.00 B
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-stream.js.map                   19.79 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/CodingAgentControlChip.js                    2.36 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/register.js                                  276.00 B
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-plan.js.map                     6.36 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/PtyTerminalPane.js                           4.06 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/TaskCardList.js.map                          14.71 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-markdown.js                     7.80 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-params.js                       850.00 B
+@elizaos/plugin-task-coordinator:build: ESM dist/ModelConfigSection.js                        3.44 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/use-orchestrator-data.js.map                 17.05 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/CockpitTerminalPanel.js.map                  6.27 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/api/coding-agents-auth-sanitize.js.map       2.12 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/AgentTabsSection.js                          6.55 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/OrchestratorView.js.map                      1.45 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/TaskCoordinatorView.js.map                   8.93 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/pty-status-dots.js.map                       185.00 B
+@elizaos/plugin-task-coordinator:build: ESM dist/CodingAgentTasksPanel.interact.js.map        3.14 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/__e2e__/dashboard-fixture.js.map             6.53 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/view-format.js.map                           4.76 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/register-slots.js                            1.28 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-markdown.helpers.js             614.00 B
+@elizaos/plugin-task-coordinator:build: ESM dist/session-hydration.js.map                     243.00 B
+@elizaos/plugin-task-coordinator:build: ESM dist/GitHubConnectionCard.js                      6.59 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-workbench-glyphs.js.map         13.76 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/components/OrchestratorSpatialView.js.map    31.64 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/api/coding-agents-preflight-normalize.js     653.00 B
+@elizaos/plugin-task-coordinator:build: ESM dist/index.js.map                                 15.80 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/PtyConsoleBase.js.map                        8.77 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/PtyConsoleDrawer.js.map                      4.85 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-capabilities.js.map             8.45 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-command.js.map                  4.49 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/OrchestratorAccountHealthPanel.js.map        6.92 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/coding-agent-settings-shared.js.map          6.12 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/CockpitSessionPane.js.map                    22.83 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/CockpitRoute.js.map                          4.64 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/LlmProviderSection.js.map                    9.22 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/components/TaskCoordinatorSpatialView.js.map 21.18 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/register-terminal-view.js                    1.19 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-diff.helpers.js.map             4.90 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/GlobalPrefsSection.js.map                    11.26 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/api/coding-agents-preflight-normalize.js.map 2.61 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/task-coordinator-view-bundle.js.map          1.17 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/CodingAgentTasksPanel.js.map                 47.33 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/register.js.map                              838.00 B
+@elizaos/plugin-task-coordinator:build: ESM dist/AgentTabsSection.js.map                      10.72 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/PtyConsoleSidePanel.js.map                   594.00 B
+@elizaos/plugin-task-coordinator:build: ESM dist/register-slots.js.map                        3.43 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/OrchestratorWorkbench.js.map                 165.45 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/ui.js.map                                    288.00 B
+@elizaos/plugin-task-coordinator:build: ESM dist/PtyTerminalPane.js.map                       7.74 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/CodingAgentSettingsSection.js.map            25.07 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-markdown.helpers.js.map         1.47 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-stream.helpers.js.map           29.78 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/CodingAgentControlChip.js.map                3.59 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/GitHubConnectionCard.js.map                  10.54 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-markdown.js.map                 14.64 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/register-terminal-view.js.map                2.59 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/orchestrator-params.js.map                   1.98 KB
+@elizaos/plugin-task-coordinator:build: ESM dist/ModelConfigSection.js.map                    5.49 KB
+@elizaos/plugin-task-coordinator:build: ESM ⚡️ Build success in 61ms
+@elizaos/plugin-health:build: $ bunx --bun vite build --config vite.config.views.ts
+@elizaos/plugin-task-coordinator:build: $ bunx --bun vite build --config vite.config.views.ts
+@elizaos/plugin-health:build: vite v8.0.16 building client environment for production...
+@elizaos/plugin-contacts:build: vite v8.0.16 building client environment for production...
+@elizaos/plugin-health:build: [2K@elizaos/plugin-health:build: transforming...✓ 4 modules transformed.
+@elizaos/plugin-contacts:build: [2K@elizaos/plugin-contacts:build: transforming...✓ 10 modules transformed.
+@elizaos/plugin-task-coordinator:build: vite v8.0.16 building client environment for production...
+@elizaos/plugin-health:build: rendering chunks...
+@elizaos/plugin-contacts:build: rendering chunks...
+@elizaos/plugin-health:build: computing gzip size...
+@elizaos/plugin-health:build: dist/views/bundle.js  7.76 kB │ gzip: 2.55 kB │ map: 23.96 kB
+@elizaos/plugin-health:build:
+@elizaos/plugin-health:build: ✓ built in 31ms
+@elizaos/plugin-contacts:build: computing gzip size...
+@elizaos/plugin-contacts:build: dist/views/web-DMSWpoWr.js    1.07 kB │ gzip: 0.51 kB │ map:  3.14 kB
+@elizaos/plugin-contacts:build: dist/views/dist-Cd2YtKy4.js   9.78 kB │ gzip: 3.56 kB │ map: 34.19 kB
+@elizaos/plugin-contacts:build: dist/views/bundle.js         11.78 kB │ gzip: 3.40 kB │ map: 30.70 kB
+@elizaos/plugin-contacts:build:
+@elizaos/plugin-contacts:build: ✓ built in 37ms
+@elizaos/plugin-health:build: $ tsc --noCheck -p tsconfig.build.json
+@elizaos/plugin-contacts:build: $ bunx tsc --noCheck -p tsconfig.build.json
+@elizaos/plugin-task-coordinator:build: [2K@elizaos/plugin-task-coordinator:build: transforming...✓ 30 modules transformed.
+@elizaos/plugin-task-coordinator:build: rendering chunks...
+@elizaos/plugin-task-coordinator:build: computing gzip size...
+@elizaos/plugin-task-coordinator:build: dist/views/addon-fit-m6I4VupF.js    1.98 kB │ gzip:  0.86 kB │ map:   3.18 kB
+@elizaos/plugin-task-coordinator:build: dist/views/bundle.js              218.30 kB │ gzip: 51.54 kB │ map: 503.28 kB
+@elizaos/plugin-task-coordinator:build: dist/views/xterm-CSb1Gh9p.js      369.18 kB │ gzip: 74.91 kB │ map: 574.82 kB
+@elizaos/plugin-task-coordinator:build:
+@elizaos/plugin-task-coordinator:build: ✓ built in 126ms
+@elizaos/plugin-task-coordinator:build: $ tsc --noCheck -p tsconfig.build.json
+@elizaos/plugin-phone:build: vite v8.0.16 building client environment for production...
+@elizaos/plugin-phone:build: [2K@elizaos/plugin-phone:build: transforming...✓ 10 modules transformed.
+@elizaos/plugin-phone:build: rendering chunks...
+@elizaos/plugin-phone:build: computing gzip size...
+@elizaos/plugin-phone:build: dist/views/web-TGRkTsa8.js    1.69 kB │ gzip: 0.70 kB │ map:  4.29 kB
+@elizaos/plugin-phone:build: dist/views/dist-Cd2YtKy4.js   9.78 kB │ gzip: 3.56 kB │ map: 34.19 kB
+@elizaos/plugin-phone:build: dist/views/bundle.js         10.98 kB │ gzip: 3.50 kB │ map: 28.51 kB
+@elizaos/plugin-phone:build:
+@elizaos/plugin-phone:build: ✓ built in 52ms
+@elizaos/plugin-phone:build: $ tsc --noCheck -p tsconfig.build.json
+@elizaos/plugin-calendar:typecheck: cache miss, executing 55f8e6e1003d347c
+@elizaos/plugin-calendar:typecheck: $ tsgo --noEmit
+@elizaos/plugin-app-control:build: $ bunx --bun vite build --config vite.config.views.ts
+@elizaos/plugin-app-control:build: vite v8.0.16 building client environment for production...
+@elizaos/plugin-app-control:build: [2K@elizaos/plugin-app-control:build: transforming...✓ 5 modules transformed.
+@elizaos/plugin-app-control:build: rendering chunks...
+@elizaos/plugin-app-control:build: computing gzip size...
+@elizaos/plugin-app-control:build: dist/views/bundle.js  5.76 kB │ gzip: 2.23 kB │ map: 16.92 kB
+@elizaos/plugin-app-control:build:
+@elizaos/plugin-app-control:build: ✓ built in 11ms
+@elizaos/agent:build: cache miss, executing 4c90405c737ad393
+@elizaos/agent:build: $ bun run build:dist
+@elizaos/agent:build: $ node ../scripts/rm-path-recursive.mjs dist && tsc --noCheck -p tsconfig.build.json && node ../scripts/prepare-package-dist.mjs packages/agent && node ../scripts/copy-package-assets.mjs packages/agent assets && node ../scripts/rewrite-dist-relative-imports-node-esm.mjs packages/agent
+@elizaos/agent:build: [rewrite-dist-relative-imports] rewrote 173 file(s)
+@elizaos/plugin-reminders:build: cache miss, executing 578e65e55f6b29a6
+@elizaos/plugin-xr:build: cache miss, executing 89b9dfa948549205
+@elizaos/app-core:build: cache miss, executing 0a38a8f68664968f
+@elizaos/app-core:typecheck: cache miss, executing c3c38673e945be61
+@elizaos/plugin-local-inference:typecheck: cache miss, executing ee0f2c513746f672
+@elizaos/plugin-reminders:build: $ bun run build:js && bun run build:types
+@elizaos/plugin-xr:build: $ bun run build:js && bun run build:types
+@elizaos/app-core:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/app-core:build: $ bun run build:dist
+@elizaos/plugin-local-inference:typecheck: $ tsgo --noEmit
+@elizaos/plugin-reminders:build: $ tsup --config ../tsup.plugin-packages.shared.ts
+@elizaos/plugin-xr:build: $ tsup --config ../tsup.plugin-packages.shared.ts
+@elizaos/app-core:build: $ node ../scripts/rm-path-recursive.mjs dist && tsc --noCheck -p tsconfig.build.json && node ../scripts/flatten-tsc-package-output.mjs packages/app-core && node ../scripts/copy-package-assets.mjs packages/app-core src/styles scripts platforms packaging patches test/scripts test/helpers && node ../scripts/prepare-package-dist.mjs packages/app-core && node ../scripts/rewrite-dist-relative-imports-node-esm.mjs packages/app-core
+@elizaos/plugin-reminders:build: CLI Building entry: src/plugin.ts, src/index.ts, src/db/schema.ts, src/db/index.ts, src/services/migration.ts
+@elizaos/plugin-reminders:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-reminders:build: CLI tsup v8.5.1
+@elizaos/plugin-reminders:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/tsup.plugin-packages.shared.ts
+@elizaos/plugin-reminders:build: CLI Target: es2022
+@elizaos/plugin-reminders:build: ESM Build start
+@elizaos/plugin-reminders:build: ESM dist/db/schema.js              3.13 KB
+@elizaos/plugin-reminders:build: ESM dist/plugin.js                 568.00 B
+@elizaos/plugin-reminders:build: ESM dist/index.js                  468.00 B
+@elizaos/plugin-reminders:build: ESM dist/db/index.js               62.00 B
+@elizaos/plugin-reminders:build: ESM dist/services/migration.js     3.73 KB
+@elizaos/plugin-reminders:build: ESM dist/plugin.js.map             1.42 KB
+@elizaos/plugin-reminders:build: ESM dist/db/schema.js.map          6.35 KB
+@elizaos/plugin-reminders:build: ESM dist/db/index.js.map           138.00 B
+@elizaos/plugin-reminders:build: ESM dist/services/migration.js.map 8.38 KB
+@elizaos/plugin-reminders:build: ESM dist/index.js.map              544.00 B
+@elizaos/plugin-reminders:build: ESM ⚡️ Build success in 77ms
+@elizaos/plugin-reminders:build: $ bunx tsc --noCheck -p tsconfig.build.json && node ../../packages/scripts/rewrite-dist-relative-imports-node-esm.mjs
+@elizaos/plugin-xr:build: CLI Building entry: src/protocol.ts, src/index.ts, src/providers/xr-context.ts, src/actions/xr-query-vision.ts, src/actions/xr-view-actions.ts, src/routes/xr-status.ts, src/routes/xr-simulator-route.ts, src/routes/xr-views.ts, src/routes/xr-connect.ts, src/routes/xr-view-host.ts, src/services/audio-pipeline.ts, src/services/xr-session-service.ts, src/services/vision-pipeline.ts
+@elizaos/plugin-xr:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-xr:build: CLI tsup v8.5.1
+@elizaos/plugin-xr:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/tsup.plugin-packages.shared.ts
+@elizaos/plugin-xr:build: CLI Target: es2022
+@elizaos/plugin-xr:build: ESM Build start
+@elizaos/plugin-xr:build: ESM dist/protocol.js                        613.00 B
+@elizaos/plugin-xr:build: ESM dist/routes/xr-status.js                838.00 B
+@elizaos/plugin-xr:build: ESM dist/routes/xr-connect.js               3.37 KB
+@elizaos/plugin-xr:build: ESM dist/index.js                           1.66 KB
+@elizaos/plugin-xr:build: ESM dist/routes/xr-views.js                 952.00 B
+@elizaos/plugin-xr:build: ESM dist/routes/xr-view-host.js             11.07 KB
+@elizaos/plugin-xr:build: ESM dist/routes/xr-simulator-route.js       1.03 KB
+@elizaos/plugin-xr:build: ESM dist/actions/xr-query-vision.js         1.37 KB
+@elizaos/plugin-xr:build: ESM dist/providers/xr-context.js            1.16 KB
+@elizaos/plugin-xr:build: ESM dist/services/xr-session-service.js     8.89 KB
+@elizaos/plugin-xr:build: ESM dist/services/audio-pipeline.js         2.65 KB
+@elizaos/plugin-xr:build: ESM dist/actions/xr-view-actions.js         11.03 KB
+@elizaos/plugin-xr:build: ESM dist/services/vision-pipeline.js        1.28 KB
+@elizaos/plugin-xr:build: ESM dist/routes/xr-status.js.map            1.55 KB
+@elizaos/plugin-xr:build: ESM dist/protocol.js.map                    4.56 KB
+@elizaos/plugin-xr:build: ESM dist/index.js.map                       2.34 KB
+@elizaos/plugin-xr:build: ESM dist/routes/xr-views.js.map             1.96 KB
+@elizaos/plugin-xr:build: ESM dist/services/xr-session-service.js.map 17.34 KB
+@elizaos/plugin-xr:build: ESM dist/routes/xr-view-host.js.map         14.00 KB
+@elizaos/plugin-xr:build: ESM dist/providers/xr-context.js.map        2.13 KB
+@elizaos/plugin-xr:build: ESM dist/actions/xr-query-vision.js.map     2.70 KB
+@elizaos/plugin-xr:build: ESM dist/actions/xr-view-actions.js.map     21.08 KB
+@elizaos/plugin-xr:build: ESM dist/routes/xr-connect.js.map           4.61 KB
+@elizaos/plugin-xr:build: ESM dist/services/audio-pipeline.js.map     5.75 KB
+@elizaos/plugin-xr:build: ESM dist/routes/xr-simulator-route.js.map   1.91 KB
+@elizaos/plugin-xr:build: ESM dist/services/vision-pipeline.js.map    2.68 KB
+@elizaos/plugin-xr:build: ESM ⚡️ Build success in 13ms
+@elizaos/plugin-xr:build: $ tsc --noCheck -p tsconfig.build.json
+@elizaos/plugin-reminders:build: [rewrite-dist-relative-imports] rewrote 2 file(s)
+@elizaos/app-core:build: [rewrite-dist-relative-imports] rewrote 118 file(s)
+@elizaos/plugin-cloud-apps:typecheck: cache miss, executing 5724dd3da4e85050
+@elizaos/plugin-feed:typecheck: cache miss, executing 2a5ae3e091e9158f
+@elizaos/plugin-anthropic-proxy:typecheck: cache miss, executing d6b5089116e38eb6
+eliza-app:typecheck: cache miss, executing e288acd6dc289caf
+@elizaos/plugin-vision:typecheck: cache miss, executing 1f89b8cc82544085
+@elizaos/bench-eliza-1-vision-cua-e2e:typecheck: cache miss, executing 76364ad505586dec
+@elizaos/plugin-linear:typecheck: cache miss, executing db326b082f5e7a73
+@elizaos/example-text-adventure:typecheck: cache miss, executing 9b98e975c88ee3a4
+@elizaos/plugin-feed:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-cloud-apps:typecheck: $ tsgo --noEmit
+@elizaos/plugin-anthropic-proxy:typecheck: $ tsgo --noEmit -p tsconfig.json
+eliza-app:typecheck: $ node ../app-core/scripts/write-homepage-release-data.mjs && tsc -b
+@elizaos/plugin-linear:typecheck: $ tsgo --noEmit
+@elizaos/plugin-vision:typecheck: $ tsgo --noEmit
+@elizaos/bench-eliza-1-vision-cua-e2e:typecheck: $ tsgo --noEmit
+@elizaos/example-text-adventure:typecheck: $ tsgo --noEmit
+@elizaos/plugin-music:typecheck: cache miss, executing cfe92bc53689d45c
+@elizaos/plugin-music:typecheck: $ tsgo --noEmit -p tsconfig.typecheck.json
+@elizaos/example-app-electron-renderer:typecheck: cache miss, executing be8712b4e33d6cb0
+@elizaos/example-app-electron-renderer:typecheck: $ tsc --noEmit
+@elizaos/plugin-todos:typecheck: cache miss, executing 311cb5fdc0f8b2ff
+@elizaos/plugin-coding-tools:typecheck: cache miss, executing c8a5ff3ffbd2ca37
+@elizaos/plugin-coding-tools:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-todos:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-blocker:build: cache miss, executing b24645fc0bf019e3
+elizaos:typecheck: cache miss, executing 70fa99dd35dee933
+@elizaos/plugin-blocker:build: $ bun run build:js && bun run build:views && bun run build:types
+elizaos:typecheck: $ tsgo --noEmit
+@elizaos/plugin-blocker:build: $ tsup --config ../tsup.plugin-packages.shared.ts
+@elizaos/plugin-app-control:typecheck: cache miss, executing f8db3c7f884c9f5b
+@elizaos/plugin-app-control:typecheck: $ tsgo --noEmit
+@elizaos/plugin-todos:build: cache miss, executing f84af889157688ad
+eliza-app:typecheck: homepage release data: stable=v2.0.3-beta.7, canary=v2.0.3-beta.7, osArtifacts=10
+@elizaos/plugin-todos:build: $ bun run build:js && bun run build:views && bun run build:types
+@elizaos/plugin-todos:build: $ tsup --config ../tsup.plugin-packages.shared.ts
+@elizaos/plugin-background-runner:typecheck: cache miss, executing da7eaa153f362424
+@elizaos/plugin-background-runner:typecheck: $ tsgo --noEmit
+@elizaos/plugin-health:typecheck: cache miss, executing c4e16bb46be8db43
+@elizaos/plugin-health:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-blocker:build: CLI Building entry: src/plugin.ts, src/types.ts, src/register-terminal-view.tsx, src/index.ts, src/register.ts, src/providers/app-blocker.ts, src/providers/website-blocker.ts, src/db/schema.ts, src/db/index.ts, src/components/focus/FocusView.tsx, src/components/focus/FocusSpatialView.tsx, src/components/focus/focus-view-bundle.ts, src/services/app-blocker/engine.ts, src/services/app-blocker/types.ts, src/services/app-blocker/access.ts, src/services/app-blocker/index.ts, src/services/app-blocker/service.ts, src/services/website-blocker/permissions.ts, src/services/website-blocker/engine.ts, src/services/website-blocker/access.ts, src/services/website-blocker/roles.ts, src/services/website-blocker/index.ts, src/services/website-blocker/service.ts
+@elizaos/plugin-blocker:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-blocker:build: CLI tsup v8.5.1
+@elizaos/plugin-blocker:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/tsup.plugin-packages.shared.ts
+@elizaos/plugin-blocker:build: CLI Target: es2022
+@elizaos/plugin-blocker:build: ESM Build start
+@elizaos/plugin-blocker:build: ESM dist/plugin.js                                   2.46 KB
+@elizaos/plugin-blocker:build: ESM dist/services/app-blocker/engine.js              2.07 KB
+@elizaos/plugin-blocker:build: ESM dist/register-terminal-view.js                   590.00 B
+@elizaos/plugin-blocker:build: ESM dist/index.js                                    848.00 B
+@elizaos/plugin-blocker:build: ESM dist/db/schema.js                                2.40 KB
+@elizaos/plugin-blocker:build: ESM dist/types.js                                    638.00 B
+@elizaos/plugin-blocker:build: ESM dist/components/focus/FocusSpatialView.js        3.71 KB
+@elizaos/plugin-blocker:build: ESM dist/components/focus/FocusView.js               3.67 KB
+@elizaos/plugin-blocker:build: ESM dist/register.js                                 183.00 B
+@elizaos/plugin-blocker:build: ESM dist/services/app-blocker/types.js               33.00 B
+@elizaos/plugin-blocker:build: ESM dist/db/index.js                                 62.00 B
+@elizaos/plugin-blocker:build: ESM dist/providers/app-blocker.js                    3.60 KB
+@elizaos/plugin-blocker:build: ESM dist/services/app-blocker/access.js              1.31 KB
+@elizaos/plugin-blocker:build: ESM dist/services/app-blocker/index.js               793.00 B
+@elizaos/plugin-blocker:build: ESM dist/providers/website-blocker.js                5.89 KB
+@elizaos/plugin-blocker:build: ESM dist/services/website-blocker/access.js          1.30 KB
+@elizaos/plugin-blocker:build: ESM dist/services/website-blocker/roles.js           586.00 B
+@elizaos/plugin-blocker:build: ESM dist/services/website-blocker/index.js           2.03 KB
+@elizaos/plugin-blocker:build: ESM dist/services/website-blocker/service.js         9.95 KB
+@elizaos/plugin-blocker:build: ESM dist/services/website-blocker/permissions.js     39.00 B
+@elizaos/plugin-blocker:build: ESM dist/components/focus/focus-view-bundle.js       113.00 B
+@elizaos/plugin-blocker:build: ESM dist/services/website-blocker/engine.js          40.53 KB
+@elizaos/plugin-blocker:build: ESM dist/services/app-blocker/service.js             769.00 B
+@elizaos/plugin-blocker:build: ESM dist/plugin.js.map                               4.72 KB
+@elizaos/plugin-blocker:build: ESM dist/types.js.map                                2.07 KB
+@elizaos/plugin-blocker:build: ESM dist/services/app-blocker/engine.js.map          4.96 KB
+@elizaos/plugin-blocker:build: ESM dist/register-terminal-view.js.map               1.54 KB
+@elizaos/plugin-blocker:build: ESM dist/index.js.map                                1.08 KB
+@elizaos/plugin-blocker:build: ESM dist/db/schema.js.map                            5.15 KB
+@elizaos/plugin-blocker:build: ESM dist/services/app-blocker/index.js.map           1.00 KB
+@elizaos/plugin-blocker:build: ESM dist/providers/app-blocker.js.map                6.04 KB
+@elizaos/plugin-blocker:build: ESM dist/components/focus/FocusView.js.map           8.70 KB
+@elizaos/plugin-blocker:build: ESM dist/services/app-blocker/types.js.map           71.00 B
+@elizaos/plugin-blocker:build: ESM dist/providers/website-blocker.js.map            8.96 KB
+@elizaos/plugin-blocker:build: ESM dist/services/website-blocker/access.js.map      2.83 KB
+@elizaos/plugin-blocker:build: ESM dist/components/focus/FocusSpatialView.js.map    8.09 KB
+@elizaos/plugin-blocker:build: ESM dist/db/index.js.map                             138.00 B
+@elizaos/plugin-blocker:build: ESM dist/register.js.map                             872.00 B
+@elizaos/plugin-blocker:build: ESM dist/services/website-blocker/roles.js.map       1.39 KB
+@elizaos/plugin-blocker:build: ESM dist/services/app-blocker/service.js.map         1.55 KB
+@elizaos/plugin-blocker:build: ESM dist/services/app-blocker/access.js.map          2.58 KB
+@elizaos/plugin-blocker:build: ESM dist/services/website-blocker/permissions.js.map 71.00 B
+@elizaos/plugin-blocker:build: ESM dist/services/website-blocker/engine.js.map      76.12 KB
+@elizaos/plugin-blocker:build: ESM dist/services/website-blocker/index.js.map       1.98 KB
+@elizaos/plugin-blocker:build: ESM dist/services/website-blocker/service.js.map     18.17 KB
+@elizaos/plugin-blocker:build: ESM dist/components/focus/focus-view-bundle.js.map   492.00 B
+@elizaos/plugin-blocker:build: ESM ⚡️ Build success in 97ms
+@elizaos/plugin-remote-desktop:typecheck: cache miss, executing e1e5c9dd2cc493da
+@elizaos/plugin-remote-desktop:typecheck: $ tsgo --noEmit -p tsconfig.json --rootDir ../..
+@elizaos/plugin-blocker:build: $ bunx --bun vite build --config vite.config.views.ts
+@elizaos/plugin-todos:build: CLI Building entry: src/types.ts, src/register-terminal-view.tsx, src/index.ts, src/register.ts, src/service.ts, src/providers/current-todos.ts, src/db/schema.ts, src/db/index.ts, src/actions/todo.ts, src/components/todos/todos-view-bundle.ts, src/components/todos/TodosView.tsx, src/components/todos/TodosSpatialView.tsx
+@elizaos/plugin-todos:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-todos:build: CLI tsup v8.5.1
+@elizaos/plugin-todos:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/tsup.plugin-packages.shared.ts
+@elizaos/plugin-todos:build: CLI Target: es2022
+@elizaos/plugin-todos:build: ESM Build start
+@elizaos/plugin-todos:build: ESM dist/types.js                                  586.00 B
+@elizaos/plugin-todos:build: ESM dist/components/todos/TodosSpatialView.js      3.03 KB
+@elizaos/plugin-todos:build: ESM dist/db/schema.js                              1.23 KB
+@elizaos/plugin-todos:build: ESM dist/index.js                                  2.19 KB
+@elizaos/plugin-todos:build: ESM dist/register.js                               183.00 B
+@elizaos/plugin-todos:build: ESM dist/actions/todo.js                           15.60 KB
+@elizaos/plugin-todos:build: ESM dist/register-terminal-view.js                 639.00 B
+@elizaos/plugin-todos:build: ESM dist/db/index.js                               62.00 B
+@elizaos/plugin-todos:build: ESM dist/service.js                                6.74 KB
+@elizaos/plugin-todos:build: ESM dist/providers/current-todos.js                1.25 KB
+@elizaos/plugin-todos:build: ESM dist/components/todos/TodosView.js             4.44 KB
+@elizaos/plugin-todos:build: ESM dist/components/todos/todos-view-bundle.js     113.00 B
+@elizaos/plugin-todos:build: ESM dist/actions/todo.js.map                       30.91 KB
+@elizaos/plugin-todos:build: ESM dist/register-terminal-view.js.map             1.60 KB
+@elizaos/plugin-todos:build: ESM dist/db/index.js.map                           138.00 B
+@elizaos/plugin-todos:build: ESM dist/service.js.map                            13.90 KB
+@elizaos/plugin-todos:build: ESM dist/providers/current-todos.js.map            2.97 KB
+@elizaos/plugin-todos:build: ESM dist/db/schema.js.map                          2.36 KB
+@elizaos/plugin-todos:build: ESM dist/register.js.map                           860.00 B
+@elizaos/plugin-todos:build: ESM dist/types.js.map                              1.63 KB
+@elizaos/plugin-todos:build: ESM dist/components/todos/TodosSpatialView.js.map  7.19 KB
+@elizaos/plugin-todos:build: ESM dist/index.js.map                              3.31 KB
+@elizaos/plugin-todos:build: ESM dist/components/todos/TodosView.js.map         12.39 KB
+@elizaos/plugin-todos:build: ESM dist/components/todos/todos-view-bundle.js.map 473.00 B
+@elizaos/plugin-todos:build: ESM ⚡️ Build success in 39ms
+@elizaos/plugin-todos:build: $ bunx --bun vite build --config vite.config.views.ts
+@elizaos/plugin-web-search:typecheck: cache miss, executing 0208c5886bd08f53
+@elizaos/plugin-blocker:build: vite v8.0.16 building client environment for production...
+@elizaos/plugin-web-search:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-blocker:build: [2K@elizaos/plugin-blocker:build: transforming...✓ 4 modules transformed.
+@elizaos/plugin-blocker:build: rendering chunks...
+@elizaos/plugin-blocker:build: computing gzip size...
+@elizaos/plugin-blocker:build: dist/views/bundle.js  5.86 kB │ gzip: 1.87 kB │ map: 16.56 kB
+@elizaos/plugin-blocker:build:
+@elizaos/plugin-blocker:build: ✓ built in 107ms
+@elizaos/plugin-todos:build: vite v8.0.16 building client environment for production...
+@elizaos/plugin-blocker:build: $ bunx tsc --noCheck -p tsconfig.build.json && node ../../packages/scripts/rewrite-dist-relative-imports-node-esm.mjs
+@elizaos/plugin-todos:build: [2K@elizaos/plugin-todos:build: transforming...✓ 4 modules transformed.
+@elizaos/plugin-todos:build: rendering chunks...
+@elizaos/plugin-social-alpha:typecheck: cache miss, executing 2ab361459250772f
+@elizaos/plugin-todos:build: computing gzip size...
+@elizaos/plugin-social-alpha:typecheck: $ node ../../packages/scripts/with-package-build-lock.mjs packages/ui -- tsgo --noEmit -p tsconfig.build.json
+@elizaos/plugin-todos:build: dist/views/bundle.js  5.85 kB │ gzip: 2.09 kB │ map: 19.33 kB
+@elizaos/plugin-todos:build:
+@elizaos/plugin-todos:build: ✓ built in 31ms
+@elizaos/ui:typecheck: cache miss, executing c38a286c2668de16
+@elizaos/plugin-todos:build: $ tsc --noCheck -p tsconfig.build.json
+@elizaos/ui:typecheck: $ bun run generate:css-strings && tsgo --noEmit -p tsconfig.json
+@elizaos/ui:typecheck: $ node ../scripts/generate-css-strings.mjs
+@elizaos/ui:typecheck: [generate-css-strings] processed 0 target(s), updated 0
+@elizaos/contracts:typecheck: cache miss, executing 7eb0cfebc7b1bc77
+@elizaos/contracts:typecheck: $ tsgo --noEmit
+@elizaos/example-browser-extension-safari:typecheck: cache miss, executing 68cb5540421e49dd
+@elizaos/example-browser-extension-safari:typecheck: $ echo 'No TypeScript config; skipping typecheck'
+@elizaos/example-browser-extension-safari:typecheck: No TypeScript config; skipping typecheck
+@elizaos/plugin-localdb:typecheck: cache miss, executing d80cb450ff98ef76
+@elizaos/plugin-localdb:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/example-agent-console:typecheck: cache miss, executing d6c6f4a6032826cd
+@elizaos/example-agent-console:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-video:typecheck: cache miss, executing 4cebcf8e94579787
+@elizaos/plugin-video:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-ainex:typecheck: cache miss, executing c6d251f3d716a2c9
+@elizaos/plugin-ainex:typecheck: $ tsgo --noEmit
+@elizaos/macosalarm:typecheck: cache miss, executing 268ed2be8213de4d
+@elizaos/macosalarm:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/operator:typecheck: cache miss, executing 61b0ca19cc92ae9c
+@elizaos/operator:typecheck: $ tsgo --noEmit
+@elizaos/logger:typecheck: cache miss, executing b89d0a84cd08a4ce
+@elizaos/logger:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/vault:typecheck: cache miss, executing 8b59b87ba9abcb71
+@elizaos/vault:typecheck: $ tsgo --noEmit -p tsconfig.json
+@moltbook/eliza-agent:typecheck: cache miss, executing 40397891f2df9dfb
+@moltbook/eliza-agent:typecheck: $ tsgo --noEmit
+@elizaos/plugin-calendly:typecheck: cache miss, executing 2aaed86e75b5d597
+@elizaos/plugin-calendly:typecheck: $ tsgo --noEmit
+@elizaos/plugin-elizacloud:typecheck: cache miss, executing ca325292651f8d88
+@elizaos/plugin-elizacloud:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-documents:typecheck: cache miss, executing 26d0863a33979897
+@elizaos/plugin-documents:typecheck: $ tsgo --noEmit -p tsconfig.build.json
+@elizaos/plugin-streaming:typecheck: cache miss, executing e0baefe122192435
+@elizaos/plugin-streaming:typecheck: $ tsgo --noEmit
+@elizaos/plugin-nostr:typecheck: cache miss, executing 061d3f573a06aa8a
+@elizaos/plugin-nostr:typecheck: $ tsgo --noEmit
+@elizaos/example-game-of-life:typecheck: cache miss, executing c5e6a39d898fd3c1
+@elizaos/example-game-of-life:typecheck: $ tsgo --noEmit
+@elizaos/setup:typecheck: cache miss, executing a393b114a7a32330
+@elizaos/plugin-polymarket:typecheck: cache miss, executing 213a0bb0cdea5b2b
+@elizaos/setup:typecheck: $ tsgo --noEmit -p tsconfig.json&& tsgo --noEmit -p tsconfig.main.json
+@elizaos/plugin-polymarket:typecheck: $ tsgo --noEmit -p tsconfig.build.json
+@elizaos/plugin-mcp:typecheck: cache miss, executing 3faac8cb8cdb27b1
+@elizaos/plugin-mcp:typecheck: $ tsgo --noEmit
+@elizaos/plugin-github:typecheck: cache miss, executing 7ef4d8241a2b11db
+@elizaos/plugin-github:typecheck: $ tsgo --noEmit
+@elizaos/plugin-messages:typecheck: cache miss, executing 99ffa0bac2eaedc9
+@elizaos/plugin-messages:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/example-app-capacitor:typecheck: cache miss, executing 2ef5f635f38cb8cd
+@elizaos/example-app-capacitor:typecheck: $ echo 'No TypeScript config; skipping typecheck'
+@elizaos/example-app-capacitor:typecheck: No TypeScript config; skipping typecheck
+@elizaos/plugin-tunnel:typecheck: cache miss, executing 6022bbde5ef41652
+@elizaos/plugin-tunnel:typecheck: $ tsgo --noEmit
+@elizaos/plugin-ollama:typecheck: cache miss, executing 3a2f0020163a3918
+@elizaos/plugin-ollama:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/os-android-system-ui:typecheck: cache miss, executing fbb9bd2dce52faff
+@elizaos/os-android-system-ui:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-google-chat:typecheck: cache miss, executing c4afa825040335d5
+@elizaos/plugin-google-chat:typecheck: $ tsgo --noEmit
+@elizaos/plugin-zai:typecheck: cache miss, executing e25240b9c409e619
+@elizaos/plugin-zai:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-twitch:typecheck: cache miss, executing 2a4c16bb4c56ef2f
+@elizaos/plugin-twitch:typecheck: $ tsgo --noEmit
+@elizaos/example-browser-extension:typecheck: cache miss, executing 3eeb929c03d5d5ce
+@elizaos/example-browser-extension:typecheck: $ echo 'No TypeScript config; skipping typecheck'
+@elizaos/example-browser-extension:typecheck: No TypeScript config; skipping typecheck
+@elizaos/plugin-ngrok:typecheck: cache miss, executing 53dafdd54bc000b8
+@elizaos/plugin-phone:typecheck: cache miss, executing 24ed570a69b5c4cd
+@elizaos/plugin-ngrok:typecheck: $ tsgo --noEmit
+@elizaos/plugin-phone:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-line:typecheck: cache miss, executing 39cb071bad2857d1
+@elizaos/plugin-line:typecheck: $ tsgo --noEmit
+@elizaos/plugin-aosp-local-inference:typecheck: cache miss, executing a6772ac5d1064f7a
+@elizaos/plugin-aosp-local-inference:typecheck: $ tsgo -p tsconfig.json --noEmit
+@elizaos/plugin-x402:typecheck: cache miss, executing a453842fd5d77161
+@elizaos/plugin-x402:typecheck: $ tsgo --noEmit
+@elizaos/plugin-vector-browser:typecheck: cache miss, executing 81a8913aeb5296b0
+@elizaos/plugin-vector-browser:typecheck: $ tsgo --noEmit -p tsconfig.build.json
+@elizaos/plugin-imessage:typecheck: cache miss, executing c0702636bcbf33a2
+elizaos-cloudflare-worker:typecheck: cache miss, executing b0d418167e1700be
+@elizaos/plugin-imessage:typecheck: $ tsgo --noEmit
+elizaos-cloudflare-worker:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/vercel-edge-examples:typecheck: cache miss, executing 6553bf80c824c5e1
+@elizaos/coding-remote-runner:typecheck: cache miss, executing 5f4a9c8497982dea
+@elizaos/vercel-edge-examples:typecheck: $ tsgo --noEmit
+@elizaos/coding-remote-runner:typecheck: $ tsgo --noEmit
+@elizaos/native-activity-tracker:typecheck: cache miss, executing 4fba144d0c065d08
+@elizaos/native-activity-tracker:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/example-app-capacitor-frontend:typecheck: cache miss, executing 91609df23f1d19e4
+@elizaos/example-app-capacitor-frontend:typecheck: $ tsc --noEmit
+@elizaos/agent:typecheck: cache miss, executing ae5b8d4bdef09010
+@elizaos/agent:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/example-mcp-server:typecheck: cache miss, executing 4a1d3e2a980d18e4
+@elizaos/example-mcp-server:typecheck: $ tsgo --noEmit
+@elizaos/plugin-wifi:typecheck: cache miss, executing 6115d350bf921c38
+@elizaos/plugin-wifi:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-registry:typecheck: cache miss, executing 4df3d6dd0db29750
+@elizaos/plugin-registry:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/os-usb-installer:typecheck: cache miss, executing b57fb66a647a172b
+@elizaos/os-usb-installer:typecheck: $ tsgo --noEmit -p tsconfig.json
+elizagotchi:typecheck: cache miss, executing 8040813553b79545
+elizagotchi:typecheck: $ tsgo --noEmit
+@elizaos/plugin-workflow:typecheck: cache miss, executing 19235d8da70aedaa
+@elizaos/plugin-workflow:typecheck: $ tsgo --noEmit -p tsconfig.typecheck.json
+@elizaos/plugin-embeddings:typecheck: cache miss, executing e5142c543871b265
+@elizaos/plugin-embeddings:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-discord-local:typecheck: cache miss, executing d599fe1a08fd5f05
+@elizaos/plugin-discord-local:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-blocker:build: [rewrite-dist-relative-imports] rewrote 11 file(s)
+@elizaos/plugin-tee:typecheck: cache miss, executing 3406cb36e339268d
+@elizaos/plugin-tee:typecheck: $ tsgo --noEmit
+@elizaos/plugin-bluebubbles:typecheck: cache miss, executing 208caf4f77ee9007
+@elizaos/plugin-feishu:typecheck: cache miss, executing 8de2bda2b660f880
+@elizaos/plugin-bluebubbles:typecheck: $ tsgo --noEmit
+@elizaos/plugin-feishu:typecheck: $ tsgo --noEmit
+@elizaos/plugin-groq:typecheck: cache miss, executing e0bdbe6e8a965260
+@elizaos/plugin-groq:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-slack:typecheck: cache miss, executing cabcb23a07540691
+@elizaos/plugin-finances:typecheck: cache miss, executing 9635a1a9ac1a1f39
+@elizaos/plugin-slack:typecheck: $ tsgo --noEmit
+@elizaos/plugin-finances:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/example-lp-manager:typecheck: cache miss, executing 7aa51d777c564b75
+@elizaos/example-lp-manager:typecheck: $ tsgo --noEmit
+@elizaos/cloud-e2e:typecheck: cache miss, executing 8af8db21ffc6546b
+@elizaos/cloud-e2e:typecheck: $ tsc --noEmit
+@elizaos/plugin-blocker:typecheck: cache miss, executing a9ca7f5ac52e1f66
+@elizaos/plugin-blocker:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-nearai:typecheck: cache miss, executing 9963ed8ade98eac4
+@elizaos/plugin-nearai:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-agent-skills:typecheck: cache miss, executing cc0ce3bfdcbf3bc5
+@elizaos/plugin-agent-skills:typecheck: $ tsgo --noEmit
+@elizaos/example-clone-ur-crush:typecheck: cache miss, executing 77cd024efedbf1ca
+@elizaos/example-clone-ur-crush:typecheck: $ tsgo --noEmit
+@elizaos/prompts:typecheck: cache miss, executing 367a91159b423ed3
+@elizaos/prompts:typecheck: $ echo 'No TypeScript source files to check'
+@elizaos/prompts:typecheck: No TypeScript source files to check
+@elizaos/plugin-form:typecheck: cache miss, executing cf6d678e4aba569a
+@elizaos/plugin-form:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/robot:typecheck: cache miss, executing 7d7b5af8c8b7a69c
+@elizaos/robot:typecheck: $ tsgo --noEmit
+@elizaos/plugin-sql:typecheck: cache miss, executing c295832c74c3772b
+@elizaos/plugin-sql:typecheck: $ tsgo --noEmit -p src/tsconfig.json
+@elizaos/plugin-screenshare:typecheck: cache miss, executing b0578987902d6f4a
+@elizaos/plugin-screenshare:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-reminders:typecheck: cache miss, executing f95dea8e8b538f38
+@elizaos/plugin-reminders:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-x:typecheck: cache miss, executing 25cd62c1a9e6110d
+@elizaos/plugin-x:typecheck: $ tsgo --noEmit
+@elizaos/plugin-relationships:typecheck: cache miss, executing ed1ae4f9a69437a0
+@elizaos/plugin-relationships:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/os-homepage:typecheck: cache miss, executing 086b8caee76528de
+@elizaos/os-homepage:typecheck: $ tsc -b
+@elizaos/example-x402-image-gen:typecheck: cache miss, executing dfd5e7fc59b9c7de
+@elizaos/example-x402-image-gen:typecheck: $ tsgo --noEmit
+@elizaos/plugin-scheduling:typecheck: cache miss, executing 5b37b04591fb8961
+@elizaos/plugin-scheduling:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-remote-manifest:typecheck: cache miss, executing c1b009756eab776d
+@elizaos/plugin-remote-manifest:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/skills:typecheck: cache miss, executing 93b60f8bf6fc489d
+@elizaos/skills:typecheck: $ tsgo --noEmit -p tsconfig.build.json
+@elizaos/plugin-openai:typecheck: cache miss, executing 1fd447971d02a8d3
+@elizaos/plugin-openai:typecheck: $ tsgo --noEmit
+@elizaos/gateway-discord:typecheck: cache miss, executing d6e62b09d2183485
+@elizaos/gateway-discord:typecheck: $ tsgo --noEmit
+@elizaos/example-farcaster:typecheck: cache miss, executing 69e746651e11fac6
+@elizaos/example-farcaster:typecheck: $ tsgo --noEmit
+@elizaos/example-app-capacitor-backend:typecheck: cache miss, executing cf9d1a7917c5019c
+@elizaos/example-app-capacitor-backend:typecheck: $ tsc --noEmit
+@elizaos/agent-server:typecheck: cache miss, executing 61d873c661b56761
+@elizaos/agent-server:typecheck: $ tsgo --noEmit
+@elizaos/plugin-pdf:typecheck: cache miss, executing 6ea74293c60e9b96
+@elizaos/plugin-pdf:typecheck: $ tsgo --noEmit
+@elizaos/plugin-starter:typecheck: cache miss, executing 61b53d8ae3b03697
+@elizaos/plugin-starter:typecheck: $ tsgo --noEmit
+@elizaos/plugin-wallet-ui:typecheck: cache miss, executing f0b1c259465d5c5a
+@elizaos/plugin-wallet-ui:typecheck: $ tsgo --noEmit -p tsconfig.build.json
+@elizaos/example-form:typecheck: cache miss, executing 5b919f3c291c051b
+@elizaos/example-form:typecheck: $ bun run --cwd ../chat typecheck
+@elizaos/example-form:typecheck: $ tsgo --noEmit
+@elizaos/cloud-routing:typecheck: cache miss, executing 7c0cfe57bb44942a
+@elizaos/cloud-routing:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-benchmarks:typecheck: cache miss, executing 23d8109b18a6ca1f
+@elizaos/plugin-instagram:typecheck: cache miss, executing a185d8ca13fb7d70
+@elizaos/plugin-benchmarks:typecheck: $ tsgo --noEmit
+@elizaos/plugin-instagram:typecheck: $ tsgo --noEmit
+@elizaos/interrupt-bench:typecheck: cache miss, executing c6a4a8a326437c7d
+@elizaos/interrupt-bench:typecheck: $ tsgo --noEmit
+@elizaos/plugin-finances:build: cache miss, executing 0e83e4a450f2a73c
+@elizaos/plugin-finances:build: $ bun run build:js && bun run build:views && bun run build:types
+@elizaos/plugin-finances:build: $ tsup --config ../tsup.plugin-packages.shared.ts
+@elizaos/example-discord:typecheck: cache miss, executing 4d16593e0638aa88
+@elizaos/plugin-goals:build: cache miss, executing a703b58813c3838b
+@elizaos/plugin-goals:build: $ bun run build:js && bun run build:views && bun run build:types
+@elizaos/example-discord:typecheck: $ tsgo --noEmit
+@elizaos/plugin-goals:build: $ tsup --config ../tsup.plugin-packages.shared.ts
+@elizaos/plugin-calendar:build: cache miss, executing c0c31d271a3a2183
+@elizaos/plugin-calendar:build: $ bun run build:js && bun run build:views && bun run build:types
+@elizaos/plugin-calendar:build: $ bun run clean && tsup --config tsup.config.ts
+@elizaos/plugin-calendar:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist .turbo
+@elizaos/plugin-finances:build: CLI Building entry: src/subscriptions-types.ts, src/payment-recurrence.ts, src/token-encryption.ts, src/plugin.ts, src/payment-types.ts, src/types.ts, src/finance-normalize.ts, src/payment-csv-import.ts, src/register-terminal-view.tsx, src/finances-service.ts, src/subscriptions-playbooks.ts, src/index.ts, src/register.ts, src/actions/finances.ts, src/db/schema.ts, src/db/finances-repository.ts, src/db/sql.ts, src/db/index.ts, src/services/migration.ts, src/services/gmail-seam.ts, src/services/subscriptions-service.ts, src/services/browser-bridge-seam.ts, src/components/finances/FinancesView.tsx, src/components/finances/finances-view-bundle.ts, src/components/finances/FinancesSpatialView.tsx
+@elizaos/plugin-finances:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-finances:build: CLI tsup v8.5.1
+@elizaos/plugin-finances:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/tsup.plugin-packages.shared.ts
+@elizaos/plugin-finances:build: CLI Target: es2022
+@elizaos/plugin-finances:build: ESM Build start
+@elizaos/plugin-finances:build: ESM dist/db/index.js                                     152.00 B
+@elizaos/plugin-finances:build: ESM dist/payment-types.js                                41.00 B
+@elizaos/plugin-finances:build: ESM dist/subscriptions-types.js                          47.00 B
+@elizaos/plugin-finances:build: ESM dist/services/gmail-seam.js                          7.32 KB
+@elizaos/plugin-finances:build: ESM dist/types.js                                        266.00 B
+@elizaos/plugin-finances:build: ESM dist/services/subscriptions-service.js               35.66 KB
+@elizaos/plugin-finances:build: ESM dist/finance-normalize.js                            1.70 KB
+@elizaos/plugin-finances:build: ESM dist/db/schema.js                                    4.89 KB
+@elizaos/plugin-finances:build: ESM dist/payment-csv-import.js                           7.12 KB
+@elizaos/plugin-finances:build: ESM dist/services/browser-bridge-seam.js                 1.13 KB
+@elizaos/plugin-finances:build: ESM dist/register-terminal-view.js                       622.00 B
+@elizaos/plugin-finances:build: ESM dist/db/sql.js                                       5.34 KB
+@elizaos/plugin-finances:build: ESM dist/finances-service.js                             38.52 KB
+@elizaos/plugin-finances:build: ESM dist/db/finances-repository.js                       18.88 KB
+@elizaos/plugin-finances:build: ESM dist/components/finances/finances-view-bundle.js     125.00 B
+@elizaos/plugin-finances:build: ESM dist/subscriptions-playbooks.js                      30.35 KB
+@elizaos/plugin-finances:build: ESM dist/components/finances/FinancesView.js             7.00 KB
+@elizaos/plugin-finances:build: ESM dist/index.js                                        2.82 KB
+@elizaos/plugin-finances:build: ESM dist/payment-recurrence.js                           6.11 KB
+@elizaos/plugin-finances:build: ESM dist/register.js                                     186.00 B
+@elizaos/plugin-finances:build: ESM dist/token-encryption.js                             3.05 KB
+@elizaos/plugin-finances:build: ESM dist/services/migration.js                           3.78 KB
+@elizaos/plugin-finances:build: ESM dist/plugin.js                                       1.39 KB
+@elizaos/plugin-finances:build: ESM dist/components/finances/FinancesSpatialView.js      5.60 KB
+@elizaos/plugin-finances:build: ESM dist/actions/finances.js                             9.92 KB
+@elizaos/plugin-finances:build: ESM dist/finance-normalize.js.map                        3.60 KB
+@elizaos/plugin-finances:build: ESM dist/finances-service.js.map                         70.41 KB
+@elizaos/plugin-finances:build: ESM dist/subscriptions-playbooks.js.map                  54.77 KB
+@elizaos/plugin-finances:build: ESM dist/components/finances/FinancesView.js.map         19.61 KB
+@elizaos/plugin-finances:build: ESM dist/services/migration.js.map                       9.79 KB
+@elizaos/plugin-finances:build: ESM dist/subscriptions-types.js.map                      71.00 B
+@elizaos/plugin-finances:build: ESM dist/services/browser-bridge-seam.js.map             4.17 KB
+@elizaos/plugin-finances:build: ESM dist/components/finances/finances-view-bundle.js.map 565.00 B
+@elizaos/plugin-finances:build: ESM dist/db/schema.js.map                                10.32 KB
+@elizaos/plugin-finances:build: ESM dist/token-encryption.js.map                         6.93 KB
+@elizaos/plugin-finances:build: ESM dist/plugin.js.map                                   2.42 KB
+@elizaos/plugin-finances:build: ESM dist/services/gmail-seam.js.map                      15.58 KB
+@elizaos/plugin-finances:build: ESM dist/db/sql.js.map                                   13.04 KB
+@elizaos/plugin-finances:build: ESM dist/payment-csv-import.js.map                       14.39 KB
+@elizaos/plugin-finances:build: ESM dist/db/index.js.map                                 217.00 B
+@elizaos/plugin-finances:build: ESM dist/db/finances-repository.js.map                   34.76 KB
+@elizaos/plugin-finances:build: ESM dist/register-terminal-view.js.map                   1.51 KB
+@elizaos/plugin-finances:build: ESM dist/services/subscriptions-service.js.map           66.84 KB
+@elizaos/plugin-finances:build: ESM dist/register.js.map                                 869.00 B
+@elizaos/plugin-finances:build: ESM dist/actions/finances.js.map                         19.67 KB
+@elizaos/plugin-finances:build: ESM dist/components/finances/FinancesSpatialView.js.map  12.37 KB
+@elizaos/plugin-finances:build: ESM dist/types.js.map                                    2.31 KB
+@elizaos/plugin-finances:build: ESM dist/payment-types.js.map                            71.00 B
+@elizaos/plugin-finances:build: ESM dist/payment-recurrence.js.map                       12.71 KB
+@elizaos/plugin-finances:build: ESM dist/index.js.map                                    4.07 KB
+@elizaos/plugin-finances:build: ESM ⚡️ Build success in 62ms
+@elizaos/plugin-finances:build: $ bunx --bun vite build --config vite.config.views.ts
+@elizaos/plugin-goals:build: CLI Building entry: src/goals-runtime.ts, src/goal-grounding.ts, src/plugin.ts, src/goals-service.ts, src/types.ts, src/register-terminal-view.tsx, src/goal-semantic-evaluator.ts, src/goal-normalize.ts, src/index.ts, src/register.ts, src/db/schema.ts, src/db/sql.ts, src/db/goals-repository.ts, src/db/index.ts, src/actions/goals.ts, src/services/migration.ts, src/services/checkin.ts, src/components/goals/GoalsSpatialView.tsx, src/components/goals/goals-view-bundle.ts, src/components/goals/GoalsView.tsx
+@elizaos/plugin-goals:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-goals:build: CLI tsup v8.5.1
+@elizaos/plugin-goals:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/tsup.plugin-packages.shared.ts
+@elizaos/plugin-goals:build: CLI Target: es2022
+@elizaos/plugin-goals:build: ESM Build start
+@elizaos/plugin-goals:build: ESM dist/goals-runtime.js                          1.29 KB
+@elizaos/plugin-goals:build: ESM dist/services/migration.js                     3.63 KB
+@elizaos/plugin-goals:build: ESM dist/services/checkin.js                       1.23 KB
+@elizaos/plugin-goals:build: ESM dist/components/goals/GoalsView.js             4.35 KB
+@elizaos/plugin-goals:build: ESM dist/components/goals/goals-view-bundle.js     113.00 B
+@elizaos/plugin-goals:build: ESM dist/components/goals/GoalsSpatialView.js      5.20 KB
+@elizaos/plugin-goals:build: ESM dist/db/sql.js                                 3.85 KB
+@elizaos/plugin-goals:build: ESM dist/actions/goals.js                          4.85 KB
+@elizaos/plugin-goals:build: ESM dist/db/index.js                               62.00 B
+@elizaos/plugin-goals:build: ESM dist/db/goals-repository.js                    7.89 KB
+@elizaos/plugin-goals:build: ESM dist/goal-grounding.js                         4.86 KB
+@elizaos/plugin-goals:build: ESM dist/plugin.js                                 1.88 KB
+@elizaos/plugin-goals:build: ESM dist/goal-normalize.js                         2.63 KB
+@elizaos/plugin-goals:build: ESM dist/types.js                                  915.00 B
+@elizaos/plugin-goals:build: ESM dist/index.js                                  1.32 KB
+@elizaos/plugin-goals:build: ESM dist/db/schema.js                              2.07 KB
+@elizaos/plugin-goals:build: ESM dist/register-terminal-view.js                 622.00 B
+@elizaos/plugin-goals:build: ESM dist/register.js                               183.00 B
+@elizaos/plugin-goals:build: ESM dist/goals-service.js                          8.98 KB
+@elizaos/plugin-goals:build: ESM dist/goal-semantic-evaluator.js                7.59 KB
+@elizaos/plugin-goals:build: ESM dist/plugin.js.map                             3.14 KB
+@elizaos/plugin-goals:build: ESM dist/goals-runtime.js.map                      3.68 KB
+@elizaos/plugin-goals:build: ESM dist/goal-grounding.js.map                     10.63 KB
+@elizaos/plugin-goals:build: ESM dist/actions/goals.js.map                      9.57 KB
+@elizaos/plugin-goals:build: ESM dist/services/checkin.js.map                   2.56 KB
+@elizaos/plugin-goals:build: ESM dist/db/index.js.map                           138.00 B
+@elizaos/plugin-goals:build: ESM dist/components/goals/GoalsView.js.map         12.17 KB
+@elizaos/plugin-goals:build: ESM dist/services/migration.js.map                 8.50 KB
+@elizaos/plugin-goals:build: ESM dist/db/sql.js.map                             8.28 KB
+@elizaos/plugin-goals:build: ESM dist/db/goals-repository.js.map                15.34 KB
+@elizaos/plugin-goals:build: ESM dist/db/schema.js.map                          4.39 KB
+@elizaos/plugin-goals:build: ESM dist/goal-normalize.js.map                     5.62 KB
+@elizaos/plugin-goals:build: ESM dist/register-terminal-view.js.map             1.58 KB
+@elizaos/plugin-goals:build: ESM dist/index.js.map                              1.81 KB
+@elizaos/plugin-goals:build: ESM dist/goals-service.js.map                      19.27 KB
+@elizaos/plugin-goals:build: ESM dist/register.js.map                           846.00 B
+@elizaos/plugin-goals:build: ESM dist/components/goals/GoalsSpatialView.js.map  11.45 KB
+@elizaos/plugin-goals:build: ESM dist/goal-semantic-evaluator.js.map            13.67 KB
+@elizaos/plugin-goals:build: ESM dist/types.js.map                              4.19 KB
+@elizaos/plugin-goals:build: ESM dist/components/goals/goals-view-bundle.js.map 473.00 B
+@elizaos/plugin-goals:build: ESM ⚡️ Build success in 37ms
+@elizaos/plugin-goals:build: $ bunx --bun vite build --config vite.config.views.ts
+@elizaos/plugin-finances:build: vite v8.0.16 building client environment for production...
+@elizaos/plugin-finances:build: [2K@elizaos/plugin-finances:build: transforming...✓ 4 modules transformed.
+@elizaos/plugin-finances:build: rendering chunks...
+@elizaos/plugin-calendar:build: CLI Building entry: src/plugin.ts, src/apple-calendar.ts, src/register-terminal-view.tsx, src/ui.ts, src/index.ts, src/register.ts, src/internal/sql.ts, src/internal/errors.ts, src/internal/detail.ts, src/internal/format.ts, src/internal/constants.ts, src/internal/normalize.ts, src/internal/google-delegates.ts, src/internal/calendar-normalize.ts, src/internal/time.ts, src/components/EventEditorDrawer.tsx, src/components/CalendarSection.tsx, src/api/client-calendar.ts, src/actions/conflict-detect.ts, src/actions/calendar.ts, src/actions/optimized-prompt-instructions.ts, src/actions/index.ts, src/actions/deps.ts, src/actions/calendar-handler.ts, src/hooks/useCalendarWeek.ts, src/service/schema.ts, src/service/CalendarService.ts, src/service/migration.ts, src/service/gate.ts, src/service/feed-preferences.ts, src/service/index.ts, src/service/CalendarRepository.ts, src/routes/calendar-routes.ts, src/routes/plugin-routes.ts, src/components/calendar/calendar-view-bundle.ts, src/components/calendar/CalendarView.tsx, src/components/calendar/CalendarSpatialView.tsx
+@elizaos/plugin-calendar:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-calendar:build: CLI tsup v8.5.1
+@elizaos/plugin-calendar:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/plugin-calendar/tsup.config.ts
+@elizaos/plugin-calendar:build: CLI Target: es2022
+@elizaos/plugin-finances:build: computing gzip size...
+@elizaos/plugin-calendar:build: ESM Build start
+@elizaos/plugin-finances:build: dist/views/bundle.js  9.58 kB │ gzip: 2.86 kB │ map: 31.59 kB
+@elizaos/plugin-finances:build:
+@elizaos/plugin-finances:build: ✓ built in 59ms
+@elizaos/plugin-finances:build: $ bunx tsc --noCheck -p tsconfig.build.json && node ../../packages/scripts/rewrite-dist-relative-imports-node-esm.mjs
+@elizaos/plugin-goals:build: vite v8.0.16 building client environment for production...
+@elizaos/plugin-goals:build: [2K@elizaos/plugin-goals:build: transforming...✓ 5 modules transformed.
+@elizaos/plugin-calendar:build: ESM dist/internal/calendar-normalize.js                  9.73 KB
+@elizaos/plugin-calendar:build: ESM dist/internal/time.js                                3.56 KB
+@elizaos/plugin-calendar:build: ESM dist/service/schema.js                               2.47 KB
+@elizaos/plugin-calendar:build: ESM dist/plugin.js                                       1.58 KB
+@elizaos/plugin-calendar:build: ESM dist/apple-calendar.js                               14.93 KB
+@elizaos/plugin-calendar:build: ESM dist/actions/calendar.js                             3.89 KB
+@elizaos/plugin-calendar:build: ESM dist/components/CalendarSection.js                   36.39 KB
+@elizaos/plugin-calendar:build: ESM dist/register-terminal-view.js                       652.00 B
+@elizaos/plugin-calendar:build: ESM dist/routes/calendar-routes.js                       4.77 KB
+@elizaos/plugin-calendar:build: ESM dist/api/client-calendar.js                          3.28 KB
+@elizaos/plugin-calendar:build: ESM dist/ui.js                                           306.00 B
+@elizaos/plugin-calendar:build: ESM dist/routes/plugin-routes.js                         7.47 KB
+@elizaos/plugin-calendar:build: ESM dist/index.js                                        1.44 KB
+@elizaos/plugin-calendar:build: ESM dist/components/calendar/CalendarView.js             3.59 KB
+@elizaos/plugin-calendar:build: ESM dist/hooks/useCalendarWeek.js                        3.75 KB
+@elizaos/plugin-calendar:build: ESM dist/register.js                                     186.00 B
+@elizaos/plugin-calendar:build: ESM dist/actions/optimized-prompt-instructions.js        5.12 KB
+@elizaos/plugin-calendar:build: ESM dist/actions/conflict-detect.js                      2.56 KB
+@elizaos/plugin-calendar:build: ESM dist/internal/sql.js                                 3.39 KB
+@elizaos/plugin-calendar:build: ESM dist/internal/errors.js                              389.00 B
+@elizaos/plugin-calendar:build: ESM dist/service/migration.js                            3.74 KB
+@elizaos/plugin-calendar:build: ESM dist/components/calendar/CalendarSpatialView.js      3.63 KB
+@elizaos/plugin-calendar:build: ESM dist/internal/detail.js                              1.84 KB
+@elizaos/plugin-calendar:build: ESM dist/actions/calendar-handler.js                     116.71 KB
+@elizaos/plugin-calendar:build: ESM dist/service/CalendarRepository.js                   9.84 KB
+@elizaos/plugin-calendar:build: ESM dist/internal/format.js                              4.43 KB
+@elizaos/plugin-calendar:build: ESM dist/internal/constants.js                           1.39 KB
+@elizaos/plugin-calendar:build: ESM dist/service/CalendarService.js                      26.04 KB
+@elizaos/plugin-calendar:build: ESM dist/actions/index.js                                264.00 B
+@elizaos/plugin-calendar:build: ESM dist/internal/normalize.js                           4.41 KB
+@elizaos/plugin-calendar:build: ESM dist/internal/time.js.map                            6.83 KB
+@elizaos/plugin-calendar:build: ESM dist/actions/deps.js                                 32.00 B
+@elizaos/plugin-calendar:build: ESM dist/internal/google-delegates.js                    13.62 KB
+@elizaos/plugin-calendar:build: ESM dist/service/schema.js.map                           5.19 KB
+@elizaos/plugin-calendar:build: ESM dist/apple-calendar.js.map                           30.46 KB
+@elizaos/plugin-calendar:build: ESM dist/components/calendar/calendar-view-bundle.js     125.00 B
+@elizaos/plugin-calendar:build: ESM dist/plugin.js.map                                   2.66 KB
+@elizaos/plugin-calendar:build: ESM dist/internal/calendar-normalize.js.map              17.80 KB
+@elizaos/plugin-calendar:build: ESM dist/service/gate.js                                 3.19 KB
+@elizaos/plugin-calendar:build: ESM dist/service/feed-preferences.js                     3.35 KB
+@elizaos/plugin-calendar:build: ESM dist/components/EventEditorDrawer.js                 29.93 KB
+@elizaos/plugin-calendar:build: ESM dist/service/index.js                                1.14 KB
+@elizaos/plugin-calendar:build: ESM dist/hooks/useCalendarWeek.js.map                    8.03 KB
+@elizaos/plugin-calendar:build: ESM dist/actions/calendar.js.map                         8.66 KB
+@elizaos/plugin-calendar:build: ESM dist/service/migration.js.map                        8.52 KB
+@elizaos/plugin-calendar:build: ESM dist/api/client-calendar.js.map                      8.77 KB
+@elizaos/plugin-calendar:build: ESM dist/index.js.map                                    2.03 KB
+@elizaos/plugin-calendar:build: ESM dist/actions/optimized-prompt-instructions.js.map    5.98 KB
+@elizaos/plugin-calendar:build: ESM dist/components/calendar/CalendarSpatialView.js.map  7.94 KB
+@elizaos/plugin-calendar:build: ESM dist/internal/sql.js.map                             7.16 KB
+@elizaos/plugin-calendar:build: ESM dist/ui.js.map                                       984.00 B
+@elizaos/plugin-calendar:build: ESM dist/internal/google-delegates.js.map                26.08 KB
+@elizaos/plugin-calendar:build: ESM dist/actions/conflict-detect.js.map                  5.74 KB
+@elizaos/plugin-calendar:build: ESM dist/internal/detail.js.map                          4.09 KB
+@elizaos/plugin-calendar:build: ESM dist/components/EventEditorDrawer.js.map             49.41 KB
+@elizaos/plugin-calendar:build: ESM dist/routes/plugin-routes.js.map                     15.10 KB
+@elizaos/plugin-calendar:build: ESM dist/service/feed-preferences.js.map                 7.29 KB
+@elizaos/plugin-calendar:build: ESM dist/components/calendar/CalendarView.js.map         7.48 KB
+@elizaos/plugin-calendar:build: ESM dist/register.js.map                                 792.00 B
+@elizaos/plugin-calendar:build: ESM dist/internal/constants.js.map                       2.20 KB
+@elizaos/plugin-calendar:build: ESM dist/service/CalendarRepository.js.map               18.06 KB
+@elizaos/plugin-calendar:build: ESM dist/internal/format.js.map                          8.49 KB
+@elizaos/plugin-calendar:build: ESM dist/actions/deps.js.map                             71.00 B
+@elizaos/plugin-calendar:build: ESM dist/internal/errors.js.map                          917.00 B
+@elizaos/plugin-calendar:build: ESM dist/components/CalendarSection.js.map               63.79 KB
+@elizaos/plugin-calendar:build: ESM dist/routes/calendar-routes.js.map                   11.95 KB
+@elizaos/plugin-calendar:build: ESM dist/service/CalendarService.js.map                  48.50 KB
+@elizaos/plugin-calendar:build: ESM dist/service/gate.js.map                             7.78 KB
+@elizaos/plugin-calendar:build: ESM dist/actions/calendar-handler.js.map                 209.52 KB
+@elizaos/plugin-calendar:build: ESM dist/internal/normalize.js.map                       8.06 KB
+@elizaos/plugin-calendar:build: ESM dist/register-terminal-view.js.map                   1.65 KB
+@elizaos/plugin-calendar:build: ESM dist/components/calendar/calendar-view-bundle.js.map 491.00 B
+@elizaos/plugin-calendar:build: ESM dist/actions/index.js.map                            539.00 B
+@elizaos/plugin-calendar:build: ESM dist/service/index.js.map                            1.18 KB
+@elizaos/plugin-calendar:build: ESM ⚡️ Build success in 50ms
+@elizaos/plugin-goals:build: rendering chunks...
+@elizaos/plugin-goals:build: computing gzip size...
+@elizaos/plugin-goals:build: dist/views/bundle.js  7.16 kB │ gzip: 2.43 kB │ map: 26.91 kB
+@elizaos/plugin-goals:build:
+@elizaos/plugin-goals:build: ✓ built in 33ms
+@elizaos/plugin-calendar:build: $ bunx --bun vite build --config vite.config.views.ts
+@elizaos/plugin-goals:build: $ tsc --noCheck -p tsconfig.build.json && node ../../packages/scripts/rewrite-dist-relative-imports-node-esm.mjs
+@elizaos/plugin-calendar:build: vite v8.0.16 building client environment for production...
+@elizaos/plugin-calendar:build: [2K@elizaos/plugin-calendar:build: transforming...✓ 6 modules transformed.
+@elizaos/plugin-inbox:build: cache miss, executing 458555c33ccc2000
+@elizaos/plugin-inbox:build: $ bun run build:js && bun run build:views && bun run build:types
+@elizaos/plugin-inbox:build: $ tsup --config ../tsup.plugin-packages.shared.ts
+@elizaos/plugin-calendar:build: rendering chunks...
+@elizaos/plugin-calendar:build: computing gzip size...
+@elizaos/plugin-calendar:build: dist/views/bundle.js  9.82 kB │ gzip: 3.12 kB │ map: 30.92 kB
+@elizaos/plugin-calendar:build:
+@elizaos/plugin-calendar:build: ✓ built in 62ms
+@elizaos/plugin-calendar:build: $ tsc --noCheck -p tsconfig.build.json
+@elizaos/plugin-inbox:build: CLI Building entry: src/plugin.ts, src/types.ts, src/register-terminal-view.tsx, src/index.ts, src/register.ts, src/inbox/unsubscribe-repository.ts, src/inbox/repository.ts, src/inbox/migration.ts, src/inbox/message-fetcher.ts, src/inbox/triage-classifier.ts, src/inbox/email-unsubscribe-types.ts, src/inbox/email-curation.ts, src/inbox/unsubscribe-service.ts, src/inbox/types.ts, src/inbox/gmail-normalize.ts, src/inbox/reflection.ts, src/inbox/google-gmail-seam.ts, src/inbox/config.ts, src/inbox/channel-deep-links.ts, src/inbox/service.ts, src/providers/inbox-triage.ts, src/providers/cross-channel-context.ts, src/actions/inbox.ts, src/db/schema.ts, src/db/sql.ts, src/db/index.ts, src/components/inbox/InboxView.tsx, src/components/inbox/inbox-view-bundle.ts, src/components/inbox/InboxSpatialView.tsx
+@elizaos/plugin-inbox:build: CLI Using tsconfig: tsconfig.json
+@elizaos/plugin-inbox:build: CLI tsup v8.5.1
+@elizaos/plugin-inbox:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/tsup.plugin-packages.shared.ts
+@elizaos/plugin-inbox:build: CLI Target: es2022
+@elizaos/plugin-inbox:build: ESM Build start
+@elizaos/plugin-inbox:build: ESM dist/plugin.js                                 1.82 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/migration.js                        3.69 KB
+@elizaos/plugin-inbox:build: ESM dist/components/inbox/InboxView.js             5.15 KB
+@elizaos/plugin-inbox:build: ESM dist/components/inbox/InboxSpatialView.js      5.48 KB
+@elizaos/plugin-inbox:build: ESM dist/providers/inbox-triage.js                 3.48 KB
+@elizaos/plugin-inbox:build: ESM dist/plugin.js.map                             2.54 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/config.js                           1.25 KB
+@elizaos/plugin-inbox:build: ESM dist/register-terminal-view.js                 589.00 B
+@elizaos/plugin-inbox:build: ESM dist/inbox/triage-classifier.js                10.66 KB
+@elizaos/plugin-inbox:build: ESM dist/providers/cross-channel-context.js        3.88 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/channel-deep-links.js               3.24 KB
+@elizaos/plugin-inbox:build: ESM dist/types.js                                  402.00 B
+@elizaos/plugin-inbox:build: ESM dist/db/sql.js                                 3.85 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/message-fetcher.js                  16.01 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/migration.js.map                    8.50 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/gmail-normalize.js                  33.78 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/service.js                          9.78 KB
+@elizaos/plugin-inbox:build: ESM dist/actions/inbox.js                          10.53 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/email-unsubscribe-types.js          51.00 B
+@elizaos/plugin-inbox:build: ESM dist/inbox/email-curation.js                   35.62 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/types.js                            33.00 B
+@elizaos/plugin-inbox:build: ESM dist/providers/cross-channel-context.js.map    8.08 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/unsubscribe-repository.js           3.64 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/reflection.js                       4.88 KB
+@elizaos/plugin-inbox:build: ESM dist/components/inbox/InboxView.js.map         15.20 KB
+@elizaos/plugin-inbox:build: ESM dist/db/index.js                               88.00 B
+@elizaos/plugin-inbox:build: ESM dist/index.js                                  1.80 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/triage-classifier.js.map            20.03 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/repository.js                       12.45 KB
+@elizaos/plugin-inbox:build: ESM dist/providers/inbox-triage.js.map             6.44 KB
+@elizaos/plugin-inbox:build: ESM dist/register.js                               183.00 B
+@elizaos/plugin-inbox:build: ESM dist/inbox/unsubscribe-service.js              11.98 KB
+@elizaos/plugin-inbox:build: ESM dist/db/schema.js                              2.92 KB
+@elizaos/plugin-inbox:build: ESM dist/components/inbox/InboxSpatialView.js.map  11.72 KB
+@elizaos/plugin-inbox:build: ESM dist/components/inbox/inbox-view-bundle.js     113.00 B
+@elizaos/plugin-inbox:build: ESM dist/types.js.map                              2.40 KB
+@elizaos/plugin-inbox:build: ESM dist/db/sql.js.map                             8.28 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/message-fetcher.js.map              31.70 KB
+@elizaos/plugin-inbox:build: ESM dist/register-terminal-view.js.map             1.48 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/channel-deep-links.js.map           6.33 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/google-gmail-seam.js                8.84 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/config.js.map                       2.85 KB
+@elizaos/plugin-inbox:build: ESM dist/actions/inbox.js.map                      22.60 KB
+@elizaos/plugin-inbox:build: ESM dist/db/index.js.map                           177.00 B
+@elizaos/plugin-inbox:build: ESM dist/inbox/service.js.map                      21.59 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/email-curation.js.map               70.76 KB
+@elizaos/plugin-inbox:build: ESM dist/index.js.map                              3.30 KB
+@elizaos/plugin-inbox:build: ESM dist/register.js.map                           845.00 B
+@elizaos/plugin-inbox:build: ESM dist/db/schema.js.map                          6.12 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/reflection.js.map                   9.33 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/gmail-normalize.js.map              63.16 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/types.js.map                        71.00 B
+@elizaos/plugin-inbox:build: ESM dist/components/inbox/inbox-view-bundle.js.map 473.00 B
+@elizaos/plugin-inbox:build: ESM dist/inbox/unsubscribe-service.js.map          23.24 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/email-unsubscribe-types.js.map      71.00 B
+@elizaos/plugin-inbox:build: ESM dist/inbox/repository.js.map                   23.59 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/google-gmail-seam.js.map            19.46 KB
+@elizaos/plugin-inbox:build: ESM dist/inbox/unsubscribe-repository.js.map       7.06 KB
+@elizaos/plugin-inbox:build: ESM ⚡️ Build success in 41ms
+@elizaos/plugin-inbox:build: $ bunx --bun vite build --config vite.config.views.ts
+@elizaos/plugin-trajectory-logger:typecheck: cache miss, executing 3aae3747a210f128
+@elizaos/plugin-trajectory-logger:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-inbox:build: vite v8.0.16 building client environment for production...
+@elizaos/plugin-inbox:build: [2K@elizaos/plugin-inbox:build: transforming...✓ 5 modules transformed.
+@elizaos/plugin-inbox:build: rendering chunks...
+@elizaos/plugin-inbox:build: computing gzip size...
+@elizaos/plugin-inbox:build: dist/views/bundle.js  7.40 kB │ gzip: 2.70 kB │ map: 28.44 kB
+@elizaos/plugin-inbox:build:
+@elizaos/plugin-inbox:build: ✓ built in 192ms
+@elizaos/plugin-inbox:build: $ tsc --noCheck -p tsconfig.build.json && node ../../packages/scripts/rewrite-dist-relative-imports-node-esm.mjs
+trajectory-viewer:typecheck: cache miss, executing 59e804c15ea8d1f3
+trajectory-viewer:typecheck: $ tsc --noEmit
+@elizaos/plugin-codex-cli:typecheck: cache miss, executing f48102e64886818f
+@elizaos/plugin-codex-cli:typecheck: $ tsgo --noEmit
+@elizaos/plugin-goals:build: [rewrite-dist-relative-imports] rewrote 8 file(s)
+@elizaos/security:typecheck: cache miss, executing 4e06d7fa636185b4
+@elizaos/security:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/gateway-webhook:typecheck: cache miss, executing c29eeeaa4ed2b16e
+@elizaos/gateway-webhook:typecheck: $ tsgo --noEmit
+@elizaos/three-agent-dialogue:typecheck: cache miss, executing d162645ec7f17e5a
+@elizaos/three-agent-dialogue:typecheck: $ tsgo --noEmit
+@elizaos/plugin-whatsapp:typecheck: cache miss, executing 3ff160bc7a4f3d04
+@elizaos/plugin-whatsapp:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos-examples/html-eliza:typecheck: cache miss, executing 41c7660b8f0bf6a7
+@elizaos-examples/html-eliza:typecheck: $ echo 'No TypeScript config; skipping typecheck'
+@elizaos-examples/html-eliza:typecheck: No TypeScript config; skipping typecheck
+@elizaos/container-control-plane:typecheck: cache miss, executing 7be2deb1bf5e8cc5
+@elizaos/container-control-plane:typecheck: $ tsgo --noEmit
+@elizaos/scenario-runner:build: cache miss, executing da51350be7fac66f
+@elizaos/scenario-runner:build: $ tsc --noCheck -p tsconfig.build.json
+@elizaos/plugin-native-settings:typecheck: cache miss, executing 2451c7faa0fd6fde
+@elizaos/plugin-native-settings:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-inmemorydb:typecheck: cache miss, executing 0940c9583680989e
+@elizaos/plugin-inmemorydb:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-suno:typecheck: cache miss, executing 9e236f8e923e3341
+@elizaos/plugin-suno:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-google-genai:typecheck: cache miss, executing 64588f889551aa7a
+@elizaos/plugin-google-genai:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/aws-examples:typecheck: cache miss, executing db32866ece3fc853
+@elizaos/aws-examples:typecheck: $ tsgo --noEmit
+@elizaos/plugin-agent-orchestrator:typecheck: cache miss, executing e04e357a7f08dbd9
+eliza-multichain-miniapp:typecheck: cache miss, executing 12abaa7d7144f409
+@elizaos/plugin-agent-orchestrator:typecheck: $ tsgo --noEmit -p tsconfig.json
+eliza-multichain-miniapp:typecheck: $ tsgo --noEmit
+@elizaos/example-smartglasses:typecheck: cache miss, executing e7b104c41f7eef60
+@elizaos/example-smartglasses:typecheck: $ bun run --cwd ../../../plugins/plugin-facewear build && node ../../../packages/scripts/ensure-workspace-symlinks.mjs && BUN_INSTALL_CACHE_DIR=/tmp/eliza-bun-cache-clean bunx --package typescript@6.0.3 tsc --noEmit -p tsconfig.json
+@elizaos/example-smartglasses:typecheck: $ bun run build:js && bun run build:views && bun run build:types
+@elizaos/example-smartglasses:typecheck: $ tsup --config ../tsup.plugin-packages.shared.ts
+@elizaos/example-smartglasses:typecheck: CLI Building entry: src/register-terminal-view.tsx, src/status-format.ts, src/index.ts, src/register.ts, src/ui/SmartglassesView.helpers.ts, src/ui/facewear-view-bundle.ts, src/ui/SmartglassesView.tsx, src/providers/smartglasses-status.ts, src/providers/facewear-context.ts, src/transport/mock.ts, src/transport/even-bridge.ts, src/transport/web-bluetooth.ts, src/transport/types.ts, src/transport/noble.ts, src/runtime/node-probe.ts, src/runtime/openxr-runtime.ts, src/protocol/xr.ts, src/protocol/smartglasses.ts, src/components/SmartglassesSpatialView.tsx, src/components/facewear-profiles.ts, src/components/SmartglassesPanelView.tsx, src/components/WearablesSettingsSection.tsx, src/components/FacewearView.tsx, src/components/FacewearSpatialView.tsx, src/actions/vision-query.ts, src/actions/microphone.ts, src/actions/xr-runtime-setup.ts, src/actions/facewear-control.ts, src/actions/facewear-connect.ts, src/actions/display-text.ts, src/actions/xr-view-actions.ts, src/actions/facewear-status.ts, src/actions/view-actions.ts, src/actions/facewear-debug.ts, src/routes/status.ts, src/routes/views.ts, src/routes/view-host.ts, src/routes/simulator-route.ts, src/routes/device-config.ts, src/routes/connect.ts, src/routes/xr-runtime.ts, src/services/smartglasses-service.ts, src/services/facewear-service.ts, src/services/audio-pipeline.ts, src/services/xr-session-service.ts, src/services/vision-pipeline.ts, src/devices/meta-quest.ts, src/devices/even-realities.ts, src/devices/registry.ts, src/devices/apple-vision-pro.ts, src/devices/xreal.ts
+@elizaos/example-smartglasses:typecheck: CLI Using tsconfig: tsconfig.json
+@elizaos/example-smartglasses:typecheck: CLI tsup v8.5.1
+@elizaos/example-smartglasses:typecheck: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/tsup.plugin-packages.shared.ts
+@elizaos/example-smartglasses:typecheck: CLI Target: es2022
+@elizaos/example-smartglasses:typecheck: ESM Build start
+@elizaos/example-smartglasses:typecheck: ESM dist/register-terminal-view.js                  1.88 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/services/xr-session-service.js             11.17 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/components/FacewearSpatialView.js          5.81 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/routes/status.js                           831.00 B
+@elizaos/example-smartglasses:typecheck: ESM dist/runtime/openxr-runtime.js                  7.39 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/components/SmartglassesSpatialView.js      8.44 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/components/facewear-profiles.js            1.04 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/components/SmartglassesPanelView.js        3.86 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/transport/even-bridge.js                   18.27 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/components/WearablesSettingsSection.js     2.03 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/transport/web-bluetooth.js                 4.97 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/transport/types.js                         33.00 B
+@elizaos/example-smartglasses:typecheck: ESM dist/transport/noble.js                         7.85 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/facewear-debug.js                  1.86 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/routes/views.js                            945.00 B
+@elizaos/example-smartglasses:typecheck: ESM dist/transport/mock.js                          3.15 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/protocol/xr.js                             607.00 B
+@elizaos/example-smartglasses:typecheck: ESM dist/status-format.js                           3.17 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/components/FacewearView.js                 3.18 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/runtime/node-probe.js                      1.63 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/devices/even-realities.js                  491.00 B
+@elizaos/example-smartglasses:typecheck: ESM dist/devices/registry.js                        2.41 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/devices/apple-vision-pro.js                532.00 B
+@elizaos/example-smartglasses:typecheck: ESM dist/services/vision-pipeline.js                1.29 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/devices/xreal.js                           501.00 B
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/facewear-status.js                 2.72 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/view-actions.js                    11.41 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/facewear-connect.js                2.72 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/providers/smartglasses-status.js           2.08 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/display-text.js                    3.20 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/xr-view-actions.js                 892.00 B
+@elizaos/example-smartglasses:typecheck: ESM dist/transport/even-bridge.js.map               36.73 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/routes/view-host.js                        11.79 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/routes/views.js.map                        1.96 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/devices/meta-quest.js                      398.00 B
+@elizaos/example-smartglasses:typecheck: ESM dist/index.js                                   9.88 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/facewear-control.js                22.98 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/register.js                                804.00 B
+@elizaos/example-smartglasses:typecheck: ESM dist/register-terminal-view.js.map              4.04 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/runtime/openxr-runtime.js.map              16.76 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/protocol/smartglasses.js                   43.80 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/ui/SmartglassesView.helpers.js             9.39 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/components/SmartglassesSpatialView.js.map  15.82 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/routes/simulator-route.js                  1.08 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/components/facewear-profiles.js.map        2.97 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/ui/facewear-view-bundle.js                 242.00 B
+@elizaos/example-smartglasses:typecheck: ESM dist/services/xr-session-service.js.map         21.86 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/components/SmartglassesPanelView.js.map    8.60 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/vision-query.js                    1.45 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/components/FacewearSpatialView.js.map      11.55 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/ui/SmartglassesView.js                     41.98 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/routes/view-host.js.map                    14.82 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/transport/noble.js.map                     17.48 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/routes/status.js.map                       1.54 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/microphone.js                      2.37 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/devices/xreal.js.map                       817.00 B
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/xr-runtime-setup.js                2.45 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/facewear-status.js.map             4.48 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/devices/meta-quest.js.map                  683.00 B
+@elizaos/example-smartglasses:typecheck: ESM dist/services/vision-pipeline.js.map            2.70 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/facewear-control.js.map            42.18 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/routes/device-config.js                    1.47 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/facewear-debug.js.map              3.44 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/providers/facewear-context.js              2.12 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/status-format.js.map                       5.94 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/protocol/xr.js.map                         4.91 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/transport/web-bluetooth.js.map             11.25 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/services/audio-pipeline.js                 2.66 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/ui/SmartglassesView.js.map                 67.09 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/services/smartglasses-service.js           27.81 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/transport/mock.js.map                      7.34 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/services/facewear-service.js               1.36 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/devices/apple-vision-pro.js.map            817.00 B
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/view-actions.js.map                21.53 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/transport/types.js.map                     71.00 B
+@elizaos/example-smartglasses:typecheck: ESM dist/components/WearablesSettingsSection.js.map 3.83 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/index.js.map                               13.12 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/runtime/node-probe.js.map                  3.44 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/ui/facewear-view-bundle.js.map             843.00 B
+@elizaos/example-smartglasses:typecheck: ESM dist/routes/device-config.js.map                2.67 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/vision-query.js.map                2.80 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/routes/connect.js                          3.36 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/ui/SmartglassesView.helpers.js.map         20.44 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/routes/simulator-route.js.map              2.00 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/xr-view-actions.js.map             1.27 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/routes/xr-runtime.js                       561.00 B
+@elizaos/example-smartglasses:typecheck: ESM dist/providers/facewear-context.js.map          3.76 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/providers/smartglasses-status.js.map       3.67 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/microphone.js.map                  4.16 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/register.js.map                            1.97 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/devices/even-realities.js.map              667.00 B
+@elizaos/example-smartglasses:typecheck: ESM dist/devices/registry.js.map                    4.62 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/display-text.js.map                5.89 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/facewear-connect.js.map            4.62 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/actions/xr-runtime-setup.js.map            4.62 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/services/audio-pipeline.js.map             5.76 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/services/facewear-service.js.map           2.95 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/protocol/smartglasses.js.map               75.46 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/routes/xr-runtime.js.map                   1.19 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/services/smartglasses-service.js.map       54.51 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/components/FacewearView.js.map             7.30 KB
+@elizaos/example-smartglasses:typecheck: ESM dist/routes/connect.js.map                      4.60 KB
+@elizaos/example-smartglasses:typecheck: ESM ⚡️ Build success in 57ms
+@elizaos/example-smartglasses:typecheck: $ bunx --bun vite build --config vite.config.views.ts
+@elizaos/example-smartglasses:typecheck: vite v8.0.16 building client environment for production...
+@elizaos/example-smartglasses:typecheck: [2K@elizaos/example-smartglasses:typecheck: transforming...✓ 9 modules transformed.
+@elizaos/example-smartglasses:typecheck: rendering chunks...
+@elizaos/example-smartglasses:typecheck: computing gzip size...
+@elizaos/example-smartglasses:typecheck: dist/views/bundle.js  19.35 kB │ gzip: 5.08 kB │ map: 109.04 kB
+@elizaos/example-smartglasses:typecheck:
+@elizaos/example-smartglasses:typecheck: ✓ built in 40ms
+@elizaos/example-smartglasses:typecheck: $ bunx tsc --noCheck -p tsconfig.build.json && node ../../packages/scripts/rewrite-dist-relative-imports-node-esm.mjs
+@elizaos/plugin-inbox:typecheck: cache miss, executing a711fd2a939d6421
+@elizaos/plugin-inbox:typecheck: $ tsgo --noEmit -p tsconfig.json
+bags-claimer:typecheck: cache miss, executing 949d91e3a21c68ce
+bags-claimer:typecheck: $ echo 'No TypeScript config; skipping typecheck'
+bags-claimer:typecheck: No TypeScript config; skipping typecheck
+@elizaos/plugin-computeruse:typecheck: cache miss, executing 801178b53c5953d7
+@elizaos/plugin-computeruse:typecheck: $ tsgo --noEmit
+@elizaos/plugin-bluesky:typecheck: cache miss, executing 8daf9e24ab51d254
+@elizaos/plugin-bluesky:typecheck: $ tsgo --noEmit
+@elizaos/app-model-tester:typecheck: cache miss, executing 8d4aa0a062a48dfb
+@elizaos/app-model-tester:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-xai:typecheck: cache miss, executing 2107d9ae8285ad1b
+@elizaos/plugin-xai:typecheck: $ tsgo --noEmit
+eliza-next-example:typecheck: cache miss, executing 49fa326dd1739e5e
+eliza-next-example:typecheck: $ tsgo --noEmit
+@elizaos/plugin-cli:typecheck: cache miss, executing 028e7da71e5371fa
+@elizaos/plugin-cli:typecheck: $ tsgo --noEmit
+@elizaos/plugin-shopify:typecheck: cache miss, executing 18aec01309330636
+@elizaos/plugin-shopify:typecheck: $ tsgo --noEmit -p tsconfig.build.json
+@elizaos-benchmarks/lib:typecheck: cache miss, executing 754903a9f87c010a
+@elizaos-benchmarks/lib:typecheck: $ tsgo --noEmit
+@elizaos/example-smartglasses:typecheck: [rewrite-dist-relative-imports] rewrote 25 file(s)
+@elizaos/tui:typecheck: cache miss, executing 1b9cc18e3e477433
+@elizaos/tui:typecheck: $ tsgo --noEmit -p tsconfig.build.json
+@elizaos/soc2-verify:typecheck: cache miss, executing 19ac38173d94e93a
+@elizaos/soc2-verify:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/example-smartglasses:typecheck: [ensure-workspace-symlinks] created=0 skipped=436 hoisted=0 missing-roots=0
+@elizaos/plugin-xr:typecheck: cache miss, executing 64b7e4f16a98ace0
+@elizaos/example-smartglasses:typecheck: Saved lockfile
+@elizaos/example-app-electron-workspace:typecheck: cache miss, executing efa5f0f78c37748e
+@elizaos/plugin-xr:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/example-app-electron-workspace:typecheck: $ echo 'No TypeScript config; skipping typecheck'
+@elizaos/example-app-electron-workspace:typecheck: No TypeScript config; skipping typecheck
+@elizaos/plugin-gitpathologist:typecheck: cache miss, executing 33acc1887d605630
+@elizaos/plugin-gitpathologist:typecheck: $ tsgo --noEmit
+@elizaos/plugin-matrix:typecheck: cache miss, executing bcba24981be3fc5e
+@elizaos/plugin-matrix:typecheck: $ tsgo --noEmit
+@elizaos/plugin-anthropic:typecheck: cache miss, executing c6f1cb9ca92aafde
+@elizaos/plugin-anthropic:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-facewear:typecheck: cache miss, executing c57f83886cfb20f1
+@elizaos/plugin-facewear:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-inbox:build: [rewrite-dist-relative-imports] rewrote 10 file(s)
+@elizaos/plugin-openrouter:typecheck: cache miss, executing edd18d19cb9adc53
+@elizaos/plugin-openrouter:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-browser:typecheck: cache miss, executing 5bc8747e1a289a74
+@elizaos/plugin-browser:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-cli-inference:typecheck: cache miss, executing 58eb00d373897f88
+@elizaos/plugin-cli-inference:typecheck: $ tsgo --noEmit
+@elizaos/registry:typecheck: cache miss, executing 1e4c6b7961e62c6a
+@elizaos/registry:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/cloud-sdk:typecheck: cache miss, executing 8d0b69fec0a9931f
+@elizaos/cloud-sdk:typecheck: $ tsgo --noEmit
+@elizaos/plugin-finances:build: [rewrite-dist-relative-imports] rewrote 8 file(s)
+@elizaos/plugin-farcaster:typecheck: cache miss, executing 73ee32ad10a80e54
+@elizaos/plugin-farcaster:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/bench-eliza-1:typecheck: cache miss, executing 1cb3ec55db4795f4
+@elizaos/bench-eliza-1:typecheck: $ tsgo --noEmit
+@elizaos/plugin-app-manager:typecheck: cache miss, executing e24f0a9f21a8c505
+@elizaos/plugin-app-manager:typecheck: $ tsgo --noEmit --rootDir ../..
+@elizaos/plugin-native-filesystem:typecheck: cache miss, executing 71df2c4edb31bc01
+@elizaos/plugin-native-filesystem:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-task-coordinator:typecheck: cache miss, executing fcbac84a61b2766c
+@elizaos/plugin-task-coordinator:typecheck: $ tsgo --noEmit -p tsconfig.build.json
+@elizaos/plugin-worker-runtime:typecheck: cache miss, executing 35891e3420af84a9
+@elizaos/plugin-worker-runtime:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/electrobun:typecheck: cache miss, executing aeae04c041f27044
+@elizaos/electrobun:typecheck: $ tsgo --noEmit
+@elizaos/core:typecheck: cache miss, executing 503622b8d9de36d1
+@elizaos/core:typecheck: $ tsgo --noEmit -p ./tsconfig.json
+@elizaos/plugin-commands:typecheck: cache miss, executing 6b12bc33e6c4d77d
+@elizaos/plugin-commands:typecheck: $ tsgo --noEmit
+@elizaos/plugin-lmstudio:typecheck: cache miss, executing e4d19deb7ca4a43d
+@elizaos/plugin-goals:typecheck: cache miss, executing 3fe07cfad6301ce1
+@elizaos/plugin-lmstudio:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-goals:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/example-tic-tac-toe:typecheck: cache miss, executing 74f95825bb6d2eb5
+@elizaos/example-tic-tac-toe:typecheck: $ tsgo --noEmit
+@elizaos/shared:typecheck: cache miss, executing ba7c89fea627844a
+@elizaos/shared:typecheck: $ tsgo --noEmit -p tsconfig.json
+elizaos-plugin-echo:typecheck: cache miss, executing 4c5552f1ad226033
+elizaos-plugin-echo:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-edge-tts:typecheck: cache miss, executing f2ff935cda730ba5
+@elizaos/plugin-edge-tts:typecheck: $ tsgo --noEmit
+@elizaos/plugin-local-storage:typecheck: cache miss, executing 9df624024839f90b
+@elizaos/plugin-local-storage:typecheck: $ tsgo --noEmit
+@elizaos/plugin-hyperliquid:typecheck: cache miss, executing 7f8f07314a7ed228
+@elizaos/plugin-hyperliquid:typecheck: $ tsgo --noEmit -p tsconfig.build.json
+@elizaos/plugin-signal:typecheck: cache miss, executing 6fd022366871bcba
+@elizaos/plugin-signal:typecheck: $ tsgo --noEmit
+@elizaos/cloud-services-common:typecheck: cache miss, executing 894276396d74f922
+@elizaos/cloud-services-common:typecheck: $ tsgo --noEmit
+@elizaos/example-autonomous:typecheck: cache miss, executing e257c72e1e232732
+@elizaos/example-autonomous:typecheck: $ tsgo --noEmit
+@elizaos/plugin-shell:typecheck: cache miss, executing 4a3b964c219a8104
+@elizaos/plugin-shell:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/macosreminders:typecheck: cache miss, executing 0296e87106bf32b1
+@elizaos/macosreminders:typecheck: $ tsgo --noEmit -p tsconfig.json
+@elizaos/plugin-elevenlabs:typecheck: cache miss, executing 4ece2501007048be
+@elizaos/plugin-elevenlabs:typecheck: $ tsgo --project tsconfig.json --noEmit
+@elizaos/plugin-google:typecheck: cache miss, executing 58ea46756bbb5384
+@elizaos/plugin-google:typecheck: $ tsgo --noEmit
+@elizaos/plugin-personal-assistant:build: cache miss, executing 916179646ce96ab8
+@elizaos/plugin-personal-assistant:build: $ bun run build:js && bun run build:types
+@elizaos/plugin-personal-assistant:build: $ bun run clean && tsup --config tsup.config.ts
+@elizaos/plugin-personal-assistant:build: $ node ../../packages/scripts/rm-path-recursive.mjs dist
+@elizaos/plugin-personal-assistant:typecheck: cache miss, executing 184a02be65e04a02
+@elizaos/plugin-personal-assistant:typecheck: $ tsc --noEmit -p tsconfig.build.json
+@elizaos/plugin-personal-assistant:build: CLI Building entry: src/plugin.ts, src/automation-node-contributor.ts, src/agent-lifeops.ts, src/client.ts, src/ui.ts, src/index.ts, src/provider.ts, src/service.ts, src/public.ts, src/followup/followup-tracker.ts, src/followup/index.ts, src/travel-time/service.ts, src/travel-time/calendar-create.ts, src/security/action-confirmation.ts, src/types/website-blocker-settings-card.ts, src/types/briefing.ts, src/types/app-blocker-settings-card.ts, src/types/document-request.ts, src/types/index.ts, src/inbox/repository.ts, src/inbox/message-fetcher.ts, src/inbox/types.ts, src/lifeops/feature-flags.ts, src/lifeops/calendar-gate.ts, src/lifeops/schema.ts, src/lifeops/schedule-state.ts, src/lifeops/privacy.ts, src/lifeops/bulk-review.ts, src/lifeops/escalation-ladders.ts, src/lifeops/service-mixin-drive.ts, src/lifeops/service-mixin-discord.ts, src/lifeops/notifications-push.ts, src/lifeops/background-planner.ts, src/lifeops/privacy-egress.ts, src/lifeops/google-plugin-delegates.ts, src/lifeops/service-mixin-calendar.ts, src/lifeops/google-scopes.ts, src/lifeops/cross-channel-search.ts, src/lifeops/repository.ts, src/lifeops/runtime-service-delegates.ts, src/lifeops/service-helpers-browser.ts, src/lifeops/continuity-probe.ts, src/lifeops/browser-session-lifecycle.ts, src/lifeops/service-mixin-relationships.ts, src/lifeops/fda-probe.ts, src/lifeops/service-mixin-reminders.ts, src/lifeops/service-normalize-gmail.ts, src/lifeops/screen-context.ts, src/lifeops/sql.ts, src/lifeops/schedule-insight.ts, src/lifeops/background-planner-dispatch.ts, src/lifeops/goal-grounding.ts, src/lifeops/bill-extraction.ts, src/lifeops/device-identity.ts, src/lifeops/travel-booking.types.ts, src/lifeops/defaults.ts, src/lifeops/time-util.ts, src/lifeops/service-helpers-misc.ts, src/lifeops/browser-constants.ts, src/lifeops/email-classifier.ts, src/lifeops/service-mixin-x.ts, src/lifeops/feature-flags.types.ts, src/lifeops/policy-memory.ts, src/lifeops/service-mixin-screentime.ts, src/lifeops/service-helpers-occurrence.ts, src/lifeops/intent-sync.ts, src/lifeops/service-mixin-inbox.ts, src/lifeops/email-unsubscribe-types.ts, src/lifeops/email-curation.ts, src/lifeops/lifeops-context.ts, src/lifeops/owner-profile.ts, src/lifeops/engine.ts, src/lifeops/service-mixin-status.ts, src/lifeops/seed-routines.ts, src/lifeops/relative-schedule-resolver.ts, src/lifeops/approval-queue.ts, src/lifeops/voice-affect.ts, src/lifeops/service-mixin-gmail.ts, src/lifeops/wave1-types.ts, src/lifeops/service-mixin-subscriptions.ts, src/lifeops/runtime.ts, src/lifeops/service-normalize-task.ts, src/lifeops/runtime-cache.ts, src/lifeops/optimized-prompt-instructions.ts, src/lifeops/approval-queue.types.ts, src/lifeops/browser-extension-store.ts, src/lifeops/service-mixin-core.ts, src/lifeops/contact-route-policy.ts, src/lifeops/service-mixin-definitions.ts, src/lifeops/enforcement-windows.ts, src/lifeops/service-types.ts, src/lifeops/access.ts, src/lifeops/device-bus-service.ts, src/lifeops/service-constants.ts, src/lifeops/service-mixin-whatsapp.ts, src/lifeops/goal-semantic-evaluator.ts, src/lifeops/service-normalize.ts, src/lifeops/redact-sensitive-data.ts, src/lifeops/service-mixin-goals.ts, src/lifeops/priority-scoring.ts, src/lifeops/imessage-outbound-probe.ts, src/lifeops/service-mixin-signal.ts, src/lifeops/service-mixin-travel.ts, src/lifeops/app-state.ts, src/lifeops/service-normalize-connector.ts, src/lifeops/telemetry-mapping.ts, src/lifeops/apple-reminders.ts, src/lifeops/sensitive-request-delivery.ts, src/lifeops/service-mixin-email-unsubscribe.ts, src/lifeops/relative-time.ts, src/lifeops/index.ts, src/lifeops/service-mixin-browser.ts, src/lifeops/telemetry-retention.ts, src/lifeops/document-review.ts, src/lifeops/schedule-sync-config.ts, src/lifeops/scheduler-task.ts, src/lifeops/stretch-decider.ts, src/lifeops/service-mixin-telegram.ts, src/lifeops/schedule-sync-contracts.ts, src/lifeops/service-mixin-health.ts, src/lifeops/service-mixin-scheduling.ts, src/lifeops/autofill-whitelist.ts, src/lifeops/service.ts, src/lifeops/service-mixin-x-read.ts, src/lifeops/service-mixin-google.ts, src/lifeops/service-helpers-reminder.ts, src/lifeops/service-mixin-imessage.ts, src/lifeops/time.ts, src/lifeops/signal-runtime-config.ts, src/lifeops/service-mixin-workflows.ts, src/contracts/lifeops.ts, src/contracts/index.ts, src/providers/work-threads.ts, src/providers/inbox-triage.ts, src/providers/recent-task-states.ts, src/providers/activity-profile.ts, src/providers/room-policy.ts, src/providers/first-run.ts, src/providers/health.ts, src/providers/cross-channel-context.ts, src/providers/lifeops.ts, src/providers/pending-prompts.ts, src/platform/lifeops-github.ts, src/platform/host.ts, src/platform/index.ts, src/utils/index.ts, src/utils/format-duration.ts, src/utils/lifeops-url.ts, src/components/WebsiteBlockerSettingsCard.tsx, src/components/AppBlockerSettingsCard.tsx, src/hooks/useInbox.ts, src/hooks/connector-error.ts, src/hooks/useDiscordConnector.ts, src/hooks/useIMessageConnector.ts, src/hooks/useLifeOpsXConnector.ts, src/hooks/useWhatsAppConnector.ts, src/hooks/useLifeOpsActivitySignals.ts, src/hooks/useLifeOpsAppState.ts, src/hooks/useGoogleLifeOpsConnector.ts, src/hooks/useSignalConnector.ts, src/hooks/useTelegramConnector.ts, src/hooks/useLifeOpsCapabilitiesStatus.ts, src/api/client-lifeops.ts, src/actions/work-thread.ts, src/actions/conflict-detect.ts, src/actions/remote-desktop.ts, src/actions/block.ts, src/actions/schedule.ts, src/actions/website-block.ts, src/actions/screen-time.ts, src/actions/inbox.ts, src/actions/entity.ts, src/actions/connector.ts, src/actions/owner-surfaces.ts, src/actions/document.ts, src/actions/life.ts, src/actions/resolve-request.ts, src/actions/password-manager.ts, src/actions/calendar.ts, src/actions/money.ts, src/actions/prioritize.ts, src/actions/app-block.ts, src/actions/scheduled-task.ts, src/actions/book-travel.ts, src/actions/autofill.ts, src/actions/brief.ts, src/actions/subscriptions.ts, src/actions/health.ts, src/actions/voice-call.ts, src/actions/credentials.ts, src/actions/payments.ts, src/activity-profile/presence-signal-bridge-service.ts, src/activity-profile/activity-tracker-service.ts, src/activity-profile/proactive-planner.ts, src/activity-profile/activity-tracker-repo.ts, src/activity-profile/proactive-worker.ts, src/activity-profile/activity-tracker-reporting.ts, src/activity-profile/types.ts, src/activity-profile/proactive-inbox-digest.ts, src/activity-profile/analyzer.ts, src/activity-profile/profile-metadata.ts, src/activity-profile/redactor.ts, src/activity-profile/focus-session.ts, src/activity-profile/service.ts, src/website-blocker/proactive-block-bridge.ts, src/website-blocker/public.ts, src/events/index.ts, src/routes/relationships.ts, src/routes/travel-provider-relay-routes.ts, src/routes/website-blocker-routes.ts, src/routes/lifeops-routes.ts, src/routes/scheduled-tasks.ts, src/routes/entities.ts, src/routes/plugin.ts, src/routes/sleep-routes.ts, src/routes/cloud-features-routes.ts, src/default-packs/autofill-whitelist-pack.ts, src/default-packs/lint.ts, src/default-packs/escalation-ladders.ts, src/default-packs/morning-brief.ts, src/default-packs/contract-types.ts, src/default-packs/followup-starter.ts, src/default-packs/habit-starters.ts, src/default-packs/consolidation-policies.ts, src/default-packs/inbox-triage-starter.ts, src/default-packs/task-definitions.ts, src/default-packs/quiet-user-watcher.ts, src/default-packs/registry-types.ts, src/default-packs/executive-assistant.ts, src/default-packs/index.ts, src/default-packs/daily-rhythm.ts, src/followup/actions/listOverdueFollowups.ts, src/followup/actions/markFollowupDone.ts, src/followup/actions/setFollowupThreshold.ts, src/lifeops/domains/workflows-service.ts, src/lifeops/domains/google-service.ts, src/lifeops/domains/gmail-service.ts, src/lifeops/domains/drive-service.ts, src/lifeops/domains/signal-service.ts, src/lifeops/domains/telegram-service.ts, src/lifeops/domains/goals-service.ts, src/lifeops/domains/subscriptions-service.ts, src/lifeops/domains/whatsapp-service.ts, src/lifeops/domains/email-unsubscribe-service.ts, src/lifeops/domains/screentime-service.ts, src/lifeops/domains/discord-service.ts, src/lifeops/domains/relationships-service.ts, src/lifeops/domains/definitions-service.ts, src/lifeops/domains/scheduling-service.ts, src/lifeops/domains/health-service.ts, src/lifeops/domains/sleep-service.ts, src/lifeops/domains/calendar-service.ts, src/lifeops/domains/status-service.ts, src/lifeops/domains/travel-service.ts, src/lifeops/domains/reminders-service.ts, src/lifeops/domains/inbox-service.ts, src/lifeops/domains/x-service.ts, src/lifeops/domains/browser-service.ts, src/lifeops/domains/imessage-service.ts, src/lifeops/domains/x-read-service.ts, src/lifeops/work-threads/types.ts, src/lifeops/work-threads/field-evaluator-thread-ops.ts, src/lifeops/work-threads/index.ts, src/lifeops/work-threads/store.ts, src/lifeops/validate/coding-task-request.ts, src/lifeops/connectors/_helpers.ts, src/lifeops/connectors/twilio.ts, src/lifeops/connectors/contract.ts, src/lifeops/connectors/mockoon-redirect.ts, src/lifeops/connectors/duffel.ts, src/lifeops/connectors/x.ts, src/lifeops/connectors/google.ts, src/lifeops/connectors/imessage.ts, src/lifeops/connectors/discord.ts, src/lifeops/connectors/telegram.ts, src/lifeops/connectors/registry.ts, src/lifeops/connectors/default-pack.ts, src/lifeops/connectors/whatsapp.ts, src/lifeops/connectors/index.ts, src/lifeops/connectors/dispatch-policy.ts, src/lifeops/connectors/signal.ts, src/lifeops/connectors/calendly.ts, src/lifeops/owner/fact-store.ts, src/lifeops/owner/profile-extraction-evaluator.ts, src/lifeops/registries/feature-flag-registry.ts, src/lifeops/registries/workflow-step-registry.ts, src/lifeops/registries/website-blocker-contribution.ts, src/lifeops/registries/event-kind-registry.ts, src/lifeops/registries/index.ts, src/lifeops/registries/app-blocker-contribution.ts, src/lifeops/registries/blocker-registry.ts, src/lifeops/registries/feature-flag-default-pack.ts, src/lifeops/registries/family-registry.ts, src/lifeops/registries/workflow-step-default-pack.ts, src/lifeops/pending-prompts/store.ts, src/lifeops/send-policy/contract.ts, src/lifeops/send-policy/registry.ts, src/lifeops/send-policy/index.ts, src/lifeops/global-pause/store.ts, src/lifeops/handoff/store.ts, src/lifeops/triggers/schedule-once.ts, src/lifeops/google/format-helpers.ts, src/lifeops/signals/bus.ts, src/lifeops/seed-routine-migration/migrator.ts, src/lifeops/scheduled-task/runtime-wiring.ts, src/lifeops/scheduled-task/scheduler.ts, src/lifeops/scheduled-task/index.ts, src/lifeops/scheduled-task/service.ts, src/lifeops/time/timezone.ts, src/lifeops/voice/grounded-reply.ts, src/lifeops/first-run/state.ts, src/lifeops/first-run/defaults.ts, src/lifeops/first-run/replay.ts, src/lifeops/first-run/questions.ts, src/lifeops/first-run/service.ts, src/lifeops/checkin/checkin-service.ts, src/lifeops/checkin/schedule-resolver.ts, src/lifeops/checkin/types.ts, src/lifeops/i18n/localized-examples-resolver.ts, src/lifeops/i18n/prompt-registry.ts, src/lifeops/i18n/localized-examples-provider.ts, src/lifeops/messaging/owner-send-policy.ts, src/lifeops/messaging/index.ts, src/lifeops/entities/voice-attribution.ts, src/lifeops/entities/types.ts, src/lifeops/entities/voice-observer-bridge.ts, src/lifeops/entities/voice-observer.ts, src/lifeops/entities/index.ts, src/lifeops/entities/merge.ts, src/lifeops/entities/store.ts, src/lifeops/relationships/mapping.ts, src/lifeops/relationships/extraction.ts, src/lifeops/relationships/types.ts, src/lifeops/relationships/index.ts, src/lifeops/relationships/store.ts, src/lifeops/channels/priority-posture.ts, src/lifeops/channels/contract.ts, src/lifeops/channels/registry.ts, src/lifeops/channels/default-pack.ts, src/lifeops/channels/index.ts, src/actions/lib/extract-life-operation.ts, src/actions/lib/extract-update-fields.ts, src/actions/lib/extract-task-plan.ts, src/actions/lib/extract-goal-plan.ts, src/actions/lib/lifeops-deferred-draft.ts, src/actions/lib/messaging-helpers.ts, src/actions/lib/scheduling-handler.ts, src/actions/lib/calendly-handler.ts, src/actions/lib/prompt-format.ts, src/actions/lib/owner-policy-writes.ts, src/website-blocker/chat-integration/block-rule-reconciler.ts, src/website-blocker/chat-integration/block-rule-schema.ts, src/website-blocker/chat-integration/block-activator.ts, src/website-blocker/chat-integration/harsh-mode-check.ts, src/website-blocker/chat-integration/index.ts, src/website-blocker/chat-integration/block-rule-service.ts
+@elizaos/plugin-personal-assistant:build: CLI Using tsconfig: ../../tsconfig.json
+@elizaos/plugin-personal-assistant:build: CLI tsup v8.5.1
+@elizaos/plugin-personal-assistant:build: CLI Using tsup config: /Users/shawwalters/.codex/worktrees/36cd/eliza/plugins/plugin-personal-assistant/tsup.config.ts
+@elizaos/plugin-personal-assistant:build: CLI Target: es2022
+@elizaos/plugin-personal-assistant:build: ESM Build start
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/privacy-egress.js                                     7.49 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/background-planner.js                                 12.38 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/email-curation.js                                     102.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/proactive-worker.js                          26.30 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/habit-starters.js                               8.48 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/activity-tracker-reporting.js                4.76 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/activity-tracker-service.js                  5.88 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-discord.js                              49.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/google-plugin-delegates.js                            13.79 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/routes/relationships.js                                       6.97 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/work-thread.js                                        20.64 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/types.js                                     706.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/document.js                                           19.42 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/routes/website-blocker-routes.js                              6.29 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/website-blocker/proactive-block-bridge.js                     4.61 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/owner-surfaces.js                                     16.54 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/service.js                                   9.30 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/routes/entities.js                                            6.91 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/schedule.js                                           5.95 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/proactive-planner.js                         19.65 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/resolve-request.js                                    12.43 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/lifeops-context.js                                    43.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/website-block.js                                      27.33 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/consolidation-policies.js                       378.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/routes/scheduled-tasks.js                                     3.87 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/intent-sync.js                                        10.89 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/connector.js                                          41.80 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/website-blocker/public.js                                     1.58 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/routes/lifeops-routes.js                                      77.47 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/conflict-detect.js                                    9.46 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/components/WebsiteBlockerSettingsCard.js                      5.36 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/inbox.js                                              290.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/activity-tracker-repo.js                     1.94 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/proactive-inbox-digest.js                    750.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/inbox-triage-starter.js                         2.33 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/routes/plugin.js                                              21.32 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-calendar.js                             50.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/life.js                                               87.12 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/brief.js                                              15.47 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/routes/travel-provider-relay-routes.js                        216.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/screen-time.js                                        1.54 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useWhatsAppConnector.js                                 1.47 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/remote-desktop.js                                     290.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/notifications-push.js                                 3.17 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useLifeOpsActivitySignals.js                            12.61 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/lint.js                                         5.39 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/money.js                                              1.39 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/connector-error.js                                      284.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/api/client-lifeops.js                                         26.15 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/task-definitions.js                             3.34 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/prioritize.js                                         16.47 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/analyzer.js                                  19.74 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-inbox.js                                381.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/subscriptions.js                                      11.32 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/habit-starters.js.map                           15.54 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useDiscordConnector.js                                  2.59 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/owner-profile.js                                      13.89 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/block.js                                              10.03 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/routes/sleep-routes.js                                        889.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/quiet-user-watcher.js                           3.54 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/app-block.js                                          12.72 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/proactive-worker.js.map                      48.57 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/entity.js                                             27.87 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/events/index.js                                               1.09 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useLifeOpsAppState.js                                   1.93 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/platform/index.js                                             97.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/google-scopes.js                                      4.32 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/health.js                                             1.11 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/activity-tracker-reporting.js.map            10.67 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/escalation-ladders.js                           536.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/profile-metadata.js                          597.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/registry-types.js                               42.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useIMessageConnector.js                                 1.47 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/stretch-decider.js                                    2.03 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/components/AppBlockerSettingsCard.js                          20.83 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/utils/index.js                                                105.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/scheduled-task.js                                     20.54 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/password-manager.js                                   6.90 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/redactor.js                                  786.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/first-run.js                                        4.10 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/utils/format-duration.js                                      382.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/book-travel.js                                        15.82 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/voice-call.js                                         22.76 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/activity-tracker-service.js.map              11.41 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/payments.js                                           149.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useLifeOpsXConnector.js                                 2.21 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/health.js                                           463.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/apple-reminders.js                                    11.07 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/engine.js                                             17.81 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useInbox.js                                             3.11 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useGoogleLifeOpsConnector.js                            20.56 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/presence-signal-bridge-service.js            5.22 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/routes/cloud-features-routes.js                               5.38 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-normalize.js                                  1.32 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/utils/lifeops-url.js                                          975.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/security/action-confirmation.js                               955.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/autofill.js                                           10.96 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/autofill-whitelist-pack.js                      1006.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useSignalConnector.js                                   2.67 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/contract-types.js                               42.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-discord.js.map                          71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/morning-brief.js                                2.71 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/focus-session.js                             1.74 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useLifeOpsCapabilitiesStatus.js                         1.48 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/credentials.js                                        5.54 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/followup/index.js                                             1.21 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/cross-channel-context.js                            6.65 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/sensitive-request-delivery.js                         3.08 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/cross-channel-search.js                               25.11 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/calendar.js                                           27.85 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/followup-starter.js                             4.29 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useTelegramConnector.js                                 2.99 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-health.js                               48.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/telemetry-mapping.js                                  4.08 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/routes/website-blocker-routes.js.map                          11.67 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/redact-sensitive-data.js                              2.71 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/travel-time/calendar-create.js                                830.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/service.js                                                    3.70 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-normalize-task.js                             17.14 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-goals.js                                47.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/work-thread.js.map                                    36.37 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/google-plugin-delegates.js.map                        25.78 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/email-curation.js.map                                 697.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-imessage.js                             50.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/public.js                                                     577.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-status.js                               48.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-telegram.js                             50.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/types/website-blocker-settings-card.js                        57.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-x.js                                    43.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/website-blocker/proactive-block-bridge.js.map                 11.60 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/types/app-blocker-settings-card.js                            53.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/routes/relationships.js.map                                   14.27 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-constants.js                                  4.78 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/time.js                                               4.79 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/website-blocker/public.js.map                                 1.96 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/goal-semantic-evaluator.js                            188.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-scheduling.js                           52.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/lifeops.js                                          27.75 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/types/index.js                                                33.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/repository.js                                         241.16 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-email-unsubscribe.js                    59.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/inbox/types.js                                                84.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/resolve-request.js.map                                22.71 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-drive.js                                331.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/privacy.js                                            1.82 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/schedule-state.js                                     24.08 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/feature-flags.types.js                                4.32 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/background-planner.js.map                             31.16 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/pending-prompts.js                                  2.64 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/signal-runtime-config.js                              1.16 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/followup/followup-tracker.js                                  10.43 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/travel-time/service.js                                        6.82 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/types/document-request.js                                     44.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/background-planner-dispatch.js                        3.47 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/autofill-whitelist.js                                 1.96 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/seed-routines.js                                      3.91 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-screentime.js                           52.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/policy-memory.js                                      30.84 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/inbox/repository.js                                           167.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/proactive-planner.js.map                     45.03 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/types/briefing.js                                             36.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/schedule-sync-contracts.js                            133.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/priority-scoring.js                                   10.17 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/privacy-egress.js.map                                 15.77 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-workflows.js                            181.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/inbox/message-fetcher.js                                      282.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-whatsapp.js                             50.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/types.js.map                                 5.04 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/calendar-gate.js                                      1.33 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/runtime-cache.js                                      125.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/routes/lifeops-routes.js.map                                  146.39 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/document.js.map                                       39.08 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service.js                                            43.19 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-travel.js                               151.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/contracts/lifeops.js                                          68.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/platform/lifeops-github.js                                    4.44 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-normalize-gmail.js                            2.51 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/relative-schedule-resolver.js                         3.43 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-types.js                                      130.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/contact-route-policy.js                               5.00 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/feature-flags.js                                      8.46 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-calendar.js.map                         71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/automation-node-contributor.js                                5.81 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/platform/host.js                                              618.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/browser-constants.js                                  643.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/schema.js                                             54.70 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/imessage-outbound-probe.js                            2.23 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/ui.js                                                         939.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/contracts/index.js                                            66.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-x-read.js                               48.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-helpers-occurrence.js                         8.24 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/routes/entities.js.map                                        14.25 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/service.js.map                               17.46 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-definitions.js                          53.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/work-threads.js                                     3.58 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/agent-lifeops.js                                              77.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/email-unsubscribe-types.js                            51.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/device-bus-service.js                                 572.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/email-classifier.js                                   361.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/document-review.js                                    28.14 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/runtime-service-delegates.js                          25.15 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/goal-grounding.js                                     544.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/app-state.js                                          2.13 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/schedule.js.map                                       11.16 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/screen-context.js                                     9.75 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/schedule-sync-config.js                               1.02 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/time-util.js                                          416.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/recent-task-states.js                               5.30 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/sql.js                                                5.33 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/access.js                                             2.50 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-signal.js                               48.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/activity-profile.js                                 9.57 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/fda-probe.js                                          1.81 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-google.js                               48.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/inbox-triage.js                                     4.71 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/client.js                                                     1.35 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/wave1-types.js                                        39.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/optimized-prompt-instructions.js                      2.97 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/enforcement-windows.js                                2.44 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/escalation-ladders.js                                 536.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-helpers-reminder.js                           38.69 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-helpers-misc.js                               17.02 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/browser-extension-store.js                            6.08 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/index.js                                                      5.63 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/index.js                                              839.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/scheduler-task.js                                     6.42 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-subscriptions.js                        55.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/runtime.js                                            3.55 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/room-policy.js                                      2.17 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-normalize-connector.js                        24.08 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/relative-time.js                                      7.17 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-helpers-browser.js                            10.50 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-reminders.js                            290.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/bill-extraction.js                                    10.61 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/telemetry-retention.js                                390.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-browser.js                              49.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/plugin.js                                                     38.55 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/schedule-insight.js                                   23.30 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-gmail.js                                47.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/voice-affect.js                                       8.34 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/travel-booking.types.js                               48.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-relationships.js                        55.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/browser-session-lifecycle.js                          9.45 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/defaults.js                                           5.77 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/provider.js                                                   4.07 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/device-identity.js                                    2.66 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/continuity-probe.js                                   5.75 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/approval-queue.js                                     18.94 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-core.js                                 16.49 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/bulk-review.js                                        34.31 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/approval-queue.types.js                               686.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/life.js.map                                           162.89 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/brief.js.map                                          33.16 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/connector-error.js.map                                  511.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/money.js.map                                          3.90 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/prioritize.js.map                                     33.47 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/task-definitions.js.map                         9.21 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/lint.js.map                                     13.62 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/remote-desktop.js.map                                 891.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/api/client-lifeops.js.map                                     68.43 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useLifeOpsActivitySignals.js.map                        23.05 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/discord.js                                 1.50 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/imessage.js                                1.50 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/i18n/localized-examples-provider.js                   1.03 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/i18n/prompt-registry.js                               7.94 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/google.js                                  2.39 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useWhatsAppConnector.js.map                             2.61 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/validate/coding-task-request.js                       448.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/x.js                                       1.74 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/app-block.js.map                                      23.27 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/twilio.js                                  3.48 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/first-run/service.js                                  18.13 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/routes/plugin.js.map                                          39.91 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/profile-metadata.js.map                      1.57 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/duffel.js                                  1.96 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/proactive-inbox-digest.js.map                1.18 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/_helpers.js                                2.56 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/routes/travel-provider-relay-routes.js.map                    308.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/quiet-user-watcher.js.map                       7.32 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/screen-time.js.map                                    2.19 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/i18n/localized-examples-resolver.js                   710.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/contract.js                                36.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/registry-types.js.map                           71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/routes/sleep-routes.js.map                                    2.32 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/notifications-push.js.map                             7.33 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/events/index.js.map                                           2.63 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/entity.js.map                                         49.39 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/platform/index.js.map                                         192.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/escalation-ladders.js.map                       1.64 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/owner-surfaces.js.map                                 28.73 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/checkin/schedule-resolver.js                          1.00 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/analyzer.js.map                              40.08 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useLifeOpsAppState.js.map                               3.45 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/mockoon-redirect.js                        1.90 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/google-scopes.js.map                                  7.04 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/voice/grounded-reply.js                               654.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/components/AppBlockerSettingsCard.js.map                      32.02 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/inbox-triage-starter.js.map                     3.99 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/stretch-decider.js.map                                6.62 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/health.js.map                                         1.65 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/intent-sync.js.map                                    21.43 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/owner/profile-extraction-evaluator.js                 8.30 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/health.js.map                                       734.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/checkin/checkin-service.js                            38.23 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/password-manager.js.map                               12.89 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/block.js.map                                          19.55 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/owner/fact-store.js                                   14.40 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/work-threads/types.js                                 33.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/utils/index.js.map                                            197.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useIMessageConnector.js.map                             2.87 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/apple-reminders.js.map                                21.78 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/lifeops-context.js.map                                71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/scheduled-task.js.map                                 41.36 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/checkin/types.js                                      33.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/payments.js.map                                       585.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/voice-call.js.map                                     40.54 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useLifeOpsXConnector.js.map                             4.10 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/work-threads/field-evaluator-thread-ops.js            8.27 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useInbox.js.map                                         7.45 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/scheduling-service.js                         12.78 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/calendar-service.js                           1.70 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/subscriptions.js.map                                  20.72 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/redactor.js.map                              2.06 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/index.js                                        4.00 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/activity-tracker-repo.js.map                 4.20 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/reminders-service.js                          147.62 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/routes/scheduled-tasks.js.map                                 9.90 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useGoogleLifeOpsConnector.js.map                        38.10 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/consolidation-policies.js.map                   1.25 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/inbox-service.js                              21.12 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/telegram.js                                1.78 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/family-registry.js                         2.81 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/work-threads/index.js                                 123.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/triggers/schedule-once.js                             2.79 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/security/action-confirmation.js.map                           1.98 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/scheduled-task/runtime-wiring.js                      13.04 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/status-service.js                             14.07 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useDiscordConnector.js.map                              4.71 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/health-service.js                             21.28 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/first-run.js.map                                    7.80 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/presence-signal-bridge-service.js.map        9.28 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/conflict-detect.js.map                                20.02 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/website-block.js.map                                  48.48 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/handoff/store.js                                      521.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/registry.js                                1.42 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/daily-rhythm.js                                 4.61 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/scheduled-task/scheduler.js                           6.28 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/whatsapp-service.js                           6.64 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/travel-service.js                             8.44 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/subscriptions-service.js                      1.35 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/pending-prompts/store.js                              501.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/work-threads/store.js                                 8.81 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/routes/cloud-features-routes.js.map                           10.93 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/time/timezone.js                                      4.80 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/utils/format-duration.js.map                                  995.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/channels/index.js                                     522.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/owner-profile.js.map                                  26.92 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/messaging/owner-send-policy.js                        2.85 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/scheduled-task/index.js                               320.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/default-pack.js                            1.42 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/email-unsubscribe-service.js                  879.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/sleep-service.js                              1.26 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/seed-routine-migration/migrator.js                    4.21 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/followup/actions/listOverdueFollowups.js                      2.75 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-normalize.js.map                              1.36 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/screentime-service.js                         16.60 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/workflows-service.js                          25.30 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/workflow-step-default-pack.js              9.63 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/entities/voice-attribution.js                         3.44 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/messaging/index.js                                    133.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/signal-runtime-config.js.map                          2.51 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/global-pause/store.js                                 523.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/book-travel.js.map                                    31.01 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/utils/lifeops-url.js.map                                      1.65 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/x-service.js                                  17.56 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/whatsapp.js                                1.59 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/followup/followup-tracker.js.map                              20.77 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/followup/actions/markFollowupDone.js                          5.51 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/feature-flag-registry.js                   1.89 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/entities/types.js                                     266.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/google-service.js                             12.02 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/relationships-service.js                      4.93 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/relationships/mapping.js                              2.82 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-inbox.js.map                            523.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/definitions-service.js                        14.85 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/channels/default-pack.js                              5.42 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/workflow-step-registry.js                  1.56 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/google/format-helpers.js                              20.80 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/gmail-service.js                              22.66 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/index.js                                   547.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/send-policy/index.js                                  316.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/runtime-cache.js.map                                  412.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/imessage-service.js                           10.01 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/signal.js                                  1.66 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/bill-extraction.js.map                                21.18 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/subscriptions-service.js.map                  4.17 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/website-blocker-contribution.js            2.18 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/dispatch-policy.js                         1021.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/followup/actions/setFollowupThreshold.js                      5.75 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/browser-service.js                            35.05 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/discord-service.js                            44.56 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/x-read-service.js                             7.97 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/telemetry-retention.js.map                            1.27 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/plugin.js.map                                                 66.19 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/entities/index.js                                     581.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/entities/voice-observer.js                            3.27 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/drive-service.js                              6.24 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/calendly.js                                1.86 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/components/WebsiteBlockerSettingsCard.js.map                  8.79 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/cross-channel-context.js.map                        13.32 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/pending-prompts.js.map                              5.91 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/pending-prompts/store.js.map                          1.85 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/event-kind-registry.js                     2.16 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/send-policy/index.js.map                              498.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/signals/bus.js                                        3.69 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-x-read.js.map                           71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/feature-flag-registry.js.map               6.80 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/website-blocker-contribution.js.map        4.63 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/types/index.js.map                                            71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/website-blocker/chat-integration/index.js                     700.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/signal-service.js                             7.38 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/entities/merge.js                                     368.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/entities/index.js.map                                 852.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/inbox.js.map                                          847.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/room-policy.js.map                                  4.37 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/entities/voice-observer-bridge.js                     2.14 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/index.js                                   3.41 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/followup/index.js.map                                         1.11 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-browser.js.map                          71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/send-policy/contract.js                               36.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/entities/types.js.map                                 822.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/telegram-service.js                           10.31 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/first-run/state.js                                    5.31 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/workflow-step-registry.js.map              7.95 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/credentials.js.map                                    10.25 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-types.js.map                                  3.33 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-imessage.js.map                         71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/channels/priority-posture.js                          531.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/x-read-service.js.map                         16.28 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/google.js.map                              5.22 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/first-run/defaults.js                                 7.08 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/channels/default-pack.js.map                          11.18 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/send-policy/registry.js                               1.73 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/gmail-service.js.map                          43.10 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/channels/contract.js                                  36.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-scheduling.js.map                       71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/owner-policy-writes.js                            5.15 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/types/website-blocker-settings-card.js.map                    71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/followup/actions/setFollowupThreshold.js.map                  10.01 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/scheduled-task/service.js                             203.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/entities/voice-observer.js.map                        7.83 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-normalize-connector.js.map                    42.36 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/goals-service.js                              31.45 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/work-threads/store.js.map                             19.53 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/index.js.map                               826.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useLifeOpsCapabilitiesStatus.js.map                     2.72 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/browser-service.js.map                        63.38 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/calendly.js.map                            3.57 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/channels/registry.js                                  1.28 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/public.js.map                                                 589.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/runtime.js.map                                        6.31 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/website-blocker/chat-integration/harsh-mode-check.js          669.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/email-unsubscribe-service.js.map              2.58 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/google/format-helpers.js.map                          39.88 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/contract.js.map                            71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/signal-service.js.map                         14.48 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/activity-profile/focus-session.js.map                         5.29 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/app-blocker-contribution.js                1.86 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/feature-flags.types.js.map                            13.71 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/autofill-whitelist-pack.js.map                  2.33 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/i18n/prompt-registry.js.map                           16.03 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/discord-service.js.map                        82.68 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/relationships/mapping.js.map                          6.56 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/i18n/localized-examples-resolver.js.map               2.80 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/entities/store.js                                     207.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/extract-goal-plan.js                              18.71 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/dispatch-policy.js.map                     5.57 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-goals.js.map                            71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/morning-brief.js.map                            5.62 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/calendar-gate.js.map                                  4.30 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/messaging/owner-send-policy.js.map                    5.77 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/channels/contract.js.map                              71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useSignalConnector.js.map                               4.86 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/i18n/localized-examples-provider.js.map               2.42 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/website-blocker/chat-integration/block-activator.js           964.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/imessage.js.map                            3.15 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/browser-constants.js.map                              1.18 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/first-run/replay.js                                   993.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-status.js.map                           71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/x-service.js.map                              34.03 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/time-util.js.map                                      1.16 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/contract-types.js.map                           71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-normalize-task.js.map                         30.17 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/scheduled-task/index.js.map                           954.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/first-run/defaults.js.map                             14.70 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/autofill.js.map                                       20.63 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/first-run/questions.js                                5.41 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/connector.js.map                                      77.08 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/send-policy/registry.js.map                           4.29 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/whatsapp-service.js.map                       12.94 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/default-pack.js.map                        3.55 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/recent-task-states.js.map                           11.67 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/website-blocker/chat-integration/block-rule-service.js        7.17 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/relative-time.js.map                                  15.26 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/blocker-registry.js                        1003.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/schema.js.map                                         104.18 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/feature-flag-default-pack.js               1.03 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/whatsapp.js.map                            3.31 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/service.js.map                                                8.96 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/channels/priority-posture.js.map                      2.49 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/drive-service.js.map                          13.40 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/google-service.js.map                         22.57 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/followup/actions/markFollowupDone.js.map                      9.86 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/channels/index.js.map                                 735.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/website-blocker/chat-integration/index.js.map                 900.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/prompt-format.js                                  1.39 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/app-blocker-contribution.js.map            3.92 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-health.js.map                           71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/relationships/extraction.js                           4.41 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/schedule-state.js.map                                 44.84 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/sql.js.map                                            13.04 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/travel-service.js.map                         18.66 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/time/timezone.js.map                                  8.51 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/website-blocker/chat-integration/block-rule-reconciler.js     4.00 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/followup-starter.js.map                         7.90 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/owner-policy-writes.js.map                        11.59 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/travel-time/calendar-create.js.map                            1.99 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/defaults.js.map                                       12.13 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/relationships/store.js                                117.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/platform/host.js.map                                          1.48 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-helpers-browser.js.map                        20.34 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/imessage-outbound-probe.js.map                        4.32 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/engine.js.map                                         31.39 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/scheduling-handler.js                             31.22 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/goal-semantic-evaluator.js.map                        599.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/voice-affect.js.map                                   17.09 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/first-run/service.js.map                              35.58 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/access.js.map                                         4.74 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/relationships-service.js.map                  10.38 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/extract-goal-plan.js.map                          31.88 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/lifeops-deferred-draft.js                         10.87 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/calendar.js.map                                       49.27 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/messaging-helpers.js                              2.95 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/provider.js.map                                               7.49 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-workflows.js.map                        974.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/ui.js.map                                                     2.05 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/repository.js.map                                     420.26 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/redact-sensitive-data.js.map                          6.51 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/send-policy/contract.js.map                           71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/sleep-service.js.map                          2.56 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/calendly-handler.js                               16.97 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/twilio.js.map                              6.90 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-telegram.js.map                         71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/contracts/index.js.map                                        149.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-signal.js.map                           71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/telegram-service.js.map                       20.56 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/extract-life-operation.js                         12.00 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-reminders.js.map                        404.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/goals-service.js.map                          59.88 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/entities/store.js.map                                 674.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/device-identity.js.map                                5.78 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/activity-profile.js.map                             16.80 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/telemetry-mapping.js.map                              7.86 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/global-pause/store.js.map                             1.70 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/prompt-format.js.map                              2.82 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-constants.js.map                              3.56 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/executive-assistant.js                          29.75 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/relationships/index.js                                454.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/extract-task-plan.js                              14.72 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/website-blocker/chat-integration/block-rule-schema.js         4.13 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/cross-channel-search.js.map                           57.84 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/entities/merge.js.map                                 716.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/runtime-service-delegates.js.map                      53.11 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/hooks/useTelegramConnector.js.map                             5.35 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/first-run/state.js.map                                13.02 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/website-blocker/chat-integration/harsh-mode-check.js.map      1.70 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/continuity-probe.js.map                               13.64 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/screentime-service.js.map                     32.36 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-helpers-misc.js.map                           32.16 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/extract-update-fields.js                          6.14 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/channels/registry.js.map                              2.89 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/inbox/types.js.map                                            516.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/fda-probe.js.map                                      3.96 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/_helpers.js.map                            6.38 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/relationships/types.js                                266.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/website-blocker/chat-integration/block-rule-reconciler.js.map 7.29 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/browser-session-lifecycle.js.map                      19.27 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-relationships.js.map                    71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/schedule-sync-config.js.map                           1.76 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/time.js.map                                           9.32 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/discord.js.map                             2.91 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/approval-queue.js.map                                 36.91 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/inbox-triage.js.map                                 8.34 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/workflows-service.js.map                      47.23 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/website-blocker/chat-integration/block-rule-service.js.map    13.15 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/executive-assistant.js.map                      45.73 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/sensitive-request-delivery.js.map                     7.18 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/goal-grounding.js.map                                 999.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/work-threads.js.map                                 6.57 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/relationships/index.js.map                            758.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-google.js.map                           71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/workflow-step-default-pack.js.map          19.92 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/extract-update-fields.js.map                      11.64 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/optimized-prompt-instructions.js.map                  3.50 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/seed-routine-migration/migrator.js.map                11.65 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/event-kind-registry.js.map                 5.81 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-core.js.map                             31.21 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/browser-extension-store.js.map                        12.93 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/extract-task-plan.js.map                          26.61 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/blocker-registry.js.map                    5.55 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/relationships/types.js.map                            806.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/entities/voice-attribution.js.map                     9.79 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/work-threads/index.js.map                             453.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/agent-lifeops.js.map                                          147.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-email-unsubscribe.js.map                71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/document-review.js.map                                61.77 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/checkin/types.js.map                                  71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/signals/bus.js.map                                    10.59 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/validate/coding-task-request.js.map                   1.52 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/travel-booking.types.js.map                           71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-definitions.js.map                      71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/family-registry.js.map                     7.85 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/triggers/schedule-once.js.map                         5.37 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/client.js.map                                                 3.13 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/website-blocker/chat-integration/block-rule-schema.js.map     8.32 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/app-state.js.map                                      4.80 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/x.js.map                                   3.32 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/messaging/index.js.map                                361.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/inbox-service.js.map                          42.78 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/work-threads/field-evaluator-thread-ops.js.map        18.40 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/telegram.js.map                            3.74 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/calendly-handler.js.map                           30.68 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/scheduler-task.js.map                                 12.00 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/schedule-insight.js.map                               48.68 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/followup/actions/listOverdueFollowups.js.map                  4.86 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/daily-rhythm.js.map                             8.19 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/relationships/extraction.js.map                       11.06 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-helpers-occurrence.js.map                     14.99 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/scheduled-task/scheduler.js.map                       14.20 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/index.js.map                                                  5.65 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/device-bus-service.js.map                             1.31 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/definitions-service.js.map                    27.92 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/types/briefing.js.map                                         71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/duffel.js.map                              3.87 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/automation-node-contributor.js.map                            10.36 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/email-classifier.js.map                               775.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/registry.js.map                            3.38 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/bulk-review.js.map                                    76.20 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-x.js.map                                71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/owner/profile-extraction-evaluator.js.map             14.58 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/scheduling-handler.js.map                         58.99 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/reminders-service.js.map                      269.58 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-subscriptions.js.map                    71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/entities/voice-observer-bridge.js.map                 5.43 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/default-packs/index.js.map                                    7.94 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/contact-route-policy.js.map                           10.65 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/types/app-blocker-settings-card.js.map                        71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/screen-context.js.map                                 19.95 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/schedule-sync-contracts.js.map                        214.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/first-run/questions.js.map                            12.14 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/checkin/schedule-resolver.js.map                      2.64 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/wave1-types.js.map                                    71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/travel-time/service.js.map                                    15.30 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/priority-scoring.js.map                               21.29 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/email-unsubscribe-types.js.map                        71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/approval-queue.types.js.map                           7.45 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/index.js.map                               4.45 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/index.js.map                                          1.18 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/voice/grounded-reply.js.map                           2.67 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/autofill-whitelist.js.map                             4.16 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-helpers-reminder.js.map                       77.02 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/first-run/replay.js.map                               3.32 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-gmail.js.map                            71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/imessage-service.js.map                       21.31 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/relationships/store.js.map                            615.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/types/document-request.js.map                                 71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/website-blocker/chat-integration/block-activator.js.map       2.71 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-drive.js.map                            3.19 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/scheduled-task/service.js.map                         922.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/registries/feature-flag-default-pack.js.map           3.02 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/extract-life-operation.js.map                     19.78 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/providers/lifeops.js.map                                      41.71 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-screentime.js.map                       71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/inbox/message-fetcher.js.map                                  780.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/seed-routines.js.map                                  7.39 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/scheduled-task/runtime-wiring.js.map                  26.21 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/signal.js.map                              3.28 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/handoff/store.js.map                                  1.80 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/scheduling-service.js.map                     26.75 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-travel.js.map                           1.84 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/background-planner-dispatch.js.map                    8.55 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/policy-memory.js.map                                  65.50 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/contracts/lifeops.js.map                                      151.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-normalize-gmail.js.map                        2.35 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/escalation-ladders.js.map                             2.01 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/privacy.js.map                                        4.64 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/status-service.js.map                         27.67 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/inbox/repository.js.map                                       645.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/work-threads/types.js.map                             71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/owner/fact-store.js.map                               34.35 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/checkin/checkin-service.js.map                        71.20 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/platform/lifeops-github.js.map                                7.71 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/calendar-service.js.map                       5.36 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service.js.map                                        106.38 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/messaging-helpers.js.map                          6.82 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/enforcement-windows.js.map                            5.62 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/actions/lib/lifeops-deferred-draft.js.map                     22.97 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/feature-flags.js.map                                  17.75 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/connectors/mockoon-redirect.js.map                    5.11 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/relative-schedule-resolver.js.map                     7.35 KB
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/service-mixin-whatsapp.js.map                         71.00 B
+@elizaos/plugin-personal-assistant:build: ESM dist/lifeops/domains/health-service.js.map                         39.49 KB
+@elizaos/plugin-personal-assistant:build: ESM ⚡️ Build success in 269ms
+@elizaos/plugin-personal-assistant:build: $ tsc --noCheck -p tsconfig.build.json
+@elizaos/plugin-training:typecheck: cache miss, executing 05cd51b0c8a16365
+@elizaos/plugin-training:typecheck: $ tsgo --noEmit -p tsconfig.typecheck.json
+@elizaos/app:typecheck: cache miss, executing d76d8ff7e147209b
+@elizaos/scenario-runner:typecheck: cache miss, executing 2262538ed14f8851
+@elizaos/scenario-runner:typecheck: $ tsgo --noEmit
+@elizaos/app:typecheck: $ tsgo --noEmit -p tsconfig.typecheck.json
+
+ Tasks:    474 successful, 474 total
+Cached:    0 cached, 474 total
+  Time:    1m34.679s
+
+$ node packages/scripts/audit-build-typecheck.mjs
+[audit-build-typecheck] ✓ build/typecheck compiler model is consistent
+$ node packages/scripts/audit-turbo-build-deps.mjs
+[audit-turbo-build-deps] ✓ no phantom #build dependency edges
+$ node packages/scripts/audit-tee-secret-leak.mjs
+audit-tee-secret-leak: PASS — 3 confidential module(s) + 2 off-device serializer(s) clean.
+$ node packages/scripts/audit-scripts.mjs
+[audit-scripts] OK — no orphan/no-op/broken scripts.
+$ node packages/scripts/generate-dist-paths-config.mjs --check && node packages/scripts/prepare-dist-path-declarations.mjs && node packages/scripts/typecheck-dist-path-consumers.mjs
+[generate-dist-paths-config] ✓ 194 path aliases are current
+[prepare-dist-path-declarations] @elizaos/prompts
+[prepare-dist-path-declarations] prepared 1 declaration emit(s)
+
+[typecheck:dist] packages/examples/_plugin/tsconfig.json
+
+[typecheck:dist] packages/examples/a2a/tsconfig.json
+
+[typecheck:dist] packages/examples/agent-console/tsconfig.json
+
+[typecheck:dist] packages/examples/app/electron/backend/tsconfig.json
+
+[typecheck:dist] packages/examples/autonomous/tsconfig.json
+
+[typecheck:dist] packages/examples/bluesky/tsconfig.json
+
+[typecheck:dist] packages/examples/chat/tsconfig.json
+
+[typecheck:dist] packages/examples/cloudflare/tsconfig.json
+
+[typecheck:dist] packages/examples/code/tsconfig.json
+
+[typecheck:dist] packages/examples/convex/tsconfig.json
+
+[typecheck:dist] packages/examples/discord/tsconfig.json
+
+[typecheck:dist] packages/examples/elizagotchi/tsconfig.json
+
+[typecheck:dist] packages/examples/farcaster-miniapp/tsconfig.json
+
+[typecheck:dist] packages/examples/farcaster/tsconfig.json
+
+[typecheck:dist] packages/examples/game-of-life/tsconfig.json
+
+[typecheck:dist] packages/examples/lp-manager/tsconfig.json
+
+[typecheck:dist] packages/examples/moltbook/tsconfig.json
+
+[typecheck:dist] packages/examples/plugin-echo/tsconfig.json
+
+[typecheck:dist] packages/examples/react/tsconfig.json
+
+[typecheck:dist] packages/examples/rest-api/elysia/tsconfig.json
+
+[typecheck:dist] packages/examples/rest-api/express/tsconfig.json
+
+[typecheck:dist] packages/examples/rest-api/hono/tsconfig.json
+
+[typecheck:dist] packages/examples/smartglasses/tsconfig.json
+
+[typecheck:dist] packages/examples/text-adventure/tsconfig.json
+
+[typecheck:dist] packages/examples/tic-tac-toe/tsconfig.json
+
+[typecheck:dist] packages/examples/trader/tsconfig.json
+
+[typecheck:dist] packages/examples/twitter-xai/tsconfig.json
+
+[typecheck:dist] packages/examples/vercel/tsconfig.json
+
+[typecheck:dist] checked 28 dist-path consumer config(s)

--- a/packages/cloud/shared/src/lib/eliza/plugin-oauth/actions/oauth.test.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-oauth/actions/oauth.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import type { IAgentRuntime, Memory } from "@elizaos/core";
+import { oauthAction } from "./oauth";
+
+function message(content: Record<string, unknown>): Memory {
+  return {
+    agentId: "agent-1",
+    entityId: "user-1",
+    roomId: "room-1",
+    content,
+  } as Memory;
+}
+
+const runtime = {} as IAgentRuntime;
+
+describe("OAUTH structured op routing (#10471)", () => {
+  test("does not infer revoke intent from raw English message text", async () => {
+    const result = await oauthAction.handler(runtime, message({ text: "disconnect google" }));
+
+    expect(result.success).toBe(false);
+    expect(result.text).toContain("OAUTH could not determine the operation");
+    expect(result.values).toEqual({ error: "MISSING" });
+  });
+
+  test("does not infer status intent from raw English completion text", async () => {
+    const result = await oauthAction.handler(runtime, message({ text: "did it work?" }));
+
+    expect(result.success).toBe(false);
+    expect(result.text).toContain("OAUTH could not determine the operation");
+    expect(result.values).toEqual({ error: "MISSING" });
+  });
+
+  test("uses structured op params even when message text is non-English", async () => {
+    const result = await oauthAction.handler(
+      runtime,
+      message({
+        text: "conecta mi cuenta",
+        actionParams: { op: "connect" },
+      }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("MISSING_PLATFORM");
+    expect(result.data).toMatchObject({ actionName: "OAUTH", op: "connect" });
+  });
+
+  test("uses legacy structured action metadata without parsing message text", async () => {
+    const result = await oauthAction.handler(
+      runtime,
+      message({
+        text: "quita mi cuenta",
+        action: "OAUTH_REVOKE",
+      }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("MISSING_PLATFORM");
+    expect(result.data).toMatchObject({ actionName: "OAUTH", op: "revoke" });
+  });
+});

--- a/packages/cloud/shared/src/lib/eliza/plugin-oauth/actions/oauth.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-oauth/actions/oauth.ts
@@ -50,6 +50,7 @@ function normalizeOp(value: unknown): OAuthOp | null {
     .toLowerCase()
     .replace(/[\s-]+/g, "_");
   const aliases: Record<string, OAuthOp> = {
+    oauth_connect: "connect",
     connect_account: "connect",
     connect_oauth: "connect",
     link: "connect",
@@ -58,17 +59,24 @@ function normalizeOp(value: unknown): OAuthOp | null {
     add_connection: "connect",
     authorize: "connect",
     authorize_app: "connect",
+    oauth_get: "get",
     check: "get",
     check_connection: "get",
     verify: "get",
     verify_connection: "get",
     status: "get",
     is_connected: "get",
+    did_it_work: "get",
+    oauth_list: "list",
     show: "list",
     show_connections: "list",
     list_connections: "list",
     my_accounts: "list",
     connected_apps: "list",
+    what_is_connected: "list",
+    my_integrations: "list",
+    show_integrations: "list",
+    oauth_revoke: "revoke",
     disconnect: "revoke",
     disconnect_account: "revoke",
     disconnect_oauth: "revoke",
@@ -82,47 +90,17 @@ function normalizeOp(value: unknown): OAuthOp | null {
   return (OAUTH_OPS as readonly string[]).includes(normalized) ? (normalized as OAuthOp) : null;
 }
 
-function inferOpFromMessage(text: string): OAuthOp | null {
-  const lower = text.toLowerCase();
-  if (
-    /\b(disconnect|unlink|remove|revoke)\b/.test(lower) &&
-    /\b(account|connection|oauth)\b/.test(lower)
-  ) {
-    return "revoke";
-  }
-  if (
-    /\b(disconnect|unlink|revoke)\b/.test(lower) ||
-    /\bdisconnect\s+(google|slack|github|twitter|x|microsoft|notion|jira|linkedin|asana|dropbox|salesforce|airtable|zoom|linear)\b/.test(
-      lower,
-    )
-  ) {
-    return "revoke";
-  }
-  if (
-    /\b(connect|link|authorize|add)\b.*\b(google|slack|github|twitter|x|microsoft|notion|jira|linkedin|asana|dropbox|salesforce|airtable|zoom|linear|account|oauth|integration)\b/.test(
-      lower,
-    ) ||
-    /\bconnect\s+(google|slack|github|twitter|x|microsoft|notion|jira|linkedin|asana|dropbox|salesforce|airtable|zoom|linear)\b/.test(
-      lower,
-    )
-  ) {
-    return "connect";
-  }
-  if (
-    /\b(list|show|what)\b.*\b(connection|account|integration)s?\b/.test(lower) ||
-    /\b(my|all)\s+(connection|account|integration)s?\b/.test(lower) ||
-    /\bconnected\s+apps?\b/.test(lower)
-  ) {
-    return "list";
-  }
-  if (
-    /\b(check|verify|status|is\s+(my|the))\b.*\b(connect|connection|connected)\b/.test(lower) ||
-    /^\s*(done|finished|completed)\s*[!?.]?\s*$/.test(lower) ||
-    /\bdid\s+it\s+work\b/.test(lower)
-  ) {
-    return "get";
-  }
-  return null;
+function readStructuredOp(message: Memory, state?: State): OAuthOp | null {
+  const params = extractParams(message, state);
+  const content = message.content as Record<string, unknown>;
+  return normalizeOp(
+    params.op ??
+      params.subaction ??
+      params.operation ??
+      params.action ??
+      content.action ??
+      content.actionName,
+  );
 }
 
 function failureResult(
@@ -523,14 +501,14 @@ export const oauthAction: ActionWithParams = {
     "REVOKE_CONNECTION",
   ],
   description:
-    "Manage cloud OAuth connections. Operations: connect (start an OAuth flow), get (check connection status), list (show all connected accounts), revoke (disconnect a platform). Supported platforms: google, linear, slack, github, notion, twitter, jira, linkedin, microsoft, asana, dropbox, salesforce, airtable, zoom. The op is inferred from message text when not explicitly provided.",
+    "Manage cloud OAuth connections. Operations: connect (start an OAuth flow), get (check connection status), list (show all connected accounts), revoke (disconnect a platform). Supported platforms: google, linear, slack, github, notion, twitter, jira, linkedin, microsoft, asana, dropbox, salesforce, airtable, zoom. The op must be supplied as a structured op/subaction/operation/action parameter.",
 
   parameters: defineActionParameters({
     op: {
       type: "string",
       description:
-        "Operation to perform: connect, get, list, or revoke. Inferred from message text when omitted.",
-      required: false,
+        "Operation to perform: connect, get, list, or revoke. Required as structured data; natural-language message text is not parsed for OAuth intent.",
+      required: true,
       enum: ["connect", "get", "list", "revoke"],
     },
     platform: {
@@ -568,11 +546,7 @@ export const oauthAction: ActionWithParams = {
     _options?: unknown,
     callback?: HandlerCallback,
   ): Promise<ActionResult> => {
-    const params = extractParams(message, state);
-    const explicitOp = normalizeOp(params.op ?? params.subaction);
-    const op =
-      explicitOp ??
-      inferOpFromMessage(typeof message.content?.text === "string" ? message.content.text : "");
+    const op = readStructuredOp(message, state);
 
     if (!op) {
       const text = `OAUTH could not determine the operation. Specify one of: ${OAUTH_OPS.join(", ")}.`;
@@ -602,7 +576,13 @@ export const oauthAction: ActionWithParams = {
 
   examples: [
     [
-      { name: "{{name1}}", content: { text: "connect google" } },
+      {
+        name: "{{name1}}",
+        content: {
+          text: "connect google",
+          actionParams: { op: "connect", platform: "google" },
+        },
+      },
       {
         name: "{{name2}}",
         content: {
@@ -612,7 +592,13 @@ export const oauthAction: ActionWithParams = {
       },
     ],
     [
-      { name: "{{name1}}", content: { text: "is my google connected?" } },
+      {
+        name: "{{name1}}",
+        content: {
+          text: "is my google connected?",
+          actionParams: { op: "get", platform: "google" },
+        },
+      },
       {
         name: "{{name2}}",
         content: {
@@ -622,7 +608,13 @@ export const oauthAction: ActionWithParams = {
       },
     ],
     [
-      { name: "{{name1}}", content: { text: "what accounts are connected?" } },
+      {
+        name: "{{name1}}",
+        content: {
+          text: "what accounts are connected?",
+          actionParams: { op: "list" },
+        },
+      },
       {
         name: "{{name2}}",
         content: {
@@ -632,7 +624,13 @@ export const oauthAction: ActionWithParams = {
       },
     ],
     [
-      { name: "{{name1}}", content: { text: "disconnect google" } },
+      {
+        name: "{{name1}}",
+        content: {
+          text: "disconnect google",
+          actionParams: { op: "revoke", platform: "google" },
+        },
+      },
       {
         name: "{{name2}}",
         content: {


### PR DESCRIPTION
Refs #10471.

## Summary
- Remove `OAUTH` operation inference from raw `message.content.text` (`disconnect google`, `did it work?`, `what accounts are connected?`, etc.).
- Resolve the OAuth operation only from structured fields: `op`, `subaction`, `operation`, `action`, or legacy structured action metadata such as `OAUTH_CONNECT` / `OAUTH_REVOKE`.
- Update the action description, `op` parameter contract, and examples so the planner is told to supply structured `op` data instead of relying on prose.
- Add regression coverage proving English prose alone no longer routes and non-English text works when paired with structured params.

## Evidence
Artifacts are in `.github/issue-evidence/10471-cloud-oauth-structured-op/`.

- `bun test --coverage-reporter=lcov packages/cloud/shared/src/lib/eliza/plugin-oauth/actions/oauth.test.ts` PASS (4 tests)
- `bun run --cwd packages/cloud/shared typecheck` PASS
- `bun run --cwd packages/cloud/shared lint` PASS
- `bun install` PASS after confirming branch head matched `origin/develop`
- `bun run verify` PASS (`Tasks: 474 successful, 474 total`, audits PASS, dist checks PASS)
- `git diff --cached --check` PASS

## Package Test Note
- `cd packages/cloud/shared && bun test --isolate --coverage-reporter=lcov` was attempted. The new OAuth tests passed inside that run, but the package exited nonzero on an unrelated existing module error in `src/lib/services/__tests__/x402-app-earnings.test.ts`: `Export named 'dbRead' not found in .../src/db/helpers.ts`. Captured in `cloud-shared-test.log`.

## N/A Evidence
- Live model trajectory: N/A for this deterministic handler routing change; the planner contract is structured `op` extraction, and the handler no longer inspects prose for operation intent.
- Screenshots / screen recording / audio: N/A. No UI, visual, or audio surface changed.
