### PR TITLE
fix(cloud): MCP public surfaces leak raw external_endpoint + creator identity (#10917, #10918)

### DIFF
--- a/packages/cloud/api/v1/discovery/route.ts
+++ b/packages/cloud/api/v1/discovery/route.ts
@@ -353,7 +353,7 @@ async function fetchLocalMcps(
       category: mcp.category,
       tags: mcp.tags ?? [],
       active: mcp.status === "live",
-      mcpEndpoint: userMcpsService.getEndpointUrl(mcp, baseUrl),
+      mcpEndpoint: userMcpsService.getPublicProxyUrl(mcp, baseUrl),
       mcpTools: mcp.tools.map((t) => t.name),
       a2aSkills: [],
       x402Support: mcp.x402_enabled,

--- a/packages/cloud/api/v1/mcps/[mcpId]/route.ts
+++ b/packages/cloud/api/v1/mcps/[mcpId]/route.ts
@@ -92,24 +92,32 @@ async function __hono_GET(
     return Response.json({ error: "MCP not found" }, { status: 404 });
   }
 
+  const isOwner = mcp.organization_id === authResult.user.organization_id;
+
   // Get stats if owner
   let stats = null;
-  if (mcp.organization_id === authResult.user.organization_id) {
+  if (isOwner) {
     stats = await userMcpsService.getStats(mcpId, mcp.organization_id);
   }
 
   // Get endpoint URL
   const baseUrl =
     process.env.NEXT_PUBLIC_APP_URL || "https://www.elizacloud.ai";
-  const endpointUrl = userMcpsService.getEndpointUrl(mcp, baseUrl);
+  const endpointUrl = isOwner
+    ? userMcpsService.getEndpointUrl(mcp, baseUrl)
+    : userMcpsService.getPublicProxyUrl(mcp, baseUrl);
+  const visibleMcp = userMcpsService.toVisibleMcpForOrganization(
+    mcp,
+    authResult.user.organization_id,
+  );
 
   return Response.json({
     mcp: {
-      ...mcp,
+      ...visibleMcp,
       endpointUrl,
     },
     stats,
-    isOwner: mcp.organization_id === authResult.user.organization_id,
+    isOwner,
   });
 }
 

--- a/packages/cloud/api/v1/mcps/route.ts
+++ b/packages/cloud/api/v1/mcps/route.ts
@@ -186,15 +186,22 @@ app.get("/", async (c) => {
 
     const { category, search, status, scope, limit, offset } = validation.data;
 
-    let mcps: Awaited<ReturnType<typeof userMcpsService.listPublic>>;
+    // Public (foreign) MCPs are redacted — no raw external_endpoint (metered-proxy
+    // bypass) and no created_by_user_id (cross-org user identity). The caller's
+    // OWN MCPs are returned in full. (#10918)
+    type ListedMcp =
+      | Awaited<ReturnType<typeof userMcpsService.listPublic>>[number]
+      | ReturnType<typeof userMcpsService.toPublicMcp>;
+    let mcps: ListedMcp[];
 
     if (scope === "public") {
-      mcps = await userMcpsService.listPublic({
+      const publicMcps = await userMcpsService.listPublic({
         category,
         search,
         limit,
         offset,
       });
+      mcps = publicMcps.map((m) => userMcpsService.toPublicMcp(m));
     } else if (scope === "own") {
       mcps = await userMcpsService.listByOrganization(user.organization_id, {
         status,
@@ -217,7 +224,12 @@ app.get("/", async (c) => {
       ]);
 
       const ownIds = new Set(ownMcps.map((m) => m.id));
-      mcps = [...ownMcps, ...publicMcps.filter((m) => !ownIds.has(m.id))];
+      mcps = [
+        ...ownMcps,
+        ...publicMcps
+          .filter((m) => !ownIds.has(m.id))
+          .map((m) => userMcpsService.toPublicMcp(m)),
+      ];
     }
 
     return c.json({

--- a/packages/cloud/api/v1/mcps/route.ts
+++ b/packages/cloud/api/v1/mcps/route.ts
@@ -201,7 +201,9 @@ app.get("/", async (c) => {
         limit,
         offset,
       });
-      mcps = publicMcps.map((m) => userMcpsService.toPublicMcp(m));
+      mcps = publicMcps.map((m) =>
+        userMcpsService.toVisibleMcpForOrganization(m, user.organization_id),
+      );
     } else if (scope === "own") {
       mcps = await userMcpsService.listByOrganization(user.organization_id, {
         status,

--- a/packages/cloud/shared/src/lib/services/user-mcps.test.ts
+++ b/packages/cloud/shared/src/lib/services/user-mcps.test.ts
@@ -504,4 +504,22 @@ describe("userMcpsService public-surface redaction (#10917/#10918)", () => {
     expect(JSON.stringify(pub)).not.toContain("secret-backend.internal");
     expect(JSON.stringify(pub)).not.toContain("11111111-1111-4111-8111-111111111111");
   });
+
+  test("toVisibleMcpForOrganization preserves owner rows and redacts foreign rows", () => {
+    const mcp = makeRow({
+      endpoint_type: "external",
+      external_endpoint: "https://secret-backend.internal/mcp",
+      created_by_user_id: "11111111-1111-4111-8111-111111111111",
+      organization_id: ORG,
+    });
+
+    const owner = userMcpsService.toVisibleMcpForOrganization(mcp, ORG);
+    expect(owner.external_endpoint).toBe("https://secret-backend.internal/mcp");
+    expect(owner.created_by_user_id).toBe("11111111-1111-4111-8111-111111111111");
+
+    const foreign = userMcpsService.toVisibleMcpForOrganization(mcp, OTHER_ORG);
+    expect(foreign.external_endpoint).toBeNull();
+    expect(foreign.created_by_user_id).toBeNull();
+    expect(JSON.stringify(foreign)).not.toContain("secret-backend.internal");
+  });
 });

--- a/packages/cloud/shared/src/lib/services/user-mcps.test.ts
+++ b/packages/cloud/shared/src/lib/services/user-mcps.test.ts
@@ -451,11 +451,57 @@ describe("userMcpsService.toRegistryFormat", () => {
     expect(entry.id).toBe(`user-${live.id}`);
     expect(entry.name).toBe("Weather Pro");
     expect(entry.status).toBe("live");
-    expect(entry.endpoint).toBe(live.external_endpoint);
     expect(entry.toolCount).toBe(1);
+
+    // Security (#10917): the public registry advertises the METERED PROXY, never
+    // the raw external backend URL (which would bypass metering/charging).
+    const proxyUrl = `https://www.elizacloud.ai/api/mcp/proxy/${live.id}${live.endpoint_path ?? "/mcp"}`;
+    expect(entry.endpoint).toBe(proxyUrl);
+    expect(entry.endpoint).not.toBe(live.external_endpoint);
     expect(entry.configTemplate.servers[live.slug]).toEqual({
       type: "streamable-http",
-      url: live.external_endpoint as string,
+      url: proxyUrl,
     });
+    // The raw external_endpoint appears NOWHERE in the public entry.
+    expect(JSON.stringify(entry)).not.toContain(live.external_endpoint as string);
+  });
+});
+
+describe("userMcpsService public-surface redaction (#10917/#10918)", () => {
+  test("getPublicProxyUrl always returns the proxy for external/container, never the raw URL", () => {
+    const external = makeRow({
+      endpoint_type: "external",
+      external_endpoint: "https://secret-backend.internal/mcp",
+      endpoint_path: "/mcp",
+    });
+    const url = userMcpsService.getPublicProxyUrl(external, "https://www.elizacloud.ai");
+    expect(url).toBe(`https://www.elizacloud.ai/api/mcp/proxy/${external.id}/mcp`);
+    expect(url).not.toContain("secret-backend.internal");
+
+    const container = makeRow({ endpoint_type: "container", container_id: "c1" });
+    expect(userMcpsService.getPublicProxyUrl(container, "https://x")).toBe(
+      `https://x/api/mcp/proxy/${container.id}/mcp`,
+    );
+
+    // getEndpointUrl (owner-only) still returns the raw URL — the split is the point.
+    expect(userMcpsService.getEndpointUrl(external, "https://x")).toBe(
+      "https://secret-backend.internal/mcp",
+    );
+  });
+
+  test("toPublicMcp drops the raw external_endpoint and created_by_user_id", () => {
+    const mcp = makeRow({
+      endpoint_type: "external",
+      external_endpoint: "https://secret-backend.internal/mcp",
+      created_by_user_id: "11111111-1111-4111-8111-111111111111",
+    });
+    const pub = userMcpsService.toPublicMcp(mcp);
+    expect(pub.external_endpoint).toBeNull();
+    expect(pub.created_by_user_id).toBeNull();
+    // Non-sensitive fields survive (still discoverable).
+    expect(pub.id).toBe(mcp.id);
+    expect(pub.name).toBe(mcp.name);
+    expect(JSON.stringify(pub)).not.toContain("secret-backend.internal");
+    expect(JSON.stringify(pub)).not.toContain("11111111-1111-4111-8111-111111111111");
   });
 });

--- a/packages/cloud/shared/src/lib/services/user-mcps.ts
+++ b/packages/cloud/shared/src/lib/services/user-mcps.ts
@@ -718,7 +718,10 @@ class UserMcpsService {
   }
 
   /**
-   * Get the full endpoint URL for an MCP
+   * Get the full endpoint URL for an MCP. Returns the RAW external backend URL
+   * for external MCPs, so this is owner-only — never call it on a public/registry
+   * surface (that leaks the raw URL and bypasses the metered proxy). Use
+   * {@link getPublicProxyUrl} for anything a non-owner can see (#10917).
    */
   getEndpointUrl(mcp: UserMcp, baseUrl: string): string {
     if (mcp.endpoint_type === "external" && mcp.external_endpoint) {
@@ -732,6 +735,32 @@ class UserMcpsService {
     }
 
     return `${baseUrl}/api/mcp/user/${mcp.slug}`;
+  }
+
+  /**
+   * Public-safe endpoint URL: always the metered proxy for external/container
+   * MCPs — never the raw `external_endpoint`, which would let a caller hit the
+   * backend directly and bypass metering/charging. Use this everywhere a
+   * non-owner can see the MCP (the registry, `?scope=public`). (#10917)
+   */
+  getPublicProxyUrl(mcp: UserMcp, baseUrl: string): string {
+    if (mcp.endpoint_type === "external" || mcp.endpoint_type === "container") {
+      return `${baseUrl}/api/mcp/proxy/${mcp.id}${mcp.endpoint_path ?? "/mcp"}`;
+    }
+    return `${baseUrl}/api/mcp/user/${mcp.slug}`;
+  }
+
+  /**
+   * Redact an MCP for a PUBLIC (non-owner) response: drop the raw
+   * `external_endpoint` (metered-proxy bypass) and the internal
+   * `created_by_user_id` (cross-org user identity), so `?scope=public` /
+   * combined listings never hand a foreign caller either. (#10918)
+   */
+  toPublicMcp(mcp: UserMcp): Omit<UserMcp, "external_endpoint" | "created_by_user_id"> & {
+    external_endpoint: null;
+    created_by_user_id: null;
+  } {
+    return { ...mcp, external_endpoint: null, created_by_user_id: null };
   }
 
   /**
@@ -774,7 +803,9 @@ class UserMcpsService {
       >;
     };
   } {
-    const endpoint = this.getEndpointUrl(mcp, baseUrl);
+    // The registry is a public discovery surface — advertise the metered proxy,
+    // never the raw external backend URL (that would bypass metering). (#10917)
+    const endpoint = this.getPublicProxyUrl(mcp, baseUrl);
 
     let pricingDescription = "Free to use";
     if (mcp.pricing_type === "credits") {

--- a/packages/cloud/shared/src/lib/services/user-mcps.ts
+++ b/packages/cloud/shared/src/lib/services/user-mcps.ts
@@ -108,6 +108,11 @@ export interface UseMcpResult {
   usageId: string;
 }
 
+export type PublicUserMcp = Omit<UserMcp, "external_endpoint" | "created_by_user_id"> & {
+  external_endpoint: null;
+  created_by_user_id: null;
+};
+
 // ============================================================================
 // Service
 // ============================================================================
@@ -756,11 +761,15 @@ class UserMcpsService {
    * `created_by_user_id` (cross-org user identity), so `?scope=public` /
    * combined listings never hand a foreign caller either. (#10918)
    */
-  toPublicMcp(mcp: UserMcp): Omit<UserMcp, "external_endpoint" | "created_by_user_id"> & {
-    external_endpoint: null;
-    created_by_user_id: null;
-  } {
+  toPublicMcp(mcp: UserMcp): PublicUserMcp {
     return { ...mcp, external_endpoint: null, created_by_user_id: null };
+  }
+
+  /**
+   * Return the owner view unchanged, otherwise redact the public view.
+   */
+  toVisibleMcpForOrganization(mcp: UserMcp, organizationId: string): UserMcp | PublicUserMcp {
+    return mcp.organization_id === organizationId ? mcp : this.toPublicMcp(mcp);
   }
 
   /**


### PR DESCRIPTION
Closes #10917 and #10918 (both: MCP public surfaces disclosing the raw external backend URL — a free bypass of the metered proxy — plus cross-org creator identity).

## The leaks
- **#10917** — unauth `GET /api/mcp/registry`: `toRegistryFormat` derived `endpoint` from `getEndpointUrl`, which for external MCPs returns the raw `external_endpoint`. It was emitted as `endpoint`, `fullEndpoint`, and `configTemplate.servers[].url`. Anyone could then call the backend directly and **bypass metering/charging** (the paid `POST /api/mcp/proxy/[mcpId]` is what adds auth + meters).
- **#10918** — `GET /api/v1/mcps?scope=public`: `listPublic()` is `SELECT *` and the rows were returned unfiltered, so any authed caller (incl. a \$0 org's key) got every **foreign** public MCP's raw `external_endpoint` + `created_by_user_id`.

## Fix
- `getPublicProxyUrl(mcp, baseUrl)` — always the metered proxy URL for external/container MCPs, **never** the raw endpoint. `toRegistryFormat` uses it for `endpoint` + configTemplate url. `getEndpointUrl` (raw) is now documented owner-only — the same split the proxy route already makes (`mcp/proxy/[mcpId]/route.ts`: owners see the real endpoint, non-owners never do).
- `toPublicMcp(mcp)` redacts a foreign row (`external_endpoint → null`, `created_by_user_id → null`). The `/api/v1/mcps` route maps the **public** portion through it (scope=public + the public half of combined); the caller's **own** MCPs are returned in full.

## Evidence
`user-mcps.test.ts` — **23/23** (the existing `toRegistryFormat` test *asserted the raw external_endpoint*, i.e. it encoded the vuln; updated to assert the proxy URL + that the raw url appears **nowhere** in the entry):
```
23 pass  0 fail  56 expect() calls
```
- registry entry advertises `…/api/mcp/proxy/<id>/mcp`; `JSON.stringify(entry)` does **not** contain the raw external_endpoint
- `getPublicProxyUrl` proxies external/container; `getEndpointUrl` still returns the raw URL for owners (the split is the point)
- `toPublicMcp` nulls both sensitive fields; non-sensitive fields survive

`mcp-proxy-helpers` 16/16 unaffected; `bun run typecheck` + `biome check` clean.

**Scope note:** the registry's `creator.organizationId` (org-level attribution for an intentionally-published MCP) is retained; only the raw-endpoint (money) + user-identity leaks are closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)