### PR TITLE
docs(ui): correct no-widget-chrome-gate description (#10744 follow-up)

### DIFF
--- a/packages/ui/docs/minimal-redesign/00-design-reference.md
+++ b/packages/ui/docs/minimal-redesign/00-design-reference.md
@@ -154,10 +154,13 @@ inline-SVG icons → no badges/tags/dividers → opacity/translate motion → re
 > widgets render DIRECTLY on the wallpaper: no tile fill, no border, no corner radius.
 > Their whole affordance is the icon + graded-white text + whitespace/rank separation;
 > hover/press is opacity + transform, never a background fill. The `no-widget-chrome-gate`
-> test enforces this: any widget container (marked `data-widget-container`) that
-> reintroduces a border, a background fill, or a `rounded-*` fails the build. When a new
-> home widget needs a container, stamp it with the marker and keep it chromeless; borders,
-> fills, and radii stay for the glass surfaces, not widgets.
+> test enforces this by scanning the widget component files: any single container
+> className that reintroduces the full glass-card triad — a corner radius (`rounded-sm`…`3xl`)
+> AND an explicit colored border AND a translucent background fill together — fails the
+> build. Legitimate inner content is unaffected (icon tiles `rounded-lg bg-white/10`,
+> `rounded-full` status dots/pills, inner rows), since none combine all three. When a new
+> home widget needs a container, keep it chromeless; borders, fills, and radii stay for the
+> glass surfaces, not widgets.
 
 ---
 


### PR DESCRIPTION
Follow-up to #10744. That note (completing #10708) described the `no-widget-chrome-gate` inaccurately: it referenced a `data-widget-container` marker (which does not exist) and said reintroducing *any one* of border/background/radius fails the build.

The actual gate (`packages/ui/src/no-widget-chrome-gate.test.ts`) scans the widget component files and fails only when a **single container className carries the full glass-card triad together** — a corner radius (`rounded-sm`…`3xl`, not `rounded-full`) AND an explicit colored border AND a translucent background fill. Inner content (icon tiles, `rounded-full` pills/dots, rows) is fine because none combine all three.

Docs-only, one paragraph, matches the merged gate. Verified against the gate source on develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)