### PR TITLE
test(orchestrator): give the router-loop-guard leak test real timeout headroom

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/router-loop-guard.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/router-loop-guard.test.ts
@@ -434,5 +434,8 @@ describe("routerLoopTransition — fuzz over event orderings", () => {
     expect(state.completionFirstPostedSession.size).toBe(
       ROUTER_LOOP_STATE_BOUND,
     );
-  });
+    // Deliberately heavy: 3×BOUND distinct keys × 3 transitions each. On a
+    // loaded CI box the pure-CPU loop runs ~4-6s, over vitest's 5s default —
+    // give it real headroom so the leak invariant isn't a flaky red.
+  }, 30_000);
 });


### PR DESCRIPTION
## Summary

Running the **full orchestrator suite** (1,274 tests) surfaced a single flaky failure: `router-loop-guard > keeps every map bounded under thousands of distinct keys (no leak)`.

That test deliberately drives `3 × ROUTER_LOOP_STATE_BOUND` distinct keys through 3 transitions each — a pure-CPU loop that runs **~4-6s** on a loaded box, over vitest's **5s default** test timeout. On a busy CI host (many concurrent vitest runs) it intermittently times out, turning a correct invariant into a flaky red.

## Fix

Raise **this one test's** timeout to 30s (test-only; no product change).

## Evidence

```
# full suite under load: only this test failed (timeout)
Test Files  1 failed | 121 passed | 3 skipped (125)
     Tests  1 failed | 1267 passed | 6 skipped (1274)

# isolated / with headroom:
router-loop-guard  11 passed (11)   tests 5.04s
```

The 6 skips are live-gated tests (self-skip without provider keys). Everything else is green — corroborating that the orchestrator's ~1,274 tests are real and passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)