### PR TITLE
fix(cloud): block Stripe Connect payout double-pay on same-key retry after rejected+refunded transfer (#11022)

### DIFF
--- a/packages/cloud/api/__tests__/stripe-connect-transfer-route.test.ts
+++ b/packages/cloud/api/__tests__/stripe-connect-transfer-route.test.ts
@@ -57,8 +57,14 @@ mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
 const getBalance = mock();
 const reduceEarnings = mock();
 const addEarnings = mock();
+const hasEarningBySourceId = mock();
 mock.module("@/lib/services/redeemable-earnings", () => ({
-  redeemableEarningsService: { getBalance, reduceEarnings, addEarnings },
+  redeemableEarningsService: {
+    getBalance,
+    reduceEarnings,
+    addEarnings,
+    hasEarningBySourceId,
+  },
 }));
 
 mock.module("@/lib/stripe", () => ({
@@ -100,6 +106,9 @@ beforeEach(() => {
   getBalance.mockReset();
   reduceEarnings.mockReset();
   addEarnings.mockReset();
+  hasEarningBySourceId.mockReset();
+  // Default: no prior compensating refund exists (the common case).
+  hasEarningBySourceId.mockResolvedValue(false);
 
   requireAdmin.mockResolvedValue({ userId: "admin-1" });
   findByUserId.mockResolvedValue({
@@ -223,5 +232,61 @@ describe("Stripe Connect transfer route — money-path invariants (#10279)", () 
     expect(res.status).toBe(409);
     expect(transferToConnectAccount).not.toHaveBeenCalled();
     expect(addEarnings).not.toHaveBeenCalled();
+  });
+
+  // #11022: a DEDUPLICATED debit whose key was already rejected + refunded must
+  // NOT fire a fresh transfer (that double-pays: fiat out + balance kept).
+  test("refuses a same-key retry after a rejected+refunded attempt (deduplicated debit + existing :refund → 409, no transfer)", async () => {
+    reduceEarnings.mockResolvedValue({
+      success: true,
+      newBalance: 100, // balance unchanged: the dedup reused the prior (rolled-back) adjustment
+      ledgerEntryId: "led_1",
+      deduplicated: true,
+    });
+    // A compensating `${key}:refund` earning from the definitively-rejected first
+    // attempt exists → the debit no longer holds funds.
+    hasEarningBySourceId.mockResolvedValue(true);
+
+    const res = await callTransfer(10);
+    const body = (await res.json()) as { success: boolean; error: string };
+
+    expect(res.status).toBe(409);
+    expect(body.success).toBe(false);
+    expect(body.error).toMatch(/fresh idempotency_key/i);
+    // The critical invariant: NO fresh transfer, so no double-pay.
+    expect(transferToConnectAccount).not.toHaveBeenCalled();
+    expect(addEarnings).not.toHaveBeenCalled();
+    // It checked the refund marker keyed on `${key}:refund`.
+    const checkArg = hasEarningBySourceId.mock.calls[0]?.[0] as {
+      sourceId: string;
+      source: string;
+    };
+    expect(checkArg.sourceId).toBe(`${IDEMPOTENCY_KEY}:refund`);
+    expect(checkArg.source).toBe("creator_revenue_share");
+  });
+
+  // The legitimate ambiguous-retry path must still work: a deduplicated debit
+  // with NO prior refund is Stripe's own transfer-idempotency replaying the
+  // single transfer — it must proceed (debited 1×, paid 1×), not be blocked.
+  test("still proceeds on a deduplicated debit when no refund exists (ambiguous-timeout retry, Stripe replays)", async () => {
+    reduceEarnings.mockResolvedValue({
+      success: true,
+      newBalance: 90,
+      ledgerEntryId: "led_1",
+      deduplicated: true,
+    });
+    hasEarningBySourceId.mockResolvedValue(false); // no compensating refund
+    transferToConnectAccount.mockResolvedValue({
+      transferId: "tr_replay",
+      amountCents: 1000,
+    });
+
+    const res = await callTransfer(10);
+    const body = (await res.json()) as { success: boolean; transferId?: string };
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.transferId).toBe("tr_replay");
+    expect(transferToConnectAccount).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cloud/api/v1/earnings/payout/stripe-connect/transfer/route.ts
+++ b/packages/cloud/api/v1/earnings/payout/stripe-connect/transfer/route.ts
@@ -113,6 +113,39 @@ async function handleTransfer(c: AppContext) {
     );
   }
 
+  // A DEDUPLICATED debit means an adjustment row for this idempotency_key already
+  // exists. That is legitimate for the ambiguous-retry case (Call 1 debited, the
+  // transfer timed out with an uncertain outcome, we held the debit; Stripe's own
+  // transfer idempotency then replays the single transfer on retry — no double
+  // pay). But if a compensating `${key}:refund` earning ALSO exists, Call 1's
+  // transfer was DEFINITIVELY rejected and the debit was rolled back — the balance
+  // was fully restored, so this debit no longer holds funds. Proceeding would fire
+  // a FRESH transfer (Stripe never persisted the rejected key) against a no-op
+  // debit and pay the creator twice while they keep the balance. Refuse the retry
+  // and require a fresh idempotency_key. (#11022)
+  if (debit.deduplicated) {
+    const alreadyRefunded =
+      await redeemableEarningsService.hasEarningBySourceId({
+        userId: user_id,
+        source: "creator_revenue_share",
+        sourceId: `${idempotency_key}:refund`,
+      });
+    if (alreadyRefunded) {
+      logger.warn("[StripeConnect] refusing retry of a rejected+refunded key", {
+        userId: user_id,
+        idempotencyKey: idempotency_key,
+      });
+      return Response.json(
+        {
+          success: false,
+          error:
+            "This idempotency_key was already rejected and the balance refunded. Retry with a fresh idempotency_key.",
+        },
+        { status: 409 },
+      );
+    }
+  }
+
   try {
     const { transferId, amountCents } = await transferToConnectAccount(
       toConnectClient(requireStripe()),

--- a/packages/cloud/shared/src/lib/services/__tests__/creator-earnings-idempotency.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/creator-earnings-idempotency.test.ts
@@ -197,3 +197,80 @@ describe("creator earnings idempotency (#10423)", () => {
     expect(await earningLedgerCount(userId)).toBe(2);
   });
 });
+
+/**
+ * #11022 — the Stripe-Connect payout double-pay guard's DB primitive.
+ *
+ * When a payout's transfer is DEFINITIVELY rejected, the route restores balance
+ * by adding a compensating `${idempotency_key}:refund` earning. `hasEarningBySourceId`
+ * is what lets the route detect, on a same-key retry, that the debit was already
+ * rolled back (a refund exists) and refuse a fresh transfer. This drives the REAL
+ * lookup against PGlite: it must find the compensating refund row (via the same
+ * normalized source_id + `entry_type='earning'` the dedup path writes) and must
+ * NOT false-positive on an unrelated key.
+ */
+describe("hasEarningBySourceId — payout refund detection (#11022)", () => {
+  test("pglite applied (loud, never a silent no-op pass)", () => {
+    expect(pgliteReady).toBe(true);
+  });
+
+  let userId: string;
+  beforeEach(async () => {
+    if (!pgliteReady) return;
+    userId = await seedUser();
+  });
+
+  test("detects a compensating `${key}:refund` earning; false for an untouched key", async () => {
+    if (!pgliteReady) return;
+    const key = "idem_key_0123456789abcdef";
+
+    // No refund yet → the legitimate ambiguous-retry path (must NOT be blocked).
+    expect(
+      await redeemableEarningsService.hasEarningBySourceId({
+        userId,
+        source: "creator_revenue_share",
+        sourceId: `${key}:refund`,
+      }),
+    ).toBe(false);
+
+    // A definitively-rejected transfer restores the balance with a compensating
+    // refund keyed exactly as the route writes it.
+    const refund = await redeemableEarningsService.addEarnings({
+      userId,
+      amount: 10,
+      source: "creator_revenue_share",
+      sourceId: `${key}:refund`,
+      dedupeBySourceId: true,
+      description: "Stripe Connect payout rejected — balance restored",
+    });
+    expect(refund.success).toBe(true);
+
+    // Now the refund is detectable → the route refuses a same-key retry.
+    expect(
+      await redeemableEarningsService.hasEarningBySourceId({
+        userId,
+        source: "creator_revenue_share",
+        sourceId: `${key}:refund`,
+      }),
+    ).toBe(true);
+
+    // A different, untouched key is unaffected (no false-positive block).
+    expect(
+      await redeemableEarningsService.hasEarningBySourceId({
+        userId,
+        source: "creator_revenue_share",
+        sourceId: "idem_key_totally_different:refund",
+      }),
+    ).toBe(false);
+
+    // And the bare debit key (not `:refund`) is a different ledger source id —
+    // the guard keys specifically on the refund marker, never the debit.
+    expect(
+      await redeemableEarningsService.hasEarningBySourceId({
+        userId,
+        source: "creator_revenue_share",
+        sourceId: key,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/redeemable-earnings.ts
+++ b/packages/cloud/shared/src/lib/services/redeemable-earnings.ts
@@ -183,6 +183,40 @@ class RedeemableEarningsService {
   }
 
   /**
+   * True when an `earning` ledger row already exists for (`source`, `sourceId`).
+   *
+   * SECURITY (money-out): a Stripe Connect payout debits under one idempotency
+   * key, then — on a DEFINITIVE Stripe rejection — compensates by adding an
+   * `${key}:refund` earning that restores the balance. The debit's own dedup row
+   * (keyed on `key`) is immutable and survives that rollback, so a later same-key
+   * retry finds the debit `deduplicated` and skips debiting while firing a FRESH
+   * transfer → double-pay. The payout route uses this to detect "this key was
+   * already rejected + refunded" (a `${key}:refund` earning exists) and refuse
+   * the retry, forcing a fresh idempotency key. Matches the `dedupeBySourceId`
+   * lookup (normalized source_id, `entry_type='earning'`).
+   */
+  async hasEarningBySourceId(params: {
+    userId: string;
+    source: EarningsSource;
+    sourceId: string;
+  }): Promise<boolean> {
+    const ledgerSourceId = normalizeLedgerSourceId(params.sourceId);
+    const [existing] = await dbRead
+      .select({ id: redeemableEarningsLedger.id })
+      .from(redeemableEarningsLedger)
+      .where(
+        and(
+          eq(redeemableEarningsLedger.user_id, params.userId),
+          eq(redeemableEarningsLedger.entry_type, "earning"),
+          eq(redeemableEarningsLedger.earnings_source, params.source),
+          eq(redeemableEarningsLedger.source_id, ledgerSourceId),
+        ),
+      )
+      .limit(1);
+    return Boolean(existing);
+  }
+
+  /**
    * Add earnings from a valid source (miniapp, agent, or mcp)
    *
    * SECURITY: This is the ONLY way earnings can be added.


### PR DESCRIPTION
Closes #11022.

## The bug (adversarially confirmed in the issue)

A Stripe Connect payout is a compensating saga: **debit** the redeemable ledger (idempotent on `idempotency_key` via `dedupeBySourceId`) → **transfer** → **refund on definitive rejection**. The debit's dedup adjustment row is immutable and survives the compensating refund, so:

1. **Call 1** (key `K`): debit succeeds; `transferToConnectAccount` throws `StripeRateLimitError` (429, `definitivelyNotCreated`); route adds a `${K}:refund` earning restoring the balance. **The `normalize(K)` debit row stays live.**
2. **Call 2** (intended idempotent retry, same `K`): `reduceEarnings` finds the live adjustment → `deduplicated:true, success:true` **without debiting**. The route checked only `!debit.success`, never `debit.deduplicated`, so it proceeded. Stripe never persisted the rejected `K`, so the transfer is **fresh** and now succeeds.

**Net:** fiat `A` paid out, `available_balance` unchanged → creator keeps full redeemable balance **and** received the fiat. Silent, up to `MAX_TRANSFER_USD`.

## The fix (issue's option (a), smallest)

On a **deduplicated** debit, look up whether a compensating `${idempotency_key}:refund` earning exists (new `redeemableEarningsService.hasEarningBySourceId`, mirroring the `dedupeBySourceId` lookup: normalized `source_id`, `entry_type='earning'`):

- **refund exists** → the prior attempt was definitively rejected + rolled back; the debit no longer holds funds. **Refuse with 409** (require a fresh `idempotency_key`) — no fresh transfer, no double-pay.
- **no refund** → the legitimate ambiguous-timeout retry; Stripe's own transfer idempotency replays the single transfer. **Proceeds** unchanged.

## Evidence

- `packages/cloud/api/__tests__/stripe-connect-transfer-route.test.ts` — **7/7** (5 existing money-path invariants + 2 new): the deduplicated-debit-with-refund retry returns 409 and calls **no** transfer; the deduplicated-debit-without-refund retry still transfers once.
- `packages/cloud/shared/src/lib/services/__tests__/creator-earnings-idempotency.test.ts` — **6/6** real-PGlite: `hasEarningBySourceId` detects the compensating refund row and does not false-positive on an untouched key or the bare debit key.

## ⚠️ Money-path — not self-merged

Per the issue, this touches real fiat movement; **leaving the merge to the money-path owner (@lalalune / @shaw)** for review of the 409-vs-proceed discriminator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)