### PR TITLE
fix(cloud-ui): stop Suspense fallback from crashing useAuth on auth routes (#10680)

### DIFF
--- a/packages/ui/src/cloud/shell/StewardProvider.test.tsx
+++ b/packages/ui/src/cloud/shell/StewardProvider.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -11,15 +11,47 @@ vi.mock("./steward-url", () => ({
   resolveBrowserStewardApiUrl: () => resolveBrowserStewardApiUrl(),
 }));
 
+// Controllable gate simulating the lazy `@stwd/*` runtime chunk. It is settled
+// by default (existing tests observe the resolved runtime synchronously). A test
+// can `hold()` it before rendering to keep the runtime suspended — exercising the
+// Suspense fallback — then `release()` it to resolve.
+const runtimeGate = vi.hoisted(() => {
+  let settled = true;
+  let pending: Promise<void> = Promise.resolve();
+  let resolvePending: (() => void) | undefined;
+  return {
+    hold() {
+      settled = false;
+      pending = new Promise<void>((resolve) => {
+        resolvePending = resolve;
+      });
+    },
+    release() {
+      if (settled) return;
+      settled = true;
+      resolvePending?.();
+    },
+    isSettled: () => settled,
+    whenReady: () => pending,
+  };
+});
+
 vi.mock("./StewardProviderRuntime", () => ({
-  default: ({ children }: { children: ReactNode }) => (
-    <div data-testid="steward-runtime">{children}</div>
-  ),
+  default: ({ children }: { children: ReactNode }) => {
+    // Reaching this branch means the page needs auth context. While the runtime
+    // is not ready, suspend so the Suspense fallback renders — mirroring the cold
+    // lazy-chunk load in production.
+    if (!runtimeGate.isSettled()) {
+      throw runtimeGate.whenReady();
+    }
+    return <div data-testid="steward-runtime">{children}</div>;
+  },
 }));
 
 import { StewardAuthProvider } from "./StewardProvider";
 
 afterEach(() => {
+  runtimeGate.release();
   cleanup();
   resolveBrowserStewardApiUrl.mockReturnValue("placeholder-steward-url");
 });
@@ -61,5 +93,35 @@ describe("StewardAuthProvider", () => {
     expect(await screen.findByTestId("steward-runtime")).toBeTruthy();
     expect(screen.getByTestId("protected-child")).toBeTruthy();
     expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  // Regression: #10680. On a cold navigation to an auth route the lazy `@stwd`
+  // runtime chunk is not yet loaded, so the Suspense fallback renders. It must
+  // NOT render the page children — they consume Steward auth context
+  // (`AuthorizeContent` calls `useAuth()`) and would throw "useAuth must be used
+  // within a <StewardProvider>" before the provider is in the tree. The fallback
+  // shows a loading state until the runtime resolves.
+  it("shows a loading state instead of the auth-consuming children during the runtime lazy-load (#10680)", async () => {
+    resolveBrowserStewardApiUrl.mockReturnValue(
+      "https://api.elizacloud.ai/steward",
+    );
+    runtimeGate.hold();
+
+    renderAt("/app-auth/authorize?app_id=app_123");
+
+    // Fallback phase — the runtime (and its StewardProvider) is not in the tree.
+    expect(screen.getByRole("status")).toBeTruthy();
+    expect(screen.queryByTestId("protected-child")).toBeNull();
+    expect(screen.queryByTestId("steward-runtime")).toBeNull();
+
+    // Runtime resolves → children render inside the provider, loading clears.
+    await act(async () => {
+      runtimeGate.release();
+      await runtimeGate.whenReady();
+    });
+
+    expect(await screen.findByTestId("steward-runtime")).toBeTruthy();
+    expect(screen.getByTestId("protected-child")).toBeTruthy();
+    expect(screen.queryByRole("status")).toBeNull();
   });
 });

--- a/packages/ui/src/cloud/shell/StewardProvider.tsx
+++ b/packages/ui/src/cloud/shell/StewardProvider.tsx
@@ -73,6 +73,35 @@ function shouldLoadStewardRuntime(pathname: string): boolean {
   );
 }
 
+/**
+ * Suspense fallback for the lazy `@stwd/*` runtime chunk. It must NOT render the
+ * page children: reaching this branch means `needsStewardRuntime` is true, so the
+ * children depend on Steward auth context (e.g. `AuthorizeContent` calls
+ * `useAuth()`). Rendering them before `StewardProvider` is in the tree throws
+ * "useAuth must be used within a <StewardProvider>" (#10680). Show a neutral
+ * loading state until the runtime resolves, then the real tree renders.
+ */
+function StewardRuntimeLoading() {
+  return (
+    <main
+      aria-busy="true"
+      aria-live="polite"
+      role="status"
+      style={{
+        alignItems: "center",
+        background: "#f8f4ef",
+        color: "#2f261f",
+        display: "flex",
+        justifyContent: "center",
+        minHeight: "100vh",
+        padding: "24px",
+      }}
+    >
+      <span style={{ fontSize: 16 }}>Loading…</span>
+    </main>
+  );
+}
+
 function StewardConfigError() {
   return (
     <main
@@ -162,7 +191,7 @@ export function StewardAuthProvider({ children }: { children: ReactNode }) {
   }
 
   return (
-    <Suspense fallback={children}>
+    <Suspense fallback={<StewardRuntimeLoading />}>
       <StewardAuthRuntimeProvider apiUrl={apiUrl} tenantId={tenantId}>
         {children}
       </StewardAuthRuntimeProvider>


### PR DESCRIPTION
Fixes #10680.

## Root cause

`StewardAuthProvider` (`packages/ui/src/cloud/shell/StewardProvider.tsx`) lazy-loads the heavy `@stwd/*` runtime chunk and wrapped it in:

```tsx
<Suspense fallback={children}>
  <StewardAuthRuntimeProvider …>{children}</StewardAuthRuntimeProvider>
</Suspense>
```

On a **cold navigation** to an auth surface (`/app-auth/authorize`, reached when signing into a monetized Eliza Cloud app), the lazy chunk isn't loaded, so React renders the Suspense **fallback** — which re-rendered the page `children` **without `StewardProvider` in the tree**. `AuthorizeContent` (`packages/ui/src/cloud-ui/components/auth/authorize-content.tsx`) calls `useAuth()` from `@stwd/react`, which throws:

> useAuth must be used within a `<StewardProvider>` with an `auth` prop.

Sign-in was broken for every monetized app using the OAuth flow.

## Fix

We only reach this branch when `needsStewardRuntime` is true — i.e. the children depend on Steward auth context **by construction** — so rendering them during the fallback is unsafe in every case, not just `/app-auth`. Replace the `fallback={children}` with a neutral `StewardRuntimeLoading` (`role="status"`) that renders until the runtime resolves; then the real tree renders inside the provider.

**Rejected alternatives:**
- *Eager import* (drop `lazy()`): would load the `@stwd/*` chunk on **every** route, defeating the deliberate code-split for non-auth surfaces (the whole reason the provider is cheap on `/docs` etc.).
- *Per-component `useAuth` guards*: fragile — any current or future child that reads auth context during the fallback would re-introduce the crash. Fixing it once at the boundary is correct.

## Verification

`packages/ui/src/cloud/shell/StewardProvider.test.tsx` — added a regression test that holds the lazy runtime suspended (controllable gate) and asserts the fallback renders the loading state, **not** the auth-consuming children:

```
✓ shows a loading state instead of the auth-consuming children during the runtime lazy-load (#10680)
Test Files  1 passed (1)   Tests  4 passed (4)
```

Confirmed it's a real regression test: with the old `fallback={children}` it **fails** (`protected-child` renders during the fallback and there is no `role="status"`); with the fix it passes. The 3 pre-existing tests (config-error, non-auth bypass, runtime load) remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)