### PR TITLE
fix(app): route Cloud auth through same-origin web proxy

### DIFF
--- a/packages/app/test/ui-smoke/cloud-provisioning-startup.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-provisioning-startup.spec.ts
@@ -295,32 +295,26 @@ async function installDirectCloudLoginRoutes(
     });
   });
 
-  await page.route(
-    "https://api.elizacloud.ai/api/auth/cli-session",
-    async (route) => {
-      if (route.request().method() !== "POST") {
-        await route.fallback();
-        return;
-      }
-      await fulfillJson(route, 200, { ok: true });
-    },
-  );
+  await page.route("**/api/auth/cli-session", async (route) => {
+    if (route.request().method() !== "POST") {
+      await route.fallback();
+      return;
+    }
+    await fulfillJson(route, 200, { ok: true });
+  });
 
-  await page.route(
-    "https://api.elizacloud.ai/api/auth/cli-session/**",
-    async (route) => {
-      if (route.request().method() !== "GET") {
-        await route.fallback();
-        return;
-      }
-      await fulfillJson(route, 200, {
-        status: "authenticated",
-        apiKey: CLOUD_AUTH_TOKEN,
-        organizationId: "ui-smoke-org",
-        userId,
-      });
-    },
-  );
+  await page.route("**/api/auth/cli-session/**", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    await fulfillJson(route, 200, {
+      status: "authenticated",
+      apiKey: CLOUD_AUTH_TOKEN,
+      organizationId: "ui-smoke-org",
+      userId,
+    });
+  });
 }
 
 async function installFirstRunSubmitRoute(

--- a/packages/ui/src/api/client-cloud-direct-auth-web.test.ts
+++ b/packages/ui/src/api/client-cloud-direct-auth-web.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: {
+    isNativePlatform: () => false,
+  },
+  CapacitorHttp: {
+    get: vi.fn(),
+    post: vi.fn(),
+    request: vi.fn(),
+  },
+}));
+
+import { setBootConfig } from "../config/boot-config";
+import { ElizaClient } from "./client-base";
+import "./client-cloud";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("ElizaClient direct Cloud auth on hosted web", () => {
+  beforeEach(() => {
+    setBootConfig({
+      branding: {},
+      cloudApiBase: "https://staging.elizacloud.ai",
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete (globalThis as Record<string, unknown>).__ELIZA_CLOUD_AUTH_TOKEN__;
+  });
+
+  it("creates CLI sessions through the same-origin proxy and opens staging auth", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse({ ok: true }));
+
+    const client = new ElizaClient("http://localhost:31337");
+    const result = await client.cloudLoginDirect(
+      "https://staging.elizacloud.ai",
+    );
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/auth/cli-session",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: expect.stringContaining("sessionId"),
+      }),
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        ok: true,
+        apiBase: "https://api-staging.elizacloud.ai",
+        sessionId: expect.any(String),
+        browserUrl: expect.stringMatching(
+          /^https:\/\/staging\.elizacloud\.ai\/auth\/cli-login\?session=/,
+        ),
+      }),
+    );
+  });
+
+  it("polls CLI sessions through the same-origin proxy", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({
+        status: "authenticated",
+        apiKey: "cloud-api-key",
+        organizationId: "org-1",
+        userId: "user-1",
+      }),
+    );
+
+    const client = new ElizaClient("http://localhost:31337");
+    const result = await client.cloudLoginPollDirect(
+      "https://api-staging.elizacloud.ai",
+      "session-1",
+    );
+
+    expect(fetchSpy).toHaveBeenCalledWith("/api/auth/cli-session/session-1");
+    expect(result).toEqual({
+      status: "authenticated",
+      organizationId: "org-1",
+      token: "cloud-api-key",
+      userId: "user-1",
+    });
+  });
+
+  it("routes direct Cloud API calls through same-origin /api/v1", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({
+        success: true,
+        data: { id: "user-1", organization_id: "org-1" },
+      }),
+    );
+
+    const client = new ElizaClient(
+      "https://api-staging.elizacloud.ai",
+      "cloud-api-key",
+    );
+    const result = await client.getCloudStatus();
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/v1/user",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer cloud-api-key",
+        }),
+      }),
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        connected: true,
+        userId: "user-1",
+        organizationId: "org-1",
+      }),
+    );
+  });
+});

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -236,6 +236,19 @@ function shouldUseNativeCloudHttp(): boolean {
   return Capacitor.isNativePlatform();
 }
 
+function resolveBrowserCloudApiRequestUrl(url: string): string {
+  if (shouldUseNativeCloudHttp() || typeof window === "undefined") return url;
+  try {
+    const parsed = new URL(url);
+    if (!DIRECT_ELIZA_CLOUD_API_BY_HOST.has(parsed.hostname.toLowerCase())) {
+      return url;
+    }
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+  } catch {
+    return url;
+  }
+}
+
 function resolveDirectCloudWebBase(cloudBase: string): string {
   const normalized = cloudBase.replace(/\/+$/, "");
   try {
@@ -500,8 +513,9 @@ async function directCloudJsonResponse<T>(
     };
   }
 
+  const requestUrl = resolveBrowserCloudApiRequestUrl(url);
   const res = await fetchDirectCloudWithTimeout(
-    url,
+    requestUrl,
     { ...init, method, headers },
     { method, url },
   );
@@ -584,8 +598,9 @@ async function directCloudRequest<T>(
     return parsed;
   }
 
+  const requestUrl = resolveBrowserCloudApiRequestUrl(url);
   const res = await fetchDirectCloudWithTimeout(
-    url,
+    requestUrl,
     { ...init, method, headers },
     { method, url },
   );
@@ -2571,11 +2586,14 @@ ElizaClient.prototype.cloudLoginDirect = async function (
       };
     }
 
-    const res = await fetch(`${authApiBase}/api/auth/cli-session`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ sessionId }),
-    });
+    const res = await fetch(
+      resolveBrowserCloudApiRequestUrl(`${authApiBase}/api/auth/cli-session`),
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sessionId }),
+      },
+    );
     if (!res.ok) {
       return { ok: false, error: `Login failed (${res.status})` };
     }
@@ -2632,7 +2650,9 @@ ElizaClient.prototype.cloudLoginPollDirect = async function (
     }
 
     const res = await fetch(
-      `${authApiBase}/api/auth/cli-session/${encodeURIComponent(sessionId)}`,
+      resolveBrowserCloudApiRequestUrl(
+        `${authApiBase}/api/auth/cli-session/${encodeURIComponent(sessionId)}`,
+      ),
     );
     if (!res.ok) {
       if (res.status === 404) {
@@ -3155,7 +3175,7 @@ ElizaClient.prototype.deleteSharedBridgeAgent = async function (
           )
         ).status
       : (
-          await fetch(url, {
+          await fetch(resolveBrowserCloudApiRequestUrl(url), {
             method: "DELETE",
             headers,
             signal: AbortSignal.timeout(20_000),


### PR DESCRIPTION
## Summary
- Routes hosted-web direct Eliza Cloud API calls for known Cloud API hosts through the existing same-origin `/api/*` app proxy.
- Keeps native/Capacitor Cloud HTTP paths on absolute Cloud URLs.
- Updates first-run Cloud provisioning smoke stubs and adds hosted-web direct auth coverage.

## Root Cause
The hosted app was starting first-run Cloud sign-in by fetching absolute Cloud API URLs such as `https://api-staging.elizacloud.ai/api/auth/cli-session` directly from the browser. Those endpoints do not currently expose the required browser CORS headers, while the app already has a Pages same-origin `/api/*` proxy for Cloud API traffic.

## Validation
- `bunx @biomejs/biome check packages/ui/src/api/client-cloud.ts packages/ui/src/api/client-cloud-direct-auth-web.test.ts packages/app/test/ui-smoke/cloud-provisioning-startup.spec.ts`
- `bun run --cwd packages/ui test src/api/client-cloud-direct-auth.test.ts src/api/client-cloud-direct-auth-web.test.ts`
- `bun run --cwd packages/ui typecheck`
- `bun run --cwd packages/app build:web`
- Local Playwright smoke against `http://127.0.0.1:4174/` confirmed the Cloud login start request is same-origin: `POST /api/auth/cli-session`, not an absolute `https://api*.elizacloud.ai` browser fetch.