### PR TITLE
fix(ui): surface a notice on action/inbox send failures instead of swallowing (#10231)

### DIFF
--- a/packages/ui/src/state/useChatSend.test.tsx
+++ b/packages/ui/src/state/useChatSend.test.tsx
@@ -11,7 +11,11 @@ import type {
 } from "../api";
 import { CLOUD_HANDOFF_PHASE_EVENT } from "../events";
 import type { LoadConversationMessagesResult } from "./internal";
-import { type UseChatSendDeps, useChatSend } from "./useChatSend";
+import {
+  buildSendFailureNotice,
+  type UseChatSendDeps,
+  useChatSend,
+} from "./useChatSend";
 
 const SHARED_BASE = "https://api.elizacloud.ai/api/v1/eliza/agents/agent-123";
 const DEDICATED_BASE = "https://agent-456.elizacloud.ai";
@@ -951,5 +955,31 @@ describe("useChatSend empty-reply failure surfacing (#10231)", () => {
       (m) => m.role === "assistant",
     );
     expect(assistant.length).toBe(0);
+  });
+});
+
+describe("buildSendFailureNotice (#10231)", () => {
+  it("maps auth/rate/availability/kind failures to status-specific copy", () => {
+    expect(buildSendFailureNotice({ status: 401 })).toContain(
+      "session expired",
+    );
+    expect(buildSendFailureNotice({ status: 403 })).toContain(
+      "session expired",
+    );
+    expect(buildSendFailureNotice({ status: 429 })).toContain("busy");
+    expect(buildSendFailureNotice({ status: 503 })).toContain("waking up");
+    expect(buildSendFailureNotice({ status: 502 })).toContain("waking up");
+    expect(buildSendFailureNotice({ kind: "timeout" })).toContain(
+      "took too long",
+    );
+    expect(buildSendFailureNotice({ kind: "network" })).toContain(
+      "check your connection",
+    );
+  });
+
+  it("falls back to a generic resend notice for an unknown failure (never empty)", () => {
+    const notice = buildSendFailureNotice(new Error("boom"));
+    expect(notice.length).toBeGreaterThan(0);
+    expect(notice).toContain("resend");
   });
 });

--- a/packages/ui/src/state/useChatSend.ts
+++ b/packages/ui/src/state/useChatSend.ts
@@ -105,6 +105,33 @@ function asStringList(value: unknown): string[] {
   return [];
 }
 
+/**
+ * Map a send/stream failure (HTTP status + error `kind`) to a user-facing notice
+ * so a stalled turn is never silent dead air. Shared by the main-chat send path
+ * and the action/inbox/connector send path — both must surface the same
+ * status-specific message. (#10231)
+ */
+export function buildSendFailureNotice(err: unknown): string {
+  const status = (err as { status?: number }).status;
+  const kind = (err as { kind?: string }).kind;
+  if (status === 401 || status === 403) {
+    return "Your session expired — sign in again and resend your message.";
+  }
+  if (status === 429) {
+    return "The agent is busy right now — wait a few seconds and resend.";
+  }
+  if (status === 503 || status === 502) {
+    return "The agent is still waking up — give it a moment and resend.";
+  }
+  if (kind === "timeout") {
+    return "The agent took too long to respond — give it a moment and resend.";
+  }
+  if (kind === "network") {
+    return "Couldn't reach the agent — check your connection and resend.";
+  }
+  return "That message didn't go through — please resend.";
+}
+
 function abortServerConversationTurn(
   roomId: string | null | undefined,
   reason: string,
@@ -1208,20 +1235,8 @@ export function useChatSend(deps: UseChatSendDeps) {
           // idle timeout is 60s — without this the user just sees the dots
           // vanish and nothing replace them, reading as "my message was lost").
           dropEmptyAssistantPlaceholder(assistantMsgId);
-          const kind = (err as { kind?: string }).kind;
           const isAuth = status === 401 || status === 403;
-          const notice = isAuth
-            ? "Your session expired — sign in again and resend your message."
-            : status === 429
-              ? "The agent is busy right now — wait a few seconds and resend."
-              : status === 503 || status === 502
-                ? "The agent is still waking up — give it a moment and resend."
-                : kind === "timeout"
-                  ? "The agent took too long to respond — give it a moment and resend."
-                  : kind === "network"
-                    ? "Couldn't reach the agent — check your connection and resend."
-                    : "That message didn't go through — please resend.";
-          setActionNotice(notice, "error", 8_000);
+          setActionNotice(buildSendFailureNotice(err), "error", 8_000);
           // Reconcile from the server for non-auth errors — loadConversationMessages
           // no longer wipes the thread on transient failures (404-only clear), so
           // this is safe; skip on auth where the reload would just fail again.
@@ -1625,6 +1640,10 @@ export function useChatSend(deps: UseChatSendDeps) {
             dropEmptyAssistantPlaceholder(assistantMsgId);
             return;
           }
+          // Surface a status-specific notice so an inbox/connector send that
+          // 5xxs, times out, or auth-fails is never silent dead air — the
+          // main-chat send path already does this; this one did not (#10231).
+          setActionNotice(buildSendFailureNotice(err), "error", 8_000);
           await loadConversationMessages(convId);
         } finally {
           // Belt-and-braces: cancel any frame still pending (idempotent).


### PR DESCRIPTION
## Bug (#10231, Lead 4)

`sendActionMessage`'s catch in `packages/ui/src/state/useChatSend.ts` (the inbox / connector / action send path) handled only the abort case; for every other failure it just did `await loadConversationMessages(convId)` and **never called `setActionNotice`**. So a Discord/Telegram/inbox send that 503s, times out, or 401s is **silent dead air** — the typing dots vanish with nothing to explain it.

The parallel main-chat send path already surfaces a status-specific notice (401/403 → "session expired", 429 → "busy", 502/503 → "waking up", timeout / network / generic).

## Fix

Extract that mapping into an exported **`buildSendFailureNotice(err)`** and call it from **both** paths so they can't drift:

- Main path: replaced its inline ternary with `setActionNotice(buildSendFailureNotice(err), …)` (kept its `isAuth` gate for the non-auth reconcile).
- Action path: now `setActionNotice(buildSendFailureNotice(err), "error", 8_000)` before reconciling — no more swallow.

## Test — `useChatSend.test.tsx` (21/21 green)

Direct coverage of `buildSendFailureNotice`: 401/403, 429, 502/503, timeout, network, and a non-empty generic fallback. The existing main-path notice tests ("waking up", "took too long", …) still pass unchanged, confirming the DRY refactor is behavior-preserving.

```
bun run --cwd packages/ui test src/state/useChatSend.test.tsx  # 21 pass
```

Scope: Lead 4 only — the assessment found leads 1-3/5-8 of #10231 already landed on develop (several with `#10231` comments) or moot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)