### PR TITLE
[codex] stabilize cloud smoke fixtures

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -179,8 +179,11 @@ jobs:
         # the deploy — the same resilience the checkout step already uses (#10310).
         run: |
           set -euo pipefail
+          install_cache="$PWD/.bun-install-cache"
           for attempt in 1 2 3; do
-            if timeout 300s bun install --no-save --ignore-scripts; then
+            test -f package.json || { echo "::error::package.json missing from $PWD"; ls -la; exit 1; }
+            mkdir -p "$install_cache"
+            if timeout 300s bun install --no-save --ignore-scripts --cache-dir "$install_cache"; then
               break
             fi
             if [ "$attempt" -eq 3 ]; then
@@ -188,6 +191,7 @@ jobs:
               exit 1
             fi
             echo "::warning::bun install attempt ${attempt} stalled or failed; retrying"
+            rm -rf node_modules "$install_cache"
           done
           git diff --exit-code -- bun.lock
 
@@ -428,8 +432,11 @@ jobs:
         # the deploy — the same resilience the checkout step already uses (#10310).
         run: |
           set -euo pipefail
+          install_cache="$PWD/.bun-install-cache"
           for attempt in 1 2 3; do
-            if timeout 300s bun install --no-save --ignore-scripts; then
+            test -f package.json || { echo "::error::package.json missing from $PWD"; ls -la; exit 1; }
+            mkdir -p "$install_cache"
+            if timeout 300s bun install --no-save --ignore-scripts --cache-dir "$install_cache"; then
               break
             fi
             if [ "$attempt" -eq 3 ]; then
@@ -437,6 +444,7 @@ jobs:
               exit 1
             fi
             echo "::warning::bun install attempt ${attempt} stalled or failed; retrying"
+            rm -rf node_modules "$install_cache"
           done
           git diff --exit-code -- bun.lock
 
@@ -708,8 +716,11 @@ jobs:
         # the deploy — the same resilience the checkout step already uses (#10310).
         run: |
           set -euo pipefail
+          install_cache="$PWD/.bun-install-cache"
           for attempt in 1 2 3; do
-            if timeout 300s bun install --no-save --ignore-scripts; then
+            test -f package.json || { echo "::error::package.json missing from $PWD"; ls -la; exit 1; }
+            mkdir -p "$install_cache"
+            if timeout 300s bun install --no-save --ignore-scripts --cache-dir "$install_cache"; then
               break
             fi
             if [ "$attempt" -eq 3 ]; then
@@ -717,6 +728,7 @@ jobs:
               exit 1
             fi
             echo "::warning::bun install attempt ${attempt} stalled or failed; retrying"
+            rm -rf node_modules "$install_cache"
           done
           git diff --exit-code -- bun.lock
 

--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -129,12 +129,16 @@ jobs:
         timeout-minutes: 20
         env:
           CHECKOUT_TOKEN: ${{ github.token }}
+        working-directory: /tmp
         run: |
           set -euo pipefail
-          mkdir -p "$CHECKOUT_DIR"
-          git init "$CHECKOUT_DIR"
-          git -C "$CHECKOUT_DIR" remote set-url origin "https://x-access-token:${CHECKOUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" 2>/dev/null \
-            || git -C "$CHECKOUT_DIR" remote add origin "https://x-access-token:${CHECKOUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          init_checkout_dir() {
+            mkdir -p "$CHECKOUT_DIR"
+            git init -q "$CHECKOUT_DIR"
+            git -C "$CHECKOUT_DIR" remote set-url origin "https://x-access-token:${CHECKOUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" 2>/dev/null \
+              || git -C "$CHECKOUT_DIR" remote add origin "https://x-access-token:${CHECKOUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          }
+          init_checkout_dir
           # Shared, heavily-loaded self-hosted box (wrangler dev + PGlite + the full
           # Worker suite): a single shallow fetch can stall for minutes or wedge
           # entirely. Retry with a per-attempt timeout so a stuck fetch aborts and
@@ -146,7 +150,11 @@ jobs:
               break
             fi
             echo "::warning::checkout fetch attempt ${attempt} stalled or failed; retrying"
-            sleep 10
+            if [ "$attempt" -lt 2 ]; then
+              rm -rf "$CHECKOUT_DIR"
+              sleep 10
+              init_checkout_dir
+            fi
           done
           [ -n "$fetched" ] || { echo "::error::git fetch failed after 2 attempts"; exit 1; }
           # checkout --force --detach fully materializes the working tree from the
@@ -378,12 +386,16 @@ jobs:
         timeout-minutes: 20
         env:
           CHECKOUT_TOKEN: ${{ github.token }}
+        working-directory: /tmp
         run: |
           set -euo pipefail
-          mkdir -p "$CHECKOUT_DIR"
-          git init "$CHECKOUT_DIR"
-          git -C "$CHECKOUT_DIR" remote set-url origin "https://x-access-token:${CHECKOUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" 2>/dev/null \
-            || git -C "$CHECKOUT_DIR" remote add origin "https://x-access-token:${CHECKOUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          init_checkout_dir() {
+            mkdir -p "$CHECKOUT_DIR"
+            git init -q "$CHECKOUT_DIR"
+            git -C "$CHECKOUT_DIR" remote set-url origin "https://x-access-token:${CHECKOUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" 2>/dev/null \
+              || git -C "$CHECKOUT_DIR" remote add origin "https://x-access-token:${CHECKOUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          }
+          init_checkout_dir
           # Shared, heavily-loaded self-hosted box (wrangler dev + PGlite + the full
           # Worker suite): a single shallow fetch can stall for minutes or wedge
           # entirely. Retry with a per-attempt timeout so a stuck fetch aborts and
@@ -399,7 +411,11 @@ jobs:
               break
             fi
             echo "::warning::checkout fetch attempt ${attempt} stalled or failed; retrying"
-            sleep 10
+            if [ "$attempt" -lt 2 ]; then
+              rm -rf "$CHECKOUT_DIR"
+              sleep 10
+              init_checkout_dir
+            fi
           done
           [ -n "$fetched" ] || { echo "::error::git fetch failed after 2 attempts"; exit 1; }
           # checkout --force --detach fully materializes the working tree from the
@@ -662,12 +678,16 @@ jobs:
         timeout-minutes: 20
         env:
           CHECKOUT_TOKEN: ${{ github.token }}
+        working-directory: /tmp
         run: |
           set -euo pipefail
-          mkdir -p "$CHECKOUT_DIR"
-          git init "$CHECKOUT_DIR"
-          git -C "$CHECKOUT_DIR" remote set-url origin "https://x-access-token:${CHECKOUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" 2>/dev/null \
-            || git -C "$CHECKOUT_DIR" remote add origin "https://x-access-token:${CHECKOUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          init_checkout_dir() {
+            mkdir -p "$CHECKOUT_DIR"
+            git init -q "$CHECKOUT_DIR"
+            git -C "$CHECKOUT_DIR" remote set-url origin "https://x-access-token:${CHECKOUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" 2>/dev/null \
+              || git -C "$CHECKOUT_DIR" remote add origin "https://x-access-token:${CHECKOUT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          }
+          init_checkout_dir
           # Shared, heavily-loaded self-hosted box (wrangler dev + PGlite + the full
           # Worker suite): a single shallow fetch can stall for minutes or wedge
           # entirely. Retry with a per-attempt timeout so a stuck fetch aborts and
@@ -683,7 +703,11 @@ jobs:
               break
             fi
             echo "::warning::checkout fetch attempt ${attempt} stalled or failed; retrying"
-            sleep 10
+            if [ "$attempt" -lt 2 ]; then
+              rm -rf "$CHECKOUT_DIR"
+              sleep 10
+              init_checkout_dir
+            fi
           done
           [ -n "$fetched" ] || { echo "::error::git fetch failed after 2 attempts"; exit 1; }
           # checkout --force --detach fully materializes the working tree from the

--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -332,7 +332,14 @@ jobs:
       - name: Clean temp checkout
         if: always()
         working-directory: /tmp
-        run: timeout 120s rm -rf "$CHECKOUT_DIR" || echo "::warning::Timed out cleaning $CHECKOUT_DIR"
+        run: |
+          set -uo pipefail
+          if [ -e "$CHECKOUT_DIR" ]; then
+            stale_dir="${CHECKOUT_DIR}.stale-${GITHUB_JOB:-job}-$(date +%s)"
+            mv "$CHECKOUT_DIR" "$stale_dir" 2>/dev/null || stale_dir="$CHECKOUT_DIR"
+            nohup bash -c 'timeout 30s rm -rf "$1" || true' _ "$stale_dir" >/dev/null 2>&1 &
+            echo "Scheduled best-effort cleanup for ${stale_dir}."
+          fi
 
   # ---------------------------------------------------------------------------
   # Console frontend (Cloudflare Pages) — packages/app at the elizacloud.ai apex.
@@ -624,7 +631,14 @@ jobs:
       - name: Clean temp checkout
         if: always()
         working-directory: /tmp
-        run: timeout 120s rm -rf "$CHECKOUT_DIR" || echo "::warning::Timed out cleaning $CHECKOUT_DIR"
+        run: |
+          set -uo pipefail
+          if [ -e "$CHECKOUT_DIR" ]; then
+            stale_dir="${CHECKOUT_DIR}.stale-${GITHUB_JOB:-job}-$(date +%s)"
+            mv "$CHECKOUT_DIR" "$stale_dir" 2>/dev/null || stale_dir="$CHECKOUT_DIR"
+            nohup bash -c 'timeout 30s rm -rf "$1" || true' _ "$stale_dir" >/dev/null 2>&1 &
+            echo "Scheduled best-effort cleanup for ${stale_dir}."
+          fi
 
   # ---------------------------------------------------------------------------
   # App frontend (Cloudflare Pages) — packages/app (the Eliza agent app) at
@@ -868,4 +882,11 @@ jobs:
       - name: Clean temp checkout
         if: always()
         working-directory: /tmp
-        run: timeout 120s rm -rf "$CHECKOUT_DIR" || echo "::warning::Timed out cleaning $CHECKOUT_DIR"
+        run: |
+          set -uo pipefail
+          if [ -e "$CHECKOUT_DIR" ]; then
+            stale_dir="${CHECKOUT_DIR}.stale-${GITHUB_JOB:-job}-$(date +%s)"
+            mv "$CHECKOUT_DIR" "$stale_dir" 2>/dev/null || stale_dir="$CHECKOUT_DIR"
+            nohup bash -c 'timeout 30s rm -rf "$1" || true' _ "$stale_dir" >/dev/null 2>&1 &
+            echo "Scheduled best-effort cleanup for ${stale_dir}."
+          fi

--- a/packages/app/test/ui-smoke/cloud-provisioning-startup.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-provisioning-startup.spec.ts
@@ -95,17 +95,6 @@ function userMessage(page: Page, text: string): Locator {
     .first();
 }
 
-function assistantMessages(page: Page, hasText: string | RegExp): Locator {
-  return page
-    .locator('[data-testid="chat-message"][data-role="assistant"]')
-    .filter({ hasText })
-    .or(
-      conversationLog(page)
-        .locator('[data-role="assistant"]')
-        .filter({ hasText }),
-    );
-}
-
 async function clickIfVisible(
   locator: Locator,
   timeoutMs = 2_000,
@@ -355,6 +344,32 @@ function parseAssistantFixtureText(
   ) as DeterministicAssistantFixture;
 }
 
+async function deterministicAssistantFixtures(
+  page: Page,
+): Promise<DeterministicAssistantFixture[]> {
+  const texts = await page
+    .locator(
+      [
+        '[data-testid="chat-message"][data-role="assistant"]',
+        '[role="log"][aria-label="conversation history"] [data-role="assistant"]',
+      ].join(", "),
+    )
+    .evaluateAll((elements) =>
+      elements
+        .map((element) => element.textContent?.trim() ?? "")
+        .filter((text) => text.includes("ui-smoke-assistant-v1")),
+    );
+
+  const fixtures: DeterministicAssistantFixture[] = [];
+  const seen = new Set<string>();
+  for (const text of texts) {
+    if (seen.has(text)) continue;
+    seen.add(text);
+    fixtures.push(parseAssistantFixtureText(text));
+  }
+  return fixtures;
+}
+
 async function expectDeterministicChatTurn(
   page: Page,
   prompt: string,
@@ -363,16 +378,9 @@ async function expectDeterministicChatTurn(
   await expect
     .poll(
       async () => {
-        const assistants = assistantMessages(page, /ui-smoke-assistant-v1/);
-        const matches: DeterministicAssistantFixture[] = [];
-        for (let i = 0; i < (await assistants.count()); i += 1) {
-          const assistantText =
-            (await assistants.nth(i).textContent())?.trim() ?? "";
-          const parsed = parseAssistantFixtureText(assistantText);
-          if (parsed.input.text === prompt) {
-            matches.push(parsed);
-          }
-        }
+        const matches = (await deterministicAssistantFixtures(page)).filter(
+          (fixture) => fixture.input.text === prompt,
+        );
         return matches.at(-1) ?? null;
       },
       {


### PR DESCRIPTION
## Summary

Stabilizes the desktop/web Cloud onboarding smoke lane and hardens the shared Cloud CF deploy workflow after the recent runner failures.

Current branch state:

- PR head: `dc521403b23d85b9ffeb5189685630ca386776dd`
- Base: `origin/develop` `b0cb2cc62486eca583eb0e7a20c8e8bb1735f0db`
- Scope is only two files:
  - `packages/app/test/ui-smoke/cloud-provisioning-startup.spec.ts`
  - `.github/workflows/cloud-cf-deploy.yml`

Changes:

- Read Cloud provisioning smoke assistant bubbles from a single DOM snapshot instead of iterating a union locator that can wait on phantom overlay matches.
- Keep upstream #10940's age-based stale checkout reclaim, which avoids deleting concurrent sibling checkouts.
- Harden manual checkout retries by running from `/tmp`, recreating the checkout dir after failed fetch attempts, and reinitializing git before retrying.
- Isolate Bun install cache per checkout and remove failed `node_modules`/cache state before retrying install.
- Make final checkout cleanup non-blocking by moving the checkout aside and scheduling best-effort background deletion.

Note: the Stripe safe-fetch mock fix this PR previously carried has now landed upstream in #10934, so the duplicate local commit was dropped during rebase.

## Validation

Latest exact head/local checks:

- `git diff --check origin/develop...HEAD` ✅
- `actionlint .github/workflows/cloud-cf-deploy.yml` ✅
- `bunx biome check .github/workflows/cloud-cf-deploy.yml packages/app/test/ui-smoke/cloud-provisioning-startup.spec.ts` ✅
- `bun test packages/cloud/api/__tests__/stripe-event-waifu.test.ts --timeout 120000` ✅
- `PATH=/home/nubs/.nvm/versions/node/v24.15.0/bin:$PATH ELIZA_NODE_PATH=/home/nubs/.nvm/versions/node/v24.15.0/bin/node ELIZA_UI_SMOKE_DISABLE_VIDEO=1 bun run --cwd packages/app test:e2e test/ui-smoke/cloud-provisioning-startup.spec.ts --project=chromium` ✅ 4/4 passed in 2.3m

CI:

- Fresh Cloud CF Deploy run for this head: https://github.com/elizaOS/eliza/actions/runs/28543578733
- Previous stale Cloud CF run from old head `3d731c32` was explicitly cancelled after this rebase/push.
