### PR TITLE
fix: default cloud API base to apex — www 308-redirect strips Authorization (all authed calls 401 on default config)

### DIFF
--- a/packages/app-core/src/services/sensitive-requests/public-link-adapter.test.ts
+++ b/packages/app-core/src/services/sensitive-requests/public-link-adapter.test.ts
@@ -100,7 +100,7 @@ describe("publicLinkSensitiveRequestAdapter", () => {
       expect(result.delivered).toBe(true);
       if (!result.delivered) throw new Error("expected success");
       expect(result.url).toBe(
-        "https://www.elizacloud.ai/api/v1/payment/app-charge/app_demo/req_pay_1/public",
+        "https://elizacloud.ai/api/v1/payment/app-charge/app_demo/req_pay_1/public",
       );
     } finally {
       if (previous !== undefined) process.env.ELIZAOS_CLOUD_BASE_URL = previous;

--- a/packages/app-core/src/services/sensitive-requests/public-link-adapter.ts
+++ b/packages/app-core/src/services/sensitive-requests/public-link-adapter.ts
@@ -17,7 +17,7 @@ import {
   toRuntimeSettings,
 } from "@elizaos/core";
 
-const CLOUD_BASE_FALLBACK = "https://www.elizacloud.ai/api/v1";
+const CLOUD_BASE_FALLBACK = "https://elizacloud.ai/api/v1";
 
 /**
  * Structural subset of `IAgentRuntime` we touch for cloud base resolution.

--- a/packages/cloud/routing/src/resolve.test.ts
+++ b/packages/cloud/routing/src/resolve.test.ts
@@ -89,7 +89,7 @@ describe("resolveCloudRoute", () => {
       ),
     ).toMatchObject({
       source: "cloud-proxy",
-      baseUrl: "https://www.elizacloud.ai/api/v1/apis/quotes",
+      baseUrl: "https://elizacloud.ai/api/v1/apis/quotes",
       headers: { Authorization: "Bearer cloud-secret" },
     });
   });

--- a/packages/cloud/routing/src/resolve.ts
+++ b/packages/cloud/routing/src/resolve.ts
@@ -9,7 +9,7 @@ import {
 } from "./features.js";
 import type { CloudRoute, FeatureCloudRoute, RouteSpec } from "./types.js";
 
-const CLOUD_BASE_FALLBACK = "https://www.elizacloud.ai/api/v1";
+const CLOUD_BASE_FALLBACK = "https://elizacloud.ai/api/v1";
 
 export interface RuntimeSettings {
   getSetting(key: string): string | boolean | number | null | undefined;

--- a/packages/cloud/shared/src/lib/eliza/config.ts
+++ b/packages/cloud/shared/src/lib/eliza/config.ts
@@ -15,7 +15,7 @@ import { expandBitRouterModelIdCandidates } from "../providers/model-id-translat
  * - Local: http://localhost:3000/api/v1
  * - Test: http://localhost:3000/api/v1 (same as local)
  * - Development: https://dev.elizacloud.ai/api/v1
- * - Production: https://www.elizacloud.ai/api/v1
+ * - Production: https://elizacloud.ai/api/v1
  */
 export function getElizaCloudApiUrl(): string {
   // Allow explicit override via environment variable
@@ -42,7 +42,7 @@ export function getElizaCloudApiUrl(): string {
   }
 
   // Production (default)
-  return "https://www.elizacloud.ai/api/v1";
+  return "https://elizacloud.ai/api/v1";
 }
 
 /**

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
@@ -1346,7 +1346,7 @@ export class DockerSandboxProvider implements SandboxProvider {
         if (!allEnv.ELIZAOS_CLOUD_BASE_URL) {
           throw new Error(
             "[docker-sandbox] ELIZAOS_CLOUD_BASE_URL is not set in container env. " +
-              "Refusing to fall back to the hardcoded prod URL (https://www.elizacloud.ai/api/v1) — " +
+              "Refusing to fall back to the hardcoded prod URL (https://elizacloud.ai/api/v1) — " +
               "this caused staging containers to silently call prod. " +
               "Configure ELIZAOS_CLOUD_BASE_URL in the daemon/Worker env (e.g. " +
               "https://api-staging.elizacloud.ai/api/v1 for staging, https://api.elizacloud.ai/api/v1 for prod).",

--- a/packages/cloud/shared/src/lib/services/message-router/index.ts
+++ b/packages/cloud/shared/src/lib/services/message-router/index.ts
@@ -861,7 +861,7 @@ class MessageRouterService {
       canVoice?: boolean;
     };
   }): Promise<{ id: string; webhookUrl: string }> {
-    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "https://www.elizacloud.ai";
+    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "https://elizacloud.ai";
     const webhookUrl = `${baseUrl}/api/webhooks/${params.provider}/${params.organizationId}`;
 
     const [record] = await dbWrite

--- a/packages/core/src/cloud-routing.test.ts
+++ b/packages/core/src/cloud-routing.test.ts
@@ -104,7 +104,7 @@ describe("resolveCloudRoute — the three modes", () => {
 		);
 		expect(route.source).toBe("cloud-proxy");
 		if (route.source !== "cloud-proxy") throw new Error("unreachable");
-		expect(route.baseUrl).toBe("https://www.elizacloud.ai/api/v1/apis/openai");
+		expect(route.baseUrl).toBe("https://elizacloud.ai/api/v1/apis/openai");
 		expect(route.headers.Authorization).toBe("Bearer cloud-key");
 	});
 

--- a/packages/core/src/cloud-routing.ts
+++ b/packages/core/src/cloud-routing.ts
@@ -28,7 +28,7 @@ export interface RouteSpec {
 		| { kind: "query"; paramName: string };
 }
 
-const CLOUD_BASE_FALLBACK = "https://www.elizacloud.ai/api/v1";
+const CLOUD_BASE_FALLBACK = "https://elizacloud.ai/api/v1";
 
 /**
  * Structural subset of `IAgentRuntime` we actually need. Avoids a hard

--- a/packages/elizaos/templates/project/apps/app/src/main.tsx
+++ b/packages/elizaos/templates/project/apps/app/src/main.tsx
@@ -154,7 +154,7 @@ const elizaBootConfig: AppBootConfig = {
     (import.meta.env.VITE_ASSET_BASE_URL as string | undefined)?.trim() ||
     undefined,
   cloudApiBase:
-    (import.meta.env.VITE_CLOUD_BASE as string) ?? "https://www.elizacloud.ai",
+    (import.meta.env.VITE_CLOUD_BASE as string) ?? "https://elizacloud.ai",
   vrmAssets: ELIZA_VRM_ASSETS,
   firstRunStyles: ELIZA_STYLE_PRESETS,
   characterEditor: CharacterEditor,

--- a/packages/examples/app/capacitor/backend/src/types.ts
+++ b/packages/examples/app/capacitor/backend/src/types.ts
@@ -76,7 +76,7 @@ export const DEFAULT_CONFIG: AppConfig = {
 
     // Eliza Cloud
     elizacloudApiKey: "",
-    elizacloudBaseUrl: "https://www.elizacloud.ai/api/v1",
+    elizacloudBaseUrl: "https://elizacloud.ai/api/v1",
     elizacloudSmallModel: "gemma-4-31b",
     elizacloudLargeModel: "gemma-4-31b",
 

--- a/packages/examples/app/capacitor/frontend/src/types.ts
+++ b/packages/examples/app/capacitor/frontend/src/types.ts
@@ -65,7 +65,7 @@ export const DEFAULT_CONFIG: AppConfig = {
     anthropicLargeModel: "claude-sonnet-4-6",
 
     elizacloudApiKey: "",
-    elizacloudBaseUrl: "https://www.elizacloud.ai/api/v1",
+    elizacloudBaseUrl: "https://elizacloud.ai/api/v1",
     elizacloudSmallModel: "gemma-4-31b",
     elizacloudLargeModel: "gemma-4-31b",
 

--- a/packages/examples/cloud/clone-ur-crush/lib/constants.ts
+++ b/packages/examples/cloud/clone-ur-crush/lib/constants.ts
@@ -7,7 +7,7 @@ export const APP_CONFIG = {
   // without NEXT_PUBLIC_ELIZA_CLOUD_URL set still redirects to a live host
   // instead of dead-ending at localhost:3000 (#9300).
   elizaCloudUrl:
-    process.env.NEXT_PUBLIC_ELIZA_CLOUD_URL || "https://www.elizacloud.ai",
+    process.env.NEXT_PUBLIC_ELIZA_CLOUD_URL || "https://elizacloud.ai",
 };
 
 export const ROUTES = {

--- a/packages/examples/cloud/clone-ur-crush/next.config.ts
+++ b/packages/examples/cloud/clone-ur-crush/next.config.ts
@@ -22,7 +22,7 @@ const nextConfig: NextConfig = {
   },
   env: {
     NEXT_PUBLIC_ELIZA_CLOUD_URL:
-      process.env.NEXT_PUBLIC_ELIZA_CLOUD_URL || "https://www.elizacloud.ai",
+      process.env.NEXT_PUBLIC_ELIZA_CLOUD_URL || "https://elizacloud.ai",
   },
 };
 

--- a/packages/examples/cloud/edad/server.ts
+++ b/packages/examples/cloud/edad/server.ts
@@ -26,7 +26,7 @@ const PORT = Number(process.env.PORT ?? 3000);
 const PUBLIC_DIR = join(import.meta.dir, "public");
 
 const CLOUD_URL = (
-  process.env.ELIZA_CLOUD_URL ?? "https://www.elizacloud.ai"
+  process.env.ELIZA_CLOUD_URL ?? "https://elizacloud.ai"
 ).replace(/\/+$/, "");
 const AFFILIATE_CODE = process.env.ELIZA_AFFILIATE_CODE ?? "";
 const APP_ID = process.env.ELIZA_APP_ID ?? "";

--- a/packages/examples/cloud/edad/test.ts
+++ b/packages/examples/cloud/edad/test.ts
@@ -7,7 +7,7 @@ const proc = Bun.spawn(["bun", "run", "server.ts"], {
     ...process.env,
     ELIZA_AFFILIATE_CODE: "AFF-TEST",
     ELIZA_APP_ID: "00000000-0000-4000-8000-000000000000",
-    ELIZA_CLOUD_URL: "https://www.elizacloud.ai",
+    ELIZA_CLOUD_URL: "https://elizacloud.ai",
     PORT: String(port),
   },
   stderr: "pipe",
@@ -75,7 +75,7 @@ try {
   if (
     body.affiliate_code !== "AFF-TEST" ||
     body.app_id !== "00000000-0000-4000-8000-000000000000" ||
-    body.cloud_url !== "https://www.elizacloud.ai"
+    body.cloud_url !== "https://elizacloud.ai"
   ) {
     throw new Error(`Unexpected config body: ${JSON.stringify(body)}`);
   }

--- a/packages/examples/cloud/x402-image-gen/server.ts
+++ b/packages/examples/cloud/x402-image-gen/server.ts
@@ -37,7 +37,7 @@ const PORT = Number(process.env.PORT ?? 3000);
 const PUBLIC_DIR = new URL("./public/", import.meta.url);
 
 const CLOUD_URL = (
-  process.env.ELIZA_CLOUD_URL ?? "https://www.elizacloud.ai"
+  process.env.ELIZA_CLOUD_URL ?? "https://elizacloud.ai"
 ).replace(/\/+$/, "");
 const API_KEY =
   process.env.ELIZAOS_CLOUD_API_KEY ?? process.env.ELIZA_CLOUD_API_KEY ?? "";

--- a/packages/shared/src/elizacloud/server-cloud-tts.ts
+++ b/packages/shared/src/elizacloud/server-cloud-tts.ts
@@ -182,7 +182,7 @@ export function resolveCloudTtsBaseUrl(
   const fromConfig =
     fromEnv.length > 0 ? null : resolveCloudBaseUrlFromConfig();
   const configured = fromEnv.length > 0 ? fromEnv : (fromConfig?.trim() ?? "");
-  const fallback = "https://www.elizacloud.ai/api/v1";
+  const fallback = "https://elizacloud.ai/api/v1";
   const base = configured.length > 0 ? configured : fallback;
 
   try {

--- a/packages/ui/src/api/client-cloud-handoff-target.test.ts
+++ b/packages/ui/src/api/client-cloud-handoff-target.test.ts
@@ -53,7 +53,7 @@ function fakeClient(detailById: Record<string, CloudCompatAgent>) {
 }
 
 const SHARED_BASE =
-  "https://www.elizacloud.ai/api/v1/eliza/agents/shared-1/api";
+  "https://elizacloud.ai/api/v1/eliza/agents/shared-1/api";
 
 describe("startCloudAgentHandoff — dedicated migration target", () => {
   // The handoff reads the shared conversation over `fetch` (authedFetch). Stub

--- a/packages/ui/src/cloud/handoff/cloud-handoff-supervisor.test.ts
+++ b/packages/ui/src/cloud/handoff/cloud-handoff-supervisor.test.ts
@@ -4,7 +4,7 @@ import {
   startCloudConversationHandoff,
 } from "./cloud-handoff-supervisor";
 
-const SHARED = "https://www.elizacloud.ai/api/v1/eliza/agents/agent-1/api";
+const SHARED = "https://elizacloud.ai/api/v1/eliza/agents/agent-1/api";
 const CONTAINER = "https://agent-1.elizacloud.ai";
 const CONV = "agent-1";
 

--- a/packages/ui/src/cloud/join/lib/resolve-cloud-connection.ts
+++ b/packages/ui/src/cloud/join/lib/resolve-cloud-connection.ts
@@ -14,7 +14,7 @@ import { readStoredStewardToken } from "@elizaos/shared/steward-session-client";
 import { getBootConfig } from "../../../config/boot-config";
 
 /** Fallback direct-cloud origin used when boot config carries no `cloudApiBase`. */
-const DEFAULT_CLOUD_API_BASE = "https://www.elizacloud.ai";
+const DEFAULT_CLOUD_API_BASE = "https://elizacloud.ai";
 
 /**
  * The resolved direct-cloud origin the join flow provisions against. Prefers the

--- a/packages/ui/src/cloud/join/lib/run-join-flow.test.ts
+++ b/packages/ui/src/cloud/join/lib/run-join-flow.test.ts
@@ -6,7 +6,7 @@ import {
   runJoinFlow,
 } from "./run-join-flow";
 
-const CLOUD_API_BASE = "https://www.elizacloud.ai";
+const CLOUD_API_BASE = "https://elizacloud.ai";
 const SHARED_BASE = "https://api.elizacloud.ai/api/v1/eliza/agents/agent-123";
 
 function makeClient(
@@ -174,10 +174,10 @@ describe("runJoinFlow", () => {
     });
 
     expect(setBaseUrl).toHaveBeenCalledWith(
-      "https://www.elizacloud.ai/api/v1/eliza/agents/agent-new",
+      "https://elizacloud.ai/api/v1/eliza/agents/agent-new",
     );
     expect(result.apiBase).toBe(
-      "https://www.elizacloud.ai/api/v1/eliza/agents/agent-new",
+      "https://elizacloud.ai/api/v1/eliza/agents/agent-new",
     );
     expect(result.dedicated).toBe(false);
   });

--- a/packages/ui/src/state/useCloudState.ts
+++ b/packages/ui/src/state/useCloudState.ts
@@ -54,7 +54,7 @@ import { isPrivateNetworkHost } from "./private-network-host";
 const ELIZA_CLOUD_LOGIN_POLL_INTERVAL_MS = 1000;
 const ELIZA_CLOUD_LOGIN_TIMEOUT_MS = 300_000;
 const ELIZA_CLOUD_LOGIN_MAX_CONSECUTIVE_ERRORS = 3;
-const DEFAULT_DIRECT_CLOUD_BASE_URL = "https://www.elizacloud.ai";
+const DEFAULT_DIRECT_CLOUD_BASE_URL = "https://elizacloud.ai";
 
 /** Cloud=Steward token-lifecycle: how often to check the JWT for expiry. */
 const STEWARD_REFRESH_CHECK_INTERVAL_MS = 60_000;
@@ -520,7 +520,7 @@ export function useCloudState({
       // direct cloud auth (no local backend) or go through the agent proxy.
       const hasBackend = hasCloudLoginBackend();
       const cloudApiBase =
-        getBootConfig().cloudApiBase ?? "https://www.elizacloud.ai";
+        getBootConfig().cloudApiBase ?? "https://elizacloud.ai";
       let useDirectAuth = !hasBackend;
 
       if (hasBackend) {

--- a/plugins/plugin-agent-orchestrator/src/services/opencode-config.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/opencode-config.ts
@@ -5,7 +5,7 @@ import type { IAgentRuntime } from "@elizaos/core";
 import { DEFAULT_CEREBRAS_TEXT_MODEL } from "@elizaos/core";
 import { readConfigCloudKey, readConfigEnvKey } from "./config-env.js";
 
-const ELIZA_CLOUD_OPENAI_BASE = "https://www.elizacloud.ai/api/v1";
+const ELIZA_CLOUD_OPENAI_BASE = "https://elizacloud.ai/api/v1";
 const OPENCODE_LOCAL_DEFAULT_BASE_URL = "http://localhost:11434/v1";
 const OPENCODE_OPENAI_COMPATIBLE_NPM = "@ai-sdk/openai-compatible";
 const OPENCODE_CEREBRAS_NPM = "@ai-sdk/cerebras";

--- a/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
@@ -22,7 +22,7 @@ const REQUEST_MAX_CHARS = 4000;
 const ACTION_LIST_LIMIT_DEFAULT = 60;
 const ACTION_LIST_LIMIT_MAX = 200;
 const CLOUD_RESPONSE_MAX_CHARS = 8000;
-const DEFAULT_CLOUD_BASE_URL = "https://www.elizacloud.ai";
+const DEFAULT_CLOUD_BASE_URL = "https://elizacloud.ai";
 
 export const PARENT_AGENT_BROKER_SLUG = "parent-agent";
 

--- a/plugins/plugin-cloud-apps/src/client.ts
+++ b/plugins/plugin-cloud-apps/src/client.ts
@@ -4,7 +4,7 @@
  * The agent reaches Eliza Cloud with the same credentials plugin-elizacloud
  * uses: the `ELIZAOS_CLOUD_API_KEY` setting (sent as the bearer/API key) and the
  * `ELIZAOS_CLOUD_BASE_URL` setting (the API base, e.g.
- * `https://www.elizacloud.ai/api/v1`). We mirror plugin-elizacloud's
+ * `https://elizacloud.ai/api/v1`). We mirror plugin-elizacloud's
  * `createElizaCloudClient` construction shape: the configured value is the API
  * base (it ends at `/api/v1`), so it is passed as `apiBaseUrl`; the site
  * `baseUrl` is the same origin with the `/api/v1` suffix stripped.
@@ -15,7 +15,7 @@ import { ElizaCloudClient } from "@elizaos/cloud-sdk";
 import type { IAgentRuntime, Memory } from "@elizaos/core";
 
 /** Default Eliza Cloud API base URL (matches the cloud runtime default). */
-export const DEFAULT_CLOUD_API_BASE_URL = "https://www.elizacloud.ai/api/v1";
+export const DEFAULT_CLOUD_API_BASE_URL = "https://elizacloud.ai/api/v1";
 
 /** Settings key holding the Eliza Cloud API key. */
 export const CLOUD_API_KEY_SETTING = "ELIZAOS_CLOUD_API_KEY";

--- a/plugins/plugin-elizacloud/src/cloud-setup.ts
+++ b/plugins/plugin-elizacloud/src/cloud-setup.ts
@@ -46,7 +46,7 @@ type ProvisionOutcome =
 // Constants
 // ---------------------------------------------------------------------------
 
-const DEFAULT_CLOUD_BASE_URL = "https://www.elizacloud.ai";
+const DEFAULT_CLOUD_BASE_URL = "https://elizacloud.ai";
 const PROVISION_TIMEOUT_MS = 120_000; // 2 minutes
 const PROVISION_POLL_INTERVAL_MS = 3_000;
 

--- a/plugins/plugin-elizacloud/src/lib/cloud-connection.ts
+++ b/plugins/plugin-elizacloud/src/lib/cloud-connection.ts
@@ -19,7 +19,7 @@ import {
   scrubCloudSecretsFromEnv,
 } from "./cloud-secrets";
 
-const DEFAULT_CLOUD_API_BASE_URL = "https://www.elizacloud.ai/api/v1";
+const DEFAULT_CLOUD_API_BASE_URL = "https://elizacloud.ai/api/v1";
 export const CLOUD_BILLING_URL =
   "https://www.elizacloud.ai/dashboard/settings?tab=billing";
 

--- a/plugins/plugin-elizacloud/src/routes/cloud-status-routes-autonomous.ts
+++ b/plugins/plugin-elizacloud/src/routes/cloud-status-routes-autonomous.ts
@@ -13,7 +13,7 @@ import { resolveCloudApiBaseUrl as resolveCanonicalCloudApiBaseUrl } from "../cl
 import { resolveCloudApiKey } from "../cloud/cloud-api-key.js";
 import { validateCloudBaseUrl } from "../cloud/validate-url.js";
 
-const DEFAULT_CLOUD_API_BASE_URL = "https://www.elizacloud.ai/api/v1";
+const DEFAULT_CLOUD_API_BASE_URL = "https://elizacloud.ai/api/v1";
 const CLOUD_BILLING_URL =
   "https://www.elizacloud.ai/dashboard/settings?tab=billing";
 

--- a/plugins/plugin-elizacloud/src/types/cloud.ts
+++ b/plugins/plugin-elizacloud/src/types/cloud.ts
@@ -348,7 +348,7 @@ export interface CloudPluginConfig {
 
 export const DEFAULT_CLOUD_CONFIG: CloudPluginConfig = {
   enabled: false,
-  baseUrl: "https://www.elizacloud.ai/api/v1",
+  baseUrl: "https://elizacloud.ai/api/v1",
   inferenceMode: "cloud",
   autoProvision: false,
   bridge: {

--- a/plugins/plugin-elizacloud/src/utils/config.ts
+++ b/plugins/plugin-elizacloud/src/utils/config.ts
@@ -41,7 +41,7 @@ export function getBaseURL(runtime: IAgentRuntime): string {
   const baseURL = (
     isBrowser() && browserURL
       ? browserURL
-      : getSetting(runtime, "ELIZAOS_CLOUD_BASE_URL", "https://www.elizacloud.ai/api/v1")
+      : getSetting(runtime, "ELIZAOS_CLOUD_BASE_URL", "https://elizacloud.ai/api/v1")
   ) as string;
   return baseURL;
 }

--- a/plugins/plugin-streaming/src/core.ts
+++ b/plugins/plugin-streaming/src/core.ts
@@ -241,7 +241,7 @@ export function createStreamingDestination(
 
 // ── Cloud relay destination ────────────────────────────────────────────────
 
-const CLOUD_BASE_FALLBACK = "https://www.elizacloud.ai/api/v1";
+const CLOUD_BASE_FALLBACK = "https://elizacloud.ai/api/v1";
 
 function readSetting(runtime: IAgentRuntime, key: string): string | null {
   const raw = runtime.getSetting(key);

--- a/plugins/plugin-wallet/src/api/wallet-routes.ts
+++ b/plugins/plugin-wallet/src/api/wallet-routes.ts
@@ -1493,7 +1493,7 @@ export async function handleWalletRoutes(
     const apiKey = resolveCloudApiKey(config, ctx.runtime ?? null) ?? "";
     const baseUrl = cloud?.baseUrl
       ? normalizeCloudSiteUrl(cloud.baseUrl)
-      : "https://www.elizacloud.ai";
+      : "https://elizacloud.ai";
     if (!apiKey) {
       error(res, "Cloud not linked — sign in to Eliza Cloud first", 400);
       return true;

--- a/plugins/plugin-wallet/src/chains/evm/__tests__/integration/live-rpc.ts
+++ b/plugins/plugin-wallet/src/chains/evm/__tests__/integration/live-rpc.ts
@@ -23,7 +23,7 @@ for (const envPath of ENV_CANDIDATE_PATHS) {
 export const LIVE_EVM_RPC_TEST = process.env.ELIZA_LIVE_EVM_RPC_TEST === "1";
 
 export const ELIZA_CLOUD_BASE_URL = (
-  process.env.ELIZAOS_CLOUD_BASE_URL?.trim() || "https://www.elizacloud.ai/api/v1"
+  process.env.ELIZAOS_CLOUD_BASE_URL?.trim() || "https://elizacloud.ai/api/v1"
 ).replace(/\/$/, "");
 export const ELIZA_CLOUD_API_KEY = process.env.ELIZAOS_CLOUD_API_KEY?.trim() || "";
 export const HAS_ELIZA_CLOUD_RPC_KEY = ELIZA_CLOUD_API_KEY.length > 0;

--- a/plugins/plugin-wallet/src/chains/evm/rpc-providers.ts
+++ b/plugins/plugin-wallet/src/chains/evm/rpc-providers.ts
@@ -269,7 +269,7 @@ export function initRPCProviderManager(runtime: IAgentRuntime): RPCProviderManag
       const cloudBase =
         getStringSetting(runtime, "ELIZAOS_CLOUD_BASE_URL") ??
         (process.env.ELIZAOS_CLOUD_BASE_URL?.trim() || undefined) ??
-        "https://www.elizacloud.ai/api/v1";
+        "https://elizacloud.ai/api/v1";
       providers.push(createElizaCloudProvider(cloudKey, cloudBase));
     }
   }

--- a/plugins/plugin-wallet/src/chains/solana/service.ts
+++ b/plugins/plugin-wallet/src/chains/solana/service.ts
@@ -894,7 +894,7 @@ export class SolanaService extends Service {
     ) {
       const cloudBaseRaw = this.runtime.getSetting("ELIZAOS_CLOUD_BASE_URL");
       const cloudBase =
-        typeof cloudBaseRaw === "string" ? cloudBaseRaw : "https://www.elizacloud.ai/api/v1";
+        typeof cloudBaseRaw === "string" ? cloudBaseRaw : "https://elizacloud.ai/api/v1";
 
       return {
         baseUrl: `${cloudBase}/proxy/birdeye`,
@@ -947,7 +947,7 @@ export class SolanaService extends Service {
     ) {
       const cloudBaseRaw = runtime.getSetting("ELIZAOS_CLOUD_BASE_URL");
       const cloudBase =
-        typeof cloudBaseRaw === "string" ? cloudBaseRaw : "https://www.elizacloud.ai/api/v1";
+        typeof cloudBaseRaw === "string" ? cloudBaseRaw : "https://elizacloud.ai/api/v1";
       return `${cloudBase}/proxy/solana-rpc?api_key=${cloudKey}`;
     }
 


### PR DESCRIPTION
## Problem — every default-config authed cloud call is broken

The default cloud API base across the codebase is `https://www.elizacloud.ai/api/v1`. That host now **308-redirects to the apex** `https://elizacloud.ai/api/v1` — and `fetch`/undici **strips the `Authorization` header on a cross-origin redirect** (per the Fetch spec; `www.` → apex is a different origin). Net effect: every authenticated call made against the default base fails.

**Proven live** (same valid key, same endpoint):

```
POST https://www.elizacloud.ai/api/v1/generate-image  → 401 {"error":"Authentication required"}
POST https://elizacloud.ai/api/v1/generate-image      → past auth (5xx from the image backend — separate server issue)
```

A live agent on the default config surfaced this as *"Couldn't generate that image — the media generation API key is invalid or expired"* on every image call, with a **valid** key. The trap is nasty because the public `GET /models` returns 200 through the redirect either way (nothing to strip), so smoke tests pass while every authed route 401s.

The shared normalizer (`packages/shared/src/elizacloud/base-url.ts`) already declares the **apex** canonical (`DEFAULT_CLOUD_SITE_URL = "https://elizacloud.ai"`) and lists `www.elizacloud.ai` as a **legacy alias** — the scattered `www` defaults are stale copies that predate that decision.

## Fix

Sweep every runtime default to the apex (36 files, string-for-string):

- plugin-elizacloud: `cloud-connection`, `utils/config` (`getBaseURL` default), `types/cloud`, `cloud-setup`, autonomous status routes
- plugin-streaming core, plugin-wallet (solana service, evm rpc-providers, wallet-routes), plugin-agent-orchestrator (opencode-config, parent-agent-broker), plugin-cloud-apps client
- `packages/core/cloud-routing` fallback, `packages/shared` server-cloud-tts, app-core public-link-adapter, `packages/cloud/routing` resolve fallback, `packages/cloud/shared` config + docker-sandbox message + message-router
- `packages/ui`: `useCloudState` direct-cloud defaults, join-flow `resolve-cloud-connection`
- examples (edad, x402-image-gen, clone-ur-crush, capacitor) + the project template, so new users don't inherit the broken default

**Deliberately untouched:** host **alias lists** that recognize `www` as valid *input* (`base-url.ts`, `persistence.ts`, `cloud-agent-base.ts` — user-configured www URLs keep normalizing correctly), and dashboard **browser links** (`/dashboard/...` GET navigations redirect harmlessly).

## Tests

- `packages/core` cloud-routing 7/7 · `packages/cloud/routing` resolve 61/61 · app-core public-link-adapter 8/8 · `packages/ui` join/handoff suites 17/17 (fixtures that pinned the old default updated alongside).
- Typecheck clean: core, shared, plugin-elizacloud, ui.

Note for ops: the server should also 308 `www` → apex with `Preserve` semantics or serve the API on both hosts, but the client must not rely on auth surviving a cross-origin redirect regardless — apex-by-default is correct either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
