### PR TITLE
fix(benchmarks): tau_bench retail/airline env data package shadowed the loader (#10199)

### DIFF
--- a/packages/benchmarks/tau-bench/elizaos_tau_bench/upstream/envs/airline/data/__init__.py
+++ b/packages/benchmarks/tau-bench/elizaos_tau_bench/upstream/envs/airline/data/__init__.py
@@ -1,21 +1,13 @@
 # Copyright Sierra
 
-import json
-import os
 from typing import Any
 
-FOLDER_PATH = os.path.dirname(__file__)
+from elizaos_tau_bench.data_assets import load_domain_data
 
 
 def load_data() -> dict[str, Any]:
-    with open(os.path.join(FOLDER_PATH, "flights.json")) as f:
-        flight_data = json.load(f)
-    with open(os.path.join(FOLDER_PATH, "reservations.json")) as f:
-        reservation_data = json.load(f)
-    with open(os.path.join(FOLDER_PATH, "users.json")) as f:
-        user_data = json.load(f)
-    return {
-        "flights": flight_data,
-        "reservations": reservation_data,
-        "users": user_data,
-    }
+    # Same shadowing fix as retail: this ``data`` package wins over the sibling
+    # ``data.py`` module on import, and this directory does not vendor the
+    # airline JSON assets, so the upstream original raised FileNotFoundError.
+    # Delegate to the shared loader (compact fixtures / official download).
+    return load_domain_data("airline")

--- a/packages/benchmarks/tau-bench/elizaos_tau_bench/upstream/envs/retail/data/__init__.py
+++ b/packages/benchmarks/tau-bench/elizaos_tau_bench/upstream/envs/retail/data/__init__.py
@@ -1,21 +1,17 @@
 # Copyright Sierra
 
-import json
-import os
 from typing import Any
 
-FOLDER_PATH = os.path.dirname(__file__)
+from elizaos_tau_bench.data_assets import load_domain_data
 
 
 def load_data() -> dict[str, Any]:
-    with open(os.path.join(FOLDER_PATH, "orders.json")) as f:
-        order_data = json.load(f)
-    with open(os.path.join(FOLDER_PATH, "products.json")) as f:
-        product_data = json.load(f)
-    with open(os.path.join(FOLDER_PATH, "users.json")) as f:
-        user_data = json.load(f)
-    return {
-        "orders": order_data,
-        "products": product_data,
-        "users": user_data,
-    }
+    # This ``data`` PACKAGE shadows the sibling ``data.py`` MODULE (on import a
+    # package wins over a same-named module), so ``from ...retail.data import
+    # load_data`` resolves HERE — not to ``data.py``. The upstream original read
+    # ``orders.json`` / ``products.json`` / ``users.json`` from this directory,
+    # which only vendors ``products.json``, so every retail run died in env_init
+    # with FileNotFoundError on ``orders.json``. Delegate to the shared loader
+    # (compact fixtures for smoke, official upstream download otherwise) exactly
+    # like ``data.py``.
+    return load_domain_data("retail")

--- a/packages/benchmarks/tau-bench/tests/test_data_assets.py
+++ b/packages/benchmarks/tau-bench/tests/test_data_assets.py
@@ -17,6 +17,29 @@ def test_smoke_data_loads_packaged_retail_fixture(monkeypatch):
     assert "yusuf_rossi_9620" in data["users"]
 
 
+def test_retail_env_data_package_delegates_to_loader(monkeypatch):
+    # Regression: the retail env does `from ...envs.retail.data import load_data`,
+    # which resolves to the ``data`` PACKAGE (it shadows the sibling ``data.py``
+    # module on import). That package only vendored ``products.json``, so the
+    # upstream original raised FileNotFoundError on ``orders.json`` and every
+    # retail env_init died. It must delegate to the shared loader instead.
+    monkeypatch.setenv("TAU_BENCH_DATA_MODE", "smoke")
+    from elizaos_tau_bench.upstream.envs.retail.data import load_data
+
+    data = load_data()
+    assert set(data) == {"orders", "products", "users"}
+    assert all(data[key] for key in data)
+
+
+def test_airline_env_data_package_delegates_to_loader(monkeypatch):
+    monkeypatch.setenv("TAU_BENCH_DATA_MODE", "smoke")
+    from elizaos_tau_bench.upstream.envs.airline.data import load_data
+
+    data = load_data()
+    assert set(data) == {"flights", "reservations", "users"}
+    assert all(data[key] for key in data)
+
+
 def test_official_data_fetches_missing_assets_to_cache(tmp_path, monkeypatch):
     cache_root = tmp_path / "cache"
     monkeypatch.setenv("TAU_BENCH_DATA_DIR", str(cache_root))


### PR DESCRIPTION
Relates to #10199 (validate the benchmark harnesses themselves — "prove every benchmark actually runs").

## The bug (found running tau_bench live on gpt-oss-120b)

Every tau_bench task failed at `env_init`:
```
[Errno 2] No such file or directory: '.../upstream/envs/retail/data/orders.json'
```
So tau_bench reported `failed` (quarantined by the publication gate) rather than a score — the retail **and** airline domains were completely non-functional.

## Root cause

Each domain env has **both** a `data.py` module (patched to delegate to the shared `load_domain_data` loader) **and** a `data/` package. On import, a **package wins over a same-named module**, so `from ...envs.retail.data import load_data` resolves to `data/__init__.py` — the upstream original that reads `orders.json`/`products.json`/`users.json` from its own folder, which only vendors `products.json`. The wrapper's fixtures / official-download path was therefore never used, and `env_init` died on `orders.json`.

The existing `test_smoke_data_loads_packaged_retail_fixture` passed because it called the wrapper (`data_assets.load_domain_data`) **directly** — never through the shadowing package the env actually imports.

## Fix

Make both `retail/data/__init__.py` and `airline/data/__init__.py` delegate to `load_domain_data(domain)`, exactly like their shadowed `data.py` siblings.

## Verification (deterministic, no model needed)

```
# before: env_init → FileNotFoundError: .../retail/data/orders.json
# after:
retail  load_data() → {orders, products, users}      (complete, non-empty)
airline load_data() → {flights, reservations, users} (complete, non-empty)

$ python -m pytest benchmarks/tau-bench/tests/test_data_assets.py
5 passed   # 3 existing + 2 new regression tests that import THROUGH the shadowing package
```

The new tests import via `...envs.retail.data`/`...envs.airline.data` — the exact path the env uses — so this class of shadowing regression is now guarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)