### PR TITLE
fix(cloud/billing): don't mint affiliate earnings from anonymous $0 chat requests (#10853)

### DIFF
--- a/packages/cloud/api/__tests__/affiliate-earnings-anon-guard.test.ts
+++ b/packages/cloud/api/__tests__/affiliate-earnings-anon-guard.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Money-leak guard (#10853): anonymous free-tier chat charges $0, so affiliate
+ * earnings must NOT be credited from anonymous requests — otherwise an attacker
+ * with an active affiliate code POSTs /api/v1/chat unauthenticated with
+ * X-Affiliate-Code=<own code> and mints cashable redeemable balance from nothing.
+ *
+ * Drives the REAL `shouldCreditAffiliateEarnings` gate (the exact predicate the
+ * billing paths use before calling redeemableEarningsService.addEarnings).
+ */
+import { describe, expect, test } from "bun:test";
+import { shouldCreditAffiliateEarnings } from "@/lib/services/affiliate-earnings-guard";
+import type { BillingContext } from "@/lib/services/ai-billing";
+
+const ctx = (over: Partial<BillingContext>): BillingContext => ({
+  organizationId: "org-real",
+  userId: "user-1",
+  model: "gpt-oss-120b",
+  affiliateCode: "AFF123",
+  ...over,
+});
+
+describe("shouldCreditAffiliateEarnings (#10853)", () => {
+  test("anonymous request (isAnonymous:true) → do NOT credit affiliate earnings", () => {
+    expect(shouldCreditAffiliateEarnings(ctx({ isAnonymous: true }))).toBe(
+      false,
+    );
+  });
+
+  test("legacy sentinel org 'anonymous' (no explicit flag) → do NOT credit", () => {
+    expect(
+      shouldCreditAffiliateEarnings(
+        ctx({ organizationId: "anonymous", isAnonymous: undefined }),
+      ),
+    ).toBe(false);
+  });
+
+  test("real authed org (isAnonymous unset) → credit as before", () => {
+    expect(shouldCreditAffiliateEarnings(ctx({}))).toBe(true);
+  });
+
+  test("real authed org (isAnonymous:false) → credit", () => {
+    expect(shouldCreditAffiliateEarnings(ctx({ isAnonymous: false }))).toBe(
+      true,
+    );
+  });
+
+  test("both signals anonymous → do NOT credit (defense in depth)", () => {
+    expect(
+      shouldCreditAffiliateEarnings(
+        ctx({ organizationId: "anonymous", isAnonymous: true }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/cloud/api/v1/chat/route.ts
+++ b/packages/cloud/api/v1/chat/route.ts
@@ -367,6 +367,9 @@ app.post("/", async (c) => {
               model: selectedModel,
               provider,
               affiliateCode,
+              // Anonymous free-tier requests are charged $0; never mint
+              // affiliate earnings from them (#10853).
+              isAnonymous,
             },
             usage,
           );

--- a/packages/cloud/shared/src/lib/services/affiliate-earnings-guard.ts
+++ b/packages/cloud/shared/src/lib/services/affiliate-earnings-guard.ts
@@ -1,0 +1,19 @@
+import type { BillingContext } from "./ai-billing";
+
+/**
+ * Affiliate earnings are funded by the affiliate markup ADDED to what the user
+ * pays. Anonymous free-tier requests charge the user $0 (their reservation is a
+ * no-op), so crediting affiliate earnings from them would mint cashable
+ * redeemable balance from nothing (#10853). Credit affiliate earnings only for
+ * real, revenue-generating requests — never anonymous ones.
+ *
+ * The `organizationId === "anonymous"` check is a defense-in-depth backup for
+ * callers that pass the legacy sentinel org without setting the explicit flag.
+ *
+ * Lives in its own module (type-only import of `BillingContext`, erased at
+ * runtime) so the money-critical predicate is unit-testable without pulling in
+ * the ai-billing → DB layer.
+ */
+export function shouldCreditAffiliateEarnings(context: BillingContext): boolean {
+  return context.isAnonymous !== true && context.organizationId !== "anonymous";
+}

--- a/packages/cloud/shared/src/lib/services/ai-billing.ts
+++ b/packages/cloud/shared/src/lib/services/ai-billing.ts
@@ -21,6 +21,7 @@ import {
   PLATFORM_MARKUP_MULTIPLIER,
 } from "../pricing";
 import { logger } from "../utils/logger";
+import { shouldCreditAffiliateEarnings } from "./affiliate-earnings-guard";
 import type { PricingBillingSource } from "./ai-pricing-definitions";
 import { type CreditReservation, creditsService, InsufficientCreditsError } from "./credits";
 import { generationsService } from "./generations";
@@ -59,6 +60,12 @@ export interface BillingContext {
   metadata?: Record<string, unknown>;
   description?: string;
   affiliateCode?: string | null;
+  /**
+   * True for anonymous free-tier requests, which are charged $0 (the reservation
+   * is a no-op). Gates affiliate earnings so a $0 request cannot mint cashable
+   * affiliate balance (#10853).
+   */
+  isAnonymous?: boolean;
 }
 
 export interface BillingResult {
@@ -248,7 +255,7 @@ export async function billUsage(
       _appliedAffiliateMarkup = true;
 
       // Credit the affiliate owner
-      if (affiliateEarnings > 0) {
+      if (affiliateEarnings > 0 && shouldCreditAffiliateEarnings(context)) {
         // Prevent double booking on identical reservations easily,
         // using the transaction ID or random ID if none present.
         const sourceId = `legacy_${crypto.randomUUID()}`;
@@ -328,7 +335,7 @@ export async function billFlatUsage(
       totalCost += affiliateEarnings;
       inputCost = totalCost;
 
-      if (affiliateEarnings > 0) {
+      if (affiliateEarnings > 0 && shouldCreditAffiliateEarnings(context)) {
         const sourceId = `legacy_${crypto.randomUUID()}`;
 
         await redeemableEarningsService


### PR DESCRIPTION
Fixes #10853.

## The bug (money creation from $0 requests)
An attacker registers an active affiliate code, then repeatedly POSTs
`/api/v1/chat` **without authentication** (anonymous free tier) with header
`X-Affiliate-Code=<their own code>`. The anonymous path charges the user **$0**
(`createAnonymousReservation`'s reconcile is a no-op and `usageService.create` is
skipped) — but `billUsage` still ran its affiliate branch unconditionally and
called `redeemableEarningsService.addEarnings(totalCost * markupPercent)`,
incrementing the affiliate's **cashable** redeemable balance. Pure money creation
with zero offsetting revenue, repeatable across cheaply-created anonymous
sessions.

## The fix
Affiliate earnings are funded by the affiliate markup **added to what the user
pays**, so they should only be credited for real, revenue-generating requests.
- Add `isAnonymous` to `BillingContext`.
- Gate **both** affiliate `addEarnings` branches (`billUsage` + `billFlatUsage`)
  on `shouldCreditAffiliateEarnings(context)` — false when `isAnonymous`, or when
  the legacy sentinel org `"anonymous"` is used (defense-in-depth backup).
- Set `isAnonymous` at the `v1/chat` anonymous call site.

Authenticated requests are unchanged — the affiliate markup is still charged to
the user and funds the payout exactly as before.

## Tests / evidence
The gate lives in its own module (`affiliate-earnings-guard.ts`, a type-only
`BillingContext` import) so the money-critical predicate is unit-tested against
the **real** production code, without pulling in the `ai-billing → DB` layer:
`affiliate-earnings-anon-guard.test.ts` — anonymous / sentinel-org → **no
credit**; real authed org (flag unset or false) → **credit**; both-anonymous
defense-in-depth. **5 pass, 0 fail.** Biome clean; the only tsgo errors in the
fresh worktree are the unrelated missing generated `core/src/i18n/generated/*`
files.

_Live-stack E2E note:_ a full request-level proof would need `cloud:mock` + a
minted anonymous cookie + an active affiliate code; I proved the money-critical
decision via the extracted real gate (same approach as #10862, which you
reviewed). Happy to add a route-level test if preferred.
