### PR TITLE
ci(janitor): force-cancel + per-run verification — reap the runs plain cancel can't (#11045)

### DIFF
--- a/.github/workflows/actions-zombie-janitor.yml
+++ b/.github/workflows/actions-zombie-janitor.yml
@@ -73,6 +73,13 @@ jobs:
             --jq '.[] | "\(.databaseId)\t\(.createdAt)\t\(.workflowName)"' |
           while IFS=$'\t' read -r id created name; do
             [ "$id" = "$SELF_RUN_ID" ] && continue
+            # The list endpoint serves STALE entries for force-killed runs —
+            # re-verify each candidate individually before judging it.
+            live_status=$(gh run view "$id" --repo "$GH_REPO" --json status --jq .status 2>/dev/null || echo "")
+            if [ "$live_status" != "in_progress" ]; then
+              echo "skip (list-stale, actually '$live_status'): $id $name"
+              continue
+            fi
             created_s=$(date -u -d "$created" +%s)
             age_h=$(( (now - created_s) / 3600 ))
             if [ "$age_h" -lt "$MAX_AGE_HOURS" ]; then
@@ -99,8 +106,15 @@ jobs:
               echo "| $id | $name | $age_h | $idle_min | would cancel (dry run) |" >> "$GITHUB_STEP_SUMMARY"
               continue
             fi
-            # Best-effort: a run finishing between list and cancel is fine.
-            if gh run cancel "$id" --repo "$GH_REPO"; then
+            # FORCE-cancel: a plain `gh run cancel` silently fails to reap runs
+            # whose runner died (they sit in cancel-requested limbo until the
+            # 6h timeout — exactly the runs this janitor exists for). The
+            # force-cancel endpoint kills them immediately; fall back to the
+            # polite cancel for anything the force path rejects.
+            if gh api -X POST "repos/$GH_REPO/actions/runs/$id/force-cancel" >/dev/null 2>&1; then
+              echo "force-cancelled zombie: $id $name (age ${age_h}h, idle ${idle_min}m)"
+              echo "| $id | $name | $age_h | $idle_min | force-cancelled |" >> "$GITHUB_STEP_SUMMARY"
+            elif gh run cancel "$id" --repo "$GH_REPO"; then
               echo "cancelled zombie: $id $name (age ${age_h}h, idle ${idle_min}m)"
               echo "| $id | $name | $age_h | $idle_min | cancelled |" >> "$GITHUB_STEP_SUMMARY"
             else


### PR DESCRIPTION
Refs #11045 (my 05:29 comment claimed this), #10839 updates 12/15.

### The two gaps (both proven live tonight, twice)
1. **`gh run cancel` can't reap dead-runner runs** — they sit in cancel-requested limbo holding org concurrency slots until GitHub's 6h timeout. These are exactly the runs the janitor exists for. The **force-cancel endpoint** (`POST /actions/runs/:id/force-cancel`) kills them instantly — it's the literal command that un-froze the org at 04:0x (5 CodeQLs) and again at 05:2x (17 buried smokes/scenarios/CodeQLs).
2. **The list endpoint lies** — `gh run list --status in_progress` serves stale entries for force-killed runs and hides deeper layers behind pagination. The janitor now re-verifies each candidate via `gh run view` and skips list-stale ghosts instead of wasting its cancel budget on them.

### Change
Same detection semantics as merged (old ≥4h AND job-idle ≥90m, kill switch, dry-run input) — only the verification step is added and the cancel path becomes force-first with polite fallback. `permissions: actions: write` already covers the force-cancel endpoint.

### Evidence
- The exact force-cancel + verify sequence, run by hand, is what recovered the org twice tonight (timeline + run ids in #10839 update 12 and #11045's 05:29 comment: queue went from starved to 0 blocked slots immediately both times).
- `yaml.safe_load` clean; script body unchanged apart from the two guarded blocks.
- N/A — screenshots/trajectories: CI workflow; the observable surface is the run-id evidence above.

— `[cloud-frontdoor]`