### PR TITLE
fix(benchmarks): reject hermes-env scores from all-incomplete rollouts (#9943)

### DIFF
--- a/packages/benchmarks/registry/scores.py
+++ b/packages/benchmarks/registry/scores.py
@@ -1562,6 +1562,33 @@ def _score_from_hermes_env_json(data: JSONValue) -> ScoreExtraction:
     }
     if "placeholder" in metric_keys and not (metric_keys & score_metric_keys):
         raise ValueError("hermes_env: placeholder-only score is not publishable")
+
+    def _metric_number(key: str) -> float | None:
+        value = metrics_dict.get(key)
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return None
+        return float(value)
+
+    # A score derived from rollouts that ALL failed to complete is not a real
+    # measurement — like the placeholder-only gate above, publishing it would
+    # larp a "0.0" the harness never actually measured. Reject when every sampled
+    # rollout is incomplete so the run is rerun / manually reviewed instead.
+    incomplete_rollouts = _metric_number("incomplete_rollouts")
+    sampled = _metric_number("sample_rows")
+    if sampled is None:
+        sampled = _metric_number("total_tasks")
+    if (
+        incomplete_rollouts is not None
+        and incomplete_rollouts > 0
+        and sampled is not None
+        and sampled > 0
+        and incomplete_rollouts >= sampled
+    ):
+        raise ValueError(
+            "hermes_env: all sampled rollouts are incomplete; a zero from "
+            "incomplete rollouts is not a real measurement and is not publishable"
+        )
+
     env_id_public = get_optional(root, "env_id_public") or get_optional(root, "env_id")
     if env_id_public is not None:
         metrics_dict["env_id"] = env_id_public


### PR DESCRIPTION
Relates to #9943 (green CI ≠ tested).

## Problem

`tests/test_registry_scores.py::test_hermes_env_all_incomplete_zero_is_not_publishable` — present since the `elizaOS v2.0.4 — clean baseline` commit — asserts that `_score_from_hermes_env_json` raises `ValueError(match="incomplete")` when a result's rollouts all failed to complete (`incomplete_rollouts` == `sample_rows`, score `0.0`). The check was **never implemented** in the scorer, so the test was **red on develop** (`git log -S "incomplete"` on `scores.py` finds nothing). This is exactly a #9943 "green CI ≠ tested" gap: a publishability gate a committed test asserts, but which didn't exist.

## Fix

Add the gate, mirroring the sibling `placeholder-only` rejection: when `incomplete_rollouts > 0` and `incomplete_rollouts >= sample_rows` (falling back to `total_tasks`), the score is derived from zero completed rollouts and is not a real measurement → raise so the run is rerun / manually reviewed rather than publishing a larped `0.0`.

- `placeholder-only` result → still raises (unchanged).
- `real metric with placeholder` (no `incomplete_rollouts` key) → still publishable (unaffected).
- `all-incomplete zero` → now correctly rejected.

## Verification

```
$ python -m pytest benchmarks/tests/test_registry_scores.py -q
3 passed   # the all-incomplete case was failing before

$ python -m pytest benchmarks/tests/test_registry_scores.py benchmarks/tests/test_ci_coverage.py -q
14 passed
```

No behavior change for valid results; only fake zeros from all-incomplete rollouts are now gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)