### PR TITLE
test(agent-stability): prove installProcessCrashGuards handles real process faults (#10203)

### DIFF
--- a/.github/issue-evidence/10203-process-crash-guards-e2e/README.md
+++ b/.github/issue-evidence/10203-process-crash-guards-e2e/README.md
@@ -1,0 +1,53 @@
+# #10203 — installProcessCrashGuards real-process E2E
+
+## Gap closed
+
+`installProcessCrashGuards` (`packages/shared/src/process-guards.ts`) is the
+seam that turns a serving agent's uncaught exception into a *supervised restart*
+(exit 75) and keeps a background promise rejection non-fatal. Its unit test
+(`process-guards.test.ts`) **deliberately mocks `process.on`** — its own comment
+says it captures the listeners "without actually attaching them to the live
+process (which would let a deliberately triggered rejection escape into the test
+runner)". So it proves the listener *logic* with a mocked `exit`, but nothing
+proved the **real** `process.on("uncaughtException" | "unhandledRejection")`
+wiring behaves per policy in an actual process. Per PR_EVIDENCE ("real E2E, no
+larp"), that seam is now proven end to end.
+
+## What the new fixture + tests do
+
+`packages/agent/test/fixtures/process-guards-child.ts` (spawned under `bun`)
+installs the real guards and triggers a REAL fault:
+
+| PG_POLICY | PG_FAULT | Expected exit | Meaning |
+| --- | --- | --- | --- |
+| restart | uncaught | **75** | supervisor would respawn |
+| exit | uncaught | **1** | supervisor would propagate |
+| keep-alive | uncaught | **0** | agent survives (degraded) |
+| (any) | rejection | **0** | background rejection non-fatal |
+
+Four `RUN_CRASH_RESTART_E2E=1`-gated cases added to
+`crash-restart-supervisor.test.ts` (same gate as the existing crash-restart +
+memory-watchdog e2e; out of the fast unit lane).
+
+## Verification (host-only; no device/key/cluster)
+
+```
+# direct fixture runs:
+PG_POLICY=restart    PG_FAULT=uncaught  -> exit=75
+PG_POLICY=exit       PG_FAULT=uncaught  -> exit=1
+PG_POLICY=keep-alive PG_FAULT=uncaught  -> exit=0
+PG_POLICY=restart    PG_FAULT=rejection -> exit=0
+
+$ RUN_CRASH_RESTART_E2E=1 bun run --cwd packages/agent test -- crash-restart-supervisor
+ Test Files  1 passed (1)
+      Tests  14 passed (14)   # 7 crash-injection + 3 memory-watchdog + 4 process-guards
+
+$ bun run --cwd packages/agent test -- crash-restart-supervisor
+      Tests  14 skipped (14)   # gate holds; fast lane unaffected
+```
+
+## N/A
+- **Live-LLM trajectory / screenshots / audio:** N/A — process-lifecycle stability
+  test (spawned `bun` children triggering real faults); no model/UI/audio path.
+- **iOS device / k8s cluster:** out of scope here — those remaining #10197/#10203
+  lanes are tracked in the (still-draft) #10616.

--- a/packages/agent/test/crash-restart-supervisor.test.ts
+++ b/packages/agent/test/crash-restart-supervisor.test.ts
@@ -19,6 +19,7 @@ import { afterAll, describe, expect, it } from "vitest";
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const CHILD = path.join(HERE, "fixtures", "crash-injection-child.ts");
 const MEMORY_CHILD = path.join(HERE, "fixtures", "memory-watchdog-child.ts");
+const GUARDS_CHILD = path.join(HERE, "fixtures", "process-guards-child.ts");
 
 // Spawns real `bun` child processes — gated like `test:tui-pty` so it stays out
 // of the fast unit lane and runs in the post-merge / on-demand lane with
@@ -67,6 +68,9 @@ const runChild = (env: Record<string, string>): Promise<number> =>
 // crash-injection child.
 const runMemoryChild = (env: Record<string, string>): Promise<number> =>
   runChildAt(MEMORY_CHILD, env, 25_000);
+
+const runGuardsChild = (env: Record<string, string>): Promise<number> =>
+  runChildAt(GUARDS_CHILD, env, 10_000);
 
 /** Supervisor mirroring run-node.mjs: respawn on 75, storm-guard, else propagate. */
 async function supervise(
@@ -211,4 +215,34 @@ describeE2E("memory watchdog -> supervised restart (real RSS pressure)", () => {
     });
     expect(code).toBe(0);
   }, 25_000);
+});
+
+// End-to-end proof for installProcessCrashGuards (#10203): the packages/shared
+// unit test can only call the captured listeners by hand with a mocked exit —
+// attaching real guards would crash the runner. These spawn a real bun child
+// that installs the guards and triggers a REAL uncaughtException / unhandled
+// rejection, proving the actual process.on(...) wiring behaves per policy.
+describeE2E("installProcessCrashGuards -> real process fault handling", () => {
+  it("exits RESTART_EXIT_CODE on a real uncaught exception (restart policy)", async () => {
+    const code = await runGuardsChild({ PG_POLICY: "restart", PG_FAULT: "uncaught" });
+    expect(code).toBe(RESTART_EXIT_CODE);
+  }, 15_000);
+
+  it("exits 1 on a real uncaught exception (exit policy)", async () => {
+    const code = await runGuardsChild({ PG_POLICY: "exit", PG_FAULT: "uncaught" });
+    expect(code).toBe(1);
+  }, 15_000);
+
+  it("survives a real uncaught exception (keep-alive policy) -> clean exit 0", async () => {
+    const code = await runGuardsChild({
+      PG_POLICY: "keep-alive",
+      PG_FAULT: "uncaught",
+    });
+    expect(code).toBe(0);
+  }, 15_000);
+
+  it("treats a real unhandled promise rejection as non-fatal -> stays alive, exit 0", async () => {
+    const code = await runGuardsChild({ PG_POLICY: "restart", PG_FAULT: "rejection" });
+    expect(code).toBe(0);
+  }, 15_000);
 });

--- a/packages/agent/test/fixtures/process-guards-child.ts
+++ b/packages/agent/test/fixtures/process-guards-child.ts
@@ -1,0 +1,53 @@
+/**
+ * Supervised child fixture for the process-crash-guards e2e (#10203). Run under
+ * `bun`. It installs the REAL `installProcessCrashGuards` from `@elizaos/shared`
+ * on a real process and then triggers a REAL fault, so the e2e proves the actual
+ * `process.on("uncaughtException" | "unhandledRejection")` wiring — not a mocked
+ * listener called by hand (which is all the `packages/shared` unit test can do,
+ * since attaching real guards would crash the test runner).
+ *
+ * Env knobs (set by the e2e):
+ *   - `PG_POLICY`  restart | exit | keep-alive   (onUncaughtException policy)
+ *   - `PG_FAULT`   uncaught | rejection          (which real fault to trigger)
+ *
+ * Expected exit codes:
+ *   uncaught + restart    → RESTART_EXIT_CODE (75)  (supervisor would respawn)
+ *   uncaught + exit       → 1                        (supervisor would propagate)
+ *   uncaught + keep-alive → 0                        (agent survives, degraded)
+ *   rejection (any policy)→ 0                        (background rejection non-fatal)
+ */
+import process from "node:process";
+
+import { installProcessCrashGuards } from "@elizaos/shared";
+
+const policy = (process.env.PG_POLICY ?? "restart") as
+  | "restart"
+  | "exit"
+  | "keep-alive";
+const fault = process.env.PG_FAULT ?? "uncaught";
+
+installProcessCrashGuards({
+  onUncaughtException: policy,
+  // Silence the guard's own logging so the child's stdio stays quiet.
+  log: () => {},
+  warn: () => {},
+});
+
+// A ref'd survival timer: for keep-alive / rejection the guards do NOT exit, so
+// the child proves it stayed alive by exiting 0 here. For restart/exit the
+// installed handler exits (75 / 1) before this fires.
+const survive = setTimeout(() => process.exit(0), 600);
+survive.ref?.();
+
+if (fault === "rejection") {
+  // A real unhandled promise rejection must be caught by the guard and left
+  // non-fatal — the process must NOT die from it.
+  Promise.reject(new Error("process-guards-child: injected background rejection"));
+} else {
+  // Throw asynchronously so it escapes as a genuine `uncaughtException` the
+  // installed handler processes. A synchronous throw at module top level would
+  // instead fail the module load before the guard could act.
+  setTimeout(() => {
+    throw new Error("process-guards-child: injected uncaught exception");
+  }, 10);
+}


### PR DESCRIPTION
Relates to #10203 (and #10197).

## Summary

Closes a real-E2E gap in the crash-guard stability seam. `installProcessCrashGuards` (`packages/shared/src/process-guards.ts`) turns a serving agent's uncaught exception into a supervised restart (exit 75) and keeps background promise rejections non-fatal. Its unit test **deliberately mocks `process.on`** — the comment says it captures the listeners "without actually attaching them to the live process (which would let a deliberately triggered rejection escape into the test runner)". So the *logic* is covered with a mocked `exit`, but nothing proved the **real** `process.on(...)` wiring behaves per policy in an actual process.

## What's added

- `packages/agent/test/fixtures/process-guards-child.ts` — a `bun` child that installs the real guards and triggers a genuine fault.
- Four `RUN_CRASH_RESTART_E2E=1`-gated cases in `crash-restart-supervisor.test.ts` (same gate + harness as the existing crash-restart + memory-watchdog e2e):

| PG_POLICY | PG_FAULT | exit | meaning |
| --- | --- | --- | --- |
| restart | uncaught | **75** | supervisor would respawn |
| exit | uncaught | **1** | supervisor would propagate |
| keep-alive | uncaught | **0** | agent survives (degraded) |
| (any) | rejection | **0** | background rejection non-fatal |

## Evidence

`.github/issue-evidence/10203-process-crash-guards-e2e/README.md`.

```
PG_POLICY=restart    PG_FAULT=uncaught  -> exit=75
PG_POLICY=exit       PG_FAULT=uncaught  -> exit=1
PG_POLICY=keep-alive PG_FAULT=uncaught  -> exit=0
PG_POLICY=restart    PG_FAULT=rejection -> exit=0

$ RUN_CRASH_RESTART_E2E=1 bun run --cwd packages/agent test -- crash-restart-supervisor
 Test Files  1 passed (1)   Tests  14 passed (14)   # 7 crash-injection + 3 watchdog + 4 process-guards

$ bun run --cwd packages/agent test -- crash-restart-supervisor
 Tests  14 skipped (14)   # gate holds; fast lane unaffected
```

### N/A
- **Live-LLM trajectory / screenshots / audio:** N/A — process-lifecycle stability test (spawned `bun` children triggering real faults).
- **iOS device / k8s cluster:** out of scope here; those remaining #10197/#10203 lanes are tracked in the still-draft #10616.

🤖 Generated with [Claude Code](https://claude.com/claude-code)