### PR TITLE
test(orchestrator): cover workbench reasoning parity

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -1011,6 +1011,63 @@ describe("AcpService", () => {
     );
   });
 
+  it("native sendPrompt forwards thought chunks as reasoning without polluting the final answer", async () => {
+    const service = new AcpService(runtime({ ELIZA_ACP_TRANSPORT: "native" }));
+    const events: Array<{ event: string; data: unknown }> = [];
+    service.onSessionEvent((_sid, event, data) => {
+      events.push({ event, data });
+    });
+    await service.start();
+    const { sessionId } = await service.spawnSession({
+      name: "native-reasoning",
+      agentType: "opencode",
+      workdir: "/tmp/acp-test",
+    });
+    const client = firstNativeClient();
+    client.prompt.mockImplementationOnce(async () => {
+      client.emit({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: "protocol-session",
+          update: {
+            sessionUpdate: "agent_thought_chunk",
+            content: { type: "text", text: "Check the failing output. " },
+          },
+        },
+      } as AcpJsonRpcMessage);
+      client.emit({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: "protocol-session",
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: "The fix is ready." },
+          },
+        },
+      } as AcpJsonRpcMessage);
+      client.emit({
+        jsonrpc: "2.0",
+        id: "prompt",
+        result: { stopReason: "end_turn" },
+      } as AcpJsonRpcMessage);
+      return { stopReason: "end_turn" };
+    });
+
+    const result = await service.sendPrompt(sessionId, "finish");
+
+    expect(result.response).toBe("The fix is ready.");
+    expect(result.finalText).toBe("The fix is ready.");
+    expect(events).toContainEqual({
+      event: "reasoning",
+      data: { text: "Check the failing output. " },
+    });
+    expect(
+      events.filter(({ event }) => event === "message").map(({ data }) => data),
+    ).toEqual([{ text: "The fix is ready." }]);
+  });
+
   it("native sendPrompt forwards sanitized ACP plan updates", async () => {
     const service = new AcpService(runtime({ ELIZA_ACP_TRANSPORT: "native" }));
     const planPayloads: Array<{ entries?: unknown }> = [];

--- a/plugins/plugin-task-coordinator/__tests__/unit/orchestrator-stream.test.ts
+++ b/plugins/plugin-task-coordinator/__tests__/unit/orchestrator-stream.test.ts
@@ -3,7 +3,10 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import { MarkdownText } from "../../src/orchestrator-markdown";
 import { sanitizeMarkdownUrl } from "../../src/orchestrator-markdown.helpers";
-import type { ConversationBlock } from "../../src/orchestrator-stream";
+import {
+  type ConversationBlock,
+  ConversationBlockView,
+} from "../../src/orchestrator-stream";
 import { buildConversation } from "../../src/orchestrator-stream.helpers";
 
 type MessageRecord = Parameters<typeof buildConversation>[0][number];
@@ -331,6 +334,62 @@ describe("buildConversation", () => {
         }),
       }),
     );
+  });
+
+  it("renders shell tools as slim action cards with tail-preserving output", () => {
+    const longOutput = `head-ok\n${"middle\n".repeat(900)}tail-error: failed assertion`;
+    const blocks = buildConversation(
+      [],
+      [
+        baseEvent({
+          id: "tool-start",
+          timestamp: 20,
+          data: {
+            toolCall: {
+              id: "tool-test",
+              title: "bash",
+              kind: "execute",
+              status: "in_progress",
+              rawInput: { command: "bun test --verbose" },
+            },
+          },
+        }),
+        baseEvent({
+          id: "tool-done",
+          timestamp: 2400,
+          data: {
+            toolCall: {
+              id: "tool-test",
+              title: "bash",
+              kind: "execute",
+              status: "completed",
+              output: longOutput,
+            },
+          },
+        }),
+      ],
+      (message) => message.senderKind,
+      new Set(["session-codex"]),
+    );
+    const toolBlock = blocks.find(
+      (block): block is Extract<ConversationBlock, { kind: "tool" }> =>
+        block.kind === "tool",
+    );
+
+    expect(toolBlock).toBeTruthy();
+    if (!toolBlock) throw new Error("expected shell tool block");
+    const html = renderToStaticMarkup(
+      createElement(ConversationBlockView, { block: toolBlock }),
+    );
+
+    expect(html).toContain("Ran");
+    expect(html).toContain("bun test --verbose");
+    expect(html).toContain("2.4s");
+    expect(html).toContain("head-ok");
+    expect(html).toContain("characters elided");
+    expect(html).toContain("tail-error: failed assertion");
+    expect(html).not.toContain("$ bun test --verbose");
+    expect(html).not.toContain(">bash<");
   });
 
   it("keeps stderr turns distinct and marks them as error output", () => {


### PR DESCRIPTION
## Summary

Relates to #8136.

This PR adds regression coverage for the orchestrator workbench parity work that is already present on `develop`:

- ACP `agent_thought_chunk` updates are forwarded as `reasoning` session events without contaminating the final assistant answer.
- Shell tool cards render the user-facing action verb (`Ran`), avoid duplicate `$ command` body echo, show duration metadata, and preserve the meaningful tail of long command output.

## Evidence

- `bun install` completed and generated the required workspace artifacts/declarations locally.
- `bun run --cwd packages/core build` passed.
- `bun run --cwd packages/agent build` passed.
- `bun run --cwd packages/ui build` passed.
- `bun run --cwd plugins/plugin-commands build` passed.
- `bunx @biomejs/biome check plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts plugins/plugin-task-coordinator/__tests__/unit/orchestrator-stream.test.ts` passed.
- `bun run --cwd plugins/plugin-agent-orchestrator test -- __tests__/unit/acp-service.test.ts` passed: 43 tests.
- `bun run --cwd plugins/plugin-task-coordinator test -- __tests__/unit/orchestrator-stream.test.ts` passed: 13 tests.
- `bun run --cwd plugins/plugin-task-coordinator test` passed: 27 files, 207 tests.
- `bun run --cwd plugins/plugin-agent-orchestrator test` passed on rerun: 121 files passed, 3 skipped; 1247 tests passed, 6 skipped.
- `bun run --cwd plugins/plugin-agent-orchestrator typecheck` passed.
- `bun run --cwd plugins/plugin-task-coordinator typecheck` passed.
- `bun run --cwd plugins/plugin-task-coordinator build` passed.
- `bun run --cwd plugins/plugin-agent-orchestrator build` passed.

## Verify blocker

`bun run verify` is currently blocked before package typecheck/lint by an existing repo-wide type-safety ratchet drift on this checkout:

- `as unknown as`: current 107 > baseline 77
- `?? 0` in core/agent/app-core: current 381 > baseline 380

The reported top files are outside this PR's two touched test files. No UI production code changed in this PR, so screenshot/video rows are N/A for this regression-coverage-only patch.
