### PR TITLE
fix(agent): send wttr.in a non-browser UA so weather WEB_FETCH returns readable data

### DIFF
--- a/packages/agent/src/runtime/custom-actions.ts
+++ b/packages/agent/src/runtime/custom-actions.ts
@@ -655,9 +655,21 @@ async function performGuardedHttpRequest(
     return { ok: false, status: 0, text: "", blocked: true };
   }
 
+  // wttr.in content-negotiates on User-Agent: any "Mozilla" UA gets the
+  // interactive HTML page (and the ?format= param is ignored), while the compact
+  // plain-text weather line the live-info WEB_FETCH actually wants is served only
+  // to a non-browser UA (it is built for `curl wttr.in`). The browser-like
+  // default above exists to satisfy WAF-fronted JSON APIs (coingecko etc.), so
+  // scope the CLI UA to wttr.in rather than changing the global default. A
+  // caller-supplied User-Agent header still wins (set below).
+  const host = parsed.hostname.toLowerCase();
+  const isPlainTextCliHost = host === "wttr.in" || host.endsWith(".wttr.in");
+  const defaultUserAgent = isPlainTextCliHost
+    ? "Eliza/1.0 (+https://elizaos.ai)"
+    : GUARDED_GET_DEFAULT_USER_AGENT;
   // Build headers via the Headers API so a caller-supplied header (in any
   // casing) cleanly overrides the default rather than being comma-joined onto it.
-  const headers = new Headers({ "User-Agent": GUARDED_GET_DEFAULT_USER_AGENT });
+  const headers = new Headers({ "User-Agent": defaultUserAgent });
   if (opts.body !== undefined) headers.set("Content-Type", "application/json");
   if (opts.headers) {
     for (const [key, value] of Object.entries(opts.headers)) {


### PR DESCRIPTION
## Problem

`performGuardedHttpGet` defaults to a browser-like User-Agent (`Mozilla/5.0 … Chrome/124`) — deliberately, so WAF-fronted JSON APIs (coingecko etc.) don't 403 (that default fixed the "every price lookup 403s" bug).

But **wttr.in content-negotiates on User-Agent**: any UA containing `Mozilla` gets the full interactive HTML page and the `?format=` parameter is ignored; the compact plain-text line is served only to non-browser UAs (it's built for `curl wttr.in`). So the live-info weather path broke:

- planner correctly routes "whats the weather in london?" → `WEB_FETCH https://wttr.in/London?format=3`
- fetch returns the HTML/CSS shell with no readable conditions
- the bot honestly punts: *"the London weather fetch came back as the wttr.in page wrapper (CSS/HTML shell) without the actual conditions line … I won't guess one."*

Verified by direct content-negotiation test:
```
UA "Mozilla/5.0 (…)"          → <!DOCTYPE html> …
UA "Eliza/1.0 (+https://…)"   → London: ☀️ +65°F
UA "curl/8.4.0"               → London: ☀️ +65°F
```

## Fix

In `performGuardedHttpRequest` (the single guarded-GET/POST choke point), scope a self-identifying non-browser UA to wttr.in hosts only:

- `wttr.in` / `*.wttr.in` → `Eliza/1.0 (+https://elizaos.ai)`
- every other host keeps the browser-like default (coingecko et al. unaffected)
- a caller-supplied `User-Agent` header still wins (set after the default, as before)

No new function/wrapper — a two-line host check inside the existing header assembly, next to the comment explaining why the browser default exists.

## Evidence (live, before/after on the same agent)

- Before: "whats the weather in london right now?" → *"I hit a snag — the London weather fetch came back as the wttr.in page wrapper (CSS/HTML shell)…"*
- After: "whats the weather in tokyo right now?" → **"Tokyo right now: partly cloudy, around 77°F. 🌤️"** (WEB_FETCH → wttr.in plain text → synthesized)
- Price lookups unaffected: "what is the current price of bitcoin right now?" → "Bitcoin is at $58,546 USD right now (via CoinGecko)."

## Checks

- `packages/agent` typecheck: the only errors are the 7 pre-existing missing-optional-module TS2307s, byte-identical on clean `develop` (verified by re-running against the unmodified base) — zero from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
