### PR TITLE
fix(agent): avoid embedding scans during document fragment boot checks

### DIFF
--- a/packages/agent/src/runtime/__tests__/default-documents.test.ts
+++ b/packages/agent/src/runtime/__tests__/default-documents.test.ts
@@ -1,0 +1,92 @@
+import type { AgentRuntime, Memory, UUID } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+
+import { listFragmentIdsForDocument } from "../default-documents.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-00000000a9e1" as UUID;
+const DOCUMENT_ID = "00000000-0000-0000-0000-0000000d0c01" as UUID;
+const OTHER_DOCUMENT_ID = "00000000-0000-0000-0000-0000000d0c02" as UUID;
+
+function fragmentMemory(index: number, documentId: UUID): Memory {
+  const suffix = index.toString(16).padStart(12, "0");
+  return {
+    id: `00000000-0000-0000-0000-${suffix}` as UUID,
+    agentId: AGENT_ID,
+    roomId: AGENT_ID,
+    entityId: AGENT_ID,
+    content: { text: `fragment ${index}` },
+    metadata: {
+      type: "fragment",
+      documentId,
+      position: index,
+    },
+  } as Memory;
+}
+
+/**
+ * Build a runtime stub whose getMemories serves `total` fragments in
+ * offset/limit pages, mirroring the SQL adapters' pagination contract.
+ */
+function makeRuntime(total: number, documentId: UUID) {
+  const rows = Array.from({ length: total }, (_, i) =>
+    fragmentMemory(i, documentId),
+  );
+  const getMemories = vi.fn(
+    async (params: {
+      limit?: number;
+      offset?: number;
+      includeEmbedding?: boolean;
+      start?: number;
+    }) => {
+      const offset = params.offset ?? 0;
+      const limit = params.limit ?? rows.length;
+      return rows.slice(offset, offset + limit);
+    },
+  );
+  const runtime = { agentId: AGENT_ID, getMemories } as unknown as AgentRuntime;
+  return { runtime, getMemories };
+}
+
+describe("listFragmentIdsForDocument", () => {
+  it("excludes embeddings from every fragment lookup", async () => {
+    // Regression: omitting includeEmbedding made plugin-sql select and
+    // deserialize every pgvector embedding at boot, pegging the main thread
+    // on self-hosted PGlite nodes even though only ids/metadata are used.
+    const { runtime, getMemories } = makeRuntime(3, DOCUMENT_ID);
+
+    await listFragmentIdsForDocument(runtime, DOCUMENT_ID);
+
+    expect(getMemories).toHaveBeenCalled();
+    for (const [params] of getMemories.mock.calls) {
+      expect(params.includeEmbedding).toBe(false);
+    }
+  });
+
+  it("paginates with offset (not the start timestamp filter) and collects all ids", async () => {
+    // Regression: passing the row offset as `start` (a createdAt filter)
+    // re-scanned nearly the whole table each loop and never made progress
+    // for documents with more than one batch of fragments.
+    const total = 250; // 3 pages at DOCUMENT_BATCH_SIZE=100
+    const { runtime, getMemories } = makeRuntime(total, DOCUMENT_ID);
+
+    const ids = await listFragmentIdsForDocument(runtime, DOCUMENT_ID);
+
+    expect(ids).toHaveLength(total);
+    expect(new Set(ids).size).toBe(total);
+
+    expect(getMemories).toHaveBeenCalledTimes(3);
+    const offsets = getMemories.mock.calls.map(([params]) => params.offset);
+    expect(offsets).toEqual([0, 100, 200]);
+    for (const [params] of getMemories.mock.calls) {
+      expect(params).not.toHaveProperty("start");
+    }
+  });
+
+  it("only returns ids belonging to the requested document", async () => {
+    const { runtime } = makeRuntime(5, OTHER_DOCUMENT_ID);
+
+    const ids = await listFragmentIdsForDocument(runtime, DOCUMENT_ID);
+
+    expect(ids).toEqual([]);
+  });
+});

--- a/packages/agent/src/runtime/default-documents.ts
+++ b/packages/agent/src/runtime/default-documents.ts
@@ -269,7 +269,23 @@ function fragmentMatchesDefinition(
   );
 }
 
-async function listFragmentIdsForDocument(
+/**
+ * List the ids of all document_fragments rows attached to a bundled document.
+ *
+ * Only ids and metadata are inspected, so embeddings are explicitly excluded
+ * (`includeEmbedding: false`). Selecting them here forced the SQL adapter to
+ * deserialize every pgvector embedding in the table on each boot, which on
+ * self-hosted PGlite nodes pegged the main thread at 100% CPU and starved the
+ * API before the agent finished starting.
+ *
+ * Pagination must use `offset` (skip N rows), not `start` (a createdAt
+ * timestamp filter): passing the row offset as `start` re-scanned nearly the
+ * whole table on every iteration and never advanced for documents with more
+ * than one batch of fragments.
+ *
+ * Exported for tests.
+ */
+export async function listFragmentIdsForDocument(
   runtime: AgentRuntime,
   documentId: UUID,
 ): Promise<UUID[]> {
@@ -281,7 +297,8 @@ async function listFragmentIdsForDocument(
       tableName: DOCUMENT_FRAGMENTS_TABLE,
       roomId: runtime.agentId,
       limit: DOCUMENT_BATCH_SIZE,
-      start: offset,
+      offset,
+      includeEmbedding: false,
     });
 
     if (batch.length === 0) break;


### PR DESCRIPTION
## Problem

On a self-hosted node (PGlite, ~400MB database), the agent booted into a state where the Node main thread sat at 100% CPU and the HTTP API never answered. Inspector profiling traced the hot path to drizzle's pgvector `mapFromDriverValue` running under PGlite WASM.

Root cause is in `packages/agent/src/runtime/default-documents.ts`, `listFragmentIdsForDocument` (called for every bundled document during boot seeding):

1. **Embeddings fetched and deserialized for no reason.** The `runtime.getMemories` call over `document_fragments` omitted `includeEmbedding: false`, so plugin-sql selected and deserialized every pgvector embedding in the table even though the caller only reads ids and metadata.
2. **Pagination used `start` instead of `offset`.** `start` is a createdAt timestamp filter, not a row offset. Passing the row offset as `start` re-scanned nearly the whole table on every iteration, and for documents with more than one batch of fragments (>100) the loop could never make correct progress.

Together these turn a boot-time bookkeeping pass into an unbounded embedding-deserialization loop on any node with a non-trivial fragment table.

## Fix

Minimal, two-line behavior change in `listFragmentIdsForDocument`:
- pass `includeEmbedding: false`
- paginate with `offset` instead of `start`

## Evidence (live node, before/after)

- Before: API starved indefinitely, main thread pinned at 100% CPU in pgvector deserialization during boot.
- After (same node, patched dist): `/api/agents` answers in ~10ms at ~3% CPU, boot reaches services + connector ready, document loading completes 20/20.

## Tests

New unit test `packages/agent/src/runtime/__tests__/default-documents.test.ts` pins both invariants against a runtime stub implementing the offset/limit pagination contract:
- every fragment lookup passes `includeEmbedding: false`
- pagination advances via `offset` (`0, 100, 200` for 250 rows), never passes `start`, and collects all ids
- ids are filtered to the requested document

```
Test Files  1 passed (1)
     Tests  3 passed (3)
```

Biome check clean on both touched files. `bun run typecheck` in `packages/agent` shows only pre-existing unrelated failures (missing `@elizaos/plugin-streaming`, `@elizaos/plugin-background-runner`, `@elizaos/cloud-routing` module declarations); no errors from this change.

## Scope

One concern only: the fragment-id lookup in the default-document seeder. No schema, adapter, or deploy changes.

— [sol-orch]