### PR TITLE
fix: let BYO embeddings own embedding routes

### DIFF
--- a/packages/agent/src/runtime/eliza-cloud-config.test.ts
+++ b/packages/agent/src/runtime/eliza-cloud-config.test.ts
@@ -23,6 +23,10 @@ const ENV_KEYS = [
   "ELIZAOS_CLOUD_ENABLED",
   "ELIZA_CLOUD_EMBEDDINGS_DISABLED",
   "ELIZAOS_CLOUD_API_KEY",
+  "EMBEDDING_BASE_URL",
+  "EMBEDDING_API_KEY",
+  "EMBEDDING_MODEL",
+  "EMBEDDING_DIMENSIONS",
   "ELIZAOS_CLOUD_BASE_URL",
   "ELIZA_CLOUD_AGENT_ID",
   "ELIZAOS_CLOUD_NANO_MODEL",
@@ -71,6 +75,37 @@ describe("applyCloudConfigToEnv cloud-container embeddings (#8769)", () => {
     expect(process.env.ELIZAOS_CLOUD_USE_INFERENCE).toBe("true");
   });
 
+  it("honors BYO embedding ownership from config.env in a cloud-provisioned container", () => {
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+
+    applyCloudConfigToEnv({
+      env: {
+        vars: {
+          ELIZAOS_CLOUD_USE_EMBEDDINGS: "false",
+          EMBEDDING_BASE_URL: "http://172.17.0.1:11434/v1",
+          EMBEDDING_API_KEY: "ollama",
+        },
+      },
+    } as ElizaConfig);
+
+    expect(process.env.ELIZAOS_CLOUD_USE_EMBEDDINGS).toBe("false");
+    expect(process.env.ELIZAOS_CLOUD_USE_INFERENCE).toBe("true");
+  });
+
+  it("lets an explicit BYO embedding endpoint own embeddings in a cloud-provisioned container", () => {
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+    process.env.ELIZAOS_CLOUD_USE_EMBEDDINGS = "false";
+    process.env.EMBEDDING_BASE_URL = "http://172.17.0.1:11434/v1";
+    process.env.EMBEDDING_API_KEY = "ollama";
+    process.env.EMBEDDING_MODEL = "nomic-embed-text";
+    process.env.EMBEDDING_DIMENSIONS = "768";
+
+    applyCloudConfigToEnv({} as ElizaConfig);
+
+    expect(process.env.ELIZAOS_CLOUD_USE_EMBEDDINGS).toBe("false");
+    expect(process.env.ELIZAOS_CLOUD_USE_INFERENCE).toBe("true");
+  });
+
   it("is a no-op when neither cloud config nor ELIZA_CLOUD_PROVISIONED is present", () => {
     // No cloud + not a container → the function returns early and must not
     // touch any cloud-usage env (so a local-only agent isn't flipped to cloud).
@@ -113,6 +148,56 @@ describe("provisioned cloud container topology (#9887)", () => {
       transport: "cloud-proxy",
       smallModel: "small-test",
     });
+  });
+
+  it("does not synthesize cloud embedding routing when config.env selects BYO embeddings", () => {
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+
+    const config: ElizaConfig = {
+      cloud: {
+        enabled: true,
+        apiKey: "cloud-test",
+        agentId: "agent-test",
+      },
+      env: {
+        vars: {
+          ELIZAOS_CLOUD_USE_EMBEDDINGS: "false",
+          EMBEDDING_BASE_URL: "http://172.17.0.1:11434/v1",
+          EMBEDDING_API_KEY: "ollama",
+        },
+      },
+    } as ElizaConfig;
+
+    ensureProvisionedCloudContainerConfig(config);
+
+    expect(config.serviceRouting?.llmText).toMatchObject({
+      backend: "elizacloud",
+      transport: "cloud-proxy",
+    });
+    expect(config.serviceRouting?.embeddings).toBeUndefined();
+  });
+
+  it("does not synthesize cloud embedding routing when BYO embeddings are explicitly selected", () => {
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+    process.env.ELIZAOS_CLOUD_USE_EMBEDDINGS = "false";
+    process.env.EMBEDDING_BASE_URL = "http://172.17.0.1:11434/v1";
+    process.env.EMBEDDING_API_KEY = "ollama";
+
+    const config: ElizaConfig = {
+      cloud: {
+        enabled: true,
+        apiKey: "cloud-test",
+        agentId: "agent-test",
+      },
+    } as ElizaConfig;
+
+    ensureProvisionedCloudContainerConfig(config);
+
+    expect(config.serviceRouting?.llmText).toMatchObject({
+      backend: "elizacloud",
+      transport: "cloud-proxy",
+    });
+    expect(config.serviceRouting?.embeddings).toBeUndefined();
   });
 
   it("repairs topology from config.env when container env has only the provisioned marker", () => {

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -1168,6 +1168,20 @@ function isProvisionedCloudContainer(env: NodeJS.ProcessEnv = process.env) {
   return env.ELIZA_CLOUD_PROVISIONED === "1";
 }
 
+function isExplicitFalseEnvValue(value: string | undefined): boolean {
+  return value?.trim().toLowerCase() === "false";
+}
+
+function hasExplicitEmbeddingProviderConfig(
+  config: ElizaConfig,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return Boolean(
+    readEffectiveEnvValue(config, "EMBEDDING_BASE_URL", env) ||
+      readEffectiveEnvValue(config, "EMBEDDING_API_KEY", env),
+  );
+}
+
 const CLOUD_ROUTING_MODEL_ENV: ReadonlyArray<[string, string]> = [
   ["ELIZAOS_CLOUD_NANO_MODEL", "nanoModel"],
   ["ELIZAOS_CLOUD_SMALL_MODEL", "smallModel"],
@@ -1275,6 +1289,12 @@ export function ensureProvisionedCloudContainerConfig(
     );
     const cloudRouting = buildDefaultElizaCloudServiceRouting({
       includeInference: true,
+      excludeServices:
+        isExplicitFalseEnvValue(
+          readEffectiveEnvValue(config, "ELIZAOS_CLOUD_USE_EMBEDDINGS", env),
+        ) && hasExplicitEmbeddingProviderConfig(config, env)
+          ? ["embeddings"]
+          : undefined,
       nanoModel: readEffectiveEnvValue(config, "ELIZAOS_CLOUD_NANO_MODEL", env),
       smallModel: readEffectiveEnvValue(
         config,
@@ -2166,16 +2186,30 @@ export function applyCloudConfigToEnv(config: ElizaConfig): void {
     topology.services.tts || isCloudContainer,
   );
   setCloudUsageEnv("ELIZAOS_CLOUD_USE_MEDIA", topology.services.media);
-  // Cloud containers always use cloud embeddings: the cloud TEXT_EMBEDDING
+  // Cloud containers normally use cloud embeddings: the cloud TEXT_EMBEDDING
   // handler (1536-dim) must win over plugin-local-inference's gte-small
   // (384-dim CPU GGUF). Without this, a dedicated cloud agent warms up and
   // serves local 384-dim embeddings while the SQL column is provisioned for the
   // cloud dimension → every memory insert is dropped on a dimension mismatch,
-  // and the CPU embedding warmup wastes boot time.
-  setCloudUsageEnv(
-    "ELIZAOS_CLOUD_USE_EMBEDDINGS",
-    topology.services.embeddings || isCloudContainer,
+  // and the CPU embedding warmup wastes boot time. The exception is an explicit
+  // BYO embedding endpoint plus ELIZAOS_CLOUD_USE_EMBEDDINGS=false: that is an
+  // operator-owned override, so preserve it instead of forcing cloud back on.
+  const hasByoEmbeddingProvider = hasExplicitEmbeddingProviderConfig(config);
+  const cloudEmbeddingsExplicitlyDisabled = isExplicitFalseEnvValue(
+    readEffectiveEnvValue(config, "ELIZAOS_CLOUD_USE_EMBEDDINGS"),
   );
+  const byoEmbeddingProviderOverridesCloud =
+    isCloudContainer &&
+    cloudEmbeddingsExplicitlyDisabled &&
+    hasByoEmbeddingProvider;
+  if (byoEmbeddingProviderOverridesCloud) {
+    process.env.ELIZAOS_CLOUD_USE_EMBEDDINGS = "false";
+  } else {
+    setCloudUsageEnv(
+      "ELIZAOS_CLOUD_USE_EMBEDDINGS",
+      topology.services.embeddings || isCloudContainer,
+    );
+  }
   setCloudUsageEnv("ELIZAOS_CLOUD_USE_RPC", topology.services.rpc);
 
   if (effectivelyEnabled) {

--- a/plugins/plugin-elizacloud/__tests__/embedding-routing.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/embedding-routing.test.ts
@@ -1,0 +1,89 @@
+import { ModelType } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { embeddingsPlugin } from "../../plugin-embeddings/src/index.ts";
+import { elizaOSCloudPlugin, registerCloudEmbeddingModels } from "../src/index.ts";
+
+type RegisteredModel = {
+  modelType: string;
+  provider: string;
+  priority: number;
+};
+
+function createRuntime() {
+  const registered: RegisteredModel[] = [];
+  return {
+    registered,
+    getSetting(key: string) {
+      return process.env[key];
+    },
+    registerModel(modelType: string, _handler: unknown, provider: string, priority = 0) {
+      registered.push({ modelType, provider, priority });
+      registered.sort((a, b) => b.priority - a.priority);
+    },
+  };
+}
+
+function registerByoEmbeddingModels(runtime: ReturnType<typeof createRuntime>) {
+  for (const [modelType, handler] of Object.entries(embeddingsPlugin.models ?? {})) {
+    runtime.registerModel(
+      modelType,
+      handler,
+      embeddingsPlugin.name,
+      embeddingsPlugin.priority ?? 0
+    );
+  }
+}
+
+function topProvider(runtime: ReturnType<typeof createRuntime>, modelType: string) {
+  return runtime.registered.find((entry) => entry.modelType === modelType)?.provider;
+}
+
+const ENV_KEYS = [
+  "ELIZAOS_CLOUD_USE_EMBEDDINGS",
+  "EMBEDDING_BASE_URL",
+  "EMBEDDING_API_KEY",
+] as const;
+
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  savedEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+  for (const key of ENV_KEYS) delete process.env[key];
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const value = savedEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe("Eliza Cloud embedding routing", () => {
+  it("does not register cloud embeddings when ELIZAOS_CLOUD_USE_EMBEDDINGS=false so BYO embeddings resolve", () => {
+    process.env.ELIZAOS_CLOUD_USE_EMBEDDINGS = "false";
+    process.env.EMBEDDING_BASE_URL = "http://172.17.0.1:11434/v1";
+    process.env.EMBEDDING_API_KEY = "ollama";
+
+    const runtime = createRuntime();
+    registerCloudEmbeddingModels(runtime as never);
+    registerByoEmbeddingModels(runtime);
+
+    expect(topProvider(runtime, ModelType.TEXT_EMBEDDING)).toBe(embeddingsPlugin.name);
+    expect(topProvider(runtime, ModelType.TEXT_EMBEDDING_BATCH)).toBe(embeddingsPlugin.name);
+    expect(runtime.registered.some((entry) => entry.provider === elizaOSCloudPlugin.name)).toBe(
+      false
+    );
+  });
+
+  it("keeps cloud embeddings as the priority winner when explicitly enabled", () => {
+    process.env.ELIZAOS_CLOUD_USE_EMBEDDINGS = "true";
+
+    const runtime = createRuntime();
+    registerCloudEmbeddingModels(runtime as never);
+    registerByoEmbeddingModels(runtime);
+
+    expect(topProvider(runtime, ModelType.TEXT_EMBEDDING)).toBe(elizaOSCloudPlugin.name);
+    expect(topProvider(runtime, ModelType.TEXT_EMBEDDING_BATCH)).toBe(elizaOSCloudPlugin.name);
+  });
+});

--- a/plugins/plugin-elizacloud/src/index.ts
+++ b/plugins/plugin-elizacloud/src/index.ts
@@ -43,6 +43,12 @@ const TEXT_MEGA_MODEL_TYPE = (ModelType.TEXT_MEGA ?? "TEXT_MEGA") as string;
 const RESPONSE_HANDLER_MODEL_TYPE = (ModelType.RESPONSE_HANDLER ?? "RESPONSE_HANDLER") as string;
 const ACTION_PLANNER_MODEL_TYPE = (ModelType.ACTION_PLANNER ?? "ACTION_PLANNER") as string;
 
+const cloudEmbeddingModels: NonNullable<Plugin["models"]> = {
+  [ModelType.TEXT_EMBEDDING]: handleTextEmbedding,
+  [ModelType.TEXT_EMBEDDING_BATCH]: (runtime, params: { texts: string[] }) =>
+    handleBatchTextEmbedding(runtime, params.texts),
+};
+
 function getProcessEnv(): ProcessEnvLike {
   if (typeof process === "undefined") {
     return {};
@@ -81,6 +87,10 @@ const textInferenceModels: NonNullable<Plugin["models"]> = {
   [ACTION_PLANNER_MODEL_TYPE]: handleActionPlanner,
 };
 
+function isExplicitFalseFlag(value: string | undefined): boolean {
+  return value?.trim().toLowerCase() === "false";
+}
+
 export function registerTextInferenceModels(runtime: IAgentRuntime): void {
   const flag = getSetting(runtime, "ELIZAOS_CLOUD_USE_INFERENCE");
   if (flag?.trim().toLowerCase() === "false") {
@@ -90,6 +100,24 @@ export function registerTextInferenceModels(runtime: IAgentRuntime): void {
     return;
   }
   for (const [modelType, handler] of Object.entries(textInferenceModels)) {
+    runtime.registerModel(
+      modelType,
+      handler as Parameters<IAgentRuntime["registerModel"]>[1],
+      elizaOSCloudPlugin.name,
+      elizaOSCloudPlugin.priority
+    );
+  }
+}
+
+export function registerCloudEmbeddingModels(runtime: IAgentRuntime): void {
+  const flag = getSetting(runtime, "ELIZAOS_CLOUD_USE_EMBEDDINGS");
+  if (isExplicitFalseFlag(flag)) {
+    logger.info(
+      "[ElizaOSCloud] Not registering cloud embedding handlers: ELIZAOS_CLOUD_USE_EMBEDDINGS=false (another provider owns TEXT_EMBEDDING)"
+    );
+    return;
+  }
+  for (const [modelType, handler] of Object.entries(cloudEmbeddingModels)) {
     runtime.registerModel(
       modelType,
       handler as Parameters<IAgentRuntime["registerModel"]>[1],
@@ -180,9 +208,11 @@ export const elizaOSCloudPlugin: Plugin = {
   async init(config, runtime) {
     // Initialize inference (OpenAI-compatible client)
     initializeOpenAI(config, runtime);
-    // Chat-brain text handlers are conditional (see textInferenceModels
-    // above); capability handlers stay in the static `models` map below.
+    // Chat-brain text handlers and embedding handlers are conditional (see
+    // textInferenceModels/cloudEmbeddingModels above); other capability handlers
+    // stay in the static `models` map below.
     registerTextInferenceModels(runtime);
+    registerCloudEmbeddingModels(runtime);
   },
 
   // ─── Runtime Event Handlers ──────────────────────────────────────────
@@ -224,16 +254,12 @@ export const elizaOSCloudPlugin: Plugin = {
   ],
 
   // ─── Capability Model Handlers ───────────────────────────────────────
-  // Always registered: these capabilities don't compete with the chat brain
-  // and must survive an external text provider. The chat-brain text handlers
-  // (TEXT_*, RESPONSE_HANDLER, ACTION_PLANNER) are registered conditionally
-  // from init() — see textInferenceModels above.
+  // Always registered: these capabilities don't compete with BYO embedding or
+  // chat-brain slots and must survive an external text provider. The chat-brain
+  // text handlers (TEXT_*, RESPONSE_HANDLER, ACTION_PLANNER) and embedding
+  // handlers are registered conditionally from init() — see textInferenceModels
+  // and cloudEmbeddingModels above.
   models: {
-    [ModelType.TEXT_EMBEDDING]: handleTextEmbedding,
-    // Batch path: one request embeds N texts (the embedding-drain service uses
-    // this to collapse serial single-text round-trips into fewer batched calls).
-    [ModelType.TEXT_EMBEDDING_BATCH]: (runtime, params: { texts: string[] }) =>
-      handleBatchTextEmbedding(runtime, params.texts),
     [ModelType.RESEARCH]: handleResearch,
     [ModelType.IMAGE]: handleImageGeneration,
     [ModelType.IMAGE_DESCRIPTION]: handleImageDescription,


### PR DESCRIPTION
## Summary
- keep hosted cloud embeddings from registering when `ELIZAOS_CLOUD_USE_EMBEDDINGS=false`
- preserve an explicit BYO embedding endpoint in provisioned cloud containers instead of forcing Cloud embeddings back on
- add focused routing/config tests for process env and config.env paths

## Production receipt
`sol-real` had memory recall failing because `TEXT_EMBEDDING` still resolved to `provider=elizaOSCloud` and hit 401 even with explicit BYO embedding env:

```
EMBEDDING_BASE_URL=http://172.17.0.1:11434/v1
EMBEDDING_API_KEY=ollama
EMBEDDING_MODEL=nomic-embed-text
EMBEDDING_DIMENSIONS=768
ELIZAOS_CLOUD_USE_EMBEDDINGS=false
```

Local hot-patch proof: raising `plugin-embeddings` priority above `plugin-elizacloud` made runtime resolve `provider=embeddings` with dimension `768`. This PR makes that behavior semantic: the cloud plugin simply does not claim `TEXT_EMBEDDING` / `TEXT_EMBEDDING_BATCH` when the host explicitly disables cloud embeddings for a configured BYO embedding endpoint.

## Tests
- `bunx vitest run packages/agent/src/runtime/eliza-cloud-config.test.ts plugins/plugin-elizacloud/__tests__/embedding-routing.test.ts`
- `cd plugins/plugin-elizacloud && bun run typecheck`
- `cd packages/agent && bun run typecheck`
- `codex review --uncommitted` found one P2 config.env gap, fixed in this PR. Follow-up codex review attempts hit local CLI output/write failures after running checks, so I treated the fixed finding plus passing focused tests/typechecks as the gate.
