### PR TITLE
fix(ui): expire steward tokens with malformed exp

### DIFF
--- a/packages/ui/src/cloud/shell/StewardProviderShared.test.ts
+++ b/packages/ui/src/cloud/shell/StewardProviderShared.test.ts
@@ -97,6 +97,10 @@ describe("tokenIsExpired", () => {
     expect(tokenIsExpired(makeJwt({ sub: "u1" }))).toBe(true);
   });
 
+  it("treats a token with a non-numeric exp as expired", () => {
+    expect(tokenIsExpired(makeJwt({ sub: "u1", exp: "soon" }))).toBe(true);
+  });
+
   it("treats an undecodable token as expired", () => {
     expect(tokenIsExpired("not-a-jwt")).toBe(true);
   });

--- a/packages/ui/src/cloud/shell/StewardProviderShared.ts
+++ b/packages/ui/src/cloud/shell/StewardProviderShared.ts
@@ -145,7 +145,9 @@ export function tokenIsExpired(token: string): boolean {
   // token is foreign/malformed, and since the 401 handlers keep any
   // NON-expired token, an exp-less one would otherwise be uncloseable — no
   // 401 could ever clear it and it never ages out on its own.
-  if (!payload.exp) return true;
+  if (typeof payload.exp !== "number" || !Number.isFinite(payload.exp)) {
+    return true;
+  }
   return payload.exp * 1000 < Date.now();
 }
 


### PR DESCRIPTION
## Summary
- Treat Steward JWTs with non-numeric or non-finite `exp` claims as expired
- Add regression coverage so malformed truthy `exp` values cannot survive the 401 keep-path

## Evidence
- `bun run --cwd packages/ui test -- src/cloud/shell/StewardProviderShared.test.ts src/cloud/shell/StewardProviderRuntime.test.tsx src/cloud/public-pages/pages/auth/email-callback-page.test.tsx`
- `bunx biome check packages/ui/src/cloud/shell/StewardProviderShared.ts packages/ui/src/cloud/shell/StewardProviderShared.test.ts`
- `bun run --cwd packages/ui typecheck`
- `bun run --cwd packages/app audit:app` passed 349 captures on the reviewed patch: broken=0, needs-work=0

Follow-up from review of #11067.