### PR TITLE
test(cloud-e2e): group-i links real owned characters — 31/31 green vs live staging

### DIFF
--- a/packages/cloud/api/test/e2e/group-i-apps-lifecycle.test.ts
+++ b/packages/cloud/api/test/e2e/group-i-apps-lifecycle.test.ts
@@ -38,6 +38,26 @@ let serverReachable = false;
 let hasTestApiKey = false;
 let hasMemberApiKey = false;
 const createdAppIds: string[] = [];
+const createdCharacterIds: string[] = [];
+
+/**
+ * Create a REAL character owned by the test user and return its id. The generic
+ * app-update path enforces character ownership (cross-tenant disclosure guard,
+ * #10852-class) — so `linked_character_ids` must reference characters that
+ * exist AND belong to the caller, not fabricated UUIDs.
+ */
+async function createTestCharacter(): Promise<string> {
+  const res = await api.post(
+    "/api/my-agents/characters",
+    { name: uniqueName("Linked Char"), bio: ["e2e linked-character fixture"] },
+    { headers: bearerHeaders() },
+  );
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { id?: string };
+  expect(body.id).toBeTruthy();
+  createdCharacterIds.push(body.id as string);
+  return body.id as string;
+}
 
 // A syntactically valid UUID that should never resolve to a real app.
 const MISSING_UUID = "00000000-0000-4000-8000-0000000000ff";
@@ -146,6 +166,11 @@ afterAll(async () => {
   if (!shouldRunAuthed()) return;
   for (const appId of createdAppIds) {
     await api.delete(`/api/v1/apps/${appId}?deleteGitHubRepo=false`, {
+      headers: bearerHeaders(),
+    });
+  }
+  for (const characterId of createdCharacterIds) {
+    await api.delete(`/api/my-agents/characters/${characterId}`, {
       headers: bearerHeaders(),
     });
   }
@@ -439,9 +464,11 @@ describe("PUT /api/v1/apps/:id", () => {
   test("happy path: sets linked_character_ids", async () => {
     if (!shouldRunAuthed()) return;
     const created = await createTestApp();
+    // Real, caller-owned characters — the update path enforces ownership, so
+    // fabricated UUIDs correctly 404 ("Character not found").
     const characters = [
-      "00000000-0000-4000-8000-000000000010",
-      "00000000-0000-4000-8000-000000000011",
+      await createTestCharacter(),
+      await createTestCharacter(),
     ];
 
     const res = await api.put(


### PR DESCRIPTION
Part of the launch e2e sweep (charter #11157, board #10561). Ran group-i-apps-lifecycle against the **live staging** Worker+DB.

### Result: 30/31 → **31/31 green** (verified twice)
The only failure was `sets linked_character_ids` (Expected 200, Received 404).

### It's a stale test, not a server bug
The generic app-update path (`packages/cloud/api/v1/apps/[id]/route.ts:97-108`) enforces character **ownership** — a caller can't link a character id that doesn't exist or belongs to another org (cross-tenant private-character disclosure guard, #10852-class; the code comment says exactly this). The test linked two **fabricated UUIDs**, which the guard correctly 404s. The server is right; the test was wrong.

### Fix
The test now creates two REAL characters owned by the test user (`POST /api/my-agents/characters`), links those, asserts the round-trip, and deletes them in `afterAll` (new `createdCharacterIds` ledger — zero residue).

### Evidence
- `31 pass / 0 fail` twice against live staging (`TEST_API_BASE_URL=https://api-staging.elizacloud.ai`, staging DSN, `TEST_REQUEST_TIMEOUT_MS=90000`).
- The other 30 lifecycle tests (create/list/detail/PUT/PATCH/DELETE/check-name/ownership-gating) already passed live — this proves the whole apps CRUD surface on real staging, the pre-arming baseline for the live deploy proof (#10823).
- N/A — screenshots: headless API e2e.

— `[cloud-frontdoor]`