### PR TITLE
ci(cloud): preflight example-code deps before publish (avoid uninstallable package)

### DIFF
--- a/.github/workflows/publish-example-code.yml
+++ b/.github/workflows/publish-example-code.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           filter: blob:none
 
-      - name: Check whether this version is already on npm
+      - name: Decide whether to publish (version-new AND deps installable)
         id: check
         run: |
           set -euo pipefail
@@ -46,13 +46,44 @@ jobs:
           VERSION=$(jq -r .version "$PKG_JSON")
           echo "Package: ${NAME}@${VERSION}"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          # Publish only if this exact name@version is NOT already published.
-          # `npm view` exits non-zero (E404) for an unpublished version.
+
+          # (1) Publish only if this exact name@version is NOT already published.
           if npm view "${NAME}@${VERSION}" version >/dev/null 2>&1; then
             echo "Already published — skipping."
             echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # (2) Preflight: `npm publish` rewrites this package's `workspace:*`
+          # @elizaos/* deps to `^<local monorepo version>`. If those versions are
+          # not on npm, the published package would be UNINSTALLABLE. Refuse to
+          # publish until every @elizaos workspace dep resolves at its local
+          # version — otherwise the monorepo 2.x beta line must be released first.
+          missing=""
+          while read -r dep localver; do
+            [ -z "$dep" ] && continue
+            if ! npm view "${dep}@${localver}" version >/dev/null 2>&1; then
+              missing="${missing} ${dep}@${localver}"
+            fi
+          done < <(
+            jq -r '.dependencies | to_entries[]
+                   | select(.key|startswith("@elizaos/"))
+                   | select(.value|startswith("workspace:"))
+                   | .key' "$PKG_JSON" |
+            while read -r dep; do
+              short="${dep#@elizaos/}"
+              for base in packages plugins; do
+                f="$base/$short/package.json"
+                if [ -f "$f" ]; then echo "$dep $(jq -r .version "$f")"; break; fi
+              done
+            done
+          )
+
+          if [ -n "$missing" ]; then
+            echo "::warning::Skipping publish — @elizaos deps not on npm at the required version(s):${missing}. Release the monorepo 2.x line first (see #10059)."
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
           else
-            echo "Not on npm yet — will publish."
+            echo "Version is new and all @elizaos deps resolve on npm — will publish."
             echo "should_publish=true" >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
Follow-up hardening to #10898 (merged).

**Why:** example-code depends on the monorepo via `workspace:*` (`@elizaos/core`, `plugin-agent-orchestrator`, `plugin-coding-tools`, `plugin-anthropic/openai/mcp/shell/sql`). `npm publish` rewrites those to `^<local version>` = currently `^2.0.3-beta.7`, but **npm only has the old line** (core 1.7.2, agent-orchestrator 0.3.9, …). So publishing now yields a package whose deps don't resolve → **uninstallable**, and the coding-runner's `npm install -g @elizaos/example-code` (cutover step 2) would fail. I caught this and **cancelled** the publish run that #10898's merge triggered (see #10059 for the full analysis).

**Fix:** the check job now preflights — for each `@elizaos/*` `workspace:*` dep, resolve the local monorepo version and verify `npm view <dep>@<localver>` exists. If any is missing → skip publish with a clear `::warning::` (release the 2.x beta line first). Publishes only when the version is new **AND** every `@elizaos` dep is installable from npm.

Net: the workflow is now safe to leave in place — it **self-skips** until eliza-code is genuinely publishable (its deps are on npm), then publishes a correct, installable package. The real step-1 unblock remains the **monorepo 2.x beta npm release** (maintainer/pipeline), tracked on #10059.

cc @lalalune