### PR TITLE
fix(orchestrator): policy-merge security + app-build misclassify + usage-state default (audit-3)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acceptance-criteria.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acceptance-criteria.test.ts
@@ -39,6 +39,10 @@ describe("detectTaskType", () => {
       "coding",
     );
     expect(detectTaskType("refactor the auth module")).toBe("coding");
+    // A bare "app"/"application" is coding, NOT an app-build — it must not pull
+    // in the app-build-only "the live URL returns HTTP 200" criterion.
+    expect(detectTaskType("refactor the app's state store")).toBe("coding");
+    expect(detectTaskType("fix the application startup crash")).toBe("coding");
   });
 
   it("classifies view-create goals", () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-policy.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-policy.test.ts
@@ -1,0 +1,51 @@
+import type { IAgentRuntime, Memory } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { requireTaskAgentAccess } from "../../src/services/task-policy.js";
+
+/**
+ * A partial TASK_AGENT_ROLE_POLICY override (e.g. only tightening slack) must
+ * MERGE over the built-in defaults, not replace them — otherwise the built-in
+ * Discord ADMIN gate is silently dropped and Discord falls through to the GUEST
+ * default, opening task-agent create/interact to anyone.
+ */
+function runtimeWith(policy: unknown): IAgentRuntime {
+  return {
+    agentId: "00000000-0000-4000-8000-00000000pol1",
+    getSetting: (k: string) =>
+      k === "TASK_AGENT_ROLE_POLICY"
+        ? typeof policy === "string"
+          ? policy
+          : JSON.stringify(policy)
+        : undefined,
+    getRoom: async () => undefined,
+    getParticipantUserState: async () => null,
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+  } as never;
+}
+
+const discordMessage = {
+  entityId: "user-x",
+  roomId: "00000000-0000-4000-8000-00000000room",
+  content: { source: "discord" },
+} as unknown as Memory;
+
+describe("requireTaskAgentAccess — policy merge", () => {
+  it("keeps the built-in Discord ADMIN gate when only another connector is overridden", async () => {
+    const result = await requireTaskAgentAccess(
+      runtimeWith({ connectors: { slack: "ADMIN" } }),
+      discordMessage,
+      "create",
+    );
+    // Discord still requires ADMIN despite the slack-only override.
+    expect(result.requiredRole).toBe("ADMIN");
+  });
+
+  it("still requires Discord ADMIN under the default policy (no override)", async () => {
+    const result = await requireTaskAgentAccess(
+      runtimeWith(undefined),
+      discordMessage,
+      "interact",
+    );
+    expect(result.requiredRole).toBe("ADMIN");
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/acceptance-criteria.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acceptance-criteria.ts
@@ -105,8 +105,12 @@ const VIEW_RE =
   /\b(view|views|viewkind|widget|dashboard\s+(?:card|panel|tile)|render\s+a\s+view)\b/i;
 const DEPLOY_RE =
   /\b(deploy|deployment|release\s+to\s+prod|ship\s+to\s+prod|production\s+rollout|provision\s+infra|autoscal\w*|hetzner|cloudflare\s+worker|publish\s+the\s+(?:site|app))\b/i;
+// Deliberately does NOT match a bare "app"/"application": "refactor the app" or
+// "fix the application startup" is coding, not an app-BUILD. Only web-app /
+// site / landing-page phrasing (or an explicit build/create-a-…-app) qualifies,
+// which is what gates the app-build-only "the live URL returns HTTP 200" criterion.
 const APP_BUILD_RE =
-  /\b(app|application|website|web\s*site|landing\s+page|web\s+app|webapp|frontend\s+app|build\s+a\s+(?:site|page|app)|create\s+a\s+(?:site|page|app))\b/i;
+  /\b(website|web\s*site|landing\s+page|web\s+app|webapp|frontend\s+app|build\s+a\s+(?:site|page|app)|create\s+a\s+(?:site|page|app))\b/i;
 
 /**
  * Classify a task from its goal text. Defaults to `coding` — the safest

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -523,8 +523,14 @@ function parseUsage(data: unknown): ParsedUsage | null {
     return null;
   }
   const stateRaw = str(data.state);
+  // Unknown/absent precision → "estimated" (the conservative label), not
+  // "measured": the UsageState union exists so an operator is never misled by a
+  // confident-looking number, so we must not stamp provider-inferred tokens as
+  // ground-truth measured just because the producer omitted `state`.
   const state: UsageState =
-    stateRaw === "measured" || stateRaw === "estimated" ? stateRaw : "measured";
+    stateRaw === "measured" || stateRaw === "estimated"
+      ? stateRaw
+      : "estimated";
   return {
     provider: str(data.provider) ?? "unknown",
     model: str(data.model),

--- a/plugins/plugin-agent-orchestrator/src/services/task-policy.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-policy.ts
@@ -96,7 +96,7 @@ function parseTaskAgentPolicy(runtime: IAgentRuntime): TaskAgentPolicyConfig {
   }
 
   const record = parsed as Record<string, unknown>;
-  const connectors =
+  const parsedConnectors =
     record.connectors &&
     typeof record.connectors === "object" &&
     !Array.isArray(record.connectors)
@@ -108,7 +108,12 @@ function parseTaskAgentPolicy(runtime: IAgentRuntime): TaskAgentPolicyConfig {
             ],
           ),
         )
-      : DEFAULT_POLICY.connectors;
+      : {};
+  // MERGE over the built-in defaults, don't replace them: a partial override
+  // (e.g. only `{"slack":"ADMIN"}`) must not silently drop the built-in Discord
+  // ADMIN gate and fall through to the GUEST default — that would open
+  // task-agent create/interact in Discord to anyone.
+  const connectors = { ...DEFAULT_POLICY.connectors, ...parsedConnectors };
 
   return {
     default: normalizeConnectorPolicy(


### PR DESCRIPTION
Three confirmed findings from a fresh full-codebase audit of the orchestrator (post the 10 merged round-1/2 fixes):

### 1. Security — policy override dropped the Discord ADMIN gate
`parseTaskAgentPolicy` **replaced** the built-in `connectors` defaults with any supplied override. A partial `TASK_AGENT_ROLE_POLICY` (e.g. only `{"connectors":{"slack":"ADMIN"}}`) silently dropped the built-in `discord: {create: ADMIN, interact: ADMIN}` gate → Discord fell through to the `GUEST` default → task-agent create/interact open to anyone. Now merges: `{...DEFAULT_POLICY.connectors, ...parsed}`.

### 2. Text-eval — bare "app" misclassified as app-build
`APP_BUILD_RE` matched a bare `app`/`application`, so **"refactor the app"** / **"fix the application startup"** were classified as an app-**build** and pulled in the app-build-only *"the live URL returns HTTP 200"* acceptance criterion. Tightened to web-app / site / landing-page phrasing (or an explicit build/create-a-…-app).

### 3. Fallback-masking — unknown usage precision stamped as "measured"
`parseUsage` defaulted an absent/unknown `state` to `"measured"` (the authoritative label), defeating the `UsageState` union's whole purpose. Now defaults to `"estimated"`; explicit values unchanged.

## Tests
- new `task-policy.test.ts`: Discord still requires ADMIN after a partial slack-only override, and under the default policy.
- `acceptance-criteria`: bare `app`/`application` → `coding`.
- 67 existing usage/service tests green (all use explicit `state` — unaffected).

```
Test Files  4 passed   Tests  86 passed
```

Remaining audit findings (store concurrency, recordUsage dedup race, SQL findSession scan, acp-service availability LARP, tasks.ts dead-code/hardcode) are catalogued in #11028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)