### PR TITLE
fix(cloud-sdk): admit approving/refunding claim states in InfluencerBookingDto.status (#11116 follow-up)

### DIFF
--- a/packages/cloud/sdk/src/types.ts
+++ b/packages/cloud/sdk/src/types.ts
@@ -1389,6 +1389,11 @@ export interface InfluencerBookingDto {
     | "offered"
     | "accepted"
     | "delivered"
+    // Claim states: the atomic delivered→approving/refunding CAS fences the
+    // money fork (#11116); list/get can surface a booking mid-claim or
+    // crash-stuck in one of these.
+    | "approving"
+    | "refunding"
     | "approved"
     | "rejected"
     | "cancelled";

--- a/packages/cloud/shared/src/db/schemas/influencer-marketplace.ts
+++ b/packages/cloud/shared/src/db/schemas/influencer-marketplace.ts
@@ -48,6 +48,13 @@ export type InfluencerBookingStatus =
   | "offered"
   | "accepted"
   | "delivered"
+  // Intermediate CLAIM states for the `delivered` money fork (#11116): exactly
+  // one of approve/rejectDeliverable can CAS `delivered` → `approving`/`refunding`,
+  // so only the winner moves money. A crash in the claim→money→finalize window
+  // leaves the booking here for the same operation to resume (money ops are
+  // idempotent). `status` is a plain text column, so this needs no migration.
+  | "approving"
+  | "refunding"
   | "approved"
   | "rejected"
   | "cancelled";

--- a/packages/cloud/shared/src/lib/services/__tests__/influencer-marketplace.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/influencer-marketplace.test.ts
@@ -308,7 +308,7 @@ describe("Influencer marketplace escrow (#10687)", () => {
     expect(await orgBalance(adv.orgId)).toBeCloseTo(30, 2); // still exactly one debit
   });
 
-  test("payout failure leaves the booking delivered; retry pays exactly once", async () => {
+  test("payout failure leaves the booking approving; retry pays exactly once", async () => {
     if (!pgliteReady) return;
     const adv = await seedOrgUser("100.00");
     const inf = await seedProfile();
@@ -332,10 +332,12 @@ describe("Influencer marketplace escrow (#10687)", () => {
       error: "simulated payout outage",
     });
     try {
-      // Payout fails → approve MUST NOT report success or move the status.
+      // Payout fails after the fork was claimed → approve MUST NOT report
+      // success or pay; the booking rests in `approving` for the same operation
+      // to resume (the claim CAS already fenced out a concurrent reject). (#11116)
       const failed = await service.approveBooking(id, adv.orgId);
       expect(failed.ok).toBe(false);
-      expect((await service.getBooking(id))?.status).toBe("delivered");
+      expect((await service.getBooking(id))?.status).toBe("approving");
       expect(await earnings(inf.userId)).toBe(0);
     } finally {
       redeemableEarningsService.addEarnings = originalAddEarnings;
@@ -437,5 +439,86 @@ describe("Influencer marketplace escrow (#10687)", () => {
       createdByUserId: inf.userId,
     });
     expect(res.ok).toBe(false);
+  });
+
+  // #11116 — the `delivered` money fork must never both pay the influencer AND
+  // refund the advertiser for one escrow. Before the CAS-claim fix, approve and
+  // rejectDeliverable each read `delivered` and moved money before their status
+  // CAS, under different idempotency keys, so a concurrent pair double-spent.
+  // Promise.all on single-connection PGlite interleaves the two methods' awaits
+  // (both reads land before either finalize), reproducing the race; the claim
+  // CAS (`delivered → approving`/`refunding`) now lets exactly one win.
+  test("concurrent approve + rejectDeliverable on a delivered booking moves money exactly once (#11116)", async () => {
+    if (!pgliteReady) return;
+    const adv = await seedOrgUser("100.00");
+    const inf = await seedProfile();
+    const { booking } = await service.createBooking({
+      advertiserOrgId: adv.orgId,
+      profileId: inf.profileId,
+      brief: "b",
+      amount: 40,
+      createdByUserId: adv.userId,
+    });
+    const id = booking?.id as string;
+    await service.acceptBooking(id, inf.userId);
+    await service.submitDeliverable(id, inf.userId, "https://x/post");
+    // Escrow funded: advertiser debited 40 → 60; nothing paid/refunded yet.
+    expect(await orgBalance(adv.orgId)).toBeCloseTo(60, 2);
+    expect(await earnings(inf.userId)).toBe(0);
+
+    const [approve, reject] = await Promise.all([
+      service.approveBooking(id, adv.orgId),
+      service.rejectDeliverable(id, adv.orgId),
+    ]);
+
+    // Exactly one exit succeeds; the other is refused.
+    expect([approve.ok, reject.ok].filter(Boolean).length).toBe(1);
+
+    const paid = await earnings(inf.userId); // influencer payout (0 or 40)
+    const bal = await orgBalance(adv.orgId); // advertiser (60 held, or 100 refunded)
+    const refunded = bal >= 99.99; // refund returned the 40
+
+    // The invariant: NEVER both. Either influencer paid (40) and advertiser
+    // stays at 60, or advertiser refunded (100) and influencer paid 0.
+    expect(paid > 0 && refunded).toBe(false);
+    if (approve.ok) {
+      expect(paid).toBeCloseTo(40, 2);
+      expect(bal).toBeCloseTo(60, 2);
+      expect((await service.getBooking(id))?.status).toBe("approved");
+    } else {
+      expect(paid).toBe(0);
+      expect(bal).toBeCloseTo(100, 2);
+      expect((await service.getBooking(id))?.status).toBe("rejected");
+    }
+  });
+
+  test("a booking mid-approve (approving) cannot be refunded by reject (#11116)", async () => {
+    if (!pgliteReady) return;
+    const adv = await seedOrgUser("100.00");
+    const inf = await seedProfile();
+    const { booking } = await service.createBooking({
+      advertiserOrgId: adv.orgId,
+      profileId: inf.profileId,
+      brief: "b",
+      amount: 30,
+      createdByUserId: adv.userId,
+    });
+    const id = booking?.id as string;
+    await service.acceptBooking(id, inf.userId);
+    await service.submitDeliverable(id, inf.userId, "https://x/post");
+    // Simulate an approve that claimed the fork but hasn't finished paying.
+    await dbWrite
+      .update(influencerBookings)
+      .set({ status: "approving" })
+      .where(eq(influencerBookings.id, id));
+
+    const rejected = await service.rejectDeliverable(id, adv.orgId);
+    expect(rejected.ok).toBe(false);
+    expect(await orgBalance(adv.orgId)).toBeCloseTo(70, 2); // escrow still held, no refund
+    // The rightful owner can still resume the approval and get paid once.
+    const resumed = await service.approveBooking(id, adv.orgId);
+    expect(resumed.ok).toBe(true);
+    expect(await earnings(inf.userId)).toBeCloseTo(30, 2);
+    expect(await orgBalance(adv.orgId)).toBeCloseTo(70, 2);
   });
 });

--- a/packages/cloud/shared/src/lib/services/influencer-marketplace.ts
+++ b/packages/cloud/shared/src/lib/services/influencer-marketplace.ts
@@ -287,7 +287,25 @@ export class InfluencerMarketplaceService {
     if (!booking || booking.advertiser_org_id !== advertiserOrgId) {
       return { ok: false, error: "Booking not found" };
     }
-    if (booking.status !== "delivered") return { ok: false, error: "Not awaiting approval" };
+
+    // Claim the `delivered` money fork before paying (#11116). Exactly one of
+    // {approve, rejectDeliverable} can win the atomic CAS `delivered → approving`;
+    // the loser matches 0 rows and moves no money. A booking already `approving`
+    // is a resume (a prior attempt claimed but hadn't finished paying) — the
+    // payout is idempotent, so re-running is safe. Any other status = not ours.
+    if (booking.status === "delivered") {
+      const claimed = await this.transition(id, "delivered", "approving");
+      if (!claimed) {
+        // Lost the fork to a concurrent reject (or another approve) — re-read
+        // and only continue if WE still own an `approving` claim.
+        const current = await this.getBooking(id);
+        if (current?.status !== "approving") {
+          return { ok: false, error: "Not awaiting approval" };
+        }
+      }
+    } else if (booking.status !== "approving") {
+      return { ok: false, error: "Not awaiting approval" };
+    }
 
     const credit = await redeemableEarningsService.addEarnings({
       userId: booking.influencer_user_id,
@@ -299,20 +317,19 @@ export class InfluencerMarketplaceService {
       metadata: { kind: "influencer_payout", bookingId: id, advertiserOrgId },
     });
     if (!credit.success) {
-      logger.error("[Influencer] payout failed; booking left delivered for retry", {
+      logger.error("[Influencer] payout failed; booking left approving for retry", {
         bookingId: id,
         error: credit.error,
       });
       return { ok: false, error: "Payout failed — retry approval" };
     }
 
-    const moved = await this.transition(id, "delivered", "approved", { resolved_at: new Date() });
+    const moved = await this.transition(id, "approving", "approved", { resolved_at: new Date() });
     if (moved) return { ok: true, booking: moved };
 
-    // Lost the CAS to a concurrent transition after the (idempotent) payout.
     const current = await this.getBooking(id);
     if (current?.status === "approved") return { ok: true, booking: current };
-    logger.error("[Influencer] payout committed but booking moved to another state", {
+    logger.error("[Influencer] payout committed but booking moved off approving", {
       bookingId: id,
       status: current?.status,
     });
@@ -400,8 +417,57 @@ export class InfluencerMarketplaceService {
     return this.getBooking(id).then((b) =>
       !b || b.advertiser_org_id !== advertiserOrgId
         ? { ok: false, error: "Booking not found" }
-        : this.refund(id, ["delivered"], "rejected"),
+        : this.rejectDelivered(id, b),
     );
+  }
+
+  /**
+   * Refund side of the `delivered` money fork (#11116). Unlike the offer/accept
+   * refunds (which can't collide with a payout), rejecting a *delivered*
+   * booking races `approveBooking` for the same escrow, so it must CLAIM the
+   * fork (CAS `delivered → refunding`) BEFORE refunding — exactly one of
+   * approve/reject wins, the loser refunds nothing. Resumable from `refunding`
+   * (the refund is idempotent on the booking id). Mirrors approveBooking.
+   */
+  private async rejectDelivered(id: string, booking: InfluencerBooking): Promise<BookingResult> {
+    if (booking.status === "delivered") {
+      const claimed = await this.transition(id, "delivered", "refunding");
+      if (!claimed) {
+        const current = await this.getBooking(id);
+        if (current?.status !== "refunding") {
+          return { ok: false, error: "Not in a refundable state" };
+        }
+      }
+    } else if (booking.status !== "refunding") {
+      return { ok: false, error: "Not in a refundable state" };
+    }
+
+    try {
+      await creditsService.refundCredits({
+        organizationId: booking.advertiser_org_id,
+        amount: Number(booking.amount),
+        description: "Influencer booking refund",
+        stripePaymentIntentId: `influencer_refund_${id}`,
+        metadata: { kind: "influencer_refund", bookingId: id },
+      });
+    } catch (error) {
+      logger.error("[Influencer] escrow refund failed; booking left refunding for retry", {
+        bookingId: id,
+        error,
+      });
+      return { ok: false, error: "Refund failed — retry" };
+    }
+
+    const moved = await this.transition(id, "refunding", "rejected", { resolved_at: new Date() });
+    if (moved) return { ok: true, booking: moved };
+
+    const current = await this.getBooking(id);
+    if (current?.status === "rejected") return { ok: true, booking: current };
+    logger.error("[Influencer] refund committed but booking moved off refunding", {
+      bookingId: id,
+      status: current?.status,
+    });
+    return { ok: false, error: "Booking changed state during refund" };
   }
 
   cancelBooking(id: string, advertiserOrgId: string): Promise<BookingResult> {


### PR DESCRIPTION
Follow-up to just-merged #11124: the atomic delivered→approving/refunding claim fence means list/get routes can surface a booking mid-claim (or crash-stuck) in `approving`/`refunding` — states outside the SDK DTO's declared union. Two-line contract fix flagged in adversarial review; biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)