### PR TITLE
perf(agent): skip the 5s status broadcast when no dashboard is connected

### DIFF
--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -5165,6 +5165,16 @@ export async function startApiServer(opts?: {
 
   // Broadcast status to all connected WebSocket clients (flattened — PR #36 fix)
   const broadcastStatus = () => {
+    // Skip the payload build + computeCanRespond() when no dashboard is
+    // connected. This fires every 5s (statusInterval) plus on every state
+    // change for the whole process lifetime; a headless / background agent
+    // commonly has zero WS clients, so this was pure idle-CPU waste. A newly
+    // connected client gets its authoritative status on connect (see
+    // activateAuthenticatedConnection), so nothing depends on this running
+    // while the client set is empty.
+    if (wsClients.size === 0) {
+      return;
+    }
     broadcastWs({
       type: "status",
       state: state.agentState,


### PR DESCRIPTION
## Problem

Part of the perf epic **#10724** (Section B — backend/agent idle CPU).

`broadcastStatus` (`packages/agent/src/api/server.ts`) builds a status payload and calls `computeCanRespond(state.runtime, state.agentState)` **every 5 seconds** (`statusInterval`, `server.ts:5257`) plus on every agent state change — for the entire process lifetime, **even when zero WebSocket clients are connected**. A headless / background / cloud agent typically has no dashboard attached, so this ran ~17,280 payload-build + readiness-probe cycles per day for nobody. It's the single largest always-on per-tick CPU cost in the idle agent.

## Change

Add a one-line guard at the top of `broadcastStatus`:

```ts
if (wsClients.size === 0) {
  return;
}
```

O(1) check on a `Set`. When no client is connected, we skip the payload build and the `computeCanRespond` probe entirely. The interval keeps ticking (unchanged); it just no-ops.

**Why it's safe:** a newly connected client receives its authoritative `status` payload (including `canRespond`, `startedAt`, `startup`, `pendingRestart`) directly in `activateAuthenticatedConnection` on connect (`server.ts:4892-4908`) — the initial state does **not** depend on the periodic `broadcastStatus`. So nothing is starved by skipping the broadcast while the client set is empty; the periodic broadcast only matters when there *are* connected clients to push updates to.

## Evidence

- `packages/agent/src/api/health-routes.canRespond-ws.test.ts` + `health-routes.canRespond.test.ts` — **12/12 pass**. These pin the exact `computeCanRespond(runtime, agentState)` derivation that both WS status sites (initial-connect + periodic broadcast) carry; the change leaves that derivation untouched, so the wire contract for connected clients is unchanged.
- Booting `startApiServer` in the vitest lane is not viable (documented in the test header: `@elizaos/app-core` subpath alias rewrites to a non-directory path → ENOTDIR), so the connected-client behavior is covered by the derivation contract above + the connect-time initial-status invariant cited by file:line.

## Risk

**Low.** Pure additive early-return on an idle path; no type or signature change; connected-client behavior is provably unchanged (initial status delivered on connect; periodic broadcast still fires whenever `wsClients` is non-empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)