### PR TITLE
fix(agent): operator UA override applies to wttr.in hosts too (follow-up to #10946)

### DIFF
--- a/packages/agent/src/runtime/actions/web-fetch.test.ts
+++ b/packages/agent/src/runtime/actions/web-fetch.test.ts
@@ -5,7 +5,7 @@ import type {
   Memory,
   State,
 } from "@elizaos/core";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   __setDnsLookupImplForTests,
   __setPinnedFetchImplForTests,
@@ -164,5 +164,90 @@ describe("WEB_FETCH action", () => {
     const { result } = await runHandler({});
     expect(result.success).toBe(false);
     expect(result.text).toContain("url");
+  });
+});
+
+describe("guarded WEB_FETCH User-Agent defaults", () => {
+  const originalOperatorUserAgent = process.env.ELIZA_WEB_FETCH_USER_AGENT;
+
+  afterEach(() => {
+    if (originalOperatorUserAgent === undefined) {
+      delete process.env.ELIZA_WEB_FETCH_USER_AGENT;
+    } else {
+      process.env.ELIZA_WEB_FETCH_USER_AGENT = originalOperatorUserAgent;
+    }
+    vi.resetModules();
+  });
+
+  async function loadGuardedFetchWithOperatorUserAgent(
+    userAgent: string | undefined,
+  ) {
+    vi.resetModules();
+    if (userAgent === undefined) {
+      delete process.env.ELIZA_WEB_FETCH_USER_AGENT;
+    } else {
+      process.env.ELIZA_WEB_FETCH_USER_AGENT = userAgent;
+    }
+    return import("../custom-actions.ts");
+  }
+
+  async function captureGuardedFetchUserAgent(
+    userAgent: string | undefined,
+    url: string,
+    headers?: Record<string, string>,
+  ): Promise<string | null> {
+    const customActions =
+      await loadGuardedFetchWithOperatorUserAgent(userAgent);
+    let capturedUserAgent: string | null = null;
+    customActions.__setDnsLookupImplForTests(async () => ["93.184.216.34"]);
+    customActions.__setPinnedFetchImplForTests(async ({ init }) => {
+      capturedUserAgent = new Headers(init.headers).get("user-agent");
+      return new Response("ok", { status: 200 });
+    });
+
+    try {
+      const result = await customActions.performGuardedHttpGet(url, {
+        headers,
+      });
+      expect(result.ok).toBe(true);
+      return capturedUserAgent;
+    } finally {
+      customActions.__setPinnedFetchImplForTests(null);
+      customActions.__setDnsLookupImplForTests(null);
+    }
+  }
+
+  it("uses the CLI User-Agent for wttr.in, including trailing-dot FQDNs", async () => {
+    await expect(
+      captureGuardedFetchUserAgent(undefined, "https://wttr.in./London"),
+    ).resolves.toBe("Eliza/1.0 (+https://elizaos.ai)");
+  });
+
+  it("honors the operator User-Agent override for wttr.in hosts", async () => {
+    await expect(
+      captureGuardedFetchUserAgent(
+        "CorpProxyAllowlist/2026",
+        "https://wttr.in/London",
+      ),
+    ).resolves.toBe("CorpProxyAllowlist/2026");
+  });
+
+  it("honors the operator User-Agent override for non-wttr.in hosts", async () => {
+    await expect(
+      captureGuardedFetchUserAgent(
+        "CorpProxyAllowlist/2026",
+        "https://api.example.test/data",
+      ),
+    ).resolves.toBe("CorpProxyAllowlist/2026");
+  });
+
+  it("keeps caller-supplied User-Agent headers above defaults", async () => {
+    await expect(
+      captureGuardedFetchUserAgent(
+        "CorpProxyAllowlist/2026",
+        "https://wttr.in/London",
+        { "user-agent": "CallerUA/1.0" },
+      ),
+    ).resolves.toBe("CallerUA/1.0");
   });
 });

--- a/packages/agent/src/runtime/custom-actions.ts
+++ b/packages/agent/src/runtime/custom-actions.ts
@@ -606,8 +606,10 @@ export interface GuardedHttpGetResult {
 // lookup. A browser-like string is what these WAF-fronted endpoints accept; it
 // is overridable via ELIZA_WEB_FETCH_USER_AGENT so operators can refresh it
 // without a code change, and any caller-supplied User-Agent header still wins.
+const GUARDED_GET_OPERATOR_USER_AGENT =
+  process.env.ELIZA_WEB_FETCH_USER_AGENT?.trim() || undefined;
 const GUARDED_GET_DEFAULT_USER_AGENT =
-  process.env.ELIZA_WEB_FETCH_USER_AGENT?.trim() ||
+  GUARDED_GET_OPERATOR_USER_AGENT ||
   [
     "Mozilla/5.0 (X11; Linux x86_64)",
     "AppleWebKit/537.36 (KHTML, like Gecko)",
@@ -660,13 +662,19 @@ async function performGuardedHttpRequest(
   // plain-text weather line the live-info WEB_FETCH actually wants is served only
   // to a non-browser UA (it is built for `curl wttr.in`). The browser-like
   // default above exists to satisfy WAF-fronted JSON APIs (coingecko etc.), so
-  // scope the CLI UA to wttr.in rather than changing the global default. A
-  // caller-supplied User-Agent header still wins (set below).
-  const host = parsed.hostname.toLowerCase();
+  // scope the CLI UA to wttr.in rather than changing the global default.
+  // Precedence: caller-supplied header (set below) > operator env override
+  // (ELIZA_WEB_FETCH_USER_AGENT applies to EVERY host — an egress proxy that
+  // allowlists a specific UA must not be bypassed for wttr.in) > per-host CLI
+  // UA > browser default. Trailing-dot FQDNs ("wttr.in.") normalize to the
+  // same host.
+  const host = parsed.hostname.toLowerCase().replace(/\.$/, "");
   const isPlainTextCliHost = host === "wttr.in" || host.endsWith(".wttr.in");
-  const defaultUserAgent = isPlainTextCliHost
-    ? "Eliza/1.0 (+https://elizaos.ai)"
-    : GUARDED_GET_DEFAULT_USER_AGENT;
+  const defaultUserAgent =
+    GUARDED_GET_OPERATOR_USER_AGENT ??
+    (isPlainTextCliHost
+      ? "Eliza/1.0 (+https://elizaos.ai)"
+      : GUARDED_GET_DEFAULT_USER_AGENT);
   // Build headers via the Headers API so a caller-supplied header (in any
   // casing) cleanly overrides the default rather than being comma-joined onto it.
   const headers = new Headers({ "User-Agent": defaultUserAgent });


### PR DESCRIPTION
## Summary

Post-merge hardening of #10946 from an adversarial review pass — two confirmed findings:

1. **Operator override bypass (minor).** The per-host wttr.in CLI UA ignored `ELIZA_WEB_FETCH_USER_AGENT`, contradicting the in-file contract ("operators can refresh the UA without a code change"). An operator whose egress proxy allowlists a specific UA would have wttr.in requests blocked at their edge with no config-level fix. Precedence is now: caller-supplied header > operator env override (applies to **every** host) > per-host CLI UA > browser default.
2. **Trailing-dot FQDN (nit).** `https://wttr.in./London` (hostname `wttr.in.`) evaded the host match and got the browser UA → HTML shell. Hostnames now normalize the trailing dot before matching.

## Checks

- `packages/agent` typecheck — no errors in `custom-actions.ts`; remaining errors are the pre-existing missing-optional-module set on clean `develop`.
- Behavior unchanged when the env override is unset (the default path is byte-identical).

Follow-up to #10946.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
