### PR TITLE
fix(cloud): persist Stripe Connect capability booleans so fiat payouts aren't permanently rejected (#11172)

### DIFF
--- a/packages/cloud/api/__tests__/stripe-connect-webhook-route.test.ts
+++ b/packages/cloud/api/__tests__/stripe-connect-webhook-route.test.ts
@@ -180,9 +180,14 @@ describe("Stripe Connect payout webhook route", () => {
     );
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toEqual({ success: true });
-    // account.updated with charges+payouts enabled => "active"
+    // account.updated with charges+payouts enabled => "active", AND the raw
+    // capability booleans are persisted (#11172): the payout transfer gate reads
+    // payouts_enabled directly (defaults false), so storing status alone left
+    // every account non-payout-ready forever. The column must be written true.
     expect(updateByAccountId).toHaveBeenCalledWith("acct_creator_1", {
       status: "active",
+      charges_enabled: true,
+      payouts_enabled: true,
     });
     expect(emitAudit).not.toHaveBeenCalled();
   });

--- a/packages/cloud/api/v1/earnings/payout/stripe-connect/webhook/route.ts
+++ b/packages/cloud/api/v1/earnings/payout/stripe-connect/webhook/route.ts
@@ -108,6 +108,15 @@ async function handlePOST(c: AppContext): Promise<Response> {
 
   await stripeConnectAccountsRepository.updateByAccountId(outcome.accountId, {
     ...(outcome.status ? { status: outcome.status } : {}),
+    // Persist the capability booleans, not just the derived status: the payout
+    // transfer gate reads `payouts_enabled` directly and it defaults false, so
+    // storing status alone left every account non-payout-ready forever (#11172).
+    ...(outcome.chargesEnabled !== undefined
+      ? { charges_enabled: outcome.chargesEnabled }
+      : {}),
+    ...(outcome.payoutsEnabled !== undefined
+      ? { payouts_enabled: outcome.payoutsEnabled }
+      : {}),
   });
   logger.info("[StripeConnect] webhook applied", {
     type: event.type,

--- a/packages/cloud/shared/src/lib/services/stripe-connect-payout.test.ts
+++ b/packages/cloud/shared/src/lib/services/stripe-connect-payout.test.ts
@@ -165,13 +165,28 @@ describe("mapConnectWebhookEvent (#8922)", () => {
     });
   });
 
-  it("refreshes account status on account.updated", () => {
+  it("refreshes account status AND surfaces the capability booleans on account.updated (#11172)", () => {
     const out = mapConnectWebhookEvent({
       type: "account.updated",
       account: "acct_1",
       data: { object: { charges_enabled: true, payouts_enabled: true } },
     });
     expect(out.status).toBe("active");
+    // #11172: the booleans MUST be returned so the route persists them — the
+    // payout gate reads payouts_enabled directly (defaults false). Deriving
+    // status alone left every account non-payout-ready forever.
+    expect(out.chargesEnabled).toBe(true);
+    expect(out.payoutsEnabled).toBe(true);
+  });
+
+  it("surfaces false capabilities too (payouts not yet enabled → column stays false, truthfully) (#11172)", () => {
+    const out = mapConnectWebhookEvent({
+      type: "account.updated",
+      account: "acct_1",
+      data: { object: { charges_enabled: true, payouts_enabled: false } },
+    });
+    expect(out.chargesEnabled).toBe(true);
+    expect(out.payoutsEnabled).toBe(false);
   });
 
   it("ignores unrelated event types", () => {

--- a/packages/cloud/shared/src/lib/services/stripe-connect-payout.ts
+++ b/packages/cloud/shared/src/lib/services/stripe-connect-payout.ts
@@ -155,6 +155,15 @@ export interface ConnectWebhookOutcome {
   payoutStatus?: ConnectPayoutStatus;
   /** Account capability refresh, for `account.updated`. */
   status?: StripeConnectStatus;
+  /**
+   * Raw capability booleans from `account.updated`. Persisted alongside `status`
+   * so the DB column reflects reality: the payout transfer gate reads
+   * `payouts_enabled` directly, and it defaults false — deriving only `status`
+   * from these and dropping the booleans left `payouts_enabled` false forever,
+   * rejecting every fiat payout (#11172).
+   */
+  chargesEnabled?: boolean;
+  payoutsEnabled?: boolean;
   /** True when the event type isn't one we act on. */
   ignored: boolean;
 }
@@ -175,12 +184,16 @@ export function mapConnectWebhookEvent(event: {
       return { accountId: event.account, payoutStatus: "paid", ignored: false };
     case "account.updated": {
       const obj = event.data?.object ?? {};
+      const chargesEnabled = obj.charges_enabled === true;
+      const payoutsEnabled = obj.payouts_enabled === true;
       return {
         accountId: event.account,
         status: connectStatusFromCapabilities({
-          charges_enabled: obj.charges_enabled === true,
-          payouts_enabled: obj.payouts_enabled === true,
+          charges_enabled: chargesEnabled,
+          payouts_enabled: payoutsEnabled,
         }),
+        chargesEnabled,
+        payoutsEnabled,
         ignored: false,
       };
     }


### PR DESCRIPTION
Closes #11172.

## Problem (HIGH — launch-blocking for the fiat payout rail)
The Connect `account.updated` webhook derived `status` from the capability booleans but **dropped the booleans**. `payouts_enabled` defaults false (migration 0150) and the payout transfer gate reads it directly:
```ts
// transfer/route.ts
if (account.status !== "active" || !account.payouts_enabled) → reject
```
So a creator fully onboards → Stripe fires `account.updated` (`charges_enabled=true, payouts_enabled=true`) → we stored `status='active'` but left `payouts_enabled=false` **forever** → every Stripe Connect fiat payout permanently rejected, with no recovery path. (On-chain hot-wallet payouts are unaffected — this is the Stripe fiat rail specifically.)

## Fix (option a — keep the column truthful)
`mapConnectWebhookEvent` now returns the raw `chargesEnabled`/`payoutsEnabled` from `account.updated`, and the webhook route persists them alongside `status` via `updateByAccountId` (which already accepts `charges_enabled?`/`payouts_enabled?`). The column reflects reality: true when Stripe reports the caps, false when it doesn't.

```ts
await stripeConnectAccountsRepository.updateByAccountId(outcome.accountId, {
  ...(outcome.status ? { status: outcome.status } : {}),
  ...(outcome.chargesEnabled !== undefined ? { charges_enabled: outcome.chargesEnabled } : {}),
  ...(outcome.payoutsEnabled !== undefined ? { payouts_enabled: outcome.payoutsEnabled } : {}),
});
```
Chose (a) over (b) (dropping the redundant gate check) so the persisted column stays accurate for any other reader, not just the transfer gate.

## Tests
- **`stripe-connect-payout.test.ts`**: mapper surfaces the booleans (both true → also `active`; charges-true/payouts-false → surfaced truthfully).
- **`stripe-connect-webhook-route.test.ts`**: the `account.updated` persist now asserts `{ status: "active", charges_enabled: true, payouts_enabled: true }` — the regression guard (previously `{ status: "active" }` alone, which is exactly the bug).

```
bun test packages/cloud/shared/src/lib/services/stripe-connect-payout.test.ts            # 12 pass
bun test packages/cloud/api/__tests__/stripe-connect-webhook-route.test.ts               # 13 pass
```
`packages/cloud/shared typecheck` + `packages/cloud/api build` + biome all clean.

## Evidence
- The write/read contract is proven by the route test asserting the exact persisted patch (the payout gate then reads a true column). No mock stands in for the persisted value.
- N/A (no UI / no new migration / no model): the column + repo method already exist; this wires the webhook to write them.

Money-path — flagging for maintainer review/merge rather than self-merge. `[cloud-security]`