### PR TITLE
fix(orchestrator): don't label a prose-mentioned URL as a probe-verified deploy

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/auto-verify-completion-evidence.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/auto-verify-completion-evidence.test.ts
@@ -189,8 +189,11 @@ describe("auto-verify completion evidence pipeline", () => {
     expect(prompt).toContain("Added caching and verified it works.");
     expect(prompt).toContain("## TEST / BUILD / TYPECHECK OUTPUT");
     expect(prompt).toContain("Tests  8 passed (8)");
-    expect(prompt).toContain("## VERIFIED URLS");
+    // The URL is only MENTIONED in the sub-agent's stdout (no router probe ran),
+    // so it is surfaced as an unproven claim — never as a probe-verified deploy.
+    expect(prompt).toContain("## CLAIMED URLS");
     expect(prompt).toContain("https://app.example.com");
+    expect(prompt).not.toContain("## VERIFIED URLS");
   });
 
   it("falls back to the bare summary when no richer evidence exists", async () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/completion-evidence-bundle.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/completion-evidence-bundle.test.ts
@@ -257,6 +257,46 @@ describe("completion-evidence bundle assembly + trajectory persistence", () => {
     expect(prompt).toContain("completion-evidence.jsonl");
   });
 
+  it("does NOT label a URL merely mentioned in prose as verified", async () => {
+    const acp = new BundleFakeAcp(workdir);
+    const prompts: string[] = [];
+    const service = new OrchestratorTaskService(
+      runtime(acp, async (_modelType, params) => {
+        prompts.push((params as { prompt: string }).prompt);
+        return '{"passed": false, "summary": "unverified", "missing": ["live"]}';
+      }),
+      { store: new OrchestratorTaskStore({ backend: "memory" }) },
+    );
+    await service.start();
+
+    const task = await service.createTask({
+      title: "Ship the landing page",
+      goal: "Build and deploy the landing page",
+      acceptanceCriteria: ["the live URL returns HTTP 200"],
+    });
+    const detail = await service.spawnAgentForTask(task.id);
+    const sessionId = detail?.sessions[0]?.sessionId;
+    if (!sessionId) throw new Error("expected a spawned session");
+
+    // A sub-agent that CLAIMS a deploy in prose — no router URL probe ran, so
+    // `subAgentVerifiedUrls` metadata is absent.
+    acp.emit(sessionId, "task_complete", {
+      response:
+        "Done — deployed to https://claimed-but-not-probed.example.com/",
+    });
+    await flush();
+    await flush();
+
+    expect(prompts).toHaveLength(1);
+    const [prompt] = prompts;
+    // The URL is surfaced, but explicitly as an unproven claim...
+    expect(prompt).toContain("## CLAIMED URLS");
+    expect(prompt).toContain("NOT probe-verified");
+    expect(prompt).toContain("https://claimed-but-not-probed.example.com/");
+    // ...and NEVER under the probe-verified header.
+    expect(prompt).not.toContain("## VERIFIED URLS");
+  });
+
   it("writes the bundle as a JSONL line and records its path on a task event", async () => {
     const acp = new BundleFakeAcp(workdir);
     const service = new OrchestratorTaskService(

--- a/plugins/plugin-agent-orchestrator/src/services/completion-evidence.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/completion-evidence.ts
@@ -105,6 +105,10 @@ export interface CompletionEvidenceBundle {
   toolOutput?: ToolOutputEvidence;
   /** URLs the router probed/verified at completion (loopback-flagged on render). */
   verifiedUrls: string[];
+  /** URLs the sub-agent merely MENTIONED in prose (never probed). Rendered in a
+   *  distinct, explicitly-unverified section so the judge can not mistake a
+   *  claimed link for a reachable deploy. */
+  mentionedUrls?: string[];
   /** Screenshot artifact paths found on the task/session. */
   screenshots: string[];
   /** Path to the persisted trajectory JSONL artifact for this completion. */
@@ -275,6 +279,25 @@ function renderUrlsSection(urls: readonly string[]): string {
   return lines.join("\n");
 }
 
+/** Render URLs the sub-agent only claimed, under a header that makes their
+ *  UN-verified status explicit — so the judge treats a pasted link as a claim,
+ *  not as proof of a reachable deploy. */
+function renderMentionedUrlsSection(urls: readonly string[]): string {
+  const unique = [...new Set(urls.map((u) => u.trim()).filter(Boolean))].slice(
+    0,
+    MAX_URLS,
+  );
+  const lines = [
+    "## CLAIMED URLS (mentioned by the sub-agent — NOT probe-verified; treat as an unproven claim)",
+  ];
+  for (const url of unique) {
+    lines.push(
+      `- ${url}${isLoopbackUrl(url) ? " (LOOPBACK — not publicly reachable)" : ""}`,
+    );
+  }
+  return lines.join("\n");
+}
+
 function renderArtifactsSection(
   artifacts: readonly EvidenceArtifactRef[],
 ): string {
@@ -349,6 +372,16 @@ export function buildCompletionEvidenceString(
   if (bundle.verifiedUrls.length > 0) {
     sections.push(renderUrlsSection(bundle.verifiedUrls));
     hasRicherSection = true;
+  }
+
+  // Claimed-but-unverified URLs are informational only — surfaced so the judge
+  // sees them, but explicitly NOT counted as "richer" evidence (a pasted link
+  // is not proof), unlike a probe-verified URL above.
+  const mentioned = (bundle.mentionedUrls ?? []).filter(
+    (url) => !bundle.verifiedUrls.includes(url),
+  );
+  if (mentioned.length > 0) {
+    sections.push(renderMentionedUrlsSection(mentioned));
   }
 
   if (bundle.toolOutput && hasToolOutput(bundle.toolOutput)) {

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -994,8 +994,11 @@ export class OrchestratorTaskService extends Service {
    *    and `mirrorChangeSetToStore` use, rendered with {@link renderChangeSetBody};
    *  - `toolOutput` — test/build/lint stdout mined from recorded `tool_running`
    *    events (and sub-agent messages) and classified by {@link classifyToolOutput};
-   *  - `verifiedUrls` — URLs probed at completion (session/task `subAgentVerifiedUrls`
-   *    metadata plus URLs mined from the summary and sub-agent replies);
+   *  - `verifiedUrls` — ONLY URLs the router actually probed at completion
+   *    (session/task `subAgentVerifiedUrls` metadata); URLs merely mentioned in
+   *    the summary / sub-agent replies go to `mentionedUrls`, rendered as an
+   *    explicitly-unverified claim so a written "deployed to https://…" cannot
+   *    masquerade as a probe-verified deploy;
    *  - `screenshots` — screenshot artifact paths on the task/session.
    *
    * Pure with respect to throwing: returns at least the summary on any error.
@@ -1055,11 +1058,20 @@ export class OrchestratorTaskService extends Service {
     ];
     const toolOutput = classifyToolOutput(toolSignals);
 
+    // ONLY router-probed URLs are "verified". URLs merely mined from the
+    // sub-agent's prose are claims, not proof, and must not be labelled verified
+    // to the judge (a sub-agent could otherwise pass by writing "deployed to
+    // https://…"). They are surfaced separately as `mentionedUrls`.
     const verifiedUrls = [
-      ...new Set([
-        ...this.metadataVerifiedUrls(doc, sessionId),
-        ...collectUrls([summary, ...subAgentReplies]),
-      ]),
+      ...new Set(this.metadataVerifiedUrls(doc, sessionId)),
+    ];
+    const verifiedSet = new Set(verifiedUrls);
+    const mentionedUrls = [
+      ...new Set(
+        collectUrls([summary, ...subAgentReplies]).filter(
+          (url) => !verifiedSet.has(url),
+        ),
+      ),
     ];
 
     const screenshots = this.collectArtifactRefs(doc, sessionId).flatMap(
@@ -1071,6 +1083,7 @@ export class OrchestratorTaskService extends Service {
       diffSummary,
       toolOutput,
       verifiedUrls,
+      mentionedUrls,
       screenshots: [...new Set(screenshots)],
     };
   }


### PR DESCRIPTION
## Summary

The completion-evidence assembler mislabeled unverified URLs as verified proof — a completion-LARP vector the verification gate exists to stop.

`collectEvidenceBundle` (orchestrator-task-service.ts) merged URLs **regex-mined from the sub-agent's free-text** summary/replies (`collectUrls([summary, ...])`) into the `verifiedUrls` field. That field renders under **`## VERIFIED URLS (probed at completion)`** and is fed to the LLM judge as proof of a reachable deploy. So a sub-agent could satisfy a *"the live URL returns HTTP 200"* criterion by simply writing **"deployed to https://myapp.example.com"** — no probe ever ran. The field's own docstring admitted it mixed probed + mined URLs.

## Fix

- `verifiedUrls` now contains **only** router-probed URLs (`subAgentVerifiedUrls` metadata, set by the router's real reachability check).
- Prose-mined URLs go to a new `mentionedUrls` field, rendered in a distinct, explicitly-unverified section:
  `## CLAIMED URLS (mentioned by the sub-agent — NOT probe-verified; treat as an unproven claim)`
  and **not** counted as "richer" evidence. The judge still sees them, but can't mistake a written link for a verified deploy.

## Tests

- New `completion-evidence-bundle` case: a mentioned-only URL renders under **CLAIMED URLS**, never **VERIFIED URLS**.
- Updated `auto-verify-completion-evidence` (which had asserted the old mislabeling of a prose URL under VERIFIED URLS → now asserts CLAIMED URLS).
- `completion-evidence` direct-render path (genuinely-probed URLs) unchanged.

```
Test Files  3 passed (3)
     Tests  19 passed (19)
```

Part of the orchestrator "text-eval / larp in verification" hardening pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)