### PR TITLE
docs(cloud/api): fix apps/containers request-response contract mismatches (#10877)

### DIFF
--- a/packages/docs/cloud/api/apps.mdx
+++ b/packages/docs/cloud/api/apps.mdx
@@ -74,11 +74,11 @@ Create a new Cloud app. The response includes a one-time app API key for server-
     "allowed_origins": ["https://placeholder.invalid"],
     "created_at": "2026-05-05T10:30:00Z"
   },
-  "apiKey": {
-    "id": "key_abc123"
-  }
+  "apiKey": "eliza_<one-time-plaintext-secret>"
 }
 ```
+
+The `apiKey` is the **plaintext** app admin key, returned as a bare string and shown **only once** at creation — it is not stored and cannot be retrieved later.
 
 <Warning>
   Store the returned API key securely. Use user bearer tokens, not this admin key, for user-facing app-scoped chat.

--- a/packages/docs/cloud/api/containers.mdx
+++ b/packages/docs/cloud/api/containers.mdx
@@ -29,8 +29,8 @@ Get all containers for your organization.
       "status": "running",
       "image_tag": "ghcr.io/acme/my-app:latest",
       "load_balancer_url": "https://my-app.example.com",
-      "cpu": 256,
-      "memory": 512,
+      "cpu": 1792,
+      "memory": 1792,
       "port": 3000,
       "desired_count": 1,
       "billing_status": "active",
@@ -49,7 +49,7 @@ Get all containers for your organization.
   <span className="path">/api/v1/containers</span>
 </div>
 
-Deploy a new container. Returns a container record and polling instructions.
+Deploy a new container. Returns the created container record; poll `GET /api/v1/containers/{id}` for deploy status.
 
 ### Request
 
@@ -61,8 +61,8 @@ The request body is **camelCase** — the server validates with a strict schema 
   "projectName": "my-app",
   "image": "ghcr.io/elizaos/example-edad:showcase",
   "port": 3000,
-  "cpu": 256,
-  "memoryMb": 512,
+  "cpu": 1792,
+  "memoryMb": 1792,
   "healthCheckPath": "/health",
   "environmentVars": {
     "PORT": "3000",
@@ -79,13 +79,10 @@ The request body is **camelCase** — the server validates with a strict schema 
 | `projectName` | string | no | Stable project identifier. |
 | `image` | string | yes | Full image reference, for example `ghcr.io/owner/repo:tag`. |
 | `port` | integer | no | Container port. Default: 3000. |
-| `cpu` | integer | no | CPU units. Default: 256. |
-| `memoryMb` | integer | no | Memory in MB. Default: 512. |
+| `cpu` | integer | no | CPU units. Default: 1792. |
+| `memoryMb` | integer | no | Memory in MB. Default: 1792. |
 | `healthCheckPath` | string | no | Health check endpoint. Default: `/health`. |
 | `environmentVars` | object | no | String environment variables (this is where `ELIZA_APP_ID` belongs). |
-| `persistVolume` | boolean | no | Mount project-scoped persistent storage at `/data`. |
-| `useHetznerVolume` | boolean | no | Use a Hetzner Cloud volume when persistent volumes are enabled and configured. |
-| `volume_size_gb` | integer | no | Declared volume size in GiB. Default: 10. |
 
 ### Response
 
@@ -98,11 +95,6 @@ The request body is **camelCase** — the server validates with a strict schema 
     "project_name": "my-app",
     "status": "deploying",
     "load_balancer_url": "https://my-app.example.com"
-  },
-  "polling": {
-    "endpoint": "/api/v1/containers/550e8400-e29b-41d4-a716-446655440000",
-    "intervalMs": 5000,
-    "expectedDurationMs": 120000
   }
 }
 ```
@@ -142,11 +134,11 @@ Get container details and deployment status.
   <span className="path">/api/v1/containers/{"{id}"}</span>
 </div>
 
-Patch supports:
+The PATCH body is **action-discriminated** (camelCase — one action per request):
 
-- `environment_vars` to replace runtime environment variables.
-- `desired_count` to scale, currently only `1`.
-- `action: "restart"` to restart the container.
+- `{ "action": "restart" }` — restart the container.
+- `{ "action": "setEnv", "environmentVars": { "KEY": "value" } }` — replace runtime environment variables.
+- `{ "action": "scale", "desiredCount": 1 }` — scale (currently only `1`).
 
 ---
 


### PR DESCRIPTION
Fixes #10877.

Corrects five documented Cloud API contracts that didn't match the code, so a developer copying the docs makes a call that fails or is silently wrong. Each was verified against the route/schema on `develop`.

| # | Doc | Was | Now (matches code) |
|---|-----|-----|--------------------|
| 1 | `containers.mdx` cpu/memoryMb default | 256 / 512 | **1792 / 1792** (`v1/containers/route.ts:327-328` `?? 1792`) |
| 2 | `containers.mdx` volume params | `persistVolume`/`useHetznerVolume`/`volume_size_gb` documented | **removed** — not in `CreateContainerSchema` (silently dropped) |
| 3 | `containers.mdx` PATCH | `environment_vars`/`desired_count` (snake, no discriminator) → 400 | **`action`-discriminated union**: `{action:"restart"}` \| `{action:"setEnv",environmentVars}` \| `{action:"scale",desiredCount}` |
| 4 | `containers.mdx` create response | `polling{}` block | **removed** — route returns only `{success,data}` |
| 5 | `apps.mdx` create response | `"apiKey": { "id": ... }` | **bare plaintext string** (`route.ts:131` `apiKey: result.apiKey`) |

### Evidence
- `bun run --cwd packages/docs test` → **15 pass / 0 fail** (nav integrity, internal links, non-empty).
- Each change cross-checked against the source of truth on `develop`: `packages/cloud/api/v1/containers/{route.ts,schema.ts}` and `packages/cloud/api/v1/apps/route.ts`.
- N/A: real-LLM trajectory / screenshots / device capture — docs-only change, no runtime or UI behavior.

Found via an adversarial multi-agent audit of the apps-launch surface (both skeptics agreed on each item).
