### PR TITLE
fix(ui): clamp relationships graph container to viewport on mobile

### DIFF
--- a/packages/app/test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts
@@ -210,6 +210,24 @@ test("relationships decomposed view: renders the graph and toggles a kind filter
     timeout: 15_000,
   });
 
+  // #11145 (fixed): the graph container is clamped to the viewport
+  // (`w-full max-w-full` + internal `overflow-auto`), so the zoomed SVG pans
+  // INSIDE it instead of stretching the layout box to the SVG width (was
+  // measured at 1188px on a 412px Pixel-7 viewport → horizontal page scroll).
+  // Assert the container's rendered box never exceeds the viewport width.
+  const viewport = page.viewportSize();
+  if (viewport) {
+    const box = await page
+      .locator("[data-graph-container]")
+      .first()
+      .boundingBox();
+    expect(box, "graph container should be laid out").not.toBeNull();
+    if (box) {
+      // +1px slack for sub-pixel rounding.
+      expect(box.width).toBeLessThanOrEqual(viewport.width + 1);
+    }
+  }
+
   await page
     .getByRole("button", { name: "Organizations", exact: true })
     .click();
@@ -251,10 +269,11 @@ async function touchPinch(
   if (!box) throw new Error(`no bounding box for ${selector}`);
   const viewport = page.viewportSize();
   if (!viewport) throw new Error("no viewport size");
-  // The graph container tracks the zoomed svg width, so on the narrow Pixel-7
-  // viewport its box centre can sit off-screen (box 1188px wide on a 412px
-  // viewport). Fingers must land on VISIBLE pixels: pinch at the centre of the
-  // container ∩ viewport intersection.
+  // Defensive (post-#11145): the graph container is now viewport-clamped, so
+  // its box should already fit on-screen — but a partially-scrolled or
+  // off-origin target is still possible, so pinch at the centre of the
+  // container ∩ viewport intersection to guarantee fingers land on VISIBLE
+  // pixels regardless.
   const left = Math.max(box.x, 0);
   const right = Math.min(box.x + box.width, viewport.width);
   const top = Math.max(box.y, 0);

--- a/packages/ui/src/components/pages/RelationshipsGraphPanel.tsx
+++ b/packages/ui/src/components/pages/RelationshipsGraphPanel.tsx
@@ -1049,7 +1049,7 @@ export function RelationshipsGraphPanel({
         {/* biome-ignore lint/a11y/noStaticElementInteractions: graph container handles tooltip dismiss on mouse leave */}
         <div
           ref={containerRef}
-          className={`${compact ? "max-h-[min(34rem,calc(100vh-120px))]" : "max-h-[min(42rem,calc(100vh-120px))]"} relative cursor-grab touch-none overflow-auto overscroll-contain rounded-none bg-transparent active:cursor-grabbing`}
+          className={`${compact ? "max-h-[min(34rem,calc(100vh-120px))]" : "max-h-[min(42rem,calc(100vh-120px))]"} relative w-full min-w-0 max-w-full cursor-grab touch-none overflow-auto overscroll-contain rounded-none bg-transparent active:cursor-grabbing`}
           data-graph-container
           onMouseLeave={hideTooltip}
           onPointerDown={beginPan}


### PR DESCRIPTION
Fixes #11145 (a #10722 QA-sweep KNOWN-BUG the specs routed around).

**Symptom:** `[data-graph-container]` at `/apps/relationships` tracked the zoomed SVG's width — measured 1188px on a 412px Pixel-7 viewport — blowing out horizontal page layout (horizontal scroll on mobile).

**Root cause:** the container has `overflow-auto` + a `max-h` clamp but **no width bound**, and the inner `<svg>` carries `style={{ width: GRAPH_WIDTH(1320) * zoom }}`. With nothing constraining the container's own width, its layout box stretched to the child SVG's width.

**Fix (one line):** add `w-full min-w-0 max-w-full` to the container so its box is bounded by its parent; the existing `overflow-auto` lets the zoomed SVG pan/scroll *inside* instead of expanding layout — exactly the issue's recommended direction.

**Un-larp the workaround:** the relationships decomposed-view spec now **asserts** `[data-graph-container]`'s rendered box never exceeds the viewport width (turning the worked-around bug into an enforced invariant), and the `touchPinch` helper's stale "box 1188px wide" comment is updated — its box∩viewport intersection stays as legitimate defensive on-screen-target math.

### Evidence
- Biome clean on both files.
- The one `tsgo` error in `packages/ui` (`iwer` missing in `src/spatial/__e2e__/immersive-fixture.ts`) is pre-existing/environmental — confirmed present on clean develop, unrelated to this change (a WebXR test dep not installed locally); my touched file (`RelationshipsGraphPanel.tsx`) typechecks clean.

### N/A rows
- Rendered before/after screenshot: **partial N/A this commit** — the full ui-smoke Playwright run (which renders `/apps/relationships` at the Pixel-7 viewport) executes in CI via the `audit-app`/decomposed-interactions lane; the new viewport-width assertion is the machine-checkable proof and will gate there. The fix is a bounded-width CSS clamp matching the issue's exact recommendation.
- Live-LLM trajectory: N/A — pure CSS layout fix, no agent/model behavior.