### PR TITLE
fix(cloud-ui): use login redirect for app-auth OAuth

### DIFF
--- a/packages/ui/src/cloud-ui/components/auth/authorize-content.test.tsx
+++ b/packages/ui/src/cloud-ui/components/auth/authorize-content.test.tsx
@@ -4,14 +4,28 @@ import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const enabledProviders = vi.hoisted(() => ({
+  passkey: true,
+  email: true,
+  siwe: false,
+  siws: false,
+  google: true,
+  discord: true,
+  github: false,
+  twitter: false,
+  oauth: ["google", "discord"],
+}));
+
 const authRef = vi.hoisted(() => ({
   current: {
     isLoading: false,
     isAuthenticated: true,
     getToken: vi.fn(() => "token-1"),
     signOut: vi.fn(),
-    providers: [],
+    providers: enabledProviders,
     isProvidersLoading: false,
+    signInWithOAuth: vi.fn(),
+    activeTenantId: "elizacloud",
   },
 }));
 
@@ -23,8 +37,28 @@ const searchParamsRef = vi.hoisted(() => ({
 }));
 
 vi.mock("@stwd/react", () => ({
-  StewardLogin: ({ title }: { title?: string }) => (
-    <div data-testid="steward-login">{title}</div>
+  DiscordIcon: ({ size }: { size?: number }) => (
+    <svg aria-hidden="true" data-size={size} data-testid="discord-icon" />
+  ),
+  GoogleIcon: ({ size }: { size?: number }) => (
+    <svg aria-hidden="true" data-size={size} data-testid="google-icon" />
+  ),
+  StewardLogin: ({
+    showDiscord,
+    showGoogle,
+    title,
+  }: {
+    showDiscord?: boolean;
+    showGoogle?: boolean;
+    title?: string;
+  }) => (
+    <div
+      data-show-discord={String(showDiscord)}
+      data-show-google={String(showGoogle)}
+      data-testid="steward-login"
+    >
+      {title}
+    </div>
   ),
   useAuth: () => authRef.current,
 }));
@@ -73,8 +107,10 @@ describe("AuthorizeContent", () => {
       isAuthenticated: true,
       getToken: vi.fn(() => "token-1"),
       signOut: vi.fn(),
-      providers: [],
+      providers: enabledProviders,
       isProvidersLoading: false,
+      signInWithOAuth: vi.fn(),
+      activeTenantId: "elizacloud",
     };
     pushMock.mockReset();
     searchParamsRef.current = new URLSearchParams(
@@ -138,9 +174,57 @@ describe("AuthorizeContent", () => {
     expect(screen.getByTestId("steward-login").textContent).toBe(
       "Sign in to authorize",
     );
+    expect(
+      screen.getByTestId("steward-login").getAttribute("data-show-google"),
+    ).toBe("false");
+    expect(
+      screen.getByTestId("steward-login").getAttribute("data-show-discord"),
+    ).toBe("false");
+    expect(
+      screen.getByRole("button", { name: "Continue with Google" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Continue with Discord" }),
+    ).toBeTruthy();
     expect(screen.queryByText("This app wants to:")).toBeNull();
     expect(screen.queryByText(/By continuing/)).toBeNull();
     expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy();
+  });
+
+  it("starts app-auth OAuth with the allowlisted Steward login redirect", async () => {
+    const user = userEvent.setup();
+    const signInWithOAuth = vi.fn(async () => ({
+      token: "token-1",
+      user: { id: "user-1", email: "nubs@example.com" },
+    }));
+    authRef.current = {
+      ...authRef.current,
+      isAuthenticated: false,
+      signInWithOAuth,
+    };
+
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        ...realLocation,
+        assign: locationAssignMock,
+        origin: "https://elizacloud.ai",
+      },
+    });
+
+    render(<AuthorizeContent />);
+
+    await waitFor(() => expect(screen.getByText("Demo App")).toBeTruthy());
+    await user.click(
+      screen.getByRole("button", { name: "Continue with Google" }),
+    );
+
+    await waitFor(() =>
+      expect(signInWithOAuth).toHaveBeenCalledWith("google", {
+        redirectUri: "https://elizacloud.ai/login",
+        tenantId: "elizacloud",
+      }),
+    );
   });
 
   it("sends signed-out users through the cancel redirect", async () => {

--- a/packages/ui/src/cloud-ui/components/auth/authorize-content.tsx
+++ b/packages/ui/src/cloud-ui/components/auth/authorize-content.tsx
@@ -1,8 +1,13 @@
 "use client";
 
-import { StewardLogin, useAuth } from "@stwd/react";
+import { DiscordIcon, GoogleIcon, StewardLogin, useAuth } from "@stwd/react";
+import type { StewardProviders } from "@stwd/sdk";
 import { AlertTriangle, Loader2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
+import {
+  buildStewardOAuthRedirectUri,
+  resolveStewardOAuthTenantId,
+} from "../../../cloud/public-pages/lib/steward-oauth-url";
 import Image from "../../runtime/image";
 import { useRouter, useSearchParams } from "../../runtime/navigation";
 import { BrandButton, BrandCard, CornerBrackets } from "../primitives";
@@ -21,6 +26,34 @@ interface AppInfo {
 }
 
 type AuthorizeStatus = "validating" | "ready" | "authorizing" | "error";
+type AppAuthorizeOAuthProvider = "google" | "discord";
+type AppAuthorizeOAuthSignIn = (
+  provider: AppAuthorizeOAuthProvider,
+  config?: { redirectUri?: string; tenantId?: string },
+) => Promise<unknown>;
+
+const APP_AUTHORIZE_OAUTH_PROVIDERS = [
+  {
+    id: "google",
+    label: "Continue with Google",
+    buttonClassName: "stwd-login__btn--google",
+    spinnerClassName: "stwd-login__spinner--dark",
+    Icon: GoogleIcon,
+  },
+  {
+    id: "discord",
+    label: "Continue with Discord",
+    buttonClassName: "stwd-login__btn--discord",
+    spinnerClassName: "",
+    Icon: DiscordIcon,
+  },
+] satisfies Array<{
+  id: AppAuthorizeOAuthProvider;
+  label: string;
+  buttonClassName: string;
+  spinnerClassName: string;
+  Icon: typeof GoogleIcon;
+}>;
 
 export function AuthorizeContent() {
   const router = useRouter();
@@ -72,6 +105,8 @@ function AuthorizeAuthenticatedContent({
     signOut,
     providers,
     isProvidersLoading,
+    signInWithOAuth,
+    activeTenantId,
   } = useAuth();
   // Steward provider discovery (Google/Discord/etc) is fetched at app shell
   // mount, but on a cold load to /app-auth/authorize the round-trip can take a
@@ -270,8 +305,11 @@ function AuthorizeAuthenticatedContent({
         />
       ) : (
         <SignedOutActions
+          activeTenantId={activeTenantId}
           onCancel={handleCancel}
+          providers={providers}
           providersReady={providersReady}
+          signInWithOAuth={signInWithOAuth}
         />
       )}
     </Frame>
@@ -373,21 +411,101 @@ function SignedInActions({
 }
 
 function SignedOutActions({
+  activeTenantId,
   onCancel,
+  providers,
   providersReady,
+  signInWithOAuth,
 }: {
+  activeTenantId: string | null;
   onCancel: () => void;
+  providers: StewardProviders | null;
   providersReady: boolean;
+  signInWithOAuth: AppAuthorizeOAuthSignIn;
 }) {
+  const [oauthLoadingProvider, setOauthLoadingProvider] =
+    useState<AppAuthorizeOAuthProvider | null>(null);
+  const [oauthError, setOauthError] = useState<string | null>(null);
+
+  const enabledOAuthProviders = APP_AUTHORIZE_OAUTH_PROVIDERS.filter(
+    ({ id }) => providers?.[id] ?? false,
+  );
+  const showPasskey = providers?.passkey ?? true;
+  const showEmail = providers?.email ?? true;
+
+  const handleOAuth = useCallback(
+    async (provider: AppAuthorizeOAuthProvider) => {
+      if (typeof window === "undefined") return;
+
+      setOauthLoadingProvider(provider);
+      setOauthError(null);
+
+      try {
+        const redirectUri = buildStewardOAuthRedirectUri(
+          window.location.origin,
+        );
+        await signInWithOAuth(provider, {
+          redirectUri,
+          tenantId: resolveStewardOAuthTenantId(activeTenantId),
+        });
+      } catch (err) {
+        setOauthError(
+          err instanceof Error ? err.message : "Unable to start OAuth sign-in.",
+        );
+      } finally {
+        setOauthLoadingProvider(null);
+      }
+    },
+    [activeTenantId, signInWithOAuth],
+  );
+
   return (
     <div className="flex w-full flex-col items-center gap-4">
       {providersReady ? (
-        <StewardLogin
-          variant="inline"
-          showPasskey
-          showEmail
-          title="Sign in to authorize"
-        />
+        <>
+          <StewardLogin
+            variant="inline"
+            showPasskey={showPasskey}
+            showEmail={showEmail}
+            showGoogle={false}
+            showDiscord={false}
+            title="Sign in to authorize"
+          />
+          {enabledOAuthProviders.length > 0 && (showPasskey || showEmail) && (
+            <div className="stwd-login__divider">
+              <span>or</span>
+            </div>
+          )}
+          {enabledOAuthProviders.length > 0 && (
+            <div className="stwd-login__oauth">
+              {enabledOAuthProviders.map(
+                ({ id, label, buttonClassName, spinnerClassName, Icon }) => (
+                  <button
+                    className={`stwd-login__btn ${buttonClassName}`}
+                    disabled={oauthLoadingProvider !== null}
+                    key={id}
+                    onClick={() => void handleOAuth(id)}
+                    type="button"
+                  >
+                    {oauthLoadingProvider === id ? (
+                      <span
+                        className={`stwd-login__spinner ${spinnerClassName}`.trim()}
+                      />
+                    ) : (
+                      <Icon size={18} />
+                    )}
+                    <span>{label}</span>
+                  </button>
+                ),
+              )}
+            </div>
+          )}
+          {oauthError && (
+            <p className="stwd-login__error" role="alert">
+              {oauthError}
+            </p>
+          )}
+        </>
       ) : (
         <div className="flex flex-col items-center gap-3 py-6">
           <Loader2 className="h-6 w-6 animate-spin text-[#FF5800]" />

--- a/packages/ui/src/cloud/public-pages/lib/steward-oauth-url.ts
+++ b/packages/ui/src/cloud/public-pages/lib/steward-oauth-url.ts
@@ -45,6 +45,10 @@ export function buildStewardOAuthRedirectUri(origin: string): string {
   return `${origin}/login`;
 }
 
+export function resolveStewardOAuthTenantId(tenantId?: string | null): string {
+  return tenantId?.trim() || DEFAULT_STEWARD_TENANT_ID;
+}
+
 export function buildStewardOAuthAuthorizeUrl(
   provider: StewardOAuthProvider,
   origin: string,
@@ -61,7 +65,7 @@ export function buildStewardOAuthAuthorizeUrl(
     buildStewardOAuthRedirectUri(origin),
     {
       stewardApiUrl,
-      stewardTenantId: options?.stewardTenantId ?? DEFAULT_STEWARD_TENANT_ID,
+      stewardTenantId: resolveStewardOAuthTenantId(options?.stewardTenantId),
       codeChallenge: options?.codeChallenge,
     },
   );


### PR DESCRIPTION
## Summary
- keep app-auth OAuth buttons out of the default `@stwd/react` redirect path, which was sending `redirect_uri=/auth/callback`
- reuse the Eliza Cloud login redirect helper so app-auth Google/Discord OAuth starts with the allowlisted `/login` redirect
- share the Steward tenant fallback so app-auth sends the same default tenant as the public login flow

## Root cause
`<StewardLogin>` delegates OAuth clicks to `signInWithOAuth(provider)` without a redirect override. The Steward SDK default is `${window.location.origin}/auth/callback`, but Eliza Cloud intentionally allowlists `/login` as the stable redirect URI. The normal `/login` page already used the helper path; `/app-auth/authorize` did not.

## Validation
- `bun run --cwd packages/ui test src/cloud-ui/components/auth/authorize-content.test.tsx src/cloud/public-pages/pages/app-auth/app-authorize-page.test.tsx src/cloud/shell/StewardProvider.test.tsx`
- `bun run --cwd packages/ui typecheck`
- `bunx @biomejs/biome check packages/ui/src/cloud-ui/components/auth/authorize-content.tsx packages/ui/src/cloud-ui/components/auth/authorize-content.test.tsx packages/ui/src/cloud/public-pages/lib/steward-oauth-url.ts`
- `git diff --check`
- Local Playwright smoke against `http://127.0.0.1:2149/app-auth/authorize?...` with stubbed app/provider endpoints: page rendered app-auth controls, Google click opened the Steward OAuth authorize URL with `redirect_uri=http://127.0.0.1:2149/login` and `tenant_id=elizacloud`; console errors: none. Screenshot: `/tmp/eliza-local-app-auth-oauth-before-click.png`