### PR TITLE
fix(agent): refresh media store dir cache

### DIFF
--- a/packages/agent/src/api/media-store.test.ts
+++ b/packages/agent/src/api/media-store.test.ts
@@ -86,6 +86,33 @@ describe("media-store", () => {
     expect(fs.existsSync(path.join(stateDir, "media", a.fileName))).toBe(true);
   });
 
+  it("recovers when the resolved state dir changes or the media dir is removed", () => {
+    const first = persistMediaBytes(Buffer.from("first-state"), "image/png");
+    fs.rmSync(path.join(stateDir, "media"), { recursive: true, force: true });
+
+    const second = persistMediaBytes(
+      Buffer.from("first-state-after-delete"),
+      "image/png",
+    );
+    expect(fs.existsSync(mediaPath(second.fileName))).toBe(true);
+    expect(fs.existsSync(mediaPath(first.fileName))).toBe(false);
+
+    const originalStateDir = stateDir;
+    const nextStateDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "media-store-test-next-"),
+    );
+    process.env.ELIZA_STATE_DIR = nextStateDir;
+    try {
+      const third = persistMediaBytes(Buffer.from("next-state"), "image/png");
+      expect(
+        fs.existsSync(path.join(nextStateDir, "media", third.fileName)),
+      ).toBe(true);
+    } finally {
+      process.env.ELIZA_STATE_DIR = originalStateDir;
+      fs.rmSync(nextStateDir, { recursive: true, force: true });
+    }
+  });
+
   it("deduplicates identical bytes (same hash + URL)", () => {
     const bytes = Buffer.from("identical-content");
     const a = persistMediaBytes(bytes, "image/jpeg");

--- a/packages/agent/src/api/media-store.ts
+++ b/packages/agent/src/api/media-store.ts
@@ -171,11 +171,12 @@ function mediaSecurityHeaders(
 let cachedMediaDir: string | null = null;
 
 function mediaDir(): string {
-  if (cachedMediaDir) return cachedMediaDir;
   const dir = path.join(resolveStateDir(), "media");
-  fs.mkdirSync(dir, { recursive: true });
-  cachedMediaDir = dir;
-  return dir;
+  if (cachedMediaDir !== dir) {
+    cachedMediaDir = dir;
+  }
+  fs.mkdirSync(cachedMediaDir, { recursive: true });
+  return cachedMediaDir;
 }
 
 function extForMime(mimeType: string): string {


### PR DESCRIPTION
## Summary
- refresh the media-store directory cache when the resolved state directory changes
- recreate the cached media directory if it was removed by test cleanup or external state cleanup
- add a regression covering deleted media dirs and ELIZA_STATE_DIR changes

## Review context
This is a follow-up to #11060, which merged while review was still running. During review I found that `background-routes.test.ts` could import `media-store.ts`, delete its temp state dir in `afterAll`, and leave `media-store.test.ts` writing into a stale cached directory when both tests run in the same process.

## Evidence
- `bun test packages/agent/src/api/background-routes.test.ts packages/agent/src/api/media-store.test.ts` — 36 passed
- `bunx biome check packages/agent/src/api/media-store.ts packages/agent/src/api/media-store.test.ts` — passed
- `bun run --cwd packages/agent typecheck` — passed
- #11060 UI review: `bun run --cwd packages/app audit:app` — 349 passed; broken=0 needs-work=0

## N/A
- Frontend screenshots/video: N/A — follow-up changes only touch agent media-store server/test behavior.
- Real-LLM trajectories: N/A — no agent/action/prompt/model behavior changes.
- Backend/frontend logs: N/A — regression is covered by deterministic local tests.
