### PR TITLE
fix(ui/first-run): hybrid 'Local + Eliza Cloud inference' onboarding dead-ends silently on login cancel (#10836)

### DIFF
--- a/packages/ui/src/first-run/use-first-run-conductor.test.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import type { ConversationMessage } from "../api";
+import { surfaceCloudLoginRetryTurn } from "./use-first-run-conductor";
+
+function applyRetry(existing: ConversationMessage[]): ConversationMessage[] {
+  let messages = [...existing];
+  surfaceCloudLoginRetryTurn({
+    seedTurn(turn) {
+      messages = messages.some((message) => message.id === turn.id)
+        ? messages
+        : [...messages, turn];
+    },
+    replaceTurn(id, next) {
+      messages = messages.map((message) =>
+        message.id === id ? next : message,
+      );
+    },
+  });
+  return messages;
+}
+
+describe("surfaceCloudLoginRetryTurn", () => {
+  it("adds the cloud OAuth retry turn when the hybrid path never seeded one", () => {
+    const messages = applyRetry([
+      {
+        id: "first-run:provider",
+        role: "assistant",
+        text: "Which model provider should Eliza use?",
+        timestamp: 1,
+        source: "first_run",
+      },
+    ]);
+
+    expect(messages.map((message) => message.id)).toEqual([
+      "first-run:provider",
+      "first-run:cloud-oauth",
+    ]);
+    expect(messages[1]?.secretRequest?.status).toBe("failed");
+    expect(messages[1]?.secretRequest?.form?.kind).toBe("oauth");
+    expect(messages[1]?.text).toContain("Connect your Eliza Cloud account");
+  });
+
+  it("replaces the existing cloud OAuth turn on the managed-cloud path", () => {
+    const messages = applyRetry([
+      {
+        id: "first-run:cloud-oauth",
+        role: "assistant",
+        text: "Connecting your Eliza Cloud account...",
+        timestamp: 1,
+        source: "first_run",
+        secretRequest: {
+          key: "elizacloud",
+          reason: "Connect your Eliza Cloud account",
+          status: "pending",
+          form: {
+            type: "sensitive_request_form",
+            kind: "oauth",
+            mode: "cloud_authenticated_link",
+            fields: [],
+            submitLabel: "Connect Eliza Cloud",
+            provider: "elizacloud",
+            authorizationUrl: "https://example.test",
+          },
+        },
+      },
+    ]);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.id).toBe("first-run:cloud-oauth");
+    expect(messages[0]?.secretRequest?.status).toBe("failed");
+    expect(messages[0]?.text).toContain("then pick Eliza Cloud again");
+  });
+});

--- a/packages/ui/src/first-run/use-first-run-conductor.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.ts
@@ -323,22 +323,29 @@ export function useFirstRunConductor(): void {
             outcome.agents.map((a) => ({ id: a.agent_id, name: a.agent_name })),
           );
           return;
-        case "needs-cloud-login":
-          replaceTurn(
+        case "needs-cloud-login": {
+          // Surface the "Connect Eliza Cloud" widget so the user can re-auth.
+          // seedTurn ADDS the turn if this path never created it — the hybrid
+          // "Local + Eliza Cloud inference" provider path never seeds a
+          // cloud-oauth turn, unlike the runtime:cloud path — then replaceTurn
+          // sets the failed/connect state. Without the seed, replaceTurn is a
+          // no-op and onboarding dead-ends silently (no widget, no error, no
+          // status) with recovery only via app restart (#10836).
+          const connectTurn = makeTurn(
             "first-run:cloud-oauth",
-            makeTurn(
-              "first-run:cloud-oauth",
-              "Connect your Eliza Cloud account to continue, then pick Eliza Cloud again.",
-              { secretRequest: cloudOAuthSecretRequest("failed") },
-            ),
+            "Connect your Eliza Cloud account to continue, then pick Eliza Cloud again.",
+            { secretRequest: cloudOAuthSecretRequest("failed") },
           );
+          seedTurn(connectTurn);
+          replaceTurn("first-run:cloud-oauth", connectTurn);
           return;
+        }
         case "error":
           seedError(outcome.message);
           return;
       }
     },
-    [seedTutorial, seedCloudAgentChoice, replaceTurn, seedError],
+    [seedTutorial, seedCloudAgentChoice, seedTurn, replaceTurn, seedError],
   );
 
   const handleFirstRunAction = React.useCallback(

--- a/packages/ui/src/first-run/use-first-run-conductor.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.ts
@@ -141,6 +141,21 @@ function cloudOAuthSecretRequest(
   };
 }
 
+interface FirstRunTurnWriter {
+  seedTurn(turn: ConversationMessage): void;
+  replaceTurn(id: string, next: ConversationMessage): void;
+}
+
+export function surfaceCloudLoginRetryTurn(writer: FirstRunTurnWriter): void {
+  const connectTurn = makeTurn(
+    "first-run:cloud-oauth",
+    "Connect your Eliza Cloud account to continue, then pick Eliza Cloud again.",
+    { secretRequest: cloudOAuthSecretRequest("failed") },
+  );
+  writer.seedTurn(connectTurn);
+  writer.replaceTurn("first-run:cloud-oauth", connectTurn);
+}
+
 export function useFirstRunConductor(): void {
   const {
     firstRunComplete,
@@ -324,20 +339,7 @@ export function useFirstRunConductor(): void {
           );
           return;
         case "needs-cloud-login": {
-          // Surface the "Connect Eliza Cloud" widget so the user can re-auth.
-          // seedTurn ADDS the turn if this path never created it — the hybrid
-          // "Local + Eliza Cloud inference" provider path never seeds a
-          // cloud-oauth turn, unlike the runtime:cloud path — then replaceTurn
-          // sets the failed/connect state. Without the seed, replaceTurn is a
-          // no-op and onboarding dead-ends silently (no widget, no error, no
-          // status) with recovery only via app restart (#10836).
-          const connectTurn = makeTurn(
-            "first-run:cloud-oauth",
-            "Connect your Eliza Cloud account to continue, then pick Eliza Cloud again.",
-            { secretRequest: cloudOAuthSecretRequest("failed") },
-          );
-          seedTurn(connectTurn);
-          replaceTurn("first-run:cloud-oauth", connectTurn);
+          surfaceCloudLoginRetryTurn({ seedTurn, replaceTurn });
           return;
         }
         case "error":


### PR DESCRIPTION
Fixes #10836.

## Bug
On the hybrid **"Local + Eliza Cloud inference"** onboarding path (runtime `On this device` / `Bring your own keys` → provider `Eliza Cloud inference`), `finishLocal` calls `handleCloudLogin`. If the Steward login is **cancelled or fails to verify**, it returns `{kind:'needs-cloud-login'}`, and `handleOutcome` calls `replaceTurn('first-run:cloud-oauth', …)`. But `replaceTurn` only rewrites an **existing** message id, and the `first-run:cloud-oauth` turn is seeded **only on the `runtime:cloud` path** — never on the local/hybrid provider path. So the map matches nothing: no OAuth widget, no error text, no status → **silent dead-end**, recoverable only by restarting the app. (`handleCloudLogin` swallows the error and no component renders `elizaCloudLoginError`, so the login layer gives no feedback either.)

## Fix
In `handleOutcome`'s `needs-cloud-login` case, `seedTurn` the connect widget (idempotent append) **before** `replaceTurn`, so the "Connect your Eliza Cloud account" widget appears regardless of which path arrived here. The `runtime:cloud` path is unchanged (`seedTurn` no-ops when the turn already exists; `replaceTurn` then sets the failed/connect state exactly as before). One added dep (`seedTurn`).

## Evidence
- **Confirmed by an adversarial audit with a full hand-traced code path** — the ChoiceWidget locks after first tap, `handleCloudLogin` doesn't re-throw, `replaceTurn` no-ops, and no component renders `elizaCloudLoginError` → silent stall. See #10836.
- `tsgo` typecheck: clean.
- **N/A for now — conductor-hook / onboarding e2e test + rendered walkthrough:** there is no existing `use-first-run-conductor` test harness (the hook drives many ports: `runFirstRunFinish`, `listOrAutoProvisionCloudAgent`, secret-request widgets), and rendered onboarding capture needs an app boot. Flagging as a fast-follow rather than ship a shallow mock; the fix itself is a 2-line seed-then-replace on the existing idempotent `seedTurn` helper. Happy to add the e2e (`packages/ui` has an onboarding `__e2e__` runner) or pair.
