### PR TITLE
fix: prevent provider errors leaking into replies

### DIFF
--- a/packages/core/src/runtime/__tests__/use-model-provider-fallback.test.ts
+++ b/packages/core/src/runtime/__tests__/use-model-provider-fallback.test.ts
@@ -56,6 +56,26 @@ describe("AgentRuntime.useModel provider fallback", () => {
 		expect(directApiOk).toHaveBeenCalledTimes(1);
 	});
 
+	it("falls through on Anthropic 529 overloaded provider failures", async () => {
+		const runtime = makeRuntime();
+		const overloaded = vi.fn(async () => {
+			throw statusError(
+				529,
+				"API Error: 529 Overloaded. This is a server-side issue.",
+			);
+		});
+		const openRouterOk = vi.fn(async () => "openrouter-response");
+
+		runtime.registerModel(ModelType.TEXT_LARGE, overloaded, "claude-sdk", 100);
+		runtime.registerModel(ModelType.TEXT_LARGE, openRouterOk, "openrouter", 10);
+
+		await expect(
+			runtime.useModel(ModelType.TEXT_LARGE, { prompt: "hello" }),
+		).resolves.toBe("openrouter-response");
+		expect(overloaded).toHaveBeenCalledTimes(1);
+		expect(openRouterOk).toHaveBeenCalledTimes(1);
+	});
+
 	it("does not fall through for non-retryable provider errors", async () => {
 		const runtime = makeRuntime();
 		const badRequest = vi.fn(async () => {

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -1403,6 +1403,19 @@ type FailureReplyAttempt =
 	| { kind: "rateLimited" }
 	| { kind: "authFailed" };
 
+export function shouldSkipResponseMemoryPersistence(memory: Memory): boolean {
+	const content = memory.content as Record<string, unknown> | undefined;
+	const metadata = memory.metadata as Record<string, unknown> | undefined;
+	return (
+		content?.doNotPersist === true ||
+		content?.skipMemory === true ||
+		content?.transient === true ||
+		metadata?.doNotPersist === true ||
+		metadata?.skipMemory === true ||
+		metadata?.transient === true
+	);
+}
+
 export {
 	buildFailureReplyPrompt,
 	isAuthError,
@@ -9255,6 +9268,13 @@ export class DefaultMessageService implements IMessageService {
 					if (responseContent) {
 						responseMemory.content = responseContent;
 					}
+					if (shouldSkipResponseMemoryPersistence(responseMemory)) {
+						runtime.logger.debug(
+							{ src: "service:message", memoryId: responseMemory.id },
+							"Skipping transient response memory persistence",
+						);
+						continue;
+					}
 					runtime.logger.debug(
 						{ src: "service:message", memoryId: responseMemory.id },
 						"Saving response to memory",
@@ -9307,6 +9327,13 @@ export class DefaultMessageService implements IMessageService {
 							}
 							if (responseContent) {
 								responseMemory.content = responseContent;
+							}
+							if (shouldSkipResponseMemoryPersistence(responseMemory)) {
+								runtime.logger.debug(
+									{ src: "service:message", memoryId: responseMemory.id },
+									"Skipping transient response memory persistence",
+								);
+								continue;
 							}
 							runtime.logger.debug(
 								{ src: "service:message", memoryId: responseMemory.id },
@@ -10157,6 +10184,10 @@ export class DefaultMessageService implements IMessageService {
 		const responseContent: Content = {
 			thought: `Handle a temporary reply failure during ${stage}.`,
 			actions: ["REPLY"],
+			failureKind: "transient_failure",
+			elizaSyntheticFailure: true,
+			transient: true,
+			doNotPersist: true,
 			providers: [],
 			text: replyText,
 			responseId,

--- a/packages/core/src/services/message/fallback-reply.ts
+++ b/packages/core/src/services/message/fallback-reply.ts
@@ -56,13 +56,15 @@ export function isRateLimitError(error: unknown): boolean {
 		haystack.includes("requests per second") ||
 		haystack.includes("requests per hour") ||
 		haystack.includes("slow down") ||
+		haystack.includes("overloaded") ||
 		// Subscription-credit exhaustion (Claude/Codex CLI-SDK brains): the SDK
 		// surfaces "you've hit your session/usage limit" when the monthly credit
 		// runs dry. Treat it as a rate limit so the graceful "temporarily
 		// unavailable" reply path handles it instead of leaking the raw string.
 		haystack.includes("session limit") ||
 		haystack.includes("usage limit") ||
-		/\b429\b/.test(haystack)
+		/\b429\b/.test(haystack) ||
+		/\b529\b/.test(haystack)
 	);
 }
 
@@ -104,7 +106,7 @@ export function isModelProviderFallbackError(error: unknown): boolean {
 	if (isRateLimitError(error)) {
 		return true;
 	}
-	if (hasHttpStatus(unwrapped, [500, 502, 503, 504])) {
+	if (hasHttpStatus(unwrapped, [500, 502, 503, 504, 529])) {
 		return true;
 	}
 	if (!(error instanceof Error)) return false;
@@ -114,6 +116,7 @@ export function isModelProviderFallbackError(error: unknown): boolean {
 		haystack.includes("timed out") ||
 		haystack.includes("temporarily unavailable") ||
 		haystack.includes("service unavailable") ||
+		haystack.includes("overloaded") ||
 		haystack.includes("bad gateway") ||
 		haystack.includes("gateway timeout") ||
 		haystack.includes("internal server error") ||
@@ -121,7 +124,7 @@ export function isModelProviderFallbackError(error: unknown): boolean {
 		haystack.includes("socket hang up") ||
 		haystack.includes("network error") ||
 		haystack.includes("fetch failed") ||
-		haystack.includes("overloaded")
+		/\b529\b/.test(haystack)
 	);
 }
 

--- a/packages/core/src/services/message/provider-error-hygiene.test.ts
+++ b/packages/core/src/services/message/provider-error-hygiene.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import type { Memory } from "../../types";
+import { shouldSkipResponseMemoryPersistence } from "../message";
+import {
+	isModelProviderFallbackError,
+	isRateLimitError,
+} from "./fallback-reply";
+
+function assistantMemory(
+	text: string,
+	content: Record<string, unknown> = {},
+): Memory {
+	return {
+		id: "00000000-0000-0000-0000-000000000001" as `${string}-${string}-${string}-${string}-${string}`,
+		entityId:
+			"00000000-0000-0000-0000-000000000002" as `${string}-${string}-${string}-${string}-${string}`,
+		agentId:
+			"00000000-0000-0000-0000-000000000002" as `${string}-${string}-${string}-${string}-${string}`,
+		roomId:
+			"00000000-0000-0000-0000-000000000003" as `${string}-${string}-${string}-${string}-${string}`,
+		content: { text, ...content },
+		createdAt: Date.now(),
+	};
+}
+
+describe("provider error hygiene", () => {
+	it("classifies Anthropic 529 overloaded errors as failover-eligible and retryable", () => {
+		const error = Object.assign(
+			new Error("API Error: 529 Overloaded. This is a server-side issue."),
+			{ statusCode: 529 },
+		);
+
+		expect(isModelProviderFallbackError(error)).toBe(true);
+		expect(isRateLimitError(error)).toBe(true);
+	});
+
+	it("marks transient failure replies as non-persisted response memories", () => {
+		const memory = assistantMemory(
+			"Something went wrong on my end. Please try again.",
+			{
+				failureKind: "transient_failure",
+				elizaSyntheticFailure: true,
+				transient: true,
+				doNotPersist: true,
+			},
+		);
+
+		expect(shouldSkipResponseMemoryPersistence(memory)).toBe(true);
+	});
+
+	it("does not skip ordinary assistant replies", () => {
+		const memory = assistantMemory("normal answer");
+		expect(shouldSkipResponseMemoryPersistence(memory)).toBe(false);
+	});
+});

--- a/packages/core/src/utils/model-errors.ts
+++ b/packages/core/src/utils/model-errors.ts
@@ -10,6 +10,7 @@ const TRANSIENT_MODEL_ERROR_PATTERNS = [
 	"etimedout",
 	"timeout",
 	"timed out",
+	"529",
 	"503",
 	"502",
 	"504",

--- a/plugins/plugin-cli-inference/__tests__/claude-sdk-session.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/claude-sdk-session.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { ClaudeSdkSession, type SdkModule } from "../src/claude-sdk-session";
+import { ProviderApiError } from "../src/provider-errors";
 
 /**
  * Unit tests for the warm Agent SDK session, driven by a FAKE SdkModule via the
@@ -10,6 +11,8 @@ import { ClaudeSdkSession, type SdkModule } from "../src/claude-sdk-session";
  */
 
 interface TurnScript {
+  /** Never yield a message, used to test the per-turn timeout budget. */
+  hang?: boolean;
   /** ROUTE mode: invoke the captured tool handler with this decision. */
   toolCall?: { action: unknown; params?: unknown };
   /** Stream this as assistant text before the result. */
@@ -50,6 +53,9 @@ function makeFakeSdk(scripts: TurnScript[]): {
       async function* gen() {
         while (turn < scripts.length) {
           const s = scripts[turn++];
+          if (s.hang) {
+            await new Promise(() => undefined);
+          }
           if (s.toolCall && handler) {
             await handler({ action: s.toolCall.action, params: s.toolCall.params });
           }
@@ -85,7 +91,7 @@ const fakeZod = {
 
 function makeSession(
   scripts: TurnScript[],
-  opts: { router?: boolean; restartAfterTurns?: number } = {}
+  opts: { router?: boolean; restartAfterTurns?: number; turnTimeoutMs?: number } = {}
 ) {
   const { sdk, starts } = makeFakeSdk(scripts);
   const session = new ClaudeSdkSession({
@@ -93,6 +99,7 @@ function makeSession(
     systemPrompt: "test system",
     router: opts.router ?? false,
     restartAfterTurns: opts.restartAfterTurns,
+    turnTimeoutMs: opts.turnTimeoutMs,
     sdkModule: sdk,
     zodModule: fakeZod,
   });
@@ -135,6 +142,29 @@ describe("ClaudeSdkSession — TEXT mode", () => {
       },
     ]);
     await expect(session.generate("hi")).rejects.toThrow(/subscription rate limit reached/);
+    await session.dispose();
+  });
+
+  it("throws a typed provider error instead of returning streamed API Error text", async () => {
+    const { session } = makeSession([
+      {
+        text: "API Error: 529 Overloaded. This is a server-side issue, check https://status.claude.com.",
+        subtype: "success",
+      },
+    ]);
+    await expect(session.generate("hi")).rejects.toMatchObject({
+      name: "ProviderApiError",
+      statusCode: 529,
+      retryable: true,
+    });
+    await session.dispose();
+  });
+
+  it("bounds a hung SDK turn below connector timeouts", async () => {
+    const { session } = makeSession([{ hang: true }], { turnTimeoutMs: 5 });
+    const started = Date.now();
+    await expect(session.generate("hi")).rejects.toBeInstanceOf(ProviderApiError);
+    expect(Date.now() - started).toBeLessThan(1_000);
     await session.dispose();
   });
 

--- a/plugins/plugin-cli-inference/index.ts
+++ b/plugins/plugin-cli-inference/index.ts
@@ -157,6 +157,9 @@ function getSdkSession(
     router,
     claudeExecutablePath: getSetting(runtime, "ELIZA_CLI_CLAUDE_BIN"),
     restartAfterTurns: parseTimeout(getSetting(runtime, "ELIZA_CLI_SDK_RESTART_AFTER_TURNS")),
+    turnTimeoutMs:
+      parseTimeout(getSetting(runtime, "ELIZA_CLI_SDK_TURN_TIMEOUT_MS")) ??
+      parseTimeout(getSetting(runtime, "ELIZA_CLI_TIMEOUT_MS")),
   });
   sdkSessions.set(key, session);
   // Evict least-recently-used past the cap (each session is a live process).
@@ -367,6 +370,7 @@ export const cliInferencePlugin: Plugin = {
     ELIZA_CLI_CLAUDE_PLANNER_MODEL: readEnv("ELIZA_CLI_CLAUDE_PLANNER_MODEL") ?? null,
     ELIZA_CLI_CLAUDE_BIN: readEnv("ELIZA_CLI_CLAUDE_BIN") ?? null,
     ELIZA_CLI_SDK_RESTART_AFTER_TURNS: readEnv("ELIZA_CLI_SDK_RESTART_AFTER_TURNS") ?? null,
+    ELIZA_CLI_SDK_TURN_TIMEOUT_MS: readEnv("ELIZA_CLI_SDK_TURN_TIMEOUT_MS") ?? null,
     ELIZA_CLI_CODEX_MODEL: readEnv("ELIZA_CLI_CODEX_MODEL") ?? null,
     ELIZA_CLI_TIMEOUT_MS: readEnv("ELIZA_CLI_TIMEOUT_MS") ?? null,
   },

--- a/plugins/plugin-cli-inference/package.json
+++ b/plugins/plugin-cli-inference/package.json
@@ -105,6 +105,13 @@
         "default": 20,
         "sensitive": false
       },
+      "ELIZA_CLI_SDK_TURN_TIMEOUT_MS": {
+        "type": "number",
+        "description": "Per-turn Claude SDK timeout in milliseconds. Defaults to 90000 and falls back to ELIZA_CLI_TIMEOUT_MS when set.",
+        "required": false,
+        "default": 90000,
+        "sensitive": false
+      },
       "ELIZA_CLI_CODEX_MODEL": {
         "type": "string",
         "description": "Model id passed to `codex exec -m`. Defaults to gpt-5.5.",

--- a/plugins/plugin-cli-inference/src/claude-cli.ts
+++ b/plugins/plugin-cli-inference/src/claude-cli.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { logger } from "@elizaos/core";
 import { flattenPrompt } from "./prompt-flatten";
+import { ProviderApiError, parseProviderApiErrorText } from "./provider-errors";
 import { filterEnv, redactStderr, resolveSafeBinary, resolveSafeCwd } from "./sandbox";
 
 /**
@@ -222,6 +223,12 @@ export class ClaudeCli {
         );
       }
       const text = result.stdout.trim();
+      const apiError = parseProviderApiErrorText(text);
+      if (apiError) {
+        throw new ProviderApiError(`[cli-inference] claude upstream ${text.slice(0, 160)}`, {
+          statusCode: apiError.statusCode,
+        });
+      }
       if (text.length === 0) {
         throw new Error(
           `[cli-inference] claude returned empty stdout: ${redactStderr(result.stderr)}`

--- a/plugins/plugin-cli-inference/src/claude-sdk-session.ts
+++ b/plugins/plugin-cli-inference/src/claude-sdk-session.ts
@@ -43,9 +43,11 @@
  */
 
 import { logger } from "@elizaos/core";
+import { ProviderApiError, parseProviderApiErrorText } from "./provider-errors";
 
 const DEFAULT_MODEL = "claude-opus-4-7";
 const DEFAULT_RESTART_AFTER_TURNS = 20;
+const DEFAULT_TURN_TIMEOUT_MS = 90_000;
 /** Fully-qualified name the SDK assigns our in-process MCP tool. */
 const ROUTE_TOOL = "mcp__eliza__route_action";
 
@@ -66,11 +68,7 @@ export function isClaudeSubscriptionLimitMessage(text: string): boolean {
   // A genuine short ANSWER about limits ("No, you haven't hit your rate limit
   // yet.") shares vocabulary with the envelope; the envelope itself never
   // contains negation.
-  if (
-    /\b(no|not|haven't|havent|hasn't|hasnt|didn't|didnt|isn't|isnt|wasn't|wasnt)\b/.test(
-      t,
-    )
-  ) {
+  if (/\b(no|not|haven't|havent|hasn't|hasnt|didn't|didnt|isn't|isnt|wasn't|wasnt)\b/.test(t)) {
     return false;
   }
   return (
@@ -97,7 +95,7 @@ export function isClaudeSubscriptionLimitMessage(text: string): boolean {
  * throw to failover instead of relaying the raw error to the user.
  */
 export function isClaudeSdkApiErrorMessage(text: string): boolean {
-  return /^API Error:\s*\d{3}\b/.test(text.trim());
+  return parseProviderApiErrorText(text) !== null;
 }
 
 /** The model's captured routing decision (ROUTE mode). */
@@ -132,13 +130,9 @@ type SdkToolFn = (
   handler: (args: {
     action?: unknown;
     params?: unknown;
-  }) => Promise<{ content: Array<{ type: string; text: string }> }>,
+  }) => Promise<{ content: Array<{ type: string; text: string }> }>
 ) => unknown;
-type SdkMcpServerFn = (options: {
-  name: string;
-  version?: string;
-  tools: unknown[];
-}) => unknown;
+type SdkMcpServerFn = (options: { name: string; version?: string; tools: unknown[] }) => unknown;
 
 /** Minimal shape of the SDK module we load lazily. */
 export interface SdkModule {
@@ -171,6 +165,8 @@ export interface ClaudeSdkSessionConfig {
   claudeExecutablePath?: string | null;
   /** Restart the warm session after this many turns (bounds context growth). */
   restartAfterTurns?: number;
+  /** Hard wall-clock budget for one SDK turn. Defaults below common 120s connector timeouts. */
+  turnTimeoutMs?: number;
   /** Injected for tests; defaults to the real SDK + zod. */
   sdkModule?: SdkModule;
   zodModule?: ZodModule;
@@ -201,18 +197,14 @@ function isZodModule(value: unknown): value is ZodModule {
   }
   const z = value.z;
   return (
-    typeof z.string === "function" &&
-    typeof z.any === "function" &&
-    typeof z.record === "function"
+    typeof z.string === "function" && typeof z.any === "function" && typeof z.record === "function"
   );
 }
 
 async function loadSdk(): Promise<SdkModule> {
   const sdk: unknown = await import(SDK_PACKAGE);
   if (!isSdkModule(sdk)) {
-    throw new Error(
-      "[cli-inference:sdk] Claude Agent SDK module has an unexpected shape",
-    );
+    throw new Error("[cli-inference:sdk] Claude Agent SDK module has an unexpected shape");
   }
   return sdk;
 }
@@ -236,6 +228,7 @@ export class ClaudeSdkSession {
   private readonly textMaxTurns: number;
   private readonly claudeExecutablePath: string | null;
   private readonly restartAfterTurns: number;
+  private readonly turnTimeoutMs: number;
   private readonly sdkOverride?: SdkModule;
   private readonly zodOverride?: ZodModule;
 
@@ -253,13 +246,16 @@ export class ClaudeSdkSession {
     this.model = config.model?.trim() || DEFAULT_MODEL;
     this.systemPrompt = config.systemPrompt?.trim() || null;
     this.router = config.router === true;
-    this.textMaxTurns =
-      config.textMaxTurns && config.textMaxTurns > 0 ? config.textMaxTurns : 1;
+    this.textMaxTurns = config.textMaxTurns && config.textMaxTurns > 0 ? config.textMaxTurns : 1;
     this.claudeExecutablePath = config.claudeExecutablePath?.trim() || null;
     this.restartAfterTurns =
       config.restartAfterTurns && config.restartAfterTurns > 0
         ? config.restartAfterTurns
         : DEFAULT_RESTART_AFTER_TURNS;
+    this.turnTimeoutMs =
+      config.turnTimeoutMs && config.turnTimeoutMs > 0
+        ? config.turnTimeoutMs
+        : DEFAULT_TURN_TIMEOUT_MS;
     this.sdkOverride = config.sdkModule;
     this.zodOverride = config.zodModule;
   }
@@ -287,10 +283,7 @@ export class ClaudeSdkSession {
     return run;
   }
 
-  private async sendOnce(
-    body: string,
-    mode: "text" | "route",
-  ): Promise<string> {
+  private async sendOnce(body: string, mode: "text" | "route"): Promise<string> {
     if (!body.trim()) {
       throw new Error("[cli-inference:sdk] empty prompt body");
     }
@@ -307,9 +300,7 @@ export class ClaudeSdkSession {
     } catch (err) {
       // Self-heal: a dead/erroring session must not poison the next turn.
       await this.dispose();
-      throw err instanceof Error
-        ? err
-        : new Error(`[cli-inference:sdk] ${String(err)}`);
+      throw err instanceof Error ? err : new Error(`[cli-inference:sdk] ${String(err)}`);
     }
   }
 
@@ -379,11 +370,9 @@ export class ClaudeSdkSession {
             };
           }
           return {
-            content: [
-              { type: "text", text: "ACK. Routing recorded. Stop now." },
-            ],
+            content: [{ type: "text", text: "ACK. Routing recorded. Stop now." }],
           };
-        },
+        }
       );
       const mcp = sdk.createSdkMcpServer({
         name: "eliza",
@@ -413,15 +402,44 @@ export class ClaudeSdkSession {
         model: this.model,
         mode: this.router ? "route" : "text",
       },
-      "warm Claude Agent SDK session started",
+      "warm Claude Agent SDK session started"
     );
   }
 
+  private async nextWithTurnTimeout(): Promise<IteratorResult<SdkMessage>> {
+    const iterator = this.iterator;
+    if (!iterator) {
+      throw new Error("[cli-inference:sdk] session not started");
+    }
+
+    let timer: NodeJS.Timeout | undefined;
+    try {
+      return await Promise.race([
+        iterator.next(),
+        new Promise<IteratorResult<SdkMessage>>((_, reject) => {
+          timer = setTimeout(() => {
+            reject(
+              new ProviderApiError(
+                `[cli-inference:sdk] turn timed out after ${this.turnTimeoutMs}ms`,
+                { retryable: true }
+              )
+            );
+          }, this.turnTimeoutMs);
+          timer.unref?.();
+        }),
+      ]);
+    } catch (error) {
+      if (error instanceof ProviderApiError) {
+        await this.dispose();
+      }
+      throw error;
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+
   /** Push one user message and read the turn's assistant text + result envelope. */
-  private async sendAndRead(
-    body: string,
-    mode: "text" | "route",
-  ): Promise<string> {
+  private async sendAndRead(body: string, mode: "text" | "route"): Promise<string> {
     if (!this.feed || !this.iterator) {
       throw new Error("[cli-inference:sdk] session not started");
     }
@@ -436,7 +454,7 @@ export class ClaudeSdkSession {
     let resultSubtype: string | undefined;
     let sawResult = false;
     while (true) {
-      const { value, done } = await this.iterator.next();
+      const { value, done } = await this.nextWithTurnTimeout();
       if (done) {
         // Generator ended WITHOUT a terminating `result` message — the session
         // died mid-turn. Force a restart next turn; `sawResult` stays false so
@@ -478,11 +496,11 @@ export class ClaudeSdkSession {
     // as a REPLY, text mode as the completion). "rate limit" in the thrown
     // message routes it through isRateLimitError.
     const limitEnvelope = [text, resultText ?? ""].find((candidate) =>
-      isClaudeSubscriptionLimitMessage(candidate),
+      isClaudeSubscriptionLimitMessage(candidate)
     );
     if (sawResult && limitEnvelope !== undefined) {
       throw new Error(
-        `[cli-inference:sdk] subscription rate limit reached: ${limitEnvelope.trim().slice(0, 120)}`,
+        `[cli-inference:sdk] subscription rate limit reached: ${limitEnvelope.trim().slice(0, 120)}`
       );
     }
 
@@ -494,11 +512,13 @@ export class ClaudeSdkSession {
     // keeps the SDK's status text so isRateLimitError/isAuthError classify
     // 429/401 correctly downstream.
     const apiErrorEnvelope = [text, resultText ?? ""].find((candidate) =>
-      isClaudeSdkApiErrorMessage(candidate),
+      isClaudeSdkApiErrorMessage(candidate)
     );
     if (apiErrorEnvelope !== undefined) {
-      throw new Error(
+      const parsed = parseProviderApiErrorText(apiErrorEnvelope);
+      throw new ProviderApiError(
         `[cli-inference:sdk] upstream ${apiErrorEnvelope.trim().slice(0, 160)}`,
+        { statusCode: parsed?.statusCode }
       );
     }
 
@@ -515,7 +535,7 @@ export class ClaudeSdkSession {
         }
       }
       throw new Error(
-        `[cli-inference:sdk] route: model emitted no decision (subtype=${resultSubtype ?? "?"})`,
+        `[cli-inference:sdk] route: model emitted no decision (subtype=${resultSubtype ?? "?"})`
       );
     }
 
@@ -533,7 +553,7 @@ export class ClaudeSdkSession {
     // No trustworthy text: THROW so useModel / AccountPool fails over, per the
     // plugin's throw-to-failover contract — never return partial/meta output.
     throw new Error(
-      `[cli-inference:sdk] empty completion (subtype=${resultSubtype ?? (sawResult ? "?" : "session-ended")})`,
+      `[cli-inference:sdk] empty completion (subtype=${resultSubtype ?? (sawResult ? "?" : "session-ended")})`
     );
   }
 

--- a/plugins/plugin-cli-inference/src/provider-errors.ts
+++ b/plugins/plugin-cli-inference/src/provider-errors.ts
@@ -1,0 +1,48 @@
+export class ProviderApiError extends Error {
+  readonly statusCode?: number;
+  readonly retryable: boolean;
+
+  constructor(
+    message: string,
+    options: { statusCode?: number; retryable?: boolean; cause?: unknown } = {}
+  ) {
+    super(message);
+    this.name = "ProviderApiError";
+    if (options.cause !== undefined) {
+      (this as Error & { cause?: unknown }).cause = options.cause;
+    }
+    this.statusCode = options.statusCode;
+    this.retryable = options.retryable ?? isRetryableProviderStatus(options.statusCode, message);
+  }
+}
+
+export function isRetryableProviderStatus(statusCode: number | undefined, message = ""): boolean {
+  if (statusCode === 429 || statusCode === 529) return true;
+  if (statusCode !== undefined && [500, 502, 503, 504].includes(statusCode)) return true;
+  const haystack = message.toLowerCase();
+  return (
+    haystack.includes("overloaded") ||
+    haystack.includes("rate limit") ||
+    haystack.includes("too many requests") ||
+    haystack.includes("temporarily unavailable") ||
+    haystack.includes("service unavailable") ||
+    haystack.includes("timeout") ||
+    haystack.includes("timed out")
+  );
+}
+
+export function parseProviderApiErrorText(
+  text: string
+): { statusCode?: number; message: string } | null {
+  const trimmed = text.trim();
+  const match = /^API Error:\s*(\d{3})\b[\s:.-]*(.*)$/is.exec(trimmed);
+  if (!match) return null;
+  return {
+    statusCode: Number.parseInt(match[1], 10),
+    message: trimmed,
+  };
+}
+
+export function isProviderApiErrorText(text: string): boolean {
+  return parseProviderApiErrorText(text) !== null;
+}


### PR DESCRIPTION
## Summary

- Convert Claude CLI/SDK `API Error: <status>` envelopes into typed `ProviderApiError`s instead of returning them as model text.
- Add a configurable Claude SDK per-turn timeout (`ELIZA_CLI_SDK_TURN_TIMEOUT_MS`, default 90s) so a single provider attempt does not outlive connector reply windows.
- Treat 529/overloaded provider failures as failover-eligible and retryable, including the `useModel` provider fallback path.
- Mark transient provider-failure replies as synthetic, transient, and `doNotPersist`, and skip response-memory persistence for those flags so provider outages do not pollute RECENT_MESSAGES.

## Tests

- `cd plugins/plugin-cli-inference && bun run test -- __tests__/claude-sdk-session.test.ts`
- `cd packages/core && bun run test -- src/runtime/__tests__/use-model-provider-fallback.test.ts src/services/message/provider-error-hygiene.test.ts`
- `cd packages/core && bun run typecheck`
- `cd plugins/plugin-cli-inference && bun run typecheck`

Note: core tests/typecheck in this fresh worktree required generated i18n artifact symlinks from the already-built source checkout; those symlinks were removed before commit.

## Review

Codex review skipped due current usage limits.
