### PR TITLE
fix(training): repair analysis-report client script (SyntaxError in hrefForPath)

### DIFF
--- a/plugins/plugin-training/src/core/training-analysis-index.test.ts
+++ b/plugins/plugin-training/src/core/training-analysis-index.test.ts
@@ -853,6 +853,38 @@ describe("training analysis index", () => {
     ]);
 
     const html = await readFile(index.indexHtmlPath, "utf8");
+
+    // The embedded report <script> must be syntactically valid. A broken regex
+    // in hrefForPath (`:///i`, parsed by the browser as a regex literal + a `//`
+    // line comment) previously left an unclosed `if (` and turned the ENTIRE
+    // <script> into a SyntaxError, disabling all report interactivity (filters,
+    // sorting, clickable source-file links). new Function() compiles without
+    // executing, so it surfaces a SyntaxError without needing a DOM.
+    const clientScript = html.match(/<script>([\s\S]*?)<\/script>/)?.[1];
+    expect(clientScript, "report client <script> not found").toBeTruthy();
+    expect(() => new Function(clientScript as string)).not.toThrow();
+
+    // hrefForPath must build valid file:// URLs for POSIX and Windows paths and
+    // pass existing URLs through (it is pure, so eval it in isolation).
+    const hrefForPathSrc = clientScript?.match(
+      /function hrefForPath\(value\)[\s\S]*?\n {4}\}/,
+    )?.[0];
+    expect(
+      hrefForPathSrc,
+      "hrefForPath not found in report script",
+    ).toBeTruthy();
+    const hrefForPath = new Function(
+      `${hrefForPathSrc}\nreturn hrefForPath;`,
+    )() as (value: string) => string | null;
+    expect(hrefForPath("https://example.com/x")).toBe("https://example.com/x");
+    expect(hrefForPath("/home/me/report.html")).toBe(
+      "file:///home/me/report.html",
+    );
+    expect(hrefForPath("C:\\Users\\me\\report.html")).toBe(
+      "file:///C:/Users/me/report.html",
+    );
+    expect(hrefForPath("plain.txt")).toBeNull();
+
     expect(html).toContain("Eliza Training Analysis");
     expect(html).toContain("Source inventory");
     expect(html).toContain("Readable source samples");

--- a/plugins/plugin-training/src/core/training-analysis-index.ts
+++ b/plugins/plugin-training/src/core/training-analysis-index.ts
@@ -2855,8 +2855,11 @@ function buildIndexHtml(manifest: TrainingAnalysisIndexManifest): string {
     function hrefForPath(value) {
       const path = typeof value === "string" ? value.trim() : "";
       if (!path) return null;
-      if (/^[a-z][a-z0-9+.-]*:///i.test(path)) return path;
-      if (path.startsWith("/")) return "file://" + encodeURI(path);
+      if (path.indexOf("://") !== -1) return path;
+      const normalized = path.split(String.fromCharCode(92)).join("/");
+      if (normalized.charAt(0) === "/") return "file://" + encodeURI(normalized);
+      if (normalized.length > 1 && normalized.charAt(1) === ":")
+        return "file:///" + encodeURI(normalized);
       return null;
     }
     function appendPathCell(row, value) {


### PR DESCRIPTION
## What & why

The training analysis report (`buildIndexHtml` in `training-analysis-index.ts`,
written to `index.html` and served as the viewer) embeds a client-side
`hrefForPath` whose URL-scheme guard was:

```js
if (/^[a-z][a-z0-9+.-]*:///i.test(path)) return path;
```

The browser parses that as the regex literal `/^[a-z][a-z0-9+.-]*:/` **followed
by a `//` line comment** — leaving an unclosed `if (` that collides with the next
line. The **entire `<script>` fails to parse** (`SyntaxError: Unexpected token
'if'`), so *all* report interactivity — search, run/tier filters, sorting, and
every clickable source-file link — is dead in every browser. Separately it only
linked POSIX paths (`startsWith("/")`), never Windows drive paths.

## Fix

Rewrite `hrefForPath` without a regex (fragile inside the HTML template literal):
`indexOf("://")` for the already-a-URL passthrough, normalize backslashes via
`String.fromCharCode(92)`, then emit `file:///C:/…` for a `C:`-drive path and
`file:///…` for a POSIX path. No regex/backslash escaping hazards in the emitted
script.

## Tests / evidence

Extends the existing report test (`training-analysis-index.test.ts`) to:
- compile **every** emitted `<script>` with `new Function()` (surfaces a
  `SyntaxError` without needing a DOM), and
- eval the extracted `hrefForPath` against URL passthrough, POSIX, Windows drive
  path, and a non-path input.

Verified fail-before / pass-after — on the old code the new assertion fails:

```
AssertionError: expected [Function] to not throw an error but
  'SyntaxError: Unexpected token 'if'' was thrown
 ❯ training-analysis-index.test.ts:865  expect(() => new Function(clientScript)).not.toThrow();
```

and passes after the fix:

```
 Test Files  1 passed (1)
      Tests  1 passed | 7 skipped (8)
```

biome clean; the change is confined to the emitted client-script string + its test.

- Real-LLM trajectory — N/A: static report-HTML generation, no model call.
- Screenshots/video — N/A: the defect is a `SyntaxError` in the emitted `<script>`, demonstrated directly by the `new Function()` compile assertion above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)