### PR TITLE
fix(cloud): cap per-org coding containers to close the fleet-DoS #11042 left open (#11023)

### DIFF
--- a/packages/cloud/api/v1/coding-containers/route.ts
+++ b/packages/cloud/api/v1/coding-containers/route.ts
@@ -51,10 +51,11 @@
  */
 
 import { Hono } from "hono";
-import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import { ApiError, failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { containersEnv } from "@/lib/config/containers-env";
 import { AGENT_PRICING } from "@/lib/constants/agent-pricing";
+import { getMaxNonTerminalAgentsForOrg } from "@/lib/constants/agent-sandbox-quota";
 import { getElizaAgentPublicWebUiUrl } from "@/lib/eliza-agent-web-ui";
 import { checkAgentCreditGate } from "@/lib/services/agent-billing-gate";
 import {
@@ -66,7 +67,10 @@ import {
   type RequestCodingAgentContainerRequest,
   RequestCodingAgentContainerRequestSchema,
 } from "@/lib/services/coding-containers";
-import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
+import {
+  AgentQuotaExceededError,
+  elizaSandboxService,
+} from "@/lib/services/eliza-sandbox";
 import { provisioningJobService } from "@/lib/services/provisioning-jobs";
 import {
   checkProvisioningWorkerHealth,
@@ -249,14 +253,41 @@ async function createCodingContainer(
   // The service takes a transaction-scoped advisory lock before checking for a
   // pending/provisioning/running sandbox, closing retry races without applying a
   // broad schema constraint that would collide with warm-pool rows.
-  const createResult = await elizaSandboxService.createCodingContainerAgent({
-    organizationId: user.organization_id,
-    userId: user.id,
-    agentName: payload.name || payload.project_name,
-    environmentVars: payload.environment_vars,
-    dockerImage: payload.image,
-    executionTier: "custom",
-  });
+  let createResult: Awaited<
+    ReturnType<typeof elizaSandboxService.createCodingContainerAgent>
+  >;
+  try {
+    createResult = await elizaSandboxService.createCodingContainerAgent({
+      organizationId: user.organization_id,
+      userId: user.id,
+      agentName: payload.name || payload.project_name,
+      environmentVars: payload.environment_vars,
+      dockerImage: payload.image,
+      executionTier: "custom",
+      // Per-org ceiling (#11023): the per-image idempotency lock collapses only
+      // same-image retries, so a distinct-image loop under an allowlisted
+      // namespace would otherwise mint unbounded custom containers on the shared
+      // fleet. Bound it by the org's balance tier — the same cap the sibling
+      // POST /api/v1/eliza/agents forceCreate path enforces (#11042).
+      maxNonTerminalAgents: getMaxNonTerminalAgentsForOrg(creditCheck.balance),
+    });
+  } catch (error) {
+    if (error instanceof AgentQuotaExceededError) {
+      logger.warn(
+        "[CodingContainers API] provision blocked: per-org quota exceeded",
+        {
+          orgId: user.organization_id,
+          count: error.count,
+          max: error.max,
+        },
+      );
+      throw new ApiError(429, "agent_quota_exceeded", error.message, {
+        count: error.count,
+        max: error.max,
+      });
+    }
+    throw error;
+  }
   if (createResult.idempotent) {
     const existing = createResult.agent;
     logger.info(

--- a/packages/cloud/api/v1/eliza/agents/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/route.ts
@@ -17,6 +17,7 @@ import {
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { containersEnv } from "@/lib/config/containers-env";
 import { AGENT_PRICING } from "@/lib/constants/agent-pricing";
+import { getMaxNonTerminalAgentsForOrg } from "@/lib/constants/agent-sandbox-quota";
 import { getElizaAgentPublicWebUiUrl } from "@/lib/eliza-agent-web-ui";
 import { checkAgentCreditGate } from "@/lib/services/agent-billing-gate";
 import {
@@ -42,22 +43,6 @@ import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
-
-/**
- * Per-org ceiling on live (non-terminal) dedicated agent sandboxes, by credit
- * tier. Mirrors the balance tiers already enforced for cloud characters in
- * `/api/v1/app/agents` (`AGENT_LIMITS`), applied here to the `agent_sandboxes`
- * (container) path so a `forceCreate` loop on a trivial balance can't exhaust
- * the shared fleet (#11023). A trivial (~$0.11) balance lands in the smallest
- * tier, bounding the DoS; funded orgs scale up.
- */
-function getMaxNonTerminalAgentsForOrg(creditBalance: number | undefined): number {
-  const balance = Number(creditBalance ?? 0);
-  if (balance >= 100.0) return 500;
-  if (balance >= 10.0) return 100;
-  if (balance >= 1.0) return 20;
-  return 5;
-}
 
 const dockerImageSchema = z
   .string()
@@ -424,11 +409,14 @@ app.post("/", async (c) => {
     });
   } catch (error) {
     if (error instanceof AgentQuotaExceededError) {
-      logger.warn("[agent-api] Agent creation blocked: per-org quota exceeded", {
-        orgId: user.organization_id,
-        count: error.count,
-        max: error.max,
-      });
+      logger.warn(
+        "[agent-api] Agent creation blocked: per-org quota exceeded",
+        {
+          orgId: user.organization_id,
+          count: error.count,
+          max: error.max,
+        },
+      );
       throw new ApiError(429, "agent_quota_exceeded", error.message, {
         currentAgents: error.count,
         maxAgents: error.max,

--- a/packages/cloud/shared/src/lib/constants/agent-sandbox-quota.ts
+++ b/packages/cloud/shared/src/lib/constants/agent-sandbox-quota.ts
@@ -1,0 +1,22 @@
+/**
+ * Per-org ceiling on live (non-terminal) dedicated agent sandboxes, by credit
+ * tier. Every dedicated/custom sandbox provisions a real container + per-tenant
+ * DB + ingress on the shared fleet, and the create-time credit gate is
+ * threshold-only (no per-agent debit), so without a per-org cap a caller on a
+ * trivial (~$0.11) balance could loop a create endpoint and exhaust the fleet —
+ * a DoS for every other tenant (#11023).
+ *
+ * Mirrors the balance tiers already enforced for cloud characters in
+ * `/api/v1/app/agents` (`AGENT_LIMITS`). A trivial balance lands in the smallest
+ * tier, bounding the DoS; funded orgs scale up. Shared by every user-facing
+ * container-create route (`POST /api/v1/eliza/agents`,
+ * `POST /api/v1/coding-containers`) so the ceiling can't drift between them;
+ * trusted internal multi-agent callers pass no cap and stay uncapped.
+ */
+export function getMaxNonTerminalAgentsForOrg(creditBalance: number | undefined): number {
+  const balance = Number(creditBalance ?? 0);
+  if (balance >= 100.0) return 500;
+  if (balance >= 10.0) return 100;
+  if (balance >= 1.0) return 20;
+  return 5;
+}

--- a/packages/cloud/shared/src/lib/services/__tests__/eliza-sandbox-coding-container-quota.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/eliza-sandbox-coding-container-quota.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Real-DB proof of the per-org quota on the CODING-CONTAINER create path (#11023).
+ *
+ * PR #11042 closed the primary fleet-DoS on POST /api/v1/eliza/agents
+ * (forceCreate) by capping createAgent's plain-insert branch, but it did NOT
+ * touch createCodingContainerAgent — the sibling path behind
+ * POST /api/v1/coding-containers. That path's advisory lock + reuse guard are
+ * keyed on the EXACT docker_image, so a loop of DISTINCT allowlisted image
+ * references (`:v1`/`:v2`/`@sha256…` under an allowlisted namespace) each misses
+ * the reuse guard and mints a fresh custom container on the shared fleet — an
+ * unbounded per-org DoS (adversarially confirmed 3/3 skeptics, high confidence).
+ *
+ * The fix gives createCodingContainerAgent the SAME maxNonTerminalAgents cap,
+ * counted UNDER the per-org agent-create advisory lock (acquired before the
+ * per-image lock so the count is atomic across concurrent distinct-image
+ * creates and the two create paths can't deadlock). Over the cap it throws
+ * AgentQuotaExceededError, which the route maps to 429.
+ *
+ * This suite drives the REAL createCodingContainerAgent against in-process
+ * PGlite (real Drizzle schema via pushSchema, same harness as
+ * app-credit-hold-concurrency.test.ts) with NOTHING mocked. PGlite serializes
+ * statements, so the lock-ORDERING property is pinned in
+ * eliza-sandbox-create-idempotency.test.ts; this file proves the behavioral
+ * quota semantics end-to-end on real SQL.
+ *
+ * Self-skips LOUDLY if PGlite/pushSchema is unavailable (never silently passes).
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
+const CAN_USE_ISOLATED_PGLITE =
+  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { pushSchema } from "drizzle-kit/api";
+import { eq } from "drizzle-orm";
+import { agentSandboxes } from "../../../db/schemas/agent-sandboxes";
+import { organizations } from "../../../db/schemas/organizations";
+import { userCharacters } from "../../../db/schemas/user-characters";
+import { users } from "../../../db/schemas/users";
+
+const PGLITE_TIMEOUT = 60_000;
+const CAP = 3;
+let pgliteReady = true;
+
+let dbWrite: typeof import("../../../db/client").dbWrite;
+let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
+let ElizaSandboxService: typeof import("../eliza-sandbox").ElizaSandboxService;
+let AgentQuotaExceededError: typeof import("../eliza-sandbox").AgentQuotaExceededError;
+
+let seq = 0;
+function uniq(p: string): string {
+  seq += 1;
+  return `${p}-${seq}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function seedOrg(): Promise<string> {
+  const [org] = await dbWrite
+    .insert(organizations)
+    .values({ name: "Org", slug: uniq("org"), credit_balance: "5.000000" })
+    .returning();
+  return org.id;
+}
+
+async function seedUser(organizationId: string): Promise<string> {
+  const [user] = await dbWrite
+    .insert(users)
+    .values({ steward_user_id: uniq("steward"), organization_id: organizationId })
+    .returning();
+  return user.id;
+}
+
+async function countOrgRows(organizationId: string): Promise<number> {
+  const rows = await dbWrite.query.agentSandboxes.findMany({
+    where: eq(agentSandboxes.organization_id, organizationId),
+  });
+  return rows.length;
+}
+
+beforeAll(async () => {
+  if (!CAN_USE_ISOLATED_PGLITE) {
+    pgliteReady = false;
+    console.warn(
+      "[eliza-sandbox-coding-container-quota.test] non-PGlite DATABASE_URL; self-skipping.",
+    );
+    return;
+  }
+  try {
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
+    ({ ElizaSandboxService, AgentQuotaExceededError } = await import("../eliza-sandbox"));
+
+    const schema = { organizations, users, userCharacters, agentSandboxes };
+    const { apply } = await pushSchema(schema as never, dbWrite as never);
+    await apply();
+  } catch (error) {
+    pgliteReady = false;
+    console.error(
+      "[eliza-sandbox-coding-container-quota.test] PGlite/pushSchema unavailable — skipping.",
+      error,
+    );
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
+describe("createCodingContainerAgent — per-org quota (#11023)", () => {
+  test(
+    "the distinct-image DoS is dead: 6 distinct-image creates at cap 3 → exactly 3 rows, surplus throw AgentQuotaExceededError",
+    async () => {
+      if (!pgliteReady) return;
+      const orgId = await seedOrg();
+      const userId = await seedUser(orgId);
+      const svc = new ElizaSandboxService();
+
+      const results = await Promise.allSettled(
+        Array.from({ length: CAP * 2 }, (_, i) =>
+          svc.createCodingContainerAgent({
+            organizationId: orgId,
+            userId,
+            agentName: `cc-${i}`,
+            // DISTINCT image per call — the exact bypass of the per-image lock.
+            dockerImage: `ghcr.io/elizaos/tool:v${i}`,
+            executionTier: "custom",
+            maxNonTerminalAgents: CAP,
+          }),
+        ),
+      );
+
+      const won = results.filter((r) => r.status === "fulfilled");
+      const lost = results.filter((r): r is PromiseRejectedResult => r.status === "rejected");
+      expect(won.length).toBe(CAP);
+      expect(lost.length).toBe(CAP);
+      for (const rejection of lost) {
+        expect(rejection.reason).toBeInstanceOf(AgentQuotaExceededError);
+      }
+      // The DB agrees: the fleet only ever received CAP containers for this org.
+      expect(await countOrgRows(orgId)).toBe(CAP);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "same-image retry at the cap reuses the active row (idempotent, no throw)",
+    async () => {
+      if (!pgliteReady) return;
+      const orgId = await seedOrg();
+      const userId = await seedUser(orgId);
+      const svc = new ElizaSandboxService();
+
+      let firstId = "";
+      for (let i = 0; i < CAP; i++) {
+        const res = await svc.createCodingContainerAgent({
+          organizationId: orgId,
+          userId,
+          agentName: `cc-${i}`,
+          dockerImage: `ghcr.io/elizaos/tool:v${i}`,
+          executionTier: "custom",
+          maxNonTerminalAgents: CAP,
+        });
+        if (i === 0) firstId = res.agent.id;
+      }
+      // At the cap, but a SAME-image call returns the existing row (retry) —
+      // never a 429, so a client retry loop can't be locked out of its own agent.
+      const retry = await svc.createCodingContainerAgent({
+        organizationId: orgId,
+        userId,
+        agentName: "cc-retry",
+        dockerImage: "ghcr.io/elizaos/tool:v0",
+        executionTier: "custom",
+        maxNonTerminalAgents: CAP,
+      });
+      expect(retry.idempotent).toBe(true);
+      expect(retry.agent.id).toBe(firstId);
+      expect(await countOrgRows(orgId)).toBe(CAP);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "unset cap stays uncapped (trusted internal callers) — mints past any ceiling",
+    async () => {
+      if (!pgliteReady) return;
+      const orgId = await seedOrg();
+      const userId = await seedUser(orgId);
+      const svc = new ElizaSandboxService();
+
+      for (let i = 0; i < CAP + 2; i++) {
+        const res = await svc.createCodingContainerAgent({
+          organizationId: orgId,
+          userId,
+          agentName: `cc-internal-${i}`,
+          dockerImage: `ghcr.io/elizaos/tool:v${i}`,
+          executionTier: "custom",
+          // maxNonTerminalAgents intentionally unset
+        });
+        expect(res.idempotent).toBe(false);
+      }
+      expect(await countOrgRows(orgId)).toBe(CAP + 2);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "quota is per-org: org A at the cap does not block org B",
+    async () => {
+      if (!pgliteReady) return;
+      const orgA = await seedOrg();
+      const userA = await seedUser(orgA);
+      const orgB = await seedOrg();
+      const userB = await seedUser(orgB);
+      const svc = new ElizaSandboxService();
+
+      for (let i = 0; i < CAP; i++) {
+        await svc.createCodingContainerAgent({
+          organizationId: orgA,
+          userId: userA,
+          agentName: `a-${i}`,
+          dockerImage: `ghcr.io/elizaos/tool:v${i}`,
+          executionTier: "custom",
+          maxNonTerminalAgents: CAP,
+        });
+      }
+      // Org A is capped; org B (fresh) must still be able to create.
+      const res = await svc.createCodingContainerAgent({
+        organizationId: orgB,
+        userId: userB,
+        agentName: "b-0",
+        dockerImage: "ghcr.io/elizaos/tool:v0",
+        executionTier: "custom",
+        maxNonTerminalAgents: CAP,
+      });
+      expect(res.idempotent).toBe(false);
+      expect(await countOrgRows(orgB)).toBe(1);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "createAgent (forceCreate) and createCodingContainerAgent share ONE per-org ceiling",
+    async () => {
+      if (!pgliteReady) return;
+      const orgId = await seedOrg();
+      const userId = await seedUser(orgId);
+      const svc = new ElizaSandboxService();
+
+      // Fill the cap via the eliza/agents forceCreate path (#11042)...
+      for (let i = 0; i < CAP; i++) {
+        await svc.createAgent({
+          organizationId: orgId,
+          userId,
+          agentName: `agent-${i}`,
+          executionTier: "dedicated-always",
+          maxNonTerminalAgents: CAP,
+        });
+      }
+      // ...then a coding-container create for the SAME org must be refused —
+      // the two routes count against the same non-terminal-sandbox pool, so an
+      // attacker can't sidestep one route's cap by pivoting to the other.
+      await expect(
+        svc.createCodingContainerAgent({
+          organizationId: orgId,
+          userId,
+          agentName: "cc-cross",
+          dockerImage: "ghcr.io/elizaos/tool:v0",
+          executionTier: "custom",
+          maxNonTerminalAgents: CAP,
+        }),
+      ).rejects.toBeInstanceOf(AgentQuotaExceededError);
+      expect(await countOrgRows(orgId)).toBe(CAP);
+    },
+    PGLITE_TIMEOUT,
+  );
+});

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-create-idempotency.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-create-idempotency.test.ts
@@ -29,9 +29,19 @@ let executeCalls: number = 0;
 // these count rows. The reuse guard instead ends in `.limit()` (returns
 // existingRows), so it never hits the thenable.
 let countRows: Array<{ count: number }> = [{ count: 0 }];
+// Ordered second-key of every advisory lock the tx took ("agent-create" or
+// "coding-container:<image>") — lets the coding-container tests assert the
+// org lock is acquired BEFORE the per-image lock (#11023 lock ordering).
+let lockKeys: string[] = [];
 
-const txExecute = mock(async (_sql: SQL) => {
+const txExecute = mock(async (sql: SQL) => {
   executeCalls += 1;
+  try {
+    const { params } = new PgDialect().sqlToQuery(sql);
+    if (params.length > 1) lockKeys.push(String(params[1] ?? ""));
+  } catch {
+    // non-advisory-lock execute (none today) — ignore for ordering capture
+  }
   return { rows: [] };
 });
 
@@ -47,8 +57,7 @@ const txSelect = mock(() => {
     orderBy: () => chain,
     for: () => chain,
     limit: () => existingRows,
-    then: (resolve: (rows: Array<{ count: number }>) => unknown) =>
-      resolve(countRows),
+    then: (resolve: (rows: Array<{ count: number }>) => unknown) => resolve(countRows),
   } as Record<string, unknown>;
   return chain;
 });
@@ -143,6 +152,7 @@ function resetTx(): void {
   capturedSelectWhere = undefined;
   executeCalls = 0;
   countRows = [{ count: 0 }];
+  lockKeys = [];
   txExecute.mockClear();
   txSelect.mockClear();
   txInsert.mockClear();
@@ -343,5 +353,97 @@ describe("ElizaSandboxService.createAgent — forceCreate per-org quota (#11023)
     } finally {
       repoCreate.mockRestore();
     }
+  });
+});
+
+describe("ElizaSandboxService.createCodingContainerAgent — same per-org quota (#11023)", () => {
+  test("acquires the ORG lock BEFORE the per-image lock, then count→insert (lock ordering + atomicity)", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const svc = new ElizaSandboxService();
+
+    // No same-image row exists (reuse guard misses) and org is under cap.
+    existingRows = [];
+    countRows = [{ count: 2 }];
+    const res = await svc.createCodingContainerAgent({
+      organizationId: ORG_A,
+      userId: USER,
+      agentName: "cc-under-cap",
+      dockerImage: "ghcr.io/elizaos/tool:v1",
+      maxNonTerminalAgents: 5,
+    });
+
+    expect(res.idempotent).toBe(false);
+    expect(insertedRows.length).toBe(1);
+    // Org lock FIRST, then the per-image lock — the image lock alone can't
+    // serialize creates with DIFFERENT images against one org's quota, and the
+    // strict org→image order keeps this path deadlock-free vs createAgent.
+    expect(lockKeys).toEqual(["agent-create", "coding-container:ghcr.io/elizaos/tool:v1"]);
+    // The quota count scoped to the org + non-terminal statuses ran under the lock.
+    expect(capturedSelectWhere).toBeDefined();
+    const sql = new PgDialect().sqlToQuery(capturedSelectWhere as SQL).sql;
+    expect(sql).toContain("organization_id");
+    expect(sql).toContain("'pending'");
+    expect(sql).toContain("'provisioning'");
+    expect(sql).toContain("'running'");
+  });
+
+  test("a distinct-image create AT the cap is refused with AgentQuotaExceededError and NO insert", async () => {
+    const { ElizaSandboxService, AgentQuotaExceededError } = await import(
+      "./eliza-sandbox.ts?actual"
+    );
+    const svc = new ElizaSandboxService();
+
+    existingRows = []; // distinct image → reuse guard misses → would insert
+    countRows = [{ count: 5 }]; // ...but the org is at its cap
+    await expect(
+      svc.createCodingContainerAgent({
+        organizationId: ORG_A,
+        userId: USER,
+        agentName: "cc-at-cap",
+        dockerImage: "ghcr.io/elizaos/tool:v6",
+        maxNonTerminalAgents: 5,
+      }),
+    ).rejects.toBeInstanceOf(AgentQuotaExceededError);
+    expect(insertedRows.length).toBe(0);
+    // Both locks were still taken (ordering preserved) before the refusal.
+    expect(lockKeys).toEqual(["agent-create", "coding-container:ghcr.io/elizaos/tool:v6"]);
+  });
+
+  test("a same-image retry at the cap still returns the existing row (idempotent) — never 429", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const svc = new ElizaSandboxService();
+
+    existingRows = [{ ...baseRow(), id: "existing-cc", docker_image: "ghcr.io/elizaos/tool:v1" }];
+    countRows = [{ count: 5 }]; // at cap — must NOT be consulted on a reuse hit
+    const res = await svc.createCodingContainerAgent({
+      organizationId: ORG_A,
+      userId: USER,
+      agentName: "cc-retry",
+      dockerImage: "ghcr.io/elizaos/tool:v1",
+      maxNonTerminalAgents: 5,
+    });
+    expect(res.idempotent).toBe(true);
+    expect(res.agent.id).toBe("existing-cc");
+    expect(insertedRows.length).toBe(0);
+  });
+
+  test("an unset cap keeps the coding-container create uncapped (trusted internal callers)", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const svc = new ElizaSandboxService();
+
+    existingRows = [];
+    countRows = [{ count: 999 }]; // would exceed any cap — but none is set
+    const res = await svc.createCodingContainerAgent({
+      organizationId: ORG_A,
+      userId: USER,
+      agentName: "cc-uncapped",
+      dockerImage: "ghcr.io/elizaos/tool:v9",
+      // maxNonTerminalAgents intentionally unset
+    });
+    expect(res.idempotent).toBe(false);
+    expect(insertedRows.length).toBe(1);
+    // Coding containers ALWAYS run in the transaction (per-image idempotency),
+    // so both locks are taken even uncapped — but no count gates the insert.
+    expect(lockKeys).toEqual(["agent-create", "coding-container:ghcr.io/elizaos/tool:v9"]);
   });
 });

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-create-idempotency.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-create-idempotency.test.ts
@@ -57,6 +57,7 @@ const txSelect = mock(() => {
     orderBy: () => chain,
     for: () => chain,
     limit: () => existingRows,
+    // biome-ignore lint/suspicious/noThenProperty: Drizzle's count chain is awaited at `.where()`, so this mock must be thenable.
     then: (resolve: (rows: Array<{ count: number }>) => unknown) => resolve(countRows),
   } as Record<string, unknown>;
   return chain;

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -670,9 +670,7 @@ export class ElizaSandboxService {
     if (!params.reuseExistingNonTerminal) {
       // Uncapped fast path for trusted internal multi-agent callers.
       if (params.maxNonTerminalAgents === undefined) {
-        const created = await agentSandboxesRepository.create(
-          this.buildAgentInsertData(params),
-        );
+        const created = await agentSandboxesRepository.create(this.buildAgentInsertData(params));
         return { agent: created, idempotent: false };
       }
 
@@ -759,6 +757,13 @@ export class ElizaSandboxService {
     });
 
     return dbWrite.transaction(async (tx) => {
+      // Acquire the per-ORG agent-create lock BEFORE the per-image lock. The
+      // image lock alone (keyed on the exact docker_image) does NOT serialize
+      // two concurrent creates for DIFFERENT images against one org, so the
+      // quota count below would not be atomic without the org lock. Taking the
+      // org lock first everywhere gives a strict org→image lock order, so this
+      // path and createAgent (org lock only) can never deadlock. (#11023)
+      await tx.execute(elizaAgentCreateAdvisoryLockSql(createParams.organizationId));
       await tx.execute(
         elizaCodingContainerImageAdvisoryLockSql(
           createParams.organizationId,
@@ -783,6 +788,29 @@ export class ElizaSandboxService {
 
       if (existing) {
         return { agent: existing, idempotent: true };
+      }
+
+      // Per-org quota (#11023): the per-image reuse guard collapses only
+      // same-image retries, so a distinct-image loop (`:v1`/`:v2`/`@sha256…`
+      // under an allowlisted namespace) would otherwise mint unbounded custom
+      // containers on the shared fleet. #11042 capped createAgent's plain-insert
+      // branch but not this route; enforce the SAME per-org ceiling here, under
+      // the org lock so the count→insert is atomic against concurrent creates.
+      // Trusted internal callers pass no cap and stay uncapped.
+      if (createParams.maxNonTerminalAgents !== undefined) {
+        const [{ count } = { count: 0 }] = await tx
+          .select({ count: sql<number>`count(*)::int` })
+          .from(agentSandboxes)
+          .where(
+            and(
+              eq(agentSandboxes.organization_id, createParams.organizationId),
+              sql`${agentSandboxes.pool_status} IS NULL`,
+              sql`${agentSandboxes.status} IN ('pending', 'provisioning', 'running')`,
+            ),
+          );
+        if (count >= createParams.maxNonTerminalAgents) {
+          throw new AgentQuotaExceededError(count, createParams.maxNonTerminalAgents);
+        }
       }
 
       const [created] = await tx


### PR DESCRIPTION
## Summary

PR #11042 closed the **primary** #11023 fleet-DoS on `POST /api/v1/eliza/agents` (`forceCreate`) by capping `createAgent`'s plain-insert branch — but it did **not** touch the sibling path behind **`POST /api/v1/coding-containers`**, which was the secondary vector explicitly named in issue #11023 ("Also via `POST /coding-containers`"). This PR extends the same cap to that path.

### The residual gap (still live after #11042)

`createCodingContainerAgent`'s advisory lock **and** reuse guard are keyed on the **exact** `docker_image` string:

```ts
// lock: hashtext("coding-container:" + image)   — per (org, EXACT image)
// reuse guard: eq(agentSandboxes.docker_image, image)  — exact-string match
```

So a loop of **distinct** allowlisted image references (`:v1` / `:v2` / `@sha256:…`, or distinct repos under an allowlisted namespace) each **misses** the reuse guard and mints a fresh `agent_sandboxes` row + real provision job. The route's only gates are:

1. image-namespace allowlist (trailing-`*` prefix match — limits **which** images, never **how many**),
2. an optional digest-pin gate (**default off**),
3. the **threshold-only** `checkAgentCreditGate` (`balance > $0.10`, no per-agent debit/hold),

and there is **no rate-limit middleware** on the route. So any authenticated org on a ~$0.11 balance can loop the endpoint and mint **unbounded** custom containers on the shared ~5-node fleet — a DoS for every other tenant. Worse, the on-demand autoscale path (`provisionAutoscaledNodeForAgent → provisionNode`) does **not** re-check `maxNodes`, so the abuse can spin up **new paid Hetzner nodes**, not just exhaust existing ones.

**Adversarial verification:** 3 independent skeptics (route/middleware, daemon/provider/schema, allowlist/lock angles), all instructed to *refute* the DoS — **0 refuted, 3 stand, high confidence**. No per-org bound exists anywhere in the request path, the daemon, or the schema; the only caps below the API are global/per-node (which fail *all* tenants once exhausted — that *is* the DoS).

## Fix — extend #11042's cap to this path, one shared ceiling

- **`@/lib/constants/agent-sandbox-quota` → `getMaxNonTerminalAgentsForOrg`** (new): the balance-tier ceiling, **extracted** from `eliza/agents/route.ts` so both container-create routes share **one** source and can't drift ($0→5, $1→20, $10→100, $100→500). `eliza/agents/route.ts` now imports it (removes its local copy).
- **`createCodingContainerAgent`** takes `maxNonTerminalAgents` (same param `createAgent` got in #11042). It acquires the per-**org** agent-create advisory lock **before** the per-image lock — the image lock alone can't serialize distinct-image creates against one org's quota, and the strict **org→image** order keeps the two create paths **deadlock-free** — then counts the org's non-terminal (`pending`/`provisioning`/`running`, non-pool) sandboxes **under that lock** and throws `AgentQuotaExceededError` past the cap. Unset cap ⇒ uncapped (trusted internal callers).
- **`coding-containers/route.ts`** passes `getMaxNonTerminalAgentsForOrg(creditCheck.balance)` and maps `AgentQuotaExceededError → ApiError(429, "agent_quota_exceeded")`, mirroring `eliza/agents`. Because the cap counts the **same** non-terminal pool, an attacker can't sidestep one route's ceiling by pivoting to the other.

## Tests (real, no larp)

**`eliza-sandbox-coding-container-quota.test.ts` (NEW — real PGlite, nothing mocked on the create path):**
- the distinct-image DoS is **bounded** to the cap (6 distinct-image creates at cap 3 → exactly 3 rows, surplus throw `AgentQuotaExceededError`);
- same-image retry at the cap still **reuses** (idempotent, no 429 — a client retry loop can't be locked out of its own agent);
- **unset cap** stays uncapped (internal callers);
- quota is **per-org** (org A at cap doesn't block org B);
- `createAgent` (forceCreate) and `createCodingContainerAgent` share **one** ceiling (no cross-route bypass).

**`eliza-sandbox-create-idempotency.test.ts` (+4 SQL-capture cases):** pin the **lock ordering** (org lock before image lock), count-under-lock atomicity, at-cap refusal with **no insert**, reuse-hit-returns-before-count, and the uncapped path.

Run:
```
bun test packages/cloud/shared/src/lib/services/__tests__/eliza-sandbox-coding-container-quota.test.ts   # 5 pass
bun test packages/cloud/shared/src/lib/services/eliza-sandbox-create-idempotency.test.ts                  # 11 pass (7 merged + 4 new)
```

Typecheck: `packages/cloud/shared typecheck` + `packages/cloud/api build` (tsc --noEmit) both clean.

## Evidence

- **Auth/multi-tenant isolation proven by test:** per-org quota + cross-route shared ceiling covered above (real PGlite, denied path asserted via the 429/`AgentQuotaExceededError`).
- **DB state:** the behavioral suite asserts the exact `agent_sandboxes` row counts after each scenario (the fleet only ever receives `cap` containers per org).
- **Real request→response trace / video / screenshots:** N/A — backend-only change to a container-provision service + its two Worker routes; there is no UI surface and no model-backed endpoint. The security property (unbounded mint → bounded to the balance tier) is a DB-count invariant, proven end-to-end against real SQL rather than a mock.
- **Migration up/down:** N/A — no schema change (reuses the existing `agent_sandboxes` columns + the existing advisory-lock helpers).

Closes the coding-containers half of #11023 (ref #11042). Money/security-adjacent (fleet + autoscale spend) — flagging for maintainer merge rather than self-merge.