### PR TITLE
fix: complete inbox ops and pump.fun wallet gaps

### DIFF
--- a/.github/issue-evidence/8652-prelaunch-gaps.md
+++ b/.github/issue-evidence/8652-prelaunch-gaps.md
@@ -1,0 +1,40 @@
+# 8652 pre-launch gaps
+
+## Scope Covered
+
+- `@elizaos/plugin-inbox` now owns persisted triage queue routes and action ops for list/search/summarize/triage/reply/snooze/archive/approve.
+- `@elizaos/plugin-wallet` now routes `pump_fun_buy` through a registered pump.fun Solana handler with the existing human confirmation gate.
+- Package docs (`README.md`, `CLAUDE.md`, `AGENTS.md`) were updated to remove stale scaffold language and document the new surfaces.
+
+## Validation
+
+Passed locally on this branch:
+
+- `bun install`
+- `bun run --cwd plugins/plugin-inbox lint`
+- `bun run --cwd plugins/plugin-inbox typecheck`
+- `bun run --cwd plugins/plugin-inbox test`
+  - 15 files passed, 1 skipped
+  - 108 tests passed, 2 skipped
+- `bun run --cwd plugins/plugin-inbox build`
+- `bun run --cwd plugins/plugin-wallet lint`
+- `bun run --cwd plugins/plugin-wallet check`
+- `bun run --cwd plugins/plugin-wallet test`
+  - 23 files passed, 1 skipped
+  - 105 tests passed, 1 skipped
+- `bun run --cwd plugins/plugin-wallet build`
+- `git diff --check`
+
+Repo-level `bun run verify` was attempted and stopped at the pre-Turbo type-safety ratchet:
+
+- `as unknown as`: 107 current > 77 baseline
+- ``?? 0`` in core/agent/app-core: 381 current > 380 baseline
+
+The ratchet output pointed at unrelated packages such as `packages/feed`, `packages/agent`, `packages/app-core`, and `packages/core`; it did not report the changed inbox or wallet files.
+
+## Evidence Notes
+
+- Real PumpPortal/on-chain transaction: N/A for this local validation because no funded Solana wallet was configured and executing a pump.fun buy would spend real SOL. The code path is covered by router/confirmation tests and build/typecheck.
+- App screenshots/video: N/A because this change does not alter `packages/app` UI; plugin-inbox view registration was regression-tested and package build produced the view bundle.
+- iOS/App Store signing evidence: N/A because this change does not touch iOS bundle IDs, signing, or native release configuration.
+- Live LLM trajectories: N/A for this local validation because `INBOX_LLM_LIVE_TEST` was not enabled and no live model endpoint was configured; the live-LLM test file skipped by design.

--- a/plugins/plugin-inbox/AGENTS.md
+++ b/plugins/plugin-inbox/AGENTS.md
@@ -6,29 +6,40 @@ Unified cross-channel inbox triage with unresolved-item tracking, snooze, archiv
 
 Adds the inbox-zero workflow to an agent: a single `INBOX` umbrella action (op-based dispatch), `INBOX_TRIAGE` + `CROSS_CHANNEL_CONTEXT` providers that surface unresolved threads to the planner each turn, and a registered `/inbox` view for human review. Aggregates threads across email, Discord, Telegram, WhatsApp, Slack, X, Farcaster, iMessage, and similar non-SMS channels. Android SMS stays in `@elizaos/plugin-messages`.
 
-This package is being extracted from `plugin-lifeops`. The current scaffold is a stub — actions return `not_implemented` and providers return empty results, but every handler has a TODO comment pointing at the file in `plugin-lifeops` it will absorb. See `README.md` for the migration mapping.
+This package owns the triage domain carved out of `plugin-lifeops`: the persisted queue, queue operations, providers, schema, migration, and terminal/app view registration. `@elizaos/plugin-personal-assistant` still owns the legacy cross-channel read aggregation route (`GET /api/lifeops/inbox`) and delegates shared triage primitives here.
 
 ## Plugin surface
 
 ### Action
 
-- `INBOX` (`src/actions/inbox.ts`) — single umbrella action with op-based dispatch. Accepted ops: `list`, `triage`, `reply`, `snooze`, `archive`, `approve`. Contexts: `inbox`, `messaging`, `communication`. Each op currently returns a `not_implemented` failure with the source path to port from.
+- `INBOX` (`src/actions/inbox.ts`) — single umbrella action with op-based dispatch. Accepted ops: `list`, `search`, `summarize`, `triage`, `reply`, `snooze`, `archive`, `approve`. `list`/`search`/`summarize` fan out through per-platform fetchers; `triage` reads the persisted unresolved queue; `reply` drafts/sends via MESSAGE triage adapters; `snooze` hides entries until an ISO timestamp; `archive` runs connector archive and resolves on success; `approve` sends the stored draft or suggested response.
 
 ### Providers
 
-- `INBOX_TRIAGE` (`src/providers/inbox-triage.ts`) — position `-4`. Will emit the user's pending cross-channel triage queue.
-- `CROSS_CHANNEL_CONTEXT` (`src/providers/cross-channel-context.ts`) — position `-3`. Will emit recent activity for the current counterparty across other channels.
+- `INBOX_TRIAGE` (`src/providers/inbox-triage.ts`) — position `14`. Emits the owner's pending urgent/needs-reply queue and recent auto-replies from `InboxRepository`.
+- `CROSS_CHANNEL_CONTEXT` (`src/providers/cross-channel-context.ts`) — position `-3`. Emits recent unresolved activity for the current counterparty across other channels.
+
+### Routes
+
+- `GET /api/lifeops/inbox/triage` — list unresolved triage entries, optionally filtered by `classification`, `limit`, and `includeSnoozed`.
+- `POST /api/lifeops/inbox/triage` — classify/persist inbound messages through `InboxService.triage`.
+- `POST /api/lifeops/inbox/:id/reply` — draft or send a connector-backed reply.
+- `POST /api/lifeops/inbox/:id/snooze` — set `snoozed_until`.
+- `POST /api/lifeops/inbox/:id/archive` — archive through the connector adapter and resolve on success.
+- `POST /api/lifeops/inbox/:id/approve` — send the stored draft/suggested response.
 
 ### Schema
 
 - `inboxSchema` (`src/db/schema.ts`) — `pgSchema("app_inbox")` with the three
-  inbox-triage tables carved out of PA's `app_lifeops` (column shape verbatim):
+  inbox-triage tables carved out of PA's `app_lifeops`:
   - `life_inbox_triage_entries` — per-thread triage decisions + draft replies.
   - `life_inbox_triage_examples` — owner-labeled few-shot classification examples.
   - `life_email_unsubscribes` — email unsubscribe attempts + outcomes.
   Registered via the plugin `schema` field; `InboxMigrationService`
   (`src/inbox/migration.ts`) does the non-destructive `app_lifeops -> app_inbox`
-  copy (skip if source missing / target non-empty, never drop the source). PA
+  copy (skip if source missing / target non-empty, never drop the source) and
+  repairs older `app_inbox.life_inbox_triage_entries` tables by adding
+  `snoozed_until` if missing. PA
   auto-registers this plugin (`ensureLifeOpsInboxPluginRegistered`) so the schema
   exists + the migration runs whenever PA is loaded. The gmail sync/projection
   tables (`life_gmail_*`, `life_inbox_messages`) are NOT part of this domain —
@@ -36,7 +47,7 @@ This package is being extracted from `plugin-lifeops`. The current scaffold is a
 
 ### View
 
-- `inbox` — `InboxView` component, path `/inbox`, bundle at `dist/views/bundle.js`. Minimal placeholder (header, channel filter chips, empty thread list) until the full UI ports over.
+- `inbox` — `InboxView` component, path `/inbox`, bundle at `dist/views/bundle.js`. Shows the cross-channel inbox surface using the shared app client.
 
 ## Layout
 
@@ -46,10 +57,18 @@ src/
   plugin.ts                           inboxPlugin definition (action + providers + schema + view)
   types.ts                            TriageDecision, ThreadSummary, channel + decision enums
   actions/
-    inbox.ts                          INBOX umbrella action — op dispatch (STUB)
+    inbox.ts                          INBOX umbrella action — fan-out + triage queue ops
+  routes/
+    inbox-routes.ts                   Triage read/write + reply/snooze/archive/approve HTTP routes
   providers/
-    inbox-triage.ts                   INBOX_TRIAGE provider (STUB)
-    cross-channel-context.ts          CROSS_CHANNEL_CONTEXT provider (STUB)
+    inbox-triage.ts                   INBOX_TRIAGE provider
+    cross-channel-context.ts          CROSS_CHANNEL_CONTEXT provider
+  inbox/
+    service.ts                        InboxService — classify/curate/search/list/digest/resolve/snooze
+    repository.ts                     InboxRepository — raw SQL over app_inbox.life_inbox_triage_*
+    migration.ts                      app_lifeops -> app_inbox copy + additive repair
+    types.ts                          InboundMessage, TriageEntry, TriageClassification, etc.
+    triage-classifier.ts              LLM classification of inbound messages
   db/
     index.ts                          re-exports schema.ts
     schema.ts                         drizzle pgSchema('app_inbox') + 3 tables
@@ -74,13 +93,11 @@ bun run --cwd plugins/plugin-inbox clean        # rm -rf dist
 
 ## Config / env vars
 
-None at the scaffold stage. Channel credentials are read from each provider plugin (`plugin-discord`, `plugin-telegram`, etc.).
+None. Channel credentials are read from each provider plugin (`plugin-discord`, `plugin-telegram`, etc.).
 
 ## How to extend
 
-**Port an op from plugin-lifeops:** open the corresponding `case` block in `src/actions/inbox.ts`, follow the TODO comment to the source file in `plugins/plugin-personal-assistant/`, and replace the `not_implemented` failure with the ported logic. Keep the op enum in `src/types.ts` in sync.
-
-**Add a new op:** add the name to `INBOX_ACTIONS` in `src/types.ts`, add a `case` to the `switch` in `src/actions/inbox.ts`, and (if the op needs new parameters) extend the `parameters` array on `inboxAction`.
+**Add a new op:** add the name to `SUBACTIONS` in `src/actions/inbox.ts`, add a case to the handler or `executeInboxQueueOperation`, and extend the action `parameters` array when the op needs new inputs. Queue ops should go through `InboxRepository` and, for connector dispatch, the shared MESSAGE triage service.
 
 **Add a provider:** create `src/providers/<name>.ts` exporting a `Provider`, then add it to the `providers` array in `src/plugin.ts`.
 
@@ -88,10 +105,10 @@ None at the scaffold stage. Channel credentials are read from each provider plug
 
 ## Conventions / gotchas
 
-- **Scaffold, not feature-complete.** Every action op currently returns a `not_implemented` failure with the source path it should pull from. Treat this package as the registration shell; the live triage logic still runs out of `plugin-lifeops` until the follow-up migration pass.
 - **`@elizaos/plugin-sql` must be loaded first.** The schema registration relies on the runtime's `runtime.db`. The plugin declares this in `dependencies: ["@elizaos/plugin-sql"]`.
 - **No Android SMS.** SMS routing intentionally stays in `plugin-messages`. Do not add SMS channel handling here.
 - **Schema name is `app_inbox`** (not `inbox`) to avoid collisions with any host-app `inbox` table the runtime might also surface.
+- **Snooze is additive.** `snoozed_until` is append-only schema growth on `life_inbox_triage_entries`; migration repairs old targets and maps old `app_lifeops` rows with `NULL AS snoozed_until`.
 - **Two build steps.** The JS/types build (tsup + tsc) and the Vite views build are separate. The views bundle (`dist/views/bundle.js`) is what the view registration's `bundlePath` points to. Both must be run for a complete build.
 - **Peer deps.** React 19 and react-dom 19 are peer dependencies. The host app must provide them.
 - See the root `AGENTS.md` for repo-wide architecture rules, logger requirements, ESM/module standards, and the cloud-frontend visual-review gate (if any of this plugin's UI ends up in `cloud-frontend`).

--- a/plugins/plugin-inbox/CLAUDE.md
+++ b/plugins/plugin-inbox/CLAUDE.md
@@ -6,29 +6,40 @@ Unified cross-channel inbox triage with unresolved-item tracking, snooze, archiv
 
 Adds the inbox-zero workflow to an agent: a single `INBOX` umbrella action (op-based dispatch), `INBOX_TRIAGE` + `CROSS_CHANNEL_CONTEXT` providers that surface unresolved threads to the planner each turn, and a registered `/inbox` view for human review. Aggregates threads across email, Discord, Telegram, WhatsApp, Slack, X, Farcaster, iMessage, and similar non-SMS channels. Android SMS stays in `@elizaos/plugin-messages`.
 
-This package is being extracted from `plugin-lifeops`. The current scaffold is a stub — actions return `not_implemented` and providers return empty results, but every handler has a TODO comment pointing at the file in `plugin-lifeops` it will absorb. See `README.md` for the migration mapping.
+This package owns the triage domain carved out of `plugin-lifeops`: the persisted queue, queue operations, providers, schema, migration, and terminal/app view registration. `@elizaos/plugin-personal-assistant` still owns the legacy cross-channel read aggregation route (`GET /api/lifeops/inbox`) and delegates shared triage primitives here.
 
 ## Plugin surface
 
 ### Action
 
-- `INBOX` (`src/actions/inbox.ts`) — single umbrella action with op-based dispatch. Accepted ops: `list`, `triage`, `reply`, `snooze`, `archive`, `approve`. Contexts: `inbox`, `messaging`, `communication`. Each op currently returns a `not_implemented` failure with the source path to port from.
+- `INBOX` (`src/actions/inbox.ts`) — single umbrella action with op-based dispatch. Accepted ops: `list`, `search`, `summarize`, `triage`, `reply`, `snooze`, `archive`, `approve`. `list`/`search`/`summarize` fan out through per-platform fetchers; `triage` reads the persisted unresolved queue; `reply` drafts/sends via MESSAGE triage adapters; `snooze` hides entries until an ISO timestamp; `archive` runs connector archive and resolves on success; `approve` sends the stored draft or suggested response.
 
 ### Providers
 
-- `INBOX_TRIAGE` (`src/providers/inbox-triage.ts`) — position `-4`. Will emit the user's pending cross-channel triage queue.
-- `CROSS_CHANNEL_CONTEXT` (`src/providers/cross-channel-context.ts`) — position `-3`. Will emit recent activity for the current counterparty across other channels.
+- `INBOX_TRIAGE` (`src/providers/inbox-triage.ts`) — position `14`. Emits the owner's pending urgent/needs-reply queue and recent auto-replies from `InboxRepository`.
+- `CROSS_CHANNEL_CONTEXT` (`src/providers/cross-channel-context.ts`) — position `-3`. Emits recent unresolved activity for the current counterparty across other channels.
+
+### Routes
+
+- `GET /api/lifeops/inbox/triage` — list unresolved triage entries, optionally filtered by `classification`, `limit`, and `includeSnoozed`.
+- `POST /api/lifeops/inbox/triage` — classify/persist inbound messages through `InboxService.triage`.
+- `POST /api/lifeops/inbox/:id/reply` — draft or send a connector-backed reply.
+- `POST /api/lifeops/inbox/:id/snooze` — set `snoozed_until`.
+- `POST /api/lifeops/inbox/:id/archive` — archive through the connector adapter and resolve on success.
+- `POST /api/lifeops/inbox/:id/approve` — send the stored draft/suggested response.
 
 ### Schema
 
 - `inboxSchema` (`src/db/schema.ts`) — `pgSchema("app_inbox")` with the three
-  inbox-triage tables carved out of PA's `app_lifeops` (column shape verbatim):
+  inbox-triage tables carved out of PA's `app_lifeops`:
   - `life_inbox_triage_entries` — per-thread triage decisions + draft replies.
   - `life_inbox_triage_examples` — owner-labeled few-shot classification examples.
   - `life_email_unsubscribes` — email unsubscribe attempts + outcomes.
   Registered via the plugin `schema` field; `InboxMigrationService`
   (`src/inbox/migration.ts`) does the non-destructive `app_lifeops -> app_inbox`
-  copy (skip if source missing / target non-empty, never drop the source). PA
+  copy (skip if source missing / target non-empty, never drop the source) and
+  repairs older `app_inbox.life_inbox_triage_entries` tables by adding
+  `snoozed_until` if missing. PA
   auto-registers this plugin (`ensureLifeOpsInboxPluginRegistered`) so the schema
   exists + the migration runs whenever PA is loaded. The gmail sync/projection
   tables (`life_gmail_*`, `life_inbox_messages`) are NOT part of this domain —
@@ -36,7 +47,7 @@ This package is being extracted from `plugin-lifeops`. The current scaffold is a
 
 ### View
 
-- `inbox` — `InboxView` component, path `/inbox`, bundle at `dist/views/bundle.js`. Minimal placeholder (header, channel filter chips, empty thread list) until the full UI ports over.
+- `inbox` — `InboxView` component, path `/inbox`, bundle at `dist/views/bundle.js`. Shows the cross-channel inbox surface using the shared app client.
 
 ## Layout
 
@@ -46,10 +57,18 @@ src/
   plugin.ts                           inboxPlugin definition (action + providers + schema + view)
   types.ts                            TriageDecision, ThreadSummary, channel + decision enums
   actions/
-    inbox.ts                          INBOX umbrella action — op dispatch (STUB)
+    inbox.ts                          INBOX umbrella action — fan-out + triage queue ops
+  routes/
+    inbox-routes.ts                   Triage read/write + reply/snooze/archive/approve HTTP routes
   providers/
-    inbox-triage.ts                   INBOX_TRIAGE provider (STUB)
-    cross-channel-context.ts          CROSS_CHANNEL_CONTEXT provider (STUB)
+    inbox-triage.ts                   INBOX_TRIAGE provider
+    cross-channel-context.ts          CROSS_CHANNEL_CONTEXT provider
+  inbox/
+    service.ts                        InboxService — classify/curate/search/list/digest/resolve/snooze
+    repository.ts                     InboxRepository — raw SQL over app_inbox.life_inbox_triage_*
+    migration.ts                      app_lifeops -> app_inbox copy + additive repair
+    types.ts                          InboundMessage, TriageEntry, TriageClassification, etc.
+    triage-classifier.ts              LLM classification of inbound messages
   db/
     index.ts                          re-exports schema.ts
     schema.ts                         drizzle pgSchema('app_inbox') + 3 tables
@@ -74,13 +93,11 @@ bun run --cwd plugins/plugin-inbox clean        # rm -rf dist
 
 ## Config / env vars
 
-None at the scaffold stage. Channel credentials are read from each provider plugin (`plugin-discord`, `plugin-telegram`, etc.).
+None. Channel credentials are read from each provider plugin (`plugin-discord`, `plugin-telegram`, etc.).
 
 ## How to extend
 
-**Port an op from plugin-lifeops:** open the corresponding `case` block in `src/actions/inbox.ts`, follow the TODO comment to the source file in `plugins/plugin-personal-assistant/`, and replace the `not_implemented` failure with the ported logic. Keep the op enum in `src/types.ts` in sync.
-
-**Add a new op:** add the name to `INBOX_ACTIONS` in `src/types.ts`, add a `case` to the `switch` in `src/actions/inbox.ts`, and (if the op needs new parameters) extend the `parameters` array on `inboxAction`.
+**Add a new op:** add the name to `SUBACTIONS` in `src/actions/inbox.ts`, add a case to the handler or `executeInboxQueueOperation`, and extend the action `parameters` array when the op needs new inputs. Queue ops should go through `InboxRepository` and, for connector dispatch, the shared MESSAGE triage service.
 
 **Add a provider:** create `src/providers/<name>.ts` exporting a `Provider`, then add it to the `providers` array in `src/plugin.ts`.
 
@@ -88,10 +105,10 @@ None at the scaffold stage. Channel credentials are read from each provider plug
 
 ## Conventions / gotchas
 
-- **Scaffold, not feature-complete.** Every action op currently returns a `not_implemented` failure with the source path it should pull from. Treat this package as the registration shell; the live triage logic still runs out of `plugin-lifeops` until the follow-up migration pass.
 - **`@elizaos/plugin-sql` must be loaded first.** The schema registration relies on the runtime's `runtime.db`. The plugin declares this in `dependencies: ["@elizaos/plugin-sql"]`.
 - **No Android SMS.** SMS routing intentionally stays in `plugin-messages`. Do not add SMS channel handling here.
 - **Schema name is `app_inbox`** (not `inbox`) to avoid collisions with any host-app `inbox` table the runtime might also surface.
+- **Snooze is additive.** `snoozed_until` is append-only schema growth on `life_inbox_triage_entries`; migration repairs old targets and maps old `app_lifeops` rows with `NULL AS snoozed_until`.
 - **Two build steps.** The JS/types build (tsup + tsc) and the Vite views build are separate. The views bundle (`dist/views/bundle.js`) is what the view registration's `bundlePath` points to. Both must be run for a complete build.
 - **Peer deps.** React 19 and react-dom 19 are peer dependencies. The host app must provide them.
 - See the root `AGENTS.md` for repo-wide architecture rules, logger requirements, ESM/module standards, and the cloud-frontend visual-review gate (if any of this plugin's UI ends up in `cloud-frontend`).

--- a/plugins/plugin-inbox/README.md
+++ b/plugins/plugin-inbox/README.md
@@ -12,11 +12,16 @@ Aggregates threads across email, Discord, Telegram, WhatsApp, Slack, X, Farcaste
 
 ### Action
 
-`INBOX` — op-based dispatch. Ops: `list`, `search`, `summarize`.
+`INBOX` — op-based dispatch. Ops: `list`, `search`, `summarize`, `triage`, `reply`, `snooze`, `archive`, `approve`.
 
 - `list` — fan-out fetch across all connected platform adapters (gmail, discord, telegram, signal, imessage, whatsapp), dedupe by message id and thread topic, return merged feed ordered by recency.
 - `search` — search across selected platforms by `query`.
 - `summarize` — return a per-platform count plus a single rolled-up summary.
+- `triage` — list persisted unresolved triage queue entries, optionally filtered by classification.
+- `reply` — draft a connector-backed response, then send after explicit confirmation.
+- `snooze` — hide a triage entry until an ISO timestamp.
+- `archive` — archive through the connector adapter and resolve on success.
+- `approve` — send the stored draft or suggested response.
 
 Fetchers are injectable via `setInboxFetchers` for tests. Owner-only.
 
@@ -27,19 +32,28 @@ Fetchers are injectable via `setInboxFetchers` for tests. Owner-only.
 
 ### Service
 
-`InboxService` (`src/inbox/service.ts`) — `triage()`, `curate()`, `triageWithCuration()`, `search()`, `list()`, `digest()`, `resolve()`. No dependency on `@elizaos/plugin-personal-assistant`.
+`InboxService` (`src/inbox/service.ts`) — `triage()`, `curate()`, `triageWithCuration()`, `search()`, `list()`, `digest()`, `resolve()`, `snooze()`. No dependency on `@elizaos/plugin-personal-assistant`.
+
+### Routes
+
+- `GET /api/lifeops/inbox/triage` — list unresolved entries.
+- `POST /api/lifeops/inbox/triage` — classify/persist inbound messages.
+- `POST /api/lifeops/inbox/:id/reply` — draft or send a reply.
+- `POST /api/lifeops/inbox/:id/snooze` — set `snoozed_until`.
+- `POST /api/lifeops/inbox/:id/archive` — archive and resolve on connector success.
+- `POST /api/lifeops/inbox/:id/approve` — send the stored draft/suggested response.
 
 ### Schema
 
 `pgSchema('app_inbox')` with three tables:
 
-- `triage_decisions` — history of decisions per (thread, decision-event).
-- `snoozed` — threads to re-surface at `wake_at`.
-- `archived` — threads explicitly removed from the active inbox.
+- `life_inbox_triage_entries` — per-thread triage decisions, draft replies, snooze timestamps, and resolution state.
+- `life_inbox_triage_examples` — owner-labeled few-shot examples for triage classification.
+- `life_email_unsubscribes` — unsubscribe attempts and outcomes.
 
 ### View
 
-`/inbox` — `InboxView` component. Minimal placeholder UI (header, channel filter chips, empty thread list) until the full triage drawer / snooze picker / approval queue lands.
+`/inbox` — `InboxView` component for the cross-channel inbox surface.
 
 ## Layout
 
@@ -49,13 +63,15 @@ src/
   plugin.ts                           inboxPlugin Plugin object
   types.ts                            TriageDecision, ThreadSummary, channel + decision enums
   actions/
-    inbox.ts                          INBOX umbrella action (list/search/summarize fan-out)
+    inbox.ts                          INBOX umbrella action (fan-out + triage queue ops)
+  routes/
+    inbox-routes.ts                   Triage read/write + reply/snooze/archive/approve routes
   providers/
     inbox-triage.ts                   inboxTriage provider — pending triage queue (position 14)
     cross-channel-context.ts          crossChannelContext provider — sender cross-channel history (position -3)
   inbox/
-    service.ts                        InboxService — triage/curate/search/list/digest/resolve
-    repository.ts                     InboxRepository — raw SQL over app_lifeops.life_inbox_triage_*
+    service.ts                        InboxService — triage/curate/search/list/digest/resolve/snooze
+    repository.ts                     InboxRepository — raw SQL over app_inbox.life_inbox_triage_*
     types.ts                          InboundMessage, TriageEntry, TriageClassification, etc.
     triage-classifier.ts              LLM classification of inbound messages
     email-curation.ts                 Email curation engine (save/archive/delete decisions)
@@ -95,5 +111,6 @@ None. Channel credentials are read from each provider plugin (`plugin-discord`, 
 - **`@elizaos/plugin-sql` must be loaded first.** The schema registration relies on `runtime.db`.
 - **No Android SMS.** SMS routing intentionally stays in `plugin-messages`. Do not add SMS channel handling here.
 - **Schema name is `app_inbox`** to avoid collision with any host-app `inbox` table the runtime might also surface.
+- **Snooze is additive.** `snoozed_until` is added to `life_inbox_triage_entries`; the migration repairs old targets and maps legacy `app_lifeops` rows with `NULL AS snoozed_until`.
 - **Two build steps.** The JS/types build (tsup + tsc) and the Vite views build are separate. Both must be run for a complete build.
 - See the root `AGENTS.md` for repo-wide architecture rules, logger requirements, ESM/module standards, and the cloud-frontend visual-review gate (if any of this plugin's UI ends up in `cloud-frontend`).

--- a/plugins/plugin-inbox/src/actions/inbox.ts
+++ b/plugins/plugin-inbox/src/actions/inbox.ts
@@ -10,6 +10,11 @@
  *   - `list`       — list recent messages across selected platforms
  *   - `search`     — search across selected platforms by `query`
  *   - `summarize`  — return a per-platform count + a single rolled-up summary
+ *   - `triage`     — list persisted triage queue entries
+ *   - `reply`      — draft or send a connector-backed reply
+ *   - `snooze`     — hide a triage entry until a future timestamp
+ *   - `archive`    — archive through the connector adapter and resolve
+ *   - `approve`    — send the stored draft/suggested response
  *
  * Behavior: fan out to each platform's adapter via the injectable fetcher hook,
  * dedupe by `id` and thread topic, merge into a single result list ordered by
@@ -31,12 +36,24 @@ import type {
   Memory,
   MessageRef,
   MessageSource,
+  ProviderDataRecord,
 } from "@elizaos/core";
 import { getDefaultTriageService, logger } from "@elizaos/core";
+import { InboxRepository } from "../inbox/repository.ts";
+import type { TriageClassification, TriageEntry } from "../inbox/types.ts";
 
 const ACTION_NAME = "INBOX";
 
-const SUBACTIONS = ["list", "search", "summarize"] as const;
+const SUBACTIONS = [
+  "list",
+  "search",
+  "summarize",
+  "triage",
+  "reply",
+  "snooze",
+  "archive",
+  "approve",
+] as const;
 
 type Subaction = (typeof SUBACTIONS)[number];
 
@@ -59,6 +76,14 @@ const PLATFORMS = [
 
 export type InboxPlatform = (typeof PLATFORMS)[number];
 
+const TRIAGE_CLASSIFICATIONS = new Set<TriageClassification>([
+  "ignore",
+  "info",
+  "notify",
+  "needs_reply",
+  "urgent",
+]);
+
 export interface InboxItem {
   readonly id: string;
   readonly platform: InboxPlatform;
@@ -71,7 +96,7 @@ export interface InboxItem {
   readonly unread?: boolean;
 }
 
-interface InboxActionParameters {
+export interface InboxActionParameters {
   subaction?: Subaction | string;
   action?: Subaction | string;
   op?: Subaction | string;
@@ -79,6 +104,17 @@ interface InboxActionParameters {
   since?: string;
   limit?: number;
   query?: string;
+  id?: string;
+  entryId?: string;
+  messageId?: string;
+  body?: string;
+  text?: string;
+  draft?: string;
+  until?: string;
+  snoozedUntil?: string;
+  confirmed?: boolean;
+  classification?: string;
+  includeSnoozed?: boolean;
 }
 
 export interface InboxSummaryEntry {
@@ -95,6 +131,12 @@ export interface InboxResult {
   readonly query?: string;
   readonly since?: string;
   readonly totalBeforeDedupe: number;
+}
+
+export interface InboxQueueOperationResult {
+  readonly success: boolean;
+  readonly text: string;
+  readonly data: ProviderDataRecord;
 }
 
 /**
@@ -300,6 +342,305 @@ function buildSummary(
   });
 }
 
+const MESSAGE_SOURCES = new Set<MessageSource>([
+  "gmail",
+  "discord",
+  "telegram",
+  "twitter",
+  "imessage",
+  "signal",
+  "whatsapp",
+  "browser_bridge",
+]);
+
+function normalizeMessageSource(value: string): MessageSource | null {
+  const normalized = value.trim().toLowerCase();
+  const source =
+    normalized === "x" || normalized === "x_dm" || normalized === "twitter_dm"
+      ? "twitter"
+      : normalized;
+  return MESSAGE_SOURCES.has(source as MessageSource)
+    ? (source as MessageSource)
+    : null;
+}
+
+function parseEntryId(params: InboxActionParameters): string | null {
+  const raw = params.entryId ?? params.id ?? params.messageId;
+  return typeof raw === "string" && raw.trim() ? raw.trim() : null;
+}
+
+function parseReplyBody(params: InboxActionParameters): string | null {
+  const raw = params.body ?? params.text ?? params.draft;
+  return typeof raw === "string" && raw.trim() ? raw.trim() : null;
+}
+
+function parseConfirmation(value: unknown): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    return ["true", "1", "yes", "y", "confirmed"].includes(normalized);
+  }
+  return false;
+}
+
+function parseSnoozeUntil(params: InboxActionParameters): string | null {
+  const raw = params.snoozedUntil ?? params.until;
+  if (typeof raw !== "string" || !raw.trim()) return null;
+  const parsed = Date.parse(raw);
+  if (!Number.isFinite(parsed)) return null;
+  return new Date(parsed).toISOString();
+}
+
+function parseClassification(value: unknown): TriageClassification | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  return TRIAGE_CLASSIFICATIONS.has(normalized as TriageClassification)
+    ? (normalized as TriageClassification)
+    : null;
+}
+
+function requireEntryId(params: InboxActionParameters): string {
+  const entryId = parseEntryId(params);
+  if (!entryId) {
+    throw new Error("entry id is required");
+  }
+  return entryId;
+}
+
+async function loadEntry(
+  repo: InboxRepository,
+  id: string,
+): Promise<TriageEntry> {
+  const entry = await repo.getById(id);
+  if (!entry) {
+    throw new Error(`inbox entry ${id} was not found`);
+  }
+  return entry;
+}
+
+function ensureMessageSource(entry: TriageEntry): MessageSource {
+  const source = normalizeMessageSource(entry.source);
+  if (!source) {
+    throw new Error(
+      `inbox entry ${entry.id} source "${entry.source}" is not supported by MESSAGE dispatch`,
+    );
+  }
+  return source;
+}
+
+function ensureSourceMessageId(entry: TriageEntry): string {
+  if (entry.sourceMessageId) return entry.sourceMessageId;
+  throw new Error(
+    `inbox entry ${entry.id} has no source message id for connector dispatch`,
+  );
+}
+
+function seedMessageRefForEntry(
+  runtime: IAgentRuntime,
+  entry: TriageEntry,
+): void {
+  const source = ensureMessageSource(entry);
+  const messageId = ensureSourceMessageId(entry);
+  const threadId = entry.sourceRoomId ?? entry.sourceMessageId;
+  const service = getDefaultTriageService();
+  if (service.getStore().getMessage(messageId)) return;
+  service.getStore().saveMessage({
+    id: messageId,
+    source,
+    externalId: messageId,
+    from: {
+      identifier: entry.sourceEntityId ?? entry.senderName ?? messageId,
+      ...(entry.senderName ? { displayName: entry.senderName } : {}),
+    },
+    to: [{ identifier: runtime.agentId }],
+    snippet: entry.snippet,
+    body: entry.threadContext?.join("\n") ?? entry.snippet,
+    receivedAtMs: Date.parse(entry.createdAt) || Date.now(),
+    hasAttachments: false,
+    isRead: false,
+    metadata: {
+      inboxEntryId: entry.id,
+      deepLink: entry.deepLink,
+      triageReasoning: entry.triageReasoning,
+    },
+    ...(threadId ? { threadId } : {}),
+    ...(entry.source === "gmail" ? { subject: entry.channelName } : {}),
+    ...(entry.sourceRoomId
+      ? { worldId: entry.sourceRoomId, channelId: entry.sourceRoomId }
+      : {}),
+  });
+}
+
+async function replyToEntry(args: {
+  runtime: IAgentRuntime;
+  repo: InboxRepository;
+  entry: TriageEntry;
+  body: string;
+  confirmed: boolean;
+}): Promise<InboxQueueOperationResult> {
+  seedMessageRefForEntry(args.runtime, args.entry);
+  const service = getDefaultTriageService();
+  const draft = await service.draftReply(
+    args.runtime,
+    ensureSourceMessageId(args.entry),
+    args.body,
+  );
+  await args.repo.updateDraftResponse(args.entry.id, args.body);
+
+  if (!args.confirmed) {
+    return {
+      success: true,
+      text: `Drafted reply for ${args.entry.senderName ?? args.entry.channelName}. Confirm before sending.`,
+      data: {
+        subaction: "reply",
+        requiresConfirmation: true,
+        entryId: args.entry.id,
+        draftId: draft.draftId,
+        preview: draft.preview,
+        source: draft.source,
+      },
+    };
+  }
+
+  const sent = await service.sendDraft(args.runtime, draft.draftId);
+  await args.repo.markResolved(args.entry.id, {
+    draftResponse: args.body,
+    autoReplied: true,
+  });
+  return {
+    success: true,
+    text: `Sent reply on ${sent.source}.`,
+    data: {
+      subaction: "reply",
+      entryId: args.entry.id,
+      draftId: sent.draftId,
+      source: sent.source,
+      externalId: sent.sentExternalId ?? null,
+    },
+  };
+}
+
+async function archiveEntry(
+  runtime: IAgentRuntime,
+  repo: InboxRepository,
+  entry: TriageEntry,
+): Promise<InboxQueueOperationResult> {
+  seedMessageRefForEntry(runtime, entry);
+  const service = getDefaultTriageService();
+  const source = ensureMessageSource(entry);
+  const messageId = ensureSourceMessageId(entry);
+  const result = await service.manage(
+    runtime,
+    messageId,
+    { kind: "archive" },
+    { source },
+  );
+  if (!result.ok) {
+    return {
+      success: false,
+      text: `Could not archive inbox entry ${entry.id}: ${result.reason ?? "adapter rejected archive"}.`,
+      data: {
+        subaction: "archive",
+        entryId: entry.id,
+        error: "ARCHIVE_FAILED",
+        reason: result.reason ?? null,
+      },
+    };
+  }
+  await repo.markResolved(entry.id);
+  return {
+    success: true,
+    text: `Archived ${entry.channelName}.`,
+    data: { subaction: "archive", entryId: entry.id, source },
+  };
+}
+
+export async function executeInboxQueueOperation(args: {
+  runtime: IAgentRuntime;
+  subaction: Extract<
+    Subaction,
+    "triage" | "reply" | "snooze" | "archive" | "approve"
+  >;
+  params: InboxActionParameters;
+}): Promise<InboxQueueOperationResult> {
+  const repo = new InboxRepository(args.runtime);
+  switch (args.subaction) {
+    case "triage": {
+      const limit =
+        typeof args.params.limit === "number" && args.params.limit > 0
+          ? Math.floor(args.params.limit)
+          : 50;
+      const classification = parseClassification(args.params.classification);
+      const entries = classification
+        ? await repo.getByClassification(classification, {
+            limit,
+            includeSnoozed: args.params.includeSnoozed === true,
+          })
+        : await repo.getUnresolved({
+            limit,
+            includeSnoozed: args.params.includeSnoozed === true,
+          });
+      return {
+        success: true,
+        text:
+          entries.length === 0
+            ? "No inbox triage items are pending."
+            : `Loaded ${entries.length} pending inbox triage items.`,
+        data: { subaction: "triage", entries },
+      };
+    }
+    case "snooze": {
+      const id = requireEntryId(args.params);
+      const until = parseSnoozeUntil(args.params);
+      if (!until) {
+        throw new Error("valid snooze timestamp is required");
+      }
+      await loadEntry(repo, id);
+      await repo.snoozeUntil(id, until);
+      return {
+        success: true,
+        text: `Snoozed inbox entry ${id} until ${until}.`,
+        data: { subaction: "snooze", entryId: id, snoozedUntil: until },
+      };
+    }
+    case "archive": {
+      const entry = await loadEntry(repo, requireEntryId(args.params));
+      return archiveEntry(args.runtime, repo, entry);
+    }
+    case "reply": {
+      const entry = await loadEntry(repo, requireEntryId(args.params));
+      const body = parseReplyBody(args.params);
+      if (!body) {
+        throw new Error("reply body is required");
+      }
+      return replyToEntry({
+        runtime: args.runtime,
+        repo,
+        entry,
+        body,
+        confirmed: parseConfirmation(args.params.confirmed),
+      });
+    }
+    case "approve": {
+      const entry = await loadEntry(repo, requireEntryId(args.params));
+      const body =
+        parseReplyBody(args.params) ??
+        entry.draftResponse ??
+        entry.suggestedResponse;
+      if (!body) {
+        throw new Error("approved entry has no draft or suggested response");
+      }
+      return replyToEntry({
+        runtime: args.runtime,
+        repo,
+        entry,
+        body,
+        confirmed: true,
+      });
+    }
+  }
+}
+
 /**
  * Owner-access guard for INBOX. Mirrors the LifeOps `hasLifeOpsAccess`
  * predicate exactly: reject when the runtime agent id or the message entity id
@@ -360,9 +701,9 @@ export const inboxAction: Action & {
     "surface:internal",
   ],
   description:
-    "Inbox: Gmail, Slack, Discord, Telegram, Signal, iMessage, WhatsApp. Merge recency feed. Subactions: list, search, summarize.",
+    "Inbox: Gmail, Slack, Discord, Telegram, Signal, iMessage, WhatsApp. Merge recency feed and operate the persisted triage queue. Subactions: list, search, summarize, triage, reply, snooze, archive, approve.",
   descriptionCompressed:
-    "INBOX list|search|summarize gmail|slack|discord|telegram|signal|imessage|whatsapp",
+    "INBOX list|search|summarize|triage|reply|snooze|archive|approve gmail|slack|discord|telegram|signal|imessage|whatsapp",
   routingHint:
     'cross-channel inbox ("show inbox", "all messages", "search every channel", "summarize inboxes") -> INBOX; per-channel -> MESSAGE',
   contexts: ["inbox", "messaging", "cross-channel"],
@@ -372,7 +713,8 @@ export const inboxAction: Action & {
   parameters: [
     {
       name: "action",
-      description: "Inbox op: list | search | summarize.",
+      description:
+        "Inbox op: list | search | summarize | triage | reply | snooze | archive | approve.",
       schema: { type: "string" as const, enum: [...SUBACTIONS] },
     },
     {
@@ -396,6 +738,27 @@ export const inboxAction: Action & {
       description: "Required for search. Free-form query.",
       schema: { type: "string" as const },
     },
+    {
+      name: "entryId",
+      description:
+        "Persisted triage entry id for reply, snooze, archive, or approve.",
+      schema: { type: "string" as const },
+    },
+    {
+      name: "body",
+      description: "Reply body for reply/approve.",
+      schema: { type: "string" as const },
+    },
+    {
+      name: "until",
+      description: "Snooze-until timestamp for snooze. ISO-8601.",
+      schema: { type: "string" as const },
+    },
+    {
+      name: "confirmed",
+      description: "Explicit owner confirmation for sending reply/approve.",
+      schema: { type: "boolean" as const },
+    },
   ],
   examples,
   handler: async (
@@ -416,9 +779,44 @@ export const inboxAction: Action & {
     if (!subaction) {
       return {
         success: false,
-        text: "Tell me which operation: list, search, or summarize.",
+        text: "Tell me which operation: list, search, summarize, triage, reply, snooze, archive, or approve.",
         data: { error: "MISSING_SUBACTION" },
       };
+    }
+
+    if (
+      subaction === "triage" ||
+      subaction === "reply" ||
+      subaction === "snooze" ||
+      subaction === "archive" ||
+      subaction === "approve"
+    ) {
+      try {
+        const result = await executeInboxQueueOperation({
+          runtime,
+          subaction,
+          params,
+        });
+        await callback?.({
+          text: result.text,
+          source: "action",
+          action: ACTION_NAME,
+        });
+        return {
+          success: result.success,
+          text: result.text,
+          data: result.data,
+        };
+      } catch (error) {
+        const text =
+          error instanceof Error ? error.message : "Inbox operation failed.";
+        await callback?.({ text, source: "action", action: ACTION_NAME });
+        return {
+          success: false,
+          text,
+          data: { subaction, error: "INBOX_OPERATION_FAILED" },
+        };
+      }
     }
 
     const platforms = resolvePlatforms(params.platforms);

--- a/plugins/plugin-inbox/src/db/schema.ts
+++ b/plugins/plugin-inbox/src/db/schema.ts
@@ -38,6 +38,7 @@ export const lifeInboxTriageEntries = inboxSchema.table(
     suggestedResponse: text("suggested_response"),
     draftResponse: text("draft_response"),
     autoReplied: boolean("auto_replied").notNull().default(false),
+    snoozedUntil: text("snoozed_until"),
     resolved: boolean("resolved").notNull().default(false),
     resolvedAt: text("resolved_at"),
     createdAt: text("created_at").notNull(),

--- a/plugins/plugin-inbox/src/inbox/migration.test.ts
+++ b/plugins/plugin-inbox/src/inbox/migration.test.ts
@@ -52,6 +52,12 @@ describe("InboxMigration", () => {
         /INSERT INTO .*app_inbox.*life_inbox_triage_entries/s.test(s),
       ),
     ).toBe(true);
+    expect(log.some((s) => /NULL AS snoozed_until/.test(s))).toBe(true);
+    expect(
+      log.some((s) =>
+        /ALTER TABLE app_inbox\."life_inbox_triage_entries"/.test(s),
+      ),
+    ).toBe(true);
     // never touches the source
     expect(log.some((s) => /DROP|ALTER .*app_lifeops/.test(s))).toBe(false);
   });

--- a/plugins/plugin-inbox/src/inbox/migration.test.ts
+++ b/plugins/plugin-inbox/src/inbox/migration.test.ts
@@ -42,6 +42,7 @@ describe("InboxMigration", () => {
       [
         [/to_regclass/, [{ present: true }]],
         [/SELECT NOT EXISTS \(SELECT 1 FROM/, [{ empty: true }]],
+        [/information_schema\.columns/, [{ present: false }]],
       ],
       log,
     );
@@ -62,12 +63,31 @@ describe("InboxMigration", () => {
     expect(log.some((s) => /DROP|ALTER .*app_lifeops/.test(s))).toBe(false);
   });
 
+  it("preserves source snooze values when the legacy source has the column", async () => {
+    const log: string[] = [];
+    const exec = fakeExec(
+      [
+        [/to_regclass/, [{ present: true }]],
+        [/SELECT NOT EXISTS \(SELECT 1 FROM/, [{ empty: true }]],
+        [/information_schema\.columns/, [{ present: true }]],
+      ],
+      log,
+    );
+
+    const r = await migrateInboxTable(exec, "life_inbox_triage_entries");
+
+    expect(r.outcome).toBe("copied");
+    expect(log.some((s) => /s\."snoozed_until"/.test(s))).toBe(true);
+    expect(log.some((s) => /NULL AS snoozed_until/.test(s))).toBe(false);
+  });
+
   it("creates the target schema and processes every inbox table", async () => {
     const log: string[] = [];
     const exec = fakeExec(
       [
         [/to_regclass/, [{ present: true }]],
         [/SELECT NOT EXISTS/, [{ empty: true }]],
+        [/information_schema\.columns/, [{ present: false }]],
       ],
       log,
     );

--- a/plugins/plugin-inbox/src/inbox/migration.ts
+++ b/plugins/plugin-inbox/src/inbox/migration.ts
@@ -16,9 +16,10 @@
  *   3. Otherwise copy every source row that is not already present in the target
  *      (a doubly-safe NOT EXISTS guard on the primary key).
  *
- * The source table is NEVER dropped or altered. The source and target share the
- * exact column shape (PA's `app_lifeops` drizzle def and this plugin's
- * `app_inbox` def are column-identical), so the `SELECT s.*` copy is safe.
+ * The source table is NEVER dropped or altered. `life_inbox_triage_entries`
+ * maps columns explicitly so old `app_lifeops` rows copy into the newer
+ * additive `snoozed_until` target column as NULL; the other two tables still
+ * use the identical-column `SELECT s.*` copy.
  */
 
 import { type IAgentRuntime, logger, Service } from "@elizaos/core";
@@ -50,6 +51,33 @@ function quoteIdent(name: string): string {
   return `"${name.replace(/"/g, '""')}"`;
 }
 
+const TRIAGE_ENTRY_COLUMNS = [
+  "id",
+  "agent_id",
+  "source",
+  "source_room_id",
+  "source_entity_id",
+  "source_message_id",
+  "channel_name",
+  "channel_type",
+  "deep_link",
+  "classification",
+  "urgency",
+  "confidence",
+  "snippet",
+  "sender_name",
+  "thread_context",
+  "triage_reasoning",
+  "suggested_response",
+  "draft_response",
+  "auto_replied",
+  "snoozed_until",
+  "resolved",
+  "resolved_at",
+  "created_at",
+  "updated_at",
+] as const;
+
 async function sourceTableExists(
   exec: SqlExecutor,
   table: MigratedInboxTable,
@@ -70,10 +98,22 @@ async function targetTableIsEmpty(
   return rows[0]?.empty === true || rows[0]?.empty === "true";
 }
 
+async function repairTargetTable(
+  exec: SqlExecutor,
+  table: MigratedInboxTable,
+): Promise<void> {
+  if (table !== "life_inbox_triage_entries") return;
+  await exec(
+    `ALTER TABLE ${TARGET_SCHEMA}.${quoteIdent(table)}
+       ADD COLUMN IF NOT EXISTS snoozed_until TEXT`,
+  );
+}
+
 export async function migrateInboxTable(
   exec: SqlExecutor,
   table: MigratedInboxTable,
 ): Promise<TableMigrationResult> {
+  await repairTargetTable(exec, table);
   if (!(await sourceTableExists(exec, table))) {
     return { table, outcome: "source-missing" };
   }
@@ -83,6 +123,22 @@ export async function migrateInboxTable(
 
   const target = `${TARGET_SCHEMA}.${quoteIdent(table)}`;
   const source = `${SOURCE_SCHEMA}.${quoteIdent(table)}`;
+  if (table === "life_inbox_triage_entries") {
+    const columns = TRIAGE_ENTRY_COLUMNS.map(quoteIdent).join(", ");
+    const sourceColumns = TRIAGE_ENTRY_COLUMNS.map((column) =>
+      column === "snoozed_until"
+        ? "NULL AS snoozed_until"
+        : `s.${quoteIdent(column)}`,
+    ).join(", ");
+    await exec(
+      `INSERT INTO ${target} (${columns})
+         SELECT ${sourceColumns} FROM ${source} AS s
+         WHERE NOT EXISTS (
+           SELECT 1 FROM ${target} AS t WHERE t.id = s.id
+         )`,
+    );
+    return { table, outcome: "copied" };
+  }
   await exec(
     `INSERT INTO ${target}
        SELECT s.* FROM ${source} AS s

--- a/plugins/plugin-inbox/src/inbox/migration.ts
+++ b/plugins/plugin-inbox/src/inbox/migration.ts
@@ -18,8 +18,8 @@
  *
  * The source table is NEVER dropped or altered. `life_inbox_triage_entries`
  * maps columns explicitly so old `app_lifeops` rows copy into the newer
- * additive `snoozed_until` target column as NULL; the other two tables still
- * use the identical-column `SELECT s.*` copy.
+ * additive `snoozed_until` target column as NULL when the source predates that
+ * column; the other two tables still use the identical-column `SELECT s.*` copy.
  */
 
 import { type IAgentRuntime, logger, Service } from "@elizaos/core";
@@ -98,6 +98,23 @@ async function targetTableIsEmpty(
   return rows[0]?.empty === true || rows[0]?.empty === "true";
 }
 
+async function sourceColumnExists(
+  exec: SqlExecutor,
+  table: MigratedInboxTable,
+  column: string,
+): Promise<boolean> {
+  const rows = await exec(
+    `SELECT EXISTS (
+       SELECT 1
+       FROM information_schema.columns
+       WHERE table_schema = '${SOURCE_SCHEMA}'
+         AND table_name = '${table}'
+         AND column_name = '${column}'
+     ) AS present`,
+  );
+  return rows[0]?.present === true || rows[0]?.present === "true";
+}
+
 async function repairTargetTable(
   exec: SqlExecutor,
   table: MigratedInboxTable,
@@ -124,10 +141,17 @@ export async function migrateInboxTable(
   const target = `${TARGET_SCHEMA}.${quoteIdent(table)}`;
   const source = `${SOURCE_SCHEMA}.${quoteIdent(table)}`;
   if (table === "life_inbox_triage_entries") {
+    const hasSourceSnoozedUntil = await sourceColumnExists(
+      exec,
+      table,
+      "snoozed_until",
+    );
     const columns = TRIAGE_ENTRY_COLUMNS.map(quoteIdent).join(", ");
     const sourceColumns = TRIAGE_ENTRY_COLUMNS.map((column) =>
       column === "snoozed_until"
-        ? "NULL AS snoozed_until"
+        ? hasSourceSnoozedUntil
+          ? `s.${quoteIdent(column)}`
+          : "NULL AS snoozed_until"
         : `s.${quoteIdent(column)}`,
     ).join(", ");
     await exec(

--- a/plugins/plugin-inbox/src/inbox/repository.ts
+++ b/plugins/plugin-inbox/src/inbox/repository.ts
@@ -109,6 +109,7 @@ function parseTriageEntry(row: Record<string, unknown>): TriageEntry {
     suggestedResponse: toText(row.suggested_response) || null,
     draftResponse: toText(row.draft_response) || null,
     autoReplied: toBoolean(row.auto_replied, false),
+    snoozedUntil: toText(row.snoozed_until) || null,
     resolved: toBoolean(row.resolved, false),
     resolvedAt: toText(row.resolved_at) || null,
     createdAt: toText(row.created_at),
@@ -228,6 +229,7 @@ export class InboxRepository {
       suggestedResponse: opts.suggestedResponse ?? null,
       draftResponse: null,
       autoReplied: false,
+      snoozedUntil: null,
       resolved: false,
       resolvedAt: null,
       createdAt: now,
@@ -235,13 +237,20 @@ export class InboxRepository {
     };
   }
 
-  async getUnresolved(opts?: { limit?: number }): Promise<TriageEntry[]> {
+  async getUnresolved(opts?: {
+    limit?: number;
+    includeSnoozed?: boolean;
+  }): Promise<TriageEntry[]> {
     const limit = opts?.limit ?? 50;
+    const snoozeClause = opts?.includeSnoozed
+      ? ""
+      : `AND (snoozed_until IS NULL OR snoozed_until <= ${sqlText(isoNow())})`;
     const rows = await executeRawSql(
       this.runtime,
       `SELECT * FROM app_inbox.life_inbox_triage_entries
        WHERE agent_id = ${sqlText(this.agentId)}
          AND resolved = FALSE
+         ${snoozeClause}
        ORDER BY
          CASE urgency WHEN 'high' THEN 0 WHEN 'medium' THEN 1 ELSE 2 END,
          created_at DESC
@@ -255,9 +264,15 @@ export class InboxRepository {
     senderName?: string | null;
     excludeSource?: string | null;
     limit?: number;
+    includeSnoozed?: boolean;
   }): Promise<TriageEntry[]> {
     const limit = opts.limit ?? 50;
     const clauses = [`agent_id = ${sqlText(this.agentId)}`, "resolved = FALSE"];
+    if (!opts.includeSnoozed) {
+      clauses.push(
+        `(snoozed_until IS NULL OR snoozed_until <= ${sqlText(isoNow())})`,
+      );
+    }
 
     if (opts.excludeSource) {
       clauses.push(`source != ${sqlText(opts.excludeSource)}`);
@@ -293,17 +308,26 @@ export class InboxRepository {
 
   async getByClassification(
     classification: TriageClassification,
-    opts?: { limit?: number; unresolvedOnly?: boolean },
+    opts?: {
+      limit?: number;
+      unresolvedOnly?: boolean;
+      includeSnoozed?: boolean;
+    },
   ): Promise<TriageEntry[]> {
     const limit = opts?.limit ?? 50;
     const unresolvedOnly = opts?.unresolvedOnly !== false;
     const resolvedClause = unresolvedOnly ? "AND resolved = FALSE" : "";
+    const snoozeClause =
+      unresolvedOnly && !opts?.includeSnoozed
+        ? `AND (snoozed_until IS NULL OR snoozed_until <= ${sqlText(isoNow())})`
+        : "";
     const rows = await executeRawSql(
       this.runtime,
       `SELECT * FROM app_inbox.life_inbox_triage_entries
        WHERE agent_id = ${sqlText(this.agentId)}
          AND classification = ${sqlText(classification)}
          ${resolvedClause}
+         ${snoozeClause}
        ORDER BY created_at DESC
        LIMIT ${limit}`,
     );
@@ -369,6 +393,40 @@ export class InboxRepository {
       this.runtime,
       `UPDATE app_inbox.life_inbox_triage_entries
        SET ${sets.join(", ")}
+       WHERE id = ${sqlText(id)} AND agent_id = ${sqlText(this.agentId)}`,
+    );
+  }
+
+  async updateDraftResponse(id: string, draftResponse: string): Promise<void> {
+    const now = isoNow();
+    await executeRawSql(
+      this.runtime,
+      `UPDATE app_inbox.life_inbox_triage_entries
+       SET draft_response = ${sqlText(draftResponse)},
+           updated_at = ${sqlText(now)}
+       WHERE id = ${sqlText(id)} AND agent_id = ${sqlText(this.agentId)}`,
+    );
+  }
+
+  async snoozeUntil(id: string, snoozedUntil: string): Promise<void> {
+    const now = isoNow();
+    await executeRawSql(
+      this.runtime,
+      `UPDATE app_inbox.life_inbox_triage_entries
+       SET snoozed_until = ${sqlText(snoozedUntil)},
+           resolved = FALSE,
+           updated_at = ${sqlText(now)}
+       WHERE id = ${sqlText(id)} AND agent_id = ${sqlText(this.agentId)}`,
+    );
+  }
+
+  async clearSnooze(id: string): Promise<void> {
+    const now = isoNow();
+    await executeRawSql(
+      this.runtime,
+      `UPDATE app_inbox.life_inbox_triage_entries
+       SET snoozed_until = NULL,
+           updated_at = ${sqlText(now)}
        WHERE id = ${sqlText(id)} AND agent_id = ${sqlText(this.agentId)}`,
     );
   }

--- a/plugins/plugin-inbox/src/inbox/service.ts
+++ b/plugins/plugin-inbox/src/inbox/service.ts
@@ -409,6 +409,11 @@ export class InboxService {
     );
   }
 
+  /** Snooze a triage entry until a future ISO timestamp. */
+  async snooze(id: string, snoozedUntil: string): Promise<void> {
+    await this.repository.snoozeUntil(id, snoozedUntil);
+  }
+
   /** Non-ignored triage entries created since `sinceIso`, urgency-ordered. */
   async digest(sinceIso: string): Promise<TriageEntry[]> {
     return this.repository.getRecentForDigest(sinceIso);

--- a/plugins/plugin-inbox/src/inbox/types.ts
+++ b/plugins/plugin-inbox/src/inbox/types.ts
@@ -117,6 +117,7 @@ export interface TriageEntry {
   suggestedResponse: string | null;
   draftResponse: string | null;
   autoReplied: boolean;
+  snoozedUntil: string | null;
   resolved: boolean;
   resolvedAt: string | null;
   createdAt: string;

--- a/plugins/plugin-inbox/src/plugin.ts
+++ b/plugins/plugin-inbox/src/plugin.ts
@@ -5,6 +5,7 @@ import { inboxDbSchema } from "./db/schema.ts";
 import { InboxMigrationService } from "./inbox/migration.ts";
 import { crossChannelContextProvider } from "./providers/cross-channel-context.ts";
 import { inboxTriageProvider } from "./providers/inbox-triage.ts";
+import { inboxRoutes } from "./routes/inbox-routes.ts";
 
 export const inboxPlugin: Plugin = {
   name: "@elizaos/plugin-inbox",
@@ -15,6 +16,7 @@ export const inboxPlugin: Plugin = {
   services: [InboxMigrationService],
   actions: [inboxAction],
   providers: [inboxTriageProvider, crossChannelContextProvider],
+  routes: inboxRoutes,
   views: [
     {
       id: "inbox",

--- a/plugins/plugin-inbox/src/routes/inbox-routes.ts
+++ b/plugins/plugin-inbox/src/routes/inbox-routes.ts
@@ -1,0 +1,165 @@
+import type {
+  IAgentRuntime,
+  Route,
+  RouteHandlerContext,
+  RouteHandlerResult,
+} from "@elizaos/core";
+import {
+  executeInboxQueueOperation,
+  type InboxQueueOperationResult,
+} from "../actions/inbox.ts";
+import { InboxService } from "../inbox/service.ts";
+import type { InboundMessage, TriageClassification } from "../inbox/types.ts";
+
+type InboxRouteOperation = "reply" | "snooze" | "archive" | "approve";
+
+const TRIAGE_CLASSIFICATIONS = new Set<TriageClassification>([
+  "ignore",
+  "info",
+  "notify",
+  "needs_reply",
+  "urgent",
+]);
+
+function json(status: number, body: unknown): RouteHandlerResult {
+  return { status, body };
+}
+
+function bodyRecord(body: unknown): Record<string, unknown> {
+  return body && typeof body === "object" && !Array.isArray(body)
+    ? (body as Record<string, unknown>)
+    : {};
+}
+
+function queryBool(value: unknown): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value !== "string") return false;
+  return ["1", "true", "yes", "on"].includes(value.trim().toLowerCase());
+}
+
+function queryInt(value: unknown, fallback: number): number {
+  if (typeof value !== "string") return fallback;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+}
+
+function firstQuery(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function routeParams(
+  ctx: RouteHandlerContext,
+  operation?: InboxRouteOperation,
+): Record<string, unknown> {
+  const body = bodyRecord(ctx.body);
+  return {
+    ...body,
+    entryId: ctx.params.id ?? body.entryId ?? body.id,
+    ...(operation ? { action: operation, subaction: operation } : {}),
+  };
+}
+
+async function runOperation(
+  runtime: IAgentRuntime,
+  operation: InboxRouteOperation,
+  params: Record<string, unknown>,
+): Promise<RouteHandlerResult> {
+  let result: InboxQueueOperationResult;
+  try {
+    result = await executeInboxQueueOperation({
+      runtime,
+      subaction: operation,
+      params,
+    });
+  } catch (error) {
+    return json(400, {
+      ok: false,
+      error: error instanceof Error ? error.message : "Inbox operation failed.",
+    });
+  }
+  return json(result.success ? 200 : 409, {
+    ok: result.success,
+    text: result.text,
+    ...result.data,
+  });
+}
+
+async function handleTriageRead(
+  ctx: RouteHandlerContext,
+): Promise<RouteHandlerResult> {
+  const service = new InboxService(ctx.runtime);
+  const classification = firstQuery(ctx.query.classification);
+  const limit = queryInt(firstQuery(ctx.query.limit), 50);
+  const includeSnoozed = queryBool(firstQuery(ctx.query.includeSnoozed));
+  const entries =
+    classification &&
+    TRIAGE_CLASSIFICATIONS.has(classification.trim() as TriageClassification)
+      ? await service
+          .getRepository()
+          .getByClassification(classification.trim() as TriageClassification, {
+            limit,
+            includeSnoozed,
+          })
+      : await service.getRepository().getUnresolved({ limit, includeSnoozed });
+  return json(200, { ok: true, entries });
+}
+
+async function handleTriageWrite(
+  ctx: RouteHandlerContext,
+): Promise<RouteHandlerResult> {
+  const body = bodyRecord(ctx.body);
+  const messages = body.messages;
+  if (!Array.isArray(messages)) {
+    return json(400, { ok: false, error: "messages array is required" });
+  }
+  const service = new InboxService(ctx.runtime);
+  const result = await service.triage(messages as InboundMessage[], {
+    classifyOnly: body.classifyOnly === true,
+    ...(typeof body.ownerContext === "string"
+      ? { ownerContext: body.ownerContext }
+      : {}),
+    ...(typeof body.exampleLimit === "number"
+      ? { exampleLimit: body.exampleLimit }
+      : {}),
+  });
+  return json(200, { ok: true, ...result });
+}
+
+async function inboxRouteHandler(
+  ctx: RouteHandlerContext,
+): Promise<RouteHandlerResult> {
+  const path = ctx.path;
+  if (path === "/api/lifeops/inbox/triage") {
+    return ctx.method === "POST"
+      ? handleTriageWrite(ctx)
+      : handleTriageRead(ctx);
+  }
+  if (path.endsWith("/reply")) {
+    return runOperation(ctx.runtime, "reply", routeParams(ctx, "reply"));
+  }
+  if (path.endsWith("/snooze")) {
+    return runOperation(ctx.runtime, "snooze", routeParams(ctx, "snooze"));
+  }
+  if (path.endsWith("/archive")) {
+    return runOperation(ctx.runtime, "archive", routeParams(ctx, "archive"));
+  }
+  if (path.endsWith("/approve")) {
+    return runOperation(ctx.runtime, "approve", routeParams(ctx, "approve"));
+  }
+  return json(404, { ok: false, error: "Inbox route not found" });
+}
+
+const inboxRouteSpecs: Array<{ type: Route["type"]; path: string }> = [
+  { type: "GET", path: "/api/lifeops/inbox/triage" },
+  { type: "POST", path: "/api/lifeops/inbox/triage" },
+  { type: "POST", path: "/api/lifeops/inbox/:id/reply" },
+  { type: "POST", path: "/api/lifeops/inbox/:id/snooze" },
+  { type: "POST", path: "/api/lifeops/inbox/:id/archive" },
+  { type: "POST", path: "/api/lifeops/inbox/:id/approve" },
+];
+
+export const inboxRoutes: Route[] = inboxRouteSpecs.map((spec) => ({
+  ...spec,
+  rawPath: true,
+  routeHandler: inboxRouteHandler,
+}));

--- a/plugins/plugin-inbox/src/routes/inbox-routes.ts
+++ b/plugins/plugin-inbox/src/routes/inbox-routes.ts
@@ -128,6 +128,10 @@ async function handleTriageWrite(
 async function inboxRouteHandler(
   ctx: RouteHandlerContext,
 ): Promise<RouteHandlerResult> {
+  if (ctx.isTrustedLocal !== true) {
+    return json(403, { ok: false, error: "Inbox routes are owner-only" });
+  }
+
   const path = ctx.path;
   if (path === "/api/lifeops/inbox/triage") {
     return ctx.method === "POST"

--- a/plugins/plugin-inbox/test/inbox-action.test.ts
+++ b/plugins/plugin-inbox/test/inbox-action.test.ts
@@ -45,6 +45,28 @@ function makeRuntime(): IAgentRuntime {
   } as unknown as IAgentRuntime;
 }
 
+function makeDbRuntime(rowsFor: (sql: string) => unknown): {
+  runtime: IAgentRuntime;
+  calls: Array<{ sql: string }>;
+} {
+  const calls: Array<{ sql: string }> = [];
+  const runtime = {
+    ...makeRuntime(),
+    agentId: "11111111-1111-1111-1111-111111111111" as UUID,
+    adapter: {
+      db: {
+        execute: async (query: { queryChunks: Array<{ value?: unknown }> }) => {
+          const chunk = query.queryChunks[0]?.value;
+          const sql = Array.isArray(chunk) ? String(chunk[0]) : String(chunk);
+          calls.push({ sql });
+          return rowsFor(sql);
+        },
+      },
+    },
+  } as unknown as IAgentRuntime;
+  return { runtime, calls };
+}
+
 function makeMessage(text = "show my inbox"): Memory {
   return {
     id: "msg-inbox-1" as UUID,
@@ -83,6 +105,38 @@ function makeItem(
   };
 }
 
+function makeTriageRow(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    id: "entry-1",
+    agent_id: "11111111-1111-1111-1111-111111111111",
+    source: "gmail",
+    source_room_id: null,
+    source_entity_id: "alice@example.com",
+    source_message_id: "gmail-msg-1",
+    channel_name: "Email from Alice",
+    channel_type: "email",
+    deep_link: null,
+    classification: "needs_reply",
+    urgency: "high",
+    confidence: 0.9,
+    snippet: "Can you confirm the launch date?",
+    sender_name: "Alice",
+    thread_context: null,
+    triage_reasoning: "asks a direct question",
+    suggested_response: "Yes, Friday.",
+    draft_response: null,
+    auto_replied: false,
+    snoozed_until: null,
+    resolved: false,
+    resolved_at: null,
+    created_at: "2026-06-17T10:00:00.000Z",
+    updated_at: "2026-06-17T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
 describe("INBOX umbrella action — cross-channel inbox", () => {
   beforeEach(() => {
     __resetInboxFetchersForTests();
@@ -106,6 +160,8 @@ describe("INBOX umbrella action — cross-channel inbox", () => {
     it("rejects calls with no subaction selector", async () => {
       const result = await callInbox(makeRuntime(), makeMessage(), {});
       expect(result.success).toBe(false);
+      expect(result.text).toContain("triage");
+      expect(result.text).toContain("approve");
       expect(result.data).toMatchObject({ error: "MISSING_SUBACTION" });
     });
 
@@ -190,7 +246,7 @@ describe("INBOX umbrella action — cross-channel inbox", () => {
       };
       expect(data.totalBeforeDedupe).toBe(2);
       expect(data.items).toHaveLength(1);
-      expect(data.items[0]!.id).toBe("g-2");
+      expect(data.items[0]?.id).toBe("g-2");
     });
   });
 
@@ -215,8 +271,8 @@ describe("INBOX umbrella action — cross-channel inbox", () => {
       });
       expect(result.success).toBe(true);
       expect(gmailFetcher).toHaveBeenCalledTimes(1);
-      const fetcherArgs = gmailFetcher.mock.calls[0]![0];
-      expect(fetcherArgs.query).toBe("launch plan");
+      const fetcherArgs = gmailFetcher.mock.calls[0]?.[0];
+      expect(fetcherArgs?.query).toBe("launch plan");
     });
   });
 
@@ -295,6 +351,55 @@ describe("INBOX umbrella action — cross-channel inbox", () => {
       const data = result.data as { items: unknown[] };
       expect(data.items).toHaveLength(0);
       expect(result.text).toContain("empty");
+    });
+  });
+
+  describe("triage queue operations", () => {
+    it("lists persisted unresolved triage entries and hides snoozed rows by default", async () => {
+      const { runtime, calls } = makeDbRuntime((sql) =>
+        sql.includes("life_inbox_triage_entries")
+          ? [makeTriageRow({ id: "entry-1" })]
+          : [],
+      );
+
+      const result = await callInbox(runtime, makeMessage(), {
+        subaction: "triage",
+        limit: 5,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.text).toContain("Loaded 1");
+      const data = result.data as { entries: Array<{ id: string }> };
+      expect(data.entries[0]?.id).toBe("entry-1");
+      const select = calls[0]?.sql ?? "";
+      expect(select).toContain("resolved = FALSE");
+      expect(select).toContain("snoozed_until IS NULL");
+      expect(select).toContain("LIMIT 5");
+    });
+
+    it("snoozes a persisted triage entry until the provided timestamp", async () => {
+      const { runtime, calls } = makeDbRuntime((sql) => {
+        if (sql.startsWith("SELECT")) return [makeTriageRow({ id: "entry-1" })];
+        return [];
+      });
+
+      const result = await callInbox(runtime, makeMessage(), {
+        subaction: "snooze",
+        entryId: "entry-1",
+        until: "2026-07-02T00:00:00-04:00",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toMatchObject({
+        subaction: "snooze",
+        entryId: "entry-1",
+        snoozedUntil: "2026-07-02T04:00:00.000Z",
+      });
+      const update = calls.find((call) => call.sql.startsWith("UPDATE"));
+      expect(update?.sql).toContain(
+        "snoozed_until = '2026-07-02T04:00:00.000Z'",
+      );
+      expect(update?.sql).toContain("resolved = FALSE");
     });
   });
 });

--- a/plugins/plugin-inbox/test/inbox-repository.test.ts
+++ b/plugins/plugin-inbox/test/inbox-repository.test.ts
@@ -60,6 +60,7 @@ function triageRow(
     suggested_response: "Sure, will do.",
     draft_response: null,
     auto_replied: false,
+    snoozed_until: null,
     resolved: false,
     resolved_at: null,
     created_at: "2026-06-17T10:00:00.000Z",
@@ -120,8 +121,29 @@ describe("InboxRepository", () => {
 
     const select = env.calls[0]?.sql ?? "";
     expect(select).toContain("resolved = FALSE");
+    expect(select).toContain("snoozed_until IS NULL");
     expect(select).toContain("CASE urgency WHEN 'high' THEN 0");
     expect(select).toContain("LIMIT 25");
+  });
+
+  it("can include snoozed unresolved rows when explicitly requested", async () => {
+    env = makeRuntime((sql) => {
+      if (sql.includes("life_inbox_triage_entries")) {
+        return [
+          triageRow({
+            id: "snoozed",
+            snoozed_until: "2099-01-01T00:00:00.000Z",
+          }),
+        ];
+      }
+      return [];
+    });
+    const repo = new InboxRepository(env.runtime);
+    const rows = await repo.getUnresolved({ includeSnoozed: true });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.snoozedUntil).toBe("2099-01-01T00:00:00.000Z");
+    expect(env.calls[0]?.sql).not.toContain("snoozed_until IS NULL");
   });
 
   it("getByClassification filters on classification and unresolved", async () => {
@@ -178,6 +200,26 @@ describe("InboxRepository", () => {
     expect(update?.sql).toContain("resolved = TRUE");
     expect(update?.sql).toContain("draft_response = 'done'");
     expect(update?.sql).toContain("auto_replied = TRUE");
+    expect(update?.sql).toContain("WHERE id = 'row-1'");
+  });
+
+  it("updateDraftResponse persists a draft without resolving the entry", async () => {
+    const repo = new InboxRepository(env.runtime);
+    await repo.updateDraftResponse("row-1", "Draft reply");
+
+    const update = env.calls.find((c) => c.sql.startsWith("UPDATE"));
+    expect(update?.sql).toContain("draft_response = 'Draft reply'");
+    expect(update?.sql).not.toContain("resolved = TRUE");
+    expect(update?.sql).toContain("WHERE id = 'row-1'");
+  });
+
+  it("snoozeUntil stores the wake timestamp and keeps the entry unresolved", async () => {
+    const repo = new InboxRepository(env.runtime);
+    await repo.snoozeUntil("row-1", "2026-07-02T04:00:00.000Z");
+
+    const update = env.calls.find((c) => c.sql.startsWith("UPDATE"));
+    expect(update?.sql).toContain("snoozed_until = '2026-07-02T04:00:00.000Z'");
+    expect(update?.sql).toContain("resolved = FALSE");
     expect(update?.sql).toContain("WHERE id = 'row-1'");
   });
 

--- a/plugins/plugin-inbox/test/inbox-routes.test.ts
+++ b/plugins/plugin-inbox/test/inbox-routes.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/actions/inbox.ts", () => ({
+  executeInboxQueueOperation: vi.fn(),
+}));
+
+vi.mock("../src/inbox/service.ts", () => ({
+  InboxService: class {
+    constructor() {
+      throw new Error("InboxService should not be constructed");
+    }
+  },
+}));
+
+function makeContext(overrides: Record<string, unknown> = {}) {
+  return {
+    body: undefined,
+    params: {},
+    query: {},
+    headers: {},
+    method: "GET",
+    path: "/api/lifeops/inbox/triage",
+    runtime: { agentId: "agent-inbox-test" },
+    inProcess: false,
+    isTrustedLocal: false,
+    ...overrides,
+  };
+}
+
+describe("inbox HTTP routes", () => {
+  it("rejects authenticated non-local callers before inbox route handling", async () => {
+    const { inboxRoutes } = await import("../src/routes/inbox-routes.ts");
+    const route = inboxRoutes.find(
+      (candidate) =>
+        candidate.type === "GET" &&
+        candidate.path === "/api/lifeops/inbox/triage",
+    );
+    expect(route?.routeHandler).toBeDefined();
+
+    const result = await route?.routeHandler?.(makeContext());
+
+    expect(result).toEqual({
+      status: 403,
+      body: { ok: false, error: "Inbox routes are owner-only" },
+    });
+  });
+});

--- a/plugins/plugin-inbox/test/inbox-service.test.ts
+++ b/plugins/plugin-inbox/test/inbox-service.test.ts
@@ -108,6 +108,7 @@ function triageRow(
     suggested_response: null,
     draft_response: null,
     auto_replied: false,
+    snoozed_until: null,
     resolved: false,
     resolved_at: null,
     created_at: "2026-06-17T10:00:00.000Z",

--- a/plugins/plugin-inbox/test/inbox-triage-provider.test.ts
+++ b/plugins/plugin-inbox/test/inbox-triage-provider.test.ts
@@ -45,6 +45,7 @@ function triageRow(
     suggested_response: null,
     draft_response: null,
     auto_replied: false,
+    snoozed_until: null,
     resolved: false,
     resolved_at: null,
     created_at: "2026-06-17T10:00:00.000Z",

--- a/plugins/plugin-inbox/test/plugin-views.test.ts
+++ b/plugins/plugin-inbox/test/plugin-views.test.ts
@@ -48,4 +48,20 @@ describe("inboxPlugin view registration", () => {
     expect(inboxPlugin.views?.[0]?.componentExport).toBe(InboxView.name);
     expect(typeof InboxView).toBe("function");
   });
+
+  it("registers the triage and queue operation HTTP routes", () => {
+    const paths = (inboxPlugin.routes ?? []).map((route) => ({
+      type: route.type,
+      path: route.path,
+    }));
+
+    expect(paths).toEqual([
+      { type: "GET", path: "/api/lifeops/inbox/triage" },
+      { type: "POST", path: "/api/lifeops/inbox/triage" },
+      { type: "POST", path: "/api/lifeops/inbox/:id/reply" },
+      { type: "POST", path: "/api/lifeops/inbox/:id/snooze" },
+      { type: "POST", path: "/api/lifeops/inbox/:id/archive" },
+      { type: "POST", path: "/api/lifeops/inbox/:id/approve" },
+    ]);
+  });
 });

--- a/plugins/plugin-wallet/AGENTS.md
+++ b/plugins/plugin-wallet/AGENTS.md
@@ -16,12 +16,13 @@ Adds a unified wallet action+provider surface to an Eliza agent, replacing the p
 | `WALLET` | `swap` | Token swap via Li.Fi (EVM) or Jupiter (Solana). |
 | `WALLET` | `bridge` | Cross-chain transfer via Li.Fi or CCTP. |
 | `WALLET` | `gov` | On-chain governance: propose, vote, queue, execute. |
+| `WALLET` | `pump_fun_buy` | Buy a pump.fun token on Solana via PumpPortal trade-local, local signing, browser coin-page open, and Solana RPC submission. |
 | `WALLET` | `token_info` | Read-only token/market data (DexScreener, Birdeye, CoinGecko). |
 | `WALLET` | `search_address` | Birdeye wallet/portfolio lookup by address. |
 
-Similes handled: `SWAP`, `SWAP_SOLANA`, `TRANSFER`, `TRANSFER_TOKEN`, `WALLET_SWAP`, `WALLET_TRANSFER`, `CROSS_CHAIN_TRANSFER`, `PREPARE_TRANSFER`, `WALLET_ACTION`, `WALLET_GOV`, `TOKEN_INFO`, `BIRDEYE_LOOKUP`, `BIRDEYE_SEARCH`, `WALLET_SEARCH_ADDRESS`.
+Similes handled: `SWAP`, `SWAP_SOLANA`, `TRANSFER`, `TRANSFER_TOKEN`, `WALLET_SWAP`, `WALLET_TRANSFER`, `CROSS_CHAIN_TRANSFER`, `PREPARE_TRANSFER`, `WALLET_ACTION`, `WALLET_GOV`, `PUMP_FUN_BUY`, `PUMPFUN_BUY`, `TOKEN_INFO`, `BIRDEYE_LOOKUP`, `BIRDEYE_SEARCH`, `WALLET_SEARCH_ADDRESS`.
 
-All on-chain subactions (`transfer`, `swap`, `bridge`, `gov`) require a user confirmation turn before execution. `mode=prepare` (default) stages without signing. Setting `mode=execute` does **not** bypass the gate — submission only happens after a confirmed reply turn. `dryRun=true` returns metadata without signing.
+All on-chain subactions (`transfer`, `swap`, `bridge`, `gov`, `pump_fun_buy`) require a user confirmation turn before execution. `mode=prepare` (default) stages without signing. Setting `mode=execute` does **not** bypass the gate — submission only happens after a confirmed reply turn. `dryRun=true` returns metadata without signing.
 
 **Providers:**
 
@@ -71,7 +72,7 @@ plugins/plugin-wallet/
     browser-shim/              Browser environment shim (build-shim.ts, shim.template.js)
     chains/
       wallet-action.ts         walletRouterAction (WALLET action, all subactions)
-      registry.ts              registerDefaultWalletChainHandlers (EVM + Solana)
+      registry.ts              registerDefaultWalletChainHandlers (EVM + Solana + pump.fun)
       evm/
         index.ts               evmPlugin (sub-plugin composed into walletPlugin)
         service.ts             EVMService
@@ -158,6 +159,9 @@ All read via `runtime.getSetting()` (or `process.env` fallback where noted).
 | `STEWARD_TENANT_ID` | Steward backend | Tenant/user identifier. |
 | `SOLANA_RPC_URL` | Solana features | RPC endpoint; skips Solana init if absent. |
 | `SOLANA_NO_ACTIONS` | No | Set to `true` to skip Solana action registration. |
+| `PUMPFUN_TRADE_LOCAL_URL` | No | PumpPortal local transaction API. Defaults to `https://pumpportal.fun/api/trade-local`. |
+| `PUMPFUN_PRIORITY_FEE_SOL` | No | Priority fee in SOL for `pump_fun_buy`. Defaults to `0.00005`. |
+| `PUMPFUN_POOL` | No | PumpPortal pool selector. Defaults to `auto`. |
 | `BIRDEYE_API_KEY` | Birdeye features | Direct API key for Birdeye. Falls back to Eliza Cloud route if absent. |
 | `BIRDEYE_WALLET_ADDR` | No | Enables `agentPortfolioProvider` for this wallet address. |
 | `BIRDEYE_NO_TRENDING` | No | Set to `true` to skip trending provider registration. |
@@ -192,8 +196,9 @@ Extend `src/analytics/birdeye/service.ts`. The service proxies all calls through
 
 ## Conventions / gotchas
 
-- **Financial confirmation gate.** All on-chain subactions (`transfer`, `swap`, `bridge`, `gov`) go through `gateWalletFinancialExecution` in `src/security/wallet-financial-confirmation.ts`, which calls `requireConfirmation` from `@elizaos/core`. The LLM cannot bypass this by passing `mode=execute` alone — a confirmed reply turn is always required. Do not remove or short-circuit this gate.
+- **Financial confirmation gate.** All on-chain subactions (`transfer`, `swap`, `bridge`, `gov`, `pump_fun_buy`) go through `gateWalletFinancialExecution` in `src/security/wallet-financial-confirmation.ts`, which calls `requireConfirmation` from `@elizaos/core`. The LLM cannot bypass this by passing `mode=execute` alone — a confirmed reply turn is always required. Do not remove or short-circuit this gate.
 - **`WalletBackend` is the only signing path.** Providers and actions must never read raw private key env vars directly. Go through `WalletBackendService.getWalletBackend()` → `WalletBackend`.
+- **pump.fun buy path.** `pump_fun_buy` is a Solana handler alias (`pumpfun`, `pump.fun`, `pump-fun`, `pump`) that requires `toToken`/`token` as a valid Solana mint and `amount` as SOL. It requests a serialized transaction from PumpPortal trade-local, signs through `WalletBackend.getSolanaSigner()` when available (falling back to the existing local `getWalletKey` Solana path), opens the token page through the optional browser service when available, then submits through `SOLANA_RPC_URL`.
 - **`handleWalletRoutes` is dependency-injected.** It imports nothing from `@elizaos/agent` to avoid a cycle. All agent-internal helpers (runtime lookup, auth, route helpers) are passed via `WalletRouteContext.deps` by `@elizaos/agent`'s server wiring.
 - **Sub-plugins.** `evmPlugin` and `solanaPlugin` are composed into `walletPlugin` in `plugin.ts`. They are not intended to be loaded directly; always depend on `@elizaos/plugin-wallet`.
 - **`SDK-LICENSE`** covers the `src/sdk/` subtree (originally from agent-wallet-sdk, MIT).

--- a/plugins/plugin-wallet/CLAUDE.md
+++ b/plugins/plugin-wallet/CLAUDE.md
@@ -16,12 +16,13 @@ Adds a unified wallet action+provider surface to an Eliza agent, replacing the p
 | `WALLET` | `swap` | Token swap via Li.Fi (EVM) or Jupiter (Solana). |
 | `WALLET` | `bridge` | Cross-chain transfer via Li.Fi or CCTP. |
 | `WALLET` | `gov` | On-chain governance: propose, vote, queue, execute. |
+| `WALLET` | `pump_fun_buy` | Buy a pump.fun token on Solana via PumpPortal trade-local, local signing, browser coin-page open, and Solana RPC submission. |
 | `WALLET` | `token_info` | Read-only token/market data (DexScreener, Birdeye, CoinGecko). |
 | `WALLET` | `search_address` | Birdeye wallet/portfolio lookup by address. |
 
-Similes handled: `SWAP`, `SWAP_SOLANA`, `TRANSFER`, `TRANSFER_TOKEN`, `WALLET_SWAP`, `WALLET_TRANSFER`, `CROSS_CHAIN_TRANSFER`, `PREPARE_TRANSFER`, `WALLET_ACTION`, `WALLET_GOV`, `TOKEN_INFO`, `BIRDEYE_LOOKUP`, `BIRDEYE_SEARCH`, `WALLET_SEARCH_ADDRESS`.
+Similes handled: `SWAP`, `SWAP_SOLANA`, `TRANSFER`, `TRANSFER_TOKEN`, `WALLET_SWAP`, `WALLET_TRANSFER`, `CROSS_CHAIN_TRANSFER`, `PREPARE_TRANSFER`, `WALLET_ACTION`, `WALLET_GOV`, `PUMP_FUN_BUY`, `PUMPFUN_BUY`, `TOKEN_INFO`, `BIRDEYE_LOOKUP`, `BIRDEYE_SEARCH`, `WALLET_SEARCH_ADDRESS`.
 
-All on-chain subactions (`transfer`, `swap`, `bridge`, `gov`) require a user confirmation turn before execution. `mode=prepare` (default) stages without signing. Setting `mode=execute` does **not** bypass the gate — submission only happens after a confirmed reply turn. `dryRun=true` returns metadata without signing.
+All on-chain subactions (`transfer`, `swap`, `bridge`, `gov`, `pump_fun_buy`) require a user confirmation turn before execution. `mode=prepare` (default) stages without signing. Setting `mode=execute` does **not** bypass the gate — submission only happens after a confirmed reply turn. `dryRun=true` returns metadata without signing.
 
 **Providers:**
 
@@ -71,7 +72,7 @@ plugins/plugin-wallet/
     browser-shim/              Browser environment shim (build-shim.ts, shim.template.js)
     chains/
       wallet-action.ts         walletRouterAction (WALLET action, all subactions)
-      registry.ts              registerDefaultWalletChainHandlers (EVM + Solana)
+      registry.ts              registerDefaultWalletChainHandlers (EVM + Solana + pump.fun)
       evm/
         index.ts               evmPlugin (sub-plugin composed into walletPlugin)
         service.ts             EVMService
@@ -158,6 +159,9 @@ All read via `runtime.getSetting()` (or `process.env` fallback where noted).
 | `STEWARD_TENANT_ID` | Steward backend | Tenant/user identifier. |
 | `SOLANA_RPC_URL` | Solana features | RPC endpoint; skips Solana init if absent. |
 | `SOLANA_NO_ACTIONS` | No | Set to `true` to skip Solana action registration. |
+| `PUMPFUN_TRADE_LOCAL_URL` | No | PumpPortal local transaction API. Defaults to `https://pumpportal.fun/api/trade-local`. |
+| `PUMPFUN_PRIORITY_FEE_SOL` | No | Priority fee in SOL for `pump_fun_buy`. Defaults to `0.00005`. |
+| `PUMPFUN_POOL` | No | PumpPortal pool selector. Defaults to `auto`. |
 | `BIRDEYE_API_KEY` | Birdeye features | Direct API key for Birdeye. Falls back to Eliza Cloud route if absent. |
 | `BIRDEYE_WALLET_ADDR` | No | Enables `agentPortfolioProvider` for this wallet address. |
 | `BIRDEYE_NO_TRENDING` | No | Set to `true` to skip trending provider registration. |
@@ -192,8 +196,9 @@ Extend `src/analytics/birdeye/service.ts`. The service proxies all calls through
 
 ## Conventions / gotchas
 
-- **Financial confirmation gate.** All on-chain subactions (`transfer`, `swap`, `bridge`, `gov`) go through `gateWalletFinancialExecution` in `src/security/wallet-financial-confirmation.ts`, which calls `requireConfirmation` from `@elizaos/core`. The LLM cannot bypass this by passing `mode=execute` alone — a confirmed reply turn is always required. Do not remove or short-circuit this gate.
+- **Financial confirmation gate.** All on-chain subactions (`transfer`, `swap`, `bridge`, `gov`, `pump_fun_buy`) go through `gateWalletFinancialExecution` in `src/security/wallet-financial-confirmation.ts`, which calls `requireConfirmation` from `@elizaos/core`. The LLM cannot bypass this by passing `mode=execute` alone — a confirmed reply turn is always required. Do not remove or short-circuit this gate.
 - **`WalletBackend` is the only signing path.** Providers and actions must never read raw private key env vars directly. Go through `WalletBackendService.getWalletBackend()` → `WalletBackend`.
+- **pump.fun buy path.** `pump_fun_buy` is a Solana handler alias (`pumpfun`, `pump.fun`, `pump-fun`, `pump`) that requires `toToken`/`token` as a valid Solana mint and `amount` as SOL. It requests a serialized transaction from PumpPortal trade-local, signs through `WalletBackend.getSolanaSigner()` when available (falling back to the existing local `getWalletKey` Solana path), opens the token page through the optional browser service when available, then submits through `SOLANA_RPC_URL`.
 - **`handleWalletRoutes` is dependency-injected.** It imports nothing from `@elizaos/agent` to avoid a cycle. All agent-internal helpers (runtime lookup, auth, route helpers) are passed via `WalletRouteContext.deps` by `@elizaos/agent`'s server wiring.
 - **Sub-plugins.** `evmPlugin` and `solanaPlugin` are composed into `walletPlugin` in `plugin.ts`. They are not intended to be loaded directly; always depend on `@elizaos/plugin-wallet`.
 - **`SDK-LICENSE`** covers the `src/sdk/` subtree (originally from agent-wallet-sdk, MIT).

--- a/plugins/plugin-wallet/README.md
+++ b/plugins/plugin-wallet/README.md
@@ -14,6 +14,7 @@ Replaces the former fan-out across `plugin-evm`, `plugin-solana`, `plugin-raydiu
 | `swap` | Token swap via Li.Fi (EVM) or Jupiter (Solana). |
 | `bridge` | Cross-chain transfer via Li.Fi route finding or CCTP (Circle's native USDC bridge). |
 | `gov` | On-chain governance: propose, vote, queue, execute via OpenZeppelin Governor. |
+| `pump_fun_buy` | Buy a pump.fun token on Solana through PumpPortal trade-local, local signing, and Solana RPC submission. |
 
 All write operations default to `mode=prepare` (stages the transaction but does not sign or send). The agent asks the user to confirm before submitting. `dryRun=true` returns metadata without signing.
 
@@ -68,6 +69,9 @@ Additional optional variables:
 | `BIRDEYE_WALLET_ADDR` | Enables portfolio provider for a specific address |
 | `BIRDEYE_NO_TRENDING` | Disable trending provider |
 | `ELIZA_AGENT_WALLET_AUTO_ENABLE` | Set to `0` to disable auto-enable |
+| `PUMPFUN_TRADE_LOCAL_URL` | Override PumpPortal local transaction API; default `https://pumpportal.fun/api/trade-local` |
+| `PUMPFUN_PRIORITY_FEE_SOL` | Priority fee in SOL for `pump_fun_buy`; default `0.00005` |
+| `PUMPFUN_POOL` | PumpPortal pool selector for `pump_fun_buy`; default `auto` |
 | `X402_SUPPORTED_NETWORKS` | Comma-separated networks for x402 micropayments |
 | `X402_GLOBAL_DAILY_LIMIT` | Daily USDC spending cap for x402 |
 | `X402_PER_REQUEST_MAX` | Per-request USDC cap for x402 |
@@ -80,7 +84,9 @@ The plugin auto-enables when any signing path is present (EVM or Solana private 
 
 ## Security model
 
-All on-chain writes (`transfer`, `swap`, `bridge`, `gov`) require an explicit user confirmation before execution. The LLM cannot authorize a transaction by itself — a confirmed human reply turn is always required. EVM recipient addresses on transfers are additionally validated via `assertEvmTransferRecipientAuthorized`.
+All on-chain writes (`transfer`, `swap`, `bridge`, `gov`, `pump_fun_buy`) require an explicit user confirmation before execution. The LLM cannot authorize a transaction by itself — a confirmed human reply turn is always required. EVM recipient addresses on transfers are additionally validated via `assertEvmTransferRecipientAuthorized`.
+
+`pump_fun_buy` accepts `toToken`, `token`, `tokenAddress`, `mint`, `query`, or `address` as the pump.fun/Solana token mint, with `amount` interpreted as SOL. When a browser service is loaded, execution opens `https://pump.fun/coin/<mint>` before requesting the serialized transaction from PumpPortal and signing through `WalletBackend.getSolanaSigner()` or the existing local Solana wallet path.
 
 `src/audit/audit-log.ts` defines `AuditLogRow` plus hash-chain helpers for action validate/handler lifecycle events and signing requests. Runtime callers own where those rows are stored.
 

--- a/plugins/plugin-wallet/src/chains/__tests__/wallet-router.test.ts
+++ b/plugins/plugin-wallet/src/chains/__tests__/wallet-router.test.ts
@@ -300,6 +300,61 @@ describe("wallet router action", () => {
     expect(result?.data?.chain).toBe("base");
   });
 
+  it("routes confirmed pump.fun buys through the pump.fun Solana handler", async () => {
+    const { runtime, service } = createService();
+    const pumpfun = handler(
+      "pumpfun",
+      "pump.fun",
+      "pump.fun-solana",
+      "solana",
+      ["pump_fun_buy"],
+    );
+    service.registerChainHandler(pumpfun);
+
+    const mint = "So11111111111111111111111111111111111111112";
+    const result = await runConfirmed(runtime, {
+      action: "pump.fun buy",
+      token: mint,
+      amount: "0.01",
+      mode: "execute",
+    });
+
+    expect(result?.success).toBe(true);
+    expect(pumpfun.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subaction: "pump_fun_buy",
+        toToken: mint,
+        amount: "0.01",
+      }),
+      expect.any(Object),
+    );
+    expect(result?.data?.chain).toBe("pumpfun");
+    expect(result?.data?.signature).toBe("soltest");
+  });
+
+  it("rejects pump.fun buys without a token mint before confirmation", async () => {
+    const { runtime, service } = createService();
+    const pumpfun = handler(
+      "pumpfun",
+      "pump.fun",
+      "pump.fun-solana",
+      "solana",
+      ["pump_fun_buy"],
+    );
+    service.registerChainHandler(pumpfun);
+
+    const result = await run(runtime, {
+      action: "PUMPFUN_BUY",
+      amount: "0.01",
+      mode: "execute",
+    });
+
+    expect(result?.success).toBe(false);
+    expect(result?.data?.error).toBe("INVALID_PARAMS");
+    expect(String(result?.text)).toContain("pump.fun token mint");
+    expect(pumpfun.execute).not.toHaveBeenCalled();
+  });
+
   it("does not execute when LLM sets confirmed:true without a user yes reply", async () => {
     const { runtime, service } = createService();
     const base = handler("base", "Base", "8453", "evm");

--- a/plugins/plugin-wallet/src/chains/registry.ts
+++ b/plugins/plugin-wallet/src/chains/registry.ts
@@ -28,6 +28,7 @@ import type {
   WalletRouterExecution,
   WalletRouterParams,
 } from "../types/wallet-router.js";
+import type { SolanaSigner } from "../wallet/backend.js";
 import { buildSendTxParams } from "./evm/actions/helpers";
 import { SwapAction } from "./evm/actions/swap";
 import { TransferAction } from "./evm/actions/transfer";
@@ -42,6 +43,9 @@ import type { SolanaService } from "./solana/service";
 
 const SOL_MINT = "So11111111111111111111111111111111111111112";
 const SOLANA_DEFAULT_RPC = "https://api.mainnet-beta.solana.com";
+const PUMPFUN_TRADE_LOCAL_URL = "https://pumpportal.fun/api/trade-local";
+const PUMPFUN_DEFAULT_PRIORITY_FEE_SOL = 0.00005;
+const PUMPFUN_DEFAULT_SLIPPAGE_BPS = 1_000;
 
 function getRuntimeSetting(runtime: IAgentRuntime, key: string): string | null {
   const value = runtime.getSetting(key);
@@ -386,6 +390,219 @@ function getSolanaConnection(runtime: IAgentRuntime): Connection {
   return new Connection(rpcUrl);
 }
 
+type BrowserAutomationService = {
+  execute: (
+    command: Record<string, unknown>,
+    targetId?: string,
+  ) => Promise<unknown>;
+};
+
+function isBrowserAutomationService(
+  value: unknown,
+): value is BrowserAutomationService {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    typeof (value as { execute?: unknown }).execute === "function"
+  );
+}
+
+function isSolanaMintAddress(value: string): boolean {
+  try {
+    const pubkey = new PublicKey(value);
+    return pubkey.toBase58() === value;
+  } catch {
+    return false;
+  }
+}
+
+async function openPumpFunCoinPage(
+  runtime: IAgentRuntime,
+  mint: string,
+): Promise<{ opened: boolean; result?: unknown; error?: string }> {
+  const browser = runtime.getService("browser");
+  if (!isBrowserAutomationService(browser)) {
+    return { opened: false, error: "browser service is not available" };
+  }
+  const url = `https://pump.fun/coin/${encodeURIComponent(mint)}`;
+  try {
+    const result = await browser.execute({
+      subaction: "navigate",
+      url,
+      show: true,
+    });
+    return { opened: true, result };
+  } catch (error) {
+    return {
+      opened: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function getNumberSetting(
+  runtime: IAgentRuntime,
+  key: string,
+  fallback: number,
+): number {
+  const raw = getRuntimeSetting(runtime, key);
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+async function pumpPortalResponseBytes(response: Response): Promise<Buffer> {
+  const contentType = response.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    const json = (await response.json()) as {
+      error?: unknown;
+      errors?: unknown;
+      message?: unknown;
+    };
+    throw new Error(
+      `PumpPortal trade-local failed: ${String(json.error ?? json.errors ?? json.message ?? "unexpected JSON response")}`,
+    );
+  }
+  return Buffer.from(await response.arrayBuffer());
+}
+
+async function resolvePumpFunSigner(context: WalletRouterContext): Promise<{
+  readonly publicKey: PublicKey;
+  signTransaction(tx: VersionedTransaction): Promise<VersionedTransaction>;
+}> {
+  if (context.walletBackend) {
+    if (!context.walletBackend.canSign("solana")) {
+      throw new Error(
+        "Solana signing is not available in this wallet backend.",
+      );
+    }
+    const signer: SolanaSigner = context.walletBackend.getSolanaSigner();
+    return {
+      publicKey: signer.publicKey,
+      signTransaction: async (tx) => {
+        const signed = await signer.signTransaction(tx);
+        if (!(signed instanceof VersionedTransaction)) {
+          throw new Error("PumpPortal returned a versioned transaction.");
+        }
+        return signed;
+      },
+    };
+  }
+
+  const { keypair } = await getWalletKey(context.runtime, true);
+  if (!keypair) {
+    throw new Error("Solana keypair is not available.");
+  }
+  return {
+    publicKey: keypair.publicKey,
+    signTransaction: async (tx) => {
+      const copy = VersionedTransaction.deserialize(tx.serialize());
+      copy.sign([keypair]);
+      return copy;
+    },
+  };
+}
+
+async function executePumpFunBuy(
+  params: WalletRouterParams,
+  context: WalletRouterContext,
+): Promise<WalletRouterExecution> {
+  const mint = params.toToken?.trim();
+  if (!mint || !isSolanaMintAddress(mint)) {
+    throw new Error("toToken must be a valid pump.fun token mint address.");
+  }
+  const amountSol = Number(params.amount);
+  if (!Number.isFinite(amountSol) || amountSol <= 0) {
+    throw new Error("amount must be a positive SOL amount.");
+  }
+
+  const signer = await resolvePumpFunSigner(context);
+
+  const browser = await openPumpFunCoinPage(context.runtime, mint);
+  const tradeLocalUrl =
+    getRuntimeSetting(context.runtime, "PUMPFUN_TRADE_LOCAL_URL") ??
+    PUMPFUN_TRADE_LOCAL_URL;
+  const priorityFee = getNumberSetting(
+    context.runtime,
+    "PUMPFUN_PRIORITY_FEE_SOL",
+    PUMPFUN_DEFAULT_PRIORITY_FEE_SOL,
+  );
+  const pool = getRuntimeSetting(context.runtime, "PUMPFUN_POOL") ?? "auto";
+  const slippage = (params.slippageBps ?? PUMPFUN_DEFAULT_SLIPPAGE_BPS) / 100;
+
+  const response = await fetch(tradeLocalUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      publicKey: signer.publicKey.toBase58(),
+      action: "buy",
+      mint,
+      amount: amountSol,
+      denominatedInSol: "true",
+      slippage,
+      priorityFee,
+      pool,
+    }),
+  });
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "");
+    throw new Error(
+      `PumpPortal trade-local failed (${response.status})${detail ? `: ${detail.slice(0, 240)}` : ""}`,
+    );
+  }
+
+  const transaction = VersionedTransaction.deserialize(
+    await pumpPortalResponseBytes(response),
+  );
+  const signedTransaction = await signer.signTransaction(transaction);
+
+  const connection = getSolanaConnection(context.runtime);
+  const signature = await connection.sendTransaction(signedTransaction, {
+    skipPreflight: false,
+    maxRetries: 3,
+    preflightCommitment: "confirmed",
+  });
+
+  const latestBlockhash = await connection.getLatestBlockhash();
+  const confirmation = await connection.confirmTransaction(
+    {
+      signature,
+      blockhash: latestBlockhash.blockhash,
+      lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+    },
+    "confirmed",
+  );
+  if (confirmation.value.err) {
+    throw new Error(
+      `Pump.fun buy failed: ${JSON.stringify(confirmation.value.err)}`,
+    );
+  }
+
+  return {
+    status: "submitted",
+    chain: "pumpfun",
+    chainId: "pump.fun-solana",
+    subaction: "pump_fun_buy",
+    dryRun: false,
+    mode: params.mode,
+    signature,
+    from: signer.publicKey.toBase58(),
+    amount: params.amount,
+    fromToken: "SOL",
+    toToken: mint,
+    metadata: {
+      pumpFunUrl: `https://pump.fun/coin/${mint}`,
+      browser,
+      tradeLocalUrl,
+      denominatedInSol: true,
+      slippage,
+      priorityFee,
+      pool,
+    },
+  };
+}
+
 async function getSolanaTokenDecimals(
   connection: Connection,
   mintAddress: string,
@@ -651,6 +868,43 @@ function createSolanaHandler(): WalletChainHandler {
   };
 }
 
+function createPumpFunHandler(): WalletChainHandler {
+  return {
+    chainId: "pump.fun-solana",
+    chain: "pumpfun",
+    name: "pump.fun",
+    aliases: ["pumpfun", "pump.fun", "pump-fun", "pump"],
+    supportedActions: ["pump_fun_buy"],
+    tokens: [
+      {
+        symbol: "SOL",
+        address: SOL_MINT,
+        decimals: 9,
+        native: true,
+      },
+    ],
+    signer: {
+      required: true,
+      kind: "solana",
+      source: "WalletBackend Solana signer or SOLANA_PRIVATE_KEY",
+      description:
+        "Required for locally signing the PumpPortal trade-local transaction after owner confirmation.",
+    },
+    dryRun: {
+      supported: true,
+      supportedActions: ["pump_fun_buy"],
+      description:
+        "Dry-run/prepare returns pump.fun handler metadata without signing.",
+    },
+    async execute(params, context) {
+      if (params.subaction === "pump_fun_buy") {
+        return executePumpFunBuy(params, context);
+      }
+      throw new Error(`pump.fun does not support ${params.subaction}.`);
+    },
+  };
+}
+
 export function registerDefaultWalletChainHandlers(
   service: WalletBackendService,
   runtime: IAgentRuntime,
@@ -664,5 +918,6 @@ export function registerDefaultWalletChainHandlers(
   );
   if (!solanaNoActions) {
     service.registerChainHandler(createSolanaHandler());
+    service.registerChainHandler(createPumpFunHandler());
   }
 }

--- a/plugins/plugin-wallet/src/chains/wallet-action.ts
+++ b/plugins/plugin-wallet/src/chains/wallet-action.ts
@@ -52,6 +52,12 @@ const LEGACY_TRANSFER_ACTIONS = new Set([
 
 const LEGACY_BRIDGE_ACTIONS = new Set(["CROSS_CHAIN_TRANSFER"]);
 const LEGACY_GOV_ACTIONS = new Set(["WALLET_GOV"]);
+const LEGACY_PUMP_FUN_ACTIONS = new Set([
+  "PUMP_FUN_BUY",
+  "PUMPFUN_BUY",
+  "BUY_PUMP_FUN",
+  "BUY_PUMPFUN",
+]);
 const LEGACY_TOKEN_INFO_ACTIONS = new Set(["TOKEN_INFO"]);
 const LEGACY_SEARCH_ADDRESS_ACTIONS = new Set([
   "BIRDEYE_SEARCH",
@@ -68,6 +74,7 @@ const WALLET_SUBACTIONS = [
   "swap",
   "bridge",
   "gov",
+  "pump_fun_buy",
   ...ANALYTICS_SUBACTIONS,
 ] as const;
 type WalletSubaction = (typeof WALLET_SUBACTIONS)[number];
@@ -128,6 +135,7 @@ function legacySubactionFromName(value: unknown): WalletSubaction | undefined {
   if (LEGACY_TRANSFER_ACTIONS.has(upper)) return "transfer";
   if (LEGACY_BRIDGE_ACTIONS.has(upper)) return "bridge";
   if (LEGACY_GOV_ACTIONS.has(upper)) return "gov";
+  if (LEGACY_PUMP_FUN_ACTIONS.has(upper)) return "pump_fun_buy";
   if (LEGACY_TOKEN_INFO_ACTIONS.has(upper)) return "token_info";
   if (LEGACY_SEARCH_ADDRESS_ACTIONS.has(upper)) return "search_address";
   return undefined;
@@ -144,7 +152,7 @@ function normalizeSubactionValue(value: unknown): WalletSubaction | undefined {
   const normalized = value
     .trim()
     .toLowerCase()
-    .replace(/[\s-]+/g, "_");
+    .replace(/[.\s-]+/g, "_");
   if ((WALLET_SUBACTIONS as readonly string[]).includes(normalized as string)) {
     return normalized as WalletSubaction;
   }
@@ -194,7 +202,14 @@ function normalizeRawParams(
       raw.toToken ??
       raw.outputToken ??
       raw.outputTokenCA ??
-      raw.outputTokenSymbol,
+      raw.outputTokenSymbol ??
+      (subaction === "pump_fun_buy"
+        ? (raw.token ??
+          raw.tokenAddress ??
+          raw.mint ??
+          raw.query ??
+          raw.address)
+        : undefined),
     amount: raw.amount,
     recipient: raw.recipient ?? raw.toAddress ?? raw.to,
     slippageBps: raw.slippageBps ?? raw.slippage,
@@ -458,9 +473,9 @@ async function runWalletRouter(
 export const walletRouterAction: Action = {
   name: "WALLET",
   description:
-    "Route wallet operations through registered chain handlers and analytics providers. Use action=transfer|swap|bridge|gov for on-chain ops (params: chain, toChain, fromToken, toToken, amount, recipient, slippageBps, mode, dryRun); action=token_info for token/market data (params: target, query, address, chain); action=search_address for Birdeye wallet/portfolio lookup (param: address).",
+    "Route wallet operations through registered chain handlers and analytics providers. Use action=transfer|swap|bridge|gov|pump_fun_buy for on-chain ops (params: chain, toChain, fromToken, toToken, amount, recipient, slippageBps, mode, dryRun); action=token_info for token/market data (params: target, query, address, chain); action=search_address for Birdeye wallet/portfolio lookup (param: address).",
   descriptionCompressed:
-    "WALLET transfer|swap|bridge|gov|token_info|search_address; chain ops + market/portfolio",
+    "WALLET transfer|swap|bridge|gov|pump_fun_buy|token_info|search_address; chain ops + market/portfolio",
   contexts: ["finance", "crypto", "wallet"],
   contextGate: { anyOf: ["finance", "crypto", "wallet"] },
   roleGate: { minRole: "ADMIN" },
@@ -475,6 +490,8 @@ export const walletRouterAction: Action = {
     "PREPARE_TRANSFER",
     "WALLET_ACTION",
     "WALLET_GOV",
+    "PUMP_FUN_BUY",
+    "PUMPFUN_BUY",
     "TOKEN_INFO",
     "BIRDEYE_LOOKUP",
     "BIRDEYE_SEARCH",
@@ -492,6 +509,7 @@ export const walletRouterAction: Action = {
         "swap",
         "bridge",
         "gov",
+        "pump_fun_buy",
         "token_info",
         "search_address",
       ],
@@ -521,7 +539,7 @@ export const walletRouterAction: Action = {
     {
       name: "toToken",
       description:
-        "Destination token symbol, native token alias, or token address.",
+        "Destination token symbol, native token alias, or token address. For pump_fun_buy, use the pump.fun token mint address.",
       required: false,
       schema: { type: "string" },
       examples: ["USDC", "SOL"],
@@ -529,7 +547,7 @@ export const walletRouterAction: Action = {
     {
       name: "amount",
       description:
-        "Human-readable token amount. Required for transfer, swap, and bridge.",
+        "Human-readable token amount. Required for transfer, swap, bridge, and pump_fun_buy. pump_fun_buy interprets this as SOL.",
       required: false,
       schema: { type: "string" },
       examples: ["0.1", "25"],

--- a/plugins/plugin-wallet/src/security/wallet-context-safety.ts
+++ b/plugins/plugin-wallet/src/security/wallet-context-safety.ts
@@ -3,7 +3,12 @@ import type { Memory } from "@elizaos/core";
 /** GHSA-7qxr-x6cg-r9cc — embedded addresses in token metadata must not become transfer recipients. */
 /** GHSA-gh63-5vpj-39qp — block financial writes on injection-flagged channel messages. */
 
-const FINANCIAL_WRITE_SUBACTIONS = new Set(["transfer", "swap", "bridge"]);
+const FINANCIAL_WRITE_SUBACTIONS = new Set([
+  "transfer",
+  "swap",
+  "bridge",
+  "pump_fun_buy",
+]);
 
 function messageHasPromptInjectionFlag(message: Memory): boolean {
   const metadata = message.content?.metadata;

--- a/plugins/plugin-wallet/src/security/wallet-financial-confirmation.ts
+++ b/plugins/plugin-wallet/src/security/wallet-financial-confirmation.ts
@@ -16,6 +16,7 @@ const ON_CHAIN_SUBACTIONS = new Set<WalletRouterParams["subaction"]>([
   "swap",
   "bridge",
   "gov",
+  "pump_fun_buy",
 ]);
 
 export function requiresWalletFinancialConfirmation(
@@ -85,6 +86,8 @@ export function walletFinancialPreview(
       return `Bridge ${params.amount ?? "?"} from ${params.chain ?? "?"} to ${params.toChain ?? "?"}? Reply yes to submit or no to cancel.`;
     case "gov":
       return `Governance ${params.op ?? "operation"} on ${chainLabel}? Reply yes to submit or no to cancel.`;
+    case "pump_fun_buy":
+      return `Buy ${params.amount ?? "?"} SOL of ${params.toToken ?? "the selected pump.fun token"} through pump.fun on ${chainLabel}? Reply yes to submit or no to cancel.`;
     default:
       return `Submit wallet ${params.subaction} on ${chainLabel}? Reply yes to confirm or no to cancel.`;
   }

--- a/plugins/plugin-wallet/src/services/wallet-backend-service.ts
+++ b/plugins/plugin-wallet/src/services/wallet-backend-service.ts
@@ -298,6 +298,13 @@ export class WalletBackendService extends Service {
         };
       }
     }
+    if (params.subaction === "pump_fun_buy" && !params.toToken) {
+      return {
+        ok: false,
+        error: "INVALID_PARAMS",
+        detail: "toToken must be the pump.fun token mint address.",
+      };
+    }
     return null;
   }
 

--- a/plugins/plugin-wallet/src/types/wallet-router.ts
+++ b/plugins/plugin-wallet/src/types/wallet-router.ts
@@ -11,6 +11,7 @@ export const WALLET_ROUTER_SUBACTIONS = [
   "swap",
   "bridge",
   "gov",
+  "pump_fun_buy",
 ] as const;
 
 export type WalletRouterSubaction = (typeof WALLET_ROUTER_SUBACTIONS)[number];


### PR DESCRIPTION
## Summary
- Adds plugin-inbox persisted triage queue operations and rawPath HTTP routes for triage, reply, snooze, archive, and approve.
- Adds additive `snoozed_until` persistence/migration repair and queue filtering so snoozed entries stay out of normal unresolved reads.
- Adds wallet `pump_fun_buy` routing through a pump.fun Solana handler using PumpPortal trade-local, the existing human confirmation gate, and WalletBackend Solana signing where available.
- Updates package docs and adds issue evidence at `.github/issue-evidence/8652-prelaunch-gaps.md`.

Refs #8652

## Validation
- `bun install`
- `bun run --cwd plugins/plugin-inbox lint`
- `bun run --cwd plugins/plugin-inbox typecheck`
- `bun run --cwd plugins/plugin-inbox test` (15 passed, 1 skipped; 108 passed, 2 skipped)
- `bun run --cwd plugins/plugin-inbox build`
- `bun run --cwd plugins/plugin-wallet lint`
- `bun run --cwd plugins/plugin-wallet check`
- `bun run --cwd plugins/plugin-wallet test` (23 passed, 1 skipped; 105 passed, 1 skipped)
- `bun run --cwd plugins/plugin-wallet build`
- `git diff --check`

## Repo Verify
- `bun run verify` was run after rebasing on `origin/develop`; it still fails before Turbo at `audit:type-safety-ratchet` because current counts exceed existing baselines (`as unknown as`: 107 > 77; `?? 0`: 381 > 380). The reported files are unrelated packages such as `packages/feed`, `packages/agent`, `packages/app-core`, and `packages/core`, not this change set.

## Evidence
- See `.github/issue-evidence/8652-prelaunch-gaps.md`.
