### PR TITLE
fix(cloud): reserve app-chat credit against max_tokens, not a fixed estimate (#10924)

### DIFF
--- a/packages/cloud/api/__tests__/chat-reservation.test.ts
+++ b/packages/cloud/api/__tests__/chat-reservation.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DEFAULT_ESTIMATED_OUTPUT_TOKENS,
+  MAX_RESERVATION_OUTPUT_TOKENS,
+  reservationOutputTokens,
+} from "../v1/apps/[id]/chat/chat-reservation";
+
+describe("reservationOutputTokens (#10924)", () => {
+  test("falls back to the default estimate when max_tokens is absent/invalid", () => {
+    expect(reservationOutputTokens(undefined)).toBe(
+      DEFAULT_ESTIMATED_OUTPUT_TOKENS,
+    );
+    expect(reservationOutputTokens(null)).toBe(DEFAULT_ESTIMATED_OUTPUT_TOKENS);
+    expect(reservationOutputTokens(0)).toBe(DEFAULT_ESTIMATED_OUTPUT_TOKENS);
+    expect(reservationOutputTokens(-100)).toBe(DEFAULT_ESTIMATED_OUTPUT_TOKENS);
+    expect(reservationOutputTokens(Number.NaN)).toBe(
+      DEFAULT_ESTIMATED_OUTPUT_TOKENS,
+    );
+  });
+
+  test("never reserves BELOW the default even for a tiny max_tokens", () => {
+    // A caller passing max_tokens:100 could still, combined with the model, cost
+    // at least the default estimate; reserving less re-opens the underestimate.
+    expect(reservationOutputTokens(100)).toBe(DEFAULT_ESTIMATED_OUTPUT_TOKENS);
+  });
+
+  test("reserves for the caller's max_tokens ceiling (the fix — no more fixed 500)", () => {
+    // The vulnerability: max_tokens forwarded to the provider but reserved as 500.
+    expect(reservationOutputTokens(8000)).toBe(8000);
+    expect(reservationOutputTokens(32000)).toBe(32000);
+  });
+
+  test("bounds a pathological max_tokens to the overflow guard", () => {
+    expect(reservationOutputTokens(10_000_000)).toBe(
+      MAX_RESERVATION_OUTPUT_TOKENS,
+    );
+    expect(reservationOutputTokens(Number.POSITIVE_INFINITY)).toBe(
+      DEFAULT_ESTIMATED_OUTPUT_TOKENS,
+    ); // Infinity is not finite → default, not the cap
+  });
+});

--- a/packages/cloud/api/v1/apps/[id]/chat/chat-reservation.ts
+++ b/packages/cloud/api/v1/apps/[id]/chat/chat-reservation.ts
@@ -1,0 +1,37 @@
+/**
+ * App-chat credit-reservation sizing (#10924).
+ *
+ * The app-chat route reserves credit up front, then forwards the caller's
+ * `max_tokens` to the provider. Reserving a FIXED estimate while the provider is
+ * allowed to generate up to `max_tokens` lets a low-balance caller consume far
+ * more inference than was reserved — and the all-or-nothing reconcile leaves the
+ * platform absorbing the shortfall. So the reservation must size to the caller's
+ * output ceiling, not a constant.
+ */
+
+export const DEFAULT_ESTIMATED_OUTPUT_TOKENS = 500;
+
+/**
+ * Overflow / pathological-input guard. Real models cap their own output well
+ * below this, so reserving up to this bound always covers the provider's actual
+ * output even when a caller passes an absurd `max_tokens`.
+ */
+export const MAX_RESERVATION_OUTPUT_TOKENS = 128_000;
+
+/**
+ * Output tokens to RESERVE credit for. Reserve for the caller's requested
+ * `max_tokens` ceiling (never below the default estimate, bounded above to guard
+ * pathological values); an absent/invalid value falls back to the default.
+ */
+export function reservationOutputTokens(
+  maxTokens: number | null | undefined,
+): number {
+  const requested = Number(maxTokens);
+  if (!Number.isFinite(requested) || requested <= 0) {
+    return DEFAULT_ESTIMATED_OUTPUT_TOKENS;
+  }
+  return Math.min(
+    Math.max(requested, DEFAULT_ESTIMATED_OUTPUT_TOKENS),
+    MAX_RESERVATION_OUTPUT_TOKENS,
+  );
+}

--- a/packages/cloud/api/v1/apps/[id]/chat/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/chat/route.ts
@@ -45,6 +45,7 @@ import { appsService } from "@/lib/services/apps";
 import { logger } from "@/lib/utils/logger";
 import { getRouteTimeoutMs } from "@/lib/utils/request-timeout";
 import type { AppEnv } from "@/types/cloud-worker-env";
+import { reservationOutputTokens } from "./chat-reservation";
 import { reconcileStreamProcessingError } from "./stream-refund";
 
 const ROUTE_MAX_DURATION = 800;
@@ -52,10 +53,6 @@ const ROUTE_MAX_DURATION = 800;
 // Safety multiplier for cost estimation to reduce undercharging risk
 // We charge 1.5x estimated upfront, then reconcile to actual
 const COST_SAFETY_MULTIPLIER = 1.5;
-
-// Default estimated output tokens for cost pre-calculation
-// This is a reasonable average for chat completions
-const DEFAULT_ESTIMATED_OUTPUT_TOKENS = 500;
 
 function isProviderHttpError(error: unknown): error is ProviderHttpError {
   return Boolean(
@@ -298,7 +295,12 @@ async function handlePOST(
       .join(" ");
 
     const estimatedInputTokens = estimateTokens(inputText);
-    const estimatedOutputTokens = DEFAULT_ESTIMATED_OUTPUT_TOKENS;
+    // #10924: reserve for the caller's max_tokens ceiling (forwarded to the
+    // provider), not a fixed estimate — otherwise a low-balance caller drains
+    // inference the all-or-nothing reconcile can't recover.
+    const estimatedOutputTokens = reservationOutputTokens(
+      chatRequest.max_tokens,
+    );
     const { totalCost: estimatedBaseCost } = await calculateCost(
       normalizedModel,
       provider,


### PR DESCRIPTION
## The drain (#10924)

`POST /api/v1/apps/:id/chat` reserves credit up front from a **fixed** output estimate (`DEFAULT_ESTIMATED_OUTPUT_TOKENS = 500`) but **forwards the caller's `max_tokens` to the provider**. So a low-balance caller can set a large `max_tokens`, have only ~500 tokens' worth reserved, and consume far more inference than reserved — and the all-or-nothing reconcile leaves the platform absorbing the shortfall. Repeatable low-balance inference drain.

## Fix

Size the reservation to the caller's `max_tokens` ceiling. Extracted a pure `reservationOutputTokens(maxTokens)` (`chat/chat-reservation.ts`):
- reserve for `max_tokens` when present,
- never below the default estimate (floor),
- bounded above by `MAX_RESERVATION_OUTPUT_TOKENS` (128k — ≥ any real model's output, so the reservation still covers the provider's actual generation; pure overflow guard),
- fall back to the default for absent/invalid/non-finite values.

The route sizes `estimatedOutputTokens` through it before the existing 1.5× safety buffer + reconcile — no change to the reconcile/refund path.

## Evidence

`__tests__/chat-reservation.test.ts` (CI-discovered by `run-unit-isolated.mjs`, verified):
```
[cloud-api unit] all 1 file(s) passed (isolated)
 4 pass / 0 fail / 10 expect() calls
```
Covers: default fallback (absent/0/negative/NaN), floor at default for tiny max_tokens, **reserve for the ceiling (8k→8k, 32k→32k — the fix)**, and pathological values bounded to the guard. Biome clean. `OpenAIChatRequest.max_tokens` confirmed typed.

Refs #10924