### PR TITLE
fix(cloud/apps): don't refund a fully-delivered app-chat stream when post-stream accounting throws (#10837)

### DIFF
--- a/packages/cloud/api/__tests__/apps-chat-stream-refund.test.ts
+++ b/packages/cloud/api/__tests__/apps-chat-stream-refund.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Money-leak guard for POST /api/v1/apps/:id/chat streaming (#10837).
+ *
+ * A streaming app-chat reserves credits up front, forwards the whole provider
+ * response, closes the writer, and only THEN runs calculateCost +
+ * reconcileCredits. Before this fix, if that post-stream accounting threw (a
+ * transient DB/pricing error), the catch unconditionally full-refunded — free
+ * inference, systemically so across concurrent streams during a DB blip.
+ *
+ * This drives the REAL `reconcileStreamProcessingError` (the exact code the
+ * route runs) against a spy credit service, asserting the refund decision.
+ */
+import { describe, expect, mock, test } from "bun:test";
+import {
+  reconcileStreamProcessingError,
+  type StreamRefundCredits,
+} from "../v1/apps/[id]/chat/stream-refund";
+
+function makeCredits() {
+  const calls: Array<{ estimatedBaseCost: number; actualBaseCost: number }> =
+    [];
+  const reconcileCredits = mock(
+    async (args: { estimatedBaseCost: number; actualBaseCost: number }) => {
+      calls.push({
+        estimatedBaseCost: args.estimatedBaseCost,
+        actualBaseCost: args.actualBaseCost,
+      });
+      return null;
+    },
+  );
+  return { calls, reconcileCredits } satisfies {
+    calls: unknown;
+    reconcileCredits: StreamRefundCredits["reconcileCredits"];
+  };
+}
+
+const base = {
+  appId: "app-1",
+  userId: "user-1",
+  reservedBaseCost: 0.05,
+  errorMessage: "transient pg timeout",
+};
+
+describe("reconcileStreamProcessingError (#10837)", () => {
+  test("stream COMPLETED then accounting threw → keep the reserved charge, NO refund", async () => {
+    const credits = makeCredits();
+    const result = await reconcileStreamProcessingError(
+      { ...base, streamCompleted: true },
+      credits,
+    );
+    expect(result.refunded).toBe(false);
+    expect(credits.reconcileCredits).not.toHaveBeenCalled();
+    expect(credits.calls).toEqual([]);
+  });
+
+  test("stream FAILED before delivery → full refund (actualBaseCost 0)", async () => {
+    const credits = makeCredits();
+    const result = await reconcileStreamProcessingError(
+      { ...base, streamCompleted: false },
+      credits,
+    );
+    expect(result.refunded).toBe(true);
+    expect(credits.reconcileCredits).toHaveBeenCalledTimes(1);
+    expect(credits.calls[0]).toEqual({
+      estimatedBaseCost: 0.05,
+      actualBaseCost: 0,
+    });
+  });
+
+  test("DB blip across 20 concurrent COMPLETED streams issues ZERO refunds (systemic-leak guard)", async () => {
+    const credits = makeCredits();
+    const results = await Promise.all(
+      Array.from({ length: 20 }, (_, i) =>
+        reconcileStreamProcessingError(
+          { ...base, userId: `user-${i}`, streamCompleted: true },
+          credits,
+        ),
+      ),
+    );
+    expect(results.every((r) => r.refunded === false)).toBe(true);
+    expect(credits.reconcileCredits).not.toHaveBeenCalled();
+  });
+
+  test("mixed batch: only the pre-delivery failures are refunded", async () => {
+    const credits = makeCredits();
+    await Promise.all([
+      reconcileStreamProcessingError(
+        { ...base, streamCompleted: true },
+        credits,
+      ),
+      reconcileStreamProcessingError(
+        { ...base, streamCompleted: false },
+        credits,
+      ),
+      reconcileStreamProcessingError(
+        { ...base, streamCompleted: true },
+        credits,
+      ),
+      reconcileStreamProcessingError(
+        { ...base, streamCompleted: false },
+        credits,
+      ),
+    ]);
+    // 2 delivered (no refund) + 2 pre-delivery failures (refund) = exactly 2 refunds.
+    expect(credits.reconcileCredits).toHaveBeenCalledTimes(2);
+    expect(credits.calls.every((c) => c.actualBaseCost === 0)).toBe(true);
+  });
+});

--- a/packages/cloud/api/v1/apps/[id]/chat/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/chat/route.ts
@@ -44,6 +44,7 @@ import { appsService } from "@/lib/services/apps";
 import { logger } from "@/lib/utils/logger";
 import { getRouteTimeoutMs } from "@/lib/utils/request-timeout";
 import type { AppEnv } from "@/types/cloud-worker-env";
+import { reconcileStreamProcessingError } from "./stream-refund";
 
 const ROUTE_MAX_DURATION = 800;
 
@@ -408,6 +409,11 @@ async function handlePOST(
       let outputTokens = 0;
       let fullContent = "";
       let writerClosed = false;
+      // True once the FULL answer has been delivered to the client and the
+      // writer closed. Distinguishes "stream failed mid-delivery" (refund) from
+      // "stream succeeded, only post-stream accounting threw" (do NOT refund —
+      // the user already received the whole answer).
+      let streamCompleted = false;
 
       // Process stream in background with error handling
       (async () => {
@@ -523,6 +529,9 @@ async function handlePOST(
 
           writerClosed = true;
           writer.close();
+          // The client has now received the complete answer. Anything that
+          // throws below is post-delivery accounting only — must not refund.
+          streamCompleted = true;
 
           // Fallback: estimate tokens if usage not provided
           if (inputTokens === 0 && outputTokens === 0) {
@@ -587,30 +596,27 @@ async function handlePOST(
             },
           });
         } catch (error) {
-          // Stream failed - refund the reserved charge since we don't know actual usage
           const errorMessage =
             error instanceof Error ? error.message : "Unknown error";
-          logger.error(
-            "[App Chat] Stream processing failed, refunding reserved",
+
+          // Refund the reserved charge ONLY when the stream failed before the
+          // client got the full answer. If it already completed and only the
+          // post-stream accounting threw, keeping the charge avoids handing out
+          // free inference. (See reconcileStreamProcessingError.)
+          const { refunded } = await reconcileStreamProcessingError(
             {
+              streamCompleted,
               appId,
               userId: user.id,
               reservedBaseCost,
-              error: errorMessage,
+              errorMessage,
             },
+            appCreditsService,
           );
 
-          await appCreditsService.reconcileCredits({
-            appId,
-            userId: user.id,
-            estimatedBaseCost: reservedBaseCost,
-            actualBaseCost: 0, // Refund full reserved amount
-            description: "Refund due to stream error",
-            metadata: { error: true, streaming: true },
-          });
-
-          // Send error event to client if writer is still open
-          if (!writerClosed) {
+          // Notify the client only when the stream failed mid-delivery (a
+          // completed stream already closed the writer with the full answer).
+          if (refunded && !writerClosed) {
             const errorEvent = `data: ${JSON.stringify({
               error: {
                 message: "Stream interrupted. Credits refunded.",

--- a/packages/cloud/api/v1/apps/[id]/chat/stream-refund.ts
+++ b/packages/cloud/api/v1/apps/[id]/chat/stream-refund.ts
@@ -1,0 +1,70 @@
+import { logger } from "@/lib/utils/logger";
+
+/**
+ * The credit-reconcile surface {@link reconcileStreamProcessingError} needs.
+ * Structural so the helper (and its test) don't import the whole app-credits
+ * service or the DB it wires up. `appCreditsService` is assignable to this.
+ */
+export interface StreamRefundCredits {
+  reconcileCredits(args: {
+    appId: string;
+    userId: string;
+    estimatedBaseCost: number;
+    actualBaseCost: number;
+    description: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<unknown>;
+}
+
+/**
+ * Money-critical (#10837): on a streaming error, refund the upfront reservation
+ * ONLY when the client did NOT receive the full answer.
+ *
+ * A streaming app-chat request reserves credits up front (`deductCredits`), then
+ * forwards the whole provider response and closes the writer, and only THEN runs
+ * `calculateCost` + `reconcileCredits`. If that post-stream accounting throws
+ * (e.g. a transient Postgres / pricing-catalog error during a DB incident), the
+ * user has already received the entire answer — refunding the reservation would
+ * hand out FREE inference, and systemically so when the blip hits many
+ * concurrent streams at once.
+ *
+ * So we refund only when `streamCompleted` is false (the stream failed before
+ * delivery); when it is true we keep the reserved charge that `deductCredits`
+ * already applied. Returns whether a refund was issued so the caller notifies
+ * the client only in the mid-delivery-failure case.
+ */
+export async function reconcileStreamProcessingError(
+  params: {
+    streamCompleted: boolean;
+    appId: string;
+    userId: string;
+    reservedBaseCost: number;
+    errorMessage: string;
+  },
+  credits: StreamRefundCredits,
+): Promise<{ refunded: boolean }> {
+  const { streamCompleted, appId, userId, reservedBaseCost, errorMessage } =
+    params;
+
+  if (streamCompleted) {
+    logger.error(
+      "[App Chat] Post-stream accounting failed AFTER full delivery; keeping reserved charge (NOT refunding)",
+      { appId, userId, reservedBaseCost, error: errorMessage },
+    );
+    return { refunded: false };
+  }
+
+  logger.error(
+    "[App Chat] Stream processing failed before delivery, refunding reserved",
+    { appId, userId, reservedBaseCost, error: errorMessage },
+  );
+  await credits.reconcileCredits({
+    appId,
+    userId,
+    estimatedBaseCost: reservedBaseCost,
+    actualBaseCost: 0, // Refund full reserved amount
+    description: "Refund due to stream error",
+    metadata: { error: true, streaming: true },
+  });
+  return { refunded: true };
+}


### PR DESCRIPTION
Fixes #10837.

## The bug (money — free inference, systemic during a DB blip)
`POST /api/v1/apps/:id/chat` with `stream:true` reserves credits up front
(`deductCredits`), forwards the **entire** provider response, closes the writer
(the client now has the full answer), and only THEN runs `calculateCost` +
`reconcileCredits`. If that post-stream accounting throws — a transient
Postgres/pricing-catalog error during a DB incident — control fell into the
`catch`, which could not tell "stream failed mid-delivery" from "stream
succeeded, accounting threw" and unconditionally reconciled with
`actualBaseCost: 0` — a **full refund of a fully-delivered answer**. During a DB
blip this fires across many concurrent streams at once, so the loss is systemic.

## The fix
Track a `streamCompleted` flag, set only after the full answer is delivered and
the writer closed. On a stream error, refund **only** when the stream did *not*
complete; when it completed and only accounting threw, keep the reserved charge
`deductCredits` already applied. The decision lives in
`reconcileStreamProcessingError` (`stream-refund.ts`) so it is unit-tested
against the real `reconcileCredits` side effect.

## Not systemic elsewhere
The sibling streaming money routes (`v1/chat/completions`, `v1/messages`) use the
idempotent `createCreditReservationSettler` + `onError` pattern (first-call-wins,
"cannot double-refund") — they don't have this bug. This is specific to
apps-chat's raw-fetch-forward implementation.

## Tests / evidence
`packages/cloud/api/__tests__/apps-chat-stream-refund.test.ts` drives the real
helper (production code, not a mock of it) against a spy credit service:
- completed stream + accounting throws → **no refund**, reserved charge kept
- failed before delivery → full refund (`actualBaseCost: 0`)
- 20 concurrent completed streams during a blip → **zero** refunds (systemic-leak guard)
- mixed batch → only the pre-delivery failures refunded

**4 pass, 0 fail; 100% line+function coverage of the helper.** Route typechecks
clean (the only tsgo errors in the fresh worktree are missing generated
`core/src/i18n/generated/*` files — unrelated env artifact).

_Evidence note:_ a full live-stream E2E of the route would require booting the
Worker + a mock provider SSE stream + a simulated DB throw; this route has no
existing test harness, so I proved the money-critical decision via the extracted
real helper. Live end-to-end against `cloud:mock` = N/A here (no harness) — happy
to add one if preferred.
