### PR TITLE
fix(cloud): reserve app inference credits upfront

### DIFF
--- a/.github/issue-evidence/10857-app-credit-hold.md
+++ b/.github/issue-evidence/10857-app-credit-hold.md
@@ -1,0 +1,38 @@
+# 10857 App Credit Hold Evidence
+
+Issue: https://github.com/elizaOS/eliza/issues/10857
+
+## What Was Verified
+
+- Monetized `X-App-Id` inference now creates an app-credit reservation before model work instead of doing a read-only balance check.
+- The upfront reservation uses the existing atomic org-ledger debit path (`reserveAndDeductCredits`) through `AppCreditsService.deductCredits`.
+- Settlement reuses the existing app reconciliation path for success, abort, and provider-error cases.
+- Creator earning idempotency uses separate stable keys for the estimate and any later overage, so overage earnings are not deduped away.
+- `/v1/messages` no longer contains the stale `checkBalance` + anonymous-reservation app-credit path.
+- `/v1/chat/completions` was updated to the same reservation helper because it had the same `X-App-Id` advisory-check pattern.
+
+## Commands Run
+
+```bash
+bunx biome check --write packages/cloud/shared/src/lib/services/app-credits.ts packages/cloud/shared/src/lib/services/__tests__/app-credits-ledger.test.ts packages/cloud/api/v1/messages/route.ts packages/cloud/api/v1/chat/completions/route.ts
+bun test packages/cloud/shared/src/lib/services/__tests__/app-credits-ledger.test.ts
+bun test packages/cloud/api/__tests__/messages-iac-fast-path.test.ts packages/cloud/api/__tests__/chat-completions-streaming-credit-leak.test.ts
+rg -n "checkBalance\\(|calculateCostWithMarkup\\(|createAnonymousReservation\\(|estimatedBaseCost: 0|No upfront debit" packages/cloud/api/v1/messages/route.ts packages/cloud/api/v1/chat/completions/route.ts
+bun run --cwd packages/cloud/shared typecheck
+bun run --cwd packages/cloud/api typecheck
+```
+
+## Results Reviewed
+
+- Biome: 4 files checked, no fixes needed after final pass.
+- App-credit ledger suite: 25 tests passed. New coverage proves upfront app inference reservation, pre-model insufficient-credit failure, zero-cost settlement refund/reversal, and distinct creator-earning idempotency keys.
+- `/v1/messages` route test: 2 tests passed.
+- Source grep: no stale app-credit advisory-check or `estimatedBaseCost: 0` path remains in `/v1/messages` or `/v1/chat/completions`; remaining `createAnonymousReservation()` matches are non-app optimistic billing fallbacks.
+- Chat-completions route test: blocked by incomplete linked dependency tree in this worktree, ending at missing `redis` from `packages/cloud/shared/src/lib/cache/client.ts`.
+- `packages/cloud/shared` and `packages/cloud/api` typechecks: blocked by the same incomplete linked dependency tree (`@cloudflare/workers-types`, `redis`, `uuid`, `viem`, `decimal.js`, and other top-level dependency links missing from the local install).
+
+## Evidence N/A / Deferred
+
+- UI screenshots/video: N/A, no UI changed.
+- Migration up/down and DB rows: N/A, no schema or migration changed.
+- Live Cloud request trace: not captured in this local pass because the worktree dependency install is incomplete and no live Cloud billing credentials/model keys were configured. The PR includes deterministic service-level coverage of the atomic debit and route-level `/v1/messages` import coverage.

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -987,9 +987,6 @@ export async function handleChatCompletionsPOST(
 
     const tBeforeReserve = Date.now();
     let reservation: CreditReservation | null = null;
-    let appCreditsInfo:
-      | { appId: string; estimatedBaseCost: number; app: typeof monetizedApp }
-      | undefined;
     // #9899 Tier-2: set when the optimistic off-path billing branch is taken;
     // replaces the reservation settler with a deferred actual-cost debit.
     let optimisticSettler:
@@ -997,7 +994,6 @@ export async function handleChatCompletionsPOST(
       | null = null;
 
     if (useAppCredits && appId && monetizedApp) {
-      // App credits path
       const { totalCost } = await calculateCost(
         normalizedModel,
         provider,
@@ -1005,42 +1001,43 @@ export async function handleChatCompletionsPOST(
         estimatedOutputTokens,
         billingSource,
       );
-      const costWithMarkup = await appCreditsService.calculateCostWithMarkup(
-        appId,
-        totalCost,
-      );
 
-      const balanceCheck = await appCreditsService.checkBalance(
-        appId,
-        user.id,
-        costWithMarkup.totalCost,
-      );
-      if (!balanceCheck.sufficient) {
-        return addCorsHeaders(
-          Response.json(
-            {
-              error: {
-                message: `Insufficient cloud credits. Required: $${costWithMarkup.totalCost.toFixed(4)}`,
-                type: "insufficient_quota",
-                code: "insufficient_credits",
+      try {
+        reservation = await appCreditsService.reserveInferenceCredits({
+          appId,
+          userId: user.id,
+          estimatedBaseCost: totalCost,
+          description: `Chat completion: ${model}`,
+          idempotencyKey,
+          metadata: {
+            model,
+            provider,
+            billingSource,
+            requestId,
+            route: "chat_completions",
+            streaming: request.stream === true,
+            estimatedInputTokens,
+            estimatedOutputTokens,
+          },
+          app: monetizedApp,
+        });
+      } catch (error) {
+        if (error instanceof InsufficientCreditsError) {
+          return addCorsHeaders(
+            Response.json(
+              {
+                error: {
+                  message: `Insufficient cloud credits. Required: $${error.required.toFixed(4)}`,
+                  type: "insufficient_quota",
+                  code: "insufficient_credits",
+                },
               },
-            },
-            { status: 402 },
-          ),
-        );
+              { status: 402 },
+            ),
+          );
+        }
+        throw error;
       }
-
-      // No upfront debit happens for the app-credits flow: the anonymous
-      // reservation records no charge, and the actual debit lands on the org balance
-      // inside `appCreditsService.reconcileCredits` after the call resolves.
-      // Reporting estimatedBaseCost=0 makes reconcile charge the full actual
-      // cost as the diff, instead of treating the estimate as already paid.
-      appCreditsInfo = {
-        appId,
-        estimatedBaseCost: 0,
-        app: monetizedApp,
-      };
-      reservation = creditsService.createAnonymousReservation();
     } else {
       // Organization credits path. #9899 Tier-2: when optimistic billing is
       // enabled AND this org's balance comfortably clears SAFE_BALANCE_THRESHOLD,
@@ -1247,7 +1244,6 @@ export async function handleChatCompletionsPOST(
           request,
           user,
           apiKey ? { id: apiKey.id } : null,
-          appCreditsInfo,
           affiliateCode,
           idempotencyKey,
           requestId,
@@ -1268,7 +1264,6 @@ export async function handleChatCompletionsPOST(
           request,
           user,
           apiKey ? { id: apiKey.id } : null,
-          appCreditsInfo,
           affiliateCode,
           idempotencyKey,
           requestId,
@@ -1356,9 +1351,6 @@ async function handleStreamingRequest(
   request: ChatRequest,
   user: { id: string; organization_id: string },
   apiKey: { id: string } | null,
-  appCreditsInfo:
-    | { appId: string; estimatedBaseCost: number; app: unknown }
-    | undefined,
   affiliateCode: string | null,
   idempotencyKey: string,
   requestId: string,
@@ -1425,26 +1417,6 @@ async function handleStreamingRequest(
         };
         const billing = await billUsage(billingContext, usage);
         const reconciliation = await settleReservation(billing.totalCost);
-
-        // Handle app credits reconciliation
-        if (appCreditsInfo) {
-          await appCreditsService.reconcileCredits({
-            appId: appCreditsInfo.appId,
-            userId: user.id,
-            estimatedBaseCost: appCreditsInfo.estimatedBaseCost,
-            actualBaseCost: billing.totalCost,
-            description: `Chat reconciliation: ${model}`,
-            // #10423: stable per-request key so a settlement retry doesn't
-            // double-credit the app creator's redeemable earnings.
-            metadata: {
-              model,
-              provider,
-              billingSource,
-              streaming: true,
-              idempotencyKey,
-            },
-          });
-        }
 
         const usageRecord = await recordUsageAnalytics(
           billingContext,
@@ -1750,9 +1722,6 @@ async function handleNonStreamingRequest(
   request: ChatRequest,
   user: { id: string; organization_id: string },
   apiKey: { id: string } | null,
-  appCreditsInfo:
-    | { appId: string; estimatedBaseCost: number; app: unknown }
-    | undefined,
   affiliateCode: string | null,
   idempotencyKey: string,
   requestId: string,
@@ -1852,26 +1821,6 @@ async function handleNonStreamingRequest(
         };
         const billing = await billUsage(billingContext, result.usage);
         const reconciliation = await settleReservation(billing.totalCost);
-
-        // Handle app credits
-        if (appCreditsInfo) {
-          await appCreditsService.reconcileCredits({
-            appId: appCreditsInfo.appId,
-            userId: user.id,
-            estimatedBaseCost: appCreditsInfo.estimatedBaseCost,
-            actualBaseCost: billing.totalCost,
-            description: `Chat: ${model}`,
-            // #10423: stable per-request key so a non-streaming settlement retry
-            // doesn't double-credit the app creator's redeemable earnings.
-            metadata: {
-              model,
-              provider,
-              billingSource,
-              streaming: false,
-              idempotencyKey,
-            },
-          });
-        }
 
         const usageRecord = await recordUsageAnalytics(
           billingContext,

--- a/packages/cloud/api/v1/messages/route.ts
+++ b/packages/cloud/api/v1/messages/route.ts
@@ -54,10 +54,9 @@ import type { PricingBillingSource } from "@/lib/services/ai-pricing-definitions
 import { appCreditsService } from "@/lib/services/app-credits";
 import { appsService } from "@/lib/services/apps";
 import { contentModerationService } from "@/lib/services/content-moderation";
-import {
-  type CreditReconciliationResult,
-  type CreditReservation,
-  creditsService,
+import type {
+  CreditReconciliationResult,
+  CreditReservation,
 } from "@/lib/services/credits";
 import { resolveInferenceAuthContext } from "@/lib/services/inference-auth-context";
 import { createCreditReservationSettler } from "@/lib/utils/credit-reservation";
@@ -139,10 +138,6 @@ type AnthropicStopReason =
   | "tool_use";
 
 type ToolNameMap = Map<string, string>;
-type AppCreditsInfo = {
-  appId: string;
-  estimatedBaseCost: number;
-};
 
 function normalizeModelId(model: string): string {
   const canonicalCerebrasModel = canonicalizeCerebrasModelId(model);
@@ -614,7 +609,6 @@ app.post("/", async (c) => {
     resolveAiProviderSource(model) ?? "bitrouter";
 
   let reservation: CreditReservation;
-  let appCreditsInfo: AppCreditsInfo | undefined;
 
   if (useAppCredits && appId && monetizedApp) {
     const { totalCost } = await calculateCost(
@@ -624,29 +618,36 @@ app.post("/", async (c) => {
       estimatedOutputTokens,
       billingSource,
     );
-    const costWithMarkup = await appCreditsService.calculateCostWithMarkup(
-      appId,
-      totalCost,
-    );
-    const balanceCheck = await appCreditsService.checkBalance(
-      appId,
-      user.id,
-      costWithMarkup.totalCost,
-    );
+    const idempotencyKey = crypto.randomUUID();
 
-    if (!balanceCheck.sufficient) {
-      return anthropicError(
-        "rate_limit_error",
-        `Insufficient cloud credits. Required: $${costWithMarkup.totalCost.toFixed(4)}`,
-        429,
-      );
+    try {
+      reservation = await appCreditsService.reserveInferenceCredits({
+        appId,
+        userId: user.id,
+        estimatedBaseCost: totalCost,
+        description: `Messages API: ${model}`,
+        idempotencyKey,
+        metadata: {
+          model,
+          provider,
+          billingSource,
+          estimatedInputTokens,
+          estimatedOutputTokens,
+          streaming: Boolean(request.stream),
+        },
+        app: monetizedApp,
+      });
+    } catch (error) {
+      if (error instanceof InsufficientCreditsError) {
+        return anthropicError(
+          "rate_limit_error",
+          `Insufficient cloud credits. Required: $${error.required.toFixed(4)}`,
+          429,
+        );
+      }
+
+      throw error;
     }
-
-    appCreditsInfo = {
-      appId,
-      estimatedBaseCost: 0,
-    };
-    reservation = creditsService.createAnonymousReservation();
   } else {
     try {
       reservation = await reserveCredits(
@@ -695,7 +696,6 @@ app.post("/", async (c) => {
         request,
         user,
         apiKey,
-        appCreditsInfo,
         affiliateCode,
         startTime,
         estimatedInputTokens,
@@ -716,7 +716,6 @@ app.post("/", async (c) => {
       request,
       user,
       apiKey,
-      appCreditsInfo,
       affiliateCode,
       startTime,
       safeParams,
@@ -760,7 +759,6 @@ async function handleNonStream(
   request: AnthropicMessagesRequest,
   user: { id: string; organization_id: string },
   apiKey: { id: string } | null,
-  appCreditsInfo: AppCreditsInfo | undefined,
   affiliateCode: string | null,
   startTime: number,
   safeParams: ReturnType<typeof getSafeModelParams>,
@@ -779,9 +777,6 @@ async function handleNonStream(
   billingSource: PricingBillingSource,
 ) {
   const provider = getProviderFromModel(model);
-  // #10423: stable per-request key so a settlement retry doesn't double-credit
-  // the app creator's redeemable earnings.
-  const requestId = crypto.randomUUID();
 
   const cotBudget = resolveAnthropicThinkingBudgetTokens(model, process.env);
   const cotOptions =
@@ -824,23 +819,6 @@ async function handleNonStream(
       result.usage,
     );
     await settleReservation(billing.totalCost);
-
-    if (appCreditsInfo) {
-      await appCreditsService.reconcileCredits({
-        appId: appCreditsInfo.appId,
-        userId: user.id,
-        estimatedBaseCost: appCreditsInfo.estimatedBaseCost,
-        actualBaseCost: billing.totalCost,
-        description: `Messages API: ${model}`,
-        metadata: {
-          model,
-          provider,
-          billingSource,
-          streaming: false,
-          idempotencyKey: requestId,
-        },
-      });
-    }
 
     await recordUsageAnalytics(
       {
@@ -919,7 +897,6 @@ async function handleStream(
   request: AnthropicMessagesRequest,
   user: { id: string; organization_id: string },
   apiKey: { id: string } | null,
-  appCreditsInfo: AppCreditsInfo | undefined,
   affiliateCode: string | null,
   startTime: number,
   estimatedInputTokens: number,
@@ -940,9 +917,6 @@ async function handleStream(
 ) {
   const provider = getProviderFromModel(model);
   const messageId = `msg_${crypto.randomUUID().replace(/-/g, "").slice(0, 24)}`;
-  // #10423: stable per-request key so a streaming settlement retry doesn't
-  // double-credit the app creator's redeemable earnings.
-  const requestId = crypto.randomUUID();
 
   const cotBudget = resolveAnthropicThinkingBudgetTokens(model, process.env);
   const cotOptions =
@@ -984,23 +958,6 @@ async function handleStream(
           totalUsage,
         );
         await settleReservation(billing.totalCost);
-
-        if (appCreditsInfo) {
-          await appCreditsService.reconcileCredits({
-            appId: appCreditsInfo.appId,
-            userId: user.id,
-            estimatedBaseCost: appCreditsInfo.estimatedBaseCost,
-            actualBaseCost: billing.totalCost,
-            description: `Messages API stream: ${model}`,
-            metadata: {
-              model,
-              provider,
-              billingSource,
-              streaming: true,
-              idempotencyKey: requestId,
-            },
-          });
-        }
 
         await recordUsageAnalytics(
           {

--- a/packages/cloud/shared/src/lib/services/__tests__/app-credits-ledger.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-credits-ledger.test.ts
@@ -56,7 +56,21 @@ const addCredits = mock();
 const reserveAndDeductCredits = mock();
 const refundCredits = mock();
 
+class MockInsufficientCreditsError extends Error {
+  constructor(
+    public readonly required: number,
+    public readonly available: number,
+    public readonly reason?: string,
+  ) {
+    super(
+      `Insufficient credits. Required: $${required.toFixed(4)}, Available: $${available.toFixed(4)}`,
+    );
+    this.name = "InsufficientCreditsError";
+  }
+}
+
 mock.module("../credits", () => ({
+  InsufficientCreditsError: MockInsufficientCreditsError,
   creditsService: {
     addCredits,
     reserveAndDeductCredits,
@@ -324,6 +338,85 @@ describe("deductCredits — debits the same org ledger", () => {
     expect(negativeAppEarnings.length).toBe(1);
     expect(negativeAppEarnings[0][1]).toBeCloseTo(-0.1, 10);
     expect(reduceEarnings).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("reserveInferenceCredits — holds app inference cost before model work", () => {
+  test("atomically debits the estimated marked-up cost up front", async () => {
+    const reservation = await freshService().reserveInferenceCredits({
+      appId: APP_ID,
+      userId: USER_ID,
+      estimatedBaseCost: 1,
+      description: "messages estimate",
+      idempotencyKey: "req-1",
+      metadata: { model: "anthropic/claude-sonnet-4" },
+    });
+
+    expect(reserveAndDeductCredits).toHaveBeenCalledTimes(1);
+    const debit = reserveAndDeductCredits.mock.calls[0][0];
+    expect(debit.organizationId).toBe(ORG_ID);
+    expect(debit.amount).toBeCloseTo(1.1, 10);
+    expect(debit.metadata.idempotencyKey).toBe("req-1:estimate");
+    expect(reservation.reservedAmount).toBeCloseTo(1.1, 10);
+    expect(reservation.reservationTransactionId).toBe("tx-2");
+    expect(addEarnings.mock.calls[0][0].sourceId).toBe("req-1:estimate:inference_markup");
+  });
+
+  test("fails before model work when the upfront app hold cannot be collected", async () => {
+    reserveAndDeductCredits.mockResolvedValue({
+      success: false,
+      newBalance: 0.05,
+      transaction: null,
+    });
+
+    await expect(
+      freshService().reserveInferenceCredits({
+        appId: APP_ID,
+        userId: USER_ID,
+        estimatedBaseCost: 1,
+        description: "messages estimate",
+      }),
+    ).rejects.toThrow("Insufficient credits");
+
+    expect(trackAppUserActivity).not.toHaveBeenCalled();
+    expect(addInferenceEarnings).not.toHaveBeenCalled();
+    expect(addEarnings).not.toHaveBeenCalled();
+  });
+
+  test("settling to zero refunds the upfront app hold and reverses creator earnings", async () => {
+    const reservation = await freshService().reserveInferenceCredits({
+      appId: APP_ID,
+      userId: USER_ID,
+      estimatedBaseCost: 1,
+      description: "messages estimate",
+      idempotencyKey: "req-2",
+    });
+
+    const result = await reservation.reconcile(0);
+
+    expect(result?.adjustmentType).toBe("refund");
+    expect(refundCredits).toHaveBeenCalledTimes(1);
+    expect(refundCredits.mock.calls[0][0].organizationId).toBe(ORG_ID);
+    expect(refundCredits.mock.calls[0][0].amount).toBeCloseTo(1.1, 10);
+    expect(reduceEarnings).toHaveBeenCalledTimes(1);
+    expect(reduceEarnings.mock.calls[0][0].amount).toBeCloseTo(0.1, 10);
+  });
+
+  test("uses distinct stable creator-earning keys for estimate and overage", async () => {
+    const reservation = await freshService().reserveInferenceCredits({
+      appId: APP_ID,
+      userId: USER_ID,
+      estimatedBaseCost: 1,
+      description: "messages estimate",
+      idempotencyKey: "req-3",
+    });
+
+    const result = await reservation.reconcile(2);
+
+    expect(result?.adjustmentType).toBe("overage");
+    expect(addEarnings).toHaveBeenCalledTimes(2);
+    expect(addEarnings.mock.calls[0][0].sourceId).toBe("req-3:estimate:inference_markup");
+    expect(addEarnings.mock.calls[1][0].sourceId).toBe("req-3:reconcile:inference_markup");
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/app-credits.ts
+++ b/packages/cloud/shared/src/lib/services/app-credits.ts
@@ -17,7 +17,12 @@ import {
   computePurchaseSplit,
   computeReconciliation,
 } from "./app-credit-math";
-import { creditsService } from "./credits";
+import {
+  type CreditReconciliationResult,
+  type CreditReservation,
+  creditsService,
+  InsufficientCreditsError,
+} from "./credits";
 import { redeemableEarningsService } from "./redeemable-earnings";
 
 /**
@@ -104,6 +109,41 @@ function validateMetadata(
   return metadata;
 }
 
+function withChargePhaseIdempotencyKey(
+  metadata: Record<string, unknown> | undefined,
+  idempotencyKey: string | undefined,
+  phase: "estimate" | "reconcile",
+): Record<string, unknown> | undefined {
+  if (!idempotencyKey) return metadata;
+  return {
+    ...metadata,
+    idempotencyKey: `${idempotencyKey}:${phase}`,
+  };
+}
+
+function mapAppReconciliationToCreditResult(
+  result: AppCreditReconciliationResult,
+  reservedAmount: number,
+  actualCost: number,
+  reservationTransactionId: string | null,
+): CreditReconciliationResult {
+  let adjustmentType: CreditReconciliationResult["adjustmentType"] = "none";
+
+  if (result.action === "refund" && result.reconciled) {
+    adjustmentType = "refund";
+  } else if (result.action === "charge") {
+    adjustmentType = result.reconciled ? "overage" : "uncollected_overage";
+  }
+
+  return {
+    reservedAmount,
+    actualCost,
+    reservationTransactionId,
+    settlementTransactionIds: [],
+    adjustmentType,
+  };
+}
+
 /**
  * Parameters for purchasing app credits.
  */
@@ -154,6 +194,25 @@ export interface AppCreditDeductionResult {
   newBalance: number;
   transactionId?: string;
   message?: string;
+}
+
+/**
+ * Parameters for atomically reserving app inference credits before model work.
+ */
+export interface AppCreditInferenceReservationParams {
+  appId: string;
+  userId: string;
+  estimatedBaseCost: number;
+  description: string;
+  metadata?: Record<string, unknown>;
+  /**
+   * Stable request id used to dedupe creator earnings across settlement retries.
+   * The service suffixes this per charge phase so the upfront estimate and a
+   * later overage adjustment can both credit the creator exactly once.
+   */
+  idempotencyKey?: string;
+  /** Optional: pass pre-fetched app to avoid N+1 query */
+  app?: App;
 }
 
 /**
@@ -315,6 +374,54 @@ export class AppCreditsService {
       platformOffset,
       creatorEarnings,
       newBalance,
+    };
+  }
+
+  async reserveInferenceCredits(
+    params: AppCreditInferenceReservationParams,
+  ): Promise<CreditReservation> {
+    const { appId, userId, estimatedBaseCost, description, metadata, idempotencyKey, app } = params;
+
+    const deduction = await this.deductCredits({
+      appId,
+      userId,
+      baseCost: estimatedBaseCost,
+      description,
+      metadata: withChargePhaseIdempotencyKey(metadata, idempotencyKey, "estimate"),
+      app,
+    });
+
+    if (!deduction.success) {
+      throw new InsufficientCreditsError(
+        deduction.totalCost,
+        deduction.newBalance,
+        "insufficient_balance",
+      );
+    }
+
+    const reservationTransactionId = deduction.transactionId ?? null;
+
+    return {
+      reservedAmount: deduction.totalCost,
+      reservationTransactionId,
+      reconcile: async (actualBaseCost: number) => {
+        const reconciliation = await this.reconcileCredits({
+          appId,
+          userId,
+          estimatedBaseCost,
+          actualBaseCost,
+          description,
+          metadata: withChargePhaseIdempotencyKey(metadata, idempotencyKey, "reconcile"),
+          app,
+        });
+
+        return mapAppReconciliationToCreditResult(
+          reconciliation,
+          deduction.totalCost,
+          actualBaseCost,
+          reservationTransactionId,
+        );
+      },
     };
   }
 


### PR DESCRIPTION
Fixes #10857

## Summary
- Added `AppCreditsService.reserveInferenceCredits()` to atomically debit the estimated app inference cost before model work and reconcile estimate-to-actual through the existing app-credit ledger.
- Updated monetized `X-App-Id` paths in `/v1/messages` and `/v1/chat/completions` to use the upfront app reservation instead of a read-only balance check plus anonymous reservation.
- Kept creator earnings idempotent without suppressing legitimate overage earnings by using separate stable charge-phase keys for estimate and reconcile adjustments.

## Evidence
- `bunx biome check --write packages/cloud/shared/src/lib/services/app-credits.ts packages/cloud/shared/src/lib/services/__tests__/app-credits-ledger.test.ts packages/cloud/api/v1/messages/route.ts packages/cloud/api/v1/chat/completions/route.ts`
- `bun test packages/cloud/shared/src/lib/services/__tests__/app-credits-ledger.test.ts` — 25 tests passed
- `bun test packages/cloud/api/__tests__/messages-iac-fast-path.test.ts` — 2 tests passed
- `rg -n "checkBalance\(|calculateCostWithMarkup\(|createAnonymousReservation\(|estimatedBaseCost: 0|No upfront debit" packages/cloud/api/v1/messages/route.ts packages/cloud/api/v1/chat/completions/route.ts` — no stale advisory-check or zero-estimate app-credit path remains; remaining anonymous reservations are non-app optimistic fallbacks

## Blocked / Not Run
- `bun test packages/cloud/api/__tests__/chat-completions-streaming-credit-leak.test.ts` is blocked in this worktree by an incomplete linked dependency tree, ending at missing `redis` from `packages/cloud/shared/src/lib/cache/client.ts`.
- `bun run --cwd packages/cloud/shared typecheck` and `bun run --cwd packages/cloud/api typecheck` are blocked by missing top-level dependency/type links in the local install (`@cloudflare/workers-types`, `redis`, `uuid`, `viem`, `decimal.js`, and others). Details are in `.github/issue-evidence/10857-app-credit-hold.md`.

## Evidence Artifact
- `.github/issue-evidence/10857-app-credit-hold.md