### PR TITLE
test(ui): fix stale chat-sheet e2e header assertion (copy button removed in #10713)

### DIFF
--- a/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
@@ -351,16 +351,15 @@ async function runDragSuite(p, pointer, tag) {
   );
   await snap(p, `${tag}-full`);
 
-  // Header (post home↔launcher consolidation, #9450): Maximize + Copy +
-  // Clear on the left, a single Launcher button on the right (the old
-  // Home/Views/Settings trio collapsed into one launcher target). Copy only
-  // shows when there's a thread (the default fixture seeds one).
+  // Header (post home↔launcher consolidation, #9450): Maximize + Clear on the
+  // left, a single Launcher button on the right (the old Home/Views/Settings
+  // trio collapsed into one launcher target). The stray copy-conversation button
+  // was removed in #10713 (#10749), so the FULL header is exactly these three.
   assert(
     (await p.getByTestId("chat-full-maximize").count()) === 1 &&
       (await p.getByTestId("chat-full-clear").count()) === 1 &&
-      (await p.getByTestId("chat-full-copy-conversation").count()) === 1 &&
       (await p.getByTestId("chat-full-launcher").count()) === 1,
-    `[${pointer}] header shows maximize + copy + clear + launcher`,
+    `[${pointer}] header shows maximize + clear + launcher`,
   );
   // Maximize → full-bleed (edge-to-edge): data-maximized flips + panel reaches x=0.
   await p.getByTestId("chat-full-maximize").click();


### PR DESCRIPTION
Found by an adversarial parallel e2e/fuzz QA sweep.

## Bug
`run-chat-sheet-e2e.mjs` (the isolated chat-sheet gesture/state e2e, and the CI "Chat shell gesture + parity e2e" lane) asserts the FULL-state chat header renders **four** buttons — including `chat-full-copy-conversation`. But **PR #10713 (#10749) removed that stray copy-conversation button.** The overlay (`ContinuousChatOverlay.tsx:3300-3330`) now renders exactly **three** `HeaderButton`s: `chat-full-maximize`, `chat-full-clear`, `chat-full-launcher`. `grep chat-full-copy-conversation` across `packages/ui/src` (excluding `__e2e__`) finds nothing.

So the four-testid AND-assertion was **permanently unsatisfiable** — instrumented per-testid counts (both pointer types): `maximize=1 clear=1 copy=0 launcher=1` → the lane failed deterministically on both the `[mouse]` and `[touch]` header checks.

## Fix
Drop the `chat-full-copy-conversation` clause and update the message/comment to `maximize + clear + launcher`.

## Verified
`bun run --cwd packages/ui test:chat-sheet-e2e` → **CHAT-SHEET E2E PASSED** (exit 0):
```
✓ [mouse] header shows maximize + clear + launcher
✓ [touch] header shows maximize + clear + launcher
```

Distinguished from an unrelated intermittent slow-touch keyboard flake (appeared in only 1 of 2 re-runs; not part of this deterministic failure) via per-testid instrumentation across two full re-runs. Test-infra correctness fix; no product code touched.