### PR TITLE
fix: canonicalize remaining Cloud defaults

### DIFF
--- a/packages/cloud/sdk/AGENTS.md
+++ b/packages/cloud/sdk/AGENTS.md
@@ -121,7 +121,7 @@ The SDK reads no env vars at runtime — callers must supply credentials via `El
 | `ELIZA_CLOUD_SDK_LIVE` | `"1"` to run any live tests |
 | `ELIZAOS_CLOUD_API_KEY` / `ELIZA_CLOUD_API_KEY` | API key for authenticated checks |
 | `ELIZA_CLOUD_SESSION_TOKEN` | Bearer token for browser-session checks |
-| `ELIZA_CLOUD_BASE_URL` | Override base URL (default `https://www.elizacloud.ai`) |
+| `ELIZA_CLOUD_BASE_URL` | Override base URL (default `https://elizacloud.ai`) |
 | `ELIZA_CLOUD_API_BASE_URL` | Override API base URL (default `https://api.elizacloud.ai/api/v1`) |
 | `ELIZA_CLOUD_SDK_LIVE_GENERATION` | `"1"` to enable paid generation checks |
 | `ELIZA_CLOUD_SDK_LIVE_RELAY` | `"1"` to enable gateway relay checks |

--- a/packages/cloud/sdk/CLAUDE.md
+++ b/packages/cloud/sdk/CLAUDE.md
@@ -121,7 +121,7 @@ The SDK reads no env vars at runtime — callers must supply credentials via `El
 | `ELIZA_CLOUD_SDK_LIVE` | `"1"` to run any live tests |
 | `ELIZAOS_CLOUD_API_KEY` / `ELIZA_CLOUD_API_KEY` | API key for authenticated checks |
 | `ELIZA_CLOUD_SESSION_TOKEN` | Bearer token for browser-session checks |
-| `ELIZA_CLOUD_BASE_URL` | Override base URL (default `https://www.elizacloud.ai`) |
+| `ELIZA_CLOUD_BASE_URL` | Override base URL (default `https://elizacloud.ai`) |
 | `ELIZA_CLOUD_API_BASE_URL` | Override API base URL (default `https://api.elizacloud.ai/api/v1`) |
 | `ELIZA_CLOUD_SDK_LIVE_GENERATION` | `"1"` to enable paid generation checks |
 | `ELIZA_CLOUD_SDK_LIVE_RELAY` | `"1"` to enable gateway relay checks |

--- a/packages/cloud/sdk/README.md
+++ b/packages/cloud/sdk/README.md
@@ -74,7 +74,7 @@ window.location.assign(authorizeUrl);
 ```
 
 The generated URL is
-`https://www.elizacloud.ai/app-auth/authorize?app_id=...&redirect_uri=...&state=...`.
+`https://elizacloud.ai/app-auth/authorize?app_id=...&redirect_uri=...&state=...`.
 Use `/app-auth/authorize`; do not use `/authorize`.
 
 `waitForCliLogin(sessionId, { timeoutMs?, intervalMs?, signal? })` and the

--- a/packages/cloud/sdk/src/app-auth.test.ts
+++ b/packages/cloud/sdk/src/app-auth.test.ts
@@ -8,11 +8,11 @@ describe("buildAppAuthorizeUrl", () => {
         appId: "app_123",
         redirectUri: "https://example.app/auth/callback",
         state: "csrf-value",
-        baseUrl: "https://www.elizacloud.ai/",
+        baseUrl: "https://elizacloud.ai/",
       }),
     );
 
-    expect(url.origin).toBe("https://www.elizacloud.ai");
+    expect(url.origin).toBe("https://elizacloud.ai");
     expect(url.pathname).toBe(APP_AUTHORIZE_PATH);
     expect(url.searchParams.get("app_id")).toBe("app_123");
     expect(url.searchParams.get("redirect_uri")).toBe(

--- a/packages/cloud/sdk/src/client.test.ts
+++ b/packages/cloud/sdk/src/client.test.ts
@@ -367,7 +367,7 @@ describe("ElizaCloudClient CLI login", () => {
 
     expect(requestedUrl).toBe("https://api.elizacloud.ai/api/auth/cli-session");
     expect(result.browserUrl).toBe(
-      "https://www.elizacloud.ai/auth/cli-login?session=cli-test-session",
+      "https://elizacloud.ai/auth/cli-login?session=cli-test-session",
     );
   });
 });

--- a/packages/cloud/sdk/src/types.ts
+++ b/packages/cloud/sdk/src/types.ts
@@ -18,7 +18,7 @@ export type {
   UpdatedUserResponse,
 } from "./types.cloud-api.js";
 
-export const DEFAULT_ELIZA_CLOUD_BASE_URL = "https://www.elizacloud.ai";
+export const DEFAULT_ELIZA_CLOUD_BASE_URL = "https://elizacloud.ai";
 export const DEFAULT_ELIZA_CLOUD_API_ORIGIN = "https://api.elizacloud.ai";
 export const DEFAULT_ELIZA_CLOUD_API_BASE_URL = `${DEFAULT_ELIZA_CLOUD_API_ORIGIN}/api/v1`;
 

--- a/packages/registry/src/first-party/generated.json
+++ b/packages/registry/src/first-party/generated.json
@@ -2044,7 +2044,7 @@
           "type": "url",
           "required": false,
           "sensitive": false,
-          "default": "https://www.elizacloud.ai/api/v1",
+          "default": "https://elizacloud.ai/api/v1",
           "label": "Cloud Base Url",
           "help": "Base URL for all ElizaOS Cloud API requests.",
           "advanced": false
@@ -8254,7 +8254,7 @@
           "type": "url",
           "required": false,
           "sensitive": false,
-          "default": "https://www.elizacloud.ai/api/v1/twitter",
+          "default": "https://elizacloud.ai/api/v1/twitter",
           "label": "Broker URL",
           "help": "Eliza Cloud X (Twitter) broker base URL. Override only to point at a self-hosted broker; otherwise leave the default.",
           "advanced": true,

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -62,7 +62,7 @@ import type {
 // ---------------------------------------------------------------------------
 
 const AGENT_TRANSFER_MIN_PASSWORD_LENGTH = 4;
-const DEFAULT_DIRECT_CLOUD_BASE_URL = "https://www.elizacloud.ai";
+const DEFAULT_DIRECT_CLOUD_BASE_URL = "https://elizacloud.ai";
 const DEFAULT_DIRECT_CLOUD_API_BASE_URL = "https://api.elizacloud.ai";
 const STAGING_DIRECT_CLOUD_BASE_URL = "https://staging.elizacloud.ai";
 const STAGING_DIRECT_CLOUD_API_BASE_URL = "https://api-staging.elizacloud.ai";

--- a/packages/ui/src/api/ios-local-agent-kernel.ts
+++ b/packages/ui/src/api/ios-local-agent-kernel.ts
@@ -40,7 +40,7 @@ const IOS_LOCAL_AGENT_IPC_BASE = "eliza-local-agent://ipc";
 const DIRECT_CLOUD_API_BASE = "https://api.elizacloud.ai";
 const DEFAULT_SYSTEM_PROMPT =
   "You are Eliza, a private on-device assistant. Answer directly and concisely.";
-const DEFAULT_CLOUD_MARKET_PREVIEW_BASE_URL = "https://www.elizacloud.ai";
+const DEFAULT_CLOUD_MARKET_PREVIEW_BASE_URL = "https://elizacloud.ai";
 const CLOUD_WALLET_MARKET_OVERVIEW_PATH = "/market/preview/wallet-overview";
 const WALLET_MARKET_OVERVIEW_CACHE_TTL_MS = 120_000;
 const WALLET_MARKET_OVERVIEW_FETCH_TIMEOUT_MS = 8_000;

--- a/packages/ui/src/components/pages/cloud-dashboard-utils.ts
+++ b/packages/ui/src/components/pages/cloud-dashboard-utils.ts
@@ -7,8 +7,7 @@ import type {
 import { pathForTab } from "../../navigation";
 import { isCloudStatusReasonApiKeyOnly } from "../../utils/cloud-status";
 
-export const ELIZA_CLOUD_INSTANCES_URL =
-  "https://www.elizacloud.ai/dashboard/app";
+export const ELIZA_CLOUD_INSTANCES_URL = "https://elizacloud.ai/dashboard/app";
 /** Marketing / docs site — "Learn more" when not connected (in-app browser on desktop). */
 export const ELIZA_CLOUD_WEB_URL = "https://elizacloud.ai";
 export const BILLING_PRESET_AMOUNTS = [10, 25, 100];

--- a/packages/ui/src/components/settings/CloudAgentsSection.test.tsx
+++ b/packages/ui/src/components/settings/CloudAgentsSection.test.tsx
@@ -72,7 +72,7 @@ vi.mock("../../api/client-cloud", () => ({
 }));
 
 vi.mock("../../config/boot-config", () => ({
-  getBootConfig: () => ({ cloudApiBase: "https://www.elizacloud.ai" }),
+  getBootConfig: () => ({ cloudApiBase: "https://elizacloud.ai" }),
 }));
 
 vi.mock("../../config/branding", () => ({

--- a/packages/ui/src/components/settings/CloudAgentsSection.tsx
+++ b/packages/ui/src/components/settings/CloudAgentsSection.tsx
@@ -103,8 +103,7 @@ export function CloudAgentsSection() {
   const [wakingId, setWakingId] = useState<string | null>(null);
   const activeId = useMemo(() => activeCloudAgentId(), []);
 
-  const cloudApiBase =
-    getBootConfig().cloudApiBase || "https://www.elizacloud.ai";
+  const cloudApiBase = getBootConfig().cloudApiBase || "https://elizacloud.ai";
 
   const refresh = useCallback(async () => {
     setLoading(true);

--- a/packages/ui/src/first-run/first-run-finish.ts
+++ b/packages/ui/src/first-run/first-run-finish.ts
@@ -530,7 +530,7 @@ export async function bindCloudAgent(
       )
     : ["An autonomous AI agent."];
   const selectedAgent = await client.selectOrProvisionCloudAgent({
-    cloudApiBase: getBootConfig().cloudApiBase || "https://www.elizacloud.ai",
+    cloudApiBase: getBootConfig().cloudApiBase || "https://elizacloud.ai",
     authToken,
     name,
     bio,
@@ -580,7 +580,7 @@ export async function bindCloudAgent(
   ) {
     const sharedAgentId = selectedAgent.agentId;
     const cloudApiBase =
-      getBootConfig().cloudApiBase || "https://www.elizacloud.ai";
+      getBootConfig().cloudApiBase || "https://elizacloud.ai";
     const createDedicatedHandoffTarget = async (): Promise<string> => {
       const dedicated = await client.createCloudCompatAgent({
         agentName: name,

--- a/packages/ui/src/first-run/use-first-run-conductor.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.ts
@@ -135,8 +135,7 @@ function cloudOAuthSecretRequest(
       fields: [],
       submitLabel: "Connect Eliza Cloud",
       provider: "elizacloud",
-      authorizationUrl:
-        getBootConfig().cloudApiBase || "https://www.elizacloud.ai",
+      authorizationUrl: getBootConfig().cloudApiBase || "https://elizacloud.ai",
     },
   };
 }

--- a/packages/ui/src/platform/ios-runtime.ts
+++ b/packages/ui/src/platform/ios-runtime.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_ELIZA_CLOUD_BASE = "https://www.elizacloud.ai";
+export const DEFAULT_ELIZA_CLOUD_BASE = "https://elizacloud.ai";
 
 export type IosRuntimeMode =
   | "remote-mac"

--- a/plugins/plugin-elizacloud/package.json
+++ b/plugins/plugin-elizacloud/package.json
@@ -130,7 +130,7 @@
         "type": "string",
         "description": "Base URL for all ElizaOS Cloud API requests.",
         "required": false,
-        "default": "https://www.elizacloud.ai/api/v1",
+        "default": "https://elizacloud.ai/api/v1",
         "sensitive": false
       },
       "ELIZAOS_CLOUD_NANO_MODEL": {

--- a/plugins/plugin-elizacloud/registry-entry.json
+++ b/plugins/plugin-elizacloud/registry-entry.json
@@ -22,7 +22,7 @@
       "type": "url",
       "required": false,
       "sensitive": false,
-      "default": "https://www.elizacloud.ai/api/v1",
+      "default": "https://elizacloud.ai/api/v1",
       "label": "Cloud Base Url",
       "help": "Base URL for all ElizaOS Cloud API requests.",
       "advanced": false

--- a/plugins/plugin-x/registry-entry.json
+++ b/plugins/plugin-x/registry-entry.json
@@ -119,7 +119,7 @@
       "type": "url",
       "required": false,
       "sensitive": false,
-      "default": "https://www.elizacloud.ai/api/v1/twitter",
+      "default": "https://elizacloud.ai/api/v1/twitter",
       "label": "Broker URL",
       "help": "Eliza Cloud X (Twitter) broker base URL. Override only to point at a self-hosted broker; otherwise leave the default.",
       "advanced": true,


### PR DESCRIPTION
## Summary
- Follow-up to #11004 after it merged: canonicalize remaining runtime defaults and registry/plugin defaults from `https://www.elizacloud.ai` to `https://elizacloud.ai`.
- Covers Cloud SDK browser/auth base docs/tests, plugin config defaults, first-party generated registry entries, first-run/settings fallbacks, mobile runtime defaults, and dashboard/market preview links.

## Evidence
- Live redirect check: `https://www.elizacloud.ai/api/v1/models` returns 308 to `https://elizacloud.ai/api/v1/models`; apex returns 200.
- Spec behavior: cross-origin redirects strip `Authorization`, so authenticated defaults should avoid the redirected `www` origin.

## Verification
- `bun run --cwd packages/cloud/sdk test` — 59 pass, 19 skip
- `bun run --cwd packages/ui test src/api/client-cloud-handoff-target.test.ts src/cloud/handoff/cloud-handoff-supervisor.test.ts src/cloud/join/lib/run-join-flow.test.ts src/api/client-cloud-direct-auth.test.ts src/api/client-cloud-agent-base.test.ts src/components/settings/CloudAgentsSection.test.tsx` — 6 files, 80 tests passed
- `bun run --cwd packages/app-core test src/services/sensitive-requests/public-link-adapter.test.ts` — 8 passed
- `bun run --cwd packages/cloud/sdk typecheck` — passed
- `bun run --cwd packages/ui typecheck` — passed
- `bun run --cwd plugins/plugin-elizacloud typecheck` — passed
- `bun run --cwd packages/registry generate:first-party:check` — passed
- `bunx biome check ...touched files...` — passed
- `bun run --cwd packages/app audit:app` — 349 passed; broken=0, needs-work=0

## Known unrelated failure
- `bun run --cwd plugins/plugin-cloud-apps typecheck` currently fails on `develop` because that plugin references Cloud SDK ad/influencer/backup exports that are not present in current `@elizaos/cloud-sdk` source. This PR does not touch `plugins/plugin-cloud-apps`.
