### PR TITLE
test(agent): cover chat attachment processing lifecycle (#10714)

### DIFF
--- a/.github/issue-evidence/10714-attachment-processing-lifecycle/README.md
+++ b/.github/issue-evidence/10714-attachment-processing-lifecycle/README.md
@@ -1,0 +1,55 @@
+# #10714 attachment processing lifecycle slice
+
+## Scope
+
+This PR adds deterministic in-repo coverage for the accepted chat-upload MIME
+set:
+
+`validateChatImages` -> `buildChatAttachments` -> content-addressed media store
+-> media serve headers/range handling -> `DefaultMessageService.processAttachments`.
+
+It also persists additive `Media` metadata for chat uploads:
+`mimeType`, `filename`, `size`, and `checksum`.
+
+This is not the full issue closeout. The issue still requires the live-model
+scenario trajectory and app upload UI screenshots/video.
+
+## Verification
+
+```bash
+bun run --cwd packages/agent test -- src/api/chat-attachment-processing-lifecycle.test.ts src/api/chat-attachments.test.ts src/api/media-store.test.ts
+```
+
+Result: 3 files passed, 40 tests passed.
+
+```bash
+bun run --cwd packages/core test -- src/services/message.processAttachments.test.ts src/features/basic-capabilities/process-attachments-documents.test.ts src/features/basic-capabilities/providers/attachments.test.ts
+```
+
+Result: 3 files passed, 20 tests passed.
+
+```bash
+bunx biome check packages/agent/src/api/server-helpers.ts packages/agent/src/api/chat-attachment-processing-lifecycle.test.ts packages/agent/src/api/chat-attachments.test.ts
+```
+
+Result: clean.
+
+## Typecheck
+
+Attempted:
+
+```bash
+bun run --cwd packages/agent typecheck
+```
+
+Blocked before this diff by unresolved workspace package declarations:
+`@elizaos/plugin-streaming`, `@elizaos/plugin-background-runner`, and
+`@elizaos/cloud-routing`.
+
+## Evidence not covered by this slice
+
+- Real-LLM trajectory: not included in this deterministic unit/lifecycle slice.
+- App upload UI screenshots/video: not included; the issue remains open for that lane.
+- Stored media domain artifacts: the lifecycle test creates a temp
+  `ELIZA_STATE_DIR`, asserts every file exists under the media store, validates
+  serve headers and audio/video Range responses, and then deletes the temp store.

--- a/packages/agent/src/api/chat-attachment-processing-lifecycle.test.ts
+++ b/packages/agent/src/api/chat-attachment-processing-lifecycle.test.ts
@@ -1,0 +1,328 @@
+import { Buffer } from "node:buffer";
+import fs from "node:fs";
+import type { ServerResponse } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import type { IAgentRuntime, Media } from "@elizaos/core";
+import { afterAll, describe, expect, it, vi } from "vitest";
+
+const oldStateDir = process.env.ELIZA_STATE_DIR;
+const stateDir = fs.mkdtempSync(
+  path.join(os.tmpdir(), "chat-attachment-lifecycle-"),
+);
+process.env.ELIZA_STATE_DIR = stateDir;
+
+// Imported after ELIZA_STATE_DIR is set so media-store resolves to the temp dir.
+const { buildChatAttachments, CHAT_UPLOAD_MIME_TYPES, validateChatImages } =
+  await import("./server-helpers.ts");
+const { mediaFileNameFromUrl, serveMediaFile } = await import(
+  "./media-store.ts"
+);
+const { ContentType, DefaultMessageService, ModelType } = await import(
+  "@elizaos/core"
+);
+
+afterAll(() => {
+  fs.rmSync(stateDir, { recursive: true, force: true });
+  if (oldStateDir === undefined) {
+    delete process.env.ELIZA_STATE_DIR;
+  } else {
+    process.env.ELIZA_STATE_DIR = oldStateDir;
+  }
+});
+
+const EXPECTED_EXT_BY_MIME: Record<
+  (typeof CHAT_UPLOAD_MIME_TYPES)[number],
+  string
+> = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/gif": "gif",
+  "image/webp": "webp",
+  "audio/mpeg": "mp3",
+  "audio/mp3": "mp3",
+  "audio/wav": "wav",
+  "audio/x-wav": "wav",
+  "audio/wave": "wav",
+  "audio/ogg": "ogg",
+  "audio/webm": "weba",
+  "audio/mp4": "m4a",
+  "audio/aac": "aac",
+  "audio/flac": "flac",
+  "video/mp4": "mp4",
+  "video/webm": "webm",
+  "video/quicktime": "mov",
+  "video/ogg": "ogv",
+  "application/pdf": "pdf",
+  "text/plain": "txt",
+  "text/csv": "csv",
+  "text/markdown": "md",
+};
+
+function expectedContentType(mimeType: string): string {
+  if (mimeType.startsWith("image/")) return ContentType.IMAGE;
+  if (mimeType.startsWith("audio/")) return ContentType.AUDIO;
+  if (mimeType.startsWith("video/")) return ContentType.VIDEO;
+  return ContentType.DOCUMENT;
+}
+
+function expectedServedMime(mimeType: string): string {
+  if (mimeType === "text/plain") return "text/plain; charset=utf-8";
+  if (mimeType === "text/csv") return "text/csv; charset=utf-8";
+  if (mimeType === "text/markdown") return "text/markdown; charset=utf-8";
+  if (mimeType === "image/jpeg") return "image/jpeg";
+  if (mimeType === "audio/mp3") return "audio/mpeg";
+  if (mimeType === "audio/x-wav" || mimeType === "audio/wave")
+    return "audio/wav";
+  return mimeType;
+}
+
+function nameForMime(
+  mimeType: (typeof CHAT_UPLOAD_MIME_TYPES)[number],
+): string {
+  return `sample.${EXPECTED_EXT_BY_MIME[mimeType]}`;
+}
+
+function buildPdf(text: string): Buffer {
+  const stream = `BT /F1 24 Tf 72 700 Td (${text}) Tj ET`;
+  const objects = [
+    "<< /Type /Catalog /Pages 2 0 R >>",
+    "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+    "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>",
+    `<< /Length ${stream.length} >>\nstream\n${stream}\nendstream`,
+    "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+  ];
+  let body = "%PDF-1.4\n";
+  const offsets: number[] = [];
+  objects.forEach((object, index) => {
+    offsets.push(body.length);
+    body += `${index + 1} 0 obj\n${object}\nendobj\n`;
+  });
+  const xrefStart = body.length;
+  body += `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`;
+  for (const offset of offsets) {
+    body += `${String(offset).padStart(10, "0")} 00000 n \n`;
+  }
+  body += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xrefStart}\n%%EOF\n`;
+  return Buffer.from(body, "latin1");
+}
+
+function bytesForMime(mimeType: string): Buffer {
+  if (mimeType === "application/pdf") {
+    return buildPdf("Hello PDF from lifecycle 10714");
+  }
+  if (mimeType === "text/plain") {
+    return Buffer.from("plain text lifecycle body", "utf8");
+  }
+  if (mimeType === "text/csv") {
+    return Buffer.from("name,score\nada,99\ngrace,97", "utf8");
+  }
+  if (mimeType === "text/markdown") {
+    return Buffer.from("# Lifecycle\n\n- upload\n- process", "utf8");
+  }
+  return Buffer.from(`binary fixture for ${mimeType}`, "utf8");
+}
+
+function makeRes(): {
+  res: ServerResponse;
+  get: () => { status: number; headers: Record<string, unknown> };
+} {
+  let status = 0;
+  let headers: Record<string, unknown> = {};
+  const res = {
+    writeHead(nextStatus: number, nextHeaders: Record<string, unknown>) {
+      status = nextStatus;
+      headers = nextHeaders;
+      return this;
+    },
+    end() {},
+    write() {
+      return true;
+    },
+    on() {
+      return this;
+    },
+    once() {
+      return this;
+    },
+    emit() {
+      return true;
+    },
+  } as unknown as ServerResponse;
+  return { res, get: () => ({ status, headers }) };
+}
+
+function serve(url: string, options: { method?: string; range?: string } = {}) {
+  const { res, get } = makeRes();
+  const handled = serveMediaFile(
+    {
+      method: options.method ?? "HEAD",
+      headers: options.range ? { range: options.range } : {},
+    } as never,
+    res,
+    url,
+  );
+  expect(handled).toBe(true);
+  return get();
+}
+
+function mediaPathFromUrl(url: string): string {
+  const fileName = mediaFileNameFromUrl(url);
+  if (!fileName) throw new Error(`expected stored media URL, got ${url}`);
+  return path.join(stateDir, "media", fileName);
+}
+
+async function mediaStoreFetch(input: unknown): Promise<Response> {
+  const raw =
+    typeof input === "string"
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : typeof (input as { url?: unknown })?.url === "string"
+          ? String((input as { url: string }).url)
+          : String(input);
+  const parsed = new URL(raw);
+  const pathName = parsed.pathname;
+  const fileName = mediaFileNameFromUrl(pathName);
+  if (!fileName) {
+    return new Response("not found", { status: 404, statusText: "Not Found" });
+  }
+  const body = fs.readFileSync(path.join(stateDir, "media", fileName));
+  const head = serve(pathName);
+  return new Response(body, {
+    status: 200,
+    statusText: "OK",
+    headers: {
+      "Content-Type": String(head.headers["Content-Type"]),
+    },
+  });
+}
+
+function makeRuntime(mimeType: string): IAgentRuntime {
+  return {
+    logger: {
+      debug: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+      error: vi.fn(),
+    },
+    getSetting: vi.fn(() => undefined),
+    getCache: vi.fn(async () => undefined),
+    setCache: vi.fn(async () => undefined),
+    fetch: mediaStoreFetch,
+    useModel: vi.fn(async (modelType: string) => {
+      if (modelType === ModelType.IMAGE_DESCRIPTION) {
+        return {
+          title: "Lifecycle image",
+          description: `description for ${mimeType}`,
+          text: `image text for ${mimeType}`,
+        };
+      }
+      if (modelType === ModelType.TRANSCRIPTION) {
+        return `transcript for ${mimeType}`;
+      }
+      throw new Error(`unexpected model: ${modelType}`);
+    }),
+  } as unknown as IAgentRuntime;
+}
+
+function expectedProcessedText(mimeType: string): string {
+  if (mimeType.startsWith("image/")) return `image text for ${mimeType}`;
+  if (mimeType.startsWith("audio/") || mimeType.startsWith("video/"))
+    return `transcript for ${mimeType}`;
+  if (mimeType === "application/pdf") return "Hello PDF from lifecycle 10714";
+  return bytesForMime(mimeType).toString("utf8");
+}
+
+describe("chat attachment upload -> store -> processing lifecycle (#10714)", () => {
+  it("accepts, persists, serves, and processes every supported upload MIME type", async () => {
+    const service = new DefaultMessageService();
+
+    for (const mimeType of CHAT_UPLOAD_MIME_TYPES) {
+      const bytes = bytesForMime(mimeType);
+      const upload = {
+        data: bytes.toString("base64"),
+        mimeType,
+        name: nameForMime(mimeType),
+      };
+
+      expect(validateChatImages([upload]), mimeType).toBeNull();
+
+      const { attachments, compactAttachments } = await buildChatAttachments([
+        upload,
+      ]);
+      const attachment = attachments?.[0];
+      const compact = compactAttachments?.[0] as
+        | (Media & { _data?: unknown; _mimeType?: unknown })
+        | undefined;
+
+      expect(attachment, mimeType).toBeDefined();
+      expect(compact, mimeType).toBeDefined();
+      expect(attachment?.url, mimeType).toMatch(
+        new RegExp(
+          `^/api/media/[a-f0-9]{64}\\.${EXPECTED_EXT_BY_MIME[mimeType]}$`,
+        ),
+      );
+      expect(fs.existsSync(mediaPathFromUrl(attachment?.url ?? ""))).toBe(true);
+      expect(attachment?.contentType).toBe(expectedContentType(mimeType));
+      expect(attachment?.mimeType).toBe(mimeType);
+      expect(attachment?.filename).toBe(upload.name);
+      expect(attachment?.size).toBe(bytes.length);
+      expect(attachment?.checksum).toMatch(/^[a-f0-9]{64}$/);
+
+      expect(compact?._data, mimeType).toBeUndefined();
+      expect(compact?._mimeType, mimeType).toBeUndefined();
+      expect(compact?.mimeType).toBe(mimeType);
+      expect(compact?.checksum).toBe(attachment?.checksum);
+
+      const head = serve(attachment?.url ?? "");
+      expect(head.status, mimeType).toBe(200);
+      expect(head.headers["Content-Type"], mimeType).toBe(
+        expectedServedMime(mimeType),
+      );
+      expect(head.headers["X-Content-Type-Options"], mimeType).toBe("nosniff");
+      const disposition = String(head.headers["Content-Disposition"]);
+      if (mimeType.startsWith("text/")) {
+        expect(disposition, mimeType).toContain("attachment");
+      } else {
+        expect(disposition, mimeType).toBe("inline");
+      }
+
+      if (mimeType.startsWith("audio/") || mimeType.startsWith("video/")) {
+        const ranged = serve(attachment?.url ?? "", {
+          method: "GET",
+          range: "bytes=0-2",
+        });
+        expect(ranged.status, mimeType).toBe(206);
+        expect(String(ranged.headers["Content-Range"]), mimeType).toMatch(
+          /^bytes 0-2\/\d+$/,
+        );
+      }
+
+      const runtime = makeRuntime(mimeType);
+      const [processed] = await service.processAttachments(runtime, [
+        attachment as Media,
+      ]);
+
+      expect(processed.text, mimeType).toBe(expectedProcessedText(mimeType));
+      if (mimeType.startsWith("image/")) {
+        expect(processed.description, mimeType).toBe(
+          `description for ${mimeType}`,
+        );
+        expect(runtime.useModel).toHaveBeenCalledWith(
+          ModelType.IMAGE_DESCRIPTION,
+          expect.objectContaining({ stream: false }),
+        );
+      }
+      if (mimeType.startsWith("audio/") || mimeType.startsWith("video/")) {
+        expect(processed.description, mimeType).toBe(
+          `Transcript: transcript for ${mimeType}`,
+        );
+        expect(runtime.useModel).toHaveBeenCalledWith(
+          ModelType.TRANSCRIPTION,
+          expect.any(Buffer),
+        );
+      }
+    }
+  });
+});

--- a/packages/agent/src/api/server-helpers.ts
+++ b/packages/agent/src/api/server-helpers.ts
@@ -450,14 +450,15 @@ const MAX_IMAGE_DATA_BYTES = 5 * 1_048_576; // 5 MB for images
 const MAX_MEDIA_DATA_BYTES = 15 * 1_048_576; // 15 MB for audio/video/pdf
 const MAX_IMAGE_NAME_LENGTH = 255;
 const BASE64_RE = /^[A-Za-z0-9+/]*={0,2}$/;
-const ALLOWED_IMAGE_MIME_TYPES = new Set([
+const CHAT_IMAGE_MIME_TYPES = [
   "image/jpeg",
   "image/png",
   "image/gif",
   "image/webp",
-]);
-const ALLOWED_CHAT_MEDIA_MIME_TYPES = new Set([
-  ...ALLOWED_IMAGE_MIME_TYPES,
+] as const;
+
+export const CHAT_UPLOAD_MIME_TYPES = [
+  ...CHAT_IMAGE_MIME_TYPES,
   "audio/mpeg",
   "audio/mp3",
   "audio/wav",
@@ -476,7 +477,9 @@ const ALLOWED_CHAT_MEDIA_MIME_TYPES = new Set([
   "text/plain",
   "text/csv",
   "text/markdown",
-]);
+] as const;
+
+const ALLOWED_CHAT_MEDIA_MIME_TYPES = new Set<string>(CHAT_UPLOAD_MIME_TYPES);
 
 export const IMAGE_ONLY_CHAT_FALLBACK_PROMPT =
   "Please review the attached file.";
@@ -575,13 +578,14 @@ export async function buildChatAttachments(
       // attachment carries a durable served URL (renderable from chat history),
       // not a throwaway `attachment:img-N` placeholder. `_data` is retained for
       // the in-memory vision/description pass so it needs no re-fetch.
+      const bytes = Buffer.from(img.data, "base64");
       let url = `attachment:img-${i}`;
+      let checksum: string | undefined;
       let thumbnailUrl: string | undefined;
       try {
-        url = persistMediaBytes(
-          Buffer.from(img.data, "base64"),
-          img.mimeType,
-        ).url;
+        const persisted = persistMediaBytes(bytes, img.mimeType);
+        url = persisted.url;
+        checksum = persisted.hash;
         if (img.thumbnail?.data) {
           // Client already produced a thumbnail (browser/webview canvas) — persist it.
           thumbnailUrl = persistMediaBytes(
@@ -591,14 +595,11 @@ export async function buildChatAttachments(
         } else if (img.mimeType.toLowerCase().startsWith("image/")) {
           // No client thumbnail (non-webview client) — pre-compute one server-side.
           thumbnailUrl =
-            (await persistImageThumbnail(
-              Buffer.from(img.data, "base64"),
-              img.mimeType,
-            )) ?? undefined;
+            (await persistImageThumbnail(bytes, img.mimeType)) ?? undefined;
         }
       } catch (err) {
         logger.warn(
-          `[buildChatAttachments] failed to persist uploaded image: ${
+          `[buildChatAttachments] failed to persist uploaded attachment: ${
             err instanceof Error ? err.message : String(err)
           }`,
         );
@@ -609,6 +610,10 @@ export async function buildChatAttachments(
         title: img.name,
         source: "client_chat",
         contentType: contentTypeForUploadMime(img.mimeType),
+        mimeType: img.mimeType,
+        filename: img.name,
+        size: bytes.length,
+        ...(checksum ? { checksum } : {}),
         ...(thumbnailUrl ? { thumbnailUrl } : {}),
         _data: img.data,
         _mimeType: img.mimeType,


### PR DESCRIPTION
## What\n\nAdds a deterministic lifecycle test for #10714's accepted chat-upload MIME set. The test drives every MIME in the exported `CHAT_UPLOAD_MIME_TYPES` source of truth through:\n\n- `validateChatImages`\n- `buildChatAttachments`\n- content-addressed media-store persistence\n- serve headers and audio/video Range responses\n- `DefaultMessageService.processAttachments`\n\nAlso adds additive upload metadata on persisted chat attachments: `mimeType`, `filename`, `size`, and `checksum`.\n\n## Verification\n\n- `bun run --cwd packages/agent test -- src/api/chat-attachment-processing-lifecycle.test.ts src/api/chat-attachments.test.ts src/api/media-store.test.ts` — 3 files / 40 tests passed\n- `bun run --cwd packages/core test -- src/services/message.processAttachments.test.ts src/features/basic-capabilities/process-attachments-documents.test.ts src/features/basic-capabilities/providers/attachments.test.ts` — 3 files / 20 tests passed\n- `bunx biome check packages/agent/src/api/server-helpers.ts packages/agent/src/api/chat-attachment-processing-lifecycle.test.ts packages/agent/src/api/chat-attachments.test.ts` — clean\n- `git diff --check` — clean\n\nAttempted `bun run --cwd packages/agent typecheck`; it is blocked before this diff by unresolved workspace declarations for `@elizaos/plugin-streaming`, `@elizaos/plugin-background-runner`, and `@elizaos/cloud-routing`.\n\n## Evidence\n\nSee `.github/issue-evidence/10714-attachment-processing-lifecycle/README.md`.\n\nThis PR is intentionally a deterministic in-repo coverage slice. It does **not** close #10714 by itself; the issue still needs the live-model trajectory and app upload UI screenshots/video lane.\n\n🤖 Generated with Codex.