### PR TITLE
fix(scripts): account for package-local inventory callers

### DIFF
--- a/.github/issue-evidence/10200-package-script-inventory.md
+++ b/.github/issue-evidence/10200-package-script-inventory.md
@@ -1,0 +1,139 @@
+# #10200 package-script inventory reachability
+
+Issue: https://github.com/elizaOS/eliza/issues/10200
+
+PR slice: make `packages/scripts/audit-scripts-inventory.mjs` account for
+workspace package-local `package.json` scripts that directly invoke
+`packages/scripts/*.mjs` helpers.
+
+## Problem found
+
+The existing inventory only modeled root scripts, CI workflows, file-to-file
+references, and the `packages/app/package.json` surface. That left package-local
+helpers mislabeled as `orphan` even when they are active package commands.
+
+Concrete example from clean `origin/develop` at `534413811a2`:
+
+```json
+{
+  "file": "run-bash-darwin-only.mjs",
+  "loc": 55,
+  "category": "orphan"
+}
+```
+
+That was false: `packages/native/ios-deps/package.json` calls the wrapper from
+eight iOS native dependency scripts.
+
+## What changed
+
+- Added a new file reachability category:
+  `reachable-from-package-script`.
+- Scans checked-in package-local `package.json` scripts, excluding generated
+  trees like `node_modules`, `dist`, `.turbo`, reports, coverage, and benchmark
+  outputs.
+- Records concrete caller metadata per file in the JSON inventory:
+  `{ packageJson, script }`.
+- Tightened file-name matching so short script names like `dev.mjs` are not
+  accidentally matched inside longer names such as `cloud-api-dev.mjs`.
+- Added a regression test proving `run-bash-darwin-only.mjs` is package-script
+  reachable through `packages/native/ios-deps/package.json`.
+
+## Inventory delta
+
+Baseline on `origin/develop` at `534413811a2`:
+
+```json
+{
+  "totalFiles": 86,
+  "orphanFiles": 26,
+  "orphanLoc": 4980,
+  "filesByCategory": {
+    "reachable-from-verify": 17,
+    "reachable-from-test": 2,
+    "reachable-from-build": 2,
+    "reachable-from-ci-workflow": 39,
+    "orphan": 26
+  }
+}
+```
+
+After this slice:
+
+```json
+{
+  "totalFiles": 86,
+  "totalLoc": 25922,
+  "orphanFiles": 18,
+  "orphanLoc": 3940,
+  "filesByCategory": {
+    "reachable-from-verify": 17,
+    "reachable-from-test": 2,
+    "reachable-from-build": 2,
+    "reachable-from-ci-workflow": 39,
+    "reachable-from-package-script": 8,
+    "orphan": 18
+  },
+  "packageScriptFileReferences": 246
+}
+```
+
+Files now classified as `reachable-from-package-script`:
+
+- `copy-package-assets.mjs`
+- `ensure-tsc-nested-output-dir.mjs`
+- `flatten-tsc-package-output.mjs`
+- `prepare-package-dist.mjs`
+- `remove-source-build-artifacts.mjs`
+- `run-bash-darwin-only.mjs`
+- `verify-package-runtime-exports.mjs`
+- `with-package-build-lock.mjs`
+
+`dev.mjs` remains `orphan` after the stricter boundary matcher, so
+`cloud-api-dev.mjs` no longer creates a false package-script hit.
+
+## Validation
+
+```bash
+bun test packages/scripts/__tests__/audit-scripts-inventory.test.ts
+```
+
+Result: 7 pass, 0 fail, including the package-script reachability regression.
+
+```bash
+bunx @biomejs/biome@2.5.1 check \
+  packages/scripts/audit-scripts-inventory.mjs \
+  packages/scripts/__tests__/audit-scripts-inventory.test.ts
+```
+
+Result: passed.
+
+```bash
+node --check packages/scripts/audit-scripts-inventory.mjs
+bun run audit:scripts:inventory
+git diff --check origin/develop...HEAD
+```
+
+Result: all passed. The normal inventory alias printed the new
+`reachable-from-package-script` bucket and wrote `reports/scripts-inventory.json`
+(gitignored).
+
+```bash
+bun install --frozen-lockfile --ignore-scripts
+bun run verify
+```
+
+Install completed without lockfile changes. `bun run verify` still stops at the
+pre-existing repository type-safety ratchet before this PR's typecheck/lint
+lanes:
+
+```text
+[type-safety-ratchet] as unknown as: 108 / 77
+[type-safety-ratchet] unsafe cast baseline exceeded
+```
+
+The reported files are outside this slice (`packages/feed`, `packages/agent`,
+`packages/app-core`, `packages/cloud`, and `plugin-capacitor-bridge`).
+
+Screenshots/screen recording: N/A. This is a repository support-script inventory
+change with no UI, app runtime, native surface, or visual output.

--- a/packages/scripts/__tests__/audit-scripts-inventory.test.ts
+++ b/packages/scripts/__tests__/audit-scripts-inventory.test.ts
@@ -27,6 +27,15 @@ const APP_CATEGORIES = [
   "orphan",
 ];
 
+const FILE_CATEGORIES = [
+  "reachable-from-verify",
+  "reachable-from-test",
+  "reachable-from-build",
+  "reachable-from-ci-workflow",
+  "reachable-from-package-script",
+  "orphan",
+];
+
 function appScriptNames() {
   const pkg = JSON.parse(
     readFileSync(
@@ -83,5 +92,24 @@ describe("script inventory: packages/app surface (issue #10200)", () => {
     expect(Array.isArray(inv.roots)).toBe(true);
     expect(Array.isArray(inv.files)).toBe(true);
     expect(inv.summary.totalRootScripts).toBe(inv.roots.length);
+  });
+
+  test("package-local script callers keep helper files out of the orphan bucket", () => {
+    for (const f of inv.files) {
+      expect(FILE_CATEGORIES).toContain(f.category);
+    }
+
+    const darwinWrapper = inv.files.find(
+      (f) => f.file === "run-bash-darwin-only.mjs",
+    );
+    expect(darwinWrapper?.category).toBe("reachable-from-package-script");
+    expect(darwinWrapper?.packageScriptCallers).toContainEqual({
+      packageJson: "packages/native/ios-deps/package.json",
+      script: "build:llama-cpp",
+    });
+    expect(
+      inv.summary.filesByCategory["reachable-from-package-script"],
+    ).toBeGreaterThan(0);
+    expect(inv.summary.packageScriptFileReferences).toBeGreaterThan(0);
   });
 });

--- a/packages/scripts/audit-scripts-inventory.mjs
+++ b/packages/scripts/audit-scripts-inventory.mjs
@@ -10,6 +10,7 @@
  *   - reachable-from-test
  *   - reachable-from-build
  *   - reachable-from-ci-workflow
+ *   - reachable-from-package-script
  *   - reachable-from-app-internal   (packages/app scripts only)
  *   - orphan
  *
@@ -59,6 +60,7 @@ const CATEGORIES = [
   "reachable-from-test",
   "reachable-from-build",
   "reachable-from-ci-workflow",
+  "reachable-from-package-script",
   "orphan",
 ];
 
@@ -73,6 +75,19 @@ const APP_CATEGORIES = [
   "reachable-from-app-internal",
   "orphan",
 ];
+
+const PACKAGE_JSON_PRUNE_DIRS = new Set([
+  ".git",
+  ".next",
+  ".turbo",
+  "aesthetic-audit-output",
+  "benchmark_results",
+  "build",
+  "coverage",
+  "dist",
+  "node_modules",
+  "reports",
+]);
 
 function readJson(file) {
   return JSON.parse(readFileSync(file, "utf8"));
@@ -97,6 +112,23 @@ function walk(dir, visit) {
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) walk(full, visit);
     else visit(full);
+  }
+}
+
+function walkPruned(dir, visit) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (!PACKAGE_JSON_PRUNE_DIRS.has(entry.name)) walkPruned(full, visit);
+    } else {
+      visit(full);
+    }
   }
 }
 
@@ -126,7 +158,9 @@ function referencedRootScripts(body) {
 function referencedScriptFiles(body, fileUniverse) {
   const found = new Set();
   for (const file of fileUniverse) {
-    if (body.includes(file)) found.add(file);
+    const escaped = file.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const re = new RegExp(`(^|[^A-Za-z0-9_.-])${escaped}($|[^A-Za-z0-9_.-])`);
+    if (re.test(body)) found.add(file);
   }
   return found;
 }
@@ -186,6 +220,42 @@ function filesFromRootScripts(reachedRoots, rootScripts, fileUniverse) {
     }
   }
   return seeds;
+}
+
+/**
+ * packages/scripts files invoked from package-local `package.json` scripts.
+ *
+ * Root reachability intentionally remains its own color; this catches the other
+ * public package script surface so helpers used by a package command are not
+ * reported as disposable just because root verify/build/CI do not call them.
+ */
+function filesFromPackageScripts(fileUniverse) {
+  const callersByFile = new Map();
+  walkPruned(ROOT, (file) => {
+    if (path.basename(file) !== "package.json") return;
+    if (path.resolve(file) === path.join(ROOT, "package.json")) return;
+
+    const pkg = readJson(file);
+    const scripts = pkg.scripts ?? {};
+    for (const [name, body] of Object.entries(scripts)) {
+      for (const scriptFile of referencedScriptFiles(body, fileUniverse)) {
+        if (!callersByFile.has(scriptFile)) callersByFile.set(scriptFile, []);
+        callersByFile.get(scriptFile).push({
+          packageJson: path.relative(ROOT, file),
+          script: name,
+        });
+      }
+    }
+  });
+
+  for (const callers of callersByFile.values()) {
+    callers.sort((a, b) =>
+      `${a.packageJson}:${a.script}`.localeCompare(
+        `${b.packageJson}:${b.script}`,
+      ),
+    );
+  }
+  return callersByFile;
 }
 
 /**
@@ -298,6 +368,7 @@ function buildInventory() {
   const rootScripts = readJson(path.join(ROOT, "package.json")).scripts ?? {};
   const fileUniverse = collectScriptFiles();
   const fileGraph = buildFileGraph(fileUniverse);
+  const packageScriptCallersByFile = filesFromPackageScripts(fileUniverse);
 
   // CI workflow corpus + the root-script names + script files it references.
   const workflowChunks = [];
@@ -334,6 +405,10 @@ function buildInventory() {
     ]),
     fileGraph,
   );
+  const packageScriptFiles = reachableFiles(
+    new Set(packageScriptCallersByFile.keys()),
+    fileGraph,
+  );
 
   const classifyRoot = (name) => {
     if (verifyRoots.has(name)) return "reachable-from-verify";
@@ -347,6 +422,7 @@ function buildInventory() {
     if (testFiles.has(file)) return "reachable-from-test";
     if (buildFiles.has(file)) return "reachable-from-build";
     if (ciFiles.has(file)) return "reachable-from-ci-workflow";
+    if (packageScriptFiles.has(file)) return "reachable-from-package-script";
     return "orphan";
   };
 
@@ -354,6 +430,7 @@ function buildInventory() {
     file,
     loc: loc(path.join(SCRIPTS_DIR, file)),
     category: classifyFile(file),
+    packageScriptCallers: packageScriptCallersByFile.get(file) ?? [],
   }));
   const roots = Object.keys(rootScripts).map((name) => ({
     name,
@@ -463,6 +540,9 @@ function buildInventory() {
       filesByCategory: fileTotals,
       locByCategory: fileLocTotals,
       rootScriptsByCategory: rootTotals,
+      packageScriptFileReferences: [
+        ...packageScriptCallersByFile.values(),
+      ].reduce((sum, callers) => sum + callers.length, 0),
       totalAppScripts: appScriptList.length,
       orphanAppScripts: appTotals.orphan,
       appScriptsByCategory: appTotals,
@@ -476,19 +556,20 @@ function buildInventory() {
 function printSummary(inv) {
   const { summary } = inv;
   const w = process.stdout.write.bind(process.stdout);
+  const categoryWidth = 31;
   w("\n[audit-scripts-inventory] packages/scripts/*.mjs reachability\n\n");
-  w("  category                       files     loc   roots\n");
-  w("  ---------------------------- ------- ------- -------\n");
+  w(`  ${"category".padEnd(categoryWidth)} files     loc   roots\n`);
+  w(`  ${"-".repeat(categoryWidth)} ------- ------- -------\n`);
   for (const c of CATEGORIES) {
     w(
-      `  ${c.padEnd(28)} ${String(summary.filesByCategory[c]).padStart(5)} ` +
+      `  ${c.padEnd(categoryWidth)} ${String(summary.filesByCategory[c]).padStart(5)} ` +
         `${String(summary.locByCategory[c]).padStart(7)} ` +
         `${String(summary.rootScriptsByCategory[c]).padStart(7)}\n`,
     );
   }
-  w("  ---------------------------- ------- ------- -------\n");
+  w(`  ${"-".repeat(categoryWidth)} ------- ------- -------\n`);
   w(
-    `  ${"TOTAL".padEnd(28)} ${String(summary.totalFiles).padStart(5)} ` +
+    `  ${"TOTAL".padEnd(categoryWidth)} ${String(summary.totalFiles).padStart(5)} ` +
       `${String(summary.totalLoc).padStart(7)} ` +
       `${String(summary.totalRootScripts).padStart(7)}\n\n`,
   );
@@ -501,7 +582,10 @@ function printSummary(inv) {
   if (orphans.length) {
     w("  orphan files:\n");
     for (const f of orphans) w(`    - ${f.file} (${f.loc} LOC)\n`);
-    w("\n");
+    w(
+      "\n  note: orphan here means no root/CI/package-script caller found, " +
+        'not "safe to delete".\n\n',
+    );
   }
 
   // packages/app — the second dense script surface (issue #10200, item 2).


### PR DESCRIPTION
Refs #10200

## Summary

- adds a `reachable-from-package-script` reachability bucket to `packages/scripts/audit-scripts-inventory.mjs`
- scans package-local `package.json` scripts for direct `packages/scripts/*.mjs` callers and records `{ packageJson, script }` caller metadata in the JSON inventory
- tightens script filename matching so short names like `dev.mjs` are not matched inside longer names such as `cloud-api-dev.mjs`
- adds a regression test proving `run-bash-darwin-only.mjs` is package-script reachable through `packages/native/ios-deps/package.json`

## Evidence

Tracked evidence: `.github/issue-evidence/10200-package-script-inventory.md`

Inventory delta on the synced branch:
- `orphanFiles`: 26 -> 18
- `orphanLoc`: 4980 -> 3940
- new `reachable-from-package-script`: 8 files / 1124 LOC
- `packageScriptFileReferences`: 246 concrete package-script caller edges

## Validation

- `bun install --frozen-lockfile --ignore-scripts`
- `bun test packages/scripts/__tests__/audit-scripts-inventory.test.ts` -> 7 pass, 0 fail
- `bunx @biomejs/biome@2.5.1 check packages/scripts/audit-scripts-inventory.mjs packages/scripts/__tests__/audit-scripts-inventory.test.ts` -> passed
- `node --check packages/scripts/audit-scripts-inventory.mjs` -> passed
- `bun run audit:scripts:inventory` -> passed, wrote gitignored `reports/scripts-inventory.json`
- `git diff --check origin/develop...HEAD` -> passed
- `bun run verify` -> still blocked by the pre-existing type-safety ratchet before this PR's lanes: `as unknown as: 108 / 77`, in files outside this slice (`packages/feed`, `packages/agent`, `packages/app-core`, `packages/cloud`, `plugin-capacitor-bridge`)

Screenshots/screen recording: N/A, repository support-script inventory only; no UI/runtime/native visual surface changed.
