### PR TITLE
fix(orchestrator): don't let a positive count mask an explicit failure marker

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/completion-failure-marker.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/completion-failure-marker.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { completionHasFailureMarkerWithoutPositiveEvidence } from "../../src/evaluators/sub-agent-completion.js";
+
+// The response evaluator uses this predicate to decide whether a sub-agent's
+// `task_complete` is actually a FAILURE that must be routed back rather than
+// relayed to the user as success. Regression coverage for the ordering bug
+// where a positive count masked an explicit tool-failure marker.
+
+describe("completionHasFailureMarkerWithoutPositiveEvidence", () => {
+  it("flags an explicit tool-failure marker even when a positive count is also present", () => {
+    // Prior bug: `found 5` short-circuited to "no failure" BEFORE the
+    // `exit code 1` failure marker was ever checked, so this relayed as success.
+    expect(
+      completionHasFailureMarkerWithoutPositiveEvidence(
+        "Ran the test suite: exit code 1. Also found 5 matching files.",
+      ),
+    ).toBe(true);
+    expect(
+      completionHasFailureMarkerWithoutPositiveEvidence(
+        "permission denied while writing output; there are 3 candidates.",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not flag a genuine positive result with no failure marker", () => {
+    expect(
+      completionHasFailureMarkerWithoutPositiveEvidence(
+        "Search complete — found 5 matching files.",
+      ),
+    ).toBe(false);
+  });
+
+  it("flags a bare failure marker", () => {
+    expect(
+      completionHasFailureMarkerWithoutPositiveEvidence(
+        "The build command exited with code 1.",
+      ),
+    ).toBe(true);
+  });
+
+  it("treats a verified/user-facing URL as decisive positive evidence (no route-back)", () => {
+    // A reachable deploy is strong positive evidence; documented short-circuit.
+    expect(
+      completionHasFailureMarkerWithoutPositiveEvidence(
+        "Deployed, though a lint step exited with code 1. https://example.test/apps/demo/",
+      ),
+    ).toBe(false);
+    expect(
+      completionHasFailureMarkerWithoutPositiveEvidence(
+        "A step exited with code 1.",
+        ["https://example.test/apps/demo/"],
+      ),
+    ).toBe(false);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-completion.ts
+++ b/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-completion.ts
@@ -305,7 +305,7 @@ function completionHasVerificationFailure(text: string): boolean {
   );
 }
 
-function completionHasFailureMarkerWithoutPositiveEvidence(
+export function completionHasFailureMarkerWithoutPositiveEvidence(
   text: string,
   verifiedUrls: readonly string[] = [],
 ): boolean {
@@ -313,8 +313,15 @@ function completionHasFailureMarkerWithoutPositiveEvidence(
   const fullText = stripRouterAnnotations(text);
   const searchable = [body, fullText].filter(Boolean).join("\n");
   if (verifiedUrls.length > 0 || hasUserFacingUrl(searchable)) return false;
-  if (POSITIVE_QUANTITATIVE_EVIDENCE_RE.test(searchable)) return false;
+  // An explicit tool-failure marker (exit code 1, "permission denied", …) means
+  // the work failed regardless of any positive count the model also reported:
+  // "tests failed, exit code 1, but I found 5 files" is still a failure. It must
+  // be checked BEFORE the positive-evidence heuristic — that heuristic exists
+  // only to keep a *successful* "found 5 results" from tripping the no-result
+  // marker below, not to override a real failure. (Prior order let a positive
+  // count mask an explicit failure and relay it to the user as success.)
   if (TOOL_FAILURE_MARKER_RE.test(searchable)) return true;
+  if (POSITIVE_QUANTITATIVE_EVIDENCE_RE.test(searchable)) return false;
   return NO_RESULT_MARKER_RE.test(fullText) && !NO_RESULT_MARKER_RE.test(body);
 }
 


### PR DESCRIPTION
## Summary

Part of the orchestrator text-eval hardening pass. The response evaluator decides whether a sub-agent's `task_complete` is a **failure to route back** or a **success to relay to the user**. That decision runs through `completionHasFailureMarkerWithoutPositiveEvidence`, which had its checks in the wrong order:

```ts
if (POSITIVE_QUANTITATIVE_EVIDENCE_RE.test(searchable)) return false; // ← ran first
if (TOOL_FAILURE_MARKER_RE.test(searchable)) return true;            // ← never reached
```

A completion like **“tests failed, exit code 1, but I found 5 files”** matched `found 5`, returned *“no failure”* early, and the explicit `exit code 1` was never inspected — so a failed task was relayed to the user as success.

## Fix

An explicit tool-failure marker (`exit code 1`, `permission denied`, …) means the work failed **regardless** of any count the model also reported. Check it **before** the positive-evidence heuristic — that heuristic exists only to keep a genuinely successful *“found 5 results”* from tripping the no-result marker, not to override a real failure.

## Test evidence

Exported the pure predicate and added `completion-failure-marker.test.ts`:

- `exit code 1` + `found 5 files` → **route back** (was: relayed as success) ✅
- `permission denied` + `there are 3 candidates` → route back ✅
- `found 5 matching files` (no failure marker) → relay (not a failure) ✅
- bare `exited with code 1` → route back ✅
- failure marker + a verified/user-facing URL → still relay (a reachable deploy is decisive; documented short-circuit) ✅

```
Test Files  2 passed (2)  — completion-failure-marker, sub-agent-completion-evaluator
     Tests  37 passed (37)
```

Existing 33-case evaluator suite unchanged and green. One-line reorder, no behavior change for any prior case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)