### PR TITLE
fix(desktop): case-insensitive deep-link host + extract testable router (#10720)

### DIFF
--- a/packages/app-core/platforms/electrobun/src/desktop-deep-link-events.test.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-deep-link-events.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { readOpenUrlEventUrl } from "./desktop-deep-link-events";
+import {
+  classifyDeepLinkRoute,
+  readOpenUrlEventUrl,
+} from "./desktop-deep-link-events";
 
 describe("desktop deep-link events", () => {
   it("accepts direct open-url string payloads", () => {
@@ -26,5 +29,44 @@ describe("desktop deep-link events", () => {
     expect(readOpenUrlEventUrl({ url: "" })).toBeNull();
     expect(readOpenUrlEventUrl({ data: { url: 42 } })).toBeNull();
     expect(readOpenUrlEventUrl(null)).toBeNull();
+  });
+});
+
+describe("classifyDeepLinkRoute (#10720)", () => {
+  it("routes <scheme>://apps/<slug> to an app open", () => {
+    expect(classifyDeepLinkRoute("elizaos://apps/plugin-viewer")).toEqual({
+      kind: "app",
+      slug: "plugin-viewer",
+    });
+  });
+
+  it("is case-insensitive on the host (custom schemes don't lowercase it)", () => {
+    // Regression: `new URL("elizaos://Apps/x").host === "Apps"` for opaque hosts,
+    // so a case-sensitive check mis-forwarded a mixed-case authored link.
+    expect(classifyDeepLinkRoute("ELIZAOS://Apps/plugin-viewer")).toEqual({
+      kind: "app",
+      slug: "plugin-viewer",
+    });
+    expect(classifyDeepLinkRoute("elizaos://APPS/wallet")).toEqual({
+      kind: "app",
+      slug: "wallet",
+    });
+  });
+
+  it("takes only the first path segment as the slug", () => {
+    expect(classifyDeepLinkRoute("elizaos://apps/wallet/inventory")).toEqual({
+      kind: "app",
+      slug: "wallet",
+    });
+  });
+
+  it("forwards non-apps hosts, empty slugs, and unparseable urls", () => {
+    expect(classifyDeepLinkRoute("elizaos://assistant?text=hi")).toEqual({
+      kind: "forward",
+    });
+    expect(classifyDeepLinkRoute("elizaos://apps/")).toEqual({
+      kind: "forward",
+    });
+    expect(classifyDeepLinkRoute("not a url")).toEqual({ kind: "forward" });
   });
 });

--- a/packages/app-core/platforms/electrobun/src/desktop-deep-link-events.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-deep-link-events.ts
@@ -15,3 +15,36 @@ export function readOpenUrlEventUrl(event: unknown): string | null {
   const url = rawUrl.trim();
   return url.length > 0 ? url : null;
 }
+
+/**
+ * Where a `<scheme>://…` deep link should be routed. `app` opens a desktop app
+ * window/details for `slug`; `forward` hands the raw URL to the renderer.
+ */
+export type DeepLinkRoute =
+  | { readonly kind: "app"; readonly slug: string }
+  | { readonly kind: "forward" };
+
+/**
+ * Classify a deep-link URL into an app-window open vs a renderer forward. Pure so
+ * the routing decision is unit-testable without an Electrobun window.
+ *
+ * Custom URL schemes parse with an OPAQUE host, which — unlike special schemes
+ * like http — is NOT lowercased by the URL parser (`new URL("elizaos://Apps/x")`
+ * → host `"Apps"`). Matching `parsed.host === "apps"` therefore mis-routed a
+ * mixed/upper-case authored link (`ELIZAOS://Apps/plugin-viewer`) to the generic
+ * forward instead of the app window; normalize the host before comparing. (#10720)
+ */
+export function classifyDeepLinkRoute(url: string): DeepLinkRoute {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { kind: "forward" };
+  }
+  // `<scheme>://apps/<slug>` → host="apps", pathname="/<slug>".
+  if (parsed.host.toLowerCase() === "apps") {
+    const slug = parsed.pathname.replace(/^\/+/, "").split("/")[0];
+    if (slug) return { kind: "app", slug };
+  }
+  return { kind: "forward" };
+}

--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -39,7 +39,10 @@ import {
   computeBottomBarFrame,
   resolveDesktopShellWindowPresentation,
 } from "./desktop-bottom-bar-config";
-import { readOpenUrlEventUrl } from "./desktop-deep-link-events";
+import {
+  classifyDeepLinkRoute,
+  readOpenUrlEventUrl,
+} from "./desktop-deep-link-events";
 import { startDesktopTestBridgeServer } from "./desktop-test-bridge-server";
 import {
   shouldCreateDesktopTray,
@@ -2135,41 +2138,27 @@ async function setupUpdater(): Promise<void> {
  * care which scheme is used; it only routes by host + pathname.
  */
 async function handleDeepLink(url: string): Promise<void> {
-  let parsed: URL;
-  try {
-    parsed = new URL(url);
-  } catch {
-    await forwardDeepLinkToRenderer(url);
-    return;
-  }
-
-  // `<scheme>://apps/<slug>` → URL parses host="apps", pathname="/<slug>"
-  if (parsed.host === "apps") {
-    const slug = parsed.pathname
-      .replace(/^\/+/, "")
-      .replace(/[?#].*$/, "")
-      .split("/")[0];
-    if (slug) {
-      const entry = findAppMenuEntryBySlug(slug);
-      if (entry) {
-        // Mirror the menu/tray handler: apps with a details page get a config
-        // review screen instead of a direct window so deep links and clicks
-        // produce identical UX.
-        if (entry.hasDetailsPage) {
-          void restoreWindow();
-          sendToActiveRenderer("desktopAppDetailsRequested", {
-            slug: entry.slug,
-          });
-        } else {
-          void getDesktopManager().openAppWindow({
-            slug: entry.slug,
-            title: entry.displayName,
-            path: entry.windowPath,
-            alwaysOnTop: false,
-          });
-        }
-        return;
+  const route = classifyDeepLinkRoute(url);
+  if (route.kind === "app") {
+    const entry = findAppMenuEntryBySlug(route.slug);
+    if (entry) {
+      // Mirror the menu/tray handler: apps with a details page get a config
+      // review screen instead of a direct window so deep links and clicks
+      // produce identical UX.
+      if (entry.hasDetailsPage) {
+        void restoreWindow();
+        sendToActiveRenderer("desktopAppDetailsRequested", {
+          slug: entry.slug,
+        });
+      } else {
+        void getDesktopManager().openAppWindow({
+          slug: entry.slug,
+          title: entry.displayName,
+          path: entry.windowPath,
+          alwaysOnTop: false,
+        });
       }
+      return;
     }
   }
 


### PR DESCRIPTION
## What

A small but real correctness fix for #10720's "custom-scheme deep-link routing into the right surface", plus test coverage for a previously-untested routing decision.

`handleDeepLink` (electrobun `index.ts`) matched the deep-link host case-sensitively:

```ts
if (parsed.host === "apps") { … open app window … }
```

Custom URL schemes parse with an **opaque host**, which the URL parser does **not** lowercase (special schemes like `http` do). So:

```js
new URL("elizaos://Apps/plugin-viewer").host // "Apps", not "apps"
```

A mixed/upper-case authored link (`ELIZAOS://Apps/plugin-viewer`) therefore fell through to the generic `forwardDeepLinkToRenderer` instead of opening the app window. Secondary cleanup: the `.replace(/[?#].*$/, "")` on `pathname` was dead code (a URL's `pathname` never contains `?`/`#`).

## Fix

- Extract a **pure** `classifyDeepLinkRoute(url): {kind:"app",slug} | {kind:"forward"}` into `desktop-deep-link-events.ts` — `host.toLowerCase()`, dead regex removed, first path segment as slug. Now the routing decision is unit-testable without an Electrobun window.
- `handleDeepLink` routes through it (behavior identical except the case-fix).

## Test — `desktop-deep-link-events.test.ts` (7/7 green)

4 new cases: lowercase / **uppercase / mixed-case** host → app open; multi-segment path → first segment as slug; non-apps host / empty slug / unparseable → forward.

```
cd packages/app-core/platforms/electrobun
bunx vitest run --config vitest.electrobun.config.ts src/desktop-deep-link-events.test.ts
# Test Files 1 passed · Tests 7 passed
```

## Honest scope

Edge-case input (most authored deep links are lowercase), so this doesn't "break normal usage" — its value is a real correctness fix plus extracting + testing a routing decision #10720 explicitly names. Chat-first desktop launch is already shipped (#10350/#9953); the rest of #10720 (in-chat onboarding default, real-shell e2e) needs a live Electrobun GUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)