### PR TITLE
fix(voice): truthful AEC echo-reference status + live-path wiring (#9583)

### DIFF
--- a/plugins/plugin-local-inference/src/routes/live-diarization-route.test.ts
+++ b/plugins/plugin-local-inference/src/routes/live-diarization-route.test.ts
@@ -161,7 +161,12 @@ describe("handleLiveDiarizationRoute", () => {
 			models: { dir: string };
 			framesReceived: number;
 			turnsObserved: number;
-			aec: { echoReferenceWired: boolean };
+			aec: {
+				echoReferenceWired: boolean;
+				playbackFramesReceived: number;
+				playbackSamplesReceived: number;
+				lastPlaybackFrameAt: number | null;
+			};
 			error?: string;
 		};
 		// On CI/host there is no fused libelizainference, so readiness fails with
@@ -173,6 +178,9 @@ describe("handleLiveDiarizationRoute", () => {
 		expect(status.framesReceived).toBe(0);
 		expect(status.turnsObserved).toBe(0);
 		expect(status.aec.echoReferenceWired).toBe(false);
+		expect(status.aec.playbackFramesReceived).toBe(0);
+		expect(status.aec.playbackSamplesReceived).toBe(0);
+		expect(status.aec.lastPlaybackFrameAt).toBeNull();
 		if (!status.ready) {
 			expect(status.error).toMatch(
 				/fused libelizainference|ABI|FFI|libelizainference/i,
@@ -196,9 +204,67 @@ describe("handleLiveDiarizationRoute", () => {
 		expect(handled).toBe(true);
 		expect(res.statusCode).toBe(200);
 		const status = res.json() as {
-			aec: { echoReferenceWired: boolean };
+			aec: { echoReferenceWired: boolean; playbackFramesReceived: number };
 		};
+		// Provider-based wiring is truthful with zero playback frames: the host
+		// owns the far-end capture, so no /api/voice/playback-frames traffic is
+		// expected on this path.
 		expect(status.aec.echoReferenceWired).toBe(true);
+		expect(status.aec.playbackFramesReceived).toBe(0);
+	});
+
+	it("reports echoReferenceWired only after playback frames are actually delivered (#9583)", async () => {
+		// Before any playback delivery the status must NOT claim a wired far-end.
+		const statusBefore = new FakeRes();
+		await handleLiveDiarizationRoute(
+			makeReq({ method: "GET", url: "/api/voice/audio-frames/status" }),
+			statusBefore as unknown as http.ServerResponse,
+			runtimeState(),
+		);
+		expect(statusBefore.statusCode).toBe(200);
+		const before = statusBefore.json() as {
+			aec: {
+				echoReferenceWired: boolean;
+				playbackFramesReceived: number;
+				lastPlaybackFrameAt: number | null;
+			};
+		};
+		expect(before.aec.echoReferenceWired).toBe(false);
+		expect(before.aec.playbackFramesReceived).toBe(0);
+		expect(before.aec.lastPlaybackFrameAt).toBeNull();
+
+		const push = new FakeRes();
+		await handleLiveDiarizationRoute(
+			makeReq({
+				method: "POST",
+				url: "/api/voice/playback-frames",
+				body: { frames: [silentFrame(0), silentFrame(1)] },
+			}),
+			push as unknown as http.ServerResponse,
+			runtimeState(),
+		);
+		expect(push.statusCode).toBe(200);
+		expect(push.json()).toMatchObject({ ok: true, framesPushed: 2 });
+
+		const statusAfter = new FakeRes();
+		await handleLiveDiarizationRoute(
+			makeReq({ method: "GET", url: "/api/voice/audio-frames/status" }),
+			statusAfter as unknown as http.ServerResponse,
+			runtimeState(),
+		);
+		expect(statusAfter.statusCode).toBe(200);
+		const after = statusAfter.json() as {
+			aec: {
+				echoReferenceWired: boolean;
+				playbackFramesReceived: number;
+				playbackSamplesReceived: number;
+				lastPlaybackFrameAt: number | null;
+			};
+		};
+		expect(after.aec.echoReferenceWired).toBe(true);
+		expect(after.aec.playbackFramesReceived).toBe(2);
+		expect(after.aec.playbackSamplesReceived).toBe(640);
+		expect(typeof after.aec.lastPlaybackFrameAt).toBe("number");
 	});
 
 	it("rejects a malformed frame batch with 400", async () => {

--- a/plugins/plugin-local-inference/src/services/voice/live-diarization-session.echo.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/live-diarization-session.echo.test.ts
@@ -9,7 +9,7 @@
  * fused VAD/encoder/diarizer) is covered by the host smoke harness.
  */
 
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { AudioFrameEvent } from "./audio-frame-consumer.js";
 import { platformPlaybackDelaySamples } from "./echo-delay.js";
 import {
@@ -122,6 +122,94 @@ describe("LiveDiarizationSession echo reference", () => {
 		expect(session.echoReferenceFrame(100, 320).some((v) => v !== 0)).toBe(
 			true,
 		);
+	});
+
+	it("reports echoReferenceWired=false while the consumer is built but no playback ever arrived (#9583)", async () => {
+		const session = new LiveDiarizationSession(fakeRuntime());
+		// Simulate the on-device state where the fused consumer built fine but no
+		// far-end playback was ever delivered. The old status computed
+		// `wired = consumer != null || options.echoReference != null` — a
+		// tautology that read true here even though the canceller had only a
+		// zero-filled reference (i.e. AEC was NOT doing anything).
+		(session as unknown as { consumer: { droppedFrames: number } }).consumer = {
+			droppedFrames: 0,
+		};
+
+		const before = await session.status();
+		expect(before.ready).toBe(true);
+		expect(before.aec.echoReferenceWired).toBe(false);
+		expect(before.aec.playbackFramesReceived).toBe(0);
+		expect(before.aec.playbackSamplesReceived).toBe(0);
+		expect(before.aec.lastPlaybackFrameAt).toBeNull();
+
+		session.pushPlayback([playbackFrame(ramp(320), 0)]);
+
+		const after = await session.status();
+		expect(after.aec.echoReferenceWired).toBe(true);
+		expect(after.aec.playbackFramesReceived).toBe(1);
+		expect(after.aec.playbackSamplesReceived).toBe(320);
+		expect(typeof after.aec.lastPlaybackFrameAt).toBe("number");
+	});
+
+	describe("status() AEC truthfulness with a deterministic build failure", () => {
+		// Force the fused-lib resolution to fail so the (heavy, host-dependent)
+		// consumer build never runs: the wired signal must track far-end DELIVERY
+		// and provider registration, not the consumer build.
+		let prevLib: string | undefined;
+		let prevDir: string | undefined;
+		beforeEach(() => {
+			prevLib = process.env.ELIZA_INFERENCE_LIBRARY;
+			prevDir = process.env.ELIZA_INFERENCE_LIB_DIR;
+			process.env.ELIZA_INFERENCE_LIBRARY = "/nonexistent/libelizainference.so";
+			delete process.env.ELIZA_INFERENCE_LIB_DIR;
+		});
+		afterEach(() => {
+			if (prevLib === undefined) delete process.env.ELIZA_INFERENCE_LIBRARY;
+			else process.env.ELIZA_INFERENCE_LIBRARY = prevLib;
+			if (prevDir !== undefined) process.env.ELIZA_INFERENCE_LIB_DIR = prevDir;
+		});
+
+		it("flips echoReferenceWired on real far-end delivery even when the consumer never built", async () => {
+			const session = new LiveDiarizationSession(fakeRuntime());
+			const before = await session.status();
+			expect(before.ready).toBe(false);
+			expect(before.aec.echoReferenceWired).toBe(false);
+
+			session.pushPlayback([
+				playbackFrame(ramp(320), 0),
+				playbackFrame(ramp(320), 1),
+			]);
+
+			const after = await session.status();
+			expect(after.aec.echoReferenceWired).toBe(true);
+			expect(after.aec.playbackFramesReceived).toBe(2);
+			expect(after.aec.playbackSamplesReceived).toBe(640);
+		});
+
+		it("reports echoReferenceWired=true for a host-registered provider with zero playback frames", async () => {
+			const session = new LiveDiarizationSession(fakeRuntime(), {
+				echoReference: () => new Float32Array(320),
+			});
+			const status = await session.status();
+			expect(status.aec.echoReferenceWired).toBe(true);
+			expect(status.aec.playbackFramesReceived).toBe(0);
+			expect(status.aec.lastPlaybackFrameAt).toBeNull();
+		});
+
+		it("keeps cumulative delivery counters (and wired) across resetPlayback", async () => {
+			const session = new LiveDiarizationSession(fakeRuntime());
+			session.pushPlayback([playbackFrame(ramp(320), 0)]);
+			session.resetPlayback();
+			// The buffer is dropped (barge-in), but the transport already proved it
+			// delivers — the wiring evidence is cumulative, not a live-buffer gauge.
+			expect(session.echoReferenceFrame(0, 320).every((v) => v === 0)).toBe(
+				true,
+			);
+			const status = await session.status();
+			expect(status.aec.echoReferenceWired).toBe(true);
+			expect(status.aec.playbackFramesReceived).toBe(1);
+			expect(status.aec.playbackSamplesReceived).toBe(320);
+		});
 	});
 
 	it("self-calibrates playback-to-mic delay from correlated echo", () => {

--- a/plugins/plugin-local-inference/src/services/voice/live-diarization-session.ts
+++ b/plugins/plugin-local-inference/src/services/voice/live-diarization-session.ts
@@ -110,9 +110,22 @@ export interface LiveDiarizationStatus {
 	framesDropped: number;
 	/** Turns segmented + attributed so far. */
 	turnsObserved: number;
-	/** Live AEC wiring status. Echo cancellation runs only when this is true. */
+	/** Live AEC wiring status. */
 	aec: {
+		/**
+		 * True only when a real far-end source exists: a host-registered echo
+		 * reference provider, or at least one playback frame with samples actually
+		 * delivered via `/api/voice/playback-frames`. Cancellation is active only
+		 * when this AND `ready` are both true. Cumulative — a playback reset does
+		 * not un-prove that the far-end transport delivered (#9583).
+		 */
 		echoReferenceWired: boolean;
+		/** Far-end playback frames delivered via /api/voice/playback-frames. */
+		playbackFramesReceived: number;
+		/** Total decoded far-end samples delivered (@16 kHz). */
+		playbackSamplesReceived: number;
+		/** Wall-clock epoch ms of the last delivered playback frame (null = never). */
+		lastPlaybackFrameAt: number | null;
 		/** Playback→mic delay (samples @16 kHz) currently applied to align the
 		 * far-end reference — self-calibrated from real echo when confident,
 		 * otherwise the `ELIZA_VOICE_ECHO_DELAY_MS` seed (default 0). */
@@ -295,6 +308,16 @@ export class LiveDiarizationSession {
 	private echoDelaySamples = resolveEchoDelaySamples();
 	private echoDelayConfidence = 0;
 	private echoDelayCalibrated = false;
+	/**
+	 * Far-end delivery evidence (#9583): frames/samples actually pushed through
+	 * {@link pushPlayback} and the wall-clock time of the last one. These drive
+	 * the truthful `aec.echoReferenceWired` status — the wiring is only "live"
+	 * once a real far-end source has delivered samples, never merely because the
+	 * consumer built. Cumulative across {@link resetPlayback}.
+	 */
+	private playbackFramesReceived = 0;
+	private playbackSamplesReceived = 0;
+	private lastPlaybackFrameAt: number | null = null;
 	/** Rolling near/far windows accumulated only while the far-end is active, used
 	 * once to estimate the playback→mic delay. Cleared after a confident estimate
 	 * and on {@link resetPlayback}. */
@@ -535,7 +558,11 @@ export class LiveDiarizationSession {
 	 */
 	pushPlayback(frames: AudioFrameEvent[]): void {
 		for (const frame of frames) {
-			this.echoBuffer.pushAt(frame.timestamp, decodeAudioFramePcm(frame));
+			const pcm = decodeAudioFramePcm(frame);
+			this.echoBuffer.pushAt(frame.timestamp, pcm);
+			this.playbackFramesReceived += 1;
+			this.playbackSamplesReceived += pcm.length;
+			this.lastPlaybackFrameAt = Date.now();
 		}
 	}
 
@@ -589,8 +616,16 @@ export class LiveDiarizationSession {
 			framesDropped: this.consumer?.droppedFrames ?? 0,
 			turnsObserved: this.turnsObserved,
 			aec: {
+				// Truthful wiring signal (#9583): a host provider is registered, or a
+				// real far-end source actually delivered samples. A merely-built
+				// consumer is NOT a far-end — with no delivery the reference reads
+				// zeros and the NLMS canceller is a passthrough.
 				echoReferenceWired:
-					this.consumer != null || this.options.echoReference != null,
+					this.options.echoReference != null ||
+					this.playbackSamplesReceived > 0,
+				playbackFramesReceived: this.playbackFramesReceived,
+				playbackSamplesReceived: this.playbackSamplesReceived,
+				lastPlaybackFrameAt: this.lastPlaybackFrameAt,
 				echoDelaySamples: this.echoDelaySamples,
 				echoDelayConfidence: this.echoDelayConfidence,
 			},


### PR DESCRIPTION
## Summary

`GET /api/voice/audio-frames/status` reported `aec.echoReferenceWired = consumer != null || options.echoReference != null` (`live-diarization-session.ts`) — true the moment the fused consumer built, even if **no far-end playback frame had ever arrived**. In that state the NLMS canceller reads a zero-filled reference and cancels nothing, so the "wired" device-evidence read was a larp signal.

This PR makes the AEC status truthful and pins it with tests that fail on the old tautology:

- The session now tracks real far-end delivery: `playbackFramesReceived`, `playbackSamplesReceived` (total decoded samples), and `lastPlaybackFrameAt` (wall-clock epoch ms), all cumulative across `resetPlayback` (a barge-in does not un-prove that the transport delivers).
- `aec.echoReferenceWired` is now true ONLY when a host echo-reference provider is registered **or** `/api/voice/playback-frames` actually delivered samples. A merely-built consumer no longer counts.
- The status DTO exposes the three new fields next to the existing `echoDelaySamples` / `echoDelayConfidence`.

No wire-format or route-contract change; the `aec` object is widened additively and only its boolean semantics are corrected. `echoReferenceWired` had no consumers outside the session and its tests.

## Tests (fail on the old tautology — verified)

New/updated coverage in `live-diarization-session.echo.test.ts` and `live-diarization-route.test.ts`:

- **wired=false with a built consumer and zero playback** (the tautology-killer: on the old computation this read true),
- wired flips to true on real far-end delivery even when the consumer never built (deterministic forced build-failure via `ELIZA_INFERENCE_LIBRARY=/nonexistent/...`),
- host-provider registration wires truthfully with `playbackFramesReceived === 0`,
- delivery counters (and wired) stay cumulative across `resetPlayback`,
- route-level end-to-end: `POST /api/voice/playback-frames` (2 frames) → `GET /api/voice/audio-frames/status` shows `wired=true, playbackFramesReceived=2, playbackSamplesReceived=640, lastPlaybackFrameAt: number`.

Red-proof: with only the `status()` computation reverted to the old tautology, exactly the 4 new truthfulness tests fail (3 session, 1 route), 25 others still pass:

```
❯ live-diarization-session.echo.test.ts (14 tests | 3 failed)
    × reports echoReferenceWired=false while the consumer is built but no playback ever arrived (#9583)
    × flips echoReferenceWired on real far-end delivery even when the consumer never built
    × keeps cumulative delivery counters (and wired) across resetPlayback
❯ live-diarization-route.test.ts (15 tests | 1 failed)
    × reports echoReferenceWired only after playback frames are actually delivered (#9583)
```

Green run (this branch):

```
bun run --cwd plugins/plugin-local-inference test -- \
  src/services/voice/nlms-echo-canceller.test.ts \
  src/services/voice/echo-reference-buffer.test.ts \
  src/services/voice/live-diarization-session.echo.test.ts \
  src/services/voice/audio-frame-consumer.test.ts \
  src/routes/live-diarization-route.test.ts
Test Files  5 passed (5)
     Tests  64 passed (64)
```

`bun run --cwd plugins/plugin-local-inference typecheck` clean; biome clean on touched files.

## Verified findings on the live AEC wiring (#9583)

1. **The host-provider seam is unregistered in production.** `voiceEchoReferenceProvider` / `getVoiceEchoReferenceProvider` (`live-diarization-route.ts:48-68`) has no producer anywhere in the repo — only the route, its test, and the consumer type. The only working live far-end source today is the WebView `PlaybackFramePump` (`packages/ui/src/voice/playback-frame-pump.ts`, wired in `useVoiceChat.ts` for both ElevenLabs and local-inference Web-Audio playback) posting to `POST /api/voice/playback-frames`. The seam is kept as the documented host hook; registration now truthfully reports wired.
2. **The old status was a tautology** — fixed here.
3. **The JNI in-process ambient pipeline has no AEC** — gap analysis below; not larped in this PR.

## JNI ambient pipeline AEC — gap analysis (native work required; intentionally NOT implemented here)

Traced end-to-end in this tree:

- Uplink: `packages/ui/src/voice/jni-voice-harness.ts:105` forwards completed mic turns to `POST /api/voice/native-pcm-turn` → `native-pcm-turn-route.ts:99-105` → `localInferenceEngine.runVoiceTurn(...)`. The mic hot path (VAD/segmentation/speaker/diariz) runs **natively** inside `ElizaVoice.pipelineProcess`; the WebView only batches base64 PCM (`jni-voice-pipeline.ts` `concatFramesToBase64`).
- Far-end: the voice pipeline in this flow is stood up with **no sink and no `onAudio`** (`engine.ts` `startVoice`, `engine-bridge.ts:1166-1172`), so TTS PCM terminates in the in-process `InMemoryAudioSink` (`scheduler.ts:205`, `ring-buffer.ts:101-107`). It is never streamed to the WebView; `VoicePipelineEvents` (`pipeline.ts:169-188`) exposes no audio hook. Nothing here for a `PlaybackFramePump`-style tap to attach to.
- When TTS is actually audible on Android in ambient/talk mode, it renders **natively via `AudioTrack`** in `plugins/plugin-native-talkmode/android/.../TalkModePlugin.kt` (`createPcmAudioTrack` ~L1501; `play()` ~L1263/L1355), driven by `TalkMode.speak()`. Native `AudioTrack` output is not reachable from Web Audio.
- Even if far-end frames were POSTed to `/api/voice/playback-frames`, that feeds `LiveDiarizationSession`'s canceller — which the JNI mic path bypasses entirely (its VAD runs native). Cancellation for the JNI path must happen before the native VAD.

**Conclusion: a clean browser-side seam does not exist. Real AEC for the JNI ambient path requires native work.** Follow-up plan (proposed for a separate issue/PR):

1. **Kotlin far-end tap:** capture the exact PCM written to the `AudioTrack` in `TalkModePlugin.kt` (`streamAndPlayLocalInferenceTts` / `streamAndPlayBionicKokoroTts` write loops), 16 kHz mono LE-s16 — the same wire format as `audioFrame`.
2. **Preferred: native NLMS pre-filter** in the JNI voice pipeline (before `eliza_inference_vad_*`), fed by a far-end ring buffer written from the Kotlin tap — single clock domain, no bridge chatter, same NLMS design as `nlms-echo-canceller.ts`.
3. **Alternative:** emit the far-end tap as a Capacitor `playbackFrame` event and run a JS NLMS over mic batches in `JniVoicePipeline` before `pipelineProcess` — no C++ change, but adds bridge traffic and cross-clock alignment.
4. Either variant can then report delivery through the same truthful counters this PR introduces.

Until then, the JNI path's only echo defenses remain speaker-attribution self-voice rejection (`resolveSelfVoiceSimilarity`) + reply-recency gating — unchanged by this PR.

## Evidence

| Evidence | Status |
| --- | --- |
| Unit tests (red-proof on old code + green run) | Attached above — 64/64 across the 5 voice suites; 4 new tests verified to fail on the reverted tautology |
| Typecheck / lint | `tsgo --noEmit` clean; biome clean on touched files |
| Backend logs | N/A — no logging-path change; the change is a status DTO computation + counters, fully covered by route-level tests exercising the real HTTP handler |
| Frontend console/network logs | N/A — no frontend change in this PR |
| Before/after screenshots (desktop + mobile) | N/A — no UI change; the status endpoint has no UI consumer |
| Video walkthrough | N/A — backend status contract change; the route-level test transcript above is the observable flow |
| Real-LLM trajectories | N/A — no agent/action/prompt/model change |
| On-device (Pixel 6a) evidence | Being captured separately on the Pixel 6a by a parallel lane — see issue #9583. This PR's truthful `playbackFramesReceived` / `lastPlaybackFrameAt` fields are what that lane reads as proof of live far-end delivery |

Closes nothing on its own; tracked under #9583.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
