### PR TITLE
fix(cloud-ui): avoid app-auth steward fallback race

### DIFF
--- a/.github/issue-evidence/10680-app-auth-suspense-fallback.md
+++ b/.github/issue-evidence/10680-app-auth-suspense-fallback.md
@@ -1,0 +1,30 @@
+# #10680 App Auth Suspense Fallback
+
+## What changed
+
+- `packages/ui/src/cloud/shell/StewardProvider.tsx` now uses `fallback={null}` while the lazy `StewardAuthRuntimeProvider` chunk loads.
+- `packages/ui/src/cloud/shell/StewardProvider.test.tsx` now asserts that `/app-auth/authorize` does not render protected children during the Suspense fallback, then renders them after the Steward runtime provider is mounted.
+
+This prevents the cold-navigation race where `AuthorizeContent` could call `useAuth()` before an ancestor `<StewardProvider>` existed.
+
+## Validation
+
+All validation below was run after rebasing onto `origin/develop` at `40fc8227c30` and running `bun install --frozen-lockfile --ignore-scripts` with no lock/install changes.
+
+- `bun run --cwd packages/ui test src/cloud/shell/StewardProvider.test.tsx src/cloud/public-pages/pages/app-auth/app-authorize-page.test.tsx`
+  - Passed: 2 files, 4 tests.
+- `bunx @biomejs/biome@2.5.1 check packages/ui/src/cloud/shell/StewardProvider.tsx packages/ui/src/cloud/shell/StewardProvider.test.tsx`
+  - Passed: 2 files checked, no fixes applied.
+- `git diff --check`
+  - Passed.
+- `bun run build:core`
+  - Passed: 64 successful tasks, including `@elizaos/ui` build and runtime export verification.
+- `bun run --cwd packages/ui typecheck`
+  - Passed.
+- `bun run verify`
+  - Blocked before typecheck/lint by the existing repository-wide type-safety ratchet baseline: `as unknown as` is 108 current vs 77 baseline. The listed files are outside this PR's touched files, including feed packages, `packages/agent`, `packages/app-core`, `packages/cloud/services/gateway-discord`, and `plugins/plugin-capacitor-bridge`.
+
+## Visual Evidence
+
+- Screenshot: N/A. This fix intentionally renders no transient fallback UI while the auth provider chunk loads; the post-load app-auth page pixels are unchanged.
+- Screen recording: N/A for the same reason. The user-visible failure was a provider timing crash, and the regression test directly captures the previously crashing phase by asserting children are absent until the Steward runtime provider mounts.

--- a/packages/ui/src/cloud/shell/StewardProvider.test.tsx
+++ b/packages/ui/src/cloud/shell/StewardProvider.test.tsx
@@ -58,6 +58,7 @@ describe("StewardAuthProvider", () => {
 
     renderAt("/app-auth/authorize?app_id=app_123");
 
+    expect(screen.queryByTestId("protected-child")).toBeNull();
     expect(await screen.findByTestId("steward-runtime")).toBeTruthy();
     expect(screen.getByTestId("protected-child")).toBeTruthy();
     expect(screen.queryByRole("alert")).toBeNull();

--- a/packages/ui/src/cloud/shell/StewardProvider.tsx
+++ b/packages/ui/src/cloud/shell/StewardProvider.tsx
@@ -162,7 +162,7 @@ export function StewardAuthProvider({ children }: { children: ReactNode }) {
   }
 
   return (
-    <Suspense fallback={children}>
+    <Suspense fallback={null}>
       <StewardAuthRuntimeProvider apiUrl={apiUrl} tenantId={tenantId}>
         {children}
       </StewardAuthRuntimeProvider>


### PR DESCRIPTION
Fixes #10680.

## Summary
- Do not render `/app-auth/authorize` children as the Suspense fallback while the lazy Steward auth runtime loads.
- Add a regression assertion that protected app-auth children stay unmounted until the Steward runtime provider is present.
- Add issue evidence documenting validation and the visual-evidence N/A rationale.

## Evidence
- `.github/issue-evidence/10680-app-auth-suspense-fallback.md`
- Rebased onto `origin/develop` at `40fc8227c30` (#10681) and ran `bun install --frozen-lockfile --ignore-scripts` with no changes.
- `bun run --cwd packages/ui test src/cloud/shell/StewardProvider.test.tsx src/cloud/public-pages/pages/app-auth/app-authorize-page.test.tsx` passed: 2 files, 4 tests.
- `bunx @biomejs/biome@2.5.1 check packages/ui/src/cloud/shell/StewardProvider.tsx packages/ui/src/cloud/shell/StewardProvider.test.tsx` passed.
- `git diff --check origin/develop...HEAD` passed.
- `bun run --cwd packages/ui typecheck` passed.
- `bun run build:core` passed: 64/64 tasks, including `@elizaos/ui` runtime export verification on the post-#10681 shortened UI build command.
- `bun run verify` is blocked before typecheck/lint by the existing repo-wide type-safety ratchet drift: `as unknown as` 108 current vs 77 baseline; listed files are outside this PR.

## Visual Evidence
Screenshot/screen recording are marked N/A in the evidence file because the fixed state is intentionally no transient fallback UI; app-auth pixels after the provider loads are unchanged, and the regression test captures the previously crashing timing window directly.