### PR TITLE
feat(benchmarks): guard against committing generated benchmark output (#10199)

### DIFF
--- a/.github/issue-evidence/10199-benchmark-artifact-guard/README.md
+++ b/.github/issue-evidence/10199-benchmark-artifact-guard/README.md
@@ -1,0 +1,54 @@
+# #10199 — benchmark artifact-commit guard
+
+## AC satisfied
+
+#10199 acceptance criteria: *"The script fails clearly when ... generated
+artifacts would be committed accidentally"* and *"Keep generated run output
+ignored; commit only final reviewed markdown scorecards and lightweight
+manifests."* No enforceable guard existed — the convention lived only in
+`benchmarks/CLAUDE.md` + `.gitignore` (which silently ignores, never fails).
+
+## What's added
+
+- `packages/benchmarks/orchestrator/artifact_guard.py` — classifies a
+  repo-relative path as generated benchmark output by matching **directory
+  components** (`benchmark_results`/`benchmark_results*`/`test_output`/
+  `trajectories`) + the two generated trajectory filenames, scoped to the
+  benchmark tree (`packages/benchmarks/**`, repo-root `benchmark_results/`). The
+  three `.gitignore`-negated reviewed artifacts are allow-listed 1:1.
+- `python -m benchmarks.orchestrator verify-artifacts` — scans `git ls-files`
+  (tracked + staged) and exits non-zero with a clear, actionable list if any
+  generated output is committed.
+
+## Why the classifier is scoped (real bug the test caught)
+
+An initial substring/component match false-positived on legitimate **source**
+`trajectories/` dirs (`packages/core/src/features/trajectories/`, UI
+`components/composites/trajectories/`) and intentionally-committed **evidence**
+(`.github/issue-evidence/**/trajectories/`). The `test_current_repo_index_is_clean`
+test (real `git ls-files` over 46,123 tracked files) caught this; the classifier
+now scopes to the benchmark tree exactly as `.gitignore` does. Source files whose
+names merely resemble output (`trajectories.js`, `trajectories.py`,
+`test_outputs.py`) are matched as filenames, never dir components, so they are
+never flagged.
+
+## Verification (host-only; no key)
+
+```
+$ python -m benchmarks.orchestrator verify-artifacts
+# Benchmark artifact guard
+OK — checked 46123 tracked file(s); no generated benchmark output is committed.
+(exit 0)
+
+$ python -m pytest benchmarks/orchestrator/tests/test_artifact_guard.py -q
+7 passed
+```
+
+Tests cover: generated-output detection, source-lookalike protection, the three
+allow-listed reviewed artifacts, dedupe/sort, injected-git report ok/fail paths,
+and the real current-repo scan.
+
+## N/A
+- Live-model trajectory / screenshots / audio: N/A — this is a deterministic
+  git-index guard; no model/UI/audio path. It complements (does not replace) the
+  key-gated full benchmark rerun still tracked in #10199.

--- a/packages/benchmarks/orchestrator/artifact_guard.py
+++ b/packages/benchmarks/orchestrator/artifact_guard.py
@@ -1,0 +1,179 @@
+"""Guard against committing generated benchmark output (#10199).
+
+Acceptance criterion for the benchmark review flow: *"The script fails clearly
+when ... generated artifacts would be committed accidentally"* and *"Keep
+generated run output ignored; commit only final reviewed markdown scorecards and
+lightweight manifests."*
+
+`benchmarks/CLAUDE.md` is explicit: anything under ``benchmark_results/`` and
+per-benchmark run output (result JSON, SQLite DBs, trajectories, logs, coverage)
+is generated and must never be committed. The repo ``.gitignore`` encodes this
+with a handful of ``!`` negations for the three intentionally-reviewed artifacts.
+
+This module turns that convention into an enforceable gate. It classifies a
+repo-relative path as a generated artifact by matching **directory components**
+(``benchmark_results``/``benchmark_results*``/``test_output``/``trajectories``)
+and the two generated trajectory filenames — never a bare substring, so source
+files like ``frontend/assets/trajectories.js`` or ``tests/test_outputs.py`` are
+never flagged. The three ``.gitignore``-negated reviewed artifacts are
+allow-listed here to stay in 1:1 sync with the ignore rules.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+# Mirrors the ``!`` negations under ``benchmark_results/`` in the repo
+# ``.gitignore``: the reviewed artifacts that ARE intentionally committed.
+ALLOWLISTED_REVIEWED_ARTIFACTS: frozenset[str] = frozenset(
+    {
+        "benchmark_results/bfcl/bfcl_best_results.json",
+        "benchmark_results/mint/MINT-BENCHMARK-REPORT.md",
+        "benchmark_results/mint/mint-benchmark-results.json",
+    }
+)
+
+# Generated files that live outside a generated directory but are still output.
+GENERATED_FILENAMES: frozenset[str] = frozenset(
+    {"trajectories.art.jsonl", "trajectories.grpo.groups.json"}
+)
+
+GitRunner = Callable[[list[str]], str]
+
+
+def _normalize(path: str) -> str:
+    normalized = path.strip().replace("\\", "/")
+    return normalized[2:] if normalized.startswith("./") else normalized
+
+
+def _is_generated_dir_component(component: str) -> bool:
+    # ``benchmark_results`` and ``benchmark_results*`` (the ``.gitignore`` glob),
+    # plus the ``test_output`` and ``trajectories`` output directories — matched
+    # as whole path components so ``test_outputs.py`` / ``trajectories.js`` don't
+    # false-positive.
+    return (
+        component == "test_output"
+        or component == "trajectories"
+        or component.startswith("benchmark_results")
+    )
+
+
+def _in_benchmark_scope(parts: list[str]) -> bool:
+    # The ``.gitignore`` scopes generated output to the benchmark tree
+    # (``/benchmarks/**`` → ``packages/benchmarks/…`` or a top-level
+    # ``benchmarks/…``) and the repo-root ``benchmark_results/``. A ``trajectories``
+    # directory anywhere else — ``packages/core/src/features/trajectories`` source,
+    # UI components, or intentionally-committed ``.github/issue-evidence/…``
+    # evidence — is NOT benchmark run output and must never be flagged.
+    if parts and parts[0].startswith("benchmark_results"):
+        return True
+    if "benchmarks" not in parts:
+        return False
+    index = parts.index("benchmarks")
+    return index == 0 or (index == 1 and parts[0] == "packages")
+
+
+def is_generated_artifact(path: str) -> bool:
+    """True when ``path`` (repo-relative) is generated benchmark output that must
+    not be committed. Allow-listed reviewed artifacts return ``False``."""
+    norm = _normalize(path)
+    if not norm:
+        return False
+    if any(
+        norm == allowed or norm.endswith(f"/{allowed}")
+        for allowed in ALLOWLISTED_REVIEWED_ARTIFACTS
+    ):
+        return False
+    parts = norm.split("/")
+    if not _in_benchmark_scope(parts):
+        return False
+    if any(_is_generated_dir_component(component) for component in parts[:-1]):
+        return True
+    return parts[-1] in GENERATED_FILENAMES
+
+
+def find_committed_generated_artifacts(paths: Iterable[str]) -> tuple[str, ...]:
+    """Filter an iterable of repo-relative paths down to the generated artifacts
+    that would be committed. Pure — the unit-testable core of the guard."""
+    seen: set[str] = set()
+    offending: list[str] = []
+    for path in paths:
+        norm = _normalize(path)
+        if norm in seen:
+            continue
+        seen.add(norm)
+        if is_generated_artifact(norm):
+            offending.append(norm)
+    return tuple(sorted(offending))
+
+
+@dataclass(frozen=True)
+class ArtifactGuardReport:
+    ok: bool
+    checked_count: int
+    offending: tuple[str, ...]
+
+    def to_markdown(self) -> str:
+        if self.ok:
+            return (
+                "# Benchmark artifact guard\n\n"
+                f"OK — checked {self.checked_count} tracked file(s); "
+                "no generated benchmark output is committed.\n"
+            )
+        lines = [
+            "# Benchmark artifact guard",
+            "",
+            f"FAILED — {len(self.offending)} generated artifact(s) are committed "
+            "or staged and must not be:",
+            "",
+        ]
+        lines.extend(f"- `{path}`" for path in self.offending)
+        lines.extend(
+            [
+                "",
+                "Generated benchmark output (result JSON, SQLite DBs, trajectories,"
+                " logs, coverage) is gitignored by design — `git rm --cached` these"
+                " and keep only reviewed markdown scorecards outside"
+                " `benchmark_results/`. See `packages/benchmarks/CLAUDE.md`.",
+                "",
+            ]
+        )
+        return "\n".join(lines)
+
+
+def _default_git_runner(repo_root: Path) -> GitRunner:
+    def run(args: list[str]) -> str:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout
+
+    return run
+
+
+def build_artifact_guard_report(
+    workspace_root: Path,
+    run_git: GitRunner | None = None,
+) -> ArtifactGuardReport:
+    """Scan the git index (tracked + staged-for-add files) for generated
+    benchmark output that would be committed.
+
+    ``run_git`` is injectable so the classifier can be tested without a real
+    repository; by default it shells out to ``git ls-files`` at the repo root.
+    """
+    repo_root = workspace_root.parent  # workspace_root is ``.../packages``
+    runner = run_git or _default_git_runner(repo_root)
+    tracked = [line for line in runner(["ls-files"]).splitlines() if line.strip()]
+    offending = find_committed_generated_artifacts(tracked)
+    return ArtifactGuardReport(
+        ok=not offending,
+        checked_count=len(tracked),
+        offending=offending,
+    )

--- a/packages/benchmarks/orchestrator/cli.py
+++ b/packages/benchmarks/orchestrator/cli.py
@@ -9,6 +9,7 @@ from typing import Any
 from uuid import uuid4
 
 from .adapters import discover_adapters
+from .artifact_guard import build_artifact_guard_report
 from .calibration_report import build_calibration_report, print_calibration_report
 from .compare_vs_random import add_compare_vs_random_parser
 from .db import (
@@ -442,6 +443,13 @@ def _cmd_validate_runtime_gates(args: argparse.Namespace) -> int:
     return 0 if report.ok else 1
 
 
+def _cmd_verify_artifacts(args: argparse.Namespace) -> int:
+    workspace_root = _workspace_root_from_here()
+    report = build_artifact_guard_report(workspace_root)
+    print(report.to_markdown())
+    return 0 if report.ok else 1
+
+
 def _parse_model_spec(spec: str) -> tuple[str, str, str | None]:
     """Parse ``provider:model[@base_url]`` into ``(provider, model, base_url)``.
 
@@ -811,6 +819,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_inventory.add_argument("--format", choices=("markdown", "json"), default="markdown")
     p_inventory.set_defaults(func=_cmd_inventory)
+
+    p_verify_artifacts = sub.add_parser(
+        "verify-artifacts",
+        help="Fail if generated benchmark output (results/DBs/trajectories) is committed",
+    )
+    p_verify_artifacts.set_defaults(func=_cmd_verify_artifacts)
 
     p_run = sub.add_parser("run", help="Run one or more benchmarks idempotently")
     p_run.add_argument("--all", action="store_true", help="Run all integrated benchmarks")

--- a/packages/benchmarks/orchestrator/tests/test_artifact_guard.py
+++ b/packages/benchmarks/orchestrator/tests/test_artifact_guard.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from benchmarks.orchestrator.artifact_guard import (
+    build_artifact_guard_report,
+    find_committed_generated_artifacts,
+    is_generated_artifact,
+)
+
+
+def _workspace_root() -> Path:
+    # ``.../packages/benchmarks/orchestrator/tests`` -> ``.../packages``
+    return Path(__file__).resolve().parents[3]
+
+
+GENERATED = [
+    "benchmark_results/mmlu/run.json",
+    "packages/benchmarks/benchmark_results/orchestrator.sqlite",
+    "packages/benchmarks/benchmark_results/comparisons/x.json",
+    "packages/benchmarks/some-bench/benchmark_results_v2/out.jsonl",
+    "packages/benchmarks/some-bench/test_output/result.json",
+    "packages/benchmarks/some-bench/trajectories/turn-1.jsonl",
+    "packages/benchmarks/some-bench/trajectories.art.jsonl",
+    "packages/benchmarks/some-bench/trajectories.grpo.groups.json",
+]
+
+# Source files whose names merely resemble generated output — must NOT be flagged.
+SOURCE_LOOKALIKES = [
+    "packages/benchmarks/HyperliquidBench/frontend/assets/trajectories.js",
+    "packages/benchmarks/lifeops-bench/eliza_lifeops_bench/ingest/trajectories.py",
+    "packages/benchmarks/tau-bench/tests/test_output_contract.py",
+    "packages/benchmarks/terminal-bench/tasks/foo/tests/test_outputs.py",
+    "packages/benchmarks/orchestrator/artifact_guard.py",
+    "packages/benchmarks/registry/commands.py",
+]
+
+# The three intentionally-committed reviewed artifacts (.gitignore ``!`` negations).
+ALLOWLISTED = [
+    "benchmark_results/bfcl/bfcl_best_results.json",
+    "benchmark_results/mint/MINT-BENCHMARK-REPORT.md",
+    "benchmark_results/mint/mint-benchmark-results.json",
+]
+
+
+def test_flags_generated_output() -> None:
+    for path in GENERATED:
+        assert is_generated_artifact(path) is True, path
+
+
+def test_does_not_flag_source_lookalikes() -> None:
+    for path in SOURCE_LOOKALIKES:
+        assert is_generated_artifact(path) is False, path
+
+
+def test_allowlisted_reviewed_artifacts_are_not_flagged() -> None:
+    for path in ALLOWLISTED:
+        assert is_generated_artifact(path) is False, path
+    # Also robust to a repo-prefixed form.
+    assert (
+        is_generated_artifact("packages/benchmarks/benchmark_results/mint/mint-benchmark-results.json")
+        is False
+    )
+
+
+def test_find_committed_generated_artifacts_dedupes_and_sorts() -> None:
+    mixed = [*SOURCE_LOOKALIKES, *GENERATED, GENERATED[0]]
+    offending = find_committed_generated_artifacts(mixed)
+    assert offending == tuple(sorted({p.strip().lstrip("./") for p in GENERATED}))
+    for path in SOURCE_LOOKALIKES:
+        assert path not in offending
+
+
+def test_report_ok_on_clean_index() -> None:
+    report = build_artifact_guard_report(
+        _workspace_root(),
+        run_git=lambda _args: "\n".join(SOURCE_LOOKALIKES),
+    )
+    assert report.ok is True
+    assert report.offending == ()
+    assert report.checked_count == len(SOURCE_LOOKALIKES)
+    assert "OK" in report.to_markdown()
+
+
+def test_report_fails_and_lists_offenders() -> None:
+    report = build_artifact_guard_report(
+        _workspace_root(),
+        run_git=lambda _args: "\n".join([*SOURCE_LOOKALIKES, *GENERATED]),
+    )
+    assert report.ok is False
+    assert set(report.offending) == {p.strip().lstrip("./") for p in GENERATED}
+    md = report.to_markdown()
+    assert "FAILED" in md
+    assert "benchmark_results/mmlu/run.json" in md
+
+
+def test_current_repo_index_is_clean() -> None:
+    # The guard's real job: the actual tracked tree must carry no committed
+    # generated benchmark output. This drives the real ``git ls-files`` path.
+    report = build_artifact_guard_report(_workspace_root())
+    assert report.ok is True, f"committed generated artifacts: {report.offending}"
+    assert report.checked_count > 0


### PR DESCRIPTION
Relates to #10199.

## Summary

Implements a deterministic acceptance criterion from #10199 that had no enforcement: *"The script fails clearly when ... generated artifacts would be committed accidentally"* + *"commit only final reviewed markdown scorecards."* The rule lived only in `benchmarks/CLAUDE.md` and `.gitignore` — which silently ignores, but never *fails* if a generated result leaks into a commit.

- **`packages/benchmarks/orchestrator/artifact_guard.py`** — classifies a repo-relative path as generated benchmark output by matching **directory components** (`benchmark_results`/`benchmark_results*`/`test_output`/`trajectories`) plus the two generated trajectory filenames, **scoped to the benchmark tree** (`packages/benchmarks/**` + repo-root `benchmark_results/`) exactly as `.gitignore` is. The three `.gitignore`-negated reviewed artifacts are allow-listed 1:1.
- **`python -m benchmarks.orchestrator verify-artifacts`** — scans `git ls-files` and exits non-zero with an actionable list if any generated output is committed/staged.

## The bug the real-repo test caught

A first naive classifier false-positived on legitimate **source** `trajectories/` directories (`packages/core/src/features/trajectories/`, UI `components/composites/trajectories/`) and intentionally-committed **evidence** (`.github/issue-evidence/**/trajectories/`). The `test_current_repo_index_is_clean` test — a *real* `git ls-files` scan over 46,123 tracked files — flagged this, and the classifier was scoped to the benchmark tree. Lookalike **filenames** (`trajectories.js`, `trajectories.py`, `test_outputs.py`) match as filenames, never directory components, so they're never flagged.

## Evidence

`.github/issue-evidence/10199-benchmark-artifact-guard/README.md`.

```
$ python -m benchmarks.orchestrator verify-artifacts
OK — checked 46123 tracked file(s); no generated benchmark output is committed.   (exit 0)

$ python -m pytest benchmarks/orchestrator/tests/test_artifact_guard.py -q
7 passed
```

Covers generated-output detection, source-lookalike protection, the three allow-listed reviewed artifacts, dedupe/sort, injected-git ok/fail report paths, and the real current-repo scan.

### N/A
- Live-model trajectory / screenshots / audio: N/A — deterministic git-index guard, no model/UI/audio path. Complements (does not replace) the key-gated full gpt-oss-120b rerun still tracked in #10199.

🤖 Generated with [Claude Code](https://claude.com/claude-code)