### PR TITLE
fix(core): embedding dimension probe fails over across providers; degraded no-silent-drop mode when all fail

### DIFF
--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -94,6 +94,7 @@ import {
   createBasicCapabilitiesPlugin,
   createMessageMemory,
   drainAppRoutePluginLoaders,
+  EmbeddingDimensionProbeError,
   type Entity,
   type LogEntry,
   logger,
@@ -4599,6 +4600,17 @@ export async function startEliza(
   const initializeCoreRuntime = async (): Promise<void> => {
     assertPersistentDatabaseRequired(runtime);
     await runtime.initialize();
+    // runtime.initialize() survives a total TEXT_EMBEDDING dimension-probe
+    // failure (EmbeddingDimensionProbeError is caught in core, which flips the
+    // runtime into embedding-disabled mode instead of writing vectors the SQL
+    // adapter would silently drop). Surface the degraded state at the boot
+    // layer too — the deferred re-probe below re-enables embeddings if a
+    // provider recovers once late plugins register.
+    if (runtime.isEmbeddingGenerationDisabled()) {
+      logger.warn(
+        "[eliza] boot continuing with embedding generation disabled: every registered TEXT_EMBEDDING provider failed the dimension probe; memory writes persist without vectors until the deferred re-probe finds a working provider",
+      );
+    }
     await prepareRuntimeForTrajectoryCapture(
       runtime,
       "runtime.initialize()",
@@ -5228,11 +5240,22 @@ export async function startEliza(
     try {
       await runtime.ensureEmbeddingDimension();
     } catch (err) {
-      logger.warn(
-        `[eliza] deferred embedding-dimension re-probe failed: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      );
+      if (err instanceof EmbeddingDimensionProbeError) {
+        // Non-fatal: core already disabled embedding generation for this
+        // runtime, so memory writes skip vectors instead of being silently
+        // dropped on dimension mismatch. Log the per-provider failures so the
+        // degraded state is diagnosable from boot logs.
+        logger.warn(
+          { attempts: err.attempts },
+          "[eliza] deferred embedding-dimension re-probe: every registered TEXT_EMBEDDING provider failed; embedding generation stays disabled (memory writes persist without vectors)",
+        );
+      } else {
+        logger.warn(
+          `[eliza] deferred embedding-dimension re-probe failed: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
     }
     await seedBundledDocumentsIfEnabled();
     await installServerSideWebSearchIfAvailable();

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -329,6 +329,39 @@ export class NoModelProviderConfiguredError extends Error {
 	}
 }
 
+/** One failed TEXT_EMBEDDING dimension-probe attempt, kept for diagnostics. */
+export interface EmbeddingProbeAttempt {
+	provider: string;
+	modelKey: string;
+	error: string;
+}
+
+/**
+ * Thrown by `AgentRuntime.ensureEmbeddingDimension` when EVERY registered
+ * TEXT_EMBEDDING provider failed the null dimension probe. Carries the
+ * per-provider failure list so callers (and logs) can show exactly which
+ * providers were tried and why each one failed.
+ *
+ * `AgentRuntime.initialize` catches this error type — and only this type —
+ * non-fatally: the runtime keeps booting with embedding generation disabled
+ * (memory writes persist without vectors) instead of either crashing boot or
+ * leaving the vector column at its default width, where later real vectors
+ * would be silently dropped on dimension mismatch by the SQL adapter (#8769).
+ */
+export class EmbeddingDimensionProbeError extends Error {
+	readonly attempts: readonly EmbeddingProbeAttempt[];
+	constructor(attempts: readonly EmbeddingProbeAttempt[]) {
+		const detail = attempts
+			.map((attempt) => `${attempt.provider}: ${attempt.error}`)
+			.join("; ");
+		super(
+			`All ${attempts.length} registered TEXT_EMBEDDING provider(s) failed the embedding dimension probe — ${detail}`,
+		);
+		this.name = "EmbeddingDimensionProbeError";
+		this.attempts = attempts;
+	}
+}
+
 const TEXT_GENERATION_MODEL_KEYS: readonly string[] = [
 	ModelType.TEXT_NANO,
 	ModelType.TEXT_SMALL,
@@ -817,6 +850,26 @@ export class AgentRuntime implements IAgentRuntime {
 	private serviceTypes = new Map<ServiceTypeName, ServiceClass[]>();
 	models = new Map<string, ModelHandler[]>();
 	routes: Route[] = [];
+	/**
+	 * Provider that answered the boot-time TEXT_EMBEDDING dimension probe. The
+	 * SQL adapter's vector column is sized from that provider's output, so all
+	 * later embedding calls without an explicit provider are pinned to it —
+	 * letting a different registration serve an embedding call can emit a
+	 * different-width vector that the adapter silently drops on dimension
+	 * mismatch (#8769). Re-set on every successful `ensureEmbeddingDimension`.
+	 */
+	private pinnedEmbeddingProvider: string | undefined;
+	/**
+	 * Non-null while embedding generation is disabled because every registered
+	 * TEXT_EMBEDDING provider failed the dimension probe. While set, memory
+	 * writes skip vector generation entirely (see `addEmbeddingToMemory` /
+	 * `queueEmbeddingGeneration`) instead of producing vectors the SQL adapter
+	 * would silently drop against a default-sized column. Cleared by the next
+	 * successful `ensureEmbeddingDimension` (e.g. the deferred boot re-probe).
+	 */
+	private embeddingGenerationDisabledReason: string | null = null;
+	/** Once-latch so the embedding-skip warning fires once, not per write. */
+	private embeddingSkipWarned = false;
 	private taskWorkers = new Map<string, TaskWorker>();
 	private sendHandlers = new Map<string, SendHandlerFunction>();
 	private messageConnectors = new Map<string, MessageConnector>();
@@ -2582,7 +2635,28 @@ export class AgentRuntime implements IAgentRuntime {
 				"No TEXT_EMBEDDING model registered, skipping embedding setup",
 			);
 		} else {
-			await this.ensureEmbeddingDimension();
+			try {
+				await this.ensureEmbeddingDimension();
+			} catch (error) {
+				if (!(error instanceof EmbeddingDimensionProbeError)) {
+					throw error;
+				}
+				// Every registered TEXT_EMBEDDING provider failed the dimension
+				// probe. Do not abort boot: ensureEmbeddingDimension() has already
+				// flipped the runtime into embedding-disabled mode, so memory writes
+				// skip vector generation instead of emitting vectors the SQL adapter
+				// would silently drop against its default-sized column (#8769). The
+				// deferred boot re-probe (packages/agent) re-runs the probe after
+				// late plugins register and re-enables embeddings on success.
+				this.logger.error(
+					{
+						src: "agent",
+						agentId: this.agentId,
+						attempts: error.attempts,
+					},
+					"All registered TEXT_EMBEDDING providers failed the dimension probe; continuing boot with embedding generation disabled — memory recall over new memories is degraded until a provider recovers",
+				);
+			}
 		}
 
 		// Resolve init promise to allow services to start
@@ -5002,9 +5076,24 @@ export class AgentRuntime implements IAgentRuntime {
 			}
 		}
 
+		// TEXT_EMBEDDING calls without an explicit provider are pinned to the
+		// provider that answered the dimension probe: the vector column was sized
+		// from its output, so serving an embedding call from any other
+		// registration (including via rate-limit failover) can emit a
+		// different-width vector that the SQL adapter silently drops (#8769).
+		// Pinning also disables mid-call provider failover for embeddings — an
+		// embedding either comes from the provider the column was sized for, or
+		// the call fails loudly. An explicit provider argument still wins.
+		const requestedProvider =
+			provider === undefined &&
+			requestedModelKey === ModelType.TEXT_EMBEDDING &&
+			this.pinnedEmbeddingProvider !== undefined
+				? this.pinnedEmbeddingProvider
+				: provider;
+
 		const resolvedModels = this.resolveModelRegistrations(
 			requestedModelKey,
-			provider,
+			requestedProvider,
 		);
 		if (resolvedModels.length === 0) {
 			this.throwNoModelHandler(requestedModelKey);
@@ -5713,7 +5802,7 @@ export class AgentRuntime implements IAgentRuntime {
 				lastModelError = error;
 				const nextModel = resolvedModels[resolvedIndex + 1];
 				if (
-					provider !== undefined ||
+					requestedProvider !== undefined ||
 					!nextModel ||
 					!this.shouldFailOverModelProvider(error)
 				) {
@@ -7975,41 +8064,163 @@ ${section_end}`;
 		}
 	}
 
+	/**
+	 * True while embedding generation is disabled because every registered
+	 * TEXT_EMBEDDING provider failed the dimension probe. While true, memory
+	 * writes persist without vectors (recall over new memories is degraded)
+	 * rather than emitting vectors the SQL adapter would silently drop against
+	 * a default-sized column. Cleared by the next successful
+	 * {@link ensureEmbeddingDimension} (e.g. the deferred boot re-probe).
+	 */
+	isEmbeddingGenerationDisabled(): boolean {
+		return this.embeddingGenerationDisabledReason !== null;
+	}
+
+	private disableEmbeddingGeneration(reason: string): void {
+		this.embeddingGenerationDisabledReason = reason;
+		this.embeddingSkipWarned = false;
+	}
+
+	private enableEmbeddingGeneration(): void {
+		if (this.embeddingGenerationDisabledReason !== null) {
+			this.logger.info(
+				{ src: "agent", agentId: this.agentId },
+				"TEXT_EMBEDDING provider recovered; embedding generation re-enabled",
+			);
+		}
+		this.embeddingGenerationDisabledReason = null;
+		this.embeddingSkipWarned = false;
+	}
+
+	/**
+	 * Once-latch warn for skipped embedding generation: the first skipped write
+	 * logs a structured warning, subsequent skips stay quiet until the flag is
+	 * cleared and re-set (a fresh degradation event warns again).
+	 */
+	private warnEmbeddingGenerationSkipped(): void {
+		if (this.embeddingSkipWarned) {
+			return;
+		}
+		this.embeddingSkipWarned = true;
+		this.logger.warn(
+			{
+				src: "agent",
+				agentId: this.agentId,
+				reason: this.embeddingGenerationDisabledReason,
+			},
+			"Embedding generation is disabled (every TEXT_EMBEDDING provider failed the dimension probe); memory writes are persisted WITHOUT vectors — recall over new memories is degraded until a provider recovers",
+		);
+	}
+
 	async ensureEmbeddingDimension() {
 		if (!this.adapter) {
 			throw new Error(
 				"Database adapter not initialized before ensureEmbeddingDimension",
 			);
 		}
-		const model = this.getModel(ModelType.TEXT_EMBEDDING);
-		if (!model) {
+		const registrations = this.resolveModelRegistrations(
+			ModelType.TEXT_EMBEDDING,
+		);
+		if (registrations.length === 0) {
 			throw new Error("No TEXT_EMBEDDING model registered");
 		}
 
-		// Pass null to get a test vector for dimension detection
-		// Model handlers should return a zero-filled vector of the correct dimension when null is passed
-		let embedding: unknown;
-		try {
-			embedding = await this.useModel(ModelType.TEXT_EMBEDDING, null);
-		} catch (error) {
-			if (error instanceof NoModelProviderConfiguredError) {
-				this.logger.warn(
-					{ src: "agent", agentId: this.agentId },
-					"No backing TEXT_EMBEDDING provider registered, skipping embedding setup",
-				);
-				return;
+		// Probe every registered TEXT_EMBEDDING provider in the same priority
+		// order useModel resolves them. The probe passes null; handlers return a
+		// zero-filled vector of their real output width. A provider that cannot
+		// answer the null probe cannot produce usable vectors either, so ANY
+		// probe failure — not just a rate limit — advances to the next
+		// registration. First success wins: it sizes the adapter's vector column
+		// and pins that provider for subsequent embedding calls, so the column
+		// width and the vectors written to it always come from the same provider.
+		const attempts: EmbeddingProbeAttempt[] = [];
+		const probedProviders = new Set<string>();
+		let allFailuresBenign = true;
+		for (const registration of registrations) {
+			if (probedProviders.has(registration.provider)) {
+				continue;
 			}
-			throw error;
-		}
-		if (!Array.isArray(embedding) || embedding.length === 0) {
-			throw new Error("Invalid embedding received");
+			probedProviders.add(registration.provider);
+
+			let embedding: unknown;
+			try {
+				embedding = await this.useModel(
+					ModelType.TEXT_EMBEDDING,
+					null,
+					registration.provider,
+				);
+			} catch (error) {
+				if (!(error instanceof NoModelProviderConfiguredError)) {
+					allFailuresBenign = false;
+				}
+				attempts.push({
+					provider: registration.provider,
+					modelKey: registration.modelKey,
+					error: error instanceof Error ? error.message : String(error),
+				});
+				this.logger.warn(
+					{
+						src: "agent",
+						agentId: this.agentId,
+						provider: registration.provider,
+						error: error instanceof Error ? error.message : String(error),
+					},
+					"TEXT_EMBEDDING provider failed the dimension probe; trying next registered provider",
+				);
+				continue;
+			}
+			if (!Array.isArray(embedding) || embedding.length === 0) {
+				allFailuresBenign = false;
+				attempts.push({
+					provider: registration.provider,
+					modelKey: registration.modelKey,
+					error: `Invalid embedding received (${Array.isArray(embedding) ? "empty array" : typeof embedding})`,
+				});
+				this.logger.warn(
+					{
+						src: "agent",
+						agentId: this.agentId,
+						provider: registration.provider,
+					},
+					"TEXT_EMBEDDING provider returned an invalid probe embedding; trying next registered provider",
+				);
+				continue;
+			}
+
+			await this.adapter.ensureEmbeddingDimension(embedding.length);
+			this.pinnedEmbeddingProvider = registration.provider;
+			this.enableEmbeddingGeneration();
+			this.logger.debug(
+				{
+					src: "agent",
+					agentId: this.agentId,
+					dimension: embedding.length,
+					provider: registration.provider,
+					failedProviders: attempts.map((attempt) => attempt.provider),
+				},
+				"Embedding dimension set",
+			);
+			return;
 		}
 
-		await this.adapter.ensureEmbeddingDimension(embedding.length);
-		this.logger.debug(
-			{ src: "agent", agentId: this.agentId, dimension: embedding.length },
-			"Embedding dimension set",
-		);
+		// Every registered handler reported "no backing provider configured"
+		// (e.g. a cloud proxy handler before login). Nothing can emit vectors,
+		// so a default-width column cannot cause a dimension mismatch — keep the
+		// long-standing benign skip.
+		if (allFailuresBenign) {
+			this.logger.warn(
+				{ src: "agent", agentId: this.agentId },
+				"No backing TEXT_EMBEDDING provider registered, skipping embedding setup",
+			);
+			return;
+		}
+
+		// All probes failed for real. Disable embedding generation so memory
+		// writes skip vector generation coherently (no silent drops downstream),
+		// and surface a typed error carrying every provider's failure.
+		const probeError = new EmbeddingDimensionProbeError(attempts);
+		this.disableEmbeddingGeneration(probeError.message);
+		throw probeError;
 	}
 
 	registerTaskWorker(taskHandler: TaskWorker): void {
@@ -8265,6 +8476,14 @@ ${section_end}`;
 		if (!memoryText) {
 			throw new Error("Cannot generate embedding: Memory content is empty");
 		}
+		if (this.embeddingGenerationDisabledReason !== null) {
+			// Every TEXT_EMBEDDING provider failed the dimension probe, so the
+			// vector column was never sized for this runtime. Skip generation
+			// explicitly (warn once) instead of producing a vector the SQL
+			// adapter would silently drop on dimension mismatch (#8769).
+			this.warnEmbeddingGenerationSkipped();
+			return memory;
+		}
 		memory.embedding = await this.useModel(ModelType.TEXT_EMBEDDING, {
 			text: memoryText,
 		});
@@ -8281,6 +8500,13 @@ ${section_end}`;
 	): Promise<void> {
 		priority = priority || "normal";
 		if (!memory || memory.embedding || !memory.content.text) {
+			return;
+		}
+		if (this.embeddingGenerationDisabledReason !== null) {
+			// See addEmbeddingToMemory: no provider passed the dimension probe,
+			// so queueing would only produce per-item generation failures (or
+			// silently dropped vectors). Skip explicitly, warn once.
+			this.warnEmbeddingGenerationSkipped();
 			return;
 		}
 

--- a/packages/core/src/runtime/__tests__/embedding-dimension.test.ts
+++ b/packages/core/src/runtime/__tests__/embedding-dimension.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, it, vi } from "vitest";
+import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
+import {
+	AgentRuntime,
+	EmbeddingDimensionProbeError,
+	NoModelProviderConfiguredError,
+} from "../../runtime";
+import { type Character, type Memory, ModelType, type UUID } from "../../types";
+
+/**
+ * Boot-time TEXT_EMBEDDING dimension-probe semantics (#10702 / #8769):
+ *
+ * 1. The probe fails over across ALL registered TEXT_EMBEDDING providers in
+ *    priority order — any probe error advances, first success wins, sizes the
+ *    vector column, and pins that provider for later embedding calls.
+ * 2. When every probe fails, a typed EmbeddingDimensionProbeError carries each
+ *    provider's failure, and the runtime enters a coherent degraded mode:
+ *    memory writes skip vector generation (warn once) instead of emitting
+ *    vectors the SQL adapter would silently drop on dimension mismatch
+ *    (plugins/plugin-sql/src/base.ts insert/update guards).
+ * 3. A later successful re-probe (the deferred boot re-probe) clears the flag
+ *    and embedding writes resume at the newly probed dimension.
+ * 4. runtime.initialize() survives a total probe failure — boot stays alive in
+ *    the degraded mode instead of crashing (#10702's original symptom).
+ */
+
+const ROOM_ID = "00000000-0000-0000-0000-000000000001" as UUID;
+
+function makeRuntime(): AgentRuntime {
+	return new AgentRuntime({
+		character: {
+			name: "EmbeddingProbeAgent",
+			bio: "test",
+			settings: {},
+		} as Character,
+		adapter: new InMemoryDatabaseAdapter(),
+		logLevel: "fatal",
+	});
+}
+
+function makeMemory(text: string): Memory {
+	return {
+		entityId: "00000000-0000-0000-0000-000000000002" as UUID,
+		roomId: ROOM_ID,
+		content: { text },
+	};
+}
+
+describe("AgentRuntime.ensureEmbeddingDimension provider failover", () => {
+	it("fails over past a broken provider on a non-rate-limit probe error and pins the working provider", async () => {
+		const runtime = makeRuntime();
+		const brokenHandler = vi.fn(async () => {
+			throw new Error("Not Implemented");
+		});
+		const healthyHandler = vi.fn(async () => new Array(768).fill(0));
+
+		runtime.registerModel(
+			ModelType.TEXT_EMBEDDING,
+			brokenHandler,
+			"ollama",
+			100,
+		);
+		runtime.registerModel(
+			ModelType.TEXT_EMBEDDING,
+			healthyHandler,
+			"elizacloud",
+			10,
+		);
+		const ensureDim = vi.spyOn(runtime.adapter, "ensureEmbeddingDimension");
+
+		await expect(runtime.ensureEmbeddingDimension()).resolves.toBeUndefined();
+
+		expect(brokenHandler).toHaveBeenCalledTimes(1);
+		expect(healthyHandler).toHaveBeenCalledTimes(1);
+		expect(ensureDim).toHaveBeenCalledWith(768);
+		expect(runtime.isEmbeddingGenerationDisabled()).toBe(false);
+
+		// The column was sized from elizacloud's output, so later embedding
+		// calls are pinned to it — the higher-priority broken provider must NOT
+		// be retried (its vectors could have a different width and would be
+		// silently dropped by the SQL adapter's dimension guard).
+		const memory = await runtime.addEmbeddingToMemory(makeMemory("hello"));
+		expect(memory.embedding).toHaveLength(768);
+		expect(brokenHandler).toHaveBeenCalledTimes(1);
+		expect(healthyHandler).toHaveBeenCalledTimes(2);
+	});
+
+	it("treats an invalid probe embedding as a failed attempt and advances", async () => {
+		const runtime = makeRuntime();
+		const emptyHandler = vi.fn(async () => []);
+		const healthyHandler = vi.fn(async () => new Array(384).fill(0));
+
+		runtime.registerModel(ModelType.TEXT_EMBEDDING, emptyHandler, "empty", 50);
+		runtime.registerModel(
+			ModelType.TEXT_EMBEDDING,
+			healthyHandler,
+			"healthy",
+			10,
+		);
+		const ensureDim = vi.spyOn(runtime.adapter, "ensureEmbeddingDimension");
+
+		await expect(runtime.ensureEmbeddingDimension()).resolves.toBeUndefined();
+		expect(ensureDim).toHaveBeenCalledWith(384);
+		expect(runtime.isEmbeddingGenerationDisabled()).toBe(false);
+	});
+
+	it("throws a typed error carrying every provider's failure when all probes fail, and gates memory writes with a single warning", async () => {
+		const runtime = makeRuntime();
+		const ollamaHandler = vi.fn(async () => {
+			throw new Error("Not Implemented");
+		});
+		const cloudHandler = vi.fn(async () => {
+			throw new Error("connect ECONNREFUSED 127.0.0.1:11434");
+		});
+
+		runtime.registerModel(
+			ModelType.TEXT_EMBEDDING,
+			ollamaHandler,
+			"ollama",
+			100,
+		);
+		runtime.registerModel(
+			ModelType.TEXT_EMBEDDING,
+			cloudHandler,
+			"elizacloud",
+			10,
+		);
+		const ensureDim = vi.spyOn(runtime.adapter, "ensureEmbeddingDimension");
+
+		const error: unknown = await runtime
+			.ensureEmbeddingDimension()
+			.catch((err: unknown) => err);
+		expect(error).toBeInstanceOf(EmbeddingDimensionProbeError);
+		const probeError = error as EmbeddingDimensionProbeError;
+		expect(probeError.attempts).toEqual([
+			{
+				provider: "ollama",
+				modelKey: ModelType.TEXT_EMBEDDING,
+				error: "Not Implemented",
+			},
+			{
+				provider: "elizacloud",
+				modelKey: ModelType.TEXT_EMBEDDING,
+				error: "connect ECONNREFUSED 127.0.0.1:11434",
+			},
+		]);
+		expect(probeError.message).toContain("ollama: Not Implemented");
+		expect(probeError.message).toContain(
+			"elizacloud: connect ECONNREFUSED 127.0.0.1:11434",
+		);
+
+		// Coherent degraded mode: no dimension was pinned, and the write path
+		// skips embedding generation instead of calling a broken provider (or
+		// writing vectors a default-sized column would silently drop).
+		expect(ensureDim).not.toHaveBeenCalled();
+		expect(runtime.isEmbeddingGenerationDisabled()).toBe(true);
+
+		const warn = vi.spyOn(runtime.logger, "warn");
+		const first = await runtime.addEmbeddingToMemory(makeMemory("hello"));
+		const second = await runtime.addEmbeddingToMemory(makeMemory("world"));
+		expect(first.embedding).toBeUndefined();
+		expect(second.embedding).toBeUndefined();
+		expect(ollamaHandler).toHaveBeenCalledTimes(1); // probe only, no per-write calls
+		expect(cloudHandler).toHaveBeenCalledTimes(1);
+
+		// queueEmbeddingGeneration must also skip: no embedding event is emitted.
+		const emitEvent = vi.spyOn(runtime, "emitEvent");
+		await runtime.queueEmbeddingGeneration(makeMemory("queued"));
+		expect(emitEvent).not.toHaveBeenCalled();
+
+		// Once-latch: exactly one skip warning across all three writes.
+		const skipWarnings = warn.mock.calls.filter(([, message]) =>
+			String(message).includes("Embedding generation is disabled"),
+		);
+		expect(skipWarnings).toHaveLength(1);
+	});
+
+	it("re-enables embedding writes at the correct dimension after a successful re-probe (recovery)", async () => {
+		const runtime = makeRuntime();
+		let recovered = false;
+		const flakyHandler = vi.fn(async () => {
+			if (!recovered) {
+				throw new Error("Not Implemented");
+			}
+			return new Array(1536).fill(0);
+		});
+
+		runtime.registerModel(
+			ModelType.TEXT_EMBEDDING,
+			flakyHandler,
+			"elizacloud",
+			100,
+		);
+		const ensureDim = vi.spyOn(runtime.adapter, "ensureEmbeddingDimension");
+
+		// Boot-time probe: provider down → degraded mode, writes skip vectors.
+		await expect(runtime.ensureEmbeddingDimension()).rejects.toBeInstanceOf(
+			EmbeddingDimensionProbeError,
+		);
+		expect(runtime.isEmbeddingGenerationDisabled()).toBe(true);
+		const degraded = await runtime.addEmbeddingToMemory(makeMemory("early"));
+		expect(degraded.embedding).toBeUndefined();
+
+		// Provider recovers; the deferred re-probe (packages/agent runDeferredBoot)
+		// calls ensureEmbeddingDimension again.
+		recovered = true;
+		await expect(runtime.ensureEmbeddingDimension()).resolves.toBeUndefined();
+
+		expect(runtime.isEmbeddingGenerationDisabled()).toBe(false);
+		expect(ensureDim).toHaveBeenCalledWith(1536);
+
+		// No silent drop after recovery: the write resumes and its vector width
+		// matches the dimension the adapter column was just configured with, so
+		// the plugin-sql dimension guard cannot drop it.
+		const restored = await runtime.addEmbeddingToMemory(makeMemory("late"));
+		expect(restored.embedding).toHaveLength(1536);
+		expect(ensureDim).toHaveBeenLastCalledWith(1536);
+	});
+
+	it("keeps the benign skip when every handler reports no backing provider configured", async () => {
+		const runtime = makeRuntime();
+		const proxyHandler = vi.fn(async () => {
+			throw new NoModelProviderConfiguredError();
+		});
+		runtime.registerModel(
+			ModelType.TEXT_EMBEDDING,
+			proxyHandler,
+			"elizacloud",
+			100,
+		);
+		const ensureDim = vi.spyOn(runtime.adapter, "ensureEmbeddingDimension");
+
+		// "No backing provider at all" means nothing will ever emit vectors, so
+		// a default-width column cannot cause a mismatch — not a degradation.
+		await expect(runtime.ensureEmbeddingDimension()).resolves.toBeUndefined();
+		expect(ensureDim).not.toHaveBeenCalled();
+		expect(runtime.isEmbeddingGenerationDisabled()).toBe(false);
+	});
+});
+
+describe("AgentRuntime.initialize with a broken TEXT_EMBEDDING provider (#10702)", () => {
+	it("boots in degraded mode when the only provider fails the probe, instead of crashing", async () => {
+		const runtime = makeRuntime();
+		const ollamaHandler = vi.fn(async () => {
+			throw new Error("Not Implemented");
+		});
+		runtime.registerModel(
+			ModelType.TEXT_EMBEDDING,
+			ollamaHandler,
+			"ollama",
+			100,
+		);
+
+		// #10702's original symptom: this rejected and killed agent boot.
+		await expect(runtime.initialize()).resolves.toBeUndefined();
+
+		// The degraded mode is explicit, not silent: embedding generation is
+		// flagged off and memory writes persist without vectors instead of the
+		// SQL adapter silently dropping mismatched ones.
+		expect(runtime.isEmbeddingGenerationDisabled()).toBe(true);
+		const memory = await runtime.addEmbeddingToMemory(makeMemory("post-boot"));
+		expect(memory.embedding).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Problem

A registered-but-broken `TEXT_EMBEDDING` provider (e.g. Ollama answering the null dimension probe with `"Not Implemented"`) crashes agent boot: the initial probe in `runtime.initialize()` → `ensureEmbeddingDimension()` rethrows every non-benign error uncaught.

#10702 tried to fix this with a blanket `catch → warn → return`, and was rejected twice for the same reason: tolerating an *arbitrary* probe failure leaves the embedding column at the SQL adapter's hardcoded `dim384` default, and `plugin-sql` then **silently drops** every mismatched-dimension embedding write (`plugins/plugin-sql/src/base.ts` insert/update guards) — the agent boots "healthy" and recalls nothing, with no surfaced error (the #8769 failure class).

## Design

**1. Probe-failover across all registered TEXT_EMBEDDING providers.** `ensureEmbeddingDimension()` now iterates `resolveModelRegistrations()` in the same priority order `useModel` resolves them, probing each provider through the existing explicit-provider `useModel` path (#10969's plumbing, not a duplicate loop). **Any** probe error — not just a rate limit — advances to the next registration: a provider that cannot answer the null probe cannot produce usable vectors either. First success sizes the vector column **and pins that provider** for subsequent embedding calls (`useModel(TEXT_EMBEDDING)` without an explicit provider resolves to the pin), so the column width and the vectors written to it always come from the same provider. #10969 itself pins nothing globally — each call re-resolves — but for embeddings specifically, mid-call rate-limit failover to a *different-width* provider is exactly the silent-drop hazard, so the pin also disables cross-provider failover for embedding calls: an embedding either comes from the provider the column was sized for, or the call fails loudly. An explicit `provider` argument still wins.

**2. All probes fail → typed degraded mode, never silent drops.** A new exported `EmbeddingDimensionProbeError` carries every provider's failure (`attempts: {provider, modelKey, error}[]`, all in the message). `ensureEmbeddingDimension()` flips the runtime into a typed embedding-disabled state and **rethrows**; `runtime.initialize()` catches *exactly that error type*, logs the full per-provider context at error level, and keeps booting. `addEmbeddingToMemory()` / `queueEmbeddingGeneration()` consult the flag (`isEmbeddingGenerationDisabled()`, no stringly-typed settings) and skip vector generation explicitly with a **once-latch** structured warning — memories persist without vectors instead of `plugin-sql` silently dropping mismatched ones. The pre-existing benign skip (every handler reporting `NoModelProviderConfiguredError` — nothing can ever emit vectors, so a default-width column cannot mismatch) is preserved unchanged.

Why the non-fatal catch sits at the `initialize()` seam rather than in `packages/agent`: the only statement after the probe inside `initialize()` is resolving `initPromise` — catching the throw *outside* `initialize()` would strand that promise and deadlock every `_ensureServiceStarted` call. The catch is typed-narrow (only `EmbeddingDimensionProbeError`; everything else still rethrows), and the boot layer (`packages/agent/src/runtime/eliza.ts`) additionally surfaces the degraded state after `runtime.initialize()` and logs per-provider attempts when the deferred re-probe also fails. This also gives every runtime host (app-core, examples, tests) the same coherent degraded boot, not just the `packages/agent` path.

**3. Recovery.** The deferred boot re-probe (`runDeferredBoot` in eliza.ts, which already re-runs `ensureEmbeddingDimension()` after the late plugin waves — the #8769 fix) clears the flag on success, re-pins provider + dimension, and embedding writes resume at the correct width. The recovery test asserts the post-recovery vector length equals the dimension the adapter column was just configured with — no silent drop window.

## How each #10702 objection is satisfied

| Objection (from both reviews) | This PR |
|---|---|
| "Generic probe error swallowed → column stays dim384 → provider recovers → every write silently dropped, zero recall, no error" | All-fail path *disables* embedding writes via a typed flag; no vector is ever written against an unsized column. Recovery re-sizes the column *before* writes resume. |
| "Keep rethrowing unknown errors in core; if degradation is wanted, *coherently disable* embedding writes behind a capability flag" | `ensureEmbeddingDimension` rethrows a typed error with full context; the flag is typed runtime state consulted by the write paths; only `initialize()` catches it, narrowly. |
| "Wrap with actionable context (which provider, which error)" | `EmbeddingDimensionProbeError.attempts` lists every provider + its error; message and structured logs include all of them. |
| "Test only asserts the swallow fired; prove the downstream outcome (dropped vectors) is gated" | Tests pin the write-path outcome: memory persists without embedding, no model call, exactly one warning, no embedding event emitted; recovery test pins width == configured column. |
| "Scope tolerance to an explicit 'provider genuinely unavailable' signal, never a bare `return` on `catch (error)`" | The benign `NoModelProviderConfiguredError`-only skip is kept as the *only* warn+return; every other failure is typed, flagged, and rethrown. |
| "Boot-crash safety already exists a layer up via the deferred re-probe" | Kept and extended: the deferred re-probe is the recovery mechanism (flag-clear + re-pin wired into `ensureEmbeddingDimension` success), and its catch now logs per-provider attempts. |
| Trailing-newline / lint nit | `biome check` clean on all three files. |

## Tests

New suite `packages/core/src/runtime/__tests__/embedding-dimension.test.ts` (real `AgentRuntime` + `InMemoryDatabaseAdapter`, same pattern as `model-provider-failover.test.ts`):

- (a) first provider probe-fails with a non-rate-limit error, second succeeds → dimension set from second (`ensureEmbeddingDimension(768)`), boot unaffected, later embedding calls pinned to the working provider (broken higher-priority provider never retried);
- invalid (empty) probe vector counts as a failed attempt and advances;
- (b) all fail → `EmbeddingDimensionProbeError` carries both providers' contexts; flag set; `addEmbeddingToMemory` ×2 + `queueEmbeddingGeneration` all skip with **one** warning total and zero event emission;
- (c) recovery: probe fails at boot → provider recovers → re-probe succeeds → flag clears → `addEmbeddingToMemory` resumes with a 1536-wide vector matching the just-configured column (no silent-drop window);
- benign `NoModelProviderConfiguredError`-only case still skips without degrading;
- (d) #10702's original case: single Ollama-style `"Not Implemented"` provider → `runtime.initialize()` **resolves** (boot alive), degraded mode explicit, writes skip.

Results (worktree on `origin/develop` tip):

- `vitest run src/runtime/__tests__/embedding-dimension.test.ts src/runtime/__tests__/model-provider-failover.test.ts` → **2 files, 9/9 passed**
- `vitest run src/runtime/__tests__` (full directory, default lane) → **59 files, 740/740 passed**
- `vitest run src/__tests__/provisioning.test.ts src/runtime/__tests__/secret-swap-use-model.test.ts src/runtime/__tests__/pii-swap-use-model.test.ts src/runtime/__tests__/action-model-routing-integration.test.ts` → **4 files, 30/30 passed**
- `packages/agent`: `vitest run src/runtime/eliza-embedding-boot-order.test.ts` (#8769 ordering invariant) → **5/5 passed**
- `bun run --cwd packages/core typecheck` → clean
- `bun run --cwd packages/agent typecheck` → only a pre-existing environmental error in `packages/ui` (`@stwd/sdk` 0.8.1 vs 0.11.0 duplicate in the shared bun store), zero errors in touched files
- `biome check` on the three changed files → clean

Supersedes #10702. Refs #8769, #10969.

🤖 Generated with [Claude Code](https://claude.com/claude-code)