### PR TITLE
fix(benchmarks): package reviewed benchmark results

### DIFF
--- a/.github/issue-evidence/10199-review-package.md
+++ b/.github/issue-evidence/10199-review-package.md
@@ -1,0 +1,108 @@
+# #10199 Review-Package Evidence
+
+Date: 2026-07-01
+Branch: `fix/10199-benchmark-review-manifest`
+Base under test: `15d2a7c58fa2aae244a455834d628795647438a5`
+Branch commit under test: `2f2605a0fb4993a59a63acc11348d454319ef37d`
+
+## Change Verified
+
+Added `python -m benchmarks.orchestrator review-package`, which writes:
+
+- `manifest.json` — machine-readable reviewed benchmark package
+- `scorecard.md` — human-readable reviewed scorecard
+
+The command exits nonzero unless:
+
+- the static benchmark inventory has no registry/directory gaps,
+- `validate-latest-readiness` passes for the selected latest snapshot,
+- no generated benchmark output is tracked by git,
+- selected latest rows exist,
+- a manual trajectory/replay review note is supplied.
+
+## Commands
+
+Focused tests:
+
+```bash
+PYTHONPATH=packages python3 -m pytest packages/benchmarks/orchestrator/tests/test_review_package.py -q
+# 3 passed in 0.19s
+```
+
+Existing guard/readiness regression tests:
+
+```bash
+PYTHONPATH=packages python3 -m pytest \
+  packages/benchmarks/orchestrator/tests/test_artifact_guard.py \
+  packages/benchmarks/orchestrator/tests/test_latest_readiness.py -q
+# 15 passed in 0.39s
+```
+
+CLI discovery:
+
+```bash
+PYTHONPATH=packages python3 -m benchmarks.orchestrator --help
+# includes review-package in the subcommand list
+```
+
+Real git-index artifact guard:
+
+```bash
+PYTHONPATH=packages python3 -m benchmarks.orchestrator verify-artifacts
+# OK - checked 46256 tracked file(s); no generated benchmark output is committed.
+```
+
+Blocked-package smoke on this clean checkout:
+
+```bash
+PYTHONPATH=packages python3 -m benchmarks.orchestrator review-package \
+  --out-dir /tmp/eliza-10199-review-package-smoke \
+  --reviewed-by codex \
+  --reviewer-note 'Smoke test only: no real latest benchmark rows exist in this checkout; focused tests cover successful packaging and blocked packaging.' \
+  --skip-runtime-gates
+# Wrote manifest: /tmp/eliza-10199-review-package-smoke/manifest.json
+# Wrote scorecard: /tmp/eliza-10199-review-package-smoke/scorecard.md
+# exits 1 because benchmark_results/latest is absent, as expected
+```
+
+Full orchestrator suite:
+
+```bash
+env -u CEREBRAS_API_KEY -u OPENAI_API_KEY -u OPENROUTER_API_KEY -u GROQ_API_KEY \
+  -u ANTHROPIC_API_KEY -u ELIZAOS_API_KEY -u BENCHMARK_MODEL_PROVIDER \
+  -u BENCHMARK_MODEL_NAME \
+  PYTHONPATH=packages python3 -m pytest packages/benchmarks/orchestrator/tests -q
+# 347 passed, 4 failed
+```
+
+The four failures are in existing `test_code_agent_matrix.py` smoke-gate expectations
+and do not touch the files changed in this PR. They reproduce after provider keys are
+removed from the environment.
+
+Repo verify:
+
+```bash
+bun install --frozen-lockfile --ignore-scripts
+# installed dependencies successfully
+
+bun run verify
+# fails in audit:type-safety-ratchet before typecheck/lint:
+# scanned 9901 tracked production source files
+# as unknown as: 108 current > 77 baseline
+# top offenders are packages/feed, packages/agent, packages/app-core,
+# packages/cloud, and plugins/plugin-capacitor-bridge
+```
+
+This is the same repo-wide unsafe-cast ratchet already blocking unrelated
+branches; this PR adds Python/Markdown only and does not touch the listed files.
+
+## Manual Review
+
+Opened `/tmp/eliza-10199-review-package-smoke/scorecard.md` and
+`/tmp/eliza-10199-review-package-smoke/manifest.json`. The scorecard clearly reports
+`blocked`, records the git SHA and reviewer note, shows inventory/artifact guard as
+`ok`, and lists the missing latest snapshot/readiness findings. The manifest contains
+the same blocking findings under `blocking_findings`.
+
+Screenshots/video: N/A for this slice. It is a CLI/operator packaging command with no
+UI surface; the generated markdown/JSON artifacts above are the reviewable output.

--- a/packages/benchmarks/orchestrator/README.md
+++ b/packages/benchmarks/orchestrator/README.md
@@ -601,6 +601,24 @@ latest artifact set.
 `validate-runtime-gates` probes the current host for the external services and
 credentials that unlock benchmarks where sample/demo fallbacks are forbidden.
 
+After the latest matrix is generated and manually spot-reviewed, package the
+reviewed result set into the committed evidence location:
+
+```bash
+/opt/miniconda3/bin/python -m benchmarks.orchestrator review-package \
+  --latest-dir packages/benchmarks/benchmark_results/latest \
+  --out-dir .github/issue-evidence/10199-benchmark-review \
+  --reviewed-by <handle> \
+  --reviewer-note "Opened the selected trajectories/replays and spot-reviewed model inputs, outputs, scores, and failure diagnostics."
+```
+
+`review-package` writes `manifest.json` plus `scorecard.md` and exits nonzero
+unless the static inventory has no gaps, `validate-latest-readiness` passes,
+the generated-artifact guard finds no committed run output, latest rows exist,
+and the manual review note is present. Use `--include-benchmarks`,
+`--exclude-benchmarks`, and `--skip-runtime-gates` only when packaging a clearly
+scoped partial matrix; the manifest records those filters.
+
 Expected real-runtime gates:
 
 - Hyperliquid rows require `HL_PRIVATE_KEY` and live execution with demo mode

--- a/packages/benchmarks/orchestrator/cli.py
+++ b/packages/benchmarks/orchestrator/cli.py
@@ -30,6 +30,7 @@ from .inventory import (
     report_to_markdown as inventory_report_to_markdown,
 )
 from .random_baseline_runner import CALIBRATION_HARNESSES, SYNTHETIC_HARNESSES
+from .review_package import build_review_package, write_review_package
 from .runner import _rebuild_latest_result_snapshots, _repair_current_compatibility_statuses, run_benchmarks
 from .matrix_validation import build_cross_matrix_report, report_to_json, report_to_markdown
 from .runtime_gates import build_runtime_gate_report, print_runtime_gate_report
@@ -450,6 +451,35 @@ def _cmd_verify_artifacts(args: argparse.Namespace) -> int:
     return 0 if report.ok else 1
 
 
+def _cmd_review_package(args: argparse.Namespace) -> int:
+    workspace_root = _workspace_root_from_here()
+    latest_dir = Path(args.latest_dir).expanduser() if args.latest_dir else None
+    package = build_review_package(
+        workspace_root,
+        latest_dir=latest_dir,
+        reviewed_by=args.reviewed_by,
+        reviewer_note=args.reviewer_note,
+        tolerance=float(args.tolerance),
+        check_runtime_gates=not bool(args.skip_runtime_gates),
+        include_benchmarks=set(_split_csv(args.include_benchmarks)) or None,
+        exclude_benchmarks=set(_split_csv(args.exclude_benchmarks)) or None,
+    )
+    manifest_path, scorecard_path = write_review_package(
+        package,
+        Path(args.out_dir).expanduser(),
+    )
+    print(f"Wrote manifest: {manifest_path}")
+    print(f"Wrote scorecard: {scorecard_path}")
+    if not package.ok:
+        print(
+            "Benchmark review package is blocked; inspect `blocking_findings` "
+            "in the manifest or the scorecard section above."
+        )
+        return 1
+    print("Benchmark review package is complete.")
+    return 0
+
+
 def _parse_model_spec(spec: str) -> tuple[str, str, str | None]:
     """Parse ``provider:model[@base_url]`` into ``(provider, model, base_url)``.
 
@@ -825,6 +855,53 @@ def build_parser() -> argparse.ArgumentParser:
         help="Fail if generated benchmark output (results/DBs/trajectories) is committed",
     )
     p_verify_artifacts.set_defaults(func=_cmd_verify_artifacts)
+
+    p_review = sub.add_parser(
+        "review-package",
+        help="Write the final reviewed benchmark scorecard and machine-readable manifest",
+    )
+    p_review.add_argument(
+        "--latest-dir",
+        default=None,
+        help="Latest snapshot directory to package (default: benchmark_results/latest)",
+    )
+    p_review.add_argument(
+        "--out-dir",
+        required=True,
+        help="Directory that receives manifest.json and scorecard.md",
+    )
+    p_review.add_argument(
+        "--reviewed-by",
+        default="",
+        help="Human reviewer name or handle recorded in the manifest",
+    )
+    p_review.add_argument(
+        "--reviewer-note",
+        required=True,
+        help="Manual note confirming trajectories/replays were opened and spot-reviewed",
+    )
+    p_review.add_argument(
+        "--tolerance",
+        type=float,
+        default=0.08,
+        help="Allowed absolute score spread across required real harnesses",
+    )
+    p_review.add_argument(
+        "--skip-runtime-gates",
+        action="store_true",
+        help="Package latest artifacts without probing host runtime prerequisites",
+    )
+    p_review.add_argument(
+        "--include-benchmarks",
+        default=None,
+        help="Comma-separated benchmark IDs to include in the review package",
+    )
+    p_review.add_argument(
+        "--exclude-benchmarks",
+        default=None,
+        help="Comma-separated benchmark IDs to exclude from the review package",
+    )
+    p_review.set_defaults(func=_cmd_review_package)
 
     p_run = sub.add_parser("run", help="Run one or more benchmarks idempotently")
     p_run.add_argument("--all", action="store_true", help="Run all integrated benchmarks")

--- a/packages/benchmarks/orchestrator/review_package.py
+++ b/packages/benchmarks/orchestrator/review_package.py
@@ -1,0 +1,444 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from .artifact_guard import ArtifactGuardReport, build_artifact_guard_report
+from .inventory import BenchmarkInventoryReport, build_inventory_report
+from .latest_readiness import ReadinessReport, validate_latest_readiness
+
+
+@dataclass(frozen=True)
+class ReviewPackage:
+    ok: bool
+    manifest: dict[str, Any]
+    markdown: str
+
+
+def build_review_package(
+    workspace_root: Path,
+    *,
+    latest_dir: Path | None = None,
+    reviewed_by: str,
+    reviewer_note: str,
+    tolerance: float = 0.08,
+    check_runtime_gates: bool = True,
+    include_benchmarks: set[str] | None = None,
+    exclude_benchmarks: set[str] | None = None,
+    generated_at: str | None = None,
+    git_sha: str | None = None,
+) -> ReviewPackage:
+    """Build the final benchmark review scorecard/manifest from latest artifacts.
+
+    The package is intentionally derived from the same validator reports an
+    operator runs manually: static inventory, latest readiness, and generated
+    artifact leak guard. It can still write a blocked package so reviewers get
+    concrete next actions, but ``ok`` is true only when every gate passes and a
+    human review note is present.
+    """
+
+    target_dir = latest_dir or workspace_root / "benchmarks" / "benchmark_results" / "latest"
+    repo_root = workspace_root.parent
+    timestamp = generated_at or _now_iso()
+    sha = git_sha or _current_git_sha(repo_root)
+    note = reviewer_note.strip()
+
+    inventory = build_inventory_report(repo_root)
+    readiness = validate_latest_readiness(
+        workspace_root,
+        tolerance=tolerance,
+        latest_dir=target_dir,
+        check_runtime_gates=check_runtime_gates,
+        include_benchmarks=include_benchmarks,
+        exclude_benchmarks=exclude_benchmarks,
+    )
+    artifact_guard = build_artifact_guard_report(workspace_root)
+    latest_rows, row_findings = _load_latest_rows(
+        target_dir,
+        include_benchmarks=include_benchmarks,
+        exclude_benchmarks=exclude_benchmarks,
+    )
+
+    blocking_findings = _blocking_findings(
+        inventory=inventory,
+        readiness=readiness,
+        artifact_guard=artifact_guard,
+        latest_rows=latest_rows,
+        row_findings=row_findings,
+        reviewer_note=note,
+    )
+    manifest = {
+        "schema_version": 1,
+        "generated_at": timestamp,
+        "git_sha": sha,
+        "reviewed_by": reviewed_by.strip(),
+        "reviewer_note": note,
+        "latest_dir": str(target_dir),
+        "filters": {
+            "include_benchmarks": sorted(include_benchmarks or []),
+            "exclude_benchmarks": sorted(exclude_benchmarks or []),
+            "runtime_gates_checked": check_runtime_gates,
+            "tolerance": tolerance,
+        },
+        "summary": {
+            "ok": not blocking_findings,
+            "latest_rows": len(latest_rows),
+            "inventory_gaps": _inventory_gap_count(inventory),
+            "readiness_findings": len(readiness.findings),
+            "artifact_offenders": len(artifact_guard.offending),
+            "blocking_findings": len(blocking_findings),
+        },
+        "gates": {
+            "inventory": _inventory_gate(inventory),
+            "latest_readiness": json.loads(readiness.to_json()),
+            "artifact_guard": _artifact_gate(artifact_guard),
+        },
+        "latest_rows": latest_rows,
+        "blocking_findings": blocking_findings,
+    }
+    return ReviewPackage(
+        ok=bool(manifest["summary"]["ok"]),
+        manifest=manifest,
+        markdown=_render_markdown(manifest),
+    )
+
+
+def write_review_package(package: ReviewPackage, out_dir: Path) -> tuple[Path, Path]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = out_dir / "manifest.json"
+    scorecard_path = out_dir / "scorecard.md"
+    manifest_path.write_text(
+        json.dumps(package.manifest, indent=2, sort_keys=True, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+    scorecard_path.write_text(package.markdown, encoding="utf-8")
+    return manifest_path, scorecard_path
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _current_git_sha(repo_root: Path) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return "unknown"
+    return result.stdout.strip() or "unknown"
+
+
+def _load_latest_rows(
+    latest_dir: Path,
+    *,
+    include_benchmarks: set[str] | None,
+    exclude_benchmarks: set[str] | None,
+) -> tuple[list[dict[str, Any]], list[dict[str, str]]]:
+    rows: list[dict[str, Any]] = []
+    findings: list[dict[str, str]] = []
+    if not latest_dir.is_dir():
+        findings.append(
+            {
+                "gate": "latest_rows",
+                "scope": str(latest_dir),
+                "reason": "missing_latest_dir",
+                "value": "latest directory does not exist",
+            }
+        )
+        return rows, findings
+
+    for path in sorted(latest_dir.glob("*.json")):
+        if path.name == "index.json":
+            continue
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            findings.append(
+                {
+                    "gate": "latest_rows",
+                    "scope": path.name,
+                    "reason": "unreadable_latest_row",
+                    "value": str(exc),
+                }
+            )
+            continue
+        if not isinstance(payload, dict):
+            findings.append(
+                {
+                    "gate": "latest_rows",
+                    "scope": path.name,
+                    "reason": "latest_row_not_object",
+                    "value": type(payload).__name__,
+                }
+            )
+            continue
+
+        benchmark_id = str(payload.get("benchmark_id") or _filename_benchmark(path))
+        if not _benchmark_selected(
+            benchmark_id,
+            include_benchmarks=include_benchmarks,
+            exclude_benchmarks=exclude_benchmarks,
+        ):
+            continue
+        rows.append(_summarize_latest_row(path, payload, benchmark_id))
+    return rows, findings
+
+
+def _filename_benchmark(path: Path) -> str:
+    stem = path.stem
+    if "__" in stem:
+        return stem.split("__", 1)[0]
+    return stem
+
+
+def _filename_agent(path: Path) -> str:
+    stem = path.stem
+    if "__" in stem:
+        return stem.split("__", 1)[1]
+    return ""
+
+
+def _summarize_latest_row(
+    path: Path,
+    payload: dict[str, Any],
+    benchmark_id: str,
+) -> dict[str, Any]:
+    metrics = payload.get("metrics")
+    metrics = metrics if isinstance(metrics, dict) else {}
+    token_metrics = payload.get("token_metrics")
+    token_metrics = token_metrics if isinstance(token_metrics, dict) else {}
+    return {
+        "file": path.name,
+        "benchmark_id": benchmark_id,
+        "agent": str(payload.get("agent") or payload.get("harness") or _filename_agent(path)),
+        "status": str(payload.get("status") or ""),
+        "provider": str(payload.get("provider") or ""),
+        "model": str(payload.get("model") or ""),
+        "run_id": str(payload.get("run_id") or ""),
+        "score": payload.get("score"),
+        "unit": payload.get("unit"),
+        "higher_is_better": payload.get("higher_is_better"),
+        "output_dir": str(payload.get("output_dir") or ""),
+        "trajectory_dir": str(
+            payload.get("trajectory_dir")
+            or payload.get("target_trajectory_dir")
+            or metrics.get("trajectory_dir")
+            or ""
+        ),
+        "input_tokens": _metric_value(payload, token_metrics, "input_tokens"),
+        "output_tokens": _metric_value(payload, token_metrics, "output_tokens"),
+        "total_tokens": _metric_value(payload, token_metrics, "total_tokens"),
+        "cached_tokens": _metric_value(payload, token_metrics, "cached_tokens"),
+    }
+
+
+def _metric_value(payload: dict[str, Any], token_metrics: dict[str, Any], key: str) -> Any:
+    return payload.get(key, token_metrics.get(key))
+
+
+def _benchmark_selected(
+    benchmark_id: str,
+    *,
+    include_benchmarks: set[str] | None,
+    exclude_benchmarks: set[str] | None,
+) -> bool:
+    if include_benchmarks is not None and benchmark_id not in include_benchmarks:
+        return False
+    if exclude_benchmarks is not None and benchmark_id in exclude_benchmarks:
+        return False
+    return True
+
+
+def _blocking_findings(
+    *,
+    inventory: BenchmarkInventoryReport,
+    readiness: ReadinessReport,
+    artifact_guard: ArtifactGuardReport,
+    latest_rows: list[dict[str, Any]],
+    row_findings: list[dict[str, str]],
+    reviewer_note: str,
+) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    if inventory.registry_entries_without_adapters:
+        findings.append(
+            _finding(
+                "inventory",
+                "registry_entries_without_adapters",
+                "registry entries have no orchestrator adapter",
+                ", ".join(inventory.registry_entries_without_adapters),
+            )
+        )
+    if inventory.benchmark_directories_without_adapters:
+        findings.append(
+            _finding(
+                "inventory",
+                "benchmark_directories_without_adapters",
+                "benchmark directories have no orchestrator adapter",
+                ", ".join(inventory.benchmark_directories_without_adapters),
+            )
+        )
+    for finding in readiness.findings:
+        row = asdict(finding)
+        row["gate"] = "latest_readiness"
+        findings.append(row)
+    for path in artifact_guard.offending:
+        findings.append(
+            _finding(
+                "artifact_guard",
+                path,
+                "generated_artifact_committed",
+                "remove generated benchmark output from the git index",
+            )
+        )
+    findings.extend(row_findings)
+    if not latest_rows:
+        findings.append(
+            _finding(
+                "latest_rows",
+                "latest",
+                "no_latest_rows",
+                "no selected latest row JSON files were found",
+            )
+        )
+    if not reviewer_note:
+        findings.append(
+            _finding(
+                "reviewer_note",
+                "manual_review",
+                "missing_reviewer_note",
+                "provide a note confirming trajectories/replays were opened and spot-reviewed",
+            )
+        )
+    return findings
+
+
+def _finding(gate: str, scope: str, reason: str, value: str) -> dict[str, Any]:
+    return {
+        "gate": gate,
+        "scope": scope,
+        "reason": reason,
+        "value": value,
+    }
+
+
+def _inventory_gap_count(report: BenchmarkInventoryReport) -> int:
+    return len(report.registry_entries_without_adapters) + len(
+        report.benchmark_directories_without_adapters
+    )
+
+
+def _inventory_gate(report: BenchmarkInventoryReport) -> dict[str, Any]:
+    return {
+        "ok": not report.has_gaps,
+        "adapter_count": report.adapter_count,
+        "registry_entry_count": report.registry_entry_count,
+        "benchmark_directory_count": report.benchmark_directory_count,
+        "checklist_count": report.checklist_count,
+        "registry_entries_without_adapters": list(report.registry_entries_without_adapters),
+        "adapters_without_registry_entries": list(report.adapters_without_registry_entries),
+        "benchmark_directories_without_adapters": list(
+            report.benchmark_directories_without_adapters
+        ),
+    }
+
+
+def _artifact_gate(report: ArtifactGuardReport) -> dict[str, Any]:
+    return {
+        "ok": report.ok,
+        "checked_count": report.checked_count,
+        "offending": list(report.offending),
+    }
+
+
+def _render_markdown(manifest: dict[str, Any]) -> str:
+    summary = manifest["summary"]
+    lines = [
+        "# Benchmark Review Scorecard",
+        "",
+        f"- status: `{'ok' if summary['ok'] else 'blocked'}`",
+        f"- git SHA: `{manifest['git_sha']}`",
+        f"- generated at: `{manifest['generated_at']}`",
+        f"- latest dir: `{manifest['latest_dir']}`",
+        f"- reviewed by: `{manifest['reviewed_by'] or 'unspecified'}`",
+        f"- latest rows: `{summary['latest_rows']}`",
+        f"- readiness findings: `{summary['readiness_findings']}`",
+        f"- artifact offenders: `{summary['artifact_offenders']}`",
+        "",
+        "## Reviewer Note",
+        "",
+        manifest["reviewer_note"] or "_Missing manual trajectory/replay review note._",
+        "",
+        "## Gate Summary",
+        "",
+        "| gate | status | detail |",
+        "| --- | --- | --- |",
+        _gate_row("inventory", manifest["gates"]["inventory"]["ok"], f"gaps={summary['inventory_gaps']}"),
+        _gate_row(
+            "latest readiness",
+            manifest["gates"]["latest_readiness"]["ok"],
+            f"findings={summary['readiness_findings']}",
+        ),
+        _gate_row(
+            "artifact guard",
+            manifest["gates"]["artifact_guard"]["ok"],
+            f"offenders={summary['artifact_offenders']}",
+        ),
+        "",
+    ]
+
+    blockers = manifest["blocking_findings"]
+    if blockers:
+        lines.extend(["## Blocking Findings", ""])
+        for finding in blockers:
+            lines.append(
+                f"- `{finding.get('gate', 'gate')}` `{finding.get('scope', '')}`: "
+                f"{finding.get('reason', '')} - {finding.get('value', '')}"
+            )
+        lines.append("")
+
+    lines.extend(
+        [
+            "## Latest Rows",
+            "",
+            "| benchmark | agent | status | score | provider | model | run id | trajectory dir |",
+            "| --- | --- | --- | --- | --- | --- | --- | --- |",
+        ]
+    )
+    for row in manifest["latest_rows"]:
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    _md(row.get("benchmark_id")),
+                    _md(row.get("agent")),
+                    _md(row.get("status")),
+                    _md(row.get("score")),
+                    _md(row.get("provider")),
+                    _md(row.get("model")),
+                    _md(row.get("run_id")),
+                    _md(row.get("trajectory_dir")),
+                ]
+            )
+            + " |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _gate_row(name: str, ok: bool, detail: str) -> str:
+    return f"| {_md(name)} | `{'ok' if ok else 'blocked'}` | {_md(detail)} |"
+
+
+def _md(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).replace("\n", " ").replace("|", "\\|")

--- a/packages/benchmarks/orchestrator/tests/test_review_package.py
+++ b/packages/benchmarks/orchestrator/tests/test_review_package.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from benchmarks.orchestrator import cli, review_package
+from benchmarks.orchestrator.artifact_guard import ArtifactGuardReport
+from benchmarks.orchestrator.inventory import BenchmarkInventoryReport
+from benchmarks.orchestrator.latest_readiness import ReadinessFinding, ReadinessReport
+from benchmarks.orchestrator.review_package import (
+    ReviewPackage,
+    build_review_package,
+    write_review_package,
+)
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _inventory(
+    *,
+    registry_gaps: tuple[str, ...] = (),
+    directory_gaps: tuple[str, ...] = (),
+) -> BenchmarkInventoryReport:
+    return BenchmarkInventoryReport(
+        adapter_count=3,
+        registry_entry_count=3,
+        benchmark_directory_count=3,
+        checklist_count=3,
+        registry_entries_without_adapters=registry_gaps,
+        adapters_without_registry_entries=(),
+        benchmark_directories_without_adapters=directory_gaps,
+        rows=[],
+    )
+
+
+def _patch_reports(
+    monkeypatch,
+    *,
+    inventory: BenchmarkInventoryReport | None = None,
+    readiness: ReadinessReport | None = None,
+    artifact_guard: ArtifactGuardReport | None = None,
+) -> None:
+    monkeypatch.setattr(
+        review_package,
+        "build_inventory_report",
+        lambda _repo_root: inventory or _inventory(),
+    )
+    monkeypatch.setattr(
+        review_package,
+        "validate_latest_readiness",
+        lambda *_args, **_kwargs: readiness
+        or ReadinessReport(latest_dir="latest", tolerance=0.08, findings=()),
+    )
+    monkeypatch.setattr(
+        review_package,
+        "build_artifact_guard_report",
+        lambda _workspace_root: artifact_guard or ArtifactGuardReport(True, 10, ()),
+    )
+
+
+def test_review_package_writes_complete_manifest_and_scorecard(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    latest = tmp_path / "benchmarks" / "benchmark_results" / "latest"
+    _write_json(latest / "index.json", {"matrix_contract": {"status": "complete"}})
+    _write_json(
+        latest / "bfcl__eliza.json",
+        {
+            "benchmark_id": "bfcl",
+            "agent": "eliza",
+            "provider": "cerebras",
+            "model": "gpt-oss-120b",
+            "status": "succeeded",
+            "score": 1.0,
+            "run_id": "run_bfcl",
+            "trajectory_dir": "/tmp/trajectories",
+        },
+    )
+    _patch_reports(monkeypatch)
+
+    package = build_review_package(
+        tmp_path / "packages",
+        latest_dir=latest,
+        reviewed_by="reviewer",
+        reviewer_note="Opened trajectory files and spot-reviewed the replay.",
+        check_runtime_gates=False,
+        generated_at="2026-07-01T00:00:00Z",
+        git_sha="abc123",
+    )
+    manifest_path, scorecard_path = write_review_package(package, tmp_path / "review")
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert package.ok is True
+    assert manifest["summary"]["ok"] is True
+    assert manifest["summary"]["latest_rows"] == 1
+    assert manifest["latest_rows"][0]["benchmark_id"] == "bfcl"
+    assert manifest["latest_rows"][0]["provider"] == "cerebras"
+    scorecard = scorecard_path.read_text(encoding="utf-8")
+    assert "# Benchmark Review Scorecard" in scorecard
+    assert "Opened trajectory files" in scorecard
+    assert "| bfcl | eliza | succeeded | 1.0 | cerebras | gpt-oss-120b | run_bfcl |" in scorecard
+
+
+def test_review_package_blocks_on_readiness_artifacts_inventory_and_note(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    latest = tmp_path / "benchmarks" / "benchmark_results" / "latest"
+    _write_json(latest / "index.json", {})
+    readiness = ReadinessReport(
+        latest_dir=str(latest),
+        tolerance=0.08,
+        findings=(
+            ReadinessFinding(
+                scope="bfcl::hermes",
+                reason="missing",
+                value="no latest row",
+            ),
+        ),
+    )
+    _patch_reports(
+        monkeypatch,
+        inventory=_inventory(registry_gaps=("missing_adapter",)),
+        readiness=readiness,
+        artifact_guard=ArtifactGuardReport(
+            ok=False,
+            checked_count=11,
+            offending=("packages/benchmarks/benchmark_results/orchestrator.sqlite",),
+        ),
+    )
+
+    package = build_review_package(
+        tmp_path / "packages",
+        latest_dir=latest,
+        reviewed_by="",
+        reviewer_note="",
+        check_runtime_gates=False,
+        generated_at="2026-07-01T00:00:00Z",
+        git_sha="abc123",
+    )
+
+    reasons = {finding["reason"] for finding in package.manifest["blocking_findings"]}
+    assert package.ok is False
+    assert {
+        "registry entries have no orchestrator adapter",
+        "missing",
+        "generated_artifact_committed",
+        "no_latest_rows",
+        "missing_reviewer_note",
+    }.issubset(reasons)
+    assert "bfcl::hermes" in package.markdown
+
+
+def test_review_package_cli_writes_blocked_package(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.setattr(cli, "_workspace_root_from_here", lambda: tmp_path / "packages")
+    monkeypatch.setattr(
+        cli,
+        "build_review_package",
+        lambda *_args, **_kwargs: ReviewPackage(
+            ok=False,
+            manifest={"summary": {"ok": False}, "blocking_findings": [{"reason": "blocked"}]},
+            markdown="# blocked\n",
+        ),
+    )
+
+    code = cli._cmd_review_package(
+        argparse.Namespace(
+            latest_dir=None,
+            out_dir=str(tmp_path / "out"),
+            reviewed_by="reviewer",
+            reviewer_note="reviewed",
+            tolerance=0.08,
+            skip_runtime_gates=True,
+            include_benchmarks=None,
+            exclude_benchmarks=None,
+        )
+    )
+
+    assert code == 1
+    assert (tmp_path / "out" / "manifest.json").is_file()
+    assert (tmp_path / "out" / "scorecard.md").is_file()
+    assert "blocked" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Refs #10199.

Adds `python -m benchmarks.orchestrator review-package`, an operator-facing final packaging gate for reviewed benchmark results. The command writes `manifest.json` and `scorecard.md` and exits nonzero unless inventory, latest-readiness, artifact-leak, latest-row, and manual-review-note requirements all pass.

Also documents the command in the orchestrator runbook and adds focused tests for complete and blocked review packages plus CLI write behavior.

## Evidence

Evidence note: `.github/issue-evidence/10199-review-package.md`

Validated:

- `PYTHONPATH=packages python3 -m pytest packages/benchmarks/orchestrator/tests/test_review_package.py packages/benchmarks/orchestrator/tests/test_artifact_guard.py packages/benchmarks/orchestrator/tests/test_latest_readiness.py -q` -> 18 passed
- `PYTHONPATH=packages python3 -m benchmarks.orchestrator verify-artifacts` -> OK, checked 46256 tracked files
- `PYTHONPATH=packages python3 -m benchmarks.orchestrator review-package ... --skip-runtime-gates` -> wrote manifest + scorecard and correctly exited 1 because this clean checkout has no `benchmark_results/latest` snapshot
- `git diff --check origin/develop...HEAD` -> pass

Repo-wide caveats:

- `bun run verify` still fails in `audit:type-safety-ratchet`: `as unknown as: 108 current > 77 baseline` in unrelated TypeScript packages (`packages/feed`, `packages/agent`, `packages/app-core`, `packages/cloud`, `plugins/plugin-capacitor-bridge`).
- Full orchestrator test suite currently has 4 existing `test_code_agent_matrix.py` smoke-gate expectation failures even after provider keys are stripped; focused tests for this PR pass.

Screenshots/video: N/A for this slice because this is a CLI/operator packaging command. The generated markdown/JSON artifacts are the reviewable output.
