### PR TITLE
fix(trajectories): expose conversation metadata in fallback API

### DIFF
--- a/packages/agent/src/api/trajectory-fallback-routes.test.ts
+++ b/packages/agent/src/api/trajectory-fallback-routes.test.ts
@@ -21,9 +21,13 @@ function mockRes(): {
   return { res, get: () => ({ status: state.status, body: state.body }) };
 }
 
-function runtimeWith(service: unknown): AgentRuntime {
+function runtimeWith(
+  service: unknown,
+  rooms: Record<string, unknown> = {},
+): AgentRuntime {
   return {
     getService: (type: string) => (type === "trajectories" ? service : null),
+    getRoom: async (id: string) => rooms[id] ?? null,
   } as unknown as AgentRuntime;
 }
 
@@ -56,7 +60,15 @@ describe("tryHandleTrajectoryFallback", () => {
     const service = {
       listTrajectories: async () => ({
         trajectories: [
-          { id: "t1", status: "completed", llmCallCount: 3 },
+          {
+            id: "t1",
+            status: "completed",
+            llmCallCount: 3,
+            source: "discord",
+            roomId: "room-1",
+            entityId: "entity-1",
+            metadata: { roomId: "room-1", entityId: "entity-1" },
+          },
           { id: "t2", status: "timeout", llmCallCount: 1 },
         ],
         total: 2,
@@ -132,6 +144,7 @@ describe("tryHandleTrajectoryFallback", () => {
         trajectoryId: id,
         endTime: 1000,
         metrics: { finalStatus: "completed" },
+        metadata: { source: "discord", roomId: "room-1", entityId: "entity-1" },
         steps: [
           {
             stepId: "s0",
@@ -169,7 +182,15 @@ describe("tryHandleTrajectoryFallback", () => {
     const { status, body } = get();
     expect(status).toBe(200);
     const b = body as {
-      trajectory: { id: string; status: string; llmCallCount: number };
+      trajectory: {
+        id: string;
+        status: string;
+        source: string;
+        roomId: string;
+        entityId: string;
+        metadata: Record<string, unknown>;
+        llmCallCount: number;
+      };
       llmCalls: Array<{ stepType: string }>;
       providerAccesses: unknown[];
       toolEvents: Array<{ actionName: string; success: boolean }>;
@@ -177,6 +198,10 @@ describe("tryHandleTrajectoryFallback", () => {
     expect(b.trajectory).toMatchObject({
       id: "abc",
       status: "completed",
+      source: "discord",
+      roomId: "room-1",
+      entityId: "entity-1",
+      metadata: { source: "discord", roomId: "room-1", entityId: "entity-1" },
       llmCallCount: 2,
     });
     expect(b.llmCalls.map((c) => c.stepType)).toEqual([
@@ -188,6 +213,49 @@ describe("tryHandleTrajectoryFallback", () => {
       actionName: "REPLY",
       success: true,
       type: "tool_result",
+    });
+  });
+
+  it("resolves room context only when requested", async () => {
+    const service = {
+      listTrajectories: async () => ({
+        trajectories: [
+          {
+            id: "t1",
+            status: "completed",
+            llmCallCount: 1,
+            metadata: { roomId: "room-1" },
+          },
+        ],
+        total: 1,
+      }),
+    };
+    const { res, get } = mockRes();
+    const handled = await tryHandleTrajectoryFallback({
+      pathname: "/api/trajectories",
+      method: "GET",
+      url: url("/api/trajectories?resolve=1"),
+      runtime: runtimeWith(service, {
+        "room-1": {
+          id: "room-1",
+          name: "ruby-trivia",
+          type: "GROUP",
+          worldId: "world-1",
+          serverId: "guild-1",
+        },
+      }),
+      res,
+    });
+    expect(handled).toBe(true);
+    const rows = (
+      get().body as { trajectories: Array<Record<string, unknown>> }
+    ).trajectories;
+    expect(rows[0].roomContext).toEqual({
+      id: "room-1",
+      name: "ruby-trivia",
+      type: "GROUP",
+      worldId: "world-1",
+      serverId: "guild-1",
     });
   });
 

--- a/packages/agent/src/api/trajectory-fallback-routes.ts
+++ b/packages/agent/src/api/trajectory-fallback-routes.ts
@@ -23,6 +23,9 @@ interface ServiceTrajectoryListItem {
   id: string;
   agentId?: string;
   source?: string;
+  roomId?: string | null;
+  entityId?: string | null;
+  metadata?: Record<string, unknown>;
   status: "active" | "completed" | "error" | "timeout";
   startTime?: number;
   endTime?: number | null;
@@ -70,6 +73,15 @@ interface ServiceTrajectory {
   endTime?: number;
   steps?: ServiceTrajectoryStep[];
   metrics?: { finalStatus?: string };
+  metadata?: Record<string, unknown>;
+}
+
+interface ResolvedRoomContext {
+  id: string;
+  name?: string;
+  type?: string;
+  worldId?: string;
+  serverId?: string;
 }
 
 interface TrajectoriesServiceLike {
@@ -106,15 +118,33 @@ function normalizeStatus(
   return status === "active" ? "active" : "completed";
 }
 
+function metadataRoomId(
+  metadata: Record<string, unknown> | undefined,
+): string | null {
+  return typeof metadata?.roomId === "string" ? metadata.roomId : null;
+}
+
+function metadataEntityId(
+  metadata: Record<string, unknown> | undefined,
+): string | null {
+  return typeof metadata?.entityId === "string" ? metadata.entityId : null;
+}
+
 function listItemToUi(
   item: ServiceTrajectoryListItem,
+  roomContext?: ResolvedRoomContext | null,
 ): Record<string, unknown> {
+  const metadata = item.metadata ?? {};
   return {
     id: item.id,
     status: normalizeStatus(item.status),
     llmCallCount: item.llmCallCount ?? 0,
     agentId: item.agentId,
     source: item.source ?? "chat",
+    roomId: item.roomId ?? metadataRoomId(metadata),
+    entityId: item.entityId ?? metadataEntityId(metadata),
+    metadata,
+    ...(roomContext ? { roomContext } : {}),
     startTime: item.startTime,
     endTime: item.endTime ?? null,
     durationMs: item.durationMs ?? null,
@@ -126,8 +156,12 @@ function listItemToUi(
 // Flatten the recorded steps into the flat UI arrays the viewer's phase
 // classifier (`summarizePhases`) reads: llmCalls keyed by stepType/purpose drive
 // HANDLE/PLAN/EVALUATE; the per-step action drives the ACTION phase.
-function detailToUi(traj: ServiceTrajectory): Record<string, unknown> {
+function detailToUi(
+  traj: ServiceTrajectory,
+  roomContext?: ResolvedRoomContext | null,
+): Record<string, unknown> {
   const id = String(traj.trajectoryId);
+  const metadata = traj.metadata ?? {};
   const llmCalls: Array<Record<string, unknown>> = [];
   const providerAccesses: Array<Record<string, unknown>> = [];
   const toolEvents: Array<Record<string, unknown>> = [];
@@ -192,7 +226,11 @@ function detailToUi(traj: ServiceTrajectory): Record<string, unknown> {
     trajectory: {
       id,
       agentId: traj.agentId ?? "",
-      source: "chat",
+      source: typeof metadata.source === "string" ? metadata.source : "chat",
+      roomId: metadataRoomId(metadata),
+      entityId: metadataEntityId(metadata),
+      metadata,
+      ...(roomContext ? { roomContext } : {}),
       status,
       startTime,
       endTime,
@@ -206,6 +244,37 @@ function detailToUi(traj: ServiceTrajectory): Record<string, unknown> {
     toolEvents,
     evaluationEvents: [],
   };
+}
+
+async function resolveRoomContext(
+  runtime: AgentRuntime | null | undefined,
+  roomId: string | null | undefined,
+  cache: Map<string, ResolvedRoomContext | null>,
+): Promise<ResolvedRoomContext | null> {
+  if (!roomId) return null;
+  if (cache.has(roomId)) return cache.get(roomId) ?? null;
+  const room = await runtime?.getRoom?.(
+    roomId as `${string}-${string}-${string}-${string}-${string}`,
+  );
+  const record =
+    room && typeof room === "object"
+      ? (room as unknown as Record<string, unknown>)
+      : null;
+  const context = record
+    ? {
+        id: String(record.id ?? roomId),
+        ...(typeof record.name === "string" ? { name: record.name } : {}),
+        ...(typeof record.type === "string" ? { type: record.type } : {}),
+        ...(typeof record.worldId === "string"
+          ? { worldId: record.worldId }
+          : {}),
+        ...(typeof record.serverId === "string"
+          ? { serverId: record.serverId }
+          : {}),
+      }
+    : null;
+  cache.set(roomId, context);
+  return context;
 }
 
 export async function tryHandleTrajectoryFallback(options: {
@@ -245,6 +314,9 @@ export async function tryHandleTrajectoryFallback(options: {
     return true;
   }
 
+  const shouldResolveRooms = url.searchParams.get("resolve") === "1";
+  const roomCache = new Map<string, ResolvedRoomContext | null>();
+
   try {
     if (isStats) {
       const stats = (await service.getStats?.()) ?? { totalTrajectories: 0 };
@@ -270,8 +342,22 @@ export async function tryHandleTrajectoryFallback(options: {
         // search box returned the full unfiltered list.
         search: url.searchParams.get("search") || undefined,
       })) ?? { trajectories: [], total: 0 };
+      const trajectories = shouldResolveRooms
+        ? await Promise.all(
+            result.trajectories.map(async (item) =>
+              listItemToUi(
+                item,
+                await resolveRoomContext(
+                  runtime,
+                  item.roomId ?? metadataRoomId(item.metadata),
+                  roomCache,
+                ),
+              ),
+            ),
+          )
+        : result.trajectories.map((item) => listItemToUi(item));
       sendJson(res, 200, {
-        trajectories: result.trajectories.map(listItemToUi),
+        trajectories,
         total: result.total,
         offset,
         limit,
@@ -286,7 +372,20 @@ export async function tryHandleTrajectoryFallback(options: {
       sendJson(res, 404, { error: `Trajectory "${detailId}" not found` });
       return true;
     }
-    sendJson(res, 200, detailToUi(traj));
+    sendJson(
+      res,
+      200,
+      detailToUi(
+        traj,
+        shouldResolveRooms
+          ? await resolveRoomContext(
+              runtime,
+              metadataRoomId(traj.metadata),
+              roomCache,
+            )
+          : null,
+      ),
+    );
     return true;
   } catch (err) {
     sendJson(res, 500, {

--- a/packages/core/src/features/trajectories/TrajectoriesService.test.ts
+++ b/packages/core/src/features/trajectories/TrajectoriesService.test.ts
@@ -171,4 +171,66 @@ describe("TrajectoriesService", () => {
 
 		expect(updates).toHaveLength(0);
 	});
+
+	it("includes persisted metadata on trajectory list rows", async () => {
+		const service = new TrajectoriesService({
+			adapter: { db: { execute: async () => ({ rows: [] }) } },
+			getService: () => null,
+			getServicesByType: () => [],
+		} as unknown as IAgentRuntime);
+		const serviceInternals = service as unknown as {
+			ensureStorageReady: () => Promise<void>;
+			executeRawSql: (
+				sqlText: string,
+			) => Promise<{ rows: Array<Record<string, unknown>>; columns: string[] }>;
+		};
+		serviceInternals.ensureStorageReady = async () => {};
+		const seenSql: string[] = [];
+		serviceInternals.executeRawSql = async (sqlText: string) => {
+			seenSql.push(sqlText);
+			if (sqlText.includes("count(*)")) {
+				return { rows: [{ total: 1 }], columns: ["total"] };
+			}
+			return {
+				rows: [
+					{
+						id: "00000000-0000-4000-8000-000000000030",
+						agent_id: "00000000-0000-4000-8000-000000000001",
+						source: "discord",
+						status: "completed",
+						start_time: 1000,
+						end_time: 1500,
+						duration_ms: 500,
+						step_count: 1,
+						llm_call_count: 2,
+						total_prompt_tokens: 10,
+						total_completion_tokens: 20,
+						total_cache_read_input_tokens: 0,
+						total_cache_creation_input_tokens: 0,
+						total_reward: 0,
+						scenario_id: null,
+						batch_id: null,
+						metadata_json: JSON.stringify({
+							roomId: "room-1",
+							entityId: "entity-1",
+							source: "discord",
+						}),
+						created_at: "1970-01-01T00:00:01.000Z",
+						updated_at: "1970-01-01T00:00:01.500Z",
+					},
+				],
+				columns: [],
+			};
+		};
+
+		const result = await service.listTrajectories({ limit: 1 });
+
+		expect(seenSql.some((sql) => sql.includes("metadata_json"))).toBe(true);
+		expect(result.trajectories[0]).toMatchObject({
+			source: "discord",
+			roomId: "room-1",
+			entityId: "entity-1",
+			metadata: { roomId: "room-1", entityId: "entity-1", source: "discord" },
+		});
+	});
 });

--- a/packages/core/src/features/trajectories/TrajectoriesService.ts
+++ b/packages/core/src/features/trajectories/TrajectoriesService.ts
@@ -82,6 +82,9 @@ export interface TrajectoryListItem {
 	id: string;
 	agentId: string;
 	source: string;
+	roomId: string | null;
+	entityId: string | null;
+	metadata: Record<string, JsonValue | undefined>;
 	status: "active" | "completed" | "error" | "timeout";
 	startTime: number;
 	endTime: number | null;
@@ -2281,7 +2284,7 @@ export class TrajectoriesService extends Service {
         id, agent_id, source, status, start_time, end_time, duration_ms,
         step_count, llm_call_count, total_prompt_tokens, total_completion_tokens,
         total_cache_read_input_tokens, total_cache_creation_input_tokens,
-        total_reward, scenario_id, batch_id, created_at, updated_at
+        total_reward, scenario_id, batch_id, metadata_json, created_at, updated_at
       FROM trajectories
       ${whereClause}
       ORDER BY created_at DESC
@@ -2303,11 +2306,19 @@ export class TrajectoriesService extends Service {
 			});
 			const rawLlmCallCount = asNumber(pickCell(row, "llm_call_count")) ?? 0;
 			const llmCallCount = rawLlmCallCount;
+			const metadata = parseTrajectoryMetadata(
+				pickCell(row, "metadata_json", "metadata"),
+			);
+			const asNullableString = (value: JsonValue | undefined): string | null =>
+				typeof value === "string" ? value : null;
 
 			return {
 				id: asString(pickCell(row, "id")) ?? "",
 				agentId: asString(pickCell(row, "agent_id")) ?? "",
 				source: asString(pickCell(row, "source")) ?? "chat",
+				roomId: asNullableString(metadata.roomId),
+				entityId: asNullableString(metadata.entityId),
+				metadata,
 				status,
 				startTime,
 				endTime: timing.endTime,


### PR DESCRIPTION
## Summary
- include persisted trajectory `metadata` plus top-level `roomId` / `entityId` on trajectory list rows
- preserve the recorded trajectory source in fallback detail responses instead of hard-coding `chat`
- add opt-in `?resolve=1` room context resolution for fallback list/detail responses, cached per request
- cover list metadata, detail source/metadata, and resolved room context with targeted tests

## Notes
- Checked for existing PRs around trajectory metadata / room context before opening this PR. I found no open PR for this concern.
- Codex review skipped due local usage limits.

## Tests
- `bunx vitest run packages/agent/src/api/trajectory-fallback-routes.test.ts packages/core/src/features/trajectories/TrajectoriesService.test.ts`
- `bunx tsc -p packages/agent/tsconfig.json --noEmit --pretty false` was attempted and still fails on existing repo-wide missing modules/type errors; the only touched-file error it surfaced was fixed before commit.
