### PR TITLE
fix(cloud): gate compat launch route on org credit (#11152)

### DIFF
--- a/packages/cloud/api/compat/agents/[id]/launch/route.ts
+++ b/packages/cloud/api/compat/agents/[id]/launch/route.ts
@@ -12,10 +12,12 @@ import type { AppEnv } from "@/types/cloud-worker-env";
  */
 
 import { envelope, errorEnvelope } from "@/lib/api/compat-envelope";
+import { checkAgentCreditGate } from "@/lib/services/agent-billing-gate";
 import {
   launchManagedElizaAgent,
   ManagedElizaLaunchError,
 } from "@/lib/services/eliza-managed-launch";
+import { logger } from "@/lib/utils/logger";
 import { requireCompatAuth } from "../../../_lib/auth";
 import { handleCompatCorsOptions, withCompatCors } from "../../../_lib/cors";
 import { handleCompatError } from "../../../_lib/error-handler";
@@ -29,6 +31,30 @@ async function __hono_POST(
   try {
     const { user } = await requireCompatAuth(request);
     const { id: agentId } = await params;
+
+    // Gate on org credit before provisioning/waking a container. launch() is a
+    // third path into elizaSandboxService.provision() (via launchManagedElizaAgent,
+    // whenever the sandbox is not already running) alongside resume and restart —
+    // both of which already enforce this gate. Without it a credit-suspended
+    // dedicated agent could be launched (re-provisioned) for free, repeatedly
+    // (elizaOS/eliza#11152; same class as the resume/restart gap #10902/#10905).
+    const creditCheck = await checkAgentCreditGate(user.organization_id);
+    if (!creditCheck.allowed) {
+      logger.warn("[compat] Launch blocked: insufficient credits", {
+        agentId,
+        orgId: user.organization_id,
+        balance: creditCheck.balance,
+      });
+      return withCompatCors(
+        Response.json(
+          errorEnvelope(
+            creditCheck.error ?? "Insufficient credits to launch this agent",
+          ),
+          { status: 402 },
+        ),
+        CORS_METHODS,
+      );
+    }
 
     const result = await launchManagedElizaAgent({
       agentId,


### PR DESCRIPTION
## What
Adds `checkAgentCreditGate` → 402 to `POST /api/compat/agents/[id]/launch`, closing the free-compute gap **#11152**.

## Why
`launch` is a **third** path into `elizaSandboxService.provision()` — via `launchManagedElizaAgent`, which calls `provision()` whenever `sandbox.status !== "running" || !sandbox.health_url` (`eliza-managed-launch.ts:210-212`). The sibling wake routes `resume` and `restart` both gate on `checkAgentCreditGate` (added by #10905, closing #10902), but `launch` was never gated — so a credit-suspended org could `POST …/launch` on a reaped dedicated agent and get a fresh container provisioned for free, repeatably. Same class as #10902; the fix #10905 landed just missed this route.

Verified on develop tip `b6d40635`: `launch/route.ts` calls `launchManagedElizaAgent` immediately after `requireCompatAuth` with no credit check, and `eliza-managed-launch.ts` has no gate anywhere (grep `credit|balance|gate|suspend` → none).

## Change
One file. Mirrors `resume/route.ts` exactly: after auth + param resolve, run `checkAgentCreditGate(user.organization_id)`; on `!allowed`, `logger.warn` + return `errorEnvelope(...)` with `{ status: 402 }`. No behavior change for orgs in good standing (gate returns `allowed: true`).

## Scope / discipline
Continuation of my own #10902/#10905 (my lane). Single concern, into `develop`, not self-merged — over to @lalalune for review. `[cloud-audit]`

Closes #11152.
