### PR TITLE
fix(cloud): close influencer escrow double-spend on the delivered money fork (#11116)

### DIFF
--- a/packages/cloud/shared/src/db/schemas/influencer-marketplace.ts
+++ b/packages/cloud/shared/src/db/schemas/influencer-marketplace.ts
@@ -48,6 +48,13 @@ export type InfluencerBookingStatus =
   | "offered"
   | "accepted"
   | "delivered"
+  // Intermediate CLAIM states for the `delivered` money fork (#11116): exactly
+  // one of approve/rejectDeliverable can CAS `delivered` → `approving`/`refunding`,
+  // so only the winner moves money. A crash in the claim→money→finalize window
+  // leaves the booking here for the same operation to resume (money ops are
+  // idempotent). `status` is a plain text column, so this needs no migration.
+  | "approving"
+  | "refunding"
   | "approved"
   | "rejected"
   | "cancelled";

--- a/packages/cloud/shared/src/lib/services/__tests__/influencer-marketplace.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/influencer-marketplace.test.ts
@@ -308,7 +308,7 @@ describe("Influencer marketplace escrow (#10687)", () => {
     expect(await orgBalance(adv.orgId)).toBeCloseTo(30, 2); // still exactly one debit
   });
 
-  test("payout failure leaves the booking delivered; retry pays exactly once", async () => {
+  test("payout failure leaves the booking approving; retry pays exactly once", async () => {
     if (!pgliteReady) return;
     const adv = await seedOrgUser("100.00");
     const inf = await seedProfile();
@@ -332,10 +332,12 @@ describe("Influencer marketplace escrow (#10687)", () => {
       error: "simulated payout outage",
     });
     try {
-      // Payout fails → approve MUST NOT report success or move the status.
+      // Payout fails after the fork was claimed → approve MUST NOT report
+      // success or pay; the booking rests in `approving` for the same operation
+      // to resume (the claim CAS already fenced out a concurrent reject). (#11116)
       const failed = await service.approveBooking(id, adv.orgId);
       expect(failed.ok).toBe(false);
-      expect((await service.getBooking(id))?.status).toBe("delivered");
+      expect((await service.getBooking(id))?.status).toBe("approving");
       expect(await earnings(inf.userId)).toBe(0);
     } finally {
       redeemableEarningsService.addEarnings = originalAddEarnings;
@@ -437,5 +439,86 @@ describe("Influencer marketplace escrow (#10687)", () => {
       createdByUserId: inf.userId,
     });
     expect(res.ok).toBe(false);
+  });
+
+  // #11116 — the `delivered` money fork must never both pay the influencer AND
+  // refund the advertiser for one escrow. Before the CAS-claim fix, approve and
+  // rejectDeliverable each read `delivered` and moved money before their status
+  // CAS, under different idempotency keys, so a concurrent pair double-spent.
+  // Promise.all on single-connection PGlite interleaves the two methods' awaits
+  // (both reads land before either finalize), reproducing the race; the claim
+  // CAS (`delivered → approving`/`refunding`) now lets exactly one win.
+  test("concurrent approve + rejectDeliverable on a delivered booking moves money exactly once (#11116)", async () => {
+    if (!pgliteReady) return;
+    const adv = await seedOrgUser("100.00");
+    const inf = await seedProfile();
+    const { booking } = await service.createBooking({
+      advertiserOrgId: adv.orgId,
+      profileId: inf.profileId,
+      brief: "b",
+      amount: 40,
+      createdByUserId: adv.userId,
+    });
+    const id = booking?.id as string;
+    await service.acceptBooking(id, inf.userId);
+    await service.submitDeliverable(id, inf.userId, "https://x/post");
+    // Escrow funded: advertiser debited 40 → 60; nothing paid/refunded yet.
+    expect(await orgBalance(adv.orgId)).toBeCloseTo(60, 2);
+    expect(await earnings(inf.userId)).toBe(0);
+
+    const [approve, reject] = await Promise.all([
+      service.approveBooking(id, adv.orgId),
+      service.rejectDeliverable(id, adv.orgId),
+    ]);
+
+    // Exactly one exit succeeds; the other is refused.
+    expect([approve.ok, reject.ok].filter(Boolean).length).toBe(1);
+
+    const paid = await earnings(inf.userId); // influencer payout (0 or 40)
+    const bal = await orgBalance(adv.orgId); // advertiser (60 held, or 100 refunded)
+    const refunded = bal >= 99.99; // refund returned the 40
+
+    // The invariant: NEVER both. Either influencer paid (40) and advertiser
+    // stays at 60, or advertiser refunded (100) and influencer paid 0.
+    expect(paid > 0 && refunded).toBe(false);
+    if (approve.ok) {
+      expect(paid).toBeCloseTo(40, 2);
+      expect(bal).toBeCloseTo(60, 2);
+      expect((await service.getBooking(id))?.status).toBe("approved");
+    } else {
+      expect(paid).toBe(0);
+      expect(bal).toBeCloseTo(100, 2);
+      expect((await service.getBooking(id))?.status).toBe("rejected");
+    }
+  });
+
+  test("a booking mid-approve (approving) cannot be refunded by reject (#11116)", async () => {
+    if (!pgliteReady) return;
+    const adv = await seedOrgUser("100.00");
+    const inf = await seedProfile();
+    const { booking } = await service.createBooking({
+      advertiserOrgId: adv.orgId,
+      profileId: inf.profileId,
+      brief: "b",
+      amount: 30,
+      createdByUserId: adv.userId,
+    });
+    const id = booking?.id as string;
+    await service.acceptBooking(id, inf.userId);
+    await service.submitDeliverable(id, inf.userId, "https://x/post");
+    // Simulate an approve that claimed the fork but hasn't finished paying.
+    await dbWrite
+      .update(influencerBookings)
+      .set({ status: "approving" })
+      .where(eq(influencerBookings.id, id));
+
+    const rejected = await service.rejectDeliverable(id, adv.orgId);
+    expect(rejected.ok).toBe(false);
+    expect(await orgBalance(adv.orgId)).toBeCloseTo(70, 2); // escrow still held, no refund
+    // The rightful owner can still resume the approval and get paid once.
+    const resumed = await service.approveBooking(id, adv.orgId);
+    expect(resumed.ok).toBe(true);
+    expect(await earnings(inf.userId)).toBeCloseTo(30, 2);
+    expect(await orgBalance(adv.orgId)).toBeCloseTo(70, 2);
   });
 });

--- a/packages/cloud/shared/src/lib/services/influencer-marketplace.ts
+++ b/packages/cloud/shared/src/lib/services/influencer-marketplace.ts
@@ -287,7 +287,25 @@ export class InfluencerMarketplaceService {
     if (!booking || booking.advertiser_org_id !== advertiserOrgId) {
       return { ok: false, error: "Booking not found" };
     }
-    if (booking.status !== "delivered") return { ok: false, error: "Not awaiting approval" };
+
+    // Claim the `delivered` money fork before paying (#11116). Exactly one of
+    // {approve, rejectDeliverable} can win the atomic CAS `delivered → approving`;
+    // the loser matches 0 rows and moves no money. A booking already `approving`
+    // is a resume (a prior attempt claimed but hadn't finished paying) — the
+    // payout is idempotent, so re-running is safe. Any other status = not ours.
+    if (booking.status === "delivered") {
+      const claimed = await this.transition(id, "delivered", "approving");
+      if (!claimed) {
+        // Lost the fork to a concurrent reject (or another approve) — re-read
+        // and only continue if WE still own an `approving` claim.
+        const current = await this.getBooking(id);
+        if (current?.status !== "approving") {
+          return { ok: false, error: "Not awaiting approval" };
+        }
+      }
+    } else if (booking.status !== "approving") {
+      return { ok: false, error: "Not awaiting approval" };
+    }
 
     const credit = await redeemableEarningsService.addEarnings({
       userId: booking.influencer_user_id,
@@ -299,20 +317,19 @@ export class InfluencerMarketplaceService {
       metadata: { kind: "influencer_payout", bookingId: id, advertiserOrgId },
     });
     if (!credit.success) {
-      logger.error("[Influencer] payout failed; booking left delivered for retry", {
+      logger.error("[Influencer] payout failed; booking left approving for retry", {
         bookingId: id,
         error: credit.error,
       });
       return { ok: false, error: "Payout failed — retry approval" };
     }
 
-    const moved = await this.transition(id, "delivered", "approved", { resolved_at: new Date() });
+    const moved = await this.transition(id, "approving", "approved", { resolved_at: new Date() });
     if (moved) return { ok: true, booking: moved };
 
-    // Lost the CAS to a concurrent transition after the (idempotent) payout.
     const current = await this.getBooking(id);
     if (current?.status === "approved") return { ok: true, booking: current };
-    logger.error("[Influencer] payout committed but booking moved to another state", {
+    logger.error("[Influencer] payout committed but booking moved off approving", {
       bookingId: id,
       status: current?.status,
     });
@@ -400,8 +417,57 @@ export class InfluencerMarketplaceService {
     return this.getBooking(id).then((b) =>
       !b || b.advertiser_org_id !== advertiserOrgId
         ? { ok: false, error: "Booking not found" }
-        : this.refund(id, ["delivered"], "rejected"),
+        : this.rejectDelivered(id, b),
     );
+  }
+
+  /**
+   * Refund side of the `delivered` money fork (#11116). Unlike the offer/accept
+   * refunds (which can't collide with a payout), rejecting a *delivered*
+   * booking races `approveBooking` for the same escrow, so it must CLAIM the
+   * fork (CAS `delivered → refunding`) BEFORE refunding — exactly one of
+   * approve/reject wins, the loser refunds nothing. Resumable from `refunding`
+   * (the refund is idempotent on the booking id). Mirrors approveBooking.
+   */
+  private async rejectDelivered(id: string, booking: InfluencerBooking): Promise<BookingResult> {
+    if (booking.status === "delivered") {
+      const claimed = await this.transition(id, "delivered", "refunding");
+      if (!claimed) {
+        const current = await this.getBooking(id);
+        if (current?.status !== "refunding") {
+          return { ok: false, error: "Not in a refundable state" };
+        }
+      }
+    } else if (booking.status !== "refunding") {
+      return { ok: false, error: "Not in a refundable state" };
+    }
+
+    try {
+      await creditsService.refundCredits({
+        organizationId: booking.advertiser_org_id,
+        amount: Number(booking.amount),
+        description: "Influencer booking refund",
+        stripePaymentIntentId: `influencer_refund_${id}`,
+        metadata: { kind: "influencer_refund", bookingId: id },
+      });
+    } catch (error) {
+      logger.error("[Influencer] escrow refund failed; booking left refunding for retry", {
+        bookingId: id,
+        error,
+      });
+      return { ok: false, error: "Refund failed — retry" };
+    }
+
+    const moved = await this.transition(id, "refunding", "rejected", { resolved_at: new Date() });
+    if (moved) return { ok: true, booking: moved };
+
+    const current = await this.getBooking(id);
+    if (current?.status === "rejected") return { ok: true, booking: current };
+    logger.error("[Influencer] refund committed but booking moved off refunding", {
+      bookingId: id,
+      status: current?.status,
+    });
+    return { ok: false, error: "Booking changed state during refund" };
   }
 
   cancelBooking(id: string, advertiserOrgId: string): Promise<BookingResult> {


### PR DESCRIPTION
Closes #11116.

## Summary
The influencer-marketplace escrow (#10687) double-spends on the `delivered` money fork. `approveBooking` (release escrow → influencer, key `influencer_booking_<id>`) and `rejectDeliverable` (refund escrow → advertiser, key `influencer_refund_<id>`) both act on a `delivered` booking, both move money **before** the atomic status CAS, and under **different** idempotency keys. The CAS blocks a double *status* transition but not the two money moves that precede it — so a concurrent approve+reject on one booking **pays the influencer AND refunds the advertiser for a single escrow.**

**Self-service, repeatable extraction:** the `amount` is advertiser-controlled, and the same-org guard only blocks booking a profile in the caller's *own* org — a sockpuppet influencer in a second attacker-controlled org passes it. So one actor books influencer=sockpuppet, funds escrow, delivers, then races `approve` + `reject`: the advertiser org is refunded **and** the sockpuppet gains cashable redeemable earnings, per cycle, near-zero-cost. (Sequential is safe — reject then sees a non-`delivered` status — so it is strictly a concurrency/TOCTOU window between the status read and the CAS.)

Full analysis, exploit, and the rejected alternative are in #11116.

## Fix — CAS-claim the delivered fork
Make the two `delivered` exits claim the fork atomically so only one can move money:
- New intermediate statuses **`approving` / `refunding`**. `status` is a plain `text` column with a TS union, so **no migration**.
- `approveBooking`: CAS `delivered → approving` to **claim** before paying. The loser matches 0 rows and pays nothing. Resumable from `approving` (payout is idempotent), so a crash in the claim→pay→finalize window is repaired by a retry.
- `rejectDeliverable`: symmetric CAS `delivered → refunding` claim before refunding.
- The offer/accept refunds (`cancelBooking`, `rejectBooking`) keep the existing `refund()` — they can't collide with a payout and are mutually idempotent on the shared refund key.

Only one of approve/rejectDeliverable can win the CAS from `delivered`, so the escrow is **released XOR refunded, never both**.

### Why not an advisory lock
The issue's first proposal (wrap `re-read → money → CAS` in a `dbWrite.transaction` holding a per-booking `pg_advisory_xact_lock`) **deadlocks single-connection PGlite** — the outer lock-holding tx pins the connection and the nested money ops wait forever, so every existing test times out. It would rely on prod pooling to work → untestable + fragile. The CAS-claim approach needs no lock and no nesting.

## Tests (real PGlite, nothing mocked on the money path)
- **`concurrent approve + rejectDeliverable … moves money exactly once (#11116)`** — `Promise.all` interleaves the two methods' awaits on single-connection PGlite (both reads land before either finalize), reproducing the race; asserts money moves **exactly once** (paid XOR refunded, never both). **Verified this test FAILS on the pre-fix code** (double-spend reproduced: `0 pass / 1 fail`) and passes on the fix — a genuine regression guard, not a tautology.
- **`a booking mid-approve (approving) cannot be refunded by reject`** — a claimed-but-unpaid booking can't be refunded out from under the approver; the owner resumes and is paid exactly once.
- Updated the payout-failure test: a failed payout now rests in `approving` (claimed + fenced) for resume, not `delivered`.

```
bun test packages/cloud/shared/src/lib/services/__tests__/influencer-marketplace.test.ts   # 14 pass
```
`packages/cloud/shared typecheck` + biome clean on all touched files.

## Evidence
- **Auth / multi-tenant isolation proven by test:** the money-safety invariant (release XOR refund) + the denied mid-approve refund are covered by real-PGlite tests, incl. the failing-on-old-code proof. 
- **DB state:** tests assert the advertiser balance and influencer redeemable earnings before/after each scenario (the escrow amount moves once, to exactly one party).
- **Real request→response trace / video / screenshots:** N/A — backend-only change to a service + its state machine, no UI surface and no model-backed endpoint; the property is a money-conservation invariant proven end-to-end against real SQL.
- **Migration up/down:** N/A — no schema/migration change (intermediate statuses are values in an existing `text` column).

Money-path — flagging for maintainer review/merge rather than self-merge; the intermediate-state design is an architectural choice in your lane.