### PR TITLE
fix(agent): export createLocalAgentBackup/listLocalAgentBackups from the barrel

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -197,6 +197,7 @@ export * from "./contracts/awareness.ts";
 export * from "./diagnostics/integration-observability.ts";
 export * from "./hooks/index.ts";
 export * from "./providers/workspace.ts";
+export * from "./services/agent-backup.ts";
 export * from "./runtime/advanced-capabilities-config.ts";
 export * from "./runtime/agent-event-service.ts";
 export * from "./runtime/core-plugins.ts";


### PR DESCRIPTION
## What & why

`@elizaos/plugin-personal-assistant` fails typecheck against `@elizaos/agent`'s built types because `services/agent-backup.ts` — whose functions are genuinely public API — was **never re-exported from the package barrel** (`packages/agent/src/index.ts`). `packages/agent/src/api/server.ts` imports `createLocalAgentBackup` / `listLocalAgentBackups` from the local module, but external consumers resolving `@elizaos/agent` never got them:

```
plugins/plugin-personal-assistant (tsc -p tsconfig.build.json):
  src/lifeops/scheduled-task/runtime-wiring.ts(11): Module '"@elizaos/agent"' has no exported member 'createLocalAgentBackup'.
  src/providers/first-run.ts(15):                    Module '"@elizaos/agent"' has no exported member 'listLocalAgentBackups'.
```

## Fix

One line — add `export * from "./services/agent-backup.ts"` to the barrel (its exports: `createAgentSnapshot`, `createLocalAgentBackup`, `listLocalAgentBackups`, `restoreAgentSnapshot`, `restoreLocalAgentBackup`, + the backup interfaces). No name collision.

## Verification

```
# before (develop): 3 errors in plugin-personal-assistant
# after (this change + the dist rebuild CI runs before typecheck):
packages/agent                 typecheck → exit 0   (no collision from the new export)
plugins/plugin-personal-assistant  typecheck → exit 0   (was 2× TS2305 + 1 stale-dist TS2339)
```

The third pre-existing error (`ScheduledTaskDispatchRecord` missing `metadata`) was a **stale local dist** of `@elizaos/plugin-scheduling` — its `src` already declares `metadata?`, so a fresh build (as CI does) resolves it; no source change needed there.

## Evidence

- **Visual / on-device: N/A** — this is a package-barrel/typecheck fix with no runtime UI surface. Proof is the typecheck transcript above (3 errors → exit 0).
- **Real-LLM trajectory: N/A** — no model/prompt/runtime-behavior change; a pure public-API export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
