### PR TITLE
fix(discord): fold-context TTL 10s→90s — bare-@mention after a split question lost the question (#11118)

### DIFF
--- a/plugins/plugin-discord/__tests__/debouncer-recent-context.test.ts
+++ b/plugins/plugin-discord/__tests__/debouncer-recent-context.test.ts
@@ -327,3 +327,46 @@ describe("Discord channel debouncer — recent unaddressed context buffer", () =
 		}
 	});
 });
+
+describe("Discord channel debouncer — human multi-message cadence (#11118)", () => {
+	function setup(options: Record<string, unknown>) {
+		const flushed: string[][] = [];
+		const debouncer = createChannelDebouncer(
+			(messages) => flushed.push(messages.map((m) => (m as { id: string }).id)),
+			{ botUserId: "123", debounceMs: 3000, coalesceEnabled: false, ...options },
+		);
+		return { flushed, debouncer };
+	}
+
+	// #11118: the user split a question across messages and sent the bare
+	// @mention pointer ~40s later. A 10s TTL had pruned the question, so the
+	// pointer reached the model with no "[Recent channel context]" and the bot
+	// replied "Yeah, I'm here. What's up?" instead of answering.
+	it("folds a question sent ~40s before the bare-mention pointer (default TTL)", () => {
+		vi.useFakeTimers();
+		try {
+			const { flushed, debouncer } = setup({ shouldRespondOnlyToMentions: true });
+			debouncer.enqueue(mockMessage("1", "what was that API error about?"));
+			vi.advanceTimersByTime(3000);
+			debouncer.enqueue(mockMessage("2", "? anyone"));
+			vi.advanceTimersByTime(37_000); // ~40s total — real human cadence
+			debouncer.enqueue(mockMessage("3", "<@123>"));
+			expect(flushed[flushed.length - 1]).toEqual(["1", "2", "3"]);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("still prunes questions older than the 90s default window", () => {
+		vi.useFakeTimers();
+		try {
+			const { flushed, debouncer } = setup({ shouldRespondOnlyToMentions: true });
+			debouncer.enqueue(mockMessage("1", "stale question"));
+			vi.advanceTimersByTime(95_000);
+			debouncer.enqueue(mockMessage("2", "<@123>"));
+			expect(flushed[flushed.length - 1]).toEqual(["2"]);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});

--- a/plugins/plugin-discord/debouncer.ts
+++ b/plugins/plugin-discord/debouncer.ts
@@ -69,7 +69,7 @@ export function createChannelDebouncer(
 	// question never has unrelated chatter prepended.
 	const bufferUnaddressed =
 		options.shouldRespondOnlyToMentions === true && !coalesceEnabled;
-	const bufferTtlMs = Math.max(options.bufferTtlMs ?? 10_000, debounceMs);
+	const bufferTtlMs = Math.max(options.bufferTtlMs ?? 90_000, debounceMs);
 	// The rolling buffer only feeds recent context to a following pointer, so a
 	// handful of lines is plenty. Cap it so a channel flooded with unaddressed
 	// messages inside the TTL window cannot grow the per-channel array without

--- a/plugins/plugin-discord/discord-events.ts
+++ b/plugins/plugin-discord/discord-events.ts
@@ -150,7 +150,13 @@ function parseEventListenerConfig(
 
 	// How long a recent unaddressed message stays eligible to be folded into a
 	// following pointer's "[Recent channel context]". Tunable like its siblings;
-	// the debouncer clamps it up to the channel debounce window.
+	// the debouncer clamps it up to the channel debounce window. Default 90s:
+	// humans split a question across messages and add the bare "@bot" pointer
+	// tens of seconds later (live #11118: question at :2x, pointer at :51 — a
+	// 10s TTL had already pruned the question, so the bot answered the bare
+	// mention with a contextless greeting). The fold buffer stays bounded
+	// (50 entries, pointer-gated), so the longer window costs no unbounded
+	// growth.
 	const recentContextTtlMsSetting = service.runtime.getSetting(
 		"DISCORD_RECENT_CONTEXT_TTL_MS",
 	) as string | number | undefined;
@@ -159,8 +165,8 @@ function parseEventListenerConfig(
 			? recentContextTtlMsSetting
 			: typeof recentContextTtlMsSetting === "string" &&
 					recentContextTtlMsSetting.trim()
-				? Number.parseInt(recentContextTtlMsSetting, 10) || 10000
-				: 10000;
+				? Number.parseInt(recentContextTtlMsSetting, 10) || 90000
+				: 90000;
 
 	const shouldRespondOnlyToMentions =
 		service.discordSettings.shouldRespondOnlyToMentions !== false;


### PR DESCRIPTION
Closes #11118.

## Problem (live)
In a mention-only channel a user asked a question across two messages, then sent a bare `@bot` pointer ~40s later — the normal human cadence. The recent-context fold buffer's **10s TTL** had already pruned the question, so the pointer reached the model with no `[Recent channel context]` and the bot replied *"Yeah, I'm here. What's up?"* instead of answering. Trajectory confirmed: no context block, the question absent from the prompt.

## Fix
Bump the default fold-window TTL 10s→90s (`DISCORD_RECENT_CONTEXT_TTL_MS` default in `discord-events.ts` + the `bufferTtlMs` fallback in `debouncer.ts`). The buffer is already **bounded** (50-entry cap, pointer-gated — a self-contained question never folds unrelated chatter), so the longer window adds no unbounded growth: a flooded channel folds at most the last 50 lines. The env override still wins.

## Tests
+2 regression tests at the incident's exact cadence: (1) a question sent ~40s before the bare pointer folds into it; (2) a question older than the 90s window still prunes. Suite 27/27; typecheck clean (1 pre-existing `@elizaos/vault` resolution error on clean develop, unrelated).

Live-proven on the VPS bot (90s already deployed there): question → 30s → bare @mention now answers *"Mount Kilimanjaro…"* instead of a greeting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)