### PR TITLE
fix(cloud): retry direct-wallet deposits on transient RPC errors, not fail-closed (#11154)

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-payments.integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-payments.integration.test.ts
@@ -760,6 +760,86 @@ d.skipIf(!process.env.DATABASE_URL || !pgliteAvailable)(
       expect(row2?.status).toBe("failed_chain");
     });
 
+    // #11154 — a transient RPC/infra failure (viem HttpRequestError, 503,
+    // timeout, rate-limit) must NOT terminally fail a genuinely-paid deposit.
+    // Before the fix the transient allowlist matched only not-yet-mined strings,
+    // so an RPC blip coincident with the cron tick set `failed_chain` on attempt
+    // 1 with no self-serve recovery. It must now stay `broadcast` and retry.
+    test("#11154 processBroadcastBatch keeps a paid deposit `broadcast` on a transient RPC error", async () => {
+      await resetTable();
+      const { payment } = await service.createPayment(env, {
+        organizationId: ORG_ID,
+        userId: USER_ID,
+        accountWalletAddress: null,
+        payerAddress: PAYER_EVM,
+        amountUsd: 10,
+        network: "bsc",
+        tokenSymbol: "USDT",
+      });
+      const hash = `0x${"a".repeat(64)}`;
+      await trustPayerProof(payment);
+      await service.attachTransaction(env, {
+        paymentId: payment.id,
+        txHash: hash,
+        userId: USER_ID,
+      });
+      // Simulate a Base/BSC RPC blip: viem throws an HttpRequestError-style
+      // message that does NOT match the terminal allowlist.
+      chainTxs.set(hash, {
+        from: PAYER_EVM,
+        to: env.CRYPTO_DIRECT_BSC_RECEIVE_ADDRESS,
+        value: 0n,
+        status: "success",
+        receiveAddress: env.CRYPTO_DIRECT_BSC_RECEIVE_ADDRESS,
+        throwTerminal: "HTTP request failed.",
+      });
+      const stats = await service.processBroadcastBatch(env);
+      expect(stats.failed).toBe(0);
+      expect(stats.stillPending).toBe(1);
+      const row = await dbWrite.query.cryptoPayments.findFirst();
+      expect(row?.status).toBe("broadcast");
+      expect(
+        Number((row?.metadata as Record<string, unknown>).verify_attempts ?? 0),
+      ).toBeGreaterThanOrEqual(1);
+    });
+
+    // #11154 — a genuinely-bad payment (wrong amount/recipient/reverted) must
+    // still fail closed on the FIRST attempt, not spin for MAX_VERIFY_ATTEMPTS.
+    test("#11154 processBroadcastBatch still fails a genuinely-bad payment on the first attempt", async () => {
+      await resetTable();
+      const { payment } = await service.createPayment(env, {
+        organizationId: ORG_ID,
+        userId: USER_ID,
+        accountWalletAddress: null,
+        payerAddress: PAYER_EVM,
+        amountUsd: 10,
+        network: "bsc",
+        tokenSymbol: "USDT",
+      });
+      const hash = `0x${"b".repeat(64)}`;
+      await trustPayerProof(payment);
+      await service.attachTransaction(env, {
+        paymentId: payment.id,
+        txHash: hash,
+        userId: USER_ID,
+      });
+      // A definitively-terminal outcome — matches the terminal allowlist.
+      chainTxs.set(hash, {
+        from: PAYER_EVM,
+        to: env.CRYPTO_DIRECT_BSC_RECEIVE_ADDRESS,
+        value: 0n,
+        status: "success",
+        receiveAddress: env.CRYPTO_DIRECT_BSC_RECEIVE_ADDRESS,
+        throwTerminal: "Transaction amount is lower than the expected payment",
+      });
+      const stats = await service.processBroadcastBatch(env);
+      expect(stats.failed).toBe(1);
+      const row = await dbWrite.query.cryptoPayments.findFirst();
+      expect(row?.status).toBe("failed_chain");
+      // Failed on the first attempt: the terminal path never bumps verify_attempts.
+      expect(Number((row?.metadata as Record<string, unknown>).verify_attempts ?? 0)).toBe(0);
+    });
+
     test("Solana confirmPayment rejects when receiving ATA owner mismatches treasury", async () => {
       await resetTable();
       // Configure the parsed-tx + ATA-owner overrides for this test only.

--- a/packages/cloud/shared/src/lib/services/direct-wallet-payments.ts
+++ b/packages/cloud/shared/src/lib/services/direct-wallet-payments.ts
@@ -1659,8 +1659,13 @@ export class DirectWalletPaymentsService {
         // only the not-yet-mined strings, so an RPC blip coincident with the cron
         // tick terminally marked a genuinely-paid deposit `failed_chain` with no
         // self-serve recovery. Inverting the default lets a blip self-heal.
+        // The allowlist quotes the EXACT strings confirmPayment's validity
+        // checks throw (broad patterns like "does not match" are avoided on
+        // purpose: an infra error phrased that way — e.g. a chain-id mismatch
+        // from the RPC client — must stay transient, or the blip burns a paid
+        // deposit again).
         const terminal =
-          /does not match|lower than the expected|does not transfer enough|transaction failed|metadata mismatch|signature mismatch|invalid amount|tampered|reverted/i.test(
+          /Transaction failed|is below the expected floor|is above the expected ceiling|amount is lower than the expected|recipient does not match|sender does not match the proven payer|was not confirmed successfully|ATA owner does not match|LEGACY_PAYMENT_MISSING_PAYER_PROOF|not a direct wallet payment|invalid direct network metadata|proof metadata mismatch|does not transfer enough|tampered/i.test(
             msg,
           );
         const transient = !terminal;

--- a/packages/cloud/shared/src/lib/services/direct-wallet-payments.ts
+++ b/packages/cloud/shared/src/lib/services/direct-wallet-payments.ts
@@ -1644,11 +1644,26 @@ export class DirectWalletPaymentsService {
         stats.confirmed += 1;
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
-        // Heuristic: receipt-not-yet-found means we should keep waiting.
-        // Anything else (wrong recipient, low value, reverted) is terminal
-        // — record it so the user sees a clear failure.
-        const transient =
-          /not found|not yet|pending|TransactionReceiptNotFoundError|could not be found/i.test(msg);
+        // Classify with a TERMINAL-error allowlist, not a transient one (#11154).
+        // Only a definitively-bad payment should fail closed on the first attempt:
+        // wrong recipient/treasury/ATA/sweep key, amount lower than expected /
+        // not enough transferred, a reverted receipt ("Transaction failed"), a
+        // tampered/mismatched quote or proof, or an invalid amount. These are the
+        // strings confirmPayment throws for genuinely-bad payments.
+        //
+        // EVERYTHING ELSE is treated as transient and retried up to
+        // MAX_VERIFY_ATTEMPTS — crucially including RPC/infra failures (viem
+        // HttpRequestError "HTTP request failed", 503/timeout/rate-limit) and the
+        // receipt-not-yet-mined cases ("not found", "not yet", "pending",
+        // TransactionReceiptNotFoundError). The old transient allowlist matched
+        // only the not-yet-mined strings, so an RPC blip coincident with the cron
+        // tick terminally marked a genuinely-paid deposit `failed_chain` with no
+        // self-serve recovery. Inverting the default lets a blip self-heal.
+        const terminal =
+          /does not match|lower than the expected|does not transfer enough|transaction failed|metadata mismatch|signature mismatch|invalid amount|tampered|reverted/i.test(
+            msg,
+          );
+        const transient = !terminal;
 
         const attempts =
           Number((metadataOf(payment) as Record<string, unknown>).verify_attempts ?? 0) + 1;


### PR DESCRIPTION
Closes #11154. Follow-up to #10964.

## Problem
`processBroadcastBatch` (the direct-wallet auto-confirm cron) classified verify failures with a **transient allowlist** — `/not found|not yet|pending|TransactionReceiptNotFoundError|could not be found/i` — and sent **everything else** to `failed_chain` on the **first** attempt. RPC/infra failures don't match that regex: a Base/BSC RPC 503 makes viem throw `HttpRequestError("HTTP request failed.")`; rate-limit/timeout throw similar. So a **genuinely-paid** deposit whose confirm happened to hit the cron during an RPC blip was marked terminally failed — funds on-chain in the treasury, credit never lands, row terminal, no self-serve retry (user-money-loss requiring manual support).

## Fix
Invert to a **terminal allowlist**. Only a definitively-bad payment fails closed on attempt 1:
```
/does not match|lower than the expected|does not transfer enough|transaction failed|metadata mismatch|signature mismatch|invalid amount|tampered|reverted/i
```
(these are the exact strings `confirmPayment` throws for wrong recipient/treasury/ATA/sweep-key, amount-too-low / not-enough-transferred, reverted receipt, tampered/mismatched quote or proof, invalid amount). **Everything else is transient** and retried up to `MAX_VERIFY_ATTEMPTS` — RPC blips self-heal. The not-yet-mined strings stay transient (unchanged), and a transient failure still goes terminal after MAX attempts (unchanged).

## Tests (real PGlite integration; on-chain verify mocked via the file's existing viem mock)
- **#11154 transient RPC error** (`throwTerminal: "HTTP request failed."`) → row stays `broadcast`, `stillPending=1`, `failed=0`, `verify_attempts` bumped. *Before the fix this was `failed_chain`.*
- **#11154 genuinely-bad payment** (amount lower than expected) → `failed_chain` on the **first** attempt (no 60× spin).
- Existing `bumps verify_attempts / gives up at MAX` and `confirms on success` paths still pass — **6/6 processBroadcastBatch green**.

`typecheck` + `biome` clean on both files. — nubs-cloud (laptop/deploy lane, money-audit)