### PR TITLE
fix(orchestrator): a 'stop <code-action>' instruction no longer cancels a live turn

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/interruption-decider.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/interruption-decider.test.ts
@@ -150,4 +150,31 @@ describe("decideInterruption", () => {
       }).action,
     ).toBe("queue");
   });
+
+  it("does NOT cancel a live turn for a 'stop <code-action>' instruction", () => {
+    // "stop using axios" changes the code, it is not "stop working" — it must
+    // reach the agent after the turn (queue), never cancel the in-flight turn.
+    expect(
+      decideInterruption({
+        ...base,
+        text: "let's stop using axios, switch to fetch",
+        sessionBusy: true,
+      }).action,
+    ).toBe("queue");
+    expect(
+      decideInterruption({
+        ...base,
+        text: "stop importing lodash everywhere",
+        sessionBusy: true,
+      }).action,
+    ).toBe("queue");
+    // ...but a genuine halt still interrupts.
+    expect(
+      decideInterruption({ ...base, text: "stop working", sessionBusy: true })
+        .action,
+    ).toBe("interrupt");
+    expect(
+      decideInterruption({ ...base, text: "stop", sessionBusy: true }).action,
+    ).toBe("interrupt");
+  });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/interruption-decider.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/interruption-decider.ts
@@ -43,6 +43,16 @@ export interface InterruptionInput {
 const STOP_PATTERN =
   /\b(stop|cancel|abort|halt|never ?mind|forget it|that'?s enough|quit it|kill it)\b/i;
 
+// "stop <gerund>" is normally a code INSTRUCTION ("stop using axios", "stop
+// importing lodash", "stop logging that") — it changes what the code does, not
+// a command to halt the agent — so it must NOT cancel the in-flight turn (it
+// queues and reaches the agent after its current turn). The exception is a
+// gerund that refers to the AGENT itself ("stop working / doing / running"),
+// which stays a genuine halt. Bare stops ("stop", "stop it", "Ada, stop") have
+// no following gerund and are unaffected.
+const STOP_CODE_INSTRUCTION_PATTERN =
+  /\bstop\s+(?!working\b|doing\b|running\b|generating\b|responding\b|that\b|this\b|it\b|now\b|everything\b|all\b)\w+ing\b/i;
+
 // Additive markers — the message AUGMENTS the current work rather than
 // redirecting it, so it must never interrupt (even when it also contains a
 // stop/correction token like "stop" or "don't forget"). "also add X", "and
@@ -100,6 +110,7 @@ export function decideInterruption(
   // or any stop in a solo room, interrupts).
   if (
     STOP_PATTERN.test(text) &&
+    !STOP_CODE_INSTRUCTION_PATTERN.test(text) &&
     !additive &&
     !(input.multiParty && !addressed)
   ) {


### PR DESCRIPTION
## Summary

The interruption decider treats any `stop` as an explicit halt, so **"let's stop using axios, switch to fetch"** — a *code instruction* — matched `STOP_PATTERN` and **cancelled the sub-agent's in-flight turn** (in a solo room). "stop using axios" changes what the code does; it is not "stop working".

## Fix

`stop <gerund>` ("stop using…", "stop importing…", "stop logging…") is a code instruction → it **queues** (reaches the agent after its turn) instead of interrupting — **except** when the gerund refers to the agent itself ("stop working / doing / running"), which stays a genuine halt. Bare stops ("stop", "stop it", "Ada, stop") have no following gerund and are unchanged.

## Tests

- "stop using axios, switch to fetch" / "stop importing lodash everywhere" → **queue**
- "stop working" / "stop" → **interrupt** (still halts)

```
Test Files  1 passed (1)
     Tests  10 passed (10)
```

> The fuller fix — threading the core `shouldRespond` LLM verdict into the decider (which already accepts it) — needs a per-message verdict source / architecture decision, and stays tracked in #11028. This closes the concrete false-cancel harm in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)