### PR TITLE
test(cloud): real-PGlite proof the app-credit hold can't overspend + fix the handler-signature test regression (#10857 follow-up)

### DIFF
--- a/packages/cloud/api/__tests__/chat-completions-streaming-credit-leak.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-streaming-credit-leak.test.ts
@@ -121,7 +121,6 @@ function callStreaming(
     REQUEST,
     { id: USER, organization_id: ORG },
     null,
-    undefined,
     null,
     "idem-1",
     "req-1",

--- a/packages/cloud/shared/src/lib/services/__tests__/app-credit-hold-concurrency.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-credit-hold-concurrency.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Real-DB proof of the upfront app-credit hold (#10857, PR #10892).
+ *
+ * The bug: monetized `X-App-Id` inference did a read-only `checkBalance` and
+ * deferred the entire charge to a post-response reconcile, so N concurrent
+ * requests could all pass the advisory check and overspend the org balance
+ * (platform absorbs the loss). The fix routes the estimate through
+ * `appCreditsService.reserveInferenceCredits` → `deductCredits` →
+ * `creditsService.reserveAndDeductCredits` — the row-locked conditional debit.
+ *
+ * The unit suite (`app-credits-ledger.test.ts`) pins the wiring with a mocked
+ * `reserveAndDeductCredits`; it cannot prove the concurrency property. This
+ * suite drives the REAL `reserveInferenceCredits` against in-process PGlite
+ * (real Drizzle schema via `pushSchema`, same harness as
+ * `creator-earnings-idempotency.test.ts`) with NOTHING mocked on the money
+ * path, and asserts:
+ *
+ *   1. (ported from #10909) 8 concurrent $0.30 holds against a $1.00 balance:
+ *      exactly 3 win, the surplus 5 throw InsufficientCreditsError, the balance
+ *      never goes negative, and exactly 3 debit rows exist.
+ *   2. Settling a winner to zero (provider failure path) refunds the full hold.
+ *   3. The phase-suffixed idempotency keys (`:estimate` / `:reconcile`) mint
+ *      creator earnings exactly once per phase against the REAL redeemable-
+ *      earnings dedupe: the overage still pays (distinct key) and a settlement
+ *      retry does not double-credit (same key) — the property that subsumes
+ *      #10873's per-request earnings dedupe.
+ *
+ * Self-skips LOUDLY if PGlite/pushSchema is unavailable (never silently passes).
+ */
+
+import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
+
+const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
+const CAN_USE_ISOLATED_PGLITE =
+  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+// Stub the non-billing fire-and-forget side-effects the successful-debit path
+// kicks off (low-credit email / webhook / auto-top-up). These are downstream
+// notifications, NOT the code under test — the hold/refund/earnings SQL below
+// runs entirely real against PGlite. Mirrors credits-deduct-guard.test.ts.
+mock.module("../email", () => ({
+  emailService: {
+    sendLowCreditsEmail: mock(async () => false),
+  },
+}));
+mock.module("../waifu-webhook", () => ({
+  resolveWaifuWebhookTarget: mock(() => null),
+  classifyCreditBalance: mock(() => null),
+  emitWaifuCreditWebhook: mock(async () => undefined),
+}));
+mock.module("../auto-top-up", () => ({
+  autoTopUpService: {
+    executeAutoTopUp: mock(async () => undefined),
+  },
+}));
+
+import { pushSchema } from "drizzle-kit/api";
+import { and, eq } from "drizzle-orm";
+import type { App } from "../../../db/repositories/apps";
+import { appEarnings, appEarningsTransactions } from "../../../db/schemas/app-earnings";
+import { appDeploymentStatusEnum, apps, appUsers } from "../../../db/schemas/apps";
+import { creditTransactions } from "../../../db/schemas/credit-transactions";
+import { organizations } from "../../../db/schemas/organizations";
+import {
+  earningsSourceEnum,
+  ledgerEntryTypeEnum,
+  redeemableEarnings,
+  redeemableEarningsLedger,
+  redeemedEarningsTracking,
+} from "../../../db/schemas/redeemable-earnings";
+import { users } from "../../../db/schemas/users";
+
+const PGLITE_TIMEOUT = 60_000;
+let pgliteReady = true;
+
+let dbWrite: typeof import("../../../db/client").dbWrite;
+let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
+let appCreditsService: typeof import("../app-credits").appCreditsService;
+let InsufficientCreditsError: typeof import("../credits").InsufficientCreditsError;
+
+let seq = 0;
+function uniq(p: string): string {
+  seq += 1;
+  return `${p}-${seq}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function seedOrg(balance: string): Promise<string> {
+  const [org] = await dbWrite
+    .insert(organizations)
+    .values({ name: "Org", slug: uniq("org"), credit_balance: balance })
+    .returning();
+  return org.id;
+}
+
+async function seedUser(organizationId: string): Promise<string> {
+  const [user] = await dbWrite
+    .insert(users)
+    .values({ steward_user_id: uniq("steward"), organization_id: organizationId })
+    .returning();
+  return user.id;
+}
+
+async function seedApp(args: {
+  organizationId: string;
+  createdByUserId: string;
+  inferenceMarkupPercentage: number;
+}): Promise<App> {
+  const [app] = await dbWrite
+    .insert(apps)
+    .values({
+      name: uniq("app"),
+      slug: uniq("app"),
+      organization_id: args.organizationId,
+      created_by_user_id: args.createdByUserId,
+      app_url: "https://app.example.test",
+      monetization_enabled: true,
+      inference_markup_percentage: args.inferenceMarkupPercentage,
+      purchase_share_percentage: 0,
+      platform_offset_amount: 0,
+    })
+    .returning();
+  return app as App;
+}
+
+async function orgBalance(organizationId: string): Promise<number> {
+  const row = await dbWrite.query.organizations.findFirst({
+    where: eq(organizations.id, organizationId),
+  });
+  return Number(row?.credit_balance ?? Number.NaN);
+}
+
+async function orgTransactions(
+  organizationId: string,
+  type: string,
+): Promise<{ amount: number }[]> {
+  const rows = await dbWrite.query.creditTransactions.findMany({
+    where: and(
+      eq(creditTransactions.organization_id, organizationId),
+      eq(creditTransactions.type, type),
+    ),
+  });
+  return rows.map((r) => ({ amount: Number(r.amount) }));
+}
+
+async function creatorRedeemableBalance(userId: string): Promise<number> {
+  const row = await dbWrite.query.redeemableEarnings.findFirst({
+    where: eq(redeemableEarnings.user_id, userId),
+  });
+  return Number(row?.available_balance ?? 0);
+}
+
+async function creatorEarningLedgerCount(userId: string): Promise<number> {
+  const rows = await dbWrite.query.redeemableEarningsLedger.findMany({
+    where: and(
+      eq(redeemableEarningsLedger.user_id, userId),
+      eq(redeemableEarningsLedger.entry_type, "earning"),
+    ),
+  });
+  return rows.length;
+}
+
+beforeAll(async () => {
+  if (!CAN_USE_ISOLATED_PGLITE) {
+    pgliteReady = false;
+    console.warn(
+      "[app-credit-hold-concurrency.test] non-PGlite DATABASE_URL; self-skipping isolation suite.",
+    );
+    return;
+  }
+  try {
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
+    ({ appCreditsService } = await import("../app-credits"));
+    ({ InsufficientCreditsError } = await import("../credits"));
+
+    const schema = {
+      organizations,
+      users,
+      apps,
+      appUsers,
+      appEarnings,
+      appEarningsTransactions,
+      creditTransactions,
+      redeemableEarnings,
+      redeemableEarningsLedger,
+      redeemedEarningsTracking,
+      appDeploymentStatusEnum,
+      earningsSourceEnum,
+      ledgerEntryTypeEnum,
+    };
+    const { apply } = await pushSchema(schema as never, dbWrite as never);
+    await apply();
+  } catch (error) {
+    pgliteReady = false;
+    console.error(
+      "[app-credit-hold-concurrency.test] PGlite/pushSchema unavailable — skipping.",
+      error,
+    );
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
+describe("reserveInferenceCredits — real row-locked upfront hold (#10857)", () => {
+  test(
+    "(ported from #10909) 8 concurrent $0.30 holds on a $1.00 balance: exactly 3 win, 5 throw InsufficientCreditsError, balance never negative",
+    async () => {
+      if (!pgliteReady) return;
+
+      const payerOrgId = await seedOrg("1.000000");
+      const consumerId = await seedUser(payerOrgId);
+      const creatorOrgId = await seedOrg("0.000000");
+      const creatorId = await seedUser(creatorOrgId);
+      // 0% markup: each hold debits exactly the $0.30 estimate, so the
+      // affordability arithmetic below is exact.
+      const app = await seedApp({
+        organizationId: creatorOrgId,
+        createdByUserId: creatorId,
+        inferenceMarkupPercentage: 0,
+      });
+      // Pre-seed the app_users activity row: first-touch row creation is a
+      // separate (unique-index-guarded, compensated) seam; the property under
+      // test here is the money hold, and a returning user is the steady state.
+      await dbWrite.insert(appUsers).values({ app_id: app.id, user_id: consumerId });
+
+      const HOLD = 0.3;
+      const N = 8;
+
+      const results = await Promise.allSettled(
+        Array.from({ length: N }, (_, i) =>
+          appCreditsService.reserveInferenceCredits({
+            appId: app.id,
+            userId: consumerId,
+            estimatedBaseCost: HOLD,
+            description: `concurrent hold ${i}`,
+            idempotencyKey: `req-${i}`,
+            metadata: { model: "test-model" },
+            app,
+          }),
+        ),
+      );
+
+      const won = results.filter((r) => r.status === "fulfilled");
+      const lost = results.filter((r) => r.status === "rejected");
+
+      // Exactly floor(1.00 / 0.30) = 3 win; the surplus fail CLOSED with the
+      // typed error the routes translate to 429/402.
+      expect(won).toHaveLength(3);
+      expect(lost).toHaveLength(N - 3);
+      for (const rejection of lost) {
+        const error = (rejection as PromiseRejectedResult).reason;
+        expect(error).toBeInstanceOf(InsufficientCreditsError);
+        const typed = error as InstanceType<typeof InsufficientCreditsError>;
+        expect(typed.required).toBeCloseTo(HOLD, 6);
+        expect(typed.available).toBeLessThan(HOLD);
+        expect(typed.reason).toBe("insufficient_balance");
+      }
+
+      // The load-bearing invariant: the balance NEVER went negative, and equals
+      // exactly the 3 affordable holds — no overspend, no platform-absorbed loss.
+      const balance = await orgBalance(payerOrgId);
+      expect(balance).toBeGreaterThanOrEqual(0);
+      expect(balance).toBeCloseTo(1.0 - 3 * HOLD, 6);
+
+      // One debit row per successful hold — no phantom or duplicate debits.
+      const debits = await orgTransactions(payerOrgId, "debit");
+      expect(debits).toHaveLength(3);
+      for (const debit of debits) {
+        expect(debit.amount).toBeCloseTo(-HOLD, 6);
+      }
+
+      // Each winner carries a real reservation the routes settle through.
+      for (const winner of won) {
+        const reservation = (winner as PromiseFulfilledResult<{ reservedAmount: number }>).value;
+        expect(reservation.reservedAmount).toBeCloseTo(HOLD, 6);
+      }
+
+      // Provider-failure path: settling one winner to zero refunds its full
+      // hold back to the org balance (the routes' settle(0) on error/abort).
+      const first = won[0] as PromiseFulfilledResult<
+        Awaited<ReturnType<typeof appCreditsService.reserveInferenceCredits>>
+      >;
+      const settlement = await first.value.reconcile(0);
+      expect(settlement?.adjustmentType).toBe("refund");
+      expect(await orgBalance(payerOrgId)).toBeCloseTo(1.0 - 2 * HOLD, 6);
+      const refunds = await orgTransactions(payerOrgId, "refund");
+      expect(refunds).toHaveLength(1);
+      expect(refunds[0].amount).toBeCloseTo(HOLD, 6);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "phase-keyed creator earnings against the REAL dedupe: estimate and overage each mint once; a settlement retry does not double-credit",
+    async () => {
+      if (!pgliteReady) return;
+
+      const payerOrgId = await seedOrg("10.000000");
+      const consumerId = await seedUser(payerOrgId);
+      const creatorOrgId = await seedOrg("0.000000");
+      const creatorId = await seedUser(creatorOrgId);
+      const app = await seedApp({
+        organizationId: creatorOrgId,
+        createdByUserId: creatorId,
+        inferenceMarkupPercentage: 10,
+      });
+
+      // Upfront hold: $1 estimate + 10% markup = $1.10 debited; the creator's
+      // 10¢ markup mints under the `<key>:estimate` phase key.
+      const reservation = await appCreditsService.reserveInferenceCredits({
+        appId: app.id,
+        userId: consumerId,
+        estimatedBaseCost: 1,
+        description: "phase-key estimate",
+        idempotencyKey: "req-phase-1",
+        metadata: { model: "test-model" },
+        app,
+      });
+      expect(reservation.reservedAmount).toBeCloseTo(1.1, 6);
+      expect(await orgBalance(payerOrgId)).toBeCloseTo(8.9, 6);
+      expect(await creatorRedeemableBalance(creatorId)).toBeCloseTo(0.1, 6);
+      expect(await creatorEarningLedgerCount(creatorId)).toBe(1);
+
+      // Actual cost $2 → $1.10 overage charge. The overage markup mints under
+      // the DISTINCT `<key>:reconcile` phase key — if the phases shared a key,
+      // the real dedupe below would swallow this legitimate 10¢.
+      const overage = await reservation.reconcile(2);
+      expect(overage?.adjustmentType).toBe("overage");
+      expect(await orgBalance(payerOrgId)).toBeCloseTo(7.8, 6);
+      expect(await creatorRedeemableBalance(creatorId)).toBeCloseTo(0.2, 6);
+      expect(await creatorEarningLedgerCount(creatorId)).toBe(2);
+
+      // A reconcile retry for the SAME request (the #10423/#10873 double-credit
+      // shape) reuses the `:reconcile` key, so the REAL redeemable-earnings
+      // dedupe drops the duplicate mint. (The routes' idempotent settler already
+      // prevents the duplicate org charge; earnings idempotency is what the
+      // phase keys must guarantee at this layer.)
+      await reservation.reconcile(2);
+      expect(await creatorRedeemableBalance(creatorId)).toBeCloseTo(0.2, 6);
+      expect(await creatorEarningLedgerCount(creatorId)).toBe(2);
+    },
+    PGLITE_TIMEOUT,
+  );
+});

--- a/packages/cloud/shared/src/lib/services/__tests__/credits-deduct-guard.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/credits-deduct-guard.test.ts
@@ -249,6 +249,53 @@ describe("reserveAndDeductCredits — atomic debit", () => {
     },
     PGLITE_TIMEOUT,
   );
+
+  test(
+    "(concurrency #10857) N concurrent debits on a limited balance NEVER overspend — only affordable ones win, balance never goes negative",
+    async () => {
+      if (!pgliteReady) return;
+      // $1.00 balance, 8 concurrent $0.30 charges — only 3 can fit ($0.90).
+      // This is the exact race the monetized-app /v1/messages path hit with the
+      // old read-only checkBalance: all 8 passed the read → served → overspend,
+      // platform absorbing the loss (#10857). The atomic reserveAndDeductCredits
+      // it now uses (via reserveInferenceCredits) must serialize on the row and
+      // reject the surplus.
+      await seedOrg("1.000000");
+      const AMOUNT = 0.3;
+      const N = 8;
+
+      const results = await Promise.all(
+        Array.from({ length: N }, (_, i) =>
+          creditsService.reserveAndDeductCredits({
+            organizationId: ORG_ID,
+            amount: AMOUNT,
+            description: `concurrent charge ${i}`,
+            metadata: { user_id: USER_ID },
+          }),
+        ),
+      );
+
+      const succeeded = results.filter((r) => r.success);
+      const failed = results.filter((r) => !r.success);
+
+      // Exactly floor(1.00 / 0.30) = 3 win; the surplus fail CLOSED.
+      expect(succeeded).toHaveLength(3);
+      expect(failed).toHaveLength(N - 3);
+      for (const f of failed) {
+        expect(f.reason).toBe("insufficient_balance");
+      }
+
+      // The load-bearing invariant: balance NEVER went negative, and it equals
+      // exactly the 3 affordable debits — no overspend, no platform-absorbed loss.
+      const finalBalance = await readBalance();
+      expect(finalBalance).toBeGreaterThanOrEqual(0);
+      expect(finalBalance).toBeCloseTo(1.0 - 3 * AMOUNT, 6);
+
+      // One debit row per successful charge — no phantom or duplicate debits.
+      expect(await listDebits()).toHaveLength(3);
+    },
+    PGLITE_TIMEOUT,
+  );
 });
 
 describe("reserve() — high-level reservation gate", () => {


### PR DESCRIPTION
## What

Follow-up to #10892 (merged) closing the two gaps called out in review there (#10857):

1. **The concurrency property is now proven for real, not transitively.** #10892's unit suite mocks `reserveAndDeductCredits` (pins the wiring only). This PR ports the real-PGlite concurrency test from the closed #10909 and adapts it to the merged surface:
   - `credits-deduct-guard.test.ts` — verbatim #10909 port on the money primitive: 8 concurrent \$0.30 `reserveAndDeductCredits` debits against a \$1.00 balance → exactly 3 win, 5 fail closed with `insufficient_balance`, balance never negative, exactly 3 debit rows.
   - `app-credit-hold-concurrency.test.ts` (new) — drives the REAL `appCreditsService.reserveInferenceCredits` end-to-end against in-process PGlite (`pushSchema` of the real Drizzle schema — organizations/users/apps/app_users/credit_transactions/app_earnings/redeemable_earnings — **nothing mocked on the money path**):
     - 8 concurrent holds → exactly 3 win, 5 throw `InsufficientCreditsError` (the routes' 429/402 input), balance never negative, `settle(0)` refunds the full hold (provider-failure path).
     - the `:estimate` / `:reconcile` phase keys mint creator earnings exactly once per phase against the real redeemable-earnings dedupe: the overage still pays (distinct key) and a reconcile retry does not double-credit (same key) — the property that subsumes #10873's per-request earnings dedupe.

2. **Fixes a test regression #10892 landed on `develop`.** `chat-completions-streaming-credit-leak.test.ts` calls the exported `handleStreamingRequest` positionally and still passed the removed `appCreditsInfo` arg, shifting `30_000` into the settler slot — 3 of its 4 tests fail on current `develop` (`TypeError: settleReservation is not a function ('settleReservation' is 30000)`) and the file typechecks red. (#10892's worktree couldn't run cloud/api tests, so this was invisible there.) Dropping the stale arg restores 4/4 green and removes the typecheck error.

## Verification (all on `develop` tip cc911aa6a8c + this change)

```
packages/cloud/shared: bun test --isolate
  app-credit-hold-concurrency.test.ts + credits-deduct-guard.test.ts + app-credits-ledger.test.ts
  → 38 pass / 0 fail (189 assertions)
  creator-earnings-idempotency.test.ts + credits-reconcile.test.ts → 17 pass / 0 fail

packages/cloud/api: bun test --isolate
  chat-completions-streaming-credit-leak.test.ts (was 1 pass / 3 FAIL on develop)
  + messages-iac-fast-path + chat-completions-optimistic-billing + chat-completions-tool-choice
  → 29 pass / 0 fail

bunx biome check → clean (3 files)
bun run --cwd packages/cloud/shared typecheck → clean
bun run --cwd packages/cloud/api typecheck → only pre-existing develop errors
  (fal/proxy/route.ts, stripe-connect-webhook-route.test.ts, src/stubs/elizaos-core.ts);
  this PR removes the chat-completions-streaming-credit-leak.test.ts error develop has today
```

The concurrency suites run the real row-locked SQL against in-process PGlite and self-skip loudly if PGlite/`pushSchema` is unavailable (same harness as `creator-earnings-idempotency.test.ts`).

## Evidence

- Real domain artifacts asserted by the tests themselves: `credit_transactions` debit/refund rows, `organizations.credit_balance`, `redeemable_earnings` balances, and `redeemable_earnings_ledger` earning rows — all read back from the DB after the real service calls.
- UI screenshots/video: N/A — test-only change, no UI surface.
- Real-LLM trajectory: N/A — no agent/action/prompt/model behavior change; the model call is not on the tested money path.
- Migration: N/A — no schema change (tests push the existing schema into PGlite).

Refs #10857 · follow-up to #10892 · ports the test offered in #10909

🤖 Generated with [Claude Code](https://claude.com/claude-code)
