### PR TITLE
fix(plugin-cloud-apps): align DEPLOY_APP gate with the server reachability contract (#10926)

### DIFF
--- a/plugins/plugin-cloud-apps/__tests__/deploy-gate.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/deploy-gate.test.ts
@@ -148,7 +148,7 @@ describe("runDeployGate", () => {
     expect(deps.statusCalls).toBe(1);
   });
 
-  it("reports unreachable when READY but /health is not 2xx (does NOT claim live)", async () => {
+  it("reports unreachable when READY but /health returns a Caddy gateway error (503)", async () => {
     const deps = makeDeps({
       statuses: [statusRes({ status: "READY" })],
       productionUrl: "https://acme.elizacloud.ai",
@@ -158,6 +158,39 @@ describe("runDeployGate", () => {
     expect(result.phase).toBe("unreachable");
     expect(result.url).toBe("https://acme.elizacloud.ai");
     expect(result.reachability?.status).toBe(503);
+  });
+
+  it("REGRESSION: an auth-gated app (READY + /health 401) is LIVE, not 'not live'", async () => {
+    // The server marks such an app READY (401 is not a gateway error), so the
+    // gate must agree instead of contradicting GET_APP_DEPLOY_STATUS.
+    const deps = makeDeps({
+      statuses: [statusRes({ status: "READY" })],
+      productionUrl: "https://acme.elizacloud.ai",
+      probe: { ok: false, status: 401 },
+    });
+    const result = await runDeployGate(deps, FAST_CONFIG);
+    expect(result.phase).toBe("ready");
+    expect(result.url).toBe("https://acme.elizacloud.ai");
+  });
+
+  it("REGRESSION: an app with no /health route (READY + 404) is LIVE", async () => {
+    const deps = makeDeps({
+      statuses: [statusRes({ status: "READY" })],
+      productionUrl: "https://acme.elizacloud.ai",
+      probe: { ok: false, status: 404 },
+    });
+    const result = await runDeployGate(deps, FAST_CONFIG);
+    expect(result.phase).toBe("ready");
+  });
+
+  it("reports unreachable when the probe never gets a response (network error, no status)", async () => {
+    const deps = makeDeps({
+      statuses: [statusRes({ status: "READY" })],
+      productionUrl: "https://acme.elizacloud.ai",
+      probe: { ok: false, error: "ECONNREFUSED" },
+    });
+    const result = await runDeployGate(deps, FAST_CONFIG);
+    expect(result.phase).toBe("unreachable");
   });
 
   it("reports unreachable when READY but no production_url exists", async () => {

--- a/plugins/plugin-cloud-apps/src/deploy-gate.ts
+++ b/plugins/plugin-cloud-apps/src/deploy-gate.ts
@@ -7,7 +7,10 @@
  *      server-reported ERROR/FAILED short-circuits immediately.
  *   2. REACHABILITY — once READY, read the authoritative `production_url` from
  *      the app row (deriveAppPublicUrl semantics — NOT the create response) and
- *      probe `<production_url>/health` for a 2xx.
+ *      probe `<production_url>/health`, treating any answer EXCEPT a Caddy
+ *      gateway error (502/503/504) as reachable — the SAME rule the server uses
+ *      to mark the app READY, so the gate never contradicts the server (an
+ *      auth-gated 401/403 app, or one with no `/health` route, is still live).
  * Only when BOTH pass do we report the app live.
  *
  * The gate is pure and fully injectable (status fetch, app fetch, probe, sleep)
@@ -17,7 +20,11 @@
  */
 
 import type { AppDeployStatusResponse, AppResponse } from "@elizaos/cloud-sdk";
-import { healthUrl, type ReachabilityResult } from "./reachability.js";
+import {
+  healthUrl,
+  type ReachabilityResult,
+  respondedLive,
+} from "./reachability.js";
 
 /** Terminal outcome of the gate. */
 export type DeployPhase = "ready" | "error" | "timeout" | "unreachable";
@@ -146,7 +153,7 @@ export async function runDeployGate(
         };
       }
       const reachability = await deps.probe(healthUrl(url, config.healthPath));
-      return reachability.ok
+      return respondedLive(reachability)
         ? {
             phase: "ready",
             url,

--- a/plugins/plugin-cloud-apps/src/reachability.ts
+++ b/plugins/plugin-cloud-apps/src/reachability.ts
@@ -51,9 +51,33 @@ export function healthUrl(base: string, path = "/health"): string {
 }
 
 /**
- * Probe a URL with a bounded HTTP GET. Never throws — a network error, abort, or
- * non-2xx all resolve to `{ ok: false, … }` so the caller can report a clear
- * "deployed but not reachable" failure instead of crashing the action.
+ * Caddy gateway statuses: the ingress is up but the upstream app isn't serving.
+ * Any OTHER completed status (200/3xx/401/403/404/…) means the app answered.
+ */
+const GATEWAY_DOWN_STATUSES = new Set([502, 503, 504]);
+
+/**
+ * Whether a probe result means the app ANSWERED — the SAME rule the server uses
+ * to mark an app READY (`isReachableStatus`: reachable unless the status is a
+ * Caddy gateway error 502/503/504). A 401/403 auth gate or a 404 still proves
+ * the container is up and serving; a network error / abort (no status at all) is
+ * NOT reachable. Using this instead of a strict-2xx check keeps the DEPLOY_APP
+ * completion gate from contradicting the server's own live decision (an
+ * auth-gated app, or one with no `/health` route, is live per the server but was
+ * previously reported "not live").
+ */
+export function respondedLive(result: ReachabilityResult): boolean {
+  return (
+    typeof result.status === "number" &&
+    !GATEWAY_DOWN_STATUSES.has(result.status)
+  );
+}
+
+/**
+ * Probe a URL with a bounded HTTP GET. Never throws — a network error or abort
+ * resolves to `{ ok: false }` with no `status`; any HTTP response resolves with
+ * its `status` (and `ok` reflecting a strict 2xx). Callers that want the
+ * server's "the app answered" rule should use {@link respondedLive}.
  */
 export async function probeReachable(
   url: string,


### PR DESCRIPTION
Fixes #10926.

### Problem
`DEPLOY_APP`'s completion gate and the **server** used different reachability rules, so an app the server marks **READY + live** was reported **"not live"** by `DEPLOY_APP` (contradicting `GET_APP_DEPLOY_STATUS`, which reads server state):
- **Server** (`app-reachability.ts` `isReachableStatus`): reachable unless the status is a Caddy gateway error **502/503/504** (401/403 auth gates and 3xx/404 count as "the app answered").
- **Plugin** (`deploy-gate.ts`): required a **strict 2xx** on `/health`.

So an **auth-gated** app (401/403) or one with **no `/health` route** (404) was live server-side but `DEPLOY_APP` said *"finished building, but … isn't answering yet, so I won't call it live."*

### Fix
Add `respondedLive(result)` to `reachability.ts` — the same rule as the server (`status` present and not in `{502,503,504}`) — and use it in the gate instead of `reachability.ok`. The gate still probes `/health`; those gateway statuses are proxy-level (path-independent), so this exactly matches the server without a probe-target change. A network error / abort (no status) stays **unreachable**.

### Evidence
- `bun test plugins/plugin-cloud-apps/__tests__/{deploy-gate,deploy-app}.test.ts` → **17 pass / 0 fail**.
- New regression tests: `READY + /health 401 → ready/live`, `READY + /health 404 → live`, `READY + network error → unreachable`. Existing `503 → unreachable` retitled + kept.
- `typecheck` clean.
- N/A — real-LLM trajectory / screenshots: pure gate logic, deterministic, covered by unit tests; no UI/model surface.

Found via an adversarial multi-agent audit (round 2). This is the completion gate I authored.
