### PR TITLE
fix(lint): biome-format files unformatted by the recent PR sweep + hook-deps ignore

### DIFF
--- a/packages/core/src/security/pii-detectors-extended.test.ts
+++ b/packages/core/src/security/pii-detectors-extended.test.ts
@@ -61,9 +61,9 @@ describe("validators — mnemonic + WIF", () => {
 
 describe("detectPii — issue-named secret classes", () => {
 	it("BIP-39 seed phrase", () => {
-		expect(valueForKind(`recovery ${VALID_MNEMONIC} stored`, "seed-phrase")).toBe(
-			VALID_MNEMONIC,
-		);
+		expect(
+			valueForKind(`recovery ${VALID_MNEMONIC} stored`, "seed-phrase"),
+		).toBe(VALID_MNEMONIC);
 		expect(
 			kinds("the quick brown fox jumps over lazy dogs run now then here"),
 		).not.toContain("seed-phrase");
@@ -104,7 +104,10 @@ describe("detectPii — issue-named secret classes", () => {
 	});
 	it("Basic-auth header (base64 user:pass) + Google OAuth refresh token", () => {
 		expect(
-			valueForKind("Authorization: Basic dXNlcjpzM2NyZXRwYXNz", "basic-auth-header"),
+			valueForKind(
+				"Authorization: Basic dXNlcjpzM2NyZXRwYXNz",
+				"basic-auth-header",
+			),
 		).toBe("dXNlcjpzM2NyZXRwYXNz");
 		expect(kinds("Authorization: Basic YWJjZGVmZ2hpamts")).not.toContain(
 			"basic-auth-header",

--- a/packages/ui/src/components/chat/widgets/agent-orchestrator-room-view.tsx
+++ b/packages/ui/src/components/chat/widgets/agent-orchestrator-room-view.tsx
@@ -211,10 +211,7 @@ function RoomCard({
   );
 
   return (
-    <div
-      className="space-y-1.5 p-2"
-      data-testid="orchestrator-room-card"
-    >
+    <div className="space-y-1.5 p-2" data-testid="orchestrator-room-card">
       {onSelectRoom ? (
         <button
           type="button"

--- a/packages/ui/src/components/chat/widgets/wallet-balance.tsx
+++ b/packages/ui/src/components/chat/widgets/wallet-balance.tsx
@@ -38,7 +38,8 @@ function formatPrice(priceUsd: number): string {
 
 /** Signed 24h-change label, e.g. "+1.2%" / "-0.4%"; empty when ~0. */
 function formatChange(change24hPct: number): string {
-  if (!Number.isFinite(change24hPct) || Math.abs(change24hPct) < 0.01) return "";
+  if (!Number.isFinite(change24hPct) || Math.abs(change24hPct) < 0.01)
+    return "";
   const sign = change24hPct > 0 ? "+" : "";
   return `${sign}${change24hPct.toFixed(1)}%`;
 }

--- a/packages/ui/src/components/pages/ChatView.tsx
+++ b/packages/ui/src/components/pages/ChatView.tsx
@@ -820,7 +820,6 @@ export function ChatView({
       </button>
     ) : null;
 
-
   const composerNode = hideComposer ? null : isGameModal ? (
     <ChatComposerShell
       variant="game-modal"

--- a/packages/ui/src/components/shell/__tests__/useShellController.fuzz.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/useShellController.fuzz.test.tsx
@@ -68,8 +68,9 @@ const composerMock = vi.hoisted(() => ({
 }));
 
 const { useAppSelectorShallowMock } = vi.hoisted(() => ({
-  useAppSelectorShallowMock: (selector: (value: typeof appMock.value) => unknown) =>
-    selector(appMock.value),
+  useAppSelectorShallowMock: (
+    selector: (value: typeof appMock.value) => unknown,
+  ) => selector(appMock.value),
 }));
 
 // Controllable voice-capture leaf: records the last handle + the onTranscript
@@ -105,7 +106,9 @@ vi.mock("../../local-inference/useHomeModelStatus", () => ({
 
 vi.mock("../../../voice/voice-capture-factory", () => ({
   createVoiceCapture: vi.fn(
-    (opts: { onTranscript?: (seg: { text: string; final: boolean }) => void }) => {
+    (opts: {
+      onTranscript?: (seg: { text: string; final: boolean }) => void;
+    }) => {
       voiceCapture.handleCount += 1;
       voiceCapture.onTranscript = opts.onTranscript ?? null;
       return {
@@ -247,7 +250,9 @@ describe("useShellController — interleaved send/voice/new-chat fuzz (#10700)",
       expect(result.current.recording).toBe(false);
       expect(result.current.transcript).toBe("");
       // new-chat actually reached the loader each time it was invoked.
-      expect(appMock.value.handleNewConversation).toHaveBeenCalledTimes(newChats);
+      expect(appMock.value.handleNewConversation).toHaveBeenCalledTimes(
+        newChats,
+      );
     });
   }
 

--- a/packages/ui/src/no-widget-chrome-gate.test.ts
+++ b/packages/ui/src/no-widget-chrome-gate.test.ts
@@ -26,7 +26,8 @@ const WIDGET_ROOTS = [
 
 const RADIUS = /\brounded-(?:sm|md|lg|xl|2xl|3xl|\[[^\]]+\])\b/; // not rounded-full (pills/dots)
 const BORDER = /\bborder\s+border-[a-z0-9/[\]-]+/; // an explicit colored border
-const BG_FILL = /\bbg-(?:black|white|bg-accent|accent|danger|warn|success)\/[0-9]+/; // translucent fill
+const BG_FILL =
+  /\bbg-(?:black|white|bg-accent|accent|danger|warn|success)\/[0-9]+/; // translucent fill
 
 function collectFiles(dir: string, out: string[] = []): string[] {
   let entries: string[];

--- a/packages/ui/src/state/useChatSend.send-voice-newchat.race.test.tsx
+++ b/packages/ui/src/state/useChatSend.send-voice-newchat.race.test.tsx
@@ -187,7 +187,10 @@ function makeHarness(seed: {
     },
     inFlightCount: () => pending.length,
     newChat: (id, roomId) => {
-      conversationsRef.current = [conversation(id, roomId), ...conversationsRef.current];
+      conversationsRef.current = [
+        conversation(id, roomId),
+        ...conversationsRef.current,
+      ];
       activeConversationIdRef.current = id;
     },
     activeId: () => activeConversationIdRef.current,
@@ -327,7 +330,9 @@ describe("#10700 shell send() → new-chat routing race", () => {
       await Promise.all([p1, p2]);
     });
 
-    expect(h.streamCalls.find((c) => c.text === "typed")?.convId).toBe("conv-A");
+    expect(h.streamCalls.find((c) => c.text === "typed")?.convId).toBe(
+      "conv-A",
+    );
   });
 });
 
@@ -419,9 +424,7 @@ describe("#10700 seeded fuzz — send-text / send-voice / new-chat invariants", 
       });
 
       // INVARIANT 1: no lost / no duplicate — exactly one stream per turn.
-      expect(h.streamCalls.length).toBe(
-        expected.length,
-      );
+      expect(h.streamCalls.length).toBe(expected.length);
 
       // INVARIANT 2: each turn routed to the conversation active at ITS enqueue,
       // regardless of any new-chat that happened while it was queued.

--- a/packages/ui/src/state/useChatSend.ts
+++ b/packages/ui/src/state/useChatSend.ts
@@ -1344,6 +1344,7 @@ export function useChatSend(deps: UseChatSendDeps) {
     return () => window.removeEventListener(CLOUD_HANDOFF_PHASE_EVENT, onPhase);
   }, [flushQueuedChatSends]);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: activeConversationIdRef is a ref — its .current is read at ENQUEUE time (always latest) and must NOT be a dependency, or this callback's identity churns on every conversation switch.
   const sendChatText = useCallback(
     async (
       rawInput: string,


### PR DESCRIPTION
## What
Fixes the `bun run lint` failures on develop introduced by recently-merged PRs. A subagent ran the full `bun run lint` (biome 2.5.1) against develop and found `@elizaos/ui#lint` failing with 7 errors + a core test-format error — all in files from the just-merged sweep (#10737, #10745, #10749, #10753, #10754, #10735).

- **Pure biome-format** (whitespace/JSX-attr/call-arg wrapping, zero logic change) across 7 files.
- **1 `biome-ignore lint/correctness/useExhaustiveDependencies`** above `sendChatText` in `useChatSend.ts` — `activeConversationIdRef.current` is a **ref** read at enqueue time and must NOT be a dependency (adding it churns the callback identity on every conversation switch). Deliberately did NOT take biome's unsafe autofix; matches the file's own convention (~line 1433) and the repo pattern (`useDataLoaders.ts:202`).

## Why it's safe
Real diff = 8 files, +30/-20. Verified **0 of the 8 intervening develop commits touch any of these 8 files**, so the 3-way merge is conflict-free and reverts nothing.

## Verification (subagent, against develop)
- `bun run typecheck`: PASS (306/306)
- `bun run lint`: **182/182 PASS after this fix** (was failing on `@elizaos/ui` before)
- `bun run build`: main build PASS (171/171). (The electrobun desktop-build fails on a **pre-existing, out-of-scope** plugin-discord `user-account-scraper` packaging bug — reproduces on the parent checkout, not merge-gated since `verify` = typecheck+lint only. Tracked separately.)

Note: the biome.json `linter.rules.preset: "recommended"` key is **valid** in biome 2.5.1 (verified against the installed schema) — not a config bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)