### PR TITLE
fix(agent): pass sandbox character settings and knowledge

### DIFF
--- a/packages/agent/src/runtime/__tests__/sandbox-character.test.ts
+++ b/packages/agent/src/runtime/__tests__/sandbox-character.test.ts
@@ -29,6 +29,8 @@ describe("applySandboxCharacterFromEnv", () => {
       topics: ["lore"],
       adjectives: ["sharp"],
       style: { all: ["concise"] },
+      settings: { discord: { autoReply: true } },
+      knowledge: [{ directory: "/knowledge" }],
     };
     const config = {} as never;
     const out = applySandboxCharacterFromEnv(config, {
@@ -40,6 +42,8 @@ describe("applySandboxCharacterFromEnv", () => {
     expect(entry.name).toBe("Nyx");
     expect(entry.system).toBe("You are Nyx.");
     expect(entry.bio).toEqual(["A mysterious agent."]);
+    expect(entry.settings).toEqual({ discord: { autoReply: true } });
+    expect(entry.knowledge).toEqual([{ directory: "/knowledge" }]);
     // The id MUST be the routing id so runtime.agentId matches the gateway.
     expect(entry.id).toBe("char-route");
     expect(entry.default).toBe(true);

--- a/packages/agent/src/runtime/build-character-config.test.ts
+++ b/packages/agent/src/runtime/build-character-config.test.ts
@@ -81,3 +81,47 @@ describe("Matrix connector secret/settings boundary", () => {
     expect("MATRIX_ACCESS_TOKEN" in secrets).toBe(false);
   });
 });
+
+describe("agent entry character passthrough", () => {
+  it("preserves injected Discord auto-reply settings", () => {
+    const character = buildCharacterFromConfig({
+      agents: {
+        list: [
+          {
+            id: "nyx",
+            name: "Nyx",
+            system: "You are Nyx.",
+            settings: { discord: { autoReply: true } },
+          },
+        ],
+      },
+    } as ElizaConfig);
+
+    expect(character.settings?.discord).toEqual({ autoReply: true });
+    expect(character.settings?.ADVANCED_CAPABILITIES).toBe("true");
+  });
+
+  it("preserves injected knowledge directories for document ingestion", () => {
+    const character = buildCharacterFromConfig({
+      agents: {
+        list: [
+          {
+            id: "nyx",
+            name: "Nyx",
+            system: "You are Nyx.",
+            knowledge: [{ directory: "/knowledge" }],
+          },
+        ],
+      },
+    } as ElizaConfig);
+
+    expect(character.documents).toEqual([
+      {
+        item: {
+          case: "directory",
+          value: { directory: "/knowledge" },
+        },
+      },
+    ]);
+  });
+});

--- a/packages/agent/src/runtime/build-character-config.ts
+++ b/packages/agent/src/runtime/build-character-config.ts
@@ -1,5 +1,6 @@
 import {
   type Character,
+  type CharacterInput,
   defaultCharacterSystemTemplate,
   mergeCharacterDefaults,
 } from "@elizaos/core";
@@ -70,6 +71,9 @@ export function buildCharacterFromConfig(config: ElizaConfig): Character {
     agentEntry?.advancedMemory ??
     config.agents?.defaults?.advancedMemory ??
     true;
+  const knowledge = agentEntry?.knowledge as
+    | CharacterInput["knowledge"]
+    | undefined;
   // Lean cloud chat agents (ELIZA_PLUGIN_SET=lean-chat) skip advanced
   // capabilities. The reflection/fact/relationship/identity evaluators they
   // register fan out a SERIAL cloud-embedding call per extracted item every
@@ -255,6 +259,10 @@ export function buildCharacterFromConfig(config: ElizaConfig): Character {
     capabilityHints.length > 0
       ? `${systemPrompt}\n\n${capabilityHints.join("\n")}`
       : systemPrompt;
+  const mergedSettings = {
+    ...(agentEntry?.settings ?? {}),
+    ...settings,
+  };
 
   return mergeCharacterDefaults({
     name,
@@ -266,8 +274,9 @@ export function buildCharacterFromConfig(config: ElizaConfig): Character {
     ...(adjectives ? { adjectives } : {}),
     ...(postExamples ? { postExamples } : {}),
     ...(mappedExamples ? { messageExamples: mappedExamples } : {}),
+    ...(knowledge ? { knowledge } : {}),
     advancedMemory,
-    settings,
+    settings: mergedSettings,
     secrets,
   });
 }

--- a/packages/agent/src/runtime/sandbox-character.ts
+++ b/packages/agent/src/runtime/sandbox-character.ts
@@ -15,7 +15,7 @@
  * so it is inert for every non-provisioned runtime.
  */
 
-import { logger } from "@elizaos/core";
+import { logger, type CharacterSettings } from "@elizaos/core";
 import type { AgentConfig } from "@elizaos/shared";
 import type { ElizaConfig } from "../config/config.ts";
 
@@ -34,7 +34,8 @@ interface SandboxCharacterJson {
   // or the @elizaos/core {examples:[{name,content}]} form; buildCharacterFromConfig
   // normalises both, so we pass it through untouched.
   messageExamples?: unknown;
-  settings?: Record<string, unknown>;
+  settings?: CharacterSettings;
+  knowledge?: AgentConfig["knowledge"];
   /**
    * Per-character connector config (e.g. `{ discord: { ... }, telegram: {...} }`).
    * Only applied when the container is the connector owner
@@ -148,6 +149,8 @@ export function applySandboxCharacterFromEnv(
             parsed.messageExamples as AgentConfig["messageExamples"],
         }
       : {}),
+    ...(parsed.settings ? { settings: parsed.settings } : {}),
+    ...(parsed.knowledge ? { knowledge: parsed.knowledge } : {}),
   };
 
   const agents = (config.agents ?? {}) as NonNullable<ElizaConfig["agents"]>;

--- a/packages/shared/src/config/types.agents.ts
+++ b/packages/shared/src/config/types.agents.ts
@@ -1,4 +1,6 @@
 import type {
+  CharacterSettings,
+  DocumentSourceItem,
   GroupChatConfig,
   HumanDelayConfig,
   IdentityConfig,
@@ -10,6 +12,12 @@ import type {
   SandboxPruneSettings,
 } from "./types.agent-defaults.js";
 import type { AgentToolsConfig, MemorySearchConfig } from "./types.tools.js";
+
+export type AgentKnowledgeSource =
+  | DocumentSourceItem
+  | string
+  | { path: string; shared?: boolean }
+  | { directory: string; shared?: boolean };
 
 export type AgentModelConfig =
   | string
@@ -63,6 +71,10 @@ export type AgentConfig = {
   /** Example social media posts in Chinese (zh-CN) demonstrating the agent's voice. */
   postExamples_zhCN?: string[];
   messageExamples?: Array<Array<{ user: string; content: { text: string } }>>;
+  /** Per-character runtime settings passed through to @elizaos/core Character. */
+  settings?: CharacterSettings;
+  /** Per-character knowledge sources passed through for document ingestion. */
+  knowledge?: AgentKnowledgeSource[];
   subagents?: {
     /** Allow spawning sub-agents under other agent ids. Use "*" to allow any. */
     allowAgents?: string[];


### PR DESCRIPTION
## Summary

- Pass `settings` and `knowledge` from `ELIZA_AGENT_CHARACTER_JSON` through the sandbox character config entry.
- Merge per-agent character settings into the final `Character.settings` without overriding runtime/env-derived settings.
- Forward per-agent knowledge sources into character document ingestion so `{ directory: "/knowledge" }` survives boot.

## Tests

- `bunx vitest run --config packages/agent/vitest.config.ts packages/agent/src/runtime/__tests__/sandbox-character.test.ts packages/agent/src/runtime/build-character-config.test.ts` ✅
- `bun run --cwd packages/agent typecheck` ⚠️ fails on existing unrelated workspace/plugin dependency/type errors (`viem`, `@lifi/sdk`, `@solana/web3.js`, `lucide-react`, plugin-wallet chain typing). No errors from the touched files when filtered.
- `git diff --check` ✅

## Notes

- Checked open PRs/issues for this exact `ELIZA_AGENT_CHARACTER_JSON` settings/knowledge passthrough concern before opening. Found no exact open PR; issue #8434 is a broad launch tracker, not this scoped fix.
- Did not run Codex review because local usage limits are currently constrained, per coordination note.
