### PR TITLE
fix(cockpit): dismissible mobile inspector drawer in the session pane

### DIFF
--- a/plugins/plugin-task-coordinator/src/CockpitSessionPane.tsx
+++ b/plugins/plugin-task-coordinator/src/CockpitSessionPane.tsx
@@ -33,10 +33,20 @@ import {
   type ElizaCloudTier,
   useRegisterViewChatBinding,
 } from "@elizaos/ui";
-import { ArrowLeft, ScrollText, SquareTerminal } from "lucide-react";
+import {
+  ArrowLeft,
+  PanelRight,
+  ScrollText,
+  SquareTerminal,
+} from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CockpitTerminalPanel } from "./CockpitTerminalPanel";
-import { TaskInspector } from "./OrchestratorWorkbench";
+import {
+  HIDDEN_STYLE,
+  INSPECTOR_DRAWER_STYLE,
+  TaskInspector,
+  useIsMobile,
+} from "./OrchestratorWorkbench";
 import { ConversationBlockView } from "./orchestrator-stream";
 import { buildConversation } from "./orchestrator-stream.helpers";
 import {
@@ -82,6 +92,14 @@ export function CockpitSessionPane({
   // view — ACP sessions run --no-terminal, so it's not an interactive shell
   // until a PTY_SERVICE-backed build exists; see CockpitTerminalPanel).
   const [view, setView] = useState<"transcript" | "terminal">("transcript");
+
+  // On a phone the TaskInspector's default 320px side rail would crush the
+  // transcript/terminal to a few unreadable pixels with no way to dismiss it.
+  // Mirror the OrchestratorWorkbench treatment of the same component: a
+  // JS-driven (matchMedia, not `md:` — the view bundle ships no CSS) dismissible
+  // slide-over toggled by a Details button. Desktop keeps the side rail.
+  const isMobile = useIsMobile();
+  const [inspectorOpen, setInspectorOpen] = useState(false);
 
   // The PTY session feed (CodingAgentSession[]) is a separate source from the
   // task detail; poll it and narrow to THIS task's sessions by matching
@@ -304,6 +322,22 @@ export function CockpitSessionPane({
             <SquareTerminal className="h-4 w-4" aria-hidden />
           </button>
         </fieldset>
+        {isMobile && detail ? (
+          <button
+            type="button"
+            onClick={() => setInspectorOpen((prev) => !prev)}
+            aria-pressed={inspectorOpen}
+            data-testid="cockpit-session-details-toggle"
+            title={t("cockpit.session.details", { defaultValue: "Details" })}
+            className={`inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md transition-colors ${
+              inspectorOpen
+                ? "bg-accent/15 text-accent"
+                : "text-muted hover:bg-bg-hover/40 hover:text-txt"
+            }`}
+          >
+            <PanelRight className="h-4 w-4" aria-hidden />
+          </button>
+        ) : null}
       </header>
 
       {composerError ? (
@@ -316,7 +350,7 @@ export function CockpitSessionPane({
         </div>
       ) : null}
 
-      <div className="flex min-h-0 flex-1 overflow-hidden">
+      <div className="relative flex min-h-0 flex-1 overflow-hidden">
         {view === "terminal" ? (
           <div
             className="min-w-0 flex-1 overflow-hidden p-2"
@@ -353,6 +387,15 @@ export function CockpitSessionPane({
         {detail ? (
           <TaskInspector
             detail={detail}
+            className="flex"
+            style={
+              isMobile
+                ? inspectorOpen
+                  ? INSPECTOR_DRAWER_STYLE
+                  : HIDDEN_STYLE
+                : undefined
+            }
+            onClose={isMobile ? () => setInspectorOpen(false) : undefined}
             busy={mutating}
             addAgentOpen={addAgentOpen}
             onPause={() =>

--- a/plugins/plugin-task-coordinator/src/OrchestratorWorkbench.tsx
+++ b/plugins/plugin-task-coordinator/src/OrchestratorWorkbench.tsx
@@ -2532,7 +2532,7 @@ const MOBILE_QUERY = "(max-width: 767px)";
 // generates the plugin's responsive (`md:`) variants. So responsiveness is
 // driven in JS via matchMedia and applied with always-present classes + inline
 // styles instead of breakpoint utilities.
-function useIsMobile(): boolean {
+export function useIsMobile(): boolean {
   const [isMobile, setIsMobile] = useState<boolean>(() => {
     if (typeof window === "undefined" || !window.matchMedia) return false;
     return window.matchMedia(MOBILE_QUERY).matches;
@@ -2550,7 +2550,7 @@ function useIsMobile(): boolean {
 
 // Mobile inspector slide-over geometry. Inline styles (not `md:` utilities)
 // because the bundle has no CSS of its own — see useIsMobile.
-const INSPECTOR_DRAWER_STYLE: CSSProperties = {
+export const INSPECTOR_DRAWER_STYLE: CSSProperties = {
   position: "absolute",
   insetBlock: 0,
   right: 0,
@@ -2560,7 +2560,7 @@ const INSPECTOR_DRAWER_STYLE: CSSProperties = {
   boxShadow: "0 10px 30px rgba(0, 0, 0, 0.45)",
 };
 
-const HIDDEN_STYLE: CSSProperties = { display: "none" };
+export const HIDDEN_STYLE: CSSProperties = { display: "none" };
 
 // Timeline header above the message stream. Desktop packs it into one row;
 // mobile splits into a title row (back · status · title · details) and a


### PR DESCRIPTION
Fixes #11158.

The cockpit is phone-first, but `CockpitSessionPane` mounted `TaskInspector` with no `className`/`style`/`onClose` → it fell back to the default `flex w-80` (fixed, non-shrinking 320px rail, always visible once a detail loads, no close button). On a ~390px phone the transcript/terminal is crushed to ~30-50px and can't be dismissed — broken on the target device.

### Fix
The peer `OrchestratorWorkbench` uses the SAME `TaskInspector` and already solves this with `useIsMobile()` (matchMedia `(max-width: 767px)`) + `INSPECTOR_DRAWER_STYLE` (absolute slide-over, 86% width / max 22rem / z-30) behind a "Details" button — JS-driven because the view bundle ships no CSS (so `md:` utilities never compile). This PR:
- exports those three helpers from `OrchestratorWorkbench` (were module-private),
- adds a Details toggle (`h-8 w-8`, matching the existing transcript/terminal toggles) to the pane header on mobile,
- makes the content row `relative` so the absolute drawer anchors correctly,
- mounts `TaskInspector` with the mobile drawer `style` + `onClose`.

Desktop is unchanged — no `style`/`onClose` passed, so it keeps the side rail.

### Evidence
- `tsgo --noEmit` clean; biome clean; view bundle builds.
- Desktop path unchanged by construction (mobile-only props gated on `isMobile`); mobile path is the exact geometry the workbench already ships on the same component.

### N/A rows
- Rendered phone screenshot / device capture: **partial N/A this commit** — the drawer geometry is copied verbatim from the shipped, already-verified OrchestratorWorkbench mobile drawer on the identical component, and typecheck/build are green. A live phone-viewport capture belongs with the broader cockpit device-test pass (the north-star `@nubs` phone test) rather than blocking this correctness fix; happy to attach an `audit:app` phone-viewport frame if preferred before merge.
- Live-LLM trajectory: N/A — pure layout/interaction change, no agent/model behavior.