### PR TITLE
fix(cloud): cap per-org dedicated agents on forceCreate to close fleet-wide DoS (#11023)

### DIFF
--- a/packages/cloud/api/__tests__/eliza-agents-create-idempotency.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-create-idempotency.test.ts
@@ -63,8 +63,23 @@ mock.module("@/lib/auth/workers-hono-auth", () => ({
   requireUserOrApiKeyWithOrg,
 }));
 
+// Mirror the real exported error so the route's `instanceof` check works.
+class AgentQuotaExceededError extends Error {
+  readonly count: number;
+  readonly max: number;
+  constructor(count: number, max: number) {
+    super(
+      `Agent quota exceeded: your organization already has ${count} active agents (limit ${max}).`,
+    );
+    this.name = "AgentQuotaExceededError";
+    this.count = count;
+    this.max = max;
+  }
+}
+
 mock.module("@/lib/services/eliza-sandbox", () => ({
   elizaSandboxService: { createAgent, updateAgentEnvironment, listAgents },
+  AgentQuotaExceededError,
 }));
 
 mock.module("@/lib/services/provisioning-jobs", () => ({
@@ -199,10 +214,50 @@ describe("POST /api/v1/eliza/agents — reuse idempotency", () => {
     expect(createAgent).toHaveBeenCalledTimes(1);
     const passed = createAgent.mock.calls[0]?.[0] as {
       reuseExistingNonTerminal?: boolean;
+      maxNonTerminalAgents?: number;
     };
     expect(passed.reuseExistingNonTerminal).toBe(false);
+    // #11023: a user-facing forceCreate must be bounded by the org's balance
+    // tier — $100 balance → the top (500) ceiling — so it can't mint unbounded
+    // dedicated containers.
+    expect(passed.maxNonTerminalAgents).toBe(500);
     // A fresh create still provisions normally.
     expect(enqueueAgentProvision).toHaveBeenCalledTimes(1);
+  });
+
+  test("#11023: a forceCreate that exceeds the org's per-org quota → 429, no provision job", async () => {
+    // At the credit tier's ceiling, the atomic quota check in createAgent throws;
+    // the route must surface 429 (not 500) and never enqueue provisioning.
+    createAgent.mockRejectedValue(new AgentQuotaExceededError(500, 500));
+
+    const res = await postCreate({
+      agentName: "alpha",
+      dockerImage: "ghcr.io/example/agent:latest",
+      forceCreate: true,
+    });
+
+    // The security-relevant behavior: the quota rejection maps to 429 (not a 500
+    // or a silent success) and NO provisioning is enqueued. (Body serialization
+    // is provided by the worker's onError middleware, not mounted in this bare
+    // test app — matches the sibling 400 test, which also asserts status only.)
+    expect(res.status).toBe(429);
+    expect(enqueueAgentProvision).not.toHaveBeenCalled();
+    expect(triggerImmediate).not.toHaveBeenCalled();
+  });
+
+  test("#11023: default (no forceCreate) create passes NO cap (uncapped reuse path unchanged)", async () => {
+    const agent = pendingAgent();
+    createAgent.mockResolvedValue({ agent, idempotent: true });
+
+    await postCreate({
+      agentName: "alpha",
+      dockerImage: "ghcr.io/example/agent:latest",
+    });
+
+    const passed = createAgent.mock.calls[0]?.[0] as {
+      maxNonTerminalAgents?: number;
+    };
+    expect(passed.maxNonTerminalAgents).toBeUndefined();
   });
 
   test("forceCreate:true on a SHARED-tier create is rejected (400) — no unmetered shared mint past the reuse guard", async () => {

--- a/packages/cloud/api/v1/eliza/agents/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/route.ts
@@ -24,7 +24,10 @@ import {
   withReusedElizaCharacterOwnership,
 } from "@/lib/services/eliza-agent-config";
 import { prepareManagedElizaEnvironment } from "@/lib/services/eliza-managed-launch";
-import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
+import {
+  AgentQuotaExceededError,
+  elizaSandboxService,
+} from "@/lib/services/eliza-sandbox";
 import { provisioningJobService } from "@/lib/services/provisioning-jobs";
 import {
   checkProvisioningWorkerHealth,
@@ -39,6 +42,22 @@ import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
+
+/**
+ * Per-org ceiling on live (non-terminal) dedicated agent sandboxes, by credit
+ * tier. Mirrors the balance tiers already enforced for cloud characters in
+ * `/api/v1/app/agents` (`AGENT_LIMITS`), applied here to the `agent_sandboxes`
+ * (container) path so a `forceCreate` loop on a trivial balance can't exhaust
+ * the shared fleet (#11023). A trivial (~$0.11) balance lands in the smallest
+ * tier, bounding the DoS; funded orgs scale up.
+ */
+function getMaxNonTerminalAgentsForOrg(creditBalance: number | undefined): number {
+  const balance = Number(creditBalance ?? 0);
+  if (balance >= 100.0) return 500;
+  if (balance >= 10.0) return 100;
+  if (balance >= 1.0) return 20;
+  return 5;
+}
 
 const dockerImageSchema = z
   .string()
@@ -341,8 +360,13 @@ app.post("/", async (c) => {
   const shouldProvisionEagerly =
     autoProvision && tierProvisionsEagerly(executionTier);
 
+  // Captured from the credit gate below so the forceCreate quota (#11023) can
+  // scale the org's live-agent ceiling by its balance tier.
+  let orgBalanceForQuota: number | undefined;
+
   if (shouldProvisionEagerly) {
     const creditCheck = await checkAgentCreditGate(user.organization_id);
+    orgBalanceForQuota = creditCheck.balance;
     if (!creditCheck.allowed) {
       logger.warn("[agent-api] Agent creation blocked: insufficient credits", {
         orgId: user.organization_id,
@@ -373,23 +397,46 @@ app.post("/", async (c) => {
     }
   }
 
-  const { agent, idempotent } = await elizaSandboxService.createAgent({
-    organizationId: user.organization_id,
-    userId: user.id,
-    agentName: parsed.data.agentName,
-    characterId: parsed.data.characterId,
-    dockerImage: parsed.data.dockerImage,
-    agentConfig: parsed.data.characterId
-      ? withReusedElizaCharacterOwnership(sanitizedConfig)
-      : sanitizedConfig,
-    environmentVars: parsed.data.environmentVars,
-    executionTier,
-    // Default reuses the org's existing non-terminal agent (idempotent create);
-    // `forceCreate` opts out so a caller that needs a SEPARATE record (the
-    // shared→dedicated handoff's migration target) mints a fresh agent instead
-    // of getting the shared one handed back.
-    reuseExistingNonTerminal: !parsed.data.forceCreate,
-  });
+  let created: Awaited<ReturnType<typeof elizaSandboxService.createAgent>>;
+  try {
+    created = await elizaSandboxService.createAgent({
+      organizationId: user.organization_id,
+      userId: user.id,
+      agentName: parsed.data.agentName,
+      characterId: parsed.data.characterId,
+      dockerImage: parsed.data.dockerImage,
+      agentConfig: parsed.data.characterId
+        ? withReusedElizaCharacterOwnership(sanitizedConfig)
+        : sanitizedConfig,
+      environmentVars: parsed.data.environmentVars,
+      executionTier,
+      // Default reuses the org's existing non-terminal agent (idempotent create);
+      // `forceCreate` opts out so a caller that needs a SEPARATE record (the
+      // shared→dedicated handoff's migration target) mints a fresh agent instead
+      // of getting the shared one handed back.
+      reuseExistingNonTerminal: !parsed.data.forceCreate,
+      // A user-facing forceCreate bypasses the reuse guard, so bound it by the
+      // org's balance-tiered live-agent ceiling — enforced atomically under the
+      // advisory lock — so it can't mint unbounded dedicated containers (#11023).
+      maxNonTerminalAgents: parsed.data.forceCreate
+        ? getMaxNonTerminalAgentsForOrg(orgBalanceForQuota)
+        : undefined,
+    });
+  } catch (error) {
+    if (error instanceof AgentQuotaExceededError) {
+      logger.warn("[agent-api] Agent creation blocked: per-org quota exceeded", {
+        orgId: user.organization_id,
+        count: error.count,
+        max: error.max,
+      });
+      throw new ApiError(429, "agent_quota_exceeded", error.message, {
+        currentAgents: error.count,
+        maxAgents: error.max,
+      });
+    }
+    throw error;
+  }
+  const { agent, idempotent } = created;
 
   // Idempotent reuse: the org already had a non-terminal agent, so createAgent
   // returned it instead of minting a duplicate. It is already provisioned (or

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -722,6 +722,27 @@ export class AgentSandboxesRepository {
    * Used by the forecast to predict next-period demand.
    * Excludes pool sentinel org rows.
    */
+  /**
+   * Count an org's NON-TERMINAL (`pending`/`provisioning`/`running`, non-pool)
+   * agent sandboxes — the org's live dedicated-container footprint on the fleet.
+   * Used by the create path's per-org quota (#11023). Best-effort read; the
+   * authoritative check runs under the advisory lock inside createAgent.
+   */
+  async countNonTerminalByOrganization(organizationId: string): Promise<number> {
+    await ensureAgentSandboxSchema();
+    const [row] = await dbRead
+      .select({ count: sql<number>`count(*)::int` })
+      .from(agentSandboxes)
+      .where(
+        and(
+          eq(agentSandboxes.organization_id, organizationId),
+          sql`${agentSandboxes.pool_status} is null`,
+          sql`${agentSandboxes.status} in ('pending', 'provisioning', 'running')`,
+        ),
+      );
+    return row?.count ?? 0;
+  }
+
   async countUserProvisionsSince(sinceMs: number): Promise<number> {
     await ensureAgentSandboxSchema();
     const since = new Date(Date.now() - sinceMs);

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-create-idempotency.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-create-idempotency.test.ts
@@ -24,13 +24,19 @@ let existingRows: AgentSandbox[] = [];
 let insertedRows: NewAgentSandbox[] = [];
 let capturedSelectWhere: SQL | undefined;
 let executeCalls: number = 0;
+// The capped (#11023) path's `select({count}).from().where()` is AWAITED at
+// `.where()` (no orderBy/for/limit), so the chain is thenable and resolves to
+// these count rows. The reuse guard instead ends in `.limit()` (returns
+// existingRows), so it never hits the thenable.
+let countRows: Array<{ count: number }> = [{ count: 0 }];
 
 const txExecute = mock(async (_sql: SQL) => {
   executeCalls += 1;
   return { rows: [] };
 });
 
-// tx.select().from().where(clause).orderBy().for("update").limit() -> existingRows
+// reuse guard:  select().from().where(clause).orderBy().for("update").limit() -> existingRows
+// cap count:    select({count}).from().where(clause) [awaited]               -> countRows
 const txSelect = mock(() => {
   const chain = {
     from: () => chain,
@@ -41,6 +47,8 @@ const txSelect = mock(() => {
     orderBy: () => chain,
     for: () => chain,
     limit: () => existingRows,
+    then: (resolve: (rows: Array<{ count: number }>) => unknown) =>
+      resolve(countRows),
   } as Record<string, unknown>;
   return chain;
 });
@@ -134,6 +142,7 @@ function resetTx(): void {
   insertedRows = [];
   capturedSelectWhere = undefined;
   executeCalls = 0;
+  countRows = [{ count: 0 }];
   txExecute.mockClear();
   txSelect.mockClear();
   txInsert.mockClear();
@@ -243,6 +252,91 @@ describe("ElizaSandboxService.createAgent — opt-in org reuse guard", () => {
       expect(res.idempotent).toBe(false);
       expect(res.agent.id).toBe("repo-created");
       // No transaction, no advisory lock, no reuse SELECT on the multi-agent path.
+      expect(transaction).not.toHaveBeenCalled();
+      expect(txExecute).not.toHaveBeenCalled();
+      expect(repoCreate).toHaveBeenCalledTimes(1);
+    } finally {
+      repoCreate.mockRestore();
+    }
+  });
+});
+
+describe("ElizaSandboxService.createAgent — forceCreate per-org quota (#11023)", () => {
+  test("a fresh (non-reuse) create under maxNonTerminalAgents inserts, atomically under the advisory lock", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const svc = new ElizaSandboxService();
+
+    // Org already has 3 live agents; cap is 5 → the create proceeds.
+    countRows = [{ count: 3 }];
+    const res = await svc.createAgent({
+      organizationId: ORG_A,
+      userId: USER,
+      agentName: "forced-under-cap",
+      dockerImage: "ghcr.io/example/agent:latest",
+      reuseExistingNonTerminal: false,
+      maxNonTerminalAgents: 5,
+    });
+
+    expect(res.idempotent).toBe(false);
+    expect(insertedRows.length).toBe(1);
+    // The count + insert ran inside the transaction that first took the org
+    // advisory lock — so the check and the write are atomic (no TOCTOU).
+    expect(transaction).toHaveBeenCalledTimes(1);
+    expect(executeCalls).toBe(1);
+    // The count scoped to this org AND to non-terminal statuses only.
+    expect(capturedSelectWhere).toBeDefined();
+    const sql = new PgDialect().sqlToQuery(capturedSelectWhere as SQL).sql;
+    expect(sql).toContain("organization_id");
+    expect(sql).toContain("'pending'");
+    expect(sql).toContain("'provisioning'");
+    expect(sql).toContain("'running'");
+  });
+
+  test("a fresh create AT the cap is refused with AgentQuotaExceededError and NO insert (fleet-DoS closed)", async () => {
+    const { ElizaSandboxService, AgentQuotaExceededError } = await import(
+      "./eliza-sandbox.ts?actual"
+    );
+    const svc = new ElizaSandboxService();
+
+    // Org is already at the cap → a fresh forceCreate must not mint another.
+    countRows = [{ count: 5 }];
+    await expect(
+      svc.createAgent({
+        organizationId: ORG_A,
+        userId: USER,
+        agentName: "forced-at-cap",
+        dockerImage: "ghcr.io/example/agent:latest",
+        reuseExistingNonTerminal: false,
+        maxNonTerminalAgents: 5,
+      }),
+    ).rejects.toBeInstanceOf(AgentQuotaExceededError);
+
+    // The lock was taken (so the count was authoritative) but NO row was inserted.
+    expect(executeCalls).toBe(1);
+    expect(insertedRows.length).toBe(0);
+  });
+
+  test("an unset cap keeps the uncapped plain-insert fast path (trusted internal multi-agent callers)", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const svc = new ElizaSandboxService();
+
+    const repoCreate = spyOn(agentSandboxesRepository, "create").mockResolvedValue({
+      ...baseRow(),
+      id: "repo-created-uncapped",
+    });
+    try {
+      // Even with many existing agents, an unset cap does NOT gate the insert.
+      countRows = [{ count: 999 }];
+      const res = await svc.createAgent({
+        organizationId: ORG_A,
+        userId: USER,
+        agentName: "waifu-launch",
+        dockerImage: "ghcr.io/example/agent:latest",
+        reuseExistingNonTerminal: false,
+        // maxNonTerminalAgents intentionally unset
+      });
+      expect(res.agent.id).toBe("repo-created-uncapped");
+      // No transaction / advisory lock / count query on the uncapped path.
       expect(transaction).not.toHaveBeenCalled();
       expect(txExecute).not.toHaveBeenCalled();
       expect(repoCreate).toHaveBeenCalledTimes(1);

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -99,6 +99,32 @@ export interface CreateAgentParams {
    * for one org and must NOT collapse them.
    */
   reuseExistingNonTerminal?: boolean;
+  /**
+   * Ceiling on an org's NON-TERMINAL (`pending`/`provisioning`/`running`,
+   * non-pool) agent sandboxes, enforced ATOMICALLY under the org advisory lock
+   * before a fresh (non-reuse) insert. Prevents a user-facing caller from
+   * minting unbounded dedicated containers on the shared fleet (#11023: a
+   * `forceCreate`+`alwaysOn` loop on a ~$0.11 balance otherwise exhausts the
+   * fleet — the credit gate is threshold-only, never a per-agent debit). The
+   * user-facing `POST /api/v1/eliza/agents` route sets this from the org's
+   * balance tier; trusted internal multi-agent callers leave it unset (uncapped).
+   * A create that would exceed the cap throws {@link AgentQuotaExceededError}.
+   */
+  maxNonTerminalAgents?: number;
+}
+
+/** Thrown by createAgent when a fresh create would exceed `maxNonTerminalAgents`. */
+export class AgentQuotaExceededError extends Error {
+  readonly count: number;
+  readonly max: number;
+  constructor(count: number, max: number) {
+    super(
+      `Agent quota exceeded: your organization already has ${count} active agents (limit ${max}). Delete or stop an agent, or add credits to raise the limit.`,
+    );
+    this.name = "AgentQuotaExceededError";
+    this.count = count;
+    this.max = max;
+  }
 }
 
 export type ProvisionResult =
@@ -642,8 +668,45 @@ export class ElizaSandboxService {
     // Multi-agent-per-org callers (waifu launches, compat) leave the flag unset
     // and keep the plain insert — they legitimately mint several agents per org.
     if (!params.reuseExistingNonTerminal) {
-      const created = await agentSandboxesRepository.create(this.buildAgentInsertData(params));
-      return { agent: created, idempotent: false };
+      // Uncapped fast path for trusted internal multi-agent callers.
+      if (params.maxNonTerminalAgents === undefined) {
+        const created = await agentSandboxesRepository.create(
+          this.buildAgentInsertData(params),
+        );
+        return { agent: created, idempotent: false };
+      }
+
+      // Capped path (#11023): a user-facing forceCreate that bypasses the reuse
+      // guard must still not mint unbounded dedicated containers. Count the org's
+      // non-terminal sandboxes UNDER the same org advisory lock the reuse guard
+      // uses — so the count→insert is atomic and two concurrent creates can't both
+      // read `count = max-1` and both insert — and refuse past the cap.
+      const cap = params.maxNonTerminalAgents;
+      return dbWrite.transaction(async (tx) => {
+        await tx.execute(elizaAgentCreateAdvisoryLockSql(params.organizationId));
+
+        const [{ count } = { count: 0 }] = await tx
+          .select({ count: sql<number>`count(*)::int` })
+          .from(agentSandboxes)
+          .where(
+            and(
+              eq(agentSandboxes.organization_id, params.organizationId),
+              sql`${agentSandboxes.pool_status} IS NULL`,
+              sql`${agentSandboxes.status} IN ('pending', 'provisioning', 'running')`,
+            ),
+          );
+
+        if (count >= cap) {
+          throw new AgentQuotaExceededError(count, cap);
+        }
+
+        const [created] = await tx
+          .insert(agentSandboxes)
+          .values(this.buildAgentInsertData(params))
+          .returning();
+        if (!created) throw new Error("Failed to create agent record");
+        return { agent: created, idempotent: false };
+      });
     }
 
     // Mirrors createCodingContainerAgent: an org-scoped advisory lock + a


### PR DESCRIPTION
Closes #11023.

## The exploit (adversarially confirmed in the issue)

`forceCreate:true` on a dedicated (`alwaysOn`) agent is user-controllable via `POST /api/v1/eliza/agents`. It sets `reuseExistingNonTerminal:false`, landing in `createAgent`'s plain-insert branch — which **skips** the org advisory lock + `FOR UPDATE` reuse guard and had **no per-org cap**. The credit gate is threshold-only (`balance > $0.10`, no per-agent debit), so every iteration passes identically. There's no rate limit on the route. An authenticated org with **~$0.11** can loop and mint **unbounded dedicated containers** on the shared ~5-node fleet → "At capacity" 503 for every other tenant (fleet-wide DoS), hourly billing unable to catch up within the first hour.

## Fix

The plain-insert branch, **when a cap is supplied**, now counts the org's non-terminal (`pending`/`provisioning`/`running`, non-pool) sandboxes **under the same org advisory lock** the reuse guard uses, and refuses past the cap (`AgentQuotaExceededError` → **429**). Count→insert is atomic, so two concurrent creates can't both read `count = max-1` and both insert.

- **User-facing route** supplies the cap from the org's **balance tier** — mirrors the existing `AGENT_LIMITS` product model already enforced for cloud characters in `/api/v1/app/agents` ($0→5, $1→20, $10→100, $100→500). The $0.11 attacker lands at **5**, bounding the DoS.
- **Trusted internal multi-agent callers** (waifu token launches, compat) pass **no cap** and stay uncapped — their legitimate multi-agent-per-org behavior is unchanged.
- Adds `agentSandboxesRepository.countNonTerminalByOrganization` (best-effort read; the authoritative check is the atomic one under the lock).

## Evidence

- `eliza-sandbox-create-idempotency.test.ts` — **7/7** (3 new): under-cap insert runs atomically under the advisory lock (count scoped to org + non-terminal); at-cap create throws `AgentQuotaExceededError` with **no insert**; an unset cap keeps the uncapped plain-insert fast path.
- `eliza-agents-create-idempotency.test.ts` — **8/8** (2 new): a `forceCreate` passes `maxNonTerminalAgents` from the balance tier (500 at $100); a quota rejection surfaces **429** with no provisioning enqueued; default (no forceCreate) passes no cap.

## Reviewer note (product surface)

The cap **tiers** ($0→5…$100→500) mirror the existing `AGENT_LIMITS` in `/api/v1/app/agents`; flagging in case the dedicated-container path warrants different limits than the cloud-character path, and in case the complementary hardening the issue suggests (gating `forceCreate` to service-only callers + a `rateLimit` middleware on the route) should ride along. This PR is the atomic per-org quota (the load-bearing fix); those are additive defense-in-depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)