### PR TITLE
fix(orchestrator): gate unauthenticated clone path against git-remote command injection (#10980 follow-up)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/git-remote-safety.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/git-remote-safety.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  assertSafeGitRef,
   assertSafeGitRemote,
   normalizeRepositoryInput,
+  UnsafeGitRefError,
   UnsafeGitRemoteError,
 } from "../../src/services/repo-input.js";
 
@@ -78,5 +80,58 @@ describe("assertSafeGitRemote", () => {
     // `::` inside an IPv6 literal must NOT trip the `<helper>::` check.
     const ipv6 = "https://[2001:db8::1]/owner/repo.git";
     expect(assertSafeGitRemote(ipv6)).toBe(ipv6);
+  });
+
+  it("rejects shell metacharacters / whitespace even behind a valid scheme", () => {
+    // The unauthenticated clone path in git-workspace-service runs the remote
+    // through a shell, so an `https://`-prefixed string with metacharacters is
+    // still command injection. A prefix-only scheme check would wave these
+    // through — the reason #10980's fix left the RCE reachable.
+    for (const bad of [
+      "https://127.0.0.1/x; touch /tmp/pwned",
+      "https://127.0.0.1/x$(touch /tmp/pwned)",
+      "https://127.0.0.1/x`id`",
+      "https://127.0.0.1/x|touch /tmp/pwned",
+      "https://127.0.0.1/x && touch /tmp/pwned",
+      "https://127.0.0.1/x\ntouch /tmp/pwned",
+    ]) {
+      expect(() => assertSafeGitRemote(bad)).toThrow(UnsafeGitRemoteError);
+    }
+  });
+});
+
+describe("assertSafeGitRef", () => {
+  it("accepts ordinary branch / ref names", () => {
+    for (const ok of [
+      "main",
+      "develop",
+      "master",
+      "feature/foo-bar",
+      "release/1.2.3",
+      "v1.0.0",
+      "eliza/task-abc123",
+    ]) {
+      expect(assertSafeGitRef(ok)).toBe(ok);
+    }
+  });
+
+  it("rejects a leading '-' (argument injection)", () => {
+    expect(() => assertSafeGitRef("--upload-pack=sh")).toThrow(
+      UnsafeGitRefError,
+    );
+  });
+
+  it("rejects shell metacharacters / whitespace (branch-name command injection)", () => {
+    for (const bad of [
+      "main; touch /tmp/pwned",
+      "main$(touch /tmp/pwned)",
+      "main`id`",
+      "main | sh",
+      "main && rm -rf /",
+      "with space",
+      "",
+    ]) {
+      expect(() => assertSafeGitRef(bad)).toThrow(UnsafeGitRefError);
+    }
   });
 });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/provision-workspace-injection.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/provision-workspace-injection.test.ts
@@ -1,0 +1,147 @@
+import { existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  UnsafeGitRefError,
+  UnsafeGitRemoteError,
+} from "../../src/services/repo-input.js";
+import { CodingWorkspaceService } from "../../src/services/workspace-service.js";
+
+// End-to-end regression for the git-remote / git-ref command-injection RCE that
+// #10980 left reachable on the UNAUTHENTICATED clone path. These tests drive the
+// REAL CodingWorkspaceService.provisionWorkspace entry (not assertSafeGitRemote in
+// isolation): every production caller — the `provision_workspace` action and
+// `POST /api/workspace/provision` — routes through it, and the lower-level
+// `git-workspace-service` clones public repos through a shell (`promisify(exec)`),
+// so an ungated repo / branch reaches `git clone … ${value} …` verbatim.
+//
+// The assertions are twofold: (1) provisionWorkspace throws at the Milady boundary
+// BEFORE the dependency's `provision()` (which owns every git/shell spawn) is
+// reached, and (2) the injected `touch <sentinel>` command never runs. Because the
+// injection cases let `provision()` call through, deleting either gate would let
+// the real shell clone execute and create the sentinel — failing the test loudly.
+
+function runtimeStub(baseDir: string): unknown {
+  return {
+    getSetting: vi.fn((key: string) =>
+      key === "ELIZA_WORKSPACE_DIR" ? baseDir : null,
+    ),
+    getService: vi.fn(() => null),
+    hasService: vi.fn(() => false),
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  };
+}
+
+interface ProvisionInternals {
+  workspaceService: { provision: (...args: unknown[]) => Promise<unknown> };
+}
+
+describe("provisionWorkspace command-injection gate (#10980 follow-up)", () => {
+  let baseDir: string;
+  let sentinel: string;
+  let service: CodingWorkspaceService;
+  let provisionSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    baseDir = join(
+      tmpdir(),
+      `orch-injection-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    sentinel = join(baseDir, "PWNED");
+    service = await CodingWorkspaceService.start(runtimeStub(baseDir) as never);
+    // Spy on the real dependency's provision so we can assert it is never reached
+    // on an injection attempt; it CALLS THROUGH (no mock impl) so a removed gate
+    // would let the shell clone actually run and create the sentinel.
+    provisionSpy = vi.spyOn(
+      (service as unknown as ProvisionInternals).workspaceService,
+      "provision",
+    );
+  });
+
+  afterEach(async () => {
+    await service.stop().catch(() => undefined);
+    rmSync(baseDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("rejects a shell-metacharacter repo on the unauthenticated path and spawns no git", async () => {
+    await expect(
+      service.provisionWorkspace({
+        repo: `https://127.0.0.1/x; touch ${sentinel}; echo`,
+      }),
+    ).rejects.toBeInstanceOf(UnsafeGitRemoteError);
+
+    expect(provisionSpy).not.toHaveBeenCalled();
+    expect(existsSync(sentinel)).toBe(false);
+  });
+
+  it("rejects command-substitution and pipe repos", async () => {
+    for (const repo of [
+      `https://127.0.0.1/x$(touch ${sentinel})`,
+      "https://127.0.0.1/x|touch /tmp/x",
+      "https://127.0.0.1/x`id`",
+      "ext::sh -c touch",
+      "file:///etc/passwd",
+    ]) {
+      await expect(service.provisionWorkspace({ repo })).rejects.toBeInstanceOf(
+        UnsafeGitRemoteError,
+      );
+    }
+    expect(provisionSpy).not.toHaveBeenCalled();
+    expect(existsSync(sentinel)).toBe(false);
+  });
+
+  it("rejects a shell-metacharacter baseBranch and spawns no git", async () => {
+    await expect(
+      service.provisionWorkspace({
+        repo: "https://github.com/elizaOS/eliza",
+        baseBranch: `main; touch ${sentinel}; echo`,
+      }),
+    ).rejects.toBeInstanceOf(UnsafeGitRefError);
+
+    expect(provisionSpy).not.toHaveBeenCalled();
+    expect(existsSync(sentinel)).toBe(false);
+  });
+
+  it("rejects a shell-metacharacter branchName and spawns no git", async () => {
+    await expect(
+      service.provisionWorkspace({
+        repo: "https://github.com/elizaOS/eliza",
+        baseBranch: "main",
+        branchName: `feat; touch ${sentinel}; echo`,
+      }),
+    ).rejects.toBeInstanceOf(UnsafeGitRefError);
+
+    expect(provisionSpy).not.toHaveBeenCalled();
+    expect(existsSync(sentinel)).toBe(false);
+  });
+
+  it("still provisions a legitimate repo + branch (gate does not block real use)", async () => {
+    provisionSpy.mockResolvedValue({
+      id: "ws-legit",
+      path: join(baseDir, "ws-legit"),
+      repo: "https://github.com/elizaOS/eliza.git",
+      branch: { name: "eliza/feature", baseBranch: "develop" },
+      strategy: "clone",
+      status: "ready",
+    });
+
+    const result = await service.provisionWorkspace({
+      repo: "elizaOS/eliza",
+      baseBranch: "develop",
+      branchName: "eliza/feature",
+    });
+
+    expect(provisionSpy).toHaveBeenCalledTimes(1);
+    const config = provisionSpy.mock.calls[0][0] as {
+      repo: string;
+      baseBranch: string;
+      branchName: string;
+    };
+    expect(config.repo).toBe("https://github.com/elizaOS/eliza.git");
+    expect(config.baseBranch).toBe("develop");
+    expect(config.branchName).toBe("eliza/feature");
+    expect(result.id).toBe("ws-legit");
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/repo-input.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/repo-input.ts
@@ -100,6 +100,15 @@ export class UnsafeGitRemoteError extends Error {
 // followed by `::`. Deliberately does NOT match IPv6 URL literals such as
 // `https://[::1]/repo` (there the `::` is not preceded by a bare leading token).
 const GIT_TRANSPORT_HELPER_RE = /^[A-Za-z][A-Za-z0-9+.-]*::/;
+// Shell metacharacters and whitespace have no place in a real git remote URL
+// (`https://host/owner/repo.git` or scp-style `user@host:path`). The lower-level
+// `git-workspace-service` clones public repos through a SHELL
+// (`promisify(exec)`, no quoting), so a remote like
+// `https://x/y; touch /tmp/pwned` is command-injection RCE even though its
+// `https://` prefix looks valid. Rejecting these keeps a single validated string
+// safe whether the downstream spawn uses `execFile` (argv) or a shell. `[`/`]`
+// are intentionally allowed so IPv6 URL literals (`https://[2001:db8::1]/…`) pass.
+const SHELL_UNSAFE_RE = /[\s"'`\\;|&$(){}<>*?~#!]/;
 // Only https / http / ssh URL transports are allowed. `file:` (local repo
 // disclosure) and `git:` (unauthenticated, MITM-able) are rejected.
 const ALLOWED_GIT_URL_SCHEME_RE = /^(?:https?|ssh):\/\//i;
@@ -119,7 +128,10 @@ const SCP_LIKE_REMOTE_RE = /^[^\s@:]+@[^\s:]+:(?!:)[^\s]+$/;
  *  - `ext::sh -c "…"` (and any `<helper>::…`) runs an arbitrary command;
  *  - a leading `-` (e.g. `--upload-pack=…`) is parsed as a git *option*
  *    (argument injection), since `execFile` does not add a `--` separator;
- *  - `file://…` clones an arbitrary local repository (info disclosure).
+ *  - `file://…` clones an arbitrary local repository (info disclosure);
+ *  - shell metacharacters / whitespace (`https://x/y; touch /tmp/pwned`) inject
+ *    commands on the unauthenticated clone path, which the lower-level
+ *    `git-workspace-service` runs through a shell (`promisify(exec)`).
  *
  * Callers MUST also spawn git with `GIT_ALLOW_PROTOCOL` restricted and a `--`
  * separator — this function is the application-level allowlist half of that
@@ -140,12 +152,59 @@ export function assertSafeGitRemote(repo: string): string {
       `Git remote uses an unsupported transport helper (e.g. ext::/fd::): ${repo}`,
     );
   }
+  if (SHELL_UNSAFE_RE.test(value)) {
+    throw new UnsafeGitRemoteError(
+      `Git remote contains shell metacharacters or whitespace (command injection): ${repo}`,
+    );
+  }
   if (ALLOWED_GIT_URL_SCHEME_RE.test(value) || SCP_LIKE_REMOTE_RE.test(value)) {
     return value;
   }
   throw new UnsafeGitRemoteError(
     `Git remote is not an https/http/ssh URL or an ssh scp-style remote: ${repo}`,
   );
+}
+
+/** Thrown by {@link assertSafeGitRef} when a branch / ref name is unsafe to
+ * interpolate into a git command. */
+export class UnsafeGitRefError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UnsafeGitRefError";
+  }
+}
+
+// A conservative allowlist for git branch / ref names: a leading alphanumeric
+// followed by alphanumerics and `. _ / -`. This is a strict subset of what
+// `git check-ref-format` permits, chosen so the value is safe to interpolate
+// into a shell command. It rejects a leading `-` (argument injection), all
+// whitespace, and every shell metacharacter, while accepting ordinary names
+// like `main`, `develop`, `feature/foo-bar`, and `release/1.2.3`.
+const SAFE_GIT_REF_RE = /^[A-Za-z0-9][A-Za-z0-9._/-]*$/;
+
+/**
+ * Validate that a branch / ref name is safe to interpolate into a git command,
+ * returning it unchanged when safe and throwing {@link UnsafeGitRefError}
+ * otherwise.
+ *
+ * The orchestrator auto-mints branch names through a sanitizer, but callers can
+ * also supply `baseBranch` / `branchName` directly (HTTP `POST /api/workspace/
+ * provision` body, action content). Those bypass the mint and flow raw into
+ * `git clone --branch …`, `git fetch origin …`, `git checkout -b …`, and
+ * `git worktree add -b …`, which the lower-level `git-workspace-service` runs
+ * through a shell — so an unvalidated ref like `main; touch /tmp/pwned` is
+ * command-injection RCE.
+ */
+export function assertSafeGitRef(ref: string, label = "git ref"): string {
+  if (typeof ref !== "string" || ref.length === 0) {
+    throw new UnsafeGitRefError(`${label} is empty.`);
+  }
+  if (!SAFE_GIT_REF_RE.test(ref)) {
+    throw new UnsafeGitRefError(
+      `${label} contains characters that are not allowed in a git ref name (letters, digits, ".", "_", "/", "-"; no leading "-"): ${ref}`,
+    );
+  }
+  return ref;
 }
 
 export function diagnoseWorkspaceBootstrapFailure(

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-service.ts
@@ -69,7 +69,11 @@ import {
 export type { AuthPromptCallback } from "./workspace-github.js";
 
 import { readConfigEnvKey } from "./config-env.js";
-import { assertSafeGitRemote, normalizeRepositoryInput } from "./repo-input.js";
+import {
+  assertSafeGitRef,
+  assertSafeGitRemote,
+  normalizeRepositoryInput,
+} from "./repo-input.js";
 import {
   commit as gitCommit,
   createPR as gitCreatePR,
@@ -442,8 +446,19 @@ export class CodingWorkspaceService {
     }
 
     // Normalize common shorthand like owner/repo before handing it to the
-    // lower-level clone service, which expects an actual remote URL.
-    const repo = normalizeRepositoryInput(options.repo);
+    // lower-level clone service, which expects an actual remote URL, then hard-
+    // gate it at the Milady boundary BEFORE any git spawn. assertSafeGitRemote
+    // rejects transport helpers, leading-"-" argument injection, non-http(s)/ssh
+    // schemes, AND shell metacharacters — so the SAME validated string is safe
+    // on every downstream strategy (credentialed execFile clone, worktree, and
+    // the dependency's unauthenticated shell clone). Throws before provision().
+    const repo = assertSafeGitRemote(normalizeRepositoryInput(options.repo));
+    // A caller-supplied branch name (HTTP body / action content) bypasses the
+    // sanitized auto-mint and flows raw into `git checkout -b` / `git worktree
+    // add -b` via the dependency's shell, so validate it as a git ref here.
+    if (options.branchName !== undefined) {
+      assertSafeGitRef(options.branchName, "branchName");
+    }
     const executionId = options.execution?.id ?? `exec-${Date.now()}`;
     const taskId = options.task?.id ?? `task-${Date.now()}`;
     const userCredentials = this.resolveUserCredentials(
@@ -460,9 +475,16 @@ export class CodingWorkspaceService {
       userCredentials?.type === "pat" || userCredentials?.type === "oauth"
         ? userCredentials.token
         : undefined;
-    const baseBranch =
+    // `baseBranch` flows into `git clone --branch …` / `git fetch origin …` via
+    // the dependency's shell. Validate it whether it was caller-supplied
+    // (untrusted) or resolved from the remote's symref (a malicious remote could
+    // return a ref with metacharacters). `??` short-circuits so an explicit
+    // baseBranch is rejected before we ever spawn `git ls-remote`.
+    const baseBranch = assertSafeGitRef(
       options.baseBranch ??
-      (await resolveDefaultBranch(repo, defaultBranchToken));
+        (await resolveDefaultBranch(repo, defaultBranchToken)),
+      "baseBranch",
+    );
 
     const workspaceConfig: WorkspaceConfig = {
       repo,


### PR DESCRIPTION
## Still-open RCE this closes

#10980 fixed the **credentialed** clone / `ls-remote` injection and the spend-cap bypass, but — as its own reviewer flagged in the [merge-review comment](https://github.com/elizaOS/eliza/pull/10980) — it left the **unauthenticated (public-repo / no-token) clone path a reachable RCE**. This PR completes exactly what that review asked for.

`CodingWorkspaceService.provisionWorkspace` only called `normalizeRepositoryInput(options.repo)` (which returns unknown input **unchanged**) and handed it straight to the `git-workspace-service` dependency's `provision()` with **no application-level gate**. When no credential is available, `provision()` runs `tryUnauthenticatedClone`, which executes:

```
git clone --branch ${baseBranch} ${cloneUrl} .
```

through a **shell** (`promisify(exec)` — no quoting, no `--`, no `GIT_ALLOW_PROTOCOL`). So a public-repo provision with

```
repo = "https://foo/bar; touch /tmp/pwned"   // no credential
```

is **host RCE**.

### Two subtleties that made a naive gate insufficient

1. **`assertSafeGitRemote` from #10980 only validated the URL *scheme prefix***, so it *accepts* `https://foo/bar; touch /tmp/pwned` (starts with `https://`). That's safe on the `execFile` argv path (metacharacters are literal bytes) but **not** on the dependency's shell path. Merely calling it in `provisionWorkspace` — the review's step 1 — would **not** have blocked the exploit.
2. **`baseBranch` / `branchName`** (from the `POST /api/workspace/provision` body and from action content) bypass the sanitized branch-name mint and flow **raw** into `git clone --branch …`, `git fetch origin …`, `git checkout -b …`, `git worktree add -b …` — a second, independent shell-injection vector (`baseBranch = "main; touch /tmp/pwned"`).

Both vectors were verified **reproducible on the current `develop` tip** before the fix (a live probe drove the real `provisionWorkspace` and the injected `touch <sentinel>` file was created on disk).

## Fix

- **`assertSafeGitRemote` now also rejects shell metacharacters / whitespace** (`;` `|` `&` `$` `` ` `` `(` `)` `<` `>` `\` quotes `*` `?` `~` `#` `!` `{` `}` and all whitespace), so the **same validated string** is safe on both the `execFile` and shell paths. IPv6 URL literals (`https://[2001:db8::1]/…`) still pass.
- **New `assertSafeGitRef`** — a conservative git-ref allowlist (`^[A-Za-z0-9][A-Za-z0-9._/-]*$`) that rejects a leading `-`, whitespace, and shell metacharacters while accepting `main`, `develop`, `feature/foo-bar`, `release/1.2.3`.
- **`provisionWorkspace` gates `repo` (assertSafeGitRemote), `branchName`, and `baseBranch` (assertSafeGitRef) at the Milady boundary BEFORE `provision()`** — so **every** strategy (credentialed clone, worktree, and the unauthenticated shell clone) is covered. The exact validated strings are the ones passed downstream; the repo gate throws before any git spawn (including the `ls-remote` default-branch lookup).

## Test

`__tests__/unit/provision-workspace-injection.test.ts` drives the **real** `provisionWorkspace` (not `assertSafeGitRemote` in isolation — that was the "false confidence" the review called out) with a metacharacter `repo` / `baseBranch` / `branchName` and **no credential**, asserting it:
- throws `UnsafeGitRemoteError` / `UnsafeGitRefError`,
- **never reaches** the dependency's `provision()` (spied, call-through), and
- **never creates** the injected sentinel file.

Because the injection cases let `provision()` call through to the real shell clone, deleting either gate makes the sentinel appear and the test fail loudly. A legitimate-repo case proves the gate does not block normal use. `git-remote-safety.test.ts` gains direct shell-metacharacter and `assertSafeGitRef` unit cases.

```
Test Files  6 passed (6)
     Tests  36 passed (36)
```

Refs #10980. Do not merge without security review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)