### PR TITLE
fix(cloud): never mark paid direct-wallet deposits failed_chain on transient RPC errors

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-payments.integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-payments.integration.test.ts
@@ -78,6 +78,8 @@ interface FakeTx {
   throwNotFound?: boolean;
   // Throw a generic terminal error
   throwTerminal?: string;
+  // Throw a real viem HttpRequestError (RPC 503) — transient infra failure
+  throwRpc?: boolean;
 }
 
 const chainTxs = new Map<string, FakeTx>();
@@ -99,6 +101,15 @@ if (SUPPORTS_VITEST_MOCK_API) {
             const err = new Error("could not be found");
             err.name = "TransactionReceiptNotFoundError";
             throw err;
+          }
+          if (tx.throwRpc) {
+            // Real viem error class + message shape for an RPC-side 503 —
+            // exactly what a flaky/overloaded RPC provider produces.
+            throw new actual.HttpRequestError({
+              url: "http://mocked-bsc",
+              status: 503,
+              details: "503 Service Unavailable",
+            });
           }
           if (tx.throwTerminal) {
             throw new Error(tx.throwTerminal);
@@ -903,6 +914,233 @@ d.skipIf(!process.env.DATABASE_URL || !pgliteAvailable)(
       const row = await dbWrite.query.cryptoPayments.findFirst();
       expect(row?.status).toBe("broadcast");
     });
+
+    // Regression for #11154: a transient RPC failure (viem HttpRequestError
+    // from a 503/timeout/rate-limited provider) is NOT evidence about the tx.
+    // Before the fix, any error outside a narrow not-found allowlist hit the
+    // unconditional failed_chain write on attempt 1 — terminally eating a
+    // genuinely-paid deposit because the RPC hiccuped once.
+    test("processBroadcastBatch does NOT fail_chain a payment on a transient RPC error (#11154)", async () => {
+      await resetTable();
+      const { payment } = await service.createPayment(env, {
+        organizationId: ORG_ID,
+        userId: USER_ID,
+        accountWalletAddress: null,
+        payerAddress: PAYER_EVM,
+        amountUsd: 10,
+        network: "bsc",
+        tokenSymbol: "USDT",
+      });
+      const meta = payment.metadata as Record<string, unknown>;
+      const tokenAddress = meta.token_address as string;
+      const hash = `0x${"9".repeat(64)}`;
+      await trustPayerProof(payment);
+      await service.attachTransaction(env, {
+        paymentId: payment.id,
+        txHash: hash,
+        userId: USER_ID,
+      });
+      // The tx is real and paid — but the RPC answers 503 on this pass.
+      chainTxs.set(hash, {
+        from: PAYER_EVM,
+        to: tokenAddress,
+        value: 0n,
+        status: "success",
+        receiveAddress: env.CRYPTO_DIRECT_BSC_RECEIVE_ADDRESS,
+        throwRpc: true,
+      });
+
+      const stats = await service.processBroadcastBatch(env);
+      expect(stats.failed).toBe(0);
+      expect(stats.stillPending).toBe(1);
+      const row = await dbWrite.query.cryptoPayments.findFirst();
+      expect(row?.status).toBe("broadcast");
+      const rowMeta = row?.metadata as Record<string, unknown>;
+      expect(Number(rowMeta.verify_attempts)).toBe(1);
+      expect(String(rowMeta.last_verify_error)).toMatch(/HTTP request failed/i);
+
+      // RPC recovers → the very next cron pass confirms and credits the org.
+      chainTxs.set(hash, {
+        from: PAYER_EVM,
+        to: tokenAddress,
+        value: 0n,
+        status: "success",
+        receiveAddress: env.CRYPTO_DIRECT_BSC_RECEIVE_ADDRESS,
+        erc20: {
+          tokenAddress,
+          from: PAYER_EVM,
+          to: env.CRYPTO_DIRECT_BSC_RECEIVE_ADDRESS,
+          value: BigInt(meta.expected_token_units as string),
+        },
+      });
+      const stats2 = await service.processBroadcastBatch(env);
+      expect(stats2.confirmed).toBe(1);
+      expect(creditsLedger).toHaveLength(1);
+    });
+
+    test("processBroadcastBatch keeps a payment in broadcast when RPC errors exhaust MAX_VERIFY_ATTEMPTS (#11154)", async () => {
+      await resetTable();
+      const { payment } = await service.createPayment(env, {
+        organizationId: ORG_ID,
+        userId: USER_ID,
+        accountWalletAddress: null,
+        payerAddress: PAYER_EVM,
+        amountUsd: 10,
+        network: "bsc",
+        tokenSymbol: "USDT",
+      });
+      const meta = payment.metadata as Record<string, unknown>;
+      const tokenAddress = meta.token_address as string;
+      const hash = `0x${"a1".repeat(32)}`;
+      await trustPayerProof(payment);
+      await service.attachTransaction(env, {
+        paymentId: payment.id,
+        txHash: hash,
+        userId: USER_ID,
+      });
+      chainTxs.set(hash, {
+        from: PAYER_EVM,
+        to: tokenAddress,
+        value: 0n,
+        status: "success",
+        receiveAddress: env.CRYPTO_DIRECT_BSC_RECEIVE_ADDRESS,
+        throwRpc: true,
+      });
+      // Simulate a prolonged RPC outage: the retry budget is already spent.
+      await dbWrite.execute(
+        `UPDATE crypto_payments SET metadata = metadata || '{"verify_attempts":60}'::jsonb WHERE id = '${payment.id}'`,
+      );
+
+      const stats = await service.processBroadcastBatch(env);
+      // Unlike a not-found tx (dropped from the mempool → failed_chain at the
+      // cap), RPC-infra errors must NEVER terminally fail a possibly-paid
+      // deposit — the row stays broadcast and keeps retrying.
+      expect(stats.failed).toBe(0);
+      expect(stats.stillPending).toBe(1);
+      const row = await dbWrite.query.cryptoPayments.findFirst();
+      expect(row?.status).toBe("broadcast");
+      expect(Number((row?.metadata as Record<string, unknown>).verify_attempts)).toBe(61);
+    });
+
+    test("processBroadcastBatch marks failed_chain immediately on sender-mismatch (terminal)", async () => {
+      await resetTable();
+      // Native BNB payment — the sender binding is tx.from, so a tx carried
+      // by any other wallet is a deterministic, terminal verify failure.
+      const { payment } = await service.createPayment(env, {
+        organizationId: ORG_ID,
+        userId: USER_ID,
+        accountWalletAddress: null,
+        payerAddress: PAYER_EVM,
+        amountUsd: 60,
+        network: "bsc",
+        tokenSymbol: "BNB",
+      });
+      const meta = payment.metadata as Record<string, unknown>;
+      const expectedUnits = BigInt(meta.expected_token_units as string);
+      const receive = env.CRYPTO_DIRECT_BSC_RECEIVE_ADDRESS;
+      const hash = `0x${"b2".repeat(32)}`;
+      await trustPayerProof(payment);
+      await service.attachTransaction(env, {
+        paymentId: payment.id,
+        txHash: hash,
+        userId: USER_ID,
+      });
+      chainTxs.set(hash, {
+        from: "0x2222222222222222222222222222222222222222", // NOT the proven payer
+        to: receive,
+        value: expectedUnits,
+        status: "success",
+        receiveAddress: receive,
+      });
+
+      const stats = await service.processBroadcastBatch(env);
+      expect(stats.failed).toBe(1);
+      const row = await dbWrite.query.cryptoPayments.findFirst();
+      expect(row?.status).toBe("failed_chain");
+      expect(String((row?.metadata as Record<string, unknown>).failure_reason)).toMatch(
+        /sender does not match the proven payer/i,
+      );
+      expect(creditsLedger).toHaveLength(0);
+    });
+
+    test("processBroadcastBatch marks failed_chain when a Solana tx failed on chain (meta.err)", async () => {
+      await resetTable();
+      solanaTestState.parsedTxOverride = {
+        slot: 7,
+        meta: {
+          err: { InstructionError: [0, "Custom"] },
+          preTokenBalances: [],
+          postTokenBalances: [],
+          fee: 0,
+          preBalances: [],
+          postBalances: [],
+        },
+        transaction: { message: { accountKeys: [], instructions: [] }, signatures: [] },
+      };
+      try {
+        const { payment } = await service.createPayment(env, {
+          organizationId: ORG_ID,
+          userId: USER_ID,
+          accountWalletAddress: null,
+          payerAddress: PAYER_SOL,
+          amountUsd: 10,
+          network: "solana",
+          tokenSymbol: "USDC",
+        });
+        const hash = "F".repeat(64);
+        await trustPayerProof(payment);
+        await service.attachTransaction(env, {
+          paymentId: payment.id,
+          txHash: hash,
+          userId: USER_ID,
+        });
+
+        const stats = await service.processBroadcastBatch(env);
+        expect(stats.failed).toBe(1);
+        const row = await dbWrite.query.cryptoPayments.findFirst();
+        expect(row?.status).toBe("failed_chain");
+        expect(String((row?.metadata as Record<string, unknown>).failure_reason)).toMatch(
+          /was not confirmed successfully/i,
+        );
+        expect(creditsLedger).toHaveLength(0);
+      } finally {
+        solanaTestState.parsedTxOverride = null;
+      }
+    });
+
+    test("processBroadcastBatch treats a Solana tx the RPC can't see yet as transient, not failed", async () => {
+      await resetTable();
+      // getParsedTransaction returns null on every poll — the tx hasn't
+      // propagated to this RPC (or was dropped; only exhaustion decides).
+      solanaTestState.parsedTxOverride = null;
+      const { payment } = await service.createPayment(env, {
+        organizationId: ORG_ID,
+        userId: USER_ID,
+        accountWalletAddress: null,
+        payerAddress: PAYER_SOL,
+        amountUsd: 10,
+        network: "solana",
+        tokenSymbol: "USDC",
+      });
+      const hash = "G".repeat(64);
+      await trustPayerProof(payment);
+      await service.attachTransaction(env, {
+        paymentId: payment.id,
+        txHash: hash,
+        userId: USER_ID,
+      });
+
+      // NOTE: slow by design — verifySolanaTokenPayment polls a null tx
+      // 12 times with a real 1.5s backoff before giving up (~18s).
+      const stats = await service.processBroadcastBatch(env);
+      expect(stats.failed).toBe(0);
+      expect(stats.stillPending).toBe(1);
+      const row = await dbWrite.query.cryptoPayments.findFirst();
+      expect(row?.status).toBe("broadcast");
+      const rowMeta = row?.metadata as Record<string, unknown>;
+      expect(Number(rowMeta.verify_attempts)).toBe(1);
+      expect(String(rowMeta.last_verify_error)).toMatch(/not found on Solana/i);
+    }, 60_000);
 
     test("BSC promo can only be redeemed once per organization", async () => {
       await resetTable();

--- a/packages/cloud/shared/src/lib/services/direct-wallet-payments.ts
+++ b/packages/cloud/shared/src/lib/services/direct-wallet-payments.ts
@@ -854,7 +854,24 @@ async function verifySolanaTokenPayment(params: {
       maxSupportedTransactionVersion: 0,
     });
   }
-  if (!tx?.meta || tx.meta.err) throw new Error("Transaction was not confirmed successfully");
+  if (!tx) {
+    // Not on chain from this RPC's view — mempool propagation, a lagging
+    // node, or a dropped tx. Phrased to match the cron's not-found
+    // classification so it retries (and only fails after the retry budget)
+    // instead of terminally failing a possibly-paid deposit on attempt 1.
+    throw new Error("Transaction not found on Solana — it may not be confirmed yet");
+  }
+  if (!tx.meta) {
+    // The RPC returned the tx without meta, so balances can't be verified
+    // yet. Deliberately does NOT match the not-found bucket: a persistently
+    // meta-less tx exists on chain and must keep retrying, not be declared
+    // dropped.
+    throw new Error("Transaction metadata unavailable from RPC");
+  }
+  if (tx.meta.err) {
+    // On chain and failed — deterministic and terminal.
+    throw new Error("Transaction was not confirmed successfully");
+  }
 
   const mint = params.cfg.tokenMint;
   const receiver = normalizeSolanaAddress(params.cfg.receiveAddress);
@@ -1600,6 +1617,9 @@ export class DirectWalletPaymentsService {
    *   - Tx reverted, recipient/amount wrong, or chain rejected → mark
    *     `failed_chain` with `metadata.failure_reason`. Surfaces in the UI
    *     waiting overlay so the user knows it's done.
+   *   - RPC/infra error (503, timeout, rate-limit) → says nothing about the
+   *     tx itself, so leave as `broadcast` and retry next tick. A paid
+   *     deposit must never be terminally failed on RPC evidence alone.
    */
   async processBroadcastBatch(
     env: Bindings,
@@ -1626,8 +1646,10 @@ export class DirectWalletPaymentsService {
     // Cap how many times the cron retries a transient verify failure on a
     // single payment. A real tx propagates within minutes; ~1 hour of
     // "not found" usually means a bad hash, wrong network, or a tx that
-    // was dropped from the mempool. Past that, mark `failed_chain` so the
-    // user sees the failure instead of an indefinite spinner.
+    // was dropped from the mempool. Past that, a NOT-FOUND tx is marked
+    // `failed_chain` so the user sees the failure instead of an indefinite
+    // spinner. Unknown (RPC/infra) errors keep retrying past the cap — see
+    // the classification in the catch below.
     const MAX_VERIFY_ATTEMPTS = 60;
 
     for (const payment of candidates) {
@@ -1644,18 +1666,33 @@ export class DirectWalletPaymentsService {
         stats.confirmed += 1;
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
-        // Heuristic: receipt-not-yet-found means we should keep waiting.
-        // Anything else (wrong recipient, low value, reverted) is terminal
-        // — record it so the user sees a clear failure.
-        const transient =
+        // Classify the failure. Money rule: only a DETERMINISTIC verification
+        // failure may terminally fail a deposit — the tx is on chain (or the
+        // payment row is provably unverifiable) and retrying can never change
+        // the outcome: reverted tx, wrong sender/recipient/amount, tampered
+        // quote, payer-proof mismatch, hash already credited to another
+        // payment, or an unverifiable legacy row. Everything OUTSIDE this
+        // allowlist retries — a transient RPC failure (503 / timeout /
+        // rate-limit thrown by getTransactionReceipt / getTransaction /
+        // getParsedTransaction, e.g. viem HttpRequestError or TimeoutError)
+        // says nothing about the tx and must never mark a genuinely-paid
+        // deposit `failed_chain`.
+        const terminal =
+          /Transaction failed|amount is lower than the expected|is (below|above) the expected (floor|ceiling)|recipient does not match|sender does not match the proven payer|was not confirmed successfully|ATA owner does not match|does not transfer enough|proof metadata mismatch|Quote signature|already processed for another payment|missing token address|LEGACY_PAYMENT_MISSING_PAYER_PROOF/i.test(
+            msg,
+          );
+        // Receipt-not-yet-found: expected while a tx propagates. Unlike the
+        // unknown/RPC bucket this IS terminal once retries are exhausted —
+        // ~1 hour of "not found" means a bad hash, wrong network, or a tx
+        // dropped from the mempool.
+        const notFound =
           /not found|not yet|pending|TransactionReceiptNotFoundError|could not be found/i.test(msg);
 
         const attempts =
           Number((metadataOf(payment) as Record<string, unknown>).verify_attempts ?? 0) + 1;
 
-        if (transient && attempts < MAX_VERIFY_ATTEMPTS) {
-          stats.stillPending += 1;
-          await dbWrite
+        const bumpVerifyAttempts = () =>
+          dbWrite
             .update(cryptoPayments)
             .set({
               updated_at: new Date(),
@@ -1672,10 +1709,31 @@ export class DirectWalletPaymentsService {
                 error: String(e),
               });
             });
+
+        if (!terminal && attempts < MAX_VERIFY_ATTEMPTS) {
+          stats.stillPending += 1;
+          await bumpVerifyAttempts();
           continue;
         }
 
-        if (transient && attempts >= MAX_VERIFY_ATTEMPTS) {
+        if (!terminal && !notFound) {
+          // Unknown (almost certainly RPC/infra) errors exhausted the retry
+          // window. The tx may be PAID — RPC trouble is not evidence about
+          // the tx, so never flip to `failed_chain` here. Keep the row in
+          // `broadcast` (the attempt counter keeps climbing for
+          // observability) and log at error level; the payment confirms as
+          // soon as the RPC recovers, or fails properly once a real
+          // terminal / not-found signal appears.
+          stats.stillPending += 1;
+          logger.error(
+            "[DirectWalletPayments] verify still failing with a non-terminal error after MAX_VERIFY_ATTEMPTS — keeping payment in broadcast",
+            { paymentId: redact.paymentId(payment.id), attempts, lastError: msg },
+          );
+          await bumpVerifyAttempts();
+          continue;
+        }
+
+        if (!terminal) {
           logger.warn(
             "[DirectWalletPayments] giving up on broadcast payment after MAX_VERIFY_ATTEMPTS",
             { paymentId: redact.paymentId(payment.id), attempts, lastError: msg },


### PR DESCRIPTION
Fixes #11154 (MED, launch-critical money loss).

## The bug

`processBroadcastBatch` — the cron that auto-confirms direct-wallet deposits stuck in `broadcast` — classified verify errors with a narrow **transient allowlist** (`/not found|not yet|pending|TransactionReceiptNotFoundError|could not be found/i`). Any error outside it skipped both retry branches and hit the **unconditional `failed_chain` write on attempt 1**.

viem's `HttpRequestError` / `TimeoutError` (RPC 503, timeout, 429 at `getTransactionReceipt` / `getTransaction`) and Solana RPC failures at `getParsedTransaction` all miss that allowlist. Result: one RPC hiccup terminally fails a **genuinely-paid** deposit — the user's on-chain money is gone from their wallet, the payment shows a chain failure, and no credits are ever issued.

## The fix

Invert to a **terminal allowlist**, mirroring the existing regex-classification style:

- **terminal** — deterministic verify failures only (reverted tx, wrong sender/recipient/amount incl. slippage floor/ceiling, tampered quote signature, payer-proof mismatch, ATA-owner mismatch, insufficient token delta, hash already credited to another payment, missing token address, unverifiable legacy row) → existing `failed_chain` block immediately. Behavior for genuinely-bad txs is unchanged.
- **not-found** — unchanged regex; retry with `verify_attempts` bump, `failed_chain` only on `MAX_VERIFY_ATTEMPTS` exhaustion (dropped tx / bad hash / wrong network), as before.
- **unknown / RPC-infra** (everything else) — retry with `verify_attempts` bump; on exhaustion **keep `status='broadcast'`** and log at error level. RPC trouble says nothing about the tx: a prolonged provider outage may delay crediting, but can never terminally eat paid money. The row confirms on the next pass after the RPC recovers.

Also split the Solana verify throw that conflated two different worlds into one terminal message: `!tx` (RPC can't see the tx yet → not-found-classified, retries) vs `tx.meta.err` (failed on chain → terminal) vs meta-less tx (unknown → retries).

## Evidence — regression tests (real classification path; only the RPC client boundary is mocked)

PGlite integration suite `packages/cloud/shared/src/lib/services/__tests__/direct-wallet-payments.integration.test.ts` (vitest lane), 5 new tests:

| scenario | expected | proves |
|---|---|---|
| real viem `HttpRequestError` (503) on attempt 1 | stays `broadcast`, `verify_attempts=1`, `last_verify_error` recorded; **confirms + credits on the next pass** after RPC recovers | the money-loss regression |
| RPC errors at `verify_attempts=60` (cap) | stays `broadcast`, attempts keep climbing, `failed:0` | outage can't terminally eat a deposit |
| native-BNB tx from a non-payer wallet | `failed_chain` on attempt 1, reason `/sender does not match the proven payer/` | terminal behavior preserved |
| Solana `tx.meta.err` set | `failed_chain` on attempt 1, reason `/was not confirmed successfully/` | terminal behavior preserved |
| Solana `getParsedTransaction` → null | stays `broadcast`, `verify_attempts=1`, error `/not found on Solana/` | the Solana leg of the split |

**Fail-without-fix proof** — with the new tests present but `direct-wallet-payments.ts` stashed back to develop:

```
× processBroadcastBatch does NOT fail_chain a payment on a transient RPC error (#11154)
    AssertionError: expected 1 to be +0   // stats.failed — deposit was marked failed_chain
× processBroadcastBatch keeps a payment in broadcast when RPC errors exhaust MAX_VERIFY_ATTEMPTS (#11154)
    AssertionError: expected 1 to be +0
× processBroadcastBatch treats a Solana tx the RPC can't see yet as transient, not failed
    AssertionError: expected 1 to be +0
Tests  3 failed | 35 passed (38)
```

With the fix restored:

```
Tests  38 passed (38)   # full file, includes all pre-existing broadcast-batch/state-machine tests
```

- `bun run --cwd packages/cloud/shared typecheck` — no errors in either touched file.
- `bunx biome check` on both files — clean.
- Backend logs: transient path logs `verify_attempts` bumps; unknown-exhaustion logs `[DirectWalletPayments] verify still failing with a non-terminal error after MAX_VERIFY_ATTEMPTS — keeping payment in broadcast` at error level for ops visibility.

Evidence rows N/A: frontend screenshots/video (cron-only backend path, no UI change), LLM trajectories (no model-touching code), migrations (no schema change).

## Residual risk

- Classification is message-regex-based (matches the file's existing style). A future verify error with a novel *terminal* message would be treated as unknown → retried forever in `broadcast` with error-level logs, which is the fail-safe direction for money (never silently eats a paid deposit; ops sees it).
- A payment whose RPC endpoint is *permanently* broken (e.g. misconfigured RPC URL) now stays `broadcast` indefinitely instead of failing after ~1h — deliberate, surfaced via the error-level log on every pass past the cap.

Money path — not self-merging; maintainer merge please.

🤖 Generated with [Claude Code](https://claude.com/claude-code)