### PR TITLE
fix(ci): enable git long paths on vault-ci windows leg

### DIFF
--- a/.github/workflows/vault-ci.yaml
+++ b/.github/workflows/vault-ci.yaml
@@ -49,6 +49,16 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
+      # Some committed evidence files under .github/issue-evidence/** exceed the
+      # Windows 260-char MAX_PATH default, which makes actions/checkout abort with
+      # "unable to create file ...: Filename too long" and fails the whole
+      # windows-latest leg before any test runs. Enable git core.longpaths on the
+      # Windows runner (git config runs fine before the repo exists) so the
+      # working tree materializes.
+      - name: Enable Git long paths (Windows)
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Setup Bun


### PR DESCRIPTION
## Problem
The `windows-latest` leg of **vault-ci** is a genuine red on develop (not queue starvation). It fails at `actions/checkout` before any test runs:

```
error: unable to create file .github/issue-evidence/9967-swabble-androidtest/android-test-results/JejuWallet_Pixel6(AVD) - 14/logcat-...permissionResult_matchesRealMicrophoneGrantAndSpeechRecognizerAvailability.txt: Filename too long
The process 'C:\Program Files\Git\bin\git.exe' failed with exit code 1
```

Committed Android logcat evidence files under `.github/issue-evidence/**` exceed Windows' 260-char `MAX_PATH` default (5 files >237 chars), so git can't materialize the working tree on Windows and the whole leg goes red.

## Fix
Add a `git config --system core.longpaths true` step gated on `runner.os == 'Windows'`, before checkout (git config runs fine before the repo exists). This directly resolves the observed `git.exe ... Filename too long` error. macOS/Linux legs are unaffected.

## Scope / notes
- One file, Windows-leg only; no test logic changed.
- `windows-ci.yml` already handles this via the registry `LongPathsEnabled` DWORD; the release/nightly Windows workflows (`nightly.yml`, `release-*`) still lack either mechanism — cheap follow-up if they start hitting it, but they aren't PR-blocking.
- Verified with `actionlint` (clean).

Part of the CI green-board push (#11108). — nubs-cloud (laptop/deploy lane)