### PR TITLE
docs(cloud): align app and container API contracts (#10877)

### DIFF
--- a/.github/issue-evidence/10877-cloud-api-doc-contracts.md
+++ b/.github/issue-evidence/10877-cloud-api-doc-contracts.md
@@ -1,0 +1,22 @@
+# #10877 cloud API docs contract evidence
+
+## Source-of-truth checks
+
+- `packages/cloud/api/v1/containers/schema.ts` accepts create-container request keys `projectName`, `memoryMb`, `healthCheckPath`, and `environmentVars`; it does not accept `persistVolume`, `useHetznerVolume`, or `volume_size_gb`.
+- `packages/cloud/api/v1/containers/route.ts` defaults create resources to `cpu: 1792` and `memoryMb: 1792`, and returns `{ success, data }` for create without a `polling` block.
+- `packages/cloud/api/v1/containers/[id]/route.ts` uses the `PatchContainerSchema` `action` union: `restart`, `setEnv`, and `scale`.
+- `packages/cloud/api/v1/apps/route.ts` returns the created app API key as `apiKey: result.apiKey`, a one-time plaintext string.
+
+## Validation
+
+```bash
+bun run --cwd packages/docs test
+```
+
+Result: 15 tests passed.
+
+## N/A artifacts
+
+- Real-LLM trajectory: N/A, docs-only contract correction.
+- Backend/frontend logs: N/A, no runtime code path changed.
+- Screenshots/video: N/A for this local pass because `@elizaos/docs` has no repo build script; Mintlify preview is outside the package scripts. The docs navigation/link suite passed locally.

--- a/packages/docs/cloud/api/apps.mdx
+++ b/packages/docs/cloud/api/apps.mdx
@@ -74,14 +74,12 @@ Create a new Cloud app. The response includes a one-time app API key for server-
     "allowed_origins": ["https://placeholder.invalid"],
     "created_at": "2026-05-05T10:30:00Z"
   },
-  "apiKey": {
-    "id": "key_abc123"
-  }
+  "apiKey": "eliza_abc123..."
 }
 ```
 
 <Warning>
-  Store the returned API key securely. Use user bearer tokens, not this admin key, for user-facing app-scoped chat.
+  Store the returned one-time plaintext API key immediately. Use user bearer tokens, not this admin key, for user-facing app-scoped chat.
 </Warning>
 
 ---

--- a/packages/docs/cloud/api/containers.mdx
+++ b/packages/docs/cloud/api/containers.mdx
@@ -29,8 +29,8 @@ Get all containers for your organization.
       "status": "running",
       "image_tag": "ghcr.io/acme/my-app:latest",
       "load_balancer_url": "https://my-app.example.com",
-      "cpu": 256,
-      "memory": 512,
+      "cpu": 1792,
+      "memory": 1792,
       "port": 3000,
       "desired_count": 1,
       "billing_status": "active",
@@ -49,7 +49,7 @@ Get all containers for your organization.
   <span className="path">/api/v1/containers</span>
 </div>
 
-Deploy a new container. Returns a container record and polling instructions.
+Deploy a new container. Returns a container record.
 
 ### Request
 
@@ -61,8 +61,8 @@ The request body is **camelCase** — the server validates with a strict schema 
   "projectName": "my-app",
   "image": "ghcr.io/elizaos/example-edad:showcase",
   "port": 3000,
-  "cpu": 256,
-  "memoryMb": 512,
+  "cpu": 1792,
+  "memoryMb": 1792,
   "healthCheckPath": "/health",
   "environmentVars": {
     "PORT": "3000",
@@ -79,13 +79,10 @@ The request body is **camelCase** — the server validates with a strict schema 
 | `projectName` | string | no | Stable project identifier. |
 | `image` | string | yes | Full image reference, for example `ghcr.io/owner/repo:tag`. |
 | `port` | integer | no | Container port. Default: 3000. |
-| `cpu` | integer | no | CPU units. Default: 256. |
-| `memoryMb` | integer | no | Memory in MB. Default: 512. |
+| `cpu` | integer | no | CPU units. Default: 1792. |
+| `memoryMb` | integer | no | Memory in MB. Default: 1792. |
 | `healthCheckPath` | string | no | Health check endpoint. Default: `/health`. |
 | `environmentVars` | object | no | String environment variables (this is where `ELIZA_APP_ID` belongs). |
-| `persistVolume` | boolean | no | Mount project-scoped persistent storage at `/data`. |
-| `useHetznerVolume` | boolean | no | Use a Hetzner Cloud volume when persistent volumes are enabled and configured. |
-| `volume_size_gb` | integer | no | Declared volume size in GiB. Default: 10. |
 
 ### Response
 
@@ -97,12 +94,12 @@ The request body is **camelCase** — the server validates with a strict schema 
     "name": "My App",
     "project_name": "my-app",
     "status": "deploying",
-    "load_balancer_url": "https://my-app.example.com"
-  },
-  "polling": {
-    "endpoint": "/api/v1/containers/550e8400-e29b-41d4-a716-446655440000",
-    "intervalMs": 5000,
-    "expectedDurationMs": 120000
+    "load_balancer_url": "https://my-app.example.com",
+    "cpu": 1792,
+    "memory": 1792,
+    "port": 3000,
+    "desired_count": 1,
+    "health_check_path": "/health"
   }
 }
 ```
@@ -142,11 +139,30 @@ Get container details and deployment status.
   <span className="path">/api/v1/containers/{"{id}"}</span>
 </div>
 
-Patch supports:
+Patch bodies are action-discriminated. Send exactly one of these shapes:
 
-- `environment_vars` to replace runtime environment variables.
-- `desired_count` to scale, currently only `1`.
-- `action: "restart"` to restart the container.
+```json
+{ "action": "restart" }
+```
+
+```json
+{
+  "action": "setEnv",
+  "environmentVars": {
+    "PORT": "3000",
+    "ELIZA_APP_ID": "uuid-abc123"
+  }
+}
+```
+
+```json
+{
+  "action": "scale",
+  "desiredCount": 1
+}
+```
+
+The current backend supports `desiredCount: 1`.
 
 ---
 

--- a/packages/docs/cloud/apps.mdx
+++ b/packages/docs/cloud/apps.mdx
@@ -59,14 +59,12 @@ curl -X POST "https://www.elizacloud.ai/api/v1/apps" \
     "allowed_origins": ["https://placeholder.invalid"],
     "created_at": "2026-05-05T10:30:00Z"
   },
-  "apiKey": {
-    "id": "key_abc123"
-  }
+  "apiKey": "eliza_abc123..."
 }
 ```
 
 <Warning>
-  The app API key is server-side only. For user-facing chat, forward the user's bearer token to the app-scoped chat endpoint so the user's organization balance is charged.
+  The app API key is returned as one-time plaintext and is server-side only. Store it immediately. For user-facing chat, forward the user's bearer token to the app-scoped chat endpoint so the user's organization balance is charged.
 </Warning>
 
 ## Creating an App

--- a/packages/docs/cloud/containers.mdx
+++ b/packages/docs/cloud/containers.mdx
@@ -12,8 +12,8 @@ Deploy custom Docker images on Eliza Cloud managed container infrastructure.
 Container deployment provides:
 
 - **Custom runtimes**: Run your own Docker image.
-- **Project identity**: Use `project_name` as the stable deployment identifier.
-- **Managed health checks**: Poll your `health_check_path` and update status.
+- **Project identity**: Use `projectName` as the stable deployment identifier in requests.
+- **Managed health checks**: Poll your `healthCheckPath` and update status.
 - **Logs and metrics**: Fetch logs and runtime metrics through the API.
 - **Earnings-first billing**: Daily hosting can be paid from redeemable earnings before org credits.
 
@@ -25,14 +25,13 @@ curl -X POST "https://www.elizacloud.ai/api/v1/containers" \
   -H "Content-Type: application/json" \
   -d '{
     "name": "my-service",
-    "project_name": "my-service",
+    "projectName": "my-service",
     "image": "ghcr.io/acme/my-service:latest",
     "port": 3000,
-    "cpu": 256,
-    "memory": 512,
-    "desired_count": 1,
-    "health_check_path": "/health",
-    "environment_vars": {
+    "cpu": 1792,
+    "memoryMb": 1792,
+    "healthCheckPath": "/health",
+    "environmentVars": {
       "NODE_ENV": "production"
     }
   }'
@@ -49,7 +48,7 @@ Push to a registry that Cloud nodes can pull from, such as GHCR, Docker Hub, or 
 
 <Step title="Create the container">
 
-Send `image`, `project_name`, `port`, resources, and any `environment_vars`.
+Send `image`, `projectName`, `port`, resources, and any `environmentVars`.
 
 </Step>
 
@@ -71,14 +70,13 @@ For app projects, patch the Eliza Cloud app `app_url` and `allowed_origins` to t
 ```json
 {
   "name": "my-service",
-  "project_name": "my-service",
+  "projectName": "my-service",
   "image": "ghcr.io/acme/my-service:latest",
   "port": 3000,
-  "cpu": 256,
-  "memory": 512,
-  "desired_count": 1,
-  "health_check_path": "/health",
-  "environment_vars": {
+  "cpu": 1792,
+  "memoryMb": 1792,
+  "healthCheckPath": "/health",
+  "environmentVars": {
     "PORT": "3000",
     "ELIZA_APP_ID": "uuid-abc123"
   }
@@ -88,14 +86,13 @@ For app projects, patch the Eliza Cloud app `app_url` and `allowed_origins` to t
 | Field | Description |
 | ----- | ----------- |
 | `name` | Human-readable container name. |
-| `project_name` | Stable project identifier used for deployment records and project-scoped volumes. |
+| `projectName` | Stable project identifier used for deployment records and project-scoped volumes. |
 | `image` | Full image reference pulled directly by the container backend. |
 | `port` | Application port. Default: 3000. |
-| `cpu` | CPU units used for API compatibility and billing. Default: 256. |
-| `memory` | Memory in MB. Default: 512. |
-| `desired_count` | Currently must be 1. |
-| `health_check_path` | HTTP health path. Default: `/health`. |
-| `environment_vars` | String key/value environment variables. |
+| `cpu` | CPU units used for API compatibility and billing. Default: 1792. |
+| `memoryMb` | Memory in MB. Default: 1792. |
+| `healthCheckPath` | HTTP health path. Default: `/health`. |
+| `environmentVars` | String key/value environment variables. |
 
 <Info>
   The current public create-container payload uses `image`, not the older `ecr_image_uri` field. The backend pulls the image directly on the target Docker node.
@@ -110,9 +107,9 @@ When earnings-first billing is off, hosting bills come only from credits and ear
 ## Best Practices
 
 - Expose a fast `/health` route.
-- Keep `desired_count` at `1`.
+- Container scaling is currently fixed at one replica.
 - Keep secrets server-side and pass only required runtime env vars.
-- Use a stable `project_name`; project-scoped persistent data is keyed by organization and project name.
+- Use a stable `projectName`; project-scoped persistent data is keyed by organization and project name.
 - For monetized apps, pass `ELIZA_APP_ID` to your container and patch the Cloud app URL after deploy.
 
 ## Next Steps


### PR DESCRIPTION
## Summary

Fixes #10877.

- Corrected Cloud container create examples to use the camelCase request contract: `projectName`, `memoryMb`, `healthCheckPath`, and `environmentVars`.
- Updated documented container defaults from `256` / `512` to the route defaults of `1792` / `1792`.
- Removed unsupported create payload volume fields and the nonexistent create-response `polling` block.
- Documented the container PATCH `action` union: `restart`, `setEnv`, and `scale` with `desiredCount`.
- Corrected Cloud app create responses to show the one-time plaintext `apiKey` string returned by the route.

## Validation

- `bun run --cwd packages/docs test` → 15 passed
- `git diff --check` → clean
- Evidence: `.github/issue-evidence/10877-cloud-api-doc-contracts.md`

## Evidence notes

- Screenshots/video: N/A for this local pass; `@elizaos/docs` has no repo build script beyond Mintlify-managed hosting/prebuild asset sync, and the docs navigation/link suite passed locally.
- Runtime logs / LLM trajectory: N/A, docs-only contract correction.
