### PR TITLE
fix(personal-assistant): connector error stringify crashes on poisoned toString (found by #11003 fuzz)

### DIFF
--- a/packages/core/src/utils/format-error.test.ts
+++ b/packages/core/src/utils/format-error.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { formatError } from "./format-error.ts";
+
+/**
+ * `formatError` is the canonical error-message extractor and runs on failure
+ * paths across the runtime, so it must never itself throw and mask the original
+ * error. `String(value)` raises `TypeError: Cannot convert object to primitive
+ * value` for null-prototype objects and objects with a poisoned
+ * `toString` / `Symbol.toPrimitive`; a pathological `Error` subclass can expose
+ * a throwing `message` getter. Every one of these must resolve to a string.
+ */
+describe("formatError", () => {
+	it("returns an Error's message", () => {
+		expect(formatError(new Error("socket hang up"))).toBe("socket hang up");
+	});
+
+	it("returns the message of an Error subclass", () => {
+		class HttpError extends Error {}
+		expect(formatError(new HttpError("bad gateway"))).toBe("bad gateway");
+	});
+
+	it("stringifies primitives", () => {
+		expect(formatError("kaboom")).toBe("kaboom");
+		expect(formatError(42)).toBe("42");
+		expect(formatError(10n)).toBe("10");
+		expect(formatError(Symbol("boom"))).toBe("Symbol(boom)");
+		expect(formatError(null)).toBe("null");
+		expect(formatError(undefined)).toBe("undefined");
+	});
+
+	it("stringifies a plain object via its toString", () => {
+		expect(formatError({})).toBe("[object Object]");
+	});
+
+	it("does not throw on a null-prototype object", () => {
+		let out = "";
+		expect(() => {
+			out = formatError(Object.create(null));
+		}).not.toThrow();
+		expect(out).toBe("[object Object]");
+	});
+
+	it("does not throw when toString throws", () => {
+		const poisoned = {
+			toString() {
+				throw new Error("poisoned toString");
+			},
+		};
+		let out = "";
+		expect(() => {
+			out = formatError(poisoned);
+		}).not.toThrow();
+		expect(out).toBe("[object Object]");
+	});
+
+	it("does not throw when Symbol.toPrimitive throws", () => {
+		const poisoned = {
+			[Symbol.toPrimitive]() {
+				throw new Error("poisoned Symbol.toPrimitive");
+			},
+		};
+		let out = "";
+		expect(() => {
+			out = formatError(poisoned);
+		}).not.toThrow();
+		expect(out).toBe("[object Object]");
+	});
+
+	it("does not throw when an Error's message getter throws", () => {
+		class WeirdError extends Error {
+			override get message(): string {
+				throw new Error("poisoned message getter");
+			}
+		}
+		let out = "";
+		expect(() => {
+			out = formatError(new WeirdError());
+		}).not.toThrow();
+		expect(out).toBe("[object Error]");
+	});
+
+	it("does not throw on a circular object", () => {
+		const circular: Record<string, unknown> = {};
+		circular.self = circular;
+		let out = "";
+		expect(() => {
+			out = formatError(circular);
+		}).not.toThrow();
+		expect(out).toBe("[object Object]");
+	});
+});

--- a/packages/core/src/utils/format-error.ts
+++ b/packages/core/src/utils/format-error.ts
@@ -1,3 +1,25 @@
+/**
+ * Canonical error-message extractor. Returns an `Error`'s `.message` and
+ * `String(value)` for everything else.
+ *
+ * Both `error.message` and `String(error)` can throw: `String()` raises
+ * `TypeError: Cannot convert object to primitive value` on a null-prototype
+ * object or one whose `toString` / `Symbol.toPrimitive` is poisoned, and a
+ * pathological `Error` subclass can expose a throwing `message` getter. This
+ * runs on error paths — it must never itself throw and mask the original
+ * failure — so both extraction attempts are guarded and fall back to a
+ * `toString`-free description of the value's type tag.
+ */
 export function formatError(error: unknown): string {
-	return error instanceof Error ? error.message : String(error);
+	try {
+		return error instanceof Error ? error.message : String(error);
+	} catch {
+		try {
+			// Object.prototype.toString ignores user-defined `toString` /
+			// `Symbol.toPrimitive`, so it cannot be poisoned: e.g. "[object Object]".
+			return Object.prototype.toString.call(error);
+		} catch {
+			return "[unstringifiable error]";
+		}
+	}
 }

--- a/plugins/plugin-personal-assistant/src/lifeops/connectors/_helpers.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/connectors/_helpers.test.ts
@@ -16,6 +16,7 @@ import {
   legacyStatusToConnectorStatus,
   rejectInvalidPayload,
 } from "./_helpers.js";
+import type { DispatchResult } from "./contract.js";
 
 describe("errorToDispatchResult", () => {
   it("maps 401/410 to auth_expired (user-actionable)", () => {
@@ -114,6 +115,78 @@ describe("errorToDispatchResult", () => {
       message: "kaboom",
     });
   });
+
+  // Regression for the crash found by the #11003 payload fuzzer: a connector
+  // that rejects with a value whose primitive conversion throws would take down
+  // the whole dispatch path (`TypeError: Cannot convert object to primitive
+  // value`) instead of producing a failure result. The helper must always
+  // return a `DispatchResult`, never rethrow.
+  describe("adversarial: unstringifiable rejection values (crash-safety)", () => {
+    it("survives a null-prototype object (no toString on the chain)", () => {
+      const poisoned = Object.create(null) as unknown;
+      let result: DispatchResult | undefined;
+      expect(() => {
+        result = errorToDispatchResult(poisoned);
+      }).not.toThrow();
+      expect(result).toEqual({
+        ok: false,
+        reason: "transport_error",
+        userActionable: false,
+        message: "[object Object]",
+      });
+    });
+
+    it("survives an object whose toString throws", () => {
+      const poisoned = {
+        toString() {
+          throw new Error("poisoned toString");
+        },
+      };
+      let result: DispatchResult | undefined;
+      expect(() => {
+        result = errorToDispatchResult(poisoned);
+      }).not.toThrow();
+      expect(result).toEqual({
+        ok: false,
+        reason: "transport_error",
+        userActionable: false,
+        message: "[object Object]",
+      });
+    });
+
+    it("survives an object whose Symbol.toPrimitive throws", () => {
+      const poisoned = {
+        [Symbol.toPrimitive]() {
+          throw new Error("poisoned Symbol.toPrimitive");
+        },
+      };
+      let result: DispatchResult | undefined;
+      expect(() => {
+        result = errorToDispatchResult(poisoned);
+      }).not.toThrow();
+      expect(result).toEqual({
+        ok: false,
+        reason: "transport_error",
+        userActionable: false,
+        message: "[object Object]",
+      });
+    });
+
+    it("stringifies a Symbol without throwing", () => {
+      const result = errorToDispatchResult(Symbol("boom"));
+      expect(result).toEqual({
+        ok: false,
+        reason: "transport_error",
+        userActionable: false,
+        message: "Symbol(boom)",
+      });
+    });
+
+    it("still prefers a real Error's message over any fallback", () => {
+      const result = errorToDispatchResult(new Error("socket hang up"));
+      expect(result.message).toBe("socket hang up");
+    });
+  });
 });
 
 describe("legacyStatusToConnectorStatus", () => {
@@ -128,7 +201,12 @@ describe("legacyStatusToConnectorStatus", () => {
     const status = legacyStatusToConnectorStatus({
       connected: true,
       degradations: [
-        { axis: "media", code: "no_media", message: "media unavailable", retryable: true },
+        {
+          axis: "media",
+          code: "no_media",
+          message: "media unavailable",
+          retryable: true,
+        },
         { axis: "reach", code: "slow", message: "slow reach", retryable: true },
       ],
     });

--- a/plugins/plugin-personal-assistant/src/lifeops/connectors/_helpers.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/connectors/_helpers.ts
@@ -7,7 +7,7 @@
  *   - {@link ConnectorStatus} — uniform `ok | degraded | disconnected` triple.
  *   - {@link DispatchResult}  — typed success / failure for `send`.
  */
-import { LifeOpsServiceError } from "@elizaos/shared";
+import { formatError, LifeOpsServiceError } from "@elizaos/shared";
 import type { ConnectorStatus, DispatchResult } from "./contract.js";
 
 export type LegacyConnectorStatus = {
@@ -121,12 +121,11 @@ export function errorToDispatchResult(error: unknown): DispatchResult {
         };
     }
   }
-  const message = error instanceof Error ? error.message : String(error);
   return {
     ok: false,
     reason: "transport_error",
     userActionable: false,
-    message,
+    message: formatError(error),
   };
 }
 

--- a/plugins/plugin-personal-assistant/src/lifeops/connectors/discord.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/connectors/discord.ts
@@ -3,6 +3,7 @@
  * (`service-mixin-discord.ts`).
  */
 import type { IAgentRuntime } from "@elizaos/core";
+import { formatError } from "@elizaos/core";
 import { LifeOpsService } from "../service.js";
 import {
   errorToDispatchResult,
@@ -38,7 +39,7 @@ export function createDiscordConnectorContribution(
       } catch (error) {
         return {
           state: "disconnected",
-          message: error instanceof Error ? error.message : String(error),
+          message: formatError(error),
           observedAt: new Date().toISOString(),
         };
       }

--- a/plugins/plugin-personal-assistant/src/lifeops/connectors/duffel.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/connectors/duffel.ts
@@ -6,6 +6,7 @@
  * `send`. Read verbs return flight offers + order state.
  */
 import type { IAgentRuntime } from "@elizaos/core";
+import { formatError } from "@elizaos/core";
 import {
   DuffelConfigError,
   readDuffelConfigFromEnv,
@@ -57,7 +58,7 @@ export function createDuffelConnectorContribution(
       } catch (error) {
         return {
           state: "disconnected",
-          message: error instanceof Error ? error.message : String(error),
+          message: formatError(error),
           observedAt,
         };
       }

--- a/plugins/plugin-personal-assistant/src/lifeops/connectors/google.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/connectors/google.ts
@@ -10,6 +10,7 @@
  * `LIFEOPS_GOOGLE_CAPABILITIES` from `@elizaos/shared`.
  */
 import type { IAgentRuntime } from "@elizaos/core";
+import { formatError } from "@elizaos/core";
 import { INTERNAL_URL } from "../access.js";
 import { LifeOpsService } from "../service.js";
 import {
@@ -78,7 +79,7 @@ export function createGoogleConnectorContribution(
       } catch (error) {
         return {
           state: "disconnected",
-          message: error instanceof Error ? error.message : String(error),
+          message: formatError(error),
           observedAt: new Date().toISOString(),
         };
       }

--- a/plugins/plugin-personal-assistant/src/lifeops/connectors/imessage.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/connectors/imessage.ts
@@ -6,6 +6,7 @@
  * `plugin-bluebubbles` on macOS.
  */
 import type { IAgentRuntime } from "@elizaos/core";
+import { formatError } from "@elizaos/core";
 import { LifeOpsService } from "../service.js";
 import {
   errorToDispatchResult,
@@ -44,7 +45,7 @@ export function createIMessageConnectorContribution(
       } catch (error) {
         return {
           state: "disconnected",
-          message: error instanceof Error ? error.message : String(error),
+          message: formatError(error),
           observedAt: new Date().toISOString(),
         };
       }

--- a/plugins/plugin-personal-assistant/src/lifeops/connectors/signal.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/connectors/signal.ts
@@ -3,6 +3,7 @@
  * (`service-mixin-signal.ts`).
  */
 import type { IAgentRuntime } from "@elizaos/core";
+import { formatError } from "@elizaos/core";
 import { LifeOpsService } from "../service.js";
 import {
   errorToDispatchResult,
@@ -38,7 +39,7 @@ export function createSignalConnectorContribution(
       } catch (error) {
         return {
           state: "disconnected",
-          message: error instanceof Error ? error.message : String(error),
+          message: formatError(error),
           observedAt: new Date().toISOString(),
         };
       }

--- a/plugins/plugin-personal-assistant/src/lifeops/connectors/telegram.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/connectors/telegram.ts
@@ -7,6 +7,7 @@
  * no-op because account credentials are owned by the Telegram plugin.
  */
 import type { IAgentRuntime } from "@elizaos/core";
+import { formatError } from "@elizaos/core";
 import { LifeOpsService } from "../service.js";
 import {
   errorToDispatchResult,
@@ -42,7 +43,7 @@ export function createTelegramConnectorContribution(
       } catch (error) {
         return {
           state: "disconnected",
-          message: error instanceof Error ? error.message : String(error),
+          message: formatError(error),
           observedAt: new Date().toISOString(),
         };
       }

--- a/plugins/plugin-personal-assistant/src/lifeops/connectors/whatsapp.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/connectors/whatsapp.ts
@@ -5,6 +5,7 @@
  * transport is owned by `@elizaos/plugin-whatsapp`.
  */
 import type { IAgentRuntime } from "@elizaos/core";
+import { formatError } from "@elizaos/core";
 import { LifeOpsService } from "../service.js";
 import {
   errorToDispatchResult,
@@ -43,7 +44,7 @@ export function createWhatsAppConnectorContribution(
       } catch (error) {
         return {
           state: "disconnected",
-          message: error instanceof Error ? error.message : String(error),
+          message: formatError(error),
           observedAt: new Date().toISOString(),
         };
       }

--- a/plugins/plugin-personal-assistant/src/lifeops/connectors/x.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/connectors/x.ts
@@ -3,6 +3,7 @@
  * (`service-mixin-x.ts`).
  */
 import type { IAgentRuntime } from "@elizaos/core";
+import { formatError } from "@elizaos/core";
 import { LifeOpsService } from "../service.js";
 import {
   errorToDispatchResult,
@@ -38,7 +39,7 @@ export function createXConnectorContribution(
       } catch (error) {
         return {
           state: "disconnected",
-          message: error instanceof Error ? error.message : String(error),
+          message: formatError(error),
           observedAt: new Date().toISOString(),
         };
       }


### PR DESCRIPTION
## The crash

A LifeOps connector that rejects with a value whose primitive conversion throws takes down the **entire dispatch path** instead of producing a failure `DispatchResult`. The connector error translator did:

```ts
const message = error instanceof Error ? error.message : String(error);
```

`String(error)` raises `TypeError: Cannot convert object to primitive value` when `error` is:
- a **null-prototype object** (`Object.create(null)` — no `toString` on the chain), or
- an object whose **`toString`** or **`Symbol.toPrimitive`** is poisoned/throws.

So a misbehaving upstream client (or an adversarial payload) turns a routine "send failed" into an uncaught `TypeError` that escapes `errorToDispatchResult` and crashes the runner. #11003's payload fuzzer caught this at `plugins/plugin-personal-assistant/src/lifeops/connectors/_helpers.ts`.

## The trigger

`errorToDispatchResult(Object.create(null))` — or any reject value with a throwing `toString`/`Symbol.toPrimitive` — threw instead of returning a `transport_error` result. The same inline pattern was duplicated across **nine** connector files (`_helpers.ts` plus the status catches in `duffel`, `x`, `imessage`, `discord`, `google`, `telegram`, `whatsapp`, `signal`), so every connector had the same latent crash.

## The fix

The root cause is the **canonical** `formatError` in `@elizaos/core` (re-exported by `@elizaos/shared`, used across the runtime, e.g. `core/roles.ts`) — it inlines the exact same unsafe `String(error)`. Rather than add a duplicate safe-stringify helper, harden the one canonical utility so it can never rethrow on an error path:

```ts
export function formatError(error: unknown): string {
  try {
    return error instanceof Error ? error.message : String(error);
  } catch {
    try {
      return Object.prototype.toString.call(error); // poison-proof, e.g. "[object Object]"
    } catch {
      return "[unstringifiable error]";
    }
  }
}
```

- Behavior is **unchanged** for every value that doesn't throw (strings, numbers, bigints, symbols, plain/circular objects → identical output).
- Also guards the rare pathological `Error` subclass with a throwing `message` getter.
- The nine duplicated inline patterns in the PA connectors now route through the now-safe `formatError` (imported from `@elizaos/core` in the connectors, `@elizaos/shared` in `_helpers.ts`), deleting the copy-pasted unsafe code.

## The tests

- **`packages/core/src/utils/format-error.test.ts`** (new, 9 cases): Error + subclass yield `.message`; primitives/plain/circular unchanged; **no throw** on null-prototype, throwing `toString`, throwing `Symbol.toPrimitive`, and a throwing `Error.message` getter.
- **`plugins/plugin-personal-assistant/src/lifeops/connectors/_helpers.test.ts`** (+5 cases): `errorToDispatchResult` no longer throws on a null-prototype object, a throwing-`toString` object, a throwing-`Symbol.toPrimitive` object, or a `Symbol`, always returning a `transport_error` `DispatchResult`; a real `Error` still yields its `.message`.

Verification:
- `bunx vitest run src/lifeops/connectors/_helpers.test.ts` → **24 passed**
- `packages/core` `bunx vitest run src/utils/format-error.test.ts` → **9 passed**
- Broader connector suite (`connectors/`, `contracts`, connector normalize) → **65 passed**
- `biome check` clean on all changed files; scoped source typecheck clean for the changed files.

## Unblocks

This is the standalone root-cause fix for the crash surfaced by **#11003**'s connector payload fuzz (`test/connector-payload-fuzz.test.ts`), which does not yet exist on `develop`. #11003 / **#10993** can rebase over this — the fuzz test will pass against this fix. Refs **#10721**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)