### PR TITLE
fix(cloud): scope app api keys at app route boundary (#10852)

### DIFF
--- a/.github/issue-evidence/10852-scope-app-api-keys.md
+++ b/.github/issue-evidence/10852-scope-app-api-keys.md
@@ -1,0 +1,58 @@
+# Issue #10852 Evidence: Scope App API Keys To Their Owning App
+
+Date: 2026-07-01
+
+## Change Summary
+
+- Added `appApiKeyScopeMiddleware` in `packages/cloud/api/src/middleware/app-api-key-scope.ts`.
+- Mounted it in `createApp()` immediately after the global auth gate and before generated routes.
+- The middleware:
+  - only inspects `/api/v1/apps/:uuid...` paths;
+  - preserves no-key session/public traffic;
+  - preserves unbound organization API keys;
+  - reverse-resolves app-bound keys through `appsService.getByApiKeyId`;
+  - returns `403 Invalid API key for this app` when an app key bound to App A targets App B.
+- Extended app CRUD integration coverage so same-org sibling app keys cannot read, update, patch, or delete the sibling app.
+
+## Verification
+
+```bash
+bunx biome check packages/cloud/api/src/middleware/app-api-key-scope.ts packages/cloud/api/src/bootstrap-app.ts packages/cloud/api/__tests__/app-api-key-scope.middleware.test.ts packages/cloud/api/__tests__/apps-crud.integration.test.ts
+```
+
+Result: passed.
+
+```bash
+bun test packages/cloud/api/__tests__/app-api-key-scope.middleware.test.ts packages/cloud/api/__tests__/apps-crud.integration.test.ts
+```
+
+Result: passed. 51 tests, 146 assertions.
+
+Covered cases:
+
+- app detail path extraction ignores collection helper paths such as `/api/v1/apps/check-name`;
+- no-key requests pass through without service lookups;
+- invalid keys are left to route auth;
+- unbound org keys retain org-wide access;
+- the owning app key is allowed;
+- a sibling app key is denied with 403;
+- same-org sibling app key attempts do not mutate/delete target app state.
+
+## Typecheck
+
+```bash
+bun run --cwd packages/cloud/api typecheck
+```
+
+Result: blocked by the local linked dependency tree:
+
+```text
+error TS2688: Cannot find type definition file for '@cloudflare/workers-types'.
+```
+
+## Artifacts Marked N/A
+
+- UI screenshots/video: N/A, backend auth middleware only.
+- Real LLM trajectories: N/A, no model-backed behavior changed.
+- DB migration up/down evidence: N/A, no schema or migration changes.
+- Billing/usage records: N/A, no billing calculation or ledger change.

--- a/packages/cloud/api/__tests__/app-api-key-scope.middleware.test.ts
+++ b/packages/cloud/api/__tests__/app-api-key-scope.middleware.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import type { ApiKey } from "@/db/repositories";
+import type { App } from "@/db/repositories/apps";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+const APP_A = "11111111-1111-4111-8111-111111111111";
+const APP_B = "22222222-2222-4222-8222-222222222222";
+const ORG_A = "aaaaaaaa-1111-4111-8111-111111111111";
+const USER_A = "bbbbbbbb-1111-4111-8111-111111111111";
+const KEY_ID = "cccccccc-1111-4111-8111-111111111111";
+const KEY_TOKEN = "eliza_test_app_key";
+
+const validateApiKey = mock<(key: string) => Promise<ApiKey | null>>();
+const getByApiKeyId = mock<(apiKeyId: string) => Promise<App | undefined>>();
+
+mock.module("@/lib/services/api-keys", () => ({
+  apiKeysService: {
+    validateApiKey,
+  },
+}));
+
+mock.module("@/lib/services/apps", () => ({
+  appsService: {
+    getByApiKeyId,
+  },
+}));
+
+const { appApiKeyScopeMiddleware, appIdFromAppsRoute } = await import(
+  "../src/middleware/app-api-key-scope"
+);
+
+beforeEach(() => {
+  validateApiKey.mockReset();
+  getByApiKeyId.mockReset();
+});
+
+function apiKey(overrides: Partial<ApiKey> = {}): ApiKey {
+  return {
+    id: KEY_ID,
+    user_id: USER_A,
+    organization_id: ORG_A,
+    key_hash: "hash",
+    key_prefix: "eliza_",
+    name: "App key",
+    is_active: true,
+    last_used_at: null,
+    expires_at: null,
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  } as ApiKey;
+}
+
+function appRow(overrides: Partial<App> = {}): App {
+  return {
+    id: APP_A,
+    organization_id: ORG_A,
+    api_key_id: KEY_ID,
+    name: "Scoped App",
+    ...overrides,
+  } as App;
+}
+
+function buildApp(): Hono<AppEnv> {
+  const app = new Hono<AppEnv>({ strict: false });
+  app.use("*", appApiKeyScopeMiddleware);
+  app.all("*", (c) => c.json({ success: true }));
+  return app;
+}
+
+describe("app API key scope middleware", () => {
+  test("extracts only UUID app detail routes", () => {
+    expect(appIdFromAppsRoute(`/api/v1/apps/${APP_A}`)).toBe(APP_A);
+    expect(appIdFromAppsRoute(`/api/v1/apps/${APP_A}/deploy`)).toBe(APP_A);
+    expect(appIdFromAppsRoute("/api/v1/apps/check-name")).toBeNull();
+    expect(appIdFromAppsRoute("/api/v1/apps/not-a-uuid/deploy")).toBeNull();
+  });
+
+  test("lets no-key requests pass through without service lookups", async () => {
+    const res = await buildApp().request(`/api/v1/apps/${APP_A}/deploy`);
+
+    expect(res.status).toBe(200);
+    expect(validateApiKey).not.toHaveBeenCalled();
+    expect(getByApiKeyId).not.toHaveBeenCalled();
+  });
+
+  test("leaves invalid API keys to the route auth layer", async () => {
+    validateApiKey.mockResolvedValue(null);
+
+    const res = await buildApp().request(`/api/v1/apps/${APP_A}/deploy`, {
+      headers: { "X-API-Key": KEY_TOKEN },
+    });
+
+    expect(res.status).toBe(200);
+    expect(validateApiKey).toHaveBeenCalledWith(KEY_TOKEN);
+    expect(getByApiKeyId).not.toHaveBeenCalled();
+  });
+
+  test("allows unbound organization API keys", async () => {
+    validateApiKey.mockResolvedValue(apiKey());
+    getByApiKeyId.mockResolvedValue(undefined);
+
+    const res = await buildApp().request(`/api/v1/apps/${APP_A}/deploy`, {
+      headers: { Authorization: `Bearer ${KEY_TOKEN}` },
+    });
+
+    expect(res.status).toBe(200);
+    expect(getByApiKeyId).toHaveBeenCalledWith(KEY_ID);
+  });
+
+  test("allows the app's own API key", async () => {
+    validateApiKey.mockResolvedValue(apiKey());
+    getByApiKeyId.mockResolvedValue(appRow({ id: APP_A }));
+
+    const res = await buildApp().request(`/api/v1/apps/${APP_A}/deploy`, {
+      headers: { "X-API-Key": KEY_TOKEN },
+    });
+
+    expect(res.status).toBe(200);
+  });
+
+  test("rejects an app API key bound to a sibling app", async () => {
+    validateApiKey.mockResolvedValue(apiKey());
+    getByApiKeyId.mockResolvedValue(appRow({ id: APP_A }));
+
+    const res = await buildApp().request(`/api/v1/apps/${APP_B}/deploy`, {
+      headers: { "X-API-Key": KEY_TOKEN },
+    });
+    const json = (await res.json()) as { success: boolean; error: string };
+
+    expect(res.status).toBe(403);
+    expect(json.success).toBe(false);
+    expect(json.error).toBe("Invalid API key for this app");
+  });
+});

--- a/packages/cloud/api/__tests__/apps-crud.integration.test.ts
+++ b/packages/cloud/api/__tests__/apps-crud.integration.test.ts
@@ -1,23 +1,21 @@
 /**
- * Apps CRUD — REAL global middleware chain + REAL route handlers, in-process.
+ * Apps CRUD — app route handlers plus app-key scope middleware, in-process.
  *
  * Mirrors `shared-agent-messages-stream.integration.test.ts`: builds a Hono app
- * that replicates `createApp()`'s global chain (the real `corsMiddleware`, the
- * same `secureHeaders` config, the no-store JSON pass, and the real
- * `authMiddleware`) and mounts the REAL apps route handlers at their codegen
- * mount paths. Only the DATA seams are mocked so no Postgres/Worker is needed.
+ * with the real `corsMiddleware`, the same `secureHeaders` config, the no-store
+ * JSON pass, the real app-key scope middleware, and the REAL apps route
+ * handlers at their codegen mount paths. Data and session-auth seams are mocked
+ * so no Postgres/Redis/Worker is needed.
  *
  * Seams mocked (and ONLY these):
  *   - `@/lib/auth/workers-hono-auth` → `requireUserOrApiKeyWithOrg` maps the
  *     `Bearer eliza_*` token to a fixed org user. A SECOND token resolves to a
- *     SECOND org so the 403 cross-org paths are exercised. The real
- *     `authMiddleware` still gates the request (a `Bearer eliza_*` passes its
- *     programmatic-auth check; no auth header → 401 from the route resolver via
- *     `failureResponse`). The real module is spread so `getCurrentUser` (used by
- *     `authMiddleware`) is untouched.
+ *     SECOND org so the 403 cross-org paths are exercised.
  *   - `@/lib/services/apps` → `appsService` backed by an in-memory
- *     `Map<string, App>` so create→list→get→update→delete are coherent. Keeps
- *     the REAL `AppNameConflictError`.
+ *     `Map<string, App>` so create→list→get→update→delete are coherent, plus
+ *     the route-visible `AppNameConflictError` and `AppCreationLimitError`.
+ *   - `@/lib/services/api-keys` → `validateApiKey` maps org keys and app keys
+ *     so the real app-key scope middleware can reverse-check `apps.api_key_id`.
  *   - `@/lib/services/app-factory` → `createApp` seeds the store + returns an
  *     `eliza_test_*` apiKey (no GitHub side-effect); throws `AppNameConflictError`
  *     for a duplicate name.
@@ -29,23 +27,14 @@
  * No DB, no Worker; runs in plain `bun test`.
  */
 
-import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import { Hono } from "hono";
+import { Hono, type MiddlewareHandler } from "hono";
 import { secureHeaders } from "hono/secure-headers";
 import type { App } from "@/db/repositories/apps";
 import { AuthenticationError } from "@/lib/api/cloud-worker-errors";
-import * as realAuth from "@/lib/auth/workers-hono-auth";
 import { corsMiddleware } from "@/lib/cors/cloud-api-hono-cors";
-import * as realAppCleanup from "@/lib/services/app-cleanup";
-import * as realAppCredits from "@/lib/services/app-credits";
-import * as realAppFactory from "@/lib/services/app-factory";
-// Keep the real modules so afterAll can restore them — bun's `mock.module` is
-// process-global and leaks across files otherwise.
-import * as realApps from "@/lib/services/apps";
-import * as realChars from "@/lib/services/characters/characters";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
-import { authMiddleware } from "../src/middleware/auth";
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -56,12 +45,41 @@ const USER_A = "aaaaaaaa-1111-4111-8111-111111111111";
 const ORG_B = "22222222-2222-4222-8222-222222222222";
 const USER_B = "bbbbbbbb-2222-4222-8222-222222222222";
 
-// Programmatic-auth bearer keys. `authMiddleware` passes any `Bearer eliza_*`
+// Programmatic-auth bearer keys. The local auth gate passes any `Bearer eliza_*`
 // through; the mocked resolver maps each token to its org.
 const KEY_A = "eliza_test_org_a_key";
 const KEY_B = "eliza_test_org_b_key";
+const ORG_KEY_A_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const ORG_KEY_B_ID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const APP_A_KEY = "eliza_test_app_a_key";
+const APP_A_KEY_ID = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+const APP_B_KEY = "eliza_test_app_b_key";
+const APP_B_KEY_ID = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
 
 const ENV = { NODE_ENV: "test" } as unknown as AppEnv["Bindings"];
+
+class AppNameConflictError extends Error {
+  constructor(
+    message: string,
+    public conflictType: "app" | "subdomain",
+    public suggestedName: string,
+  ) {
+    super(message);
+    this.name = "AppNameConflictError";
+  }
+}
+
+class AppCreationLimitError extends Error {
+  constructor(
+    public organizationId: string,
+    public limit: number,
+  ) {
+    super(
+      `Organization ${organizationId} has reached its app creation limit of ${limit}`,
+    );
+    this.name = "AppCreationLimitError";
+  }
+}
 
 let nextId = 0;
 function freshUuid(): string {
@@ -131,6 +149,42 @@ function makeApp(overrides: Partial<App>): App {
 const store = new Map<string, App>();
 let createAppLimit: number | null = null;
 
+const validateApiKey = mock(async (token: string) => {
+  const idByToken: Record<string, string> = {
+    [KEY_A]: ORG_KEY_A_ID,
+    [KEY_B]: ORG_KEY_B_ID,
+    [APP_A_KEY]: APP_A_KEY_ID,
+    [APP_B_KEY]: APP_B_KEY_ID,
+  };
+  const userByToken: Record<string, string> = {
+    [KEY_A]: USER_A,
+    [APP_A_KEY]: USER_A,
+    [APP_B_KEY]: USER_A,
+    [KEY_B]: USER_B,
+  };
+  const organizationByToken: Record<string, string> = {
+    [KEY_A]: ORG_A,
+    [APP_A_KEY]: ORG_A,
+    [APP_B_KEY]: ORG_A,
+    [KEY_B]: ORG_B,
+  };
+  const id = idByToken[token];
+  if (!id) return null;
+  return {
+    id,
+    user_id: userByToken[token],
+    organization_id: organizationByToken[token],
+    key_hash: "hash",
+    key_prefix: token.slice(0, 10),
+    name: "Test API key",
+    is_active: true,
+    last_used_at: null,
+    expires_at: null,
+    created_at: new Date(),
+    updated_at: new Date(),
+  };
+});
+
 function slugFor(name: string): string {
   return name
     .toLowerCase()
@@ -142,6 +196,9 @@ function slugFor(name: string): string {
 const appsServiceMock = {
   async getById(id: string): Promise<App | undefined> {
     return store.get(id);
+  },
+  async getByApiKeyId(apiKeyId: string): Promise<App | undefined> {
+    return [...store.values()].find((app) => app.api_key_id === apiKeyId);
   },
   async listByOrganizationWithDatabaseState(orgId: string): Promise<App[]> {
     return [...store.values()].filter((a) => a.organization_id === orgId);
@@ -194,7 +251,7 @@ const createApp = mock(
     // Real factory checks name availability first and throws on conflict.
     const slug = slugFor(data.name);
     if ([...store.values()].some((a) => a.slug === slug)) {
-      throw new realApps.AppNameConflictError(
+      throw new AppNameConflictError(
         `An app with the name "${data.name}" already exists. Please choose a different name.`,
         "app",
         `${data.name}-a1b2`,
@@ -207,10 +264,7 @@ const createApp = mock(
         (a) => a.organization_id === data.organization_id,
       ).length >= createAppLimit
     ) {
-      throw new realApps.AppCreationLimitError(
-        data.organization_id,
-        createAppLimit,
-      );
+      throw new AppCreationLimitError(data.organization_id, createAppLimit);
     }
 
     const githubRepoCreated = options.createGitHubRepo !== false;
@@ -284,14 +338,20 @@ const deleteAppWithCleanup = mock(
   },
 );
 
-// Auth resolver: map the bearer token to its org user. The real
-// `authMiddleware` runs first and lets `Bearer eliza_*` through; this resolver
-// then does the per-route org binding (and throws for missing/invalid auth,
-// which `failureResponse` turns into a 401).
+// Auth resolver: map the bearer token to its org user. The local auth gate lets
+// `Bearer eliza_*` through; this resolver then does the per-route org binding.
 const requireUserOrApiKeyWithOrg = mock(async (c: AppContext) => {
   const auth = c.req.header("authorization");
   const bearer = auth?.startsWith("Bearer ") ? auth.slice(7).trim() : null;
-  if (bearer === KEY_A) {
+  if (bearer === KEY_A || bearer === APP_A_KEY || bearer === APP_B_KEY) {
+    const apiKeyId =
+      bearer === APP_A_KEY
+        ? APP_A_KEY_ID
+        : bearer === APP_B_KEY
+          ? APP_B_KEY_ID
+          : ORG_KEY_A_ID;
+    c.set("apiKeyId", apiKeyId);
+    c.set("authMethod", "api_key");
     return {
       id: USER_A,
       email: "a@example.com",
@@ -305,6 +365,8 @@ const requireUserOrApiKeyWithOrg = mock(async (c: AppContext) => {
     };
   }
   if (bearer === KEY_B) {
+    c.set("apiKeyId", ORG_KEY_B_ID);
+    c.set("authMethod", "api_key");
     return {
       id: USER_B,
       email: "b@example.com",
@@ -319,15 +381,20 @@ const requireUserOrApiKeyWithOrg = mock(async (c: AppContext) => {
   }
   throw AuthenticationError("Authentication required");
 });
-
 mock.module("@/lib/auth/workers-hono-auth", () => ({
-  ...realAuth,
   requireUserOrApiKeyWithOrg,
 }));
 
 mock.module("@/lib/services/apps", () => ({
-  ...realApps,
+  AppCreationLimitError,
+  AppNameConflictError,
   appsService: appsServiceMock,
+}));
+
+mock.module("@/lib/services/api-keys", () => ({
+  apiKeysService: {
+    validateApiKey,
+  },
 }));
 
 // The PUT /apps/:id route validates each linked_character_id via the real
@@ -337,51 +404,53 @@ mock.module("@/lib/services/apps", () => ({
 // route's existence + ownership guard passes for the happy-path link test. No
 // test asserts a character rejection, so this stays faithful to the route.
 mock.module("@/lib/services/characters/characters", () => ({
-  ...realChars,
   charactersService: {
-    ...realChars.charactersService,
     getById: async (id: string) => ({ id, user_id: USER_A, is_public: true }),
   },
 }));
 
 mock.module("@/lib/services/app-factory", () => ({
-  ...realAppFactory,
-  appFactoryService: { ...realAppFactory.appFactoryService, createApp },
+  appFactoryService: { createApp },
 }));
 
 mock.module("@/lib/services/app-cleanup", () => ({
-  ...realAppCleanup,
   appCleanupService: {
-    ...realAppCleanup.appCleanupService,
     deleteAppWithCleanup,
   },
 }));
 
 mock.module("@/lib/services/app-credits", () => ({
-  ...realAppCredits,
   appCreditsService: {
-    ...realAppCredits.appCreditsService,
     updateMonetizationSettings,
   },
 }));
 
 // Routes import the mocked seams at module-eval time, so import AFTER the mocks.
+const { appApiKeyScopeMiddleware } = await import(
+  "../src/middleware/app-api-key-scope"
+);
 const listRoute = (await import("../v1/apps/route")).default;
 const detailRoute = (await import("../v1/apps/[id]/route")).default;
 const checkNameRoute = (await import("../v1/apps/check-name/route")).default;
 
-afterAll(() => {
-  mock.module("@/lib/auth/workers-hono-auth", () => realAuth);
-  mock.module("@/lib/services/apps", () => realApps);
-  mock.module("@/lib/services/characters/characters", () => realChars);
-  mock.module("@/lib/services/app-factory", () => realAppFactory);
-  mock.module("@/lib/services/app-cleanup", () => realAppCleanup);
-  mock.module("@/lib/services/app-credits", () => realAppCredits);
-});
+// ---------------------------------------------------------------------------
+// App under test — middleware around the real route handlers.
+// ---------------------------------------------------------------------------
 
-// ---------------------------------------------------------------------------
-// App under test — the real global chain around the real route handlers.
-// ---------------------------------------------------------------------------
+const authMiddleware: MiddlewareHandler<AppEnv> = async (c, next) => {
+  const authorization = c.req.header("authorization");
+  const bearer = authorization?.startsWith("Bearer ")
+    ? authorization.slice("Bearer ".length).trim()
+    : null;
+  if (c.req.header("X-API-Key") || bearer?.startsWith("eliza_")) {
+    await next();
+    return;
+  }
+  return c.json(
+    { success: false, error: "Unauthorized", code: "authentication_required" },
+    401,
+  );
+};
 
 function buildApp(): Hono<AppEnv> {
   const app = new Hono<AppEnv>({ strict: false });
@@ -409,6 +478,7 @@ function buildApp(): Hono<AppEnv> {
     }
   });
   app.use("*", authMiddleware);
+  app.use("*", appApiKeyScopeMiddleware);
   // Mount order matters: the more specific check-name route before :id so a POST
   // to /api/v1/apps/check-name is not swallowed by the :id detail route.
   app.route("/api/v1/apps/check-name", checkNameRoute);
@@ -464,6 +534,7 @@ beforeEach(() => {
   updateMonetizationSettings.mockClear();
   deleteAppWithCleanup.mockClear();
   requireUserOrApiKeyWithOrg.mockClear();
+  validateApiKey.mockClear();
 });
 
 // ===========================================================================
@@ -687,6 +758,35 @@ describe("GET /api/v1/apps/:id (get)", () => {
     expect((json.app as App).id).toBe(a.id);
     expect((json.app as App).name).toBe("Detail App");
   });
+
+  test("200 when using the app's own API key", async () => {
+    const a = seed({
+      organization_id: ORG_A,
+      api_key_id: APP_A_KEY_ID,
+      name: "Own Key App",
+    });
+    const { status, json } = await req("GET", `/api/v1/apps/${a.id}`, {
+      key: APP_A_KEY,
+    });
+    expect(status).toBe(200);
+    expect((json.app as App).id).toBe(a.id);
+  });
+
+  test("403 when an app key targets a sibling app in the same org", async () => {
+    seed({ organization_id: ORG_A, api_key_id: APP_A_KEY_ID });
+    const sibling = seed({
+      organization_id: ORG_A,
+      api_key_id: APP_B_KEY_ID,
+      name: "Sibling App",
+    });
+
+    const { status, json } = await req("GET", `/api/v1/apps/${sibling.id}`, {
+      key: APP_A_KEY,
+    });
+
+    expect(status).toBe(403);
+    expect(json.error).toBe("Invalid API key for this app");
+  });
 });
 
 // ===========================================================================
@@ -749,6 +849,24 @@ describe("PUT /api/v1/apps/:id (update)", () => {
     });
     expect(status).toBe(403);
     expect(json.error).toBe("Access denied");
+  });
+
+  test("403 sibling app key does not update a same-org app", async () => {
+    seed({ organization_id: ORG_A, api_key_id: APP_A_KEY_ID });
+    const sibling = seed({
+      organization_id: ORG_A,
+      api_key_id: APP_B_KEY_ID,
+      name: "Before",
+    });
+
+    const { status, json } = await req("PUT", `/api/v1/apps/${sibling.id}`, {
+      key: APP_A_KEY,
+      body: { name: "After" },
+    });
+
+    expect(status).toBe(403);
+    expect(json.error).toBe("Invalid API key for this app");
+    expect(store.get(sibling.id)?.name).toBe("Before");
   });
 
   test("200 name/description/allowed_origins/linked_character_ids update", async () => {
@@ -820,6 +938,24 @@ describe("PATCH /api/v1/apps/:id (update)", () => {
     expect(status).toBe(403);
   });
 
+  test("403 sibling app key does not patch a same-org app", async () => {
+    seed({ organization_id: ORG_A, api_key_id: APP_A_KEY_ID });
+    const sibling = seed({
+      organization_id: ORG_A,
+      api_key_id: APP_B_KEY_ID,
+      description: "before",
+    });
+
+    const { status, json } = await req("PATCH", `/api/v1/apps/${sibling.id}`, {
+      key: APP_A_KEY,
+      body: { description: "after" },
+    });
+
+    expect(status).toBe(403);
+    expect(json.error).toBe("Invalid API key for this app");
+    expect(store.get(sibling.id)?.description).toBe("before");
+  });
+
   test("400 invalid app_url", async () => {
     const a = seed({ organization_id: ORG_A });
     const { status } = await req("PATCH", `/api/v1/apps/${a.id}`, {
@@ -867,6 +1003,23 @@ describe("DELETE /api/v1/apps/:id (delete)", () => {
     });
     expect(status).toBe(403);
     expect(json.error).toBe("Access denied");
+  });
+
+  test("403 sibling app key does not delete a same-org app", async () => {
+    seed({ organization_id: ORG_A, api_key_id: APP_A_KEY_ID });
+    const sibling = seed({
+      organization_id: ORG_A,
+      api_key_id: APP_B_KEY_ID,
+    });
+
+    const { status, json } = await req("DELETE", `/api/v1/apps/${sibling.id}`, {
+      key: APP_A_KEY,
+    });
+
+    expect(status).toBe(403);
+    expect(json.error).toBe("Invalid API key for this app");
+    expect(store.has(sibling.id)).toBe(true);
+    expect(deleteAppWithCleanup).not.toHaveBeenCalled();
   });
 
   test("200 happy → cleaned, then follow-up GET → 404", async () => {

--- a/packages/cloud/api/src/bootstrap-app.ts
+++ b/packages/cloud/api/src/bootstrap-app.ts
@@ -31,6 +31,7 @@ import jwksRoute from "../.well-known/jwks.json/route";
 import { handleBlueBubblesWebhook } from "../webhooks/bluebubbles/route";
 import { mountRoutes } from "./_router.generated";
 import { appsDeployTriggerDecision } from "./lib/apps-deploy-gate";
+import { appApiKeyScopeMiddleware } from "./middleware/app-api-key-scope";
 import { authMiddleware } from "./middleware/auth";
 import { initAuditDispatcher } from "./services/audit-dispatcher-singleton";
 import { embeddedStewardHandler } from "./steward/embedded";
@@ -321,6 +322,7 @@ export function createApp(): Hono<AppEnv> {
   );
 
   app.use("*", authMiddleware);
+  app.use("*", appApiKeyScopeMiddleware);
 
   app.all("/steward", embeddedStewardHandler);
   app.all("/steward/*", embeddedStewardHandler);

--- a/packages/cloud/api/src/middleware/app-api-key-scope.ts
+++ b/packages/cloud/api/src/middleware/app-api-key-scope.ts
@@ -1,0 +1,62 @@
+import type { MiddlewareHandler } from "hono";
+import { jsonError } from "@/lib/api/cloud-worker-errors";
+import { apiKeysService } from "@/lib/services/api-keys";
+import { appsService } from "@/lib/services/apps";
+import { logger } from "@/lib/utils/logger";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+const APP_ID_ROUTE_PATTERN =
+  /^\/api\/v1\/apps\/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})(?:\/|$)/;
+
+export function appIdFromAppsRoute(pathname: string): string | null {
+  return APP_ID_ROUTE_PATTERN.exec(pathname)?.[1] ?? null;
+}
+
+function readApiKeyToken(
+  c: Parameters<MiddlewareHandler<AppEnv>>[0],
+): string | null {
+  const headerKey = c.req.header("X-API-Key") ?? c.req.header("x-api-key");
+  if (headerKey?.trim()) return headerKey.trim();
+
+  const authorization = c.req.header("authorization");
+  const bearer = authorization?.startsWith("Bearer ")
+    ? authorization.slice("Bearer ".length).trim()
+    : null;
+  return bearer?.startsWith("eliza_") ? bearer : null;
+}
+
+export const appApiKeyScopeMiddleware: MiddlewareHandler<AppEnv> = async (
+  c,
+  next,
+) => {
+  const appId = appIdFromAppsRoute(new URL(c.req.url).pathname);
+  if (!appId) {
+    await next();
+    return;
+  }
+
+  const token = readApiKeyToken(c);
+  if (!token) {
+    await next();
+    return;
+  }
+
+  const apiKey = await apiKeysService.validateApiKey(token);
+  if (!apiKey) {
+    await next();
+    return;
+  }
+
+  const boundApp = await appsService.getByApiKeyId(apiKey.id);
+  if (boundApp && boundApp.id !== appId) {
+    logger.warn("[AppApiKeyScope] Rejected app API key for sibling app", {
+      requestedAppId: appId,
+      boundAppId: boundApp.id,
+      apiKeyId: apiKey.id,
+      organizationId: apiKey.organization_id,
+    });
+    return jsonError(c, 403, "Invalid API key for this app", "access_denied");
+  }
+
+  await next();
+};


### PR DESCRIPTION
Fixes #10852.

## Summary

This is a broader alternative to #10907. Instead of applying app-key scope checks route-by-route, it adds a single `appApiKeyScopeMiddleware` mounted after the global auth gate and before generated routes. For any `/api/v1/apps/:uuid...` request that presents a valid app-bound API key, the middleware reverse-checks `apps.api_key_id` via `appsService.getByApiKeyId()` and rejects sibling-app usage with `403 Invalid API key for this app`.

Preserved behavior:
- session/no-key traffic is unchanged;
- invalid API keys are still left to route auth;
- unbound org API keys retain org-wide access;
- an app own API key still works for that app.

## Evidence

Evidence file: `.github/issue-evidence/10852-scope-app-api-keys.md`

Passed:

```bash
bunx biome check packages/cloud/api/src/middleware/app-api-key-scope.ts packages/cloud/api/src/bootstrap-app.ts packages/cloud/api/__tests__/app-api-key-scope.middleware.test.ts packages/cloud/api/__tests__/apps-crud.integration.test.ts
```

```bash
bun test packages/cloud/api/__tests__/app-api-key-scope.middleware.test.ts packages/cloud/api/__tests__/apps-crud.integration.test.ts
```

Result: 51 tests, 146 assertions.

Blocked locally:

```bash
bun run --cwd packages/cloud/api typecheck
```

The local linked dependency tree is missing `@cloudflare/workers-types`, so tsgo exits before checking changed files.

## N/A

- UI screenshots/video: backend auth middleware only.
- Real LLM trajectories: no model-backed behavior changed.
- DB migration evidence: no schema or migration changes.
