### PR TITLE
fix(ui): dedupe controlled launcher dock tiles

### DIFF
--- a/packages/ui/src/components/pages/Launcher.test.tsx
+++ b/packages/ui/src/components/pages/Launcher.test.tsx
@@ -431,7 +431,8 @@ describe("Launcher controlled favorites (desktop tabs)", () => {
   it("clamps the dock to LAUNCHER_DOCK_LIMIT even when more are supplied", () => {
     // Controlled mode (onToggleFavorite set) renders the caller's favoriteIds.
     // A caller that supplies more than the cap must still render at most
-    // LAUNCHER_DOCK_LIMIT dock tiles (the iOS-style 4-slot dock).
+    // LAUNCHER_DOCK_LIMIT dock tiles (the iOS-style 4-slot dock), and those
+    // docked ids must not duplicate in the page grid.
     const ids = ["a", "b", "c", "d", "e", "f"];
     render(
       <Launcher
@@ -445,6 +446,17 @@ describe("Launcher controlled favorites (desktop tabs)", () => {
       .getByTestId("launcher-dock")
       .querySelectorAll('[data-testid^="launcher-tile-"]');
     expect(dockTiles).toHaveLength(LAUNCHER_DOCK_LIMIT);
+    expect(
+      within(screen.getByTestId("launcher-dock")).getByTestId(
+        "launcher-tile-a",
+      ),
+    ).toBeTruthy();
+
+    const page = within(screen.getByTestId("launcher-page-0"));
+    expect(page.queryByTestId("launcher-tile-a")).toBeNull();
+    expect(page.queryByTestId("launcher-tile-d")).toBeNull();
+    expect(page.getByTestId("launcher-tile-e")).toBeTruthy();
+    expect(page.getByTestId("launcher-tile-f")).toBeTruthy();
   });
 });
 

--- a/packages/ui/src/components/pages/Launcher.tsx
+++ b/packages/ui/src/components/pages/Launcher.tsx
@@ -425,10 +425,14 @@ export function Launcher({
     return result.length > 0 ? result : [[]];
   }, [pageGroups, byId, favoriteSet]);
 
-  const pages = useMemo(
-    () => curatedPages ?? (layout.pages.length > 0 ? layout.pages : [[]]),
-    [curatedPages, layout.pages],
-  );
+  const pages = useMemo(() => {
+    const sourcePages =
+      curatedPages ?? (layout.pages.length > 0 ? layout.pages : [[]]);
+    const filtered = sourcePages
+      .map((page) => page.filter((id) => !favoriteSet.has(id)))
+      .filter((page) => page.length > 0);
+    return filtered.length > 0 ? filtered : [[]];
+  }, [curatedPages, layout.pages, favoriteSet]);
 
   // Report the page count up so an outer surface (the rail) can size the single
   // unified page indicator. Fires only on an actual count change.


### PR DESCRIPTION
Follow-up to #10800 / #9144.

## Summary
- Filters the final launcher page list against the rendered dock set, so controlled `favoriteIds` from desktop-tab pins do not duplicate as page tiles.
- Extends the controlled-favorites component test to assert the 4-tile dock cap and that docked ids are absent from the page grid while non-docked ids remain.

## Evidence
```bash
bunx biome check packages/ui/src/components/pages/Launcher.tsx packages/ui/src/components/pages/Launcher.test.tsx
bun run --cwd packages/ui test -- src/components/pages/Launcher.test.tsx src/state/launcher-layout.test.ts src/state/launcher-layout.property.test.ts --coverage.enabled=false
bun run --cwd packages/ui typecheck
bun install
```

Results:
- Biome: clean.
- Focused tests: 49 passed.
- `packages/ui` typecheck: passed.
- `bun install`: completed with no tracked changes.

Repo-wide verify note: #10800 already documents the current upstream `audit:type-safety-ratchet` baseline failure on `develop`; this follow-up only touches the launcher UI component/test and was validated with the focused gates above.