### PR TITLE
fix(core): give simile-named candidate actions the exact-hint floor so the real action gets exposed

### DIFF
--- a/packages/core/src/runtime/__tests__/action-retrieval.test.ts
+++ b/packages/core/src/runtime/__tests__/action-retrieval.test.ts
@@ -144,6 +144,35 @@ describe("action catalogue and retrieval", () => {
 		});
 	});
 
+	it("exposes a parent whose SIMILE is named as a candidate hint (2026-07-01)", () => {
+		// Live regression: Stage-1 routed "generate an image of a corgi" to the
+		// media context and named the action by its simile GENERATE_IMAGE, but the
+		// real parent is GENERATE_MEDIA. scoreExactHints matched hints only against
+		// the parent's canonical name, so GENERATE_MEDIA got no exact-hint boost,
+		// was never exposed to the planner, and the model reported "no image tool"
+		// even though the action was registered and in-context.
+		const catalog = buildActionCatalog([
+			{
+				name: "GENERATE_MEDIA",
+				description: "Generate or process images, audio, and video.",
+				similes: ["GENERATE_IMAGE", "CREATE_IMAGE", "GENERATE_VIDEO"],
+				tags: ["media"],
+				contexts: ["media", "files"],
+			},
+			{ name: "WEB_SEARCH", description: "Search the web.", similes: [] },
+		]);
+		const response = retrieveActions({
+			catalog,
+			messageText: "generate an image of a corgi wearing sunglasses",
+			candidateActions: ["GENERATE_IMAGE"],
+		});
+		expect(response.results[0]).toMatchObject({
+			name: "GENERATE_MEDIA",
+			score: 1,
+			matchedBy: expect.arrayContaining(["exact"]),
+		});
+	});
+
 	it("matches candidate action namespaces and child names with regex scoring", () => {
 		const catalog = buildActionCatalog(actions);
 		const namespaceResponse = retrieveActions({

--- a/packages/core/src/runtime/action-retrieval.ts
+++ b/packages/core/src/runtime/action-retrieval.ts
@@ -274,6 +274,16 @@ export function retrieveActions(
 	const candidateActions = dedupeNormalizedStrings(input.candidateActions);
 	const parentActionHints = dedupeNormalizedStrings([
 		...(input.parentActionHints ?? []),
+		// A candidate the model named may be a parent's canonical name OR one of
+		// its declared similes — Stage-1 routinely names GENERATE_MEDIA as
+		// "GENERATE_IMAGE". Resolve either form to the canonical parent name so it
+		// earns the exact-hint score floor and is reliably exposed to the planner,
+		// instead of the real action being silently displaced out of the tier cut
+		// (which made the model report "no such tool" for a registered, in-context
+		// action).
+		...candidateActions.flatMap((actionName) =>
+			resolveCandidateToParentNames(input.catalog.parents, actionName),
+		),
 		...candidateActions.flatMap((actionName) =>
 			candidateNamespaceParentExists(input.catalog.parents, actionName)
 				? []
@@ -827,6 +837,32 @@ export function parentAliasesForCandidateAction(actionName: string): string[] {
 	if (parent) return [parent];
 	if (looksLikeViewCandidateAction(normalized)) return ["VIEWS"];
 	return [];
+}
+
+/**
+ * Resolve a candidate action name the model emitted to the canonical parent
+ * name(s) it refers to — matching either the parent's own name or one of its
+ * declared similes. Returns [] when the candidate names no registered parent (a
+ * hallucinated action), so it never fabricates an exposure. Used to give an
+ * in-catalog candidate the exact-hint score floor whether the model named the
+ * canonical action or a simile of it.
+ */
+function resolveCandidateToParentNames(
+	parents: ActionCatalogParent[],
+	candidate: string,
+): string[] {
+	const normalized = normalizeActionName(candidate);
+	if (!normalized) return [];
+	const matches: string[] = [];
+	for (const parent of parents) {
+		if (
+			parent.normalizedName === normalized ||
+			parent.similes.some((simile) => normalizeActionName(simile) === normalized)
+		) {
+			matches.push(parent.normalizedName);
+		}
+	}
+	return matches;
 }
 
 function looksLikeViewCandidateAction(normalizedActionName: string): boolean {


### PR DESCRIPTION
## Problem

Stage-1 (the response handler) routinely names an action by one of its declared **similes** rather than its canonical name — observed live: "generate an image of a corgi" was routed to the `media` context with `candidateActionNames: ["GENERATE_IMAGE"]`, but the registered parent action is `GENERATE_MEDIA` (`GENERATE_IMAGE` is one of its similes).

In `retrieveActions`, candidate names only feed regex/keyword scoring — the exact-hint score floor (`scoreExactHints`) matches **canonical parent names only**. So the real action earned no exact-hint floor, was displaced out of the tier cut by higher-scoring generic actions, and was never exposed to the planner. The planner then saw the simile string with no runnable tool behind it and answered:

> "I can't generate images this turn — no image-generation tool is exposed in my current action set."

…for an action that was registered and in-context. (Diagnosed live on elizaOS/eliza#10819; role gates ruled out — the sender was ADMIN.)

## Fix

`resolveCandidateToParentNames(parents, candidate)`: resolve each model-emitted candidate to the canonical parent name(s) it refers to, matching the parent's own name **or any declared simile**, and feed the result into the existing `parentActionHints` set so it earns the exact-hint score floor. Returns `[]` for a candidate that names no registered parent, so a hallucinated action never fabricates an exposure.

No new scoring stage, no behavior change for canonical-name candidates — just the simile form now resolves to the same floor the canonical form already got.

## Tests

- New regression test: catalog with `GENERATE_MEDIA` (similes `GENERATE_IMAGE`/`CREATE_IMAGE`/`GENERATE_VIDEO`) + candidate `GENERATE_IMAGE` → `GENERATE_MEDIA` ranks first with `score: 1, matchedBy: ["exact"]`.
- Full `action-retrieval` + `action-tiering` suites green on this branch (3 files / 37 tests).
- Typecheck clean.

Part of elizaOS/eliza#10819 (exposure robustness half; the capability-wiring half — cloud IMAGE handler suppression — is tracked separately there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
