### PR TITLE
fix(personal-assistant): remove dead google-mode stub + trim over-advertised Duffel caps (#10721 slice 2)

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/connectors/duffel.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/connectors/duffel.ts
@@ -23,12 +23,12 @@ export function createDuffelConnectorContribution(
 ): ConnectorContribution {
   return {
     kind: "duffel",
-    capabilities: [
-      "duffel.flights.search",
-      "duffel.offers.read",
-      "duffel.orders.read",
-      "duffel.orders.create",
-    ],
+    // Only what this contribution actually serves: `read` performs a flight
+    // search (which returns offers). It has no order read/create path — those
+    // must not be advertised, or `registry.byCapability("duffel.orders.create")`
+    // resolves a connector that only searches flights (real order creation lives
+    // on LifeOpsService.bookFlightItinerary → travel-service). (#10721)
+    capabilities: ["duffel.flights.search", "duffel.offers.read"],
     modes: ["cloud", "local"],
     describe: { label: "Duffel (Travel)" },
     async start() {},

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/google-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/google-service.ts
@@ -231,13 +231,6 @@ export class GoogleDomain {
     // methods.
   }
 
-  public async setPreferredGoogleConnectorMode(
-    _mode: LifeOpsConnectorMode | null,
-    _side?: LifeOpsConnectorSide,
-  ): Promise<LifeOpsConnectorGrant | null> {
-    return null;
-  }
-
   public async requireGoogleCalendarGrant(
     requestUrl: URL,
     requestedMode?: LifeOpsConnectorMode,

--- a/plugins/plugin-personal-assistant/src/lifeops/service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/service.ts
@@ -392,13 +392,6 @@ export class LifeOpsService extends LifeOpsServiceBase {
     return this.googleDomain.deleteCalendarReminderPlansForEvents(_eventIds);
   }
 
-  public setPreferredGoogleConnectorMode(
-    _mode: LifeOpsConnectorMode | null,
-    _side?: LifeOpsConnectorSide,
-  ): Promise<LifeOpsConnectorGrant | null> {
-    return this.googleDomain.setPreferredGoogleConnectorMode(_mode, _side);
-  }
-
   public requireGoogleCalendarGrant(
     requestUrl: URL,
     requestedMode?: LifeOpsConnectorMode,


### PR DESCRIPTION
Two verified de-larp removals from the #10721 audit (#10953), both zero-consumer:

- **Delete `setPreferredGoogleConnectorMode`** (GoogleDomain + LifeOpsService facade) — a public API that ignored both args, persisted nothing, returned `null`, with **zero callers** anywhere. A caller trying to change a preference got a silent no-op.
- **Trim the Duffel connector `capabilities`** to what it serves (`flights.search`, `offers.read`). It never implemented `orders.read`/`orders.create` (the `read` verb always flight-searches; `send` refuses), so `registry.byCapability("duffel.orders.create")` resolved a non-functional connector. Nothing consumes those caps; real order creation is `LifeOpsService.bookFlightItinerary`.

Connector-type imports remain used (no dangling); biome clean; no test asserts the trimmed caps. Net −14 lines of dead/misleading surface. Refs #10721.

🤖 Generated with [Claude Code](https://claude.com/claude-code)