### PR TITLE
fix(cloud): persist Connect payouts_enabled from webhook — unblock every fiat payout (#11172)

### DIFF
--- a/packages/cloud/api/v1/earnings/payout/stripe-connect/webhook/route.ts
+++ b/packages/cloud/api/v1/earnings/payout/stripe-connect/webhook/route.ts
@@ -108,6 +108,15 @@ async function handlePOST(c: AppContext): Promise<Response> {
 
   await stripeConnectAccountsRepository.updateByAccountId(outcome.accountId, {
     ...(outcome.status ? { status: outcome.status } : {}),
+    // Persist the capability flags too — the payout transfer gate checks
+    // `payouts_enabled` directly, so without this the column stays false and
+    // every payout is rejected even for a fully-onboarded account (#11172).
+    ...(outcome.charges_enabled !== undefined
+      ? { charges_enabled: outcome.charges_enabled }
+      : {}),
+    ...(outcome.payouts_enabled !== undefined
+      ? { payouts_enabled: outcome.payouts_enabled }
+      : {}),
   });
   logger.info("[StripeConnect] webhook applied", {
     type: event.type,

--- a/packages/cloud/shared/src/lib/services/stripe-connect-payout.ts
+++ b/packages/cloud/shared/src/lib/services/stripe-connect-payout.ts
@@ -155,6 +155,14 @@ export interface ConnectWebhookOutcome {
   payoutStatus?: ConnectPayoutStatus;
   /** Account capability refresh, for `account.updated`. */
   status?: StripeConnectStatus;
+  /**
+   * Raw Stripe capability flags for `account.updated`, persisted alongside
+   * `status` so the payout gate (which checks `payouts_enabled` directly) sees
+   * the real Stripe state. Without persisting these the column stays at its
+   * migration default `false` and every payout is rejected (elizaOS/eliza#11172).
+   */
+  charges_enabled?: boolean;
+  payouts_enabled?: boolean;
   /** True when the event type isn't one we act on. */
   ignored: boolean;
 }
@@ -175,12 +183,16 @@ export function mapConnectWebhookEvent(event: {
       return { accountId: event.account, payoutStatus: "paid", ignored: false };
     case "account.updated": {
       const obj = event.data?.object ?? {};
+      const charges_enabled = obj.charges_enabled === true;
+      const payouts_enabled = obj.payouts_enabled === true;
       return {
         accountId: event.account,
         status: connectStatusFromCapabilities({
-          charges_enabled: obj.charges_enabled === true,
-          payouts_enabled: obj.payouts_enabled === true,
+          charges_enabled,
+          payouts_enabled,
         }),
+        charges_enabled,
+        payouts_enabled,
         ignored: false,
       };
     }


### PR DESCRIPTION
## What
Persists `charges_enabled` / `payouts_enabled` from the Stripe Connect `account.updated` webhook, closing the launch-blocker **#11172** (every fiat payout permanently rejected).

## Why
`mapConnectWebhookEvent` derived `status` from the capability booleans but **dropped them**; the webhook handler persisted only `status`. The payout transfer gate (`transfer/route.ts:73`) checks `account.payouts_enabled` **directly**, and that column defaults `false` (migration 0150) with **no production writer** — so a fully-onboarded creator (`status='active'`) still fails `!account.payouts_enabled` and can never withdraw via the fiat rail.

## Change (2 files, minimal)
- `stripe-connect-payout.ts`: `ConnectWebhookOutcome` carries `charges_enabled?` / `payouts_enabled?`; the `account.updated` case returns them (computed once, still feeds `connectStatusFromCapabilities`).
- `webhook/route.ts`: persist those flags via `updateByAccountId` (the repository setter already accepts them).

Chosen the "keep the column truthful" fix (option a from #11172) over dropping the gate's column check (option b) — it doesn't alter the gate's security posture, just makes `payouts_enabled` reflect real Stripe state. No new migration; no behavior change for the status enum.

## Verification
- The gate `status === 'active' && payouts_enabled` now passes for an onboarded account, because `account.updated` (both caps true) writes `status='active'` **and** `payouts_enabled=true`.
- Capability loss (`payouts_enabled=false`) now writes both `status` (→ non-active via `connectStatusFromCapabilities`) and the column, so the gate closes correctly.
- Existing tests `stripe-connect-webhook-route.test.ts` / `stripe-connect-transfer-route.test.ts` cover the surface; recommend a case asserting the column is written on `account.updated`.

Money-path — not self-merged. @lalalune, this is the **top launch-blocker** if fiat payout is in scope. `[cloud-audit]`

Closes #11172.
