### PR TITLE
fix(ui/chat): her-grade QA batch 3 — 14 majors across gestures, voice, copy/paste, streaming, deep-links + CI lane

### DIFF
--- a/packages/app/src/deep-link-routing.test.ts
+++ b/packages/app/src/deep-link-routing.test.ts
@@ -1,6 +1,9 @@
 import * as fc from "fast-check";
 import { describe, expect, it } from "vitest";
-import { buildAssistantLaunchHashRoute } from "./deep-link-routing";
+import {
+  buildAssistantLaunchHashRoute,
+  resolveDeepLinkNavigationIntent,
+} from "./deep-link-routing";
 
 function params(hashRoute: string): URLSearchParams {
   return new URLSearchParams(hashRoute.split("?")[1] ?? "");
@@ -272,5 +275,61 @@ describe("assistant launch deep-link routing", () => {
       }),
       { numRuns: 500 },
     );
+  });
+});
+
+describe("top-level-surface deep-link navigation intents", () => {
+  it("routes a settings deep link to the settings tab", () => {
+    expect(resolveDeepLinkNavigationIntent("settings")).toEqual({
+      viewId: "settings",
+      viewPath: "/settings",
+    });
+  });
+
+  it("routes a wallet deep link to the inventory tab (/wallet)", () => {
+    expect(resolveDeepLinkNavigationIntent("wallet")).toEqual({
+      viewId: "inventory",
+      viewPath: "/wallet",
+    });
+  });
+
+  it("treats the inventory alias like wallet", () => {
+    expect(resolveDeepLinkNavigationIntent("inventory")).toEqual({
+      viewId: "inventory",
+      viewPath: "/wallet",
+    });
+  });
+
+  it("routes a browser deep link to the browser tab", () => {
+    expect(resolveDeepLinkNavigationIntent("browser")).toEqual({
+      viewId: "browser",
+      viewPath: "/browser",
+    });
+  });
+
+  it("routes a bare connectors deep link to Settings → Connectors", () => {
+    expect(resolveDeepLinkNavigationIntent("connectors")).toEqual({
+      viewId: "settings",
+      viewPath: "/settings",
+      subview: "connectors",
+    });
+  });
+
+  it("routes a per-provider connectors deep link to Settings → Connectors", () => {
+    expect(
+      resolveDeepLinkNavigationIntent("settings/connectors/discord"),
+    ).toEqual({
+      viewId: "settings",
+      viewPath: "/settings",
+      subview: "connectors",
+    });
+  });
+
+  it("returns null for chat-launch and unknown paths (handled elsewhere)", () => {
+    expect(resolveDeepLinkNavigationIntent("chat")).toBeNull();
+    expect(resolveDeepLinkNavigationIntent("ask")).toBeNull();
+    expect(resolveDeepLinkNavigationIntent("share")).toBeNull();
+    expect(resolveDeepLinkNavigationIntent("connect")).toBeNull();
+    expect(resolveDeepLinkNavigationIntent("totally-unknown")).toBeNull();
   });
 });

--- a/packages/app/src/deep-link-routing.ts
+++ b/packages/app/src/deep-link-routing.ts
@@ -5,6 +5,62 @@ export interface AssistantLaunchHashRouteOptions {
   generateLaunchId?: () => string;
 }
 
+/**
+ * In-app navigation intent for a deep link that targets a top-level surface
+ * (Settings, Wallet, Browser, Connectors) instead of the chat-launch flow.
+ *
+ * Structurally a subset of the app's `NavigateViewDetail` (packages/ui
+ * app-navigate-view.ts): `viewPath` drives `tabFromPath` → `setTab`, and
+ * `subview` deep-links a Settings section. The caller dispatches this on the
+ * `eliza:navigate:view` event bus.
+ */
+export interface DeepLinkNavigationIntent {
+  viewId: string;
+  viewPath: string;
+  subview?: string;
+}
+
+/**
+ * Resolve a deep-link path to an in-app tab/section navigation intent, or
+ * `null` when the path is not a top-level-surface deep link (chat-launch and
+ * share/connect paths are handled elsewhere).
+ *
+ * These links previously set `window.location.hash` directly. On the
+ * mobile/Capacitor entrypoint the app is not served over `file:` and is not an
+ * app-window, so `getWindowNavigationPath()` reads `location.pathname` (never
+ * the hash) — the target tab never opened. Returning a navigation intent lets
+ * the caller dispatch the same `eliza:navigate:view` event the rest of the app
+ * uses, which opens the surface on every platform. (Chat-launch deep links stay
+ * on the hash: the always-mounted ContinuousChatOverlay claims the launch
+ * payload from the hash directly.)
+ */
+export function resolveDeepLinkNavigationIntent(
+  path: string,
+): DeepLinkNavigationIntent | null {
+  // eliza://connectors and eliza://settings/connectors/<provider> → open
+  // Settings focused on the Connectors section (a Settings section, not a
+  // top-level tab).
+  if (
+    path === "connectors" ||
+    /^settings\/connectors\/[a-z0-9-]+$/i.test(path)
+  ) {
+    return { viewId: "settings", viewPath: "/settings", subview: "connectors" };
+  }
+
+  switch (path) {
+    case "settings":
+      return { viewId: "settings", viewPath: "/settings" };
+    case "wallet":
+    case "inventory":
+      // `/wallet` resolves to the `inventory` tab via `tabFromPath`.
+      return { viewId: "inventory", viewPath: "/wallet" };
+    case "browser":
+      return { viewId: "browser", viewPath: "/browser" };
+    default:
+      return null;
+  }
+}
+
 function withDefaultSearchParam(
   params: URLSearchParams,
   key: string,

--- a/packages/app/src/main.network-fallback.test.ts
+++ b/packages/app/src/main.network-fallback.test.ts
@@ -1,0 +1,85 @@
+import { NETWORK_STATUS_CHANGE_EVENT } from "@elizaos/ui/events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createMobileLifecycle } from "./mobile-lifecycle";
+
+// The live Android/Capacitor entrypoint (main.tsx `getMobileLifecycle()`)
+// delegates its network listener to this helper's `initializeNetworkListener`,
+// so the #10472 window `online`/`offline` fallback runs in production. Before
+// that wiring the fallback lived only in this helper and had zero importers.
+//
+// Simulate the exact on-device failure that motivated the fallback: the
+// Capacitor `Network` plugin is absent from the Android WebView bridge, so
+// `import("@capacitor/network")` rejects and no native listener registers — only
+// the window online/offline fallback can drive NETWORK_STATUS_CHANGE_EVENT.
+vi.mock("@capacitor/network", () => {
+  throw new Error("Network plugin unavailable (simulated Android WebView)");
+});
+
+function makeLifecycle() {
+  return createMobileLifecycle({
+    isNative: true,
+    isIOS: false,
+    isAndroid: true,
+    logPrefix: "[test]",
+    handleDeepLink: () => {},
+  });
+}
+
+function captureNetworkEvents(): {
+  events: boolean[];
+  dispose: () => void;
+} {
+  const events: boolean[] = [];
+  const handler = (event: Event) => {
+    const detail = (event as CustomEvent<{ connected: boolean }>).detail;
+    events.push(detail.connected);
+  };
+  document.addEventListener(NETWORK_STATUS_CHANGE_EVENT, handler);
+  return {
+    events,
+    dispose: () =>
+      document.removeEventListener(NETWORK_STATUS_CHANGE_EVENT, handler),
+  };
+}
+
+describe("network-status online/offline fallback (wired via getMobileLifecycle)", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("dispatches NETWORK_STATUS_CHANGE_EVENT from window offline/online when the Network plugin is unavailable", async () => {
+    const capture = captureNetworkEvents();
+    try {
+      await makeLifecycle().initializeNetworkListener();
+
+      window.dispatchEvent(new Event("offline"));
+      window.dispatchEvent(new Event("online"));
+
+      expect(capture.events).toEqual([false, true]);
+    } finally {
+      capture.dispose();
+    }
+  });
+
+  it("dedupes repeated transitions so only real changes emit an event", async () => {
+    const capture = captureNetworkEvents();
+    try {
+      await makeLifecycle().initializeNetworkListener();
+
+      window.dispatchEvent(new Event("offline"));
+      window.dispatchEvent(new Event("offline"));
+      window.dispatchEvent(new Event("online"));
+      window.dispatchEvent(new Event("online"));
+
+      expect(capture.events).toEqual([false, true]);
+    } finally {
+      capture.dispose();
+    }
+  });
+});

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -69,8 +69,6 @@ import {
   CONNECT_EVENT,
   dispatchAppEvent,
   MOBILE_RUNTIME_MODE_CHANGED_EVENT,
-  NETWORK_STATUS_CHANGE_EVENT,
-  type NetworkStatusChangeDetail,
   SHARE_TARGET_EVENT,
   TRAY_ACTION_EVENT,
 } from "@elizaos/ui/events";
@@ -139,13 +137,21 @@ import {
 import { APP_ENV_ALIASES, APP_ENV_PREFIX } from "./brand-env";
 import { APP_CHARACTER_CATALOG } from "./character-catalog";
 import { isTrustedAppLink } from "./deep-link-handler";
-import { buildAssistantLaunchHashRoute } from "./deep-link-routing";
+import {
+  buildAssistantLaunchHashRoute,
+  type DeepLinkNavigationIntent,
+  resolveDeepLinkNavigationIntent,
+} from "./deep-link-routing";
 import { runEmbedHandshake } from "./embed-bootstrap";
 import {
   apiBaseToDeviceBridgeUrl,
   type IosRuntimeConfig,
   resolveIosRuntimeConfig,
 } from "./ios-runtime";
+import {
+  createMobileLifecycle,
+  type MobileLifecycle,
+} from "./mobile-lifecycle";
 import {
   SIDE_EFFECT_APP_MODULE_LOADERS,
   type SideEffectAppModuleLoader,
@@ -348,7 +354,6 @@ let mobileAgentTunnelStartPromise: Promise<void> | null = null;
 let mobileRuntimeModeListenerInstalled = false;
 let keyboardListenersRegistered = false;
 let lifecycleListenersRegistered = false;
-let networkStatusListenerRegistered = false;
 let activeVisibilityHandler: (() => void) | null = null;
 let iosFullBunSmokeStarted = false;
 let iosOnboardingSmokeStarted = false;
@@ -1438,7 +1443,7 @@ async function initializePlatform(): Promise<void> {
     await initializeKeyboard();
     initializeAppLifecycle();
     initializeMobileRuntimeModeListener();
-    void initializeNetworkListener();
+    void getMobileLifecycle().initializeNetworkListener();
     void initializeMobileDeviceBridge();
     void initializeMobileAgentTunnel();
     void registerMobileBlockerBackends();
@@ -1602,28 +1607,30 @@ function initializeAppLifecycle(): void {
 }
 
 /**
- * Listen to {@link Network.addListener "networkStatusChange"} and bridge it
- * to {@link NETWORK_STATUS_CHANGE_EVENT} so renderer-side consumers (notably
- * the WebSocket reconnect scheduler in `client-base.ts`) can stop burning
- * backoff attempts during airplane mode.
- *
- * Idempotent: HMR or repeated `initializePlatform()` invocations return after
- * the first registration (each Capacitor listener fires its handler N times if
- * added N times).
+ * Live Android/Capacitor lifecycle helper. `main.tsx` keeps its own
+ * status-bar / keyboard / app-lifecycle wiring (the app-lifecycle path carries
+ * the hardware-back `minimizeApp` behavior the extracted helper predates), but
+ * the network listener is delegated here so the #10472 window `online`/`offline`
+ * fallback actually runs in the live entrypoint. Before this the fallback lived
+ * only in `mobile-lifecycle.ts` and had zero importers, so on Android — where
+ * the Capacitor `Network` plugin can be absent from the WebView bridge — the
+ * `networkStatusChange` listener never registered and NETWORK_STATUS_CHANGE_EVENT
+ * (consumed by the WebSocket reconnect scheduler) never fired on a connectivity
+ * change. Constructed once, lazily, so the factory's per-instance idempotency
+ * guard holds across repeated `initializePlatform()` calls.
  */
-async function initializeNetworkListener(): Promise<void> {
-  if (networkStatusListenerRegistered) return;
-  networkStatusListenerRegistered = true;
-  try {
-    const { Network } = await import("@capacitor/network");
-    await Network.addListener("networkStatusChange", (status) => {
-      const detail: NetworkStatusChangeDetail = { connected: status.connected };
-      dispatchAppEvent(NETWORK_STATUS_CHANGE_EVENT, detail);
+let mobileLifecycleInstance: MobileLifecycle | null = null;
+function getMobileLifecycle(): MobileLifecycle {
+  if (!mobileLifecycleInstance) {
+    mobileLifecycleInstance = createMobileLifecycle({
+      isNative,
+      isIOS,
+      isAndroid,
+      logPrefix: APP_LOG_PREFIX,
+      handleDeepLink,
     });
-  } catch (error) {
-    networkStatusListenerRegistered = false;
-    logNativePluginUnavailable("Network", error);
   }
+  return mobileLifecycleInstance;
 }
 
 // Universal/App-Link hosts whose `https://<host>/<path>` links route into the
@@ -1725,11 +1732,18 @@ function handleDeepLink(url: string): void {
     return;
   }
 
-  // eliza://settings/connectors/<provider> — open Settings → Connectors.
-  // The new Connectors section renders one inline expansion per connector;
-  // we no longer scroll/highlight a specific provider panel.
-  if (/^settings\/connectors\/[a-z0-9-]+$/i.test(path)) {
-    window.location.hash = "#connectors";
+  // Top-level-surface deep links (settings, wallet, browser, connectors, and
+  // the https://eliza.app/<path> universal links that map to them). Dispatched
+  // on the in-app `eliza:navigate:view` bus rather than written to
+  // `window.location.hash`: on the mobile/Capacitor entrypoint the app is not
+  // served over file: and is not an app-window, so the hash is never read for
+  // tab navigation (`getWindowNavigationPath` returns `location.pathname`) and
+  // the target tab never opened. (Chat-launch deep links below stay on the
+  // hash — the always-mounted ContinuousChatOverlay claims the launch payload
+  // from the hash directly.)
+  const navigationIntent = resolveDeepLinkNavigationIntent(path);
+  if (navigationIntent) {
+    dispatchDeepLinkNavigation(navigationIntent);
     return;
   }
 
@@ -1753,16 +1767,6 @@ function handleDeepLink(url: string): void {
       break;
     case "contacts":
       setHashRoute("contacts", parsed.searchParams);
-      break;
-    case "wallet":
-    case "inventory":
-      setHashRoute("wallet", parsed.searchParams);
-      break;
-    case "browser":
-      setHashRoute("browser", parsed.searchParams);
-      break;
-    case "settings":
-      window.location.hash = "#settings";
       break;
     case "connect": {
       const gatewayUrl = parsed.searchParams.get("url");
@@ -1853,6 +1857,21 @@ function getDeepLinkPath(parsed: URL): string {
 function setHashRoute(route: string, params: URLSearchParams): void {
   const query = params.toString();
   window.location.hash = query ? `#${route}?${query}` : `#${route}`;
+}
+
+/**
+ * Dispatch a top-level-surface deep link on the in-app `eliza:navigate:view`
+ * bus (consumed in packages/ui App.tsx: `viewPath` → `tabFromPath` → `setTab`,
+ * `subview` → Settings section). This is the platform-agnostic navigation path
+ * the rest of the app uses; a raw `window.location.hash` write does not open a
+ * tab on the mobile/Capacitor entrypoint (see `resolveDeepLinkNavigationIntent`).
+ */
+function dispatchDeepLinkNavigation(intent: DeepLinkNavigationIntent): void {
+  window.dispatchEvent(
+    new CustomEvent<DeepLinkNavigationIntent>("eliza:navigate:view", {
+      detail: intent,
+    }),
+  );
 }
 
 async function initializeDesktopShell(): Promise<void> {

--- a/packages/app/test/hmr/hmr-dependency-levels.spec.ts
+++ b/packages/app/test/hmr/hmr-dependency-levels.spec.ts
@@ -30,6 +30,13 @@ const LEVELS = [
     file: "plugins/plugin-contacts/src/components/ContactsAppView.tsx",
   },
   {
+    // Developer-only coding cockpit (/cockpit). CockpitRoute is the plugin-side
+    // view container (wires the presentational @elizaos/ui CockpitView to the
+    // live orchestrator client), so it is the source guaranteed in the view graph.
+    name: "plugin view cockpit",
+    file: "plugins/plugin-task-coordinator/src/CockpitRoute.tsx",
+  },
+  {
     name: "plugin view focus",
     file: "plugins/plugin-blocker/src/components/focus/FocusView.tsx",
   },
@@ -129,14 +136,10 @@ const LEVELS = [
     name: "plugin view training",
     file: "plugins/plugin-training/src/ui/FineTuningView.tsx",
   },
-  {
-    name: "plugin view facewear",
-    file: "plugins/plugin-facewear/src/components/FacewearView.tsx",
-  },
-  {
-    name: "plugin view smartglasses",
-    file: "plugins/plugin-facewear/src/ui/SmartglassesView.tsx",
-  },
+  // facewear + smartglasses were converted from GUI views to TUI views
+  // (their GUI config moved to Settings → Wearables), so they no longer carry
+  // a GUI HMR source probe — their stale probes are removed to keep the matrix
+  // in lockstep with the GUI VIEW_CASES set.
 ] as const;
 
 // Vite's client logs these to the page console when it processes a change.

--- a/packages/ui/src/api/client-base-stream-abort.test.ts
+++ b/packages/ui/src/api/client-base-stream-abort.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "./client";
+
+/**
+ * FIX: once the SSE response headers arrive, `rawRequestOnce` detaches its
+ * request-phase abort listener, so the caller's AbortSignal was no longer wired
+ * to the fetch during the body read. Aborting the client controller therefore
+ * did nothing to the streaming read loop — a client-side Stop relied entirely on
+ * the separate server-abort POST to eventually close the stream. These tests
+ * pin that the signal now tears the read loop down immediately.
+ */
+describe("streamChatEndpoint client abort", () => {
+  it("stops the read loop and cancels the reader when the client aborts mid-stream", async () => {
+    const encoder = new TextEncoder();
+    const controller = new AbortController();
+    let readCalls = 0;
+    const read = vi.fn(() => {
+      readCalls += 1;
+      if (readCalls === 1) {
+        // First token arrives, then the server goes quiet (still generating).
+        return Promise.resolve({
+          done: false,
+          value: encoder.encode(
+            'data: {"type":"token","text":"partial","fullText":"partial"}\n\n',
+          ),
+        });
+      }
+      // The stream is now stalled between tokens. Simulate the user hitting Stop
+      // while this read is pending — the abort must tear the loop down without
+      // waiting for this (never-resolving) read or the 60s idle timeout.
+      queueMicrotask(() => controller.abort());
+      return new Promise<never>(() => {});
+    });
+    const cancel = vi.fn(async () => {});
+    const request = vi.fn(async () => {
+      return {
+        ok: true,
+        status: 200,
+        body: { getReader: () => ({ read, cancel }) },
+      } as unknown as Response;
+    });
+    const client = new ElizaClient("http://agent.example:31337", "token");
+    client.setRequestTransport({ request });
+    const onToken = vi.fn();
+
+    const result = await client.streamChatEndpoint(
+      "/api/conversations/conv-1/messages/stream",
+      "hello",
+      onToken,
+      "DM",
+      controller.signal,
+    );
+
+    // The partial that streamed before the stop is preserved and returned as an
+    // interrupted (completed:false) turn.
+    expect(onToken).toHaveBeenCalledWith("partial", "partial");
+    expect(result.text).toBe("partial");
+    expect(result.completed).toBe(false);
+    // The read loop stopped consuming: the reader was cancelled with the client
+    // abort reason and no read was issued past the stalled second one.
+    expect(cancel).toHaveBeenCalledWith("elizaos-sse-client-abort");
+    expect(read).toHaveBeenCalledTimes(2);
+  });
+
+  it("completes normally and never client-cancels when the signal is not aborted", async () => {
+    // The abort wiring must not disturb a normal terminal-done completion, and
+    // the per-read abort promise must not leak an unhandled rejection.
+    const encoder = new TextEncoder();
+    const controller = new AbortController();
+    const read = vi
+      .fn()
+      .mockResolvedValueOnce({
+        done: false,
+        value: encoder.encode(
+          'data: {"type":"token","text":"hi","fullText":"hi"}\n\n' +
+            'data: {"type":"done","fullText":"hi","agentName":"Eliza"}\n\n',
+        ),
+      })
+      .mockRejectedValueOnce(new Error("read after terminal event"));
+    const cancel = vi.fn(async () => {});
+    const request = vi.fn(async () => {
+      return {
+        ok: true,
+        status: 200,
+        body: { getReader: () => ({ read, cancel }) },
+      } as unknown as Response;
+    });
+    const client = new ElizaClient("http://agent.example:31337", "token");
+    client.setRequestTransport({ request });
+
+    const result = await client.streamChatEndpoint(
+      "/api/conversations/conv-1/messages/stream",
+      "hi",
+      vi.fn(),
+      "DM",
+      controller.signal,
+    );
+
+    expect(result).toEqual({ text: "hi", agentName: "Eliza", completed: true });
+    expect(cancel).toHaveBeenCalledWith("elizaos-sse-terminal-done");
+    expect(cancel).not.toHaveBeenCalledWith("elizaos-sse-client-abort");
+  });
+});

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -1599,11 +1599,39 @@ export class ElizaClient {
     // the idle timeout below aborts the read so the UI doesn't hang forever.
     const SSE_IDLE_TIMEOUT_MS = 60_000;
     while (true) {
+      // Client-side abort (user Stop / navigation away) must stop consuming the
+      // body IMMEDIATELY — not wait for the separate server-abort POST to close
+      // the stream, nor for the 60s idle timeout to fire. `rawRequestOnce`
+      // detaches its request-phase abort listener the moment response headers
+      // arrive, so the caller's `signal` is no longer wired to the fetch during
+      // the body read; honour it here by cancelling the reader (which closes the
+      // body and frees the connection) and returning whatever streamed so far as
+      // an interrupted (`completed: false`) turn.
+      if (signal?.aborted) {
+        void reader.cancel("elizaos-sse-client-abort").catch(() => {});
+        break;
+      }
       let done = false;
       let value: Uint8Array | undefined;
       let idleTimedOut = false;
       try {
         const readPromise = reader.read();
+        // Reject the in-flight read the instant the caller aborts, so a stream
+        // stalled between tokens tears down at once instead of blocking on the
+        // pending read until the idle timeout. The listener is removed when the
+        // read settles so it never leaks across loop iterations.
+        const abortPromise = new Promise<never>((_, reject) => {
+          if (!signal) return;
+          const onAbort = () => {
+            const abortErr = new Error("SSE read aborted by client");
+            abortErr.name = "AbortError";
+            reject(abortErr);
+          };
+          signal.addEventListener("abort", onAbort, { once: true });
+          void readPromise.finally(() =>
+            signal.removeEventListener("abort", onAbort),
+          );
+        });
         const timeoutPromise = new Promise<never>((_, reject) => {
           const id = setTimeout(() => {
             idleTimedOut = true;
@@ -1612,14 +1640,24 @@ export class ElizaClient {
           // Clear timeout if the read resolves first
           void readPromise.finally(() => clearTimeout(id));
         });
-        ({ done, value } = await Promise.race([readPromise, timeoutPromise]));
+        ({ done, value } = await Promise.race([
+          readPromise,
+          abortPromise,
+          timeoutPromise,
+        ]));
       } catch {
-        // Only the 60s idle timeout sets `idleTimedOut`; a user abort or a
-        // mid-stream network drop rejects the read without it. Stamp the stall
-        // as a transient provider issue so the consumer carries `failureKind`
-        // onto the turn and the renderer shows a Retry affordance instead of a
-        // bare, ambiguous "interrupted" badge that locks the partial text.
-        // User-stop / network-drop stay failureKind-less (genuine interrupt).
+        // A client abort wins over everything else: cancel the reader and stop —
+        // the partial streamed so far is returned as an interrupted turn.
+        if (signal?.aborted) {
+          void reader.cancel("elizaos-sse-client-abort").catch(() => {});
+          break;
+        }
+        // Only the 60s idle timeout sets `idleTimedOut`; a mid-stream network
+        // drop rejects the read without it. Stamp the stall as a transient
+        // provider issue so the consumer carries `failureKind` onto the turn and
+        // the renderer shows a Retry affordance instead of a bare, ambiguous
+        // "interrupted" badge that locks the partial text. Network-drop stays
+        // failureKind-less (genuine interrupt).
         if (idleTimedOut) {
           streamState.doneFailureKind =
             streamState.doneFailureKind ?? "provider_issue";

--- a/packages/ui/src/components/chat/TranscriptViewerOverlay.test.tsx
+++ b/packages/ui/src/components/chat/TranscriptViewerOverlay.test.tsx
@@ -157,7 +157,7 @@ describe("TranscriptViewerOverlay", () => {
     await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
 
-  it("copies the text to the clipboard", async () => {
+  it("copies the text to the clipboard and reports 'Copied' on success", async () => {
     render(
       <TranscriptViewerOverlay
         attachment={transcriptAttachment()}
@@ -168,6 +168,57 @@ describe("TranscriptViewerOverlay", () => {
     fireEvent.click(screen.getByTestId("transcript-copy"));
     await waitFor(() =>
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith("hello world"),
+    );
+    // "Copied" is shown only because the write actually resolved.
+    await waitFor(() =>
+      expect(screen.getByTestId("transcript-copy").textContent).toContain(
+        "Copied",
+      ),
+    );
+  });
+
+  it("does NOT report 'Copied' when the clipboard write rejects — surfaces the failure", async () => {
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockRejectedValue(new Error("denied")) },
+    });
+    render(
+      <TranscriptViewerOverlay
+        attachment={transcriptAttachment()}
+        onClose={() => {}}
+      />,
+    );
+    await waitFor(() => screen.getByTestId("transcript-text"));
+    fireEvent.click(screen.getByTestId("transcript-copy"));
+    // The failure is surfaced on the control, and it never claims success.
+    await waitFor(() =>
+      expect(screen.getByTestId("transcript-copy").textContent).toMatch(
+        /failed/i,
+      ),
+    );
+    expect(screen.getByTestId("transcript-copy").textContent).not.toContain(
+      "Copied",
+    );
+  });
+
+  it("does NOT report 'Copied' when the clipboard is unavailable and the Share fallback also fails", async () => {
+    // No Clipboard API and no Web Share API — Share falls back to copy, which
+    // then has nothing to write to.
+    Object.assign(navigator, { clipboard: undefined, share: undefined });
+    render(
+      <TranscriptViewerOverlay
+        attachment={transcriptAttachment()}
+        onClose={() => {}}
+      />,
+    );
+    await waitFor(() => screen.getByTestId("transcript-text"));
+    fireEvent.click(screen.getByTestId("transcript-share"));
+    await waitFor(() =>
+      expect(screen.getByTestId("transcript-copy").textContent).toMatch(
+        /failed/i,
+      ),
+    );
+    expect(screen.getByTestId("transcript-copy").textContent).not.toContain(
+      "Copied",
     );
   });
 

--- a/packages/ui/src/components/chat/TranscriptViewerOverlay.tsx
+++ b/packages/ui/src/components/chat/TranscriptViewerOverlay.tsx
@@ -87,6 +87,19 @@ type LoadState =
     };
 
 /**
+ * Copy-button feedback. `copied` only shows after a clipboard write actually
+ * resolved; `failed` surfaces when the write rejected or the clipboard was
+ * unavailable — so the button never claims success when nothing was copied.
+ */
+type CopyStatus = "idle" | "copied" | "failed";
+
+function copyButtonLabel(status: CopyStatus): string {
+  if (status === "copied") return "Copied";
+  if (status === "failed") return "Copy failed";
+  return "Copy";
+}
+
+/**
  * Pull the readable transcript text out of a not-yet-loaded attachment, with
  * the durable id marker (if present) split off. Prefers the server-extracted
  * `text`; falls back to decoding the `data:`/served URL.
@@ -182,7 +195,7 @@ export function TranscriptViewerOverlay({
   const [value, setValue] = React.useState("");
   const [editing, setEditing] = React.useState(false);
   const [saving, setSaving] = React.useState(false);
-  const [copied, setCopied] = React.useState(false);
+  const [copyStatus, setCopyStatus] = React.useState<CopyStatus>("idle");
   const [confirmDelete, setConfirmDelete] = React.useState(false);
   const [saveError, setSaveError] = React.useState<string | null>(null);
 
@@ -245,13 +258,24 @@ export function TranscriptViewerOverlay({
     return () => window.removeEventListener("keydown", onKey);
   }, [onClose]);
 
-  const handleCopy = React.useCallback(async () => {
+  const handleCopy = React.useCallback(async (): Promise<boolean> => {
     try {
-      await navigator.clipboard?.writeText(value);
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 1500);
+      // Optional chaining alone is a trap: `navigator.clipboard?.writeText(v)`
+      // is `undefined` (not a rejection) when the clipboard API is missing, so
+      // `await` resolves and we'd falsely report "Copied". Require the method.
+      if (!navigator.clipboard?.writeText) {
+        throw new Error("Clipboard unavailable");
+      }
+      await navigator.clipboard.writeText(value);
+      setCopyStatus("copied");
+      window.setTimeout(() => setCopyStatus("idle"), 1500);
+      return true;
     } catch {
-      // clipboard blocked (insecure context) — no-op; share/save remain.
+      // Clipboard blocked/missing (e.g. insecure context) — surface the failure
+      // (share/download remain as alternatives) instead of a phantom success.
+      setCopyStatus("failed");
+      window.setTimeout(() => setCopyStatus("idle"), 2500);
+      return false;
     }
   }, [value]);
 
@@ -527,16 +551,21 @@ export function TranscriptViewerOverlay({
           <Button
             variant="ghost"
             size="sm"
-            onClick={handleCopy}
+            onClick={() => void handleCopy()}
             data-testid="transcript-copy"
-            className="text-white/85 hover:bg-white/10"
+            className={cn(
+              "hover:bg-white/10",
+              copyStatus === "failed"
+                ? "text-[color:var(--danger,#f87171)]"
+                : "text-white/85",
+            )}
           >
-            {copied ? (
+            {copyStatus === "copied" ? (
               <Check className="mr-1.5 h-4 w-4 text-[color:var(--ok)]" />
             ) : (
               <Copy className="mr-1.5 h-4 w-4" />
             )}
-            {copied ? "Copied" : "Copy"}
+            {copyButtonLabel(copyStatus)}
           </Button>
           <Button
             variant="ghost"

--- a/packages/ui/src/components/settings/VoiceSection.tsx
+++ b/packages/ui/src/components/settings/VoiceSection.tsx
@@ -133,9 +133,13 @@ export interface VoiceSectionProps {
    * we render an empty-state banner until model downloads are available.
    */
   modelsPanel?: React.ReactNode;
-  /** Whether the user has at least one wake-word configured. */
+  /**
+   * Whether the "hey <name>" wake-word listening loop is enabled. Wired by
+   * VoiceSectionMount to the persisted device-local pref the shell's
+   * useWakeListenWindow reads; defaults off only when no caller supplies it.
+   */
   wakeWordEnabled?: boolean;
-  /** Toggle wake-word listening (caller wires Swabble). */
+  /** Toggle wake-word listening on/off (persisted + read by the shell). */
   onWakeWordToggle?: (next: boolean) => void;
   className?: string;
 }

--- a/packages/ui/src/components/settings/VoiceSectionMount.test.tsx
+++ b/packages/ui/src/components/settings/VoiceSectionMount.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// jsdom in this env ships a localStorage whose methods can throw; back it with an
+// in-memory Storage so the persisted wake-word pref actually round-trips.
+{
+  const store = new Map<string, string>();
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: {
+      get length() {
+        return store.size;
+      },
+      clear: () => store.clear(),
+      getItem: (k: string) => (store.has(k) ? (store.get(k) as string) : null),
+      key: (i: number) => Array.from(store.keys())[i] ?? null,
+      removeItem: (k: string) => void store.delete(k),
+      setItem: (k: string, v: string) => void store.set(k, String(v)),
+    } as Storage,
+  });
+}
+
+const clientMock = vi.hoisted(() => ({
+  getConfig: vi.fn(),
+  updateConfig: vi.fn(),
+  getLocalInferenceDeviceTier: vi.fn(),
+  fetch: vi.fn(),
+}));
+
+vi.mock("../../api/client", () => ({ client: clientMock }));
+
+// Voice profiles hit the network on mount; stub the sub-section since these
+// tests are about the wake-word toggle wiring, not profiles.
+vi.mock("./VoiceProfileSection", () => ({
+  VoiceProfileSection: () => null,
+}));
+
+import { VoiceSectionMount } from "./VoiceSectionMount";
+
+const WAKE_KEY = "eliza:voice:wake-word-enabled";
+
+describe("VoiceSectionMount — wake-word toggle wiring (FIX 3)", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    clientMock.getConfig.mockResolvedValue({});
+    clientMock.updateConfig.mockResolvedValue({});
+    clientMock.getLocalInferenceDeviceTier.mockResolvedValue({
+      tier: "GOOD",
+      reason: "",
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("defaults the wake-word toggle ON (no stored pref) and reflects it", async () => {
+    render(<VoiceSectionMount />);
+    const toggle = (await screen.findByTestId(
+      "voice-section-wake-toggle",
+    )) as HTMLInputElement;
+    expect(toggle.checked).toBe(true);
+    // Let the mount-time async config/tier fetches settle to avoid act warnings.
+    await waitFor(() =>
+      expect(clientMock.getLocalInferenceDeviceTier).toHaveBeenCalled(),
+    );
+  });
+
+  it("persists the toggle so the shell's wake pref maps to actual enablement", async () => {
+    const user = userEvent.setup();
+    render(<VoiceSectionMount />);
+    const toggle = (await screen.findByTestId(
+      "voice-section-wake-toggle",
+    )) as HTMLInputElement;
+
+    // Turning it off writes the persisted pref the shell reads for wake gating.
+    await user.click(toggle);
+    await waitFor(() => expect(toggle.checked).toBe(false));
+    expect(window.localStorage.getItem(WAKE_KEY)).toBe("false");
+
+    // Turning it back on flips the pref again.
+    await user.click(toggle);
+    await waitFor(() => expect(toggle.checked).toBe(true));
+    expect(window.localStorage.getItem(WAKE_KEY)).toBe("true");
+  });
+
+  it("reflects a persisted wake-word-disabled pref on mount", async () => {
+    window.localStorage.setItem(WAKE_KEY, "false");
+    render(<VoiceSectionMount />);
+    const toggle = (await screen.findByTestId(
+      "voice-section-wake-toggle",
+    )) as HTMLInputElement;
+    expect(toggle.checked).toBe(false);
+  });
+});

--- a/packages/ui/src/components/settings/VoiceSectionMount.tsx
+++ b/packages/ui/src/components/settings/VoiceSectionMount.tsx
@@ -16,7 +16,11 @@ import * as React from "react";
 import { client } from "../../api/client";
 import type { DeviceTier } from "../../api/client-local-inference";
 import { createVoiceProfilesClient } from "../../api/client-voice-profiles";
-import { saveVadAutoStop } from "../../state/persistence";
+import {
+  loadWakeWordEnabled,
+  saveVadAutoStop,
+  saveWakeWordEnabled,
+} from "../../state/persistence";
 import {
   VOICE_CONTINUOUS_MODES,
   type VoiceContinuousMode,
@@ -86,6 +90,12 @@ export function VoiceSectionMount(): React.ReactElement {
     DEFAULT_VOICE_SECTION_PREFS,
   );
   const [persistError, setPersistError] = React.useState<string | null>(null);
+  // Wake-word listening is a device-local pref (localStorage mirror the shell
+  // reads synchronously — see useShellController's useWakeListenWindow), not part
+  // of the `messages.voice` config blob. Seed from the persisted value.
+  const [wakeWordEnabled, setWakeWordEnabled] = React.useState<boolean>(() =>
+    loadWakeWordEnabled(),
+  );
   const [tier, setTier] = React.useState<DeviceTier | null>(null);
   const [tierSummary, setTierSummary] = React.useState<string | undefined>(
     undefined,
@@ -117,6 +127,13 @@ export function VoiceSectionMount(): React.ReactElement {
     return () => {
       cancelled = true;
     };
+  }, []);
+
+  // Persist the wake-word toggle and update local state so the control reflects
+  // it immediately; the shell picks the new value up on its next render.
+  const handleWakeWordToggle = React.useCallback((next: boolean) => {
+    setWakeWordEnabled(next);
+    saveWakeWordEnabled(next);
   }, []);
 
   const handlePrefsChange = React.useCallback(
@@ -160,6 +177,8 @@ export function VoiceSectionMount(): React.ReactElement {
         prefs={prefs}
         onPrefsChange={(next) => void handlePrefsChange(next)}
         profilesClient={profilesClient}
+        wakeWordEnabled={wakeWordEnabled}
+        onWakeWordToggle={handleWakeWordToggle}
       />
     </>
   );

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -1614,6 +1614,60 @@ describe("ContinuousChatOverlay", () => {
     }
   });
 
+  it("push-to-talk dictates into the composer on release; the label matches (never 'send')", () => {
+    vi.useFakeTimers();
+    try {
+      const sinkRef: { fn: ((text: string) => void) | null } = { fn: null };
+      const send = vi.fn();
+      const startRecording = vi.fn();
+      const stopRecording = vi.fn();
+      const setDictationSink = vi.fn(
+        (sink: ((text: string) => void) | null) => {
+          sinkRef.fn = sink;
+        },
+      );
+      render(
+        <ContinuousChatOverlay
+          controller={makeController({
+            send,
+            startRecording,
+            stopRecording,
+            setDictationSink,
+          } as unknown as Partial<ShellController>)}
+        />,
+      );
+
+      const mic = screen.getByTestId("chat-composer-mic");
+      // Hold past the 200ms arm → dictation capture begins (intent "dictate").
+      fireEvent.pointerDown(mic, { button: 0, pointerId: 1 });
+      act(() => {
+        vi.advanceTimersByTime(220);
+      });
+      expect(startRecording).toHaveBeenCalledWith("dictate");
+
+      // The label must match the behavior: release inserts the dictation into
+      // the composer, it does NOT send. (Regression: it read "release to send",
+      // but the handler only fills the draft — see setDictationSink below.)
+      const label = mic.getAttribute("aria-label") ?? "";
+      expect(label).not.toContain("send");
+      expect(label).toBe("release to insert");
+
+      // Release ends the capture; the final transcript arrives via the
+      // dictation sink and lands in the composer draft — nothing is sent.
+      fireEvent.pointerUp(mic, { button: 0, pointerId: 1 });
+      expect(stopRecording).toHaveBeenCalledTimes(1);
+      act(() => {
+        sinkRef.fn?.("hello from voice");
+      });
+      expect(send).not.toHaveBeenCalled();
+      expect(
+        (screen.getByLabelText("message") as HTMLTextAreaElement).value,
+      ).toBe("hello from voice");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("drops the finished transcript into the composer as an attachment, not an auto-sent message", () => {
     let sink:
       | ((
@@ -2011,6 +2065,33 @@ describe("ContinuousChatOverlay swipe-nav", () => {
     fireEvent.pointerUp(el, { clientX: 285, clientY: 140, pointerId: 4 });
 
     expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("does NOT switch conversations when a mouse drag was highlighting bubble text", () => {
+    // The swipe binding lives on the transcript, which contains the selectable
+    // message bubbles. A horizontal MOUSE drag to highlight text would commit as
+    // a swipe and navigate away — destroying the selection. A live (non-
+    // collapsed) selection at release means the gesture was a highlight, so the
+    // swipe is skipped (mirrors the ThreadLine tap-reveal guard).
+    const { controller, onSelect } = makeSwipeController();
+    render(<ContinuousChatOverlay controller={controller} />);
+    openSheet();
+
+    const getSelection = vi.spyOn(window, "getSelection").mockReturnValue({
+      toString: () => "selected bubble text",
+    } as unknown as Selection);
+    try {
+      const el = thread();
+      // The exact gesture that DOES navigate in the passing test above — only
+      // the live selection differs.
+      fireEvent.pointerDown(el, { clientX: 300, clientY: 300, pointerId: 6 });
+      fireEvent.pointerMove(el, { clientX: 280, clientY: 302, pointerId: 6 });
+      fireEvent.pointerUp(el, { clientX: 180, clientY: 302, pointerId: 6 });
+
+      expect(onSelect).not.toHaveBeenCalled();
+    } finally {
+      getSelection.mockRestore();
+    }
   });
 
   it("does not bind the swipe gesture while the sheet is collapsed", () => {

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -801,6 +801,21 @@ function isNestedInteractiveTarget(
 }
 
 /**
+ * True while there's a live (non-collapsed) text selection. The
+ * conversation-swipe binding lives on the transcript surface, which contains
+ * the selectable message bubbles — so a MOUSE drag to highlight bubble text
+ * travels horizontally and otherwise reads as a swipe, navigating away and
+ * destroying the selection on release. The swipe handlers consult this to skip
+ * navigation when the gesture was really a highlight, mirroring the ThreadLine
+ * tap-reveal guard (`window.getSelection()` non-collapsed). Touch drags don't
+ * create a selection, so a genuine finger swipe is unaffected.
+ */
+function hasLiveTextSelection(): boolean {
+  const sel = typeof window !== "undefined" ? window.getSelection() : null;
+  return !!sel && sel.toString().trim().length > 0;
+}
+
+/**
  * One icon-only control in a message's click-to-reveal action row (#10713).
  * Overlay glass styling: no card fill, neutral resting → neutral-opacity hover;
  * an active (e.g. playing) control tints with the orange accent. `stopPropagation`
@@ -1438,6 +1453,13 @@ export function ContinuousChatOverlay({
     },
     onSwipeLeft: () => {
       setSwipeDx(0);
+      // A mouse highlight drag inside a bubble finishes here too; never switch
+      // the conversation out from under a live text selection (destroying it).
+      // Mirrors the ThreadLine tap-reveal selection guard.
+      if (hasLiveTextSelection()) {
+        swipeJank.end();
+        return;
+      }
       // Tag the flushed window with the committed direction so the ring shows
       // which way a janky swipe went (left → "next", the older conversation).
       swipeJank.end("next");
@@ -1445,6 +1467,10 @@ export function ContinuousChatOverlay({
     },
     onSwipeRight: () => {
       setSwipeDx(0);
+      if (hasLiveTextSelection()) {
+        swipeJank.end();
+        return;
+      }
       swipeJank.end("prev");
       conversationNav.goPrev();
     },
@@ -4430,7 +4456,11 @@ export function ContinuousChatOverlay({
                       icon={Mic}
                       label={
                         pttHolding
-                          ? "release to send"
+                          ? // Press-and-hold dictates into the composer draft; a
+                            // release drops the transcript into the text box and
+                            // does NOT send (see beginPushToTalkPress /
+                            // setDictationSink). Label the real behavior.
+                            "release to insert"
                           : transcriptionMode
                             ? "stop transcription"
                             : handsFree

--- a/packages/ui/src/components/shell/__tests__/useShellController.fuzz.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/useShellController.fuzz.test.tsx
@@ -59,6 +59,7 @@ const appMock = vi.hoisted(() => ({
     conversations: [] as Array<{ id: string }>,
     setTab: vi.fn(),
     handleChatStop: vi.fn(),
+    setActionNotice: vi.fn(),
     uiLanguage: "en",
     elizaCloudVoiceProxyAvailable: false,
   },

--- a/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
@@ -81,6 +81,7 @@ const appMock = vi.hoisted(() => ({
     conversations: [] as Array<{ id: string }>,
     setTab: vi.fn(),
     handleChatStop: vi.fn(),
+    setActionNotice: vi.fn(),
     uiLanguage: "en",
     elizaCloudVoiceProxyAvailable: false,
   },
@@ -146,9 +147,30 @@ const voiceOutputMock = vi.hoisted(() => ({
   toggleAgentVoiceMute: vi.fn(),
   needsAudioUnlock: false,
   unlockAudio: vi.fn(),
+  // Captures the `lastTurnVoice` the controller feeds its voice-output consumer
+  // each render — lastTurnVoice is internal (not on the public controller
+  // return), so this real consumer boundary is where the flag is observable.
+  lastTurnVoiceSeen: undefined as boolean | undefined,
 }));
 vi.mock("../useShellVoiceOutput", () => ({
-  useShellVoiceOutput: () => voiceOutputMock,
+  useShellVoiceOutput: (opts?: { lastTurnVoice?: boolean }) => {
+    voiceOutputMock.lastTurnVoiceSeen = opts?.lastTurnVoice;
+    return voiceOutputMock;
+  },
+}));
+
+// Wake-listen window is stubbed to a capture-only surface: it records the
+// `enabled` option (the Settings wake-word toggle → persisted pref → shell) and
+// otherwise stays inert, so the wake-gating assertions are deterministic and the
+// real native subscription never runs in jsdom.
+const wakeListenMock = vi.hoisted(() => ({
+  lastEnabled: undefined as boolean | undefined,
+}));
+vi.mock("../../../voice/useWakeListenWindow", () => ({
+  useWakeListenWindow: (opts: { enabled: boolean }) => {
+    wakeListenMock.lastEnabled = opts.enabled;
+    return { phase: "idle" as const };
+  },
 }));
 
 afterEach(() => {
@@ -161,11 +183,18 @@ afterEach(() => {
   appMock.value.chatFirstTokenReceived = false;
   appMock.serverTurnStatus = null;
   appMock.value.sendChatText.mockClear();
+  appMock.value.setActionNotice.mockClear();
   appMock.value.agentStatus = { ...READY_STATUS };
   appMock.value.handleNewConversation = vi.fn(() => Promise.resolve());
   appMock.value.handleSelectConversation = vi.fn(() => Promise.resolve());
   appMock.value.activeConversationId = null;
   appMock.value.conversations = [];
+  voiceOutputMock.stopSpeaking.mockClear();
+  voiceOutputMock.lastTurnVoiceSeen = undefined;
+  wakeListenMock.lastEnabled = undefined;
+  try {
+    window.localStorage.clear();
+  } catch {}
 });
 
 describe("useShellController", () => {
@@ -1161,5 +1190,165 @@ describe("useShellController — transcription mode", () => {
     });
     expect(result.current.transcriptionMode).toBe(false);
     expect(captureHandles[0]?.stop).toHaveBeenCalled();
+  });
+});
+
+// ── FIX 1: conversation switch/clear stops in-flight TTS + resets the latch ───
+// A voice reply that is still being spoken must not bleed into the conversation
+// the user swipes/clears into, and the "speak the next turn" latch (lastTurnVoice)
+// must not be inherited by the target thread. Both the swipe/select path and the
+// clear path must (a) stop in-flight TTS and (b) reset lastTurnVoice.
+describe("useShellController — conversation change stops TTS + resets voice latch", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    voiceOutputMock.speaking = false;
+    voiceOutputMock.stopSpeaking.mockClear();
+    voiceOutputMock.lastTurnVoiceSeen = undefined;
+    appMock.value.sendChatText.mockClear();
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it("swiping to another conversation stops in-flight TTS and clears lastTurnVoice", async () => {
+    appMock.value.conversations = [{ id: "a" }, { id: "b" }];
+    appMock.value.activeConversationId = "a";
+
+    const { result } = renderHook(() => useShellController());
+
+    // The last turn was voice → the latch is set (the reply gets spoken).
+    act(() =>
+      result.current.send("what's the weather", { channelType: "VOICE_DM" }),
+    );
+    expect(voiceOutputMock.lastTurnVoiceSeen).toBe(true);
+
+    voiceOutputMock.stopSpeaking.mockClear();
+    await act(async () => {
+      result.current.conversationNav.goNext();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(appMock.value.handleSelectConversation).toHaveBeenCalledWith("b");
+    // (a) in-flight speech is stopped, (b) the latch is reset for the new thread.
+    expect(voiceOutputMock.stopSpeaking).toHaveBeenCalled();
+    expect(voiceOutputMock.lastTurnVoiceSeen).toBe(false);
+  });
+
+  it("clearing the conversation stops in-flight TTS and clears lastTurnVoice", async () => {
+    const { result } = renderHook(() => useShellController());
+
+    act(() =>
+      result.current.send("remind me later", { channelType: "VOICE_DM" }),
+    );
+    expect(voiceOutputMock.lastTurnVoiceSeen).toBe(true);
+
+    voiceOutputMock.stopSpeaking.mockClear();
+    await act(async () => {
+      result.current.clearConversation();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(voiceOutputMock.stopSpeaking).toHaveBeenCalled();
+    expect(voiceOutputMock.lastTurnVoiceSeen).toBe(false);
+  });
+});
+
+// ── FIX 2: a swallowed mic permission / capture-start failure surfaces a notice ─
+describe("useShellController — mic capture-failure notice", () => {
+  beforeEach(() => {
+    createVoiceCaptureMock.mockReset();
+    appMock.value.setActionNotice.mockClear();
+    appMock.value.agentStatus = { ...READY_STATUS };
+    voiceOutputMock.speaking = false;
+    try {
+      window.localStorage.clear();
+    } catch {}
+  });
+
+  /** Install a capture whose start() rejects with the given error. */
+  function installRejectingCapture(err: unknown): void {
+    createVoiceCaptureMock.mockImplementation(
+      () =>
+        ({
+          start: vi.fn(() => Promise.reject(err)),
+          stop: vi.fn(() => Promise.resolve()),
+          dispose: vi.fn(),
+          getAnalyser: vi.fn(() => null),
+        }) as never,
+    );
+  }
+
+  /** Let the start() promise chain (.then → .catch) settle under real timers. */
+  async function flushCaptureStart(): Promise<void> {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+
+  it("surfaces a permission-denied notice (NotAllowedError) instead of failing silently", async () => {
+    const denied = new Error("Permission denied");
+    denied.name = "NotAllowedError";
+    installRejectingCapture(denied);
+
+    const { result } = renderHook(() => useShellController());
+    await act(async () => {
+      result.current.startRecording();
+    });
+    await flushCaptureStart();
+
+    expect(appMock.value.setActionNotice).toHaveBeenCalledTimes(1);
+    const [text, tone] = appMock.value.setActionNotice.mock.calls[0] as [
+      string,
+      string,
+    ];
+    expect(text.toLowerCase()).toContain("permission");
+    expect(tone).toBe("error");
+    // Recording state is cleaned up (not stuck "on").
+    expect(result.current.recording).toBe(false);
+  });
+
+  it("distinguishes a missing device (NotFoundError) from a denial", async () => {
+    const missing = new Error("Requested device not found");
+    missing.name = "NotFoundError";
+    installRejectingCapture(missing);
+
+    const { result } = renderHook(() => useShellController());
+    await act(async () => {
+      result.current.startRecording();
+    });
+    await flushCaptureStart();
+
+    expect(appMock.value.setActionNotice).toHaveBeenCalledTimes(1);
+    const [text, tone] = appMock.value.setActionNotice.mock.calls[0] as [
+      string,
+      string,
+    ];
+    expect(text.toLowerCase()).toContain("microphone");
+    expect(text.toLowerCase()).not.toContain("permission");
+    expect(tone).toBe("error");
+  });
+});
+
+// ── FIX 3: the Settings wake-word toggle actually gates wake listening ────────
+describe("useShellController — wake-word enablement", () => {
+  afterEach(() => {
+    try {
+      window.localStorage.clear();
+    } catch {}
+  });
+
+  it("enables wake listening by default (no stored pref)", () => {
+    renderHook(() => useShellController());
+    expect(wakeListenMock.lastEnabled).toBe(true);
+  });
+
+  it("disables wake listening when the persisted pref is off", () => {
+    window.localStorage.setItem("eliza:voice:wake-word-enabled", "false");
+    renderHook(() => useShellController());
+    expect(wakeListenMock.lastEnabled).toBe(false);
+  });
+
+  it("re-enables wake listening when the pref is on", () => {
+    window.localStorage.setItem("eliza:voice:wake-word-enabled", "true");
+    renderHook(() => useShellController());
+    expect(wakeListenMock.lastEnabled).toBe(true);
   });
 });

--- a/packages/ui/src/components/shell/use-pull-gesture.test.ts
+++ b/packages/ui/src/components/shell/use-pull-gesture.test.ts
@@ -475,6 +475,111 @@ describe("usePullGesture rAF coalescing (#9141)", () => {
     expect(onPullDown).not.toHaveBeenCalled();
   });
 
+  it("keeps a horizontal swipe alive when a child hands over its implicit touch capture at axis-commit", () => {
+    // A swipe that STARTS on an interactive/selectable child (e.g. a message
+    // bubble) gives that child implicit touch pointer capture on pointerdown.
+    // When the deferred-capture path takes the pointer at axis-commit
+    // (setPointerCapture on the swipe surface), the child fires
+    // `lostpointercapture`, which BUBBLES up to the surface's handler with
+    // `target` === the child (not the surface). That must NOT cancel the
+    // gesture — otherwise a genuine finger swipe that began on a bubble
+    // self-cancels the instant it commits. Only a capture loss on the surface
+    // ITSELF (rotation / OS takeover) settles the gesture.
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((cb: FrameRequestCallback) => {
+        cb(0);
+        return 1;
+      }),
+    );
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+    let t = 0;
+    vi.spyOn(performance, "now").mockImplementation(() => t);
+
+    const setPointerCapture = vi.fn();
+    const surface = { setPointerCapture, releasePointerCapture() {} };
+    // A DESCENDANT element (the bubble) — distinct from the swipe surface.
+    const child = {};
+
+    const onSwipeLeft = vi.fn();
+    const onCancel = vi.fn();
+    const { result } = renderHook(() =>
+      usePullGesture({
+        onDragX: vi.fn(),
+        onDragReset: vi.fn(),
+        onSwipeLeft,
+        onSwipeRight: vi.fn(),
+        onCancel,
+      }),
+    );
+    const b = result.current;
+
+    t = 0;
+    b.onPointerDown(pointer(300, 300, 1, surface)); // deferred capture (swipe-only)
+    // A slow 12px move: crosses AXIS_COMMIT_SLOP (commits X + captures) but is
+    // under BOTH the swipe distance (64) and velocity (0.4) thresholds, so the
+    // legacy `onLostPointerCapture: cancel` path could not even mis-fire it as a
+    // commit-on-cancel swipe — it just aborted the gesture.
+    t = 500;
+    b.onPointerMove(pointer(288, 300, 1, surface)); // dx=12 → commits X, captures
+    expect(setPointerCapture).toHaveBeenCalledWith(1);
+
+    // The child loses its implicit touch capture to the surface and fires
+    // `lostpointercapture`, bubbling here with target=child.
+    b.onLostPointerCapture({
+      target: child,
+      currentTarget: surface,
+      pointerId: 1,
+    } as unknown as React.PointerEvent);
+
+    // The finger keeps dragging left, then releases well past the threshold.
+    t = 600;
+    b.onPointerMove(pointer(150, 300, 1, surface));
+    t = 650;
+    b.onPointerUp(pointer(150, 300, 1, surface));
+
+    expect(onSwipeLeft).toHaveBeenCalledTimes(1);
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("still settles the gesture when the surface ITSELF loses capture (rotation)", () => {
+    // The case `onLostPointerCapture` exists for: the OS revokes OUR capture
+    // (device rotation) with the loss reported on the bound element itself
+    // (target === currentTarget). That must still cancel/settle the gesture.
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((cb: FrameRequestCallback) => {
+        cb(0);
+        return 1;
+      }),
+    );
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+
+    const surface = { setPointerCapture() {}, releasePointerCapture() {} };
+    const onDragReset = vi.fn();
+    const onCancel = vi.fn();
+    const { result } = renderHook(() =>
+      usePullGesture({
+        onDrag: vi.fn(),
+        onDragReset,
+        onPullUp: vi.fn(),
+        onCancel,
+      }),
+    );
+    const b = result.current;
+
+    b.onPointerDown(pointer(100, 300, 1, surface));
+    b.onPointerMove(pointer(100, 280, 1, surface)); // small vertical drag
+    b.onLostPointerCapture({
+      target: surface,
+      currentTarget: surface,
+      pointerId: 1,
+    } as unknown as React.PointerEvent);
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onDragReset).toHaveBeenCalled();
+  });
+
   it("still commits a steep drag (vertical well past the cone) as a vertical pull", () => {
     vi.stubGlobal(
       "requestAnimationFrame",

--- a/packages/ui/src/components/shell/use-pull-gesture.ts
+++ b/packages/ui/src/components/shell/use-pull-gesture.ts
@@ -460,6 +460,26 @@ export function usePullGesture(
     ],
   );
 
+  // A `lostpointercapture` that BUBBLED UP from a descendant (its `target` is
+  // not the element the binding is on) is that child's IMPLICIT touch capture
+  // being handed to US at axis-commit — a swipe that STARTS on an interactive/
+  // selectable child (e.g. a message bubble) gives that child implicit pointer
+  // capture on pointerdown; when the deferred-capture path then calls
+  // `setPointerCapture` on this surface, the child fires `lostpointercapture`,
+  // which bubbles here. Treating it as a cancel (as `onLostPointerCapture:
+  // cancel` did) aborts the swipe the instant it commits, so a genuine
+  // horizontal swipe that began on a bubble self-cancels. Ignore it: only a
+  // capture loss on the bound element ITSELF (`target === currentTarget` —
+  // device rotation / OS takeover, the case this handler exists for) should
+  // settle the gesture.
+  const lostCapture = React.useCallback(
+    (event: React.PointerEvent) => {
+      if (event.target !== event.currentTarget) return;
+      cancel(event);
+    },
+    [cancel],
+  );
+
   // Cancel any in-flight coalesced frame if the consumer unmounts mid-gesture.
   React.useEffect(() => cancelDrag, [cancelDrag]);
 
@@ -468,6 +488,6 @@ export function usePullGesture(
     onPointerMove,
     onPointerUp: finish,
     onPointerCancel: cancel,
-    onLostPointerCapture: cancel,
+    onLostPointerCapture: lostCapture,
   };
 }

--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -19,6 +19,7 @@ import type { AppContextValue } from "../../state/internal";
 import {
   loadContinuousChatMode,
   loadVadAutoStop,
+  loadWakeWordEnabled,
   saveContinuousChatMode,
 } from "../../state/persistence";
 import { deriveAgentReady } from "../../state/types";
@@ -203,6 +204,42 @@ export interface ShellController {
  * standalone-surface path). A final transcript is submitted through the same
  * `send` handler. The phase drives the pill glow and waveform mode.
  */
+/**
+ * Turn a mic-capture start failure into a clear, actionable notice. Reads the
+ * DOMException `name` (getUserMedia rejects with `NotAllowedError` on a denied
+ * permission, `NotFoundError` when no device exists) and its message so we
+ * distinguish "denied" vs "no device" vs a generic failure, instead of
+ * swallowing the rejection and leaving a mic tap silent.
+ */
+function describeCaptureFailure(err: unknown): string {
+  const name =
+    typeof err === "object" &&
+    err !== null &&
+    "name" in err &&
+    typeof (err as { name: unknown }).name === "string"
+      ? (err as { name: string }).name
+      : "";
+  const message = err instanceof Error ? err.message : String(err ?? "");
+  const haystack = `${name} ${message}`.toLowerCase();
+  if (
+    haystack.includes("notallowed") ||
+    haystack.includes("permissiondenied") ||
+    haystack.includes("permission denied") ||
+    haystack.includes("not-allowed")
+  ) {
+    return "Microphone access was denied. Enable microphone permission in your browser or system settings to use voice.";
+  }
+  if (
+    haystack.includes("notfound") ||
+    haystack.includes("devices not found") ||
+    haystack.includes("no device") ||
+    haystack.includes("no microphone")
+  ) {
+    return "No microphone was found. Connect a microphone to use voice.";
+  }
+  return "Could not start the microphone. Check your microphone permissions and try again.";
+}
+
 /** Shallow equality for two optional string lists (topic-change detection). */
 function sameStringList(a?: string[], b?: string[]): boolean {
   if (a === b) return true;
@@ -232,6 +269,7 @@ const selectShellController = (s: AppContextValue) => ({
   conversations: s.conversations,
   setTab: s.setTab,
   handleChatStop: s.handleChatStop,
+  setActionNotice: s.setActionNotice,
 });
 
 export function useShellController(): ShellController {
@@ -249,6 +287,7 @@ export function useShellController(): ShellController {
     conversations,
     setTab,
     handleChatStop,
+    setActionNotice,
   } = useAppSelectorShallow(selectShellController);
   // The wake phrase for transcript-mode inline replies follows the character
   // name (issue #9880); falls back to the running agent name, then "eliza".
@@ -292,6 +331,16 @@ export function useShellController(): ShellController {
   const conversationLoadingSeqRef = React.useRef(0);
   const conversationTransitionBusyRef = React.useRef(false);
 
+  // Stop any in-flight assistant speech across a conversation change. `voiceOutput`
+  // is defined far below (after the conversation-switch handlers), so mirror its
+  // `stopSpeaking` into a ref the clear/switch handlers can call at gesture time
+  // without a definition-order/closure problem. Defaults to a no-op until wired.
+  const stopSpeakingRef = React.useRef<() => void>(() => {});
+  // Guards the capture-failure notice so the hands-free re-listen loop's retries
+  // (which re-call startCapture every ~250ms) don't spam the toast; cleared on
+  // the next successful start so a later failure re-notifies.
+  const captureFailureNoticedRef = React.useRef(false);
+
   const runWithConversationLoading = React.useCallback(
     (task: () => Promise<unknown>) => {
       const seq = conversationLoadingSeqRef.current + 1;
@@ -331,16 +380,22 @@ export function useShellController(): ShellController {
   // conversation is kept and remains swipe-reachable).
   const clearConversation = React.useCallback(() => {
     // A fresh conversation's bootstrap greeting is NOT a reply to a voice turn —
-    // clear the voice flag so the greeting isn't spoken aloud after a prior
-    // voice session.
+    // stop any reply still being spoken from the prior session and clear the
+    // voice flag so the greeting isn't spoken aloud after it.
+    stopSpeakingRef.current();
     setLastTurnVoice(false);
     runWithConversationLoading(handleNewConversation);
   }, [handleNewConversation, runWithConversationLoading]);
 
   // Switch conversations behind a loading flag so an uncached swipe shows the
   // spinner; a cached one resolves within the same tick (thread already painted).
+  // A switch must not leave the previous thread's spoken reply playing into the
+  // new one, nor inherit its "speak the next turn" latch: stop in-flight TTS and
+  // reset lastTurnVoice so the target conversation starts silent.
   const selectConversation = React.useCallback(
     (id: string) => {
+      stopSpeakingRef.current();
+      setLastTurnVoice(false);
       runWithConversationLoading(() => handleSelectConversation(id));
     },
     [handleSelectConversation, runWithConversationLoading],
@@ -867,15 +922,26 @@ export function useShellController(): ShellController {
       handle
         .start()
         .then(() => {
+          // A clean start clears the failure latch so a later denial re-notifies.
+          captureFailureNoticedRef.current = false;
           if (captureRef.current === handle) setAnalyser(handle.getAnalyser());
         })
-        .catch(() => {
+        .catch((err: unknown) => {
           captureRef.current = null;
           setAnalyser(null);
           setRecording(false);
+          // Mic permission denial / capture failure was previously swallowed —
+          // the user tapped the mic and nothing happened with no feedback.
+          // Surface a clear, actionable notice through the shell's toast channel
+          // (denied vs no-device distinguished where possible). Guarded so the
+          // hands-free re-listen loop's retries don't spam it.
+          if (!captureFailureNoticedRef.current) {
+            captureFailureNoticedRef.current = true;
+            setActionNotice(describeCaptureFailure(err), "error", 6000);
+          }
         });
     },
-    [send, stopCapture, finalizeTranscriptSession],
+    [send, stopCapture, finalizeTranscriptSession, setActionNotice],
   );
 
   const toggleRecording = React.useCallback(() => {
@@ -925,6 +991,9 @@ export function useShellController(): ShellController {
     uiLanguage,
     cloudConnected: elizaCloudVoiceProxyAvailable,
   });
+  // Wire the forward ref so the conversation-switch / clear handlers (defined
+  // above `voiceOutput`) can stop in-flight assistant speech at gesture time.
+  stopSpeakingRef.current = voiceOutput.stopSpeaking;
 
   // `recording` (push-to-talk press or continuous capture) wins over an
   // in-flight response so the pill shows the red "listening" pulse the instant
@@ -1024,8 +1093,14 @@ export function useShellController(): ShellController {
   // ../../voice/VOICE_UX.md.
   const wakeAlreadyAlwaysOn =
     handsFree && loadContinuousChatMode() === "always-on";
+  // The Settings → Voice "Wake word" toggle gates this listening loop. Read the
+  // persisted pref synchronously each render (same direct-read pattern as
+  // loadContinuousChatMode above); it defaults ON so wake stays available unless
+  // the user turns it off. A disabled pref makes useWakeListenWindow inert (no
+  // native subscription, no mic effect).
+  const wakeWordEnabled = loadWakeWordEnabled();
   useWakeListenWindow({
-    enabled: true,
+    enabled: wakeWordEnabled,
     alwaysOn: wakeAlreadyAlwaysOn,
     agentBusy: responding,
     characterName: wakeCharacterName,

--- a/packages/ui/src/hooks/useContextMenu.test.ts
+++ b/packages/ui/src/hooks/useContextMenu.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+//
+// useContextMenu — the desktop (Electrobun) selection context-menu wiring.
+// Covers the two regressions this hook owned:
+//   • Quote-in-Chat must reach the LIVE floating composer via the chat-prefill
+//     event, not the unmounted detached-window ChatView `chatInput` slice.
+//   • The custom selection menu must not shadow the native Cut/Copy/Paste menu
+//     on editable fields (inputs/textareas/contenteditable).
+
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type BridgeListener = (payload: unknown) => void;
+
+const { isElectrobunRuntime, invokeDesktopBridgeRequest, subscribed } =
+  vi.hoisted(() => {
+    const listeners = new Map<string, BridgeListener>();
+    return {
+      subscribed: listeners,
+      isElectrobunRuntime: vi.fn(() => true),
+      invokeDesktopBridgeRequest: vi.fn(() => Promise.resolve(undefined)),
+    };
+  });
+
+vi.mock("../bridge", () => ({
+  isElectrobunRuntime,
+  invokeDesktopBridgeRequest,
+  subscribeDesktopBridgeEvent: (opts: {
+    rpcMessage: string;
+    listener: BridgeListener;
+  }) => {
+    subscribed.set(opts.rpcMessage, opts.listener);
+    return () => {
+      subscribed.delete(opts.rpcMessage);
+    };
+  },
+}));
+
+vi.mock("../chat", () => ({
+  loadSavedCustomCommands: () => [],
+  appendSavedCustomCommand: vi.fn(),
+}));
+
+import { CHAT_PREFILL_EVENT, type ChatPrefillEventDetail } from "../events";
+import { __setAppValueForTests } from "../state/app-store";
+import type { AppContextValue } from "../state/internal";
+import { useContextMenu } from "./useContextMenu";
+
+function seedStore(): void {
+  __setAppValueForTests({
+    setState: vi.fn(),
+    handleChatSend: vi.fn(),
+    setActionNotice: vi.fn(),
+  } as unknown as AppContextValue);
+}
+
+/** Fire a native `contextmenu` on `target`; returns whether it was prevented. */
+function fireContextMenu(target: EventTarget): boolean {
+  const event = new MouseEvent("contextmenu", {
+    bubbles: true,
+    cancelable: true,
+  });
+  target.dispatchEvent(event);
+  return event.defaultPrevented;
+}
+
+beforeEach(() => {
+  seedStore();
+});
+
+afterEach(() => {
+  cleanup();
+  __setAppValueForTests(null);
+  subscribed.clear();
+  invokeDesktopBridgeRequest.mockClear();
+  isElectrobunRuntime.mockReturnValue(true);
+  document.body.innerHTML = "";
+});
+
+describe("useContextMenu — Quote-in-Chat", () => {
+  it("routes the selection through the chat-prefill event the live composer listens to", () => {
+    const received: ChatPrefillEventDetail[] = [];
+    const onPrefill = (e: Event) =>
+      received.push((e as CustomEvent<ChatPrefillEventDetail>).detail);
+    window.addEventListener(CHAT_PREFILL_EVENT, onPrefill);
+
+    renderHook(() => useContextMenu());
+    const quoteInChat = subscribed.get("contextMenuQuoteInChat");
+    expect(quoteInChat).toBeTypeOf("function");
+
+    quoteInChat?.({ text: "the selected passage" });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].text).toContain("the selected passage");
+    // Prefill (never auto-select) so the user can keep typing after the quote.
+    expect(received[0].select).toBe(false);
+
+    window.removeEventListener(CHAT_PREFILL_EVENT, onPrefill);
+  });
+});
+
+describe("useContextMenu — native menu preservation", () => {
+  it("does NOT preventDefault on an editable target (native Cut/Copy/Paste kept)", () => {
+    renderHook(() => useContextMenu());
+
+    const input = document.createElement("input");
+    input.value = "hello world";
+    document.body.appendChild(input);
+    input.setSelectionRange(0, 5);
+
+    expect(fireContextMenu(input)).toBe(false);
+    expect(invokeDesktopBridgeRequest).not.toHaveBeenCalled();
+  });
+
+  it("shows the custom menu on a non-editable message target", () => {
+    const getSelection = vi.spyOn(window, "getSelection").mockReturnValue({
+      toString: () => "a quoted message",
+    } as unknown as Selection);
+
+    renderHook(() => useContextMenu());
+
+    const message = document.createElement("div");
+    message.textContent = "a quoted message";
+    document.body.appendChild(message);
+
+    expect(fireContextMenu(message)).toBe(true);
+    expect(invokeDesktopBridgeRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ params: { text: "a quoted message" } }),
+    );
+
+    getSelection.mockRestore();
+  });
+});

--- a/packages/ui/src/hooks/useContextMenu.ts
+++ b/packages/ui/src/hooks/useContextMenu.ts
@@ -14,8 +14,8 @@ import {
   loadSavedCustomCommands,
   type SavedCustomCommand,
 } from "../chat";
+import { dispatchChatPrefill } from "../events";
 import { useAppSelectorShallow } from "../state/app-store";
-import { useChatInputRef } from "../state/ChatComposerContext.hooks";
 
 export type CustomCommand = SavedCustomCommand;
 
@@ -49,6 +49,22 @@ function getSelectedText(target: EventTarget | null): string {
   return "";
 }
 
+/**
+ * Editable native targets (text inputs, textareas, contenteditable) own the
+ * platform's Cut/Copy/Paste context menu. Suppressing it there would strip the
+ * user's clipboard editing, so the custom selection menu only takes over
+ * non-editable surfaces (message text, links).
+ */
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (
+    target instanceof HTMLInputElement ||
+    target instanceof HTMLTextAreaElement
+  ) {
+    return true;
+  }
+  return target instanceof HTMLElement && target.isContentEditable;
+}
+
 export function useContextMenu(): ContextMenuState {
   const { setState, handleChatSend, setActionNotice } = useAppSelectorShallow(
     (s) => ({
@@ -57,9 +73,6 @@ export function useContextMenu(): ContextMenuState {
       setActionNotice: s.setActionNotice,
     }),
   );
-  // useChatInputRef() returns a stable MutableRefObject — subscribing to it never
-  // causes re-renders, so App.tsx (which calls this hook) stays quiet while typing.
-  const chatInputRef = useChatInputRef();
   const desktopRuntime = isElectrobunRuntime();
 
   const [saveCommandModalOpen, setSaveCommandModalOpen] = useState(false);
@@ -95,8 +108,11 @@ export function useContextMenu(): ContextMenuState {
       const command = payload as { text: string } | undefined;
       if (!command?.text) return;
       const quoted = `> ${command.text}\n\n`;
-      const existing = chatInputRef?.current ?? "";
-      setState("chatInput", quoted + existing);
+      // Route through the same prefill channel the live floating composer
+      // (ContinuousChatOverlay) consumes. Writing to the app-store `chatInput`
+      // slice would land in the detached-window ChatView, which is not mounted
+      // on the surface where the context menu fires — so the quote vanished.
+      dispatchChatPrefill({ text: quoted, select: false });
     };
 
     const unsubscribers = [
@@ -127,7 +143,7 @@ export function useContextMenu(): ContextMenuState {
         unsubscribe();
       }
     };
-  }, [setState, handleChatSend, chatInputRef]);
+  }, [setState, handleChatSend]);
 
   useEffect(() => {
     if (!desktopRuntime || typeof window === "undefined") {
@@ -136,6 +152,11 @@ export function useContextMenu(): ContextMenuState {
 
     const onContextMenu = (event: MouseEvent) => {
       if (event.defaultPrevented) {
+        return;
+      }
+
+      // Never shadow the native Cut/Copy/Paste menu on editable fields.
+      if (isEditableTarget(event.target)) {
         return;
       }
 

--- a/packages/ui/src/platform/window-shell.test.ts
+++ b/packages/ui/src/platform/window-shell.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseWindowShellRoute,
+  resolveDetachedShellPathname,
+  resolveDetachedShellTarget,
+} from "./window-shell";
+
+describe("parseWindowShellRoute", () => {
+  it("parses the connectors surface window (?shell=surface&tab=connectors)", () => {
+    // The desktop "New Connectors Window" opens with this query
+    // (packages/app-core .../surface-windows.ts buildSurfaceShellQuery). It must
+    // resolve to a scoped surface route, NOT fall through to `{ mode: "main" }`
+    // (which renders a full second dashboard).
+    expect(parseWindowShellRoute("?shell=surface&tab=connectors")).toEqual({
+      mode: "surface",
+      tab: "connectors",
+    });
+  });
+
+  it("still parses the other scoped surface windows", () => {
+    for (const tab of [
+      "browser",
+      "chat",
+      "release",
+      "triggers",
+      "plugins",
+      "cloud",
+    ] as const) {
+      expect(parseWindowShellRoute(`?shell=surface&tab=${tab}`)).toEqual({
+        mode: "surface",
+        tab,
+      });
+    }
+  });
+
+  it("falls back to main for an unknown surface tab", () => {
+    expect(parseWindowShellRoute("?shell=surface&tab=bogus")).toEqual({
+      mode: "main",
+    });
+  });
+});
+
+describe("resolveDetachedShellTarget", () => {
+  it("scopes the connectors window to the Connectors settings section", () => {
+    const target = resolveDetachedShellTarget({
+      mode: "surface",
+      tab: "connectors",
+    });
+    expect(target).toEqual({ tab: "settings", settingsSection: "connectors" });
+  });
+
+  it("resolves the connectors window pathname to /settings", () => {
+    expect(
+      resolveDetachedShellPathname({ mode: "surface", tab: "connectors" }),
+    ).toBe("/settings");
+  });
+});

--- a/packages/ui/src/platform/window-shell.ts
+++ b/packages/ui/src/platform/window-shell.ts
@@ -7,6 +7,7 @@ export type DetachedSurfaceTab =
   | "release"
   | "triggers"
   | "plugins"
+  | "connectors"
   | "cloud";
 
 export type WindowShellRoute =
@@ -47,6 +48,7 @@ export function parseWindowShellRoute(search: string): WindowShellRoute {
       tab === "release" ||
       tab === "triggers" ||
       tab === "plugins" ||
+      tab === "connectors" ||
       tab === "cloud"
     ) {
       return { mode: "surface", tab };
@@ -121,6 +123,11 @@ export function resolveDetachedShellTarget(
       return { tab: "triggers" };
     case "plugins":
       return { tab: "plugins" };
+    case "connectors":
+      // Connectors is a Settings section, not a standalone tab. Scope the
+      // window to that section (matching `cloud`/`release`) so the detached
+      // Connectors window renders the Connectors surface, not the full shell.
+      return { tab: "settings", settingsSection: "connectors" };
     case "cloud":
       return { tab: "settings", settingsSection: "cloud" };
   }

--- a/packages/ui/src/state/AppContext.resync.test.tsx
+++ b/packages/ui/src/state/AppContext.resync.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+
+import { renderHook } from "@testing-library/react";
+import type { MutableRefObject } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { RESYNC_EVENT, type ResyncEventDetail } from "./AppContext.hooks";
+import type { LoadConversationMessagesResult } from "./internal";
+import { useResyncReconcile } from "./useResyncReconcile";
+
+/**
+ * AppContext dispatches RESYNC_EVENT after a WebSocket reconnect so the active
+ * conversation can be reconciled. Historically the event had NO listener — the
+ * reconcile was dead code. These tests pin the live wiring: on resync the active
+ * conversation is reloaded, and only the active one.
+ */
+function dispatchResync(conversationId: string | null): void {
+  window.dispatchEvent(
+    new CustomEvent<ResyncEventDetail>(RESYNC_EVENT, {
+      detail: { conversationId },
+    }),
+  );
+}
+
+function setup(activeId: string | null) {
+  const activeConversationIdRef = {
+    current: activeId,
+  } as MutableRefObject<string | null>;
+  const loadConversationMessages = vi.fn(
+    async (): Promise<LoadConversationMessagesResult> => ({ ok: true }),
+  );
+  const view = renderHook(() =>
+    useResyncReconcile({ activeConversationIdRef, loadConversationMessages }),
+  );
+  return { activeConversationIdRef, loadConversationMessages, view };
+}
+
+describe("useResyncReconcile", () => {
+  it("reloads the active conversation on resync", () => {
+    const { loadConversationMessages } = setup("conv-1");
+    dispatchResync("conv-1");
+    expect(loadConversationMessages).toHaveBeenCalledTimes(1);
+    expect(loadConversationMessages).toHaveBeenCalledWith("conv-1");
+  });
+
+  it("falls back to the active conversation when the event carries a null id", () => {
+    const { loadConversationMessages } = setup("conv-active");
+    dispatchResync(null);
+    expect(loadConversationMessages).toHaveBeenCalledWith("conv-active");
+  });
+
+  it("does not reload when the resync targets a non-active conversation", () => {
+    const { loadConversationMessages } = setup("conv-active");
+    dispatchResync("conv-other");
+    expect(loadConversationMessages).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when there is no active conversation and no target", () => {
+    const { loadConversationMessages } = setup(null);
+    dispatchResync(null);
+    expect(loadConversationMessages).not.toHaveBeenCalled();
+  });
+
+  it("detaches the listener on unmount", () => {
+    const { loadConversationMessages, view } = setup("conv-1");
+    view.unmount();
+    dispatchResync("conv-1");
+    expect(loadConversationMessages).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/state/AppContext.tsx
+++ b/packages/ui/src/state/AppContext.tsx
@@ -88,6 +88,7 @@ import { useMiscUiState } from "./useMiscUiState";
 import { useNavigationState } from "./useNavigationState";
 import { usePairingState } from "./usePairingState";
 import { usePluginsSkillsState } from "./usePluginsSkillsState";
+import { useResyncReconcile } from "./useResyncReconcile";
 import { useStartupCoordinator } from "./useStartupCoordinator";
 import { useTabSync } from "./useTabSync";
 import { useTriggersState } from "./useTriggersState";
@@ -1406,6 +1407,12 @@ function AppProviderInner({
       }
     });
   }, []);
+
+  // Live consumer of the RESYNC_EVENT dispatched above. Without this the resync
+  // signal had no listener, so a reconnect never reconciled messages the agent
+  // emitted while the socket was down. This reloads the active conversation from
+  // the server on resync so those missed messages appear without a refresh.
+  useResyncReconcile({ activeConversationIdRef, loadConversationMessages });
 
   // ── Pairing ────────────────────────────────────────────────────────
 

--- a/packages/ui/src/state/persistence.ts
+++ b/packages/ui/src/state/persistence.ts
@@ -787,6 +787,28 @@ export function saveContinuousChatMode(mode: ContinuousChatModeValue): void {
   }, undefined);
 }
 
+/* ── Wake-word listening persistence ────────────────────────────────────── */
+// Device-local master switch for the "hey <name>" wake-word listening window
+// (see useWakeListenWindow). Stored here — not under `messages.voice` — because
+// it gates a device-local capture loop the shell reads synchronously on render,
+// the same dual-store pattern continuous-chat-mode and vad-auto-stop use. It
+// defaults ON so existing installs keep the always-available wake entry ramp;
+// the Settings → Voice toggle is what lets a user turn it off.
+const WAKE_WORD_ENABLED_KEY = "eliza:voice:wake-word-enabled";
+
+export function loadWakeWordEnabled(): boolean {
+  return tryLocalStorage(() => {
+    const stored = localStorage.getItem(WAKE_WORD_ENABLED_KEY);
+    return stored === null ? true : stored === "true";
+  }, true);
+}
+
+export function saveWakeWordEnabled(value: boolean): void {
+  tryLocalStorage(() => {
+    localStorage.setItem(WAKE_WORD_ENABLED_KEY, String(value));
+  }, undefined);
+}
+
 /* ── VAD auto-stop persistence ──────────────────────────────────────────── */
 // Local mirror of the `vadAutoStop` voice setting (source of truth is the agent
 // config under `messages.voice`). Stored here too so the capture hot path

--- a/packages/ui/src/state/useChatSend.test.tsx
+++ b/packages/ui/src/state/useChatSend.test.tsx
@@ -290,6 +290,91 @@ describe("useChatSend stop handling", () => {
     expect(mocks.client.abortConversationTurn).toHaveBeenCalledTimes(1);
     expect(deps.setActionNotice).not.toHaveBeenCalled();
   });
+
+  it("keeps a locally-committed partial reply after a STOP whose reload lacks it", async () => {
+    // STOP mid-stream resolves the stream with the partial + completed:false.
+    // The server never persisted the partial, so the post-turn history reload
+    // full-replaces local state with ONLY the persisted user turn. The partial
+    // the user was watching must survive that reload — re-attached as an
+    // interrupted assistant turn.
+    mocks.client.sendConversationMessageStream.mockImplementation(
+      async (
+        _id: string,
+        _text: string,
+        onToken: (token: string, accumulatedText?: string) => void,
+      ) => {
+        onToken("Here is the par", "Here is the par");
+        return { text: "Here is the par", completed: false };
+      },
+    );
+    const deps = makeDeps({
+      activeConversationId: "conv-1",
+      conversations: [conversation("conv-1", "room-1")],
+    });
+    // Server full-replace reload: only the persisted user turn survives (the
+    // stopped assistant reply was never written server-side).
+    vi.mocked(deps.loadConversationMessages).mockImplementation(async () => {
+      deps.setConversationMessages([
+        { id: "server-user-1", role: "user", text: "hello", timestamp: 1 },
+      ]);
+      return { ok: true };
+    });
+    const { result } = renderHook(() => useChatSend(deps));
+
+    await act(async () => {
+      await result.current.sendChatText("hello", { conversationId: "conv-1" });
+    });
+
+    const assistantMessages = deps.conversationMessagesRef.current.filter(
+      (m) => m.role === "assistant",
+    );
+    expect(assistantMessages).toHaveLength(1);
+    expect(assistantMessages[0].text).toBe("Here is the par");
+    expect(assistantMessages[0].interrupted).toBe(true);
+  });
+
+  it("does NOT duplicate the partial when the server persisted the stopped reply", async () => {
+    mocks.client.sendConversationMessageStream.mockImplementation(
+      async (
+        _id: string,
+        _text: string,
+        onToken: (token: string, accumulatedText?: string) => void,
+      ) => {
+        onToken("Here is the par", "Here is the par");
+        return { text: "Here is the par", completed: false };
+      },
+    );
+    const deps = makeDeps({
+      activeConversationId: "conv-1",
+      conversations: [conversation("conv-1", "room-1")],
+    });
+    // Server DID persist the (truncated) reply — the reload carries it, so the
+    // partial must not be re-attached a second time.
+    vi.mocked(deps.loadConversationMessages).mockImplementation(async () => {
+      deps.setConversationMessages([
+        { id: "server-user-1", role: "user", text: "hello", timestamp: 1 },
+        {
+          id: "server-asst-1",
+          role: "assistant",
+          text: "Here is the par",
+          timestamp: 2,
+          interrupted: true,
+        },
+      ]);
+      return { ok: true };
+    });
+    const { result } = renderHook(() => useChatSend(deps));
+
+    await act(async () => {
+      await result.current.sendChatText("hello", { conversationId: "conv-1" });
+    });
+
+    const assistantMessages = deps.conversationMessagesRef.current.filter(
+      (m) => m.role === "assistant",
+    );
+    expect(assistantMessages).toHaveLength(1);
+    expect(assistantMessages[0].id).toBe("server-asst-1");
+  });
 });
 
 function http404(): Error {

--- a/packages/ui/src/state/useChatSend.ts
+++ b/packages/ui/src/state/useChatSend.ts
@@ -870,6 +870,38 @@ export function useChatSend(deps: UseChatSendDeps) {
     [setConversationMessages],
   );
 
+  // Re-attach a stopped/interrupted turn's partial reply after the post-turn
+  // history reload full-replaced it away. The server frequently does NOT persist
+  // a reply that was cut off mid-stream, so the reload returns a thread without
+  // it and the bubble the user was watching stream in silently vanishes. Append
+  // the partial as an interrupted assistant turn — but ONLY when the reloaded
+  // thread's last message is not already an assistant turn (i.e. the server has
+  // no reply for this turn). When the server DID persist a reply the reload
+  // already carries it, so it is kept as-is and never duplicated.
+  const reattachInterruptedPartial = useCallback(
+    (partialText: string) => {
+      const text = partialText.trim();
+      if (!text) return;
+      setConversationMessages((prev) => {
+        const last = prev[prev.length - 1];
+        if (last?.role === "assistant") return prev;
+        return [
+          ...prev,
+          {
+            id: `local-interrupted-${Date.now()}-${Math.random()
+              .toString(36)
+              .slice(2, 8)}`,
+            role: "assistant",
+            text,
+            timestamp: Date.now(),
+            interrupted: true,
+          },
+        ];
+      });
+    },
+    [setConversationMessages],
+  );
+
   const runQueuedChatSend = useCallback(
     async (turn: Omit<QueuedChatSend, "resolve" | "reject">) => {
       const hasAttachedImages = Boolean(turn.images?.length);
@@ -1117,7 +1149,15 @@ export function useChatSend(deps: UseChatSendDeps) {
           });
         }
 
-        if (!data.completed && streamedAssistantText.trim()) {
+        // A stopped / dropped turn keeps a partial reply the user was watching.
+        // Snapshot it BEFORE the reload below (which full-replaces local state
+        // with the server's copy) so it can be re-attached if the server never
+        // persisted it.
+        const interruptedPartial =
+          !data.completed && streamedAssistantText.trim()
+            ? data.text.trim() || streamedAssistantText
+            : null;
+        if (interruptedPartial) {
           applyStreamingTextModification(setConversationMessages, {
             messageId: assistantMsgId,
             mode: "interrupt",
@@ -1128,6 +1168,12 @@ export function useChatSend(deps: UseChatSendDeps) {
         // mirrored by the optimistic streaming draft in local state.
         if (activeConversationIdRef.current === convId) {
           await loadConversationMessages(convId);
+          // The reload above full-replaces the thread; a stopped reply is often
+          // NOT persisted server-side, so re-attach the partial the user watched
+          // stream in (no-op / no duplicate when the server kept it).
+          if (interruptedPartial) {
+            reattachInterruptedPartial(interruptedPartial);
+          }
         }
 
         const userMessageCount = conversationMessagesRef.current.filter(
@@ -1392,6 +1438,7 @@ export function useChatSend(deps: UseChatSendDeps) {
       setCompanionMessageCutoffTs,
       setConversationMessages,
       dropEmptyAssistantPlaceholder,
+      reattachInterruptedPartial,
       setConversations,
       setActionNotice,
       setChatInput,
@@ -1727,7 +1774,13 @@ export function useChatSend(deps: UseChatSendDeps) {
             });
           }
 
-          if (!data.completed && streamedAssistantText.trim()) {
+          // Snapshot a stopped/dropped partial before the reload below so it can
+          // survive a full-replace the server's copy lacks (see runQueuedChatSend).
+          const interruptedPartial =
+            !data.completed && streamedAssistantText.trim()
+              ? data.text.trim() || streamedAssistantText
+              : null;
+          if (interruptedPartial) {
             applyStreamingTextModification(setConversationMessages, {
               messageId: assistantMsgId,
               mode: "interrupt",
@@ -1738,6 +1791,9 @@ export function useChatSend(deps: UseChatSendDeps) {
           // additional action-generated messages during a successful send.
           if (activeConversationIdRef.current === convId) {
             await loadConversationMessages(convId);
+            if (interruptedPartial) {
+              reattachInterruptedPartial(interruptedPartial);
+            }
           }
 
           void loadConversations();

--- a/packages/ui/src/state/useResyncReconcile.ts
+++ b/packages/ui/src/state/useResyncReconcile.ts
@@ -1,0 +1,52 @@
+/**
+ * Live consumer for the WebSocket-reconnect resync signal.
+ *
+ * `AppContext` dispatches {@link RESYNC_EVENT} on `client.onReconnect` after a
+ * dropped socket comes back. Historically that event had NO listener, so the
+ * reconcile it was meant to trigger never ran: messages the agent emitted while
+ * the socket was down stayed hidden until a manual refresh. This hook wires the
+ * missing listener and performs the reconcile.
+ */
+
+import { type MutableRefObject, useEffect } from "react";
+import { RESYNC_EVENT, type ResyncEventDetail } from "./AppContext.hooks";
+import type { LoadConversationMessagesResult } from "./internal";
+
+export interface UseResyncReconcileDeps {
+  /** Stable ref whose `.current` is the conversation the user is viewing. */
+  activeConversationIdRef: MutableRefObject<string | null>;
+  /** Full-replace reload of a conversation's messages from the server. */
+  loadConversationMessages: (
+    convId: string,
+  ) => Promise<LoadConversationMessagesResult>;
+}
+
+/**
+ * On {@link RESYNC_EVENT}, reload the affected conversation from the server so
+ * messages missed during a WebSocket gap appear without a manual refresh.
+ *
+ * Only the conversation the user is currently viewing is force-reloaded here; a
+ * background conversation is reconciled the next time it is opened (its normal
+ * load already fetches the latest server state). The resync can also arrive
+ * after the user navigated away, so the active-id guard drops a reload targeting
+ * a conversation that is no longer on screen.
+ */
+export function useResyncReconcile({
+  activeConversationIdRef,
+  loadConversationMessages,
+}: UseResyncReconcileDeps): void {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onResync = (event: Event) => {
+      const detail = (event as CustomEvent<ResyncEventDetail>).detail;
+      const convId = detail?.conversationId ?? activeConversationIdRef.current;
+      if (!convId) return;
+      if (activeConversationIdRef.current !== convId) return;
+      void loadConversationMessages(convId);
+    };
+    window.addEventListener(RESYNC_EVENT, onResync);
+    return () => window.removeEventListener(RESYNC_EVENT, onResync);
+    // `activeConversationIdRef` is a stable ref read at event time; re-subscribe
+    // only when the loader identity changes.
+  }, [activeConversationIdRef, loadConversationMessages]);
+}


### PR DESCRIPTION
## Summary

Fixes 14 confirmed **major** findings from the her-grade QA sweep (each root-caused by reading code first; several guard-tests verified to fail without their fix). Five disjoint file clusters + a CI-lane fix, all with real behavior tests.

### Gestures & selection (overlay)
- Mouse text-selection in a chat bubble / the open transcript triggered a conversation swipe (selection destroyed) — added a live-selection guard on both swipe handlers.
- A touch swipe that STARTED on a message bubble self-cancelled at axis-commit (the bubble's implicit-capture handover bubbled a `lostpointercapture` wired to `cancel`) — now ignores descendant capture-handover, settles only on a genuine self-loss.

### Voice
- Conversation swipe/select kept the previous reply's TTS playing + inherited the voice latch — now stopSpeaking + reset lastTurnVoice.
- Mic permission denial was silent — surfaces a denied/no-device notice.
- The Settings 'Wake word' toggle was dead while wake was hardcoded ON — wired to a persisted pref.
- Push-to-talk mislabeled 'release to send' (it dictates into the composer) — relabeled 'release to insert'.

### Copy / context menu
- Transcript Copy/Share reported 'Copied' when nothing was copied — tri-state honest status.
- Desktop right-click 'Quote in Chat' wrote to an unmounted composer — now dispatches the CHAT_PREFILL_EVENT the live overlay consumes.
- The custom context menu killed native Cut/Copy/Paste in inputs — native menu preserved on editable targets.

### Streaming
- STOP mid-stream lost the partial reply (post-turn reload full-replaced it away) — re-attach as an interrupted turn without duplicating a server-persisted one.
- Client abort never propagated to the SSE read after headers — signal now cancels the read loop immediately.
- WS-reconnect resync was dead code (RESYNC_EVENT had no listener) — new useResyncReconcile reloads the active conversation on reconnect.

### Deep-links / platform
- eliza:// tab routes (settings/wallet/browser/connectors) were navigation no-ops (hash writes the mobile entrypoint never reads) — routed through the real navigate:view bus.
- Desktop 'New Connectors Window' opened a full dashboard — scoped to the connectors settings surface.
- #10472's Android online/offline fallback was dead code (never imported) — wired into the live entrypoint.

### CI
- Included: the packages/app HMR-coverage lane fix (cockpit probe added, stale facewear/smartglasses probes removed) — already merged via #11121, base of this branch.

## Evidence
1361 `packages/ui` unit + 24 `packages/app` (deep-link/network/hmr-coverage) + gesture e2e (chat-sheet, conversation-swipe, chatux, home-screen) all green.

Refs the #10722 sweep, #10472, #9148. Remaining: #10231 stale Steward token, jump-to-message on terminal/inbox surface, Android hardware-back, AOSP phone/messages/contacts deep-links (documented follow-ups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)