### PR TITLE
fix(core): connect SSRF fetches through pinned DNS

### DIFF
--- a/packages/agent/src/api/media-runtime.ts
+++ b/packages/agent/src/api/media-runtime.ts
@@ -9,7 +9,12 @@
  */
 
 import type { IAgentRuntime, Memory, Route } from "@elizaos/core";
-import { fetchRemoteMedia, logger } from "@elizaos/core";
+import {
+  fetchRemoteMedia,
+  logger,
+  nodeLookupFn,
+  nodePinnedFetch,
+} from "@elizaos/core";
 import {
   ensureThumbnailForStoredFile,
   gcUnreferencedMedia,
@@ -43,6 +48,8 @@ async function rehostRemoteMediaUrl(url: string): Promise<string | null> {
     const { buffer, contentType } = await fetchRemoteMedia({
       url,
       maxBytes: REHOST_MAX_BYTES,
+      lookupFn: nodeLookupFn,
+      pinnedFetchImpl: nodePinnedFetch,
     });
     return persistMediaBytes(buffer, contentType ?? "application/octet-stream")
       .url;

--- a/packages/core/src/media/fetch.ts
+++ b/packages/core/src/media/fetch.ts
@@ -11,6 +11,7 @@
 import {
 	fetchWithSsrfGuard,
 	type LookupFn,
+	type PinnedLookupFetchLike,
 	type SsrfPolicy,
 } from "../network/index.js";
 import { detectMime, extensionForMime } from "./mime.js";
@@ -47,6 +48,7 @@ export type FetchMediaOptions = {
 	timeoutMs?: number;
 	ssrfPolicy?: SsrfPolicy;
 	lookupFn?: LookupFn;
+	pinnedFetchImpl?: PinnedLookupFetchLike;
 };
 
 function stripQuotes(value: string): string {
@@ -120,6 +122,7 @@ async function fetchGuardedMedia(options: FetchMediaOptions): Promise<{
 			timeoutMs: options.timeoutMs,
 			policy: options.ssrfPolicy,
 			lookupFn: options.lookupFn,
+			pinnedFetchImpl: options.pinnedFetchImpl,
 		});
 	} catch (err) {
 		throw new MediaFetchError(

--- a/packages/core/src/network/fetch-guard.test.ts
+++ b/packages/core/src/network/fetch-guard.test.ts
@@ -90,3 +90,49 @@ describe("fetchWithSsrfGuard without a lookupFn (literal-host checks)", () => {
 		await release();
 	});
 });
+
+describe("fetchWithSsrfGuard with DNS pinning", () => {
+	it("passes the vetted pinned lookup to the transport", async () => {
+		let lookupCalls = 0;
+		const lookupFn = async () => {
+			lookupCalls += 1;
+			return [{ address: "93.184.216.34", family: 4 }];
+		};
+		const pinnedFetchImpl = vi.fn(async ({ lookup }) => {
+			const resolved = await new Promise<{ address: string; family: number }>(
+				(resolve, reject) => {
+					lookup("example.com", (error, address, family) => {
+						if (error) {
+							reject(error);
+							return;
+						}
+						if (typeof address !== "string" || typeof family !== "number") {
+							reject(new Error("expected single pinned address"));
+							return;
+						}
+						resolve({ address, family });
+					});
+				},
+			);
+			expect(resolved).toEqual({ address: "93.184.216.34", family: 4 });
+			return new Response("ok", { status: 200 });
+		});
+
+		const { response, release } = await fetchWithSsrfGuard({
+			url: "https://example.com/resource",
+			lookupFn,
+			pinnedFetchImpl,
+		});
+
+		expect(response.status).toBe(200);
+		expect(lookupCalls).toBe(1);
+		expect(pinnedFetchImpl).toHaveBeenCalledTimes(1);
+		expect(pinnedFetchImpl).toHaveBeenCalledWith(
+			expect.objectContaining({
+				addresses: ["93.184.216.34"],
+				url: expect.objectContaining({ hostname: "example.com" }),
+			}),
+		);
+		await release();
+	});
+});

--- a/packages/core/src/network/fetch-guard.ts
+++ b/packages/core/src/network/fetch-guard.ts
@@ -9,6 +9,8 @@ import {
 	isBlockedHostname,
 	isPrivateIpAddress,
 	type LookupFn,
+	type PinnedHostname,
+	type PinnedLookup,
 	resolvePinnedHostname,
 	resolvePinnedHostnameWithPolicy,
 	SsrfBlockedError,
@@ -23,6 +25,7 @@ type FetchLike = (
 export type GuardedFetchOptions = {
 	url: string;
 	fetchImpl?: FetchLike;
+	pinnedFetchImpl?: PinnedLookupFetchLike;
 	init?: RequestInit;
 	maxRedirects?: number;
 	timeoutMs?: number;
@@ -31,6 +34,17 @@ export type GuardedFetchOptions = {
 	lookupFn?: LookupFn;
 };
 
+export type PinnedLookupFetchParams = {
+	url: URL;
+	init: RequestInit;
+	lookup: PinnedLookup;
+	addresses: string[];
+};
+
+export type PinnedLookupFetchLike = (
+	params: PinnedLookupFetchParams,
+) => Promise<Response>;
+
 export type GuardedFetchResult = {
 	response: Response;
 	finalUrl: string;
@@ -38,6 +52,36 @@ export type GuardedFetchResult = {
 };
 
 const DEFAULT_MAX_REDIRECTS = 3;
+
+type NodePinnedFetchDefaults = {
+	lookupFn: LookupFn;
+	pinnedFetchImpl: PinnedLookupFetchLike;
+};
+
+let nodePinnedFetchDefaults:
+	| Promise<NodePinnedFetchDefaults | null>
+	| undefined;
+
+function isNodeLikeRuntime(): boolean {
+	const runtime = globalThis as {
+		Bun?: unknown;
+		process?: { versions?: { node?: string } };
+	};
+	return Boolean(runtime.Bun || runtime.process?.versions?.node);
+}
+
+async function loadNodePinnedFetchDefaults(): Promise<NodePinnedFetchDefaults | null> {
+	if (!isNodeLikeRuntime()) {
+		return null;
+	}
+	nodePinnedFetchDefaults ??= import("./node-pinned-fetch.js")
+		.then(({ nodeLookupFn, nodePinnedFetch }) => ({
+			lookupFn: nodeLookupFn,
+			pinnedFetchImpl: nodePinnedFetch,
+		}))
+		.catch(() => null);
+	return nodePinnedFetchDefaults;
+}
 
 function isRedirectStatus(status: number): boolean {
 	return (
@@ -104,6 +148,13 @@ export async function fetchWithSsrfGuard(
 	if (!fetcher) {
 		throw new Error("fetch is not available");
 	}
+	const nodeDefaults =
+		!params.pinnedFetchImpl && !params.fetchImpl
+			? await loadNodePinnedFetchDefaults()
+			: null;
+	const lookupFn = params.lookupFn ?? nodeDefaults?.lookupFn;
+	const pinnedFetchImpl =
+		params.pinnedFetchImpl ?? nodeDefaults?.pinnedFetchImpl;
 
 	const maxRedirects =
 		typeof params.maxRedirects === "number" &&
@@ -143,21 +194,20 @@ export async function fetchWithSsrfGuard(
 		}
 
 		try {
-			if (params.lookupFn) {
+			let pinned: PinnedHostname | undefined;
+			if (lookupFn) {
 				// A DNS lookup is available → pin the resolved address(es). This is
 				// the strongest mode: it also defends against DNS rebinding.
 				const usePolicy = Boolean(
 					params.policy?.allowPrivateNetwork ||
 						params.policy?.allowedHostnames?.length,
 				);
-				if (usePolicy) {
-					await resolvePinnedHostnameWithPolicy(parsedUrl.hostname, {
-						lookupFn: params.lookupFn,
-						policy: params.policy,
-					});
-				} else {
-					await resolvePinnedHostname(parsedUrl.hostname, params.lookupFn);
-				}
+				pinned = usePolicy
+					? await resolvePinnedHostnameWithPolicy(parsedUrl.hostname, {
+							lookupFn,
+							policy: params.policy,
+						})
+					: await resolvePinnedHostname(parsedUrl.hostname, lookupFn);
 			} else {
 				// No lookupFn (e.g. environment-agnostic core, which has no node:dns
 				// to pin with): fall back to synchronous literal-host checks — block
@@ -188,14 +238,21 @@ export async function fetchWithSsrfGuard(
 				}
 			}
 
-			// Note: In browser environments, we can't pin DNS, so we rely on policy validation only
 			const init: RequestInit = {
 				...(params.init ? { ...params.init } : {}),
 				redirect: "manual",
 				...(signal ? { signal } : {}),
 			};
 
-			const response = await fetcher(parsedUrl.toString(), init);
+			const response =
+				pinned && pinnedFetchImpl
+					? await pinnedFetchImpl({
+							url: parsedUrl,
+							init,
+							lookup: pinned.lookup,
+							addresses: pinned.addresses,
+						})
+					: await fetcher(parsedUrl.toString(), init);
 
 			if (isRedirectStatus(response.status)) {
 				const location = response.headers.get("location");

--- a/packages/core/src/network/index.ts
+++ b/packages/core/src/network/index.ts
@@ -8,7 +8,11 @@ export {
 	fetchWithSsrfGuard,
 	type GuardedFetchOptions,
 	type GuardedFetchResult,
+	type PinnedLookupFetchLike,
+	type PinnedLookupFetchParams,
 } from "./fetch-guard.js";
+
+export { nodeLookupFn, nodePinnedFetch } from "./node-pinned-fetch.js";
 
 export {
 	assertPublicHostname,
@@ -17,6 +21,7 @@ export {
 	isPrivateIpAddress,
 	type LookupFn,
 	type PinnedHostname,
+	type PinnedLookup,
 	resolvePinnedHostname,
 	resolvePinnedHostnameWithPolicy,
 	SsrfBlockedError,

--- a/packages/core/src/network/node-pinned-fetch.ts
+++ b/packages/core/src/network/node-pinned-fetch.ts
@@ -1,0 +1,172 @@
+import { Buffer } from "node:buffer";
+import { lookup as dnsLookup } from "node:dns/promises";
+import {
+	type RequestOptions as HttpRequestOptions,
+	type IncomingMessage,
+	request as requestHttp,
+} from "node:http";
+import { request as requestHttps } from "node:https";
+import type { PinnedLookupFetchLike } from "./fetch-guard.js";
+import type { LookupFn } from "./ssrf.js";
+
+export const nodeLookupFn: LookupFn = async (hostname, options) => {
+	const results = await dnsLookup(hostname, options);
+	return results.map((entry) => ({
+		address: entry.address,
+		family: entry.family,
+	}));
+};
+
+function toRequestHeaders(headers: Headers): Record<string, string> {
+	const normalized: Record<string, string> = {};
+	headers.forEach((value, key) => {
+		normalized[key] = value;
+	});
+	return normalized;
+}
+
+async function requestBodyToBuffer(
+	body: NonNullable<RequestInit["body"]>,
+): Promise<Buffer> {
+	if (typeof body === "string") return Buffer.from(body);
+	if (body instanceof ArrayBuffer) return Buffer.from(body);
+	if (ArrayBuffer.isView(body)) {
+		return Buffer.from(body.buffer, body.byteOffset, body.byteLength);
+	}
+	return Buffer.from(await new Response(body).arrayBuffer());
+}
+
+function nodeReadableChunkToUint8Array(
+	chunk: Buffer | Uint8Array | string,
+): Uint8Array {
+	if (typeof chunk === "string") return new Uint8Array(Buffer.from(chunk));
+	return new Uint8Array(chunk);
+}
+
+function incomingMessageToWebBody(
+	stream: IncomingMessage,
+	cleanup: () => void,
+): BodyInit {
+	const iterator = stream[Symbol.asyncIterator]() as AsyncIterator<
+		Buffer | Uint8Array | string
+	>;
+
+	return new ReadableStream<Uint8Array>({
+		async pull(controller) {
+			try {
+				const next = await iterator.next();
+				if (next.done) {
+					cleanup();
+					controller.close();
+					return;
+				}
+				controller.enqueue(nodeReadableChunkToUint8Array(next.value));
+			} catch (error) {
+				cleanup();
+				controller.error(error);
+			}
+		},
+		async cancel(reason) {
+			cleanup();
+			await iterator.return?.();
+			stream.destroy(reason instanceof Error ? reason : undefined);
+		},
+	});
+}
+
+function responseFromIncomingMessage(
+	response: IncomingMessage,
+	cleanup: () => void,
+): Response {
+	const headers = new Headers();
+	for (const [key, value] of Object.entries(response.headers)) {
+		if (Array.isArray(value)) {
+			for (const item of value) headers.append(key, item);
+		} else if (typeof value === "string") {
+			headers.set(key, value);
+		}
+	}
+
+	const status = response.statusCode ?? 500;
+	const init = {
+		status,
+		statusText: response.statusMessage,
+		headers,
+	} satisfies ResponseInit;
+	if (status === 204 || status === 205 || status === 304) {
+		cleanup();
+		return new Response(null, init);
+	}
+	return new Response(incomingMessageToWebBody(response, cleanup), init);
+}
+
+export const nodePinnedFetch: PinnedLookupFetchLike = async ({
+	url,
+	init,
+	lookup,
+}) => {
+	const method = (init.method ?? "GET").toUpperCase();
+	const headers = new Headers(init.headers);
+	let body: Buffer | undefined;
+	if (init.body !== undefined && init.body !== null) {
+		body = await requestBodyToBuffer(init.body);
+		if (!headers.has("content-length")) {
+			headers.set("content-length", String(body.length));
+		}
+	}
+
+	const requestFn = url.protocol === "https:" ? requestHttps : requestHttp;
+	const requestOptions: HttpRequestOptions = {
+		protocol: url.protocol,
+		hostname: url.hostname,
+		port: url.port ? Number(url.port) : undefined,
+		method,
+		path: `${url.pathname}${url.search}`,
+		headers: toRequestHeaders(headers),
+		lookup: lookup as HttpRequestOptions["lookup"],
+		...(url.protocol === "https:" ? { servername: url.hostname } : undefined),
+	};
+
+	return new Promise<Response>((resolve, reject) => {
+		let settled = false;
+		const signal = init.signal ?? undefined;
+
+		const cleanupSignal = () => {
+			signal?.removeEventListener("abort", onAbort);
+		};
+
+		const rejectOnce = (error: Error) => {
+			if (settled) return;
+			settled = true;
+			cleanupSignal();
+			reject(error);
+		};
+
+		const onAbort = () => {
+			request.destroy(new DOMException("Aborted", "AbortError"));
+		};
+
+		const request = requestFn(requestOptions, (response) => {
+			if (settled) return;
+			settled = true;
+			resolve(responseFromIncomingMessage(response, cleanupSignal));
+		});
+
+		request.on("error", (error) => {
+			rejectOnce(error);
+		});
+
+		if (signal) {
+			if (signal.aborted) {
+				onAbort();
+			} else {
+				signal.addEventListener("abort", onAbort, { once: true });
+			}
+		}
+
+		if (body) {
+			request.write(body);
+		}
+		request.end();
+	});
+};

--- a/packages/core/src/network/ssrf.ts
+++ b/packages/core/src/network/ssrf.ts
@@ -328,7 +328,7 @@ export function createPinnedLookup(params: {
 export type PinnedHostname = {
 	hostname: string;
 	addresses: string[];
-	lookup: unknown;
+	lookup: PinnedLookup;
 };
 
 /**


### PR DESCRIPTION
Fixes #11147.\n\n## Summary\n- make etchWithSsrfGuard keep the esolvePinnedHostname* result and pass its pinned lookup into the actual transport when a pinned transport is available\n- add a Node/Bun HTTP(S) pinned transport (
odePinnedFetch) plus 
odeLookupFn; global Node/Bun guarded fetches load it lazily unless a caller supplies a custom etchImpl\n- thread pinned transports through etchRemoteMedia, and explicitly wire agent media rehosting to the Node lookup/transport\n- add a regression test proving the guard hands the vetted pinned lookup to transport instead of merely validating before normal fetch\n\n## Evidence\n- un install -> completed successfully after rebase onto origin/develop\n- un run --cwd packages/core test -- src/network/fetch-guard.test.ts src/network/ssrf.test.ts src/media/fetch.test.ts -> 3 files / 28 tests passed\n- un run --cwd packages/core typecheck -> passed\n- unx @biomejs/biome@2.5.1 check packages/core/src/network/fetch-guard.ts packages/core/src/network/fetch-guard.test.ts packages/core/src/network/node-pinned-fetch.ts packages/core/src/network/ssrf.ts packages/core/src/network/index.ts packages/core/src/media/fetch.ts packages/agent/src/api/media-runtime.ts -> passed\n- un run --cwd packages/core build -> Node, browser, edge, and testing bundles built successfully\n- git diff --check origin/develop...HEAD -> passed\n\n## Known non-change blocker\n- un run --cwd packages/agent typecheck is blocked in this worktree by missing optional/workspace modules: @elizaos/plugin-streaming, @elizaos/plugin-background-runner, and @elizaos/cloud-routing. The errors are module-resolution failures outside the touched files; core typecheck/build passed.\n\nScreenshots/video are N/A: this is a backend/runtime SSRF transport fix with unit/build evidence.