### PR TITLE
fix(cloud): floor app-credit inference holds at MIN_RESERVATION so a $0 estimate can't 500

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/app-credit-hold-concurrency.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-credit-hold-concurrency.test.ts
@@ -25,6 +25,10 @@
  *      `reconcile_charge` leg vs the `deduct` leg) and a settlement retry does
  *      not double-credit (same leg) — the property that subsumes #10873's
  *      per-request earnings dedupe.
+ *   4. A $0 estimate (free/unpriced model) opens a MIN_RESERVATION floor hold
+ *      instead of throwing `reserveAndDeductCredits`' "Amount must be positive"
+ *      (which the routes surfaced as a 500), and reconcile trues the floor up
+ *      to the actual cost in both directions.
  *
  * Self-skips LOUDLY if PGlite/pushSchema is unavailable (never silently passes).
  */
@@ -87,6 +91,7 @@ let dbWrite: typeof import("../../../db/client").dbWrite;
 let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
 let appCreditsService: typeof import("../app-credits").appCreditsService;
 let InsufficientCreditsError: typeof import("../credits").InsufficientCreditsError;
+let MIN_RESERVATION: typeof import("../credits").MIN_RESERVATION;
 
 let seq = 0;
 function uniq(p: string): string {
@@ -180,7 +185,7 @@ beforeAll(async () => {
   try {
     ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
     ({ appCreditsService } = await import("../app-credits"));
-    ({ InsufficientCreditsError } = await import("../credits"));
+    ({ InsufficientCreditsError, MIN_RESERVATION } = await import("../credits"));
 
     const schema = {
       organizations,
@@ -351,6 +356,63 @@ describe("reserveInferenceCredits — real row-locked upfront hold (#10857)", ()
       await reservation.reconcile(2);
       expect(await creatorRedeemableBalance(creatorId)).toBeCloseTo(0.2, 6);
       expect(await creatorEarningLedgerCount(creatorId)).toBe(2);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a $0 estimate opens a MIN_RESERVATION floor hold instead of throwing 'Amount must be positive' (residual of #10892)",
+    async () => {
+      if (!pgliteReady) return;
+
+      const payerOrgId = await seedOrg("1.000000");
+      const consumerId = await seedUser(payerOrgId);
+      const creatorOrgId = await seedOrg("0.000000");
+      const creatorId = await seedUser(creatorOrgId);
+      // 0% markup: the hold and every reconcile adjustment move exactly the
+      // base-cost figures asserted below.
+      const app = await seedApp({
+        organizationId: creatorOrgId,
+        createdByUserId: creatorId,
+        inferenceMarkupPercentage: 0,
+      });
+      await dbWrite.insert(appUsers).values({ app_id: app.id, user_id: consumerId });
+
+      // calculateCost returns $0 for free/unpriced models; before the floor,
+      // that reached reserveAndDeductCredits' amount<=0 guard as a PLAIN Error
+      // (not InsufficientCreditsError), which /v1/chat/completions and
+      // /v1/messages rethrow as a 500 on every monetized-app request.
+      const reservation = await appCreditsService.reserveInferenceCredits({
+        appId: app.id,
+        userId: consumerId,
+        estimatedBaseCost: 0,
+        description: "zero-estimate hold",
+        idempotencyKey: "req-zero-1",
+        metadata: { model: "free-model" },
+        app,
+      });
+      expect(reservation.reservedAmount).toBeCloseTo(MIN_RESERVATION, 9);
+      expect(await orgBalance(payerOrgId)).toBeCloseTo(1 - MIN_RESERVATION, 9);
+
+      // Actual $0 → the floor refunds in full; a free call costs nothing.
+      const settlement = await reservation.reconcile(0);
+      expect(settlement?.adjustmentType).toBe("refund");
+      expect(await orgBalance(payerOrgId)).toBeCloseTo(1.0, 9);
+
+      // A $0-estimate call whose ACTUAL cost is real still charges through the
+      // overage leg — the floor never under-collects.
+      const second = await appCreditsService.reserveInferenceCredits({
+        appId: app.id,
+        userId: consumerId,
+        estimatedBaseCost: 0,
+        description: "zero-estimate hold with real cost",
+        idempotencyKey: "req-zero-2",
+        metadata: { model: "free-model" },
+        app,
+      });
+      const overage = await second.reconcile(0.05);
+      expect(overage?.adjustmentType).toBe("overage");
+      expect(await orgBalance(payerOrgId)).toBeCloseTo(0.95, 6);
     },
     PGLITE_TIMEOUT,
   );

--- a/packages/cloud/shared/src/lib/services/__tests__/app-credits-ledger.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-credits-ledger.test.ts
@@ -71,6 +71,9 @@ class MockInsufficientCreditsError extends Error {
 
 mock.module("../credits", () => ({
   InsufficientCreditsError: MockInsufficientCreditsError,
+  // Must mirror the real export — app-credits.ts imports it for the $0-estimate
+  // floor; a missing export would break the module link under this mock.
+  MIN_RESERVATION: 0.000001,
   creditsService: {
     addCredits,
     reserveAndDeductCredits,

--- a/packages/cloud/shared/src/lib/services/app-credits.ts
+++ b/packages/cloud/shared/src/lib/services/app-credits.ts
@@ -23,6 +23,7 @@ import {
   type CreditReservation,
   creditsService,
   InsufficientCreditsError,
+  MIN_RESERVATION,
 } from "./credits";
 import { redeemableEarningsService } from "./redeemable-earnings";
 
@@ -414,10 +415,18 @@ export class AppCreditsService {
   ): Promise<CreditReservation> {
     const { appId, userId, estimatedBaseCost, description, metadata, idempotencyKey, app } = params;
 
+    // A $0 estimate (free/unpriced model) must still open a valid hold:
+    // reserveAndDeductCredits throws on amount <= 0, which surfaced as a 500 on
+    // /v1/chat/completions and /v1/messages for monetized apps. Floor the hold
+    // at MIN_RESERVATION — the same floor the org-credits reservation path
+    // applies — and reconcile trues it up to actual cost (refunding the floor
+    // when actual stays $0).
+    const flooredEstimate = Math.max(estimatedBaseCost, MIN_RESERVATION);
+
     const deduction = await this.deductCredits({
       appId,
       userId,
-      baseCost: estimatedBaseCost,
+      baseCost: flooredEstimate,
       description,
       metadata: withChargeIdempotencyKey(metadata, idempotencyKey),
       app,
@@ -440,7 +449,9 @@ export class AppCreditsService {
         const reconciliation = await this.reconcileCredits({
           appId,
           userId,
-          estimatedBaseCost,
+          // Reconcile against the FLOORED estimate — that is what was actually
+          // debited; using the raw $0 estimate would skip refunding the floor.
+          estimatedBaseCost: flooredEstimate,
           actualBaseCost,
           description,
           metadata: withChargeIdempotencyKey(metadata, idempotencyKey),


### PR DESCRIPTION
## The bug (residual of #10892)

`calculateCost` returns **$0** for free/unpriced models. Both monetized-app LLM routes feed that estimate straight into the upfront hold:

- `packages/cloud/api/v1/chat/completions/route.ts` → `reserveInferenceCredits({ estimatedBaseCost: totalCost, ... })`
- `packages/cloud/api/v1/messages/route.ts` → same

`reserveInferenceCredits` → `deductCredits` → `creditsService.reserveAndDeductCredits`, whose guard `if (amount <= 0) throw new Error("Amount must be positive")` throws a **plain Error** — not `InsufficientCreditsError` — so both routes' catch blocks rethrow it as a **500 on every monetized-app request** against a $0-priced model.

The org-credits reservation path already solved this exact problem: `credits.ts` floors with `Math.max(estimatedCost * COST_BUFFER, MIN_RESERVATION)`. The app-credits path (added in #10892) never got the floor.

## The fix

`reserveInferenceCredits` now floors the hold at `MIN_RESERVATION` ($0.000001) and threads the **floored** value into the reconcile closure — that is what was actually debited, so:

- actual $0 → the floor refunds in full (a free call costs the user nothing)
- actual > $0 → the overage leg charges the real cost as usual
- estimate > 0 → `Math.max` is a no-op; behavior byte-identical to today

No route changes needed; the settle paths are untouched.

## Evidence (real PGlite, nothing mocked on the money path)

New test in `app-credit-hold-concurrency.test.ts` (the #10857/#10892 real-DB suite):

1. `estimatedBaseCost: 0` → reservation **succeeds** with `reservedAmount ≈ MIN_RESERVATION`; org balance debited exactly the floor.
2. `reconcile(0)` → `adjustmentType: "refund"`, balance back to the **exact** starting value.
3. A second $0-estimate hold settled at `reconcile(0.05)` → `adjustmentType: "overage"`, balance down exactly $0.05 — the floor never under-collects.

**Regression validity proven:** with the service change reverted (`git stash` of `app-credits.ts` only), the new test fails with exactly `error: Amount must be positive` from `credits.ts`; with the fix, 3/3 pass (51 expects).

- `app-credit-hold-concurrency.test.ts`: 3/3 pass (the 2 pre-existing concurrency/earnings-dedupe tests untouched and green)
- `app-credits-ledger.test.ts`: 26/26 alone (its `../credits` module mock gains the `MIN_RESERVATION` export the service now imports)
- `credits-deduct-guard.test.ts`: 10/10 alone
- `messages-iac-fast-path` + `chat-completions-optimistic-billing` (the routes' suites): green
- typecheck (filtered to touched files) + biome: clean

Note: running `app-credits-ledger` and `credits-deduct-guard` in ONE `bun test` invocation fails on develop too (bun `mock.module` leaks across files in-process; `creditsService.reserve` is undefined) — pre-existing, unrelated, identical before/after this change.

Frontend evidence: N/A — backend money-path availability fix, no UI surface.
Trajectories: N/A — no agent/prompt/model behavior change; deterministic billing arithmetic.

**Money path — do not self-merge** (maintainer review + merge, per lane policy).