### PR TITLE
ci(cloud-cf-deploy): timebox git checkout so a stalled runner fails fast

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -124,7 +124,8 @@ jobs:
           # checkout --force --detach fully materializes the working tree from the
           # fetched commit; the prior extra `git reset --hard` re-wrote the entire
           # tree a second time, doubling the slowest part on this large repo.
-          git -C "$CHECKOUT_DIR" checkout --force --detach FETCH_HEAD
+          timeout 300s git -C "$CHECKOUT_DIR" checkout --force --detach FETCH_HEAD \
+            || { echo "::error::git checkout (working-tree materialization) timed out or failed after 300s"; exit 1; }
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
@@ -316,7 +317,8 @@ jobs:
           # checkout --force --detach fully materializes the working tree from the
           # fetched commit; the prior extra `git reset --hard` re-wrote the entire
           # tree a second time, doubling the slowest part on this large repo.
-          git -C "$CHECKOUT_DIR" checkout --force --detach FETCH_HEAD
+          timeout 300s git -C "$CHECKOUT_DIR" checkout --force --detach FETCH_HEAD \
+            || { echo "::error::git checkout (working-tree materialization) timed out or failed after 300s"; exit 1; }
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
@@ -526,7 +528,8 @@ jobs:
           # checkout --force --detach fully materializes the working tree from the
           # fetched commit; the prior extra `git reset --hard` re-wrote the entire
           # tree a second time, doubling the slowest part on this large repo.
-          git -C "$CHECKOUT_DIR" checkout --force --detach FETCH_HEAD
+          timeout 300s git -C "$CHECKOUT_DIR" checkout --force --detach FETCH_HEAD \
+            || { echo "::error::git checkout (working-tree materialization) timed out or failed after 300s"; exit 1; }
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:


### PR DESCRIPTION
## What
Wraps the working-tree materialization step (`git checkout --force --detach FETCH_HEAD`) in the three Cloud CF Deploy jobs with `timeout 300s` + explicit failure, so a checkout that hangs on disk I/O aborts fast instead of eating the whole 20-min step and pinning the runner.

## Why (evidence)
A subagent investigation of the persistent `Cloud CF Deploy` develop failures found they are **100% self-hosted-runner infra**, not code/secrets/workflow:
- A zombie runner **`eliza-robot-11`** reports `online` but cancels every job it accepts (**25/25 failures, 0 successes**) in 5–112s (`##[error]The operation was canceled`, no failing step).
- All 22 fleet runners are processes on **one box** (`eliza-staging-robot-1`); I/O contention stalls `git checkout` to the 20-min timeout (run `78351e4f4`: fetch done 09:45:43 → checkout timeout 10:02:34).
- Proof it's not code/secrets: on a healthy runner (robot-20, run `b1ac9db22`) the full pipeline is **green** — Cloudflare creds present, deploy succeeds. Same YAML.

## Scope / limits
This is **partial hardening only** — it makes symptom #2 (checkout stall) fail fast, but does **not** fix symptom #1 (robot-11's job-level cancel happens before any step runs). The actual cure is operator/infra:
1. Remove/restart the wedged `eliza-robot-11` runner (it is `online`, poisoning the queue).
2. Relieve the oversubscribed host (22 runners on one box), or
3. Flip the repo Actions variable `CLOUD_CF_DEPLOY_RUNNER_JSON` back to `["ubuntu-latest"]` to route deploys off the fleet until it's fixed.

No-op when checkout completes normally; deploy targets and logic are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)