### PR TITLE
fix(orchestrator): pin SSRF-vetted DNS answers to the connection — close the rebinding TOCTOU (#11028)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/ssrf-guard.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/ssrf-guard.test.ts
@@ -6,6 +6,7 @@ import {
   SsrfBlockedError,
   safeFetch,
   setHostResolver,
+  setPinnedTransport,
 } from "../../src/services/ssrf-guard.js";
 
 /**
@@ -18,6 +19,7 @@ import {
 
 afterEach(() => {
   setHostResolver(); // reset to system resolver
+  setPinnedTransport(); // reset to the node pinned transport
   vi.unstubAllGlobals();
 });
 
@@ -64,7 +66,7 @@ describe("assertHostAllowed", () => {
     setHostResolver(() => {
       throw new Error("resolver must not be called for localhost");
     });
-    await expect(assertHostAllowed("localhost")).resolves.toBeUndefined();
+    await expect(assertHostAllowed("localhost")).resolves.toBeNull();
   });
 
   it("blocks an IP-literal metadata host directly", async () => {
@@ -85,7 +87,9 @@ describe("assertHostAllowed", () => {
 
   it("allows a hostname that resolves only to public addresses", async () => {
     setHostResolver(async () => [{ address: "93.184.216.34" }]);
-    await expect(assertHostAllowed("example.com")).resolves.toBeUndefined();
+    await expect(assertHostAllowed("example.com")).resolves.toEqual([
+      "93.184.216.34",
+    ]);
   });
 
   it("blocks when resolution fails or returns nothing", async () => {
@@ -122,7 +126,7 @@ describe("assertUrlAllowed", () => {
     await expect(
       assertUrlAllowed("http://169.254.169.254/latest/meta-data/"),
     ).rejects.toBeInstanceOf(SsrfBlockedError);
-    await expect(assertUrlAllowed("https://8.8.8.8/")).resolves.toBeUndefined();
+    await expect(assertUrlAllowed("https://8.8.8.8/")).resolves.toBeNull();
   });
 });
 
@@ -170,5 +174,93 @@ describe("safeFetch", () => {
     await expect(safeFetch("http://8.8.8.8/")).rejects.toThrow(
       /too many redirects/,
     );
+  });
+});
+
+describe("safeFetch DNS-rebinding pin (#11028)", () => {
+  const fakeResponse = (status: number, location?: string): Response =>
+    ({
+      status,
+      headers: new Headers(location ? { location } : {}),
+      body: null,
+    }) as unknown as Response;
+
+  it("connects hostname targets through the PINNED transport with the vetted addresses, never plain fetch", async () => {
+    // Rebinding resolver: answers PUBLIC on the vetting lookup and the
+    // metadata IP on any later lookup. The connection must use the first
+    // (vetted) answer — a second resolution is the TOCTOU under test.
+    let calls = 0;
+    setHostResolver(async () => {
+      calls += 1;
+      return calls === 1
+        ? [{ address: "93.184.216.34" }]
+        : [{ address: "169.254.169.254" }];
+    });
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    const transport = vi.fn(async () => fakeResponse(200));
+    setPinnedTransport(transport);
+
+    const res = await safeFetch("http://build-preview.example/");
+    expect(res.status).toBe(200);
+    // The request went through the pinned transport with the VETTED address…
+    expect(transport).toHaveBeenCalledTimes(1);
+    expect(transport).toHaveBeenCalledWith(
+      "http://build-preview.example/",
+      expect.anything(),
+      ["93.184.216.34"],
+    );
+    // …and never through plain fetch (which would re-resolve DNS and hand the
+    // rebinding resolver its second, internal answer).
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("re-vets and re-pins every redirect hop with that hop's own addresses", async () => {
+    setHostResolver(async (host) =>
+      host === "a.example"
+        ? [{ address: "93.184.216.34" }]
+        : [{ address: "142.250.72.14" }],
+    );
+    const transport = vi.fn(async (url: string) =>
+      url.startsWith("http://a.example")
+        ? fakeResponse(302, "http://b.example/next")
+        : fakeResponse(200),
+    );
+    setPinnedTransport(transport);
+
+    const res = await safeFetch("http://a.example/");
+    expect(res.status).toBe(200);
+    expect(transport).toHaveBeenNthCalledWith(
+      1,
+      "http://a.example/",
+      expect.anything(),
+      ["93.184.216.34"],
+    );
+    expect(transport).toHaveBeenNthCalledWith(
+      2,
+      "http://b.example/next",
+      expect.anything(),
+      ["142.250.72.14"],
+    );
+  });
+
+  it("still blocks a hostname whose vetting resolution is internal (pin never reached)", async () => {
+    setHostResolver(async () => [{ address: "169.254.169.254" }]);
+    const transport = vi.fn();
+    setPinnedTransport(transport);
+    await expect(safeFetch("http://evil.example/")).rejects.toBeInstanceOf(
+      SsrfBlockedError,
+    );
+    expect(transport).not.toHaveBeenCalled();
+  });
+
+  it("IP-literal and localhost targets keep using plain fetch (no DNS to rebind)", async () => {
+    const fetchSpy = vi.fn(async () => fakeResponse(200));
+    vi.stubGlobal("fetch", fetchSpy);
+    const transport = vi.fn();
+    setPinnedTransport(transport);
+    await safeFetch("http://127.0.0.1:3000/build");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(transport).not.toHaveBeenCalled();
   });
 });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
@@ -4,7 +4,10 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { Content, HandlerCallback, Memory } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { setHostResolver } from "../../src/services/ssrf-guard.js";
+import {
+  setHostResolver,
+  setPinnedTransport,
+} from "../../src/services/ssrf-guard.js";
 import {
   extractShortToolDeliverable,
   extractSubResources,
@@ -48,10 +51,17 @@ function restoreStubbedGlobals(): void {
     });
   }
   stubbedGlobals.clear();
+  setPinnedTransport();
 }
 
 function stubFetch(fetchMock: typeof fetch): void {
   stubGlobalValue("fetch", fetchMock);
+  // The SSRF guard pins hostname connections through its own transport
+  // (#11028) instead of global fetch; route it through the same mock so the
+  // URL-verification tests keep serving their per-URL responses.
+  setPinnedTransport(async (url, init) =>
+    fetchMock(url, { ...init, redirect: "manual" }),
+  );
 }
 
 function makeAcpService(session: SessionInfo): {

--- a/plugins/plugin-agent-orchestrator/src/services/ssrf-guard.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/ssrf-guard.ts
@@ -26,7 +26,10 @@
  */
 
 import { lookup as dnsLookup } from "node:dns/promises";
+import { request as httpRequest, type IncomingMessage } from "node:http";
+import { request as httpsRequest } from "node:https";
 import { isIP } from "node:net";
+import { Readable } from "node:stream";
 
 const MAX_REDIRECTS = 5;
 
@@ -196,12 +199,20 @@ export function classifyIpLiteral(
  * Resolve `hostname` and assert every resolved address is fetch-safe
  * (loopback or public). Throws `SsrfBlockedError` if the host is, or resolves
  * to, a blocked (non-public, non-loopback) address. Checking *all* resolved
- * addresses defeats DNS rebinding to an internal IP.
+ * addresses defeats a rebinding answer that mixes public and internal IPs.
+ *
+ * Returns the vetted addresses for DNS hostnames so the caller can PIN the
+ * connection to them (#11028): validating here and letting `fetch` resolve
+ * again leaves a rebinding window where the second lookup answers with an
+ * internal IP. Returns `null` for `localhost` and IP literals — their
+ * "resolution" is local/static, so there is nothing to rebind.
  */
-export async function assertHostAllowed(hostname: string): Promise<void> {
+export async function assertHostAllowed(
+  hostname: string,
+): Promise<string[] | null> {
   const host = hostname.replace(/^\[|\]$/g, "");
   // `localhost` is loopback by convention; allow without a DNS round-trip.
-  if (host.toLowerCase() === "localhost") return;
+  if (host.toLowerCase() === "localhost") return null;
 
   // IP literal: classify directly, no DNS.
   if (isIP(host) !== 0) {
@@ -209,7 +220,7 @@ export async function assertHostAllowed(hostname: string): Promise<void> {
     if (verdict === "blocked") {
       throw new SsrfBlockedError(host, `non-public address ${host}`);
     }
-    return;
+    return null;
   }
 
   // Hostname: resolve to all addresses and reject if any is blocked.
@@ -223,10 +234,13 @@ export async function assertHostAllowed(hostname: string): Promise<void> {
       `DNS resolution failed for ${host}: ${reason}`,
     );
   }
-  if (records.length === 0) {
+  const addresses = records
+    .map((record) => record.address)
+    .filter((address) => typeof address === "string" && address.length > 0);
+  if (addresses.length === 0) {
     throw new SsrfBlockedError(host, `no addresses resolved for ${host}`);
   }
-  for (const { address } of records) {
+  for (const address of addresses) {
     if (classifyIpLiteral(address) === "blocked") {
       throw new SsrfBlockedError(
         host,
@@ -234,10 +248,16 @@ export async function assertHostAllowed(hostname: string): Promise<void> {
       );
     }
   }
+  return addresses;
 }
 
-/** Assert the full URL's host is fetch-safe. */
-export async function assertUrlAllowed(url: string | URL): Promise<void> {
+/**
+ * Assert the full URL's host is fetch-safe. Returns the vetted addresses to
+ * pin the connection to (`null` when the host is an IP literal/localhost).
+ */
+export async function assertUrlAllowed(
+  url: string | URL,
+): Promise<string[] | null> {
   let parsed: URL;
   try {
     parsed = typeof url === "string" ? new URL(url) : url;
@@ -250,7 +270,114 @@ export async function assertUrlAllowed(url: string | URL): Promise<void> {
       `unsupported protocol ${parsed.protocol}`,
     );
   }
-  await assertHostAllowed(parsed.hostname);
+  return assertHostAllowed(parsed.hostname);
+}
+
+/** Node-style lookup callback signature (`net.connect`/`tls.connect`). */
+type NodeLookupCallback = (
+  err: Error | null,
+  address: string | Array<{ address: string; family: number }>,
+  family?: number,
+) => void;
+
+/**
+ * Build a `lookup` implementation for `http(s).request` that only ever
+ * answers with the addresses vetted by `assertHostAllowed`. The socket layer
+ * never consults real DNS, so a rebinding resolver cannot swap in an internal
+ * address between validation and connection.
+ */
+function createPinnedLookup(
+  addresses: string[],
+): (
+  host: string,
+  options: { all?: boolean } | NodeLookupCallback,
+  callback?: NodeLookupCallback,
+) => void {
+  const records = addresses.map((address) => ({
+    address,
+    family: address.includes(":") ? 6 : 4,
+  }));
+  return (_host, options, callback) => {
+    const cb = typeof options === "function" ? options : callback;
+    if (!cb) return;
+    const all = typeof options === "object" && options.all === true;
+    if (all) {
+      cb(null, records);
+      return;
+    }
+    cb(null, records[0].address, records[0].family);
+  };
+}
+
+/**
+ * One redirect-free request with the connection pinned to the vetted
+ * addresses, wrapped back into a standard `Response`. Injectable so tests can
+ * observe the pinned path without opening sockets.
+ */
+export type PinnedTransport = (
+  url: string,
+  init: Omit<RequestInit, "redirect">,
+  addresses: string[],
+) => Promise<Response>;
+
+function nodePinnedTransport(
+  url: string,
+  init: Omit<RequestInit, "redirect">,
+  addresses: string[],
+): Promise<Response> {
+  const parsed = new URL(url);
+  const isHttps = parsed.protocol === "https:";
+  const requestFn = isHttps ? httpsRequest : httpRequest;
+  return new Promise<Response>((resolve, reject) => {
+    const req = requestFn(
+      {
+        protocol: parsed.protocol,
+        hostname: parsed.hostname,
+        port: parsed.port || (isHttps ? "443" : "80"),
+        path: `${parsed.pathname}${parsed.search}`,
+        method: init.method ?? "GET",
+        headers: Object.fromEntries(new Headers(init.headers ?? {}).entries()),
+        // The pin: TLS SNI + certificate verification still use the original
+        // hostname, but the socket connects to a vetted address only.
+        lookup: createPinnedLookup(addresses),
+      },
+      (res: IncomingMessage) => {
+        const status = res.statusCode ?? 0;
+        const headers = new Headers();
+        for (const [name, value] of Object.entries(res.headers)) {
+          if (Array.isArray(value)) {
+            for (const entry of value) headers.append(name, entry);
+          } else if (typeof value === "string") {
+            headers.set(name, value);
+          }
+        }
+        // Statuses that forbid a body in the Response constructor.
+        const body =
+          status === 204 || status === 205 || status === 304
+            ? null
+            : (Readable.toWeb(res) as unknown as BodyInit);
+        resolve(new Response(body, { status, headers }));
+      },
+    );
+    const signal = init.signal;
+    if (signal) {
+      const onAbort = () =>
+        req.destroy(
+          signal.reason instanceof Error ? signal.reason : new Error("aborted"),
+        );
+      if (signal.aborted) onAbort();
+      else signal.addEventListener("abort", onAbort, { once: true });
+    }
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+let pinnedTransport: PinnedTransport = nodePinnedTransport;
+
+/** Override the pinned transport (test seam). Pass no argument to reset. */
+export function setPinnedTransport(transport?: PinnedTransport): void {
+  pinnedTransport = transport ?? nodePinnedTransport;
 }
 
 /**
@@ -261,6 +388,12 @@ export async function assertUrlAllowed(url: string | URL): Promise<void> {
  * before fetching it — so a public page cannot redirect the verifier into an
  * internal or cloud-metadata endpoint. Caps redirects at `MAX_REDIRECTS`.
  *
+ * For DNS hostnames the connection is PINNED to the addresses the validation
+ * step resolved (#11028): `fetch` resolves DNS a second time, and a rebinding
+ * resolver could answer that second lookup with an internal address. IP
+ * literals and `localhost` connect through plain `fetch` — there is no DNS to
+ * rebind.
+ *
  * Throws `SsrfBlockedError` if any hop targets a blocked host; otherwise
  * behaves like `fetch` and returns the final `Response`.
  */
@@ -270,8 +403,10 @@ export async function safeFetch(
 ): Promise<Response> {
   let current = url;
   for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
-    await assertUrlAllowed(current);
-    const res = await fetch(current, { ...init, redirect: "manual" });
+    const pinned = await assertUrlAllowed(current);
+    const res = pinned
+      ? await pinnedTransport(current, init, pinned)
+      : await fetch(current, { ...init, redirect: "manual" });
     if (res.status < 300 || res.status >= 400) {
       return res;
     }


### PR DESCRIPTION
## Pin SSRF-vetted DNS answers to the connection (#11028 — DNS-rebinding TOCTOU)

`safeFetch` in the orchestrator's SSRF guard validated a hostname's resolution (`assertUrlAllowed`) and then called `fetch()` — **which resolves DNS again**. A rebinding resolver answers the vetting lookup with a public IP and the connection lookup with an internal one (`169.254.169.254`, RFC1918), defeating the guard on exactly the surface it protects: GET-probes of URLs extracted from **untrusted sub-agent narration**.

### Fix
- `assertHostAllowed` / `assertUrlAllowed` now **return the vetted addresses** for DNS hostnames (`null` for `localhost`/IP literals — nothing to rebind).
- `safeFetch` routes hostname targets through a **pinned node `http`/`https` transport** whose `lookup` only ever answers with the vetted addresses — the socket layer never consults real DNS. TLS SNI + certificate verification keep the original hostname (no IP-in-URL tricks). Every redirect hop re-vets and re-pins with that hop's own addresses. IP-literal/localhost targets keep plain `fetch`.
- `setPinnedTransport` test seam (mirrors the existing `setHostResolver`); the router suite's `stubFetch` helper routes the pinned transport through the same per-URL mock, so its 89 URL-verification tests are unchanged in intent.

### Evidence (fail-without-fix)
New `safeFetch DNS-rebinding pin (#11028)` suite drives a **rebinding resolver** (public IP on the vetting lookup, metadata IP on any later lookup) and asserts: the request goes through the pinned transport **with the vetted address**, plain `fetch` is never called for hostname targets, every redirect hop re-pins, blocked resolutions never reach the transport, and IP-literal/localhost targets keep plain fetch. Reverting `safeFetch` to validate-then-fetch → **2 tests red** ("never plain fetch" + hop re-pin); restored → green.

- `ssrf-guard.test.ts`: **19/19** · `sub-agent-router.test.ts`: **89/89** · `tsgo --noEmit`: **0 errors** · biome clean.

Note for a follow-up: core's `fetchWithSsrfGuard` has the same validate-then-fetch shape (its `resolvePinnedHostname` result — including the ready-made pinned `lookup` — is discarded), and no runtime caller passes a `lookupFn` at all. Filing separately since core is environment-agnostic and the connection-pinning seam belongs at a node-only boundary.

Refs #11028 #10980

🤖 Generated with [Claude Code](https://claude.com/claude-code)
