### PR TITLE
fix(core): fail over exhausted model providers

### DIFF
--- a/.github/issue-evidence/10893-provider-failover.md
+++ b/.github/issue-evidence/10893-provider-failover.md
@@ -1,0 +1,31 @@
+# Issue #10893 — CLI SDK Provider Failover
+
+## Scope
+
+- Runtime-only change in `packages/core/src/runtime.ts`.
+- `AgentRuntime.useModel` now tries the next registered provider when the
+  preferred provider throws a recognized rate-limit/session-limit exhaustion
+  error.
+- Explicit provider calls remain pinned to that provider, preserving
+  per-action model routing behavior.
+
+## Validation
+
+- `bun test packages/core/src/runtime/__tests__/model-provider-failover.test.ts`
+- `bun test packages/core/src/services/__tests__/failure-reply-prompt.test.ts`
+- `bun test packages/core/src/runtime/__tests__/streaming-use-model.test.ts`
+- `bun run --cwd packages/core typecheck`
+- `bun run --cwd packages/core build:node`
+- `bun run biome check packages/core/src/runtime.ts packages/core/src/runtime/__tests__/model-provider-failover.test.ts .github/issue-evidence/10893-provider-failover.md`
+- `git diff --check`
+
+## Evidence Matrix
+
+- Backend/runtime logs: covered by the focused `AgentRuntime.useModel` unit
+  tests above, including exhausted preferred provider, non-retriable error, and
+  explicit provider pinning.
+- Real-LLM trajectory: N/A — this fix is verified with deterministic provider
+  handlers because reproducing a live subscription-exhausted CLI SDK account is
+  not available in the local environment.
+- Frontend screenshots/video: N/A — no UI surface changed.
+- Console/network logs: N/A — no browser or network flow changed.

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -76,6 +76,7 @@ import {
 	SecretSwapSession,
 } from "./security/secret-swap";
 import { DefaultMessageService } from "./services/message";
+import { isRateLimitError } from "./services/message/fallback-reply";
 import type { ToolPolicyService } from "./services/tool-policy";
 import { decryptSecret, getSalt } from "./settings";
 import {
@@ -769,6 +770,12 @@ function timeoutAfter(ms: number): Promise<"timeout"> {
 	return new Promise((resolve) => {
 		setTimeout(() => resolve("timeout"), ms);
 	});
+}
+
+interface ResolvedModelRegistration {
+	handler: ModelHandler["handler"];
+	modelKey: string;
+	provider: string;
 }
 
 export class AgentRuntime implements IAgentRuntime {
@@ -4563,17 +4570,16 @@ export class AgentRuntime implements IAgentRuntime {
 	private resolveModelRegistration(
 		modelType: ModelTypeName | string,
 		provider?: string,
-	):
-		| {
-				handler: (
-					runtime: IAgentRuntime,
-					params: Record<string, JsonValue | object>,
-				) => Promise<JsonValue | object>;
-				modelKey: string;
-				provider: string;
-		  }
-		| undefined {
+	): ResolvedModelRegistration | undefined {
+		return this.resolveModelRegistrations(modelType, provider)[0];
+	}
+
+	private resolveModelRegistrations(
+		modelType: ModelTypeName | string,
+		provider?: string,
+	): ResolvedModelRegistration[] {
 		const requestedModelKey = String(modelType);
+		const resolvedModels: ResolvedModelRegistration[] = [];
 
 		for (const candidateKey of getModelFallbackChain(requestedModelKey)) {
 			const models = this.models.get(candidateKey);
@@ -4581,38 +4587,89 @@ export class AgentRuntime implements IAgentRuntime {
 				continue;
 			}
 
-			const modelWithProvider =
-				provider && models.find((model) => model.provider === provider);
-			if (provider && !modelWithProvider) {
-				continue;
+			const candidateModels = provider
+				? models.filter((model) => model.provider === provider)
+				: models;
+
+			for (const resolvedModel of candidateModels) {
+				if (candidateKey !== requestedModelKey) {
+					this.logger.debug(
+						{
+							src: "agent",
+							agentId: this.agentId,
+							requestedModel: requestedModelKey,
+							resolvedModel: candidateKey,
+							provider: resolvedModel.provider,
+						},
+						"Model fallback applied",
+					);
+				}
+
+				resolvedModels.push({
+					handler: resolvedModel.handler,
+					modelKey: candidateKey,
+					provider: resolvedModel.provider,
+				});
 			}
 
-			const resolvedModel = modelWithProvider ?? models[0];
-			if (!resolvedModel) {
-				continue;
+			if (provider && candidateModels.length > 0) {
+				break;
 			}
-
-			if (candidateKey !== requestedModelKey) {
-				this.logger.debug(
-					{
-						src: "agent",
-						agentId: this.agentId,
-						requestedModel: requestedModelKey,
-						resolvedModel: candidateKey,
-						provider: resolvedModel.provider,
-					},
-					"Model fallback applied",
-				);
-			}
-
-			return {
-				handler: resolvedModel.handler,
-				modelKey: candidateKey,
-				provider: resolvedModel.provider,
-			};
 		}
 
-		return undefined;
+		return resolvedModels;
+	}
+
+	private logModelProviderFailover(args: {
+		requestedModelKey: string;
+		failedModel: ResolvedModelRegistration;
+		nextModel: ResolvedModelRegistration;
+		error: unknown;
+	}): void {
+		this.logger.warn(
+			{
+				src: "agent",
+				agentId: this.agentId,
+				requestedModel: args.requestedModelKey,
+				failedModel: args.failedModel.modelKey,
+				failedProvider: args.failedModel.provider,
+				nextModel: args.nextModel.modelKey,
+				nextProvider: args.nextModel.provider,
+				error:
+					args.error instanceof Error ? args.error.message : String(args.error),
+			},
+			"Model provider rate-limited; trying next registered provider",
+		);
+	}
+
+	private shouldFailOverModelProvider(error: unknown): boolean {
+		return isRateLimitError(error);
+	}
+
+	private throwNoModelHandler(requestedModelKey: string): never {
+		// If the request is for a text-generation model AND no text-generation
+		// handler is registered for ANY of the text model types, this is the
+		// "no LLM provider configured at all" state — surface a typed error
+		// so callers (chat UI, etc.) can render an actionable hint instead of
+		// a generic "No handler found for delegate type" parse-failure message.
+		// Issue: elizaOS/eliza#7203.
+		if (TEXT_GENERATION_MODEL_KEYS.includes(requestedModelKey)) {
+			const hasAnyTextHandler = TEXT_GENERATION_MODEL_KEYS.some((key) => {
+				const handlers = this.models.get(key);
+				return Array.isArray(handlers) && handlers.length > 0;
+			});
+			if (!hasAnyTextHandler) {
+				throw new NoModelProviderConfiguredError();
+			}
+		}
+		throw new Error(`No handler found for delegate type: ${requestedModelKey}`);
+	}
+
+	private rethrowModelFailoverError(error: unknown): never {
+		if (error instanceof Error) {
+			throw error;
+		}
+		throw new Error(String(error));
 	}
 
 	getModel(
@@ -4945,706 +5002,735 @@ export class AgentRuntime implements IAgentRuntime {
 			}
 		}
 
-		const resolvedModel = this.resolveModelRegistration(
+		const resolvedModels = this.resolveModelRegistrations(
 			requestedModelKey,
 			provider,
 		);
-		const resolvedModelKey = resolvedModel?.modelKey ?? requestedModelKey;
-		const handler = resolvedModel?.handler;
-		if (!handler) {
-			// If the request is for a text-generation model AND no text-generation
-			// handler is registered for ANY of the text model types, this is the
-			// "no LLM provider configured at all" state — surface a typed error
-			// so callers (chat UI, etc.) can render an actionable hint instead of
-			// a generic "No handler found for delegate type" parse-failure message.
-			// Issue: elizaOS/eliza#7203.
-			if (TEXT_GENERATION_MODEL_KEYS.includes(requestedModelKey)) {
-				const hasAnyTextHandler = TEXT_GENERATION_MODEL_KEYS.some((key) => {
-					const handlers = this.models.get(key);
-					return Array.isArray(handlers) && handlers.length > 0;
-				});
-				if (!hasAnyTextHandler) {
-					throw new NoModelProviderConfiguredError();
-				}
-			}
-			const errorMsg = `No handler found for delegate type: ${requestedModelKey}`;
-			throw new Error(errorMsg);
+		if (resolvedModels.length === 0) {
+			this.throwNoModelHandler(requestedModelKey);
 		}
 
-		const binaryModels: string[] = [
-			ModelType.TRANSCRIPTION,
-			ModelType.IMAGE,
-			ModelType.AUDIO,
-			ModelType.VIDEO,
-		];
-		// PII swap skips binary-input modalities (nothing to swap) and TEXT_EMBEDDING
-		// (a random per-turn surrogate would destabilize embeddings), but — unlike
-		// the secret gate — swaps IMAGE prompts, whose text can carry real names.
-		const PII_SWAP_SKIP_MODELS: string[] = [
-			ModelType.TRANSCRIPTION,
-			ModelType.AUDIO,
-			ModelType.VIDEO,
-			ModelType.TEXT_EMBEDDING,
-		];
-		let modelParams: ModelParamsMap[T];
-		const paramsClone = isPlainObject(params)
-			? { ...(params as Record<string, JsonValue | object>) }
-			: params;
-		if (
-			params === null ||
-			params === undefined ||
-			typeof params !== "object" ||
-			Array.isArray(params) ||
-			BufferUtils.isBuffer(params)
+		let lastModelError: unknown;
+		for (
+			let resolvedIndex = 0;
+			resolvedIndex < resolvedModels.length;
+			resolvedIndex++
 		) {
-			modelParams = paramsClone as ModelParamsMap[T];
-		} else {
-			// Include model settings from character configuration if available
-			const modelSettings = this.getModelSettings(requestedModelKey);
+			const resolvedModel = resolvedModels[resolvedIndex];
+			if (!resolvedModel) {
+				continue;
+			}
+			const resolvedModelKey = resolvedModel.modelKey;
+			const handler = resolvedModel.handler;
 
-			if (modelSettings) {
-				// Apply model settings if configured — merged object is narrowed at handlers after routing.
-				const merged: object = {
-					...modelSettings,
-					...(paramsClone as Record<string, JsonValue | object>),
+			try {
+				const binaryModels: string[] = [
+					ModelType.TRANSCRIPTION,
+					ModelType.IMAGE,
+					ModelType.AUDIO,
+					ModelType.VIDEO,
+				];
+				// PII swap skips binary-input modalities (nothing to swap) and TEXT_EMBEDDING
+				// (a random per-turn surrogate would destabilize embeddings), but — unlike
+				// the secret gate — swaps IMAGE prompts, whose text can carry real names.
+				const PII_SWAP_SKIP_MODELS: string[] = [
+					ModelType.TRANSCRIPTION,
+					ModelType.AUDIO,
+					ModelType.VIDEO,
+					ModelType.TEXT_EMBEDDING,
+				];
+				let modelParams: ModelParamsMap[T];
+				const paramsClone = isPlainObject(params)
+					? { ...(params as Record<string, JsonValue | object>) }
+					: params;
+				if (
+					params === null ||
+					params === undefined ||
+					typeof params !== "object" ||
+					Array.isArray(params) ||
+					BufferUtils.isBuffer(params)
+				) {
+					modelParams = paramsClone as ModelParamsMap[T];
+				} else {
+					// Include model settings from character configuration if available
+					const modelSettings = this.getModelSettings(requestedModelKey);
+
+					if (modelSettings) {
+						// Apply model settings if configured — merged object is narrowed at handlers after routing.
+						const merged: object = {
+							...modelSettings,
+							...(paramsClone as Record<string, JsonValue | object>),
+						};
+						modelParams = merged as ModelParamsMap[T];
+					} else {
+						// No model settings configured, use params as-is
+						modelParams = paramsClone as ModelParamsMap[T];
+					}
+
+					// Auto-populate user parameter from character name if not provided
+					// The `user` parameter is used by LLM providers for tracking and analytics purposes.
+					// We only auto-populate when user is undefined (not explicitly set to empty string or null)
+					// to allow users to intentionally set an empty identifier if needed.
+					const shouldAttachUser =
+						requestedModelKey === ModelType.TEXT_NANO ||
+						requestedModelKey === ModelType.TEXT_SMALL ||
+						requestedModelKey === ModelType.TEXT_MEDIUM ||
+						requestedModelKey === ModelType.TEXT_LARGE ||
+						requestedModelKey === ModelType.TEXT_MEGA ||
+						requestedModelKey === ModelType.RESPONSE_HANDLER ||
+						requestedModelKey === ModelType.ACTION_PLANNER ||
+						requestedModelKey === ModelType.TEXT_REASONING_SMALL ||
+						requestedModelKey === ModelType.TEXT_REASONING_LARGE ||
+						requestedModelKey === ModelType.TEXT_COMPLETION;
+					if (
+						shouldAttachUser &&
+						isPlainObject(modelParams) &&
+						this.character.name
+					) {
+						const modelParamsRecord = modelParams as Record<
+							string,
+							JsonValue | object
+						>;
+						if (modelParamsRecord.user === undefined) {
+							modelParamsRecord.user = this.character.name;
+						}
+					}
+				}
+				const startTime =
+					typeof performance !== "undefined" &&
+					typeof performance.now === "function"
+						? performance.now()
+						: Date.now();
+
+				// Get streaming config
+				// Define interface for params that may have streaming properties
+				interface StreamingParams {
+					stream?: boolean;
+					onStreamChunk?: StreamChunkCallback;
+					signal?: AbortSignal;
+					streamStructured?: boolean;
+					responseSkeleton?: ResponseSkeleton;
+				}
+				const streamingCtx = getStreamingContext();
+				const paramsAsStreaming = isPlainObject(modelParams)
+					? (modelParams as StreamingParams)
+					: undefined;
+				const paramsChunk = paramsAsStreaming?.onStreamChunk;
+				const ctxChunk = streamingCtx?.onStreamChunk;
+				const msgId = streamingCtx?.messageId;
+				const abortSignal = streamingCtx?.abortSignal;
+				const explicitStream = paramsAsStreaming?.stream;
+				const resolvedProviderName = resolvedModel?.provider;
+				// stream: false = force no stream, otherwise stream if any callback exists.
+				// Vision describes are often hidden preprocessing/OCR calls inside a chat
+				// turn; do not leak those chunks into the visible chat stream unless the
+				// call itself opts in.
+				const requiresExplicitStreaming =
+					requestedModelKey === ModelType.IMAGE_DESCRIPTION;
+				const shouldStream =
+					explicitStream === false
+						? false
+						: requiresExplicitStreaming
+							? explicitStream === true
+							: !!(paramsChunk || ctxChunk || explicitStream);
+				const structuredStreamFields =
+					shouldStream && paramsAsStreaming?.streamStructured === true
+						? resolveResponseSkeletonStreamFields(
+								paramsAsStreaming.responseSkeleton,
+							)
+						: [];
+				const downstreamChunk = (chunk: string, accumulated?: string): void => {
+					void (async () => {
+						if (paramsChunk) await paramsChunk(chunk, msgId, accumulated);
+						if (ctxChunk) await ctxChunk(chunk, msgId, accumulated);
+					})();
 				};
-				modelParams = merged as ModelParamsMap[T];
-			} else {
-				// No model settings configured, use params as-is
-				modelParams = paramsClone as ModelParamsMap[T];
-			}
+				const structuredExtractor =
+					structuredStreamFields.length > 0 &&
+					paramsAsStreaming?.responseSkeleton
+						? new ResponseSkeletonStreamExtractor({
+								skeleton: paramsAsStreaming.responseSkeleton,
+								streamFields: structuredStreamFields,
+								unordered: true,
+								onChunk: (chunk, _field, accumulated) =>
+									downstreamChunk(chunk, accumulated),
+								...(abortSignal ? { abortSignal } : {}),
+							})
+						: undefined;
+				let handlerDeliveredStream = false;
+				let streamedText = "";
+				let secretSwapSession: SecretSwapSession | null = null;
+				let guardedStreamBuffer = "";
+				let piiSwapSession: PseudonymSession | null = null;
+				const emitModelStreamChunk = async (
+					safeChunk: string,
+					visibleChunk = safeChunk,
+				): Promise<void> => {
+					if (abortSignal?.aborted) return;
+					if (streamedText === "" && safeChunk.length > 0) {
+						markInference(INFERENCE_MARKS.firstToken);
+					}
+					streamedText += safeChunk;
+					const trajStream = getTrajectoryContext();
+					await this.invokePipelineHooks(
+						"model_stream_chunk",
+						modelStreamChunkPipelineHookContext({
+							source: "use_model",
+							chunk: safeChunk,
+							messageId: msgId,
+							roomId:
+								(trajStream?.roomId as UUID | undefined) ??
+								this.currentRoomId ??
+								this.agentId,
+							runId: this.getCurrentRunId(),
+							...(trajStream?.messageId
+								? { responseId: trajStream.messageId as UUID }
+								: {}),
+							accumulated: streamedText,
+						}),
+						"Model stream chunk (useModel)",
+						false,
+					);
+					await runInsideModelStreamChunkDelivery(async () => {
+						if (structuredExtractor) {
+							structuredExtractor.push(visibleChunk);
+							return;
+						}
+						if (paramsChunk) await paramsChunk(visibleChunk, msgId, undefined);
+						if (ctxChunk) await ctxChunk(visibleChunk, msgId, undefined);
+					});
+				};
+				const deliverModelStreamChunk = async (
+					chunk: string,
+				): Promise<void> => {
+					if (abortSignal?.aborted) return;
+					if (secretSwapSession || piiSwapSession) {
+						guardedStreamBuffer += chunk;
+						return;
+					}
+					await emitModelStreamChunk(chunk);
+				};
+				const flushGuardedStream = async (): Promise<void> => {
+					if (
+						abortSignal?.aborted ||
+						(!secretSwapSession && !piiSwapSession) ||
+						guardedStreamBuffer.length === 0
+					) {
+						return;
+					}
+					let safeText = guardedStreamBuffer;
+					guardedStreamBuffer = "";
+					if (secretSwapSession) {
+						safeText = secretSwapSession.substituteText(safeText);
+					}
+					if (piiSwapSession) {
+						safeText = piiSwapSession.substituteText(safeText);
+					}
+					if (safeText.length > 0) {
+						const visibleText = piiSwapSession
+							? piiSwapSession.restoreText(safeText)
+							: safeText;
+						await emitModelStreamChunk(safeText, visibleText);
+					}
+				};
+				// Wire the handler-facing stream callback for local providers AND for the
+				// prefer-local router ("eliza-router"): the router resolves to itself as
+				// the top-priority handler but invokes the underlying provider's handler
+				// directly and forwards `onStreamChunk` transparently, so on mobile (where
+				// the router is always the resolved provider, dispatching to the on-device
+				// capacitor-llama / bionic host) streaming is only wired if we recognize
+				// it here. Scoped to the streaming gate only — it intentionally does NOT
+				// change validation/pricing semantics keyed on isLocalProvider().
+				const resolvedIsStreamableLocal =
+					!!resolvedProviderName &&
+					(isLocalProvider(resolvedProviderName) ||
+						resolvedProviderName === "eliza-router");
+				const handlerStreamChunk: StreamChunkCallback | undefined =
+					shouldStream &&
+					resolvedIsStreamableLocal &&
+					(paramsChunk || ctxChunk || structuredExtractor)
+						? async (chunk) => {
+								handlerDeliveredStream = true;
+								await deliverModelStreamChunk(chunk);
+							}
+						: undefined;
 
-			// Auto-populate user parameter from character name if not provided
-			// The `user` parameter is used by LLM providers for tracking and analytics purposes.
-			// We only auto-populate when user is undefined (not explicitly set to empty string or null)
-			// to allow users to intentionally set an empty identifier if needed.
-			const shouldAttachUser =
-				requestedModelKey === ModelType.TEXT_NANO ||
-				requestedModelKey === ModelType.TEXT_SMALL ||
-				requestedModelKey === ModelType.TEXT_MEDIUM ||
-				requestedModelKey === ModelType.TEXT_LARGE ||
-				requestedModelKey === ModelType.TEXT_MEGA ||
-				requestedModelKey === ModelType.RESPONSE_HANDLER ||
-				requestedModelKey === ModelType.ACTION_PLANNER ||
-				requestedModelKey === ModelType.TEXT_REASONING_SMALL ||
-				requestedModelKey === ModelType.TEXT_REASONING_LARGE ||
-				requestedModelKey === ModelType.TEXT_COMPLETION;
-			if (
-				shouldAttachUser &&
-				isPlainObject(modelParams) &&
-				this.character.name
-			) {
-				const modelParamsRecord = modelParams as Record<
-					string,
-					JsonValue | object
-				>;
-				if (modelParamsRecord.user === undefined) {
-					modelParamsRecord.user = this.character.name;
+				if (isPlainObject(modelParams) && paramsAsStreaming) {
+					paramsAsStreaming.stream = shouldStream;
+					if (handlerStreamChunk) {
+						paramsAsStreaming.onStreamChunk = handlerStreamChunk;
+					} else {
+						delete paramsAsStreaming.onStreamChunk;
+					}
+					// Plumb the streaming-context abort signal into model params so the
+					// underlying handler can wire it into its transport (e.g. local
+					// llama's `stopOnAbortSignal`, fetch's `signal`). Only inject when
+					// the caller didn't already pass one explicitly.
+					if (paramsAsStreaming.signal === undefined && abortSignal) {
+						paramsAsStreaming.signal = abortSignal;
+					}
 				}
-			}
-		}
-		const startTime =
-			typeof performance !== "undefined" &&
-			typeof performance.now === "function"
-				? performance.now()
-				: Date.now();
 
-		// Get streaming config
-		// Define interface for params that may have streaming properties
-		interface StreamingParams {
-			stream?: boolean;
-			onStreamChunk?: StreamChunkCallback;
-			signal?: AbortSignal;
-			streamStructured?: boolean;
-			responseSkeleton?: ResponseSkeleton;
-		}
-		const streamingCtx = getStreamingContext();
-		const paramsAsStreaming = isPlainObject(modelParams)
-			? (modelParams as StreamingParams)
-			: undefined;
-		const paramsChunk = paramsAsStreaming?.onStreamChunk;
-		const ctxChunk = streamingCtx?.onStreamChunk;
-		const msgId = streamingCtx?.messageId;
-		const abortSignal = streamingCtx?.abortSignal;
-		const explicitStream = paramsAsStreaming?.stream;
-		const resolvedProviderName = resolvedModel?.provider;
-		// stream: false = force no stream, otherwise stream if any callback exists.
-		// Vision describes are often hidden preprocessing/OCR calls inside a chat
-		// turn; do not leak those chunks into the visible chat stream unless the
-		// call itself opts in.
-		const requiresExplicitStreaming =
-			requestedModelKey === ModelType.IMAGE_DESCRIPTION;
-		const shouldStream =
-			explicitStream === false
-				? false
-				: requiresExplicitStreaming
-					? explicitStream === true
-					: !!(paramsChunk || ctxChunk || explicitStream);
-		const structuredStreamFields =
-			shouldStream && paramsAsStreaming?.streamStructured === true
-				? resolveResponseSkeletonStreamFields(
-						paramsAsStreaming.responseSkeleton,
-					)
-				: [];
-		const downstreamChunk = (chunk: string, accumulated?: string): void => {
-			void (async () => {
-				if (paramsChunk) await paramsChunk(chunk, msgId, accumulated);
-				if (ctxChunk) await ctxChunk(chunk, msgId, accumulated);
-			})();
-		};
-		const structuredExtractor =
-			structuredStreamFields.length > 0 && paramsAsStreaming?.responseSkeleton
-				? new ResponseSkeletonStreamExtractor({
-						skeleton: paramsAsStreaming.responseSkeleton,
-						streamFields: structuredStreamFields,
-						unordered: true,
-						onChunk: (chunk, _field, accumulated) =>
-							downstreamChunk(chunk, accumulated),
-						...(abortSignal ? { abortSignal } : {}),
-					})
-				: undefined;
-		let handlerDeliveredStream = false;
-		let streamedText = "";
-		let secretSwapSession: SecretSwapSession | null = null;
-		let guardedStreamBuffer = "";
-		let piiSwapSession: PseudonymSession | null = null;
-		const emitModelStreamChunk = async (
-			safeChunk: string,
-			visibleChunk = safeChunk,
-		): Promise<void> => {
-			if (abortSignal?.aborted) return;
-			if (streamedText === "" && safeChunk.length > 0) {
-				markInference(INFERENCE_MARKS.firstToken);
-			}
-			streamedText += safeChunk;
-			const trajStream = getTrajectoryContext();
-			await this.invokePipelineHooks(
-				"model_stream_chunk",
-				modelStreamChunkPipelineHookContext({
-					source: "use_model",
-					chunk: safeChunk,
-					messageId: msgId,
-					roomId:
-						(trajStream?.roomId as UUID | undefined) ??
-						this.currentRoomId ??
-						this.agentId,
-					runId: this.getCurrentRunId(),
-					...(trajStream?.messageId
-						? { responseId: trajStream.messageId as UUID }
-						: {}),
-					accumulated: streamedText,
-				}),
-				"Model stream chunk (useModel)",
-				false,
-			);
-			await runInsideModelStreamChunkDelivery(async () => {
-				if (structuredExtractor) {
-					structuredExtractor.push(visibleChunk);
-					return;
+				const textModelKey = TEXT_GENERATION_MODEL_KEYS.includes(
+					String(resolvedModelKey),
+				)
+					? String(resolvedModelKey)
+					: requestedModelKey;
+				let effectiveSystemPrompt = this.attachEffectiveSystemPrompt(
+					textModelKey,
+					modelParams,
+				);
+
+				if (
+					this.isSecretSwapEnabled() &&
+					!binaryModels.includes(resolvedModelKey)
+				) {
+					// Reuse one session per turn so every model call in the turn shares a
+					// nonce and the action-execution boundary can restore what this call
+					// swapped. The session hangs off the turn-scoped trajectory context;
+					// calls outside a trajectory scope fall back to a per-call session
+					// (no egress restore — there is no execution boundary to restore at).
+					const trajectoryCtx = getTrajectoryContext();
+					secretSwapSession =
+						trajectoryCtx?.secretSwapSession ?? this.createSecretSwapSession();
+					if (trajectoryCtx && !trajectoryCtx.secretSwapSession) {
+						trajectoryCtx.secretSwapSession = secretSwapSession;
+					}
+					modelParams = secretSwapSession.substituteInValue(modelParams);
+					effectiveSystemPrompt =
+						effectiveSystemPrompt === undefined
+							? undefined
+							: secretSwapSession.substituteText(effectiveSystemPrompt);
 				}
-				if (paramsChunk) await paramsChunk(visibleChunk, msgId, undefined);
-				if (ctxChunk) await ctxChunk(visibleChunk, msgId, undefined);
-			});
-		};
-		const deliverModelStreamChunk = async (chunk: string): Promise<void> => {
-			if (abortSignal?.aborted) return;
-			if (secretSwapSession || piiSwapSession) {
-				guardedStreamBuffer += chunk;
-				return;
-			}
-			await emitModelStreamChunk(chunk);
-		};
-		const flushGuardedStream = async (): Promise<void> => {
-			if (
-				abortSignal?.aborted ||
-				(!secretSwapSession && !piiSwapSession) ||
-				guardedStreamBuffer.length === 0
-			) {
-				return;
-			}
-			let safeText = guardedStreamBuffer;
-			guardedStreamBuffer = "";
-			if (secretSwapSession) {
-				safeText = secretSwapSession.substituteText(safeText);
-			}
-			if (piiSwapSession) {
-				safeText = piiSwapSession.substituteText(safeText);
-			}
-			if (safeText.length > 0) {
-				const visibleText = piiSwapSession
-					? piiSwapSession.restoreText(safeText)
-					: safeText;
-				await emitModelStreamChunk(safeText, visibleText);
-			}
-		};
-		// Wire the handler-facing stream callback for local providers AND for the
-		// prefer-local router ("eliza-router"): the router resolves to itself as
-		// the top-priority handler but invokes the underlying provider's handler
-		// directly and forwards `onStreamChunk` transparently, so on mobile (where
-		// the router is always the resolved provider, dispatching to the on-device
-		// capacitor-llama / bionic host) streaming is only wired if we recognize
-		// it here. Scoped to the streaming gate only — it intentionally does NOT
-		// change validation/pricing semantics keyed on isLocalProvider().
-		const resolvedIsStreamableLocal =
-			!!resolvedProviderName &&
-			(isLocalProvider(resolvedProviderName) ||
-				resolvedProviderName === "eliza-router");
-		const handlerStreamChunk: StreamChunkCallback | undefined =
-			shouldStream &&
-			resolvedIsStreamableLocal &&
-			(paramsChunk || ctxChunk || structuredExtractor)
-				? async (chunk) => {
-						handlerDeliveredStream = true;
+
+				// Models the PII swap must NOT touch: binary-input modalities (nothing to
+				// swap) and — unlike the secret gate — IMAGE is INCLUDED (its text prompt
+				// can carry real names), while TEXT_EMBEDDING is EXCLUDED (a per-turn-random
+				// surrogate would embed the same real text differently every turn and wreck
+				// semantic memory retrieval; embeddings stay on the real text).
+				let piiIngressText = "";
+				if (
+					this.isPiiSwapEnabled() &&
+					!PII_SWAP_SKIP_MODELS.includes(resolvedModelKey)
+				) {
+					// Turn-scoped like the secret session (same mapping all turn), so the
+					// execution boundary can restore what this call swapped.
+					const trajectoryCtx = getTrajectoryContext();
+					piiSwapSession =
+						trajectoryCtx?.piiSwapSession ?? this.createPiiSwapSession();
+					if (trajectoryCtx && !trajectoryCtx.piiSwapSession) {
+						trajectoryCtx.piiSwapSession = piiSwapSession;
+					}
+					// The awaited detection step: learn every named entity in the assembled
+					// prompt (params + system prompt), then substitute synchronously. Ordered
+					// after the secret pass, so the NER model reads opaque
+					// `__ELIZA_SECRET_…__` placeholders, never a raw secret. The ONNX
+					// inference is offloaded to onnxruntime's threadpool, so it overlaps the
+					// event loop rather than blocking other turns.
+					piiIngressText = this.collectPromptText(
+						modelParams,
+						effectiveSystemPrompt,
+					);
+					await piiSwapSession.learn(piiIngressText);
+					modelParams = piiSwapSession.substituteInValue(modelParams);
+					effectiveSystemPrompt =
+						effectiveSystemPrompt === undefined
+							? undefined
+							: piiSwapSession.substituteText(effectiveSystemPrompt);
+				}
+
+				await this.invokePipelineHooks(
+					"pre_model",
+					preModelPipelineHookContext({
+						requestedModelType: String(modelType),
+						resolvedModelKey,
+						provider: resolvedModel.provider,
+						roomId: getTrajectoryContext()?.roomId,
+						params: modelParams,
+					}),
+					"Pre-model pipeline hook",
+				);
+				if (secretSwapSession) {
+					modelParams = secretSwapSession.substituteInValue(modelParams);
+					const postHookSystemPrompt = resolveEffectiveSystemPrompt({
+						params: modelParams,
+						fallback: effectiveSystemPrompt,
+					});
+					effectiveSystemPrompt =
+						postHookSystemPrompt === undefined
+							? undefined
+							: secretSwapSession.substituteText(postHookSystemPrompt);
+				}
+				if (piiSwapSession) {
+					// pre_model hooks may have injected fresh text (RAG snippets, extra
+					// context) with never-seen PII. If the assembled text changed, re-run
+					// detection so that new PII is swapped too — not just already-learned
+					// values re-masked. learn() is idempotent, so this only adds new entities.
+					const postHookText = this.collectPromptText(
+						modelParams,
+						effectiveSystemPrompt,
+					);
+					if (postHookText !== piiIngressText) {
+						await piiSwapSession.learn(postHookText);
+					}
+					modelParams = piiSwapSession.substituteInValue(modelParams);
+					const postHookSystemPrompt = resolveEffectiveSystemPrompt({
+						params: modelParams,
+						fallback: effectiveSystemPrompt,
+					});
+					effectiveSystemPrompt =
+						postHookSystemPrompt === undefined
+							? undefined
+							: piiSwapSession.substituteText(postHookSystemPrompt);
+				}
+
+				const hookedParamsObj =
+					modelParams &&
+					typeof modelParams === "object" &&
+					!Array.isArray(modelParams)
+						? (modelParams as Record<string, JsonValue | object>)
+						: null;
+				const promptContent =
+					(hookedParamsObj &&
+					"prompt" in hookedParamsObj &&
+					typeof hookedParamsObj.prompt === "string"
+						? hookedParamsObj.prompt
+						: null) ||
+					(hookedParamsObj &&
+					"input" in hookedParamsObj &&
+					typeof hookedParamsObj.input === "string"
+						? hookedParamsObj.input
+						: null) ||
+					(hookedParamsObj &&
+					"messages" in hookedParamsObj &&
+					Array.isArray(hookedParamsObj.messages)
+						? stringifyStructuredForPrompt({
+								messages: hookedParamsObj.messages,
+							})
+						: null) ||
+					(typeof modelParams === "string" ? modelParams : null);
+
+				if (!binaryModels.includes(resolvedModelKey)) {
+					this.logger.trace(
+						{
+							src: "agent",
+							agentId: this.agentId,
+							model: resolvedModelKey,
+							params: modelParams,
+						},
+						"Model input",
+					);
+				} else {
+					let sizeInfo = "unknown size";
+					if (Buffer.isBuffer(modelParams)) {
+						sizeInfo = `${modelParams.length} bytes`;
+					} else if (
+						typeof Blob !== "undefined" &&
+						modelParams instanceof Blob
+					) {
+						sizeInfo = `${modelParams.size} bytes`;
+					} else if (typeof modelParams === "object" && modelParams !== null) {
+						if ("audio" in modelParams && Buffer.isBuffer(modelParams.audio)) {
+							sizeInfo = `${(modelParams.audio as Buffer).length} bytes`;
+						} else if (
+							"audio" in modelParams &&
+							typeof Blob !== "undefined" &&
+							modelParams.audio instanceof Blob
+						) {
+							sizeInfo = `${(modelParams.audio as Blob).size} bytes`;
+						}
+					}
+					this.logger.trace(
+						{
+							src: "agent",
+							agentId: this.agentId,
+							model: resolvedModelKey,
+							size: sizeInfo,
+						},
+						"Model input (binary)",
+					);
+				}
+
+				this.logger.debug(
+					{
+						src: "agent",
+						agentId: this.agentId,
+						model: resolvedModelKey,
+						provider: resolvedModel.provider,
+						...(lookupCaller?.caller ? { caller: lookupCaller.caller } : {}),
+						...(lookupCaller?.callerStack.length
+							? { callerStack: lookupCaller.callerStack }
+							: {}),
+					},
+					"Using model",
+				);
+
+				const rawResponse = await handler(
+					this,
+					modelParams as Record<string, JsonValue | object>,
+				);
+
+				let safeRawResponse: unknown =
+					secretSwapSession?.substituteInValue(rawResponse) ?? rawResponse;
+				safeRawResponse =
+					piiSwapSession?.substituteInValue(safeRawResponse) ?? safeRawResponse;
+				const resultRef: { current: unknown } = { current: safeRawResponse };
+				const modelOutToTrajectoryString = (v: unknown) =>
+					typeof v === "string"
+						? v
+						: stringifyStructuredForPrompt({ response: v });
+
+				// Stream: broadcast to callbacks if streaming
+				if (
+					shouldStream &&
+					(paramsChunk || ctxChunk) &&
+					isTextStreamResult(rawResponse)
+				) {
+					for await (const chunk of rawResponse.textStream) {
+						if (abortSignal?.aborted) break;
 						await deliverModelStreamChunk(chunk);
 					}
-				: undefined;
+					await flushGuardedStream();
+					structuredExtractor?.flush();
 
-		if (isPlainObject(modelParams) && paramsAsStreaming) {
-			paramsAsStreaming.stream = shouldStream;
-			if (handlerStreamChunk) {
-				paramsAsStreaming.onStreamChunk = handlerStreamChunk;
-			} else {
-				delete paramsAsStreaming.onStreamChunk;
-			}
-			// Plumb the streaming-context abort signal into model params so the
-			// underlying handler can wire it into its transport (e.g. local
-			// llama's `stopOnAbortSignal`, fetch's `signal`). Only inject when
-			// the caller didn't already pass one explicitly.
-			if (paramsAsStreaming.signal === undefined && abortSignal) {
-				paramsAsStreaming.signal = abortSignal;
-			}
-		}
+					const trajStreamEnd = getTrajectoryContext();
+					await this.invokePipelineHooks(
+						"model_stream_end",
+						modelStreamEndPipelineHookContext({
+							source: "use_model",
+							roomId:
+								(trajStreamEnd?.roomId as UUID | undefined) ??
+								this.currentRoomId ??
+								this.agentId,
+							runId: this.getCurrentRunId(),
+							messageId: msgId ?? trajStreamEnd?.messageId,
+							text: streamedText,
+						}),
+						"Model stream end (useModel)",
+						true,
+					);
 
-		const textModelKey = TEXT_GENERATION_MODEL_KEYS.includes(
-			String(resolvedModelKey),
-		)
-			? String(resolvedModelKey)
-			: requestedModelKey;
-		let effectiveSystemPrompt = this.attachEffectiveSystemPrompt(
-			textModelKey,
-			modelParams,
-		);
+					// Signal stream end to allow context to reset state between useModel calls
+					const streamingCtxEnd = getStreamingContext();
+					const ctxEnd = streamingCtxEnd?.onStreamEnd;
+					if (ctxEnd) ctxEnd();
 
-		if (
-			this.isSecretSwapEnabled() &&
-			!binaryModels.includes(resolvedModelKey)
-		) {
-			// Reuse one session per turn so every model call in the turn shares a
-			// nonce and the action-execution boundary can restore what this call
-			// swapped. The session hangs off the turn-scoped trajectory context;
-			// calls outside a trajectory scope fall back to a per-call session
-			// (no egress restore — there is no execution boundary to restore at).
-			const trajectoryCtx = getTrajectoryContext();
-			secretSwapSession =
-				trajectoryCtx?.secretSwapSession ?? this.createSecretSwapSession();
-			if (trajectoryCtx && !trajectoryCtx.secretSwapSession) {
-				trajectoryCtx.secretSwapSession = secretSwapSession;
-			}
-			modelParams = secretSwapSession.substituteInValue(modelParams);
-			effectiveSystemPrompt =
-				effectiveSystemPrompt === undefined
-					? undefined
-					: secretSwapSession.substituteText(effectiveSystemPrompt);
-		}
+					// Preserve tool calls + finishReason + usage from the stream result.
+					// The streaming branch used to collapse the response to `streamedText`
+					// (a bare string), discarding any `toolCalls` surfaced by the provider
+					// as a Promise. Callers like `parsePlannerOutput` then saw
+					// `toolCalls.length === 0` and incremented `required_tool_misses` even
+					// though the LLM had emitted a valid native tool call.
+					const streamRaw = rawResponse as {
+						toolCalls?: unknown;
+						finishReason?: unknown;
+						usage?: unknown;
+						providerMetadata?: unknown;
+					};
+					const hasToolCallsField = "toolCalls" in streamRaw;
+					const resolvedToolCalls = hasToolCallsField
+						? await Promise.resolve(streamRaw.toolCalls).catch(() => [])
+						: [];
+					const hasResolvedToolCalls =
+						Array.isArray(resolvedToolCalls) && resolvedToolCalls.length > 0;
+					// Only widen to a GenerateText-shape result when the stream actually
+					// surfaced tool calls. The original streaming contract returns a bare
+					// string; the wider object exists solely to preserve `toolCalls` for
+					// `parsePlannerOutput`, which is irrelevant when none were emitted.
+					if (hasResolvedToolCalls) {
+						const resolvedFinishReason =
+							"finishReason" in streamRaw
+								? await Promise.resolve(streamRaw.finishReason).catch(
+										() => undefined,
+									)
+								: undefined;
+						const resolvedUsage =
+							"usage" in streamRaw
+								? await Promise.resolve(streamRaw.usage).catch(() => undefined)
+								: undefined;
+						resultRef.current = {
+							text: streamedText,
+							toolCalls: resolvedToolCalls,
+							finishReason: resolvedFinishReason,
+							usage: resolvedUsage,
+							providerMetadata: streamRaw.providerMetadata,
+						};
+					} else {
+						resultRef.current = streamedText;
+					}
 
-		// Models the PII swap must NOT touch: binary-input modalities (nothing to
-		// swap) and — unlike the secret gate — IMAGE is INCLUDED (its text prompt
-		// can carry real names), while TEXT_EMBEDDING is EXCLUDED (a per-turn-random
-		// surrogate would embed the same real text differently every turn and wreck
-		// semantic memory retrieval; embeddings stay on the real text).
-		let piiIngressText = "";
-		if (
-			this.isPiiSwapEnabled() &&
-			!PII_SWAP_SKIP_MODELS.includes(resolvedModelKey)
-		) {
-			// Turn-scoped like the secret session (same mapping all turn), so the
-			// execution boundary can restore what this call swapped.
-			const trajectoryCtx = getTrajectoryContext();
-			piiSwapSession =
-				trajectoryCtx?.piiSwapSession ?? this.createPiiSwapSession();
-			if (trajectoryCtx && !trajectoryCtx.piiSwapSession) {
-				trajectoryCtx.piiSwapSession = piiSwapSession;
-			}
-			// The awaited detection step: learn every named entity in the assembled
-			// prompt (params + system prompt), then substitute synchronously. Ordered
-			// after the secret pass, so the NER model reads opaque
-			// `__ELIZA_SECRET_…__` placeholders, never a raw secret. The ONNX
-			// inference is offloaded to onnxruntime's threadpool, so it overlaps the
-			// event loop rather than blocking other turns.
-			piiIngressText = this.collectPromptText(
-				modelParams,
-				effectiveSystemPrompt,
-			);
-			await piiSwapSession.learn(piiIngressText);
-			modelParams = piiSwapSession.substituteInValue(modelParams);
-			effectiveSystemPrompt =
-				effectiveSystemPrompt === undefined
-					? undefined
-					: piiSwapSession.substituteText(effectiveSystemPrompt);
-		}
+					const elapsedTime =
+						(typeof performance !== "undefined" &&
+						typeof performance.now === "function"
+							? performance.now()
+							: Date.now()) - startTime;
 
-		await this.invokePipelineHooks(
-			"pre_model",
-			preModelPipelineHookContext({
-				requestedModelType: String(modelType),
-				resolvedModelKey,
-				provider: resolvedModel.provider,
-				roomId: getTrajectoryContext()?.roomId,
-				params: modelParams,
-			}),
-			"Pre-model pipeline hook",
-		);
-		if (secretSwapSession) {
-			modelParams = secretSwapSession.substituteInValue(modelParams);
-			const postHookSystemPrompt = resolveEffectiveSystemPrompt({
-				params: modelParams,
-				fallback: effectiveSystemPrompt,
-			});
-			effectiveSystemPrompt =
-				postHookSystemPrompt === undefined
-					? undefined
-					: secretSwapSession.substituteText(postHookSystemPrompt);
-		}
-		if (piiSwapSession) {
-			// pre_model hooks may have injected fresh text (RAG snippets, extra
-			// context) with never-seen PII. If the assembled text changed, re-run
-			// detection so that new PII is swapped too — not just already-learned
-			// values re-masked. learn() is idempotent, so this only adds new entities.
-			const postHookText = this.collectPromptText(
-				modelParams,
-				effectiveSystemPrompt,
-			);
-			if (postHookText !== piiIngressText) {
-				await piiSwapSession.learn(postHookText);
-			}
-			modelParams = piiSwapSession.substituteInValue(modelParams);
-			const postHookSystemPrompt = resolveEffectiveSystemPrompt({
-				params: modelParams,
-				fallback: effectiveSystemPrompt,
-			});
-			effectiveSystemPrompt =
-				postHookSystemPrompt === undefined
-					? undefined
-					: piiSwapSession.substituteText(postHookSystemPrompt);
-		}
+					await this.invokePipelineHooks(
+						"post_model",
+						postModelPipelineHookContext({
+							requestedModelType: String(modelType),
+							resolvedModelKey,
+							provider: resolvedModel.provider,
+							roomId: getTrajectoryContext()?.roomId,
+							durationMs: Math.round(elapsedTime),
+							params: modelParams,
+							result: resultRef,
+							streaming: true,
+						}),
+						"Post-model pipeline hook",
+					);
+					resultRef.current =
+						secretSwapSession?.substituteInValue(resultRef.current) ??
+						resultRef.current;
+					resultRef.current =
+						piiSwapSession?.substituteInValue(resultRef.current) ??
+						resultRef.current;
 
-		const hookedParamsObj =
-			modelParams &&
-			typeof modelParams === "object" &&
-			!Array.isArray(modelParams)
-				? (modelParams as Record<string, JsonValue | object>)
-				: null;
-		const promptContent =
-			(hookedParamsObj &&
-			"prompt" in hookedParamsObj &&
-			typeof hookedParamsObj.prompt === "string"
-				? hookedParamsObj.prompt
-				: null) ||
-			(hookedParamsObj &&
-			"input" in hookedParamsObj &&
-			typeof hookedParamsObj.input === "string"
-				? hookedParamsObj.input
-				: null) ||
-			(hookedParamsObj &&
-			"messages" in hookedParamsObj &&
-			Array.isArray(hookedParamsObj.messages)
-				? stringifyStructuredForPrompt({ messages: hookedParamsObj.messages })
-				: null) ||
-			(typeof modelParams === "string" ? modelParams : null);
+					this.logger.trace(
+						{
+							src: "agent",
+							agentId: this.agentId,
+							model: resolvedModelKey,
+							duration: Number(elapsedTime.toFixed(2)),
+							streaming: true,
+						},
+						"Model output (stream with callback complete)",
+					);
 
-		if (!binaryModels.includes(resolvedModelKey)) {
-			this.logger.trace(
-				{
-					src: "agent",
-					agentId: this.agentId,
-					model: resolvedModelKey,
-					params: modelParams,
-				},
-				"Model input",
-			);
-		} else {
-			let sizeInfo = "unknown size";
-			if (Buffer.isBuffer(modelParams)) {
-				sizeInfo = `${modelParams.length} bytes`;
-			} else if (typeof Blob !== "undefined" && modelParams instanceof Blob) {
-				sizeInfo = `${modelParams.size} bytes`;
-			} else if (typeof modelParams === "object" && modelParams !== null) {
-				if ("audio" in modelParams && Buffer.isBuffer(modelParams.audio)) {
-					sizeInfo = `${(modelParams.audio as Buffer).length} bytes`;
-				} else if (
-					"audio" in modelParams &&
-					typeof Blob !== "undefined" &&
-					modelParams.audio instanceof Blob
-				) {
-					sizeInfo = `${(modelParams.audio as Blob).size} bytes`;
+					this.logModelCall(
+						String(modelType),
+						resolvedModelKey,
+						modelParams,
+						promptContent,
+						effectiveSystemPrompt,
+						elapsedTime,
+						resolvedModel.provider,
+						resultRef.current,
+					);
+
+					if (String(modelType) !== ModelType.TEXT_EMBEDDING) {
+						await this.recordUseModelTrajectory({
+							modelType: String(modelType),
+							resolvedModelKey: String(resolvedModelKey),
+							provider: resolvedModel.provider,
+							modelParams,
+							promptContent,
+							result: resultRef.current,
+							response: modelOutToTrajectoryString(resultRef.current),
+							elapsedTime,
+						});
+					}
+
+					return resultRef.current as R;
 				}
-			}
-			this.logger.trace(
-				{
-					src: "agent",
-					agentId: this.agentId,
-					model: resolvedModelKey,
-					size: sizeInfo,
-				},
-				"Model input (binary)",
-			);
-		}
 
-		this.logger.debug(
-			{
-				src: "agent",
-				agentId: this.agentId,
-				model: resolvedModelKey,
-				provider: resolvedModel.provider,
-				...(lookupCaller?.caller ? { caller: lookupCaller.caller } : {}),
-				...(lookupCaller?.callerStack.length
-					? { callerStack: lookupCaller.callerStack }
-					: {}),
-			},
-			"Using model",
-		);
+				if (handlerDeliveredStream) {
+					await flushGuardedStream();
+					structuredExtractor?.flush();
+					const trajStreamEnd = getTrajectoryContext();
+					await this.invokePipelineHooks(
+						"model_stream_end",
+						modelStreamEndPipelineHookContext({
+							source: "use_model",
+							roomId:
+								(trajStreamEnd?.roomId as UUID | undefined) ??
+								this.currentRoomId ??
+								this.agentId,
+							runId: this.getCurrentRunId(),
+							messageId: msgId ?? trajStreamEnd?.messageId,
+							text: streamedText,
+						}),
+						"Model stream end (useModel)",
+						true,
+					);
+					const streamingCtxEnd = getStreamingContext();
+					const ctxEnd = streamingCtxEnd?.onStreamEnd;
+					if (ctxEnd) ctxEnd();
+				}
 
-		const rawResponse = await handler(
-			this,
-			modelParams as Record<string, JsonValue | object>,
-		);
+				const elapsedTime =
+					(typeof performance !== "undefined" &&
+					typeof performance.now === "function"
+						? performance.now()
+						: Date.now()) - startTime;
 
-		let safeRawResponse: unknown =
-			secretSwapSession?.substituteInValue(rawResponse) ?? rawResponse;
-		safeRawResponse =
-			piiSwapSession?.substituteInValue(safeRawResponse) ?? safeRawResponse;
-		const resultRef: { current: unknown } = { current: safeRawResponse };
-		const modelOutToTrajectoryString = (v: unknown) =>
-			typeof v === "string" ? v : stringifyStructuredForPrompt({ response: v });
+				await this.invokePipelineHooks(
+					"post_model",
+					postModelPipelineHookContext({
+						requestedModelType: String(modelType),
+						resolvedModelKey,
+						provider: resolvedModel.provider,
+						roomId: getTrajectoryContext()?.roomId,
+						durationMs: Math.round(elapsedTime),
+						params: modelParams,
+						result: resultRef,
+						streaming: handlerDeliveredStream,
+					}),
+					"Post-model pipeline hook",
+				);
+				resultRef.current =
+					secretSwapSession?.substituteInValue(resultRef.current) ??
+					resultRef.current;
+				resultRef.current =
+					piiSwapSession?.substituteInValue(resultRef.current) ??
+					resultRef.current;
 
-		// Stream: broadcast to callbacks if streaming
-		if (
-			shouldStream &&
-			(paramsChunk || ctxChunk) &&
-			isTextStreamResult(rawResponse)
-		) {
-			for await (const chunk of rawResponse.textStream) {
-				if (abortSignal?.aborted) break;
-				await deliverModelStreamChunk(chunk);
-			}
-			await flushGuardedStream();
-			structuredExtractor?.flush();
+				this.logger.trace(
+					{
+						src: "agent",
+						agentId: this.agentId,
+						model: resolvedModelKey,
+						duration: Number(elapsedTime.toFixed(2)),
+					},
+					"Model output",
+				);
 
-			const trajStreamEnd = getTrajectoryContext();
-			await this.invokePipelineHooks(
-				"model_stream_end",
-				modelStreamEndPipelineHookContext({
-					source: "use_model",
-					roomId:
-						(trajStreamEnd?.roomId as UUID | undefined) ??
-						this.currentRoomId ??
-						this.agentId,
-					runId: this.getCurrentRunId(),
-					messageId: msgId ?? trajStreamEnd?.messageId,
-					text: streamedText,
-				}),
-				"Model stream end (useModel)",
-				true,
-			);
-
-			// Signal stream end to allow context to reset state between useModel calls
-			const streamingCtxEnd = getStreamingContext();
-			const ctxEnd = streamingCtxEnd?.onStreamEnd;
-			if (ctxEnd) ctxEnd();
-
-			// Preserve tool calls + finishReason + usage from the stream result.
-			// The streaming branch used to collapse the response to `streamedText`
-			// (a bare string), discarding any `toolCalls` surfaced by the provider
-			// as a Promise. Callers like `parsePlannerOutput` then saw
-			// `toolCalls.length === 0` and incremented `required_tool_misses` even
-			// though the LLM had emitted a valid native tool call.
-			const streamRaw = rawResponse as {
-				toolCalls?: unknown;
-				finishReason?: unknown;
-				usage?: unknown;
-				providerMetadata?: unknown;
-			};
-			const hasToolCallsField = "toolCalls" in streamRaw;
-			const resolvedToolCalls = hasToolCallsField
-				? await Promise.resolve(streamRaw.toolCalls).catch(() => [])
-				: [];
-			const hasResolvedToolCalls =
-				Array.isArray(resolvedToolCalls) && resolvedToolCalls.length > 0;
-			// Only widen to a GenerateText-shape result when the stream actually
-			// surfaced tool calls. The original streaming contract returns a bare
-			// string; the wider object exists solely to preserve `toolCalls` for
-			// `parsePlannerOutput`, which is irrelevant when none were emitted.
-			if (hasResolvedToolCalls) {
-				const resolvedFinishReason =
-					"finishReason" in streamRaw
-						? await Promise.resolve(streamRaw.finishReason).catch(
-								() => undefined,
-							)
-						: undefined;
-				const resolvedUsage =
-					"usage" in streamRaw
-						? await Promise.resolve(streamRaw.usage).catch(() => undefined)
-						: undefined;
-				resultRef.current = {
-					text: streamedText,
-					toolCalls: resolvedToolCalls,
-					finishReason: resolvedFinishReason,
-					usage: resolvedUsage,
-					providerMetadata: streamRaw.providerMetadata,
-				};
-			} else {
-				resultRef.current = streamedText;
-			}
-
-			const elapsedTime =
-				(typeof performance !== "undefined" &&
-				typeof performance.now === "function"
-					? performance.now()
-					: Date.now()) - startTime;
-
-			await this.invokePipelineHooks(
-				"post_model",
-				postModelPipelineHookContext({
-					requestedModelType: String(modelType),
+				this.logModelCall(
+					String(modelType),
 					resolvedModelKey,
-					provider: resolvedModel.provider,
-					roomId: getTrajectoryContext()?.roomId,
-					durationMs: Math.round(elapsedTime),
-					params: modelParams,
-					result: resultRef,
-					streaming: true,
-				}),
-				"Post-model pipeline hook",
-			);
-			resultRef.current =
-				secretSwapSession?.substituteInValue(resultRef.current) ??
-				resultRef.current;
-			resultRef.current =
-				piiSwapSession?.substituteInValue(resultRef.current) ??
-				resultRef.current;
-
-			this.logger.trace(
-				{
-					src: "agent",
-					agentId: this.agentId,
-					model: resolvedModelKey,
-					duration: Number(elapsedTime.toFixed(2)),
-					streaming: true,
-				},
-				"Model output (stream with callback complete)",
-			);
-
-			this.logModelCall(
-				String(modelType),
-				resolvedModelKey,
-				modelParams,
-				promptContent,
-				effectiveSystemPrompt,
-				elapsedTime,
-				resolvedModel.provider,
-				resultRef.current,
-			);
-
-			if (String(modelType) !== ModelType.TEXT_EMBEDDING) {
-				await this.recordUseModelTrajectory({
-					modelType: String(modelType),
-					resolvedModelKey: String(resolvedModelKey),
-					provider: resolvedModel.provider,
 					modelParams,
 					promptContent,
-					result: resultRef.current,
-					response: modelOutToTrajectoryString(resultRef.current),
+					effectiveSystemPrompt,
 					elapsedTime,
+					resolvedModel.provider,
+					resultRef.current,
+				);
+
+				if (String(modelType) !== ModelType.TEXT_EMBEDDING) {
+					await this.recordUseModelTrajectory({
+						modelType: String(modelType),
+						resolvedModelKey: String(resolvedModelKey),
+						provider: resolvedModel.provider,
+						modelParams,
+						promptContent,
+						result: resultRef.current,
+						response: modelOutToTrajectoryString(resultRef.current),
+						elapsedTime,
+					});
+				}
+				return resultRef.current as R;
+			} catch (error) {
+				lastModelError = error;
+				const nextModel = resolvedModels[resolvedIndex + 1];
+				if (
+					provider !== undefined ||
+					!nextModel ||
+					!this.shouldFailOverModelProvider(error)
+				) {
+					this.rethrowModelFailoverError(error);
+				}
+				this.logModelProviderFailover({
+					requestedModelKey,
+					failedModel: resolvedModel,
+					nextModel,
+					error,
 				});
 			}
-
-			return resultRef.current as R;
 		}
-
-		if (handlerDeliveredStream) {
-			await flushGuardedStream();
-			structuredExtractor?.flush();
-			const trajStreamEnd = getTrajectoryContext();
-			await this.invokePipelineHooks(
-				"model_stream_end",
-				modelStreamEndPipelineHookContext({
-					source: "use_model",
-					roomId:
-						(trajStreamEnd?.roomId as UUID | undefined) ??
-						this.currentRoomId ??
-						this.agentId,
-					runId: this.getCurrentRunId(),
-					messageId: msgId ?? trajStreamEnd?.messageId,
-					text: streamedText,
-				}),
-				"Model stream end (useModel)",
-				true,
-			);
-			const streamingCtxEnd = getStreamingContext();
-			const ctxEnd = streamingCtxEnd?.onStreamEnd;
-			if (ctxEnd) ctxEnd();
-		}
-
-		const elapsedTime =
-			(typeof performance !== "undefined" &&
-			typeof performance.now === "function"
-				? performance.now()
-				: Date.now()) - startTime;
-
-		await this.invokePipelineHooks(
-			"post_model",
-			postModelPipelineHookContext({
-				requestedModelType: String(modelType),
-				resolvedModelKey,
-				provider: resolvedModel.provider,
-				roomId: getTrajectoryContext()?.roomId,
-				durationMs: Math.round(elapsedTime),
-				params: modelParams,
-				result: resultRef,
-				streaming: handlerDeliveredStream,
-			}),
-			"Post-model pipeline hook",
+		this.rethrowModelFailoverError(
+			lastModelError ??
+				new Error(`No handler found for delegate type: ${requestedModelKey}`),
 		);
-		resultRef.current =
-			secretSwapSession?.substituteInValue(resultRef.current) ??
-			resultRef.current;
-		resultRef.current =
-			piiSwapSession?.substituteInValue(resultRef.current) ?? resultRef.current;
-
-		this.logger.trace(
-			{
-				src: "agent",
-				agentId: this.agentId,
-				model: resolvedModelKey,
-				duration: Number(elapsedTime.toFixed(2)),
-			},
-			"Model output",
-		);
-
-		this.logModelCall(
-			String(modelType),
-			resolvedModelKey,
-			modelParams,
-			promptContent,
-			effectiveSystemPrompt,
-			elapsedTime,
-			resolvedModel.provider,
-			resultRef.current,
-		);
-
-		if (String(modelType) !== ModelType.TEXT_EMBEDDING) {
-			await this.recordUseModelTrajectory({
-				modelType: String(modelType),
-				resolvedModelKey: String(resolvedModelKey),
-				provider: resolvedModel.provider,
-				modelParams,
-				promptContent,
-				result: resultRef.current,
-				response: modelOutToTrajectoryString(resultRef.current),
-				elapsedTime,
-			});
-		}
-		return resultRef.current as R;
 	}
 
 	/**

--- a/packages/core/src/runtime/__tests__/model-provider-failover.test.ts
+++ b/packages/core/src/runtime/__tests__/model-provider-failover.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
+import { AgentRuntime } from "../../runtime";
+import { type Character, ModelType } from "../../types";
+
+function makeRuntime(): AgentRuntime {
+	return new AgentRuntime({
+		character: {
+			name: "ProviderFailoverAgent",
+			bio: "test",
+			settings: {},
+		} as Character,
+		adapter: new InMemoryDatabaseAdapter(),
+		logLevel: "fatal",
+	});
+}
+
+describe("AgentRuntime.useModel provider failover", () => {
+	it("tries the next registered provider when the preferred provider is exhausted", async () => {
+		const runtime = makeRuntime();
+		const exhaustedHandler = vi.fn(async () => {
+			throw new Error("You've hit your session limit for now.");
+		});
+		const backupHandler = vi.fn(async () => "backup response");
+
+		runtime.registerModel(
+			ModelType.TEXT_LARGE,
+			exhaustedHandler,
+			"claude-sdk",
+			100,
+		);
+		runtime.registerModel(
+			ModelType.TEXT_LARGE,
+			backupHandler,
+			"elizacloud",
+			10,
+		);
+
+		await expect(
+			runtime.useModel(ModelType.TEXT_LARGE, { prompt: "hello" }),
+		).resolves.toBe("backup response");
+		expect(exhaustedHandler).toHaveBeenCalledTimes(1);
+		expect(backupHandler).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not fail over on ordinary provider errors", async () => {
+		const runtime = makeRuntime();
+		const failingHandler = vi.fn(async () => {
+			throw new Error("invalid request payload");
+		});
+		const backupHandler = vi.fn(async () => "backup response");
+
+		runtime.registerModel(
+			ModelType.TEXT_LARGE,
+			failingHandler,
+			"claude-sdk",
+			100,
+		);
+		runtime.registerModel(
+			ModelType.TEXT_LARGE,
+			backupHandler,
+			"elizacloud",
+			10,
+		);
+
+		await expect(
+			runtime.useModel(ModelType.TEXT_LARGE, { prompt: "hello" }),
+		).rejects.toThrow("invalid request payload");
+		expect(failingHandler).toHaveBeenCalledTimes(1);
+		expect(backupHandler).not.toHaveBeenCalled();
+	});
+
+	it("does not switch providers when a provider is explicitly requested", async () => {
+		const runtime = makeRuntime();
+		const exhaustedHandler = vi.fn(async () => {
+			throw new Error("session limit reached");
+		});
+		const backupHandler = vi.fn(async () => "backup response");
+
+		runtime.registerModel(
+			ModelType.TEXT_LARGE,
+			exhaustedHandler,
+			"claude-sdk",
+			100,
+		);
+		runtime.registerModel(
+			ModelType.TEXT_LARGE,
+			backupHandler,
+			"elizacloud",
+			10,
+		);
+
+		await expect(
+			runtime.useModel(ModelType.TEXT_LARGE, { prompt: "hello" }, "claude-sdk"),
+		).rejects.toThrow("session limit reached");
+		expect(exhaustedHandler).toHaveBeenCalledTimes(1);
+		expect(backupHandler).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary

Closes #10893.

- resolves all registered model handlers in priority order instead of selecting a single default handler up front
- retries the next registered provider when the current provider throws a recognized rate-limit/session-limit exhaustion error
- keeps explicit provider calls pinned, so per-action routing/provider hints do not silently switch providers
- adds focused `AgentRuntime.useModel` coverage for exhausted provider failover, ordinary error propagation, and explicit provider pinning

## Evidence

See `.github/issue-evidence/10893-provider-failover.md`.

## Validation

- `bun run install:light`
- `bun run --cwd packages/core prebuild`
- `bun test packages/core/src/runtime/__tests__/model-provider-failover.test.ts packages/core/src/services/__tests__/failure-reply-prompt.test.ts packages/core/src/runtime/__tests__/streaming-use-model.test.ts`
- `bun run biome check packages/core/src/runtime.ts packages/core/src/runtime/__tests__/model-provider-failover.test.ts .github/issue-evidence/10893-provider-failover.md`
- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/core build:node`
- `git diff --check HEAD~1..HEAD`

## Full Verify

`bun run verify` was attempted after rebasing onto `origin/develop`. It did not complete: it reported an unrelated formatting failure in `packages/cloud/shared/src/lib/services/app-credits.ts` under `@elizaos/cloud-shared:lint`, then exited with code 139 while other workspace tasks were draining. The verify run also auto-formatted two unrelated core files; those generated edits were reverted and are not part of this branch.

## Non-Applicable Evidence

- UI screenshots/video: N/A — runtime-only change.
- Browser console/network logs: N/A — no browser flow changed.
- Real-LLM trajectory: N/A — deterministic runtime handlers reproduce the exhausted-provider path; no live exhausted CLI SDK subscription is available locally.
