### PR TITLE
fix(app/desktop): reject bare printable chat hotkeys with no modifier (#10716)

### DIFF
--- a/packages/ui/src/state/useChatOverlayHotkey.test.ts
+++ b/packages/ui/src/state/useChatOverlayHotkey.test.ts
@@ -102,4 +102,15 @@ describe("acceleratorFromKeyboardEvent", () => {
       acceleratorFromKeyboardEvent({ ...base, key: "F5", shiftKey: true }),
     ).toBe("Shift+F5");
   });
+
+  it("rejects a bare printable key with no modifier (would hijack it globally)", () => {
+    expect(acceleratorFromKeyboardEvent({ ...base, key: "c" })).toBeNull();
+    expect(acceleratorFromKeyboardEvent({ ...base, key: "1" })).toBeNull();
+    // A named key may still bind on its own.
+    expect(acceleratorFromKeyboardEvent({ ...base, key: "F5" })).toBe("F5");
+    // Any modifier makes a printable key bindable again.
+    expect(
+      acceleratorFromKeyboardEvent({ ...base, key: "c", ctrlKey: true }),
+    ).toBe("CommandOrControl+C");
+  });
 });

--- a/packages/ui/src/state/useChatOverlayHotkey.ts
+++ b/packages/ui/src/state/useChatOverlayHotkey.ts
@@ -103,6 +103,15 @@ export function acceleratorFromKeyboardEvent(event: {
   if (MODIFIER_KEYS.has(event.key)) {
     return null;
   }
+  const hasModifier =
+    event.ctrlKey || event.metaKey || event.altKey || event.shiftKey;
+  // A bare single printable character (e.g. "C") is rejected as a global
+  // accelerator — registering it would hijack that key everywhere the app is
+  // backgrounded. Require at least one modifier for printable keys; named keys
+  // (F-keys, Space, arrows, …) may bind on their own.
+  if (event.key.length === 1 && !hasModifier) {
+    return null;
+  }
   const parts: string[] = [];
   if (event.ctrlKey || event.metaKey) {
     parts.push("CommandOrControl");


### PR DESCRIPTION
## What & why

Small follow-up hardening to **#10716** (the programmable chat-summon hotkey merged in #10826), addressing a **minor finding from the pre-merge review**.

`acceleratorFromKeyboardEvent` (`packages/ui/src/state/useChatOverlayHotkey.ts`) accepted a **bare single printable key** with no modifier — e.g. pressing just `C` recorded `"C"` as the global accelerator. Registered as an OS-level `GlobalShortcut`, that would **hijack that key everywhere** the app is backgrounded (you could never type a lowercase `c` in any other app).

## Change

Reject a bare single printable character when no modifier is held; function/named keys (F-keys, Space, arrows, …) may still bind on their own, and any modifier makes a printable key bindable again. One guard, four new assertions.

```ts
const hasModifier = event.ctrlKey || event.metaKey || event.altKey || event.shiftKey;
if (event.key.length === 1 && !hasModifier) return null;  // bare printable → nothing to bind
```

## Evidence

- `bun run --cwd packages/ui vitest run src/state/useChatOverlayHotkey.test.ts` → **11 passed** (on `develop` base). New cases: bare `c`/`1` → `null`; `F5` alone → `"F5"`; `Ctrl+c` → `"CommandOrControl+C"`. Existing cases (incl. `Shift+F5`) unchanged.
- Pure function change; no runtime/agent/UI-render path. **Real-LLM trajectory / screenshots / device capture: N/A** — this is input-validation logic exercised directly by the unit test.
