### PR TITLE
fix(cloud): scope per-app API keys to their own app across ALL /apps/:id/* routes (#10852)

### DIFF
--- a/packages/cloud/api/v1/apps/[id]/analytics/requests/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/analytics/requests/route.ts
@@ -32,7 +32,7 @@ async function handleGET(
 ): Promise<Response> {
   const { params } = context ?? { params: Promise.resolve({ id: "" }) };
   try {
-    const { user } = await requireAuthOrApiKeyWithOrg(request);
+    const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
     const { id } = await params;
     const { searchParams } = new URL(request.url);
 
@@ -48,6 +48,14 @@ async function handleGET(
     if (existingApp.organization_id !== user.organization_id) {
       return Response.json(
         { success: false, error: "Access denied" },
+        { status: 403 },
+      );
+    }
+
+    // A per-app API key may only act on its own app, never a sibling (#10852).
+    if (await appsService.isApiKeyScopedToOtherApp(apiKey?.id, id)) {
+      return Response.json(
+        { success: false, error: "This API key is scoped to a different app" },
         { status: 403 },
       );
     }

--- a/packages/cloud/api/v1/apps/[id]/analytics/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/analytics/route.ts
@@ -41,6 +41,14 @@ app.get("/", async (c) => {
       return c.json({ success: false, error: "Access denied" }, 403);
     }
 
+    // A per-app API key may only act on its own app, never a sibling (#10852).
+    if (await appsService.isApiKeyScopedToOtherApp(c.get("apiKeyId"), id)) {
+      return c.json(
+        { success: false, error: "This API key is scoped to a different app" },
+        403,
+      );
+    }
+
     const analytics = await appsService.getAnalytics(
       id,
       periodType,

--- a/packages/cloud/api/v1/apps/[id]/charges/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/charges/route.ts
@@ -15,6 +15,7 @@ import {
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { appChargeRequestsService } from "@/lib/services/app-charge-requests";
+import { appsService } from "@/lib/services/apps";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -49,6 +50,13 @@ app.post("/", async (c) => {
     const user = await requireUserOrApiKeyWithOrg(c);
     const appId = c.req.param("id");
     if (!appId) return c.json({ success: false, error: "Missing app id" }, 400);
+    // A per-app API key may only charge for its own app, never a sibling (#10852).
+    if (await appsService.isApiKeyScopedToOtherApp(c.get("apiKeyId"), appId)) {
+      return c.json(
+        { success: false, error: "This API key is scoped to a different app" },
+        403,
+      );
+    }
 
     const body = await c.req.json().catch(() => null);
     const parsed = CreateChargeSchema.safeParse(body);
@@ -93,6 +101,13 @@ app.get("/", async (c) => {
     const user = await requireUserOrApiKeyWithOrg(c);
     const appId = c.req.param("id");
     if (!appId) return c.json({ success: false, error: "Missing app id" }, 400);
+    // A per-app API key may only read its own app's charges, never a sibling (#10852).
+    if (await appsService.isApiKeyScopedToOtherApp(c.get("apiKeyId"), appId)) {
+      return c.json(
+        { success: false, error: "This API key is scoped to a different app" },
+        403,
+      );
+    }
 
     const limitParam = c.req.query("limit");
     const limit = limitParam ? Number.parseInt(limitParam, 10) : 50;

--- a/packages/cloud/api/v1/apps/[id]/chat/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/chat/route.ts
@@ -197,7 +197,7 @@ async function handlePOST(
       );
     }
 
-    const { user } = authResult;
+    const { user, apiKey } = authResult;
 
     // Access control: non-monetized apps are internal (same org only)
     // Monetized apps are public (anyone with credits can use)
@@ -210,6 +210,22 @@ async function handlePOST(
           {
             error: {
               message: "Access denied to this app",
+              type: "invalid_request_error",
+              code: "access_denied",
+            },
+          },
+          { status: 403 },
+        ),
+      );
+    }
+
+    // A per-app API key may only act on its own app, never a sibling (#10852).
+    if (await appsService.isApiKeyScopedToOtherApp(apiKey?.id, appId)) {
+      return withCors(
+        Response.json(
+          {
+            error: {
+              message: "This API key is scoped to a different app",
               type: "invalid_request_error",
               code: "access_denied",
             },

--- a/packages/cloud/api/v1/apps/[id]/database/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/database/route.ts
@@ -38,6 +38,13 @@ async function loadOwnedApp(c: AppContext) {
   if (!appRow || appRow.organization_id !== user.organization_id) {
     return { error: "App not found", status: 404 as const };
   }
+  // A per-app API key may only act on its own app, never a sibling (#10852).
+  if (await appsService.isApiKeyScopedToOtherApp(c.get("apiKeyId"), appId)) {
+    return {
+      error: "This API key is scoped to a different app",
+      status: 403 as const,
+    };
+  }
   return { appRow, appId };
 }
 

--- a/packages/cloud/api/v1/apps/[id]/deploy/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/deploy/route.ts
@@ -55,6 +55,13 @@ app.post("/", async (c) => {
       // 403 — the caller is authed but not the owning org.
       return c.json({ success: false, error: "Access denied" }, 403);
     }
+    // A per-app API key may only act on its own app, never a sibling (#10852).
+    if (await appsService.isApiKeyScopedToOtherApp(c.get("apiKeyId"), appId)) {
+      return c.json(
+        { success: false, error: "This API key is scoped to a different app" },
+        403,
+      );
+    }
 
     const deployGate = appsDeployOrganizationDecision(
       c.env,

--- a/packages/cloud/api/v1/apps/[id]/deploy/status/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/deploy/status/route.ts
@@ -31,6 +31,14 @@ app.get("/", async (c) => {
       return c.json({ success: false, error: "Access denied" }, 403);
     }
 
+    // A per-app API key may only act on its own app, never a sibling (#10852).
+    if (await appsService.isApiKeyScopedToOtherApp(c.get("apiKeyId"), appId)) {
+      return c.json(
+        { success: false, error: "This API key is scoped to a different app" },
+        403,
+      );
+    }
+
     const record = await appDeploymentsService.getLatestDeployment(appId);
     if (!record) {
       return c.json({

--- a/packages/cloud/api/v1/apps/[id]/discord-automation/post/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/discord-automation/post/route.ts
@@ -11,6 +11,7 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 
 import { z } from "zod";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
+import { appsService } from "@/lib/services/apps";
 import { discordAppAutomationService } from "@/lib/services/discord-automation/app-automation";
 import { logger } from "@/lib/utils/logger";
 
@@ -22,8 +23,16 @@ async function __hono_POST(
   request: Request,
   { params }: RouteContext<{ id: string }>,
 ): Promise<Response> {
-  const { user } = await requireAuthOrApiKeyWithOrg(request);
+  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
   const { id: appId } = await params;
+
+  // A per-app API key may only act on its own app, never a sibling (#10852).
+  if (await appsService.isApiKeyScopedToOtherApp(apiKey?.id, appId)) {
+    return Response.json(
+      { success: false, error: "This API key is scoped to a different app" },
+      { status: 403 },
+    );
+  }
 
   let body: z.infer<typeof postSchema>;
   try {

--- a/packages/cloud/api/v1/apps/[id]/discord-automation/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/discord-automation/route.ts
@@ -13,6 +13,7 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 
 import { z } from "zod";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
+import { appsService } from "@/lib/services/apps";
 import { discordAppAutomationService } from "@/lib/services/discord-automation/app-automation";
 import { logger } from "@/lib/utils/logger";
 
@@ -31,8 +32,16 @@ async function __hono_GET(
   request: Request,
   { params }: RouteContext<{ id: string }>,
 ): Promise<Response> {
-  const { user } = await requireAuthOrApiKeyWithOrg(request);
+  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
   const { id: appId } = await params;
+
+  // A per-app API key may only act on its own app, never a sibling (#10852).
+  if (await appsService.isApiKeyScopedToOtherApp(apiKey?.id, appId)) {
+    return Response.json(
+      { success: false, error: "This API key is scoped to a different app" },
+      { status: 403 },
+    );
+  }
 
   try {
     const status = await discordAppAutomationService.getAutomationStatus(
@@ -59,8 +68,16 @@ async function __hono_POST(
   request: Request,
   { params }: RouteContext<{ id: string }>,
 ): Promise<Response> {
-  const { user } = await requireAuthOrApiKeyWithOrg(request);
+  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
   const { id: appId } = await params;
+
+  // A per-app API key may only act on its own app, never a sibling (#10852).
+  if (await appsService.isApiKeyScopedToOtherApp(apiKey?.id, appId)) {
+    return Response.json(
+      { success: false, error: "This API key is scoped to a different app" },
+      { status: 403 },
+    );
+  }
 
   let body: z.infer<typeof automationConfigSchema>;
   try {
@@ -150,8 +167,16 @@ async function __hono_DELETE(
   request: Request,
   { params }: RouteContext<{ id: string }>,
 ): Promise<Response> {
-  const { user } = await requireAuthOrApiKeyWithOrg(request);
+  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
   const { id: appId } = await params;
+
+  // A per-app API key may only act on its own app, never a sibling (#10852).
+  if (await appsService.isApiKeyScopedToOtherApp(apiKey?.id, appId)) {
+    return Response.json(
+      { success: false, error: "This API key is scoped to a different app" },
+      { status: 403 },
+    );
+  }
 
   try {
     await discordAppAutomationService.disableAutomation(

--- a/packages/cloud/api/v1/apps/[id]/domains/[domain]/dns/[recordId]/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/[domain]/dns/[recordId]/route.ts
@@ -46,6 +46,13 @@ async function loadCloudflareManagedDomain(c: AppContext) {
   if (!appRow || appRow.organization_id !== user.organization_id) {
     return { error: "App not found", status: 404 as const };
   }
+  // A per-app API key may only act on its own app, never a sibling (#10852).
+  if (await appsService.isApiKeyScopedToOtherApp(c.get("apiKeyId"), appId)) {
+    return {
+      error: "This API key is scoped to a different app",
+      status: 403 as const,
+    };
+  }
 
   const md = await managedDomainsService.getDomainByName(
     decodeURIComponent(domainParam),

--- a/packages/cloud/api/v1/apps/[id]/domains/[domain]/dns/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/[domain]/dns/route.ts
@@ -42,6 +42,13 @@ async function loadCloudflareManagedDomain(c: AppContext) {
   if (!appRow || appRow.organization_id !== user.organization_id) {
     return { error: "App not found", status: 404 as const };
   }
+  // A per-app API key may only act on its own app, never a sibling (#10852).
+  if (await appsService.isApiKeyScopedToOtherApp(c.get("apiKeyId"), appId)) {
+    return {
+      error: "This API key is scoped to a different app",
+      status: 403 as const,
+    };
+  }
 
   const md = await managedDomainsService.getDomainByName(
     decodeURIComponent(domainParam),

--- a/packages/cloud/api/v1/apps/[id]/domains/buy/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/buy/route.ts
@@ -78,6 +78,14 @@ app.post("/", async (c) => {
       return c.json({ success: false, error: "Access denied" }, 403);
     }
 
+    // A per-app API key may only act on its own app, never a sibling (#10852).
+    if (await appsService.isApiKeyScopedToOtherApp(c.get("apiKeyId"), appId)) {
+      return c.json(
+        { success: false, error: "This API key is scoped to a different app" },
+        403,
+      );
+    }
+
     // Claim the idempotency key BEFORE any debit/register. The unique insert is
     // the single point of serialization: only the winner runs the purchase; a
     // concurrent/retried buy of the same domain short-circuits below.

--- a/packages/cloud/api/v1/apps/[id]/domains/check/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/check/route.ts
@@ -28,6 +28,14 @@ app.post("/", async (c) => {
       return c.json({ success: false, error: "App not found" }, 404);
     }
 
+    // A per-app API key may only act on its own app, never a sibling (#10852).
+    if (await appsService.isApiKeyScopedToOtherApp(c.get("apiKeyId"), appId)) {
+      return c.json(
+        { success: false, error: "This API key is scoped to a different app" },
+        403,
+      );
+    }
+
     const parsed = CheckSchema.safeParse(await c.req.json());
     if (!parsed.success) {
       return c.json(

--- a/packages/cloud/api/v1/apps/[id]/domains/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/route.ts
@@ -30,6 +30,13 @@ async function loadOwnedApp(c: AppContext) {
   if (!appRow || appRow.organization_id !== user.organization_id) {
     return { error: "App not found", status: 404 as const };
   }
+  // A per-app API key may only act on its own app, never a sibling (#10852).
+  if (await appsService.isApiKeyScopedToOtherApp(c.get("apiKeyId"), appId)) {
+    return {
+      error: "This API key is scoped to a different app",
+      status: 403 as const,
+    };
+  }
   return { user, app: appRow, appId };
 }
 

--- a/packages/cloud/api/v1/apps/[id]/domains/status/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/status/route.ts
@@ -27,6 +27,14 @@ app.post("/", async (c) => {
       return c.json({ success: false, error: "App not found" }, 404);
     }
 
+    // A per-app API key may only act on its own app, never a sibling (#10852).
+    if (await appsService.isApiKeyScopedToOtherApp(c.get("apiKeyId"), appId)) {
+      return c.json(
+        { success: false, error: "This API key is scoped to a different app" },
+        403,
+      );
+    }
+
     const parsed = StatusSchema.safeParse(await c.req.json());
     if (!parsed.success) {
       return c.json(

--- a/packages/cloud/api/v1/apps/[id]/domains/sync/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/sync/route.ts
@@ -29,6 +29,14 @@ app.post("/", async (c) => {
       return c.json({ success: false, error: "App not found" }, 404);
     }
 
+    // A per-app API key may only act on its own app, never a sibling (#10852).
+    if (await appsService.isApiKeyScopedToOtherApp(c.get("apiKeyId"), appId)) {
+      return c.json(
+        { success: false, error: "This API key is scoped to a different app" },
+        403,
+      );
+    }
+
     const domains = await managedDomainsService.listForApp(
       user.organization_id,
       appId,

--- a/packages/cloud/api/v1/apps/[id]/domains/verify/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/verify/route.ts
@@ -33,6 +33,14 @@ app.post("/", async (c) => {
       return c.json({ success: false, error: "App not found" }, 404);
     }
 
+    // A per-app API key may only act on its own app, never a sibling (#10852).
+    if (await appsService.isApiKeyScopedToOtherApp(c.get("apiKeyId"), appId)) {
+      return c.json(
+        { success: false, error: "This API key is scoped to a different app" },
+        403,
+      );
+    }
+
     const parsed = VerifySchema.safeParse(await c.req.json());
     if (!parsed.success) {
       return c.json(

--- a/packages/cloud/api/v1/apps/[id]/earnings/history/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/earnings/history/route.ts
@@ -34,7 +34,7 @@ async function __hono_GET(
   { params }: { params: Promise<{ id: string }> },
 ) {
   try {
-    const { user } = await requireAuthOrApiKeyWithOrg(request);
+    const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
     const { id } = await params;
 
     // Parse query params (filter out nulls to use defaults)
@@ -81,6 +81,14 @@ async function __hono_GET(
           success: false,
           error: "Access denied",
         },
+        { status: 403 },
+      );
+    }
+
+    // A per-app API key may only act on its own app, never a sibling (#10852).
+    if (await appsService.isApiKeyScopedToOtherApp(apiKey?.id, id)) {
+      return Response.json(
+        { success: false, error: "This API key is scoped to a different app" },
         { status: 403 },
       );
     }

--- a/packages/cloud/api/v1/apps/[id]/earnings/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/earnings/route.ts
@@ -22,7 +22,7 @@ async function __hono_GET(
   { params }: { params: Promise<{ id: string }> },
 ) {
   try {
-    const { user } = await requireAuthOrApiKeyWithOrg(request);
+    const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
     const { id } = await params;
 
     const daysParam = new URL(request.url).searchParams.get("days");
@@ -42,6 +42,14 @@ async function __hono_GET(
     if (app.organization_id !== user.organization_id) {
       return Response.json(
         { success: false, error: "Access denied" },
+        { status: 403 },
+      );
+    }
+
+    // A per-app API key may only act on its own app, never a sibling (#10852).
+    if (await appsService.isApiKeyScopedToOtherApp(apiKey?.id, id)) {
+      return Response.json(
+        { success: false, error: "This API key is scoped to a different app" },
         { status: 403 },
       );
     }

--- a/packages/cloud/api/v1/apps/[id]/earnings/withdraw/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/earnings/withdraw/route.ts
@@ -65,7 +65,7 @@ async function handlePOST(
       );
     }
 
-    const { user } = await requireAuthOrApiKeyWithOrg(request);
+    const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
     const { id } = await context.params;
 
     const app = await appsService.getById(id);
@@ -80,6 +80,14 @@ async function handlePOST(
     if (app.organization_id !== user.organization_id) {
       return Response.json(
         { success: false, error: "Access denied" },
+        { status: 403 },
+      );
+    }
+
+    // A per-app API key may only act on its own app, never a sibling (#10852).
+    if (await appsService.isApiKeyScopedToOtherApp(apiKey?.id, id)) {
+      return Response.json(
+        { success: false, error: "This API key is scoped to a different app" },
         { status: 403 },
       );
     }

--- a/packages/cloud/api/v1/apps/[id]/generate-image/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/generate-image/route.ts
@@ -256,6 +256,15 @@ app.post("/", async (c) => {
     ) {
       return jsonError(c, 403, "Access denied to this app", "access_denied");
     }
+    // A per-app API key may only act on its own app, never a sibling (#10852).
+    if (await appsService.isApiKeyScopedToOtherApp(c.get("apiKeyId"), appId)) {
+      return jsonError(
+        c,
+        403,
+        "This API key is scoped to a different app",
+        "access_denied",
+      );
+    }
 
     if (!c.env.BLOB)
       return jsonError(

--- a/packages/cloud/api/v1/apps/[id]/monetization/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/monetization/route.ts
@@ -26,7 +26,7 @@ async function __hono_GET(
   { params }: { params: Promise<{ id: string }> },
 ) {
   try {
-    const { user } = await requireAuthOrApiKeyWithOrg(request);
+    const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
     const { id } = await params;
 
     const app = await appsService.getById(id);
@@ -41,6 +41,14 @@ async function __hono_GET(
     if (app.organization_id !== user.organization_id) {
       return Response.json(
         { success: false, error: "Access denied" },
+        { status: 403 },
+      );
+    }
+
+    // A per-app API key may only act on its own app, never a sibling (#10852).
+    if (await appsService.isApiKeyScopedToOtherApp(apiKey?.id, id)) {
+      return Response.json(
+        { success: false, error: "This API key is scoped to a different app" },
         { status: 403 },
       );
     }
@@ -82,7 +90,7 @@ async function __hono_PUT(
   { params }: { params: Promise<{ id: string }> },
 ) {
   try {
-    const { user } = await requireAuthOrApiKeyWithOrg(request);
+    const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
     const { id } = await params;
 
     const app = await appsService.getById(id);
@@ -97,6 +105,14 @@ async function __hono_PUT(
     if (app.organization_id !== user.organization_id) {
       return Response.json(
         { success: false, error: "Access denied" },
+        { status: 403 },
+      );
+    }
+
+    // A per-app API key may only act on its own app, never a sibling (#10852).
+    if (await appsService.isApiKeyScopedToOtherApp(apiKey?.id, id)) {
+      return Response.json(
+        { success: false, error: "This API key is scoped to a different app" },
         { status: 403 },
       );
     }

--- a/packages/cloud/api/v1/apps/[id]/promote/analytics/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/promote/analytics/route.ts
@@ -12,12 +12,20 @@ async function __hono_GET(
   { params }: RouteContext<{ id: string }>,
 ) {
   try {
-    const { user } = await requireAuthOrApiKeyWithOrg(request);
+    const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
     const { id } = await params;
 
     const app = await appsService.getById(id);
     if (!app || app.organization_id !== user.organization_id) {
       return Response.json({ error: "App not found" }, { status: 404 });
+    }
+
+    // A per-app API key may only act on its own app, never a sibling (#10852).
+    if (await appsService.isApiKeyScopedToOtherApp(apiKey?.id, id)) {
+      return Response.json(
+        { success: false, error: "This API key is scoped to a different app" },
+        { status: 403 },
+      );
     }
 
     const url = new URL(request.url);

--- a/packages/cloud/api/v1/apps/[id]/promote/assets/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/promote/assets/route.ts
@@ -31,12 +31,20 @@ async function __hono_POST(
   request: Request,
   { params }: RouteContext<{ id: string }>,
 ) {
-  const { user } = await requireAuthOrApiKeyWithOrg(request);
+  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
   const { id } = await params;
 
   const app = await appsService.getById(id);
   if (!app || app.organization_id !== user.organization_id) {
     return Response.json({ error: "App not found" }, { status: 404 });
+  }
+
+  // A per-app API key may only act on its own app, never a sibling (#10852).
+  if (await appsService.isApiKeyScopedToOtherApp(apiKey?.id, id)) {
+    return Response.json(
+      { success: false, error: "This API key is scoped to a different app" },
+      { status: 403 },
+    );
   }
 
   const body = await request.json();
@@ -153,12 +161,20 @@ async function __hono_GET(
   request: Request,
   { params }: RouteContext<{ id: string }>,
 ) {
-  const { user } = await requireAuthOrApiKeyWithOrg(request);
+  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
   const { id } = await params;
 
   const app = await appsService.getById(id);
   if (!app || app.organization_id !== user.organization_id) {
     return Response.json({ error: "App not found" }, { status: 404 });
+  }
+
+  // A per-app API key may only act on its own app, never a sibling (#10852).
+  if (await appsService.isApiKeyScopedToOtherApp(apiKey?.id, id)) {
+    return Response.json(
+      { success: false, error: "This API key is scoped to a different app" },
+      { status: 403 },
+    );
   }
 
   const url = new URL(request.url);

--- a/packages/cloud/api/v1/apps/[id]/promote/preview/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/promote/preview/route.ts
@@ -40,7 +40,7 @@ async function __hono_POST(
   request: Request,
   { params }: RouteContext<{ id: string }>,
 ): Promise<Response> {
-  const { user } = await requireAuthOrApiKeyWithOrg(request);
+  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
   const { id } = await params;
 
   const body = await request.json();
@@ -58,6 +58,14 @@ async function __hono_POST(
   const app = await appsService.getById(id);
   if (!app || app.organization_id !== user.organization_id) {
     return Response.json({ error: "App not found" }, { status: 404 });
+  }
+
+  // A per-app API key may only act on its own app, never a sibling (#10852).
+  if (await appsService.isApiKeyScopedToOtherApp(apiKey?.id, id)) {
+    return Response.json(
+      { success: false, error: "This API key is scoped to a different app" },
+      { status: 403 },
+    );
   }
 
   // Create a preview app object with the selected character for generation

--- a/packages/cloud/api/v1/apps/[id]/promote/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/promote/route.ts
@@ -6,6 +6,7 @@ import {
   appPromotionService,
   type PromotionConfig,
 } from "@/lib/services/app-promotion";
+import { appsService } from "@/lib/services/apps";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -113,8 +114,16 @@ async function __hono_GET(
   request: Request,
   { params }: RouteContext<{ id: string }>,
 ) {
-  const { user } = await requireAuthOrApiKeyWithOrg(request);
+  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
   const { id } = await params;
+
+  // A per-app API key may only act on its own app, never a sibling (#10852).
+  if (await appsService.isApiKeyScopedToOtherApp(apiKey?.id, id)) {
+    return Response.json(
+      { success: false, error: "This API key is scoped to a different app" },
+      { status: 403 },
+    );
+  }
 
   const url = new URL(request.url);
   const isHistory = url.searchParams.get("history") === "true";
@@ -139,8 +148,16 @@ async function __hono_POST(
   request: Request,
   { params }: RouteContext<{ id: string }>,
 ) {
-  const { user } = await requireAuthOrApiKeyWithOrg(request);
+  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
   const { id } = await params;
+
+  // A per-app API key may only act on its own app, never a sibling (#10852).
+  if (await appsService.isApiKeyScopedToOtherApp(apiKey?.id, id)) {
+    return Response.json(
+      { success: false, error: "This API key is scoped to a different app" },
+      { status: 403 },
+    );
+  }
 
   const body = await request.json();
   const parsed = PromotionConfigSchema.safeParse(body);

--- a/packages/cloud/api/v1/apps/[id]/regenerate-api-key/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/regenerate-api-key/route.ts
@@ -19,7 +19,7 @@ async function handlePOST(
     );
   }
   try {
-    const { user } = await requireAuthOrApiKeyWithOrg(request);
+    const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
     const { id } = await context.params;
 
     const existingApp = await appsService.getById(id);
@@ -40,6 +40,15 @@ async function handlePOST(
           success: false,
           error: "Access denied",
         },
+        { status: 403 },
+      );
+    }
+
+    // A per-app API key may only act on its own app, never a sibling — and must
+    // never rotate another app's key (#10852).
+    if (await appsService.isApiKeyScopedToOtherApp(apiKey?.id, id)) {
+      return Response.json(
+        { success: false, error: "This API key is scoped to a different app" },
         { status: 403 },
       );
     }

--- a/packages/cloud/api/v1/apps/[id]/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/route.ts
@@ -49,6 +49,13 @@ app.get("/", async (c) => {
     if (found.organization_id !== user.organization_id) {
       return c.json({ success: false, error: "Access denied" }, 403);
     }
+    // A per-app API key may only act on its own app, never a sibling (#10852).
+    if (await appsService.isApiKeyScopedToOtherApp(c.get("apiKeyId"), id)) {
+      return c.json(
+        { success: false, error: "This API key is scoped to a different app" },
+        403,
+      );
+    }
     return c.json({
       success: true,
       app: await appsService.withDatabaseState(found),
@@ -68,6 +75,13 @@ async function updateApp(c: AppContext, verb: "PUT" | "PATCH") {
   if (!existing) return c.json({ success: false, error: "App not found" }, 404);
   if (existing.organization_id !== user.organization_id) {
     return c.json({ success: false, error: "Access denied" }, 403);
+  }
+  // A per-app API key may only act on its own app, never a sibling (#10852).
+  if (await appsService.isApiKeyScopedToOtherApp(c.get("apiKeyId"), id)) {
+    return c.json(
+      { success: false, error: "This API key is scoped to a different app" },
+      403,
+    );
   }
 
   const rawBody = await c.req.json();
@@ -159,6 +173,13 @@ app.delete("/", async (c) => {
       return c.json({ success: false, error: "App not found" }, 404);
     if (existing.organization_id !== user.organization_id) {
       return c.json({ success: false, error: "Access denied" }, 403);
+    }
+    // A per-app API key may only act on its own app, never a sibling (#10852).
+    if (await appsService.isApiKeyScopedToOtherApp(c.get("apiKeyId"), id)) {
+      return c.json(
+        { success: false, error: "This API key is scoped to a different app" },
+        403,
+      );
     }
 
     const deleteGitHubRepo = c.req.query("deleteGitHubRepo") !== "false";

--- a/packages/cloud/api/v1/apps/[id]/telegram-automation/post/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/telegram-automation/post/route.ts
@@ -11,6 +11,7 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 
 import { z } from "zod";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
+import { appsService } from "@/lib/services/apps";
 import { telegramAppAutomationService } from "@/lib/services/telegram-automation/app-automation";
 import { logger } from "@/lib/utils/logger";
 
@@ -24,8 +25,16 @@ async function __hono_POST(
   request: Request,
   { params }: RouteContext<{ id: string }>,
 ): Promise<Response> {
-  const { user } = await requireAuthOrApiKeyWithOrg(request);
+  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
   const { id: appId } = await params;
+
+  // A per-app API key may only act on its own app, never a sibling (#10852).
+  if (await appsService.isApiKeyScopedToOtherApp(apiKey?.id, appId)) {
+    return Response.json(
+      { success: false, error: "This API key is scoped to a different app" },
+      { status: 403 },
+    );
+  }
 
   let body: z.infer<typeof postSchema>;
   try {

--- a/packages/cloud/api/v1/apps/[id]/telegram-automation/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/telegram-automation/route.ts
@@ -13,6 +13,7 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 
 import { z } from "zod";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
+import { appsService } from "@/lib/services/apps";
 import { telegramAppAutomationService } from "@/lib/services/telegram-automation/app-automation";
 import { logger } from "@/lib/utils/logger";
 
@@ -33,8 +34,16 @@ async function __hono_GET(
   request: Request,
   { params }: RouteContext<{ id: string }>,
 ): Promise<Response> {
-  const { user } = await requireAuthOrApiKeyWithOrg(request);
+  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
   const { id: appId } = await params;
+
+  // A per-app API key may only act on its own app, never a sibling (#10852).
+  if (await appsService.isApiKeyScopedToOtherApp(apiKey?.id, appId)) {
+    return Response.json(
+      { success: false, error: "This API key is scoped to a different app" },
+      { status: 403 },
+    );
+  }
 
   try {
     const status = await telegramAppAutomationService.getAutomationStatus(
@@ -61,8 +70,16 @@ async function __hono_POST(
   request: Request,
   { params }: RouteContext<{ id: string }>,
 ): Promise<Response> {
-  const { user } = await requireAuthOrApiKeyWithOrg(request);
+  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
   const { id: appId } = await params;
+
+  // A per-app API key may only act on its own app, never a sibling (#10852).
+  if (await appsService.isApiKeyScopedToOtherApp(apiKey?.id, appId)) {
+    return Response.json(
+      { success: false, error: "This API key is scoped to a different app" },
+      { status: 403 },
+    );
+  }
 
   let body: z.infer<typeof automationConfigSchema>;
   try {
@@ -150,8 +167,16 @@ async function __hono_DELETE(
   request: Request,
   { params }: RouteContext<{ id: string }>,
 ): Promise<Response> {
-  const { user } = await requireAuthOrApiKeyWithOrg(request);
+  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
   const { id: appId } = await params;
+
+  // A per-app API key may only act on its own app, never a sibling (#10852).
+  if (await appsService.isApiKeyScopedToOtherApp(apiKey?.id, appId)) {
+    return Response.json(
+      { success: false, error: "This API key is scoped to a different app" },
+      { status: 403 },
+    );
+  }
 
   try {
     await telegramAppAutomationService.disableAutomation(

--- a/packages/cloud/api/v1/apps/[id]/twitter-automation/post/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/twitter-automation/post/route.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { z } from "zod";
 import type { RouteContext } from "@/lib/api/hono-next-style-params";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
+import { appsService } from "@/lib/services/apps";
 import { twitterAppAutomationService } from "@/lib/services/twitter-automation/app-automation";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -17,8 +18,16 @@ async function __hono_POST(
   request: Request,
   { params }: RouteContext<{ id: string }>,
 ): Promise<Response> {
-  const { user } = await requireAuthOrApiKeyWithOrg(request);
+  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
   const { id } = await params;
+
+  // A per-app API key may only act on its own app, never a sibling (#10852).
+  if (await appsService.isApiKeyScopedToOtherApp(apiKey?.id, id)) {
+    return Response.json(
+      { success: false, error: "This API key is scoped to a different app" },
+      { status: 403 },
+    );
+  }
 
   const body = await request.json();
   const parsed = PostTweetSchema.safeParse(body);

--- a/packages/cloud/api/v1/apps/[id]/twitter-automation/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/twitter-automation/route.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { z } from "zod";
 import type { RouteContext } from "@/lib/api/hono-next-style-params";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
+import { appsService } from "@/lib/services/apps";
 import { twitterAppAutomationService } from "@/lib/services/twitter-automation/app-automation";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -22,8 +23,16 @@ async function __hono_GET(
   request: Request,
   { params }: RouteContext<{ id: string }>,
 ): Promise<Response> {
-  const { user } = await requireAuthOrApiKeyWithOrg(request);
+  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
   const { id } = await params;
+
+  // A per-app API key may only act on its own app, never a sibling (#10852).
+  if (await appsService.isApiKeyScopedToOtherApp(apiKey?.id, id)) {
+    return Response.json(
+      { success: false, error: "This API key is scoped to a different app" },
+      { status: 403 },
+    );
+  }
 
   const status = await twitterAppAutomationService.getAutomationStatus(
     user.organization_id,
@@ -37,8 +46,16 @@ async function __hono_POST(
   request: Request,
   { params }: RouteContext<{ id: string }>,
 ): Promise<Response> {
-  const { user } = await requireAuthOrApiKeyWithOrg(request);
+  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
   const { id } = await params;
+
+  // A per-app API key may only act on its own app, never a sibling (#10852).
+  if (await appsService.isApiKeyScopedToOtherApp(apiKey?.id, id)) {
+    return Response.json(
+      { success: false, error: "This API key is scoped to a different app" },
+      { status: 403 },
+    );
+  }
 
   const body = await request.json();
   const parsed = TwitterAutomationConfigSchema.safeParse(body);
@@ -107,8 +124,16 @@ async function __hono_DELETE(
   request: Request,
   { params }: RouteContext<{ id: string }>,
 ): Promise<Response> {
-  const { user } = await requireAuthOrApiKeyWithOrg(request);
+  const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
   const { id } = await params;
+
+  // A per-app API key may only act on its own app, never a sibling (#10852).
+  if (await appsService.isApiKeyScopedToOtherApp(apiKey?.id, id)) {
+    return Response.json(
+      { success: false, error: "This API key is scoped to a different app" },
+      { status: 403 },
+    );
+  }
 
   logger.info("[Twitter Automation API] Disabling automation", {
     appId: id,

--- a/packages/cloud/api/v1/apps/[id]/users/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/users/route.ts
@@ -21,7 +21,7 @@ async function __hono_GET(
   { params }: { params: Promise<{ id: string }> },
 ) {
   try {
-    const { user } = await requireAuthOrApiKeyWithOrg(request);
+    const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
     const { id } = await params;
     const { searchParams } = new URL(request.url);
     const limit = searchParams.get("limit")
@@ -47,6 +47,14 @@ async function __hono_GET(
           success: false,
           error: "Access denied",
         },
+        { status: 403 },
+      );
+    }
+
+    // A per-app API key may only act on its own app, never a sibling (#10852).
+    if (await appsService.isApiKeyScopedToOtherApp(apiKey?.id, id)) {
+      return Response.json(
+        { success: false, error: "This API key is scoped to a different app" },
         { status: 403 },
       );
     }

--- a/packages/cloud/shared/src/lib/services/__tests__/apps-api-key-scope.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/apps-api-key-scope.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Guard test for #10852 — per-app API keys must not act on sibling apps.
+ *
+ * A per-app API key (`apps.api_key_id`) is minted as a plain org credential, so
+ * on its own it authorizes every org-scoped `/apps/:id/*` route. `appsService.
+ * isApiKeyScopedToOtherApp` is the shared guard the app routes now call to
+ * reject a key owned by a DIFFERENT app while leaving org-level keys and session
+ * auth untouched. These tests drive the real guard (only its repo + cache
+ * boundaries are stubbed), covering both the allowed and denied paths.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+const APP_A = "aaaaaaaa-0000-4000-8000-000000000001";
+const APP_B = "bbbbbbbb-0000-4000-8000-000000000002";
+const KEY_A = "key-owned-by-app-a";
+const ORG_KEY = "org-level-key-owned-by-no-app";
+
+// Force a cache miss so getByApiKeyId resolves through the (mocked) repository.
+mock.module("../../cache/client", () => ({
+  cache: {
+    get: mock(async () => null),
+    set: mock(async () => undefined),
+    del: mock(async () => undefined),
+  },
+}));
+
+// Only KEY_A belongs to an app (APP_A). ORG_KEY / anything else belongs to no app.
+mock.module("../../../db/repositories/apps", () => ({
+  appsRepository: {
+    findByApiKeyId: mock(async (apiKeyId: string) =>
+      apiKeyId === KEY_A ? { id: APP_A, api_key_id: KEY_A } : undefined,
+    ),
+  },
+}));
+
+const { appsService } = await import("../apps");
+
+describe("appsService.isApiKeyScopedToOtherApp (#10852)", () => {
+  test("session auth (no apiKeyId) is never treated as cross-app", async () => {
+    expect(await appsService.isApiKeyScopedToOtherApp(undefined, APP_B)).toBe(false);
+    expect(await appsService.isApiKeyScopedToOtherApp(null, APP_B)).toBe(false);
+    expect(await appsService.isApiKeyScopedToOtherApp("", APP_B)).toBe(false);
+  });
+
+  test("an app's key acting on a DIFFERENT app is rejected (the exploit)", async () => {
+    expect(await appsService.isApiKeyScopedToOtherApp(KEY_A, APP_B)).toBe(true);
+  });
+
+  test("an app's key acting on its OWN app is allowed", async () => {
+    expect(await appsService.isApiKeyScopedToOtherApp(KEY_A, APP_A)).toBe(false);
+  });
+
+  test("an org-level key (owned by no app) is allowed on any app", async () => {
+    expect(await appsService.isApiKeyScopedToOtherApp(ORG_KEY, APP_B)).toBe(false);
+    expect(await appsService.isApiKeyScopedToOtherApp(ORG_KEY, APP_A)).toBe(false);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/apps.ts
+++ b/packages/cloud/shared/src/lib/services/apps.ts
@@ -239,6 +239,30 @@ export class AppsService {
   }
 
   /**
+   * App-scope guard for per-app API keys (#10852).
+   *
+   * A per-app API key (`apps.api_key_id`) is minted as an ordinary org
+   * credential, so on its own it authorizes every org-scoped route. This asserts
+   * that a key used against an `/apps/:id/*` route belongs to THAT app: a key
+   * owned by a *different* app in the same org is rejected — closing cross-app
+   * compromise (delete / rotate-key / redeploy / charge a sibling app) via a
+   * leaked or embedded app key.
+   *
+   * Keys owned by no app (org-level keys) and session auth (no `apiKeyId`) pass
+   * through untouched, so org owners keep full app-management access.
+   *
+   * @returns `true` when the key is scoped to a DIFFERENT app and must be denied.
+   */
+  async isApiKeyScopedToOtherApp(
+    apiKeyId: string | null | undefined,
+    appId: string,
+  ): Promise<boolean> {
+    if (!apiKeyId) return false;
+    const owningApp = await this.getByApiKeyId(apiKeyId);
+    return Boolean(owningApp && owningApp.id !== appId);
+  }
+
+  /**
    * Invalidate app cache (call on update/delete).
    *
    * Clears all derived keys: byId, byApiKeyId, costMarkup. The byId payload may


### PR DESCRIPTION
Fixes #10852.

## Bug
Per-app API keys (`apps.api_key_id`) are minted as **plain org credentials** — the `api_keys` row has no app scope. So `requireUserOrApiKeyWithOrg` resolves an app key to a full org `AuthedUser`, indistinguishable from a normal org key, and every `/apps/:id/*` route gated only on `app.organization_id === user.organization_id` accepts it. A leaked or embedded key for **app A** therefore authorizes actions on any **sibling app B in the same org**. Only `/apps/:id/characters` enforced app scope.

**The surface is broader than first reported.** Enumerating every `/apps/:id/*` route showed ~29 API-key-accepting handlers with this hole, including money/data-critical ones verified in code:
- **`earnings/withdraw`** — app A's key can withdraw sibling app B's earnings (money theft).
- **`domains/buy`** — buy domains billed to the org against app B.
- **`database`** — read/write app B's database (data exfiltration).
- plus `deploy`, `regenerate-api-key` (rotate B's key), `PATCH`/`DELETE /apps/:id`, `charges`, `generate-image`, `monetization`, `domains/*` (DNS), `earnings`, `analytics`, `promote/*`, `*-automation/*`, `users`, `chat`, …

## Fix
A shared guard on the existing reverse-link — **no schema migration, no backfill**:

```ts
// appsService
async isApiKeyScopedToOtherApp(apiKeyId, appId) {
  if (!apiKeyId) return false;                 // session / no key → unaffected
  const owningApp = await this.getByApiKeyId(apiKeyId);  // cached
  return Boolean(owningApp && owningApp.id !== appId);    // key owned by a *different* app → deny
}
```

Applied to **every** `/apps/:id/*` handler that authenticates + operates on the app (via `c.get("apiKeyId")` for Hono routes, `apiKey?.id` for the `requireAuthOrApiKeyWithOrg` routes; several files guard once inside a shared `loadOwnedApp` / DNS-domain loader so all their handlers are covered). The guard is a **no-op for session auth and org-level keys** (owned by no app), so org owners keep full management access — it only ever rejects a per-app key acting on a *different* app.

## Why the reverse-link (not a new `app_id` column)
It reuses the same `apps.api_key_id` binding `/apps/:id/characters` already checks, via the cached `getByApiKeyId` (~5ms hit), so there is no migration, no backfill, and no dual-write to keep in sync. A dedicated `api_keys.app_id`/kind column is still worth adding later as defense-in-depth (lets the auth resolver reject app keys on non-app routes too); tracked as follow-up. This PR closes the exploitable cross-app access now.

## Evidence
- **Unit test** `apps-api-key-scope.test.ts` drives the real guard (only its repo + cache boundaries stubbed): no key → allow, cross-app key → **deny**, same-app key → allow, org-level key → allow. **4/4 pass.**
- `tsgo` typecheck: clean across `cloud/shared` + `cloud/api`.
- **N/A** — real-LLM trajectory / screenshots: backend auth change, no model or UI surface.

Security-critical — **not self-merged**; requesting review. Confirmed real by an adversarial audit with a full code trace (#10852).
