### PR TITLE
fix(orchestrator): stop advertising busy sub-agents as reusable + drop phantom task view

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/active-workspace-context.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/active-workspace-context.test.ts
@@ -1,0 +1,83 @@
+import type { Memory, State } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { activeWorkspaceContextProvider } from "../../src/providers/active-workspace-context.js";
+
+/**
+ * The provider used to compute "reusable" sessions by comparing against an
+ * always-empty task list, so it advertised EVERY session — including busy,
+ * mid-turn ones — to the planner as idle/re-taskable (nextAction=SEND_TO_AGENT).
+ * It also reported a phantom taskCount:0 + dead task/pending blocks. These
+ * assert the corrected behavior: only idle ("ready") sessions are reusable.
+ */
+function mkSession(id: string, name: string, status: string) {
+  return {
+    id,
+    name,
+    agentType: "opencode",
+    status,
+    workdir: `/work/${id}`,
+    metadata: {},
+  };
+}
+
+function runtimeWithSessions(sessions: unknown[]) {
+  const acp = { listSessions: () => sessions };
+  return {
+    getService: (t: string) =>
+      t === "ACP_SERVICE" || t === "ACP_SUBPROCESS_SERVICE" ? acp : undefined,
+    getSetting: () => undefined,
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+  } as never;
+}
+
+describe("activeWorkspaceContextProvider reusable sessions", () => {
+  it("advertises only idle (ready) sessions as reusable, never busy mid-turn ones", async () => {
+    const runtime = runtimeWithSessions([
+      mkSession("s-ready", "Ada", "ready"),
+      mkSession("s-busy", "Bo", "busy"),
+      mkSession("s-tool", "Cy", "tool_running"),
+    ]);
+    const res = await activeWorkspaceContextProvider.get(
+      runtime,
+      {} as Memory,
+      {} as State,
+    );
+    const text = res.text ?? "";
+    const lines = text.split("\n");
+    const idx = lines.findIndex((l) => l.startsWith("reusableAgents["));
+    expect(idx).toBeGreaterThanOrEqual(0);
+    // Exactly ONE reusable session (the ready one), not all three.
+    expect(lines[idx]).toContain("reusableAgents[1]");
+    const entry = lines[idx + 1] ?? "";
+    expect(entry).toContain("Ada");
+    expect(entry).toContain("SEND_TO_AGENT");
+    // The busy / tool_running sessions are NOT offered as reusable.
+    expect(entry).not.toContain("Bo");
+    expect(entry).not.toContain("Cy");
+  });
+
+  it("no longer reports a phantom taskCount / tasks block", async () => {
+    const runtime = runtimeWithSessions([mkSession("s1", "Ada", "ready")]);
+    const res = await activeWorkspaceContextProvider.get(
+      runtime,
+      {} as Memory,
+      {} as State,
+    );
+    const text = res.text ?? "";
+    expect(text).not.toContain("taskCount:");
+    expect(text).not.toMatch(/^tasks\[/m);
+    // data.currentTasks is honestly empty (task state lives in the task service).
+    const data = res.data as { currentTasks?: unknown[] } | undefined;
+    expect(data?.currentTasks).toEqual([]);
+  });
+
+  it("has no reusable agents when the only session is busy", async () => {
+    const runtime = runtimeWithSessions([mkSession("s-busy", "Bo", "busy")]);
+    const res = await activeWorkspaceContextProvider.get(
+      runtime,
+      {} as Memory,
+      {} as State,
+    );
+    expect(res.text ?? "").not.toContain("reusableAgents[");
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/providers/active-workspace-context.ts
+++ b/plugins/plugin-agent-orchestrator/src/providers/active-workspace-context.ts
@@ -15,22 +15,10 @@ import {
   formatTaskAgentStatus,
   getTaskAgentFrameworkState,
   TASK_AGENT_FRAMEWORK_LABELS,
-  truncateTaskAgentText,
 } from "../services/task-agent-frameworks.js";
 import type { SessionInfo } from "../services/types.js";
 import type { WorkspaceResult } from "../services/workspace-service.js";
 import { getCodingWorkspaceService } from "../services/workspace-service.js";
-
-interface TaskLike {
-  sessionId: string;
-  agentType: string;
-  label: string;
-  originalTask: string;
-  status: string;
-  decisions: Array<{ reasoning?: string }>;
-  completionSummary?: string;
-  registeredAt: number;
-}
 
 type FrameworkState = Awaited<ReturnType<typeof getTaskAgentFrameworkState>>;
 
@@ -43,23 +31,11 @@ const FALLBACK_FRAMEWORK_STATE: FrameworkState = {
   },
 };
 
-function uniqueTasks(tasks: TaskLike[]): TaskLike[] {
-  const seen = new Set<string>();
-  const result: TaskLike[] = [];
-  for (const task of tasks) {
-    if (seen.has(task.sessionId)) continue;
-    seen.add(task.sessionId);
-    result.push(task);
-  }
-  return result;
-}
-
 export const activeWorkspaceContextProvider: Provider = {
   name: "ACTIVE_WORKSPACE_CONTEXT",
   description:
-    "Live status of active workspaces, task-agent sessions, and current task progress",
-  descriptionCompressed:
-    "Live status of workspaces, task agents, and progress.",
+    "Live status of active coding workspaces and task-agent sessions",
+  descriptionCompressed: "Live status of workspaces and task agents.",
   position: 1,
   contexts: ["code", "tasks", "agent_internal"],
   contextGate: { anyOf: ["code", "tasks", "agent_internal"] },
@@ -108,11 +84,13 @@ export const activeWorkspaceContextProvider: Provider = {
       );
       workspaces = [];
     }
-    const tasks = uniqueTasks([]);
-    const reusableSessions = sessions.filter((session) => {
-      const currentTask = tasks.find((task) => task.sessionId === session.id);
-      return currentTask?.status !== "active";
-    });
+    // A session is reusable (safe to re-task via SEND_TO_AGENT) only when it is
+    // idle — "ready" — not mid-turn (busy/running/tool_running) or terminal.
+    // The prior filter compared against an always-empty task list, so it
+    // advertised EVERY session (including busy, mid-turn ones) as reusable.
+    const reusableSessions = sessions.filter(
+      (session) => session.status === "ready",
+    );
 
     const lines: string[] = [
       "active_workspace_context:",
@@ -120,14 +98,9 @@ export const activeWorkspaceContextProvider: Provider = {
       `  preferredReason: ${frameworkState.preferred.reason}`,
       `  workspaceCount: ${workspaces.length}`,
       `  sessionCount: ${sessions.length}`,
-      `  taskCount: ${tasks.length}`,
     ];
 
-    if (
-      workspaces.length === 0 &&
-      sessions.length === 0 &&
-      tasks.length === 0
-    ) {
+    if (workspaces.length === 0 && sessions.length === 0) {
       lines.push("guidance:");
       lines.push(
         "  createTask: Use ACPX CREATE_AGENT_TASK when the user needs anything more involved than a simple direct reply.",
@@ -178,41 +151,6 @@ export const activeWorkspaceContextProvider: Provider = {
         }
       }
 
-      if (tasks.length > 0) {
-        lines.push(`tasks[${tasks.length}]{status,label,agentType,detail}:`);
-        for (const task of tasks
-          .slice()
-          .sort((left, right) => right.registeredAt - left.registeredAt)) {
-          const latestDecision = task.decisions.at(-1);
-          const detail =
-            task.completionSummary ||
-            latestDecision?.reasoning ||
-            truncateTaskAgentText(task.originalTask, 110);
-          lines.push(
-            `  ${task.status},${task.label},${task.agentType},${detail.replace(/\s+/g, " ").trim()}`,
-          );
-        }
-      }
-
-      const pending: Array<{
-        taskContext: { label: string };
-        promptText: string;
-        llmDecision: { action?: string };
-      }> = [];
-      if (pending.length > 0) {
-        lines.push("pendingConfirmations:");
-        lines.push(`  count: ${pending.length}`);
-        lines.push("  supervision: acp");
-        lines.push(
-          `pendingItems[${pending.length}]{label,prompt,suggestedAction}:`,
-        );
-        for (const confirmation of pending) {
-          lines.push(
-            `  ${confirmation.taskContext.label},${truncateTaskAgentText(confirmation.promptText, 140)},${confirmation.llmDecision.action ?? "review"}`,
-          );
-        }
-      }
-
       if (reusableSessions.length > 0) {
         lines.push(
           `reusableAgents[${reusableSessions.length}]{label,agentType,status,nextAction}:`,
@@ -229,7 +167,7 @@ export const activeWorkspaceContextProvider: Provider = {
       }
     }
 
-    if (sessions.length > 0 || tasks.length > 0) {
+    if (sessions.length > 0) {
       lines.push("actions:");
       lines.push("  unblockOrAssign: SEND_TO_AGENT");
       lines.push("  inspectProgress: provider.active_workspace_context");
@@ -257,7 +195,9 @@ export const activeWorkspaceContextProvider: Provider = {
           status: session.status,
           workdir: session.workdir,
         })),
-        currentTasks: tasks,
+        // This provider surfaces workspace + session context only; durable task
+        // state lives in OrchestratorTaskService and is surfaced elsewhere.
+        currentTasks: [],
         preferredTaskAgent: frameworkState.preferred,
         frameworks: frameworkState.frameworks,
       },


### PR DESCRIPTION
## Summary

`active-workspace-context` (injected into the planner every turn) computed "reusable" sessions by comparing against a **hardcoded-empty task list** (`const tasks = uniqueTasks([])`). Consequences:

- `taskCount` was always **0**; the `tasks[...]` and `pendingConfirmations` render blocks were **dead** (never executed).
- The reusable filter (`currentTask?.status !== "active"`, where `currentTask` was *always* undefined) matched **every** session — so busy, mid-turn agents were advertised to the planner as idle/re-taskable with `nextAction=SEND_TO_AGENT`. The planner could re-task an agent that's actively working.

## Fix

- **Reusable = real session status.** Only an idle `ready` session is reusable (`busy`/`running`/`tool_running` are mid-turn; terminal can't be re-tasked).
- **Removed the structurally-dead machinery** — `TaskLike`, `uniqueTasks`, the dead task/pending render blocks, `taskCount`, and `currentTasks` — so the provider stops reporting a phantom task view. Durable task state lives in `OrchestratorTaskService` and is surfaced elsewhere. Description corrected to drop the false "current task progress".

## Tests (new)

- only `ready` sessions appear in `reusableAgents` (busy/tool_running do **not**)
- no phantom `taskCount:`/`tasks[` block; `data.currentTasks` is honestly `[]`
- no `reusableAgents` when the only session is busy

```
Test Files  1 passed (1)
     Tests  3 passed (3)
```

Closes the provider half of #11028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)