### PR TITLE
test(cloud-e2e): scope the org-debit ledger count to TEST_ORGANIZATION_ID (#11125 follow-up)

### DIFF
--- a/packages/cloud/api/test/e2e/_helpers/ledger.ts
+++ b/packages/cloud/api/test/e2e/_helpers/ledger.ts
@@ -13,12 +13,21 @@ import { sql } from "drizzle-orm";
 /**
  * Count org-ledger inference debits created at/after `since`. The
  * app-attributed path writes `Chat completion: <model>`; the plain org path
- * writes `AI request: <model>` — match both.
+ * writes `AI request: <model>` — match both. Scoped to the preload's test org
+ * (TEST_ORGANIZATION_ID) so unrelated traffic on shared staging can never
+ * satisfy the assertion.
  */
 export async function countAiRequestDebitsSince(since: Date): Promise<number> {
+  const orgId = process.env.TEST_ORGANIZATION_ID;
+  if (!orgId) {
+    throw new Error(
+      "countAiRequestDebitsSince: TEST_ORGANIZATION_ID is not set (preload seeds it)",
+    );
+  }
   const res = (await dbRead.execute(
     sql`SELECT count(*) AS n FROM credit_transactions
         WHERE type = 'debit'
+          AND organization_id = ${orgId}
           AND (description LIKE 'AI request:%' OR description LIKE 'Chat completion:%')
           AND created_at >= ${since.toISOString()}`,
   )) as { rows?: Array<{ n?: string | number }> };


### PR DESCRIPTION
Adversarial review of just-merged #11125 flagged that `countAiRequestDebitsSince` counts debits across ALL orgs — on shared staging the org-debit assertion could be satisfied by unrelated traffic. The e2e preload (`test/e2e/preload.ts:203`) already seeds `TEST_ORGANIZATION_ID` and sibling suites (group-c) already require it; this scopes the WHERE clause and fails loud if unset. Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)