### PR TITLE
perf(orchestrator): cache session metadata + evict terminal legacy task state in SwarmCoordinatorService

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/swarm-coordinator-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/swarm-coordinator-service.test.ts
@@ -30,6 +30,7 @@ function makeAcpStub(session?: Record<string, unknown>) {
   let handler:
     | ((sessionId: string, event: string, data: unknown) => void)
     | null = null;
+  let currentSession = session;
   return {
     onSessionEvent: vi.fn(
       (h: (sessionId: string, event: string, data: unknown) => void) => {
@@ -39,7 +40,10 @@ function makeAcpStub(session?: Record<string, unknown>) {
         };
       },
     ),
-    getSession: vi.fn(async () => session),
+    getSession: vi.fn(async () => currentSession),
+    setSession(nextSession?: Record<string, unknown>) {
+      currentSession = nextSession;
+    },
     emit(sessionId: string, event: string, data: unknown) {
       handler?.(sessionId, event, data);
     },
@@ -454,6 +458,149 @@ describe("SwarmCoordinatorService", () => {
       ],
     });
     await coordinator.stop();
+  });
+  it("caches session metadata per session so streaming events do not re-hit getSession", async () => {
+    const acp = makeAcpStub({
+      agentType: "codex",
+      workdir: "/tmp/wd",
+      metadata: { label: "build-site", originRoomId: "origin-room-20" },
+    });
+    const runtime = makeRuntime({ [AcpService.serviceType]: acp });
+    const coordinator = await SwarmCoordinatorService.start(runtime);
+
+    const received: SwarmEvent[] = [];
+    coordinator.subscribe((e) => received.push(e));
+
+    // First enrichable event populates the cache with exactly one lookup.
+    acp.emit("sess-cache", "tool_running", { toolCall: { title: "Bash" } });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(acp.getSession).toHaveBeenCalledTimes(1);
+
+    // Later enrichable events reuse the cache: no further getSession calls.
+    acp.emit("sess-cache", "tool_running", { toolCall: { title: "Read" } });
+    acp.emit("sess-cache", "usage_update", { tokens: 10 });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(acp.getSession).toHaveBeenCalledTimes(1);
+
+    // Cached metadata still enriches later events.
+    expect(received.at(-1)?.data).toMatchObject({
+      originRoomId: "origin-room-20",
+      label: "build-site",
+      workdir: "/tmp/wd",
+      agentType: "codex",
+    });
+    await coordinator.stop();
+  });
+
+  it("does not cache a session miss (event racing session persistence)", async () => {
+    const acp = makeAcpStub(undefined);
+    const runtime = makeRuntime({ [AcpService.serviceType]: acp });
+    const coordinator = await SwarmCoordinatorService.start(runtime);
+
+    const received: SwarmEvent[] = [];
+    coordinator.subscribe((e) => received.push(e));
+
+    // Event arrives before the session is persisted: no metadata available.
+    acp.emit("sess-race", "tool_running", {});
+    await new Promise((r) => setTimeout(r, 0));
+    expect(received.at(-1)?.data).not.toHaveProperty("label");
+
+    // Session shows up. The next event must retry the lookup (miss not pinned).
+    acp.setSession({
+      agentType: "codex",
+      workdir: "/tmp/wd",
+      metadata: { label: "late-session", originRoomId: "origin-room-30" },
+    });
+    acp.emit("sess-race", "tool_running", {});
+    await new Promise((r) => setTimeout(r, 0));
+    expect(received.at(-1)?.data).toMatchObject({
+      label: "late-session",
+      originRoomId: "origin-room-30",
+      workdir: "/tmp/wd",
+    });
+    await coordinator.stop();
+  });
+
+  it("skips getSession enrichment for high-frequency streaming events", async () => {
+    const acp = makeAcpStub({
+      agentType: "codex",
+      metadata: { label: "build-site" },
+    });
+    const runtime = makeRuntime({ [AcpService.serviceType]: acp });
+    const coordinator = await SwarmCoordinatorService.start(runtime);
+
+    const received: SwarmEvent[] = [];
+    coordinator.subscribe((e) => received.push(e));
+
+    acp.emit("sess-stream", "message", { text: "chunk 1" });
+    acp.emit("sess-stream", "reasoning", { text: "thinking" });
+    acp.emit("sess-stream", "plan", { entries: [] });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(acp.getSession).not.toHaveBeenCalled();
+    expect(received).toHaveLength(3);
+    // Raw payloads pass through untouched.
+    expect(received[0].data).toEqual({ text: "chunk 1" });
+    await coordinator.stop();
+  });
+
+  it("evicts legacy task state after the post-terminal grace window", async () => {
+    vi.useFakeTimers();
+    try {
+      const acp = makeAcpStub({
+        agentType: "codex",
+        workdir: "/tmp/wd",
+        metadata: { label: "build-site", initialTask: "build it" },
+      });
+      const runtime = makeRuntime({ [AcpService.serviceType]: acp });
+      const coordinator = await SwarmCoordinatorService.start(runtime);
+
+      acp.emit("sess-evict", "tool_running", {});
+      await vi.advanceTimersByTimeAsync(0);
+      expect(coordinator.tasks.has("sess-evict")).toBe(true);
+
+      acp.emit("sess-evict", "task_complete", { response: "done" });
+      await vi.advanceTimersByTimeAsync(0);
+      // Terminal context stays visible through the grace window so Discord
+      // timeout suppression + synthesis consumers can still read it.
+      expect(coordinator.tasks.get("sess-evict")).toMatchObject({
+        status: "completed",
+      });
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(coordinator.tasks.has("sess-evict")).toBe(false);
+      await coordinator.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("eviction does not fire a duplicate swarm-complete for the session", async () => {
+    vi.useFakeTimers();
+    try {
+      const acp = makeAcpStub({
+        agentType: "codex",
+        metadata: { label: "build-site" },
+      });
+      const runtime = makeRuntime({ [AcpService.serviceType]: acp });
+      const coordinator = await SwarmCoordinatorService.start(runtime);
+
+      const fired = vi.fn(async () => {});
+      coordinator.setSwarmCompleteCallback(fired);
+
+      acp.emit("sess-dup", "task_complete", { response: "done" });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(fired).toHaveBeenCalledTimes(1);
+
+      // After eviction clears synthesizedCompletionSessions, a straggler
+      // duplicate terminal event may synthesize again (state was released),
+      // but the eviction itself must not fire anything.
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(fired).toHaveBeenCalledTimes(1);
+      await coordinator.stop();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("retries ACP binding when ACP is not yet registered, then binds", async () => {

--- a/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
@@ -134,6 +134,16 @@ interface LegacyCoordinatorTask {
   };
 }
 
+interface EnrichmentMetadata {
+  metadata: Record<string, unknown>;
+  workdir?: string;
+  agentType?: string;
+}
+
+const STREAMING_SESSION_EVENTS = new Set(["message", "reasoning", "plan"]);
+
+const LEGACY_TASK_EVICTION_GRACE_MS = 60_000;
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -161,6 +171,14 @@ export class SwarmCoordinatorService extends Service {
   private swarmCompleteCallback: SwarmCompleteCallback | null = null;
   private readonly inFlightDecisionSessions = new Set<string>();
   private readonly synthesizedCompletionSessions = new Set<string>();
+  private readonly enrichmentMetadataCache = new Map<
+    string,
+    EnrichmentMetadata
+  >();
+  private readonly legacyTaskEvictionTimers = new Map<
+    string,
+    ReturnType<typeof setTimeout>
+  >();
 
   /**
    * Legacy coordinator surface consumed by Discord timeout suppression and
@@ -214,6 +232,11 @@ export class SwarmCoordinatorService extends Service {
     this.swarmCompleteCallback = null;
     this.inFlightDecisionSessions.clear();
     this.synthesizedCompletionSessions.clear();
+    this.enrichmentMetadataCache.clear();
+    for (const timer of this.legacyTaskEvictionTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.legacyTaskEvictionTimers.clear();
     this.tasks.clear();
   }
 
@@ -368,7 +391,9 @@ export class SwarmCoordinatorService extends Service {
     event: string,
     data: unknown,
   ): Promise<void> {
-    const enrichedData = await this.enrichEventData(sessionId, data);
+    const enrichedData = this.shouldEnrichEvent(event)
+      ? await this.enrichEventData(sessionId, data)
+      : data;
 
     // App/plugin creation flows carry a custom app-verification validator in
     // session metadata. The verification-room bridge intentionally ignores raw
@@ -380,6 +405,7 @@ export class SwarmCoordinatorService extends Service {
       this.hasAppVerificationValidator(enrichedData)
     ) {
       await this.runCustomValidatorAndDispatch(sessionId, enrichedData);
+      this.scheduleLegacyTaskEviction(sessionId);
       return;
     }
 
@@ -395,6 +421,10 @@ export class SwarmCoordinatorService extends Service {
 
     if (event === "blocked" || event === "login_required") {
       void this.maybeRouteAgentDecision(sessionId, event, enrichedData);
+    }
+
+    if (this.isTerminalEvent(event)) {
+      this.scheduleLegacyTaskEviction(sessionId);
     }
   }
 
@@ -469,19 +499,19 @@ export class SwarmCoordinatorService extends Service {
     this.synthesizedCompletionSessions.add(sessionId);
 
     const record = isRecord(data) ? data : {};
-    let session: Awaited<ReturnType<AcpService["getSession"]>> | undefined;
+    let sessionMeta: EnrichmentMetadata = { metadata: {} };
     try {
-      session = await this.acp()?.getSession(sessionId);
+      sessionMeta = await this.getEnrichmentMetadata(sessionId);
     } catch {
-      session = undefined;
+      sessionMeta = { metadata: {} };
     }
-    const meta = isRecord(session?.metadata) ? session.metadata : {};
+    const meta = sessionMeta.metadata;
     const label =
       readString(record, "label") ?? readString(meta, "label") ?? sessionId;
     const agentType =
       readString(record, "agentType") ??
       readString(meta, "agentType") ??
-      session?.agentType ??
+      sessionMeta.agentType ??
       "unknown";
     const originalTask =
       readString(record, "initialTask") ??
@@ -492,7 +522,7 @@ export class SwarmCoordinatorService extends Service {
     const workdir =
       readString(record, "workdir") ??
       readString(meta, "workdir") ??
-      session?.workdir;
+      sessionMeta.workdir;
     const roomId =
       readString(record, "originRoomId") ??
       readString(meta, "originRoomId") ??
@@ -552,6 +582,27 @@ export class SwarmCoordinatorService extends Service {
     return null;
   }
 
+  private isTerminalEvent(event: string): boolean {
+    return TERMINAL_SESSION_STATUSES.has(this.legacyStatusForEvent(event));
+  }
+
+  private scheduleLegacyTaskEviction(sessionId: string): void {
+    const existing = this.legacyTaskEvictionTimers.get(sessionId);
+    if (existing) clearTimeout(existing);
+
+    // Give same-turn consumers (swarm synthesis, verification routing, and
+    // Discord timeout suppression) a short grace window to observe terminal
+    // context, then evict legacy state so completed sessions do not accumulate
+    // for the lifetime of the runtime.
+    const timer = setTimeout(() => {
+      this.legacyTaskEvictionTimers.delete(sessionId);
+      this.tasks.delete(sessionId);
+      this.synthesizedCompletionSessions.delete(sessionId);
+      this.enrichmentMetadataCache.delete(sessionId);
+    }, LEGACY_TASK_EVICTION_GRACE_MS);
+    this.legacyTaskEvictionTimers.set(sessionId, timer);
+  }
+
   private dispatchSwarmEvent(swarmEvent: SwarmEvent): void {
     // Fan out to in-process subscribers (verification-room-bridge et al).
     for (const listener of this.listeners) {
@@ -580,6 +631,31 @@ export class SwarmCoordinatorService extends Service {
     }
   }
 
+  private shouldEnrichEvent(event: string): boolean {
+    return !STREAMING_SESSION_EVENTS.has(event);
+  }
+
+  private async getEnrichmentMetadata(
+    sessionId: string,
+  ): Promise<EnrichmentMetadata> {
+    const cached = this.enrichmentMetadataCache.get(sessionId);
+    if (cached) return cached;
+
+    const session = await this.acp()?.getSession(sessionId);
+    // Do NOT cache a miss: an event can race session-store persistence, and
+    // pinning `{}` would strip routing metadata from every later event of the
+    // session. A miss stays uncached so the next event retries the lookup.
+    if (!session) return { metadata: {} };
+
+    const cachedMetadata: EnrichmentMetadata = {
+      metadata: isRecord(session.metadata) ? session.metadata : {},
+      ...(session.workdir ? { workdir: session.workdir } : {}),
+      ...(session.agentType ? { agentType: session.agentType } : {}),
+    };
+    this.enrichmentMetadataCache.set(sessionId, cachedMetadata);
+    return cachedMetadata;
+  }
+
   private async enrichEventData(
     sessionId: string,
     data: unknown,
@@ -588,8 +664,8 @@ export class SwarmCoordinatorService extends Service {
       ? { ...data }
       : { value: data };
     try {
-      const session = await this.acp()?.getSession(sessionId);
-      const meta = isRecord(session?.metadata) ? session.metadata : {};
+      const sessionMeta = await this.getEnrichmentMetadata(sessionId);
+      const meta = sessionMeta.metadata;
       for (const key of [
         "originRoomId",
         "originConnectorMessageId",
@@ -612,11 +688,11 @@ export class SwarmCoordinatorService extends Service {
           record[key] = meta[key];
         }
       }
-      if (record.workdir === undefined && session?.workdir) {
-        record.workdir = session.workdir;
+      if (record.workdir === undefined && sessionMeta.workdir) {
+        record.workdir = sessionMeta.workdir;
       }
-      if (record.agentType === undefined && session?.agentType) {
-        record.agentType = session.agentType;
+      if (record.agentType === undefined && sessionMeta.agentType) {
+        record.agentType = sessionMeta.agentType;
       }
     } catch {
       // Best-effort enrichment only; raw data is still useful to consumers.


### PR DESCRIPTION
## What

Follow-up hardening on the SWARM_COORDINATOR adapter restored in #10981 (kanban #10561). One concern: per-event enrichment cost + unbounded legacy state growth in `SwarmCoordinatorService`.

## Why

- `enrichEventData` called `acp.getSession()` on **every** session event. A busy coding session emits hundreds of `tool_running` / `usage_update` events, each paying a session-store read to re-derive the same static routing metadata (`originRoomId`, `label`, `workdir`, `agentType`, ...).
- High-frequency streaming events (`message` / `reasoning` / `plan`) were enriched too, even though their consumers (ws activity rail) only read the payload text.
- The legacy `tasks` map (Discord timeout-suppression surface), `synthesizedCompletionSessions`, and any metadata cache grew for the lifetime of the runtime — completed sessions were never released.

## How

- **Per-session metadata cache** (`enrichmentMetadataCache`): session metadata is fetched once per session, later events reuse it. A store **miss is deliberately not cached** — an early event can race session persistence, and pinning `{}` would strip routing metadata from every later event of that session. The next event retries the lookup.
- **Streaming-event skip**: `message` / `reasoning` / `plan` bypass enrichment entirely and pass the raw payload through.
- **Terminal-state eviction**: terminal events (per the shared `TERMINAL_SESSION_STATUSES` mapping) schedule a 60s grace eviction of the legacy task entry, synthesis dedupe entry, and metadata cache entry. The grace window keeps terminal context visible to same-turn consumers (swarm synthesis, verification routing, Discord timeout suppression). Timers are tracked per session and cleared on `stop()`.

Validator completion routing from #10981 is preserved: the app-verification path still runs the real verifier before dispatch and now also schedules eviction after dispatch.

## Testing

Ran in `plugins/plugin-agent-orchestrator`:

- `bunx vitest run __tests__/unit/swarm-coordinator-service.test.ts` — **20/20 green** (15 existing + 5 new)
- `bunx vitest run __tests__/unit/acp-service.test.ts` — green (63/63 across both files)
- `biome check` on both touched files — clean

New tests pin:
1. metadata fetched once per session (later events don't re-hit `getSession`)
2. a session-store miss is not cached (event racing persistence gets metadata on the next event)
3. streaming events never call `getSession` and pass raw payloads through
4. legacy task state visible through the grace window, evicted after it
5. eviction does not fire a duplicate swarm-complete

Caveats:
- `bun run typecheck` in the plugin currently fails on a **pre-existing, unrelated** error on develop (`packages/app-core/src/services/coding-account-bridge.ts` can't resolve `@elizaos/agent/utils/atomic-json` under tsgo; reproduces with a clean checkout of develop, no diff applied). No type errors in the touched files.
- Codex review skipped this round due to local usage limits; targeted unit coverage above instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
