### PR TITLE
fix(cloud): reinstate won dispute clawbacks

### DIFF
--- a/.github/issue-evidence/10997-stripe-dispute-reinstatement.md
+++ b/.github/issue-evidence/10997-stripe-dispute-reinstatement.md
@@ -1,0 +1,41 @@
+# #10997 Stripe Dispute Reinstatement Evidence
+
+## Change
+
+- Added `charge.dispute.funds_reinstated` handling in the Stripe queue.
+- Reinstatement is idempotent on `stripe:dispute:<id>:reinstated`.
+- The restored amount is capped to the actual applied dispute clawback, so a won dispute cannot over-credit an org.
+- Refund/dispute clawbacks are capped at the original credit grant before computing the delta, so Stripe gross amounts above granted credits cannot over-claw.
+- Removed a duplicate `DEFAULT_CEREBRAS_TEXT_MODEL` export in the Cloudflare worker stub that made `packages/cloud/api` typecheck fail on the current base.
+
+## Verification
+
+```bash
+bunx biome check packages/cloud/api/src/queue/stripe-event.ts packages/cloud/api/__tests__/stripe-event-clawback.test.ts packages/cloud/api/src/stubs/elizaos-core.ts
+```
+
+Result: passed (`Checked 3 files`).
+
+```bash
+bun test packages/cloud/api/__tests__/stripe-event-clawback.test.ts
+```
+
+Result: passed (`6 pass, 0 fail`).
+
+Covered:
+- cumulative `charge.refunded` delta clawback
+- grant-capped refund clawback
+- refund redelivery no-op
+- `charge.dispute.funds_withdrawn` dispute-key clawback
+- `charge.dispute.funds_reinstated` restoring only applied dispute clawback
+- reinstatement no-op when no matching dispute clawback exists
+
+```bash
+bun run --cwd packages/cloud/api typecheck
+```
+
+Result: passed (`tsgo --noEmit`).
+
+## UI / Live Stripe Evidence
+
+N/A: server-side Stripe queue accounting fix with unit coverage around the event processor. No `packages/app` UI changed. Live Stripe replay was not run because this path requires real Stripe dispute lifecycle events and a funded test account; the focused queue tests exercise the event payloads and idempotency keys directly.

--- a/packages/cloud/api/__tests__/stripe-event-clawback.test.ts
+++ b/packages/cloud/api/__tests__/stripe-event-clawback.test.ts
@@ -1,16 +1,36 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-const getTransactionByStripePaymentIntent = mock(async () => ({
-  id: "tx-credit",
-  organization_id: "org-1",
-  amount: "100",
-}));
+type MockCreditTransaction = {
+  id: string;
+  organization_id: string;
+  amount: string;
+  type?: string;
+};
+
+const getTransactionByStripePaymentIntent = mock(
+  async (
+    _paymentIntentId: string,
+  ): Promise<MockCreditTransaction | undefined> => ({
+    id: "tx-credit",
+    organization_id: "org-1",
+    amount: "100",
+    type: "credit",
+  }),
+);
 const getClawedBackUsdForPaymentIntent = mock(async () => 0);
 const clawbackCredits = mock(async () => ({
   newBalance: 25,
   appliedAmount: 20,
   shortfallAmount: 0,
   alreadyProcessed: false,
+}));
+const refundCredits = mock(async () => ({
+  transaction: {
+    id: "tx-reinstated",
+    organization_id: "org-1",
+    amount: "45",
+  },
+  newBalance: 70,
 }));
 
 mock.module("@/db/helpers", () => ({
@@ -39,6 +59,7 @@ mock.module("@/lib/services/credits", () => ({
     getTransactionByStripePaymentIntent,
     getClawedBackUsdForPaymentIntent,
     clawbackCredits,
+    refundCredits,
   },
 }));
 mock.module("@/lib/services/discord", () => ({
@@ -69,6 +90,7 @@ describe("stripe queue credit clawbacks", () => {
       id: "tx-credit",
       organization_id: "org-1",
       amount: "100",
+      type: "credit",
     });
     getClawedBackUsdForPaymentIntent.mockClear();
     getClawedBackUsdForPaymentIntent.mockResolvedValue(0);
@@ -78,6 +100,15 @@ describe("stripe queue credit clawbacks", () => {
       appliedAmount: 20,
       shortfallAmount: 0,
       alreadyProcessed: false,
+    });
+    refundCredits.mockClear();
+    refundCredits.mockResolvedValue({
+      transaction: {
+        id: "tx-reinstated",
+        organization_id: "org-1",
+        amount: "45",
+      },
+      newBalance: 70,
     });
   });
 
@@ -116,8 +147,53 @@ describe("stripe queue credit clawbacks", () => {
       metadata: {
         payment_intent_id: "pi_1",
         reversed_usd: 50,
+        capped_reversed_usd: 50,
         source: "charge.refunded",
         reference: "charge ch_1",
+      },
+    });
+  });
+
+  test("charge.refunded caps clawback at credits actually granted", async () => {
+    getTransactionByStripePaymentIntent.mockResolvedValueOnce({
+      id: "tx-credit",
+      organization_id: "org-1",
+      amount: "40",
+    });
+
+    const result = await processStripeEvent({
+      attempts: 1,
+      body: {
+        kind: "stripe.event",
+        eventId: "evt_refund_gross",
+        eventType: "charge.refunded",
+        receivedAt: Date.now(),
+        event: {
+          id: "evt_refund_gross",
+          type: "charge.refunded",
+          data: {
+            object: {
+              id: "ch_taxed",
+              amount_refunded: 5000,
+              payment_intent: "pi_taxed",
+            },
+          },
+        },
+      },
+    } as unknown as Parameters<typeof processStripeEvent>[0]);
+
+    expect(result).toBe("ack");
+    expect(clawbackCredits).toHaveBeenCalledWith({
+      organizationId: "org-1",
+      amount: 40,
+      description: "Stripe charge.refunded clawback — charge ch_taxed",
+      stripePaymentIntentId: "stripe:refund:ch_taxed:5000",
+      metadata: {
+        payment_intent_id: "pi_taxed",
+        reversed_usd: 50,
+        capped_reversed_usd: 40,
+        source: "charge.refunded",
+        reference: "charge ch_taxed",
       },
     });
   });
@@ -183,9 +259,90 @@ describe("stripe queue credit clawbacks", () => {
       metadata: {
         payment_intent_id: "pi_1",
         reversed_usd: 75,
+        capped_reversed_usd: 75,
         source: "charge.dispute.funds_withdrawn",
         reference: "dispute dp_1 (charge ch_1)",
       },
     });
+  });
+
+  test("charge.dispute.funds_reinstated restores only the applied dispute clawback", async () => {
+    getTransactionByStripePaymentIntent.mockImplementationOnce(async (key) => {
+      expect(key).toBe("stripe:dispute:dp_1");
+      return {
+        id: "tx-clawback",
+        organization_id: "org-1",
+        amount: "-45",
+        type: "clawback",
+      };
+    });
+
+    const result = await processStripeEvent({
+      attempts: 1,
+      body: {
+        kind: "stripe.event",
+        eventId: "evt_dispute_reinstated",
+        eventType: "charge.dispute.funds_reinstated",
+        receivedAt: Date.now(),
+        event: {
+          id: "evt_dispute_reinstated",
+          type: "charge.dispute.funds_reinstated",
+          data: {
+            object: {
+              id: "dp_1",
+              amount: 7500,
+              charge: "ch_1",
+              payment_intent: "pi_1",
+            },
+          },
+        },
+      },
+    } as unknown as Parameters<typeof processStripeEvent>[0]);
+
+    expect(result).toBe("ack");
+    expect(refundCredits).toHaveBeenCalledWith({
+      organizationId: "org-1",
+      amount: 45,
+      description:
+        "Stripe charge.dispute.funds_reinstated reinstatement — dispute dp_1 (charge ch_1)",
+      stripePaymentIntentId: "stripe:dispute:dp_1:reinstated",
+      metadata: {
+        payment_intent_id: "pi_1",
+        reinstated_usd: 75,
+        applied_reinstatement_usd: 45,
+        clawback_key: "stripe:dispute:dp_1",
+        source: "charge.dispute.funds_reinstated",
+        reference: "dispute dp_1 (charge ch_1)",
+      },
+    });
+  });
+
+  test("charge.dispute.funds_reinstated is a no-op without a matching clawback", async () => {
+    getTransactionByStripePaymentIntent.mockResolvedValueOnce(undefined);
+
+    const result = await processStripeEvent({
+      attempts: 1,
+      body: {
+        kind: "stripe.event",
+        eventId: "evt_dispute_reinstated_noop",
+        eventType: "charge.dispute.funds_reinstated",
+        receivedAt: Date.now(),
+        event: {
+          id: "evt_dispute_reinstated_noop",
+          type: "charge.dispute.funds_reinstated",
+          data: {
+            object: {
+              id: "dp_missing",
+              amount: 7500,
+              charge: "ch_1",
+              payment_intent: "pi_1",
+            },
+          },
+        },
+      },
+    } as unknown as Parameters<typeof processStripeEvent>[0]);
+
+    expect(result).toBe("ack");
+    expect(refundCredits).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/src/queue/stripe-event.ts
+++ b/packages/cloud/api/src/queue/stripe-event.ts
@@ -111,6 +111,9 @@ export async function processStripeEvent(
       case "charge.dispute.funds_withdrawn":
         await handleChargeDisputeFundsWithdrawn(event);
         break;
+      case "charge.dispute.funds_reinstated":
+        await handleChargeDisputeFundsReinstated(event);
+        break;
       default:
         logger.debug(`[Stripe Queue] Unhandled event type: ${event.type}`);
     }
@@ -836,7 +839,7 @@ async function handlePaymentIntentFailed(event: Stripe.Event): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
-// charge.refunded / charge.dispute.funds_withdrawn — credit clawback (#10920)
+// charge.refunded / charge.dispute.* — credit clawback/reinstatement (#10920, #10997)
 // ---------------------------------------------------------------------------
 
 /** The payment intent id off a charge, whether expanded or a bare string. */
@@ -849,11 +852,11 @@ function chargePaymentIntentId(charge: Stripe.Charge): string | undefined {
 /**
  * Claw back org credits for the portion of a top-up charge that Stripe reversed.
  * Balance top-ups grant credits 1:1 with USD, so `usdReversed` credits are
- * removed up to the org's current balance. Any unrecovered portion is recorded
- * on the clawback transaction metadata because the organizations table has a
- * nonnegative balance constraint. Only the DELTA past what was already clawed
- * for this payment intent is removed, so multiple partial refunds and
- * re-delivered webhooks are safe.
+ * removed up to the original grant and the org's current balance. Any
+ * unrecovered portion is recorded on the clawback transaction metadata because
+ * the organizations table has a nonnegative balance constraint. Only the DELTA
+ * past what was already clawed for this payment intent is removed, so multiple
+ * partial refunds and re-delivered webhooks are safe.
  */
 async function clawbackForReversal(params: {
   paymentIntentId: string | undefined;
@@ -876,12 +879,22 @@ async function clawbackForReversal(params: {
     return;
   }
 
+  const grantAmount = Number(grant.amount);
+  if (!Number.isFinite(grantAmount) || grantAmount <= 0) {
+    logger.warn(
+      `[Stripe Queue] ${source} ${reference}: invalid credit grant amount for PI ${paymentIntentId}`,
+      { amount: grant.amount },
+    );
+    return;
+  }
+
+  const cappedUsdReversed = Math.min(usdReversed, grantAmount);
   const alreadyClawed =
     await creditsService.getClawedBackUsdForPaymentIntent(paymentIntentId);
-  const delta = Math.round((usdReversed - alreadyClawed) * 1e6) / 1e6;
+  const delta = Math.round((cappedUsdReversed - alreadyClawed) * 1e6) / 1e6;
   if (delta <= 0) {
     logger.info(
-      `[Stripe Queue] ${source} ${reference}: $${usdReversed.toFixed(2)} already clawed back for PI ${paymentIntentId}`,
+      `[Stripe Queue] ${source} ${reference}: $${cappedUsdReversed.toFixed(2)} already clawed back for PI ${paymentIntentId}`,
     );
     return;
   }
@@ -894,6 +907,7 @@ async function clawbackForReversal(params: {
     metadata: {
       payment_intent_id: paymentIntentId,
       reversed_usd: usdReversed,
+      capped_reversed_usd: cappedUsdReversed,
       source,
       reference,
     },
@@ -939,7 +953,8 @@ async function handleChargeDisputeFundsWithdrawn(
     typeof dispute.payment_intent === "string"
       ? dispute.payment_intent
       : dispute.payment_intent?.id;
-  // A lost/withdrawn dispute pulls the full disputed amount back out.
+  // Stripe withdraws funds when the dispute opens. If the platform wins, the
+  // separate `funds_reinstated` event below compensates the applied clawback.
   await clawbackForReversal({
     paymentIntentId,
     usdReversed: (dispute.amount ?? 0) / 100,
@@ -947,4 +962,60 @@ async function handleChargeDisputeFundsWithdrawn(
     source: "charge.dispute.funds_withdrawn",
     reference: `dispute ${dispute.id}${chargeId ? ` (charge ${chargeId})` : ""}`,
   });
+}
+
+async function handleChargeDisputeFundsReinstated(
+  event: Stripe.Event,
+): Promise<void> {
+  const dispute = event.data.object as Stripe.Dispute;
+  const chargeId =
+    typeof dispute.charge === "string" ? dispute.charge : dispute.charge?.id;
+  const paymentIntentId =
+    typeof dispute.payment_intent === "string"
+      ? dispute.payment_intent
+      : dispute.payment_intent?.id;
+  const source = "charge.dispute.funds_reinstated";
+  const reference = `dispute ${dispute.id}${chargeId ? ` (charge ${chargeId})` : ""}`;
+  const clawbackKey = `stripe:dispute:${dispute.id}`;
+
+  const clawback =
+    await creditsService.getTransactionByStripePaymentIntent(clawbackKey);
+  if (clawback?.type !== "clawback") {
+    logger.info(
+      `[Stripe Queue] ${source} ${reference}: no dispute clawback found; nothing to reinstate`,
+    );
+    return;
+  }
+
+  const appliedClawbackUsd = Math.abs(Number(clawback.amount));
+  const reinstatedUsd = Math.min(
+    (dispute.amount ?? 0) / 100,
+    appliedClawbackUsd,
+  );
+  if (!Number.isFinite(reinstatedUsd) || reinstatedUsd <= 0) {
+    logger.info(
+      `[Stripe Queue] ${source} ${reference}: no applied clawback amount to reinstate`,
+      { clawbackAmount: clawback.amount, disputeAmount: dispute.amount },
+    );
+    return;
+  }
+
+  const result = await creditsService.refundCredits({
+    organizationId: clawback.organization_id,
+    amount: reinstatedUsd,
+    description: `Stripe ${source} reinstatement — ${reference}`,
+    stripePaymentIntentId: `${clawbackKey}:reinstated`,
+    metadata: {
+      payment_intent_id: paymentIntentId,
+      reinstated_usd: (dispute.amount ?? 0) / 100,
+      applied_reinstatement_usd: reinstatedUsd,
+      clawback_key: clawbackKey,
+      source,
+      reference,
+    },
+  });
+
+  logger.info(
+    `[Stripe Queue] Reinstated $${reinstatedUsd.toFixed(2)} to org ${clawback.organization_id} for ${source} ${reference} (new balance $${result.newBalance.toFixed(2)})`,
+  );
 }


### PR DESCRIPTION
## Summary

Fixes #10997.

- Handle `charge.dispute.funds_reinstated` in the Stripe event queue.
- Restore only the amount actually applied by the dispute clawback, keyed idempotently as `stripe:dispute:<id>:reinstated`.
- Cap refund/dispute clawbacks at the original credit grant before computing the cumulative delta so Stripe gross amounts cannot over-claw more credits than were granted.
- Remove the duplicate `DEFAULT_CEREBRAS_TEXT_MODEL` worker-stub export that made `packages/cloud/api` typecheck fail on the current base.

## Evidence

See `.github/issue-evidence/10997-stripe-dispute-reinstatement.md`.

Commands run:

```bash
bunx biome check packages/cloud/api/src/queue/stripe-event.ts packages/cloud/api/__tests__/stripe-event-clawback.test.ts packages/cloud/api/src/stubs/elizaos-core.ts
bun test packages/cloud/api/__tests__/stripe-event-clawback.test.ts
bun run --cwd packages/cloud/api typecheck
```

All passed.

## UI / Live Stripe

N/A: server-side Stripe queue accounting fix. No `packages/app` UI changed. Live Stripe replay requires real dispute lifecycle events and a funded test account; the focused queue tests exercise the event payloads and idempotency keys directly.