### PR TITLE
test(app): fix per-view interaction e2e (all 33 views) — stub 501 pollers + color-input fill

### DIFF
--- a/packages/app/test/ui-smoke/all-views-interaction.spec.ts
+++ b/packages/app/test/ui-smoke/all-views-interaction.spec.ts
@@ -93,6 +93,12 @@ async function fillOrToggleInput(input: Locator, index: number): Promise<void> {
     await input.fill("42");
     return;
   }
+  if (type === "color") {
+    // A color input only accepts a valid #rrggbb value — filling arbitrary text
+    // (e.g. the Custom background color picker) throws "Malformed value".
+    await input.fill("#3366ff");
+    return;
+  }
   if (type === "email" || label.includes("email")) {
     await input.fill("smoke@example.com");
     return;

--- a/packages/app/test/ui-smoke/helpers.ts
+++ b/packages/app/test/ui-smoke/helpers.ts
@@ -112,6 +112,13 @@ function shouldIgnoreRequestFailure(url: string, failureText: string): boolean {
 function shouldIgnoreHttpError(url: string, status: number): boolean {
   if (status < 400) return true;
   if (url.startsWith("data:") || url.startsWith("blob:")) return true;
+  // Avatar / background EXISTENCE probes: the client's `hasCustomVrm` /
+  // `hasCustomBackground` issue a HEAD to `/api/avatar/vrm|background` with
+  // `allowNonOk` and treat any non-ok response as "no custom asset" (falls back
+  // to the default avatar/background). In the zero-key smoke stack that probe
+  // legitimately answers non-2xx, which is the expected zero-state — the client
+  // handles it and renders the default — not a diagnostic error.
+  if (/\/api\/avatar\/(vrm|background)(\?|$)/.test(url)) return true;
   return false;
 }
 
@@ -1910,6 +1917,58 @@ export async function installDefaultAppRoutes(page: Page): Promise<void> {
       body: JSON.stringify({ data: [] }),
     });
   });
+
+  // LifeOps scheduled-tasks poller — a shell/home-surface GET behind the lifeops
+  // widget that sits under many views. The zero-key smoke stack returns 501; a
+  // fresh agent has no scheduled tasks, so the canonical empty list matches real
+  // zero-state and keeps the diagnostics guard clean.
+  await page.route("**/api/lifeops/scheduled-tasks**", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ scheduledTasks: [], tasks: [] }),
+    });
+  });
+
+  // Files view poller — `GET /api/files` lists stored files (files-routes.ts);
+  // the zero-key smoke stack returns 501. A fresh agent has no stored files, so
+  // the canonical empty list matches real zero-state and keeps diagnostics clean.
+  await page.route("**/api/files", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ files: [] }),
+    });
+  });
+
+  // Avatar / background EXISTENCE probes — `hasCustomVrm` / `hasCustomBackground`
+  // do a HEAD (with `allowNonOk`) and treat any non-ok as "no custom asset"
+  // (falls back to the default). The zero-key smoke stack answers 501 — a 5xx
+  // the per-view diagnostics collectors flag as a server error. A fresh agent
+  // has no custom avatar, so answer a clean 404: the client still falls back to
+  // the default, and a 4xx is the expected zero-state, not a server error.
+  for (const asset of ["vrm", "background"]) {
+    await page.route(`**/api/avatar/${asset}**`, async (route) => {
+      const method = route.request().method();
+      if (method !== "GET" && method !== "HEAD") {
+        await route.fallback();
+        return;
+      }
+      await route.fulfill({
+        status: 404,
+        contentType: "application/json",
+        body: JSON.stringify({ error: `no custom ${asset}` }),
+      });
+    });
+  }
 
   // Approval/needs-attention poller — shell-level GET on the home surface. The
   // zero-key smoke stack has no approval queue, so return the canonical empty


### PR DESCRIPTION
Found by running the every-view interaction e2e against the built app + live-stack stub. The suite (`all-views-interaction.spec.ts` — "exercise every control, no crash" on all **33** default views) failed on **every** view; **now 33/33 pass**.

## Root causes + fixes
1. **Three shell-level pollers 501 from the zero-key stub** (they sit behind every view), tripping both the shared diagnostics guard and the spec's own `>=500` collector:
   - `/api/avatar/vrm` (+ `/background`) — a HEAD existence probe (`hasCustomVrm`/`hasCustomBackground` treat any non-ok as "no custom asset"). Interceptor now answers **404** (a 4xx = expected zero-state), and `shouldIgnoreHttpError` ignores the avatar probes.
   - `/api/lifeops/scheduled-tasks`, `/api/files` — interceptors answer the canonical **empty zero-state** (`{scheduledTasks:[]}`, `{files:[]}`).
2. **Spec crashed on `<input type="color">`** (the `background` view's Custom-background color picker): it filled `"smoke input N"` → "Malformed value" (color inputs need `#rrggbb`). Added a `type === "color"` handler that fills a valid hex.

## Verified
`bun run --cwd packages/app test:e2e -- test/ui-smoke/all-views-interaction.spec.ts --project=chromium` → **33 passed (was 0)**.

Test-infra only; no product code touched. This unblocks the #10719 per-view interaction coverage on the real built app.