### PR TITLE
fix(benchmarks): classify recall_bench into the smoke CI lane (#9956)

### DIFF
--- a/packages/benchmarks/orchestrator/ci_coverage.py
+++ b/packages/benchmarks/orchestrator/ci_coverage.py
@@ -61,6 +61,7 @@ CI_LANE_BY_BENCHMARK: dict[str, str] = {
     "openclaw_bench": "smoke",
     "orchestrator_lifecycle": "smoke",
     "realm": "smoke",
+    "recall_bench": "smoke",
     "rlm_bench": "smoke",
     "scambench": "smoke",
     "mind2web": "smoke",


### PR DESCRIPTION
Relates to #9956 (recall-bench) and the #9475/#10199 CI-lane discipline.

## Problem

`recall_bench` was added to the registry (`registry/commands.py`) as a public benchmark but never classified in `CI_LANE_BY_BENCHMARK` (`orchestrator/ci_coverage.py`). The `tests/test_ci_coverage.py::test_every_public_benchmark_has_a_ci_lane_or_manual_marker` check keeps that mapping 1:1 with the registry, so it was **red on develop**:

```
public benchmarks with NO CI lane: ['recall_bench']
```

## Fix

Classify `recall_bench` as **`smoke`**. Its registry entry is explicitly *"Secret-free and CI-safe"* with `env_vars=()` — it drives the real `DocumentService` / `searchMemories` / FACTS path deterministically (forced embed fail-open), which is precisely the smoke lane definition ("no-key mock/sample path exercisable in CI"), matching how `gsm8k`/`mmlu`/`realm` are laned.

## Verification

```
$ python -m pytest benchmarks/tests/test_ci_coverage.py -q
4 passed   # was 1 failed
```

One-line classification; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)