### PR TITLE
fix(elizacloud): auto-send X-App-Id from ELIZA_APP_ID for per-app attribution (#10423)

### DIFF
--- a/plugins/plugin-elizacloud/__tests__/app-attribution-header.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/app-attribution-header.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Per-app monetization attribution header (#10423).
+ *
+ * A deployed Eliza Cloud app container has `ELIZA_APP_ID` injected by the deploy
+ * path. Every inference the agent sends to Eliza Cloud must then carry the
+ * `X-App-Id` header so the charge lands on the APP's credits + creator earnings,
+ * not the caller's own org. `createCloudApiClient` wires this from the runtime
+ * setting into the SDK's `defaultHeaders`, so it rides on ALL model paths
+ * (chat/responses/embeddings/images) without each one re-plumbing it.
+ *
+ * Absent `ELIZA_APP_ID`, no header is sent (a normal local agent bills its own
+ * org). The cloud independently authorizes the header and soft-falls-back to
+ * caller billing for an unauthorized id, so this is attribution, not a trust
+ * boundary — but the agent must actually SEND it, which is what this pins.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createCloudApiClient } from "../src/utils/sdk-client";
+
+function makeRuntime(settings: Record<string, string | undefined>): IAgentRuntime {
+  return {
+    getSetting: (key: string) => settings[key],
+  } as unknown as IAgentRuntime;
+}
+
+/** Install a fetch stub that records the outgoing request and returns 200 JSON. */
+function captureFetch(): { calls: Request[] } {
+  const calls: Request[] = [];
+  const stub = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push(new Request(input as RequestInfo, init));
+    return new Response("{}", {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  });
+  globalThis.fetch = stub as unknown as typeof fetch;
+  return { calls };
+}
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+const BASE = {
+  ELIZAOS_CLOUD_API_KEY: "eliza_test_key",
+  ELIZAOS_CLOUD_BASE_URL: "https://elizacloud.ai/api/v1",
+};
+
+describe("app attribution header (#10423)", () => {
+  it("sends X-App-Id from ELIZA_APP_ID on every cloud request", async () => {
+    const { calls } = captureFetch();
+    const runtime = makeRuntime({ ...BASE, ELIZA_APP_ID: "app-uuid-123" });
+
+    await createCloudApiClient(runtime).requestRaw("GET", "/models");
+
+    expect(calls.length).toBe(1);
+    expect(calls[0].headers.get("X-App-Id")).toBe("app-uuid-123");
+    // Auth still rides along — attribution does not displace the caller key.
+    expect(calls[0].headers.get("Authorization")).toContain("eliza_test_key");
+  });
+
+  it("omits X-App-Id entirely when ELIZA_APP_ID is not set (bills the caller org)", async () => {
+    const { calls } = captureFetch();
+    const runtime = makeRuntime({ ...BASE });
+
+    await createCloudApiClient(runtime).requestRaw("GET", "/models");
+
+    expect(calls.length).toBe(1);
+    expect(calls[0].headers.has("X-App-Id")).toBe(false);
+  });
+
+  it("reads ELIZA_APP_ID from runtime settings (not just env)", async () => {
+    const { calls } = captureFetch();
+    // No env involvement: the value comes from the runtime setting reader.
+    const runtime = makeRuntime({ ...BASE, ELIZA_APP_ID: "from-runtime-setting" });
+
+    await createCloudApiClient(runtime, true).requestRaw("GET", "/models");
+
+    expect(calls[0].headers.get("X-App-Id")).toBe("from-runtime-setting");
+  });
+});

--- a/plugins/plugin-elizacloud/src/utils/config.ts
+++ b/plugins/plugin-elizacloud/src/utils/config.ts
@@ -64,6 +64,22 @@ export function getApiKey(runtime: IAgentRuntime): string | undefined {
 }
 
 /**
+ * The Eliza Cloud app this agent's inference should be attributed to (#10423).
+ *
+ * The managed deploy path injects the platform-authoritative `ELIZA_APP_ID`
+ * (the app's UUID) into a deployed app container, so its inference bills the
+ * app's credits + the creator's earnings rather than the caller's own org. When
+ * set, {@link createCloudApiClient} attaches it as the `X-App-Id` header on
+ * every request. The cloud verifies the caller is authorized for the app and
+ * falls back to normal (caller-org) billing when it is not — so a non-app agent
+ * that happens to carry an unrelated `ELIZA_APP_ID` (e.g. the desktop bundle id)
+ * is simply billed normally, never rejected.
+ */
+export function getAppId(runtime: IAgentRuntime): string | undefined {
+  return getSetting(runtime, "ELIZA_APP_ID");
+}
+
+/**
  * Truthiness for host-written cloud flags: "true" or "1" (trimmed,
  * case-insensitive), mirroring how core `isCloudConnected` reads
  * `ELIZAOS_CLOUD_ENABLED`. Runtime boolean `true` arrives here as the

--- a/plugins/plugin-elizacloud/src/utils/sdk-client.ts
+++ b/plugins/plugin-elizacloud/src/utils/sdk-client.ts
@@ -2,6 +2,7 @@ import { CloudApiClient, ElizaCloudClient } from "@elizaos/cloud-sdk";
 import type { IAgentRuntime } from "@elizaos/core";
 import {
   getApiKey,
+  getAppId,
   getBaseURL,
   getEmbeddingApiKey,
   getEmbeddingBaseURL,
@@ -22,12 +23,26 @@ function apiKeyForRuntime(runtime: IAgentRuntime, embedding = false): string | u
   return embedding ? getEmbeddingApiKey(runtime) : getApiKey(runtime);
 }
 
+/**
+ * Per-app attribution header (#10423). When the agent runs as a deployed Eliza
+ * Cloud app (`ELIZA_APP_ID` injected by the deploy path), every request carries
+ * `X-App-Id` so inference bills the app's credits + creator earnings. Absent it,
+ * no header is sent and billing stays with the caller's own org.
+ */
+function appAttributionHeaders(
+  runtime: IAgentRuntime,
+): Record<string, string> | undefined {
+  const appId = getAppId(runtime);
+  return appId ? { "X-App-Id": appId } : undefined;
+}
+
 export function createCloudApiClient(runtime: IAgentRuntime, embedding = false): CloudApiClient {
   const baseUrl = embedding ? getEmbeddingBaseURL(runtime) : getBaseURL(runtime);
   return new ElizaCloudClient({
     apiBaseUrl: trimTrailingSlash(baseUrl),
     baseUrl: apiBaseToSiteBaseUrl(baseUrl),
     apiKey: apiKeyForRuntime(runtime, embedding),
+    defaultHeaders: appAttributionHeaders(runtime),
   }).v1;
 }
 
@@ -37,5 +52,6 @@ export function createElizaCloudClient(runtime: IAgentRuntime): ElizaCloudClient
     apiBaseUrl,
     baseUrl: apiBaseToSiteBaseUrl(apiBaseUrl),
     apiKey: apiKeyForRuntime(runtime),
+    defaultHeaders: appAttributionHeaders(runtime),
   });
 }


### PR DESCRIPTION
Closes the code half of #10423. Product decision confirmed by @shaw: **inject `ELIZA_APP_ID` + auto-send `X-App-Id`**.

## The gap

The managed deploy path already injects the platform-authoritative `ELIZA_APP_ID` into a deployed app container (`app-deploy-orchestrator`, with the caller-supplied value stripped first — both covered by `app-deploy-orchestrator.test.ts`). But **nothing on the agent side read it**, so a deployed app's inference was attributed to nobody — it billed the caller's own org instead of the app's credits + the creator's earnings, which is the entire premise of per-app monetization.

## Fix

`createCloudApiClient` (the one factory every Eliza Cloud model path uses) now reads `ELIZA_APP_ID` (new `getAppId`) and, when present, passes it as the SDK's `defaultHeaders` `X-App-Id`. So it rides on **every** model path — chat / responses / embeddings / images — without each re-plumbing it. Absent the var, no header is sent and billing stays with the caller's org.

**Safe by construction:** the cloud independently authorizes the header (`getAuthorizedMonetizedAppForUser`) and the inference route (`chat/completions`) **soft-falls-back** to caller billing when the id is unauthorized/unknown/monetization-off (`useAppCredits=false`, no reject). So an agent that carries an unrelated `ELIZA_APP_ID` (e.g. the desktop bundle id `ai.elizaos.app`) is simply billed normally — never rejected. Attribution, not a trust boundary.

## Evidence

- `app-attribution-header.test.ts` — **3/3**: `X-App-Id` sent from the setting (auth still rides along), omitted when unset, read from runtime settings (not just env). Mocks `fetch` and asserts the real outgoing headers via `createCloudApiClient(...).requestRaw`.
- Deploy-side injection + caller-env strip already proven by `app-deploy-orchestrator.test.ts` (asserts `ELIZA_APP_ID: req.appId` and that a spoofed caller value is stripped).

The full `deploy → app inference → charge lands on app credits + creator earnings` **staging e2e** remains the Phase-4 live-infra proof (issue point 3) — this PR closes the reachable code gap at both ends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)