### PR TITLE
fix(cloud): SSP campaign delete refunds off actual spend, not the full budget (#11151)

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/ad-campaign-credit-reconciliation.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/ad-campaign-credit-reconciliation.test.ts
@@ -119,6 +119,67 @@ describe("deleteCampaign — refunds only the UNUSED budget fraction", () => {
     // fractionSpent clamps to 1 → creditsRemaining 0 → no refund call.
     expect(refund).not.toHaveBeenCalled();
   });
+
+  // #11151 — internal (miniapp) SSP campaigns accrue spend on `credits_spent`
+  // (written by recordServe), NOT `total_spend` (only the external-provider sync
+  // writes that). Before the fix, an internal campaign had total_spend "0" so
+  // deleteCampaign refunded the FULL allocation after it spent real budget on
+  // impressions. The refund must now honor credits_spent too.
+  test("#11151 internal campaign spent via credits_spent → refunds only the unused portion, not the full allocation", async () => {
+    track(
+      spyOn(adCampaignsRepository, "findById").mockResolvedValue(
+        // external_campaign_id null (internal), total_spend "0", but 40 allocated
+        // credits actually spent on served impressions.
+        makeCampaign({ credits_spent: "40", total_spend: "0" }) as never,
+      ),
+    );
+    const refund = track(
+      spyOn(creditsService, "refundCredits").mockResolvedValue({ success: true } as never),
+    );
+    track(spyOn(adTransactionsRepository, "create").mockResolvedValue({} as never));
+
+    await advertisingService.deleteCampaign(CAMPAIGN_ID, ORG_ID);
+
+    expect(refund).toHaveBeenCalledTimes(1);
+    const arg = refund.mock.calls[0]?.[0] as { amount: number };
+    // credits_spent is already in allocated-credit units: 110 - 40 = 70.
+    // Pre-fix this refunded the full 110 (free advertising).
+    expect(arg.amount).toBeCloseTo(70, 9);
+  });
+
+  test("#11151 fully-spent internal campaign (credits_spent ≥ allocated) refunds nothing", async () => {
+    track(
+      spyOn(adCampaignsRepository, "findById").mockResolvedValue(
+        makeCampaign({ credits_spent: "110", total_spend: "0" }) as never,
+      ),
+    );
+    const refund = track(
+      spyOn(creditsService, "refundCredits").mockResolvedValue({ success: true } as never),
+    );
+    track(spyOn(adTransactionsRepository, "create").mockResolvedValue({} as never));
+
+    await advertisingService.deleteCampaign(CAMPAIGN_ID, ORG_ID);
+
+    expect(refund).not.toHaveBeenCalled();
+  });
+
+  test("#11151 mixed spend takes the MAX of internal+external measures (no double-refund)", async () => {
+    track(
+      spyOn(adCampaignsRepository, "findById").mockResolvedValue(
+        // credits_spent 40 (allocated units) vs total_spend 100 USD → 100*1.1 = 110
+        // allocated-credit units; the external measure dominates → nothing left.
+        makeCampaign({ credits_spent: "40", total_spend: "100" }) as never,
+      ),
+    );
+    const refund = track(
+      spyOn(creditsService, "refundCredits").mockResolvedValue({ success: true } as never),
+    );
+    track(spyOn(adTransactionsRepository, "create").mockResolvedValue({} as never));
+
+    await advertisingService.deleteCampaign(CAMPAIGN_ID, ORG_ID);
+
+    expect(refund).not.toHaveBeenCalled();
+  });
 });
 
 describe("updateCampaign — reconciles the credit hold on a budget change", () => {

--- a/packages/cloud/shared/src/lib/services/advertising/index.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/index.ts
@@ -778,16 +778,23 @@ class AdvertisingService {
       }
     }
 
-    // Refund the genuinely-UNUSED budget. The old `creditsAllocated -
-    // credits_spent` refunded 100% of the allocation on every delete, because
-    // `credits_spent` is never written (its only writer, incrementSpend, has no
-    // callers) — so deleting a campaign that had spent its budget on real ads
-    // refunded the whole prepaid budget + markup ("free advertising"). Base the
-    // spent portion on the REAL recorded ad spend (`total_spend`, kept in sync by
-    // getCampaignMetrics) scaled by the same effective markup applied at
-    // allocation (credits_allocated / budget_amount), so the refund is exactly
-    // the unused fraction. Best-effort refresh spend first so a never-synced
-    // campaign can't over-refund.
+    // Refund the genuinely-UNUSED budget. Spend accrues on TWO different columns
+    // depending on the campaign type, and the refund must honor BOTH (#11151):
+    //   - internal miniapp SSP spend → `credits_spent` (allocated-credit units,
+    //     written by adSlotsRepository.recordServe on every served impression,
+    //     #10942/#11029). NOTE: the earlier "credits_spent is never written"
+    //     reasoning is STALE — it only checked incrementSpend's callers and
+    //     missed recordServe's direct UPDATE.
+    //   - external-provider spend → `total_spend` (USD, synced by getCampaignMetrics).
+    // Refunding off `total_spend` ALONE let a purely-internal campaign
+    // (external_campaign_id = null, so total_spend stays "0") refund its ENTIRE
+    // prepaid budget + markup after spending it on real impressions ("free
+    // advertising", platform eats the publisher payouts). Convert the external
+    // USD spend into allocated-credit units at the same markup applied at
+    // allocation, take the MAX of the two spent measures, and refund only the
+    // remainder — so a campaign of either kind (or both) can never be refunded
+    // past its genuinely-unused allocation. Best-effort refresh external spend
+    // first so a never-synced provider campaign can't over-refund.
     let totalSpendUsd = parseFloat(campaign.total_spend);
     if (campaign.external_campaign_id) {
       try {
@@ -807,9 +814,15 @@ class AdvertisingService {
     }
     const creditsAllocated = parseFloat(campaign.credits_allocated);
     const budgetAmountUsd = parseFloat(campaign.budget_amount);
-    const fractionSpent =
-      budgetAmountUsd > 0 ? Math.min(1, Math.max(0, totalSpendUsd / budgetAmountUsd)) : 0;
-    const creditsRemaining = Math.max(0, creditsAllocated * (1 - fractionSpent));
+    const markup = budgetAmountUsd > 0 ? creditsAllocated / budgetAmountUsd : 1;
+    // credits_spent is already in allocated-credit units; total_spend is USD → scale by markup.
+    const internalSpentCredits = Math.max(0, parseFloat(campaign.credits_spent));
+    const externalSpentCredits = Math.max(0, totalSpendUsd) * markup;
+    const creditsSpent = Math.min(
+      creditsAllocated,
+      Math.max(internalSpentCredits, externalSpentCredits),
+    );
+    const creditsRemaining = Math.max(0, creditsAllocated - creditsSpent);
 
     if (creditsRemaining > 0) {
       await creditsService.refundCredits({


### PR DESCRIPTION
Closes #11151.

## Problem (HIGH — net platform loss)
`deleteCampaign` (`advertising/index.ts`) refunded unused budget as `credits_allocated * (1 - total_spend/budget_amount)`. But `total_spend` is written **only** by the external-provider metrics sync — an **internal miniapp SSP campaign** (`external_campaign_id = null`) never has it written, so it stays `"0"`, while its real spend accrues on **`credits_spent`** via `recordServe` on every served impression (#10942/#11029).

So deleting a spent internal campaign refunded its **entire prepaid budget + markup** after it consumed real impressions → advertiser gets free advertising **and** publishers were already paid real `redeemable_earnings` out of platform funds. The in-code comment justifying `total_spend` ("`credits_spent` is never written, its only writer incrementSpend has no callers") was **stale** — it missed `recordServe`'s direct `UPDATE ad_campaigns SET credits_spent = credits_spent + price`.

## Fix
Compute the spent portion from **both** columns and refund only the remainder:
```ts
const markup = budgetAmountUsd > 0 ? creditsAllocated / budgetAmountUsd : 1;
const internalSpentCredits = Math.max(0, parseFloat(campaign.credits_spent)); // allocated-credit units
const externalSpentCredits = Math.max(0, totalSpendUsd) * markup;             // USD → allocated-credit units
const creditsSpent = Math.min(creditsAllocated, Math.max(internalSpentCredits, externalSpentCredits));
const creditsRemaining = Math.max(0, creditsAllocated - creditsSpent);
```
`credits_spent` is already in allocated-credit units (it's debited from the `credits_allocated` pool and bounds eligibility); `total_spend` (USD) is scaled by the same markup applied at allocation. Taking the **max** covers internal-only, external-only, and mixed campaigns; clamping prevents over-refund.

## Tests (`ad-campaign-credit-reconciliation.test.ts`, +3)
- **internal `credits_spent=40` → refunds 70, not the full 110** (the bug).
- fully-spent internal (`credits_spent ≥ allocated`) → refunds nothing.
- mixed spend takes the MAX of internal+external (no double/over-refund).
- Existing external `total_spend`-path tests unchanged (same 66 / 0 outcomes) — the fix is a superset.

```
bun test packages/cloud/shared/src/lib/services/__tests__/ad-campaign-credit-reconciliation.test.ts   # 8 pass
```
`packages/cloud/shared typecheck` + biome clean.

## Evidence
- Money-conservation invariant (refund ≤ genuinely-unused allocation) proven by the 3 new cases + the 2 preserved external-path cases; no mock stands in for the refund math under test.
- N/A (no UI / no migration / no model).

Money-path — flagging for maintainer review/merge rather than self-merge. `[cloud-security]`