### PR TITLE
fix(agent): route cloud image generation through image model

### DIFF
--- a/.github/issue-evidence/10819-cloud-image-generation.md
+++ b/.github/issue-evidence/10819-cloud-image-generation.md
@@ -1,0 +1,38 @@
+# 10819 Cloud Image Generation Evidence
+
+Issue: https://github.com/elizaOS/eliza/issues/10819
+
+## What Was Verified
+
+- Cloud-selected image generation in `AgentMediaGenerationService` routes through the registered `ModelType.IMAGE` handler instead of the removed direct Cloud image provider.
+- Own-key image generation still routes to the configured direct provider instead of the Cloud image model.
+- The stale agent-side `/media/image/generate` fetch path is removed from tracked source.
+- Direct own-key image/video/audio providers remain covered by the existing provider tests.
+- Missing Cloud image model registration fails with a clear "requires Eliza Cloud or a direct image provider" error.
+
+## Commands Run
+
+```bash
+bun install
+bunx biome check --write packages/agent/src/services/media-generation.ts packages/agent/src/services/media-generation.test.ts packages/agent/src/providers/media-provider.ts packages/agent/src/providers/media-provider.test.ts
+bunx vitest run --config packages/agent/vitest.config.ts packages/agent/src/providers/media-provider.test.ts packages/agent/src/services/media-generation.test.ts --coverage.enabled=false
+bunx vitest run --config packages/core/vitest.config.ts packages/core/src/features/advanced-capabilities/actions/generateMedia.test.ts --coverage.enabled=false
+rg -n "/media/image/generate|ElizaCloudImageProvider" packages/agent/src packages/core/src plugins/plugin-elizacloud/src packages/cloud/sdk/src packages/cloud/api/v1 || true
+bun run --cwd packages/agent typecheck
+bun run verify
+```
+
+## Results Reviewed
+
+- Post-rebase `bun install`: completed with no lockfile changes.
+- Agent focused Vitest: 2 test files passed, 17 tests passed.
+- Core action Vitest: 1 test file passed, 8 tests passed.
+- Source grep: no stale `/media/image/generate`, `media/image/generate`, or `ElizaCloudImageProvider` matches in tracked source paths.
+- `packages/agent` typecheck: blocked by pre-existing command-plugin export/type errors outside this change (`commands-routes`, `plugin-discord/catalog-commands`, `plugin-task-coordinator/orchestrator-command`). The new media-generation test type error found on the first run was fixed and did not recur.
+- Root `bun run verify`: blocked before package checks by the repo-wide type-safety ratchet (`?? 0` count 382 > baseline 380). The branch diff adds no `?? 0`, `as unknown as`, `: any`, or ts-ignore/expect-error patterns.
+
+## Evidence N/A / Deferred
+
+- UI screenshots/video: N/A, no UI changed.
+- Frontend logs/network: N/A, no frontend request path changed.
+- Live Cloud generation trajectory: not captured in this local pass because the shell has no `ELIZAOS_CLOUD_API_KEY`, `ANTHROPIC_API_KEY`, `CEREBRAS_API_KEY`, or `OPENAI_API_KEY` configured. The PR includes deterministic coverage proving the agent path now delegates to the existing plugin-elizacloud `ModelType.IMAGE` handler, which already uses `ElizaCloudClient.generateImage()`.

--- a/packages/agent/src/providers/media-provider.test.ts
+++ b/packages/agent/src/providers/media-provider.test.ts
@@ -3,6 +3,7 @@ import { ElizaSchema } from "../config/zod-schema";
 import {
   type AudioGenerationProvider,
   createAudioProvider,
+  createImageProvider,
   createVideoProvider,
   createVisionProvider,
 } from "./media-provider";
@@ -215,6 +216,66 @@ describe("media audio provider routing", () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/voiceId/);
+  });
+});
+
+describe("media image provider routing", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("does not expose a direct Eliza Cloud image fetch provider", () => {
+    expect(() =>
+      createImageProvider(undefined, {
+        cloudMediaDisabled: false,
+        elizaCloudApiKey: "eliza_cloud_key",
+        elizaCloudBaseUrl: "https://api.elizacloud.ai/api/v1",
+      }),
+    ).toThrow(/ModelType\.IMAGE/);
+  });
+
+  it("still creates configured own-key image providers", async () => {
+    const calls: FetchCall[] = [];
+    fakeMediaFetch(
+      Response.json({
+        images: [{ url: "https://cdn.example/fal-image.png" }],
+      }),
+      calls,
+    );
+
+    const provider = createImageProvider(
+      {
+        mode: "own-key",
+        provider: "fal",
+        fal: {
+          apiKey: "fal-key",
+          model: "fal-ai/flux-pro",
+          baseUrl: "https://fal.test",
+        },
+      },
+      { cloudMediaDisabled: false },
+    );
+
+    await expect(
+      provider.generate({
+        prompt: "glass lighthouse",
+        size: "square_hd",
+      }),
+    ).resolves.toEqual({
+      success: true,
+      data: {
+        imageUrl: "https://cdn.example/fal-image.png",
+      },
+    });
+    expect(calls[0].url).toBe("https://fal.test/fal-ai/flux-pro");
+    expect(calls[0].init?.headers).toMatchObject({
+      Authorization: "Key fal-key",
+    });
+    expect(calls[0].body).toMatchObject({
+      prompt: "glass lighthouse",
+      image_size: "square_hd",
+      num_images: 1,
+    });
   });
 });
 

--- a/packages/agent/src/providers/media-provider.ts
+++ b/packages/agent/src/providers/media-provider.ts
@@ -2,7 +2,7 @@
  * Media Provider Abstraction Layer
  *
  * Provides a single interface for media generation across multiple providers:
- * - Image Generation: FAL.ai, OpenAI (DALL-E), Google (Imagen), xAI, Eliza Cloud
+ * - Image Generation: FAL.ai, OpenAI (DALL-E), Google (Imagen), xAI
  * - Video Generation: FAL.ai, OpenAI (Sora), Google (Veo), Eliza Cloud
  * - Audio Generation: Suno, ElevenLabs (SFX), Eliza Cloud
  * - Vision (Analysis): OpenAI, Google, Anthropic, xAI, Eliza Cloud
@@ -297,57 +297,6 @@ export interface VisionAnalysisProvider {
 // ============================================================================
 // Eliza Cloud Provider Implementations
 // ============================================================================
-
-class ElizaCloudImageProvider implements ImageGenerationProvider {
-  name = "eliza-cloud";
-  private baseUrl: string;
-  private apiKey?: string;
-
-  constructor(baseUrl: string, apiKey?: string) {
-    this.baseUrl = baseUrl;
-    this.apiKey = apiKey;
-  }
-
-  async generate(
-    options: ImageGenerationOptions,
-  ): Promise<MediaProviderResult<ImageGenerationResult>> {
-    const response = await fetchWithTimeout(
-      `${this.baseUrl}/media/image/generate`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          ...(this.apiKey ? { Authorization: `Bearer ${this.apiKey}` } : {}),
-        },
-        body: JSON.stringify({
-          prompt: options.prompt,
-          size: options.size,
-          quality: options.quality,
-          style: options.style,
-        }),
-      },
-    );
-
-    if (!response.ok) {
-      const text = await response.text();
-      return { success: false, error: `Eliza Cloud error: ${text}` };
-    }
-
-    const data = (await response.json()) as {
-      imageUrl?: string;
-      imageBase64?: string;
-      revisedPrompt?: string;
-    };
-    return {
-      success: true,
-      data: {
-        imageUrl: data.imageUrl,
-        imageBase64: data.imageBase64,
-        revisedPrompt: data.revisedPrompt,
-      },
-    };
-  }
-}
 
 class ElizaCloudVideoProvider implements VideoGenerationProvider {
   name = "eliza-cloud";
@@ -1879,7 +1828,8 @@ export function createImageProvider(
   config: ImageConfig | undefined,
   options: MediaProviderFactoryOptions,
 ): ImageGenerationProvider {
-  const mode = config?.mode ?? (options.cloudMediaDisabled ? "local" : "cloud");
+  const mode =
+    config?.mode ?? (options.cloudMediaDisabled ? "own-key" : "cloud");
   const provider = mode === "cloud" ? "cloud" : (config?.provider ?? "cloud");
 
   switch (provider) {
@@ -1911,9 +1861,9 @@ export function createImageProvider(
         "Configure a direct provider (fal, openai, google, xai) or enable cloud media.",
     );
   }
-  return new ElizaCloudImageProvider(
-    options.elizaCloudBaseUrl ?? "https://elizacloud.ai/api/v1",
-    options.elizaCloudApiKey,
+  throw new Error(
+    "Cloud image generation is handled by the registered ModelType.IMAGE model. " +
+      "Enable @elizaos/plugin-elizacloud with ELIZAOS_CLOUD_API_KEY, or configure a direct provider (fal, openai, google, xai).",
   );
 }
 
@@ -1921,7 +1871,8 @@ export function createVideoProvider(
   config: VideoConfig | undefined,
   options: MediaProviderFactoryOptions,
 ): VideoGenerationProvider {
-  const mode = config?.mode ?? (options.cloudMediaDisabled ? "local" : "cloud");
+  const mode =
+    config?.mode ?? (options.cloudMediaDisabled ? "own-key" : "cloud");
   const provider = mode === "cloud" ? "cloud" : (config?.provider ?? "cloud");
 
   switch (provider) {
@@ -2101,7 +2052,8 @@ export function createVisionProvider(
   config: VisionConfig | undefined,
   options: MediaProviderFactoryOptions,
 ): VisionAnalysisProvider {
-  const mode = config?.mode ?? (options.cloudMediaDisabled ? "local" : "cloud");
+  const mode =
+    config?.mode ?? (options.cloudMediaDisabled ? "own-key" : "cloud");
   const provider = mode === "cloud" ? "cloud" : (config?.provider ?? "cloud");
 
   switch (provider) {

--- a/packages/agent/src/services/media-generation.test.ts
+++ b/packages/agent/src/services/media-generation.test.ts
@@ -1,4 +1,4 @@
-import type { IAgentRuntime } from "@elizaos/core";
+import { type IAgentRuntime, ModelType } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const configMock = vi.hoisted(() => ({
@@ -20,11 +20,22 @@ vi.mock("@elizaos/shared", async () => {
   };
 });
 
-function runtime(): IAgentRuntime {
-  return {} as IAgentRuntime;
+type RuntimeOverrides = Omit<
+  Partial<IAgentRuntime>,
+  "getModel" | "useModel"
+> & {
+  getModel?: (modelType: string) => ReturnType<IAgentRuntime["getModel"]>;
+  useModel?: (
+    modelType: string,
+    params: { prompt: string; size?: string; count?: number },
+  ) => Promise<Array<{ url: string }>>;
+};
+
+function runtime(overrides: RuntimeOverrides = {}): IAgentRuntime {
+  return overrides as IAgentRuntime;
 }
 
-describe("AgentMediaGenerationService video generation", () => {
+describe("AgentMediaGenerationService media generation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     configMock.isElizaCloudServiceSelectedInConfig.mockReturnValue(false);
@@ -85,6 +96,145 @@ describe("AgentMediaGenerationService video generation", () => {
       unknown
     >;
     expect(requestBody.duration).toBe(9);
+  });
+
+  it("routes cloud image generation through the registered image model", async () => {
+    const imageModel = async () => ({});
+    const useModel = vi.fn(async () => [
+      { url: "https://cdn.example/generated.png" },
+    ]);
+    const getModel = vi.fn((modelType: string) =>
+      modelType === ModelType.IMAGE ? imageModel : undefined,
+    );
+    configMock.isElizaCloudServiceSelectedInConfig.mockReturnValue(true);
+    configMock.loadElizaConfig.mockReturnValue({
+      cloud: {
+        apiKey: "eliza_cloud_key",
+        baseUrl: "https://api.elizacloud.ai/api/v1",
+      },
+      media: {
+        image: {
+          mode: "cloud",
+        },
+      },
+    });
+
+    const { AgentMediaGenerationService } = await import(
+      "./media-generation.ts"
+    );
+    const service = new AgentMediaGenerationService(
+      runtime({
+        getModel,
+        useModel,
+      }),
+    );
+
+    await expect(
+      service.generateMedia({
+        mediaType: "image",
+        prompt: "a cat in a little space helmet",
+        size: "1024x1024",
+      }),
+    ).resolves.toEqual({
+      mediaType: "image",
+      url: "https://cdn.example/generated.png",
+      imageUrl: "https://cdn.example/generated.png",
+      mimeType: "image/png",
+    });
+
+    expect(getModel).toHaveBeenCalledWith(ModelType.IMAGE);
+    expect(useModel).toHaveBeenCalledWith(ModelType.IMAGE, {
+      prompt: "a cat in a little space helmet",
+      size: "1024x1024",
+      count: 1,
+    });
+  });
+
+  it("uses configured own-key image providers instead of the image model", async () => {
+    const fetchMock = vi.fn(async () =>
+      Response.json({
+        images: [{ url: "https://cdn.example/fal-image.png" }],
+      }),
+    );
+    const useModel = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    configMock.isElizaCloudServiceSelectedInConfig.mockReturnValue(true);
+    configMock.loadElizaConfig.mockReturnValue({
+      media: {
+        image: {
+          mode: "own-key",
+          provider: "fal",
+          fal: {
+            apiKey: "fal-key",
+            model: "fal-ai/flux-pro",
+            baseUrl: "https://fal.test",
+          },
+        },
+      },
+    });
+
+    const { AgentMediaGenerationService } = await import(
+      "./media-generation.ts"
+    );
+    const service = new AgentMediaGenerationService(
+      runtime({
+        useModel,
+      }),
+    );
+
+    await expect(
+      service.generateMedia({
+        mediaType: "image",
+        prompt: "a glass lighthouse",
+        size: "square_hd",
+      }),
+    ).resolves.toEqual({
+      mediaType: "image",
+      url: "https://cdn.example/fal-image.png",
+      imageUrl: "https://cdn.example/fal-image.png",
+      imageBase64: undefined,
+      revisedPrompt: undefined,
+      mimeType: "image/png",
+    });
+
+    expect(useModel).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://fal.test/fal-ai/flux-pro",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Key fal-key",
+        }),
+      }),
+    );
+  });
+
+  it("reports cloud image generation unavailable when no image model is registered", async () => {
+    configMock.isElizaCloudServiceSelectedInConfig.mockReturnValue(true);
+    configMock.loadElizaConfig.mockReturnValue({
+      media: {
+        image: {
+          mode: "cloud",
+        },
+      },
+    });
+
+    const { AgentMediaGenerationService } = await import(
+      "./media-generation.ts"
+    );
+    const service = new AgentMediaGenerationService(
+      runtime({
+        getModel: vi.fn(() => undefined),
+      }),
+    );
+
+    expect(service.canGenerateMedia({ mediaType: "image" })).toBe(false);
+    await expect(
+      service.generateMedia({
+        mediaType: "image",
+        prompt: "a cat",
+      }),
+    ).rejects.toThrow(/requires Eliza Cloud or a direct image provider/);
   });
 
   it("lets explicit request duration override configured video defaultDuration", async () => {

--- a/packages/agent/src/services/media-generation.ts
+++ b/packages/agent/src/services/media-generation.ts
@@ -3,10 +3,12 @@ import {
   IMediaGenerationService,
   type MediaGenerationRequest,
   type MediaGenerationResponse,
+  ModelType,
   ServiceType,
 } from "@elizaos/core";
 import { isElizaCloudServiceSelectedInConfig } from "@elizaos/shared";
 import { loadElizaConfig } from "../config/config.ts";
+import type { ImageConfig } from "../config/types.eliza.ts";
 import {
   createAudioProvider,
   createImageProvider,
@@ -27,11 +29,59 @@ function getMediaProviderOptions(): MediaProviderFactoryOptions {
   };
 }
 
+function imageConfigUsesCloud(
+  config: ImageConfig | undefined,
+  options: MediaProviderFactoryOptions,
+): boolean {
+  const mode =
+    config?.mode ?? (options.cloudMediaDisabled ? "own-key" : "cloud");
+  return mode === "cloud" && !options.cloudMediaDisabled;
+}
+
+function hasImageGenerationModel(runtime: IAgentRuntime): boolean {
+  return typeof runtime.getModel(ModelType.IMAGE) === "function";
+}
+
+async function generateImageWithModel(
+  runtime: IAgentRuntime,
+  request: MediaGenerationRequest,
+): Promise<MediaGenerationResponse> {
+  if (!hasImageGenerationModel(runtime)) {
+    throw new Error(
+      "Image generation requires Eliza Cloud or a direct image provider. " +
+        "Enable @elizaos/plugin-elizacloud with ELIZAOS_CLOUD_API_KEY, or configure an own-key image provider.",
+    );
+  }
+
+  const imageResponse = await runtime.useModel(ModelType.IMAGE, {
+    prompt: request.prompt,
+    size: request.size,
+    count: 1,
+  });
+  const firstImage = Array.isArray(imageResponse)
+    ? imageResponse[0]
+    : undefined;
+  const imageUrl = firstImage?.url;
+
+  if (!imageUrl) {
+    throw new Error(
+      "Image generation requires Eliza Cloud or a direct image provider, but no image URL was returned.",
+    );
+  }
+
+  return {
+    mediaType: "image",
+    url: imageUrl,
+    imageUrl,
+    mimeType: "image/png",
+  };
+}
+
 export class AgentMediaGenerationService extends IMediaGenerationService {
   static override readonly serviceType = ServiceType.MEDIA_GENERATION;
 
   override readonly capabilityDescription: string =
-    "Generates image, video, and audio through configured local media providers.";
+    "Generates image, video, and audio through configured media providers or a registered image model.";
 
   static async start(
     runtime: IAgentRuntime,
@@ -48,6 +98,9 @@ export class AgentMediaGenerationService extends IMediaGenerationService {
     const providerOptions = getMediaProviderOptions();
     try {
       if (request.mediaType === "image") {
+        if (imageConfigUsesCloud(config.media?.image, providerOptions)) {
+          return hasImageGenerationModel(this.runtime);
+        }
         createImageProvider(config.media?.image, providerOptions);
         return true;
       }
@@ -69,6 +122,10 @@ export class AgentMediaGenerationService extends IMediaGenerationService {
     const providerOptions = getMediaProviderOptions();
 
     if (request.mediaType === "image") {
+      if (imageConfigUsesCloud(config.media?.image, providerOptions)) {
+        return generateImageWithModel(this.runtime, request);
+      }
+
       const result = await createImageProvider(
         config.media?.image,
         providerOptions,


### PR DESCRIPTION
Fixes #10819

## Summary
- Removed the stale agent-side Eliza Cloud image provider that posted to `/media/image/generate`.
- Routed Cloud-selected image generation through the registered `ModelType.IMAGE` handler, so `@elizaos/plugin-elizacloud` owns the Cloud SDK `/generate-image` call.
- Kept own-key image providers on the direct provider path and added clear errors when no Cloud image model or direct provider is configured.

## Evidence
- `bun install` — completed post-rebase with no lockfile changes
- `bunx biome check --write packages/agent/src/services/media-generation.ts packages/agent/src/services/media-generation.test.ts packages/agent/src/providers/media-provider.ts packages/agent/src/providers/media-provider.test.ts`
- `bunx vitest run --config packages/agent/vitest.config.ts packages/agent/src/providers/media-provider.test.ts packages/agent/src/services/media-generation.test.ts --coverage.enabled=false` — 2 files, 17 tests passed
- `bunx vitest run --config packages/core/vitest.config.ts packages/core/src/features/advanced-capabilities/actions/generateMedia.test.ts --coverage.enabled=false` — 1 file, 8 tests passed
- `rg -n "/media/image/generate|ElizaCloudImageProvider" packages/agent/src packages/core/src plugins/plugin-elizacloud/src packages/cloud/sdk/src packages/cloud/api/v1 || true` — no tracked source matches
- `bun run --cwd packages/agent typecheck` — blocked by pre-existing command-plugin export/type errors outside this change; details are in `.github/issue-evidence/10819-cloud-image-generation.md`
- `bun run verify` — blocked by the repo-wide type-safety ratchet before package checks (`?? 0` count 382 > baseline 380); this branch diff adds none of the flagged patterns

## Evidence Artifact
- `.github/issue-evidence/10819-cloud-image-generation.md`

## Not Captured
- Live Cloud trajectory was not captured locally because this shell has no `ELIZAOS_CLOUD_API_KEY`, `ANTHROPIC_API_KEY`, `CEREBRAS_API_KEY`, or `OPENAI_API_KEY` configured.