### PR TITLE
fix(core): make reflection extraction schemas strict-structured-output safe

### DIFF
--- a/.github/issue-evidence/11123-reflection-strict-schema.md
+++ b/.github/issue-evidence/11123-reflection-strict-schema.md
@@ -1,0 +1,76 @@
+# Evidence — #11123 reflection extraction fails on strict structured-output providers
+
+Setup: real eliza-code in-process agent (sql + plugin-openai + coding-tools +
+shell) pointed at the REAL Eliza Cloud (`gpt-oss-120b`, cerebras-served)
+through a local logging proxy (`:8899 → api.elizacloud.ai`) so every request
+body and response is captured verbatim. Nothing mocked.
+
+## 1. The bug, observed live (pre-fix)
+
+Every turn: the main reply succeeds, then the post-turn reflection call dies —
+
+```
+[03:03:01] POST /v1/chat/completions {"model":"gpt-oss-120b","stream":true,…,"hasTools":1}                  → 200 in 7175ms
+[03:03:03] POST /v1/chat/completions {"model":"gpt-oss-120b","stream":true,"response_format":"json_schema"} → 200 in 1427ms ⚠ERROR
+    ↳ {"error":{"message":"Bad Request","type":"rate_limit_error","code":500}}
+```
+
+The captured request body is core's combined reflection schema
+(factMemory/relationships/identities ops). Fact/relationship/identity
+memories are never written.
+
+## 2. Root cause isolated by live bisection (same endpoint, same model)
+
+| response_format.json_schema variant | result |
+|---|---|
+| object `{properties:{}, additionalProperties:false, required:[]}` | ✅ 200, valid JSON returned |
+| object `{additionalProperties:false}` — **no `properties`** | ❌ `Bad Request` |
+| object `{additionalProperties:true}` | ❌ `Bad Request` |
+| array `{items:…, maxItems:16}` | ❌ `Bad Request` |
+| `enum` / missing top-level `name` | ✅ fine |
+
+The reflection schema hits BOTH failing shapes: `structured_fields` /
+`metadata` are object nodes without `properties`, and `keywords` carries
+`maxItems: 16`.
+
+## 3. The fix, verified live (post-fix, same proxy, same prompt class)
+
+```
+[03:41:59] POST /v1/chat/completions {…,"hasTools":1}                              → 200 in 8617ms
+[03:42:04] POST /v1/chat/completions {…,"response_format":"json_schema"}           → 200 in 4967ms      (no error chunk)
+```
+
+The extraction stream completes cleanly — 4.9s of real generation instead of
+a fast reject.
+
+## 4. Mutation checks — the new invariant test catches both shapes
+
+Test: walks every reflection evaluator's response schema; every object node
+must declare `properties` + `additionalProperties:false`, and no node may use
+strict-unsupported constraint keywords (`maxItems`, `minItems`, `maxLength`,
+`pattern`, `minimum`, …).
+
+- Revert `structured_fields` to the bare object → `Tests 1 failed | 2 passed`.
+- Re-add `maxItems: 16` to keywords → `Tests 1 failed | 2 passed`.
+- Fixed code → `Tests 3 passed (3)`.
+
+## 5. Behavior preserved
+
+- `properties: {}` on the open-ended objects changes nothing semantically —
+  the code already documented "no extra keys land in structured_fields".
+- The 16-keyword cap moves from the wire schema into code: zod now **trims**
+  to 16 (previously `.max(16)` would fail the whole op on the 17th keyword),
+  and storage re-caps via `MAX_KEYWORDS` (`fact-keywords.ts:66,127`) as
+  before.
+- Full evaluator suite green; `tsgo --noEmit` clean; full multi-target core
+  build (`node + browser + edge`) green; biome clean.
+
+## N/A rows
+
+- Screenshots / video: N/A — headless runtime/schema change, no UI surface.
+- Frontend logs: N/A — no client involved; the wire captures above are the
+  network evidence.
+- Live-LLM trajectory file: the proxy captures in §1/§3 ARE the live model
+  interaction (request body + streamed response) for the exact code path
+  changed; the reflection call's output is consumed internally by the
+  evaluator (no user-visible reply to record).

--- a/packages/core/src/features/advanced-capabilities/evaluators/factExtractor.schema.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/factExtractor.schema.ts
@@ -65,7 +65,14 @@ export type VerificationStatus = z.infer<typeof VerificationStatusEnum>;
  * insertions on schema drift.
  */
 const StructuredFieldsSchema = z.record(z.string(), z.unknown());
-const KeywordsSchema = z.array(z.string().min(1)).max(16).optional();
+// Trim instead of reject: the wire schema can no longer advertise a max
+// (strict structured-output validators reject `maxItems`), so an over-long
+// keyword list from the model must degrade to the first 16 rather than
+// failing the whole op. Storage re-caps via MAX_KEYWORDS anyway.
+const KeywordsSchema = z
+	.array(z.string().min(1))
+	.transform((keywords) => keywords.slice(0, 16))
+	.optional();
 
 const AddDurableOpSchema = z.object({
 	op: z.literal("add_durable"),

--- a/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.test.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.test.ts
@@ -141,3 +141,62 @@ describe("factMemoryEvaluator keyword dedupe", () => {
 		expect(result?.data).toMatchObject({ added: 0, strengthened: 1 });
 	});
 });
+
+describe("reflection evaluator schemas are strict-structured-output safe", () => {
+	// Strict-mode validators (Cerebras, Groq, OpenAI strict) reject any object
+	// node that lacks an explicit `properties` map or allows additional
+	// properties — the WHOLE extraction request 400s ("Bad Request"), so the
+	// agent silently never writes fact/relationship memories. Walk every
+	// evaluator's response schema and assert the invariant on each object node.
+	function assertStrictObjectNodes(node: unknown, path: string): void {
+		if (node === null || typeof node !== "object") return;
+		if (Array.isArray(node)) {
+			node.forEach((item, i) => assertStrictObjectNodes(item, `${path}[${i}]`));
+			return;
+		}
+		const record = node as Record<string, unknown>;
+		// Strict mode also rejects value-constraint keywords (maxItems,
+		// minItems, maxLength, pattern, minimum, ...) — enforce caps in code,
+		// never on the wire.
+		for (const banned of [
+			"maxItems",
+			"minItems",
+			"uniqueItems",
+			"maxLength",
+			"minLength",
+			"pattern",
+			"format",
+			"minimum",
+			"maximum",
+			"multipleOf",
+			"minProperties",
+			"maxProperties",
+		]) {
+			expect(
+				record[banned],
+				`${path} must not use strict-unsupported keyword "${banned}"`,
+			).toBeUndefined();
+		}
+		if (record.type === "object") {
+			expect(record.properties, `${path} must declare properties`).toBeTypeOf(
+				"object",
+			);
+			expect(
+				record.additionalProperties,
+				`${path} must set additionalProperties: false`,
+			).toBe(false);
+		}
+		for (const [key, value] of Object.entries(record)) {
+			assertStrictObjectNodes(value, `${path}.${key}`);
+		}
+	}
+
+	it("every object node in every reflection schema has explicit properties + additionalProperties:false", async () => {
+		const { reflectionItems } = await import("./reflection-items.ts");
+		for (const evaluator of reflectionItems) {
+			const schema = (evaluator as { schema?: unknown }).schema;
+			if (!schema) continue;
+			assertStrictObjectNodes(schema, evaluator.name ?? "evaluator");
+		}
+	});
+});

--- a/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.ts
@@ -80,14 +80,24 @@ const factOpsSchema: JSONSchema = {
 					category: { type: "string" },
 					// Strict-mode JSON schema validators (Groq, Cerebras, OpenAI strict
 					// tools) require every nested object to carry
-					// `additionalProperties: false`. We accept this means no extra keys
-					// land in `structured_fields` — the field stays for API contract,
-					// the model can always omit it (not in `required`).
-					structured_fields: { type: "object", additionalProperties: false },
+					// `additionalProperties: false` AND an explicit `properties` map —
+					// an object node without `properties` is rejected outright
+					// ("Bad Request"), which kills the whole extraction call. We accept
+					// this means no extra keys land in `structured_fields` — the field
+					// stays for API contract, the model can always omit it (not in
+					// `required`).
+					structured_fields: {
+						type: "object",
+						properties: {},
+						additionalProperties: false,
+					},
+					// No maxItems: strict structured-output validators (Cerebras, OpenAI
+					// strict) reject array length constraints outright — the whole
+					// extraction request 400s. The 16-keyword cap is enforced in code
+					// (zod trim + MAX_KEYWORDS at storage) instead of on the wire.
 					keywords: {
 						type: "array",
 						items: { type: "string" },
-						maxItems: 16,
 					},
 					verification_status: { type: "string" },
 					valid_at: { type: "string" },
@@ -118,8 +128,13 @@ const relationshipSchema: JSONSchema = {
 					targetEntityId: { type: "string" },
 					tags: { type: "array", items: { type: "string" } },
 					// Strict mode: every object must carry additionalProperties:false
-					// even when the property is logically open-ended.
-					metadata: { type: "object", additionalProperties: false },
+					// AND an explicit properties map even when the property is
+					// logically open-ended — omitting `properties` is a hard reject.
+					metadata: {
+						type: "object",
+						properties: {},
+						additionalProperties: false,
+					},
 				},
 				required: ["sourceEntityId", "targetEntityId"],
 				additionalProperties: false,


### PR DESCRIPTION
Fixes #11123.

Every post-turn reflection/fact-extraction call from an agent on a strict structured-output provider (Cerebras via Eliza Cloud — i.e. every cloud agent on `gpt-oss-120b`-class models — and OpenAI strict) failed with a provider "Bad Request": **fact, relationship, and identity memories were never extracted or persisted.** The agent replies fine, so the breakage is silent (only symptom: a raw error object dumped mid-stream).

Found live while exercising the cockpit terminal's in-process agent (#11040 follow-up); root-caused by capturing every request through a logging proxy and bisecting the schema shapes against the real endpoint.

### Two strict-mode violations in `reflection-items.ts`

| violation | strict-mode rule | fix |
|---|---|---|
| `structured_fields` / `metadata` declared `{type:"object", additionalProperties:false}` with **no `properties`** | every object node must carry an explicit `properties` map | `properties: {}` (semantics unchanged — the code already documented that no extra keys land there) |
| `keywords: {…, maxItems: 16}` | array length constraints are rejected | drop `maxItems` from the wire; the cap is enforced in code — zod **trims** to 16 (previously `.max(16)` failed the whole op on the 17th keyword) and storage re-caps via `MAX_KEYWORDS` |

The file's own comments show it already *tried* to be strict-safe (`additionalProperties: false` everywhere) — these were the two remaining rules the validators enforce with a hard 400.

### Live bisection (api.elizacloud.ai, gpt-oss-120b, stream + json_schema)

- object `{properties:{}, additionalProperties:false}` → ✅ · object without `properties` → ❌ Bad Request · `additionalProperties:true` → ❌ · array with `maxItems` → ❌ · `enum`/missing `name` → ✅

### Proof (full captures in `.github/issue-evidence/11123-reflection-strict-schema.md`)

- **Pre-fix live:** reflection call → SSE error chunk `{"message":"Bad Request",…}` after every successful reply.
- **Post-fix live:** identical call → 200, clean stream, 4.9 s of real generation — extraction completes.
- **Mutation-checked test:** new invariant test walks every reflection evaluator schema (object nodes must have `properties` + `additionalProperties:false`; bans `maxItems`/`minItems`/`maxLength`/`pattern`/… ) — goes red on each pre-fix shape individually, green on the fix.
- Evaluator suite green, `tsgo --noEmit` clean, full multi-target core build (node+browser+edge) green, biome clean.

### N/A rows
- Screenshots/video: N/A — headless runtime/schema change, no UI surface.
- Frontend logs: N/A — no client; the proxy wire captures are the network evidence.
- Scenario-runner trajectory: the proxy captures the exact live model interaction (request body + streamed response) for the changed path; the reflection output is consumed internally by the evaluator, not rendered.