### PR TITLE
fix(cloud/security): scope per-app API keys to their own app (#10852)

### DIFF
--- a/packages/cloud/api/v1/apps/[id]/charges/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/charges/route.ts
@@ -9,6 +9,7 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import { appKeyScopeViolation } from "@/lib/auth/app-key-scope";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
   RateLimitPresets,
@@ -49,6 +50,14 @@ app.post("/", async (c) => {
     const user = await requireUserOrApiKeyWithOrg(c);
     const appId = c.req.param("id");
     if (!appId) return c.json({ success: false, error: "Missing app id" }, 400);
+    // #10852: an app's API key must not open charge requests for a SIBLING app.
+    const scopeViolation = await appKeyScopeViolation(
+      c.get("authMethod"),
+      c.get("apiKeyId"),
+      appId,
+    );
+    if (scopeViolation)
+      return c.json({ success: false, error: scopeViolation }, 403);
 
     const body = await c.req.json().catch(() => null);
     const parsed = CreateChargeSchema.safeParse(body);

--- a/packages/cloud/api/v1/apps/[id]/deploy/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/deploy/route.ts
@@ -16,6 +16,7 @@ import { Hono } from "hono";
 import { appsDeployOrganizationDecision } from "@/api-app/lib/apps-deploy-gate";
 import { containersRepository } from "@/db/repositories/containers";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import { appKeyScopeViolation } from "@/lib/auth/app-key-scope";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { appDeploymentsService } from "@/lib/services/app-deployments";
 import { appsService } from "@/lib/services/apps";
@@ -55,6 +56,14 @@ app.post("/", async (c) => {
       // 403 — the caller is authed but not the owning org.
       return c.json({ success: false, error: "Access denied" }, 403);
     }
+    // #10852: an app's API key must not deploy a SIBLING app in the same org.
+    const scopeViolation = await appKeyScopeViolation(
+      c.get("authMethod"),
+      c.get("apiKeyId"),
+      appId,
+    );
+    if (scopeViolation)
+      return c.json({ success: false, error: scopeViolation }, 403);
 
     const deployGate = appsDeployOrganizationDecision(
       c.env,

--- a/packages/cloud/api/v1/apps/[id]/generate-image/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/generate-image/route.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { dbRead, dbWrite } from "@/db/client";
 import { appImageGenerationIdempotency } from "@/db/schemas/app-image-generation-idempotency";
 import { jsonError } from "@/lib/api/cloud-worker-errors";
+import { appKeyScopeViolation } from "@/lib/auth/app-key-scope";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
   RateLimitPresets,
@@ -256,6 +257,14 @@ app.post("/", async (c) => {
     ) {
       return jsonError(c, 403, "Access denied to this app", "access_denied");
     }
+    // #10852: an app's API key must not spend credits via a SIBLING app.
+    const scopeViolation = await appKeyScopeViolation(
+      c.get("authMethod"),
+      c.get("apiKeyId"),
+      appId,
+    );
+    if (scopeViolation)
+      return jsonError(c, 403, scopeViolation, "access_denied");
 
     if (!c.env.BLOB)
       return jsonError(

--- a/packages/cloud/api/v1/apps/[id]/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/route.ts
@@ -10,6 +10,7 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import { appKeyScopeViolation } from "@/lib/auth/app-key-scope";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { appCleanupService } from "@/lib/services/app-cleanup";
 import { appsService } from "@/lib/services/apps";
@@ -69,6 +70,14 @@ async function updateApp(c: AppContext, verb: "PUT" | "PATCH") {
   if (existing.organization_id !== user.organization_id) {
     return c.json({ success: false, error: "Access denied" }, 403);
   }
+  // #10852: an app's API key must not mutate a SIBLING app in the same org.
+  const scopeViolation = await appKeyScopeViolation(
+    c.get("authMethod"),
+    c.get("apiKeyId"),
+    id,
+  );
+  if (scopeViolation)
+    return c.json({ success: false, error: scopeViolation }, 403);
 
   const rawBody = await c.req.json();
   const validationResult = UpdateAppSchema.safeParse(rawBody);
@@ -160,6 +169,14 @@ app.delete("/", async (c) => {
     if (existing.organization_id !== user.organization_id) {
       return c.json({ success: false, error: "Access denied" }, 403);
     }
+    // #10852: an app's API key must not delete a SIBLING app in the same org.
+    const scopeViolation = await appKeyScopeViolation(
+      c.get("authMethod"),
+      c.get("apiKeyId"),
+      id,
+    );
+    if (scopeViolation)
+      return c.json({ success: false, error: scopeViolation }, 403);
 
     const deleteGitHubRepo = c.req.query("deleteGitHubRepo") !== "false";
 

--- a/packages/cloud/shared/src/lib/auth/__tests__/app-key-scope.test.ts
+++ b/packages/cloud/shared/src/lib/auth/__tests__/app-key-scope.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { appKeyScopeViolation } from "../app-key-scope";
+
+const APP_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const APP_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+describe("appKeyScopeViolation (#10852) — per-app API key scoping", () => {
+  test("allows user/session auth (org-scoped, unchanged)", async () => {
+    const lookup = async () => {
+      throw new Error("lookup must not run for user auth");
+    };
+    expect(await appKeyScopeViolation("session", "irrelevant", APP_B, lookup)).toBeNull();
+    expect(await appKeyScopeViolation(undefined, undefined, APP_B, lookup)).toBeNull();
+  });
+
+  test("allows an ORG api key (owns no app → org-scoped)", async () => {
+    const lookup = async () => undefined; // no app owns this key
+    expect(await appKeyScopeViolation("api_key", "org-key-1", APP_B, lookup)).toBeNull();
+  });
+
+  test("allows an app's key on its OWN app route", async () => {
+    const lookup = async () => ({ id: APP_B }); // this key belongs to app B
+    expect(await appKeyScopeViolation("api_key", "b-key", APP_B, lookup)).toBeNull();
+  });
+
+  test("BLOCKS app A's key acting on sibling app B (the vulnerability)", async () => {
+    const lookup = async () => ({ id: APP_A }); // key belongs to app A...
+    const violation = await appKeyScopeViolation("api_key", "a-key", APP_B, lookup); // ...used on app B
+    expect(violation).toBe("This API key is scoped to a different app");
+  });
+
+  test("guards even when apiKeyId is present but authMethod is not api_key", async () => {
+    const lookup = async () => ({ id: APP_A });
+    // Defensive: only enforce for the api_key path; a mislabeled context must not
+    // 403 a legitimate org user.
+    expect(await appKeyScopeViolation("session", "a-key", APP_B, lookup)).toBeNull();
+  });
+});

--- a/packages/cloud/shared/src/lib/auth/app-key-scope.ts
+++ b/packages/cloud/shared/src/lib/auth/app-key-scope.ts
@@ -1,0 +1,37 @@
+import { appsService } from "../services/apps";
+
+/**
+ * App API keys (`apps.api_key_id`) are minted as plain org credentials with no
+ * schema-level scope, so without this guard an app's own key can act on ANY
+ * sibling app in the same org — delete it, redeploy it, rotate its key, or spend
+ * org credits through its charge/image routes. (#10852)
+ *
+ * The correct scope is: an **app key is bound to its own app**; a normal **org
+ * key owns no app and stays org-scoped** (unchanged behavior). We can't tell app
+ * keys from org keys at the schema level (no `app_id`/scope column), so we
+ * reverse-map the presented key through `apps.api_key_id`: if the key belongs to
+ * a DIFFERENT app than the route's, reject.
+ *
+ * Returns the 403 reason string when the credential is a foreign app key, or
+ * `null` when it is allowed for this app (org key, user auth, or the app's own
+ * key).
+ */
+export async function appKeyScopeViolation(
+  authMethod: string | undefined,
+  apiKeyId: string | undefined,
+  appId: string,
+  lookup: (keyId: string) => Promise<{ id: string } | undefined> = (keyId) =>
+    appsService.getByApiKeyId(keyId),
+): Promise<string | null> {
+  // User auth (session/JWT) is org-scoped by the existing org check — leave it.
+  if (authMethod !== "api_key" || !apiKeyId) return null;
+  const owningApp = await lookup(apiKeyId);
+  // owningApp == undefined → an org key (not any app's key) → org-scoped, allow.
+  // owningApp.id === appId  → the app's own key → allow.
+  if (owningApp && owningApp.id !== appId) {
+    return "This API key is scoped to a different app";
+  }
+  return null;
+}
+
+export const APP_KEY_SCOPE_FORBIDDEN = "This API key is scoped to a different app";


### PR DESCRIPTION
## Scope per-app API keys to their own app (#10852)

**The vulnerability (high — intra-org privilege escalation + real credit spend).** App API keys (`apps.api_key_id`) are minted by `apps.ts` as plain org credentials with **no** schema-level scope, and `requireUserOrApiKeyWithOrg` resolves any valid key to a full org `AuthedUser`. Every `/apps/[id]/*` route gated **only** on `app.organization_id === user.organization_id` — so **App A's own key** could act on **any sibling app B in the same org**:

- `DELETE /apps/B` — full cleanup + delete
- `POST /apps/B/deploy` — redeploy
- `POST /apps/B/generate-image` — **spend the org's credits** through B
- `POST /apps/B/charges` — open charge requests for B
- `PATCH/PUT /apps/B` — modify B

One leaked, app-distributed key = compromise of every sibling app in that org. Only `/apps/[id]/characters` app-scoped its key (`app.api_key_id !== apiKey.id`), proving the intent — realized nowhere else.

## Fix — no schema migration

A shared guard `appKeyScopeViolation(authMethod, apiKeyId, appId)` reverse-maps the presented key through the **existing** `appsService.getByApiKeyId`:
- **app key** (owns an app) → allowed only on **its own** app; rejected (403) on a sibling.
- **org key** (owns no app → `getByApiKeyId` returns undefined) → org-scoped, **unchanged**.
- **user/session auth** → untouched (the existing org check governs it).

Applied to the mutating + credit-spend routes: `DELETE`, `PUT`/`PATCH`, `deploy`, `generate-image`, `charges` (`packages/cloud/api/v1/apps/[id]/…`).

## Evidence

`packages/cloud/shared/src/lib/auth/__tests__/app-key-scope.test.ts` — **5 pass**:
- user/session auth allowed (lookup never runs),
- org key allowed,
- app's own key on its own app allowed,
- **App A's key on sibling B → BLOCKED** (`"This API key is scoped to a different app"`) — the vulnerability,
- defensive: a non-`api_key` context is never 403'd.

Biome clean. (Ran in a `develop` worktree with real deps.)

## Follow-ups (called out, not in this PR)

- `regenerate-api-key` uses a different auth entry (raw `Request`, not the Hono `c`); it needs the same guard adapted to that path.
- Long-term, an explicit `api_keys.app_id`/`kind` column would make app keys distinguishable at the schema level (no per-request reverse-lookup) — a maintainer design call; this PR is the migration-free enforcement.

Cross-ORG tenant boundary was already intact; this closes the intra-org sibling-app blast radius. Security-path change — flagging for review.
