### PR TITLE
test(cloud): restore showcase monetization e2e

### DIFF
--- a/packages/cloud/api/src/stubs/elizaos-core.ts
+++ b/packages/cloud/api/src/stubs/elizaos-core.ts
@@ -10,8 +10,6 @@
 const NOT_AVAILABLE =
   "@elizaos/core runtime APIs are not available in the Cloudflare Workers API bundle. Route agent runtime work through the agent-server sidecar.";
 
-export const DEFAULT_CEREBRAS_TEXT_MODEL = "gemma-4-31b";
-
 function unavailable(name: string): never {
   throw new Error(`${name}: ${NOT_AVAILABLE}`);
 }

--- a/packages/test/cloud-e2e/AGENTS.md
+++ b/packages/test/cloud-e2e/AGENTS.md
@@ -57,11 +57,12 @@ bun run cloud:login:test-wallet --base <local-stack-url>
 
 ## Conventions / gotchas
 
-- **Bun + `eliza-source` condition is mandatory.** The `test` scripts pass
-  `--conditions=eliza-source --bun`, and the config / `buildSharedEnv` re-inject
-  `--conditions=eliza-source` into `BUN_OPTIONS` so spawned subprocesses resolve
-  workspace source (notably plugin-sql's peer dep on core). Running Playwright
-  without it will mis-resolve packages.
+- **Bun + `eliza-source` condition is mandatory.** The `test` scripts run
+  `bun --conditions=eliza-source playwright ...` so Bun drives the package
+  command while Playwright workers use Node. The config / `buildSharedEnv`
+  re-inject `--conditions=eliza-source` into `BUN_OPTIONS` so spawned Bun
+  subprocesses resolve workspace source (notably plugin-sql's peer dep on core).
+  Running Playwright without it will mis-resolve packages.
 - **`NODE_ENV=test` and KMS pinned in config.** `playwright.config.ts` sets
   `NODE_ENV ??= "test"` and `ELIZA_KMS_BACKEND ??= "memory"` before cloud-shared
   crypto is imported — the runner seeds/encrypts keys in-process (not a

--- a/packages/test/cloud-e2e/CLAUDE.md
+++ b/packages/test/cloud-e2e/CLAUDE.md
@@ -57,11 +57,12 @@ bun run cloud:login:test-wallet --base <local-stack-url>
 
 ## Conventions / gotchas
 
-- **Bun + `eliza-source` condition is mandatory.** The `test` scripts pass
-  `--conditions=eliza-source --bun`, and the config / `buildSharedEnv` re-inject
-  `--conditions=eliza-source` into `BUN_OPTIONS` so spawned subprocesses resolve
-  workspace source (notably plugin-sql's peer dep on core). Running Playwright
-  without it will mis-resolve packages.
+- **Bun + `eliza-source` condition is mandatory.** The `test` scripts run
+  `bun --conditions=eliza-source playwright ...` so Bun drives the package
+  command while Playwright workers use Node. The config / `buildSharedEnv`
+  re-inject `--conditions=eliza-source` into `BUN_OPTIONS` so spawned Bun
+  subprocesses resolve workspace source (notably plugin-sql's peer dep on core).
+  Running Playwright without it will mis-resolve packages.
 - **`NODE_ENV=test` and KMS pinned in config.** `playwright.config.ts` sets
   `NODE_ENV ??= "test"` and `ELIZA_KMS_BACKEND ??= "memory"` before cloud-shared
   crypto is imported — the runner seeds/encrypts keys in-process (not a

--- a/packages/test/cloud-e2e/package.json
+++ b/packages/test/cloud-e2e/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "bun --conditions=eliza-source --bun playwright test",
-    "test:headed": "bun --conditions=eliza-source --bun playwright test --headed",
-    "test:ui": "bun --conditions=eliza-source --bun playwright test --ui",
+    "test": "bun --conditions=eliza-source playwright test",
+    "test:headed": "bun --conditions=eliza-source playwright test --headed",
+    "test:ui": "bun --conditions=eliza-source playwright test --ui",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/test/cloud-e2e/tests/example-apps-showcase.spec.ts
+++ b/packages/test/cloud-e2e/tests/example-apps-showcase.spec.ts
@@ -65,6 +65,7 @@
 
 import { randomUUID } from "node:crypto";
 import { appEarningsRepository } from "@elizaos/cloud-shared/db/repositories/app-earnings";
+import { appsRepository } from "@elizaos/cloud-shared/db/repositories/apps";
 import { containersRepository } from "@elizaos/cloud-shared/db/repositories/containers";
 import { appCreditsService } from "@elizaos/cloud-shared/lib/services/app-credits";
 import {
@@ -320,6 +321,23 @@ async function deployAndMonetizeApp(ctx: {
   expect(appId, `${app.name}: apps.create returns an id`).toBeTruthy();
   if (!appId) throw new Error(`${app.name}: apps.create did not return an id`);
 
+  // New apps must pass the compliance-review gate before monetization opens.
+  const draftMonetize = await authed(
+    "PUT",
+    `/api/v1/apps/${appId}/monetization`,
+    {
+      monetizationEnabled: true,
+      inferenceMarkupPercentage: MARKUP_PCT,
+      purchaseSharePercentage: 10,
+    },
+  );
+  expect(
+    draftMonetize.status,
+    `${app.name}: draft app cannot enable monetization before review`,
+  ).toBe(403);
+
+  await approveAppForShowcaseMonetization(appId);
+
   // ── 2. enable monetization BEFORE the charge (it must drive the markup). ──
   const monetize = await authed("PUT", `/api/v1/apps/${appId}/monetization`, {
     monetizationEnabled: true,
@@ -513,4 +531,15 @@ async function deployAndMonetizeApp(ctx: {
     totalCost: charge.totalCost,
     markup: charge.creatorMarkup,
   };
+}
+
+async function approveAppForShowcaseMonetization(appId: string): Promise<void> {
+  // This spec validates deploy + billing + earnings, not the live review model.
+  // Mirror the review-gate e2e helper's deterministic "grandfathered approval"
+  // so the monetization path opens while the draft 403 above keeps the gate visible.
+  await appsRepository.update(appId, {
+    review_status: "approved",
+    review_content_hash: null,
+    reviewed_at: new Date(),
+  });
 }

--- a/packages/test/cloud-e2e/tests/monetized-full-loop.spec.ts
+++ b/packages/test/cloud-e2e/tests/monetized-full-loop.spec.ts
@@ -50,6 +50,7 @@
  */
 
 import { appEarningsRepository } from "@elizaos/cloud-shared/db/repositories/app-earnings";
+import { appsRepository } from "@elizaos/cloud-shared/db/repositories/apps";
 import { stripeConnectAccountsRepository } from "@elizaos/cloud-shared/db/repositories/stripe-connect-accounts";
 import { appCreditsService } from "@elizaos/cloud-shared/lib/services/app-credits";
 import { redeemableEarningsService } from "@elizaos/cloud-shared/lib/services/redeemable-earnings";
@@ -212,6 +213,21 @@ test.describe("monetized full loop", () => {
     ).toBeLessThan(0.01);
 
     // ── e. Enable monetization (inference markup + purchase share). ─────────
+    const draftMonetization = await authed(
+      "PUT",
+      `/api/v1/apps/${appId}/monetization`,
+      {
+        monetizationEnabled: true,
+        inferenceMarkupPercentage: 100,
+        purchaseSharePercentage: 10,
+      },
+    );
+    expect(
+      draftMonetization.status,
+      "draft app cannot enable monetization before compliance approval",
+    ).toBe(403);
+    await approveAppForMonetizedLoop(appId);
+
     const monetization = await authed(
       "PUT",
       `/api/v1/apps/${appId}/monetization`,
@@ -545,3 +561,15 @@ test.describe("monetized full loop", () => {
     ).toBeLessThan(1e-9);
   });
 });
+
+async function approveAppForMonetizedLoop(appId: string): Promise<void> {
+  // This suite validates billing/monetization/payout behavior, not the live
+  // compliance-review classifier. Keep the draft 403 assertion above, then open
+  // the gate with the same deterministic grandfathered approval used by the
+  // review-gate e2e helper.
+  await appsRepository.update(appId, {
+    review_status: "approved",
+    review_content_hash: null,
+    reviewed_at: new Date(),
+  });
+}


### PR DESCRIPTION
## Summary

Restores the #9300 showcase/cloud-e2e loop on current `develop` after two drift points:

- removes a duplicate `DEFAULT_CEREBRAS_TEXT_MODEL` export from the Cloudflare Worker `@elizaos/core` stub, which made `wrangler dev` fail before cloud-e2e could boot the API
- makes the showcase and monetized full-loop specs explicitly account for the newer app compliance-review gate: first assert draft apps cannot enable monetization (`403`), then apply the same deterministic grandfathered approval pattern used by the review-gate e2e before testing deploy/billing/earnings/payout behavior
- runs cloud-e2e Playwright workers under Node while still launching through Bun with `--conditions=eliza-source`; this avoids the current Bun canary `packages/core/dist/node/index.node.js` source-map/runtime failure while preserving source resolution for spawned Bun subprocesses

## Evidence

- `git diff --check` passed
- `bun run --cwd packages/cloud/api test __tests__/elizaos-core-stub.test.ts` passed: 1 test
- `bunx biome check packages/cloud/api/src/stubs/elizaos-core.ts packages/test/cloud-e2e/package.json packages/test/cloud-e2e/CLAUDE.md packages/test/cloud-e2e/AGENTS.md packages/test/cloud-e2e/tests/example-apps-showcase.spec.ts packages/test/cloud-e2e/tests/monetized-full-loop.spec.ts` passed
- `bun run cloud:e2e -- example-apps-showcase.spec.ts remote-app-deploy.spec.ts monetized-full-loop.spec.ts showcase-brand-lint.spec.ts example-edad-real-deploy.spec.ts example-clone-ur-crush-real-deploy.spec.ts` passed: 7 passed, 2 skipped in 3.3m

Manual/diagnostic evidence before the final script change:

- The duplicate export caused `remote-app-deploy.spec.ts` to fail at stack boot: cloud-api never reached `/api/health`; `.logs/cloud-api.log` showed Wrangler build errors for duplicate `DEFAULT_CEREBRAS_TEXT_MODEL`.
- After removing `--bun`, `remote-app-deploy.spec.ts` passed through the package script path.
- The real-staging drivers still honest-skip without `MONETIZED_LOOP_REAL` + live staging secrets, so this PR does not claim the remaining operator-gated live-cloud-container DoD.

## Typecheck note

`bun run --cwd packages/test/cloud-e2e typecheck` is still blocked on existing unrelated errors in `tests/app-client-handoff-success.spec.ts` and `tests/app-client-onboarding.spec.ts` resolving `@elizaos/ui/api` / `@elizaos/ui/config` plus implicit `any` parameters. This PR does not touch those files.

Refs #9300.
