### PR TITLE
test(orchestrator): keyless e2e of app-creation via a deterministic fake ACP agent

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/fixtures/fake-acp-agent.mjs
+++ b/plugins/plugin-agent-orchestrator/__tests__/fixtures/fake-acp-agent.mjs
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+/**
+ * Deterministic FAKE ACP coding agent — replays the "ideal" Claude-Code / Codex
+ * ACP session for a given app-build scenario, with NO LLM. Speaks the same
+ * newline-delimited JSON-RPC over stdio that NativeAcpClient drives:
+ *   ← initialize            → { protocolVersion, agentCapabilities, agentInfo }
+ *   ← session/new           → { sessionId }
+ *   ← session/prompt        → (server emits session/update notifications +
+ *                              fs/write_text_file REQUESTS the orchestrator
+ *                              executes, then) { stopReason: "end_turn" }
+ *
+ * Scenario is chosen by FAKE_ACP_SCENARIO (default "random-color"). Because the
+ * orchestrator performs the real fs writes, the workspace genuinely gets the
+ * app files and the whole spawn→prompt→tool→complete→verify→done flow runs
+ * deterministically for keyless e2e.
+ */
+import { createInterface } from "node:readline";
+
+const SCENARIO = process.env.FAKE_ACP_SCENARIO || "random-color";
+const PROTOCOL_VERSION = 1;
+
+// Each scenario: the files the "agent" writes + the completion evidence it
+// reports (a real diff + real-looking test-runner output, internally consistent
+// — the shape the grilling verifier accepts).
+const SCENARIOS = {
+  "random-color": {
+    plan: ["Create index.html", "Add the random-color script", "Verify it renders"],
+    files: [
+      {
+        path: "index.html",
+        content: `<!doctype html><html><head><meta charset="utf-8"><title>Random Color</title></head>
+<body><button id="go">New color</button>
+<script src="./app.js"></script></body></html>\n`,
+      },
+      {
+        path: "app.js",
+        content: `function randomColor(){return '#'+Math.floor(Math.random()*0xffffff).toString(16).padStart(6,'0');}
+document.getElementById('go').addEventListener('click',()=>{document.body.style.background=randomColor();});
+export { randomColor };\n`,
+      },
+      {
+        path: "app.test.js",
+        content: `import { describe, it, expect } from "vitest";
+import { randomColor } from "./app.js";
+describe("randomColor", () => {
+  it("returns a #rrggbb hex string", () => expect(randomColor()).toMatch(/^#[0-9a-f]{6}$/));
+  it("is deterministic in shape across calls", () => { for (let i=0;i<5;i++) expect(randomColor()).toMatch(/^#[0-9a-f]{6}$/); });
+});\n`,
+      },
+    ],
+    completion: `Done — built a random-color web app.
+
+\`\`\`diff
+diff --git a/index.html b/index.html
+new file mode 100644
+diff --git a/app.js b/app.js
+new file mode 100644
+diff --git a/app.test.js b/app.test.js
+new file mode 100644
+\`\`\`
+
+\`\`\`
+$ npm test
+
+ RUN  v4.1.5
+ ✓ app.test.js (2 tests) 12ms
+
+ Test Files  1 passed (1)
+      Tests  2 passed (2)
+\`\`\`
+`,
+  },
+  "todo-list": {
+    plan: ["Create the todo model", "Add add/remove", "Test it"],
+    files: [
+      {
+        path: "todo.js",
+        content: `export function createTodos(){const items=[];return{add:t=>{items.push({t,done:false});return items.length;},remove:i=>items.splice(i,1),all:()=>items.slice()};}\n`,
+      },
+      {
+        path: "todo.test.js",
+        content: `import { describe, it, expect } from "vitest";
+import { createTodos } from "./todo.js";
+describe("todos", () => {
+  it("adds and lists", () => { const t=createTodos(); t.add("a"); t.add("b"); expect(t.all().length).toBe(2); });
+  it("removes", () => { const t=createTodos(); t.add("a"); t.remove(0); expect(t.all().length).toBe(0); });
+  it("marks shape", () => { const t=createTodos(); t.add("x"); expect(t.all()[0]).toEqual({t:"x",done:false}); });
+});\n`,
+      },
+    ],
+    completion: `Done — implemented an in-memory todo list.
+
+\`\`\`diff
+diff --git a/todo.js b/todo.js
+new file mode 100644
+diff --git a/todo.test.js b/todo.test.js
+new file mode 100644
+\`\`\`
+
+\`\`\`
+$ npm test
+ Test Files  1 passed (1)
+      Tests  3 passed (3)
+\`\`\`
+`,
+  },
+};
+
+const scenario = SCENARIOS[SCENARIO] ?? SCENARIOS["random-color"];
+
+const out = process.stdout;
+function send(obj) {
+  out.write(`${JSON.stringify(obj)}\n`);
+}
+function notify(method, params) {
+  send({ jsonrpc: "2.0", method, params });
+}
+function update(sessionId, update) {
+  notify("session/update", { sessionId, update });
+}
+
+// Outgoing REQUESTS to the client (fs/write_text_file) need a reply; track them.
+let nextReqId = 1;
+const pendingClientReplies = new Map();
+function requestClient(method, params) {
+  const id = `fa-${nextReqId++}`;
+  return new Promise((resolve) => {
+    pendingClientReplies.set(id, resolve);
+    send({ jsonrpc: "2.0", id, method, params });
+  });
+}
+
+let sessionCounter = 0;
+
+async function handlePrompt(sessionId) {
+  update(sessionId, { sessionUpdate: "session_started" });
+  update(sessionId, {
+    sessionUpdate: "plan",
+    entries: scenario.plan.map((content, i) => ({
+      content,
+      status: i === 0 ? "in_progress" : "pending",
+      priority: "medium",
+    })),
+  });
+  for (const file of scenario.files) {
+    update(sessionId, {
+      sessionUpdate: "tool_call",
+      toolCall: { title: `Write ${file.path}`, kind: "edit", status: "in_progress" },
+    });
+    // The orchestrator performs the real write into the workspace.
+    await requestClient("fs/write_text_file", {
+      sessionId,
+      path: file.path,
+      content: file.content,
+    });
+    update(sessionId, {
+      sessionUpdate: "tool_call",
+      toolCall: { title: `Write ${file.path}`, kind: "edit", status: "completed" },
+    });
+  }
+  update(sessionId, {
+    sessionUpdate: "agent_message_chunk",
+    content: { type: "text", text: scenario.completion },
+  });
+}
+
+const rl = createInterface({ input: process.stdin });
+rl.on("line", async (line) => {
+  const trimmed = line.trim();
+  if (!trimmed) return;
+  let msg;
+  try {
+    msg = JSON.parse(trimmed);
+  } catch {
+    return;
+  }
+  // A reply to one of our fs/write_text_file requests.
+  if (msg.id !== undefined && (msg.result !== undefined || msg.error !== undefined) && pendingClientReplies.has(msg.id)) {
+    const resolve = pendingClientReplies.get(msg.id);
+    pendingClientReplies.delete(msg.id);
+    resolve(msg.result);
+    return;
+  }
+  const { id, method, params } = msg;
+  if (method === "initialize") {
+    send({
+      jsonrpc: "2.0",
+      id,
+      result: {
+        protocolVersion: PROTOCOL_VERSION,
+        agentCapabilities: { promptCapabilities: { image: false } },
+        agentInfo: { name: "fake-acp-agent", version: "1.0.0" },
+      },
+    });
+  } else if (method === "session/new") {
+    const sessionId = `fake-session-${++sessionCounter}`;
+    send({ jsonrpc: "2.0", id, result: { sessionId } });
+  } else if (method === "session/prompt") {
+    const sessionId = params?.sessionId ?? `fake-session-${sessionCounter}`;
+    await handlePrompt(sessionId);
+    send({ jsonrpc: "2.0", id, result: { stopReason: "end_turn" } });
+  } else if (method === "session/cancel" || method === "session/close") {
+    if (id !== undefined) send({ jsonrpc: "2.0", id, result: {} });
+  } else if (id !== undefined) {
+    // Unknown request: reply empty so the client doesn't hang.
+    send({ jsonrpc: "2.0", id, result: {} });
+  }
+});

--- a/plugins/plugin-agent-orchestrator/src/__tests__/keyless-app-creation.e2e.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/keyless-app-creation.e2e.test.ts
@@ -1,0 +1,103 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AcpService } from "../services/acp-service.js";
+
+/**
+ * KEYLESS end-to-end of app-creation-through-orchestration — NO LLM.
+ *
+ * The real {@link AcpService} spawns a deterministic FAKE ACP coding agent
+ * (`__tests__/fixtures/fake-acp-agent.mjs`) that replays the "ideal"
+ * Claude-Code/Codex session over the real ACP JSON-RPC protocol: it emits a
+ * plan + tool-call updates and issues `fs/write_text_file` requests that the
+ * ORCHESTRATOR executes into the workspace, then returns `end_turn` with a
+ * consistent diff + test-runner completion. This proves the whole
+ * spawn → prompt → tool → file-write → task_complete pipeline deterministically,
+ * so app-creation orchestration is CI-testable without a live model.
+ */
+const FAKE_AGENT = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "__tests__",
+  "fixtures",
+  "fake-acp-agent.mjs",
+);
+
+function makeRuntime(): IAgentRuntime {
+  return {
+    agentId: "00000000-0000-4000-8000-0000keyless01",
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+    getSetting: (k: string) => {
+      if (k === "ELIZA_ACP_TRANSPORT") return "native";
+      if (k === "ELIZA_ACP_DEFAULT_AGENT") return "elizaos";
+      if (k === "ELIZA_ACP_NO_TERMINAL") return "true";
+      if (k === "ELIZA_ELIZAOS_ACP_COMMAND") return `node ${FAKE_AGENT}`;
+      return process.env[k as keyof typeof process.env] as string | undefined;
+    },
+  } as never;
+}
+
+function gitInit(dir: string): void {
+  execFileSync("git", ["init", "-q"], { cwd: dir });
+  execFileSync("git", ["config", "user.email", "e2e@test.local"], { cwd: dir });
+  execFileSync("git", ["config", "user.name", "e2e"], { cwd: dir });
+}
+
+describe("keyless app-creation e2e (fake ACP agent, no LLM)", () => {
+  let workdir: string;
+  let service: AcpService;
+  let sessionId: string | undefined;
+
+  beforeEach(() => {
+    workdir = mkdtempSync(join(tmpdir(), "keyless-app-e2e-"));
+    gitInit(workdir);
+    service = new AcpService(makeRuntime());
+  });
+  afterEach(async () => {
+    if (sessionId) await service.closeSession(sessionId).catch(() => {});
+    await service.stop().catch(() => {});
+    rmSync(workdir, { recursive: true, force: true });
+    sessionId = undefined;
+  });
+
+  it("spawns the agent, which builds a random-color app the orchestrator writes to disk, ending in task_complete", async () => {
+    const events: string[] = [];
+    service.onSessionEvent((_sid, name) => events.push(name));
+    await service.start();
+
+    const spawned = await service.spawnSession({
+      agentType: "elizaos",
+      workdir,
+      approvalPreset: "permissive",
+      timeoutMs: 60_000,
+    });
+    sessionId = spawned.sessionId;
+
+    const result = await service.sendPrompt(
+      sessionId,
+      "Build a random-color web app with a button and a test",
+      { timeoutMs: 60_000 },
+    );
+
+    // The orchestrator executed the agent's fs/write_text_file requests.
+    expect(existsSync(join(workdir, "index.html"))).toBe(true);
+    expect(existsSync(join(workdir, "app.js"))).toBe(true);
+    expect(existsSync(join(workdir, "app.test.js"))).toBe(true);
+    expect(readFileSync(join(workdir, "app.js"), "utf8")).toContain(
+      "randomColor",
+    );
+
+    // The full orchestration event stream fired, ending in task_complete.
+    expect(events).toContain("plan");
+    expect(events).toContain("tool_running");
+    expect(events).toContain("task_complete");
+    expect(result.stopReason).toBe("end_turn");
+    // The completion carries real, consistent evidence (diff + runner output).
+    expect(String(result.finalText)).toMatch(/Tests\s+2 passed/);
+  }, 90_000);
+});


### PR DESCRIPTION
## Summary

Captures the "ideal" Claude-Code/Codex ACP session as a **deterministic fake agent**, enabling a **keyless, no-LLM end-to-end test of the whole app-creation-through-orchestration pipeline**.

`__tests__/fixtures/fake-acp-agent.mjs` speaks the real ACP JSON-RPC protocol over stdio exactly as `NativeAcpClient` drives it:
- `initialize` / `session/new`
- on `session/prompt`: emits `session_started`, a `plan`, `tool_call` updates, and issues **`fs/write_text_file` requests that the orchestrator executes into the workspace**, then returns `{stopReason: "end_turn"}` with an internally-consistent diff + test-runner completion.

Scenario-selectable (`random-color` / `todo-list`) via `FAKE_ACP_SCENARIO`.

## The e2e (un-gated vitest — runs in CI, no key)

Drives the **real `AcpService`**: `spawn → prompt →` the agent builds a random-color web app `→` the orchestrator writes `index.html`/`app.js`/`app.test.js` to the workspace `→` the full event stream `ready → plan → tool_running → message → task_complete` fires, ending in `end_turn`.

```
event stream: ready → plan → tool_running×6 → message → task_complete
workspace files: index.html ✓ app.js ✓ app.test.js ✓   (5 git entries)
stopReason: end_turn   task_complete: 1   runner output: ✓
Test Files 1 passed (1)   Tests 1 passed (1)
```

## Why

The live-LLM path is covered by the gated gemma-4-31b tests (#11006, #11039). This gives the app-creation flow a **deterministic** twin that always runs in CI — so a regression in the spawn/tool/write/complete pipeline is caught without a model, and the fake agent is the foundation for a full multi-task lifecycle e2e + a recorded UI walkthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)