### PR TITLE
fix(cloud): idempotent app-creator earnings — stop settlement-retry double-credit (#10423)

### DIFF
--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -1434,7 +1434,9 @@ async function handleStreamingRequest(
             estimatedBaseCost: appCreditsInfo.estimatedBaseCost,
             actualBaseCost: billing.totalCost,
             description: `Chat reconciliation: ${model}`,
-            metadata: { model, provider, billingSource, streaming: true },
+            // #10423: stable per-request key so a settlement retry doesn't
+            // double-credit the app creator's redeemable earnings.
+            metadata: { model, provider, billingSource, streaming: true, idempotencyKey },
           });
         }
 

--- a/packages/cloud/api/v1/messages/route.ts
+++ b/packages/cloud/api/v1/messages/route.ts
@@ -779,6 +779,9 @@ async function handleNonStream(
   billingSource: PricingBillingSource,
 ) {
   const provider = getProviderFromModel(model);
+  // #10423: stable per-request key so a settlement retry doesn't double-credit
+  // the app creator's redeemable earnings.
+  const requestId = crypto.randomUUID();
 
   const cotBudget = resolveAnthropicThinkingBudgetTokens(model, process.env);
   const cotOptions =
@@ -829,7 +832,7 @@ async function handleNonStream(
         estimatedBaseCost: appCreditsInfo.estimatedBaseCost,
         actualBaseCost: billing.totalCost,
         description: `Messages API: ${model}`,
-        metadata: { model, provider, billingSource, streaming: false },
+        metadata: { model, provider, billingSource, streaming: false, idempotencyKey: requestId },
       });
     }
 
@@ -931,6 +934,9 @@ async function handleStream(
 ) {
   const provider = getProviderFromModel(model);
   const messageId = `msg_${crypto.randomUUID().replace(/-/g, "").slice(0, 24)}`;
+  // #10423: stable per-request key so a streaming settlement retry doesn't
+  // double-credit the app creator's redeemable earnings.
+  const requestId = crypto.randomUUID();
 
   const cotBudget = resolveAnthropicThinkingBudgetTokens(model, process.env);
   const cotOptions =
@@ -980,7 +986,7 @@ async function handleStream(
             estimatedBaseCost: appCreditsInfo.estimatedBaseCost,
             actualBaseCost: billing.totalCost,
             description: `Messages API stream: ${model}`,
-            metadata: { model, provider, billingSource, streaming: true },
+            metadata: { model, provider, billingSource, streaming: true, idempotencyKey: requestId },
           });
         }
 

--- a/packages/cloud/shared/src/lib/services/__tests__/creator-earnings-idempotency.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/creator-earnings-idempotency.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Creator-earnings idempotency (#10423) — real Drizzle schema, in-process PGlite.
+ *
+ * The reported money bug: app/agent inference creator-earnings called
+ * `redeemableEarningsService.addEarnings` WITHOUT `dedupeBySourceId` and keyed
+ * on `appId` (which repeats across every charge), so a settlement retry (a
+ * re-run of the chat/message `onFinish` for the SAME request) double-credited
+ * the creator. The fix keys the credit on a stable per-charge id
+ * (`idempotencyKey`/`stripePaymentIntentId`) with `dedupeBySourceId: true`.
+ *
+ * These tests drive the REAL `addEarnings` against PGlite and assert:
+ *   1. Same (source, sourceId) + dedupe → credited ONCE; the retry returns
+ *      `deduplicated: true` and adds no ledger 'earning' row.
+ *   2. The OLD behavior (no dedupe, appId-keyed) DOUBLE-credits — pinning the bug.
+ *   3. `normalizeLedgerSourceId` maps the composite key deterministically, so a
+ *      retry of the same request dedupes while distinct requests do not.
+ *
+ * Self-skips LOUDLY if PGlite/pushSchema is unavailable (never silently passes).
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
+const CAN_USE_ISOLATED_PGLITE =
+  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { pushSchema } from "drizzle-kit/api";
+import { and, eq } from "drizzle-orm";
+import { closeDatabaseConnectionsForTests, dbWrite } from "../../../db/client";
+import {
+  earningsSourceEnum,
+  ledgerEntryTypeEnum,
+  redeemableEarnings,
+  redeemableEarningsLedger,
+  redeemedEarningsTracking,
+} from "../../../db/schemas/redeemable-earnings";
+import { organizations } from "../../../db/schemas/organizations";
+import { users } from "../../../db/schemas/users";
+
+const PGLITE_TIMEOUT = 60_000;
+let pgliteReady = true;
+let redeemableEarningsService: typeof import("../redeemable-earnings").redeemableEarningsService;
+
+let seq = 0;
+function uniq(p: string): string {
+  seq += 1;
+  return `${p}-${seq}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function seedUser(): Promise<string> {
+  const [org] = await dbWrite
+    .insert(organizations)
+    .values({ name: "Org", slug: uniq("org") })
+    .returning();
+  const [user] = await dbWrite
+    .insert(users)
+    .values({ steward_user_id: uniq("steward"), organization_id: org.id })
+    .returning();
+  return user.id;
+}
+
+async function balanceOf(userId: string): Promise<number> {
+  const row = await dbWrite.query.redeemableEarnings.findFirst({
+    where: eq(redeemableEarnings.user_id, userId),
+  });
+  return Number(row?.available_balance ?? 0);
+}
+
+async function earningLedgerCount(userId: string): Promise<number> {
+  const rows = await dbWrite.query.redeemableEarningsLedger.findMany({
+    where: and(
+      eq(redeemableEarningsLedger.user_id, userId),
+      eq(redeemableEarningsLedger.entry_type, "earning"),
+    ),
+  });
+  return rows.length;
+}
+
+beforeAll(async () => {
+  if (!CAN_USE_ISOLATED_PGLITE) {
+    pgliteReady = false;
+    console.warn(
+      "[creator-earnings-idempotency.test] non-PGlite DATABASE_URL; self-skipping isolation suite.",
+    );
+    return;
+  }
+  try {
+    ({ redeemableEarningsService } = await import("../redeemable-earnings"));
+    const schema = {
+      organizations,
+      users,
+      redeemableEarnings,
+      redeemableEarningsLedger,
+      redeemedEarningsTracking,
+      earningsSourceEnum,
+      ledgerEntryTypeEnum,
+    };
+    const { apply } = await pushSchema(schema as never, dbWrite as never);
+    await apply();
+  } catch (error) {
+    pgliteReady = false;
+    console.error(
+      "[creator-earnings-idempotency.test] PGlite/pushSchema unavailable — skipping.",
+      error,
+    );
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests();
+});
+
+describe("creator earnings idempotency (#10423)", () => {
+  let userId: string;
+  beforeEach(async () => {
+    if (!pgliteReady) return;
+    userId = await seedUser();
+  });
+
+  test("FIX: same per-charge key + dedupe credits once; the retry is deduplicated", async () => {
+    if (!pgliteReady) return;
+    const sourceId = "req-abc:inference_markup"; // a retried onFinish reuses this
+    const first = await redeemableEarningsService.addEarnings({
+      userId,
+      amount: 0.5,
+      source: "miniapp",
+      sourceId,
+      dedupeBySourceId: true,
+      description: "Inference markup",
+    });
+    const second = await redeemableEarningsService.addEarnings({
+      userId,
+      amount: 0.5,
+      source: "miniapp",
+      sourceId,
+      dedupeBySourceId: true,
+      description: "Inference markup",
+    });
+
+    expect(first.success).toBe(true);
+    expect(first.deduplicated).toBe(false);
+    expect(second.success).toBe(true);
+    expect(second.deduplicated).toBe(true);
+    expect(await balanceOf(userId)).toBeCloseTo(0.5, 6);
+    expect(await earningLedgerCount(userId)).toBe(1);
+  });
+
+  test("BUG (pinned): the old appId-keyed, no-dedupe behavior double-credits", async () => {
+    if (!pgliteReady) return;
+    // Two charges from the SAME request that both key on appId with no dedupe —
+    // exactly the pre-fix behavior — accrue twice.
+    const appScopedId = "11111111-1111-4111-8111-111111111111"; // an appId
+    await redeemableEarningsService.addEarnings({
+      userId,
+      amount: 0.5,
+      source: "miniapp",
+      sourceId: appScopedId,
+      description: "Inference markup",
+    });
+    await redeemableEarningsService.addEarnings({
+      userId,
+      amount: 0.5,
+      source: "miniapp",
+      sourceId: appScopedId,
+      description: "Inference markup",
+    });
+    expect(await balanceOf(userId)).toBeCloseTo(1.0, 6);
+    expect(await earningLedgerCount(userId)).toBe(2);
+  });
+
+  test("distinct requests still credit separately (dedupe is per-charge, not per-app)", async () => {
+    if (!pgliteReady) return;
+    await redeemableEarningsService.addEarnings({
+      userId,
+      amount: 0.3,
+      source: "miniapp",
+      sourceId: "req-1:inference_markup",
+      dedupeBySourceId: true,
+      description: "markup",
+    });
+    await redeemableEarningsService.addEarnings({
+      userId,
+      amount: 0.3,
+      source: "miniapp",
+      sourceId: "req-2:inference_markup",
+      dedupeBySourceId: true,
+      description: "markup",
+    });
+    expect(await balanceOf(userId)).toBeCloseTo(0.6, 6);
+    expect(await earningLedgerCount(userId)).toBe(2);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/app-credits.ts
+++ b/packages/cloud/shared/src/lib/services/app-credits.ts
@@ -832,11 +832,25 @@ export class AppCreditsService {
     // Use provided app to avoid N+1 query, or fetch if not provided
     const app = providedApp ?? (await appsRepository.findById(appId));
     if (app?.created_by_user_id) {
+      // #10423: make the creator credit IDEMPOTENT. A settlement retry (a
+      // re-run of the chat/message `onFinish` for the SAME request, or a
+      // webhook retry) must not double-credit. Key on a stable per-charge id —
+      // the request idempotency key (inference) or the Stripe payment intent
+      // (purchase) — never on `appId`, which repeats across every charge.
+      // Fall back to the (non-idempotent) app-scoped id only when no per-charge
+      // key is present, preserving the prior behavior for callers without one.
+      const chargeKey =
+        (typeof metadata.idempotencyKey === "string" && metadata.idempotencyKey) ||
+        (typeof metadata.stripePaymentIntentId === "string" && metadata.stripePaymentIntentId) ||
+        null;
+      const sourceId = chargeKey ? `${chargeKey}:${type}` : appId;
+
       const result = await redeemableEarningsService.addEarnings({
         userId: app.created_by_user_id,
         amount,
         source: "miniapp", // Database enum value - "miniapp" refers to apps
-        sourceId: appId,
+        sourceId,
+        dedupeBySourceId: chargeKey !== null,
         description:
           type === "inference_markup"
             ? `Inference markup from app: ${app.name || appId}`
@@ -848,6 +862,15 @@ export class AppCreditsService {
           ...metadata,
         },
       });
+
+      if (result.deduplicated) {
+        logger.info("[AppCredits] Creator earning already recorded — skipped duplicate", {
+          appId,
+          creatorId: app.created_by_user_id,
+          amount,
+          sourceId,
+        });
+      }
 
       if (!result.success) {
         logger.error("[AppCredits] Failed to credit redeemable earnings", {

--- a/packages/cloud/shared/src/lib/services/redeemable-earnings.ts
+++ b/packages/cloud/shared/src/lib/services/redeemable-earnings.ts
@@ -55,6 +55,8 @@ interface AddEarningsResult {
   success: boolean;
   newBalance: number;
   ledgerEntryId: string;
+  /** True when an existing (source, sourceId) ledger entry was reused (dedupeBySourceId). */
+  deduplicated?: boolean;
   error?: string;
 }
 
@@ -333,6 +335,7 @@ class RedeemableEarningsService {
         success: true,
         newBalance: Number(result.earnings?.available_balance ?? 0),
         ledgerEntryId: result.ledgerEntryId,
+        deduplicated: true,
       };
     }
 
@@ -348,6 +351,7 @@ class RedeemableEarningsService {
       success: true,
       newBalance: Number(result.earnings.available_balance),
       ledgerEntryId: result.ledgerEntryId,
+      deduplicated: false,
     };
   }
 


### PR DESCRIPTION
## Idempotent app-creator earnings — stop the settlement-retry double-credit (#10423)

### The bug

The app/agent inference billing path credited the creator's **redeemable earnings** via `redeemableEarningsService.addEarnings` **without `dedupeBySourceId`**, keyed on `appId` (`app-credits.ts` `recordCreatorEarnings`). `appId` repeats across *every* charge, so:

- A **settlement retry** — a re-run of the chat/message `onFinish` for the **same request** (isolate recycle, `waitUntil` re-fire) — credited the creator **again** (and double-debited the user).
- The ledger `source_idx` is non-unique, so there was no DB backstop either.

The purchase-share path was already protected by upstream Stripe payment-intent dedup; this is the inference-markup gap #10423 flags.

### The fix

`recordCreatorEarnings` now keys the credit on a **stable per-charge id** and enables dedupe:

- **Inference:** the request idempotency key (`idempotency-key`/`x-request-id` on `chat/completions`; a stable per-invocation key on `messages`), threaded into the reconcile metadata.
- **Purchase:** `stripePaymentIntentId` (already in the metadata).
- `sourceId = \`${chargeKey}:${type}\`` with `dedupeBySourceId: true`. `normalizeLedgerSourceId` hashes this to a deterministic uuid, so a retry of the same charge resolves to the same ledger row and reuses it.
- **Safe fallback:** when no per-charge key is present, it keeps the prior `appId`-keyed, no-dedupe behavior — so no existing caller changes.

`AddEarningsResult` now surfaces `deduplicated` so callers/tests can observe the skip.

### Evidence

Real-PGlite test (`creator-earnings-idempotency.test.ts`, 3 pass) proves **both** sides:
- **Bug pinned:** two `addEarnings` calls with the old appId key + no dedupe → balance `1.0`, two ledger rows.
- **Fix:** two calls with the same per-charge key + dedupe → balance `0.5`, one ledger row, second call `deduplicated: true`.
- **No over-dedup:** two *distinct* request keys still credit separately (`0.6`, two rows).

`tsc --noEmit` clean across `cloud-shared` + `cloud-api`.

### Scope / notes

- This fixes the **creator redeemable double-credit** (the load-bearing money). The `app_earnings` shadow table (non-load-bearing analytics, per the monetization review) is not reordered here; a retry can still double-count that shadow counter — a follow-up, not lost/double money.
- The `messages` route uses a stable per-invocation key (the retry-within-settlement case); `chat/completions` additionally honors the client `idempotency-key`/`x-request-id` header for cross-request idempotency.

**MONEY PATH — do not self-merge; needs ops review** per repo policy.

Part of #10423.
