### PR TITLE
ui(views): strip card chrome from Apps/Files views to flat eliza aesthetic (#10710 batch 2)

### DIFF
--- a/packages/ui/src/components/pages/ElizaOsAppsView.tsx
+++ b/packages/ui/src/components/pages/ElizaOsAppsView.tsx
@@ -157,7 +157,8 @@ function Panel({
   children: ReactNode;
 }) {
   return (
-    <section className="rounded-sm border border-border bg-card p-4">
+    /* Flat — no card/border. The shell owns the page's horizontal padding. */
+    <section>
       <div className="mb-4">
         <h2 className="text-base font-semibold text-txt">{title}</h2>
         {description ? (
@@ -349,7 +350,7 @@ function StatusNotice({
   }
   if (notice) {
     return (
-      <div className="rounded-sm border border-border bg-bg px-3 py-2 text-sm text-muted">
+      <div className="px-3 py-2 text-sm text-muted">
         {notice}
       </div>
     );
@@ -359,7 +360,7 @@ function StatusNotice({
 
 function EmptyState({ children }: { children: ReactNode }) {
   return (
-    <div className="rounded-sm border border-border bg-bg p-3 text-sm text-muted">
+    <div className="px-1 py-2 text-sm text-muted">
       {children}
     </div>
   );
@@ -505,7 +506,7 @@ const PhoneContactRow = memo(function PhoneContactRow({
     [onSms, contactNumber],
   );
   return (
-    <div className="rounded-sm border border-border bg-bg p-3 text-sm">
+    <div className="p-3 text-sm">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="min-w-0">
           <div className="font-medium text-txt">
@@ -567,7 +568,7 @@ function PhoneRoleRow({
   onRequest: (role: AndroidRoleStatus) => void;
 }) {
   return (
-    <div className="flex flex-wrap items-center justify-between gap-2 rounded-sm border border-border bg-card p-2 text-sm">
+    <div className="flex flex-wrap items-center justify-between gap-2 p-2 text-sm">
       <div className="min-w-0">
         <div className="font-medium text-txt">
           {role.role}: {role.held ? heldLabel : notHeldLabel}
@@ -1156,7 +1157,7 @@ export function PhonePageView() {
         >
           {selectedCall ? (
             <div className="grid gap-3">
-              <div className="rounded-sm border border-border bg-bg p-3 text-sm">
+              <div className="p-3 text-sm">
                 <div className="font-medium text-txt">
                   {callDisplayName(selectedCall)}
                 </div>
@@ -1170,7 +1171,7 @@ export function PhonePageView() {
                 </div>
               </div>
               {selectedCall.transcription ? (
-                <div className="rounded-sm border border-border bg-bg p-3 text-sm text-txt">
+                <div className="p-3 text-sm text-txt">
                   <div className="mb-1 text-xs font-medium uppercase text-muted">
                     {t("elizaosapps.phone.transcript.voicemail", {
                       defaultValue: "Voicemail transcription",
@@ -1299,14 +1300,14 @@ export function PhonePageView() {
             </div>
           </div>
           <div className="grid gap-3">
-            <div className="grid gap-1 rounded-sm border border-border bg-bg p-3 text-sm text-muted">
+            <div className="grid gap-1 p-3 text-sm text-muted">
               {status.length > 0
                 ? status.map((line) => <div key={line}>{line}</div>)
                 : t("elizaosapps.phone.dialer.noStatus", {
                     defaultValue: "No status loaded.",
                   })}
             </div>
-            <div className="grid gap-2 rounded-sm border border-border bg-bg p-3">
+            <div className="grid gap-2 p-3">
               <div className="text-sm font-medium text-txt">
                 {t("elizaosapps.phone.dialer.defaultRoles", {
                   defaultValue: "Android default roles",
@@ -1353,7 +1354,7 @@ export function PhonePageView() {
                 {t("elizaosapps.phone.settings", { defaultValue: "Settings" })}
               </SecondaryButton>
             </div>
-            <div className="rounded-sm border border-border bg-bg p-3">
+            <div className="p-3">
               <div className="mb-3 text-sm font-medium text-txt">
                 {t("elizaosapps.phone.newContact.title", {
                   defaultValue: "New Contact",
@@ -1705,7 +1706,7 @@ export function MessagesPageView() {
         >
           <div className="grid gap-3">
             {incomingSms ? (
-              <div className="rounded-sm border border-border bg-bg p-3 text-sm">
+              <div className="p-3 text-sm">
                 <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-muted">
                   <span>
                     {incomingSms.sender ||
@@ -1800,7 +1801,7 @@ export function MessagesPageView() {
               messages.map((message) => (
                 <div
                   key={message.id}
-                  className="rounded-sm border border-border bg-bg p-3 text-sm"
+                  className="p-3 text-sm"
                 >
                   <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-muted">
                     <span>
@@ -2010,7 +2011,7 @@ export function ContactsPageView() {
               contacts.map((contact) => (
                 <div
                   key={contact.id}
-                  className="rounded-sm border border-border bg-bg p-3 text-sm"
+                  className="p-3 text-sm"
                 >
                   <div className="font-medium text-txt">
                     {contact.displayName}

--- a/packages/ui/src/components/pages/FilesView.tsx
+++ b/packages/ui/src/components/pages/FilesView.tsx
@@ -183,7 +183,6 @@ function FileShareButton({
       type="button"
       variant="outline"
       size="sm"
-      className="rounded-sm"
       data-testid="file-share"
       aria-label={t("filesview.shareFile", {
         name: file.fileName,
@@ -247,7 +246,7 @@ const FileCard = memo(function FileCard({
 
   return (
     <li
-      className="flex flex-col gap-3 rounded-sm p-3"
+      className="flex flex-col gap-3 p-3"
       data-testid="file-card"
       data-file-name={file.fileName}
       data-file-kind={kind}
@@ -291,7 +290,6 @@ const FileCard = memo(function FileCard({
           type="button"
           variant="outline"
           size="sm"
-          className="rounded-sm"
           data-testid="file-download"
           aria-label={t("filesview.downloadFile", {
             name: file.fileName,
@@ -316,7 +314,7 @@ const FileCard = memo(function FileCard({
           type="button"
           variant="surfaceDestructive"
           size="sm"
-          className="ml-auto rounded-sm"
+          className="ml-auto"
           data-testid="file-delete"
           disabled={deleting}
           aria-label={t("filesview.deleteFile", {


### PR DESCRIPTION
## Summary

Batch-2 sweep for #10710 (audit-and-strip default views to the minimal eliza aesthetic), aligned with the `evaluateStrictGate` scorer from #10970.

## Per-view results

- **ElizaOsAppsView.tsx** — Panel wrapper flattened to a bare `<section>` (SettingsView flat reference pattern); 11 nested content boxes de-carded (border+bg-card → padding-only): StatusNotice, EmptyState, phone contact/role rows, call-detail/voicemail boxes, dialer status, new-contact form, incoming-SMS, message + contact list items. KEPT: interactive `hover:border-primary` buttons (functional affordance) and the semantic destructive error box.
- **FilesView.tsx** — removed redundant `rounded-sm` overrides on Button (primitive already applies it) and an invisible radius on the bg-less FileCard `<li>`.
- **BrowserWorkspaceView.tsx** — audited, SKIPPED: its `bg-card/20` bars are functional browser toolbars (address bar, tab strip), not content cards; no card-chrome wrappers exist.
- **DocumentsView.tsx** — audited, SKIPPED: already flattened in #10379; remaining borders are semantic (pills/badges/tabs).

## Gate alignment

Read `evaluateStrictGate` + `aesthetic-audit-rules`: the edits remove ~13 border edges from ElizaOsAppsView (directly lowers borderDividerDensity) and drop off-token radii from background-less elements.

## Flag for a separate slice (global, not per-view)

`packages/ui/src/styles/base.css` collapses ALL radius tokens (`--radius-sm..3xl`) to `--radius-xs: 3px`, and 3px is off-scale per the audit's allowed set `[0,6,8,12,16,20,24] ±1` — so every `rounded-*` element app-wide reports a borderRadiusViolation regardless of per-view sweeps. That's a shared-primitive decision (token fix in base.css), filing separately rather than smuggling it into a view sweep.

## Verification

- Style-only: no behavior/props/test-id changes
- Tests green: FilesView (10), ElizaOsAppsView permission-gate (7), documents-detail (2), AppsView.mockapp (4) — no snapshot diffs
- Typecheck: zero errors in touched files
- codex review (gpt-5.5): no issues identified
- git diff --check clean

🤖 Built by Sol (agent). Co-authored-by: wakesync.