### PR TITLE
fix(cloud): land post-auth surfaces on /join, not the dead /dashboard

### DIFF
--- a/packages/ui/src/cloud/public-pages/lib/login-return-to.ts
+++ b/packages/ui/src/cloud/public-pages/lib/login-return-to.ts
@@ -9,7 +9,10 @@
 // The post-login landing is the join flow (`/join`): it select-or-provisions a
 // Cloud agent and drops the user straight into chat (the headline migration
 // outcome), instead of a "No agents yet" management table. See cloud/join.
-const DEFAULT_LOGIN_RETURN_TO = "/join";
+// Exported so every post-auth surface (login, email magic-link callback, invite
+// accept) lands on the same place — a bare `/dashboard` has no index route and
+// dead-ends on the cloud 404 (`CloudRouterShell` `dashboard/*` → CloudNotFound).
+export const DEFAULT_LOGIN_RETURN_TO = "/join";
 const PENDING_OAUTH_RETURN_TO_KEY = "eliza.login.oauth.returnTo";
 const PENDING_OAUTH_RETURN_TO_TTL_MS = 10 * 60 * 1000;
 

--- a/packages/ui/src/cloud/public-pages/pages/auth/email-callback-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/email-callback-page.tsx
@@ -19,6 +19,7 @@ import {
   LocalStewardAuthContext,
   StewardAuthProvider,
 } from "../../../shell/StewardProvider";
+import { DEFAULT_LOGIN_RETURN_TO } from "../../lib/login-return-to";
 import { syncStewardSessionCookie } from "../../lib/steward-session";
 import { usePageTitle } from "../../lib/use-page-title";
 
@@ -70,7 +71,7 @@ function EmailCallbackContent() {
       return;
     }
 
-    const destination = returnTo ?? "/dashboard";
+    const destination = returnTo ?? DEFAULT_LOGIN_RETURN_TO;
 
     let redirectTimer: ReturnType<typeof setTimeout> | null = null;
     const finishSuccess = () => {

--- a/packages/ui/src/cloud/public-pages/pages/invite/invite-accept-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/invite/invite-accept-page.tsx
@@ -35,6 +35,7 @@ import {
 } from "../../../../components/primitives";
 import { ApiError, api } from "../../../lib/api-client";
 import { useCloudT } from "../../../shell/CloudI18nProvider";
+import { DEFAULT_LOGIN_RETURN_TO } from "../../lib/login-return-to";
 import { useSessionAuth } from "../../lib/use-session-auth";
 
 interface InviteDetails {
@@ -146,10 +147,10 @@ export default function InviteAcceptPage() {
       if (data.success) {
         toast.success(
           t("cloud.invite.accepted", {
-            defaultValue: "Invitation accepted! Redirecting to dashboard...",
+            defaultValue: "Invitation accepted! Redirecting…",
           }),
         );
-        setTimeout(() => navigate("/dashboard"), 1500);
+        setTimeout(() => navigate(DEFAULT_LOGIN_RETURN_TO), 1500);
       } else {
         setError(
           data.error ||


### PR DESCRIPTION
## What
Email magic-link callback + invite-accept redirected to a **bare `/dashboard`** after auth. But `/dashboard` has **no index route** — `CloudRouterShell`'s `dashboard/*` catch-all renders `CloudNotFound` (404). So a first-time user signs in fine and lands on **"Not found"**.

## Fix
The login (OAuth/passkey) already lands on `/join` via `DEFAULT_LOGIN_RETURN_TO` (select-or-provision an agent → drop into chat). Export it and reuse it in the callback + invite so every post-auth surface lands on the same working home. Also drops the stale "Redirecting to dashboard" copy.

## Test
- `packages/ui` typecheck + email-callback test green, biome clean.
- Verified live on staging (manual deploy): magic-link sign-in now lands on `/join` instead of the 404.

Follow-up to #10540 (which fixed the callback's missing StewardAuthProvider).