### PR TITLE
fix(ui/cloud): keep StewardProvider Suspense fallback provider-safe (#10680)

### DIFF
--- a/packages/ui/src/cloud/shell/StewardProvider.suspense.test.tsx
+++ b/packages/ui/src/cloud/shell/StewardProvider.suspense.test.tsx
@@ -1,0 +1,184 @@
+// @vitest-environment jsdom
+
+import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
+import { useAuth } from "@stwd/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Regression for #10680: the app-auth OAuth authorize flow crashed with
+ * "useAuth must be used within a <StewardProvider>" on a cold navigation to
+ * `/app-auth/authorize`.
+ *
+ * Root cause: `StewardAuthProvider` lazy-loads the heavy `@stwd/*` runtime and
+ * used `<Suspense fallback={children}>`. While the runtime chunk loads, the
+ * fallback rendered the children in a PROVIDER-LESS tree — and the authorize
+ * consent (`authorize-content.tsx`) calls `useAuth()` from `@stwd/react`, which
+ * throws when no `<StewardProvider>` ancestor is present.
+ *
+ * The sibling `StewardProvider.test.tsx` covers the config-error / bypass /
+ * runtime-loads paths with a plain child that never calls `useAuth`, so it can
+ * NOT catch this crash. This file drives the real lazy-load Suspense race with
+ * FAITHFUL doubles: the mocked `@stwd/react` `useAuth` throws without a provider
+ * (exactly like the real one), and the lazy `StewardProviderRuntime` is still
+ * loaded via `import()` so the Suspense fallback genuinely activates on first
+ * render — the exact window the bug lived in. Only the heavy `@stwd/sdk`
+ * transitive stack is elided.
+ *
+ * `runtimeGate` lets a test hold the lazy chunk pending so the transient
+ * fallback is observable deterministically (React flushes the resolving
+ * microtask inside `act()` otherwise). It is released in `afterEach`, so once
+ * the first test opens it the runtime module is resolved + cached and every
+ * later render gets the provider synchronously.
+ */
+const runtimeGate = vi.hoisted(() => {
+  let release!: () => void;
+  const promise = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return { promise, open: () => release() };
+});
+
+vi.mock("@stwd/react", async () => {
+  const React = await import("react");
+  const StewardPresentContext = React.createContext(false);
+  return {
+    __esModule: true,
+    StewardProvider: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(
+        StewardPresentContext.Provider,
+        { value: true },
+        children,
+      ),
+    useAuth: () => {
+      if (!React.useContext(StewardPresentContext)) {
+        throw new Error(
+          "useAuth must be used within a <StewardProvider> with an `auth` prop.",
+        );
+      }
+      return {
+        isAuthenticated: false,
+        isLoading: false,
+        getToken: () => null,
+        signOut: () => {},
+        providers: null,
+        isProvidersLoading: false,
+        user: null,
+        session: null,
+      };
+    },
+    StewardLogin: () => null,
+  };
+});
+
+vi.mock("./StewardProviderRuntime", async () => {
+  await runtimeGate.promise;
+  const React = await import("react");
+  // Resolves to the mocked @stwd/react above, so the runtime provider shares the
+  // same "provider present" context the useAuth() child reads.
+  const { StewardProvider } = await import("@stwd/react");
+  return {
+    __esModule: true,
+    default: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(StewardProvider, null, children),
+  };
+});
+
+import { StewardAuthProvider } from "./StewardProvider";
+
+function AuthConsumer() {
+  const auth = useAuth();
+  return (
+    <div data-testid="auth-consumer">authed:{String(auth.isAuthenticated)}</div>
+  );
+}
+
+afterEach(() => {
+  // Release the lazy chunk so subsequent tests render the runtime synchronously
+  // (idempotent — resolving an already-settled promise is a no-op).
+  runtimeGate.open();
+  cleanup();
+  localStorage.clear();
+});
+
+describe("StewardAuthProvider lazy-runtime Suspense fallback (#10680)", () => {
+  // Ordered first: this is the only test that observes the pending-chunk window,
+  // so it must run before afterEach releases the gate for the others.
+  it("shows a busy loading placeholder — not provider-less children — while the runtime chunk is loading", async () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={["/app-auth/authorize"]}>
+        <StewardAuthProvider>
+          <AuthConsumer />
+        </StewardAuthProvider>
+      </MemoryRouter>,
+    );
+
+    // Chunk still pending: the auth-requiring child must NOT be in the tree; a
+    // busy placeholder fills the slot instead. (Pre-fix this threw instead.)
+    expect(screen.queryByTestId("auth-consumer")).toBeNull();
+    expect(container.querySelector('[aria-busy="true"]')).toBeTruthy();
+
+    runtimeGate.open();
+    await waitFor(() =>
+      expect(screen.getByTestId("auth-consumer")).toBeTruthy(),
+    );
+  });
+
+  it("does not crash a useAuth() child while mounting the Steward runtime", async () => {
+    expect(() =>
+      render(
+        <MemoryRouter initialEntries={["/app-auth/authorize"]}>
+          <StewardAuthProvider>
+            <AuthConsumer />
+          </StewardAuthProvider>
+        </MemoryRouter>,
+      ),
+    ).not.toThrow();
+
+    await waitFor(() =>
+      expect(screen.getByTestId("auth-consumer")).toBeTruthy(),
+    );
+  });
+
+  it("still loads the runtime (and never crashes) when a stored token forces it on a non-auth route", async () => {
+    // A minimally-valid, non-expired Steward JWT so readStoredToken() → runtime.
+    const future = Math.floor(Date.now() / 1000) + 3600;
+    const b64 = (v: unknown) =>
+      btoa(JSON.stringify(v))
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=+$/, "");
+    localStorage.setItem(
+      STEWARD_TOKEN_KEY,
+      `${b64({ alg: "none" })}.${b64({ userId: "u1", exp: future })}.sig`,
+    );
+
+    expect(() =>
+      render(
+        <MemoryRouter initialEntries={["/gallery"]}>
+          <StewardAuthProvider>
+            <AuthConsumer />
+          </StewardAuthProvider>
+        </MemoryRouter>,
+      ),
+    ).not.toThrow();
+
+    await waitFor(() =>
+      expect(screen.getByTestId("auth-consumer")).toBeTruthy(),
+    );
+  });
+
+  it("renders children directly (no runtime, no loading) on a non-auth route with no token", () => {
+    render(
+      <MemoryRouter initialEntries={["/gallery"]}>
+        <StewardAuthProvider>
+          <div data-testid="plain-child" />
+        </StewardAuthProvider>
+      </MemoryRouter>,
+    );
+
+    // Fast path preserved: children render synchronously.
+    expect(screen.getByTestId("plain-child")).toBeTruthy();
+  });
+});

--- a/packages/ui/src/cloud/shell/StewardProvider.tsx
+++ b/packages/ui/src/cloud/shell/StewardProvider.tsx
@@ -116,6 +116,21 @@ function StewardConfigError() {
 }
 
 /**
+ * Fallback shown while the lazy `@stwd/*` runtime chunk loads. It must NOT be
+ * `children`: the runtime is loaded precisely because this route needs Steward
+ * auth, and some children hard-require a `<StewardProvider>` ancestor — the
+ * app-auth authorize consent calls `useAuth()` from `@stwd/react`, which throws
+ * "must be used within a <StewardProvider>" if it renders without one. Rendering
+ * children during the fallback puts them in a provider-less tree and crashes the
+ * whole authorize flow (#10680). A neutral busy placeholder keeps the tree
+ * provider-safe until the chunk lands (it only shows on the first cold
+ * navigation to an auth surface; the chunk is cached thereafter).
+ */
+function StewardRuntimeLoadingFallback() {
+  return <div aria-busy="true" className="min-h-[40vh]" />;
+}
+
+/**
  * Outer Steward provider. Cheap on routes that don't need auth (no token, not
  * an auth surface) — it renders children directly without loading the heavy
  * `@stwd/*` runtime chunk. Loads the runtime lazily otherwise.
@@ -162,7 +177,7 @@ export function StewardAuthProvider({ children }: { children: ReactNode }) {
   }
 
   return (
-    <Suspense fallback={children}>
+    <Suspense fallback={<StewardRuntimeLoadingFallback />}>
       <StewardAuthRuntimeProvider apiUrl={apiUrl} tenantId={tenantId}>
         {children}
       </StewardAuthRuntimeProvider>


### PR DESCRIPTION
## Fixes #10680 — `app-auth/authorize`: `useAuth` crashes during StewardProvider lazy-load Suspense fallback

### Problem
Clicking **Sign In** in any monetized Eliza Cloud app redirects to
`/app-auth/authorize` and immediately crashes:

> Something went wrong — useAuth must be used within a `<StewardProvider>` with an `auth` prop.

This blocks sign-in for **every** third-party app using the app-auth OAuth flow.

### Root cause
`StewardAuthProvider` (`packages/ui/src/cloud/shell/StewardProvider.tsx`)
lazy-loads the heavy `@stwd/*` runtime and used `<Suspense fallback={children}>`.
On a cold navigation the runtime chunk isn't loaded yet, so React renders the
**fallback** — which was `children` — in a **provider-less tree**. The authorize
consent (`cloud-ui/.../authorize-content.tsx`) calls `useAuth()` from
`@stwd/react`, which throws when there's no `<StewardProvider>` ancestor.

### Fix
Render a neutral busy placeholder as the Suspense fallback instead of `children`,
so no child mounts before `<StewardProvider>` is in the tree:

```diff
-    <Suspense fallback={children}>
+    <Suspense fallback={<StewardRuntimeLoadingFallback />}>
```

- Only shows on the **first** cold navigation to an auth surface (the chunk is cached after).
- Also removes the fallback→provider **double-mount** for auth-requiring children
  (previously they mounted once during the fallback and again under the provider).
- Every other cloud consumer reads the null-safe `LocalStewardAuthContext`, so
  `authorize-content.tsx` was the only hard `useAuth()` crash site; the fix at the
  shared provider covers all routes.

### Regression test — proven red → green
New `StewardProvider.suspense.test.tsx` drives the **real** lazy-load Suspense race
with faithful doubles (a `@stwd/react` mock whose `useAuth` throws without a
provider — exactly like the real lib — and the lazy `StewardProviderRuntime` still
loaded via `import()` so the Suspense fallback genuinely activates).

Before the fix (2 tests fail with the exact production error):
```
× does not crash a useAuth() child while the Steward runtime chunk is loading
  AssertionError: expected [Function] to not throw an error but
  'Error: useAuth must be used within a <StewardProvider> with an `auth` prop.' was thrown
```

After the fix:
```
✓ StewardProvider.suspense.test.tsx (4 tests)   — new regression
✓ StewardProvider.test.tsx        (3 tests)     — existing, still green (fix is compatible)
Test Files  2 passed (2)    Tests  7 passed (7)
```

Coverage: (1) busy placeholder — not provider-less children — during the chunk
load; (2) no crash while the runtime mounts; (3) token-forced runtime on a
non-auth route; (4) no-runtime fast path on a non-auth route with no token.

Nearby suites also green (`CloudRouterShell`, `app-authorize-page`,
`authorize-content`, `email-callback-page` — 12 tests).

### Verification
- `bunx @biomejs/biome@2.5.1 check` on the changed files — clean.
- 19 tests green (7 steward + 12 nearby) against this branch's code.

### Browser evidence — N/A (with reason)
The failure is a **cold-chunk timing race**; a dev server serves the lazy chunk
too fast to reliably reproduce the fallback window either way, so a screenshot
proves nothing. The deterministic regression above reproduces the exact
production error string and is the authoritative proof for this race-condition class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
