### PR TITLE
fix(training): well-formed file:// URLs for local artifact links on Windows

### DIFF
--- a/plugins/plugin-training/src/core/training-collection-runner.ts
+++ b/plugins/plugin-training/src/core/training-collection-runner.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { basename, dirname, join, resolve } from "node:path";
 import type { Trajectory } from "@elizaos/agent";
+import { toLocalFileUrl } from "../util/local-file-url.js";
 import {
   type ActionBenchmarkRunOptions,
   type ActionBenchmarkRunResult,
@@ -2176,7 +2177,9 @@ function escapeHtml(value: unknown): string {
 }
 
 function fileHref(path: string): string {
-  return encodeURI(`file://${path}`);
+  // `file://${path}` yields a broken URL for Windows drive paths (C:\… →
+  // file://C:%5C…). toLocalFileUrl produces file:///C:/… on both platforms.
+  return toLocalFileUrl(path);
 }
 
 function compactCollectionIndexValue(value: unknown): string {

--- a/plugins/plugin-training/src/ui/FineTuningView.tsx
+++ b/plugins/plugin-training/src/ui/FineTuningView.tsx
@@ -49,6 +49,7 @@ import {
   ELIZA_ONE_BENCHMARK_TIER_LIST,
   ELIZA_ONE_BENCHMARK_TIERS,
 } from "../core/eliza1-benchmark-recipe.js";
+import { toLocalFileUrl } from "../util/local-file-url.js";
 import {
   type FineTuningSnapshot,
   FineTuningSpatialView,
@@ -85,8 +86,9 @@ const DEFAULT_ELIZA1_HF_DATASET_FILES = ELIZA_ONE_BENCHMARK_TIERS.flatMap(
 );
 
 function localViewerUrl(path: string): string {
-  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(path)) return path;
-  return encodeURI(`file://${path}`);
+  // `file://${path}` breaks on Windows drive paths (C:\… → file://C:%5C…, where
+  // the browser reads `C:` as the host). toLocalFileUrl handles both platforms.
+  return toLocalFileUrl(path);
 }
 
 interface AnalysisCoverageSummary {

--- a/plugins/plugin-training/src/util/local-file-url.test.ts
+++ b/plugins/plugin-training/src/util/local-file-url.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { toLocalFileUrl } from "./local-file-url";
+
+/**
+ * `file://${path}` is malformed on Windows: a drive path (`C:\…`) has no leading
+ * slash and uses backslashes, so the browser reads `C:` as the URL host and the
+ * link fails to open. `toLocalFileUrl` must yield `file:///C:/…` on Windows and
+ * `file:///…` on POSIX, and pass through inputs that are already URLs.
+ */
+describe("toLocalFileUrl", () => {
+  it("converts a Windows drive path to a valid file:// URL (C: is NOT the host)", () => {
+    const url = toLocalFileUrl("C:\\Users\\me\\report.html");
+    expect(url).toBe("file:///C:/Users/me/report.html");
+    const parsed = new URL(url);
+    expect(parsed.protocol).toBe("file:");
+    // The pre-fix bug parsed `C:` as the authority/host — assert it does not.
+    expect(parsed.host).toBe("");
+    expect(parsed.pathname).toBe("/C:/Users/me/report.html");
+  });
+
+  it("converts a POSIX absolute path", () => {
+    expect(toLocalFileUrl("/home/me/report.html")).toBe(
+      "file:///home/me/report.html",
+    );
+  });
+
+  it("percent-encodes spaces and reserved chars in the path", () => {
+    expect(toLocalFileUrl("C:\\my reports\\a b.html")).toBe(
+      "file:///C:/my%20reports/a%20b.html",
+    );
+    expect(toLocalFileUrl("/tmp/a b.json")).toBe("file:///tmp/a%20b.json");
+  });
+
+  it("normalizes mixed/back slashes", () => {
+    expect(toLocalFileUrl("C:/Users\\me/x.html")).toBe(
+      "file:///C:/Users/me/x.html",
+    );
+  });
+
+  it("passes an existing http(s)/file/blob/data URL through unchanged", () => {
+    expect(toLocalFileUrl("https://example.com/a")).toBe(
+      "https://example.com/a",
+    );
+    expect(toLocalFileUrl("http://x/y")).toBe("http://x/y");
+    expect(toLocalFileUrl("file:///already/there")).toBe(
+      "file:///already/there",
+    );
+  });
+
+  it("roots a bare relative path under file:// (no crash on unexpected input)", () => {
+    expect(toLocalFileUrl("report.html")).toBe("file:///report.html");
+  });
+});

--- a/plugins/plugin-training/src/util/local-file-url.ts
+++ b/plugins/plugin-training/src/util/local-file-url.ts
@@ -1,0 +1,26 @@
+/**
+ * Convert a filesystem path into a well-formed `file://` URL that works on both
+ * POSIX and Windows.
+ *
+ * The naive `file://${path}` form is broken on Windows: an absolute drive path
+ * like `C:\Users\me\report.html` has no leading slash and uses backslashes, so
+ * `encodeURI("file://C:\\Users\\me\\report.html")` yields
+ * `file://C:%5CUsers%5Cme%5Creport.html` — the browser then parses `C:` as the
+ * URL *authority/host* and the link fails to open. A valid file URL for a drive
+ * path needs three slashes and forward separators: `file:///C:/Users/me/...`.
+ *
+ * This normalizes backslashes to `/`, guarantees a leading `/` (so a Windows
+ * `C:/…` becomes `/C:/…` → `file:///C:/…`), percent-encodes the result, and
+ * passes through inputs that are already a URL. It is intentionally
+ * dependency-free / browser-safe (no `node:url`) so the report UIs can use it
+ * too.
+ */
+export function toLocalFileUrl(path: string): string {
+  // Already an absolute URL (http(s)://, file://, blob:, data:, etc.).
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(path)) {
+    return path;
+  }
+  const normalized = path.replace(/\\/g, "/");
+  const rooted = normalized.startsWith("/") ? normalized : `/${normalized}`;
+  return encodeURI(`file://${rooted}`);
+}


### PR DESCRIPTION
## What & why

`plugin-training` builds local-artifact links (fine-tuning dashboard + the
training-collection HTML index) with `encodeURI(\`file://\${path}\`)`. On Windows
an absolute path is `C:\Users\…\report.html` — no leading slash, backslash
separators — so this produces `file://C:%5CUsers%5C…`, and the browser parses
`C:` as the URL **authority/host**, so the link fails to open. A valid file URL
for a drive path needs three slashes and forward separators:
`file:///C:/Users/…`.

Two direct call sites were affected:
- `localViewerUrl` — `src/ui/FineTuningView.tsx`
- `fileHref` — `src/core/training-collection-runner.ts`

## Fix

New dependency-free, browser-safe helper `toLocalFileUrl(path)`
(`src/util/local-file-url.ts`): normalizes backslashes → `/`, guarantees a
leading slash so `C:/…` → `/C:/…` → `file:///C:/…`, percent-encodes, and passes
through inputs that are already URLs (`http(s)://`, `file://`, …). Both call
sites now route through it. POSIX behavior is unchanged
(`/home/…` → `file:///home/…`).

## Tests / evidence

`src/util/local-file-url.test.ts` — 6 cases, all green:
- Windows drive path → `file:///C:/Users/me/report.html`, and asserts `new URL(...).host === ""` (i.e. `C:` is **not** parsed as the host — the exact bug).
- POSIX absolute path; space/reserved-char encoding; mixed/back-slash normalization; existing-URL passthrough; bare relative path.

```
 Test Files  1 passed (1)
      Tests  6 passed (6)     # plugins/plugin-training/src/util/local-file-url.test.ts
```

biome check clean; the fix is type-trivial (helper returns `string`).

- Real-LLM trajectory — N/A: pure URL-string construction, no model call.
- Screenshots/video — N/A: the user-visible effect is the `href` format shown in the test (`file://C:%5C…` before → `file:///C:/…` after).
- Scope note: the training-analysis *report viewer*'s own client-side path linker (`hrefForPath`, embedded inside a generated-HTML template with its own pre-existing quirks) is a separate client-side mechanism and is intentionally not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)