### PR TITLE
fix(orchestrator): arm the per-origin spawn cap on dashboard/web too (#8875)

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/spawn-cap-origin-key.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/spawn-cap-origin-key.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Per-origin spawn-cap key coverage for #8875 — the "weak model re-spawns one
+ * request ~70x" loop, on Discord AND dashboard/web.
+ *
+ * The source-level fix (the completion evaluator treating a truncated/blocked
+ * sub-agent completion as terminal) is transport-independent and covered by
+ * `sub-agent-completion-finish-reason.test.ts`. This file pins the SECOND half
+ * the issue explicitly called out: the defense-in-depth per-origin cap must be
+ * ARMED on the connector-less dashboard/web path too, where it previously
+ * no-op'd because the key was derived from a connector message id that web
+ * never has.
+ *
+ * The two sides of the cap live in different modules and MUST agree on the key
+ * for record (SubAgentRouter.recordOriginResult) + enforce (TASKS action) to
+ * meet. We prove that agreement directly, plus the cap store's accumulate +
+ * relay behavior, without standing up the whole spawn pipeline.
+ */
+
+import type { Memory } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  spawnOriginKeyFor as rawSpawnOriginKeyFor,
+  spawnRootIdFor,
+} from "../actions/tasks.ts";
+import {
+  SubAgentRouter,
+  spawnRootIdFromMeta,
+} from "../services/sub-agent-router.ts";
+
+/** These fixtures always carry an id, so the key is always defined; assert that
+ * once here so every callsite gets a concrete `string`. */
+function spawnOriginKeyFor(
+  message: Memory,
+  content: Record<string, unknown>,
+  agentType: string,
+): string {
+  const key = rawSpawnOriginKeyFor(message, content, agentType);
+  if (!key) throw new Error("expected a defined spawn-origin key");
+  return key;
+}
+
+const ROOT_MSG = "11111111-1111-4111-8111-111111111111";
+const SYNTH_MSG_1 = "22222222-2222-4222-8222-222222222222";
+const SYNTH_MSG_2 = "33333333-3333-4333-8333-333333333333";
+const ROOM = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+
+/** A minimal inbound Memory (spawnRootIdFor reads only `id` + `metadata`). */
+function msg(id: string, metadata: Record<string, unknown> = {}): Memory {
+  return { id, metadata } as unknown as Memory;
+}
+
+/** The session metadata tasks.ts persists at spawn time (the fields readOrigin
+ * / spawnRootIdFromMeta consume), for a given derived root id. */
+function spawnedSessionMeta(
+  rootId: string,
+  extra: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    taskRoomId: ROOM,
+    roomId: ROOM,
+    messageId: ROOT_MSG,
+    spawnRootMessageId: rootId,
+    ...extra,
+  };
+}
+
+describe("per-origin spawn cap key (#8875)", () => {
+  describe("web / dashboard (no connector message id)", () => {
+    it("arms the cap off the user message id on the first spawn", () => {
+      // Before the fix this returned undefined → the whole cap block was skipped
+      // on web and the ~70x loop ran unbounded.
+      expect(spawnRootIdFor(msg(ROOT_MSG), { metadata: {} })).toBe(ROOT_MSG);
+      expect(spawnOriginKeyFor(msg(ROOT_MSG), { metadata: {} }, "coder")).toBe(
+        `${ROOT_MSG}\0coder`,
+      );
+    });
+
+    it("stays anchored to the ROOT id across re-spawns (synthetic inbound churn)", () => {
+      // Each re-injected completion is a fresh Memory with a NEW random id, but
+      // SubAgentRouter re-stamps `spawnRootMessageId` = the original root. The
+      // key must follow the root, not the synthetic per-hop id.
+      const respawn1 = spawnOriginKeyFor(
+        msg(SYNTH_MSG_1, {}),
+        { metadata: { spawnRootMessageId: ROOT_MSG } },
+        "coder",
+      );
+      const respawn2 = spawnOriginKeyFor(
+        msg(SYNTH_MSG_2, {}),
+        { metadata: { spawnRootMessageId: ROOT_MSG } },
+        "coder",
+      );
+      const firstSpawn = spawnOriginKeyFor(
+        msg(ROOT_MSG),
+        { metadata: {} },
+        "coder",
+      );
+      expect(respawn1).toBe(firstSpawn);
+      expect(respawn2).toBe(firstSpawn);
+    });
+
+    it("would DRIFT (and never accumulate) if the root id were not propagated", () => {
+      // Documents exactly why the propagated field is load-bearing: without it,
+      // a synthetic inbound keys on its own fresh id and every hop is a new key.
+      const drifted = spawnOriginKeyFor(
+        msg(SYNTH_MSG_1, {}),
+        { metadata: {} },
+        "coder",
+      );
+      const firstSpawn = spawnOriginKeyFor(
+        msg(ROOT_MSG),
+        { metadata: {} },
+        "coder",
+      );
+      expect(drifted).not.toBe(firstSpawn);
+    });
+
+    it("separates distinct agent types under the same request", () => {
+      const coder = spawnOriginKeyFor(msg(ROOT_MSG), { metadata: {} }, "coder");
+      const browser = spawnOriginKeyFor(
+        msg(ROOT_MSG),
+        { metadata: {} },
+        "browser",
+      );
+      expect(coder).not.toBe(browser);
+    });
+  });
+
+  describe("discord / connectors (connector message id present)", () => {
+    it("keys on the connector message id (unchanged behavior)", () => {
+      const discord = msg(ROOT_MSG, { discord: { messageId: "disc-987" } });
+      expect(spawnRootIdFor(discord, { metadata: {} })).toBe("disc-987");
+      expect(spawnOriginKeyFor(discord, { metadata: {} }, "coder")).toBe(
+        "disc-987\0coder",
+      );
+    });
+
+    it("prefers an explicit originConnectorMessageId in content metadata", () => {
+      const key = spawnRootIdFor(msg(ROOT_MSG), {
+        metadata: { originConnectorMessageId: "conn-root-1" },
+      });
+      expect(key).toBe("conn-root-1");
+    });
+  });
+
+  describe("record (router) + enforce (action) agree on the key", () => {
+    it("router readback of the persisted metadata equals the action's derived root — web", () => {
+      const rootId = spawnRootIdFor(msg(ROOT_MSG), { metadata: {} });
+      // What tasks.ts writes into the spawned session metadata:
+      const meta = spawnedSessionMeta(rootId);
+      // What the router reads back to key recordOriginResult:
+      expect(spawnRootIdFromMeta(meta)).toBe(rootId);
+    });
+
+    it("agrees across a re-spawn hop — web", () => {
+      const respawnRoot = spawnRootIdFor(msg(SYNTH_MSG_1, {}), {
+        metadata: { spawnRootMessageId: ROOT_MSG },
+      });
+      expect(respawnRoot).toBe(ROOT_MSG);
+      expect(spawnRootIdFromMeta(spawnedSessionMeta(respawnRoot))).toBe(
+        ROOT_MSG,
+      );
+    });
+
+    it("agrees on discord — connector id", () => {
+      const discord = msg(ROOT_MSG, { discord: { messageId: "disc-987" } });
+      const rootId = spawnRootIdFor(discord, { metadata: {} });
+      const meta = spawnedSessionMeta(rootId, {
+        originConnectorMessageId: "disc-987",
+      });
+      expect(spawnRootIdFromMeta(meta)).toBe("disc-987");
+    });
+
+    it("falls back to the session messageId for pre-fix sessions (no spawnRootMessageId)", () => {
+      // A session spawned before this change persists messageId but not
+      // spawnRootMessageId; it must still resolve to a stable id, not undefined.
+      const legacyMeta = {
+        taskRoomId: ROOM,
+        roomId: ROOM,
+        messageId: ROOT_MSG,
+      };
+      expect(spawnRootIdFromMeta(legacyMeta)).toBe(ROOT_MSG);
+    });
+
+    it("returns undefined for empty metadata", () => {
+      expect(spawnRootIdFromMeta(undefined)).toBeUndefined();
+      expect(spawnRootIdFromMeta({})).toBeUndefined();
+    });
+  });
+
+  describe("cap store accumulates + relays for a web key", () => {
+    const runtime = {
+      agentId: "00000000-0000-4000-8000-000000000001",
+      getSetting: () => undefined,
+      logger: { debug() {}, info() {}, warn() {}, error() {} },
+    } as never;
+
+    it("counts serial re-spawns of one origin and keeps the best result", () => {
+      const router = new SubAgentRouter(runtime);
+      const key = spawnOriginKeyFor(msg(ROOT_MSG), { metadata: {} }, "coder");
+
+      expect(router.spawnCountForOrigin(key)).toBe(0);
+      router.noteSpawnForOrigin(key);
+      router.noteSpawnForOrigin(key);
+      router.noteSpawnForOrigin(key);
+      expect(router.spawnCountForOrigin(key)).toBe(3);
+
+      // A distinct request in the same room (different root id) is independent.
+      const otherKey = spawnOriginKeyFor(
+        msg(SYNTH_MSG_2, {}),
+        { metadata: {} },
+        "coder",
+      );
+      expect(router.spawnCountForOrigin(otherKey)).toBe(0);
+
+      // Best result keeps the LONGEST non-empty completion (a later truncated
+      // stub must not clobber the fuller earlier answer).
+      router.recordOriginResult(key, { text: "479" });
+      router.recordOriginResult(key, { text: "479001600 (the full answer)" });
+      router.recordOriginResult(key, { text: "x" });
+      expect(router.bestResultFor(key)?.text).toBe(
+        "479001600 (the full answer)",
+      );
+    });
+
+    it("relays the recorded result at the cap for the SAME key a re-spawn resolves", () => {
+      const router = new SubAgentRouter(runtime);
+      const firstKey = spawnOriginKeyFor(
+        msg(ROOT_MSG),
+        { metadata: {} },
+        "coder",
+      );
+      router.recordOriginResult(firstKey, {
+        text: "final answer",
+        deliverable: "42",
+      });
+
+      // A later re-spawn hop derives the SAME key from the propagated root id,
+      // so it finds the relayable result instead of spawning again.
+      const respawnKey = spawnOriginKeyFor(
+        msg(SYNTH_MSG_1, {}),
+        { metadata: { spawnRootMessageId: ROOT_MSG } },
+        "coder",
+      );
+      expect(respawnKey).toBe(firstKey);
+      expect(router.bestResultFor(respawnKey)?.deliverable).toBe("42");
+    });
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -284,6 +284,39 @@ function connectorMessageIdFromMemory(
   );
 }
 
+/**
+ * The stable per-request root id used to key the per-origin spawn cap (#8875).
+ * On the FIRST spawn it is the connector message id (Discord/connectors) or,
+ * when none exists (dashboard/web), the user message id. SubAgentRouter stamps
+ * this id back onto every synthetic re-spawn inbound as `spawnRootMessageId`,
+ * so a request that re-spawns resolves the SAME id on EVERY transport — the
+ * connector-less dashboard/web path previously produced no key at all, so the
+ * cap silently never fired there. Kept as a pure exported fn so the record
+ * (SubAgentRouter) and enforce (this action) sides can be proven to agree.
+ */
+export function spawnRootIdFor(
+  message: Memory,
+  content: Record<string, unknown>,
+): string | undefined {
+  return (
+    connectorMessageIdFromMemory(message, content) ??
+    plainString(objectValue(content.metadata)?.spawnRootMessageId) ??
+    message.id
+  );
+}
+
+/** `spawnRootIdFor` scoped to an agent type — the exact per-origin cap key.
+ * `undefined` only when the inbound carries no id at all (the cap is skipped,
+ * exactly as before). */
+export function spawnOriginKeyFor(
+  message: Memory,
+  content: Record<string, unknown>,
+  agentType: string,
+): string | undefined {
+  const root = spawnRootIdFor(message, content);
+  return root ? `${root}\0${agentType}` : undefined;
+}
+
 function pickRoutingString(
   params: Record<string, unknown>,
   content: Record<string, unknown>,
@@ -1046,9 +1079,12 @@ async function runSpawnAgent(
     const spawnCapRouter = isSpawnCapRouter(spawnCapRouterService)
       ? spawnCapRouterService
       : undefined;
-    const spawnOriginKey = originConnectorMessageId
-      ? `${originConnectorMessageId}\0${agentType}`
-      : undefined;
+    // The stable per-request root id + cap key (see spawnRootIdFor). Anchored to
+    // ONE user request across the whole re-spawn loop on EVERY transport,
+    // closing the dashboard/web no-op where `originConnectorMessageId` is absent
+    // and the cap silently never fired (#8875).
+    const spawnRootMessageId = spawnRootIdFor(message, content);
+    const spawnOriginKey = spawnOriginKeyFor(message, content, agentType);
     if (spawnCapRouter && spawnOriginKey) {
       const cap = maxSpawnsPerOrigin(runtime);
       if (spawnCapRouter.spawnCountForOrigin(spawnOriginKey) >= cap) {
@@ -1084,6 +1120,11 @@ async function runSpawnAgent(
       metadata: {
         ...extraMetadata,
         ...(originConnectorMessageId ? { originConnectorMessageId } : {}),
+        // Persist the stable root id so SubAgentRouter re-stamps it onto the
+        // next synthetic re-spawn inbound (keeping the per-origin spawn cap
+        // anchored to ONE user request across the whole loop, on every
+        // transport — including connector-less dashboard/web). (#8875)
+        ...(spawnRootMessageId ? { spawnRootMessageId } : {}),
         requestedType: explicitAgentType ?? agentType,
         messageId: message.id,
         roomId: swarmRoomMetadata.taskRoomId,

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -1074,14 +1074,18 @@ export class SubAgentRouter extends Service {
       // Remember the best (longest) result for this root origin so the spawn
       // cap (tasks.ts) can relay it instead of re-spawning when a weak model's
       // later completion for the SAME user request comes back truncated/blocked.
-      // Key on the connector message id only — the stable root id the router
-      // stamps onto each synthetic re-spawn inbound and that tasks.ts reads back
-      // (so record + enforce agree); a request without one simply isn't capped.
-      if (origin.parentConnectorMessageId) {
-        this.recordOriginResult(
-          `${origin.parentConnectorMessageId}\0${session.agentType}`,
-          { text, deliverable },
-        );
+      // Key on the stable root id — the connector message id when present, else
+      // the user message id the router stamps onto each synthetic re-spawn
+      // inbound as `spawnRootMessageId` (dashboard/web has no connector id).
+      // This MUST match tasks.ts's `spawnOriginKey` derivation so record +
+      // enforce agree on every transport (#8875).
+      const originResultKey =
+        origin.parentConnectorMessageId ?? origin.spawnRootMessageId;
+      if (originResultKey) {
+        this.recordOriginResult(`${originResultKey}\0${session.agentType}`, {
+          text,
+          deliverable,
+        });
       }
       const preview = (deliverable ?? text).trim().slice(0, 200);
       void getNotifier(this.runtime)
@@ -1218,6 +1222,12 @@ export class SubAgentRouter extends Service {
               : {}),
             ...(origin.parentConnectorMessageId
               ? { originConnectorMessageId: origin.parentConnectorMessageId }
+              : {}),
+            // Re-stamp the stable root id so the NEXT re-spawn anchors its
+            // per-origin cap key to the same user request on connector-less
+            // (dashboard/web) transports. (#8875)
+            ...(origin.spawnRootMessageId
+              ? { spawnRootMessageId: origin.spawnRootMessageId }
               : {}),
             ...(origin.source ? { originSource: origin.source } : {}),
             ...(sessionRouteId ? { workdirRouteId: sessionRouteId } : {}),
@@ -1752,6 +1762,9 @@ interface OriginInfo {
   userId?: UUID;
   parentMessageId?: UUID;
   parentConnectorMessageId?: string;
+  /** Stable per-request root id for the per-origin spawn cap; present on every
+   * transport (connector message id, else the origin user message id). (#8875) */
+  spawnRootMessageId?: string;
   label: string;
   source?: string;
 }
@@ -1772,6 +1785,26 @@ function swarmRoomsMetadata(
 
 function pickPlainString(value: unknown): string | undefined {
   return typeof value === "string" ? value.trim() || undefined : undefined;
+}
+
+/**
+ * The stable per-request root id read from a session's metadata for the
+ * per-origin spawn cap (#8875). MUST resolve to the same value that tasks.ts's
+ * `spawnRootIdFor` produced when the session was spawned, so the router's
+ * `recordOriginResult` and the action's cap enforcement key on the same origin
+ * on every transport. Newer spawns persist `spawnRootMessageId`; the fallbacks
+ * keep sessions that predate this change (in-flight across a deploy) capped by
+ * their stable id too.
+ */
+export function spawnRootIdFromMeta(
+  meta: Record<string, unknown> | undefined,
+): string | undefined {
+  if (!meta) return undefined;
+  return (
+    pickPlainString(meta.spawnRootMessageId) ??
+    pickPlainString(meta.originConnectorMessageId) ??
+    pickUuid(meta.messageId)
+  );
 }
 
 function readOrigin(session: SessionInfo): OriginInfo | null {
@@ -1795,6 +1828,7 @@ function readOrigin(session: SessionInfo): OriginInfo | null {
     userId: pickUuid(meta.userId),
     parentMessageId: pickUuid(meta.messageId),
     parentConnectorMessageId: pickPlainString(meta.originConnectorMessageId),
+    spawnRootMessageId: spawnRootIdFromMeta(meta),
     label: pickLabel(meta) ?? session.name ?? session.id,
     source: typeof meta.source === "string" ? meta.source : undefined,
   };


### PR DESCRIPTION
## What / why

Closes the second half of #8875 (the weak-model "re-spawn one request ~70×" loop). The **source-level** fix — the completion evaluator treating a truncated/blocked sub-agent completion as terminal and relaying the best partial once instead of re-spawning — is transport-independent and already on `develop` (`sub-agent-completion.ts`, covered by `sub-agent-completion-finish-reason.test.ts`).

This PR fixes the **defense-in-depth per-origin spawn cap**, which #8875 (and the closed #8873) explicitly called out as no-op'ing on the dashboard/web path:

> a singleton-`Map` cap … no-ops on the dashboard/web path (no connector message id)

### Root cause

`tasks.ts` derived the cap key from `originConnectorMessageId` **only**:

```ts
const spawnOriginKey = originConnectorMessageId ? `${originConnectorMessageId}\0${agentType}` : undefined;
```

Dashboard/web has no connector message id → `spawnOriginKey === undefined` → the entire `if (spawnCapRouter && spawnOriginKey)` block is skipped → the cap never fires. Compounding it: `SubAgentRouter` mints a **fresh `randomUUID()`** for every re-injected completion, so `message.id` drifts every hop and can't anchor the loop either.

### Fix

Key the cap on a stable per-request **root id present on every transport**, agreed on by both sides:

- `spawnRootIdFor(message, content)` = connector message id → else propagated `spawnRootMessageId` → else the user `message.id`.
- `tasks.ts` persists `spawnRootMessageId` into the spawned session metadata.
- `SubAgentRouter` reads it back through a single shared seam (`spawnRootIdFromMeta`) to key `recordOriginResult`, and **re-stamps** it onto each synthetic re-spawn inbound — so a re-spawn resolves the **same** key as the first spawn, on Discord **and** web. Discord behavior is unchanged (still keys on the connector id).

## Evidence

New `src/__tests__/spawn-cap-origin-key.test.ts` (13 cases) + existing suites — **24/24 green**:

```
Test Files  3 passed (3)
     Tests  24 passed (24)
```

Covered adversarially:
- **web arming** — first spawn now keys off the user message id (was `undefined`).
- **cross-respawn stability** — synthetic-inbound UUID churn keeps the same key; a companion case asserts the key *would* drift without the propagated field (why it's load-bearing).
- **Discord parity** — unchanged connector-id keying.
- **record ↔ enforce agreement** — router readback (`spawnRootIdFromMeta`) equals the action's derived root on web, across a re-spawn hop, and on Discord.
- **pre-fix session fallback** — sessions spawned before this change (no `spawnRootMessageId`) still resolve a stable id via `messageId`.
- **cap store** — accumulates serial re-spawns, keeps the longest result, relays it at the cap for the same key a re-spawn resolves.

`bunx tsc` clean on the edited files; `biome check` clean.

### Not in this PR / follow-up
Live cerebras+opencode trajectory (per `PR_EVIDENCE.md`) requires a provider key + the coding stack; the unit/integration layer here proves the key invariant that makes the cap fire on both transports. The source-level terminal-completion fix (the primary bound on the loop) is already merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)