### PR TITLE
fix(cloud): stop staging Steward session from looping the sign-in

### DIFF
--- a/packages/ui/src/cloud/shell/StewardProviderRuntime.tsx
+++ b/packages/ui/src/cloud/shell/StewardProviderRuntime.tsx
@@ -120,6 +120,17 @@ function AuthTokenSync({ children }: { children: ReactNode }) {
             });
             return;
           }
+          // Same stale-proxy guard as the refresh path: a still-valid token that
+          // gets a 401 from the session-sync endpoint is far more likely a
+          // misproxied control plane than a real revocation. Only clear once the
+          // token is actually expired, so a stale staging proxy can't loop us.
+          const current = readStoredToken();
+          if (current && !tokenIsExpired(current)) {
+            console.warn(
+              "[steward] Session-sync 401 but stored token still valid — keeping it (likely a stale control-plane proxy)",
+            );
+            return;
+          }
           console.warn(
             "[steward] Stored token rejected by server (401) - clearing",
           );
@@ -169,11 +180,25 @@ function AuthTokenSync({ children }: { children: ReactNode }) {
             return;
           }
           if (res.status === 401) {
-            if (wasAuthenticated.current && lastSyncedToken.current) {
-              lastSyncedToken.current = null;
-              wasAuthenticated.current = false;
+            // A refresh 401 normally means the session was revoked → clear so it
+            // self-heals. But a STALE co-hosted proxy (staging's FRONTEND_ALIAS
+            // pointing at the wrong control plane) 401s a still-VALID session,
+            // and wiping it here kicks the user back to /login on every refresh
+            // tick — the sign-in loop. So only clear when the stored token is
+            // actually expired (keeping it is useless then); a still-valid token
+            // rides until real expiry and any genuine revocation self-heals then.
+            const stored = readStoredToken();
+            if (!stored || tokenIsExpired(stored)) {
+              if (wasAuthenticated.current && lastSyncedToken.current) {
+                lastSyncedToken.current = null;
+                wasAuthenticated.current = false;
+              }
+              clearStaleStewardSession();
+            } else {
+              console.warn(
+                "[steward] Refresh 401 but stored token still valid — keeping it (likely a stale control-plane proxy, not a revoked session)",
+              );
             }
-            clearStaleStewardSession();
           }
         } catch (err) {
           console.warn("[steward] Auto-refresh failed", err);

--- a/packages/ui/src/cloud/shell/StewardProviderShared.test.ts
+++ b/packages/ui/src/cloud/shell/StewardProviderShared.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// The Steward auth endpoints are resolved per browser host: co-hosted cloud
+// surfaces bypass the Pages/Worker proxy and call the matching API worker
+// directly. The regression this guards: `staging.elizacloud.ai` used to have no
+// direct mapping, so session-sync + refresh fell through to the same-origin
+// relative path and a stale worker proxy 401'd (then wiped) a valid session —
+// the sign-in loop. Staging MUST resolve to api-staging, not prod api.
+
+function setHostname(hostname: string): void {
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: {
+      hostname,
+      origin: `https://${hostname}`,
+      href: `https://${hostname}/`,
+    },
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+async function loadEndpoints() {
+  // Neutralize any configured API base so the host-based branch is exercised.
+  vi.stubEnv("VITE_API_URL", "");
+  vi.stubEnv("NEXT_PUBLIC_API_URL", "");
+  vi.resetModules();
+  return import("./StewardProviderShared");
+}
+
+describe("Steward auth endpoint resolution", () => {
+  it("routes staging to the api-staging worker directly (not prod, not same-origin)", async () => {
+    setHostname("staging.elizacloud.ai");
+    const { configuredSessionEndpoint, configuredRefreshEndpoint } =
+      await loadEndpoints();
+
+    expect(configuredSessionEndpoint()).toBe(
+      "https://api-staging.elizacloud.ai/api/auth/steward-session",
+    );
+    expect(configuredRefreshEndpoint()).toBe(
+      "https://api-staging.elizacloud.ai/api/auth/steward-refresh",
+    );
+  });
+
+  it("routes prod to the prod api worker directly", async () => {
+    setHostname("elizacloud.ai");
+    const { configuredSessionEndpoint, configuredRefreshEndpoint } =
+      await loadEndpoints();
+
+    expect(configuredSessionEndpoint()).toBe(
+      "https://api.elizacloud.ai/api/auth/steward-session",
+    );
+    expect(configuredRefreshEndpoint()).toBe(
+      "https://api.elizacloud.ai/api/auth/steward-refresh",
+    );
+  });
+
+  it("falls back to the same-origin relative path on an unknown host", async () => {
+    setHostname("localhost");
+    const { configuredSessionEndpoint, configuredRefreshEndpoint } =
+      await loadEndpoints();
+
+    expect(configuredSessionEndpoint()).toBe("/api/auth/steward-session");
+    expect(configuredRefreshEndpoint()).toBe("/api/auth/steward-refresh");
+  });
+});

--- a/packages/ui/src/cloud/shell/StewardProviderShared.ts
+++ b/packages/ui/src/cloud/shell/StewardProviderShared.ts
@@ -25,15 +25,35 @@ function trimTrailingSlash(value: string): string {
   return value.replace(/\/+$/, "");
 }
 
-const ELIZA_CLOUD_COOKIE_HOSTS = new Set([
-  "elizacloud.ai",
-  "www.elizacloud.ai",
-  "dev.elizacloud.ai",
-]);
-const ELIZA_CLOUD_DIRECT_SESSION_ENDPOINT =
-  "https://api.elizacloud.ai/api/auth/steward-session";
-const ELIZA_CLOUD_DIRECT_REFRESH_ENDPOINT =
-  "https://api.elizacloud.ai/api/auth/steward-refresh";
+// Hosts where the SPA is co-hosted with a Cloudflare Pages/Worker deployment
+// that proxies the Steward auth endpoints to the API worker. We bypass that
+// proxy and hit the matching API worker directly so session-sync + refresh keep
+// working even when the Pages Functions bundle / FRONTEND_ALIAS proxy is stale.
+// Per-host base — staging MUST resolve to api-staging, NOT prod api. When it
+// fell through to the same-origin relative path (staging absent here), a stale
+// worker proxy 401'd a valid session and clearStaleStewardSession wiped it →
+// the sign-in loop. Mirrors steward-url.ts's ELIZA_CLOUD_DIRECT_API_BY_HOST.
+const ELIZA_CLOUD_DIRECT_API_BY_HOST: Record<string, string> = {
+  "elizacloud.ai": "https://api.elizacloud.ai",
+  "www.elizacloud.ai": "https://api.elizacloud.ai",
+  "dev.elizacloud.ai": "https://api.elizacloud.ai",
+  "staging.elizacloud.ai": "https://api-staging.elizacloud.ai",
+};
+
+function directCloudApiBase(): string | undefined {
+  if (typeof window === "undefined") return undefined;
+  return ELIZA_CLOUD_DIRECT_API_BY_HOST[window.location.hostname.toLowerCase()];
+}
+
+function directStewardSessionEndpoint(): string | undefined {
+  const base = directCloudApiBase();
+  return base ? `${base}${STEWARD_SESSION_ENDPOINT}` : undefined;
+}
+
+function directStewardRefreshEndpoint(): string | undefined {
+  const base = directCloudApiBase();
+  return base ? `${base}${STEWARD_REFRESH_ENDPOINT}` : undefined;
+}
 
 export type LocalStewardAuthValue = {
   isAuthenticated: boolean;
@@ -63,10 +83,7 @@ function isLocalhostApiBase(value: string): boolean {
 }
 
 function isBrowserOnElizaHost(): boolean {
-  return (
-    typeof window !== "undefined" &&
-    ELIZA_CLOUD_COOKIE_HOSTS.has(window.location.hostname.toLowerCase())
-  );
+  return directCloudApiBase() !== undefined;
 }
 
 function configuredApiBase(): string | undefined {
@@ -86,8 +103,9 @@ export function configuredSessionEndpoint(): string {
       return `${trimTrailingSlash(apiBase)}${STEWARD_SESSION_ENDPOINT}`;
     }
   }
-  if (isBrowserOnElizaHost()) {
-    return ELIZA_CLOUD_DIRECT_SESSION_ENDPOINT;
+  const direct = directStewardSessionEndpoint();
+  if (direct) {
+    return direct;
   }
   return STEWARD_SESSION_ENDPOINT;
 }
@@ -99,8 +117,9 @@ export function configuredRefreshEndpoint(): string {
       return `${trimTrailingSlash(apiBase)}${STEWARD_REFRESH_ENDPOINT}`;
     }
   }
-  if (isBrowserOnElizaHost()) {
-    return ELIZA_CLOUD_DIRECT_REFRESH_ENDPOINT;
+  const direct = directStewardRefreshEndpoint();
+  if (direct) {
+    return direct;
   }
   return STEWARD_REFRESH_ENDPOINT;
 }
@@ -108,8 +127,9 @@ export function configuredRefreshEndpoint(): string {
 function stewardSessionClearUrls(): string[] {
   if (typeof window === "undefined") return [configuredSessionEndpoint()];
   const urls = new Set([STEWARD_SESSION_ENDPOINT, configuredSessionEndpoint()]);
-  if (isBrowserOnElizaHost()) {
-    urls.add(ELIZA_CLOUD_DIRECT_SESSION_ENDPOINT);
+  const direct = directStewardSessionEndpoint();
+  if (direct) {
+    urls.add(direct);
   }
   return [...urls];
 }


### PR DESCRIPTION
## What

Kills the infinite re-login popup loop on `staging.elizacloud.ai`: sign in, land in the app, get told to sign in again, popup, repeat — the session never actually sticks.

## Why

The Steward shell resolves the session/refresh endpoints per browser host. Prod hosts (`elizacloud.ai`, `www`, `dev`) had a direct-API mapping and hit their control plane straight; **`staging.elizacloud.ai` had none**, so it fell through to the same-origin relative path and rode the `FRONTEND_ALIAS` worker proxy.

When that proxy is stale or misrouted (which is exactly the class of bug we've been chasing on staging) it `401`s a perfectly valid session. Both 401 handlers in the runtime then call `clearStaleStewardSession()` → the token gets wiped → the app bounces to `/login` on every refresh tick. That's the loop.

## Changes

1. **`StewardProviderShared.ts`** — replace the prod-only host `Set` + two hardcoded prod endpoint constants with a per-host direct-API map that includes `staging.elizacloud.ai → https://api-staging.elizacloud.ai`. Now mirrors `steward-url.ts`'s existing `ELIZA_CLOUD_DIRECT_API_BY_HOST` (which already had staging — this removes the asymmetry). Staging now hits its own control plane directly, bypassing the flaky proxy.

2. **`StewardProviderRuntime.tsx`** — don't wipe a still-**valid** (non-expired) token on a refresh/session-sync `401`. A genuinely revoked session self-heals when the token actually expires; a proxy blip no longer nukes a good session and loops the user. Applied to both 401 paths (session-sync + refresh).

3. **`StewardProviderShared.test.ts`** — new unit coverage for the host→endpoint resolution (staging → api-staging, prod → api, unknown host → same-origin relative).

## Honest scope

This is the client-side hardening. Change 1 is the real fix if the staging Pages/Worker proxy is the thing 401ing; change 2 is defense-in-depth that breaks the loop mechanism *regardless* of what's 401ing. **If the 401 root cause is actually the `api-staging` control plane itself rejecting the Steward session (tenant/audience mismatch) rather than a proxy misroute, that's an infra fix, not this** — but even then, change 2 stops the client from looping.

## Test

- `bunx vitest run packages/ui/src/cloud/shell/StewardProviderShared.test.ts packages/ui/src/cloud/shell/StewardProvider.test.tsx` → 7 passed
- `bun run --cwd packages/ui typecheck` → clean
- biome clean

## Update: prod loops too — this guard applies there as well

Follow-up diagnosis (live probes + worker logs + code audit, adversarially verified): **prod (elizacloud.ai) shows the same re-login loop but NOT via the staging proxy story** — prod already ships the direct `api.elizacloud.ai` mapping and its auth transport (CORS, cookies, proxy) checks out healthy.

What prod actually hits is the same **wipe mechanism** through a different door: sessions that end up with no usable `steward-refresh-token` cookie (Steward doesn't issue refresh tokens for SIWE sign-ins; two client sync paths POST `{token}` only; a lost multi-tab refresh rotation race makes the server delete all three cookies). Any authed-route 401 then fires `steward-unauthorized` → forced refresh → instant `401 missing_token` → the deployed (pre-this-PR) bundle wipes localStorage → `/login`. All sampled prod refresh 401s in the last 48h are the 0–2ms missing-cookie branch, several from the real SPA origins.

So the keep-valid-token-on-401 guard in this PR is **not staging-specific defense-in-depth — it breaks the prod loop mechanism too** (session survives to its natural ~15 min expiry instead of dying on the first noisy 401). Honest limits, unchanged: it doesn't *establish* a refresh path, so refresh-less sessions still end at token expiry, and there's a separate server-side sign-in-completion failure being escalated internally. Follow-ups worth their own PRs: treat refresh `401 {code:missing_token}` as "no refresh path" (never a session-kill), forward `refreshToken` on every sync path that has one, and make the refresh single-flight cross-tab.
