### PR TITLE
fix(embed): time-box the embed auth handshake fetch (#9947)

### DIFF
--- a/packages/app/src/embed-bootstrap.test.ts
+++ b/packages/app/src/embed-bootstrap.test.ts
@@ -239,4 +239,31 @@ describe("runEmbedHandshake", () => {
     expect(outcome).toEqual({ status: "failed", reason: "network_error" });
     expect(setToken).not.toHaveBeenCalled();
   });
+
+  it("fails closed when the auth request times out", async () => {
+    vi.useFakeTimers();
+    try {
+      const { client, setToken } = fakeClient();
+      const fetchImpl = vi.fn(
+        (_url: string, _init?: RequestInit) => new Promise<Response>(() => {}),
+      );
+      const outcomePromise = runEmbedHandshake({
+        win: fakeWin("/embed", "?platform=telegram", "tg"),
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        client,
+        timeoutMs: 25,
+      });
+
+      await vi.advanceTimersByTimeAsync(25);
+
+      await expect(outcomePromise).resolves.toEqual({
+        status: "failed",
+        reason: "network_timeout",
+      });
+      expect(setToken).not.toHaveBeenCalled();
+      expect(fetchImpl.mock.calls[0][1]?.signal).toBeInstanceOf(AbortSignal);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/packages/app/src/embed-bootstrap.ts
+++ b/packages/app/src/embed-bootstrap.ts
@@ -44,7 +44,10 @@ interface EmbedHandshakeDeps {
   win?: Window;
   fetchImpl?: typeof fetch;
   client?: EmbedClient;
+  timeoutMs?: number;
 }
+
+const DEFAULT_EMBED_AUTH_TIMEOUT_MS = 10_000;
 
 export function isEmbedPath(pathname: string): boolean {
   return pathname === "/embed" || pathname.startsWith("/embed/");
@@ -133,12 +136,17 @@ export async function runEmbedHandshake(
   const fetchImpl = deps.fetchImpl ?? fetch;
   const accountId = params.get("accountId") ?? undefined;
   const base = embedClient.getBaseUrl().replace(/\/+$/, "");
+  const timeoutMs = deps.timeoutMs ?? DEFAULT_EMBED_AUTH_TIMEOUT_MS;
 
   let response: Response;
+  const abortController =
+    typeof AbortController !== "undefined" ? new AbortController() : null;
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   try {
-    response = await fetchImpl(`${base}/api/embed/auth`, {
+    const authRequest = fetchImpl(`${base}/api/embed/auth`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
+      signal: abortController?.signal,
       body: JSON.stringify({
         platform,
         signedLaunchPayload,
@@ -146,8 +154,19 @@ export async function runEmbedHandshake(
         ...(oauthState ? { state: oauthState } : {}),
       }),
     });
+    const timeout = new Promise<"timeout">((resolve) => {
+      timeoutHandle = setTimeout(() => resolve("timeout"), timeoutMs);
+    });
+    const result = await Promise.race([authRequest, timeout]);
+    if (result === "timeout") {
+      abortController?.abort();
+      return { status: "failed", reason: "network_timeout" };
+    }
+    response = result;
   } catch {
     return { status: "failed", reason: "network_error" };
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
   }
 
   if (!response.ok) {


### PR DESCRIPTION
The `/embed` client bootstrap awaited `POST /api/embed/auth` with **no timeout**, so a stalled network or unresponsive server left the embed session hanging forever with no failure surfaced. This races the fetch against a default **10s timeout** (configurable via `deps.timeoutMs`) backed by an `AbortController` that aborts the in-flight request, returning `{ status: "failed", reason: "network_timeout" }` so the caller can surface a real error. Adds a test for the timeout path.

**Provenance:** salvaged from the stranded no-PR branch `feat/9947-embed-spa-page` (a post-merge follow-up to the merged #10653). Verified the change is a clean superset of `develop` — the salvage tree differs from develop only by this timeout logic + its test (47+/1-, the single deletion is the intended fetch-line refactor into the timeout race).

🤖 Generated with [Claude Code](https://claude.com/claude-code)