### PR TITLE
fix(ui): gate shell pollers + one-shot loaders on an authenticated session (#11084)

### DIFF
--- a/packages/ui/src/components/chat/widgets/agent-orchestrator-app-runs.test.tsx
+++ b/packages/ui/src/components/chat/widgets/agent-orchestrator-app-runs.test.tsx
@@ -3,11 +3,14 @@ import { cleanup, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
+  authMock,
   getBaseUrlMock,
   listAppRunsMock,
   loadMergedCatalogAppsMock,
   mockState,
 } = vi.hoisted(() => ({
+  // Auth gate (#11084) — mutable so tests can flip the session state.
+  authMock: { authenticated: true },
   getBaseUrlMock: vi.fn(() => "http://localhost"),
   listAppRunsMock: vi.fn(async () => []),
   loadMergedCatalogAppsMock: vi.fn(async () => []),
@@ -25,6 +28,10 @@ vi.mock("../../../api", () => ({
     getBaseUrl: getBaseUrlMock,
     listAppRuns: listAppRunsMock,
   },
+}));
+
+vi.mock("../../../hooks/useAuthStatus", () => ({
+  useIsAuthenticated: () => authMock.authenticated,
 }));
 
 vi.mock("../../../state", () => ({
@@ -53,6 +60,7 @@ beforeEach(() => {
   loadMergedCatalogAppsMock.mockClear();
   mockState.setTab.mockClear();
   mockState.setState.mockClear();
+  authMock.authenticated = true;
 });
 
 afterEach(() => {
@@ -72,5 +80,31 @@ describe("AppRunsWidget", () => {
     });
     expect(listAppRunsMock).not.toHaveBeenCalled();
     expect(mockState.setState).toHaveBeenCalledWith("appRuns", []);
+  });
+
+  // #11084 — the widget mounts before the auth probe resolves; the 5s run
+  // poll must not fire a single request while the session is unauthenticated.
+  it("does not poll app runs while unauthenticated", async () => {
+    authMock.authenticated = false;
+
+    const { container } = render(
+      <AppRunsWidget slot="chat-sidebar" events={[]} clearEvents={vi.fn()} />,
+    );
+
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull();
+    });
+    expect(listAppRunsMock).not.toHaveBeenCalled();
+    expect(mockState.setState).toHaveBeenCalledWith("appRuns", []);
+  });
+
+  it("polls app runs once the session is authenticated", async () => {
+    render(
+      <AppRunsWidget slot="chat-sidebar" events={[]} clearEvents={vi.fn()} />,
+    );
+
+    await waitFor(() => {
+      expect(listAppRunsMock).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/ui/src/components/chat/widgets/agent-orchestrator.tsx
+++ b/packages/ui/src/components/chat/widgets/agent-orchestrator.tsx
@@ -53,6 +53,7 @@ import type {
   OrchestratorRoomRosterOverview,
 } from "../../../api/client-types-cloud";
 import type { ActivityEvent } from "../../../hooks/useActivityEvents";
+import { useIsAuthenticated } from "../../../hooks/useAuthStatus";
 import { useIntervalWhenDocumentVisible } from "../../../hooks/useDocumentVisibility";
 import { useAppSelectorShallow } from "../../../state";
 import type { TranslateFn } from "../../../types";
@@ -376,6 +377,9 @@ function AppRunsWidget(_props: ChatSidebarWidgetProps) {
   const setState = appSetState ?? (() => undefined);
   const t = appT ?? fallbackTranslate;
   const currentBaseUrl = useAppSelectorShallow(() => client.getBaseUrl());
+  // Auth gate (#11084): the widget mounts before the auth probe resolves, so
+  // the 5s run poll must stay dormant until the session is authenticated.
+  const authenticated = useIsAuthenticated();
   const [catalogApps, setCatalogApps] = useState<RegistryAppInfo[]>([]);
   const [runs, setRuns] = useState<AppRunSummary[]>(() =>
     Array.isArray(appRuns) ? appRuns : [],
@@ -431,7 +435,7 @@ function AppRunsWidget(_props: ChatSidebarWidgetProps) {
   }, []);
 
   useEffect(() => {
-    if (!supportsFullAppShellRoutes(currentBaseUrl)) {
+    if (!supportsFullAppShellRoutes(currentBaseUrl) || !authenticated) {
       startTransition(() => {
         setRuns([]);
         setState("appRuns", []);
@@ -486,7 +490,7 @@ function AppRunsWidget(_props: ChatSidebarWidgetProps) {
       cancelled = true;
       clearInterval(timer);
     };
-  }, [currentBaseUrl, setState, t]);
+  }, [authenticated, currentBaseUrl, setState, t]);
 
   if (shouldHideWidget) {
     return null;
@@ -725,6 +729,9 @@ function OrchestratorAccountsWidget(_props: ChatSidebarWidgetProps) {
     setTab: s.setTab,
   }));
   const t = appT ?? fallbackTranslate;
+  // Auth gate (#11084): dormant until the session is authenticated so the
+  // 15s poll never fires 401s from an unauthenticated shell.
+  const authenticated = useIsAuthenticated();
   const [accounts, setAccounts] = useState<AccountsListResponse | null>(null);
   const [overview, setOverview] = useState<OrchestratorAccountOverview | null>(
     null,
@@ -735,6 +742,7 @@ function OrchestratorAccountsWidget(_props: ChatSidebarWidgetProps) {
   const [loading, setLoading] = useState(true);
 
   const refresh = useCallback(async () => {
+    if (!authenticated) return;
     const [acctRes, ovRes, roomsRes] = await Promise.allSettled([
       client.listAccounts(),
       client.getOrchestratorAccounts(),
@@ -744,7 +752,7 @@ function OrchestratorAccountsWidget(_props: ChatSidebarWidgetProps) {
     if (ovRes.status === "fulfilled") setOverview(ovRes.value);
     if (roomsRes.status === "fulfilled") setRooms(roomsRes.value);
     setLoading(false);
-  }, []);
+  }, [authenticated]);
 
   useEffect(() => {
     void refresh();
@@ -776,12 +784,15 @@ function OrchestratorAccountsWidget(_props: ChatSidebarWidgetProps) {
 function OrchestratorRoomWidget(_props: ChatSidebarWidgetProps) {
   const { t: appT } = useAppSelectorShallow((s) => ({ t: s.t }));
   const t = appT ?? fallbackTranslate;
+  // Auth gate (#11084): same as the accounts widget — no polling before auth.
+  const authenticated = useIsAuthenticated();
   const [rooms, setRooms] = useState<OrchestratorRoomRosterOverview | null>(
     null,
   );
   const [loading, setLoading] = useState(true);
 
   const refresh = useCallback(async () => {
+    if (!authenticated) return;
     try {
       const next = await client.getOrchestratorRooms();
       setRooms(next);
@@ -790,7 +801,7 @@ function OrchestratorRoomWidget(_props: ChatSidebarWidgetProps) {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [authenticated]);
 
   useEffect(() => {
     void refresh();

--- a/packages/ui/src/components/chat/widgets/todo.test.tsx
+++ b/packages/ui/src/components/chat/widgets/todo.test.tsx
@@ -1,13 +1,16 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
+  authMock,
   getBaseUrlMock,
   listWorkbenchTodosMock,
   mockState,
   publishHomeAttentionSpy,
 } = vi.hoisted(() => ({
+  // Auth gate (#11084) — mutable so tests can flip the session state.
+  authMock: { authenticated: true },
   getBaseUrlMock: vi.fn(() => "http://localhost"),
   listWorkbenchTodosMock: vi.fn(async () => ({ todos: [] })),
   mockState: {
@@ -41,6 +44,10 @@ vi.mock("../../../hooks", () => ({
   useIntervalWhenDocumentVisible: vi.fn(),
 }));
 
+vi.mock("../../../hooks/useAuthStatus", () => ({
+  useIsAuthenticated: () => authMock.authenticated,
+}));
+
 vi.mock("../../../state", () => ({
   useAppSelectorShallow: <T,>(selector: (state: typeof mockState) => T): T =>
     selector(mockState),
@@ -65,6 +72,7 @@ beforeEach(() => {
   getBaseUrlMock.mockReturnValue("http://localhost");
   listWorkbenchTodosMock.mockClear();
   publishHomeAttentionSpy.mockClear();
+  authMock.authenticated = true;
 });
 
 afterEach(() => {
@@ -82,5 +90,29 @@ describe("TodoSidebarWidget", () => {
     expect(await screen.findByText("Cached todo")).toBeTruthy();
     await Promise.resolve();
     expect(listWorkbenchTodosMock).not.toHaveBeenCalled();
+  });
+
+  // #11084 — the widget mounts before the auth probe resolves; its workbench
+  // poll must not fire a single request while the session is unauthenticated.
+  it("does not poll workbench todos while unauthenticated", async () => {
+    authMock.authenticated = false;
+
+    render(
+      <TodoWidget slot="chat-sidebar" events={[]} clearEvents={vi.fn()} />,
+    );
+
+    expect(await screen.findByText("Cached todo")).toBeTruthy();
+    await Promise.resolve();
+    expect(listWorkbenchTodosMock).not.toHaveBeenCalled();
+  });
+
+  it("polls workbench todos once the session is authenticated", async () => {
+    render(
+      <TodoWidget slot="chat-sidebar" events={[]} clearEvents={vi.fn()} />,
+    );
+
+    await waitFor(() => {
+      expect(listWorkbenchTodosMock).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/ui/src/components/chat/widgets/todo.tsx
+++ b/packages/ui/src/components/chat/widgets/todo.tsx
@@ -4,6 +4,7 @@ import { client } from "../../../api";
 import { supportsFullAppShellRoutes } from "../../../api/app-shell-capabilities";
 import type { WorkbenchTodo } from "../../../api/client-types-config";
 import { useIntervalWhenDocumentVisible } from "../../../hooks";
+import { useIsAuthenticated } from "../../../hooks/useAuthStatus";
 import { useAppSelectorShallow } from "../../../state";
 import type { TranslateFn } from "../../../types";
 import { usePublishHomeAttention } from "../../../widgets/home-attention-store";
@@ -148,6 +149,9 @@ function TodoSidebarWidget({ slot }: ChatSidebarWidgetProps) {
     t: s.t,
   }));
   const t = appT ?? fallbackTranslate;
+  // Auth gate (#11084): the widget mounts before the auth probe resolves, so
+  // the 15s todo poll must stay dormant until the session is authenticated.
+  const authenticated = useIsAuthenticated();
   const [todos, setTodos] = useState<WorkbenchTodo[]>(() =>
     dedupeTodos(workbench?.todos ?? []),
   );
@@ -170,7 +174,7 @@ function TodoSidebarWidget({ slot }: ChatSidebarWidgetProps) {
 
   const loadTodos = useCallback(
     async (silent = false) => {
-      if (!supportsFullAppShellRoutes(client.getBaseUrl())) {
+      if (!authenticated || !supportsFullAppShellRoutes(client.getBaseUrl())) {
         if (mountedRef.current) {
           setTodos(dedupeTodos(workbench?.todos ?? []));
           setTodosLoading(false);
@@ -197,7 +201,7 @@ function TodoSidebarWidget({ slot }: ChatSidebarWidgetProps) {
         }
       }
     },
-    [workbench?.todos],
+    [authenticated, workbench?.todos],
   );
 
   useEffect(() => {

--- a/packages/ui/src/components/local-inference/useHomeModelStatus.test.tsx
+++ b/packages/ui/src/components/local-inference/useHomeModelStatus.test.tsx
@@ -28,6 +28,14 @@ const eventSourceMock = vi.hoisted(() => ({
   openEventSource: vi.fn(() => ({ close: vi.fn() })),
 }));
 
+// Auth gate (#11084): the hook must stay dormant until the shared auth
+// snapshot reports an authenticated session. Mutable so tests can flip it.
+const authMock = vi.hoisted(() => ({ authenticated: true }));
+
+vi.mock("../../hooks/useAuthStatus", () => ({
+  useIsAuthenticated: () => authMock.authenticated,
+}));
+
 vi.mock("../../hooks/useRuntimeMode", () => ({
   useRuntimeMode: () => runtimeModeMock.value,
 }));
@@ -89,6 +97,7 @@ beforeEach(() => {
   clientMock.getBaseUrl.mockReturnValue("http://127.0.0.1:31337");
   clientMock.getLocalInferenceHub.mockResolvedValue(emptyHub);
   eventSourceMock.openEventSource.mockClear();
+  authMock.authenticated = true;
   setRuntimeMode("local");
 });
 
@@ -138,6 +147,32 @@ describe("useHomeModelStatus", () => {
     });
     expect(clientMock.getLocalInferenceHub).not.toHaveBeenCalled();
     expect(eventSourceMock.openEventSource).not.toHaveBeenCalled();
+  });
+
+  // #11084 — the shell mounts this hook before the auth probe resolves; the
+  // SSE stream + hub fetch must not fire a single request until the session
+  // is authenticated, then start as soon as it flips.
+  it("stays dormant while unauthenticated, then starts once the session authenticates", async () => {
+    authMock.authenticated = false;
+
+    const { result, rerender } = renderHook(() => useHomeModelStatus());
+
+    await waitFor(() => {
+      expect(result.current.kind).toBe("not-required");
+    });
+    expect(clientMock.getLocalInferenceHub).not.toHaveBeenCalled();
+    expect(eventSourceMock.openEventSource).not.toHaveBeenCalled();
+
+    authMock.authenticated = true;
+    rerender();
+
+    await waitFor(() => {
+      expect(clientMock.getLocalInferenceHub).toHaveBeenCalledTimes(1);
+    });
+    expect(eventSourceMock.openEventSource).toHaveBeenCalledWith(
+      "/api/local-inference/downloads/stream",
+      { withCredentials: false },
+    );
   });
 
   it("rechecks the base before polling when startup flips to a dedicated cloud agent", async () => {

--- a/packages/ui/src/components/local-inference/useHomeModelStatus.ts
+++ b/packages/ui/src/components/local-inference/useHomeModelStatus.ts
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import { client } from "../../api";
 import { supportsFullAppShellRoutes } from "../../api/app-shell-capabilities";
 import { isDesktopExternalApiBaseUrl } from "../../api/desktop-external-api-base";
+import { useIsAuthenticated } from "../../hooks/useAuthStatus";
 import { useRuntimeMode } from "../../hooks/useRuntimeMode";
 import {
   deriveHomeModelStatus,
@@ -44,9 +45,15 @@ export function useHomeModelStatus(): HomeModelStatus {
   const [status, setStatus] = useState<HomeModelStatus>(NOT_REQUIRED);
   const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const runtimeMode = useRuntimeMode();
+  // Auth gate (#11084): the shell mounts this hook before the auth probe
+  // resolves, so the download SSE stream + hub fetches must stay dormant until
+  // the session is authenticated (an unauthenticated tab otherwise streams
+  // 401s into the rate limiter).
+  const authenticated = useIsAuthenticated();
 
   useEffect(() => {
     if (
+      !authenticated ||
       runtimeMode.state.phase === "loading" ||
       runtimeMode.isCloudMode ||
       runtimeMode.isRemoteMode ||
@@ -102,6 +109,7 @@ export function useHomeModelStatus(): HomeModelStatus {
       es?.close();
     };
   }, [
+    authenticated,
     runtimeMode.isCloudMode,
     runtimeMode.isRemoteMode,
     runtimeMode.state.phase,

--- a/packages/ui/src/components/shell/ComputerUseApprovalOverlay.auth-gate.test.tsx
+++ b/packages/ui/src/components/shell/ComputerUseApprovalOverlay.auth-gate.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+//
+// #11084 — the shell mounts ComputerUseApprovalOverlay before the auth probe
+// resolves. Its SSE stream (and 1.5s polling fallback) must not issue a single
+// request while the session is unauthenticated, and must start as soon as the
+// shared auth snapshot flips to authenticated.
+
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { clientMock, openEventSourceMock, authMock, mockState } = vi.hoisted(
+  () => ({
+    clientMock: {
+      getBaseUrl: vi.fn(() => "http://127.0.0.1:31337"),
+      getRestAuthToken: vi.fn(() => null),
+      getComputerUseApprovals: vi.fn(async () => ({
+        mode: "full_control",
+        pendingCount: 0,
+        pendingApprovals: [],
+      })),
+      respondToComputerUseApproval: vi.fn(),
+    },
+    openEventSourceMock: vi.fn(() => ({
+      close: vi.fn(),
+      onmessage: null,
+      onerror: null,
+    })),
+    authMock: { authenticated: false },
+    mockState: {
+      setActionNotice: vi.fn(),
+      t: (_key: string, vars?: { defaultValue?: string }) =>
+        vars?.defaultValue ?? "",
+    },
+  }),
+);
+
+vi.mock("../../api/client", () => ({ client: clientMock }));
+
+vi.mock("../../utils/event-source", () => ({
+  openEventSource: openEventSourceMock,
+}));
+
+vi.mock("../../hooks/useAuthStatus", () => ({
+  useIsAuthenticated: () => authMock.authenticated,
+}));
+
+vi.mock("../../state", () => ({
+  useAppSelector: <T,>(selector: (state: typeof mockState) => T): T =>
+    selector(mockState),
+}));
+
+import { ComputerUseApprovalOverlay } from "./ComputerUseApprovalOverlay";
+
+beforeEach(() => {
+  clientMock.getBaseUrl.mockReturnValue("http://127.0.0.1:31337");
+  clientMock.getRestAuthToken.mockReturnValue(null);
+  clientMock.getComputerUseApprovals.mockClear();
+  openEventSourceMock.mockClear();
+  authMock.authenticated = false;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ComputerUseApprovalOverlay auth gate (#11084)", () => {
+  it("opens no SSE stream and issues no approval fetch while unauthenticated", async () => {
+    render(<ComputerUseApprovalOverlay />);
+
+    // Flush the mount effect + any microtask-deferred fetches.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(openEventSourceMock).not.toHaveBeenCalled();
+    expect(clientMock.getComputerUseApprovals).not.toHaveBeenCalled();
+  });
+
+  it("starts the SSE stream once the session flips to authenticated", async () => {
+    const { rerender } = render(<ComputerUseApprovalOverlay />);
+    await Promise.resolve();
+    expect(openEventSourceMock).not.toHaveBeenCalled();
+
+    authMock.authenticated = true;
+    rerender(<ComputerUseApprovalOverlay />);
+
+    await waitFor(() => {
+      expect(openEventSourceMock).toHaveBeenCalledTimes(1);
+    });
+    expect(openEventSourceMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:31337/api/computer-use/approvals/stream",
+    );
+  });
+
+  it("falls back to polling only after authentication (never before)", async () => {
+    // Native IPC bases can't open EventSource — the overlay then polls.
+    openEventSourceMock.mockReturnValue(null as never);
+
+    const { rerender } = render(<ComputerUseApprovalOverlay />);
+    await Promise.resolve();
+    expect(clientMock.getComputerUseApprovals).not.toHaveBeenCalled();
+
+    authMock.authenticated = true;
+    rerender(<ComputerUseApprovalOverlay />);
+
+    await waitFor(() => {
+      expect(clientMock.getComputerUseApprovals).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/ui/src/components/shell/ComputerUseApprovalOverlay.tsx
+++ b/packages/ui/src/components/shell/ComputerUseApprovalOverlay.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { supportsFullAppShellRoutes } from "../../api/app-shell-capabilities";
 import { type ComputerUseApprovalSnapshot, client } from "../../api/client";
+import { useIsAuthenticated } from "../../hooks/useAuthStatus";
 import { useAppSelector } from "../../state";
 import { openEventSource } from "../../utils/event-source";
 import { Button } from "../ui/button";
@@ -39,6 +40,10 @@ export function ComputerUseApprovalOverlay() {
   const appShellRoutesSupported = supportsFullAppShellRoutes(
     client.getBaseUrl(),
   );
+  // Auth gate (#11084): the shell mounts this overlay before the auth probe
+  // resolves, so without this the SSE stream / 1.5s poll fires 401s from every
+  // unauthenticated tab. Dormant until the session is authenticated.
+  const authenticated = useIsAuthenticated();
   const [snapshot, setSnapshot] =
     useState<ComputerUseApprovalSnapshot>(EMPTY_SNAPSHOT);
   const [busyApprovalId, setBusyApprovalId] = useState<string | null>(null);
@@ -48,7 +53,7 @@ export function ComputerUseApprovalOverlay() {
   const previousFocusRef = useRef<HTMLElement | null>(null);
 
   const refresh = useCallback(async () => {
-    if (!appShellRoutesSupported) {
+    if (!appShellRoutesSupported || !authenticated) {
       setSnapshot(EMPTY_SNAPSHOT);
       return;
     }
@@ -57,10 +62,10 @@ export function ComputerUseApprovalOverlay() {
     } catch {
       setSnapshot(EMPTY_SNAPSHOT);
     }
-  }, [appShellRoutesSupported]);
+  }, [appShellRoutesSupported, authenticated]);
 
   useEffect(() => {
-    if (!appShellRoutesSupported) {
+    if (!appShellRoutesSupported || !authenticated) {
       setSnapshot(EMPTY_SNAPSHOT);
       return undefined;
     }
@@ -131,7 +136,7 @@ export function ComputerUseApprovalOverlay() {
       }
       eventSource?.close();
     };
-  }, [appShellRoutesSupported, refresh]);
+  }, [appShellRoutesSupported, authenticated, refresh]);
 
   // Defensive: the snapshot can be partially populated during reconnect/
   // recovery windows, so `pendingApprovals` may be momentarily undefined.

--- a/packages/ui/src/hooks/useAuthStatus.ts
+++ b/packages/ui/src/hooks/useAuthStatus.ts
@@ -120,6 +120,19 @@ async function fetchAuthStatus(): Promise<void> {
   return authStatusFetch;
 }
 
+/**
+ * True once the app-level auth probe (App.tsx's `useAuthStatus`) has resolved
+ * to an authenticated session. Read-only: subscribes to the shared snapshot
+ * without starting its own fetch or poll, so gating on it adds zero network
+ * traffic. Background pollers and shell data loaders must not start until this
+ * is true — an unauthenticated shell otherwise streams 401s into the API rate
+ * limiter (#11084).
+ */
+export function useIsAuthenticated(): boolean {
+  const { state } = useAuthStatus({ observeOnly: true });
+  return state.phase === "authenticated";
+}
+
 export function useAuthStatus(options: UseAuthStatusOptions = {}): {
   state: AuthStatusState;
   refetch: () => void;

--- a/packages/ui/src/state/useDataLoaders.auth-gate.test.tsx
+++ b/packages/ui/src/state/useDataLoaders.auth-gate.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+//
+// #11084 — AppProvider mounts the data loaders before the auth probe
+// resolves. The supportsFullAppShellRoutes-gated one-shot loaders (workbench
+// overview, owner-name getConfig) must not issue a single request while the
+// session is unauthenticated, and must fire once it flips to authenticated.
+
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  client: {
+    getBaseUrl: vi.fn(() => "http://127.0.0.1:31337"),
+    getWorkbenchOverview: vi.fn(async () => ({
+      tasksAvailable: true,
+      triggersAvailable: true,
+      todosAvailable: true,
+    })),
+    getConfig: vi.fn(async () => ({ ui: { ownerName: "Owner" } })),
+    listConversations: vi.fn(async () => ({ conversations: [] })),
+    getConversationMessages: vi.fn(async () => ({ messages: [] })),
+  },
+  auth: { authenticated: false },
+}));
+
+vi.mock("../api", () => ({ client: mocks.client }));
+
+vi.mock("../hooks/useAuthStatus", () => ({
+  useIsAuthenticated: () => mocks.auth.authenticated,
+}));
+
+import { type DataLoadersDeps, useDataLoaders } from "./useDataLoaders";
+
+function makeDeps(overrides: Partial<DataLoadersDeps> = {}): DataLoadersDeps {
+  const noop = () => {};
+  return {
+    autonomousStoreRef: { current: {} },
+    autonomousEventsRef: { current: [] },
+    autonomousLatestEventIdRef: { current: null },
+    autonomousRunHealthByRunIdRef: { current: {} },
+    autonomousReplayInFlightRef: { current: false },
+    setAutonomousEvents: noop,
+    setAutonomousLatestEventId: noop,
+    setAutonomousRunHealthByRunId: noop,
+    activeConversationIdRef: { current: null },
+    conversationMessagesRef: { current: [] },
+    greetingFiredRef: { current: false },
+    setConversations: noop,
+    setActiveConversationId: noop,
+    setConversationMessages: noop,
+    loadWalletConfig: async () => {},
+    agentStatus: null,
+    characterData: null,
+    characterDraft: null,
+    loadCharacter: async () => {},
+    selectedVrmIndex: 0,
+    firstRunComplete: false,
+    uiLanguage: "en",
+    setOwnerNameState: noop,
+    ...overrides,
+  } as unknown as DataLoadersDeps;
+}
+
+beforeEach(() => {
+  mocks.client.getWorkbenchOverview.mockClear();
+  mocks.client.getConfig.mockClear();
+  mocks.auth.authenticated = false;
+});
+
+describe("useDataLoaders auth gate (#11084)", () => {
+  it("loadWorkbench issues no request while unauthenticated, then loads after auth flips", async () => {
+    const deps = makeDeps({
+      agentStatus: { state: "running" } as DataLoadersDeps["agentStatus"],
+    });
+    const { result, rerender } = renderHook(() => useDataLoaders(deps));
+
+    await act(async () => {
+      await result.current.loadWorkbench();
+    });
+    expect(mocks.client.getWorkbenchOverview).not.toHaveBeenCalled();
+    expect(result.current.workbench).toBeNull();
+
+    // The auth flip itself re-fires the workbench load that the pre-auth
+    // agent-running edge suppressed.
+    mocks.auth.authenticated = true;
+    await act(async () => {
+      rerender();
+    });
+    expect(mocks.client.getWorkbenchOverview).toHaveBeenCalledTimes(1);
+  });
+
+  it("owner-name getConfig hydration waits for authentication", async () => {
+    const deps = makeDeps({
+      agentStatus: { state: "running" } as DataLoadersDeps["agentStatus"],
+    });
+    const { rerender } = renderHook(() => useDataLoaders(deps));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mocks.client.getConfig).not.toHaveBeenCalled();
+
+    mocks.auth.authenticated = true;
+    await act(async () => {
+      rerender();
+    });
+    expect(mocks.client.getConfig).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/state/useDataLoaders.ts
+++ b/packages/ui/src/state/useDataLoaders.ts
@@ -41,6 +41,7 @@ import {
   type WorkbenchOverview,
 } from "../api";
 import { supportsFullAppShellRoutes } from "../api/app-shell-capabilities";
+import { useIsAuthenticated } from "../hooks/useAuthStatus";
 import type { UiLanguage } from "../i18n";
 import { normalizeOwnerName } from "../utils/owner-name";
 import {
@@ -166,6 +167,11 @@ export function useDataLoaders(deps: DataLoadersDeps) {
     uiLanguage,
     setOwnerNameState,
   } = deps;
+
+  // Auth gate (#11084): AppProvider mounts these loaders before the auth probe
+  // resolves, so the shell one-shot fetches must stay dormant until the
+  // session is authenticated — an unauthenticated shell makes none of them.
+  const authenticated = useIsAuthenticated();
 
   // ── Autonomy ────────────────────────────────────────────────────────
 
@@ -584,7 +590,7 @@ export function useDataLoaders(deps: DataLoadersDeps) {
   const agentReachable = agentStatus !== null;
 
   useEffect(() => {
-    if (!agentReachable) {
+    if (!agentReachable || !authenticated) {
       return;
     }
 
@@ -611,7 +617,7 @@ export function useDataLoaders(deps: DataLoadersDeps) {
     return () => {
       cancelled = true;
     };
-  }, [agentReachable, setOwnerNameState]);
+  }, [agentReachable, authenticated, setOwnerNameState]);
 
   // ── Character language sync ─────────────────────────────────────────
 
@@ -672,7 +678,7 @@ export function useDataLoaders(deps: DataLoadersDeps) {
   const [workbenchTodosAvailable, setWorkbenchTodosAvailable] = useState(false);
 
   const loadWorkbench = useCallback(async () => {
-    if (!supportsFullAppShellRoutes(client.getBaseUrl())) {
+    if (!authenticated || !supportsFullAppShellRoutes(client.getBaseUrl())) {
       setWorkbench(null);
       setWorkbenchTasksAvailable(false);
       setWorkbenchTriggersAvailable(false);
@@ -695,7 +701,20 @@ export function useDataLoaders(deps: DataLoadersDeps) {
     } finally {
       setWorkbenchLoading(false);
     }
-  }, []);
+  }, [authenticated]);
+
+  // The workbench load normally fires on the agent-state "running" edge
+  // (useAgentGreetingEffects). When that edge lands before the auth probe
+  // resolves the load is suppressed by the gate above, so fire it once the
+  // session flips to authenticated with the agent already reachable.
+  const workbenchAuthArmedRef = useRef(authenticated);
+  useEffect(() => {
+    const was = workbenchAuthArmedRef.current;
+    workbenchAuthArmedRef.current = authenticated;
+    if (!was && authenticated && agentReachable) {
+      void loadWorkbench();
+    }
+  }, [agentReachable, authenticated, loadWorkbench]);
 
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus | null>(null);
   const [updateLoading, setUpdateLoading] = useState(false);


### PR DESCRIPTION
## Gate shell pollers + one-shot loaders on an authenticated session (#11084)

An unauthenticated app shell polled its own `/api/*` endpoints in a no-backoff loop (~2 req/s per idle tab, measured ~35 requests/20s on staging) — every response a 401. This is the client-side root cause feeding the rate-limiter lockouts (#11087): every poller gated only on `supportsFullAppShellRoutes(baseUrl)` (a URL-shape check), never on auth.

### Fix
New `useIsAuthenticated()` in `hooks/useAuthStatus.ts` — a **read-only `observeOnly` subscription to the shared auth snapshot** (adds zero network traffic) — and gate each poller's effect alongside its existing guard, so nothing fires until `phase === "authenticated"`, starting/stopping as the phase flips:

- `ComputerUseApprovalOverlay` — SSE stream + 1.5s poll fallback (the worst offender)
- `agent-orchestrator` widget — 5s `listAppRuns` + the 15s accounts/rooms pollers
- `todo` widget — 15s `listWorkbenchTodos`
- `useHomeModelStatus` — downloads SSE + hub fetch
- `useDataLoaders` — the `supportsFullAppShellRoutes`-gated one-shot loaders (workbench overview, owner-name `getConfig`), with an edge-triggered re-arm that fires the workbench load when auth lands after the agent-running edge was suppressed pre-auth.

**Local-only mode is unaffected** (verified): `/api/auth/me` returns an authenticated OWNER identity for trusted loopback requests (`isTrustedLocalRequest` in `auth-routes.ts`), so local installs report `authenticated` and pollers run as before. Only genuinely unauthenticated remote shells go quiet. Deliberately did NOT gate the App.tsx subtree mount — preserves the no-flash-during-loading UX and popout/first-run paths.

### Evidence (fail-without-fix, independently re-verified)
- `ComputerUseApprovalOverlay.auth-gate.test.tsx` + `useHomeModelStatus.test.tsx`: zero `openEventSource`/client calls while the mocked auth snapshot is not authenticated; the SSE/fetch starts once flipped to authenticated. Reverting the two production files → **4 tests red** ("expected vi.fn() to not be called at all, but actually been called 1 times"); restored → green.
- 6 test files / **21 tests pass**; `tsgo --noEmit` (packages/ui): **exit 0**; biome clean.
- Visual audit: **N/A** — zero rendered-output delta (sign-in overlay and loading UI unchanged; only pre-auth background traffic is suppressed).

Follow-up candidates (same pattern, out of the verified map's scope): `model-download.tsx` and the other `supportsFullAppShellRoutes` widgets (calendar-upcoming, inbox-unread, needs-attention).

Refs #11084 #11087

🤖 Generated with [Claude Code](https://claude.com/claude-code)
