### PR TITLE
fix(ui): her-grade QA batch 4 — expired Steward-token heal, Android back closes sheet, jump-to-message on terminal surface

### DIFF
--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -68,6 +68,7 @@ import {
   COMMAND_PALETTE_EVENT,
   CONNECT_EVENT,
   dispatchAppEvent,
+  dispatchBackIntent,
   MOBILE_RUNTIME_MODE_CHANGED_EVENT,
   SHARE_TARGET_EVENT,
   TRAY_ACTION_EVENT,
@@ -1572,6 +1573,13 @@ function initializeAppLifecycle(): void {
 
   void Promise.resolve(
     CapacitorApp.addListener("backButton", ({ canGoBack }) => {
+      // Give the shell first crack at the back press: an open chat sheet (or any
+      // future back-dismissable overlay) closes ONE layer and reports it
+      // handled, so hardware back dismisses the sheet instead of navigating the
+      // app out from under it — matching desktop/web Escape-to-close (#9148).
+      // `dispatchBackIntent` resolves synchronously; only an unhandled press
+      // falls through to the app's default back below.
+      if (dispatchBackIntent()) return;
       if (canGoBack) {
         window.history.back();
       } else {

--- a/packages/ui/src/components/conversations/ConversationsSidebar.jump.test.tsx
+++ b/packages/ui/src/components/conversations/ConversationsSidebar.jump.test.tsx
@@ -205,4 +205,35 @@ describe("ConversationsSidebar jump-to-message (#9955)", () => {
     });
     expect(loadConversationMessagesAround).not.toHaveBeenCalled();
   });
+
+  it("clears an active terminal/inbox surface and lands on chat before jumping", async () => {
+    // ChatView renders the terminal branch first and the inbox branch second,
+    // so with either active a jump switched the conversation invisibly beneath
+    // it and the anchor never mounted. jumpToMessage must clear both and set
+    // the chat tab (mirroring handleRowSelect).
+    const scroll = scrollSpy();
+    const el = document.createElement("div");
+    el.id = getChatMessageAnchorId(OLD_MESSAGE_ID);
+    document.body.appendChild(el);
+
+    const setState = vi.fn();
+    const setTab = vi.fn();
+    appMock.value = makeAppState({
+      activeTerminalSessionId: "pty-1",
+      activeInboxChat: null,
+      loadConversationMessagesAround: vi.fn(async () => true),
+      setState,
+      setTab,
+    });
+
+    render(<ConversationsSidebar />);
+    await openSearchAndJump();
+
+    await waitFor(() => expect(scroll).toHaveBeenCalledTimes(1), {
+      timeout: 3000,
+    });
+    expect(setState).toHaveBeenCalledWith("activeTerminalSessionId", null);
+    expect(setState).toHaveBeenCalledWith("activeInboxChat", null);
+    expect(setTab).toHaveBeenCalledWith("chat");
+  });
 });

--- a/packages/ui/src/components/conversations/ConversationsSidebar.tsx
+++ b/packages/ui/src/components/conversations/ConversationsSidebar.tsx
@@ -480,6 +480,15 @@ export function ConversationsSidebar({
     (result: ConversationMessageSearchResult) => {
       const anchorId = getChatMessageAnchorId(result.messageId);
       void (async () => {
+        // Clear any active terminal/inbox surface and land on the chat tab
+        // BEFORE selecting — ChatView renders the terminal branch first and the
+        // inbox branch second, so without this a search-result jump switched
+        // the conversation invisibly underneath a terminal/connector chat, the
+        // anchor never mounted, and the user saw nothing (mirrors
+        // handleRowSelect / handleNewChat).
+        setState("activeInboxChat", null);
+        setState("activeTerminalSessionId", null);
+        setTab("chat");
         // Select the conversation and let its recent window load first, so the
         // in-window case (the common one) scrolls without a second fetch.
         await handleSelectConversation(result.conversationId);
@@ -506,6 +515,8 @@ export function ConversationsSidebar({
       loadConversationMessagesAround,
       waitForAnchor,
       scrollAndFlashAnchor,
+      setState,
+      setTab,
       mobile,
       onClose,
     ],

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -41,7 +41,7 @@ import type {
   Conversation,
   ConversationMessage,
 } from "../../api/client-types-chat";
-import { CHAT_PREFILL_EVENT } from "../../events";
+import { CHAT_PREFILL_EVENT, ELIZA_BACK_INTENT_EVENT } from "../../events";
 import {
   LAYOUT_SHIFT_INTENT_ATTR,
   LAYOUT_SHIFT_INTENT_TRANSIENT,
@@ -729,6 +729,45 @@ describe("ContinuousChatOverlay", () => {
     fireEvent.focus(input);
     expect(sheet.getAttribute("data-variant")).toBe("open");
     fireEvent.keyDown(input, { key: "Escape" });
+    expect(sheet.getAttribute("data-variant")).toBe("closed");
+  });
+
+  it("closes the sheet and marks the intent handled on an Android back-intent while open", () => {
+    render(<ContinuousChatOverlay controller={makeController()} />);
+    const input = screen.getByLabelText("message");
+    const sheet = screen.getByTestId("chat-sheet");
+    // Open the sheet (type-to-open → half detent).
+    fireEvent.focus(input);
+    expect(sheet.getAttribute("data-variant")).toBe("open");
+
+    // main.tsx dispatches this synchronously and reads back `detail.handled`.
+    const detail = { handled: false };
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(ELIZA_BACK_INTENT_EVENT, { detail }),
+      );
+    });
+
+    expect(detail.handled).toBe(true);
+    expect(sheet.getAttribute("data-variant")).toBe("closed");
+  });
+
+  it("leaves the Android back-intent unhandled while the sheet is at rest (native falls through)", () => {
+    render(<ContinuousChatOverlay controller={makeController()} />);
+    const sheet = screen.getByTestId("chat-sheet");
+    // At rest: the sheet is closed (collapsed input bar), not opened.
+    expect(sheet.getAttribute("data-variant")).toBe("closed");
+
+    const detail = { handled: false };
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(ELIZA_BACK_INTENT_EVENT, { detail }),
+      );
+    });
+
+    // Nothing consumed it, so main.tsx would fall through to history.back() /
+    // minimizeApp(); the sheet stays closed.
+    expect(detail.handled).toBe(false);
     expect(sheet.getAttribute("data-variant")).toBe("closed");
   });
 

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -42,8 +42,10 @@ import {
 } from "../../chat/slash-menu";
 import type { SlashCommandController } from "../../chat/useSlashCommandController";
 import {
+  type BackIntentEventDetail,
   CHAT_PREFILL_EVENT,
   type ChatPrefillEventDetail,
+  ELIZA_BACK_INTENT_EVENT,
   TUTORIAL_CHAT_CONTROL_EVENT,
   type TutorialChatControlDetail,
 } from "../../events";
@@ -3275,6 +3277,30 @@ export function ContinuousChatOverlay({
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
   }, [sheetOpen, collapse]);
+
+  // Android hardware/gesture back closes the open chat sheet FIRST — the same
+  // "dismiss the open surface" behavior desktop/web get from Escape (#9148).
+  // `main.tsx` dispatches ELIZA_BACK_INTENT on the Capacitor `backButton` press;
+  // while the sheet is open (and not pinned by onboarding) we collapse it via
+  // the shared `collapse` path and flip `detail.handled` so native does NOT ALSO
+  // run history.back()/minimizeApp() and navigate the app out from under it. At
+  // rest (input/pill) — or while first-run pins the sheet open + undismissable —
+  // we leave the intent unhandled so native falls through to its default back
+  // (backgrounding the app instead of freezing). Web/desktop never dispatch the
+  // event, so this is inert there.
+  React.useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+    const onBackIntent = (event: Event) => {
+      const detail = (event as CustomEvent<BackIntentEventDetail>).detail;
+      if (!detail || detail.handled) return;
+      if (!sheetOpen || firstRunOpen) return;
+      detail.handled = true;
+      collapse();
+    };
+    window.addEventListener(ELIZA_BACK_INTENT_EVENT, onBackIntent);
+    return () =>
+      window.removeEventListener(ELIZA_BACK_INTENT_EVENT, onBackIntent);
+  }, [sheetOpen, firstRunOpen, collapse]);
 
   // Auto-grow the composer with multi-line input: snap to the content height
   // (capped by `max-h` in CSS, which then scrolls). Runs on every draft change

--- a/packages/ui/src/events/index.ts
+++ b/packages/ui/src/events/index.ts
@@ -194,6 +194,45 @@ export function dispatchOpenNotificationCenter(): void {
   window.dispatchEvent(new CustomEvent(OPEN_NOTIFICATION_CENTER_EVENT));
 }
 
+// ── Android hardware back ─────────────────────────────────────────────────
+/**
+ * The Android hardware/gesture back press, surfaced to shell consumers BEFORE
+ * the app's default back behavior runs (#9148). Native (`main.tsx`) dispatches
+ * this on the Capacitor `backButton` event; a consumer with an open,
+ * back-dismissable surface — today the {@link ContinuousChatOverlay} chat sheet
+ * — closes ONE layer and flips `detail.handled = true`. The dispatcher reads
+ * `handled` synchronously (custom events dispatch synchronously, so every
+ * listener has run by the time `dispatchEvent` returns) and only falls through
+ * to `history.back()` / `minimizeApp()` when nothing consumed the press. This
+ * gives Android hardware-back the same "dismiss the open sheet first" behavior
+ * desktop/web get from Escape. Web/desktop simply never dispatch it, so the
+ * fall-through path is unchanged there.
+ */
+export const ELIZA_BACK_INTENT_EVENT = "eliza:back-intent" as const;
+
+export interface BackIntentEventDetail {
+  /**
+   * A consumer flips this to `true` when it handles the back press (e.g. by
+   * closing an open sheet). While it stays `false` the dispatcher falls through
+   * to the app's default back behavior — so a back press at rest still
+   * navigates / backgrounds the app as before.
+   */
+  handled: boolean;
+}
+
+/**
+ * Dispatch the Android back-intent to shell consumers and report whether one of
+ * them handled it (closed a surface). Returns `false` when nothing consumed the
+ * press — including off-window (SSR) — so the caller can fall through to its
+ * default back behavior. See {@link ELIZA_BACK_INTENT_EVENT}.
+ */
+export function dispatchBackIntent(): boolean {
+  if (typeof window === "undefined") return false;
+  const detail: BackIntentEventDetail = { handled: false };
+  window.dispatchEvent(new CustomEvent(ELIZA_BACK_INTENT_EVENT, { detail }));
+  return detail.handled;
+}
+
 // ── Event-name unions (shared base widened with the UI-only events) ───────
 
 export type ElizaDocumentEventName =
@@ -206,7 +245,8 @@ export type ElizaWindowEventName =
   | typeof TUTORIAL_CHAT_CONTROL_EVENT
   | typeof CHAT_PREFILL_EVENT
   | typeof CLOUD_HANDOFF_PHASE_EVENT
-  | typeof CLOUD_HANDOFF_RETRY_EVENT;
+  | typeof CLOUD_HANDOFF_RETRY_EVENT
+  | typeof ELIZA_BACK_INTENT_EVENT;
 
 export type ElizaEventName = ElizaDocumentEventName | ElizaWindowEventName;
 

--- a/packages/ui/src/state/startup-phase-restore.steward-refresh.test.ts
+++ b/packages/ui/src/state/startup-phase-restore.steward-refresh.test.ts
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+//
+// #10231 launch-blocker #4 — a returning cloud user whose stored Steward JWT
+// expired while the app was closed must NOT boot into a permanently-401ing
+// session. `applyRestoredConnection`'s cloud branch refreshes an expired /
+// near-expiry stored JWT BEFORE handing it to the client, so the first authed
+// call carries a live token (or, if the refresh fails, the session restores
+// unauthenticated rather than dialing with a known-dead credential).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PersistedActiveServer } from "./persistence";
+import { applyRestoredConnection } from "./startup-phase-restore";
+
+const STEWARD_TOKEN_KEY = "steward_session_token";
+const STEWARD_REFRESH_PATH = "/api/auth/steward-refresh";
+
+/** Build a minimal (unsigned) JWT whose payload carries the given `exp`. */
+function makeJwt(expSecondsFromNow: number | null): string {
+  const enc = (obj: unknown) =>
+    btoa(JSON.stringify(obj))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+  const header = enc({ alg: "none", typ: "JWT" });
+  const payload = enc(
+    expSecondsFromNow === null
+      ? {}
+      : { exp: Math.floor(Date.now() / 1000) + expSecondsFromNow },
+  );
+  return `${header}.${payload}.sig`;
+}
+
+/** A cloud active-server with a concrete (non-agentless) apiBase so the restore
+ * backfill returns immediately without any network round-trip. */
+function cloudServer(
+  overrides: Partial<PersistedActiveServer> = {},
+): PersistedActiveServer {
+  return {
+    id: "cloud:agent-123",
+    kind: "cloud",
+    label: "Eliza Cloud",
+    apiBase: "https://agent-123.example.com",
+    ...overrides,
+  };
+}
+
+function fakeClient() {
+  return { setBaseUrl: vi.fn(), setToken: vi.fn() };
+}
+
+describe("applyRestoredConnection — cloud Steward token refresh at restore", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  const realFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    localStorage.clear();
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("refreshes an EXPIRED stored JWT before setting it, and sets the refreshed token", async () => {
+    localStorage.setItem(STEWARD_TOKEN_KEY, makeJwt(-60));
+    const fresh = makeJwt(3600);
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ token: fresh }),
+    });
+
+    const client = fakeClient();
+    await applyRestoredConnection({
+      restoredActiveServer: cloudServer(),
+      clientRef: client,
+    });
+
+    // A single refresh POST to the same-origin endpoint (web / jsdom).
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(STEWARD_REFRESH_PATH);
+    expect(init).toMatchObject({ method: "POST", credentials: "include" });
+    // The client receives the REFRESHED token, not the expired one.
+    expect(client.setToken).toHaveBeenCalledWith(fresh);
+    // The fresh token is mirrored back to localStorage.
+    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBe(fresh);
+  });
+
+  it("refreshes a NEAR-EXPIRY stored JWT (inside the refresh-ahead margin)", async () => {
+    // 30s of life left is under the 120s refresh-ahead margin.
+    localStorage.setItem(STEWARD_TOKEN_KEY, makeJwt(30));
+    const fresh = makeJwt(3600);
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ token: fresh }),
+    });
+
+    const client = fakeClient();
+    await applyRestoredConnection({
+      restoredActiveServer: cloudServer(),
+      clientRef: client,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(client.setToken).toHaveBeenCalledWith(fresh);
+  });
+
+  it("does NOT refresh a comfortably-valid stored JWT (instant restore)", async () => {
+    const valid = makeJwt(3600);
+    localStorage.setItem(STEWARD_TOKEN_KEY, valid);
+
+    const client = fakeClient();
+    await applyRestoredConnection({
+      restoredActiveServer: cloudServer(),
+      clientRef: client,
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(client.setToken).toHaveBeenCalledWith(valid);
+    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBe(valid);
+  });
+
+  it("does NOT refresh an opaque (non-JWT) token; uses it as-is", async () => {
+    localStorage.setItem(STEWARD_TOKEN_KEY, "opaque-device-code-token");
+
+    const client = fakeClient();
+    await applyRestoredConnection({
+      restoredActiveServer: cloudServer(),
+      clientRef: client,
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(client.setToken).toHaveBeenCalledWith("opaque-device-code-token");
+  });
+
+  it("leaves the session UNAUTHENTICATED (and clears the token) when refresh fails, without looping", async () => {
+    localStorage.setItem(STEWARD_TOKEN_KEY, makeJwt(-60));
+    fetchMock.mockResolvedValue({ ok: false, json: async () => ({}) });
+
+    const client = fakeClient();
+    await applyRestoredConnection({
+      // No provision-time accessToken to fall back to.
+      restoredActiveServer: cloudServer({ accessToken: undefined }),
+      clientRef: client,
+    });
+
+    // Exactly one refresh attempt — no retry loop.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // The dead credential is dropped and the client is left unauthenticated.
+    expect(client.setToken).toHaveBeenCalledWith(null);
+    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBeNull();
+  });
+
+  it("falls back to the provision-time token when refresh fails but the JWT is still (barely) alive", async () => {
+    // 30s left → attempts refresh, but the token is not yet expired, so a
+    // failed refresh keeps it rather than dropping to unauthenticated.
+    const nearExpiry = makeJwt(30);
+    localStorage.setItem(STEWARD_TOKEN_KEY, nearExpiry);
+    fetchMock.mockResolvedValue({ ok: false, json: async () => ({}) });
+
+    const client = fakeClient();
+    await applyRestoredConnection({
+      restoredActiveServer: cloudServer(),
+      clientRef: client,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(client.setToken).toHaveBeenCalledWith(nearExpiry);
+    // Still-alive token is retained for the useCloudState lifecycle refresh.
+    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBe(nearExpiry);
+  });
+});

--- a/packages/ui/src/state/startup-phase-restore.ts
+++ b/packages/ui/src/state/startup-phase-restore.ts
@@ -6,14 +6,23 @@
  */
 
 import { logger } from "@elizaos/logger";
-import { readStoredStewardToken } from "@elizaos/shared/steward-session-client";
+import {
+  clearStoredStewardToken,
+  readStoredStewardToken,
+  writeStoredStewardToken,
+} from "@elizaos/shared/steward-session-client";
 import { client, type FirstRunOptions } from "../api";
+import {
+  cloudTokenSecsRemaining,
+  refreshCloudStewardSession,
+} from "../api/client-cloud";
 import {
   getBackendStartupTimeoutMs,
   invokeDesktopBridgeRequestWithTimeout,
   isElectrobunRuntime,
   scanProviderCredentials,
 } from "../bridge";
+import { getBootConfig } from "../config/boot-config";
 import {
   ANDROID_LOCAL_AGENT_IPC_BASE,
   ANDROID_LOCAL_AGENT_LABEL,
@@ -30,6 +39,7 @@ import {
   isAndroid,
   isForceFreshFirstRunEnabled,
   isIOS,
+  isNative,
 } from "../platform";
 import type { ExistingElizaInstallInfo } from "../types";
 import {
@@ -55,6 +65,26 @@ import { buildStaticFirstRunOptions } from "./startup-first-run-options";
 // in api/client-cloud.ts; kept inline because that constant is module-private.
 const DIRECT_CLOUD_API_BASE = "https://api.elizacloud.ai";
 const DESKTOP_RESTORE_RPC_TIMEOUT_MS = 5_000;
+
+/**
+ * A stored Steward JWT with at least this many seconds of life left restores
+ * as-is (no refresh). Below it — or already expired — the restore boundary
+ * refreshes first so we never hand the client a dead token. Mirrors
+ * `STEWARD_REFRESH_AHEAD_SECS` in `state/useCloudState.ts` and
+ * `PRE_RENDER_REFRESH_AHEAD_SECS` in the native apps studio.
+ */
+const STEWARD_RESTORE_REFRESH_AHEAD_SECS = 120;
+/**
+ * Hard cap on how long the restore-boundary Steward refresh may block startup.
+ * The refresh is a network POST that can hang; if it doesn't settle in time we
+ * fall back to the stored/provision token (the useCloudState lifecycle refresh
+ * and the api-client 401 self-heal remain the backstops).
+ */
+const STEWARD_RESTORE_REFRESH_TIMEOUT_MS = 4_000;
+/** Steward refresh endpoint path (same-origin on web; `api.` host on native). */
+const STEWARD_REFRESH_PATH = "/api/auth/steward-refresh";
+/** Default direct Cloud site base used to derive the native refresh endpoint. */
+const RESTORE_DEFAULT_DIRECT_CLOUD_BASE_URL = "https://elizacloud.ai";
 
 function isDevUiPort(): boolean {
   return typeof window !== "undefined" && window.location.port === "2138";
@@ -331,6 +361,102 @@ async function requestDesktopAgentStartForStartup(): Promise<void> {
   });
 }
 
+/**
+ * Resolve the Steward refresh endpoint for the current target. Hosted web uses
+ * the same-origin cookie path (the HttpOnly `steward-refresh-token` cookie
+ * travels automatically), so we return `undefined` to let
+ * {@link refreshCloudStewardSession} fall back to its same-origin default.
+ * Native (`capacitor://localhost`) has no same-origin cookie, so refresh against
+ * the configured Cloud API base (Bearer-refresh). Mirrors
+ * `resolveStewardRefreshEndpoint` in `state/useCloudState.ts`.
+ */
+function resolveRestoreStewardRefreshEndpoint(): string | undefined {
+  if (!isNative) return undefined;
+  const cloudBase =
+    getBootConfig().cloudApiBase?.trim() ||
+    RESTORE_DEFAULT_DIRECT_CLOUD_BASE_URL;
+  try {
+    const url = new URL(cloudBase);
+    const host = url.hostname.toLowerCase();
+    const apiHost =
+      host === "elizacloud.ai" ||
+      host === "www.elizacloud.ai" ||
+      host === "dev.elizacloud.ai"
+        ? "api.elizacloud.ai"
+        : host;
+    return `${url.protocol}//${apiHost}${STEWARD_REFRESH_PATH}`;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Pick the Steward token to hand the client when restoring a cloud session.
+ *
+ * A returning user's stored JWT can EXPIRE while the app is closed. Blindly
+ * setting an expired token boots into a permanently-401ing session: the
+ * proactive lifecycle refresh (useCloudState) is the only other refresh path,
+ * and a stale token means the very first authed call 401s — so the connection
+ * never establishes and the refresh that would have healed it is starved. To
+ * break that deadlock at the restore boundary, before handing the token to the
+ * client we:
+ *   - use a comfortably-valid JWT as-is (instant restore, no needless refresh);
+ *   - leave an opaque / device-code token (no decodable `exp`) untouched;
+ *   - refresh an expired / near-expiry JWT (cookie path on web, Bearer on
+ *     native), bounded by a timeout so a hung network can't stall startup;
+ *   - on a failed refresh, drain a truly-expired token and return `null`
+ *     (unauthenticated) rather than dial with a known-dead credential — a
+ *     merely near-expiry-but-still-live token is kept so the useCloudState
+ *     lifecycle refresh can retry ahead of the real `exp`.
+ *
+ * The refresh runs at most once per restore, so there is no refresh loop.
+ */
+async function resolveRestoredStewardToken(): Promise<string | null> {
+  const stored = readStoredStewardToken()?.trim();
+  if (!stored) return null;
+  const secs = cloudTokenSecsRemaining(stored);
+  // Opaque/device-code token (no decodable `exp`) → nothing to refresh.
+  if (secs === null) return stored;
+  // Comfortably valid → restore instantly.
+  if (secs >= STEWARD_RESTORE_REFRESH_AHEAD_SECS) return stored;
+
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const refreshed = await Promise.race([
+    refreshCloudStewardSession({
+      endpoint: resolveRestoreStewardRefreshEndpoint(),
+    }).catch(() => null),
+    new Promise<null>((resolve) => {
+      timeout = setTimeout(
+        () => resolve(null),
+        STEWARD_RESTORE_REFRESH_TIMEOUT_MS,
+      );
+    }),
+  ]);
+  if (timeout) clearTimeout(timeout);
+
+  if (refreshed?.token) {
+    writeStoredStewardToken(refreshed.token);
+    // Let the native Steward auth context + any storage listeners pick up the
+    // fresh JWT without waiting for the next read.
+    try {
+      if (typeof window !== "undefined") {
+        window.dispatchEvent(new CustomEvent("steward-token-sync"));
+      }
+    } catch {
+      // best-effort — listeners re-read on their next tick regardless
+    }
+    return refreshed.token;
+  }
+
+  // Refresh failed / timed out. A truly-expired token is a dead credential —
+  // drop it so we restore unauthenticated instead of a guaranteed-401 dial.
+  if (secs <= 0) {
+    clearStoredStewardToken();
+    return null;
+  }
+  return stored;
+}
+
 export async function applyRestoredConnection(args: {
   restoredActiveServer: PersistedActiveServer;
   clientRef: Pick<typeof client, "setBaseUrl" | "setToken">;
@@ -352,9 +478,11 @@ export async function applyRestoredConnection(args: {
     const resolved = await backfillCloudApiBase(restoredActiveServer);
     clientRef.setBaseUrl(resolved.apiBase ?? null);
     // Cloud = Steward everywhere (DECISIONS.md D3): prefer the live Steward
-    // session token (it auto-refreshes ahead of expiry) over the token captured
-    // at provision time, which may have rotated since.
-    const stewardToken = readStoredStewardToken()?.trim();
+    // session token over the token captured at provision time (which may have
+    // rotated since). If that stored JWT expired while the app was closed,
+    // refresh it BEFORE handing it to the client so a returning user never
+    // boots into a permanently-401ing session (see resolveRestoredStewardToken).
+    const stewardToken = await resolveRestoredStewardToken();
     clientRef.setToken(stewardToken || resolved.accessToken || null);
     return;
   }

--- a/packages/ui/src/state/useCloudState.steward-refresh.test.tsx
+++ b/packages/ui/src/state/useCloudState.steward-refresh.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+//
+// #10231 launch-blocker #4 — the Cloud=Steward token-lifecycle refresh must arm
+// on stored-token PRESENCE, not on `elizaCloudConnected`. A returning user's
+// stored JWT can already be expired at mount; `elizaCloudConnected` only flips
+// true after a successful status/credits poll, which can't happen while every
+// call 401s on the dead token. Gating on the connection flag therefore
+// deadlocked expired-token users. These tests lock the presence-gated behavior.
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useCloudState } from "./useCloudState";
+
+const STEWARD_TOKEN_KEY = "steward_session_token";
+const STEWARD_REFRESH_PATH = "/api/auth/steward-refresh";
+
+/** Build a minimal (unsigned) JWT whose payload carries the given `exp`. */
+function makeJwt(expSecondsFromNow: number | null): string {
+  const enc = (obj: unknown) =>
+    btoa(JSON.stringify(obj))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+  const header = enc({ alg: "none", typ: "JWT" });
+  const payload = enc(
+    expSecondsFromNow === null
+      ? {}
+      : { exp: Math.floor(Date.now() / 1000) + expSecondsFromNow },
+  );
+  return `${header}.${payload}.sig`;
+}
+
+function makeParams() {
+  return {
+    setActionNotice: vi.fn(),
+    loadWalletConfig: vi.fn(async () => {}),
+    t: (key: string) => key,
+  };
+}
+
+/** Yield a few macrotasks so mount effects (and their async bodies) settle. */
+async function flush(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 25));
+}
+
+describe("useCloudState — Steward refresh arms on stored-token presence", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  const realFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    localStorage.clear();
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("refreshes an expired stored JWT at mount even while disconnected (deadlock fix)", async () => {
+    localStorage.setItem(STEWARD_TOKEN_KEY, makeJwt(-60));
+    const fresh = makeJwt(3600);
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ token: fresh }),
+    });
+
+    const { result } = renderHook(() => useCloudState(makeParams()));
+    // Never connected — the effect must still fire on stored-token presence.
+    expect(result.current.elizaCloudConnected).toBe(false);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(fetchMock.mock.calls[0][0]).toBe(STEWARD_REFRESH_PATH);
+    // On success the refreshed token is mirrored back to localStorage.
+    await waitFor(() =>
+      expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBe(fresh),
+    );
+  });
+
+  it("does NOT refresh a comfortably-valid stored JWT (no needless work)", async () => {
+    const valid = makeJwt(3600);
+    localStorage.setItem(STEWARD_TOKEN_KEY, valid);
+
+    renderHook(() => useCloudState(makeParams()));
+    await flush();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBe(valid);
+  });
+
+  it("does nothing when no Steward token is stored", async () => {
+    renderHook(() => useCloudState(makeParams()));
+    await flush();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("leaves the session unauthenticated without looping when refresh fails", async () => {
+    const stale = makeJwt(-60);
+    localStorage.setItem(STEWARD_TOKEN_KEY, stale);
+    fetchMock.mockResolvedValue({ ok: false, json: async () => ({}) });
+
+    const { result } = renderHook(() => useCloudState(makeParams()));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    // The 60s lifecycle interval has not advanced — exactly one mount attempt,
+    // no tight retry loop.
+    await flush();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result.current.elizaCloudConnected).toBe(false);
+    // The stale token is left in place for pollCloudCredits() to surface as
+    // auth-rejected (the effect never wipes it on a failed refresh).
+    expect(localStorage.getItem(STEWARD_TOKEN_KEY)).toBe(stale);
+  });
+});

--- a/packages/ui/src/state/useCloudState.ts
+++ b/packages/ui/src/state/useCloudState.ts
@@ -953,8 +953,19 @@ export function useCloudState({
   // via the same-origin cookie path; native refreshes against the cloud API
   // base (Bearer-refresh). A 401 / no-token outcome is left for the next
   // pollCloudCredits() to surface as auth-rejected.
+  //
+  // Armed on stored-token PRESENCE, not on `elizaCloudConnected`: a returning
+  // user's stored JWT can already be expired at mount, and `elizaCloudConnected`
+  // only flips true after a successful status/credits poll — which can't happen
+  // while every call 401s on the dead token. Gating on the connection flag
+  // therefore deadlocked expired-token users (nothing ever refreshed the token
+  // that blocked the connection). Presence-gating breaks that: the check runs at
+  // mount for any stored token and refreshes a near-expiry/expired JWT so the
+  // next poll can succeed. A comfortably-valid token still no-ops (see the
+  // `secs >= STEWARD_REFRESH_AHEAD_SECS` guard), so this adds no needless work.
+  //
+  // biome-ignore lint/correctness/useExhaustiveDependencies: elizaCloudConnected is an intentional re-arm trigger, not read inside — a fresh login writes a new token and flips connected, and the effect must re-run to arm the lifecycle refresh on that token. Presence of a stored token (checked at the top) is the real gate.
   useEffect(() => {
-    if (!elizaCloudConnected) return;
     if (!readStoredStewardToken()?.trim()) return;
 
     let disposed = false;


### PR DESCRIPTION
## Summary

Three confirmed **major** findings from the her-grade QA sweep, each root-caused and pinned with real tests.

- **Expired Steward token deadlock (#10231 launch-blocker #4):** a returning cloud user whose stored JWT expired booted into a permanently-401ing session — the restore set the token with no expiry check, and the only refresh effect was gated on `elizaCloudConnected` which can't flip true while every call 401s. Defense-in-depth: refresh at the restore boundary (`cloudTokenSecsRemaining` → `refreshCloudStewardSession` before `setToken`, 4s-bounded, once) **and** arm the refresh effect on stored-token presence. Failed refresh drains to a clean unauthenticated state, no loop. +10 tests.

- **Android hardware back never closed the open chat sheet** (navigated under it / backgrounded the app) while desktop/web get Escape-to-close. New `ELIZA_BACK_INTENT_EVENT` (synchronous, mutable `handled` detail): the overlay collapses one detent when the sheet is open and marks it handled; `main.tsx` dispatches the intent first and only falls through to `history.back()`/minimize when unhandled. +2 tests. (The existing `touch-gesture.android.spec` KEYCODE_BACK step now actually closes the sheet on-device.)

- **Jump-to-message did nothing when a terminal/inbox surface was active:** ChatView renders the terminal branch first, so a search-result jump switched the conversation invisibly beneath it and the anchor never mounted. Now clears `activeTerminalSessionId`/`activeInboxChat` + `setTab('chat')` before selecting (mirrors handleRowSelect). +1 test.

Also filed the two previously-untracked KNOWN-BUGs the de-larp specs routed around: #11144 (ShellBackButton occludes the first filter chip) and #11145 (relationships graph overflows mobile).

## Evidence
164 `packages/ui` unit (the one transient delete-confirm fail is a parallel-load flake — 7/7 isolated) + chat-sheet e2e green.

Refs #10231, #9148, the #10722 sweep. Remaining are platform-consistency/larp/coverage items tracked in the sweep summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)