### PR TITLE
fix(cloud): direct-wallet cron retries transient RPC errors instead of failing paid deposits (#11154)

### DIFF
--- a/packages/cloud/shared/src/lib/services/direct-wallet-payments.ts
+++ b/packages/cloud/shared/src/lib/services/direct-wallet-payments.ts
@@ -1644,11 +1644,16 @@ export class DirectWalletPaymentsService {
         stats.confirmed += 1;
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
-        // Heuristic: receipt-not-yet-found means we should keep waiting.
-        // Anything else (wrong recipient, low value, reverted) is terminal
-        // — record it so the user sees a clear failure.
-        const transient =
-          /not found|not yet|pending|TransactionReceiptNotFoundError|could not be found/i.test(msg);
+        // Classify by a TERMINAL allowlist, not a transient one. Only a genuine
+        // payment-validity failure should burn a broadcast row to `failed_chain`;
+        // everything else — RPC 5xx / timeouts / "HTTP request failed" / a
+        // receipt not yet mined — is transient infra and must be retried, or a
+        // real paid deposit is lost the first time the RPC hiccups (#11154).
+        const terminal =
+          /Transaction failed|is below the expected floor|is above the expected ceiling|amount is lower than the expected|recipient does not match|sender does not match the proven payer|was not confirmed successfully|ATA owner does not match|LEGACY_PAYMENT_MISSING_PAYER_PROOF|not a direct wallet payment|invalid direct network metadata/i.test(
+            msg,
+          );
+        const transient = !terminal;
 
         const attempts =
           Number((metadataOf(payment) as Record<string, unknown>).verify_attempts ?? 0) + 1;


### PR DESCRIPTION
Closes #11154. Inverts \`processBroadcastBatch\` from a transient-allowlist to a **terminal-allowlist**: only genuine payment-validity failures (reverted, amount mismatch, wrong recipient, sender-not-proven-payer, Solana meta.err, wrong ATA, legacy-missing-proof, bad metadata) fail fast; RPC 5xx / timeouts / receipt-not-yet-mined retry up to MAX_VERIFY_ATTEMPTS and self-heal. Safe direction — an unknown error costs extra retries, never a lost paid deposit. One-line-of-logic change, no schema. Money-path, not self-merged — @lalalune. `[cloud-audit]`