### PR TITLE
fix(embed): bound launch auth handshake (#9947)

### DIFF
--- a/.github/issue-evidence/9947-embed-auth-timeout/README.md
+++ b/.github/issue-evidence/9947-embed-auth-timeout/README.md
@@ -1,0 +1,30 @@
+# #9947 embed auth timeout follow-up
+
+Follow-up to the merged embed client bootstrap (#10653). The `/embed` SPA
+authenticates before mounting by posting the platform launch payload to
+`/api/embed/auth`. Without a timeout, a stalled iframe/network request could
+leave the app blank indefinitely instead of mounting in the unauthenticated
+fallback state.
+
+## Change
+
+- Bound the embed auth request with a 10s timeout.
+- Abort the fetch when supported.
+- Return `network_timeout` without installing a token when the request never
+  resolves.
+
+## Validation
+
+Run from `/tmp/eliza-pr-9947-timeout`:
+
+```bash
+bun install --frozen-lockfile --ignore-scripts
+bun run build:core
+bun run --cwd packages/app test src/embed-bootstrap.test.ts
+bunx @biomejs/biome check packages/app/src/embed-bootstrap.ts packages/app/src/embed-bootstrap.test.ts .github/issue-evidence/9947-embed-auth-timeout/README.md
+git diff --check origin/develop...HEAD
+```
+
+The connector URL-tagging tests were already validated on the merged #10653
+branch before this follow-up was split out; this PR only changes the app
+bootstrap timeout path.

--- a/packages/app/src/embed-bootstrap.test.ts
+++ b/packages/app/src/embed-bootstrap.test.ts
@@ -239,4 +239,31 @@ describe("runEmbedHandshake", () => {
     expect(outcome).toEqual({ status: "failed", reason: "network_error" });
     expect(setToken).not.toHaveBeenCalled();
   });
+
+  it("fails closed when the auth request times out", async () => {
+    vi.useFakeTimers();
+    try {
+      const { client, setToken } = fakeClient();
+      const fetchImpl = vi.fn(
+        (_url: string, _init?: RequestInit) => new Promise<Response>(() => {}),
+      );
+      const outcomePromise = runEmbedHandshake({
+        win: fakeWin("/embed", "?platform=telegram", "tg"),
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        client,
+        timeoutMs: 25,
+      });
+
+      await vi.advanceTimersByTimeAsync(25);
+
+      await expect(outcomePromise).resolves.toEqual({
+        status: "failed",
+        reason: "network_timeout",
+      });
+      expect(setToken).not.toHaveBeenCalled();
+      expect(fetchImpl.mock.calls[0][1]?.signal).toBeInstanceOf(AbortSignal);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/packages/app/src/embed-bootstrap.ts
+++ b/packages/app/src/embed-bootstrap.ts
@@ -44,7 +44,10 @@ interface EmbedHandshakeDeps {
   win?: Window;
   fetchImpl?: typeof fetch;
   client?: EmbedClient;
+  timeoutMs?: number;
 }
+
+const DEFAULT_EMBED_AUTH_TIMEOUT_MS = 10_000;
 
 export function isEmbedPath(pathname: string): boolean {
   return pathname === "/embed" || pathname.startsWith("/embed/");
@@ -133,12 +136,17 @@ export async function runEmbedHandshake(
   const fetchImpl = deps.fetchImpl ?? fetch;
   const accountId = params.get("accountId") ?? undefined;
   const base = embedClient.getBaseUrl().replace(/\/+$/, "");
+  const timeoutMs = deps.timeoutMs ?? DEFAULT_EMBED_AUTH_TIMEOUT_MS;
 
   let response: Response;
+  const abortController =
+    typeof AbortController !== "undefined" ? new AbortController() : null;
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   try {
-    response = await fetchImpl(`${base}/api/embed/auth`, {
+    const authRequest = fetchImpl(`${base}/api/embed/auth`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
+      signal: abortController?.signal,
       body: JSON.stringify({
         platform,
         signedLaunchPayload,
@@ -146,8 +154,19 @@ export async function runEmbedHandshake(
         ...(oauthState ? { state: oauthState } : {}),
       }),
     });
+    const timeout = new Promise<"timeout">((resolve) => {
+      timeoutHandle = setTimeout(() => resolve("timeout"), timeoutMs);
+    });
+    const result = await Promise.race([authRequest, timeout]);
+    if (result === "timeout") {
+      abortController?.abort();
+      return { status: "failed", reason: "network_timeout" };
+    }
+    response = result;
   } catch {
     return { status: "failed", reason: "network_error" };
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
   }
 
   if (!response.ok) {


### PR DESCRIPTION
## Summary
- bounds the `/embed` pre-mount auth exchange with a 10s timeout
- aborts the fetch when supported and fails closed with `network_timeout`
- adds regression coverage for a never-resolving auth request so the app does not remain blank indefinitely

## Evidence
- `bun install --frozen-lockfile --ignore-scripts`
- `bun run build:core` -> 64/64 tasks passed
- `bun run --cwd packages/app test src/embed-bootstrap.test.ts` -> 14/14 passed
- `bunx @biomejs/biome check packages/app/src/embed-bootstrap.ts packages/app/src/embed-bootstrap.test.ts .github/issue-evidence/9947-embed-auth-timeout/README.md`
- `git diff --check origin/develop...HEAD`

Evidence note: `.github/issue-evidence/9947-embed-auth-timeout/README.md`

Refs #9947