### PR TITLE
test(cockpit): regression tests for the #11040 terminal-crash fixes

### DIFF
--- a/packages/examples/code/src/components/narrow-terminal.test.ts
+++ b/packages/examples/code/src/components/narrow-terminal.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { AgentRuntime } from "@elizaos/core";
+import { TUI, visibleWidth } from "@elizaos/tui";
+import { VirtualTerminal } from "@elizaos/tui/testing";
+import { useStore } from "../lib/store.js";
+import { ChatPane } from "./ChatPane.js";
+import { MainScreen } from "./MainScreen.js";
+import { StatusBar } from "./StatusBar.js";
+import { TaskPane } from "./TaskPane.js";
+
+// Regression for #11040 / #10830: the cockpit xterm is ~43 cols. At that
+// width the eliza-code TUI used to abort every frame — the composer row
+// exceeded the terminal width (editor rendered at innerWidth, then wrapped in
+// "│ > … │" chrome → width + 1) and the 47-col help footer overflowed too.
+// The TUI's final render guard throws when any line's visible width exceeds
+// the terminal width (see packages/tui/src/tui.ts: `visibleWidth(line) >
+// width`), so an overflow is a hard crash, not a cosmetic glitch.
+//
+// The fix has two seams and this suite bites both:
+//   * ChatPane renders the editor at innerWidth - 3 so the composer row fits.
+//   * MainScreen clips every assembled line via truncateToWidth so fixed-width
+//     chrome (the 47-col footer) can never overflow.
+
+const PHONE_COLS = 43;
+
+function makeScreen(cols: number) {
+  const terminal = new VirtualTerminal(cols, 24);
+  const tui = new TUI(terminal);
+  const chatPane = new ChatPane({ onSubmit: async () => {}, tui });
+  const statusBar = new StatusBar();
+  // TaskPane is not rendered on the default (chat-focused) path; it only needs
+  // to satisfy MainScreen's `syncFocus` call, so a runtime is never touched.
+  const taskPane = new TaskPane({
+    runtime: {} as unknown as AgentRuntime,
+    tui,
+  });
+  const mainScreen = new MainScreen(terminal, statusBar, chatPane, taskPane);
+  return { chatPane, mainScreen };
+}
+
+// Keep the shared zustand store deterministic across tests.
+afterEach(() => {
+  useStore.getState().setInputValue("");
+});
+
+describe("eliza-code TUI at cockpit phone width", () => {
+  test("MainScreen never emits a line wider than the terminal (would crash the TUI)", () => {
+    const { chatPane, mainScreen } = makeScreen(PHONE_COLS);
+    // Chat focused → the full 47-col help footer renders (the fixed-width
+    // overflow the clip seam guards). Add a long message so the message area
+    // has real content too.
+    chatPane.syncFocus(true);
+    const state = useStore.getState();
+    state.addMessage(
+      state.currentRoomId,
+      "system",
+      "Booting eliza-code interactive session on Eliza Cloud and attaching to the cockpit terminal.",
+    );
+    state.setInputValue(
+      "please refactor the extremely long identifier names in this module now",
+    );
+
+    let lines: string[] = [];
+    expect(() => {
+      lines = mainScreen.render(PHONE_COLS);
+    }).not.toThrow();
+
+    expect(lines.length).toBeGreaterThan(0);
+    for (const line of lines) {
+      // Exactly the invariant the TUI render guard enforces before it throws.
+      expect(visibleWidth(line)).toBeLessThanOrEqual(PHONE_COLS);
+    }
+  });
+
+  test.each([
+    39, 43, 47, 60,
+  ])("MainScreen output fits within %i columns", (cols) => {
+    const { chatPane, mainScreen } = makeScreen(cols);
+    chatPane.syncFocus(true);
+    const lines = mainScreen.render(cols);
+    const widest = Math.max(...lines.map(visibleWidth));
+    expect(widest).toBeLessThanOrEqual(cols);
+  });
+
+  test("ChatPane composer row fits inside the terminal width", () => {
+    const { chatPane } = makeScreen(PHONE_COLS);
+    chatPane.syncFocus(true);
+    const lines = chatPane.renderContent(PHONE_COLS, 24);
+
+    // The composer row is the line directly under the editor's top border.
+    // Match glyphs directly (they survive the surrounding SGR color codes) so
+    // no control-character ANSI-stripping regex is needed.
+    const topBorderIdx = lines.findIndex((l) => l.includes("┌"));
+    expect(topBorderIdx).toBeGreaterThanOrEqual(0);
+    const composer = lines[topBorderIdx + 1];
+    expect(composer).toContain(">");
+
+    // Without the innerWidth - 3 fix this row is width + 1 (44) and the TUI
+    // aborts; with the fix it is width - 2 (41).
+    expect(visibleWidth(composer)).toBeLessThanOrEqual(PHONE_COLS);
+  });
+});

--- a/packages/scripts/__tests__/view-bundle-single-chunk.test.ts
+++ b/packages/scripts/__tests__/view-bundle-single-chunk.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import { createViewBundleConfig } from "../view-bundle-vite.config.ts";
+
+// The two rolldown output fields this config controls. Typed narrowly instead
+// of importing rolldown's `OutputOptions` (rolldown is not a resolvable
+// dependency in this worktree).
+type ViewBundleOutput = {
+  codeSplitting?: boolean;
+  exports?: string;
+};
+
+// Regression for #11040 / #10830: the cockpit terminal pane rendered blank
+// because a plugin view bundle was code-split. Rolldown emitted a lazy chunk
+// that re-imported "./bundle.js" WITHOUT the ?hostExternalRuntime query the
+// shell's DynamicViewLoader loaded the entry with. The browser then fetched
+// the raw bundle as a second module whose bare externals ("@elizaos/ui",
+// "react") could not resolve — killing the whole lazy graph, including
+// PtyTerminalPane's xterm import.
+//
+// The fix is `output.codeSplitting: false` in the shared view-bundle Vite
+// config, so every view is one self-contained bundle.js. This suite asserts
+// that seam directly. (A full build assertion would need rolldown, which is
+// not installed in this worktree — the property is the single source of truth
+// the build consumes.)
+
+function outputOf(
+  opts?: Parameters<typeof createViewBundleConfig>[0],
+): ViewBundleOutput {
+  const cfg = createViewBundleConfig(
+    opts ?? {
+      packageName: "@elizaos/plugin-example",
+      viewId: "example-view",
+      entry: "./src/views/example-view-bundle.ts",
+    },
+  );
+  const output = cfg.build?.rollupOptions?.output;
+  expect(output).toBeDefined();
+  expect(Array.isArray(output)).toBe(false);
+  return output as ViewBundleOutput;
+}
+
+describe("view-bundle Vite config: single self-contained bundle", () => {
+  test("disables code splitting so no lazy chunk re-imports ./bundle.js", () => {
+    const output = outputOf();
+    // Must be explicitly false — `undefined` lets rolldown fall back to
+    // code-splitting, which reintroduces the blank-terminal bug.
+    expect(output.codeSplitting).toBe(false);
+  });
+
+  test("emits exactly one ES module named bundle.js with named exports", () => {
+    const cfg = createViewBundleConfig({
+      packageName: "@elizaos/plugin-example",
+      viewId: "example-view",
+      entry: "./src/views/example-view-bundle.ts",
+    });
+    const lib = cfg.build?.lib as {
+      formats?: string[];
+      fileName?: (format: string, entryName: string) => string;
+    };
+    expect(lib?.formats).toEqual(["es"]);
+    expect(typeof lib?.fileName).toBe("function");
+    expect(lib?.fileName?.("es", "example")).toBe("bundle.js");
+    expect(outputOf().exports).toBe("named");
+  });
+
+  test("keeps code splitting off regardless of caller options", () => {
+    for (const additionalExternals of [[], ["three"], ["@elizaos/plugin-x"]]) {
+      const output = outputOf({
+        packageName: "@elizaos/plugin-x",
+        viewId: "x",
+        entry: "./src/x.ts",
+        outDir: "dist/custom",
+        componentExport: "XView",
+        additionalExternals,
+      });
+      expect(output.codeSplitting).toBe(false);
+    }
+  });
+});

--- a/plugins/plugin-pty/test/pty-routes.test.ts
+++ b/plugins/plugin-pty/test/pty-routes.test.ts
@@ -448,3 +448,96 @@ describe("GET + DELETE /api/pty/sessions", () => {
     expect(res.status).toBe(400);
   });
 });
+
+// Regression edges for #11040 / #10830. The truthy-allowlist and both-tier
+// model pins are covered above; these lock the remaining branches of the
+// fail-closed `interactiveEnabled` gate and prove the two model env fallbacks
+// (`?? PTY_ELIZA_CLOUD_FAST_MODEL` / `?? PTY_ELIZA_CLOUD_SMART_MODEL`) are
+// independent — a bug that swaps or collapses them would still spawn, so only
+// the resolved model env can catch it.
+describe("PTY interactive gate + model fallbacks (regression edges)", () => {
+  it("defaults to enabled when the flag is unset or empty", async () => {
+    for (const settings of [
+      { PTY_ELIZA_CLOUD_API_KEY: "sk" }, // flag absent
+      { PTY_ELIZA_CLOUD_API_KEY: "sk", PTY_INTERACTIVE_ENABLED: "" },
+      { PTY_ELIZA_CLOUD_API_KEY: "sk", PTY_INTERACTIVE_ENABLED: "   " },
+    ]) {
+      const h = makeHarness({ settings });
+      const res = await routeByName("pty-spawn-session")(
+        ctx(h.runtime, { cwd: process.cwd() }),
+      );
+      expect(res.status, JSON.stringify(settings)).toBe(200);
+      expect(h.calls, JSON.stringify(settings)).toHaveLength(1);
+    }
+  });
+
+  it("normalizes case + surrounding whitespace before the truthy allowlist", async () => {
+    for (const value of [" TrUe ", "\tON\n", " 1 ", "  yEs  "]) {
+      const h = makeHarness({
+        settings: {
+          PTY_ELIZA_CLOUD_API_KEY: "sk",
+          PTY_INTERACTIVE_ENABLED: value,
+        },
+      });
+      const res = await routeByName("pty-spawn-session")(
+        ctx(h.runtime, { cwd: process.cwd() }),
+      );
+      expect(res.status, JSON.stringify(value)).toBe(200);
+      expect(h.calls, JSON.stringify(value)).toHaveLength(1);
+    }
+  });
+
+  it("fails closed on a truthy-looking but unrecognized flag", async () => {
+    // A plausible operator typo that is NOT in the allowlist must disable
+    // spawning rather than silently leave it on.
+    for (const value of [" enabled ", "yep", "2", "y"]) {
+      const h = makeHarness({
+        settings: {
+          PTY_ELIZA_CLOUD_API_KEY: "sk",
+          PTY_INTERACTIVE_ENABLED: value,
+        },
+      });
+      const res = await routeByName("pty-spawn-session")(
+        ctx(h.runtime, { cwd: process.cwd() }),
+      );
+      expect(res.status, JSON.stringify(value)).toBe(403);
+      expect(h.calls, JSON.stringify(value)).toHaveLength(0);
+    }
+  });
+
+  it("applies the FAST tier env fallback without touching the SMART default", async () => {
+    const h = makeHarness({
+      settings: {
+        PTY_ELIZA_CLOUD_API_KEY: "sk",
+        PTY_ELIZA_CLOUD_FAST_MODEL: "fast-only",
+      },
+    });
+    const res = await routeByName("pty-spawn-session")(
+      ctx(h.runtime, { cwd: process.cwd() }),
+    );
+    expect(res.status).toBe(200);
+    const env = h.calls[0].opts.env;
+    expect(env?.OPENAI_SMALL_MODEL).toBe("fast-only");
+    expect(env?.OPENAI_MEDIUM_MODEL).toBe("fast-only");
+    // SMART unset → the cerebras default, not the FAST pin.
+    expect(env?.OPENAI_LARGE_MODEL).toBe("gemma-4-31b");
+  });
+
+  it("applies the SMART tier env fallback without touching the FAST default", async () => {
+    const h = makeHarness({
+      settings: {
+        PTY_ELIZA_CLOUD_API_KEY: "sk",
+        PTY_ELIZA_CLOUD_SMART_MODEL: "smart-only",
+      },
+    });
+    const res = await routeByName("pty-spawn-session")(
+      ctx(h.runtime, { cwd: process.cwd() }),
+    );
+    expect(res.status).toBe(200);
+    const env = h.calls[0].opts.env;
+    // FAST unset → the cerebras default, not the SMART pin.
+    expect(env?.OPENAI_SMALL_MODEL).toBe("gemma-4-31b");
+    expect(env?.OPENAI_MEDIUM_MODEL).toBe("gemma-4-31b");
+    expect(env?.OPENAI_LARGE_MODEL).toBe("smart-only");
+  });
+});


### PR DESCRIPTION
Follow-up to **#11043** (merged as `0777843a13`, by @NubsCarson), which fixed three hard-crash root causes behind #11040 / #10830 but merged with **no regression tests for two of the three crashes**. This PR is test-only — it adds/extends coverage so a revert of any of the three source fixes turns a test red. No source changes.

Each test was confirmed to **bite**: I temporarily reverted each fix in a scratch worktree and watched the corresponding test fail, then restored.

### 1. TUI narrow-width crash — `packages/examples/code/src/components/narrow-terminal.test.ts` (new, bun:test)
The cockpit xterm is ~43 cols. At that width the eliza-code TUI aborted every frame: the composer row exceeded the terminal width and the 47-col help footer overflowed. The TUI's final render guard *throws* when any line's visible width exceeds the terminal width, so this is a hard crash.
- Builds the real `MainScreen` + `ChatPane` over a `VirtualTerminal` and asserts no rendered line exceeds the terminal width across 39/43/47/60 cols — exactly the invariant the render guard enforces.
- A focused case asserts the `ChatPane` composer row fits.
- **Bite:** revert `MainScreen` `truncateToWidth` clip → 47-col footer overflows (fails at 39/43); revert `ChatPane` `innerWidth - 3` → composer row is width+1 (44 > 43, fails).

### 2. view-bundle single chunk — `packages/scripts/__tests__/view-bundle-single-chunk.test.ts` (new, bun:test)
A code-split view bundle emitted a lazy chunk that re-imported `./bundle.js` without the `?hostExternalRuntime` query, so the browser refetched the raw bundle and its bare externals failed to resolve — leaving the terminal pane blank.
- Asserts the shared view-bundle Vite config sets rolldown `output.codeSplitting: false` (must be explicitly `false`, not `undefined`), emits a single `es` `bundle.js`, and uses named exports.
- **Bite:** delete the `codeSplitting: false` line → assertion fails (`undefined`). (A full build assertion needs rolldown, which isn't installed in-worktree; the config property is the single source of truth the build consumes.)

### 3. pty interactive gate + model fallbacks — `plugins/plugin-pty/test/pty-routes.test.ts` (extended, vitest)
The truthy-allowlist and both-tier model pins were already covered by @lalalune's `6986a09b27f` (merged). This adds the remaining edges:
- Fail-closed gate: unset/empty/whitespace → default-on; `trim`+`lowercase` normalization on the enable path; a truthy-*looking* but unrecognized flag (`" enabled "`, `"yep"`, `"2"`, `"y"`) fails **closed**.
- The `PTY_ELIZA_CLOUD_FAST_MODEL` / `PTY_ELIZA_CLOUD_SMART_MODEL` `??` env fallbacks are **independent** (only-FAST-pinned leaves SMART at the cerebras default, and vice-versa).
- **Bite:** revert the gate to case-sensitive fail-open → fail-closed test fails; drop `.trim().toLowerCase()` → normalization test fails; remove either model `??` → the matching independence test fails.

### Results
- `bun test packages/examples/code/src/components/narrow-terminal.test.ts` → 6 pass
- `bun test packages/scripts/__tests__/view-bundle-single-chunk.test.ts` → 3 pass
- `bunx vitest run plugins/plugin-pty/test/pty-routes.test.ts` → 29 pass
- `biome check` clean on all three files.

Credit to @NubsCarson for the fixes in #11043.

🤖 Generated with [Claude Code](https://claude.com/claude-code)