### PR TITLE
ci(cloud-cf-deploy): reclaim leaked checkout dirs before materializing (fixes #10839)

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -98,6 +98,26 @@ jobs:
       CHECKOUT_DIR: /tmp/eliza-checkout-${{ github.run_id }}-${{ github.run_attempt }}-deploy-api
       CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS: ${{ vars.CLOUD_CF_CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS || '600' }}
     steps:
+      - name: Reclaim disk from leaked checkouts of prior runs
+        run: |
+          set -uo pipefail
+          # Cancelled/killed deploy runs never reach the trailing "Clean temp
+          # checkout" step, so their /tmp/eliza-checkout-* trees (a full ~46k-file
+          # monorepo materialization) leak and pile up on this shared self-hosted
+          # box until disk/inodes are exhausted and this run's own materialization
+          # blows its timeout — freezing prod (elizaOS/eliza#10839). Reclaim every
+          # stale checkout dir that is NOT from this run before we materialize ours.
+          # Deploys serialize on this box and the prefix is unique to this workflow,
+          # so nothing live is touched; best-effort, never fails the deploy.
+          reclaimed=0
+          for d in /tmp/eliza-checkout-*; do
+            [ -e "$d" ] || continue
+            case "$d" in /tmp/eliza-checkout-${{ github.run_id }}-*) continue ;; esac
+            timeout 120s rm -rf "$d" 2>/dev/null || echo "::warning::cleanup of $d exceeded 120s (non-fatal)"
+            reclaimed=$((reclaimed + 1))
+          done
+          echo "Reclaimed ${reclaimed} leaked checkout dir(s) from prior runs."
+          df -h /tmp / 2>/dev/null | tail -2 || true
       - name: Checkout repository
         timeout-minutes: 20
         env:
@@ -316,6 +336,26 @@ jobs:
       CHECKOUT_DIR: /tmp/eliza-checkout-${{ github.run_id }}-${{ github.run_attempt }}-deploy-console
       CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS: ${{ vars.CLOUD_CF_CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS || '600' }}
     steps:
+      - name: Reclaim disk from leaked checkouts of prior runs
+        run: |
+          set -uo pipefail
+          # Cancelled/killed deploy runs never reach the trailing "Clean temp
+          # checkout" step, so their /tmp/eliza-checkout-* trees (a full ~46k-file
+          # monorepo materialization) leak and pile up on this shared self-hosted
+          # box until disk/inodes are exhausted and this run's own materialization
+          # blows its timeout — freezing prod (elizaOS/eliza#10839). Reclaim every
+          # stale checkout dir that is NOT from this run before we materialize ours.
+          # Deploys serialize on this box and the prefix is unique to this workflow,
+          # so nothing live is touched; best-effort, never fails the deploy.
+          reclaimed=0
+          for d in /tmp/eliza-checkout-*; do
+            [ -e "$d" ] || continue
+            case "$d" in /tmp/eliza-checkout-${{ github.run_id }}-*) continue ;; esac
+            timeout 120s rm -rf "$d" 2>/dev/null || echo "::warning::cleanup of $d exceeded 120s (non-fatal)"
+            reclaimed=$((reclaimed + 1))
+          done
+          echo "Reclaimed ${reclaimed} leaked checkout dir(s) from prior runs."
+          df -h /tmp / 2>/dev/null | tail -2 || true
       - name: Checkout repository
         timeout-minutes: 20
         env:
@@ -569,6 +609,26 @@ jobs:
       CHECKOUT_DIR: /tmp/eliza-checkout-${{ github.run_id }}-${{ github.run_attempt }}-deploy-app
       CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS: ${{ vars.CLOUD_CF_CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS || '600' }}
     steps:
+      - name: Reclaim disk from leaked checkouts of prior runs
+        run: |
+          set -uo pipefail
+          # Cancelled/killed deploy runs never reach the trailing "Clean temp
+          # checkout" step, so their /tmp/eliza-checkout-* trees (a full ~46k-file
+          # monorepo materialization) leak and pile up on this shared self-hosted
+          # box until disk/inodes are exhausted and this run's own materialization
+          # blows its timeout — freezing prod (elizaOS/eliza#10839). Reclaim every
+          # stale checkout dir that is NOT from this run before we materialize ours.
+          # Deploys serialize on this box and the prefix is unique to this workflow,
+          # so nothing live is touched; best-effort, never fails the deploy.
+          reclaimed=0
+          for d in /tmp/eliza-checkout-*; do
+            [ -e "$d" ] || continue
+            case "$d" in /tmp/eliza-checkout-${{ github.run_id }}-*) continue ;; esac
+            timeout 120s rm -rf "$d" 2>/dev/null || echo "::warning::cleanup of $d exceeded 120s (non-fatal)"
+            reclaimed=$((reclaimed + 1))
+          done
+          echo "Reclaimed ${reclaimed} leaked checkout dir(s) from prior runs."
+          df -h /tmp / 2>/dev/null | tail -2 || true
       - name: Checkout repository
         timeout-minutes: 20
         env:


### PR DESCRIPTION
Fixes #10839.

## Problem
`cloud-cf-deploy` has **0 successful full deploys in ~2h** — Deploy Console (elizacloud.ai) + Deploy App (app.elizacloud.ai) both fail at:
```
##[error]git checkout (working-tree materialization) timed out or failed after 600s
```
**Prod is frozen on a pre-15:00-UTC build.** Everything merged since (UI sign-in fix #10671, fleet backlog) is stuck. The `git fetch` succeeds; it's the ~46k-file working-tree materialization that stalls.

## Root cause
Each of the 3 deploy jobs materializes into `/tmp/eliza-checkout-${run_id}-*-deploy-{api,console,app}` and only `rm -rf`s **its own** dir in a trailing `Clean temp checkout` step. Cancelled/killed runs never reach it (concurrency cancels aggressively — **10 cancelled runs in the last 30**), so their trees leak. On this shared, heavily-loaded self-hosted box (`hetzner-robot`, + wrangler dev + PGlite + full Worker suite) the leaks accumulate until disk/inodes are exhausted → materialization blows the 600s cap → cancel → **more leaks → death spiral.**

`#10772`/`#10797` mitigate adjacent symptoms but don't reclaim the leaked trees — runs *after* both merged still time out at materialization.

## Fix
A best-effort **pre-checkout reclaim** step in all 3 jobs that removes every `/tmp/eliza-checkout-*` dir **not** from the current `run_id`, before materializing this run's tree:
- Runs *on the box* as the first thing each deploy does → the **next deploy self-heals** the wedge (no runner SSH needed) and it prevents recurrence.
- Safe: deploys serialize on this box; the current run's 3 dirs (`-deploy-api/console/app`, same `run_id`) are preserved; the `/tmp/eliza-checkout-*` prefix is unique to this workflow so wrangler/Worker/PGlite state is untouched.
- Never fails the deploy (per-dir 120s `timeout`, warnings only).

## Verification
- YAML validated (`yaml.safe_load`); the reclaim step is the **first** step of each of `deploy-api`, `deploy-console`, `deploy-app`, ahead of `Checkout repository`.
- The self-heal is observable in the next deploy's log: `Reclaimed N leaked checkout dir(s)…` + a `df -h` before materialization.

## Follow-ups (issue #10839)
Move to a persistent bare mirror + `git worktree` (incremental materialization, seconds not minutes); make the trailing cleanup `if: always()`; alert on N consecutive deploy failures so a wedge pages instead of silently freezing prod.

cc @lalalune — this is the current prod-deploy blocker.
