### PR TITLE
fix(plugin-cloud-apps): DELETE_APP reconciles downstream state (#10876)

### DIFF
--- a/plugins/plugin-cloud-apps/__tests__/app-facts.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/app-facts.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "bun:test";
+import {
+  recordAppDeployFact,
+  removeAppDeployFact,
+} from "../src/app-facts.ts";
+import { makeApp, makeRoomMessage, memoryRuntime } from "./helpers";
+
+const appIdOf = (m: { metadata?: unknown }) =>
+  (m.metadata as { appId?: string } | undefined)?.appId;
+
+describe("app deploy facts", () => {
+  it("records a durable deploy fact, then removeAppDeployFact purges it", async () => {
+    const runtime = memoryRuntime();
+    const message = makeRoomMessage("deploy acme");
+    const app = makeApp({ id: "id-acme", name: "Acme Bot", slug: "acme-bot" });
+
+    const rec = await recordAppDeployFact(
+      runtime,
+      message,
+      app,
+      "https://acme.apps.elizacloud.ai",
+    );
+    expect(rec.written).toBe(true);
+    expect(runtime.__facts.some((m) => appIdOf(m) === "id-acme")).toBe(true);
+
+    const removed = await removeAppDeployFact(runtime, message, "id-acme");
+    expect(removed).toBe(true);
+    expect(runtime.__facts.some((m) => appIdOf(m) === "id-acme")).toBe(false);
+  });
+
+  it("removeAppDeployFact returns false when there is no fact for the app", async () => {
+    const runtime = memoryRuntime();
+    expect(
+      await removeAppDeployFact(runtime, makeRoomMessage("x"), "id-nope"),
+    ).toBe(false);
+  });
+
+  it("re-deploying updates the single fact in place, and it stays removable", async () => {
+    const runtime = memoryRuntime();
+    const message = makeRoomMessage("deploy");
+    const app = makeApp({ id: "id-x", name: "X App", slug: "x-app" });
+
+    await recordAppDeployFact(
+      runtime,
+      message,
+      app,
+      "https://x-1.apps.elizacloud.ai",
+    );
+    const second = await recordAppDeployFact(
+      runtime,
+      message,
+      app,
+      "https://x-2.apps.elizacloud.ai",
+    );
+    expect(second.updated).toBe(true);
+    expect(runtime.__facts.filter((m) => appIdOf(m) === "id-x").length).toBe(1);
+
+    expect(await removeAppDeployFact(runtime, message, "id-x")).toBe(true);
+    expect(runtime.__facts.length).toBe(0);
+  });
+});

--- a/plugins/plugin-cloud-apps/__tests__/delete-app.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/delete-app.test.ts
@@ -91,6 +91,42 @@ describe("DELETE_APP", () => {
     expect(cb.calls.at(-1)?.text).toContain("Deleted");
   });
 
+  it("partial-cleanup failure: reports partial, does NOT claim the container/DB are gone", async () => {
+    // The DELETE route returns HTTP 200 with { success:false, errors } when
+    // cleanup partially fails (continueOnError) — the SDK returns it normally.
+    setDeleteApp(() =>
+      Promise.resolve({
+        success: false,
+        message: "partial cleanup",
+        errors: ["tenant_db teardown failed"],
+      }),
+    );
+    const runtime = keyedRuntime();
+    const cb = captureCallback();
+    await deleteAppAction.handler(
+      runtime,
+      makeMessage("delete Acme Bot"),
+      undefined,
+      undefined,
+      cb.fn,
+    );
+    const result = await deleteAppAction.handler(
+      runtime,
+      makeMessage("confirm"),
+      undefined,
+      { confirm: true },
+      cb.fn,
+    );
+    expect(result?.success ?? true).toBe(false);
+    expect((result?.data as { partial?: boolean }).partial).toBe(true);
+    expect((result?.data as { errors?: string[] }).errors).toContain(
+      "tenant_db teardown failed",
+    );
+    const reply = cb.calls.at(-1)?.text ?? "";
+    expect(reply).not.toContain("are gone");
+    expect(reply.toLowerCase()).toContain("dashboard");
+  });
+
   it("a bare 'yes' is NOT enough to delete (connector-agnostic safety)", async () => {
     const deletes = trackDeletes();
     const runtime = keyedRuntime();

--- a/plugins/plugin-cloud-apps/__tests__/helpers.ts
+++ b/plugins/plugin-cloud-apps/__tests__/helpers.ts
@@ -283,6 +283,11 @@ export function memoryRuntime(
       if (idx >= 0) facts[idx] = { ...facts[idx], ...patch } as Memory;
       return Promise.resolve(idx >= 0);
     },
+    deleteMemory: (id: string) => {
+      const idx = facts.findIndex((m) => (m as { id?: string }).id === id);
+      if (idx >= 0) facts.splice(idx, 1);
+      return Promise.resolve();
+    },
   } as unknown as MemoryRuntime;
   return runtime;
 }

--- a/plugins/plugin-cloud-apps/src/actions/create-app.ts
+++ b/plugins/plugin-cloud-apps/src/actions/create-app.ts
@@ -25,6 +25,7 @@ import type {
 } from "@elizaos/core";
 import { logger } from "@elizaos/core";
 import { getCloudClient, resolveCloudApiKey } from "../client.js";
+import { invalidateAppsCache } from "../providers/cloud-apps.js";
 
 /**
  * Draft sentinel URL the server recognizes as "not yet deployed" (suppresses the
@@ -245,6 +246,8 @@ export const createAppAction: Action = {
     try {
       const body = buildCreateBody(intent);
       const { app, warnings } = await client.createApp(body);
+      // A new app now exists — drop the provider cache so it shows up this turn.
+      invalidateAppsCache(runtime);
 
       const lines = [`Created "${app.name}" on Eliza Cloud (status: draft).`];
       if (intent.description) lines.push(intent.description);

--- a/plugins/plugin-cloud-apps/src/actions/delete-app.ts
+++ b/plugins/plugin-cloud-apps/src/actions/delete-app.ts
@@ -22,12 +22,14 @@ import type {
   State,
 } from "@elizaos/core";
 import { logger } from "@elizaos/core";
+import { removeAppDeployFact } from "../app-facts.js";
 import {
   extractAppReference,
   getCloudClient,
   resolveApp,
   resolveCloudApiKey,
 } from "../client.js";
+import { invalidateAppsCache } from "../providers/cloud-apps.js";
 import {
   confirmationPrompt,
   confirmationRoomId,
@@ -154,6 +156,40 @@ export const deleteAppAction: Action = {
       };
       try {
         const result = await client.deleteApp(target.id);
+        // Any delete attempt can change the app inventory — force the provider to
+        // re-fetch so it never serves the just-deleted app from its 60s cache.
+        invalidateAppsCache(runtime);
+
+        // The DELETE route runs cleanup with continueOnError and returns HTTP 200
+        // with { success:false, errors } on PARTIAL failure (e.g. container
+        // teardown failed because the node was unreachable). Don't claim
+        // everything is gone in that case — the tenant DB / container may survive.
+        if (result.success === false || (result.errors?.length ?? 0) > 0) {
+          const detail = result.errors?.length
+            ? ` (${result.errors.join("; ")})`
+            : "";
+          const partial =
+            `I hit a problem deleting "${target.name}" — some resources may not ` +
+            `have been fully torn down${detail}. Check your Eliza Cloud dashboard ` +
+            `to confirm what remains.`;
+          await callback?.({ text: partial, actions: ["DELETE_APP"] });
+          return {
+            success: false,
+            text: result.message || `Partial delete for ${target.name}.`,
+            userFacingText: partial,
+            data: {
+              app: { id: target.id, name: target.name, slug: target.slug },
+              deleted: false,
+              partial: true,
+              errors: result.errors ?? [],
+              cleaned: result.cleaned,
+            },
+          };
+        }
+
+        // Clean success: purge the durable "app is live" fact so the agent stops
+        // recalling the deleted app as live at its old URL.
+        await removeAppDeployFact(runtime, message, target.id);
         const reply = `Deleted "${target.name}". Its container and tenant database are gone.`;
         await callback?.({ text: reply, actions: ["DELETE_APP"] });
         return {

--- a/plugins/plugin-cloud-apps/src/actions/deploy-app.ts
+++ b/plugins/plugin-cloud-apps/src/actions/deploy-app.ts
@@ -27,6 +27,7 @@ import type {
 } from "@elizaos/core";
 import { logger } from "@elizaos/core";
 import { recordAppDeployFact } from "../app-facts.js";
+import { invalidateAppsCache } from "../providers/cloud-apps.js";
 import {
   extractAppReference,
   getCloudClient,
@@ -65,6 +66,9 @@ async function reportLive(
   const reply = `"${app.name}" is live at ${url} 🎉`;
   // Best-effort, idempotent facts cache — never fails the deploy.
   const fact = await recordAppDeployFact(runtime, message, app, url);
+  // The app's deployment status just changed — refresh the provider cache so it
+  // reflects the new live URL/status within the same conversation.
+  invalidateAppsCache(runtime);
   await callback?.({ text: reply, actions: ["DEPLOY_APP"] });
   return {
     success: true,

--- a/plugins/plugin-cloud-apps/src/app-facts.ts
+++ b/plugins/plugin-cloud-apps/src/app-facts.ts
@@ -138,3 +138,31 @@ export async function recordAppDeployFact(
     return { written: false, updated: false };
   }
 }
+
+/**
+ * Purge the durable "app is live" deploy fact for `appId` (if one exists) after
+ * the app is deleted — otherwise the agent keeps recalling a deleted app as
+ * live at its old URL forever (the fact is `kind:"durable"`, so it never
+ * decays). Best-effort: returns `false` when there's nothing to remove or the
+ * runtime has no delete API; a failure never blocks the delete.
+ */
+export async function removeAppDeployFact(
+  runtime: IAgentRuntime,
+  message: Memory,
+  appId: string,
+): Promise<boolean> {
+  if (typeof runtime.deleteMemory !== "function") return false;
+  try {
+    const existing = await findExistingDeployFact(runtime, message, appId);
+    if (!existing?.id) return false;
+    await runtime.deleteMemory(existing.id);
+    return true;
+  } catch (err) {
+    logger.warn(
+      `[CloudApps] Failed to remove deploy fact for ${appId}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return false;
+  }
+}

--- a/plugins/plugin-cloud-apps/src/providers/cloud-apps.ts
+++ b/plugins/plugin-cloud-apps/src/providers/cloud-apps.ts
@@ -26,6 +26,16 @@ const TTL = 60_000;
 const MAX_APPS_RENDERED = 10;
 const appsCaches = new WeakMap<IAgentRuntime, { apps: AppDto[]; at: number }>();
 
+/**
+ * Drop the cached app list for a runtime so the next provider read re-fetches
+ * live. Call after a mutating action (create/delete/deploy) so the CLOUD_APPS
+ * provider never keeps serving a just-deleted app (or hiding a just-created one)
+ * inside the 60s TTL window of the same conversation.
+ */
+export function invalidateAppsCache(runtime: IAgentRuntime): void {
+  appsCaches.delete(runtime);
+}
+
 const EMPTY: ProviderResult = { text: "" };
 
 function render(apps: AppDto[]): ProviderResult {


### PR DESCRIPTION
Fixes #10876.

`DELETE_APP` didn't reconcile downstream state after `client.deleteApp()`. Three related defects, all fixed here:

### 1. False success on partial-cleanup failure
The DELETE route runs `deleteAppWithCleanup(id, { continueOnError: true })` and returns **HTTP 200 with `{ success:false, errors:[…] }`** on partial failure (e.g. container teardown fails because the node is unreachable). The SDK only throws on non-2xx, so the plugin never saw it and always replied *"container and tenant database are gone"* + `success:true` — while the tenant DB (with user data) could still be alive and/or a container still running + billing.
**Fix:** branch on `result.success === false || result.errors?.length` → report a partial outcome that names what failed and tells the user to check the dashboard, `success:false`. Only claim "gone" on a clean success. (Now consistent with `WITHDRAW_APP_EARNINGS`/`REGENERATE_APP_API_KEY`, which already check `result.success`.)

### 2. Stale "app is live" durable fact
Deploy writes a `kind:"durable"` (non-decaying) facts-memory row (*"…deployed X — live at https://…"*). Delete never purged it, so the agent kept recalling a **deleted app as live**.
**Fix:** new `removeAppDeployFact(runtime, message, appId)` (reuses `findExistingDeployFact` + `runtime.deleteMemory`), called after a clean delete.

### 3. Stale provider cache
The `CLOUD_APPS` provider caches `listApps()` for 60s and no mutation busted it, so a just-deleted app stayed in the agent's context (and a just-created one was hidden) for the rest of the conversation.
**Fix:** new exported `invalidateAppsCache(runtime)`, called from `CREATE_APP`, `DEPLOY_APP`, and `DELETE_APP` after a successful mutation.

### Evidence
- `bun test plugins/plugin-cloud-apps/__tests__/` → all green (adds `app-facts.test.ts` + a `delete-app` partial-failure case).
  - New: `DELETE_APP` partial-cleanup (`{success:false, errors:['tenant_db …']}`) → reply does **not** say "are gone", `success:false`, `data.partial === true`, errors surfaced.
  - New: `recordAppDeployFact` → `removeAppDeployFact` purges the durable fact; returns `false` when none exists; idempotent re-deploy keeps one fact and stays removable.
- `bun run --cwd plugins/plugin-cloud-apps typecheck` → clean.
- N/A — real-LLM trajectory: no LLM provider key in this environment; the reconciliation logic is deterministic and covered by the unit reproductions. N/A — screenshots: agent action text only, no UI surface.

Found via an adversarial multi-agent audit of the apps-launch surface (both skeptics agreed on the false-success defect; the stale-fact and stale-cache issues surfaced on the provider-ux lens).
