### PR TITLE
feat(app/desktop): native tray/menu view-opening + programmable global hotkey floating chat (#10716)

### DIFF
--- a/.github/issue-evidence/10716-desktop-native-tray-hotkey/README.md
+++ b/.github/issue-evidence/10716-desktop-native-tray-hotkey/README.md
@@ -1,0 +1,49 @@
+# Evidence — #10716 native tray/menu view-opening + programmable global hotkey floating chat
+
+Branch: `feat/10716-desktop-native-tray-hotkey`
+
+## What shipped
+
+| Acceptance criterion | Implementation | Proof |
+| --- | --- | --- |
+| Tray opens a view in its **own window** (chat + ≥2 non-default views) | `tray-menu.ts` generates a "Views" section from the shared internal-tool-app catalog (`getInternalToolAppDescriptors`); `DesktopTrayRuntime` opens each `tray-app-<slug>` via `openDesktopAppWindow` | `tray-menu.test.ts` (8) |
+| Menu bar **"Views"** submenu opens each view in its own window | `application-menu.ts` — `buildViewsMenu()` (renamed from Apps) → `apps:<slug>` → existing `handleAppEntryMenuAction` own-window open | `application-menu.test.ts` (8, NEW suite the issue asked for) |
+| Programmable global hotkey **fronts chat** even when backgrounded | `main.tsx` registers `summon-chat` (user accelerator ← `localStorage`, per-platform default) → on press `Desktop.showWindow()+focusWindow()` | `desktop-hotkey.test.ts` (31) |
+| Default hotkey no longer collides with the command palette | Default is `⌘⇧Space` / `Ctrl+Shift+Space`, asserted `!== CommandOrControl+K` | `desktop-hotkey.test.ts` |
+| Tray-icon click summons/fronts chat identically to the hotkey | `native/desktop.ts` `trayClickHandler` now `showWindow().then(focusWindow())` | code + review |
+| Floating chat is the reused `chat-overlay` (no parallel renderer) | Summon show+focuses the existing bottom-bar/`ChatOverlayShell` window; no new window class | code (non-goal respected) |
+| Programmable hotkey exposed in **Desktop settings** | `DesktopChatHotkeySetting` (record keystroke → validate safe-global → persist → re-register) rendered in `DesktopWorkspaceSection` | `DesktopChatHotkeySetting.test.tsx` (5) |
+| `application-menu` / tray / `surface-windows` suites pass, extended with new tests | 52 new assertions across 3 packages | `unit-tests.log` |
+
+## Tests — 52 new assertions, all green (`unit-tests.log`)
+
+- `@elizaos/ui` `desktop-hotkey.test.ts` — 31 (accelerator normalize/validate, safe-global gate, per-platform default, keystroke capture, display formatting, localStorage load/save, resolve).
+- `@elizaos/ui` `DesktopChatHotkeySetting.test.tsx` — 5 (render, record+persist, reject unsafe, Escape cancel, reset-to-default).
+- `@elizaos/electrobun` `application-menu.test.ts` — 8 (NEW; Views submenu, Summon Chat click path w/o local accelerator, agent-ready gating, browser gating, entry resolution).
+- `@elizaos/app-core` `tray-menu.test.ts` — 8 (Views section generated from the launcher catalog, ordering, slug↔descriptor round-trip, splice position, quit-last).
+
+Typecheck: clean for every changed file across `@elizaos/ui`, `@elizaos/app-core`,
+`@elizaos/electrobun`, and `@elizaos/app` (`tsgo --noEmit`; the only worktree
+errors are pre-existing generated-i18n stubs unrelated to this change).
+
+## Real-LLM trajectory
+
+**N/A** — desktop-shell window/hotkey wiring; no model/prompt/action path (per the
+issue's own evidence section).
+
+## Live native-shell capture (hotkey-when-backgrounded, cursor-screenshot)
+
+**Deferred to a human on a built desktop app.** The summon-when-backgrounded flow
+requires a global OS key event delivered to a running Electrobun build and an
+OS-level screenshot — it cannot be driven from a headless/agent environment. To
+capture from a freshly built desktop app (`reference_desktop_prod_build_launch`):
+
+1. Build + launch the desktop app; open **Settings → Desktop Workspace**, set a
+   custom "Summon chat hotkey" (e.g. `⌘⇧J`).
+2. Background the app (focus another app), press the accelerator → the floating
+   chat fronts. Capture `GET /api/dev/cursor-screenshot` before/after and
+   `GET /api/dev/console-log` showing `desktopShortcutPressed { id: "summon-chat" }`.
+3. Open the tray menu → click a "Views" entry → the view opens in its own window
+   (`[main-window]` / `[DesktopManager]` logs).
+
+The code paths these exercise are each covered by the unit suites above.

--- a/packages/app-core/platforms/electrobun/src/application-menu.test.ts
+++ b/packages/app-core/platforms/electrobun/src/application-menu.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildApplicationMenu,
+  findAppMenuEntryBySlug,
+  getAppMenuEntries,
+  parseSettingsWindowAction,
+} from "./application-menu";
+
+function build(overrides?: {
+  isMac?: boolean;
+  browserEnabled?: boolean;
+  agentReady?: boolean;
+}) {
+  return buildApplicationMenu({
+    isMac: overrides?.isMac ?? true,
+    browserEnabled: overrides?.browserEnabled ?? false,
+    detachedWindows: [],
+    agentReady: overrides?.agentReady ?? true,
+  });
+}
+
+function findMenu(menus: ReturnType<typeof build>, label: string) {
+  return menus.find((m) => m.label === label);
+}
+
+function collectActions(item: {
+  action?: string;
+  submenu?: Array<{ action?: string; submenu?: unknown }>;
+}): string[] {
+  const actions: string[] = [];
+  if (item.action) actions.push(item.action);
+  for (const child of item.submenu ?? []) {
+    actions.push(...collectActions(child));
+  }
+  return actions;
+}
+
+describe("buildApplicationMenu structure", () => {
+  it("includes the expected top-level menus", () => {
+    const menu = build();
+    const labels = menu.map((m) => m.label);
+    expect(labels).toEqual(
+      expect.arrayContaining(["File", "Edit", "View", "Desktop", "Views", "Window"]),
+    );
+  });
+
+  it("exposes a Views submenu with one entry per internal tool view", () => {
+    const views = findMenu(build(), "Views");
+    expect(views).toBeDefined();
+    const entries = getAppMenuEntries();
+    expect(views?.submenu).toHaveLength(entries.length);
+    for (const entry of entries) {
+      const item = views?.submenu?.find(
+        (i) => i.action === `apps:${entry.slug}`,
+      );
+      expect(item, `menu item for ${entry.slug}`).toBeDefined();
+      expect(item?.label).toBe(entry.displayName);
+    }
+  });
+
+  it("routes every Views entry through the apps: handler (own-window open)", () => {
+    const views = findMenu(build(), "Views");
+    for (const item of views?.submenu ?? []) {
+      expect(item.action?.startsWith("apps:")).toBe(true);
+    }
+  });
+
+  it("adds a Summon Chat click path in the Desktop menu with no local accelerator", () => {
+    const desktop = findMenu(build(), "Desktop");
+    const summon = desktop?.submenu?.find((i) => i.action === "summon-chat");
+    expect(summon).toBeDefined();
+    expect(summon?.label).toBe("Summon Chat");
+    // The chat hotkey is a GLOBAL shortcut (works when backgrounded); binding a
+    // local menu accelerator here would double-register it.
+    expect(summon?.accelerator).toBeUndefined();
+  });
+
+  it("does not surface detached-window (new-window) actions until the agent is ready", () => {
+    const notReady = build({ agentReady: false });
+    const windowMenu = findMenu(notReady, "Window");
+    const actions = collectActions(windowMenu ?? {});
+    expect(actions.some((a) => a.startsWith("new-window:"))).toBe(false);
+
+    const ready = build({ agentReady: true });
+    const readyActions = collectActions(findMenu(ready, "Window") ?? {});
+    expect(readyActions).toContain("new-window:chat");
+  });
+
+  it("hides the browser window entry unless the browser is enabled", () => {
+    const noBrowser = collectActions(findMenu(build(), "Window") ?? {});
+    expect(noBrowser).not.toContain("new-window:browser");
+    const withBrowser = collectActions(
+      findMenu(build({ browserEnabled: true }), "Window") ?? {},
+    );
+    expect(withBrowser).toContain("new-window:browser");
+  });
+});
+
+describe("app menu entry resolution", () => {
+  it("resolves entries by slug and rejects unknown slugs", () => {
+    const entries = getAppMenuEntries();
+    expect(entries.length).toBeGreaterThan(0);
+    for (const entry of entries) {
+      expect(findAppMenuEntryBySlug(entry.slug)).toEqual(entry);
+      expect(entry.windowPath.startsWith("/apps/")).toBe(true);
+    }
+    expect(findAppMenuEntryBySlug("does-not-exist")).toBeUndefined();
+  });
+});
+
+describe("parseSettingsWindowAction", () => {
+  it("extracts the settings tab hint or undefined", () => {
+    expect(parseSettingsWindowAction("open-settings")).toBeUndefined();
+    expect(parseSettingsWindowAction("open-settings-desktop")).toBe("desktop");
+    expect(parseSettingsWindowAction("open-settings-voice")).toBe("voice");
+    expect(parseSettingsWindowAction("summon-chat")).toBeUndefined();
+    expect(parseSettingsWindowAction(undefined)).toBeUndefined();
+  });
+});

--- a/packages/app-core/platforms/electrobun/src/application-menu.test.ts
+++ b/packages/app-core/platforms/electrobun/src/application-menu.test.ts
@@ -23,10 +23,9 @@ function findMenu(menus: ReturnType<typeof build>, label: string) {
   return menus.find((m) => m.label === label);
 }
 
-function collectActions(item: {
-  action?: string;
-  submenu?: Array<{ action?: string; submenu?: unknown }>;
-}): string[] {
+type MenuNode = { action?: string; submenu?: MenuNode[] };
+
+function collectActions(item: MenuNode): string[] {
   const actions: string[] = [];
   if (item.action) actions.push(item.action);
   for (const child of item.submenu ?? []) {
@@ -40,7 +39,14 @@ describe("buildApplicationMenu structure", () => {
     const menu = build();
     const labels = menu.map((m) => m.label);
     expect(labels).toEqual(
-      expect.arrayContaining(["File", "Edit", "View", "Desktop", "Views", "Window"]),
+      expect.arrayContaining([
+        "File",
+        "Edit",
+        "View",
+        "Desktop",
+        "Views",
+        "Window",
+      ]),
     );
   });
 

--- a/packages/app-core/platforms/electrobun/src/application-menu.ts
+++ b/packages/app-core/platforms/electrobun/src/application-menu.ts
@@ -173,9 +173,15 @@ export function parseSettingsWindowAction(
   return tabHint || undefined;
 }
 
-function buildAppsMenu(): ApplicationMenuItem {
+/**
+ * "Views" submenu — opens each internal tool view directly in its own window
+ * from the menu bar, without going through the in-app launcher (#10716). Each
+ * `apps:<slug>` action is handled in `index.ts` (`handleAppEntryMenuAction`),
+ * which opens the app window (or the details page for configurable views).
+ */
+function buildViewsMenu(): ApplicationMenuItem {
   return {
-    label: "Apps",
+    label: "Views",
     submenu: APP_MENU_ENTRIES.map((entry) => ({
       label: entry.displayName,
       action: `apps:${entry.slug}`,
@@ -188,6 +194,11 @@ function buildDesktopMenu(isMac: boolean): ApplicationMenuItem {
   return {
     label: "Desktop",
     submenu: [
+      // Click path for the programmable global chat hotkey (#10716); the
+      // accelerator itself is registered globally (works when backgrounded) and
+      // configured in Desktop settings, so no local accelerator is bound here.
+      { label: "Summon Chat", action: "summon-chat" },
+      { type: "separator" },
       { label: "Desktop Workspace", action: "open-settings-desktop" },
       { label: "Voice Controls", action: "open-settings-voice" },
       { label: "Permissions", action: "open-settings-permissions" },
@@ -335,7 +346,7 @@ export function buildApplicationMenu({
       ],
     },
     buildDesktopMenu(isMac),
-    buildAppsMenu(),
+    buildViewsMenu(),
     {
       label: "Window",
       submenu: [

--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -1946,6 +1946,17 @@ async function setupUpdater(): Promise<void> {
         void getDesktopManager().showWindow();
         return true;
       }
+      if (action === "summon-chat") {
+        // "Summon Chat" menu/tray click path (#10716): restore (create if the
+        // app is tray-first), show, and focus the chat surface — same outcome
+        // as the programmable global hotkey, which the renderer summons.
+        void (async () => {
+          await restoreWindow();
+          await getDesktopManager().showWindow();
+          await getDesktopManager().focusWindow();
+        })();
+        return true;
+      }
       return false;
     };
 

--- a/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
@@ -492,6 +492,47 @@ describe("DesktopManager main window controls", () => {
     expect(electrobunMock.Utils.quit).not.toHaveBeenCalled();
   });
 
+  it("does not track global shortcuts rejected by the OS", async () => {
+    electrobunMock.GlobalShortcut.register.mockReturnValueOnce(false);
+    const manager = new DesktopManager();
+
+    const result = await manager.registerShortcut({
+      id: "summon-chat",
+      accelerator: "CommandOrControl+Shift+Space",
+    });
+    await manager.unregisterShortcut({ id: "summon-chat" });
+
+    expect(result).toEqual({ success: false });
+    expect(electrobunMock.GlobalShortcut.register).toHaveBeenCalledWith(
+      "CommandOrControl+Shift+Space",
+      expect.any(Function),
+    );
+    expect(electrobunMock.GlobalShortcut.unregister).not.toHaveBeenCalled();
+  });
+
+  it("tracks successfully registered global shortcuts for replacement and unregister", async () => {
+    const manager = new DesktopManager();
+
+    await manager.registerShortcut({
+      id: "summon-chat",
+      accelerator: "CommandOrControl+Shift+Space",
+    });
+    await manager.registerShortcut({
+      id: "summon-chat",
+      accelerator: "CommandOrControl+J",
+    });
+    await manager.unregisterShortcut({ id: "summon-chat" });
+
+    expect(electrobunMock.GlobalShortcut.unregister).toHaveBeenNthCalledWith(
+      1,
+      "CommandOrControl+Shift+Space",
+    );
+    expect(electrobunMock.GlobalShortcut.unregister).toHaveBeenNthCalledWith(
+      2,
+      "CommandOrControl+J",
+    );
+  });
+
   it("opens tray popover as an app renderer with preload, rpc, partition, and API injection", async () => {
     const manager = new DesktopManager();
     const rpc = { request: {}, send: {}, setTransport: vi.fn() };

--- a/packages/app-core/platforms/electrobun/src/native/desktop.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop.ts
@@ -841,12 +841,15 @@ export class DesktopManager {
     }
 
     try {
-      GlobalShortcut.register(options.accelerator, () => {
+      const registered = GlobalShortcut.register(options.accelerator, () => {
         this.send("desktopShortcutPressed", {
           id: options.id,
           accelerator: options.accelerator,
         });
       });
+      if (registered === false) {
+        return { success: false };
+      }
       this.shortcuts.set(options.id, options);
       return { success: true };
     } catch {

--- a/packages/app-core/platforms/electrobun/src/native/desktop.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop.ts
@@ -713,11 +713,15 @@ export class DesktopManager {
           );
         });
       } else {
-        void this.showWindow().catch((err: unknown) => {
-          logger.warn(
-            `[Desktop] Failed to show window from tray click: ${err instanceof Error ? err.message : String(err)}`,
-          );
-        });
+        // Click-to-summon (#10716): show AND focus so a tray-icon click fronts
+        // the floating chat identically to the programmable global hotkey.
+        void this.showWindow()
+          .then(() => this.focusWindow())
+          .catch((err: unknown) => {
+            logger.warn(
+              `[Desktop] Failed to summon window from tray click: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          });
       }
       this.send("desktopTrayClick", {
         x: 0,

--- a/packages/app-core/src/runtime/desktop/DesktopTrayRuntime.tsx
+++ b/packages/app-core/src/runtime/desktop/DesktopTrayRuntime.tsx
@@ -1,13 +1,17 @@
 import {
   getElectrobunRendererRpc,
   invokeDesktopBridgeRequest,
+  openDesktopAppWindow,
   subscribeDesktopBridgeEvent,
 } from "@elizaos/ui/bridge/electrobun-rpc";
 import { isElectrobunRuntime } from "@elizaos/ui/bridge/electrobun-runtime";
+import { getInternalToolAppDescriptors } from "@elizaos/ui/components/apps/internal-tool-apps";
 import { TRAY_ACTION_EVENT } from "@elizaos/ui/events";
 import { useApp } from "@elizaos/ui/state/useApp";
 import { openDesktopSettingsWindow } from "@elizaos/ui/utils/desktop-workspace";
 import { useEffect } from "react";
+
+import { desktopTrayAppSlug, TRAY_APP_ITEM_PREFIX } from "./tray-menu";
 
 interface TrayActionDetail {
   itemId?: string;
@@ -179,8 +183,26 @@ export function DesktopTrayRuntime() {
               ipcChannel: "desktop:quit",
             });
             return;
-          default:
+          default: {
+            // Tray "Views" items open the tool view in its own window (#10716),
+            // resolving the descriptor from the same catalog the tray menu was
+            // built from.
+            if (itemId.startsWith(TRAY_APP_ITEM_PREFIX)) {
+              const slug = itemId.slice(TRAY_APP_ITEM_PREFIX.length);
+              const descriptor = getInternalToolAppDescriptors().find(
+                (candidate) => desktopTrayAppSlug(candidate.name) === slug,
+              );
+              if (descriptor?.windowPath) {
+                await openDesktopAppWindow({
+                  slug,
+                  title: descriptor.displayName,
+                  path: descriptor.windowPath,
+                  alwaysOnTop: false,
+                });
+              }
+            }
             return;
+          }
         }
       };
 

--- a/packages/app-core/src/runtime/desktop/tray-menu.test.ts
+++ b/packages/app-core/src/runtime/desktop/tray-menu.test.ts
@@ -1,0 +1,87 @@
+import { getInternalToolAppDescriptors } from "@elizaos/ui/components/apps/internal-tool-apps";
+import { describe, expect, it } from "vitest";
+import {
+  buildDesktopTrayViewItems,
+  buildLocalizedTrayMenu,
+  desktopTrayAppSlug,
+  DESKTOP_TRAY_MENU_ITEMS,
+  TRAY_APP_ITEM_PREFIX,
+} from "./tray-menu";
+
+const identity = (key: string, vars?: { defaultValue?: string }): string =>
+  vars?.defaultValue ?? key;
+
+describe("desktopTrayAppSlug", () => {
+  it("strips the @elizaos/ scope", () => {
+    expect(desktopTrayAppSlug("@elizaos/app-plugin-viewer")).toBe(
+      "app-plugin-viewer",
+    );
+    expect(desktopTrayAppSlug("plain")).toBe("plain");
+  });
+});
+
+describe("buildDesktopTrayViewItems", () => {
+  it("mirrors the internal tool-app catalog (one item per view with a window path)", () => {
+    const descriptors = getInternalToolAppDescriptors().filter(
+      (d) => d.windowPath !== null,
+    );
+    const items = buildDesktopTrayViewItems();
+    expect(items).toHaveLength(descriptors.length);
+    expect(items.length).toBeGreaterThan(0);
+    for (const item of items) {
+      expect(item.id.startsWith(TRAY_APP_ITEM_PREFIX)).toBe(true);
+      expect(typeof item.label).toBe("string");
+      expect(item.label?.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("orders items by catalog order", () => {
+    const items = buildDesktopTrayViewItems();
+    const expected = [...getInternalToolAppDescriptors()]
+      .filter((d) => d.windowPath !== null)
+      .sort((a, b) => a.order - b.order)
+      .map((d) => `${TRAY_APP_ITEM_PREFIX}${desktopTrayAppSlug(d.name)}`);
+    expect(items.map((i) => i.id)).toEqual(expected);
+  });
+
+  it("produces slugs the renderer can resolve back to a descriptor", () => {
+    const bySlug = new Map(
+      getInternalToolAppDescriptors().map((d) => [desktopTrayAppSlug(d.name), d]),
+    );
+    for (const item of buildDesktopTrayViewItems()) {
+      const slug = item.id.slice(TRAY_APP_ITEM_PREFIX.length);
+      expect(bySlug.has(slug)).toBe(true);
+    }
+  });
+});
+
+describe("buildLocalizedTrayMenu", () => {
+  it("splices the Views section immediately after Open Voice Controls", () => {
+    const menu = buildLocalizedTrayMenu(identity);
+    const voiceIdx = menu.findIndex((i) => i.id === "tray-open-voice-controls");
+    expect(voiceIdx).toBeGreaterThanOrEqual(0);
+    expect(menu[voiceIdx + 1]?.id).toBe("tray-sep-views");
+    expect(menu[voiceIdx + 2]?.id.startsWith(TRAY_APP_ITEM_PREFIX)).toBe(true);
+  });
+
+  it("keeps every fixed item and appends only the Views section", () => {
+    const menu = buildLocalizedTrayMenu(identity);
+    for (const fixed of DESKTOP_TRAY_MENU_ITEMS) {
+      expect(menu.some((i) => i.id === fixed.id)).toBe(true);
+    }
+    const views = buildDesktopTrayViewItems();
+    expect(menu.length).toBe(DESKTOP_TRAY_MENU_ITEMS.length + views.length + 1);
+  });
+
+  it("still ends with the quit item after the views section", () => {
+    const menu = buildLocalizedTrayMenu(identity);
+    expect(menu[menu.length - 1]?.id).toBe("quit");
+  });
+
+  it("resolves labels through the translator", () => {
+    const menu = buildLocalizedTrayMenu((key, vars) =>
+      key === "desktop.tray.openChat" ? "CHAT!" : (vars?.defaultValue ?? key),
+    );
+    expect(menu.find((i) => i.id === "tray-open-chat")?.label).toBe("CHAT!");
+  });
+});

--- a/packages/app-core/src/runtime/desktop/tray-menu.test.ts
+++ b/packages/app-core/src/runtime/desktop/tray-menu.test.ts
@@ -3,8 +3,8 @@ import { describe, expect, it } from "vitest";
 import {
   buildDesktopTrayViewItems,
   buildLocalizedTrayMenu,
-  desktopTrayAppSlug,
   DESKTOP_TRAY_MENU_ITEMS,
+  desktopTrayAppSlug,
   TRAY_APP_ITEM_PREFIX,
 } from "./tray-menu";
 
@@ -46,7 +46,10 @@ describe("buildDesktopTrayViewItems", () => {
 
   it("produces slugs the renderer can resolve back to a descriptor", () => {
     const bySlug = new Map(
-      getInternalToolAppDescriptors().map((d) => [desktopTrayAppSlug(d.name), d]),
+      getInternalToolAppDescriptors().map((d) => [
+        desktopTrayAppSlug(d.name),
+        d,
+      ]),
     );
     for (const item of buildDesktopTrayViewItems()) {
       const slug = item.id.slice(TRAY_APP_ITEM_PREFIX.length);

--- a/packages/app-core/src/runtime/desktop/tray-menu.ts
+++ b/packages/app-core/src/runtime/desktop/tray-menu.ts
@@ -1,3 +1,4 @@
+import { getInternalToolAppDescriptors } from "@elizaos/ui/components/apps/internal-tool-apps";
 import type { DesktopClickAuditItem } from "@elizaos/ui/utils/desktop-workspace";
 
 interface DesktopTrayMenuItem {
@@ -6,6 +7,36 @@ interface DesktopTrayMenuItem {
   /** i18n key for {@link label}; resolved at menu-build time. */
   labelKey?: string;
   type?: "normal" | "separator";
+}
+
+/**
+ * Prefix for tray items that open an internal tool view in its own desktop
+ * window (#10716). The renderer's `DesktopTrayRuntime` matches this prefix,
+ * resolves the descriptor by slug, and opens the view window via the same
+ * `eliza:navigate:view` bus the launcher uses — so the tray view list stays in
+ * lockstep with the launcher catalog instead of duplicating a static list.
+ */
+export const TRAY_APP_ITEM_PREFIX = "tray-app-";
+
+/** Stable tray-item slug for an internal tool app name (`@elizaos/x` → `x`). */
+export function desktopTrayAppSlug(name: string): string {
+  return name.replace(/^@elizaos\//, "");
+}
+
+/**
+ * Tray "Views" items generated from the shared internal-tool-app catalog
+ * (`getInternalToolAppDescriptors`), ordered by catalog `order`. Each opens the
+ * view in its own window. Returned separately so callers can splice a
+ * separator around the section.
+ */
+export function buildDesktopTrayViewItems(): DesktopTrayMenuItem[] {
+  return [...getInternalToolAppDescriptors()]
+    .filter((descriptor) => descriptor.windowPath !== null)
+    .sort((a, b) => a.order - b.order)
+    .map((descriptor) => ({
+      id: `${TRAY_APP_ITEM_PREFIX}${desktopTrayAppSlug(descriptor.name)}`,
+      label: descriptor.displayName,
+    }));
 }
 
 export const DESKTOP_TRAY_MENU_ITEMS: readonly DesktopTrayMenuItem[] = [
@@ -62,17 +93,33 @@ export const DESKTOP_TRAY_MENU_ITEMS: readonly DesktopTrayMenuItem[] = [
 
 /**
  * Build the tray menu with labels translated by `t`. Separators and any item
- * without a `labelKey` pass through unchanged. The native tray is rebuilt from
- * this at desktop boot, so it reflects the resolved UI language.
+ * without a `labelKey` pass through unchanged. A generated "Views" section
+ * (one item per internal tool view, each opening its own window — #10716) is
+ * spliced in after the fixed open-surface items. The native tray is rebuilt
+ * from this at desktop boot, so it reflects the resolved UI language.
  */
 export function buildLocalizedTrayMenu(
   t: (key: string, vars?: { defaultValue?: string }) => string,
 ): DesktopTrayMenuItem[] {
-  return DESKTOP_TRAY_MENU_ITEMS.map((item) =>
+  const localize = (item: DesktopTrayMenuItem): DesktopTrayMenuItem =>
     item.labelKey
       ? { ...item, label: t(item.labelKey, { defaultValue: item.label }) }
-      : { ...item },
-  );
+      : { ...item };
+
+  const viewItems = buildDesktopTrayViewItems();
+  const viewsSection: DesktopTrayMenuItem[] =
+    viewItems.length > 0
+      ? [{ id: "tray-sep-views", type: "separator" }, ...viewItems]
+      : [];
+
+  const result: DesktopTrayMenuItem[] = [];
+  for (const item of DESKTOP_TRAY_MENU_ITEMS) {
+    result.push(localize(item));
+    if (item.id === "tray-open-voice-controls") {
+      result.push(...viewsSection);
+    }
+  }
+  return result;
 }
 
 export const DESKTOP_TRAY_CLICK_AUDIT: readonly DesktopClickAuditItem[] = [

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -123,6 +123,11 @@ import {
   measureStartup,
 } from "@elizaos/ui/state/startup-telemetry";
 import { ELIZA_DEFAULT_THEME } from "@elizaos/ui/themes";
+import {
+  loadDesktopHotkeySettings,
+  resolveChatSummonAccelerator,
+  SUMMON_CHAT_SHORTCUT_ID,
+} from "@elizaos/ui/utils/desktop-hotkey";
 // biome-ignore lint/correctness/noUnusedImports: classic JSX output in this app bundle expects React in module scope.
 import * as React from "react";
 import { type ComponentType, lazy, StrictMode, Suspense } from "react";
@@ -1868,6 +1873,33 @@ async function initializeDesktopShell(): Promise<void> {
     accelerator: "CommandOrControl+K",
   });
 
+  // Programmable global hotkey that fronts the floating chat overlay, à la
+  // Claude Desktop / Wispr Flow (#10716). The accelerator is user-configurable
+  // in Desktop settings (persisted in localStorage); re-register on change.
+  const registerChatSummonShortcut = async (): Promise<void> => {
+    const accelerator = resolveChatSummonAccelerator(
+      loadDesktopHotkeySettings(),
+    );
+    const result = await Desktop.registerShortcut({
+      id: SUMMON_CHAT_SHORTCUT_ID,
+      accelerator,
+    });
+    if (!result?.success) {
+      console.warn(
+        `${APP_LOG_PREFIX} chat summon hotkey ${accelerator} was rejected by the OS`,
+      );
+    }
+  };
+  await registerChatSummonShortcut();
+  window.addEventListener("eliza:desktop:hotkey-changed", () => {
+    void registerChatSummonShortcut();
+  });
+
+  const summonChat = async (): Promise<void> => {
+    await Desktop.showWindow();
+    await Desktop.focusWindow();
+  };
+
   subscribeDesktopBridgeEvent({
     rpcMessage: "desktopShortcutPressed",
     ipcChannel: "desktop:shortcutPressed",
@@ -1875,6 +1907,8 @@ async function initializeDesktopShell(): Promise<void> {
       const id = (payload as { id?: string } | null | undefined)?.id;
       if (id === "command-palette") {
         dispatchAppEvent(COMMAND_PALETTE_EVENT);
+      } else if (id === SUMMON_CHAT_SHORTCUT_ID) {
+        void summonChat();
       }
     },
   });

--- a/packages/ui/src/components/settings/DesktopChatHotkeySetting.test.tsx
+++ b/packages/ui/src/components/settings/DesktopChatHotkeySetting.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  DESKTOP_HOTKEY_STORAGE_KEY,
+  loadDesktopHotkeySettings,
+} from "../../utils/desktop-hotkey";
+import { DesktopChatHotkeySetting } from "./DesktopChatHotkeySetting";
+
+describe("DesktopChatHotkeySetting", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  it("shows the default accelerator and no reset button when unset", () => {
+    render(<DesktopChatHotkeySetting platform="win32" />);
+    // Pinned to win32 for a deterministic (glyph-free) display string.
+    expect(screen.getByTestId("chat-hotkey-current").textContent).toBe(
+      "Control+Shift+Space",
+    );
+    expect(screen.queryByTestId("chat-hotkey-reset")).toBeNull();
+  });
+
+  it("records a valid keystroke, persists it, and re-renders", () => {
+    render(<DesktopChatHotkeySetting platform="win32" />);
+    fireEvent.click(screen.getByTestId("chat-hotkey-record"));
+    expect(screen.getByTestId("chat-hotkey-current").textContent).toBe(
+      "Press keys…",
+    );
+
+    fireEvent.keyDown(window, {
+      key: "j",
+      code: "KeyJ",
+      metaKey: true,
+      shiftKey: true,
+    });
+
+    expect(screen.getByTestId("chat-hotkey-current").textContent).toBe(
+      "Command+Shift+J",
+    );
+    expect(loadDesktopHotkeySettings()).toEqual({
+      chatSummonAccelerator: "Command+Shift+J",
+    });
+    expect(localStorage.getItem(DESKTOP_HOTKEY_STORAGE_KEY)).toContain(
+      "Command+Shift+J",
+    );
+  });
+
+  it("rejects an unsafe (bare/Shift-only) keystroke while recording", () => {
+    render(<DesktopChatHotkeySetting platform="win32" />);
+    fireEvent.click(screen.getByTestId("chat-hotkey-record"));
+    fireEvent.keyDown(window, { key: "k", code: "KeyK", shiftKey: true });
+    expect(screen.getByRole("alert")).toBeTruthy();
+    // Still recording, nothing persisted.
+    expect(screen.getByTestId("chat-hotkey-current").textContent).toBe(
+      "Press keys…",
+    );
+    expect(localStorage.getItem(DESKTOP_HOTKEY_STORAGE_KEY)).toBeNull();
+  });
+
+  it("cancels recording on Escape", () => {
+    render(<DesktopChatHotkeySetting platform="win32" />);
+    fireEvent.click(screen.getByTestId("chat-hotkey-record"));
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.getByTestId("chat-hotkey-current").textContent).toBe(
+      "Control+Shift+Space",
+    );
+  });
+
+  it("resets a custom accelerator back to the default", () => {
+    localStorage.setItem(
+      DESKTOP_HOTKEY_STORAGE_KEY,
+      JSON.stringify({ chatSummonAccelerator: "Command+Shift+J" }),
+    );
+    render(<DesktopChatHotkeySetting platform="win32" />);
+    expect(screen.getByTestId("chat-hotkey-current").textContent).toBe(
+      "Command+Shift+J",
+    );
+    fireEvent.click(screen.getByTestId("chat-hotkey-reset"));
+    expect(screen.getByTestId("chat-hotkey-current").textContent).toBe(
+      "Control+Shift+Space",
+    );
+    expect(loadDesktopHotkeySettings()).toEqual({
+      chatSummonAccelerator: null,
+    });
+  });
+});

--- a/packages/ui/src/components/settings/DesktopChatHotkeySetting.test.tsx
+++ b/packages/ui/src/components/settings/DesktopChatHotkeySetting.test.tsx
@@ -1,16 +1,43 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   DESKTOP_HOTKEY_STORAGE_KEY,
   loadDesktopHotkeySettings,
 } from "../../utils/desktop-hotkey";
+
+const invokeDesktopBridgeRequest = vi.fn(
+  async (_options: {
+    rpcMethod: string;
+    ipcChannel: string;
+    params?: unknown;
+  }) => ({ success: true }),
+);
+vi.mock("../../bridge", () => ({
+  invokeDesktopBridgeRequest: (options: {
+    rpcMethod: string;
+    ipcChannel: string;
+    params?: unknown;
+  }) => invokeDesktopBridgeRequest(options),
+}));
+
 import { DesktopChatHotkeySetting } from "./DesktopChatHotkeySetting";
 
 describe("DesktopChatHotkeySetting", () => {
   beforeEach(() => {
     localStorage.clear();
+    invokeDesktopBridgeRequest.mockReset();
+    invokeDesktopBridgeRequest.mockImplementation(async () => ({
+      success: true,
+    }));
   });
   afterEach(() => {
     cleanup();
@@ -26,28 +53,39 @@ describe("DesktopChatHotkeySetting", () => {
     expect(screen.queryByTestId("chat-hotkey-reset")).toBeNull();
   });
 
-  it("records a valid keystroke, persists it, and re-renders", () => {
+  it("records a valid keystroke, registers it, persists it, and re-renders", async () => {
     render(<DesktopChatHotkeySetting platform="win32" />);
     fireEvent.click(screen.getByTestId("chat-hotkey-record"));
     expect(screen.getByTestId("chat-hotkey-current").textContent).toBe(
       "Press keys…",
     );
 
-    fireEvent.keyDown(window, {
-      key: "j",
-      code: "KeyJ",
-      metaKey: true,
-      shiftKey: true,
+    await act(async () => {
+      fireEvent.keyDown(window, {
+        key: "j",
+        code: "KeyJ",
+        metaKey: true,
+        shiftKey: true,
+      });
+      await Promise.resolve();
     });
 
-    expect(screen.getByTestId("chat-hotkey-current").textContent).toBe(
-      "Command+Shift+J",
+    await waitFor(() =>
+      expect(screen.getByTestId("chat-hotkey-current").textContent).toBe(
+        "Command+Shift+J",
+      ),
     );
     expect(loadDesktopHotkeySettings()).toEqual({
       chatSummonAccelerator: "Command+Shift+J",
     });
     expect(localStorage.getItem(DESKTOP_HOTKEY_STORAGE_KEY)).toContain(
       "Command+Shift+J",
+    );
+    expect(invokeDesktopBridgeRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rpcMethod: "desktopRegisterShortcut",
+        params: { id: "summon-chat", accelerator: "Command+Shift+J" },
+      }),
     );
   });
 
@@ -72,7 +110,7 @@ describe("DesktopChatHotkeySetting", () => {
     );
   });
 
-  it("resets a custom accelerator back to the default", () => {
+  it("resets a custom accelerator back to the default", async () => {
     localStorage.setItem(
       DESKTOP_HOTKEY_STORAGE_KEY,
       JSON.stringify({ chatSummonAccelerator: "Command+Shift+J" }),
@@ -81,12 +119,60 @@ describe("DesktopChatHotkeySetting", () => {
     expect(screen.getByTestId("chat-hotkey-current").textContent).toBe(
       "Command+Shift+J",
     );
-    fireEvent.click(screen.getByTestId("chat-hotkey-reset"));
-    expect(screen.getByTestId("chat-hotkey-current").textContent).toBe(
-      "Control+Shift+Space",
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("chat-hotkey-reset"));
+      await Promise.resolve();
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("chat-hotkey-current").textContent).toBe(
+        "Control+Shift+Space",
+      ),
     );
     expect(loadDesktopHotkeySettings()).toEqual({
       chatSummonAccelerator: null,
     });
+  });
+
+  it("surfaces an OS-rejected accelerator without persisting it", async () => {
+    invokeDesktopBridgeRequest.mockImplementation(async (options) => {
+      if (
+        options.rpcMethod === "desktopRegisterShortcut" &&
+        (options.params as { accelerator?: string } | undefined)
+          ?.accelerator === "Command+Shift+J"
+      ) {
+        return { success: false };
+      }
+      return { success: true };
+    });
+
+    render(<DesktopChatHotkeySetting platform="win32" />);
+    fireEvent.click(screen.getByTestId("chat-hotkey-record"));
+    await act(async () => {
+      fireEvent.keyDown(window, {
+        key: "j",
+        code: "KeyJ",
+        metaKey: true,
+        shiftKey: true,
+      });
+      await Promise.resolve();
+    });
+
+    expect(loadDesktopHotkeySettings()).toEqual({
+      chatSummonAccelerator: null,
+    });
+    expect(screen.getByTestId("chat-hotkey-current").textContent).toBe(
+      "Control+Shift+Space",
+    );
+    expect(
+      await screen.findByText(
+        "The operating system rejected Command+Shift+J. Choose a different shortcut.",
+      ),
+    ).toBeTruthy();
+    expect(invokeDesktopBridgeRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rpcMethod: "desktopRegisterShortcut",
+        params: { id: "summon-chat", accelerator: "Control+Shift+Space" },
+      }),
+    );
   });
 });

--- a/packages/ui/src/components/settings/DesktopChatHotkeySetting.tsx
+++ b/packages/ui/src/components/settings/DesktopChatHotkeySetting.tsx
@@ -1,5 +1,6 @@
 import { Keyboard } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
+import { invokeDesktopBridgeRequest } from "../../bridge";
 import {
   acceleratorFromKeyboardEvent,
   currentPlatform,
@@ -15,10 +16,29 @@ import { Button } from "../ui/button";
 
 /** Event the renderer shell listens for to re-register the global shortcut. */
 const HOTKEY_CHANGED_EVENT = "eliza:desktop:hotkey-changed";
+const SUMMON_CHAT_SHORTCUT_ID = "summon-chat";
 
 function announceChange(): void {
   if (typeof window !== "undefined") {
     window.dispatchEvent(new CustomEvent(HOTKEY_CHANGED_EVENT));
+  }
+}
+
+async function syncChatSummonShortcut(accelerator: string): Promise<void> {
+  await invokeDesktopBridgeRequest<void>({
+    rpcMethod: "desktopUnregisterShortcut",
+    ipcChannel: "desktop:unregisterShortcut",
+    params: { id: SUMMON_CHAT_SHORTCUT_ID },
+  });
+  const result = await invokeDesktopBridgeRequest<{ success: boolean }>({
+    rpcMethod: "desktopRegisterShortcut",
+    ipcChannel: "desktop:registerShortcut",
+    params: { id: SUMMON_CHAT_SHORTCUT_ID, accelerator },
+  });
+  if (result?.success === false) {
+    throw new Error(
+      `The operating system rejected ${accelerator}. Choose a different shortcut.`,
+    );
   }
 }
 
@@ -45,11 +65,35 @@ export function DesktopChatHotkeySetting({
   const effective = resolveChatSummonAccelerator(settings, platform);
   const isCustom = settings.chatSummonAccelerator !== null;
 
-  const commit = useCallback((next: DesktopHotkeySettings) => {
-    const stored = saveDesktopHotkeySettings(next);
-    setSettings(stored);
-    announceChange();
-  }, []);
+  const commit = useCallback(
+    async (next: DesktopHotkeySettings) => {
+      const effectiveNext = resolveChatSummonAccelerator(next, platform);
+      const previousEffective = resolveChatSummonAccelerator(
+        settings,
+        platform,
+      );
+      try {
+        await syncChatSummonShortcut(effectiveNext);
+        const stored = saveDesktopHotkeySettings(next);
+        setSettings(stored);
+        setError(null);
+        announceChange();
+      } catch (syncError) {
+        if (previousEffective !== effectiveNext) {
+          try {
+            await syncChatSummonShortcut(previousEffective);
+          } catch {
+            // The original binding failed to restore; keep the visible error
+            // focused on the user's rejected replacement.
+          }
+        }
+        setError(
+          syncError instanceof Error ? syncError.message : String(syncError),
+        );
+      }
+    },
+    [platform, settings],
+  );
 
   useEffect(() => {
     if (!recording) return;
@@ -70,9 +114,8 @@ export function DesktopChatHotkeySetting({
         );
         return;
       }
-      commit({ chatSummonAccelerator: accelerator });
       setRecording(false);
-      setError(null);
+      void commit({ chatSummonAccelerator: accelerator });
     };
 
     window.addEventListener("keydown", onKeyDown, { capture: true });
@@ -123,7 +166,7 @@ export function DesktopChatHotkeySetting({
                 type="button"
                 variant="ghost"
                 size="sm"
-                onClick={() => commit({ chatSummonAccelerator: null })}
+                onClick={() => void commit({ chatSummonAccelerator: null })}
                 data-testid="chat-hotkey-reset"
               >
                 Reset to default ({defaultLabel})

--- a/packages/ui/src/components/settings/DesktopChatHotkeySetting.tsx
+++ b/packages/ui/src/components/settings/DesktopChatHotkeySetting.tsx
@@ -1,0 +1,142 @@
+import { Keyboard } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import {
+  acceleratorFromKeyboardEvent,
+  currentPlatform,
+  type DesktopHotkeySettings,
+  defaultChatSummonAccelerator,
+  formatAcceleratorForDisplay,
+  isSafeGlobalAccelerator,
+  loadDesktopHotkeySettings,
+  resolveChatSummonAccelerator,
+  saveDesktopHotkeySettings,
+} from "../../utils/desktop-hotkey";
+import { Button } from "../ui/button";
+
+/** Event the renderer shell listens for to re-register the global shortcut. */
+const HOTKEY_CHANGED_EVENT = "eliza:desktop:hotkey-changed";
+
+function announceChange(): void {
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new CustomEvent(HOTKEY_CHANGED_EVENT));
+  }
+}
+
+/**
+ * Desktop-settings control for the programmable global chat hotkey (#10716).
+ * Records a keystroke, validates it as a safe global accelerator, persists it,
+ * and asks the shell to re-register — mirroring Claude Desktop's hotkey field.
+ */
+export function DesktopChatHotkeySetting({
+  className = "",
+  platform: platformProp,
+}: {
+  className?: string;
+  /** Overridable for deterministic tests; defaults to the detected OS. */
+  platform?: NodeJS.Platform;
+}) {
+  const [settings, setSettings] = useState<DesktopHotkeySettings>(() =>
+    loadDesktopHotkeySettings(),
+  );
+  const [recording, setRecording] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const platform = platformProp ?? currentPlatform();
+  const effective = resolveChatSummonAccelerator(settings, platform);
+  const isCustom = settings.chatSummonAccelerator !== null;
+
+  const commit = useCallback((next: DesktopHotkeySettings) => {
+    const stored = saveDesktopHotkeySettings(next);
+    setSettings(stored);
+    announceChange();
+  }, []);
+
+  useEffect(() => {
+    if (!recording) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (event.key === "Escape") {
+        setRecording(false);
+        setError(null);
+        return;
+      }
+      const accelerator = acceleratorFromKeyboardEvent(event);
+      if (!accelerator) return; // modifier-only or unsupported — keep listening
+      if (!isSafeGlobalAccelerator(accelerator)) {
+        setError(
+          "Pick a combination with ⌘/Ctrl/Alt (a bare or Shift-only key would hijack typing).",
+        );
+        return;
+      }
+      commit({ chatSummonAccelerator: accelerator });
+      setRecording(false);
+      setError(null);
+    };
+
+    window.addEventListener("keydown", onKeyDown, { capture: true });
+    return () =>
+      window.removeEventListener("keydown", onKeyDown, { capture: true });
+  }, [recording, commit]);
+
+  const defaultLabel = formatAcceleratorForDisplay(
+    defaultChatSummonAccelerator(platform),
+    platform,
+  );
+
+  return (
+    <div
+      className={`rounded-lg border border-border bg-card px-4 py-3 ${className}`}
+    >
+      <div className="flex items-start gap-3">
+        <Keyboard className="mt-0.5 h-4 w-4 shrink-0 text-muted" />
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-medium text-txt">Summon chat hotkey</div>
+          <p className="mt-0.5 text-xs text-muted">
+            Global shortcut that brings the floating chat to the foreground from
+            any app — even when the desktop window is in the background.
+          </p>
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <kbd
+              className="rounded-sm border border-border bg-bg px-2 py-1 font-mono text-xs text-txt"
+              data-testid="chat-hotkey-current"
+            >
+              {recording
+                ? "Press keys…"
+                : formatAcceleratorForDisplay(effective, platform)}
+            </kbd>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                setError(null);
+                setRecording((value) => !value);
+              }}
+              data-testid="chat-hotkey-record"
+            >
+              {recording ? "Cancel" : "Change"}
+            </Button>
+            {isCustom && !recording ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => commit({ chatSummonAccelerator: null })}
+                data-testid="chat-hotkey-reset"
+              >
+                Reset to default ({defaultLabel})
+              </Button>
+            ) : null}
+          </div>
+          {error ? (
+            <p className="mt-2 text-xs text-danger" role="alert">
+              {error}
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/settings/DesktopWorkspaceSection.tsx
+++ b/packages/ui/src/components/settings/DesktopWorkspaceSection.tsx
@@ -24,6 +24,7 @@ import {
 } from "../../utils/desktop-workspace";
 import { Button } from "../ui/button";
 import { SettingsTextarea } from "../ui/settings-controls";
+import { DesktopChatHotkeySetting } from "./DesktopChatHotkeySetting";
 import { DesktopWorkspaceDisplay } from "./DesktopWorkspaceDisplay";
 import { useDesktopDiagnosticsText } from "./DesktopWorkspaceDisplay.hooks";
 import { SettingsGroup, SettingsRow, SettingsStack } from "./settings-layout";
@@ -393,6 +394,8 @@ export function DesktopWorkspaceSection({
             {t("desktopworkspacesection.OpenDesktopSettingsWindow")}
           </WorkspaceActionButton>
         </div>
+
+        <DesktopChatHotkeySetting />
 
         {(actionError || actionMessage) && (
           <div

--- a/packages/ui/src/utils/desktop-hotkey.test.ts
+++ b/packages/ui/src/utils/desktop-hotkey.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_DESKTOP_HOTKEY_SETTINGS,
+  defaultChatSummonAccelerator,
+  isSafeGlobalAccelerator,
+  isValidAccelerator,
+  normalizeAccelerator,
+  parseDesktopHotkeySettings,
+  resolveChatSummonAccelerator,
+  serializeDesktopHotkeySettings,
+  SUMMON_CHAT_SHORTCUT_ID,
+} from "./desktop-hotkey";
+
+describe("defaultChatSummonAccelerator", () => {
+  it("uses Command+Shift+Space on macOS (distinct from Spotlight / ⌘K)", () => {
+    expect(defaultChatSummonAccelerator("darwin")).toBe("Command+Shift+Space");
+  });
+
+  it("uses Control+Shift+Space off macOS", () => {
+    expect(defaultChatSummonAccelerator("win32")).toBe("Control+Shift+Space");
+    expect(defaultChatSummonAccelerator("linux")).toBe("Control+Shift+Space");
+  });
+
+  it("never collides with the command-palette binding", () => {
+    for (const platform of ["darwin", "win32", "linux"] as const) {
+      expect(defaultChatSummonAccelerator(platform)).not.toBe(
+        "CommandOrControl+K",
+      );
+    }
+  });
+});
+
+describe("normalizeAccelerator", () => {
+  it("canonicalizes modifier aliases and casing", () => {
+    expect(normalizeAccelerator("cmd+shift+space")).toBe("Command+Shift+Space");
+    expect(normalizeAccelerator("CmdOrCtrl+k")).toBe("CommandOrControl+K");
+    expect(normalizeAccelerator("option+Enter")).toBe("Alt+Enter");
+    expect(normalizeAccelerator("meta+j")).toBe("Super+J");
+  });
+
+  it("orders modifiers canonically so equivalent strings compare equal", () => {
+    expect(normalizeAccelerator("Shift+Command+K")).toBe("Command+Shift+K");
+    expect(normalizeAccelerator("Command+Shift+K")).toBe("Command+Shift+K");
+    expect(normalizeAccelerator("Alt+Control+F5")).toBe("Control+Alt+F5");
+  });
+
+  it("accepts function keys F1–F24", () => {
+    expect(normalizeAccelerator("Command+F12")).toBe("Command+F12");
+    expect(normalizeAccelerator("Control+F24")).toBe("Control+F24");
+    expect(normalizeAccelerator("Command+F25")).toBeNull();
+    expect(normalizeAccelerator("Command+F0")).toBeNull();
+  });
+
+  it("rejects empty, whitespace, and malformed input", () => {
+    expect(normalizeAccelerator("")).toBeNull();
+    expect(normalizeAccelerator("   ")).toBeNull();
+    expect(normalizeAccelerator("Command+")).toBeNull();
+    expect(normalizeAccelerator("+K")).toBeNull();
+    expect(normalizeAccelerator(null)).toBeNull();
+    expect(normalizeAccelerator(undefined)).toBeNull();
+  });
+
+  it("rejects a modifier-only accelerator (no key)", () => {
+    expect(normalizeAccelerator("Command+Shift")).toBeNull();
+    expect(normalizeAccelerator("Control")).toBeNull();
+  });
+
+  it("rejects two keys or unknown tokens", () => {
+    expect(normalizeAccelerator("Command+K+J")).toBeNull();
+    expect(normalizeAccelerator("Command+Frobnicate")).toBeNull();
+    expect(normalizeAccelerator("Hyper+K")).toBeNull();
+  });
+
+  it("rejects duplicate modifiers", () => {
+    expect(normalizeAccelerator("Command+Command+K")).toBeNull();
+  });
+});
+
+describe("isValidAccelerator", () => {
+  it("mirrors normalizeAccelerator success/failure", () => {
+    expect(isValidAccelerator("Command+Shift+Space")).toBe(true);
+    expect(isValidAccelerator("nope")).toBe(false);
+  });
+});
+
+describe("isSafeGlobalAccelerator", () => {
+  it("accepts accelerators with a non-Shift modifier", () => {
+    expect(isSafeGlobalAccelerator("Command+Shift+Space")).toBe(true);
+    expect(isSafeGlobalAccelerator("Control+J")).toBe(true);
+    expect(isSafeGlobalAccelerator("Alt+Space")).toBe(true);
+  });
+
+  it("rejects bare keys and Shift-only accelerators (would hijack typing)", () => {
+    expect(isSafeGlobalAccelerator("K")).toBe(false);
+    expect(isSafeGlobalAccelerator("Shift+K")).toBe(false);
+    expect(isSafeGlobalAccelerator("Space")).toBe(false);
+  });
+
+  it("rejects invalid accelerators", () => {
+    expect(isSafeGlobalAccelerator("")).toBe(false);
+    expect(isSafeGlobalAccelerator("Command+")).toBe(false);
+  });
+});
+
+describe("parseDesktopHotkeySettings", () => {
+  it("defaults on missing / non-object / corrupt input", () => {
+    expect(parseDesktopHotkeySettings(undefined)).toEqual(
+      DEFAULT_DESKTOP_HOTKEY_SETTINGS,
+    );
+    expect(parseDesktopHotkeySettings(null)).toEqual(
+      DEFAULT_DESKTOP_HOTKEY_SETTINGS,
+    );
+    expect(parseDesktopHotkeySettings("garbage")).toEqual(
+      DEFAULT_DESKTOP_HOTKEY_SETTINGS,
+    );
+    expect(parseDesktopHotkeySettings(42)).toEqual(
+      DEFAULT_DESKTOP_HOTKEY_SETTINGS,
+    );
+  });
+
+  it("normalizes a valid stored accelerator", () => {
+    expect(
+      parseDesktopHotkeySettings({ chatSummonAccelerator: "shift+cmd+j" }),
+    ).toEqual({ chatSummonAccelerator: "Command+Shift+J" });
+  });
+
+  it("drops an invalid or unsafe stored accelerator back to default", () => {
+    expect(
+      parseDesktopHotkeySettings({ chatSummonAccelerator: "not-a-key" }),
+    ).toEqual({ chatSummonAccelerator: null });
+    expect(
+      parseDesktopHotkeySettings({ chatSummonAccelerator: "Shift+K" }),
+    ).toEqual({ chatSummonAccelerator: null });
+    expect(parseDesktopHotkeySettings({ chatSummonAccelerator: 5 })).toEqual({
+      chatSummonAccelerator: null,
+    });
+  });
+});
+
+describe("serializeDesktopHotkeySettings", () => {
+  it("round-trips through parse", () => {
+    const settings = { chatSummonAccelerator: "Command+Shift+J" };
+    const json = serializeDesktopHotkeySettings(settings);
+    expect(parseDesktopHotkeySettings(JSON.parse(json))).toEqual(settings);
+  });
+
+  it("normalizes on the way out and ends with a trailing newline", () => {
+    const json = serializeDesktopHotkeySettings({
+      chatSummonAccelerator: "shift+cmd+j",
+    });
+    expect(JSON.parse(json)).toEqual({
+      chatSummonAccelerator: "Command+Shift+J",
+    });
+    expect(json.endsWith("\n")).toBe(true);
+  });
+
+  it("serializes the default (null) accelerator", () => {
+    const json = serializeDesktopHotkeySettings({ chatSummonAccelerator: null });
+    expect(JSON.parse(json)).toEqual({ chatSummonAccelerator: null });
+  });
+});
+
+describe("resolveChatSummonAccelerator", () => {
+  it("returns the per-platform default when no override is set", () => {
+    expect(
+      resolveChatSummonAccelerator({ chatSummonAccelerator: null }, "darwin"),
+    ).toBe("Command+Shift+Space");
+    expect(
+      resolveChatSummonAccelerator({ chatSummonAccelerator: null }, "linux"),
+    ).toBe("Control+Shift+Space");
+  });
+
+  it("returns a valid, normalized override", () => {
+    expect(
+      resolveChatSummonAccelerator(
+        { chatSummonAccelerator: "shift+cmd+j" },
+        "darwin",
+      ),
+    ).toBe("Command+Shift+J");
+  });
+
+  it("falls back to default for an unsafe override", () => {
+    expect(
+      resolveChatSummonAccelerator({ chatSummonAccelerator: "Shift+K" }, "darwin"),
+    ).toBe("Command+Shift+Space");
+  });
+});
+
+describe("SUMMON_CHAT_SHORTCUT_ID", () => {
+  it("is stable and not the command-palette id", () => {
+    expect(SUMMON_CHAT_SHORTCUT_ID).toBe("summon-chat");
+    expect(SUMMON_CHAT_SHORTCUT_ID).not.toBe("command-palette");
+  });
+});

--- a/packages/ui/src/utils/desktop-hotkey.test.ts
+++ b/packages/ui/src/utils/desktop-hotkey.test.ts
@@ -1,15 +1,38 @@
 import { describe, expect, it } from "vitest";
 import {
+  acceleratorFromKeyboardEvent,
   DEFAULT_DESKTOP_HOTKEY_SETTINGS,
   defaultChatSummonAccelerator,
+  formatAcceleratorForDisplay,
   isSafeGlobalAccelerator,
   isValidAccelerator,
   normalizeAccelerator,
   parseDesktopHotkeySettings,
   resolveChatSummonAccelerator,
-  serializeDesktopHotkeySettings,
   SUMMON_CHAT_SHORTCUT_ID,
+  serializeDesktopHotkeySettings,
 } from "./desktop-hotkey";
+
+function keyEvent(
+  overrides: Partial<{
+    metaKey: boolean;
+    ctrlKey: boolean;
+    altKey: boolean;
+    shiftKey: boolean;
+    key: string;
+    code: string;
+  }>,
+) {
+  return {
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    key: "",
+    code: "",
+    ...overrides,
+  };
+}
 
 describe("defaultChatSummonAccelerator", () => {
   it("uses Command+Shift+Space on macOS (distinct from Spotlight / ⌘K)", () => {
@@ -155,7 +178,9 @@ describe("serializeDesktopHotkeySettings", () => {
   });
 
   it("serializes the default (null) accelerator", () => {
-    const json = serializeDesktopHotkeySettings({ chatSummonAccelerator: null });
+    const json = serializeDesktopHotkeySettings({
+      chatSummonAccelerator: null,
+    });
     expect(JSON.parse(json)).toEqual({ chatSummonAccelerator: null });
   });
 });
@@ -181,7 +206,10 @@ describe("resolveChatSummonAccelerator", () => {
 
   it("falls back to default for an unsafe override", () => {
     expect(
-      resolveChatSummonAccelerator({ chatSummonAccelerator: "Shift+K" }, "darwin"),
+      resolveChatSummonAccelerator(
+        { chatSummonAccelerator: "Shift+K" },
+        "darwin",
+      ),
     ).toBe("Command+Shift+Space");
   });
 });
@@ -190,5 +218,71 @@ describe("SUMMON_CHAT_SHORTCUT_ID", () => {
   it("is stable and not the command-palette id", () => {
     expect(SUMMON_CHAT_SHORTCUT_ID).toBe("summon-chat");
     expect(SUMMON_CHAT_SHORTCUT_ID).not.toBe("command-palette");
+  });
+});
+
+describe("acceleratorFromKeyboardEvent", () => {
+  it("returns null while only modifiers are held (keep recording)", () => {
+    expect(
+      acceleratorFromKeyboardEvent(keyEvent({ metaKey: true, key: "Meta" })),
+    ).toBeNull();
+    expect(
+      acceleratorFromKeyboardEvent(keyEvent({ shiftKey: true, key: "Shift" })),
+    ).toBeNull();
+  });
+
+  it("builds a canonical accelerator from modifiers + key", () => {
+    expect(
+      acceleratorFromKeyboardEvent(
+        keyEvent({ metaKey: true, shiftKey: true, key: "j", code: "KeyJ" }),
+      ),
+    ).toBe("Command+Shift+J");
+  });
+
+  it("maps Space and arrow keys correctly", () => {
+    expect(
+      acceleratorFromKeyboardEvent(
+        keyEvent({ ctrlKey: true, shiftKey: true, key: " ", code: "Space" }),
+      ),
+    ).toBe("Control+Shift+Space");
+    expect(
+      acceleratorFromKeyboardEvent(
+        keyEvent({ metaKey: true, key: "ArrowUp", code: "ArrowUp" }),
+      ),
+    ).toBe("Command+Up");
+  });
+
+  it("handles function keys and named keys", () => {
+    expect(
+      acceleratorFromKeyboardEvent(
+        keyEvent({ ctrlKey: true, key: "F5", code: "F5" }),
+      ),
+    ).toBe("Control+F5");
+    expect(
+      acceleratorFromKeyboardEvent(
+        keyEvent({ altKey: true, key: "Enter", code: "Enter" }),
+      ),
+    ).toBe("Alt+Enter");
+  });
+
+  it("returns null for unsupported keys", () => {
+    expect(
+      acceleratorFromKeyboardEvent(keyEvent({ metaKey: true, key: "Dead" })),
+    ).toBeNull();
+  });
+});
+
+describe("formatAcceleratorForDisplay", () => {
+  it("renders macOS glyphs", () => {
+    expect(formatAcceleratorForDisplay("Command+Shift+Space", "darwin")).toBe(
+      "⌘⇧Space",
+    );
+    expect(formatAcceleratorForDisplay("Control+Alt+J", "darwin")).toBe("⌃⌥J");
+  });
+
+  it("leaves the normalized string as-is off macOS", () => {
+    expect(formatAcceleratorForDisplay("control+shift+space", "win32")).toBe(
+      "Control+Shift+Space",
+    );
   });
 });

--- a/packages/ui/src/utils/desktop-hotkey.ts
+++ b/packages/ui/src/utils/desktop-hotkey.ts
@@ -46,9 +46,7 @@ export function currentPlatform(): NodeJS.Platform {
 export function defaultChatSummonAccelerator(
   platform: NodeJS.Platform = currentPlatform(),
 ): string {
-  return platform === "darwin"
-    ? "Command+Shift+Space"
-    : "Control+Shift+Space";
+  return platform === "darwin" ? "Command+Shift+Space" : "Control+Shift+Space";
 }
 
 /**
@@ -114,7 +112,9 @@ function canonicalKeyToken(raw: string): string | null {
  * it is not a valid accelerator (empty, no key, two keys, or an unknown token).
  * Modifier order is canonicalized so equivalent strings compare equal.
  */
-export function normalizeAccelerator(input: string | null | undefined): string | null {
+export function normalizeAccelerator(
+  input: string | null | undefined,
+): string | null {
   if (typeof input !== "string") return null;
   const trimmed = input.trim();
   if (trimmed.length === 0) return null;
@@ -166,7 +166,9 @@ export function isValidAccelerator(input: string | null | undefined): boolean {
  * we require at least one non-Shift modifier (Cmd/Ctrl/Alt/Super) to avoid
  * hijacking ordinary typing. Used to gate user-entered accelerators.
  */
-export function isSafeGlobalAccelerator(input: string | null | undefined): boolean {
+export function isSafeGlobalAccelerator(
+  input: string | null | undefined,
+): boolean {
   const normalized = normalizeAccelerator(input);
   if (!normalized) return false;
   const tokens = normalized.split("+");
@@ -200,7 +202,9 @@ export const DEFAULT_DESKTOP_HOTKEY_SETTINGS: DesktopHotkeySettings = {
  * dropped (reverts to the default) rather than silently registering a bad
  * binding.
  */
-export function parseDesktopHotkeySettings(raw: unknown): DesktopHotkeySettings {
+export function parseDesktopHotkeySettings(
+  raw: unknown,
+): DesktopHotkeySettings {
   if (!raw || typeof raw !== "object") {
     return { ...DEFAULT_DESKTOP_HOTKEY_SETTINGS };
   }
@@ -277,4 +281,78 @@ export function saveDesktopHotkeySettings(
     }
   }
   return normalized;
+}
+
+/** Keyboard-event keys that are modifiers, not the accelerator's "key" token. */
+const MODIFIER_EVENT_KEYS: ReadonlySet<string> = new Set([
+  "Meta",
+  "Control",
+  "Alt",
+  "Shift",
+  "CapsLock",
+  "OS",
+  "AltGraph",
+]);
+
+type CapturedKeyEvent = Pick<
+  KeyboardEvent,
+  "metaKey" | "ctrlKey" | "altKey" | "shiftKey" | "key" | "code"
+>;
+
+/**
+ * Build a normalized accelerator from a captured `keydown`, for a
+ * record-shortcut UI. Returns `null` while only modifiers are held (keep
+ * recording) or for an unsupported key. The result still passes through
+ * {@link normalizeAccelerator}, so callers should additionally gate on
+ * {@link isSafeGlobalAccelerator} before persisting.
+ */
+export function acceleratorFromKeyboardEvent(
+  event: CapturedKeyEvent,
+): string | null {
+  if (MODIFIER_EVENT_KEYS.has(event.key)) {
+    return null;
+  }
+
+  const modifiers: string[] = [];
+  if (event.metaKey) modifiers.push("Command");
+  if (event.ctrlKey) modifiers.push("Control");
+  if (event.altKey) modifiers.push("Alt");
+  if (event.shiftKey) modifiers.push("Shift");
+
+  let key: string | null = null;
+  if (event.code === "Space" || event.key === " ") {
+    key = "Space";
+  } else if (/^Arrow(Up|Down|Left|Right)$/.test(event.key)) {
+    key = event.key.slice("Arrow".length);
+  } else {
+    key = canonicalKeyToken(event.key);
+  }
+  if (!key) return null;
+
+  return normalizeAccelerator([...modifiers, key].join("+"));
+}
+
+/**
+ * Human-friendly rendering of an accelerator for display (⌘⇧Space on macOS,
+ * `Ctrl+Shift+Space` elsewhere). Purely cosmetic — never persisted.
+ */
+export function formatAcceleratorForDisplay(
+  accelerator: string,
+  platform: NodeJS.Platform = currentPlatform(),
+): string {
+  const normalized = normalizeAccelerator(accelerator);
+  if (!normalized) return accelerator;
+  if (platform !== "darwin") return normalized;
+  const SYMBOLS: Record<string, string> = {
+    CommandOrControl: "⌘",
+    Command: "⌘",
+    Control: "⌃",
+    Alt: "⌥",
+    Shift: "⇧",
+    Super: "⌘",
+  };
+  return normalized
+    .split("+")
+    .map((token) => SYMBOLS[token] ?? token)
+    .join("");
 }

--- a/packages/ui/src/utils/desktop-hotkey.ts
+++ b/packages/ui/src/utils/desktop-hotkey.ts
@@ -1,0 +1,280 @@
+/**
+ * Programmable global hotkey that summons the floating chat overlay to the
+ * foreground (Claude-Desktop / Wispr-Flow style), plus the persisted desktop
+ * hotkey settings it reads from.
+ *
+ * This module is intentionally pure (no Electrobun / filesystem imports) so the
+ * accelerator validation, defaulting, and settings (de)serialization are unit
+ * testable. It ships in the renderer bundle: the desktop shell registers the
+ * chat hotkey from the renderer (same path as the command palette) and persists
+ * the chosen accelerator in `localStorage`. The renderer summon handler lives in
+ * `packages/app/src/main.tsx`; the "Summon Chat" menu/tray click paths live in
+ * the Electrobun main process.
+ *
+ * Issue #10716.
+ */
+
+/** Global-shortcut id for the chat-summon accelerator (distinct from the
+ * `command-palette` binding on `CommandOrControl+K`). */
+export const SUMMON_CHAT_SHORTCUT_ID = "summon-chat";
+
+/** localStorage key the desktop shell persists the hotkey settings JSON under. */
+export const DESKTOP_HOTKEY_STORAGE_KEY = "eliza:desktop:hotkey-settings";
+
+/**
+ * Browser-safe OS detection. This module ships in the renderer bundle, where
+ * `process` is absent — fall back to the user agent.
+ */
+export function currentPlatform(): NodeJS.Platform {
+  if (typeof process !== "undefined" && process.platform) {
+    return process.platform;
+  }
+  if (typeof navigator !== "undefined") {
+    const ua = `${navigator.platform ?? ""} ${navigator.userAgent ?? ""}`;
+    if (/Mac|iPhone|iPad|iPod/i.test(ua)) return "darwin";
+    if (/Win/i.test(ua)) return "win32";
+  }
+  return "linux";
+}
+
+/**
+ * Default accelerator that summons/fronts the floating chat overlay.
+ *
+ * macOS: ⌘⇧Space — deliberately distinct from Spotlight (⌘Space) and the
+ * command palette (⌘K). Elsewhere: Ctrl+Shift+Space.
+ */
+export function defaultChatSummonAccelerator(
+  platform: NodeJS.Platform = currentPlatform(),
+): string {
+  return platform === "darwin"
+    ? "Command+Shift+Space"
+    : "Control+Shift+Space";
+}
+
+/**
+ * Modifier tokens Electrobun's `GlobalShortcut` accepts (Electron-compatible
+ * accelerator grammar). Canonical spelling is the map value; aliases resolve to
+ * it so `cmd`, `CmdOrCtrl`, `option` all normalize.
+ */
+const MODIFIER_ALIASES: ReadonlyMap<string, string> = new Map([
+  ["command", "Command"],
+  ["cmd", "Command"],
+  ["control", "Control"],
+  ["ctrl", "Control"],
+  ["commandorcontrol", "CommandOrControl"],
+  ["cmdorctrl", "CommandOrControl"],
+  ["alt", "Alt"],
+  ["option", "Alt"],
+  ["altgr", "AltGr"],
+  ["shift", "Shift"],
+  ["super", "Super"],
+  ["meta", "Super"],
+]);
+
+/**
+ * Canonical spellings for the accepted non-modifier "key" token. A valid
+ * accelerator has exactly one key token plus zero or more modifiers.
+ */
+const KEY_ALIASES: ReadonlyMap<string, string> = new Map([
+  ["space", "Space"],
+  ["tab", "Tab"],
+  ["backspace", "Backspace"],
+  ["delete", "Delete"],
+  ["del", "Delete"],
+  ["insert", "Insert"],
+  ["return", "Return"],
+  ["enter", "Enter"],
+  ["up", "Up"],
+  ["down", "Down"],
+  ["left", "Left"],
+  ["right", "Right"],
+  ["home", "Home"],
+  ["end", "End"],
+  ["pageup", "PageUp"],
+  ["pagedown", "PageDown"],
+  ["escape", "Escape"],
+  ["esc", "Escape"],
+  ["plus", "Plus"],
+]);
+
+function canonicalKeyToken(raw: string): string | null {
+  const lower = raw.toLowerCase();
+  const alias = KEY_ALIASES.get(lower);
+  if (alias) return alias;
+  // Single alphanumeric character (letters upper-cased for stable comparison).
+  if (/^[a-z0-9]$/.test(lower)) return lower.toUpperCase();
+  // Function keys F1–F24.
+  const fn = /^f([1-9]|1[0-9]|2[0-4])$/.exec(lower);
+  if (fn) return `F${fn[1]}`;
+  return null;
+}
+
+/**
+ * Normalize an accelerator string to canonical Electrobun form, or `null` when
+ * it is not a valid accelerator (empty, no key, two keys, or an unknown token).
+ * Modifier order is canonicalized so equivalent strings compare equal.
+ */
+export function normalizeAccelerator(input: string | null | undefined): string | null {
+  if (typeof input !== "string") return null;
+  const trimmed = input.trim();
+  if (trimmed.length === 0) return null;
+
+  const parts = trimmed.split("+").map((p) => p.trim());
+  if (parts.some((p) => p.length === 0)) return null;
+
+  const modifiers: string[] = [];
+  let key: string | null = null;
+
+  for (const part of parts) {
+    const modifier = MODIFIER_ALIASES.get(part.toLowerCase());
+    if (modifier) {
+      if (modifiers.includes(modifier)) return null; // duplicate modifier
+      modifiers.push(modifier);
+      continue;
+    }
+    const keyToken = canonicalKeyToken(part);
+    if (!keyToken) return null; // unknown token
+    if (key) return null; // more than one key
+    key = keyToken;
+  }
+
+  if (!key) return null; // accelerator must include a key
+
+  // Stable modifier ordering (Electron convention: Ctrl/Cmd, Alt, Shift, Super).
+  const ORDER = [
+    "CommandOrControl",
+    "Command",
+    "Control",
+    "Alt",
+    "AltGr",
+    "Shift",
+    "Super",
+  ];
+  modifiers.sort((a, b) => ORDER.indexOf(a) - ORDER.indexOf(b));
+
+  return [...modifiers, key].join("+");
+}
+
+/** Whether `input` is a valid accelerator. */
+export function isValidAccelerator(input: string | null | undefined): boolean {
+  return normalizeAccelerator(input) !== null;
+}
+
+/**
+ * Whether the accelerator is a safe *global* hotkey. A bare key or a single
+ * Shift+key is rejected — global shortcuts steal the binding from every app, so
+ * we require at least one non-Shift modifier (Cmd/Ctrl/Alt/Super) to avoid
+ * hijacking ordinary typing. Used to gate user-entered accelerators.
+ */
+export function isSafeGlobalAccelerator(input: string | null | undefined): boolean {
+  const normalized = normalizeAccelerator(input);
+  if (!normalized) return false;
+  const tokens = normalized.split("+");
+  return tokens.some(
+    (t) =>
+      t === "CommandOrControl" ||
+      t === "Command" ||
+      t === "Control" ||
+      t === "Alt" ||
+      t === "AltGr" ||
+      t === "Super",
+  );
+}
+
+/** Persisted desktop hotkey preferences (state-dir JSON). */
+export interface DesktopHotkeySettings {
+  /**
+   * User-chosen accelerator for summoning chat. `null` means "use the
+   * per-platform default" ({@link defaultChatSummonAccelerator}).
+   */
+  chatSummonAccelerator: string | null;
+}
+
+export const DEFAULT_DESKTOP_HOTKEY_SETTINGS: DesktopHotkeySettings = {
+  chatSummonAccelerator: null,
+};
+
+/**
+ * Parse persisted settings from unknown JSON, tolerating a missing/partial/
+ * corrupt file by falling back to defaults. An invalid or unsafe accelerator is
+ * dropped (reverts to the default) rather than silently registering a bad
+ * binding.
+ */
+export function parseDesktopHotkeySettings(raw: unknown): DesktopHotkeySettings {
+  if (!raw || typeof raw !== "object") {
+    return { ...DEFAULT_DESKTOP_HOTKEY_SETTINGS };
+  }
+  const candidate = (raw as { chatSummonAccelerator?: unknown })
+    .chatSummonAccelerator;
+  if (typeof candidate !== "string") {
+    return { ...DEFAULT_DESKTOP_HOTKEY_SETTINGS };
+  }
+  const normalized = normalizeAccelerator(candidate);
+  if (!normalized || !isSafeGlobalAccelerator(normalized)) {
+    return { ...DEFAULT_DESKTOP_HOTKEY_SETTINGS };
+  }
+  return { chatSummonAccelerator: normalized };
+}
+
+/** Serialize settings to canonical JSON for persistence. */
+export function serializeDesktopHotkeySettings(
+  settings: DesktopHotkeySettings,
+): string {
+  const accelerator = settings.chatSummonAccelerator
+    ? normalizeAccelerator(settings.chatSummonAccelerator)
+    : null;
+  return `${JSON.stringify({ chatSummonAccelerator: accelerator }, null, 2)}\n`;
+}
+
+/**
+ * Resolve the effective chat-summon accelerator: the user override when it is a
+ * valid safe global hotkey, else the per-platform default.
+ */
+export function resolveChatSummonAccelerator(
+  settings: DesktopHotkeySettings,
+  platform: NodeJS.Platform = currentPlatform(),
+): string {
+  const override = settings.chatSummonAccelerator;
+  if (override && isSafeGlobalAccelerator(override)) {
+    return normalizeAccelerator(override) as string;
+  }
+  return defaultChatSummonAccelerator(platform);
+}
+
+/**
+ * Load persisted hotkey settings from `localStorage` (renderer). Never throws —
+ * returns defaults when storage is unavailable or the stored value is corrupt.
+ */
+export function loadDesktopHotkeySettings(): DesktopHotkeySettings {
+  if (typeof localStorage === "undefined") {
+    return { ...DEFAULT_DESKTOP_HOTKEY_SETTINGS };
+  }
+  try {
+    const raw = localStorage.getItem(DESKTOP_HOTKEY_STORAGE_KEY);
+    if (!raw) return { ...DEFAULT_DESKTOP_HOTKEY_SETTINGS };
+    return parseDesktopHotkeySettings(JSON.parse(raw));
+  } catch {
+    return { ...DEFAULT_DESKTOP_HOTKEY_SETTINGS };
+  }
+}
+
+/**
+ * Persist hotkey settings to `localStorage` (renderer). Returns the normalized
+ * settings actually stored so callers can re-register with the canonical value.
+ */
+export function saveDesktopHotkeySettings(
+  settings: DesktopHotkeySettings,
+): DesktopHotkeySettings {
+  const normalized = parseDesktopHotkeySettings(settings);
+  if (typeof localStorage !== "undefined") {
+    try {
+      localStorage.setItem(
+        DESKTOP_HOTKEY_STORAGE_KEY,
+        serializeDesktopHotkeySettings(normalized),
+      );
+    } catch {
+      // Storage full / disabled — the in-memory registration still applies.
+    }
+  }
+  return normalized;
+}

--- a/packages/ui/src/utils/index.ts
+++ b/packages/ui/src/utils/index.ts
@@ -21,6 +21,7 @@ export * from "./clipboard";
 export * from "./cloud-status";
 export * from "./desktop-bug-report";
 export * from "./desktop-dialogs";
+export * from "./desktop-hotkey";
 export * from "./desktop-workspace";
 export * from "./documents-upload-image";
 export * from "./eliza-cloud-model-route";


### PR DESCRIPTION
Closes #10716.

Wires the desktop shell's existing-but-disconnected primitives (tray, menu, `GlobalShortcut`, the transparent always-on-top `chat-overlay`) into the three requested "native app" behaviors: **open any view from the tray/menu in its own window**, a **programmable global hotkey that fronts chat**, and **click-to-summon**.

### What changed
- **Programmable chat hotkey** (`@elizaos/ui/utils/desktop-hotkey`, pure + browser-safe): accelerator normalize/validate, a *safe-global* gate (rejects bare/Shift-only bindings that would hijack typing), per-platform default `⌘⇧Space` / `Ctrl+Shift+Space` (deliberately **not** `⌘K`), keystroke capture, and `localStorage` persistence. `main.tsx` registers `summon-chat` alongside the existing `command-palette` binding and, on press, `show+focus`es the floating chat — re-registering when settings change.
- **Tray → views in their own window**: `tray-menu.ts` generates a "Views" section from the shared internal-tool-app catalog (`getInternalToolAppDescriptors` — the same source the launcher/menu use, so no duplicated list); `DesktopTrayRuntime` opens each `tray-app-<slug>` via `openDesktopAppWindow`.
- **Menu bar "Views" submenu**: the former "Apps" submenu → **Views**, each entry opening its own window through the existing `apps:<slug>` handler; a **Summon Chat** click path added to the Desktop menu (no local accelerator — the global shortcut owns the keypress). The Electrobun main process handles `summon-chat` (restore+show+focus).
- **Click-to-summon**: the tray-icon click now `show+focus` (parity with the hotkey).
- **Settings surface**: `DesktopChatHotkeySetting` (record → validate → persist → re-register, with reset-to-default) rendered in the Desktop Workspace settings section.

### Non-goals respected
No second tray/menu framework, no parallel chat renderer (reuses `ChatOverlayShell`), no mobile/web changes, OS-rejection surfaced via `GlobalShortcut.register` returning false.

### Tests — 52 new assertions, all green
`@elizaos/ui` `desktop-hotkey.test.ts` (31) · `DesktopChatHotkeySetting.test.tsx` (5) · `@elizaos/electrobun` `application-menu.test.ts` (8, the **new** suite the issue asked for) · `@elizaos/app-core` `tray-menu.test.ts` (8). Typecheck clean across all four packages.

### Evidence
`.github/issue-evidence/10716-desktop-native-tray-hotkey/` — full test log + a capture-status matrix mapping every acceptance criterion to its proof.

| Evidence type | Status |
| --- | --- |
| Unit/component tests (52) + typecheck | ✅ attached (`unit-tests.log`) |
| Real-LLM trajectory | N/A — desktop shell window/hotkey wiring, no model path (per the issue) |
| Live native-shell capture (summon-when-backgrounded, tray→own-window) | Deferred to a human on a **built** desktop app — a global OS keypress + OS-level screenshot can't be driven headlessly; exact repro recipe in the evidence README, and each code path is unit-covered |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
