### PR TITLE
refactor(ui): flatten residual card chrome to the minimal eliza aesthetic (#10710)

### DIFF
--- a/packages/ui/src/components/desktop/DesktopTabBar.tsx
+++ b/packages/ui/src/components/desktop/DesktopTabBar.tsx
@@ -44,7 +44,7 @@ function TabButton({
           : "border-border/40 bg-card/60 text-muted hover:border-border hover:text-txt"
       }`}
     >
-      <span className="flex h-4 w-4 shrink-0 items-center justify-center rounded-[3px] bg-accent/10 text-accent">
+      <span className="flex h-4 w-4 shrink-0 items-center justify-center rounded-sm bg-accent/10 text-accent">
         <ViewIcon icon={tab.icon} label={tab.label} className="h-3 w-3" />
       </span>
       <button

--- a/packages/ui/src/components/pages/AutomationsFeed.tsx
+++ b/packages/ui/src/components/pages/AutomationsFeed.tsx
@@ -615,10 +615,10 @@ function OverviewStat({
   value: number;
 }) {
   return (
-    <div
-      className="rounded-sm border border-border/40 bg-bg-accent/25 px-3 py-2"
-      data-testid={`automation-stat-${statKey}`}
-    >
+    // Flat — no card border/fill (#10710, "no card chrome"): the grid gap +
+    // label/value type hierarchy group the stats; the surrounding surface shows
+    // through, matching the minimal eliza aesthetic (cf. SettingsView flat rows).
+    <div className="py-1" data-testid={`automation-stat-${statKey}`}>
       <div className="text-2xs font-medium uppercase tracking-normal text-muted-strong">
         {label}
       </div>


### PR DESCRIPTION
## Summary

Audit-and-strip pass for #10710 (default-visible views → minimal "eliza"
aesthetic), done the hard way: stood up a fresh `develop` worktree with its own
install, ran `audit:app`, and **reviewed the actual rendered pixels of every
default view** (188 screenshots across 4 viewports) before touching anything.

## Finding: the aesthetic is already ~achieved on develop

The primary content-card offender the issue named (`rounded-lg border
border-white/10 bg-black/55` cards) is **gone from the real default-view
components**. Verified by screenshot that the default surfaces already read flat:

- **Character** — icon + heading sections (Personality / Relationships /
  Knowledge / Skills / Experience), no cards.
- **Wallet (inventory)** — balance, address rows, token list all borderless on
  the neutral surface.
- **Apps / Settings** — already flat.
- **Launcher springboard** (which apps/views/contacts/rolodex fall back to in the
  keyless audit — hence their identical density) — flat icon tiles + one dock;
  the deliberate iOS aesthetic, not gratuitous card chrome.

## What this PR strips (the genuine residuals)

- **`AutomationsFeed` `OverviewStat`**: the 4 metric tiles wrapped each value in
  a `rounded-sm border border-border/40 bg-bg-accent/25` card — the exact
  "border … bg … card" pattern the issue targets. Flattened to no border/fill;
  the grid gap + label/value type hierarchy group the stats and the surface
  shows through (matches the flat SettingsView rows + the durable "no card
  chrome" direction). See before/after below.
- **`DesktopTabBar`** tab icon badge: off-token `rounded-[3px]` (the audit flags
  any radius off the 0/6/8/12/16/20/24 token scale) → the `rounded-sm` token
  class the parent tab already uses. It was the only off-token arbitrary radius
  in the entire `packages/ui/src` tree.

`packages/ui` typecheck + biome clean.

## Evidence

- Before/after screenshots of `builtin-automations` (mobile-portrait) attached to
  the issue.
- The full 188-screenshot `audit:app` walk confirmed the other default views are
  already flat (spot-checked character/wallet/apps/settings/launcher by hand).

## Deferred (honest)

- **`ELIZA_AUDIT_APP_STRICT` flip**: needs a clean full `audit:app` run to seed
  the `AESTHETIC_VERDICT_DEBT` allowlist. The audit's screenshot walk stalls
  before writing `report.json` in this local environment (captures all 188 rest
  shots, then hangs on the hover phase), so the debt-seed + strict flip must come
  from a CI audit run. Findings + the strict-flip recipe posted to #10710.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
