### PR TITLE
fix(cloud): lock down tenant DB maintenance access

### DIFF
--- a/.github/issue-evidence/10838-tenant-db-maintenance-lockdown.md
+++ b/.github/issue-evidence/10838-tenant-db-maintenance-lockdown.md
@@ -1,0 +1,31 @@
+# #10838 tenant DB maintenance lockdown evidence
+
+## Scenario
+
+`buildIdempotentAdminDdl()` now prepends shared maintenance-database hardening before creating or updating a tenant role/database.
+
+The pure DDL contract test asserts the emitted statements:
+
+- `GRANT CONNECT ON DATABASE "postgres" TO CURRENT_USER`
+- `GRANT CONNECT ON DATABASE "template1" TO CURRENT_USER`
+- `REVOKE CONNECT ON DATABASE "postgres" FROM PUBLIC`
+- `REVOKE CONNECT ON DATABASE "template1" FROM PUBLIC`
+- `REVOKE ALL ON SCHEMA public FROM PUBLIC`
+
+## Expected proof
+
+Tenant roles no longer inherit default PUBLIC CONNECT to the cluster maintenance databases when the provisioning admin DDL is applied. The admin/current user keeps maintenance access.
+
+## Validation
+
+```bash
+bun test packages/cloud/shared/src/lib/services/tenant-db/__tests__/tenant-db-provisioner.test.ts
+bun run biome check packages/cloud/shared/src/lib/services/tenant-db/tenant-db-provisioner.ts packages/cloud/shared/src/lib/services/tenant-db/__tests__/tenant-db-provisioner.test.ts .github/issue-evidence/10838-tenant-db-maintenance-lockdown.md
+bun run --cwd packages/cloud/shared typecheck
+```
+
+## N/A artifacts
+
+- Screenshots/video: N/A, backend DDL hardening only.
+- Frontend logs/network: N/A, no frontend path.
+- Real-LLM trajectories: N/A, no model/action/prompt path.

--- a/packages/cloud/shared/src/lib/services/tenant-db/__tests__/tenant-db-provisioner.test.ts
+++ b/packages/cloud/shared/src/lib/services/tenant-db/__tests__/tenant-db-provisioner.test.ts
@@ -3,6 +3,7 @@ import {
   buildDeprovisionDdl,
   buildDsn,
   buildIdempotentAdminDdl,
+  buildMaintenanceDbHardeningDdl,
   buildTenantDdl,
   deriveTenantIdent,
   quoteIdent,
@@ -51,6 +52,18 @@ describe("buildIdempotentAdminDdl — the hard cross-tenant boundary as a contra
     expect(joined).toContain(
       `GRANT CONNECT ON DATABASE ${quoteIdent(ident.dbName)} TO ${quoteIdent(ident.roleName)}`,
     );
+  });
+
+  test("hardens shared maintenance databases before creating tenant credentials", () => {
+    const hardening = buildMaintenanceDbHardeningDdl();
+    expect(hardening).toEqual([
+      `GRANT CONNECT ON DATABASE ${quoteIdent("postgres")} TO CURRENT_USER`,
+      `GRANT CONNECT ON DATABASE ${quoteIdent("template1")} TO CURRENT_USER`,
+      `REVOKE CONNECT ON DATABASE ${quoteIdent("postgres")} FROM PUBLIC`,
+      `REVOKE CONNECT ON DATABASE ${quoteIdent("template1")} FROM PUBLIC`,
+      "REVOKE ALL ON SCHEMA public FROM PUBLIC",
+    ]);
+    expect(ddl.slice(0, hardening.length)).toEqual(hardening);
   });
 
   test("the role is least-privilege (no superuser/createdb/createrole)", () => {

--- a/packages/cloud/shared/src/lib/services/tenant-db/tenant-db-provisioner.ts
+++ b/packages/cloud/shared/src/lib/services/tenant-db/tenant-db-provisioner.ts
@@ -90,6 +90,22 @@ export function deriveTenantIdent(appId: string): TenantDbIdent {
 }
 
 /**
+ * Cluster maintenance-DB hardening. Tenant credentials are scoped to their own
+ * database, but Postgres defaults leave PUBLIC able to CONNECT to shared
+ * maintenance databases. Re-applying these statements on each provision is
+ * idempotent and closes metadata-leak footholds from tenant roles.
+ */
+export function buildMaintenanceDbHardeningDdl(): string[] {
+  return [
+    `GRANT CONNECT ON DATABASE ${quoteIdent("postgres")} TO CURRENT_USER`,
+    `GRANT CONNECT ON DATABASE ${quoteIdent("template1")} TO CURRENT_USER`,
+    `REVOKE CONNECT ON DATABASE ${quoteIdent("postgres")} FROM PUBLIC`,
+    `REVOKE CONNECT ON DATABASE ${quoteIdent("template1")} FROM PUBLIC`,
+    "REVOKE ALL ON SCHEMA public FROM PUBLIC",
+  ];
+}
+
+/**
  * Admin-connection DDL: create the role, create its database, and lock down
  * connect privileges so ONLY this role can open the database. Statement order
  * is load-bearing — the role must exist before the database can be owned by it.
@@ -121,6 +137,7 @@ export function buildIdempotentAdminDdl(
   const role = quoteIdent(ident.roleName);
   const db = quoteIdent(ident.dbName);
   const statements: string[] = [
+    ...buildMaintenanceDbHardeningDdl(),
     // CREATE ROLE has no IF NOT EXISTS; the DO block swallows the duplicate so a
     // retry is a no-op for an already-created role. Password is set by ALTER ROLE.
     `DO $$ BEGIN CREATE ROLE ${role} LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT; EXCEPTION WHEN duplicate_object THEN NULL; END $$`,


### PR DESCRIPTION
## Summary

- Adds idempotent maintenance-database hardening to tenant DB admin provisioning DDL.
- Revokes PUBLIC CONNECT from `postgres` and `template1`, grants maintenance access back to the provisioning admin/current user, and revokes PUBLIC privileges on the maintenance `public` schema.
- Extends the pure tenant DB provisioner contract test to pin the emitted DDL order.

## Root Cause

Tenant provisioning revoked PUBLIC CONNECT only on the tenant database. Tenant roles could still inherit default PUBLIC CONNECT to shared maintenance databases on the same cluster, exposing cross-tenant metadata and a default-public-schema foothold.

## Validation

- `bun test packages/cloud/shared/src/lib/services/tenant-db/__tests__/tenant-db-provisioner.test.ts`
- `bun run biome check packages/cloud/shared/src/lib/services/tenant-db/tenant-db-provisioner.ts packages/cloud/shared/src/lib/services/tenant-db/__tests__/tenant-db-provisioner.test.ts .github/issue-evidence/10838-tenant-db-maintenance-lockdown.md`
- `bun run --cwd packages/cloud/shared typecheck`

Evidence: `.github/issue-evidence/10838-tenant-db-maintenance-lockdown.md`

## Evidence Notes

- Screenshots/video: N/A, backend DDL hardening only.
- Frontend logs/network: N/A, no frontend path.
- Real-LLM trajectory: N/A, no model/action/prompt path.

Fixes #10838