### PR TITLE
fix(cloud): self-heal orphaned rate-limit counters — dropped pexpire bricks an IP/key with permanent 429s (live prod incident)

### DIFF
--- a/packages/cloud/shared/src/lib/middleware/rate-limit-hono-cloudflare.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-hono-cloudflare.ts
@@ -5,7 +5,11 @@
  */
 
 import type { Context, MiddlewareHandler } from "hono";
-import type { AppContext, AppEnv, Bindings } from "../../types/cloud-worker-env";
+import type {
+  AppContext,
+  AppEnv,
+  Bindings,
+} from "../../types/cloud-worker-env";
 import { buildRedisClient, type CompatibleRedis } from "../cache/redis-factory";
 import { logger } from "../utils/logger";
 
@@ -99,7 +103,11 @@ interface CheckResult {
   retryAfter?: number;
 }
 
-function rateLimitHeaders(config: RateLimitConfig, result: CheckResult, policy: string) {
+function rateLimitHeaders(
+  config: RateLimitConfig,
+  result: CheckResult,
+  policy: string,
+) {
   return {
     "X-RateLimit-Limit": String(config.maxRequests),
     "X-RateLimit-Remaining": String(result.remaining),
@@ -116,13 +124,16 @@ function fallOpenResult(config: RateLimitConfig): CheckResult {
   };
 }
 
-function applyRateLimitHeaders(c: Context, headers: Record<string, string>): void {
+function applyRateLimitHeaders(
+  c: Context,
+  headers: Record<string, string>,
+): void {
   for (const [k, v] of Object.entries(headers)) {
     c.res.headers.set(k, v);
   }
 }
 
-async function checkUpstash(
+export async function checkUpstash(
   redis: CompatibleRedis,
   key: string,
   windowMs: number,
@@ -130,11 +141,20 @@ async function checkUpstash(
 ): Promise<CheckResult> {
   const fullKey = `ratelimit:${key}`;
   const count = await redis.incr(fullKey);
-  if (count === 1) {
+  let ttl = count === 1 ? null : await redis.pttl(fullKey);
+  if (count === 1 || ttl === null || ttl < 0) {
+    // First request of a window — or an ORPHANED counter: if the pexpire after
+    // a previous window's first incr ever failed (Workers sub-request drop),
+    // the key has no TTL (pttl -1), so the counter grows forever and the
+    // client is permanently 429'd while resetAt/retryAfter keep promising a
+    // 60s reset that never happens (observed live: an IP at ~26 req/hour
+    // locked out of every endpoint, including public /models). Always re-arm
+    // the window here so a missed expiry heals on the next request instead of
+    // bricking the key.
     await redis.pexpire(fullKey, windowMs);
+    ttl = windowMs;
   }
-  const ttl = await redis.pttl(fullKey);
-  const resetAt = Date.now() + (ttl !== null && ttl > 0 ? ttl : windowMs);
+  const resetAt = Date.now() + (ttl > 0 ? ttl : windowMs);
   const allowed = count <= maxRequests;
   return {
     allowed,
@@ -155,18 +175,25 @@ export function rateLimit(config: RateLimitConfig): MiddlewareHandler<AppEnv> {
     }
 
     if (
-      (env.RATE_LIMIT_DISABLED === "true" || env.PLAYWRIGHT_TEST_AUTH === "true") &&
+      (env.RATE_LIMIT_DISABLED === "true" ||
+        env.PLAYWRIGHT_TEST_AUTH === "true") &&
       env.NODE_ENV !== "production"
     ) {
       await next();
-      applyRateLimitHeaders(c, rateLimitHeaders(config, fallOpenResult(config), "disabled"));
+      applyRateLimitHeaders(
+        c,
+        rateLimitHeaders(config, fallOpenResult(config), "disabled"),
+      );
       return;
     }
 
     const redis = getRedis(env);
     if (!redis) {
       await next();
-      applyRateLimitHeaders(c, rateLimitHeaders(config, fallOpenResult(config), "fall-open"));
+      applyRateLimitHeaders(
+        c,
+        rateLimitHeaders(config, fallOpenResult(config), "fall-open"),
+      );
       return;
     }
 
@@ -175,7 +202,12 @@ export function rateLimit(config: RateLimitConfig): MiddlewareHandler<AppEnv> {
     let policy = "redis";
 
     try {
-      result = await checkUpstash(redis, key, config.windowMs, config.maxRequests);
+      result = await checkUpstash(
+        redis,
+        key,
+        config.windowMs,
+        config.maxRequests,
+      );
     } catch (error) {
       // Rate limiting is protective middleware. If its backing store is down
       // or unreachable in local Worker dev, requests should fall open instead

--- a/packages/cloud/shared/src/lib/middleware/rate-limit-orphaned-counter.test.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-orphaned-counter.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "bun:test";
+import type { CompatibleRedis } from "../cache/redis-factory";
+import { checkUpstash } from "./rate-limit-hono-cloudflare";
+
+// Live incident (2026-07-02): an IP making ~26 requests/hour was permanently
+// 429'd on EVERY endpoint (including the public /models) with
+// "retryAfter: 60" that never came true. Root cause: `pexpire` is only issued
+// on count===1; if that one sub-request drops, the counter key has no TTL
+// (pttl -1) and grows forever. checkUpstash must self-heal orphaned counters.
+function fakeRedis(state: { count: number; ttl: number | null }) {
+  const calls: string[] = [];
+  const redis = {
+    incr: async () => {
+      calls.push("incr");
+      state.count += 1;
+      return state.count;
+    },
+    pexpire: async (_key: string, ms: number) => {
+      calls.push("pexpire");
+      state.ttl = ms;
+      return 1;
+    },
+    pttl: async () => {
+      calls.push("pttl");
+      return state.ttl ?? -1;
+    },
+  } as unknown as CompatibleRedis;
+  return { redis, calls, state };
+}
+
+describe("checkUpstash — orphaned-counter self-heal", () => {
+  it("re-arms the window when the counter has no TTL (pttl -1)", async () => {
+    // A bricked key: huge count, no expiry (the original pexpire was lost).
+    const { redis, calls, state } = fakeRedis({ count: 50_000, ttl: null });
+    const result = await checkUpstash(redis, "ip:1.2.3.4", 60_000, 600);
+    // Still denied this request (the count is real), but the key now expires:
+    expect(result.allowed).toBe(false);
+    expect(calls).toContain("pexpire");
+    expect(state.ttl).toBe(60_000);
+    // ... so the NEXT window starts clean instead of 429ing forever.
+  });
+
+  it("arms the window on the first request of a window", async () => {
+    const { redis, state } = fakeRedis({ count: 0, ttl: null });
+    const result = await checkUpstash(redis, "ip:1.2.3.4", 60_000, 600);
+    expect(result.allowed).toBe(true);
+    expect(state.ttl).toBe(60_000);
+    expect(result.remaining).toBe(599);
+  });
+
+  it("does NOT re-arm a healthy in-window counter (would extend the window)", async () => {
+    const { redis, calls } = fakeRedis({ count: 10, ttl: 30_000 });
+    const result = await checkUpstash(redis, "ip:1.2.3.4", 60_000, 600);
+    expect(result.allowed).toBe(true);
+    expect(calls).not.toContain("pexpire");
+    // resetAt reflects the REAL remaining window, not a fresh one.
+    expect(result.resetAt - Date.now()).toBeLessThanOrEqual(30_000);
+  });
+
+  it("reports an honest retryAfter for a denied request on a healed key", async () => {
+    const { redis } = fakeRedis({ count: 700, ttl: null });
+    const result = await checkUpstash(redis, "ip:1.2.3.4", 60_000, 600);
+    expect(result.allowed).toBe(false);
+    expect(result.retryAfter).toBeGreaterThan(0);
+    expect(result.retryAfter).toBeLessThanOrEqual(60);
+  });
+});


### PR DESCRIPTION
## Production incident (live, 2026-07-02 ~00:45 UTC): one IP permanently 429'd on every endpoint

An IP making **~26 requests/hour** got hard-locked out of the entire API — authed inference, `credits/summary`, apps, and the **public `/models`** — with:

```
429 {"code":"rate_limit_exceeded","message":"Rate limit exceeded. Maximum 600 requests per 60 seconds.","retryAfter":60}
```

`retryAfter: 60` never came true — the 429 persisted across many minutes of near-zero traffic. Timeline detail that gives the bug away: the key worked fine for ~2 hours of light use, then flipped to permanent 429 — i.e. right when the **cumulative** request count crossed 600.

## Root cause — `checkUpstash` orphans its counter if one `pexpire` drops

```ts
const count = await redis.incr(fullKey);
if (count === 1) {
  await redis.pexpire(fullKey, windowMs);   // ← issued exactly once, ever
}
```

If that single `pexpire` sub-request is lost (Workers sub-request drop, Upstash REST hiccup), the key has **no TTL** (`pttl` → -1) and increments forever. Once the cumulative count crosses `maxRequests`, every request is denied — and the `pttl <= 0` fallback (`resetAt = now + windowMs`) **fabricates a 60s reset** in the response headers, so the client is told to retry-in-60 forever.

## Fix

Re-arm the window whenever the key has no TTL (`count === 1` **or** `pttl < 0`) — a missed expiry now heals on the next request instead of bricking the key. The inflated count is left intact and expires with the re-armed window (a real abuser stays limited; the healed key recovers within one window). Also saves a `pttl` round-trip on the first-request path.

Ops note: existing orphaned keys in prod Redis heal automatically on the first request after this deploys — no manual `DEL ratelimit:*` needed (though it wouldn't hurt).

## Second observation (not changed here, flagging for the cloud owners)

`getDefaultKey` returns the literal `"public"` for unauthenticated requests with no anon session — one **global** bucket shared by all anonymous traffic worldwide. If any public route uses the default key generator rather than `getIpKey`, normal aggregate traffic + one crawler exhausts 600/min for everyone. Worth an audit of which presets each public route uses.

## Tests

4 regression tests with a fake `CompatibleRedis` (`rate-limit-orphaned-counter.test.ts`): bricked-key re-arm; first-request arming; **no** re-arm of a healthy in-window counter (would silently extend windows); honest `retryAfter` on a healed-but-denied key. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
