### PR TITLE
test(core): satisfy Biome in reflection schema invariant

### DIFF
--- a/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.test.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.test.ts
@@ -151,7 +151,9 @@ describe("reflection evaluator schemas are strict-structured-output safe", () =>
 	function assertStrictObjectNodes(node: unknown, path: string): void {
 		if (node === null || typeof node !== "object") return;
 		if (Array.isArray(node)) {
-			node.forEach((item, i) => assertStrictObjectNodes(item, `${path}[${i}]`));
+			node.forEach((item, i) => {
+				assertStrictObjectNodes(item, `${path}[${i}]`);
+			});
 			return;
 		}
 		const record = node as Record<string, unknown>;


### PR DESCRIPTION
## Summary\n- Fix the post-#11129 Biome lint regression in eflection-items.test.ts by giving the array orEach callback a block body.\n- No behavior changes; keeps the strict structured-output invariant test intact while making current develop pass the repo-pinned Biome rule.\n\n## Evidence\n- Before on current develop: unx @biomejs/biome@2.5.1 check packages/core/src/features/advanced-capabilities/evaluators/reflection-items.test.ts failed with lint/suspicious/useIterableCallbackReturn.\n- After: unx @biomejs/biome@2.5.1 check packages/core/src/features/advanced-capabilities/evaluators/reflection-items.test.ts -> passed.\n- un run --cwd packages/core test -- src/features/advanced-capabilities/evaluators/reflection-items.test.ts -> 1 file / 3 tests passed.\n- un run --cwd packages/core typecheck -> passed.\n- git diff --check -> passed.\n\nRefs #11129 / #11123.