### PR TITLE
fix(agent): route cloud media through model handlers

### DIFF
--- a/.github/issue-evidence/10986-cloud-media-model-routing.md
+++ b/.github/issue-evidence/10986-cloud-media-model-routing.md
@@ -1,0 +1,56 @@
+# #10986 Cloud Media Model Routing Evidence
+
+## Change
+
+- Removed agent-side Eliza Cloud video/audio fetch providers that posted to nonexistent `/media/video/generate` and `/media/audio/generate` endpoints.
+- Cloud-selected video now routes through `runtime.useModel(ModelType.VIDEO)`.
+- Cloud-selected music now routes through `runtime.useModel(ModelType.AUDIO)` and `plugin-elizacloud` calls the real `/api/v1/generate-music` SDK route.
+- Cloud-selected speech routes through existing `ModelType.TEXT_TO_SPEECH`.
+- Direct own-key providers remain direct (`fal`, `openai`, `google`, `suno`, `elevenlabs`).
+- Cloud SFX fails clearly because Cloud only exposes music/TTS here; use a direct SFX provider.
+- `AudioProcessingParams` and `VideoProcessingParams` were widened additively for generation fields.
+
+## Verification
+
+```bash
+rg -n "media/video/generate|media/audio/generate|ElizaCloud(Video|Audio)Provider|createCloudAudioProvider" packages/agent plugins/plugin-elizacloud packages/cloud/api -g '*.ts' -g '*.d.ts'
+```
+
+Result: no matches.
+
+```bash
+bunx biome check packages/agent/src/providers/media-provider.ts packages/agent/src/providers/media-provider.test.ts packages/agent/src/services/media-generation.ts packages/agent/src/services/media-generation.test.ts packages/core/src/types/model.ts plugins/plugin-elizacloud/src/index.ts plugins/plugin-elizacloud/src/models/index.ts plugins/plugin-elizacloud/src/models/media.ts plugins/plugin-elizacloud/__tests__/cloud-media-generation.test.ts
+```
+
+Result: passed (`Checked 6 files`).
+
+```bash
+bunx vitest run --config vitest.config.ts src/providers/media-provider.test.ts src/services/media-generation.test.ts
+```
+
+Run from `packages/agent`. Result: passed (`2 passed`, `22 tests`).
+
+```bash
+bunx vitest run --config vitest.config.ts __tests__/cloud-media-generation.test.ts
+```
+
+Run from `plugins/plugin-elizacloud`. Result: passed (`1 passed`, `3 tests`).
+
+```bash
+bun run --cwd plugins/plugin-elizacloud typecheck
+bun run --cwd packages/core typecheck
+```
+
+Result: both passed.
+
+## Known Current-Base Typecheck Drift
+
+```bash
+bun run --cwd packages/agent typecheck
+```
+
+Result: failed on unrelated current-base command catalog / plugin export drift and missing `@elizaos/cloud-routing` declarations in wallet plugin imports. The rerun no longer reports media-routing or `plugin-elizacloud` handler type errors.
+
+## Live Cloud Evidence
+
+N/A for this code PR: live Cloud video/music calls require valid Cloud credentials and paid generation credits. The new plugin tests assert the SDK methods and payloads for the real generated routes (`postApiV1GenerateVideo`, `postApiV1GenerateMusic`) without hitting dead endpoints.

--- a/packages/agent/src/providers/media-provider.test.ts
+++ b/packages/agent/src/providers/media-provider.test.ts
@@ -217,6 +217,16 @@ describe("media audio provider routing", () => {
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/voiceId/);
   });
+
+  it("does not expose a direct Eliza Cloud audio fetch provider", () => {
+    expect(() =>
+      createAudioProvider(undefined, {
+        cloudMediaDisabled: false,
+        elizaCloudApiKey: "eliza_cloud_key",
+        elizaCloudBaseUrl: "https://api.elizacloud.ai/api/v1",
+      }),
+    ).toThrow(/ModelType\.AUDIO\/TEXT_TO_SPEECH/);
+  });
 });
 
 describe("media image provider routing", () => {
@@ -355,6 +365,16 @@ describe("media video provider routing", () => {
       error: "No video returned from FAL",
     });
     expect(calls).toHaveLength(1);
+  });
+
+  it("does not expose a direct Eliza Cloud video fetch provider", () => {
+    expect(() =>
+      createVideoProvider(undefined, {
+        cloudMediaDisabled: false,
+        elizaCloudApiKey: "eliza_cloud_key",
+        elizaCloudBaseUrl: "https://api.elizacloud.ai/api/v1",
+      }),
+    ).toThrow(/ModelType\.VIDEO/);
   });
 });
 

--- a/packages/agent/src/providers/media-provider.ts
+++ b/packages/agent/src/providers/media-provider.ts
@@ -55,7 +55,6 @@ async function withProviderErrorBoundary<T>(
   }
 }
 
-const DEFAULT_ELIZA_CLOUD_BASE_URL = "https://elizacloud.ai/api/v1";
 const DEFAULT_AUDIO_TIMEOUT_MS = 120_000;
 
 const VEO_OPERATION_POLL_INTERVAL_MS = 10_000;
@@ -113,15 +112,6 @@ function getAudioKind(
     normalizeAudioKind(config?.kind) ??
     normalizeAudioKind(config?.defaultKind) ??
     "music"
-  );
-}
-
-function createCloudAudioProvider(
-  options: MediaProviderFactoryOptions,
-): AudioGenerationProvider {
-  return new ElizaCloudAudioProvider(
-    options.elizaCloudBaseUrl ?? DEFAULT_ELIZA_CLOUD_BASE_URL,
-    options.elizaCloudApiKey,
   );
 }
 
@@ -292,117 +282,6 @@ export interface VisionAnalysisProvider {
   analyze(
     options: VisionAnalysisOptions,
   ): Promise<MediaProviderResult<VisionAnalysisResult>>;
-}
-
-// ============================================================================
-// Eliza Cloud Provider Implementations
-// ============================================================================
-
-class ElizaCloudVideoProvider implements VideoGenerationProvider {
-  name = "eliza-cloud";
-  private baseUrl: string;
-  private apiKey?: string;
-
-  constructor(baseUrl: string, apiKey?: string) {
-    this.baseUrl = baseUrl;
-    this.apiKey = apiKey;
-  }
-
-  async generate(
-    options: VideoGenerationOptions,
-  ): Promise<MediaProviderResult<VideoGenerationResult>> {
-    const response = await fetchWithTimeout(
-      `${this.baseUrl}/media/video/generate`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          ...(this.apiKey ? { Authorization: `Bearer ${this.apiKey}` } : {}),
-        },
-        body: JSON.stringify({
-          prompt: options.prompt,
-          duration: options.duration,
-          aspectRatio: options.aspectRatio,
-          imageUrl: options.imageUrl,
-        }),
-      },
-    );
-
-    if (!response.ok) {
-      const text = await response.text();
-      return { success: false, error: `Eliza Cloud error: ${text}` };
-    }
-
-    const data = (await response.json()) as {
-      videoUrl?: string;
-      thumbnailUrl?: string;
-      duration?: number;
-    };
-    return {
-      success: true,
-      data: {
-        videoUrl: data.videoUrl,
-        thumbnailUrl: data.thumbnailUrl,
-        duration: data.duration,
-      },
-    };
-  }
-}
-
-class ElizaCloudAudioProvider implements AudioGenerationProvider {
-  name = "eliza-cloud";
-  private baseUrl: string;
-  private apiKey?: string;
-
-  constructor(baseUrl: string, apiKey?: string) {
-    this.baseUrl = baseUrl;
-    this.apiKey = apiKey;
-  }
-
-  async generate(
-    options: AudioGenerationOptions,
-  ): Promise<MediaProviderResult<AudioGenerationResult>> {
-    const response = await fetchWithTimeout(
-      `${this.baseUrl}/media/audio/generate`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          ...(this.apiKey ? { Authorization: `Bearer ${this.apiKey}` } : {}),
-        },
-        body: JSON.stringify({
-          prompt: options.prompt,
-          kind: options.kind,
-          audioKind: options.audioKind,
-          duration: options.duration,
-          instrumental: options.instrumental,
-          genre: options.genre,
-          voiceId: options.voiceId,
-          modelId: options.modelId,
-          outputFormat: options.outputFormat,
-        }),
-      },
-    );
-
-    if (!response.ok) {
-      const text = await response.text();
-      return { success: false, error: `Eliza Cloud error: ${text}` };
-    }
-
-    const data = (await response.json()) as {
-      audioUrl?: string;
-      title?: string;
-      duration?: number;
-    };
-    return {
-      success: true,
-      data: {
-        audioUrl: data.audioUrl,
-        title: data.title,
-        duration: data.duration,
-      },
-    };
-  }
 }
 
 class ElizaCloudVisionProvider implements VisionAnalysisProvider {
@@ -1899,9 +1778,9 @@ export function createVideoProvider(
         "Configure a direct provider (fal, openai, google) or enable cloud media.",
     );
   }
-  return new ElizaCloudVideoProvider(
-    options.elizaCloudBaseUrl ?? "https://elizacloud.ai/api/v1",
-    options.elizaCloudApiKey,
+  throw new Error(
+    "Cloud video generation is handled by the registered ModelType.VIDEO model. " +
+      "Enable @elizaos/plugin-elizacloud with ELIZAOS_CLOUD_API_KEY, or configure a direct provider (fal, openai, google).",
   );
 }
 
@@ -1940,22 +1819,20 @@ function getAutoAudioProvider(
 
 function missingAudioProviderError(kind: AudioKind): string {
   return (
-    `No ${kind} audio provider configured and cloud media is disabled. ` +
-    "Configure a direct provider (suno, elevenlabs, fal) or enable cloud media."
+    `No ${kind} audio provider configured. ` +
+    "Configure a direct provider (suno, elevenlabs, fal), or use cloud media through the registered ModelType.AUDIO/TEXT_TO_SPEECH models."
   );
 }
 
 class RoutedAudioProvider implements AudioGenerationProvider {
   name = "audio-router";
   private config?: AudioGenConfig;
-  private options: MediaProviderFactoryOptions;
 
   constructor(
     config: AudioGenConfig | undefined,
-    options: MediaProviderFactoryOptions,
+    _options: MediaProviderFactoryOptions,
   ) {
     this.config = config;
-    this.options = options;
   }
 
   async generate(
@@ -1968,13 +1845,7 @@ class RoutedAudioProvider implements AudioGenerationProvider {
       "cloud";
 
     if (providerName === "cloud") {
-      if (this.options.cloudMediaDisabled) {
-        return { success: false, error: missingAudioProviderError(kind) };
-      }
-      return createCloudAudioProvider(this.options).generate({
-        ...options,
-        kind,
-      });
+      return { success: false, error: missingAudioProviderError(kind) };
     }
 
     try {
@@ -2011,14 +1882,7 @@ class RoutedAudioProvider implements AudioGenerationProvider {
       };
     }
 
-    if (this.options.cloudMediaDisabled) {
-      return { success: false, error: missingAudioProviderError(kind) };
-    }
-
-    return createCloudAudioProvider(this.options).generate({
-      ...options,
-      kind,
-    });
+    return { success: false, error: missingAudioProviderError(kind) };
   }
 }
 
@@ -2035,13 +1899,16 @@ export function createAudioProvider(
         "Audio media is configured for cloud mode but cloud media is disabled.",
       );
     }
-    return createCloudAudioProvider(options);
+    throw new Error(
+      "Cloud audio generation is handled by the registered ModelType.AUDIO/TEXT_TO_SPEECH models. " +
+        "Enable @elizaos/plugin-elizacloud with ELIZAOS_CLOUD_API_KEY, or configure a direct provider (suno, elevenlabs, fal).",
+    );
   }
 
-  if (options.cloudMediaDisabled && !hasUsableDirectAudioProvider(config)) {
+  if (!hasUsableDirectAudioProvider(config)) {
     throw new Error(
-      "No audio provider configured and cloud media is disabled. " +
-        "Configure a direct provider (suno, elevenlabs, fal) or enable cloud media.",
+      "No audio provider configured. " +
+        "Configure a direct provider (suno, elevenlabs, fal), or select cloud media with @elizaos/plugin-elizacloud enabled.",
     );
   }
 

--- a/packages/agent/src/services/media-generation.test.ts
+++ b/packages/agent/src/services/media-generation.test.ts
@@ -27,8 +27,8 @@ type RuntimeOverrides = Omit<
   getModel?: (modelType: string) => ReturnType<IAgentRuntime["getModel"]>;
   useModel?: (
     modelType: string,
-    params: { prompt: string; size?: string; count?: number },
-  ) => Promise<Array<{ url: string }>>;
+    params: Record<string, unknown>,
+  ) => Promise<unknown>;
 };
 
 function runtime(overrides: RuntimeOverrides = {}): IAgentRuntime {
@@ -147,6 +147,176 @@ describe("AgentMediaGenerationService media generation", () => {
       prompt: "a cat in a little space helmet",
       size: "1024x1024",
       count: 1,
+    });
+  });
+
+  it("routes cloud video generation through the registered video model", async () => {
+    const videoModel = async () => ({});
+    const useModel = vi.fn(async () => ({
+      videoUrl: "https://cdn.example/generated-video.mp4",
+      duration: 6,
+      mimeType: "video/mp4",
+    }));
+    const getModel = vi.fn((modelType: string) =>
+      modelType === ModelType.VIDEO ? videoModel : undefined,
+    );
+    configMock.isElizaCloudServiceSelectedInConfig.mockReturnValue(true);
+    configMock.loadElizaConfig.mockReturnValue({
+      media: {
+        video: {
+          mode: "cloud",
+          defaultDuration: 6,
+        },
+      },
+    });
+
+    const { AgentMediaGenerationService } = await import(
+      "./media-generation.ts"
+    );
+    const service = new AgentMediaGenerationService(
+      runtime({
+        getModel,
+        useModel,
+      }),
+    );
+
+    expect(service.canGenerateMedia({ mediaType: "video" })).toBe(true);
+    await expect(
+      service.generateMedia({
+        mediaType: "video",
+        prompt: "glass lighthouse pan",
+        aspectRatio: "16:9",
+        imageUrl: "https://example.com/ref.png",
+      }),
+    ).resolves.toEqual({
+      mediaType: "video",
+      url: "https://cdn.example/generated-video.mp4",
+      videoUrl: "https://cdn.example/generated-video.mp4",
+      thumbnailUrl: undefined,
+      duration: 6,
+      mimeType: "video/mp4",
+    });
+
+    expect(getModel).toHaveBeenCalledWith(ModelType.VIDEO);
+    expect(useModel).toHaveBeenCalledWith(ModelType.VIDEO, {
+      prompt: "glass lighthouse pan",
+      duration: 6,
+      durationSeconds: 6,
+      aspectRatio: "16:9",
+      imageUrl: "https://example.com/ref.png",
+      referenceUrl: "https://example.com/ref.png",
+    });
+  });
+
+  it("routes cloud music generation through the registered audio model", async () => {
+    const audioModel = async () => ({});
+    const useModel = vi.fn(async () => ({
+      audioUrl: "https://cdn.example/generated-song.mp3",
+      title: "generated-song.mp3",
+      duration: 12,
+      mimeType: "audio/mpeg",
+    }));
+    const getModel = vi.fn((modelType: string) =>
+      modelType === ModelType.AUDIO ? audioModel : undefined,
+    );
+    configMock.isElizaCloudServiceSelectedInConfig.mockReturnValue(true);
+    configMock.loadElizaConfig.mockReturnValue({
+      media: {
+        audio: {
+          mode: "cloud",
+        },
+      },
+    });
+
+    const { AgentMediaGenerationService } = await import(
+      "./media-generation.ts"
+    );
+    const service = new AgentMediaGenerationService(
+      runtime({
+        getModel,
+        useModel,
+      }),
+    );
+
+    expect(
+      service.canGenerateMedia({ mediaType: "audio", audioKind: "music" }),
+    ).toBe(true);
+    await expect(
+      service.generateMedia({
+        mediaType: "audio",
+        audioKind: "music",
+        prompt: "ambient synth pulse",
+        duration: 12,
+        instrumental: true,
+        genre: "ambient",
+      }),
+    ).resolves.toEqual({
+      mediaType: "audio",
+      audioKind: "music",
+      url: "https://cdn.example/generated-song.mp3",
+      audioUrl: "https://cdn.example/generated-song.mp3",
+      title: "generated-song.mp3",
+      duration: 12,
+      mimeType: "audio/mpeg",
+    });
+
+    expect(useModel).toHaveBeenCalledWith(ModelType.AUDIO, {
+      prompt: "ambient synth pulse",
+      audioKind: "music",
+      duration: 12,
+      durationSeconds: 12,
+      instrumental: true,
+      genre: "ambient",
+      seed: undefined,
+    });
+  });
+
+  it("routes cloud speech generation through the registered text-to-speech model", async () => {
+    const ttsModel = async () => ({});
+    const useModel = vi.fn(async () => new Uint8Array([1, 2, 3]));
+    const getModel = vi.fn((modelType: string) =>
+      modelType === ModelType.TEXT_TO_SPEECH ? ttsModel : undefined,
+    );
+    configMock.isElizaCloudServiceSelectedInConfig.mockReturnValue(true);
+    configMock.loadElizaConfig.mockReturnValue({
+      media: {
+        audio: {
+          mode: "cloud",
+        },
+      },
+    });
+
+    const { AgentMediaGenerationService } = await import(
+      "./media-generation.ts"
+    );
+    const service = new AgentMediaGenerationService(
+      runtime({
+        getModel,
+        useModel,
+      }),
+    );
+
+    expect(
+      service.canGenerateMedia({ mediaType: "audio", audioKind: "tts" }),
+    ).toBe(true);
+    await expect(
+      service.generateMedia({
+        mediaType: "audio",
+        audioKind: "tts",
+        prompt: "hello world",
+        voice: "narrator",
+      }),
+    ).resolves.toEqual({
+      mediaType: "audio",
+      audioKind: "tts",
+      url: "data:audio/mpeg;base64,AQID",
+      audioUrl: "data:audio/mpeg;base64,AQID",
+      mimeType: "audio/mpeg",
+    });
+
+    expect(useModel).toHaveBeenCalledWith(ModelType.TEXT_TO_SPEECH, {
+      text: "hello world",
+      voice: "narrator",
     });
   });
 

--- a/packages/agent/src/services/media-generation.ts
+++ b/packages/agent/src/services/media-generation.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import {
   type IAgentRuntime,
   IMediaGenerationService,
@@ -8,7 +9,11 @@ import {
 } from "@elizaos/core";
 import { isElizaCloudServiceSelectedInConfig } from "@elizaos/shared";
 import { loadElizaConfig } from "../config/config.ts";
-import type { ImageConfig } from "../config/types.eliza.ts";
+import type {
+  AudioGenConfig,
+  ImageConfig,
+  VideoConfig,
+} from "../config/types.eliza.ts";
 import {
   createAudioProvider,
   createImageProvider,
@@ -38,8 +43,55 @@ function imageConfigUsesCloud(
   return mode === "cloud" && !options.cloudMediaDisabled;
 }
 
+function videoConfigUsesCloud(
+  config: VideoConfig | undefined,
+  options: MediaProviderFactoryOptions,
+): boolean {
+  const mode =
+    config?.mode ?? (options.cloudMediaDisabled ? "own-key" : "cloud");
+  return mode === "cloud" && !options.cloudMediaDisabled;
+}
+
+function audioConfigUsesCloud(
+  config: AudioGenConfig | undefined,
+  options: MediaProviderFactoryOptions,
+): boolean {
+  const mode =
+    config?.mode ?? (options.cloudMediaDisabled ? "own-key" : "cloud");
+  return mode === "cloud" && !options.cloudMediaDisabled;
+}
+
+function hasGenerationModel(
+  runtime: IAgentRuntime,
+  modelType: string,
+): boolean {
+  return typeof runtime.getModel(modelType) === "function";
+}
+
 function hasImageGenerationModel(runtime: IAgentRuntime): boolean {
-  return typeof runtime.getModel(ModelType.IMAGE) === "function";
+  return hasGenerationModel(runtime, ModelType.IMAGE);
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function bytesToAudioDataUrl(value: Buffer | ArrayBuffer | Uint8Array): string {
+  const bytes =
+    value instanceof ArrayBuffer
+      ? Buffer.from(value)
+      : Buffer.from(value.buffer, value.byteOffset, value.byteLength);
+  return `data:audio/mpeg;base64,${bytes.toString("base64")}`;
 }
 
 async function generateImageWithModel(
@@ -77,6 +129,124 @@ async function generateImageWithModel(
   };
 }
 
+async function generateVideoWithModel(
+  runtime: IAgentRuntime,
+  request: MediaGenerationRequest,
+  config: VideoConfig | undefined,
+): Promise<MediaGenerationResponse> {
+  if (!hasGenerationModel(runtime, ModelType.VIDEO)) {
+    throw new Error(
+      "Video generation requires Eliza Cloud or a direct video provider. " +
+        "Enable @elizaos/plugin-elizacloud with ELIZAOS_CLOUD_API_KEY, or configure an own-key video provider.",
+    );
+  }
+
+  const videoResponse = await runtime.useModel(ModelType.VIDEO, {
+    prompt: request.prompt,
+    duration: request.duration ?? config?.defaultDuration,
+    durationSeconds: request.duration ?? config?.defaultDuration,
+    aspectRatio: request.aspectRatio,
+    imageUrl: request.imageUrl,
+    referenceUrl: request.imageUrl,
+  });
+
+  if (!isRecord(videoResponse)) {
+    throw new Error(
+      "Video generation requires Eliza Cloud or a direct video provider, but no video URL was returned.",
+    );
+  }
+
+  const videoUrl =
+    stringValue(videoResponse.videoUrl) ?? stringValue(videoResponse.url);
+  if (!videoUrl) {
+    throw new Error(
+      "Video generation requires Eliza Cloud or a direct video provider, but no video URL was returned.",
+    );
+  }
+
+  return {
+    mediaType: "video",
+    url: videoUrl,
+    videoUrl,
+    thumbnailUrl: stringValue(videoResponse.thumbnailUrl),
+    duration: numberValue(videoResponse.duration),
+    mimeType: stringValue(videoResponse.mimeType) ?? "video/mp4",
+  };
+}
+
+async function generateAudioWithModel(
+  runtime: IAgentRuntime,
+  request: MediaGenerationRequest,
+): Promise<MediaGenerationResponse> {
+  if (request.audioKind === "tts") {
+    if (!hasGenerationModel(runtime, ModelType.TEXT_TO_SPEECH)) {
+      throw new Error(
+        "Speech audio generation requires Eliza Cloud TTS or a direct audio provider.",
+      );
+    }
+
+    const speech = await runtime.useModel(ModelType.TEXT_TO_SPEECH, {
+      text: request.prompt,
+      voice: request.voice,
+    });
+    const audioUrl = bytesToAudioDataUrl(speech);
+    return {
+      mediaType: "audio",
+      audioKind: "tts",
+      url: audioUrl,
+      audioUrl,
+      mimeType: "audio/mpeg",
+    };
+  }
+
+  if (request.audioKind === "sfx") {
+    throw new Error(
+      "Cloud sound-effect generation is not available. Configure a direct ElevenLabs or FAL audio provider.",
+    );
+  }
+
+  if (!hasGenerationModel(runtime, ModelType.AUDIO)) {
+    throw new Error(
+      "Music generation requires Eliza Cloud or a direct audio provider. " +
+        "Enable @elizaos/plugin-elizacloud with ELIZAOS_CLOUD_API_KEY, or configure an own-key audio provider.",
+    );
+  }
+
+  const audioResponse = await runtime.useModel(ModelType.AUDIO, {
+    prompt: request.prompt,
+    audioKind: request.audioKind ?? "music",
+    duration: request.duration,
+    durationSeconds: request.duration,
+    instrumental: request.instrumental,
+    genre: request.genre,
+    seed: request.seed,
+  });
+
+  if (!isRecord(audioResponse)) {
+    throw new Error(
+      "Music generation requires Eliza Cloud or a direct audio provider, but no audio URL was returned.",
+    );
+  }
+
+  const audioUrl =
+    stringValue(audioResponse.audioUrl) ?? stringValue(audioResponse.url);
+  if (!audioUrl) {
+    throw new Error(
+      "Music generation requires Eliza Cloud or a direct audio provider, but no audio URL was returned.",
+    );
+  }
+
+  return {
+    mediaType: "audio",
+    audioKind: request.audioKind,
+    url: audioUrl,
+    audioUrl,
+    title: stringValue(audioResponse.title),
+    duration: numberValue(audioResponse.duration),
+    mimeType: stringValue(audioResponse.mimeType) ?? "audio/mpeg",
+  };
+}
+
 export class AgentMediaGenerationService extends IMediaGenerationService {
   static override readonly serviceType = ServiceType.MEDIA_GENERATION;
 
@@ -105,8 +275,20 @@ export class AgentMediaGenerationService extends IMediaGenerationService {
         return true;
       }
       if (request.mediaType === "video") {
+        if (videoConfigUsesCloud(config.media?.video, providerOptions)) {
+          return hasGenerationModel(this.runtime, ModelType.VIDEO);
+        }
         createVideoProvider(config.media?.video, providerOptions);
         return true;
+      }
+      if (audioConfigUsesCloud(config.media?.audio, providerOptions)) {
+        if (request.audioKind === "sfx") return false;
+        return hasGenerationModel(
+          this.runtime,
+          request.audioKind === "tts"
+            ? ModelType.TEXT_TO_SPEECH
+            : ModelType.AUDIO,
+        );
       }
       createAudioProvider(config.media?.audio, providerOptions);
       return true;
@@ -153,6 +335,14 @@ export class AgentMediaGenerationService extends IMediaGenerationService {
     }
 
     if (request.mediaType === "video") {
+      if (videoConfigUsesCloud(config.media?.video, providerOptions)) {
+        return generateVideoWithModel(
+          this.runtime,
+          request,
+          config.media?.video,
+        );
+      }
+
       const result = await createVideoProvider(
         config.media?.video,
         providerOptions,
@@ -175,6 +365,10 @@ export class AgentMediaGenerationService extends IMediaGenerationService {
         duration: result.data.duration,
         mimeType: "video/mp4",
       };
+    }
+
+    if (audioConfigUsesCloud(config.media?.audio, providerOptions)) {
+      return generateAudioWithModel(this.runtime, request);
     }
 
     const result = await createAudioProvider(

--- a/packages/core/src/types/model.ts
+++ b/packages/core/src/types/model.ts
@@ -924,16 +924,39 @@ export interface TextToSpeechParams {
  * Parameters for audio processing models
  */
 export interface AudioProcessingParams {
-	audioUrl: string;
-	processingType: string;
+	audioUrl?: string;
+	processingType?: string;
+	prompt?: string;
+	audioKind?: "music" | "sfx" | "tts" | string;
+	text?: string;
+	duration?: number;
+	durationSeconds?: number;
+	instrumental?: boolean;
+	genre?: string;
+	voice?: string;
+	model?: string;
+	provider?: string;
+	outputFormat?: string;
+	referenceUrl?: string;
+	seed?: number;
 }
 
 /**
  * Parameters for video processing models
  */
 export interface VideoProcessingParams {
-	videoUrl: string;
-	processingType: string;
+	videoUrl?: string;
+	processingType?: string;
+	prompt?: string;
+	duration?: number;
+	durationSeconds?: number;
+	aspectRatio?: string;
+	imageUrl?: string;
+	referenceUrl?: string;
+	model?: string;
+	resolution?: string;
+	audio?: boolean;
+	voiceControl?: boolean;
 }
 
 // ============================================================================

--- a/plugins/plugin-elizacloud/__tests__/cloud-media-generation.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/cloud-media-generation.test.ts
@@ -1,0 +1,130 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  handleAudioGeneration,
+  handleVideoGeneration,
+  setCloudMediaClientFactoryForTesting,
+} from "../src/models/media";
+
+function runtime(): IAgentRuntime {
+  return {} as IAgentRuntime;
+}
+
+describe("Eliza Cloud media model handlers", () => {
+  afterEach(() => {
+    setCloudMediaClientFactoryForTesting(null);
+  });
+
+  it("posts video generation to /generate-video through the SDK route", async () => {
+    const postApiV1GenerateVideo = vi.fn(async () => ({
+      success: true,
+      id: "gen_video",
+      requestId: "req_video",
+      video: {
+        url: "https://cdn.example/video.mp4",
+        content_type: "video/mp4",
+      },
+      seed: 7,
+    }));
+    setCloudMediaClientFactoryForTesting(() => ({
+      routes: {
+        postApiV1GenerateVideo,
+        postApiV1GenerateMusic: vi.fn(),
+      },
+    }));
+
+    await expect(
+      handleVideoGeneration(runtime(), {
+        prompt: "glass lighthouse pan",
+        durationSeconds: 6,
+        imageUrl: "https://example.com/ref.png",
+        aspectRatio: "16:9",
+      })
+    ).resolves.toMatchObject({
+      url: "https://cdn.example/video.mp4",
+      videoUrl: "https://cdn.example/video.mp4",
+      mimeType: "video/mp4",
+      duration: 6,
+      requestId: "req_video",
+      id: "gen_video",
+      seed: 7,
+    });
+
+    expect(postApiV1GenerateVideo).toHaveBeenCalledWith({
+      json: {
+        prompt: "glass lighthouse pan",
+        referenceUrl: "https://example.com/ref.png",
+        durationSeconds: 6,
+        resolution: "16:9",
+      },
+      timeoutMs: expect.any(Number),
+    });
+  });
+
+  it("posts music generation to /generate-music through the SDK route", async () => {
+    const postApiV1GenerateMusic = vi.fn(async () => ({
+      success: true,
+      id: "gen_music",
+      requestId: "req_music",
+      status: "completed",
+      music: {
+        url: "https://cdn.example/song.mp3",
+        content_type: "audio/mpeg",
+        file_name: "song.mp3",
+      },
+    }));
+    setCloudMediaClientFactoryForTesting(() => ({
+      routes: {
+        postApiV1GenerateVideo: vi.fn(),
+        postApiV1GenerateMusic,
+      },
+    }));
+
+    await expect(
+      handleAudioGeneration(runtime(), {
+        prompt: "ambient synth pulse",
+        audioKind: "music",
+        durationSeconds: 12,
+        instrumental: true,
+        genre: "ambient",
+      })
+    ).resolves.toMatchObject({
+      url: "https://cdn.example/song.mp3",
+      audioUrl: "https://cdn.example/song.mp3",
+      mimeType: "audio/mpeg",
+      title: "song.mp3",
+      duration: 12,
+      requestId: "req_music",
+      id: "gen_music",
+      status: "completed",
+    });
+
+    expect(postApiV1GenerateMusic).toHaveBeenCalledWith({
+      json: {
+        prompt: "ambient synth pulse",
+        durationSeconds: 12,
+        instrumental: true,
+        extraInput: { genre: "ambient" },
+      },
+      timeoutMs: expect.any(Number),
+    });
+  });
+
+  it("fails cloud SFX clearly instead of calling the music route", async () => {
+    const postApiV1GenerateMusic = vi.fn();
+    setCloudMediaClientFactoryForTesting(() => ({
+      routes: {
+        postApiV1GenerateVideo: vi.fn(),
+        postApiV1GenerateMusic,
+      },
+    }));
+
+    await expect(
+      handleAudioGeneration(runtime(), {
+        prompt: "glass chime",
+        audioKind: "sfx",
+      })
+    ).rejects.toThrow(/direct SFX provider/);
+    expect(postApiV1GenerateMusic).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-elizacloud/src/index.ts
+++ b/plugins/plugin-elizacloud/src/index.ts
@@ -11,6 +11,7 @@ import {
   handleActionPlanner,
   handleImageDescription,
   handleImageGeneration,
+  handleAudioGeneration,
   handleResearch,
   handleResponseHandler,
   handleBatchTextEmbedding,
@@ -21,6 +22,7 @@ import {
   handleTextNano,
   handleTextSmall,
   handleTextToSpeech,
+  handleVideoGeneration,
 } from "./models";
 // Cloud services
 import { CloudAuthService } from "./services/cloud-auth";
@@ -236,6 +238,8 @@ export const elizaOSCloudPlugin: Plugin = {
     [ModelType.IMAGE]: handleImageGeneration,
     [ModelType.IMAGE_DESCRIPTION]: handleImageDescription,
     [ModelType.TEXT_TO_SPEECH]: handleTextToSpeech,
+    [ModelType.AUDIO]: handleAudioGeneration,
+    [ModelType.VIDEO]: handleVideoGeneration,
   },
 
   tests: [

--- a/plugins/plugin-elizacloud/src/models/index.ts
+++ b/plugins/plugin-elizacloud/src/models/index.ts
@@ -1,6 +1,7 @@
 export type { BatchEmbeddingResult } from "./embeddings";
 export { handleBatchTextEmbedding, handleTextEmbedding } from "./embeddings";
 export { handleImageDescription, handleImageGeneration } from "./image";
+export { handleAudioGeneration, handleVideoGeneration } from "./media";
 export { handleResearch } from "./research";
 export { fetchTextToSpeech, handleTextToSpeech } from "./speech";
 export {

--- a/plugins/plugin-elizacloud/src/models/media.ts
+++ b/plugins/plugin-elizacloud/src/models/media.ts
@@ -1,0 +1,184 @@
+import type {
+  AudioProcessingParams,
+  IAgentRuntime,
+  JsonValue,
+  VideoProcessingParams,
+} from "@elizaos/core";
+import { logger } from "@elizaos/core";
+import { resolveCloudTimeoutMs } from "../utils/config";
+import { createElizaCloudClient } from "../utils/sdk-client";
+
+interface CloudMediaClient {
+  routes: {
+    postApiV1GenerateVideo<T = unknown>(options: {
+      json: Record<string, unknown>;
+      timeoutMs?: number;
+    }): Promise<T>;
+    postApiV1GenerateMusic<T = unknown>(options: {
+      json: Record<string, unknown>;
+      timeoutMs?: number;
+    }): Promise<T>;
+  };
+}
+
+type CloudMediaClientFactory = (runtime: IAgentRuntime) => CloudMediaClient;
+
+let cloudMediaClientFactory: CloudMediaClientFactory = (runtime) =>
+  createElizaCloudClient(runtime) as CloudMediaClient;
+
+export function setCloudMediaClientFactoryForTesting(
+  factory: CloudMediaClientFactory | null,
+): void {
+  cloudMediaClientFactory =
+    factory ??
+    ((runtime) => createElizaCloudClient(runtime) as CloudMediaClient);
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function booleanValue(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+type CloudMediaModelResult = Record<string, JsonValue>;
+
+function cleanRecord(
+  record: Record<string, JsonValue | undefined>,
+): CloudMediaModelResult {
+  return Object.fromEntries(
+    Object.entries(record).filter(([, value]) => value !== undefined),
+  ) as CloudMediaModelResult;
+}
+
+interface CloudVideoResponse {
+  success?: boolean;
+  id?: string;
+  requestId?: string;
+  video?: {
+    url?: string;
+    content_type?: string;
+    width?: number;
+    height?: number;
+  };
+  seed?: number;
+}
+
+export async function handleVideoGeneration(
+  runtime: IAgentRuntime,
+  params: VideoProcessingParams,
+): Promise<CloudMediaModelResult> {
+  const prompt = stringValue(params.prompt);
+  if (!prompt) {
+    throw new Error("Cloud video generation requires a prompt");
+  }
+
+  const referenceUrl =
+    stringValue(params.referenceUrl) ?? stringValue(params.imageUrl);
+  const durationSeconds =
+    numberValue(params.durationSeconds) ?? numberValue(params.duration);
+
+  logger.log("[ELIZAOS_CLOUD] Using VIDEO model via /generate-video");
+  const response = await cloudMediaClientFactory(
+    runtime,
+  ).routes.postApiV1GenerateVideo<CloudVideoResponse>({
+    json: cleanRecord({
+      prompt,
+      model: stringValue(params.model),
+      referenceUrl,
+      durationSeconds,
+      resolution: stringValue(params.resolution ?? params.aspectRatio),
+      audio: booleanValue(params.audio),
+      voiceControl: booleanValue(params.voiceControl),
+    }),
+    timeoutMs: resolveCloudTimeoutMs("ELIZAOS_CLOUD_VIDEO_TIMEOUT_MS", 300_000),
+  });
+
+  const videoUrl = response.video?.url;
+  if (!videoUrl) {
+    throw new Error("Eliza Cloud video generation returned no video URL");
+  }
+
+  return cleanRecord({
+    url: videoUrl,
+    videoUrl,
+    mimeType: response.video?.content_type ?? "video/mp4",
+    duration: durationSeconds,
+    requestId: response.requestId,
+    id: response.id,
+    seed: response.seed,
+  });
+}
+
+interface CloudMusicResponse {
+  success?: boolean;
+  id?: string;
+  requestId?: string;
+  status?: string;
+  music?: {
+    url?: string;
+    content_type?: string;
+    file_name?: string;
+  };
+}
+
+export async function handleAudioGeneration(
+  runtime: IAgentRuntime,
+  params: AudioProcessingParams,
+): Promise<CloudMediaModelResult> {
+  const kind = stringValue(params.audioKind) ?? "music";
+  if (kind !== "music") {
+    throw new Error(
+      "Eliza Cloud AUDIO generation supports music. Use TEXT_TO_SPEECH for speech or configure a direct SFX provider.",
+    );
+  }
+
+  const prompt = stringValue(params.prompt ?? params.text);
+  if (!prompt) {
+    throw new Error("Cloud music generation requires a prompt");
+  }
+
+  const durationSeconds =
+    numberValue(params.durationSeconds) ?? numberValue(params.duration);
+
+  logger.log("[ELIZAOS_CLOUD] Using AUDIO model via /generate-music");
+  const response = await cloudMediaClientFactory(
+    runtime,
+  ).routes.postApiV1GenerateMusic<CloudMusicResponse>({
+    json: cleanRecord({
+      prompt,
+      model: stringValue(params.model),
+      provider: stringValue(params.provider),
+      durationSeconds,
+      referenceUrl: stringValue(params.referenceUrl ?? params.audioUrl),
+      seed: numberValue(params.seed),
+      outputFormat: stringValue(params.outputFormat),
+      instrumental: booleanValue(params.instrumental),
+      extraInput: params.genre ? { genre: params.genre } : undefined,
+    }),
+    timeoutMs: resolveCloudTimeoutMs("ELIZAOS_CLOUD_MUSIC_TIMEOUT_MS", 300_000),
+  });
+
+  const audioUrl = response.music?.url;
+  if (!audioUrl) {
+    throw new Error("Eliza Cloud music generation returned no audio URL");
+  }
+
+  return cleanRecord({
+    url: audioUrl,
+    audioUrl,
+    mimeType: response.music?.content_type ?? "audio/mpeg",
+    title: response.music?.file_name,
+    duration: durationSeconds,
+    requestId: response.requestId,
+    id: response.id,
+    status: response.status,
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #10986.

- Remove agent-side Eliza Cloud video/audio providers that posted to nonexistent `/media/video/generate` and `/media/audio/generate` endpoints.
- Route Cloud-selected video through `ModelType.VIDEO` and Cloud-selected music through `ModelType.AUDIO`.
- Register `plugin-elizacloud` handlers for `ModelType.VIDEO` and `ModelType.AUDIO` using the generated SDK routes for `/api/v1/generate-video` and `/api/v1/generate-music`.
- Keep own-key providers on the direct path, route Cloud TTS through the existing `ModelType.TEXT_TO_SPEECH`, and fail Cloud SFX clearly.
- Widen core AUDIO/VIDEO model params additively for media generation fields.

## Evidence

See `.github/issue-evidence/10986-cloud-media-model-routing.md`.

Commands run:

```bash
rg -n "media/video/generate|media/audio/generate|ElizaCloud(Video|Audio)Provider|createCloudAudioProvider" packages/agent plugins/plugin-elizacloud packages/cloud/api -g '*.ts' -g '*.d.ts'
bunx biome check packages/agent/src/providers/media-provider.ts packages/agent/src/providers/media-provider.test.ts packages/agent/src/services/media-generation.ts packages/agent/src/services/media-generation.test.ts packages/core/src/types/model.ts plugins/plugin-elizacloud/src/index.ts plugins/plugin-elizacloud/src/models/index.ts plugins/plugin-elizacloud/src/models/media.ts plugins/plugin-elizacloud/__tests__/cloud-media-generation.test.ts
(cd packages/agent && bunx vitest run --config vitest.config.ts src/providers/media-provider.test.ts src/services/media-generation.test.ts)
(cd plugins/plugin-elizacloud && bunx vitest run --config vitest.config.ts __tests__/cloud-media-generation.test.ts)
bun run --cwd plugins/plugin-elizacloud typecheck
bun run --cwd packages/core typecheck
```

All passed. The stale-endpoint grep returned no matches.

`bun run --cwd packages/agent typecheck` still fails on unrelated current-base command catalog/plugin export drift and missing `@elizaos/cloud-routing` declarations in wallet plugin imports; no media-routing or plugin-elizacloud handler type errors remain.

## Live Cloud

N/A: live Cloud video/music calls require valid Cloud credentials and paid generation credits. Unit tests assert the SDK calls and payloads for the real generated routes instead of the removed dead endpoints.