### PR TITLE
test(ui): long adversarial chat-overlay fuzz walks + consolidated multi-modal QA evidence

### DIFF
--- a/.github/issue-evidence/qa-modality-coverage/README.md
+++ b/.github/issue-evidence/qa-modality-coverage/README.md
@@ -1,0 +1,71 @@
+# elizaOS App — automated UI/chat QA coverage (multi-modal, this Linux host)
+
+A consolidated record of the automated QA now exercising the app UI + chat
+across **web (real Chromium), Android emulator, and a physical Android device**,
+plus property/fuzz and every-view aesthetic gating — run and verified on one
+Linux host. Two real test-infra bugs surfaced by the sweep were fixed (below).
+
+## 1. Web — every default view, real Chromium (`audit:app`)
+
+`bun run --cwd packages/app audit:app` boots a live stack (API stub + built app)
+and walks **~50 views × 4 viewports = 349 tests** in real headless Chromium,
+screenshotting each + scoring blank/broken/console-error/blue/hover/radius.
+
+- Result: **349 passed, 0 broken, 0 needs-work** (after the audit-gate fix below).
+- Before the fix: **236 / 348 view-combos were falsely `needs-work`** — every one
+  from a single mis-classified colour (the overlay's near-black scrim
+  `rgba(10,10,12,0.5)` read as "blue"). Fixed in **#10710 → merged #10795** with
+  an absolute-chroma floor; re-ran the full audit before/after to prove
+  `needs-work 236 → 0`, `flagged-blue 236 → 0`.
+
+## 2. Web — isolated real-Chromium e2e fleet (16 runners) + fuzz
+
+An adversarial parallel sweep ran all 16 isolated `__e2e__` runners (each
+self-bundles its fixture and drives **real pointer/keyboard input**, recording
+screenshots + video) plus the property/fuzz suites, then re-verified every
+failure to separate real bugs from flakes/env.
+
+- **15 / 19 green · 130 / 130 fuzz · 0 product UI/UX regressions.**
+- Passing surfaces (with artifacts): agent-surface, background (+webm),
+  chat-ambient, chat-sheet-frame-glitch (+`transition.gif`), chatux-gesture
+  (+webm), conversation-swipe (+`conversation-swipe-interleaving.webm`),
+  ftu-home (+2 webm), home-screen (+`mobile-launcher-flow.webm`), launcher
+  (+`launcher-walkthrough.webm`), orchestrator-accounts, tutorial (+webm),
+  view-lifecycle (keep-alive/LRU/RAF-pause/render-storm/crash-recovery/memory
+  slope, +webm+telemetry).
+- Fuzz suites (130/130): chat-overlay detent state-machine (invariants after
+  every step), shell-controller send/voice/new-chat lifecycle, message parsers,
+  genui validator, screen-background.
+
+### Real bugs found + fixed by the sweep
+1. **`run-chat-sheet-e2e.mjs` stale header assertion** — required a
+   `chat-full-copy-conversation` button that PR #10713 (#10749) removed, so the
+   chat-sheet gesture/parity lane was permanently red. Fixed (drop the clause) →
+   **PR #10824**; verified `CHAT-SHEET E2E PASSED`.
+2. **`bottombar` + `fused-wake` e2e import-crash** — `@tailwindcss/postcss` +
+   `postcss` were undeclared deps of `packages/ui`, so both runners crashed at
+   import before any test. Declared them → **PR #10833**; `bottombar` now PASSES,
+   `fused-wake` imports and skips gracefully.
+
+### Environment-blocked (not code)
+`perf-gate-e2e` frame-budget assertions fail on this **software-GL, oversubscribed
+(load ~42 on 24 cores)** host — proven **identical on `origin/develop`** (develop
+marginally worse: CLS 5.04 vs 4.41), so no branch regression. Needs a real GPU
+compositor host. See `android-on-device.md` for the host-backend Android specs.
+
+## 3. Android — emulator + physical device (real WebView, CDP-over-adb)
+
+See `android-on-device.md`. Route-coverage **47/47** render-safe on both the
+`emulator-5554` AND the physical device `27051JEGR10034`; console-sweep **47
+views, 0 console errors** on-device.
+
+## 4. Scenario-runner
+
+Built + functional (CLI → scenario discovery → deterministic proxy mode). Runs in
+the main tree; blocked in a fresh worktree only by the documented cross-plugin
+subpath cascade (`plugin-*/subpath` not built) — infra, not a scenario defect.
+
+## Session PRs (7)
+Merged: #10711/#10740, #10717/#10750, #10712/#10760, #10722/#10766, #10710/#10795.
+Open (adversarial-QA bug fixes): #10824 (chat-sheet stale assertion),
+#10833 (ui e2e tailwind/postcss deps).

--- a/.github/issue-evidence/qa-modality-coverage/README.md
+++ b/.github/issue-evidence/qa-modality-coverage/README.md
@@ -66,6 +66,5 @@ the main tree; blocked in a fresh worktree only by the documented cross-plugin
 subpath cascade (`plugin-*/subpath` not built) — infra, not a scenario defect.
 
 ## Session PRs (7)
-Merged: #10711/#10740, #10717/#10750, #10712/#10760, #10722/#10766, #10710/#10795.
-Open (adversarial-QA bug fixes): #10824 (chat-sheet stale assertion),
-#10833 (ui e2e tailwind/postcss deps).
+Merged: #10711/#10740, #10717/#10750, #10712/#10760, #10722/#10766, #10710/#10795,
+#10824 (chat-sheet stale assertion), #10833 (ui e2e tailwind/postcss deps).

--- a/.github/issue-evidence/qa-modality-coverage/android-on-device.md
+++ b/.github/issue-evidence/qa-modality-coverage/android-on-device.md
@@ -1,0 +1,41 @@
+# Android on-device QA coverage (emulator + physical device)
+
+Run on this Linux host against a live Android environment: **1 physical device
+(`27051JEGR10034`) + 2 emulators**, the shipping app `ai.elizaos.app` installed on
+all three, driven via CDP-over-adb (`packages/app/playwright.android.config.ts`,
+the harness foregrounds the app and connects Playwright to the on-device WebView).
+
+## Route coverage — every app view renders render-safe on the real WebView
+`route-coverage.android.spec.ts` navigates all `DIRECT_ROUTE_CASES` +
+`MANAGER_VISIBLE_VIEW_TILE_CASES` against the **real on-device agent** and asserts
+each mounts its React root without tripping the error boundary:
+
+| target | result |
+| --- | --- |
+| Android emulator (`emulator-5554`) | **47 / 47 passed** (36.6s) |
+| Physical device (`27051JEGR10034`) | **47 / 47 passed** (46.1s) |
+
+Views covered: chat, home/launcher, apps, views, settings, character, wallet,
+browser, automations, background, calendar, contacts, documents, feed, finances,
+focus, goals, health, inbox, messages, phone, relationships, screenshare,
+social-alpha, task-coordinator, todos, trajectory-logger, orchestrator (+tui),
+facewear/smartglasses (tui), model-tester, vector-browser, …
+
+> The physical device's first pass failed once on a transient agent-warmup timing
+> (`on-device agent healthy` only after ~30s uptime); it passed cleanly once warm.
+
+## Console-error sweep — zero console errors on every shipping view (on-device)
+`console-sweep.android.spec.ts` on `emulator-5554`: **47 views walked — CLEAN, no
+console errors / exceptions on any shipping view** (1.3m). Confirms the prior
+`#10196` permission-gate fixes hold (contacts/messages/phone no longer log
+Capacitor permission rejections on-device).
+
+## Host-backend CI-lane specs (env-blocked here, not bugs)
+`touch-gesture` (real finger-swipe → launcher) and `view-runtime-soak` are
+designed for the **host-backend lane**: they clear app data + re-onboard via a
+remote deep-link to a real agent on `:31337` (`adb reverse`). Run without that
+lane the app sits on the onboarding screen ("How should Eliza run?"), so the
+`home-launcher-surface` swipe target / view-churn telemetry never materialize
+(env, not a UI defect — the recorded video shows the onboarding screen). Real-touch
+gesture behaviour is covered on web by the merged `#10722` real-touch CDP helper +
+de-larped conversation-swipe e2e.

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.fuzz.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.fuzz.test.tsx
@@ -779,3 +779,91 @@ describe("ContinuousChatOverlay — bug (b): keyboard dismiss restores prior sta
     assertInvariants("send-commits-open");
   });
 });
+
+// ── Extended long-path adversarial fuzz (longer paths, input variety) ─────────
+// A senior-QA / adversarial pass on top of the state-machine matrix above: LONG
+// seeded random walks (150 steps each, 6 seeds = 900 driven interactions) that
+// interleave every gesture / keyboard / backdrop action with a corpus of
+// ADVERSARIAL composer inputs (empty, whitespace, 5k chars, emoji + CJK + RTL,
+// markup, control chars, multiline, symbol soup). After EVERY step the full
+// invariant set must hold; whenever the composer is live it must round-trip the
+// exact input; and after the whole storm the sheet must recover to a usable,
+// unstuck composer. Reproduces deterministically per seed.
+describe("ContinuousChatOverlay — long adversarial random walk", () => {
+  const ADVERSARIAL_INPUTS: readonly string[] = [
+    "",
+    "   ",
+    "\n\n\t  ",
+    "hi",
+    "the quick brown fox jumps over the lazy dog",
+    "a".repeat(5000),
+    "😀🎉🔥 emoji · 你好世界 · مرحبا بالعالم",
+    "<script>alert('xss')</script>",
+    "line one\nline two\nline three",
+    "```ts\nconst x = 1;\n```",
+    "  padded surface  ",
+    "\u001b[31mansi\u001b[0m control",
+    "@#$%^&*(){}[]|\\/<>?~`",
+  ];
+
+  const walkActions: Array<() => void> = [
+    () => grabber() && tap(grabber() as Element, 180),
+    () => grabber() && flickUp(grabber() as Element),
+    () => grabber() && flickDown(grabber() as Element),
+    () => grabber() && slowDrag(grabber() as Element, 420, 200),
+    () => grabber() && slowDrag(grabber() as Element, 200, 420),
+    () => tap(pill(), 400),
+    () => flick(pill(), 420, 400),
+    focusReal,
+    blurReal,
+    () => fireEvent.keyDown(input(), { key: "Enter" }),
+    () => fireEvent.keyDown(input(), { key: "Enter", shiftKey: true }),
+    () => fireEvent.keyDown(input(), { key: "Escape" }),
+    () => fireEvent.click(backdrop()),
+    () => fireEvent.pointerDown(document.body),
+    () => {
+      const b = screen.queryByTestId("chat-full-maximize");
+      if (b) fireEvent.click(b);
+    },
+    () => {
+      const b = screen.queryByTestId("chat-full-clear");
+      if (b) fireEvent.click(b);
+    },
+  ];
+
+  for (const seed of [1, 7, 42, 101, 2718, 31337]) {
+    it(`seed ${seed}: 150-step walk keeps invariants + round-trips input + recovers`, () => {
+      render(<ContinuousChatOverlay controller={makeController()} />);
+      let s = seed >>> 0;
+      const rand = () => {
+        s = (Math.imul(s, 1103515245) + 12345) & 0x7fffffff;
+        return s / 0x7fffffff;
+      };
+      for (let step = 0; step < 150; step += 1) {
+        if (rand() < 0.3) {
+          const payload =
+            ADVERSARIAL_INPUTS[Math.floor(rand() * ADVERSARIAL_INPUTS.length)];
+          // The composer is live in every detent except the collapsed pill.
+          if (detentOf() !== "pill") {
+            fireEvent.change(input(), { target: { value: payload } });
+            expect(
+              input().value,
+              `seed ${seed} step ${step} input round-trip`,
+            ).toBe(payload);
+          }
+        } else {
+          walkActions[Math.floor(rand() * walkActions.length)]();
+        }
+        assertInvariants(`seed ${seed} step ${step}`);
+      }
+      // No stuck state after the storm: reach a live composer and round-trip.
+      if (detentOf() === "pill") tap(pill(), 400);
+      focusReal();
+      fireEvent.change(input(), { target: { value: "recovered" } });
+      expect(input().value, `seed ${seed} recovered composer`).toBe(
+        "recovered",
+      );
+      assertInvariants(`seed ${seed} recovered`);
+    });
+  }
+});


### PR DESCRIPTION
## Extended fuzz (longer paths + input variety)
Adds a long-path adversarial pass on top of the existing detent state-machine matrix in `ContinuousChatOverlay.fuzz.test.tsx`:

- **6 seeds × 150-step seeded random walks = 900 driven interactions**, interleaving every gesture / keyboard / backdrop action with an **adversarial composer-input corpus**: empty, whitespace, **5 000 chars**, emoji + CJK + RTL, `<script>` markup, multiline, ANSI/control escapes, symbol soup.
- After **every** step the full invariant set holds (no impossible/stuck state); whenever the composer is live it must **round-trip the exact input**; after the storm the sheet must **recover** to a usable composer.
- Deterministic per seed. **Full suite: 119 passed** (113 existing + 6 new). Zero product bugs — the overlay state machine is robust to the storm.

## Consolidated multi-modal QA evidence
`.github/issue-evidence/qa-modality-coverage/` documents the automated UI/chat QA exercised on one Linux host:
- **Web** — `audit:app` walks every default view × 4 viewports (**349 tests, 0 broken, 0 needs-work** after the audit-gate fix #10795); the isolated real-Chromium e2e fleet (16 runners) + property/fuzz suites = **15/19 green + 130/130 fuzz, 0 product regressions**, with screenshots + video recordings per surface.
- **Android** — route-coverage **47/47** on an emulator **and** a physical device; console-sweep **47 views clean** on-device (real WebView, CDP-over-adb).
- **Scenario-runner** — built + functional (deterministic proxy mode); fresh-worktree plugin-subpath cascade documented.
- The two real **test-infra bugs** the adversarial sweep surfaced + fixed: stale chat-sheet header assertion (#10824) and undeclared `@tailwindcss/postcss` dep (#10833).

Test-only + evidence; no product code touched.