### PR TITLE
fix(cloud): don't mint affiliate earnings for anonymous free-tier requests (#10853)

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/ai-billing-anon-affiliate.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/ai-billing-anon-affiliate.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Guard test for #10853 — anonymous free-tier chat must NOT mint affiliate
+ * earnings.
+ *
+ * billUsage applied the affiliate markup + credited the affiliate owner
+ * (redeemableEarningsService.addEarnings, cashable) whenever an active
+ * affiliateCode was present — with no check that the request was actually
+ * billed. On the anonymous free-tier path (organizationId "anonymous", a no-op
+ * reservation) the user pays $0, so an org owner could farm their own affiliate
+ * code via free anon requests, minting redeemable_earnings out of nothing.
+ *
+ * These tests drive the REAL billUsage. Only the pure downstream boundaries are
+ * stubbed (pricing math + the affiliate lookup + the earnings/usage/generation
+ * side-effect writers); the affiliate GUARD under test runs for real, so each
+ * test fails if the guard regresses.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+import * as realPricing from "../../pricing";
+
+// Deterministic cost so the affiliate math is predictable (no pricing catalog).
+mock.module("../../pricing", () => ({
+  ...realPricing,
+  calculateCost: mock(async () => ({ inputCost: 0.1, outputCost: 0.2, totalCost: 0.3 })),
+}));
+
+// Active affiliate code (10% markup) owned by AFFILIATE_USER.
+const AFFILIATE_USER = "00000000-0000-4000-8000-00000000aff1";
+mock.module("../../../db/repositories/affiliates", () => ({
+  affiliatesRepository: {
+    getAffiliateCodeByCode: mock(async () => ({
+      id: "aff-code-1",
+      user_id: AFFILIATE_USER,
+      markup_percent: "10",
+      is_active: true,
+    })),
+  },
+}));
+
+// Spy the cashable-earnings write — the thing that must NOT fire for anon.
+const addEarnings = mock(async () => ({ ledgerId: "l1" }));
+mock.module("../redeemable-earnings", () => ({
+  redeemableEarningsService: { addEarnings },
+}));
+
+// Side-effect writers billUsage calls — stub so the test needs no DB rows.
+mock.module("../usage", () => ({
+  usageService: { recordUsage: mock(async () => undefined), record: mock(async () => undefined) },
+}));
+mock.module("../generations", () => ({
+  generationsService: { record: mock(async () => undefined), create: mock(async () => undefined) },
+}));
+
+const { billUsage } = await import("../ai-billing");
+
+const USAGE = { promptTokens: 1000, completionTokens: 500, totalTokens: 1500 };
+const BASE = {
+  userId: "00000000-0000-4000-8000-00000000user",
+  model: "openai/gpt-oss-120b",
+  provider: "openai",
+  affiliateCode: "PARTNER10",
+};
+
+beforeEach(() => {
+  addEarnings.mockClear();
+});
+
+describe("billUsage affiliate earnings guard (#10853)", () => {
+  test("anonymous request with an affiliate code mints NO affiliate earnings", async () => {
+    const result = await billUsage({ ...BASE, organizationId: "anonymous" }, USAGE);
+
+    // The load-bearing assertion: no cashable earnings created for a $0 request.
+    expect(addEarnings).not.toHaveBeenCalled();
+    // And the affiliate markup was not layered onto the (uncollected) cost.
+    expect(result.totalCost).toBeCloseTo(0.3, 6);
+  });
+
+  test("a real paying org with the same affiliate code STILL credits the affiliate (regression)", async () => {
+    const result = await billUsage(
+      { ...BASE, organizationId: "00000000-0000-4000-8000-0000000000org" },
+      USAGE,
+    );
+
+    expect(addEarnings).toHaveBeenCalledTimes(1);
+    const arg = addEarnings.mock.calls[0][0] as { userId: string; amount: number; source: string };
+    expect(arg.userId).toBe(AFFILIATE_USER);
+    expect(arg.source).toBe("affiliate");
+    expect(arg.amount).toBeCloseTo(0.3 * 0.1, 6); // 10% of the $0.30 cost
+    // Affiliate markup was layered onto the charged cost for the paying org.
+    expect(result.totalCost).toBeCloseTo(0.3 + 0.03, 6);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/ai-billing.ts
+++ b/packages/cloud/shared/src/lib/services/ai-billing.ts
@@ -230,9 +230,14 @@ export async function billUsage(
   let baseTotalCost = totalCost / PLATFORM_MARKUP_MULTIPLIER;
   let platformMarkup = totalCost - baseTotalCost;
 
-  // Apply affiliate markup if present
+  // Apply affiliate markup if present — but NOT for anonymous (free-tier)
+  // requests. An "anonymous" org pays $0 (its reservation is a no-op), so there
+  // is no collected affiliate revenue to share; minting affiliate earnings here
+  // would create cashable redeemable_earnings out of nothing — an org owner
+  // could farm their own affiliate code via free anon requests (#10853). Only
+  // credit the affiliate when the request is billed to a real paying org.
   let _appliedAffiliateMarkup = false;
-  if (context.affiliateCode) {
+  if (context.affiliateCode && context.organizationId !== "anonymous") {
     const affiliate = await affiliatesRepository.getAffiliateCodeByCode(context.affiliateCode);
     if (affiliate && affiliate.is_active) {
       const markupPercent = Number(affiliate.markup_percent) / 100;


### PR DESCRIPTION
Fixes #10853.

## Bug
`billUsage` applies the affiliate markup and credits the affiliate owner via `redeemableEarningsService.addEarnings` (cashable `redeemable_earnings`) whenever an active `affiliateCode` is present — **with no check that the request was actually billed.** On the anonymous free-tier path (`v1/chat` calls `billUsage` with `organizationId: "anonymous"` and a no-op reservation), the user pays **$0**, yet the affiliate is still credited a % of the computed cost. An org owner can farm their own affiliate code via free anon requests → mint cashable earnings **out of nothing.**

## Fix
Gate the affiliate block on a real paying org: `if (context.affiliateCode && context.organizationId !== "anonymous")`. An anonymous request collects no revenue, so there is no affiliate share to pay. Paying orgs are unchanged.

## Evidence
Real unit test (`__tests__/ai-billing-anon-affiliate.test.ts`) drives the **real `billUsage`** (only the pure downstream boundaries — pricing math, affiliate lookup, the earnings writer — are stubbed; the guard under test runs for real):
- **anonymous** + active affiliate code → `addEarnings` **never called**, no affiliate markup layered on. ✓
- **real paying org** + same affiliate code → `addEarnings` **called once** with the affiliate owner + 10% of cost; markup layered on (regression guard). ✓

`bun test`: 2 pass / 0 fail. `tsgo` typecheck: clean.

Confirmed real by an adversarial audit with a full code trace (#10853). Money-path — not self-merged; requesting review.
