### PR TITLE
fix(cloud): expose Cerebras default in Worker core stub

### DIFF
--- a/packages/cloud/api/__tests__/elizaos-core-stub.test.ts
+++ b/packages/cloud/api/__tests__/elizaos-core-stub.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  DEFAULT_CEREBRAS_TEXT_MODEL,
+  DEFAULT_ELIZA_CLOUD_FREE_TEXT_MODEL,
+  DEFAULT_ELIZA_CLOUD_TEXT_MODEL,
+} from "../src/stubs/elizaos-core";
+
+describe("elizaos-core Worker stub", () => {
+  test("exports the Eliza Cloud default text model aliases used by plugin-elizacloud", () => {
+    expect(DEFAULT_CEREBRAS_TEXT_MODEL).toBe("gemma-4-31b");
+    expect(DEFAULT_ELIZA_CLOUD_TEXT_MODEL).toBe(DEFAULT_CEREBRAS_TEXT_MODEL);
+    expect(DEFAULT_ELIZA_CLOUD_FREE_TEXT_MODEL).toBe(
+      DEFAULT_CEREBRAS_TEXT_MODEL,
+    );
+  });
+});

--- a/packages/cloud/api/src/stubs/elizaos-core.ts
+++ b/packages/cloud/api/src/stubs/elizaos-core.ts
@@ -240,7 +240,9 @@ const workerLogger = {
 export const logger = workerLogger;
 export const elizaLogger = workerLogger;
 
-export const DEFAULT_ELIZA_CLOUD_TEXT_MODEL = "deepseek/deepseek-chat";
+export const DEFAULT_CEREBRAS_TEXT_MODEL = "gemma-4-31b";
+export const DEFAULT_ELIZA_CLOUD_TEXT_MODEL = DEFAULT_CEREBRAS_TEXT_MODEL;
+export const DEFAULT_ELIZA_CLOUD_FREE_TEXT_MODEL = DEFAULT_CEREBRAS_TEXT_MODEL;
 export const DEFAULT_MAX_BODY_BYTES = 1_048_576;
 
 /**
@@ -943,7 +945,9 @@ export type MediaGenerationResponse = Record<string, unknown>;
 export default {
   logger,
   elizaLogger,
+  DEFAULT_CEREBRAS_TEXT_MODEL,
   DEFAULT_ELIZA_CLOUD_TEXT_MODEL,
+  DEFAULT_ELIZA_CLOUD_FREE_TEXT_MODEL,
   ContentType,
   EventType,
   ChannelType,


### PR DESCRIPTION
## Summary

Fixes the Cloud API Worker deploy bundle failure on merged `develop` by aligning the Worker-safe `@elizaos/core` shim with the real core text-model exports.

The failing staging deploy reached checkout, install, linked workspace build, Worker verification, Worker e2e, and Worker build, then `wrangler deploy --env staging` failed because `plugins/plugin-elizacloud` now imports `DEFAULT_CEREBRAS_TEXT_MODEL` from `@elizaos/core`, but `packages/cloud/api/src/stubs/elizaos-core.ts` did not export it.

This PR:
- exports `DEFAULT_CEREBRAS_TEXT_MODEL = "gemma-4-31b"` from the Worker shim
- aliases `DEFAULT_ELIZA_CLOUD_TEXT_MODEL` and `DEFAULT_ELIZA_CLOUD_FREE_TEXT_MODEL` to that value, matching `packages/core/src/contracts/service-routing.ts`
- adds a focused regression test so the stub export mismatch is caught directly

## Evidence

Failure observed in develop Cloud CF Deploy run:
- https://github.com/elizaOS/eliza/actions/runs/28527230744/job/84574613287
- failing step: `Deploy to Cloudflare Workers`
- error: no matching export in `src/stubs/elizaos-core.ts` for import `DEFAULT_CEREBRAS_TEXT_MODEL`

## Validation

- `bun run --cwd packages/cloud/api typecheck`
- `bun run --cwd packages/cloud/api build`
- `bun test packages/cloud/api/__tests__/elizaos-core-stub.test.ts`
- `bunx biome check packages/cloud/api/src/stubs/elizaos-core.ts packages/cloud/api/__tests__/elizaos-core-stub.test.ts`
- `git diff --check`
- `bunx wrangler deploy --env staging --dry-run`
