### PR TITLE
test(cloud): run the money-path PGlite proof suites for real in CI (kill self-skip-to-green + latent red)

### DIFF
--- a/.github/workflows/cloud-tests.yml
+++ b/.github/workflows/cloud-tests.yml
@@ -75,6 +75,14 @@ jobs:
       - name: Run cloud unit tests
         run: bun run test:cloud
 
+      # The bun `test:cloud` lane skips suites that need the Vitest-only module
+      # mock API (`vi.mock` + `vi.importActual`) — see `SUPPORTS_VITEST_MOCK_API`.
+      # Run those under Vitest here so the direct-wallet payer/state-machine proof
+      # (33 tests, in-process PGlite) actually executes instead of vacuously
+      # skipping. Uses pglite://memory — no DB service required.
+      - name: Run cloud vitest-only suites
+        run: bun run --cwd packages/cloud/shared test:vitest
+
   integration-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 25

--- a/packages/cloud/shared/package.json
+++ b/packages/cloud/shared/package.json
@@ -27,6 +27,7 @@
     "check:tenant-scope:self-test": "bun test scripts/check-tenant-scope.test.ts",
     "verify:tenant-isolation": "bun scripts/verify-tenant-db-isolation.ts",
     "test": "bun test --isolate",
+    "test:vitest": "vitest run",
     "preflight:messaging-gateways": "node scripts/messaging-gateway-preflight.mjs",
     "preflight:messaging-gateways:strict": "node scripts/messaging-gateway-preflight.mjs --strict",
     "db:check-migrations": "drizzle-kit check",

--- a/packages/cloud/shared/src/lib/services/__tests__/ad-inventory.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/ad-inventory.test.ts
@@ -7,15 +7,18 @@
  * the impression id). Also covers eligibility (paused slot, no-budget, and
  * no-self-serve) and click dedup.
  *
- * Self-skips LOUDLY if PGlite/pushSchema is unavailable.
+ * Fails loudly (via the `pgliteReady` guard) if PGlite/pushSchema ever fails to initialize — never a silent skip.
  */
 
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 
-const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
-const CAN_USE_ISOLATED_PGLITE =
-  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
-process.env.DATABASE_URL ||= "pglite://memory";
+// This proof owns its DB: force an isolated in-memory PGlite regardless of the
+// ambient DATABASE_URL / TEST_DATABASE_URL the CI lane exports. resolveDatabaseUrl
+// prefers TEST_DATABASE_URL, so BOTH are pinned — otherwise the suite is steered
+// to a Postgres that isn't up under the unit lane and self-skips to a vacuous
+// green (a money-path proof shipping unproven).
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
 process.env.NODE_ENV ||= "test";
 process.env.MOCK_REDIS = "1";
 
@@ -136,10 +139,6 @@ async function creatorBalance(userId: string): Promise<number> {
 }
 
 beforeAll(async () => {
-  if (!CAN_USE_ISOLATED_PGLITE) {
-    pgliteReady = false;
-    return;
-  }
   try {
     ({ adInventoryService: service } = await import("../ad-inventory"));
     const schema = {

--- a/packages/cloud/shared/src/lib/services/__tests__/app-backup.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-backup.test.ts
@@ -2,16 +2,20 @@
  * App config backup/restore (#10204 "backing up") — real Drizzle schema, PGlite.
  *
  * Exports a secret-free config snapshot of an app and restores it as a NEW app
- * (new slug + new API key) with monetization reapplied. Self-skips LOUDLY if
- * PGlite/pushSchema is unavailable.
+ * (new slug + new API key) with monetization reapplied. Fails loudly (via the
+ * `pgliteReady` guard) if PGlite/pushSchema ever fails to initialize — never a
+ * silent skip.
  */
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 
-const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
-const CAN_USE_ISOLATED_PGLITE =
-  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
-process.env.DATABASE_URL ||= "pglite://memory";
+// This proof owns its DB: force an isolated in-memory PGlite regardless of the
+// ambient DATABASE_URL / TEST_DATABASE_URL the CI lane exports. resolveDatabaseUrl
+// prefers TEST_DATABASE_URL, so BOTH are pinned — otherwise the suite is steered
+// to a Postgres that isn't up under the unit lane and self-skips to a vacuous
+// green (a money-path proof shipping unproven).
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
 process.env.NODE_ENV ||= "test";
 process.env.MOCK_REDIS = "1";
 
@@ -50,10 +54,6 @@ async function seed(): Promise<{ orgId: string; userId: string }> {
 }
 
 beforeAll(async () => {
-  if (!CAN_USE_ISOLATED_PGLITE) {
-    pgliteReady = false;
-    return;
-  }
   try {
     ({ appBackupService } = await import("../app-backup"));
     ({ appsService } = await import("../apps"));

--- a/packages/cloud/shared/src/lib/services/__tests__/app-charge-callback-cross-tenant.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-charge-callback-cross-tenant.test.ts
@@ -17,12 +17,13 @@
  * channel. The only thing stubbed is `memoriesRepository.create` — the
  * downstream sink being gated, NOT the authorization logic under test.
  *
- * Self-skips if PGlite is unavailable (mirrors the sibling billing suites).
+ * Fails loudly (via the `pgliteReady` guard) if PGlite/pushSchema ever fails to initialize — never a silent skip.
  */
 
 import { afterAll, beforeAll, beforeEach, describe, expect, spyOn, test } from "bun:test";
 
-process.env.DATABASE_URL ||= "pglite://memory";
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
 process.env.NODE_ENV ||= "test";
 process.env.MOCK_REDIS ||= "1";
 
@@ -233,4 +234,12 @@ describe("appChargeCallbacksService.dispatch — settlement memory write is gate
     expect(result.roomMessageCreated).toBe(false);
     expect(createSpy).not.toHaveBeenCalled();
   });
+});
+
+// Loud guard: PGlite is in-process (no network), so `pgliteReady` must be true.
+// If pushSchema/PGlite ever fails to init, the DB-dependent tests above
+// early-return; this turns that silent no-op into a hard CI failure so a
+// money-path proof can never masquerade as a vacuous green.
+test("pglite schema applied — never a silent skip", () => {
+  expect(pgliteReady).toBe(true);
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/app-credit-hold-concurrency.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-credit-hold-concurrency.test.ts
@@ -30,15 +30,18 @@
  *      (which the routes surfaced as a 500), and reconcile trues the floor up
  *      to the actual cost in both directions.
  *
- * Self-skips LOUDLY if PGlite/pushSchema is unavailable (never silently passes).
+ * Fails loudly (via the `pgliteReady` guard) if PGlite/pushSchema ever fails to initialize — never a silent skip.
  */
 
 import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
 
-const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
-const CAN_USE_ISOLATED_PGLITE =
-  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
-process.env.DATABASE_URL ||= "pglite://memory";
+// This proof owns its DB: force an isolated in-memory PGlite regardless of the
+// ambient DATABASE_URL / TEST_DATABASE_URL the CI lane exports. resolveDatabaseUrl
+// prefers TEST_DATABASE_URL, so BOTH are pinned — otherwise the suite is steered
+// to a Postgres that isn't up under the unit lane and self-skips to a vacuous
+// green (a money-path proof shipping unproven).
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
 process.env.NODE_ENV ||= "test";
 process.env.MOCK_REDIS = "1";
 
@@ -175,13 +178,6 @@ async function creatorEarningLedgerCount(userId: string): Promise<number> {
 }
 
 beforeAll(async () => {
-  if (!CAN_USE_ISOLATED_PGLITE) {
-    pgliteReady = false;
-    console.warn(
-      "[app-credit-hold-concurrency.test] non-PGlite DATABASE_URL; self-skipping isolation suite.",
-    );
-    return;
-  }
   try {
     ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
     ({ appCreditsService } = await import("../app-credits"));
@@ -416,4 +412,12 @@ describe("reserveInferenceCredits — real row-locked upfront hold (#10857)", ()
     },
     PGLITE_TIMEOUT,
   );
+});
+
+// Loud guard: PGlite is in-process (no network), so `pgliteReady` must be true.
+// If pushSchema/PGlite ever fails to init, the DB-dependent tests above
+// early-return; this turns that silent no-op into a hard CI failure so a
+// money-path proof can never masquerade as a vacuous green.
+test("pglite schema applied — never a silent skip", () => {
+  expect(pgliteReady).toBe(true);
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/app-credits-idempotency.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-credits-idempotency.test.ts
@@ -8,15 +8,18 @@
  * creator's redeemable balance is credited exactly ONCE — i.e. a settlement
  * retry no longer double-credits.
  *
- * Self-skips LOUDLY if PGlite/pushSchema is unavailable.
+ * Fails loudly (via the `pgliteReady` guard) if PGlite/pushSchema ever fails to initialize — never a silent skip.
  */
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 
-const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
-const CAN_USE_ISOLATED_PGLITE =
-  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
-process.env.DATABASE_URL ||= "pglite://memory";
+// This proof owns its DB: force an isolated in-memory PGlite regardless of the
+// ambient DATABASE_URL / TEST_DATABASE_URL the CI lane exports. resolveDatabaseUrl
+// prefers TEST_DATABASE_URL, so BOTH are pinned — otherwise the suite is steered
+// to a Postgres that isn't up under the unit lane and self-skips to a vacuous
+// green (a money-path proof shipping unproven).
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
 process.env.NODE_ENV ||= "test";
 process.env.MOCK_REDIS = "1";
 
@@ -98,11 +101,6 @@ async function appCreatorEarningsCounter(appId: string): Promise<number> {
 }
 
 beforeAll(async () => {
-  if (!CAN_USE_ISOLATED_PGLITE) {
-    pgliteReady = false;
-    console.warn("[app-credits-idempotency.test] non-PGlite DATABASE_URL; self-skipping.");
-    return;
-  }
   try {
     ({ appCreditsService } = await import("../app-credits"));
     const schema = {

--- a/packages/cloud/shared/src/lib/services/__tests__/app-earnings-withdrawal-idempotency.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-earnings-withdrawal-idempotency.test.ts
@@ -19,12 +19,13 @@
  * unique index, the conditional-CAS debit, the JSONB idempotency lookup). Only
  * `appsRepository.findById` (an unrelated app-existence + monetization check over
  * the 185-column `apps` relational schema) is stubbed — the thing under test,
- * the withdrawal money path, is fully real. Self-skips if PGlite is unavailable.
+ * the withdrawal money path, is fully real. Fails loudly (via the `pgliteReady` guard) if PGlite/pushSchema ever fails to initialize — never a silent skip.
  */
 
 import { afterAll, afterEach, beforeAll, describe, expect, spyOn, test } from "bun:test";
 
-process.env.DATABASE_URL ||= "pglite://memory";
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
 process.env.NODE_ENV ||= "test";
 
 const APP_ID = "00000000-0000-0000-0000-0000000000a1";
@@ -268,4 +269,12 @@ describe("requestWithdrawal idempotency (#10878)", () => {
     },
     PGLITE_TIMEOUT,
   );
+});
+
+// Loud guard: PGlite is in-process (no network), so `pgliteReady` must be true.
+// If pushSchema/PGlite ever fails to init, the DB-dependent tests above
+// early-return; this turns that silent no-op into a hard CI failure so a
+// money-path proof can never masquerade as a vacuous green.
+test("pglite schema applied — never a silent skip", () => {
+  expect(pgliteReady).toBe(true);
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/container-billing-idempotency.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/container-billing-idempotency.test.ts
@@ -13,12 +13,13 @@
  *
  * The DB-backed cases run against in-process PGlite so the real SQL (FOR UPDATE,
  * the JSONB-keyed lookup, and the partial unique indexes from migration 0139)
- * executes. They self-skip if PGlite is unavailable.
+ * executes. They fail loudly (via the `pgliteReady` guard) if PGlite/pushSchema ever fails to initialize — never a silent skip.
  */
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 
-process.env.DATABASE_URL ||= "pglite://memory";
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
 process.env.NODE_ENV ||= "test";
 
 import { computeContainerBillingPeriod } from "../container-billing-policy";
@@ -443,4 +444,12 @@ describe("container billing gate + row-lock guard", () => {
     },
     PGLITE_TIMEOUT,
   );
+});
+
+// Loud guard: PGlite is in-process (no network), so `pgliteReady` must be true.
+// If pushSchema/PGlite ever fails to init, the DB-dependent tests above
+// early-return; this turns that silent no-op into a hard CI failure so a
+// money-path proof can never masquerade as a vacuous green.
+test("pglite schema applied — never a silent skip", () => {
+  expect(pgliteReady).toBe(true);
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/containers-slot-release-idempotency.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/containers-slot-release-idempotency.test.ts
@@ -12,13 +12,14 @@
  * the marker lives in `metadata`.
  *
  * Runs against in-process PGlite so the real SQL (jsonb_set / jsonb_exists,
- * GREATEST clamping, the cross-table transaction) executes. Self-skips if PGlite
- * is unavailable.
+ * GREATEST clamping, the cross-table transaction) executes. Fails loudly (via the
+ * `pgliteReady` guard) if PGlite ever fails to initialize — never a silent skip.
  */
 
-import { beforeAll, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 
-process.env.DATABASE_URL ||= "pglite://memory";
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
 process.env.NODE_ENV ||= "test";
 
 const PGLITE_TIMEOUT = 60000;
@@ -28,12 +29,13 @@ const CONTAINER_ID = "00000000-0000-0000-0000-0000000000c3";
 const NODE_ID = "node-1";
 
 let dbWrite: typeof import("../../../db/client").dbWrite;
+let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
 let containersRepository: typeof import("../../../db/repositories/containers").containersRepository;
 let pgliteReady = true;
 
 beforeAll(async () => {
   try {
-    ({ dbWrite } = await import("../../../db/client"));
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
     ({ containersRepository } = await import("../../../db/repositories/containers"));
 
     // Minimal schema: only the columns tryReleaseNodeSlot reads/writes.
@@ -59,6 +61,10 @@ beforeAll(async () => {
     console.warn("[containers-slot-release] PGlite unavailable, skipping DB cases:", error);
   }
 }, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
 
 async function allocatedCount(): Promise<number> {
   const res = await dbWrite.execute(
@@ -128,4 +134,12 @@ describe("containersRepository.tryReleaseNodeSlot — idempotency", () => {
     },
     PGLITE_TIMEOUT,
   );
+});
+
+// Loud guard: PGlite is in-process (no network), so `pgliteReady` must be true.
+// If pushSchema/PGlite ever fails to init, the DB-dependent tests above
+// early-return; this turns that silent no-op into a hard CI failure so a
+// money-path proof can never masquerade as a vacuous green.
+test("pglite schema applied — never a silent skip", () => {
+  expect(pgliteReady).toBe(true);
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/creator-earnings-idempotency.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/creator-earnings-idempotency.test.ts
@@ -15,15 +15,18 @@
  *   3. `normalizeLedgerSourceId` maps the composite key deterministically, so a
  *      retry of the same request dedupes while distinct requests do not.
  *
- * Self-skips LOUDLY if PGlite/pushSchema is unavailable (never silently passes).
+ * Fails loudly (via the `pgliteReady` guard) if PGlite/pushSchema ever fails to initialize — never a silent skip.
  */
 
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 
-const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
-const CAN_USE_ISOLATED_PGLITE =
-  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
-process.env.DATABASE_URL ||= "pglite://memory";
+// This proof owns its DB: force an isolated in-memory PGlite regardless of the
+// ambient DATABASE_URL / TEST_DATABASE_URL the CI lane exports. resolveDatabaseUrl
+// prefers TEST_DATABASE_URL, so BOTH are pinned — otherwise the suite is steered
+// to a Postgres that isn't up under the unit lane and self-skips to a vacuous
+// green (a money-path proof shipping unproven).
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
 process.env.NODE_ENV ||= "test";
 process.env.MOCK_REDIS = "1";
 
@@ -80,13 +83,6 @@ async function earningLedgerCount(userId: string): Promise<number> {
 }
 
 beforeAll(async () => {
-  if (!CAN_USE_ISOLATED_PGLITE) {
-    pgliteReady = false;
-    console.warn(
-      "[creator-earnings-idempotency.test] non-PGlite DATABASE_URL; self-skipping isolation suite.",
-    );
-    return;
-  }
   try {
     ({ redeemableEarningsService } = await import("../redeemable-earnings"));
     const schema = {

--- a/packages/cloud/shared/src/lib/services/__tests__/credits-deduct-guard.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/credits-deduct-guard.test.ts
@@ -16,12 +16,13 @@
  * things stubbed are the fire-and-forget, non-billing side-effects on the success
  * path (email/webhook/auto-top-up) — never the deduct/guard arithmetic itself.
  *
- * Self-skips if PGlite is unavailable (mirrors the sibling suite).
+ * Fails loudly (via the `pgliteReady` guard) if PGlite/pushSchema ever fails to initialize — never a silent skip.
  */
 
 import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
-process.env.DATABASE_URL ||= "pglite://memory";
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
 process.env.NODE_ENV ||= "test";
 // Force the cache client onto its in-memory backend so the awaited
 // `CacheInvalidation.onCreditMutation` on the success path never reaches a real
@@ -450,4 +451,12 @@ describe("reconcile() — settle reserved vs actual", () => {
     },
     PGLITE_TIMEOUT,
   );
+});
+
+// Loud guard: PGlite is in-process (no network), so `pgliteReady` must be true.
+// If pushSchema/PGlite ever fails to init, the DB-dependent tests above
+// early-return; this turns that silent no-op into a hard CI failure so a
+// money-path proof can never masquerade as a vacuous green.
+test("pglite schema applied — never a silent skip", () => {
+  expect(pgliteReady).toBe(true);
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts
@@ -8,12 +8,13 @@
  * PGlite DB so the real refundCredits / deductCredits SQL (the FOR UPDATE
  * row-lock, the atomic credit_balance movement, and the credit_transactions
  * insert) actually executes; balances are read back from the DB and asserted to
- * the cent. They self-skip if PGlite is unavailable.
+ * the cent. They fail loudly (via the `pgliteReady` guard) if PGlite/pushSchema ever fails to initialize — never a silent skip.
  */
 
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 
-process.env.DATABASE_URL ||= "pglite://memory";
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
 process.env.NODE_ENV ||= "test";
 
 const PGLITE_TIMEOUT = 60000;
@@ -592,4 +593,12 @@ describe("CreditsService.clawbackCredits (#10920)", () => {
     },
     PGLITE_TIMEOUT,
   );
+});
+
+// Loud guard: PGlite is in-process (no network), so `pgliteReady` must be true.
+// If pushSchema/PGlite ever fails to init, the DB-dependent tests above
+// early-return; this turns that silent no-op into a hard CI failure so a
+// money-path proof can never masquerade as a vacuous green.
+test("pglite schema applied — never a silent skip", () => {
+  expect(pgliteReady).toBe(true);
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/crypto-payments-topup-idempotency.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/crypto-payments-topup-idempotency.test.ts
@@ -15,12 +15,14 @@
  * These run the REAL confirmPayment against in-process PGlite (real SQL: the
  * SELECT … FOR UPDATE, the status transition, the WITH-CTE credit insert +
  * balance update). Only the invoice + discord side-effects are stubbed — the
- * invoice stub is armed to throw to exercise the atomic rollback. Self-skips if
- * PGlite is unavailable.
+ * invoice stub is armed to throw to exercise the atomic rollback. Fails loudly
+ * (via the `pgliteReady` guard) if PGlite ever fails to initialize — never a
+ * silent skip.
  */
 import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
-process.env.DATABASE_URL ||= "pglite://memory";
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
 process.env.NODE_ENV ||= "test";
 
 const ORG_ID = "00000000-0000-4000-8000-0000000000c1";
@@ -280,4 +282,12 @@ describe("crypto top-up — no double-credit (idempotent + atomic)", () => {
     },
     PGLITE_TIMEOUT,
   );
+});
+
+// Loud guard: PGlite is in-process (no network), so `pgliteReady` must be true.
+// If pushSchema/PGlite ever fails to init, the DB-dependent tests above
+// early-return; this turns that silent no-op into a hard CI failure so a
+// money-path proof can never masquerade as a vacuous green.
+test("pglite schema applied — never a silent skip", () => {
+  expect(pgliteReady).toBe(true);
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-payments.integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-payments.integration.test.ts
@@ -43,7 +43,10 @@ const d = SUPPORTS_VITEST_MOCK_API ? describe : describe.skip;
 // PGlite in-process; receive addresses for all three networks so config is
 // `enabled`. RPC URLs go through the mocked viem transport, so values don't
 // matter beyond being non-empty.
+// resolveDatabaseUrl prefers TEST_DATABASE_URL — pin BOTH so this proof owns its
+// in-memory PGlite even when the CI lane exports a real `postgresql://` URL.
 process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
 process.env.NODE_ENV = "test";
 process.env.CRYPTO_DIRECT_BASE_RECEIVE_ADDRESS = "0x000000000000000000000000000000000000ba5e";
 process.env.CRYPTO_DIRECT_BSC_RECEIVE_ADDRESS = "0x0000000000000000000000000000000000000b5c";

--- a/packages/cloud/shared/src/lib/services/__tests__/domain-maintenance.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/domain-maintenance.test.ts
@@ -12,12 +12,13 @@
  * Health probes mock only `safeFetch` (the outbound network), running the real
  * `is_live` sync against PGlite.
  *
- * Self-skips if PGlite is unavailable.
+ * Fails loudly (via the `pgliteReady` guard) if PGlite/pushSchema ever fails to initialize — never a silent skip.
  */
 
 import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
-process.env.DATABASE_URL ||= "pglite://memory";
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
 process.env.NODE_ENV ||= "test";
 process.env.MOCK_REDIS ||= "1";
 process.env.ELIZA_CF_REGISTRAR_DEV_STUB = "1";
@@ -313,4 +314,12 @@ describe("custom-domain health probe (#10244)", () => {
     expect(summary.checked).toBe(0);
     expect(safeFetchMock).not.toHaveBeenCalled();
   });
+});
+
+// Loud guard: PGlite is in-process (no network), so `pgliteReady` must be true.
+// If pushSchema/PGlite ever fails to init, the DB-dependent tests above
+// early-return; this turns that silent no-op into a hard CI failure so a
+// money-path proof can never masquerade as a vacuous green.
+test("pglite schema applied — never a silent skip", () => {
+  expect(pgliteReady).toBe(true);
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/inference-billing-ledger.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/inference-billing-ledger.test.ts
@@ -20,12 +20,13 @@
  *     age-ordered across batches; inline-then-sweep never double-charges.
  *   - Concurrency: a same-org burst cannot collectively overdraw.
  *
- * Self-skips if PGlite is unavailable (mirrors the sibling suite).
+ * Fails loudly (via the `pgliteReady` guard) if PGlite/pushSchema ever fails to initialize — never a silent skip.
  */
 
 import { afterAll, beforeAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 
-process.env.DATABASE_URL ||= "pglite://memory";
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
 process.env.NODE_ENV ||= "test";
 process.env.MOCK_REDIS ||= "1";
 
@@ -659,4 +660,12 @@ describe("resolveInferenceBillingLedger — backstop selector", () => {
     expect(ledger.resolveInferenceBillingLedger({ INFERENCE_BILLING_LEDGER: "" })).toBe("kv");
     expect(ledger.resolveInferenceBillingLedger({})).toBe("kv");
   });
+});
+
+// Loud guard: PGlite is in-process (no network), so `pgliteReady` must be true.
+// If pushSchema/PGlite ever fails to init, the DB-dependent tests above
+// early-return; this turns that silent no-op into a hard CI failure so a
+// money-path proof can never masquerade as a vacuous green.
+test("pglite schema applied — never a silent skip", () => {
+  expect(pgliteReady).toBe(true);
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/influencer-marketplace.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/influencer-marketplace.test.ts
@@ -9,15 +9,18 @@
  * including the failure-mode paths (payout outage, refund outage, funding
  * crash windows, client create retries) exercised below.
  *
- * Self-skips LOUDLY if PGlite/pushSchema is unavailable.
+ * Fails loudly (via the `pgliteReady` guard) if PGlite/pushSchema ever fails to initialize — never a silent skip.
  */
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 
-const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
-const CAN_USE_ISOLATED_PGLITE =
-  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
-process.env.DATABASE_URL ||= "pglite://memory";
+// This proof owns its DB: force an isolated in-memory PGlite regardless of the
+// ambient DATABASE_URL / TEST_DATABASE_URL the CI lane exports. resolveDatabaseUrl
+// prefers TEST_DATABASE_URL, so BOTH are pinned — otherwise the suite is steered
+// to a Postgres that isn't up under the unit lane and self-skips to a vacuous
+// green (a money-path proof shipping unproven).
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
 process.env.NODE_ENV ||= "test";
 process.env.MOCK_REDIS = "1";
 
@@ -83,10 +86,6 @@ async function seedProfile() {
 }
 
 beforeAll(async () => {
-  if (!CAN_USE_ISOLATED_PGLITE) {
-    pgliteReady = false;
-    return;
-  }
   try {
     ({ influencerMarketplaceService: service } = await import("../influencer-marketplace"));
     ({ creditsService } = await import("../credits"));

--- a/packages/cloud/shared/src/lib/services/__tests__/managed-domains-squat.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/managed-domains-squat.test.ts
@@ -8,15 +8,18 @@
  * as strings) with exactly the migration's two indexes, so the test exercises the
  * real uniqueness semantics without pulling the full FK closure.
  *
- * Self-skips LOUDLY if PGlite is unavailable (never a silent pass).
+ * Fails loudly (via the `pgliteReady` guard) if PGlite/pushSchema ever fails to initialize — never a silent skip.
  */
 
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 
-const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
-const CAN_USE_ISOLATED_PGLITE =
-  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
-process.env.DATABASE_URL ||= "pglite://memory";
+// This proof owns its DB: force an isolated in-memory PGlite regardless of the
+// ambient DATABASE_URL / TEST_DATABASE_URL the CI lane exports. resolveDatabaseUrl
+// prefers TEST_DATABASE_URL, so BOTH are pinned — otherwise the suite is steered
+// to a Postgres that isn't up under the unit lane and self-skips to a vacuous
+// green (a money-path proof shipping unproven).
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
 process.env.NODE_ENV ||= "test";
 process.env.MOCK_REDIS = "1";
 
@@ -57,10 +60,6 @@ async function insertRow(row: {
 }
 
 beforeAll(async () => {
-  if (!CAN_USE_ISOLATED_PGLITE) {
-    pgliteReady = false;
-    return;
-  }
   try {
     ({ managedDomainsService: svc } = await import("../managed-domains"));
     // Raw table + the exact indexes migration 0163 creates. Enum columns are
@@ -169,10 +168,7 @@ describe("managed-domains squat fix (#11024)", () => {
           .update(managedDomains)
           .set({ verified: true })
           .where(
-            and(
-              eq(managedDomains.organizationId, orgA),
-              eq(managedDomains.domain, "shared.com"),
-            ),
+            and(eq(managedDomains.organizationId, orgA), eq(managedDomains.domain, "shared.com")),
           );
       })(),
     ).rejects.toThrow();
@@ -181,7 +177,12 @@ describe("managed-domains squat fix (#11024)", () => {
   test("a cloudflare row is exclusive on its own (registrar-based exclusivity)", async () => {
     if (!pgliteReady) return;
     const orgA = orgId();
-    await insertRow({ organizationId: orgA, domain: "cf.com", registrar: "cloudflare", verified: false });
+    await insertRow({
+      organizationId: orgA,
+      domain: "cf.com",
+      registrar: "cloudflare",
+      verified: false,
+    });
     // Even unverified, a cloudflare row holds the exclusive slot.
     expect((await svc.getDomainByName("cf.com"))?.organizationId).toBe(orgA);
     // A second cloudflare row for the same domain (different org) is refused.
@@ -206,7 +207,12 @@ describe("managed-domains squat fix (#11024)", () => {
 
     await insertRow({ organizationId: orgStale, domain: "stale.com", createdAt: old });
     await insertRow({ organizationId: orgFresh, domain: "fresh.com" }); // now
-    await insertRow({ organizationId: orgVerified, domain: "verified.com", verified: true, createdAt: old });
+    await insertRow({
+      organizationId: orgVerified,
+      domain: "verified.com",
+      verified: true,
+      createdAt: old,
+    });
 
     const released = await svc.releaseStaleUnverifiedExternals(1000 * 60 * 60 * 24); // 24h TTL
     expect(released).toBe(1); // only the stale unverified external

--- a/packages/cloud/shared/src/lib/services/__tests__/payout-stale-lock-recovery.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/payout-stale-lock-recovery.test.ts
@@ -22,7 +22,7 @@
  * in-process PGlite. Only the chain clients (viem) and the RPC/env helpers are
  * stubbed — the DB selectors, the lock, the recovery SQL, the broadcast-hash
  * persistence, and the per-redemption try/catch all run for real, so each test
- * fails if the real logic regresses. Self-skips if PGlite is unavailable.
+ * fails if the real logic regresses. Fails loudly (via the `pgliteReady` guard) if PGlite/pushSchema ever fails to initialize — never a silent skip.
  */
 
 import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -30,7 +30,8 @@ import * as realViem from "viem";
 import * as realViemAccounts from "viem/accounts";
 import * as realCloudBindings from "../../runtime/cloud-bindings";
 
-process.env.DATABASE_URL ||= "pglite://memory";
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
 process.env.NODE_ENV ||= "test";
 process.env.MOCK_REDIS ||= "1";
 
@@ -222,6 +223,7 @@ beforeAll(async () => {
         eliza_price_usd numeric(18,8) NOT NULL DEFAULT '0',
         eliza_amount numeric(24,8) NOT NULL DEFAULT '0',
         price_quote_expires_at timestamp NOT NULL DEFAULT now(),
+        asset text NOT NULL DEFAULT 'usdc',
         network text NOT NULL DEFAULT 'base',
         payout_address text NOT NULL DEFAULT '0x0000000000000000000000000000000000000000',
         address_signature text,
@@ -690,4 +692,12 @@ describe("payout stale-lock recovery (#10553)", () => {
     },
     PGLITE_TIMEOUT,
   );
+});
+
+// Loud guard: PGlite is in-process (no network), so `pgliteReady` must be true.
+// If pushSchema/PGlite ever fails to init, the DB-dependent tests above
+// early-return; this turns that silent no-op into a hard CI failure so a
+// money-path proof can never masquerade as a vacuous green.
+test("pglite schema applied — never a silent skip", () => {
+  expect(pgliteReady).toBe(true);
 });

--- a/packages/cloud/shared/vitest.config.ts
+++ b/packages/cloud/shared/vitest.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * Vitest lane for cloud/shared suites that require the Vitest-only module-mock
+ * API (`vi.mock` + `vi.importActual`), which bun-test's `vi` shim does not
+ * implement. The bun `test:cloud` lane picks these files up but they gate to
+ * `describe.skip` under bun (see `SUPPORTS_VITEST_MOCK_API`), so without this
+ * lane the direct-wallet payer/state-machine proof (33 tests) never runs
+ * anywhere — a vacuous skip on the crypto-payments money path. This config
+ * runs it for real against in-process PGlite.
+ *
+ * Do NOT set `passWithNoTests`: if the include glob ever matches nothing, the
+ * lane must red rather than silently pass.
+ */
+export default defineConfig({
+  test: {
+    include: ["src/lib/services/__tests__/direct-wallet-payments.integration.test.ts"],
+    environment: "node",
+    testTimeout: 120_000,
+    hookTimeout: 120_000,
+    // Each suite pins DATABASE_URL/TEST_DATABASE_URL to pglite://memory at module
+    // load; mirror it here so the proof owns its DB even if the lane exports a
+    // real postgres URL.
+    env: {
+      NODE_ENV: "test",
+      DATABASE_URL: "pglite://memory",
+      TEST_DATABASE_URL: "pglite://memory",
+      MOCK_REDIS: "1",
+    },
+  },
+});


### PR DESCRIPTION
## Problem

The cloud money-path PGlite proof suites in `packages/cloud/shared/src/lib/services/__tests__/` never actually execute in a completed CI lane — they self-skip to a vacuous green (or a latent red), so the concurrency / idempotency / payer proofs for #10857, #10903, #10847, #10423 provide **zero** assertion coverage.

### Root cause (verified, not paraphrased)

- `.github/workflows/cloud-tests.yml` sets, at the workflow `env` level (all jobs), a **real** `DATABASE_URL` / `TEST_DATABASE_URL = postgresql://postgres@127.0.0.1:5432/postgres`. The `unit-tests` job runs `bun run test:cloud` with **no DB service** — nothing listens on 5432.
- `resolveDatabaseUrl()` (`db/database-url.ts`) prefers `TEST_DATABASE_URL || DATABASE_URL`, so the suites are steered to that unreachable Postgres.
- Each proof then either:
  - **(variant 1)** computes `CAN_USE_ISOLATED_PGLITE = DATABASE_URL === "" || startsWith("pglite")` → false → `beforeAll` sets `pgliteReady = false` and every test early-returns → **0 assertions, vacuous green**; or
  - **(variant 2)** does `DATABASE_URL ||= "pglite://memory"` (a no-op under the real ambient URL) → `pushSchema` hits `ECONNREFUSED` → caught → `pgliteReady = false` → same vacuous green.
- Six variant-1 suites additionally carry `test("pglite applied", () => expect(pgliteReady).toBe(true))`, which **fails** (not skips) under that lane env → **latent red**.
- `direct-wallet-payments.integration.test.ts` gates on `SUPPORTS_VITEST_MOCK_API` (`vi.importActual`, absent under bun) → `describe.skip` under the bun `test:cloud` lane → **33 payer/state-machine tests never run anywhere** (`test:cloud:integration` only runs `packages/cloud/api/test/e2e`, not cloud/shared).

### Reproduction (the spec)

Under the exact lane env (`DATABASE_URL`/`TEST_DATABASE_URL` = a `postgresql://` that isn't up; local repro uses a dead port because the dev box has a real Postgres on 5432 — CI has nothing listening):

| suite | before | after |
|---|---|---|
| `app-credit-hold-concurrency` | 3 pass / **0 expect()** (self-skip) | 4 pass / **52 expect()** |
| `credits-deduct-guard` | 10 pass / **0 expect()** ("PGlite unavailable, skipping") | 11 pass / **67 expect()** |
| `app-credits-idempotency` | **RED** (`pglite applied` fails, `pgliteReady=false`) | 6 pass / **18 expect()** |
| `creator-earnings-idempotency` | 6 pass / **0 expect()** (self-skip) | 6 pass / **17 expect()** |
| `payout-stale-lock-recovery` | self-skip → **1 pass / 13 fail** once forced to run | 14 pass / **77 expect()** |
| `direct-wallet-payments.integration` | **33 skip** (bun) | **33 pass** (vitest lane) |

All 17 forced-PGlite suites now run for real (12/13/6/3/3/4/15/7/10/21/14/7/10 pass; non-zero `expect()` each), plus the 33-test Vitest suite.

## Fix

- **Force an isolated in-memory PGlite in every proof suite**, independent of the lane's ambient DB: hard-set BOTH `process.env.DATABASE_URL` and `process.env.TEST_DATABASE_URL = "pglite://memory"` at module load (17 suites). Removed the now-dead `CAN_USE_ISOLATED_PGLITE` ambient early-skip.
- **Kill the skip-to-green masquerade:** every proof suite now has a loud `test("pglite schema applied — never a silent skip", () => expect(pgliteReady).toBe(true))`. If PGlite/`pushSchema` ever genuinely fails to initialize, the suite **reds**. The previously-latent-red `pglite applied` guards now **pass** because PGlite is reachable — they become real guards.
- **Run the Vitest-only suite for real:** added `packages/cloud/shared/vitest.config.ts` + a `test:vitest` script + a `Run cloud vitest-only suites` step in the `unit-tests` job. `direct-wallet-payments.integration.test.ts` runs its 33 tests under Vitest against in-process PGlite (still cleanly skips under the bun lane so `test:cloud` doesn't crash on `vi.importActual`).
- **Fixed two latent bugs the self-skip had hidden:**
  - `containers-slot-release-idempotency` never closed its PGlite connection (dangling handle → **exit 99** despite 0 failures) → added `afterAll` close.
  - `payout-stale-lock-recovery`'s hand-written `token_redemptions` DDL was missing the `asset` column added in #10732 → 13 tests failed with `column "asset" does not exist` → added the column.
- Updated stale "self-skips" docstrings to describe the new fail-loud behavior.
- `cloud-tests.yml` `paths:` already triggers on `packages/cloud/shared/**` and the workflow file, so this change fires the lane.

**No assertion was weakened.**

## Out of scope (documented)

- `payout-fork.integration.test.ts` stays gated on `RUN_FORK_TESTS=1` — it needs the external `anvil` binary + live Base/BSC mainnet RPCs, a legitimate external-dependency opt-in, not a DB self-skip.
- `ai-billing-anon-affiliate.test.ts` mocks all DB writers and already runs for real (verified 7 `expect()` under the lane env) — not a PGlite proof.

Refs #10857, #10903, #10200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
