### PR TITLE
fix(ui): native domain-buy 'Add credits' CTA opens real Eliza Cloud billing (#10925)

### DIFF
--- a/packages/ui/src/cloud/applications/components/BuyDomainCard.tsx
+++ b/packages/ui/src/cloud/applications/components/BuyDomainCard.tsx
@@ -34,6 +34,7 @@ import {
 import { Button } from "../../../components/ui/button";
 import { Input } from "../../../components/ui/input";
 import { openExternalUrl } from "../../../utils/openExternalUrl";
+import { resolveCloudConsoleUrl } from "../lib/native-cloud-nav";
 import { ApiError, api } from "../../lib/api-client";
 import { useCloudT } from "../../shell/CloudI18nProvider";
 
@@ -159,7 +160,12 @@ export function BuyDomainCard({ appId, onPurchased }: BuyDomainCardProps) {
   }
 
   function openBilling() {
-    void openExternalUrl(`${window.location.origin}/dashboard/billing`);
+    // Resolve the real cloud console host from boot config, NOT
+    // window.location.origin — on the native Applications studio the WebView
+    // origin is `https://localhost` (Capacitor) / the Electrobun scheme, so
+    // `${origin}/dashboard/billing` would dead-end at the device instead of
+    // Eliza Cloud billing. resolveCloudConsoleUrl is correct on web + native.
+    void openExternalUrl(resolveCloudConsoleUrl("/dashboard/billing"));
   }
 
   return (


### PR DESCRIPTION
Fixes #10925.

### Problem
On the native Applications studio (Capacitor iOS/Android or Electrobun), the domain-buy card's **"Add credits"** CTA opened `https://localhost/dashboard/billing` instead of Eliza Cloud billing — so a user who hit "insufficient credits" while buying a domain couldn't top up, and the purchase dead-ended.

`BuyDomainCard.tsx:162` built the URL from `window.location.origin`, but on native the WebView origin is **not** `elizacloud.ai` (`capacitor.config.ts` serves from `https://localhost`; Electrobun uses its own desktop scheme).

### Fix
Use the existing `resolveCloudConsoleUrl("/dashboard/billing")` helper (`native-cloud-nav.ts`), which derives the real console host from `getBootConfig().cloudApiBase` and is correct on **both** web and native. Sibling components (`app-promote`, `app-monetization-settings`) already route `/dashboard/*` links through this helper; `BuyDomainCard` was the lone outlier still using `window.location.origin`.

### Evidence
- `bun run --cwd packages/ui typecheck` → clean.
- The change is a one-line swap to a shared, already-used helper (`resolveCloudConsoleUrl`), whose host-resolution is unit-covered; on web `resolveCloudConsoleUrl("/dashboard/billing")` yields the same `https://elizacloud.ai/dashboard/billing` the old code produced, and on native it yields the real host instead of `localhost`.
- N/A — before/after screenshots + video: this is a native-only, insufficient-credits error-path CTA whose only change is the external URL opened (system-browser handoff); reproducing needs a native build + an under-funded org. The URL resolution is deterministic and matches the sibling components' proven pattern.

Found via an adversarial multi-agent audit (round 2, both skeptics confirmed; native-only).
