### PR TITLE
test(cloud): make the #10902 compat credit-gate test CI-discoverable (#10718)

### DIFF
--- a/packages/cloud/api/__tests__/compat-agent-credit-gate.test.ts
+++ b/packages/cloud/api/__tests__/compat-agent-credit-gate.test.ts
@@ -57,7 +57,7 @@ const provision = mock(async () => ({
 
 const snapshot = mock(async () => undefined);
 
-mock.module("../../../_lib/auth", () => ({
+mock.module("../compat/_lib/auth", () => ({
   requireCompatAuth,
 }));
 
@@ -95,8 +95,12 @@ mock.module("@/lib/utils/logger", () => ({
   },
 }));
 
-const { default: resumeRoute } = await import("./resume/route");
-const { default: restartRoute } = await import("./restart/route");
+const { default: resumeRoute } = await import(
+  "../compat/agents/[id]/resume/route"
+);
+const { default: restartRoute } = await import(
+  "../compat/agents/[id]/restart/route"
+);
 
 describe("compat agent resume/restart credit gate", () => {
   const app = new Hono();


### PR DESCRIPTION
The credit-gate test added by #10905 lived outside `__tests__/`, but the cloud/api unit runner (`test/run-unit-isolated.mjs`) only walks `packages/cloud/api/__tests__/` — so **CI never ran it** (it only passed via a direct `bun test <path>`). A test that exists but doesn't run (ref #10718 anti-larp).

This relocates it into `__tests__/`, adjusting the `./resume/route`/`./restart/route` dynamic imports and the one `../../../_lib/auth` relative mock → `../compat/_lib/auth`. Verified the runner now discovers it and it passes:

```
[cloud-api unit] all 1 file(s) passed (isolated)
 4 pass / 0 fail / 18 expect() calls
```

Asserts 402 on insufficient credit, `checkAgentCreditGate` called, and `provision`/`snapshot` NOT called — for both resume and restart. No change to the #10902 fix itself. Git tracks it as a rename.

Refs #10902 #10718