### PR TITLE
ci(cloud-cf-deploy): make checkout reclaim concurrency-safe (age-based, fixes regression in #10842)

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -104,19 +104,19 @@ jobs:
           # Cancelled/killed deploy runs never reach the trailing "Clean temp
           # checkout" step, so their /tmp/eliza-checkout-* trees (a full ~46k-file
           # monorepo materialization) leak and pile up on this shared self-hosted
-          # box until disk/inodes are exhausted and this run's own materialization
-          # blows its timeout — freezing prod (elizaOS/eliza#10839). Reclaim every
-          # stale checkout dir that is NOT from this run before we materialize ours.
-          # Deploys serialize on this box and the prefix is unique to this workflow,
-          # so nothing live is touched; best-effort, never fails the deploy.
-          reclaimed=0
-          for d in /tmp/eliza-checkout-*; do
-            [ -e "$d" ] || continue
-            case "$d" in /tmp/eliza-checkout-${{ github.run_id }}-*) continue ;; esac
-            timeout 120s rm -rf "$d" 2>/dev/null || echo "::warning::cleanup of $d exceeded 120s (non-fatal)"
-            reclaimed=$((reclaimed + 1))
-          done
-          echo "Reclaimed ${reclaimed} leaked checkout dir(s) from prior runs."
+          # box until disk/inodes are exhausted and materialization times out —
+          # freezing prod (elizaOS/eliza#10839). Reclaim leaked trees, but ONLY
+          # ones idle >90 min: a real deploy job runs <~50 min and self-cleans, so
+          # a dir untouched for 90 min is a definitively-dead leak.
+          # CONCURRENCY-SAFE: push deploys use per-SHA concurrency groups (NOT
+          # serialized), so sibling runs materialize at the same time; the age
+          # filter never deletes another run's actively-writing checkout (its mtime
+          # stays fresh), and we also exclude this run's own dirs by name.
+          # (The prior run_id-only filter deleted concurrent siblings' live
+          # checkouts — this replaces it.) Best-effort; never fails the deploy.
+          stale=$(find /tmp -maxdepth 1 -type d -name 'eliza-checkout-*' -mmin +90 ! -name "eliza-checkout-${{ github.run_id }}-*" 2>/dev/null | wc -l | tr -d ' ')
+          find /tmp -maxdepth 1 -type d -name 'eliza-checkout-*' -mmin +90 ! -name "eliza-checkout-${{ github.run_id }}-*" -exec rm -rf {} + 2>/dev/null || true
+          echo "Reclaimed ${stale} stale (idle >90min) leaked checkout dir(s)."
           df -h /tmp / 2>/dev/null | tail -2 || true
       - name: Checkout repository
         timeout-minutes: 20
@@ -342,19 +342,19 @@ jobs:
           # Cancelled/killed deploy runs never reach the trailing "Clean temp
           # checkout" step, so their /tmp/eliza-checkout-* trees (a full ~46k-file
           # monorepo materialization) leak and pile up on this shared self-hosted
-          # box until disk/inodes are exhausted and this run's own materialization
-          # blows its timeout — freezing prod (elizaOS/eliza#10839). Reclaim every
-          # stale checkout dir that is NOT from this run before we materialize ours.
-          # Deploys serialize on this box and the prefix is unique to this workflow,
-          # so nothing live is touched; best-effort, never fails the deploy.
-          reclaimed=0
-          for d in /tmp/eliza-checkout-*; do
-            [ -e "$d" ] || continue
-            case "$d" in /tmp/eliza-checkout-${{ github.run_id }}-*) continue ;; esac
-            timeout 120s rm -rf "$d" 2>/dev/null || echo "::warning::cleanup of $d exceeded 120s (non-fatal)"
-            reclaimed=$((reclaimed + 1))
-          done
-          echo "Reclaimed ${reclaimed} leaked checkout dir(s) from prior runs."
+          # box until disk/inodes are exhausted and materialization times out —
+          # freezing prod (elizaOS/eliza#10839). Reclaim leaked trees, but ONLY
+          # ones idle >90 min: a real deploy job runs <~50 min and self-cleans, so
+          # a dir untouched for 90 min is a definitively-dead leak.
+          # CONCURRENCY-SAFE: push deploys use per-SHA concurrency groups (NOT
+          # serialized), so sibling runs materialize at the same time; the age
+          # filter never deletes another run's actively-writing checkout (its mtime
+          # stays fresh), and we also exclude this run's own dirs by name.
+          # (The prior run_id-only filter deleted concurrent siblings' live
+          # checkouts — this replaces it.) Best-effort; never fails the deploy.
+          stale=$(find /tmp -maxdepth 1 -type d -name 'eliza-checkout-*' -mmin +90 ! -name "eliza-checkout-${{ github.run_id }}-*" 2>/dev/null | wc -l | tr -d ' ')
+          find /tmp -maxdepth 1 -type d -name 'eliza-checkout-*' -mmin +90 ! -name "eliza-checkout-${{ github.run_id }}-*" -exec rm -rf {} + 2>/dev/null || true
+          echo "Reclaimed ${stale} stale (idle >90min) leaked checkout dir(s)."
           df -h /tmp / 2>/dev/null | tail -2 || true
       - name: Checkout repository
         timeout-minutes: 20
@@ -615,19 +615,19 @@ jobs:
           # Cancelled/killed deploy runs never reach the trailing "Clean temp
           # checkout" step, so their /tmp/eliza-checkout-* trees (a full ~46k-file
           # monorepo materialization) leak and pile up on this shared self-hosted
-          # box until disk/inodes are exhausted and this run's own materialization
-          # blows its timeout — freezing prod (elizaOS/eliza#10839). Reclaim every
-          # stale checkout dir that is NOT from this run before we materialize ours.
-          # Deploys serialize on this box and the prefix is unique to this workflow,
-          # so nothing live is touched; best-effort, never fails the deploy.
-          reclaimed=0
-          for d in /tmp/eliza-checkout-*; do
-            [ -e "$d" ] || continue
-            case "$d" in /tmp/eliza-checkout-${{ github.run_id }}-*) continue ;; esac
-            timeout 120s rm -rf "$d" 2>/dev/null || echo "::warning::cleanup of $d exceeded 120s (non-fatal)"
-            reclaimed=$((reclaimed + 1))
-          done
-          echo "Reclaimed ${reclaimed} leaked checkout dir(s) from prior runs."
+          # box until disk/inodes are exhausted and materialization times out —
+          # freezing prod (elizaOS/eliza#10839). Reclaim leaked trees, but ONLY
+          # ones idle >90 min: a real deploy job runs <~50 min and self-cleans, so
+          # a dir untouched for 90 min is a definitively-dead leak.
+          # CONCURRENCY-SAFE: push deploys use per-SHA concurrency groups (NOT
+          # serialized), so sibling runs materialize at the same time; the age
+          # filter never deletes another run's actively-writing checkout (its mtime
+          # stays fresh), and we also exclude this run's own dirs by name.
+          # (The prior run_id-only filter deleted concurrent siblings' live
+          # checkouts — this replaces it.) Best-effort; never fails the deploy.
+          stale=$(find /tmp -maxdepth 1 -type d -name 'eliza-checkout-*' -mmin +90 ! -name "eliza-checkout-${{ github.run_id }}-*" 2>/dev/null | wc -l | tr -d ' ')
+          find /tmp -maxdepth 1 -type d -name 'eliza-checkout-*' -mmin +90 ! -name "eliza-checkout-${{ github.run_id }}-*" -exec rm -rf {} + 2>/dev/null || true
+          echo "Reclaimed ${stale} stale (idle >90min) leaked checkout dir(s)."
           df -h /tmp / 2>/dev/null | tail -2 || true
       - name: Checkout repository
         timeout-minutes: 20


### PR DESCRIPTION
## Regression in #10842 (mine)
My reclaim step (#10842) removed every `/tmp/eliza-checkout-*` dir **not matching the current run_id**, assuming deploys serialize on the box. They **don't** — push deploys use per-SHA concurrency groups, so multiple runs materialize checkouts on the shared self-hosted box simultaneously. **Observed right now: 6 runs with a Checkout step `in_progress` concurrently.** So each run's reclaim was **deleting sibling runs' actively-materializing checkout trees mid-write**, corrupting/failing their checkout and *adding* churn to the wedge it was meant to fix.

## Fix
Reclaim by **age**, not run_id: only remove `/tmp/eliza-checkout-*` dirs **idle >90 min**. A real deploy job runs <~50 min and self-cleans, so a dir untouched for 90 min is a definitively-dead leak. An actively-writing sibling checkout keeps a fresh mtime → never matched; the current run's dirs are also excluded by name.
```
find /tmp -maxdepth 1 -type d -name 'eliza-checkout-*' -mmin +90 ! -name "eliza-checkout-${run_id}-*" -exec rm -rf {} +
```
Still bounds the disk-exhausting leak accumulation (#10839) without the concurrency footgun. Best-effort; never fails the deploy.

## Verification
YAML validated; all 3 deploy jobs (api/console/app) converted (0 old run_id loops, 3 age-based finds). Portable (no bashisms/process-substitution).

**Urgency:** the current deploy wedge is partly self-inflicted by the #10842 regression under the concurrent-run pileup — this should be merged ahead of the next deploy. cc @lalalune