### PR TITLE
fix(cloud): reverse creator earnings on app-inference compensation refund (#10846)

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/app-credits-ledger.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-credits-ledger.test.ts
@@ -284,6 +284,47 @@ describe("deductCredits — debits the same org ledger", () => {
     expect(refund.metadata.reason).toBe("post_debit_accounting_failed");
     expect(refund.metadata.originalChargeTransactionId).toBe("tx-2");
   });
+
+  // #10846: when the failure happens AFTER creator earnings are committed (the
+  // apps aggregate-counter update throws), compensating only the consumer would
+  // leave the creator holding `creatorMarkup` of unbacked redeemable earnings.
+  // The catch must ALSO reverse those earnings.
+  test("reverses committed creator earnings when the apps-counter update throws post-earnings", async () => {
+    reserveAndDeductCredits.mockResolvedValue({
+      success: true,
+      newBalance: 41.4,
+      transaction: { id: "tx-2" },
+    });
+    // trackAppUserActivity + recordCreatorEarnings (addInferenceEarnings /
+    // createTransaction / addEarnings) all succeed (defaults) — so the creator's
+    // app-earnings + redeemable balance ARE committed...
+    // ...then the very next write, the apps aggregate-counter update, throws.
+    whereMock.mockRejectedValueOnce(new Error("apps counter update failed"));
+
+    await expect(
+      freshService().deductCredits({
+        appId: APP_ID,
+        userId: USER_ID,
+        baseCost: 1, // 10% markup → creatorMarkup = 0.10, totalCost = 1.10
+        description: "inference",
+      }),
+    ).rejects.toThrow("apps counter update failed");
+
+    // Consumer is made whole (the full $1.10).
+    expect(addCredits).toHaveBeenCalledTimes(1);
+    expect(addCredits.mock.calls[0][0].amount).toBeCloseTo(1.1, 10);
+
+    // AND the committed creator earnings are reversed — the two stores
+    // recordCreatorEarnings incremented: the app-earnings ledger gets a NEGATIVE
+    // adjustment, and the creator's redeemable balance is reduced. Without the
+    // fix, neither of these fires and unbacked earnings are minted.
+    const negativeAppEarnings = addInferenceEarnings.mock.calls.filter(
+      (c) => typeof c[1] === "number" && c[1] < 0,
+    );
+    expect(negativeAppEarnings.length).toBe(1);
+    expect(negativeAppEarnings[0][1]).toBeCloseTo(-0.1, 10);
+    expect(reduceEarnings).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("reconcileCredits — charges/refunds the estimate↔actual delta (#9145)", () => {

--- a/packages/cloud/shared/src/lib/services/app-credits.ts
+++ b/packages/cloud/shared/src/lib/services/app-credits.ts
@@ -398,6 +398,10 @@ export class AppCreditsService {
       };
     }
 
+    // #10846: track whether the creator earnings were committed, so a failure in
+    // the *following* (non-co-transactional) apps-counter update can reverse them
+    // instead of leaving unbacked earnings minted when the consumer is refunded.
+    let creatorEarningsRecorded = false;
     try {
       // Track app user activity (creates/updates app_users record)
       await this.trackAppUserActivity(app, userId, totalCost.toFixed(4), metadata);
@@ -418,6 +422,9 @@ export class AppCreditsService {
           },
           app, // Pass app to avoid N+1 query
         );
+        // Earnings (app-earnings ledger + creator redeemable balance) are now
+        // committed; the apps aggregate counter below is a separate write.
+        creatorEarningsRecorded = true;
 
         await dbWrite
           .update(apps)
@@ -438,6 +445,42 @@ export class AppCreditsService {
         chargeTransactionId: orgDeduct.transaction?.id,
         error: postDebitError instanceof Error ? postDebitError.message : String(postDebitError),
       });
+      // #10846: if the creator earnings were already committed (recordCreatorEarnings
+      // succeeded, the apps-counter update then threw), reverse them BEFORE
+      // compensating the consumer — otherwise the consumer nets to zero while the
+      // creator keeps `creatorMarkup` of redeemable earnings nobody paid for. This
+      // mirrors the reconcileCredits refund branch, which already pairs the two.
+      // The apps aggregate counter was never incremented (its update is what threw),
+      // so it needs no adjustment here. Best-effort + logged: a reversal failure must
+      // not mask the original error or block the consumer refund.
+      if (creatorEarningsRecorded) {
+        try {
+          await this.reverseCreatorEarnings(appId, userId, creatorMarkup, {
+            type: "compensation_reversal",
+            baseCost,
+            markupPercentage,
+            totalCost,
+            description,
+            chargeTransactionId: orgDeduct.transaction?.id,
+            reason: "post_debit_accounting_failed",
+            ...metadata,
+          });
+        } catch (reversalError) {
+          logger.error(
+            "[AppCredits] Failed to reverse creator earnings during compensation — manual reconciliation may be needed",
+            {
+              appId,
+              userId,
+              creatorMarkup,
+              chargeTransactionId: orgDeduct.transaction?.id,
+              error:
+                reversalError instanceof Error
+                  ? reversalError.message
+                  : String(reversalError),
+            },
+          );
+        }
+      }
       await creditsService.addCredits({
         organizationId: user.organization_id,
         amount: totalCost,


### PR DESCRIPTION
## Reverse creator earnings on app-inference compensation refund (#10846 finding 1)

**The leak (money-integrity, systemic under a DB blip).** In `AppCreditsService.deductCredits`, three writes are **not** co-transactional:
1. `reserveAndDeductCredits(totalCost)` — consumer debit (`baseCost + creatorMarkup`). Committed.
2. `recordCreatorEarnings(creatorMarkup)` — commits the creator's app-earnings ledger **and** redeemable balance, in its own tx.
3. `dbWrite.update(apps)` — increments the `apps` aggregate counters.

If (2) commits but (3) throws (a realistic transient — row-lock/deadlock/statement-timeout on the hot `apps` row, or a connection reset), the catch compensates **only the consumer** via `addCredits(totalCost)` and re-throws. Net: consumer back to zero, but the **creator keeps `creatorMarkup` of redeemable-for-token/fiat earnings nobody paid for** — unbacked earnings minted, systemically so during a blip.

`reverseCreatorEarnings` already exists and is already paired with the refund in the **sibling** `reconcileCredits` branch; the `deductCredits` catch never called it.

## Fix

- Track `creatorEarningsRecorded`, set `true` only after `recordCreatorEarnings` returns.
- In the catch, when set, `reverseCreatorEarnings(appId, userId, creatorMarkup, …)` **before** the consumer refund — reducing exactly the two stores `recordCreatorEarnings` incremented (app-earnings ledger + redeemable balance). The `apps` aggregate counter is left alone because its update is precisely the write that threw.
- Best-effort + logged: a reversal failure can't mask the original error or block the consumer refund.

## Evidence — real regression test

Added to `app-credits-ledger.test.ts` (same mock-seam harness as the existing compensation test): arms `reserveAndDeductCredits` + `recordCreatorEarnings` success, then rejects the apps-counter `update().set().where()`, and asserts:
- consumer refunded the full **$1.10**, AND
- the app-earnings ledger gets a **-0.10** adjustment, AND
- `reduceEarnings` (creator redeemable reduction) fires **once**.

```
# pre-fix develop → new test FAILS (no reversal): expect(negativeAppEarnings.length).toBe(1)
# with fix        → 22 pass / 0 fail   (biome clean, cloud-shared)
```

Verified locally against develop-state (fails on pre-fix, passes on fix).

## Scope

Only **finding 1**. **Finding 2** (`credits.ts` reconcile retry double-apply) is a distinct file/path — not included; tracked in #10846.
