### PR TITLE
fix(ui/test): shim Node >=25's broken Web Storage global in the jsdom setup

### DIFF
--- a/packages/ui/vitest.setup.ts
+++ b/packages/ui/vitest.setup.ts
@@ -40,6 +40,51 @@ if (typeof Element !== "undefined") {
   }
 }
 
+// Node ≥25 ships a Web Storage `localStorage`/`sessionStorage` global that is
+// non-functional without `--localstorage-file` (its methods are missing) and
+// SHADOWS jsdom's Storage — even `window.localStorage` resolves to it here, so
+// every jsdom test touching storage throws `localStorage.getItem is not a
+// function` on hosts running Node ≥25 (CI's Node 24 gates the global behind a
+// flag and is unaffected). Install a real in-memory Storage on both access
+// paths, only when the present one is broken — never overwrite a working one.
+function createMemoryStorage(): Storage {
+  const store = new Map<string, string>();
+  return {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (key: string) => store.get(key) ?? null,
+    key: (index: number) => [...store.keys()][index] ?? null,
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      store.set(key, String(value));
+    },
+  };
+}
+
+if (typeof window !== "undefined") {
+  for (const name of ["localStorage", "sessionStorage"] as const) {
+    const existing = (globalThis as Record<string, unknown>)[name] as
+      | Storage
+      | undefined;
+    if (existing && typeof existing.getItem === "function") continue;
+    const memory = createMemoryStorage();
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      writable: true,
+      value: memory,
+    });
+    Object.defineProperty(window, name, {
+      configurable: true,
+      writable: true,
+      value: memory,
+    });
+  }
+}
+
 // @testing-library/react's act() checks this flag to decide whether to use
 // synchronous flushing. It must be set before any test code runs so that
 // React renders triggered inside act() complete synchronously in jsdom.


### PR DESCRIPTION
## Shim Node ≥25's broken Web Storage global in the packages/ui jsdom setup

Node ≥25 ships a `localStorage`/`sessionStorage` global that is **non-functional without `--localstorage-file`** (its methods are missing) and **shadows jsdom's Storage** — even `window.localStorage` resolves to it. Every packages/ui jsdom test touching storage throws `localStorage.getItem is not a function` on Node ≥25 hosts: `ftu-welcome.test.tsx` was 5/8 red locally while green in CI (Node 24 gates the global behind a flag).

**Fix:** install an in-memory `Storage` on both access paths (`globalThis` + `window`) in `vitest.setup.ts`, **only when the present implementation is broken** — a working implementation is never overwritten. This generalizes the per-file workaround `StewardProviderRuntime.test.tsx` already carries and follows the setup file's existing only-when-absent shim convention (`Element.prototype.scrollTo`).

### Evidence
- Before (Node v25.2.1): `ftu-welcome.test.tsx` **5 failed / 3 passed** on unmodified develop. After: **8/8**.
- Storage-heavy neighbors stay green: `useDisplayPreferences.background.test.tsx` + `StewardProviderRuntime.test.tsx` + `persistence.background.test.ts` — **26/26** (the per-file stub still wins because the shim skips working implementations).
- `node -e 'console.log(typeof localStorage, typeof localStorage.getItem)'` on this host: `object undefined` + the `--localstorage-file` warning — the exact broken shape the shim detects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
