### PR TITLE
fix(benchmarks): reasoning-safe token budgets for MMLU/GSM8K (#10199)

### DIFF
--- a/.github/issue-evidence/10199-standard-benchmarks-reasoning-fix/SCORECARD.md
+++ b/.github/issue-evidence/10199-standard-benchmarks-reasoning-fix/SCORECARD.md
@@ -1,0 +1,52 @@
+# #10199 — gpt-oss-120b standard-benchmark rerun + harness truncation fix
+
+Model: **gpt-oss-120b** · Provider: **cerebras** (`https://api.cerebras.ai/v1`)
+Base SHA: `617621c0131` · Date: 2026-07-01 · Reviewer: read the trajectories/failures by hand (below).
+
+## Harness bug found + fixed (the "validate the harness itself" AC)
+
+gpt-oss is a **reasoning** model: it spends completion tokens on hidden reasoning
+before the visible answer. The MMLU (`max_tokens=256`) and GSM8K
+(`max_tokens=384`) adapters truncated mid-reasoning, so the visible answer was
+**empty / missing the `#### <int>` line**, scored as wrong — silently depressing
+a real score. This is a scorer/partial-output-handling defect, not a model result.
+
+| Benchmark | before (old default) | after (reasoning-safe) | cause |
+|---|---|---|---|
+| MMLU (25, abstract_algebra) | **0.48**, 11/25 empty visible outputs | **0.92**, 0 empty | `max_tokens` 256 → 2048 |
+| GSM8K (25) | **0.72**, format_ok 0.72 | **1.00** | `max_tokens` 384 → 2048 |
+| HumanEval (15) | **1.00** (default 2048 already ok) | **1.00** | unaffected |
+
+Same items, same seed — the deltas are pure truncation, confirmed by inspecting
+the `failures` (all `"predicted": "<empty>"`, `"empty_visible_output": true`)
+and re-running the identical set with a larger budget.
+
+## Fix
+
+- `benchmarks/standard/mmlu.py`: `DEFAULT_MAX_TOKENS` 256 → 2048; a loud
+  **truncation warning** + `empty_output_rate` in `raw_json` so a partially-empty
+  run is never mistaken for a real low score (a single MCQ letter costs ~1 token,
+  so non-reasoning models are unaffected; only reasoning headroom changes).
+- `benchmarks/standard/gsm8k.py`: runner + CLI `--max-tokens` default 384 → 2048.
+
+## Verification
+
+Deterministic:
+```
+$ python -m pytest benchmarks/standard/tests/test_mmlu.py benchmarks/standard/tests/test_gsm8k.py
+26 passed   # incl. a new partial-empty test that asserts the truncation warning + rate
+```
+Live (real gpt-oss-120b on Cerebras), with the NEW defaults (no flags):
+```
+MMLU  --limit 25 → score 0.92, empty_outputs 0, empty_output_rate 0.0
+GSM8K --limit 25 → score 1.00
+HumanEval --limit 15 → pass@1 1.00
+```
+
+## Notes / N/A
+- Raw result JSON + trajectories are **generated and not committed** (per the
+  benchmarks convention + the new `verify-artifacts` guard from #10664); this
+  reviewed scorecard is the committed artifact.
+- Scope: the graded rerun covers the standard academic subset (MMLU/GSM8K/HumanEval)
+  and fixes the harness truncation bug for reasoning models. The full 43-benchmark
+  registry rerun + HITL multi-Codex harness remain the larger #10199 scope.

--- a/packages/benchmarks/standard/gsm8k.py
+++ b/packages/benchmarks/standard/gsm8k.py
@@ -149,7 +149,11 @@ class GSM8KRunner:
         self,
         *,
         examples: Iterable[dict[str, object]] | None = None,
-        max_tokens: int = 384,
+        # Reasoning models spend the token budget on hidden reasoning before the
+        # visible answer; at the old 384-token default they truncated before the
+        # `#### <int>` line (gpt-oss-120b: 25 GSM8K items 0.72 -> 1.0 once given
+        # room). Non-reasoning models stop early and are unaffected.
+        max_tokens: int = 2048,
         include_edge_scenarios: bool = False,
     ) -> None:
         self._examples = list(examples) if examples is not None else None
@@ -251,7 +255,7 @@ class _GSM8KFactory(RunnerFactory):
         parser.add_argument(
             "--max-tokens",
             type=int,
-            default=384,
+            default=2048,
             help="Cap on generated tokens per problem (chain-of-thought needs headroom)",
         )
 

--- a/packages/benchmarks/standard/mmlu.py
+++ b/packages/benchmarks/standard/mmlu.py
@@ -41,7 +41,14 @@ BENCHMARK_ID = "mmlu"
 DATASET_VERSION = "cais/mmlu@2023-09-15"
 EXPANDED_DATASET_VERSION = "cais/mmlu@2023-09-15+edge-v1"
 DATASET_NAME = "cais/mmlu"
-DEFAULT_MAX_TOKENS = 256
+# Reasoning models (gpt-oss, o-series, …) spend completion tokens on hidden
+# reasoning before emitting the visible answer. At the old 256-token default they
+# routinely exhausted the budget mid-reasoning and returned an EMPTY visible
+# answer, which the harness scored as wrong — silently depressing a real ~0.92 to
+# ~0.48 (gpt-oss-120b, abstract_algebra: 11/25 empty). A single MCQ letter costs
+# ~1 token, so the only reason to raise this is reasoning headroom; non-reasoning
+# models stop early and are unaffected. See the truncation warning in `run`.
+DEFAULT_MAX_TOKENS = 2048
 
 
 SYSTEM_PROMPT = (
@@ -241,6 +248,23 @@ class MMLURunner:
                 f"MMLU generated empty visible output for all {n} evaluated examples; "
                 "treating this as a harness/model transport error rather than accuracy=0"
             )
+        empty_output_rate = round(empty_outputs / n, 4)
+        if empty_outputs:
+            # Partial empties silently depress the score: they are scored as wrong
+            # even though the harness never got an answer. Surface it loudly so a
+            # truncated run is never mistaken for a real low score (the usual cause
+            # is a reasoning model exhausting max_tokens on hidden reasoning).
+            log.warning(
+                "MMLU: %d/%d (%.0f%%) evaluated examples returned empty visible "
+                "output and were scored as misses — the accuracy UNDERSTATES the "
+                "model. Reasoning models can exhaust max_tokens (%d) on hidden "
+                "reasoning before the answer; raise --max-tokens or lower reasoning "
+                "effort, then re-run.",
+                empty_outputs,
+                n,
+                100 * empty_output_rate,
+                self._max_tokens,
+            )
 
         accuracy = correct / n
         subject_accuracy: dict[str, float] = {
@@ -262,6 +286,7 @@ class MMLURunner:
             raw_json={
                 "subject_accuracy": subject_accuracy,
                 "empty_outputs": empty_outputs,
+                "empty_output_rate": empty_output_rate,
             },
             failures=failures,
             elapsed_s=stats.elapsed(),

--- a/packages/benchmarks/standard/tests/test_mmlu.py
+++ b/packages/benchmarks/standard/tests/test_mmlu.py
@@ -113,7 +113,35 @@ def test_mmlu_runner_raises_when_all_visible_outputs_empty(tmp_path: Path) -> No
 
 
 def test_mmlu_default_token_budget_allows_reasoning_models() -> None:
-    assert DEFAULT_MAX_TOKENS >= 256
+    # Raised from 256 so a reasoning model's hidden reasoning does not exhaust the
+    # budget before the visible answer (the 0.48-vs-0.92 gpt-oss-120b truncation).
+    assert DEFAULT_MAX_TOKENS >= 2048
+
+
+def test_mmlu_runner_partial_empty_outputs_surface_truncation_signal(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    import logging
+
+    # Alternating empty / non-empty visible output — a reasoning model truncating
+    # on some items. These are scored as misses, so the harness MUST surface the
+    # empty rate + a loud warning rather than silently reporting a depressed score.
+    runner = MMLURunner(examples=list(SMOKE_FIXTURES))
+    with caplog.at_level(logging.WARNING):
+        result = runner.run(
+            client=MockClient(["", "B"]),
+            model="mock-model",
+            endpoint="http://mock",
+            output_dir=tmp_path,
+            limit=None,
+        )
+
+    empty = result.raw_json["empty_outputs"]
+    assert 0 < empty < result.n, "expected partial (not all) empty outputs"
+    assert result.raw_json["empty_output_rate"] == pytest.approx(round(empty / result.n, 4))
+    assert any(
+        "UNDERSTATES" in record.getMessage() for record in caplog.records
+    ), "a partial-empty run must emit the truncation warning"
 
 
 def test_mmlu_runner_writes_results_file(tmp_path: Path) -> None:


### PR DESCRIPTION
Relates to #10199 (validate the benchmark harnesses themselves, not just the score) and #9943.

## The bug (found by running the real target model)

#10199's stated target is **gpt-oss-120b** — a *reasoning* model that spends completion tokens on hidden reasoning before the visible answer. Running it live against the standard harnesses surfaced a real scorer defect:

- **MMLU** (`max_tokens=256`) and **GSM8K** (`max_tokens=384`) truncated the model mid-reasoning, so the visible answer was **empty** (MMLU) or missing the `#### <int>` line (GSM8K), scored as **wrong** — silently depressing a real score.

Same items, live on Cerebras (`api.cerebras.ai/v1`):

| Benchmark | before | after | delta cause |
|---|---|---|---|
| MMLU (25, abstract_algebra) | **0.48**, 11/25 empty visible | **0.92**, 0 empty | `max_tokens` 256→2048 |
| GSM8K (25) | **0.72** | **1.00** | `max_tokens` 384→2048 |
| HumanEval (15) | 1.00 (already ok at 2048) | 1.00 | unaffected |

Confirmed by inspecting the `failures` (all `"predicted": "<empty>"`, `"empty_visible_output": true`) and re-running the identical set with a larger budget.

## Fix

- `mmlu.py`: `DEFAULT_MAX_TOKENS` 256 → 2048; emit a **loud truncation warning** + expose `empty_output_rate` in `raw_json` so a partially-empty run is never mistaken for a real low score. A single MCQ letter costs ~1 token — non-reasoning models stop early and are unaffected; only reasoning headroom changes.
- `gsm8k.py`: runner + CLI `--max-tokens` default 384 → 2048.

## Verification

```
$ python -m pytest benchmarks/standard/tests/test_mmlu.py benchmarks/standard/tests/test_gsm8k.py
26 passed   # incl. a new partial-empty test asserting the truncation warning + rate

# live, NEW defaults (no flags), real gpt-oss-120b:
MMLU  25 → 0.92, empty_outputs 0     GSM8K 25 → 1.00     HumanEval 15 → 1.00
```

Reviewed scorecard: `.github/issue-evidence/10199-standard-benchmarks-reasoning-fix/SCORECARD.md`. Raw result JSON/trajectories are generated + **not committed** (per the benchmarks convention + the `verify-artifacts` guard from #10664).

Scope: fixes the harness truncation for reasoning models + delivers the graded gpt-oss-120b standard-subset rerun. The full 43-benchmark registry rerun + HITL multi-Codex harness remain the larger #10199 scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)