### PR TITLE
fix(core): dedupe DST fall-back cron double-fire + guard non-representable base (#11046)

### DIFF
--- a/packages/core/src/services/triggerScheduling.test.ts
+++ b/packages/core/src/services/triggerScheduling.test.ts
@@ -49,3 +49,57 @@ describe("computeNextCronRunAtMs - `N/step` schedules recurringly", () => {
 		expect(after).toBe(Date.UTC(2024, 0, 1, 0, 35, 0));
 	});
 });
+
+describe("computeNextCronRunAtMs - DST fall-back dedupe (#11046)", () => {
+	// America/New_York falls back 2026-11-01 02:00 EDT -> 01:00 EST, so local
+	// 01:30 occurs twice: 05:30Z (EDT) and 06:30Z (EST). A daily `30 1 * * *`
+	// must fire ONCE that day (the first instant), not once per pass.
+	const NY = "America/New_York";
+	const at = (iso: string) => Date.parse(iso);
+
+	it("fires the FIRST instant of the repeated hour", () => {
+		// From the prior day's fire, the next run is the EDT (first) pass.
+		expect(computeNextCronRunAtMs("30 1 * * *", at("2026-10-31T05:30:00.000Z"), NY)).toBe(
+			at("2026-11-01T05:30:00.000Z"),
+		);
+	});
+
+	it("does NOT double-fire at the repeated hour's second instant", () => {
+		// Immediately after the EDT fire, the next run skips the EST duplicate
+		// (06:30Z same day) and lands on the next local day (01:30 EST).
+		expect(computeNextCronRunAtMs("30 1 * * *", at("2026-11-01T05:30:00.000Z"), NY)).toBe(
+			at("2026-11-02T06:30:00.000Z"),
+		);
+	});
+
+	it("resumes normal once-per-day firing after the transition", () => {
+		expect(computeNextCronRunAtMs("30 1 * * *", at("2026-11-02T06:30:00.000Z"), NY)).toBe(
+			at("2026-11-03T06:30:00.000Z"),
+		);
+	});
+});
+
+describe("computeNextCronRunAtMs - non-representable base guard (#11046)", () => {
+	it("returns null immediately for a base at/over the max representable Date", () => {
+		// Number.MAX_SAFE_INTEGER (~9.007e15) exceeds the max Date (±8.64e15), so
+		// every scanned candidate would be an Invalid Date. The guard bails instead
+		// of scanning ~366 days of Invalid-Date minutes.
+		const started = performance.now();
+		const result = computeNextCronRunAtMs(
+			"0 0 29 2 *",
+			Number.MAX_SAFE_INTEGER,
+			"America/New_York",
+		);
+		const elapsedMs = performance.now() - started;
+		expect(result).toBeNull();
+		// Was a ~26s Invalid-Date scan without the guard; a generous ceiling.
+		expect(elapsedMs).toBeLessThan(2000);
+	});
+
+	it("returns null for non-finite bases", () => {
+		expect(computeNextCronRunAtMs("* * * * *", Number.NaN)).toBeNull();
+		expect(
+			computeNextCronRunAtMs("* * * * *", Number.POSITIVE_INFINITY),
+		).toBeNull();
+	});
+});

--- a/packages/core/src/services/triggerScheduling.ts
+++ b/packages/core/src/services/triggerScheduling.ts
@@ -7,6 +7,9 @@ export const DISABLED_TRIGGER_INTERVAL_MS = 365 * 24 * 60 * 60 * 1000;
 const CRON_FIELDS = 5;
 const CRON_SCAN_WINDOW_MS = 366 * 24 * 60 * 60 * 1000;
 const CRON_MINUTE_MS = 60_000;
+const CRON_HOUR_MS = 60 * CRON_MINUTE_MS;
+/** Max timestamp a JS Date can represent (±8.64e15 ms); beyond this a Date is Invalid. */
+const MAX_REPRESENTABLE_MS = 8_640_000_000_000_000;
 
 interface CronRange {
 	min: number;
@@ -134,13 +137,9 @@ function cronMatchesUTC(schedule: CronSchedule, candidateMs: number): boolean {
 	);
 }
 
-function getTimezoneOffsetMs(
-	timezone: string | undefined,
-	atMs: number,
-): number {
-	if (!timezone || timezone === "UTC") return 0;
+function buildTzFormatter(timezone: string): Intl.DateTimeFormat | null {
 	try {
-		const formatter = new Intl.DateTimeFormat("en-US", {
+		return new Intl.DateTimeFormat("en-US", {
 			timeZone: timezone,
 			year: "numeric",
 			month: "2-digit",
@@ -150,35 +149,59 @@ function getTimezoneOffsetMs(
 			second: "2-digit",
 			hour12: false,
 		});
-		const parts = formatter.formatToParts(new Date(atMs));
-		const get = (type: string): number => {
-			const part = parts.find((p) => p.type === type);
-			return part ? Number(part.value) : 0;
-		};
-		const tzDate = Date.UTC(
-			get("year"),
-			get("month") - 1,
-			get("day"),
-			get("hour"),
-			get("minute"),
-			get("second"),
-		);
-		return tzDate - atMs;
 	} catch {
-		return 0;
+		return null;
 	}
+}
+
+function offsetMsFromFormatter(
+	formatter: Intl.DateTimeFormat,
+	atMs: number,
+): number {
+	const parts = formatter.formatToParts(new Date(atMs));
+	const get = (type: string): number => {
+		const part = parts.find((p) => p.type === type);
+		return part ? Number(part.value) : 0;
+	};
+	const tzDate = Date.UTC(
+		get("year"),
+		get("month") - 1,
+		get("day"),
+		get("hour"),
+		get("minute"),
+		get("second"),
+	);
+	return tzDate - atMs;
+}
+
+function getTimezoneOffsetMs(
+	timezone: string | undefined,
+	atMs: number,
+): number {
+	if (!timezone || timezone === "UTC") return 0;
+	const formatter = buildTzFormatter(timezone);
+	return formatter ? offsetMsFromFormatter(formatter, atMs) : 0;
 }
 
 function cronMatches(
 	schedule: CronSchedule,
 	candidateMs: number,
-	timezone?: string,
+	timezone: string | undefined,
+	formatter: Intl.DateTimeFormat | null,
 ): boolean {
-	if (!timezone || timezone === "UTC") {
+	if (!timezone || timezone === "UTC" || !formatter) {
 		return cronMatchesUTC(schedule, candidateMs);
 	}
-	const offsetMs = getTimezoneOffsetMs(timezone, candidateMs);
-	return cronMatchesUTC(schedule, candidateMs + offsetMs);
+	const wallMs = candidateMs + offsetMsFromFormatter(formatter, candidateMs);
+	if (!cronMatchesUTC(schedule, wallMs)) return false;
+	// DST fall-back: the ambiguous local hour repeats (e.g. NY 01:00–01:59 occurs
+	// twice on the transition day). Fire only the FIRST instant, matching common
+	// cron implementations — reject a candidate whose wall-clock equals the
+	// wall-clock one hour earlier. That earlier instant already matched and fired,
+	// so counting this one too double-fires the cron on the transition day.
+	const prevMs = candidateMs - CRON_HOUR_MS;
+	const prevWallMs = prevMs + offsetMsFromFormatter(formatter, prevMs);
+	return wallMs !== prevWallMs;
 }
 
 export function computeNextCronRunAtMs(
@@ -188,16 +211,27 @@ export function computeNextCronRunAtMs(
 ): number | null {
 	const schedule = parseCronExpression(expression);
 	if (!schedule) return null;
+	// Bail on a non-representable base: scanning forward from a timestamp at/over
+	// the max Date value would build ~366 days of Invalid Dates before returning
+	// null (a ~26s pathological scan).
+	if (!Number.isFinite(fromMs) || fromMs >= MAX_REPRESENTABLE_MS) return null;
 
 	const start = Math.floor(fromMs / CRON_MINUTE_MS) * CRON_MINUTE_MS;
-	const cutoff = start + CRON_SCAN_WINDOW_MS;
+	// Cap the window at the max representable Date so a base near the ceiling
+	// scans only the representable remainder, not ~527k Invalid-Date candidates.
+	const cutoff = Math.min(start + CRON_SCAN_WINDOW_MS, MAX_REPRESENTABLE_MS);
+	// Hoist ONE formatter for the entire scan. Previously getTimezoneOffsetMs
+	// allocated a fresh Intl.DateTimeFormat per candidate minute — up to ~527k
+	// allocations across the 366-day window.
+	const formatter =
+		timezone && timezone !== "UTC" ? buildTzFormatter(timezone) : null;
 
 	for (
 		let candidate = start + CRON_MINUTE_MS;
 		candidate <= cutoff;
 		candidate += CRON_MINUTE_MS
 	) {
-		if (cronMatches(schedule, candidate, timezone)) {
+		if (cronMatches(schedule, candidate, timezone, formatter)) {
 			return candidate;
 		}
 	}

--- a/plugins/plugin-scheduling/src/scheduled-task/dst-boundaries.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/dst-boundaries.test.ts
@@ -300,13 +300,11 @@ describe("cron with tz across DST transitions", () => {
     );
   });
 
-  it("KNOWN LIMIT (pinned): a cron inside the repeated hour double-fires on fall-back day", async () => {
-    // `computeNextCronRunAtMs` (@elizaos/core) matches wall-clock fields on
-    // both passes through the repeated 01:00-01:59 hour, so "30 1 * * *"
-    // fires at 01:30 EDT AND 01:30 EST on 2026-11-01 — twice on one local
-    // day. Fixing this means deduplicating ambiguous-hour matches in core's
-    // cron scan; out of scope for the scheduling spine (documented residual).
-    // This test pins the current behavior so a core-side fix flips it loudly.
+  it("a cron inside the repeated fall-back hour fires ONCE (first instant), not twice (#11046)", async () => {
+    // `computeNextCronRunAtMs` (@elizaos/core) now dedupes the ambiguous
+    // fall-back hour: "30 1 * * *" fires at 01:30 EDT on 2026-11-01 (the first
+    // pass) but NOT again at 01:30 EST the same day — matching common cron
+    // implementations. Then it resumes firing at 01:30 EST from Nov 2 onward.
     const occurrences = await occurrenceChain(
       "30 1 * * *",
       NY,
@@ -315,10 +313,14 @@ describe("cron with tz across DST transitions", () => {
       3,
     );
     expect(occurrences).toEqual([
-      "2026-11-01T05:30:00.000Z", // 01:30 EDT (first pass)
-      "2026-11-01T06:30:00.000Z", // 01:30 EST (second pass — the double fire)
-      "2026-11-02T06:30:00.000Z",
+      "2026-11-01T05:30:00.000Z", // 01:30 EDT (first pass — the only fall-back-day fire)
+      "2026-11-02T06:30:00.000Z", // 01:30 EST (next day)
+      "2026-11-03T06:30:00.000Z", // 01:30 EST
     ]);
+    // Every fire is a distinct local day (no double-fire on the transition day).
+    expect(new Set(occurrences.map((iso) => localDate(iso, NY))).size).toBe(
+      occurrences.length,
+    );
   });
 
   it("daily 03:00 Berlin lands exactly on the spring-forward transition instant", async () => {


### PR DESCRIPTION
## DST fall-back cron double-fire + pathological scan cost (#11046)

`computeNextCronRunAtMs` (`packages/core/src/services/triggerScheduling.ts`) scanned wall-clock minutes and matched **both** instants of the ambiguous DST fall-back hour.

### Bug 1 — DST fall-back double-fire
America/New_York falls back `2026-11-01 02:00 EDT → 01:00 EST`, so local `01:30` occurs twice (`05:30Z` EDT and `06:30Z` EST). A daily `30 1 * * *` fired **twice** on the transition day.

**Fix:** `cronMatches` now rejects the repeated hour's *second* instant — a candidate whose wall-clock equals the wall-clock one hour earlier (the first instant already matched and fired). Fires the first instant only, matching common cron implementations; resumes normal once-per-day firing (01:30 EST) from the next day.

### Bug 2 — pathological scan cost
`getTimezoneOffsetMs` allocated a fresh `Intl.DateTimeFormat` per candidate minute (up to ~527k across the 366-day window); a base near the max representable Date scanned ~366 days of Invalid Dates (~26s) before returning null.

**Fix:** hoist one formatter across the whole scan; bail immediately on a non-representable base (`>= max Date` / non-finite) and cap the window at the max representable Date.

### Evidence (fail-without-fix)
- Flips the KNOWN-LIMIT pin in `plugins/plugin-scheduling/src/scheduled-task/dst-boundaries.test.ts` from asserting the double-fire to asserting single-fire.
- New core tests `triggerScheduling.test.ts › DST fall-back dedupe (#11046)` (first-instant fires, second-instant skipped, resumes daily) + `non-representable base guard`.
- Reverted the dedupe → `does NOT double-fire` test fails (double-fire returns). Restored → green.
- core `triggerScheduling.test.ts`: **23 passed** · plugin-scheduling `dst-boundaries.test.ts`: **17 passed** · core `tsc --noEmit`: **exit 0**.

Refs #11046 #10721 #10723

🤖 Generated with [Claude Code](https://claude.com/claude-code)
