### PR TITLE
fix(plugin-discord): build the user-account-scraper subpath bundle (unblocks desktop build)

### DIFF
--- a/plugins/plugin-discord/build.ts
+++ b/plugins/plugin-discord/build.ts
@@ -1,9 +1,14 @@
 #!/usr/bin/env bun
 /**
  * Build script for @elizaos/plugin-discord (Node). Orchestration lives in the
- * shared driver; this lists only what differs. Single bundled `dist/index.js`
- * plus a per-file `.d.ts` tree, whose bare relative re-exports are rewritten to
- * NodeNext-resolvable paths.
+ * shared driver; this lists only what differs. Two bundled entrypoints:
+ *   - `dist/index.js`                       the plugin barrel (`.` export)
+ *   - `dist/user-account-scraper/index.js`  the `./user-account-scraper` subpath
+ *     export — its own dedicated Node bundle so the export map's runtime target
+ *     resolves to a real emitted file (used by plugin-personal-assistant).
+ * Both are accompanied by a per-file `.d.ts` tree (emitted by tsc over the whole
+ * source tree, so `dist/user-account-scraper/index.d.ts` is produced too), whose
+ * bare relative re-exports are rewritten to NodeNext-resolvable paths.
  */
 import { buildPlugin } from "../plugin-build";
 
@@ -15,6 +20,13 @@ await buildPlugin({
 			label: "Node",
 			entry: "index.ts",
 			outSubdir: "",
+			target: "node",
+			format: "esm",
+		},
+		{
+			label: "user-account-scraper subpath",
+			entry: "user-account-scraper/index.ts",
+			outSubdir: "user-account-scraper",
 			target: "node",
 			format: "esm",
 		},


### PR DESCRIPTION
## What
Adds a second build target in `plugins/plugin-discord/build.ts` so the build emits `dist/user-account-scraper/index.js` (+ `.d.ts`), which the `./user-account-scraper` export map points to.

## Why (in-scope regression from #10728)
#10728 repointed the `./user-account-scraper` export from `./dist/index.js` → `./dist/user-account-scraper/index.js` (a dedicated subpath bundle, + an `eliza-source` condition) but never added a build target for it. So the file was never emitted, and the desktop packaging assertion `assertRequiredBundledPackagesLanded` (electrobun `copy-runtime-node-modules.ts`) hard-failed:
`error: [runtime-copy] @elizaos/plugin-discord (missing runtime entry .../dist/user-account-scraper/index.js) … Bundle is unsafe to ship.`
The subpath is real (consumed by 3 `plugin-personal-assistant` lifeops files). This completes #10728's intent rather than reverting it.

## Verification (real, both directions)
- `bun run --cwd plugins/plugin-discord build` now emits `dist/user-account-scraper/index.js` (592 B, re-exports buildDiscordProbeScript / DISCORD_APP_URL / captureDiscordDeliveryStatus / DiscordUserAccountScraperImpl / …) **and** `dist/user-account-scraper/index.d.ts` (1417 B).
- Imported the **real** `assertRequiredBundledPackagesLanded` and ran it: **PASS** on the fixed dist; the **exact reported error** on a simulated pre-fix dist. Confirmed `@elizaos/plugin-discord` ∈ `CORE_PLUGINS`/`BASELINE_BUNDLED_RUNTIME_PACKAGES` (the failing code path), and a Node export-map resolution check passes for all of import/default/types.
- `typecheck` + `biome check build.ts`: clean.

Only `build.ts` changes (dist is gitignored). Verified the 3-way merge is conflict-free (0 intervening develop commits touch build.ts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)