### PR TITLE
fix(core): stop forcing a web search on complete plain-text Stage-1 answers (27s → 5.5s)

### DIFF
--- a/packages/core/src/__tests__/message-routing-live-regression.test.ts
+++ b/packages/core/src/__tests__/message-routing-live-regression.test.ts
@@ -3,6 +3,7 @@ import { parseActionParams } from "../actions";
 import type { Action, ActionResult, IAgentRuntime } from "../index";
 import {
 	actionResultsSuppressPostActionContinuation,
+	applyDirectCurrentCandidateBackstopToMessageHandler,
 	extractPlannerActionNames,
 	findWebLookupActionName,
 	findWebLookupActionNames,
@@ -20,6 +21,84 @@ const logger = {
 	warn: vi.fn(),
 	error: vi.fn(),
 };
+
+describe("plain-text backstop — complete-direct-reply valve (2026-07-01)", () => {
+	// Live regression: the Stage-1 model sometimes answers in plain prose instead
+	// of the structured field envelope. That path (synthesizeSimpleReplyFromPlainText)
+	// runs through applyDirectCurrentCandidateBackstopToMessageHandler, which infers
+	// WEB_FETCH/WEB_SEARCH candidates for almost any interrogative — so a COMPLETE
+	// plain-text answer ("Your lucky number is 4291.", a solved riddle) was promoted
+	// to requiresTool=true and forced through a pointless web search + a slow extra
+	// planner round, while the identical answer in JSON form went direct. The valve
+	// mirrors the structured path's shouldPreferCompleteDirectReply.
+	const WEB_ACTIONS = [
+		{ name: "REPLY" },
+		{ name: "WEB_SEARCH", similes: ["SEARCH_WEB"] },
+		{ name: "WEB_FETCH" },
+		{ name: "TASKS" },
+	] as unknown as ReadonlyArray<Pick<Action, "name" | "similes" | "tags">>;
+	const simplePlainReply = (reply: string) => ({
+		processMessage: "RESPOND" as const,
+		plan: { contexts: ["simple"], reply, simple: true },
+		thought: "",
+	});
+
+	it("keeps a COMPLETE plain-text answer direct instead of forcing a web search", () => {
+		const out = applyDirectCurrentCandidateBackstopToMessageHandler(
+			simplePlainReply("Your lucky number is 4291."),
+			{
+				actions: WEB_ACTIONS,
+				messageText: "my lucky number is 4291. what is my lucky number?",
+			},
+		);
+		// inference DOES tag this with WEB_FETCH/WEB_SEARCH, but the finished
+		// answer + weak signals must win: stays simple, no forced tool.
+		expect(out.plan.simple).not.toBe(false);
+		expect(out.plan.requiresTool).not.toBe(true);
+	});
+
+	it("keeps a solved-reasoning plain-text answer direct", () => {
+		const out = applyDirectCurrentCandidateBackstopToMessageHandler(
+			simplePlainReply(
+				"3 minutes. Each machine makes one widget in 3 minutes, so 100 machines run in parallel and still finish in 3 minutes.",
+			),
+			{
+				actions: WEB_ACTIONS,
+				messageText:
+					"if 3 machines make 3 widgets in 3 minutes, how long for 100 machines to make 100 widgets?",
+			},
+		);
+		expect(out.plan.simple).not.toBe(false);
+		expect(out.plan.requiresTool).not.toBe(true);
+	});
+
+	it("still forces the tool for a live-info ACK reply (not a complete answer)", () => {
+		const out = applyDirectCurrentCandidateBackstopToMessageHandler(
+			simplePlainReply("Checking the current price now."),
+			{
+				actions: WEB_ACTIONS,
+				messageText: "what is the current price of bitcoin right now?",
+			},
+		);
+		// an ack fails looksLikeCompleteDirectReply → live-info still fetches.
+		expect(out.plan.requiresTool).toBe(true);
+		expect(out.plan.candidateActions?.length ?? 0).toBeGreaterThan(0);
+	});
+
+	it("still plans a coding-work request even with a complete-looking reply", () => {
+		const out = applyDirectCurrentCandidateBackstopToMessageHandler(
+			simplePlainReply(
+				"I'll build a simple hello-world web page with an h1 and some basic styling for you.",
+			),
+			{
+				actions: WEB_ACTIONS,
+				messageText: "build me a simple hello-world web page",
+			},
+		);
+		// coding work must not be short-circuited by the complete-reply valve.
+		expect(out.plan.requiresTool).toBe(true);
+	});
+});
 
 describe("live routing regressions", () => {
 	it("extracts inline params from planner action strings", () => {

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -3927,7 +3927,7 @@ function filterRunnableCandidateActions(
 	});
 }
 
-function applyDirectCurrentCandidateBackstopToMessageHandler(
+export function applyDirectCurrentCandidateBackstopToMessageHandler(
 	messageHandler: MessageHandlerResult,
 	runtimeContext:
 		| {
@@ -3960,6 +3960,37 @@ function applyDirectCurrentCandidateBackstopToMessageHandler(
 		runtimeContext,
 	);
 	if (runnableCandidateActions.length === 0) return messageHandler;
+
+	// The structured-envelope path (messageHandlerFromFieldResult) already refuses
+	// to force-plan over a finished answer whose only planning signals are weak,
+	// injectable ones (a simple/general context + search/shell-class candidates)
+	// via shouldPreferCompleteDirectReply. The plain-text fallback lands here
+	// instead and previously skipped that valve, so a COMPLETE plain-text answer
+	// ("Your lucky number is 4291." / a solved logic puzzle) that this backstop
+	// happened to tag with an inferred WEB_SEARCH candidate got promoted to
+	// requiresTool=true — forcing a pointless web search + a slow extra planner
+	// round, even though the identical answer in JSON form (contexts=[simple])
+	// went direct. Apply the same structural valve here so the two Stage-1 shapes
+	// route identically. Live-info stays correct: its Stage-1 reply is an ack
+	// ("Checking the price now."), not a complete answer, so it fails
+	// looksLikeCompleteDirectReply and still forces the fetch. Coding/spawn stays
+	// correct too: a strong (non-weak) candidate fails hasOnlyWeakDirectReplyPlanningSignals.
+	// The extra !looksLikeCodingWorkRequest guard mirrors the structured path's
+	// !modelCommittedToDelegation gate: spawn-class actions (TASKS_SPAWN_AGENT, …)
+	// are ALSO in the weak-override set, so without this a plain-text "build the
+	// app" reply that read as a complete sentence could be kept direct and never
+	// spawn. Restricting the valve to non-coding-work turns keeps the build-spawn
+	// path intact while still short-circuiting finished plain-text answers.
+	if (
+		!looksLikeCodingWorkRequest(currentMessageText) &&
+		shouldPreferCompleteDirectReply({
+			replyText: String(messageHandler.plan.reply ?? ""),
+			candidateActions: runnableCandidateActions,
+			contexts: messageHandler.plan.contexts ?? [],
+		})
+	) {
+		return messageHandler;
+	}
 
 	const planningContexts = (messageHandler.plan.contexts ?? []).filter(
 		(context) => context !== SIMPLE_CONTEXT_ID,
@@ -4097,6 +4128,7 @@ const WEAK_DIRECT_REPLY_OVERRIDE_ACTIONS = new Set(
 		"TASKS",
 		"TASKS_SPAWN_AGENT",
 		"TERMINAL",
+		"WEB_FETCH",
 		"WEB_SEARCH",
 	].map(normalizeActionIdentifier),
 );


### PR DESCRIPTION
## Problem

Stage-1 sometimes answers in **plain prose** instead of the structured field envelope. That path (`synthesizeSimpleReplyFromPlainText`) runs through `applyDirectCurrentCandidateBackstopToMessageHandler`, whose inference tags almost any interrogative with `WEB_FETCH`/`WEB_SEARCH` candidates. The backstop then **unconditionally** promoted the turn to `requiresTool: true` — so a *complete* plain-text answer got forced through a pointless web search plus an extra slow planner round.

Measured live (same question, same agent):

| Stage-1 output shape | Path | Latency |
|---|---|---|
| structured JSON (`contexts:["simple"]`) | direct reply | ~5s |
| plain prose (identical answer) | forced `WEB_SEARCH` + 2 planner rounds | **~27s** |

Examples that hit it live: "my lucky number is 4291. what is my lucky number?" (answer already complete), and a solved logic riddle — both correct answers, both dragged through a web search whose results the evaluator then discarded.

## Fix

Give the plain-text backstop the **same** structural valve the structured-envelope path already uses (`shouldPreferCompleteDirectReply`): a finished answer whose only planning signals are weak/injectable ones (simple/general context + search/shell-class candidates) stays direct. Two adjustments make it exactly equivalent, not looser:

- gated by `!looksLikeCodingWorkRequest(currentMessageText)` — mirroring the structured path's `modelCommittedToDelegation` guard, because spawn-class actions are also in the weak-override set; a plain-text "build the app" reply can never be kept direct.
- `WEB_FETCH` added to `WEAK_DIRECT_REPLY_OVERRIDE_ACTIONS` (`WEB_SEARCH` was already there) — the backstop infers both, and a finished answer tagged with either is the same weak signal.

Live-info stays correct by construction: its Stage-1 reply is an ack ("Checking the price now."), which fails `looksLikeCompleteDirectReply`, so price/weather still force the fetch.

## Evidence (live, before/after)

- Before: riddle → `messageHandler → toolSearch → planner ×2 → tool → evaluation`, `REPLY + WEB_SEARCH`, 27.4s.
- After: same-shape riddle → `messageHandler` only, direct reply, **5.5s**, answer correct ("5 minutes — the printers run in parallel…").
- Live-info regression check after the fix: "what is the current price of bitcoin right now?" → `WEB_FETCH` → "$58,546 (via CoinGecko)" — still fetches.

## Tests

4 new regression tests in `message-routing-live-regression.test.ts`: complete plain-text answer stays direct (2 shapes); live-info **ack** still forces the tool; coding-work request with a complete-looking reply still plans. Suites on this branch: `message-routing-live-regression` + `message-handler-bogus-candidates` → 59/59 green; core typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
