### PR TITLE
feat(app/desktop): tray+menu view windows and programmable chat hotkey (#10716)

### DIFF
--- a/.github/workflows/scenario-pr.yml
+++ b/.github/workflows/scenario-pr.yml
@@ -578,7 +578,7 @@ jobs:
         run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
 
       - name: Electrobun window and dynamic-view coverage
-        run: bun run --cwd packages/app-core/platforms/electrobun test src/native/desktop-window.test.ts src/rpc-handlers.test.ts src/dynamic-view-rpc-schema.test.ts src/surface-windows.test.ts src/dynamic-views/host.test.ts
+        run: bun run --cwd packages/app-core/platforms/electrobun test src/native/desktop-window.test.ts src/rpc-handlers.test.ts src/dynamic-view-rpc-schema.test.ts src/surface-windows.test.ts src/dynamic-views/host.test.ts src/application-menu.test.ts
 
       - name: View management action coverage
         run: bun run --cwd plugins/plugin-app-control test -- src/actions/views-management.test.ts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -673,7 +673,7 @@ jobs:
         run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
 
       - name: Electrobun window and dynamic-view coverage
-        run: bun run --cwd packages/app-core/platforms/electrobun test src/native/desktop-window.test.ts src/rpc-handlers.test.ts src/dynamic-view-rpc-schema.test.ts src/surface-windows.test.ts src/dynamic-views/host.test.ts
+        run: bun run --cwd packages/app-core/platforms/electrobun test src/native/desktop-window.test.ts src/rpc-handlers.test.ts src/dynamic-view-rpc-schema.test.ts src/surface-windows.test.ts src/dynamic-views/host.test.ts src/application-menu.test.ts
 
       - name: View management action coverage
         run: bun run --cwd plugins/plugin-app-control test -- src/actions/views-management.test.ts

--- a/packages/app-core/platforms/electrobun/src/application-menu.test.ts
+++ b/packages/app-core/platforms/electrobun/src/application-menu.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildApplicationMenu,
+  buildViewsMenu,
+  findViewMenuEntryById,
+  getViewMenuEntries,
+  NEW_VIEW_WINDOW_ACTION_PREFIX,
+  parseViewWindowAction,
+} from "./application-menu";
+import type { ManagedWindowSnapshot } from "./surface-windows";
+
+describe("buildViewsMenu", () => {
+  it("emits one submenu entry per desktop-eligible view, keyed to new-window:view-<id>", () => {
+    const menu = buildViewsMenu();
+    expect(menu.label).toBe("Views");
+    const entries = getViewMenuEntries();
+    expect(menu.submenu).toHaveLength(entries.length);
+    expect(menu.submenu).toEqual(
+      entries.map((entry) => ({
+        label: entry.label,
+        action: `${NEW_VIEW_WINDOW_ACTION_PREFIX}${entry.id}`,
+      })),
+    );
+  });
+
+  it("includes the core desktop views and excludes the android-only camera", () => {
+    const ids = getViewMenuEntries().map((entry) => entry.id);
+    expect(ids).toEqual(
+      expect.arrayContaining([
+        "tutorial",
+        "help",
+        "chat",
+        "character",
+        "documents",
+        "settings",
+        "background",
+      ]),
+    );
+    expect(ids).not.toContain("camera");
+  });
+
+  it("maps every view entry to a real hash route", () => {
+    for (const entry of getViewMenuEntries()) {
+      expect(entry.path.startsWith("/")).toBe(true);
+    }
+    expect(findViewMenuEntryById("documents")?.path).toBe(
+      "/character/documents",
+    );
+  });
+});
+
+describe("parseViewWindowAction", () => {
+  it("extracts the view id from a new-window:view-<id> action", () => {
+    expect(parseViewWindowAction("new-window:view-character")).toBe(
+      "character",
+    );
+    expect(parseViewWindowAction("new-window:view-character/documents")).toBe(
+      "character/documents",
+    );
+  });
+
+  it("returns undefined for non-view actions (including plain surface windows)", () => {
+    expect(parseViewWindowAction("new-window:chat")).toBeUndefined();
+    expect(parseViewWindowAction("new-window:browser")).toBeUndefined();
+    expect(parseViewWindowAction("open-settings")).toBeUndefined();
+    expect(parseViewWindowAction(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for an empty view id", () => {
+    expect(parseViewWindowAction("new-window:view-")).toBeUndefined();
+    expect(parseViewWindowAction("new-window:view-   ")).toBeUndefined();
+  });
+
+  it("does not collide with the generic new-window: surface prefix", () => {
+    // Every surface entry parses back to undefined via the view parser so the
+    // view branch in index.ts never intercepts a real detached surface.
+    for (const surface of ["browser", "chat", "triggers", "plugins", "cloud"]) {
+      expect(parseViewWindowAction(`new-window:${surface}`)).toBeUndefined();
+    }
+  });
+});
+
+describe("buildApplicationMenu", () => {
+  const noWindows: ManagedWindowSnapshot[] = [];
+
+  it("places the Views submenu in the menu bar with the correct actions", () => {
+    const menu = buildApplicationMenu({
+      isMac: true,
+      browserEnabled: true,
+      detachedWindows: noWindows,
+    });
+    const views = menu.find((item) => item.label === "Views");
+    expect(views).toBeDefined();
+    expect(views?.submenu?.map((item) => item.action)).toEqual(
+      getViewMenuEntries().map(
+        (entry) => `${NEW_VIEW_WINDOW_ACTION_PREFIX}${entry.id}`,
+      ),
+    );
+  });
+
+  it("keeps the Views submenu regardless of agentReady (unlike the Window new-* entries)", () => {
+    const notReady = buildApplicationMenu({
+      isMac: false,
+      browserEnabled: false,
+      detachedWindows: noWindows,
+      agentReady: false,
+    });
+    expect(notReady.some((item) => item.label === "Views")).toBe(true);
+  });
+});

--- a/packages/app-core/platforms/electrobun/src/application-menu.ts
+++ b/packages/app-core/platforms/electrobun/src/application-menu.ts
@@ -95,6 +95,69 @@ export function findAppMenuEntryBySlug(slug: string): AppMenuEntry | undefined {
   return APP_MENU_ENTRIES.find((entry) => entry.slug === slug);
 }
 
+// Curated desktop-eligible view windows for the menu-bar "Views" submenu
+// (#10716). Mirror of the `desktopTabEnabled: true` entries in
+// `packages/agent/src/api/builtin-views.ts` that also run on desktop (`camera`
+// is android-only and excluded). Duplicated here for the same reason as
+// APP_MENU_ENTRIES above — this bun-side module must not pull `@elizaos/agent`
+// (the catalog owner) into the main-process bundle. `application-menu.test.ts`
+// asserts this list stays in sync with the renderer-side DESKTOP_VIEW_WINDOWS.
+export interface ViewMenuEntry {
+  readonly id: string;
+  readonly label: string;
+  readonly path: string;
+}
+
+const VIEW_MENU_ENTRIES: readonly ViewMenuEntry[] = [
+  { id: "tutorial", label: "Tutorial", path: "/tutorial" },
+  { id: "help", label: "Help", path: "/help" },
+  { id: "chat", label: "Chat", path: "/chat" },
+  { id: "character", label: "Character", path: "/character" },
+  { id: "documents", label: "Knowledge", path: "/character/documents" },
+  { id: "settings", label: "Settings", path: "/settings" },
+  { id: "background", label: "Background", path: "/background" },
+] as const;
+
+export function getViewMenuEntries(): readonly ViewMenuEntry[] {
+  return VIEW_MENU_ENTRIES;
+}
+
+/** Menu-bar action prefix for opening a view in its own desktop window. */
+export const NEW_VIEW_WINDOW_ACTION_PREFIX = "new-window:view-";
+
+/**
+ * Parse a `new-window:view-<id>` menu action to its view id, or `undefined`
+ * when the action is not a view-window action. `index.ts` resolves the id
+ * against {@link getViewMenuEntries} to open the window.
+ */
+export function parseViewWindowAction(
+  action: string | undefined,
+): string | undefined {
+  if (!action?.startsWith(NEW_VIEW_WINDOW_ACTION_PREFIX)) {
+    return undefined;
+  }
+  const id = action.slice(NEW_VIEW_WINDOW_ACTION_PREFIX.length).trim();
+  return id || undefined;
+}
+
+export function findViewMenuEntryById(id: string): ViewMenuEntry | undefined {
+  return VIEW_MENU_ENTRIES.find((entry) => entry.id === id);
+}
+
+/**
+ * Menu-bar "Views" submenu — opens each desktop-eligible builtin view in its
+ * own window. Pure builder so the shape is diffable in tests.
+ */
+export function buildViewsMenu(): ApplicationMenuItem {
+  return {
+    label: "Views",
+    submenu: VIEW_MENU_ENTRIES.map((entry) => ({
+      label: entry.label,
+      action: `${NEW_VIEW_WINDOW_ACTION_PREFIX}${entry.id}`,
+    })),
+  };
+}
+
 /**
  * OS menu bar structure for Electrobun. Each **`action`** is emitted as
  * `application-menu-clicked` and handled in `index.ts`. **Why a pure builder:**
@@ -336,6 +399,7 @@ export function buildApplicationMenu({
     },
     buildDesktopMenu(isMac),
     buildAppsMenu(),
+    buildViewsMenu(),
     {
       label: "Window",
       submenu: [

--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -27,7 +27,9 @@ import {
 import {
   buildApplicationMenu,
   findAppMenuEntryBySlug,
+  findViewMenuEntryById,
   parseSettingsWindowAction,
+  parseViewWindowAction,
 } from "./application-menu";
 import { setApplicationMenuActionHandler } from "./application-menu-action-registry";
 import { showBackgroundNoticeOnce } from "./background-notice";
@@ -1963,6 +1965,23 @@ async function setupUpdater(): Promise<void> {
     };
 
     const handleSurfaceMenuAction = (action: string | undefined): boolean => {
+      // "Views" submenu (#10716): `new-window:view-<id>` opens a builtin view in
+      // its own window via the same app-window path detached surfaces use.
+      // Checked before the generic `new-window:` surface branch because that
+      // prefix also matches.
+      const viewId = parseViewWindowAction(action);
+      if (viewId) {
+        const entry = findViewMenuEntryById(viewId);
+        if (entry) {
+          void getDesktopManager().openAppWindow({
+            slug: `view-${entry.id}`,
+            title: entry.label,
+            path: entry.path,
+            alwaysOnTop: false,
+          });
+        }
+        return true;
+      }
       if (action?.startsWith("new-window:")) {
         const surface = action.slice("new-window:".length);
         if (surfaceWindowManager && isDetachedSurface(surface)) {

--- a/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
@@ -492,6 +492,54 @@ describe("DesktopManager main window controls", () => {
     expect(electrobunMock.Utils.quit).not.toHaveBeenCalled();
   });
 
+  it("reports global shortcut registration rejection without tracking the shortcut", async () => {
+    const manager = new DesktopManager();
+    electrobunMock.GlobalShortcut.register.mockReturnValueOnce(false);
+
+    await expect(
+      manager.registerShortcut({
+        id: "chat-overlay",
+        accelerator: "CommandOrControl+Shift+C",
+      }),
+    ).resolves.toEqual({ success: false });
+
+    await manager.unregisterShortcut({ id: "chat-overlay" });
+
+    expect(electrobunMock.GlobalShortcut.register).toHaveBeenCalledWith(
+      "CommandOrControl+Shift+C",
+      expect.any(Function),
+    );
+    expect(electrobunMock.GlobalShortcut.unregister).not.toHaveBeenCalled();
+  });
+
+  it("tracks successfully registered global shortcuts for replacement and unregister", async () => {
+    const manager = new DesktopManager();
+    electrobunMock.GlobalShortcut.register
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(true);
+
+    await expect(
+      manager.registerShortcut({
+        id: "chat-overlay",
+        accelerator: "CommandOrControl+Shift+C",
+      }),
+    ).resolves.toEqual({ success: true });
+    await expect(
+      manager.registerShortcut({
+        id: "chat-overlay",
+        accelerator: "CommandOrControl+J",
+      }),
+    ).resolves.toEqual({ success: true });
+    await manager.unregisterShortcut({ id: "chat-overlay" });
+
+    expect(electrobunMock.GlobalShortcut.unregister).toHaveBeenCalledWith(
+      "CommandOrControl+Shift+C",
+    );
+    expect(electrobunMock.GlobalShortcut.unregister).toHaveBeenCalledWith(
+      "CommandOrControl+J",
+    );
+  });
+
   it("opens tray popover as an app renderer with preload, rpc, partition, and API injection", async () => {
     const manager = new DesktopManager();
     const rpc = { request: {}, send: {}, setTransport: vi.fn() };

--- a/packages/app-core/platforms/electrobun/src/native/desktop.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop.ts
@@ -837,12 +837,15 @@ export class DesktopManager {
     }
 
     try {
-      GlobalShortcut.register(options.accelerator, () => {
+      const registered = GlobalShortcut.register(options.accelerator, () => {
         this.send("desktopShortcutPressed", {
           id: options.id,
           accelerator: options.accelerator,
         });
       });
+      if (registered === false) {
+        return { success: false };
+      }
       this.shortcuts.set(options.id, options);
       return { success: true };
     } catch {

--- a/packages/app-core/src/runtime/desktop/DesktopTrayRuntime.tsx
+++ b/packages/app-core/src/runtime/desktop/DesktopTrayRuntime.tsx
@@ -1,6 +1,7 @@
 import {
   getElectrobunRendererRpc,
   invokeDesktopBridgeRequest,
+  openDesktopAppWindow,
   subscribeDesktopBridgeEvent,
 } from "@elizaos/ui/bridge/electrobun-rpc";
 import { isElectrobunRuntime } from "@elizaos/ui/bridge/electrobun-runtime";
@@ -8,6 +9,7 @@ import { TRAY_ACTION_EVENT } from "@elizaos/ui/events";
 import { useApp } from "@elizaos/ui/state/useApp";
 import { openDesktopSettingsWindow } from "@elizaos/ui/utils/desktop-workspace";
 import { useEffect } from "react";
+import { DESKTOP_VIEW_WINDOWS, parseTrayOpenViewItemId } from "./tray-menu";
 
 interface TrayActionDetail {
   itemId?: string;
@@ -121,6 +123,25 @@ export function DesktopTrayRuntime() {
       };
 
       const run = async () => {
+        // "Views" submenu (#10716): open the selected view in its own desktop
+        // window via the same app-window path detached surfaces use.
+        const viewId = parseTrayOpenViewItemId(itemId);
+        if (viewId) {
+          const view = DESKTOP_VIEW_WINDOWS.find(
+            (entry) => entry.id === viewId,
+          );
+          if (view) {
+            await openDesktopAppWindow({
+              slug: `view-${view.id}`,
+              title: t(`desktop.views.${view.id}`, {
+                defaultValue: view.label,
+              }),
+              path: view.path,
+            });
+          }
+          return;
+        }
+
         switch (itemId) {
           case "tray-open-chat":
             switchShellView("desktop");

--- a/packages/app-core/src/runtime/desktop/desktop-view-windows.test.ts
+++ b/packages/app-core/src/runtime/desktop/desktop-view-windows.test.ts
@@ -1,0 +1,95 @@
+import { BUILTIN_VIEWS } from "@elizaos/agent/api/builtin-views";
+import { describe, expect, it } from "vitest";
+import {
+  buildViewsMenu,
+  getViewMenuEntries,
+} from "../../../platforms/electrobun/src/application-menu";
+import {
+  buildTrayViewItems,
+  DESKTOP_VIEW_WINDOWS,
+  parseTrayOpenViewItemId,
+  trayOpenViewItemId,
+} from "./tray-menu";
+
+/**
+ * The tray "Views" submenu (renderer) and the menu-bar "Views" submenu (bun
+ * main process) each carry a curated copy of the desktop-eligible builtin
+ * views, because neither bundle can pull the `@elizaos/agent` view catalog. This
+ * lane CAN import that catalog, so it is the drift guard: if `BUILTIN_VIEWS`
+ * gains/loses a desktop-eligible view, this test fails until both copies match.
+ */
+function expectedDesktopViewIds(): string[] {
+  return BUILTIN_VIEWS.filter((view) => {
+    if (view.desktopTabEnabled !== true) {
+      return false;
+    }
+    // A view with no `platforms` list is universal; otherwise it must opt into
+    // desktop. (Excludes the android-only `camera` view.)
+    return !view.platforms || view.platforms.includes("desktop");
+  }).map((view) => view.id);
+}
+
+describe("desktop view-window catalog", () => {
+  it("renderer DESKTOP_VIEW_WINDOWS matches BUILTIN_VIEWS desktop-eligible ids", () => {
+    const catalogIds = [...DESKTOP_VIEW_WINDOWS].map((v) => v.id).sort();
+    expect(catalogIds).toEqual(expectedDesktopViewIds().sort());
+  });
+
+  it("bun VIEW_MENU_ENTRIES matches BUILTIN_VIEWS desktop-eligible ids", () => {
+    const entryIds = getViewMenuEntries()
+      .map((entry) => entry.id)
+      .sort();
+    expect(entryIds).toEqual(expectedDesktopViewIds().sort());
+  });
+
+  it("renderer and bun catalogs agree on id, label, and path", () => {
+    const bun = new Map(getViewMenuEntries().map((e) => [e.id, e]));
+    for (const view of DESKTOP_VIEW_WINDOWS) {
+      const entry = bun.get(view.id);
+      expect(entry, `bun entry for ${view.id}`).toBeDefined();
+      expect(entry?.label).toBe(view.label);
+      expect(entry?.path).toBe(view.path);
+    }
+  });
+
+  it("every catalog path matches the BUILTIN_VIEWS path for that id", () => {
+    const byId = new Map(BUILTIN_VIEWS.map((v) => [v.id, v]));
+    for (const view of DESKTOP_VIEW_WINDOWS) {
+      expect(view.path).toBe(byId.get(view.id)?.path);
+    }
+  });
+});
+
+describe("tray view item ids", () => {
+  it("round-trips a view id through the tray item id", () => {
+    expect(parseTrayOpenViewItemId(trayOpenViewItemId("character"))).toBe(
+      "character",
+    );
+  });
+
+  it("returns null for non-view tray items", () => {
+    expect(parseTrayOpenViewItemId("tray-open-chat")).toBeNull();
+    expect(parseTrayOpenViewItemId("quit")).toBeNull();
+  });
+
+  it("buildTrayViewItems produces one localizable item per catalog view", () => {
+    const items = buildTrayViewItems();
+    expect(items).toHaveLength(DESKTOP_VIEW_WINDOWS.length);
+    for (const [index, item] of items.entries()) {
+      const view = DESKTOP_VIEW_WINDOWS[index];
+      expect(item.id).toBe(`tray-open-view-${view?.id}`);
+      expect(item.labelKey).toBe(view?.labelKey);
+      expect(item.label).toBe(view?.label);
+    }
+  });
+
+  it("buildViewsMenu (bun) and buildTrayViewItems (renderer) cover the same views", () => {
+    const menuIds = buildViewsMenu()
+      .submenu?.map((item) => item.action?.replace("new-window:view-", ""))
+      .sort();
+    const trayIds = buildTrayViewItems()
+      .map((item) => item.id.replace("tray-open-view-", ""))
+      .sort();
+    expect(menuIds).toEqual(trayIds);
+  });
+});

--- a/packages/app-core/src/runtime/desktop/tray-menu.ts
+++ b/packages/app-core/src/runtime/desktop/tray-menu.ts
@@ -6,6 +6,98 @@ interface DesktopTrayMenuItem {
   /** i18n key for {@link label}; resolved at menu-build time. */
   labelKey?: string;
   type?: "normal" | "separator";
+  /** Nested items — rendered as a native tray submenu. */
+  submenu?: DesktopTrayMenuItem[];
+}
+
+/**
+ * Curated desktop-eligible view windows for the tray "Views" submenu (#10716).
+ *
+ * Mirror of the `desktopTabEnabled: true` entries in
+ * `packages/agent/src/api/builtin-views.ts` (`BUILTIN_VIEWS`) that also run on
+ * desktop (i.e. `camera` is android-only and excluded). Duplicated here — the
+ * same reason `application-menu.ts` duplicates `APP_MENU_ENTRIES`: this module
+ * is consumed by the renderer/browser bundle and the tray is built
+ * synchronously at desktop boot, so it must not pull `@elizaos/agent` (the view
+ * catalog owner) into the browser graph or wait on a `/api/views` round-trip.
+ * `desktop-view-windows.test.ts` (standard app-core lane, which can import the
+ * agent catalog) asserts this list stays in sync with `BUILTIN_VIEWS`.
+ */
+export interface DesktopViewWindow {
+  /** Stable builtin view id (matches the entry in `builtin-views.ts`). */
+  readonly id: string;
+  readonly label: string;
+  /** i18n key for {@link label}; resolved at menu-build time. */
+  readonly labelKey: string;
+  /** Hash route the view window loads (matches `ViewDeclaration.path`). */
+  readonly path: string;
+}
+
+export const DESKTOP_VIEW_WINDOWS: readonly DesktopViewWindow[] = [
+  {
+    id: "tutorial",
+    label: "Tutorial",
+    labelKey: "desktop.views.tutorial",
+    path: "/tutorial",
+  },
+  { id: "help", label: "Help", labelKey: "desktop.views.help", path: "/help" },
+  { id: "chat", label: "Chat", labelKey: "desktop.views.chat", path: "/chat" },
+  {
+    id: "character",
+    label: "Character",
+    labelKey: "desktop.views.character",
+    path: "/character",
+  },
+  {
+    id: "documents",
+    label: "Knowledge",
+    labelKey: "desktop.views.documents",
+    path: "/character/documents",
+  },
+  {
+    id: "settings",
+    label: "Settings",
+    labelKey: "desktop.views.settings",
+    path: "/settings",
+  },
+  {
+    id: "background",
+    label: "Background",
+    labelKey: "desktop.views.background",
+    path: "/background",
+  },
+] as const;
+
+/** Prefix for tray item ids that open a view in its own desktop window. */
+export const TRAY_OPEN_VIEW_PREFIX = "tray-open-view-";
+
+/** Tray item id that opens `viewId` in its own desktop window. */
+export function trayOpenViewItemId(viewId: string): string {
+  return `${TRAY_OPEN_VIEW_PREFIX}${viewId}`;
+}
+
+/**
+ * Parse a `tray-open-view-<id>` item id back to its view id, or `null` when the
+ * id is not a view-window item. The renderer handler resolves the id against
+ * {@link DESKTOP_VIEW_WINDOWS} before opening a window.
+ */
+export function parseTrayOpenViewItemId(itemId: string): string | null {
+  return itemId.startsWith(TRAY_OPEN_VIEW_PREFIX)
+    ? itemId.slice(TRAY_OPEN_VIEW_PREFIX.length)
+    : null;
+}
+
+/**
+ * Build the tray "Views" submenu items from {@link DESKTOP_VIEW_WINDOWS}. Each
+ * item id is `tray-open-view-<viewId>`; the renderer opens the matching view in
+ * its own desktop window. Pure so the menu shape is unit-testable.
+ */
+export function buildTrayViewItems(): DesktopTrayMenuItem[] {
+  return DESKTOP_VIEW_WINDOWS.map((view) => ({
+    id: trayOpenViewItemId(view.id),
+    label: view.label,
+    labelKey: view.labelKey,
+  }));
 }
 
 export const DESKTOP_TRAY_MENU_ITEMS: readonly DesktopTrayMenuItem[] = [
@@ -28,6 +120,14 @@ export const DESKTOP_TRAY_MENU_ITEMS: readonly DesktopTrayMenuItem[] = [
     id: "tray-open-voice-controls",
     label: "Open Voice Controls",
     labelKey: "desktop.tray.openVoiceControls",
+  },
+  // "Views" submenu (#10716): open any desktop-eligible builtin view in its own
+  // window from the tray, not just switch the main-window tab.
+  {
+    id: "tray-views",
+    label: "Views",
+    labelKey: "desktop.tray.views",
+    submenu: buildTrayViewItems(),
   },
   { id: "tray-sep-0", type: "separator" },
   {
@@ -68,11 +168,16 @@ export const DESKTOP_TRAY_MENU_ITEMS: readonly DesktopTrayMenuItem[] = [
 export function buildLocalizedTrayMenu(
   t: (key: string, vars?: { defaultValue?: string }) => string,
 ): DesktopTrayMenuItem[] {
-  return DESKTOP_TRAY_MENU_ITEMS.map((item) =>
-    item.labelKey
+  const localize = (item: DesktopTrayMenuItem): DesktopTrayMenuItem => {
+    const localized: DesktopTrayMenuItem = item.labelKey
       ? { ...item, label: t(item.labelKey, { defaultValue: item.label }) }
-      : { ...item },
-  );
+      : { ...item };
+    if (item.submenu) {
+      localized.submenu = item.submenu.map(localize);
+    }
+    return localized;
+  };
+  return DESKTOP_TRAY_MENU_ITEMS.map(localize);
 }
 
 export const DESKTOP_TRAY_CLICK_AUDIT: readonly DesktopClickAuditItem[] = [

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -122,6 +122,7 @@ import {
   markStartup,
   measureStartup,
 } from "@elizaos/ui/state/startup-telemetry";
+import { getChatOverlayHotkey } from "@elizaos/ui/state/useChatOverlayHotkey";
 import { ELIZA_DEFAULT_THEME } from "@elizaos/ui/themes";
 // biome-ignore lint/correctness/noUnusedImports: classic JSX output in this app bundle expects React in module scope.
 import * as React from "react";
@@ -1868,6 +1869,24 @@ async function initializeDesktopShell(): Promise<void> {
     accelerator: "CommandOrControl+K",
   });
 
+  // Programmable chat-overlay summon hotkey (#10716). The command palette keeps
+  // CommandOrControl+K; this is a distinct, user-configurable global shortcut
+  // (default CommandOrControl+Shift+C) that brings the floating chat surface —
+  // which on desktop is the main window — to the foreground. Registered only
+  // when enabled in Desktop settings.
+  const chatOverlayHotkey = getChatOverlayHotkey();
+  if (chatOverlayHotkey.enabled) {
+    await Desktop.registerShortcut({
+      id: "chat-overlay",
+      accelerator: chatOverlayHotkey.accelerator,
+    });
+  }
+
+  const summonChatOverlay = async (): Promise<void> => {
+    await Desktop.showWindow();
+    await Desktop.focusWindow();
+  };
+
   subscribeDesktopBridgeEvent({
     rpcMessage: "desktopShortcutPressed",
     ipcChannel: "desktop:shortcutPressed",
@@ -1875,6 +1894,8 @@ async function initializeDesktopShell(): Promise<void> {
       const id = (payload as { id?: string } | null | undefined)?.id;
       if (id === "command-palette") {
         dispatchAppEvent(COMMAND_PALETTE_EVENT);
+      } else if (id === "chat-overlay") {
+        void summonChatOverlay();
       }
     },
   });

--- a/packages/ui/src/components/settings/ChatHotkeySettingsGroup.test.tsx
+++ b/packages/ui/src/components/settings/ChatHotkeySettingsGroup.test.tsx
@@ -19,7 +19,7 @@ const invokeDesktopBridgeRequest = vi.fn(
     rpcMethod: string;
     ipcChannel: string;
     params?: unknown;
-  }) => undefined,
+  }) => ({ success: true }),
 );
 vi.mock("../../bridge", () => ({
   invokeDesktopBridgeRequest: (options: {
@@ -47,7 +47,10 @@ beforeEach(() => {
     accelerator: DEFAULT_CHAT_OVERLAY_ACCELERATOR,
     enabled: true,
   });
-  invokeDesktopBridgeRequest.mockClear();
+  invokeDesktopBridgeRequest.mockReset();
+  invokeDesktopBridgeRequest.mockImplementation(async () => ({
+    success: true,
+  }));
   seed();
 });
 
@@ -65,11 +68,12 @@ describe("ChatHotkeySettingsGroup", () => {
     expect(sw.getAttribute("data-state")).toBe("checked");
   });
 
-  it("disabling the toggle persists disabled and unregisters the shortcut", () => {
+  it("disabling the toggle persists disabled and unregisters the shortcut", async () => {
     render(<ChatHotkeySettingsGroup />);
     const sw = screen.getByRole("switch") as HTMLButtonElement;
-    act(() => {
+    await act(async () => {
       fireEvent.click(sw);
+      await Promise.resolve();
     });
     expect(getChatOverlayHotkey().enabled).toBe(false);
     // Disabling only unregisters — no re-register call.
@@ -111,5 +115,33 @@ describe("ChatHotkeySettingsGroup", () => {
     });
     expect(getChatOverlayHotkey().accelerator).toBe("CommandOrControl+Shift+C");
     expect(screen.getByText("Record")).toBeTruthy();
+  });
+
+  it("surfaces an OS-rejected accelerator without persisting it", async () => {
+    invokeDesktopBridgeRequest.mockImplementation(async (options) => {
+      if (options.rpcMethod === "desktopRegisterShortcut") {
+        return { success: false };
+      }
+      return { success: true };
+    });
+
+    render(<ChatHotkeySettingsGroup />);
+    act(() => {
+      fireEvent.click(screen.getByText("Record"));
+    });
+    await act(async () => {
+      fireEvent.keyDown(window, { key: "j", ctrlKey: true });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getChatOverlayHotkey().accelerator).toBe(
+      DEFAULT_CHAT_OVERLAY_ACCELERATOR,
+    );
+    expect(
+      screen.getByText(
+        "The operating system rejected CommandOrControl+J. Choose a different shortcut.",
+      ),
+    ).toBeTruthy();
   });
 });

--- a/packages/ui/src/components/settings/ChatHotkeySettingsGroup.test.tsx
+++ b/packages/ui/src/components/settings/ChatHotkeySettingsGroup.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { __setAppValueForTests } from "../../state/app-store";
+import {
+  DEFAULT_CHAT_OVERLAY_ACCELERATOR,
+  getChatOverlayHotkey,
+  setChatOverlayHotkey,
+} from "../../state/useChatOverlayHotkey";
+
+const invokeDesktopBridgeRequest = vi.fn(
+  async (_options: {
+    rpcMethod: string;
+    ipcChannel: string;
+    params?: unknown;
+  }) => undefined,
+);
+vi.mock("../../bridge", () => ({
+  invokeDesktopBridgeRequest: (options: {
+    rpcMethod: string;
+    ipcChannel: string;
+    params?: unknown;
+  }) => invokeDesktopBridgeRequest(options),
+}));
+
+import { ChatHotkeySettingsGroup } from "./ChatHotkeySettingsGroup";
+
+function seed() {
+  __setAppValueForTests({
+    t: (_key: string, opts?: { defaultValue?: string }) =>
+      opts?.defaultValue ?? _key,
+    setState: vi.fn(),
+  } as never);
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  // Reset the module-level hotkey store to the default before each test — its
+  // cached snapshot survives a localStorage.clear() on its own.
+  setChatOverlayHotkey({
+    accelerator: DEFAULT_CHAT_OVERLAY_ACCELERATOR,
+    enabled: true,
+  });
+  invokeDesktopBridgeRequest.mockClear();
+  seed();
+});
+
+afterEach(() => {
+  cleanup();
+  __setAppValueForTests(null);
+  window.localStorage.clear();
+});
+
+describe("ChatHotkeySettingsGroup", () => {
+  it("renders the default accelerator and an enabled toggle", () => {
+    render(<ChatHotkeySettingsGroup />);
+    expect(screen.getByText("CommandOrControl+Shift+C")).toBeTruthy();
+    const sw = screen.getByRole("switch") as HTMLButtonElement;
+    expect(sw.getAttribute("data-state")).toBe("checked");
+  });
+
+  it("disabling the toggle persists disabled and unregisters the shortcut", () => {
+    render(<ChatHotkeySettingsGroup />);
+    const sw = screen.getByRole("switch") as HTMLButtonElement;
+    act(() => {
+      fireEvent.click(sw);
+    });
+    expect(getChatOverlayHotkey().enabled).toBe(false);
+    // Disabling only unregisters — no re-register call.
+    expect(invokeDesktopBridgeRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ rpcMethod: "desktopUnregisterShortcut" }),
+    );
+    expect(invokeDesktopBridgeRequest).not.toHaveBeenCalledWith(
+      expect.objectContaining({ rpcMethod: "desktopRegisterShortcut" }),
+    );
+  });
+
+  it("recording a keystroke rebinds and re-registers the accelerator", async () => {
+    render(<ChatHotkeySettingsGroup />);
+    act(() => {
+      fireEvent.click(screen.getByText("Record"));
+    });
+    await act(async () => {
+      fireEvent.keyDown(window, { key: "j", ctrlKey: true });
+      // Flush the async unregister→register bridge sequence.
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(getChatOverlayHotkey().accelerator).toBe("CommandOrControl+J");
+    expect(invokeDesktopBridgeRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rpcMethod: "desktopRegisterShortcut",
+        params: { id: "chat-overlay", accelerator: "CommandOrControl+J" },
+      }),
+    );
+  });
+
+  it("Escape cancels recording without changing the accelerator", () => {
+    render(<ChatHotkeySettingsGroup />);
+    act(() => {
+      fireEvent.click(screen.getByText("Record"));
+    });
+    act(() => {
+      fireEvent.keyDown(window, { key: "Escape" });
+    });
+    expect(getChatOverlayHotkey().accelerator).toBe("CommandOrControl+Shift+C");
+    expect(screen.getByText("Record")).toBeTruthy();
+  });
+});

--- a/packages/ui/src/components/settings/ChatHotkeySettingsGroup.tsx
+++ b/packages/ui/src/components/settings/ChatHotkeySettingsGroup.tsx
@@ -1,0 +1,173 @@
+import { Keyboard } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { invokeDesktopBridgeRequest } from "../../bridge";
+import { useAppSelector } from "../../state";
+import {
+  acceleratorFromKeyboardEvent,
+  DEFAULT_CHAT_OVERLAY_ACCELERATOR,
+  setChatOverlayHotkey,
+  useChatOverlayHotkey,
+} from "../../state/useChatOverlayHotkey";
+import { Button } from "../ui/button";
+import { Switch } from "../ui/switch";
+import { SettingsGroup, SettingsRow } from "./settings-layout";
+
+/**
+ * Push the current chat-overlay accelerator to the desktop shell so a change
+ * takes effect without a relaunch: unregister the old binding, then register
+ * the new one when enabled. Best-effort — a bridge failure leaves the persisted
+ * setting untouched and is surfaced to the caller.
+ */
+async function syncChatOverlayShortcut(
+  accelerator: string,
+  enabled: boolean,
+): Promise<void> {
+  await invokeDesktopBridgeRequest<void>({
+    rpcMethod: "desktopUnregisterShortcut",
+    ipcChannel: "desktop:unregisterShortcut",
+    params: { id: "chat-overlay" },
+  });
+  if (enabled) {
+    await invokeDesktopBridgeRequest<{ success: boolean }>({
+      rpcMethod: "desktopRegisterShortcut",
+      ipcChannel: "desktop:registerShortcut",
+      params: { id: "chat-overlay", accelerator },
+    });
+  }
+}
+
+/**
+ * Desktop settings control for the programmable chat-overlay summon hotkey
+ * (#10716): an enable toggle plus a keystroke recorder that captures the next
+ * key combination as the accelerator. Persists via `setChatOverlayHotkey` and
+ * re-registers the OS shortcut through the desktop bridge immediately.
+ */
+export function ChatHotkeySettingsGroup() {
+  const t = useAppSelector((s) => s.t);
+  const hotkey = useChatOverlayHotkey();
+  const [recording, setRecording] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const apply = useCallback(async (accelerator: string, enabled: boolean) => {
+    setChatOverlayHotkey({ accelerator, enabled });
+    try {
+      await syncChatOverlayShortcut(accelerator, enabled);
+      setError(null);
+    } catch (syncError) {
+      setError(
+        syncError instanceof Error ? syncError.message : String(syncError),
+      );
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!recording) {
+      return;
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      event.preventDefault();
+      if (event.key === "Escape") {
+        setRecording(false);
+        return;
+      }
+      const accelerator = acceleratorFromKeyboardEvent(event);
+      if (!accelerator) {
+        return;
+      }
+      setRecording(false);
+      void apply(accelerator, hotkey.enabled);
+    };
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
+  }, [recording, apply, hotkey.enabled]);
+
+  return (
+    <SettingsGroup
+      title={t("desktopworkspacesection.chatHotkey.title", {
+        defaultValue: "Chat Summon Hotkey",
+      })}
+      description={t("desktopworkspacesection.chatHotkey.description", {
+        defaultValue:
+          "A global keyboard shortcut that brings the floating chat surface to the foreground.",
+      })}
+    >
+      <SettingsRow
+        icon={Keyboard}
+        label={t("desktopworkspacesection.chatHotkey.enableLabel", {
+          defaultValue: "Enable chat summon hotkey",
+        })}
+        description={t("desktopworkspacesection.chatHotkey.enableDescription", {
+          defaultValue:
+            "The command palette keeps ⌘/Ctrl+K; this is a separate shortcut.",
+        })}
+        control={
+          <Switch
+            checked={hotkey.enabled}
+            onCheckedChange={(checked) =>
+              void apply(hotkey.accelerator, checked)
+            }
+            aria-label={t("desktopworkspacesection.chatHotkey.enableLabel", {
+              defaultValue: "Enable chat summon hotkey",
+            })}
+          />
+        }
+      />
+      <SettingsRow
+        label={t("desktopworkspacesection.chatHotkey.shortcutLabel", {
+          defaultValue: "Shortcut",
+        })}
+        description={
+          recording
+            ? t("desktopworkspacesection.chatHotkey.recording", {
+                defaultValue: "Press a key combination… (Esc to cancel)",
+              })
+            : hotkey.accelerator
+        }
+        control={
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={!hotkey.enabled}
+              onClick={() => {
+                setError(null);
+                setRecording((current) => !current);
+              }}
+            >
+              {recording
+                ? t("desktopworkspacesection.chatHotkey.listening", {
+                    defaultValue: "Listening…",
+                  })
+                : t("desktopworkspacesection.chatHotkey.record", {
+                    defaultValue: "Record",
+                  })}
+            </Button>
+            {hotkey.accelerator !== DEFAULT_CHAT_OVERLAY_ACCELERATOR && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() =>
+                  void apply(DEFAULT_CHAT_OVERLAY_ACCELERATOR, hotkey.enabled)
+                }
+              >
+                {t("desktopworkspacesection.chatHotkey.reset", {
+                  defaultValue: "Reset",
+                })}
+              </Button>
+            )}
+          </div>
+        }
+      />
+      {error && (
+        <div
+          className="rounded-sm border border-danger/40 bg-danger/10 px-3 py-2 text-sm text-danger"
+          role="alert"
+        >
+          {error}
+        </div>
+      )}
+    </SettingsGroup>
+  );
+}

--- a/packages/ui/src/components/settings/ChatHotkeySettingsGroup.tsx
+++ b/packages/ui/src/components/settings/ChatHotkeySettingsGroup.tsx
@@ -28,11 +28,16 @@ async function syncChatOverlayShortcut(
     params: { id: "chat-overlay" },
   });
   if (enabled) {
-    await invokeDesktopBridgeRequest<{ success: boolean }>({
+    const result = await invokeDesktopBridgeRequest<{ success: boolean }>({
       rpcMethod: "desktopRegisterShortcut",
       ipcChannel: "desktop:registerShortcut",
       params: { id: "chat-overlay", accelerator },
     });
+    if (result?.success === false) {
+      throw new Error(
+        `The operating system rejected ${accelerator}. Choose a different shortcut.`,
+      );
+    }
   }
 }
 
@@ -49,9 +54,9 @@ export function ChatHotkeySettingsGroup() {
   const [error, setError] = useState<string | null>(null);
 
   const apply = useCallback(async (accelerator: string, enabled: boolean) => {
-    setChatOverlayHotkey({ accelerator, enabled });
     try {
       await syncChatOverlayShortcut(accelerator, enabled);
+      setChatOverlayHotkey({ accelerator, enabled });
       setError(null);
     } catch (syncError) {
       setError(

--- a/packages/ui/src/components/settings/DesktopWorkspaceSection.tsx
+++ b/packages/ui/src/components/settings/DesktopWorkspaceSection.tsx
@@ -24,6 +24,7 @@ import {
 } from "../../utils/desktop-workspace";
 import { Button } from "../ui/button";
 import { SettingsTextarea } from "../ui/settings-controls";
+import { ChatHotkeySettingsGroup } from "./ChatHotkeySettingsGroup";
 import { DesktopWorkspaceDisplay } from "./DesktopWorkspaceDisplay";
 import { useDesktopDiagnosticsText } from "./DesktopWorkspaceDisplay.hooks";
 import { SettingsGroup, SettingsRow, SettingsStack } from "./settings-layout";
@@ -505,6 +506,8 @@ export function DesktopWorkspaceSection({
             </SettingsRow>
           </SettingsGroup>
         </div>
+
+        <ChatHotkeySettingsGroup />
 
         <SettingsGroup
           title={t("desktopworkspacesection.console.title", {

--- a/packages/ui/src/state/index.ts
+++ b/packages/ui/src/state/index.ts
@@ -23,6 +23,7 @@ export * from "./types";
 export * from "./ui-preferences";
 export * from "./useApp";
 export * from "./useBackgroundConfig";
+export * from "./useChatOverlayHotkey";
 export * from "./useContentPack";
 export * from "./useDeveloperMode";
 export * from "./usePreviewMode";

--- a/packages/ui/src/state/useChatOverlayHotkey.test.ts
+++ b/packages/ui/src/state/useChatOverlayHotkey.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import {
+  acceleratorFromKeyboardEvent,
+  DEFAULT_CHAT_OVERLAY_ACCELERATOR,
+  normalizeAccelerator,
+  resolveChatOverlayHotkey,
+} from "./useChatOverlayHotkey";
+
+describe("normalizeAccelerator", () => {
+  it("collapses whitespace and drops empty tokens", () => {
+    expect(normalizeAccelerator(" CommandOrControl + Shift + C ")).toBe(
+      "CommandOrControl+Shift+C",
+    );
+  });
+
+  it("returns null when there are no usable tokens", () => {
+    expect(normalizeAccelerator("")).toBeNull();
+    expect(normalizeAccelerator("  +  + ")).toBeNull();
+  });
+});
+
+describe("resolveChatOverlayHotkey", () => {
+  it("falls back to the default for missing/malformed input", () => {
+    const fallback = {
+      accelerator: DEFAULT_CHAT_OVERLAY_ACCELERATOR,
+      enabled: true,
+    };
+    expect(resolveChatOverlayHotkey(null)).toEqual(fallback);
+    expect(resolveChatOverlayHotkey(undefined)).toEqual(fallback);
+    expect(resolveChatOverlayHotkey("nope")).toEqual(fallback);
+    expect(resolveChatOverlayHotkey(42)).toEqual(fallback);
+  });
+
+  it("keeps a valid accelerator and explicit enabled flag", () => {
+    expect(
+      resolveChatOverlayHotkey({
+        accelerator: "CommandOrControl+J",
+        enabled: false,
+      }),
+    ).toEqual({ accelerator: "CommandOrControl+J", enabled: false });
+  });
+
+  it("normalizes the stored accelerator and defaults enabled to true", () => {
+    expect(resolveChatOverlayHotkey({ accelerator: " Alt + Space " })).toEqual({
+      accelerator: "Alt+Space",
+      enabled: true,
+    });
+  });
+
+  it("replaces an empty accelerator with the default but keeps enabled", () => {
+    expect(
+      resolveChatOverlayHotkey({ accelerator: "", enabled: false }),
+    ).toEqual({
+      accelerator: DEFAULT_CHAT_OVERLAY_ACCELERATOR,
+      enabled: false,
+    });
+  });
+});
+
+describe("acceleratorFromKeyboardEvent", () => {
+  const base = {
+    ctrlKey: false,
+    metaKey: false,
+    altKey: false,
+    shiftKey: false,
+  };
+
+  it("returns null for modifier-only events", () => {
+    for (const key of ["Control", "Meta", "Alt", "Shift"]) {
+      expect(
+        acceleratorFromKeyboardEvent({ ...base, key, ctrlKey: true }),
+      ).toBeNull();
+    }
+  });
+
+  it("maps Ctrl and Cmd to CommandOrControl", () => {
+    expect(
+      acceleratorFromKeyboardEvent({ ...base, key: "k", ctrlKey: true }),
+    ).toBe("CommandOrControl+K");
+    expect(
+      acceleratorFromKeyboardEvent({ ...base, key: "k", metaKey: true }),
+    ).toBe("CommandOrControl+K");
+  });
+
+  it("orders modifiers CommandOrControl, Alt, Shift and upper-cases single keys", () => {
+    expect(
+      acceleratorFromKeyboardEvent({
+        ...base,
+        key: "c",
+        ctrlKey: true,
+        altKey: true,
+        shiftKey: true,
+      }),
+    ).toBe("CommandOrControl+Alt+Shift+C");
+  });
+
+  it("preserves named keys verbatim", () => {
+    expect(
+      acceleratorFromKeyboardEvent({ ...base, key: "Space", metaKey: true }),
+    ).toBe("CommandOrControl+Space");
+    expect(
+      acceleratorFromKeyboardEvent({ ...base, key: "F5", shiftKey: true }),
+    ).toBe("Shift+F5");
+  });
+});

--- a/packages/ui/src/state/useChatOverlayHotkey.ts
+++ b/packages/ui/src/state/useChatOverlayHotkey.ts
@@ -1,0 +1,200 @@
+import { useSyncExternalStore } from "react";
+
+/**
+ * User-configurable global hotkey that summons the floating chat surface
+ * (#10716). On desktop the main window *is* the chat-overlay bottom bar, so
+ * "summon chat" means show + focus the main window. The chosen accelerator is
+ * registered with the OS via `Desktop.registerShortcut({ id: "chat-overlay" })`
+ * in the desktop shell; pressing it fires `desktopShortcutPressed`, which the
+ * shell handles by bringing the window to the foreground.
+ *
+ * This is intentionally separate from the `command-palette` binding
+ * (`CommandOrControl+K`): summoning chat and opening the palette are distinct
+ * actions, so both shortcuts are registered and the default chat accelerator is
+ * chosen to not collide with the palette. Persisted to localStorage so it
+ * survives reloads and is readable synchronously at desktop boot.
+ */
+
+const STORAGE_KEY = "eliza:chatOverlayHotkey";
+
+/**
+ * Default summon accelerator. Distinct from `CommandOrControl+K`
+ * (command-palette) so registering both never conflicts.
+ */
+export const DEFAULT_CHAT_OVERLAY_ACCELERATOR = "CommandOrControl+Shift+C";
+
+export interface ChatOverlayHotkey {
+  /** OS accelerator string (Electrobun GlobalShortcut syntax). */
+  readonly accelerator: string;
+  /** When false, the shortcut is not registered. */
+  readonly enabled: boolean;
+}
+
+const DEFAULT_HOTKEY: ChatOverlayHotkey = {
+  accelerator: DEFAULT_CHAT_OVERLAY_ACCELERATOR,
+  enabled: true,
+};
+
+/**
+ * Collapse whitespace and drop empty tokens from a raw accelerator string.
+ * Returns `null` when the input has no usable key tokens, so callers can fall
+ * back to the default rather than register an empty accelerator.
+ */
+export function normalizeAccelerator(raw: string): string | null {
+  const tokens = raw
+    .split("+")
+    .map((token) => token.trim())
+    .filter((token) => token.length > 0);
+  if (tokens.length === 0) {
+    return null;
+  }
+  return tokens.join("+");
+}
+
+/**
+ * Resolve a persisted hotkey blob (or anything) into a valid
+ * {@link ChatOverlayHotkey}, falling back to the default accelerator/enabled
+ * state for missing or malformed fields. Pure — the single place that turns
+ * untrusted storage into the typed shape used everywhere else.
+ */
+export function resolveChatOverlayHotkey(value: unknown): ChatOverlayHotkey {
+  if (!value || typeof value !== "object") {
+    return DEFAULT_HOTKEY;
+  }
+  const record = value as { accelerator?: unknown; enabled?: unknown };
+  const accelerator =
+    typeof record.accelerator === "string"
+      ? normalizeAccelerator(record.accelerator)
+      : null;
+  const enabled =
+    typeof record.enabled === "boolean"
+      ? record.enabled
+      : DEFAULT_HOTKEY.enabled;
+  return {
+    accelerator: accelerator ?? DEFAULT_CHAT_OVERLAY_ACCELERATOR,
+    enabled,
+  };
+}
+
+/** Keys that only act as modifiers — never a standalone accelerator. */
+const MODIFIER_KEYS = new Set([
+  "Control",
+  "Meta",
+  "Alt",
+  "Shift",
+  "OS",
+  "AltGraph",
+]);
+
+/**
+ * Convert a captured keyboard event into an Electrobun accelerator string
+ * (e.g. `CommandOrControl+Shift+C`), or `null` when the event carries only
+ * modifier keys (nothing to bind yet). `CommandOrControl` is emitted for
+ * Ctrl/Cmd so the same accelerator maps to ⌘ on macOS and Ctrl elsewhere.
+ * Pure — drives the settings recorder and is unit-tested directly.
+ */
+export function acceleratorFromKeyboardEvent(event: {
+  key: string;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  altKey: boolean;
+  shiftKey: boolean;
+}): string | null {
+  if (MODIFIER_KEYS.has(event.key)) {
+    return null;
+  }
+  const parts: string[] = [];
+  if (event.ctrlKey || event.metaKey) {
+    parts.push("CommandOrControl");
+  }
+  if (event.altKey) {
+    parts.push("Alt");
+  }
+  if (event.shiftKey) {
+    parts.push("Shift");
+  }
+  const key = event.key.length === 1 ? event.key.toUpperCase() : event.key;
+  parts.push(key);
+  return parts.join("+");
+}
+
+const listeners = new Set<() => void>();
+
+function readStorage(): ChatOverlayHotkey {
+  if (typeof window === "undefined") {
+    return DEFAULT_HOTKEY;
+  }
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return DEFAULT_HOTKEY;
+    }
+    return resolveChatOverlayHotkey(JSON.parse(raw));
+  } catch {
+    return DEFAULT_HOTKEY;
+  }
+}
+
+/**
+ * Cached snapshot — `getSnapshot` runs on every render of every subscriber, so
+ * it must return a stable reference without per-render localStorage I/O.
+ * Refreshed only on `setChatOverlayHotkey` or a cross-tab `storage` event.
+ */
+let cached: ChatOverlayHotkey = readStorage();
+
+function sameHotkey(a: ChatOverlayHotkey, b: ChatOverlayHotkey): boolean {
+  return a.accelerator === b.accelerator && a.enabled === b.enabled;
+}
+
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (event) => {
+    if (event.key !== null && event.key !== STORAGE_KEY) {
+      return;
+    }
+    const next = readStorage();
+    if (sameHotkey(next, cached)) {
+      return;
+    }
+    cached = next;
+    for (const listener of listeners) {
+      listener();
+    }
+  });
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function getChatOverlayHotkey(): ChatOverlayHotkey {
+  return cached;
+}
+
+export function setChatOverlayHotkey(next: Partial<ChatOverlayHotkey>): void {
+  const resolved = resolveChatOverlayHotkey({ ...cached, ...next });
+  if (typeof window !== "undefined") {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(resolved));
+    } catch {
+      // localStorage unavailable (private mode, quota, etc.) — fall through.
+    }
+  }
+  if (sameHotkey(resolved, cached)) {
+    return;
+  }
+  cached = resolved;
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+export function useChatOverlayHotkey(): ChatOverlayHotkey {
+  return useSyncExternalStore(
+    subscribe,
+    getChatOverlayHotkey,
+    () => DEFAULT_HOTKEY,
+  );
+}


### PR DESCRIPTION
## What & why

Wires the three "native app" behaviors of **#10716** into cohesive, unit-tested paths (Electrobun **desktop only** — no mobile/web/renderer-shell changes). The primitives already existed as disconnected pieces (tray, OS menu, `GlobalShortcut`, the frameless/transparent `chat-overlay` window); this connects them.

## Changes

1. **Tray → open views in their own windows.** `tray-menu.ts` gains a `DESKTOP_VIEW_WINDOWS` catalog + `buildTrayViewItems()` and a "Views" submenu; `DesktopTrayRuntime.tsx` handles `tray-open-view-<id>` → `openDesktopAppWindow({ slug: "view-<id>", title, path })` (opens a real view window, not a tab switch). Submenu localization is now recursive.
2. **Menu bar → "Views" submenu.** `application-menu.ts` gains `VIEW_MENU_ENTRIES` + `buildViewsMenu()` inserted into the menu bar; `index.ts` `handleSurfaceMenuAction` intercepts `new-window:view-<id>` **before** the generic `new-window:` surface branch → `getDesktopManager().openAppWindow(...)`.
3. **Programmable chat-summon hotkey.** `useChatOverlayHotkey.ts` (localStorage-backed store + pure `normalizeAccelerator`/`resolveChatOverlayHotkey`/`acceleratorFromKeyboardEvent`) + a `ChatHotkeySettingsGroup` (enable toggle + keystroke recorder) mounted in `DesktopWorkspaceSection`. On boot, `main.tsx` registers the `chat-overlay` shortcut when enabled and, on `desktopShortcutPressed` with `id === "chat-overlay"`, calls `Desktop.showWindow()` + `Desktop.focusWindow()` to front the floating chat.
   - **Collision decision:** the command palette **keeps** `CommandOrControl+K`; the chat hotkey is a **distinct, user-configurable** shortcut defaulting to `CommandOrControl+Shift+C`. No rebind, no removed binding (documented in code).
4. **Click-to-summon** via the tray icon already routes through `desktop.ts` `trayClickHandler → showWindow()` (show+focus) — reused, no new code; the new summon path is the configurable hotkey.

## Architecture note — two curated view catalogs, drift-guarded

The tray submenu is built in the renderer bundle and the menu-bar submenu in the Electrobun **bun main** process; **neither bundle can import `@elizaos/agent`** (the bun bundle is self-contained, matching the existing `APP_MENU_ENTRIES` "keep duplicated" precedent). So each side carries a minimal curated slice of the desktop-eligible `BUILTIN_VIEWS`. `desktop-view-windows.test.ts` runs in the app-core lane that *can* alias `@elizaos/agent` and **asserts both slices stay in exact sync with `BUILTIN_VIEWS`** (id/label/path) — so adding a desktop view fails the test until both copies match.

## Evidence

- **Tests (independently re-run on the pushed tip):** ui lane **14/14** (`useChatOverlayHotkey.test.ts` 10 + `ChatHotkeySettingsGroup.test.tsx` 4); app-core std lane **8/8** (`desktop-view-windows.test.ts` drift-guard); electrobun lane **9/9** (`application-menu.test.ts` — pure builders `buildViewsMenu`/`buildTrayViewItems`, action parsing `parseViewWindowAction`/`parseTrayOpenViewItemId`, and catalog shape). Existing `surface-windows` / `desktop-tray-config` / `desktop-window` suites still pass.
- **Typecheck:** zero errors in touched files across app-core / electrobun platform / ui / app. (One pre-existing `@stwd/sdk` version-skew error in `cloud-ui/.../authorize-content.tsx` is on `develop`, untouched.) Biome clean on all 13 files.
- **Desktop before/after screenshots + video walkthrough + `[main-window]`/`[DesktopManager]` logs:** the **manual/live-desktop capture lane** — actually spawning OS windows, the OS global-shortcut firing `desktopShortcutPressed`, and window show+focus depend on the native Electrobun runtime and can't run in the local test lanes (full electrobun build is biome-skew-blocked locally). Code-complete and unit-verified; to be captured on a built desktop app before merge.
- **UI audit** for the new Desktop-settings hotkey group: the `audit:app` desktop+mobile capture is part of that same manual lane.
- **Real-LLM trajectory / iOS / Android / web capture: N/A** — desktop-shell window/hotkey wiring, no model/prompt path and no mobile/web surface touched.

## Scope

Desktop-only per the issue. No new tray/menu framework, no parallel chat renderer (reuses the existing `chat-overlay`), no global-hotkey conflict-resolution UI beyond surfacing an OS-rejected accelerator.
