### PR TITLE
fix(cloud): apps chat streaming — don't full-refund a delivered answer when accounting throws (#10837)

### DIFF
--- a/packages/cloud/api/v1/apps/[id]/chat/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/chat/route.ts
@@ -587,11 +587,52 @@ async function handlePOST(
             },
           });
         } catch (error) {
-          // Stream failed - refund the reserved charge since we don't know actual usage
           const errorMessage =
             error instanceof Error ? error.message : "Unknown error";
+
+          if (writerClosed) {
+            // The full response was already streamed to the client and the writer
+            // was closed (writerClosed is set right after the stream loop, before
+            // the post-stream accounting). Reaching the catch with writerClosed
+            // means accounting (calculateCost / reconcileCredits) threw AFTER
+            // delivery — the user already received the complete answer, so a
+            // refund here would hand out free inference. Keep the reserved charge
+            // instead (best-effort; if this reconcile also throws, the
+            // reservation simply stands — never a refund of a delivered answer).
+            logger.error(
+              "[App Chat] Accounting failed AFTER the response was delivered — keeping reserved charge, NOT refunding",
+              { appId, userId: user.id, reservedBaseCost, error: errorMessage },
+            );
+            try {
+              await appCreditsService.reconcileCredits({
+                appId,
+                userId: user.id,
+                estimatedBaseCost: reservedBaseCost,
+                actualBaseCost: reservedBaseCost, // delivered → keep the reservation, do NOT refund
+                description:
+                  "Response delivered; post-stream accounting failed — reserved charge kept",
+                metadata: { error: true, streaming: true, deliveredBeforeError: true },
+              });
+            } catch (reconcileError) {
+              logger.error(
+                "[App Chat] Post-delivery reconcile also failed; reserved charge stands",
+                {
+                  appId,
+                  userId: user.id,
+                  error:
+                    reconcileError instanceof Error
+                      ? reconcileError.message
+                      : String(reconcileError),
+                },
+              );
+            }
+            return;
+          }
+
+          // Stream failed BEFORE the response was fully delivered — the user did
+          // not receive the answer, so refund the reserved charge.
           logger.error(
-            "[App Chat] Stream processing failed, refunding reserved",
+            "[App Chat] Stream failed before delivery, refunding reserved",
             {
               appId,
               userId: user.id,
@@ -609,19 +650,17 @@ async function handlePOST(
             metadata: { error: true, streaming: true },
           });
 
-          // Send error event to client if writer is still open
-          if (!writerClosed) {
-            const errorEvent = `data: ${JSON.stringify({
-              error: {
-                message: "Stream interrupted. Credits refunded.",
-                type: "api_error",
-                code: "stream_error",
-              },
-            })}\n\ndata: [DONE]\n\n`;
-            const encoder = new TextEncoder();
-            writer.write(encoder.encode(errorEvent));
-            writer.close();
-          }
+          // Send error event to client (the writer is still open on this path).
+          const errorEvent = `data: ${JSON.stringify({
+            error: {
+              message: "Stream interrupted. Credits refunded.",
+              type: "api_error",
+              code: "stream_error",
+            },
+          })}\n\ndata: [DONE]\n\n`;
+          const encoder = new TextEncoder();
+          writer.write(encoder.encode(errorEvent));
+          writer.close();
         }
       })();
 


### PR DESCRIPTION
Fixes #10837.

## Bug
`POST /api/v1/apps/:id/chat` (stream). Credits are reserved up front. After the full provider response is streamed to the client and `writer.close()` runs (`writerClosed = true`), post-stream accounting (`calculateCost` / `reconcileCredits`) runs **inside the same try**. If it throws — e.g. a transient Postgres/pricing-catalog error during a DB incident — the catch cannot tell "stream failed mid-delivery" from "stream fully delivered, accounting threw" and unconditionally called `reconcileCredits({ actualBaseCost: 0 })` — a **full refund of a delivered answer** → free inference, systemic across concurrent streams during a blip.

## Fix
Gate the refund on the existing `writerClosed` flag:
- `writerClosed === true` → the response was already delivered → **keep the reserved charge** (`actualBaseCost: reservedBaseCost`), best-effort; if that reconcile also throws, the reservation stands. Never refund a delivered answer.
- `writerClosed === false` → the user did not receive the answer → refund as before + emit the error SSE event.

One-condition change on an existing delivery signal; the happy path and the genuine mid-stream-failure refund path are unchanged.

## Evidence
- **Bug is confirmed by an adversarial audit with a full hand-traced code path** (reserve → stream → close → accounting-throw → catch → `actualBaseCost: 0`); see #10837. The `writerClosed` flag was already computed and consulted (for the error-SSE decision) but not for the refund decision.
- `tsgo` typecheck: clean.
- **N/A for now — streaming-route integration test:** a deterministic end-to-end test needs ~10 mocked seams (auth, `appsService.getById`, `appCreditsService`, `calculateCost`, `withProviderFallback` streaming `Response`, cors/rate-limit/models) plus settling the fire-and-forget async streaming IIFE. Flagging as a fast-follow rather than ship a timing-flaky test; happy to add it or pair. The change is a single guard on an already-present flag.

Money-path change — **not self-merged; requesting maintainer review.**
