### PR TITLE
fix(cloud): add agent_quota_exceeded to ApiErrorCode — develop Worker typecheck is red, blocking all Worker deploys

### DIFF
--- a/packages/cloud/shared/src/lib/api/cloud-worker-errors.ts
+++ b/packages/cloud/shared/src/lib/api/cloud-worker-errors.ts
@@ -16,6 +16,7 @@ export type ApiErrorCode =
   | "access_denied"
   | "resource_not_found"
   | "rate_limit_exceeded"
+  | "agent_quota_exceeded"
   | "validation_error"
   | "insufficient_credits"
   | "session_not_ready"


### PR DESCRIPTION
### Problem
`d13cb3158d` (#11042, the forceCreate fleet-DoS quota cap) throws `ApiError(429, "agent_quota_exceeded", …)` at `packages/cloud/api/v1/eliza/agents/route.ts:432` but never added the code to the `ApiErrorCode` union in `packages/cloud/shared/src/lib/api/cloud-worker-errors.ts`. Result on current develop:

```
v1/eliza/agents/route.ts(432,31): error TS2345: Argument of type '"agent_quota_exceeded"'
  is not assignable to parameter of type 'ApiErrorCode | undefined'.
```

That typecheck is the **'Verify Worker' hard gate in cloud-cf-deploy** — every staging/production Worker deploy fails at it until this lands (discovered while executing the local prod-refresh fallback during the #10839 outage).

### Fix
One line: add `"agent_quota_exceeded"` to the union. Type-only — zero runtime delta (the route already throws it; the union is erased at build).

### Evidence
- Before: `bun run --cwd packages/cloud/api typecheck` exits 1 with the error above on develop tip.
- After: exits 0 (verified on the deploy worktree at the same tip with exactly this change).
- N/A — screenshots/logs/trajectories: one-line type-union addition with no behavior change; the typecheck transcript above is the entire observable surface.