### PR TITLE
fix(orchestrator): task-store concurrency + delete correctness (#11028)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts
@@ -682,3 +682,47 @@ describe("RuntimeDbTaskStore", () => {
     expect(detail?.sessions[0]?.sessionId).toBe("session-1");
   });
 });
+
+describe("orchestrator-task-store audit follow-ups (#11028)", () => {
+  it("SQL deleteTask reports whether the task existed, not an unconditional true", async () => {
+    const store = new RuntimeDbTaskStore(new FakeSqlAdapter());
+    const { task } = await store.createTask(createInput({ title: "real" }));
+    expect(await store.deleteTask(task.id)).toBe(true);
+    // A task that never existed must return false so DELETE /tasks/:id can 404
+    // instead of answering a misleading 200.
+    expect(await store.deleteTask("does-not-exist")).toBe(false);
+    // Already deleted → false on a second call.
+    expect(await store.deleteTask(task.id)).toBe(false);
+  });
+
+  it("FileTaskStore merges a concurrent insert instead of clobbering it", async () => {
+    const path = await tempFile();
+    const a = new FileTaskStore(path);
+    const b = new FileTaskStore(path);
+    // Both instances load the empty file; each inserts a distinct task. Before
+    // the read-merge-write fix, b's whole-document write clobbered a's task.
+    const ta = await a.createTask(createInput({ title: "from A" }));
+    const tb = await b.createTask(createInput({ title: "from B" }));
+    const reader = new FileTaskStore(path);
+    const ids = (await reader.listTasks()).map((t) => t.id);
+    expect(ids).toContain(ta.task.id);
+    expect(ids).toContain(tb.task.id);
+  });
+
+  it("FileTaskStore delete is honored even when afterWrite re-reads the deleted task from a concurrent write", async () => {
+    const path = await tempFile();
+    const a = new FileTaskStore(path);
+    const seed = await a.createTask(createInput({ title: "seed" }));
+    // A concurrent insert lands on disk (a second instance persists task X).
+    const b = new FileTaskStore(path);
+    const x = await b.createTask(createInput({ title: "X" }));
+    // `a` (which only knows about seed) deletes it. afterWrite re-reads disk
+    // {seed, X}; the tombstone drops seed while the concurrent insert X survives.
+    // Without the tombstone the re-read would resurrect seed.
+    expect(await a.deleteTask(seed.task.id)).toBe(true);
+    const reader = new FileTaskStore(path);
+    const ids = (await reader.listTasks()).map((t) => t.id);
+    expect(ids).not.toContain(seed.task.id);
+    expect(ids).toContain(x.task.id);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
@@ -89,8 +89,17 @@ const MAX_USAGE = 1000;
 const MAX_DECISIONS = 300;
 const MAX_ARTIFACTS = 200;
 
+// How long a waiter keeps trying to acquire the lock before giving up.
 const FILE_LOCK_ACQUIRE_TIMEOUT_MS = 30_000;
-const FILE_LOCK_STALE_MS = 30_000;
+// A lock is only reclaimed as "stale" once it is older than this. It MUST be
+// shorter than the acquire timeout (so a waiter can reclaim a dead lock within
+// its own wait window) yet far longer than a legitimate hold — the guarded work
+// is a single atomic temp-file write + rename, sub-second even for large task
+// histories, so a lock older than 10s means the holder died mid-write. Setting
+// this equal to the acquire timeout (the previous value) let a waiter give up at
+// the exact moment a lock became reclaimable, and risked reclaiming a lock still
+// held by a slow-but-alive writer.
+const FILE_LOCK_STALE_MS = 10_000;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -522,6 +531,11 @@ function defaultStateFile(runtime?: TaskStoreRuntime): string {
 export class FileTaskStore extends InMemoryTaskStore {
   private readonly lockFile: string;
   private loaded = false;
+  // Ids deleted by this process since the last persist. afterWrite() re-reads the
+  // on-disk document set under the lock and merges it with this process's
+  // in-memory docs; tombstones ensure a task this process deleted is not
+  // resurrected from a concurrent process's copy of the file.
+  private readonly tombstones = new Set<string>();
 
   constructor(
     private readonly filePath: string,
@@ -583,6 +597,9 @@ export class FileTaskStore extends InMemoryTaskStore {
   }
   override async deleteTask(id: string) {
     await this.ensureLoaded();
+    // Record the tombstone BEFORE the write so afterWrite()'s disk merge removes
+    // it even if a concurrent process's on-disk copy still carries the task.
+    this.tombstones.add(id);
     return super.deleteTask(id);
   }
   override async addSession(session: OrchestratorTaskSession) {
@@ -628,8 +645,40 @@ export class FileTaskStore extends InMemoryTaskStore {
   protected override async afterWrite(): Promise<void> {
     await this.withLock(async () => {
       await mkdir(dirname(this.filePath), { recursive: true });
+      // Read-merge-write under the lock so a concurrent process's inserts/updates
+      // to OTHER tasks survive this process's whole-document write. Merge order:
+      //   1. seed from the current on-disk set (picks up concurrent inserts),
+      //   2. drop this process's deletes (tombstones),
+      //   3. overlay this process's in-memory docs (its inserts/updates win; a
+      //      re-created id is present in this.docs so it is restored after the
+      //      tombstone delete).
+      // Residual: two processes updating DIFFERENT fields of the SAME task still
+      // resolves last-writer-wins at the document level (matching the SQL
+      // backend's single-row semantics); cross-task lost updates are eliminated.
+      const merged = new Map<string, OrchestratorTaskDocument>();
+      try {
+        const contents = await readFile(this.filePath, "utf8");
+        const parsed = JSON.parse(contents) as unknown;
+        if (Array.isArray(parsed)) {
+          for (const raw of parsed) {
+            const doc = normalizeTaskDocument(raw);
+            if (doc) merged.set(doc.task.id, doc);
+          }
+        }
+      } catch (error) {
+        const code =
+          isRecord(error) && typeof error.code === "string" ? error.code : "";
+        if (code !== "ENOENT") throw error;
+      }
+      for (const id of this.tombstones) merged.delete(id);
+      for (const [id, doc] of this.docs) merged.set(id, doc);
+      // Adopt the merged view so subsequent reads in this process observe the
+      // concurrent inserts too, then clear the applied tombstones.
+      this.docs.clear();
+      for (const [id, doc] of merged) this.docs.set(id, doc);
+      this.tombstones.clear();
       const tempPath = `${this.filePath}.${process.pid}.${Date.now()}.tmp`;
-      const payload = JSON.stringify([...this.docs.values()], null, 2);
+      const payload = JSON.stringify([...merged.values()], null, 2);
       await writeFile(tempPath, `${payload}\n`, "utf8");
       await rename(tempPath, this.filePath);
     });
@@ -858,6 +907,13 @@ export class RuntimeDbTaskStore {
   async deleteTask(id: string): Promise<boolean> {
     return this.enqueue(async () => {
       await this.ensureInitialized();
+      // The SqlExecutor.run contract returns void (no affected-row count that is
+      // portable across the raw-sqlite and drizzle backends), so probe existence
+      // first and report it faithfully. Returning an unconditional `true` (the
+      // previous behavior) diverged from InMemoryTaskStore.deleteTask and made
+      // the DELETE /tasks/:id route answer 200 for tasks that never existed.
+      const existing = await this.loadOne(id);
+      if (!existing) return false;
       await this.exec().run("DELETE FROM orchestrator_tasks WHERE id = ?", [
         id,
       ]);


### PR DESCRIPTION
Three durable-task-store fixes from the 2026-07 orchestrator audit follow-ups (**#11028**). All self-contained in `orchestrator-task-store.ts` + covered by unit tests.

## Fixes

1. **FileTaskStore lost cross-process updates.** It loaded the JSON once and every mutation wrote the whole in-memory document set back, clobbering tasks a concurrent process had inserted. `afterWrite()` now **read-merge-writes under the lock**: seed from the on-disk set → drop this process's deletes (tombstones) → overlay this process's docs. Concurrent inserts survive; a deleted task isn't resurrected by the re-read. Same-document field updates still resolve last-writer-wins (matching the SQL backend's single-row semantics).

2. **`RuntimeDbTaskStore.deleteTask` always returned `true`** regardless of whether a row existed → `DELETE /tasks/:id` answered 200 for tasks that never existed. It now probes existence (`loadOne`) and reports it faithfully, matching `InMemoryTaskStore.deleteTask`. (`SqlExecutor.run` returns `void` — no portable affected-row count across the raw-sqlite and drizzle backends — so existence is probed.)

3. **File lock stale-threshold equaled the acquire timeout** (both 30s): a waiter gave up exactly when a lock became reclaimable, and a slow-but-alive writer risked having its lock broken. Stale is now 10s — shorter than the 30s acquire window (so a waiter can reclaim a genuinely dead lock within its wait), and far longer than the sub-second temp-file write+rename (so a live holder is never stolen from).

## Evidence

```
$ bunx vitest run __tests__/unit/orchestrator-task-store.test.ts
Test Files  1 passed (1)
     Tests  32 passed (32)
```

New cases (all passing):
- SQL `deleteTask` returns the real boolean, incl. unknown-id → `false` and double-delete → `false`.
- `FileTaskStore` merges a concurrent insert instead of clobbering it.
- `FileTaskStore` delete is honored even when `afterWrite` re-reads the deleted task from a concurrent write (tombstone), while the concurrent insert is preserved.

Refs #11028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)