### PR TITLE
fix(core): dedupe non-hour DST fallback cron repeats

### DIFF
--- a/packages/core/src/services/triggerScheduling.test.ts
+++ b/packages/core/src/services/triggerScheduling.test.ts
@@ -59,23 +59,44 @@ describe("computeNextCronRunAtMs - DST fall-back dedupe (#11046)", () => {
 
 	it("fires the FIRST instant of the repeated hour", () => {
 		// From the prior day's fire, the next run is the EDT (first) pass.
-		expect(computeNextCronRunAtMs("30 1 * * *", at("2026-10-31T05:30:00.000Z"), NY)).toBe(
-			at("2026-11-01T05:30:00.000Z"),
-		);
+		expect(
+			computeNextCronRunAtMs("30 1 * * *", at("2026-10-31T05:30:00.000Z"), NY),
+		).toBe(at("2026-11-01T05:30:00.000Z"));
 	});
 
 	it("does NOT double-fire at the repeated hour's second instant", () => {
 		// Immediately after the EDT fire, the next run skips the EST duplicate
 		// (06:30Z same day) and lands on the next local day (01:30 EST).
-		expect(computeNextCronRunAtMs("30 1 * * *", at("2026-11-01T05:30:00.000Z"), NY)).toBe(
-			at("2026-11-02T06:30:00.000Z"),
-		);
+		expect(
+			computeNextCronRunAtMs("30 1 * * *", at("2026-11-01T05:30:00.000Z"), NY),
+		).toBe(at("2026-11-02T06:30:00.000Z"));
 	});
 
 	it("resumes normal once-per-day firing after the transition", () => {
-		expect(computeNextCronRunAtMs("30 1 * * *", at("2026-11-02T06:30:00.000Z"), NY)).toBe(
-			at("2026-11-03T06:30:00.000Z"),
-		);
+		expect(
+			computeNextCronRunAtMs("30 1 * * *", at("2026-11-02T06:30:00.000Z"), NY),
+		).toBe(at("2026-11-03T06:30:00.000Z"));
+	});
+
+	it("dedupes non-hour fall-back offsets such as Lord Howe's 30-minute transition", () => {
+		const lordHowe = "Australia/Lord_Howe";
+		// Lord Howe falls back by 30 minutes on 2026-04-05: local 01:45 occurs
+		// at 14:45Z (UTC+11) and again at 15:15Z (UTC+10:30). The second instant
+		// must not be treated as a separate cron fire.
+		expect(
+			computeNextCronRunAtMs(
+				"45 1 * * *",
+				at("2026-04-03T14:45:00.000Z"),
+				lordHowe,
+			),
+		).toBe(at("2026-04-04T14:45:00.000Z"));
+		expect(
+			computeNextCronRunAtMs(
+				"45 1 * * *",
+				at("2026-04-04T14:45:00.000Z"),
+				lordHowe,
+			),
+		).toBe(at("2026-04-05T15:15:00.000Z"));
 	});
 });
 

--- a/packages/core/src/services/triggerScheduling.ts
+++ b/packages/core/src/services/triggerScheduling.ts
@@ -8,6 +8,12 @@ const CRON_FIELDS = 5;
 const CRON_SCAN_WINDOW_MS = 366 * 24 * 60 * 60 * 1000;
 const CRON_MINUTE_MS = 60_000;
 const CRON_HOUR_MS = 60 * CRON_MINUTE_MS;
+const CRON_FALLBACK_LOOKBACKS_MS = [
+	30 * CRON_MINUTE_MS,
+	CRON_HOUR_MS,
+	2 * CRON_HOUR_MS,
+	3 * CRON_HOUR_MS,
+] as const;
 /** Max timestamp a JS Date can represent (±8.64e15 ms); beyond this a Date is Invalid. */
 const MAX_REPRESENTABLE_MS = 8_640_000_000_000_000;
 
@@ -174,15 +180,6 @@ function offsetMsFromFormatter(
 	return tzDate - atMs;
 }
 
-function getTimezoneOffsetMs(
-	timezone: string | undefined,
-	atMs: number,
-): number {
-	if (!timezone || timezone === "UTC") return 0;
-	const formatter = buildTzFormatter(timezone);
-	return formatter ? offsetMsFromFormatter(formatter, atMs) : 0;
-}
-
 function cronMatches(
 	schedule: CronSchedule,
 	candidateMs: number,
@@ -194,14 +191,25 @@ function cronMatches(
 	}
 	const wallMs = candidateMs + offsetMsFromFormatter(formatter, candidateMs);
 	if (!cronMatchesUTC(schedule, wallMs)) return false;
-	// DST fall-back: the ambiguous local hour repeats (e.g. NY 01:00–01:59 occurs
-	// twice on the transition day). Fire only the FIRST instant, matching common
-	// cron implementations — reject a candidate whose wall-clock equals the
-	// wall-clock one hour earlier. That earlier instant already matched and fired,
-	// so counting this one too double-fires the cron on the transition day.
-	const prevMs = candidateMs - CRON_HOUR_MS;
-	const prevWallMs = prevMs + offsetMsFromFormatter(formatter, prevMs);
-	return wallMs !== prevWallMs;
+	// DST fall-back: an ambiguous local time repeats. Fire only the FIRST
+	// instant, matching common cron implementations. The repeated span is not
+	// always one hour (Australia/Lord_Howe falls back by 30 minutes), so derive
+	// the actual offset delta and reject candidates whose wall-clock already
+	// existed at candidate-delta.
+	const candidateOffset = offsetMsFromFormatter(formatter, candidateMs);
+	for (const lookbackMs of CRON_FALLBACK_LOOKBACKS_MS) {
+		const priorOffset = offsetMsFromFormatter(
+			formatter,
+			candidateMs - lookbackMs,
+		);
+		if (priorOffset <= candidateOffset) continue;
+		const offsetDelta = priorOffset - candidateOffset;
+		const priorSameWallMs = candidateMs - offsetDelta;
+		const priorWallMs =
+			priorSameWallMs + offsetMsFromFormatter(formatter, priorSameWallMs);
+		if (wallMs === priorWallMs) return false;
+	}
+	return true;
 }
 
 export function computeNextCronRunAtMs(

--- a/plugins/plugin-scheduling/src/scheduled-task/dst-boundaries.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/dst-boundaries.test.ts
@@ -8,6 +8,8 @@
  *    (06:00:00Z). The local hour 01:00-01:59 happens twice.
  *  - Europe/Berlin spring-forward: 2026-03-29 02:00 CET -> 03:00 CEST
  *    (01:00:00Z). Fall-back: 2026-10-25 03:00 CEST -> 02:00 CET (01:00:00Z).
+ *  - Australia/Lord_Howe fall-back: 2026-04-05 02:00 LHDT -> 01:30 LHST
+ *    (15:00:00Z Apr 4). The repeated local span is 30 minutes, not an hour.
  *
  * Where behavior at a nonexistent/ambiguous local time is a judgment call the
  * tests PIN the current behavior with an explicit comment instead of
@@ -28,6 +30,7 @@ import type {
 const MINUTE_MS = 60_000;
 const NY = "America/New_York";
 const BERLIN = "Europe/Berlin";
+const LORD_HOWE = "Australia/Lord_Howe";
 
 function makeTask(args: {
   trigger: ScheduledTaskTrigger;
@@ -321,6 +324,24 @@ describe("cron with tz across DST transitions", () => {
     expect(new Set(occurrences.map((iso) => localDate(iso, NY))).size).toBe(
       occurrences.length,
     );
+  });
+
+  it("a cron inside Lord Howe's 30-minute repeated fall-back span also fires once", async () => {
+    const occurrences = await occurrenceChain(
+      "45 1 * * *",
+      LORD_HOWE,
+      "2026-04-03T14:45:00.000Z", // Apr 4 01:45 LHDT
+      "2026-04-08T00:00:00.000Z",
+      3,
+    );
+    expect(occurrences).toEqual([
+      "2026-04-04T14:45:00.000Z", // Apr 5 01:45 LHDT (first pass)
+      "2026-04-05T15:15:00.000Z", // Apr 6 01:45 LHST
+      "2026-04-06T15:15:00.000Z", // Apr 7 01:45 LHST
+    ]);
+    expect(
+      new Set(occurrences.map((iso) => localDate(iso, LORD_HOWE))).size,
+    ).toBe(occurrences.length);
   });
 
   it("daily 03:00 Berlin lands exactly on the spring-forward transition instant", async () => {


### PR DESCRIPTION
## Summary
- Fix the DST fall-back cron dedupe added in #11099 so it uses the actual timezone offset delta instead of assuming every repeated wall-clock span is exactly one hour
- Cover Australia/Lord_Howe, whose DST fall-back repeats only a 30-minute local span
- Preserve the existing “first ambiguous instant only” cron behavior from #11099

## Review notes
- Cronie/Red Hat documents avoiding duplicate cron runs when the clock moves backward.
- Lord Howe Island uses a 30-minute DST adjustment, so a hard-coded one-hour duplicate check still double-fired local times like `01:45`.

## Evidence
- `bun test packages/core/src/services/triggerScheduling.test.ts plugins/plugin-scheduling/src/scheduled-task/dst-boundaries.test.ts` — 29 passed
- `bunx biome check packages/core/src/services/triggerScheduling.ts packages/core/src/services/triggerScheduling.test.ts plugins/plugin-scheduling/src/scheduled-task/dst-boundaries.test.ts`
- `bun run --cwd packages/core typecheck`
- `bun run --cwd plugins/plugin-scheduling typecheck`
- `bun run --cwd packages/core build`

Follow-up from review of #11099.