### PR TITLE
fix(orchestrator): attach chat-create sessions with real post-run status (follow-up to #10978)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/create-task-attaches-sessions.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/create-task-attaches-sessions.test.ts
@@ -7,24 +7,36 @@
  *
  * Pinned surfaces:
  *   1. Happy path — one attachSession call per spawned session, with the
- *      minted taskId, matching sessionId/agentType/workdir/status, and the
- *      per-part label the create action assembled.
+ *      minted taskId, matching sessionId/agentType/workdir, the per-part label
+ *      the create action assembled, and the session's REAL post-run status.
+ *      For a single-turn create, `runPromptAndClose` / `runPromptViaSmithers`
+ *      have already stopped the session before the thread is minted, so the
+ *      status attach receives is terminal (`stopped`), NOT the stale `ready`
+ *      snapshot captured at spawn time.
  *   2. Attach failure is soft — attachSession throwing is logged, but the
  *      action still returns `success: true` with the widget block (same
  *      policy as thread-mint failure).
  *   3. Thread-mint failure path is clean — when createTask throws, the
  *      action does NOT try to attach (there's no taskId), and the widget
  *      block is omitted while the ACP sessions still ran.
+ *   4. Real end-to-end sequence — driving the create action against a stateful
+ *      ACP mock (spawn → prompt → stop) and a REAL OrchestratorTaskService,
+ *      the minted task is NOT falsely promoted to `active` and its
+ *      `activeSessionCount` stays 0, because every attached session is already
+ *      terminal. This is the regression the stale-status bug produced.
  *
  * These complement `create-task-emits-widget-block.test.ts` (which pins the
  * mint+widget-block contract) and `attach-session.test.ts` (which pins the
- * service-level attach semantics).
+ * service-level attach semantics, including the live-session → `active`
+ * promotion branch).
  */
 
 import * as os from "node:os";
 import type { IAgentRuntime } from "@elizaos/core";
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { createTaskAction } from "../../src/actions/tasks.js";
+import { OrchestratorTaskService } from "../../src/services/orchestrator-task-service.js";
+import { OrchestratorTaskStore } from "../../src/services/orchestrator-task-store.js";
 import {
   callback,
   memory,
@@ -34,15 +46,108 @@ import {
 
 const THREAD_ID = "aaaabbbb-1111-2222-3333-444455556666";
 
-function runtimeWithServices(opts: {
-  acp: ReturnType<typeof serviceMock>;
-  taskService?: {
-    createTask?: (input: unknown) => Promise<unknown>;
-    attachSession?: (
-      taskId: string,
-      input: Record<string, unknown>,
-    ) => Promise<boolean>;
+// Force the direct `runPromptAndClose` path (deterministic single-turn) and
+// suppress the default-acceptance-criteria auto-verifier so the real service
+// used below doesn't fire it — both branches stop the session in `finally`,
+// so the stale-status bug is identical on either runner.
+const PREV_SMITHERS = process.env.ELIZA_ORCHESTRATOR_SMITHERS;
+const PREV_GOAL_CONTRACT = process.env.ELIZA_REQUIRE_GOAL_CONTRACT;
+beforeAll(() => {
+  process.env.ELIZA_ORCHESTRATOR_SMITHERS = "0";
+  process.env.ELIZA_REQUIRE_GOAL_CONTRACT = "0";
+});
+afterAll(() => {
+  if (PREV_SMITHERS === undefined)
+    delete process.env.ELIZA_ORCHESTRATOR_SMITHERS;
+  else process.env.ELIZA_ORCHESTRATOR_SMITHERS = PREV_SMITHERS;
+  if (PREV_GOAL_CONTRACT === undefined)
+    delete process.env.ELIZA_REQUIRE_GOAL_CONTRACT;
+  else process.env.ELIZA_REQUIRE_GOAL_CONTRACT = PREV_GOAL_CONTRACT;
+});
+
+/**
+ * Stateful ACP stand-in that models the real create lifecycle the shared
+ * `serviceMock` fakes away: `spawnSession` returns a `ready` session,
+ * `stopSession` flips its stored status to `stopped`, and `getSession` returns
+ * the CURRENT (post-run) status. The create action's attach loop refreshes the
+ * status via `getSession`, so this is what lets the test observe the terminal
+ * status instead of the stale `ready` snapshot.
+ */
+function statefulAcp() {
+  const sessions = new Map<
+    string,
+    {
+      id: string;
+      name: string;
+      agentType: string;
+      workdir: string;
+      status: string;
+      metadata?: Record<string, unknown>;
+    }
+  >();
+  let counter = 0;
+  return {
+    defaultApprovalPreset: "standard",
+    spawnSession: vi.fn(async (opts: Record<string, unknown>) => {
+      const id = `sess-${++counter}`;
+      const record = {
+        id,
+        name: `agent-${counter}`,
+        agentType: (opts.agentType as string) ?? "codex",
+        workdir: (opts.workdir as string) ?? "/tmp/acp",
+        status: "ready",
+        metadata: opts.metadata as Record<string, unknown> | undefined,
+      };
+      sessions.set(id, record);
+      return {
+        sessionId: id,
+        id,
+        name: record.name,
+        agentType: record.agentType,
+        workdir: record.workdir,
+        status: "ready",
+        metadata: record.metadata,
+      };
+    }),
+    sendPrompt: vi.fn(async (sid: string) => ({
+      sessionId: sid,
+      response: "done",
+      finalText: "done",
+      stopReason: "end_turn",
+      durationMs: 7,
+    })),
+    sendToSession: vi.fn(async (sid: string) => ({
+      sessionId: sid,
+      response: "done",
+      finalText: "done",
+      stopReason: "end_turn",
+      durationMs: 7,
+    })),
+    sendKeysToSession: vi.fn(async () => undefined),
+    stopSession: vi.fn(async (sid: string) => {
+      const record = sessions.get(sid);
+      if (record) record.status = "stopped";
+    }),
+    cancelSession: vi.fn(async () => undefined),
+    getSession: vi.fn(async (sid: string) => sessions.get(sid)),
+    listSessions: vi.fn(async () => [...sessions.values()]),
+    onSessionEvent: vi.fn(() => () => undefined),
+    emitSessionEvent: vi.fn(),
+    resolveAgentType: vi.fn(async () => "codex"),
   };
+}
+
+function runtimeWithServices(opts: {
+  acp: ReturnType<typeof serviceMock> | ReturnType<typeof statefulAcp>;
+  taskService?:
+    | {
+        createTask?: (input: unknown) => Promise<unknown>;
+        attachSession?: (
+          taskId: string,
+          input: Record<string, unknown>,
+        ) => Promise<boolean>;
+      }
+    | OrchestratorTaskService;
 }): IAgentRuntime {
   return {
     getService: vi.fn((serviceType: string) => {
@@ -63,8 +168,15 @@ function runtimeWithServices(opts: {
 }
 
 describe("TASKS:create attaches spawned sessions to the minted task thread", () => {
-  it("calls attachSession(taskId, {sessionId, ...}) for each successful spawn", async () => {
-    const acp = serviceMock();
+  it("attaches each spawned session with its REAL post-run (terminal) status", async () => {
+    // The single-turn create path stops the session (runPromptAndClose's
+    // `finally`) BEFORE the thread is minted, so the SpawnResult.status
+    // captured at spawn time is a stale `ready`. The attach loop must refresh
+    // the true status from the service — passing `ready` would make
+    // attachSession falsely promote the task to `active` and count a dead
+    // session as live. This uses a stateful ACP mock so `getSession` returns
+    // the post-stop status instead of a frozen `ready` snapshot.
+    const acp = statefulAcp();
     const createTask = vi.fn(async () => ({
       id: THREAD_ID,
       title: "Build planner",
@@ -108,7 +220,9 @@ describe("TASKS:create attaches spawned sessions to the minted task thread", () 
     expect((input.sessionId as string).length).toBeGreaterThan(0);
     expect(input.agentType).toBe("codex");
     expect(input.workdir).toBe(workdir);
-    expect(input.status).toBe("ready");
+    // The session was stopped before mint — the attach status must reflect
+    // that terminal reality, not the stale spawn-time `ready`.
+    expect(input.status).toBe("stopped");
     expect(input.model).toBe("gpt-5.5");
     // The per-part label the create action assigned rides through.
     expect(typeof input.label).toBe("string");
@@ -191,5 +305,59 @@ describe("TASKS:create attaches spawned sessions to the minted task thread", () 
     expect(result?.success).toBe(true);
     expect(result?.data?.taskId).toBeNull();
     expect(attachSession).not.toHaveBeenCalled();
+  });
+
+  it("does NOT falsely promote the minted task to active for a single-turn create (real service)", async () => {
+    // The regression this whole PR-follow-up fixes: drive the real sequence —
+    // spawn → runPromptAndClose (stops the session) → createTask → attachSession
+    // — against a REAL OrchestratorTaskService. Because the session is already
+    // terminal by attach time, the task must stay `open` with
+    // `activeSessionCount === 0`; a stale `ready` status would have promoted it
+    // to `active` and counted a dead session as live.
+    const acp = statefulAcp();
+    const store = new OrchestratorTaskStore({ backend: "memory" });
+    const taskService = new OrchestratorTaskService(
+      { getService: () => acp, logger: console } as never,
+      { store },
+    );
+    await taskService.start();
+
+    const runtime = runtimeWithServices({ acp, taskService });
+    const cb = callback();
+    const workdir = os.tmpdir();
+
+    const result = await createTaskAction.handler(
+      runtime,
+      memory({}),
+      state,
+      {
+        parameters: {
+          action: "create",
+          title: "Ship widget",
+          goal: "Bind chat-spawned sessions to the durable thread",
+          task: "fix bug",
+          agentType: "codex",
+          workdir,
+          approvalPreset: "readonly",
+          timeout_ms: 1000,
+        },
+      },
+      cb,
+    );
+
+    expect(result?.success).toBe(true);
+    const taskId = result?.data?.taskId as string;
+    expect(typeof taskId).toBe("string");
+    expect(taskId.length).toBeGreaterThan(0);
+
+    const detail = await taskService.getTask(taskId);
+    expect(detail?.sessionCount).toBe(1);
+    // The finished single-turn session is indexed for history/attribution but
+    // must NOT be counted as live, and must NOT promote the task.
+    expect(detail?.activeSessionCount).toBe(0);
+    expect(detail?.status).not.toBe("active");
+    expect(detail?.status).toBe("open");
+    expect(detail?.sessions[0]?.status).toBe("stopped");
+    expect(detail?.sessions[0]?.stoppedAt).toBeTypeOf("number");
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -875,11 +875,22 @@ async function runCreate(
     for (const [index, session] of sessions.entries()) {
       const hint = sessionAttachHints[index];
       try {
+        // Every session that resolved fulfilled above was driven through
+        // runPromptAndClose / runPromptViaSmithers, which stop it in their
+        // `finally` before we reach here. So the `SpawnResult.status` captured
+        // at spawn time is a stale `ready` snapshot — passing it would make
+        // attachSession falsely promote the task to `active` and count a
+        // finished single-turn session as live. Read the real post-run status
+        // from the service instead; a fulfilled outcome always means the
+        // session was stopped, so fall back to a terminal status if its record
+        // is already gone.
+        const refreshed = await service.getSession(session.sessionId);
+        const effectiveStatus = refreshed?.status ?? "stopped";
         await taskService.attachSession(threadId, {
           sessionId: session.sessionId,
           agentType: session.agentType,
           workdir: session.workdir,
-          status: session.status,
+          status: effectiveStatus,
           ...(session.metadata ? { metadata: session.metadata } : {}),
           ...(hint?.label ? { label: hint.label } : {}),
           ...(hint?.originalTask ? { originalTask: hint.originalTask } : {}),


### PR DESCRIPTION
## Follow-up to #10978 — fixes the false-liveness bug flagged in review

#10978 landed the `OrchestratorTaskService.attachSession` API (correct: it branches on terminal status), but the **create-path wiring passes a stale status**, producing false liveness. This PR fixes the wiring and de-larps the test that blessed the bug.

### Bug → Fix → Test

**Bug (verified by static data-flow + a failing test).**
In `runCreate` (`plugins/plugin-agent-orchestrator/src/actions/tasks.ts`), `session` is the `SpawnResult` from `service.spawnSession(...)`, whose `.status` is `"ready"` and is **never refreshed**. Every session that resolves *fulfilled* has already been driven through `runPromptAndClose` / `runPromptViaSmithers`, both of which `stopSession(...)` in their `finally` **before** the durable task is minted. The attach loop then passed `status: session.status` (stale `"ready"`) to `attachSession`, so on the single-turn create path a **terminal** session was attached as non-terminal → the task was promoted to `active` and a dead session was counted in `activeSessionCount` → the task widget showed **false liveness (0/0 → 1 live for a finished session)**.

**Fix.** Refresh the real post-run status from the service via `getSession()` right before attach (`closeSession` sets it to `"stopped"`), with a terminal fallback since a fulfilled outcome *always* means the session was stopped:

```ts
const refreshed = await service.getSession(session.sessionId);
const effectiveStatus = refreshed?.status ?? "stopped";
await taskService.attachSession(threadId, { ...session, status: effectiveStatus, ... });
```

`attachSession` already does the right thing given an honest status (indexes for history + token attribution, sets `stoppedAt`, does **not** `advanceTaskStatus("active")`).

**Tests.**
- Corrected the blessing assertion in `create-task-attaches-sessions.test.ts` — it asserted `input.status === "ready"` against the shared `serviceMock` (whose `stopSession` is a no-op and `getSession` returns a frozen `ready`). It now drives a **stateful ACP mock** (spawn → prompt → stop → `getSession` returns post-stop status) and asserts the terminal `"stopped"`.
- Added a **real-sequence e2e** that drives `createTaskAction.handler` against that stateful ACP mock **and a REAL `OrchestratorTaskService`**, then asserts the minted task stays `open`, `activeSessionCount === 0`, `sessionCount === 1`, and the attached session is `stopped` with a numeric `stoppedAt`.
- Both new assertions **fail against the pre-fix source** (observed: `activeSessionCount` 1, status `active`, attach status `ready`) and pass after — proving they catch the regression, not larp.
- The live-session → `active` promotion branch stays covered by `attach-session.test.ts` (`runCreate` structurally never leaves a session live, so that branch is exercised at the service level).

### Verification

- `bunx vitest run` on the touched + related files: **82 passed** (`attach-session`, `create-task-attaches-sessions`, `create-task`, `create-task-default-criteria`, `create-task-emits-widget-block`, `orchestrator-task-service`).
- Reverted the source fix locally → the two new assertions fail as described → restored.
- `bunx tsgo --noEmit -p tsconfig.json`: **exit 0** (after generating the i18n keyword data a fresh worktree needs).
- `bunx @biomejs/biome check`: clean on both changed files.
- No change to the `spawnRootMessageId` spawn-cap anchoring (#8875/#10890) or the `getService` service-lookup path — the diff is isolated to the create-path attach loop + its test.

### Token-attribution residual (honest note)

The deeper mint-before-spawn reorder (which would also recover the pre-mint usage events lost for single-turn creates, listed as a residual in #10978) ripples across the task-title/goal derivation, swarm-room resolution, and the spawn lifecycle, so it's deferred. This PR ships the correct-liveness fix; the pre-mint token-attribution slice remains a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)