### PR TITLE
fix(ci): cloud-cf-deploy — raise bun-install per-attempt timeout 300s→900s, keep cache warm across retries

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -191,21 +191,33 @@ jobs:
         # sibling deploy job on the same run succeeded. Retry with a per-attempt
         # timeout so a stuck/killed install aborts and retries instead of failing
         # the deploy — the same resilience the checkout step already uses (#10310).
+        # The cap must exceed the box's real worst-case SLOW install, not just
+        # catch hangs: healthy installs here run ~190-300s+ (run 28532809562's
+        # first attempt already blew a 300s cap and only survived via retry),
+        # and on 2026-07-01 run 28545551059 failed 3/3 attempts at a 300s cap
+        # while making real progress — wedging prod for hours (#10839). 900s
+        # matches CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS; a true hang still aborts.
         run: |
           set -euo pipefail
           install_cache="$PWD/.bun-install-cache"
+          install_timeout="${BUN_INSTALL_TIMEOUT_SECONDS:-900}"
           for attempt in 1 2 3; do
             test -f package.json || { echo "::error::package.json missing from $PWD"; ls -la; exit 1; }
             mkdir -p "$install_cache"
-            if timeout 300s bun install --no-save --ignore-scripts --cache-dir "$install_cache"; then
+            if timeout "${install_timeout}s" bun install --no-save --ignore-scripts --cache-dir "$install_cache"; then
               break
             fi
             if [ "$attempt" -eq 3 ]; then
               echo "::error::bun install failed after ${attempt} attempts"
               exit 1
             fi
-            echo "::warning::bun install attempt ${attempt} stalled or failed; retrying"
-            rm -rf node_modules "$install_cache"
+            echo "::warning::bun install attempt ${attempt} timed out (>${install_timeout}s) or failed; retrying"
+            # Keep the download cache warm for the retry — the timeout bites in
+            # the link phase, not download, and a cold cache makes the retry
+            # SLOWER (more likely to time out again). Nuke it only before the
+            # final attempt so a corrupted cache entry can't fail all three.
+            rm -rf node_modules
+            if [ "$attempt" -eq 2 ]; then rm -rf "$install_cache"; fi
           done
           git diff --exit-code -- bun.lock
 
@@ -465,21 +477,33 @@ jobs:
         # sibling deploy job on the same run succeeded. Retry with a per-attempt
         # timeout so a stuck/killed install aborts and retries instead of failing
         # the deploy — the same resilience the checkout step already uses (#10310).
+        # The cap must exceed the box's real worst-case SLOW install, not just
+        # catch hangs: healthy installs here run ~190-300s+ (run 28532809562's
+        # first attempt already blew a 300s cap and only survived via retry),
+        # and on 2026-07-01 run 28545551059 failed 3/3 attempts at a 300s cap
+        # while making real progress — wedging prod for hours (#10839). 900s
+        # matches CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS; a true hang still aborts.
         run: |
           set -euo pipefail
           install_cache="$PWD/.bun-install-cache"
+          install_timeout="${BUN_INSTALL_TIMEOUT_SECONDS:-900}"
           for attempt in 1 2 3; do
             test -f package.json || { echo "::error::package.json missing from $PWD"; ls -la; exit 1; }
             mkdir -p "$install_cache"
-            if timeout 300s bun install --no-save --ignore-scripts --cache-dir "$install_cache"; then
+            if timeout "${install_timeout}s" bun install --no-save --ignore-scripts --cache-dir "$install_cache"; then
               break
             fi
             if [ "$attempt" -eq 3 ]; then
               echo "::error::bun install failed after ${attempt} attempts"
               exit 1
             fi
-            echo "::warning::bun install attempt ${attempt} stalled or failed; retrying"
-            rm -rf node_modules "$install_cache"
+            echo "::warning::bun install attempt ${attempt} timed out (>${install_timeout}s) or failed; retrying"
+            # Keep the download cache warm for the retry — the timeout bites in
+            # the link phase, not download, and a cold cache makes the retry
+            # SLOWER (more likely to time out again). Nuke it only before the
+            # final attempt so a corrupted cache entry can't fail all three.
+            rm -rf node_modules
+            if [ "$attempt" -eq 2 ]; then rm -rf "$install_cache"; fi
           done
           git diff --exit-code -- bun.lock
 
@@ -770,21 +794,33 @@ jobs:
         # sibling deploy job on the same run succeeded. Retry with a per-attempt
         # timeout so a stuck/killed install aborts and retries instead of failing
         # the deploy — the same resilience the checkout step already uses (#10310).
+        # The cap must exceed the box's real worst-case SLOW install, not just
+        # catch hangs: healthy installs here run ~190-300s+ (run 28532809562's
+        # first attempt already blew a 300s cap and only survived via retry),
+        # and on 2026-07-01 run 28545551059 failed 3/3 attempts at a 300s cap
+        # while making real progress — wedging prod for hours (#10839). 900s
+        # matches CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS; a true hang still aborts.
         run: |
           set -euo pipefail
           install_cache="$PWD/.bun-install-cache"
+          install_timeout="${BUN_INSTALL_TIMEOUT_SECONDS:-900}"
           for attempt in 1 2 3; do
             test -f package.json || { echo "::error::package.json missing from $PWD"; ls -la; exit 1; }
             mkdir -p "$install_cache"
-            if timeout 300s bun install --no-save --ignore-scripts --cache-dir "$install_cache"; then
+            if timeout "${install_timeout}s" bun install --no-save --ignore-scripts --cache-dir "$install_cache"; then
               break
             fi
             if [ "$attempt" -eq 3 ]; then
               echo "::error::bun install failed after ${attempt} attempts"
               exit 1
             fi
-            echo "::warning::bun install attempt ${attempt} stalled or failed; retrying"
-            rm -rf node_modules "$install_cache"
+            echo "::warning::bun install attempt ${attempt} timed out (>${install_timeout}s) or failed; retrying"
+            # Keep the download cache warm for the retry — the timeout bites in
+            # the link phase, not download, and a cold cache makes the retry
+            # SLOWER (more likely to time out again). Nuke it only before the
+            # final attempt so a corrupted cache entry can't fail all three.
+            rm -rf node_modules
+            if [ "$attempt" -eq 2 ]; then rm -rf "$install_cache"; fi
           done
           git diff --exit-code -- bun.lock
 


### PR DESCRIPTION
## Problem (live prod wedge, #10839 continuation)

Prod deploys are failing again — **0 successful develop deploys since 16:35 UTC**. Run [28545551059](https://github.com/elizaOS/eliza/actions/runs/28545551059) failed 3/3 bun-install attempts: extract completes in seconds, then the link phase is killed at exactly the `timeout 300s` cap, every attempt, on all Pages jobs.

The cap is below the box's real worst-case **slow-but-healthy** install:
- Green run [28540728089](https://github.com/elizaOS/eliza/actions/runs/28540728089): install completed in **192.66s** — already 64% of budget.
- Green run [28532809562](https://github.com/elizaOS/eliza/actions/runs/28532809562): **attempt 1 already blew the 300s cap** and the deploy only survived via retry.
- The retry path made things worse: `rm -rf $install_cache` between attempts forces a **colder, slower** retry — more likely to time out, not less.

(Contributing factor: the box floats `bun-version: canary` and a new canary build `eba370b69` landed between the last green run (`52a1ddf07`, 19:33) and the failures (20:25+); whether it's a slower link phase or box load, the fix is the same — the cap must exceed worst-case slow installs, and only catch true hangs.)

## Fix
- Per-attempt timeout **300s → 900s**, tunable via `BUN_INSTALL_TIMEOUT_SECONDS` — mirrors the checkout step's `CHECKOUT_MATERIALIZE_TIMEOUT_SECONDS` treatment (#10772). A genuine hang still aborts; a slow install completes.
- **Keep the download cache warm across retries** (timeout bites in the link phase, not download); still nuked before the final attempt so a corrupted cache entry can't fail all three.
- Applied identically to all three deploy jobs (api/console/app).

## Verification
This PR's own `cloud-cf-deploy` PR run exercises the new install step on the same self-hosted box against the current (suspect) bun canary — a green install there is the live proof. Workflow-only change; no app code touched.