### PR TITLE
fix(core): fall back across useModel providers

### DIFF
--- a/.github/issue-evidence/10893-usemodel-provider-fallback.md
+++ b/.github/issue-evidence/10893-usemodel-provider-fallback.md
@@ -1,0 +1,35 @@
+# Issue #10893 - useModel Provider Fallback
+
+## Scope
+
+- Issue: https://github.com/elizaOS/eliza/issues/10893
+- Change: default `AgentRuntime.useModel` resolution now tries the next registered model provider when the preferred provider fails with a provider-fallback-eligible error.
+- Eligible failures: existing rate-limit/session-limit classifier, plus transient 5xx/network-style provider failures.
+- Guardrails: explicit provider calls still use the pinned provider, non-retryable provider errors still surface, and fallback is skipped once a streaming attempt has emitted visible output.
+
+## Evidence
+
+- `bun run --cwd packages/core prebuild`
+  - Result: pass. Regenerated the missing validation keyword data required for core tests/typecheck.
+- `bun test packages/core/src/runtime/__tests__/use-model-provider-fallback.test.ts`
+  - Result: pass. 4 tests, covering rate-limit fallback, 5xx fallback, non-retryable stop, and explicit-provider stop.
+- `bun test packages/core/src/services/__tests__/failure-reply-prompt.test.ts`
+  - Result: pass. 19 tests, including new provider-fallback classifier coverage.
+- `bunx biome check packages/core/src/runtime.ts packages/core/src/services/message.ts packages/core/src/services/message/fallback-reply.ts packages/core/src/runtime/__tests__/use-model-provider-fallback.test.ts packages/core/src/services/__tests__/failure-reply-prompt.test.ts`
+  - Result: pass.
+- `bun run --cwd packages/core typecheck`
+  - Result: pass.
+- `git fetch origin && git rebase origin/develop`
+  - Result: pass after resolving `packages/core/src/runtime.ts` against the upstream provider-failover loop added on `develop`.
+- `bun install`
+  - Result: pass. `bun.lock` install churn was discarded because it was unrelated to this issue.
+- `bun run verify`
+  - Result: blocked by an unrelated existing formatting failure in `packages/cloud/shared/src/lib/services/app-credits.ts` during `@elizaos/cloud-shared#lint`.
+  - The failing file is outside this issue's scope and was not modified by this branch. The worktree was clean after the failed verify run.
+
+## Artifact Matrix
+
+- Real-LLM trajectory: N/A. This change is covered by deterministic `AgentRuntime.useModel` tests with simulated provider failures; no live provider credentials are required to verify the fallback decision.
+- Backend/frontend logs: N/A. No server route or UI path changed.
+- Screenshots/video: N/A. No UI changed.
+- Per-platform capture: N/A. No native/mobile/desktop surface changed.

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -76,7 +76,7 @@ import {
 	SecretSwapSession,
 } from "./security/secret-swap";
 import { DefaultMessageService } from "./services/message";
-import { isRateLimitError } from "./services/message/fallback-reply";
+import { isModelProviderFallbackError } from "./services/message/fallback-reply";
 import type { ToolPolicyService } from "./services/tool-policy";
 import { decryptSecret, getSalt } from "./settings";
 import {
@@ -4661,8 +4661,12 @@ export class AgentRuntime implements IAgentRuntime {
 				continue;
 			}
 
+			const modelWithProvider =
+				provider && models.find((model) => model.provider === provider);
 			const candidateModels = provider
-				? models.filter((model) => model.provider === provider)
+				? modelWithProvider
+					? [modelWithProvider]
+					: []
 				: models;
 
 			for (const resolvedModel of candidateModels) {
@@ -4712,12 +4716,12 @@ export class AgentRuntime implements IAgentRuntime {
 				error:
 					args.error instanceof Error ? args.error.message : String(args.error),
 			},
-			"Model provider rate-limited; trying next registered provider",
+			"Model provider failed; trying next registered provider",
 		);
 	}
 
 	private shouldFailOverModelProvider(error: unknown): boolean {
-		return isRateLimitError(error);
+		return isModelProviderFallbackError(error);
 	}
 
 	private throwNoModelHandler(requestedModelKey: string): never {
@@ -5100,6 +5104,7 @@ export class AgentRuntime implements IAgentRuntime {
 		}
 
 		let lastModelError: unknown;
+		let providerAttemptStartedOutput = false;
 		for (
 			let resolvedIndex = 0;
 			resolvedIndex < resolvedModels.length;
@@ -5111,6 +5116,7 @@ export class AgentRuntime implements IAgentRuntime {
 			}
 			const resolvedModelKey = resolvedModel.modelKey;
 			const handler = resolvedModel.handler;
+			providerAttemptStartedOutput = false;
 
 			try {
 				const binaryModels: string[] = [
@@ -5256,6 +5262,9 @@ export class AgentRuntime implements IAgentRuntime {
 					visibleChunk = safeChunk,
 				): Promise<void> => {
 					if (abortSignal?.aborted) return;
+					if (safeChunk.length > 0) {
+						providerAttemptStartedOutput = true;
+					}
 					if (streamedText === "" && safeChunk.length > 0) {
 						markInference(INFERENCE_MARKS.firstToken);
 					}
@@ -5804,6 +5813,7 @@ export class AgentRuntime implements IAgentRuntime {
 				if (
 					requestedProvider !== undefined ||
 					!nextModel ||
+					providerAttemptStartedOutput ||
 					!this.shouldFailOverModelProvider(error)
 				) {
 					this.rethrowModelFailoverError(error);

--- a/packages/core/src/runtime/__tests__/use-model-provider-fallback.test.ts
+++ b/packages/core/src/runtime/__tests__/use-model-provider-fallback.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
+import { AgentRuntime } from "../../runtime";
+import { type Character, ModelType } from "../../types";
+
+function makeRuntime(): AgentRuntime {
+	return new AgentRuntime({
+		character: {
+			name: "ProviderFallbackAgent",
+			bio: "test",
+			settings: {},
+		} as Character,
+		adapter: new InMemoryDatabaseAdapter(),
+		logLevel: "fatal",
+	});
+}
+
+function statusError(statusCode: number, message: string): Error {
+	const error = new Error(message) as Error & { statusCode: number };
+	error.statusCode = statusCode;
+	return error;
+}
+
+describe("AgentRuntime.useModel provider fallback", () => {
+	it("falls through to the next provider when the preferred provider is rate-limited", async () => {
+		const runtime = makeRuntime();
+		const cliSdkFails = vi.fn(async () => {
+			throw statusError(429, "you have hit your session limit");
+		});
+		const cloudOk = vi.fn(async () => "cloud-response");
+
+		runtime.registerModel(ModelType.TEXT_LARGE, cliSdkFails, "claude-sdk", 100);
+		runtime.registerModel(ModelType.TEXT_LARGE, cloudOk, "eliza-cloud", 10);
+
+		await expect(
+			runtime.useModel(ModelType.TEXT_LARGE, { prompt: "hello" }),
+		).resolves.toBe("cloud-response");
+		expect(cliSdkFails).toHaveBeenCalledTimes(1);
+		expect(cloudOk).toHaveBeenCalledTimes(1);
+	});
+
+	it("falls through on transient 5xx provider failures", async () => {
+		const runtime = makeRuntime();
+		const unavailable = vi.fn(async () => {
+			throw statusError(503, "service unavailable");
+		});
+		const directApiOk = vi.fn(async () => "direct-api-response");
+
+		runtime.registerModel(ModelType.TEXT_LARGE, unavailable, "claude-sdk", 100);
+		runtime.registerModel(ModelType.TEXT_LARGE, directApiOk, "anthropic", 10);
+
+		await expect(
+			runtime.useModel(ModelType.TEXT_LARGE, { prompt: "hello" }),
+		).resolves.toBe("direct-api-response");
+		expect(unavailable).toHaveBeenCalledTimes(1);
+		expect(directApiOk).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not fall through for non-retryable provider errors", async () => {
+		const runtime = makeRuntime();
+		const badRequest = vi.fn(async () => {
+			throw statusError(400, "bad request");
+		});
+		const backup = vi.fn(async () => "unused");
+
+		runtime.registerModel(ModelType.TEXT_LARGE, badRequest, "claude-sdk", 100);
+		runtime.registerModel(ModelType.TEXT_LARGE, backup, "eliza-cloud", 10);
+
+		await expect(
+			runtime.useModel(ModelType.TEXT_LARGE, { prompt: "hello" }),
+		).rejects.toThrow("bad request");
+		expect(badRequest).toHaveBeenCalledTimes(1);
+		expect(backup).not.toHaveBeenCalled();
+	});
+
+	it("honors an explicitly pinned provider instead of trying another provider", async () => {
+		const runtime = makeRuntime();
+		const cliSdkFails = vi.fn(async () => {
+			throw statusError(429, "you have hit your session limit");
+		});
+		const cloudOk = vi.fn(async () => "unused");
+
+		runtime.registerModel(ModelType.TEXT_LARGE, cliSdkFails, "claude-sdk", 100);
+		runtime.registerModel(ModelType.TEXT_LARGE, cloudOk, "eliza-cloud", 10);
+
+		await expect(
+			runtime.useModel(ModelType.TEXT_LARGE, { prompt: "hello" }, "claude-sdk"),
+		).rejects.toThrow("session limit");
+		expect(cliSdkFails).toHaveBeenCalledTimes(1);
+		expect(cloudOk).not.toHaveBeenCalled();
+	});
+});

--- a/packages/core/src/services/__tests__/failure-reply-prompt.test.ts
+++ b/packages/core/src/services/__tests__/failure-reply-prompt.test.ts
@@ -1,6 +1,10 @@
 import { APICallError, RetryError } from "ai";
 import { describe, expect, it } from "vitest";
-import { buildFailureReplyPrompt, isRateLimitError } from "../message";
+import {
+	buildFailureReplyPrompt,
+	isModelProviderFallbackError,
+	isRateLimitError,
+} from "../message";
 
 /**
  * Pinned hard rules for the transient-failure reply prompt.
@@ -210,5 +214,42 @@ describe("isRateLimitError", () => {
 		expect(isRateLimitError(null)).toBe(false);
 		expect(isRateLimitError(undefined)).toBe(false);
 		expect(isRateLimitError({ message: "429" })).toBe(false);
+	});
+});
+
+describe("isModelProviderFallbackError", () => {
+	it("reuses the rate-limit classifier for CLI-SDK subscription/session limits", () => {
+		expect(
+			isModelProviderFallbackError(
+				new Error("You've hit your session limit. Please try again later."),
+			),
+		).toBe(true);
+	});
+
+	it("unwraps a RetryError-wrapped 5xx APICallError structurally", () => {
+		const inner = new APICallError({
+			message: "upstream unavailable",
+			url: "https://api.example.test/v1/chat/completions",
+			requestBodyValues: {},
+			statusCode: 503,
+		});
+		const err = new RetryError({
+			message: "Failed after 3 attempts.",
+			reason: "maxRetriesExceeded",
+			errors: [inner],
+		});
+		expect(isModelProviderFallbackError(err)).toBe(true);
+	});
+
+	it("does not treat non-retryable auth or validation errors as provider fallback", () => {
+		for (const statusCode of [400, 401, 403, 404]) {
+			const err = new APICallError({
+				message: "non retryable upstream error",
+				url: "https://api.example.test/v1/chat/completions",
+				requestBodyValues: {},
+				statusCode,
+			});
+			expect(isModelProviderFallbackError(err)).toBe(false);
+		}
 	});
 });

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -1406,6 +1406,7 @@ type FailureReplyAttempt =
 export {
 	buildFailureReplyPrompt,
 	isAuthError,
+	isModelProviderFallbackError,
 	isRateLimitError,
 	stripReasoningBlocks,
 } from "./message/fallback-reply";

--- a/packages/core/src/services/message/fallback-reply.ts
+++ b/packages/core/src/services/message/fallback-reply.ts
@@ -93,6 +93,38 @@ export function isAuthError(error: unknown): boolean {
 	);
 }
 
+/**
+ * Detect failures where another model provider is worth trying before giving up.
+ * This intentionally includes {@link isRateLimitError} so subscription-credit
+ * exhaustion from CLI-SDK providers follows the same structural 429/session-limit
+ * classifier as the graceful reply path.
+ */
+export function isModelProviderFallbackError(error: unknown): boolean {
+	const unwrapped = unwrapRetryError(error);
+	if (isRateLimitError(error)) {
+		return true;
+	}
+	if (hasHttpStatus(unwrapped, [500, 502, 503, 504])) {
+		return true;
+	}
+	if (!(error instanceof Error)) return false;
+	const haystack = `${error.name} ${error.message}`.toLowerCase();
+	return (
+		haystack.includes("timeout") ||
+		haystack.includes("timed out") ||
+		haystack.includes("temporarily unavailable") ||
+		haystack.includes("service unavailable") ||
+		haystack.includes("bad gateway") ||
+		haystack.includes("gateway timeout") ||
+		haystack.includes("internal server error") ||
+		haystack.includes("econnreset") ||
+		haystack.includes("socket hang up") ||
+		haystack.includes("network error") ||
+		haystack.includes("fetch failed") ||
+		haystack.includes("overloaded")
+	);
+}
+
 export function buildFailureReplyPrompt(recentMessages: string): string {
 	return [
 		"You hit a transient model error and have to send a short user-facing reply.",


### PR DESCRIPTION
## Summary

Closes #10893.

This builds on the upstream `useModel` provider failover loop and broadens it so chats can recover from transient provider failures, including CLI-SDK subscription/session-limit failures, 5xx responses, timeouts, and common network reset/fetch failures. It also preserves explicit pinned-provider calls and avoids blending streamed output by refusing failover after a provider has emitted visible chunks.

## Changes

- Add `isModelProviderFallbackError` beside the existing failure-reply classifier and re-export it from `services/message`.
- Use that classifier for `AgentRuntime.useModel` provider failover.
- Keep exact pinned-provider behavior when `options.provider` is supplied.
- Add focused runtime tests for rate-limit fallback, transient 5xx fallback, non-retryable 400 handling, and pinned-provider no-fallback behavior.
- Add classifier coverage for CLI-SDK subscription/session-limit text, RetryError-wrapped 503 responses, and non-retryable 4xx statuses.

## Evidence

Evidence file: `.github/issue-evidence/10893-usemodel-provider-fallback.md`

Passed:

- `bun run --cwd packages/core prebuild`
- `bun test packages/core/src/runtime/__tests__/use-model-provider-fallback.test.ts` (4 tests)
- `bun test packages/core/src/services/__tests__/failure-reply-prompt.test.ts` (19 tests)
- `bunx biome check packages/core/src/runtime.ts packages/core/src/services/message.ts packages/core/src/services/message/fallback-reply.ts packages/core/src/runtime/__tests__/use-model-provider-fallback.test.ts packages/core/src/services/__tests__/failure-reply-prompt.test.ts`
- `bun run --cwd packages/core typecheck`
- `git fetch origin && git rebase origin/develop`
- `bun install`

Blocked / unrelated:

- Root `bun run verify` currently fails in `@elizaos/cloud-shared#lint` because `packages/cloud/shared/src/lib/services/app-credits.ts` needs an existing formatting change. That file is outside this issue and is not modified by this branch.
