### PR TITLE
ci(cloud-cf-deploy): make checkout reclaim unfailable — sibling-run races were killing deploy jobs at step one

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -99,8 +99,8 @@ jobs:
       CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS: ${{ vars.CLOUD_CF_CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS || '600' }}
     steps:
       - name: Reclaim disk from leaked checkouts of prior runs
+        continue-on-error: true
         run: |
-          set -uo pipefail
           # Cancelled/killed deploy runs never reach the trailing "Clean temp
           # checkout" step, so their /tmp/eliza-checkout-* trees (a full ~46k-file
           # monorepo materialization) leak and pile up on this shared self-hosted
@@ -112,12 +112,19 @@ jobs:
           # serialized), so sibling runs materialize at the same time; the age
           # filter never deletes another run's actively-writing checkout (its mtime
           # stays fresh), and we also exclude this run's own dirs by name.
-          # (The prior run_id-only filter deleted concurrent siblings' live
-          # checkouts — this replaces it.) Best-effort; never fails the deploy.
+          # UNFAILABLE BY CONSTRUCTION: sibling runs execute this same step at the
+          # same moment, so one sibling's rm -rf can race another's find into
+          # ENOENT (exit 1) — under the job's default `bash -e` (plus the pipefail
+          # this step previously set) that killed whole deploy jobs at step one.
+          # set +e swallows every failure mode, exit 0 guarantees the step, and
+          # continue-on-error guards future edits.
+          set +e
+          set +o pipefail
           stale=$(find /tmp -maxdepth 1 -type d -name 'eliza-checkout-*' -mmin +90 ! -name "eliza-checkout-${{ github.run_id }}-*" 2>/dev/null | wc -l | tr -d ' ')
-          find /tmp -maxdepth 1 -type d -name 'eliza-checkout-*' -mmin +90 ! -name "eliza-checkout-${{ github.run_id }}-*" -exec rm -rf {} + 2>/dev/null || true
-          echo "Reclaimed ${stale} stale (idle >90min) leaked checkout dir(s)."
-          df -h /tmp / 2>/dev/null | tail -2 || true
+          find /tmp -maxdepth 1 -type d -name 'eliza-checkout-*' -mmin +90 ! -name "eliza-checkout-${{ github.run_id }}-*" -exec rm -rf {} + 2>/dev/null
+          echo "Reclaimed ${stale:-0} stale (idle >90min) leaked checkout dir(s)."
+          df -h /tmp / 2>/dev/null | tail -2
+          exit 0
       - name: Checkout repository
         timeout-minutes: 20
         env:
@@ -337,8 +344,8 @@ jobs:
       CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS: ${{ vars.CLOUD_CF_CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS || '600' }}
     steps:
       - name: Reclaim disk from leaked checkouts of prior runs
+        continue-on-error: true
         run: |
-          set -uo pipefail
           # Cancelled/killed deploy runs never reach the trailing "Clean temp
           # checkout" step, so their /tmp/eliza-checkout-* trees (a full ~46k-file
           # monorepo materialization) leak and pile up on this shared self-hosted
@@ -350,12 +357,19 @@ jobs:
           # serialized), so sibling runs materialize at the same time; the age
           # filter never deletes another run's actively-writing checkout (its mtime
           # stays fresh), and we also exclude this run's own dirs by name.
-          # (The prior run_id-only filter deleted concurrent siblings' live
-          # checkouts — this replaces it.) Best-effort; never fails the deploy.
+          # UNFAILABLE BY CONSTRUCTION: sibling runs execute this same step at the
+          # same moment, so one sibling's rm -rf can race another's find into
+          # ENOENT (exit 1) — under the job's default `bash -e` (plus the pipefail
+          # this step previously set) that killed whole deploy jobs at step one.
+          # set +e swallows every failure mode, exit 0 guarantees the step, and
+          # continue-on-error guards future edits.
+          set +e
+          set +o pipefail
           stale=$(find /tmp -maxdepth 1 -type d -name 'eliza-checkout-*' -mmin +90 ! -name "eliza-checkout-${{ github.run_id }}-*" 2>/dev/null | wc -l | tr -d ' ')
-          find /tmp -maxdepth 1 -type d -name 'eliza-checkout-*' -mmin +90 ! -name "eliza-checkout-${{ github.run_id }}-*" -exec rm -rf {} + 2>/dev/null || true
-          echo "Reclaimed ${stale} stale (idle >90min) leaked checkout dir(s)."
-          df -h /tmp / 2>/dev/null | tail -2 || true
+          find /tmp -maxdepth 1 -type d -name 'eliza-checkout-*' -mmin +90 ! -name "eliza-checkout-${{ github.run_id }}-*" -exec rm -rf {} + 2>/dev/null
+          echo "Reclaimed ${stale:-0} stale (idle >90min) leaked checkout dir(s)."
+          df -h /tmp / 2>/dev/null | tail -2
+          exit 0
       - name: Checkout repository
         timeout-minutes: 20
         env:
@@ -610,8 +624,8 @@ jobs:
       CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS: ${{ vars.CLOUD_CF_CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS || '600' }}
     steps:
       - name: Reclaim disk from leaked checkouts of prior runs
+        continue-on-error: true
         run: |
-          set -uo pipefail
           # Cancelled/killed deploy runs never reach the trailing "Clean temp
           # checkout" step, so their /tmp/eliza-checkout-* trees (a full ~46k-file
           # monorepo materialization) leak and pile up on this shared self-hosted
@@ -623,12 +637,19 @@ jobs:
           # serialized), so sibling runs materialize at the same time; the age
           # filter never deletes another run's actively-writing checkout (its mtime
           # stays fresh), and we also exclude this run's own dirs by name.
-          # (The prior run_id-only filter deleted concurrent siblings' live
-          # checkouts — this replaces it.) Best-effort; never fails the deploy.
+          # UNFAILABLE BY CONSTRUCTION: sibling runs execute this same step at the
+          # same moment, so one sibling's rm -rf can race another's find into
+          # ENOENT (exit 1) — under the job's default `bash -e` (plus the pipefail
+          # this step previously set) that killed whole deploy jobs at step one.
+          # set +e swallows every failure mode, exit 0 guarantees the step, and
+          # continue-on-error guards future edits.
+          set +e
+          set +o pipefail
           stale=$(find /tmp -maxdepth 1 -type d -name 'eliza-checkout-*' -mmin +90 ! -name "eliza-checkout-${{ github.run_id }}-*" 2>/dev/null | wc -l | tr -d ' ')
-          find /tmp -maxdepth 1 -type d -name 'eliza-checkout-*' -mmin +90 ! -name "eliza-checkout-${{ github.run_id }}-*" -exec rm -rf {} + 2>/dev/null || true
-          echo "Reclaimed ${stale} stale (idle >90min) leaked checkout dir(s)."
-          df -h /tmp / 2>/dev/null | tail -2 || true
+          find /tmp -maxdepth 1 -type d -name 'eliza-checkout-*' -mmin +90 ! -name "eliza-checkout-${{ github.run_id }}-*" -exec rm -rf {} + 2>/dev/null
+          echo "Reclaimed ${stale:-0} stale (idle >90min) leaked checkout dir(s)."
+          df -h /tmp / 2>/dev/null | tail -2
+          exit 0
       - name: Checkout repository
         timeout-minutes: 20
         env:


### PR DESCRIPTION
## The regression (mine)

#10940's reclaim step runs under the job's default `bash -e` shell **plus** a `set -uo pipefail` I added. Push deploys use per-SHA concurrency groups, so **multiple runs execute this same step on the box at the same moment**. One sibling's `rm -rf` deletes a stale dir while another sibling's `find` is mid-scan → `find` exits 1 (ENOENT) → with pipefail the `stale=$(find … | wc -l)` assignment fails → `-e` kills the **entire deploy job at step one**.

Observed live: run [28543468069](https://github.com/elizaOS/eliza/actions/runs/28543468069) Deploy App — reclaim step `failure` in 2.7s with zero output, all deploy steps skipped. This is also why PR #10941's Deploy App check failed in 39s.

The step's own comment says *"Best-effort; never fails the deploy"* — my shell options violated that contract.

## Fix

- `set +e` + `set +o pipefail` — every failure mode inside the step is swallowed
- unconditional `exit 0` — the step cannot report failure
- `continue-on-error: true` — belt-and-suspenders so no future edit to this step can wedge deploys again
- applied to all 3 deploy jobs; reclaim semantics (age-based >90min idle, exclude own run) unchanged

## Evidence

- YAML validated (`yaml.safe_load` OK)
- Simulated the exact failure under `bash -e`: pipeline member exits 1 → step still exits 0:
```
bash -e -c 'set +e; set +o pipefail; stale=$(bash -c "echo x; exit 1" | wc -l); echo "Reclaimed ${stale:-0}"; exit 0'
→ Reclaimed 1 / exit 0
```

Part of the #10839 deploy-wedge recovery. Root-cause chain: leaked checkouts (#10842) → run_id-reclaim deleted live siblings (#10940) → pipefail race killed jobs (this PR).