### PR TITLE
fix(ui): back off the vision screen-capture poller on a 404 route (#10724)

### DIFF
--- a/packages/ui/src/state/screen-capture-bridge.test.ts
+++ b/packages/ui/src/state/screen-capture-bridge.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Make isNativeMobile() true and the capture plugin present so the poller runs.
+vi.mock("@capacitor/core", () => ({
+  Capacitor: { getPlatform: () => "android" },
+}));
+vi.mock("../bridge/native-plugins", () => ({
+  getScreenCapturePlugin: () => ({}),
+}));
+
+import {
+  __resetScreenCaptureBridgeForTests,
+  computePollDelayMs,
+  initScreenCaptureBridge,
+} from "./screen-capture-bridge";
+
+describe("computePollDelayMs — vision-poll backoff curve", () => {
+  it("stays at the fast 1500ms interval below the failure threshold", () => {
+    for (const failures of [0, 1, 2, 3, 4]) {
+      expect(computePollDelayMs(failures)).toBe(1500);
+    }
+  });
+
+  it("backs off exponentially once the streak crosses the threshold", () => {
+    expect(computePollDelayMs(5)).toBe(3000); // 1500 * 2^1
+    expect(computePollDelayMs(6)).toBe(6000); // 1500 * 2^2
+    expect(computePollDelayMs(7)).toBe(12000);
+    expect(computePollDelayMs(8)).toBe(24000);
+  });
+
+  it("caps the backoff at 60s", () => {
+    expect(computePollDelayMs(100)).toBe(60000);
+    expect(computePollDelayMs(10_000)).toBe(60000);
+  });
+});
+
+describe("screen-capture bridge poller — a 404 route is not hammered forever", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockReset();
+    __resetScreenCaptureBridgeForTests();
+  });
+  afterEach(() => {
+    __resetScreenCaptureBridgeForTests();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("backs off under sustained 404s instead of polling every 1500ms", async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 404 });
+    initScreenCaptureBridge();
+
+    // Over a 120s horizon, a fixed 1500ms poller would fire ~80 times. With the
+    // backoff the streak stretches the interval toward the 60s cap, so it fires
+    // an order of magnitude less.
+    await vi.advanceTimersByTimeAsync(120_000);
+
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(0);
+    expect(fetchMock.mock.calls.length).toBeLessThan(20);
+  });
+
+  it("does not schedule further polls after reset (no leaked timer)", async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 404 });
+    initScreenCaptureBridge();
+    await vi.advanceTimersByTimeAsync(5000);
+    __resetScreenCaptureBridgeForTests();
+    const callsAtReset = fetchMock.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(fetchMock.mock.calls.length).toBe(callsAtReset);
+  });
+});

--- a/packages/ui/src/state/screen-capture-bridge.ts
+++ b/packages/ui/src/state/screen-capture-bridge.ts
@@ -16,6 +16,29 @@ import { getScreenCapturePlugin } from "../bridge/native-plugins";
 
 const POLL_INTERVAL_MS = 1500;
 
+/**
+ * Once this many polls fail in a row, stop hammering the route every 1500ms and
+ * back off exponentially. The common cause is a `404` — the vision plugin isn't
+ * loaded in this config (e.g. on-device inference with no vision), so
+ * `/api/vision/capture-requests` is unregistered and every 1500ms poll 404s
+ * forever, burning CPU/network/battery and spamming logs. A single success snaps
+ * the interval back to fast, so a vision backend that comes online later still
+ * recovers. (#10724)
+ */
+const BACKOFF_AFTER_FAILURES = 5;
+const MAX_BACKOFF_MS = 60_000;
+
+/**
+ * Poll delay (ms) for the current consecutive-failure streak: the fast interval
+ * until the streak crosses {@link BACKOFF_AFTER_FAILURES}, then exponential
+ * backoff capped at {@link MAX_BACKOFF_MS}. Pure — unit-tested without timers.
+ */
+export function computePollDelayMs(consecutiveFailures: number): number {
+  if (consecutiveFailures < BACKOFF_AFTER_FAILURES) return POLL_INTERVAL_MS;
+  const over = consecutiveFailures - BACKOFF_AFTER_FAILURES + 1;
+  return Math.min(MAX_BACKOFF_MS, POLL_INTERVAL_MS * 2 ** over);
+}
+
 interface CaptureRequest {
   requestId: string;
   createdAt: number;
@@ -27,7 +50,8 @@ interface CaptureRequest {
 }
 
 let started = false;
-let pollTimer: ReturnType<typeof setInterval> | null = null;
+let pollTimer: ReturnType<typeof setTimeout> | null = null;
+let consecutiveFailures = 0;
 
 /** Frugal screen-understanding defaults: half-res, q70 → tens of KB per frame. */
 function clampScale(scale: number): number {
@@ -104,12 +128,19 @@ async function poll(): Promise<void> {
   let requests: CaptureRequest[];
   try {
     const res = await fetch("/api/vision/capture-requests");
-    if (!res.ok) return;
+    if (!res.ok) {
+      // 404 = the vision route isn't registered in this config; other non-ok is
+      // transient. Either way, count toward backoff so we don't spin at 1500ms.
+      consecutiveFailures += 1;
+      return;
+    }
+    consecutiveFailures = 0;
     const data = (await res.json()) as { requests?: unknown };
     const list = Array.isArray(data.requests) ? data.requests : [];
     requests = list.filter(isCaptureRequest);
   } catch {
-    // Agent not reachable yet (early boot) — next tick retries.
+    // Agent not reachable yet (early boot) — count, next tick retries fast.
+    consecutiveFailures += 1;
     return;
   }
   for (const request of requests) {
@@ -121,20 +152,30 @@ async function poll(): Promise<void> {
  * Idempotent boot: start the capture-request poller on Android/iOS native.
  * No-op on web/desktop and on repeat calls.
  */
+function scheduleNextPoll(delayMs: number): void {
+  pollTimer = setTimeout(() => {
+    void poll().finally(() => {
+      // Re-arm from the current failure streak so a persistently-404 route backs
+      // off instead of polling forever; a success resets the streak to fast.
+      if (started) scheduleNextPoll(computePollDelayMs(consecutiveFailures));
+    });
+  }, delayMs);
+}
+
 export function initScreenCaptureBridge(): void {
   if (started) return;
   if (!isNativeMobile()) return;
   started = true;
-  pollTimer = setInterval(() => {
-    void poll();
-  }, POLL_INTERVAL_MS);
+  consecutiveFailures = 0;
+  scheduleNextPoll(POLL_INTERVAL_MS);
 }
 
 /** Test-only reset hook. */
 export function __resetScreenCaptureBridgeForTests(): void {
   if (pollTimer) {
-    clearInterval(pollTimer);
+    clearTimeout(pollTimer);
     pollTimer = null;
   }
   started = false;
+  consecutiveFailures = 0;
 }


### PR DESCRIPTION
## Found on-device (physical Pixel 6a) while profiling for #10724

Choosing **On-device inference** (no vision plugin) leaves the renderer's screen-capture bridge polling `GET /api/vision/capture-requests` **every 1500ms → `404 Not Found`, forever**:

```
GET http://127.0.0.1:31337/api/vision/capture-requests  →  404  (every ~1.5s, at idle, no agent, no vision)
```

The route is only registered by `plugin-vision` (`plugins/plugin-vision/src/routes.ts`), so on any config without vision it doesn't exist. The old poller did `if (!res.ok) return` — it skipped the body but the fixed `setInterval` kept firing, so it 404-spammed at 1.5s **indefinitely**, burning CPU / network / battery and flooding logcat. Exactly the idle-waste / never-stopping-timer class #10724 targets.

## Fix

- **`computePollDelayMs(consecutiveFailures)`** — pure, unit-tested: fast 1500ms until 5 consecutive failures, then exponential backoff `3s→6s→12s→…` capped at **60s**.
- Track the failure streak in `poll()` (increment on non-ok / throw, **reset to 0 on any success**) and re-arm from it. A vision backend that comes online later still recovers to the fast interval on its first success.
- Swapped the fixed `setInterval` for a self-rescheduling `setTimeout`; reset clears the timer and the streak.

Over a 120s idle-404 horizon this drops from ~80 polls to ~10.

## Test — `screen-capture-bridge.test.ts` (5/5 green)

- backoff curve: fast below threshold, exponential at/above, capped at 60s
- end-to-end: 120s under sustained 404 fires **<20** times (not ~80)
- no leaked timer after reset

On-device evidence (the 404 loop + the memory baseline that surfaced it) is in the companion evidence PR for #10724.

🤖 Generated with [Claude Code](https://claude.com/claude-code)