### PR TITLE
ci(cloud-cf-deploy): retry bun install so a stalled self-hosted box doesn't fail the deploy

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -144,7 +144,25 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ env.CHECKOUT_DIR }}
-        run: bun install --no-save --ignore-scripts && git diff --exit-code -- bun.lock
+        # The shared self-hosted deploy box can stall or kill a single bun
+        # install mid-flight (contended cache/IO), which surfaced as a
+        # "cancelled" install step failing an otherwise-green deploy while every
+        # sibling deploy job on the same run succeeded. Retry with a per-attempt
+        # timeout so a stuck/killed install aborts and retries instead of failing
+        # the deploy — the same resilience the checkout step already uses (#10310).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if timeout 300s bun install --no-save --ignore-scripts; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::bun install failed after ${attempt} attempts"
+              exit 1
+            fi
+            echo "::warning::bun install attempt ${attempt} stalled or failed; retrying"
+          done
+          git diff --exit-code -- bun.lock
 
       - name: Build linked elizaOS workspaces
         working-directory: ${{ env.CHECKOUT_DIR }}
@@ -348,7 +366,25 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ env.CHECKOUT_DIR }}
-        run: bun install --no-save --ignore-scripts && git diff --exit-code -- bun.lock
+        # The shared self-hosted deploy box can stall or kill a single bun
+        # install mid-flight (contended cache/IO), which surfaced as a
+        # "cancelled" install step failing an otherwise-green deploy while every
+        # sibling deploy job on the same run succeeded. Retry with a per-attempt
+        # timeout so a stuck/killed install aborts and retries instead of failing
+        # the deploy — the same resilience the checkout step already uses (#10310).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if timeout 300s bun install --no-save --ignore-scripts; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::bun install failed after ${attempt} attempts"
+              exit 1
+            fi
+            echo "::warning::bun install attempt ${attempt} stalled or failed; retrying"
+          done
+          git diff --exit-code -- bun.lock
 
       - name: Build linked elizaOS core workspace
         working-directory: ${{ env.CHECKOUT_DIR }}
@@ -583,7 +619,25 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ env.CHECKOUT_DIR }}
-        run: bun install --no-save --ignore-scripts && git diff --exit-code -- bun.lock
+        # The shared self-hosted deploy box can stall or kill a single bun
+        # install mid-flight (contended cache/IO), which surfaced as a
+        # "cancelled" install step failing an otherwise-green deploy while every
+        # sibling deploy job on the same run succeeded. Retry with a per-attempt
+        # timeout so a stuck/killed install aborts and retries instead of failing
+        # the deploy — the same resilience the checkout step already uses (#10310).
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if timeout 300s bun install --no-save --ignore-scripts; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::bun install failed after ${attempt} attempts"
+              exit 1
+            fi
+            echo "::warning::bun install attempt ${attempt} stalled or failed; retrying"
+          done
+          git diff --exit-code -- bun.lock
 
       - name: Build linked elizaOS core workspace
         working-directory: ${{ env.CHECKOUT_DIR }}


### PR DESCRIPTION
## Symptom

[Run 28530892609](https://github.com/elizaOS/eliza/actions/runs/28530892609) — **Deploy Console (Pages · elizacloud.ai)** failed. The job's **"Install dependencies"** step was **cancelled at exactly 16:04:24, 59s after it started** (deps already resolved/extracted), then all later steps skipped and cleanup ran.

## Why it's a flake, not a real error

In the **same run**, on the same self-hosted fleet:
- `Deploy App (app.elizacloud.ai)` → **success** (~9 min)
- `Deploy API Worker` → **success** (~9 min)
- `Deploy Console` → **failure** (install cancelled at 59s)

The three jobs are structurally identical; only the console's install got killed, and its runner (`eliza-robot-2`) stayed alive to run the cleanup step. There's **no `timeout-minutes`** on the install step or job, so this is the shared, heavily-loaded box stalling/killing one `bun install` mid-flight — a per-job flake. The same commit deployed successfully 12 min earlier, and prior runs show "cancelled" installs too.

## Fix

The `Checkout repository` step already guards this exact self-hosted-stall class with a per-attempt-timeout retry loop (added for the #10310 stuck-checkout). The install step had no guard. This wraps all **three** deploy jobs' installs in the same pattern:

```bash
for attempt in 1 2 3; do
  if timeout 300s bun install --no-save --ignore-scripts; then break; fi
  [ "$attempt" -eq 3 ] && { echo "::error::…"; exit 1; }
  echo "::warning::bun install attempt ${attempt} stalled or failed; retrying"
done
git diff --exit-code -- bun.lock   # lockfile-drift check unchanged
```

- **Healthy runner:** first attempt passes — no behavior change.
- **Stalled/killed install:** aborts at 300s and retries instead of failing an otherwise-green deploy.
- A genuine lockfile problem still fails (the `git diff` check is outside the retry, unchanged).

YAML validated (`yaml.safe_load`). Not re-running the original failed job — its SHA has been superseded by newer develop deploys, so a re-run would push stale code over newer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)