### PR TITLE
fix(orchestrator): cancel pending legacy-task eviction when a session resumes (post-#11086)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/swarm-coordinator-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/swarm-coordinator-service.test.ts
@@ -575,6 +575,39 @@ describe("SwarmCoordinatorService", () => {
     }
   });
 
+  it("cancels the pending eviction when the session resumes within the grace window", async () => {
+    vi.useFakeTimers();
+    try {
+      const acp = makeAcpStub({
+        agentType: "codex",
+        workdir: "/tmp/wd",
+        metadata: { label: "build-site", initialTask: "build it" },
+      });
+      const runtime = makeRuntime({ [AcpService.serviceType]: acp });
+      const coordinator = await SwarmCoordinatorService.start(runtime);
+
+      // Turn 1 completes and schedules the 60s eviction. task_complete fires at
+      // the end of every prompt turn — it is NOT the end of the session.
+      acp.emit("sess-resume", "task_complete", { response: "turn 1 done" });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(coordinator.tasks.has("sess-resume")).toBe(true);
+
+      // A follow-up turn reuses the same session WITHIN the grace window: a
+      // non-terminal event must cancel the pending eviction.
+      await vi.advanceTimersByTimeAsync(30_000);
+      acp.emit("sess-resume", "tool_running", { toolCall: { title: "Bash" } });
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Past the original 60s deadline the live task state must survive — without
+      // the cancel it is evicted mid-turn, blinding Discord suppression + routing.
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(coordinator.tasks.has("sess-resume")).toBe(true);
+      await coordinator.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("eviction does not fire a duplicate swarm-complete for the session", async () => {
     vi.useFakeTimers();
     try {

--- a/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
@@ -409,6 +409,24 @@ export class SwarmCoordinatorService extends Service {
       return;
     }
 
+    // A non-terminal event means the session resumed: a follow-up prompt turn
+    // reuses the same session (task_complete fires at the end of every turn, then
+    // the session returns to a non-terminal status and accepts more input). Cancel
+    // any pending post-terminal eviction so the still-live task state and its
+    // enrichment cache are not deleted mid-turn — an eviction inside the grace
+    // window blinds Discord timeout suppression and task routing until the next
+    // ACP event happens to recreate the entry.
+    // A non-terminal event means the session resumed: a follow-up prompt turn
+    // reuses the same session (task_complete fires at the end of every turn, then
+    // the session returns to a non-terminal status and accepts more input). Cancel
+    // any pending post-terminal eviction so the still-live task state and its
+    // enrichment cache are not deleted mid-turn — an eviction inside the grace
+    // window blinds Discord timeout suppression and task routing until the next
+    // ACP event happens to recreate the entry.
+    if (!this.isTerminalEvent(event)) {
+      this.cancelLegacyTaskEviction(sessionId);
+    }
+
     const swarmEvent: SwarmEvent = {
       type: event,
       sessionId,
@@ -601,6 +619,13 @@ export class SwarmCoordinatorService extends Service {
       this.enrichmentMetadataCache.delete(sessionId);
     }, LEGACY_TASK_EVICTION_GRACE_MS);
     this.legacyTaskEvictionTimers.set(sessionId, timer);
+  }
+
+  private cancelLegacyTaskEviction(sessionId: string): void {
+    const existing = this.legacyTaskEvictionTimers.get(sessionId);
+    if (!existing) return;
+    clearTimeout(existing);
+    this.legacyTaskEvictionTimers.delete(sessionId);
   }
 
   private dispatchSwarmEvent(swarmEvent: SwarmEvent): void {


### PR DESCRIPTION
## Cancel pending legacy-task eviction on session resume (follow-up to #11086)

An adversarial post-merge review of #11086 found a real correctness regression in its new eviction feature.

### The bug

#11086 added a 60s post-terminal eviction of legacy task state in `SwarmCoordinatorService` (to stop completed sessions accumulating for the runtime's lifetime). But:

- `task_complete` fires at the **end of every prompt turn** (`acp-service.ts:1633`), not the end of the session.
- After it, the session returns to a **non-terminal** status (`ready`) and **accepts follow-ups** — follow-up user messages are forwarded into the **same** session (`active-session-forward.ts` skips only terminal statuses).
- `handleAcpEvent` schedules eviction on the terminal event but **no non-terminal event cancels it**.

So a follow-up turn arriving within the 60s grace window has its **still-live task state (and enrichment cache) evicted mid-turn** (`tasks.delete` + cache delete). The entry only self-heals on the next ACP event — during a long silent tool call that gap can last minutes, during which:

- Discord timeout suppression (`plugin-discord/messages.ts` `hasActiveTaskAgentWorkForMessage`) returns `false` for an in-flight task, and
- `getAllTaskContexts` login-routing misses the session,
- the recreated entry also loses event-payload-only fields like `threadId` (falls back to `sessionId`).

### The fix

Cancel the pending eviction timer on **any non-terminal event** for the session (a resume). Terminal events still schedule eviction as before; the app-verification `task_complete` path is unaffected.

### Evidence (fail-without-fix)

New test `swarm-coordinator-service.test.ts › cancels the pending eviction when the session resumes within the grace window`:
- turn 1 `task_complete` schedules the 60s eviction → at +30s a follow-up `tool_running` arrives → past +60s the live task state **survives**.
- Revert the cancel → the test fails (`tasks.has("sess-resume") === false`, evicted mid-turn). ✅ verified both directions.

- `swarm-coordinator-service.test.ts`: **21 passed**
- `tsgo --noEmit -p tsconfig.json`: **0 errors**

Refs #11086

🤖 Generated with [Claude Code](https://claude.com/claude-code)
