### PR TITLE
fix(cloud): claim escrow before generic refund so it cannot double-spend vs a racing payout (#11167)

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/influencer-marketplace.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/influencer-marketplace.test.ts
@@ -354,7 +354,7 @@ describe("Influencer marketplace escrow (#10687)", () => {
     expect(await earnings(inf.userId)).toBeCloseTo(25, 2);
   });
 
-  test("refund failure leaves the prior status; retry refunds exactly once", async () => {
+  test("refund failure leaves the claimed `refunding` status; retry resumes and refunds exactly once", async () => {
     if (!pgliteReady) return;
     const adv = await seedOrgUser("50.00");
     const inf = await seedProfile();
@@ -373,10 +373,12 @@ describe("Influencer marketplace escrow (#10687)", () => {
       throw new Error("simulated refund outage");
     };
     try {
-      // Refund fails → the booking MUST NOT be marked rejected.
+      // Refund fails AFTER the claim → the booking MUST NOT be marked rejected;
+      // it rests in `refunding` (the claim fences out deliver/approve) so the
+      // same operation can resume. (#11167)
       const failed = await service.rejectBooking(id, inf.userId);
       expect(failed.ok).toBe(false);
-      expect((await service.getBooking(id))?.status).toBe("offered");
+      expect((await service.getBooking(id))?.status).toBe("refunding");
       expect(await orgBalance(adv.orgId)).toBeCloseTo(30, 2);
     } finally {
       creditsService.refundCredits = originalRefund;
@@ -520,5 +522,85 @@ describe("Influencer marketplace escrow (#10687)", () => {
     expect(resumed.ok).toBe(true);
     expect(await earnings(inf.userId)).toBeCloseTo(30, 2);
     expect(await orgBalance(adv.orgId)).toBeCloseTo(70, 2);
+  });
+
+  // #11167 — the GENERIC refund (offer/accept fork) must claim the booking
+  // before moving money, exactly like the #11116 `delivered` fork. Before the
+  // claim, refund() was refund-then-CAS: it read `accepted`, committed the
+  // refund, and only then CAS'd the status — so during its read→refund gap a
+  // concurrent deliver + approve could pay the influencer out of the SAME
+  // escrow (advertiser refunded AND influencer paid). The gated refundCredits
+  // below deterministically parks the reject inside that gap while the
+  // deliver + approve race in; the claim CAS (`accepted → refunding`) now
+  // fences them out before any money moves.
+  test("generic refund from accepted cannot double-spend vs racing deliver+approve (#11167)", async () => {
+    if (!pgliteReady) return;
+    const adv = await seedOrgUser("100.00");
+    const inf = await seedProfile();
+    const { booking } = await service.createBooking({
+      advertiserOrgId: adv.orgId,
+      profileId: inf.profileId,
+      brief: "b",
+      amount: 40,
+      createdByUserId: adv.userId,
+    });
+    const id = booking?.id as string;
+    await service.acceptBooking(id, inf.userId);
+    // Escrow funded: advertiser debited 40 → 60; nothing paid/refunded yet.
+    expect(await orgBalance(adv.orgId)).toBeCloseTo(60, 2);
+    expect(await earnings(inf.userId)).toBe(0);
+
+    // Park the FIRST refundCredits call on a manual gate: the reject has done
+    // its read (+claim, with the fix) but its money move is frozen mid-flight.
+    const originalRefund = creditsService.refundCredits.bind(creditsService);
+    let releaseGate: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      releaseGate = resolve;
+    });
+    let gateReached = false;
+    creditsService.refundCredits = async (params) => {
+      if (!gateReached) {
+        gateReached = true;
+        await gate;
+      }
+      return originalRefund(params);
+    };
+
+    const rejectPromise = service.rejectBooking(id, inf.userId);
+    try {
+      // Wait until the reject is actually parked at refundCredits.
+      const deadline = Date.now() + 5_000;
+      while (!gateReached && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+      expect(gateReached).toBe(true);
+
+      // While the refund is in its read→money gap, race the payout path in.
+      const submitted = await service.submitDeliverable(id, inf.userId, "https://x/post");
+      const approved = await service.approveBooking(id, adv.orgId);
+
+      releaseGate();
+      const rejected = await rejectPromise;
+
+      const paid = await earnings(inf.userId); // influencer payout (0 or 40)
+      const bal = await orgBalance(adv.orgId); // advertiser (60 held, or 100 refunded)
+      const refunded = bal >= 99.99; // refund returned the 40
+
+      // The invariant: one escrow NEVER funds both a refund and a payout.
+      expect(paid > 0 && refunded).toBe(false);
+
+      // With the claim, the reject owns the booking: deliver/approve are
+      // fenced out, the refund wins, and the advertiser is made whole.
+      expect(submitted.ok).toBe(false);
+      expect(approved.ok).toBe(false);
+      expect(rejected.ok).toBe(true);
+      expect((await service.getBooking(id))?.status).toBe("rejected");
+      expect(bal).toBeCloseTo(100, 2);
+      expect(paid).toBe(0);
+    } finally {
+      releaseGate();
+      creditsService.refundCredits = originalRefund;
+      await rejectPromise;
+    }
   });
 });

--- a/packages/cloud/shared/src/lib/services/influencer-marketplace.ts
+++ b/packages/cloud/shared/src/lib/services/influencer-marketplace.ts
@@ -337,13 +337,20 @@ export class InfluencerMarketplaceService {
   }
 
   /**
-   * Refund the advertiser (deliverable rejected, influencer declined, or cancel).
+   * Refund the advertiser (influencer declined, or advertiser cancel).
    *
-   * Refund-then-finalize: the refund runs BEFORE the status move. The refund is
-   * idempotent on the booking id (one refund per booking, ever), so a
-   * crash/retry refunds at most once, and a refund failure leaves the prior
-   * status so the operation can be retried — this can never mark a booking
-   * rejected/cancelled while the advertiser is still debited.
+   * Claim-then-refund (#11167, mirroring the #11116 `delivered` fork): the
+   * offer/accept refunds ALSO race a payout — `accepted` is one hop from the
+   * payable `delivered` state, so a refund that moves money before claiming
+   * the booking can collide with a concurrent deliver + approve and pay one
+   * escrow out twice. So the refund first CLAIMS the booking with an atomic
+   * CAS `<from> → refunding` — once claimed, no other transition can enter
+   * (accept needs `offered`, submitDeliverable needs `accepted`, approve needs
+   * `delivered`/`approving`) — and only then moves money. The refund is
+   * idempotent on the booking id (one refund per booking, ever) and a refund
+   * failure leaves the booking `refunding` so the operation can be resumed —
+   * this can never mark a booking rejected/cancelled while the advertiser is
+   * still debited, and never refunds an escrow a payout already claimed.
    */
   private async refund(
     id: string,
@@ -352,7 +359,20 @@ export class InfluencerMarketplaceService {
   ): Promise<BookingResult> {
     const booking = await this.getBooking(id);
     if (!booking) return { ok: false, error: "Booking not found" };
-    if (!allowedFrom.includes(booking.status)) {
+
+    if (allowedFrom.includes(booking.status)) {
+      const claimed = await this.transition(id, booking.status, "refunding");
+      if (!claimed) {
+        // Lost the claim to a concurrent transition — re-read and continue
+        // only if a refund claim (concurrent or crashed) owns the booking.
+        const current = await this.getBooking(id);
+        if (current?.status !== "refunding") {
+          return { ok: false, error: "Not in a refundable state" };
+        }
+      }
+    } else if (booking.status !== "refunding") {
+      // `refunding` is a resume (a prior attempt claimed but hadn't finished
+      // refunding); anything else is not ours to refund.
       return { ok: false, error: "Not in a refundable state" };
     }
 
@@ -365,40 +385,27 @@ export class InfluencerMarketplaceService {
         metadata: { kind: "influencer_refund", bookingId: id },
       });
     } catch (error) {
-      logger.error("[Influencer] escrow refund failed; booking left in prior status for retry", {
+      logger.error("[Influencer] escrow refund failed; booking left refunding for retry", {
         bookingId: id,
-        from: booking.status,
         to,
         error,
       });
       return { ok: false, error: "Refund failed — retry" };
     }
 
-    const moved = await this.transition(id, booking.status, to, { resolved_at: new Date() });
+    const moved = await this.transition(id, "refunding", to, { resolved_at: new Date() });
     if (moved) return { ok: true, booking: moved };
 
-    // The refund is committed, so the booking MUST end in a refunded state.
+    // The refund is committed, so the booking MUST already be in a refunded
+    // state: once the claim is won nothing but a concurrent resume of this
+    // refund can move the booking.
     const current = await this.getBooking(id);
-    if (!current) return { ok: false, error: "Booking not found" };
-    if (current.status === "rejected" || current.status === "cancelled") {
-      return { ok: true, booking: current }; // a concurrent refund path finalized first
+    if (current && (current.status === "rejected" || current.status === "cancelled")) {
+      return { ok: true, booking: current }; // a concurrent resume finalized first
     }
-    if (current.status !== "approved") {
-      // A non-money transition (e.g. accept) raced in; force-finalize so the
-      // booking state agrees with the committed refund.
-      const forced = await this.transition(id, current.status, to, { resolved_at: new Date() });
-      if (forced) {
-        logger.warn("[Influencer] booking force-finalized after refund raced a transition", {
-          bookingId: id,
-          racedStatus: current.status,
-          to,
-        });
-        return { ok: true, booking: forced };
-      }
-    }
-    logger.error("[Influencer] refund committed but booking could not be finalized", {
+    logger.error("[Influencer] refund committed but booking moved off refunding", {
       bookingId: id,
-      status: current.status,
+      status: current?.status,
       to,
     });
     return { ok: false, error: "Booking changed state during refund" };
@@ -422,12 +429,12 @@ export class InfluencerMarketplaceService {
   }
 
   /**
-   * Refund side of the `delivered` money fork (#11116). Unlike the offer/accept
-   * refunds (which can't collide with a payout), rejecting a *delivered*
+   * Refund side of the `delivered` money fork (#11116). Rejecting a *delivered*
    * booking races `approveBooking` for the same escrow, so it must CLAIM the
    * fork (CAS `delivered → refunding`) BEFORE refunding — exactly one of
    * approve/reject wins, the loser refunds nothing. Resumable from `refunding`
-   * (the refund is idempotent on the booking id). Mirrors approveBooking.
+   * (the refund is idempotent on the booking id). Mirrors approveBooking; the
+   * generic offer/accept `refund()` uses the same claim (#11167).
    */
   private async rejectDelivered(id: string, booking: InfluencerBooking): Promise<BookingResult> {
     if (booking.status === "delivered") {


### PR DESCRIPTION
Fixes #11167 — **HIGH, money path: maintainer merge please (do not self-merge).** `[cloud-money]`

## Bug

The generic `refund()` in `packages/cloud/shared/src/lib/services/influencer-marketplace.ts` — routing `rejectBooking` (`allowedFrom=[offered, accepted]`) and `cancelBooking` (`[offered]`) — was **refund-then-CAS**: plain `getBooking` read + `allowedFrom` check, `creditsService.refundCredits()` commits money, and only THEN the atomic `transition(status → to)`.

During the read→refund gap a booking can move `accepted → delivered → approving`, and `approveBooking` pays the influencer — so **one funded escrow finances BOTH a refund (advertiser) and a payout (influencer)**. `refundCredits` idempotency (`influencer_refund_<id>`) blocks repeat refunds, not this refund-vs-payout collision. The `delivered` fork was fenced exactly against this by #11116 (`rejectDelivered` claims `delivered → refunding` BEFORE refunding); the offer/accept fork was left open — its own comment ("can't collide with a payout") was the wrong assumption, since `accepted` is one hop from payable `delivered`.

## Fix — mirror #11116's claim-then-refund, reusing the existing `refunding` status

- **Claim before money:** after the read, CAS `<from> → refunding`. On a lost claim, re-read and continue only if the booking is `refunding` (a concurrent/crashed claim to resume); otherwise refuse. A booking already `refunding` is admitted directly as a resume.
- **Money only after owning the claim:** `refundCredits` failure now leaves the booking `refunding` for retry (the claim fences deliver/approve out) instead of restoring the prior status.
- **Finalize** with CAS `refunding → to` (+`resolved_at`); on a miss, succeed iff a concurrent resume already finalized to `rejected`/`cancelled`.
- **Deleted the force-finalize fallback:** once the claim is won nothing can race in (accept needs `offered`, submitDeliverable needs `accepted`, approve needs `delivered`/`approving`) — that branch was the approving-hijack half of the bug.

`refunding` already exists in the schema enum (`db/schemas/influencer-marketplace.ts`) and the SDK DTO (`cloud/sdk/src/types.ts`) — no schema/DTO change.

## Regression test (real PGlite, deterministic interleave)

`generic refund from accepted cannot double-spend vs racing deliver+approve (#11167)`: seeds advertiser org 100, funds a 40 booking, accepts; monkey-patches `creditsService.refundCredits` so the first call parks on a manual gate (the suite's existing pattern) — freezing `rejectBooking` inside its read(+claim)→money gap; races `submitDeliverable` + `approveBooking` in; releases the gate; asserts the conservation invariant **never (refunded AND paid)**, plus with the fix: submit/approve `ok:false`, reject `ok:true`, final status `rejected`, advertiser balance 100, influencer earnings 0.

Also updated the refund-outage test to the new resting state: failure leaves `refunding` (not the prior status) and the retry resumes the claim, refunding exactly once.

## Proof — the test fails without the source change

Fixed tree (both files):
```
 15 pass
 0 fail
 83 expect() calls
Ran 15 tests across 1 file. [3.73s]
```

Source file reverted to `origin/develop` (tests kept):
```
(fail) … > refund failure leaves the claimed `refunding` status; retry resumes and refunds exactly once
(fail) … > generic refund from accepted cannot double-spend vs racing deliver+approve (#11167)
 13 pass
 2 fail
```
On the unfixed source the race lands **both** money moves: influencer earnings 40 AND advertiser refunded to 100 from one 40 escrow — the conservation assertion (`expect(paid > 0 && refunded).toBe(false)`, test line ~590) is the failure.

## Verification

- `bun test src/lib/services/__tests__/influencer-marketplace.test.ts` → 15 pass / 0 fail (full suite incl. #11116 races, funding-crash resumes, idempotency retries).
- `bun run --cwd packages/cloud/shared typecheck` → clean (zero errors).
- `bunx biome check` on both touched files → clean.

## Evidence (PR_EVIDENCE.md)

- Real domain artifacts: the tests run the real service against real Drizzle/PGlite rows — org `credit_balance`, `credit_transactions` (keyed `influencer_refund_<id>`), `redeemable_earnings`, and booking-status rows are asserted directly; the fail-without-fix run above shows the actual double-spend landing in the DB.
- Concurrency covered deterministically (gated in-flight refund vs racing deliver+approve), plus error paths (refund outage → `refunding` resume), repeat-call idempotency, and denied-state paths.
- Screenshots / video / LLM trajectories: N/A — server-only money-path service change; no UI surface, no model in the path.

## Residual risk

- A crash after the claim but before `refundCredits` leaves a booking parked in `refunding` with no automatic sweeper — same recovery posture as #11116's `rejectDelivered` and `approving` (any client retry of reject/cancel resumes and completes the refund). Escrow-safe: money can no longer be lost or doubled, only delayed until a retry.
- A `refunding` booking claimed via `rejectDelivered` could in principle be resumed by `cancelBooking` and finalize `cancelled` instead of `rejected` — both are terminal refunded states, money moves exactly once (keyed refund), so this is cosmetic status divergence only.
- The pre-existing #11167 "related residuals" (fundBooking crash-window stranded debit; failure-path DELETE race) are separate MED findings, intentionally not folded into this single-concern fix.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>