### PR TITLE
fix(lifeops): harden scheduler tick liveness + owner-send double-send race (post-#10993)

### DIFF
--- a/packages/core/src/services/task-scheduler.test.ts
+++ b/packages/core/src/services/task-scheduler.test.ts
@@ -70,6 +70,31 @@ describe("task-scheduler", () => {
 		expect(errorSpy).toHaveBeenCalledTimes(2);
 	});
 
+	it("re-arms a still-registered agent after a transient getTasks rejection (no re-register)", async () => {
+		let getTasksCalls = 0;
+		const adapter = {
+			getTasks: vi.fn(async () => {
+				getTasksCalls += 1;
+				if (getTasksCalls === 1) throw new Error("db outage");
+				return [] as Task[];
+			}),
+		} as unknown as IDatabaseAdapter;
+
+		startTaskScheduler(adapter);
+		registerTaskSchedulerRuntime(makeRuntime(), {
+			runTick: vi.fn(async () => undefined),
+		});
+
+		await runOneTick();
+		expect(getTasksCalls).toBe(1);
+
+		// No re-register: a transient rejection must re-arm the still-registered
+		// agent so the next tick queries again. Without the re-arm the agent is
+		// drained on the failing tick and stays silent forever (getTasksCalls stuck at 1).
+		await runOneTick();
+		expect(getTasksCalls).toBe(2);
+	});
+
 	it("keeps re-querying while an agent's queue is non-empty and goes quiet when it empties", async () => {
 		const task = { id: "t1", agentId: AGENT_ID } as unknown as Task;
 		const queues: Task[][] = [[task], [task], []];

--- a/packages/core/src/services/task-scheduler.ts
+++ b/packages/core/src/services/task-scheduler.ts
@@ -42,10 +42,22 @@ async function tick(): Promise<void> {
 	if (!adp) return;
 
 	const agentIds = snapshot as UUID[];
-	const allTasks = await adp.getTasks({
-		tags: ["queue"],
-		agentIds,
-	});
+	let allTasks: Task[];
+	try {
+		allTasks = await adp.getTasks({
+			tags: ["queue"],
+			agentIds,
+		});
+	} catch (error) {
+		// A transient getTasks rejection must NOT permanently silence the cleared
+		// agents: we already drained dirtyAgents above, so re-arm the ones still
+		// registered before rethrowing. Otherwise one DB hiccup drops every repeat
+		// task (incl. the LifeOps heartbeat) until each agent is marked dirty again.
+		for (const aid of snapshot) {
+			if (registry.has(aid)) dirtyAgents.add(aid);
+		}
+		throw error;
+	}
 
 	// Group by task.agentId so each runtime only receives its own tasks. WHY: runTick expects one agent's tasks.
 	const byAgent = new Map<string, Task[]>();

--- a/packages/core/src/services/task.test.ts
+++ b/packages/core/src/services/task.test.ts
@@ -91,6 +91,40 @@ describe("TaskService tick re-arm", () => {
 		expect(execute).toHaveBeenCalledTimes(3);
 	});
 
+	it("re-arms the tick after a transient getTasks rejection instead of going silent", async () => {
+		const { runtime, tasks, workers } = makeTaskRuntime();
+		const execute = vi.fn(async () => undefined);
+		workers.set("HEARTBEAT", { name: "HEARTBEAT", execute });
+		tasks.set("t-repeat", {
+			id: "t-repeat" as UUID,
+			name: "HEARTBEAT",
+			agentId: AGENT_ID,
+			tags: ["queue", "repeat"],
+			metadata: { updateInterval: 60_000, updatedAt: T0 },
+		});
+
+		// The first tick's query rejects (a transient DB blip); every later query
+		// recovers. checkTasks clears tasksDirty BEFORE awaiting getTasks, so
+		// without re-arming on failure the gate would stay disarmed forever and the
+		// heartbeat would never run again after a single hiccup.
+		let calls = 0;
+		const realGetTasks = runtime.getTasks.bind(runtime);
+		(runtime as { getTasks: IAgentRuntime["getTasks"] }).getTasks = (async (
+			params: Parameters<IAgentRuntime["getTasks"]>[0],
+		) => {
+			calls += 1;
+			if (calls === 1) throw new Error("transient db outage");
+			return realGetTasks(params);
+		}) as IAgentRuntime["getTasks"];
+
+		service = (await TaskService.start(runtime)) as TaskService;
+
+		await vi.advanceTimersByTimeAsync(61_000);
+		// The tick recovered (queried again after the rejection) and fired the task.
+		expect(calls).toBeGreaterThan(1);
+		expect(execute).toHaveBeenCalledTimes(1);
+	});
+
 	it("runs a task created after the tick disarmed on an empty queue once markDirty is called", async () => {
 		const { runtime, tasks, workers } = makeTaskRuntime();
 		const execute = vi.fn(async () => undefined);

--- a/packages/core/src/services/task.ts
+++ b/packages/core/src/services/task.ts
@@ -263,10 +263,20 @@ export class TaskService extends Service {
 		this.tasksDirty = false;
 
 		// WHY queue only: approval/follow-up etc. are stored but run on user trigger or external cron; one place for "scheduled by tick".
-		const allTasks = await this.runtime.getTasks({
-			tags: ["queue"],
-			agentIds: [this.runtime.agentId],
-		});
+		let allTasks: Task[];
+		try {
+			allTasks = await this.runtime.getTasks({
+				tags: ["queue"],
+				agentIds: [this.runtime.agentId],
+			});
+		} catch (error) {
+			// A transient getTasks rejection must NOT permanently disarm the tick:
+			// we already cleared tasksDirty above, so without re-arming a single DB
+			// hiccup would silence every repeat task (incl. the LifeOps heartbeat)
+			// until an unrelated createTask/updateTask happened to call markDirty().
+			this.tasksDirty = true;
+			throw error;
+		}
 
 		if (!allTasks || allTasks.length === 0) {
 			// Empty queue: stay disarmed until markDirty() (createTask/updateTask) re-arms.

--- a/plugins/plugin-personal-assistant/src/lifeops/messaging/owner-send-policy.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/messaging/owner-send-policy.ts
@@ -85,18 +85,24 @@ export function registerOwnerSendApprovalWorker(runtime: IAgentRuntime): void {
           `[OwnerSendPolicy] refusing to execute send approval ${taskId}: unknown action ${JSON.stringify(actionName)}; nothing was sent`,
         );
       }
+      // Atomically CLAIM the executor before awaiting the send. A Map get+delete
+      // runs to completion synchronously (single-threaded event loop) before any
+      // await, so a concurrent CHOOSE_OPTION confirm for the same task sees no
+      // executor and takes the "lost executor" path below instead of sending a
+      // second time. Deleting only after the awaited send left a window in which
+      // two overlapping confirms both fetched the executor and double-sent.
       const executor = executorsFor(rt).get(taskId);
       if (!executor) {
-        // The executor closure over the triage draft does not survive a
-        // restart. Delete the dead task and fail loudly — the owner must
-        // re-issue the send.
+        // Either the draft executor closure did not survive a restart, or a
+        // concurrent confirm already claimed it. Delete the dead task and fail
+        // loudly — the owner must re-issue the send.
         await rt.deleteTask(task.id);
         throw new Error(
-          `[OwnerSendPolicy] approved send ${taskId} can no longer execute (draft executor lost, e.g. after a restart); nothing was sent — please re-send the draft`,
+          `[OwnerSendPolicy] approved send ${taskId} can no longer execute (draft executor lost, e.g. after a restart or a duplicate confirm); nothing was sent — please re-send the draft`,
         );
       }
-      const { externalId } = await executor();
       executorsFor(rt).delete(taskId);
+      const { externalId } = await executor();
       await rt.deleteTask(task.id);
       logger.info(
         `[OwnerSendPolicy] approved send ${taskId} executed (externalId=${externalId})`,

--- a/plugins/plugin-personal-assistant/test/owner-send-approval-worker.test.ts
+++ b/plugins/plugin-personal-assistant/test/owner-send-approval-worker.test.ts
@@ -175,4 +175,42 @@ describe("owner send-approval worker", () => {
       first,
     );
   });
+
+  it("a concurrent duplicate confirm does not double-send (atomic claim)", async () => {
+    const harness = makeRuntime();
+    // Gate the send so both confirms are in-flight before either completes —
+    // this is the window a second CHOOSE_OPTION confirm for the same task could
+    // slip through if the executor were only consumed AFTER the awaited send.
+    let release: () => void = () => undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let sends = 0;
+    const executor = vi.fn(async () => {
+      sends += 1;
+      await gate;
+      return { externalId: `ext-${sends}` };
+    });
+    const policy = createOwnerSendPolicy();
+    await policy.enqueueApproval(harness.runtime, makeDraft(), executor);
+    const task = harness.createdTasks.at(-1);
+    if (!task) throw new Error("enqueueApproval created no task");
+
+    // Two overlapping confirms for the SAME task, then release the gated send.
+    const first = dispatchChosenOption(harness.runtime, task, "confirm");
+    const second = dispatchChosenOption(harness.runtime, task, "confirm");
+    release();
+    const settled = await Promise.allSettled([first, second]);
+
+    // Exactly one send happened; the loser rejected with re-send guidance and
+    // never invoked the executor. Consuming the executor before the await makes
+    // the claim atomic on the single-threaded event loop.
+    expect(sends).toBe(1);
+    expect(executor).toHaveBeenCalledTimes(1);
+    const rejected = settled.filter((r) => r.status === "rejected");
+    expect(rejected).toHaveLength(1);
+    expect((rejected[0] as PromiseRejectedResult).reason).toMatchObject({
+      message: expect.stringMatching(/no longer execute/u),
+    });
+  });
 });


### PR DESCRIPTION
## Post-merge hardening of the LifeOps scheduler spine (follow-up to #10993)

An adversarial post-merge review of #10993 (the LifeOps/PA de-larp campaign) surfaced **three latent bugs in the merged spine**. All three are proven fail-without-fix (revert the production hunk → the paired test goes red).

### 1. Owner-send double-send race (HIGH)

`OWNER_SEND_APPROVAL`'s task worker consumed the held executor only **after** the awaited send:

```
const executor = executorsFor(rt).get(taskId);
const { externalId } = await executor();   // ← yields here
executorsFor(rt).delete(taskId);            // ← consumed only now
```

Two overlapping `CHOOSE_OPTION` confirms for the same task (e.g. the owner double-taps confirm, or a confirm arrives on two channels) both `get()` the still-present executor across the `await` and **send twice**. The approval-*queue* path (RESOLVE_REQUEST) was already CAS-protected by #10993, but this second task-worker path was not.

**Fix:** claim the executor with a synchronous `Map.delete` **before** the `await`. On the single-threaded event loop the get+delete completes before any yield, so a concurrent confirm sees no executor and takes the existing "draft executor lost — please re-send" path instead of double-sending.

### 2 & 3. Transient DB error permanently silences the scheduler (MEDIUM ×2)

Both tick paths — `TaskService.checkTasks` (local timer) and the `task-scheduler` daemon `tick` — clear their dirty gate **before** awaiting `getTasks`:

```
this.tasksDirty = false;                 // (checkTasks)
const allTasks = await getTasks(...);    // if this REJECTS, the gate stays disarmed forever
```

A single transient `getTasks` rejection leaves the gate disarmed with a non-empty queue, so **every repeat task (including the LifeOps 60s heartbeat) goes permanently silent** until an unrelated create/update happens to call `markDirty()` — reintroducing the exact "repeat task runs at most once per boot" failure #10993 fixed, via one DB hiccup.

**Fix:** re-arm the dirty state on a failed query before rethrowing (the timer's `.catch` still logs it). The daemon re-arms only agents still registered.

## Evidence (fail-without-fix, all local)

| # | Test | Revert → |
|---|------|----------|
| 1 | `owner-send-approval-worker.test.ts › a concurrent duplicate confirm does not double-send` | `sends === 2` (double-send) ❌ |
| 2 | `task.test.ts › re-arms the tick after a transient getTasks rejection` | heartbeat never re-fires ❌ |
| 3 | `task-scheduler.test.ts › re-arms a still-registered agent after a transient getTasks rejection` | `getTasksCalls` stuck at 1 ❌ |

- core `task.test.ts` + `task-scheduler.test.ts`: **15 passed** · PA `owner-send-approval-worker.test.ts`: **7 passed**
- `bunx tsc --noEmit` (core): **exit 0**
- Each fix reverted individually → its paired test fails; restored → green.

Refs #10993 #10721 #10723

🤖 Generated with [Claude Code](https://claude.com/claude-code)
