### PR TITLE
ci(cloud-cf-deploy): fetch over HTTP/1.1 + 3rd retry — h2 stream resets are the current deploy blocker (#10839)

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -143,20 +143,26 @@ jobs:
           # Worker suite): a single shallow fetch can stall for minutes or wedge
           # entirely. Retry with a per-attempt timeout so a stuck fetch aborts and
           # retries instead of burning the whole step budget (the #10310 stuck-checkout).
+          # http.version=HTTP/1.1: with 3 deploy jobs (+ CodeQL) fetching this
+          # large repo concurrently on one loaded box, HTTP/2 fetches die with
+          # `RPC failed; curl 92 ... stream was not closed cleanly: CANCEL` /
+          # `early EOF` / `fetch-pack: invalid index-pack output` (observed run
+          # 28544777730, both attempts). HTTP/1.1 avoids the h2 stream-reset
+          # path entirely at negligible cost for a single-stream shallow fetch.
           fetched=
-          for attempt in 1 2; do
-            if timeout 420s git -C "$CHECKOUT_DIR" -c protocol.version=2 fetch --force --no-tags --depth=1 origin "$GITHUB_SHA"; then
+          for attempt in 1 2 3; do
+            if timeout 420s git -C "$CHECKOUT_DIR" -c protocol.version=2 -c http.version=HTTP/1.1 fetch --force --no-tags --depth=1 origin "$GITHUB_SHA"; then
               fetched=1
               break
             fi
             echo "::warning::checkout fetch attempt ${attempt} stalled or failed; retrying"
-            if [ "$attempt" -lt 2 ]; then
+            if [ "$attempt" -lt 3 ]; then
               rm -rf "$CHECKOUT_DIR"
               sleep 10
               init_checkout_dir
             fi
           done
-          [ -n "$fetched" ] || { echo "::error::git fetch failed after 2 attempts"; exit 1; }
+          [ -n "$fetched" ] || { echo "::error::git fetch failed after 3 attempts"; exit 1; }
           # checkout --force --detach fully materializes the working tree from the
           # fetched commit; the prior extra `git reset --hard` re-wrote the entire
           # tree a second time, doubling the slowest part on this large repo. Keep

--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -413,24 +413,28 @@ jobs:
           # Worker suite): a single shallow fetch can stall for minutes or wedge
           # entirely. Retry with a per-attempt timeout so a stuck fetch aborts and
           # retries instead of burning the whole step budget (the #10310 stuck-checkout).
+          # http.version=HTTP/1.1: concurrent fetches of this large repo on the
+          # loaded box die under HTTP/2 (`curl 92 ... CANCEL` / `early EOF` /
+          # `invalid index-pack output`, observed run 28544777730); HTTP/1.1
+          # avoids the h2 stream-reset path at negligible single-stream cost.
           fetched=
-          for attempt in 1 2; do
+          for attempt in 1 2 3; do
             # Pages builds materialize packages/app + linked UI/core workspaces.
             # Blobless fetch pushes that cost into checkout as lazy hydration and
             # has repeatedly timed out on the deploy fleet, so use a normal
             # shallow fetch here.
-            if timeout 420s git -C "$CHECKOUT_DIR" -c protocol.version=2 fetch --force --no-tags --depth=1 origin "$GITHUB_SHA"; then
+            if timeout 420s git -C "$CHECKOUT_DIR" -c protocol.version=2 -c http.version=HTTP/1.1 fetch --force --no-tags --depth=1 origin "$GITHUB_SHA"; then
               fetched=1
               break
             fi
             echo "::warning::checkout fetch attempt ${attempt} stalled or failed; retrying"
-            if [ "$attempt" -lt 2 ]; then
+            if [ "$attempt" -lt 3 ]; then
               rm -rf "$CHECKOUT_DIR"
               sleep 10
               init_checkout_dir
             fi
           done
-          [ -n "$fetched" ] || { echo "::error::git fetch failed after 2 attempts"; exit 1; }
+          [ -n "$fetched" ] || { echo "::error::git fetch failed after 3 attempts"; exit 1; }
           # checkout --force --detach fully materializes the working tree from the
           # fetched commit; the prior extra `git reset --hard` re-wrote the entire
           # tree a second time, doubling the slowest part on this large repo. Keep
@@ -712,24 +716,28 @@ jobs:
           # Worker suite): a single shallow fetch can stall for minutes or wedge
           # entirely. Retry with a per-attempt timeout so a stuck fetch aborts and
           # retries instead of burning the whole step budget (the #10310 stuck-checkout).
+          # http.version=HTTP/1.1: concurrent fetches of this large repo on the
+          # loaded box die under HTTP/2 (`curl 92 ... CANCEL` / `early EOF` /
+          # `invalid index-pack output`, observed run 28544777730); HTTP/1.1
+          # avoids the h2 stream-reset path at negligible single-stream cost.
           fetched=
-          for attempt in 1 2; do
+          for attempt in 1 2 3; do
             # Pages builds materialize packages/app + linked UI/core workspaces.
             # Blobless fetch pushes that cost into checkout as lazy hydration and
             # has repeatedly timed out on the deploy fleet, so use a normal
             # shallow fetch here.
-            if timeout 420s git -C "$CHECKOUT_DIR" -c protocol.version=2 fetch --force --no-tags --depth=1 origin "$GITHUB_SHA"; then
+            if timeout 420s git -C "$CHECKOUT_DIR" -c protocol.version=2 -c http.version=HTTP/1.1 fetch --force --no-tags --depth=1 origin "$GITHUB_SHA"; then
               fetched=1
               break
             fi
             echo "::warning::checkout fetch attempt ${attempt} stalled or failed; retrying"
-            if [ "$attempt" -lt 2 ]; then
+            if [ "$attempt" -lt 3 ]; then
               rm -rf "$CHECKOUT_DIR"
               sleep 10
               init_checkout_dir
             fi
           done
-          [ -n "$fetched" ] || { echo "::error::git fetch failed after 2 attempts"; exit 1; }
+          [ -n "$fetched" ] || { echo "::error::git fetch failed after 3 attempts"; exit 1; }
           # checkout --force --detach fully materializes the working tree from the
           # fetched commit; the prior extra `git reset --hard` re-wrote the entire
           # tree a second time, doubling the slowest part on this large repo. Keep


### PR DESCRIPTION
## Current sole blocker on #10839

Disk is recovered (`/dev/md2` 54% used, reclaim reports 0 stale dirs) and the reclaim step is unfailable (#10955). The dispatch recovery run [28544777730](https://github.com/elizaOS/eliza/actions/runs/28544777730) exposed what now kills every checkout: **the shallow fetch itself dies under HTTP/2** when 3 deploy jobs (+ CodeQL, which shares the hetzner-robot pool) fetch the large monorepo concurrently:

```
error: RPC failed; curl 92 HTTP/2 stream 3 was not closed cleanly: CANCEL (err 8)
error: 1288 bytes of body are still expected
fatal: early EOF
fatal: fetch-pack: invalid index-pack output
```

Both attempts, all 3 jobs. This is the well-known libcurl h2 stream-reset failure on large transfers from loaded/lossy connections.

## Fix

- `-c http.version=HTTP/1.1` on the fetch — avoids the h2 stream-reset path entirely; negligible cost for a single-stream shallow fetch (multiplexing buys nothing here).
- 3rd retry attempt (was 2).
- Applied to all 3 deploy jobs; everything else unchanged.

## Evidence
- YAML validated.
- Failure mode + timestamps from the run 28544777730 job logs quoted above (attempt 1 died at 2m51s with curl 92; attempt 2 stalled to the 420s timeout).

Root-cause chain on #10839 so far: leaked checkouts (#10842) → run_id reclaim raced siblings (#10940) → pipefail killed jobs (#10955) → **h2 fetch resets (this PR)**.