### PR TITLE
fix(cloud): cold-boot-aware per-job timeout stops double-provisioning a slow agent (#10919)

### DIFF
--- a/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
@@ -440,7 +440,7 @@ const HEALTH_CHECK_POLL_INTERVAL_MS = 3_000;
  * `/api/health` answers over the tailnet; 180s lost that race and failed the
  * provision even though the agent came up. 6 min gives slow cold boots room.
  */
-const HEALTH_CHECK_TIMEOUT_MS = 360_000;
+export const HEALTH_CHECK_TIMEOUT_MS = 360_000;
 
 /** SSH command timeout for docker pull (can be slow on first pull). */
 export const PULL_TIMEOUT_MS = 300_000; // 5 min

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-per-job-timeout.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-per-job-timeout.test.ts
@@ -29,8 +29,9 @@ import { withTimeout } from "../utils/with-timeout";
 // Import the provider's REAL pull ceiling so this test tracks the production
 // constant (and goes red if either drifts), rather than asserting against a
 // hand-copied literal that can silently diverge.
-import { PULL_TIMEOUT_MS } from "./docker-sandbox-provider";
-import { PER_JOB_TIMEOUT_MS } from "./provisioning-jobs";
+import { HEALTH_CHECK_TIMEOUT_MS, PULL_TIMEOUT_MS } from "./docker-sandbox-provider";
+import { JOB_TYPES } from "./provisioning-job-types";
+import { PER_JOB_TIMEOUT_MS, resolvePerJobTimeoutMs } from "./provisioning-jobs";
 
 /** A cold `docker pull` of a freshly-pinned image takes ~2.5 min on the node. */
 const COLD_PULL_MS = 150_000;
@@ -97,5 +98,46 @@ describe("PER_JOB_TIMEOUT_MS sizing (cold-pull orphaning fix)", () => {
     await expect(withTimeout(hungCreate, newCeiling, "job agent_provision")).rejects.toThrow(
       /timed out/,
     );
+  });
+});
+
+/**
+ * Cold-boot-aware per-job timeout (#10919). The flat PER_JOB_TIMEOUT_MS (300s)
+ * matches only the leaf `docker pull` ceiling, not a FULL cold boot
+ * (pull + agent health-check ≈ up to 11 min). At the flat 300s the wrap rejected
+ * a slow cold provision mid-boot → incrementAttempt flipped it to `pending` → a
+ * later poll re-claimed it → a second provision force-removed the first
+ * still-booting container. `resolvePerJobTimeoutMs` fixes this by giving cold-boot
+ * job types the full boot budget.
+ */
+describe("resolvePerJobTimeoutMs — cold-boot job types outlast a full boot (#10919)", () => {
+  /** The real worst-case cold boot: image pull + agent health-check. */
+  const FULL_COLD_BOOT_MS = PULL_TIMEOUT_MS + HEALTH_CHECK_TIMEOUT_MS;
+
+  test("AGENT_PROVISION's per-job timeout exceeds the full cold-boot budget", () => {
+    const timeout = resolvePerJobTimeoutMs(JOB_TYPES.AGENT_PROVISION);
+    // Must clear pull(300s) + health(360s) ≈ 11 min so the wrap can't fire
+    // before a legitimate cold boot finishes (the flat 300s did not).
+    expect(timeout).toBeGreaterThanOrEqual(FULL_COLD_BOOT_MS);
+    expect(timeout).toBeGreaterThan(PER_JOB_TIMEOUT_MS);
+  });
+
+  test("every cold-boot lifecycle type gets the extended budget", () => {
+    for (const type of [
+      JOB_TYPES.AGENT_PROVISION,
+      JOB_TYPES.AGENT_RESUME,
+      JOB_TYPES.AGENT_WAKE,
+      JOB_TYPES.AGENT_RESTART,
+      JOB_TYPES.AGENT_UPGRADE,
+      JOB_TYPES.AGENT_DOWNGRADE,
+    ]) {
+      expect(resolvePerJobTimeoutMs(type)).toBeGreaterThanOrEqual(FULL_COLD_BOOT_MS);
+    }
+  });
+
+  test("fast ops (e.g. AGENT_DELETE) keep the tight flat ceiling", () => {
+    expect(resolvePerJobTimeoutMs(JOB_TYPES.AGENT_DELETE)).toBe(PER_JOB_TIMEOUT_MS);
+    // An unknown/non-lifecycle type also falls back to the flat ceiling.
+    expect(resolvePerJobTimeoutMs("some_other_job")).toBe(PER_JOB_TIMEOUT_MS);
   });
 });

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -737,6 +737,31 @@ const COLD_BOOT_JOB_TYPES: ReadonlySet<ProvisioningJobType> = new Set([
   JOB_TYPES.AGENT_DOWNGRADE,
 ]);
 
+/**
+ * Per-job execution timeout for the `withTimeout(executeJob(job), …)` wrap,
+ * BY JOB TYPE (#10919).
+ *
+ * The flat `PER_JOB_TIMEOUT_MS` (300s) matches only the leaf `docker pull`
+ * ceiling — NOT a full cold boot, which is image-pull (`PULL_TIMEOUT_MS` 300s) +
+ * agent health-check (`HEALTH_CHECK_TIMEOUT_MS` 360s) ≈ up to 11 min. At the flat
+ * 300s, a legitimate slow cold provision had its awaiter rejected mid-boot; the
+ * catch's `incrementAttempt` flipped the still-running job to `pending`, a later
+ * poll re-claimed it (nothing blocks a non-`in_progress` re-claim), and the
+ * second provision collided on the deterministic `agent-<id>` name and
+ * force-removed the first still-booting container — provision flapping on the
+ * exact cold-start path every new dedicated agent hits.
+ *
+ * Cold-boot job types therefore get the same 15-min budget `recoverStaleJobs`
+ * already uses, so the per-job wrap can't fire before a legitimate cold boot
+ * finishes (15 min > ~11 min). Fast ops keep the tight 300s. This is the wrap's
+ * counterpart to the stale-recovery threshold — both are now cold-boot-aware.
+ */
+export function resolvePerJobTimeoutMs(jobType: string): number {
+  return COLD_BOOT_JOB_TYPES.has(jobType as ProvisioningJobType)
+    ? Math.max(PER_JOB_TIMEOUT_MS, COLD_BOOT_STALE_JOB_THRESHOLD_MS)
+    : PER_JOB_TIMEOUT_MS;
+}
+
 export class ProvisioningJobService {
   /**
    * Common path for the seven `enqueueAgent*Once` methods. Acquires the
@@ -1599,8 +1624,15 @@ export class ProvisioningJobService {
         // underlying SSH/headscale I/O — those are themselves bounded. On
         // timeout this throws → the catch below runs incrementAttempt, which
         // flips the row to error/deletion_failed once attempts exhaust;
-        // recoverStaleJobs (5-min in_progress threshold) is the backstop.
-        await withTimeout(this.executeJob(job), PER_JOB_TIMEOUT_MS, `job ${job.type}`);
+        // recoverStaleJobs is the backstop. The timeout is BY JOB TYPE
+        // (resolvePerJobTimeoutMs): cold-boot types get the full ~11-min boot
+        // budget so a slow cold provision is not rejected mid-boot → no
+        // premature incrementAttempt → no re-claim → no double-provision (#10919).
+        await withTimeout(
+          this.executeJob(job),
+          resolvePerJobTimeoutMs(job.type),
+          `job ${job.type}`,
+        );
         result.succeeded++;
       } catch (err) {
         result.failed++;


### PR DESCRIPTION
Closes #10919 (the reported trigger).

## The chain
`recoverStaleJobs` was already made cold-boot-aware (15-min threshold for the lifecycle job types), but the `withTimeout(executeJob(job), PER_JOB_TIMEOUT_MS)` wrap (`provisioning-jobs.ts:1628`) was still a **flat 300s**. That matches only the leaf `docker pull` ceiling — a full cold boot is `PULL_TIMEOUT_MS`(300s) + `HEALTH_CHECK_TIMEOUT_MS`(360s) ≈ up to **11 min**. So on the exact cold-start path every new dedicated agent hits:

1. At T+300s the wrap rejects the awaiter **mid-boot** (`withTimeout` is a pure promise-race; the real provision keeps running).
2. The catch runs `incrementAttempt` → the still-running job (0→1<3) flips to `pending`, `scheduled_for=T+330s`.
3. A later poll **re-claims** it (`claimPendingJobs` only skips `in_progress`; nothing blocks it).
4. The second `docker create --name agent-<id>` collides → misclassified as a port collision → `docker rm -f agent-<id>` **force-removes the first still-booting container**.

## The fix
`resolvePerJobTimeoutMs(jobType)` gives cold-boot job types the same **15-min** budget `recoverStaleJobs` already uses (15 min > ~11 min, so the wrap can't fire before a legitimate cold boot finishes), while fast ops keep the tight 300s. It reuses the existing `COLD_BOOT_JOB_TYPES` set — it's the wrap's counterpart to the already-fixed stale-recovery threshold. This breaks the chain at step 1 for the common slow-cold-boot case.

## Evidence
`provisioning-jobs-per-job-timeout.test.ts` — **6/6** (3 existing + 3 new):
```
6 pass  0 fail
```
- `AGENT_PROVISION`'s per-job timeout now **≥ PULL+HEALTH** (the flat 300s did **not** clear it — asserted against the imported provider constants so it goes red on drift)
- every cold-boot lifecycle type gets the extended budget
- fast ops (`AGENT_DELETE`) + unknown types keep the flat ceiling

Related provisioning suites **29/29**; `bun run typecheck` + `biome check` clean.

## Scope
The issue also lists deeper defenses — an execution-time provisioning mutex in `trySetProvisioning`, and the `create()` `'already in use'` misclassification that force-removes our own booting container. Those need the real docker+SSH stack to verify (the issue itself notes the full fix "needs real testing against external systems") and are left for a coordinated follow-up; this PR closes the reported **trigger** (the premature per-job timeout) deterministically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)