### PR TITLE
perf(build): populate the Turbo cache + drop typecheck-only examples/benchmarks from the build graph

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "dev:agent": "bun run --cwd packages/agent dev",
     "dev:core": "bun run --cwd packages/core dev",
     "start:debug": "NODE_NO_WARNINGS=1 LOG_LEVEL=debug bun run --cwd packages/agent start",
-    "build": "node packages/scripts/run-turbo.mjs run build --concurrency=8 --filter='!@elizaos/electrobun' --cache=local:rw,remote:r --output-logs=errors-only && bun run --cwd packages/app-core/platforms/electrobun build && bun run check:view-bundles",
+    "build": "node packages/scripts/run-turbo.mjs run build --concurrency=8 --filter='!@elizaos/electrobun' --filter='!./packages/examples/**' --filter='!./packages/benchmarks/**' --cache=local:rw,remote:r --output-logs=errors-only && bun run --cwd packages/app-core/platforms/electrobun build && bun run check:view-bundles",
     "build:typescript": "node packages/scripts/run-turbo.mjs run build",
     "build:client": "node packages/scripts/run-turbo.mjs run build --filter=@elizaos/app",
     "build:views": "node packages/scripts/build-views.mjs",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "dev:agent": "bun run --cwd packages/agent dev",
     "dev:core": "bun run --cwd packages/core dev",
     "start:debug": "NODE_NO_WARNINGS=1 LOG_LEVEL=debug bun run --cwd packages/agent start",
-    "build": "node packages/scripts/run-turbo.mjs run build --concurrency=8 --filter='!@elizaos/electrobun' --cache=local:r,remote:r --output-logs=errors-only && bun run --cwd packages/app-core/platforms/electrobun build && bun run check:view-bundles",
+    "build": "node packages/scripts/run-turbo.mjs run build --concurrency=8 --filter='!@elizaos/electrobun' --cache=local:rw,remote:r --output-logs=errors-only && bun run --cwd packages/app-core/platforms/electrobun build && bun run check:view-bundles",
     "build:typescript": "node packages/scripts/run-turbo.mjs run build",
     "build:client": "node packages/scripts/run-turbo.mjs run build --filter=@elizaos/app",
     "build:views": "node packages/scripts/build-views.mjs",


### PR DESCRIPTION
Part of the build/script track of **#10200** and the perf epic **#10724**. Two independent, verified build-time wins on the repo's most-run build command (`bun run build` — called by `quality.yml`, `nightly.yml`, `apple-store-release.yml`, `deploy-homepage.yml`, `jsdoc-automation.yml`, and every contributor).

## 1. Populate the Turbo cache (`--cache=local:r` → `local:rw`)

`local:r` = local cache **read-only**: the build read cache but never *wrote* it, so every 2nd-and-later `bun run build` re-ran cold and the 855 MB `.turbo` cache was only ever filled by side-channel commands. No other turbo call in the repo sets `--cache=` (default is `local:rw`); this flag was introduced incidentally in a bulk reorg (`5064b7b`). `remote` stays `r` → **no new writes** to the shared remote cache (status quo preserved).

**Measured** (isolated `--cache-dir`, `@elizaos/shared#build`):

| flag | run 1 | run 2 | cache dir |
|---|---|---|---|
| `local:r` (before)  | 0 cached | **0 cached** | **0 files — never writes** |
| `local:rw` (after)  | 0 cached | **1 cached (hit)** | **3 files — writes + hits** |

## 2. Drop typecheck-only examples + benchmarks from the build graph

`bun run build` pulled all 30+ example packages and 30+ benchmark suites into the turbo `build` graph. Most define `build` as `bun run typecheck` / `tsc --noEmit` — no artifact, no test lane, not in `build:core` — yet each ran a full type-check inside the prod build critical path.

**Verified via `turbo run build --dry`:**
- build graph **243 → 190 tasks** (53 removed, ~22%)
- non-excluded tasks depending on an excluded package: **0** — cannot break another package's build
- **No coverage lost**: examples/benchmarks are still type-checked by `bun run typecheck` / `verify` (turbo `typecheck` keeps all 53 + the dedicated `run-examples-benchmarks.mjs typecheck` pass)
- No CI workflow deploys an example artifact from the root build (all use `build` as a pass/fail gate)

## Risk

**Low.** (1) enables local cache writes only (remote unchanged; turbo keys are content hashes so no stale hits); (2) removes leaf packages with zero dependents from the build graph, with type coverage retained elsewhere. CI's own `build` + `typecheck` gates validate end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)