### PR TITLE
fix(cloud): keep Stripe clawbacks nonnegative

### DIFF
--- a/.github/issue-evidence/10920-stripe-refund-clawback.md
+++ b/.github/issue-evidence/10920-stripe-refund-clawback.md
@@ -1,0 +1,25 @@
+# 10920 Stripe Refund Clawback Evidence
+
+## Scope
+
+Backend-only Stripe queue and credit ledger fix. No UI, frontend logs,
+screenshots, video, audio, or real-LLM trajectories apply.
+
+## Verification
+
+```bash
+bun test packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts
+```
+
+Result: 14 pass, 0 fail, 71 expect() calls. This ran the PGlite-backed path with
+the test `organizations.credit_balance` CHECK constraint enabled.
+
+```bash
+bun test packages/cloud/api/__tests__/stripe-event-clawback.test.ts packages/cloud/api/__tests__/stripe-event-waifu.test.ts
+```
+
+Result: 4 pass, 0 fail, 14 expect() calls.
+
+Note: run the shared-service and API queue suites separately. The API queue test
+mocks `@/lib/services/credits`, which contaminates the later shared-service
+import when both files run in one Bun process.

--- a/packages/cloud/api/__tests__/stripe-event-clawback.test.ts
+++ b/packages/cloud/api/__tests__/stripe-event-clawback.test.ts
@@ -6,7 +6,12 @@ const getTransactionByStripePaymentIntent = mock(async () => ({
   amount: "100",
 }));
 const getClawedBackUsdForPaymentIntent = mock(async () => 0);
-const clawbackCredits = mock(async () => ({ newBalance: 25 }));
+const clawbackCredits = mock(async () => ({
+  newBalance: 25,
+  appliedAmount: 20,
+  shortfallAmount: 0,
+  alreadyProcessed: false,
+}));
 
 mock.module("@/db/helpers", () => ({
   dbRead: {},
@@ -68,7 +73,12 @@ describe("stripe queue credit clawbacks", () => {
     getClawedBackUsdForPaymentIntent.mockClear();
     getClawedBackUsdForPaymentIntent.mockResolvedValue(0);
     clawbackCredits.mockClear();
-    clawbackCredits.mockResolvedValue({ newBalance: 25 });
+    clawbackCredits.mockResolvedValue({
+      newBalance: 25,
+      appliedAmount: 20,
+      shortfallAmount: 0,
+      alreadyProcessed: false,
+    });
   });
 
   test("charge.refunded claws back only the new cumulative refund delta", async () => {

--- a/packages/cloud/api/src/queue/stripe-event.ts
+++ b/packages/cloud/api/src/queue/stripe-event.ts
@@ -849,9 +849,11 @@ function chargePaymentIntentId(charge: Stripe.Charge): string | undefined {
 /**
  * Claw back org credits for the portion of a top-up charge that Stripe reversed.
  * Balance top-ups grant credits 1:1 with USD, so `usdReversed` credits are
- * removed — allowing the balance to go negative, since the org may already have
- * spent them. Only the DELTA past what was already clawed for this payment intent
- * is removed, so multiple partial refunds and re-delivered webhooks are safe.
+ * removed up to the org's current balance. Any unrecovered portion is recorded
+ * on the clawback transaction metadata because the organizations table has a
+ * nonnegative balance constraint. Only the DELTA past what was already clawed
+ * for this payment intent is removed, so multiple partial refunds and
+ * re-delivered webhooks are safe.
  */
 async function clawbackForReversal(params: {
   paymentIntentId: string | undefined;
@@ -896,8 +898,20 @@ async function clawbackForReversal(params: {
       reference,
     },
   });
+
+  if (result.alreadyProcessed) {
+    logger.info(
+      `[Stripe Queue] ${source} ${reference}: clawback key ${idempotencyKey} already processed`,
+    );
+    return;
+  }
+
   logger.warn(
-    `[Stripe Queue] Clawed back $${delta.toFixed(2)} from org ${grant.organization_id} for ${source} ${reference} (new balance $${result.newBalance.toFixed(2)})`,
+    `[Stripe Queue] Clawed back $${result.appliedAmount.toFixed(2)} from org ${grant.organization_id} for ${source} ${reference} (new balance $${result.newBalance.toFixed(2)})`,
+    {
+      requestedUsd: delta,
+      unrecoveredUsd: result.shortfallAmount,
+    },
   );
 }
 

--- a/packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts
@@ -74,7 +74,7 @@ beforeAll(async () => {
         id uuid PRIMARY KEY,
         name text NOT NULL DEFAULT 'test-org',
         slug text NOT NULL DEFAULT 'test-org',
-        credit_balance numeric(20,6) NOT NULL DEFAULT '0',
+        credit_balance numeric(20,6) NOT NULL DEFAULT '0' CHECK (credit_balance >= 0),
         settings jsonb DEFAULT '{}',
         stripe_customer_id text,
         billing_email text,
@@ -498,17 +498,15 @@ describe("CreditsService.reconcile idempotency (#10846)", () => {
 });
 
 /**
- * #10920: a Stripe refund / chargeback must claw back the credits the top-up
- * granted — even below zero, since the org may already have spent them —
- * idempotently, so a re-delivered webhook or a growing cumulative partial-refund
- * total never double-charges.
+ * #10920: a Stripe refund / chargeback must claw back credits the top-up
+ * granted, while respecting the live credit_balance >= 0 check constraint.
  */
 describe("CreditsService.clawbackCredits (#10920)", () => {
   test(
-    "decrements the balance BELOW zero and records a negative clawback tx",
+    "floors the balance at zero and records unrecovered shortfall metadata",
     async () => {
       if (!pgliteReady) return;
-      await seedOrg("50"); // org spent a $1000 top-up down to $50
+      await seedOrg("50"); // org spent a $100 top-up down to $50
       const r = await creditsService.clawbackCredits({
         organizationId: ORG_ID,
         amount: 100,
@@ -516,9 +514,23 @@ describe("CreditsService.clawbackCredits (#10920)", () => {
         stripePaymentIntentId: "stripe:refund:ch_1:10000",
         metadata: { payment_intent_id: "pi_1" },
       });
-      expect(await getBalance()).toBeCloseTo(-50, 6);
-      expect(r.newBalance).toBeCloseTo(-50, 6);
+
+      expect(await getBalance()).toBeCloseTo(0, 6);
+      expect(r.newBalance).toBeCloseTo(0, 6);
+      expect(r.appliedAmount).toBeCloseTo(50, 6);
+      expect(r.shortfallAmount).toBeCloseTo(50, 6);
+      expect(r.alreadyProcessed).toBe(false);
       expect(await countByType("clawback")).toBe(1);
+
+      const clawbackRow = await dbWrite.execute(
+        `SELECT amount, metadata FROM credit_transactions WHERE organization_id = '${ORG_ID}' AND type = 'clawback';`,
+      );
+      const row = clawbackRow.rows[0] as {
+        amount: string;
+        metadata: Record<string, unknown>;
+      };
+      expect(Number(row.amount)).toBeCloseTo(-50, 6);
+      expect(Number(row.metadata.unrecovered_clawback_usd)).toBeCloseTo(50, 6);
     },
     PGLITE_TIMEOUT,
   );
@@ -529,23 +541,32 @@ describe("CreditsService.clawbackCredits (#10920)", () => {
       if (!pgliteReady) return;
       await seedOrg("100");
       const key = "stripe:refund:ch_2:5000";
-      for (let i = 0; i < 2; i++) {
-        await creditsService.clawbackCredits({
-          organizationId: ORG_ID,
-          amount: 50,
-          description: "refund clawback",
-          stripePaymentIntentId: key,
-          metadata: { payment_intent_id: "pi_2" },
-        });
-      }
+
+      const first = await creditsService.clawbackCredits({
+        organizationId: ORG_ID,
+        amount: 50,
+        description: "refund clawback",
+        stripePaymentIntentId: key,
+        metadata: { payment_intent_id: "pi_2" },
+      });
+      const second = await creditsService.clawbackCredits({
+        organizationId: ORG_ID,
+        amount: 50,
+        description: "refund clawback",
+        stripePaymentIntentId: key,
+        metadata: { payment_intent_id: "pi_2" },
+      });
+
       expect(await getBalance()).toBeCloseTo(50, 6); // clawed once, not twice
       expect(await countByType("clawback")).toBe(1);
+      expect(second.transaction.id).toBe(first.transaction.id);
+      expect(second.alreadyProcessed).toBe(true);
     },
     PGLITE_TIMEOUT,
   );
 
   test(
-    "getClawedBackUsdForPaymentIntent sums prior clawbacks (for partial-refund deltas)",
+    "getClawedBackUsdForPaymentIntent sums prior applied clawbacks (for partial-refund deltas)",
     async () => {
       if (!pgliteReady) return;
       await seedOrg("100");
@@ -563,6 +584,7 @@ describe("CreditsService.clawbackCredits (#10920)", () => {
         stripePaymentIntentId: "stripe:refund:ch_3:5000",
         metadata: { payment_intent_id: "pi_3" },
       });
+
       expect(await creditsService.getClawedBackUsdForPaymentIntent("pi_3")).toBeCloseTo(50, 6);
       expect(await creditsService.getClawedBackUsdForPaymentIntent("pi_none")).toBe(0);
       // Balance clawed the full $50 across the two partials.

--- a/packages/cloud/shared/src/lib/services/credits.ts
+++ b/packages/cloud/shared/src/lib/services/credits.ts
@@ -146,6 +146,12 @@ interface CreditMutationRow {
   created_at: Date | string | null;
 }
 
+interface ClawbackMutationRow extends CreditMutationRow {
+  applied_amount: string | number | null;
+  shortfall_amount: string | number | null;
+  already_processed: boolean | string | number | null;
+}
+
 function isPgTrue(value: boolean | string | number | null | undefined): boolean {
   return value === true || value === 1 || value === "1" || value === "t" || value === "true";
 }
@@ -820,13 +826,12 @@ export class CreditsService {
   }
 
   /**
-   * Claw back credits after a Stripe refund / chargeback (#10920). Decrements the
-   * balance by `amount` USD, ALLOWING it to go negative — the org was refunded
-   * (or lost a dispute for) credits it may already have spent, so it genuinely
-   * owes the difference; flooring at zero would silently forgive the retained
-   * value. Idempotent on `stripePaymentIntentId` (key it on the refund/dispute so
-   * a re-delivered webhook doesn't double-claw). Records a negative `clawback`
-   * transaction.
+   * Claw back credits after a Stripe refund / chargeback (#10920). The live
+   * organizations table forbids negative credit balances, so this applies as much
+   * of the clawback as the current balance can cover, floors the balance at zero,
+   * and records any unrecovered shortfall in transaction metadata for follow-up.
+   * Idempotent on `stripePaymentIntentId` (key it on the refund/dispute so a
+   * re-delivered webhook doesn't double-claw).
    */
   async clawbackCredits(params: {
     organizationId: string;
@@ -834,21 +839,157 @@ export class CreditsService {
     description: string;
     stripePaymentIntentId: string;
     metadata?: Record<string, unknown>;
-  }): Promise<{ transaction: CreditTransaction; newBalance: number }> {
+  }): Promise<{
+    transaction: CreditTransaction;
+    newBalance: number;
+    appliedAmount: number;
+    shortfallAmount: number;
+    alreadyProcessed: boolean;
+  }> {
     if (params.amount <= 0) {
       throw new Error("Clawback amount must be positive");
     }
 
-    const result = await this.applyCreditIncrease({
-      organizationId: params.organizationId,
-      // Negative → the shared path decrements the balance (with no zero floor)
-      // and writes a negative-amount transaction.
-      amount: -params.amount,
-      description: params.description,
-      metadata: params.metadata,
-      stripePaymentIntentId: params.stripePaymentIntentId,
-      transactionType: "clawback",
-    });
+    const metadataJson = JSON.stringify(params.metadata ?? {});
+    const rows = await sqlRows<ClawbackMutationRow>(
+      dbWrite,
+      sql`
+        WITH org AS (
+          SELECT id, credit_balance::numeric AS current_balance
+          FROM organizations
+          WHERE id = ${params.organizationId}
+          FOR UPDATE
+        ),
+        existing AS (
+          SELECT
+            id,
+            organization_id,
+            user_id,
+            amount,
+            type,
+            description,
+            metadata,
+            stripe_payment_intent_id,
+            created_at
+          FROM credit_transactions
+          WHERE stripe_payment_intent_id = ${params.stripePaymentIntentId}
+          LIMIT 1
+        ),
+        candidate AS (
+          SELECT
+            id,
+            current_balance,
+            LEAST(${String(params.amount)}::numeric, GREATEST(current_balance, 0)) AS applied_amount,
+            GREATEST(current_balance - ${String(params.amount)}::numeric, 0) AS new_balance,
+            GREATEST(${String(params.amount)}::numeric - GREATEST(current_balance, 0), 0) AS shortfall_amount
+          FROM org
+          WHERE NOT EXISTS (SELECT 1 FROM existing)
+        ),
+        updated AS (
+          UPDATE organizations AS o
+          SET
+            credit_balance = candidate.new_balance,
+            updated_at = NOW()
+          FROM candidate
+          WHERE o.id = candidate.id
+          RETURNING o.credit_balance AS new_balance
+        ),
+        inserted AS (
+          INSERT INTO credit_transactions (
+            organization_id,
+            amount,
+            type,
+            description,
+            metadata,
+            stripe_payment_intent_id,
+            created_at
+          )
+          SELECT
+            candidate.id,
+            -candidate.applied_amount,
+            'clawback',
+            ${params.description},
+            ${metadataJson}::jsonb || jsonb_build_object(
+              'requested_clawback_usd', ${String(params.amount)}::numeric,
+              'applied_clawback_usd', candidate.applied_amount,
+              'unrecovered_clawback_usd', candidate.shortfall_amount
+            ),
+            ${params.stripePaymentIntentId},
+            NOW()
+          FROM candidate
+          WHERE EXISTS (SELECT 1 FROM updated)
+          ON CONFLICT (stripe_payment_intent_id) DO NOTHING
+          RETURNING
+            id,
+            organization_id,
+            user_id,
+            amount,
+            type,
+            description,
+            metadata,
+            stripe_payment_intent_id,
+            created_at
+        ),
+        chosen_transaction AS (
+          SELECT * FROM inserted
+          UNION ALL
+          SELECT * FROM existing
+          WHERE NOT EXISTS (SELECT 1 FROM inserted)
+          LIMIT 1
+        )
+        SELECT
+          EXISTS(SELECT 1 FROM org) AS org_exists,
+          (SELECT current_balance FROM org) AS current_balance,
+          COALESCE((SELECT new_balance FROM updated), (SELECT current_balance FROM org)) AS new_balance,
+          chosen_transaction.id,
+          chosen_transaction.organization_id,
+          chosen_transaction.user_id,
+          chosen_transaction.amount,
+          chosen_transaction.type,
+          chosen_transaction.description,
+          chosen_transaction.metadata,
+          chosen_transaction.stripe_payment_intent_id,
+          chosen_transaction.created_at,
+          COALESCE((SELECT applied_amount FROM candidate), ABS((SELECT amount FROM existing)), 0) AS applied_amount,
+          COALESCE(
+            (SELECT shortfall_amount FROM candidate),
+            NULLIF((SELECT metadata->>'unrecovered_clawback_usd' FROM existing), '')::numeric,
+            0
+          ) AS shortfall_amount,
+          EXISTS(SELECT 1 FROM existing) AS already_processed
+        FROM (SELECT 1) AS singleton
+        LEFT JOIN chosen_transaction ON true
+      `,
+    );
+
+    const row = rows[0];
+    if (!row || !isPgTrue(row.org_exists)) {
+      throw new Error("Organization not found");
+    }
+    if (!row.id) {
+      const existing = await this.getTransactionByStripePaymentIntent(params.stripePaymentIntentId);
+      const org = await organizationsRepository.findById(params.organizationId);
+      if (existing && org) {
+        const metadata = parseMetadata(existing.metadata);
+        return {
+          transaction: existing,
+          newBalance: Number.parseFloat(String(org.credit_balance)),
+          appliedAmount: Math.abs(Number(existing.amount)),
+          shortfallAmount: Number(metadata.unrecovered_clawback_usd ?? 0),
+          alreadyProcessed: true,
+        };
+      }
+      throw new Error("[CreditsService] Clawback did not return a transaction row");
+    }
+
+    const result = {
+      transaction: toCreditTransaction(row),
+      newBalance: parseNumeric(row.new_balance, "new_balance"),
+      appliedAmount: parseNumeric(row.applied_amount, "applied_amount"),
+      shortfallAmount: parseNumeric(row.shortfall_amount, "shortfall_amount"),
+      alreadyProcessed: isPgTrue(row.already_processed),
+    };
+
     invalidateOrganizationCache(params.organizationId).catch((error) => {
       logger.error("[CreditsService] Failed to invalidate org cache:", error);
     });


### PR DESCRIPTION
## Summary
- follow up to #10938: replace negative-balance Stripe clawbacks with a clamp that respects the live `credit_balance >= 0` CHECK constraint
- record applied and unrecovered clawback amounts in transaction metadata and queue logs
- add DB-backed coverage with the production CHECK constraint present

## Evidence
- `.github/issue-evidence/10920-stripe-refund-clawback.md`

## Validation
- `bun run biome check packages/cloud/shared/src/lib/services/credits.ts packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts packages/cloud/api/src/queue/stripe-event.ts packages/cloud/api/__tests__/stripe-event-clawback.test.ts packages/cloud/api/__tests__/stripe-event-waifu.test.ts .github/issue-evidence/10920-stripe-refund-clawback.md`
- `bun run --cwd packages/cloud/shared typecheck`
- `bun run --cwd packages/cloud/api typecheck`
- `bun test packages/cloud/api/__tests__/stripe-event-clawback.test.ts packages/cloud/api/__tests__/stripe-event-waifu.test.ts`
- `bun test packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts`
- `git diff --check`

## Notes
- Run the shared-service and API queue test commands separately; the API queue test intentionally mocks `@/lib/services/credits`, which contaminates later imports in the same Bun process.
- UI/video/screenshots/audio/real-LLM trajectories: N/A, backend Stripe queue and credit ledger only.