### PR TITLE
fix(ci): per-SHA concurrency for deploy-apps-worker (#10839)

### DIFF
--- a/.github/workflows/deploy-apps-worker.yml
+++ b/.github/workflows/deploy-apps-worker.yml
@@ -43,7 +43,16 @@ on:
           - production
 
 concurrency:
-  group: deploy-apps-worker-${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'production' || 'staging') }}
+  # Per-commit group (mirrors cloud-cf-deploy #10802/#10973). A SHARED
+  # deploy-apps-worker-<env> group with cancel-in-progress:false makes GitHub
+  # keep only the latest PENDING run per group and silently cancel the older
+  # pending ones (no annotation) — so a hot develop push/dispatch stream
+  # produces a chain of cancelled runs and zero completed deploys
+  # (elizaOS/eliza#10839). Keying on github.sha too gives each commit its own
+  # group: no deploy is ever superseded, the self-hosted runner serializes them,
+  # and the latest commit always lands. Env stays in the key so staging and
+  # production never block each other.
+  group: deploy-apps-worker-${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'production' || 'staging') }}-${{ github.sha }}
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/deploy-apps-worker.yml
+++ b/.github/workflows/deploy-apps-worker.yml
@@ -49,9 +49,12 @@ concurrency:
   # pending ones (no annotation) — so a hot develop push/dispatch stream
   # produces a chain of cancelled runs and zero completed deploys
   # (elizaOS/eliza#10839). Keying on github.sha too gives each commit its own
-  # group: no deploy is ever superseded, the self-hosted runner serializes them,
-  # and the latest commit always lands. Env stays in the key so staging and
-  # production never block each other.
+  # group so no run is ever silently superseded. Jobs run on ubuntu-latest
+  # (no runner-level serialization), so a host-side flock in the SSH scripts
+  # serializes concurrent deploys against the shared apps-control host; each
+  # run deploys the branch tip at fetch time, so the last to execute lands the
+  # newest code. Env stays in the key so staging and production never block
+  # each other.
   group: deploy-apps-worker-${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'production' || 'staging') }}-${{ github.sha }}
   cancel-in-progress: false
 
@@ -151,6 +154,11 @@ jobs:
           envs: DEPLOY_BRANCH,SYSTEMD_UNIT
           script: |
             set -euo pipefail
+            # Serialize deploys on the host: per-SHA concurrency groups mean
+            # overlapping runs are expected; without this they would interleave
+            # git clean/bun install/systemctl restart on the same checkout.
+            exec 9>/tmp/eliza-apps-worker-deploy.lock
+            flock -w 900 9 || { echo "::error::another apps-worker deploy holds the host lock after 15m"; exit 1; }
             echo "=== Deploying eliza-apps-worker (branch: $DEPLOY_BRANCH) ==="
 
             cd /opt/eliza
@@ -227,6 +235,11 @@ jobs:
           envs: SYSTEMD_UNIT
           script: |
             set -euo pipefail
+            # Hold the same host lock as the deploy step so a concurrent run's
+            # restart can never flip the unit mid-check (false red). 240s wait
+            # stays under this step's 5m command_timeout.
+            exec 9>/tmp/eliza-apps-worker-deploy.lock
+            flock -w 240 9 || { echo "::error::another apps-worker deploy holds the host lock after 4m"; exit 1; }
             # The apps worker has no HTTP endpoint; health = active + stable +
             # no fatal/restart-loop in the journal since deploy.
             HEALTH_SINCE_TS="$(date -u '+%Y-%m-%d %H:%M:%S')"


### PR DESCRIPTION
## What
Gives `deploy-apps-worker.yml` a **per-SHA concurrency group** (`…-${{ github.sha }}`), mirroring the fix cloud-cf-deploy already carries (#10802/#10973). Closes the "staging apps-daemon dispatches keep getting cancelled with no comment trail" symptom on #10839.

## Why
The shared group `deploy-apps-worker-<env>` + `cancel-in-progress: false` makes GitHub keep only the **latest pending** run per group and **silently cancel** older pending ones (no annotation). Under a hot develop push/dispatch stream that yields a chain of `cancelled` runs with only the newest `pending` — verified on the live run list (12 runs 01:18→04:43, all cancelled except the latest pending). It looked like an agent sweep loop but the cancel annotations are empty (no `gh run cancel`, no concurrency-priority message); it's the group config cancelling its own runs.

## Change
One line + comment. Append `-${{ github.sha }}` to the group so each commit gets its own group → no deploy is ever superseded, the self-hosted runner serializes them, and the latest commit lands. Env stays in the key so staging and production don't block each other. `cancel-in-progress: false` unchanged.

## Not touched
`arm-apps-daemon.yml` is `workflow_dispatch`-only (no push stream) and keyed on env+target; there keep-latest-pending is defensible (avoids two concurrent arms of the same host). Guidance for that one: dispatch once and wait — don't re-dispatch on a perceived hang (that's what created the self-cancelling chain).

Single concern, into `develop`, not self-merged — @lalalune. Unblocks the staging apps-daemon proof (the launch chain's last link per #11157). `[cloud-audit]`

Refs #10839.
