### PR TITLE
feat(app): bootstrap embedded launch sessions

### DIFF
--- a/.github/issue-evidence/9947-embed-client/README.md
+++ b/.github/issue-evidence/9947-embed-client/README.md
@@ -1,0 +1,33 @@
+# Issue #9947 embed client bootstrap evidence
+
+## Scope
+
+- Added a `/embed` launch bootstrap in `packages/app` that reads platform launch payloads before the normal app mount.
+- Telegram launch uses `window.Telegram.WebApp.initData`; Discord launch uses the OAuth `code` query param. Both also accept an explicit `signedLaunchPayload` query param for local/proxy launch paths.
+- The bootstrap posts `{ platform, signedLaunchPayload }` to `/api/embed/auth`, stores a returned session token through the existing UI client token path, removes sensitive query params, and fails closed when payloads, auth, or token minting are missing.
+
+## Validation
+
+- `bun run --cwd packages/app test src/embed-launch.test.ts`
+  - Passed: 1 file, 6 tests.
+- `bun run --cwd packages/app-core test src/api/embed-auth-routes.test.ts src/api/auth/embed-session-token.test.ts`
+  - Passed: 2 files, 13 tests.
+- `bun run --cwd packages/app lint`
+  - Passed after rebase: 123 files checked.
+- `git diff --check`
+  - Passed.
+- `bun run --cwd packages/app audit:app`
+  - Passed after rebase: 349 tests.
+  - Audit summary: broken=0, needs-work=0, needs-eyeball=212, good=136.
+
+## Typecheck
+
+- `bun run --cwd packages/app typecheck`
+  - Blocked by existing workspace reference/type errors outside this change, including unresolved `@elizaos/plugin-streaming`, `@elizaos/vault`, `@elizaos/tui`, `@elizaos/skills`, `@elizaos/cloud-sdk`, and pre-existing plugin app-manager / elizacloud type errors.
+  - No reported typecheck errors were in `packages/app/src/embed-launch.ts`, `packages/app/src/embed-launch.test.ts`, or `packages/app/src/main.tsx`.
+
+## Evidence notes
+
+- Real LLM trajectory: N/A. This is an app launch/auth bootstrap change and does not exercise an agent response path.
+- Live Telegram/Discord walkthrough: pending real bot/activity credentials and deployed `ELIZA_EMBED_SESSION_SECRET`/token verifier configuration. The local slice validates the browser bootstrap and server auth contract with unit tests plus the full app audit.
+- Server token acceptance is expected to land via the companion server-side embed session authentication work; this client stores the minted token through the existing `ElizaClient.setToken` path so subsequent API probes can send the bearer token once the server accepts embed session tokens.

--- a/packages/app/src/embed-launch.test.ts
+++ b/packages/app/src/embed-launch.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { bootstrapEmbedLaunch } from "./embed-launch";
+
+function locationFor(path: string): Location {
+  return new URL(`https://app.eliza.example${path}`) as unknown as Location;
+}
+
+function okJson(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function fetchMock(response: Response): typeof fetch {
+  return vi.fn(async () => response) as unknown as typeof fetch;
+}
+
+describe("bootstrapEmbedLaunch", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    delete (window as Window & { Telegram?: unknown }).Telegram;
+  });
+
+  it("skips non-/embed paths", async () => {
+    const fetch = fetchMock(okJson({ token: "tok" }));
+    const result = await bootstrapEmbedLaunch({
+      fetch,
+      location: locationFor("/"),
+      applyToken: vi.fn(),
+    });
+    expect(result.status).toBe("skipped");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("authenticates Telegram initData and stores the returned token", async () => {
+    const ready = vi.fn();
+    (window as Window & { Telegram?: unknown }).Telegram = {
+      WebApp: { initData: "tg-init-data", ready },
+    };
+    const applyToken = vi.fn();
+    const markReady = vi.fn();
+    const fetch = fetchMock(okJson({ token: "embed-token", expiresAt: 123 }));
+
+    const result = await bootstrapEmbedLaunch({
+      fetch,
+      location: locationFor("/embed?platform=telegram"),
+      applyToken,
+      markReady,
+    });
+
+    expect(result).toEqual({ status: "authenticated", platform: "telegram" });
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/embed/auth",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          platform: "telegram",
+          signedLaunchPayload: "tg-init-data",
+        }),
+      }),
+    );
+    expect(applyToken).toHaveBeenCalledWith("embed-token");
+    expect(markReady).toHaveBeenCalledWith("telegram");
+    expect(ready).toHaveBeenCalled();
+  });
+
+  it("authenticates a Discord OAuth code and removes it from the URL", async () => {
+    const applyToken = vi.fn();
+    const replaceState = vi.fn();
+    const fetch = fetchMock(okJson({ token: "discord-token" }));
+
+    const result = await bootstrapEmbedLaunch({
+      fetch,
+      location: locationFor("/embed?platform=discord&code=oauth-code"),
+      history: { replaceState },
+      applyToken,
+    });
+
+    expect(result).toEqual({ status: "authenticated", platform: "discord" });
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/embed/auth",
+      expect.objectContaining({
+        body: JSON.stringify({
+          platform: "discord",
+          signedLaunchPayload: "oauth-code",
+        }),
+      }),
+    );
+    expect(applyToken).toHaveBeenCalledWith("discord-token");
+    expect(replaceState).toHaveBeenCalledWith(
+      null,
+      "",
+      "/embed?platform=discord",
+    );
+  });
+
+  it("fails closed when the launch payload is missing", async () => {
+    const fetch = fetchMock(okJson({ token: "tok" }));
+    const result = await bootstrapEmbedLaunch({
+      fetch,
+      location: locationFor("/embed?platform=discord"),
+      applyToken: vi.fn(),
+    });
+    expect(result).toEqual({ status: "missing-payload", platform: "discord" });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("does not store a token when auth rejects", async () => {
+    const applyToken = vi.fn();
+    const fetch = fetchMock(new Response("forbidden", { status: 403 }));
+    const result = await bootstrapEmbedLaunch({
+      fetch,
+      location: locationFor(
+        "/embed?platform=telegram&signedLaunchPayload=forged",
+      ),
+      applyToken,
+    });
+    expect(result).toEqual({
+      status: "auth-failed",
+      platform: "telegram",
+      statusCode: 403,
+    });
+    expect(applyToken).not.toHaveBeenCalled();
+  });
+
+  it("does not store a token when the route returns no token", async () => {
+    const applyToken = vi.fn();
+    const fetch = fetchMock(okJson({ token: null }));
+    const result = await bootstrapEmbedLaunch({
+      fetch,
+      location: locationFor(
+        "/embed?platform=telegram&signedLaunchPayload=valid",
+      ),
+      applyToken,
+    });
+    expect(result).toEqual({ status: "no-token", platform: "telegram" });
+    expect(applyToken).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/embed-launch.ts
+++ b/packages/app/src/embed-launch.ts
@@ -1,0 +1,148 @@
+import { client } from "@elizaos/ui/api";
+
+type EmbedPlatform = "telegram" | "discord";
+
+interface TelegramWebAppLike {
+  initData?: string;
+  ready?: () => void;
+}
+
+interface EmbedWindow extends Window {
+  Telegram?: {
+    WebApp?: TelegramWebAppLike;
+  };
+}
+
+export type EmbedBootstrapStatus =
+  | "skipped"
+  | "authenticated"
+  | "missing-payload"
+  | "auth-failed"
+  | "no-token";
+
+export interface EmbedBootstrapResult {
+  status: EmbedBootstrapStatus;
+  platform?: EmbedPlatform;
+  statusCode?: number;
+  error?: string;
+}
+
+interface EmbedBootstrapDeps {
+  fetch: typeof fetch;
+  location: Location;
+  history?: Pick<History, "replaceState">;
+  applyToken: (token: string) => void;
+  markReady?: (platform: EmbedPlatform) => void;
+}
+
+interface EmbedAuthResponse {
+  token?: unknown;
+  expiresAt?: unknown;
+}
+
+const EMBED_AUTH_PATH = "/api/embed/auth";
+
+function isEmbedPath(pathname: string): boolean {
+  return pathname === "/embed" || pathname.startsWith("/embed/");
+}
+
+function normalizePlatform(value: string | null): EmbedPlatform | null {
+  return value === "telegram" || value === "discord" ? value : null;
+}
+
+function telegramLaunchPayload(win: EmbedWindow): string | null {
+  const initData = win.Telegram?.WebApp?.initData;
+  return typeof initData === "string" && initData.trim()
+    ? initData.trim()
+    : null;
+}
+
+function resolveSignedLaunchPayload(
+  platform: EmbedPlatform,
+  params: URLSearchParams,
+  win: EmbedWindow,
+): string | null {
+  const explicit = params.get("signedLaunchPayload");
+  if (explicit?.trim()) return explicit.trim();
+  if (platform === "telegram") return telegramLaunchPayload(win);
+  const code = params.get("code");
+  return code?.trim() || null;
+}
+
+function cleanupSensitiveParams(
+  location: Location,
+  history: Pick<History, "replaceState"> | undefined,
+): void {
+  if (!history) return;
+  const url = new URL(location.href);
+  let changed = false;
+  for (const key of ["code", "signedLaunchPayload"]) {
+    if (url.searchParams.has(key)) {
+      url.searchParams.delete(key);
+      changed = true;
+    }
+  }
+  if (changed) {
+    history.replaceState(null, "", `${url.pathname}${url.search}${url.hash}`);
+  }
+}
+
+export async function bootstrapEmbedLaunch(
+  deps?: Partial<EmbedBootstrapDeps>,
+): Promise<EmbedBootstrapResult> {
+  if (typeof window === "undefined") return { status: "skipped" };
+  const win = window as EmbedWindow;
+  const location = deps?.location ?? window.location;
+  if (!isEmbedPath(location.pathname)) return { status: "skipped" };
+
+  const params = new URLSearchParams(location.search);
+  const platform = normalizePlatform(params.get("platform"));
+  if (!platform) {
+    return { status: "missing-payload", error: "missing_embed_platform" };
+  }
+
+  const signedLaunchPayload = resolveSignedLaunchPayload(platform, params, win);
+  if (!signedLaunchPayload) {
+    return { status: "missing-payload", platform };
+  }
+
+  const fetchImpl = deps?.fetch ?? window.fetch.bind(window);
+  const applyToken =
+    deps?.applyToken ?? ((token: string) => client.setToken(token));
+  let response: Response;
+  try {
+    response = await fetchImpl(EMBED_AUTH_PATH, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ platform, signedLaunchPayload }),
+    });
+  } catch (err) {
+    return {
+      status: "auth-failed",
+      platform,
+      error: err instanceof Error ? err.message : "embed_auth_network_error",
+    };
+  }
+
+  if (!response.ok) {
+    return {
+      status: "auth-failed",
+      platform,
+      statusCode: response.status,
+    };
+  }
+
+  const body = (await response
+    .json()
+    .catch(() => null)) as EmbedAuthResponse | null;
+  const token = typeof body?.token === "string" ? body.token.trim() : "";
+  if (!token) {
+    return { status: "no-token", platform };
+  }
+
+  applyToken(token);
+  cleanupSensitiveParams(location, deps?.history ?? window.history);
+  deps?.markReady?.(platform);
+  win.Telegram?.WebApp?.ready?.();
+  return { status: "authenticated", platform };
+}

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -135,6 +135,7 @@ import { APP_ENV_ALIASES, APP_ENV_PREFIX } from "./brand-env";
 import { APP_CHARACTER_CATALOG } from "./character-catalog";
 import { isTrustedAppLink } from "./deep-link-handler";
 import { buildAssistantLaunchHashRoute } from "./deep-link-routing";
+import { bootstrapEmbedLaunch } from "./embed-launch";
 import {
   apiBaseToDeviceBridgeUrl,
   type IosRuntimeConfig,
@@ -2647,6 +2648,22 @@ async function main(): Promise<void> {
   } catch (err) {
     console.error(
       `${APP_LOG_PREFIX} Failed to apply managed cloud launch session:`,
+      err instanceof Error ? err.message : err,
+    );
+  }
+
+  try {
+    const embedBootstrap = await bootstrapEmbedLaunch();
+    if (embedBootstrap.status !== "skipped") {
+      console.info(`${APP_LOG_PREFIX} Embed launch bootstrap`, {
+        status: embedBootstrap.status,
+        platform: embedBootstrap.platform,
+        statusCode: embedBootstrap.statusCode,
+      });
+    }
+  } catch (err) {
+    console.error(
+      `${APP_LOG_PREFIX} Failed to bootstrap embedded launch session:`,
       err instanceof Error ? err.message : err,
     );
   }


### PR DESCRIPTION
## Summary

- Adds a `/embed` startup bootstrap in `packages/app` before the normal app mount.
- Reads Telegram `window.Telegram.WebApp.initData`, Discord OAuth `code`, or explicit `signedLaunchPayload`, then posts `{ platform, signedLaunchPayload }` to `/api/embed/auth`.
- Stores a returned scoped token through the existing `ElizaClient.setToken` path, removes sensitive query params, and fails closed on missing payload/auth/token.

Fixes #9947 for the client bootstrap slice.

## Evidence

Evidence file: `.github/issue-evidence/9947-embed-client/README.md`

Passed:

- `bun run --cwd packages/app test src/embed-launch.test.ts` - 1 file, 6 tests
- `bun run --cwd packages/app-core test src/api/embed-auth-routes.test.ts src/api/auth/embed-session-token.test.ts` - 2 files, 13 tests
- `bun run --cwd packages/app lint` - 123 files checked
- `git diff --check`
- `bun run --cwd packages/app audit:app` after rebasing onto latest `origin/develop` - 349 passed; broken=0, needs-work=0

Blocked / N/A:

- `bun run --cwd packages/app typecheck` is blocked by existing workspace reference/type errors outside this change (`@elizaos/plugin-streaming`, `@elizaos/vault`, `@elizaos/tui`, `@elizaos/skills`, `@elizaos/cloud-sdk`, plus existing plugin app-manager / elizacloud type errors). No errors were reported in this PR's touched app files.
- Real LLM trajectory is N/A; this is an app launch/auth bootstrap path.
- Live Telegram/Discord walkthrough remains pending real bot/activity credentials and deployed embed session secret/verifier configuration.
