### PR TITLE
fix(approvals): enforce expiry at the transition boundary in both stores (#11092)

### DIFF
--- a/packages/agent/src/services/approval/service.test.ts
+++ b/packages/agent/src/services/approval/service.test.ts
@@ -326,6 +326,47 @@ describe("ApprovalService", () => {
     expect(after?.state).toBe("expired");
   });
 
+  it("a lapsed pending request is refused and expired at the transition boundary (#11092)", async () => {
+    // No purge runs: the lazy guard alone must keep an expired approval from
+    // ever executing — nothing calls purgeExpired periodically in production.
+    const runtime = createApprovalTableRuntime("agent-1");
+    const queue = (await ApprovalService.start(runtime)).getQueue();
+    const enqueued = await queue.enqueue(
+      messageInput({
+        subjectUserId: "owner-lapsed",
+        expiresAt: new Date(Date.now() - 5 * 60 * 1000),
+      }),
+    );
+    expect(enqueued.state).toBe("pending");
+
+    await expect(
+      queue.approve(enqueued.id, {
+        resolvedBy: "owner-lapsed",
+        resolutionReason: "approving after expiry",
+      }),
+    ).rejects.toBeInstanceOf(ApprovalStateTransitionError);
+
+    const after = await queue.byId(enqueued.id);
+    expect(after?.state).toBe("expired");
+    expect(after?.resolvedBy).toBeNull();
+  });
+
+  it("a fresh pending request still approves normally under the expiry guard (#11092)", async () => {
+    const runtime = createApprovalTableRuntime("agent-1");
+    const queue = (await ApprovalService.start(runtime)).getQueue();
+    const enqueued = await queue.enqueue(
+      messageInput({
+        subjectUserId: "owner-fresh",
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      }),
+    );
+    const approved = await queue.approve(enqueued.id, {
+      resolvedBy: "owner-fresh",
+      resolutionReason: "in time",
+    });
+    expect(approved.state).toBe("approved");
+  });
+
   it("rejects invalid state transitions hard", async () => {
     const runtime = createApprovalTableRuntime("agent-1");
     const queue = (await ApprovalService.start(runtime)).getQueue();
@@ -378,7 +419,9 @@ describe("PgApprovalQueue transition CAS (TOCTOU)", () => {
     const enqueued = await queue.enqueue(
       messageInput({
         subjectUserId: "owner-race",
-        expiresAt: new Date(Date.now() - 60 * 1000),
+        // Future expiresAt: the lazy expiry guard (#11092) must not preempt
+        // the interleave — this test exercises the CAS window itself.
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
       }),
     );
 

--- a/packages/agent/src/services/approval/store.ts
+++ b/packages/agent/src/services/approval/store.ts
@@ -704,6 +704,24 @@ export class PgApprovalQueue implements ApprovalQueue {
     return rowToRequest(rows[0]);
   }
 
+  /**
+   * Lazily enforce expiry at the transition boundary (#11092): no production
+   * caller runs purgeExpired periodically, so without this check a request
+   * whose expiresAt has passed stays `pending` forever and remains approvable.
+   * A lapsed pending row is flipped to `expired` (CAS — a concurrent
+   * transition wins cleanly) and the attempted transition is refused as
+   * from-expired, the same typed error callers already handle.
+   */
+  private async refuseLapsedPending(
+    current: ApprovalRequest,
+    target: ApprovalRequestState,
+  ): Promise<void> {
+    if (current.state !== "pending" || target === "expired") return;
+    if (current.expiresAt.getTime() > Date.now()) return;
+    await this.transitionWithoutResolution(current.id, "expired");
+    throw new ApprovalStateTransitionError(current.id, "expired", target);
+  }
+
   private async transitionWithResolution(
     id: string,
     target: ApprovalRequestState,
@@ -711,6 +729,7 @@ export class PgApprovalQueue implements ApprovalQueue {
   ): Promise<ApprovalRequest> {
     const current = await this.fetchById(id);
     if (!current) throw new ApprovalNotFoundError(id);
+    await this.refuseLapsedPending(current, target);
     assertTransition(id, current.state, target);
     const now = new Date();
     // Compare-and-swap on the observed state: without the `AND state =`
@@ -742,6 +761,7 @@ export class PgApprovalQueue implements ApprovalQueue {
   ): Promise<ApprovalRequest> {
     const current = await this.fetchById(id);
     if (!current) throw new ApprovalNotFoundError(id);
+    await this.refuseLapsedPending(current, target);
     assertTransition(id, current.state, target);
     const now = new Date();
     // Compare-and-swap on the observed state — see transitionWithResolution.

--- a/plugins/plugin-personal-assistant/src/lifeops/approval-queue.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/approval-queue.ts
@@ -725,6 +725,24 @@ export class PgApprovalQueue implements ApprovalQueue {
     throw new ApprovalTransitionConflictError(id, actual.state, target);
   }
 
+  /**
+   * Lazily enforce expiry at the transition boundary (#11092): no production
+   * caller runs purgeExpired periodically, so without this check a request
+   * whose expiresAt has passed stays `pending` forever and remains approvable.
+   * A lapsed pending row is flipped to `expired` (CAS — a concurrent
+   * transition wins cleanly) and the attempted transition is refused as
+   * from-expired, the same typed error callers already handle.
+   */
+  private async refuseLapsedPending(
+    current: ApprovalRequest,
+    target: ApprovalRequestState,
+  ): Promise<void> {
+    if (current.state !== "pending" || target === "expired") return;
+    if (current.expiresAt.getTime() > Date.now()) return;
+    await this.transitionWithoutResolution(current.id, "expired");
+    throw new ApprovalStateTransitionError(current.id, "expired", target);
+  }
+
   private async transitionWithResolution(
     id: string,
     target: ApprovalRequestState,
@@ -732,6 +750,7 @@ export class PgApprovalQueue implements ApprovalQueue {
   ): Promise<ApprovalRequest> {
     const current = await this.fetchById(id);
     if (!current) throw new ApprovalNotFoundError(id);
+    await this.refuseLapsedPending(current, target);
     assertTransition(id, current.state, target);
     const now = new Date();
     // Compare-and-swap: the state guard makes the read-assert-write race-safe.
@@ -762,6 +781,7 @@ export class PgApprovalQueue implements ApprovalQueue {
   ): Promise<ApprovalRequest> {
     const current = await this.fetchById(id);
     if (!current) throw new ApprovalNotFoundError(id);
+    await this.refuseLapsedPending(current, target);
     assertTransition(id, current.state, target);
     const now = new Date();
     // Compare-and-swap: see transitionWithResolution.

--- a/plugins/plugin-personal-assistant/test/approval-queue.toctou.integration.test.ts
+++ b/plugins/plugin-personal-assistant/test/approval-queue.toctou.integration.test.ts
@@ -130,20 +130,22 @@ afterAll(async () => {
 });
 
 describe("ApprovalQueue TOCTOU (real PGlite, controlled interleavings)", () => {
-  it("purgeExpired landing inside approve()'s window cannot be overwritten", async () => {
+  it("an expiry landing inside approve()'s window cannot be overwritten", async () => {
+    // Future expiresAt: the lazy expiry guard (#11092) must not preempt the
+    // race — this test exercises the CAS window itself, with a concurrent
+    // markExpired standing in for any pending -> expired transition.
     const enqueued = await queue.enqueue(
       spendMoneyInput({
-        // Already past due: pending until purgeExpired runs.
-        expiresAt: new Date(Date.now() - 5 * 60 * 1000),
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
       }),
     );
     expect(enqueued.state).toBe("pending");
 
-    // approve() reads `pending`, then the purge expires the row before the
-    // approve write lands — the classic race that used to resurrect the row.
+    // approve() reads `pending`, then the row expires before the approve
+    // write lands — the classic race that used to resurrect the row.
     queue.betweenReadAndWrite = async () => {
-      const purged = await queue.purgeExpired(new Date());
-      expect(purged).toContain(enqueued.id);
+      const expired = await queue.markExpired(enqueued.id);
+      expect(expired.state).toBe("expired");
     };
 
     await expect(
@@ -154,6 +156,30 @@ describe("ApprovalQueue TOCTOU (real PGlite, controlled interleavings)", () => {
     ).rejects.toBeInstanceOf(ApprovalTransitionConflictError);
 
     // The forbidden expired -> approved transition never happened.
+    const after = await queue.byId(enqueued.id);
+    expect(after?.state).toBe("expired");
+    expect(after?.resolvedBy).toBeNull();
+  }, 60_000);
+
+  it("a lapsed pending request is refused and expired at the boundary — no purge needed (#11092)", async () => {
+    // No interleaving hook: the guard itself must enforce expiry, because
+    // nothing runs purgeExpired periodically in production.
+    const enqueued = await queue.enqueue(
+      spendMoneyInput({
+        subjectUserId: "owner-lapsed",
+        expiresAt: new Date(Date.now() - 5 * 60 * 1000),
+      }),
+    );
+    expect(enqueued.state).toBe("pending");
+
+    await expect(
+      queue.approve(enqueued.id, {
+        resolvedBy: "owner-lapsed",
+        resolutionReason: "approving after expiry",
+      }),
+    ).rejects.toBeInstanceOf(ApprovalStateTransitionError);
+
+    // The lazy guard flipped the row to expired; it never executed.
     const after = await queue.byId(enqueued.id);
     expect(after?.state).toBe("expired");
     expect(after?.resolvedBy).toBeNull();


### PR DESCRIPTION
## Enforce approval expiry at the transition boundary (#11092)

`purgeExpired()`/`markExpired()` exist in **both twin approval stores** but have **zero production callers** — so a request whose `expiresAt` passed stayed `pending` forever and `approve()` succeeded on it. An expired approval (send/spend/sign) remained executable indefinitely. The #10993 CAS guard defends the concurrent-purge race, but no purge ever runs.

### Fix — lazy, fail-closed, both stores
New `refuseLapsedPending` in `packages/agent/src/services/approval/store.ts` **and** `plugins/plugin-personal-assistant/src/lifeops/approval-queue.ts`, called at the top of both transition paths: a transition attempted on a lapsed pending row (other than the expiry transition itself) flips the row `pending → expired` (via the existing CAS — a concurrent transition wins cleanly) and refuses the attempt as **from-expired** with the typed `ApprovalStateTransitionError` callers already handle. Expiry is now enforced with **no sweep required**; the sweep primitives remain for hygiene.

### Test reconciliation
The two TOCTOU CAS tests previously used **past-due fixtures**, which the new guard would preempt (making them vacuous). Converted to future `expiresAt` so they keep exercising the CAS window itself: agent side keeps its raw-SQL interleave; PA side uses `markExpired` as the concurrent flip. Assertions unchanged (loser gets the typed conflict; row stays `expired`).

### Evidence (fail-without-fix, both stores)
| Suite | With guard | Guard reverted |
|---|---|---|
| agent `service.test.ts` (12 tests, incl. 2 new) | **12/12** | `a lapsed pending request is refused…` **red** (approve succeeds on the expired row) |
| PA `approval-queue.toctou.integration.test.ts` (5 tests, real PGlite) | **5/5** | `…no purge needed (#11092)` **red** |

- agent `tsgo --noEmit`: **exit 0**. PA typecheck: only the pre-existing `routes/plugin.ts` stale-app-core-dist error (not in this diff).

Closes #11092. Refs #10993 #11090.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
