### PR TITLE
test(lifeops): un-orphan the src-level scheduler integration suite + fix the lane's core/node alias (#10723)

### DIFF
--- a/packages/test/vitest/integration.config.ts
+++ b/packages/test/vitest/integration.config.ts
@@ -39,6 +39,23 @@ const integrationResolveAlias: ModuleAlias[] = [
   ...getOptionalPluginSdkAliases(repoRoot),
   ...(elizaCoreEntry
     ? [
+        // The string alias below prefix-matches subpath imports, so
+        // "@elizaos/core/node" would otherwise rewrite to
+        // "<core entry file>/node" (ENOTDIR). Pin the /node subpath to the
+        // node entry first — same fix plugin-personal-assistant's own
+        // vitest.config.ts carries. Without it this lane cannot load the
+        // personal-assistant plugin graph (plugin-calendly's dist imports
+        // "@elizaos/core/node").
+        {
+          find: /^@elizaos\/core\/node$/,
+          replacement: path.join(
+            elizaWorkspaceRoot,
+            "packages",
+            "core",
+            "src",
+            "index.node.ts",
+          ),
+        },
         {
           find: "@elizaos/core",
           replacement: elizaCoreEntry,
@@ -135,6 +152,15 @@ export default defineConfig({
       // them now so the existing coverage runs.
       "eliza/plugins/plugin-personal-assistant/test/**/*.integration.test.ts",
       "eliza/plugins/*/test/**/*.integration.test.ts",
+      // Src-level plugin integration tests were dead the same way: the
+      // scheduler suite at plugin-personal-assistant/src/lifeops/
+      // scheduled-task/scheduler.integration.test.ts (10 real-DB tests of the
+      // production processDueScheduledTasks wiring) matched neither the
+      // plugin's unit lane (integration suffix excluded) nor the test/**
+      // globs above — vitest reported "No test files found" even when the
+      // file was passed explicitly. Include src/** so the suite runs.
+      "eliza/plugins/plugin-personal-assistant/src/**/*.integration.test.ts",
+      "eliza/plugins/*/src/**/*.integration.test.ts",
     ],
     setupFiles: ["eliza/packages/app-core/test/setup.ts"],
     exclude: [

--- a/plugins/plugin-personal-assistant/package.json
+++ b/plugins/plugin-personal-assistant/package.json
@@ -49,7 +49,7 @@
     "test": "vitest run --config vitest.config.ts",
     "test:app-state": "vitest run --config vitest.config.ts eliza/plugins/plugin-personal-assistant/test/lifeops-app-state.test.ts",
     "test:background-real": "vitest run --config vitest.background-real.config.ts test/scheduled-task-end-to-end.e2e.test.ts test/reminder-review-job.real.e2e.test.ts test/lifeops-scheduling.real.test.ts test/schedule-merged-state.real.test.ts",
-    "test:integration": "cd ../../.. && vitest run --config eliza/packages/test/vitest/integration.config.ts eliza/plugins/plugin-personal-assistant/test/life-smoke.integration.test.ts eliza/plugins/plugin-personal-assistant/test/owner-agent-permission-matrix.integration.test.ts",
+    "test:integration": "cd ../../.. && vitest run --config eliza/packages/test/vitest/integration.config.ts eliza/plugins/plugin-personal-assistant/test/life-smoke.integration.test.ts eliza/plugins/plugin-personal-assistant/test/owner-agent-permission-matrix.integration.test.ts eliza/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.integration.test.ts",
     "test:scenarios": "cd ../.. && bun packages/scenario-runner/src/cli.ts list plugins/plugin-personal-assistant/test/scenarios",
     "bench:work-threads": "cd ../.. && bun plugins/plugin-personal-assistant/scripts/work-thread-benchmark.ts",
     "verify:live-schedule": "bun run ./scripts/verify-live-schedule-data.ts",


### PR DESCRIPTION
## What & why

Follow-up to #10965 (scheduler fire-budget fix), which flagged that `plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.integration.test.ts` — **10 real-DB tests of the production `processDueScheduledTasks` wiring** — is **orphaned**: the plugin's unit lane excludes the `.integration.` suffix (even for explicitly-passed files → "No test files found"), and the root integration config only had `test/**` globs. The config's own header comment documents fixing this exact gap class before for `test/**` files; this extends it to `src/**`.

## Changes

1. **`packages/test/vitest/integration.config.ts`** — add `eliza/plugins/plugin-personal-assistant/src/**/*.integration.test.ts` + `eliza/plugins/*/src/**/*.integration.test.ts` to the include (comment matches the existing precedent).
2. **Same file — a second load-bearing fix found while verifying:** the `@elizaos/core` **string** alias prefix-matches subpath imports, so `@elizaos/core/node` rewrote to `"<core entry>/node"` (**ENOTDIR**) — which broke the **whole lane** (including the two pre-existing `test/**` files) in any fully-built checkout (`plugin.ts → @elizaos/plugin-calendly dist → import "@elizaos/core/node"`). Pinned `/^@elizaos\/core\/node$/` to `index.node.ts` ahead of the string alias — the same fix the plugin's own `vitest.config.ts` already carries. **Proven**: `life-smoke.integration.test.ts` failed identically pre-fix, passes post-fix.
3. **`plugins/plugin-personal-assistant/package.json`** — append the scheduler suite to `test:integration`.

## Verification (real runs, correct layout)

Executed through the lane's expected layout (repo mounted as `eliza/` inside a parent):
- scheduler suite: **10/10 passed** (~83 s, real PGlite).
- pre-existing files: `life-smoke` **14 passed**; `owner-agent-permission-matrix` 1 skipped **by its own documented env gate** (unchanged).
- **Fail-without-fix proven**: on the original config the same invocation prints `No test files found, exiting with code 1`.
- Glob-risk check: 3 other src-level integration files exist (app-control / local-inference / video) — all env- or availability-gated, and this config's **only** consumer passes explicit file filters, so the broad glob cannot turn any existing invocation red.

## Follow-up worth noting (not this PR)

`run-all-tests.mjs --only=test` (the default PR gate via `test:server`/`test:client`) returns early before `EXTRA_SCRIPT_NAMES`, so **`test:integration` only runs via `test:all` / `test:ci:live` / direct invocation — it is not wired into any workflow yml**. The lane is now correct and complete; wiring it into a CI workflow is a separate operator/infra decision.

**Android/visual: N/A** — test-lane wiring. **Real-LLM: N/A.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
