### PR TITLE
fix(android): run the Mali flash-attn gate before staging into jniLibs (post-#11173 audit)

### DIFF
--- a/packages/app-core/scripts/stage-elizavoice-lib.mjs
+++ b/packages/app-core/scripts/stage-elizavoice-lib.mjs
@@ -344,6 +344,17 @@ if (variant === "cpu") {
   }
 }
 
+// Gate the BUILT artifacts before anything touches the shipping jniLibs dir:
+// running the Mali check only after staging (as before) left the rejected
+// libggml-vulkan.so already copied over a previously-good set on a red run,
+// where a later gradle build that skips this script would package it.
+if (variant === "vulkan") {
+  assertVulkanMaliMitigation({
+    lib: path.join(binDir, "libelizainference.so"),
+    target: `android-${abi}-vulkan`,
+  });
+}
+
 const staged = [];
 for (const name of toStage) {
   const src = path.join(binDir, name);


### PR DESCRIPTION
Post-merge audit finding on #11173: the fail-closed Mali gate in `stage-elizavoice-lib.mjs` fired only **after** the vulkan sibling set was already stripped + copied into the shipping `jniLibs` dir — a red run exits 1 but leaves the rejected `libggml-vulkan.so` staged over a previously-good set, and a later gradle/APK build that skips this script would package the artifact the gate just rejected.

**Fix:** gate the BUILT artifacts in `binDir` before the staging loop (helper derives `libggml-vulkan.so` next to the passed lib, so pointing it at the binDir engine checks the built backend; jniLibs stays untouched on red). The existing post-stage check remains as the belt that the mitigation marker survived `llvm-strip`.

Evidence: `node --check` clean; `verify-fused-symbols` helper tests 4/4 (the helper's fail-closed throw on marker-less backends is what both call sites rely on — unchanged). Ordering-only change in a build script; no unit seam exists without refactoring the script into functions, stated honestly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)