### PR TITLE
fix(cloud): gate compat agent resume/restart on org credit (#10902)

### DIFF
--- a/packages/cloud/api/compat/agents/[id]/credit-gate.test.ts
+++ b/packages/cloud/api/compat/agents/[id]/credit-gate.test.ts
@@ -1,0 +1,207 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const requireCompatAuth = mock(async () => ({
+  user: {
+    id: "user-1",
+    organization_id: "org-1",
+  },
+  authMethod: "standard" as const,
+}));
+
+const requireAuthOrApiKeyWithOrg = mock(async () => ({
+  user: {
+    id: "user-1",
+    organization_id: "org-1",
+  },
+}));
+const requireServiceKey = mock(() => ({
+  organizationId: "org-1",
+  userId: "user-1",
+}));
+const authenticateWaifuBridge = mock(async () => null);
+
+const checkAgentCreditGate = mock(async () => ({
+  allowed: false,
+  balance: 0,
+  error: "Insufficient credits",
+}));
+
+const getAgent = mock(async () => ({
+  id: "agent-1",
+  organization_id: "org-1",
+}));
+
+const getAgentForWrite = mock(
+  async (): Promise<{
+    id: string;
+    organization_id: string;
+    status: string;
+  } | null> => ({
+    id: "agent-1",
+    organization_id: "org-1",
+    status: "stopped",
+  }),
+);
+
+const defaultWritableAgent = {
+  id: "agent-1",
+  organization_id: "org-1",
+  status: "stopped",
+};
+
+const provision = mock(async () => ({
+  success: true,
+  sandboxRecord: { status: "running" },
+}));
+
+const snapshot = mock(async () => undefined);
+
+mock.module("../../../_lib/auth", () => ({
+  requireCompatAuth,
+}));
+
+mock.module("@/lib/auth", () => ({
+  requireAuthOrApiKeyWithOrg,
+}));
+
+mock.module("@/lib/auth/service-key", () => ({
+  ServiceKeyAuthError: class ServiceKeyAuthError extends Error {},
+  requireServiceKey,
+}));
+
+mock.module("@/lib/auth/waifu-bridge", () => ({
+  authenticateWaifuBridge,
+}));
+
+mock.module("@/lib/services/agent-billing-gate", () => ({
+  checkAgentCreditGate,
+}));
+
+mock.module("@/lib/services/eliza-sandbox", () => ({
+  elizaSandboxService: {
+    getAgent,
+    getAgentForWrite,
+    provision,
+    snapshot,
+  },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+    error: mock(() => undefined),
+  },
+}));
+
+const { default: resumeRoute } = await import("./resume/route");
+const { default: restartRoute } = await import("./restart/route");
+
+describe("compat agent resume/restart credit gate", () => {
+  const app = new Hono();
+  app.route("/api/compat/agents/:id/resume", resumeRoute);
+  app.route("/api/compat/agents/:id/restart", restartRoute);
+
+  beforeEach(() => {
+    requireCompatAuth.mockClear();
+    requireAuthOrApiKeyWithOrg.mockClear();
+    requireServiceKey.mockClear();
+    authenticateWaifuBridge.mockClear();
+    authenticateWaifuBridge.mockResolvedValue(null);
+    checkAgentCreditGate.mockClear();
+    checkAgentCreditGate.mockResolvedValue({
+      allowed: false,
+      balance: 0,
+      error: "Insufficient credits",
+    });
+    getAgent.mockClear();
+    getAgent.mockResolvedValue({
+      id: "agent-1",
+      organization_id: "org-1",
+    });
+    getAgentForWrite.mockClear();
+    getAgentForWrite.mockResolvedValue(defaultWritableAgent);
+    provision.mockClear();
+    snapshot.mockClear();
+  });
+
+  test("blocks compat resume before provisioning when the org has insufficient credits", async () => {
+    const response = await app.fetch(
+      new Request("https://api.example.test/api/compat/agents/agent-1/resume", {
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(402);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: "Insufficient credits",
+    });
+    expect(getAgentForWrite).toHaveBeenCalledWith("agent-1", "org-1");
+    expect(checkAgentCreditGate).toHaveBeenCalledWith("org-1");
+    expect(provision).not.toHaveBeenCalled();
+  });
+
+  test("blocks compat restart before snapshot/provision when the org has insufficient credits", async () => {
+    const response = await app.fetch(
+      new Request(
+        "https://api.example.test/api/compat/agents/agent-1/restart",
+        {
+          method: "POST",
+        },
+      ),
+    );
+
+    expect(response.status).toBe(402);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: "Insufficient credits",
+    });
+    expect(getAgent).toHaveBeenCalledWith("agent-1", "org-1");
+    expect(checkAgentCreditGate).toHaveBeenCalledWith("org-1");
+    expect(snapshot).not.toHaveBeenCalled();
+    expect(provision).not.toHaveBeenCalled();
+  });
+
+  test("does not check credits when the compat agent lookup fails", async () => {
+    getAgentForWrite.mockResolvedValueOnce(null);
+
+    const response = await app.fetch(
+      new Request("https://api.example.test/api/compat/agents/missing/resume", {
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(404);
+    expect(checkAgentCreditGate).not.toHaveBeenCalled();
+    expect(provision).not.toHaveBeenCalled();
+  });
+
+  test("allows funded compat resume and restart to reach sandbox operations", async () => {
+    checkAgentCreditGate.mockResolvedValue({
+      allowed: true,
+      balance: 5,
+      error: "",
+    });
+
+    const resumeResponse = await app.fetch(
+      new Request("https://api.example.test/api/compat/agents/agent-1/resume", {
+        method: "POST",
+      }),
+    );
+    const restartResponse = await app.fetch(
+      new Request(
+        "https://api.example.test/api/compat/agents/agent-1/restart",
+        {
+          method: "POST",
+        },
+      ),
+    );
+
+    expect(resumeResponse.status).toBe(200);
+    expect(restartResponse.status).toBe(200);
+    expect(provision).toHaveBeenCalledWith("agent-1", "org-1");
+    expect(snapshot).toHaveBeenCalledWith("agent-1", "org-1");
+  });
+});

--- a/packages/cloud/api/compat/agents/[id]/restart/route.ts
+++ b/packages/cloud/api/compat/agents/[id]/restart/route.ts
@@ -12,6 +12,7 @@ import {
   errorEnvelope,
   toCompatOpResult,
 } from "@/lib/api/compat-envelope";
+import { checkAgentCreditGate } from "@/lib/services/agent-billing-gate";
 import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
 import { logger } from "@/lib/utils/logger";
 import { requireCompatAuth } from "../../../_lib/auth";
@@ -35,6 +36,27 @@ async function __hono_POST(
     if (!agent) {
       return withCompatCors(
         Response.json(errorEnvelope("Agent not found"), { status: 404 }),
+        CORS_METHODS,
+      );
+    }
+
+    // Gate on org credit before snapshot + re-provision — matches the paid-check
+    // every v1 wake route enforces. Without it a credit-suspended dedicated agent
+    // could be restarted for free, repeatedly (elizaOS/eliza#10902).
+    const creditCheck = await checkAgentCreditGate(user.organization_id);
+    if (!creditCheck.allowed) {
+      logger.warn("[compat] Restart blocked: insufficient credits", {
+        agentId,
+        orgId: user.organization_id,
+        balance: creditCheck.balance,
+      });
+      return withCompatCors(
+        Response.json(
+          errorEnvelope(
+            creditCheck.error ?? "Insufficient credits to restart this agent",
+          ),
+          { status: 402 },
+        ),
         CORS_METHODS,
       );
     }

--- a/packages/cloud/api/compat/agents/[id]/restart/route.ts
+++ b/packages/cloud/api/compat/agents/[id]/restart/route.ts
@@ -40,7 +40,7 @@ async function __hono_POST(
       );
     }
 
-    // Gate on org credit before snapshot + re-provision — matches the paid-check
+    // Gate on org credit before snapshot + re-provision; matches the paid-check
     // every v1 wake route enforces. Without it a credit-suspended dedicated agent
     // could be restarted for free, repeatedly (elizaOS/eliza#10902).
     const creditCheck = await checkAgentCreditGate(user.organization_id);

--- a/packages/cloud/api/compat/agents/[id]/resume/route.ts
+++ b/packages/cloud/api/compat/agents/[id]/resume/route.ts
@@ -12,6 +12,7 @@ import {
   errorEnvelope,
   toCompatOpResult,
 } from "@/lib/api/compat-envelope";
+import { checkAgentCreditGate } from "@/lib/services/agent-billing-gate";
 import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
 import { logger } from "@/lib/utils/logger";
 import { requireCompatAuth } from "../../../_lib/auth";
@@ -37,6 +38,28 @@ async function __hono_POST(
     if (!agent) {
       return withCompatCors(
         Response.json(errorEnvelope("Agent not found"), { status: 404 }),
+        CORS_METHODS,
+      );
+    }
+
+    // Gate on org credit before re-provisioning a container — matches the
+    // paid-check every v1 wake route enforces (v1/agents/[agentId]/resume,
+    // v1/eliza/agents/[agentId]/resume|provision). Without it a credit-suspended
+    // dedicated agent could be resumed for free, repeatedly (elizaOS/eliza#10902).
+    const creditCheck = await checkAgentCreditGate(user.organization_id);
+    if (!creditCheck.allowed) {
+      logger.warn("[compat] Resume blocked: insufficient credits", {
+        agentId,
+        orgId: user.organization_id,
+        balance: creditCheck.balance,
+      });
+      return withCompatCors(
+        Response.json(
+          errorEnvelope(
+            creditCheck.error ?? "Insufficient credits to resume this agent",
+          ),
+          { status: 402 },
+        ),
         CORS_METHODS,
       );
     }

--- a/packages/cloud/api/compat/agents/[id]/resume/route.ts
+++ b/packages/cloud/api/compat/agents/[id]/resume/route.ts
@@ -42,7 +42,7 @@ async function __hono_POST(
       );
     }
 
-    // Gate on org credit before re-provisioning a container — matches the
+    // Gate on org credit before re-provisioning a container; matches the
     // paid-check every v1 wake route enforces (v1/agents/[agentId]/resume,
     // v1/eliza/agents/[agentId]/resume|provision). Without it a credit-suspended
     // dedicated agent could be resumed for free, repeatedly (elizaOS/eliza#10902).


### PR DESCRIPTION
Fixes #10902.

## Problem
`POST /api/compat/agents/[id]/resume` (route.ts:46) and `/restart` (route.ts:53) call `elizaSandboxService.provision()` with **no** `checkAgentCreditGate` — while every `v1` wake route enforces it and returns **402** when `credit_balance <= AGENT_PRICING.MINIMUM_DEPOSIT` ($0.10). `provision()` unconditionally calls `reactivateSandboxBillingAfterFunding` (billing_status→'active', balance-unaware).

**Effect:** the hourly sweep suspends a dedicated agent on insufficient credit *and does not bill the running hour*; the owner (normal Steward/API-key session, org-scoped so no IDOR) could then hit the compat resume/restart route to re-provision the container + reactivate billing on a zero balance — **repeatable un-billed dedicated compute + node-capacity burn**.

## Fix
Add `checkAgentCreditGate(user.organization_id)` before `provision()` in both compat routes, returning 402 when `!allowed` — a direct mirror of the already-tested gate in `v1/agents/[agentId]/resume`.

## Verification
- `CreditGateResult` = `{ allowed, balance, error? }`; usage matches the v1 route exactly; import `@/lib/services/agent-billing-gate` resolves.
- Both routes stay org-scoped (`getAgentForWrite`/`getAgent`) — no behavior change for funded orgs; only adds the 402 on `<= $0.10`.
- No existing test pins the old ungated behavior. Mirrors the tested v1 gate pattern; a dedicated compat-route unit test is a clean follow-up.

Found by an adversarial launch-readiness audit of surfaces not covered by the sibling gap-audit. cc @lalalune