### PR TITLE
refactor(voice): rename OmniVoiceBackend→TtsBackend — #9649 salvage item 4

### DIFF
--- a/plugins/plugin-local-inference/native/AGENTS.md
+++ b/plugins/plugin-local-inference/native/AGENTS.md
@@ -124,7 +124,7 @@ Backbones (do not change without explicit human approval):
   once wrapped it has been removed. Do not add a new standalone wrapper;
   new voice code goes through `libelizainference`.
 
-  Kokoro and OmniVoice both satisfy the same `OmniVoiceBackend +
+  Kokoro and OmniVoice both satisfy the same `TtsBackend +
   StreamingTtsBackend` contract — the runtime selector
   (`services/voice/kokoro/runtime-selection.ts`) picks one at arm time
   based on the tier policy, the `ELIZA_TTS_BACKEND` env override

--- a/plugins/plugin-local-inference/native/CLAUDE.md
+++ b/plugins/plugin-local-inference/native/CLAUDE.md
@@ -124,7 +124,7 @@ Backbones (do not change without explicit human approval):
   once wrapped it has been removed. Do not add a new standalone wrapper;
   new voice code goes through `libelizainference`.
 
-  Kokoro and OmniVoice both satisfy the same `OmniVoiceBackend +
+  Kokoro and OmniVoice both satisfy the same `TtsBackend +
   StreamingTtsBackend` contract — the runtime selector
   (`services/voice/kokoro/runtime-selection.ts`) picks one at arm time
   based on the tier policy, the `ELIZA_TTS_BACKEND` env override

--- a/plugins/plugin-local-inference/src/services/engine.ts
+++ b/plugins/plugin-local-inference/src/services/engine.ts
@@ -1234,7 +1234,7 @@ export class LocalInferenceEngine {
 	 *   - a working ASR (the bridge's `createStreamingTranscriber` throws
 	 *     `AsrUnavailableError` when the fused decoder is unavailable — the
 	 *     fused build is the sole on-device ASR runtime),
-	 *   - a real OmniVoice TTS backend on the bridge (the `StubOmniVoiceBackend`
+	 *   - a real TTS backend on the bridge (the `StubTtsBackend`
 	 *     is rejected — it emits zeros).
 	 * Any missing piece fails loudly with the specific component named.
 	 *
@@ -1337,7 +1337,7 @@ export class LocalInferenceEngine {
 		if (backendId === "stub") {
 			throw new VoiceStartupError(
 				"missing-fused-build",
-				"[voice] Cannot start a live voice session on the StubOmniVoiceBackend (it emits silence). Start the bridge with useFfiBackend:true or a real backendOverride.",
+				"[voice] Cannot start a live voice session on the StubTtsBackend (it emits silence). Start the bridge with useFfiBackend:true or a real backendOverride.",
 			);
 		}
 
@@ -1675,7 +1675,7 @@ export class LocalInferenceEngine {
 		if ((bridge.backend as { id?: string }).id === "stub") {
 			throw new VoiceStartupError(
 				"missing-fused-build",
-				"[voice] Cannot synthesize speech with StubOmniVoiceBackend (it emits silence). Start voice with useFfiBackend:true or inject a real backend.",
+				"[voice] Cannot synthesize speech with StubTtsBackend (it emits silence). Start voice with useFfiBackend:true or inject a real backend.",
 			);
 		}
 		return bridge.synthesizeTextToWav(text, signal);

--- a/plugins/plugin-local-inference/src/services/voice/engine-bridge.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/engine-bridge.test.ts
@@ -14,7 +14,7 @@
  *   - `synthesize` (whole-phrase) routes through the streaming entry when
  *     supported and concatenates the chunks;
  *   - `cancelSignal` flips end the stream at the next chunk boundary;
- *   - `StubOmniVoiceBackend` implements the same seam for scheduler tests.
+ *   - `StubTtsBackend` implements the same seam for scheduler tests.
  */
 
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
@@ -27,12 +27,12 @@ import {
 	FfiOmniVoiceBackend,
 	isStreamingTtsBackend,
 	nativeRejectedRangeToRollbackRange,
-	StubOmniVoiceBackend,
+	StubTtsBackend,
 	type TtsPcmChunk,
 } from "./engine-bridge";
 import type { VoiceLifecycleLoaders } from "./lifecycle";
 import type { MmapRegionHandle, RefCountedResource } from "./shared-resources";
-import type { OmniVoiceBackend, Phrase, SpeakerPreset } from "./types";
+import type { Phrase, SpeakerPreset, TtsBackend } from "./types";
 import { writeVoicePresetFile } from "./voice-preset-format";
 
 function phrase(text: string): Phrase {
@@ -274,9 +274,9 @@ describe("nativeRejectedRangeToRollbackRange", () => {
 	});
 });
 
-describe("StubOmniVoiceBackend — streaming seam", () => {
+describe("StubTtsBackend — streaming seam", () => {
 	it("implements StreamingTtsBackend and emits a fixed number of chunks + final tail", async () => {
-		const backend = new StubOmniVoiceBackend(24_000);
+		const backend = new StubTtsBackend(24_000);
 		expect(isStreamingTtsBackend(backend)).toBe(true);
 		const chunks: TtsPcmChunk[] = [];
 		const res = await backend.synthesizeStream({
@@ -299,7 +299,7 @@ describe("StubOmniVoiceBackend — streaming seam", () => {
 	});
 
 	it("honours a mid-stream cancel via onChunk returning true", async () => {
-		const backend = new StubOmniVoiceBackend(24_000);
+		const backend = new StubTtsBackend(24_000);
 		let n = 0;
 		const res = await backend.synthesizeStream({
 			phrase: phrase("got it"),
@@ -357,7 +357,7 @@ describe("EngineVoiceBridge direct synthesis guard", () => {
 				observedSamples = args.pcm.length;
 				return "Hello, say hello back.";
 			},
-		} as OmniVoiceBackend & {
+		} as TtsBackend & {
 			transcribe(args: {
 				pcm: Float32Array;
 				sampleRate: number;

--- a/plugins/plugin-local-inference/src/services/voice/engine-bridge.ts
+++ b/plugins/plugin-local-inference/src/services/voice/engine-bridge.ts
@@ -14,7 +14,7 @@
  * and barge-in cancellation (mic VAD → drain ring buffer + cancel TTS).
  *
  * Two TTS backends are exposed:
- *   - `StubOmniVoiceBackend`: deterministic synthetic PCM. Used by tests
+ *   - `StubTtsBackend`: deterministic synthetic PCM. Used by tests
  *     and any path that wants the streaming graph without real audio.
  *   - `FfiOmniVoiceBackend`: forwards through the fused
  *     `libelizainference.{dylib,so,dll}` ABI. The bridge creates the
@@ -111,7 +111,6 @@ import {
 import type {
 	AudioChunk,
 	AudioSink,
-	OmniVoiceBackend,
 	Phrase,
 	RejectedTokenRange,
 	SchedulerConfig,
@@ -119,6 +118,7 @@ import type {
 	StreamingTranscriber,
 	TextToken,
 	TranscriptionAudio,
+	TtsBackend,
 	VadEventSource,
 } from "./types";
 import { decodeMonoPcm16Wav, encodeMonoPcm16Wav } from "./wav-codec";
@@ -216,14 +216,14 @@ export interface TtsPcmChunk {
  * in-flight forward pass at the next kernel boundary (barge-in /
  * MTP-rejected tail).
  *
- * Both `OmniVoiceBackend` implementations in this module satisfy it:
+ * Both `TtsBackend` implementations in this module satisfy it:
  *   - `FfiOmniVoiceBackend` forwards to
  *     `eliza_inference_tts_synthesize_stream` when the loaded build
  *     advertises streaming TTS (`tts_stream_supported() == 1`), else it
  *     synthesizes whole and emits the result as one body chunk + a final
  *     tail (no silent "streaming" lie — the chunk count just collapses
  *     to one when the build is non-streaming);
- *   - `StubOmniVoiceBackend` emits deterministic synthetic PCM split
+ *   - `StubTtsBackend` emits deterministic synthetic PCM split
  *     into a fixed number of chunks so scheduler tests can observe the
  *     incremental handoff without a real model.
  */
@@ -247,8 +247,8 @@ export interface StreamingTtsBackend {
 
 /** True when `backend` implements the `StreamingTtsBackend` seam. */
 export function isStreamingTtsBackend(
-	backend: OmniVoiceBackend,
-): backend is OmniVoiceBackend & StreamingTtsBackend {
+	backend: TtsBackend,
+): backend is TtsBackend & StreamingTtsBackend {
 	return (
 		typeof (backend as Partial<StreamingTtsBackend>).synthesizeStream ===
 		"function"
@@ -261,9 +261,7 @@ export function isStreamingTtsBackend(
  * cancel signal honoured at the kernel-tick boundary so barge-in tests
  * observe cancellation without waiting on a real model.
  */
-export class StubOmniVoiceBackend
-	implements OmniVoiceBackend, StreamingTtsBackend
-{
+export class StubTtsBackend implements TtsBackend, StreamingTtsBackend {
 	readonly id = "stub" as const;
 	private readonly sampleRate: number;
 	calls = 0;
@@ -351,9 +349,7 @@ export class StubOmniVoiceBackend
  * the engine layer's startup-error taxonomy stays unified. No silent
  * fallback (AGENTS.md §3 + §9).
  */
-export class FfiOmniVoiceBackend
-	implements OmniVoiceBackend, StreamingTtsBackend
-{
+export class FfiOmniVoiceBackend implements TtsBackend, StreamingTtsBackend {
 	readonly id = "ffi" as const;
 	private readonly ffi: ElizaInferenceFfi;
 	private readonly getContext: () => ElizaInferenceContextHandle;
@@ -603,13 +599,13 @@ export interface EngineVoiceBridgeOptions {
 	 * (e.g. one that holds synthesis open until a deferred resolves) so
 	 * rollback timing can be observed deterministically.
 	 */
-	backendOverride?: OmniVoiceBackend;
+	backendOverride?: TtsBackend;
 	/**
 	 * Override only the TTS backend while keeping the fused bundle lifecycle
 	 * and ASR FFI loaded. Used when a bundle falls back from OmniVoice speech
 	 * to Kokoro speech but still needs bundled Gemma ASR for mic input.
 	 */
-	ttsBackendOverride?: OmniVoiceBackend;
+	ttsBackendOverride?: TtsBackend;
 	/** Optional speaker preset paired with `ttsBackendOverride`. */
 	speakerPresetOverride?: SpeakerPreset;
 	/**
@@ -896,7 +892,7 @@ function buildCancellationWiring(
  */
 export class EngineVoiceBridge {
 	readonly scheduler: VoiceScheduler;
-	readonly backend: OmniVoiceBackend;
+	readonly backend: TtsBackend;
 	readonly lifecycle: VoiceLifecycle;
 	/** Loaded FFI handle when running against the fused build (else null). */
 	readonly ffi: ElizaInferenceFfi | null;
@@ -953,7 +949,7 @@ export class EngineVoiceBridge {
 
 	private constructor(
 		scheduler: VoiceScheduler,
-		backend: OmniVoiceBackend,
+		backend: TtsBackend,
 		bundleRoot: string,
 		lifecycle: VoiceLifecycle,
 		ffi: ElizaInferenceFfi | null,
@@ -1078,7 +1074,7 @@ export class EngineVoiceBridge {
 		// setting `useFfiBackend: false` (test TTS + empty evict transition).
 		let ffiHandle: ElizaInferenceFfi | null = null;
 		let ffiContextRef: FfiContextRef | null = null;
-		let backend: OmniVoiceBackend;
+		let backend: TtsBackend;
 		const asrAvailable = bundleHasRegularFile(
 			path.join(opts.bundleRoot, "asr"),
 		);
@@ -1129,7 +1125,7 @@ export class EngineVoiceBridge {
 					sampleRate,
 				});
 		} else {
-			backend = opts.ttsBackendOverride ?? new StubOmniVoiceBackend(sampleRate);
+			backend = opts.ttsBackendOverride ?? new StubTtsBackend(sampleRate);
 		}
 
 		const config: SchedulerConfig = {
@@ -1409,12 +1405,12 @@ export class EngineVoiceBridge {
 
 	/**
 	 * True when this bridge runs against a TTS backend that produces real
-	 * audio — i.e. anything but the `StubOmniVoiceBackend` (which yields
+	 * audio — i.e. anything but the `StubTtsBackend` (which yields
 	 * zeros and is tests-only). The prewarm + first-audio-filler paths gate
 	 * on this so the cache never holds silence (AGENTS.md §3 — no fake data).
 	 */
 	hasRealTtsBackend(): boolean {
-		return !(this.backend instanceof StubOmniVoiceBackend);
+		return !(this.backend instanceof StubTtsBackend);
 	}
 
 	/**
@@ -1570,7 +1566,7 @@ export class EngineVoiceBridge {
 	/**
 	 * The streaming-TTS seam W9's scheduler drives: returns the active
 	 * backend as a `StreamingTtsBackend` (`FfiOmniVoiceBackend` against the
-	 * fused build, `StubOmniVoiceBackend` for tests). The scheduler calls
+	 * fused build, `StubTtsBackend` for tests). The scheduler calls
 	 * `synthesizeStream(...)` for each phrase and writes the delivered PCM
 	 * segments into its `PcmRingBuffer` on the same scheduler tick. Returns
 	 * null when an injected `backendOverride` does not implement the seam.
@@ -1738,7 +1734,7 @@ export class EngineVoiceBridge {
 				? signal.reason
 				: new DOMException("Aborted", "AbortError");
 		}
-		const backendTimed = this.backend as OmniVoiceBackend & {
+		const backendTimed = this.backend as TtsBackend & {
 			transcribeTimed?: (
 				args: TranscriptionAudio,
 			) => Promise<{ text: string; words: AsrWordTiming[] }>;
@@ -1840,7 +1836,7 @@ export class EngineVoiceBridge {
 				transcriber.dispose();
 			}
 		}
-		const backendBatch = this.backend as OmniVoiceBackend & {
+		const backendBatch = this.backend as TtsBackend & {
 			transcribe?: (args: TranscriptionAudio) => Promise<string>;
 		};
 		if (typeof backendBatch.transcribe === "function") {

--- a/plugins/plugin-local-inference/src/services/voice/index.ts
+++ b/plugins/plugin-local-inference/src/services/voice/index.ts
@@ -100,7 +100,7 @@ export {
 	type EngineVoiceBridgeOptions,
 	encodeMonoPcm16Wav,
 	FfiOmniVoiceBackend,
-	StubOmniVoiceBackend,
+	StubTtsBackend,
 	type VoiceTurnEvents,
 } from "./engine-bridge";
 export {

--- a/plugins/plugin-local-inference/src/services/voice/kokoro/kokoro-backend.ts
+++ b/plugins/plugin-local-inference/src/services/voice/kokoro/kokoro-backend.ts
@@ -1,7 +1,7 @@
 /**
  * Kokoro-82M TTS backend.
  *
- * Implements the same `OmniVoiceBackend + StreamingTtsBackend` seam that
+ * Implements the same `TtsBackend + StreamingTtsBackend` seam that
  * `FfiOmniVoiceBackend` (the OmniVoice path) satisfies, so a
  * `VoiceScheduler` instance does not need to know which TTS family it is
  * driving. The runtime selection layer (`runtime-selection.ts`) picks
@@ -20,10 +20,10 @@
 
 import type {
 	AudioChunk,
-	OmniVoiceBackend,
 	Phrase,
 	SpeakerPreset,
 	StreamingTtsBackend,
+	TtsBackend,
 	TtsPcmChunk,
 } from "../types";
 import type { KokoroRuntime } from "./kokoro-runtime";
@@ -62,7 +62,7 @@ export const KOKORO_MOBILE_TTFA_BUDGET_MS = 700;
  * the full waveform in one forward, but we surface it as one body chunk +
  * tail so the scheduler protocol is identical for both backends.
  */
-export class KokoroTtsBackend implements OmniVoiceBackend, StreamingTtsBackend {
+export class KokoroTtsBackend implements TtsBackend, StreamingTtsBackend {
 	readonly id = "kokoro" as const;
 	private readonly runtime: KokoroRuntime;
 	private readonly defaultVoiceId: string;

--- a/plugins/plugin-local-inference/src/services/voice/kokoro/kokoro-engine-discovery.ts
+++ b/plugins/plugin-local-inference/src/services/voice/kokoro/kokoro-engine-discovery.ts
@@ -87,7 +87,7 @@ export function kokoroEngineModelDir(rootOverride?: string): string {
 /**
  * Probe disk for a usable Kokoro layout. Returns null when any required
  * piece is missing — the engine then falls back to its existing behaviour
- * (fused omnivoice or `StubOmniVoiceBackend`).
+ * (fused omnivoice or `StubTtsBackend`).
  */
 export function resolveKokoroEngineConfig(
 	rootOverride?: string,

--- a/plugins/plugin-local-inference/src/services/voice/phrase-cache.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/phrase-cache.test.ts
@@ -2,7 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { EngineVoiceBridge, StubOmniVoiceBackend } from "./engine-bridge";
+import { EngineVoiceBridge, StubTtsBackend } from "./engine-bridge";
 import type { VoiceLifecycleLoaders } from "./lifecycle";
 import {
 	canonicalizePhraseText,
@@ -12,12 +12,7 @@ import {
 	PhraseCache,
 } from "./phrase-cache";
 import type { MmapRegionHandle, RefCountedResource } from "./shared-resources";
-import type {
-	AudioChunk,
-	OmniVoiceBackend,
-	Phrase,
-	SpeakerPreset,
-} from "./types";
+import type { AudioChunk, Phrase, SpeakerPreset, TtsBackend } from "./types";
 import { writeVoicePresetFile } from "./voice-preset-format";
 
 // --- the canonical seed/filler constants -----------------------------------
@@ -98,7 +93,7 @@ describe("PhraseCache LRU", () => {
 
 // --- engine-bridge prewarm / filler gating ---------------------------------
 
-class RecordingBackend implements OmniVoiceBackend {
+class RecordingBackend implements TtsBackend {
 	readonly synthesized: string[] = [];
 	async synthesize(args: {
 		phrase: Phrase;
@@ -163,7 +158,7 @@ describe("EngineVoiceBridge phrase prewarm + first-audio filler", () => {
 			bundleRoot,
 			useFfiBackend: false,
 		});
-		expect(bridge.backend).toBeInstanceOf(StubOmniVoiceBackend);
+		expect(bridge.backend).toBeInstanceOf(StubTtsBackend);
 		expect(bridge.hasRealTtsBackend()).toBe(false);
 	});
 

--- a/plugins/plugin-local-inference/src/services/voice/scheduler.t2.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/scheduler.t2.test.ts
@@ -13,11 +13,11 @@ import { InMemoryAudioSink } from "./ring-buffer";
 import { type TtsPhraseChunkMetrics, VoiceScheduler } from "./scheduler";
 import type {
 	AudioChunk,
-	OmniVoiceBackend,
 	Phrase,
 	SpeakerPreset,
 	StreamingTtsBackend,
 	TextToken,
+	TtsBackend,
 	TtsPcmChunk,
 } from "./types";
 
@@ -34,9 +34,7 @@ function makePreset(): SpeakerPreset {
 	};
 }
 
-class ScriptedStreamingBackend
-	implements OmniVoiceBackend, StreamingTtsBackend
-{
+class ScriptedStreamingBackend implements TtsBackend, StreamingTtsBackend {
 	constructor(private readonly chunks: ReadonlyArray<Float32Array>) {}
 	async synthesize(): Promise<AudioChunk> {
 		throw new Error("not used");

--- a/plugins/plugin-local-inference/src/services/voice/scheduler.ts
+++ b/plugins/plugin-local-inference/src/services/voice/scheduler.ts
@@ -14,13 +14,13 @@ import type {
 	AudioChunk,
 	AudioSink,
 	BargeInSignal,
-	OmniVoiceBackend,
 	Phrase,
 	RejectedTokenRange,
 	SchedulerConfig,
 	SpeakerPreset,
 	StreamingTtsBackend,
 	TextToken,
+	TtsBackend,
 	TtsPcmChunk,
 	VoiceAudioSource,
 	VoiceSchedulerPhraseTelemetry,
@@ -81,7 +81,7 @@ export interface SchedulerEvents {
 }
 
 export interface SchedulerDeps {
-	backend: OmniVoiceBackend;
+	backend: TtsBackend;
 	sink?: AudioSink;
 	phraseCache?: PhraseCache;
 	/** Optional. Required only when `config.chunkerConfig.chunkOn ===
@@ -119,8 +119,8 @@ function phraseTelemetry(phrase: Phrase): VoiceSchedulerPhraseTelemetry {
 }
 
 function isStreamingTtsBackend(
-	backend: OmniVoiceBackend,
-): backend is OmniVoiceBackend & StreamingTtsBackend {
+	backend: TtsBackend,
+): backend is TtsBackend & StreamingTtsBackend {
 	return (
 		typeof (backend as Partial<StreamingTtsBackend>).synthesizeStream ===
 		"function"
@@ -128,8 +128,8 @@ function isStreamingTtsBackend(
 }
 
 function isNativeCancelableTtsBackend(
-	backend: OmniVoiceBackend,
-): backend is OmniVoiceBackend & NativeCancelableTtsBackend {
+	backend: TtsBackend,
+): backend is TtsBackend & NativeCancelableTtsBackend {
 	return (
 		typeof (backend as Partial<NativeCancelableTtsBackend>).cancelTts ===
 		"function"
@@ -169,7 +169,7 @@ export class VoiceScheduler {
 	 * correct play through without re-synthesizing.
 	 */
 	readonly prefixQueue = new PrefixPreservingQueue();
-	private readonly backend: OmniVoiceBackend;
+	private readonly backend: TtsBackend;
 	private readonly phraseCache: PhraseCache;
 	private readonly events: SchedulerEvents;
 	private readonly sampleRate: number;

--- a/plugins/plugin-local-inference/src/services/voice/turn-controller.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/turn-controller.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { StubOmniVoiceBackend } from "./engine-bridge";
+import { StubTtsBackend } from "./engine-bridge";
 import type { EotClassifier } from "./eot-classifier";
 import { InMemoryAudioSink } from "./ring-buffer";
 import { VoiceScheduler } from "./scheduler";
@@ -55,7 +55,7 @@ function makeScheduler(): VoiceScheduler {
 			ringBufferCapacity: 4096,
 			sampleRate: 24000,
 		},
-		{ backend: new StubOmniVoiceBackend(24000), sink: new InMemoryAudioSink() },
+		{ backend: new StubTtsBackend(24000), sink: new InMemoryAudioSink() },
 	);
 }
 

--- a/plugins/plugin-local-inference/src/services/voice/types.ts
+++ b/plugins/plugin-local-inference/src/services/voice/types.ts
@@ -94,7 +94,7 @@ export interface AudioSink {
 	bufferedSamples(): number;
 }
 
-export interface OmniVoiceBackend {
+export interface TtsBackend {
 	synthesize(args: {
 		phrase: Phrase;
 		preset: SpeakerPreset;

--- a/plugins/plugin-local-inference/src/services/voice/voice.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/voice.test.ts
@@ -8,11 +8,11 @@ import { RollbackQueue } from "./rollback-queue";
 import { VoiceScheduler } from "./scheduler";
 import type {
 	AudioChunk,
-	OmniVoiceBackend,
 	Phrase,
 	SpeakerPreset,
 	StreamingTtsBackend,
 	TextToken,
+	TtsBackend,
 	TtsPcmChunk,
 	VadEvent,
 	VoiceSchedulerTelemetryEvent,
@@ -36,7 +36,7 @@ function makePreset(): SpeakerPreset {
 	};
 }
 
-class FakeBackend implements OmniVoiceBackend {
+class FakeBackend implements TtsBackend {
 	calls = 0;
 	cancelObserved: number[] = [];
 	delay = 0;
@@ -70,7 +70,7 @@ class FakeBackend implements OmniVoiceBackend {
 	}
 }
 
-class StreamingBackend implements OmniVoiceBackend, StreamingTtsBackend {
+class StreamingBackend implements TtsBackend, StreamingTtsBackend {
 	calls = 0;
 	streamCalls = 0;
 	cancelCalls = 0;


### PR DESCRIPTION
## What & why

Item 4 of #9649 (salvage unmerged work from stale branches). The `feat/kokoro-only-tts` cleanup was orphaned when its carrier branch `feat/gemma-litert-migration` was deleted from the remote with **no PR ever carrying it** (confirmed: zero PRs had that head; no other branch carries the rename). This re-authors the **valid half** on current develop:

- **Shipped:** rename the engine-agnostic TTS seam `OmniVoiceBackend` → `TtsBackend` and `StubOmniVoiceBackend` → `StubTtsBackend` (14 files, +55/−66, pure rename + import-order). The interface is the backend-neutral contract both Kokoro and OmniVoice implement — its old name was misleading.
- **Deliberately NOT taken (invalid on current develop):**
  - the branch's removal of `FfiOmniVoiceBackend`/`useFfiBackend` — they are **live production code** (`engine.ts` sets `useFfiBackend: true`; `engine-bridge.ts` instantiates `FfiOmniVoiceBackend` as the fused streaming backend; `native/AGENTS.md` documents Kokoro AND OmniVoice as the two runtime-selectable engines). `FfiOmniVoiceBackend` keeps its name — it IS OmniVoice-specific.
  - the samantha-preset module removal — `kokoro-engine-discovery.ts` still references the preset flow.

## Verification

- Grep-zero: no bare `OmniVoiceBackend` remains outside the intentionally-kept `FfiOmniVoiceBackend`.
- **Full `plugin-local-inference` suite: 220 files, 2213 passed / 0 failed** (in the implementation worktree); voice lane re-verified on the cherry-picked branch against current develop (72/72). `tsgo --noEmit` clean; biome clean.
- No external importers affected (only outside refs are an `FfiOmniVoiceBackend` comment in a build script and a prebuilt OS-image artifact regenerated by its own pipeline — both untouched).

**Fail-without-fix: N/A** — a symbol rename has no red-to-green counterfactual; the proof is grep-zero + full-suite green. **Android/visual: N/A** — type-level rename, no runtime behavior change.

## The rest of #9649 (full disposition on the issue)

Items 1–3 dispositioned with code anchors in the issue comment: [1] Android Tesseract = superseded-by-decision (ML Kit decision record; bridge seam reusable but must land WITH the ML Kit plugin), [2] AEC refinements = all three ideas already on develop, [3] Kokoro smoke CI gate = already on develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
