### PR TITLE
hardening(ui): drop unbounded GLSL sink + stop WebGL-context rebuild on uniform tweaks (#11088)

### DIFF
--- a/packages/ui/src/backgrounds/ProgrammableShaderBackground.rebuild.test.tsx
+++ b/packages/ui/src/backgrounds/ProgrammableShaderBackground.rebuild.test.tsx
@@ -1,0 +1,193 @@
+// @vitest-environment jsdom
+/**
+ * Effect-splitting contract (#11088): a uniform/color-only prop change must
+ * MUTATE the live uniforms in place — never tear down + rebuild the
+ * THREE.WebGLRenderer (browsers cap ~16 live WebGL contexts, and a rebuild
+ * recompiles the shader). Only a `source` change may rebuild. THREE is mocked
+ * so renderer construction is observable in jsdom.
+ */
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ProgrammableShaderBackground } from "./ProgrammableShaderBackground";
+import { DEFAULT_SHADER_UNIFORMS } from "./shader-schema";
+
+const state = vi.hoisted(() => ({
+  rendererCount: 0,
+  renderCalls: 0,
+  uniformSets: [] as Array<Record<string, { value: unknown }>>,
+}));
+
+vi.mock("three", () => {
+  const compilingGl = {
+    FRAGMENT_SHADER: 0x8b30,
+    COMPILE_STATUS: 0x8b81,
+    createShader: () => ({}),
+    shaderSource: () => {},
+    compileShader: () => {},
+    getShaderParameter: () => true,
+    getShaderInfoLog: () => "",
+    deleteShader: () => {},
+  };
+  class WebGLRenderer {
+    domElement = document.createElement("canvas");
+    constructor() {
+      state.rendererCount += 1;
+    }
+    getContext() {
+      return compilingGl;
+    }
+    setPixelRatio() {}
+    setSize() {}
+    render() {
+      state.renderCalls += 1;
+    }
+    dispose() {}
+  }
+  class Vector2 {
+    set() {}
+  }
+  class Vector3 {
+    constructor(
+      public x = 0,
+      public y = 0,
+      public z = 0,
+    ) {}
+    set(x: number, y: number, z: number) {
+      this.x = x;
+      this.y = y;
+      this.z = z;
+      return this;
+    }
+  }
+  class Scene {
+    add() {}
+  }
+  class Camera {}
+  class BufferGeometry {
+    setAttribute() {}
+    dispose() {}
+  }
+  class BufferAttribute {}
+  class RawShaderMaterial {
+    uniforms: Record<string, { value: unknown }>;
+    constructor(params: { uniforms: Record<string, { value: unknown }> }) {
+      this.uniforms = params.uniforms;
+      state.uniformSets.push(params.uniforms);
+    }
+    dispose() {}
+  }
+  class Mesh {}
+  return {
+    WebGLRenderer,
+    Vector2,
+    Vector3,
+    Scene,
+    Camera,
+    BufferGeometry,
+    BufferAttribute,
+    RawShaderMaterial,
+    Mesh,
+  };
+});
+
+const SOURCE_A =
+  "precision highp float; void main(){ gl_FragColor = vec4(1.0); }";
+const SOURCE_B =
+  "precision highp float; void main(){ gl_FragColor = vec4(0.5); }";
+
+beforeEach(() => {
+  state.rendererCount = 0;
+  state.renderCalls = 0;
+  state.uniformSets.length = 0;
+  // Freeze the animation loop so frame counts are deterministic.
+  vi.stubGlobal("requestAnimationFrame", () => 1);
+  vi.stubGlobal("cancelAnimationFrame", () => {});
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("ProgrammableShaderBackground — uniform tweaks must not rebuild the GL context (#11088)", () => {
+  it("mutates live uniforms in place on a uniform/color-only change (no renderer rebuild)", () => {
+    const { rerender } = render(
+      <ProgrammableShaderBackground
+        source={SOURCE_A}
+        uniforms={DEFAULT_SHADER_UNIFORMS}
+        color="#ffffff"
+      />,
+    );
+    expect(state.rendererCount).toBe(1);
+    expect(state.uniformSets).toHaveLength(1);
+    const live = state.uniformSets[0];
+    expect(live.u_speed.value).toBe(DEFAULT_SHADER_UNIFORMS.u_speed);
+
+    rerender(
+      <ProgrammableShaderBackground
+        source={SOURCE_A}
+        uniforms={{ ...DEFAULT_SHADER_UNIFORMS, u_speed: 2.5 }}
+        color="#000000"
+      />,
+    );
+    // The heavy build path was NOT re-entered…
+    expect(state.rendererCount).toBe(1);
+    expect(state.uniformSets).toHaveLength(1);
+    // …and the SAME live uniform objects were mutated in place.
+    expect(live.u_speed.value).toBe(2.5);
+    const colorVec = live.u_color.value as { x: number; y: number; z: number };
+    expect(colorVec.x).toBe(0);
+    expect(colorVec.y).toBe(0);
+    expect(colorVec.z).toBe(0);
+  });
+
+  it("rebuilds (recompiles) only when the shader source changes", () => {
+    const { rerender } = render(
+      <ProgrammableShaderBackground
+        source={SOURCE_A}
+        uniforms={DEFAULT_SHADER_UNIFORMS}
+        color="#ffffff"
+      />,
+    );
+    expect(state.rendererCount).toBe(1);
+    rerender(
+      <ProgrammableShaderBackground
+        source={SOURCE_B}
+        uniforms={DEFAULT_SHADER_UNIFORMS}
+        color="#ffffff"
+      />,
+    );
+    expect(state.rendererCount).toBe(2);
+    expect(state.uniformSets).toHaveLength(2);
+  });
+
+  it("repaints the single static frame after a tweak under reduced motion", () => {
+    vi.stubGlobal(
+      "matchMedia",
+      () => ({ matches: true }) as unknown as MediaQueryList,
+    );
+
+    const { rerender } = render(
+      <ProgrammableShaderBackground
+        source={SOURCE_A}
+        uniforms={DEFAULT_SHADER_UNIFORMS}
+        color="#ffffff"
+      />,
+    );
+    // Reduced motion renders exactly one static frame on mount.
+    expect(state.renderCalls).toBe(1);
+    rerender(
+      <ProgrammableShaderBackground
+        source={SOURCE_A}
+        uniforms={{ ...DEFAULT_SHADER_UNIFORMS, u_seed: 42 }}
+        color="#ffffff"
+      />,
+    );
+    // No rebuild — one extra repaint at the new frozen seed phase.
+    expect(state.rendererCount).toBe(1);
+    expect(state.renderCalls).toBe(2);
+    expect(state.uniformSets[0].u_seed.value).toBe(42);
+    expect(state.uniformSets[0].u_time.value).toBe(42);
+  });
+});

--- a/packages/ui/src/backgrounds/ProgrammableShaderBackground.tsx
+++ b/packages/ui/src/backgrounds/ProgrammableShaderBackground.tsx
@@ -22,6 +22,7 @@ import {
   hexToRgb,
   normalizeUniforms,
   type ShaderUniformValues,
+  uniformsEqual,
 } from "./shader-schema";
 
 /** RawShaderMaterial gets no three.js injection, so the vertex stage is explicit.
@@ -39,6 +40,16 @@ export interface ProgrammableShaderBackgroundProps {
   /** Called when the shader can't run (no WebGL, compile error, GPU stall,
    * context loss). The parent swaps in the color-field fallback. */
   onFallback?: (reason: string) => void;
+}
+
+/** Live handles the lightweight uniform-tweak effect mutates in place, so a
+ * uniform/color change never tears down the WebGL context (#11088). */
+interface LiveShaderHandle {
+  uniformDefs: Record<string, THREE.IUniform>;
+  renderFrame: (timeSec: number) => void;
+  reduceMotion: boolean;
+  appliedUniforms: ShaderUniformValues;
+  appliedColor: string;
 }
 
 /** Compile-validate a fragment shader in the live GL context. Returns the
@@ -68,7 +79,17 @@ export function ProgrammableShaderBackground({
   const hostRef = useRef<HTMLDivElement>(null);
   const fallbackRef = useRef(onFallback);
   fallbackRef.current = onFallback;
+  // Latest uniform/color props for the (source-keyed) build effect, so a
+  // rebuild always compiles against the current values without depending on
+  // them (a dependency would rebuild the whole GL context per tweak).
+  const uniformsRef = useRef(uniforms);
+  uniformsRef.current = uniforms;
+  const colorRef = useRef(color);
+  colorRef.current = color;
+  const liveRef = useRef<LiveShaderHandle | null>(null);
 
+  // Heavy path — renderer + context + compile. Keyed on `source` ONLY: a new
+  // shader genuinely needs a recompile; anything else is a uniform mutation.
   useEffect(() => {
     const host = hostRef.current;
     if (!host) return;
@@ -100,7 +121,7 @@ export function ProgrammableShaderBackground({
       return;
     }
 
-    const clamped = normalizeUniforms(uniforms);
+    const clamped = normalizeUniforms(uniformsRef.current);
     const dpr = Math.min(
       typeof window !== "undefined" ? window.devicePixelRatio || 1 : 1,
       2,
@@ -127,7 +148,7 @@ export function ProgrammableShaderBackground({
         3,
       ),
     );
-    const [r, g, b] = hexToRgb(color);
+    const [r, g, b] = hexToRgb(colorRef.current);
     const uniformDefs: Record<string, THREE.IUniform> = {
       u_time: { value: 0 },
       u_resolution: { value: new THREE.Vector2(width * dpr, height * dpr) },
@@ -153,6 +174,7 @@ export function ProgrammableShaderBackground({
 
     const cleanup = () => {
       disposed = true;
+      liveRef.current = null;
       if (raf) cancelAnimationFrame(raf);
       resizeObserver?.disconnect();
       canvas.removeEventListener("webglcontextlost", onContextLost);
@@ -196,6 +218,14 @@ export function ProgrammableShaderBackground({
       renderer?.render(scene, camera);
     };
 
+    liveRef.current = {
+      uniformDefs,
+      renderFrame: renderAt,
+      reduceMotion,
+      appliedUniforms: clamped,
+      appliedColor: colorRef.current,
+    };
+
     if (reduceMotion) {
       // (5) reduced-motion: one static frame at the seed phase, no animation.
       renderAt(clamped.u_seed);
@@ -224,7 +254,36 @@ export function ProgrammableShaderBackground({
     };
     raf = requestAnimationFrame(loop);
     return cleanup;
-  }, [source, uniforms, color]);
+  }, [source]);
+
+  // Light path — uniform/color tweaks mutate the live uniforms in place.
+  // Rebuilding the renderer for a value change would churn the browser's
+  // ~16-live-WebGL-context budget and recompile the shader for nothing
+  // (#11088); the running rAF loop picks the new values up on the next frame.
+  useEffect(() => {
+    const live = liveRef.current;
+    if (!live) return;
+    const clamped = normalizeUniforms(uniforms);
+    if (
+      uniformsEqual(clamped, live.appliedUniforms) &&
+      color === live.appliedColor
+    ) {
+      return;
+    }
+    live.uniformDefs.u_speed.value = clamped.u_speed;
+    live.uniformDefs.u_scale.value = clamped.u_scale;
+    live.uniformDefs.u_intensity.value = clamped.u_intensity;
+    live.uniformDefs.u_seed.value = clamped.u_seed;
+    const [r, g, b] = hexToRgb(color);
+    (live.uniformDefs.u_color.value as THREE.Vector3).set(r, g, b);
+    live.appliedUniforms = clamped;
+    live.appliedColor = color;
+    if (live.reduceMotion) {
+      // No rAF loop under reduced motion — repaint the single static frame at
+      // the (possibly new) frozen seed phase.
+      live.renderFrame(clamped.u_seed);
+    }
+  }, [uniforms, color]);
 
   return (
     <div

--- a/packages/ui/src/backgrounds/useBackgroundApplyChannel.test.tsx
+++ b/packages/ui/src/backgrounds/useBackgroundApplyChannel.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { __setAppValueForTests } from "../state/app-store";
+import type { BackgroundConfig } from "../state/ui-preferences";
+import { emitViewEvent } from "../views/view-event-bus";
+import { getShaderPreset } from "./shader-presets";
+import { isPlausibleFragmentSource } from "./shader-schema";
+import {
+  BACKGROUND_APPLY_EVENT,
+  useBackgroundApplyChannel,
+} from "./useBackgroundApplyChannel";
+
+function Channel(): null {
+  useBackgroundApplyChannel();
+  return null;
+}
+
+function mountChannel(backgroundConfig: BackgroundConfig) {
+  const setBackgroundConfig = vi.fn();
+  __setAppValueForTests({
+    backgroundConfig,
+    setBackgroundConfig,
+    undoBackgroundConfig: () => {},
+    redoBackgroundConfig: () => {},
+    canUndoBackground: false,
+    canRedoBackground: false,
+  } as never);
+  render(<Channel />);
+  return setBackgroundConfig;
+}
+
+function apply(payload: Record<string, unknown>): void {
+  act(() => {
+    emitViewEvent(BACKGROUND_APPLY_EVENT, payload, "agent");
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  __setAppValueForTests(null);
+});
+
+/** A GPU bomb: a bounded `for` loop with a pathological literal bound. It
+ * passes the static gate (writes gl_FragColor, no while/do, < 16KB) AND the
+ * GL compile — one frame of it can stall the GPU long before the frame-time
+ * watchdog's 5-slow-frame threshold. The channel must refuse raw GLSL text
+ * outright; presets are the only source of shader code (#11088). */
+const FOR_BOMB = `precision highp float;
+void main(){
+  float acc = 0.0;
+  for (int i = 0; i < 200000; i++) { acc += sin(float(i) * 0.001); }
+  gl_FragColor = vec4(acc, acc, acc, 1.0);
+}`;
+
+describe("useBackgroundApplyChannel — raw GLSL source is not a sink (#11088)", () => {
+  it("sanity: the for-bomb slips past the static gate (why the channel must drop it)", () => {
+    expect(isPlausibleFragmentSource(FOR_BOMB)).toBe(true);
+  });
+
+  it("ignores a payload carrying raw GLSL `source` text (glsl mode)", () => {
+    const setBackgroundConfig = mountChannel({
+      mode: "shader",
+      color: "#101010",
+    });
+    apply({ op: "set", mode: "glsl", source: FOR_BOMB });
+    expect(setBackgroundConfig).not.toHaveBeenCalled();
+  });
+
+  it("ignores a payload carrying only raw `source` (no mode/preset)", () => {
+    const setBackgroundConfig = mountChannel({
+      mode: "shader",
+      color: "#101010",
+    });
+    apply({ op: "set", source: FOR_BOMB });
+    expect(setBackgroundConfig).not.toHaveBeenCalled();
+  });
+
+  it("applies the PRESET source when a payload names a preset alongside raw text", () => {
+    const setBackgroundConfig = mountChannel({
+      mode: "shader",
+      color: "#101010",
+    });
+    apply({ op: "set", mode: "glsl", presetId: "aurora", source: FOR_BOMB });
+    expect(setBackgroundConfig).toHaveBeenCalledTimes(1);
+    const config = setBackgroundConfig.mock.calls[0][0] as BackgroundConfig;
+    expect(config.mode).toBe("glsl");
+    expect(config.shader?.source).toBe(getShaderPreset("aurora")?.source);
+    expect(config.shader?.source).not.toContain("200000");
+  });
+
+  it("still applies plain preset payloads (the intended path)", () => {
+    const setBackgroundConfig = mountChannel({
+      mode: "shader",
+      color: "#101010",
+    });
+    apply({ op: "set", mode: "glsl", presetId: "aurora" });
+    expect(setBackgroundConfig).toHaveBeenCalledTimes(1);
+    const config = setBackgroundConfig.mock.calls[0][0] as BackgroundConfig;
+    expect(config.mode).toBe("glsl");
+    expect(config.shader?.presetId).toBe("aurora");
+    expect(config.shader?.source).toBe(getShaderPreset("aurora")?.source);
+  });
+
+  it("still applies a uniform-only tweak to a live glsl background", () => {
+    const auroraSource = getShaderPreset("aurora")?.source ?? "";
+    const setBackgroundConfig = mountChannel({
+      mode: "glsl",
+      color: "#101010",
+      shader: {
+        presetId: "aurora",
+        source: auroraSource,
+        uniforms: { u_speed: 1, u_scale: 1, u_intensity: 1, u_seed: 0 },
+      },
+    });
+    apply({ op: "set", mode: "glsl", uniforms: { u_speed: 0.25 } });
+    expect(setBackgroundConfig).toHaveBeenCalledTimes(1);
+    const config = setBackgroundConfig.mock.calls[0][0] as BackgroundConfig;
+    expect(config.shader?.source).toBe(auroraSource);
+    expect(config.shader?.uniforms.u_speed).toBe(0.25);
+  });
+});

--- a/packages/ui/src/backgrounds/useBackgroundApplyChannel.ts
+++ b/packages/ui/src/backgrounds/useBackgroundApplyChannel.ts
@@ -85,10 +85,11 @@ export function useBackgroundApplyChannel(): void {
     const uniformPatch = readUniformPatch(payload.uniforms);
     const presetId =
       typeof payload.presetId === "string" ? payload.presetId : undefined;
-    const explicitSource =
-      typeof payload.source === "string" ? payload.source : undefined;
-    const wantsGlsl =
-      payload.mode === "glsl" || Boolean(presetId) || Boolean(explicitSource);
+    // Raw GLSL text in the payload is deliberately NOT accepted (#11088):
+    // presets are the only source of shader code, so a crafted `source` field
+    // (e.g. a bounded-for GPU bomb that would slip past the static gate) has
+    // no path to the compiler. Payloads may only name a preset id.
+    const wantsGlsl = payload.mode === "glsl" || Boolean(presetId);
 
     // ── Programmable GLSL shader (#10694) ────────────────────────────────
     if (wantsGlsl) {
@@ -96,7 +97,6 @@ export function useBackgroundApplyChannel(): void {
       // keep the same source, merge the patch.
       const current = backgroundConfig;
       if (
-        !explicitSource &&
         !presetId &&
         uniformPatch &&
         current.mode === "glsl" &&
@@ -114,7 +114,7 @@ export function useBackgroundApplyChannel(): void {
       }
 
       const preset = presetId ? getShaderPreset(presetId) : undefined;
-      const source = explicitSource ?? preset?.source;
+      const source = preset?.source;
       if (source && isPlausibleFragmentSource(source)) {
         setBackgroundConfig(
           makeGlslConfig({


### PR DESCRIPTION
## GLSL background hardening (#11088, follow-up to #11083)

Two latent hardening fixes from the post-merge review of the programmable shader background. No rendered-output change → **visual audit N/A** (Fix 1 removes an unreachable path; Fix 2 renders byte-identically, just without a context teardown).

### Fix 1 — drop the unbounded raw-GLSL sink (defense-in-depth)
`useBackgroundApplyChannel` accepted a raw `source` field from any `background:apply` broadcaster (`explicitSource`). The static gate bans `while`/`do` and caps size but does **not** bound `for`-loop counts, so a crafted `for(int i=0;i<200000;i++)` slips past the gate + GL compile and stalls the GPU for one pathological frame (the frame-time watchdog needs 5 consecutive slow frames — the first freezes first).

**Fix:** drop the `explicitSource` branch entirely — presets are the only source of shader code, so raw text has no path to the compiler. Confirmed no shipped caller broadcasts a raw `source` field (grep). This is the cleaner root fix (remove the surface) vs. a for-loop heuristic.

### Fix 2 — stop rebuilding the WebGL context on uniform-only tweaks (perf)
The single build effect was keyed `[source, uniforms, color]`, so a uniform-only tweak tore down + rebuilt the `THREE.WebGLRenderer` + WebGL context and recompiled the shader (browsers cap ~16 live contexts → churn + GC pressure).

**Fix:** split into a heavy build/compile effect keyed on `source` only (compiling against `uniformsRef`/`colorRef` current values) + a lightweight effect keyed on `[uniforms, color]` that mutates `uniformDefs.u_*.value` in place (with a `uniformsEqual` short-circuit and a reduced-motion static repaint). The running rAF loop picks up the new values next frame.

### Evidence (fail-without-fix)
- `ProgrammableShaderBackground.rebuild.test.tsx` (THREE mocked; counts renderer constructions): a uniform/color-only change keeps `rendererCount === 1` and mutates the live uniform in place; a source change rebuilds. Reverting the dep-split → 2 tests fail (`rendererCount` climbs on tweak). Independently re-verified.
- `useBackgroundApplyChannel.test.tsx`: the raw-`source` path is no longer accepted.
- **9 tests pass**; `uniformsEqual` export + `u_color` `Vector3` type verified.

Refs #11088 #11083 #10694

🤖 Generated with [Claude Code](https://claude.com/claude-code)
