### PR TITLE
fix(cloud): atomic upfront credit hold for monetized-app /v1/messages — stop concurrent overspend (#10857)

### DIFF
--- a/packages/cloud/api/__tests__/messages-iac-fast-path.test.ts
+++ b/packages/cloud/api/__tests__/messages-iac-fast-path.test.ts
@@ -14,6 +14,7 @@ const aiActual = require("ai") as Record<string, unknown>;
 const ORG = "00000000-0000-4000-8000-0000000000aa";
 const USER = "00000000-0000-4000-8000-0000000000bb";
 const API_KEY_ID = "00000000-0000-4000-8000-0000000000cc";
+const APP_ID = "00000000-0000-4000-8000-0000000000dd";
 
 mock.module("@/lib/pricing", () => ({
   calculateCost: async () => ({
@@ -100,17 +101,22 @@ mock.module("@/lib/services/credits", () => ({
   },
 }));
 
+const deductCredits = mock();
+const reconcileCredits = mock();
 mock.module("@/lib/services/app-credits", () => ({
   appCreditsService: {
     calculateCostWithMarkup: async () => ({ totalCost: 0.002 }),
     checkBalance: async () => ({ sufficient: true }),
+    deductCredits,
+    reconcileCredits,
     recordUsage: async () => undefined,
   },
 }));
 
+const getAuthorizedMonetizedAppForUser = mock();
 mock.module("@/lib/services/apps", () => ({
   appsService: {
-    getAuthorizedMonetizedAppForUser: async () => null,
+    getAuthorizedMonetizedAppForUser,
     getById: async () => null,
   },
 }));
@@ -152,6 +158,9 @@ beforeEach(() => {
   moderateInBackground.mockReset();
   reserveCredits.mockReset();
   billUsage.mockReset();
+  deductCredits.mockReset();
+  reconcileCredits.mockReset();
+  getAuthorizedMonetizedAppForUser.mockReset();
   estimateInputTokens.mockReset();
   recordUsageAnalytics.mockReset();
   createCreditReservationSettler.mockReset();
@@ -169,9 +178,25 @@ beforeEach(() => {
   validateApiKey.mockResolvedValue({ id: API_KEY_ID });
   shouldBlockUser.mockResolvedValue(false);
   estimateInputTokens.mockReturnValue(8);
+  getAuthorizedMonetizedAppForUser.mockResolvedValue(null);
   reserveCredits.mockResolvedValue({
     reservedAmount: 0.01,
     reconcile: async () => null,
+  });
+  deductCredits.mockResolvedValue({
+    success: true,
+    baseCost: 0.003,
+    creatorMarkup: 0,
+    totalCost: 0.003,
+    creatorEarnings: 0,
+    newBalance: 1,
+  });
+  reconcileCredits.mockResolvedValue({
+    reconciled: true,
+    difference: -0.003,
+    action: "refund",
+    adjustedAmount: 0.003,
+    newBalance: 1,
   });
   createCreditReservationSettler.mockReturnValue(async () => null);
   generateText.mockImplementation(() => {
@@ -179,12 +204,13 @@ beforeEach(() => {
   });
 });
 
-function postMessages() {
+function postMessages(headers: Record<string, string> = {}) {
   return messagesRoute.request("/", {
     method: "POST",
     headers: {
       "content-type": "application/json",
       "x-api-key": "eliza_test_key",
+      ...headers,
     },
     body: JSON.stringify({
       model: "claude-3-5-sonnet-20241022",
@@ -233,5 +259,41 @@ describe("/v1/messages IAC fast path", () => {
     expect(shouldBlockUser).not.toHaveBeenCalled();
     expect(reserveCredits).not.toHaveBeenCalled();
     expect(generateText).not.toHaveBeenCalled();
+  });
+
+  test("monetized app provider failure refunds the upfront app-credit hold", async () => {
+    getAuthorizedMonetizedAppForUser.mockResolvedValueOnce({
+      id: APP_ID,
+      monetization_enabled: true,
+      platform_offset_amount: "0",
+      purchase_share_percentage: "0",
+      inference_markup_percentage: "0",
+    });
+
+    const response = await postMessages({ "X-App-Id": APP_ID });
+
+    expect(response.status).toBe(500);
+    expect(reserveCredits).not.toHaveBeenCalled();
+    expect(deductCredits).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appId: APP_ID,
+        userId: USER,
+        baseCost: expect.closeTo(0.003, 10),
+      }),
+    );
+    expect(generateText).toHaveBeenCalledTimes(1);
+    expect(reconcileCredits).toHaveBeenCalledTimes(1);
+    expect(reconcileCredits).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appId: APP_ID,
+        userId: USER,
+        estimatedBaseCost: expect.closeTo(0.003, 10),
+        actualBaseCost: 0,
+        metadata: expect.objectContaining({
+          reason: "non_stream_error",
+          streaming: false,
+        }),
+      }),
+    );
   });
 });

--- a/packages/cloud/api/v1/messages/route.ts
+++ b/packages/cloud/api/v1/messages/route.ts
@@ -149,6 +149,49 @@ type AppCreditsInfo = {
   estimatedBaseCost: number;
 };
 
+type RefundAppCreditHold = (
+  reason: string,
+  metadata?: Record<string, unknown>,
+) => Promise<void>;
+
+function createAppCreditHoldRefunder(args: {
+  appCreditsInfo: AppCreditsInfo | undefined;
+  userId: string;
+  model: string;
+  provider: string;
+  billingSource: PricingBillingSource;
+}): RefundAppCreditHold {
+  let refunded = false;
+  return async (reason, metadata = {}) => {
+    if (!args.appCreditsInfo || refunded) return;
+    refunded = true;
+    try {
+      await appCreditsService.reconcileCredits({
+        appId: args.appCreditsInfo.appId,
+        userId: args.userId,
+        estimatedBaseCost: args.appCreditsInfo.estimatedBaseCost,
+        actualBaseCost: 0,
+        description: `Messages API refund: ${args.model}`,
+        metadata: {
+          model: args.model,
+          provider: args.provider,
+          billingSource: args.billingSource,
+          reason,
+          ...metadata,
+        },
+      });
+    } catch (error) {
+      logger.error("[Messages API] Failed to refund app credit hold", {
+        appId: args.appCreditsInfo.appId,
+        userId: args.userId,
+        estimatedBaseCost: args.appCreditsInfo.estimatedBaseCost,
+        reason,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  };
+}
+
 function normalizeModelId(model: string): string {
   const canonicalCerebrasModel = canonicalizeCerebrasModelId(model);
   if (canonicalCerebrasModel !== model) return canonicalCerebrasModel;
@@ -488,6 +531,8 @@ app.post("/", async (c) => {
   let settleReservation:
     | ((actualCost: number) => Promise<CreditReconciliationResult | null>)
     | null = null;
+  let refundAppCreditHold: RefundAppCreditHold | null = null;
+  let appCreditsInfo: AppCreditsInfo | undefined;
 
   let user: { id: string; organization_id: string };
   let apiKey: { id: string } | null = null;
@@ -619,7 +664,6 @@ app.post("/", async (c) => {
     resolveAiProviderSource(model) ?? "bitrouter";
 
   let reservation: CreditReservation;
-  let appCreditsInfo: AppCreditsInfo | undefined;
 
   if (useAppCredits && appId && monetizedApp) {
     const { totalCost: estimatedBaseCost } = await calculateCost(
@@ -696,6 +740,13 @@ app.post("/", async (c) => {
     }
   }
 
+  refundAppCreditHold = createAppCreditHoldRefunder({
+    appCreditsInfo,
+    userId: user.id,
+    model,
+    provider,
+    billingSource,
+  });
   settleReservation = createCreditReservationSettler(reservation);
 
   const messages = anthropicMessagesToModelMessages(request.messages);
@@ -727,6 +778,7 @@ app.post("/", async (c) => {
         c.req.raw.signal,
         routeTimeoutMs,
         settleReservation,
+        refundAppCreditHold,
         billingSource,
       );
     }
@@ -747,9 +799,13 @@ app.post("/", async (c) => {
       c.req.raw.signal,
       routeTimeoutMs,
       settleReservation,
+      refundAppCreditHold,
       billingSource,
     );
   } catch (error) {
+    await refundAppCreditHold?.("route_error", {
+      streaming: request?.stream ?? false,
+    });
     await settleReservation?.(0);
     const message = error instanceof Error ? error.message : String(error);
     logger.error("[Messages API] Error", { error: message });
@@ -798,6 +854,7 @@ async function handleNonStream(
   settleReservation: (
     actualCost: number,
   ) => Promise<CreditReconciliationResult | null>,
+  refundAppCreditHold: RefundAppCreditHold,
   billingSource: PricingBillingSource,
 ) {
   const provider = getProviderFromModel(model);
@@ -854,7 +911,13 @@ async function handleNonStream(
         estimatedBaseCost: appCreditsInfo.estimatedBaseCost,
         actualBaseCost: billing.totalCost,
         description: `Messages API: ${model}`,
-        metadata: { model, provider, billingSource, streaming: false, idempotencyKey: requestId },
+        metadata: {
+          model,
+          provider,
+          billingSource,
+          streaming: false,
+          idempotencyKey: requestId,
+        },
       });
     }
 
@@ -923,6 +986,7 @@ async function handleNonStream(
       },
     });
   } catch (error) {
+    await refundAppCreditHold("non_stream_error", { streaming: false });
     await settleReservation(0);
     throw error;
   }
@@ -952,6 +1016,7 @@ async function handleStream(
   settleReservation: (
     actualCost: number,
   ) => Promise<CreditReconciliationResult | null>,
+  refundAppCreditHold: RefundAppCreditHold,
   billingSource: PricingBillingSource,
 ) {
   const provider = getProviderFromModel(model);
@@ -1008,7 +1073,13 @@ async function handleStream(
             estimatedBaseCost: appCreditsInfo.estimatedBaseCost,
             actualBaseCost: billing.totalCost,
             description: `Messages API stream: ${model}`,
-            metadata: { model, provider, billingSource, streaming: true, idempotencyKey: requestId },
+            metadata: {
+              model,
+              provider,
+              billingSource,
+              streaming: true,
+              idempotencyKey: requestId,
+            },
           });
         }
 
@@ -1038,6 +1109,10 @@ async function handleStream(
       }
     },
     onAbort: async () => {
+      await refundAppCreditHold("stream_aborted", {
+        streaming: true,
+        estimatedInputTokens,
+      });
       await settleReservation(0);
       logger.info("[Messages API] Stream aborted before completion", {
         model,
@@ -1050,6 +1125,10 @@ async function handleStream(
     // non-streaming error path's settleReservation(0); the settler is
     // idempotent (first-call-wins) so this cannot double-refund.
     onError: async ({ error }: { error: unknown }) => {
+      await refundAppCreditHold("stream_provider_error", {
+        streaming: true,
+        estimatedInputTokens,
+      });
       await settleReservation(0);
       logger.error(
         "[Messages API] Stream provider error — reservation refunded",
@@ -1293,6 +1372,10 @@ async function handleStream(
         // leaked (a permanent overcharge). The settler is first-call-wins
         // idempotent, so this cannot double-refund if onError already won the
         // race. Mirrors the /v1/chat/completions backstop.
+        await refundAppCreditHold("stream_error_backstop", {
+          streaming: true,
+          estimatedInputTokens,
+        });
         await settleReservation(0);
         const message = error instanceof Error ? error.message : String(error);
         logger.error("[Messages API] Stream error", { error: message });

--- a/packages/cloud/api/v1/messages/route.ts
+++ b/packages/cloud/api/v1/messages/route.ts
@@ -67,6 +67,11 @@ import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
 const ROUTE_MAX_DURATION = 800;
 
+// Buffer the upfront monetized-app credit hold above the estimate to reduce
+// undercharge risk; reconciled to the actual cost after the response. Matches
+// the /apps/:id/chat route's COST_SAFETY_MULTIPLIER.
+const COST_SAFETY_MULTIPLIER = 1.5;
+
 type AnthropicTextBlock = { type: "text"; text: string };
 
 type AnthropicImageBlock = {
@@ -617,34 +622,51 @@ app.post("/", async (c) => {
   let appCreditsInfo: AppCreditsInfo | undefined;
 
   if (useAppCredits && appId && monetizedApp) {
-    const { totalCost } = await calculateCost(
+    const { totalCost: estimatedBaseCost } = await calculateCost(
       normalizedModel,
       provider,
       estimatedInputTokens,
       estimatedOutputTokens,
       billingSource,
     );
-    const costWithMarkup = await appCreditsService.calculateCostWithMarkup(
-      appId,
-      totalCost,
-    );
-    const balanceCheck = await appCreditsService.checkBalance(
-      appId,
-      user.id,
-      costWithMarkup.totalCost,
-    );
 
-    if (!balanceCheck.sufficient) {
+    // Atomically HOLD the (buffered) estimate up front. deductCredits is a
+    // row-locked debit on the org balance, so N concurrent monetized-app
+    // requests serialize and the surplus ones get a clean 429 instead of all
+    // passing a read-only balance check and overspending the org balance while
+    // the platform absorbs the loss (#10857). The old checkBalance +
+    // estimatedBaseCost:0 path deferred the entire charge to the post-response
+    // reconcile with nothing held. Mirrors the /apps/:id/chat route; the hold is
+    // reconciled to the actual cost after the response (estimatedBaseCost below).
+    const reservedBaseCost = estimatedBaseCost * COST_SAFETY_MULTIPLIER;
+    const deductionResult = await appCreditsService.deductCredits({
+      appId,
+      userId: user.id,
+      baseCost: reservedBaseCost,
+      description: `Messages API: ${model}`,
+      metadata: {
+        model,
+        provider,
+        billingSource,
+        estimatedInputTokens,
+        estimatedOutputTokens,
+        safetyMultiplier: COST_SAFETY_MULTIPLIER,
+      },
+      app: monetizedApp,
+    });
+
+    if (!deductionResult.success) {
       return anthropicError(
         "rate_limit_error",
-        `Insufficient cloud credits. Required: $${costWithMarkup.totalCost.toFixed(4)}`,
+        deductionResult.message ||
+          `Insufficient cloud credits. Required: $${deductionResult.totalCost.toFixed(4)}`,
         429,
       );
     }
 
     appCreditsInfo = {
       appId,
-      estimatedBaseCost: 0,
+      estimatedBaseCost: reservedBaseCost,
     };
     reservation = creditsService.createAnonymousReservation();
   } else {

--- a/packages/cloud/shared/src/lib/services/__tests__/credits-deduct-guard.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/credits-deduct-guard.test.ts
@@ -249,6 +249,52 @@ describe("reserveAndDeductCredits — atomic debit", () => {
     },
     PGLITE_TIMEOUT,
   );
+
+  test(
+    "(concurrency #10857) N concurrent debits on a limited balance NEVER overspend — only affordable ones win, balance never goes negative",
+    async () => {
+      if (!pgliteReady) return;
+      // $1.00 balance, 8 concurrent $0.30 charges — only 3 can fit ($0.90).
+      // This is the exact race the monetized-app /v1/messages path hit with the
+      // old read-only checkBalance: all 8 passed the read → served → overspend,
+      // platform absorbing the loss (#10857). The atomic reserveAndDeductCredits
+      // it now uses must serialize on the row and reject the surplus.
+      await seedOrg("1.000000");
+      const AMOUNT = 0.3;
+      const N = 8;
+
+      const results = await Promise.all(
+        Array.from({ length: N }, (_, i) =>
+          creditsService.reserveAndDeductCredits({
+            organizationId: ORG_ID,
+            amount: AMOUNT,
+            description: `concurrent charge ${i}`,
+            metadata: { user_id: USER_ID },
+          }),
+        ),
+      );
+
+      const succeeded = results.filter((r) => r.success);
+      const failed = results.filter((r) => !r.success);
+
+      // Exactly floor(1.00 / 0.30) = 3 win; the surplus fail CLOSED.
+      expect(succeeded).toHaveLength(3);
+      expect(failed).toHaveLength(N - 3);
+      for (const f of failed) {
+        expect(f.reason).toBe("insufficient_balance");
+      }
+
+      // The load-bearing invariant: balance NEVER went negative, and it equals
+      // exactly the 3 affordable debits — no overspend, no platform-absorbed loss.
+      const finalBalance = await readBalance();
+      expect(finalBalance).toBeGreaterThanOrEqual(0);
+      expect(finalBalance).toBeCloseTo(1.0 - 3 * AMOUNT, 6);
+
+      // One debit row per successful charge — no phantom or duplicate debits.
+      expect(await listDebits()).toHaveLength(3);
+    },
+    PGLITE_TIMEOUT,
+  );
 });
 
 describe("reserve() — high-level reservation gate", () => {


### PR DESCRIPTION
Fixes #10857.

## Bug
The monetized-app branch of `/v1/messages` (requests with `X-App-Id`) held **no credits up front**:
```ts
const balanceCheck = await appCreditsService.checkBalance(appId, user.id, costWithMarkup.totalCost); // read-only, no lock
if (!balanceCheck.sufficient) return 429;
appCreditsInfo = { appId, estimatedBaseCost: 0 };            // nothing held
reservation = creditsService.createAnonymousReservation();  // no-op
```
`checkBalance` is a plain balance read. So **N concurrent** `/v1/messages` for the same org all pass it, all get served by the model, and only the deferred post-response `reconcileCredits` actually debits — where `reserveAndDeductCredits` is atomic, so only ~1 succeeds and the other N-1 hit *"Insufficient org balance for additional charge (platform absorbing loss)"*. The user gets **N paid completions for ~1 charge**; the platform eats the rest. The org-credit (non-app) path never had this hole — it reserves atomically via `reserveCredits` and returns 429 when the hold can't be covered.

## Fix
Give the app path the **same atomic upfront hold** the working `/apps/:id/chat` route already uses: `appCreditsService.deductCredits` (a row-locked `reserveAndDeductCredits` on the org balance) for the buffered estimate, `429` on insufficient, then reconcile estimate→actual after the response (unchanged reconcile call, now seeded with the real held amount).

**Charge-neutral by construction:** the net `actualBaseCost` charged is identical to before (reconcile still lands on `billing.totalCost`); the *only* change is that the estimate is now **held atomically** up front, so concurrent requests serialize on the row and the surplus get a clean 429 instead of free inference.

## Evidence
- **Real-PGlite concurrency test** added to `credits-deduct-guard.test.ts` (the suite that covers this exact atomic primitive) — reproduces the race the fix closes: **8 concurrent $0.30 debits on a $1.00 balance → exactly 3 succeed, 5 fail closed (`insufficient_balance`), balance never goes negative, one debit row per win.** This is the property the old `checkBalance` lacked. **10/10 pass.**
- `tsgo` typecheck: clean.

Confirmed real by an adversarial audit with a full code trace (#10857). Money-path — **not self-merged**; requesting review.

### Evidence checklist
- Backend logs / DB rows: the test asserts the persisted `organizations.credit_balance` + `credit_transactions` debit rows after the concurrent burst (real Drizzle rows via PGlite). ✓
- Real-LLM trajectory: **N/A** — pure billing/concurrency change, no model/prompt behavior touched.
- Screenshots/video: **N/A** — backend-only, no UI surface.
