### PR TITLE
fix(orchestrator): serialize task file store first load

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../../src/services/orchestrator-task-store.js";
 import type {
   CreateTaskInput,
+  OrchestratorTaskDocument,
   OrchestratorTaskPlanRevision,
   OrchestratorTaskSession,
 } from "../../src/services/orchestrator-task-types.js";
@@ -445,6 +446,34 @@ describe("InMemoryTaskStore", () => {
 });
 
 describe("FileTaskStore", () => {
+  it("serializes first-touch loads so concurrent operations cannot hydrate over each other", async () => {
+    const file = await tempFile();
+    const seed = new FileTaskStore(file);
+    await seed.createTask(createInput({ title: "seed" }));
+
+    class CountingFileTaskStore extends FileTaskStore {
+      loadCount = 0;
+      override hydrate(docs: OrchestratorTaskDocument[]): void {
+        this.loadCount += 1;
+        super.hydrate(docs);
+      }
+    }
+
+    const store = new CountingFileTaskStore(file);
+    const created = await Promise.all(
+      Array.from({ length: 25 }, (_, i) =>
+        store.createTask(createInput({ title: `concurrent ${i}` })),
+      ),
+    );
+
+    expect(store.loadCount).toBe(1);
+    const listed = await store.listTasks({ includeArchived: true });
+    expect(listed).toHaveLength(created.length + 1);
+    for (const doc of created) {
+      expect(listed.map((task) => task.id)).toContain(doc.task.id);
+    }
+  });
+
   it("persists tasks atomically and reloads them in a fresh store", async () => {
     const file = await tempFile();
     const store = new FileTaskStore(file);

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
@@ -533,27 +533,33 @@ export class FileTaskStore extends InMemoryTaskStore {
 
   private async ensureLoaded(): Promise<void> {
     if (this.loaded) return;
-    try {
-      const contents = await readFile(this.filePath, "utf8");
-      const parsed = JSON.parse(contents) as unknown;
-      if (Array.isArray(parsed)) {
-        this.hydrate(
-          parsed
-            .map(normalizeTaskDocument)
-            .filter((doc): doc is OrchestratorTaskDocument => doc !== null),
-        );
+    await this.enqueue(async () => {
+      if (this.loaded) return;
+      try {
+        const contents = await readFile(this.filePath, "utf8");
+        const parsed = JSON.parse(contents) as unknown;
+        if (Array.isArray(parsed)) {
+          this.hydrate(
+            parsed
+              .map(normalizeTaskDocument)
+              .filter((doc): doc is OrchestratorTaskDocument => doc !== null),
+          );
+        } else {
+          this.hydrate([]);
+        }
+      } catch (error) {
+        const code =
+          isRecord(error) && typeof error.code === "string" ? error.code : "";
+        if (code !== "ENOENT") {
+          this.logger?.warn?.(
+            "[OrchestratorTaskStore] task file unreadable; starting empty",
+            error,
+          );
+        }
+        this.hydrate([]);
       }
-    } catch (error) {
-      const code =
-        isRecord(error) && typeof error.code === "string" ? error.code : "";
-      if (code !== "ENOENT") {
-        this.logger?.warn?.(
-          "[OrchestratorTaskStore] task file unreadable; starting empty",
-          error,
-        );
-      }
-    }
-    this.loaded = true;
+      this.loaded = true;
+    });
   }
 
   override async createTask(input: CreateTaskInput) {


### PR DESCRIPTION
## Summary

Fixes one still-real reliability follow-up from #11028: `FileTaskStore.ensureLoaded()` now serializes its first durable hydrate through the existing write queue, matching the session-store pattern. Concurrent first-touch operations can no longer run multiple out-of-band hydrates that clobber an already-enqueued write.

## Triage from #11028

| Item | Status | Notes |
| --- | --- | --- |
| `tasks.ts` intent-parsing cluster | still-real | Not picked: broad swarm-active planner/action file with mixed product decisions. Recent audit comment still lists several smaller issues there. |
| `active-workspace-context.ts` hardcoded `tasks=[]` | fixed | Covered by merged #11061, reusable sessions now derive from real session status and phantom task machinery was removed. |
| interruption false cancel on `stop <code-action>` | fixed | Covered by merged #11062 for regex false-cancel; deeper `shouldRespond` verdict threading remains still-real but broader architecture. |
| supervisor digest staleness | fixed | Covered by merged #11059. |
| `orchestrator-task-store.ts` file first-touch race | fixed in this PR | Highest-value tractable item selected. |
| `orchestrator-task-store.ts` wider cross-process RMW / SQL delete true / stale-lock threshold | still-real | Not picked: broader than one concern, some requires cross-process/SQL semantics beyond this PR. |
| `ssrf-guard.ts` DNS-rebinding TOCTOU pin | still-real | Deferred per issue comment: needs undici Agent/custom lookup and meaningful integration seam. |
| full benchmark matrix | still-real / infra-blocked | Requires Docker/Modal/datasets not available here. |
| Round-3 `acp-service` busy-guard TOCTOU | still-real | Separate file/concern, avoided to keep this PR narrow. |
| Round-3 `recordUsage` dedup check-then-act | still-real | Separate service/concern. |
| Round-3 SQL `findSession` `LIKE '%id%'` hot path | still-real | Separate SQL/indexing concern. |
| Round-3 `getAvailableAgents` availability LARP | still-real | Separate availability/probe concern. |
| Provider error hygiene | fixed | Covered by merged #11096. |
| Session store adapter/runtime DB persistence | fixed | Covered by merged #11020. |
| Swarm coordinator restore / cache cleanup | fixed | Covered by merged #10981 and #11086. |

## Tests

- `bunx vitest run --config vitest.config.ts __tests__/unit/orchestrator-task-store.test.ts` ✅, 29 passed
- `bun run typecheck` ⚠️ attempted, blocked by baseline missing generated/workspace modules unrelated to this change:
  - `@elizaos/contracts`
  - `@elizaos/agent/utils/atomic-json`
  - `./generated/validation-keyword-data.{ts,js}`

Codex review was skipped due current usage limits, per lane instruction.

Fixes one checklist item from #11028.
