### PR TITLE
fix(agent,elizacloud): per-capability cloud arbitration — keep IMAGE/media/TTS alive under an external text brain

### DIFF
--- a/packages/agent/src/runtime/eliza-cloud-config.test.ts
+++ b/packages/agent/src/runtime/eliza-cloud-config.test.ts
@@ -363,6 +363,88 @@ describe("provisioned cloud container topology (#9887)", () => {
     expect(names.has("@elizaos/plugin-local-inference")).toBe(false);
   });
 
+  it("marks inference explicitly OFF while loading the plugin for media (#10819)", () => {
+    // Capability-only topology: an external provider owns the text brain,
+    // media is cloud-routed. The plugin must load with the credential intact
+    // and an EXPLICIT inference denial, so image generation works without the
+    // cloud stealing the chat-brain slots.
+    const config: ElizaConfig = {
+      cloud: {
+        enabled: true,
+        apiKey: "cloud-test",
+        agentId: "agent-test",
+      },
+      serviceRouting: {
+        media: {
+          backend: "elizacloud",
+          transport: "cloud-proxy",
+        },
+      },
+    } as ElizaConfig;
+
+    const topology = resolveElizaCloudTopology(
+      config as Record<string, unknown>,
+    );
+    expect(topology.services.inference).toBe(false);
+    expect(topology.services.media).toBe(true);
+    expect(topology.shouldLoadPlugin).toBe(true);
+
+    applyCloudConfigToEnv(config);
+
+    // Tri-state contract with plugin-elizacloud's registerTextInferenceModels:
+    // explicit "false" (not unset) → skip chat-brain handlers, keep IMAGE/TTS.
+    expect(process.env.ELIZAOS_CLOUD_USE_INFERENCE).toBe("false");
+    expect(process.env.ELIZAOS_CLOUD_USE_MEDIA).toBe("true");
+    // The credential survives for the selected capabilities…
+    expect(process.env.ELIZAOS_CLOUD_API_KEY).toBe("cloud-test");
+    // …without flipping the inference-coupled ENABLED flag.
+    expect(process.env.ELIZAOS_CLOUD_ENABLED).toBeUndefined();
+  });
+
+  it("keeps an env-provided key when config carries none but cloud services are selected (#10819)", () => {
+    process.env.ELIZAOS_CLOUD_API_KEY = "env-key";
+    const config: ElizaConfig = {
+      cloud: { enabled: true, agentId: "agent-test" },
+      serviceRouting: {
+        media: { backend: "elizacloud", transport: "cloud-proxy" },
+      },
+    } as ElizaConfig;
+
+    applyCloudConfigToEnv(config);
+
+    expect(process.env.ELIZAOS_CLOUD_API_KEY).toBe("env-key");
+    expect(process.env.ELIZAOS_CLOUD_USE_INFERENCE).toBe("false");
+  });
+
+  it("still scrubs a leaked [REDACTED] placeholder from the env (#10819)", () => {
+    process.env.ELIZAOS_CLOUD_API_KEY = "[REDACTED]";
+    const config: ElizaConfig = {
+      cloud: { enabled: true, agentId: "agent-test" },
+      serviceRouting: {
+        media: { backend: "elizacloud", transport: "cloud-proxy" },
+      },
+    } as ElizaConfig;
+
+    applyCloudConfigToEnv(config);
+
+    expect(process.env.ELIZAOS_CLOUD_API_KEY).toBeUndefined();
+  });
+
+  it("still clears a stale env key when cloud is disabled with no service selected", () => {
+    // BYOK / disconnected hygiene must survive the capability-only change:
+    // cloud present-but-disabled and nothing routed → full env cleanse, so a
+    // leftover key can never zombie-load cloud behavior.
+    process.env.ELIZAOS_CLOUD_API_KEY = "stale-key";
+    const config: ElizaConfig = {
+      cloud: { enabled: false, apiKey: "stale-key" },
+    } as ElizaConfig;
+
+    applyCloudConfigToEnv(config);
+
+    expect(process.env.ELIZAOS_CLOUD_API_KEY).toBeUndefined();
+    expect(process.env.ELIZAOS_CLOUD_USE_INFERENCE).toBeUndefined();
+  });
+
   it("keeps managed cloud containers on the full runtime, not the thin client", () => {
     const config: ElizaConfig = {
       deploymentTarget: {

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -2124,7 +2124,22 @@ export function applyCloudConfigToEnv(config: ElizaConfig): void {
     );
   }
 
-  setCloudUsageEnv("ELIZAOS_CLOUD_USE_INFERENCE", effectivelyEnabled);
+  // USE_INFERENCE is a TRI-state contract with plugin-elizacloud's chat-brain
+  // registration (registerTextInferenceModels): "true" → Cloud serves the text
+  // slots; explicit "false" → the plugin is loaded for its capabilities only
+  // (image/media/TTS/embeddings/research) and must NOT register the chat-brain
+  // handlers another provider owns; unset → no host policy (standalone plugin
+  // use keeps its historical register-everything behavior). Deleting the var
+  // when inference is off (the old behavior) was indistinguishable from "no
+  // policy", so the plugin could never load capability-only — the host nuked
+  // the API key instead and lost image generation as collateral (#10819).
+  if (effectivelyEnabled) {
+    process.env.ELIZAOS_CLOUD_USE_INFERENCE = "true";
+  } else if (shouldLoadCloudPlugin) {
+    process.env.ELIZAOS_CLOUD_USE_INFERENCE = "false";
+  } else {
+    delete process.env.ELIZAOS_CLOUD_USE_INFERENCE;
+  }
   setCloudUsageEnv(
     "ELIZAOS_CLOUD_USE_TTS",
     topology.services.tts || isCloudContainer,
@@ -2152,17 +2167,25 @@ export function applyCloudConfigToEnv(config: ElizaConfig): void {
     logger.info(
       `[eliza] Cloud config: inference=${topology.services.inference}, runtime=${topology.runtime}, hasApiKey=${Boolean(cloud?.apiKey || process.env.ELIZAOS_CLOUD_API_KEY)}, baseUrl=${cloud?.baseUrl ?? "(default)"}, isCloudContainer=${isCloudContainer}`,
     );
-    // Only propagate the API key when cloud is enabled AND it is a real
-    // credential — never set the literal "[REDACTED]" placeholder (which can
-    // leak into the config via UI round-trips through the redacted GET → PUT
-    // cycle). WHY: when enabled is false (BYOK / disconnected), leaving the key
-    // in process.env still auto-loads @elizaos/plugin-elizacloud and steals
-    // TEXT_LARGE even if the JSON says cloud is off.
+    // Only propagate the API key from config when it is a real credential —
+    // never set the literal "[REDACTED]" placeholder (which can leak into the
+    // config via UI round-trips through the redacted GET → PUT cycle). When
+    // config carries no key, an env-provided key is KEPT: this branch means at
+    // least one cloud service is selected, and the selected capabilities need
+    // the credential. The historical wholesale delete here existed to stop the
+    // key from auto-loading @elizaos/plugin-elizacloud and stealing TEXT_LARGE;
+    // that is now prevented structurally by ELIZAOS_CLOUD_USE_INFERENCE=false
+    // (the plugin skips chat-brain registration), so deleting the key — and
+    // losing image/media/TTS with it — is no longer necessary (#10819). Only a
+    // leaked placeholder is still scrubbed.
     const isRealApiKey =
       cloud?.apiKey && cloud.apiKey.trim().toUpperCase() !== "[REDACTED]";
     if (isRealApiKey) {
       process.env.ELIZAOS_CLOUD_API_KEY = cloud.apiKey;
-    } else if (!isCloudContainer) {
+    } else if (
+      !isCloudContainer &&
+      process.env.ELIZAOS_CLOUD_API_KEY?.trim().toUpperCase() === "[REDACTED]"
+    ) {
       delete process.env.ELIZAOS_CLOUD_API_KEY;
     }
     if (cloud?.baseUrl) {

--- a/plugins/plugin-elizacloud/AGENTS.md
+++ b/plugins/plugin-elizacloud/AGENTS.md
@@ -4,7 +4,7 @@ Eliza Cloud integration — multi-model inference, container provisioning, agent
 
 ## Purpose / role
 
-Connects an Eliza agent to Eliza Cloud for hosted AI inference (text, embeddings, TTS, STT, image), container lifecycle management, real-time agent bridging via WebSocket, and billing/credit flows. Auto-enables when `ELIZAOS_CLOUD_API_KEY` or `ELIZAOS_CLOUD_ENABLED=true` is present (see `auto-enable.ts`). This plugin has priority 50, which means it wins the default text-generation slot over other direct provider plugins (priority 0) when no explicit routing preference is configured.
+Connects an Eliza agent to Eliza Cloud for hosted AI inference (text, embeddings, TTS, STT, image), container lifecycle management, real-time agent bridging via WebSocket, and billing/credit flows. Auto-enables when `ELIZAOS_CLOUD_API_KEY` or `ELIZAOS_CLOUD_ENABLED=true` is present (see `auto-enable.ts`). This plugin has priority 50, which means it wins the default text-generation slot over other direct provider plugins (priority 0) when no explicit routing preference is configured — **unless the host writes `ELIZAOS_CLOUD_USE_INFERENCE=false`** (`applyCloudConfigToEnv`), in which case the chat-brain handlers (`TEXT_*`, `RESPONSE_HANDLER`, `ACTION_PLANNER`) are not registered at all and only the capability handlers (IMAGE, IMAGE_DESCRIPTION, TEXT_TO_SPEECH, embeddings, RESEARCH) stay active. This capability-only mode is how an agent keeps Cloud image/media/TTS while an external provider (a CLI/SDK subscription brain, a local model) owns the text brain (elizaOS/eliza#10819).
 
 The plugin has two distinct export surfaces:
 
@@ -13,11 +13,27 @@ The plugin has two distinct export surfaces:
 
 ## Plugin surface
 
-### Model handlers (registered in `models` map)
+### Model handlers
+
+Two registration groups (elizaOS/eliza#10819):
+
+**Capability handlers — always registered (static `models` map).** These don't
+compete with the chat brain and must survive an external text provider:
 
 | Slot | Handler | File |
 |---|---|---|
 | `TEXT_EMBEDDING` | `handleTextEmbedding` | `src/models/embeddings.ts` |
+| `RESEARCH` | `handleResearch` | `src/models/research.ts` |
+| `IMAGE` | `handleImageGeneration` | `src/models/image.ts` |
+| `IMAGE_DESCRIPTION` | `handleImageDescription` | `src/models/image.ts` |
+| `TEXT_TO_SPEECH` | `handleTextToSpeech` | `src/models/speech.ts` |
+
+**Chat-brain handlers — registered from `init()`** (`registerTextInferenceModels`,
+`src/index.ts`), skipped when the host writes `ELIZAOS_CLOUD_USE_INFERENCE=false`
+(registered when it is `true` or unset — unset preserves standalone plugin use):
+
+| Slot | Handler | File |
+|---|---|---|
 | `TEXT_NANO` | `handleTextNano` | `src/models/text.ts` |
 | `TEXT_SMALL` | `handleTextSmall` | `src/models/text.ts` |
 | `TEXT_MEDIUM` | `handleTextMedium` | `src/models/text.ts` |
@@ -25,10 +41,6 @@ The plugin has two distinct export surfaces:
 | `TEXT_MEGA` | `handleTextMega` | `src/models/text.ts` |
 | `RESPONSE_HANDLER` | `handleResponseHandler` | `src/models/text.ts` |
 | `ACTION_PLANNER` | `handleActionPlanner` | `src/models/text.ts` |
-| `RESEARCH` | `handleResearch` | `src/models/research.ts` |
-| `IMAGE` | `handleImageGeneration` | `src/models/image.ts` |
-| `IMAGE_DESCRIPTION` | `handleImageDescription` | `src/models/image.ts` |
-| `TEXT_TO_SPEECH` | `handleTextToSpeech` | `src/models/speech.ts` |
 
 ### Providers
 

--- a/plugins/plugin-elizacloud/CLAUDE.md
+++ b/plugins/plugin-elizacloud/CLAUDE.md
@@ -4,7 +4,7 @@ Eliza Cloud integration — multi-model inference, container provisioning, agent
 
 ## Purpose / role
 
-Connects an Eliza agent to Eliza Cloud for hosted AI inference (text, embeddings, TTS, STT, image), container lifecycle management, real-time agent bridging via WebSocket, and billing/credit flows. Auto-enables when `ELIZAOS_CLOUD_API_KEY` or `ELIZAOS_CLOUD_ENABLED=true` is present (see `auto-enable.ts`). This plugin has priority 50, which means it wins the default text-generation slot over other direct provider plugins (priority 0) when no explicit routing preference is configured.
+Connects an Eliza agent to Eliza Cloud for hosted AI inference (text, embeddings, TTS, STT, image), container lifecycle management, real-time agent bridging via WebSocket, and billing/credit flows. Auto-enables when `ELIZAOS_CLOUD_API_KEY` or `ELIZAOS_CLOUD_ENABLED=true` is present (see `auto-enable.ts`). This plugin has priority 50, which means it wins the default text-generation slot over other direct provider plugins (priority 0) when no explicit routing preference is configured — **unless the host writes `ELIZAOS_CLOUD_USE_INFERENCE=false`** (`applyCloudConfigToEnv`), in which case the chat-brain handlers (`TEXT_*`, `RESPONSE_HANDLER`, `ACTION_PLANNER`) are not registered at all and only the capability handlers (IMAGE, IMAGE_DESCRIPTION, TEXT_TO_SPEECH, embeddings, RESEARCH) stay active. This capability-only mode is how an agent keeps Cloud image/media/TTS while an external provider (a CLI/SDK subscription brain, a local model) owns the text brain (elizaOS/eliza#10819).
 
 The plugin has two distinct export surfaces:
 
@@ -13,11 +13,27 @@ The plugin has two distinct export surfaces:
 
 ## Plugin surface
 
-### Model handlers (registered in `models` map)
+### Model handlers
+
+Two registration groups (elizaOS/eliza#10819):
+
+**Capability handlers — always registered (static `models` map).** These don't
+compete with the chat brain and must survive an external text provider:
 
 | Slot | Handler | File |
 |---|---|---|
 | `TEXT_EMBEDDING` | `handleTextEmbedding` | `src/models/embeddings.ts` |
+| `RESEARCH` | `handleResearch` | `src/models/research.ts` |
+| `IMAGE` | `handleImageGeneration` | `src/models/image.ts` |
+| `IMAGE_DESCRIPTION` | `handleImageDescription` | `src/models/image.ts` |
+| `TEXT_TO_SPEECH` | `handleTextToSpeech` | `src/models/speech.ts` |
+
+**Chat-brain handlers — registered from `init()`** (`registerTextInferenceModels`,
+`src/index.ts`), skipped when the host writes `ELIZAOS_CLOUD_USE_INFERENCE=false`
+(registered when it is `true` or unset — unset preserves standalone plugin use):
+
+| Slot | Handler | File |
+|---|---|---|
 | `TEXT_NANO` | `handleTextNano` | `src/models/text.ts` |
 | `TEXT_SMALL` | `handleTextSmall` | `src/models/text.ts` |
 | `TEXT_MEDIUM` | `handleTextMedium` | `src/models/text.ts` |
@@ -25,10 +41,6 @@ The plugin has two distinct export surfaces:
 | `TEXT_MEGA` | `handleTextMega` | `src/models/text.ts` |
 | `RESPONSE_HANDLER` | `handleResponseHandler` | `src/models/text.ts` |
 | `ACTION_PLANNER` | `handleActionPlanner` | `src/models/text.ts` |
-| `RESEARCH` | `handleResearch` | `src/models/research.ts` |
-| `IMAGE` | `handleImageGeneration` | `src/models/image.ts` |
-| `IMAGE_DESCRIPTION` | `handleImageDescription` | `src/models/image.ts` |
-| `TEXT_TO_SPEECH` | `handleTextToSpeech` | `src/models/speech.ts` |
 
 ### Providers
 

--- a/plugins/plugin-elizacloud/__tests__/unit/text-inference-gating.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/text-inference-gating.test.ts
@@ -1,0 +1,107 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { ModelType } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { elizaOSCloudPlugin, registerTextInferenceModels } from "../../src/index";
+
+/**
+ * Chat-brain arbitration regression guard (elizaOS/eliza#10819).
+ *
+ * The plugin used to register its TEXT_* / RESPONSE_HANDLER / ACTION_PLANNER
+ * handlers unconditionally in the static `models` map at priority 50, which
+ * silently stole the chat brain from priority-0 provider plugins whenever a
+ * Cloud key was present. Hosts worked around it by deleting
+ * ELIZAOS_CLOUD_API_KEY wholesale — killing Cloud IMAGE/media/TTS as
+ * collateral, so "generate an image" hard-failed on any agent whose text brain
+ * was an external provider.
+ *
+ * The contract now: chat-brain handlers register from init() via
+ * registerTextInferenceModels, honoring the host-written tri-state
+ * ELIZAOS_CLOUD_USE_INFERENCE — explicit "false" skips them (capability-only
+ * mode), "true"/unset registers them (cloud brain / standalone use).
+ */
+
+const CHAT_BRAIN_SLOTS = [
+  String(ModelType.TEXT_NANO ?? "TEXT_NANO"),
+  String(ModelType.TEXT_MEDIUM ?? "TEXT_MEDIUM"),
+  String(ModelType.TEXT_SMALL),
+  String(ModelType.TEXT_LARGE),
+  String(ModelType.TEXT_MEGA ?? "TEXT_MEGA"),
+  String(ModelType.RESPONSE_HANDLER ?? "RESPONSE_HANDLER"),
+  String(ModelType.ACTION_PLANNER ?? "ACTION_PLANNER"),
+];
+
+function fakeRuntime(settings: Record<string, string | undefined>) {
+  const registered: Array<{
+    modelType: string;
+    provider: string;
+    priority?: number;
+  }> = [];
+  const runtime = {
+    getSetting: (key: string) => settings[key],
+    registerModel: (
+      modelType: string,
+      _handler: unknown,
+      provider: string,
+      priority?: number,
+    ) => {
+      registered.push({ modelType, provider, priority });
+    },
+  } as unknown as IAgentRuntime;
+  return { runtime, registered };
+}
+
+// The plugin's getSetting falls back to process.env; isolate the suite from
+// the outer environment so a host-written flag can't skew assertions.
+let savedFlag: string | undefined;
+beforeEach(() => {
+  savedFlag = process.env.ELIZAOS_CLOUD_USE_INFERENCE;
+  delete process.env.ELIZAOS_CLOUD_USE_INFERENCE;
+});
+afterEach(() => {
+  if (savedFlag === undefined) delete process.env.ELIZAOS_CLOUD_USE_INFERENCE;
+  else process.env.ELIZAOS_CLOUD_USE_INFERENCE = savedFlag;
+});
+
+describe("registerTextInferenceModels — chat-brain arbitration (#10819)", () => {
+  it("registers every chat-brain slot when the host sets USE_INFERENCE=true", () => {
+    const { runtime, registered } = fakeRuntime({
+      ELIZAOS_CLOUD_USE_INFERENCE: "true",
+    });
+    registerTextInferenceModels(runtime);
+    expect(registered.map((r) => r.modelType).sort()).toEqual(
+      [...CHAT_BRAIN_SLOTS].sort(),
+    );
+    for (const r of registered) {
+      expect(r.provider).toBe(elizaOSCloudPlugin.name);
+      expect(r.priority).toBe(elizaOSCloudPlugin.priority);
+    }
+  });
+
+  it("registers when the flag is unset (standalone plugin use, no host policy)", () => {
+    const { runtime, registered } = fakeRuntime({});
+    registerTextInferenceModels(runtime);
+    expect(registered).toHaveLength(CHAT_BRAIN_SLOTS.length);
+  });
+
+  it("registers NOTHING when the host explicitly denies inference (capability-only mode)", () => {
+    const { runtime, registered } = fakeRuntime({
+      ELIZAOS_CLOUD_USE_INFERENCE: "false",
+    });
+    registerTextInferenceModels(runtime);
+    expect(registered).toHaveLength(0);
+  });
+
+  it("keeps capability handlers in the static models map and chat-brain slots out of it", () => {
+    const models = elizaOSCloudPlugin.models ?? {};
+    // Capabilities that must survive an external text brain:
+    expect(models).toHaveProperty(String(ModelType.IMAGE));
+    expect(models).toHaveProperty(String(ModelType.IMAGE_DESCRIPTION));
+    expect(models).toHaveProperty(String(ModelType.TEXT_TO_SPEECH));
+    expect(models).toHaveProperty(String(ModelType.TEXT_EMBEDDING));
+    expect(models).toHaveProperty(String(ModelType.RESEARCH));
+    // Chat-brain slots are init-registered, never static:
+    for (const slot of CHAT_BRAIN_SLOTS) {
+      expect(models).not.toHaveProperty(slot);
+    }
+  });
+});

--- a/plugins/plugin-elizacloud/src/index.ts
+++ b/plugins/plugin-elizacloud/src/index.ts
@@ -31,6 +31,7 @@ import { CloudContainerService } from "./services/cloud-container";
 import { CloudCredentialProvider } from "./services/cloud-credential-provider";
 import { CloudManagedGatewayRelayService } from "./services/cloud-managed-gateway-relay";
 import { CloudModelRegistryService } from "./services/cloud-model-registry";
+import { getSetting } from "./utils/config";
 import { createCloudApiClient } from "./utils/sdk-client";
 import { createWaifuMeteringHandler } from "./utils/waifu-metering";
 
@@ -48,6 +49,53 @@ function getProcessEnv(): ProcessEnvLike {
 }
 
 const env = getProcessEnv();
+
+// ─── Chat-brain text-inference handlers ───────────────────────────────
+// Registered from init() rather than the static `models` map so a host can
+// run a DIFFERENT text brain (a CLI/SDK subscription provider, a local
+// model, …) while keeping Cloud's capability handlers — IMAGE,
+// IMAGE_DESCRIPTION, TEXT_TO_SPEECH, embeddings, RESEARCH — active. At
+// priority 50 a static registration silently steals the chat-brain slots
+// from priority-0 provider plugins whenever a Cloud key is present, which
+// forced hosts to nuke ELIZAOS_CLOUD_API_KEY wholesale and lose image/media
+// generation as collateral (elizaOS/eliza#10819).
+//
+// The host expresses the arbitration decision through
+// ELIZAOS_CLOUD_USE_INFERENCE (written by applyCloudConfigToEnv):
+//   - explicit "false"  → another provider owns the chat brain; skip these
+//                         handlers, capability handlers stay registered.
+//   - "true" or unset   → Cloud serves the chat brain (unset preserves
+//                         standalone plugin use outside the agent host).
+// Mirrors plugin-openai's registerMediaModels() conditional-registration
+// pattern; init() runs before the runtime's static-models registration
+// loop, so both paths land in the same priority-sorted registry.
+const textInferenceModels: NonNullable<Plugin["models"]> = {
+  [TEXT_NANO_MODEL_TYPE]: handleTextNano,
+  [TEXT_MEDIUM_MODEL_TYPE]: handleTextMedium,
+  [ModelType.TEXT_SMALL]: handleTextSmall,
+  [ModelType.TEXT_LARGE]: handleTextLarge,
+  [TEXT_MEGA_MODEL_TYPE]: handleTextMega,
+  [RESPONSE_HANDLER_MODEL_TYPE]: handleResponseHandler,
+  [ACTION_PLANNER_MODEL_TYPE]: handleActionPlanner,
+};
+
+export function registerTextInferenceModels(runtime: IAgentRuntime): void {
+  const flag = getSetting(runtime, "ELIZAOS_CLOUD_USE_INFERENCE");
+  if (flag?.trim().toLowerCase() === "false") {
+    logger.info(
+      "[ElizaOSCloud] Not registering chat-brain text handlers: ELIZAOS_CLOUD_USE_INFERENCE=false (another provider owns the text brain; image/media/TTS/embedding handlers stay active)"
+    );
+    return;
+  }
+  for (const [modelType, handler] of Object.entries(textInferenceModels)) {
+    runtime.registerModel(
+      modelType,
+      handler as Parameters<IAgentRuntime["registerModel"]>[1],
+      elizaOSCloudPlugin.name,
+      elizaOSCloudPlugin.priority
+    );
+  }
+}
 
 export const elizaOSCloudPlugin: Plugin = {
   name: "elizaOSCloud",
@@ -130,6 +178,9 @@ export const elizaOSCloudPlugin: Plugin = {
   async init(config, runtime) {
     // Initialize inference (OpenAI-compatible client)
     initializeOpenAI(config, runtime);
+    // Chat-brain text handlers are conditional (see textInferenceModels
+    // above); capability handlers stay in the static `models` map below.
+    registerTextInferenceModels(runtime);
   },
 
   // ─── Runtime Event Handlers ──────────────────────────────────────────
@@ -170,20 +221,17 @@ export const elizaOSCloudPlugin: Plugin = {
     modelRegistryProvider,
   ],
 
-  // ─── Inference Model Handlers ────────────────────────────────────────
+  // ─── Capability Model Handlers ───────────────────────────────────────
+  // Always registered: these capabilities don't compete with the chat brain
+  // and must survive an external text provider. The chat-brain text handlers
+  // (TEXT_*, RESPONSE_HANDLER, ACTION_PLANNER) are registered conditionally
+  // from init() — see textInferenceModels above.
   models: {
     [ModelType.TEXT_EMBEDDING]: handleTextEmbedding,
     // Batch path: one request embeds N texts (the embedding-drain service uses
     // this to collapse serial single-text round-trips into fewer batched calls).
     [ModelType.TEXT_EMBEDDING_BATCH]: (runtime, params: { texts: string[] }) =>
       handleBatchTextEmbedding(runtime, params.texts),
-    [TEXT_NANO_MODEL_TYPE]: handleTextNano,
-    [TEXT_MEDIUM_MODEL_TYPE]: handleTextMedium,
-    [ModelType.TEXT_SMALL]: handleTextSmall,
-    [ModelType.TEXT_LARGE]: handleTextLarge,
-    [TEXT_MEGA_MODEL_TYPE]: handleTextMega,
-    [RESPONSE_HANDLER_MODEL_TYPE]: handleResponseHandler,
-    [ACTION_PLANNER_MODEL_TYPE]: handleActionPlanner,
     [ModelType.RESEARCH]: handleResearch,
     [ModelType.IMAGE]: handleImageGeneration,
     [ModelType.IMAGE_DESCRIPTION]: handleImageDescription,


### PR DESCRIPTION
## Problem (elizaOS/eliza#10819)

A cloud-keyed agent whose **text brain is an external provider** (a CLI/SDK subscription brain, a local model) cannot generate images — even though Eliza Cloud's Fal-backed image pipeline is one env var away.

Root cause chain, proven on a live agent by dumping the runtime's registered model handlers:

1. `applyCloudConfigToEnv` treats "cloud inference off" as "cloud off": `effectivelyEnabled = topology.services.inference || isCloudContainer`, and when false it **deletes `ELIZAOS_CLOUD_API_KEY` wholesale**. The inline comment says why: leaving the key would auto-load `plugin-elizacloud`, whose **unconditional** `models` map at **priority 50** steals `TEXT_LARGE` from the priority-0 brain plugin.
2. With the key nuked, plugin-elizacloud registers **zero** handlers → `getModel(ModelType.IMAGE)` is `undefined` → `hasImageGenerationModel()` false → `GENERATE_MEDIA.validate()` fails every turn → the action never enters the planner catalog → *"I can't generate images — no image tool is exposed."* (Live probe: registered models were `cli-inference` text slots + `embeddings` + `edge-tts` only.)

So the all-or-nothing brain guard kills image/media/TTS as collateral. The per-service intent already exists (`ELIZAOS_CLOUD_USE_MEDIA`/`_TTS`/`_EMBEDDINGS` flags) but nothing gated the plugin's chat-brain registration.

## Fix — arbitrate per capability, not per key

**plugin-elizacloud** — chat-brain handlers (`TEXT_NANO/SMALL/MEDIUM/LARGE/MEGA`, `RESPONSE_HANDLER`, `ACTION_PLANNER`) move out of the static `models` map into `init()`-time registration (`registerTextInferenceModels`), skipped on an explicit `ELIZAOS_CLOUD_USE_INFERENCE=false`. Capability handlers (`IMAGE`, `IMAGE_DESCRIPTION`, `TEXT_TO_SPEECH`, embeddings, `RESEARCH`) stay static — they never compete with the chat brain. This mirrors plugin-openai's existing `registerMediaModels()` conditional-registration precedent (`plugins/plugin-openai/index.ts:108`); `init()` runs before the runtime's static-models loop, so both paths land in the same priority-sorted registry.

**applyCloudConfigToEnv** — `USE_INFERENCE` becomes an explicit tri-state: `"true"` (cloud brain) / `"false"` (plugin loaded capability-only) / deleted (plugin not loaded). The old delete-on-false was indistinguishable from "no policy". With brain-stealing prevented structurally, an env-provided API key is now **kept** when cloud services are selected (only a leaked `"[REDACTED]"` placeholder is scrubbed); disconnected/BYOK configs with no cloud service still get the full env cleanse.

**Blast-radius audit before changing semantics:** mapped every consumer of the touched vars. `USE_INFERENCE` had **zero behavioral readers** (write-only + tests) — safe to define the contract. `ELIZAOS_CLOUD_ENABLED` is read by wallet RPC proxies, `isCloudConnected`, legacy cloud-TTS, and device-auth as "cloud available" — **untouched** by this PR.

## Evidence

Real registration path (`AgentRuntime` + the real plugin object):

```
USE_INFERENCE=false  → IMAGE=function  TEXT_LARGE=undefined  ACTION_PLANNER=undefined   ← capability-only: image alive, no steal
USE_INFERENCE=true   → IMAGE=function  TEXT_LARGE=function   ACTION_PLANNER=function    ← cloud brain unchanged
unset                → IMAGE=function  TEXT_LARGE=function   ACTION_PLANNER=function    ← standalone use unchanged
```

Live before-state (the bug): agent with a valid cloud key + CLI-SDK brain → registered models contained **no** elizaOSCloud entries; "generate an image of a robot playing guitar" → *"Image generation isn't available to me this turn."*

## Tests

- **New** `plugins/plugin-elizacloud/__tests__/unit/text-inference-gating.test.ts` (4): registers all 7 chat-brain slots on `"true"`/unset with the plugin's name+priority; registers nothing on `"false"`; static map keeps capabilities and excludes chat-brain slots.
- **New** host cases in `packages/agent/src/runtime/eliza-cloud-config.test.ts` (4): capability-only topology → `USE_INFERENCE="false"` + `USE_MEDIA="true"` + key retained + `ENABLED` untouched; env-key retention; `[REDACTED]` scrub; disabled-no-service full cleanse.
- Full plugin suite 27/29 files green (260 tests; the 1 failing routes test fails identically on clean `develop` — pre-existing). `eliza-cloud-config` 15/15. Plugin typecheck clean; agent typecheck errors are the pre-existing missing-optional-module set from `develop` (none introduced).
- Docs: plugin `CLAUDE.md`/`AGENTS.md` model-handler table split into the two registration groups (kept identical, per repo rule).

Closes the capability-wiring half of #10819 (the retrieval/simile-exposure half is #10945). Also narrows #10893: with capability handlers surviving, a follow-up can use cloud text as a rate-limit fallback tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
