### PR TITLE
fix(benchmarks): classify view bundle KPI outside adapters

### DIFF
--- a/packages/benchmarks/AGENTS.md
+++ b/packages/benchmarks/AGENTS.md
@@ -15,7 +15,9 @@ viewer/          Static results UI
 tests/           Suite-level tests (registry, scoring, normalization, acceptance gate)
 *-adapter/       Agent harness bridges: eliza / hermes / openclaw / smithers
 agentbench_matrix/  Code-agent comparison adapter (driven by orchestrator/code_agent_matrix.py); the duplicate *_matrix/ + app_eval/ import-shim variants were removed in #9475
-loadperf/ memperf/ mobile-resource/  Resource/device KPI harnesses (infra/CPU/memory/battery), NOT agent benchmarks — own CI lanes, not orchestrator adapters
+loadperf/ memperf/ mobile-resource/ view-bundle-size/
+                 Resource/device/bundle KPI harnesses (infra/CPU/memory/battery/bundle size),
+                 NOT agent benchmarks — own CI lanes, not orchestrator adapters
 <benchmark>/     One self-contained benchmark per directory
 benchmark_results/   Generated run output — GITIGNORED, never commit
 ```

--- a/packages/benchmarks/CLAUDE.md
+++ b/packages/benchmarks/CLAUDE.md
@@ -15,7 +15,9 @@ viewer/          Static results UI
 tests/           Suite-level tests (registry, scoring, normalization, acceptance gate)
 *-adapter/       Agent harness bridges: eliza / hermes / openclaw / smithers
 agentbench_matrix/  Code-agent comparison adapter (driven by orchestrator/code_agent_matrix.py); the duplicate *_matrix/ + app_eval/ import-shim variants were removed in #9475
-loadperf/ memperf/ mobile-resource/  Resource/device KPI harnesses (infra/CPU/memory/battery), NOT agent benchmarks — own CI lanes, not orchestrator adapters
+loadperf/ memperf/ mobile-resource/ view-bundle-size/
+                 Resource/device/bundle KPI harnesses (infra/CPU/memory/battery/bundle size),
+                 NOT agent benchmarks — own CI lanes, not orchestrator adapters
 <benchmark>/     One self-contained benchmark per directory
 benchmark_results/   Generated run output — GITIGNORED, never commit
 ```

--- a/packages/benchmarks/README.md
+++ b/packages/benchmarks/README.md
@@ -47,7 +47,7 @@ its own directory and carries `README.md` + `AGENTS.md` + `CLAUDE.md`.
 | `<benchmark>/` | One directory per benchmark — harness code, data, tests, and docs. |
 | `*-adapter/` | Harness bridges (`eliza`, `hermes`, `openclaw`, `smithers`) that let one benchmark run against different agent backends. |
 | `agentbench_matrix/` | Code-agent comparison adapter for the real `agentbench`, driven by `orchestrator/code_agent_matrix.py`. (The dup `*_matrix` / import-shim variants for vendored sources were removed in #9475.) |
-| `loadperf/`, `memperf/`, `mobile-resource/` | Direct resource/load KPI workbenches with their own CI lanes; not suite-orchestrator adapters. |
+| `loadperf/`, `memperf/`, `mobile-resource/`, `view-bundle-size/` | Direct resource/load/bundle KPI workbenches with their own CI lanes; not suite-orchestrator adapters. |
 | `framework/`, `lib/`, `standard/` | Shared harness framework, helpers, and the standard academic adapters (MMLU, HumanEval, GSM8K, MT-Bench, dispatched by `run.py`). |
 | `viewer/` | Static browser UI for inspecting normalized results. |
 | `tests/` | Suite-level tests (registry scores, runner normalization, acceptance gate, …). |

--- a/packages/benchmarks/orchestrator/adapters.py
+++ b/packages/benchmarks/orchestrator/adapters.py
@@ -76,6 +76,7 @@ IGNORED_BENCHMARK_DIRS = {
     "loadperf",
     "memperf",
     "mobile-resource",
+    "view-bundle-size",
     "voice",
     # Legacy/partial shim with no source files in this checkout.
     "eliza-format",

--- a/packages/benchmarks/orchestrator/tests/test_adapter_discovery.py
+++ b/packages/benchmarks/orchestrator/tests/test_adapter_discovery.py
@@ -81,6 +81,7 @@ def test_discovery_covers_all_real_benchmark_directories() -> None:
     assert ".pytest_cache" not in discovery.all_directories
     assert "memperf" not in discovery.all_directories
     assert "mobile-resource" not in discovery.all_directories
+    assert "view-bundle-size" not in discovery.all_directories
     assert "skillsbench" not in discovery.all_directories
     assert "skillsbench" not in orchestrator_adapters.IGNORED_BENCHMARK_DIRS
     assert not (_workspace_root() / "benchmarks" / "skillsbench").exists()


### PR DESCRIPTION
## Summary

- classify `packages/benchmarks/view-bundle-size` as a direct bundle KPI harness, alongside load/memory/mobile KPI workbenches, outside orchestrator adapter discovery
- pin that classification in `test_adapter_discovery.py` so `list-benchmarks` no longer reports it as an uncovered agent benchmark directory
- update benchmark docs/agent guides to include the bundle KPI lane

## Evidence

Focused checks:

```text
PYTHONPATH=packages python3 -m pytest packages/benchmarks/orchestrator/tests/test_adapter_discovery.py -q
→ 114 passed in 29.26s

PYTHONPATH=packages python3 -m benchmarks.orchestrator list-benchmarks
→ Total adapters: 53
→ Total benchmark dirs: 43
→ All benchmark directories are covered by adapters.

bun test packages/benchmarks/view-bundle-size/metric-schema.test.ts
→ 9 pass, 0 fail

python3 -m pytest codex-adapter/tests smithers-adapter/tests hermes-adapter/tests openclaw-adapter/tests -q
→ 275 passed in 11.46s

python3 -m pytest tests/test_ci_coverage.py tests/test_registry_scores.py tests/test_runner_normalization.py tests/test_acceptance_gate.py orchestrator/tests/test_review_package.py orchestrator/tests/test_artifact_guard.py orchestrator/tests/test_inventory.py orchestrator/tests/test_latest_readiness.py orchestrator/tests/test_latest_publishability.py -q
→ 77 passed in 12.10s

git diff --check
→ pass
cmp -s packages/benchmarks/CLAUDE.md packages/benchmarks/AGENTS.md
→ pass
```

Pre-PR sync/install:

```text
git fetch origin
→ ok
git rebase origin/develop
→ Current branch fix/10199-view-bundle-size-discovery is up to date.
bun install
→ Checked 4820 installs across 5103 packages (no changes)
```

Full verifier attempt:

```text
bun run verify
→ failed after 7m23s at @elizaos/cloud-shared#lint
→ unrelated formatter issue in packages/cloud/shared/src/lib/services/app-credits.ts
→ verifier summary before failure: Tasks: 232 successful, 276 total
```

The verifier also ran Biome with `--write` in unrelated packages; those auto-writes were reverted so this branch is clean and contains only the benchmark classification commit.

## Screenshots / video

N/A: CLI/docs/orchestrator discovery classification only; no UI surface changed.

Fixes a concrete #10199 harness-review gap found during the open-issue evidence sweep.