### PR TITLE
fix(agent): fingerprint + warn when a config/vault cloud key clobbers the env key (#11038)

### DIFF
--- a/packages/agent/src/runtime/eliza-cloud-config.test.ts
+++ b/packages/agent/src/runtime/eliza-cloud-config.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ElizaConfig } from "../config/config.ts";
 import {
   applyCloudConfigToEnv,
+  cloudApiKeyFingerprint,
   ensureProvisionedCloudContainerConfig,
   shouldStartElizaCloudThinClient,
 } from "./eliza.ts";
@@ -462,5 +463,71 @@ describe("provisioned cloud container topology (#9887)", () => {
 
     process.env.ELIZA_CLOUD_PROVISIONED = "1";
     expect(shouldStartElizaCloudThinClient(config)).toBe(false);
+  });
+});
+
+describe("stale vault/config key clobber guard (#11038)", () => {
+  const cloudConfig = (apiKey: string): ElizaConfig =>
+    ({
+      cloud: {
+        enabled: true,
+        apiKey,
+        connection: { provider: "eliza-cloud" },
+      },
+    }) as unknown as ElizaConfig;
+
+  it("warns with fingerprints when the config key differs from a non-empty env key (config still wins)", () => {
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    process.env.ELIZAOS_CLOUD_API_KEY =
+      "eliza_real_key_0123456789012345678901234567890123456789012345678901234567890123";
+    const placeholder = "eliza_test_placeholder_0123456";
+
+    applyCloudConfigToEnv(cloudConfig(placeholder));
+
+    // The config/vault value wins (documented behavior)…
+    expect(process.env.ELIZAOS_CLOUD_API_KEY).toBe(placeholder);
+    // …but the override is loudly fingerprinted so 401s are diagnosable.
+    const msg = warn.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(msg).toContain("differs from process.env.ELIZAOS_CLOUD_API_KEY");
+    // Fingerprints of both keys (first-6 + computed length), never the secret.
+    expect(msg).toContain(`eliza_…(len ${placeholder.length})`);
+    expect(msg).toContain("(len 79)");
+    expect(msg).toContain("#11038");
+    // Never the full secret.
+    expect(msg).not.toContain("0123456789012345678901234567890123456789");
+    warn.mockRestore();
+  });
+
+  it("does not warn when config and env agree", () => {
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    process.env.ELIZAOS_CLOUD_API_KEY = "eliza_same_key_012345678901234567890123456789";
+    applyCloudConfigToEnv(
+      cloudConfig("eliza_same_key_012345678901234567890123456789"),
+    );
+    expect(
+      warn.mock.calls.some((c) => String(c[0]).includes("differs from")),
+    ).toBe(false);
+    warn.mockRestore();
+  });
+
+  it("does not warn when there is no env key to clobber", () => {
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+    delete process.env.ELIZAOS_CLOUD_API_KEY;
+    applyCloudConfigToEnv(cloudConfig("eliza_fresh_key_01234567890123456789"));
+    expect(process.env.ELIZAOS_CLOUD_API_KEY).toBe(
+      "eliza_fresh_key_01234567890123456789",
+    );
+    expect(
+      warn.mock.calls.some((c) => String(c[0]).includes("differs from")),
+    ).toBe(false);
+    warn.mockRestore();
+  });
+
+  it("fingerprints keys without leaking them", () => {
+    expect(cloudApiKeyFingerprint(undefined)).toBe("(none)");
+    expect(cloudApiKeyFingerprint("  ")).toBe("(none)");
+    expect(cloudApiKeyFingerprint("eliza_abcdef123456")).toBe(
+      "eliza_…(len 18)",
+    );
   });
 });

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -2112,6 +2112,17 @@ export async function autoFetchCloudGithubToken(
 }
 
 /**
+ * Non-secret fingerprint of a cloud API key for boot logs and mismatch
+ * warnings (#11038): first 6 chars + length, so `hasApiKey=true` can never
+ * mean "yes, a 31-char placeholder" without the log showing it.
+ */
+export function cloudApiKeyFingerprint(value: string | undefined): string {
+  const v = value?.trim();
+  if (!v) return "(none)";
+  return `${v.slice(0, 6)}…(len ${v.length})`;
+}
+
+/**
  * Propagate cloud config from Eliza config into process.env so the
  * ElizaCloud plugin can discover settings at startup.
  */
@@ -2186,7 +2197,7 @@ export function applyCloudConfigToEnv(config: ElizaConfig): void {
 
   if (shouldLoadCloudPlugin) {
     logger.info(
-      `[eliza] Cloud config: inference=${topology.services.inference}, runtime=${topology.runtime}, hasApiKey=${Boolean(cloud?.apiKey || process.env.ELIZAOS_CLOUD_API_KEY)}, baseUrl=${cloud?.baseUrl ?? "(default)"}, isCloudContainer=${isCloudContainer}`,
+      `[eliza] Cloud config: inference=${topology.services.inference}, runtime=${topology.runtime}, hasApiKey=${Boolean(cloud?.apiKey || process.env.ELIZAOS_CLOUD_API_KEY)}, apiKey=${cloudApiKeyFingerprint(cloud?.apiKey ?? process.env.ELIZAOS_CLOUD_API_KEY)}, baseUrl=${cloud?.baseUrl ?? "(default)"}, isCloudContainer=${isCloudContainer}`,
     );
     // Only propagate the API key from config when it is a real credential —
     // never set the literal "[REDACTED]" placeholder (which can leak into the
@@ -2202,6 +2213,20 @@ export function applyCloudConfigToEnv(config: ElizaConfig): void {
     const isRealApiKey =
       cloud?.apiKey && cloud.apiKey.trim().toUpperCase() !== "[REDACTED]";
     if (isRealApiKey) {
+      // #11038: a stale/placeholder vault entry resolved into config here
+      // silently CLOBBERS a valid key already in the service env, and the
+      // resulting 401s are indistinguishable from a server-side auth outage
+      // (env inspection lies — /proc shows the spawn-time value). The config
+      // key still wins (by design), but a mismatch against a non-empty env
+      // value is loudly fingerprinted so the operator can see which credential
+      // is actually on the wire.
+      const configKey = (cloud?.apiKey ?? "").trim();
+      const envKey = process.env.ELIZAOS_CLOUD_API_KEY?.trim();
+      if (envKey && configKey && envKey !== configKey) {
+        logger.warn(
+          `[eliza] Cloud API key from config (${cloudApiKeyFingerprint(configKey)}) differs from process.env.ELIZAOS_CLOUD_API_KEY (${cloudApiKeyFingerprint(envKey)}) — the config/vault value wins and will OVERRIDE the env key. If cloud calls start returning 401 "Invalid or expired API key", the vault likely holds a stale/placeholder entry (#11038).`,
+        );
+      }
       process.env.ELIZAOS_CLOUD_API_KEY = cloud.apiKey;
     } else if (
       !isCloudContainer &&


### PR DESCRIPTION
Implements #11038's guardrails #1 (the fully-general env-mismatch variant) and #3 (boot-log fingerprint). A stale `vault://`-resolved placeholder in `config.cloud.apiKey` silently overrides a valid env key and 401s like a server outage; now the override is loudly fingerprinted (`eliza_…(len 31)` vs `(len 79)`) at the exact clobber site in `applyCloudConfigToEnv`, and the boot `Cloud config:` line carries `apiKey=<fp>` so `hasApiKey=true` can't hide a placeholder. Override behavior unchanged (config wins by design). Guardrail #2 (never seed placeholder secrets) is a data/discipline item — the seeding path isn't in this repo's code (couldn't locate a writer of `eliza_test..._key`).

Tests: real `applyCloudConfigToEnv` + logger spy — mismatch warns with both fingerprints, never the full secret, config still wins; agreeing keys and no-env-key stay silent; fingerprint unit cases. 19/19; fail-without-fix proven (revert → 2 red); `packages/agent` typecheck exit 0.

**Android/visual: N/A** — server boot-log guardrail. **Real-LLM: N/A.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)