### PR TITLE
fix(phone): treat a null permission status as not-granted (#10196)

### DIFF
--- a/plugins/plugin-phone/src/components/PhoneView.test.tsx
+++ b/plugins/plugin-phone/src/components/PhoneView.test.tsx
@@ -205,6 +205,24 @@ describe("PhoneView — recent calls", () => {
     await screen.findByText("READ_CALL_LOG denied");
   });
 
+  it("does not fetch the call log when requestPermissions throws (#10196)", async () => {
+    // A failed permission request must block the read; otherwise we call
+    // listRecentCalls, which rejects and Capacitor logs the raw rejection.
+    phoneBridge.requestPermissions.mockRejectedValueOnce(
+      new Error("bridge unavailable"),
+    );
+    render(React.createElement(PhoneView));
+    await screen.findByText(/Phone access is needed/i);
+    expect(phoneBridge.listRecentCalls).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch the call log when phone permission is denied", async () => {
+    phoneBridge.requestPermissions.mockResolvedValueOnce({ phone: "denied" });
+    render(React.createElement(PhoneView));
+    await screen.findByText(/Phone access is needed/i);
+    expect(phoneBridge.listRecentCalls).not.toHaveBeenCalled();
+  });
+
   it("polls the recent call log on a quiet 20s interval", async () => {
     vi.useFakeTimers();
     try {

--- a/plugins/plugin-phone/src/components/PhoneView.tsx
+++ b/plugins/plugin-phone/src/components/PhoneView.tsx
@@ -68,8 +68,13 @@ export function PhoneView() {
     setLoading(true);
     setError(null);
     try {
+      // A null status means requestPermissions() itself threw — treat that as
+      // "not granted" and stop. Otherwise we fall through to listRecentCalls,
+      // which rejects ("READ_CALL_LOG permission is required") and Capacitor
+      // logs the raw rejection to the console (#10196). Web reports "granted",
+      // so the web/desktop path is unchanged.
       const status = await Phone.requestPermissions().catch(() => null);
-      if (status && status.phone !== "granted") {
+      if (status?.phone !== "granted") {
         setCalls([]);
         setCallReady(false);
         setError(


### PR DESCRIPTION
`PhoneView.requestPermissions()` is wrapped in `.catch(() => null)`, so when the request itself throws, `status` is null. The old guard `if (status && status.phone !== "granted")` was **false** for null and fell through to `listRecentCalls`, which rejects with "READ_CALL_LOG permission is required" and Capacitor logs the raw rejection to the console (#10196). Using `status?.phone !== "granted"` makes a failed request stop the read. Web reports `"granted"`, so the web/desktop path is unchanged. Adds tests for the throw and denied paths.

**Provenance:** salvaged from the stranded no-PR branch `fix/open-issues-linux-cloud-slices-pr-clean2`. Its `ElizaOsAppsView` permission gate already landed via merged #10552; this `PhoneView` null-status guard did not. Verified a clean superset of develop (24+/1-, the single deletion is the replaced condition line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)