### PR TITLE
fix(core): bare legacy "TASKS" is not a delegation commitment in the simple-context shape

### DIFF
--- a/packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts
+++ b/packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts
@@ -272,6 +272,39 @@ describe("messageHandlerFromFieldResult — bogus candidate actions", () => {
 		expect(handler.plan.candidateActions).toEqual(["TASKS_SPAWN_AGENT"]);
 	});
 
+	it("does NOT treat bare legacy 'TASKS' as a delegation commitment in the SIMPLE-context shape", () => {
+		// Adversarial-review probe on the simple-context spawn fix: a loosely
+		// coding-shaped status question ("update me on the project") where the
+		// model routed contexts=["simple"], answered completely, and named the
+		// ambiguous legacy alias "TASKS" (task-list management as much as
+		// delegation; not a registered action here — the registry has
+		// TASKS_SPAWN_AGENT). Without a planning context backing it, the
+		// ambiguous alias must not override the complete direct answer into
+		// forced planning. Unambiguous spawn-class names (TASKS_SPAWN_AGENT,
+		// previous test) still commit.
+		const handler = messageHandlerFromFieldResult(
+			{
+				shouldRespond: "RESPOND",
+				contexts: ["simple"],
+				candidateActionNames: ["TASKS"],
+				replyText:
+					"The project is on track — the build pipeline was green this morning and the last deploy finished cleanly.",
+				intents: ["project status"],
+				facts: [],
+				addressedTo: [],
+			},
+			undefined,
+			{
+				actions: REAL_ACTIONS,
+				messageText: "update me on the project",
+			},
+		);
+
+		expect(handler.plan.simple).toBe(true);
+		expect(handler.plan.requiresTool).not.toBe(true);
+		expect(handler.plan.contexts).toEqual(["simple"]);
+	});
+
 	it("still force-plans a genuine build ask when the model only acked", () => {
 		const handler = messageHandlerFromFieldResult(
 			{

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -3789,6 +3789,15 @@ export function messageHandlerFromFieldResult(
 		modelProvidedRunnableDelegationCandidate(
 			rawCandidateActions,
 			runtimeContext?.actions ?? [],
+			// With a planning context the model's own routing already signals
+			// work, so any delegation-class candidate (including the ambiguous
+			// legacy alias "TASKS") confirms the commitment. In the contradictory
+			// contexts=[simple] shape the candidate is the ONLY delegation
+			// signal, so it must be unambiguous — bare "TASKS" (task-list
+			// management as much as delegation) on a loosely coding-shaped
+			// message ("update me on the project") must not override a complete
+			// direct answer into forced planning.
+			{ requireUnambiguous: initialPlanningContexts.length === 0 },
 		);
 	const preferCompleteDirectReply =
 		!preemptDirect &&
@@ -4113,13 +4122,22 @@ function shouldPreferCompleteDirectReply(args: {
 function modelProvidedRunnableDelegationCandidate(
 	candidateActions: readonly string[],
 	actions: ReadonlyArray<Pick<Action, "name" | "similes" | "tags">>,
+	opts?: { requireUnambiguous?: boolean },
 ): boolean {
 	if (candidateActions.length === 0) return false;
 	const delegationActionName = findCodingDelegationActionName(actions);
 	if (!delegationActionName) return false;
+	// Bare "TASKS" is the one legacy alias that is ambiguous — it names task-list
+	// management as readily as coding delegation. When the caller needs an
+	// unambiguous commitment (no planning context backing the candidate), it only
+	// counts if the REGISTERED delegation action is itself named TASKS (then the
+	// model named the real action, not the ambiguous alias).
+	const legacyNames = opts?.requireUnambiguous
+		? LEGACY_CODING_DELEGATION_ACTION_NAMES.filter((name) => name !== "TASKS")
+		: LEGACY_CODING_DELEGATION_ACTION_NAMES;
 	const wanted = new Set<string>([
 		normalizeActionIdentifier(delegationActionName),
-		...LEGACY_CODING_DELEGATION_ACTION_NAMES.map(normalizeActionIdentifier),
+		...legacyNames.map(normalizeActionIdentifier),
 	]);
 	return candidateActions.some((name) =>
 		wanted.has(normalizeActionIdentifier(name)),


### PR DESCRIPTION
## Summary

Post-merge hardening of the simple-context spawn fix from an adversarial review pass — one confirmed (probe-verified) finding.

**The regression:** dropping the planning-context requirement let `modelCommittedToDelegation` fire on the **bare legacy alias `"TASKS"`** for messages that loosely trip the coding-work classifier. Reviewer's empirical probe: `"update me on the project"` + `contexts:["simple"]` + `candidateActionNames:["TASKS"]` + a complete status answer → base answered directly; merged branch force-planned it (`simple=false`, `requiresTool=true`, backstop-inferred spawn candidate) — a redundant planner turn / possible false spawn on a status question.

**The fix:** in the contradictory `contexts=["simple"]` shape the candidate is the *only* delegation signal, so it must be unambiguous. `modelProvidedRunnableDelegationCandidate` now excludes the legacy `"TASKS"` alias in that shape — unless the registered delegation action is itself named `TASKS`, in which case the model named the real action, not an alias. Explicit spawn-class names (`TASKS_SPAWN_AGENT`, `SPAWN_AGENT`, `START_CODING_TASK`, …) keep committing, so the live build-spawn fix ("build me a hello-world page" → spawn) is untouched. With a planning context backing the candidate, behavior is byte-identical to today.

## Tests

- New regression test = the reviewer's exact probe (bare `"TASKS"` + simple context + complete answer → stays direct).
- The neighboring guards' tests all green: the simple-context `TASKS_SPAWN_AGENT` spawn case, the non-simple-context case, the ack-only case. `message-handler-bogus-candidates` + `message-routing` suites: 61/61. Core typecheck clean.

Follow-up to the merged simple-context spawn fix; part of the adversarial-review hardening batch with #10975 and #10976.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
