### PR TITLE
fix(ui/chat): pin queued turn's conversation at enqueue — send/voice/new-chat routing race (#10700)

### DIFF
--- a/.github/issue-evidence/10700-chat-send-voice-newchat-fuzz/SCENARIOS.md
+++ b/.github/issue-evidence/10700-chat-send-voice-newchat-fuzz/SCENARIOS.md
@@ -1,0 +1,478 @@
+# #10700 — Interleaved send-text / send-voice / new-chat lifecycle fuzz
+
+Deterministic + seeded scenario matrix for the two harnesses that guard the
+chat send/voice/new-chat race:
+
+1. **Component fuzz** (vitest + jsdom): drives the REAL send queue
+   (`useChatSend` via `renderHook(useChatSend, deps)`) plus a thin real-shape
+   `send()` wrapper, network mocked at the `ElizaClient` layer.
+2. **Playwright e2e** (`packages/app/test/ui-smoke/`): modeled on
+   `chat-clear-swipe.spec.ts`, desktop chromium + Pixel-7 mobile lanes, stateful
+   in-spec conversation store at the network layer.
+
+The user checklist (loud/quiet voice, multi-speaker, room noise, speakers
+entering/leaving, long-form transcription, button smashing, all button states,
+voice toggle storms, interleaved text+voice, transcribe-on/off while sending,
+swiping mid-voice, view switching mid-chat/mid-transcription, TTS echo
+rejection) maps onto the action alphabet + condition modifiers below. Every
+checklist item is tagged `[C#]` and cross-referenced in §6.
+
+---
+
+## 0. Root-cause recap (the code the matrix defends)
+
+Ground truth, read this session:
+
+- `packages/ui/src/state/useChatSend.ts`
+  - `sendChatText(rawInput, options)` (~1347) pushes a queued turn with
+    `conversationId: options?.conversationId` (~1366) — **undefined when the
+    caller omits it** — then `void flushQueuedChatSends()`.
+  - `runQueuedChatSend` (~787) resolves the target late at drain time:
+    `convId = turn.conversationId ?? activeConversationIdRef.current ?? ""`
+    (~824). If still empty it calls `client.createConversation(...)` (~828) and
+    pins the new id into `activeConversationIdRef.current` (~841).
+  - `flushQueuedChatSends` (~1266) is single-flight via `chatSendBusyRef`.
+  - `handleChatSend` (~1379) snapshots `conversationId:
+    activeConversationIdRef.current` **at enqueue** (~1407) — the typed composer
+    path is NOT exposed to the race.
+- `packages/ui/src/components/shell/useShellController.ts`
+  - `send(text, options)` (~600): sets `lastTurnVoice = (channelType ===
+    "VOICE_DM")`, calls `sendChatText(trimmed, options?)` — **the `options` it
+    forwards never contains a `conversationId`** (voice `onCommit` at ~704 and
+    suggestion sends pass only `channelType`/`metadata`). This is the
+    unprotected asymmetric surface.
+  - `clearConversation` (~327): `setLastTurnVoice(false)` then
+    `runWithConversationLoading(handleNewConversation)`, which activates a new
+    conversation (mutating `activeConversationId`).
+  - `runWithConversationLoading` (~290): seq-guarded, 12s watchdog
+    (`CONVERSATION_LOADING_MAX_MS`).
+  - Voice: `startCapture` (~656) bails if `captureRef` set;
+    `stopCaptureAndDrain` (~629) sets `explicitStopRef`, clears
+    `turnCarryoverRef`, resets aggregator; `toggleRecording` (~876);
+    `toggleTranscriptionMode` (~1049); `stopTranscriptionAndMic` (~1094).
+
+**THE RACE.** A `clearConversation()` (new-chat) issued between a
+shell-`send()` enqueue and its drain reroutes that turn to the NEW conversation,
+because `runQueuedChatSend` resolves `activeConversationIdRef.current` *late*.
+The typed path is safe (enqueue-time pin); the voice/suggestion path is not.
+
+**The fix trap (regression risk #ii).** The obvious fix — pin
+`conversationId = activeConversationIdRef.current` at enqueue inside the shell
+`send()` path too — must NOT break the legitimate cold-open case where
+`activeConversationIdRef.current` is `null`/`""` and a double-send should create
+**exactly one** conversation and land both turns in it. If the fix pins `""` at
+enqueue and the drain treats `""` as "no target, create a new one" per turn,
+a cold-open double-send creates TWO conversations. So the enqueue-time pin must
+only capture a *non-empty* id; an empty id must stay late-bound so both queued
+turns share the single conversation the first drain creates.
+
+---
+
+## 1. Action alphabet (the random walk)
+
+Each action is a pure closure over the harness controls. The component fuzz and
+the e2e share this alphabet; the e2e maps each to a real gesture (§5).
+
+| Action | Symbol | Component-level effect | Target-conversation semantics |
+|---|---|---|---|
+| **send-text** | `T` | `send(text, { conversationId: activeIdRef.current })` via the typed `handleChatSend` shape (enqueue-time pin) | pinned active id at enqueue |
+| **send-voice** | `V` | `send(turn, { channelType: "VOICE_DM", metadata })` via the shell voice `onCommit` shape (NO conversationId) | late-bound at drain |
+| **send-suggestion** | `S` | `send(text, { channelType: "DM", metadata })` (NO conversationId) — same asymmetric surface as voice, text payload | late-bound at drain |
+| **rec-on** | `R+` | `toggleRecording()` / `toggleHandsFree()` from idle → capture opens | n/a (mic state) |
+| **rec-off** | `R-` | `toggleRecording()` from listening → `stopCaptureAndDrain` (discards half-utterance) | n/a |
+| **transcribe-on** | `X+` | `toggleTranscriptionMode()` off→on (record-only; pauses reply loop) | n/a |
+| **transcribe-off** | `X-` | `toggleTranscriptionMode()` on→off (leaves mic on, resumes hands-free loop) | n/a |
+| **mic-master-off** | `M-` | `stopTranscriptionAndMic()` (mic parent off — kills transcript too) | n/a |
+| **new-chat** | `N` | `clearConversation()` → activates a fresh conversation; `setLastTurnVoice(false)` | mutates active id |
+| **swipe-conv** | `W±` | `conversationNav.goNext()` / `goPrev()` | mutates active id (adjacency) |
+| **switch-view** | `Y` | `setTab(nextView)` (chat ↔ another surface) then back | n/a (view only) |
+| **drain-tick** | `·` | advance fake timers / flush microtasks — lets an in-flight queue settle | resolves late-bound turns |
+
+**Zero-gap / rapid modifier.** Any two actions may fire inside a single `act()`
+with NO intervening `drain-tick` and NO rerender. The high-value pairs — the
+ones a rendered overlay cannot reproduce deterministically — are:
+`V·then·N` (send-voice then new-chat before drain),
+`S·then·N`, `T·then·N`, `N·then·V`, `R+·then·V-commit`, `X+·then·W`,
+`N·then·N` (double new-chat), `V·then·V` at cold open (double send, no active id).
+
+**Condition modifiers** (applied to `V` and `R+` to satisfy the acoustic
+checklist — realized as `onTranscript` payload shapes fed to the fake capture,
+per the existing `fireFinalTranscript` helper in
+`useShellController.test.tsx`):
+
+| Modifier | Checklist | Realization at the capture boundary |
+|---|---|---|
+| `loud→quiet` | [C1] | two finals with descending `amplitude`/`gain` fields on the transcript payload; assert single committed turn, no split |
+| `multi-speaker` | [C2] | finals carry distinct `speakerLabel`/diarization; overlapping timestamps |
+| `room-noise` | [C3] | interleave a disfluency/echo final (`"um uh"`) with a real request final |
+| `speaker-enter-exit` | [C4] | a transient `speakerLabel` appears for one final then never returns; assert it doesn't corrupt the aggregator turn |
+| `long-form` | [C5] | `X+` session with N accumulated finals, then `X-`; assert ONE session, all segments |
+| `tts-echo` | [C14] | a final whose text equals the latest assistant reply (seed `conversationMessages`); assert `shouldRespondToVoiceTurn` suppresses → no send |
+
+These modifiers ride on top of the alphabet; they change *what* a `V`/`R+`
+produces, not the walk structure.
+
+---
+
+## 2. Invariant set (assert after EVERY step)
+
+Let `delivered[c]` = the ordered list of `(convId, text)` the mocked client
+actually received (component: `client.sendConversationMessageStream` calls,
+keyed by its `convId` arg; e2e: the stateful store's appended user messages per
+room). Let `intended` = the ordered list of `(action, text, expectedTarget)`
+the walk issued, where `expectedTarget` is computed by the **reference model**
+(§2.1). After each step, and again after a terminal `drain-tick`:
+
+**(a) No message lost.** Every non-empty `T`/`S` and every committed `V`
+(one that passed `shouldRespondToVoiceTurn` + the EOT aggregator) appears
+**exactly once** in `delivered`, in its `expectedTarget` conversation.
+Suppressed voice turns (echo/disfluency/held-mid-clause) appear **zero** times.
+
+**(b) No duplicates.** `delivered` has no `(convId, text, nonce)` appearing
+twice. Each queued turn resolves-or-rejects exactly once (the queue's
+`resolve()`/`reject()` fire once per turn — assert via a per-turn settle
+counter).
+
+**(c) Ordering within a conversation.** For any conversation `c`, the
+subsequence of `delivered[c]` matches the subsequence of `intended` items whose
+`expectedTarget === c`, in issue order. (The single-flight `chatSendBusyRef`
+drain guarantees FIFO; a regression that parallelizes drains would reorder.)
+
+**(d) new-chat clean reset.** After `N` (and its `drain-tick`):
+- the prior conversation's `delivered[prev]` is **unmutated** (no turn leaks
+  backward or forward across the boundary);
+- the new conversation is empty of user turns except those the walk issued
+  *after* `N` resolved (greeting-only is allowed);
+- `lastTurnVoice === false` immediately after `clearConversation` (assert on the
+  controller — the fresh greeting must not be spoken);
+- exactly ONE `createConversation` fired for that `N` (no orphan/double create).
+
+**(e) No stuck latches after the walk.** At end of walk + a full drain:
+- `recording === false` unless the last mic action left it intentionally on;
+  a `V`/`R+`/`R-` sequence that ends in `R-`/`M-` must land `recording=false`,
+  `handsFree=false`, `transcriptionMode=false`;
+- `captureRef.current === null` after any `R-`/`M-`/close (no orphaned capture
+  handle — assert the fake capture's `stop()` was called and `dispose()` ran);
+- `chatSendBusyRef.current === false` and `chatSendQueueRef.current.length === 0`
+  (queue fully drained, single-flight released);
+- `conversationLoading === false` (the seq-guarded flag cleared; watchdog not
+  left armed — assert with fake timers that no pending `setConversationLoading`
+  remains);
+- `serverTurnStatus`/`chatSending` settled to idle.
+
+**(f) Active-id integrity** (inherited from the #9954 nav block): the active
+conversation is always a member of the list; `nav.index` tracks it;
+`hasPrev`/`hasNext` are exact index boundaries; no swipe resolved against a
+stale index.
+
+### 2.1 Reference model (`expectedTarget`)
+
+A pure, deterministic oracle the harness runs in lockstep with the real hook.
+It owns a shadow of `(activeId, conversations[], pendingQueue[])` and applies:
+
+```
+on T(text):        pin = activeId (may be "" / null); enqueue(text, pin)
+on V(text)/S(text): enqueue(text, LATE)              // late marker
+on N:              // clearConversation
+                   newId = freshId(); conversations.unshift(newId); activeId = newId
+on W±:             activeId = adjacent(activeId, dir)   // guarded, no-op at edge
+on drain-tick / whenever the queue can advance (single-flight, FIFO):
+   for each queued turn in order:
+     target = turn.pin (if non-empty) ?? activeId (if non-empty) ?? createOne()
+     // createOne() creates exactly one conversation, pins activeId to it,
+     // and SUBSEQUENT late/empty turns in the same drain reuse that activeId
+     record delivered(target, text)
+```
+
+`expectedTarget` is whatever this model records. Both harnesses assert the real
+`delivered` equals the model's `delivered` after every step. The model encodes
+the correct fix semantics (empty pin stays late; non-empty pin is honored;
+cold-open batch shares one created conversation) so it doubles as the spec for
+regression #ii.
+
+---
+
+## 3. Named deterministic regression cases
+
+These are hand-authored, non-random `it(...)` cases pinning the exact race
+windows. They run FIRST (before the seeded walks) so a reintroduced bug fails
+with a legible name, not a seed number.
+
+### (i) `new-chat while a shell-send() turn is queued must NOT deliver to the new conversation`
+Setup: `activeConversationIdRef.current = "conv-A"`, conversations `[A]`.
+Freeze the drain by making `sendConversationMessageStream` return a pending
+promise (deferred) so `chatSendBusyRef` stays busy through step 2.
+1. `V("hello A")` — shell voice send, no conversationId. It enqueues; the drain
+   picks it up and is now awaiting the deferred stream against `convId = "A"`
+   (late-bound at drain START, already resolved to A).
+   *Sub-variant (i-b):* enqueue `V` but DO NOT let the drain start (hold
+   `flushQueuedChatSends` before the first `shift`, e.g. keep an earlier turn
+   in-flight) so `convId` is resolved AFTER the `N`.
+2. `N()` — `clearConversation`; new conversation `fresh-1` becomes active
+   (`activeConversationIdRef.current = "fresh-1"`).
+3. Resolve the deferred stream; `drain-tick`.
+Assert: `delivered["conv-A"] === ["hello A"]`, `delivered["fresh-1"]` contains
+NO `"hello A"`. In sub-variant (i-b) — the true regression — the turn was
+resolved after `N`, so a reverted fix (late-bind with no enqueue pin) delivers
+to `fresh-1` and FAILS; the fixed hook (enqueue-time capture of the non-empty
+`"conv-A"`) delivers to `conv-A`.
+
+### (ii) `cold-open double shell-send must create exactly ONE conversation`
+Setup: `activeConversationIdRef.current = null`, conversations `[]`. Make
+`createConversation` resolve to `fresh-1` and record call count. Make
+`sendConversationMessageStream` resolve normally.
+1. In a SINGLE `act()`, with no drain between: `V("first")` then `V("second")`
+   (both empty-pinned, late-bound).
+2. `drain-tick`.
+Assert: `createConversation` called **exactly once**;
+`delivered["fresh-1"] === ["first", "second"]` in order; no second conversation.
+This is the guardrail against an over-eager enqueue-pin fix that would pin `""`
+per turn and create two conversations. Also run the mixed variant `T("a")` then
+`V("b")` at cold open → still one conversation, both turns (the typed path pins
+`null`→ stays late; identical outcome).
+
+### (iii) `toggle-recording while a converse turn commits must not orphan captureRef`
+Setup: hands-free engaged (`R+`), fake capture #1 open.
+1. Fire a final that commits a turn (`V` via `onCommit` → `send(...VOICE_DM)`).
+2. In the SAME `act()`, before the re-listen loop re-arms, `R-`
+   (`toggleRecording` → `stopCaptureAndDrain`).
+Assert: `captureHandles[0].stop` called, `dispose` ran, `captureRef.current ===
+null`, `recording === false`, `explicitStopRef` caused the half-utterance
+carryover to be discarded (no phantom second `send`). The committed turn is
+delivered exactly once; no capture #2 is opened after `R-`.
+*Variant (iii-b):* `R-` fires DURING the commit's microtask (interleave with a
+`drain-tick` of length 0) — assert the same, no double-stop, no orphan.
+
+### (iv) `new-chat while runWithConversationLoading pending stays seq-consistent`
+Setup: make `handleNewConversation` return a controllable deferred (as in the
+existing watchdog test).
+1. `N()` — `clearConversation`; `conversationLoading === true`, seq = 1.
+2. Before it resolves, `N()` again — seq = 2, `conversationLoading` still true.
+3. Resolve the FIRST create (seq 1); assert it does NOT clear the flag
+   (seq guard: `conversationLoadingSeqRef.current === 2`), spinner stays.
+4. Resolve the SECOND create (seq 2); `conversationLoading === false`.
+5. `drain-tick` past `CONVERSATION_LOADING_MAX_MS`; assert no late watchdog
+   re-sticks the flag and no stray `setConversationLoading(true)` fires.
+Assert additionally: exactly the final `N`'s conversation is active; the first
+create's conversation is not left active/orphaned in a way that violates (f);
+`lastTurnVoice === false` throughout.
+*Variant (iv-b):* interleave a `V(...)` between the two `N`s and assert the
+voice turn lands in whichever conversation the reference model says (the one
+active at its drain), never split.
+
+---
+
+## 4. Component fuzz — level recommendation & exact wiring
+
+### Recommendation: drive the REAL `useChatSend` via `renderHook(useChatSend, deps)` (its injected-deps seam), NOT the full AppContext-mounted `useShellController`.
+
+**Why.** The #10700 race lives entirely in the enqueue-vs-drain timing of
+`useChatSend` — the late `activeConversationIdRef.current` read in
+`runQueuedChatSend` (~824) versus the enqueue-time pin in `handleChatSend`
+(~1407). `useChatSend` already accepts a `UseChatSendDeps` object with the exact
+refs the race turns on (`activeConversationIdRef`, `conversationsRef`,
+`chatSendBusyRef`, `chatSendQueueRef` internal, `setActiveConversationId`) and a
+mockable `client` — this is the seam that lets us drive the interleaving
+deterministically (freeze a drain on a deferred stream, mutate
+`activeConversationIdRef.current` to model `clearConversation`, resolve, and
+assert the target). Mounting the full `useShellController` through a real
+`AppContext` provider would (1) drag in the entire chat/voice/nav graph and its
+transitive barrel imports (the existing shell test mocks `../../state`,
+`../../state/app-store`, `useHomeModelStatus`, `useShellVoiceOutput`, and the
+voice-capture factory precisely to avoid that), (2) make the race
+non-deterministic — the overlay rerenders after every op so the closure is
+always fresh and the two-op-single-closure window (the actual bug) never fires,
+which is *exactly* the limitation the #9954 nav block calls out and works around
+with its "rapid burst, no rerender between" cases, and (3) couple the fuzz to
+unrelated UI churn. The narrow hook is more faithful to the race AND less
+fragile.
+
+**But keep the shell `send()` shape honest.** The race is asymmetric because the
+shell `send()` forwards options WITHOUT a `conversationId`. So the component
+fuzz wraps `useChatSend` in a tiny in-test `send()` that mirrors
+`useShellController.send` exactly:
+```ts
+// mirrors packages/ui/src/components/shell/useShellController.ts send() (~600)
+const sendVoice = (text: string, meta = {}) =>
+  result.current.sendChatText(text, { channelType: "VOICE_DM", metadata: meta });   // NO conversationId
+const sendSuggestion = (text: string) =>
+  result.current.sendChatText(text, { channelType: "DM" });                          // NO conversationId
+const sendTyped = (text: string) =>
+  result.current.sendChatText(text, { conversationId: deps.activeConversationIdRef.current }); // enqueue-time pin (handleChatSend shape)
+const newChat = () => {                       // mirrors clearConversation's id mutation
+  const id = freshId();
+  deps.setConversations((p) => [conversation(id, `room-${id}`), ...p]);
+  deps.setActiveConversationId(id);
+  deps.activeConversationIdRef.current = id;  // the exact late-read source of the race
+};
+```
+`new-chat`'s voice-flag reset (`setLastTurnVoice(false)`) and the recording
+latches (invariant e) are covered by the SEPARATE existing
+`useShellController.test.tsx` voice suite; this fuzz owns the queue-routing
+invariants (a–d, f). Do not duplicate the voice state machine here — assert the
+routing, and let the shell test own the mic/transcription lifecycle. (A thin
+bridge test in `useShellController.test.tsx` still asserts that the real `send()`
+forwards NO `conversationId` for `VOICE_DM`, so the two harnesses agree on the
+asymmetric surface — see the existing `channelType: "VOICE_DM"` assertions at
+lines ~729/821/958.)
+
+### Exact `deps` + client mock (extends the existing `makeDeps` in `useChatSend.test.tsx`)
+
+Reuse the file's `makeDeps(overrides)` verbatim (it already builds live
+`conversationsRef` + `activeConversationIdRef` + real `setConversations` /
+`setActiveConversationId` that mutate the refs). Mock on `mocks.client`:
+
+- `createConversation` → returns `{ conversation: conversation(freshId(),
+  roomId) }`; **increment a call counter** (invariant ii). Default: resolve
+  synchronously; a variant returns a deferred to model a slow cold-open create.
+- `sendConversationMessageStream(convId, text, onToken, channelType, signal,
+  images, metadata, onStatus)` → the ONLY delivery sink. Push
+  `{ convId, text, channelType, nonce }` into a `delivered` array, optionally
+  call `onToken("ok", "ok")` then resolve `{ text: "ok", agentName: "a",
+  completed: true }`. A "freeze" variant returns a deferred keyed by a barrier so
+  the harness can hold a drain open across an `N` (regression i/i-b).
+- `sendWsMessage`, `abortConversationTurn` → `vi.fn()` (as today).
+- Keep `elizaCloudEnabled/Connected: false` so the handoff-freeze path stays
+  inert (no `CLOUD_HANDOFF_PHASE_EVENT`), isolating the new-chat race.
+
+Fake timers (`vi.useFakeTimers`) drive `drain-tick`
+(`await vi.advanceTimersByTimeAsync(0)` for microtask flush; larger advances for
+the throttled streaming commit + the `runWithConversationLoading` watchdog when
+the shell reset semantics are in scope). Seeded RNG via the existing
+`mulberry32` (copy from `useShellController.test.tsx`) for the walks; 12 seeds ×
+40 steps like the nav block, plus a dedicated ≥25-step "rapid burst, no
+drain-tick between two ops" block that fires the `V·N` / `S·N` / `V·V`-cold-open
+pairs — the only shape that exercises the late-bind window.
+
+**File:** `packages/ui/src/state/__tests__/chat-send-newchat-fuzz.test.tsx`
+(new; co-located with the state hook, jsdom, imports the real `useChatSend` and
+the file's own `makeDeps` pattern).
+
+---
+
+## 5. E2E action script → real Playwright gestures
+
+Modeled on `chat-clear-swipe.spec.ts`: stateful in-spec `makeStore()` +
+`installConversationStore(page, store)` mocking `/api/conversations`,
+`/api/conversations/*/messages`, DELETE/PATCH, greeting, cleanup-empty — extended
+to also record **user** sends per room so the e2e can assert invariants (a)–(d)
+against the store, not just greetings.
+
+**Store extension.** Add a `POST /api/conversations/*/messages` (or the actual
+send endpoint — mirror `sendConversationMessageStream`'s transport; capture the
+SSE/stream POST) handler that appends `{ role:"user", text }` to
+`store.messages[id]` keyed by the URL's conversation id, and records
+`store.sent.push({ id, text })`. The active conversation for a send is whatever
+the client targets in the request path/body — so the store observes the SAME
+`convId` the race would misroute, giving a real end-to-end assertion of target
+routing (not a client-side proxy).
+
+**Lanes.** Desktop chromium + `mobile-chromium` (Pixel 7), exactly as the model
+spec's projects. Voice-real-audio lanes (`chromium-voice-mic`,
+`--use-file-for-fake-audio-capture`) run the acoustic-modifier subset (§6 C1–C5,
+C14) using the `known-phrase` WAV fixture; the deterministic routing walk runs
+on the standard lanes with the STT boundary shimmed (as in `tts-stt-e2e.spec.ts`
+— shimmed `webkitSpeechRecognition` feeding scripted finals) so the walk is
+byte-stable.
+
+| Action | Real gesture / keystroke |
+|---|---|
+| open sheet | `pointerDrag('[data-testid="chat-sheet-grabber"]', 0, -220, 8)` → expect overlay `data-open="true"` (then `-400` to FULL for the header clear control) |
+| **send-text** `T` | `page.getByTestId("chat-composer-textarea").fill(text)` → `page.keyboard.press("Enter")` (Enter submits; Shift+Enter is newline per composer keydown ~3721) |
+| **send-voice** `V` | voice-mic lane: play the fixture WAV via `--use-file-for-fake-audio-capture` after `chat-composer-mic` is active; shimmed lane: `page.evaluate` dispatch a scripted final transcript into the STT shim → the converse `onCommit` fires `send(...VOICE_DM)` |
+| **send-suggestion** `S` | `page.getByTestId("chat-suggestion-0").click()` (the suggestion chip → `send(text, {channelType})`, no conversationId — the same asymmetric surface) |
+| **rec-on** `R+` | `page.getByTestId("chat-composer-mic").click()` (idle→listening/handsfree); assert `active` state on the mic SoftButton |
+| **rec-off** `R-` | `page.getByTestId("chat-composer-mic").click()` while listening (→ stop); or `chat-composer-stop` if a reply is streaming |
+| **transcribe-on** `X+` | `page.getByTestId("chat-composer-transcribe").click()` (voice-mode only; #10699 additive button); assert `chat-transcribing-badge` visible |
+| **transcribe-off** `X-` | `page.getByTestId("chat-composer-transcribe").click()` again → mic stays on (badge clears, mic still `active`) |
+| **mic-master-off** `M-` | `page.getByTestId("chat-composer-mic").click()` while transcribing (mic parent → both off); badge + active clear |
+| **new-chat** `N` | expand to FULL, `page.getByTestId("chat-full-clear").click()`; assert fresh greeting text, NO `conversation-undo-toast`, exactly one create in `store.created` |
+| **swipe-conv** `W-` (older) | `pointerDrag("#continuous-thread", -160, 0, 12)` (desktop) / `touchDrag(...)` (Pixel-7, real CDP touch); assert thread text flips to the next conversation |
+| **swipe-conv** `W+` (newer) | `pointerDrag("#continuous-thread", 160, 0, 12)` / `touchDrag` |
+| **switch-view** `Y` | swipe the collapsed grabber horizontally to the launcher rail (`pointerDrag('[data-testid="chat-sheet-grabber"]', -180, -6, 12)` → `home-launcher-surface` `data-page="launcher"`), open a view, return to `/chat` — assert the pending queue drained to the right conversation across the view switch |
+| **drain-tick** `·` | `page.waitForResponse` on the send endpoint / `expect.poll(() => store.sent.length)` — settle before the next assertion |
+
+**Named e2e specs** (each ends with `expectNoPageDiagnostics`):
+
+1. `voice-send-then-newchat-routes-to-prior.spec.ts` — [regression i] open sheet,
+   `V("route me")`, immediately `N`, assert `store.sent` has `"route me"` under
+   the PRIOR room and the fresh room has only its greeting.
+2. `cold-open-double-send-one-conversation.spec.ts` — [regression ii] from a
+   cleared/empty state, `V("first")` + `V("second")` back-to-back, assert
+   `store.created.length === 1` and both under that one room, in order.
+3. `interleaved-text-voice-transcribe-walk.spec.ts` — the seeded walk on desktop
+   + Pixel-7: a scripted 20-step sequence
+   `T,V,X+,T,X-,V,W-,S,N,V,Y,T,W+,R+,V,R-,N,S,V,·` with an invariant assertion
+   after each mutation (store routing + no-duplicate + ordering + no undo toast +
+   no stuck badge/mic).
+4. `transcription-mid-session-swipe-and-view.spec.ts` — [C5,C11,C12,C13]
+   `X+`, feed long-form finals, `W-` swipe mid-transcription, `Y` switch view and
+   back, `X-`; assert ONE transcript session finalized with all segments, no
+   send leaked, mic/badge state consistent.
+5. `button-smash.spec.ts` — [C6,C7,C8,C9] a tight loop of rapid clicks across
+   `chat-composer-mic` / `chat-composer-transcribe` / `chat-composer-action` /
+   `chat-composer-stop` (all reachable states) with random 0–30ms gaps; assert at
+   the end: no stuck `recording`/badge, queue drained, exactly the intended sends
+   delivered, no `conversation-undo-toast`, `expectNoPageDiagnostics`.
+6. Voice-mic real-audio lane variant of (1)+(3) subset — [C1–C4,C14] the
+   acoustic modifiers via the WAV fixture + a seeded-echo assistant message to
+   drive TTS-echo rejection (assert the echoed final produces NO send).
+
+**Files:** `packages/app/test/ui-smoke/chat-send-voice-newchat-*.spec.ts`,
+reusing `helpers.ts` (`seedAppStorage`, `installDefaultAppRoutes`,
+`installPageDiagnosticsGuard`, `expectNoPageDiagnostics`, `openAppPath`,
+`pointerDrag`/`touchDrag` copied from `chat-clear-swipe.spec.ts`).
+
+---
+
+## 6. Checklist coverage matrix
+
+| # | Condition | Component fuzz | E2E |
+|---|---|---|---|
+| C1 | Voice loud→quiet | `loud→quiet` modifier on `V` (amplitude fields); assert one committed turn | voice-mic real-audio lane (spec 6) |
+| C2 | Multiple/overlapping speakers | `multi-speaker` modifier; assert aggregator/diarization doesn't split or drop | spec 6 |
+| C3 | Background room conversation | `room-noise` modifier (disfluency interleave, `shouldRespond` gate) | spec 6 |
+| C4 | Speakers enter/leave | `speaker-enter-exit` modifier; transient label doesn't corrupt turn | spec 6 |
+| C5 | Long-form transcription | `X+ …finals… X-` → ONE session, all segments (invariant a for transcription) | spec 4 |
+| C6 | Button smashing | rapid-modifier pairs across all actions, no drain-tick between | spec 5 |
+| C7 | All button states | alphabet covers mic idle/listening/handsfree/transcribing, send, stop, transcribe on/off, disabled | specs 3,5 (assert each SoftButton `active`/`disabled`/badge) |
+| C8 | Voice on/off toggle storms | `R+ R- R+ R-…` and `X+ X- …` bursts; invariant (e) latches clear | spec 5 |
+| C9 | Text while doing voice | interleave `T`/`S` with `R+`/`V` in the walk; routing invariants (a–d) | spec 3 |
+| C10 | Transcribe on/off while sending | `X+ T X- T` sequences; assert sends route + session integrity | spec 3,4 |
+| C11 | Swipe mid-voice/mid-transcription | `V`/`X+` then `W±`; invariant (f) + no lost turn | spec 3,4 |
+| C12 | Iterate back-and-forth | seeded 40-step walks (component) / 20-step (e2e) | specs (all) |
+| C13 | Open/switch views mid-chat/mid-transcription | `Y` in the walk; assert queue drains to right conv across switch | spec 3,4 |
+| C14 | TTS echo rejection | `tts-echo` modifier (final == latest assistant reply) → NO send | spec 6 |
+
+---
+
+## 7. Determinism controls
+
+- Component: `vi.useFakeTimers()` (already the pattern in both existing test
+  files); seeded `mulberry32`; `TZ=UTC` from the UI test setup; no
+  `Date.now()`-derived assertions (the `audit:ui-determinism` gate forbids new
+  render-time nondeterminism). Every seed is logged so a failing walk is
+  reproducible by seed.
+- E2E: stateful in-spec store (no live backend); STT shim for scripted finals on
+  the standard lanes; `--use-file-for-fake-audio-capture` + `known-phrase` WAV on
+  the voice-mic lane; `SMOKE_GENERATED_AT` frozen timestamps; `E2E_RECORD=1` for
+  the video walkthrough evidence.
+- Both: the reference model (§2.1) is the single oracle both harnesses assert
+  against, so a divergence between "what the queue did" and "what should have
+  happened" fails loudly with the exact `(action, expectedTarget, actual)` diff.
+
+---
+
+## 8. Evidence to attach (PR_EVIDENCE.md)
+
+- Component fuzz: seed list + pass output; a deliberately-reverted-fix run
+  showing regressions (i) and (ii) FAIL (proof the tests have teeth).
+- E2E: before/after full-page screenshots desktop + Pixel-7, a video walkthrough
+  of the interleaved walk (spec 3), console + network logs showing the send
+  endpoint hitting the CORRECT conversation id after a new-chat, and the store's
+  `sent`/`created`/`deleted` arrays dumped per test.
+- Voice-mic lane: the real WAV-driven trajectory + the TTS-echo-suppressed case.
+- N/A: live-LLM trajectory — this matrix mocks the model at the client layer by
+  design (it tests client-side send routing, not model behavior); mark N/A with
+  this reason, and cross-link the separate live voice-turn scenario if the reply
+  gate (`core.voice_turn_signal`) is touched.

--- a/.github/issue-evidence/10726-voice-delarp/CRITICAL_ASSESSMENT.md
+++ b/.github/issue-evidence/10726-voice-delarp/CRITICAL_ASSESSMENT.md
@@ -1,0 +1,302 @@
+# Voice stack LARP audit — #10726 critical assessment
+
+Skeptical staff-engineer review of the elizaOS voice test + source surface.
+Every classification below is grounded in the actual file I read this session
+(paths + line evidence inline). I read: all 11 `voice-workbench-*.spec.ts`,
+`voice-workbench-cases.ts`, `voice-realaudio.spec.ts`, `transcript-realaudio.spec.ts`,
+`voice-selftest-e2e.spec.ts`, `voice-desktop-selftest.spec.ts`, `tts-stt-e2e.spec.ts`;
+the source: `voice-selftest/voice-workbench-player.ts`, `voice-selftest-harness.ts`,
+`VoiceWorkbenchShell.tsx`, `local-asr-transcribe.ts`, `local-asr-capture.ts`,
+`voice-provider-defaults.ts`, `@elizaos/shared/voice-wer.ts`; the real-service tier:
+`scripts/voice-workbench.ts`, `workbench-real-services.ts`, `workbench-logic-services.ts`,
+`acoustic-speaker-attribution.test.ts` + `__test-helpers__/synthetic-speech.ts`,
+`voice-speaker-diarizer.test.ts`, `voice-speaker-encoder.test.ts`; the CI wiring:
+`playwright.ui-smoke.config.ts`, `voice-workbench.yml`, `voice-live-e2e.yml`; and the
+matrix doc `VOICE_LIVE_MATRIX.md`.
+
+---
+
+## A. Critical Assessment — what is wrong, why, and the risk
+
+### The central finding: the voice stack is NOT uniformly larp — it is a three-tier pyramid, and the browser e2e tier (the one that "looks" like the real integration test) is the larp-heavy tier.
+
+There are **three distinct test tiers** for the same voice pipeline, and they are
+easy to conflate because they share names and vocabulary ("workbench", "self-test",
+"scenario"):
+
+1. **Browser e2e tier** (`packages/app/test/ui-smoke/*.spec.ts`, Playwright).
+   Drives the **real client pipeline** (real `runVoiceSelfTest` / `runVoiceWorkbench`
+   production functions, real WAV capture in the mic lane) but **mocks every model
+   backend**: `/api/asr/local-inference`, `/api/conversations/.../messages/stream`,
+   and `/api/tts/*` are all Playwright `page.route` fulfillments returning canned
+   payloads. This is where the larp is.
+
+2. **Headless real-decision tier** (`plugins/plugin-local-inference/src/services/voice/`,
+   Vitest, CI-gated on PRs via `voice-workbench.yml`). `voice:workbench --logic`
+   runs the **actual shipped decision modules** (`scoreEndOfTurnHeuristic`,
+   `buildVoiceTurnSignal`, `OnlineSpeakerClusterer` blind clustering, `selfVoiceSimilarity`)
+   against synthesized speech, with a committed regression **baseline** that fails CI
+   on drift. `acoustic-speaker-attribution.test.ts` proves the DER gate is
+   non-tautological (label comes from audio, gate trips on genuine misattribution).
+   This tier is genuinely REAL for decision logic — no larp.
+
+3. **Provisioned acoustic tier** (`*.real.test.ts`, `voice:workbench --real`,
+   `voice-live-e2e.yml`, `voice:matrix`). Real fused `libelizainference` ASR + Kokoro
+   TTS + WeSpeaker + pyannote. Nightly / self-hosted-GPU / hardware-gated. Correctly
+   `skipped` (never false-`pass`) when the model bundle/ABI is absent. Cannot run in a
+   keyless coding session; the honesty contract here is sound.
+
+**The risk**: a reader who only looks at `packages/app/test/ui-smoke/` — the tests
+named "voice-realaudio", "voice-selftest", "voice-workbench-diarization",
+"voice-workbench-entity-extraction" — will believe the voice models are being tested.
+They are not. Every one of those specs asserts against a **canned ASR transcript** and
+a **canned agent reply** that the spec itself wrote into a `page.route` handler. The
+"WER ≤ 0.34" assertion in the self-test is scored against a transcript the mock
+returned verbatim, so WER is structurally 0.0 — it can never catch an ASR quality
+regression. The word "REAL-AUDIO" in the file headers is accurate only for the
+*audio-in + WAV-encode + POST* half; the ASR/agent/TTS half is mocked, and the file
+headers do say so — but the test *names* and the DOM `data-overall="pass"` verdicts
+overstate what is proven.
+
+### Specific structural larp patterns found
+
+1. **Canned-transcript WER (self-test + workbench e2e).** In
+   `voice-selftest-e2e.spec.ts` the ASR mock returns the exact `EXPECTED_PHRASE`
+   (`"what time is it"`), then `runVoiceSelfTest` scores `wordErrorRate(expectedPhrase, transcript)`
+   → always 0.0. The WER gate is real code (`@elizaos/shared/voice-wer.ts` is a real
+   Levenshtein) but the *input* is the ground truth, so the assertion is a tautology in
+   the browser lane. Same in `voice-workbench-cases.ts` (`asrCursor` walks the turns and
+   returns `turn.asrText ?? turn.text`).
+
+2. **Diarization is structurally impossible to pass in the browser lane, and the spec
+   asserts exactly that.** `VoiceWorkbenchShell.tsx` (line 105-130) calls
+   `runVoiceWorkbench` **without** `resolvePredictedSpeakerLabel`. Per
+   `voice-workbench-player.ts` `scoreWorkbenchDiarization`, no predicted label ⇒
+   `unattributed` ⇒ `evaluated=false` ⇒ `status="skipped"`. `voice-workbench-cases.ts`
+   then *asserts* `diarization.status === "skipped"` and `predictedSpeakerLabel === null`
+   for every scenario. So the two "diarization" and "multi-speaker" browser specs prove
+   the **absence** of a diarizer, dressed up with speaker labels in the scenario. This is
+   honest (it reports skipped, not fake-pass) but it is **not diarization coverage** — the
+   real diarization coverage is entirely in tier 2/3.
+
+3. **Entity-extraction is not tested at all in the browser lane.**
+   `voice-workbench-entity-extraction.spec.ts` sets `expectedEntity: "jordan"` /
+   `"priya"`, but the player (`voice-workbench-player.ts` line 428) only copies
+   `expectedEntity` into `detail.expectedEntity` "for the benchmark layer to score" —
+   **nothing asserts the agent extracted the entity**. The agent reply is the mock's
+   `"reply to owner"` string. There is zero entity-extraction assertion. The spec passes
+   by scoring the respond-decision + a WER of 0 on the mocked transcript. Pure larp with
+   respect to its stated purpose.
+
+4. **voice-recognition (voice→entity) is not tested in the browser lane either.**
+   `voice-workbench-voice-recognition.spec.ts` declares `entityId` per participant, but
+   the player carries `expectedSpeakerLabel` only and the case file asserts
+   `predictedSpeakerLabel === null` + `speakerAttributionRan === false`. There is no
+   voice-enrollment, no speaker match, no entity resolution. It is a respond-decision
+   test wearing a voice-recognition costume.
+
+5. **Noise rejection / speaker isolation has NO browser-lane coverage at all.** There is
+   no `voice-workbench-noise.spec.ts` (the task brief lists "noise" among the 11 but the
+   filesystem has 11 workbench specs and none is noise/overlap; the acoustic classes live
+   in tier 2/3 via `corpus-augment.ts` + the `--real` matrix). All noise/reverb/overlap/
+   echo handling is exercised only by the synthetic-speech DSP tier-2 tests and the
+   provisioned tier-3 matrix. The browser e2e feeds a clean 220 Hz sine `tinyWav()` (or
+   the single clean `known-phrase.wav`) — never noisy or overlapping audio.
+
+6. **`tts-stt-e2e.spec.ts` STT is a hand-written shim.** It installs a fake
+   `window.webkitSpeechRecognition` and a `__sttSimulate()` global; the "STT" it tests is
+   its own shim echoing the string back. It proves the *composer wiring* (mic button →
+   `startListening` → interim transcript renders), which is legitimate wiring coverage,
+   but it is not STT and the file header honestly says so.
+
+7. **The strongest browser-lane test is real only on the audio-in half.**
+   `voice-realaudio.spec.ts` genuinely runs Chromium `--use-file-for-fake-audio-capture`
+   → real `getUserMedia` → real `startLocalAsrRecorder` (real `ScriptProcessor` PCM
+   capture + `encodeMonoPcm16Wav`) → real base64 POST. The barge-in test even patches
+   `AudioContext.createBufferSource` to prove the in-flight TTS source is disconnected on
+   START_TRANSCRIPTION. That capture/barge-in machinery is real and valuable. But the ASR
+   response is still `bytes > 1000 ? EXPECTED_PHRASE : ""` — a byte-count gate, not
+   transcription. So it proves "we captured >1 KB of real audio and POSTed it," not "the
+   model transcribed it."
+
+### Why this accumulated
+
+The keyless PR lane genuinely cannot run the fused models (no GPU, no `libelizainference`,
+no bundles). The team's response — a real-decision tier-2 + a provisioned tier-3 with a
+strict honesty contract (`skipped` never `pass`) — is architecturally correct. The debt is
+that the **browser e2e tier was allowed to carry model-quality-sounding names and
+assertions** (WER, diarization, entity-extraction, voice-recognition) while only proving
+client wiring. The names write checks the mocks can't cash.
+
+---
+
+## B. Every voice test, classified
+
+Legend: **REAL** = drives the actual audio/ASR/TTS/decision path under test.
+**LARP** = asserts against a mock/shim standing in for the thing the test name claims.
+**PARTIAL** = real for one half of the pipeline (usually client wiring / audio-in),
+mocked for the model half.
+
+### Browser e2e tier — `packages/app/test/ui-smoke/`
+
+| Test file | Class | Verdict | Evidence (what is mocked) |
+|---|---|---|---|
+| `voice-realaudio.spec.ts` — mic-capture round-trip | capture | **PARTIAL** | Real fake-mic audio-in + real WAV capture/POST; ASR returns `EXPECTED_PHRASE` on `bytes>1000`, agent SSE + TTS mocked. Proves capture, not transcription. |
+| `voice-realaudio.spec.ts` — barge-in during TTS | barge-in | **PARTIAL** (best in tier) | Real audio-in, real 2nd WAV drain, real `AudioContext` source disconnect probe. Genuinely proves barge-in silences playback. Backends still mocked. |
+| `transcript-realaudio.spec.ts` (test 1: real-audio + linkage) | transcription | **PARTIAL** | Real capture → real `/api/transcripts` POST body; transcript/media/knowledge backends mocked; `segmentCount>0` comes from real client session accumulation, transcript text is canned. |
+| `transcript-realaudio.spec.ts` (test 2: viewer/actions) | transcription-UI | **PARTIAL** | Real UI-flow coverage of viewer/player/attachment; audio is real, all persisted data is mock echo. |
+| `voice-selftest-e2e.spec.ts` | round-trip | **LARP** (as ASR quality) / PARTIAL (as wiring) | ASR mock returns `EXPECTED_PHRASE` verbatim → WER structurally 0.0; SSE + TTS mocked. Real client round-trip wiring, zero model quality. |
+| `voice-desktop-selftest.spec.ts` | round-trip (desktop cfg) | **LARP** (as ASR) / PARTIAL (as config) | Same mocks as above; the *real* thing proven is platform=desktop → `/api/tts/local-inference` route selection. That config assertion is real. |
+| `voice-workbench-diarization.spec.ts` | diarization | **LARP** | No diarizer provided; asserts `diarization.status==="skipped"`, `predictedSpeakerLabel===null`. Proves absence of a diarizer, not diarization. |
+| `voice-workbench-multi-speaker.spec.ts` | multi-speaker | **LARP** | Same mock lane; only respond-decision + canned-WER scored; no speaker separation. |
+| `voice-workbench-multi-voice.spec.ts` | multi-voice | **LARP** | `ttsVoiceId` declared but TTS is one shared `tinyWav()`; no voice distinction asserted. |
+| `voice-workbench-voice-recognition.spec.ts` | voice→entity | **LARP** | `entityId` declared, but `speakerAttributionRan===false` asserted; no enrollment/match/resolution. |
+| `voice-workbench-entity-extraction.spec.ts` | entity-from-voice | **LARP** | `expectedEntity` only copied into report detail; **no assertion the agent extracted it**; agent reply is a canned string. |
+| `voice-workbench-transcription-mode.spec.ts` | dictation WER | **LARP** (as WER) | `expectedTranscript` == mocked ASR text → WER 0.0. Proves dictation *plumbing*, not accuracy. |
+| `voice-workbench-eot.spec.ts` | end-of-turn | **LARP** | EOT decision is encoded in `expectRespond` + the mock's per-turn respond/no-respond; the real EOT heuristic is never invoked in this lane. |
+| `voice-workbench-respond-no-respond.spec.ts` | chime-in gate | **LARP** | Respond decision comes from the mock's per-turn cursor, not the shipped respond-gate; real gate lives in tier 2. |
+| `voice-workbench-pauses.spec.ts` | pauses/timing | **LARP** | Injects `pausesMs` sleeps; asserts turns still respond via mock. No timing behavior verified against a real detector. |
+| `voice-workbench-multi-agent-room.spec.ts` | multi-agent routing | **LARP** | Addressing decision from mock cursor; no real router. |
+| `tts-stt-e2e.spec.ts` — provider matrix | selection | **REAL** | Imports and asserts the real `pickDefaultVoiceProvider` pure function. Genuine. |
+| `tts-stt-e2e.spec.ts` — SSE token+done | wire format | **REAL** (of the fixture contract) | Asserts the live-stack fixture SSE shape; real transport contract, fixture reply. |
+| `tts-stt-e2e.spec.ts` — TTS cloud payload | wire format | **PARTIAL** | Real renderer→endpoint payload shape asserted; TTS handler mocked (returns tiny mp3). |
+| `tts-stt-e2e.spec.ts` — STT capture path (×2, incl. always-on) | STT wiring | **LARP** (as STT) / PARTIAL (as wiring) | `webkitSpeechRecognition` is a hand-written shim; `__sttSimulate` echoes the string. Proves composer wiring, not recognition. |
+
+### UI unit/source tier — `packages/ui/src/voice/`
+
+These are real unit tests of real pure logic (not larp), listed for completeness — they
+test what they claim (VAD auto-stop math, WAV codec, wake-name matching, EOT scorer,
+turn-signal gate, transcript session, capture factory). Notable REAL ones:
+`voice-capture-factory.test.ts`, `local-asr-capture.test.ts`, `end-of-turn.test.ts`,
+`should-respond.test.ts`, `voice-turn-signal.test.ts`, `wake-name-match.test.ts`,
+`wake-controller.test.ts`/`.fuzz`, `voice-provider-defaults.test.ts`. Verdict for the
+group: **REAL** (pure-logic units; no model claim to falsify).
+
+### Headless decision tier — `plugins/plugin-local-inference/src/services/voice/` (Vitest, PR-gated)
+
+| Test / lane | Verdict | Evidence |
+|---|---|---|
+| `voice:workbench --logic` (CI PR lane, w/ regression baseline) | **REAL** (decision logic) | Runs shipped `scoreEndOfTurnHeuristic`, `buildVoiceTurnSignal`, `OnlineSpeakerClusterer`, `selfVoiceSimilarity`; committed baseline fails CI on drift. No models, but no ground-truth echo. |
+| `acoustic-speaker-attribution.test.ts` | **REAL** | Blind clusters synthetic-speech clips by timbre; DER scorer trips on genuine misattribution; same-voice cos-sim >0.9, cross-voice low. Non-tautological. |
+| `voice-speaker-diarizer.test.ts` | **REAL** (reducer) | Golden cases for `classifyFramesToSegments` powerset reducer + pyannote constants. Real FFI coverage deferred to `diarizer-fused.real.test.ts`. |
+| `voice-speaker-encoder.test.ts` | **REAL** (constants + centroid) | WeSpeaker dims/sample-rate/model-ids + `averageEmbeddings`. Real FFI in `encoder-fused.real.test.ts`. |
+| `voice:workbench --mock` (CI plumbing) | **LARP by design** (honest) | Ground-truth echo; explicitly the runner→scorer→report plumbing lane, not a quality claim. |
+
+### Provisioned acoustic tier — hardware-gated (nightly / self-hosted / `--real`)
+
+| Lane | Verdict | Evidence |
+|---|---|---|
+| `*.real.test.ts` (asr-timed / diarizer-fused / encoder-fused / kokoro-engine-bridge) | **REAL** (gated) | Real fused `libelizainference` ABI; skipped without a built lib. |
+| `voice:workbench --real` + `voice-live-e2e.yml` + `voice:matrix` | **REAL** (gated) | Real fused ASR + Kokoro TTS + WeSpeaker + pyannote + optional ElevenLabs; `--require-green` turns skip into failure on opted-in hardware. |
+
+**Tallies (browser e2e tier — the tier #10726 is really about):**
+20 discrete browser-lane test cases → **REAL: 2** (provider matrix, SSE wire), **PARTIAL: 5**
+(both realaudio, both transcript-realaudio, TTS-cloud payload), **LARP: 13** (both selftests,
+all 10 workbench specs, the STT-shim cases).
+
+Counting the strongest interpretation of each *file* (rather than each case), and folding in
+the genuinely-real decision/acoustic tiers as context: the browser e2e surface is
+**~65% LARP / ~25% PARTIAL / ~10% REAL** for what its names claim.
+
+---
+
+## C. Recommendations, ranked
+
+### HIGH confidence — achievable in a coding session (no hardware)
+
+1. **Stop the browser workbench specs from claiming model classes they don't test.**
+   The diarization/multi-speaker/multi-voice/voice-recognition/entity-extraction/eot/
+   respond-no-respond browser specs are LARP relative to their names. Two options, both
+   session-doable:
+   (a) **Rename + re-scope** them to what they prove ("respond-decision plumbing over a
+   mocked backend") and move the class name to the tier-2 `--logic` suite, OR
+   (b) **Delete the redundant browser specs** and keep the tier-2 `workbench-logic-services`
+   + `acoustic-speaker-attribution` tests as the canonical class coverage. The browser lane
+   should keep only what needs a browser (capture, barge-in, transcript UI, provider matrix,
+   SSE wire). This removes the misleading `data-overall="pass"` diarization/entity verdicts.
+
+2. **Add a real entity-extraction assertion to tier 2 (or a `--logic` scenario), since the
+   browser one asserts nothing.** The entity-extraction scenario currently only stashes
+   `expectedEntity` in report detail. Wire the shipped name-extraction path
+   (`workbench-logic-services.ts` already has inline patterns mirroring `IDENTIFY_SPEAKER`)
+   into a scored assertion with a regression baseline. Session-doable — no model needed,
+   the extraction is regex/heuristic in the logic tier.
+
+3. **Make the self-test WER non-tautological in at least one CI-runnable lane.** Feed the
+   ASR mock a *degraded* transcript (dropped/substituted words) in a dedicated spec and
+   assert the WER gate actually *fails* at the boundary (e.g. WER 0.5 must fail the ≤0.34
+   gate). Right now nothing proves the WER gate rejects bad ASR — only that it accepts
+   perfect ASR. This is a session-doable negative test that gives the gate teeth.
+
+4. **Add synthetic-noise mixing to the tier-2 acoustic tests (the "noise rejection" gap).**
+   `synthetic-speech.ts` already generates formant-based speech; `corpus-augment.ts` exists.
+   Add a `voice-workbench-noise` **tier-2** case that mixes additive noise / a second
+   overlapping speaker into the synthetic clip and asserts the blind clusterer still
+   separates speakers and the respond-gate still rejects the bystander at a target SNR.
+   Fully session-doable (deterministic DSP, no models) and it closes the one class with
+   literally zero non-hardware coverage.
+
+5. **Kill the "REAL-AUDIO" overclaim in headers/names or qualify it.** `voice-realaudio.spec.ts`
+   is real audio-*in* only. Rename to `voice-capture-realaudio` or add "(ASR mocked)" so the
+   next reader doesn't take it as end-to-end transcription proof. Trivial, session-doable.
+
+### MEDIUM confidence — session-doable but needs care
+
+6. **Provide a `resolvePredictedSpeakerLabel` backed by the tier-2 `OnlineSpeakerClusterer`
+   to the browser workbench player**, so the diarization browser spec can score a *real*
+   (synthetic-audio) DER instead of asserting `skipped`. The clusterer is pure JS and
+   already runs in Node; bundling it into the shell is plausible but risks pulling
+   plugin-local-inference into the UI bundle (dependency-direction concern flagged in the
+   player header). Prefer keeping diarization in tier 2 (rec #1b) unless a browser-native
+   diarization demo is a product goal.
+
+7. **Add a negative/adversarial suite to the barge-in + capture tests.** Empty capture
+   (<1 KB), aborted mid-capture, ASR 502, TTS silent-buffer — the self-test harness already
+   distinguishes these (silent-buffer → fail), but no browser spec exercises the failure
+   branches. Session-doable with more `page.route` variants that return errors and assert
+   the UI surfaces them (not a false pass).
+
+### LOW confidence — genuinely needs hardware (honest N/A with the exact blocker)
+
+8. **Pillar 2 — model loading on all devices (macOS/Linux/Windows/iOS/Android).**
+   **N/A in this coding session.** Real multi-device model-load benchmarking requires: a
+   built `libelizainference.so`/dylib per platform, the pinned Kokoro GGUF + eliza-1 ASR
+   bundle staged on disk, and a booted simulator/device or Electrobun package per OS. The
+   `VOICE_LIVE_MATRIX.md` already scaffolds this correctly (env gates
+   `ELIZA_VOICE_{MACOS,WINDOWS}_ELECTROBUN_READY`, `ELIZA_VOICE_{IOS,ANDROID}_READY`,
+   `ELIZA_INFERENCE_LIBRARY` + `ELIZA_ASR_BUNDLE`, `--require-green`). **Blocker:** no fused
+   library, no model bundles, and no device/simulator are reachable from a keyless coding
+   container. Concrete follow-up: run `bun run voice:matrix -- --run --require-green` on each
+   provisioned self-hosted runner and attach the per-platform `voice-matrix.json` + screenshots;
+   there is nothing to *build* in the harness — only to *execute on hardware*.
+
+9. **Pillar 3 — STT quality / model selection (WER + latency benchmark).**
+   Selection logic **exists and is REAL/testable now**: `pickDefaultVoiceProvider`
+   (unit-tested) picks tts/asr per platform×runtime; `isLocalInferenceAsrReady` degrades to
+   browser/cloud ASR when local isn't provisioned; the Stage-B matrix cells
+   (`stt.stage-b.apple-sfspeech`, `stt.stage-b.evaluation`) define the WER/latency/RTF/battery
+   schema. A real WER+latency harness needs: real ASR backends (SFSpeechRecognizer on macOS/iOS,
+   Android SpeechRecognizer, fused ASR on Linux), a labelled speech corpus with noise variants,
+   and per-device runs. **Blocker:** on-device ASR engines + labelled corpus + devices — not
+   reachable here. The schema (`eliza_voice_stage_b_stt_eval_v1`) is already defined; the work is
+   executing it on hardware and reviewing the reports, not writing new harness code.
+
+10. **Pillars 4 & 5 on real audio (voice→entity + noise/isolation with real models).**
+    The *logic* is coverable in-session (recs #2, #4). The *real-model* proof
+    (WeSpeaker enrollment → entity resolution on real voices; pyannote separation under
+    real reverb/overlap) is the tier-3 `--real` matrix. **Blocker:** WeSpeaker/pyannote
+    fused ABI + real multi-speaker recordings + GPU runner. Already wired in
+    `voice-live-e2e.yml`; execute nightly and attach `voice-matrix` artifacts.
+
+### Bottom line
+
+The voice stack is **not** a hollow larp — it has a genuinely rigorous tier-2 (real shipped
+decision gates + non-tautological acoustic clustering, PR-gated with a regression baseline)
+and a correctly-gated tier-3 (real fused models, honest skip). The problem #10726 should
+target is narrow and fixable in a session: the **browser e2e tier carries model-quality
+names over mocked backends**, producing ~13 LARP specs whose green `pass` verdicts imply
+diarization / entity-extraction / voice-recognition / WER accuracy that they never exercise.
+De-larp = rename/rescope those specs to "wiring," move the class claims to the real tier-2
+suite (adding the missing entity-extraction assertion and a synthetic-noise case), and add a
+negative WER test so the accuracy gate has teeth. Everything model-quality on real devices is
+honest hardware N/A with the matrix already scaffolded to execute it.

--- a/.github/issue-evidence/10726-voice-delarp/QA_CHECKLIST.md
+++ b/.github/issue-evidence/10726-voice-delarp/QA_CHECKLIST.md
@@ -1,0 +1,340 @@
+# elizaOS Voice + Chat — Definitive Manual QA Checklist
+
+**Issue:** #10726 (voice de-larp)
+**Surface under test:** live chat overlay `packages/ui/src/components/shell/ContinuousChatOverlay.tsx`, state machine `packages/ui/src/components/shell/useShellController.ts`, send queue `packages/ui/src/state/useChatSend.ts`, voice capture `packages/ui/src/voice/`.
+**Execution model:** tap-by-tap. Every item has precise steps, an expected result, a PASS/FAIL/N-A checkbox, and the automated spec that covers it (or `GAP` where nothing does).
+
+---
+
+## How to run this checklist
+
+1. **Build first.** `bun run build` then boot: web (`bun run dev`), desktop (`bun run dev:desktop`), or the on-device app. A screenshot of a stale bundle proves nothing (see root `PR_EVIDENCE.md`).
+2. **Grant mic permission** before the acoustic sections; deny it once (row A-mic-perm) to exercise the denied path.
+3. For every FAIL, capture: the composer screenshot, `GET /api/dev/console-log`, and the `/api/tts/cloud` + SSE network trace.
+4. A row is **not** N-A unless the reason is written in-line.
+
+### Canonical testIds / labels (verified in source)
+- Mic control: `chat-composer-mic`. Label cycles: `talk` (idle) → `stop listening` (recording, push-to-talk off) → `end conversation` (hands-free) → `release to send` (PTT holding) → `stop transcription` (transcription mode). `active` when `recording || handsFree || transcriptionMode`.
+- Transcribe control: `chat-composer-transcribe` (voice mode only, additive, beside mic). Label: `start transcription` / `stop transcription`. `active` when `transcriptionMode`. (#10699)
+- Send control: `chat-composer-action`. Label: `send` / `send another` (while responding) / `send (agent stopped)` (disabled when `!canSend`).
+- Stop-generating control: `chat-composer-stop`. Label: `stop generating`. Appears in the trailing slot while a reply streams and the composer is empty.
+- Transcribing badge: `chat-transcribing-badge`.
+- Trailing slot morphs IN PLACE between send / stop / mic (one persistent `<div>`, no remount).
+
+### elizaOS voice semantics (do not confuse these)
+- **Echo rejection** = `shouldRespondToVoiceTurn(turn, respondContext)` client pre-filter (drops agent-TTS echo / disfluency before a round-trip) **+** the server gate `core.voice_turn_signal`, which is the single authority on whether the agent replies. Client attaches `voiceTurnSignal` via `buildVoiceTurnSignal`.
+- **Converse (hands-free)** routes finals through `TurnAggregator` (semantic end-of-turn); commits call `send(turn, {channelType:'VOICE_DM', metadata:{voiceSource, voiceTurnSignal}})`.
+- **Transcription mode** = record-only, long-form, VERBATIM. The agent **never replies** to a transcribed turn. It is **additive**: mic stays on, composer keeps working; enabling it pauses the hands-free reply loop. Finalizing drops the transcript into the composer as an attachment.
+- **The mic is the master control.** Transcribe-off (`toggleTranscriptionMode` off-path) leaves the mic ON. Only the **mic button** (`stopTranscriptionAndMic`) turns the mic — and therefore transcription — fully OFF.
+- **Dictation (push-to-talk)** bypasses the aggregator: press-release is the turn boundary, fills the composer draft only.
+- **THE RACE (#10700):** a shell `send()` enqueue resolves its `conversationId` LATE at drain time (`turn.conversationId ?? activeConversationIdRef.current ?? ""`). A `clearConversation` (new chat) between a voice/suggestion enqueue and its drain can reroute the turn to the NEW conversation. `handleChatSend` (typed sends) snapshots `conversationId` at enqueue and is NOT exposed. Cold-open double-send must create exactly ONE conversation.
+
+---
+
+# SECTION A — Button-state matrix (every control × every state)
+
+For each row, drive the app into the STATE, read the control, and confirm LABEL + `active`/`aria-pressed` + enabled. Verify via the trailing-slot testId.
+
+## A.1 Mic control (`chat-composer-mic`) label + active per state
+
+- [ ] **A-mic-1 — Idle (mic off, no draft, not responding).** Steps: fresh chat, empty composer, no voice. Expect: mic glyph, label `talk`, `active=false`. Covers: `voice-selftest-e2e.spec.ts`.
+- [ ] **A-mic-2 — Recording, PTT off (hands-free single-listen).** Steps: tap mic to start listening (not hands-free). Expect: label `stop listening`, `active=true`. Covers: `voice-workbench-voice-recognition.spec.ts`.
+- [ ] **A-mic-3 — Hands-free engaged (always-on converse).** Steps: enable hands-free/continuous mode. Expect: label `end conversation`, `active=true`. Covers: `voice-workbench-respond-no-respond.spec.ts`.
+- [ ] **A-mic-4 — Push-to-talk holding.** Steps: press-and-hold mic (`beginPushToTalkPress`), do not release. Expect: label `release to send`, `active=true`. Covers: `GAP` (no PTT-hold label spec) — NEW `voice-button-matrix.spec.ts`.
+- [ ] **A-mic-5 — Transcription mode.** Steps: enter transcription (button/slash/phrase). Expect: mic label `stop transcription`, `active=true`. Covers: `voice-workbench-transcription-mode.spec.ts`.
+- [ ] **A-mic-6 — Draft present (mic hidden → send shown).** Steps: type any text. Expect: trailing slot is SEND (`chat-composer-action`), mic not rendered in trailing slot. Covers: `full-walkthrough.spec.ts`.
+- [ ] **A-mic-7 — Reply streaming, empty composer (mic → stop).** Steps: send, then while reply streams keep composer empty. Expect: trailing slot is STOP (`chat-composer-stop`), label `stop generating`. Covers: `GAP` — NEW `voice-button-matrix.spec.ts`.
+- [ ] **A-mic-8 — Mic permission denied.** Steps: deny OS mic permission, tap mic. Expect: capture does not start, no stuck `recording=true`, a clear denied affordance (not a silent no-op that looks live). Covers: `GAP` — NEW `voice-permission-denied.spec.ts`.
+- [ ] **A-mic-9 — `aria-pressed` mirrors `active`.** Steps: for each of A-mic-2/3/5, read `aria-pressed`. Expect: matches `active`. Covers: `GAP` — NEW `voice-button-matrix.spec.ts`.
+
+## A.2 Transcribe control (`chat-composer-transcribe`, #10699)
+
+- [ ] **A-tr-1 — Hidden outside voice mode.** Steps: text-only (no voice engaged). Expect: transcribe control NOT in DOM. Covers: `GAP` — NEW `voice-button-matrix.spec.ts`.
+- [ ] **A-tr-2 — Visible in voice mode, resting.** Steps: engage voice/hands-free. Expect: transcribe control present beside mic, label `start transcription`, `active=false`. Covers: `voice-workbench-transcription-mode.spec.ts`.
+- [ ] **A-tr-3 — Active while transcribing.** Steps: enter transcription. Expect: label `stop transcription`, `active=true`, `aria-pressed=true`. Covers: `voice-workbench-transcription-mode.spec.ts`.
+- [ ] **A-tr-4 — Additive: mic still active when transcribe active.** Steps: enter transcription. Expect: BOTH transcribe `active` AND mic `active` (mic label `stop transcription`). Covers: `GAP` — NEW `voice-button-matrix.spec.ts`.
+- [ ] **A-tr-5 — Transcribe distinct from mic testId.** Steps: inspect DOM in voice mode. Expect: `chat-composer-transcribe` and `chat-composer-mic` are two separate elements. Covers: `GAP` — NEW `voice-button-matrix.spec.ts`.
+
+## A.3 Send control (`chat-composer-action`)
+
+- [ ] **A-send-1 — Enabled with draft, agent up.** Steps: type text, agent ready. Expect: label `send`, enabled. Covers: `full-walkthrough.spec.ts`.
+- [ ] **A-send-2 — `send another` while responding.** Steps: send, then type again while reply streams. Expect: label `send another`, enabled. Covers: `GAP` — NEW `voice-button-matrix.spec.ts`.
+- [ ] **A-send-3 — Disabled when agent stopped.** Steps: force `!canSend` (agent stopped). Expect: label `send (agent stopped)`, `disabled=true`. Covers: `GAP` — NEW `voice-button-matrix.spec.ts`.
+- [ ] **A-send-4 — Image-only send valid.** Steps: attach image, no text. Expect: send enabled (send is valid with image-only). Covers: `full-walkthrough.spec.ts`.
+- [ ] **A-send-5 — Empty-empty no-op.** Steps: no text, no image, tap where send would be. Expect: mic shown instead, no empty message sent. Covers: `full-walkthrough.spec.ts`.
+- [ ] **A-send-6 — `onPointerDown` preventDefault keeps keyboard up (mobile).** Steps: on Pixel-7 lane, tap send once. Expect: message sends on FIRST tap, keyboard stays up. Covers: `GAP` — NEW `voice-button-matrix.spec.ts` (mobile-chromium).
+
+## A.4 Stop-generating control (`chat-composer-stop`)
+
+- [ ] **A-stop-1 — Appears while streaming, empty composer.** Steps: send, keep composer empty during stream. Expect: STOP shown, label `stop generating`. Covers: `GAP` — NEW `voice-button-matrix.spec.ts`.
+- [ ] **A-stop-2 — Interrupts generation.** Steps: tap stop mid-stream. Expect: generation aborts, stream ends, control returns to mic. Covers: `GAP` — NEW `voice-button-matrix.spec.ts`.
+- [ ] **A-stop-3 — Hidden when composer has draft during stream.** Steps: type during stream. Expect: trailing slot becomes SEND (`send another`), not STOP. Covers: `GAP` — NEW `voice-button-matrix.spec.ts`.
+
+## A.5 Transcribing badge (`chat-transcribing-badge`)
+
+- [ ] **A-badge-1 — Shown only while transcribing.** Steps: enter transcription. Expect: badge visible; exit → badge gone. Covers: `voice-workbench-transcription-mode.spec.ts`.
+- [ ] **A-badge-2 — Badge clears on mic-master-off.** Steps: transcribing, tap mic (master off). Expect: badge gone, transcript finalized. Covers: `GAP` — NEW `transcription-lifecycle.spec.ts`.
+
+## A.6 Trailing-slot morph integrity
+
+- [ ] **A-morph-1 — In-place morph, no remount pop.** Steps: type one char (mic→send), delete it (send→mic). Expect: one persistent `<div>`; no scale/fade remount flicker on each keystroke crossing the draft boundary. Covers: `GAP` — NEW `voice-button-matrix.spec.ts` (visual).
+- [ ] **A-morph-2 — Slot precedence: send > stop > mic.** Steps: draft present + reply streaming. Expect: SEND wins (not STOP). Then clear draft mid-stream → STOP. Then stream ends → MIC. Covers: `GAP` — NEW `voice-button-matrix.spec.ts`.
+
+---
+
+# SECTION B — Voice capture & acoustic conditions
+
+> Real audio only. Use the `chromium-voice-mic` Playwright project with `--use-file-for-fake-audio-capture` and WAV fixtures (`voice-realaudio.spec.ts` model). Known-phrase fixture: `@elizaos/ui/src/voice/voice-selftest/fixtures/known-phrase`.
+
+## B.1 USER SCENARIO: voice getting loud then quiet (dynamic amplitude mid-utterance)
+
+- [ ] **B-amp-1 — Loud→quiet ramp within one utterance.** Steps: play a WAV that starts loud, decays to near-whisper, all one sentence. Expect: full utterance transcribed as ONE turn (VAD does not cut on the quiet tail); analyser reflects amplitude; end-of-turn fires once at true end. Covers: `GAP` — NEW `voice-realaudio-dynamics.spec.ts` (dynamic-gain WAV).
+- [ ] **B-amp-2 — Quiet→loud swell.** Steps: WAV rising from whisper to shout. Expect: no early cutoff at the quiet head, one committed turn. Covers: `GAP` — NEW `voice-realaudio-dynamics.spec.ts`.
+- [ ] **B-amp-3 — Amplitude dip does not false-trigger end-of-turn.** Steps: loud → brief quiet dip (< silence threshold) → loud again. Expect: single turn, not two. Covers: `voice-workbench-pauses.spec.ts` (pause tolerance) + `GAP` for real dynamic-gain audio.
+
+## B.2 USER SCENARIO: multiple voices / speakers overlapping
+
+- [ ] **B-multi-1 — Two speakers overlapping.** Steps: WAV with two simultaneous voices. Expect: diarization separates or the aggregator commits coherent turns; agent does not merge both into one garbled reply. Covers: `voice-workbench-multi-speaker.spec.ts`, `voice-workbench-diarization.spec.ts`.
+- [ ] **B-multi-2 — Multiple distinct voices sequentially.** Steps: 3 different speakers in turn. Expect: distinct turns; wrong-speaker turns gated appropriately. Covers: `voice-workbench-multi-voice.spec.ts`.
+- [ ] **B-multi-3 — Multi-agent room.** Steps: agent-room scenario with multiple agents/speakers. Expect: only intended turns route to the agent. Covers: `voice-workbench-multi-agent-room.spec.ts`.
+
+## B.3 USER SCENARIO: background conversation in the room while user talks to agent
+
+- [ ] **B-babble-1 — Room babble under the user's voice.** Steps: WAV: user speaks a command over continuous background chatter. Expect: the user's turn is captured; babble does not produce spurious agent replies (`shouldRespondToVoiceTurn` + `core.voice_turn_signal` gate). Covers: `voice-workbench-noise.spec.ts` if present, else `GAP` — NEW `voice-realaudio-babble.spec.ts`.
+- [ ] **B-babble-2 — Babble-only (no user command).** Steps: WAV of pure background conversation, no direct address. Expect: ZERO agent replies (server gate suppresses). Covers: `voice-workbench-respond-no-respond.spec.ts` + `GAP` for real babble WAV.
+- [ ] **B-babble-3 — Low SNR command.** Steps: quiet command buried in loud babble. Expect: either a clean transcript or a graceful no-commit — never a hallucinated command routed to the agent. Covers: `GAP` — NEW `voice-realaudio-babble.spec.ts`.
+
+## B.4 USER SCENARIO: people walking INTO the room, talking, then LEAVING (transient speakers)
+
+- [ ] **B-enter-1 — Speaker enters mid-session, speaks, exits.** Steps: WAV: user talking → a second voice fades IN, says something, fades OUT → user resumes. Expect: the transient voice does not corrupt the user's turn; agent does not reply to the passer-by. Covers: `GAP` — NEW `voice-realaudio-transient-speaker.spec.ts`.
+- [ ] **B-enter-2 — Transient speaker during hands-free.** Steps: hands-free on, transient voice enters. Expect: no misrouted reply; hands-free loop stays stable. Covers: `GAP` — NEW `voice-realaudio-transient-speaker.spec.ts`.
+- [ ] **B-enter-3 — Transient speaker during transcription.** Steps: transcription on, person enters/talks/leaves. Expect: their speech is captured VERBATIM into the transcript (record-only), agent still never replies. Covers: `voice-workbench-transcription-mode.spec.ts` + `GAP` for transient-audio.
+
+## B.5 USER SCENARIO: voice over conversation in the room — agent TTS echoed back through mic (echo rejection)
+
+- [ ] **B-echo-1 — Agent TTS looped into mic.** Steps: hands-free on, agent replies (TTS plays), feed that TTS audio back into the mic. Expect: `shouldRespondToVoiceTurn` drops it client-side (recentAgentReply match, low replyAgeMs, agentSpeaking=true); server `core.voice_turn_signal` confirms no reply. Agent does NOT answer itself. Covers: `voice-workbench-respond-no-respond.spec.ts` + `GAP` for real TTS-echo WAV → NEW `voice-echo-rejection.spec.ts`.
+- [ ] **B-echo-2 — Echo while `agentSpeaking=true`.** Steps: echo arrives during active TTS. Expect: dropped (agentSpeaking flag). Covers: `GAP` — NEW `voice-echo-rejection.spec.ts`.
+- [ ] **B-echo-3 — Real user talks OVER agent TTS (barge-in).** Steps: user speaks a genuine new command while TTS plays. Expect: user turn is NOT dropped as echo (distinct from agent audio); barge-in interrupts/queues correctly. Covers: `GAP` — NEW `voice-echo-rejection.spec.ts`.
+- [ ] **B-echo-4 — Stale-reply echo age.** Steps: echo arrives long after the reply (high replyAgeMs). Expect: gate still resolves correctly (server authority), no double-answer. Covers: `GAP` — NEW `voice-echo-rejection.spec.ts`.
+
+## B.6 Disfluency / thinking-noise gate
+
+- [ ] **B-dis-1 — Pure filler ("um", "uh").** Steps: WAV of only disfluency. Expect: no commit, no reply. Covers: `voice-workbench-respond-no-respond.spec.ts`.
+- [ ] **B-dis-2 — Filler then real command.** Steps: "uh… what's the weather". Expect: filler head trimmed, command committed once. Covers: `voice-workbench-eot.spec.ts`.
+
+## B.7 Pauses / end-of-turn
+
+- [ ] **B-eot-1 — Slow speaker with mid-clause pause.** Steps: WAV with a long pause mid-sentence (converse). Expect: aggregator waits, does not cut off; single turn on true completion. Covers: `voice-workbench-pauses.spec.ts`, `voice-workbench-eot.spec.ts`.
+- [ ] **B-eot-2 — Clean auto-stop carryover (one-shot backend).** Steps: local-inference auto-stops on silence with a held (unfinished) turn. Expect: `turnCarryoverRef` carries the pending fragment into the next capture; continuation appends, does NOT drop. Covers: `GAP` — NEW `voice-carryover.spec.ts`.
+- [ ] **B-eot-3 — Explicit stop discards half-utterance.** Steps: mid-utterance, tap mic off / type (barge-in). Expect: `explicitStopRef` set → half-finished turn DISCARDED (not carried, not committed). Covers: `GAP` — NEW `voice-carryover.spec.ts`.
+
+## B.8 Entity extraction over voice
+
+- [ ] **B-ent-1 — Named entities in a voice turn.** Steps: WAV naming a person/place/time. Expect: entities extracted and enriched into the voice turn signal. Covers: `voice-workbench-entity-extraction.spec.ts`.
+
+## B.9 Additional acoustic edge cases
+
+- [ ] **B-x-1 — Clipping / over-driven mic.** Steps: WAV that clips (0 dBFS square-ish peaks). Expect: no crash in the analyser; transcript degrades gracefully, no phantom command. Covers: `GAP` — NEW `voice-realaudio-dynamics.spec.ts`.
+- [ ] **B-x-2 — Near-silence whole utterance.** Steps: WAV at −45 dBFS throughout. Expect: no false end-of-turn commit spam; either one quiet transcript or a clean no-commit. Covers: `GAP` — NEW `voice-realaudio-dynamics.spec.ts`.
+- [ ] **B-x-3 — Sudden onset (cold-start speech).** Steps: WAV that begins with speech in frame 0 (no lead-in silence). Expect: no clipped first word. Covers: `GAP` — NEW `voice-realaudio-dynamics.spec.ts`.
+- [ ] **B-x-4 — Long trailing silence after speech.** Steps: command then 10s silence. Expect: single commit at end-of-speech, capture returns to idle/re-listen; no hang. Covers: `voice-workbench-eot.spec.ts` + `GAP` for the long-tail assert.
+- [ ] **B-x-5 — Cross-talk: user + agent-TTS simultaneously (both live).** Steps: user speaks a NEW command exactly while agent TTS plays. Expect: user command answered, agent audio not treated as a turn (echo gate isolates agent audio only). Covers: `GAP` — NEW `voice-echo-rejection.spec.ts`.
+- [ ] **B-x-6 — Music / non-speech noise.** Steps: WAV of music, no speech. Expect: zero commits, zero replies. Covers: `voice-workbench-noise.spec.ts` if present, else `GAP` — NEW `voice-realaudio-babble.spec.ts`.
+- [ ] **B-x-7 — Same speaker, two rooms of reverb.** Steps: dry then heavily reverberant capture of the same command. Expect: both transcribe; reverb does not spawn a duplicate turn. Covers: `GAP` — NEW `voice-realaudio-dynamics.spec.ts`.
+- [ ] **B-x-8 — Diarization: one speaker mislabeled across a pause.** Steps: single speaker with a 3s pause. Expect: not split into two speakers. Covers: `voice-workbench-diarization.spec.ts`.
+
+---
+
+# SECTION C — Transcription lifecycle (record-only; agent never replies)
+
+## C.1 Start paths
+
+- [ ] **C-start-1 — Start via transcribe BUTTON.** Steps: voice mode, tap `chat-composer-transcribe`. Expect: `transcriptionMode=true`, hands-free reply loop PAUSED, capture starts with `transcription` intent, badge shown. Covers: `voice-workbench-transcription-mode.spec.ts`.
+- [ ] **C-start-2 — Start via SPOKEN start phrase.** Steps: while conversing, speak the start phrase (`isTranscriptionStartPhrase`). Expect: `setTranscript("")` then transcription toggles ON; the phrase itself is consumed (not sent as a turn). Covers: `GAP` — NEW `transcription-lifecycle.spec.ts`.
+- [ ] **C-start-3 — Start via SERVER event.** Steps: dispatch `VOICE_CONTROL_EVENT` `command:"start"`. Expect: transcription turns ON (idempotent — "start" while already on is a no-op). Covers: `GAP` — NEW `transcription-lifecycle.spec.ts`.
+- [ ] **C-start-4 — Start via SLASH command.** Steps: type the transcription slash command. Expect: transcription engages. Covers: `GAP` — NEW `transcription-lifecycle.spec.ts`.
+- [ ] **C-start-5 — Enter forces chat open + unlocks audio.** Steps: from pilled/closed, enter transcription. Expect: `setIsOpen(true)`, `voiceOutput.unlockAudio()`, `beginTranscriptSession()`. Covers: `GAP` — NEW `transcription-lifecycle.spec.ts`.
+
+## C.2 Stop paths (button-off vs mic-master-off) — CRITICAL distinction
+
+- [ ] **C-stop-1 — Transcribe button off leaves MIC ON.** Steps: transcribing hands-free, tap `chat-composer-transcribe` off. Expect: session finalized, transcript → composer, hands-free reply loop RESUMES (`resumeHandsFreeAfterTranscriptRef`), MIC stays ON. Covers: `voice-workbench-transcription-mode.spec.ts` + `GAP` for resume-assert.
+- [ ] **C-stop-2 — MIC button turns transcription fully OFF.** Steps: transcribing, tap `chat-composer-mic` (→ `stopTranscriptionAndMic`). Expect: transcription off, session finalized, mic MASTER off, hands-free NOT resumed, prior continuous mode persisted so auto-engage does not re-open the mic. Covers: `GAP` — NEW `transcription-lifecycle.spec.ts`.
+- [ ] **C-stop-3 — Stop via SPOKEN exit phrase.** Steps: speak the exit phrase. Expect: transcription finalizes (off-path semantics: mic stays on). Covers: `GAP` — NEW `transcription-lifecycle.spec.ts`.
+- [ ] **C-stop-4 — Stop via SERVER event.** Steps: dispatch `VOICE_CONTROL_EVENT` `command:"stop"`. Expect: transcription off (idempotent — "stop" while idle is a no-op). Covers: `GAP` — NEW `transcription-lifecycle.spec.ts`.
+- [ ] **C-stop-5 — Started-with-mic-off case.** Steps: enter transcription while hands-free was OFF, then transcribe-button-off. Expect: hands-free does NOT get spuriously turned on (restore prior state only). Covers: `GAP` — NEW `transcription-lifecycle.spec.ts`.
+
+## C.3 Transcript-drops-into-composer
+
+- [ ] **C-drop-1 — Finalize drops transcript as composer attachment.** Steps: transcribe a paragraph, exit. Expect: transcript record created + chat link-widget; content lands in the composer to send with next message. Covers: `voice-workbench-transcription-mode.spec.ts` + `GAP` for attachment-in-composer assert.
+- [ ] **C-drop-2 — Verbatim, no aggregator trimming.** Steps: transcribe with disfluencies/pauses. Expect: transcript is VERBATIM (transcription bypasses echo/disfluency aggregator; every final sent as-is after exit-phrase detection). Covers: `GAP` — NEW `transcription-lifecycle.spec.ts`.
+- [ ] **C-drop-3 — Agent NEVER replies to a transcribed turn.** Steps: transcribe a full session. Expect: zero agent replies during transcription (record-only). Covers: `voice-workbench-transcription-mode.spec.ts`.
+- [ ] **C-drop-4 — Wake-triggered inline reply folds into transcript (#9880).** Steps: during transcription, trigger a wake-word inline reply. Expect: the agent's answer is folded into the transcript record, speaker-labeled with the character name; one-shot flag cleared. Covers: `GAP` — NEW `transcription-lifecycle.spec.ts`.
+
+## C.4 Re-listen loop
+
+- [ ] **C-loop-1 — Long-form continues across silence auto-stops.** Steps: transcribe with several long silences (one-shot backend auto-stops each). Expect: re-listen loop re-opens `transcription` capture; recording continues; no lost segments. Covers: `GAP` — NEW `transcription-lifecycle.spec.ts`.
+- [ ] **C-loop-2 — Re-listen suppressed while sending / speaking / draft present.** Steps: transcribing, then send / TTS plays / draft typed. Expect: re-listen timer does NOT re-open capture until those clear. Covers: `GAP` — NEW `transcription-lifecycle.spec.ts`.
+- [ ] **C-loop-3 — Re-listen requires `ready`.** Steps: transcription on but agent not `ready` (model warming). Expect: loop waits; no capture spun up prematurely; resumes when ready. Covers: `GAP` — NEW `transcription-lifecycle.spec.ts`.
+- [ ] **C-loop-4 — No double-capture from the loop.** Steps: force rapid loop ticks. Expect: loop no-ops when `recording || captureRef` already set. Covers: `GAP` — NEW `transcription-storm.spec.ts`.
+
+## C.6 Transcription state-restore correctness
+
+- [ ] **C-rest-1 — Prior continuous mode restored on mic-master-off.** Steps: hands-free OFF, enter transcription, mic-master-off. Expect: `saveContinuousChatMode(prior)` restores the pre-transcription mode; auto-engage does NOT re-open mic. Covers: `GAP` — NEW `transcription-lifecycle.spec.ts`.
+- [ ] **C-rest-2 — `isOpen` stays open after finalize.** Steps: transcribe from open chat, exit. Expect: chat remains open with transcript in composer. Covers: `GAP` — NEW `transcription-lifecycle.spec.ts`.
+- [ ] **C-rest-3 — Transcript session id uniqueness.** Steps: two transcription sessions back-to-back. Expect: two distinct transcript records, no merge. Covers: `GAP` — NEW `transcription-lifecycle.spec.ts`.
+
+## C.5 USER SCENARIO: transcription on/off storms
+
+- [ ] **C-storm-1 — 10× transcribe on/off via button.** Steps: tap `chat-composer-transcribe` on/off 10× fast. Expect: ends in a definite state matching last tap; no stuck capture (`captureRef` non-null while UI idle); no duplicate transcript sessions; badge state matches. Covers: `GAP` — NEW `transcription-storm.spec.ts`.
+- [ ] **C-storm-2 — Mixed button/mic on-off storm.** Steps: alternate transcribe-toggle and mic-tap rapidly. Expect: mic-master-off always wins for mic; no orphaned session; hands-free resume flag never left dangling. Covers: `GAP` — NEW `transcription-storm.spec.ts`.
+- [ ] **C-storm-3 — Server start/stop event storm.** Steps: fire alternating `voice-control` start/stop events rapidly. Expect: idempotent settle, final state matches last event. Covers: `GAP` — NEW `transcription-storm.spec.ts`.
+
+---
+
+# SECTION D — Interleaving & lifecycle
+
+## D.1 USER SCENARIO: sending TEXT messages while doing voice (interleaved text + voice)
+
+- [ ] **D-mix-1 — Type + send while hands-free listening.** Steps: hands-free on, type a text message, send. Expect: text turn sends as `DM` (not `VOICE_DM`); voice loop unaffected; reply not spoken (lastTurnVoice=false for the text turn). Covers: `GAP` — NEW `voice-text-interleave.spec.ts`.
+- [ ] **D-mix-2 — Voice turn then immediate text turn.** Steps: speak a command (VOICE_DM), then immediately type+send. Expect: both land in the SAME conversation in order; voice reply spoken, text reply not. Covers: `GAP` — NEW `voice-text-interleave.spec.ts`.
+- [ ] **D-mix-3 — Text mid-voice-utterance (barge-in-by-typing).** Steps: start speaking, begin typing before the utterance commits. Expect: half-utterance discarded (`explicitStopRef`), text turn sends cleanly, no ghost voice turn. Covers: `GAP` — NEW `voice-text-interleave.spec.ts`.
+- [ ] **D-mix-4 — lastTurnVoice flips correctly per turn.** Steps: alternate voice/text several times. Expect: each reply's spoken-ness matches that turn's channel (VOICE_DM→spoken, DM→silent). Covers: `GAP` — NEW `voice-text-interleave.spec.ts`.
+
+## D.2 USER SCENARIO: transcribing on/off repeatedly WHILE sending messages
+
+- [ ] **D-txsend-1 — Send during transcription.** Steps: transcribing, type+send a text message. Expect: message sends; re-listen loop pauses during send then resumes; transcript session intact. Covers: `GAP` — NEW `transcription-send-interleave.spec.ts`.
+- [ ] **D-txsend-2 — Transcribe-off, send, transcribe-on, send (×5).** Steps: repeat toggle+send. Expect: no lost/dup messages; each transcript finalization drops into composer; no misroute. Covers: `GAP` — NEW `transcription-send-interleave.spec.ts`.
+- [ ] **D-txsend-3 — Finalize-into-composer then send that transcript.** Steps: transcribe, exit (transcript in composer), send it. Expect: exactly one message with the transcript attachment. Covers: `GAP` — NEW `transcription-send-interleave.spec.ts`.
+
+## D.3 USER SCENARIO: turning voice on and off multiple times in a row (toggle storms)
+
+- [ ] **D-vstorm-1 — 15× mic on/off.** Steps: tap mic on/off 15× fast. Expect: final state matches last tap; `startCapture` bails if `captureRef` already set (no double-capture); no stuck `recording`; analyser cleaned up. Covers: `GAP` — NEW `voice-toggle-storm.spec.ts`.
+- [ ] **D-vstorm-2 — Hands-free engage/disengage storm.** Steps: toggle continuous mode rapidly. Expect: one capture at most; loop does not spawn duplicates. Covers: `GAP` — NEW `voice-toggle-storm.spec.ts`.
+- [ ] **D-vstorm-3 — PTT press/release storm.** Steps: rapid press-release-press. Expect: each press-release = one turn boundary; no orphaned holding state (`pttHolding` stuck). Covers: `GAP` — NEW `voice-toggle-storm.spec.ts`.
+
+## D.4 USER SCENARIO: smashing all the buttons (rapid chaotic taps on every control)
+
+- [ ] **D-smash-1 — Chaotic multi-control mash.** Steps: rapidly tap mic, transcribe, send, stop, new-chat, swipe in random order for ~15s. Expect: app never enters an inconsistent state; no stuck spinner (conversation-loading watchdog `CONVERSATION_LOADING_MAX_MS` clears it); no stuck recording/sending; console has zero page-diagnostics errors (`expectNoPageDiagnostics`). Covers: `GAP` — NEW `voice-chaos-monkey.spec.ts`.
+- [ ] **D-smash-2 — Send-spam single-flight.** Steps: mash send 10× on one draft. Expect: single-flight drain (`flushQueuedChatSends` guarded by `chatSendBusyRef`) sends the draft once; no duplicate turns. Covers: `GAP` — NEW `voice-chaos-monkey.spec.ts`.
+- [ ] **D-smash-3 — Stop-spam mid-stream.** Steps: mash stop during a reply. Expect: idempotent abort, no crash. Covers: `GAP` — NEW `voice-chaos-monkey.spec.ts`.
+
+## D.5 USER SCENARIO: swiping the chat (conversation swipe) mid-voice / mid-transcription
+
+- [ ] **D-swipe-1 — Swipe to adjacent conversation while hands-free.** Steps: hands-free on, swipe (`selectAdjacentConversation`). Expect: switch behind loading flag; voice loop points at the switched conversation after settle; no turn misrouted to the old convo. Covers: `chat-clear-swipe.spec.ts` (swipe model) + `GAP` for voice-active swipe.
+- [ ] **D-swipe-2 — Swipe mid-transcription.** Steps: transcribing, swipe conversations. Expect: transcript session survives or finalizes cleanly into the correct conversation; no cross-conversation transcript bleed. Covers: `GAP` — NEW `transcription-swipe.spec.ts`.
+- [ ] **D-swipe-3 — Swipe with an in-flight voice turn (THE RACE, #10700).** Steps: commit a voice turn (enqueued), immediately swipe/new-chat before drain. Expect: the voice turn lands in the conversation it was SPOKEN into, NOT the newly-selected one. This is the unprotected shell `send()` surface (late `activeConversationIdRef` binding). Covers: `chat-clear-swipe.spec.ts` model → NEW `voice-send-race.spec.ts`.
+- [ ] **D-swipe-4 — Swipe spinner never hangs.** Steps: swipe to an uncached conversation on a model-bound agent. Expect: spinner shows, then watchdog force-clears within `CONVERSATION_LOADING_MAX_MS` (12s); conversation usable. Covers: `conversation-management.spec.ts` + `GAP` for watchdog assert.
+
+## D.6 USER SCENARIO: opening / switching VIEWS while chatting AND while transcribing
+
+- [ ] **D-view-1 — Switch views while a reply streams.** Steps: send, switch to another view (e.g. models/tasks) mid-stream, return. Expect: stream continues/completes; message not lost; returning shows the completed reply. Covers: `GAP` — NEW `voice-view-switch.spec.ts`.
+- [ ] **D-view-2 — Switch views while hands-free.** Steps: hands-free on, switch views. Expect: mic state survives per product intent (or cleanly pauses); no stuck capture; return restores expected state. Covers: `GAP` — NEW `voice-view-switch.spec.ts`.
+- [ ] **D-view-3 — Switch views WHILE transcribing.** Steps: transcribing, open a different view, come back. Expect: transcript session continues recording (or is preserved); no lost segments; badge state consistent on return. Covers: `GAP` — NEW `voice-view-switch.spec.ts`.
+- [ ] **D-view-4 — View switch mid-voice-turn does not misroute.** Steps: commit voice turn, switch view before drain. Expect: turn lands in the correct conversation (same #10700 late-binding surface). Covers: `GAP` — NEW `voice-send-race.spec.ts`.
+
+## D.7 USER SCENARIO: new-chat mid-send (#10700 core)
+
+- [ ] **D-newchat-1 — New chat between voice enqueue and drain.** Steps: commit a voice turn, tap new-chat (`clearConversation`) before the queue drains. Expect: the voice turn is delivered to its ORIGINAL conversation; the new chat is empty + greeted; `lastTurnVoice` reset false so the greeting is not spoken. Covers: `chat-clear-swipe.spec.ts` model → NEW `voice-send-race.spec.ts`.
+- [ ] **D-newchat-2 — Cold-open double-send creates exactly ONE conversation.** Steps: from cold open (no active conversation), fire two sends near-simultaneously (voice + suggestion). Expect: exactly ONE conversation created (single-flight `createConversation`), both turns land in it. Covers: `GAP` — NEW `voice-send-race.spec.ts`.
+- [ ] **D-newchat-3 — Suggestion-chip send is on the unprotected surface.** Steps: tap a suggested prompt, new-chat before drain. Expect: same race semantics as voice (shell `send()` path, not `handleChatSend`). Verify chip send routes correctly. Covers: `GAP` — NEW `voice-send-race.spec.ts`.
+- [ ] **D-newchat-4 — Typed send is NOT exposed to the race.** Steps: type+send (`handleChatSend`), new-chat before drain. Expect: turn lands in the ORIGINAL conversation (conversationId snapshotted at enqueue). Confirms the asymmetry. Covers: `chat-clear-swipe.spec.ts`.
+
+## D.8 USER SCENARIO: iterate back and forth like a real user
+
+- [ ] **D-iter-1 — Full realistic session loop.** Steps: hands-free → speak → agent replies (TTS) → type a correction → swipe to old convo → speak there → transcribe a note → exit transcription → send the note → new chat → speak again. Expect: every turn in the correct conversation, correct spoken-ness, no dup/lost, clean final state. Covers: `full-walkthrough.spec.ts` (25-step model) → EXTEND with voice legs.
+- [ ] **D-iter-2 — Speak → transcribe → speak (mode hop).** Steps: hands-free converse, enter transcription (reply loop pauses), transcribe, exit (reply loop resumes), converse again. Expect: reply loop correctly pauses/resumes; no dropped voice turns at the boundaries. Covers: `GAP` — NEW `transcription-lifecycle.spec.ts`.
+- [ ] **D-iter-3 — Voice → text → swipe → voice, all one thread until swipe.** Steps: as named. Expect: pre-swipe turns in convo A, post-swipe voice in convo B; nothing bleeds. Covers: `GAP` — NEW `voice-send-race.spec.ts`.
+
+## D.9 Concurrency & ordering guarantees
+
+- [ ] **D-conc-1 — Two voice turns committed back-to-back.** Steps: two quick utterances before the first drains. Expect: FIFO order preserved in the single conversation; single-flight drain, no interleave corruption. Covers: `GAP` — NEW `voice-send-race.spec.ts`.
+- [ ] **D-conc-2 — Voice turn during cloud handoff freeze.** Steps: commit a voice turn while `CLOUD_HANDOFF_PHASE_EVENT: migrating` is active. Expect: turn HELD (queue frozen, composer shows accepted, `chatSending` on), drained to the DEDICATED container after `switched`, delivered exactly once. Covers: `GAP` — NEW `voice-send-race.spec.ts`.
+- [ ] **D-conc-3 — Handoff timeout/failure keeps turn on shared agent.** Steps: commit voice turn, handoff `timed-out`/`failed`. Expect: turn drains to the still-working shared agent exactly once. Covers: `GAP` — NEW `voice-send-race.spec.ts`.
+- [ ] **D-conc-4 — Slash/prefixed command via voice-transcribed text.** Steps: dictate text that becomes a `/command`. Expect: `tryHandlePrefixedChatCommand` handles it, no server turn sent, local command turn appended. Covers: `GAP` — NEW `voice-text-interleave.spec.ts`.
+
+---
+
+# SECTION E — Cross-cutting invariants (assert on EVERY section-B/C/D item)
+
+- [ ] **E-1 — No lost message.** Every enqueued turn appears exactly once in a conversation. Covers: `chat-clear-swipe.spec.ts`, `conversation-management.spec.ts`.
+- [ ] **E-2 — No duplicate message.** Single-flight drain never double-sends. Covers: `GAP` — NEW `voice-send-race.spec.ts`.
+- [ ] **E-3 — No misrouted message.** A turn never lands in a conversation other than the one it was created against (#10700). Covers: `chat-clear-swipe.spec.ts` → NEW `voice-send-race.spec.ts`.
+- [ ] **E-4 — No stuck recording.** After any storm/mash, `recording=false` and `captureRef=null` when the UI shows idle. Covers: `GAP` — NEW `voice-toggle-storm.spec.ts`.
+- [ ] **E-5 — No stuck sending.** After drain, `chatSending=false`, `chatSendBusyRef=false`. Covers: `GAP` — NEW `voice-chaos-monkey.spec.ts`.
+- [ ] **E-6 — No stuck spinner.** Conversation-loading always clears (resolve or watchdog ≤12s). Covers: `conversation-management.spec.ts` + `GAP` for watchdog.
+- [ ] **E-7 — Clean state reset on new chat.** `clearConversation` resets draft, `lastTurnVoice=false`, empty greeted conversation, prior non-empty convo still swipe-reachable. Covers: `chat-clear-swipe.spec.ts`.
+- [ ] **E-8 — Analyser lifecycle clean.** `setAnalyser(null)` on every capture end (stop/dispose/error). No leaked AudioContext. Covers: `GAP` — NEW `voice-toggle-storm.spec.ts`.
+- [ ] **E-9 — No hands-free resume-flag leak.** `resumeHandsFreeAfterTranscriptRef` never left `true` after a mic-master-off. Covers: `GAP` — NEW `transcription-lifecycle.spec.ts`.
+- [ ] **E-10 — Zero page diagnostics.** `expectNoPageDiagnostics` passes (no uncaught errors/console.error) through the whole session. Covers: helper in `test/ui-smoke/helpers.ts` (all specs).
+- [ ] **E-11 — Echo never self-answers.** Agent TTS echoed back never produces a reply, across all acoustic sections. Covers: NEW `voice-echo-rejection.spec.ts`.
+- [ ] **E-12 — Server gate is authority.** For every "should not reply" case, confirm `core.voice_turn_signal` was the decider (not just the client pre-filter). Covers: `voice-workbench-respond-no-respond.spec.ts`.
+- [ ] **E-13 — Optimistic user bubble on every send.** Each send renders the user bubble + typing indicator immediately, even while the agent warms (server holds the turn). No invisible queueing. Covers: `full-walkthrough.spec.ts` + `GAP` for warming-hold assert.
+- [ ] **E-14 — Empty assistant bubble pruned.** A never-filled assistant placeholder (empty `text`, matching `assistantMsgId`) is removed, not left as a blank bubble. Covers: `GAP` — NEW `voice-chaos-monkey.spec.ts`.
+- [ ] **E-15 — Draft cleared before debounce on send.** After send, `clearChatDraft(activeConversationId)` fires before the debounce window so a background-app pause cannot snapshot the empty-then-restored draft. Covers: `GAP` — NEW `voice-text-interleave.spec.ts`.
+- [ ] **E-16 — `voiceSource` recorded on voice turns.** Every VOICE_DM turn carries `metadata.voiceSource` (the backend that produced it). Covers: `GAP` — NEW `voice-send-race.spec.ts`.
+- [ ] **E-17 — No AudioContext leak across a full session.** Enter/exit voice + transcription ≥10× and confirm AudioContext count returns to baseline. Covers: `GAP` — NEW `voice-toggle-storm.spec.ts`.
+- [ ] **E-18 — Transcript never routed to the server as a reply-eligible turn.** Confirm transcribed finals never carry a `voiceTurnSignal` that would trigger a reply. Covers: `GAP` — NEW `transcription-lifecycle.spec.ts`.
+
+---
+
+# SECTION F — Per-platform notes
+
+Run the whole matrix (A–E) on each platform. Rebuild + redeploy before every capture (a stale install proves nothing).
+
+## F.1 macOS desktop (Electrobun — `Eliza-dev.app` = prod build)
+
+- [ ] **F-mac-1 — Real mic capture path.** Native mic through the desktop shell; not mocked-bridge Chromium. Evidence: `GET /api/dev/cursor-screenshot`.
+- [ ] **F-mac-2 — Audio unlock on first voice.** `voiceOutput.unlockAudio()` succeeds; TTS plays. Covers: `voice-desktop-selftest.spec.ts`.
+- [ ] **F-mac-3 — Echo rejection with real speakers→mic loop.** Play TTS through speakers, capture via real mic. Expect: no self-answer. Covers: `GAP` (hardware) → manual.
+- [ ] **F-mac-4 — Toggle/transcription storms on native.** Same as D.3/C.5 on desktop. Covers: `GAP` → manual + NEW specs re-run under desktop project.
+
+## F.2 Web (Chromium — `chromium` / `chromium-voice-mic` / `mobile-chromium`)
+
+- [ ] **F-web-1 — Fake-audio WAV capture works.** `--use-file-for-fake-audio-capture` drives real transcription. Covers: `voice-realaudio.spec.ts`, `transcript-realaudio.spec.ts`.
+- [ ] **F-web-2 — shimmed webkitSpeechRecognition + SSE + `/api/tts/cloud`.** Covers: `tts-stt-e2e.spec.ts`.
+- [ ] **F-web-3 — Mobile-chromium (Pixel 7) composer + keyboard.** Send keeps keyboard up (A-send-6). Covers: NEW `voice-button-matrix.spec.ts` (mobile-chromium).
+- [ ] **F-web-4 — Mic permission prompt / denied (A-mic-8).** Covers: NEW `voice-permission-denied.spec.ts`.
+
+## F.3 iOS simulator
+
+- [ ] **F-ios-sim-1 — Rebuild + cap sync + reinstall before capture.** Renderer change is baked into the IPA; restarting the old app does NOT pick it up. Confirm `versionName`/on-screen marker. Evidence: `capture:ios-sim`.
+- [ ] **F-ios-sim-2 — Mic permission dialog (Capacitor).** Grant/deny paths. Covers: `GAP` → manual.
+- [ ] **F-ios-sim-3 — Voice capture + transcription lifecycle on sim.** Covers: `GAP` → manual re-run of C/D.
+- [ ] **F-ios-sim-4 — View-switch while transcribing (native nav).** Covers: `GAP` → manual (D.6).
+
+## F.4 Real iOS device
+
+- [ ] **F-ios-dev-1 — Real-mic acoustic matrix (B.1–B.5).** Loud→quiet, multi-speaker, room babble, people entering/leaving, agent-TTS echo — all with the physical mic/speaker in a real room. This is the definitive echo-rejection test (real acoustic loopback). Covers: `GAP` → manual, recorded walkthrough + audio.
+- [ ] **F-ios-dev-2 — Background/foreground during voice.** Backgrounding mid-utterance/mid-transcription; return. Expect: no stuck capture, no lost transcript. Covers: `GAP` → manual.
+- [ ] **F-ios-dev-3 — Bluetooth/AirPods route change mid-session.** Expect: capture survives or fails gracefully, no self-answer via route echo. Covers: `GAP` → manual.
+- [ ] **F-ios-dev-4 — Full realistic loop (D.8) on device, narrated + recorded.** Covers: `GAP` → manual, video + audio + logs.
+
+---
+
+# NEW automated specs to add (model each on `chat-clear-swipe.spec.ts`'s stateful in-spec conversation store, desktop + Pixel-7 lanes; use `seedAppStorage`, `installDefaultAppRoutes`, `installPageDiagnosticsGuard`, `expectNoPageDiagnostics`)
+
+1. `voice-button-matrix.spec.ts` — A.1–A.6 label/active/aria/disabled/morph across states.
+2. `voice-permission-denied.spec.ts` — A-mic-8, F-web-4.
+3. `voice-realaudio-dynamics.spec.ts` — B.1 loud↔quiet dynamic-gain WAV.
+4. `voice-realaudio-babble.spec.ts` — B.3 room babble / low SNR.
+5. `voice-realaudio-transient-speaker.spec.ts` — B.4 enter/talk/leave.
+6. `voice-echo-rejection.spec.ts` — B.5 agent-TTS echo + barge-in.
+7. `voice-carryover.spec.ts` — B.7 carryover vs explicit-stop discard.
+8. `transcription-lifecycle.spec.ts` — C start/stop paths, drop-into-composer, re-listen, wake-fold.
+9. `transcription-storm.spec.ts` — C.5 on/off storms.
+10. `transcription-swipe.spec.ts` — D.5 swipe mid-transcription.
+11. `transcription-send-interleave.spec.ts` — D.2 transcribe on/off while sending.
+12. `voice-text-interleave.spec.ts` — D.1 interleaved text + voice.
+13. `voice-toggle-storm.spec.ts` — D.3 voice on/off storms + E-4/E-8.
+14. `voice-chaos-monkey.spec.ts` — D.4 button-smashing + E-5.
+15. `voice-send-race.spec.ts` — D.5/D.7 #10700 misroute + cold-open dedupe (E-2/E-3).
+16. `voice-view-switch.spec.ts` — D.6 view switching while chatting/transcribing.
+
+---
+
+## Sign-off
+
+- [ ] Every A/B/C/D/E/F row is PASS or has a written N-A reason.
+- [ ] Every user-demanded scenario (loud→quiet, multi-speaker, room babble, enter/leave, transcription, button-smashing, all button states, toggle storms, text-while-voice, transcribe on/off while sending, swipe mid-voice, iterate back-and-forth, view-switch while chatting/transcribing, agent-TTS echo rejection) has at least one PASS row.
+- [ ] Every GAP has a NEW spec landed OR a written waiver.
+- [ ] Real-LLM trajectory, backend+frontend logs, before/after screenshots (desktop+mobile), and a narrated video walkthrough attached under `.github/issue-evidence/10726-voice-delarp/` per `PR_EVIDENCE.md`.

--- a/packages/app/playwright.ui-smoke.config.ts
+++ b/packages/app/playwright.ui-smoke.config.ts
@@ -133,7 +133,7 @@ export default defineConfig({
       // personal-assistant domain views, so each lifeops view is exercised at
       // the same WebView viewport that ships on Capacitor iOS/Android.
       testMatch:
-        /(backgrounds|apps-personal-assistant-decomposed-interactions|chat-clear-swipe)\.spec\.ts/,
+        /(backgrounds|apps-personal-assistant-decomposed-interactions|chat-clear-swipe|chat-send-voice-newchat-fuzz)\.spec\.ts/,
       use: { ...devices["Pixel 7"] },
     },
     {

--- a/packages/app/test/ui-smoke/chat-send-voice-newchat-fuzz.spec.ts
+++ b/packages/app/test/ui-smoke/chat-send-voice-newchat-fuzz.spec.ts
@@ -1,0 +1,402 @@
+// Full-stack e2e for the interleaved send / new-chat message lifecycle on the
+// REAL web app — the genuinely-real useShellController + useChatSend + composer,
+// driven with real keyboard/pointer input, network mocked statefully (#10700).
+//
+// The composer submit + tapped suggestions + voice converse turns all route
+// through the shell `send()` path, which enqueues WITHOUT an explicit
+// conversationId. Before #10700's fix, `runQueuedChatSend` resolved the target
+// LATE (activeConversationIdRef at drain time), so a new-chat issued while a turn
+// was still queued rerouted that turn into the wrong conversation. This spec
+// proves, end to end in the browser, that a turn lands in the conversation it was
+// sent in even when a new chat is started while it is mid-flight — and that a
+// storm of interleaved sends / new-chats / swipes / view-switches raises no page
+// diagnostics and leaves no stuck state.
+//
+// The stateful store records, per conversation, the user messages the client
+// actually delivered to `…/messages/stream` — the routing ground truth. Record a
+// video with E2E_RECORD=1.
+
+import { expect, test } from "@playwright/test";
+import {
+  expectNoPageDiagnostics,
+  installDefaultAppRoutes,
+  installPageDiagnosticsGuard,
+  openAppPath,
+  seedAppStorage,
+} from "./helpers";
+
+const NOW = Date.now();
+
+type Msg = { id: string; role: string; text: string; timestamp: number };
+type ConvRecord = {
+  id: string;
+  title: string;
+  roomId: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+const SEED: ConvRecord[] = [
+  {
+    id: "conv-primary",
+    title: "Primary thread",
+    roomId: "room-primary",
+    createdAt: new Date(NOW).toISOString(),
+    updatedAt: new Date(NOW).toISOString(),
+  },
+  {
+    id: "conv-secondary",
+    title: "Secondary thread",
+    roomId: "room-secondary",
+    createdAt: new Date(NOW - 1000).toISOString(),
+    updatedAt: new Date(NOW - 1000).toISOString(),
+  },
+];
+const SEED_MESSAGES: Record<string, Msg[]> = {
+  "conv-primary": [
+    {
+      id: "p1",
+      role: "assistant",
+      text: "PRIMARY: ready when you are.",
+      timestamp: NOW - 5000,
+    },
+  ],
+  "conv-secondary": [
+    {
+      id: "s1",
+      role: "assistant",
+      text: "SECONDARY: this is another thread.",
+      timestamp: NOW - 6000,
+    },
+  ],
+};
+
+function makeStore() {
+  return {
+    convos: SEED.map((c) => ({ ...c })),
+    messages: structuredClone(SEED_MESSAGES),
+    /** convId -> ordered user texts the client actually delivered here. */
+    delivered: {} as Record<string, string[]>,
+    created: [] as string[],
+    deleted: [] as string[],
+    /** Streams still deliberately held open (for the in-flight race window). */
+    streamCount: 0,
+  };
+}
+type Store = ReturnType<typeof makeStore>;
+
+/**
+ * Install the stateful conversation store. `firstStreamDelayMs` holds the FIRST
+ * message stream open long enough to (a) keep `responding` true so the composer
+ * exposes "send another", and (b) open the window in which a second turn is
+ * queued behind it and a new-chat can fire before the queue drains.
+ */
+async function installConversationStore(
+  page: import("@playwright/test").Page,
+  store: Store,
+  firstStreamDelayMs = 1600,
+) {
+  await page.route("**/api/conversations", async (route) => {
+    const method = route.request().method();
+    if (method === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ conversations: store.convos }),
+      });
+      return;
+    }
+    if (method === "POST") {
+      const n = store.created.length + 1;
+      const id = `conv-fresh-${n}`;
+      const ts = new Date(NOW + n * 1000).toISOString();
+      const record: ConvRecord = {
+        id,
+        title: "New chat",
+        roomId: `room-fresh-${n}`,
+        createdAt: ts,
+        updatedAt: ts,
+      };
+      const greetingText = `FRESH ${n} — how can I help?`;
+      store.convos.unshift(record);
+      store.messages[id] = [
+        {
+          id: `g-${id}`,
+          role: "assistant",
+          text: greetingText,
+          timestamp: NOW + n * 1000,
+        },
+      ];
+      store.created.push(id);
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          conversation: record,
+          greeting: { text: greetingText },
+        }),
+      });
+      return;
+    }
+    await route.fallback();
+  });
+
+  await page.route("**/api/conversations/cleanup-empty", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ deleted: [] }),
+    });
+  });
+
+  // The message STREAM — records the delivery target (the ground truth for
+  // routing) and streams a short SSE reply.
+  await page.route(
+    "**/api/conversations/*/messages/stream",
+    async (route) => {
+      const url = new URL(route.request().url());
+      const convId = url.pathname.split("/").slice(-3, -2)[0] ?? "";
+      const body = JSON.parse(route.request().postData() ?? "{}") as {
+        text?: string;
+      };
+      const userText = (body.text ?? "").trim();
+      (store.delivered[convId] ??= []).push(userText);
+      store.messages[convId] ??= [];
+      store.messages[convId].push({
+        id: `u-${convId}-${store.messages[convId].length}`,
+        role: "user",
+        text: userText,
+        timestamp: Date.now(),
+      });
+      const assistantText = `ack: ${userText}`;
+      store.messages[convId].push({
+        id: `a-${convId}-${store.messages[convId].length}`,
+        role: "assistant",
+        text: assistantText,
+        timestamp: Date.now(),
+      });
+      store.streamCount += 1;
+      if (store.streamCount === 1 && firstStreamDelayMs > 0) {
+        await new Promise((r) => setTimeout(r, firstStreamDelayMs));
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "text/event-stream",
+        body:
+          `data: ${JSON.stringify({ type: "token", text: assistantText, fullText: assistantText })}\n\n` +
+          `data: ${JSON.stringify({ type: "done", fullText: assistantText, agentName: "Eliza" })}\n\n`,
+      });
+    },
+  );
+
+  await page.route("**/api/conversations/*/messages", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    const url = new URL(route.request().url());
+    const id = url.pathname.split("/").slice(-2, -1)[0] ?? "";
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ messages: store.messages[id] ?? [] }),
+    });
+  });
+
+  await page.route("**/api/conversations/*/greeting**", async (route) => {
+    const url = new URL(route.request().url());
+    const id = url.pathname.split("/").slice(-2, -1)[0] ?? "";
+    const text = store.messages[id]?.[0]?.text ?? "Hi — how can I help?";
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ text }),
+    });
+  });
+
+  await page.route("**/api/conversations/*", async (route) => {
+    const method = route.request().method();
+    const url = new URL(route.request().url());
+    const id = url.pathname.split("/").pop() ?? "";
+    if (method === "DELETE") {
+      store.deleted.push(id);
+      store.convos = store.convos.filter((c) => c.id !== id);
+      await route.fulfill({ status: 200, contentType: "application/json", body: "{}" });
+      return;
+    }
+    if (method === "PATCH") {
+      await route.fulfill({ status: 200, contentType: "application/json", body: "{}" });
+      return;
+    }
+    await route.fallback();
+  });
+}
+
+const OVERLAY = "continuous-chat-overlay";
+const COMPOSER = 'textarea[aria-label="message"], [data-testid="chat-composer-textarea"]';
+
+async function expandToFull(page: import("@playwright/test").Page) {
+  // Focus the composer to open the sheet, then maximize so the header controls
+  // (new-chat / clear) are reachable.
+  await page.locator(COMPOSER).first().click();
+  const grabber = page.getByTestId("chat-sheet-grabber");
+  if (await grabber.count()) {
+    const box = await grabber.first().boundingBox();
+    if (box) {
+      await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+      await page.mouse.down();
+      await page.mouse.move(box.x + box.width / 2, box.y - 320, { steps: 10 });
+      await page.mouse.up();
+    }
+  }
+}
+
+async function typeAndSend(page: import("@playwright/test").Page, text: string) {
+  const composer = page.locator(COMPOSER).first();
+  await composer.click();
+  await composer.fill(text);
+  await page.getByTestId("chat-composer-action").click();
+}
+
+let store: Store;
+
+test.beforeEach(async ({ page }) => {
+  store = makeStore();
+  installPageDiagnosticsGuard(page);
+  await seedAppStorage(page, { "eliza:tutorial-autolaunched": "1" });
+  await installDefaultAppRoutes(page);
+});
+
+test("a turn queued while a new chat starts lands in the conversation it was sent in, not the new one (#10700)", async ({
+  page,
+}, testInfo) => {
+  await installConversationStore(page, store, 1600);
+  await openAppPath(page, "/chat");
+  const overlay = page.getByTestId(OVERLAY);
+  await expect(overlay).toBeVisible({ timeout: 20_000 });
+  await expandToFull(page);
+  await testInfo.attach("01-primary-open.png", {
+    body: await page.screenshot(),
+    contentType: "image/png",
+  });
+
+  // Turn 1 into conv-primary — its stream is held ~1.6s, so `responding` stays
+  // true and the composer exposes "send another".
+  await typeAndSend(page, "route-alpha");
+
+  // Turn 2 is queued BEHIND turn 1 (single-flight) while conv-primary is active.
+  const composer = page.locator(COMPOSER).first();
+  await composer.fill("route-beta");
+  await page.getByTestId("chat-composer-action").click();
+
+  // Start a NEW chat while turn 2 is still queued. Pre-fix this rerouted the
+  // queued turn to the fresh conversation; post-fix it is pinned to conv-primary.
+  const clear = page.getByTestId("chat-full-clear");
+  await expect(clear).toBeVisible({ timeout: 15_000 });
+  await clear.click();
+  await testInfo.attach("02-new-chat-mid-flight.png", {
+    body: await page.screenshot(),
+    contentType: "image/png",
+  });
+
+  // Let the queue fully drain.
+  await expect
+    .poll(() => (store.delivered["conv-primary"] ?? []).length, {
+      timeout: 15_000,
+    })
+    .toBe(2);
+
+  // ROUTING INVARIANT: both turns landed in conv-primary, none in the fresh one.
+  expect(store.delivered["conv-primary"]).toEqual(["route-alpha", "route-beta"]);
+  for (const freshId of store.created) {
+    expect(store.delivered[freshId] ?? []).not.toContain("route-beta");
+    expect(store.delivered[freshId] ?? []).not.toContain("route-alpha");
+  }
+  await testInfo.attach("03-routing-settled.png", {
+    body: await page.screenshot(),
+    contentType: "image/png",
+  });
+
+  await expectNoPageDiagnostics(page, "send-newchat-race");
+});
+
+test("interleaved send / new-chat / swipe / view-switch storm raises no diagnostics and never gets stuck (#10700)", async ({
+  page,
+}, testInfo) => {
+  await installConversationStore(page, store, 0);
+  await openAppPath(page, "/chat");
+  const overlay = page.getByTestId(OVERLAY);
+  await expect(overlay).toBeVisible({ timeout: 20_000 });
+  await expandToFull(page);
+
+  // A user iterating like a real person: send, new chat, send, swipe, send,
+  // switch view + back, send, new chat — rapidly, in the same session.
+  for (let round = 0; round < 4; round++) {
+    await typeAndSend(page, `storm-${round}-a`);
+    await page.waitForTimeout(120);
+    // New chat.
+    const clear = page.getByTestId("chat-full-clear");
+    if (await clear.count()) {
+      await clear.click();
+      await page.waitForTimeout(120);
+    }
+    await typeAndSend(page, `storm-${round}-b`);
+    await page.waitForTimeout(120);
+    // Swipe the thread (real touch drag via CDP).
+    const thread = page.getByTestId("chat-thread");
+    if (await thread.count()) {
+      const box = await thread.first().boundingBox();
+      if (box) {
+        const cy = box.y + box.height / 2;
+        const client = await page.context().newCDPSession(page);
+        try {
+          await client.send("Input.dispatchTouchEvent", {
+            type: "touchStart",
+            touchPoints: [{ x: box.x + box.width * 0.8, y: cy }],
+          });
+          for (let i = 1; i <= 10; i++) {
+            await client.send("Input.dispatchTouchEvent", {
+              type: "touchMove",
+              touchPoints: [
+                { x: box.x + box.width * 0.8 - i * 18, y: cy },
+              ],
+            });
+          }
+          await client.send("Input.dispatchTouchEvent", {
+            type: "touchEnd",
+            touchPoints: [],
+          });
+        } finally {
+          await client.detach();
+        }
+      }
+    }
+    await page.waitForTimeout(120);
+    // Switch away to home and back to chat — chatting across a view switch.
+    await openAppPath(page, "/");
+    await page.waitForTimeout(120);
+    await openAppPath(page, "/chat");
+    await expect(page.getByTestId(OVERLAY)).toBeVisible({ timeout: 15_000 });
+    await expandToFull(page);
+    await testInfo.attach(`storm-round-${round}.png`, {
+      body: await page.screenshot(),
+      contentType: "image/png",
+    });
+  }
+
+  // NO STUCK STATE: after the storm the composer is idle — no stop control
+  // latched on, the mic/send control is reachable.
+  await expect(page.getByTestId("chat-composer-stop")).toHaveCount(0);
+  const composer = page.locator(COMPOSER).first();
+  await composer.click();
+  await composer.fill("final settle");
+  await expect(composer).toHaveValue("final settle");
+
+  // Every delivered message went to SOME real conversation (none dropped into
+  // the void) and no message was duplicated within a conversation.
+  const allDelivered = Object.values(store.delivered).flat();
+  const storms = allDelivered.filter((t) => t.startsWith("storm-"));
+  expect(new Set(storms).size).toBe(storms.length); // no duplicates
+
+  await expectNoPageDiagnostics(page, "send-newchat-storm");
+});

--- a/packages/shared/src/voice-wer.test.ts
+++ b/packages/shared/src/voice-wer.test.ts
@@ -72,3 +72,48 @@ describe("wordErrorRate", () => {
     expect(wordErrorRate("alpha beta", "gamma delta")).toBe(1);
   });
 });
+
+// De-larp guard (#10726). The voice self-test's WER quality gate accepts a
+// transcript only when `wer <= werTolerance` (default 0.34 in
+// voice-selftest-harness.ts). The mocked-ASR self-test lane always feeds the
+// EXPECTED phrase back verbatim, so its measured WER is always 0.0 — a
+// tautology that proves the gate ACCEPTS a perfect transcript but never that it
+// REJECTS a bad one. These cases pin that the metric genuinely discriminates
+// ASR quality across the 0.34 boundary, so a real (degraded) transcript would
+// fail the gate rather than sail through.
+describe("WER discriminates real vs degraded ASR (self-test gate = 0.34)", () => {
+  const GATE = 0.34; // voice-selftest-harness.ts default `werTolerance`
+  const REFERENCE = "the quick brown fox jumps over the lazy dog"; // 9 words
+  const passesGate = (hyp: string) => wordErrorRate(REFERENCE, hyp) <= GATE;
+
+  it("a perfect transcript passes the gate (WER 0)", () => {
+    expect(wordErrorRate(REFERENCE, REFERENCE)).toBe(0);
+    expect(passesGate(REFERENCE)).toBe(true);
+  });
+
+  it("a near-perfect transcript (1 slip in 9) passes the gate", () => {
+    // realistic single-word ASR slip → 1/9 ≈ 0.111, well under 0.34
+    const hyp = "the quick brown fox jumped over the lazy dog";
+    expect(wordErrorRate(REFERENCE, hyp)).toBeLessThan(GATE);
+    expect(passesGate(hyp)).toBe(true);
+  });
+
+  it("a heavily degraded transcript FAILS the gate (WER > 0.34)", () => {
+    // ~half the words wrong — the kind of output a broken/unloaded ASR model
+    // produces. The gate MUST reject it.
+    const hyp = "the quiet brown box bumps under a hazy dog";
+    expect(wordErrorRate(REFERENCE, hyp)).toBeGreaterThan(GATE);
+    expect(passesGate(hyp)).toBe(false);
+  });
+
+  it("garbage / hallucinated output FAILS the gate", () => {
+    const hyp = "please connect a provider to continue";
+    expect(wordErrorRate(REFERENCE, hyp)).toBeGreaterThan(GATE);
+    expect(passesGate(hyp)).toBe(false);
+  });
+
+  it("an empty transcript (silent / dropped capture) FAILS the gate", () => {
+    expect(wordErrorRate(REFERENCE, "")).toBe(1);
+    expect(passesGate("")).toBe(false);
+  });
+});

--- a/packages/ui/src/state/useChatSend.send-voice-newchat.race.test.tsx
+++ b/packages/ui/src/state/useChatSend.send-voice-newchat.race.test.tsx
@@ -1,0 +1,445 @@
+// @vitest-environment jsdom
+//
+// #10700 — interleaved send-text / send-voice / new-chat lifecycle.
+//
+// The send queue is a stateful machine, not a set of pure calls. A turn enqueued
+// through the SHELL send() path (voice converse turns + tapped suggestions)
+// carries NO explicit conversationId, so `runQueuedChatSend` resolves its target
+// LATE — `turn.conversationId ?? activeConversationIdRef.current ?? ""`
+// (useChatSend.ts ~824) — at DRAIN time. A `new-chat` (clearConversation) issued
+// while such a turn is still queued flips `activeConversationIdRef.current`, so
+// the queued turn drains into the WRONG (new) conversation. The composer path
+// (handleChatSend) snapshots conversationId at enqueue and is immune; the shell
+// send() path is the asymmetric, unprotected surface this suite pins.
+//
+// The definitive routing truth is the first argument of
+// `client.sendConversationMessageStream(convId, text, …)` — that is where the
+// turn is actually delivered. We assert on it. The single-flight drain lets us
+// park a turn in flight and enqueue another BEHIND it, opening a deterministic
+// window to fire a new-chat while a turn is queued (no microtask racing).
+
+import { act, renderHook } from "@testing-library/react";
+import type { MutableRefObject } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  CodingAgentSession,
+  Conversation,
+  ConversationMessage,
+  ImageAttachment,
+} from "../api";
+import type { LoadConversationMessagesResult } from "./internal";
+import { type UseChatSendDeps, useChatSend } from "./useChatSend";
+
+const mocks = vi.hoisted(() => ({
+  client: {
+    abortConversationTurn: vi.fn(() => Promise.resolve({ aborted: true })),
+    createConversation: vi.fn(),
+    sendConversationMessage: vi.fn(),
+    sendConversationMessageStream: vi.fn(),
+    sendWsMessage: vi.fn(),
+    stopCodingAgent: vi.fn(),
+    renameConversation: vi.fn(() => Promise.resolve()),
+    truncateConversationMessages: vi.fn(() => Promise.resolve()),
+    getBaseUrl: vi.fn(() => ""),
+  },
+}));
+
+vi.mock("../api", () => ({ client: mocks.client }));
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: { isNativePlatform: () => false, getPlatform: () => "web" },
+  CapacitorHttp: { get: vi.fn(), post: vi.fn(), request: vi.fn() },
+}));
+
+function conversation(id: string, roomId: string): Conversation {
+  return {
+    id,
+    roomId,
+    title: "New Chat",
+    createdAt: "2026-05-15T00:00:00.000Z",
+    updatedAt: "2026-05-15T00:00:00.000Z",
+  };
+}
+
+// ── A controllable in-memory conversation store shared by the deps + mocks ────
+
+interface StreamCall {
+  convId: string;
+  text: string;
+  channelType: string;
+}
+
+interface RaceHarness {
+  deps: UseChatSendDeps;
+  /** Every stream the hook opened, in order — the routing ground truth. */
+  streamCalls: StreamCall[];
+  /** Resolve the single in-flight stream, advancing the single-flight drain. */
+  resolveInFlight: (reply?: string) => void;
+  /** Number of streams still awaiting resolution (0 or 1 under single-flight). */
+  inFlightCount: () => number;
+  /** Simulate clearConversation's net effect on the send hook: switch active. */
+  newChat: (id: string, roomId: string) => void;
+  /** The conversation active right now (what a shell send() would bind to). */
+  activeId: () => string | null;
+}
+
+function makeHarness(seed: {
+  activeConversationId: string | null;
+  conversations: Conversation[];
+}): RaceHarness {
+  const conversationsRef = {
+    current: [...seed.conversations],
+  } as MutableRefObject<Conversation[]>;
+  const conversationMessagesRef = {
+    current: [],
+  } as MutableRefObject<ConversationMessage[]>;
+  const activeConversationIdRef = {
+    current: seed.activeConversationId,
+  } as MutableRefObject<string | null>;
+
+  const setConversations: UseChatSendDeps["setConversations"] = (value) => {
+    conversationsRef.current =
+      typeof value === "function" ? value(conversationsRef.current) : value;
+  };
+  const setConversationMessages: UseChatSendDeps["setConversationMessages"] = (
+    value,
+  ) => {
+    conversationMessagesRef.current =
+      typeof value === "function"
+        ? value(conversationMessagesRef.current)
+        : value;
+  };
+  const setActiveConversationId: UseChatSendDeps["setActiveConversationId"] = (
+    value,
+  ) => {
+    activeConversationIdRef.current = value;
+  };
+
+  const streamCalls: StreamCall[] = [];
+  const pending: Array<(reply: { text: string; completed: boolean }) => void> =
+    [];
+
+  mocks.client.sendConversationMessageStream.mockImplementation(
+    (
+      id: string,
+      text: string,
+      _onToken: unknown,
+      channelType: string,
+    ): Promise<{ text: string; completed: boolean }> => {
+      streamCalls.push({ convId: id, text, channelType });
+      return new Promise((resolve) => {
+        pending.push(resolve);
+      });
+    },
+  );
+
+  // Cold-open conversation creation hands out deterministic ids.
+  let created = 0;
+  mocks.client.createConversation.mockImplementation(() => {
+    created += 1;
+    const conv = conversation(`created-${created}`, `room-created-${created}`);
+    return Promise.resolve({ conversation: conv });
+  });
+
+  const deps: UseChatSendDeps = {
+    t: (key) => key,
+    uiLanguage: "en",
+    tab: "chat",
+    activeConversationId: seed.activeConversationId,
+    ptySessionsRef: { current: [] } as MutableRefObject<CodingAgentSession[]>,
+    setChatInput: vi.fn(),
+    setChatSending: vi.fn(),
+    setChatFirstTokenReceived: vi.fn(),
+    setServerTurnStatus: vi.fn(),
+    setChatLastUsage: vi.fn(),
+    setChatPendingImages: vi.fn(),
+    setConversations,
+    setActiveConversationId,
+    setCompanionMessageCutoffTs: vi.fn(),
+    setConversationMessages,
+    setUnreadConversations: vi.fn(),
+    setActionNotice: vi.fn(),
+    activeConversationIdRef,
+    chatInputRef: { current: "" } as MutableRefObject<string>,
+    chatPendingImagesRef: { current: [] } as MutableRefObject<
+      ImageAttachment[]
+    >,
+    conversationsRef,
+    conversationMessagesRef,
+    chatAbortRef: { current: null } as MutableRefObject<AbortController | null>,
+    chatSendBusyRef: { current: false } as MutableRefObject<boolean>,
+    chatSendNonceRef: { current: 0 },
+    loadConversations: vi.fn(async () => conversationsRef.current),
+    loadConversationMessages: vi.fn(
+      async (): Promise<LoadConversationMessagesResult> => ({ ok: true }),
+    ),
+    elizaCloudEnabled: false,
+    elizaCloudConnected: false,
+    pollCloudCredits: vi.fn(async () => true),
+  };
+
+  return {
+    deps,
+    streamCalls,
+    resolveInFlight: (reply = "reply") => {
+      const next = pending.shift();
+      next?.({ text: reply, completed: true });
+    },
+    inFlightCount: () => pending.length,
+    newChat: (id, roomId) => {
+      conversationsRef.current = [conversation(id, roomId), ...conversationsRef.current];
+      activeConversationIdRef.current = id;
+    },
+    activeId: () => activeConversationIdRef.current,
+  };
+}
+
+/** Let queued microtasks + the drain loop settle. */
+async function settle(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+type Send = (
+  text: string,
+  options?: {
+    channelType?: "DM" | "VOICE_DM";
+    conversationId?: string | null;
+  },
+) => Promise<void>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.client.getBaseUrl.mockReturnValue("");
+});
+
+describe("#10700 shell send() → new-chat routing race", () => {
+  it("routes a queued VOICE_DM turn to the conversation it was sent in, NOT a mid-flight new chat", async () => {
+    const h = makeHarness({
+      activeConversationId: "conv-A",
+      conversations: [conversation("conv-A", "room-A")],
+    });
+    const { result } = renderHook(() => useChatSend(h.deps));
+    const send = result.current.sendChatText as unknown as Send;
+
+    // Turn 1 (composer path, explicit conv) holds the single-flight drain: its
+    // stream is opened but left in flight, parking the queue.
+    const p1 = send("first", { conversationId: "conv-A" });
+    await settle();
+    expect(h.inFlightCount()).toBe(1);
+
+    // Turn 2 is a SHELL voice turn: no conversationId. It sits behind turn 1.
+    const p2 = send("voice turn", { channelType: "VOICE_DM" });
+    await settle();
+
+    // While the voice turn is queued, the user starts a NEW chat.
+    h.newChat("conv-B", "room-B");
+    await settle();
+    expect(h.activeId()).toBe("conv-B");
+
+    // Drain turn 1, then turn 2.
+    await act(async () => {
+      h.resolveInFlight();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await settle();
+    await act(async () => {
+      h.resolveInFlight();
+    });
+    await act(async () => {
+      await Promise.all([p1, p2]);
+    });
+
+    const voiceStream = h.streamCalls.find((c) => c.text === "voice turn");
+    expect(voiceStream).toBeDefined();
+    // The turn belongs to conv-A (where it was spoken), never conv-B.
+    expect(voiceStream?.convId).toBe("conv-A");
+    expect(voiceStream?.channelType).toBe("VOICE_DM");
+  });
+
+  it("does NOT create a second conversation on a cold-open double shell-send", async () => {
+    // Regression guard for the fix: pinning conversationId at enqueue must NOT
+    // make a rapid second cold-open turn spawn its own conversation. When no
+    // conversation exists, both turns must land in the single one that gets
+    // created — the enqueue pin stays null (cold open) and the drain-time
+    // fallback joins the just-created conversation.
+    const h = makeHarness({
+      activeConversationId: null,
+      conversations: [],
+    });
+    const { result } = renderHook(() => useChatSend(h.deps));
+    const send = result.current.sendChatText as unknown as Send;
+
+    const p1 = send("cold one", { channelType: "VOICE_DM" });
+    const p2 = send("cold two", { channelType: "VOICE_DM" });
+    await settle();
+
+    // Drain both turns.
+    await act(async () => {
+      h.resolveInFlight();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await settle();
+    await act(async () => {
+      h.resolveInFlight();
+    });
+    await act(async () => {
+      await Promise.all([p1, p2]);
+    });
+
+    expect(mocks.client.createConversation).toHaveBeenCalledTimes(1);
+    const convIds = new Set(h.streamCalls.map((c) => c.convId));
+    expect(convIds.size).toBe(1);
+    expect(h.streamCalls.map((c) => c.text)).toEqual(["cold one", "cold two"]);
+  });
+
+  it("keeps composer (explicit-conv) sends immune to a mid-flight new-chat", async () => {
+    // Control: the handleChatSend path already snapshots conversationId, so it
+    // must remain correctly routed under the same interleaving (no regression).
+    const h = makeHarness({
+      activeConversationId: "conv-A",
+      conversations: [conversation("conv-A", "room-A")],
+    });
+    const { result } = renderHook(() => useChatSend(h.deps));
+    const send = result.current.sendChatText as unknown as Send;
+
+    const p1 = send("hold", { conversationId: "conv-A" });
+    await settle();
+    const p2 = send("typed", { conversationId: "conv-A" });
+    await settle();
+    h.newChat("conv-B", "room-B");
+    await settle();
+
+    await act(async () => {
+      h.resolveInFlight();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await settle();
+    await act(async () => {
+      h.resolveInFlight();
+    });
+    await act(async () => {
+      await Promise.all([p1, p2]);
+    });
+
+    expect(h.streamCalls.find((c) => c.text === "typed")?.convId).toBe("conv-A");
+  });
+});
+
+// ── Seeded fuzz: random interleavings of send-text / send-voice / new-chat ─────
+
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+interface ExpectedTurn {
+  text: string;
+  expectedConv: string;
+  kind: "text" | "voice";
+}
+
+describe("#10700 seeded fuzz — send-text / send-voice / new-chat invariants", () => {
+  for (const seed of [1, 7, 42, 1337, 90210]) {
+    it(`seed ${seed}: every turn routes to its enqueue-time conversation`, async () => {
+      const rng = mulberry32(seed);
+      const h = makeHarness({
+        activeConversationId: "conv-0",
+        conversations: [conversation("conv-0", "room-0")],
+      });
+      const { result } = renderHook(() => useChatSend(h.deps));
+      const send = result.current.sendChatText as unknown as Send;
+
+      const expected: ExpectedTurn[] = [];
+      const pendingPromises: Promise<void>[] = [];
+      let convCounter = 0;
+      let turnCounter = 0;
+      const trace: string[] = [];
+
+      const STEPS = 40;
+      for (let step = 0; step < STEPS; step++) {
+        const roll = rng();
+        if (roll < 0.4) {
+          // SHELL voice send — the asymmetric surface (no conversationId).
+          const text = `v${turnCounter++}`;
+          const expectedConv = h.activeId() as string;
+          expected.push({ text, expectedConv, kind: "voice" });
+          trace.push(`step ${step}: send-voice "${text}" @ ${expectedConv}`);
+          pendingPromises.push(send(text, { channelType: "VOICE_DM" }));
+          await settle();
+        } else if (roll < 0.7) {
+          // Composer text send — explicit conversationId (control path).
+          const text = `t${turnCounter++}`;
+          const expectedConv = h.activeId() as string;
+          expected.push({ text, expectedConv, kind: "text" });
+          trace.push(`step ${step}: send-text "${text}" @ ${expectedConv}`);
+          pendingPromises.push(send(text, { conversationId: expectedConv }));
+          await settle();
+        } else if (roll < 0.88) {
+          // New chat — flip the active conversation while turns may be queued.
+          convCounter += 1;
+          const id = `conv-${convCounter}`;
+          trace.push(`step ${step}: new-chat -> ${id}`);
+          h.newChat(id, `room-${convCounter}`);
+          await settle();
+        } else if (h.inFlightCount() > 0) {
+          // Drain one in-flight turn, advancing the single-flight queue.
+          trace.push(`step ${step}: drain-one`);
+          await act(async () => {
+            h.resolveInFlight();
+            await Promise.resolve();
+            await Promise.resolve();
+          });
+          await settle();
+        }
+      }
+
+      // Drain everything that remains.
+      for (let i = 0; i < STEPS + 5 && h.inFlightCount() > 0; i++) {
+        await act(async () => {
+          h.resolveInFlight();
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+        await settle();
+      }
+      await act(async () => {
+        await Promise.allSettled(pendingPromises);
+      });
+
+      // INVARIANT 1: no lost / no duplicate — exactly one stream per turn.
+      expect(h.streamCalls.length).toBe(
+        expected.length,
+      );
+
+      // INVARIANT 2: each turn routed to the conversation active at ITS enqueue,
+      // regardless of any new-chat that happened while it was queued.
+      for (const turn of expected) {
+        const call = h.streamCalls.find((c) => c.text === turn.text);
+        const detail = `${turn.kind} "${turn.text}" expected @ ${turn.expectedConv}\nTRACE:\n${trace.join("\n")}`;
+        expect(call, `missing stream for ${detail}`).toBeDefined();
+        expect(call?.convId, `misrouted ${detail}`).toBe(turn.expectedConv);
+      }
+
+      // INVARIANT 3: ordering — streams open in enqueue order (single-flight).
+      expect(h.streamCalls.map((c) => c.text)).toEqual(
+        expected.map((t) => t.text),
+      );
+
+      // INVARIANT 4: no stuck sending — the queue is fully drained.
+      expect(h.deps.chatSendBusyRef.current).toBe(false);
+      expect(h.inFlightCount()).toBe(0);
+    });
+  }
+});

--- a/packages/ui/src/state/useChatSend.ts
+++ b/packages/ui/src/state/useChatSend.ts
@@ -1363,7 +1363,18 @@ export function useChatSend(deps: UseChatSendDeps) {
         chatSendQueueRef.current.push({
           rawInput,
           channelType: options?.channelType ?? "DM",
-          conversationId: options?.conversationId,
+          // Pin the target conversation at ENQUEUE, not at drain (#10700). The
+          // shell send() path (voice converse turns + tapped suggestions) omits
+          // conversationId, so without this the queued turn resolved its target
+          // LATE in runQueuedChatSend as `activeConversationIdRef.current` — and
+          // a new-chat between enqueue and drain rerouted it to the wrong (new)
+          // conversation. Snapshot the active conversation now so the turn lands
+          // where it was sent. When there is NO active conversation (cold open),
+          // stay null and let the drain-time create-or-join resolve it, so a
+          // rapid second cold-open turn still joins the one created conversation
+          // rather than spawning its own.
+          conversationId:
+            options?.conversationId ?? activeConversationIdRef.current ?? null,
           images: options?.images,
           metadata: buildChatViewMetadata(tab, options?.metadata),
           resolve,


### PR DESCRIPTION
## What & why

Closes #10700. Fixes a real **lost/misrouted-message race** in the chat send queue and adds the fuzz + e2e coverage the issue asks for, plus a first bite of #10726 voice de-larp.

The shell `send()` path — voice converse turns **and** tapped suggestions **and** the continuous-overlay composer submit — enqueues a turn with **no explicit `conversationId`**. `runQueuedChatSend` then resolved the target **late, at drain time**: `turn.conversationId ?? activeConversationIdRef.current ?? ""` (`useChatSend.ts:824`). So a **new chat** (`clearConversation`) started while such a turn is still queued flipped the active id and **rerouted the queued turn into the wrong (new) conversation**. The typed composer path (`handleChatSend`) already snapshots `conversationId` at enqueue and was immune — the shell `send()` path was the asymmetric, unprotected surface.

### The fix (1 line + a guard against the obvious regression)
`sendChatText` now **pins the active conversation at enqueue**:
```ts
conversationId: options?.conversationId ?? activeConversationIdRef.current ?? null,
```
Cold open stays `null` on purpose, so a rapid **second** first-message still joins the **one** conversation the first drain creates (drain-time create-or-join) instead of spawning a second.

## Evidence

### Deterministic proof the harness catches the bug and the fix resolves it
New `packages/ui/src/state/useChatSend.send-voice-newchat.race.test.tsx` renders the **real** `useChatSend` queue (mocked `client`; the definitive routing truth is the `convId` arg of `client.sendConversationMessageStream`). The single-flight queue lets it park a turn in flight, enqueue a voice turn behind it, fire a new-chat, then drain — a deterministic reproduction of the race window.

- **Against the current (unfixed) code:** `6 failed | 2 passed` — the race case + all 5 fuzz seeds fail exactly as the bug predicts (a queued voice turn routed to a mid-flight new chat).
- **With the fix:** `8 passed` (3 named regressions + 5 seeds), and it stays green against the **current develop** base (verified in an isolated worktree).
- 3 named regressions: (i) mid-flight new-chat routing, (ii) cold-open double-send creates exactly **one** conversation, (iii) composer (explicit-conv) path unaffected. 5-seed fuzz asserts no-lost / no-duplicate / correct-routing / in-order / no-stuck after every step.
- Existing `useChatSend.test.tsx` (19) and `useShellController.test.tsx` (39) stay green.

### Real-browser e2e
`packages/app/test/ui-smoke/chat-send-voice-newchat-fuzz.spec.ts` (registered on the **desktop-chromium + Pixel-7** lanes) drives the genuinely-real `useShellController` + `useChatSend` + composer with real input against a stateful store that records per-conversation deliveries, and asserts (1) a turn queued while a new chat starts lands in the conversation it was sent in, and (2) an interleaved send/new-chat/swipe/view-switch storm raises no page diagnostics, drops/duplicates no message, and leaves no stuck composer. Parses + collects on both lanes (`playwright … --list`).
- **Honest status:** the full app-build e2e run is blocked **locally** by an environment biome skew (installed CLI 2.4.16 vs the repo's `biome.json` schema 2.5.1 — `@elizaos/registry#build` dies before the dev server boots). CI runs biome 2.5.1, so it builds+runs there. The deterministic component fuzz above is the rigorous proof of the fix; the e2e is the integration + screenshot/video layer that runs in CI.
- **Real-LLM trajectory: N/A** — this is a client-side conversation-routing fix in the send queue; the routing decision is proven deterministically against the client send call, and the e2e drives the real composer→send path in-browser. No model behavior changes.

### #10726 down-payment (voice de-larp)
- `.github/issue-evidence/10726-voice-delarp/CRITICAL_ASSESSMENT.md` — grounded audit (of 20 browser voice e2e cases: **2 REAL / 5 PARTIAL / 13 LARP**), with specifics (self-test WER is a tautology; diarization specs assert `status==='skipped'`; entity-extraction asserts nothing) and honest hardware N/A scoping.
- `QA_CHECKLIST.md` — 151-item tap-by-tap voice QA checklist covering every demanded condition (loud→quiet, multi-speaker, room babble, speakers entering/leaving, echo rejection, button-state matrix, toggle storms, text-while-voice, swipe/view-switch interleaving), each mapped to a covering spec or flagged GAP.
- `SCENARIOS.md` — the #10700 action alphabet + invariant oracle + regression matrix.
- `voice-wer.test.ts` — **de-larps the WER gate**: proves `wordErrorRate` genuinely rejects degraded/hallucinated/empty ASR across the 0.34 self-test threshold (not just the always-0.0 mock).

## Notes
#10699 (transcription button) landed separately via #10746, so this branch intentionally does **not** include it. Built in an isolated worktree because `develop` is a hot swarm; verified against `develop` @ `112c5623bfd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
