### PR TITLE
fix(core): surface every sub-planner step so the planner advances past the first successful op (#8007)

### DIFF
--- a/packages/core/src/__tests__/message-action-dedupe.test.ts
+++ b/packages/core/src/__tests__/message-action-dedupe.test.ts
@@ -79,4 +79,56 @@ describe("subPlannerResultToPlannerToolResult", () => {
 		expect(result.continueChain).toBeUndefined();
 		expect(result.success).toBe(true);
 	});
+
+	// Regression for elizaOS/eliza#8007: a multi-step sub-planner collapse must
+	// surface EVERY executed sub-step to the parent loop — not only the terminal
+	// one — so the outer planner can see which ops already succeeded and advance
+	// instead of re-running the umbrella action from the first step.
+	it("aggregates all sub-steps into the diagnostic text and data", () => {
+		const multiStep = {
+			status: "finished",
+			finalMessage: "Opened a PR for hello-world.",
+			trajectory: {
+				steps: [
+					{
+						iteration: 1,
+						toolCall: { name: "provision_workspace" },
+						result: { success: true, text: "workspace ws-1 ready" },
+					},
+					{
+						iteration: 2,
+						toolCall: { name: "spawn_agent" },
+						result: { success: true, text: "spawned agent a-1" },
+					},
+					{
+						iteration: 3,
+						toolCall: { name: "submit_workspace" },
+						result: { success: false, error: "no diff to submit" },
+					},
+				],
+			},
+		} as unknown as SubResult;
+
+		const result = subPlannerResultToPlannerToolResult(multiStep);
+
+		// The diagnostic text (what the parent planner reasons over) carries the
+		// full progression, not just the terminal step.
+		expect(result.text).toContain("provision_workspace");
+		expect(result.text).toContain("spawn_agent");
+		expect(result.text).toContain("submit_workspace");
+		expect(result.text).toContain("✓");
+		expect(result.text).toContain("✗");
+
+		// The user-facing text stays the synthesized final message.
+		expect(result.userFacingText).toBe("Opened a PR for hello-world.");
+
+		// Structured sub-step data lets downstream action context see which ops
+		// already completed.
+		expect(result.data?.completedSubActions).toEqual([
+			"provision_workspace",
+			"spawn_agent",
+		]);
+		expect(Array.isArray(result.data?.subSteps)).toBe(true);
+		expect((result.data?.subSteps as unknown[]).length).toBe(3);
+	});
 });

--- a/packages/core/src/__tests__/message-action-dedupe.test.ts
+++ b/packages/core/src/__tests__/message-action-dedupe.test.ts
@@ -56,7 +56,7 @@ describe("subPlannerResultToPlannerToolResult", () => {
 		// A fire-and-forget sub-action (e.g. TASKS_SPAWN_AGENT) returns
 		// continueChain:false. Without propagating it through the umbrella
 		// result, the parent planner loop evaluates CONTINUE and re-runs the
-		// umbrella — producing duplicate spawns on a single user turn.
+		// umbrella, producing duplicate spawns on a single user turn.
 		const result = subPlannerResultToPlannerToolResult(
 			subResult(
 				{ success: true, text: "On it.", continueChain: false },
@@ -81,8 +81,8 @@ describe("subPlannerResultToPlannerToolResult", () => {
 	});
 
 	// Regression for elizaOS/eliza#8007: a multi-step sub-planner collapse must
-	// surface EVERY executed sub-step to the parent loop — not only the terminal
-	// one — so the outer planner can see which ops already succeeded and advance
+	// surface EVERY executed sub-step to the parent loop, not only the terminal
+	// one, so the outer planner can see which ops already succeeded and advance
 	// instead of re-running the umbrella action from the first step.
 	it("aggregates all sub-steps into the diagnostic text and data", () => {
 		const multiStep = {
@@ -116,8 +116,8 @@ describe("subPlannerResultToPlannerToolResult", () => {
 		expect(result.text).toContain("provision_workspace");
 		expect(result.text).toContain("spawn_agent");
 		expect(result.text).toContain("submit_workspace");
-		expect(result.text).toContain("✓");
-		expect(result.text).toContain("✗");
+		expect(result.text).toContain("OK");
+		expect(result.text).toContain("FAIL");
 
 		// The user-facing text stays the synthesized final message.
 		expect(result.userFacingText).toBe("Opened a PR for hello-world.");

--- a/packages/core/src/runtime/__tests__/planner-loop-8007-multistep.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-8007-multistep.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi } from "vitest";
+import { runPlannerLoop } from "../planner-loop";
+
+/**
+ * Regression coverage for issue elizaOS/eliza#8007:
+ * "v5 planner loops on `decision: CONTINUE` without advancing past the first
+ *  successful tool call."
+ *
+ * The reported repro was a multi-step orchestrator turn (TASKS
+ * provision_workspace → spawn_agent → submit_workspace) where the planner kept
+ * re-dispatching the first op (`provision_workspace`) on every CONTINUE turn —
+ * 8 successive `ACTION_STARTED actionName=TASKS op=provision_workspace` events —
+ * until the trajectory limit fired and Discord showed the 120s timeout.
+ *
+ * Two framework mechanisms now bound and unblock this loop; these tests pin
+ * both against the exact orchestrator shape from the issue:
+ *
+ *  1. Prior successful tool results ARE surfaced into the next planner turn's
+ *     messages (via `trajectoryStepsToMessages`), so a capable model can see
+ *     "provision already succeeded, now spawn" and advance.
+ *  2. When a weak model instead re-issues the IDENTICAL successful call, the
+ *     redundant-success loop-breaker executes it once, skips the repeats, and —
+ *     past `maxRepeatedToolCalls` — forces one terminal synthesis instead of
+ *     running the turn to the trajectory/token limit.
+ */
+describe("v5 planner #8007 — multi-step orchestrator advance", () => {
+	const REPO = "acme/hello-world";
+
+	it("advances through distinct sub-ops instead of restarting from the first", async () => {
+		const executed: string[] = [];
+		const seenMessages: unknown[][] = [];
+
+		const provision = {
+			id: "c1",
+			name: "TASKS",
+			arguments: { action: "provision_workspace", repo: REPO },
+		};
+		const spawn = {
+			id: "c2",
+			name: "TASKS",
+			arguments: { action: "spawn_agent", repo: REPO },
+		};
+		const submit = {
+			id: "c3",
+			name: "TASKS",
+			arguments: { action: "submit_workspace", repo: REPO },
+		};
+
+		const runtime = {
+			useModel: vi.fn(
+				async (_modelType: unknown, params: { messages: unknown[] }) => {
+					seenMessages.push(params.messages);
+					const turn = runtime.useModel.mock.calls.length;
+					if (turn === 1) return { text: "", toolCalls: [provision] };
+					if (turn === 2) return { text: "", toolCalls: [spawn] };
+					return { text: "", toolCalls: [submit] };
+				},
+			),
+			logger: { debug: vi.fn(), warn: vi.fn() },
+		};
+
+		const executeToolCall = vi.fn(
+			async (toolCall: { params?: { action?: string } }) => {
+				const op = toolCall.params?.action ?? "unknown";
+				executed.push(op);
+				return {
+					success: true,
+					text: `${op} completed for ${REPO}`,
+				};
+			},
+		);
+
+		// The evaluator advances the plan while ops remain, and finishes once the
+		// terminal op (submit_workspace) has completed.
+		const evaluate = vi.fn(async () => {
+			if (executed.includes("submit_workspace")) {
+				return {
+					success: true,
+					decision: "FINISH" as const,
+					messageToUser: "PR opened for hello-world.",
+				};
+			}
+			return {
+				success: true,
+				decision: "CONTINUE" as const,
+				thought: "Keep advancing the multi-step task.",
+			};
+		});
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			tools: [{ name: "TASKS", description: "Orchestrator task operations." }],
+			executeToolCall,
+			evaluate,
+		});
+
+		// The planner advanced through all three distinct ops in order — it did
+		// NOT re-dispatch provision_workspace on the second CONTINUE turn.
+		expect(executed).toEqual([
+			"provision_workspace",
+			"spawn_agent",
+			"submit_workspace",
+		]);
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toContain("PR opened");
+
+		// The prior successful step must be visible to the model on the next
+		// planner turn — this is the exact signal #8007 said was missing ("the
+		// LLM does not see 'you already provisioned a workspace, now spawn'").
+		const secondTurnMessages = JSON.stringify(seenMessages[1] ?? []);
+		expect(secondTurnMessages).toContain("provision_workspace completed");
+	});
+
+	it("bounds a weak model that re-issues the identical successful op (no 8x loop)", async () => {
+		// Exact #8007 repro: the planner keeps emitting the same
+		// TASKS provision_workspace call every CONTINUE turn. The redundant
+		// loop-breaker runs it once, skips the repeats, and forces a terminal
+		// synthesis — no TrajectoryLimitExceeded, no 120s Discord timeout.
+		const provision = {
+			id: "p1",
+			name: "TASKS",
+			arguments: { action: "provision_workspace", repo: REPO },
+		};
+
+		const runtime = {
+			useModel: vi
+				.fn()
+				.mockResolvedValueOnce({ text: "", toolCalls: [provision] })
+				.mockResolvedValueOnce({ text: "", toolCalls: [provision] })
+				.mockResolvedValueOnce({ text: "", toolCalls: [provision] })
+				.mockResolvedValueOnce(
+					'{"thought":"Workspace already provisioned.","messageToUser":"Workspace is ready.","toolCalls":[]}',
+				),
+			logger: { debug: vi.fn(), warn: vi.fn() },
+		};
+
+		const executeToolCall = vi.fn(async () => ({
+			success: true,
+			text: "workspace ws-1 provisioned",
+		}));
+
+		const evaluate = vi.fn(async () => ({
+			success: true,
+			decision: "CONTINUE" as const,
+			thought: "Not done yet.",
+		}));
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			tools: [{ name: "TASKS", description: "Orchestrator task operations." }],
+			config: { maxRepeatedToolCalls: 1 },
+			executeToolCall,
+			evaluate,
+		});
+
+		// Provision ran exactly once; the identical repeats were skipped, not
+		// re-executed 8x.
+		expect(executeToolCall).toHaveBeenCalledTimes(1);
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toContain("ready");
+	});
+});

--- a/packages/core/src/runtime/__tests__/planner-loop-8007-multistep.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-8007-multistep.test.ts
@@ -7,9 +7,9 @@ import { runPlannerLoop } from "../planner-loop";
  *  successful tool call."
  *
  * The reported repro was a multi-step orchestrator turn (TASKS
- * provision_workspace → spawn_agent → submit_workspace) where the planner kept
- * re-dispatching the first op (`provision_workspace`) on every CONTINUE turn —
- * 8 successive `ACTION_STARTED actionName=TASKS op=provision_workspace` events —
+ * provision_workspace -> spawn_agent -> submit_workspace) where the planner kept
+ * re-dispatching the first op (`provision_workspace`) on every CONTINUE turn,
+ * 8 successive `ACTION_STARTED actionName=TASKS op=provision_workspace` events,
  * until the trajectory limit fired and Discord showed the 120s timeout.
  *
  * Two framework mechanisms now bound and unblock this loop; these tests pin
@@ -19,11 +19,11 @@ import { runPlannerLoop } from "../planner-loop";
  *     messages (via `trajectoryStepsToMessages`), so a capable model can see
  *     "provision already succeeded, now spawn" and advance.
  *  2. When a weak model instead re-issues the IDENTICAL successful call, the
- *     redundant-success loop-breaker executes it once, skips the repeats, and —
- *     past `maxRepeatedToolCalls` — forces one terminal synthesis instead of
+ *     redundant-success loop-breaker executes it once, skips the repeats, and
+ *     past `maxRepeatedToolCalls` forces one terminal synthesis instead of
  *     running the turn to the trajectory/token limit.
  */
-describe("v5 planner #8007 — multi-step orchestrator advance", () => {
+describe("v5 planner #8007 - multi-step orchestrator advance", () => {
 	const REPO = "acme/hello-world";
 
 	it("advances through distinct sub-ops instead of restarting from the first", async () => {
@@ -95,7 +95,7 @@ describe("v5 planner #8007 — multi-step orchestrator advance", () => {
 			evaluate,
 		});
 
-		// The planner advanced through all three distinct ops in order — it did
+		// The planner advanced through all three distinct ops in order; it did
 		// NOT re-dispatch provision_workspace on the second CONTINUE turn.
 		expect(executed).toEqual([
 			"provision_workspace",
@@ -106,7 +106,7 @@ describe("v5 planner #8007 — multi-step orchestrator advance", () => {
 		expect(result.finalMessage).toContain("PR opened");
 
 		// The prior successful step must be visible to the model on the next
-		// planner turn — this is the exact signal #8007 said was missing ("the
+		// planner turn; this is the exact signal #8007 said was missing ("the
 		// LLM does not see 'you already provisioned a workspace, now spawn'").
 		const secondTurnMessages = JSON.stringify(seenMessages[1] ?? []);
 		expect(secondTurnMessages).toContain("provision_workspace completed");
@@ -116,7 +116,7 @@ describe("v5 planner #8007 — multi-step orchestrator advance", () => {
 		// Exact #8007 repro: the planner keeps emitting the same
 		// TASKS provision_workspace call every CONTINUE turn. The redundant
 		// loop-breaker runs it once, skips the repeats, and forces a terminal
-		// synthesis — no TrajectoryLimitExceeded, no 120s Discord timeout.
+		// synthesis: no TrajectoryLimitExceeded, no 120s Discord timeout.
 		const provision = {
 			id: "p1",
 			name: "TASKS",

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -5096,6 +5096,77 @@ function plannerToolCallHasActionParameter(toolCall: PlannerToolCall): boolean {
 	return false;
 }
 
+/**
+ * One entry per executed sub-planner step, projected for the parent loop. This
+ * is the structured record the outer planner's next turn reasons over so it can
+ * see which multi-step operations already succeeded and advance to the next one
+ * instead of re-dispatching the umbrella action from scratch (issue
+ * elizaOS/eliza#8007).
+ */
+interface SubPlannerSubStep {
+	action: string;
+	success: boolean;
+	summary?: string;
+	error?: string;
+}
+
+const SUB_STEP_SUMMARY_MAX_CHARS = 400;
+
+function truncateSubStepText(text: string): string {
+	const trimmed = text.trim();
+	if (trimmed.length <= SUB_STEP_SUMMARY_MAX_CHARS) return trimmed;
+	return `${trimmed.slice(0, SUB_STEP_SUMMARY_MAX_CHARS)}…`;
+}
+
+function collectSubPlannerSubSteps(
+	subResult: Awaited<ReturnType<typeof runSubPlanner>>,
+): SubPlannerSubStep[] {
+	const subSteps: SubPlannerSubStep[] = [];
+	for (const step of subResult.trajectory.steps) {
+		if (!step.toolCall?.name || !step.result) continue;
+		const result = step.result;
+		const errorText =
+			typeof result.error === "string"
+				? result.error
+				: result.error instanceof Error
+					? result.error.message
+					: undefined;
+		const summarySource =
+			typeof result.text === "string" && result.text.trim().length > 0
+				? result.text
+				: typeof result.userFacingText === "string"
+					? result.userFacingText
+					: undefined;
+		subSteps.push({
+			action: step.toolCall.name,
+			success: result.success,
+			...(summarySource ? { summary: truncateSubStepText(summarySource) } : {}),
+			...(errorText ? { error: truncateSubStepText(errorText) } : {}),
+		});
+	}
+	return subSteps;
+}
+
+/**
+ * Diagnostic, log-shaped projection of the full sub-planner trajectory. Renders
+ * every executed sub-step as `✓/✗ <action> — <summary/error>` so the parent
+ * planner's tool-result message carries the progression (e.g.
+ * `provision_workspace ✓, spawn_agent ✓, submit_workspace ✗`) instead of only
+ * the terminal step. Without this the outer LLM cannot tell that step 1 already
+ * succeeded and re-dispatches the umbrella action on every CONTINUE turn.
+ */
+function renderSubStepDiagnosticText(subSteps: SubPlannerSubStep[]): string {
+	return subSteps
+		.map((step) => {
+			const marker = step.success ? "✓" : "✗";
+			const detail = step.error ?? step.summary;
+			return detail
+				? `${marker} ${step.action} — ${detail}`
+				: `${marker} ${step.action}`;
+		})
+		.join("\n");
+}
+
 export function subPlannerResultToPlannerToolResult(
 	subResult: Awaited<ReturnType<typeof runSubPlanner>>,
 ): PlannerToolResult {
@@ -5104,11 +5175,36 @@ export function subPlannerResultToPlannerToolResult(
 		subResult.trajectory.steps[subResult.trajectory.steps.length - 1];
 	const success = evaluator?.success ?? lastStep?.result?.success ?? true;
 	const userFacingText = subResult.finalMessage ?? evaluator?.messageToUser;
+
+	// Aggregate EVERY executed sub-step — not just the terminal one — so the
+	// parent planner's next turn can see which operations already succeeded and
+	// advance to the next op instead of re-running the umbrella action from the
+	// first step (issue elizaOS/eliza#8007). The per-step progression flows to
+	// the outer LLM through `text` (the diagnostic tool-result projection) and
+	// to downstream action context through `data.subSteps` /
+	// `data.completedSubActions`.
+	const subSteps = collectSubPlannerSubSteps(subResult);
+	const diagnosticText = renderSubStepDiagnosticText(subSteps);
+	const completedSubActions = subSteps
+		.filter((step) => step.success)
+		.map((step) => step.action);
+
 	return {
 		success,
-		text: userFacingText,
+		// Diagnostic channel: the whole progression, so CONTINUE re-planning
+		// sees the completed steps. Falls back to the user-facing text when the
+		// sub-planner executed no discrete steps.
+		text: diagnosticText.length > 0 ? diagnosticText : userFacingText,
 		userFacingText,
-		data: lastStep?.result?.data,
+		data: {
+			...(lastStep?.result?.data ?? {}),
+			...(subSteps.length > 0
+				? {
+						subSteps,
+						completedSubActions,
+					}
+				: {}),
+		},
 		error: lastStep?.result?.error,
 		// Propagate the terminal sub-action's chain signal to the parent
 		// loop. A sub-action that returns `continueChain: false` (e.g.

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -5115,7 +5115,7 @@ const SUB_STEP_SUMMARY_MAX_CHARS = 400;
 function truncateSubStepText(text: string): string {
 	const trimmed = text.trim();
 	if (trimmed.length <= SUB_STEP_SUMMARY_MAX_CHARS) return trimmed;
-	return `${trimmed.slice(0, SUB_STEP_SUMMARY_MAX_CHARS)}…`;
+	return `${trimmed.slice(0, SUB_STEP_SUMMARY_MAX_CHARS)}...`;
 }
 
 function collectSubPlannerSubSteps(
@@ -5149,19 +5149,20 @@ function collectSubPlannerSubSteps(
 
 /**
  * Diagnostic, log-shaped projection of the full sub-planner trajectory. Renders
- * every executed sub-step as `✓/✗ <action> — <summary/error>` so the parent
+ * every executed sub-step as `OK/FAIL <action>: <summary/error>` so the parent
  * planner's tool-result message carries the progression (e.g.
- * `provision_workspace ✓, spawn_agent ✓, submit_workspace ✗`) instead of only
- * the terminal step. Without this the outer LLM cannot tell that step 1 already
- * succeeded and re-dispatches the umbrella action on every CONTINUE turn.
+ * `OK provision_workspace, OK spawn_agent, FAIL submit_workspace`) instead of
+ * only the terminal step. Without this the outer LLM cannot tell that step 1
+ * already succeeded and re-dispatches the umbrella action on every CONTINUE
+ * turn.
  */
 function renderSubStepDiagnosticText(subSteps: SubPlannerSubStep[]): string {
 	return subSteps
 		.map((step) => {
-			const marker = step.success ? "✓" : "✗";
+			const marker = step.success ? "OK" : "FAIL";
 			const detail = step.error ?? step.summary;
 			return detail
-				? `${marker} ${step.action} — ${detail}`
+				? `${marker} ${step.action}: ${detail}`
 				: `${marker} ${step.action}`;
 		})
 		.join("\n");
@@ -5176,7 +5177,7 @@ export function subPlannerResultToPlannerToolResult(
 	const success = evaluator?.success ?? lastStep?.result?.success ?? true;
 	const userFacingText = subResult.finalMessage ?? evaluator?.messageToUser;
 
-	// Aggregate EVERY executed sub-step — not just the terminal one — so the
+	// Aggregate every executed sub-step, not just the terminal one, so the
 	// parent planner's next turn can see which operations already succeeded and
 	// advance to the next op instead of re-running the umbrella action from the
 	// first step (issue elizaOS/eliza#8007). The per-step progression flows to
@@ -5188,6 +5189,19 @@ export function subPlannerResultToPlannerToolResult(
 	const completedSubActions = subSteps
 		.filter((step) => step.success)
 		.map((step) => step.action);
+	const terminalData = lastStep?.result?.data;
+	const data =
+		terminalData || subSteps.length > 0
+			? {
+					...(terminalData ?? {}),
+					...(subSteps.length > 0
+						? {
+								subSteps,
+								completedSubActions,
+							}
+						: {}),
+				}
+			: undefined;
 
 	return {
 		success,
@@ -5196,21 +5210,13 @@ export function subPlannerResultToPlannerToolResult(
 		// sub-planner executed no discrete steps.
 		text: diagnosticText.length > 0 ? diagnosticText : userFacingText,
 		userFacingText,
-		data: {
-			...(lastStep?.result?.data ?? {}),
-			...(subSteps.length > 0
-				? {
-						subSteps,
-						completedSubActions,
-					}
-				: {}),
-		},
+		data,
 		error: lastStep?.result?.error,
 		// Propagate the terminal sub-action's chain signal to the parent
 		// loop. A sub-action that returns `continueChain: false` (e.g.
-		// TASKS_SPAWN_AGENT — fire-and-forget) terminates the sub-planner,
+		// TASKS_SPAWN_AGENT, fire-and-forget) terminates the sub-planner,
 		// but without this the parent planner loop never sees the flag,
-		// evaluates CONTINUE, and re-runs the umbrella action — producing
+		// evaluates CONTINUE, and re-runs the umbrella action, producing
 		// duplicate spawns on a single user turn.
 		continueChain: lastStep?.result?.continueChain,
 	};


### PR DESCRIPTION
## What & why

Fixes the sub-planner half of #8007 — *"v5 planner loops on `decision: CONTINUE` without advancing past the first successful tool call."*

When a **multi-step sub-planner (umbrella) action** runs — e.g. `TASKS` `provision_workspace → spawn_agent → submit_workspace` — `subPlannerResultToPlannerToolResult` collapsed the entire sub-trajectory down to **only the terminal step's `data`** plus the synthesized user-facing message. The parent planner's next turn therefore never saw that step 1 already succeeded, so on `decision: CONTINUE` it re-dispatched the umbrella action and the sub-planner re-ran from `provision_workspace` — exactly the loop in #8007 (8× `ACTION_STARTED provision_workspace`, then the 120s Discord timeout fallback).

## The fix (`packages/core/src/services/message.ts`)

Aggregate **every** executed sub-step into the collapsed result:

- **`text`** (the diagnostic tool-result projection the parent planner reasons over) now renders the full progression:
  ```
  ✓ provision_workspace — workspace ws-1 ready
  ✓ spawn_agent — spawned agent a-1
  ✗ submit_workspace — no diff to submit
  ```
- **`data.subSteps` / `data.completedSubActions`** carry the same progression structurally for downstream action context.
- **`userFacingText`** is unchanged (still the synthesized final message shown to the user).

## Scope note — the two halves of #8007

| Path | Status |
|------|--------|
| **Sub-planner umbrella** (`subActions`) collapse dropping intermediate successes | **Fixed here** |
| **Dispatcher** outer planner re-picking the same `TASKS` subaction | Already bounded on `develop` — the redundant-success loop-breaker (`maxRepeatedToolCalls` + `partitionRedundantSucceededCalls`, `planner-loop.ts:548-573`) executes an identical successful call once, skips the repeats, and forces one terminal synthesis; prior steps are made visible by the v6 tool-message rendering (`trajectoryStepsToMessages`, `planner-rendering.ts:107`). Both landed **2026-06-21**, ~a month *after* the issue was filed (2026-05-26), which is why the issue had no linked fix. |

## Evidence (deterministic)

New regression tests pin all three mechanisms against the exact orchestrator repro:

- `packages/core/src/runtime/__tests__/planner-loop-8007-multistep.test.ts`
  - **advances through distinct sub-ops** (`provision → spawn → submit`) instead of restarting from the first, and asserts the prior success is present in the next turn's messages.
  - **bounds a weak model** that re-issues the identical successful op — provision runs exactly once, no `TrajectoryLimitExceeded`, no 120s timeout.
- `packages/core/src/__tests__/message-action-dedupe.test.ts` — sub-step aggregation into `text` + `data`.

```
$ bun run --cwd packages/core test -- planner-loop sub-planner message-action-dedupe
 Test Files  8 passed
      Tests  95 passed
```
typecheck (tsgo) clean · biome clean.

Real-LLM trajectory: N/A for this deterministic collapse/rendering change — the trigger is a structured multi-step trajectory shape, unit-deterministic without a live sub-agent-spawning stack. The live cerebras+opencode weak-model trajectory is tracked as the sibling acceptance bar in #8875 (finishReason relay, already merged in #9047).

Relates to #8007 (closed by #10828, which added the dispatcher-path regression but **no production change**). This PR fixes a **distinct, still-live seam** on `develop`: the sub-planner umbrella collapse — verify with `git show origin/develop:packages/core/src/services/message.ts` still showing `data: lastStep?.result?.data`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
