### PR TITLE
fix(lifeops): derive route actor from auth

### DIFF
--- a/.github/issue-evidence/10999-lifeops-route-actor-auth.md
+++ b/.github/issue-evidence/10999-lifeops-route-actor-auth.md
@@ -1,0 +1,36 @@
+# Issue 10999 - LifeOps Route Actor Auth
+
+## Summary
+
+LifeOps raw-route authorization no longer trusts client-supplied
+`x-eliza-entity-id` or `x-eliza-actor-entity-id` headers, and missing actor
+headers no longer default remote callers to the owner. Private LifeOps routes
+now first pass through app-core route authorization, then require a
+server-derived owner route role from trusted loopback access, configured owner
+token access, or an authenticated owner session resolved from the auth store.
+
+The existing `adminEntityId` route-context field remains a server-side owner
+identifier for handlers/UI projections; it is no longer used as an ambient
+request actor.
+
+## Verification
+
+- `bunx biome check plugins/plugin-personal-assistant/src/routes/plugin.ts plugins/plugin-personal-assistant/src/routes/plugin.test.ts`
+  - Passed.
+- `bun run --cwd plugins/plugin-personal-assistant test src/routes/plugin.test.ts`
+  - Passed: 1 file, 6 tests.
+
+## Blocked / N/A
+
+- `bun test plugins/plugin-personal-assistant/src/routes/plugin.test.ts`
+  - N/A as a validation command for this package: direct Bun test does not load
+    the plugin Vitest/workspace resolver and failed before tests on
+    `@elizaos/plugin-scheduling`.
+- `bun run --cwd plugins/plugin-personal-assistant typecheck`
+  - Blocked on current `develop` package/export drift outside this change,
+    including unresolved workspace subpaths such as
+    `@elizaos/plugin-calendar/routes/calendar-routes`,
+    `@elizaos/plugin-finances/finances-service`, and
+    `@elizaos/plugin-scheduling`.
+- Screenshots/video are N/A because this is a server-side route authorization
+  fix with no UI surface change.

--- a/packages/app-core/src/api/auth.ts
+++ b/packages/app-core/src/api/auth.ts
@@ -28,6 +28,12 @@ import { isTrustedLocalRequest } from "./compat-route-shared.js";
 import { sendJsonError } from "./response.js";
 
 export { tokenMatches } from "./auth/tokens.js";
+export {
+  type AuthContextSource,
+  type EnsureSessionOptions,
+  ensureSessionForRequest,
+  type ResolvedAuthContext,
+} from "./auth/auth-context.js";
 
 interface CompatStateLike {
   current:

--- a/plugins/plugin-personal-assistant/src/routes/plugin.test.ts
+++ b/plugins/plugin-personal-assistant/src/routes/plugin.test.ts
@@ -1,6 +1,37 @@
 import type http from "node:http";
+import { _resetAuthRateLimiter } from "@elizaos/app-core/api/auth";
 import type { AgentRuntime, Route } from "@elizaos/core";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lifeops/scheduled-task/service.js", () => ({
+  getScheduledTaskRunner: () => null,
+}));
+
+vi.mock("./entities.js", () => ({
+  handleEntityRoutes: async () => false,
+}));
+
+vi.mock("./lifeops-routes.js", () => ({
+  handleLifeOpsRoutes: async () => undefined,
+}));
+
+vi.mock("./relationships.js", () => ({
+  handleRelationshipRoutes: async () => false,
+}));
+
+vi.mock("./scheduled-tasks.js", () => ({
+  DEV_REGISTRIES_ROUTE_PATHS: [],
+  makeScheduledTasksRouteHandler: () => async () => false,
+}));
+
+vi.mock("./sleep-routes.js", () => ({
+  handleSleepRoutes: async () => undefined,
+}));
+
+vi.mock("./website-blocker-routes.js", () => ({
+  handleWebsiteBlockerRoutes: async () => undefined,
+}));
+
 import {
   personalAssistantRoutesPlugin,
   requireLifeOpsRouteOwnerAdminAccess,
@@ -15,11 +46,18 @@ type CapturedResponse = http.ServerResponse & {
 function createRequest(
   url: string,
   headers: http.IncomingHttpHeaders = {},
+  options: { method?: string; remoteAddress?: string; host?: string } = {},
 ): http.IncomingMessage {
   return {
-    method: "GET",
+    method: options.method ?? "GET",
     url,
-    headers,
+    headers: {
+      host: options.host ?? "example.test",
+      ...headers,
+    },
+    socket: {
+      remoteAddress: options.remoteAddress ?? "203.0.113.10",
+    },
   } as http.IncomingMessage;
 }
 
@@ -82,30 +120,81 @@ function findRoute(
 }
 
 describe("LifeOps raw route owner/admin gate", () => {
-  it("allows actors with an ADMIN role", async () => {
+  beforeEach(() => {
+    _resetAuthRateLimiter();
+    delete process.env.ELIZA_API_TOKEN;
+    delete process.env.ELIZA_REQUIRE_LOCAL_AUTH;
+  });
+
+  afterEach(() => {
+    _resetAuthRateLimiter();
+    delete process.env.ELIZA_API_TOKEN;
+    delete process.env.ELIZA_REQUIRE_LOCAL_AUTH;
+  });
+
+  it("allows configured owner bearer tokens without trusting actor headers", async () => {
+    process.env.ELIZA_API_TOKEN = "owner-token";
     const res = createResponse();
     const allowed = await requireLifeOpsRouteOwnerAdminAccess({
       req: createRequest("/api/lifeops/app-state", {
-        "x-eliza-entity-id": "admin-1",
+        authorization: "Bearer owner-token",
+        "x-eliza-entity-id": "spoofed-admin",
       }),
       res,
-      runtime: createRuntime({ roles: { "admin-1": "ADMIN" } }),
+      runtime: createRuntime({ roles: { "spoofed-admin": "GUEST" } }),
     });
 
     expect(allowed).toBe(true);
     expect(res.writableEnded).toBe(false);
   });
 
-  it("keeps existing local UI calls mapped to the default owner when no actor header is present", async () => {
+  it("allows trusted local UI calls without an actor header", async () => {
     const res = createResponse();
     const allowed = await requireLifeOpsRouteOwnerAdminAccess({
-      req: createRequest("/api/lifeops/app-state"),
+      req: createRequest(
+        "/api/lifeops/app-state",
+        {},
+        { remoteAddress: "127.0.0.1", host: "localhost:3000" },
+      ),
       res,
       runtime: createRuntime({ ownerId: null }),
     });
 
     expect(allowed).toBe(true);
     expect(res.writableEnded).toBe(false);
+  });
+
+  it("denies remote headerless raw routes instead of defaulting to owner", async () => {
+    const res = createResponse();
+    const runtime = createRuntime({ ownerId: null });
+    const allowed = await requireLifeOpsRouteOwnerAdminAccess({
+      req: createRequest("/api/lifeops/app-state"),
+      res,
+      runtime,
+    });
+
+    expect(allowed).toBe(false);
+    expect(runtime.getAllWorlds).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(JSON.parse(res.body)).toEqual({ error: "Unauthorized" });
+  });
+
+  it("denies spoofed actor headers even when they name the canonical owner", async () => {
+    const res = createResponse();
+    const runtime = createRuntime();
+    const allowed = await requireLifeOpsRouteOwnerAdminAccess({
+      req: createRequest("/api/lifeops/app-state", {
+        "x-eliza-entity-id": "owner-1",
+        "x-eliza-actor-entity-id": "owner-1",
+      }),
+      res,
+      runtime,
+    });
+
+    expect(allowed).toBe(false);
+    expect(runtime.getAllWorlds).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(JSON.parse(res.body)).toEqual({ error: "Unauthorized" });
   });
 
   it("denies private raw routes for explicit non-admin actors before the route handler runs", async () => {
@@ -120,9 +209,9 @@ describe("LifeOps raw route owner/admin gate", () => {
       createRuntime({ roles: { "user-1": "USER" } }) as never,
     );
 
-    expect(res.statusCode).toBe(403);
+    expect(res.statusCode).toBe(401);
     expect(JSON.parse(res.body)).toEqual({
-      error: "LifeOps routes require OWNER or ADMIN access",
+      error: "Unauthorized",
     });
   });
 

--- a/plugins/plugin-personal-assistant/src/routes/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/routes/plugin.ts
@@ -1,21 +1,26 @@
 import type http from "node:http";
 import { TLSSocket } from "node:tls";
 import { handleConnectorAccountRoutes } from "@elizaos/agent";
+import { AuthStore } from "@elizaos/app-core";
+import {
+  ensureRouteAuthorized,
+  ensureSessionForRequest,
+  getCompatApiToken,
+  getProvidedApiToken,
+  tokenMatches,
+} from "@elizaos/app-core/api/auth";
+import { isTrustedLocalRequest } from "@elizaos/app-core/api/compat-route-shared";
 import type {
   AgentRuntime,
   LegacyRouteHandler,
   Plugin,
-  RoleName,
-  RolesWorldMetadata,
   Route,
   UUID,
 } from "@elizaos/core";
 import {
   sendJson as httpSendJson,
   sendJsonError as httpSendJsonError,
-  ROLE_RANK,
   resolveCanonicalOwnerId,
-  resolveEntityRole,
   stringToUuid,
 } from "@elizaos/core";
 import { readJsonBody as httpReadJsonBody } from "@elizaos/shared";
@@ -93,49 +98,48 @@ function routeOwnerEntityId(runtime: AgentRuntime | null): UUID | null {
   return null;
 }
 
-function routeActorEntityId(
-  req: http.IncomingMessage,
-  runtime: AgentRuntime | null,
-): UUID | null {
-  const headerActor =
-    firstHeaderValue(req.headers["x-eliza-entity-id"]) ??
-    firstHeaderValue(req.headers["x-eliza-actor-entity-id"]);
-  if (headerActor) {
-    return headerActor as UUID;
-  }
-  return routeOwnerEntityId(runtime);
+function runtimeAuthDb(runtime: AgentRuntime): unknown {
+  return (runtime as { adapter?: { db?: unknown } | null }).adapter?.db;
 }
 
-async function resolveRouteActorRole(
-  runtime: AgentRuntime,
-  actorEntityId: UUID,
-): Promise<RoleName> {
-  const ownerEntityId = routeOwnerEntityId(runtime);
-  if (ownerEntityId && actorEntityId === ownerEntityId) {
-    return "OWNER";
+function hasConfiguredOwnerToken(req: http.IncomingMessage): boolean {
+  const expectedToken = getCompatApiToken();
+  const providedToken = getProvidedApiToken(req);
+  return Boolean(
+    expectedToken &&
+      providedToken &&
+      tokenMatches(expectedToken, providedToken),
+  );
+}
+
+async function requestHasOwnerRouteRole(args: {
+  req: http.IncomingMessage;
+  res: http.ServerResponse;
+  runtime: AgentRuntime;
+}): Promise<boolean> {
+  const { req, res, runtime } = args;
+  if (isTrustedLocalRequest(req)) {
+    return true;
   }
 
-  const worlds =
-    typeof runtime.getAllWorlds === "function"
-      ? await runtime.getAllWorlds()
-      : [];
-  let bestRole: RoleName = "GUEST";
-  for (const world of worlds) {
-    const metadata = (world.metadata ?? {}) as RolesWorldMetadata;
-    const role = await resolveEntityRole(
-      runtime,
-      world,
-      metadata,
-      actorEntityId,
-    );
-    if (ROLE_RANK[role] > ROLE_RANK[bestRole]) {
-      bestRole = role;
-    }
-    if (ROLE_RANK[bestRole] >= ROLE_RANK.ADMIN) {
-      return bestRole;
-    }
+  const db = runtimeAuthDb(runtime);
+  if (!db) {
+    return hasConfiguredOwnerToken(req);
   }
-  return bestRole;
+
+  if (
+    process.env.ELIZA_REQUIRE_LOCAL_AUTH === "1" &&
+    hasConfiguredOwnerToken(req)
+  ) {
+    return true;
+  }
+
+  const store = new AuthStore(db as ConstructorParameters<typeof AuthStore>[0]);
+  const context = await ensureSessionForRequest(req, res, {
+    store,
+    allowBootstrapBearer: false,
+  });
+  return context?.identity?.kind === "owner";
 }
 
 export async function requireLifeOpsRouteOwnerAdminAccess(args: {
@@ -149,15 +153,14 @@ export async function requireLifeOpsRouteOwnerAdminAccess(args: {
     return false;
   }
 
-  const actorEntityId = routeActorEntityId(req, runtime);
-  if (!actorEntityId) {
-    error(res, "LifeOps routes require OWNER or ADMIN access", 403);
-    return false;
-  }
-
   try {
-    const role = await resolveRouteActorRole(runtime, actorEntityId);
-    if (ROLE_RANK[role] >= ROLE_RANK.ADMIN) {
+    const authorized = await ensureRouteAuthorized(req, res, {
+      current: runtime,
+    });
+    if (!authorized) {
+      return false;
+    }
+    if (await requestHasOwnerRouteRole({ req, res, runtime })) {
       return true;
     }
   } catch {


### PR DESCRIPTION
## Summary
- Stops LifeOps raw-route auth from trusting client-supplied `x-eliza-entity-id` / `x-eliza-actor-entity-id` headers.
- Fails remote headerless requests closed through app-core route auth instead of defaulting them to the owner.
- Keeps trusted loopback and configured owner-token access, and derives owner session access through the auth store.
- Adds focused route-gate regression tests for spoofed owner headers, headerless remote requests, trusted local calls, owner-token calls, and public route bypass.

Fixes #10999.

## Verification
- `bunx biome check plugins/plugin-personal-assistant/src/routes/plugin.ts plugins/plugin-personal-assistant/src/routes/plugin.test.ts`
- `bun run --cwd plugins/plugin-personal-assistant test src/routes/plugin.test.ts`

## Evidence
- `.github/issue-evidence/10999-lifeops-route-actor-auth.md`

## Notes
- `bun run --cwd plugins/plugin-personal-assistant typecheck` is blocked on current `develop` workspace/export drift outside this patch; representative unresolved subpaths are listed in the evidence file.