### PR TITLE
fix(cli-inference): never relay the SDK's "API Error: NNN" envelope as a user reply (leaked 18x live)

### DIFF
--- a/plugins/plugin-cli-inference/__tests__/subscription-limit.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/subscription-limit.test.ts
@@ -45,3 +45,34 @@ describe("isClaudeSubscriptionLimitMessage", () => {
     }
   });
 });
+
+// Second leak class (2026-07-02): the SDK streams upstream API failures as
+// assistant text — "API Error: 400 messages: text content blocks must be
+// non-empty" was relayed verbatim to Discord users 18x when empty relay lines
+// produced an empty content block.
+import { isClaudeSdkApiErrorMessage } from "../src/claude-sdk-session.ts";
+
+describe("isClaudeSdkApiErrorMessage", () => {
+  it("matches the SDK's API-error envelope", () => {
+    for (const s of [
+      "API Error: 400 messages: text content blocks must be non-empty",
+      "API Error: 429 rate limited",
+      "API Error: 529 overloaded",
+      "  API Error: 500 internal server error",
+    ]) {
+      expect(isClaudeSdkApiErrorMessage(s)).toBe(true);
+    }
+  });
+
+  it("does not match genuine answers that mention API errors", () => {
+    for (const s of [
+      "An API Error: 400 usually means your request body is malformed.",
+      "You're seeing 'API Error: 400' because the content block was empty.",
+      "The API returned an error: 400.",
+      "Error handling matters — retry on API Error status codes like 429.",
+      "42",
+    ]) {
+      expect(isClaudeSdkApiErrorMessage(s)).toBe(false);
+    }
+  });
+});

--- a/plugins/plugin-cli-inference/__tests__/subscription-limit.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/subscription-limit.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { isClaudeSubscriptionLimitMessage } from "../src/claude-sdk-session.ts";
+import {
+  isClaudeSdkApiErrorMessage,
+  isClaudeSubscriptionLimitMessage,
+} from "../src/claude-sdk-session.ts";
 
 // Live regression (2026-07-01): when the Agent SDK monthly credit ran dry the SDK
 // ended the turn cleanly but streamed the subscription-limit UI string as the
@@ -8,21 +11,33 @@ import { isClaudeSubscriptionLimitMessage } from "../src/claude-sdk-session.ts";
 describe("isClaudeSubscriptionLimitMessage", () => {
   it("matches the real leaked subscription-limit strings", () => {
     expect(
-      isClaudeSubscriptionLimitMessage("You've hit your session limit · resets 9:30pm (UTC)")
+      isClaudeSubscriptionLimitMessage(
+        "You've hit your session limit · resets 9:30pm (UTC)",
+      ),
     ).toBe(true);
     expect(
-      isClaudeSubscriptionLimitMessage("You've hit your session limit · resets 11:30am (UTC)")
+      isClaudeSubscriptionLimitMessage(
+        "You've hit your session limit · resets 11:30am (UTC)",
+      ),
     ).toBe(true);
     expect(
-      isClaudeSubscriptionLimitMessage("You've reached your usage limit for this month.")
+      isClaudeSubscriptionLimitMessage(
+        "You've reached your usage limit for this month.",
+      ),
     ).toBe(true);
   });
 
   it("matches known envelope variants (CLI epoch form, non-UTC interpunct)", () => {
     // The classic Claude CLI limit string: "Claude AI usage limit reached|<epoch>".
-    expect(isClaudeSubscriptionLimitMessage("Claude AI usage limit reached|1735689600")).toBe(true);
+    expect(
+      isClaudeSubscriptionLimitMessage(
+        "Claude AI usage limit reached|1735689600",
+      ),
+    ).toBe(true);
     // Interpunct separator variants without a "(UTC)" suffix.
-    expect(isClaudeSubscriptionLimitMessage("5-hour limit reached ∙ resets 3am")).toBe(true);
+    expect(
+      isClaudeSubscriptionLimitMessage("5-hour limit reached ∙ resets 3am"),
+    ).toBe(true);
   });
 
   it("does not match genuine model answers, even ones discussing limits", () => {
@@ -50,8 +65,6 @@ describe("isClaudeSubscriptionLimitMessage", () => {
 // assistant text — "API Error: 400 messages: text content blocks must be
 // non-empty" was relayed verbatim to Discord users 18x when empty relay lines
 // produced an empty content block.
-import { isClaudeSdkApiErrorMessage } from "../src/claude-sdk-session.ts";
-
 describe("isClaudeSdkApiErrorMessage", () => {
   it("matches the SDK's API-error envelope", () => {
     for (const s of [

--- a/plugins/plugin-cli-inference/src/claude-sdk-session.ts
+++ b/plugins/plugin-cli-inference/src/claude-sdk-session.ts
@@ -66,7 +66,11 @@ export function isClaudeSubscriptionLimitMessage(text: string): boolean {
   // A genuine short ANSWER about limits ("No, you haven't hit your rate limit
   // yet.") shares vocabulary with the envelope; the envelope itself never
   // contains negation.
-  if (/\b(no|not|haven't|havent|hasn't|hasnt|didn't|didnt|isn't|isnt|wasn't|wasnt)\b/.test(t)) {
+  if (
+    /\b(no|not|haven't|havent|hasn't|hasnt|didn't|didnt|isn't|isnt|wasn't|wasnt)\b/.test(
+      t,
+    )
+  ) {
     return false;
   }
   return (
@@ -128,9 +132,13 @@ type SdkToolFn = (
   handler: (args: {
     action?: unknown;
     params?: unknown;
-  }) => Promise<{ content: Array<{ type: string; text: string }> }>
+  }) => Promise<{ content: Array<{ type: string; text: string }> }>,
 ) => unknown;
-type SdkMcpServerFn = (options: { name: string; version?: string; tools: unknown[] }) => unknown;
+type SdkMcpServerFn = (options: {
+  name: string;
+  version?: string;
+  tools: unknown[];
+}) => unknown;
 
 /** Minimal shape of the SDK module we load lazily. */
 export interface SdkModule {
@@ -193,14 +201,18 @@ function isZodModule(value: unknown): value is ZodModule {
   }
   const z = value.z;
   return (
-    typeof z.string === "function" && typeof z.any === "function" && typeof z.record === "function"
+    typeof z.string === "function" &&
+    typeof z.any === "function" &&
+    typeof z.record === "function"
   );
 }
 
 async function loadSdk(): Promise<SdkModule> {
   const sdk: unknown = await import(SDK_PACKAGE);
   if (!isSdkModule(sdk)) {
-    throw new Error("[cli-inference:sdk] Claude Agent SDK module has an unexpected shape");
+    throw new Error(
+      "[cli-inference:sdk] Claude Agent SDK module has an unexpected shape",
+    );
   }
   return sdk;
 }
@@ -241,7 +253,8 @@ export class ClaudeSdkSession {
     this.model = config.model?.trim() || DEFAULT_MODEL;
     this.systemPrompt = config.systemPrompt?.trim() || null;
     this.router = config.router === true;
-    this.textMaxTurns = config.textMaxTurns && config.textMaxTurns > 0 ? config.textMaxTurns : 1;
+    this.textMaxTurns =
+      config.textMaxTurns && config.textMaxTurns > 0 ? config.textMaxTurns : 1;
     this.claudeExecutablePath = config.claudeExecutablePath?.trim() || null;
     this.restartAfterTurns =
       config.restartAfterTurns && config.restartAfterTurns > 0
@@ -274,7 +287,10 @@ export class ClaudeSdkSession {
     return run;
   }
 
-  private async sendOnce(body: string, mode: "text" | "route"): Promise<string> {
+  private async sendOnce(
+    body: string,
+    mode: "text" | "route",
+  ): Promise<string> {
     if (!body.trim()) {
       throw new Error("[cli-inference:sdk] empty prompt body");
     }
@@ -291,7 +307,9 @@ export class ClaudeSdkSession {
     } catch (err) {
       // Self-heal: a dead/erroring session must not poison the next turn.
       await this.dispose();
-      throw err instanceof Error ? err : new Error(`[cli-inference:sdk] ${String(err)}`);
+      throw err instanceof Error
+        ? err
+        : new Error(`[cli-inference:sdk] ${String(err)}`);
     }
   }
 
@@ -360,8 +378,12 @@ export class ClaudeSdkSession {
                   : {},
             };
           }
-          return { content: [{ type: "text", text: "ACK. Routing recorded. Stop now." }] };
-        }
+          return {
+            content: [
+              { type: "text", text: "ACK. Routing recorded. Stop now." },
+            ],
+          };
+        },
       );
       const mcp = sdk.createSdkMcpServer({
         name: "eliza",
@@ -386,13 +408,20 @@ export class ClaudeSdkSession {
     this.iterator = this.query[Symbol.asyncIterator]();
     this.turns = 0;
     logger.debug(
-      { src: "cli-inference:sdk", model: this.model, mode: this.router ? "route" : "text" },
-      "warm Claude Agent SDK session started"
+      {
+        src: "cli-inference:sdk",
+        model: this.model,
+        mode: this.router ? "route" : "text",
+      },
+      "warm Claude Agent SDK session started",
     );
   }
 
   /** Push one user message and read the turn's assistant text + result envelope. */
-  private async sendAndRead(body: string, mode: "text" | "route"): Promise<string> {
+  private async sendAndRead(
+    body: string,
+    mode: "text" | "route",
+  ): Promise<string> {
     if (!this.feed || !this.iterator) {
       throw new Error("[cli-inference:sdk] session not started");
     }
@@ -449,11 +478,11 @@ export class ClaudeSdkSession {
     // as a REPLY, text mode as the completion). "rate limit" in the thrown
     // message routes it through isRateLimitError.
     const limitEnvelope = [text, resultText ?? ""].find((candidate) =>
-      isClaudeSubscriptionLimitMessage(candidate)
+      isClaudeSubscriptionLimitMessage(candidate),
     );
     if (sawResult && limitEnvelope !== undefined) {
       throw new Error(
-        `[cli-inference:sdk] subscription rate limit reached: ${limitEnvelope.trim().slice(0, 120)}`
+        `[cli-inference:sdk] subscription rate limit reached: ${limitEnvelope.trim().slice(0, 120)}`,
       );
     }
 
@@ -465,11 +494,11 @@ export class ClaudeSdkSession {
     // keeps the SDK's status text so isRateLimitError/isAuthError classify
     // 429/401 correctly downstream.
     const apiErrorEnvelope = [text, resultText ?? ""].find((candidate) =>
-      isClaudeSdkApiErrorMessage(candidate)
+      isClaudeSdkApiErrorMessage(candidate),
     );
     if (apiErrorEnvelope !== undefined) {
       throw new Error(
-        `[cli-inference:sdk] upstream ${apiErrorEnvelope.trim().slice(0, 160)}`
+        `[cli-inference:sdk] upstream ${apiErrorEnvelope.trim().slice(0, 160)}`,
       );
     }
 
@@ -486,7 +515,7 @@ export class ClaudeSdkSession {
         }
       }
       throw new Error(
-        `[cli-inference:sdk] route: model emitted no decision (subtype=${resultSubtype ?? "?"})`
+        `[cli-inference:sdk] route: model emitted no decision (subtype=${resultSubtype ?? "?"})`,
       );
     }
 
@@ -504,7 +533,7 @@ export class ClaudeSdkSession {
     // No trustworthy text: THROW so useModel / AccountPool fails over, per the
     // plugin's throw-to-failover contract — never return partial/meta output.
     throw new Error(
-      `[cli-inference:sdk] empty completion (subtype=${resultSubtype ?? (sawResult ? "?" : "session-ended")})`
+      `[cli-inference:sdk] empty completion (subtype=${resultSubtype ?? (sawResult ? "?" : "session-ended")})`,
     );
   }
 

--- a/plugins/plugin-cli-inference/src/claude-sdk-session.ts
+++ b/plugins/plugin-cli-inference/src/claude-sdk-session.ts
@@ -83,6 +83,19 @@ export function isClaudeSubscriptionLimitMessage(text: string): boolean {
   );
 }
 
+/**
+ * The Claude Code / Agent SDK surfaces API failures by STREAMING its error
+ * string as assistant text and terminating the turn cleanly — e.g.
+ * "API Error: 400 messages: text content blocks must be non-empty" (observed
+ * live 18x when empty relay lines produced an empty text content block).
+ * That format is the SDK's own error envelope, never a genuine completion:
+ * real answers don't open with "API Error: <status>". Detect it so callers
+ * throw to failover instead of relaying the raw error to the user.
+ */
+export function isClaudeSdkApiErrorMessage(text: string): boolean {
+  return /^API Error:\s*\d{3}\b/.test(text.trim());
+}
+
 /** The model's captured routing decision (ROUTE mode). */
 export interface RouteDecision {
   action: string;
@@ -441,6 +454,22 @@ export class ClaudeSdkSession {
     if (sawResult && limitEnvelope !== undefined) {
       throw new Error(
         `[cli-inference:sdk] subscription rate limit reached: ${limitEnvelope.trim().slice(0, 120)}`
+      );
+    }
+
+    // Same leak shape, different envelope: an upstream API failure ("API
+    // Error: 400 messages: text content blocks must be non-empty", 429s, 5xx)
+    // is streamed as assistant text and the turn terminates cleanly — without
+    // this guard it is returned as the completion and relayed verbatim to the
+    // user (observed live 18x). Throw per the failover contract; the message
+    // keeps the SDK's status text so isRateLimitError/isAuthError classify
+    // 429/401 correctly downstream.
+    const apiErrorEnvelope = [text, resultText ?? ""].find((candidate) =>
+      isClaudeSdkApiErrorMessage(candidate)
+    );
+    if (apiErrorEnvelope !== undefined) {
+      throw new Error(
+        `[cli-inference:sdk] upstream ${apiErrorEnvelope.trim().slice(0, 160)}`
       );
     }
 


### PR DESCRIPTION
## Problem — raw `API Error: 400 …` relayed to Discord users 18×

Live incident (cozy dev server, 2026-07-01 ~23:00 UTC): empty Minecraft-relay lines (`2fingersBTW | ZenithProxy: ` with no content) reached the RESPONSE_HANDLER; the flattened prompt produced an empty text content block; Anthropic rejected it with 400. The Agent SDK then **streamed its own error string as assistant text and terminated the turn cleanly** — so `sendAndRead` returned

```
API Error: 400 messages: text content blocks must be non-empty
```

as the "completion", and the bot posted it verbatim to the channel. 18 occurrences in the log; users immediately noticed ("so it can't see tags, weird").

Same leak shape as the subscription-limit envelope fixed in #10944/#10975 — the SDK surfaces a meta-string as assistant text — just a different envelope.

## Fix

`isClaudeSdkApiErrorMessage` next to the existing limit detector: start-anchored `^API Error:\s*\d{3}\b`. The SDK's error format is never a genuine completion — real answers that *discuss* API errors ("An API Error: 400 usually means…") don't open with the envelope, and the anchor keeps them out. Guarded in `sendAndRead` right after the limit check, before either mode returns, checking both the streamed text and the result-envelope echo. The thrown message keeps the SDK's status text so `isRateLimitError` / `isAuthError` classify 429/401 correctly downstream, and the useModel failover (#10969) gets a classed throw instead of a poisoned completion.

## Tests

- +2 test groups (10 assertions): the envelope matches across statuses (400/429/529, leading whitespace); genuine answers mentioning API errors mid-sentence do not.
- plugin suite: 5 files, 68/68 green; typecheck 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
