### PR TITLE
feat(ui,app,desktop): desktop-native notification entry (#10706) + deferred-items resolution

### DIFF
--- a/packages/app-core/platforms/electrobun/src/application-menu.test.ts
+++ b/packages/app-core/platforms/electrobun/src/application-menu.test.ts
@@ -107,4 +107,25 @@ describe("buildApplicationMenu", () => {
     });
     expect(notReady.some((item) => item.label === "Views")).toBe(true);
   });
+
+  it("exposes a Desktop → Notifications item that opens the notification center (#10706)", () => {
+    const menu = buildApplicationMenu({
+      isMac: true,
+      browserEnabled: true,
+      detachedWindows: noWindows,
+    });
+    const desktop = menu.find((item) => item.label === "Desktop");
+    expect(desktop).toBeDefined();
+    const notifications = desktop?.submenu?.find(
+      (item) => item.label === "Notifications",
+    );
+    expect(notifications).toBeDefined();
+    // Routed to the renderer as `open-notifications`
+    // (DesktopSurfaceNavigationRuntime opens the center in place); distinct from
+    // the "Send Test Notification" native-toast smoke item.
+    expect(notifications?.action).toBe("open-notifications");
+    expect(
+      desktop?.submenu?.some((item) => item.action === "desktop-notify"),
+    ).toBe(true);
+  });
 });

--- a/packages/app-core/platforms/electrobun/src/application-menu.ts
+++ b/packages/app-core/platforms/electrobun/src/application-menu.ts
@@ -271,6 +271,10 @@ function buildDesktopMenu(isMac: boolean): ApplicationMenuItem {
       { label: `Maximize ${appName}`, action: "maximize-main-window" },
       { label: `Restore ${appName} Size`, action: "restore-main-window" },
       { type: "separator" },
+      // The visible native way into the notification center on desktop, where
+      // the floating bell is hidden and the home pull-down is the only other
+      // entry point (#10706). Routed to the renderer as `open-notifications`.
+      { label: "Notifications", action: "open-notifications" },
       { label: "Send Test Notification", action: "desktop-notify" },
       { label: "Restart Agent", action: "restart-agent" },
       { label: `Relaunch ${appName}`, action: "relaunch" },

--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -2092,7 +2092,11 @@ async function setupUpdater(): Promise<void> {
         void getDesktopManager().quit();
         return true;
       }
-      if (action?.startsWith("navigate-")) {
+      if (action?.startsWith("navigate-") || action === "open-notifications") {
+        // `open-notifications` (#10706): the desktop-native "Notifications"
+        // menu/tray item. Reuses the same renderer channel as `navigate-*`;
+        // DesktopSurfaceNavigationRuntime opens the notification center in place
+        // rather than switching tabs.
         void getDesktopManager().showWindow();
         sendToActiveRenderer("desktopTrayMenuClick", { itemId: action });
         return true;

--- a/packages/app-core/src/runtime/desktop/DesktopSurfaceNavigationRuntime.tsx
+++ b/packages/app-core/src/runtime/desktop/DesktopSurfaceNavigationRuntime.tsx
@@ -1,4 +1,5 @@
 import { subscribeDesktopBridgeEvent } from "@elizaos/ui/bridge/electrobun-rpc";
+import { dispatchOpenNotificationCenter } from "@elizaos/ui/events";
 import { useApp } from "@elizaos/ui/state/useApp";
 import { useEffect } from "react";
 import type { Tab } from "../../../../ui/src/navigation";
@@ -21,6 +22,14 @@ export function DesktopSurfaceNavigationRuntime() {
       listener: (payload) => {
         const itemId =
           (payload as { itemId?: string } | null | undefined)?.itemId ?? "";
+        // The desktop-native "Notifications" menu/tray item (#10706): open the
+        // notification center in place instead of navigating a tab — the
+        // visible native way in where the floating bell is hidden.
+        if (itemId === "open-notifications") {
+          switchShellView("desktop");
+          dispatchOpenNotificationCenter();
+          return;
+        }
         let target: Tab | null = null;
         if (itemId.startsWith("show-main:")) {
           const candidate = itemId.slice("show-main:".length) as Tab;

--- a/packages/app/src/deep-link-handler.test.ts
+++ b/packages/app/src/deep-link-handler.test.ts
@@ -70,6 +70,32 @@ describe("createDeepLinkHandler — universal (https) app links", () => {
     expect(window.location.hash).toBe("#connectors");
   });
 
+  it("opens the notification center on a notifications deep link without changing route (#10706)", async () => {
+    const { OPEN_NOTIFICATION_CENTER_EVENT } = await import(
+      "@elizaos/ui/events"
+    );
+    const { handle, dispatchDeepLinkCallback } = makeHandler();
+    let opened = 0;
+    const onOpen = () => {
+      opened += 1;
+    };
+    window.addEventListener(OPEN_NOTIFICATION_CENTER_EVENT, onOpen);
+    try {
+      handle("elizaos://notifications");
+      // In-place open — no route change — and the callback still fires.
+      expect(opened).toBe(1);
+      expect(window.location.hash).toBe("");
+      expect(dispatchDeepLinkCallback).toHaveBeenCalledWith(
+        "elizaos://notifications",
+      );
+      // Same via a universal https app link.
+      handle("https://eliza.app/notifications");
+      expect(opened).toBe(2);
+    } finally {
+      window.removeEventListener(OPEN_NOTIFICATION_CENTER_EVENT, onOpen);
+    }
+  });
+
   it("carries query params through a universal link", () => {
     const { handle } = makeHandler();
     handle("https://eliza.app/messages?to=alice");

--- a/packages/app/src/deep-link-handler.ts
+++ b/packages/app/src/deep-link-handler.ts
@@ -4,7 +4,11 @@
 // first-run redirects. Pure routing logic — share-target persistence and
 // CONNECT event dispatch are injected so the dispatcher stays test-friendly.
 
-import { CONNECT_EVENT, dispatchAppEvent } from "@elizaos/ui/events";
+import {
+  CONNECT_EVENT,
+  dispatchAppEvent,
+  dispatchOpenNotificationCenter,
+} from "@elizaos/ui/events";
 import { routeFirstRunDeepLink } from "@elizaos/ui/first-run/deep-link-handler";
 import type { ShareTargetPayload } from "@elizaos/ui/platform";
 import { applyLaunchConnection } from "@elizaos/ui/platform/browser-launch";
@@ -97,6 +101,13 @@ export function createDeepLinkHandler(ctx: DeepLinkHandlerContext) {
         break;
       case "settings":
         window.location.hash = "#settings";
+        ctx.dispatchDeepLinkCallback(url);
+        break;
+      case "notifications":
+        // Desktop-native entry point (#10706): the "Notifications" menu/tray
+        // item opens the notification center in place (no route change), the
+        // one visible way in where the floating bell is hidden.
+        dispatchOpenNotificationCenter();
         ctx.dispatchDeepLinkCallback(url);
         break;
       case "connect":

--- a/packages/ui/src/components/shell/NotificationCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationCenter.test.tsx
@@ -245,4 +245,30 @@ describe("NotificationCenter", () => {
       "Oldest urgent",
     ]);
   });
+
+  it("headless opens the sheet on OPEN_NOTIFICATION_CENTER_EVENT and closes on backdrop (#10706)", async () => {
+    const { OPEN_NOTIFICATION_CENTER_EVENT } = await import("../../events");
+    seedNotifications([notification("n1", "Payment failed", "system")]);
+    const user = userEvent.setup();
+
+    // The headless instance renders nothing until the surface-agnostic open
+    // event fires (the desktop-native "Notifications" menu/tray + the
+    // <scheme>://notifications deep link dispatch it).
+    render(<NotificationCenter headless />);
+    expect(screen.queryByTestId("notification-sheet")).toBeNull();
+
+    window.dispatchEvent(new CustomEvent(OPEN_NOTIFICATION_CENTER_EVENT));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("notification-sheet")).toBeTruthy();
+    });
+    // The seeded notification is visible in the opened sheet.
+    expect(screen.getByText("Payment failed")).toBeTruthy();
+
+    // Backdrop dismiss closes it again.
+    await user.click(screen.getByTestId("notification-sheet-backdrop"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("notification-sheet")).toBeNull();
+    });
+  });
 });

--- a/packages/ui/src/components/shell/NotificationCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationCenter.tsx
@@ -7,6 +7,7 @@ import {
   useMemo,
   useState,
 } from "react";
+import { OPEN_NOTIFICATION_CENTER_EVENT } from "../../events";
 import { cn } from "../../lib/utils";
 import { useAppSelector } from "../../state";
 import { categoryIcon } from "../../state/notifications/category-icon";
@@ -291,11 +292,39 @@ export function NotificationCenter({
     return () => window.removeEventListener("keydown", onKey);
   }, [variant, open, onOpenChange]);
 
+  // Surface-agnostic open (#10706): the single always-mounted headless instance
+  // listens for OPEN_NOTIFICATION_CENTER_EVENT and reveals the pull-down sheet.
+  // This is how desktop — where the floating bell is hidden — gets a visible
+  // native way in (the "Notifications" menu/tray item and the
+  // `<scheme>://notifications` deep link both dispatch this event). Only the
+  // headless owner listens, so a transient pull-down/bell instance never double-
+  // opens.
+  const [selfOpen, setSelfOpen] = useState(false);
+  useEffect(() => {
+    if (!headless) return;
+    const onOpen = () => setSelfOpen(true);
+    window.addEventListener(OPEN_NOTIFICATION_CENTER_EVENT, onOpen);
+    return () =>
+      window.removeEventListener(OPEN_NOTIFICATION_CENTER_EVENT, onOpen);
+  }, [headless]);
+
   const hasUnread = unreadCount > 0;
 
   // Hidden for now: keep the store + toast routing live (the effect above) but
-  // render no bell. Drop the `headless` prop to bring the button back.
-  if (headless) return null;
+  // render no bell. Drop the `headless` prop to bring the button back. When an
+  // OPEN_NOTIFICATION_CENTER_EVENT has fired, the headless owner renders the
+  // pull-down sheet as a child (one level, variant="sheet" — no recursion).
+  if (headless) {
+    if (!selfOpen) return null;
+    return (
+      <NotificationCenter
+        variant="sheet"
+        open
+        onOpenChange={setSelfOpen}
+        className={className}
+      />
+    );
+  }
 
   const panelBody = (
     <>

--- a/packages/ui/src/events/index.ts
+++ b/packages/ui/src/events/index.ts
@@ -140,6 +140,16 @@ export const TUTORIAL_CHAT_CONTROL_EVENT =
 export const CHAT_PREFILL_EVENT = "eliza:chat:prefill" as const;
 /** Open the keyword message-search panel (fired by the chat search affordance). */
 export const CHAT_MESSAGE_SEARCH_EVENT = "eliza:chat:message-search" as const;
+/**
+ * Open the notification center from anywhere (#10706). On mobile the home
+ * pull-down owns opening the sheet; this window event is the surface-agnostic
+ * entry point the desktop-native "Notifications" menu/tray item + the
+ * `<scheme>://notifications` deep link use, so desktop gets a visible native way
+ * in (the floating bell is hidden there). The single always-mounted headless
+ * NotificationCenter is the one listener.
+ */
+export const OPEN_NOTIFICATION_CENTER_EVENT =
+  "eliza:notifications:open" as const;
 
 export interface TutorialChatControlDetail {
   /**
@@ -175,6 +185,13 @@ export function dispatchTutorialChatControl(
 export function dispatchChatPrefill(detail: ChatPrefillEventDetail): void {
   if (typeof window === "undefined") return;
   window.dispatchEvent(new CustomEvent(CHAT_PREFILL_EVENT, { detail }));
+}
+
+/** Request the notification center to open (surface-agnostic — see
+ * {@link OPEN_NOTIFICATION_CENTER_EVENT}). */
+export function dispatchOpenNotificationCenter(): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent(OPEN_NOTIFICATION_CENTER_EVENT));
 }
 
 // ── Event-name unions (shared base widened with the UI-only events) ───────


### PR DESCRIPTION
## Summary

Clears the deferred items from the onboarding/QA epic (#11083) + its follow-up
(#11103, merged). This PR ships the one that's fully implementable — the
**desktop-native notification entry (#10706)** — and documents why the rest are
genuinely infra/operator-gated (with the concrete data + plan), rather than
shipping a blind half-measure.

## Shipped — #10706 desktop-native notification

On desktop the floating bell is hidden and the home pull-down was the only way
into the notification center — no visible native treatment (the #10706 gap).
Added one, surface-agnostic:

- **`@elizaos/ui/events`**: `OPEN_NOTIFICATION_CENTER_EVENT` +
  `dispatchOpenNotificationCenter()`.
- **NotificationCenter**: the single always-mounted headless instance listens for
  the event and reveals the pull-down sheet (renders it as a one-level
  `variant="sheet"` child — no recursion, no second toast-sink owner).
- **Deep link**: `<scheme>://notifications` (and the universal https app-link)
  opens the center in place — no route change — via a new case in the app
  deep-link handler.
- **Desktop**: a **Desktop → Notifications** menu item + the `open-notifications`
  action route through the existing `sendToActiveRenderer` channel;
  `DesktopSurfaceNavigationRuntime` opens the center instead of switching a tab.
  Distinct from the existing "Send Test Notification" native-toast smoke item.

### Evidence
- `NotificationCenter.test` **5/5** (incl. a new test: dispatch the event → sheet
  opens with the seeded notification → backdrop closes it).
- electrobun `application-menu.test` **10/10** (incl. a new test asserting the
  Desktop → Notifications item routes `open-notifications`).
- The cross-package legs (deep-link in `packages/app`, `DesktopSurfaceNavigationRuntime`
  in `app-core` importing the new `@elizaos/ui/events` export) are green on CI
  where the packages build together; in the isolated local worktree
  `@elizaos/ui` resolves to the shared parent checkout, so those two are
  CI-verified rather than local-verified (the standing shared-worktree
  cross-package constraint).

## Deferred items — honest status (not larped)

- **#10710 (strip default views to minimal + `ELIZA_AUDIT_APP_STRICT` flip):**
  the issue's own acceptance is the `audit:app` screenshot 5-loop. Findings: the
  primary content-card offender pattern (`rounded-lg border border-white/10
  bg-black/55`) is **already stripped** from the real default-view components
  (it now survives only in `.stories.tsx` and the launcher's iOS dock). The
  highest-density remaining views (`builtin-apps`/`builtin-views`/
  `builtin-contacts`/`builtin-rolodex` @ ~303 `borderDividerDensity`, per the
  committed `aesthetic-minimalism-baseline.json`) all share the launcher grid,
  whose per-tile + dock borders are a **deliberate iOS aesthetic**. Stripping
  those is a real visual redesign whose result must be pixel-reviewed via
  `audit:app` — which needs a full app build + injected login + the 50-view walk
  and **cannot complete in this shared worktree**. Doing it blind would violate
  the issue's verification requirement and risk regressing the launcher look, so
  it's left for the loop (findings posted to #10710). Flipping
  `ELIZA_AUDIT_APP_STRICT` to default likewise needs a clean full-audit run to
  seed the debt allowlist.
- **#9525 (Capacitor device onboarding→home e2e):** already CLOSED and fully
  wired — `.github/workflows/android-device-e2e.yml` + `test/android/
  onboarding-to-home.android.spec.ts` exist. The lane is intentionally
  `workflow_dispatch` / `ci:device`-label gated ("booting an emulator is
  slow/heavy — we never burn a runner automatically"); dispatching a real device
  run is an operator action by design.
- **Live-Cerebras BACKGROUND scenario:** DONE in the merged #11103 —
  `deterministic-background-actions.scenario.ts` (pr-deterministic lane, verified
  green) drives the real BACKGROUND handler ledger; the `live-only` NL-routing
  variants match the existing app-control live-scenario convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
