### PR TITLE
fix(core): complete-direct-reply valve never keeps a hallucinated answer to an explicitly fresh ask

### DIFF
--- a/packages/core/src/__tests__/message-routing-live-regression.test.ts
+++ b/packages/core/src/__tests__/message-routing-live-regression.test.ts
@@ -85,6 +85,25 @@ describe("plain-text backstop — complete-direct-reply valve (2026-07-01)", () 
 		expect(out.plan.candidateActions?.length ?? 0).toBeGreaterThan(0);
 	});
 
+	it("forces the fetch even when the model HALLUCINATES a complete answer to a fresh ask", () => {
+		// Adversarial-review hardening: the valve must never keep a
+		// confident-but-unverified plain-text "answer" to an explicitly fresh
+		// question — a stale price delivered confidently is worse than the extra
+		// fetch. looksLikeWebSearchRequest gates the valve off for the
+		// current-info + market/news/weather class.
+		const out = applyDirectCurrentCandidateBackstopToMessageHandler(
+			simplePlainReply(
+				"Bitcoin is trading at $45,000 right now, up 2% on the day.",
+			),
+			{
+				actions: WEB_ACTIONS,
+				messageText: "what is the current price of bitcoin right now?",
+			},
+		);
+		expect(out.plan.requiresTool).toBe(true);
+		expect(out.plan.candidateActions?.length ?? 0).toBeGreaterThan(0);
+	});
+
 	it("still plans a coding-work request even with a complete-looking reply", () => {
 		const out = applyDirectCurrentCandidateBackstopToMessageHandler(
 			simplePlainReply(

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -4010,8 +4010,16 @@ export function applyDirectCurrentCandidateBackstopToMessageHandler(
 	// app" reply that read as a complete sentence could be kept direct and never
 	// spawn. Restricting the valve to non-coding-work turns keeps the build-spawn
 	// path intact while still short-circuiting finished plain-text answers.
+	// The !looksLikeWebSearchRequest guard closes the freshness hole the valve
+	// would otherwise open (adversarial review): on an explicitly fresh ask
+	// ("what's the current BTC price?") a model that confidently HALLUCINATES a
+	// complete-looking plain-text answer must not be kept direct — a stale price
+	// delivered confidently is worse than the extra fetch. The valve's wins
+	// (lucky-number echoes, solved riddles, static knowledge) carry no
+	// current-info signal and keep taking the direct path.
 	if (
 		!looksLikeCodingWorkRequest(currentMessageText) &&
+		!looksLikeWebSearchRequest(currentMessageText) &&
 		shouldPreferCompleteDirectReply({
 			replyText: String(messageHandler.plan.reply ?? ""),
 			candidateActions: runnableCandidateActions,


### PR DESCRIPTION
## Summary

Post-merge hardening of the plain-text over-routing valve from an adversarial review pass.

**The confirmed finding (kernel of the review's major):** the valve kept *any* complete-looking plain-text answer direct — including a confidently **hallucinated** answer to an explicitly fresh question. `"what is the current price of bitcoin right now?"` → model emits `"Bitcoin is trading at $45,000 right now, up 2% on the day."` in plain prose → valve keeps it → the user gets a stale/invented price. Pre-valve, that turn was forced through the fetch and got real data. For the freshness-critical class, the extra fetch is strictly better than a confident stale answer.

**The fix:** gate the valve with the existing `looksLikeWebSearchRequest` classifier (explicit search asks OR current-info signal + market/news/weather nouns — with its built-in "don't browse" negation escape). The freshness-critical class now always fetches regardless of how complete the plain-text reply looks; the valve's wins (lucky-number echoes, solved riddles, static knowledge — no current-info signal) keep the direct path.

**On the review's second major ("the tests verify nothing"):** independently A/B'd — the merged valve tests **fail 4/4** on pre-valve code and pass on merged code, so the suite does pin the behavior. That claim was refuted; this PR addresses the part that survived verification.

## Tests

New regression test: hallucinated complete answer + fresh ask → `requiresTool=true` with web candidates (fetch forced). Full `message-routing-live-regression` + `message-handler-bogus-candidates`: 61/61 green. Core typecheck clean.

Part of the adversarial-review hardening batch (#10975, #10976, #10977, #10982).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
