### PR TITLE
fix(orchestrator): attach chat-action spawned sessions to their minted task thread

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/attach-session.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/attach-session.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Pins {@link OrchestratorTaskService.attachSession} — the public API used by
+ * `TASKS:create` to bind ACP sessions it spawned via `AcpService.spawnSession`
+ * directly (with its own multi-part label / prefix / model routing) into an
+ * existing task thread's session index. Without this the store's
+ * `sessionTaskIndex` never learns about those sessions, `resolveTaskId`
+ * returns undefined, the event bridge drops their events, and DTOs report
+ * `0/0 agents` with no token attribution.
+ *
+ * Pinned surfaces:
+ *   1. Attaching a LIVE session indexes it against the task (sessionCount
+ *      goes up, latestSessionId flips, activeSessionCount reflects it) AND
+ *      promotes the task status from `open` → `active`.
+ *   2. Attaching a TERMINAL-ON-ARRIVAL session (the chat create action's
+ *      `runPromptAndClose` has already stopped it before mint) still indexes
+ *      it for history + future token attribution, but does NOT falsely claim
+ *      liveness (task status stays `open`, activeSessionCount stays 0).
+ *   3. `resolveTaskId` (exercised via the ACP event bridge) resolves the
+ *      attached session back to its task, so post-attach session events land
+ *      as task events and token usage rolls up onto the session record.
+ *   4. Idempotent: attaching the same sessionId twice is a no-op — no
+ *      duplicate rows, no double-status-advance.
+ *   5. Unknown taskId returns `false` without throwing (attach failure in
+ *      the create action must be logged, not demote the action's success).
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { OrchestratorTaskService } from "../../src/services/orchestrator-task-service.js";
+import { OrchestratorTaskStore } from "../../src/services/orchestrator-task-store.js";
+
+// Suppress default-acceptance-criteria auto-fill so `task_complete` events in
+// these tests don't fire the auto-verifier (matches the pattern used in
+// orchestrator-task-service.test.ts).
+const PREV_GOAL_CONTRACT = process.env.ELIZA_REQUIRE_GOAL_CONTRACT;
+beforeAll(() => {
+  process.env.ELIZA_REQUIRE_GOAL_CONTRACT = "0";
+});
+afterAll(() => {
+  if (PREV_GOAL_CONTRACT === undefined)
+    delete process.env.ELIZA_REQUIRE_GOAL_CONTRACT;
+  else process.env.ELIZA_REQUIRE_GOAL_CONTRACT = PREV_GOAL_CONTRACT;
+});
+
+/**
+ * Minimal ACP stand-in: captures the orchestrator's event-subscription hook
+ * so a test can drive session events after attach (to exercise resolveTaskId
+ * via the bridge) without needing a real ACP subprocess.
+ */
+class FakeAcp {
+  private handler:
+    | ((sessionId: string, event: string, data: unknown) => void)
+    | null = null;
+
+  onSessionEvent(
+    cb: (sessionId: string, event: string, data: unknown) => void,
+  ): () => void {
+    this.handler = cb;
+    return () => {
+      this.handler = null;
+    };
+  }
+
+  emit(sessionId: string, event: string, data: unknown = {}): void {
+    this.handler?.(sessionId, event, data);
+  }
+}
+
+function runtime(acp?: FakeAcp): IAgentRuntime {
+  return {
+    getService: () => acp ?? null,
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  } as never;
+}
+
+async function makeService(acp?: FakeAcp): Promise<{
+  service: OrchestratorTaskService;
+  taskId: string;
+}> {
+  const store = new OrchestratorTaskStore({ backend: "memory" });
+  const service = new OrchestratorTaskService(runtime(acp), { store });
+  await service.start();
+  const task = await service.createTask({
+    title: "Ship widget",
+    goal: "Bind chat-spawned sessions to the durable thread",
+  });
+  return { service, taskId: task.id };
+}
+
+/** Yield a macrotask so the event bridge's async work settles. */
+const flush = (): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("OrchestratorTaskService.attachSession", () => {
+  it("indexes a live session on the task and promotes status open→active", async () => {
+    const { service, taskId } = await makeService();
+
+    const before = await service.getTask(taskId);
+    expect(before?.status).toBe("open");
+    expect(before?.sessionCount).toBe(0);
+    expect(before?.activeSessionCount).toBe(0);
+
+    const ok = await service.attachSession(taskId, {
+      sessionId: "chat-sess-1",
+      agentType: "codex",
+      workdir: "/tmp/workdir",
+      status: "ready",
+      label: "planner",
+      originalTask: "wire attach",
+      model: "gpt-5.5",
+    });
+    expect(ok).toBe(true);
+
+    const after = await service.getTask(taskId);
+    expect(after?.sessionCount).toBe(1);
+    expect(after?.activeSessionCount).toBe(1);
+    expect(after?.latestSessionId).toBe("chat-sess-1");
+    expect(after?.status).toBe("active");
+    const attached = after?.sessions[0];
+    expect(attached?.sessionId).toBe("chat-sess-1");
+    expect(attached?.framework).toBe("codex");
+    expect(attached?.label).toBe("planner");
+    expect(attached?.model).toBe("gpt-5.5");
+    expect(attached?.originalTask).toBe("wire attach");
+  });
+
+  it("indexes a terminal-on-arrival session without falsely advancing status", async () => {
+    // Mirrors the real chat-create path: `runPromptAndClose` has already
+    // stopped the session before we mint the thread, so the SpawnResult's
+    // status is terminal by the time attach runs. We still want the session
+    // linked (for the widget's history + future token attribution), but the
+    // task should NOT be lied to about liveness.
+    const { service, taskId } = await makeService();
+
+    const ok = await service.attachSession(taskId, {
+      sessionId: "chat-sess-terminal",
+      agentType: "codex",
+      workdir: "/tmp/workdir",
+      status: "completed",
+      label: "planner",
+    });
+    expect(ok).toBe(true);
+
+    const detail = await service.getTask(taskId);
+    expect(detail?.sessionCount).toBe(1);
+    expect(detail?.activeSessionCount).toBe(0);
+    expect(detail?.status).toBe("open"); // NOT promoted
+    expect(detail?.sessions[0]?.status).toBe("completed");
+    expect(detail?.sessions[0]?.stoppedAt).toBeTypeOf("number");
+  });
+
+  it("makes resolveTaskId route post-attach session events onto the task", async () => {
+    // The event bridge's `resolveTaskId` is the whole reason this API exists.
+    // Attach → emit a session event on the fake ACP → the orchestrator
+    // resolves the session back to its task and records the event on the
+    // task's event log. Without attach the event would be dropped.
+    const acp = new FakeAcp();
+    const { service, taskId } = await makeService(acp);
+    await service.attachSession(taskId, {
+      sessionId: "chat-sess-2",
+      agentType: "codex",
+      workdir: "/tmp/workdir",
+      status: "ready",
+      label: "planner",
+    });
+
+    acp.emit("chat-sess-2", "message", { text: "hello from sub-agent" });
+    await flush();
+
+    const detail = await service.getTask(taskId);
+    const messageFromSubAgent = detail?.messages.find(
+      (m) => m.senderKind === "sub_agent" && m.sessionId === "chat-sess-2",
+    );
+    expect(messageFromSubAgent?.content).toBe("hello from sub-agent");
+  });
+
+  it("is idempotent: attaching the same sessionId twice does not duplicate rows", async () => {
+    const { service, taskId } = await makeService();
+    const first = await service.attachSession(taskId, {
+      sessionId: "chat-sess-3",
+      agentType: "codex",
+      workdir: "/tmp/workdir",
+      status: "ready",
+      label: "planner",
+    });
+    const second = await service.attachSession(taskId, {
+      sessionId: "chat-sess-3",
+      agentType: "codex",
+      workdir: "/tmp/workdir",
+      status: "ready",
+      label: "planner-2",
+    });
+    expect(first).toBe(true);
+    expect(second).toBe(true);
+
+    const detail = await service.getTask(taskId);
+    expect(detail?.sessionCount).toBe(1);
+    // The store's addSession upserts by sessionId — one row, regardless.
+    expect(
+      detail?.sessions.filter((s) => s.sessionId === "chat-sess-3").length,
+    ).toBe(1);
+  });
+
+  it("returns false on unknown taskId without throwing", async () => {
+    const { service } = await makeService();
+    const ok = await service.attachSession("no-such-task", {
+      sessionId: "chat-sess-4",
+      agentType: "codex",
+      workdir: "/tmp/workdir",
+      status: "ready",
+    });
+    expect(ok).toBe(false);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/create-task-attaches-sessions.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/create-task-attaches-sessions.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Pins the wiring between `TASKS:create` and
+ * {@link OrchestratorTaskService.attachSession}: on a successful spawn +
+ * mint, every session that `service.spawnSession` returned must be attached
+ * to the freshly-minted task thread so the widget/panel read agent count and
+ * token usage instead of `0/0`.
+ *
+ * Pinned surfaces:
+ *   1. Happy path — one attachSession call per spawned session, with the
+ *      minted taskId, matching sessionId/agentType/workdir/status, and the
+ *      per-part label the create action assembled.
+ *   2. Attach failure is soft — attachSession throwing is logged, but the
+ *      action still returns `success: true` with the widget block (same
+ *      policy as thread-mint failure).
+ *   3. Thread-mint failure path is clean — when createTask throws, the
+ *      action does NOT try to attach (there's no taskId), and the widget
+ *      block is omitted while the ACP sessions still ran.
+ *
+ * These complement `create-task-emits-widget-block.test.ts` (which pins the
+ * mint+widget-block contract) and `attach-session.test.ts` (which pins the
+ * service-level attach semantics).
+ */
+
+import * as os from "node:os";
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { createTaskAction } from "../../src/actions/tasks.js";
+import {
+  callback,
+  memory,
+  serviceMock,
+  state,
+} from "../../src/test-utils/action-test-utils.js";
+
+const THREAD_ID = "aaaabbbb-1111-2222-3333-444455556666";
+
+function runtimeWithServices(opts: {
+  acp: ReturnType<typeof serviceMock>;
+  taskService?: {
+    createTask?: (input: unknown) => Promise<unknown>;
+    attachSession?: (
+      taskId: string,
+      input: Record<string, unknown>,
+    ) => Promise<boolean>;
+  };
+}): IAgentRuntime {
+  return {
+    getService: vi.fn((serviceType: string) => {
+      if (
+        serviceType === "ACP_SERVICE" ||
+        serviceType === "ACP_SUBPROCESS_SERVICE"
+      ) {
+        return opts.acp;
+      }
+      if (serviceType === "ORCHESTRATOR_TASK_SERVICE") {
+        return opts.taskService ?? null;
+      }
+      return null;
+    }),
+    hasService: vi.fn(() => true),
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  } as never;
+}
+
+describe("TASKS:create attaches spawned sessions to the minted task thread", () => {
+  it("calls attachSession(taskId, {sessionId, ...}) for each successful spawn", async () => {
+    const acp = serviceMock();
+    const createTask = vi.fn(async () => ({
+      id: THREAD_ID,
+      title: "Build planner",
+    }));
+    const attachSession = vi.fn(async () => true);
+    const runtime = runtimeWithServices({
+      acp,
+      taskService: { createTask, attachSession },
+    });
+    const cb = callback();
+    const workdir = os.tmpdir();
+
+    const result = await createTaskAction.handler(
+      runtime,
+      memory({}),
+      state,
+      {
+        parameters: {
+          action: "create",
+          title: "Build planner",
+          goal: "Ship a working planner",
+          task: "fix bug",
+          agentType: "codex",
+          workdir,
+          model: "gpt-5.5",
+          approvalPreset: "readonly",
+          timeout_ms: 1000,
+        },
+      },
+      cb,
+    );
+
+    expect(result?.success).toBe(true);
+    expect(result?.data?.taskId).toBe(THREAD_ID);
+    // One spawn happened → one attach.
+    expect(attachSession).toHaveBeenCalledTimes(1);
+    const [attachedTaskId, attachedInput] = attachSession.mock.calls[0] ?? [];
+    expect(attachedTaskId).toBe(THREAD_ID);
+    const input = attachedInput as Record<string, unknown>;
+    expect(typeof input.sessionId).toBe("string");
+    expect((input.sessionId as string).length).toBeGreaterThan(0);
+    expect(input.agentType).toBe("codex");
+    expect(input.workdir).toBe(workdir);
+    expect(input.status).toBe("ready");
+    expect(input.model).toBe("gpt-5.5");
+    // The per-part label the create action assigned rides through.
+    expect(typeof input.label).toBe("string");
+    expect((input.label as string).length).toBeGreaterThan(0);
+  });
+
+  it("still returns success (with the widget) when attachSession throws", async () => {
+    // Attach failure must be logged, not demote the action — same soft-fail
+    // policy as thread-mint failure. The ACP sessions are still running.
+    const acp = serviceMock();
+    const createTask = vi.fn(async () => ({
+      id: THREAD_ID,
+      title: "Build planner",
+    }));
+    const attachSession = vi.fn(async () => {
+      throw new Error("store offline");
+    });
+    const runtime = runtimeWithServices({
+      acp,
+      taskService: { createTask, attachSession },
+    });
+    const cb = callback();
+    const workdir = os.tmpdir();
+
+    const result = await createTaskAction.handler(
+      runtime,
+      memory({}),
+      state,
+      {
+        parameters: {
+          action: "create",
+          task: "fix bug",
+          agentType: "codex",
+          workdir,
+          approvalPreset: "readonly",
+          timeout_ms: 1000,
+        },
+      },
+      cb,
+    );
+
+    expect(result?.success).toBe(true);
+    expect(result?.text).toContain(`[TASK:${THREAD_ID}]`);
+    expect(attachSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not attempt to attach when thread-mint fails (no taskId)", async () => {
+    // No taskId → no attach call. Sessions are still running; the widget is
+    // just omitted from the callback prose (create-task-emits-widget-block
+    // already pins that surface — here we only guarantee the attach guard).
+    const acp = serviceMock();
+    const createTask = vi.fn(async () => {
+      throw new Error("mint failed");
+    });
+    const attachSession = vi.fn(async () => true);
+    const runtime = runtimeWithServices({
+      acp,
+      taskService: { createTask, attachSession },
+    });
+    const cb = callback();
+    const workdir = os.tmpdir();
+
+    const result = await createTaskAction.handler(
+      runtime,
+      memory({}),
+      state,
+      {
+        parameters: {
+          action: "create",
+          task: "fix bug",
+          agentType: "codex",
+          workdir,
+          approvalPreset: "readonly",
+          timeout_ms: 1000,
+        },
+      },
+      cb,
+    );
+
+    expect(result?.success).toBe(true);
+    expect(result?.data?.taskId).toBeNull();
+    expect(attachSession).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -735,16 +735,21 @@ async function runCreate(
           model,
         );
       }
-      return { session, label, agentType };
+      return { session, label, agentType, originalTask: taskWithRouteHints };
     }),
   );
 
   const results: Array<Record<string, unknown>> = [];
   const sessions: SpawnResult[] = [];
+  // Parallel to `sessions`; carries the per-part context needed to attach a
+  // successful spawn into the durable task thread minted below. Kept out of
+  // SpawnResult so the ACP contract stays lean.
+  const sessionAttachHints: Array<{ label: string; originalTask: string }> = [];
   for (const [index, outcome] of settled.entries()) {
     if (outcome.status === "fulfilled") {
-      const { session, label } = outcome.value;
+      const { session, label, originalTask } = outcome.value;
       sessions.push(session);
+      sessionAttachHints.push({ label, originalTask });
       results.push({
         id: session.sessionId,
         sessionId: session.sessionId,
@@ -796,16 +801,12 @@ async function runCreate(
   // The ACP sessions have already succeeded; a failure here is logged but
   // never demotes the action's success — the agents are still running.
   //
-  // KNOWN GAP (tracked): the ACP sessions spawned above via
-  // `service.spawnSession` are NOT attached to this durable thread — only
-  // sessions created through `OrchestratorTaskService.spawnAgentForTask`
-  // land in the task store's session index (see `resolveTaskId`). So the
-  // freshly-minted thread reads `0/0 agents` and no token usage until/unless
-  // a session reports an event that resolves back to it. The widget still
-  // renders and navigates correctly; wiring true session linkage (a public
-  // `attachSession`, or routing create through `spawnAgentForTask`) is a
-  // follow-up slice that touches the spawn lifecycle — see
-  // docs/orchestrator-dashboard-task-widget-secrets-assessment.md.
+  // The ACP sessions spawned above via `service.spawnSession` are then
+  // registered against the freshly-minted thread through the task service's
+  // `attachSession` — without that, `resolveTaskId` never learns about them,
+  // event routing drops their session events, and the widget reads `0/0
+  // agents`. Per-session attach failures are logged but never demote the
+  // action's success, same policy as thread-mint failure.
   const taskTitle =
     pickString(params, content, "title") ??
     pickString(params, content, "goal") ??
@@ -834,10 +835,10 @@ async function runCreate(
       ? swarmRoomMetadata.originRoomId
       : undefined;
   let threadId: string | null = null;
+  const taskService = runtime.getService?.(
+    OrchestratorTaskService.serviceType,
+  ) as OrchestratorTaskService | null | undefined;
   try {
-    const taskService = runtime.getService?.(
-      OrchestratorTaskService.serviceType,
-    ) as OrchestratorTaskService | null | undefined;
     if (taskService && typeof taskService.createTask === "function") {
       const detail = await taskService.createTask({
         title: taskTitle,
@@ -860,6 +861,38 @@ async function runCreate(
       }`,
     );
     threadId = null;
+  }
+
+  // Bind every successfully spawned session to the freshly-minted thread so
+  // the task widget / tasks panel sees them (sessionCount, latestSessionId,
+  // token usage). Thread-mint-failed path skips this cleanly — no taskId to
+  // attach against, and the sessions are still running / stopped independently.
+  if (
+    threadId &&
+    taskService &&
+    typeof taskService.attachSession === "function"
+  ) {
+    for (const [index, session] of sessions.entries()) {
+      const hint = sessionAttachHints[index];
+      try {
+        await taskService.attachSession(threadId, {
+          sessionId: session.sessionId,
+          agentType: session.agentType,
+          workdir: session.workdir,
+          status: session.status,
+          ...(session.metadata ? { metadata: session.metadata } : {}),
+          ...(hint?.label ? { label: hint.label } : {}),
+          ...(hint?.originalTask ? { originalTask: hint.originalTask } : {}),
+          ...(model ? { model } : {}),
+        });
+      } catch (error) {
+        logger(runtime).warn(
+          `[TASKS:create] attachSession failed for ${session.sessionId} on task ${threadId}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    }
   }
 
   const widgetBlock = threadId

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -222,6 +222,25 @@ export interface SpawnAgentForTaskOptions {
   nestingDepth?: number;
 }
 
+/** Descriptor for an already-spawned ACP session that we want to bind to an
+ *  existing task thread. Only what the attach path genuinely needs — identity,
+ *  workdir + status from the spawn, and the caller's context that isn't
+ *  discoverable from the SpawnResult (originalTask, model, providerSource,
+ *  repo). See {@link OrchestratorTaskService.attachSession}. */
+export interface AttachSessionInput {
+  sessionId: string;
+  agentType: string;
+  workdir: string;
+  status: string;
+  metadata?: Record<string, unknown>;
+  label?: string;
+  originalTask?: string;
+  model?: string;
+  providerSource?: string;
+  repo?: string;
+  goalPrompt?: string;
+}
+
 export interface AddMessageInput {
   content: string;
   senderKind: TaskMessageSenderKind;
@@ -2662,6 +2681,96 @@ export class OrchestratorTaskService extends Service {
     this.sessionTaskIndex.set(result.sessionId, taskId);
     await this.advanceTaskStatus(taskId, "active");
     return this.getTask(taskId);
+  }
+
+  /**
+   * Bind an ACP session that was spawned OUTSIDE `spawnAgentForTask` (e.g. the
+   * `TASKS:create` chat action, which spawns via `AcpService.spawnSession`
+   * directly and does its own multi-part label / prefix / model routing) into
+   * an existing task thread's session index.
+   *
+   * Without this the task store's `sessionTaskIndex` never learns about those
+   * sessions, so `resolveTaskId` returns undefined, the event bridge drops
+   * their events, and DTOs read `0/0 agents` with no token attribution.
+   *
+   * Idempotent: attaching the same sessionId twice is a no-op (the store's
+   * `addSession` also upserts by sessionId). If the task doesn't exist, returns
+   * `false` — callers treat that as a soft failure, same policy as thread-mint
+   * failure in the create action.
+   *
+   * Only advances the task status to `active` for a non-terminal session; a
+   * session that's already `completed` / `stopped` / `error` on arrival gets
+   * indexed for history + token attribution but doesn't lie about liveness.
+   */
+  async attachSession(
+    taskId: string,
+    input: AttachSessionInput,
+  ): Promise<boolean> {
+    const doc = await this.store.getTask(taskId);
+    if (!doc) return false;
+    // Idempotent short-circuit — already indexed against THIS task.
+    if (this.sessionTaskIndex.get(input.sessionId) === taskId) {
+      const existing = doc.sessions.find(
+        (s) => s.sessionId === input.sessionId,
+      );
+      if (existing) return true;
+    }
+    const account = accountMetaFromSessionMetadata(input.metadata);
+    const ts = nowIso();
+    const now = Date.now();
+    const originalTask = input.originalTask ?? doc.task.goal;
+    const session: OrchestratorTaskSession = {
+      id: randomUUID(),
+      taskId,
+      sessionId: input.sessionId,
+      framework: input.agentType,
+      ...(input.providerSource ? { providerSource: input.providerSource } : {}),
+      ...(input.model ? { model: input.model } : {}),
+      ...(account
+        ? {
+            accountProviderId: account.providerId,
+            accountId: account.accountId,
+            accountLabel: account.label,
+          }
+        : {}),
+      label: input.label ?? input.sessionId,
+      originalTask,
+      ...(input.goalPrompt ? { goalPrompt: input.goalPrompt } : {}),
+      workdir: input.workdir,
+      ...(input.repo ? { repo: input.repo } : {}),
+      status: input.status,
+      decisionCount: 0,
+      autoResolvedCount: 0,
+      registeredAt: now,
+      lastActivityAt: now,
+      idleCheckCount: 0,
+      taskDelivered: false,
+      lastSeenDecisionIndex: 0,
+      spawnedAt: now,
+      ...(TERMINAL_TASK_SESSION_STATUSES.has(input.status)
+        ? { stoppedAt: now }
+        : {}),
+      retryCount: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      reasoningTokens: 0,
+      cacheTokens: 0,
+      costUsd: 0,
+      usageState: "unavailable",
+      metadata: {},
+      createdAt: ts,
+      updatedAt: ts,
+    };
+    await this.store.addSession(session);
+    this.sessionTaskIndex.set(input.sessionId, taskId);
+    // Only claim liveness if the session actually is live — a terminal-on-
+    // arrival session (chat action's runPromptAndClose already stopped it) gets
+    // indexed for history + future token attribution without falsely promoting
+    // task status.
+    if (!TERMINAL_TASK_SESSION_STATUSES.has(input.status)) {
+      await this.advanceTaskStatus(taskId, "active");
+    }
+    return true;
   }
 
   async sendToTaskAgent(


### PR DESCRIPTION
## Summary

Closes the KNOWN GAP documented in `plugins/plugin-agent-orchestrator/src/actions/tasks.ts`: chat-action `TASKS:create` spawns ACP sessions directly via `service.spawnSession`, then mints a durable orchestrator task thread, but the sessions were never registered in the task store's session index. Result: the task widget / tasks panel reads **0/0 agents** and `resolveTaskId` can't route session events back to the thread.

## What changed

- New public `attachSession(taskId, input)` on `OrchestratorTaskService`: binds an already-spawned session into the thread's session list + `sessionTaskIndex`. Idempotent, soft-fails on unknown taskId, only advances thread status to `active` for non-terminal sessions (terminal-on-arrival sessions from `runPromptAndClose` don't fake liveness).
- `tasks.ts` create action: after the thread mint, every successfully spawned session is attached with its per-part label/originalTask hints. Attach failures are logged and never demote the action's success (same policy as thread-mint failure).
- KNOWN GAP comment replaced with a pointer note.

## Why (a) attachSession, not (b) reroute through spawnAgentForTask

The create action has its own per-part `parseAgentPrefix` label routing, workdir-route resolution, and prompt lifecycle. `spawnAgentForTask` duplicates several of those concerns (`assignAgentName`, its own goal-prompt build); rerouting would duplicate or fight them. `attachSession` is the minimal surface.

## Tests

- 8 new unit tests: 5 service-level (`attach-session.test.ts`) + 3 action-level (`create-task-attaches-sessions.test.ts`)
- Full plugin suite: 1030/1030 passing
- `bun run build` + biome lint clean

## Known residual (follow-up slice, out of scope)

Sessions that complete BEFORE the thread mint fired their usage/`task_complete` events against a not-yet-existing taskId, so historical token attribution for the current single-turn create flow stays lost. Fixing that requires minting the thread before `runPromptAndClose` (spawn-lifecycle reorder). This PR guarantees the sessions appear on the thread (sessionCount / latestSessionId) and all FUTURE events/re-dispatches route correctly.

Live-verified on a self-hosted container: plugin hot-deployed, suite re-run (989/989 in the deploy checkout), spawn e2e green.

🤖 Built by Sol (agent). Co-authored-by: wakesync.