### PR TITLE
fix(cloud): complete creator-earnings idempotency — ALS key across all money routes (#10423 follow-up)

### DIFF
--- a/packages/cloud/api/src/bootstrap-app.ts
+++ b/packages/cloud/api/src/bootstrap-app.ts
@@ -177,10 +177,18 @@ export function createApp(): Hono<AppEnv> {
     await runWithCloudBindingsAsync(
       c.env as Record<string, unknown>,
       async () =>
-        // Expose the client IP to shared library code (anti-sybil grant checks)
-        // without threading it through every call site.
-        runWithRequestContext({ clientIp: getRequestIp(c) }, async () =>
-          runWithDbCacheAsync(async () => next()),
+        // Expose the client IP + a stable per-request idempotency key to shared
+        // library code (anti-sybil grant checks; idempotent money settlement,
+        // #10423) without threading them through every call site.
+        runWithRequestContext(
+          {
+            clientIp: getRequestIp(c),
+            idempotencyKey:
+              c.req.header("idempotency-key") ||
+              c.req.header("x-request-id") ||
+              crypto.randomUUID(),
+          },
+          async () => runWithDbCacheAsync(async () => next()),
         ),
     );
   });

--- a/packages/cloud/api/v1/messages/route.ts
+++ b/packages/cloud/api/v1/messages/route.ts
@@ -779,9 +779,6 @@ async function handleNonStream(
   billingSource: PricingBillingSource,
 ) {
   const provider = getProviderFromModel(model);
-  // #10423: stable per-request key so a settlement retry doesn't double-credit
-  // the app creator's redeemable earnings.
-  const requestId = crypto.randomUUID();
 
   const cotBudget = resolveAnthropicThinkingBudgetTokens(model, process.env);
   const cotOptions =
@@ -940,9 +937,6 @@ async function handleStream(
 ) {
   const provider = getProviderFromModel(model);
   const messageId = `msg_${crypto.randomUUID().replace(/-/g, "").slice(0, 24)}`;
-  // #10423: stable per-request key so a streaming settlement retry doesn't
-  // double-credit the app creator's redeemable earnings.
-  const requestId = crypto.randomUUID();
 
   const cotBudget = resolveAnthropicThinkingBudgetTokens(model, process.env);
   const cotOptions =

--- a/packages/cloud/shared/src/lib/runtime/request-context.ts
+++ b/packages/cloud/shared/src/lib/runtime/request-context.ts
@@ -13,6 +13,14 @@ import { AsyncLocalStorage } from "node:async_hooks";
 
 interface RequestContext {
   clientIp?: string;
+  /**
+   * Stable per-request idempotency key (from the `Idempotency-Key`/`X-Request-Id`
+   * header, else a per-request uuid). #10423: money-settlement code keys the
+   * app-creator earnings credit on this so a retried settlement (a re-run of the
+   * chat/message `onFinish` for the SAME request) doesn't double-credit — without
+   * threading it through every intermediate helper.
+   */
+  idempotencyKey?: string;
 }
 
 const als = new AsyncLocalStorage<RequestContext>();
@@ -27,4 +35,9 @@ export async function runWithRequestContext<T>(
 /** The originating client IP for the current request, or `undefined`. */
 export function getClientIp(): string | undefined {
   return als.getStore()?.clientIp;
+}
+
+/** The stable per-request idempotency key for the current request, or `undefined`. */
+export function getRequestIdempotencyKey(): string | undefined {
+  return als.getStore()?.idempotencyKey;
 }

--- a/packages/cloud/shared/src/lib/services/__tests__/app-credits-idempotency.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-credits-idempotency.test.ts
@@ -119,7 +119,10 @@ beforeAll(async () => {
     await apply();
   } catch (error) {
     pgliteReady = false;
-    console.error("[app-credits-idempotency.test] PGlite/pushSchema unavailable — skipping.", error);
+    console.error(
+      "[app-credits-idempotency.test] PGlite/pushSchema unavailable — skipping.",
+      error,
+    );
   }
 }, PGLITE_TIMEOUT);
 
@@ -160,10 +163,20 @@ describe("deductCredits creator-earnings idempotency (#10423)", () => {
     const { appId, payerUserId, creatorUserId } = await seed();
 
     await runWithRequestContext({ idempotencyKey: "req-A" }, async () =>
-      appCreditsService.deductCredits({ appId, userId: payerUserId, baseCost: 0.01, description: "a" }),
+      appCreditsService.deductCredits({
+        appId,
+        userId: payerUserId,
+        baseCost: 0.01,
+        description: "a",
+      }),
     );
     await runWithRequestContext({ idempotencyKey: "req-B" }, async () =>
-      appCreditsService.deductCredits({ appId, userId: payerUserId, baseCost: 0.01, description: "b" }),
+      appCreditsService.deductCredits({
+        appId,
+        userId: payerUserId,
+        baseCost: 0.01,
+        description: "b",
+      }),
     );
     expect(await creatorBalance(creatorUserId)).toBeCloseTo(0.02, 6);
   });

--- a/packages/cloud/shared/src/lib/services/__tests__/app-credits-idempotency.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-credits-idempotency.test.ts
@@ -1,0 +1,170 @@
+/**
+ * App-credits creator-earnings idempotency — REAL path (#10423).
+ *
+ * Drives the CHANGED code end-to-end: `AppCreditsService.deductCredits` →
+ * `recordCreatorEarnings` → `redeemableEarningsService.addEarnings`, twice with
+ * the SAME request idempotency key (via the `runWithRequestContext` ALS the
+ * Cloud API sets per request), against in-process PGlite. Asserts the app
+ * creator's redeemable balance is credited exactly ONCE — i.e. a settlement
+ * retry no longer double-credits.
+ *
+ * Self-skips LOUDLY if PGlite/pushSchema is unavailable.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
+const CAN_USE_ISOLATED_PGLITE =
+  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { pushSchema } from "drizzle-kit/api";
+import { eq } from "drizzle-orm";
+import { closeDatabaseConnectionsForTests, dbWrite } from "../../../db/client";
+import { appEarnings, appEarningsTransactions } from "../../../db/schemas/app-earnings";
+import {
+  appDeploymentStatusEnum,
+  apps,
+  appUsers,
+  userDatabaseStatusEnum,
+} from "../../../db/schemas/apps";
+import { creditTransactions } from "../../../db/schemas/credit-transactions";
+import { organizations } from "../../../db/schemas/organizations";
+import {
+  earningsSourceEnum,
+  ledgerEntryTypeEnum,
+  redeemableEarnings,
+  redeemableEarningsLedger,
+  redeemedEarningsTracking,
+} from "../../../db/schemas/redeemable-earnings";
+import { users } from "../../../db/schemas/users";
+import { runWithRequestContext } from "../../runtime/request-context";
+
+const PGLITE_TIMEOUT = 60_000;
+let pgliteReady = true;
+let appCreditsService: typeof import("../app-credits").appCreditsService;
+
+let seq = 0;
+function uniq(p: string): string {
+  seq += 1;
+  return `${p}-${seq}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function seed(): Promise<{ appId: string; payerUserId: string; creatorUserId: string }> {
+  const [payerOrg] = await dbWrite
+    .insert(organizations)
+    .values({ name: "Payer", slug: uniq("payer"), credit_balance: "100.000000" })
+    .returning();
+  const [payer] = await dbWrite
+    .insert(users)
+    .values({ steward_user_id: uniq("payer-u"), organization_id: payerOrg.id })
+    .returning();
+  const [creatorOrg] = await dbWrite
+    .insert(organizations)
+    .values({ name: "Creator", slug: uniq("creator") })
+    .returning();
+  const [creator] = await dbWrite
+    .insert(users)
+    .values({ steward_user_id: uniq("creator-u"), organization_id: creatorOrg.id })
+    .returning();
+  const [app] = await dbWrite
+    .insert(apps)
+    .values({
+      name: "Monetized App",
+      slug: uniq("app"),
+      organization_id: creatorOrg.id,
+      created_by_user_id: creator.id,
+      app_url: "https://placeholder.invalid",
+      monetization_enabled: true,
+      inference_markup_percentage: 100,
+    })
+    .returning();
+  return { appId: app.id, payerUserId: payer.id, creatorUserId: creator.id };
+}
+
+async function creatorBalance(userId: string): Promise<number> {
+  const row = await dbWrite.query.redeemableEarnings.findFirst({
+    where: eq(redeemableEarnings.user_id, userId),
+  });
+  return Number(row?.available_balance ?? 0);
+}
+
+beforeAll(async () => {
+  if (!CAN_USE_ISOLATED_PGLITE) {
+    pgliteReady = false;
+    console.warn("[app-credits-idempotency.test] non-PGlite DATABASE_URL; self-skipping.");
+    return;
+  }
+  try {
+    ({ appCreditsService } = await import("../app-credits"));
+    const schema = {
+      organizations,
+      users,
+      apps,
+      appUsers,
+      appEarnings,
+      appEarningsTransactions,
+      redeemableEarnings,
+      redeemableEarningsLedger,
+      redeemedEarningsTracking,
+      creditTransactions,
+      appDeploymentStatusEnum,
+      userDatabaseStatusEnum,
+      earningsSourceEnum,
+      ledgerEntryTypeEnum,
+    };
+    const { apply } = await pushSchema(schema as never, dbWrite as never);
+    await apply();
+  } catch (error) {
+    pgliteReady = false;
+    console.error("[app-credits-idempotency.test] PGlite/pushSchema unavailable — skipping.", error);
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests();
+});
+
+describe("deductCredits creator-earnings idempotency (#10423)", () => {
+  test("pglite applied (loud, never silent no-op)", () => {
+    expect(pgliteReady).toBe(true);
+  });
+
+  test("two deductCredits with the SAME request idempotency key credit the creator once", async () => {
+    if (!pgliteReady) return;
+    const { appId, payerUserId, creatorUserId } = await seed();
+
+    const deduct = () =>
+      runWithRequestContext({ idempotencyKey: "settle-key-1" }, async () =>
+        appCreditsService.deductCredits({
+          appId,
+          userId: payerUserId,
+          baseCost: 0.01,
+          description: "inference",
+        }),
+      );
+
+    const first = await deduct();
+    const second = await deduct(); // a settlement retry for the SAME request
+
+    expect(first.success).toBe(true);
+    expect(second.success).toBe(true);
+    // markup = baseCost * 100% = 0.01, credited exactly once (not 0.02).
+    expect(await creatorBalance(creatorUserId)).toBeCloseTo(0.01, 6);
+  });
+
+  test("different request keys credit the creator per charge", async () => {
+    if (!pgliteReady) return;
+    const { appId, payerUserId, creatorUserId } = await seed();
+
+    await runWithRequestContext({ idempotencyKey: "req-A" }, async () =>
+      appCreditsService.deductCredits({ appId, userId: payerUserId, baseCost: 0.01, description: "a" }),
+    );
+    await runWithRequestContext({ idempotencyKey: "req-B" }, async () =>
+      appCreditsService.deductCredits({ appId, userId: payerUserId, baseCost: 0.01, description: "b" }),
+    );
+    expect(await creatorBalance(creatorUserId)).toBeCloseTo(0.02, 6);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/__tests__/creator-earnings-idempotency.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/creator-earnings-idempotency.test.ts
@@ -114,6 +114,10 @@ afterAll(async () => {
 });
 
 describe("creator earnings idempotency (#10423)", () => {
+  test("pglite applied (loud, never a silent no-op pass)", () => {
+    expect(pgliteReady).toBe(true);
+  });
+
   let userId: string;
   beforeEach(async () => {
     if (!pgliteReady) return;

--- a/packages/cloud/shared/src/lib/services/app-credits.ts
+++ b/packages/cloud/shared/src/lib/services/app-credits.ts
@@ -11,6 +11,7 @@ import { usersRepository } from "../../db/repositories/users";
 import { apps } from "../../db/schemas/apps";
 import { cache } from "../cache/client";
 import { CacheKeys, CacheTTL } from "../cache/keys";
+import { getRequestIdempotencyKey } from "../runtime/request-context";
 import { logger } from "../utils/logger";
 import {
   computeInferenceCharge,
@@ -852,42 +853,24 @@ export class AppCreditsService {
     metadata: Record<string, unknown>,
     providedApp?: App,
   ): Promise<void> {
-    // Update app-level earnings tracking
-    if (type === "inference_markup") {
-      await appEarningsRepository.addInferenceEarnings(appId, amount);
-    } else {
-      await appEarningsRepository.addPurchaseEarnings(appId, amount);
-    }
-
-    // Create transaction record
-    await appEarningsRepository.createTransaction({
-      app_id: appId,
-      user_id: userId,
-      type,
-      amount: String(amount),
-      description:
-        type === "inference_markup" ? "Inference markup earnings" : "Credit purchase share",
-      metadata,
-    });
-
-    // CRITICAL: Credit the app creator's redeemable_earnings balance
-    // This allows them to redeem earnings as elizaOS tokens
-    // Use provided app to avoid N+1 query, or fetch if not provided
+    // CRITICAL: Credit the app creator's redeemable_earnings balance FIRST — it
+    // is the idempotency gate. #10423: a settlement retry (a re-run of the
+    // chat/message `onFinish` for the SAME request, or a webhook retry) must not
+    // double-credit. Key on a stable per-charge id — the request idempotency key
+    // (inference) or the Stripe payment intent (purchase) — never on `appId`,
+    // which repeats across every charge. Fall back to the (non-idempotent)
+    // app-scoped id only when no per-charge key is present, preserving prior
+    // behavior for callers without one.
     const app = providedApp ?? (await appsRepository.findById(appId));
-    if (app?.created_by_user_id) {
-      // #10423: make the creator credit IDEMPOTENT. A settlement retry (a
-      // re-run of the chat/message `onFinish` for the SAME request, or a
-      // webhook retry) must not double-credit. Key on a stable per-charge id —
-      // the request idempotency key (inference) or the Stripe payment intent
-      // (purchase) — never on `appId`, which repeats across every charge.
-      // Fall back to the (non-idempotent) app-scoped id only when no per-charge
-      // key is present, preserving the prior behavior for callers without one.
-      const chargeKey =
-        (typeof metadata.idempotencyKey === "string" && metadata.idempotencyKey) ||
-        (typeof metadata.stripePaymentIntentId === "string" && metadata.stripePaymentIntentId) ||
-        null;
-      const sourceId = chargeKey ? `${chargeKey}:${type}` : appId;
+    const chargeKey =
+      (typeof metadata.idempotencyKey === "string" && metadata.idempotencyKey) ||
+      (typeof metadata.stripePaymentIntentId === "string" && metadata.stripePaymentIntentId) ||
+      getRequestIdempotencyKey() ||
+      null;
 
+    let deduplicated = false;
+    if (app?.created_by_user_id) {
+      const sourceId = chargeKey ? `${chargeKey}:${type}` : appId;
       const result = await redeemableEarningsService.addEarnings({
         userId: app.created_by_user_id,
         amount,
@@ -905,17 +888,16 @@ export class AppCreditsService {
           ...metadata,
         },
       });
+      deduplicated = result.deduplicated === true;
 
-      if (result.deduplicated) {
-        logger.info("[AppCredits] Creator earning already recorded — skipped duplicate", {
+      if (deduplicated) {
+        logger.info("[AppCredits] Creator earning already recorded — skipping duplicate", {
           appId,
           creatorId: app.created_by_user_id,
           amount,
           sourceId,
         });
-      }
-
-      if (!result.success) {
+      } else if (!result.success) {
         logger.error("[AppCredits] Failed to credit redeemable earnings", {
           appId,
           creatorId: app.created_by_user_id,
@@ -931,6 +913,29 @@ export class AppCreditsService {
         });
       }
     }
+
+    // A dedup retry already recorded everything on the first pass — skip the
+    // shadow app_earnings + audit-transaction writes so they don't double-count
+    // the withdrawable ceiling (#10423).
+    if (deduplicated) return;
+
+    // Shadow app-level earnings tracking (analytics / withdrawable ceiling).
+    if (type === "inference_markup") {
+      await appEarningsRepository.addInferenceEarnings(appId, amount);
+    } else {
+      await appEarningsRepository.addPurchaseEarnings(appId, amount);
+    }
+
+    // Create transaction record
+    await appEarningsRepository.createTransaction({
+      app_id: appId,
+      user_id: userId,
+      type,
+      amount: String(amount),
+      description:
+        type === "inference_markup" ? "Inference markup earnings" : "Credit purchase share",
+      metadata,
+    });
   }
 
   /**
@@ -945,30 +950,26 @@ export class AppCreditsService {
     amount: number,
     metadata: Record<string, unknown>,
   ): Promise<void> {
-    // Reduce app-level inference earnings (use negative value)
-    await appEarningsRepository.addInferenceEarnings(appId, -amount);
-
-    // Create transaction record for audit trail
-    await appEarningsRepository.createTransaction({
-      app_id: appId,
-      user_id: userId,
-      type: "inference_markup",
-      amount: String(-amount), // Negative to indicate reduction
-      description: "Reconciliation adjustment (refund)",
-      metadata: {
-        ...metadata,
-        type: "reconciliation_refund",
-      },
-    });
-
-    // Reduce the app creator's redeemable_earnings balance
+    // #10423 (symmetry with recordCreatorEarnings): the reversal must also be
+    // idempotent, or a retried reconciliation would double-DEBIT the creator.
+    // Key the reduce on the SAME per-charge id + a distinct suffix so a retry
+    // of the same refund reuses the prior ledger entry instead of reducing
+    // twice. reduceEarnings is the gate; skip the shadow writes on a dedup retry.
     const app = await appsRepository.findById(appId);
+    const chargeKey =
+      (typeof metadata.idempotencyKey === "string" && metadata.idempotencyKey) ||
+      (typeof metadata.stripePaymentIntentId === "string" && metadata.stripePaymentIntentId) ||
+      getRequestIdempotencyKey() ||
+      null;
+
+    let deduplicated = false;
     if (app?.created_by_user_id) {
       const result = await redeemableEarningsService.reduceEarnings({
         userId: app.created_by_user_id,
         amount,
         source: "miniapp",
-        sourceId: appId,
+        sourceId: chargeKey ? `${chargeKey}:reconciliation_refund` : appId,
+        dedupeBySourceId: chargeKey !== null,
         description: `Reconciliation adjustment for app: ${app.name || appId}`,
         metadata: {
           appId,
@@ -977,8 +978,15 @@ export class AppCreditsService {
           ...metadata,
         },
       });
+      deduplicated = result.deduplicated === true;
 
-      if (!result.success) {
+      if (deduplicated) {
+        logger.info("[AppCredits] Creator earning reversal already applied — skipping duplicate", {
+          appId,
+          creatorId: app.created_by_user_id,
+          amount,
+        });
+      } else if (!result.success) {
         logger.error("[AppCredits] Failed to reduce redeemable earnings", {
           appId,
           creatorId: app.created_by_user_id,
@@ -994,6 +1002,22 @@ export class AppCreditsService {
         });
       }
     }
+
+    if (deduplicated) return;
+
+    // Shadow app-level reduction (use negative value) + audit trail.
+    await appEarningsRepository.addInferenceEarnings(appId, -amount);
+    await appEarningsRepository.createTransaction({
+      app_id: appId,
+      user_id: userId,
+      type: "inference_markup",
+      amount: String(-amount), // Negative to indicate reduction
+      description: "Reconciliation adjustment (refund)",
+      metadata: {
+        ...metadata,
+        type: "reconciliation_refund",
+      },
+    });
   }
 
   /**


### PR DESCRIPTION
## Complete the creator-earnings idempotency fix (#10423 follow-up)

The first pass (merged in the original #10810) was **incomplete** — an adversarial review found it didn't actually stop the double-credit on the most important paths. This completes it.

### What the review caught (and this fixes)
- **BLOCKER — messages route was a no-op:** it minted a *fresh* `crypto.randomUUID()` per handler invocation, so a settlement retry got a new key and `dedupeBySourceId` never matched → still double-credited.
- **`apps/[id]/chat` (the primary app-creator monetization route) was never fixed** — 6 reconcile/deduct call sites with no key.
- **chat/completions non-streaming reconcile** omitted the key (only the streaming one had it).
- **Refund path (`reverseCreatorEarnings`) still keyed on `appId`** with no dedupe → a retried reconciliation could double-**debit** the creator.
- **`app_earnings` shadow table double-counted** on retry (written outside the dedupe guard), inflating the withdrawable ceiling.
- The test only drove the `addEarnings` primitive, never the changed `deductCredits`/`recordCreatorEarnings` path.

### The fix
- **Request-scoped idempotency key via the existing `runWithRequestContext` ALS.** `bootstrap-app` injects a stable per-request key (`Idempotency-Key`/`X-Request-Id` header, else a uuid); `recordCreatorEarnings`/`reverseCreatorEarnings` read it as the `chargeKey` fallback. This fixes **all** money routes at once — messages, `apps/[id]/chat`, chat/completions — with **no** helper threading, and a **safe null-fallback** (no regression if ever absent).
- Dropped the messages-route per-invocation UUID; added the key to chat/completions' non-streaming reconcile.
- `reverseCreatorEarnings` now keys on the same per-charge id (`…:reconciliation_refund`) + `dedupeBySourceId`.
- Restructured both: the redeemable `addEarnings`/`reduceEarnings` dedupe gate runs **first**; the shadow `app_earnings` + audit-transaction writes are **skipped on a dedup retry** (fixes the shadow double-count).

### Evidence
- **Real-path test** (`app-credits-idempotency.test`, PGlite): `deductCredits` twice with the **same** ALS key → creator credited **once** (`0.01`, not `0.02`); distinct keys → `0.02`. Plus the addEarnings-primitive tests and **loud `pgliteReady` asserts** (no silent-skip green). **7 pass.**
- `tsc --noEmit` clean across cloud-shared + cloud-api.

**MONEY PATH — do not self-merge; needs ops review.** Continues #10423 after the original #10810 merged.
