### PR TITLE
fix(cloud/apps): scope per-app API keys to their own app — stop cross-app compromise (#10852)

### DIFF
--- a/packages/cloud/api/__tests__/app-key-scope.test.ts
+++ b/packages/cloud/api/__tests__/app-key-scope.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Least-privilege guard for per-app API keys (#10852).
+ *
+ * App-minted keys are full org credentials with no scope column, so without this
+ * guard App A's key can DELETE/rotate/deploy/spend against sibling app B in the
+ * same org. `isCrossAppKeyUsage` (the real predicate the /apps/[id]/* routes gate
+ * on) restricts an app key to its own app while leaving org keys / sessions with
+ * full org access.
+ */
+import { describe, expect, test } from "bun:test";
+import { isCrossAppKeyUsage } from "@/lib/auth/app-key-scope";
+
+describe("isCrossAppKeyUsage (#10852)", () => {
+  test("app A's key acting on sibling app B → DENY", () => {
+    expect(
+      isCrossAppKeyUsage({
+        apiKeyId: "key-A",
+        owningAppId: "app-A",
+        requestedAppId: "app-B",
+      }),
+    ).toBe(true);
+  });
+
+  test("app A's key acting on its own app A → allow", () => {
+    expect(
+      isCrossAppKeyUsage({
+        apiKeyId: "key-A",
+        owningAppId: "app-A",
+        requestedAppId: "app-A",
+      }),
+    ).toBe(false);
+  });
+
+  test("normal org key (no app claims it) → allow (full org access unchanged)", () => {
+    expect(
+      isCrossAppKeyUsage({
+        apiKeyId: "org-key",
+        owningAppId: undefined,
+        requestedAppId: "app-B",
+      }),
+    ).toBe(false);
+  });
+
+  test("session auth (no api key) → allow", () => {
+    expect(
+      isCrossAppKeyUsage({
+        apiKeyId: undefined,
+        owningAppId: undefined,
+        requestedAppId: "app-B",
+      }),
+    ).toBe(false);
+  });
+
+  test("session auth but an app happens to match id → still allow (no key presented)", () => {
+    // Defensive: without an api key there is no app-key credential to constrain.
+    expect(
+      isCrossAppKeyUsage({
+        apiKeyId: null,
+        owningAppId: "app-A",
+        requestedAppId: "app-B",
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/cloud/api/v1/apps/[id]/analytics/requests/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/analytics/requests/route.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { nextStyleParams } from "@/lib/api/hono-next-style-params";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
+import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import {
   RateLimitPresets,
   rateLimit,
@@ -32,7 +33,7 @@ async function handleGET(
 ): Promise<Response> {
   const { params } = context ?? { params: Promise.resolve({ id: "" }) };
   try {
-    const { user } = await requireAuthOrApiKeyWithOrg(request);
+    const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
     const { id } = await params;
     const { searchParams } = new URL(request.url);
 
@@ -46,6 +47,12 @@ async function handleGET(
     }
 
     if (existingApp.organization_id !== user.organization_id) {
+      return Response.json(
+        { success: false, error: "Access denied" },
+        { status: 403 },
+      );
+    }
+    if (await isAppKeyOutOfScope(apiKey?.id, id)) {
       return Response.json(
         { success: false, error: "Access denied" },
         { status: 403 },

--- a/packages/cloud/api/v1/apps/[id]/analytics/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/analytics/route.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 
+import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { appsService } from "@/lib/services/apps";
 import { logger } from "@/lib/utils/logger";
@@ -38,6 +39,9 @@ app.get("/", async (c) => {
     }
 
     if (existingApp.organization_id !== user.organization_id) {
+      return c.json({ success: false, error: "Access denied" }, 403);
+    }
+    if (await isAppKeyOutOfScope(c.get("apiKeyId"), id)) {
       return c.json({ success: false, error: "Access denied" }, 403);
     }
 

--- a/packages/cloud/api/v1/apps/[id]/characters/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/characters/route.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
+import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { appsService } from "@/lib/services/apps";
 import { charactersService } from "@/lib/services/characters/characters";
 import { logger } from "@/lib/utils/logger";
@@ -136,7 +137,7 @@ async function __hono_PUT(
   { params }: { params: Promise<{ id: string }> },
 ) {
   try {
-    const { user } = await requireAuthOrApiKeyWithOrg(request);
+    const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
     const { id } = await params;
 
     const existingApp = await appsService.getById(id);
@@ -149,6 +150,12 @@ async function __hono_PUT(
     }
 
     if (existingApp.organization_id !== user.organization_id) {
+      return Response.json(
+        { success: false, error: "Access denied" },
+        { status: 403 },
+      );
+    }
+    if (await isAppKeyOutOfScope(apiKey?.id, id)) {
       return Response.json(
         { success: false, error: "Access denied" },
         { status: 403 },

--- a/packages/cloud/api/v1/apps/[id]/charges/[chargeId]/checkout/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/charges/[chargeId]/checkout/route.ts
@@ -5,6 +5,7 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { SUPPORTED_PAY_CURRENCIES } from "@/lib/config/crypto";
 import {
@@ -37,6 +38,9 @@ app.post("/", async (c) => {
     const chargeId = c.req.param("chargeId");
     if (!appId || !chargeId) {
       return c.json({ success: false, error: "Missing route parameters" }, 400);
+    }
+    if (await isAppKeyOutOfScope(c.get("apiKeyId"), appId)) {
+      return c.json({ success: false, error: "Access denied" }, 403);
     }
 
     const body = await c.req.json().catch(() => null);

--- a/packages/cloud/api/v1/apps/[id]/charges/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/charges/route.ts
@@ -9,6 +9,7 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
   RateLimitPresets,
@@ -49,6 +50,10 @@ app.post("/", async (c) => {
     const user = await requireUserOrApiKeyWithOrg(c);
     const appId = c.req.param("id");
     if (!appId) return c.json({ success: false, error: "Missing app id" }, 400);
+    // An app-scoped API key may only act on its own app, never a sibling (#10852).
+    if (await isAppKeyOutOfScope(c.get("apiKeyId"), appId)) {
+      return c.json({ success: false, error: "Access denied" }, 403);
+    }
 
     const body = await c.req.json().catch(() => null);
     const parsed = CreateChargeSchema.safeParse(body);
@@ -93,6 +98,10 @@ app.get("/", async (c) => {
     const user = await requireUserOrApiKeyWithOrg(c);
     const appId = c.req.param("id");
     if (!appId) return c.json({ success: false, error: "Missing app id" }, 400);
+    // An app-scoped API key may only read its own app's charges (#10852).
+    if (await isAppKeyOutOfScope(c.get("apiKeyId"), appId)) {
+      return c.json({ success: false, error: "Access denied" }, 403);
+    }
 
     const limitParam = c.req.query("limit");
     const limit = limitParam ? Number.parseInt(limitParam, 10) : 50;

--- a/packages/cloud/api/v1/apps/[id]/chat/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/chat/route.ts
@@ -10,6 +10,7 @@ import {
   type RouteContext,
 } from "@/lib/api/hono-next-style-params";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
+import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import {
   addCorsHeaders,
   createPreflightResponse,
@@ -198,6 +199,20 @@ async function handlePOST(
     }
 
     const { user } = authResult;
+    if (await isAppKeyOutOfScope(authResult.apiKey?.id, appId)) {
+      return withCors(
+        Response.json(
+          {
+            error: {
+              message: "Access denied to this app",
+              type: "invalid_request_error",
+              code: "access_denied",
+            },
+          },
+          { status: 403 },
+        ),
+      );
+    }
 
     // Access control: non-monetized apps are internal (same org only)
     // Monetized apps are public (anyone with credits can use)

--- a/packages/cloud/api/v1/apps/[id]/database/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/database/route.ts
@@ -16,6 +16,7 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
   type AppDatabaseMode,
@@ -37,6 +38,9 @@ async function loadOwnedApp(c: AppContext) {
   const appRow = await appsService.getById(appId);
   if (!appRow || appRow.organization_id !== user.organization_id) {
     return { error: "App not found", status: 404 as const };
+  }
+  if (await isAppKeyOutOfScope(c.get("apiKeyId"), appId)) {
+    return { error: "Access denied", status: 403 as const };
   }
   return { appRow, appId };
 }

--- a/packages/cloud/api/v1/apps/[id]/deploy/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/deploy/route.ts
@@ -16,6 +16,7 @@ import { Hono } from "hono";
 import { appsDeployOrganizationDecision } from "@/api-app/lib/apps-deploy-gate";
 import { containersRepository } from "@/db/repositories/containers";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { appDeploymentsService } from "@/lib/services/app-deployments";
 import { appsService } from "@/lib/services/apps";
@@ -53,6 +54,10 @@ app.post("/", async (c) => {
     }
     if (appRow.organization_id !== user.organization_id) {
       // 403 — the caller is authed but not the owning org.
+      return c.json({ success: false, error: "Access denied" }, 403);
+    }
+    // An app-scoped API key may only act on its own app, never a sibling (#10852).
+    if (await isAppKeyOutOfScope(c.get("apiKeyId"), appId)) {
       return c.json({ success: false, error: "Access denied" }, 403);
     }
 

--- a/packages/cloud/api/v1/apps/[id]/deploy/status/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/deploy/status/route.ts
@@ -8,6 +8,7 @@
 
 import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { appDeploymentsService } from "@/lib/services/app-deployments";
 import { appsService } from "@/lib/services/apps";
@@ -28,6 +29,9 @@ app.get("/", async (c) => {
       return c.json({ success: false, error: "App not found" }, 404);
     }
     if (appRow.organization_id !== user.organization_id) {
+      return c.json({ success: false, error: "Access denied" }, 403);
+    }
+    if (await isAppKeyOutOfScope(c.get("apiKeyId"), appId)) {
       return c.json({ success: false, error: "Access denied" }, 403);
     }
 

--- a/packages/cloud/api/v1/apps/[id]/discord-automation/post/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/discord-automation/post/route.ts
@@ -11,6 +11,7 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 
 import { z } from "zod";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
+import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { discordAppAutomationService } from "@/lib/services/discord-automation/app-automation";
 import { logger } from "@/lib/utils/logger";
 
@@ -22,8 +23,11 @@ async function __hono_POST(
   request: Request,
   { params }: RouteContext<{ id: string }>,
 ): Promise<Response> {
-  const { user } = await requireAuthOrApiKeyWithOrg(request);
+  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
   const { id: appId } = await params;
+  if (await isAppKeyOutOfScope(apiKey?.id, appId)) {
+    return Response.json({ error: "Access denied" }, { status: 403 });
+  }
 
   let body: z.infer<typeof postSchema>;
   try {

--- a/packages/cloud/api/v1/apps/[id]/discord-automation/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/discord-automation/route.ts
@@ -13,6 +13,7 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 
 import { z } from "zod";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
+import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { discordAppAutomationService } from "@/lib/services/discord-automation/app-automation";
 import { logger } from "@/lib/utils/logger";
 
@@ -31,8 +32,11 @@ async function __hono_GET(
   request: Request,
   { params }: RouteContext<{ id: string }>,
 ): Promise<Response> {
-  const { user } = await requireAuthOrApiKeyWithOrg(request);
+  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
   const { id: appId } = await params;
+  if (await isAppKeyOutOfScope(apiKey?.id, appId)) {
+    return Response.json({ error: "Access denied" }, { status: 403 });
+  }
 
   try {
     const status = await discordAppAutomationService.getAutomationStatus(
@@ -59,8 +63,11 @@ async function __hono_POST(
   request: Request,
   { params }: RouteContext<{ id: string }>,
 ): Promise<Response> {
-  const { user } = await requireAuthOrApiKeyWithOrg(request);
+  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
   const { id: appId } = await params;
+  if (await isAppKeyOutOfScope(apiKey?.id, appId)) {
+    return Response.json({ error: "Access denied" }, { status: 403 });
+  }
 
   let body: z.infer<typeof automationConfigSchema>;
   try {
@@ -150,8 +157,11 @@ async function __hono_DELETE(
   request: Request,
   { params }: RouteContext<{ id: string }>,
 ): Promise<Response> {
-  const { user } = await requireAuthOrApiKeyWithOrg(request);
+  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
   const { id: appId } = await params;
+  if (await isAppKeyOutOfScope(apiKey?.id, appId)) {
+    return Response.json({ error: "Access denied" }, { status: 403 });
+  }
 
   try {
     await discordAppAutomationService.disableAutomation(

--- a/packages/cloud/api/v1/apps/[id]/domains/[domain]/dns/[recordId]/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/[domain]/dns/[recordId]/route.ts
@@ -7,6 +7,7 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { appsService } from "@/lib/services/apps";
 import { cloudflareDnsService } from "@/lib/services/cloudflare-dns";
@@ -45,6 +46,9 @@ async function loadCloudflareManagedDomain(c: AppContext) {
   const appRow = await appsService.getById(appId);
   if (!appRow || appRow.organization_id !== user.organization_id) {
     return { error: "App not found", status: 404 as const };
+  }
+  if (await isAppKeyOutOfScope(c.get("apiKeyId"), appId)) {
+    return { error: "Access denied", status: 403 as const };
   }
 
   const md = await managedDomainsService.getDomainByName(

--- a/packages/cloud/api/v1/apps/[id]/domains/[domain]/dns/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/[domain]/dns/route.ts
@@ -10,6 +10,7 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { appsService } from "@/lib/services/apps";
 import { cloudflareDnsService } from "@/lib/services/cloudflare-dns";
@@ -41,6 +42,9 @@ async function loadCloudflareManagedDomain(c: AppContext) {
   const appRow = await appsService.getById(appId);
   if (!appRow || appRow.organization_id !== user.organization_id) {
     return { error: "App not found", status: 404 as const };
+  }
+  if (await isAppKeyOutOfScope(c.get("apiKeyId"), appId)) {
+    return { error: "Access denied", status: 403 as const };
   }
 
   const md = await managedDomainsService.getDomainByName(

--- a/packages/cloud/api/v1/apps/[id]/domains/buy/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/buy/route.ts
@@ -18,6 +18,7 @@ import { dbRead, dbWrite } from "@/db/client";
 import { creditTransactionsRepository } from "@/db/repositories/credit-transactions";
 import { domainPurchaseIdempotency } from "@/db/schemas/domain-purchase-idempotency";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { getCloudAwareEnv } from "@/lib/runtime/cloud-bindings";
 import { appDomainsCompat } from "@/lib/services/app-domains-compat";
@@ -75,6 +76,9 @@ app.post("/", async (c) => {
     const appRow = await appsService.getById(appId);
     if (!appRow) return c.json({ success: false, error: "App not found" }, 404);
     if (appRow.organization_id !== user.organization_id) {
+      return c.json({ success: false, error: "Access denied" }, 403);
+    }
+    if (await isAppKeyOutOfScope(c.get("apiKeyId"), appId)) {
       return c.json({ success: false, error: "Access denied" }, 403);
     }
 

--- a/packages/cloud/api/v1/apps/[id]/domains/check/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/check/route.ts
@@ -7,6 +7,7 @@
 
 import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { appsService } from "@/lib/services/apps";
 import { cloudflareRegistrarService } from "@/lib/services/cloudflare-registrar";
@@ -26,6 +27,9 @@ app.post("/", async (c) => {
     const appRow = await appsService.getById(appId);
     if (!appRow || appRow.organization_id !== user.organization_id) {
       return c.json({ success: false, error: "App not found" }, 404);
+    }
+    if (await isAppKeyOutOfScope(c.get("apiKeyId"), appId)) {
+      return c.json({ success: false, error: "Access denied" }, 403);
     }
 
     const parsed = CheckSchema.safeParse(await c.req.json());

--- a/packages/cloud/api/v1/apps/[id]/domains/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/route.ts
@@ -11,6 +11,7 @@
 import crypto from "node:crypto";
 import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { appDomainsCompat } from "@/lib/services/app-domains-compat";
 import { appsService } from "@/lib/services/apps";
@@ -29,6 +30,9 @@ async function loadOwnedApp(c: AppContext) {
   const appRow = await appsService.getById(appId);
   if (!appRow || appRow.organization_id !== user.organization_id) {
     return { error: "App not found", status: 404 as const };
+  }
+  if (await isAppKeyOutOfScope(c.get("apiKeyId"), appId)) {
+    return { error: "Access denied", status: 403 as const };
   }
   return { user, app: appRow, appId };
 }

--- a/packages/cloud/api/v1/apps/[id]/domains/status/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/status/route.ts
@@ -7,6 +7,7 @@
 
 import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { appsService } from "@/lib/services/apps";
 import { cloudflareRegistrarService } from "@/lib/services/cloudflare-registrar";
@@ -25,6 +26,9 @@ app.post("/", async (c) => {
     const appRow = await appsService.getById(appId);
     if (!appRow || appRow.organization_id !== user.organization_id) {
       return c.json({ success: false, error: "App not found" }, 404);
+    }
+    if (await isAppKeyOutOfScope(c.get("apiKeyId"), appId)) {
+      return c.json({ success: false, error: "Access denied" }, 403);
     }
 
     const parsed = StatusSchema.safeParse(await c.req.json());

--- a/packages/cloud/api/v1/apps/[id]/domains/sync/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/sync/route.ts
@@ -8,6 +8,7 @@
 
 import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { appsService } from "@/lib/services/apps";
 import { cloudflareRegistrarService } from "@/lib/services/cloudflare-registrar";
@@ -27,6 +28,9 @@ app.post("/", async (c) => {
     const appRow = await appsService.getById(appId);
     if (!appRow || appRow.organization_id !== user.organization_id) {
       return c.json({ success: false, error: "App not found" }, 404);
+    }
+    if (await isAppKeyOutOfScope(c.get("apiKeyId"), appId)) {
+      return c.json({ success: false, error: "Access denied" }, 403);
     }
 
     const domains = await managedDomainsService.listForApp(

--- a/packages/cloud/api/v1/apps/[id]/domains/verify/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/verify/route.ts
@@ -12,6 +12,7 @@
 import { promises as dns } from "node:dns";
 import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { appsService } from "@/lib/services/apps";
 import { managedDomainsService } from "@/lib/services/managed-domains";
@@ -31,6 +32,9 @@ app.post("/", async (c) => {
     const appRow = await appsService.getById(appId);
     if (!appRow || appRow.organization_id !== user.organization_id) {
       return c.json({ success: false, error: "App not found" }, 404);
+    }
+    if (await isAppKeyOutOfScope(c.get("apiKeyId"), appId)) {
+      return c.json({ success: false, error: "Access denied" }, 403);
     }
 
     const parsed = VerifySchema.safeParse(await c.req.json());

--- a/packages/cloud/api/v1/apps/[id]/earnings/history/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/earnings/history/route.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
+import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { appEarningsService } from "@/lib/services/app-earnings";
 import { appsService } from "@/lib/services/apps";
 import { logger } from "@/lib/utils/logger";
@@ -34,7 +35,7 @@ async function __hono_GET(
   { params }: { params: Promise<{ id: string }> },
 ) {
   try {
-    const { user } = await requireAuthOrApiKeyWithOrg(request);
+    const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
     const { id } = await params;
 
     // Parse query params (filter out nulls to use defaults)
@@ -76,6 +77,15 @@ async function __hono_GET(
     }
 
     if (app.organization_id !== user.organization_id) {
+      return Response.json(
+        {
+          success: false,
+          error: "Access denied",
+        },
+        { status: 403 },
+      );
+    }
+    if (await isAppKeyOutOfScope(apiKey?.id, id)) {
       return Response.json(
         {
           success: false,

--- a/packages/cloud/api/v1/apps/[id]/earnings/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/earnings/route.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
+import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { appEarningsService } from "@/lib/services/app-earnings";
 import { appsService } from "@/lib/services/apps";
 import { logger } from "@/lib/utils/logger";
@@ -22,7 +23,7 @@ async function __hono_GET(
   { params }: { params: Promise<{ id: string }> },
 ) {
   try {
-    const { user } = await requireAuthOrApiKeyWithOrg(request);
+    const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
     const { id } = await params;
 
     const daysParam = new URL(request.url).searchParams.get("days");
@@ -40,6 +41,12 @@ async function __hono_GET(
     }
 
     if (app.organization_id !== user.organization_id) {
+      return Response.json(
+        { success: false, error: "Access denied" },
+        { status: 403 },
+      );
+    }
+    if (await isAppKeyOutOfScope(apiKey?.id, id)) {
       return Response.json(
         { success: false, error: "Access denied" },
         { status: 403 },

--- a/packages/cloud/api/v1/apps/[id]/earnings/withdraw/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/earnings/withdraw/route.ts
@@ -7,6 +7,7 @@ import {
   type RouteContext,
 } from "@/lib/api/hono-next-style-params";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
+import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import {
   RateLimitPresets,
   rateLimit,
@@ -65,7 +66,7 @@ async function handlePOST(
       );
     }
 
-    const { user } = await requireAuthOrApiKeyWithOrg(request);
+    const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
     const { id } = await context.params;
 
     const app = await appsService.getById(id);
@@ -78,6 +79,12 @@ async function handlePOST(
     }
 
     if (app.organization_id !== user.organization_id) {
+      return Response.json(
+        { success: false, error: "Access denied" },
+        { status: 403 },
+      );
+    }
+    if (await isAppKeyOutOfScope(apiKey?.id, id)) {
       return Response.json(
         { success: false, error: "Access denied" },
         { status: 403 },

--- a/packages/cloud/api/v1/apps/[id]/generate-image/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/generate-image/route.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { dbRead, dbWrite } from "@/db/client";
 import { appImageGenerationIdempotency } from "@/db/schemas/app-image-generation-idempotency";
 import { jsonError } from "@/lib/api/cloud-worker-errors";
+import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
   RateLimitPresets,
@@ -254,6 +255,10 @@ app.post("/", async (c) => {
       !appRecord.monetization_enabled &&
       appRecord.organization_id !== user.organization_id
     ) {
+      return jsonError(c, 403, "Access denied to this app", "access_denied");
+    }
+    // An app-scoped API key may only act on its own app, never a sibling (#10852).
+    if (await isAppKeyOutOfScope(c.get("apiKeyId"), appId)) {
       return jsonError(c, 403, "Access denied to this app", "access_denied");
     }
 

--- a/packages/cloud/api/v1/apps/[id]/monetization/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/monetization/route.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
+import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { appCreditsService } from "@/lib/services/app-credits";
 import { appsService } from "@/lib/services/apps";
 import { logger } from "@/lib/utils/logger";
@@ -26,7 +27,7 @@ async function __hono_GET(
   { params }: { params: Promise<{ id: string }> },
 ) {
   try {
-    const { user } = await requireAuthOrApiKeyWithOrg(request);
+    const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
     const { id } = await params;
 
     const app = await appsService.getById(id);
@@ -39,6 +40,12 @@ async function __hono_GET(
     }
 
     if (app.organization_id !== user.organization_id) {
+      return Response.json(
+        { success: false, error: "Access denied" },
+        { status: 403 },
+      );
+    }
+    if (await isAppKeyOutOfScope(apiKey?.id, id)) {
       return Response.json(
         { success: false, error: "Access denied" },
         { status: 403 },
@@ -82,7 +89,7 @@ async function __hono_PUT(
   { params }: { params: Promise<{ id: string }> },
 ) {
   try {
-    const { user } = await requireAuthOrApiKeyWithOrg(request);
+    const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
     const { id } = await params;
 
     const app = await appsService.getById(id);
@@ -95,6 +102,12 @@ async function __hono_PUT(
     }
 
     if (app.organization_id !== user.organization_id) {
+      return Response.json(
+        { success: false, error: "Access denied" },
+        { status: 403 },
+      );
+    }
+    if (await isAppKeyOutOfScope(apiKey?.id, id)) {
       return Response.json(
         { success: false, error: "Access denied" },
         { status: 403 },

--- a/packages/cloud/api/v1/apps/[id]/promote/analytics/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/promote/analytics/route.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { nextJsonFromCaughtError } from "@/lib/api/errors";
 import type { RouteContext } from "@/lib/api/hono-next-style-params";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
+import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { advertisingService } from "@/lib/services/advertising";
 import { appsService } from "@/lib/services/apps";
 import { conversionTrackingService } from "@/lib/services/conversion-tracking";
@@ -12,12 +13,15 @@ async function __hono_GET(
   { params }: RouteContext<{ id: string }>,
 ) {
   try {
-    const { user } = await requireAuthOrApiKeyWithOrg(request);
+    const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
     const { id } = await params;
 
     const app = await appsService.getById(id);
     if (!app || app.organization_id !== user.organization_id) {
       return Response.json({ error: "App not found" }, { status: 404 });
+    }
+    if (await isAppKeyOutOfScope(apiKey?.id, id)) {
+      return Response.json({ error: "Access denied" }, { status: 403 });
     }
 
     const url = new URL(request.url);

--- a/packages/cloud/api/v1/apps/[id]/promote/assets/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/promote/assets/route.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { z } from "zod";
 import type { RouteContext } from "@/lib/api/hono-next-style-params";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
+import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import {
   AD_COPY_GENERATION_COST,
   estimateAssetGenerationCost,
@@ -31,12 +32,15 @@ async function __hono_POST(
   request: Request,
   { params }: RouteContext<{ id: string }>,
 ) {
-  const { user } = await requireAuthOrApiKeyWithOrg(request);
+  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
   const { id } = await params;
 
   const app = await appsService.getById(id);
   if (!app || app.organization_id !== user.organization_id) {
     return Response.json({ error: "App not found" }, { status: 404 });
+  }
+  if (await isAppKeyOutOfScope(apiKey?.id, id)) {
+    return Response.json({ error: "Access denied" }, { status: 403 });
   }
 
   const body = await request.json();
@@ -153,12 +157,15 @@ async function __hono_GET(
   request: Request,
   { params }: RouteContext<{ id: string }>,
 ) {
-  const { user } = await requireAuthOrApiKeyWithOrg(request);
+  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
   const { id } = await params;
 
   const app = await appsService.getById(id);
   if (!app || app.organization_id !== user.organization_id) {
     return Response.json({ error: "App not found" }, { status: 404 });
+  }
+  if (await isAppKeyOutOfScope(apiKey?.id, id)) {
+    return Response.json({ error: "Access denied" }, { status: 403 });
   }
 
   const url = new URL(request.url);

--- a/packages/cloud/api/v1/apps/[id]/promote/preview/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/promote/preview/route.ts
@@ -12,6 +12,7 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 
 import { z } from "zod";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
+import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { appsService } from "@/lib/services/apps";
 import {
   getDiscordConfigWithDefaults,
@@ -40,7 +41,7 @@ async function __hono_POST(
   request: Request,
   { params }: RouteContext<{ id: string }>,
 ): Promise<Response> {
-  const { user } = await requireAuthOrApiKeyWithOrg(request);
+  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
   const { id } = await params;
 
   const body = await request.json();
@@ -58,6 +59,9 @@ async function __hono_POST(
   const app = await appsService.getById(id);
   if (!app || app.organization_id !== user.organization_id) {
     return Response.json({ error: "App not found" }, { status: 404 });
+  }
+  if (await isAppKeyOutOfScope(apiKey?.id, id)) {
+    return Response.json({ error: "Access denied" }, { status: 403 });
   }
 
   // Create a preview app object with the selected character for generation

--- a/packages/cloud/api/v1/apps/[id]/promote/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/promote/route.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { z } from "zod";
 import type { RouteContext } from "@/lib/api/hono-next-style-params";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
+import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import {
   appPromotionService,
   type PromotionConfig,
@@ -113,8 +114,11 @@ async function __hono_GET(
   request: Request,
   { params }: RouteContext<{ id: string }>,
 ) {
-  const { user } = await requireAuthOrApiKeyWithOrg(request);
+  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
   const { id } = await params;
+  if (await isAppKeyOutOfScope(apiKey?.id, id)) {
+    return Response.json({ error: "Access denied" }, { status: 403 });
+  }
 
   const url = new URL(request.url);
   const isHistory = url.searchParams.get("history") === "true";
@@ -139,8 +143,11 @@ async function __hono_POST(
   request: Request,
   { params }: RouteContext<{ id: string }>,
 ) {
-  const { user } = await requireAuthOrApiKeyWithOrg(request);
+  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
   const { id } = await params;
+  if (await isAppKeyOutOfScope(apiKey?.id, id)) {
+    return Response.json({ error: "Access denied" }, { status: 403 });
+  }
 
   const body = await request.json();
   const parsed = PromotionConfigSchema.safeParse(body);

--- a/packages/cloud/api/v1/apps/[id]/regenerate-api-key/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/regenerate-api-key/route.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
+import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import {
   RateLimitPresets,
   rateLimit,
@@ -19,7 +20,7 @@ async function handlePOST(
     );
   }
   try {
-    const { user } = await requireAuthOrApiKeyWithOrg(request);
+    const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
     const { id } = await context.params;
 
     const existingApp = await appsService.getById(id);
@@ -40,6 +41,14 @@ async function handlePOST(
           success: false,
           error: "Access denied",
         },
+        { status: 403 },
+      );
+    }
+    // An app-scoped API key may only rotate its OWN app's key, never a sibling's
+    // (#10852) — otherwise App A's key could DoS App B by rotating B's key.
+    if (await isAppKeyOutOfScope(apiKey?.id, id)) {
+      return Response.json(
+        { success: false, error: "Access denied" },
         { status: 403 },
       );
     }

--- a/packages/cloud/api/v1/apps/[id]/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/route.ts
@@ -10,6 +10,7 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { appCleanupService } from "@/lib/services/app-cleanup";
 import { appsService } from "@/lib/services/apps";
@@ -67,6 +68,10 @@ async function updateApp(c: AppContext, verb: "PUT" | "PATCH") {
   const existing = await appsService.getById(id);
   if (!existing) return c.json({ success: false, error: "App not found" }, 404);
   if (existing.organization_id !== user.organization_id) {
+    return c.json({ success: false, error: "Access denied" }, 403);
+  }
+  // An app-scoped API key may only act on its own app, never a sibling (#10852).
+  if (await isAppKeyOutOfScope(c.get("apiKeyId"), id)) {
     return c.json({ success: false, error: "Access denied" }, 403);
   }
 
@@ -158,6 +163,10 @@ app.delete("/", async (c) => {
     if (!existing)
       return c.json({ success: false, error: "App not found" }, 404);
     if (existing.organization_id !== user.organization_id) {
+      return c.json({ success: false, error: "Access denied" }, 403);
+    }
+    // An app-scoped API key may only act on its own app, never a sibling (#10852).
+    if (await isAppKeyOutOfScope(c.get("apiKeyId"), id)) {
       return c.json({ success: false, error: "Access denied" }, 403);
     }
 

--- a/packages/cloud/api/v1/apps/[id]/telegram-automation/post/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/telegram-automation/post/route.ts
@@ -11,6 +11,7 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 
 import { z } from "zod";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
+import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { telegramAppAutomationService } from "@/lib/services/telegram-automation/app-automation";
 import { logger } from "@/lib/utils/logger";
 
@@ -24,8 +25,11 @@ async function __hono_POST(
   request: Request,
   { params }: RouteContext<{ id: string }>,
 ): Promise<Response> {
-  const { user } = await requireAuthOrApiKeyWithOrg(request);
+  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
   const { id: appId } = await params;
+  if (await isAppKeyOutOfScope(apiKey?.id, appId)) {
+    return Response.json({ error: "Access denied" }, { status: 403 });
+  }
 
   let body: z.infer<typeof postSchema>;
   try {

--- a/packages/cloud/api/v1/apps/[id]/telegram-automation/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/telegram-automation/route.ts
@@ -13,6 +13,7 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 
 import { z } from "zod";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
+import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { telegramAppAutomationService } from "@/lib/services/telegram-automation/app-automation";
 import { logger } from "@/lib/utils/logger";
 
@@ -33,8 +34,11 @@ async function __hono_GET(
   request: Request,
   { params }: RouteContext<{ id: string }>,
 ): Promise<Response> {
-  const { user } = await requireAuthOrApiKeyWithOrg(request);
+  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
   const { id: appId } = await params;
+  if (await isAppKeyOutOfScope(apiKey?.id, appId)) {
+    return Response.json({ error: "Access denied" }, { status: 403 });
+  }
 
   try {
     const status = await telegramAppAutomationService.getAutomationStatus(
@@ -61,8 +65,11 @@ async function __hono_POST(
   request: Request,
   { params }: RouteContext<{ id: string }>,
 ): Promise<Response> {
-  const { user } = await requireAuthOrApiKeyWithOrg(request);
+  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
   const { id: appId } = await params;
+  if (await isAppKeyOutOfScope(apiKey?.id, appId)) {
+    return Response.json({ error: "Access denied" }, { status: 403 });
+  }
 
   let body: z.infer<typeof automationConfigSchema>;
   try {
@@ -150,8 +157,11 @@ async function __hono_DELETE(
   request: Request,
   { params }: RouteContext<{ id: string }>,
 ): Promise<Response> {
-  const { user } = await requireAuthOrApiKeyWithOrg(request);
+  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
   const { id: appId } = await params;
+  if (await isAppKeyOutOfScope(apiKey?.id, appId)) {
+    return Response.json({ error: "Access denied" }, { status: 403 });
+  }
 
   try {
     await telegramAppAutomationService.disableAutomation(

--- a/packages/cloud/api/v1/apps/[id]/twitter-automation/post/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/twitter-automation/post/route.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { z } from "zod";
 import type { RouteContext } from "@/lib/api/hono-next-style-params";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
+import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { twitterAppAutomationService } from "@/lib/services/twitter-automation/app-automation";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -17,8 +18,11 @@ async function __hono_POST(
   request: Request,
   { params }: RouteContext<{ id: string }>,
 ): Promise<Response> {
-  const { user } = await requireAuthOrApiKeyWithOrg(request);
+  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
   const { id } = await params;
+  if (await isAppKeyOutOfScope(apiKey?.id, id)) {
+    return Response.json({ error: "Access denied" }, { status: 403 });
+  }
 
   const body = await request.json();
   const parsed = PostTweetSchema.safeParse(body);

--- a/packages/cloud/api/v1/apps/[id]/twitter-automation/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/twitter-automation/route.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { z } from "zod";
 import type { RouteContext } from "@/lib/api/hono-next-style-params";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
+import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { twitterAppAutomationService } from "@/lib/services/twitter-automation/app-automation";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -22,8 +23,11 @@ async function __hono_GET(
   request: Request,
   { params }: RouteContext<{ id: string }>,
 ): Promise<Response> {
-  const { user } = await requireAuthOrApiKeyWithOrg(request);
+  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
   const { id } = await params;
+  if (await isAppKeyOutOfScope(apiKey?.id, id)) {
+    return Response.json({ error: "Access denied" }, { status: 403 });
+  }
 
   const status = await twitterAppAutomationService.getAutomationStatus(
     user.organization_id,
@@ -37,8 +41,11 @@ async function __hono_POST(
   request: Request,
   { params }: RouteContext<{ id: string }>,
 ): Promise<Response> {
-  const { user } = await requireAuthOrApiKeyWithOrg(request);
+  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
   const { id } = await params;
+  if (await isAppKeyOutOfScope(apiKey?.id, id)) {
+    return Response.json({ error: "Access denied" }, { status: 403 });
+  }
 
   const body = await request.json();
   const parsed = TwitterAutomationConfigSchema.safeParse(body);
@@ -107,8 +114,11 @@ async function __hono_DELETE(
   request: Request,
   { params }: RouteContext<{ id: string }>,
 ): Promise<Response> {
-  const { user } = await requireAuthOrApiKeyWithOrg(request);
+  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
   const { id } = await params;
+  if (await isAppKeyOutOfScope(apiKey?.id, id)) {
+    return Response.json({ error: "Access denied" }, { status: 403 });
+  }
 
   logger.info("[Twitter Automation API] Disabling automation", {
     appId: id,

--- a/packages/cloud/api/v1/apps/[id]/users/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/users/route.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
+import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
 import { appsService } from "@/lib/services/apps";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -21,7 +22,7 @@ async function __hono_GET(
   { params }: { params: Promise<{ id: string }> },
 ) {
   try {
-    const { user } = await requireAuthOrApiKeyWithOrg(request);
+    const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
     const { id } = await params;
     const { searchParams } = new URL(request.url);
     const limit = searchParams.get("limit")
@@ -42,6 +43,15 @@ async function __hono_GET(
     }
 
     if (existingApp.organization_id !== user.organization_id) {
+      return Response.json(
+        {
+          success: false,
+          error: "Access denied",
+        },
+        { status: 403 },
+      );
+    }
+    if (await isAppKeyOutOfScope(apiKey?.id, id)) {
       return Response.json(
         {
           success: false,

--- a/packages/cloud/shared/src/lib/auth/app-key-scope.ts
+++ b/packages/cloud/shared/src/lib/auth/app-key-scope.ts
@@ -1,0 +1,56 @@
+/**
+ * Per-app API key scoping (#10852).
+ *
+ * App-minted API keys (`apps.api_key_id`) are stored in `api_keys` with NO
+ * app_id/scope column, so `requireUserOrApiKeyWithOrg` resolves them to a FULL
+ * org `AuthedUser` — indistinguishable from a normal org key. Every `/apps/[id]/*`
+ * route then gates only on `app.organization_id === user.organization_id`, so
+ * App A's key can DELETE / rotate / deploy / spend against any sibling app B in
+ * the same org. Only `characters/route.ts` app-scopes (via the reverse match
+ * `app.api_key_id === apiKey.id`), proving the intent — realized nowhere else.
+ *
+ * This closes the hole without an `api_keys` schema migration by reverse-matching
+ * the resolved key against `apps.api_key_id` (a lookup that already exists,
+ * `appsService.getByApiKeyId`): if the credential IS an app key, it may only act
+ * on its own app; a normal org key or session keeps full org access unchanged.
+ */
+
+/**
+ * Pure predicate: is this an app key being used for a DIFFERENT app than the one
+ * it belongs to?
+ *
+ * - `apiKeyId` absent → session auth → not cross-app (false).
+ * - `owningAppId` absent → the key is a normal org key (no app claims it) → false.
+ * - both present and differ → an app key used cross-app → true (deny).
+ */
+export function isCrossAppKeyUsage(params: {
+  apiKeyId: string | null | undefined;
+  owningAppId: string | null | undefined;
+  requestedAppId: string;
+}): boolean {
+  return Boolean(
+    params.apiKeyId && params.owningAppId && params.owningAppId !== params.requestedAppId,
+  );
+}
+
+/**
+ * Resolve whether the request's API key (if any) is an app key scoped to a
+ * DIFFERENT app than `requestedAppId`. Returns true → the caller should 403.
+ * `apiKeyId` is `undefined`/`null` for session auth (never out of scope).
+ *
+ * `appsService` is imported dynamically so this module — and the pure
+ * predicate's unit tests — don't pull in the apps/DB layer.
+ */
+export async function isAppKeyOutOfScope(
+  apiKeyId: string | null | undefined,
+  requestedAppId: string,
+): Promise<boolean> {
+  if (!apiKeyId) return false;
+  const { appsService } = await import("../services/apps");
+  const owningApp = await appsService.getByApiKeyId(apiKeyId);
+  return isCrossAppKeyUsage({
+    apiKeyId,
+    owningAppId: owningApp?.id,
+    requestedAppId,
+  });
+}


### PR DESCRIPTION
Fixes #10852.

## The bug (intra-org privilege escalation)
App-minted API keys (`apps.api_key_id`) are stored in `api_keys` with **no
app_id/scope column**, so `requireUserOrApiKeyWithOrg` resolves them to a full
org `AuthedUser` — indistinguishable from a normal org key. Every `/apps/[id]/*`
route gated only on `app.organization_id === user.organization_id`, so **App A's
key could act on any sibling app B in the same org**: `DELETE /apps/B`, rotate
B's key (DoS), PATCH/deploy B, and spend org credits via B's charges /
generate-image. Only `characters/route.ts` app-scopes (reverse-match
`app.api_key_id === apiKey.id`) — the intended scoping, realized nowhere else. A
single leaked app key = full compromise of every sibling app in the org.

## The fix (no `api_keys` migration)
A shared guard reverse-matches the resolved key against `apps.api_key_id`
(`appsService.getByApiKeyId`, which already exists): **if the credential IS an
app key, it may only act on its own app; a normal org key or session keeps full
org access, unchanged.** Applied to the mutating + spending + app-scoped-read
routes:
`route.ts` (PATCH/PUT + DELETE), `deploy`, `regenerate-api-key`, `charges` (POST
create + GET list), `generate-image`.

The money-critical decision is the pure `isCrossAppKeyUsage`; `isAppKeyOutOfScope`
does the lookup (dynamic `appsService` import so the predicate is unit-testable
without the DB layer).

## Tests / evidence
`app-key-scope.test.ts` drives the real predicate: app A's key on app B → **deny**;
on its own app A → allow; normal org key (no app claims it) / session → **allow**
(full org access unchanged); null-key defensive case. **5 pass.** Biome clean;
typecheck clean for the touched files (the only tsgo noise is the unrelated
missing generated `core/src/i18n/generated/*` files, per cloud-shared's own
CLAUDE.md note about transitive-import typecheck noise).

## Note
The proper long-term fix is an explicit `api_keys.app_id` scope column + backfill,
enforced in `requireUserOrApiKeyWithOrg`. This reverse-match closes the hole
**now** without a migration on the auth-critical `api_keys` table — happy to do
the schema version as a follow-up if you'd prefer that shape. Live-stack denied-
path E2E (`cloud:mock`, per #9853/#9948) = N/A here; proved via the real predicate.
