### PR TITLE
test(app): launcher-view e2e coverage gate + view inventory (#10719)

### DIFF
--- a/packages/app/docs/LAUNCHER_VIEW_COVERAGE.md
+++ b/packages/app/docs/LAUNCHER_VIEW_COVERAGE.md
@@ -1,0 +1,104 @@
+# Launcher view coverage inventory (#10719)
+
+Checked-in inventory of every **default-launcher view** — the tiles the `/views`
+launcher grid renders — and its automated + manual test-coverage status. This
+doc is the human-readable companion to the enforced gate
+[`packages/app/test/launcher-view-coverage.test.ts`](../test/launcher-view-coverage.test.ts).
+
+**The gate is what keeps this honest.** Adding a new launcher view to
+`BUILTIN_VIEWS` ([`packages/agent/src/api/builtin-views.ts`](../../agent/src/api/builtin-views.ts))
+without a coverage entry **fails CI**. This doc is a table a reviewer can read;
+the gate is the assertion a CI run enforces. Keep them in sync — the gate's
+`covers a stable, non-empty set of launcher views` test pins the exact roster
+below, so a drift in either surface is caught.
+
+## What "default-launcher view" means
+
+A `BUILTIN_VIEWS` entry appears in the launcher grid when the launcher filter
+(`mergeViewCatalog` in [`packages/ui/src/hooks/view-catalog.ts`](../../ui/src/hooks/view-catalog.ts),
+plus the native-OS strip in [`useAvailableViews`](../../ui/src/hooks/useAvailableViews.ts))
+would ever place it there:
+
+- `visibleInManager !== false` (internal views are hidden from the grid), **and**
+- the id is **not** a native-OS-fork-only surface (`phone` / `messages` /
+  `contacts` / `camera` are stripped on web, desktop, iOS, and stock Play-Store
+  Android — they only exist on the AOSP ElizaOS fork).
+
+`viewKind` / `developerOnly` do **not** exclude a view from the launcher:
+`developer`- and `preview`-kind views render in the grid when the matching
+Settings toggle is on (`isViewVisible` gates them per-toggle). They still need
+coverage, so they are in the table below.
+
+`camera` (`viewKind: preview`, `platforms: ["android"]`, native-OS) is the one
+`BUILTIN_VIEWS` entry that is **not** a default-launcher view; it is intentionally
+excluded from this inventory and the gate.
+
+## Two evidence lanes
+
+| Lane | Produced by | Enforced by the gate? |
+| --- | --- | --- |
+| **Automated smoke** | `builtin-views-visual.spec.ts` (desktop + mobile boot-smoke: view mounts, renders content, no uncaught page error) | ✅ Yes — every launcher view's path must be in the smoke matrix, and its spec/runner files must exist. |
+| **Dedicated e2e** | The `run-*-e2e.mjs` runners (real view → esbuild → headless Chromium, real interactions, video) | ✅ Existence of the referenced runner file is asserted; running it is a CI lane, not this vitest gate. |
+| **Manual / on-device capture** | `bun run --cwd packages/app audit:app` (live full-page audit), `capture:ios-sim` / `capture:android-emu` / `capture:linux-desktop` / `capture:windows-desktop`, video walkthroughs | ❌ No — needs a booted renderer / device; tracked here, produced in the PR-evidence lane per [`PR_EVIDENCE.md`](../../../PR_EVIDENCE.md). |
+
+The vitest gate is deliberately **boot-free** (file reads + set diffs), like its
+sibling [`route-coverage.test.ts`](../test/route-coverage.test.ts), so it runs on
+every PR in the cheap `test:client` lane instead of behind a ~12-min cold-renderer
+Playwright boot.
+
+## Inventory
+
+Every default-launcher view id from `BUILTIN_VIEWS`, its route, its kind, and its
+coverage. "Smoke" = covered by the desktop+mobile boot-smoke in
+`builtin-views-visual.spec.ts`. "Dedicated e2e" = a `run-*-e2e.mjs` runner that
+drives the real view. "Manual capture lane" = the on-device / audit-screenshot /
+video evidence that only the manual/CI lane produces.
+
+| View id | Path | Kind | Smoke | Dedicated e2e | Manual capture lane |
+| --- | --- | --- | --- | --- | --- |
+| `tutorial` | `/tutorial` | system | ✅ smoke | `packages/ui/src/components/pages/tutorial/__e2e__/run-tutorial-e2e.mjs` | `audit:app` + video |
+| `help` | `/help` | system | ✅ smoke | smoke-only | `audit:app` |
+| `chat` | `/chat` | system | ✅ smoke | `packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs` | `audit:app` + video + on-device |
+| `character` | `/character` | system | ✅ smoke | smoke-only | `audit:app` |
+| `documents` | `/character/documents` | system | ✅ smoke | smoke-only | `audit:app` |
+| `automations` | `/automations` | system | ✅ smoke | smoke-only | `audit:app` |
+| `plugins-page` | `/apps/plugins` | system | ✅ smoke | smoke-only | `audit:app` |
+| `trajectories` | `/apps/trajectories` | developer | ✅ smoke | smoke-only | `audit:app` (developer toggle on) |
+| `transcripts` | `/apps/transcripts` | system | ✅ smoke | smoke-only | `audit:app` + audio |
+| `memories` | `/apps/memories` | system | ✅ smoke | smoke-only | `audit:app` |
+| `database` | `/apps/database` | developer | ✅ smoke | smoke-only | `audit:app` (developer toggle on) |
+| `logs` | `/apps/logs` | developer | ✅ smoke | smoke-only | `audit:app` (developer toggle on) |
+| `settings` | `/settings` | system | ✅ smoke | smoke-only | `audit:app` + video |
+| `background` | `/background` | preview | ✅ smoke | `packages/ui/src/components/pages/__e2e__/run-background-e2e.mjs` | `audit:app` + video (preview toggle on) |
+
+### Coverage gaps
+
+**None.** Every default-launcher view has automated smoke coverage (cross-checked
+by the gate: each view's `path` is asserted present in
+`builtin-views-visual.spec.ts`'s `BUILTIN_VIEW_CASES`). Four views additionally
+have dedicated interaction e2e runners (`tutorial`, `chat`, `background`, and —
+via the shell chat-sheet runner — the `chat` surface). The remaining views are
+`smoke-only`: boot-smoke is their automated floor, and the manual/CI capture lane
+(`audit:app` + on-device captures) supplies the full-page-screenshot / video /
+device evidence per `PR_EVIDENCE.md`.
+
+If a launcher view is ever added with **no** smoke case, the gate's "every
+launcher view's smoke spec actually covers its declared path" assertion fails —
+so a real gap can never land silently.
+
+## How to add coverage for a new launcher view
+
+When you add a view to `BUILTIN_VIEWS` that is a default-launcher view (the gate
+tells you if it is), do all three:
+
+1. Add a `{ id, path }` case for the view's route to `BUILTIN_VIEW_CASES` in
+   [`packages/app/test/ui-smoke/builtin-views-visual.spec.ts`](../test/ui-smoke/builtin-views-visual.spec.ts).
+   (Add a dedicated `run-*-e2e.mjs` runner too if the view has real interactions
+   worth driving.)
+2. Add a `LAUNCHER_VIEW_COVERAGE` entry in
+   [`packages/app/test/launcher-view-coverage.test.ts`](../test/launcher-view-coverage.test.ts)
+   and update the pinned roster in its "stable set" test.
+3. Add a row to the inventory table above.
+
+Then capture the manual-lane evidence (`audit:app`, on-device where relevant) for
+the PR per `PR_EVIDENCE.md`.

--- a/packages/app/test/launcher-view-coverage.test.ts
+++ b/packages/app/test/launcher-view-coverage.test.ts
@@ -1,0 +1,289 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { type EnabledViewKinds, isViewVisible } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { BUILTIN_VIEWS } from "../../agent/src/api/builtin-views";
+
+/**
+ * Launcher-view e2e/smoke coverage gate (#10719, vitest, boot-free).
+ *
+ * Sibling to route-coverage.test.ts, but view-SPECIFIC: route-coverage proves
+ * every reachable ROUTE has an all-pages smoke click; this proves every
+ * default-LAUNCHER view (the tiles the /views grid renders from BUILTIN_VIEWS)
+ * has a checked-in coverage entry — a smoke spec at minimum, plus the dedicated
+ * e2e runner when one exists.
+ *
+ * The core acceptance criterion (issue #10719): adding a NEW launcher view to
+ * BUILTIN_VIEWS without a coverage entry FAILS here. LAUNCHER_VIEW_COVERAGE is
+ * the checked-in inventory the gate enforces; every launcher-visible view id
+ * must appear in it, every referenced spec/runner file must exist on disk, and
+ * every entry's smoke spec must actually cover the view's path in
+ * builtin-views-visual.spec.ts (so the map can't drift from reality).
+ *
+ * Evidence lanes this gate DOES and DOES NOT enforce:
+ *   - ENFORCED (automated, here): every launcher view is mapped, its spec/runner
+ *     files exist, and its path is in the desktop+mobile screenshot-smoke matrix.
+ *   - MANUAL / CI capture lane (NOT enforced here, tracked in
+ *     docs/LAUNCHER_VIEW_COVERAGE.md): live full-page audit screenshots
+ *     (`audit:app`), on-device captures (`capture:ios-sim` / `capture:android-emu`
+ *     / desktop), and video walkthroughs. Those need a booted renderer / device
+ *     and cannot run in cheap vitest.
+ */
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, "../../..");
+const BUILTIN_VIEWS_VISUAL_SPEC = path.join(
+  HERE,
+  "ui-smoke",
+  "builtin-views-visual.spec.ts",
+);
+
+/**
+ * AOSP-ElizaOS-fork-only native device surfaces. `useAvailableViews` strips
+ * these from the router + launcher on every other build (web, desktop, iOS,
+ * stock Play-Store Android), so they are NOT default-launcher views and are not
+ * gated here. Mirrors `NATIVE_OS_VIEW_IDS` in
+ * packages/ui/src/hooks/useAvailableViews.ts — keep in sync.
+ */
+const NATIVE_OS_VIEW_IDS: ReadonlySet<string> = new Set([
+  "phone",
+  "messages",
+  "contacts",
+  "camera",
+]);
+
+/**
+ * A view is a default-launcher view when the launcher filter would ever place
+ * it in the /views grid. Replicates the predicate from `mergeViewCatalog`
+ * (packages/ui/src/hooks/view-catalog.ts) + the native-OS strip in
+ * `useAvailableViews`:
+ *   - `visibleInManager !== false` (internal views are hidden), AND
+ *   - not a native-OS-fork-only surface (stripped on the default builds).
+ *
+ * `viewKind`/`developerOnly` are NOT part of this predicate: developer/preview
+ * views ARE launcher views — they render in the grid when the matching Settings
+ * toggle is on (`isViewVisible` gates them per-toggle, not out of the launcher).
+ * So they still require coverage.
+ */
+function isDefaultLauncherView(view: {
+  id: string;
+  visibleInManager?: boolean;
+}): boolean {
+  if (view.visibleInManager === false) return false;
+  if (NATIVE_OS_VIEW_IDS.has(view.id)) return false;
+  return true;
+}
+
+interface LauncherViewCoverage {
+  /**
+   * Smoke coverage: the desktop+mobile screenshot boot-smoke that guarantees the
+   * view mounts without an uncaught page error at both viewports. Value is the
+   * repo-relative path of the spec that covers it. Every launcher view MUST have
+   * one — it is the floor.
+   */
+  smokeSpec: string;
+  /**
+   * Dedicated interaction/flow e2e runner, when one exists (bundles the real
+   * view with esbuild → headless Chromium, drives real interactions, captures a
+   * video). Absent for views whose only automated coverage is the boot-smoke.
+   */
+  e2e?: string;
+}
+
+const BUILTIN_VIEWS_VISUAL_SPEC_REL = path.relative(
+  REPO_ROOT,
+  BUILTIN_VIEWS_VISUAL_SPEC,
+);
+
+/**
+ * The checked-in launcher-view coverage inventory. Every default-launcher view
+ * id from BUILTIN_VIEWS MUST appear here. `smokeSpec` is the boot-smoke that
+ * covers the view (asserted below to actually cover the view's path); `e2e`
+ * names the dedicated interaction runner when one exists.
+ *
+ * Human-readable table + evidence-lane notes: docs/LAUNCHER_VIEW_COVERAGE.md.
+ */
+const LAUNCHER_VIEW_COVERAGE: Record<string, LauncherViewCoverage> = {
+  tutorial: {
+    smokeSpec: BUILTIN_VIEWS_VISUAL_SPEC_REL,
+    e2e: "packages/ui/src/components/pages/tutorial/__e2e__/run-tutorial-e2e.mjs",
+  },
+  help: { smokeSpec: BUILTIN_VIEWS_VISUAL_SPEC_REL },
+  chat: {
+    smokeSpec: BUILTIN_VIEWS_VISUAL_SPEC_REL,
+    e2e: "packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs",
+  },
+  character: { smokeSpec: BUILTIN_VIEWS_VISUAL_SPEC_REL },
+  documents: { smokeSpec: BUILTIN_VIEWS_VISUAL_SPEC_REL },
+  automations: { smokeSpec: BUILTIN_VIEWS_VISUAL_SPEC_REL },
+  "plugins-page": { smokeSpec: BUILTIN_VIEWS_VISUAL_SPEC_REL },
+  trajectories: { smokeSpec: BUILTIN_VIEWS_VISUAL_SPEC_REL },
+  transcripts: { smokeSpec: BUILTIN_VIEWS_VISUAL_SPEC_REL },
+  memories: { smokeSpec: BUILTIN_VIEWS_VISUAL_SPEC_REL },
+  database: { smokeSpec: BUILTIN_VIEWS_VISUAL_SPEC_REL },
+  logs: { smokeSpec: BUILTIN_VIEWS_VISUAL_SPEC_REL },
+  settings: { smokeSpec: BUILTIN_VIEWS_VISUAL_SPEC_REL },
+  background: {
+    smokeSpec: BUILTIN_VIEWS_VISUAL_SPEC_REL,
+    e2e: "packages/ui/src/components/pages/__e2e__/run-background-e2e.mjs",
+  },
+};
+
+/** Repo-relative → path values the builtin-views-visual smoke spec covers. */
+function smokeSpecCoveredPaths(specRelPath: string): Set<string> {
+  const source = readFileSync(path.resolve(REPO_ROOT, specRelPath), "utf8");
+  return new Set(
+    [...source.matchAll(/path:\s*"([^"]+)"/g)].map((match) => match[1] ?? ""),
+  );
+}
+
+function defaultLauncherViews() {
+  return BUILTIN_VIEWS.filter(isDefaultLauncherView);
+}
+
+describe("launcher view coverage gate", () => {
+  it("every default-launcher view is present in the coverage map", () => {
+    const launcherViewIds = defaultLauncherViews().map((view) => view.id);
+    const uncovered = launcherViewIds.filter(
+      (id) => !(id in LAUNCHER_VIEW_COVERAGE),
+    );
+
+    expect(
+      uncovered,
+      [
+        `New launcher view(s) added to BUILTIN_VIEWS without coverage: ${uncovered.join(", ")}.`,
+        "To fix: (1) add a smoke case for the view's path to BUILTIN_VIEW_CASES in",
+        "packages/app/test/ui-smoke/builtin-views-visual.spec.ts (and a dedicated",
+        "e2e runner if the view has real interactions worth driving), then (2) add",
+        "a LAUNCHER_VIEW_COVERAGE entry here and a row in",
+        "packages/app/docs/LAUNCHER_VIEW_COVERAGE.md.",
+      ].join(" "),
+    ).toEqual([]);
+  });
+
+  it("coverage map has no stale entries (every mapped id is still a launcher view)", () => {
+    const launcherViewIds = new Set(
+      defaultLauncherViews().map((view) => view.id),
+    );
+    const stale = Object.keys(LAUNCHER_VIEW_COVERAGE).filter(
+      (id) => !launcherViewIds.has(id),
+    );
+
+    expect(
+      stale,
+      `LAUNCHER_VIEW_COVERAGE references ids that are no longer default-launcher views: ${stale.join(", ")}. Remove them.`,
+    ).toEqual([]);
+  });
+
+  it("every referenced smoke spec and e2e runner file exists on disk", () => {
+    const missing: string[] = [];
+    for (const [id, coverage] of Object.entries(LAUNCHER_VIEW_COVERAGE)) {
+      const smokeAbs = path.resolve(REPO_ROOT, coverage.smokeSpec);
+      if (!existsSync(smokeAbs)) {
+        missing.push(`${id} smokeSpec ${coverage.smokeSpec}`);
+      }
+      if (coverage.e2e) {
+        const e2eAbs = path.resolve(REPO_ROOT, coverage.e2e);
+        if (!existsSync(e2eAbs)) {
+          missing.push(`${id} e2e ${coverage.e2e}`);
+        }
+      }
+    }
+
+    expect(
+      missing,
+      `Coverage map references files that do not exist: ${missing.join(", ")}. Fix the path or add the missing spec/runner.`,
+    ).toEqual([]);
+  });
+
+  it("every launcher view's smoke spec actually covers its declared path", () => {
+    const byPathCache = new Map<string, Set<string>>();
+    const failures: string[] = [];
+
+    for (const view of defaultLauncherViews()) {
+      const coverage = LAUNCHER_VIEW_COVERAGE[view.id];
+      // Presence is asserted by a separate test; skip here so the failure is
+      // reported once, by the right test.
+      if (!coverage) continue;
+      if (!view.path) {
+        failures.push(`${view.id} has no path in BUILTIN_VIEWS`);
+        continue;
+      }
+      let covered = byPathCache.get(coverage.smokeSpec);
+      if (!covered) {
+        covered = smokeSpecCoveredPaths(coverage.smokeSpec);
+        byPathCache.set(coverage.smokeSpec, covered);
+      }
+      if (!covered.has(view.path)) {
+        failures.push(
+          `${view.id} (${view.path}) is not covered by ${coverage.smokeSpec}`,
+        );
+      }
+    }
+
+    expect(
+      failures,
+      [
+        `Launcher view path(s) missing from their mapped smoke spec: ${failures.join("; ")}.`,
+        "The smoke spec's BUILTIN_VIEW_CASES must include a case whose `path`",
+        "matches the view's BUILTIN_VIEWS `path`.",
+      ].join(" "),
+    ).toEqual([]);
+  });
+
+  it("covers a stable, non-empty set of launcher views", () => {
+    const launcherViewIds = defaultLauncherViews()
+      .map((view) => view.id)
+      .sort();
+    // Guards against a bad predicate silently emptying the set (which would make
+    // every other assertion trivially pass). This is the current default-launcher
+    // roster; update it (and the doc) when BUILTIN_VIEWS changes intentionally.
+    expect(launcherViewIds).toEqual(
+      [
+        "automations",
+        "background",
+        "character",
+        "chat",
+        "database",
+        "documents",
+        "help",
+        "logs",
+        "memories",
+        "plugins-page",
+        "settings",
+        "trajectories",
+        "transcripts",
+        "tutorial",
+      ].sort(),
+    );
+  });
+
+  it("developer/preview launcher views are gated by their Settings toggle, not out of the launcher", () => {
+    // A launcher view's per-build visibility is
+    //   isDefaultLauncherView(v) && isViewVisible(v, enabledKinds).
+    // Proving `isViewVisible` gates developer/preview views (rather than the
+    // launcher predicate excluding them) is why the coverage map must still cover
+    // them: they DO render in the grid when the toggle is on.
+    const TOGGLES_OFF: EnabledViewKinds = { developer: false, preview: false };
+    const TOGGLES_ON: EnabledViewKinds = { developer: true, preview: true };
+
+    const gatedByToggle = defaultLauncherViews().filter(
+      (view) =>
+        !isViewVisible(view, TOGGLES_OFF) && isViewVisible(view, TOGGLES_ON),
+    );
+    const gatedIds = gatedByToggle.map((view) => view.id).sort();
+
+    // trajectories/database/logs are developer-kind; background is preview-kind.
+    expect(gatedIds).toEqual(
+      ["background", "database", "logs", "trajectories"].sort(),
+    );
+    // Each toggle-gated view is still a default-launcher view and still covered.
+    for (const view of gatedByToggle) {
+      expect(
+        LAUNCHER_VIEW_COVERAGE[view.id],
+        `toggle-gated launcher view "${view.id}" must still be in the coverage map`,
+      ).toBeDefined();
+    }
+  });
+});


### PR DESCRIPTION
## What & why

Closes the standing-baseline half of **#10719**: a boot-free **launcher-view coverage gate** so *adding a new default-launcher view without coverage fails a check*, plus a checked-in view inventory. This is the "CI step that flags a newly-added launcher view with no e2e test + capture" acceptance criterion.

It is deliberately **view-specific** and complements the existing `route-coverage.test.ts` (which proves every reachable *route* has an all-pages smoke click). This one proves every default-**launcher** view — the tiles the `/views` grid renders from `BUILTIN_VIEWS` — has a checked-in coverage entry.

## What it enforces (6 tests, `packages/app/test/launcher-view-coverage.test.ts`)

- Enumerates the default-launcher set from `BUILTIN_VIEWS` (source of truth), replicating the real launcher predicate: `visibleInManager !== false` and not a native-OS-fork-only surface (`phone/messages/contacts/camera`, stripped by `useAvailableViews` on default builds). `developer`/`preview` views are still gated (they render per Settings toggle), proven via `isViewVisible`.
- **Every launcher-visible view id must be in `LAUNCHER_VIEW_COVERAGE`** → a new view added to `BUILTIN_VIEWS` without a coverage entry fails here (the core criterion).
- No stale map entries; every referenced smoke spec + e2e runner file exists on disk (`existsSync`); every view's `path` is actually present in `builtin-views-visual.spec.ts`'s `BUILTIN_VIEW_CASES` (parsed from source, so the map can't silently drift from reality).
- The presence-failure message tells a contributor the exact 3 steps to fix.

## Inventory (`packages/app/docs/LAUNCHER_VIEW_COVERAGE.md`)

14 default-launcher views, **all covered, no gaps**: `tutorial, help, chat, character, documents, automations, plugins-page, trajectories, transcripts, memories, database, logs, settings, background`. All have desktop+mobile screenshot-smoke; 3 have dedicated e2e runners (`tutorial`, `chat`, `background`). `camera` is excluded as native-OS-only (`platforms: ["android"]`). The doc's evidence-lane table marks which artifacts are **enforced here** vs the **manual/CI capture lane** (`audit:app`, `capture:ios-sim/android-emu/desktop`, video).

## Evidence

- **Gate green:** `bun run --cwd packages/app vitest run test/launcher-view-coverage.test.ts` → **6 passed (6)**. Independently re-run on the pushed tip.
- **Gate actually catches a new uncovered view** (the whole point): temporarily added `{ id: "fake-uncovered-view", visibleInManager: true, path: "/fake-uncovered" }` to `BUILTIN_VIEWS` → gate failed **2 failed | 4 passed** with `New launcher view(s) added to BUILTIN_VIEWS without coverage: fake-uncovered-view` — then reverted (working tree byte-clean; `builtin-views.ts` unmodified in this PR).
- **Backend logs / real-LLM trajectory / screenshots / device capture: N/A** — this PR adds a *static coverage gate*, not a UI/agent code path. It has no runtime behavior of its own; it exists to *require* those capture lanes for future views. `builtin-views.ts` is untouched.
- **Typecheck:** the two new files add zero type errors. (Pre-existing `@stwd/sdk` version-skew error in `cloud-ui/.../authorize-content.tsx` is on `develop`, unmodified here.)

## Scope note

The full per-view video + on-device/simulator walkthrough matrix from the issue is the **manual/CI capture lane** documented in the inventory — it needs a booted renderer/device and can't run in cheap vitest. This PR nails down the enforceable, boot-free half; the doc is the source of truth for the rest.
