### PR TITLE
fix(cloud): stop steward sign-in 500ing on profile-refresh conflicts + make sync failures observable

### DIFF
--- a/packages/cloud/api/auth/steward-nonce-exchange/route.ts
+++ b/packages/cloud/api/auth/steward-nonce-exchange/route.ts
@@ -35,7 +35,7 @@ import {
   verifyStewardTokenCached,
 } from "@/lib/auth/steward-client";
 import { signStewardMutatingRequest } from "@/lib/steward/sign";
-import { syncUserFromSteward } from "@/lib/steward-sync";
+import { describeSyncError, syncUserFromSteward } from "@/lib/steward-sync";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -431,9 +431,11 @@ app.post("/", async (c) => {
     });
   } catch (error) {
     logExchange("sync-failed");
+    // Workers Logs indexes only the message STRING — an Error passed in the
+    // context object is dropped entirely (a week of these prod 500s was
+    // unobservable because of exactly that). Inline everything.
     logger.error(
-      "[steward-nonce-exchange] Failed to sync Steward user before setting cookie",
-      { stewardUserId: claims.userId, error },
+      `[steward-nonce-exchange] Failed to sync Steward user before setting cookie (stewardUserId=${claims.userId}): ${describeSyncError(error)}`,
     );
     return c.json(
       errorBody("Could not sync Steward user", "steward_user_sync_failed"),

--- a/packages/cloud/api/auth/steward-session/route.ts
+++ b/packages/cloud/api/auth/steward-session/route.ts
@@ -17,7 +17,7 @@ import {
   type StewardVerifyEnv,
   verifyStewardTokenCached,
 } from "@/lib/auth/steward-client";
-import { syncUserFromSteward } from "@/lib/steward-sync";
+import { describeSyncError, syncUserFromSteward } from "@/lib/steward-sync";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -211,12 +211,11 @@ app.post("/", async (c) => {
       });
     } catch (error) {
       logStewardAuth("sync-failed", null);
+      // Workers Logs indexes only the message STRING — an Error passed in the
+      // context object is dropped entirely. Inline everything (same fix as the
+      // steward-nonce-exchange twin catch).
       logger.error(
-        "[steward-auth] Failed to sync Steward user before setting cookie",
-        {
-          stewardUserId: claims.userId,
-          error,
-        },
+        `[steward-auth] Failed to sync Steward user before setting cookie (stewardUserId=${claims.userId}): ${describeSyncError(error)}`,
       );
       return c.json(
         errorBody("Could not sync Steward user", "steward_user_sync_failed"),

--- a/packages/cloud/shared/src/lib/steward-sync-grant.test.ts
+++ b/packages/cloud/shared/src/lib/steward-sync-grant.test.ts
@@ -201,7 +201,9 @@ describe("syncUserFromSteward — initial-credits grant fallback", () => {
       c.message.includes("addCredits failed for new org"),
     );
     expect(grantError).toBeDefined();
-    expect((grantError!.context as { organizationId: string }).organizationId).toBe("org-new-1");
-    expect((grantError!.context as { error: string }).error).toBe("ledger write failed");
+    // The failure detail is inlined in the message string — Workers Logs drops
+    // logger context objects, which is how this failure stayed invisible.
+    expect(grantError!.message).toContain("org-new-1");
+    expect(grantError!.message).toContain("ledger write failed");
   });
 });

--- a/packages/cloud/shared/src/lib/steward-sync-profile-refresh.test.ts
+++ b/packages/cloud/shared/src/lib/steward-sync-profile-refresh.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Tests for the existing-user profile refresh in syncUserFromSteward (branch 1)
+ * and the error-description helpers behind the sign-in observability fix.
+ *
+ * Branch 1 writes claims-derived email/wallet_address into UNIQUE columns with
+ * every login. When another row already owns the value, that update 23505s on
+ * EVERY sign-in of the same user — the deterministic per-user loop behind the
+ * prod steward-nonce-exchange 500s. The refresh is best-effort: the user is
+ * already identified by steward_user_id, so a unique-constraint conflict must
+ * log loudly and keep the stored profile instead of failing the whole sign-in.
+ * Any other update failure still aborts (and is now logged with its Postgres
+ * code/constraint inlined in the message, since Workers Logs drops context
+ * objects).
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const updateCalls: Array<{ id: string; data: unknown }> = [];
+const loggerErrorCalls: Array<{ message: string; context?: unknown }> = [];
+let updateImpl: (id: string, data: unknown) => Promise<unknown> = async (id, data) => {
+  updateCalls.push({ id, data });
+  return undefined;
+};
+
+const storedUser = {
+  id: "user-1",
+  steward_user_id: "steward-123",
+  email: "old@example.com",
+  name: "old-name",
+  wallet_address: null,
+  email_verified: true,
+  wallet_verified: false,
+  organization: { id: "org-1", name: "org" },
+};
+const refreshedUser = { ...storedUser, email: "alice@example.com", name: "alice" };
+
+mock.module("./services/users", () => ({
+  usersService: {
+    getByStewardId: async () => storedUser,
+    getByStewardIdForWrite: async () => refreshedUser,
+    getByEmailWithOrganization: async () => undefined,
+    getByWalletAddress: async () => undefined,
+    getByWalletAddressWithOrganization: async () => undefined,
+    getStewardIdentityForWrite: async () => undefined,
+    create: async () => {
+      throw new Error("create must not run for an existing user");
+    },
+    update: (id: string, data: unknown) => updateImpl(id, data),
+    linkStewardId: async () => undefined,
+    upsertStewardIdentity: async () => undefined,
+  },
+}));
+
+mock.module("./utils/logger", () => ({
+  logger: {
+    error: (message: string, context?: unknown) => {
+      loggerErrorCalls.push({ message, context });
+    },
+    warn: () => {},
+    info: () => {},
+    debug: () => {},
+  },
+  redact: {
+    id: (v: string) => v,
+    orgId: (v: string) => v,
+    userId: (v: string) => v,
+  },
+}));
+
+function pgError(
+  message: string,
+  fields: { code?: string; constraint?: string; detail?: string },
+): Error {
+  return Object.assign(new Error(message), fields);
+}
+
+// Claims email differs from the stored row → shouldUpdate fires.
+const baseParams = {
+  stewardUserId: "steward-123",
+  email: "alice@example.com",
+  name: "alice",
+};
+
+describe("syncUserFromSteward — existing-user profile refresh (branch 1)", () => {
+  beforeEach(() => {
+    updateCalls.length = 0;
+    loggerErrorCalls.length = 0;
+    updateImpl = async (id, data) => {
+      updateCalls.push({ id, data });
+      return undefined;
+    };
+  });
+
+  test("happy path: refresh succeeds and the re-read row is returned", async () => {
+    const { syncUserFromSteward } = await import("./steward-sync");
+
+    const result = await syncUserFromSteward(baseParams);
+
+    expect(updateCalls).toHaveLength(1);
+    expect(result).toBe(refreshedUser as never);
+    expect(loggerErrorCalls).toHaveLength(0);
+  });
+
+  test("unique-constraint conflict: sign-in continues with the stored profile and the collision is logged with its constraint inlined", async () => {
+    updateImpl = async () => {
+      throw pgError("duplicate key value violates unique constraint", {
+        code: "23505",
+        constraint: "users_email_unique",
+        detail: "Key (email)=(alice@example.com) already exists.",
+      });
+    };
+
+    const { syncUserFromSteward } = await import("./steward-sync");
+
+    const result = await syncUserFromSteward(baseParams);
+
+    // Sign-in resolved with the pre-refresh row — no throw, no 500.
+    expect(result).toBe(storedUser as never);
+    const conflictLog = loggerErrorCalls.find((c) =>
+      c.message.includes("continuing sign-in with the stored profile"),
+    );
+    expect(conflictLog).toBeDefined();
+    // Everything needed to identify the collision is IN the message string
+    // (Workers Logs drops logger context objects).
+    expect(conflictLog!.message).toContain("user-1");
+    expect(conflictLog!.message).toContain("code=23505");
+    expect(conflictLog!.message).toContain("constraint=users_email_unique");
+    expect(conflictLog!.message).toContain("alice@example.com");
+  });
+
+  test("driver-wrapped conflict (code on error.cause) is tolerated the same way", async () => {
+    updateImpl = async () => {
+      throw new Error("update failed", {
+        cause: pgError("duplicate key value violates unique constraint", {
+          code: "23505",
+          constraint: "users_wallet_address_unique",
+        }),
+      });
+    };
+
+    const { syncUserFromSteward } = await import("./steward-sync");
+
+    const result = await syncUserFromSteward(baseParams);
+
+    expect(result).toBe(storedUser as never);
+    expect(
+      loggerErrorCalls.some((c) => c.message.includes("constraint=users_wallet_address_unique")),
+    ).toBe(true);
+  });
+
+  test("non-conflict failure still aborts the sync — and is logged with the error inlined", async () => {
+    updateImpl = async () => {
+      throw new Error("Connection terminated unexpectedly");
+    };
+
+    const { syncUserFromSteward } = await import("./steward-sync");
+
+    await expect(syncUserFromSteward(baseParams)).rejects.toThrow(
+      "Connection terminated unexpectedly",
+    );
+    const failureLog = loggerErrorCalls.find((c) => c.message.includes("profile refresh failed"));
+    expect(failureLog).toBeDefined();
+    expect(failureLog!.message).toContain("Connection terminated unexpectedly");
+  });
+});
+
+describe("error-description helpers", () => {
+  test("isUniqueViolation matches direct and cause-wrapped 23505s, nothing else", async () => {
+    const { isUniqueViolation } = await import("./steward-sync");
+
+    expect(isUniqueViolation(pgError("dup", { code: "23505" }))).toBe(true);
+    expect(
+      isUniqueViolation(new Error("wrapped", { cause: pgError("dup", { code: "23505" }) })),
+    ).toBe(true);
+    expect(isUniqueViolation(pgError("fk", { code: "23503" }))).toBe(false);
+    expect(isUniqueViolation(new Error("plain"))).toBe(false);
+    expect(isUniqueViolation("string")).toBe(false);
+    expect(isUniqueViolation(null)).toBe(false);
+  });
+
+  test("describeSyncError inlines message, code, constraint and detail", async () => {
+    const { describeSyncError } = await import("./steward-sync");
+
+    const described = describeSyncError(
+      pgError("duplicate key value violates unique constraint", {
+        code: "23505",
+        constraint: "users_email_unique",
+        detail: "Key (email)=(a@b.co) already exists.",
+      }),
+    );
+    expect(described).toContain("duplicate key value violates unique constraint");
+    expect(described).toContain("code=23505");
+    expect(described).toContain("constraint=users_email_unique");
+    expect(described).toContain("detail=Key (email)=(a@b.co) already exists.");
+  });
+
+  test("describeSyncError reads Postgres fields from error.cause for wrapped driver errors", async () => {
+    const { describeSyncError } = await import("./steward-sync");
+
+    const described = describeSyncError(
+      new Error("query failed", {
+        cause: pgError("dup", { code: "23505", constraint: "users_wallet_address_unique" }),
+      }),
+    );
+    expect(described).toContain("query failed");
+    expect(described).toContain("code=23505");
+    expect(described).toContain("constraint=users_wallet_address_unique");
+  });
+
+  test("describeSyncError appends a stack excerpt for non-Postgres errors", async () => {
+    const { describeSyncError } = await import("./steward-sync");
+
+    const described = describeSyncError(new Error("something unexpected"));
+    expect(described).toContain("something unexpected");
+    expect(described).toContain("stack=");
+  });
+});

--- a/packages/cloud/shared/src/lib/steward-sync.ts
+++ b/packages/cloud/shared/src/lib/steward-sync.ts
@@ -66,6 +66,39 @@ function extractErrorMetadata(candidate: unknown): {
   };
 }
 
+/** True for a Postgres unique-constraint violation (23505), directly or via `cause`. */
+export function isUniqueViolation(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  if (extractErrorMetadata(error).code === "23505") return true;
+  return "cause" in error && extractErrorMetadata(error.cause).code === "23505";
+}
+
+/**
+ * One-line description of a sync failure with the Postgres fields
+ * (code/constraint/detail) inlined, falling through to `cause` for wrapped
+ * driver errors. Workers Logs only indexes the message STRING — an Error
+ * passed in a logger context object is dropped entirely — so callers must
+ * interpolate this into the log message itself, never attach it as metadata.
+ */
+export function describeSyncError(error: unknown): string {
+  const meta = extractErrorMetadata(error);
+  const causeMeta =
+    error && typeof error === "object" && "cause" in error
+      ? extractErrorMetadata(error.cause)
+      : { code: undefined, constraint: undefined, detail: undefined, message: "" };
+  const code = meta.code ?? causeMeta.code;
+  const constraint = meta.constraint ?? causeMeta.constraint;
+  const detail = meta.detail ?? causeMeta.detail;
+  const parts = [meta.message || causeMeta.message || String(error)];
+  if (code) parts.push(`code=${code}`);
+  if (constraint) parts.push(`constraint=${constraint}`);
+  if (detail) parts.push(`detail=${detail}`);
+  if (!code && error instanceof Error && error.stack) {
+    parts.push(`stack=${error.stack.split("\n").slice(0, 4).join(" | ")}`);
+  }
+  return parts.join(" ");
+}
+
 function isRecoverableStewardProjectionConflict(error: unknown): boolean {
   if (!error || typeof error !== "object") {
     return false;
@@ -232,18 +265,36 @@ export async function syncUserFromSteward(
       (walletAddress && !user.wallet_verified);
 
     if (shouldUpdate) {
-      await usersService.update(user.id, {
-        name,
-        email: email || user.email,
-        email_verified: !!email || user.email_verified,
-        wallet_address: walletAddress || user.wallet_address,
-        wallet_chain_type: resolvedWalletChainType || user.wallet_chain_type,
-        wallet_verified: walletAddress ? true : user.wallet_verified,
-        updated_at: new Date(),
-      });
+      try {
+        await usersService.update(user.id, {
+          name,
+          email: email || user.email,
+          email_verified: !!email || user.email_verified,
+          wallet_address: walletAddress || user.wallet_address,
+          wallet_chain_type: resolvedWalletChainType || user.wallet_chain_type,
+          wallet_verified: walletAddress ? true : user.wallet_verified,
+          updated_at: new Date(),
+        });
 
-      // Re-read from primary to avoid replica lag
-      user = (await usersService.getByStewardIdForWrite(stewardUserId))!;
+        // Re-read from primary to avoid replica lag
+        user = (await usersService.getByStewardIdForWrite(stewardUserId))!;
+      } catch (error) {
+        // This refresh writes claims-derived email/wallet_address into UNIQUE
+        // columns. When another row already owns the value, the same user
+        // 23505s on EVERY login — but they are already identified by
+        // steward_user_id, so the conflict must not fail the whole sign-in:
+        // keep the stored profile and log the collision loudly instead.
+        // Anything other than a unique violation still aborts the sync.
+        if (!isUniqueViolation(error)) {
+          logger.error(
+            `[StewardSync] Existing-user profile refresh failed for user ${user.id}: ${describeSyncError(error)}`,
+          );
+          throw error;
+        }
+        logger.error(
+          `[StewardSync] Existing-user profile refresh conflicts with another row for user ${user.id} — continuing sign-in with the stored profile: ${describeSyncError(error)}`,
+        );
+      }
     }
 
     return user;
@@ -280,6 +331,9 @@ export async function syncUserFromSteward(
           await rollbackCreatedUserSafely(newUser.id, "invite", error);
         }
         if (!recovered) {
+          logger.error(
+            `[StewardSync] Invited-user creation failed for ${stewardUserId}: ${describeSyncError(error)}`,
+          );
           throw error;
         }
       }
@@ -334,6 +388,9 @@ export async function syncUserFromSteward(
         await usersService.upsertStewardIdentity(existingByEmail.id, stewardUserId);
       } catch (error) {
         await restorePreviousStewardUserIdSafely(existingByEmail.id, previousStewardUserId, error);
+        logger.error(
+          `[StewardSync] Identity projection upsert failed while email-linking user ${existingByEmail.id}: ${describeSyncError(error)}`,
+        );
         throw error;
       }
 
@@ -373,6 +430,9 @@ export async function syncUserFromSteward(
           existingByWallet.id,
           existingByWallet.steward_user_id,
           error,
+        );
+        logger.error(
+          `[StewardSync] Identity projection upsert failed while wallet-linking user ${existingByWallet.id}: ${describeSyncError(error)}`,
         );
         throw error;
       }
@@ -448,12 +508,7 @@ export async function syncUserFromSteward(
       });
     } catch (error) {
       logger.error(
-        "[StewardSync] addCredits failed for new org; rolling back signup organization",
-        {
-          organizationId: organization.id,
-          initialCredits,
-          error: error instanceof Error ? error.message : String(error),
-        },
+        `[StewardSync] addCredits failed for new org ${organization.id} (initialCredits=${initialCredits}); rolling back signup organization: ${describeSyncError(error)}`,
       );
       try {
         await organizationsService.delete(organization.id);
@@ -485,17 +540,7 @@ export async function syncUserFromSteward(
       is_active: true,
     });
   } catch (error) {
-    const isDuplicateError =
-      error &&
-      typeof error === "object" &&
-      (("code" in error && error.code === "23505") ||
-        ("cause" in error &&
-          error.cause &&
-          typeof error.cause === "object" &&
-          "code" in error.cause &&
-          error.cause.code === "23505"));
-
-    if (isDuplicateError) {
+    if (isUniqueViolation(error)) {
       let existingUser: UserWithOrganization | undefined;
       const maxRetries = 3;
 
@@ -565,10 +610,9 @@ export async function syncUserFromSteward(
       await organizationsService.delete(organization.id);
     }
 
-    logger.error("[StewardSync] Failed to create user", {
-      stewardUserId,
-      error: error instanceof Error ? error.message : String(error),
-    });
+    logger.error(
+      `[StewardSync] Failed to create user for ${stewardUserId}: ${describeSyncError(error)}`,
+    );
     throw error;
   }
 
@@ -590,6 +634,9 @@ export async function syncUserFromSteward(
     if (!recovered) {
       await rollbackCreatedUserSafely(createdUser.id, "signup", error);
       await organizationsService.delete(organization.id);
+      logger.error(
+        `[StewardSync] Identity projection upsert failed for new user ${createdUser.id}: ${describeSyncError(error)}`,
+      );
       throw error;
     }
   }


### PR DESCRIPTION
## What

Prod `POST /api/auth/steward-nonce-exchange` has been returning 500 on ~half its requests for over a week — a successful Steward OAuth that never becomes a cloud session, so the user lands back on /login and loops. This PR makes the failure class impossible for existing users and makes whatever remains self-identifying in Workers Logs.

## Diagnosis (live logs + code audit, adversarially verified)

- Every 500 logs only `[steward-nonce-exchange] Failed to sync Steward user before setting cookie` — **the underlying error never reached Workers Logs** because the catch passed the `Error` inside a logger context object, and Workers Logs only indexes the message *string*. A week of prod failures with an unobservable cause.
- The failures are **deterministic per user**: over 7 days, 8 client IPs *only* ever got 500s while 8 others *only* got 200s. Not transient infra — the same users fail on every login attempt.
- Failing requests throw sub-second after entering the sync (total wall time is dominated by the upstream Steward exchange fetch, identical for 200s and 500s). No timeout shape, no general Neon problem (`steward-session`, same sync, same DB: zero 5xx in 7d).
- Every *logged* throw path inside `syncUserFromSteward` shows zero occurrences in 7d — the throw comes from one of the **silent** writes. The prime suspect fitting all three facts: the existing-user profile refresh writes claims-derived `email`/`wallet_address` into UNIQUE columns on every login. A user whose Steward claims carry a value owned by another row hits `23505` on **every** sign-in, forever.

## Changes

1. **Resilience** (`steward-sync.ts` branch 1): the profile refresh is best-effort — the user is already identified by `steward_user_id`. A unique-constraint conflict now logs the collision (with the constraint name) and continues sign-in with the stored profile instead of 500ing the whole login. Any other failure still aborts.
2. **Observability**: new `describeSyncError()` inlines message + pg `code`/`constraint`/`detail` (falling through to `error.cause` for wrapped driver errors) into the log **message** at: both route catches (`steward-nonce-exchange` + `steward-session`), the previously-silent rethrow sites (invite create, email-linking, wallet-linking, signup projection upsert), and the two existing logs whose detail lived in dropped context objects. If anything still 500s after this deploys, the log names the exact failing write and constraint.
3. `isUniqueViolation()` extracted from step-5's inline duplicate check (identical semantics), reused by the new guard.

## Honest scope

The 23505-on-profile-refresh is the highest-confidence explanation consistent with all the evidence, but the error was literally unobservable — if some failing cohort remains after this deploys, change 2 turns the next occurrence into a one-look diagnosis instead of another week of blind 500s.

## Test

- `bun test src/lib/steward-sync-profile-refresh.test.ts src/lib/steward-sync-grant.test.ts` (from packages/cloud/shared) → 10 pass: conflict → sign-in continues + constraint inlined in the message; cause-wrapped conflict tolerated; non-conflict failure still aborts (and is logged); grant-fallback suite updated for the interpolated message.
- `cloud/shared` typecheck clean. `cloud/api` typecheck has one **pre-existing** develop error (`v1/eliza/agents/route.ts` `agent_quota_exceeded`), untouched here.
- biome clean.