### PR TITLE
ci(cloud-cf-deploy): serialize branch deploys per ref (fixes robot-fleet thrash, removes manual escort)

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -63,16 +63,22 @@ on:
           - production
 
 concurrency:
-  # Manual deploys (workflow_dispatch) and branch deploys must run to
-  # completion: cancelling an in-progress push deploy lets a busy develop/main
-  # stream starve Cloudflare publishes indefinitely. A SHARED ref-scoped push
-  # group did exactly that under a hot push stream — GitHub cancels the older
-  # pending (and, in practice, the just-started) run on every new commit, so a
-  # rapidly-pushed develop produced zero completed deploys. Give each push/
-  # dispatch its OWN per-commit group so no deploy is ever superseded; the
-  # self-hosted runner serializes them and the latest commit always lands. PRs
-  # keep the dedupe-to-latest group + cancel-in-progress to avoid CI churn.
-  group: cloud-cf-deploy-${{ github.ref }}-${{ github.event_name == 'pull_request' && 'pr' || github.sha }}
+  # Serialize branch deploys (push + workflow_dispatch) per ref so the shared-host
+  # self-hosted robot fleet runs exactly ONE deploy at a time. The per-commit-group
+  # design this replaces assumed "the self-hosted runner serializes them", but it
+  # does NOT: the robot slots share disk, so concurrent runs saturate I/O and every
+  # run times out (checkout materialization / bun-install link phase >900s). One run
+  # alone always succeeds.
+  #
+  # A shared per-ref group with cancel-in-progress:false is the fix. The earlier
+  # shared-group attempt failed only because it cancelled IN-PROGRESS runs on every
+  # push (zero completions). Here cancel-in-progress is false for branch deploys, so
+  # GitHub PROTECTS the running deploy and just queues the next one, superseding only
+  # the stale *pending* run — the in-flight deploy always finishes and the latest
+  # commit always lands next. This also removes the need for the manual out-of-band
+  # deploy-serialization escort. PRs keep a per-PR dedupe group + cancel-in-progress
+  # to avoid preview-deploy churn. Refs #11108.
+  group: cloud-cf-deploy-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('branch-{0}', github.ref) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Default to least privilege. Override per-job where needed.


### PR DESCRIPTION
Closes #11108.

## Problem
Cloud CF Deploy runs on the shared-host `hetzner-robot` fleet. The current concurrency uses a **per-commit group** (`…-${{ github.sha }}`) so every develop push spawns an independent deploy run, and they run **concurrently** on the fleet. The robot slots share disk, so N concurrent runs saturate I/O and **every one times out** (checkout materialization or bun-install link phase >900s). Evidence across 2026-07-01→02: every concurrent pair failed; every run that owned the fleet alone succeeded. The design comment assumed `the self-hosted runner serializes them` — it does not.

This is also a live capacity drain: thrashing deploys each hold 3 runner jobs, feeding the current ~500-deep Actions backlog.

Right now this is worked around by a **manual out-of-band escort** (an agent protects the in-flight run and defers newcomers). This PR makes GitHub do it natively.

## Fix
Shared **per-ref** group for `push` + `workflow_dispatch` with `cancel-in-progress: false`:
- `branch-refs/heads/develop` and `branch-refs/heads/main` serialize independently.
- `cancel-in-progress:false` → GitHub **protects the running deploy** and queues the next, superseding only the stale **pending** run. The in-flight deploy always finishes; the newest commit always lands next. One deploy at a time, no thrash.
- PRs keep a per-PR dedupe group (`pr-<num>`) + `cancel-in-progress:true` for preview churn — unchanged behavior.

## Why this doesn't reproduce the earlier shared-group failure
The in-file comment records that a prior shared group produced zero completions. That happened because it **cancelled in-progress runs** on every push. Here `cancel-in-progress` is **false** for branch deploys, so in-progress is never cancelled — only stale *pending* runs are superseded. That's the exact difference.

## Validation
- `actionlint` clean.
- Resolved group names: PR → `cloud-cf-deploy-pr-<n>`; develop push/dispatch → `cloud-cf-deploy-branch-refs/heads/develop`; main → `…/main`.
- Semantics match GitHub's documented concurrency behavior (1 running + ≤1 pending per group; new run supersedes pending, not running, when cancel-in-progress is false).

## Follow-on
Once merged, the manual deploy escort can be retired. Fleet capacity + the flaky `eliza-robot-15` slot are still worth addressing separately (comments on #11108). — nubs-cloud (laptop/deploy lane)