### PR TITLE
fix(cli-inference): harden the subscription-limit detector per adversarial review (follow-up to #10944)

### DIFF
--- a/plugins/plugin-cli-inference/__tests__/claude-sdk-session.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/claude-sdk-session.test.ts
@@ -126,6 +126,18 @@ describe("ClaudeSdkSession — TEXT mode", () => {
     await session.dispose();
   });
 
+  it("THROWS when the subscription-limit envelope is only in result.result", async () => {
+    const { session } = makeSession([
+      {
+        text: "",
+        subtype: "success",
+        resultText: "You've hit your session limit · resets 9:30pm (UTC)",
+      },
+    ]);
+    await expect(session.generate("hi")).rejects.toThrow(/subscription rate limit reached/);
+    await session.dispose();
+  });
+
   it("self-heals: a throwing turn disposes, the next call re-starts the session", async () => {
     const { session, starts } = makeSession([
       { text: "", subtype: "error_max_turns" }, // turn 1 throws
@@ -184,6 +196,25 @@ describe("ClaudeSdkSession — ROUTE mode", () => {
     const out = JSON.parse(await session.route("hi"));
     expect(out.action).toBe("REPLY");
     expect(out.params.text).toBe("real");
+    await session.dispose();
+  });
+
+  it("the captured decision wins over residual subscription-limit text", async () => {
+    const { session } = makeSession(
+      [
+        {
+          toolCall: { action: "WEB_FETCH", params: { url: "https://example.test" } },
+          text: "You've hit your session limit · resets 9:30pm (UTC)",
+          subtype: "error_max_turns",
+        },
+      ],
+      { router: true }
+    );
+    const out = JSON.parse(await session.route("price?"));
+    expect(out).toEqual({
+      action: "WEB_FETCH",
+      params: { url: "https://example.test" },
+    });
     await session.dispose();
   });
 

--- a/plugins/plugin-cli-inference/__tests__/subscription-limit.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/subscription-limit.test.ts
@@ -24,6 +24,17 @@ describe("isClaudeSubscriptionLimitMessage", () => {
     ).toBe(true);
   });
 
+  it("matches known envelope variants (CLI epoch form, non-UTC interpunct)", () => {
+    // The classic Claude CLI limit string: "Claude AI usage limit reached|<epoch>".
+    expect(
+      isClaudeSubscriptionLimitMessage("Claude AI usage limit reached|1735689600"),
+    ).toBe(true);
+    // Interpunct separator variants without a "(UTC)" suffix.
+    expect(
+      isClaudeSubscriptionLimitMessage("5-hour limit reached ∙ resets 3am"),
+    ).toBe(true);
+  });
+
   it("does not match genuine model answers, even ones discussing limits", () => {
     for (const answer of [
       "Bitcoin is at $58,546 USD right now (via CoinGecko).",
@@ -32,6 +43,13 @@ describe("isClaudeSubscriptionLimitMessage", () => {
       // a real, long answer that happens to explain rate limits must NOT trip it
       "The API rate limit is 60 requests per minute and it resets hourly; " +
         "handle it with exponential backoff so you never exceed the quota in production.",
+      // adversarial-review probes: SHORT genuine answers about the user's limits.
+      "No, you haven't hit your rate limit yet.",
+      "Your API limit resets at midnight (UTC).",
+      "It means you hit your session limit for the subscription.",
+      "Yes — you hit the daily limit on that key; try tomorrow.",
+      // mid-sentence second-person phrase (envelope form is start-anchored)
+      "Yes — you've hit your daily limit on that key.",
     ]) {
       expect(isClaudeSubscriptionLimitMessage(answer)).toBe(false);
     }

--- a/plugins/plugin-cli-inference/__tests__/subscription-limit.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/subscription-limit.test.ts
@@ -8,31 +8,21 @@ import { isClaudeSubscriptionLimitMessage } from "../src/claude-sdk-session.ts";
 describe("isClaudeSubscriptionLimitMessage", () => {
   it("matches the real leaked subscription-limit strings", () => {
     expect(
-      isClaudeSubscriptionLimitMessage(
-        "You've hit your session limit · resets 9:30pm (UTC)",
-      ),
+      isClaudeSubscriptionLimitMessage("You've hit your session limit · resets 9:30pm (UTC)")
     ).toBe(true);
     expect(
-      isClaudeSubscriptionLimitMessage(
-        "You've hit your session limit · resets 11:30am (UTC)",
-      ),
+      isClaudeSubscriptionLimitMessage("You've hit your session limit · resets 11:30am (UTC)")
     ).toBe(true);
     expect(
-      isClaudeSubscriptionLimitMessage(
-        "You've reached your usage limit for this month.",
-      ),
+      isClaudeSubscriptionLimitMessage("You've reached your usage limit for this month.")
     ).toBe(true);
   });
 
   it("matches known envelope variants (CLI epoch form, non-UTC interpunct)", () => {
     // The classic Claude CLI limit string: "Claude AI usage limit reached|<epoch>".
-    expect(
-      isClaudeSubscriptionLimitMessage("Claude AI usage limit reached|1735689600"),
-    ).toBe(true);
+    expect(isClaudeSubscriptionLimitMessage("Claude AI usage limit reached|1735689600")).toBe(true);
     // Interpunct separator variants without a "(UTC)" suffix.
-    expect(
-      isClaudeSubscriptionLimitMessage("5-hour limit reached ∙ resets 3am"),
-    ).toBe(true);
+    expect(isClaudeSubscriptionLimitMessage("5-hour limit reached ∙ resets 3am")).toBe(true);
   });
 
   it("does not match genuine model answers, even ones discussing limits", () => {

--- a/plugins/plugin-cli-inference/src/claude-sdk-session.ts
+++ b/plugins/plugin-cli-inference/src/claude-sdk-session.ts
@@ -63,11 +63,27 @@ const ROUTE_TOOL = "mcp__eliza__route_action";
 export function isClaudeSubscriptionLimitMessage(text: string): boolean {
   const t = text.trim().toLowerCase();
   if (t.length > 160) return false; // the real limit string is short; a long answer isn't it
-  return (
-    /\b(hit|reached|exceeded)\b[^.]*\b(session|usage|rate|weekly|daily|monthly)\s+limit\b/.test(
+  // A genuine short ANSWER about limits ("No, you haven't hit your rate limit
+  // yet.") shares vocabulary with the envelope; the envelope itself never
+  // contains negation.
+  if (
+    /\b(no|not|haven't|havent|hasn't|hasnt|didn't|didnt|isn't|isnt|wasn't|wasnt)\b/.test(
       t,
-    ) ||
-    (/\blimit\b/.test(t) && /\bresets?\b[^.]*\(utc\)/.test(t))
+    )
+  ) {
+    return false;
+  }
+  return (
+    // The UI envelope's interpunct separator ("· resets 9:30pm (UTC)",
+    // "∙ resets 3am") — model prose doesn't join clauses with an interpunct.
+    /[·∙•]\s*resets\b/.test(t) ||
+    // The envelope IS the whole message and opens second-person: "You've hit
+    // your session limit …". Anchored at the start so a genuine answer that
+    // merely contains the phrase mid-sentence ("Yes — you've hit your daily
+    // limit on that key") does not match.
+    /^you'?ve (hit|reached|exceeded) your\b[^.]*\blimit\b/.test(t) ||
+    // The classic Claude CLI form: "Claude AI usage limit reached|<unix-epoch>".
+    /\bclaude( ai)? usage limit reached\s*\|/.test(t)
   );
 }
 
@@ -406,26 +422,33 @@ export class ClaudeSdkSession {
       }
     }
 
-    // A dried-up subscription credit ends the turn cleanly but streams the limit
-    // string as the "answer". Detect it BEFORE either mode returns so it fails
+    if (mode === "route" && this.pendingDecision) {
+      // The decision is captured in the MCP handler the moment the model calls
+      // route_action — that IS the success signal (the turn then ends
+      // subtype=error_max_turns, which is normal). Return it regardless of how
+      // the turn terminated, and BEFORE the limit guard below: a validly
+      // captured decision must never be discarded because residual preamble
+      // text happened to mention limits.
+      return JSON.stringify(this.pendingDecision);
+    }
+
+    // A dried-up subscription credit ends the turn cleanly but surfaces the
+    // limit string as the "answer" — as streamed assistant text and/or as the
+    // result-envelope echo. Detect BOTH before either mode returns so it fails
     // over / becomes a graceful rate-limit reply instead of leaking "You've hit
-    // your session limit ..." to the user (route mode would otherwise relay it as
-    // a REPLY, text mode as the completion). "rate limit" in the thrown message
-    // routes it through isRateLimitError.
-    if (sawResult && isClaudeSubscriptionLimitMessage(text)) {
+    // your session limit ..." to the user (route mode would otherwise relay it
+    // as a REPLY, text mode as the completion). "rate limit" in the thrown
+    // message routes it through isRateLimitError.
+    const limitEnvelope = [text, resultText ?? ""].find((candidate) =>
+      isClaudeSubscriptionLimitMessage(candidate),
+    );
+    if (sawResult && limitEnvelope !== undefined) {
       throw new Error(
-        `[cli-inference:sdk] subscription rate limit reached: ${text.trim().slice(0, 120)}`,
+        `[cli-inference:sdk] subscription rate limit reached: ${limitEnvelope.trim().slice(0, 120)}`,
       );
     }
 
     if (mode === "route") {
-      // The decision is captured in the MCP handler the moment the model calls
-      // route_action — that IS the success signal (the turn then ends
-      // subtype=error_max_turns, which is normal). Return it regardless of how
-      // the turn terminated.
-      if (this.pendingDecision) {
-        return JSON.stringify(this.pendingDecision);
-      }
       // No decision: the model went off-contract (it was told to call the tool
       // and "produce no plain-text answer"), so any residual text is a planning
       // preamble, not a finished reply — never surface it as a user REPLY. Only

--- a/plugins/plugin-cli-inference/src/claude-sdk-session.ts
+++ b/plugins/plugin-cli-inference/src/claude-sdk-session.ts
@@ -66,11 +66,7 @@ export function isClaudeSubscriptionLimitMessage(text: string): boolean {
   // A genuine short ANSWER about limits ("No, you haven't hit your rate limit
   // yet.") shares vocabulary with the envelope; the envelope itself never
   // contains negation.
-  if (
-    /\b(no|not|haven't|havent|hasn't|hasnt|didn't|didnt|isn't|isnt|wasn't|wasnt)\b/.test(
-      t,
-    )
-  ) {
+  if (/\b(no|not|haven't|havent|hasn't|hasnt|didn't|didnt|isn't|isnt|wasn't|wasnt)\b/.test(t)) {
     return false;
   }
   return (
@@ -440,11 +436,11 @@ export class ClaudeSdkSession {
     // as a REPLY, text mode as the completion). "rate limit" in the thrown
     // message routes it through isRateLimitError.
     const limitEnvelope = [text, resultText ?? ""].find((candidate) =>
-      isClaudeSubscriptionLimitMessage(candidate),
+      isClaudeSubscriptionLimitMessage(candidate)
     );
     if (sawResult && limitEnvelope !== undefined) {
       throw new Error(
-        `[cli-inference:sdk] subscription rate limit reached: ${limitEnvelope.trim().slice(0, 120)}`,
+        `[cli-inference:sdk] subscription rate limit reached: ${limitEnvelope.trim().slice(0, 120)}`
       );
     }
 


### PR DESCRIPTION
## Summary

Post-merge hardening of #10944 from an adversarial review pass (six independent reviewers were run against the merged batch; these are the confirmed findings for the limit detector).

**Detector false-positive class closed.** The merged detector matched short genuine answers about the *user's* limits: `"No, you haven't hit your rate limit yet."`, `"Your API limit resets at midnight (UTC)."`, `"It means you hit your session limit for the subscription."` → all matched → the guard threw → the user got the canned rate-limit reply instead of their answer (a class that can never succeed on retry), and the warm session was disposed (fresh cold-start). Fixed structurally:

- **negation guard** — the envelope never contains negation; genuine answers about "haven't hit" do
- **start-anchored second-person form** — the envelope IS the whole message (`^You've hit your … limit`); a mid-sentence `"Yes — you've hit your daily limit on that key"` no longer matches
- **interpunct-separator branch** (`· resets` / `∙ resets`) — model prose doesn't join clauses with an interpunct

**Coverage extended to known variants the first cut missed:** the classic CLI form `Claude AI usage limit reached|<epoch>` and interpunct variants without a `(UTC)` suffix — these would previously have leaked verbatim.

**Structural completeness:** the guard now checks the result-envelope echo (`result.result`) as well as the streamed assistant text, and a validly captured route decision is returned **before** the limit guard so residual planner preamble mentioning limits can never discard a good decision.

## Tests

`subscription-limit.test.ts` extended with the reviewer's exact probes (5 genuine-answer negatives incl. the mid-sentence second-person case) + the two new envelope variants as positives. Full `plugin-cli-inference` suite: 5 files / 64 tests green. Typecheck clean.

Follow-up to #10944.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
