### PR TITLE
fix(personal-assistant): de-larp audit + Discord DispatchResult fix + timezone tests (#10721 slice 1)

### DIFF
--- a/.github/issue-evidence/10721-pa-delarp-audit.md
+++ b/.github/issue-evidence/10721-pa-delarp-audit.md
@@ -1,0 +1,44 @@
+# Personal-assistant de-larp audit (#10721) — critical assessment, slice 1
+
+A ranked, evidence-backed audit of `plugins/plugin-personal-assistant` against the
+issue's targets (larp/stubs, weak typing, frozen-contract violations,
+`promptInstructions`-content-driven behavior, untested branches). Findings were
+produced by a 4-category parallel audit and **re-verified against the code**; each
+is marked **fixed-in-this-PR** or **scoped follow-up** (with why).
+
+Frozen contracts (per `plugins/plugin-personal-assistant/README.md`): a single
+`ScheduledTask` runner (no second scheduler); `EntityStore`/`RelationshipStore`
+only; behavior structural on `kind`/`trigger`/`shouldFire`/`completionCheck`/
+`pipeline` — never on `promptInstructions` string content; connector dispatch
+returns a typed `DispatchResult` — never a bare `boolean`.
+
+## HIGH — top priorities (scoped follow-ups; too risky to fix blind)
+
+### H1. A second LifeOps scheduling mechanism fires GM/GN/nudges directly, bypassing the single runner
+`src/activity-profile/proactive-worker.ts:478-559,940-1005` (wired `src/plugin.ts:1005,1012`). The proactive worker builds its **own** schedule and fires user-facing messages itself — its own `scheduledFor` timing gate, its own `recordFiredAction` fire-log, and direct `runtime.sendMessageToTarget(...)` / `emitProactiveAssistantEvent(...)` — never routing through the `ScheduledTask` runner. Registered by default (`registerProactiveTaskWorker` + `ensureProactiveAgentTask`; task description literally *"Proactive agent: GM/GN/nudges based on activity profile"*). **GM/GN are ALSO the `daily-rhythm` ScheduledTask pack → double-scheduled.** Violates the README's "There is no second LifeOps scheduling mechanism" invariant, and bypasses the runner's `shouldFire` gates, global-pause, send-policy, escalation ladder, and typed `DispatchResult`.
+**Follow-up:** model GM/GN/nudges/downtime/goal-check-ins/quiet-user nags as `ScheduledTask` records (they already exist as `daily-rhythm`/watcher/checkin packs); delete the parallel planner + fire-log + direct dispatch. Large, behavior-sensitive refactor — must be done with real-runtime scenario evidence, not blind.
+
+### H2. Soft-failure `DispatchResult {ok:false}` is silently recorded as a successful fire (retry/escalation is dead code) — CONFIRMED REAL BUG
+`plugins/plugin-scheduling/src/scheduled-task/runner.ts:~1117-1124` returns `{ kind: "fired", task }` whenever a `dispatchResult` exists — it **never branches on `dispatchResult.ok === false`**. The production dispatcher returns `{ok:false}` for **disconnected channels** and **send-policy denials**, so those are recorded as "fired": the user silently never receives the message, and `src/lifeops/connectors/dispatch-policy.ts` `decideDispatchPolicy` (retry/backoff/escalation) is **never called** — dead code.
+**Follow-up:** after `dispatchResult = await dispatcher.dispatch(...)`, branch on `!dispatchResult.ok` and route through `decideDispatchPolicy` (retry/hold/escalate) instead of `{kind:"fired"}`. Changes dispatch/retry behavior across every scheduled item — needs dedicated tests + real-runtime evidence. (Also: `runtime-wiring.ts:257-281` mislabels `require_approval` denials as `auth_expired`, mis-driving that same policy.)
+
+## MEDIUM / LOW — ranked follow-ups
+
+- **Google reminder-plan deletion is a no-op stub with a misleading comment** — `src/lifeops/domains/google-service.ts:226-232` `deleteCalendarReminderPlansForEvents` is empty; both `clearGoogleConnectorData` (145) and `clearGoogleGrantData` (181) call it expecting real deletion. No `withCalendar` override exists (verified pre- and post-refactor); `life_reminder_plans` has no FK/cascade to calendar events. → disconnecting Google / deleting a grant **orphans reminder-plan rows**. Fix: implement real deletion in `LifeOpsRepository` or remove the dead call sites + false comment.
+- **Duffel connector advertises `orders.read`/`orders.create` it never implements** — `src/lifeops/connectors/duffel.ts:26-31,76-87`; `read` ignores the capability and always calls `searchFlights`. `registry.byCapability("duffel.orders.create")` resolves a connector that only searches flights. Fix: trim capabilities to what's served, or route order verbs to the real order path.
+- **`setPreferredGoogleConnectorMode` is a dead stub** — `google-service.ts:234-239` returns `null`, ignores both args, zero callers, exposed publicly via `service.ts:395`. Fix: implement (persist + return grant) or delete method + facade.
+- **`checkin-service.ts:736` counts "action needed" by substring-matching a display `reason` label** instead of the structural `replyNeeded` field (label source `303-306`). *(A structural-field fix was drafted this PR but reverted pending checkin-test validation — see below.)* Fix: carry `replyNeeded` structurally and count on it.
+- **`processDueScheduledTasks` error-recording branches are untested** — `src/lifeops/scheduled-task/scheduler.ts:157-167,191-197,235-242,271-281` (completion_timeout/fire/pending_prompt/dispatch_failed → `result.errors`) have zero positive coverage. Fix: inject throwing stubs + a `dispatch_failed` dispatcher, assert `result.errors`.
+- **Untyped `as` casts at real boundaries** — proactive dispatch emits via an `as` cast defeating the typed event contract (`proactive-worker.ts:889-903`, dup `runtime-wiring.ts:298-306`); `approval-queue.ts:775` double-casts through `unknown`; `plugin.ts:911-937` stashes registries onto the runtime via untyped intersection casts (read them back through the typed accessors instead).
+- **DST-incorrect `endOfLocalDayMs`** — `src/actions/lib/scheduling-handler.ts:181-185` assumes a fixed 1440-minute local day; wrong near spring-forward/fall-back. Fix: compute next local midnight via zoned parts. (The new `timezone.test.ts` in this PR protects the resolver these depend on.)
+- **Delegation-failure HTTP status decided by substring-matching a free-text reason** — `x-service.ts:135` (dup `whatsapp-service.ts:279`, `x-read-service.ts:63`). Fix: add a typed `reasonCode` discriminant to the unavailable variant.
+
+## Fixed in this PR (verified)
+
+1. **Discord `DispatchResult` reported `channelId` as `messageId`** — `src/lifeops/connectors/discord.ts`. `sendDiscordMessage` returns no per-message id (only a `channelId`), yet the connector did `return { ok: true, messageId: result.channelId }`, corrupting the dispatch state log. **Fixed:** `return { ok: true }` (messageId is optional on the success variant, matching the Google connector). Biome-clean; mirrors the proven `google.ts` pattern.
+2. **Timezone resolver had no unit coverage** — added `src/lifeops/time/timezone.test.ts` (**17 tests, all pass** under the plugin's vitest): alias map (pst/est/cst→IANA), explicit-IANA passthrough, longest-alias precedence, city inference. Locks the resolver that drives scheduling timezone selection (and guards the DST follow-up above).
+
+*(Reverted from this PR pending validation: the `checkin-service.ts` structural-signal refactor and a `scheduler.ts` error-branch test — both are listed above as follow-ups; the checkin refactor needs the checkin test suite green to verify no behavior change, and the scheduler test needs its mock-setup reworked for the plugin's vitest config.)*
+
+## `promptInstructions`-content-driven behavior
+**None found** driving control flow (the frozen contract holds). The two "free-text branch" smells above (checkin label substring-match, delegation-status substring-match) are on display/reason strings, not `promptInstructions`, and are listed as typed-discriminant follow-ups.

--- a/plugins/plugin-personal-assistant/src/lifeops/connectors/discord.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/connectors/discord.ts
@@ -46,12 +46,16 @@ export function createDiscordConnectorContribution(
     async send(payload: unknown): Promise<DispatchResult> {
       if (!isConnectorSendPayload(payload)) return rejectInvalidPayload();
       try {
-        const result = await service.sendDiscordMessage({
+        // `sendDiscordMessage` returns a channelId, not a per-message id, so we
+        // do not surface a `messageId` here (mislabeling a channel id as a
+        // message id corrupts the dispatch state log). `messageId` is optional
+        // on the success variant, matching the Google connector.
+        await service.sendDiscordMessage({
           side: "owner",
           channelId: payload.target,
           text: payload.message,
         });
-        return { ok: true, messageId: result.channelId };
+        return { ok: true };
       } catch (error) {
         return errorToDispatchResult(error);
       }

--- a/plugins/plugin-personal-assistant/src/lifeops/time/timezone.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/time/timezone.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit coverage for the timezone resolver (`timezone.ts`).
+ *
+ * These three functions turn free-form user text ("pst", "I live in Tokyo",
+ * "America/Chicago") into IANA zone ids that downstream local-day / DST math
+ * depends on. They had no direct test; this file pins the alias map, explicit
+ * IANA passthrough, longest-alias matching, and the Intl-backed city inference
+ * so a future DST / local-day fix can refactor the callers with a safety net.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  extractExplicitTimeZoneFromText,
+  inferTimeZoneFromLocationText,
+  normalizeExplicitTimeZoneToken,
+} from "./timezone.ts";
+
+describe("normalizeExplicitTimeZoneToken — alias map", () => {
+  it.each([
+    ["pst", "America/Los_Angeles"],
+    ["pdt", "America/Los_Angeles"],
+    ["mst", "America/Denver"],
+    ["cst", "America/Chicago"],
+    ["est", "America/New_York"],
+    ["utc", "UTC"],
+    ["gmt", "UTC"],
+  ])("maps abbreviation %s → %s", (input, expected) => {
+    expect(normalizeExplicitTimeZoneToken(input)).toBe(expected);
+  });
+
+  it("is case-insensitive", () => {
+    expect(normalizeExplicitTimeZoneToken("PST")).toBe("America/Los_Angeles");
+    expect(normalizeExplicitTimeZoneToken("Est")).toBe("America/New_York");
+  });
+
+  it("normalizes multi-word aliases", () => {
+    expect(normalizeExplicitTimeZoneToken("Pacific Standard Time")).toBe(
+      "America/Los_Angeles",
+    );
+    expect(normalizeExplicitTimeZoneToken("central time")).toBe(
+      "America/Chicago",
+    );
+  });
+});
+
+describe("normalizeExplicitTimeZoneToken — explicit IANA passthrough", () => {
+  it("returns a valid IANA id unchanged", () => {
+    expect(normalizeExplicitTimeZoneToken("America/New_York")).toBe(
+      "America/New_York",
+    );
+    expect(normalizeExplicitTimeZoneToken("Europe/London")).toBe(
+      "Europe/London",
+    );
+    expect(normalizeExplicitTimeZoneToken("Asia/Tokyo")).toBe("Asia/Tokyo");
+  });
+
+  it("returns null for unknown / empty tokens", () => {
+    expect(normalizeExplicitTimeZoneToken("not a zone")).toBeNull();
+    expect(normalizeExplicitTimeZoneToken("")).toBeNull();
+    expect(normalizeExplicitTimeZoneToken("   ")).toBeNull();
+    expect(normalizeExplicitTimeZoneToken(null)).toBeNull();
+    expect(normalizeExplicitTimeZoneToken(undefined)).toBeNull();
+  });
+});
+
+describe("extractExplicitTimeZoneFromText", () => {
+  it("prefers a literal IANA id embedded in prose", () => {
+    expect(
+      extractExplicitTimeZoneFromText("let's meet in America/Chicago tonight"),
+    ).toBe("America/Chicago");
+  });
+
+  it("matches multi-word aliases inside a sentence (longest-alias precedence)", () => {
+    // The alias loop is sorted longest-first so the most specific phrase is
+    // tried before its single-word fragments. "pacific standard" wins here,
+    // and "eastern" is recovered even when the trailing "time" word is
+    // collapsed by the canonicalizer.
+    expect(
+      extractExplicitTimeZoneFromText(
+        "I am currently in pacific standard time",
+      ),
+    ).toBe("America/Los_Angeles");
+    expect(extractExplicitTimeZoneFromText("catch up, eastern time?")).toBe(
+      "America/New_York",
+    );
+  });
+
+  it("returns null when no zone is present", () => {
+    expect(extractExplicitTimeZoneFromText("no timezone here")).toBeNull();
+    expect(extractExplicitTimeZoneFromText("")).toBeNull();
+  });
+});
+
+describe("inferTimeZoneFromLocationText — city inference", () => {
+  it("infers a zone from a city name not present in the alias map (Intl-backed)", () => {
+    // "tokyo" / "berlin" are NOT in TIME_ZONE_ALIASES, so a hit proves the
+    // Intl.supportedValuesOf city map — not the static alias table — resolved
+    // them.
+    expect(inferTimeZoneFromLocationText("I live in Tokyo now")).toBe(
+      "Asia/Tokyo",
+    );
+    expect(inferTimeZoneFromLocationText("moving to Berlin next month")).toBe(
+      "Europe/Berlin",
+    );
+  });
+
+  it("still honors the explicit alias path first", () => {
+    expect(inferTimeZoneFromLocationText("I live in Chicago")).toBe(
+      "America/Chicago",
+    );
+    expect(inferTimeZoneFromLocationText("denver")).toBe("America/Denver");
+  });
+
+  it("returns null for text with no resolvable location", () => {
+    expect(inferTimeZoneFromLocationText("qwerty zzz")).toBeNull();
+    expect(inferTimeZoneFromLocationText("")).toBeNull();
+  });
+});


### PR DESCRIPTION
First slice of **#10721** (personal-assistant de-larp audit). A 4-category parallel audit of `plugin-personal-assistant`, re-verified against the code, with the safe repairs applied and the risky findings scoped as follow-ups.

## Critical assessment (deliverable #1)
`.github/issue-evidence/10721-pa-delarp-audit.md` — ranked, evidence-backed. Two **HIGH** findings (kept as scoped follow-ups — too behavior-sensitive to fix blind):
- **H1:** `proactive-worker.ts` is a **second scheduling mechanism** — it plans + fires GM/GN/nudges/check-ins directly (own timing gate, own fire-log, direct `sendMessageToTarget`), bypassing the single `ScheduledTask` runner (README invariant), and GM/GN are **double-scheduled** (also in `daily-rhythm`).
- **H2 (confirmed real bug):** the scheduler runner records a connector `DispatchResult {ok:false}` (disconnected channel / send-policy denial) as `{kind:"fired"}` — the user **silently never receives the message**, and `decideDispatchPolicy` (retry/backoff/escalation) is **dead code** because the runner never branches on `!ok`.

Plus ranked MEDIUM/LOW follow-ups (Google reminder-plan no-op stub → orphaned rows; Duffel over-advertised `orders.*` capabilities; dead `setPreferredGoogleConnectorMode`; untyped `as` casts at real boundaries; DST-incorrect `endOfLocalDayMs`; delegation-status substring-matching). No `promptInstructions`-content-driven behavior found (contract holds).

## Fixed + verified in this PR
1. **Discord `DispatchResult` no longer mislabels `channelId` as `messageId`** (`connectors/discord.ts` → `return { ok: true }`, matching the Google connector) — was corrupting the dispatch state log. Biome-clean.
2. **`timezone.test.ts`** — **17 tests, pass** under the plugin's vitest; covers the resolver that drives scheduling timezone selection (alias map, IANA passthrough, longest-alias precedence, city inference).

Conservatively **reverted pending validation** (→ follow-ups, documented): a `checkin-service.ts` structural-signal refactor (needs the checkin suite green to confirm no behavior change) and a `scheduler.ts` error-branch test (mock-setup needs reworking for the plugin's vitest config). Only genuinely-verified changes ship here. Refs #10721.

🤖 Generated with [Claude Code](https://claude.com/claude-code)