### PR TITLE
fix(lifeops): format reminder priority test

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/domains/reminder-notification-priority.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/reminder-notification-priority.test.ts
@@ -21,7 +21,9 @@ const priority = (
 describe("resolveReminderNotificationPriority", () => {
   it("tiers a calendar event starting SOON (≤ 2h) as high", () => {
     expect(priority("calendar_event", at(10 * 60_000))).toBe("high"); // 10 min
-    expect(priority("calendar_event", at(REMINDER_SOON_WINDOW_MS))).toBe("high"); // exactly 2h
+    expect(priority("calendar_event", at(REMINDER_SOON_WINDOW_MS))).toBe(
+      "high",
+    ); // exactly 2h
   });
 
   it("treats an overdue / just-started calendar event as high", () => {


### PR DESCRIPTION
## Summary

- formats the new reminder priority unit test from #10756 so Biome passes
- no behavior changes

## Why

Latest `develop` at `b658205a5b` introduced a small formatter drift in `reminder-notification-priority.test.ts`. Biome would reflow one long assertion, which can fail the formatting gate despite the LifeOps behavior being correct.

## Validation

- `bunx @biomejs/biome check plugins/plugin-personal-assistant/src/lifeops/domains/reminder-notification-priority.ts plugins/plugin-personal-assistant/src/lifeops/domains/reminder-notification-priority.test.ts plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.ts`
- `bun run --cwd plugins/plugin-personal-assistant test src/lifeops/domains/reminder-notification-priority.test.ts`
- `bun run --cwd packages/ui typecheck`
- `bun run --cwd packages/app build:web` (`[verify-chunk-safety] OK`)

Note: `bun run --cwd plugins/plugin-personal-assistant typecheck` still fails on existing package-wide unresolved workspace/type drift outside this formatting fix; the new helper/test path itself validates with the targeted test and Biome check above.
