### PR TITLE
revert(core): #10945 simile candidate hint-feeding — redundant (tiering already resolves similes) and regresses canonical-wins

### DIFF
--- a/packages/core/src/runtime/__tests__/action-retrieval.test.ts
+++ b/packages/core/src/runtime/__tests__/action-retrieval.test.ts
@@ -144,35 +144,6 @@ describe("action catalogue and retrieval", () => {
 		});
 	});
 
-	it("exposes a parent whose SIMILE is named as a candidate hint (2026-07-01)", () => {
-		// Live regression: Stage-1 routed "generate an image of a corgi" to the
-		// media context and named the action by its simile GENERATE_IMAGE, but the
-		// real parent is GENERATE_MEDIA. scoreExactHints matched hints only against
-		// the parent's canonical name, so GENERATE_MEDIA got no exact-hint boost,
-		// was never exposed to the planner, and the model reported "no image tool"
-		// even though the action was registered and in-context.
-		const catalog = buildActionCatalog([
-			{
-				name: "GENERATE_MEDIA",
-				description: "Generate or process images, audio, and video.",
-				similes: ["GENERATE_IMAGE", "CREATE_IMAGE", "GENERATE_VIDEO"],
-				tags: ["media"],
-				contexts: ["media", "files"],
-			},
-			{ name: "WEB_SEARCH", description: "Search the web.", similes: [] },
-		]);
-		const response = retrieveActions({
-			catalog,
-			messageText: "generate an image of a corgi wearing sunglasses",
-			candidateActions: ["GENERATE_IMAGE"],
-		});
-		expect(response.results[0]).toMatchObject({
-			name: "GENERATE_MEDIA",
-			score: 1,
-			matchedBy: expect.arrayContaining(["exact"]),
-		});
-	});
-
 	it("matches candidate action namespaces and child names with regex scoring", () => {
 		const catalog = buildActionCatalog(actions);
 		const namespaceResponse = retrieveActions({

--- a/packages/core/src/runtime/action-retrieval.ts
+++ b/packages/core/src/runtime/action-retrieval.ts
@@ -274,16 +274,6 @@ export function retrieveActions(
 	const candidateActions = dedupeNormalizedStrings(input.candidateActions);
 	const parentActionHints = dedupeNormalizedStrings([
 		...(input.parentActionHints ?? []),
-		// A candidate the model named may be a parent's canonical name OR one of
-		// its declared similes — Stage-1 routinely names GENERATE_MEDIA as
-		// "GENERATE_IMAGE". Resolve either form to the canonical parent name so it
-		// earns the exact-hint score floor and is reliably exposed to the planner,
-		// instead of the real action being silently displaced out of the tier cut
-		// (which made the model report "no such tool" for a registered, in-context
-		// action).
-		...candidateActions.flatMap((actionName) =>
-			resolveCandidateToParentNames(input.catalog.parents, actionName),
-		),
 		...candidateActions.flatMap((actionName) =>
 			candidateNamespaceParentExists(input.catalog.parents, actionName)
 				? []
@@ -837,32 +827,6 @@ export function parentAliasesForCandidateAction(actionName: string): string[] {
 	if (parent) return [parent];
 	if (looksLikeViewCandidateAction(normalized)) return ["VIEWS"];
 	return [];
-}
-
-/**
- * Resolve a candidate action name the model emitted to the canonical parent
- * name(s) it refers to — matching either the parent's own name or one of its
- * declared similes. Returns [] when the candidate names no registered parent (a
- * hallucinated action), so it never fabricates an exposure. Used to give an
- * in-catalog candidate the exact-hint score floor whether the model named the
- * canonical action or a simile of it.
- */
-function resolveCandidateToParentNames(
-	parents: ActionCatalogParent[],
-	candidate: string,
-): string[] {
-	const normalized = normalizeActionName(candidate);
-	if (!normalized) return [];
-	const matches: string[] = [];
-	for (const parent of parents) {
-		if (
-			parent.normalizedName === normalized ||
-			parent.similes.some((simile) => normalizeActionName(simile) === normalized)
-		) {
-			matches.push(parent.normalizedName);
-		}
-	}
-	return matches;
 }
 
 function looksLikeViewCandidateAction(normalizedActionName: string): boolean {


### PR DESCRIPTION
## Summary

Reverts #10945 (my own PR). A post-merge adversarial review found — and I have **independently verified with hermetic A/B probes** — that the change is redundant for its stated purpose, and that its only actual behavioral delta is a regression.

### 1. The stated bug was not real at this layer (verified)

The tiering layer already resolves simile-named candidates: `matchesCandidate` (`action-tiering.ts`) matches candidates against `parent.similes`, and the candidate-promotion loop lifts the owning parent into tier-A at any retrieval score; candidates also feed the keyword/BM25 query while similes live in the parent's searchText.

A/B on the PR's exact motivating scenario (catalog with `GENERATE_MEDIA` ~ similes `GENERATE_IMAGE/...`, candidate `["GENERATE_IMAGE"]`, plus 20 decoy actions to pressure the tier cut):

```
BASE   (pre-#10945): tierA = ["GENERATE_MEDIA"]  ← already exposed
MERGED (with #10945): tierA = ["GENERATE_MEDIA"]  ← identical
```

The live "no image tool" incident that motivated #10819 was the **unregistered-handler** case (cloud IMAGE handler suppressed — fixed by #10961), where this PR is a no-op by design (`resolveCandidateToParentNames` returns `[]` for unregistered names).

### 2. The one real behavior change is an anti-squatting regression (verified)

When a candidate names a real action that is **also** another parent's declared simile (`TASKS` is a registered action; `SCHEDULED_TASKS` declares simile `"TASKS"`):

```
BASE:   TASKS score 1.0/0.95 (canonical)   SCHEDULED_TASKS 0.77   ← canonical wins
MERGED: TASKS exact 1.0                    SCHEDULED_TASKS exact 1.0 ← simile owner force-tied
```

The simile owner is boosted to exact-1.0 parity, crossing the retrieval-override threshold and bypassing the tiering's documented "canonical names win over similes" protection.

### Also removed with the revert

The per-message `O(candidates × parents × similes)` normalization pass, which bought nothing.

Credit to the adversarial review process for catching this — the review evidence and these reproduction probes are what this revert is based on. The `action-retrieval` + `action-tiering` suites are green on the reverted tree; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
