### PR TITLE
fix(ui): declare contracts dependency for wallet widget

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2615,6 +2615,7 @@
         "@capacitor/core": "8.4.0",
         "@elizaos/cloud-sdk": "workspace:*",
         "@elizaos/cloud-shared": "workspace:*",
+        "@elizaos/contracts": "workspace:*",
         "@elizaos/core": "workspace:*",
         "@elizaos/logger": "workspace:*",
         "@elizaos/shared": "workspace:*",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -323,6 +323,7 @@
     "@capacitor/core": "8.4.0",
     "@elizaos/cloud-sdk": "workspace:*",
     "@elizaos/cloud-shared": "workspace:*",
+    "@elizaos/contracts": "workspace:*",
     "@elizaos/core": "workspace:*",
     "@elizaos/logger": "workspace:*",
     "@elizaos/shared": "workspace:*",

--- a/packages/ui/src/components/chat/widgets/wallet-price-holdings.test.ts
+++ b/packages/ui/src/components/chat/widgets/wallet-price-holdings.test.ts
@@ -161,10 +161,9 @@ describe("selectPricedHoldings", () => {
 
   it("renders nothing when no qualifying priced holdings exist", () => {
     expect(
-      selectPricedHoldings(
-        balances([{ symbol: "SHIB", valueUsd: "0.10" }]),
-        [price("SHIB", 0.00001)],
-      ),
+      selectPricedHoldings(balances([{ symbol: "SHIB", valueUsd: "0.10" }]), [
+        price("SHIB", 0.00001),
+      ]),
     ).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Adds the missing `@elizaos/contracts` workspace dependency to `@elizaos/ui` so the newly merged wallet price holdings widget can import its response/snapshot types on a clean install.

## Root Cause

`packages/ui/src/components/chat/widgets/wallet-price-holdings.ts` imports `WalletBalancesResponse` and `WalletMarketPriceSnapshot` from `@elizaos/contracts`, but `packages/ui/package.json` did not declare that workspace package. Local installs with stale symlinks can hide this; clean CI installs fail `packages/ui` typecheck.

## Changes

- Declares `@elizaos/contracts: workspace:*` in `packages/ui/package.json`
- Updates `bun.lock`
- Applies Biome formatting to the wallet price holdings focused test

## Validation

- `bun install`
- `bun run --cwd packages/ui typecheck`
- `bun run --cwd packages/ui test src/components/chat/widgets/wallet-price-holdings.test.ts src/cloud-ui/components/auth/authorize-content.test.tsx src/cloud/public-pages/pages/app-auth/app-authorize-page.test.tsx src/cloud/shell/StewardProvider.test.tsx`
- `bunx @biomejs/biome check packages/ui/package.json packages/ui/src/components/chat/widgets/wallet-price-holdings.ts packages/ui/src/components/chat/widgets/wallet-price-holdings.test.ts packages/ui/src/cloud-ui/components/auth/authorize-content.tsx packages/ui/src/cloud-ui/components/auth/authorize-content.test.tsx packages/ui/src/cloud/public-pages/lib/steward-oauth-url.ts`
- `bun run --cwd packages/app build:web`
