### PR TITLE
feat(vision): Android OCR via ML Kit Text Recognition v2 over the OCR bridge seam (#11001)

### DIFF
--- a/.github/issue-evidence/11001-mlkit-ocr-android/README.md
+++ b/.github/issue-evidence/11001-mlkit-ocr-android/README.md
@@ -1,0 +1,51 @@
+# #11001 — Android OCR via ML Kit Text Recognition v2 (bridge + native answerer)
+
+On-device evidence for the ML Kit OCR bridge landing: the engine-agnostic OCR
+bridge seam (salvaged per #9649 item 1 from `feat/9105-tesseract-ship`) plus the
+new `@elizaos/capacitor-mlkit-text` native answerer, verified on a real device
+and an emulator.
+
+## What was verified
+
+`MlKitTextReaderInstrumentedTest` (`connectedDebugAndroidTest`, the #9453
+evidence pattern) drives the **real ML Kit Text Recognition v2 engine** through
+`MlKitTextReader` — the exact class the shipped Capacitor plugin delegates to:
+
+- `recognize_returnsRealTextAndBoxes` — renders `HELLO ELIZA 42` / `OCR BRIDGE`
+  into a bitmap, runs recognition, asserts the real text comes back, every
+  bounding box is positive and inside the bitmap, the two rendered lines land
+  in distinct block/line groups (so the bridge's `mapOcrWordsToResult`
+  grouping stays meaningful), and line 1 sits above line 2.
+- `recognize_blankImageReturnsNoWords` — a blank bitmap yields zero words
+  (no hallucinated text).
+
+## Runs
+
+| Target | Device | OS | Result |
+|---|---|---|---|
+| Real device | Pixel 6a (`27051JEGR10034`) | Android 16 | 2/2 passed — `connectedDebugAndroidTest-pixel6a-android16.xml` |
+| Emulator | `eliza-viewtest` AVD (x86_64) | Android 14 | 2/2 passed — `connectedDebugAndroidTest-emulator-android14.xml` |
+
+Command (from `packages/app-core/platforms/android`):
+
+```bash
+ANDROID_SERIAL=<serial> ./gradlew :elizaos-capacitor-mlkit-text:connectedDebugAndroidTest
+```
+
+## Bridge plumbing coverage (unit, vitest)
+
+- `plugins/plugin-vision`: `ocr-bridge.test.ts`, `ocr-service-android-bridge.test.ts`,
+  `routes.ocr.test.ts` — 13 tests (request queue/timeout/failure, word→coords
+  mapping incl. tile offsets, route validation incl. malformed bodies).
+- `packages/ui`: `src/state/ocr-bridge.test.ts` — 2 tests (renderer poller).
+- `plugins/plugin-native-mlkit-text`: `src/web.test.ts` — web fallback rejects
+  unsupported.
+
+## Engine-dependency note
+
+The plugin uses the **bundled** `com.google.mlkit:text-recognition:16.0.1`
+artifact (model inside the app, no Play-Services model download, no network),
+not the unbundled `play-services-mlkit-text-recognition` variant the issue
+mentioned (~260 KB). Bundled keeps recognition deterministic on devices and
+emulators without Google Play, at ~4 MB APK cost. No Tesseract4Android binaries
+are anywhere in the tree (per the #9105 engine decision).

--- a/.github/issue-evidence/11001-mlkit-ocr-android/connectedDebugAndroidTest-emulator-android14.xml
+++ b/.github/issue-evidence/11001-mlkit-ocr-android/connectedDebugAndroidTest-emulator-android14.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<testsuite name="ai.eliza.plugins.mlkittext.MlKitTextReaderInstrumentedTest" tests="2" failures="0" errors="0" skipped="0" time="3.998" timestamp="2026-07-02T02:54:46" hostname="localhost">
+  <properties>
+    <property name="device" value="eliza-viewtest(AVD) - 14" />
+    <property name="flavor" value="" />
+    <property name="project" value=":elizaos-capacitor-mlkit-text" />
+  </properties>
+  <testcase name="recognize_blankImageReturnsNoWords" classname="ai.eliza.plugins.mlkittext.MlKitTextReaderInstrumentedTest" time="1.585" />
+  <testcase name="recognize_returnsRealTextAndBoxes" classname="ai.eliza.plugins.mlkittext.MlKitTextReaderInstrumentedTest" time="1.186" />
+</testsuite>

--- a/.github/issue-evidence/11001-mlkit-ocr-android/connectedDebugAndroidTest-pixel6a-android16.xml
+++ b/.github/issue-evidence/11001-mlkit-ocr-android/connectedDebugAndroidTest-pixel6a-android16.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<testsuite name="ai.eliza.plugins.mlkittext.MlKitTextReaderInstrumentedTest" tests="2" failures="0" errors="0" skipped="0" time="1.86" timestamp="2026-07-02T02:52:42" hostname="localhost">
+  <properties>
+    <property name="device" value="Pixel 6a - 16" />
+    <property name="flavor" value="" />
+    <property name="project" value=":elizaos-capacitor-mlkit-text" />
+  </properties>
+  <testcase name="recognize_blankImageReturnsNoWords" classname="ai.eliza.plugins.mlkittext.MlKitTextReaderInstrumentedTest" time="0.763" />
+  <testcase name="recognize_returnsRealTextAndBoxes" classname="ai.eliza.plugins.mlkittext.MlKitTextReaderInstrumentedTest" time="0.438" />
+</testsuite>

--- a/bun.lock
+++ b/bun.lock
@@ -232,6 +232,7 @@
         "@elizaos/capacitor-gateway": "workspace:*",
         "@elizaos/capacitor-location": "workspace:*",
         "@elizaos/capacitor-messages": "workspace:*",
+        "@elizaos/capacitor-mlkit-text": "workspace:*",
         "@elizaos/capacitor-mobile-agent-bridge": "workspace:*",
         "@elizaos/capacitor-mobile-signals": "workspace:*",
         "@elizaos/capacitor-phone": "workspace:*",
@@ -370,6 +371,7 @@
         "@elizaos/capacitor-gateway": "workspace:*",
         "@elizaos/capacitor-location": "workspace:*",
         "@elizaos/capacitor-messages": "workspace:*",
+        "@elizaos/capacitor-mlkit-text": "workspace:*",
         "@elizaos/capacitor-mobile-agent-bridge": "workspace:*",
         "@elizaos/capacitor-mobile-signals": "workspace:*",
         "@elizaos/capacitor-phone": "workspace:*",
@@ -4207,6 +4209,19 @@
         "@capacitor/core": "^8.3.1",
       },
     },
+    "plugins/plugin-native-mlkit-text": {
+      "name": "@elizaos/capacitor-mlkit-text",
+      "version": "2.0.3-beta.7",
+      "devDependencies": {
+        "@capacitor/core": "^8.3.1",
+        "rollup": "^4.60.2",
+        "typescript": "^6.0.3",
+        "vitest": "^4.0.0",
+      },
+      "peerDependencies": {
+        "@capacitor/core": "^8.3.1",
+      },
+    },
     "plugins/plugin-native-mobile-agent-bridge": {
       "name": "@elizaos/capacitor-mobile-agent-bridge",
       "version": "2.0.3-beta.7",
@@ -6123,6 +6138,8 @@
     "@elizaos/capacitor-location": ["@elizaos/capacitor-location@workspace:plugins/plugin-native-location"],
 
     "@elizaos/capacitor-messages": ["@elizaos/capacitor-messages@workspace:plugins/plugin-native-messages"],
+
+    "@elizaos/capacitor-mlkit-text": ["@elizaos/capacitor-mlkit-text@workspace:plugins/plugin-native-mlkit-text"],
 
     "@elizaos/capacitor-mobile-agent-bridge": ["@elizaos/capacitor-mobile-agent-bridge@workspace:plugins/plugin-native-mobile-agent-bridge"],
 

--- a/packages/app-core/package.json
+++ b/packages/app-core/package.json
@@ -219,6 +219,7 @@
     "@elizaos/capacitor-gateway": "workspace:*",
     "@elizaos/capacitor-location": "workspace:*",
     "@elizaos/capacitor-messages": "workspace:*",
+    "@elizaos/capacitor-mlkit-text": "workspace:*",
     "@elizaos/capacitor-mobile-agent-bridge": "workspace:*",
     "@elizaos/capacitor-mobile-signals": "workspace:*",
     "@elizaos/capacitor-phone": "workspace:*",

--- a/packages/app-core/platforms/android/app/capacitor.build.gradle
+++ b/packages/app-core/platforms/android/app/capacitor.build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation project(':elizaos-capacitor-gateway')
     implementation project(':elizaos-capacitor-location')
     implementation project(':elizaos-capacitor-messages')
+    implementation project(':elizaos-capacitor-mlkit-text')
     implementation project(':elizaos-capacitor-mobile-agent-bridge')
     implementation project(':elizaos-capacitor-mobile-signals')
     implementation project(':elizaos-capacitor-phone')

--- a/packages/app-core/platforms/android/capacitor.settings.gradle
+++ b/packages/app-core/platforms/android/capacitor.settings.gradle
@@ -62,6 +62,9 @@ project(':elizaos-capacitor-location').projectDir = new File('../../../../plugin
 include ':elizaos-capacitor-messages'
 project(':elizaos-capacitor-messages').projectDir = new File('../../../../plugins/plugin-native-messages/android')
 
+include ':elizaos-capacitor-mlkit-text'
+project(':elizaos-capacitor-mlkit-text').projectDir = new File('../../../../plugins/plugin-native-mlkit-text/android')
+
 include ':elizaos-capacitor-mobile-agent-bridge'
 project(':elizaos-capacitor-mobile-agent-bridge').projectDir = new File('../../../../plugins/plugin-native-mobile-agent-bridge/android')
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -120,6 +120,7 @@
     "@elizaos/capacitor-gateway": "workspace:*",
     "@elizaos/capacitor-location": "workspace:*",
     "@elizaos/capacitor-messages": "workspace:*",
+    "@elizaos/capacitor-mlkit-text": "workspace:*",
     "@elizaos/capacitor-mobile-agent-bridge": "workspace:*",
     "@elizaos/capacitor-mobile-signals": "workspace:*",
     "@elizaos/capacitor-phone": "workspace:*",

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -110,6 +110,7 @@ import {
   syncDetachedShellLocation,
 } from "@elizaos/ui/platform/window-shell";
 import { AppProvider } from "@elizaos/ui/state";
+import { initOcrBridge } from "@elizaos/ui/state/ocr-bridge";
 import {
   applyUiTheme,
   loadUiLanguage,
@@ -2759,6 +2760,7 @@ async function main(): Promise<void> {
     // plugin. Idempotent + native-gated; runs only after the local-agent
     // fetch bridge is installed so `/api/...` routes resolve to the agent.
     initScreenCaptureBridge();
+    initOcrBridge();
   } else if (isAndroid) {
     initializeCapacitorBridge();
     installAndroidNativeAgentFetchBridge();
@@ -2767,6 +2769,7 @@ async function main(): Promise<void> {
     // plugin. Idempotent + native-gated; runs only after the Android fetch
     // bridge is installed so `/api/...` routes resolve to the agent.
     initScreenCaptureBridge();
+    initOcrBridge();
     // Expose window.__diarizationPump (WebView→bun-agent PCM pump) and
     // window.__jniVoice (the in-process JNI voice pipeline — the four fused
     // voice classifiers running IN the bionic app process via the ElizaVoice

--- a/packages/ui/src/bridge/native-plugins.ts
+++ b/packages/ui/src/bridge/native-plugins.ts
@@ -605,6 +605,25 @@ export interface ScreenCapturePluginLike extends NativePlugin {
   }): Promise<ScreenCaptureScreenshotResult>;
 }
 
+export interface TesseractWord {
+  text: string;
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+  confidence: number;
+  block: number;
+  par: number;
+  line: number;
+}
+
+export interface TesseractPluginLike extends NativePlugin {
+  recognize?: (options: {
+    image: string;
+    psm?: number;
+  }) => Promise<{ words: TesseractWord[] }>;
+}
+
 export interface WebsiteBlockerPermissionResult {
   status: "granted" | "denied" | "not-determined" | "not-applicable";
   canRequest: boolean;
@@ -896,6 +915,13 @@ export function getLocationPlugin(): LocationPluginLike {
 
 export function getScreenCapturePlugin(): ScreenCapturePluginLike {
   return getNativePlugin<ScreenCapturePluginLike>("ScreenCapture");
+}
+
+export function getTesseractPlugin(): TesseractPluginLike {
+  const plugins = getCapacitorPlugins();
+  return (plugins.Tesseract ??
+    plugins.ElizaTesseract ??
+    {}) as TesseractPluginLike;
 }
 
 export function getCanvasPlugin(): GenericNativePlugin {

--- a/packages/ui/src/state/ocr-bridge.test.ts
+++ b/packages/ui/src/state/ocr-bridge.test.ts
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { __resetOcrBridgeForTests, initOcrBridge } from "./ocr-bridge";
+
+const recognizeMock = vi.fn();
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: {
+    getPlatform: () => "android",
+  },
+}));
+
+vi.mock("../bridge/native-plugins", () => ({
+  getTesseractPlugin: () => ({
+    recognize: recognizeMock,
+  }),
+}));
+
+describe("ocr bridge", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    recognizeMock.mockReset();
+    __resetOcrBridgeForTests();
+  });
+
+  afterEach(() => {
+    __resetOcrBridgeForTests();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("polls queued OCR requests and posts recognized words", async () => {
+    const word = {
+      text: "Save",
+      left: 1,
+      top: 2,
+      width: 3,
+      height: 4,
+      confidence: 90,
+      block: 1,
+      par: 1,
+      line: 1,
+    };
+    recognizeMock.mockResolvedValue({ words: [word] });
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            requests: [{ requestId: "ocr-1", imageBase64: "abcd", psm: 11 }],
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true })));
+
+    initOcrBridge();
+    await vi.advanceTimersByTimeAsync(1200);
+
+    expect(fetchMock).toHaveBeenNthCalledWith(1, "/api/vision/ocr-requests");
+    expect(recognizeMock).toHaveBeenCalledWith({ image: "abcd", psm: 11 });
+    expect(fetchMock).toHaveBeenNthCalledWith(2, "/api/vision/ocr-result", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        requestId: "ocr-1",
+        words: [word],
+      }),
+    });
+  });
+
+  it("posts an error result when native recognition fails", async () => {
+    recognizeMock.mockRejectedValue(new Error("missing traineddata"));
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            requests: [{ requestId: "ocr-2", imageBase64: "abcd" }],
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true })));
+
+    initOcrBridge();
+    await vi.advanceTimersByTimeAsync(1200);
+
+    expect(fetchMock).toHaveBeenNthCalledWith(2, "/api/vision/ocr-result", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        requestId: "ocr-2",
+        error: "missing traineddata",
+      }),
+    });
+  });
+});

--- a/packages/ui/src/state/ocr-bridge.ts
+++ b/packages/ui/src/state/ocr-bridge.ts
@@ -1,0 +1,101 @@
+import { Capacitor } from "@capacitor/core";
+import { getTesseractPlugin } from "../bridge/native-plugins";
+
+const POLL_INTERVAL_MS = 1200;
+
+interface OcrRequest {
+  requestId: string;
+  createdAt: number;
+  imageBase64: string;
+  psm?: number;
+}
+
+let started = false;
+let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+function stopPolling(): void {
+  if (pollTimer) {
+    clearInterval(pollTimer);
+    pollTimer = null;
+  }
+  started = false;
+}
+
+function isNativeMobile(): boolean {
+  try {
+    const platform = Capacitor.getPlatform();
+    return platform === "android" || platform === "ios";
+  } catch {
+    return false;
+  }
+}
+
+function isOcrRequest(value: unknown): value is OcrRequest {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { requestId?: unknown }).requestId === "string" &&
+    typeof (value as { imageBase64?: unknown }).imageBase64 === "string"
+  );
+}
+
+async function postOcrResult(body: Record<string, unknown>): Promise<void> {
+  await fetch("/api/vision/ocr-result", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function serveRequest(request: OcrRequest): Promise<void> {
+  try {
+    const opts: { image: string; psm?: number } = {
+      image: request.imageBase64,
+    };
+    if (typeof request.psm === "number") opts.psm = request.psm;
+    const plugin = getTesseractPlugin();
+    if (typeof plugin.recognize !== "function") {
+      throw new Error("native OCR plugin unavailable");
+    }
+    const result = await plugin.recognize(opts);
+    await postOcrResult({
+      requestId: request.requestId,
+      words: result.words,
+    });
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    await postOcrResult({ requestId: request.requestId, error: reason }).catch(
+      () => {},
+    );
+  }
+}
+
+async function poll(): Promise<void> {
+  let requests: OcrRequest[];
+  try {
+    const res = await fetch("/api/vision/ocr-requests");
+    if (!res.ok) return;
+    const data = (await res.json()) as { requests?: unknown };
+    const list = Array.isArray(data.requests) ? data.requests : [];
+    requests = list.filter(isOcrRequest);
+  } catch {
+    return;
+  }
+
+  for (const request of requests) {
+    await serveRequest(request);
+  }
+}
+
+export function initOcrBridge(): void {
+  if (started) return;
+  if (!isNativeMobile()) return;
+  started = true;
+  pollTimer = setInterval(() => {
+    void poll();
+  }, POLL_INTERVAL_MS);
+}
+
+export function __resetOcrBridgeForTests(): void {
+  stopPolling();
+}

--- a/plugins/plugin-native-mlkit-text/AGENTS.md
+++ b/plugins/plugin-native-mlkit-text/AGENTS.md
@@ -1,0 +1,55 @@
+# @elizaos/capacitor-mlkit-text
+
+Capacitor plugin for on-device OCR text recognition through Android ML Kit.
+
+## Purpose / Role
+
+This is a Capacitor plugin, not an elizaOS runtime plugin. It exposes a
+`Tesseract`-compatible JavaScript surface (`recognize({ image, psm? })`) so the
+renderer-pulled OCR bridge in `@elizaos/plugin-vision` can run native Android OCR
+without bundling Tesseract binaries.
+
+The package intentionally avoids checked-in model/native binaries. Android uses
+Google ML Kit's text-recognition dependency; web rejects with a clear
+unsupported error.
+
+## Layout
+
+```
+src/
+  definitions.ts   JS contract and word shape
+  index.ts         registerPlugin("Tesseract")
+  web.ts           unsupported web fallback
+android/
+  build.gradle
+  src/main/AndroidManifest.xml
+  src/main/java/ai/eliza/plugins/mlkittext/
+    MlKitTextPlugin.kt   Capacitor surface (base64 decode + JS bridge)
+    MlKitTextReader.kt   Engine wrapper: ML Kit recognizer + word mapping
+  src/androidTest/java/ai/eliza/plugins/mlkittext/
+    MlKitTextReaderInstrumentedTest.kt   On-device OCR of a rendered bitmap
+```
+
+## Commands
+
+Run from repo root:
+
+```bash
+bun run --cwd plugins/plugin-native-mlkit-text build
+bun run --cwd plugins/plugin-native-mlkit-text test
+```
+
+On-device instrumented test (from `packages/app-core/platforms/android`, with a
+device/emulator attached — pin one with `ANDROID_SERIAL=<serial>`):
+
+```bash
+./gradlew :elizaos-capacitor-mlkit-text:connectedDebugAndroidTest
+```
+
+## Gotchas
+
+- Keep the plugin name as `Tesseract` for compatibility with the existing UI
+  bridge lookup and the stale #9649 branch's renderer contract.
+- Do not add committed OCR model binaries to this package. If Android OCR needs a
+  downloadable model in the future, stage it through the normal artifact path and
+  document the proof.

--- a/plugins/plugin-native-mlkit-text/CLAUDE.md
+++ b/plugins/plugin-native-mlkit-text/CLAUDE.md
@@ -1,0 +1,55 @@
+# @elizaos/capacitor-mlkit-text
+
+Capacitor plugin for on-device OCR text recognition through Android ML Kit.
+
+## Purpose / Role
+
+This is a Capacitor plugin, not an elizaOS runtime plugin. It exposes a
+`Tesseract`-compatible JavaScript surface (`recognize({ image, psm? })`) so the
+renderer-pulled OCR bridge in `@elizaos/plugin-vision` can run native Android OCR
+without bundling Tesseract binaries.
+
+The package intentionally avoids checked-in model/native binaries. Android uses
+Google ML Kit's text-recognition dependency; web rejects with a clear
+unsupported error.
+
+## Layout
+
+```
+src/
+  definitions.ts   JS contract and word shape
+  index.ts         registerPlugin("Tesseract")
+  web.ts           unsupported web fallback
+android/
+  build.gradle
+  src/main/AndroidManifest.xml
+  src/main/java/ai/eliza/plugins/mlkittext/
+    MlKitTextPlugin.kt   Capacitor surface (base64 decode + JS bridge)
+    MlKitTextReader.kt   Engine wrapper: ML Kit recognizer + word mapping
+  src/androidTest/java/ai/eliza/plugins/mlkittext/
+    MlKitTextReaderInstrumentedTest.kt   On-device OCR of a rendered bitmap
+```
+
+## Commands
+
+Run from repo root:
+
+```bash
+bun run --cwd plugins/plugin-native-mlkit-text build
+bun run --cwd plugins/plugin-native-mlkit-text test
+```
+
+On-device instrumented test (from `packages/app-core/platforms/android`, with a
+device/emulator attached — pin one with `ANDROID_SERIAL=<serial>`):
+
+```bash
+./gradlew :elizaos-capacitor-mlkit-text:connectedDebugAndroidTest
+```
+
+## Gotchas
+
+- Keep the plugin name as `Tesseract` for compatibility with the existing UI
+  bridge lookup and the stale #9649 branch's renderer contract.
+- Do not add committed OCR model binaries to this package. If Android OCR needs a
+  downloadable model in the future, stage it through the normal artifact path and
+  document the proof.

--- a/plugins/plugin-native-mlkit-text/README.md
+++ b/plugins/plugin-native-mlkit-text/README.md
@@ -1,0 +1,10 @@
+# @elizaos/capacitor-mlkit-text
+
+Android ML Kit text recognition plugin for elizaOS.
+
+Exports a Capacitor plugin named `Tesseract` with a Tesseract-compatible
+`recognize({ image })` method. `image` is a base64-encoded PNG/JPEG/WebP. The
+result is `{ words }`, where each word has `text`, `left`, `top`, `width`,
+`height`, `confidence`, `block`, `par`, and `line` fields.
+
+This package does not commit OCR model binaries.

--- a/plugins/plugin-native-mlkit-text/android/build.gradle
+++ b/plugins/plugin-native-mlkit-text/android/build.gradle
@@ -1,0 +1,46 @@
+ext {
+    junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
+    androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.7.0'
+    androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.5'
+    androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.5.1'
+}
+
+apply plugin: 'com.android.library'
+apply plugin: 'org.jetbrains.kotlin.android'
+
+android {
+    namespace "ai.eliza.plugins.mlkittext"
+    compileSdk project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 36
+
+    defaultConfig {
+        minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 26
+        targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 36
+        versionCode 1
+        versionName "1.0"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_21
+        targetCompatibility JavaVersion.VERSION_21
+    }
+
+    kotlinOptions {
+        jvmTarget = "21"
+    }
+}
+
+repositories {
+    google()
+    mavenCentral()
+}
+
+dependencies {
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
+    implementation project(':capacitor-android')
+    implementation "com.google.mlkit:text-recognition:16.0.1"
+    testImplementation "junit:junit:$junitVersion"
+    androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
+    androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
+}

--- a/plugins/plugin-native-mlkit-text/android/src/androidTest/java/ai/eliza/plugins/mlkittext/MlKitTextReaderInstrumentedTest.kt
+++ b/plugins/plugin-native-mlkit-text/android/src/androidTest/java/ai/eliza/plugins/mlkittext/MlKitTextReaderInstrumentedTest.kt
@@ -1,0 +1,108 @@
+package ai.eliza.plugins.mlkittext
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Typeface
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * On-device instrumented test for ML Kit text recognition (issue #11001).
+ *
+ * Renders a known string into a bitmap, runs the real ML Kit Text Recognition
+ * v2 engine through [MlKitTextReader] — the exact class the Capacitor plugin
+ * ships — and asserts real text plus sane bounding boxes come back. Mirrors
+ * the #9453 `connectedDebugAndroidTest` evidence pattern.
+ *
+ * Run: `./gradlew :elizaos-capacitor-mlkit-text:connectedDebugAndroidTest`
+ */
+@RunWith(AndroidJUnit4::class)
+class MlKitTextReaderInstrumentedTest {
+
+    private fun renderTextBitmap(lines: List<String>): Bitmap {
+        val bitmap = Bitmap.createBitmap(900, 160 + lines.size * 120, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+        canvas.drawColor(Color.WHITE)
+        val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = Color.BLACK
+            textSize = 84f
+            typeface = Typeface.create(Typeface.SANS_SERIF, Typeface.BOLD)
+        }
+        lines.forEachIndexed { index, line ->
+            canvas.drawText(line, 48f, 140f + index * 120f, paint)
+        }
+        return bitmap
+    }
+
+    private fun recognizeBlocking(bitmap: Bitmap): List<OcrWord> {
+        val latch = CountDownLatch(1)
+        var words: List<OcrWord>? = null
+        var failure: Exception? = null
+        MlKitTextReader().recognize(
+            bitmap,
+            onSuccess = { result ->
+                words = result
+                latch.countDown()
+            },
+            onFailure = { error ->
+                failure = error
+                latch.countDown()
+            },
+        )
+        assertTrue("recognition completes within 60s", latch.await(60, TimeUnit.SECONDS))
+        failure?.let { throw AssertionError("ML Kit recognition failed: ${it.message}", it) }
+        return requireNotNull(words)
+    }
+
+    @Test
+    fun recognize_returnsRealTextAndBoxes() {
+        val bitmap = renderTextBitmap(listOf("HELLO ELIZA 42", "OCR BRIDGE"))
+        val words = recognizeBlocking(bitmap)
+
+        assertTrue("recognizer returns words", words.isNotEmpty())
+        val joined = words.joinToString(" ") { it.text.uppercase() }
+        assertTrue("'$joined' contains HELLO", joined.contains("HELLO"))
+        assertTrue("'$joined' contains ELIZA", joined.contains("ELIZA"))
+        assertTrue("'$joined' contains 42", joined.contains("42"))
+        assertTrue("'$joined' contains BRIDGE", joined.contains("BRIDGE"))
+
+        for (word in words) {
+            assertTrue("word '${word.text}' has positive box", word.width > 0 && word.height > 0)
+            assertTrue("word '${word.text}' box inside bitmap", word.left >= 0 && word.top >= 0)
+            assertTrue(
+                "word '${word.text}' right edge inside bitmap",
+                word.left + word.width <= bitmap.width,
+            )
+            assertTrue(
+                "word '${word.text}' bottom edge inside bitmap",
+                word.top + word.height <= bitmap.height,
+            )
+            assertTrue("word '${word.text}' confidence sane", word.confidence in 0..100)
+        }
+
+        // The two rendered lines must land in different block/line groups so the
+        // bridge's block/par/line grouping (mapOcrWordsToResult) stays meaningful.
+        val groupKeys = words.map { "${it.block}/${it.par}/${it.line}" }.toSet()
+        assertTrue("two rendered lines produce >= 2 groups, got $groupKeys", groupKeys.size >= 2)
+
+        // Words on the first rendered line must sit above words on the second.
+        val helloTop = words.first { it.text.uppercase().contains("HELLO") }.top
+        val bridgeTop = words.first { it.text.uppercase().contains("BRIDGE") }.top
+        assertTrue("HELLO ($helloTop) renders above BRIDGE ($bridgeTop)", helloTop < bridgeTop)
+    }
+
+    @Test
+    fun recognize_blankImageReturnsNoWords() {
+        val blank = Bitmap.createBitmap(400, 200, Bitmap.Config.ARGB_8888).apply {
+            Canvas(this).drawColor(Color.WHITE)
+        }
+        val words = recognizeBlocking(blank)
+        assertTrue("blank image yields no words, got $words", words.isEmpty())
+    }
+}

--- a/plugins/plugin-native-mlkit-text/android/src/main/AndroidManifest.xml
+++ b/plugins/plugin-native-mlkit-text/android/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/plugins/plugin-native-mlkit-text/android/src/main/java/ai/eliza/plugins/mlkittext/MlKitTextPlugin.kt
+++ b/plugins/plugin-native-mlkit-text/android/src/main/java/ai/eliza/plugins/mlkittext/MlKitTextPlugin.kt
@@ -1,0 +1,70 @@
+package ai.eliza.plugins.mlkittext
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.util.Base64
+import com.getcapacitor.JSArray
+import com.getcapacitor.JSObject
+import com.getcapacitor.Plugin
+import com.getcapacitor.PluginCall
+import com.getcapacitor.PluginMethod
+import com.getcapacitor.annotation.CapacitorPlugin
+
+@CapacitorPlugin(name = "Tesseract")
+class MlKitTextPlugin : Plugin() {
+    private val reader = MlKitTextReader()
+
+    @PluginMethod
+    fun recognize(call: PluginCall) {
+        val imageBase64 = call.getString("image")
+        if (imageBase64.isNullOrBlank()) {
+            call.reject("image is required")
+            return
+        }
+
+        val bitmap = try {
+            decodeBitmap(imageBase64)
+        } catch (error: Exception) {
+            call.reject("invalid base64 image: ${error.message}")
+            return
+        }
+
+        reader.recognize(
+            bitmap,
+            onSuccess = { words ->
+                call.resolve(JSObject().apply { put("words", toJsArray(words)) })
+            },
+            onFailure = { error ->
+                call.reject("ML Kit text recognition failed: ${error.message}")
+            },
+        )
+    }
+
+    private fun decodeBitmap(imageBase64: String): Bitmap {
+        val comma = imageBase64.indexOf(',')
+        val payload = if (comma >= 0) imageBase64.substring(comma + 1) else imageBase64
+        val bytes = Base64.decode(payload, Base64.DEFAULT)
+        return BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+            ?: throw IllegalArgumentException("decoded image is not a bitmap")
+    }
+
+    private fun toJsArray(words: List<OcrWord>): JSArray {
+        val array = JSArray()
+        for (word in words) {
+            array.put(
+                JSObject().apply {
+                    put("text", word.text)
+                    put("left", word.left)
+                    put("top", word.top)
+                    put("width", word.width)
+                    put("height", word.height)
+                    put("confidence", word.confidence)
+                    put("block", word.block)
+                    put("par", word.par)
+                    put("line", word.line)
+                },
+            )
+        }
+        return array
+    }
+}

--- a/plugins/plugin-native-mlkit-text/android/src/main/java/ai/eliza/plugins/mlkittext/MlKitTextReader.kt
+++ b/plugins/plugin-native-mlkit-text/android/src/main/java/ai/eliza/plugins/mlkittext/MlKitTextReader.kt
@@ -1,0 +1,69 @@
+package ai.eliza.plugins.mlkittext
+
+import android.graphics.Bitmap
+import android.graphics.Rect
+import com.google.mlkit.vision.common.InputImage
+import com.google.mlkit.vision.text.Text
+import com.google.mlkit.vision.text.TextRecognition
+import com.google.mlkit.vision.text.latin.TextRecognizerOptions
+
+data class OcrWord(
+    val text: String,
+    val left: Int,
+    val top: Int,
+    val width: Int,
+    val height: Int,
+    val confidence: Int,
+    val block: Int,
+    val par: Int,
+    val line: Int,
+)
+
+/**
+ * Engine wrapper around ML Kit Text Recognition v2 shared by the Capacitor
+ * plugin and the instrumented test (issue #11001): one recognizer, one
+ * word mapping, so the tested path is exactly the shipped path.
+ */
+class MlKitTextReader {
+    private val recognizer by lazy {
+        TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
+    }
+
+    fun recognize(
+        bitmap: Bitmap,
+        onSuccess: (List<OcrWord>) -> Unit,
+        onFailure: (Exception) -> Unit,
+    ) {
+        recognizer.process(InputImage.fromBitmap(bitmap, 0))
+            .addOnSuccessListener { text -> onSuccess(mapWords(text)) }
+            .addOnFailureListener(onFailure)
+    }
+
+    private fun mapWords(text: Text): List<OcrWord> {
+        val words = mutableListOf<OcrWord>()
+        text.textBlocks.forEachIndexed { blockIndex, block ->
+            block.lines.forEachIndexed { lineIndex, line ->
+                line.elements.forEach { element ->
+                    val box = element.boundingBox ?: Rect()
+                    words.add(
+                        OcrWord(
+                            text = element.text,
+                            left = box.left,
+                            top = box.top,
+                            width = box.width(),
+                            height = box.height(),
+                            // ML Kit's Latin recognizer does not expose a
+                            // per-element confidence; the bridge contract
+                            // requires one, so report full confidence.
+                            confidence = 100,
+                            block = blockIndex,
+                            par = 0,
+                            line = lineIndex,
+                        ),
+                    )
+                }
+            }
+        }
+        return words
+    }
+}

--- a/plugins/plugin-native-mlkit-text/package.json
+++ b/plugins/plugin-native-mlkit-text/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@elizaos/capacitor-mlkit-text",
+  "version": "2.0.3-beta.7",
+  "description": "Android ML Kit text recognition Capacitor plugin for elizaOS OCR.",
+  "keywords": [
+    "ocr",
+    "mlkit",
+    "android",
+    "capacitor"
+  ],
+  "main": "./dist/plugin.cjs.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/esm/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/esm/index.d.ts",
+      "bun": "./src/index.ts",
+      "development": "./src/index.ts",
+      "import": "./dist/esm/index.js",
+      "require": "./dist/plugin.cjs.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "unpkg": "dist/plugin.js",
+  "files": [
+    "android/src/main/",
+    "android/build.gradle",
+    "dist/"
+  ],
+  "author": "elizaOS",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/elizaOS/eliza"
+  },
+  "scripts": {
+    "build": "node ../../packages/scripts/with-package-build-lock.mjs plugins/plugin-native-mlkit-text -- bun run build:unlocked",
+    "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist",
+    "test": "vitest run",
+    "prepublishOnly": "bun run build",
+    "watch": "tsc --watch",
+    "build:unlocked": "bun run clean && tsc && bunx rollup -c rollup.config.mjs"
+  },
+  "devDependencies": {
+    "@capacitor/core": "^8.3.1",
+    "rollup": "^4.60.2",
+    "typescript": "^6.0.3",
+    "vitest": "^4.0.0"
+  },
+  "peerDependencies": {
+    "@capacitor/core": "^8.3.1"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "capacitor": {
+    "android": {
+      "src": "android"
+    }
+  },
+  "elizaos": {
+    "platforms": [
+      "android"
+    ],
+    "runtime": "browser",
+    "platformDetails": {
+      "android": true
+    }
+  }
+}

--- a/plugins/plugin-native-mlkit-text/rollup.config.mjs
+++ b/plugins/plugin-native-mlkit-text/rollup.config.mjs
@@ -1,0 +1,22 @@
+export default {
+  input: "dist/esm/index.js",
+  output: [
+    {
+      file: "dist/plugin.js",
+      format: "iife",
+      name: "capacitorMlKitText",
+      globals: {
+        "@capacitor/core": "capacitorExports",
+      },
+      sourcemap: true,
+      inlineDynamicImports: true,
+    },
+    {
+      file: "dist/plugin.cjs.js",
+      format: "cjs",
+      sourcemap: true,
+      inlineDynamicImports: true,
+    },
+  ],
+  external: ["@capacitor/core"],
+};

--- a/plugins/plugin-native-mlkit-text/src/definitions.ts
+++ b/plugins/plugin-native-mlkit-text/src/definitions.ts
@@ -1,0 +1,24 @@
+export interface MlKitTextWord {
+  text: string;
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+  confidence: number;
+  block: number;
+  par: number;
+  line: number;
+}
+
+export interface RecognizeOptions {
+  image: string;
+  psm?: number;
+}
+
+export interface RecognizeResult {
+  words: MlKitTextWord[];
+}
+
+export interface MlKitTextPlugin {
+  recognize(options: RecognizeOptions): Promise<RecognizeResult>;
+}

--- a/plugins/plugin-native-mlkit-text/src/index.ts
+++ b/plugins/plugin-native-mlkit-text/src/index.ts
@@ -1,0 +1,12 @@
+import { registerPlugin } from "@capacitor/core";
+
+import type { MlKitTextPlugin } from "./definitions";
+
+export * from "./definitions";
+
+const loadWeb = () =>
+  import("./web").then((module) => new module.MlKitTextWeb());
+
+export const Tesseract = registerPlugin<MlKitTextPlugin>("Tesseract", {
+  web: loadWeb,
+});

--- a/plugins/plugin-native-mlkit-text/src/web.test.ts
+++ b/plugins/plugin-native-mlkit-text/src/web.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { MlKitTextWeb } from "./web";
+
+describe("MlKitTextWeb", () => {
+  it("fails clearly outside Android", async () => {
+    const plugin = new MlKitTextWeb();
+    await expect(plugin.recognize({ image: "abcd" })).rejects.toThrow(
+      "only available on Android",
+    );
+  });
+});

--- a/plugins/plugin-native-mlkit-text/src/web.ts
+++ b/plugins/plugin-native-mlkit-text/src/web.ts
@@ -1,0 +1,13 @@
+import { WebPlugin } from "@capacitor/core";
+
+import type {
+  MlKitTextPlugin,
+  RecognizeOptions,
+  RecognizeResult,
+} from "./definitions";
+
+export class MlKitTextWeb extends WebPlugin implements MlKitTextPlugin {
+  async recognize(_options: RecognizeOptions): Promise<RecognizeResult> {
+    throw new Error("ML Kit text recognition is only available on Android");
+  }
+}

--- a/plugins/plugin-native-mlkit-text/tsconfig.json
+++ b/plugins/plugin-native-mlkit-text/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2020", "DOM"],
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist/esm",
+    "rootDir": "src",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/plugins/plugin-vision/src/index.ts
+++ b/plugins/plugin-vision/src/index.ts
@@ -1,7 +1,13 @@
 import type { Plugin } from "@elizaos/core";
-import { logger, promoteSubactionsToActions } from "@elizaos/core";
+import {
+  isAndroidMobile,
+  logger,
+  promoteSubactionsToActions,
+} from "@elizaos/core";
 import { visionAction } from "./action";
 import { wireComputerUseOcrBridge } from "./computeruse-ocr-bridge";
+import { OcrBridgeService } from "./ocr-bridge";
+import { AndroidBridgeOcrService } from "./ocr-service-android-bridge";
 import { LinuxTesseractOcrService } from "./ocr-service-linux-tesseract";
 import { PaddleOcrService } from "./ocr-service-paddleocr";
 import { WindowsMediaOcrService } from "./ocr-service-windows";
@@ -26,7 +32,7 @@ export const visionPlugin: Plugin = {
   name: "vision",
   description:
     "Provides visual perception through camera integration and scene analysis",
-  services: [VisionService, ScreenCaptureBridgeService],
+  services: [VisionService, ScreenCaptureBridgeService, OcrBridgeService],
   providers: [visionProvider],
   routes: visionRoutes,
   actions: [...promoteSubactionsToActions(visionAction)],
@@ -65,7 +71,9 @@ export const visionPlugin: Plugin = {
       // NPU-accelerated): Windows.Media.Ocr on Windows; the classic tesseract
       // CLI on Linux when installed; otherwise the docTR / Apple-Vision chain.
       // Native providers can override via registerOcrWithCoordsService later.
-      if (PaddleOcrService.isAvailable()) {
+      if (isAndroidMobile() && _runtime) {
+        registerOcrWithCoordsService(new AndroidBridgeOcrService(_runtime));
+      } else if (PaddleOcrService.isAvailable()) {
         // Opt-in alternate engine (#9581): ELIZA_VISION_OCR_BACKEND=paddleocr.
         // Cross-platform; only selected when explicitly requested so it never
         // displaces a verified default provider.

--- a/plugins/plugin-vision/src/ocr-bridge.test.ts
+++ b/plugins/plugin-vision/src/ocr-bridge.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { OcrBridgeService, type OcrBridgeWord } from "./ocr-bridge.js";
+
+function makeBridge(timeoutMs = 20_000): OcrBridgeService {
+  return new OcrBridgeService(undefined, timeoutMs);
+}
+
+const SAMPLE_PNG = new Uint8Array([1, 2, 3, 4]);
+
+const WORD: OcrBridgeWord = {
+  text: "Save",
+  left: 10,
+  top: 20,
+  width: 40,
+  height: 16,
+  confidence: 90,
+  block: 1,
+  par: 1,
+  line: 1,
+};
+
+describe("OcrBridgeService", () => {
+  it("enqueues an OCR request and drains it once", () => {
+    const bridge = makeBridge();
+    void bridge.requestOcr(SAMPLE_PNG, 11);
+
+    const drained = bridge.takeRequests();
+    expect(drained).toHaveLength(1);
+    expect(drained[0].imageBase64).toBe(
+      Buffer.from(SAMPLE_PNG).toString("base64"),
+    );
+    expect(drained[0].psm).toBe(11);
+    expect(typeof drained[0].requestId).toBe("string");
+    expect(typeof drained[0].createdAt).toBe("number");
+    expect(bridge.takeRequests()).toHaveLength(0);
+  });
+
+  it("submitResult resolves the matching pending promise", async () => {
+    const bridge = makeBridge();
+    const wordsPromise = bridge.requestOcr(SAMPLE_PNG);
+    const [request] = bridge.takeRequests();
+
+    expect(bridge.submitResult(request.requestId, [WORD])).toBe(true);
+    expect(await wordsPromise).toEqual([WORD]);
+  });
+
+  it("rejects unknown or already-consumed request ids", async () => {
+    const bridge = makeBridge();
+    const wordsPromise = bridge.requestOcr(SAMPLE_PNG);
+    const [request] = bridge.takeRequests();
+
+    expect(bridge.submitResult("missing", [WORD])).toBe(false);
+    expect(bridge.submitResult(request.requestId, [WORD])).toBe(true);
+    await wordsPromise;
+    expect(bridge.submitResult(request.requestId, [WORD])).toBe(false);
+  });
+
+  it("failRequest resolves the pending promise as null", async () => {
+    const bridge = makeBridge();
+    const wordsPromise = bridge.requestOcr(SAMPLE_PNG);
+    const [request] = bridge.takeRequests();
+
+    expect(bridge.failRequest(request.requestId, "native_unavailable")).toBe(
+      true,
+    );
+    expect(await wordsPromise).toBeNull();
+    expect(bridge.failRequest(request.requestId, "again")).toBe(false);
+  });
+
+  it("resolves null when the renderer never responds", async () => {
+    const bridge = makeBridge(5);
+    await expect(bridge.requestOcr(SAMPLE_PNG)).resolves.toBeNull();
+  });
+
+  it("stop clears queued and pending requests", async () => {
+    const bridge = makeBridge();
+    const first = bridge.requestOcr(SAMPLE_PNG);
+    const second = bridge.requestOcr(SAMPLE_PNG);
+    void bridge.requestOcr(SAMPLE_PNG);
+
+    await bridge.stop();
+
+    await expect(first).resolves.toBeNull();
+    await expect(second).resolves.toBeNull();
+    expect(bridge.takeRequests()).toHaveLength(0);
+  });
+});

--- a/plugins/plugin-vision/src/ocr-bridge.ts
+++ b/plugins/plugin-vision/src/ocr-bridge.ts
@@ -1,0 +1,108 @@
+import { type IAgentRuntime, logger, Service } from "@elizaos/core";
+
+export const OCR_BRIDGE_SERVICE_TYPE = "vision-ocr-bridge";
+
+const REQUEST_OCR_TIMEOUT_MS = 20_000;
+
+export interface OcrBridgeWord {
+  text: string;
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+  confidence: number;
+  block: number;
+  par: number;
+  line: number;
+}
+
+export interface OcrRequest {
+  requestId: string;
+  createdAt: number;
+  imageBase64: string;
+  psm?: number;
+}
+
+interface PendingOcr {
+  resolve: (words: OcrBridgeWord[] | null) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+export class OcrBridgeService extends Service {
+  static override serviceType: string = OCR_BRIDGE_SERVICE_TYPE;
+  override capabilityDescription =
+    "Renderer-pulled bridge for agent-triggered on-device OCR.";
+
+  private readonly queue: OcrRequest[] = [];
+  private readonly pending = new Map<string, PendingOcr>();
+  private readonly timeoutMs: number;
+
+  constructor(runtime?: IAgentRuntime, timeoutMs = REQUEST_OCR_TIMEOUT_MS) {
+    super(runtime);
+    this.timeoutMs = timeoutMs;
+  }
+
+  static async start(runtime: IAgentRuntime): Promise<OcrBridgeService> {
+    return new OcrBridgeService(runtime);
+  }
+
+  requestOcr(
+    pngBytes: Uint8Array,
+    psm?: number,
+  ): Promise<OcrBridgeWord[] | null> {
+    const requestId = crypto.randomUUID();
+    const request: OcrRequest = {
+      requestId,
+      createdAt: Date.now(),
+      imageBase64: Buffer.from(pngBytes).toString("base64"),
+    };
+    if (typeof psm === "number") request.psm = psm;
+    this.queue.push(request);
+
+    return new Promise<OcrBridgeWord[] | null>((resolve) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(requestId);
+        logger.debug(
+          `[OcrBridgeService] OCR request ${requestId} timed out after ${this.timeoutMs}ms`,
+        );
+        resolve(null);
+      }, this.timeoutMs);
+      if (typeof timer.unref === "function") timer.unref();
+      this.pending.set(requestId, { resolve, timer });
+    });
+  }
+
+  takeRequests(): OcrRequest[] {
+    return this.queue.splice(0, this.queue.length);
+  }
+
+  submitResult(requestId: string, words: OcrBridgeWord[]): boolean {
+    const pendingOcr = this.pending.get(requestId);
+    if (!pendingOcr) return false;
+    this.pending.delete(requestId);
+    clearTimeout(pendingOcr.timer);
+    pendingOcr.resolve(words);
+    return true;
+  }
+
+  failRequest(requestId: string, reason: string): boolean {
+    const pendingOcr = this.pending.get(requestId);
+    if (!pendingOcr) return false;
+    this.pending.delete(requestId);
+    clearTimeout(pendingOcr.timer);
+    logger.debug(
+      `[OcrBridgeService] OCR request ${requestId} failed: ${reason}`,
+    );
+    pendingOcr.resolve(null);
+    return true;
+  }
+
+  async stop(): Promise<void> {
+    this.queue.length = 0;
+    for (const [requestId, pendingOcr] of this.pending) {
+      clearTimeout(pendingOcr.timer);
+      pendingOcr.resolve(null);
+      this.pending.delete(requestId);
+    }
+  }
+}

--- a/plugins/plugin-vision/src/ocr-service-android-bridge.test.ts
+++ b/plugins/plugin-vision/src/ocr-service-android-bridge.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import type { OcrBridgeWord } from "./ocr-bridge.js";
+import { mapOcrWordsToResult } from "./ocr-service-android-bridge.js";
+
+function word(
+  overrides: Partial<OcrBridgeWord> & { text: string },
+): OcrBridgeWord {
+  return {
+    left: 0,
+    top: 0,
+    width: 10,
+    height: 10,
+    confidence: 90,
+    block: 0,
+    par: 0,
+    line: 0,
+    ...overrides,
+  };
+}
+
+describe("mapOcrWordsToResult", () => {
+  it("groups native words by block/paragraph/line and shifts to display coords", () => {
+    const result = mapOcrWordsToResult(
+      [
+        word({
+          text: "Save",
+          left: 10,
+          top: 20,
+          width: 40,
+          height: 16,
+          block: 1,
+          par: 1,
+          line: 1,
+        }),
+        word({
+          text: "File",
+          left: 60,
+          top: 20,
+          width: 36,
+          height: 16,
+          block: 1,
+          par: 1,
+          line: 1,
+        }),
+        word({
+          text: "Cancel",
+          left: 10,
+          top: 44,
+          width: 52,
+          height: 16,
+          block: 1,
+          par: 1,
+          line: 2,
+        }),
+      ],
+      200,
+      60,
+      100,
+      200,
+    );
+
+    expect(result.blocks).toHaveLength(2);
+    expect(result.blocks[0].text).toBe("Save File");
+    expect(result.blocks[0].bbox).toEqual({
+      x: 110,
+      y: 220,
+      width: 86,
+      height: 16,
+    });
+    expect(result.blocks[0].words.map((item) => item.text)).toEqual([
+      "Save",
+      "File",
+    ]);
+    expect(result.blocks[1].text).toBe("Cancel");
+    expect(result.blocks[1].bbox).toEqual({
+      x: 110,
+      y: 244,
+      width: 52,
+      height: 16,
+    });
+  });
+
+  it("keeps identical line numbers in different blocks or paragraphs separate", () => {
+    const result = mapOcrWordsToResult(
+      [
+        word({ text: "A", block: 0, par: 0, line: 0 }),
+        word({ text: "B", block: 0, par: 1, line: 0 }),
+        word({ text: "C", block: 1, par: 0, line: 0 }),
+      ],
+      100,
+      100,
+      0,
+      0,
+    );
+
+    expect(result.blocks.map((block) => block.text)).toEqual(["A", "B", "C"]);
+  });
+
+  it("skips blank words and tolerates zero tile dimensions", () => {
+    const result = mapOcrWordsToResult(
+      [word({ text: "  " }), word({ text: "x", left: 5 })],
+      0,
+      0,
+      0,
+      0,
+    );
+
+    expect(result.blocks).toHaveLength(1);
+    expect(result.blocks[0].text).toBe("x");
+    expect(result.blocks[0].semantic_position).toBeDefined();
+  });
+});

--- a/plugins/plugin-vision/src/ocr-service-android-bridge.ts
+++ b/plugins/plugin-vision/src/ocr-service-android-bridge.ts
@@ -1,0 +1,162 @@
+import { type IAgentRuntime, logger } from "@elizaos/core";
+import {
+  OCR_BRIDGE_SERVICE_TYPE,
+  type OcrBridgeService,
+  type OcrBridgeWord,
+} from "./ocr-bridge.js";
+import {
+  computeSemanticPosition,
+  type OcrWithCoordsBlock,
+  type OcrWithCoordsInput,
+  type OcrWithCoordsResult,
+  type OcrWithCoordsService,
+  type OcrWithCoordsWord,
+} from "./ocr-with-coords.js";
+import type { BoundingBox } from "./types.js";
+
+function readPngDimensions(png: Uint8Array): { width: number; height: number } {
+  if (png.byteLength < 24) return { width: 0, height: 0 };
+  const view = new DataView(png.buffer, png.byteOffset, png.byteLength);
+  return {
+    width: view.getUint32(16, false),
+    height: view.getUint32(20, false),
+  };
+}
+
+function lineToBlock(
+  words: readonly OcrBridgeWord[],
+  tileWidth: number,
+  tileHeight: number,
+  sourceX: number,
+  sourceY: number,
+): OcrWithCoordsBlock {
+  const mappedWords: OcrWithCoordsWord[] = words.map((word) => {
+    const tileBox: BoundingBox = {
+      x: word.left,
+      y: word.top,
+      width: word.width,
+      height: word.height,
+    };
+    return {
+      text: word.text,
+      bbox: {
+        x: word.left + sourceX,
+        y: word.top + sourceY,
+        width: word.width,
+        height: word.height,
+      },
+      semantic_position: computeSemanticPosition({
+        bbox: tileBox,
+        tileWidth,
+        tileHeight,
+      }),
+    };
+  });
+
+  let minX = Number.POSITIVE_INFINITY;
+  let minY = Number.POSITIVE_INFINITY;
+  let maxX = Number.NEGATIVE_INFINITY;
+  let maxY = Number.NEGATIVE_INFINITY;
+  for (const word of words) {
+    minX = Math.min(minX, word.left);
+    minY = Math.min(minY, word.top);
+    maxX = Math.max(maxX, word.left + word.width);
+    maxY = Math.max(maxY, word.top + word.height);
+  }
+  if (!Number.isFinite(minX)) {
+    minX = 0;
+    minY = 0;
+    maxX = 0;
+    maxY = 0;
+  }
+
+  const tileBlockBox: BoundingBox = {
+    x: minX,
+    y: minY,
+    width: maxX - minX,
+    height: maxY - minY,
+  };
+  return {
+    text: words.map((word) => word.text).join(" "),
+    bbox: {
+      x: minX + sourceX,
+      y: minY + sourceY,
+      width: maxX - minX,
+      height: maxY - minY,
+    },
+    words: mappedWords,
+    semantic_position: computeSemanticPosition({
+      bbox: tileBlockBox,
+      tileWidth,
+      tileHeight,
+    }),
+  };
+}
+
+export function mapOcrWordsToResult(
+  words: readonly OcrBridgeWord[],
+  tileWidth: number,
+  tileHeight: number,
+  sourceX: number,
+  sourceY: number,
+): OcrWithCoordsResult {
+  const safeWidth = tileWidth > 0 ? tileWidth : 1;
+  const safeHeight = tileHeight > 0 ? tileHeight : 1;
+  const order: string[] = [];
+  const groups = new Map<string, OcrBridgeWord[]>();
+  for (const word of words) {
+    if (word.text.trim().length === 0) continue;
+    const key = `${word.block}/${word.par}/${word.line}`;
+    let group = groups.get(key);
+    if (!group) {
+      group = [];
+      groups.set(key, group);
+      order.push(key);
+    }
+    group.push(word);
+  }
+  return {
+    blocks: order.map((key) =>
+      lineToBlock(
+        groups.get(key) as OcrBridgeWord[],
+        safeWidth,
+        safeHeight,
+        sourceX,
+        sourceY,
+      ),
+    ),
+  };
+}
+
+export class AndroidBridgeOcrService implements OcrWithCoordsService {
+  readonly name = "android-ocr-bridge";
+
+  constructor(private readonly runtime: IAgentRuntime) {}
+
+  async describe(input: OcrWithCoordsInput): Promise<OcrWithCoordsResult> {
+    if (input.pngBytes.byteLength === 0) return { blocks: [] };
+    const bridge = this.runtime.getService<OcrBridgeService>(
+      OCR_BRIDGE_SERVICE_TYPE,
+    );
+    if (!bridge) return { blocks: [] };
+    const words = await bridge.requestOcr(input.pngBytes);
+    if (!words || words.length === 0) return { blocks: [] };
+    try {
+      const { width, height } = readPngDimensions(input.pngBytes);
+      return mapOcrWordsToResult(
+        words,
+        width,
+        height,
+        input.sourceX,
+        input.sourceY,
+      );
+    } catch (error) {
+      logger.warn(
+        `[AndroidBridgeOcrService] map failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return { blocks: [] };
+    }
+  }
+}

--- a/plugins/plugin-vision/src/routes.ocr.test.ts
+++ b/plugins/plugin-vision/src/routes.ocr.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { OcrBridgeService, type OcrBridgeWord } from "./ocr-bridge.js";
+import { ocrRequestsRoute, ocrResultRoute } from "./routes.js";
+
+function makeRuntime(bridge: OcrBridgeService | null) {
+  return {
+    getService: () => bridge,
+  };
+}
+
+async function callRoute(
+  route: typeof ocrRequestsRoute,
+  bridge: OcrBridgeService | null,
+  body?: unknown,
+) {
+  return route.routeHandler?.({
+    runtime: makeRuntime(bridge),
+    body,
+  } as never);
+}
+
+function parseBody(result: unknown): unknown {
+  const body = (result as { body?: string }).body;
+  return typeof body === "string" ? JSON.parse(body) : null;
+}
+
+const WORD: OcrBridgeWord = {
+  text: "Save",
+  left: 1,
+  top: 2,
+  width: 3,
+  height: 4,
+  confidence: 90,
+  block: 1,
+  par: 1,
+  line: 1,
+};
+
+describe("OCR bridge routes", () => {
+  it("drains queued OCR requests and accepts recognized words", async () => {
+    const bridge = new OcrBridgeService(undefined, 30_000);
+    const wordsPromise = bridge.requestOcr(new Uint8Array([1, 2, 3]), 11);
+
+    const getResult = await callRoute(ocrRequestsRoute, bridge);
+    const getBody = parseBody(getResult) as {
+      requests: Array<{ requestId: string; imageBase64: string; psm?: number }>;
+    };
+    expect(getBody.requests).toHaveLength(1);
+    expect(getBody.requests[0].imageBase64).toBe(
+      Buffer.from([1, 2, 3]).toString("base64"),
+    );
+    expect(getBody.requests[0].psm).toBe(11);
+
+    const postResult = await callRoute(ocrResultRoute, bridge, {
+      requestId: getBody.requests[0].requestId,
+      words: [WORD, { text: "bad" }],
+    });
+    expect((postResult as { status: number }).status).toBe(200);
+    expect(parseBody(postResult)).toEqual({ ok: true });
+    expect(await wordsPromise).toEqual([WORD]);
+  });
+
+  it("returns empty queue when the bridge service is unavailable", async () => {
+    const result = await callRoute(ocrRequestsRoute, null);
+    expect((result as { status: number }).status).toBe(200);
+    expect(parseBody(result)).toEqual({ requests: [] });
+  });
+
+  it("rejects malformed OCR results", async () => {
+    const bridge = new OcrBridgeService(undefined, 30_000);
+    const result = await callRoute(ocrResultRoute, bridge, { words: [] });
+    expect((result as { status: number }).status).toBe(400);
+    expect(parseBody(result)).toEqual({ ok: false, error: "invalid_body" });
+  });
+
+  it("settles pending OCR requests on renderer error", async () => {
+    const bridge = new OcrBridgeService(undefined, 30_000);
+    const wordsPromise = bridge.requestOcr(new Uint8Array([1]));
+    const [request] = bridge.takeRequests();
+
+    const result = await callRoute(ocrResultRoute, bridge, {
+      requestId: request.requestId,
+      error: "native OCR plugin unavailable",
+    });
+
+    expect((result as { status: number }).status).toBe(200);
+    expect(await wordsPromise).toBeNull();
+  });
+});

--- a/plugins/plugin-vision/src/routes.ts
+++ b/plugins/plugin-vision/src/routes.ts
@@ -7,6 +7,11 @@
 
 import type { Route } from "@elizaos/core";
 import {
+  OCR_BRIDGE_SERVICE_TYPE,
+  type OcrBridgeService,
+  type OcrBridgeWord,
+} from "./ocr-bridge";
+import {
   SCREEN_CAPTURE_BRIDGE_SERVICE_TYPE,
   type ScreenCaptureBridgeService,
 } from "./screen-capture-bridge";
@@ -102,4 +107,80 @@ export const screenFrameRoute: Route = {
   },
 };
 
-export const visionRoutes: Route[] = [captureRequestsRoute, screenFrameRoute];
+function isOcrWord(value: unknown): value is OcrBridgeWord {
+  if (typeof value !== "object" || value === null) return false;
+  const word = value as Record<string, unknown>;
+  return (
+    typeof word.text === "string" &&
+    typeof word.left === "number" &&
+    typeof word.top === "number" &&
+    typeof word.width === "number" &&
+    typeof word.height === "number" &&
+    typeof word.confidence === "number" &&
+    typeof word.block === "number" &&
+    typeof word.par === "number" &&
+    typeof word.line === "number"
+  );
+}
+
+export const ocrRequestsRoute: Route = {
+  type: "GET",
+  path: "/api/vision/ocr-requests",
+  rawPath: true,
+  routeHandler: async (ctx) => {
+    const bridge = ctx.runtime.getService<OcrBridgeService>(
+      OCR_BRIDGE_SERVICE_TYPE,
+    );
+    if (!bridge) return jsonResult(200, { requests: [] });
+    return jsonResult(200, { requests: bridge.takeRequests() });
+  },
+};
+
+export const ocrResultRoute: Route = {
+  type: "POST",
+  path: "/api/vision/ocr-result",
+  rawPath: true,
+  routeHandler: async (ctx) => {
+    const bridge = ctx.runtime.getService<OcrBridgeService>(
+      OCR_BRIDGE_SERVICE_TYPE,
+    );
+    if (!bridge)
+      return jsonResult(404, { ok: false, error: "bridge_unavailable" });
+
+    const body = ctx.body;
+    if (
+      typeof body !== "object" ||
+      body === null ||
+      typeof (body as Record<string, unknown>).requestId !== "string"
+    ) {
+      return jsonResult(400, { ok: false, error: "invalid_body" });
+    }
+    const requestId = (body as Record<string, unknown>).requestId as string;
+
+    if ((body as Record<string, unknown>).error !== undefined) {
+      const failed = bridge.failRequest(
+        requestId,
+        String((body as Record<string, unknown>).error),
+      );
+      return failed
+        ? jsonResult(200, { ok: true })
+        : jsonResult(404, { ok: false, error: "unknown_request" });
+    }
+
+    const rawWords = (body as Record<string, unknown>).words;
+    if (!Array.isArray(rawWords)) {
+      return jsonResult(400, { ok: false, error: "invalid_body" });
+    }
+    const ok = bridge.submitResult(requestId, rawWords.filter(isOcrWord));
+    return ok
+      ? jsonResult(200, { ok: true })
+      : jsonResult(404, { ok: false, error: "unknown_request" });
+  },
+};
+
+export const visionRoutes: Route[] = [
+  captureRequestsRoute,
+  screenFrameRoute,
+  ocrRequestsRoute,
+  ocrResultRoute,
+];


### PR DESCRIPTION
## What

Closes #11001. Lands the engine-agnostic OCR bridge seam (salvaged from `feat/9105-tesseract-ship` per #9649 item 1) **together with** its native answerer, so Android agents get real coordinate-OCR through the same `ocr-with-coords` seam Linux gets from vendored Tesseract (#9453):

- **`@elizaos/capacitor-mlkit-text`** — Capacitor plugin (registered as `Tesseract` for the renderer contract) backed by ML Kit Text Recognition v2. `MlKitTextReader` is the shared engine wrapper (one recognizer + one word mapping) used by both the shipped plugin and the instrumented test, so the tested path is exactly the shipped path.
- **`plugin-vision`** — `OcrBridgeService` (renderer-pulled request queue with timeout), `/api/vision/ocr-requests` + `/api/vision/ocr-result` routes (validated bodies), `AndroidBridgeOcrService` mapping bridge words into display-absolute `OcrWithCoordsResult` (block/par/line grouping + tile offsets + semantic positions); registered as the coord-OCR provider on Android (`isAndroidMobile()`).
- **`packages/ui` + `packages/app`** — renderer poller (`initOcrBridge`) answering bridge requests through the native plugin; mounted on the iOS/Android boot paths next to the existing screen-capture bridge.
- Bridge + answerer land **together** — registering the bridge without a native answerer strands Android OCR requests (the verified failure mode called out in the issue).

**No Tesseract4Android binaries anywhere in the tree** (per the #9105 engine decision record). One deliberate deviation: the plugin uses the **bundled** `com.google.mlkit:text-recognition:16.0.1` (~4 MB in-APK model, on-device, zero network, no Play-Services model download) instead of the unbundled ~260 KB Play-Services artifact the issue mentioned — bundled keeps recognition deterministic on devices/emulators without Google Play. Happy to flip if reviewers prefer the unbundled artifact.

## Evidence (PR_EVIDENCE.md)

| Type | Artifact |
|---|---|
| On-device (real hardware) | `connectedDebugAndroidTest` **PASSED 2/2 on Pixel 6a, Android 16** — `.github/issue-evidence/11001-mlkit-ocr-android/connectedDebugAndroidTest-pixel6a-android16.xml` |
| On-device (emulator) | **PASSED 2/2 on x86_64 AVD, Android 14** — `connectedDebugAndroidTest-emulator-android14.xml` |
| What the instrumented test proves | Real ML Kit engine OCRs a canvas-rendered `HELLO ELIZA 42` / `OCR BRIDGE` bitmap → real text back, every box positive & inside the bitmap, the two rendered lines land in distinct block/line groups (keeps `mapOcrWordsToResult` grouping meaningful), line order correct; blank-image control returns zero words (no hallucination). Mirrors the #9453 evidence pattern. |
| Unit tests | 13 (plugin-vision bridge/mapping/routes) + 2 (ui poller) + 1 (mlkit web fallback) — all green on this branch (develop base) |
| Typecheck | `plugin-vision` `tsgo --noEmit` clean |
| Backend logs | `[OcrBridgeService]` debug logs on timeout/failure paths (exercised in unit tests) |
| Screenshots / video | N/A — headless bridge + native engine; no UI surface changed. The instrumented-test XMLs are the on-device capture per the #9453 precedent. |
| Real-LLM trajectories | N/A — no agent/prompt/model change; provider-level OCR plumbing only. |
| Audio walkthrough | N/A — no voice surface. |

Refs: #11001 (closes), #9649 (salvage item 1 disposition), #9105 / #9453 (engine decision + Linux precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)