### PR TITLE
fix(agent): allow PATCH in CORS preflight

### DIFF
--- a/packages/agent/src/api/server-helpers-auth.ts
+++ b/packages/agent/src/api/server-helpers-auth.ts
@@ -196,7 +196,7 @@ export function applyCors(
     res.setHeader("Vary", "Origin");
     res.setHeader(
       "Access-Control-Allow-Methods",
-      "GET, POST, PUT, DELETE, OPTIONS",
+      "GET, POST, PUT, PATCH, DELETE, OPTIONS",
     );
     res.setHeader("Access-Control-Allow-Headers", CORS_ALLOWED_HEADERS);
     res.setHeader("Access-Control-Allow-Credentials", "true");

--- a/packages/agent/test/api/server-helpers-auth.test.ts
+++ b/packages/agent/test/api/server-helpers-auth.test.ts
@@ -85,6 +85,9 @@ describe("applyCors", () => {
       CORS_ALLOWED_HEADERS,
     );
     expect(res.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+    expect(res.headers.get("Access-Control-Allow-Methods")).toBe(
+      "GET, POST, PUT, PATCH, DELETE, OPTIONS",
+    );
 
     const allowedHeaders = String(
       res.headers.get("Access-Control-Allow-Headers"),


### PR DESCRIPTION
## Summary
- add PATCH to the agent server CORS Access-Control-Allow-Methods list
- assert the method list in the applyCors regression test

## Why
The browser app sends PATCH requests for routes such as /api/conversations/:id. Current agent preflight responses omitted PATCH, so localhost/cloud browser clients could fail before the request reached the route.

This matches the observed console failure:

```
Method PATCH is not allowed by Access-Control-Allow-Methods in preflight response.
```

## Validation
- bun test packages/agent/test/api/server-helpers-auth.test.ts
- git diff --check

Note: this branch needed the repo i18n keyword generator before the focused test because the fresh worktree was missing ignored generated i18n data. The generated files remain untracked/ignored and are not part of this PR.