### PR TITLE
test(elizacloud): fix gating test broken by #11063 (embeddings moved out of the static map) — fails on clean develop

### DIFF
--- a/plugins/plugin-elizacloud/__tests__/unit/text-inference-gating.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/text-inference-gating.test.ts
@@ -97,8 +97,12 @@ describe("registerTextInferenceModels — chat-brain arbitration (#10819)", () =
     expect(models).toHaveProperty(String(ModelType.IMAGE));
     expect(models).toHaveProperty(String(ModelType.IMAGE_DESCRIPTION));
     expect(models).toHaveProperty(String(ModelType.TEXT_TO_SPEECH));
-    expect(models).toHaveProperty(String(ModelType.TEXT_EMBEDDING));
     expect(models).toHaveProperty(String(ModelType.RESEARCH));
+    // Embeddings moved OUT of the static map in #11063: they init-register via
+    // registerCloudEmbeddingModels so an explicit ELIZAOS_CLOUD_USE_EMBEDDINGS=false
+    // lets a BYO embedding provider own TEXT_EMBEDDING (a static registration
+    // would always win on plugin priority and 429-loop against the cloud).
+    expect(models).not.toHaveProperty(String(ModelType.TEXT_EMBEDDING));
     // Chat-brain slots are init-registered, never static:
     for (const slot of CHAT_BRAIN_SLOTS) {
       expect(models).not.toHaveProperty(slot);

--- a/plugins/plugin-elizacloud/__tests__/unit/text-inference-gating.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/text-inference-gating.test.ts
@@ -38,12 +38,7 @@ function fakeRuntime(settings: Record<string, string | undefined>) {
   }> = [];
   const runtime = {
     getSetting: (key: string) => settings[key],
-    registerModel: (
-      modelType: string,
-      _handler: unknown,
-      provider: string,
-      priority?: number,
-    ) => {
+    registerModel: (modelType: string, _handler: unknown, provider: string, priority?: number) => {
       registered.push({ modelType, provider, priority });
     },
   } as unknown as IAgentRuntime;
@@ -68,9 +63,7 @@ describe("registerTextInferenceModels — chat-brain arbitration (#10819)", () =
       ELIZAOS_CLOUD_USE_INFERENCE: "true",
     });
     registerTextInferenceModels(runtime);
-    expect(registered.map((r) => r.modelType).sort()).toEqual(
-      [...CHAT_BRAIN_SLOTS].sort(),
-    );
+    expect(registered.map((r) => r.modelType).sort()).toEqual([...CHAT_BRAIN_SLOTS].sort());
     for (const r of registered) {
       expect(r.provider).toBe(elizaOSCloudPlugin.name);
       expect(r.priority).toBe(elizaOSCloudPlugin.priority);


### PR DESCRIPTION
#11063 moved `TEXT_EMBEDDING` out of `elizaOSCloudPlugin.models` into init-time `registerCloudEmbeddingModels` (gated on `ELIZAOS_CLOUD_USE_EMBEDDINGS`) but didn't update the #10819 arbitration test that asserts static membership — `text-inference-gating.test.ts` fails on clean develop (`expected { …(6) } to have property "TEXT_EMBEDDING"`).

Updates the expectation to assert embeddings are **not** static, with a comment capturing why that matters: a static registration wins on plugin priority over an operator's BYO embedding provider. Observed live: a deployment with `EMBEDDING_BASE_URL`/`EMBEDDING_API_KEY` (OpenAI direct, 1536-dim) had every embedding call routed to the cloud instead — which 429-looped during the #11087 rate-limiter incident while the configured provider sat unused. After #11063 + `ELIZAOS_CLOUD_USE_EMBEDDINGS=false`, the same deployment logs `[BatchEmbeddings] Got 1 embeddings (1536d)` via the BYO provider.

Suite: 14 files green with this change (was 1 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)