### PR TITLE
fix(plugin-openai): live Cerebras #7620 refusal test never exercised zai-glm-4.7

### DIFF
--- a/plugins/plugin-openai/__tests__/cerebras-spawn-subagent-refusal.live.test.ts
+++ b/plugins/plugin-openai/__tests__/cerebras-spawn-subagent-refusal.live.test.ts
@@ -122,6 +122,15 @@ const HANDLE_RESPONSE_TOOL = {
         "facts",
         "addressedTo",
       ],
+      // Cerebras strict-grammar models diverge here: `gpt-oss-120b` tolerates a
+      // strict tool schema whose root omits `additionalProperties`, but
+      // `zai-glm-4.7` (GLM) 400s with `'additionalProperties' is required to be
+      // supplied and set to false`. Production never hits this because the
+      // OpenAI plugin runs every tool schema through `sanitizeJsonSchema` /
+      // `normalizeSchemaForCerebras` (models/text.ts), which inject this on
+      // every object node. This raw-fetch reproduction must mirror that wire
+      // contract, otherwise the GLM trials never reach the model under test.
+      additionalProperties: false,
     },
     strict: true,
   },


### PR DESCRIPTION
## What

The live regression test `plugins/plugin-openai/__tests__/cerebras-spawn-subagent-refusal.live.test.ts` (guards the elizaOS/eliza#7620 Stage-1 refusal-suppression fix) built its `HANDLE_RESPONSE` tool schema **without `additionalProperties: false`** on the root object.

Discovered by running the repo's Cerebras-gated live tests with a real `CEREBRAS_API_KEY`.

## The bug

`gpt-oss-120b` tolerates a strict tool schema whose root omits `additionalProperties`. **`zai-glm-4.7` (GLM) does not** — it rejects it at the wire:

```
400 invalid_request_error
'additionalProperties' is required to be supplied and set to false
```

So **every** `zai-glm-4.7` trial 400'd before reaching the model. The `bucket.failures < trials*0.5` sanity assertion then failed, and — more importantly — the #7620 refusal-suppression path was **never actually exercised for GLM**. The test claimed to cover "representative Cerebras reasoning models" including `zai-glm-4.7`, but silently only ever tested `gpt-oss-120b`. That is a larp per `PR_EVIDENCE.md`: the hand-rolled wire payload diverged from what production sends.

This matters because `zai-glm-4.7` is the **proven default coding model** (#10059) and a **recommended Cloud default** (#8434) — the exact model this test purported to guard.

## Production is unaffected

The OpenAI plugin runs every tool schema through `sanitizeJsonSchema` + `normalizeSchemaForCerebras` (`plugins/plugin-openai/models/text.ts`), which inject `additionalProperties: false` on **every** object node before the request goes out. Confirmed by direct API probe: `zai-glm-4.7` accepts an otherwise-identical strict tool schema **with** `additionalProperties: false`. The test just wasn't mirroring that contract.

## The fix

Add `additionalProperties: false` to the test's `HANDLE_RESPONSE` tool-parameters root so the raw-fetch reproduction matches the production wire contract.

## Evidence (live, `CEREBRAS_API_KEY` + `ELIZA_RUN_LIVE_TESTS=1`)

Before — `zai-glm-4.7`: 8/8 HTTP failures, assertion fail. After:

```
=== gpt-oss-120b (6 trials) ===          === zai-glm-4.7 (6 trials) ===
  HTTP / parse failures:   0 (0.0%)        HTTP / parse failures:   0 (0.0%)
  Picked spawn candidate:  6 (100.0%)      Picked spawn candidate:  6 (100.0%)
  Routed to planning ctx:  6 (100.0%)      Routed to planning ctx:  6 (100.0%)
  LEAKED refusal (bug):    0 (0.0%)        LEAKED refusal (bug):    0 (0.0%)
```

Primary + adversarial suites green for **both** models (4 passed). Broader Cerebras live/offline sweep run alongside (all green): `field-registry-cerebras.live` (2), `cerebras-config.live`, `cloud-streaming.live`, `trajectory.live`, `journey-cerebras-eval` (29, Cerebras-as-judge), `cerebras-endpoint` autowire (11), `cerebras-judge` (25), model-chooser (18), cloud provider-fallback (17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)