### PR TITLE
test(cloud/api): unit runner sweeps the whole package, not just __tests__/ (#10104)

### DIFF
--- a/packages/cloud/api/__tests__/stripe-event-waifu.test.ts
+++ b/packages/cloud/api/__tests__/stripe-event-waifu.test.ts
@@ -103,6 +103,9 @@ mock.module("@/lib/services/referrals", () => ({
     calculateRevenueSplits,
   },
 }));
+mock.module("@/lib/security/safe-fetch", () => ({
+  safeFetch: webhookFetch,
+}));
 mock.module("@/lib/stripe", () => ({
   requireStripe: () => ({}),
 }));
@@ -118,7 +121,6 @@ describe("stripe checkout queue waifu top-up callback", () => {
     createInvoice.mockClear();
     calculateRevenueSplits.mockClear();
     webhookFetch.mockClear();
-    globalThis.fetch = webhookFetch as unknown as typeof fetch;
   });
 
   test("emits token and wallet context for agent credit top-ups", async () => {

--- a/packages/cloud/api/billing/checkout/verify/route.test.ts
+++ b/packages/cloud/api/billing/checkout/verify/route.test.ts
@@ -123,6 +123,10 @@ mock.module("@/lib/services/organizations", () => ({
   },
 }));
 
+mock.module("@/lib/security/safe-fetch", () => ({
+  safeFetch: webhookFetch,
+}));
+
 mock.module("@/lib/stripe", () => ({
   requireStripe: () => ({
     checkout: {
@@ -156,7 +160,6 @@ describe("billing checkout verify service-key agent bridge", () => {
     retrieveSession.mockClear();
     dbRead.select.mockClear();
     webhookFetch.mockClear();
-    globalThis.fetch = webhookFetch as unknown as typeof fetch;
   });
 
   test("applies agent owner org credits and emits topped-up webhook", async () => {

--- a/packages/cloud/api/cron/agent-billing/route.test.ts
+++ b/packages/cloud/api/cron/agent-billing/route.test.ts
@@ -82,6 +82,10 @@ mock.module("@/lib/services/eliza-sandbox", () => ({
   },
 }));
 
+mock.module("@/lib/security/safe-fetch", () => ({
+  safeFetch: webhookFetch,
+}));
+
 mock.module("@/lib/utils/logger", () => ({
   logger: {
     info: mock(() => undefined),
@@ -103,7 +107,6 @@ describe("agent billing cron waifu lifecycle callbacks", () => {
     shutdownSandbox.mockClear();
     sendContainerShutdownWarningEmail.mockClear();
     webhookFetch.mockClear();
-    globalThis.fetch = webhookFetch as unknown as typeof fetch;
     listBillableSandboxes.mockImplementation(async () => ({
       runningSandboxes: [runningSandbox],
       stoppedWithBackups: [],

--- a/packages/cloud/api/test/run-unit-isolated.mjs
+++ b/packages/cloud/api/test/run-unit-isolated.mjs
@@ -25,11 +25,17 @@ import { fileURLToPath } from "node:url";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const pkgRoot = path.resolve(here, "..");
-const testsDir = path.join(pkgRoot, "__tests__");
+// Sweep the WHOLE package for unit tests, EXCLUDING dirs that run in a
+// different lane or are build output: `test/` holds the e2e harness (its own
+// `test:e2e` lane + a live server), and node_modules/dist/.turbo are artifacts.
+// Rooting the walk at `__tests__/` only meant colocated `<resource>/route.test.ts`
+// unit tests (billing, cron, credits, webhooks, …) never ran in CI.
+const EXCLUDED_DIRS = new Set(["node_modules", "dist", ".turbo", "test"]);
 
 function walk(dir) {
   const out = [];
   for (const entry of readdirSync(dir)) {
+    if (EXCLUDED_DIRS.has(entry)) continue;
     const full = path.join(dir, entry);
     if (statSync(full).isDirectory()) out.push(...walk(full));
     else if (/\.(test|spec)\.tsx?$/.test(entry)) out.push(full);
@@ -38,7 +44,8 @@ function walk(dir) {
 }
 
 const filter = process.argv[2];
-let files = walk(testsDir).sort();
+// Each file still runs in its own `bun test` process (mock.module isolation).
+let files = walk(pkgRoot).sort();
 if (filter) files = files.filter((f) => f.includes(filter));
 
 if (files.length === 0) {

--- a/packages/cloud/api/test/run-unit-isolated.mjs
+++ b/packages/cloud/api/test/run-unit-isolated.mjs
@@ -15,7 +15,7 @@
  * between concurrent bun processes. The unit suite is small; correctness first.
  *
  * Usage:
- *   node test/run-unit-isolated.mjs            # every test file under __tests__
+ *   node test/run-unit-isolated.mjs            # every unit test file in this package
  *   node test/run-unit-isolated.mjs <substr>   # only files whose path matches
  */
 import { spawnSync } from "node:child_process";

--- a/packages/cloud/api/v1/agents/route.test.ts
+++ b/packages/cloud/api/v1/agents/route.test.ts
@@ -42,8 +42,10 @@ const createCharacter = mock(async (input: Record<string, unknown>) => ({
 }));
 const deleteCharacter = mock(async () => undefined);
 const createAgent = mock(async (input: Record<string, unknown>) => ({
-  id: "cloud-agent-1",
-  input,
+  agent: {
+    id: "cloud-agent-1",
+    input,
+  },
 }));
 const provisionAgent = mock(
   async (): Promise<{

--- a/packages/cloud/shared/src/lib/services/__tests__/x402-app-earnings.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/x402-app-earnings.test.ts
@@ -67,6 +67,7 @@ const whereMock = mock();
 const setMock = mock(() => ({ where: whereMock }));
 const updateMock = mock(() => ({ set: setMock }));
 mock.module("../../../db/helpers", () => ({
+  dbRead: {},
   dbWrite: { update: updateMock },
 }));
 

--- a/packages/scripts/test-cloud-run.mjs
+++ b/packages/scripts/test-cloud-run.mjs
@@ -6,7 +6,13 @@
 // `$OLDPWD` semantics.
 
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -55,6 +61,26 @@ const cloudScriptsTests = path.join(repoRoot, "packages", "scripts", "cloud");
 // Fail loud if a test root is missing. `bun test <nonexistent-dir>` exits 0 with
 // no tests run, so a stale path (e.g. after a package move) turns this gate into
 // a silent false-green instead of a failure. Guard against that recurring.
+// Also sweep colocated `<resource>/route.test.ts` unit tests that live
+// OUTSIDE __tests__/ (billing, cron, credits, webhooks, …) — previously run by
+// no lane. Exclude `test/` (the e2e harness: its own `test:e2e` lane + a live
+// server) and build output. Each file is passed explicitly to `bun test`.
+const cloudApiRoot = path.join(repoRoot, "packages", "cloud", "api");
+const EXCLUDED_API_DIRS = new Set(["test", "node_modules", "dist", ".turbo"]);
+function walkApiUnitTests(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    if (EXCLUDED_API_DIRS.has(entry)) continue;
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...walkApiUnitTests(full));
+    else if (/\.(test|spec)\.tsx?$/.test(entry)) out.push(full);
+  }
+  return out;
+}
+const cloudApiUnitTests = existsSync(cloudApiRoot)
+  ? walkApiUnitTests(cloudApiRoot).sort()
+  : [];
+
 const testRoots = { cloudSharedSrc, cloudApiTests, cloudScriptsTests };
 const missing = Object.entries(testRoots)
   .filter(([, dir]) => !existsSync(dir))
@@ -72,7 +98,7 @@ const result = spawnSync(
   [
     "test",
     cloudSharedSrc,
-    cloudApiTests,
+    ...cloudApiUnitTests,
     cloudScriptsTests,
     "--timeout",
     "120000",


### PR DESCRIPTION
## Summary

`packages/cloud/api` has **26 colocated `<resource>/route.test.ts` unit tests that never run in any lane** — including money-path suites (`billing/checkout/verify`, `cron/agent-billing`, `cron/container-billing`, `cron/sweep-inference-charges`, `v1/credits/balance`, `v1/credits/checkout`, `webhooks/*`). This is the "test exists but doesn't run" larp #10718 targets, at scale (generalizes the single-file relocation in #10928).

**Root cause — BOTH runners scope to `__tests__/`:**
- local `test` script → `test/run-unit-isolated.mjs` walks `__tests__/` only;
- **CI** `test:cloud` (`cloud-tests.yml`) → `packages/scripts/test-cloud-run.mjs` runs `bun test packages/cloud/api/__tests__ --isolate` — also `__tests__/`-only.

So the colocated tests only ever executed when a human typed `bun test <path>` directly.

## Fix

Broaden **both** runners to sweep the whole package, excluding `test/` (the e2e harness — its own `test:e2e` lane + a live server) and build output. Each file still runs isolated (per-process locally / `--isolate` in CI), preserving the `mock.module` isolation.

## Local verification (this Windows box, stale checkout)

Ran the colocated files via `bun test <file>` (the exact mechanism both runners use):
- **18 of 19** locally-present colocated files pass cleanly (e.g. `webhooks/bluebubbles` 10/10, `cron/container-billing` 5/5, `cron/agent-billing` 3/3, `billing/checkout/verify` 2/2, `v1/credits/*` 1/1).
- **`v1/agents/route.test.ts` → 3 failures**: the `service agent provisioning route` cases expect `201`/`202` but the handler returns **500**. That test file, its `route.ts`, and `packages/cloud/shared` are all **unchanged between develop and my checkout**, so this is very likely a **genuine dormant-test signal on develop** (a never-run money-path test hiding a real 500), not a stale-tree artifact.

## Merge gate — do NOT merge until CI is green

This PR's own CI runs develop's actual `cloud-shared`, so it is the authoritative adjudicator of the 26. **If CI is green → merge (26 dead tests resurrected).** If CI reproduces the `v1/agents` 500s (or others among the 7 develop-only colocated files I couldn't run locally), those are real de-larp findings to fix first — the whole point of making dead tests run.

Refs #10104 (structural CI-gating gaps), #10718 (never-run hygiene), follows #10928.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
