### PR TITLE
fix(core): honor an explicit spawn candidate even when Stage-1 contradictorily routes contexts=[simple]

### DIFF
--- a/packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts
+++ b/packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts
@@ -237,6 +237,41 @@ describe("messageHandlerFromFieldResult — bogus candidate actions", () => {
 		);
 	});
 
+	it("force-plans a build ask even when the model routes to SIMPLE context but names TASKS_SPAWN_AGENT (audit 2026-07-01)", () => {
+		// Live regression: for "build the app" the model returned contexts:["simple"]
+		// + candidateActionNames:["TASKS_SPAWN_AGENT"] with a chatty complete-looking
+		// ack ("Yep, you're the boss — I'm building it for you, no argument"). The
+		// complete-direct-reply override treated TASKS_SPAWN_AGENT as a "weak" signal,
+		// and because the context was simple (not a planning context), the
+		// modelCommittedToDelegation guard did NOT fire — so the spawn was suppressed
+		// and the bot CLAIMED to build while never spawning. Fix: an explicit runnable
+		// spawn candidate on a coding-work request is committed delegation regardless
+		// of a contradictory simple context.
+		const handler = messageHandlerFromFieldResult(
+			{
+				shouldRespond: "RESPOND",
+				contexts: ["simple"],
+				candidateActionNames: ["TASKS_SPAWN_AGENT"],
+				replyText:
+					"Yep, you're the boss — I'm building it for you, no argument.",
+				intents: ["build the app", "spawn coding sub-agent"],
+				facts: [],
+				addressedTo: [],
+			},
+			undefined,
+			{
+				actions: REAL_ACTIONS,
+				messageText: "just build the web app for me",
+			},
+		);
+
+		expect(handler.plan.simple).toBe(false);
+		expect(handler.plan.requiresTool).toBe(true);
+		// the simple marker is promoted to a real planning context so the planner runs
+		expect(handler.plan.contexts).toEqual(["general"]);
+		expect(handler.plan.candidateActions).toEqual(["TASKS_SPAWN_AGENT"]);
+	});
+
 	it("still force-plans a genuine build ask when the model only acked", () => {
 		const handler = messageHandlerFromFieldResult(
 			{

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -3753,9 +3753,20 @@ export function messageHandlerFromFieldResult(
 	// candidate backstop (which excludes creative-writing / explanation asks), so
 	// it is model-agnostic and regresses neither the direct-answer nor the
 	// poem-about-an-app path.
+	// An explicit, runnable spawn/delegation candidate in the model's OWN
+	// candidate list — for a message that structurally looks like coding work — is
+	// a firm "delegate this" commitment, and must win EVEN when the model ALSO
+	// (contradictorily) routed contexts=[simple] with a chatty complete-looking
+	// replyText. Previously this also required a non-simple planning context
+	// (`initialPlanningContexts.length > 0`); dropping that requirement closes the
+	// live bug where "build the app" came back with contexts=[simple] +
+	// candidateActionNames=[TASKS_SPAWN_AGENT], so shouldPreferCompleteDirectReply
+	// treated the spawn as "weak", suppressed it, and the bot said "I'm building
+	// it" while never spawning. Still safe: looksLikeCodingWorkRequest excludes
+	// creative-writing / explanation asks, and the candidate must be a REGISTERED
+	// delegation action — so this never fires on a poem or a how-do-I question.
 	const modelCommittedToDelegation =
 		!preemptDirect &&
-		initialPlanningContexts.length > 0 &&
 		looksLikeCodingWorkRequest(currentMessageText) &&
 		modelProvidedRunnableDelegationCandidate(
 			rawCandidateActions,


### PR DESCRIPTION
## Problem

Live regression (demo-critical): for a genuine build request like **"build me a simple hello-world web page"**, Stage-1 sometimes returns the contradictory shape

```
contexts: ["simple"]  +  candidateActionNames: ["TASKS_SPAWN_AGENT"]  +  a chatty complete-looking ack
("Yep, you're the boss — I'm building it for you, no argument.")
```

`modelCommittedToDelegation` — the guard that protects an explicit spawn commitment from the complete-direct-reply override — required a **non-simple planning context** (`initialPlanningContexts.length > 0`). With `contexts=["simple"]` it never fired, so `shouldPreferCompleteDirectReply` treated `TASKS_SPAWN_AGENT` as a weak/injectable signal and kept the ack as the final reply. Net effect: **the bot said "I'm building it" and never spawned anything.**

## Fix

Drop the `initialPlanningContexts.length > 0` requirement from `modelCommittedToDelegation`. An explicit, **runnable** spawn/delegation candidate in the model's own candidate list — for a message that structurally looks like coding work (`looksLikeCodingWorkRequest`) — is a firm "delegate this" commitment, and must win even when the model *also* (contradictorily) routed `contexts=["simple"]`.

Still safe by construction:
- `looksLikeCodingWorkRequest` excludes creative-writing / explanation asks (a poem about an app, "how do I…") — those never trip it;
- the candidate must be a **registered** delegation action (`modelProvidedRunnableDelegationCandidate` resolves against the runtime registry), so a hallucinated action name never forces planning;
- when it fires, the `simple` marker is promoted to a real planning context (`["general"]`), the planner runs, and the spawn executes — the existing non-simple-context path is unchanged.

## Evidence (live, same agent, before/after)

- Before: cozy-dev users asked for builds; trajectory shows `contexts:["simple"] + candidateActionNames:["TASKS_SPAWN_AGENT"]` → ack delivered, no spawn, no app.
- After: "build me a simple hello-world web page please" → `TASKS_SPAWN_AGENT` executed, coding sub-agent built and deployed the page; live at a public URL within ~1 min (trajectory `tj-da1be617f605e3`, 2026-07-01).

## Tests

- New regression test: coding-work message + `contexts:["simple"]` + `candidateActionNames:["TASKS_SPAWN_AGENT"]` + complete-looking replyText → asserts `plan.simple === false`, `plan.requiresTool === true`, contexts promoted to `["general"]`, candidate preserved.
- The neighboring guards keep their existing tests: the non-simple-context spawn case, the only-acked case, and the poem/explanation direct-answer cases all stay green.
- Suites on this branch: `message-handler-bogus-candidates` + `message-routing` + `message-handler-output` → 3 files / 64 tests green. Core typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
