### PR TITLE
fix(cloud): gate compat agent launch on org credit (closes #11152)

### DIFF
--- a/packages/cloud/api/__tests__/compat-agent-credit-gate.test.ts
+++ b/packages/cloud/api/__tests__/compat-agent-credit-gate.test.ts
@@ -57,6 +57,17 @@ const provision = mock(async () => ({
 
 const snapshot = mock(async () => undefined);
 
+// launch/route.ts calls launchManagedElizaAgent (which itself wraps provision),
+// not elizaSandboxService.provision directly — mock it at that seam.
+const launchManagedElizaAgent = mock(async () => ({
+  agentId: "agent-1",
+  agentName: "Agent One",
+  appUrl: "https://app.example.test/launch/agent-1",
+  launchSessionId: "sess-1",
+  issuedAt: "2026-07-02T00:00:00.000Z",
+  connection: { host: "agent-1.example.test" },
+}));
+
 mock.module("../compat/_lib/auth", () => ({
   requireCompatAuth,
 }));
@@ -87,6 +98,13 @@ mock.module("@/lib/services/eliza-sandbox", () => ({
   },
 }));
 
+mock.module("@/lib/services/eliza-managed-launch", () => ({
+  launchManagedElizaAgent,
+  ManagedElizaLaunchError: class ManagedElizaLaunchError extends Error {
+    status = 400;
+  },
+}));
+
 mock.module("@/lib/utils/logger", () => ({
   logger: {
     info: mock(() => undefined),
@@ -101,11 +119,15 @@ const { default: resumeRoute } = await import(
 const { default: restartRoute } = await import(
   "../compat/agents/[id]/restart/route"
 );
+const { default: launchRoute } = await import(
+  "../compat/agents/[id]/launch/route"
+);
 
-describe("compat agent resume/restart credit gate", () => {
+describe("compat agent resume/restart/launch credit gate", () => {
   const app = new Hono();
   app.route("/api/compat/agents/:id/resume", resumeRoute);
   app.route("/api/compat/agents/:id/restart", restartRoute);
+  app.route("/api/compat/agents/:id/launch", launchRoute);
 
   beforeEach(() => {
     requireCompatAuth.mockClear();
@@ -128,6 +150,7 @@ describe("compat agent resume/restart credit gate", () => {
     getAgentForWrite.mockResolvedValue(defaultWritableAgent);
     provision.mockClear();
     snapshot.mockClear();
+    launchManagedElizaAgent.mockClear();
   });
 
   test("blocks compat resume before provisioning when the org has insufficient credits", async () => {
@@ -166,6 +189,22 @@ describe("compat agent resume/restart credit gate", () => {
     expect(checkAgentCreditGate).toHaveBeenCalledWith("org-1");
     expect(snapshot).not.toHaveBeenCalled();
     expect(provision).not.toHaveBeenCalled();
+  });
+
+  test("blocks compat launch before provisioning when the org has insufficient credits (elizaOS/eliza#11152)", async () => {
+    const response = await app.fetch(
+      new Request("https://api.example.test/api/compat/agents/agent-1/launch", {
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(402);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: "Insufficient credits",
+    });
+    expect(checkAgentCreditGate).toHaveBeenCalledWith("org-1");
+    expect(launchManagedElizaAgent).not.toHaveBeenCalled();
   });
 
   test("does not check credits when the compat agent lookup fails", async () => {
@@ -207,5 +246,27 @@ describe("compat agent resume/restart credit gate", () => {
     expect(restartResponse.status).toBe(200);
     expect(provision).toHaveBeenCalledWith("agent-1", "org-1");
     expect(snapshot).toHaveBeenCalledWith("agent-1", "org-1");
+  });
+
+  test("allows funded compat launch to reach launchManagedElizaAgent", async () => {
+    checkAgentCreditGate.mockResolvedValue({
+      allowed: true,
+      balance: 5,
+      error: "",
+    });
+
+    const response = await app.fetch(
+      new Request("https://api.example.test/api/compat/agents/agent-1/launch", {
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(checkAgentCreditGate).toHaveBeenCalledWith("org-1");
+    expect(launchManagedElizaAgent).toHaveBeenCalledWith({
+      agentId: "agent-1",
+      organizationId: "org-1",
+      userId: "user-1",
+    });
   });
 });

--- a/packages/cloud/api/compat/agents/[id]/launch/route.ts
+++ b/packages/cloud/api/compat/agents/[id]/launch/route.ts
@@ -12,10 +12,12 @@ import type { AppEnv } from "@/types/cloud-worker-env";
  */
 
 import { envelope, errorEnvelope } from "@/lib/api/compat-envelope";
+import { checkAgentCreditGate } from "@/lib/services/agent-billing-gate";
 import {
   launchManagedElizaAgent,
   ManagedElizaLaunchError,
 } from "@/lib/services/eliza-managed-launch";
+import { logger } from "@/lib/utils/logger";
 import { requireCompatAuth } from "../../../_lib/auth";
 import { handleCompatCorsOptions, withCompatCors } from "../../../_lib/cors";
 import { handleCompatError } from "../../../_lib/error-handler";
@@ -29,6 +31,28 @@ async function __hono_POST(
   try {
     const { user } = await requireCompatAuth(request);
     const { id: agentId } = await params;
+
+    // Gate on org credit before provisioning. `launch` is the third path into
+    // the same dedicated-agent `provision()` wake as `resume`/`restart` (gated
+    // by #10905 after #10902); without the gate a credit-suspended org could
+    // re-provision a reaped container for free, repeatedly (elizaOS/eliza#11152).
+    const creditCheck = await checkAgentCreditGate(user.organization_id);
+    if (!creditCheck.allowed) {
+      logger.warn("[compat] Launch blocked: insufficient credits", {
+        agentId,
+        orgId: user.organization_id,
+        balance: creditCheck.balance,
+      });
+      return withCompatCors(
+        Response.json(
+          errorEnvelope(
+            creditCheck.error ?? "Insufficient credits to launch this agent",
+          ),
+          { status: 402 },
+        ),
+        CORS_METHODS,
+      );
+    }
 
     const result = await launchManagedElizaAgent({
       agentId,


### PR DESCRIPTION
Closes #11152. `[cloud-money]`

## The gap (third path, same class as #10902/#10905)
#10902 found the compat `resume`/`restart` routes woke a dedicated agent with no credit check; #10905 gated both → 402. The **`launch`** route is a third path into the same `provision()` wake and was never gated:

- `POST /api/compat/agents/[id]/launch` called `launchManagedElizaAgent` (→ `elizaSandboxService.provision`) with **no** `checkAgentCreditGate`.
- Repro: an org with zero/negative balance owning a dedicated agent whose container was reaped (`status='stopped'`) POSTs `launch` with its own API key → fresh container, no 402. Repeat = free dedicated compute. Scoped to the caller's own org, exactly like #10902.

## Fix (smallest correct — mirrors resume/restart)
`checkAgentCreditGate(user.organization_id)` before `launchManagedElizaAgent`; on `!allowed`, return the compat 402 envelope. Funded orgs (`balance > MINIMUM_DEPOSIT`) are unaffected.

## Evidence
Extended `packages/cloud/api/__tests__/compat-agent-credit-gate.test.ts` (the #10902/#10905 suite) with launch coverage:
- insufficient credits → **402**, `launchManagedElizaAgent` **not** called;
- funded → **200**, `launchManagedElizaAgent` called with the right args.

**Regression validity proven:** with the route change stashed, both new tests FAIL (launch provisions with no gate → 200); with the fix, **6/6 pass** (25 expects). `typecheck` (cloud-api, tsgo) + `biome` clean on both touched files.

Frontend/trajectories: N/A — backend auth-gate on a money path, no UI or model behavior change.

**Money path — do not self-merge** (maintainer review + merge). cc @lalalune