### PR TITLE
fix(cloud): block refunded Stripe Connect payout retries

### DIFF
--- a/.github/issue-evidence/11022-stripe-connect-retry-double-pay.md
+++ b/.github/issue-evidence/11022-stripe-connect-retry-double-pay.md
@@ -1,0 +1,45 @@
+# #11022 Stripe Connect Retry Double-Pay Evidence
+
+## Change
+
+- Blocked a Stripe Connect payout retry when the ledger debit is deduplicated and a prior compensating refund exists for the same `idempotency_key`.
+- Kept normal same-key retry behavior intact when no refund exists, so Stripe idempotency can still replay a successful or ambiguous transfer.
+- Added a primary-read ledger helper that checks normalized earning source IDs without duplicating ledger source-id logic in the route.
+
+## Verification
+
+```bash
+bun test packages/cloud/api/__tests__/stripe-connect-transfer-route.test.ts
+```
+
+Result: passed (`7 pass, 0 fail`).
+
+Covered:
+- successful payout debits once and transfers
+- definitive Stripe rejection refunds once
+- same-key retry after a refunded rejection returns `409` before any Stripe transfer
+- same-key retry without a refund still reaches Stripe idempotency replay
+- ambiguous failures hold the debit for reconciliation
+- failed debit short-circuits before Stripe
+
+```bash
+bunx biome check packages/cloud/api/v1/earnings/payout/stripe-connect/transfer/route.ts packages/cloud/api/__tests__/stripe-connect-transfer-route.test.ts packages/cloud/shared/src/lib/services/redeemable-earnings.ts
+```
+
+Result: passed (`Checked 3 files`).
+
+```bash
+bun run --cwd packages/cloud/api typecheck
+```
+
+Result: passed (`tsgo --noEmit`).
+
+```bash
+bun run --cwd packages/cloud/shared typecheck
+```
+
+Result: passed (`tsgo --noEmit`).
+
+## UI / Live Stripe Evidence
+
+N/A: server-side admin-gated Stripe Connect money-path fix. No `packages/app` UI changed. Live Stripe replay was not run because the exploit requires a real transient Stripe rejection/retry sequence against Connect transfers; the focused route tests exercise the exact pre-Stripe guard and preserve the intended idempotent replay path.

--- a/packages/cloud/api/__tests__/stripe-connect-transfer-route.test.ts
+++ b/packages/cloud/api/__tests__/stripe-connect-transfer-route.test.ts
@@ -57,8 +57,14 @@ mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
 const getBalance = mock();
 const reduceEarnings = mock();
 const addEarnings = mock();
+const hasEarningForSourceId = mock();
 mock.module("@/lib/services/redeemable-earnings", () => ({
-  redeemableEarningsService: { getBalance, reduceEarnings, addEarnings },
+  redeemableEarningsService: {
+    getBalance,
+    reduceEarnings,
+    addEarnings,
+    hasEarningForSourceId,
+  },
 }));
 
 mock.module("@/lib/stripe", () => ({
@@ -100,6 +106,7 @@ beforeEach(() => {
   getBalance.mockReset();
   reduceEarnings.mockReset();
   addEarnings.mockReset();
+  hasEarningForSourceId.mockReset();
 
   requireAdmin.mockResolvedValue({ userId: "admin-1" });
   findByUserId.mockResolvedValue({
@@ -120,6 +127,7 @@ beforeEach(() => {
     ledgerEntryId: "led_1",
   });
   addEarnings.mockResolvedValue({ success: true, newBalance: 100 });
+  hasEarningForSourceId.mockResolvedValue(false);
 });
 
 describe("Stripe Connect transfer route — money-path invariants (#10279)", () => {
@@ -180,6 +188,65 @@ describe("Stripe Connect transfer route — money-path invariants (#10279)", () 
     expect(refundArg.sourceId).toBe(`${IDEMPOTENCY_KEY}:refund`);
     expect(refundArg.dedupeBySourceId).toBe(true);
     expect(refundArg.amount).toBe(10);
+  });
+
+  test("refunded same-key retry is blocked before a fresh Stripe transfer", async () => {
+    reduceEarnings.mockResolvedValue({
+      success: true,
+      newBalance: 100,
+      ledgerEntryId: "led_original_debit",
+      deduplicated: true,
+    });
+    hasEarningForSourceId.mockResolvedValue(true);
+
+    const res = await callTransfer(10);
+    const body = (await res.json()) as {
+      success: boolean;
+      error: string;
+      requiresFreshIdempotencyKey?: boolean;
+    };
+
+    expect(res.status).toBe(409);
+    expect(body.success).toBe(false);
+    expect(body.error).toBe(
+      "Prior payout attempt was rejected and refunded; use a fresh idempotency_key",
+    );
+    expect(body.requiresFreshIdempotencyKey).toBe(true);
+    expect(hasEarningForSourceId).toHaveBeenCalledWith({
+      userId: USER_ID,
+      source: "creator_revenue_share",
+      sourceId: `${IDEMPOTENCY_KEY}:refund`,
+    });
+    expect(transferToConnectAccount).not.toHaveBeenCalled();
+    expect(addEarnings).not.toHaveBeenCalled();
+  });
+
+  test("deduped same-key retry without refund still reaches Stripe idempotency replay", async () => {
+    reduceEarnings.mockResolvedValue({
+      success: true,
+      newBalance: 90,
+      ledgerEntryId: "led_original_debit",
+      deduplicated: true,
+    });
+    hasEarningForSourceId.mockResolvedValue(false);
+    transferToConnectAccount.mockResolvedValue({
+      transferId: "tr_replayed",
+      amountCents: 1000,
+    });
+
+    const res = await callTransfer(10);
+    const body = (await res.json()) as {
+      success: boolean;
+      transferId?: string;
+      newBalance?: number;
+    };
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.transferId).toBe("tr_replayed");
+    expect(body.newBalance).toBe(90);
+    expect(transferToConnectAccount).toHaveBeenCalledTimes(1);
+    expect(addEarnings).not.toHaveBeenCalled();
   });
 
   test("AMBIGUOUS Stripe failure (5xx) HOLDS the debit — no re-credit, needsReconciliation", async () => {

--- a/packages/cloud/api/v1/earnings/payout/stripe-connect/transfer/route.ts
+++ b/packages/cloud/api/v1/earnings/payout/stripe-connect/transfer/route.ts
@@ -112,6 +112,28 @@ async function handleTransfer(c: AppContext) {
       { status: 409 },
     );
   }
+  if (debit.deduplicated) {
+    const priorRefund = await redeemableEarningsService.hasEarningForSourceId({
+      userId: user_id,
+      source: "creator_revenue_share",
+      sourceId: `${idempotency_key}:refund`,
+    });
+    if (priorRefund) {
+      logger.warn("[StripeConnect] refunded payout retry blocked", {
+        userId: user_id,
+        idempotencyKey: idempotency_key,
+      });
+      return Response.json(
+        {
+          success: false,
+          error:
+            "Prior payout attempt was rejected and refunded; use a fresh idempotency_key",
+          requiresFreshIdempotencyKey: true,
+        },
+        { status: 409 },
+      );
+    }
+  }
 
   try {
     const { transferId, amountCents } = await transferToConnectAccount(

--- a/packages/cloud/shared/src/lib/services/redeemable-earnings.ts
+++ b/packages/cloud/shared/src/lib/services/redeemable-earnings.ts
@@ -147,6 +147,28 @@ const normalizeLedgerMetadata = (metadata?: Record<string, unknown>): Record<str
 // ============================================================================
 
 class RedeemableEarningsService {
+  async hasEarningForSourceId(params: {
+    userId: string;
+    source: EarningsSource;
+    sourceId: string;
+  }): Promise<boolean> {
+    const ledgerSourceId = normalizeLedgerSourceId(params.sourceId);
+    const [existingLedger] = await dbWrite
+      .select({ id: redeemableEarningsLedger.id })
+      .from(redeemableEarningsLedger)
+      .where(
+        and(
+          eq(redeemableEarningsLedger.user_id, params.userId),
+          eq(redeemableEarningsLedger.entry_type, "earning"),
+          eq(redeemableEarningsLedger.earnings_source, params.source),
+          eq(redeemableEarningsLedger.source_id, ledgerSourceId),
+        ),
+      )
+      .limit(1);
+
+    return !!existingLedger;
+  }
+
   /**
    * Get user's current redeemable balance
    */


### PR DESCRIPTION
## Summary

Closes #11022.

This blocks the Stripe Connect double-pay retry window where a same-key retry after a definitive rejection/refund could dedupe the ledger debit but still create a fresh Stripe transfer. If the debit is deduplicated and the matching `:refund` earning exists, the route now returns 409 and requires a fresh idempotency key. Normal same-key retry behavior without a prior refund still reaches Stripe idempotency replay.

## Evidence

- Added `.github/issue-evidence/11022-stripe-connect-retry-double-pay.md`

## Verification

- `bun test packages/cloud/api/__tests__/stripe-connect-transfer-route.test.ts` (7 pass, 0 fail)
- `bunx biome check packages/cloud/api/v1/earnings/payout/stripe-connect/transfer/route.ts packages/cloud/api/__tests__/stripe-connect-transfer-route.test.ts packages/cloud/shared/src/lib/services/redeemable-earnings.ts` (passed)
- `bun run --cwd packages/cloud/api typecheck` (passed)
- `bun run --cwd packages/cloud/shared typecheck` (passed)

## UI / Live Stripe

N/A: server-side admin-gated Stripe Connect money-path fix. No app UI changed. Live Stripe replay was not run because the exploit requires a real transient Stripe rejection/retry sequence against Connect transfers; the focused route tests exercise the pre-Stripe guard and preserve the intended replay path.