### PR TITLE
feat(orchestrator): ViewKind contract in the generated economics SKILLS.md (#8917)

### DIFF
--- a/.github/issue-evidence/8917-viewkind-skills-manifest/README.md
+++ b/.github/issue-evidence/8917-viewkind-skills-manifest/README.md
@@ -1,0 +1,62 @@
+# #8917 — ViewKind contract for sub-agents + min-plugin template
+
+**Branch:** `feat/8917-viewkind-skills-manifest` (off `develop`)
+
+## What #8917 asked for
+
+1. `VIEW_KIND_CONTRACT` section in the min-plugin `SCAFFOLD.md` + guidance on the
+   template's view entry.
+2. A viewKind rule line in `buildCreatePrompt`.
+3. **A ViewKind section in the economics SKILLS.md** so Cloud-deployed views are
+   correctly categorized.
+
+## State before this PR (measured on `develop`)
+
+- (1) `min-plugin/SCAFFOLD.md` §"View kind" — **already merged** (PR #8962). The
+  min-plugin template ships no `views` entry by design (README: "one provider,
+  no UI"), so the guidance lives in SCAFFOLD.md rather than a template field.
+- (2) `views-create.ts:461` `viewKindRule` — **already merged** (PR #8962),
+  covered by `views-create.viewkind.test.ts` (3 tests, green).
+- (3) **The economics SKILLS.md had no ViewKind content.** That SKILLS.md is the
+  *generated* manifest the orchestrator writes to `workdir/SKILLS.md` for
+  economics-profile tasks (`orchestrator-task-service.ts` →
+  `buildSkillsManifest`). This was the only remaining gap.
+
+## What this PR adds
+
+- `skill-manifest.ts` gains an opt-in `includeViewKindContract` option that
+  appends a "View kind" section documenting all four kinds (`release` default /
+  `preview` / `developer` / `system` — never `system` for a created view),
+  kept in sync with `resolveViewKind` (core default `release`).
+- `orchestrator-task-service.ts` sets `includeViewKindContract: true` at the
+  economics call site — the only production caller — so a Cloud-deploying
+  sub-agent sees the contract. The generic manifest stays clean (off by default).
+
+## Evidence in this folder
+
+- `generated-economics-SKILLS.md` — the **actual** manifest produced by
+  `buildSkillsManifest(..., { includeViewKindContract: true })` (same options the
+  economics call site uses). See the `## View kind` section (lines ~23-32).
+
+## Tests (green)
+
+- `skill-manifest.test.ts` — appends the ViewKind contract when the flag is set
+  (asserts all four kinds + `Do not use` + `resolves to release`); omits it by
+  default. **4 passed** (2 new).
+- `views-create.viewkind.test.ts` (merged slice) — **3 passed**, unchanged.
+
+Typecheck + Biome clean for touched files.
+
+## Note on the "developer" kind (issue ambiguity)
+
+The issue's scenario expects a sub-agent to be able to assign `viewKind:
+'developer'` for a dev-tooling view. The merged `viewKindRule` in
+`views-create.ts` steers sub-agents to `release`/`preview` and forbids `system`
+(silent on `developer`). This PR's SKILLS.md section documents `developer` as a
+real option (dev tooling), matching the issue intent, without changing the
+prompt's default steering.
+
+## Verdict
+
+`good` — the generated economics SKILLS.md now carries the ViewKind contract;
+the SCAFFOLD.md + buildCreatePrompt asks were already merged and remain green.

--- a/.github/issue-evidence/8917-viewkind-skills-manifest/generated-economics-SKILLS.md
+++ b/.github/issue-evidence/8917-viewkind-skills-manifest/generated-economics-SKILLS.md
@@ -1,0 +1,33 @@
+# Available skills
+
+These skills are installed or task-scoped in the parent agent. To use one, send a USE_SKILL request back via the parent (slug + optional args).
+
+Protocol: send a message to the parent of the form `USE_SKILL <slug> <json_args>` and the parent will execute the skill and return the result. The `<json_args>` portion is optional; omit it for skills that take no parameters or use defaults.
+
+## Recommended for this task
+
+- **Parent Eliza Agent** (`parent-agent`) — Task-scoped bridge for asking the running parent Eliza agent to use its loaded capabilities, actions, providers, connectors, and confirmation flow.
+  - Protocol: Use when workspace context is not enough and the parent agent should do something with its own capabilities. Examples: `USE_SKILL parent-agent {"request":"Find the next free 30 minute slot on my calendar"}`, `USE_SKILL parent-agent {"mode":"list-actions","query":"github"}`, `USE_SKILL parent-agent {"mode":"list-cloud-commands"}`, or `USE_SKILL parent-agent {"mode":"cloud-command","command":"apps.list"}`. Mutating, paid, or destructive Cloud commands require an explicit user yes on a follow-up turn (not LLM `confirmed`). For paid self-spend commands (e.g. `domains.buy`, `containers.create`), pass `params.spendEstimateUsd` (such as the price from `domains.check`) so they auto-authorize within the configured agent spend cap instead of stalling. To delegate part of your work to a NEW parallel sub-agent on this same task, use `USE_SKILL parent-agent {"mode":"spawn-sub-agent","task":"<instruction for the child>","label":"<optional name>"}` — it spawns a child sub-agent (bounded nesting depth) whose progress shows in this task's thread; keep working, do not block waiting on it.
+
+## All enabled skills
+
+_(none)_
+
+## Task-scoped broker skills
+
+These slugs are requestable only for this spawned task because the parent orchestrator allow-listed them.
+
+- **Parent Eliza Agent** (`parent-agent`) — Task-scoped bridge for asking the running parent Eliza agent to use its loaded capabilities, actions, providers, connectors, and confirmation flow.
+  - Protocol: Use when workspace context is not enough and the parent agent should do something with its own capabilities. Examples: `USE_SKILL parent-agent {"request":"Find the next free 30 minute slot on my calendar"}`, `USE_SKILL parent-agent {"mode":"list-actions","query":"github"}`, `USE_SKILL parent-agent {"mode":"list-cloud-commands"}`, or `USE_SKILL parent-agent {"mode":"cloud-command","command":"apps.list"}`. Mutating, paid, or destructive Cloud commands require an explicit user yes on a follow-up turn (not LLM `confirmed`). For paid self-spend commands (e.g. `domains.buy`, `containers.create`), pass `params.spendEstimateUsd` (such as the price from `domains.check`) so they auto-authorize within the configured agent spend cap instead of stalling. To delegate part of your work to a NEW parallel sub-agent on this same task, use `USE_SKILL parent-agent {"mode":"spawn-sub-agent","task":"<instruction for the child>","label":"<optional name>"}` — it spawns a child sub-agent (bounded nesting depth) whose progress shows in this task's thread; keep working, do not block waiting on it.
+
+## View kind (if you ship a view)
+
+Any `Plugin.views` entry you create must set `viewKind` so the shell categorizes it correctly. The four kinds:
+
+- `release` — a finished, public, production-ready view. **This is the default** for a user-facing view; omitting `viewKind` resolves to `release`.
+- `preview` — unfinished/experimental; hidden until the user enables it in Settings.
+- `developer` — dev tooling (logs, DB inspectors, trajectory viewers); shown in dev builds, hidden in production until enabled.
+- `system` — reserved for built-in core views. **Do not use** for a view you create.
+
+Pick `release` for anything you intend users to see, `preview` while it is still rough, and `developer` for an inspector/diagnostic surface.
+

--- a/plugins/plugin-agent-orchestrator/src/__tests__/skill-manifest.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/skill-manifest.test.ts
@@ -72,4 +72,30 @@ describe("buildSkillsManifest", () => {
     expect(manifest.markdown).toContain("Build Monetized App");
     expect(manifest.markdown).not.toContain("Disabled");
   });
+
+  it("appends the ViewKind contract when includeViewKindContract is set (#8917)", async () => {
+    const manifest = await buildSkillsManifest(createRuntime(), {
+      recommendedSlugs: [PARENT_AGENT_BROKER_SLUG],
+      virtualSkills: [PARENT_AGENT_BROKER_MANIFEST_ENTRY],
+      includeViewKindContract: true,
+    });
+
+    expect(manifest.markdown).toContain("## View kind");
+    expect(manifest.markdown).toContain("`release`");
+    expect(manifest.markdown).toContain("`preview`");
+    expect(manifest.markdown).toContain("`developer`");
+    expect(manifest.markdown).toContain("`system`");
+    expect(manifest.markdown).toContain("Do not use");
+    // Default resolution is documented so an omitted viewKind is unambiguous.
+    expect(manifest.markdown).toContain("resolves to `release`");
+  });
+
+  it("omits the ViewKind contract from the generic manifest by default (#8917)", async () => {
+    const manifest = await buildSkillsManifest(createRuntime(), {
+      virtualSkills: [PARENT_AGENT_BROKER_MANIFEST_ENTRY],
+    });
+
+    // The generic manifest must stay clean — ViewKind is app-build-only.
+    expect(manifest.markdown).not.toContain("View kind");
+  });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -2569,6 +2569,9 @@ export class OrchestratorTaskService extends Service {
         const manifest = await buildSkillsManifest(this.runtime, {
           recommendedSlugs: ["build-monetized-app", "eliza-cloud"],
           virtualSkills: [{ ...PARENT_AGENT_BROKER_MANIFEST_ENTRY }],
+          // Economics tasks may deploy Cloud views — teach the sub-agent the
+          // ViewKind contract so views are categorized correctly. (#8917)
+          includeViewKindContract: true,
         });
         await writeFile(join(workdir, "SKILLS.md"), manifest.markdown, "utf8");
       } catch (err) {

--- a/plugins/plugin-agent-orchestrator/src/services/skill-manifest.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/skill-manifest.ts
@@ -48,6 +48,13 @@ export interface BuildSkillsManifestOptions {
   recommendedSlugs?: string[];
   /** Additional task-scoped skills handled by the orchestrator bridge. */
   virtualSkills?: ManifestSkillEntry[];
+  /**
+   * Append a "View kind" contract section so a Cloud-deploying sub-agent
+   * categorizes any `Plugin.views` entry it ships (release default / preview /
+   * developer; never system). Only relevant to app-building / economics tasks,
+   * so it is opt-in and off by default for the generic manifest. (#8917)
+   */
+  includeViewKindContract?: boolean;
 }
 
 export interface SkillsManifestResult {
@@ -84,10 +91,32 @@ function renderEntries(entries: ManifestSkillEntry[]): string {
     .join("\n");
 }
 
+/**
+ * The ViewKind taxonomy a Cloud-deploying sub-agent must set on any view it
+ * ships. Kept in sync with `resolveViewKind` in
+ * `packages/core/src/types/view-kind.ts` (default `release`). (#8917)
+ */
+function renderViewKindContract(): string[] {
+  return [
+    "## View kind (if you ship a view)",
+    "",
+    "Any `Plugin.views` entry you create must set `viewKind` so the shell categorizes it correctly. The four kinds:",
+    "",
+    "- `release` — a finished, public, production-ready view. **This is the default** for a user-facing view; omitting `viewKind` resolves to `release`.",
+    "- `preview` — unfinished/experimental; hidden until the user enables it in Settings.",
+    "- `developer` — dev tooling (logs, DB inspectors, trajectory viewers); shown in dev builds, hidden in production until enabled.",
+    "- `system` — reserved for built-in core views. **Do not use** for a view you create.",
+    "",
+    "Pick `release` for anything you intend users to see, `preview` while it is still rough, and `developer` for an inspector/diagnostic surface.",
+    "",
+  ];
+}
+
 function renderManifest(
   recommended: ManifestSkillEntry[],
   available: ManifestSkillEntry[],
   virtualSkills: ManifestSkillEntry[],
+  includeViewKindContract = false,
 ): string {
   const lines: string[] = [];
   lines.push("# Available skills");
@@ -123,6 +152,10 @@ function renderManifest(
     lines.push(renderEntries(virtualSkills));
     lines.push("");
   }
+
+  if (includeViewKindContract) {
+    lines.push(...renderViewKindContract());
+  }
   return lines.join("\n");
 }
 
@@ -154,7 +187,12 @@ export async function buildSkillsManifest(
       .map((slug) => virtualBySlug.get(slug))
       .filter((entry): entry is ManifestSkillEntry => Boolean(entry));
     return {
-      markdown: renderManifest(recommendedVirtualEntries, [], virtualEntries),
+      markdown: renderManifest(
+        recommendedVirtualEntries,
+        [],
+        virtualEntries,
+        opts.includeViewKindContract ?? false,
+      ),
       slugs: virtualEntries.map((entry) => entry.slug),
     };
   }
@@ -203,6 +241,7 @@ export async function buildSkillsManifest(
       recommendedEntries,
       availableEntries,
       virtualEntries,
+      opts.includeViewKindContract ?? false,
     ),
     slugs: dedupedSlugs,
   };


### PR DESCRIPTION
## Summary

Closes #8917.

The min-plugin `SCAFFOLD.md` §"View kind" guidance and the `views-create` `buildCreatePrompt` `viewKindRule` already landed in #8962. The remaining ask — **a ViewKind section in the economics SKILLS.md** — was missing. That SKILLS.md is the *generated* manifest the orchestrator writes to `workdir/SKILLS.md` for economics-profile tasks (`orchestrator-task-service.ts` → `buildSkillsManifest`), so a Cloud-deploying sub-agent never saw the ViewKind taxonomy.

## Changes

- `skill-manifest.ts` — opt-in `includeViewKindContract` option appends a "View kind" section documenting all four kinds (`release` default / `preview` / `developer` / never `system`), kept in sync with `resolveViewKind` (core default `release`).
- `orchestrator-task-service.ts` — sets `includeViewKindContract: true` at the economics call site (the only production caller of `buildSkillsManifest`); the generic sub-agent manifest stays clean.

## Tests

- `skill-manifest.test.ts` — renders the ViewKind contract when the flag is set (asserts all four kinds + "Do not use" + "resolves to `release`") and omits it by default (**4 passed**, 2 new).
- `views-create.viewkind.test.ts` (merged slice) — **3 passed**, unchanged.

Typecheck + Biome clean for touched files.

## Evidence

`.github/issue-evidence/8917-viewkind-skills-manifest/generated-economics-SKILLS.md` — the **actual** manifest produced with the same options the economics call site uses; see the `## View kind` section.

| Evidence | Status |
| --- | --- |
| Domain artifact (generated SKILLS.md) | ✅ committed |
| Unit tests | ✅ 4 passed |
| Real-LLM trajectory | N/A — deterministic manifest generation; no model/prompt behavior change. The issue's "sub-agent assigns viewKind in a scenario" AC depends on a live economics task run; the contract is now present in the manifest the sub-agent reads. |

Note on `developer`: the issue expects a sub-agent to be able to pick `viewKind: 'developer'`. The merged `viewKindRule` steers `release`/`preview` and forbids `system` (silent on `developer`); this PR's SKILLS.md documents `developer` as a real dev-tooling option, matching the issue intent, without changing the prompt's default steering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
