### PR TITLE
[codex] Fix runtime settings precedence over stale DB agent settings

### DIFF
--- a/.github/issue-evidence/10818-runtime-settings-precedence.md
+++ b/.github/issue-evidence/10818-runtime-settings-precedence.md
@@ -1,0 +1,37 @@
+# 10818 Runtime Settings Precedence Evidence
+
+Issue: https://github.com/elizaOS/eliza/issues/10818
+
+## What Was Verified
+
+- A fresh constructor `settings` value overrides a stale DB-persisted agent setting on restart.
+- The same override works when the stale DB value was persisted through `agents.settings.secrets` or `agents.secrets`.
+- Explicit character-file settings still override constructor settings, preserving per-agent character configuration precedence.
+
+## Commands Run
+
+```bash
+bunx @biomejs/biome check packages/core/src/runtime.ts packages/core/src/__tests__/runtime-settings.test.ts .github/issue-evidence/10818-runtime-settings-precedence.md
+bun run --cwd packages/core typecheck
+bun run --cwd packages/core test -- runtime-settings.test.ts
+bun run --cwd packages/core build:node
+bun run verify
+```
+
+## Results Reviewed
+
+- Biome on touched files: passed with no fixes applied.
+- `packages/core` typecheck: passed.
+- `runtime-settings.test.ts`: 6 tests passed.
+- `packages/core` Node-only build: passed and emitted declarations successfully.
+- Root `bun run verify`: blocked before package checks by the current repo-wide
+  type-safety ratchet, unrelated to this change:
+  - `as unknown as`: 109 current > 77 baseline
+  - `?? 0` in core/agent/app-core: 384 current > 380 baseline
+
+## Evidence N/A
+
+- UI screenshots/video: N/A, this is a backend runtime settings-resolution fix with no rendered UI.
+- Frontend logs/network: N/A, no frontend request path is involved.
+- Real-LLM trajectory: N/A, no model call or agent action routing is involved; the bug is deterministic initialization and `getSetting()` behavior.
+- Domain artifacts: covered by the in-memory adapter regression that seeds and reuses an existing agent row with persisted settings/secrets.

--- a/packages/core/src/__tests__/runtime-settings.test.ts
+++ b/packages/core/src/__tests__/runtime-settings.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { InMemoryDatabaseAdapter } from "../database/inMemoryAdapter";
 import { AgentRuntime } from "../runtime";
 import type { Character } from "../types";
 
@@ -56,6 +57,73 @@ describe("AgentRuntime.getSetting", () => {
 		});
 
 		expect(runtime.getSetting("ROUTE_POLICY")).toBe('{"default":"guest"}');
+	});
+
+	it("keeps character settings ahead of constructor settings", () => {
+		const runtime = new AgentRuntime({
+			character: {
+				name: "character-settings-override-test",
+				settings: {
+					ROUTE_POLICY: '{"default":"owner"}',
+				},
+			} as Character,
+			settings: {
+				ROUTE_POLICY: '{"default":"guest"}',
+			},
+		});
+
+		expect(runtime.getSetting("ROUTE_POLICY")).toBe('{"default":"owner"}');
+	});
+
+	it("uses fresh constructor settings over DB-persisted agent settings on restart", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		const characterName = "runtime-settings-restart-test";
+		const firstRuntime = new AgentRuntime({
+			character: {
+				name: characterName,
+				bio: ["test"],
+				settings: {},
+			} as Character,
+			adapter,
+			settings: { FOO: "v1" },
+			logLevel: "fatal",
+		});
+
+		let secondRuntime: AgentRuntime | undefined;
+		try {
+			await firstRuntime.initialize({ skipMigrations: true });
+			expect(firstRuntime.getSetting("FOO")).toBe("v1");
+			await adapter.updateAgents([
+				{
+					agentId: firstRuntime.agentId,
+					agent: {
+						settings: { FOO: "v1", secrets: { BAR: "v1" } },
+						secrets: { BAZ: "v1" },
+					},
+				},
+			]);
+
+			secondRuntime = new AgentRuntime({
+				character: {
+					name: characterName,
+					bio: ["test"],
+					settings: {},
+				} as Character,
+				adapter,
+				settings: { FOO: "v2", BAR: "v2", BAZ: "v2" },
+				logLevel: "fatal",
+			});
+			await secondRuntime.initialize({ skipMigrations: true });
+
+			expect(secondRuntime.getSetting("FOO")).toBe("v2");
+			expect(secondRuntime.getSetting("BAR")).toBe("v2");
+			expect(secondRuntime.getSetting("BAZ")).toBe("v2");
+		} finally {
+			await firstRuntime.stop({ fast: true });
+			await secondRuntime?.stop({ fast: true });
+			firstRuntime.promptBatcher.dispose();
+			secondRuntime?.promptBatcher.dispose();
+		}
 	});
 });
 

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -2403,8 +2403,51 @@ export class AgentRuntime implements IAgentRuntime {
 		// Merge DB-persisted settings back into runtime character
 		// This ensures settings from previous runs are available
 		if (existingAgent.settings) {
+			const dbSettings = isPlainObject(existingAgent.settings)
+				? existingAgent.settings
+				: {};
+			const dbExtraSettings = isPlainObject(dbSettings.extra)
+				? dbSettings.extra
+				: {};
+			const dbSettingsSecrets = isPlainObject(dbSettings.secrets)
+				? dbSettings.secrets
+				: {};
+			const characterSettings = isPlainObject(this.character.settings)
+				? this.character.settings
+				: {};
+			const characterExtraSettings = isPlainObject(characterSettings.extra)
+				? characterSettings.extra
+				: {};
+			const characterSettingsSecrets = isPlainObject(characterSettings.secrets)
+				? characterSettings.secrets
+				: {};
+			const characterSecrets =
+				this.character.secrets && typeof this.character.secrets === "object"
+					? this.character.secrets
+					: {};
+			const dbSettingsWithRuntimeOverrides = { ...existingAgent.settings };
+
+			for (const key of Object.keys(this.settings)) {
+				const runtimeValue = this.getRuntimeSettingValue(key);
+				if (runtimeValue === undefined) {
+					continue;
+				}
+
+				const hasDbValue =
+					Object.hasOwn(dbSettings, key) || Object.hasOwn(dbExtraSettings, key);
+				const hasCharacterValue =
+					Object.hasOwn(characterSettings, key) ||
+					Object.hasOwn(characterExtraSettings, key) ||
+					Object.hasOwn(characterSettingsSecrets, key) ||
+					Object.hasOwn(characterSecrets, key);
+
+				if (hasDbValue && !hasCharacterValue) {
+					dbSettingsWithRuntimeOverrides[key] = runtimeValue;
+				}
+			}
+
 			this.character.settings = {
-				...existingAgent.settings,
+				...dbSettingsWithRuntimeOverrides,
 				...this.character.settings, // Character file overrides DB
 			};
 
@@ -2414,27 +2457,34 @@ export class AgentRuntime implements IAgentRuntime {
 				existingAgent.secrets && typeof existingAgent.secrets === "object"
 					? existingAgent.secrets
 					: {};
-			const dbSettingsSecrets =
-				existingAgent.settings.secrets &&
-				typeof existingAgent.settings.secrets === "object"
-					? existingAgent.settings.secrets
-					: {};
-			const settingsSecrets =
-				this.character.settings.secrets &&
-				typeof this.character.settings.secrets === "object"
-					? this.character.settings.secrets
-					: {};
-			const characterSecrets =
-				this.character.secrets && typeof this.character.secrets === "object"
-					? this.character.secrets
-					: {};
+			const runtimeSecretOverrides: Record<string, string | boolean | number> =
+				{};
+
+			for (const key of Object.keys(this.settings)) {
+				const runtimeValue = this.getRuntimeSettingValue(key);
+				if (runtimeValue === undefined) {
+					continue;
+				}
+
+				const hasDbSecret =
+					Object.hasOwn(dbSecrets, key) ||
+					Object.hasOwn(dbSettingsSecrets, key);
+				const hasCharacterSecret =
+					Object.hasOwn(characterSecrets, key) ||
+					Object.hasOwn(characterSettingsSecrets, key);
+
+				if (hasDbSecret && !hasCharacterSecret) {
+					runtimeSecretOverrides[key] = runtimeValue;
+				}
+			}
 
 			// Merge into both locations that getSetting() checks
 			const mergedSecrets = {
 				...dbSecrets,
 				...dbSettingsSecrets,
+				...runtimeSecretOverrides,
 				...characterSecrets,
-				...settingsSecrets, // settings.secrets has priority
+				...characterSettingsSecrets, // character settings.secrets has priority
 			};
 
 			if (Object.keys(mergedSecrets).length > 0) {
@@ -2723,6 +2773,20 @@ export class AgentRuntime implements IAgentRuntime {
 		return undefined;
 	}
 
+	private getRuntimeSettingValue(
+		key: string,
+	): string | boolean | number | undefined {
+		const value = this.settings[key];
+		if (
+			typeof value === "string" ||
+			typeof value === "boolean" ||
+			typeof value === "number"
+		) {
+			return value;
+		}
+		return undefined;
+	}
+
 	getSetting(key: string): string | boolean | number | null {
 		const settings = this.character.settings;
 		const secrets = this.character.secrets;
@@ -2752,7 +2816,7 @@ export class AgentRuntime implements IAgentRuntime {
 			extraSettings?.[key] ??
 			nestedSecrets?.[key] ??
 			this.getCharacterEnvSetting(key) ??
-			this.settings[key];
+			this.getRuntimeSettingValue(key);
 
 		// Handle each type appropriately
 		if (value === undefined || value === null) {


### PR DESCRIPTION
## Summary

Fixes #10818.

This updates `AgentRuntime.initialize()` so DB-persisted agent settings are still merged into the runtime, but a fresh constructor/runtime `settings` value wins when the only conflicting value came from the existing DB row. Explicit character-file settings and character secrets continue to take precedence, preserving per-agent configuration behavior.

## Root Cause

`initialize()` merged `existingAgent.settings` into `character.settings`, while `getSetting()` only checked constructor `settings` as the final fallback. Once a key existed in the persisted agent row, it could shadow new constructor/env-forwarded values on subsequent boots.

## Validation

- `bunx @biomejs/biome check packages/core/src/runtime.ts packages/core/src/__tests__/runtime-settings.test.ts .github/issue-evidence/10818-runtime-settings-precedence.md`
- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/core test -- runtime-settings.test.ts`
- `bun run --cwd packages/core build:node`
- `bun run verify` attempted; currently blocked before package checks by the existing repo-wide type-safety ratchet (`as unknown as` and `?? 0` baselines), unrelated to this change.

Evidence: `.github/issue-evidence/10818-runtime-settings-precedence.md`
