### PR TITLE
fix(background): media-store wallpaper uploads + GC pin; ci: revive the dead desktop-packaged lane

### DIFF
--- a/.github/workflows/app-live-e2e.yml
+++ b/.github/workflows/app-live-e2e.yml
@@ -340,10 +340,16 @@ jobs:
           submodules: false
 
       - name: Install WebKitGTK + xvfb for the Electrobun webview
+        # libayatana-appindicator3-1: libNativeWrapper.so (tray support) links
+        # against it; without it every packaged spec dies at launch with
+        # ERR_DLOPEN_FAILED before the test bridge comes up (the lane was red
+        # for 5+ days with "Packaged app exited before the desktop test bridge
+        # became ready").
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            xvfb libwebkit2gtk-4.1-0 libgtk-3-0 mesa-utils libgl1-mesa-dri
+            xvfb libwebkit2gtk-4.1-0 libgtk-3-0 mesa-utils libgl1-mesa-dri \
+            libayatana-appindicator3-1
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e

--- a/packages/agent/src/api/background-routes.test.ts
+++ b/packages/agent/src/api/background-routes.test.ts
@@ -1,0 +1,92 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { RouteHandlerContext } from "@elizaos/core";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+let stateDir: string;
+
+beforeAll(() => {
+  stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "background-routes-test-"));
+  process.env.ELIZA_STATE_DIR = stateDir;
+});
+
+afterAll(() => {
+  fs.rmSync(stateDir, { recursive: true, force: true });
+});
+
+// Imported after env is set so the media store resolves to the temp dir.
+const { backgroundUploadImageRoute } = await import("./background-routes.ts");
+const { gcUnreferencedMedia, readBackgroundPins } = await import(
+  "./media-store.ts"
+);
+
+// A 1x1 transparent PNG.
+const TINY_PNG_DATA_URL =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+
+function callUpload(body: unknown) {
+  // The route only reads ctx.body; the runtime is untouched on this path.
+  return backgroundUploadImageRoute.routeHandler?.({
+    body,
+  } as unknown as RouteHandlerContext) as Promise<{
+    status: number;
+    body: { url?: string; error?: string };
+  }>;
+}
+
+describe("POST /api/background/upload-image (wallpaper re-host, quota fix)", () => {
+  it("persists an image data URL to the media store and returns a served URL", async () => {
+    const res = await callUpload({ dataUrl: TINY_PNG_DATA_URL });
+    expect(res.status).toBe(200);
+    expect(res.body.url).toMatch(/^\/api\/media\/[0-9a-f]{64}\.png$/);
+    // The bytes really landed in the content-addressed store.
+    const fileName = res.body.url?.split("/").pop() ?? "";
+    expect(fs.existsSync(path.join(stateDir, "media", fileName))).toBe(true);
+  });
+
+  it("is content-addressed: the same image re-hosts to the same URL", async () => {
+    const a = await callUpload({ dataUrl: TINY_PNG_DATA_URL });
+    const b = await callUpload({ dataUrl: TINY_PNG_DATA_URL });
+    expect(a.body.url).toBe(b.body.url);
+  });
+
+  it("rejects a non-image payload", async () => {
+    const res = await callUpload({
+      dataUrl: "data:text/html;base64,PHNjcmlwdD48L3NjcmlwdD4=",
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.url).toBeUndefined();
+  });
+
+  it("rejects a missing/non-string payload", async () => {
+    expect((await callUpload({})).status).toBe(400);
+    expect((await callUpload({ dataUrl: 42 })).status).toBe(400);
+  });
+
+  it("rejects an oversized data URL", async () => {
+    const huge = `data:image/jpeg;base64,${"A".repeat(9 * 1024 * 1024)}`;
+    const res = await callUpload({ dataUrl: huge });
+    expect(res.status).toBe(413);
+  });
+
+  it("rejects an undecodable data URL", async () => {
+    const res = await callUpload({ dataUrl: "data:image/png;base64," });
+    expect(res.status).toBe(400);
+  });
+
+  it("pins the wallpaper so the orphan GC never collects it (client-side-only referent)", async () => {
+    const res = await callUpload({ dataUrl: TINY_PNG_DATA_URL });
+    const fileName = res.body.url?.split("/").pop() ?? "";
+    expect(readBackgroundPins()).toContain(fileName);
+
+    // Age the file past the GC grace window, then sweep with an EMPTY
+    // reference set (no message references the wallpaper — that's the bug
+    // this pin exists to fix). The pinned file must survive.
+    const filePath = path.join(stateDir, "media", fileName);
+    const old = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    fs.utimesSync(filePath, old, old);
+    gcUnreferencedMedia(new Set());
+    expect(fs.existsSync(filePath)).toBe(true);
+  });
+});

--- a/packages/agent/src/api/background-routes.ts
+++ b/packages/agent/src/api/background-routes.ts
@@ -18,7 +18,11 @@ import {
   type Route,
   ServiceType,
 } from "@elizaos/core";
-import { persistDataUrl, persistMediaBytes } from "./media-store.ts";
+import {
+  persistDataUrl,
+  persistMediaBytes,
+  pinBackgroundMedia,
+} from "./media-store.ts";
 
 interface GenerateImageBody {
   prompt?: unknown;
@@ -111,6 +115,9 @@ export const backgroundGenerateImageRoute: Route = {
         sourceUrl,
         result.mimeType ?? "image/png",
       );
+      // The wallpaper's only referent is the client's persisted config, which
+      // the orphan GC cannot see — pin it so it survives the daily sweep.
+      pinBackgroundMedia(url);
       return jsonResult(200, { url });
     } catch (err) {
       // Translate a provider/transport failure into a clear client error.
@@ -118,5 +125,49 @@ export const backgroundGenerateImageRoute: Route = {
         error: err instanceof Error ? err.message : "Image generation failed.",
       });
     }
+  },
+};
+
+interface UploadImageBody {
+  dataUrl?: unknown;
+}
+
+/**
+ * Cap on an uploaded wallpaper data URL. The client downscales to ≤4 MB of
+ * bytes before uploading; base64 inflates ~4/3, so allow modest headroom.
+ */
+const BACKGROUND_UPLOAD_MAX_CHARS = 8 * 1024 * 1024;
+
+/**
+ * Re-host a user-picked wallpaper into the content-addressed media store
+ * (authenticated write — the same normalization the generate route performs),
+ * so the client persists a short, stable `/api/media/<hash>` reference instead
+ * of a multi-MB data URL that silently blows the localStorage quota.
+ */
+export const backgroundUploadImageRoute: Route = {
+  type: "POST",
+  path: "/api/background/upload-image",
+  rawPath: true,
+  name: "background-upload-image",
+  routeHandler: async (ctx) => {
+    const body = (ctx.body ?? {}) as UploadImageBody;
+    const dataUrl = typeof body.dataUrl === "string" ? body.dataUrl.trim() : "";
+    if (!dataUrl.startsWith("data:image/")) {
+      return jsonResult(400, { error: "An image data URL is required." });
+    }
+    if (dataUrl.length > BACKGROUND_UPLOAD_MAX_CHARS) {
+      return jsonResult(413, { error: "That image is too large." });
+    }
+    const persisted = persistDataUrl(dataUrl);
+    if (!persisted) {
+      return jsonResult(400, { error: "Could not decode that image." });
+    }
+    // The wallpaper's only referent is the client's persisted config, which
+    // the orphan GC cannot see — pin it so it survives the daily sweep.
+    pinBackgroundMedia(persisted.url);
+    logger.info(
+      `[background] re-hosted uploaded wallpaper as ${persisted.url}`,
+    );
+    return jsonResult(200, { url: persisted.url });
   },
 };

--- a/packages/agent/src/api/media-store.ts
+++ b/packages/agent/src/api/media-store.ts
@@ -395,6 +395,58 @@ export function mediaFileNameFromUrl(url: string): string | null {
   return MEDIA_FILE_NAME.test(name) ? name : null;
 }
 
+// ── Background-wallpaper pins ────────────────────────────────────────────────
+// The active wallpaper (generated or uploaded via the background routes) is
+// referenced only from the CLIENT's persisted config — no message or document
+// carries its URL — so the orphan GC would delete it after the grace window
+// and the wallpaper would 404 on the next load. Pinning is a tiny, capped,
+// append-only exemption list the GC unions into its reference set: not a
+// refcount engine, just a named "still in use" ledger for the one media class
+// with no server-side referent. Capped so replaced wallpapers eventually GC.
+
+const BACKGROUND_PINS_FILE = "background-pins.json";
+/** Keep the last N wallpapers pinned — covers the 10-deep client undo history. */
+const MAX_BACKGROUND_PINS = 12;
+
+function backgroundPinsPath(): string {
+  return path.join(mediaDir(), BACKGROUND_PINS_FILE);
+}
+
+/** Stored filenames (`<sha256>.<ext>`) of pinned wallpapers, newest last. */
+export function readBackgroundPins(): string[] {
+  try {
+    const raw = fs.readFileSync(backgroundPinsPath(), "utf8");
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (name): name is string =>
+        typeof name === "string" && MEDIA_FILE_NAME.test(name),
+    );
+  } catch {
+    return [];
+  }
+}
+
+/** Pin a served wallpaper URL so the orphan GC never collects it. */
+export function pinBackgroundMedia(url: string): void {
+  const name = mediaFileNameFromUrl(url);
+  if (!name) return;
+  try {
+    const pins = readBackgroundPins().filter((existing) => existing !== name);
+    pins.push(name);
+    fs.writeFileSync(
+      backgroundPinsPath(),
+      JSON.stringify(pins.slice(-MAX_BACKGROUND_PINS)),
+    );
+  } catch (err) {
+    logger.warn(
+      `[media-store] could not pin background media ${name}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+}
+
 // Orphan GC grace: never delete files younger than this, so media that was just
 // persisted but not yet referenced by a saved message (or just served) survives.
 const GC_MIN_AGE_MS = 60 * 60 * 1000;
@@ -402,7 +454,9 @@ const GC_MIN_AGE_MS = 60 * 60 * 1000;
 /**
  * Delete stored media files not referenced by any live attachment. `referenced`
  * is the set of `<sha256>.<ext>` filenames still in use (built from message
- * attachment URLs via {@link mediaFileNameFromUrl}). Files younger than the
+ * attachment URLs via {@link mediaFileNameFromUrl}); pinned wallpapers (see
+ * {@link pinBackgroundMedia} — client-side-only referents) are unioned in
+ * here so every GC caller is safe by construction. Files younger than the
  * grace window are kept. Best-effort; returns counts.
  */
 export function gcUnreferencedMedia(referenced: Set<string>): {
@@ -414,10 +468,11 @@ export function gcUnreferencedMedia(referenced: Set<string>): {
   try {
     const dir = mediaDir();
     const now = Date.now();
+    const pinned = new Set(readBackgroundPins());
     for (const name of fs.readdirSync(dir)) {
       if (!MEDIA_FILE_NAME.test(name)) continue;
       scanned += 1;
-      if (referenced.has(name)) continue;
+      if (referenced.has(name) || pinned.has(name)) continue;
       try {
         const stat = fs.statSync(path.join(dir, name));
         if (now - stat.mtimeMs < GC_MIN_AGE_MS) continue; // grace window

--- a/packages/agent/src/runtime/eliza-plugin.ts
+++ b/packages/agent/src/runtime/eliza-plugin.ts
@@ -28,7 +28,10 @@ import { runtimeAction } from "../actions/runtime.ts";
 import { settingsAction } from "../actions/settings-actions.ts";
 import { terminalAction } from "../actions/terminal.ts";
 import { triggerAction } from "../actions/trigger.ts";
-import { backgroundGenerateImageRoute } from "../api/background-routes.ts";
+import {
+  backgroundGenerateImageRoute,
+  backgroundUploadImageRoute,
+} from "../api/background-routes.ts";
 import { filesRoutes } from "../api/files-routes.ts";
 import {
   mediaFileRoute,
@@ -232,7 +235,12 @@ export function createElizaPlugin(config?: ElizaPluginConfig): Plugin {
 
     // Public media route — only reached on iOS (in-process dispatch, no HTTP
     // server). HTTP platforms serve media via the pre-auth handler in server.ts.
-    routes: [mediaFileRoute, backgroundGenerateImageRoute, ...filesRoutes],
+    routes: [
+      mediaFileRoute,
+      backgroundGenerateImageRoute,
+      backgroundUploadImageRoute,
+      ...filesRoutes,
+    ],
 
     actions: [
       terminalAction,

--- a/packages/ui/src/api/client-background.ts
+++ b/packages/ui/src/api/client-background.ts
@@ -16,6 +16,15 @@ declare module "./client-base" {
       prompt: string,
       size?: string,
     ): Promise<{ url: string }>;
+    /**
+     * Re-host a user-picked wallpaper (downscaled data URL) into the
+     * content-addressed media store, returning a durable same-origin
+     * `/api/media/<hash>` URL. Persisting THAT keeps the background config +
+     * undo history tiny instead of stacking multi-MB data URLs into the
+     * ~5 MB localStorage quota (where writes fail silently and the wallpaper
+     * reverts on reload).
+     */
+    uploadBackgroundImage(dataUrl: string): Promise<{ url: string }>;
   }
 }
 
@@ -31,5 +40,15 @@ ElizaClient.prototype.generateBackgroundImage = async function (
   return this.fetch<{ url: string }>("/api/background/generate-image", {
     method: "POST",
     body: JSON.stringify({ prompt, ...(size ? { size } : {}) }),
+  });
+};
+
+ElizaClient.prototype.uploadBackgroundImage = async function (
+  this: ElizaClient,
+  dataUrl,
+) {
+  return this.fetch<{ url: string }>("/api/background/upload-image", {
+    method: "POST",
+    body: JSON.stringify({ dataUrl }),
   });
 };

--- a/packages/ui/src/components/settings/BackgroundSettingsControls.tsx
+++ b/packages/ui/src/components/settings/BackgroundSettingsControls.tsx
@@ -121,7 +121,19 @@ export function BackgroundSettingsControls({
       event.target.value = "";
       if (!file) return;
       try {
-        const imageUrl = await fileToBackgroundDataUrl(file);
+        const dataUrl = await fileToBackgroundDataUrl(file);
+        // Re-host into the media store so the persisted config (and the undo
+        // history) carries a tiny /api/media/<hash> URL instead of a multi-MB
+        // data URL that silently blows the localStorage quota. Offline or
+        // server-less, fall back to the data URL — the wallpaper still works,
+        // it just persists fat.
+        let imageUrl = dataUrl;
+        try {
+          const { url } = await client.uploadBackgroundImage(dataUrl);
+          if (url) imageUrl = url;
+        } catch {
+          // Keep the data-URL fallback.
+        }
         setBackgroundConfig({ mode: "image", color: activeColor, imageUrl });
         setError(null);
       } catch (err) {

--- a/packages/ui/src/state/persistence.ts
+++ b/packages/ui/src/state/persistence.ts
@@ -212,12 +212,34 @@ export function saveBackgroundConfig(config: BackgroundConfig): void {
  */
 const UI_BACKGROUND_HISTORY_STORAGE_KEY = "eliza:ui-background-history";
 export const MAX_BACKGROUND_HISTORY = 10;
+/**
+ * Data-URL image entries are the quota hazard: one downscaled photo is 1–4 MB
+ * against localStorage's ~5 MB total, and `tryLocalStorage` swallows
+ * QuotaExceededError — the write silently fails and the wallpaper reverts on
+ * reload. Media-store (`/api/media/<hash>`) entries are tiny, so only inline
+ * data URLs are capped: keep the single most recent one (uploads are re-hosted
+ * to the media store on the primary path; a data URL only persists as the
+ * offline fallback).
+ */
+export const MAX_BACKGROUND_HISTORY_DATA_URLS = 1;
 
 export function normalizeBackgroundHistory(value: unknown): BackgroundConfig[] {
   if (!Array.isArray(value)) return [];
-  return value
+  const bounded = value
     .map((entry) => normalizeBackgroundConfig(entry))
     .slice(-MAX_BACKGROUND_HISTORY);
+  let dataUrlBudget = MAX_BACKGROUND_HISTORY_DATA_URLS;
+  const kept: BackgroundConfig[] = [];
+  // Walk newest → oldest so the retained data-URL entry is the most recent.
+  for (let i = bounded.length - 1; i >= 0; i--) {
+    const entry = bounded[i];
+    if (entry.imageUrl?.startsWith("data:")) {
+      if (dataUrlBudget === 0) continue;
+      dataUrlBudget--;
+    }
+    kept.unshift(entry);
+  }
+  return kept;
 }
 
 export function loadBackgroundHistory(): BackgroundConfig[] {

--- a/packages/ui/src/state/useDisplayPreferences.background.test.tsx
+++ b/packages/ui/src/state/useDisplayPreferences.background.test.tsx
@@ -6,6 +6,8 @@ import {
   loadBackgroundHistory,
   loadHomeTimeWidgetHidden,
   MAX_BACKGROUND_HISTORY,
+  MAX_BACKGROUND_HISTORY_DATA_URLS,
+  normalizeBackgroundHistory,
   saveHomeTimeWidgetHidden,
 } from "./persistence";
 import { DEFAULT_BACKGROUND_COLOR } from "./ui-preferences";
@@ -145,6 +147,50 @@ describe("useDisplayPreferences — background history + undo", () => {
       });
     }
     expect(loadBackgroundHistory().length).toBe(MAX_BACKGROUND_HISTORY);
+  });
+
+  it("caps inline data-URL image entries to the single most recent (quota hazard)", () => {
+    expect(MAX_BACKGROUND_HISTORY_DATA_URLS).toBe(1);
+    const dataEntry = (n: number) => ({
+      mode: "image",
+      color: "#111111",
+      imageUrl: `data:image/jpeg;base64,${"A".repeat(8)}${n}`,
+    });
+    const mediaEntry = (n: number) => ({
+      mode: "image",
+      color: "#222222",
+      imageUrl: `/api/media/hash${n}.jpg`,
+    });
+    const normalized = normalizeBackgroundHistory([
+      dataEntry(1),
+      mediaEntry(1),
+      dataEntry(2),
+      { mode: "shader", color: "#333333" },
+      mediaEntry(2),
+      dataEntry(3),
+    ]);
+    const dataUrls = normalized.filter((e) => e.imageUrl?.startsWith("data:"));
+    // Only the most recent data-URL entry survives; media-store + shader
+    // entries are all kept in order.
+    expect(dataUrls.length).toBe(1);
+    expect(dataUrls[0]?.imageUrl).toContain("3");
+    expect(normalized.map((e) => e.imageUrl ?? e.color)).toEqual([
+      "/api/media/hash1.jpg",
+      "#333333",
+      "/api/media/hash2.jpg",
+      dataEntry(3).imageUrl,
+    ]);
+  });
+
+  it("keeps a full history of media-store image entries (tiny URLs, no cap pressure)", () => {
+    const entries = Array.from({ length: MAX_BACKGROUND_HISTORY }, (_, i) => ({
+      mode: "image",
+      color: "#000000",
+      imageUrl: `/api/media/h${i}.jpg`,
+    }));
+    expect(normalizeBackgroundHistory(entries).length).toBe(
+      MAX_BACKGROUND_HISTORY,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Closes the final confirmed finding from the deep UI/UX QA sweep (#10722) and revives a CI lane that's been dead for 5+ days.

### Wallpaper uploads → media store (+ GC pin)
- Uploaded wallpapers persisted as 1–4 MB data URLs into localStorage (~5 MB quota) with a 10-deep history in one key; `QuotaExceededError` is swallowed, so the write silently failed and the wallpaper reverted on reload. Uploads now re-host via `POST /api/background/upload-image` into the content-addressed media store (authenticated-write rehost, mirroring the generate route); the client persists the tiny `/api/media/<sha256>` URL, with the data-URL path kept as an offline fallback. Inline data-URL history entries are capped to the single most recent.
- **Found while fixing:** BOTH wallpaper paths (generated and uploaded) were exposed to the daily orphan-media GC — a wallpaper's only referent is the client's persisted config, which `collectReferencedMedia` can't see, so the active wallpaper 404'd after the grace window. Added a tiny capped pin ledger (`media/background-pins.json`, last 12) unioned into the GC reference set — a named exemption, not a refcount engine (#8876 frozen contract respected: no DB table, no `fileId`, no second store).

### CI: desktop-packaged lane
- `app-live-e2e.yml`'s Linux runner never installed `libayatana-appindicator3-1`; `libNativeWrapper.so` (tray) fails to dlopen and every packaged spec died at launch ("Packaged app exited before the desktop test bridge became ready") — red on develop since ≥2026-06-27. One-line apt addition.

## Evidence
- 7 new route tests (persist, content-addressing, non-image/oversize/undecodable rejects, **pin-survives-GC-past-grace-window with an empty reference set**); media-store suite 28/28 unchanged.
- 2 new history-cap tests; background UI suites green (BackgroundSettingsControls/Section, AppearanceSettingsSection.background, background-image).
- CI-lane root cause from the failing job log of run 84488748212 (identical dlopen failure across all 3 specs).

Refs #10722 #10694 #8876.

🤖 Generated with [Claude Code](https://claude.com/claude-code)