### PR TITLE
fix(accounts): probe direct-API keys before keeping them in rotation (#11033 regression)

### DIFF
--- a/packages/agent/src/api/accounts-routes.ts
+++ b/packages/agent/src/api/accounts-routes.ts
@@ -44,6 +44,10 @@ import {
 } from "../auth/account-storage.ts";
 import { getAccessToken } from "../auth/credentials.ts";
 import {
+  directProviderBaseUrl,
+  probeDirectApiKey,
+} from "../auth/direct-api-probe.ts";
+import {
   cancelFlow,
   getFlowState,
   startAnthropicOAuthFlow,
@@ -393,37 +397,6 @@ function asDirectProvider(
     : null;
 }
 
-function directProviderBaseUrl(providerId: DirectAccountProvider): string {
-  switch (providerId) {
-    case "anthropic-api":
-      return (
-        process.env.ANTHROPIC_BASE_URL?.trim() || "https://api.anthropic.com/v1"
-      );
-    case "openai-api":
-      return process.env.OPENAI_BASE_URL?.trim() || "https://api.openai.com/v1";
-    case "deepseek-api":
-      return (
-        process.env.DEEPSEEK_BASE_URL?.trim() || "https://api.deepseek.com"
-      );
-    case "zai-api":
-      return (
-        process.env.ZAI_BASE_URL?.trim() ||
-        process.env.Z_AI_BASE_URL?.trim() ||
-        "https://api.z.ai/api/paas/v4"
-      );
-    case "moonshot-api":
-      return (
-        process.env.MOONSHOT_BASE_URL?.trim() ||
-        process.env.KIMI_BASE_URL?.trim() ||
-        "https://api.moonshot.ai/v1"
-      );
-    case "cerebras-api":
-      return (
-        process.env.CEREBRAS_BASE_URL?.trim() || "https://api.cerebras.ai/v1"
-      );
-  }
-}
-
 function codingPlanProviderBaseUrl(
   providerId: Extract<SubscriptionProvider, "zai-coding" | "kimi-coding">,
 ): string {
@@ -461,60 +434,6 @@ async function probeCodingPlanKey(
         Authorization: `Bearer ${apiKey}`,
       },
     });
-    const latencyMs = Date.now() - start;
-    if (!response.ok) {
-      const text = await response.text().catch(() => "");
-      return {
-        ok: false,
-        status: response.status,
-        error: `${providerId} ${response.status}: ${text.slice(0, 200)}`,
-        latencyMs,
-      };
-    }
-    return { ok: true, status: response.status, latencyMs };
-  } catch (err) {
-    return {
-      ok: false,
-      status: 0,
-      error: err instanceof Error ? err.message : String(err),
-      latencyMs: Date.now() - start,
-    };
-  } finally {
-    clearTimeout(timer);
-  }
-}
-
-async function probeDirectApiKey(
-  providerId: DirectAccountProvider,
-  apiKey: string,
-): Promise<{
-  ok: boolean;
-  status: number;
-  error?: string;
-  latencyMs: number;
-}> {
-  const start = Date.now();
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 10_000);
-  try {
-    const baseUrl = directProviderBaseUrl(providerId).replace(/\/+$/, "");
-    const response =
-      providerId === "anthropic-api"
-        ? await fetch(`${baseUrl}/models?limit=1`, {
-            method: "GET",
-            signal: controller.signal,
-            headers: {
-              "anthropic-version": "2023-06-01",
-              "x-api-key": apiKey,
-            },
-          })
-        : await fetch(`${baseUrl}/models`, {
-            method: "GET",
-            signal: controller.signal,
-            headers: {
-              Authorization: `Bearer ${apiKey}`,
-            },
-          });
     const latencyMs = Date.now() - start;
     if (!response.ok) {
       const text = await response.text().catch(() => "");

--- a/packages/agent/src/auth/direct-api-probe.ts
+++ b/packages/agent/src/auth/direct-api-probe.ts
@@ -1,0 +1,101 @@
+// Direct-API key server-side probe. Extracted from the accounts route
+// (#11033 follow-up) so the coding-account bridge can verify a pooled
+// direct-API credential against the provider — a locally-stored key with the
+// never-expires sentinel resolves fine offline, so a cached-but-revoked key
+// can only be caught by an authed round-trip.
+import type { DirectAccountProvider } from "./types.ts";
+
+/** Provider base URL for a direct-API key, honoring the *_BASE_URL overrides. */
+export function directProviderBaseUrl(
+  providerId: DirectAccountProvider,
+): string {
+  switch (providerId) {
+    case "anthropic-api":
+      return (
+        process.env.ANTHROPIC_BASE_URL?.trim() || "https://api.anthropic.com/v1"
+      );
+    case "openai-api":
+      return process.env.OPENAI_BASE_URL?.trim() || "https://api.openai.com/v1";
+    case "deepseek-api":
+      return (
+        process.env.DEEPSEEK_BASE_URL?.trim() || "https://api.deepseek.com"
+      );
+    case "zai-api":
+      return (
+        process.env.ZAI_BASE_URL?.trim() ||
+        process.env.Z_AI_BASE_URL?.trim() ||
+        "https://api.z.ai/api/paas/v4"
+      );
+    case "moonshot-api":
+      return (
+        process.env.MOONSHOT_BASE_URL?.trim() ||
+        process.env.KIMI_BASE_URL?.trim() ||
+        "https://api.moonshot.ai/v1"
+      );
+    case "cerebras-api":
+      return (
+        process.env.CEREBRAS_BASE_URL?.trim() || "https://api.cerebras.ai/v1"
+      );
+  }
+}
+
+export interface DirectApiProbeResult {
+  ok: boolean;
+  status: number;
+  error?: string;
+  latencyMs: number;
+}
+
+/**
+ * Verify a direct-API key against the provider with a minimal authed GET
+ * (`/models`). `ok` is true only on a 2xx; a 401/403 (revoked/invalid) returns
+ * `ok:false` with the status so the caller can mark the account needs-reauth.
+ */
+export async function probeDirectApiKey(
+  providerId: DirectAccountProvider,
+  apiKey: string,
+): Promise<DirectApiProbeResult> {
+  const start = Date.now();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 10_000);
+  try {
+    const baseUrl = directProviderBaseUrl(providerId).replace(/\/+$/, "");
+    const response =
+      providerId === "anthropic-api"
+        ? await fetch(`${baseUrl}/models?limit=1`, {
+            method: "GET",
+            signal: controller.signal,
+            headers: {
+              "anthropic-version": "2023-06-01",
+              "x-api-key": apiKey,
+            },
+          })
+        : await fetch(`${baseUrl}/models`, {
+            method: "GET",
+            signal: controller.signal,
+            headers: {
+              Authorization: `Bearer ${apiKey}`,
+            },
+          });
+    const latencyMs = Date.now() - start;
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      return {
+        ok: false,
+        status: response.status,
+        error: `${providerId} ${response.status}: ${text.slice(0, 200)}`,
+        latencyMs,
+      };
+    }
+    return { ok: true, status: response.status, latencyMs };
+  } catch (err) {
+    return {
+      ok: false,
+      status: 0,
+      error: err instanceof Error ? err.message : String(err),
+      latencyMs: Date.now() - start,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/packages/agent/src/auth/types.ts
+++ b/packages/agent/src/auth/types.ts
@@ -95,6 +95,15 @@ export function isSubscriptionProvider(
   );
 }
 
+export function isDirectAccountProvider(
+  value: unknown,
+): value is DirectAccountProvider {
+  return (
+    typeof value === "string" &&
+    (DIRECT_ACCOUNT_PROVIDER_IDS as readonly string[]).includes(value)
+  );
+}
+
 export function isOAuthSubscriptionProvider(
   value: unknown,
 ): value is OAuthSubscriptionProvider {

--- a/packages/app-core/src/services/coding-account-bridge.ts
+++ b/packages/app-core/src/services/coding-account-bridge.ts
@@ -35,8 +35,10 @@ import { accountRefreshMutex } from "@elizaos/agent/auth/refresh-mutex";
 import type { DirectAccountProvider } from "@elizaos/agent/auth/types";
 import {
   DIRECT_ACCOUNT_PROVIDER_ENV,
+  isDirectAccountProvider,
   isSubscriptionProvider,
 } from "@elizaos/agent/auth/types";
+import { probeDirectApiKey } from "@elizaos/agent/auth/direct-api-probe";
 import { writeJsonAtomicSync } from "@elizaos/agent/utils/atomic-json";
 import { logger, resolveStateDir } from "@elizaos/core";
 import type {
@@ -473,6 +475,25 @@ function makeBridge(pool: AccountPool): CodingAgentSelectorBridge {
                 ? { codexAccountId: record.organizationId }
                 : {}),
             });
+          } else if (isDirectAccountProvider(providerId)) {
+            // #11033 regression fix: a direct-API key resolves offline from
+            // local storage with a never-expires sentinel, so a successful
+            // `getAccessToken` proves NOTHING — a cached-but-revoked key that
+            // just 401'd a session would otherwise be logged "verified" and
+            // kept in rotation forever (doomed failover respawns). Probe it
+            // against the provider; only a real 2xx keeps it, a 401/403 falls
+            // through to markNeedsReauth. A network/timeout blip (status 0)
+            // is inconclusive → leave rotation state to the keep-alive sweep.
+            const probe = await probeDirectApiKey(providerId, token);
+            if (!probe.ok) {
+              if (probe.status === 401 || probe.status === 403) {
+                return pool.markNeedsReauth(accountId, detail, { providerId });
+              }
+              logger.info(
+                `[coding-account-bridge] ${providerId}/${accountId} auth-failure verify was inconclusive (probe status ${probe.status}${probe.error ? `: ${probe.error}` : ""}) — leaving rotation state to the keep-alive sweep`,
+              );
+              return;
+            }
           }
           logger.info(
             `[coding-account-bridge] ${providerId}/${accountId} reported an auth failure but its credential verifies — keeping it in rotation (injected token likely expired mid-session)${detail ? `: ${detail}` : ""}`,

--- a/packages/app-core/src/services/multi-account-refresh-failover.test.ts
+++ b/packages/app-core/src/services/multi-account-refresh-failover.test.ts
@@ -386,4 +386,91 @@ describe("bridge.markNeedsReauth verifies before evicting", () => {
       "needs-reauth",
     );
   });
+  // #11033 regression: direct-API keys resolve offline from local storage with
+  // a never-expires sentinel, so a successful getAccessToken proves nothing —
+  // a cached-but-revoked key that 401'd a session must be probed against the
+  // provider, not blindly kept in rotation.
+  it("marks a REVOKED direct-API key needs-reauth (probe 401), not kept in rotation", async () => {
+    writeAccount("anthropic-api", "ada-anthropic-api", {
+      access: "sk-ant-revoked",
+      refresh: "",
+      expires: Number.MAX_SAFE_INTEGER,
+    });
+    // The direct-key probe (GET /models) returns 401 → the stored key is dead.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: false,
+        status: 401,
+        text: async () => '{"error":{"type":"authentication_error"}}',
+        json: async () => ({ error: { type: "authentication_error" } }),
+      })),
+    );
+    getDefaultAccountPool();
+    const bridge = getCodingAgentSelectorBridge();
+
+    await bridge?.markNeedsReauth(
+      "anthropic-api",
+      "ada-anthropic-api",
+      "sub-agent session s-2 (claude)",
+    );
+
+    const pool = getDefaultAccountPool();
+    expect(pool.get("ada-anthropic-api", "anthropic-api")?.health).toBe(
+      "needs-reauth",
+    );
+  });
+
+  it("keeps a still-valid direct-API key in rotation (probe 200)", async () => {
+    writeAccount("anthropic-api", "ada-anthropic-api", {
+      access: "sk-ant-good",
+      refresh: "",
+      expires: Number.MAX_SAFE_INTEGER,
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true, status: 200, json: async () => ({}) })),
+    );
+    getDefaultAccountPool();
+    const bridge = getCodingAgentSelectorBridge();
+
+    await bridge?.markNeedsReauth(
+      "anthropic-api",
+      "ada-anthropic-api",
+      "sub-agent session s-2 (claude)",
+    );
+
+    const pool = getDefaultAccountPool();
+    expect(pool.get("ada-anthropic-api", "anthropic-api")?.health).not.toBe(
+      "needs-reauth",
+    );
+  });
+
+  it("leaves a direct-API key alone on an inconclusive probe (network blip, status 0)", async () => {
+    writeAccount("anthropic-api", "ada-anthropic-api", {
+      access: "sk-ant-good",
+      refresh: "",
+      expires: Number.MAX_SAFE_INTEGER,
+    });
+    // A rejected fetch → probeDirectApiKey returns { ok:false, status:0 }.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("ECONNRESET");
+      }),
+    );
+    getDefaultAccountPool();
+    const bridge = getCodingAgentSelectorBridge();
+
+    await bridge?.markNeedsReauth(
+      "anthropic-api",
+      "ada-anthropic-api",
+      "sub-agent session s-2 (claude)",
+    );
+
+    const pool = getDefaultAccountPool();
+    expect(pool.get("ada-anthropic-api", "anthropic-api")?.health).not.toBe(
+      "needs-reauth",
+    );
+  });
 });


### PR DESCRIPTION
Fixes the MAJOR regression the post-merge review of #11033 flagged. #11033's verify-before-evict keeps a pooled coding account in rotation if `getAccessToken` returns a token — but a **direct-API** key (anthropic-api/openai-api/cerebras-api) resolves offline from local storage with the never-expires sentinel, so `isSubscriptionProvider` is false, no server probe runs, and a **revoked** key that just 401'd a sub-agent is logged "credential verifies — keeping it in rotation" and stays `health=ok` forever (doomed failover respawns until the lineage cap). On develop the mark was unconditional → strict regression for direct-API pools.

**Fix:** probe direct-API keys against the provider (`GET /models`) before keeping them. 2xx keeps; 401/403 → `markNeedsReauth`; inconclusive (network blip, status 0) → left to the keep-alive sweep (mirrors the subscription transient-blip path).
- Extracted `probeDirectApiKey` + `directProviderBaseUrl` from `accounts-routes.ts` into shared `@elizaos/agent/auth/direct-api-probe` (route re-imports; behavior unchanged there).
- Added `isDirectAccountProvider` guard.

Tests (real pool + stubbed fetch, no bridge mock): revoked key (401)→needs-reauth, valid (200)→kept, inconclusive (0)→left. **Fail-without-fix proven** (revert bridge → revoked-key test red). 13/13; both packages typecheck exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)