### PR TITLE
fix(agent): stop streaming OAuth access+refresh tokens over the accounts SSE status endpoint

### DIFF
--- a/.github/issue-evidence/10957-oauth-token-sse-leak.md
+++ b/.github/issue-evidence/10957-oauth-token-sse-leak.md
@@ -1,0 +1,68 @@
+# Evidence — #10957 OAuth accounts SSE status stream leaks access+refresh tokens
+
+Fix: `packages/agent/src/auth/oauth-flow.ts` — `FlowState.account` is now the
+credential-free `FlowAccountSummary` (`Omit<AccountCredentialRecord, "credentials">`),
+type-enforcing that tokens can never enter the SSE-broadcast state. The
+in-process `OAuthFlowHandle.completion` promise and the on-disk record keep the
+full credentials.
+
+## 1. The bug, demonstrated (mutation check — tests run against the UNFIXED code)
+
+The new tests drive the real `startCodexOAuthFlow` → `startGenericFlow` →
+`persistAccount` → emit path (only the vendor OAuth network layer faked) and
+assert on `JSON.stringify(state)` — byte-for-byte what
+`handleOAuthStatusSse` writes to the wire. Against the pre-fix
+`oauth-flow.ts` they fail, showing the cleartext tokens inside the SSE frame:
+
+```
+❯ src/auth/oauth-flow.test.ts (4 tests | 2 failed) 36ms
+AssertionError: expected '{"sessionId":"29ee950b-59e2-4388-a0a3…' not to contain 'codex-access-token-SECRET'
+Received: "{"sessionId":"29ee950b-59e2-4388-a0a3-399ab3a1e280","providerId":"openai-codex",
+"status":"success","authUrl":"https://auth.openai.com/authorize?fake","needsCodeSubmission":false,
+"startedAt":1782935651233,"account":{"id":"acct-2","providerId":"openai-codex","label":"Work",
+"source":"oauth","credentials":{"access":"codex-access-token-SECRET",
+"refresh":"codex-refresh-token-SECRET","expires":1782935711233},
+"createdAt":1782935651233,"updatedAt":1782935651233},"endedAt":1782935651233}"
+```
+
+That `credentials` blob is exactly what every
+`GET /api/accounts/:provider/oauth/status` subscriber received.
+
+## 2. The fix, verified (same tests against the fixed code)
+
+```
+✓ src/auth/oauth-flow.test.ts (4 tests) — Tests 4 passed (4)
+  ✓ emits a success state without the OAuth tokens
+  ✓ replays a token-free terminal state to late subscribers
+  ✓ keeps the full credentials on the completion promise and on disk
+  ✓ emits an account-free error state when the exchange fails
+```
+
+Full auth suite (`packages/agent/src/auth`): `Test Files 2 passed (2), Tests 14 passed (14)`.
+
+## 3. No regressions
+
+- **Typecheck:** `bun run --cwd packages/agent typecheck` error sets diffed
+  pristine-HEAD vs with-fix: **identical** (66 pre-existing environmental
+  errors in unrelated packages — unbuilt `@elizaos/cloud-routing` workspace dep
+  etc.; zero introduced).
+- **Biome:** `biome check` clean on both touched files.
+- **Consumers audited:** no code reads `FlowState.account.credentials`
+  anywhere (repo-wide grep). The UI already types the frame's `account` as
+  credential-free `LinkedAccountConfig`, and both `onCreated` consumers
+  (`AccountList.tsx`, `AccountConnectBlock.tsx`) ignore the argument and
+  refetch — so the redaction is invisible to the client. The token-needing
+  paths (CLI/pool via `OAuthFlowHandle.completion`, `onAccountSaved`,
+  `saveAccount` on disk) are unchanged and covered by test 3.
+
+## N/A rows
+
+- Screenshots / video / frontend logs: **N/A** — backend-only redaction of an
+  SSE payload field the UI never read or rendered; no user-visible pixel
+  changes.
+- Live-LLM trajectory: **N/A** — no agent/action/provider/prompt/model
+  behavior involved; this is HTTP credential-surface hygiene.
+- Real vendor OAuth exchange: **N/A** — completing a live Anthropic/OpenAI
+  browser login is inherently interactive; the vendor boundary is the only
+  faked seam, and everything downstream of it (flow registry, persistence,
+  emit, wire serialization) runs real in the tests.

--- a/packages/agent/src/auth/oauth-flow.test.ts
+++ b/packages/agent/src/auth/oauth-flow.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Tests the OAuth flow orchestrator's state broadcast: the `FlowState`
+ * emitted to `/api/accounts/:provider/oauth/status` SSE subscribers must
+ * never carry the OAuth access/refresh tokens, while the in-process
+ * `OAuthFlowHandle.completion` promise and the on-disk credential record
+ * keep the full credentials.
+ *
+ * Only the vendor OAuth network layer (`startCodexLogin`) is faked — the
+ * real `startGenericFlow`, `persistAccount`/`saveAccount`, `setTerminal`,
+ * and listener emit paths all run for real against a temp ELIZA_HOME.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadAccount } from "./account-storage";
+import {
+  _resetFlowRegistry,
+  type FlowState,
+  startCodexOAuthFlow,
+  subscribeFlow,
+} from "./oauth-flow";
+import type { CodexFlow } from "./openai-codex";
+import { startCodexLogin } from "./openai-codex";
+import type { OAuthCredentials } from "./types";
+
+vi.mock("./openai-codex.ts", () => ({
+  startCodexLogin: vi.fn(),
+}));
+
+const ACCESS_TOKEN = "codex-access-token-SECRET";
+const REFRESH_TOKEN = "codex-refresh-token-SECRET";
+
+const tempHomes: string[] = [];
+
+function useTempElizaHome(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-oauth-flow-test-"));
+  tempHomes.push(dir);
+  vi.stubEnv("ELIZA_HOME", dir);
+  vi.stubEnv("HOME", dir);
+  vi.stubEnv("USERPROFILE", dir);
+  return dir;
+}
+
+/** A controllable fake vendor flow: the test resolves the token exchange. */
+function stubCodexLogin(): {
+  resolveCredentials: (creds: OAuthCredentials) => void;
+} {
+  let resolveCredentials!: (creds: OAuthCredentials) => void;
+  const credentials = new Promise<OAuthCredentials>((resolve) => {
+    resolveCredentials = resolve;
+  });
+  const flow: CodexFlow = {
+    authUrl: "https://auth.openai.com/authorize?fake",
+    state: "fake-state",
+    submitCode: () => undefined,
+    credentials,
+    close: () => undefined,
+  };
+  vi.mocked(startCodexLogin).mockResolvedValue(flow);
+  return { resolveCredentials };
+}
+
+afterEach(() => {
+  _resetFlowRegistry();
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+  for (const dir of tempHomes.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("oauth-flow FlowState broadcast", () => {
+  it("emits a success state without the OAuth tokens", async () => {
+    useTempElizaHome();
+    const vendor = stubCodexLogin();
+
+    const handle = await startCodexOAuthFlow({
+      label: "Personal",
+      accountId: "acct-1",
+    });
+    const frames: FlowState[] = [];
+    subscribeFlow(handle.sessionId, (state) => {
+      frames.push(state);
+    });
+
+    vendor.resolveCredentials({
+      access: ACCESS_TOKEN,
+      refresh: REFRESH_TOKEN,
+      expires: Date.now() + 60_000,
+    });
+    await handle.completion;
+
+    const success = frames.find((f) => f.status === "success");
+    expect(success).toBeDefined();
+    // The account summary is present for the UI…
+    expect(success?.account).toMatchObject({
+      id: "acct-1",
+      providerId: "openai-codex",
+      label: "Personal",
+      source: "oauth",
+    });
+    // …but carries no credential material.
+    expect(success?.account).not.toHaveProperty("credentials");
+    // Exactly what the SSE route writes: JSON.stringify(state). No token
+    // string may survive that serialization.
+    for (const frame of frames) {
+      const wire = JSON.stringify(frame);
+      expect(wire).not.toContain(ACCESS_TOKEN);
+      expect(wire).not.toContain(REFRESH_TOKEN);
+    }
+  });
+
+  it("replays a token-free terminal state to late subscribers", async () => {
+    useTempElizaHome();
+    const vendor = stubCodexLogin();
+
+    const handle = await startCodexOAuthFlow({
+      label: "Work",
+      accountId: "acct-2",
+    });
+    vendor.resolveCredentials({
+      access: ACCESS_TOKEN,
+      refresh: REFRESH_TOKEN,
+      expires: Date.now() + 60_000,
+    });
+    await handle.completion;
+
+    // A subscriber attaching after the flow finished gets the terminal
+    // state replayed synchronously — that replay must be clean too.
+    let replayed: FlowState | null = null;
+    subscribeFlow(handle.sessionId, (state) => {
+      replayed = state;
+    });
+    expect(replayed).not.toBeNull();
+    const wire = JSON.stringify(replayed);
+    expect(wire).not.toContain(ACCESS_TOKEN);
+    expect(wire).not.toContain(REFRESH_TOKEN);
+  });
+
+  it("keeps the full credentials on the completion promise and on disk", async () => {
+    useTempElizaHome();
+    const vendor = stubCodexLogin();
+
+    const handle = await startCodexOAuthFlow({
+      label: "Personal",
+      accountId: "acct-3",
+    });
+    vendor.resolveCredentials({
+      access: ACCESS_TOKEN,
+      refresh: REFRESH_TOKEN,
+      expires: Date.now() + 60_000,
+    });
+
+    // In-process consumers (CLI, credential pool) still get the tokens.
+    const { account } = await handle.completion;
+    expect(account.credentials.access).toBe(ACCESS_TOKEN);
+    expect(account.credentials.refresh).toBe(REFRESH_TOKEN);
+
+    // And the persisted record is intact.
+    const saved = loadAccount("openai-codex", "acct-3");
+    expect(saved?.credentials.access).toBe(ACCESS_TOKEN);
+    expect(saved?.credentials.refresh).toBe(REFRESH_TOKEN);
+  });
+
+  it("emits an account-free error state when the exchange fails", async () => {
+    useTempElizaHome();
+    let rejectCredentials!: (err: Error) => void;
+    const credentials = new Promise<OAuthCredentials>((_resolve, reject) => {
+      rejectCredentials = reject;
+    });
+    vi.mocked(startCodexLogin).mockResolvedValue({
+      authUrl: "https://auth.openai.com/authorize?fake",
+      state: "fake-state",
+      submitCode: () => undefined,
+      credentials,
+      close: () => undefined,
+    });
+
+    const handle = await startCodexOAuthFlow({
+      label: "Personal",
+      accountId: "acct-4",
+    });
+    const frames: FlowState[] = [];
+    subscribeFlow(handle.sessionId, (state) => {
+      frames.push(state);
+    });
+
+    rejectCredentials(new Error("exchange failed"));
+    await expect(handle.completion).rejects.toThrow("exchange failed");
+
+    const terminal = frames.find((f) => f.status === "error");
+    expect(terminal).toBeDefined();
+    expect(terminal?.account).toBeUndefined();
+    expect(terminal?.error).toBe("exchange failed");
+  });
+});

--- a/packages/agent/src/auth/oauth-flow.ts
+++ b/packages/agent/src/auth/oauth-flow.ts
@@ -40,6 +40,15 @@ export type FlowStatus =
   | "cancelled"
   | "timeout";
 
+/**
+ * Credential-free projection of an `AccountCredentialRecord` — the only
+ * account shape allowed into {@link FlowState}. `FlowState` is serialized
+ * verbatim to every `/api/accounts/:provider/oauth/status` SSE subscriber,
+ * so the OAuth access/refresh tokens must never enter it. In-process
+ * callers that need the tokens use `OAuthFlowHandle.completion` instead.
+ */
+export type FlowAccountSummary = Omit<AccountCredentialRecord, "credentials">;
+
 export interface FlowState {
   sessionId: string;
   providerId: SubscriptionProvider;
@@ -48,7 +57,7 @@ export interface FlowState {
   authUrl?: string;
   /** Anthropic only — the user must paste `code#state`; Codex uses the loopback callback. */
   needsCodeSubmission: boolean;
-  account?: AccountCredentialRecord;
+  account?: FlowAccountSummary;
   error?: string;
   startedAt: number;
   endedAt?: number;
@@ -310,7 +319,11 @@ async function startGenericFlow(args: {
       if (opts.onAccountSaved) {
         await opts.onAccountSaved(record);
       }
-      setTerminal({ status: "success", account: record });
+      // The broadcast state must never carry the tokens — every SSE
+      // subscriber receives it verbatim; only the in-process completion
+      // promise gets the full record.
+      const { credentials: _credentials, ...accountSummary } = record;
+      setTerminal({ status: "success", account: accountSummary });
       resolveCompletion({ account: record });
     } catch (err) {
       clearTimeout(timer);


### PR DESCRIPTION
Fixes #10957

## The leak

On OAuth success the flow orchestrator emitted the **full `AccountCredentialRecord` — cleartext `credentials.access` + `credentials.refresh`** — into the broadcast `FlowState` (`oauth-flow.ts` `setTerminal({ status: "success", account: record })`), and `handleOAuthStatusSse` writes every frame verbatim (`res.write(`data: ${JSON.stringify(state)}\n\n`)`). So `GET /api/accounts/:provider/oauth/status` served the user's Anthropic/ChatGPT subscription tokens — including the **long-lived refresh token** — to every subscriber, and `subscribeFlow`'s synchronous terminal-state replay re-served them to late reconnects for the 10-minute GC window.

No client ever needed it: the UI types the frame's `account` as the credential-free `LinkedAccountConfig` (whose doc says *"The on-disk credential blob is intentionally not part of this type"*), and both `onCreated` consumers ignore the argument and refetch.

## The fix — type-enforced, not just redacted

- `FlowState.account` is now `FlowAccountSummary = Omit<AccountCredentialRecord, "credentials">` — tokens **cannot** enter the broadcast state by construction; a future regression is a compile error, not a code-review catch.
- The success emit strips `credentials`; everything else about the frame is unchanged (`id`, `providerId`, `label`, `source`, timestamps, `organizationId`, `email`).
- The in-process `OAuthFlowHandle.completion` promise (CLI, `onAccountSaved` → pool wiring) and the on-disk `saveAccount` record keep the full credentials — those paths are untouched and covered by a test.

## Evidence — `.github/issue-evidence/10957-oauth-token-sse-leak.md`

- **Real-path tests** (`packages/agent/src/auth/oauth-flow.test.ts`, 4 tests): drive the real `startCodexOAuthFlow` → `startGenericFlow` → `persistAccount` (temp `ELIZA_HOME`) → emit pipeline, faking only the vendor OAuth network layer. They assert `JSON.stringify(state)` — byte-for-byte what the SSE route writes — contains neither token, on live emit **and** late-subscriber replay; that `completion` + the persisted record retain full credentials; and that the error path emits no account.
- **Mutation-checked:** run against the pre-fix `oauth-flow.ts`, the leak tests fail with the tokens visible in the wire frame (full output in the evidence file) — the tests demonstrably catch this bug.
- **Suite:** `packages/agent/src/auth` → 2 files, 14 tests, all green.
- **Typecheck:** agent-package error sets diffed pristine-HEAD vs with-fix → **identical** (66 pre-existing environmental errors in unrelated packages; zero introduced). Biome clean.
- Screenshots / video / live-LLM trajectory: **N/A** — backend-only redaction of an SSE field no client reads or renders; no agent/model behavior involved (reasons in the evidence file).