### PR TITLE
fix(cloud): return locked earnings to available_balance when a redemption fails (no stranded funds)

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/payout-stale-lock-recovery.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/payout-stale-lock-recovery.test.ts
@@ -181,6 +181,32 @@ async function readRedemption(id: string): Promise<{
   };
 }
 
+/** Read the redeeming user's earnings balances via the redemption's user_id. */
+async function readEarnings(
+  redemptionId: string,
+): Promise<{ available_balance: number; total_pending: number }> {
+  const r = await dbWrite.execute(
+    `SELECT re.available_balance, re.total_pending
+       FROM redeemable_earnings re
+       JOIN token_redemptions tr ON tr.user_id = re.user_id
+      WHERE tr.id = '${redemptionId}';`,
+  );
+  const row = r.rows[0] as { available_balance: string; total_pending: string };
+  return {
+    available_balance: Number(row.available_balance),
+    total_pending: Number(row.total_pending),
+  };
+}
+
+/** Count refund ledger entries for a redemption (idempotency assertion). */
+async function refundLedgerCount(redemptionId: string): Promise<number> {
+  const r = await dbWrite.execute(
+    `SELECT count(*)::int AS n FROM redeemable_earnings_ledger
+      WHERE redemption_id = '${redemptionId}' AND entry_type = 'refund';`,
+  );
+  return (r.rows[0] as { n: number }).n;
+}
+
 beforeAll(async () => {
   try {
     ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
@@ -594,6 +620,73 @@ describe("payout stale-lock recovery (#10553)", () => {
       expect(row.requires_review).toBe(false);
       expect(sendRawTxMock.mock.calls.length).toBe(0);
       expect(sendAlertMock.mock.calls.length).toBe(0);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "(g) a retries-exhausted redemption returns its locked earnings to available_balance exactly once",
+    async () => {
+      if (!pgliteReady) return;
+      // Seeded: total_pending=10 (locked), available_balance=90, usd_value=10.
+      const id = await seedRedemption({
+        status: "processing",
+        broadcastTxHash: null,
+        startedMinutesAgo: 10,
+        retryCount: 3, // == MAX_RETRY_ATTEMPTS → recovery marks it 'failed'
+      });
+
+      const before = await readEarnings(id);
+      expect(before.available_balance).toBeCloseTo(90, 4);
+      expect(before.total_pending).toBeCloseTo(10, 4);
+
+      await service.processBatch();
+
+      const row = await readRedemption(id);
+      expect(row.status).toBe("failed");
+      expect(row.broadcast_tx_hash).toBeNull();
+
+      // The $10 was returned from total_pending to available_balance (previously
+      // stranded forever — rejectRedemption only touches 'pending' rows).
+      const after = await readEarnings(id);
+      expect(after.available_balance).toBeCloseTo(100, 4);
+      expect(after.total_pending).toBeCloseTo(0, 4);
+      expect(await refundLedgerCount(id)).toBe(1);
+
+      // Idempotent: a second batch does NOT refund again (ledger guard).
+      await service.processBatch();
+      const after2 = await readEarnings(id);
+      expect(after2.available_balance).toBeCloseTo(100, 4);
+      expect(await refundLedgerCount(id)).toBe(1);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "(h) a broadcast-but-unconfirmed row is NEVER refunded (reverse-double-pay guard)",
+    async () => {
+      if (!pgliteReady) return;
+      // A stale row WITH a broadcast hash: tokens may be on-chain, so it must be
+      // routed to reconciliation (left 'processing'), never failed+refunded —
+      // refunding available_balance while tokens went out would be a reverse
+      // double-pay.
+      const id = await seedRedemption({
+        status: "processing",
+        broadcastTxHash: `0x${"d".repeat(64)}`,
+        startedMinutesAgo: 10,
+        retryCount: 0,
+      });
+
+      const before = await readEarnings(id);
+      await service.processBatch();
+
+      const row = await readRedemption(id);
+      // Not failed (reconciliation path), and crucially NOT refunded.
+      expect(row.status).toBe("processing");
+      const after = await readEarnings(id);
+      expect(after.available_balance).toBeCloseTo(before.available_balance, 4);
+      expect(after.total_pending).toBeCloseTo(before.total_pending, 4);
+      expect(await refundLedgerCount(id)).toBe(0);
     },
     PGLITE_TIMEOUT,
   );

--- a/packages/cloud/shared/src/lib/services/payout-processor.ts
+++ b/packages/cloud/shared/src/lib/services/payout-processor.ts
@@ -24,10 +24,14 @@
  * 7. Updates record with tx hash (status = completed)
  *
  * FAILURE HANDLING:
- * - Failed transactions are marked as "failed" with reason
+ * - Failed transactions are marked as "failed" with reason (requires_review)
  * - Automatic retry up to MAX_RETRY_ATTEMPTS
- * - Manual intervention required after max retries
- * - Balance is NOT auto-refunded on failure (requires admin review)
+ * - Manual intervention flagged after max retries
+ * - A provably-un-broadcast failed redemption (no tokens sent) returns its
+ *   locked earnings from total_pending to the user's available_balance
+ *   (refundStrandedRedemption); a broadcast-but-unconfirmed redemption is left
+ *   for on-chain reconciliation and NOT auto-refunded (would be a reverse
+ *   double-pay).
  *
  * ============================================================================
  */
@@ -57,6 +61,7 @@ import {
   type SupportedNetwork,
 } from "./eliza-token-price";
 import { payoutAlertsService } from "./payout-alerts";
+import { redeemableEarningsService } from "./redeemable-earnings";
 
 // Configuration
 const PAYOUT_CONFIG = {
@@ -401,9 +406,17 @@ export class PayoutProcessorService {
       await payoutAlertsService.sendAlert({
         severity: "high",
         title: "Payout retries exhausted",
-        message: `${exhausted.length} stale redemption(s) exceeded retry attempts before any broadcast was detected. Manual review required to release or refund the payout.`,
+        message: `${exhausted.length} stale redemption(s) exceeded retry attempts before any broadcast was detected. Locked earnings are being returned to the users' available balance.`,
         details: { redemptionIds: exhausted.map((r) => r.id) },
       });
+      // These are provably-un-broadcast EVM rows (WHERE ne solana + broadcast_tx_hash
+      // IS NULL), so no tokens were sent — return the locked earnings to the users.
+      for (const r of exhausted) {
+        await this.refundStrandedRedemption(
+          r.id,
+          "Stale processing lock reached MAX_RETRY_ATTEMPTS (no broadcast detected)",
+        );
+      }
     }
     if (stuck.length > 0) {
       logger.error(
@@ -923,11 +936,16 @@ export class PayoutProcessorService {
               "A retryable payout failure reached MAX_RETRY_ATTEMPTS and was marked failed for manual review instead of being orphaned in approved.",
             details: { redemptionId, reason },
           });
+          // Retryable failures never sent tokens (this branch even cleared
+          // broadcast_tx_hash), so return the locked earnings to the user.
+          await this.refundStrandedRedemption(redemptionId, `Payout retries exhausted: ${reason}`);
         }
       }
     } else {
-      // Mark as failed (requires manual intervention)
-      await dbWrite
+      // Mark as failed (requires manual intervention). Guard on status
+      // 'processing' + RETURNING so the transition (and the refund below) happens
+      // exactly once, even if this is called twice for the same row.
+      const failedRows = await dbWrite
         .update(tokenRedemptions)
         .set({
           status: "failed",
@@ -937,7 +955,18 @@ export class PayoutProcessorService {
           processing_worker_id: null,
           updated_at: new Date(),
         })
-        .where(eq(tokenRedemptions.id, redemptionId));
+        .where(
+          and(eq(tokenRedemptions.id, redemptionId), eq(tokenRedemptions.status, "processing")),
+        )
+        .returning({ id: tokenRedemptions.id });
+
+      if (failedRows.length > 0) {
+        // Non-retryable failures are terminal validation errors that occur
+        // before any transfer is broadcast; refundStrandedRedemption additionally
+        // guards on broadcast_tx_hash IS NULL, so a (future) post-broadcast
+        // non-retryable error is left for reconciliation, never refunded.
+        await this.refundStrandedRedemption(redemptionId, `Payout failed: ${reason}`);
+      }
     }
 
     logger.error("[PayoutProcessor] Payout failed", {
@@ -945,6 +974,73 @@ export class PayoutProcessorService {
       reason,
       retryable,
     });
+  }
+
+  /**
+   * Return a permanently-failed redemption's locked USD from `total_pending`
+   * back to the user's `available_balance` (#10059-adjacent earnings-stranding
+   * fix). Requesting a redemption locks the earnings (available -= usd,
+   * total_pending += usd); markCompleted moves that to total_redeemed on success.
+   * A redemption that ends `failed` (retries exhausted / non-retryable / stale
+   * Solana) previously left the USD stuck in total_pending forever —
+   * rejectRedemption only refunds `pending` rows, and refundRedemption had no
+   * callers — so the creator could neither receive tokens nor re-access those
+   * earnings without a manual DB fix.
+   *
+   * SAFETY: only refund a row that is `failed` AND provably never broadcast a
+   * transfer (`broadcast_tx_hash IS NULL`). A row that may have broadcast is left
+   * for on-chain reconciliation — refunding it while tokens are/were in flight
+   * would be a reverse double-pay. IDEMPOTENT: skips if a refund ledger entry for
+   * this redemption already exists. Never throws (the row is requires_review) so
+   * a refund hiccup can't crash the batch or un-fail the redemption.
+   */
+  private async refundStrandedRedemption(redemptionId: string, reason: string): Promise<void> {
+    try {
+      const [row] = await dbRead
+        .select({
+          userId: tokenRedemptions.user_id,
+          usdValue: tokenRedemptions.usd_value,
+          status: tokenRedemptions.status,
+          broadcastTxHash: tokenRedemptions.broadcast_tx_hash,
+        })
+        .from(tokenRedemptions)
+        .where(eq(tokenRedemptions.id, redemptionId))
+        .limit(1);
+
+      // Only refund a terminally-failed, provably-un-broadcast redemption.
+      if (!row || row.status !== "failed" || row.broadcastTxHash) return;
+
+      // Idempotency: never refund the same redemption twice.
+      const [existingRefund] = await dbRead
+        .select({ id: redeemableEarningsLedger.id })
+        .from(redeemableEarningsLedger)
+        .where(
+          and(
+            eq(redeemableEarningsLedger.redemption_id, redemptionId),
+            eq(redeemableEarningsLedger.entry_type, "refund"),
+          ),
+        )
+        .limit(1);
+      if (existingRefund) return;
+
+      await redeemableEarningsService.refundRedemption({
+        userId: row.userId,
+        redemptionId,
+        amount: Number(row.usdValue),
+        reason,
+      });
+
+      logger.info("[PayoutProcessor] Refunded stranded earnings for failed redemption", {
+        redemptionId,
+        amount: row.usdValue,
+        reason,
+      });
+    } catch (error) {
+      logger.error("[PayoutProcessor] Failed to refund stranded redemption earnings", {
+        redemptionId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   /**


### PR DESCRIPTION
Closes #10911.

A token redemption **locks** the creator's earnings (`available_balance -= usd`, `total_pending += usd`). `markCompleted` moves that to `total_redeemed` on success — but a **`failed`** redemption (retries exhausted / non-retryable / stale-EVM recovery) left the USD stuck in `total_pending` **forever**: `rejectRedemption` only refunds `pending` rows, and `refundRedemption` had **zero callers**. The creator could neither receive tokens nor re-access those earnings without a manual DB fix.

**Fix:** a `refundStrandedRedemption` helper returns the locked USD to `available_balance` (via the existing `refundRedemption`), wired into `markFailed`'s two terminal branches + `recoverStaleProcessing`'s EVM exhausted branch.

**Money-safety (money OUT — a wrong refund is a reverse double-pay):**
- refunds only `failed` + `broadcast_tx_hash IS NULL` (provably no tokens sent); a broadcast row is left for reconciliation, never refunded;
- **idempotent** — skips if a `refund` ledger entry exists; terminal UPDATEs guard `status='processing'` + RETURNING so the transition fires once;
- Solana stale-escalation deliberately stays manual (its existing design);
- never throws (row is `requires_review`) → can't crash the batch or un-fail the row.

**Evidence — real-PGlite tests:** (g) retries-exhausted → $10 moves `total_pending`→`available_balance` (90→100, pending→0), one refund ledger row, no double-refund on re-run; (h) a broadcast-but-unconfirmed row is left `processing` and NEVER refunded. Both fail on the pre-fix code. **13 pass**; `cloud-shared` typecheck + biome (2.5.1) clean.

> ⚠️ Money-path change — **not self-merged.** Maintainer review/merge. Found via a payout deep-scan; part of the money-integrity sweep tracked on #10561.