### PR TITLE
fix(cloud): bucket unauthenticated rate-limit traffic per-IP, not a global "public" key (#11087)

### DIFF
--- a/packages/cloud/shared/src/lib/middleware/rate-limit-default-key.test.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-default-key.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { AppContext } from "../../../types/cloud-worker-env";
+import type { AppContext } from "../../types/cloud-worker-env";
 import { getDefaultKey } from "./rate-limit-hono-cloudflare";
 
 /**

--- a/packages/cloud/shared/src/lib/middleware/rate-limit-default-key.test.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-default-key.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import type { AppContext } from "../../../types/cloud-worker-env";
+import { getDefaultKey } from "./rate-limit-hono-cloudflare";
+
+/**
+ * #11087 (design flag): the default rate-limit key generator must NOT collapse
+ * all unauthenticated traffic into one global bucket. Before the fix,
+ * `getDefaultKey` returned the literal "public" for any request without an
+ * api-key/user/anon-session — so a single flooder (600/min) 429-locked EVERY
+ * anonymous client worldwide on every route using the default key generator.
+ * The fix buckets anonymous traffic PER-IP; "public" survives only when the IP
+ * is unresolvable.
+ */
+
+function ctx(headers: Record<string, string>, user?: { id: string }): AppContext {
+  const lower: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) lower[k.toLowerCase()] = v;
+  return {
+    req: { header: (name: string) => lower[name.toLowerCase()] },
+    get: (key: string) => (key === "user" ? user : undefined),
+  } as unknown as AppContext;
+}
+
+describe("getDefaultKey — #11087 per-IP anonymous bucketing", () => {
+  test("api key (x-api-key) → apikey: bucket", () => {
+    expect(getDefaultKey(ctx({ "x-api-key": "abc" }))).toBe("apikey:abc");
+  });
+
+  test("Bearer eliza_ token → apikey: bucket", () => {
+    expect(getDefaultKey(ctx({ authorization: "Bearer eliza_xyz" }))).toBe("apikey:eliza_xyz");
+  });
+
+  test("authenticated user → user: bucket", () => {
+    expect(getDefaultKey(ctx({}, { id: "u1" }))).toBe("user:u1");
+  });
+
+  test("anon session header → anon: bucket", () => {
+    expect(getDefaultKey(ctx({ "x-anonymous-session": "s1" }))).toBe("anon:s1");
+  });
+
+  test("UNAUTHENTICATED with an IP → per-IP bucket, NOT global 'public' (the fix)", () => {
+    expect(getDefaultKey(ctx({ "cf-connecting-ip": "203.0.113.7" }))).toBe("ip:203.0.113.7");
+    expect(getDefaultKey(ctx({ "x-forwarded-for": "198.51.100.9, 10.0.0.1" }))).toBe(
+      "ip:198.51.100.9",
+    );
+  });
+
+  test("two different anonymous IPs get DISTINCT buckets — one flooder can't lock out the other", () => {
+    const a = getDefaultKey(ctx({ "cf-connecting-ip": "203.0.113.1" }));
+    const b = getDefaultKey(ctx({ "cf-connecting-ip": "203.0.113.2" }));
+    expect(a).not.toBe(b);
+    expect(a).not.toBe("public");
+    expect(b).not.toBe("public");
+  });
+
+  test("only when the IP is unresolvable does it fall back to 'public' (bounded last resort)", () => {
+    expect(getDefaultKey(ctx({}))).toBe("public");
+  });
+});

--- a/packages/cloud/shared/src/lib/middleware/rate-limit-hono-cloudflare.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-hono-cloudflare.ts
@@ -5,11 +5,7 @@
  */
 
 import type { Context, MiddlewareHandler } from "hono";
-import type {
-  AppContext,
-  AppEnv,
-  Bindings,
-} from "../../types/cloud-worker-env";
+import type { AppContext, AppEnv, Bindings } from "../../types/cloud-worker-env";
 import { buildRedisClient, type CompatibleRedis } from "../cache/redis-factory";
 import { logger } from "../utils/logger";
 
@@ -93,7 +89,15 @@ function getDefaultKey(c: AppContext): string {
     null;
   if (anon) return `anon:${anon}`;
 
-  return "public";
+  // Unauthenticated public traffic buckets PER-IP, not a global constant.
+  // Returning the literal "public" put ALL anonymous traffic worldwide into one
+  // window, so a single flooder (600/min) 429-locked every anonymous client on
+  // every route using the default key generator (#11087). Per-IP confines the
+  // limit to the abuser. "public" survives only as the last resort when the IP
+  // is unresolvable (e.g. a proxy stripped forwarding headers) — still bounded,
+  // but no longer the common path.
+  const ip = getRequestIp(c);
+  return ip ? `ip:${ip}` : "public";
 }
 
 interface CheckResult {
@@ -103,11 +107,7 @@ interface CheckResult {
   retryAfter?: number;
 }
 
-function rateLimitHeaders(
-  config: RateLimitConfig,
-  result: CheckResult,
-  policy: string,
-) {
+function rateLimitHeaders(config: RateLimitConfig, result: CheckResult, policy: string) {
   return {
     "X-RateLimit-Limit": String(config.maxRequests),
     "X-RateLimit-Remaining": String(result.remaining),
@@ -124,10 +124,7 @@ function fallOpenResult(config: RateLimitConfig): CheckResult {
   };
 }
 
-function applyRateLimitHeaders(
-  c: Context,
-  headers: Record<string, string>,
-): void {
+function applyRateLimitHeaders(c: Context, headers: Record<string, string>): void {
   for (const [k, v] of Object.entries(headers)) {
     c.res.headers.set(k, v);
   }
@@ -175,25 +172,18 @@ export function rateLimit(config: RateLimitConfig): MiddlewareHandler<AppEnv> {
     }
 
     if (
-      (env.RATE_LIMIT_DISABLED === "true" ||
-        env.PLAYWRIGHT_TEST_AUTH === "true") &&
+      (env.RATE_LIMIT_DISABLED === "true" || env.PLAYWRIGHT_TEST_AUTH === "true") &&
       env.NODE_ENV !== "production"
     ) {
       await next();
-      applyRateLimitHeaders(
-        c,
-        rateLimitHeaders(config, fallOpenResult(config), "disabled"),
-      );
+      applyRateLimitHeaders(c, rateLimitHeaders(config, fallOpenResult(config), "disabled"));
       return;
     }
 
     const redis = getRedis(env);
     if (!redis) {
       await next();
-      applyRateLimitHeaders(
-        c,
-        rateLimitHeaders(config, fallOpenResult(config), "fall-open"),
-      );
+      applyRateLimitHeaders(c, rateLimitHeaders(config, fallOpenResult(config), "fall-open"));
       return;
     }
 
@@ -202,12 +192,7 @@ export function rateLimit(config: RateLimitConfig): MiddlewareHandler<AppEnv> {
     let policy = "redis";
 
     try {
-      result = await checkUpstash(
-        redis,
-        key,
-        config.windowMs,
-        config.maxRequests,
-      );
+      result = await checkUpstash(redis, key, config.windowMs, config.maxRequests);
     } catch (error) {
       // Rate limiting is protective middleware. If its backing store is down
       // or unreachable in local Worker dev, requests should fall open instead


### PR DESCRIPTION
Ref #11087 (the design flag it raised, after the self-heal #11085 already merged + deployed).

## Problem
`getDefaultKey` (`packages/cloud/shared/src/lib/middleware/rate-limit-hono-cloudflare.ts`) returned the literal **`"public"`** for any request with no api-key, user session, or anon-session — i.e. all genuinely unauthenticated traffic shared **one global rate-limit window**. On any route using the default key generator (no explicit `keyGenerator`), a single flooder hitting 600/min **429-locks every anonymous client worldwide**, including the public `/models` endpoint. #11087 flagged this explicitly:

> `getDefaultKey` returns the literal `"public"` for unauthenticated no-session requests — one global bucket for all anonymous traffic worldwide on any route using the default key generator. Worth auditing which public routes use `getDefaultKey` vs `getIpKey`.

## Fix
Fall back to a **per-IP** bucket instead of a global constant:
```ts
const ip = getRequestIp(c);
return ip ? `ip:${ip}` : "public";
```
- Uses the same IP resolution as `getIpKey` (`cf-connecting-ip` preferred — set by Cloudflare, not client-spoofable — then `x-real-ip`, then first `x-forwarded-for`).
- `"public"` survives only when the IP is unresolvable (e.g. a proxy stripped forwarding headers) — still bounded, but no longer the common path.
- A flood now confines its 429s to the abuser's IP; other anonymous clients are unaffected.
- Authed paths (api-key / user / anon-session) are unchanged.

## Test (`rate-limit-default-key.test.ts`, 7 cases)
- api-key / Bearer `eliza_` / user / anon-session buckets unchanged.
- **UNAUTHENTICATED + IP → `ip:<ip>`, NOT `"public"`** (the fix).
- **Two different anonymous IPs get DISTINCT buckets** — one flooder can't lock out another.
- `"public"` only when the IP is unresolvable.

```
bun test packages/cloud/shared/src/lib/middleware/rate-limit-default-key.test.ts   # 7 pass
```
`packages/cloud/shared typecheck` + biome clean.

## Evidence
- The DoS property (per-IP isolation) is proven by the distinct-buckets test; the denied-vs-allowed keying is a pure-function assertion, no mock stands in for the thing under test.
- N/A (no UI / no migration / no model): keying logic change in a Worker middleware; property is a unit invariant.

Security — flagging for maintainer review/merge rather than self-merge. `[cloud-security]`