### PR TITLE
fix(orchestrator): close git-remote command injection + spend-cap $0 bypass

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/git-remote-safety.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/git-remote-safety.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertSafeGitRemote,
+  normalizeRepositoryInput,
+  UnsafeGitRemoteError,
+} from "../../src/services/repo-input.js";
+
+// The coding orchestrator clones repos on behalf of sub-agents whose task text
+// is model/attacker-influenced. `git clone` / `git ls-remote` expose command
+// execution and local-disclosure vectors through the remote argument, so every
+// repo string is run through assertSafeGitRemote before it reaches git.
+
+describe("assertSafeGitRemote", () => {
+  it("accepts https / http / ssh URLs and scp-style ssh remotes", () => {
+    for (const ok of [
+      "https://github.com/owner/repo.git",
+      "https://github.com/owner/repo",
+      "http://git.internal.example/owner/repo.git",
+      "ssh://git@github.com/owner/repo.git",
+      "git@github.com:owner/repo.git",
+      "user-name@host.example.com:group/sub/repo",
+    ]) {
+      expect(assertSafeGitRemote(ok)).toBe(ok);
+    }
+  });
+
+  it("accepts the output of normalizeRepositoryInput for every shorthand form", () => {
+    for (const input of [
+      "owner/repo",
+      "owner/repo.git",
+      "github.com/owner/repo",
+      "https://github.com/owner/repo/",
+      "git@github.com:owner/repo.git",
+    ]) {
+      const normalized = normalizeRepositoryInput(input);
+      expect(() => assertSafeGitRemote(normalized)).not.toThrow();
+    }
+  });
+
+  it("rejects the ext:: remote-helper (arbitrary command execution / RCE)", () => {
+    expect(() => assertSafeGitRemote('ext::sh -c "touch /tmp/pwned"')).toThrow(
+      UnsafeGitRemoteError,
+    );
+    // any <helper>:: transport prefix, not just ext
+    expect(() => assertSafeGitRemote("fd::17/repo")).toThrow(
+      UnsafeGitRemoteError,
+    );
+    expect(() => assertSafeGitRemote("foo::bar")).toThrow(UnsafeGitRemoteError);
+  });
+
+  it("rejects a leading '-' (argument injection, e.g. --upload-pack=…)", () => {
+    expect(() => assertSafeGitRemote("--upload-pack=touch /tmp/pwned")).toThrow(
+      UnsafeGitRemoteError,
+    );
+    expect(() => assertSafeGitRemote("-oProxyCommand=sh")).toThrow(
+      UnsafeGitRemoteError,
+    );
+  });
+
+  it("rejects file:// (local repository disclosure) and git:// (unauthenticated)", () => {
+    expect(() => assertSafeGitRemote("file:///etc/passwd")).toThrow(
+      UnsafeGitRemoteError,
+    );
+    expect(() => assertSafeGitRemote("git://evil.example/repo")).toThrow(
+      UnsafeGitRemoteError,
+    );
+  });
+
+  it("rejects empty / whitespace / bare tokens that are not valid remotes", () => {
+    expect(() => assertSafeGitRemote("")).toThrow(UnsafeGitRemoteError);
+    expect(() => assertSafeGitRemote("   ")).toThrow(UnsafeGitRemoteError);
+    expect(() => assertSafeGitRemote("just-a-word")).toThrow(
+      UnsafeGitRemoteError,
+    );
+  });
+
+  it("does not misclassify an IPv6 https URL as a transport helper", () => {
+    // `::` inside an IPv6 literal must NOT trip the `<helper>::` check.
+    const ipv6 = "https://[2001:db8::1]/owner/repo.git";
+    expect(assertSafeGitRemote(ipv6)).toBe(ipv6);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/__tests__/spend-allowance.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/spend-allowance.test.ts
@@ -77,6 +77,63 @@ describe("estimateSelfSpendCostUsd", () => {
       estimateSelfSpendCostUsd("domains.buy", { [SPEND_HINT_PARAM]: "abc" }),
     ).toBeNull();
   });
+
+  // Regression: an attacker-declared cost of exactly 0 must not slip a paid
+  // command under the cap. The old `hint ?? default` returned 0 for containers
+  // (nullish `??` does not catch 0) and `0` for hint-required commands.
+  it("never meters a container below its base cost even with a 0 or under-declared hint", () => {
+    expect(
+      estimateSelfSpendCostUsd("containers.create", { [SPEND_HINT_PARAM]: 0 }),
+    ).toBe(CONTAINER_DAILY_COST_USD);
+    expect(
+      estimateSelfSpendCostUsd("containers.update", {
+        [SPEND_HINT_PARAM]: 0.01,
+      }),
+    ).toBe(CONTAINER_DAILY_COST_USD);
+    // a hint above the base is still honored
+    expect(
+      estimateSelfSpendCostUsd("containers.create", { [SPEND_HINT_PARAM]: 3 }),
+    ).toBe(3);
+  });
+
+  it("treats a declared cost of 0 for a hint-required paid command as unknown (confirm)", () => {
+    expect(
+      estimateSelfSpendCostUsd("domains.buy", { [SPEND_HINT_PARAM]: 0 }),
+    ).toBeNull();
+    expect(
+      estimateSelfSpendCostUsd("media.image.generate", {
+        [SPEND_HINT_PARAM]: "0",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("decideSpendAuthorization — spend-cap bypass regression", () => {
+  it("does NOT auto-authorize a domains.buy declared at $0 under a cap", () => {
+    const decision = decideSpendAuthorization({
+      command: "domains.buy",
+      risk: "paid",
+      capUsd: 50,
+      alreadySpentUsd: 0,
+      params: { [SPEND_HINT_PARAM]: 0 },
+    });
+    expect(decision.autoAuthorize).toBe(false);
+    expect(decision.reason).toBe("unknown-cost");
+  });
+
+  it("meters a 0-hint container at its base cost so a tiny cap is respected", () => {
+    // Cap $0.50 < base $0.67: a 0-declared container must NOT auto-authorize.
+    const decision = decideSpendAuthorization({
+      command: "containers.create",
+      risk: "paid",
+      capUsd: 0.5,
+      alreadySpentUsd: 0,
+      params: { [SPEND_HINT_PARAM]: 0 },
+    });
+    expect(decision.estimatedCostUsd).toBe(CONTAINER_DAILY_COST_USD);
+    expect(decision.autoAuthorize).toBe(false);
+    expect(decision.reason).toBe("over-cap");
+  });
 });
 
 describe("decideSpendAuthorization", () => {

--- a/plugins/plugin-agent-orchestrator/src/services/repo-input.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/repo-input.ts
@@ -85,6 +85,69 @@ export function normalizeRepositoryInput(repo: string): string {
   return withoutTrailingSlash;
 }
 
+/** Thrown by {@link assertSafeGitRemote} when a repo string is unsafe to hand
+ * to `git` as a positional remote argument. */
+export class UnsafeGitRemoteError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UnsafeGitRemoteError";
+  }
+}
+
+// A remote-helper transport prefix like `ext::`, `fd::`, `foo::` — the `ext`
+// helper executes an arbitrary shell command, so `git clone 'ext::sh -c "…"'`
+// is remote code execution. Matches a scheme-like leading token immediately
+// followed by `::`. Deliberately does NOT match IPv6 URL literals such as
+// `https://[::1]/repo` (there the `::` is not preceded by a bare leading token).
+const GIT_TRANSPORT_HELPER_RE = /^[A-Za-z][A-Za-z0-9+.-]*::/;
+// Only https / http / ssh URL transports are allowed. `file:` (local repo
+// disclosure) and `git:` (unauthenticated, MITM-able) are rejected.
+const ALLOWED_GIT_URL_SCHEME_RE = /^(?:https?|ssh):\/\//i;
+// scp-style SSH remote: `[user@]host:path`, with a single `:` (not `::`, which
+// would be a transport helper) and no whitespace.
+const SCP_LIKE_REMOTE_RE = /^[^\s@:]+@[^\s:]+:(?!:)[^\s]+$/;
+
+/**
+ * Validate that a repository string is safe to pass to `git` as a positional
+ * remote argument, returning it unchanged when safe and throwing
+ * {@link UnsafeGitRemoteError} otherwise.
+ *
+ * The coding orchestrator clones repos on behalf of sub-agents whose task text
+ * is model/attacker-influenced. Without this gate a repo string reaches
+ * `git clone` / `git ls-remote` verbatim, and git exposes several code-exec /
+ * disclosure vectors through the remote argument:
+ *  - `ext::sh -c "…"` (and any `<helper>::…`) runs an arbitrary command;
+ *  - a leading `-` (e.g. `--upload-pack=…`) is parsed as a git *option*
+ *    (argument injection), since `execFile` does not add a `--` separator;
+ *  - `file://…` clones an arbitrary local repository (info disclosure).
+ *
+ * Callers MUST also spawn git with `GIT_ALLOW_PROTOCOL` restricted and a `--`
+ * separator — this function is the application-level allowlist half of that
+ * defense-in-depth pair.
+ */
+export function assertSafeGitRemote(repo: string): string {
+  const value = repo.trim();
+  if (!value) {
+    throw new UnsafeGitRemoteError("Git remote is empty.");
+  }
+  if (value.startsWith("-")) {
+    throw new UnsafeGitRemoteError(
+      `Git remote may not begin with "-" (argument injection): ${repo}`,
+    );
+  }
+  if (GIT_TRANSPORT_HELPER_RE.test(value)) {
+    throw new UnsafeGitRemoteError(
+      `Git remote uses an unsupported transport helper (e.g. ext::/fd::): ${repo}`,
+    );
+  }
+  if (ALLOWED_GIT_URL_SCHEME_RE.test(value) || SCP_LIKE_REMOTE_RE.test(value)) {
+    return value;
+  }
+  throw new UnsafeGitRemoteError(
+    `Git remote is not an https/http/ssh URL or an ssh scp-style remote: ${repo}`,
+  );
+}
+
 export function diagnoseWorkspaceBootstrapFailure(
   repo: string,
   errorMessage: string,

--- a/plugins/plugin-agent-orchestrator/src/services/spend-allowance.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/spend-allowance.ts
@@ -105,14 +105,21 @@ export function estimateSelfSpendCostUsd(
   command: string,
   params?: Record<string, unknown>,
 ): number | null {
-  const hint = toNonNegativeNumber(params?.[SPEND_HINT_PARAM]);
+  const rawHint = toNonNegativeNumber(params?.[SPEND_HINT_PARAM]);
+  // A declared cost of exactly 0 for a *paid* command is not a credible price —
+  // treat it as "no hint". Otherwise an attacker-declared `spendEstimateUsd: 0`
+  // meters the command at $0 and slips under any cap forever (the old
+  // `hint ?? default` also returned 0, because `??` only catches null/undefined).
+  const positiveHint = rawHint !== null && rawHint > 0 ? rawHint : null;
   if (command === "containers.create" || command === "containers.update") {
-    // Containers have a known base daily cost even without a hint.
-    return hint ?? CONTAINER_DAILY_COST_USD;
+    // Containers have a known base daily cost. Never meter below it — a caller
+    // that omits or under-declares the hint is still charged at least the base.
+    return Math.max(positiveHint ?? 0, CONTAINER_DAILY_COST_USD);
   }
-  // domains.buy, media.*, promote.*, advertising.* — require an explicit hint
-  // (e.g. the quoted price from domains.check). Unknown → confirm.
-  return hint;
+  // domains.buy, media.*, promote.*, advertising.* — require an explicit,
+  // positive hint (e.g. the quoted price from domains.check). Unknown or a
+  // non-positive declared cost → null → the caller asks a human to confirm.
+  return positiveHint;
 }
 
 export interface SpendDecisionInput {

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-service.ts
@@ -69,7 +69,7 @@ import {
 export type { AuthPromptCallback } from "./workspace-github.js";
 
 import { readConfigEnvKey } from "./config-env.js";
-import { normalizeRepositoryInput } from "./repo-input.js";
+import { assertSafeGitRemote, normalizeRepositoryInput } from "./repo-input.js";
 import {
   commit as gitCommit,
   createPR as gitCreatePR,
@@ -138,9 +138,20 @@ function lookupDefaultBranch(
   token?: string,
 ): Promise<string | null> {
   return new Promise((resolve) => {
+    try {
+      // Reject unsafe remotes (ext::, file://, leading "-", …) BEFORE spawning
+      // git — an unsafe URL is treated as an unresolved default branch, and the
+      // subsequent clone rejects it as the hard gate. See assertSafeGitRemote.
+      assertSafeGitRemote(repoUrl);
+    } catch {
+      resolve(null);
+      return;
+    }
     execFile(
       "git",
-      ["ls-remote", "--symref", repoUrl, "HEAD"],
+      // `--` ends option parsing so a repo that survives validation can never
+      // be reinterpreted as a git flag.
+      ["ls-remote", "--symref", "--", repoUrl, "HEAD"],
       {
         timeout: 10_000,
         encoding: "utf-8",
@@ -191,10 +202,20 @@ function isGitHubRepository(repo: string): boolean {
   return false;
 }
 
+// Restrict which transports git may use for these spawns. Blocks `ext`
+// (arbitrary command execution), `file` (local repo disclosure), and the git://
+// daemon (unauthenticated / MITM-able), while keeping the transports real
+// remotes use. Defense-in-depth alongside assertSafeGitRemote — this also
+// covers transports reached indirectly (HTTP redirects, submodules).
+const GIT_ALLOWED_PROTOCOLS = "http:https:ssh";
+
 function gitHubTokenEnv(repo: string, token?: string): NodeJS.ProcessEnv {
-  if (!token || !isGitHubRepository(repo)) return process.env;
+  if (!token || !isGitHubRepository(repo)) {
+    return { ...process.env, GIT_ALLOW_PROTOCOL: GIT_ALLOWED_PROTOCOLS };
+  }
   return {
     ...process.env,
+    GIT_ALLOW_PROTOCOL: GIT_ALLOWED_PROTOCOLS,
     GIT_CONFIG_COUNT: "1",
     GIT_CONFIG_KEY_0: "http.https://github.com/.extraheader",
     GIT_CONFIG_VALUE_0: `Authorization: Basic ${Buffer.from(
@@ -357,6 +378,12 @@ export class CodingWorkspaceService {
       workspace: CloneOverrideWorkspace,
       token?: string,
     ) => {
+      // Hard gate: reject unsafe remotes before spawning git. Throws
+      // UnsafeGitRemoteError (propagated to the provision caller) for ext::,
+      // file://, leading-"-" argument injection, etc.
+      const safeRepo = assertSafeGitRemote(
+        normalizeRepositoryInput(workspace.repo),
+      );
       await new Promise<void>((resolve, reject) => {
         execFile(
           "git",
@@ -364,7 +391,10 @@ export class CodingWorkspaceService {
             "clone",
             "--branch",
             workspace.branch.baseBranch,
-            normalizeRepositoryInput(workspace.repo),
+            // `--` ends option parsing; the repo and target dir are strictly
+            // positional and can never be reinterpreted as git flags.
+            "--",
+            safeRepo,
             ".",
           ],
           {


### PR DESCRIPTION
## Summary

An adversarial audit of `plugin-agent-orchestrator` (the coding sub-agent orchestrator) surfaced **two real, independently-exploitable security holes**, both reachable from model/attacker-influenced input (a sub-agent's task text / repo argument / self-spend params). This PR closes both, with tests.

### 1. Git-remote command injection / RCE — `workspace-service.ts`

`git ls-remote` (default-branch probe) and the credential-safe `git clone` override passed the repo string to `git` **verbatim** — no scheme allowlist, no `--` separator, no `GIT_ALLOW_PROTOCOL`. `normalizeRepositoryInput()` returns unknown inputs unchanged (`repo-input.ts`), so these reach git directly:

- `ext::sh -c "…"` — git's `ext` remote helper executes an **arbitrary shell command → host RCE**.
- `--upload-pack=…` / `-oProxyCommand=…` — parsed as a git **option** (argument injection), because `execFile` adds no `--`.
- `file:///…` — clones an **arbitrary local repository** (info disclosure).

**Fix (defense-in-depth, both layers):**
- New `assertSafeGitRemote()` (`repo-input.ts`): application-level allowlist — accepts only `https`/`http`/`ssh` URLs and scp-style ssh remotes (`git@host:owner/repo`); rejects `<helper>::` transports, a leading `-`, `file:`/`git:`, and bare tokens. IPv6 `https://[…]` URLs are **not** misclassified as transport helpers.
- Both git spawns now insert a `--` end-of-options separator.
- git is spawned with `GIT_ALLOW_PROTOCOL=http:https:ssh`, which blocks `ext`/`file`/`git` **even when reached indirectly** (HTTP redirects, submodules). Verified locally: `GIT_ALLOW_PROTOCOL=http:https:ssh git ls-remote 'ext::…'` → `fatal: transport 'ext' not allowed`.

### 2. Spend-cap bypass via attacker-declared `$0` cost — `spend-allowance.ts`

`estimateSelfSpendCostUsd` metered self-spend against the **caller-supplied** `spendEstimateUsd`, and `hint ?? CONTAINER_DAILY_COST_USD` returned `0` for a declared `0` (nullish `??` does not catch `0`). A sub-agent could pass `spendEstimateUsd: 0` and run **unlimited** container / domain / media spend under any cap.

**Fix:** a declared `0` for a paid command is treated as "no credible price" → falls to human confirmation (`unknown-cost`); containers are never metered below their known base daily cost even if the hint is omitted or under-declared.

> Residual (documented, out of scope here): a *positive-but-under-declared* hint for `domains.buy`/`media.*` is still trusted — fully closing that requires a server-side price/quote lookup rather than an agent-supplied hint. Tracked for follow-up.

## Test evidence

New + existing suites run against the identical-to-develop code (`bunx vitest run`):

- **`git-remote-safety.test.ts` (new):** accepts real remotes incl. IPv6 https + every `normalizeRepositoryInput` shorthand; rejects `ext::`, `fd::`, `foo::`, leading `-`/`--upload-pack=`, `file://`, `git://`, empty, and bare tokens.
- **`spend-allowance.test.ts`:** new regression cases — a `$0` container hint meters at base cost (tiny cap → `over-cap`, not auto-authorized); a `$0` `domains.buy` hint → `unknown-cost` (confirm). All prior cases still pass.
- `repo-parsing`, `resolve-default-branch`, `provision-workspace` green.

```
Test Files  3 passed (3) — git-remote-safety, repo-parsing, spend-allowance → 49 passed
Test Files  2 passed (2) — resolve-default-branch, provision-workspace     →  7 passed
```

Typecheck clean for all changed files; biome formatted.

## Risk / compatibility

- Valid GitHub/GitLab/Bitbucket https + scp-ssh remotes are unaffected (they pass the allowlist unchanged).
- Plain `git://` and `file://` remotes are now rejected — intentional (insecure / disclosure). No first-party flow uses them.

Part of the orchestrator hardening pass (issues #9960, #8875, #8124 area).

🤖 Generated with [Claude Code](https://claude.com/claude-code)