### PR TITLE
fix(cli-inference,core): stop leaking the subscription session-limit string as a user-facing reply

### DIFF
--- a/packages/core/src/services/message/fallback-reply.ts
+++ b/packages/core/src/services/message/fallback-reply.ts
@@ -56,6 +56,12 @@ export function isRateLimitError(error: unknown): boolean {
 		haystack.includes("requests per second") ||
 		haystack.includes("requests per hour") ||
 		haystack.includes("slow down") ||
+		// Subscription-credit exhaustion (Claude/Codex CLI-SDK brains): the SDK
+		// surfaces "you've hit your session/usage limit" when the monthly credit
+		// runs dry. Treat it as a rate limit so the graceful "temporarily
+		// unavailable" reply path handles it instead of leaking the raw string.
+		haystack.includes("session limit") ||
+		haystack.includes("usage limit") ||
 		/\b429\b/.test(haystack)
 	);
 }

--- a/plugins/plugin-cli-inference/__tests__/subscription-limit.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/subscription-limit.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { isClaudeSubscriptionLimitMessage } from "../src/claude-sdk-session.ts";
+
+// Live regression (2026-07-01): when the Agent SDK monthly credit ran dry the SDK
+// ended the turn cleanly but streamed the subscription-limit UI string as the
+// assistant "answer", and the bot relayed it to Discord users verbatim
+// ("You've hit your session limit · resets 9:30pm (UTC)") 7 times.
+describe("isClaudeSubscriptionLimitMessage", () => {
+  it("matches the real leaked subscription-limit strings", () => {
+    expect(
+      isClaudeSubscriptionLimitMessage(
+        "You've hit your session limit · resets 9:30pm (UTC)",
+      ),
+    ).toBe(true);
+    expect(
+      isClaudeSubscriptionLimitMessage(
+        "You've hit your session limit · resets 11:30am (UTC)",
+      ),
+    ).toBe(true);
+    expect(
+      isClaudeSubscriptionLimitMessage(
+        "You've reached your usage limit for this month.",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match genuine model answers, even ones discussing limits", () => {
+    for (const answer of [
+      "Bitcoin is at $58,546 USD right now (via CoinGecko).",
+      "Paris.",
+      "3 minutes. The machines run in parallel so the time never changes.",
+      // a real, long answer that happens to explain rate limits must NOT trip it
+      "The API rate limit is 60 requests per minute and it resets hourly; " +
+        "handle it with exponential backoff so you never exceed the quota in production.",
+    ]) {
+      expect(isClaudeSubscriptionLimitMessage(answer)).toBe(false);
+    }
+  });
+});

--- a/plugins/plugin-cli-inference/src/claude-sdk-session.ts
+++ b/plugins/plugin-cli-inference/src/claude-sdk-session.ts
@@ -49,6 +49,28 @@ const DEFAULT_RESTART_AFTER_TURNS = 20;
 /** Fully-qualified name the SDK assigns our in-process MCP tool. */
 const ROUTE_TOOL = "mcp__eliza__route_action";
 
+/**
+ * When the monthly Agent SDK credit runs dry (documented caveat: the subscription
+ * limit can be hit mid-month), the SDK ends the turn CLEANLY but streams the
+ * subscription limit UI string as the assistant text — e.g. "You've hit your
+ * session limit · resets 9:30pm (UTC)". Without this guard that meta-string is
+ * returned as the turn's completion and relayed verbatim to the user as the reply.
+ * Match the SDK's own limit envelope (a fixed provider string, NOT user content)
+ * so the caller can THROW to failover / a graceful rate-limit reply instead of
+ * leaking it. Kept narrow to the subscription-limit signature to avoid catching a
+ * genuine model answer that happens to discuss limits.
+ */
+export function isClaudeSubscriptionLimitMessage(text: string): boolean {
+  const t = text.trim().toLowerCase();
+  if (t.length > 160) return false; // the real limit string is short; a long answer isn't it
+  return (
+    /\b(hit|reached|exceeded)\b[^.]*\b(session|usage|rate|weekly|daily|monthly)\s+limit\b/.test(
+      t,
+    ) ||
+    (/\blimit\b/.test(t) && /\bresets?\b[^.]*\(utc\)/.test(t))
+  );
+}
+
 /** The model's captured routing decision (ROUTE mode). */
 export interface RouteDecision {
   action: string;
@@ -382,6 +404,18 @@ export class ClaudeSdkSession {
         if (typeof msg.result === "string") resultText = msg.result;
         break;
       }
+    }
+
+    // A dried-up subscription credit ends the turn cleanly but streams the limit
+    // string as the "answer". Detect it BEFORE either mode returns so it fails
+    // over / becomes a graceful rate-limit reply instead of leaking "You've hit
+    // your session limit ..." to the user (route mode would otherwise relay it as
+    // a REPLY, text mode as the completion). "rate limit" in the thrown message
+    // routes it through isRateLimitError.
+    if (sawResult && isClaudeSubscriptionLimitMessage(text)) {
+      throw new Error(
+        `[cli-inference:sdk] subscription rate limit reached: ${text.trim().slice(0, 120)}`,
+      );
     }
 
     if (mode === "route") {


### PR DESCRIPTION
## Problem

When the Claude Agent SDK's monthly subscription credit runs dry, the SDK ends the turn **cleanly** (`result` message arrives) but streams the subscription-limit UI string as the assistant text. The `claude-sdk` brain (`ELIZA_CHAT_VIA_CLI=claude-sdk`) then returns that string as the turn's completion — and the bot relays it **verbatim to end users as its reply**:

> You've hit your session limit · resets 9:30pm (UTC)

Observed **7×** on a live Discord agent (bot.log `Message sent (text=You've hit your session limit · resets ...)`), including as the "answer" to a normal user question. The `plugin-cli-inference` docs already flag this exact caveat ("the monthly Agent SDK credit can run dry mid-month"), but nothing guarded the output path.

## Fix

Two small pieces, reusing the existing failover contract rather than adding a new mechanism:

1. **`claude-sdk-session.ts`** — new `isClaudeSubscriptionLimitMessage()` detects the SDK's own limit envelope (structural signature: short string + `hit/reached … session|usage|rate limit` or `limit … resets …(UTC)`; a >160-char cap so a genuine answer that merely *discusses* rate limits never trips it). Checked once, before **either** mode returns (route mode would relay it as a REPLY, text mode as the completion) → **throws** per the plugin's documented throw-to-failover contract, with "rate limit" in the message.
2. **`fallback-reply.ts`** — the existing `isRateLimitError()` additionally recognizes `session limit` / `usage limit`, so the thrown error routes through the **existing** graceful rate-limit reply path ("temporarily unavailable") instead of leaking.

## Evidence

- Live repro: user asked "whats the current eth price and also the weather in paris?" → delivered reply was the raw limit string (trajectory `tj-cf969a04d3c041`, 2026-07-01).
- `grep -c "Message sent (text=You've hit your session limit" bot.log` → 7 leaked sends before the fix.
- After fix (live-verified on the same agent): limit turns fail over to the graceful rate-limit reply; normal turns unaffected (smoke: "whats 7 times 6" → "42").

## Tests

- New `__tests__/subscription-limit.test.ts`: matches the real leaked strings; rejects genuine answers including a long answer that discusses rate limits.
- Full `plugin-cli-inference` suite: 5 files / 63 tests green on this branch.
- `packages/core` `failure-reply-prompt.test.ts` (exercises `isRateLimitError`): 16/16 green.
- Typecheck clean on both packages.

Related: #10893 (follow-up — automatic failover to a backup tier when the credit is exhausted; this PR stops the leak, that issue restores continuity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
