### PR TITLE
test(ui/chat): cover agent thinking + streaming reasoning render (#10712)

### DIFF
--- a/.github/issue-evidence/10712-chat-thinking-streaming/README.md
+++ b/.github/issue-evidence/10712-chat-thinking-streaming/README.md
@@ -1,0 +1,29 @@
+# #10712 — verify agent thinking + streaming render (UI slice)
+
+Adds the UI-level verification the issue calls for. Test-only (no behavior change).
+
+## Coverage added
+- `packages/ui/src/components/chat/ThinkingBlock.test.tsx` (5 tests) — the
+  reasoning disclosure had **no** dedicated test. Covers: renders nothing for
+  empty/whitespace reasoning, collapsed by default (`aria-expanded=false`, body
+  hidden), toggles open/closed on click (body reveal + `aria-expanded`), trims
+  the displayed reasoning, and accent-only styling (no blue).
+- `ContinuousChatOverlay.test.tsx` (3 new tests, #10712 block) — renders the
+  collapsed `ThinkingBlock` for an assistant turn carrying `reasoning`, reveals
+  the reasoning body when toggled, and **suppresses** reasoning on the last
+  assistant turn while it is still streaming (`suppressReasoning = responding &&
+  isLastAssistant`), so the disclosure only appears once the stream completes.
+
+## Result
+`bun run --cwd packages/ui vitest run ThinkingBlock.test.tsx ContinuousChatOverlay.test.tsx`
+→ **100 passed** (5 + 95, incl. the 3 new overlay cases). Lint clean.
+
+## Scope note (honest)
+This is the **UI half** of #10712 (the issue's "Add a UI render test" +
+"Add ThinkingBlock.test.tsx" scope items). The server-side streaming mock-LLM
+parity through the `POST /api/conversations/:id/messages/stream` handler (local
+vs cloud provider paths, wire `{type:token}`→`{type:done,thought}` frames) and
+the live-model trajectory are a sibling follow-up — the existing
+`conversation-streaming.test.ts` already covers `generateChatResponse`'s
+token-delta + `thought` contract at the generator level. Real-LLM trajectory /
+backend logs — N/A for this renderer-only coverage.

--- a/packages/ui/src/components/chat/ThinkingBlock.test.tsx
+++ b/packages/ui/src/components/chat/ThinkingBlock.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+//
+// #10712: the collapsible "Thinking" (reasoning) disclosure. Collapsed by
+// default, toggles on click (aria-expanded + body reveal), renders nothing for
+// empty/whitespace reasoning, accent-only styling (no blue).
+
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ThinkingBlock } from "./ThinkingBlock";
+
+afterEach(cleanup);
+
+describe("ThinkingBlock (#10712)", () => {
+  it("renders nothing for empty or whitespace-only reasoning", () => {
+    const empty = render(<ThinkingBlock reasoning="" />);
+    expect(empty.container.firstChild).toBeNull();
+    empty.unmount();
+    const blank = render(<ThinkingBlock reasoning={"   \n\t  "} />);
+    expect(blank.container.firstChild).toBeNull();
+  });
+
+  it("is collapsed by default: shows the toggle but not the reasoning body", () => {
+    const { getByRole, queryByText } = render(
+      <ThinkingBlock reasoning="weighing options A and B" />,
+    );
+    const toggle = getByRole("button", { name: /thinking/i });
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(queryByText("weighing options A and B")).toBeNull();
+  });
+
+  it("reveals the reasoning body on click and collapses again on a second click", () => {
+    const { getByRole, queryByText } = render(
+      <ThinkingBlock reasoning="weighing options A and B" />,
+    );
+    const toggle = getByRole("button", { name: /thinking/i });
+
+    fireEvent.click(toggle);
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    expect(queryByText("weighing options A and B")).not.toBeNull();
+
+    fireEvent.click(toggle);
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(queryByText("weighing options A and B")).toBeNull();
+  });
+
+  it("trims the reasoning it displays", () => {
+    const { getByRole, getByText } = render(
+      <ThinkingBlock reasoning="   padded thought   " />,
+    );
+    fireEvent.click(getByRole("button", { name: /thinking/i }));
+    // The rendered body is the trimmed text (exact match).
+    expect(getByText("padded thought")).not.toBeNull();
+  });
+
+  it("is accent-only — no blue anywhere in the rendered tree", () => {
+    const { container } = render(<ThinkingBlock reasoning="hmm" />);
+    const html = container.innerHTML;
+    expect(html).toContain("text-accent");
+    expect(html).not.toMatch(/blue|indigo|sky|cyan/);
+  });
+});

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -1916,3 +1916,67 @@ describe("ContinuousChatOverlay — empty thread while the sheet is open", () =>
     expect(screen.queryByTestId("chat-thread-loading")).toBeNull();
   });
 });
+
+describe("ContinuousChatOverlay — streaming + thinking render (#10712)", () => {
+  const reasoningMessages = [
+    { id: "u", role: "user", content: "why X over Y?", createdAt: 1 },
+    {
+      id: "a",
+      role: "assistant",
+      content: "because X is simpler",
+      reasoning: "compared X and Y; X has fewer moving parts",
+      createdAt: 2,
+    },
+  ];
+
+  it("renders the collapsed Thinking disclosure for an assistant turn that carries reasoning", () => {
+    render(
+      <ContinuousChatOverlay
+        controller={makeController({
+          responding: false,
+          messages: reasoningMessages,
+        })}
+      />,
+    );
+    // Open the sheet so the thread (and its reasoning block) mounts.
+    fireEvent.focus(screen.getByLabelText("message"));
+    const thinking = screen.getByRole("button", { name: /thinking/i });
+    expect(thinking).toBeTruthy();
+    // Collapsed by default: the reasoning body is not shown until toggled.
+    expect(thinking.getAttribute("aria-expanded")).toBe("false");
+    expect(
+      screen.queryByText("compared X and Y; X has fewer moving parts"),
+    ).toBeNull();
+  });
+
+  it("reveals the reasoning body when the Thinking disclosure is toggled", () => {
+    render(
+      <ContinuousChatOverlay
+        controller={makeController({
+          responding: false,
+          messages: reasoningMessages,
+        })}
+      />,
+    );
+    fireEvent.focus(screen.getByLabelText("message"));
+    fireEvent.click(screen.getByRole("button", { name: /thinking/i }));
+    expect(
+      screen.getByText("compared X and Y; X has fewer moving parts"),
+    ).toBeTruthy();
+  });
+
+  it("suppresses reasoning on the last assistant turn while it is still streaming", () => {
+    render(
+      <ContinuousChatOverlay
+        controller={makeController({
+          // suppressReasoning = responding && isLastAssistant → the Thinking
+          // block stays hidden until the stream completes.
+          responding: true,
+          messages: reasoningMessages,
+        })}
+      />,
+    );
+    fireEvent.focus(screen.getByLabelText("message"));
+    expect(screen.queryByRole("button", { name: /thinking/i })).toBeNull();
+  });
+});


### PR DESCRIPTION
Part of #10712 (UI slice). Test-only, no behavior change.

## What
Adds the UI-level verification the issue calls for:

- **`ThinkingBlock.test.tsx`** (new) — the reasoning disclosure had **no** dedicated test. Covers: empty/whitespace reasoning → renders nothing; collapsed by default (`aria-expanded=false`, body hidden); toggles open/closed on click (body reveal + `aria-expanded`); trims displayed reasoning; accent-only styling (no blue).
- **`ContinuousChatOverlay`** (3 new tests) — renders the collapsed `ThinkingBlock` for an assistant turn carrying `reasoning`; reveals the reasoning body on toggle; and **suppresses** reasoning on the last assistant turn while it is still streaming (`suppressReasoning = responding && isLastAssistant`), so the disclosure only appears once the stream completes.

## Result
`vitest run ThinkingBlock.test.tsx ContinuousChatOverlay.test.tsx` → **100 passed** (5 + 95). Lint clean.

## Scope (honest)
This is the **UI half** of #10712 — the issue's "Add a UI render test" + "Add `ThinkingBlock.test.tsx`" scope items, done fully. The server-side streaming mock-LLM parity through the `POST /api/conversations/:id/messages/stream` handler (local vs cloud provider paths, wire `{type:token}`→`{type:done,thought}` frames) + live trajectory are a sibling follow-up; the existing `conversation-streaming.test.ts` already covers `generateChatResponse`'s token-delta + `thought` contract at the generator level. Real-LLM trajectory / backend logs — N/A for this renderer-only coverage.