### PR TITLE
test(lifeops): green the develop red left by #11041 (stale {ok:false}→fired assertion)

### DIFF
--- a/plugins/plugin-personal-assistant/test/lifeops-scheduled-task-simulation.test.ts
+++ b/plugins/plugin-personal-assistant/test/lifeops-scheduled-task-simulation.test.ts
@@ -102,7 +102,11 @@ describe("LifeOps scheduled-task simulation harness", () => {
     });
     const fired = await h.firePrimitive(triage);
 
-    expect(fired.state.status).toBe("fired");
+    // #11041 (#10721 H2): a typed {ok:false} dispatch is now recorded as
+    // "failed", NOT "fired" — recording a failed connector send as "fired" was
+    // silent message loss that the retry/backoff policy could never see. The
+    // typed DispatchResult is still preserved on metadata as the domain artifact.
+    expect(fired.state.status).toBe("failed");
     expect(fired.metadata?.lastDispatchResult).toEqual({
       ok: false,
       reason: "auth_expired",


### PR DESCRIPTION
**Develop is red** from #11041's admin-merge: it correctly changed a typed `{ok:false}` dispatch to record status `"failed"` (not `"fired"` — the silent-message-loss bug #10721 H2), but left a pre-existing simulation test asserting the OLD contract. `lifeops-scheduled-task-simulation.test.ts > "preserves typed DispatchResult failures as domain artifacts"` → `expected 'failed' to be 'fired'`.

Updated the assertion to the new (correct) contract; the `metadata.lastDispatchResult` artifact assertion is unchanged. The test now pins #11041's fix — it would go red if reverted. 4/4 green. (The #11041 production change itself is correct and untouched.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)