### PR TITLE
fix(cloud): net won-dispute reinstatements out of the clawback tally (#11155)

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts
@@ -593,6 +593,56 @@ describe("CreditsService.clawbackCredits (#10920)", () => {
     },
     PGLITE_TIMEOUT,
   );
+
+  test(
+    "getClawedBackUsdForPaymentIntent nets won-dispute reinstatements (#11155)",
+    async () => {
+      if (!pgliteReady) return;
+      await seedOrg("100");
+
+      // Dispute opens: Stripe withdraws the funds → dispute clawback tagged
+      // with the payment intent (mirrors handleChargeDisputeFundsWithdrawn).
+      await creditsService.clawbackCredits({
+        organizationId: ORG_ID,
+        amount: 10,
+        description: "dispute clawback",
+        stripePaymentIntentId: "stripe:dispute:dp_r1",
+        metadata: { payment_intent_id: "pi_r1" },
+      });
+      expect(await creditsService.getClawedBackUsdForPaymentIntent("pi_r1")).toBeCloseTo(10, 6);
+
+      // Platform wins the dispute: funds_reinstated writes a `refund` row
+      // (mirrors handleChargeDisputeFundsReinstated in stripe-event.ts).
+      await creditsService.refundCredits({
+        organizationId: ORG_ID,
+        amount: 10,
+        description: "Stripe charge.dispute.funds_reinstated reinstatement — dispute dp_r1",
+        stripePaymentIntentId: "stripe:dispute:dp_r1:reinstated",
+        metadata: {
+          payment_intent_id: "pi_r1",
+          source: "charge.dispute.funds_reinstated",
+        },
+      });
+
+      // The tally nets to 0 so a later charge.refunded claws the FULL refund
+      // delta instead of under-clawing by the reinstated amount.
+      expect(await creditsService.getClawedBackUsdForPaymentIntent("pi_r1")).toBeCloseTo(0, 6);
+
+      // An ordinary (non-reinstatement) refund tagged with the same payment
+      // intent must NOT reduce the tally.
+      await creditsService.refundCredits({
+        organizationId: ORG_ID,
+        amount: 5,
+        description: "unrelated refund",
+        metadata: { payment_intent_id: "pi_r1" },
+      });
+      expect(await creditsService.getClawedBackUsdForPaymentIntent("pi_r1")).toBeCloseTo(0, 6);
+
+      // Balance: 100 - 10 (clawback) + 10 (reinstatement) + 5 (refund) = 105.
+      expect(await getBalance()).toBeCloseTo(105, 6);
+    },
+    PGLITE_TIMEOUT,
+  );
 });
 
 // Loud guard: PGlite is in-process (no network), so `pgliteReady` must be true.

--- a/packages/cloud/shared/src/lib/services/credits.ts
+++ b/packages/cloud/shared/src/lib/services/credits.ts
@@ -1001,6 +1001,14 @@ export class CreditsService {
    * `clawback` debits tagged with it). Lets the refund handler claw back only the
    * DELTA of a cumulative `amount_refunded` across multiple partial refunds
    * without double-charging. (#10920)
+   *
+   * Won-dispute reinstatements (the `refund` row that
+   * handleChargeDisputeFundsReinstated writes with
+   * metadata.source = 'charge.dispute.funds_reinstated') NET AGAINST the tally:
+   * clawback rows carry a negative amount (so `-amount` adds), reinstatement
+   * refunds carry a positive amount (so `-amount` subtracts). Without netting,
+   * a refund that follows a won dispute would see the stale dispute clawback
+   * as "already clawed" and under-claw by that amount. (#11155)
    */
   async getClawedBackUsdForPaymentIntent(paymentIntentId: string): Promise<number> {
     const rows = await sqlRows<{ total: string | number | null }>(
@@ -1008,8 +1016,11 @@ export class CreditsService {
       sql`
         SELECT COALESCE(SUM(-amount), 0) AS total
         FROM credit_transactions
-        WHERE type = 'clawback'
-          AND metadata->>'payment_intent_id' = ${paymentIntentId}
+        WHERE metadata->>'payment_intent_id' = ${paymentIntentId}
+          AND (
+            type = 'clawback'
+            OR (type = 'refund' AND metadata->>'source' = 'charge.dispute.funds_reinstated')
+          )
       `,
     );
     return parseNumeric(rows[0]?.total ?? 0, "clawed_back_total");


### PR DESCRIPTION
Fixes #11155 (MED, money path).

## Bug

`getClawedBackUsdForPaymentIntent` (`packages/cloud/shared/src/lib/services/credits.ts`) summed only `type='clawback'` rows tagged with the payment intent. It ignored the positive `type='refund'` reinstatement row that `handleChargeDisputeFundsReinstated` (`packages/cloud/api/src/queue/stripe-event.ts`) writes with `metadata.source='charge.dispute.funds_reinstated'` when the platform wins a dispute.

Sequence that loses money:
1. Dispute opens → `charge.dispute.funds_withdrawn` claws back \$X (tally = X).
2. Platform wins → `charge.dispute.funds_reinstated` refunds \$X back to the org (tally still = X — stale).
3. Later `charge.refunded` on the same payment intent computes its delta against the stale tally and **under-claws by \$X** — the platform eats the loss.

## Fix (read-path only)

Include the reinstatement refund rows in the tally's `SUM(-amount)`:

- clawback rows carry a **negative** amount → `-amount` adds to the tally;
- reinstatement refunds carry a **positive** amount → `-amount` subtracts;

so the tally nets to the true outstanding clawed-back total. Ordinary refunds tagged with the same payment intent are excluded (filtered on `metadata->>'source'`), so only the dispute-reinstatement compensation nets.

The write-path alternative (a positive "clawback" row at reinstatement time) is blocked by `clawbackCredits`' `amount <= 0` guard; this read-path netting keeps the ledger rows semantically honest (`refund` stays a refund).

## Test — real PGlite, proves fail-without-fix

`packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts` → "getClawedBackUsdForPaymentIntent nets won-dispute reinstatements (#11155)":

- seed org \$100; claw \$10 for a dispute (`stripe:dispute:dp_r1`, `payment_intent_id: pi_r1`) → tally = 10 ✔
- write the reinstatement `refund` exactly as the stripe-event handler does (`source: charge.dispute.funds_reinstated`) → **tally nets to 0** ✔
- an ordinary refund tagged with the same payment intent does **not** reduce the tally ✔
- balance asserted to the cent (100 − 10 + 10 + 5 = 105) ✔

**Red without the source change** (source stashed, test kept):

```
error: expect(received).toBeCloseTo(expected, precision)
Expected: 0
Received: 10
(fail) ... nets won-dispute reinstatements (#11155)
 15 pass / 1 fail
```

**Green with the fix:** `16 pass, 0 fail, 76 expect() calls` (whole `credits-reconcile` suite).

## Evidence

- Real-path test: real PGlite DB, real `clawbackCredits`/`refundCredits` SQL (FOR UPDATE lock, atomic balance movement, `credit_transactions` insert), balances read back from the DB — no mocks; suite hard-fails if PGlite doesn't init (never a silent skip).
- Typecheck: `bun run --cwd packages/cloud/shared typecheck` → no errors in touched files (pre-existing transitive-import noise only, per package CLAUDE.md).
- Lint: `bunx biome check` on both files → clean.
- Screenshots / video / LLM trajectories: N/A — backend SQL read-path in the Stripe webhook money path; no UI or model surface. Domain artifact = the `credit_transactions` rows + tally asserted in the test above.

## Risk

- Read-path-only change; no schema or write-path changes.
- Netting only triggers on rows carrying `metadata.source='charge.dispute.funds_reinstated'`, which only `handleChargeDisputeFundsReinstated` writes — ordinary refunds and partial-refund delta math (#10920) are unchanged (existing tally test still green).

Money path — maintainer merge please, do not self-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)