### PR TITLE
docs(ui): document chromeless-widget exception in design reference (#10708)

### DIFF
--- a/packages/ui/docs/minimal-redesign/00-design-reference.md
+++ b/packages/ui/docs/minimal-redesign/00-design-reference.md
@@ -148,6 +148,17 @@ generous `gap-8`/`gap-5`/`gap-3` whitespace.
 borders, `backdrop-blur-2xl`, faint inset top edge) → fixed white text graded by opacity → lucide or
 inline-SVG icons → no badges/tags/dividers → opacity/translate motion → render only when populated.
 
+> **Widgets are the CHROMELESS EXCEPTION to the glass-tile language (#10708).** The
+> rounded-2xl/3xl border + `bg-black/*` glass surface above is for material surfaces
+> (`HomeCard`, launcher tiles, modals, popovers), NOT for home/dashboard widgets. Home
+> widgets render DIRECTLY on the wallpaper: no tile fill, no border, no corner radius.
+> Their whole affordance is the icon + graded-white text + whitespace/rank separation;
+> hover/press is opacity + transform, never a background fill. The `no-widget-chrome-gate`
+> test enforces this: any widget container (marked `data-widget-container`) that
+> reintroduces a border, a background fill, or a `rounded-*` fails the build. When a new
+> home widget needs a container, stamp it with the marker and keep it chromeless; borders,
+> fills, and radii stay for the glass surfaces, not widgets.
+
 ---
 
 ## (B) Token / theme system — full token list + how to reference


### PR DESCRIPTION
Small follow-up to #10737 (which closed #10708).

## What
#10737 shipped the chromeless home widgets + the `no-widget-chrome-gate`, but didn't add the **design-reference note** that #10708 listed as a criterion:

> Note in `packages/ui/docs/minimal-redesign/00-design-reference.md` that widgets are the chromeless exception to the glass-tile language (borders/bg/radius are for glass surfaces, not widgets).

This adds exactly that note: widgets render directly on the wallpaper (no fill/border/radius), hover/press is opacity + transform, and the `no-widget-chrome-gate` enforces it via the `data-widget-container` marker. It keeps the doc consistent with the merged behavior + gate, so future contributors know widgets are the intentional exception to the documented glass-tile language.

## Scope
Docs-only, one file, no behavior change. Completes the last open criterion of #10708 on top of @lalalune's merged #10737.

Co-authored-by: wakesync <shadow@shad0w.xyz>