### PR TITLE
fix(core): format document attachment tests

### DIFF
--- a/packages/core/src/features/basic-capabilities/process-attachments-documents.test.ts
+++ b/packages/core/src/features/basic-capabilities/process-attachments-documents.test.ts
@@ -71,7 +71,9 @@ function stubFetch(byUrl: Record<string, FetchResult>): void {
 		return {
 			ok: true,
 			statusText: "OK",
-			headers: { get: (h: string) => (/content-type/i.test(h) ? hit.contentType : null) },
+			headers: {
+				get: (h: string) => (/content-type/i.test(h) ? hit.contentType : null),
+			},
 			text: async () => hit.text ?? "",
 			arrayBuffer: async () => {
 				const b = hit.bytes ?? Buffer.from(hit.text ?? "", "utf-8");
@@ -90,7 +92,10 @@ describe("processAttachments — document types (#10714)", () => {
 	it("reads a text/plain document onto attachment.text", async () => {
 		const url = "https://media.test/notes.txt";
 		stubFetch({
-			[url]: { contentType: "text/plain; charset=utf-8", text: "plain notes body" },
+			[url]: {
+				contentType: "text/plain; charset=utf-8",
+				text: "plain notes body",
+			},
 		});
 		const [out] = await processAttachments([doc(url)], makeRuntime());
 		expect(out.text).toBe("plain notes body");
@@ -108,7 +113,9 @@ describe("processAttachments — document types (#10714)", () => {
 	it("reads a text/markdown document (previously skipped) onto attachment.text", async () => {
 		const url = "https://media.test/readme.md";
 		const md = "# Title\n\n- one\n- two";
-		stubFetch({ [url]: { contentType: "text/markdown; charset=utf-8", text: md } });
+		stubFetch({
+			[url]: { contentType: "text/markdown; charset=utf-8", text: md },
+		});
 		const [out] = await processAttachments([doc(url)], makeRuntime());
 		expect(out.text).toBe(md);
 	});

--- a/packages/core/src/services/message.processAttachments.test.ts
+++ b/packages/core/src/services/message.processAttachments.test.ts
@@ -127,25 +127,22 @@ describe("DefaultMessageService.processAttachments", () => {
 	it.each([
 		["text/csv; charset=utf-8", "name,score\nada,99", "csv"],
 		["text/markdown; charset=utf-8", "# Title\n\n- a\n- b", "md"],
-	])(
-		"extracts %s documents (previously skipped)",
-		async (mime, body, ext) => {
-			const bytes = Buffer.from(body, "utf8");
-			const localFetch = localDocFetch(bytes, mime);
-			const svc = new DefaultMessageService();
-			const runtime = mockRuntime(localFetch as unknown as typeof fetch);
+	])("extracts %s documents (previously skipped)", async (mime, body, ext) => {
+		const bytes = Buffer.from(body, "utf8");
+		const localFetch = localDocFetch(bytes, mime);
+		const svc = new DefaultMessageService();
+		const runtime = mockRuntime(localFetch as unknown as typeof fetch);
 
-			const out = await svc.processAttachments(runtime, [
-				{
-					id: "doc",
-					url: `/api/media/abc.${ext}`,
-					contentType: ContentType.DOCUMENT,
-				},
-			]);
+		const out = await svc.processAttachments(runtime, [
+			{
+				id: "doc",
+				url: `/api/media/abc.${ext}`,
+				contentType: ContentType.DOCUMENT,
+			},
+		]);
 
-			expect(out[0].text).toBe(body);
-		},
-	);
+		expect(out[0].text).toBe(body);
+	});
 
 	it("extracts real text from an application/pdf document (previously skipped)", async () => {
 		// A minimal, valid single-page PDF with known text + correct xref, so the
@@ -167,7 +164,8 @@ describe("DefaultMessageService.processAttachments", () => {
 		});
 		const xrefStart = body.length;
 		body += `xref\n0 ${objs.length + 1}\n0000000000 65535 f \n`;
-		for (const off of offsets) body += `${String(off).padStart(10, "0")} 00000 n \n`;
+		for (const off of offsets)
+			body += `${String(off).padStart(10, "0")} 00000 n \n`;
 		body += `trailer\n<< /Size ${objs.length + 1} /Root 1 0 R >>\nstartxref\n${xrefStart}\n%%EOF\n`;
 		const bytes = Buffer.from(body, "latin1");
 


### PR DESCRIPTION
## Summary

Post-merge formatting cleanup for #10773.

Biome flagged two newly merged document-attachment tests after latest `develop` advanced to `a06537e450`. This PR applies only Biome formatting to those tests; no behavior changes.

## Validation

- `bun run --cwd packages/core test src/features/basic-capabilities/process-attachments-documents.test.ts src/services/message.processAttachments.test.ts` ✅ (2 files / 12 tests)
- `bun run --cwd packages/core typecheck` ✅
- `bunx @biomejs/biome check packages/core/src/features/basic-capabilities/index.ts packages/core/src/features/basic-capabilities/process-attachments-documents.test.ts packages/core/src/services/message.processAttachments.test.ts packages/core/src/services/message.ts` ✅
- `bun run --cwd packages/app build:web` ✅ with `[verify-chunk-safety] OK`
