### PR TITLE
fix(ui): gate the 12 remaining always-on widgets on an authenticated session (#11084 follow-up)

### DIFF
--- a/packages/ui/src/components/chat/widgets/agent-activity.test.tsx
+++ b/packages/ui/src/components/chat/widgets/agent-activity.test.tsx
@@ -1,6 +1,16 @@
 // @vitest-environment jsdom
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Auth gate (#11084) — mutable so tests can flip the session state. Default
+// authenticated so the pre-gate behavior tests exercise the live poll path.
+const { authMock } = vi.hoisted(() => ({
+  authMock: { authenticated: true },
+}));
+vi.mock("../../../hooks/useAuthStatus", () => ({
+  useIsAuthenticated: () => authMock.authenticated,
+}));
+
 import type { FeedActivityItem } from "../../../api/client-types-feed";
 import type { WidgetProps } from "../../../widgets/types";
 
@@ -50,6 +60,7 @@ const homeProps: Partial<WidgetProps> = {
 
 describe("AgentActivityWidget", () => {
   beforeEach(() => {
+    authMock.authenticated = true;
     getFeedAgentActivityMock.mockReset();
     openViewMock.mockReset();
   });

--- a/packages/ui/src/components/chat/widgets/agent-activity.tsx
+++ b/packages/ui/src/components/chat/widgets/agent-activity.tsx
@@ -6,6 +6,7 @@ import { client } from "../../../api";
 //   - FeedActivityItem: { id, type, timestamp, summary?, contentPreview?, ticker?, … }
 //   - FeedActivityFeed: { items: FeedActivityItem[]; total: number }
 import type { FeedActivityItem } from "../../../api/client-types-feed";
+import { useIsAuthenticated } from "../../../hooks/useAuthStatus";
 import { withTimeout } from "../../../utils/with-timeout";
 import type { WidgetProps } from "../../../widgets/types";
 import { HomeWidgetCard, useWidgetNavigation } from "./home-widget-card";
@@ -77,6 +78,10 @@ export function AgentActivityWidget({
 }: Partial<WidgetProps>) {
   const [state, setState] = useState<AgentActivityState>(INITIAL_STATE);
   const nav = useWidgetNavigation();
+  // Auth gate (#11084): the widget mounts before the auth probe resolves, so
+  // the one-shot activity fetch must stay dormant until the session is
+  // authenticated (it fires once the phase flips).
+  const authenticated = useIsAuthenticated();
 
   const load = useCallback(async (signal: { cancelled: boolean }) => {
     try {
@@ -100,12 +105,13 @@ export function AgentActivityWidget({
   }, []);
 
   useEffect(() => {
+    if (!authenticated) return;
     const signal = { cancelled: false };
     void load(signal);
     return () => {
       signal.cancelled = true;
     };
-  }, [load]);
+  }, [authenticated, load]);
 
   const latest = state.items[0] ?? null;
   // "+N" counts the activity not shown as the single datum.

--- a/packages/ui/src/components/chat/widgets/browser-status.tsx
+++ b/packages/ui/src/components/chat/widgets/browser-status.tsx
@@ -17,6 +17,7 @@ import {
   client,
 } from "../../../api";
 import { useIntervalWhenDocumentVisible } from "../../../hooks";
+import { useIsAuthenticated } from "../../../hooks/useAuthStatus";
 import { useAppSelector } from "../../../state";
 import { WidgetSection } from "./shared";
 import type { ChatSidebarWidgetProps } from "./types";
@@ -62,15 +63,19 @@ export function BrowserStatusSidebarWidget(_props: ChatSidebarWidgetProps) {
   const [snapshot, setSnapshot] = useState<BrowserWorkspaceSnapshot | null>(
     null,
   );
+  // Auth gate (#11084): the widget mounts before the auth probe resolves, so
+  // the 4s workspace poll must stay dormant until the session is authenticated.
+  const authenticated = useIsAuthenticated();
 
   const poll = useCallback(async () => {
+    if (!authenticated) return;
     try {
       const next = await client.getBrowserWorkspace();
       setSnapshot(next);
     } catch {
       // Transient errors — keep the last snapshot.
     }
-  }, []);
+  }, [authenticated]);
 
   useEffect(() => {
     void poll();

--- a/packages/ui/src/components/chat/widgets/calendar-upcoming.test.tsx
+++ b/packages/ui/src/components/chat/widgets/calendar-upcoming.test.tsx
@@ -7,6 +7,16 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Auth gate (#11084) — mutable so tests can flip the session state. Default
+// authenticated so the pre-gate behavior tests exercise the live poll path.
+const { authMock } = vi.hoisted(() => ({
+  authMock: { authenticated: true },
+}));
+vi.mock("../../../hooks/useAuthStatus", () => ({
+  useIsAuthenticated: () => authMock.authenticated,
+}));
+
 import { HOME_SIGNAL_WEIGHTS } from "../../../widgets/home-priority";
 
 const { getBaseUrlMock, publishMock, listConnectorAccountsMock } = vi.hoisted(
@@ -110,6 +120,7 @@ afterEach(() => {
 });
 
 beforeEach(() => {
+  authMock.authenticated = true;
   getBaseUrlMock.mockReset();
   getBaseUrlMock.mockReturnValue("http://localhost");
   publishMock.mockReset();
@@ -238,5 +249,37 @@ describe("CalendarUpcomingWidget", () => {
     window.removeEventListener("eliza:navigate:view", onNav);
 
     expect(navEvents).toContain("/calendar");
+  });
+
+  // #11084 — the widget mounts before the auth probe resolves; the connector
+  // probe and the calendar feed must stay dormant while unauthenticated.
+  it("does not probe the connector or fetch the feed while unauthenticated", async () => {
+    authMock.authenticated = false;
+    connectedGoogle();
+    mockFeed([event({ id: "a", title: "Standup" })]);
+
+    render(<CalendarUpcomingWidget {...homeProps} />);
+
+    await Promise.resolve();
+    expect(listConnectorAccountsMock).not.toHaveBeenCalled();
+    expect(globalThis.fetch as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+  });
+
+  it("starts the probe + feed once the session flips to authenticated", async () => {
+    authMock.authenticated = false;
+    connectedGoogle();
+    mockFeed([event({ id: "a", title: "Standup" })]);
+
+    const { rerender } = render(<CalendarUpcomingWidget {...homeProps} />);
+    await Promise.resolve();
+    expect(listConnectorAccountsMock).not.toHaveBeenCalled();
+
+    authMock.authenticated = true;
+    rerender(<CalendarUpcomingWidget {...homeProps} />);
+
+    const card = await screen.findByTestId("chat-widget-calendar-upcoming");
+    expect(card.textContent).toContain("Standup");
+    expect(listConnectorAccountsMock).toHaveBeenCalled();
+    expect(globalThis.fetch as ReturnType<typeof vi.fn>).toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/components/chat/widgets/calendar-upcoming.tsx
+++ b/packages/ui/src/components/chat/widgets/calendar-upcoming.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { client } from "../../../api";
 import { supportsFullAppShellRoutes } from "../../../api/app-shell-capabilities";
 import { useIntervalWhenDocumentVisible } from "../../../hooks";
+import { useIsAuthenticated } from "../../../hooks/useAuthStatus";
 import { useNow } from "../../../hooks/useNow";
 import { withTimeout } from "../../../utils/with-timeout";
 import { usePublishHomeAttention } from "../../../widgets/home-attention-store";
@@ -129,6 +130,12 @@ export function CalendarUpcomingWidget({
   const [feedLoaded, setFeedLoaded] = useState(false);
   const [connection, setConnection] = useState<ConnectionState>("unknown");
   const nav = useWidgetNavigation();
+  // Auth gate (#11084): the widget mounts before the auth probe resolves, so
+  // the connector probe + feed poll must stay dormant until the session is
+  // authenticated. While unauthenticated the connection stays "unknown"
+  // (the loading tile behind the sign-in overlay); the probe re-fires when the
+  // phase flips because it participates in the callback deps below.
+  const authenticated = useIsAuthenticated();
 
   const probeConnection = useCallback(async () => {
     if (!supportsFullAppShellRoutes(client.getBaseUrl())) {
@@ -137,6 +144,7 @@ export function CalendarUpcomingWidget({
       setEvents([]);
       return false;
     }
+    if (!authenticated) return false;
 
     try {
       const res = await withTimeout(
@@ -159,7 +167,7 @@ export function CalendarUpcomingWidget({
       setConnection("disconnected");
       return false;
     }
-  }, []);
+  }, [authenticated]);
 
   const loadEvents = useCallback(async () => {
     const now = new Date();
@@ -205,7 +213,7 @@ export function CalendarUpcomingWidget({
   }, [probeConnection, loadEvents]);
 
   useIntervalWhenDocumentVisible(() => {
-    if (connection === "connected") void loadEvents();
+    if (authenticated && connection === "connected") void loadEvents();
   }, CALENDAR_REFRESH_INTERVAL_MS);
 
   // `useNow` is 0 on first render (deterministic render path — no Date.now in

--- a/packages/ui/src/components/chat/widgets/finances-alerts.test.tsx
+++ b/packages/ui/src/components/chat/widgets/finances-alerts.test.tsx
@@ -2,6 +2,15 @@
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+// Auth gate (#11084) — mutable so tests can flip the session state. Default
+// authenticated so the pre-gate behavior tests exercise the live poll path.
+const { authMock } = vi.hoisted(() => ({
+  authMock: { authenticated: true },
+}));
+vi.mock("../../../hooks/useAuthStatus", () => ({
+  useIsAuthenticated: () => authMock.authenticated,
+}));
+
 // client.getBaseUrl() — the widget builds raw fetch URLs from it (FinancesView
 // pattern). Keep the mock minimal: a stable base.
 vi.mock("../../../api", () => ({
@@ -80,6 +89,7 @@ const fetchProps: Partial<WidgetProps> = { slot: "home" };
 
 describe("FinancesAlertsWidget (#9143)", () => {
   beforeEach(() => {
+    authMock.authenticated = true;
     publishHomeAttentionSpy.mockReset();
   });
 

--- a/packages/ui/src/components/chat/widgets/finances-alerts.tsx
+++ b/packages/ui/src/components/chat/widgets/finances-alerts.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { client } from "../../../api";
 import { supportsFullAppShellRoutes } from "../../../api/app-shell-capabilities";
 import { useIntervalWhenDocumentVisible } from "../../../hooks";
+import { useIsAuthenticated } from "../../../hooks/useAuthStatus";
 import { useNow } from "../../../hooks/useNow";
 import { usePublishHomeAttention } from "../../../widgets/home-attention-store";
 import { HOME_SIGNAL_WEIGHTS } from "../../../widgets/home-priority";
@@ -195,9 +196,12 @@ function financesEqual(
 function FinancesAlertsWidget(_props: Partial<WidgetProps>) {
   const [data, setData] = useState<FinancesWidgetData | null>(null);
   const nav = useWidgetNavigation();
+  // Auth gate (#11084): the widget mounts before the auth probe resolves, so
+  // the money polls must stay dormant until the session is authenticated.
+  const authenticated = useIsAuthenticated();
 
   const load = useCallback(async () => {
-    if (!supportsFullAppShellRoutes(client.getBaseUrl())) {
+    if (!authenticated || !supportsFullAppShellRoutes(client.getBaseUrl())) {
       setData(null);
       return;
     }
@@ -219,7 +223,7 @@ function FinancesAlertsWidget(_props: Partial<WidgetProps>) {
     } catch {
       // Transient/poll failure: keep the last good snapshot (todo.tsx pattern).
     }
-  }, []);
+  }, [authenticated]);
 
   useEffect(() => {
     void load();

--- a/packages/ui/src/components/chat/widgets/goals-attention.test.tsx
+++ b/packages/ui/src/components/chat/widgets/goals-attention.test.tsx
@@ -8,6 +8,15 @@ import {
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+// Auth gate (#11084) — mutable so tests can flip the session state. Default
+// authenticated so the pre-gate behavior tests exercise the live poll path.
+const { authMock } = vi.hoisted(() => ({
+  authMock: { authenticated: true },
+}));
+vi.mock("../../../hooks/useAuthStatus", () => ({
+  useIsAuthenticated: () => authMock.authenticated,
+}));
+
 const { getBaseUrlMock, publishHomeAttentionSpy } = vi.hoisted(() => ({
   getBaseUrlMock: vi.fn(() => "http://localhost"),
   publishHomeAttentionSpy: vi.fn(),
@@ -72,6 +81,7 @@ afterEach(() => {
 });
 
 beforeEach(() => {
+  authMock.authenticated = true;
   publishHomeAttentionSpy.mockClear();
 });
 

--- a/packages/ui/src/components/chat/widgets/goals-attention.tsx
+++ b/packages/ui/src/components/chat/widgets/goals-attention.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { client } from "../../../api";
 import { supportsFullAppShellRoutes } from "../../../api/app-shell-capabilities";
 import { useIntervalWhenDocumentVisible } from "../../../hooks";
+import { useIsAuthenticated } from "../../../hooks/useAuthStatus";
 import { usePublishHomeAttention } from "../../../widgets/home-attention-store";
 import { HOME_SIGNAL_WEIGHTS } from "../../../widgets/home-priority";
 import type { WidgetProps } from "../../../widgets/types";
@@ -157,9 +158,12 @@ export function GoalsAttentionWidget(_props: Partial<WidgetProps>) {
   // home surface renders nothing (not a card) until we actually know the data.
   const [goals, setGoals] = useState<AttentionGoal[] | null>(null);
   const nav = useWidgetNavigation();
+  // Auth gate (#11084): the widget mounts before the auth probe resolves, so
+  // the 20s goals poll must stay dormant until the session is authenticated.
+  const authenticated = useIsAuthenticated();
 
   const load = useCallback(async () => {
-    if (!supportsFullAppShellRoutes(client.getBaseUrl())) {
+    if (!authenticated || !supportsFullAppShellRoutes(client.getBaseUrl())) {
       setGoals([]);
       return;
     }
@@ -171,7 +175,7 @@ export function GoalsAttentionWidget(_props: Partial<WidgetProps>) {
     } catch {
       // Silent fallback to the last good render (matches todo.tsx); never log.
     }
-  }, []);
+  }, [authenticated]);
 
   useEffect(() => {
     void load();

--- a/packages/ui/src/components/chat/widgets/health-sleep.test.tsx
+++ b/packages/ui/src/components/chat/widgets/health-sleep.test.tsx
@@ -8,6 +8,15 @@ import {
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+// Auth gate (#11084) — mutable so tests can flip the session state. Default
+// authenticated so the pre-gate behavior tests exercise the live poll path.
+const { authMock } = vi.hoisted(() => ({
+  authMock: { authenticated: true },
+}));
+vi.mock("../../../hooks/useAuthStatus", () => ({
+  useIsAuthenticated: () => authMock.authenticated,
+}));
+
 const { getBaseUrlMock, publishHomeAttentionSpy } = vi.hoisted(() => ({
   getBaseUrlMock: vi.fn(() => "http://localhost"),
   publishHomeAttentionSpy: vi.fn(),
@@ -90,6 +99,7 @@ afterEach(() => {
 });
 
 beforeEach(() => {
+  authMock.authenticated = true;
   publishHomeAttentionSpy.mockClear();
 });
 

--- a/packages/ui/src/components/chat/widgets/health-sleep.tsx
+++ b/packages/ui/src/components/chat/widgets/health-sleep.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import { client } from "../../../api";
 import { supportsFullAppShellRoutes } from "../../../api/app-shell-capabilities";
 import { useIntervalWhenDocumentVisible } from "../../../hooks";
+import { useIsAuthenticated } from "../../../hooks/useAuthStatus";
 import { usePublishHomeAttention } from "../../../widgets/home-attention-store";
 import { HOME_SIGNAL_WEIGHTS } from "../../../widgets/home-priority";
 import type { WidgetProps } from "../../../widgets/types";
@@ -178,9 +179,12 @@ export function HealthSleepWidget(_props: Partial<WidgetProps>) {
   // there's data, and a transient fetch error never clobbers a populated card.
   const [data, setData] = useState<SleepWidgetData | null>(null);
   const nav = useWidgetNavigation();
+  // Auth gate (#11084): the widget mounts before the auth probe resolves, so
+  // the 20s sleep poll must stay dormant until the session is authenticated.
+  const authenticated = useIsAuthenticated();
 
   const load = useCallback(async () => {
-    if (!supportsFullAppShellRoutes(client.getBaseUrl())) {
+    if (!authenticated || !supportsFullAppShellRoutes(client.getBaseUrl())) {
       setData({ latest: null, classification: null });
       return;
     }
@@ -192,7 +196,7 @@ export function HealthSleepWidget(_props: Partial<WidgetProps>) {
     } catch {
       // Silent fallback to the last good render (matches todo.tsx); never log.
     }
-  }, []);
+  }, [authenticated]);
 
   useEffect(() => {
     void load();

--- a/packages/ui/src/components/chat/widgets/inbox-unread.test.tsx
+++ b/packages/ui/src/components/chat/widgets/inbox-unread.test.tsx
@@ -8,6 +8,15 @@ import {
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+// Auth gate (#11084) — mutable so tests can flip the session state. Default
+// authenticated so the pre-gate behavior tests exercise the live poll path.
+const { authMock } = vi.hoisted(() => ({
+  authMock: { authenticated: true },
+}));
+vi.mock("../../../hooks/useAuthStatus", () => ({
+  useIsAuthenticated: () => authMock.authenticated,
+}));
+
 const { getBaseUrlMock, publishHomeAttentionSpy } = vi.hoisted(() => ({
   getBaseUrlMock: vi.fn(() => "http://localhost"),
   publishHomeAttentionSpy: vi.fn(),
@@ -61,19 +70,18 @@ function message(patch: {
   };
 }
 
-function mockInbox(messages: ReturnType<typeof message>[]): void {
-  vi.stubGlobal(
-    "fetch",
-    vi.fn(async () => ({
-      ok: true,
-      status: 200,
-      json: async () => ({
-        messages,
-        channelCounts: {},
-        fetchedAt: "2026-01-01T00:00:00.000Z",
-      }),
-    })),
-  );
+function mockInbox(messages: ReturnType<typeof message>[]) {
+  const stub = vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      messages,
+      channelCounts: {},
+      fetchedAt: "2026-01-01T00:00:00.000Z",
+    }),
+  }));
+  vi.stubGlobal("fetch", stub);
+  return stub;
 }
 
 const fetchProps: Partial<WidgetProps> = { slot: "home" };
@@ -84,6 +92,7 @@ afterEach(() => {
 });
 
 beforeEach(() => {
+  authMock.authenticated = true;
   getBaseUrlMock.mockReturnValue("http://localhost");
   publishHomeAttentionSpy.mockClear();
 });
@@ -175,5 +184,40 @@ describe("InboxUnreadWidget (#9143)", () => {
     window.removeEventListener("eliza:navigate:view", onNav);
 
     expect(navEvents).toContain("/inbox");
+  });
+
+  // #11084 — the widget mounts before the auth probe resolves; the 20s inbox
+  // poll must not fire a single request while the session is unauthenticated.
+  it("does not poll the inbox while unauthenticated", async () => {
+    authMock.authenticated = false;
+    const fetchStub = mockInbox([
+      message({ id: "m1", sender: "Dana", priorityScore: 90 }),
+    ]);
+
+    const { container } = render(<InboxUnreadWidget {...fetchProps} />);
+
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull();
+    });
+    expect(fetchStub).not.toHaveBeenCalled();
+  });
+
+  it("starts the inbox poll once the session flips to authenticated", async () => {
+    authMock.authenticated = false;
+    const fetchStub = mockInbox([
+      message({ id: "m1", sender: "Dana", priorityScore: 90 }),
+    ]);
+
+    const { rerender } = render(<InboxUnreadWidget {...fetchProps} />);
+    await Promise.resolve();
+    expect(fetchStub).not.toHaveBeenCalled();
+
+    authMock.authenticated = true;
+    rerender(<InboxUnreadWidget {...fetchProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-widget-inbox-unread")).toBeTruthy();
+    });
+    expect(fetchStub).toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/components/chat/widgets/inbox-unread.tsx
+++ b/packages/ui/src/components/chat/widgets/inbox-unread.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { client } from "../../../api";
 import { supportsFullAppShellRoutes } from "../../../api/app-shell-capabilities";
 import { useIntervalWhenDocumentVisible } from "../../../hooks";
+import { useIsAuthenticated } from "../../../hooks/useAuthStatus";
 import { usePublishHomeAttention } from "../../../widgets/home-attention-store";
 import { HOME_SIGNAL_WEIGHTS } from "../../../widgets/home-priority";
 import type { WidgetProps } from "../../../widgets/types";
@@ -84,10 +85,13 @@ export function InboxUnreadWidget(_props: Partial<WidgetProps>) {
   const [unread, setUnread] = useState<UnreadThread[]>([]);
   const [loaded, setLoaded] = useState(false);
   const nav = useWidgetNavigation();
+  // Auth gate (#11084): the widget mounts before the auth probe resolves, so
+  // the 20s inbox poll must stay dormant until the session is authenticated.
+  const authenticated = useIsAuthenticated();
 
   const loadInbox = useCallback(async () => {
     const baseUrl = client.getBaseUrl();
-    if (!supportsFullAppShellRoutes(baseUrl)) {
+    if (!authenticated || !supportsFullAppShellRoutes(baseUrl)) {
       setLoaded(true);
       setUnread([]);
       return;
@@ -103,7 +107,7 @@ export function InboxUnreadWidget(_props: Partial<WidgetProps>) {
     } finally {
       setLoaded(true);
     }
-  }, []);
+  }, [authenticated]);
 
   useEffect(() => {
     void loadInbox();

--- a/packages/ui/src/components/chat/widgets/model-download.test.tsx
+++ b/packages/ui/src/components/chat/widgets/model-download.test.tsx
@@ -7,6 +7,16 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Auth gate (#11084) — mutable so tests can flip the session state. Default
+// authenticated so the pre-gate behavior tests exercise the live poll path.
+const { authMock } = vi.hoisted(() => ({
+  authMock: { authenticated: true },
+}));
+vi.mock("../../../hooks/useAuthStatus", () => ({
+  useIsAuthenticated: () => authMock.authenticated,
+}));
+
 import type {
   LocalInferenceSlotReadiness,
   ModelHubSnapshot,
@@ -103,6 +113,7 @@ function hub(
 
 describe("ModelDownloadWidget", () => {
   beforeEach(() => {
+    authMock.authenticated = true;
     getHubMock.mockReset();
     startDownloadMock.mockReset();
     startDownloadMock.mockResolvedValue({ job: {} });
@@ -248,5 +259,41 @@ describe("ModelDownloadWidget", () => {
         container.querySelector('[data-testid="chat-widget-model-download"]'),
       ).toBeNull(),
     );
+  });
+
+  // #11084 — the home surface mounts the widget before the auth probe
+  // resolves; the hub fetch (and download stream) must stay dormant while the
+  // session is unauthenticated.
+  it("does not fetch the hub while unauthenticated", async () => {
+    authMock.authenticated = false;
+    getHubMock.mockResolvedValue(
+      hub({ TEXT_LARGE: slot({ state: "downloading" }) }),
+    );
+
+    const { container } = render(<ModelDownloadWidget />);
+
+    await Promise.resolve();
+    expect(getHubMock).not.toHaveBeenCalled();
+    // Dormant → the first-fetch loading hold renders nothing.
+    expect(
+      container.querySelector('[data-testid="chat-widget-model-download"]'),
+    ).toBeNull();
+  });
+
+  it("starts the hub fetch once the session flips to authenticated", async () => {
+    authMock.authenticated = false;
+    getHubMock.mockResolvedValue(
+      hub({ TEXT_LARGE: slot({ state: "downloading" }) }),
+    );
+
+    const { rerender } = render(<ModelDownloadWidget />);
+    await Promise.resolve();
+    expect(getHubMock).not.toHaveBeenCalled();
+
+    authMock.authenticated = true;
+    rerender(<ModelDownloadWidget />);
+
+    await screen.findByTestId("chat-widget-model-download");
+    expect(getHubMock).toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/components/chat/widgets/model-download.tsx
+++ b/packages/ui/src/components/chat/widgets/model-download.tsx
@@ -1,6 +1,7 @@
 import { Download, Loader2, TriangleAlert } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { client } from "../../../api";
+import { useIsAuthenticated } from "../../../hooks/useAuthStatus";
 import {
   deriveHomeModelStatus,
   type HomeModelStatus,
@@ -102,8 +103,17 @@ function rowsFromReadiness(
 export function useLocalModelDownloads(): LocalModelDownloads {
   const [state, setState] = useState<LocalModelDownloads>(INITIAL);
   const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Auth gate (#11084): the home surface mounts this widget before the auth
+  // probe resolves, so the hub fetch + download SSE stream must stay dormant
+  // until the session is authenticated (mirrors useHomeModelStatus).
+  const authenticated = useIsAuthenticated();
 
   useEffect(() => {
+    if (!authenticated) {
+      setState(INITIAL);
+      return;
+    }
+
     let cancelled = false;
 
     const refresh = async () => {
@@ -148,7 +158,7 @@ export function useLocalModelDownloads(): LocalModelDownloads {
       if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current);
       es?.close();
     };
-  }, []);
+  }, [authenticated]);
 
   return state;
 }

--- a/packages/ui/src/components/chat/widgets/music-player.tsx
+++ b/packages/ui/src/components/chat/widgets/music-player.tsx
@@ -2,6 +2,7 @@ import { Music, Pause, Play, RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { fetchWithCsrf } from "../../../api/csrf-client";
 import { useIntervalWhenDocumentVisible } from "../../../hooks";
+import { useIsAuthenticated } from "../../../hooks/useAuthStatus";
 import { resolveApiUrl } from "../../../utils/asset-url";
 import { EmptyWidgetState, WidgetSection } from "./shared";
 import type { ChatSidebarWidgetProps } from "./types";
@@ -39,8 +40,12 @@ export function MusicPlayerSidebarWidget(_props: ChatSidebarWidgetProps) {
   const [audioError, setAudioError] = useState<string | null>(null);
   const [audioPaused, setAudioPaused] = useState(true);
   const isPlaying = player.kind === "playing";
+  // Auth gate (#11084): the widget mounts before the auth probe resolves, so
+  // the 5s status poll must stay dormant until the session is authenticated.
+  const authenticated = useIsAuthenticated();
 
   const pollOnce = useCallback(async () => {
+    if (!authenticated) return;
     setPlayer((prev) => (prev.kind === "idle" ? { kind: "loading" } : prev));
     try {
       const res = await fetchWithCsrf(resolveApiUrl("/music-player/status"));
@@ -74,7 +79,7 @@ export function MusicPlayerSidebarWidget(_props: ChatSidebarWidgetProps) {
       });
       setAudioPaused(true);
     }
-  }, []);
+  }, [authenticated]);
 
   useEffect(() => {
     void pollOnce();

--- a/packages/ui/src/components/chat/widgets/needs-attention.test.tsx
+++ b/packages/ui/src/components/chat/widgets/needs-attention.test.tsx
@@ -9,6 +9,15 @@ import {
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+// Auth gate (#11084) — mutable so tests can flip the session state. Default
+// authenticated so the pre-gate behavior tests exercise the live poll path.
+const { authMock } = vi.hoisted(() => ({
+  authMock: { authenticated: true },
+}));
+vi.mock("../../../hooks/useAuthStatus", () => ({
+  useIsAuthenticated: () => authMock.authenticated,
+}));
+
 const {
   getBaseUrlMock,
   listPendingActionsMock,
@@ -80,6 +89,7 @@ afterEach(() => {
 });
 
 beforeEach(() => {
+  authMock.authenticated = true;
   getBaseUrlMock.mockReturnValue("http://localhost");
   publishHomeAttentionSpy.mockReset();
   dispatchChatPrefillSpy.mockReset();
@@ -209,5 +219,36 @@ describe("NeedsAttentionWidget (#9449)", () => {
       text: "Approve: Send the contract",
       select: true,
     });
+  });
+
+  // #11084 — the widget mounts before the auth probe resolves; the 20s
+  // approvals poll must not fire a single request while unauthenticated.
+  it("does not poll pending actions while unauthenticated", async () => {
+    authMock.authenticated = false;
+    mockPending([pending({ id: "a-1", title: "Send the contract" })]);
+
+    const { container } = render(<NeedsAttentionWidget {...fetchProps} />);
+
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull();
+    });
+    expect(listPendingActionsMock).not.toHaveBeenCalled();
+  });
+
+  it("starts the approvals poll once the session flips to authenticated", async () => {
+    authMock.authenticated = false;
+    mockPending([pending({ id: "a-1", title: "Send the contract" })]);
+
+    const { rerender } = render(<NeedsAttentionWidget {...fetchProps} />);
+    await Promise.resolve();
+    expect(listPendingActionsMock).not.toHaveBeenCalled();
+
+    authMock.authenticated = true;
+    rerender(<NeedsAttentionWidget {...fetchProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-widget-needs-attention")).toBeTruthy();
+    });
+    expect(listPendingActionsMock).toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/components/chat/widgets/needs-attention.tsx
+++ b/packages/ui/src/components/chat/widgets/needs-attention.tsx
@@ -5,6 +5,7 @@ import { client } from "../../../api";
 import { supportsFullAppShellRoutes } from "../../../api/app-shell-capabilities";
 import { dispatchChatPrefill } from "../../../events";
 import { useIntervalWhenDocumentVisible } from "../../../hooks";
+import { useIsAuthenticated } from "../../../hooks/useAuthStatus";
 import { useNow } from "../../../hooks/useNow";
 import { usePublishHomeAttention } from "../../../widgets/home-attention-store";
 import { HOME_SIGNAL_WEIGHTS } from "../../../widgets/home-priority";
@@ -55,9 +56,12 @@ export function useApprovals(): {
   const [pending, setPending] = useState<PendingUserAction[]>([]);
   const [loaded, setLoaded] = useState(false);
   const mountedRef = useRef(true);
+  // Auth gate (#11084): the widget mounts before the auth probe resolves, so
+  // the 20s approvals poll must stay dormant until the session is authenticated.
+  const authenticated = useIsAuthenticated();
 
   const load = useCallback(async () => {
-    if (!supportsFullAppShellRoutes(client.getBaseUrl())) {
+    if (!authenticated || !supportsFullAppShellRoutes(client.getBaseUrl())) {
       if (mountedRef.current) {
         setPending([]);
         setLoaded(true);
@@ -75,7 +79,7 @@ export function useApprovals(): {
         setLoaded(true);
       }
     }
-  }, []);
+  }, [authenticated]);
 
   useEffect(
     () => () => {

--- a/packages/ui/src/components/chat/widgets/relationships-attention.test.tsx
+++ b/packages/ui/src/components/chat/widgets/relationships-attention.test.tsx
@@ -7,6 +7,16 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Auth gate (#11084) — mutable so tests can flip the session state. Default
+// authenticated so the pre-gate behavior tests exercise the live poll path.
+const { authMock } = vi.hoisted(() => ({
+  authMock: { authenticated: true },
+}));
+vi.mock("../../../hooks/useAuthStatus", () => ({
+  useIsAuthenticated: () => authMock.authenticated,
+}));
+
 import type {
   RelationshipsMergeCandidate,
   RelationshipsPersonSummary,
@@ -100,6 +110,7 @@ const fetchProps: Partial<WidgetProps> = { slot: "home" };
 
 describe("RelationshipsAttentionWidget (#9143)", () => {
   beforeEach(() => {
+    authMock.authenticated = true;
     getBaseUrlMock.mockReturnValue("http://localhost");
     getRelationshipsPeopleMock.mockReset();
     getRelationshipsCandidatesMock.mockReset();

--- a/packages/ui/src/components/chat/widgets/relationships-attention.tsx
+++ b/packages/ui/src/components/chat/widgets/relationships-attention.tsx
@@ -11,6 +11,7 @@ import type {
   RelationshipsPersonSummary,
 } from "../../../api/client-types-relationships";
 import { useIntervalWhenDocumentVisible } from "../../../hooks";
+import { useIsAuthenticated } from "../../../hooks/useAuthStatus";
 import { usePublishHomeAttention } from "../../../widgets/home-attention-store";
 import { HOME_SIGNAL_WEIGHTS } from "../../../widgets/home-priority";
 import type { WidgetProps } from "../../../widgets/types";
@@ -126,9 +127,12 @@ export function RelationshipsAttentionWidget({
 }: Partial<WidgetProps>) {
   const [data, setData] = useState<RelationshipsAttentionData>(EMPTY_DATA);
   const nav = useWidgetNavigation();
+  // Auth gate (#11084): the widget mounts before the auth probe resolves, so
+  // the relationships poll must stay dormant until the session is authenticated.
+  const authenticated = useIsAuthenticated();
 
   const load = useCallback(async () => {
-    if (!supportsFullAppShellRoutes(client.getBaseUrl())) {
+    if (!authenticated || !supportsFullAppShellRoutes(client.getBaseUrl())) {
       setData(EMPTY_DATA);
       return;
     }
@@ -147,7 +151,7 @@ export function RelationshipsAttentionWidget({
       // Network/agent failure — keep the last good data (or empty); never
       // surface a broken card. Matches todo.tsx's silent-fallback catch.
     }
-  }, []);
+  }, [authenticated]);
 
   useEffect(() => {
     void load();

--- a/packages/ui/src/components/chat/widgets/wallet-balance.test.tsx
+++ b/packages/ui/src/components/chat/widgets/wallet-balance.test.tsx
@@ -12,6 +12,15 @@ import {
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+// Auth gate (#11084) — mutable so tests can flip the session state. Default
+// authenticated so the pre-gate behavior tests exercise the live poll path.
+const { authMock } = vi.hoisted(() => ({
+  authMock: { authenticated: true },
+}));
+vi.mock("../../../hooks/useAuthStatus", () => ({
+  useIsAuthenticated: () => authMock.authenticated,
+}));
+
 vi.mock("../../../api", () => ({
   client: {
     getWalletBalances: vi.fn(),
@@ -82,6 +91,7 @@ function overview(
 }
 
 beforeEach(() => {
+  authMock.authenticated = true;
   navOpenView.mockReset();
   getWalletBalances.mockReset();
   getWalletMarketOverview.mockReset();

--- a/packages/ui/src/components/chat/widgets/wallet-balance.tsx
+++ b/packages/ui/src/components/chat/widgets/wallet-balance.tsx
@@ -12,6 +12,7 @@ import type { WalletBalancesResponse } from "@elizaos/shared";
 import { Wallet } from "lucide-react";
 import { useEffect, useState } from "react";
 import { client } from "../../../api";
+import { useIsAuthenticated } from "../../../hooks/useAuthStatus";
 import type { WidgetProps } from "../../../widgets/types";
 import { useWidgetNavigation } from "./home-widget-card";
 import {
@@ -51,8 +52,13 @@ export function WalletBalanceWidget(
   const [holdings, setHoldings] = useState<PricedHolding[] | null>(null);
   const [loading, setLoading] = useState(true);
   const nav = useWidgetNavigation();
+  // Auth gate (#11084): the widget mounts before the auth probe resolves, so
+  // the one-shot balances/prices fetch must stay dormant until the session is
+  // authenticated (it fires once the phase flips).
+  const authenticated = useIsAuthenticated();
 
   useEffect(() => {
+    if (!authenticated) return;
     let cancelled = false;
     void (async () => {
       try {
@@ -74,7 +80,7 @@ export function WalletBalanceWidget(
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [authenticated]);
 
   // First load pending: a quiet placeholder keeps the grid cell stable.
   if (loading && holdings == null) {


### PR DESCRIPTION
## Gate the remaining always-on widgets on an authenticated session (follow-up to #11107, refs #11084)

#11107 gated the main shell pollers; this completes the sweep across the **12 remaining home/chat-sidebar widgets** that fetched on mount or on an interval gated only on `supportsFullAppShellRoutes` — or on nothing at all:

- `model-download` (hub fetch + download SSE, mirrors `useHomeModelStatus`)
- `calendar-upcoming` (connector probe + 60s feed poll), `inbox-unread` (20s), `needs-attention` (20s), `goals-attention`, `health-sleep`, `finances-alerts`, `relationships-attention` (20s lifeops polls)
- `wallet-balance`, `agent-activity` (fully ungated one-shot mount fetches)
- `browser-status` (fully ungated **4s** poll), `music-player` (fully ungated **5s** poll)

Each gate is the merged `useIsAuthenticated()` pattern (read-only `observeOnly` snapshot subscription, zero added network) alongside the existing guard, deps updated — dormant pre-auth, starts when the phase flips. Audited and deliberately skipped: `task-widget` (mounts only inside an authenticated chat thread; freezes after consecutive 401s) and `agent-provisioning` (single bounded poll during a live post-auth handoff).

### Evidence (fail-without-fix, independently re-verified)
- 8 new jsdom auth-gate tests across 4 widgets (zero client calls unauthenticated → fetch starts on auth flip). Reverting a gated production file → its gate tests red ("does not poll the inbox while unauthenticated" etc.); restore → green. Verified on `inbox-unread` by the reviewer.
- Widget dir: **176 passing** including the 8 new tests. The 5 failures in `ftu-welcome.test.tsx` are a **pre-existing develop red** (fails identically on unmodified `origin/develop`; this branch does not touch that file — being fixed separately).
- `tsgo --noEmit` (packages/ui): clean. Biome: clean.
- Visual audit: **N/A** — zero rendered-output delta; pre-auth traffic suppression only.

Refs #11084 #11107 #11087

🤖 Generated with [Claude Code](https://claude.com/claude-code)
