### PR TITLE
fix(local-inference): avoid CPU embedding preset on GPU hosts

### DIFF
--- a/.github/issue-evidence/10727-local-embedding-accelerator.md
+++ b/.github/issue-evidence/10727-local-embedding-accelerator.md
@@ -1,0 +1,70 @@
+# 10727 local embedding accelerator preset evidence
+
+Date: 2026-07-01
+Branch: `codex/fix/10727-local-embedding-accelerator`
+PR: https://github.com/elizaOS/eliza/pull/10814
+
+## What changed
+
+The local embedding preset detector no longer treats every non-Apple-Silicon
+host as CPU-only. It now keeps CPU fallback for low-RAM or CPU-only machines,
+selects the accelerated `gpuLayers: "auto"` preset for Metal/CUDA/Vulkan-capable
+profiles, and exposes a hardware-profile helper for async probe consumers.
+
+## Commands run
+
+```bash
+bun run --cwd plugins/plugin-local-inference lint:check
+# PASS - Checked 426 files. No fixes applied.
+
+bun run --cwd plugins/plugin-local-inference typecheck
+# PASS - tsgo --noEmit
+
+bunx vitest run plugins/plugin-local-inference/src/runtime/embedding-presets.test.ts
+# PASS - 1 file, 6 tests
+```
+
+Before the final rebase, the full plugin suite passed:
+
+```bash
+bun run --cwd plugins/plugin-local-inference test
+# PASS - 220 test files passed, 1 skipped
+# PASS - 2200 tests passed, 14 skipped
+```
+
+After the final rebase, a full plugin-suite rerun hit four timeout failures under
+machine contention in unrelated tests:
+
+- `__tests__/freeze-voice-cli.test.ts`
+- `__tests__/imagegen-sd-cpp-probe.test.ts`
+- `src/local-inference-routes.test.ts`
+- `src/services/ffi-unload-ordering.test.ts`
+
+Those exact files passed in isolation:
+
+```bash
+bunx vitest run --root plugins/plugin-local-inference \
+  __tests__/freeze-voice-cli.test.ts \
+  __tests__/imagegen-sd-cpp-probe.test.ts \
+  src/local-inference-routes.test.ts \
+  src/services/ffi-unload-ordering.test.ts
+# PASS - 4 files, 33 tests
+```
+
+Repo-level verify was attempted and stopped before package checks on unrelated
+type-safety ratchet baseline drift:
+
+```bash
+bun run verify
+# FAIL in audit:type-safety-ratchet
+# as unknown as: 109 current > 77 baseline
+# ?? 0 (core/agent/app-core): 384 current > 380 baseline
+```
+
+## N/A evidence
+
+- UI screenshots/video: N/A - no UI surface changed.
+- Real LLM trajectory: N/A - no prompt, action, provider, or model trajectory changed.
+- On-device model lifecycle matrix: not captured here. This PR fixes the concrete
+  CPU-default preset bug called out in #10727; the full model/device matrix still
+  requires the target hardware fleet.

--- a/plugins/plugin-local-inference/src/index.ts
+++ b/plugins/plugin-local-inference/src/index.ts
@@ -55,8 +55,12 @@ export {
 // Embedding preset detection exported for runtime boot wiring.
 export {
 	detectEmbeddingPreset,
+	detectEmbeddingPresetForHardware,
 	detectEmbeddingTier,
+	detectEmbeddingTierForHardware,
 	EMBEDDING_PRESETS,
+	type EmbeddingAcceleratorBackend,
+	type EmbeddingHardwareProfile,
 	type EmbeddingPreset,
 	type EmbeddingTier,
 } from "./runtime/embedding-presets.js";

--- a/plugins/plugin-local-inference/src/runtime/embedding-presets.test.ts
+++ b/plugins/plugin-local-inference/src/runtime/embedding-presets.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+	detectEmbeddingPresetForHardware,
+	detectEmbeddingTierForHardware,
+} from "./embedding-presets";
+
+describe("embedding preset detection", () => {
+	it.each([
+		"metal",
+		"cuda",
+		"vulkan",
+	] as const)("uses the accelerated preset for %s hosts", (gpuBackend) => {
+		expect(detectEmbeddingTierForHardware({ totalRamGB: 32, gpuBackend })).toBe(
+			"standard",
+		);
+		expect(
+			detectEmbeddingPresetForHardware({ totalRamGB: 32, gpuBackend })
+				.gpuLayers,
+		).toBe("auto");
+	});
+
+	it("keeps CPU fallback for CPU-only hosts", () => {
+		expect(
+			detectEmbeddingPresetForHardware({
+				totalRamGB: 32,
+				gpuBackend: null,
+			}).gpuLayers,
+		).toBe(0);
+	});
+
+	it("keeps CPU fallback for low-RAM hosts even when a GPU is present", () => {
+		expect(
+			detectEmbeddingTierForHardware({
+				totalRamGB: 8,
+				gpuBackend: "cuda",
+			}),
+		).toBe("fallback");
+	});
+
+	it("uses the performance preset only on large accelerated hosts", () => {
+		expect(
+			detectEmbeddingTierForHardware({
+				totalRamGB: 128,
+				gpuBackend: "cuda",
+			}),
+		).toBe("performance");
+		expect(
+			detectEmbeddingTierForHardware({
+				totalRamGB: 128,
+				gpuBackend: null,
+			}),
+		).toBe("fallback");
+	});
+});

--- a/plugins/plugin-local-inference/src/runtime/embedding-presets.ts
+++ b/plugins/plugin-local-inference/src/runtime/embedding-presets.ts
@@ -1,6 +1,13 @@
 import os from "node:os";
+import { detectGpu } from "../services/gpu-detect.js";
 
 export type EmbeddingTier = "fallback" | "standard" | "performance";
+export type EmbeddingAcceleratorBackend = "cuda" | "metal" | "vulkan";
+
+export interface EmbeddingHardwareProfile {
+	totalRamGB: number;
+	gpuBackend?: EmbeddingAcceleratorBackend | null;
+}
 
 export interface EmbeddingPreset {
 	tier: EmbeddingTier;
@@ -29,8 +36,7 @@ export const EMBEDDING_PRESETS: Record<EmbeddingTier, EmbeddingPreset> = {
 	fallback: {
 		tier: "fallback",
 		label: "Efficient (CPU)",
-		description:
-			"gte-small local embeddings for Intel Macs and low-RAM machines",
+		description: "gte-small local embeddings for CPU-only and low-RAM machines",
 		model: GTE_SMALL_EMBEDDING.model,
 		modelRepo: GTE_SMALL_EMBEDDING.modelRepo,
 		dimensions: GTE_SMALL_EMBEDDING.dimensions,
@@ -40,8 +46,8 @@ export const EMBEDDING_PRESETS: Record<EmbeddingTier, EmbeddingPreset> = {
 	},
 	standard: {
 		tier: "standard",
-		label: "Efficient (Metal GPU)",
-		description: "gte-small local embeddings with Metal acceleration",
+		label: "Efficient (GPU)",
+		description: "gte-small local embeddings with GPU acceleration",
 		model: GTE_SMALL_EMBEDDING.model,
 		modelRepo: GTE_SMALL_EMBEDDING.modelRepo,
 		dimensions: GTE_SMALL_EMBEDDING.dimensions,
@@ -65,15 +71,36 @@ export const EMBEDDING_PRESETS: Record<EmbeddingTier, EmbeddingPreset> = {
 };
 
 const BYTES_PER_GB = 1024 ** 3;
+const LOW_RAM_FALLBACK_GB = 8;
+const PERFORMANCE_RAM_GB = 128;
+
+export function detectEmbeddingTierForHardware(
+	hardware: EmbeddingHardwareProfile,
+): EmbeddingTier {
+	if (hardware.totalRamGB <= LOW_RAM_FALLBACK_GB) return "fallback";
+	if (!hardware.gpuBackend) return "fallback";
+	if (hardware.totalRamGB >= PERFORMANCE_RAM_GB) return "performance";
+	return "standard";
+}
+
+export function detectEmbeddingPresetForHardware(
+	hardware: EmbeddingHardwareProfile,
+): EmbeddingPreset {
+	return EMBEDDING_PRESETS[detectEmbeddingTierForHardware(hardware)];
+}
+
+function detectLocalEmbeddingGpuBackend(): EmbeddingAcceleratorBackend | null {
+	if (process.platform === "darwin") return "metal";
+	const gpu = detectGpu();
+	return gpu.nvidiaPresent && gpu.gpu ? "cuda" : null;
+}
 
 export function detectEmbeddingTier(): EmbeddingTier {
 	const totalRamGB = Math.round(os.totalmem() / BYTES_PER_GB);
-	const isMac = process.platform === "darwin";
-	const isAppleSilicon = isMac && process.arch === "arm64";
-
-	if (!isAppleSilicon || totalRamGB <= 8) return "fallback";
-	if (totalRamGB >= 128) return "performance";
-	return "standard";
+	return detectEmbeddingTierForHardware({
+		totalRamGB,
+		gpuBackend: detectLocalEmbeddingGpuBackend(),
+	});
 }
 
 export function detectEmbeddingPreset(): EmbeddingPreset {

--- a/plugins/plugin-local-inference/src/runtime/index.ts
+++ b/plugins/plugin-local-inference/src/runtime/index.ts
@@ -20,7 +20,13 @@ export {
 	findExistingEmbeddingModelForWarmupReuse,
 	isEmbeddingWarmupReuseDisabled,
 } from "./embedding-manager-support.js";
-export { detectEmbeddingPreset } from "./embedding-presets.js";
+export {
+	detectEmbeddingPreset,
+	detectEmbeddingPresetForHardware,
+	detectEmbeddingTierForHardware,
+	type EmbeddingAcceleratorBackend,
+	type EmbeddingHardwareProfile,
+} from "./embedding-presets.js";
 export { shouldWarmupLocalEmbeddingModel } from "./embedding-warmup-policy.js";
 export { ensureLocalInferenceHandler } from "./ensure-local-inference-handler.js";
 export {


### PR DESCRIPTION
## Summary
- Fix local embedding preset detection so CUDA and macOS Metal hosts choose the accelerated `gpuLayers: "auto"` preset instead of the CPU fallback.
- Add hardware-profile helpers for callers that already have an async hardware probe, including Vulkan-capable devices.
- Cover accelerated, CPU-only, low-RAM, and large-host tier decisions with focused runtime tests.

Relates to #10727.

## Evidence
See `.github/issue-evidence/10727-local-embedding-accelerator.md` for the durable evidence note.

- `bun run --cwd plugins/plugin-local-inference lint:check` ✅
- `bun run --cwd plugins/plugin-local-inference typecheck` ✅
- `bunx vitest run plugins/plugin-local-inference/src/runtime/embedding-presets.test.ts` ✅
- `bun run --cwd plugins/plugin-local-inference test` ✅ before the final rebase: 2200 passed / 14 skipped. After rebase, the full suite hit four timeout failures under machine contention; rerunning those exact four files in isolation passed: 33 passed.
- `bun run verify` ❌ blocked before package checks by existing repo-wide type-safety ratchet baseline drift unrelated to this change: `as unknown as` current 109 > baseline 77, and `?? 0` current 384 > baseline 380.

## Evidence N/A
- UI screenshots/video: N/A - no UI surface changed.
- Real LLM trajectory: N/A - no prompt/model behavior or agent trajectory changed.
- On-device model lifecycle matrix: not captured in this PR. This PR fixes the concrete CPU-default preset bug called out in #10727; the full model × device publish/download/load/run matrix still requires access to the target hardware fleet.
