### PR TITLE
fix(cloud): idempotent credit reconcile — no double refund/charge on retry (#10846 finding 2)

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts
@@ -408,3 +408,91 @@ describe("CreditsService.reconcile", () => {
     PGLITE_TIMEOUT,
   );
 });
+
+/**
+ * #10846 finding 2: the reconcile retry loop double-applied the refund/overage
+ * on a commit-then-ack-loss because neither branch carried a dedupe key. The fix
+ * derives a stable `recon:<reservation_transaction_id>:<phase>` key and threads
+ * it into refundCredits / deductCredits, so a re-run of an already-settled
+ * reconcile is a no-op. Re-invoking reconcile with the same reservation id is the
+ * observable equivalent of the retry (the key is what protects the retry).
+ */
+describe("CreditsService.reconcile idempotency (#10846)", () => {
+  const RES_ID = "00000000-0000-0000-0000-0000000000f6";
+
+  test(
+    "a re-run refund with the same reservation id does NOT double-credit",
+    async () => {
+      if (!pgliteReady) return;
+      await seedOrg("10");
+      const args = {
+        organizationId: ORG_ID,
+        reservedAmount: 1.0,
+        actualCost: 0.4,
+        description: "reconcile refund idempotent",
+        metadata: { user_id: USER_ID, reservation_transaction_id: RES_ID },
+      };
+
+      const first = await creditsService.reconcile(args);
+      const second = await creditsService.reconcile(args);
+
+      // Refund applied exactly once: balance = 10 + 0.6, one refund row.
+      expect(await getBalance()).toBeCloseTo(10.6, 6);
+      expect(await countByType("refund")).toBe(1);
+      expect(await countTransactions()).toBe(1);
+      // Both invocations report the SAME settlement transaction.
+      expect(second.settlementTransactionIds).toEqual(first.settlementTransactionIds);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a re-run overage with the same reservation id does NOT double-charge",
+    async () => {
+      if (!pgliteReady) return;
+      await seedOrg("20");
+      const args = {
+        organizationId: ORG_ID,
+        reservedAmount: 0.4,
+        actualCost: 1.0,
+        description: "reconcile overage idempotent",
+        metadata: { user_id: USER_ID, reservation_transaction_id: RES_ID },
+      };
+
+      const first = await creditsService.reconcile(args);
+      const second = await creditsService.reconcile(args);
+
+      // Overage charged exactly once: balance = 20 - 0.6, one debit row.
+      expect(await getBalance()).toBeCloseTo(19.4, 6);
+      expect(await countByType("debit")).toBe(1);
+      expect(await countTransactions()).toBe(1);
+      expect(second.settlementTransactionIds).toEqual(first.settlementTransactionIds);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "without a reservation id the fix is opt-in — behavior is unchanged (still double-applies)",
+    async () => {
+      if (!pgliteReady) return;
+      await seedOrg("10");
+      // No reservation_transaction_id ⇒ no dedupe key ⇒ prior non-idempotent
+      // behavior is preserved (this documents that the fix does NOT silently
+      // change any existing caller that lacks a reservation id).
+      const args = {
+        organizationId: ORG_ID,
+        reservedAmount: 1.0,
+        actualCost: 0.4,
+        description: "reconcile refund no-key",
+        metadata: { user_id: USER_ID },
+      };
+
+      await creditsService.reconcile(args);
+      await creditsService.reconcile(args);
+
+      expect(await getBalance()).toBeCloseTo(11.2, 6);
+      expect(await countByType("refund")).toBe(2);
+    },
+    PGLITE_TIMEOUT,
+  );
+});

--- a/packages/cloud/shared/src/lib/services/credits.ts
+++ b/packages/cloud/shared/src/lib/services/credits.ts
@@ -116,6 +116,14 @@ export interface DeductCreditsParams {
   session_token?: string;
   /** Optional tokens consumed for usage tracking. */
   tokens_consumed?: number;
+  /**
+   * Optional idempotency key. When set, a prior committed deduction with the
+   * same key returns that transaction instead of deducting again — backed by the
+   * unique index on `stripe_payment_intent_id`. Used by {@link reconcile} so a
+   * retry after a commit-then-ack-loss cannot double-charge an overage (#10846).
+   * Omit it (all existing callers) for the unchanged non-idempotent behavior.
+   */
+  stripePaymentIntentId?: string;
 }
 
 export interface ReserveAndDeductParams extends DeductCreditsParams {
@@ -448,11 +456,30 @@ export class CreditsService {
       session_token,
       tokens_consumed,
       minimumBalanceRequired = 0,
+      stripePaymentIntentId,
     } = params;
 
     if (amount <= 0) {
       throw new Error("Amount must be positive");
     }
+
+    // Opt-in idempotency: a keyed deduction that already committed (e.g. a
+    // reconcile retry after the commit landed but the ack was lost) returns the
+    // prior transaction instead of deducting again. The unique index on
+    // stripe_payment_intent_id is the concurrency backstop (a racing duplicate
+    // aborts the whole atomic statement, and the caller retries into this
+    // check). Callers that pass no key keep the exact previous behavior. (#10846)
+    if (stripePaymentIntentId) {
+      const existing = await this.getTransactionByStripePaymentIntent(stripePaymentIntentId);
+      if (existing) {
+        return {
+          success: true,
+          newBalance: await this.getOrganizationBalanceUsd(organizationId),
+          transaction: existing,
+        };
+      }
+    }
+    const stripeId = stripePaymentIntentId ?? null;
 
     const metadataJson = JSON.stringify(metadata ?? {});
     const rows = await sqlRows<CreditMutationRow>(
@@ -489,6 +516,7 @@ export class CreditsService {
             type,
             description,
             metadata,
+            stripe_payment_intent_id,
             created_at
           )
           SELECT
@@ -497,6 +525,7 @@ export class CreditsService {
             'debit',
             ${description},
             ${metadataJson}::jsonb,
+            ${stripeId},
             NOW()
           FROM eligible
           WHERE EXISTS (SELECT 1 FROM updated)
@@ -764,7 +793,7 @@ export class CreditsService {
     transaction: CreditTransaction;
     newBalance: number;
   }> {
-    const { organizationId, amount, description, metadata } = params;
+    const { organizationId, amount, description, metadata, stripePaymentIntentId } = params;
 
     if (amount <= 0) {
       throw new Error("Refund amount must be positive");
@@ -775,6 +804,10 @@ export class CreditsService {
       amount,
       description,
       metadata,
+      // Thread the idempotency key so a reconcile retry doesn't double-refund
+      // (applyCreditIncrease dedupes on stripe_payment_intent_id via ON
+      // CONFLICT DO NOTHING). (#10846)
+      stripePaymentIntentId,
       transactionType: "refund",
     }).then(async (result) => {
       invalidateOrganizationCache(organizationId).catch((error) => {
@@ -822,6 +855,19 @@ export class CreditsService {
       actual: actualCost,
     };
 
+    // Stable per-(reservation, phase) idempotency key. Threaded into
+    // refund/deduct as `stripePaymentIntentId` so a retry of an already-committed
+    // reconcile (commit-then-ack-loss) is a no-op instead of a second refund
+    // (platform loss) or a second overage charge (consumer double-charge).
+    // Without a reservation id there is nothing stable to key on, so we keep the
+    // prior non-idempotent behavior. (#10846 finding 2)
+    const reservationTxId =
+      typeof metadata?.reservation_transaction_id === "string"
+        ? metadata.reservation_transaction_id
+        : null;
+    const reconKey = (phase: "refund" | "overage"): string | undefined =>
+      reservationTxId ? `recon:${reservationTxId}:${phase}` : undefined;
+
     const MAX_RETRIES = 3;
     const RETRY_DELAY_MS = 100;
 
@@ -833,6 +879,7 @@ export class CreditsService {
             amount: difference,
             description: `${description} (refund)`,
             metadata: { ...baseMetadata, type: "reconciliation_refund" },
+            stripePaymentIntentId: reconKey("refund"),
           });
           logger.info("[Credits] Reconciled - refunded excess", {
             organizationId,
@@ -858,6 +905,7 @@ export class CreditsService {
           amount: overage,
           description: `${description} (overage)`,
           metadata: { ...baseMetadata, type: "reconciliation_overage" },
+          stripePaymentIntentId: reconKey("overage"),
         });
         if (!overageResult.success || !overageResult.transaction) {
           logger.warn("[Credits] Reconciled - overage uncollected", {


### PR DESCRIPTION
Closes the remaining half of #10846. **Finding 1** (creator-earnings reversal on compensation) landed in #10910; this PR fixes **finding 2**.

## The bug (non-idempotent reconcile retry)

`CreditsService.reconcile` settles every metered request and, on a difference, calls `refundCredits` (excess) or `deductCredits` (overage) inside a `1..MAX_RETRIES` loop with **no dedupe key**. On a **commit-then-ack-loss** (Worker→Hyperdrive→Railway reset after Postgres commits but before the client sees the ack), the call throws, the catch sleeps and **re-runs the mutation**, committing a **second** settlement:
- refund branch → org **double-credited** (platform loss)
- overage branch → consumer **double-charged**

`reservation_transaction_id` was available in metadata but only copied into the return DTO, never used to dedupe.

## The fix

Derive a stable `recon:<reservation_transaction_id>:<phase>` key and thread it into both branches as `stripePaymentIntentId`:

- **Refund** — `refundCredits` now forwards `stripePaymentIntentId` into `applyCreditIncrease` (it was silently dropping it). That path already dedupes via `ON CONFLICT (stripe_payment_intent_id) DO NOTHING` + a lookup fallback, so a retry is a no-op.
- **Overage** — `deductCredits`/`reserveAndDeductCredits` gain an **opt-in** `stripePaymentIntentId`: when set, a pre-check returns the prior transaction instead of deducting again, and the key is written into the row so the **unique index** on `stripe_payment_intent_id` is the concurrency backstop (a racing duplicate aborts the whole atomic `WITH`-statement; the retry falls into the pre-check). **Callers that pass no key keep byte-identical behavior** — verified by a dedicated test.
- `reconcile` only keys when a `reservation_transaction_id` is present.

## Evidence

`credits-reconcile.test.ts` gains 3 real-PGlite cases (**11/11** total) that run the REAL `reconcile` → refund/deduct SQL against in-process PGlite (FOR UPDATE row-lock, atomic balance move, unique index):

```
11 pass  0 fail  56 expect() calls
```

- a re-run refund with the same reservation id does **not** double-credit (balance +0.6 **once**, one refund row, same settlement id)
- a re-run overage does **not** double-charge (−0.6 **once**, one debit row)
- **without** a reservation id the fix is opt-in and behavior is **unchanged** (still double-applies) — proves no silent change to existing callers

Full credits regression suite **49/49** green (`credits-reconcile`, `credits-deduct-guard`, `inference-billing-ledger`, `container-billing-idempotency`); `bun run typecheck` + `biome check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)