### PR TITLE
docs(cloud): map app platform lifecycle

### DIFF
--- a/.github/issue-evidence/10690-app-platform-review.md
+++ b/.github/issue-evidence/10690-app-platform-review.md
@@ -1,0 +1,74 @@
+# #10690 App Platform Review Evidence
+
+Date: 2026-07-01
+Branch: `fix/10690-app-platform-review-docs`
+Base under test: `15d2a7c58fa2aae244a455834d628795647438a5`
+
+## Change Verified
+
+This PR completes a local, reviewable #10690 slice:
+
+- adds `packages/cloud/APP_PLATFORM_REVIEW.md`, covering app lifecycle,
+  backend hosting, custom domains, analytics, SEO, advertising/growth,
+  content generation, agent skill contract, access policy, and cross-issue
+  coordination;
+- records a concrete managed-frontend hosting decision: Worker/R2 static host
+  with active app manifest, app/domain routing, SEO injection, page analytics,
+  cache policy, and rollback;
+- adds `packages/skills/skills/eliza-cloud/references/app-platform-lifecycle.md`;
+- updates `packages/skills/skills/eliza-cloud/SKILL.md` so bundled agents use
+  the unified app lifecycle and do not claim managed frontend hosting exists
+  before it lands.
+
+## Manual Review
+
+Opened and reviewed:
+
+- `packages/cloud/APP_PLATFORM_REVIEW.md`
+- `packages/skills/skills/eliza-cloud/SKILL.md`
+- `packages/skills/skills/eliza-cloud/references/app-platform-lifecycle.md`
+
+The review doc maps concrete route/schema/service owner files and links the
+new sibling issues:
+
+- #10687 advertising/growth marketplace
+- #10688 content generation + files/assets CRUD
+- #10689 Atlas video/provider registry
+- #10691 non-CI app/domain money-path e2e
+- #10692 any-device GitHub/device-code connect
+
+Screenshots/video: N/A for this slice. It is docs/skill guidance with no UI or
+runtime route changes. The reviewable artifacts are the Markdown files above.
+
+Live cloud e2e: N/A for this slice. It does not alter a Cloud route, DB schema,
+money path, or frontend view. The issue remains open for the implementation and
+live-evidence slices.
+
+## Commands
+
+```bash
+bun install --frozen-lockfile --ignore-scripts
+# installed dependencies successfully
+
+bun run --cwd packages/skills lint:check
+# Checked 6 files in 15ms. No fixes applied.
+
+node packages/shared/scripts/generate-keywords.mjs --target ts
+# generated the ignored core/shared i18n keyword data needed by the skill tests
+
+bun run --cwd packages/skills test
+# 60 pass, 0 fail
+
+git diff --check
+# pass
+
+bun run verify
+# fails in audit:type-safety-ratchet before typecheck/lint:
+# scanned 9901 tracked production source files
+# as unknown as: 108 current > 77 baseline
+# top offenders are packages/feed, packages/agent, packages/app-core,
+# packages/cloud, and plugins/plugin-capacitor-bridge
+```
+
+The repo-wide verify failure is unrelated to this docs/skill slice and matches
+the current unsafe-cast ratchet failure observed on other branches.

--- a/packages/cloud/APP_PLATFORM_REVIEW.md
+++ b/packages/cloud/APP_PLATFORM_REVIEW.md
@@ -1,0 +1,134 @@
+# Eliza Cloud App Platform Review
+
+Issue: #10690
+Date: 2026-07-01
+
+This review maps the current Cloud app platform and fixes the product contract
+that agents should follow while the missing managed-frontend host is built.
+
+## Current Platform Map
+
+| Surface | Current owner files | Current state |
+| --- | --- | --- |
+| App lifecycle | `packages/cloud/api/v1/apps/route.ts`, `packages/cloud/api/v1/apps/[id]/route.ts`, `packages/cloud/shared/src/db/schemas/apps.ts`, `packages/cloud/shared/src/lib/services/apps.ts`, `packages/cloud/shared/src/lib/services/app-factory.ts` | Real. Apps are org-owned, have API keys, `app_url`, `allowed_origins`, `production_url`, GitHub repo metadata, deployment state, monetization fields, automation config, promotional assets, and usage counters. |
+| Backend hosting | `packages/cloud/api/v1/apps/[id]/deploy/route.ts`, `packages/cloud/api/v1/apps/[id]/deploy/status/route.ts`, `packages/cloud/shared/src/lib/services/app-deploy-orchestrator.ts`, `packages/cloud/shared/src/lib/services/app-deployments.ts`, `packages/cloud/shared/src/db/schemas/containers.ts`, `packages/cloud/shared/src/db/schemas/app-databases.ts`, `packages/cloud/services/container-control-plane/` | Real but production-gated. Container deploys are queued, quota-checked, billed, and run through the control-plane/Hetzner path when `APPS_DEPLOY_ENABLED=1` and the org allowlist permits it. |
+| Custom domains | `packages/cloud/api/v1/apps/[id]/domains/*/route.ts`, `packages/cloud/api/v1/domains/*/route.ts`, `packages/cloud/shared/src/db/schemas/app-domains.ts`, `packages/cloud/shared/src/db/schemas/managed-domains.ts`, `packages/cloud/shared/src/lib/services/managed-domains.ts`, `packages/cloud/shared/src/lib/services/domain-pricing.ts`, `packages/cloud/shared/src/lib/services/domain-health.ts`, `packages/cloud/shared/src/lib/services/domain-renewals.ts` | Real. Managed buys, external verification, DNS, SSL/status, health, and renewals exist. Live registration is money/secret gated and tracked by #10621/#10691. |
+| Analytics | `packages/cloud/api/v1/apps/[id]/analytics/route.ts`, `packages/cloud/api/v1/apps/[id]/analytics/requests/route.ts`, `packages/cloud/api/v1/apps/[id]/users/route.ts`, `packages/cloud/shared/src/db/schemas/apps.ts`, `packages/cloud/shared/src/lib/services/app-analytics.ts`, `packages/cloud/shared/src/lib/services/analytics.ts`, `packages/cloud/shared/src/lib/services/analytics-derived.ts` | Real for API and request analytics. It does not yet include a first-class hosted-frontend page-view/session/funnel beacon. |
+| SEO and promotion | `packages/cloud/api/v1/apps/[id]/promote/route.ts`, `packages/cloud/api/v1/apps/[id]/promote/preview/route.ts`, `packages/cloud/api/v1/apps/[id]/promote/assets/route.ts`, `packages/cloud/shared/src/lib/services/app-promotion.ts`, `packages/cloud/shared/src/lib/services/app-promotion-assets.ts`, `packages/cloud/shared/src/lib/services/seo.ts` | Real but not fully effective for unhosted frontends. SEO can generate metadata/artifacts and promotion can post or configure channels, but Cloud cannot inject page metadata until it hosts or controls the frontend response. |
+| Advertising and growth | `packages/cloud/api/v1/advertising/**/route.ts`, `packages/cloud/shared/src/lib/services/advertising/`, `packages/cloud/shared/src/db/schemas/ad-accounts.ts`, `ad-campaigns.ts`, `ad-creatives.ts`, `ad-transactions.ts` | Real for advertiser-side Google/Meta/TikTok campaign/account/creative paths. Influencer marketplace, PR distribution, publisher inventory/SSP, brand approval, and more networks are tracked by #10687. |
+| Content generation | `packages/cloud/api/v1/generate-image/route.ts`, `generate-video/route.ts`, `generate-music/route.ts`, `generate-prompts/route.ts`, `packages/cloud/api/v1/apps/[id]/generate-image/route.ts`, `packages/cloud/shared/src/lib/services/generations.ts`, `packages/cloud/shared/src/db/schemas/generations.ts`, `packages/cloud/shared/src/lib/providers/image/` | Real for image, video, music, and prompt generation. Files/assets CRUD, video/audio provider registries, provider roster expansion, and scenario coverage are tracked by #10688/#10689. |
+| Agent skill contract | `packages/skills/skills/eliza-cloud/SKILL.md`, `references/apps-and-containers.md`, `references/cloud-backend-and-monetization.md`, `references/payments-and-promotion.md` | Real but needed a unified lifecycle reference. This PR adds `references/app-platform-lifecycle.md` and points the skill at it. |
+
+## Platform Contract
+
+The durable integration unit is the Cloud app record. Every self-serve app
+capability should attach to the app record, not to one-off routes:
+
+1. Create or reuse an org-owned app.
+2. Configure app auth: `app_url`, `allowed_origins`, redirect URIs, and API key
+   custody.
+3. Choose frontend hosting.
+4. Deploy a backend container only when server-side code is required.
+5. Attach a managed or verified custom domain.
+6. Enable monetization, usage billing, creator earnings, and payout paths.
+7. Add content generation, promotion, SEO, advertising, and analytics.
+8. Prove the full lifecycle through scenario evidence.
+
+The app record is already the shared key for auth, domains, analytics,
+monetization, promotion assets, content generation, and backend deploy. New
+surfaces should extend that contract instead of creating parallel product
+identities.
+
+## Frontend Hosting Decision
+
+Managed frontend hosting is the largest missing seam. The platform currently
+stores external `app_url` values and backend `production_url` values, but it
+does not own user frontend artifacts.
+
+Use a Worker/R2 static-host implementation for first-class frontend hosting.
+
+Recommended shape:
+
+- Store immutable frontend build artifacts in R2 under an org/app/deployment
+  prefix.
+- Add a frontend deployment record that points an app at the active manifest,
+  build metadata, content hash, and rollback target.
+- Serve hosted frontend responses through a Cloud Worker route or app hostname
+  handler so Cloud can inject analytics beacons, SEO metadata, security
+  headers, cache policy, and app-auth bootstrap consistently.
+- Keep container hosting for server-side workloads. Do not force a container for
+  static frontend-only apps.
+- Reuse existing app domains so a custom domain can target either the hosted
+  frontend, backend container, or an app-level routing policy.
+
+Why this path:
+
+- It uses the existing Cloudflare Worker/R2 operating model and bindings.
+- It avoids provisioning one Cloudflare Pages project per user app.
+- It gives Cloud control over SEO and page analytics at response time.
+- It keeps the frontend and backend lifecycles separate while preserving one
+  app/product identity.
+
+## Required Implementation Slices
+
+1. Frontend artifact model and routes:
+   - schema/repository for frontend deployments and active manifest
+   - upload/finalize/list/activate/rollback routes under `apps/[id]/frontend`
+   - R2 object prefix policy and manifest validation
+2. Hosted frontend serve path:
+   - route/hostname resolution from app/domain to active frontend manifest
+   - fallback to app container or external `app_url` when no frontend deployment
+     exists
+   - cache headers and safe content-type handling
+3. SEO and page analytics:
+   - metadata injection from app/SEO artifacts
+   - `robots.txt` and `sitemap.xml` ownership for hosted frontends
+   - lightweight page-view/session/funnel beacon tied to `appAnalytics` or a
+     sibling page analytics table
+4. Skill and UI lifecycle:
+   - dashboard trigger for upload/activate/rollback
+   - `eliza-cloud` skill steps for create -> host frontend -> deploy backend ->
+     buy/attach domain -> analytics/SEO -> ads/content
+5. Evidence:
+   - non-CI app/domain money-path scenario from #10691
+   - app-platform walkthrough with screenshots/video once UI exists
+   - DB rows, logs, hosted URL, and domain artifacts per `PR_EVIDENCE.md`
+
+## Generality And Access Review
+
+| Capability | Access state | Required policy |
+| --- | --- | --- |
+| App CRUD/auth | Available to authenticated org users/API keys | Keep org isolation and API-key custody enforced. |
+| Backend deploy | Production-gated by env and org allowlist | Keep gate until #10621 deploy image/secrets/staging evidence are done; expose clear 503/403 errors. |
+| Domains | Available by route, but live registrar depends on production keys and credits | Use #10691 for real purchase evidence; all paid buys need explicit confirmation. |
+| Analytics | Available for API/request paths | Add hosted frontend analytics only after frontend host exists. |
+| SEO | Available as artifacts/provider calls | Make response injection real through managed frontend hosting. |
+| Advertising | Advertiser-side paid campaigns exist | Do not start spend without account ownership, policy, destination URL, creative, audience, and budget confirmation. |
+| Content generation | General media generation exists | Add files/assets CRUD and provider registries before treating generated assets as a managed library. |
+
+## Cross-Issue Coordination
+
+- #10621: GA operator gate for deployment secrets, image digest, staging e2e,
+  payout, and registrar money paths.
+- #10687: advertising and growth marketplace, including influencer, PR, ad
+  inventory, more networks, approval, and publisher revenue.
+- #10688: content-generation API completion and files/assets CRUD.
+- #10689: Atlas video and video provider registry.
+- #10691: non-CI full app create/deploy/domain-buy money-path scenario.
+- #10692: any-device GitHub/device-code connect for fresh cloud agents.
+- #8434: launch tracker that should consume the evidence from these slices.
+
+## Done Criteria For The Umbrella
+
+#10690 should stay open until a reviewer can verify, without reading code:
+
+- a fresh user creates an app,
+- uploads or generates a hosted frontend,
+- deploys a backend container if needed,
+- buys or attaches a domain,
+- sees page and API analytics,
+- applies SEO metadata,
+- generates content assets,
+- runs or schedules promotion/ads with explicit confirmation,
+- and captures screenshots, video, logs, DB rows, hosted URLs, provider
+  artifacts, and money-path evidence.

--- a/packages/skills/skills/eliza-cloud/SKILL.md
+++ b/packages/skills/skills/eliza-cloud/SKILL.md
@@ -25,6 +25,8 @@ Treat Eliza Cloud as the default managed backend before inventing separate auth,
 
 - `references/cloud-backend-and-monetization.md` for apps, auth, billing, and earnings
 - `references/apps-and-containers.md` for deployment, domains, and container workflow
+- `references/app-platform-lifecycle.md` for the unified app platform contract,
+  current frontend-hosting reality, and app lifecycle order
 - `references/payments-and-promotion.md` for app charges, x402 requests, local billing proxy aliases, payout redemptions, promotion assets, advertising, image/video/music/TTS generation, and parent-agent Cloud commands
 
 ## Skill Pairing
@@ -42,6 +44,13 @@ For new agent-built apps, defer to `build-monetized-app`: register a Cloud app,
 build and push a container image, deploy that container, enable monetization,
 patch the app URL/origins, and then offer a custom domain. Static hosting is
 only for legacy/local apps or edits to an existing static app.
+
+Cloud is the app platform contract, but managed frontend hosting is not
+first-class yet. Until the Worker/R2 frontend host described in
+`packages/cloud/APP_PLATFORM_REVIEW.md` lands, use an external/static frontend
+URL for frontend-only apps, and deploy a container only when the app needs
+server-side code. Do not promise that Cloud can upload and serve arbitrary
+frontend build artifacts as a managed static site yet.
 
 For existing app work:
 

--- a/packages/skills/skills/eliza-cloud/references/app-platform-lifecycle.md
+++ b/packages/skills/skills/eliza-cloud/references/app-platform-lifecycle.md
@@ -1,0 +1,109 @@
+# Eliza Cloud App Platform Lifecycle
+
+Use this reference when a user asks to create, host, deploy, monetize, promote,
+or operate an Eliza Cloud app.
+
+## Product Contract
+
+The Cloud app record is the product identity. Attach capabilities to that app
+record instead of inventing separate per-feature identities.
+
+Use this order:
+
+1. Create or reuse an app: `POST /api/v1/apps`.
+2. Configure browser auth: `app_url`, `allowed_origins`, redirect URIs, and the
+   public app URL.
+3. Decide how the frontend is hosted.
+4. Deploy a backend container only if server-side code is required.
+5. Attach or buy a domain.
+6. Enable monetization and earnings if the app should make money.
+7. Add analytics, SEO, content generation, and promotion/ads as app-level
+   features.
+8. Capture evidence: screenshots/video for UI, logs, DB rows, provider
+   artifacts, and money-path records.
+
+## Current Hosting Reality
+
+Cloud has first-class app records, app auth, backend container deploys, custom
+domains, analytics, monetization, promotion, advertising, and content
+generation. It does not yet have first-class managed frontend hosting for user
+build artifacts.
+
+Until managed frontend hosting lands:
+
+- For static frontend-only apps, use an external/static host and register that
+  URL in `app_url` and `allowed_origins`.
+- For apps that need server-side code, deploy a container and use its
+  `production_url` or attached custom domain.
+- Do not claim Cloud can upload and serve arbitrary user frontend build output
+  as a managed static site yet.
+- Do not deploy a container just to get a static frontend online.
+
+The planned managed frontend host should be Worker/R2 based: immutable frontend
+artifacts in R2, an active manifest on the app, Worker/hostname serving,
+SEO/meta injection, page analytics beaconing, cache policy, rollback, and
+domain routing through the existing app/domain model.
+
+## Backend Container Rule
+
+Use a container only for real server-side work:
+
+- API routes or custom server logic
+- webhooks
+- background jobs
+- existing Dockerized apps
+- private server-side credentials
+
+Do not use a container when Cloud APIs plus a static frontend are enough.
+
+## Domain Rule
+
+Prefer the existing app domain model:
+
+- check availability and pricing before buying,
+- confirm exact spend before a managed domain purchase,
+- attach external domains through TXT verification,
+- use status/health routes to verify DNS and SSL,
+- record purchase ids and cleanup notes for live tests.
+
+Domain purchase is a money path. Never start it from a worker without explicit
+parent/user confirmation.
+
+## Analytics And SEO Rule
+
+Current analytics are strongest for API/request usage. Page-view/session/funnel
+analytics become first-class once Cloud owns frontend responses.
+
+Current SEO can create metadata/artifacts, but Cloud cannot reliably inject
+them into arbitrary external frontends. For external hosts, return the metadata
+for the app builder to install. For managed frontend hosting, inject metadata,
+`robots.txt`, `sitemap.xml`, and structured data at the serving layer.
+
+## Promotion, Advertising, And Content
+
+Use app-scoped content generation and promotion only after the destination URL
+is real.
+
+- Generate images/video/music/prompts through the Cloud generation routes.
+- Store successful promotional assets on the app record where available.
+- Create ad accounts/campaigns/creatives as drafts first.
+- Do not start ad delivery without account ownership, platform policy,
+  destination URL, approved creative, audience, and explicit budget
+  confirmation.
+- Influencer marketplace, PR distribution, publisher ad inventory, and more ad
+  networks are separate growth workstreams.
+
+## Source Map
+
+- Platform review: `packages/cloud/APP_PLATFORM_REVIEW.md`
+- App routes: `packages/cloud/api/v1/apps/**/route.ts`
+- Domain routes: `packages/cloud/api/v1/apps/[id]/domains/**/route.ts`
+- Backend deploy: `packages/cloud/api/v1/apps/[id]/deploy/route.ts`
+- App schema: `packages/cloud/shared/src/db/schemas/apps.ts`
+- Deploy services: `packages/cloud/shared/src/lib/services/app-deployments.ts`,
+  `app-deploy-orchestrator.ts`
+- Promotion: `packages/cloud/shared/src/lib/services/app-promotion.ts`,
+  `app-promotion-assets.ts`
+- SEO: `packages/cloud/shared/src/lib/services/seo.ts`
+- Advertising: `packages/cloud/shared/src/lib/services/advertising/`
+- Content generation: `packages/cloud/shared/src/lib/services/generations.ts`


### PR DESCRIPTION
## Summary

Refs #10690.

Adds the written architecture review deliverable for the Cloud app-platform umbrella:

- `packages/cloud/APP_PLATFORM_REVIEW.md` maps app lifecycle, backend hosting, domains, analytics, SEO, advertising/growth, content generation, and the agent skill contract to concrete route/schema/service owners.
- Records a concrete managed-frontend hosting decision: Worker/R2 static host with active app manifest, app/domain routing, SEO injection, page analytics, cache policy, and rollback.
- Adds `packages/skills/skills/eliza-cloud/references/app-platform-lifecycle.md`.
- Updates `eliza-cloud` skill guidance so bundled agents use the unified lifecycle and do not claim managed frontend hosting exists before it lands.

## Evidence

Evidence note: `.github/issue-evidence/10690-app-platform-review.md`

Validated:

- `bun run --cwd packages/skills lint:check` -> pass
- `node packages/shared/scripts/generate-keywords.mjs --target ts` -> generated ignored keyword data needed by skill tests
- `bun run --cwd packages/skills test` -> 60 pass, 0 fail
- `git diff --check origin/develop...HEAD` -> pass

Repo-wide caveat:

- `bun run verify` still fails in `audit:type-safety-ratchet`: `as unknown as: 108 current > 77 baseline` in unrelated TypeScript packages (`packages/feed`, `packages/agent`, `packages/app-core`, `packages/cloud`, `plugins/plugin-capacitor-bridge`).

Screenshots/video/live cloud e2e: N/A for this slice because it is docs/skill guidance only and changes no route, DB schema, frontend view, or money path.

## Remaining #10690 Scope

Keep #10690 open for the implementation slices: managed frontend hosting, hosted page analytics, SEO injection, dashboard triggers, and full live walkthrough evidence across app creation, frontend hosting, backend deploy, domain, analytics, SEO, ads, and content generation.
