### PR TITLE
fix(orchestrator): persist ACP sessions via runtime DB

### DIFF
--- a/.github/issue-evidence/10991-acp-session-runtime-db.md
+++ b/.github/issue-evidence/10991-acp-session-runtime-db.md
@@ -1,0 +1,30 @@
+# Issue 10991 - ACP Session Runtime DB
+
+## Summary
+
+`AcpSessionStore` now prefers the modern `runtime.adapter` property and falls
+back to legacy `runtime.databaseAdapter`, matching the runtime shape used by
+current elizaOS agents. The runtime DB backend also recognizes the eliza
+`BaseDrizzleAdapter` shape (`adapter.db.execute`) in addition to older raw SQL
+adapters.
+
+The SQL backend now routes all reads/writes through a small executor abstraction
+and uses portable `INSERT ... ON CONFLICT (id) DO UPDATE` upserts instead of
+SQLite-only `INSERT OR REPLACE`, so the runtime DB path works for pglite,
+Postgres, and modern SQLite.
+
+## Verification
+
+- `bunx biome check plugins/plugin-agent-orchestrator/src/services/session-store.ts plugins/plugin-agent-orchestrator/src/services/acp-service.ts plugins/plugin-agent-orchestrator/src/services/types.ts plugins/plugin-agent-orchestrator/__tests__/unit/session-store.test.ts`
+  - Passed.
+- `bunx vitest run --config vitest.config.ts __tests__/unit/session-store.test.ts`
+  - Passed from `plugins/plugin-agent-orchestrator`: 1 file, 15 tests.
+- `bun run --cwd plugins/plugin-agent-orchestrator typecheck`
+  - Passed.
+
+## Blocked / N/A
+
+- A live ACP restart trajectory is N/A in this worktree because no live acpx
+  subprocess/runtime container was running. The unit coverage exercises modern
+  adapter selection, eliza drizzle-shaped adapter writes, legacy fallback, and
+  portable upsert SQL.

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/session-store.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/session-store.test.ts
@@ -259,6 +259,46 @@ describe("AcpSessionStore", () => {
     expect(store.backend).toBe("runtime-db");
   });
 
+  it("selects the modern runtime.adapter DB backend", () => {
+    const adapter = { query: vi.fn() };
+    const store = new AcpSessionStore({
+      runtime: { adapter },
+    });
+    expect(store.backend).toBe("runtime-db");
+  });
+
+  it("recognizes and writes through eliza drizzle-shaped runtime adapters", async () => {
+    const execute = vi.fn(async () => ({ rows: [] }));
+    const adapter = { db: { execute } };
+    const store = new AcpSessionStore({
+      runtime: { adapter },
+    });
+    expect(store.backend).toBe("runtime-db");
+
+    await store.create(session());
+
+    expect(execute).toHaveBeenCalled();
+  });
+
+  it("prefers runtime.adapter over legacy databaseAdapter and uses portable upsert", async () => {
+    const modern = { query: vi.fn(async () => []) };
+    const legacy = { query: vi.fn(async () => []) };
+    const store = new AcpSessionStore({
+      runtime: { adapter: modern, databaseAdapter: legacy },
+    });
+
+    await store.create(session());
+
+    expect(modern.query).toHaveBeenCalled();
+    expect(legacy.query).not.toHaveBeenCalled();
+    const sqlText = modern.query.mock.calls
+      .map(([sql]) => String(sql))
+      .join("\n");
+    expect(sqlText).toContain("INSERT INTO acp_sessions");
+    expect(sqlText).toContain("ON CONFLICT (id) DO UPDATE SET");
+    expect(sqlText).not.toContain("INSERT OR REPLACE");
+  });
+
   it("selects explicit in-memory backend and warns", () => {
     const logger = { warn: vi.fn() };
     const store = new AcpSessionStore({

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -53,6 +53,7 @@ type RuntimeLike = IAgentRuntime & {
     >
   >;
   services?: Map<string, unknown[]>;
+  adapter?: unknown;
   databaseAdapter?: unknown;
   getSetting?: (key: string) => string | undefined | null;
 };
@@ -2899,6 +2900,7 @@ function boolSetting(value: string | undefined): boolean | undefined {
 
 function createDefaultSessionStore(runtime: RuntimeLike): SessionStore {
   const runtimeForStore = {
+    adapter: runtime.adapter,
     databaseAdapter: runtime.databaseAdapter,
     logger: runtime.logger,
     getSetting: (key: string) => {

--- a/plugins/plugin-agent-orchestrator/src/services/session-store.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/session-store.ts
@@ -24,7 +24,7 @@ type Logger = NonNullable<SessionStoreRuntime["logger"]>;
 const FILE_LOCK_ACQUIRE_TIMEOUT_MS = 30_000;
 const FILE_LOCK_STALE_MS = 30_000;
 
-type SqlDatabaseAdapter = {
+type RawSqlDatabaseAdapter = {
   query?: (sql: string, params?: unknown[]) => Promise<unknown> | unknown;
   execute?: (sql: string, params?: unknown[]) => Promise<unknown> | unknown;
   run?: (sql: string, params?: unknown[]) => Promise<unknown> | unknown;
@@ -32,6 +32,17 @@ type SqlDatabaseAdapter = {
   get?: (sql: string, params?: unknown[]) => Promise<unknown> | unknown;
   select?: (sql: string, params?: unknown[]) => Promise<unknown[]> | unknown[];
 };
+
+type ElizaDrizzleAdapter = {
+  db: {
+    execute: (query: unknown) => Promise<unknown> | unknown;
+  };
+};
+
+interface SqlExecutor {
+  run(sql: string, params?: unknown[]): Promise<void>;
+  all(sql: string, params?: unknown[]): Promise<unknown[]>;
+}
 
 type StoredSession = Omit<SessionInfo, "createdAt" | "lastActivityAt"> & {
   createdAt: string;
@@ -129,11 +140,25 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
-function isSqlDatabaseAdapter(value: unknown): value is SqlDatabaseAdapter {
+function isRawSqlDatabaseAdapter(
+  value: unknown,
+): value is RawSqlDatabaseAdapter {
   if (!isRecord(value)) return false;
   return ["query", "execute", "run", "all", "get", "select"].some(
     (method) => typeof value[method] === "function",
   );
+}
+
+function isElizaDrizzleAdapter(value: unknown): value is ElizaDrizzleAdapter {
+  if (!isRecord(value)) return false;
+  const db = value.db;
+  return isRecord(db) && typeof db.execute === "function";
+}
+
+function isPersistableAdapter(
+  value: unknown,
+): value is RawSqlDatabaseAdapter | ElizaDrizzleAdapter {
+  return isRawSqlDatabaseAdapter(value) || isElizaDrizzleAdapter(value);
 }
 
 function normalizeRows(result: unknown): unknown[] {
@@ -144,6 +169,68 @@ function normalizeRows(result: unknown): unknown[] {
     if (Array.isArray(value)) return value;
   }
   return [];
+}
+
+async function resolveSqlExecutor(
+  adapter: RawSqlDatabaseAdapter | ElizaDrizzleAdapter,
+): Promise<SqlExecutor> {
+  if (isElizaDrizzleAdapter(adapter)) {
+    const drizzle = (await import("drizzle-orm")) as {
+      sql: {
+        raw(text: string): unknown;
+        param(value: unknown): unknown;
+        join(chunks: unknown[], separator?: unknown): unknown;
+      };
+    };
+    const buildQuery = (text: string, params: unknown[] = []): unknown => {
+      if (params.length === 0) return drizzle.sql.raw(text);
+      const parts = text.split("?");
+      if (parts.length - 1 !== params.length) {
+        throw new Error(
+          `acpx SessionStore SQL placeholder mismatch: ${
+            parts.length - 1
+          } placeholders for ${params.length} params`,
+        );
+      }
+      const chunks: unknown[] = [];
+      for (let i = 0; i < parts.length; i++) {
+        chunks.push(drizzle.sql.raw(parts[i]));
+        if (i < params.length) chunks.push(drizzle.sql.param(params[i]));
+      }
+      return drizzle.sql.join(chunks);
+    };
+    return {
+      async run(text, params) {
+        await adapter.db.execute(buildQuery(text, params));
+      },
+      async all(text, params) {
+        return normalizeRows(
+          await adapter.db.execute(buildQuery(text, params)),
+        );
+      },
+    };
+  }
+
+  const runFn = adapter.execute ?? adapter.run ?? adapter.query;
+  const allFn = adapter.all ?? adapter.select ?? adapter.query;
+  if (!runFn) {
+    throw new Error(
+      "acpx SessionStore raw adapter exposes none of execute, run, or query",
+    );
+  }
+  if (!allFn) {
+    throw new Error(
+      "acpx SessionStore raw adapter exposes none of all, select, or query",
+    );
+  }
+  return {
+    async run(text, params = []) {
+      await runFn.call(adapter, text, params);
+    },
+    async all(text, params = []) {
+      return normalizeRows(await allFn.call(adapter, text, params));
+    },
+  };
 }
 
 function rowToSession(row: unknown): SessionInfo {
@@ -501,9 +588,10 @@ export class FileSessionStore extends InMemorySessionStore {
 export class RuntimeDbSessionStore implements SessionStore {
   private readonly writes = new WriteQueue();
   private initPromise: Promise<void> | undefined;
+  private executor: SqlExecutor | undefined;
 
   constructor(
-    private readonly adapter: SqlDatabaseAdapter,
+    private readonly adapter: RawSqlDatabaseAdapter | ElizaDrizzleAdapter,
     private readonly logger?: Logger,
   ) {
     void this.logger;
@@ -620,41 +708,55 @@ export class RuntimeDbSessionStore implements SessionStore {
 
   private async ensureInitialized(): Promise<void> {
     this.initPromise ??= (async () => {
-      await this.execute(SESSION_TABLE_SQL);
-      for (const sql of SESSION_INDEX_SQL) await this.execute(sql);
+      this.executor = await resolveSqlExecutor(this.adapter);
+      await this.executor.run(SESSION_TABLE_SQL);
+      for (const sql of SESSION_INDEX_SQL) await this.executor.run(sql);
     })();
     await this.initPromise;
   }
 
+  private exec(): SqlExecutor {
+    if (!this.executor) {
+      throw new Error(
+        "acpx SessionStore executor accessed before initialization",
+      );
+    }
+    return this.executor;
+  }
+
   private async upsert(session: SessionInfo): Promise<void> {
     await this.execute(
-      `INSERT OR REPLACE INTO acp_sessions (
+      `INSERT INTO acp_sessions (
         id, name, agent_type, workdir, status, acpx_record_id, acpx_session_id, agent_session_id,
         pid, approval_preset, created_at, last_activity_at, last_error, metadata
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT (id) DO UPDATE SET
+        name = excluded.name,
+        agent_type = excluded.agent_type,
+        workdir = excluded.workdir,
+        status = excluded.status,
+        acpx_record_id = excluded.acpx_record_id,
+        acpx_session_id = excluded.acpx_session_id,
+        agent_session_id = excluded.agent_session_id,
+        pid = excluded.pid,
+        approval_preset = excluded.approval_preset,
+        created_at = excluded.created_at,
+        last_activity_at = excluded.last_activity_at,
+        last_error = excluded.last_error,
+        metadata = excluded.metadata`,
       sessionToParams(session),
     );
   }
 
-  private async execute(sql: string, params: unknown[] = []): Promise<unknown> {
-    const fn = this.adapter.execute ?? this.adapter.run ?? this.adapter.query;
-    if (!fn)
-      throw new Error(
-        "Runtime database adapter does not expose execute, run, or query",
-      );
-    return fn.call(this.adapter, sql, params);
+  private async execute(sql: string, params: unknown[] = []): Promise<void> {
+    await this.exec().run(sql, params);
   }
 
   private async getMany(
     sql: string,
     params: unknown[],
   ): Promise<SessionInfo[]> {
-    const fn = this.adapter.all ?? this.adapter.select ?? this.adapter.query;
-    if (!fn)
-      throw new Error(
-        "Runtime database adapter does not expose all, select, or query",
-      );
-    const rows = normalizeRows(await fn.call(this.adapter, sql, params));
+    const rows = await this.exec().all(sql, params);
     return rows.map(rowToSession);
   }
 
@@ -662,10 +764,6 @@ export class RuntimeDbSessionStore implements SessionStore {
     sql: string,
     params: unknown[],
   ): Promise<SessionInfo | null> {
-    if (this.adapter.get) {
-      const row = await this.adapter.get.call(this.adapter, sql, params);
-      return row ? rowToSession(row) : null;
-    }
     const [row] = await this.getMany(sql, params);
     return row;
   }
@@ -682,11 +780,12 @@ export class AcpSessionStore implements SessionStore {
   private readonly delegate: SessionStore;
 
   constructor(options: AcpSessionStoreOptions = {}) {
-    const adapter = options.runtime?.databaseAdapter;
+    const adapter =
+      options.runtime?.adapter ?? options.runtime?.databaseAdapter;
     const logger = options.runtime?.logger;
     if (
       (options.backend === undefined || options.backend === "runtime-db") &&
-      isSqlDatabaseAdapter(adapter)
+      isPersistableAdapter(adapter)
     ) {
       this.backend = "runtime-db";
       this.delegate = new RuntimeDbSessionStore(adapter, logger);

--- a/plugins/plugin-agent-orchestrator/src/services/types.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/types.ts
@@ -184,6 +184,7 @@ export interface SessionStore {
 }
 
 export interface SessionStoreRuntime {
+  adapter?: unknown;
   databaseAdapter?: unknown;
   logger?: {
     warn?: (message: string, ...args: unknown[]) => void;


### PR DESCRIPTION
## Summary
- Fixes ACP session persistence backend selection to prefer modern `runtime.adapter` and fall back to legacy `runtime.databaseAdapter`.
- Detects both raw SQL adapters and eliza `BaseDrizzleAdapter`-style adapters via `adapter.db.execute`.
- Routes SQL through a small executor abstraction and replaces SQLite-only `INSERT OR REPLACE` with portable `INSERT ... ON CONFLICT (id) DO UPDATE`.
- Adds regression coverage for modern adapter selection, drizzle-shaped adapter writes, legacy fallback, adapter precedence, and portable upsert SQL.

Fixes #10991.

## Verification
- `bunx biome check plugins/plugin-agent-orchestrator/src/services/session-store.ts plugins/plugin-agent-orchestrator/src/services/acp-service.ts plugins/plugin-agent-orchestrator/src/services/types.ts plugins/plugin-agent-orchestrator/__tests__/unit/session-store.test.ts`
- `bunx vitest run --config vitest.config.ts __tests__/unit/session-store.test.ts` from `plugins/plugin-agent-orchestrator`
- `bun run --cwd plugins/plugin-agent-orchestrator typecheck`

## Evidence
- `.github/issue-evidence/10991-acp-session-runtime-db.md`

## Notes
- This is the ACP-session sibling to #10987, but it is intentionally self-contained and does not stack on that open PR.