### PR TITLE
fix(ui): commit real-touch horizontal flicks that a janked WebView coalesces or cancels (#9943)

### DIFF
--- a/packages/app/scripts/lib/android-device.mjs
+++ b/packages/app/scripts/lib/android-device.mjs
@@ -238,6 +238,28 @@ function bootCompleted(adbBin, serial) {
  * for boot completion. Returns the device serial. Throws loudly if no device
  * can be obtained (so a CI lane that should have an emulator fails visibly).
  */
+/**
+ * Suppress system error/ANR dialogs on the test device. On a software-GPU
+ * emulator under load, the Pixel Launcher / SystemUI routinely ANR; the dialog
+ * window then HOLDS INPUT FOCUS, so every `adb shell input` swipe/tap goes to
+ * the dialog and the app under test receives ZERO input events (observed as
+ * `mCurrentFocus=… Application Not Responding: …nexuslauncher` while a touch
+ * spec's page recorder counted 0 events). Standard Android CI hardening.
+ */
+function suppressErrorDialogs(adbBin, serial, log = () => {}) {
+  const ok = adbTry(adbBin, [
+    "-s",
+    serial,
+    "shell",
+    "settings",
+    "put",
+    "global",
+    "hide_error_dialogs",
+    "1",
+  ]);
+  if (ok) log(`error/ANR dialogs suppressed on ${serial}`);
+}
+
 export async function ensureEmulatorBooted({
   adb: adbBin = resolveAdb(),
   emulator = resolveEmulator(),
@@ -249,6 +271,7 @@ export async function ensureEmulatorBooted({
   if (existing.length > 0) {
     const serial = process.env.ANDROID_SERIAL ?? existing[0];
     log(`reusing attached device ${serial}`);
+    suppressErrorDialogs(adbBin, serial, log);
     return serial;
   }
 
@@ -329,6 +352,7 @@ export async function ensureEmulatorBooted({
     const devices = listDevices(adbBin);
     if (devices.length > 0 && bootCompleted(adbBin, devices[0])) {
       log(`emulator ${devices[0]} boot completed (log: ${logFile})`);
+      suppressErrorDialogs(adbBin, devices[0], log);
       return devices[0];
     }
   }

--- a/packages/app/test/android/touch-gesture.android.spec.ts
+++ b/packages/app/test/android/touch-gesture.android.spec.ts
@@ -262,6 +262,52 @@ async function androidTouchDrag(
   ]);
 }
 
+/**
+ * Wait until the WebView main thread is responsive enough to receive input.
+ * On a software-GPU emulator the embedded runtime's boot stalls the main
+ * thread in multi-second chunks (logcat `Davey! duration=1793ms`, `Skipped 47
+ * frames`); while stalled, Android's input pipeline can drop the ENTIRE adb
+ * swipe sequence — the page then sees zero pointer events, and no commit
+ * logic can fire on events that never arrive. Requires several consecutive
+ * low-latency event-loop samples before letting the gesture proceed.
+ */
+async function waitForResponsiveMainThread(
+  page: Page,
+  {
+    maxLatencyMs = 250,
+    consecutive = 3,
+    timeoutMs = 120_000,
+  }: { maxLatencyMs?: number; consecutive?: number; timeoutMs?: number } = {},
+) {
+  const startedAt = Date.now();
+  let streak = 0;
+  let lastLatency = -1;
+  while (Date.now() - startedAt < timeoutMs) {
+    lastLatency = await page.evaluate(
+      () =>
+        new Promise<number>((resolve) => {
+          const t0 = performance.now();
+          setTimeout(() => resolve(performance.now() - t0), 0);
+        }),
+    );
+    streak = lastLatency <= maxLatencyMs ? streak + 1 : 0;
+    if (streak >= consecutive) {
+      writeStage("main-thread-responsive", {
+        lastLatency,
+        waitedMs: Date.now() - startedAt,
+      });
+      return;
+    }
+    await page.waitForTimeout(500);
+  }
+  // Proceed anyway — the retry loop around the drag still gets its chance —
+  // but record that the settle gate never opened (this run will be slow).
+  writeStage("main-thread-still-janked", {
+    lastLatency,
+    waitedMs: Date.now() - startedAt,
+  });
+}
+
 async function ensureCollapsedHome(page: Page, adb: string, serial: string) {
   const overlay = page.getByTestId("continuous-chat-overlay");
   const surface = page.getByTestId("home-launcher-surface");
@@ -390,15 +436,41 @@ test.describe
         const beforePage = await surface.getAttribute("data-page");
         writeStage("install-touch-recorder", { beforePage, serial });
         await installTouchRecorder(page);
-        writeStage("dispatch-horizontal-touch", { beforePage, serial });
-        await androidTouchDrag(
-          page,
-          adb,
-          serial,
-          '[data-testid="chat-sheet-grabber"]',
-          -150,
-          -6,
-        );
+        // A stalled main thread drops the whole adb swipe before the page sees
+        // a single pointer event — settle first, then dispatch with bounded,
+        // LOGGED retries whenever zero events were delivered (no silent
+        // retries; the final assertion below is unchanged and strict).
+        await waitForResponsiveMainThread(page);
+        const maxDragAttempts = 3;
+        for (let attempt = 1; attempt <= maxDragAttempts; attempt++) {
+          writeStage("dispatch-horizontal-touch", {
+            attempt,
+            beforePage,
+            serial,
+          });
+          await androidTouchDrag(
+            page,
+            adb,
+            serial,
+            '[data-testid="chat-sheet-grabber"]',
+            -150,
+            -6,
+          );
+          const delivered = await page
+            .waitForFunction(
+              () => (window.__elizaTouchGestureEvents?.length ?? 0) > 0,
+              undefined,
+              { timeout: 8_000 },
+            )
+            .then(() => true)
+            .catch(() => false);
+          if (delivered) break;
+          writeStage("retry-dispatch-no-events-delivered", {
+            attempt,
+            serial,
+          });
+          await waitForResponsiveMainThread(page, { timeoutMs: 30_000 });
+        }
 
         writeStage("assert-launcher", { beforePage, serial });
         await expect

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -401,6 +401,61 @@ describe("ContinuousChatOverlay", () => {
     expect(sheet.getAttribute("data-variant")).toBe("closed");
   });
 
+  it("routes a grabber flick whose moves were coalesced into the release to the launcher (#9943)", () => {
+    // REAL touch on a janked Android WebView delivers pointerdown → pointerup
+    // with the whole travel between them (every pointermove coalesced away).
+    // The swipe must still commit from the release deltas.
+    render(<ContinuousChatOverlay controller={makeController()} />);
+    const sheet = screen.getByTestId("chat-sheet");
+    const grabber = screen.getByTestId("chat-sheet-grabber");
+
+    expect(getShellSurface().page).toBe("home");
+
+    fireEvent.pointerDown(grabber, {
+      clientX: 260,
+      clientY: 420,
+      pointerId: 1,
+    });
+    fireEvent.pointerUp(grabber, {
+      clientX: 110,
+      clientY: 414,
+      pointerId: 1,
+    });
+
+    expect(getShellSurface().page).toBe("launcher");
+    expect(sheet.getAttribute("data-variant")).toBe("closed");
+  });
+
+  it("routes a grabber flick that ends in pointercancel after crossing the threshold to the launcher (#9943)", () => {
+    // Android's touch pipeline can revoke the pointer AFTER the finger already
+    // completed the swipe (renderer-unresponsive ack timeout) — the observed
+    // track must commit instead of being discarded.
+    render(<ContinuousChatOverlay controller={makeController()} />);
+    const sheet = screen.getByTestId("chat-sheet");
+    const grabber = screen.getByTestId("chat-sheet-grabber");
+
+    expect(getShellSurface().page).toBe("home");
+
+    fireEvent.pointerDown(grabber, {
+      clientX: 260,
+      clientY: 420,
+      pointerId: 1,
+    });
+    fireEvent.pointerMove(grabber, {
+      clientX: 110,
+      clientY: 414,
+      pointerId: 1,
+    });
+    fireEvent.pointerCancel(grabber, {
+      clientX: 0,
+      clientY: 0,
+      pointerId: 1,
+    });
+
+    expect(getShellSurface().page).toBe("launcher");
+    expect(sheet.getAttribute("data-variant")).toBe("closed");
+  });
+
   // Regression guard for #9142: the grabber bar was hardcoded `opacity-0`
   // unconditionally, so on desktop/web (no OS home indicator) the handle was
   // grabbable but the bar never painted. It must be visible off-iOS.

--- a/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
@@ -28,6 +28,7 @@ import { build } from "esbuild";
 import { chromium } from "playwright";
 import {
   touchDragHold,
+  touchSwipe,
   touchTap,
 } from "../../../testing/real-touch-gestures.ts";
 
@@ -480,6 +481,136 @@ try {
   await mobile.waitForSelector('[data-testid="chat-sheet"]');
   await mobile.waitForTimeout(700);
   await runDragSuite(mobile, "touch", "mobile");
+
+  // ===== GRABBER horizontal flick → launcher intent, REAL touch (#9943) =====
+  // The collapsed grabber's horizontal swipe pages home → launcher through the
+  // shell-surface store (goLauncher). Android's on-device spec drives this with
+  // a real finger; drive it here through Chromium's REAL touch pipeline
+  // (Input.dispatchTouchEvent, hit-test + touch-action + implicit capture), and
+  // ALSO under a janked main thread (fire-and-forget dispatch → the renderer
+  // coalesces the moves), the failure shape of the Davey!-janked WebView.
+  {
+    const surfacePage = (p) =>
+      p.evaluate(
+        () =>
+          globalThis[Symbol.for("elizaos.ui.shell-surface-store")]?.state
+            ?.page ?? "home",
+      );
+    const resetSurface = (p) =>
+      p.evaluate(() => {
+        const s = globalThis[Symbol.for("elizaos.ui.shell-surface-store")];
+        if (s) {
+          s.state = { ...s.state, page: "home" };
+          for (const l of s.listeners) l();
+        }
+      });
+    const grabberSel = '[data-testid="chat-sheet-grabber"]';
+
+    const p = await browser.newPage({
+      viewport: { width: 402, height: 874 },
+      hasTouch: true,
+      isMobile: true,
+      deviceScaleFactor: 2,
+    });
+    attachConsole(p, sink);
+    await p.goto(url);
+    await p.waitForSelector(grabberSel);
+    await p.waitForTimeout(700);
+
+    // 1. Plain real-touch flick (adb-like: 150px left over ~280ms).
+    assert(
+      (await surfacePage(p)) === "home",
+      "[grabber-swipe] starts on the home surface",
+    );
+    await touchSwipe(p, grabberSel, -150, -6, { steps: 14, stepDelayMs: 20 });
+    await p.waitForTimeout(400);
+    assert(
+      (await surfacePage(p)) === "launcher",
+      "[grabber-swipe] REAL-touch left flick on the grabber commits goLauncher (#9943)",
+    );
+    await snap(p, "grabber-real-touch-launcher");
+
+    // 2. Real-touch flick with the main thread JANKED: dispatch the whole
+    // sequence fire-and-forget so the renderer coalesces the moves (this is
+    // what a 700ms+ frame on the Android WebView does to a 280ms finger swipe).
+    await resetSurface(p);
+    const box = await p.locator(grabberSel).first().boundingBox();
+    const cx = box.x + box.width / 2;
+    const cy = box.y + box.height / 2;
+    const cdp = await p.context().newCDPSession(p);
+    const touchPoint = (x, y) => [
+      { x, y, id: 1, radiusX: 4, radiusY: 4, force: 1 },
+    ];
+    const busy = p
+      .evaluate((ms) => {
+        const end = performance.now() + ms;
+        while (performance.now() < end) {
+          // burn the main thread across the whole swipe
+        }
+      }, 1200)
+      .catch(() => {});
+    await p.waitForTimeout(80); // let the busy loop engage
+    const sends = [
+      cdp.send("Input.dispatchTouchEvent", {
+        type: "touchStart",
+        touchPoints: touchPoint(cx, cy),
+      }),
+    ];
+    for (let i = 1; i <= 14; i += 1) {
+      sends.push(
+        cdp.send("Input.dispatchTouchEvent", {
+          type: "touchMove",
+          touchPoints: touchPoint(cx - (150 * i) / 14, cy - (6 * i) / 14),
+        }),
+      );
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    sends.push(
+      cdp.send("Input.dispatchTouchEvent", {
+        type: "touchEnd",
+        touchPoints: [],
+      }),
+    );
+    await Promise.allSettled(sends);
+    await busy;
+    await p.waitForTimeout(600);
+    assert(
+      (await surfacePage(p)) === "launcher",
+      "[grabber-swipe] real-touch flick still commits with the main thread janked / moves coalesced (#9943)",
+    );
+    await cdp.detach().catch(() => {});
+
+    // 3. Synthetic PointerEvent path (jsdom-style dispatch) stays green.
+    await resetSurface(p);
+    await p.evaluate((sel) => {
+      const g = document.querySelector(sel);
+      const r = g.getBoundingClientRect();
+      const cx0 = r.x + r.width / 2;
+      const cy0 = r.y + r.height / 2;
+      const fire = (type, x, y) =>
+        g.dispatchEvent(
+          new PointerEvent(type, {
+            bubbles: true,
+            cancelable: true,
+            pointerId: 7,
+            pointerType: "touch",
+            isPrimary: true,
+            clientX: x,
+            clientY: y,
+          }),
+        );
+      fire("pointerdown", cx0, cy0);
+      fire("pointermove", cx0 - 75, cy0 - 3);
+      fire("pointermove", cx0 - 150, cy0 - 6);
+      fire("pointerup", cx0 - 150, cy0 - 6);
+    }, grabberSel);
+    await p.waitForTimeout(400);
+    assert(
+      (await surfacePage(p)) === "launcher",
+      "[grabber-swipe] synthetic PointerEvent flick still commits (parity)",
+    );
+    await p.close();
+  }
 
   // ===== CONTROLS + INPUT STATES (mobile viewport for the tactile surface) =====
   const ctrl = async () =>

--- a/packages/ui/src/components/shell/use-pull-gesture.test.ts
+++ b/packages/ui/src/components/shell/use-pull-gesture.test.ts
@@ -90,6 +90,7 @@ describe("usePullGesture rAF coalescing (#9141)", () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
   it("collapses many pointermoves in a frame into ONE onDrag with the last value", () => {
@@ -233,6 +234,171 @@ describe("usePullGesture rAF coalescing (#9141)", () => {
     expect(onDragReset).toHaveBeenCalled();
     expect(onCancel).toHaveBeenCalledTimes(1);
     expect(onPullUp).not.toHaveBeenCalled();
+  });
+
+  it("commits a horizontal flick whose moves were ALL coalesced into the release (#9943)", () => {
+    // REAL touch on a busy device (Android WebView main thread janked): the
+    // browser coalesces every intermediate pointermove into the release, so the
+    // handler sees pointerdown → pointerup with the full travel between them
+    // and the axis never committed mid-gesture. The release deltas alone must
+    // resolve the swipe — the vertical path already works this way.
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((cb: FrameRequestCallback) => {
+        cb(0);
+        return 1;
+      }),
+    );
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+    let t = 0;
+    vi.spyOn(performance, "now").mockImplementation(() => t);
+
+    const onSwipeLeft = vi.fn();
+    const onSettleFree = vi.fn();
+    const onPullUp = vi.fn();
+    const onTap = vi.fn();
+    const { result } = renderHook(() =>
+      usePullGesture({
+        onDrag: vi.fn(),
+        onDragReset: vi.fn(),
+        onPullUp,
+        onPullDown: vi.fn(),
+        onSettleFree,
+        onSwipeLeft,
+        onSwipeRight: vi.fn(),
+        onTap,
+      }),
+    );
+    const b = result.current;
+
+    t = 0;
+    b.onPointerDown(pointer(300, 300));
+    t = 280; // adb-like 280ms flick; NO pointermove was delivered
+    b.onPointerUp(pointer(150, 294));
+
+    expect(onSwipeLeft).toHaveBeenCalledTimes(1);
+    expect(onSettleFree).not.toHaveBeenCalled();
+    expect(onPullUp).not.toHaveBeenCalled();
+    expect(onTap).not.toHaveBeenCalled();
+  });
+
+  it("commits a horizontal flick that ends in pointercancel after crossing the threshold (#9943)", () => {
+    // Android's touch pipeline can revoke the pointer (`pointercancel`) AFTER
+    // the finger already completed the swipe — renderer-unresponsive ack
+    // timeout / OS takeover — even under `touch-action: none`. A track that
+    // already crossed the horizontal swipe threshold must commit, not vanish.
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((cb: FrameRequestCallback) => {
+        cb(0);
+        return 1;
+      }),
+    );
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+    let t = 0;
+    vi.spyOn(performance, "now").mockImplementation(() => t);
+
+    const onSwipeLeft = vi.fn();
+    const onCancel = vi.fn();
+    const { result } = renderHook(() =>
+      usePullGesture({
+        onDrag: vi.fn(),
+        onDragReset: vi.fn(),
+        onPullUp: vi.fn(),
+        onSettleFree: vi.fn(),
+        onSwipeLeft,
+        onSwipeRight: vi.fn(),
+        onCancel,
+      }),
+    );
+    const b = result.current;
+
+    t = 0;
+    b.onPointerDown(pointer(300, 300));
+    t = 100;
+    b.onPointerMove(pointer(210, 298));
+    t = 200;
+    b.onPointerMove(pointer(150, 296));
+    t = 250;
+    b.onPointerCancel(pointer(150, 296));
+
+    expect(onSwipeLeft).toHaveBeenCalledTimes(1);
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("still treats a pre-threshold pointercancel as a cancel (#9943)", () => {
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((cb: FrameRequestCallback) => {
+        cb(0);
+        return 1;
+      }),
+    );
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+    let t = 0;
+    vi.spyOn(performance, "now").mockImplementation(() => t);
+
+    const onSwipeLeft = vi.fn();
+    const onCancel = vi.fn();
+    const { result } = renderHook(() =>
+      usePullGesture({
+        onDrag: vi.fn(),
+        onDragReset: vi.fn(),
+        onSwipeLeft,
+        onSwipeRight: vi.fn(),
+        onCancel,
+      }),
+    );
+    const b = result.current;
+
+    t = 0;
+    b.onPointerDown(pointer(300, 300));
+    t = 500; // slow 40px drift: under both distance (64) and velocity (0.4)
+    b.onPointerMove(pointer(260, 298));
+    t = 520;
+    b.onPointerCancel(pointer(260, 298));
+
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("never swipe-commits a cancel after the gesture committed to the VERTICAL axis (#9943)", () => {
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((cb: FrameRequestCallback) => {
+        cb(0);
+        return 1;
+      }),
+    );
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+    let t = 0;
+    vi.spyOn(performance, "now").mockImplementation(() => t);
+
+    const onSwipeLeft = vi.fn();
+    const onCancel = vi.fn();
+    const { result } = renderHook(() =>
+      usePullGesture({
+        onDrag: vi.fn(),
+        onDragReset: vi.fn(),
+        onPullUp: vi.fn(),
+        onSwipeLeft,
+        onSwipeRight: vi.fn(),
+        onCancel,
+      }),
+    );
+    const b = result.current;
+
+    t = 0;
+    b.onPointerDown(pointer(300, 300));
+    t = 50;
+    b.onPointerMove(pointer(298, 280)); // dy=20 dominates → commits to y
+    t = 150;
+    b.onPointerMove(pointer(180, 270)); // finger drifts far left afterwards
+    t = 200;
+    b.onPointerCancel(pointer(180, 270));
+
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+    expect(onCancel).toHaveBeenCalledTimes(1);
   });
 
   it("ignores moves and releases from a different pointer id", () => {

--- a/packages/ui/src/components/shell/use-pull-gesture.ts
+++ b/packages/ui/src/components/shell/use-pull-gesture.ts
@@ -157,6 +157,11 @@ export function usePullGesture(
   } | null>(null);
   // Which axis the gesture committed to, once it crossed AXIS_COMMIT_SLOP.
   const axis = React.useRef<"x" | "y" | null>(null);
+  // Last observed pointer position/time while pressed. REAL touch can end a
+  // gesture with `pointercancel` (Android's renderer-unresponsive touch
+  // pipeline, OS takeover) whose event coordinates are not trustworthy, so the
+  // cancel-time commit decision (#9943) reads this tracked position instead.
+  const last = React.useRef<{ x: number; y: number; t: number } | null>(null);
 
   // Coalesce the continuous drag updates to at most one per animation frame.
   // A trackpad/touch panel emits pointermove well above the display refresh
@@ -216,6 +221,7 @@ export function usePullGesture(
         pointerId: event.pointerId,
       };
       axis.current = null;
+      last.current = { x: event.clientX, y: event.clientY, t: start.current.t };
       // Pure horizontal swipe surfaces defer capture until axis commit so native
       // vertical scrolling still works. A vertical pull handle captures
       // immediately even when it also supports horizontal swipes; otherwise a
@@ -235,6 +241,11 @@ export function usePullGesture(
     (event: React.PointerEvent) => {
       const s = start.current;
       if (!s || s.pointerId !== event.pointerId) return;
+      last.current = {
+        x: event.clientX,
+        y: event.clientY,
+        t: performance.now(),
+      };
       const dy = s.y - event.clientY; // up positive
       const dx = s.x - event.clientX; // left positive
 
@@ -292,6 +303,7 @@ export function usePullGesture(
       const committedAxis = axis.current;
       start.current = null;
       axis.current = null;
+      last.current = null;
       if (!s) return;
 
       const deltaUp = s.y - event.clientY; // up positive
@@ -312,8 +324,23 @@ export function usePullGesture(
         return;
       }
 
-      // Horizontal swipe path (only when the gesture committed to the X axis).
-      if (committedAxis === "x") {
+      // Horizontal swipe path. Normally gated on the mid-gesture X-axis commit,
+      // but REAL touch on a busy device (Android WebView with a janked main
+      // thread) can coalesce EVERY intermediate pointermove into the release —
+      // the handler then sees pointerdown → pointerup with the full travel
+      // between them and no committed axis. Derive the axis from the release
+      // deltas with the same dominance rule as the mid-gesture commit so a real
+      // finger flick still commits (#9943); the vertical path below already
+      // resolves from release deltas alone.
+      const releaseAxis =
+        committedAxis ??
+        (hasSwipe && movedX >= AXIS_COMMIT_SLOP && movedX > movedY
+          ? "x"
+          : null);
+      if (releaseAxis === "x") {
+        // The mid-gesture commit (which resets the other axis's visual) never
+        // ran on the derived-axis path — settle the vertical visual now.
+        if (committedAxis === null) onDragReset?.();
         onDragX?.(0); // settle the swipe visual
         const swipe = resolveSwipe(
           deltaLeft,
@@ -345,6 +372,7 @@ export function usePullGesture(
     },
     [
       flushPendingDrag,
+      hasSwipe,
       onDragReset,
       onDragX,
       onPullUp,
@@ -364,14 +392,59 @@ export function usePullGesture(
     (event: React.PointerEvent) => {
       const s = start.current;
       if (!s || s.pointerId !== event.pointerId) return;
+      const committedAxis = axis.current;
+      const l = last.current;
       cancelDrag();
       start.current = null;
       axis.current = null;
+      last.current = null;
+      // Commit-on-cancel (REAL touch, #9943): Android's touch pipeline can
+      // revoke the pointer with `pointercancel` AFTER the finger already
+      // completed the flick — the renderer-unresponsive ack timeout or an OS
+      // takeover, which `touch-action: none` on the handle cannot prevent
+      // (it only stops scroll-takeover cancels). If the track we observed
+      // before the cancel already crossed the horizontal swipe threshold on a
+      // horizontal-dominant, non-vertically-committed gesture, honor the swipe
+      // the user performed instead of silently discarding it. The cancel
+      // event's own coordinates are NOT trustworthy (Chromium may report a
+      // stale/zero position), so this reads only the tracked pointermoves.
+      if (hasSwipe && committedAxis !== "y" && l) {
+        const deltaUp = s.y - l.y; // up positive
+        const deltaLeft = s.x - l.x; // left positive
+        const movedX = Math.abs(deltaLeft);
+        if (movedX >= AXIS_COMMIT_SLOP && movedX > Math.abs(deltaUp)) {
+          const elapsed = Math.max(1, l.t - s.t);
+          const swipe = resolveSwipe(
+            deltaLeft,
+            deltaLeft / elapsed,
+            deltaUp,
+            distanceThresholdX,
+            velocityThresholdX,
+          );
+          if (swipe) {
+            onDragReset?.();
+            onDragX?.(0);
+            if (swipe === "left") onSwipeLeft?.();
+            else onSwipeRight?.();
+            return;
+          }
+        }
+      }
       onDragReset?.();
       onDragX?.(0);
       onCancel?.();
     },
-    [cancelDrag, onDragReset, onDragX, onCancel],
+    [
+      cancelDrag,
+      hasSwipe,
+      onDragReset,
+      onDragX,
+      onSwipeLeft,
+      onSwipeRight,
+      onCancel,
+      distanceThresholdX,
+      velocityThresholdX,
+    ],
   );
 
   // Cancel any in-flight coalesced frame if the consumer unmounts mid-gesture.


### PR DESCRIPTION
## Summary

Root cause + fix for the long-standing **'flick does not commit' gap under real touch** — the on-device chat-grabber swipe spec (`touch-gesture.android.spec.ts`) red, and the redness the #10766 audit documented as deferred on the web harness.

**Mechanism** (instrumented, evidence in the commit): the horizontal swipe commit in `use-pull-gesture.ts` was hard-gated on a *mid-gesture* axis commit that only `onPointerMove` can set, and `cancel()` discarded gestures unconditionally — while the vertical path resolves from release deltas alone. A janked Android WebView (700–2800 ms main-thread stalls across the swipe window, per the failing run's logcat) ends the sequence without a usable pre-release move in two ways: **coalesced-into-release** (`pointerdown → pointerup` carrying the full travel, no committed axis → fell into the vertical settle branch) and **cancel-after-flick** (renderer-unresponsive ack timeout / OS takeover fires `pointercancel` after the finger crossed the threshold — `touch-action: none` can't stop these). Only horizontal flicks died; identical vertical flicks committed.

**Fix (no thresholds loosened):** `finish()` derives the axis from release deltas with the same dominance rule when no mid-gesture commit happened (symmetric with the vertical path); `cancel()` honors a horizontal swipe whose *tracked* moves already crossed the threshold on a horizontal-dominant, non-vertically-committed track (cancel-event coords are untrustworthy). Vertical semantics unchanged.

## Evidence
- 4 new unit tests (2 red pre-fix, 2 guard rails); 2 overlay-level tests driving the real grabber to `page: "launcher"` under both endings.
- New `[grabber-swipe]` e2e section in `run-chat-sheet-e2e.mjs`: real CDP-touch flick → launcher, the same flick under a 1200 ms main-thread jank with fire-and-forget dispatch (coalesced moves), synthetic parity.
- `use-pull-gesture` 21/21 · `ContinuousChatOverlay` 108/108 · fuzz 126/126 · chat-sheet / chatux / conversation-swipe runners ALL PASSED · typecheck clean.
- On-device re-verification on the Pixel-7 emulator is running now; result will be posted on this PR.

Refs #9943, #10722.

🤖 Generated with [Claude Code](https://claude.com/claude-code)