### PR TITLE
fix(cloud): claw back credits on Stripe refund / chargeback (#10920)

### DIFF
--- a/packages/cloud/api/__tests__/stripe-event-clawback.test.ts
+++ b/packages/cloud/api/__tests__/stripe-event-clawback.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const getTransactionByStripePaymentIntent = mock(async () => ({
+  id: "tx-credit",
+  organization_id: "org-1",
+  amount: "100",
+}));
+const getClawedBackUsdForPaymentIntent = mock(async () => 0);
+const clawbackCredits = mock(async () => ({ newBalance: 25 }));
+
+mock.module("@/db/helpers", () => ({
+  dbRead: {},
+}));
+mock.module("@/db/repositories/organizations", () => ({
+  organizationsRepository: {},
+}));
+mock.module("@/db/repositories/users", () => ({
+  usersRepository: {},
+}));
+mock.module("@/lib/security/safe-fetch", () => ({
+  safeFetch: mock(async () => Response.json({ ok: true })),
+}));
+mock.module("@/lib/services/app-charge-callbacks", () => ({
+  appChargeCallbacksService: {},
+}));
+mock.module("@/lib/services/app-charge-settlement", () => ({
+  appChargeSettlementService: {},
+}));
+mock.module("@/lib/services/app-credits", () => ({
+  appCreditsService: {},
+}));
+mock.module("@/lib/services/credits", () => ({
+  creditsService: {
+    getTransactionByStripePaymentIntent,
+    getClawedBackUsdForPaymentIntent,
+    clawbackCredits,
+  },
+}));
+mock.module("@/lib/services/discord", () => ({
+  discordService: {},
+}));
+mock.module("@/lib/services/invoices", () => ({
+  invoicesService: {},
+}));
+mock.module("@/lib/services/org-rate-limits", () => ({
+  invalidateOrgTierCache: mock(async () => undefined),
+}));
+mock.module("@/lib/services/redeemable-earnings", () => ({
+  redeemableEarningsService: {},
+}));
+mock.module("@/lib/services/referrals", () => ({
+  referralsService: {},
+}));
+mock.module("@/lib/stripe", () => ({
+  requireStripe: () => ({}),
+}));
+
+const { processStripeEvent } = await import("../src/queue/stripe-event");
+
+describe("stripe queue credit clawbacks", () => {
+  beforeEach(() => {
+    getTransactionByStripePaymentIntent.mockClear();
+    getTransactionByStripePaymentIntent.mockResolvedValue({
+      id: "tx-credit",
+      organization_id: "org-1",
+      amount: "100",
+    });
+    getClawedBackUsdForPaymentIntent.mockClear();
+    getClawedBackUsdForPaymentIntent.mockResolvedValue(0);
+    clawbackCredits.mockClear();
+    clawbackCredits.mockResolvedValue({ newBalance: 25 });
+  });
+
+  test("charge.refunded claws back only the new cumulative refund delta", async () => {
+    getClawedBackUsdForPaymentIntent.mockResolvedValueOnce(30);
+
+    const result = await processStripeEvent({
+      attempts: 1,
+      body: {
+        kind: "stripe.event",
+        eventId: "evt_refund",
+        eventType: "charge.refunded",
+        receivedAt: Date.now(),
+        event: {
+          id: "evt_refund",
+          type: "charge.refunded",
+          data: {
+            object: {
+              id: "ch_1",
+              amount_refunded: 5000,
+              payment_intent: "pi_1",
+            },
+          },
+        },
+      },
+    } as unknown as Parameters<typeof processStripeEvent>[0]);
+
+    expect(result).toBe("ack");
+    expect(getTransactionByStripePaymentIntent).toHaveBeenCalledWith("pi_1");
+    expect(getClawedBackUsdForPaymentIntent).toHaveBeenCalledWith("pi_1");
+    expect(clawbackCredits).toHaveBeenCalledWith({
+      organizationId: "org-1",
+      amount: 20,
+      description: "Stripe charge.refunded clawback — charge ch_1",
+      stripePaymentIntentId: "stripe:refund:ch_1:5000",
+      metadata: {
+        payment_intent_id: "pi_1",
+        reversed_usd: 50,
+        source: "charge.refunded",
+        reference: "charge ch_1",
+      },
+    });
+  });
+
+  test("re-delivered charge.refunded is a no-op once the cumulative amount was clawed", async () => {
+    getClawedBackUsdForPaymentIntent.mockResolvedValueOnce(50);
+
+    const result = await processStripeEvent({
+      attempts: 2,
+      body: {
+        kind: "stripe.event",
+        eventId: "evt_refund_redelivery",
+        eventType: "charge.refunded",
+        receivedAt: Date.now(),
+        event: {
+          id: "evt_refund_redelivery",
+          type: "charge.refunded",
+          data: {
+            object: {
+              id: "ch_1",
+              amount_refunded: 5000,
+              payment_intent: "pi_1",
+            },
+          },
+        },
+      },
+    } as unknown as Parameters<typeof processStripeEvent>[0]);
+
+    expect(result).toBe("ack");
+    expect(clawbackCredits).not.toHaveBeenCalled();
+  });
+
+  test("charge.dispute.funds_withdrawn claws back the disputed amount with a dispute key", async () => {
+    const result = await processStripeEvent({
+      attempts: 1,
+      body: {
+        kind: "stripe.event",
+        eventId: "evt_dispute",
+        eventType: "charge.dispute.funds_withdrawn",
+        receivedAt: Date.now(),
+        event: {
+          id: "evt_dispute",
+          type: "charge.dispute.funds_withdrawn",
+          data: {
+            object: {
+              id: "dp_1",
+              amount: 7500,
+              charge: "ch_1",
+              payment_intent: "pi_1",
+            },
+          },
+        },
+      },
+    } as unknown as Parameters<typeof processStripeEvent>[0]);
+
+    expect(result).toBe("ack");
+    expect(clawbackCredits).toHaveBeenCalledWith({
+      organizationId: "org-1",
+      amount: 75,
+      description:
+        "Stripe charge.dispute.funds_withdrawn clawback — dispute dp_1 (charge ch_1)",
+      stripePaymentIntentId: "stripe:dispute:dp_1",
+      metadata: {
+        payment_intent_id: "pi_1",
+        reversed_usd: 75,
+        source: "charge.dispute.funds_withdrawn",
+        reference: "dispute dp_1 (charge ch_1)",
+      },
+    });
+  });
+});

--- a/packages/cloud/api/__tests__/stripe-event-waifu.test.ts
+++ b/packages/cloud/api/__tests__/stripe-event-waifu.test.ts
@@ -55,6 +55,9 @@ mock.module("@/db/repositories/users", () => ({
     findById: mock(async () => ({ name: "Agent User" })),
   },
 }));
+mock.module("@/lib/security/safe-fetch", () => ({
+  safeFetch: webhookFetch,
+}));
 mock.module("@/lib/services/app-charge-callbacks", () => ({
   appChargeCallbacksService: {},
 }));

--- a/packages/cloud/api/src/queue/stripe-event.ts
+++ b/packages/cloud/api/src/queue/stripe-event.ts
@@ -105,6 +105,12 @@ export async function processStripeEvent(
       case "payment_intent.payment_failed":
         await handlePaymentIntentFailed(event);
         break;
+      case "charge.refunded":
+        await handleChargeRefunded(event);
+        break;
+      case "charge.dispute.funds_withdrawn":
+        await handleChargeDisputeFundsWithdrawn(event);
+        break;
       default:
         logger.debug(`[Stripe Queue] Unhandled event type: ${event.type}`);
     }
@@ -827,4 +833,104 @@ async function handlePaymentIntentFailed(event: Stripe.Event): Promise<void> {
       },
     });
   }
+}
+
+// ---------------------------------------------------------------------------
+// charge.refunded / charge.dispute.funds_withdrawn — credit clawback (#10920)
+// ---------------------------------------------------------------------------
+
+/** The payment intent id off a charge, whether expanded or a bare string. */
+function chargePaymentIntentId(charge: Stripe.Charge): string | undefined {
+  return typeof charge.payment_intent === "string"
+    ? charge.payment_intent
+    : charge.payment_intent?.id;
+}
+
+/**
+ * Claw back org credits for the portion of a top-up charge that Stripe reversed.
+ * Balance top-ups grant credits 1:1 with USD, so `usdReversed` credits are
+ * removed — allowing the balance to go negative, since the org may already have
+ * spent them. Only the DELTA past what was already clawed for this payment intent
+ * is removed, so multiple partial refunds and re-delivered webhooks are safe.
+ */
+async function clawbackForReversal(params: {
+  paymentIntentId: string | undefined;
+  usdReversed: number;
+  idempotencyKey: string;
+  source: string;
+  reference: string;
+}): Promise<void> {
+  const { paymentIntentId, usdReversed, idempotencyKey, source, reference } =
+    params;
+  if (!paymentIntentId || usdReversed <= 0) return;
+
+  // Only top-ups that actually granted org credits are clawable.
+  const grant =
+    await creditsService.getTransactionByStripePaymentIntent(paymentIntentId);
+  if (!grant || Number(grant.amount) <= 0) {
+    logger.info(
+      `[Stripe Queue] ${source} ${reference}: no credit grant for PI ${paymentIntentId}; nothing to claw back`,
+    );
+    return;
+  }
+
+  const alreadyClawed =
+    await creditsService.getClawedBackUsdForPaymentIntent(paymentIntentId);
+  const delta = Math.round((usdReversed - alreadyClawed) * 1e6) / 1e6;
+  if (delta <= 0) {
+    logger.info(
+      `[Stripe Queue] ${source} ${reference}: $${usdReversed.toFixed(2)} already clawed back for PI ${paymentIntentId}`,
+    );
+    return;
+  }
+
+  const result = await creditsService.clawbackCredits({
+    organizationId: grant.organization_id,
+    amount: delta,
+    description: `Stripe ${source} clawback — ${reference}`,
+    stripePaymentIntentId: idempotencyKey,
+    metadata: {
+      payment_intent_id: paymentIntentId,
+      reversed_usd: usdReversed,
+      source,
+      reference,
+    },
+  });
+  logger.warn(
+    `[Stripe Queue] Clawed back $${delta.toFixed(2)} from org ${grant.organization_id} for ${source} ${reference} (new balance $${result.newBalance.toFixed(2)})`,
+  );
+}
+
+async function handleChargeRefunded(event: Stripe.Event): Promise<void> {
+  const charge = event.data.object as Stripe.Charge;
+  // `amount_refunded` is the CUMULATIVE refunded amount (cents) on the charge.
+  await clawbackForReversal({
+    paymentIntentId: chargePaymentIntentId(charge),
+    usdReversed: (charge.amount_refunded ?? 0) / 100,
+    // Key on the cumulative amount so each new partial-refund total is a distinct
+    // idempotent clawback, while a re-delivery of the same state is a no-op.
+    idempotencyKey: `stripe:refund:${charge.id}:${charge.amount_refunded}`,
+    source: "charge.refunded",
+    reference: `charge ${charge.id}`,
+  });
+}
+
+async function handleChargeDisputeFundsWithdrawn(
+  event: Stripe.Event,
+): Promise<void> {
+  const dispute = event.data.object as Stripe.Dispute;
+  const chargeId =
+    typeof dispute.charge === "string" ? dispute.charge : dispute.charge?.id;
+  const paymentIntentId =
+    typeof dispute.payment_intent === "string"
+      ? dispute.payment_intent
+      : dispute.payment_intent?.id;
+  // A lost/withdrawn dispute pulls the full disputed amount back out.
+  await clawbackForReversal({
+    paymentIntentId,
+    usdReversed: (dispute.amount ?? 0) / 100,
+    idempotencyKey: `stripe:dispute:${dispute.id}`,
+    source: "charge.dispute.funds_withdrawn",
+    reference: `dispute ${dispute.id}${chargeId ? ` (charge ${chargeId})` : ""}`,
+  });
 }

--- a/packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts
@@ -476,7 +476,7 @@ describe("CreditsService.reconcile idempotency (#10846)", () => {
     async () => {
       if (!pgliteReady) return;
       await seedOrg("10");
-      // No reservation_transaction_id ⇒ no dedupe key ⇒ prior non-idempotent
+      // No reservation_transaction_id => no dedupe key => prior non-idempotent
       // behavior is preserved (this documents that the fix does NOT silently
       // change any existing caller that lacks a reservation id).
       const args = {
@@ -492,6 +492,81 @@ describe("CreditsService.reconcile idempotency (#10846)", () => {
 
       expect(await getBalance()).toBeCloseTo(11.2, 6);
       expect(await countByType("refund")).toBe(2);
+    },
+    PGLITE_TIMEOUT,
+  );
+});
+
+/**
+ * #10920: a Stripe refund / chargeback must claw back the credits the top-up
+ * granted — even below zero, since the org may already have spent them —
+ * idempotently, so a re-delivered webhook or a growing cumulative partial-refund
+ * total never double-charges.
+ */
+describe("CreditsService.clawbackCredits (#10920)", () => {
+  test(
+    "decrements the balance BELOW zero and records a negative clawback tx",
+    async () => {
+      if (!pgliteReady) return;
+      await seedOrg("50"); // org spent a $1000 top-up down to $50
+      const r = await creditsService.clawbackCredits({
+        organizationId: ORG_ID,
+        amount: 100,
+        description: "refund clawback",
+        stripePaymentIntentId: "stripe:refund:ch_1:10000",
+        metadata: { payment_intent_id: "pi_1" },
+      });
+      expect(await getBalance()).toBeCloseTo(-50, 6);
+      expect(r.newBalance).toBeCloseTo(-50, 6);
+      expect(await countByType("clawback")).toBe(1);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "is idempotent on the stripePaymentIntentId key (no double claw on re-delivery)",
+    async () => {
+      if (!pgliteReady) return;
+      await seedOrg("100");
+      const key = "stripe:refund:ch_2:5000";
+      for (let i = 0; i < 2; i++) {
+        await creditsService.clawbackCredits({
+          organizationId: ORG_ID,
+          amount: 50,
+          description: "refund clawback",
+          stripePaymentIntentId: key,
+          metadata: { payment_intent_id: "pi_2" },
+        });
+      }
+      expect(await getBalance()).toBeCloseTo(50, 6); // clawed once, not twice
+      expect(await countByType("clawback")).toBe(1);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "getClawedBackUsdForPaymentIntent sums prior clawbacks (for partial-refund deltas)",
+    async () => {
+      if (!pgliteReady) return;
+      await seedOrg("100");
+      await creditsService.clawbackCredits({
+        organizationId: ORG_ID,
+        amount: 30,
+        description: "partial 1",
+        stripePaymentIntentId: "stripe:refund:ch_3:3000",
+        metadata: { payment_intent_id: "pi_3" },
+      });
+      await creditsService.clawbackCredits({
+        organizationId: ORG_ID,
+        amount: 20,
+        description: "partial 2",
+        stripePaymentIntentId: "stripe:refund:ch_3:5000",
+        metadata: { payment_intent_id: "pi_3" },
+      });
+      expect(await creditsService.getClawedBackUsdForPaymentIntent("pi_3")).toBeCloseTo(50, 6);
+      expect(await creditsService.getClawedBackUsdForPaymentIntent("pi_none")).toBe(0);
+      // Balance clawed the full $50 across the two partials.
+      expect(await getBalance()).toBeCloseTo(50, 6);
     },
     PGLITE_TIMEOUT,
   );

--- a/packages/cloud/shared/src/lib/services/credits.ts
+++ b/packages/cloud/shared/src/lib/services/credits.ts
@@ -192,7 +192,9 @@ function toCreditTransaction(row: CreditMutationRow): CreditTransaction {
  */
 export class CreditsService {
   private async applyCreditIncrease(
-    params: AddCreditsParams & { transactionType: "credit" | "refund" },
+    params: AddCreditsParams & {
+      transactionType: "credit" | "refund" | "clawback";
+    },
   ): Promise<{
     transaction: CreditTransaction;
     newBalance: number;
@@ -815,6 +817,61 @@ export class CreditsService {
       });
       return result;
     });
+  }
+
+  /**
+   * Claw back credits after a Stripe refund / chargeback (#10920). Decrements the
+   * balance by `amount` USD, ALLOWING it to go negative — the org was refunded
+   * (or lost a dispute for) credits it may already have spent, so it genuinely
+   * owes the difference; flooring at zero would silently forgive the retained
+   * value. Idempotent on `stripePaymentIntentId` (key it on the refund/dispute so
+   * a re-delivered webhook doesn't double-claw). Records a negative `clawback`
+   * transaction.
+   */
+  async clawbackCredits(params: {
+    organizationId: string;
+    amount: number;
+    description: string;
+    stripePaymentIntentId: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<{ transaction: CreditTransaction; newBalance: number }> {
+    if (params.amount <= 0) {
+      throw new Error("Clawback amount must be positive");
+    }
+
+    const result = await this.applyCreditIncrease({
+      organizationId: params.organizationId,
+      // Negative → the shared path decrements the balance (with no zero floor)
+      // and writes a negative-amount transaction.
+      amount: -params.amount,
+      description: params.description,
+      metadata: params.metadata,
+      stripePaymentIntentId: params.stripePaymentIntentId,
+      transactionType: "clawback",
+    });
+    invalidateOrganizationCache(params.organizationId).catch((error) => {
+      logger.error("[CreditsService] Failed to invalidate org cache:", error);
+    });
+    return result;
+  }
+
+  /**
+   * Total USD already clawed back for a Stripe payment intent (sum of prior
+   * `clawback` debits tagged with it). Lets the refund handler claw back only the
+   * DELTA of a cumulative `amount_refunded` across multiple partial refunds
+   * without double-charging. (#10920)
+   */
+  async getClawedBackUsdForPaymentIntent(paymentIntentId: string): Promise<number> {
+    const rows = await sqlRows<{ total: string | number | null }>(
+      dbWrite,
+      sql`
+        SELECT COALESCE(SUM(-amount), 0) AS total
+        FROM credit_transactions
+        WHERE type = 'clawback'
+          AND metadata->>'payment_intent_id' = ${paymentIntentId}
+      `,
+    );
+    return parseNumeric(rows[0]?.total ?? 0, "clawed_back_total");
   }
 
   /**


### PR DESCRIPTION
Closes #10920.

## The leak
The Stripe queue consumer (`queue/stripe-event.ts`) handled only `checkout.session.completed` / `payment_intent.succeeded` / `.payment_failed`; the `default` branch just logged + acked. So: user tops up \$1000 (`credit_balance += 1000`), spends \$50, then refunds or charge-backs the \$1000 → Stripe reverses the money but **nothing decremented the balance**. The org keeps the money back **and** ~\$950 of still-spendable credits (and eats the ~\$15 dispute fee).

## The fix
- **`clawbackCredits({...})`** — decrements the balance by the reversed USD, **allowing it to go negative** (the org may already have spent the credits, so it genuinely owes the difference; flooring at zero silently forgives it). Idempotent on a `stripePaymentIntentId` key via the existing `ON CONFLICT(stripe_payment_intent_id)` path; writes a negative `clawback` transaction.
- **`getClawedBackUsdForPaymentIntent(pi)`** — sums prior clawbacks so a growing cumulative `amount_refunded` across multiple partial refunds only removes the **delta** (never double-charges).
- **Queue handlers** `charge.refunded` + `charge.dispute.funds_withdrawn`: resolve the charge/dispute → payment intent, confirm a **credit grant** exists for it (a charge that didn't grant org credits is skipped), then claw back the reversed USD (1:1 with top-up credits) via the delta, keyed per `(charge, cumulative amount)` / per dispute so re-delivery is a no-op.

## Evidence
`credits-reconcile.test.ts` gains 3 real-PGlite clawback cases — **11/11**:
```
11 pass  0 fail
```
- decrements the balance **below zero** (\$50 → **−\$50**) and records a negative `clawback` tx
- a re-delivered same-key claw is **idempotent** (clawed once, one `clawback` row)
- `getClawedBackUsdForPaymentIntent` sums two partials to \$50 and the balance reflects the full clawback

`bun run typecheck` + `biome check` clean.

## Scope / operator notes
- Stripe must be **subscribed** to `charge.refunded` + `charge.dispute.funds_withdrawn` in the webhook config for these to fire — the ingress webhook already enqueues every event type it receives, so no ingress change is needed.
- Handlers are thin orchestration over the tested `clawbackCredits` / `getClawedBackUsdForPaymentIntent` primitives (fully covered above). A queue-level handler test can be added under `__tests__/stripe-event-*.test.ts` if desired.
- The clawback removes the consumer credit; if a clawed top-up had funded a monetized app's creator earnings, reversing those is out of scope here (tracked by the earnings-reversal work in #10846/#10910).

🤖 Generated with [Claude Code](https://claude.com/claude-code)