### PR TITLE
fix(orchestrator): refuse auto-validation of a criteria-free task via the route

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-routes.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-routes.test.ts
@@ -679,4 +679,30 @@ describe("orchestrator routes — room, telemetry, agents", () => {
       ).status,
     ).toBe(404);
   });
+
+  it("refuses to auto-validate a criteria-free task (no silent zero-verification pass)", async () => {
+    const service = makeService();
+    const id = await seedTask(service, "No criteria");
+    // Force the exact state the gate protects: validating, with no criteria.
+    // Without the gate, verifyGoalCompletion returns passed:true with NO model
+    // call and the task would be marked done.
+    await service.updateTask(id, {
+      status: "validating",
+      acceptanceCriteria: [],
+    });
+
+    const result = await call(
+      service,
+      "POST",
+      `/api/orchestrator/tasks/${id}/auto-validate`,
+      { completionEvidence: "I did the thing, trust me." },
+    );
+    expect(result.status).toBe(422);
+    expect(String(result.json.error)).toContain("no acceptance criteria");
+
+    // The task must NOT have advanced to done — the gate returns before any
+    // validation runs.
+    const after = await service.getTask(id);
+    expect(after?.status).toBe("validating");
+  });
 });

--- a/plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts
@@ -511,6 +511,19 @@ async function dispatchOrchestratorRoutes(
         );
         return true;
       }
+      // A criteria-free task cannot be auto-validated: `verifyGoalCompletion`
+      // short-circuits an empty criteria set to `passed: true` with NO model
+      // call, so forwarding that here would mark the task `done` with zero
+      // verification. The auto path parks such a task in `validating` instead;
+      // this route must be consistent and refuse rather than rubber-stamp it.
+      if (doc.acceptanceCriteria.length === 0) {
+        sendError(
+          res,
+          "Task has no acceptance criteria; auto-validation cannot verify it (it would pass with no LLM judgment). Add acceptance criteria or validate the task manually.",
+          422,
+        );
+        return true;
+      }
       const verdict = await verifyGoalCompletion(
         ctx.runtime,
         {


### PR DESCRIPTION
## Summary

`POST /api/orchestrator/tasks/:id/auto-validate` gated only on `status === "validating"`, **not** on whether the task had acceptance criteria. `verifyGoalCompletion` short-circuits an **empty** criteria set to `passed: true` with **no model call** — so a criteria-free task in `validating` was forwarded to `validateTask` and marked `done` with **zero verification**.

The auto path (`autoVerifyCompletion`) already parks a criteria-free task in `validating` rather than passing it; the HTTP route was the inconsistent gap that could silently rubber-stamp a task.

## Fix

The route now returns **422** for a criteria-free task and tells the caller to add acceptance criteria or validate manually, instead of forwarding a no-judgment `passed: true`.

## Test

New case: a `validating`, criteria-free task → `422` with `"no acceptance criteria"`, and the task **stays `validating`** (never advances to `done`).

```
Test Files  1 passed (1)
     Tests  20 passed (20)   orchestrator-routes
```

Part of the orchestrator "text-eval / larp in verification" hardening pass (#8896, #8124).

🤖 Generated with [Claude Code](https://claude.com/claude-code)