### PR TITLE
fix(core): restore PII in early replies

### DIFF
--- a/.github/issue-evidence/10827-pii-reply-boundary.md
+++ b/.github/issue-evidence/10827-pii-reply-boundary.md
@@ -1,0 +1,52 @@
+# Issue #10827 - PII Reply Boundary Evidence
+
+Date: 2026-07-01
+Branch: `fix/10827-pii-reply-boundary`
+
+## Change Verified
+
+- `develop` already contains the merged #10943 final-response fix in `restorePiiInUserReplyText` / `createV5ReplyStrategyResult`.
+- This branch adds the missing response-handler early-reply egress restore, so the visible early callback receives real values too.
+- This branch adds higher-level Stage 1/planner regressions proving direct reply, terminal `messageToUser`, terminal `REPLY`, and early-reply behavior through `runV5MessageRuntimeStage1`.
+- The regressions leave Stage 1/planner internals redacted: `messageHandler.plan.reply` and the planner model context contain the surrogate, not `Dana Whitfield`.
+
+## Manual Review
+
+I inspected the focused regression assertions in `packages/core/src/__tests__/message-runtime-stage1.test.ts`:
+
+- Direct/simple reply returns `I can email Dana Whitfield at Acme Robotics.` while the message-handler plan keeps the surrogate reply.
+- Terminal planner `messageToUser` returns `Dana Whitfield is available for the renewal call.` while the planner context contains the surrogate and does not contain `Dana Whitfield`.
+- Terminal planner `REPLY` tool-call text returns `I can follow up with Dana Whitfield.`
+- Early response-handler reply callback receives `I'll check Dana Whitfield's status.`, while planner context still receives the surrogate early-reply text.
+
+## Commands Run
+
+```bash
+bun run --cwd packages/core test message-runtime-stage1.test.ts pii-swap-reply-egress.test.ts pii-swap-egress.test.ts pii-swap-use-model.test.ts
+```
+
+Result: 4 test files passed, 90 tests passed.
+
+```bash
+bunx @biomejs/biome@2.5.1 check packages/core/src/services/message.ts packages/core/src/__tests__/message-runtime-stage1.test.ts
+```
+
+Result: checked 2 files, no fixes applied.
+
+Note: I also tried including the already-merged `packages/core/src/runtime/__tests__/pii-swap-reply-egress.test.ts` in the Biome command. Biome reported an import-order issue in that pre-existing `develop` file, so the clean Biome evidence above is scoped to this branch's changed files.
+
+```bash
+bun run --cwd packages/core typecheck
+```
+
+Result: `tsgo --noEmit -p ./tsconfig.json` completed successfully.
+
+```bash
+git diff --check
+```
+
+Result: no whitespace errors.
+
+## Screenshots / Recordings
+
+N/A for this patch: the changed surface is a core backend privacy boundary with no UI files touched. The user-facing artifact is the returned reply content, covered by the focused regressions above. A live chat capture against a running app/model remains useful PR evidence if the branch is taken all the way to a PR, but it was not required to validate the code path changed here.

--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -6,9 +6,14 @@ import type { ResponseHandlerEvaluator } from "../runtime/response-handler-evalu
 import type { ResponseHandlerFieldEvaluator } from "../runtime/response-handler-field-evaluator";
 import { ResponseHandlerFieldRegistry } from "../runtime/response-handler-field-registry";
 import {
+	GazetteerEntityRecognizer,
+	PseudonymSession,
+} from "../security/index.js";
+import {
 	messageHandlerFromFieldResult,
 	runV5MessageRuntimeStage1,
 } from "../services/message";
+import { runWithTrajectoryContext } from "../trajectory-context";
 import type { Memory } from "../types/memory";
 import { ModelType } from "../types/model";
 import { ChannelType, type UUID } from "../types/primitives";
@@ -174,6 +179,35 @@ function makeRuntime(
 	} as IAgentRuntime;
 }
 
+function makePiiSession(): PseudonymSession {
+	return new PseudonymSession({
+		salt: "fixed",
+		recognizer: new GazetteerEntityRecognizer([
+			{ kind: "person", value: "Dana Whitfield" },
+			{ kind: "org", value: "Acme Robotics" },
+		]),
+	});
+}
+
+async function seededPiiSession(): Promise<{
+	session: PseudonymSession;
+	dana: string;
+	acme: string;
+}> {
+	const session = makePiiSession();
+	await session.learn("Dana Whitfield works at Acme Robotics.");
+	const dana = session.entries.find(
+		(entry) => entry.value === "Dana Whitfield",
+	)?.surrogate;
+	const acme = session.entries.find(
+		(entry) => entry.value === "Acme Robotics",
+	)?.surrogate;
+	if (!dana || !acme) {
+		throw new Error("PII test session did not mint expected surrogates");
+	}
+	return { session, dana, acme };
+}
+
 describe("runV5MessageRuntimeStage1", () => {
 	it("keeps the message pipeline from laundering missing planner inputs through empty fallbacks", async () => {
 		const source = await readFile(
@@ -256,6 +290,128 @@ describe("runV5MessageRuntimeStage1", () => {
 		);
 		if (result.kind === "direct_reply") {
 			expect(result.result.responseContent?.text).toBe("Hello.");
+		}
+	});
+
+	it("restores PII surrogates at the direct reply boundary only", async () => {
+		const { session, dana, acme } = await seededPiiSession();
+		const redactedReply = `I can email ${dana} at ${acme}.`;
+		const runtime = makeRuntime([
+			stage1Response({
+				thought: "Direct answer.",
+				contexts: ["simple"],
+				replyText: redactedReply,
+			}),
+		]);
+
+		const result = await runWithTrajectoryContext(
+			{ runId: "pii-direct-reply", piiSwapSession: session },
+			() =>
+				runV5MessageRuntimeStage1({
+					runtime,
+					message: makeMessage(),
+					state: makeState(),
+					responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+				}),
+		);
+
+		expect(result.kind).toBe("direct_reply");
+		expect(result.messageHandler.plan.reply).toBe(redactedReply);
+		expect(result.messageHandler.plan.reply).not.toContain("Dana Whitfield");
+		if (result.kind === "direct_reply") {
+			expect(result.result.responseContent?.text).toBe(
+				"I can email Dana Whitfield at Acme Robotics.",
+			);
+			expect(result.result.responseMessages[0]?.content.text).toBe(
+				"I can email Dana Whitfield at Acme Robotics.",
+			);
+		}
+	});
+
+	it("restores terminal planner messageToUser while keeping planner context redacted", async () => {
+		const { session, dana } = await seededPiiSession();
+		const earlyRedactedReply = `I'll check ${dana}'s status.`;
+		const runtime = makeRuntime([
+			stage1Response({
+				thought: "Acknowledge, then plan.",
+				contexts: ["general"],
+				replyText: earlyRedactedReply,
+				extra: { requiresTool: true },
+			}),
+			JSON.stringify({
+				thought: "Finished.",
+				toolCalls: [],
+				messageToUser: `${dana} is available for the renewal call.`,
+			}),
+		]);
+		const earlyReply = vi.fn(async () => undefined);
+
+		const result = await runWithTrajectoryContext(
+			{ runId: "pii-planner-message-to-user", piiSwapSession: session },
+			() =>
+				runV5MessageRuntimeStage1({
+					runtime,
+					message: makeMessage(),
+					state: makeState(),
+					responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+					onResponseHandlerEarlyReply: earlyReply,
+				}),
+		);
+
+		expect(earlyReply).toHaveBeenCalledWith(
+			expect.objectContaining({
+				text: "I'll check Dana Whitfield's status.",
+			}),
+		);
+		const plannerParams = JSON.stringify(useModelCalls(runtime)[1]?.[1] ?? {});
+		expect(plannerParams).toContain(dana);
+		expect(plannerParams).not.toContain("Dana Whitfield");
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind === "planned_reply") {
+			expect(result.result.responseContent?.text).toBe(
+				"Dana Whitfield is available for the renewal call.",
+			);
+		}
+	});
+
+	it("restores terminal planner REPLY text at final delivery", async () => {
+		const { session, dana } = await seededPiiSession();
+		const runtime = makeRuntime([
+			stage1Response({
+				thought: "Planner should provide the terminal reply.",
+				contexts: ["general"],
+				extra: { requiresTool: true },
+			}),
+			{
+				text: "",
+				toolCalls: [
+					{
+						id: "reply-1",
+						name: "REPLY",
+						arguments: {
+							text: `I can follow up with ${dana}.`,
+						},
+					},
+				],
+			},
+		]);
+
+		const result = await runWithTrajectoryContext(
+			{ runId: "pii-terminal-reply", piiSwapSession: session },
+			() =>
+				runV5MessageRuntimeStage1({
+					runtime,
+					message: makeMessage(),
+					state: makeState(),
+					responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+				}),
+		);
+
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind === "planned_reply") {
+			expect(result.result.responseContent?.text).toBe(
+				"I can follow up with Dana Whitfield.",
+			);
 		}
 	});
 

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -6115,7 +6115,7 @@ export async function runV5MessageRuntimeStage1(args: {
 			typeof onResponseHandlerEarlyReply === "function";
 		if (earlyReplySent && typeof onResponseHandlerEarlyReply === "function") {
 			await onResponseHandlerEarlyReply({
-				text: earlyReplyText,
+				text: restorePiiInUserReplyText(earlyReplyText),
 				messageHandler,
 			});
 		}


### PR DESCRIPTION
## Summary

Follow-up for #10827 after #10943. The merged fix restores PII surrogates in final `createV5ReplyStrategyResult` responses; this patch applies the same `restorePiiInUserReplyText` helper to response-handler early replies before visible delivery.

It also adds Stage 1/planner regressions proving:

- direct/simple replies show real values while the message-handler plan keeps surrogates
- terminal planner `messageToUser` shows real values while planner context keeps surrogates
- terminal planner `REPLY` text shows real values at final delivery
- response-handler early replies show real values while planner context keeps the surrogate early-reply text

## Evidence

Evidence artifact: `.github/issue-evidence/10827-pii-reply-boundary.md`

Commands run:

```bash
bun run --cwd packages/core test message-runtime-stage1.test.ts pii-swap-reply-egress.test.ts pii-swap-egress.test.ts pii-swap-use-model.test.ts
```

Result: 4 test files passed, 90 tests passed.

```bash
bunx @biomejs/biome@2.5.1 check packages/core/src/services/message.ts packages/core/src/__tests__/message-runtime-stage1.test.ts
```

Result: checked 2 files, no fixes applied.

```bash
bun run --cwd packages/core typecheck
```

Result: passed.

```bash
git diff --check
```

Result: no whitespace errors.

## Screenshots / Recordings

N/A: this is a core backend privacy-boundary patch with no UI files touched. The user-facing artifact is the returned reply content, covered by the regression assertions above.

## Notes

I also tried including the already-merged `packages/core/src/runtime/__tests__/pii-swap-reply-egress.test.ts` in the direct Biome command. Biome reported an import-order issue in that pre-existing `develop` file, so the clean Biome evidence is scoped to files changed in this PR.
