### PR TITLE
fix(ui/chat): no-lost-message on new-chat, full-gesture diagonal swipe, app-build phrasing, home-screen runner repair

### DIFF
--- a/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
@@ -197,6 +197,20 @@ async function swipeLeft(locator) {
   await locator.page().mouse.move(endX, y, { steps: 8 });
   await locator.page().mouse.up();
 }
+// Mirror of swipeLeft for the mouse drag-paging regression section (the
+// real-touch conversion dropped this helper but kept its call site — the
+// nested-pager mouse arbitration asserts genuinely need MOUSE input).
+async function swipeRight(locator) {
+  const box = await locator.boundingBox();
+  if (!box) throw new Error("missing swipe target bounds");
+  const y = box.y + box.height * 0.45;
+  const startX = box.x + box.width * 0.22;
+  const endX = box.x + box.width * 0.78;
+  await locator.page().mouse.move(startX, y);
+  await locator.page().mouse.down();
+  await locator.page().mouse.move(endX, y, { steps: 8 });
+  await locator.page().mouse.up();
+}
 // Horizontal touch-swipes across an element, driven through Chromium's real
 // touch input path. These keep the mobile pagers honest — the inner launcher
 // pager AND the outer home↔launcher rail: hit-testing, touch-action, implicit

--- a/packages/ui/src/components/shell/use-pull-gesture.test.ts
+++ b/packages/ui/src/components/shell/use-pull-gesture.test.ts
@@ -427,4 +427,71 @@ describe("usePullGesture rAF coalescing (#9141)", () => {
     b.onPointerUp(pointer(100, 180, 1));
     expect(onPullUp).toHaveBeenCalledTimes(1);
   });
+
+  it("commits a FULL constant-slope diagonal swipe (65px across, 75px down) — #10715", () => {
+    // The issue closure's exact exemplar: a deliberate diagonal whose vertical
+    // drift EXCEEDS its horizontal travel (65x across, 75y down; slope ~49°
+    // from horizontal). Every point of a constant-slope drag has ax/ay ≈ 0.87,
+    // so the old strict `ax > ay` mid-gesture commit locked axis "y" at 8px of
+    // travel and the widened release-time cone was never consulted. The
+    // widened commit (ax ≥ 0.8·ay when the binding can swipe) must land this
+    // as a horizontal swipe end to end.
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((cb: FrameRequestCallback) => {
+        cb(0);
+        return 1;
+      }),
+    );
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+
+    const onSwipeLeft = vi.fn();
+    const onPullUp = vi.fn();
+    const onPullDown = vi.fn();
+    const { result } = renderHook(() =>
+      usePullGesture({ onSwipeLeft, onPullUp, onPullDown }),
+    );
+    const b = result.current;
+
+    // Finger moves LEFT (x decreasing) and DOWN (y increasing) on a straight
+    // line from (300, 300) to (235, 375) in 10 constant-slope steps.
+    b.onPointerDown(pointer(300, 300));
+    for (let step = 1; step <= 10; step++) {
+      b.onPointerMove(pointer(300 - step * 6.5, 300 + step * 7.5));
+    }
+    b.onPointerUp(pointer(235, 375));
+
+    expect(onSwipeLeft).toHaveBeenCalledTimes(1);
+    expect(onPullUp).not.toHaveBeenCalled();
+    expect(onPullDown).not.toHaveBeenCalled();
+  });
+
+  it("still commits a steep drag (vertical well past the cone) as a vertical pull", () => {
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((cb: FrameRequestCallback) => {
+        cb(0);
+        return 1;
+      }),
+    );
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+
+    const onSwipeLeft = vi.fn();
+    const onPullUp = vi.fn();
+    const { result } = renderHook(() =>
+      usePullGesture({ onSwipeLeft, onPullUp }),
+    );
+    const b = result.current;
+
+    // ~63° from horizontal (ax/ay = 0.5, well under the 0.8 cone): a scroll-ish
+    // upward drag must stay a vertical pull even on a swipe-capable binding.
+    b.onPointerDown(pointer(300, 300));
+    for (let step = 1; step <= 10; step++) {
+      b.onPointerMove(pointer(300 - step * 4, 300 - step * 8));
+    }
+    b.onPointerUp(pointer(260, 220));
+
+    expect(onPullUp).toHaveBeenCalledTimes(1);
+    expect(onSwipeLeft).not.toHaveBeenCalled();
+  });
 });

--- a/packages/ui/src/components/shell/use-pull-gesture.ts
+++ b/packages/ui/src/components/shell/use-pull-gesture.ts
@@ -253,7 +253,15 @@ export function usePullGesture(
         const ax = Math.abs(dx);
         const ay = Math.abs(dy);
         if (Math.max(ax, ay) >= AXIS_COMMIT_SLOP) {
-          axis.current = ax > ay ? "x" : "y";
+          // Same widened cone as resolveSwipe (#10715): when this binding can
+          // swipe, a deliberate diagonal (horizontal ≥ 0.8× vertical) commits
+          // the X axis. A strict ax > ay here re-narrowed the cone to 45° at
+          // the FIRST 8px of travel, so the exact diagonals the release-time
+          // dominance check was widened for never reached it.
+          const horizontalWins = hasSwipe
+            ? ax >= ay * HORIZONTAL_DOMINANCE_RATIO
+            : ax > ay;
+          axis.current = horizontalWins ? "x" : "y";
           // Take over the pointer now that intent is clear (deferred-capture path).
           if (hasSwipe && !hasVerticalPull) {
             try {
@@ -334,7 +342,9 @@ export function usePullGesture(
       // resolves from release deltas alone.
       const releaseAxis =
         committedAxis ??
-        (hasSwipe && movedX >= AXIS_COMMIT_SLOP && movedX > movedY
+        (hasSwipe &&
+        movedX >= AXIS_COMMIT_SLOP &&
+        movedX >= movedY * HORIZONTAL_DOMINANCE_RATIO
           ? "x"
           : null);
       if (releaseAxis === "x") {
@@ -412,7 +422,10 @@ export function usePullGesture(
         const deltaUp = s.y - l.y; // up positive
         const deltaLeft = s.x - l.x; // left positive
         const movedX = Math.abs(deltaLeft);
-        if (movedX >= AXIS_COMMIT_SLOP && movedX > Math.abs(deltaUp)) {
+        if (
+          movedX >= AXIS_COMMIT_SLOP &&
+          movedX >= Math.abs(deltaUp) * HORIZONTAL_DOMINANCE_RATIO
+        ) {
           const elapsed = Math.max(1, l.t - s.t);
           const swipe = resolveSwipe(
             deltaLeft,

--- a/packages/ui/src/state/useChatCallbacks.ts
+++ b/packages/ui/src/state/useChatCallbacks.ts
@@ -864,8 +864,15 @@ export function useChatCallbacks(deps: UseChatCallbacksDeps) {
         !hasUserMessage &&
         previousMessages.length <= 1;
 
-      send.interruptActiveChatPipeline();
+      // Interrupt FIRST (it restores any undelivered queued sends to the
+      // composer), then wipe the draft for the new chat — and re-apply the
+      // restore after the wipe so the user's queued words survive new-chat
+      // (#10700 "no message is lost").
+      const restoredQueuedText = send.interruptActiveChatPipeline();
       resetConversationDraftState();
+      if (restoredQueuedText) {
+        setChatInput(restoredQueuedText);
+      }
       // Snapshot the navigation epoch AFTER the draft reset — `resetConversationDraftState`
       // itself bumps this epoch, so capturing it before (the old order) made the
       // navigated-away guard below fire on EVERY call, silently abandoning the

--- a/packages/ui/src/state/useChatLifecycle.ts
+++ b/packages/ui/src/state/useChatLifecycle.ts
@@ -154,7 +154,7 @@ export interface UseChatLifecycleDeps {
   requestGreetingWhenRunning: (convId: string | null) => Promise<void>;
 
   // Reset conversation state
-  interruptActiveChatPipeline: () => void;
+  interruptActiveChatPipeline: () => string;
   resetConversationDraftState: () => void;
   setActiveConversationId: (v: string | null) => void;
   setConversationMessages: (

--- a/packages/ui/src/state/useChatSend.send-voice-newchat.race.test.tsx
+++ b/packages/ui/src/state/useChatSend.send-voice-newchat.race.test.tsx
@@ -334,6 +334,70 @@ describe("#10700 shell send() → new-chat routing race", () => {
       "conv-A",
     );
   });
+
+  it("restores a queued-undelivered send to the composer when new-chat interrupts (no lost message)", async () => {
+    // The REAL new-chat path (handleNewConversation) calls
+    // interruptActiveChatPipeline() BEFORE switching conversations, which
+    // drains the send queue. A turn enqueued behind an in-flight one (the
+    // composer explicitly offers "send another") was resolved WITHOUT
+    // delivery: composer already cleared at enqueue, optimistic bubble only
+    // painted at drain → the words vanished with no trace. The interrupt must
+    // restore the undelivered text to the composer (and return it, so the
+    // new-chat draft wipe can re-apply it).
+    const h = makeHarness({
+      activeConversationId: "conv-A",
+      conversations: [conversation("conv-A", "room-A")],
+    });
+    const { result } = renderHook(() => useChatSend(h.deps));
+    const send = result.current.sendChatText as unknown as Send;
+
+    const p1 = send("hold", { conversationId: "conv-A" });
+    await settle();
+    // Queued BEHIND the in-flight turn — never drained before the interrupt.
+    const p2 = send("my queued words", { conversationId: "conv-A" });
+    await settle();
+
+    let restored = "";
+    await act(async () => {
+      restored = result.current.interruptActiveChatPipeline();
+    });
+    // The mock stream only settles via resolveInFlight — the abort does not
+    // reject it. Release it so p1 can settle; p2 settled at interrupt time.
+    await act(async () => {
+      h.resolveInFlight();
+    });
+    await act(async () => {
+      await Promise.allSettled([p1, p2]);
+    });
+
+    // Not delivered anywhere…
+    expect(
+      h.streamCalls.find((c) => c.text === "my queued words"),
+    ).toBeUndefined();
+    // …but restored to the composer, returned to the caller, and announced.
+    expect(restored).toBe("my queued words");
+    expect(h.deps.setChatInput).toHaveBeenCalledWith("my queued words");
+    expect(h.deps.setActionNotice).toHaveBeenCalledWith(
+      expect.stringContaining("restored"),
+      "info",
+      expect.any(Number),
+    );
+  });
+
+  it("interrupt with an empty queue restores nothing", async () => {
+    const h = makeHarness({
+      activeConversationId: "conv-A",
+      conversations: [conversation("conv-A", "room-A")],
+    });
+    const { result } = renderHook(() => useChatSend(h.deps));
+
+    let restored = "not-empty";
+    await act(async () => {
+      restored = result.current.interruptActiveChatPipeline();
+    });
+    expect(restored).toBe("");
+    expect(h.deps.setChatInput).not.toHaveBeenCalled();
+  });
 });
 
 // ── Seeded fuzz: random interleavings of send-text / send-voice / new-chat ─────

--- a/packages/ui/src/state/useChatSend.ts
+++ b/packages/ui/src/state/useChatSend.ts
@@ -497,12 +497,33 @@ export function useChatSend(deps: UseChatSendDeps) {
     };
   }, []);
 
-  const resolveQueuedChatSends = useCallback(() => {
+  const resolveQueuedChatSends = useCallback((): string => {
     const queued = chatSendQueueRef.current.splice(0);
+    if (queued.length === 0) return "";
     for (const turn of queued) {
       turn.resolve();
     }
-  }, []);
+    // These turns were accepted ("send another" while a reply streamed), the
+    // composer was cleared at enqueue, and their optimistic bubble only paints
+    // at drain — so an interrupt here (new chat / conversation switch) would
+    // otherwise vanish the user's words with no trace (#10700's "no message is
+    // lost" guarantee). Mirror the cold-open create-failure path: restore the
+    // text to the composer and say why. Returned so a caller that wipes the
+    // draft AFTER interrupting (new chat) can re-apply the restore.
+    const restored = queued
+      .map((turn) => turn.rawInput.trim())
+      .filter((text) => text.length > 0)
+      .join("\n");
+    if (restored) {
+      setChatInput(restored);
+      setActionNotice(
+        "Your unsent message was restored to the input.",
+        "info",
+        6_000,
+      );
+    }
+    return restored;
+  }, [setActionNotice, setChatInput]);
 
   const resolveConversationRoomId = useCallback(
     async (
@@ -526,8 +547,8 @@ export function useChatSend(deps: UseChatSendDeps) {
     [conversationsRef, loadConversations],
   );
 
-  const interruptActiveChatPipeline = useCallback(() => {
-    resolveQueuedChatSends();
+  const interruptActiveChatPipeline = useCallback((): string => {
+    const restoredQueuedText = resolveQueuedChatSends();
     const activeTurn = activeChatTurnRef.current;
     if (activeTurn?.roomId) {
       abortServerConversationTurn(activeTurn.roomId, "ui-chat-stop");
@@ -548,6 +569,7 @@ export function useChatSend(deps: UseChatSendDeps) {
     setChatSending(false);
     setChatFirstTokenReceived(false);
     setServerTurnStatus(null);
+    return restoredQueuedText;
   }, [
     chatAbortRef,
     flushStreamingText,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acceptance-criteria.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acceptance-criteria.test.ts
@@ -59,6 +59,25 @@ describe("detectTaskType", () => {
     expect(detectTaskType("create a web app that lists todos")).toBe(
       "app-build",
     );
+    // Canonical grammatical phrasing: "an app" and up to two intervening
+    // words must classify (a bare `build\s+a\s+app` regressed these to
+    // coding, silently dropping the live-URL acceptance criterion).
+    expect(detectTaskType("build an app that tracks expenses")).toBe(
+      "app-build",
+    );
+    expect(detectTaskType("create an app for my book club")).toBe("app-build");
+    expect(detectTaskType("make an app that shows the weather")).toBe(
+      "app-build",
+    );
+    expect(detectTaskType("build a todo app with reminders")).toBe("app-build");
+    expect(detectTaskType("create an expense tracking app")).toBe("app-build");
+  });
+
+  it("keeps refactor/fix phrasing with intervening verbs as coding", () => {
+    // The verb branch must not overreach: mentioning app-ish words without a
+    // build/create/make verb (or web/site phrasing) stays coding.
+    expect(detectTaskType("build an approach for caching")).toBe("coding");
+    expect(detectTaskType("update the app manifest parser")).toBe("coding");
   });
 
   it("classifies deploy goals", () => {

--- a/plugins/plugin-agent-orchestrator/src/services/acceptance-criteria.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acceptance-criteria.ts
@@ -107,10 +107,14 @@ const DEPLOY_RE =
   /\b(deploy|deployment|release\s+to\s+prod|ship\s+to\s+prod|production\s+rollout|provision\s+infra|autoscal\w*|hetzner|cloudflare\s+worker|publish\s+the\s+(?:site|app))\b/i;
 // Deliberately does NOT match a bare "app"/"application": "refactor the app" or
 // "fix the application startup" is coding, not an app-BUILD. Only web-app /
-// site / landing-page phrasing (or an explicit build/create-a-…-app) qualifies,
-// which is what gates the app-build-only "the live URL returns HTTP 200" criterion.
+// site / landing-page phrasing — or an explicit build/create/make-a(n)-…-app —
+// qualifies, which is what gates the app-build-only "the live URL returns
+// HTTP 200" criterion. The verb branch accepts "a" OR "an" plus up to two
+// intervening words so canonical phrasing like "build an app" and
+// "create a todo app" classifies correctly (a bare `build\s+a\s+app` never
+// matches grammatical English and silently regressed those to coding).
 const APP_BUILD_RE =
-  /\b(website|web\s*site|landing\s+page|web\s+app|webapp|frontend\s+app|build\s+a\s+(?:site|page|app)|create\s+a\s+(?:site|page|app))\b/i;
+  /\b(website|web\s*site|landing\s+page|web\s+app|webapp|frontend\s+app|(?:build|create|make)\s+an?\s+(?:\w+[ -]){0,2}(?:site|page|app|application)\b)/i;
 
 /**
  * Classify a task from its goal text. Defaults to `coding` — the safest


### PR DESCRIPTION
## Summary

Four adversarially-confirmed findings from the her-grade QA sweep (17 find-agents + refutation wave over chat/input/gesture surfaces):

- **No-lost-message on new-chat (#10700's core guarantee):** `interruptActiveChatPipeline` resolved queued sends **without delivery** — composer cleared at enqueue, optimistic bubble only at drain, so words sent via *send another* followed by new-chat vanished untraceably. Undelivered text is now restored to the composer with a notice (mirrors the cold-open create-failure path) and returned so new-chat can re-apply it after its draft wipe. +2 regression tests through the real interrupt; the routing fuzz suite stays 10/10.
- **#10715 part 2 — the widened swipe cone never applied to real gestures:** it existed only in release-time `resolveSwipe`; the mid-gesture axis commit still used strict `ax > ay` at 8 px, so the closure's own 65×75 exemplar locked axis y before the cone was consulted. Commit, coalesced-release, and commit-on-cancel paths now share `HORIZONTAL_DOMINANCE_RATIO`. +2 full-gesture tests (constant-slope diagonal commits; steep drag stays vertical).
- **APP_BUILD_RE (landed via #11073) can't match grammatical English:** `build\s+a\s+app` never matches 'build **an** app' / 'build a **todo** app' — canonical asks silently regressed to `coding`, dropping the live-URL acceptance criterion. Verb branch now accepts `an?` + ≤2 intervening words. +7 classification tests incl. anti-overreach guards.
- **run-home-screen-e2e red on develop since #11083**: the real-touch conversion deleted the mouse `swipeRight` helper but kept its call site (the nested-pager mouse-arbitration section genuinely needs mouse input). Restored.

## Evidence
- 338 unit tests green across overlay/gesture/chat-state/home suites.
- All four gesture e2e runners PASSED post-change (chatux, chat-sheet, conversation-swipe, home-screen — the last red on develop before this).
- Baseline before changes: 6/6 runners green on pre-#11083 develop; the home-screen red bisects cleanly to the dropped helper.

Refs #10700 #10715 #10722 #11073 #11083.

🤖 Generated with [Claude Code](https://claude.com/claude-code)