### PR TITLE
fix(cloud): honor job max attempts during stale recovery

### DIFF
--- a/.github/issue-evidence/10854-stale-job-max-attempts.md
+++ b/.github/issue-evidence/10854-stale-job-max-attempts.md
@@ -1,0 +1,35 @@
+# #10854 stale job max_attempts evidence
+
+## Scenario
+
+The regression test seeds two `agent_message` jobs that are already stale:
+
+- `max_attempts = 1`, `attempts = 0`, `status = in_progress`
+- `max_attempts = 3`, `attempts = 0`, `status = in_progress`
+
+`jobsRepository.recoverStaleJobs({ type: "agent_message", staleThresholdMs: 5 * 60 * 1000, maxAttempts: 3 })`
+then runs against an in-process PGlite `jobs` table.
+
+## Expected proof
+
+- The single-attempt job becomes `failed`, `attempts = 1`.
+- The retryable job becomes `pending`, `attempts = 1`.
+- The recovered count is `1`, because only the retryable job is re-queued.
+
+This proves recovery uses each row's `max_attempts` instead of the caller-wide fallback.
+
+## Validation
+
+```bash
+bun test packages/cloud/shared/src/db/repositories/__tests__/jobs-recovery.test.ts packages/cloud/shared/src/lib/services/provisioning-jobs-stale-threshold.test.ts
+bun run biome check packages/cloud/shared/src/db/repositories/jobs.ts packages/cloud/shared/src/lib/services/provisioning-jobs.ts packages/cloud/shared/src/db/repositories/__tests__/jobs-recovery.test.ts
+bun run --cwd packages/cloud/shared typecheck
+```
+
+All passed locally on the exact PR branch.
+
+## N/A artifacts
+
+- Screenshots/video: N/A, backend repository retry-state fix only.
+- Frontend console/network logs: N/A, no frontend path.
+- Real-LLM trajectories: N/A, no model/action/prompt path.

--- a/packages/cloud/shared/src/db/repositories/__tests__/jobs-recovery.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/jobs-recovery.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Real-DB coverage for stale job recovery respecting each row's max_attempts.
+ *
+ * The provisioning daemon enqueues some non-idempotent jobs with max_attempts=1.
+ * If a worker dies while such a row is in_progress, stale recovery must fail it
+ * instead of re-queueing it under a generic service-level retry budget.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { jobs } from "../../schemas/jobs";
+
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS ||= "1";
+
+const PGLITE_TIMEOUT = 60_000;
+const ORG_ID = "00000000-0000-4000-8000-000000001854";
+
+let dbWrite: typeof import("../../client").dbWrite;
+let closeDb: typeof import("../../client").closeDatabaseConnectionsForTests | undefined;
+let repo: typeof import("../jobs").jobsRepository;
+let pgliteReady = true;
+
+async function seedJob(params: {
+  id: string;
+  maxAttempts: number;
+  attempts?: number;
+}): Promise<void> {
+  await dbWrite.execute(
+    `INSERT INTO jobs (
+			id,
+			type,
+			status,
+			data,
+			attempts,
+			max_attempts,
+			organization_id,
+			scheduled_for,
+			started_at,
+			created_at,
+			updated_at
+		)
+		VALUES (
+			'${params.id}',
+			'agent_message',
+			'in_progress',
+			'{}'::jsonb,
+			${params.attempts ?? 0},
+			${params.maxAttempts},
+			'${ORG_ID}',
+			NOW() - INTERVAL '10 minutes',
+			NOW() - INTERVAL '10 minutes',
+			NOW() - INTERVAL '10 minutes',
+			NOW() - INTERVAL '10 minutes'
+		);`,
+  );
+}
+
+beforeAll(async () => {
+  try {
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../client"));
+    ({ jobsRepository: repo } = await import("../jobs"));
+    await dbWrite.execute(
+      `CREATE TABLE IF NOT EXISTS jobs (
+				id uuid PRIMARY KEY,
+				type text NOT NULL,
+				status text NOT NULL DEFAULT 'pending',
+				data jsonb NOT NULL,
+				data_storage text NOT NULL DEFAULT 'inline',
+				data_key text,
+				agent_id text,
+				character_id text,
+				result jsonb,
+				result_storage text NOT NULL DEFAULT 'inline',
+				result_key text,
+				error text,
+				error_storage text NOT NULL DEFAULT 'inline',
+				error_key text,
+				attempts integer NOT NULL DEFAULT 0,
+				max_attempts integer NOT NULL DEFAULT 3,
+				organization_id uuid NOT NULL,
+				user_id uuid,
+				api_key_id uuid,
+				generation_id uuid,
+				webhook_url text,
+				webhook_status text,
+				estimated_completion_at timestamp,
+				scheduled_for timestamp NOT NULL DEFAULT now(),
+				started_at timestamp,
+				completed_at timestamp,
+				created_at timestamp NOT NULL DEFAULT now(),
+				updated_at timestamp NOT NULL DEFAULT now()
+			);`,
+    );
+  } catch (error) {
+    pgliteReady = false;
+    console.warn("[jobs-recovery] PGlite unavailable, skipping:", error);
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
+describe("jobsRepository.recoverStaleJobs", () => {
+  beforeEach(async () => {
+    if (!pgliteReady) return;
+    await dbWrite.execute("DELETE FROM jobs;");
+  });
+
+  test("uses each stale row's max_attempts instead of a caller-wide fallback", async () => {
+    if (!pgliteReady) return;
+    const singleAttemptJobId = "00000000-0000-4000-8000-000000010854";
+    const retryableJobId = "00000000-0000-4000-8000-000000020854";
+    await seedJob({ id: singleAttemptJobId, maxAttempts: 1 });
+    await seedJob({ id: retryableJobId, maxAttempts: 3 });
+
+    const recovered = await repo.recoverStaleJobs({
+      type: "agent_message",
+      staleThresholdMs: 5 * 60 * 1000,
+      maxAttempts: 3,
+    });
+
+    expect(recovered).toBe(1);
+    const rows = await dbWrite
+      .select({
+        id: jobs.id,
+        status: jobs.status,
+        attempts: jobs.attempts,
+        error: jobs.error,
+      })
+      .from(jobs)
+      .orderBy(jobs.id);
+
+    const singleAttempt = rows.find((row) => row.id === singleAttemptJobId);
+    const retryable = rows.find((row) => row.id === retryableJobId);
+    expect(singleAttempt).toMatchObject({
+      status: "failed",
+      attempts: 1,
+      error: "Job timed out 1 times - max attempts reached",
+    });
+    expect(retryable).toMatchObject({
+      status: "pending",
+      attempts: 1,
+      error: "Job timed out - recovered for retry (attempt 1/3)",
+    });
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/jobs.ts
+++ b/packages/cloud/shared/src/db/repositories/jobs.ts
@@ -391,7 +391,7 @@ export class JobsRepository {
     type: string;
     organizationId?: string;
     staleThresholdMs: number;
-    maxAttempts: number;
+    maxAttempts?: number;
   }): Promise<number> {
     const staleThreshold = new Date(Date.now() - filters.staleThresholdMs);
     const conditions = [
@@ -416,10 +416,11 @@ export class JobsRepository {
     // Process each stale job, incrementing attempts and failing if max reached
     for (const job of staleJobs) {
       const newAttempts = (job.attempts || 0) + 1;
-      const isFailed = newAttempts >= filters.maxAttempts;
+      const maxAttempts = job.max_attempts ?? filters.maxAttempts ?? 3;
+      const isFailed = newAttempts >= maxAttempts;
       const timeoutError = isFailed
         ? `Job timed out ${newAttempts} times - max attempts reached`
-        : `Job timed out - recovered for retry (attempt ${newAttempts}/${filters.maxAttempts})`;
+        : `Job timed out - recovered for retry (attempt ${newAttempts}/${maxAttempts})`;
 
       await dbWrite
         .update(jobs)

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -2868,7 +2868,6 @@ export class ProvisioningJobService {
         staleThresholdMs: COLD_BOOT_JOB_TYPES.has(jobType)
           ? COLD_BOOT_STALE_JOB_THRESHOLD_MS
           : DEFAULT_STALE_JOB_THRESHOLD_MS,
-        maxAttempts: 3,
       });
       totalRecovered += recovered;
     }


### PR DESCRIPTION
## Summary

- Fixes stale job recovery so each row's `max_attempts` controls whether recovery fails or requeues the job.
- Removes the provisioning service's hardcoded `maxAttempts: 3` recovery budget.
- Adds a real PGlite regression proving a stale `max_attempts=1` job is failed while a `max_attempts=3` job is re-queued.

## Root Cause

`ProvisioningJobService.recoverStaleJobs()` always passed `maxAttempts: 3`, and `jobsRepository.recoverStaleJobs()` used that caller-wide value for every stale row. Single-attempt jobs such as `AGENT_MESSAGE` and `AGENT_DOWNGRADE` could therefore be recovered back to `pending` after a worker death even though their row contract says they should never retry.

## Validation

- `bun run --cwd packages/core build` (required so cloud-shared plugin-sql imports resolve in the fresh worktree)
- `bun test packages/cloud/shared/src/db/repositories/__tests__/jobs-recovery.test.ts packages/cloud/shared/src/lib/services/provisioning-jobs-stale-threshold.test.ts`
- `bun run biome check packages/cloud/shared/src/db/repositories/jobs.ts packages/cloud/shared/src/lib/services/provisioning-jobs.ts packages/cloud/shared/src/db/repositories/__tests__/jobs-recovery.test.ts .github/issue-evidence/10854-stale-job-max-attempts.md`
- `bun run --cwd packages/cloud/shared typecheck`

Evidence: `.github/issue-evidence/10854-stale-job-max-attempts.md`

## Evidence Notes

- Screenshots/video: N/A, backend repository retry-state fix only.
- Frontend logs/network: N/A, no frontend path.
- Real-LLM trajectory: N/A, no model/action/prompt path.

Fixes #10854