### PR TITLE
ci(deploy-apps-worker): keep the host-lock wait under the SSH command_timeout (post-#11165 polish)

### DIFF
--- a/.github/workflows/deploy-apps-worker.yml
+++ b/.github/workflows/deploy-apps-worker.yml
@@ -158,7 +158,9 @@ jobs:
             # overlapping runs are expected; without this they would interleave
             # git clean/bun install/systemctl restart on the same checkout.
             exec 9>/tmp/eliza-apps-worker-deploy.lock
-            flock -w 900 9 || { echo "::error::another apps-worker deploy holds the host lock after 15m"; exit 1; }
+            # 540s keeps the lock wait under this step's 10m command_timeout so
+            # a starved waiter fails with THIS message, not an opaque SSH kill.
+            flock -w 540 9 || { echo "::error::another apps-worker deploy holds the host lock after 9m"; exit 1; }
             echo "=== Deploying eliza-apps-worker (branch: $DEPLOY_BRANCH) ==="
 
             cd /opt/eliza


### PR DESCRIPTION
One-number polish from the post-merge review of #11165: the deploy step's `flock -w 900` (15m) exceeds its own `command_timeout: 10m`, so a lock-starved run dies as an opaque SSH kill instead of the intended `::error::another apps-worker deploy holds the host lock` message. 540s keeps the clean failure path reachable (health-check's 240s wait was already consistent with its 5m timeout). No behavior change for uncontended deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)