### PR TITLE
fix(core): wait for embeddings before character docs

### DIFF
--- a/packages/core/src/features/documents/service-character-ingest.test.ts
+++ b/packages/core/src/features/documents/service-character-ingest.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { createMockRuntime, MOCK_AGENT_ID } from "../../testing/mock-runtime";
+import type { Memory, UUID } from "../../types";
+import { MemoryType, ModelType } from "../../types";
+import { DocumentService } from "./service.ts";
+
+const DOCUMENTS_TABLE = "documents";
+const DOCUMENT_FRAGMENTS_TABLE = "document_fragments";
+
+function embeddingFor(text: string): number[] {
+	return [text.length, 1, 0.5];
+}
+
+describe("DocumentService character document ingestion boot races", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	test("waits for delayed TEXT_EMBEDDING registration before ingesting character documents", async () => {
+		vi.useFakeTimers();
+
+		let embeddingRegistered = false;
+		const created: Array<{ memory: Memory; table: string }> = [];
+
+		const runtime = createMockRuntime({
+			getSetting: () => undefined,
+			getModel: (type: string) =>
+				type === ModelType.TEXT_EMBEDDING && embeddingRegistered
+					? async () => embeddingFor("registered")
+					: undefined,
+			getMemoryById: async () => null,
+			getMemories: async () => [],
+			createMemory: async (memory: Memory, table: string): Promise<UUID> => {
+				created.push({ memory, table });
+				return memory.id as UUID;
+			},
+			updateMemory: async () => true,
+			deleteMemory: async () => {},
+			addEmbeddingToMemory: async (memory: Memory) => {
+				memory.embedding = embeddingFor(memory.content.text ?? "");
+				return memory;
+			},
+		});
+		const service = new DocumentService(runtime);
+
+		setTimeout(() => {
+			embeddingRegistered = true;
+		}, 1_075);
+
+		const processing = service.processCharacterDocuments(
+			["Character knowledge that should not ingest until embeddings exist."],
+			{ embeddingWaitTimeoutMs: 500, embeddingWaitIntervalMs: 25 },
+		);
+
+		await vi.advanceTimersByTimeAsync(1_000);
+		expect(created).toHaveLength(0);
+
+		await vi.advanceTimersByTimeAsync(100);
+		await processing;
+
+		expect(created.some((entry) => entry.table === DOCUMENTS_TABLE)).toBe(true);
+		expect(
+			created.some((entry) => entry.table === DOCUMENT_FRAGMENTS_TABLE),
+		).toBe(true);
+		expect(
+			created
+				.filter((entry) => entry.table === DOCUMENT_FRAGMENTS_TABLE)
+				.every((entry) => Array.isArray(entry.memory.embedding)),
+		).toBe(true);
+	});
+
+	test("reprocesses an existing content-id document stub when it has zero fragments", async () => {
+		const created: Array<{ memory: Memory; table: string }> = [];
+		const deleted: UUID[] = [];
+		let existingDocumentId: UUID | null = null;
+
+		const runtime = createMockRuntime({
+			getSetting: () => undefined,
+			getModel: (type: string) =>
+				type === ModelType.TEXT_EMBEDDING
+					? async () => embeddingFor("registered")
+					: undefined,
+			getMemoryById: async (id: UUID) => {
+				if (existingDocumentId === null) {
+					existingDocumentId = id;
+				}
+				if (id !== existingDocumentId || deleted.includes(id)) {
+					return null;
+				}
+				return {
+					id,
+					agentId: MOCK_AGENT_ID,
+					content: { text: "stale stub" },
+					metadata: { type: MemoryType.DOCUMENT, documentId: id },
+				} as Memory;
+			},
+			getMemories: async ({ tableName }) =>
+				tableName === DOCUMENT_FRAGMENTS_TABLE ? [] : [],
+			deleteMemory: async (id: UUID) => {
+				deleted.push(id);
+			},
+			createMemory: async (memory: Memory, table: string): Promise<UUID> => {
+				created.push({ memory, table });
+				return memory.id as UUID;
+			},
+			updateMemory: async () => true,
+			useModel: async (type: string, params: { text?: string }) => {
+				if (type !== ModelType.TEXT_EMBEDDING) {
+					throw new Error(`unexpected model ${type}`);
+				}
+				return embeddingFor(params.text ?? "");
+			},
+		});
+		const service = new DocumentService(runtime);
+
+		const result = await service.addDocument({
+			agentId: MOCK_AGENT_ID,
+			worldId: MOCK_AGENT_ID,
+			roomId: MOCK_AGENT_ID,
+			entityId: MOCK_AGENT_ID,
+			content: "A document that previously booted into a zero-fragment stub.",
+			contentType: "text/plain",
+			originalFilename: "boot-race.txt",
+		});
+
+		expect(existingDocumentId).toBe(result.clientDocumentId);
+		expect(deleted).toEqual([result.clientDocumentId]);
+		expect(result.fragmentCount).toBeGreaterThan(0);
+		expect(created.some((entry) => entry.table === DOCUMENTS_TABLE)).toBe(true);
+		expect(
+			created.some((entry) => entry.table === DOCUMENT_FRAGMENTS_TABLE),
+		).toBe(true);
+	});
+});

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -64,6 +64,8 @@ const HYBRID_BM25_WEIGHT = 1 - HYBRID_VECTOR_WEIGHT;
 const DOCUMENTS_TABLE = "documents";
 const DOCUMENT_FRAGMENTS_TABLE = "document_fragments";
 const PRE_DOCUMENTS_TABLE = "knowledge";
+const CHARACTER_DOCUMENT_EMBEDDING_WAIT_TIMEOUT_MS = 120_000;
+const CHARACTER_DOCUMENT_EMBEDDING_WAIT_INTERVAL_MS = 1_000;
 const DOCUMENT_SCOPES = new Set<DocumentVisibilityScope>([
 	"global",
 	"owner-private",
@@ -643,24 +645,24 @@ export class DocumentService extends Service {
 				(existingDocument.metadata?.type === MemoryType.DOCUMENT ||
 					existingDocument.metadata?.type === MemoryType.CUSTOM)
 			) {
-				logger.info(`"${options.originalFilename}" already exists - skipping`);
+				const fragmentCount =
+					await this.getDocumentFragmentCount(contentBasedId);
+				if (fragmentCount === 0) {
+					logger.warn(
+						`"${options.originalFilename}" already exists with 0 fragments; deleting stale document stub and reprocessing`,
+					);
+					await this.runtime.deleteMemory(contentBasedId);
+				} else {
+					logger.info(
+						`"${options.originalFilename}" already exists with ${fragmentCount} fragments - skipping`,
+					);
 
-				const fragments = await this.runtime.getMemories({
-					tableName: DOCUMENT_FRAGMENTS_TABLE,
-				});
-
-				const relatedFragments = fragments.filter(
-					(f) =>
-						f.metadata?.type === MemoryType.FRAGMENT &&
-						(f.metadata as DocumentFragmentMemoryMetadata | undefined)
-							?.documentId === contentBasedId,
-				);
-
-				return {
-					clientDocumentId: contentBasedId,
-					storedDocumentMemoryId: existingDocument.id as UUID,
-					fragmentCount: relatedFragments.length,
-				};
+					return {
+						clientDocumentId: contentBasedId,
+						storedDocumentMemoryId: existingDocument.id as UUID,
+						fragmentCount,
+					};
+				}
 			}
 		} catch (error) {
 			logger.debug(
@@ -869,9 +871,42 @@ export class DocumentService extends Service {
 		}
 	}
 
+	private async getDocumentFragmentCount(documentId: UUID): Promise<number> {
+		const fragments = await this.runtime.getMemories({
+			tableName: DOCUMENT_FRAGMENTS_TABLE,
+			agentId: this.runtime.agentId,
+			count: 10_000,
+		});
+
+		return fragments.filter(
+			(f) =>
+				f.metadata?.type === MemoryType.FRAGMENT &&
+				(f.metadata as DocumentFragmentMemoryMetadata | undefined)
+					?.documentId === documentId,
+		).length;
+	}
+
 	async checkExistingDocument(documentId: UUID): Promise<boolean> {
 		const existingDocument = await this.runtime.getMemoryById(documentId);
-		return !!existingDocument;
+		if (!existingDocument) {
+			return false;
+		}
+
+		if (
+			existingDocument.metadata?.type === MemoryType.DOCUMENT ||
+			existingDocument.metadata?.type === MemoryType.CUSTOM
+		) {
+			const fragmentCount = await this.getDocumentFragmentCount(documentId);
+			if (fragmentCount === 0) {
+				logger.warn(
+					`Document ${documentId} already exists with 0 fragments; deleting stale document stub and reprocessing`,
+				);
+				await this.runtime.deleteMemory(documentId);
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	async searchDocuments(
@@ -1249,8 +1284,68 @@ export class DocumentService extends Service {
 		}
 	}
 
-	async processCharacterDocuments(items: string[]): Promise<void> {
+	private async waitForCharacterDocumentEmbeddingModel(options?: {
+		timeoutMs?: number;
+		intervalMs?: number;
+	}): Promise<boolean> {
+		if (this.runtime.getModel(ModelType.TEXT_EMBEDDING)) {
+			return true;
+		}
+
+		const timeoutMs =
+			options?.timeoutMs ?? CHARACTER_DOCUMENT_EMBEDDING_WAIT_TIMEOUT_MS;
+		const intervalMs = Math.max(
+			1,
+			options?.intervalMs ?? CHARACTER_DOCUMENT_EMBEDDING_WAIT_INTERVAL_MS,
+		);
+		const deadline = Date.now() + timeoutMs;
+		let attempts = 0;
+
+		logger.info(
+			`TEXT_EMBEDDING model is not registered yet; waiting up to ${timeoutMs}ms before processing character documents`,
+		);
+
+		while (Date.now() < deadline) {
+			attempts++;
+			await new Promise((resolve) =>
+				setTimeout(
+					resolve,
+					Math.min(intervalMs, Math.max(1, deadline - Date.now())),
+				),
+			);
+
+			if (this.runtime.getModel(ModelType.TEXT_EMBEDDING)) {
+				logger.info(
+					`TEXT_EMBEDDING model registered after ${attempts} wait attempt(s); processing character documents`,
+				);
+				return true;
+			}
+		}
+
+		logger.warn(
+			`TEXT_EMBEDDING model was still not registered after ${timeoutMs}ms; skipping character document ingestion to avoid creating empty-fragment stubs`,
+		);
+		return false;
+	}
+
+	async processCharacterDocuments(
+		items: string[],
+		options?: {
+			embeddingWaitTimeoutMs?: number;
+			embeddingWaitIntervalMs?: number;
+		},
+	): Promise<void> {
 		await new Promise((resolve) => setTimeout(resolve, 1000));
+		const hasEmbeddingModel = await this.waitForCharacterDocumentEmbeddingModel(
+			{
+				timeoutMs: options?.embeddingWaitTimeoutMs,
+				intervalMs: options?.embeddingWaitIntervalMs,
+			},
+		);
+		if (!hasEmbeddingModel) {
+			return;
+		}
+
 		logger.info(`Processing ${items.length} character documents items`);
 
 		const processingPromises = items.map(async (item) => {


### PR DESCRIPTION
## Summary
- wait for `ModelType.TEXT_EMBEDDING` before processing character `documents` / `knowledge` entries on startup
- bound the wait at 120s with clear logs, and skip character ingestion rather than creating empty-fragment stubs if the handler never appears
- treat existing document memories with zero fragments as stale stubs: delete and reprocess instead of permanently skipping future ingestion

## Why
Production hit a boot race where character knowledge loaded before deferred model plugins registered `TEXT_EMBEDDING`. Each chunk failed with `No handler found for delegate type: TEXT_EMBEDDING`, but the document row was still stored with 0 fragments. Later boots saw the document id already existed and skipped it forever.

I checked open PRs/issues for this exact concern first. I only found broad trackers, not an existing targeted fix for character document ingestion + zero-fragment stub recovery.

## Tests
- `bun run --cwd packages/core test src/features/documents/service-character-ingest.test.ts`
- `bun run --cwd packages/core test src/features/documents/service-character-ingest.test.ts src/features/documents/service-batch-embed.test.ts src/features/documents/recall-embed.test.ts src/features/documents/utils.test.ts src/features/documents/__tests__/search.test.ts`
- `node packages/shared/scripts/generate-keywords.mjs --target ts && bun run --cwd packages/core typecheck`
- `bunx @biomejs/biome check packages/core/src/features/documents/service.ts packages/core/src/features/documents/service-character-ingest.test.ts`

## Notes
- Codex review intentionally not run due local usage limits.
- No dev-wiring files touched.
