### PR TITLE
fix(openai): strip strict-unsupported schema constraints at the wire choke point

### DIFF
--- a/.github/issue-evidence/11153-central-strict-schema-strip.md
+++ b/.github/issue-evidence/11153-central-strict-schema-strip.md
@@ -1,0 +1,81 @@
+# Evidence — #11153 centralize strict-provider constraint stripping
+
+Follow-up to #11123 (which fixed one schema). This centralizes the fix at the
+single wire choke point so the whole bug class dies.
+
+## 1. The choke point (verified by reading the code)
+
+`sanitizeJsonSchema` (plugins/plugin-openai/models/text.ts) is called by BOTH
+send paths:
+- response_format: `buildStructuredOutput` → `jsonSchema(sanitizeJsonSchema(schema, true))` (text.ts:399)
+- tools: `normalizeNativeTools` → `sanitizeJsonSchema(rawSchema, true)` (text.ts:439)
+
+Pre-fix it did `let sanitized = { ...record }` — spreading every key through, so
+constraint keywords reached the wire untouched.
+
+## 2. The exact rejected set — bisected LIVE (api.elizacloud.ai / gpt-oss-120b, response_format json_schema)
+
+```
+array.maxItems    → REJECTED       num.minimum     → ok
+array.minItems    → REJECTED       num.maximum     → ok
+str.maxLength     → REJECTED       num.multipleOf  → ok
+str.minLength     → REJECTED       array.uniqueItems → ok
+str.pattern       → REJECTED
+str.format        → REJECTED
+obj.minProperties → REJECTED
+obj.maxProperties → REJECTED  (symmetric with minProperties)
+```
+
+Correction to prior lore: numeric bounds (`minimum`/`maximum`/`multipleOf`) and
+`uniqueItems` are ACCEPTED — so `search-experiences`'s `minimum/maximum`
+(flagged suspect in the sweep) is a non-issue and is left untouched.
+
+## 3. The fix
+
+`stripStrictUnsupportedConstraints(node)` removes the rejected set and folds a
+human phrase into `description` (`maxItems: 3` → "(at most 3 items)"), so the
+model keeps the guidance. Called unconditionally at the top of
+`sanitizeJsonSchema` (recursion reaches nested nodes via properties/items/
+anyOf/oneOf/allOf). NOT gated on `isCerebrasMode` — that helper is proxy-blind
+(`api.elizacloud.ai` + `OPENAI_API_KEY` looks like plain OpenAI, the exact
+deployment where #11123 fired). Lossless: `parseAndValidate`
+(runtime/validated-model-call.ts) re-checks the caller's ORIGINAL schema
+app-side, so real bounds still gate the returned value.
+
+## 4. Live proof of the transform (real exported function → real cloud)
+
+`__INTERNAL_sanitizeJsonSchema` run on a schema carrying `maxItems`+`minLength`,
+then both the raw and sanitized forms sent to the live endpoint:
+
+```
+sanitized has maxItems?  false
+sanitized has minLength? false
+raw (maxItems+minLength) → REJECTED {"error":{"message":"Bad Request","code":500}}
+sanitized (stripped)     → OK
+```
+
+## 5. Unit coverage (mutation-checked)
+
+New `__tests__/sanitize-json-schema.shape.test.ts` (15 tests): every rejected
+keyword is stripped + folded into description at any depth (nested arrays,
+anyOf); every accepted keyword is preserved; existing descriptions are kept;
+the pre-existing additionalProperties/required behavior is unchanged. Disabling
+the strip call turns 10 of 15 red (mutation check performed).
+
+- Full plugin shape suite: 78/78. `tsgo --noEmit` clean. Build clean. Biome clean.
+
+## Scope boundary (deliberately NOT done centrally)
+
+Injecting `properties: {}` on bare object nodes is NOT centralized: the two
+Cerebras validators disagree — the TOOL grammar rejects empty `properties:{}`
+(wants a real property or anyOf; see text.ts:431-436 + `normalizeSchemaForCerebras`),
+while response_format REQUIRES it (#11123 live bisection). So that stays
+surface-specific: per-schema on the response_format side (#11123/#11129 handled
+today's reflection schemas), `normalizeSchemaForCerebras` on the tool side.
+
+## N/A rows
+
+- Screenshots / video / frontend logs: N/A — provider schema-transform, no UI.
+- Live-LLM trajectory file: the §2/§4 live captures ARE the model interaction
+  (request schema + response) for the changed transform; the calls carry a
+  fixed prompt, no agent/action behavior changed.

--- a/plugins/plugin-openai/__tests__/sanitize-json-schema.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/sanitize-json-schema.shape.test.ts
@@ -104,6 +104,25 @@ describe("sanitizeJsonSchema strict-constraint stripping", () => {
     }
   });
 
+  it("strips rejected keywords inside $defs / patternProperties / contains", () => {
+    const out = sanitize({
+      type: "object",
+      properties: { ref: { $ref: "#/$defs/code" } },
+      required: ["ref"],
+      additionalProperties: false,
+      // zod's toJSONSchema hoists reused/nullable sub-schemas here.
+      $defs: { code: { type: "string", pattern: "^[A-Z]+$", maxLength: 4 } },
+      patternProperties: {
+        "^x": { type: "array", items: { type: "string" }, maxItems: 2 },
+      },
+      contains: { type: "string", minLength: 1 },
+    });
+    const keys = collectKeys(out);
+    for (const [keyword] of REJECTED) {
+      expect(keys.has(keyword)).toBe(false);
+    }
+  });
+
   it("preserves an existing description when folding a hint", () => {
     const out = sanitize({
       type: "object",

--- a/plugins/plugin-openai/__tests__/sanitize-json-schema.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/sanitize-json-schema.shape.test.ts
@@ -1,0 +1,135 @@
+/**
+ * sanitizeJsonSchema is the single wire choke point every response_format
+ * schema and every tool schema funnels through. Strict-grammar providers
+ * (Cerebras via Eliza Cloud, OpenAI strict) reject a fixed set of constraint
+ * keywords with a hard 400 that fails the ENTIRE request — bisected live
+ * against api.elizacloud.ai/gpt-oss-120b (#11123/#11141). These tests lock the
+ * strip behavior: the rejected keywords must never survive to the wire, at any
+ * depth, and the intent must be preserved in `description`.
+ */
+
+import { describe, expect, it } from "vitest";
+import { __INTERNAL_sanitizeJsonSchema as sanitize } from "../models/text";
+
+// Keywords bisected as REJECTED by the strict grammar.
+const REJECTED = [
+  ["maxItems", 3],
+  ["minItems", 1],
+  ["maxLength", 10],
+  ["minLength", 1],
+  ["pattern", "^x"],
+  ["format", "date-time"],
+  ["minProperties", 1],
+  ["maxProperties", 4],
+] as const;
+
+// Bisected as ACCEPTED — must be left untouched.
+const ACCEPTED = [
+  ["minimum", 0],
+  ["maximum", 20],
+  ["multipleOf", 2],
+  ["uniqueItems", true],
+] as const;
+
+function collectKeys(node: unknown, acc = new Set<string>()): Set<string> {
+  if (!node || typeof node !== "object") return acc;
+  if (Array.isArray(node)) {
+    for (const item of node) collectKeys(item, acc);
+    return acc;
+  }
+  for (const [key, value] of Object.entries(node)) {
+    acc.add(key);
+    collectKeys(value, acc);
+  }
+  return acc;
+}
+
+describe("sanitizeJsonSchema strict-constraint stripping", () => {
+  for (const [keyword, value] of REJECTED) {
+    it(`strips ${keyword} and folds it into description`, () => {
+      const out = sanitize({
+        type: "object",
+        properties: { a: { type: "string", [keyword]: value } },
+        required: ["a"],
+        additionalProperties: false,
+      });
+      const prop = (out.properties as Record<string, Record<string, unknown>>).a;
+      expect(prop[keyword]).toBeUndefined();
+      expect(typeof prop.description).toBe("string");
+      expect((prop.description as string).length).toBeGreaterThan(0);
+    });
+  }
+
+  for (const [keyword, value] of ACCEPTED) {
+    it(`preserves ${keyword} (accepted by the grammar)`, () => {
+      const out = sanitize({
+        type: "object",
+        properties: { a: { type: "number", [keyword]: value } },
+        required: ["a"],
+        additionalProperties: false,
+      });
+      const prop = (out.properties as Record<string, Record<string, unknown>>).a;
+      expect(prop[keyword]).toBe(value);
+    });
+  }
+
+  it("strips rejected keywords at every depth (nested arrays, unions)", () => {
+    const out = sanitize({
+      type: "object",
+      properties: {
+        list: {
+          type: "array",
+          maxItems: 5,
+          items: {
+            type: "object",
+            properties: {
+              tags: { type: "array", items: { type: "string" }, minItems: 1 },
+              code: { type: "string", pattern: "^[A-Z]+$" },
+            },
+          },
+        },
+        choice: {
+          anyOf: [
+            { type: "string", maxLength: 8 },
+            { type: "object", properties: {}, minProperties: 1 },
+          ],
+        },
+      },
+      required: ["list"],
+      additionalProperties: false,
+    });
+    const keys = collectKeys(out);
+    for (const [keyword] of REJECTED) {
+      expect(keys.has(keyword)).toBe(false);
+    }
+  });
+
+  it("preserves an existing description when folding a hint", () => {
+    const out = sanitize({
+      type: "object",
+      properties: {
+        kw: {
+          type: "array",
+          items: { type: "string" },
+          maxItems: 16,
+          description: "Search keywords.",
+        },
+      },
+      required: ["kw"],
+      additionalProperties: false,
+    });
+    const prop = (out.properties as Record<string, Record<string, unknown>>).kw;
+    expect(prop.maxItems).toBeUndefined();
+    expect(prop.description).toContain("Search keywords.");
+    expect(prop.description).toContain("16");
+  });
+
+  it("still forces additionalProperties:false + required on objects (unchanged)", () => {
+    const out = sanitize({
+      type: "object",
+      properties: { a: { type: "string" }, b: { type: "number" } },
+    });
+    expect(out.additionalProperties).toBe(false);
+    expect(new Set(out.required as string[])).toEqual(new Set(["a", "b"]));
+  });
+});

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -801,6 +801,30 @@ function sanitizeJsonSchema(schema: unknown, isRoot = false): JSONSchema7 {
     }
   }
 
+  // Every other schema-bearing keyword must be walked too, or a stripped
+  // keyword nested inside one survives to the wire. `$defs`/`definitions`
+  // matter most in practice: zod's `toJSONSchema` hoists reused/nullable
+  // sub-schemas into `$defs`, so a `.max()`/`.regex()` on a shared field would
+  // otherwise slip through the strip. `contains`/`propertyNames`/`not`/`if`/
+  // `then`/`else` take a single sub-schema; `patternProperties`/`$defs`/
+  // `definitions` are maps of them.
+  for (const singleKey of ["contains", "propertyNames", "not", "if", "then", "else"] as const) {
+    const value = sanitized[singleKey];
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      sanitized[singleKey] = sanitizeJsonSchema(value);
+    }
+  }
+  for (const mapKey of ["patternProperties", "$defs", "definitions"] as const) {
+    const value = sanitized[mapKey];
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      const walked: Record<string, unknown> = {};
+      for (const [key, sub] of Object.entries(value as Record<string, unknown>)) {
+        walked[key] = sanitizeJsonSchema(sub);
+      }
+      sanitized[mapKey] = walked;
+    }
+  }
+
   return sanitized as JSONSchema7;
 }
 

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -685,6 +685,47 @@ function hasIllegalStrictRoot(node: Record<string, unknown>): boolean {
   return false;
 }
 
+// Constraint keywords that strict-grammar providers reject with a hard 400
+// that fails the ENTIRE request. The exact set was bisected live against
+// api.elizacloud.ai / gpt-oss-120b (Cerebras): maxItems/minItems/maxLength/
+// minLength/pattern/format/min-maxProperties are rejected; numeric bounds
+// (minimum/maximum/multipleOf) and uniqueItems are accepted, so they are NOT
+// stripped. Each maps to a human phrase folded into `description` so the model
+// still sees the intent after the machine-readable keyword is removed.
+const STRICT_UNSUPPORTED_CONSTRAINTS: Record<string, (value: unknown) => string> = {
+  maxItems: (v) => `at most ${v} items`,
+  minItems: (v) => `at least ${v} items`,
+  maxLength: (v) => `at most ${v} characters`,
+  minLength: (v) => `at least ${v} characters`,
+  pattern: (v) => `matching the pattern ${v}`,
+  format: (v) => `in ${v} format`,
+  minProperties: (v) => `at least ${v} properties`,
+  maxProperties: (v) => `at most ${v} properties`,
+};
+
+/**
+ * Removes constraint keywords that strict-grammar providers reject, folding
+ * each into the node's `description` so the model keeps the guidance. Mutates
+ * the passed (already-shallow-copied) node in place.
+ *
+ * Removing them from the wire is lossless for correctness: `parseAndValidate`
+ * (runtime/validated-model-call.ts) re-checks the caller's ORIGINAL schema
+ * app-side, so any real bound is still enforced on the returned value.
+ */
+function stripStrictUnsupportedConstraints(node: Record<string, unknown>): void {
+  const hints: string[] = [];
+  for (const [keyword, phrase] of Object.entries(STRICT_UNSUPPORTED_CONSTRAINTS)) {
+    if (keyword in node) {
+      hints.push(phrase(node[keyword]));
+      delete node[keyword];
+    }
+  }
+  if (hints.length === 0) return;
+  const existing = typeof node.description === "string" ? node.description.trim() : "";
+  const suffix = `(${hints.join(", ")})`;
+  node.description = existing ? `${existing} ${suffix}` : suffix;
+}
+
 function sanitizeJsonSchema(schema: unknown, isRoot = false): JSONSchema7 {
   if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
     // Permissive fallback: no `properties: {}`/`additionalProperties: false`
@@ -695,6 +736,16 @@ function sanitizeJsonSchema(schema: unknown, isRoot = false): JSONSchema7 {
 
   const record = schema as Record<string, unknown>;
   let sanitized: Record<string, unknown> = { ...record };
+
+  // This is the single wire choke point — every response_format schema
+  // (buildStructuredOutput) and every tool schema (normalizeNativeTools)
+  // funnels through here, so strip the strict-unsupported constraint keywords
+  // centrally instead of relying on each schema author to remember the rule.
+  // UNCONDITIONAL, not Cerebras-gated: isCerebrasMode is proxy-blind — an agent
+  // pointed at api.elizacloud.ai with OPENAI_API_KEY looks like plain OpenAI,
+  // which is exactly the deployment where the 400 fired (#11123/#11141). The
+  // recursion below reaches nested nodes via properties/items/unions.
+  stripStrictUnsupportedConstraints(sanitized);
 
   if (typeof sanitized.type !== "string") {
     const inferredType = inferJsonSchemaType(sanitized, isRoot);
@@ -1391,3 +1442,5 @@ export const __INTERNAL_resolveProviderOptions = resolveProviderOptions;
 export const __INTERNAL_normalizeNativeMessages = normalizeNativeMessages;
 /** @internal — exported for unit tests only. */
 export const __INTERNAL_stripReasoningParts = stripReasoningParts;
+/** @internal — exported for unit tests only. */
+export const __INTERNAL_sanitizeJsonSchema = sanitizeJsonSchema;


### PR DESCRIPTION
Fixes #11153. Follow-up to #11129 (merged) — that fixed one schema; this kills the whole bug class in one place.

### Why centralize
Any hand-written response/tool schema with a strict-unsupported constraint keyword silently 400s the ENTIRE request on Cerebras/Eliza Cloud. The type system actively permits those keywords (core `JsonSchema` declares `minimum`/`pattern`; `jsonSchemaFromLocal` copies them into every action tool schema), authors are many, and even core's own strict-aware reflection schema shipped one. `sanitizeJsonSchema` (`plugins/plugin-openai/models/text.ts`) is the single point every schema funnels through — response_format via `buildStructuredOutput` (L399) and tools via `normalizeNativeTools` (L439) — so it's the right home.

### The exact rejected set — bisected LIVE (api.elizacloud.ai / gpt-oss-120b)
| rejected → stripped | accepted → untouched |
|---|---|
| `maxItems` `minItems` `maxLength` `minLength` `pattern` `format` `minProperties` `maxProperties` | `minimum` `maximum` `multipleOf` `uniqueItems` |

Correction to the usual "all constraints rejected" lore: **numeric bounds are fine**, so `search-experiences`'s `minimum/maximum` (flagged suspect in my sweep) is a non-issue and is left alone.

### The fix
`stripStrictUnsupportedConstraints` removes the rejected set and folds each into `description` (`maxItems: 3` → "(at most 3 items)") so the model keeps the guidance. Called unconditionally at the top of `sanitizeJsonSchema`; recursion reaches nested nodes. **Not** `isCerebrasMode`-gated — that helper is proxy-blind (`api.elizacloud.ai` + `OPENAI_API_KEY` looks like plain OpenAI, the exact deployment where #11123 fired). Lossless: `parseAndValidate` re-checks the caller's ORIGINAL schema app-side, so real bounds still gate the returned value.

Catches the confirmed `experienceSchema` `maxItems: 3` evaluator 400 (experience-items.ts:27) and any future same-class schema.

### Proof
- **Live transform** (real exported `sanitizeJsonSchema` → real cloud): raw schema with `maxItems`+`minLength` → `{"error":{"message":"Bad Request","code":500}}`; the same schema after sanitize → **OK, clean stream**.
- **Unit**: new `sanitize-json-schema.shape.test.ts` — 15 tests, every rejected keyword stripped+folded at any depth (nested arrays / anyOf), every accepted keyword preserved, existing descriptions kept, pre-existing additionalProperties/required behavior unchanged. Mutation-checked: disabling the strip turns 10/15 red.
- Plugin shape suite **78/78**; `tsgo --noEmit` clean; build clean; biome clean.
- Full evidence: `.github/issue-evidence/11153-central-strict-schema-strip.md`.

### Scope boundary
Injecting `properties: {}` on bare object nodes is deliberately NOT centralized — the tool grammar rejects empty `properties:{}` while response_format requires it (both verified), so that stays surface-specific (per-schema on response_format per #11129; `normalizeSchemaForCerebras` on tools).

### N/A rows
- Screenshots/video/frontend: N/A — provider schema transform, no UI.
- Live-LLM trajectory file: the live captures above ARE the model interaction for the changed transform (fixed prompt; no agent/action/prompt behavior changed).