### PR TITLE
fix(orchestrator): surface supervisor staleness so a stuck task isn't deduped silent

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-supervisor.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-supervisor.test.ts
@@ -4,6 +4,7 @@ import {
   runSupervisorTick,
   type SupervisorTaskView,
   statusEmoji,
+  supervisorStalenessLabel,
   TaskSupervisorService,
 } from "../../src/services/task-supervisor-service.js";
 
@@ -138,6 +139,54 @@ describe("runSupervisorTick (#8900)", () => {
     expect(seen.has(ROOM_A)).toBe(false);
     const second = await runSupervisorTick(views, send, seen);
     expect(second.posted).toEqual([ROOM_A]); // retried successfully
+  });
+
+  it("re-posts a STUCK task when its staleness band escalates (not deduped silent)", async () => {
+    const send = vi.fn(async () => undefined);
+    const seen = new Map<string, string>();
+    // First tick: task is fresh (no staleness) → posts.
+    const first = await runSupervisorTick(
+      [view({ id: "t1", status: "active" })],
+      send,
+      seen,
+    );
+    expect(first.posted).toEqual([ROOM_A]);
+    // Same task, same status/sessions, but now idle 8m+ (a stall) → the digest
+    // changes and it RE-POSTS, instead of being deduped into silence.
+    const second = await runSupervisorTick(
+      [view({ id: "t1", status: "active", staleness: "⏳ idle 8m+" })],
+      send,
+      seen,
+    );
+    expect(second.posted).toEqual([ROOM_A]);
+  });
+});
+
+describe("supervisorStalenessLabel (#8900)", () => {
+  const t0 = 1_000_000_000_000;
+  const min = (m: number) => t0 - m * 60_000;
+  it("returns undefined when fresh or activity time is unknown", () => {
+    expect(supervisorStalenessLabel(min(1), t0)).toBeUndefined();
+    expect(supervisorStalenessLabel(null, t0)).toBeUndefined();
+    expect(supervisorStalenessLabel(undefined, t0)).toBeUndefined();
+    expect(supervisorStalenessLabel(0, t0)).toBeUndefined();
+  });
+  it("escalates through coarse bands as idle time grows", () => {
+    expect(supervisorStalenessLabel(min(4), t0)).toBe("⏳ idle 3m+");
+    expect(supervisorStalenessLabel(min(10), t0)).toBe("⏳ idle 8m+");
+    expect(supervisorStalenessLabel(min(25), t0)).toBe("⏳ idle 20m+");
+    expect(supervisorStalenessLabel(min(90), t0)).toBe("⚠️ stalled 45m+");
+  });
+  it("folds into the digest line", () => {
+    const digest = composeRoomDigest([
+      view({
+        id: "t1",
+        label: "grind",
+        status: "active",
+        staleness: "⏳ idle 8m+",
+      }),
+    ]);
+    expect(digest).toContain("grind — active (1 running) ⏳ idle 8m+");
   });
 });
 

--- a/plugins/plugin-agent-orchestrator/src/services/task-supervisor-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-supervisor-service.ts
@@ -50,9 +50,48 @@ export interface SupervisorTaskView {
   activeSessions: number;
   /** Latest session label (often "agentType · account"), if any. */
   sessionLabel?: string | null;
+  /** Coarse staleness indicator for a progress-expected task that has gone
+   *  idle (e.g. "⏳ idle 8m+"), or undefined when fresh. Folded into the digest
+   *  line so a genuinely STUCK task changes the digest and re-posts, instead of
+   *  being deduped into silence after the first post. */
+  staleness?: string;
   /** The originating chat target; null tasks (no chat origin) are skipped. */
   origin: { roomId: string; source: string } | null;
 }
+
+// Coarse staleness bands (minutes → label), highest first. Bucketed on purpose:
+// steady progress within a band still dedups, but a stall crossing into the
+// next band changes the digest and re-posts, escalating as it worsens.
+const SUPERVISOR_STALENESS_BANDS: ReadonlyArray<readonly [number, string]> = [
+  [45, "⚠️ stalled 45m+"],
+  [20, "⏳ idle 20m+"],
+  [8, "⏳ idle 8m+"],
+  [3, "⏳ idle 3m+"],
+];
+
+/** Coarse staleness label for a progress-expected task, or undefined when it is
+ *  fresh / has no known activity time. Pure (takes `nowMs`) so the digest stays
+ *  deterministic and unit-testable without a clock. */
+export function supervisorStalenessLabel(
+  latestActivityAt: number | null | undefined,
+  nowMs: number,
+): string | undefined {
+  if (typeof latestActivityAt !== "number" || latestActivityAt <= 0) {
+    return undefined;
+  }
+  const ageMin = (nowMs - latestActivityAt) / 60_000;
+  for (const [min, label] of SUPERVISOR_STALENESS_BANDS) {
+    if (ageMin >= min) return label;
+  }
+  return undefined;
+}
+
+/** Statuses where the sub-agent is expected to be MAKING PROGRESS, so a long
+ *  idle indicates a stall worth surfacing. (waiting_on_user / blocked are
+ *  legitimately idle — no stall indicator there.) */
+const PROGRESS_EXPECTED_STATUSES: ReadonlySet<OrchestratorTaskStatus> = new Set(
+  ["active", "validating"],
+);
 
 /** Compose the digest body for one room's set of live tasks. Deterministic. */
 export function composeRoomDigest(views: SupervisorTaskView[]): string {
@@ -67,7 +106,8 @@ export function composeRoomDigest(views: SupervisorTaskView[]): string {
       const detail = v.sessionLabel ? ` · ${v.sessionLabel}` : "";
       const sessions =
         v.activeSessions > 0 ? ` (${v.activeSessions} running)` : "";
-      return `${statusEmoji(v.status)} ${v.label} — ${v.status}${sessions}${detail}`;
+      const stale = v.staleness ? ` ${v.staleness}` : "";
+      return `${statusEmoji(v.status)} ${v.label} — ${v.status}${sessions}${detail}${stale}`;
     });
   return [header, ...lines].join("\n");
 }
@@ -167,6 +207,7 @@ interface TaskServiceLike {
       status: OrchestratorTaskStatus;
       activeSessionCount: number;
       latestSessionLabel: string | null;
+      latestActivityAt: number | null;
     }>
   >;
   getTaskOriginTarget(
@@ -281,6 +322,7 @@ export class TaskSupervisorService extends Service {
     try {
       const tasks = await taskSvc.listTasks({ includeArchived: false });
       const live = tasks.filter((t) => LIVE_STATUSES.has(t.status));
+      const now = Date.now();
       const views: SupervisorTaskView[] = await Promise.all(
         live.map(async (t) => ({
           id: t.id,
@@ -288,6 +330,11 @@ export class TaskSupervisorService extends Service {
           status: t.status,
           activeSessions: t.activeSessionCount,
           sessionLabel: t.latestSessionLabel,
+          // Surface a stall only for progress-expected statuses; waiting_on_user
+          // / blocked are legitimately idle.
+          staleness: PROGRESS_EXPECTED_STATUSES.has(t.status)
+            ? supervisorStalenessLabel(t.latestActivityAt, now)
+            : undefined,
           origin: await taskSvc.getTaskOriginTarget(t.id),
         })),
       );


### PR DESCRIPTION
## Summary

Follow-up to the supervisor tick hardening (#11019, merged). The digest change-key was built only from `{status, activeSessions, sessionLabel, label}` — none of which move while a sub-agent grinds — so after the first post a genuinely **STUCK** `active`/`validating` task was **deduped into permanent silence**. That defeats the "juggler tells you how tasks are doing" purpose for exactly the case you'd want it.

## Fix

Fold a **coarse staleness bucket** (from the task's `latestActivityAt`) into the digest line for progress-expected statuses:

`fresh → (nothing)`, then `⏳ idle 3m+` → `⏳ idle 8m+` → `⏳ idle 20m+` → `⚠️ stalled 45m+`.

Bucketed on purpose — steady progress within a band still **dedups**, but crossing a band changes the digest and **re-posts**, escalating as it worsens. `waiting_on_user` / `blocked` are legitimately idle → no indicator. The bucket is computed in `runOnce` (with the clock); the digest composer stays **pure** (`supervisorStalenessLabel(latestActivityAt, nowMs)`).

## Tests

- band mapping (fresh/unknown → undefined; 4m/10m/25m/90m → the four bands)
- staleness folds into the digest line
- a stuck task **re-posts** when its band escalates (not deduped silent)

```
Test Files  2 passed (2)
     Tests  16 passed (16)   task-supervisor
```

Closes the supervisor half of #11028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)