### PR TITLE
fix(cloud): green two develop reds left by #11042 (per-org agent cap)

### DIFF
--- a/packages/cloud/api/__tests__/eliza-agents-orphan-cleanup.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-orphan-cleanup.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { AgentQuotaExceededError } from "@/lib/services/eliza-sandbox";
 
 /**
  * Regression test for the orphaned-`pending` sandbox bug.
@@ -70,6 +71,10 @@ mock.module("@/lib/services/eliza-managed-launch", () => ({
 }));
 
 mock.module("@/lib/services/eliza-sandbox", () => ({
+  // route.ts imports AgentQuotaExceededError at module top level; the whole
+  // module is replaced here, so it must be re-exported or the import is
+  // undefined and route.ts fails to load (#11042).
+  AgentQuotaExceededError,
   elizaSandboxService: {
     createAgent,
     updateAgentEnvironment,

--- a/packages/cloud/shared/src/lib/api/cloud-worker-errors.ts
+++ b/packages/cloud/shared/src/lib/api/cloud-worker-errors.ts
@@ -19,6 +19,7 @@ export type ApiErrorCode =
   | "validation_error"
   | "insufficient_credits"
   | "session_not_ready"
+  | "agent_quota_exceeded"
   | "internal_error";
 
 export interface ApiErrorOptions {


### PR DESCRIPTION
**Develop is red** from the admin-merge of #11042. Two gate breaks, both fixed:

1. **Typecheck (TS2345):** `v1/eliza/agents/route.ts:432` throws `new ApiError(429, "agent_quota_exceeded", …)` but the code was never added to the `ApiErrorCode` union in `cloud-worker-errors.ts`. Added the member.
2. **Test load failure:** `eliza-agents-orphan-cleanup.test.ts` `mock.module`s the entire `@/lib/services/eliza-sandbox`, but `route.ts` imports `AgentQuotaExceededError` from it at module top level; the mock omitted that export → `Export named 'AgentQuotaExceededError' not found` → route.ts can't load. Re-export it from the mock.

The #11042 fix itself is architecturally sound (per-org cap under the same `pg_advisory_xact_lock` as the reuse guard) — this only greens the two gates it shipped broken. `packages/cloud/api` typecheck exit 0; orphan-cleanup 5/5, create-idempotency 8/8 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)