### PR TITLE
fix(orchestrator): recognize eliza-shaped DB adapter so task threads survive restarts

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts
@@ -599,6 +599,12 @@ describe("RuntimeDbTaskStore", () => {
     const store = new RuntimeDbTaskStore(capturing);
     await store.createTask(createInput({ title: "portable upsert" }));
 
+    // The DDL must use BIGINT for the ms-epoch column: Date.now() (~1.75e12)
+    // overflows postgres/pglite int4, and this SQL path is exactly the one
+    // that now engages on those backends.
+    const createTable = seenSql.find((s) => /CREATE TABLE/i.test(s));
+    expect(createTable).toMatch(/last_activity_at BIGINT/i);
+
     const upserts = seenSql.filter((s) => /INSERT\s+INTO/i.test(s));
     expect(upserts.length).toBeGreaterThan(0);
     for (const sql of upserts) {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts
@@ -607,15 +607,15 @@ describe("RuntimeDbTaskStore", () => {
     }
   });
 
-  it("round-trips through the drizzle SQL builder against an eliza-shaped adapter", { timeout: 30_000 }, async () => {
+  it("round-trips through the drizzle SQL builder against an eliza-shaped adapter", {
+    timeout: 30_000,
+  }, async () => {
     // Prove the eliza `BaseDrizzleAdapter` path actually assembles valid
     // drizzle SQL objects. We use drizzle-orm's own SQL class to render the
     // query to plain SQL + params, then feed that into the FakeSqlAdapter so
     // the round-trip semantics are the same as the raw path.
     const drizzle = await import("drizzle-orm");
-    const pgDialect = new (
-      await import("drizzle-orm/pg-core")
-    ).PgDialect();
+    const pgDialect = new (await import("drizzle-orm/pg-core")).PgDialect();
     const adapter = new FakeSqlAdapter();
     const drizzleShaped = {
       db: {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts
@@ -179,6 +179,27 @@ describe("OrchestratorTaskStore backend selection", () => {
     expect(store.backend).toBe("runtime-db");
   });
 
+  it("reads the modern `runtime.adapter` property, not just the legacy `runtime.databaseAdapter`", () => {
+    // packages/core/src/runtime.ts exposes `public adapter!: IDatabaseAdapter`,
+    // so this is how a real eliza runtime feeds a database into the store.
+    const store = new OrchestratorTaskStore({
+      runtime: { adapter: new FakeSqlAdapter() },
+    });
+    expect(store.backend).toBe("runtime-db");
+  });
+
+  it("recognizes an eliza `BaseDrizzleAdapter` shape (adapter.db.execute)", () => {
+    // The real @elizaos/plugin-sql adapter exposes SQL through `adapter.db`
+    // (a drizzle instance) rather than flat top-level methods. The store must
+    // recognize this shape too, or every real container falls to the file
+    // backend.
+    const fakeDrizzleAdapter = { db: { execute: () => Promise.resolve([]) } };
+    const store = new OrchestratorTaskStore({
+      runtime: { adapter: fakeDrizzleAdapter },
+    });
+    expect(store.backend).toBe("runtime-db");
+  });
+
   it("lets an explicit memory backend win over an available adapter", () => {
     const store = new OrchestratorTaskStore({
       backend: "memory",
@@ -518,5 +539,111 @@ describe("RuntimeDbTaskStore", () => {
       createInput({ title: "query only" }),
     );
     expect((await store.getTask(task.id))?.task.title).toBe("query only");
+  });
+
+  it("survives a service restart: a fresh store over the same adapter still lists the task and its sessions", async () => {
+    // Regression for the live symptom: `/api/orchestrator/tasks` returned a
+    // task before a container restart and `{"tasks":[]}` after. The docker
+    // filesystem was ephemeral, so the file backend lost its JSON. This test
+    // proves the SQL backend does NOT depend on any in-memory state: a
+    // completely new store instance layered over the same durable rows can
+    // still see the task and every session that was attached to it.
+    const adapter = new FakeSqlAdapter();
+
+    const service1 = new RuntimeDbTaskStore(adapter);
+    const { task } = await service1.createTask(
+      createInput({ title: "e2e reliability test page" }),
+    );
+    await service1.addSession(sessionFor(task.id, { sessionId: "session-a" }));
+    await service1.addSession(
+      sessionFor(task.id, {
+        id: "row-2",
+        sessionId: "session-b",
+        label: "reviewer",
+      }),
+    );
+
+    // Discard service1 entirely to simulate the container being torn down.
+    // Rows stay in `adapter` because that's the persistent SQL surface.
+    const service2 = new RuntimeDbTaskStore(adapter);
+
+    const listed = await service2.listTasks();
+    expect(listed.map((t) => t.id)).toContain(task.id);
+    expect(listed.find((t) => t.id === task.id)?.title).toBe(
+      "e2e reliability test page",
+    );
+
+    const detail = await service2.getTask(task.id);
+    expect(detail?.sessions.map((s) => s.sessionId).sort()).toEqual([
+      "session-a",
+      "session-b",
+    ]);
+
+    // And a session lookup by id still resolves back to the right task.
+    const found = await service2.findSession("session-b");
+    expect(found?.taskId).toBe(task.id);
+  });
+
+  it("emits a portable ON CONFLICT upsert so postgres/pglite/sqlite all accept it", async () => {
+    // Old code emitted `INSERT OR REPLACE INTO ...`, which is SQLite-only.
+    // Postgres and pglite reject that. Capture the SQL and assert on it.
+    const seenSql: string[] = [];
+    const adapter = new FakeSqlAdapter();
+    const capturing = {
+      execute: (sql: string, params?: unknown[]) => {
+        seenSql.push(sql);
+        return adapter.execute(sql, params);
+      },
+      all: (sql: string, params?: unknown[]) => adapter.all(sql, params),
+    };
+    const store = new RuntimeDbTaskStore(capturing);
+    await store.createTask(createInput({ title: "portable upsert" }));
+
+    const upserts = seenSql.filter((s) => /INSERT\s+INTO/i.test(s));
+    expect(upserts.length).toBeGreaterThan(0);
+    for (const sql of upserts) {
+      expect(sql).toMatch(/ON CONFLICT/i);
+      expect(sql).not.toMatch(/INSERT\s+OR\s+REPLACE/i);
+    }
+  });
+
+  it("round-trips through the drizzle SQL builder against an eliza-shaped adapter", { timeout: 30_000 }, async () => {
+    // Prove the eliza `BaseDrizzleAdapter` path actually assembles valid
+    // drizzle SQL objects. We use drizzle-orm's own SQL class to render the
+    // query to plain SQL + params, then feed that into the FakeSqlAdapter so
+    // the round-trip semantics are the same as the raw path.
+    const drizzle = await import("drizzle-orm");
+    const pgDialect = new (
+      await import("drizzle-orm/pg-core")
+    ).PgDialect();
+    const adapter = new FakeSqlAdapter();
+    const drizzleShaped = {
+      db: {
+        execute: async (query: unknown) => {
+          if (query instanceof drizzle.SQL) {
+            const { sql, params } = pgDialect.sqlToQuery(query);
+            const head = sql.trim().slice(0, 6).toUpperCase();
+            if (head === "SELECT") return adapter.all(sql, params);
+            return adapter.execute(sql, params);
+          }
+          throw new Error(
+            "drizzle-shaped adapter received a non-SQL object; store" +
+              " is emitting the wrong query type",
+          );
+        },
+      },
+    };
+    const store = new RuntimeDbTaskStore(drizzleShaped);
+    const { task } = await store.createTask(
+      createInput({ title: "drizzle round trip" }),
+    );
+    await store.addSession(sessionFor(task.id));
+
+    // A completely new store over the same durable adapter still lists it.
+    const reopened = new RuntimeDbTaskStore(drizzleShaped);
+    const listed = await reopened.listTasks();
+    expect(listed.map((t) => t.id)).toContain(task.id);
+    const detail = await reopened.getTask(task.id);
+    expect(detail?.sessions[0]?.sessionId).toBe("session-1");
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -146,6 +146,9 @@ type RuntimeLike = IAgentRuntime & {
       (message: string, data?: unknown) => void
     >
   >;
+  /** Modern eliza runtime property. */
+  adapter?: unknown;
+  /** Legacy alias for pre-2026 runtimes and some container harnesses. */
   databaseAdapter?: unknown;
   getSetting?: (key: string) => string | undefined | null;
 };
@@ -590,6 +593,10 @@ export class OrchestratorTaskService extends Service {
       opts.store ??
       new OrchestratorTaskStore({
         runtime: {
+          // Feed both names. The store prefers `adapter` and falls back to
+          // `databaseAdapter`. This keeps ancient hand-rolled runtimes working
+          // while wiring modern eliza runtimes to the SQL backend for real.
+          adapter: this.runtime.adapter,
           databaseAdapter: this.runtime.databaseAdapter,
           logger: this.runtime.logger,
           getSetting: (key) => {

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
@@ -46,12 +46,17 @@ interface Logger {
 }
 
 interface TaskStoreRuntime {
+  /** Modern eliza runtime exposes the DB adapter as `runtime.adapter`. */
+  adapter?: unknown;
+  /** Legacy alias kept for pre-2026 runtimes and custom container harnesses. */
   databaseAdapter?: unknown;
   logger?: Logger;
   getSetting?: (key: string) => string | undefined;
 }
 
-type SqlDatabaseAdapter = {
+/** Raw shape: an adapter that exposes flat SQL methods directly. Older test
+ * harnesses (and hand-rolled sqlite bindings) look like this. */
+type RawSqlDatabaseAdapter = {
   query?: (sql: string, params?: unknown[]) => Promise<unknown> | unknown;
   execute?: (sql: string, params?: unknown[]) => Promise<unknown> | unknown;
   run?: (sql: string, params?: unknown[]) => Promise<unknown> | unknown;
@@ -59,6 +64,23 @@ type SqlDatabaseAdapter = {
   get?: (sql: string, params?: unknown[]) => Promise<unknown> | unknown;
   select?: (sql: string, params?: unknown[]) => Promise<unknown[]> | unknown[];
 };
+
+/** Eliza shape: `BaseDrizzleAdapter` from @elizaos/plugin-sql. The raw
+ * executor lives on `adapter.db.execute(sql\`...\`)` (drizzle's tagged-template
+ * SQL). We only need `.execute` here. It returns a rowset for SELECTs and an
+ * ack for writes, which is all this store's storage-layer touches. */
+type ElizaDrizzleAdapter = {
+  db: {
+    execute: (query: unknown) => Promise<unknown> | unknown;
+  };
+};
+
+/** Unified low-level executor. `run` performs a mutation and ignores the
+ * result; `all` runs a SELECT and returns rows. */
+interface SqlExecutor {
+  run(sql: string, params?: unknown[]): Promise<void>;
+  all(sql: string, params?: unknown[]): Promise<unknown[]>;
+}
 
 // Bound auxiliary inline collections so telemetry/artifact chatter cannot grow
 // without limit. The primary operator timeline (messages + events) remains
@@ -99,11 +121,114 @@ function normalizeTaskDocument(
   };
 }
 
-function isSqlDatabaseAdapter(value: unknown): value is SqlDatabaseAdapter {
+function isRawSqlDatabaseAdapter(
+  value: unknown,
+): value is RawSqlDatabaseAdapter {
   if (!isRecord(value)) return false;
   return ["query", "execute", "run", "all", "get", "select"].some(
     (method) => typeof value[method] === "function",
   );
+}
+
+function isElizaDrizzleAdapter(value: unknown): value is ElizaDrizzleAdapter {
+  if (!isRecord(value)) return false;
+  const db = value.db;
+  return isRecord(db) && typeof db.execute === "function";
+}
+
+function isPersistableAdapter(
+  value: unknown,
+): value is RawSqlDatabaseAdapter | ElizaDrizzleAdapter {
+  return isRawSqlDatabaseAdapter(value) || isElizaDrizzleAdapter(value);
+}
+
+/**
+ * Resolve a raw or eliza-shaped adapter to a unified `SqlExecutor`.
+ *
+ * For raw adapters we pick the best available method for each operation.
+ * For eliza adapters we bake a tiny drizzle-flavored parameter binder: the
+ * SQL we emit uses `?` placeholders, so we substitute drizzle's own
+ * `sql\`...\`` template that concatenates literal string segments with
+ * `sql.param(value)` bind markers, using the drizzle runtime already loaded
+ * next to the adapter. Since we only invoke this from within an environment
+ * that ships `@elizaos/plugin-sql` (drizzle-orm is present), we require it
+ * lazily at first use to avoid a hard dependency here.
+ */
+async function resolveSqlExecutor(
+  adapter: RawSqlDatabaseAdapter | ElizaDrizzleAdapter,
+): Promise<SqlExecutor> {
+  if (isElizaDrizzleAdapter(adapter)) {
+    // Lazily require drizzle's sql builder. Cast through unknown, since the
+    // eliza adapter guarantees drizzle-orm is installed alongside it.
+    const drizzle = (await import("drizzle-orm")) as {
+      sql: {
+        raw(text: string): unknown;
+        param(value: unknown): unknown;
+        join(chunks: unknown[], separator?: unknown): unknown;
+      };
+    };
+    const buildQuery = (text: string, params: unknown[] = []): unknown => {
+      if (params.length === 0) return drizzle.sql.raw(text);
+      // Split the emitted SQL on `?` placeholders and interleave drizzle
+      // bind-param chunks between the literal fragments. We only ever emit
+      // `?` (never `?N`) below, so a naive split is safe here.
+      const parts = text.split("?");
+      if (parts.length - 1 !== params.length) {
+        throw new Error(
+          `orchestrator-task-store: placeholder/param count mismatch (${
+            parts.length - 1
+          } placeholders vs ${params.length} params)`,
+        );
+      }
+      const chunks: unknown[] = [];
+      for (let i = 0; i < parts.length; i++) {
+        chunks.push(drizzle.sql.raw(parts[i]));
+        if (i < params.length) chunks.push(drizzle.sql.param(params[i]));
+      }
+      return drizzle.sql.join(chunks);
+    };
+    return {
+      async run(text, params) {
+        await adapter.db.execute(buildQuery(text, params));
+      },
+      async all(text, params) {
+        const result = await adapter.db.execute(buildQuery(text, params));
+        return normalizeRowset(result);
+      },
+    };
+  }
+
+  const runFn = adapter.execute ?? adapter.run ?? adapter.query;
+  const allFn = adapter.all ?? adapter.select ?? adapter.query;
+  if (!runFn) {
+    throw new Error(
+      "orchestrator-task-store: raw adapter exposes none of execute/run/query",
+    );
+  }
+  if (!allFn) {
+    throw new Error(
+      "orchestrator-task-store: raw adapter exposes none of all/select/query",
+    );
+  }
+  return {
+    async run(text, params = []) {
+      await runFn.call(adapter, text, params);
+    },
+    async all(text, params = []) {
+      const result = await allFn.call(adapter, text, params);
+      return normalizeRowset(result);
+    },
+  };
+}
+
+function normalizeRowset(result: unknown): unknown[] {
+  if (Array.isArray(result)) return result;
+  if (isRecord(result)) {
+    for (const key of ["rows", "results", "data", "values"]) {
+      if (Array.isArray(result[key])) return result[key] as unknown[];
+    }
+  }
+  return [];
 }
 
 function nowIso(): string {
@@ -565,13 +690,21 @@ const TASK_INDEX_SQL = [
 ];
 
 /** SQL backend. Stores the whole document as a JSON column with indexed
- * columns for the list query, so all reads/writes are single-row operations. */
+ * columns for the list query, so all reads/writes are single-row operations.
+ *
+ * Accepts either a raw sqlite-style adapter (older test harnesses,
+ * hand-rolled bindings) or an eliza `BaseDrizzleAdapter` (postgres/pglite),
+ * routing through {@link resolveSqlExecutor}. Upsert SQL uses `ON CONFLICT`
+ * so it's portable across postgres, pglite, and sqlite ≥3.24. */
 export class RuntimeDbTaskStore {
   private readonly cache = new InMemoryTaskStore();
   private initPromise: Promise<void> | undefined;
+  private executor: SqlExecutor | undefined;
   private tail = Promise.resolve();
 
-  constructor(private readonly adapter: SqlDatabaseAdapter) {}
+  constructor(
+    private readonly adapter: RawSqlDatabaseAdapter | ElizaDrizzleAdapter,
+  ) {}
 
   private enqueue<T>(operation: () => Promise<T>): Promise<T> {
     const run = this.tail.then(operation, operation);
@@ -584,31 +717,20 @@ export class RuntimeDbTaskStore {
 
   private async ensureInitialized(): Promise<void> {
     this.initPromise ??= (async () => {
-      await this.exec(TASK_TABLE_SQL);
-      for (const sql of TASK_INDEX_SQL) await this.exec(sql);
+      this.executor = await resolveSqlExecutor(this.adapter);
+      await this.executor.run(TASK_TABLE_SQL);
+      for (const sql of TASK_INDEX_SQL) await this.executor.run(sql);
     })();
     await this.initPromise;
   }
 
-  private async exec(sql: string, params: unknown[] = []): Promise<unknown> {
-    const fn = this.adapter.execute ?? this.adapter.run ?? this.adapter.query;
-    if (!fn)
-      throw new Error("Runtime DB adapter exposes none of execute/run/query");
-    return fn.call(this.adapter, sql, params);
-  }
-
-  private async rows(sql: string, params: unknown[] = []): Promise<unknown[]> {
-    const fn = this.adapter.all ?? this.adapter.select ?? this.adapter.query;
-    if (!fn)
-      throw new Error("Runtime DB adapter exposes none of all/select/query");
-    const result = await fn.call(this.adapter, sql, params);
-    if (Array.isArray(result)) return result;
-    if (isRecord(result)) {
-      for (const key of ["rows", "results", "data", "values"]) {
-        if (Array.isArray(result[key])) return result[key] as unknown[];
-      }
+  private exec(): SqlExecutor {
+    if (!this.executor) {
+      throw new Error(
+        "orchestrator-task-store: executor accessed before ensureInitialized()",
+      );
     }
-    return [];
+    return this.executor;
   }
 
   private parseDoc(row: unknown): OrchestratorTaskDocument | null {
@@ -623,10 +745,22 @@ export class RuntimeDbTaskStore {
 
   private async persist(doc: OrchestratorTaskDocument): Promise<void> {
     const searchText = buildSearchText(doc);
-    await this.exec(
-      `INSERT OR REPLACE INTO orchestrator_tasks
+    // Portable upsert. Postgres/pglite need ON CONFLICT DO UPDATE; sqlite
+    // ≥3.24 accepts the same syntax. Named-column DO UPDATE avoids the
+    // sqlite-only INSERT OR REPLACE form we used to emit.
+    await this.exec().run(
+      `INSERT INTO orchestrator_tasks
        (id, status, archived, priority, title, search_text, updated_at, last_activity_at, document)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT (id) DO UPDATE SET
+         status = excluded.status,
+         archived = excluded.archived,
+         priority = excluded.priority,
+         title = excluded.title,
+         search_text = excluded.search_text,
+         updated_at = excluded.updated_at,
+         last_activity_at = excluded.last_activity_at,
+         document = excluded.document`,
       [
         doc.task.id,
         doc.task.status,
@@ -642,7 +776,7 @@ export class RuntimeDbTaskStore {
   }
 
   private async loadOne(id: string): Promise<OrchestratorTaskDocument | null> {
-    const rows = await this.rows(
+    const rows = await this.exec().all(
       "SELECT document FROM orchestrator_tasks WHERE id = ?",
       [id],
     );
@@ -683,7 +817,7 @@ export class RuntimeDbTaskStore {
       filter.limit && filter.limit > 0
         ? `LIMIT ${Math.floor(filter.limit)}`
         : "";
-    const rows = await this.rows(
+    const rows = await this.exec().all(
       `SELECT document FROM orchestrator_tasks ${where} ORDER BY last_activity_at DESC ${limit}`,
       params,
     );
@@ -715,7 +849,7 @@ export class RuntimeDbTaskStore {
   async deleteTask(id: string): Promise<boolean> {
     return this.enqueue(async () => {
       await this.ensureInitialized();
-      await this.exec("DELETE FROM orchestrator_tasks WHERE id = ?", [id]);
+      await this.exec().run("DELETE FROM orchestrator_tasks WHERE id = ?", [id]);
       return true;
     });
   }
@@ -742,7 +876,7 @@ export class RuntimeDbTaskStore {
 
   async findSession(sessionId: string) {
     await this.ensureInitialized();
-    const rows = await this.rows(
+    const rows = await this.exec().all(
       "SELECT document FROM orchestrator_tasks WHERE document LIKE ?",
       [`%${sessionId}%`],
     );
@@ -786,11 +920,16 @@ export class OrchestratorTaskStore {
   private readonly delegate: InMemoryTaskStore | RuntimeDbTaskStore;
 
   constructor(options: OrchestratorTaskStoreOptions = {}) {
-    const adapter = options.runtime?.databaseAdapter;
+    // Prefer the modern `runtime.adapter` property (see
+    // packages/core/src/runtime.ts declares `public adapter!: IDatabaseAdapter`);
+    // fall back to the legacy `runtime.databaseAdapter` name that older test
+    // harnesses and some custom container runtimes still use.
+    const adapter =
+      options.runtime?.adapter ?? options.runtime?.databaseAdapter;
     const logger = options.runtime?.logger;
     if (
       (options.backend === undefined || options.backend === "runtime-db") &&
-      isSqlDatabaseAdapter(adapter)
+      isPersistableAdapter(adapter)
     ) {
       this.backend = "runtime-db";
       this.delegate = new RuntimeDbTaskStore(adapter);

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
@@ -672,6 +672,9 @@ export class FileTaskStore extends InMemoryTaskStore {
   }
 }
 
+// `last_activity_at` holds a Date.now() ms epoch (~1.75e12), which overflows
+// postgres/pglite int4 — BIGINT is required there and maps to sqlite's 64-bit
+// INTEGER affinity, so it is portable across every backend this store engages.
 const TASK_TABLE_SQL = `CREATE TABLE IF NOT EXISTS orchestrator_tasks (
   id TEXT PRIMARY KEY,
   status TEXT NOT NULL,
@@ -680,7 +683,7 @@ const TASK_TABLE_SQL = `CREATE TABLE IF NOT EXISTS orchestrator_tasks (
   title TEXT,
   search_text TEXT,
   updated_at TEXT NOT NULL,
-  last_activity_at INTEGER NOT NULL,
+  last_activity_at BIGINT NOT NULL,
   document TEXT NOT NULL
 )`;
 

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
@@ -849,7 +849,9 @@ export class RuntimeDbTaskStore {
   async deleteTask(id: string): Promise<boolean> {
     return this.enqueue(async () => {
       await this.ensureInitialized();
-      await this.exec().run("DELETE FROM orchestrator_tasks WHERE id = ?", [id]);
+      await this.exec().run("DELETE FROM orchestrator_tasks WHERE id = ?", [
+        id,
+      ]);
       return true;
     });
   }


### PR DESCRIPTION
## Summary

Orchestrator task threads silently vanish across container restarts on self-hosted deployments. Observed live today: `/api/orchestrator/tasks` returned a task before a restart and `{"tasks":[]}` after.

## Root cause (three stacked failures, receipts inline)

1. `orchestrator-task-service.ts:593` fed the store `runtime.databaseAdapter`, but modern runtimes expose the adapter as `runtime.adapter` (`packages/core/src/runtime.ts:785`) → the store's guard saw `undefined`.
2. Even with the right property, `isSqlDatabaseAdapter` (`orchestrator-task-store.ts:121`) required flat `query/execute/run/...` methods that the real `BaseDrizzleAdapter` (`plugins/plugin-sql/src/base.ts:299`) doesn't expose.
3. The persist SQL used SQLite-only `INSERT OR REPLACE` (`orchestrator-task-store.ts:632`), which pglite/postgres reject.

Net effect: **100% of self-hosted containers silently fell through to `FileTaskStore`** at `~/.eliza/plugin-acp/orchestrator-tasks.json` — ephemeral container fs, gone on restart.

## What changed (plugin-scoped)

- Recognize the eliza drizzle adapter shape (`adapter.db.execute(query)`) so the SQL backend actually engages; both adapter shapes unified behind a `SqlExecutor` interface (eliza path builds queries via `sql.raw`/`sql.param`/`sql.join` from the existing `?`-placeholder templates, lazy drizzle-orm import).
- Portable `INSERT ... ON CONFLICT (id) DO UPDATE` (pglite, postgres, sqlite ≥3.24).
- Service feeds both `runtime.adapter` (preferred) and `runtime.databaseAdapter` (legacy fallback).

## Tests

+5 new (adapter selection, eliza-shape detection, **service-restart survival regression test**, portable upsert, drizzle SQL-builder round-trip via `PgDialect.sqlToQuery`). Plugin suite 1027/1027, build clean.

## Known siblings (follow-up, out of scope)

`acp-service.ts:2902` and `session-store.ts:685` have the same `runtime.databaseAdapter` property-name bug — ACP session state also never engages the runtime DB backend. Filing separately to keep this PR one-concern.

## Deployment note

File-backend operators (no SQL adapter) still need a persistent mount for `~/.eliza/plugin-acp/` or `ELIZA_ACP_STATE_DIR` — docs follow-up, not a code bug.

🤖 Built by Sol (agent). Co-authored-by: wakesync.