### PR TITLE
fix(app-core): make real e2e deps deterministic

### DIFF
--- a/.github/workflows/app-real-e2e.yml
+++ b/.github/workflows/app-real-e2e.yml
@@ -70,10 +70,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Install browser drivers (the suite imports puppeteer-core/playwright-core)
+      - name: Install browser drivers
         run: |
           set -euo pipefail
-          bun add --cwd packages/app-core puppeteer-core playwright-core
           bunx playwright install --with-deps chromium
 
       - name: Run browser-driven real app e2e

--- a/bun.lock
+++ b/bun.lock
@@ -349,6 +349,7 @@
         "bun-types": "^1.3.12",
         "playwright": "^1.59.1",
         "playwright-core": "^1.58.2",
+        "puppeteer-core": "^24.43.1",
         "react-test-renderer": "^19.2.4",
         "sharp": "^0.34.5",
         "tailwindcss": "^4.3.1",

--- a/packages/app-core/package.json
+++ b/packages/app-core/package.json
@@ -285,6 +285,7 @@
     "bun-types": "^1.3.12",
     "playwright": "^1.59.1",
     "playwright-core": "^1.58.2",
+    "puppeteer-core": "^24.43.1",
     "react-test-renderer": "^19.2.4",
     "sharp": "^0.34.5",
     "tailwindcss": "^4.3.1",

--- a/packages/app-core/vitest.app-real-e2e.config.ts
+++ b/packages/app-core/vitest.app-real-e2e.config.ts
@@ -23,6 +23,10 @@ const here = path.dirname(fileURLToPath(import.meta.url));
  */
 export default defineConfig({
   ...baseConfig,
+  resolve: {
+    ...baseConfig.resolve,
+    preserveSymlinks: false,
+  },
   test: {
     ...baseConfig.test,
     setupFiles: [path.join(here, "test/setup.ts")],


### PR DESCRIPTION
## Summary

Make the browser-driven real app E2E lane deterministic instead of mutating package dependencies during CI.

## Why

While checking the launch-readiness app/cloud test signal, `bun run --cwd packages/app-core test:app-real-e2e` failed before executing tests because the suite imports `puppeteer-core` but `packages/app-core` did not declare it. After that, UI dependencies imported through symlinked third-party packages also failed under the shared Vitest config's `preserveSymlinks: true` behavior.

This PR keeps the real-E2E lane self-contained by:

- declaring `puppeteer-core` in `packages/app-core` dev dependencies
- disabling symlink preservation only for the dedicated `vitest.app-real-e2e.config.ts` lane so third-party packages resolve their own transitive deps from their real `.bun` locations
- removing the CI-time `bun add --cwd packages/app-core puppeteer-core playwright-core` mutation from `.github/workflows/app-real-e2e.yml`

## Validation

- `bun install --frozen-lockfile`
- `bunx @biomejs/biome check .github/workflows/app-real-e2e.yml packages/app-core/vitest.app-real-e2e.config.ts packages/app-core/package.json packages/ui/package.json bun.lock`
- `ELIZA_LIVE_TEST=1 bun run --cwd packages/app-core test:app-real-e2e` -> clean self-skip locally because no live provider keys are configured
- `bun run --cwd packages/ui typecheck`
- `bun run --cwd packages/app build:web` -> passed; `[verify-chunk-safety] OK`

## Notes

Local environment has no live provider keys, so this proves the real-E2E loader/config path is clean and self-skips as designed, not that the live provider chat path passed locally.
