### PR TITLE
fix(cloud): stop unverified domain attach from being a global squat lock (#11024)

### DIFF
--- a/packages/cloud/api/v1/apps/[id]/domains/[domain]/dns/[recordId]/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/[domain]/dns/[recordId]/route.ts
@@ -51,9 +51,7 @@ async function loadCloudflareManagedDomain(c: AppContext) {
     return { error: "Access denied", status: 403 as const };
   }
 
-  const md = await managedDomainsService.getDomainByName(
-    decodeURIComponent(domainParam),
-  );
+  const md = await managedDomainsService.getOwnDomainRow(user.organization_id, decodeURIComponent(domainParam));
   if (!md || md.organizationId !== user.organization_id || md.appId !== appId) {
     return { error: "Domain not attached to this app", status: 404 as const };
   }

--- a/packages/cloud/api/v1/apps/[id]/domains/[domain]/dns/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/[domain]/dns/route.ts
@@ -47,9 +47,7 @@ async function loadCloudflareManagedDomain(c: AppContext) {
     return { error: "Access denied", status: 403 as const };
   }
 
-  const md = await managedDomainsService.getDomainByName(
-    decodeURIComponent(domainParam),
-  );
+  const md = await managedDomainsService.getOwnDomainRow(user.organization_id, decodeURIComponent(domainParam));
   if (!md || md.organizationId !== user.organization_id || md.appId !== appId) {
     return { error: "Domain not attached to this app", status: 404 as const };
   }

--- a/packages/cloud/api/v1/apps/[id]/domains/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/route.ts
@@ -87,17 +87,27 @@ app.post("/", async (c) => {
     }
     const { domain } = parsed.data;
 
-    const existing = await managedDomainsService.getDomainByName(domain);
+    // Block only when another org holds the domain's EXCLUSIVE slot — a verified
+    // or cloudflare row. A mere unverified pending row from another org is NOT
+    // exclusive (getDomainByName returns null for it), so it can no longer squat
+    // the global namespace and deny a legitimate attach (#11024).
+    const exclusive = await managedDomainsService.getDomainByName(domain);
+    if (exclusive && exclusive.organizationId !== ctx.user.organization_id) {
+      return c.json(
+        {
+          success: false,
+          error: "Domain is already registered to a different organization",
+        },
+        409,
+      );
+    }
+
+    // Reuse the caller's OWN row (verified or pending) instead of minting a dup.
+    const existing = await managedDomainsService.getOwnDomainRow(
+      ctx.user.organization_id,
+      domain,
+    );
     if (existing) {
-      if (existing.organizationId !== ctx.user.organization_id) {
-        return c.json(
-          {
-            success: false,
-            error: "Domain is already registered to a different organization",
-          },
-          409,
-        );
-      }
       await managedDomainsService.assignToResource(existing.id, {
         type: "app",
         id: ctx.appId,
@@ -172,7 +182,10 @@ app.delete("/", async (c) => {
     }
     const { domain } = parsed.data;
 
-    const md = await managedDomainsService.getDomainByName(domain);
+    const md = await managedDomainsService.getOwnDomainRow(
+      ctx.user.organization_id,
+      domain,
+    );
     if (
       !md ||
       md.organizationId !== ctx.user.organization_id ||

--- a/packages/cloud/api/v1/apps/[id]/domains/status/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/status/route.ts
@@ -42,7 +42,7 @@ app.post("/", async (c) => {
       );
     }
 
-    const md = await managedDomainsService.getDomainByName(parsed.data.domain);
+    const md = await managedDomainsService.getOwnDomainRow(user.organization_id, parsed.data.domain);
     if (
       !md ||
       md.organizationId !== user.organization_id ||

--- a/packages/cloud/api/v1/apps/[id]/domains/verify/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/domains/verify/route.ts
@@ -48,7 +48,7 @@ app.post("/", async (c) => {
       );
     }
 
-    const md = await managedDomainsService.getDomainByName(parsed.data.domain);
+    const md = await managedDomainsService.getOwnDomainRow(user.organization_id, parsed.data.domain);
     if (
       !md ||
       md.organizationId !== user.organization_id ||

--- a/packages/cloud/shared/src/db/migrations/0163_domain_squat_partial_unique.sql
+++ b/packages/cloud/shared/src/db/migrations/0163_domain_squat_partial_unique.sql
@@ -1,0 +1,15 @@
+-- #11024: an unverified external-domain attach must no longer be a GLOBAL
+-- ownership lock. Replace the global unique on `domain` with a PARTIAL unique
+-- (only verified / cloudflare rows are globally exclusive) plus an
+-- (organization_id, domain) unique. Different orgs may now each hold a competing
+-- UNVERIFIED pending row, so an unproven attach can't squat the namespace and
+-- permanently deny the rightful owner. Serving already requires verified+active.
+--
+-- Safe backfill: the domain column was globally unique before this migration, so
+-- (organization_id, domain) is already unique (a subset) and every verified /
+-- cloudflare row is already unique on domain — both new indexes build without
+-- collision on existing data.
+ALTER TABLE "managed_domains" DROP CONSTRAINT IF EXISTS "managed_domains_domain_unique";--> statement-breakpoint
+DROP INDEX IF EXISTS "managed_domains_domain_idx";--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "managed_domains_domain_exclusive_idx" ON "managed_domains" USING btree ("domain") WHERE "managed_domains"."verified" = true OR "managed_domains"."registrar" = 'cloudflare';--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "managed_domains_org_domain_idx" ON "managed_domains" USING btree ("organization_id","domain");

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1128,6 +1128,13 @@
       "when": 1780964400000,
       "tag": "0162_ad_slot_payout_settlement",
       "breakpoints": true
+    },
+    {
+      "idx": 161,
+      "version": "7",
+      "when": 1781050800000,
+      "tag": "0163_domain_squat_partial_unique",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/schemas/managed-domains.ts
+++ b/packages/cloud/shared/src/db/schemas/managed-domains.ts
@@ -5,7 +5,7 @@
  * Supports assignment to apps, containers, agents, and MCPs.
  */
 
-import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { type InferInsertModel, type InferSelectModel, sql } from "drizzle-orm";
 import {
   boolean,
   index,
@@ -130,8 +130,12 @@ export const managedDomains = pgTable(
       .notNull()
       .references(() => organizations.id, { onDelete: "cascade" }),
 
-    // Domain name (lowercase, normalized)
-    domain: text("domain").notNull().unique(),
+    // Domain name (lowercase, normalized). NOT globally unique on its own: only
+    // VERIFIED or cloudflare-registrar rows are globally exclusive (partial
+    // unique index below). Different orgs may each hold a competing UNVERIFIED
+    // pending row for the same domain, so an unproven attach can't squat the
+    // global namespace and permanently deny the rightful owner (#11024).
+    domain: text("domain").notNull(),
 
     // Registration details
     registrar: domainRegistrarEnum("registrar").notNull().default("external"),
@@ -208,7 +212,18 @@ export const managedDomains = pgTable(
   },
   (table) => ({
     organizationIdx: index("managed_domains_org_idx").on(table.organizationId),
-    domainIdx: uniqueIndex("managed_domains_domain_idx").on(table.domain),
+    // Only VERIFIED or cloudflare rows hold the exclusive global slot for a
+    // domain. Unverified external pending rows are NOT globally unique, so they
+    // can't squat the namespace (#11024). The reader (`getDomainByName`) returns
+    // this exclusive row; serving already requires verified+active.
+    domainExclusiveIdx: uniqueIndex("managed_domains_domain_exclusive_idx")
+      .on(table.domain)
+      .where(sql`${table.verified} = true OR ${table.registrar} = 'cloudflare'`),
+    // An org still can't hold two rows for the same domain.
+    orgDomainIdx: uniqueIndex("managed_domains_org_domain_idx").on(
+      table.organizationId,
+      table.domain,
+    ),
     appIdx: index("managed_domains_app_idx").on(table.appId),
     containerIdx: index("managed_domains_container_idx").on(table.containerId),
     agentIdx: index("managed_domains_agent_idx").on(table.agentId),

--- a/packages/cloud/shared/src/lib/services/__tests__/managed-domains-squat.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/managed-domains-squat.test.ts
@@ -1,0 +1,218 @@
+/**
+ * #11024 — an unverified external-domain attach must not be a GLOBAL ownership
+ * lock. Real in-process PGlite, real `managedDomainsService` readers, real
+ * indexes from migration 0163: only VERIFIED / cloudflare rows are globally
+ * exclusive; different orgs may each hold a competing UNVERIFIED pending row.
+ *
+ * The table is raw-created here (enum columns as TEXT — drizzle reads/writes them
+ * as strings) with exactly the migration's two indexes, so the test exercises the
+ * real uniqueness semantics without pulling the full FK closure.
+ *
+ * Self-skips LOUDLY if PGlite is unavailable (never a silent pass).
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
+const CAN_USE_ISOLATED_PGLITE =
+  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { and, eq, sql } from "drizzle-orm";
+import { closeDatabaseConnectionsForTests, dbWrite } from "../../../db/client";
+import { managedDomains } from "../../../db/schemas/managed-domains";
+
+const PGLITE_TIMEOUT = 60_000;
+let pgliteReady = true;
+let svc: typeof import("../managed-domains").managedDomainsService;
+
+let seq = 0;
+const orgId = (): string => {
+  seq += 1;
+  // deterministic uuid-shaped ids
+  return `00000000-0000-4000-8000-${String(seq).padStart(12, "0")}`;
+};
+
+async function insertRow(row: {
+  organizationId: string;
+  domain: string;
+  registrar?: "external" | "cloudflare";
+  verified?: boolean;
+  createdAt?: Date;
+}): Promise<string> {
+  const [created] = await dbWrite
+    .insert(managedDomains)
+    .values({
+      organizationId: row.organizationId,
+      domain: row.domain,
+      registrar: row.registrar ?? "external",
+      verified: row.verified ?? false,
+      status: "pending",
+      ...(row.createdAt ? { createdAt: row.createdAt } : {}),
+    })
+    .returning({ id: managedDomains.id });
+  return created.id;
+}
+
+beforeAll(async () => {
+  if (!CAN_USE_ISOLATED_PGLITE) {
+    pgliteReady = false;
+    return;
+  }
+  try {
+    ({ managedDomainsService: svc } = await import("../managed-domains"));
+    // Raw table + the exact indexes migration 0163 creates. Enum columns are
+    // TEXT (drizzle round-trips them as strings). FKs omitted (irrelevant to
+    // uniqueness); only the columns the schema maps are present.
+    await dbWrite.execute(sql`
+      CREATE TABLE IF NOT EXISTS "managed_domains" (
+        "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+        "organization_id" uuid NOT NULL,
+        "domain" text NOT NULL,
+        "registrar" text NOT NULL DEFAULT 'external',
+        "registered_at" timestamp, "expires_at" timestamp,
+        "auto_renew" boolean NOT NULL DEFAULT true,
+        "status" text NOT NULL DEFAULT 'pending',
+        "registrant_info" jsonb,
+        "resource_type" text,
+        "app_id" uuid, "container_id" uuid, "agent_id" uuid, "mcp_id" uuid,
+        "nameserver_mode" text NOT NULL DEFAULT 'external',
+        "dns_records" jsonb DEFAULT '[]'::jsonb,
+        "ssl_status" text DEFAULT 'pending', "ssl_expires_at" timestamp,
+        "verified" boolean NOT NULL DEFAULT false,
+        "verification_token" text, "verified_at" timestamp,
+        "moderation_status" text NOT NULL DEFAULT 'clean',
+        "moderation_flags" jsonb DEFAULT '[]'::jsonb,
+        "last_health_check" timestamp,
+        "is_live" boolean NOT NULL DEFAULT false,
+        "health_check_error" text, "content_hash" text,
+        "last_content_scan_at" timestamp, "last_ai_scan_at" timestamp,
+        "ai_scan_model" text, "content_scan_confidence" real,
+        "content_scan_cache" jsonb, "suspended_at" timestamp,
+        "suspension_reason" text, "suspension_notification" jsonb,
+        "owner_notified_at" timestamp,
+        "cloudflare_zone_id" text, "cloudflare_registration_id" text,
+        "purchase_price" text, "renewal_price" text,
+        "payment_method" text, "stripe_payment_intent_id" text,
+        "created_at" timestamp NOT NULL DEFAULT now(),
+        "updated_at" timestamp NOT NULL DEFAULT now()
+      );
+    `);
+    await dbWrite.execute(
+      sql`CREATE UNIQUE INDEX IF NOT EXISTS "managed_domains_domain_exclusive_idx" ON "managed_domains" ("domain") WHERE "verified" = true OR "registrar" = 'cloudflare';`,
+    );
+    await dbWrite.execute(
+      sql`CREATE UNIQUE INDEX IF NOT EXISTS "managed_domains_org_domain_idx" ON "managed_domains" ("organization_id","domain");`,
+    );
+  } catch (error) {
+    pgliteReady = false;
+    console.error("[managed-domains-squat.test] PGlite unavailable — skipping.", error);
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests();
+});
+
+beforeEach(async () => {
+  if (pgliteReady) await dbWrite.delete(managedDomains);
+});
+
+describe("managed-domains squat fix (#11024)", () => {
+  test("pglite applied (loud, never a silent no-op pass)", () => {
+    expect(pgliteReady).toBe(true);
+  });
+
+  test("two orgs can each hold a competing UNVERIFIED pending row for the same domain (no squat lock)", async () => {
+    if (!pgliteReady) return;
+    const orgA = orgId();
+    const orgB = orgId();
+
+    const aId = await insertRow({ organizationId: orgA, domain: "victim-brand.com" });
+    // The rightful org is NOT blocked from inserting its own pending row.
+    const bId = await insertRow({ organizationId: orgB, domain: "victim-brand.com" });
+    expect(aId).not.toBe(bId);
+
+    // While only unverified rows exist, the domain has NO exclusive owner — the
+    // serve/resolve path (which uses getDomainByName) resolves to nothing.
+    expect(await svc.getDomainByName("victim-brand.com")).toBeNull();
+    // Each org still sees its OWN pending row.
+    expect((await svc.getOwnDomainRow(orgA, "victim-brand.com"))?.id).toBe(aId);
+    expect((await svc.getOwnDomainRow(orgB, "victim-brand.com"))?.id).toBe(bId);
+  });
+
+  test("verifying promotes a row to the exclusive slot; the other org can no longer verify the same domain", async () => {
+    if (!pgliteReady) return;
+    const orgA = orgId();
+    const orgB = orgId();
+    await insertRow({ organizationId: orgA, domain: "shared.com" });
+    await insertRow({ organizationId: orgB, domain: "shared.com" });
+
+    // Org B proves ownership → its row becomes exclusive.
+    await dbWrite
+      .update(managedDomains)
+      .set({ verified: true })
+      .where(and(eq(managedDomains.organizationId, orgB), eq(managedDomains.domain, "shared.com")));
+
+    const exclusive = await svc.getDomainByName("shared.com");
+    expect(exclusive?.organizationId).toBe(orgB);
+
+    // Org A can NOT now also verify — the partial unique index forbids a second
+    // exclusive row for the domain (this is the race the fix closes at /verify).
+    // Wrap in an async IIFE: a drizzle update builder is a thenable query
+    // builder, not a real Promise, so `.rejects` must be given an actual Promise.
+    await expect(
+      (async () => {
+        await dbWrite
+          .update(managedDomains)
+          .set({ verified: true })
+          .where(
+            and(
+              eq(managedDomains.organizationId, orgA),
+              eq(managedDomains.domain, "shared.com"),
+            ),
+          );
+      })(),
+    ).rejects.toThrow();
+  });
+
+  test("a cloudflare row is exclusive on its own (registrar-based exclusivity)", async () => {
+    if (!pgliteReady) return;
+    const orgA = orgId();
+    await insertRow({ organizationId: orgA, domain: "cf.com", registrar: "cloudflare", verified: false });
+    // Even unverified, a cloudflare row holds the exclusive slot.
+    expect((await svc.getDomainByName("cf.com"))?.organizationId).toBe(orgA);
+    // A second cloudflare row for the same domain (different org) is refused.
+    await expect(
+      insertRow({ organizationId: orgId(), domain: "cf.com", registrar: "cloudflare" }),
+    ).rejects.toThrow();
+  });
+
+  test("an org still can't hold two rows for one domain ((org,domain) unique)", async () => {
+    if (!pgliteReady) return;
+    const orgA = orgId();
+    await insertRow({ organizationId: orgA, domain: "dup.com" });
+    await expect(insertRow({ organizationId: orgA, domain: "dup.com" })).rejects.toThrow();
+  });
+
+  test("releaseStaleUnverifiedExternals reclaims old unverified externals, spares verified + fresh", async () => {
+    if (!pgliteReady) return;
+    const old = new Date(Date.now() - 1000 * 60 * 60 * 72); // 72h ago
+    const orgStale = orgId();
+    const orgFresh = orgId();
+    const orgVerified = orgId();
+
+    await insertRow({ organizationId: orgStale, domain: "stale.com", createdAt: old });
+    await insertRow({ organizationId: orgFresh, domain: "fresh.com" }); // now
+    await insertRow({ organizationId: orgVerified, domain: "verified.com", verified: true, createdAt: old });
+
+    const released = await svc.releaseStaleUnverifiedExternals(1000 * 60 * 60 * 24); // 24h TTL
+    expect(released).toBe(1); // only the stale unverified external
+
+    expect(await svc.getOwnDomainRow(orgStale, "stale.com")).toBeNull(); // reclaimed
+    expect(await svc.getOwnDomainRow(orgFresh, "fresh.com")).not.toBeNull(); // spared (fresh)
+    expect(await svc.getDomainByName("verified.com")).not.toBeNull(); // spared (verified)
+  });
+});

--- a/packages/cloud/shared/src/lib/services/managed-domains.ts
+++ b/packages/cloud/shared/src/lib/services/managed-domains.ts
@@ -12,7 +12,7 @@
  * work, not wrapping a one-line insert.
  */
 
-import { and, eq, isNotNull, lte } from "drizzle-orm";
+import { and, eq, isNotNull, lte, or } from "drizzle-orm";
 import { dbRead, dbWrite } from "../../db/client";
 import {
   type DomainRegistrantInfo,
@@ -97,10 +97,14 @@ export async function upsertCloudflareRegisteredDomain(
   input: UpsertCloudflareDomainInput,
 ): Promise<ManagedDomain> {
   const normalized = input.domain.toLowerCase().trim();
-  const existing = await getDomainByName(normalized);
-  if (existing && existing.organizationId !== input.organizationId) {
+  // Block if ANOTHER org already holds the exclusive slot; otherwise operate on
+  // THIS org's own row (which may be an unverified external pending row that
+  // getDomainByName intentionally hides — we upgrade it to cloudflare here).
+  const exclusive = await getDomainByName(normalized);
+  if (exclusive && exclusive.organizationId !== input.organizationId) {
     throw new Error("managed domain belongs to a different organization");
   }
+  const existing = await getOwnDomainRow(input.organizationId, normalized);
 
   const now = new Date();
   const status = input.status ?? (input.cloudflareZoneId ? "active" : "pending");
@@ -208,12 +212,76 @@ export async function getDomainById(domainId: string): Promise<ManagedDomain | n
   return row ?? null;
 }
 
+/**
+ * The globally EXCLUSIVE row for a domain: a verified row, or a cloudflare
+ * registrar row. At most one exists (enforced by the partial unique index).
+ * Returns null when only unverified external pending rows exist — those never
+ * own the domain globally, so an unverified squat can't be mistaken for the
+ * rightful owner (#11024). Serving/resolution callers want exactly this: they
+ * already gate on `verified && status==='active'`, and must never resolve a host
+ * to another org's unproven pending row.
+ */
 export async function getDomainByName(domain: string): Promise<ManagedDomain | null> {
   const normalized = domain.toLowerCase().trim();
   const row = await dbRead.query.managedDomains.findFirst({
-    where: eq(managedDomains.domain, normalized),
+    where: and(
+      eq(managedDomains.domain, normalized),
+      or(eq(managedDomains.verified, true), eq(managedDomains.registrar, "cloudflare")),
+    ),
   });
   return row ?? null;
+}
+
+/**
+ * The caller org's OWN row for a domain (verified or not). App-management routes
+ * (attach/verify/dns/status/rename/buy) operate on the caller's own pending row,
+ * which `getDomainByName` intentionally hides while it is unverified. Scoped to
+ * `(organization_id, domain)`, which is unique — so at most one row.
+ */
+export async function getOwnDomainRow(
+  organizationId: string,
+  domain: string,
+): Promise<ManagedDomain | null> {
+  const normalized = domain.toLowerCase().trim();
+  const row = await dbRead.query.managedDomains.findFirst({
+    where: and(
+      eq(managedDomains.domain, normalized),
+      eq(managedDomains.organizationId, organizationId),
+    ),
+  });
+  return row ?? null;
+}
+
+/**
+ * Hard-delete a managed-domain row (the reclaim primitive #11024's expiry cron
+ * needs — `unassignFromResource` only nulls resource FKs and keeps the row, so
+ * before this there was no way to release a stale unverified pending row). Only
+ * ever call for rows the caller owns or for expired unverified externals.
+ */
+export async function releaseDomain(domainId: string): Promise<void> {
+  await dbWrite.delete(managedDomains).where(eq(managedDomains.id, domainId));
+}
+
+/**
+ * Delete external rows that are still unverified after `olderThanMs` — the
+ * reclaim path that stops an unproven attach from squatting a domain forever.
+ * Returns the number of rows released. Intended for a periodic cron.
+ */
+export async function releaseStaleUnverifiedExternals(
+  olderThanMs: number,
+): Promise<number> {
+  const cutoff = new Date(Date.now() - olderThanMs);
+  const deleted = await dbWrite
+    .delete(managedDomains)
+    .where(
+      and(
+        eq(managedDomains.verified, false),
+        eq(managedDomains.registrar, "external"),
+        lte(managedDomains.createdAt, cutoff),
+      ),
+    )
+    .returning({ id: managedDomains.id });
+  return deleted.length;
 }
 
 export async function listForOrganization(organizationId: string): Promise<ManagedDomain[]> {
@@ -411,6 +479,9 @@ export const managedDomainsService = {
   syncStatus,
   getDomainById,
   getDomainByName,
+  getOwnDomainRow,
+  releaseDomain,
+  releaseStaleUnverifiedExternals,
   listForOrganization,
   listForApp,
   listVerifiedAppOrigins,


### PR DESCRIPTION
Closes #11024.

## The bug (adversarially confirmed in the issue)

`POST /api/v1/apps/{appId}/domains` with a domain you don't own wrote a **globally-unique** `managed_domains` row (`domain` had column `.unique()` **and** `uniqueIndex managed_domains_domain_idx`) with `verified=false` and **zero DNS proof**. Because the domain was globally unique, that unverified pending row occupied the one global slot — so the rightful org's attach (`route.ts:92`) **and** buy (`buy/route.ts:194`) both hard-409'd forever, and there was **no reclaim path** (`unassignFromResource` only nulls FKs; no delete existed). A permanent cross-tenant namespace squat over arbitrarily many domains.

## Fix: only verified / cloudflare rows are globally exclusive

- **Migration 0163:** drop the global unique on `domain`; add a **partial** unique index `(domain) WHERE verified = true OR registrar = 'cloudflare'`, plus a `(organization_id, domain)` unique. Different orgs may now each hold a competing **unverified** pending row — a squat no longer denies anyone. (Safe backfill: the column was globally unique before, so both new indexes build without collision.)
- **`getDomainByName`** now returns the **exclusive** row (verified/cloudflare) or `null`. The serve/resolve/ingress paths already gate on `verified && status==='active'`, so an unverified squat can never resolve as the owner — behavior there is unchanged. New **`getOwnDomainRow(org, domain)`** for the app-management routes (attach/verify/status/dns/rename), which act on the caller's own possibly-unverified row (which `getDomainByName` now intentionally hides).
- **Attach + buy** 409 **only** when another org holds the exclusive slot; `upsertCloudflareRegisteredDomain` upgrades the caller's own pending row instead of colliding on `(org,domain)`.
- **Reclaim:** new `releaseDomain` (a real delete — none existed) + `releaseStaleUnverifiedExternals(ttlMs)` for an expiry cron.

## Evidence

- `managed-domains-squat.test.ts` — **6/6 real-PGlite** against migration 0163's actual indexes: two orgs hold competing pending rows; `getDomainByName` is `null` until verified; verifying promotes one to exclusive **and blocks the other org's verify** (partial-unique race — the point where ownership is actually proven); cloudflare exclusivity; `(org,domain)` unique; stale-external reclaim spares verified + fresh rows.
- No regression: `domains-buy-credit-debit` **10/10**, `hosted-frontend-serve.integration` **9/9**.

## Reviewer note

This changes `managed_domains` uniqueness on a live table and the domain-attach semantics (competing pending rows), and touches the reader on the public serve path (13 call sites audited — serve/resolve/ingress use the exclusive reader, app-management routes use the org-scoped reader). Flagging for a maintainer eye before it lands. Follow-up (noted, not in this PR): wire `releaseStaleUnverifiedExternals` into a periodic cron with a 24–72h TTL, and add the DNS-TXT proof gate at `/verify` before promotion (the partial-unique already fails the loser closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)