### PR TITLE
fix(orchestrator): guard the supervisor tick against overlap + unhandled rejections

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-supervisor.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-supervisor.test.ts
@@ -4,6 +4,7 @@ import {
   runSupervisorTick,
   type SupervisorTaskView,
   statusEmoji,
+  TaskSupervisorService,
 } from "../../src/services/task-supervisor-service.js";
 
 const ROOM_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
@@ -137,5 +138,55 @@ describe("runSupervisorTick (#8900)", () => {
     expect(seen.has(ROOM_A)).toBe(false);
     const second = await runSupervisorTick(views, send, seen);
     expect(second.posted).toEqual([ROOM_A]); // retried successfully
+  });
+});
+
+describe("TaskSupervisorService.runOnce resilience", () => {
+  function runtimeWith(taskSvc: unknown) {
+    return {
+      getService: (type: string) =>
+        type === "ORCHESTRATOR_TASK_SERVICE" ? taskSvc : undefined,
+      sendMessageToTarget: async () => undefined,
+      // Supervisor disabled → start() does not arm the interval timer.
+      getSetting: (k: string) =>
+        k === "ELIZA_ORCHESTRATOR_SUPERVISOR" ? "0" : undefined,
+      logger: { debug() {}, info() {}, warn() {}, error() {} },
+    } as never;
+  }
+
+  it("swallows a throwing task service instead of rejecting (no unhandled rejection per tick)", async () => {
+    const svc = await TaskSupervisorService.start(
+      runtimeWith({
+        listTasks: async () => {
+          throw new Error("db exploded");
+        },
+        getTaskOriginTarget: async () => null,
+      }),
+    );
+    await expect(svc.runOnce()).resolves.toEqual({ posted: [], skipped: [] });
+    await svc.stop();
+  });
+
+  it("still posts a digest on a healthy tick", async () => {
+    const svc = await TaskSupervisorService.start(
+      runtimeWith({
+        listTasks: async () => [
+          {
+            id: "t1",
+            title: "Alpha",
+            status: "active",
+            activeSessionCount: 1,
+            latestSessionLabel: "codex",
+          },
+        ],
+        getTaskOriginTarget: async () => ({
+          roomId: ROOM_A,
+          source: "telegram",
+        }),
+      }),
+    );
+    const result = await svc.runOnce();
+    expect(result.posted).toEqual([ROOM_A]);
+    await svc.stop();
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/task-supervisor-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-supervisor-service.ts
@@ -180,6 +180,10 @@ export class TaskSupervisorService extends Service {
     "Proactively posts a per-room status digest of all in-flight orchestrator tasks (the multi-task juggler).";
 
   private timer: ReturnType<typeof setInterval> | undefined;
+  /** Guards against overlapping ticks: a slow `runOnce` (N network sends) must
+   *  not have the next interval fire a concurrent one — two ticks would race the
+   *  `seen` dedup map and double-post. */
+  private ticking = false;
   /** roomId → last-posted digest, for change-driven dedup. */
   private readonly seen = new Map<string, string>();
   private readonly digestSinks = new Map<
@@ -207,7 +211,14 @@ export class TaskSupervisorService extends Service {
 
   private startTimer(): void {
     this.timer = setInterval(() => {
-      void this.runOnce();
+      // Skip this tick if the previous one is still in flight — never run two
+      // concurrently. `runOnce` swallows its own errors, so the `finally`
+      // always clears the flag.
+      if (this.ticking) return;
+      this.ticking = true;
+      void this.runOnce().finally(() => {
+        this.ticking = false;
+      });
     }, this.intervalMs());
     // The digest loop must never, by itself, keep the process alive.
     (this.timer as { unref?: () => void }).unref?.();
@@ -264,29 +275,41 @@ export class TaskSupervisorService extends Service {
     ) {
       return { posted: [], skipped: [] };
     }
-    const tasks = await taskSvc.listTasks({ includeArchived: false });
-    const live = tasks.filter((t) => LIVE_STATUSES.has(t.status));
-    const views: SupervisorTaskView[] = await Promise.all(
-      live.map(async (t) => ({
-        id: t.id,
-        label: t.title,
-        status: t.status,
-        activeSessions: t.activeSessionCount,
-        sessionLabel: t.latestSessionLabel,
-        origin: await taskSvc.getTaskOriginTarget(t.id),
-      })),
-    );
-    const result = await runSupervisorTick(
-      views,
-      (target, content) => this.sendDigest(target, content, send),
-      this.seen,
-    );
-    if (result.posted.length > 0) {
-      logger.info(
-        `[TaskSupervisorService] digest posted to ${result.posted.length} room(s)`,
+    // Guard the whole tick: a rejected `listTasks` / origin lookup / send would
+    // otherwise surface as an unhandled rejection on every interval (the timer
+    // calls this fire-and-forget) — noisy, and fatal under strict handling.
+    try {
+      const tasks = await taskSvc.listTasks({ includeArchived: false });
+      const live = tasks.filter((t) => LIVE_STATUSES.has(t.status));
+      const views: SupervisorTaskView[] = await Promise.all(
+        live.map(async (t) => ({
+          id: t.id,
+          label: t.title,
+          status: t.status,
+          activeSessions: t.activeSessionCount,
+          sessionLabel: t.latestSessionLabel,
+          origin: await taskSvc.getTaskOriginTarget(t.id),
+        })),
       );
+      const result = await runSupervisorTick(
+        views,
+        (target, content) => this.sendDigest(target, content, send),
+        this.seen,
+      );
+      if (result.posted.length > 0) {
+        logger.info(
+          `[TaskSupervisorService] digest posted to ${result.posted.length} room(s)`,
+        );
+      }
+      return result;
+    } catch (error) {
+      logger.warn(
+        `[TaskSupervisorService] tick failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return { posted: [], skipped: [] };
     }
-    return result;
   }
 
   async stop(): Promise<void> {


### PR DESCRIPTION
## Summary

The multi-task supervisor (`TaskSupervisorService`, the "juggler" that posts per-room status digests) armed its interval as `setInterval(() => void this.runOnce())` with **no reentrancy guard and no error handling** around the tick body:

- **Overlapping ticks:** `runOnce` does N network `getTaskOriginTarget` + `send` calls. If it runs longer than the interval, the next tick starts concurrently — two ticks race the `seen` dedup map and can **double-post** a digest.
- **Unhandled rejection per tick:** a rejected `listTasks` / origin lookup / `send` becomes an unhandled promise rejection on every interval (fire-and-forget) — noisy, and process-fatal under strict `unhandledRejection` handling.

## Fix

- An in-flight `ticking` flag: the interval **skips** while a tick is still running (`finally` always clears it).
- `runOnce`'s body wrapped in try/catch — logs and returns an empty result on failure; the interval keeps ticking.

## Tests

New service-level cases:
- `runOnce` swallows a throwing task service → **resolves** `{posted:[],skipped:[]}` (does not reject).
- still posts a digest on a healthy tick.

```
Test Files  2 passed (2)
     Tests  12 passed (12)   task-supervisor
```

> Follow-up (documented, not in this PR): the digest change-key has no staleness term, so a genuinely *stuck* task is deduped into silence after the first post — folding a coarse `lastActivityAt` age bucket into the key would re-surface stalls.

Part of the orchestrator "handling loops and timeouts" hardening pass (#8900, #8885).

🤖 Generated with [Claude Code](https://claude.com/claude-code)