### PR TITLE
test(scenario-runner): skippable-check ratchet + factory-scenario hardening (#9310)

### DIFF
--- a/packages/scenario-runner/src/skippable-check-ratchet.test.ts
+++ b/packages/scenario-runner/src/skippable-check-ratchet.test.ts
@@ -1,21 +1,20 @@
 /**
- * Action-effect ratchet (#9310, systemic theme 3).
+ * Skippable-dependency ratchet (#9310, systemic theme 7).
  *
- * `actionCalled` (even `status:"success"`) only proves the handler RAN and
- * returned success — not that the correct todo/event/draft/state actually
- * resulted. "The LIFE action was called" ≠ "the todo was marked done". A
- * scenario whose ENTIRE `finalChecks` array is `actionCalled` entries proves a
- * call, never an effect, and so cannot fail for the real reason.
+ * A handful of finalChecks return a PASSING `skipped-dependency-missing` when
+ * their capture context is absent (the service that would have recorded the
+ * evidence was never registered), rather than failing. Verified against
+ * `final-checks/index.ts`, exactly two check types do this:
+ *   - `approvalRequestExists`  (skips when `ctx.approvalRequests === undefined`)
+ *   - `pushSent`               (skips when the push capture is undefined)
+ * (`connectorDispatchOccurred` does NOT — it treats a missing capture as empty
+ * and fails, so it is a real effect check and is intentionally excluded here.)
  *
- * The effect-proving finalCheck kinds are the ones that read produced state:
- * `custom` predicates, `memoryWriteOccurred`/`memoryContains`,
- * `connectorDispatchOccurred`, `walletBalance*`, `judgeRubric`, etc. A scenario
- * with at least one of those (or a real per-turn assertion) is fine.
- *
- * Rewriting the backlog is per-scenario work (add an effect finalCheck to each);
- * this guard is a RATCHET like echo-assertion-ratchet: the count may only go
- * DOWN. Adding a new actionCalled-only scenario turns this RED. When you give an
- * actionCalled-only scenario a real effect check, lower BASELINE to match.
+ * A scenario whose ENTIRE `finalChecks` array is those skippable types proves
+ * nothing in an environment where the dependency isn't wired: it silently
+ * passes. Like the echo and action-effect ratchets, this is a guard — the count
+ * may only go DOWN. A scenario needs a non-skippable check (a `custom` predicate,
+ * memory/state read, etc.) alongside so it can actually fail for the real reason.
  */
 
 import { readdirSync, readFileSync, statSync } from "node:fs";
@@ -32,6 +31,9 @@ const SCENARIO_ROOTS = [
   "plugins/plugin-health/test/scenarios",
   "plugins/plugin-agent-orchestrator/test/scenarios",
 ].map((r) => resolve(repoRoot, r));
+
+/** The check types that return a PASSING `skipped-dependency-missing`. */
+const SKIPPABLE = new Set(["approvalRequestExists", "pushSent"]);
 
 function walkScenarioFiles(dir: string): string[] {
   let entries: string[] = [];
@@ -61,10 +63,7 @@ function propName(name: ts.PropertyName): string | undefined {
   return undefined;
 }
 
-/**
- * The `type` string values of every object in the scenario's top-level
- * `finalChecks: [...]` array, in order. Empty if there is no such array.
- */
+/** The `type` strings of the scenario's top-level `finalChecks: [...]` array. */
 function finalCheckTypes(sourceFile: ts.SourceFile): string[] {
   const types: string[] = [];
   let found = false;
@@ -95,10 +94,10 @@ function finalCheckTypes(sourceFile: ts.SourceFile): string[] {
 /**
  * True only for `export default scenario({...})` — a DIRECT scenario whose
  * literal `finalChecks` is the complete set. Factory-built scenarios
- * (`export default buildXScenario({...})`) augment their checks inside the
- * factory (e.g. the connector-certification factory adds `memoryWriteOccurred`
- * + a `custom` predicate), so their file-local `finalChecks` is only a fragment
- * and must NOT be judged statically — else they read as false positives.
+ * (`export default buildXScenario({...})`) have their checks augmented inside
+ * the factory (the connector-certification factory, for example, adds
+ * `memoryWriteOccurred` + a `custom` predicate), so their file-local
+ * `finalChecks` is only a fragment and must NOT be judged statically.
  */
 function isDirectScenarioExport(sourceFile: ts.SourceFile): boolean {
   for (const statement of sourceFile.statements) {
@@ -115,41 +114,38 @@ function isDirectScenarioExport(sourceFile: ts.SourceFile): boolean {
   return false;
 }
 
-/** A scenario whose finalChecks are all `actionCalled` (≥1) proves calls, not effects. */
-function isActionCalledOnly(file: string): boolean {
+function isEntirelySkippable(file: string): boolean {
   const src = readFileSync(file, "utf8");
   const sf = ts.createSourceFile(file, src, ts.ScriptTarget.Latest, true);
   // Only judge scenarios whose complete finalChecks are statically visible.
   if (!isDirectScenarioExport(sf)) return false;
   const types = finalCheckTypes(sf);
   if (types.length === 0) return false;
-  return types.every((t) => t === "actionCalled");
+  return types.every((t) => SKIPPABLE.has(t));
 }
 
 const flagged = SCENARIO_ROOTS.flatMap(walkScenarioFiles)
-  .filter(isActionCalledOnly)
+  .filter(isEntirelySkippable)
   .map((f) => relative(repoRoot, f));
 
-// Current debt (theme 3 of #9310 — down from the 104 the issue reported as the
-// corpus has been de-larped). Lower this as actionCalled-only scenarios are given
-// a real effect finalCheck (custom predicate / memory / connector). Never raise.
-const BASELINE = 60;
+// Current debt (theme 7 of #9310). Lower this as such scenarios gain a
+// non-skippable check that reads produced state. Never raise.
+const BASELINE = 0;
 
-describe("action-effect ratchet (#9310)", () => {
+describe("skippable-check ratchet (#9310)", () => {
   it("finds the scenario corpus (guard is actually scanning)", () => {
     const total = SCENARIO_ROOTS.flatMap(walkScenarioFiles).length;
     expect(total).toBeGreaterThan(400);
   });
 
-  it(`does not grow actionCalled-only scenarios beyond ${BASELINE}`, () => {
+  it(`does not grow entirely-skippable scenarios beyond ${BASELINE}`, () => {
     if (flagged.length > BASELINE) {
-      const overflow = flagged.slice(BASELINE);
       throw new Error(
-        `actionCalled-only scenarios grew to ${flagged.length} (baseline ${BASELINE}). ` +
-          `A finalChecks array that is entirely 'actionCalled' proves the handler ran, ` +
-          `not that it produced the right effect — add a 'custom'/'memoryWriteOccurred'/` +
-          `'connectorDispatchOccurred' check that reads the produced state. New offenders:\n` +
-          overflow.join("\n"),
+        `scenarios whose finalChecks are ALL silently-skippable (${[...SKIPPABLE].join("/")}) ` +
+          `grew to ${flagged.length} (baseline ${BASELINE}). Such a scenario passes ` +
+          `vacuously when the approval/push service isn't registered — add a check that ` +
+          `reads produced state (a 'custom' predicate, memory/DB read). Offenders:\n` +
+          flagged.slice(BASELINE).join("\n"),
       );
     }
     expect(flagged.length).toBeLessThanOrEqual(BASELINE);


### PR DESCRIPTION
Advances #9310 with theme 7 (skipped-dependency-missing silent pass) and hardens the theme-3 ratchet from #11057.

## Theme 7 — skippable-check ratchet (new)

`approvalRequestExists` and `pushSent` return a **passing** `skipped-dependency-missing` when their capture context is absent (the approval/push service was never registered) — verified against `final-checks/index.ts`. A scenario whose **entire** `finalChecks` array is those types passes **vacuously** wherever that dependency isn't wired. (`connectorDispatchOccurred` does *not* skip — it treats a missing capture as empty and fails — so it's a real effect check and is excluded.) New ratchet, **baseline 0**.

## Factory-scenario hardening (fixes a latent false positive in both ratchets)

Both this and the theme-3 `action-effect-ratchet` now only judge **direct** `export default scenario({...})` scenarios — whose literal `finalChecks` is the complete set. Factory-built scenarios (`export default buildXScenario({...})`) augment their checks *inside* the factory: e.g. the connector-certification factory adds `memoryWriteOccurred` + a `custom` predicate. Judging their file-local `finalChecks` fragment statically was a false positive — `connector.twilio-voice.certify-core` reads as `approvalRequestExists`+`pushSent`-only but actually carries real effect checks. Excluding factories drops the theme-7 count to its true **0**.

The theme-3 action-effect true count is **unchanged (60)** — none of its flagged scenarios were factory false positives — so that part is defensive hardening against future regressions, not a baseline change.

## Evidence

- **14/14** across all four anti-larp ratchets (`echo` / `corpus-assertion` / `action-effect` / new `skippable-check`). Test-only, no runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)