### PR TITLE
fix(ui): elizacloud.ai apex lands authenticated users on the cloud console (credits/manage), not chat

### DIFF
--- a/packages/ui/src/cloud/shell/CloudRouterShell.test.tsx
+++ b/packages/ui/src/cloud/shell/CloudRouterShell.test.tsx
@@ -40,11 +40,14 @@ function setHostname(hostname: string): void {
   });
 }
 
-function renderCatchAll(): void {
+function renderCatchAll(initialPath = "/"): void {
   render(
-    <MemoryRouter initialEntries={["/"]}>
+    <MemoryRouter initialEntries={[initialPath]}>
       <Routes>
         <Route path="/login" element={<div data-testid="login-page" />} />
+        {/* The console home target. The real app renders billing here; the test
+            just needs a marker to prove the apex root redirected to it. */}
+        <Route path="/settings" element={<div data-testid="console-home" />} />
         <Route
           path="*"
           element={
@@ -73,11 +76,23 @@ describe("CloudRouterShell apex catch-all (Gate B)", () => {
     expect(screen.queryByTestId("agent-app")).toBeNull();
   });
 
-  it("renders the agent app on apex when a valid Steward session exists", () => {
+  it("redirects an authenticated apex ROOT visitor to the console home (credits/manage), not chat", () => {
     setHostname("elizacloud.ai");
     localStorage.setItem(STEWARD_TOKEN_KEY, stewardToken(FUTURE_EXP));
-    renderCatchAll();
+    renderCatchAll("/");
+    expect(screen.getByTestId("console-home")).toBeTruthy();
+    expect(screen.queryByTestId("agent-app")).toBeNull();
+    expect(screen.queryByTestId("login-page")).toBeNull();
+  });
+
+  it("still renders the agent app for an authenticated apex DEEP link (not the bare root)", () => {
+    // A shared-agent / deep link on the apex must keep working — only the bare
+    // landing is rerouted to the console home.
+    setHostname("elizacloud.ai");
+    localStorage.setItem(STEWARD_TOKEN_KEY, stewardToken(FUTURE_EXP));
+    renderCatchAll("/some/agent/deep-link");
     expect(screen.getByTestId("agent-app")).toBeTruthy();
+    expect(screen.queryByTestId("console-home")).toBeNull();
     expect(screen.queryByTestId("login-page")).toBeNull();
   });
 

--- a/packages/ui/src/cloud/shell/CloudRouterShell.tsx
+++ b/packages/ui/src/cloud/shell/CloudRouterShell.tsx
@@ -185,13 +185,34 @@ function isApexControlPlaneHost(): boolean {
 }
 
 /**
+ * Where an authenticated visitor landing on the apex ROOT is sent. The apex
+ * (elizacloud.ai) is the cloud CONSOLE — its job is "add credits / manage your
+ * account", not chat (chat is the agent app's home, served from
+ * app.elizacloud.ai). `/settings#billing` is the canonical credits/billing
+ * surface (every in-app billing link resolves here, e.g. the
+ * `dashboard/billing → /settings#billing` compat redirect above) and its tabbed
+ * shell (Billing · Developer/API keys · Connections · Organization) is the
+ * account-management hub. Both domains serve the SAME packages/app bundle, so
+ * without this the apex and the app subdomain look identical when signed in.
+ */
+const APEX_AUTHENTICATED_HOME = "/settings#billing";
+
+/**
  * Catch-all element. Renders the agent app exactly as before, EXCEPT on an apex
- * control-plane host where the Steward session is resolved-and-unauthenticated —
- * there it redirects to the registered cloud `/login` page (`returnTo`
- * preserved) instead of booting the agent shell that would 401-wall. The apex
- * 401-wall was a router fall-through: no route registers the apex root `/`, so
- * an unauthenticated apex visitor hit this catch-all and booted the agent
- * runtime against a backend that isn't there.
+ * control-plane host, where it makes the two domains behave differently:
+ *
+ *  - unauthenticated → the Steward `/login` page (`returnTo` preserved) instead
+ *    of booting the agent shell that would 401-wall on `/api/*`. (The apex
+ *    401-wall was a router fall-through: no route registers the apex root `/`,
+ *    so an unauthenticated apex visitor hit this catch-all and booted the agent
+ *    runtime against a backend that isn't there.)
+ *  - authenticated AND on the bare apex root (`/`) → the cloud console home
+ *    ({@link APEX_AUTHENTICATED_HOME}) instead of chat, so elizacloud.ai lands
+ *    on the credits/manage dashboard. Deeper apex paths (a shared agent, a deep
+ *    link) still render the app so those links keep working.
+ *
+ * Every non-apex host (per-agent subdomains, app.elizacloud.ai, localhost) is
+ * untouched: chat stays home.
  */
 export function AppCatchAllRoute({
   appElement,
@@ -200,11 +221,21 @@ export function AppCatchAllRoute({
 }): React.JSX.Element {
   const { ready, authenticated } = useSessionAuth();
   const location = useLocation();
-  if (isApexControlPlaneHost() && ready && !authenticated) {
-    const returnTo = encodeURIComponent(
-      `${location.pathname}${location.search}`,
-    );
-    return <Navigate to={`/login?returnTo=${returnTo}`} replace />;
+  if (isApexControlPlaneHost() && ready) {
+    if (!authenticated) {
+      const returnTo = encodeURIComponent(
+        `${location.pathname}${location.search}`,
+      );
+      return <Navigate to={`/login?returnTo=${returnTo}`} replace />;
+    }
+    // Authenticated on the bare apex root → the console home. Guard on the root
+    // path (and no tab hash) so we redirect ONLY the landing, never a deep link
+    // the user navigated to on purpose. The target is `/settings`, which is not
+    // an apex-console route, so it re-enters this catch-all at a non-root path
+    // and renders the app (which reads `#billing`) — no redirect loop.
+    if (location.pathname === "/" && !location.hash) {
+      return <Navigate to={APEX_AUTHENTICATED_HOME} replace />;
+    }
   }
   return <>{appElement}</>;
 }


### PR DESCRIPTION
## Problem

`elizacloud.ai` (the cloud console) and `app.elizacloud.ai` (the agent app) serve the **same** `packages/app` bundle, and `CloudRouterShell` kept "chat is home" on **every** host. So when you're signed in, both domains render the identical chat app — and the apex never shows the thing it exists for: **add credits / manage your account**. (Unauthenticated apex already correctly redirects to Steward `/login`; this is only the authenticated landing.)

## Fix

`AppCatchAllRoute` now, on an apex control-plane host (`elizacloud.ai` / `www` / `staging` / `dev`), sends an **authenticated** visitor who lands on the **bare root `/`** to the console home — `/settings#billing`, the canonical credits/billing surface (every in-app billing link resolves here; its tabbed shell of **Billing · Developer/API keys · Connections · Organization** is the account-management hub).

Deliberately narrow:
- **Unauthenticated apex → `/login`**: unchanged.
- **Authenticated apex deep link** (a shared agent, a deep link): still renders the app, so those links keep working — only the bare landing is rerouted.
- **Every non-apex host** (per-agent subdomains, `app.elizacloud.ai`, `localhost`): untouched — chat stays home.
- **No redirect loop**: `/settings` isn't an apex-console route, so it re-enters the catch-all at a non-root path and renders the app, which reads `#billing`.

## Why `/settings#billing` and not a bespoke overview

The old `@elizaos/cloud-frontend` dashboard was dissolved into the app: `dashboard/billing → /settings#billing`, `dashboard/api-keys → /settings#api-keys` (see `DASHBOARD_REDIRECTS`). There is no standalone `/dashboard` overview route today, and `/settings` **is** the management hub (credits front-and-center + tabs for keys/connections/org). If we later want a dedicated overview page, flipping `APEX_AUTHENTICATED_HOME` is a one-line change.

## Verification

- `packages/ui` unit suite `CloudRouterShell.test.tsx` — **7/7 pass**, including the two new cases: apex+auth+root → console home, apex+auth+deep-link → agent app (deep links preserved). Existing cases (unauth→login, staging→login, per-agent subdomain→app, localhost→app) unchanged.
- `biome check` clean; `tsgo` typecheck clean on `packages/ui`.
- Frontend visual proof: **N/A pre-deploy** — the render target `/settings#billing` is an existing, unchanged, already-tested surface; this PR only changes *which* existing surface the apex root lands on. Once it deploys to `staging.elizacloud.ai`, an authenticated visit to the apex root should land on the billing/credits page instead of chat (will attach the staging screenshot on deploy).

Closes the console-UX half of the launch console issue. Prod (`elizacloud.ai`) additionally needs a deliberate develop→prod promote to leave the current frozen build — tracked separately.
