### PR TITLE
fix(ui/platform): getFrontendPlatform detects electrobun desktop (was mis-reporting 'web')

### DIFF
--- a/packages/ui/src/platform/platform-guards.test.ts
+++ b/packages/ui/src/platform/platform-guards.test.ts
@@ -1,7 +1,11 @@
 // @vitest-environment jsdom
 
-import { afterEach, describe, expect, it } from "vitest";
-import { getActiveViewModality } from "./platform-guards";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const isElectrobunRuntime = vi.hoisted(() => vi.fn(() => false));
+vi.mock("../bridge/electrobun-runtime", () => ({ isElectrobunRuntime }));
+
+import { getActiveViewModality, getFrontendPlatform } from "./platform-guards";
 
 const w = window as unknown as Record<string, unknown>;
 
@@ -18,5 +22,25 @@ describe("getActiveViewModality", () => {
   it("returns xr when the WebXR view host context is present", () => {
     w.__elizaXRContext = { viewId: "wallet" };
     expect(getActiveViewModality()).toBe("xr");
+  });
+});
+
+describe("getFrontendPlatform", () => {
+  afterEach(() => {
+    isElectrobunRuntime.mockReturnValue(false);
+  });
+
+  it("reports desktop when the Electrobun runtime is detected (not the dead __ELECTROBUN__ flag)", () => {
+    // Regression: the old check read window.__ELECTROBUN__, which the shell
+    // sets nowhere, so desktop was mis-reported as "web". It must use the
+    // real isElectrobunRuntime() signal instead.
+    isElectrobunRuntime.mockReturnValue(true);
+    expect(getFrontendPlatform()).toBe("desktop");
+  });
+
+  it("does not report desktop when not in the Electrobun runtime", () => {
+    isElectrobunRuntime.mockReturnValue(false);
+    // jsdom + no Capacitor native platform → web.
+    expect(getFrontendPlatform()).toBe("web");
   });
 });

--- a/packages/ui/src/platform/platform-guards.ts
+++ b/packages/ui/src/platform/platform-guards.ts
@@ -8,11 +8,10 @@
  */
 
 import { Capacitor } from "@capacitor/core";
+import { isElectrobunRuntime } from "../bridge/electrobun-runtime";
 
 declare global {
   interface Window {
-    /** Set by the Electrobun desktop shell. */
-    __ELECTROBUN__?: unknown;
     /** Set by the XR view-host (plugin-facewear / plugin-xr) inside a headset. */
     __elizaXRContext?: unknown;
   }
@@ -25,12 +24,17 @@ export type FrontendPlatform = "ios" | "android" | "web" | "desktop";
  * Detect the current frontend platform.
  *
  * Resolution order:
- * 1. `window.__ELECTROBUN__` — set by the Electrobun desktop shell.
+ * 1. Electrobun desktop shell — via `isElectrobunRuntime()` (the renderer's
+ *    `__electrobunWindowId`/`__electrobunWebviewId` + RPC bridge, the same
+ *    signal platform/init.ts uses). The legacy `window.__ELECTROBUN__` flag
+ *    this used to read is set NOWHERE in the shell, so desktop was silently
+ *    mis-reported as "web" (wrong frontendPlatform to the server + wrong
+ *    provider / runtime-class / available-views gating on desktop).
  * 2. Capacitor.getPlatform() — set by the Capacitor runtime on iOS/Android.
  * 3. Default: "web".
  */
 export function getFrontendPlatform(): FrontendPlatform {
-  if (typeof window !== "undefined" && window.__ELECTROBUN__) {
+  if (isElectrobunRuntime()) {
     return "desktop";
   }
   const getPlatform = (Capacitor as { getPlatform?: () => unknown })


### PR DESCRIPTION
`getFrontendPlatform()` gated desktop detection on `window.__ELECTROBUN__`, which the Electrobun shell sets **nowhere** — so the desktop app reported platform `'web'`, mis-reporting frontendPlatform to the server and mis-gating provider entries / local-inference runtime-class / available-views. Now uses `isElectrobunRuntime()` (the `__electrobunWindowId`/`__electrobunWebviewId` + RPC-bridge signal `platform/init.ts` already trusts). Dead `__ELECTROBUN__` window-type removed. +2 tests; caller suites green.

Found via the #10722 QA sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)