### PR TITLE
ci(cloud): scoped npm publish workflow for @elizaos/example-code (eliza-code) (#10059)

### DIFF
--- a/.github/workflows/publish-example-code.yml
+++ b/.github/workflows/publish-example-code.yml
@@ -1,0 +1,106 @@
+# Publishes @elizaos/example-code (npm) — the elizaOS-owned "eliza-code" coding
+# agent (runtime + coding tools + orchestrator; the opencode replacement, #10059).
+# The Cloud coding-container runner installs this package to run eliza-code, so it
+# must exist on npm before the runner image can bundle it.
+#
+# Scoped, single-package publish (modeled on publish-plugin-elizacloud.yml): it
+# publishes ONLY @elizaos/example-code, never triggers a monorepo release. The
+# guard is an npm-existence check (not a git-version diff), so it publishes the
+# first-ever version correctly, is idempotent (a re-run when the version already
+# exists is a no-op), and never republishes an existing version.
+name: Publish @elizaos/example-code
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - "packages/examples/code/**"
+      - ".github/workflows/publish-example-code.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: publish-example-code-${{ github.ref }}
+  cancel-in-progress: false
+
+# Default to least privilege. Override per-job where needed.
+permissions:
+  contents: read
+
+jobs:
+  check_npm:
+    runs-on: ubuntu-24.04
+    outputs:
+      should_publish: ${{ steps.check.outputs.should_publish }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          filter: blob:none
+
+      - name: Check whether this version is already on npm
+        id: check
+        run: |
+          set -euo pipefail
+          PKG_JSON="packages/examples/code/package.json"
+          NAME=$(jq -r .name "$PKG_JSON")
+          VERSION=$(jq -r .version "$PKG_JSON")
+          echo "Package: ${NAME}@${VERSION}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          # Publish only if this exact name@version is NOT already published.
+          # `npm view` exits non-zero (E404) for an unpublished version.
+          if npm view "${NAME}@${VERSION}" version >/dev/null 2>&1; then
+            echo "Already published — skipping."
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Not on npm yet — will publish."
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  publish_npm:
+    needs: check_npm
+    if: needs.check_npm.outputs.should_publish == 'true'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      id-token: write # npm OIDC trusted publishing (SOC2 CC9.2)
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+          filter: blob:none
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: canary
+
+      - name: Install and build
+        working-directory: packages/examples/code
+        run: |
+          bun install
+          bun run build
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Publish to npm
+        # Publishes under the `beta` dist-tag because the version is a
+        # pre-release (2.0.0-beta.x) — it must NOT hijack `@latest`. The Cloud
+        # runner pins the exact version, so the tag is for hygiene, not resolution.
+        # Auth: prefer npm OIDC (id-token: write); NPM_TOKEN is the fallback.
+        working-directory: packages/examples/code
+        run: npm publish --tag beta --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"
+
+      - name: Create git tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "example-code-v${{ needs.check_npm.outputs.version }}" \
+            -m "example-code v${{ needs.check_npm.outputs.version }}" || true
+          git push origin "example-code-v${{ needs.check_npm.outputs.version }}" || true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Unblocks **step 1** of the #10059 coding-agent cutover — the maintainer-confirmed **Option 2 / coding-container** path. The Cloud coding-container runner installs `@elizaos/example-code` to run eliza-code, but the package **is not on npm yet** (registry 404), so the runner image can't bundle it.

### What this adds
A scoped, single-package publish workflow **modeled on the existing `publish-plugin-elizacloud.yml`** (same pinned actions, same npm OIDC + `NPM_TOKEN` auth, `npm publish --access public`). It publishes **only** `@elizaos/example-code` — it never triggers a monorepo `lerna publish` / release.

### Why not just run the existing release?
The only other npm path is `release.yaml` → `lerna publish from-package`, which publishes the **entire `@elizaos/*` scope** on a release event. That's the wrong blast radius for "publish one new example package," and it needs the org `NPM_TOKEN` (not available on a dev box). This workflow is the correct scoped tool.

### Improvement over the elizacloud model
The elizacloud workflow gates on a **git version diff** (republish-on-bump). That never fires for a **first** publish. This one gates on an **npm-existence check** (`npm view name@version`): it (a) correctly publishes the first-ever version, (b) is **idempotent** — a re-run when the version already exists is a no-op, and (c) never republishes an existing version. Publishes under the **`beta`** dist-tag since the version is a pre-release (`2.0.0-beta.x`), so it doesn't hijack `@latest`.

### How the publish happens
Merging this PR touches the workflow-file path → the `push` trigger runs the workflow → it sees `2.0.0-beta.0` is unpublished → publishes it **in CI with the org `NPM_TOKEN`**. No local token, no whole-scope release, fully auditable. (Also `workflow_dispatch`-able for re-runs.)

### Verified
`@elizaos/example-code` builds clean locally — `dist/index.js` + `dist/acp.js` (bin `eliza-code-acp` → `./dist/acp.js`, the ACP entry the runner env needs).

### Follow-up (gated on this landing + the publish)
Add the `eliza-code` install line (pinning the exact version) to `coding-remote-runner/Dockerfile`, then the runner env flip (`ELIZA_ACP_DEFAULT_AGENT=elizaos` + `ELIZA_ELIZAOS_ACP_COMMAND`) + redeploy + a live app-build verify. Tracked on #10059.

cc @lalalune @0xSolace — this is the sanctioned way to get eliza-code onto npm without a monorepo release; merge triggers the scoped publish.