### PR TITLE
fix(build): never ship a stale desktop fused lib to a device (no-stale-pieces)

### DIFF
--- a/packages/app-core/package.json
+++ b/packages/app-core/package.json
@@ -46,6 +46,8 @@
     "voice:interactive": "bun ./scripts/voice-interactive.mjs",
     "voice:duet": "bun ./scripts/voice-duet.mjs",
     "build:fused-desktop": "node ./scripts/stage-desktop-fused-lib.mjs",
+    "build:fused-desktop:ensure": "node ./scripts/stage-desktop-fused-lib.mjs --ensure",
+    "build:fused-desktop:check": "node ./scripts/stage-desktop-fused-lib.mjs --check",
     "build:flatpak": "node ./scripts/build-flatpak.mjs",
     "build:flatpak:store": "ELIZA_BUILD_VARIANT=store node ./scripts/build-flatpak.mjs",
     "build:flatpak:direct": "ELIZA_BUILD_VARIANT=direct node ./scripts/build-flatpak.mjs",

--- a/packages/app-core/scripts/desktop-build.mjs
+++ b/packages/app-core/scripts/desktop-build.mjs
@@ -5,7 +5,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolveElectrobunDir, resolveMainAppDir } from "./lib/app-dir.mjs";
-import { maxMtimeUnder } from "./lib/artifact-staleness.mjs";
+import { artifactStaleness, maxMtimeUnder } from "./lib/artifact-staleness.mjs";
 import {
   buildWindowsRepairSteps,
   classifyElectrobunViewFailure,
@@ -1177,6 +1177,36 @@ function ensureFusedLibSubmodule() {
 }
 
 /**
+ * Whether the already-staged fused lib is OLDER than the native fork source it
+ * was built from — the classic "dev→device stale native lib" trap: a rebuild
+ * landed in the fork's build dir (or the fork submodule was updated) but the
+ * copy staged into the app bundle was never refreshed, so the app ships a lib
+ * that no longer matches the source. Mirrors the renderer freshness guard
+ * (assertRendererRebuiltSince). Skipped when the fork isn't checked out (a
+ * sidecar-less prebuilt drop-in is trusted, same as the variant gate).
+ */
+function fusedLibSourceStaleness() {
+  if (!fusedLibAlreadyStaged())
+    return { stale: false, reason: "no staged lib" };
+  if (!fs.existsSync(path.join(FUSED_LIB_FORK_DIR, "CMakeLists.txt")))
+    return { stale: false, reason: "fork not checked out (trust staged)" };
+  const staged = fusedLibFilenames()
+    .map((n) => path.join(FUSED_LIB_OUT_DIR, n))
+    .find((p) => fs.existsSync(p));
+  if (!staged) return { stale: false, reason: "no staged lib" };
+  return artifactStaleness(staged, {
+    sourceDirs: [
+      path.join(FUSED_LIB_FORK_DIR, "tools", "kokoro"),
+      path.join(FUSED_LIB_FORK_DIR, "tools", "omnivoice"),
+      path.join(FUSED_LIB_FORK_DIR, "tools", "tts"),
+      path.join(FUSED_LIB_FORK_DIR, "src"),
+      path.join(FUSED_LIB_FORK_DIR, "ggml", "src"),
+    ],
+    sourceFiles: [path.join(FUSED_LIB_FORK_DIR, "CMakeLists.txt")],
+  });
+}
+
+/**
  * Build + stage the fused `libelizainference` into the desktop bundle so a
  * COMPILED app ships with working local inference — no first-run download, no
  * manual `build:fused-desktop`. The "auto" variant bakes CPU in and layers the
@@ -1207,8 +1237,14 @@ function stageDesktopFusedLib() {
       process.env.ELIZA_DESKTOP_FUSED_LIB_REQUIRED === "1") &&
     process.env.ELIZA_DESKTOP_FUSED_LIB_OPTIONAL !== "1";
 
+  // Never reuse a staged lib that is OLDER than the fork source it was built
+  // from — that is the "stale native lib reaches the device" bug. Treated the
+  // same as a wrong-variant lib: rebuilt when we can, dropped otherwise.
+  const sourceStale = fusedLibSourceStaleness();
+
   if (
     fusedLibStagedForCurrentVariant() &&
+    !sourceStale.stale &&
     process.env.ELIZA_DESKTOP_REBUILD_FUSED_LIB !== "1"
   ) {
     console.log(
@@ -1216,6 +1252,14 @@ function stageDesktopFusedLib() {
         `(variant=${FUSED_LIB_VARIANT}, ${process.platform})`,
     );
     return;
+  }
+
+  if (sourceStale.stale) {
+    console.warn(
+      `[desktop-build] Staged fused lib is STALE vs the native fork source ` +
+        `(${sourceStale.reason}). It will be rebuilt/dropped so no stale native ` +
+        `lib is shipped to a device.`,
+    );
   }
 
   // A staged lib whose sidecar names a DIFFERENT variant/platform is a confirmed
@@ -1233,17 +1277,19 @@ function stageDesktopFusedLib() {
   }
 
   if (!shouldBuild) {
-    if (variantMismatch) {
+    if (variantMismatch || sourceStale.stale) {
       // Can't rebuild here (no toolchain requested) and the staged lib is the
-      // wrong variant — drop it so the app cleanly falls back to cloud inference
-      // instead of dlopen()-ing a mismatched backend on the device.
+      // wrong variant OR stale vs source — drop it so the app cleanly falls back
+      // to cloud inference instead of dlopen()-ing a mismatched/stale backend on
+      // the device.
       for (const name of fusedLibFilenames()) {
         fs.rmSync(path.join(FUSED_LIB_OUT_DIR, name), { force: true });
       }
       fs.rmSync(FUSED_LIB_SIDECAR, { force: true });
       console.warn(
-        "[desktop-build] Removed the mismatched fused lib; this build ships without " +
-          "local inference. Rebuild with --build-fused-lib to stage the right variant.",
+        `[desktop-build] Removed the ${sourceStale.stale ? "stale" : "mismatched"} fused lib; ` +
+          "this build ships without local inference. Rebuild with --build-fused-lib " +
+          "to stage a fresh, matching lib.",
       );
       return;
     }

--- a/packages/app-core/scripts/stage-desktop-fused-lib-staleness.test.mjs
+++ b/packages/app-core/scripts/stage-desktop-fused-lib-staleness.test.mjs
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+// Exercises the desktop fused-lib staleness guard (`--check`): a stale or
+// unstamped staged lib must exit non-zero (2) so build/deploy flows never ship
+// a native lib that no longer matches the fork source; a stamp matching the
+// current fork exits 0.
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const script = path.join(scriptDir, "stage-desktop-fused-lib.mjs");
+const forkDir = path.join(
+  scriptDir,
+  "..",
+  "..",
+  "..",
+  "plugins/plugin-local-inference/native/llama.cpp",
+);
+const libName =
+  process.platform === "win32"
+    ? "elizainference.dll"
+    : process.platform === "darwin"
+      ? "libelizainference.dylib"
+      : "libelizainference.so";
+const STAMP = ".eliza-fused-build-stamp.json";
+
+function currentFork() {
+  try {
+    return execFileSync("git", ["-C", forkDir, "rev-parse", "HEAD"], {
+      encoding: "utf8",
+    }).trim();
+  } catch {
+    return "unknown";
+  }
+}
+
+/** Run `--check --out <dir>`; return the process exit code (0 fresh, 2 stale). */
+function checkExitCode(outDir) {
+  try {
+    execFileSync("node", [script, "--check", "--out", outDir], {
+      stdio: "ignore",
+    });
+    return 0;
+  } catch (err) {
+    return err.status ?? 1;
+  }
+}
+
+function mkTmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "fused-stale-"));
+}
+
+test("--check: empty dir (no staged lib) is STALE → exit 2", () => {
+  const dir = mkTmp();
+  try {
+    assert.equal(checkExitCode(dir), 2);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("--check: staged lib without a stamp is STALE → exit 2", () => {
+  const dir = mkTmp();
+  try {
+    fs.writeFileSync(path.join(dir, libName), Buffer.from("fake-lib-bytes"));
+    assert.equal(checkExitCode(dir), 2);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("--check: stamp matching the current fork + lib hash is FRESH → exit 0", () => {
+  const dir = mkTmp();
+  try {
+    const bytes = Buffer.from("fake-lib-bytes-fresh");
+    fs.writeFileSync(path.join(dir, libName), bytes);
+    const sha = createHash("sha256").update(bytes).digest("hex");
+    fs.writeFileSync(
+      path.join(dir, STAMP),
+      JSON.stringify({
+        forkCommit: currentFork(),
+        forkDirty: "",
+        backend: "test",
+        fusedLib: libName,
+        fusedSha256: sha,
+        builtAt: "now",
+      }),
+    );
+    assert.equal(checkExitCode(dir), 0);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("--check: stamp from a DIFFERENT fork commit is STALE → exit 2", () => {
+  const dir = mkTmp();
+  try {
+    const bytes = Buffer.from("fake-lib-bytes-stale");
+    fs.writeFileSync(path.join(dir, libName), bytes);
+    const sha = createHash("sha256").update(bytes).digest("hex");
+    fs.writeFileSync(
+      path.join(dir, STAMP),
+      JSON.stringify({
+        forkCommit: "0000000000000000000000000000000000000000",
+        forkDirty: "",
+        backend: "test",
+        fusedLib: libName,
+        fusedSha256: sha,
+        builtAt: "old",
+      }),
+    );
+    // Only meaningful when we can read a real (different) fork HEAD; if the fork
+    // submodule isn't checked out, forkCommit() is "unknown" and would also
+    // differ from the all-zeros commit, so this still asserts STALE.
+    assert.equal(checkExitCode(dir), 2);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("--check: staged lib whose bytes don't match the stamp hash is STALE → exit 2", () => {
+  const dir = mkTmp();
+  try {
+    fs.writeFileSync(path.join(dir, libName), Buffer.from("actual-bytes"));
+    fs.writeFileSync(
+      path.join(dir, STAMP),
+      JSON.stringify({
+        forkCommit: currentFork(),
+        forkDirty: "",
+        backend: "test",
+        fusedLib: libName,
+        fusedSha256: createHash("sha256").update("OTHER").digest("hex"),
+        builtAt: "now",
+      }),
+    );
+    assert.equal(checkExitCode(dir), 2);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/app-core/scripts/stage-desktop-fused-lib.mjs
+++ b/packages/app-core/scripts/stage-desktop-fused-lib.mjs
@@ -34,13 +34,16 @@
  */
 
 import { execFileSync, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
   copyFileSync,
   existsSync,
   mkdirSync,
   readdirSync,
+  readFileSync,
   realpathSync,
   rmSync,
+  writeFileSync,
 } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -101,13 +104,86 @@ function have(cmd, args = ["--version"]) {
   }
 }
 
+// ---- Staleness guard -------------------------------------------------------
+// The #1 way the staged fused lib goes stale in dev→device: a rebuild lands in
+// the build dir (e.g. building a CLI target rebuilds `elizainference` too) but
+// the STAGE step is not re-run, so `<stateDir>/local-inference/lib` keeps an
+// older copy; or a `git submodule update` restores fork sources with rewound
+// mtimes so an incremental cmake keeps stale objects. Both produce a lib that
+// silently mismatches the current source. We fingerprint the fork (commit +
+// uncommitted-tree hash) and the staged lib (sha256) into a build stamp so:
+//   - a normal run auto-CLEAN-rebuilds when the fork changed since the stamp;
+//   - `--check` fast-detects a stale staged lib (non-zero exit) without building.
+const STAMP_FILE = ".eliza-fused-build-stamp.json";
+const FUSED_LIB_NAME =
+  process.platform === "win32"
+    ? "elizainference.dll"
+    : process.platform === "darwin"
+      ? "libelizainference.dylib"
+      : "libelizainference.so";
+function forkCommit() {
+  try {
+    return execFileSync("git", ["-C", forkSrc, "rev-parse", "HEAD"], {
+      encoding: "utf8",
+    }).trim();
+  } catch {
+    return "unknown";
+  }
+}
+function forkDirtyHash() {
+  try {
+    const s = execFileSync(
+      "git",
+      [
+        "-C",
+        forkSrc,
+        "status",
+        "--porcelain",
+        "--untracked-files=no",
+        "--",
+        "tools",
+        "src",
+        "ggml",
+        "common",
+        "CMakeLists.txt",
+      ],
+      { encoding: "utf8", maxBuffer: 16 * 1024 * 1024 },
+    ).trim();
+    return s ? createHash("sha256").update(s).digest("hex").slice(0, 16) : "";
+  } catch {
+    return "";
+  }
+}
+function sha256File(p) {
+  try {
+    return createHash("sha256").update(readFileSync(p)).digest("hex");
+  } catch {
+    return null;
+  }
+}
+function readStamp(dir) {
+  try {
+    return JSON.parse(readFileSync(path.join(dir, STAMP_FILE), "utf8"));
+  } catch {
+    return null;
+  }
+}
+
 function parseArgs(argv) {
-  const out = { variant: "auto", outDir: null, jobs: null, force: false };
+  const out = {
+    variant: "auto",
+    outDir: null,
+    jobs: null,
+    force: false,
+    check: false,
+  };
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === "--variant") out.variant = argv[++i];
     else if (argv[i] === "--out") out.outDir = argv[++i];
     else if (argv[i] === "--jobs") out.jobs = parseInt(argv[++i], 10);
     else if (argv[i] === "--force") out.force = true;
+    else if (argv[i] === "--check") out.check = true;
+    else if (argv[i] === "--ensure") out.ensure = true;
     else die(`unknown arg: ${argv[i]}`);
   }
   const ok = ["auto", "cpu", "cuda", "vulkan", "metal", "hip"];
@@ -266,7 +342,67 @@ const {
   outDir: outOverride,
   jobs: jobsArg,
   force,
+  check,
+  ensure,
 } = parseArgs(process.argv.slice(2));
+
+const stagedOutDir =
+  outOverride || path.join(resolveStateDir(), "local-inference", "lib");
+const currentFork = forkCommit();
+const currentDirty = forkDirtyHash();
+
+// Shared staleness verdict for --check / --ensure. Returns the reasons the
+// staged fused lib is stale ([] = fresh).
+function stagedStalenessReasons() {
+  const stamp = readStamp(stagedOutDir);
+  const stagedSha = sha256File(path.join(stagedOutDir, FUSED_LIB_NAME));
+  const reasons = [];
+  if (!stagedSha) reasons.push(`staged ${FUSED_LIB_NAME} is missing`);
+  if (!stamp) reasons.push("no build stamp (built by an older/raw cmake path)");
+  if (stamp && stamp.forkCommit !== currentFork)
+    reasons.push(
+      `fork commit changed (${String(stamp.forkCommit).slice(0, 10)} → ${currentFork.slice(0, 10)})`,
+    );
+  if (stamp && (stamp.forkDirty || "") !== currentDirty)
+    reasons.push("fork working tree changed (uncommitted source edits)");
+  if (stamp && stagedSha && stamp.fusedSha256 !== stagedSha)
+    reasons.push("staged lib hash != stamp (partial copy / tampered)");
+  return reasons;
+}
+
+// `--check`: fast staleness probe — no build. Exit 0 = the staged fused lib
+// matches the current fork; exit 2 = stale. Build/deploy flows call this to
+// fail-fast (or trigger a rebuild) before shipping to a device.
+if (check) {
+  const reasons = stagedStalenessReasons();
+  if (reasons.length) {
+    console.error(
+      `[stage-desktop-fused-lib] STALE: ${reasons.join("; ")}.\n` +
+        "  Rebuild: bun run --cwd packages/app-core build:fused-desktop",
+    );
+    process.exit(2);
+  }
+  log(
+    `FRESH: staged libelizainference matches fork ${currentFork.slice(0, 10)}${currentDirty ? " (+local edits)" : ""}.`,
+  );
+  process.exit(0);
+}
+
+// `--ensure`: the build/deploy entry point — fast when the staged lib already
+// matches the current fork (skip the build), rebuild + re-stage when stale.
+// This is what guarantees "no stale native lib reaches a device": every build
+// that runs this either confirms freshness or produces a matching lib.
+if (ensure) {
+  const reasons = stagedStalenessReasons();
+  if (!reasons.length) {
+    log(
+      `up to date — staged libelizainference matches fork ${currentFork.slice(0, 10)}; skipping rebuild.`,
+    );
+    process.exit(0);
+  }
+  log(`rebuilding — staged lib is stale: ${reasons.join("; ")}`);
+  // fall through to the full build below.
+}
 
 if (!existsSync(path.join(forkSrc, "CMakeLists.txt"))) {
   die(
@@ -282,10 +418,24 @@ log(
 );
 
 const buildDir = path.join(forkSrc, `build-desktop-${backend}`);
-const outDir =
-  outOverride || path.join(resolveStateDir(), "local-inference", "lib");
+const outDir = stagedOutDir;
 
-if (force && existsSync(buildDir)) {
+// Self-healing clean rebuild: if the existing build dir was produced from a
+// DIFFERENT fork commit / working tree than we have now, an incremental cmake
+// can silently keep stale objects (git can restore fork sources with rewound
+// mtimes on a submodule update). Wipe it so the produced lib always matches the
+// current source — the guarantee "no stale native lib reaches a device".
+const priorBuildStamp = readStamp(buildDir);
+const forkChanged =
+  priorBuildStamp &&
+  (priorBuildStamp.forkCommit !== currentFork ||
+    (priorBuildStamp.forkDirty || "") !== currentDirty);
+if ((force || forkChanged) && existsSync(buildDir)) {
+  if (forkChanged && !force) {
+    log(
+      `fork changed since last build (${String(priorBuildStamp.forkCommit).slice(0, 10)} → ${currentFork.slice(0, 10)}) — clean rebuild to avoid stale objects`,
+    );
+  }
   removePathRecursive(buildDir);
 }
 mkdirSync(buildDir, { recursive: true });
@@ -415,6 +565,25 @@ for (const s of staged) log(`  ${s}`);
 // NOT re-exported by the fused lib — so llama_* is checked across the whole
 // staged set, not the fused lib alone. A half-fused link drops eliza/ov.
 verifyFusedSymbols(outDir);
+
+// Stamp the staged set with the fork fingerprint + the staged fused-lib sha256.
+// `--check` reads this to fast-detect a stale staged lib, and the next build
+// reads the buildDir copy to self-heal an incremental build from another commit.
+const buildStamp = JSON.stringify(
+  {
+    forkCommit: currentFork,
+    forkDirty: currentDirty,
+    backend,
+    fusedLib: fusedName,
+    fusedSha256: sha256File(path.join(outDir, fusedName)),
+    builtAt: new Date().toISOString(),
+  },
+  null,
+  2,
+);
+writeFileSync(path.join(outDir, STAMP_FILE), buildStamp);
+writeFileSync(path.join(buildDir, STAMP_FILE), buildStamp);
+log(`stamped build → fork ${currentFork.slice(0, 10)}${currentDirty ? " (+local edits)" : ""}`);
 
 function definedSymbols(libPath) {
   const tool =

--- a/packages/app-core/vitest.config.ts
+++ b/packages/app-core/vitest.config.ts
@@ -154,6 +154,7 @@ export default defineConfig({
       // Uses Node.js built-in test runner (node:test), not vitest.
       "scripts/android-sms-gateway-template.test.mjs",
       "scripts/stage-android-agent.test.mjs",
+      "scripts/stage-desktop-fused-lib-staleness.test.mjs",
       "scripts/build-helpers/arm64-simd.test.mjs",
       // Uses bun:test, not vitest.
       "scripts/aosp/stage-default-models.test.mjs",


### PR DESCRIPTION
## Why
A stale staged `libelizainference` is a real dev→device trap and it **bit us for real**: on my Mac the staged fused lib (04:41) was older than a rebuilt one (17:05) in the fork build dir, and it produced **unintelligible Kokoro TTS** — the eliza-1 ASR extracted only `"The."` from 11.5 s. The *current* build is perfect (pure-C++ `kokoro-tts` CLI **and** the raw FFI against the 17:05 lib both round-trip through ASR flawlessly). So "Kokoro is broken" was a **stale native lib**, not a code bug.

How a stale lib happens: building *any* CLI target rebuilds `elizainference` too, or the fork submodule updates — but the copy staged into `<stateDir>/local-inference/lib` (dev) / `dist/local-inference/lib` (bundle) is never refreshed, so the app dlopen()s a lib that no longer matches its source. The renderer + mobile-web bundles already guard freshness (`assertRendererRebuiltSince`, `mobile-web-build-reuse`); the **desktop fused lib was the one gap**.

## What
- **`stage-desktop-fused-lib.mjs`**: fingerprints the fork (commit + uncommitted-tree hash) + the staged lib (sha256) into a build stamp.
  - A normal run **auto-clean-rebuilds** when the fork changed since the stamp (an incremental cmake can keep stale objects when git rewinds mtimes on a submodule update).
  - New `--check` (fast staleness probe; exit **2** = stale, **0** = fresh) and `--ensure` (rebuild only when stale) modes + `build:fused-desktop:{check,ensure}` scripts for build/deploy to gate on.
- **`desktop-build.mjs`**: the fused-lib reuse gate now also invalidates a staged lib **older than the fork source** (via the existing `artifactStaleness` helper) — rebuilt when a toolchain is present, else dropped so the app cleanly falls back to cloud inference rather than shipping a stale native lib.
- **Test**: 5 cases drive the `--check` exit codes (missing / unstamped / mismatched-commit / mismatched-hash → 2; matching → 0). Registered in the app-core vitest include. `node --test` green (5/5).

## Follow-up (same pattern, not in this PR)
Mobile native libs (`stage-elizavoice-lib.mjs` Android, `build-llama-cpp-mtp.mjs` iOS) can adopt the identical fork-fingerprint stamp; the mobile *web* bundle is already reuse-guarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)