### PR TITLE
fix(app/audit): stop the dark chat-overlay scrim reading as blue — 236 false needs-work → 0 (#10710)

### DIFF
--- a/.github/issue-evidence/10710-audit-blue-false-positive/README.md
+++ b/.github/issue-evidence/10710-audit-blue-false-positive/README.md
@@ -1,0 +1,43 @@
+# #10710 — fix the aesthetic-audit blue false-positive that marked every view `needs-work`
+
+## Problem (found by running `audit:app` on this Linux host)
+The all-views aesthetic audit (the per-view QA gate: ~50 views × 4 viewports)
+marked **236 of 348** view/viewport combos `needs-work` — and **every single one**
+was driven by the *same* colour, `rgba(10, 10, 12, 0.5)`, classified as `"blue"`
+(a no-blue brand violation). That colour is the continuous-chat overlay's dark
+scrim, painted on **every** view, so one mis-classification dragged the whole
+app to `needs-work` and made the gate untrustworthy.
+
+`rgba(10,10,12,0.5)` is perceptually **pure black**: `b` is only 2/255 above
+`r`/`g`. But at that low luminance the saturation *ratio* (`chroma/max = 2/12 =
+0.17`) slips past the `saturation < 0.15` achromatic gate, and the hue lands at
+240° → the classifier calls it `blue`.
+
+## Fix
+`packages/app/test/ui-smoke/aesthetic-audit-rules.ts` `bucket()` — add an
+**absolute-chroma floor** to the achromatic gate:
+`if (saturation < 0.15 || chroma < 12) return lum < 0.08 ? "black" : "neutral";`
+A near-achromatic dark scrim (chroma 2) is now correctly `black`; a genuinely
+saturated dark navy (`rgb(10,10,40)`, chroma 30) still falls through to the blue
+band, so real brand violations still surface.
+
+## Result (re-ran the full `audit:app` before/after)
+| | needs-work | needs-eyeball | good | broken | still flagged blue |
+|---|---|---|---|---|---|
+| **before** | **236** | 0 | 112 | 0 | 236 |
+| **after** | **0** | 212 | 136 | 0 | **0** |
+
+`before-verdict-summary.json` / `after-verdict-summary.json` are the machine
+summaries from the two full audit runs (349 tests each, ~20 min). No view is
+actually a blue violation; the remaining `needs-eyeball` are the *soft*,
+non-blocking radius/density signals (e.g. the overlay's 32px sheet radius) — the
+gate now reports the true state and passes with **zero broken and zero
+needs-work** for the default set.
+
+## Tests
+`packages/app/test/audit/aesthetic-audit-rules.test.ts` — **30 passed** (added a
+regression case: `rgba(10,10,12,0.5)` → `black`, `rgb(12,12,14)` → `black`,
+`rgb(240,241,244)` → `neutral`; the existing navy `rgb(10,10,40)` → `blue` guard
+still holds).
+
+Real-LLM trajectory / backend logs — N/A (test-infra correctness fix).

--- a/.github/issue-evidence/10710-audit-blue-false-positive/after-verdict-summary.json
+++ b/.github/issue-evidence/10710-audit-blue-false-positive/after-verdict-summary.json
@@ -1,0 +1,8 @@
+{
+  "when": "after",
+  "counts": {
+    "good": 136,
+    "needs-eyeball": 212
+  },
+  "stillFlaggedBlue": 0
+}

--- a/.github/issue-evidence/10710-audit-blue-false-positive/before-verdict-summary.json
+++ b/.github/issue-evidence/10710-audit-blue-false-positive/before-verdict-summary.json
@@ -1,0 +1,10 @@
+{
+  "when": "before",
+  "counts": {
+    "needs-work": 236,
+    "good": 112
+  },
+  "blueDriver": {
+    "rgba(10, 10, 12, 0.5)": 348
+  }
+}

--- a/packages/app/test/audit/aesthetic-audit-rules.test.ts
+++ b/packages/app/test/audit/aesthetic-audit-rules.test.ts
@@ -50,6 +50,18 @@ describe("bucket (#8796 no-blue / orange detection)", () => {
     // return, letting a dark-blue brand violation escape the no-blue rule.
     expect(bucket("rgb(10, 10, 40)")).toBe("blue");
   });
+  it("treats a near-black dark scrim as black, not blue — audit false-positive (#10710)", () => {
+    // rgba(10,10,12): chroma is only 2 (b just 2 above r,g), but at this low
+    // luminance chroma/max = 0.17 slips past the saturation-ratio gate and the
+    // hue lands at 240° → a naive classifier mislabels an essentially-BLACK
+    // scrim as "blue". Because the chat overlay paints this scrim on EVERY view,
+    // that single false-positive dragged all 236 default view/viewport combos to
+    // `needs-work`. The absolute-chroma floor keeps it out of the blue band.
+    expect(bucket("rgba(10, 10, 12, 0.5)")).toBe("black");
+    expect(bucket("rgb(12, 12, 14)")).toBe("black");
+    // A faint cool-gray light surface likewise stays neutral, not blue.
+    expect(bucket("rgb(240, 241, 244)")).toBe("neutral");
+  });
   it("buckets near-black and pure white", () => {
     expect(bucket("rgb(10, 10, 10)")).toBe("black");
     expect(bucket("rgb(255, 255, 255)")).toBe("white");

--- a/packages/app/test/ui-smoke/aesthetic-audit-rules.ts
+++ b/packages/app/test/ui-smoke/aesthetic-audit-rules.ts
@@ -200,7 +200,14 @@ export function bucket(color: string): Bucket {
   // Very light + near-achromatic = white.
   if (lum > 0.95 && saturation < 0.05) return "white";
   // Achromatic (gray scale): neutral, or black only when genuinely dark.
-  if (saturation < 0.15) return lum < 0.08 ? "black" : "neutral";
+  // Gate on ABSOLUTE chroma too, not just the saturation RATIO: at low
+  // luminance a 1–2/255 channel spread yields a high `chroma/max` ratio yet is
+  // perceptually black — so a dark scrim like `rgba(10,10,12,0.5)` (chroma 2,
+  // ratio 0.17) must not escape this gate and get hue-classified as a saturated
+  // "blue" (240°), which mislabels an essentially-black overlay as a brand
+  // violation. A genuinely-saturated dark navy `rgb(10,10,40)` has chroma 30 and
+  // still falls through to the blue band below.
+  if (saturation < 0.15 || chroma < 12) return lum < 0.08 ? "black" : "neutral";
 
   // Chromatic — classify by hue (degrees, 0–360).
   let hue = 0;


### PR DESCRIPTION
Found by running `audit:app` (the per-view aesthetic QA gate) on a Linux host and analyzing `report.json`.

## Problem
The all-views aesthetic audit marked **236 of 348** view/viewport combos `needs-work` — and **every single one** was driven by the *same* colour `rgba(10, 10, 12, 0.5)` classified as `"blue"` (a no-blue brand violation). That colour is the continuous-chat overlay's dark scrim, painted on **every** view, so one mis-classification dragged the whole app to `needs-work` and made the gate untrustworthy.

`rgba(10,10,12,0.5)` is perceptually **pure black** (`b` only 2/255 above `r`/`g`). But at that low luminance the saturation *ratio* (`chroma/max = 2/12 = 0.17`) slips past the `saturation < 0.15` achromatic gate, and the hue lands at 240° → the classifier calls it `blue`.

## Fix
`bucket()` in `aesthetic-audit-rules.ts` — add an **absolute-chroma floor** to the achromatic gate:
```ts
if (saturation < 0.15 || chroma < 12) return lum < 0.08 ? "black" : "neutral";
```
A near-achromatic dark scrim (chroma 2) is now correctly `black`; a genuinely saturated dark navy `rgb(10,10,40)` (chroma 30) still falls through to the blue band so **real** brand violations still surface (existing guard test unchanged).

## Result — re-ran the full `audit:app` before/after (349 tests each, ~20 min)
| | needs-work | needs-eyeball | good | broken | flagged blue |
|---|---|---|---|---|---|
| **before** | **236** | 0 | 112 | 0 | 236 |
| **after** | **0** | 212 | 136 | 0 | **0** |

No view is actually a blue violation — the gate now reports the true state and passes with **zero broken and zero needs-work** for the default set (the remaining `needs-eyeball` are the *soft*, non-blocking radius/density signals, e.g. the overlay's 32px sheet radius). Machine summaries attached under `.github/issue-evidence/10710-audit-blue-false-positive/`.

## Tests
`aesthetic-audit-rules.test.ts` — **30 passed** (added the scrim regression case: `rgba(10,10,12,0.5)` → `black`, `rgb(12,12,14)` → `black`, `rgb(240,241,244)` → `neutral`; the navy `rgb(10,10,40)` → `blue` guard still holds).

Real-LLM trajectory / backend logs — N/A (test-infra correctness fix). This makes the per-view aesthetic gate trustworthy — the prerequisite for #10710's "tighten the audit gate" AC and the #10719 per-view coverage gate.