### PR TITLE
fix(ui/chat): overlay draft persistence + retry on failed turns (platform parity) + de-larp STOP test

### DIFF
--- a/packages/ui/src/components/composites/chat/chat-composer.stop.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-composer.stop.test.tsx
@@ -137,12 +137,6 @@ function deferred<T = void>(): {
   return { promise, resolve };
 }
 
-function abortError(): Error {
-  const err = new Error("aborted");
-  err.name = "AbortError";
-  return err;
-}
-
 function makeDeps(
   conversations: Conversation[],
   activeConversationId: string,
@@ -212,9 +206,17 @@ describe("useChatSend.handleChatStop", () => {
     });
   });
 
-  it("stops the growing assistant bubble and POSTs the backend turn abort", async () => {
+  it("keeps the interrupted partial (marked interrupted) and POSTs the backend turn abort", async () => {
     const started = deferred();
     let emitToken: ((token: string) => void) | null = null;
+    let lastStreamed = "";
+    // Mirror the REAL stream client (client-base.ts): a user Stop aborts the
+    // signal, and the client CANCELS the reader and RESOLVES with whatever
+    // streamed so far as an interrupted turn (`completed: false`) — it does NOT
+    // reject with an AbortError. That resolve is exactly what drives
+    // useChatSend's interrupt-marking + reattachInterruptedPartial; a mock that
+    // rejected instead would exercise the wrong (drop-empty-placeholder) path
+    // and could never assert the interrupted bubble is KEPT.
     mocks.client.sendConversationMessageStream.mockImplementation(
       (
         _id: string,
@@ -223,12 +225,22 @@ describe("useChatSend.handleChatStop", () => {
         _channelType: string,
         signal?: AbortSignal,
       ) => {
-        emitToken = (token: string) => onToken(token, token);
+        emitToken = (token: string) => {
+          lastStreamed = token;
+          onToken(token, token);
+        };
         started.resolve();
-        return new Promise((_resolve, reject) => {
-          signal?.addEventListener("abort", () => reject(abortError()), {
-            once: true,
-          });
+        return new Promise((resolve) => {
+          signal?.addEventListener(
+            "abort",
+            () =>
+              resolve({
+                text: lastStreamed,
+                agentName: "Eliza",
+                completed: false,
+              }),
+            { once: true },
+          );
         });
       },
     );
@@ -236,6 +248,19 @@ describe("useChatSend.handleChatStop", () => {
     const { deps, conversationMessagesRef } = makeDeps(
       [conversation("conv-1", "room-1")],
       "conv-1",
+    );
+    // Simulate the post-turn history reload: the server did NOT persist the
+    // reply that was cut off mid-stream, so the reload full-replaces the thread
+    // with just the user turn. This is precisely the case reattachInterruptedPartial
+    // exists to heal — without it the partial the user watched stream in would
+    // silently vanish. Assigned BEFORE renderHook so useChatSend's callbacks
+    // close over this override.
+    deps.loadConversationMessages = vi.fn(
+      async (): Promise<LoadConversationMessagesResult> => {
+        conversationMessagesRef.current =
+          conversationMessagesRef.current.filter((m) => m.role === "user");
+        return { ok: true };
+      },
     );
     const { result } = renderHook(() => useChatSend(deps));
 
@@ -264,7 +289,8 @@ describe("useChatSend.handleChatStop", () => {
     );
     expect(assistantBefore?.text).toBe("partial reply so far");
 
-    // Stop: abort fires, the stream rejects, the bubble stops growing.
+    // Stop: abort fires, the stream resolves as interrupted, the partial is
+    // marked + reattached after the reload that dropped it.
     act(() => {
       result.current.handleChatStop();
     });
@@ -277,14 +303,21 @@ describe("useChatSend.handleChatStop", () => {
       "room-1",
       "ui-chat-stop",
     );
-    // No further token can grow the bubble after abort — its text is frozen at
-    // the last streamed value (the empty interrupted draft is dropped, a
-    // non-empty one stays put).
+    // STOP-keeps-the-partial (reattachInterruptedPartial): after the stop, the
+    // partial assistant bubble the user watched stream in MUST still exist,
+    // carry the interrupted marker, and hold exactly the partial text — even
+    // though the post-turn reload full-replaced the thread without it. No
+    // `?? fallback`: a deleted bubble (the pre-fix regression) fails here.
     const assistantAfter = conversationMessagesRef.current.find(
       (m) => m.role === "assistant",
     );
-    expect(assistantAfter?.text ?? "partial reply so far").toBe(
-      "partial reply so far",
-    );
+    expect(assistantAfter).toBeDefined();
+    expect(assistantAfter?.interrupted).toBe(true);
+    expect(assistantAfter?.text).toBe("partial reply so far");
+    // And it is the ONLY assistant turn — reattach never duplicates the bubble.
+    expect(
+      conversationMessagesRef.current.filter((m) => m.role === "assistant")
+        .length,
+    ).toBe(1);
   });
 });

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -18,6 +18,11 @@ import {
   vi,
 } from "vitest";
 
+import {
+  clearChatDraft,
+  writeChatDraft,
+} from "../../state/ChatComposerContext.hooks";
+
 // The resting overlay's suggestion strip fetches model suggestions via the
 // shared client; stub it so the strip stays on its static fallback in tests.
 vi.mock("../../api/client", () => ({
@@ -2674,5 +2679,73 @@ describe("ContinuousChatOverlay — OS assistant / deep-link launch (#9148)", ()
       (screen.getByLabelText("message") as HTMLTextAreaElement).value,
     ).toBe("");
     expect(toggleHandsFree).not.toHaveBeenCalled();
+  });
+
+  it("shows Retry on a recoverable failed assistant turn and re-sends the preceding user turn", () => {
+    const controller = makeController({
+      messages: [
+        {
+          id: "u1",
+          role: "user",
+          content: "what's the weather?",
+          createdAt: 1,
+        },
+        {
+          id: "a1",
+          role: "assistant",
+          content: "",
+          createdAt: 2,
+          failureKind: "rate_limited",
+        },
+      ],
+    } as unknown as Partial<ShellController>);
+    render(<ContinuousChatOverlay controller={controller} />);
+    fireEvent.focus(screen.getByLabelText("message"));
+    const retry = screen.getByTestId("thread-line-retry");
+    expect(retry).toBeTruthy();
+    fireEvent.click(retry);
+    expect(controller.send).toHaveBeenCalledWith("what's the weather?");
+  });
+
+  it("does NOT show Retry on an unrecoverable failure (no_provider / insufficient_credits)", () => {
+    const controller = makeController({
+      messages: [
+        { id: "u1", role: "user", content: "hi", createdAt: 1 },
+        {
+          id: "a1",
+          role: "assistant",
+          content: "",
+          createdAt: 2,
+          failureKind: "insufficient_credits",
+        },
+      ],
+    } as unknown as Partial<ShellController>);
+    render(<ContinuousChatOverlay controller={controller} />);
+    fireEvent.focus(screen.getByLabelText("message"));
+    expect(screen.queryByTestId("thread-line-retry")).toBeNull();
+  });
+
+  it("restores the persisted composer draft for the active conversation (overlay draft parity)", () => {
+    // The overlay wires useChatComposerDraftPersistence keyed by the
+    // controller's conversationNav.activeId — closing the platform gap where
+    // only the desktop ChatView restored drafts. A draft stored for the active
+    // conversation must repopulate the composer on mount.
+    clearChatDraft("conv-draft-x");
+    writeChatDraft("conv-draft-x", "half-written thought");
+    const controller = makeController({
+      conversationNav: {
+        hasPrev: false,
+        hasNext: false,
+        goPrev: () => {},
+        goNext: () => {},
+        activeId: "conv-draft-x",
+        index: 0,
+      },
+    } as unknown as Partial<ShellController>);
+    render(<ContinuousChatOverlay controller={controller} />);
+    expect(
+      (screen.getByLabelText("message") as HTMLTextAreaElement).value,
+    ).toBe("half-written thought");
+    clearChatDraft("conv-draft-x");
   });
 });

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -57,6 +57,10 @@ import {
 import { Z_SHELL_OVERLAY } from "../../lib/floating-layers";
 import { cn } from "../../lib/utils";
 import { claimAssistantLaunchPayloadFromHash } from "../../platform/assistant-launch-payload";
+import {
+  clearChatDraft,
+  useChatComposerDraftPersistence,
+} from "../../state/ChatComposerContext.hooks";
 import { goHome, goLauncher } from "../../state/shell-surface-store";
 import { useViewChatBinding } from "../../state/view-chat-binding";
 import { copyTextToClipboard } from "../../utils/clipboard";
@@ -935,6 +939,7 @@ const ThreadLine = React.memo(function ThreadLine({
   onCopy,
   onSpeak,
   onEdit,
+  onRetry,
   speaking,
   onOpenSettings,
   turnStatus,
@@ -951,6 +956,10 @@ const ThreadLine = React.memo(function ThreadLine({
   onSpeak?: (id: string, text: string) => void;
   /** Save an edited user message and resend it (reveal-row Edit). Stable id. */
   onEdit?: (text: string) => void;
+  /** Retry a failed/interrupted assistant turn — re-sends the preceding user
+   *  turn. Receives the assistant turn's id so the parent can walk back to the
+   *  user turn that produced it. Stable identity. */
+  onRetry?: (assistantId: string) => void;
   /** True while assistant voice output is playing — drives Play↔Stop. */
   speaking?: boolean;
   /** Jump to Settings from the no_provider gate. Stable identity. */
@@ -1046,6 +1055,17 @@ const ThreadLine = React.memo(function ThreadLine({
   const canEdit =
     isUser && !!onEdit && trimmed.length > 0 && !message.id.startsWith("temp-");
   const hasActions = canRowCopy || canSpeak || canEdit;
+
+  // A recoverable assistant failure (the agent was rate-limited or the provider
+  // stalled / the stream was interrupted) gets a one-tap Retry that re-sends the
+  // preceding user turn — mirroring ChatView's MessageContent gate. `no_provider`
+  // (its own Settings gate above) and `insufficient_credits` are excluded: a
+  // retry can't fix those.
+  const canRetry =
+    isAssistant &&
+    !!onRetry &&
+    (message.failureKind === "rate_limited" ||
+      message.failureKind === "provider_issue");
 
   const toggleRevealed = React.useCallback(() => {
     if (!hasActions || editing) return;
@@ -1351,6 +1371,24 @@ const ThreadLine = React.memo(function ThreadLine({
             ) : null}
           </div>
         ) : null}
+        {/* Retry a recoverable failure by re-sending the preceding user turn.
+            Always visible on the failed turn (not gated behind the reveal row)
+            so a stalled turn isn't a dead end the user has to retype. */}
+        {canRetry ? (
+          <button
+            type="button"
+            data-testid="thread-line-retry"
+            aria-label="Retry"
+            onClick={(e) => {
+              e.stopPropagation();
+              onRetry?.(message.id);
+            }}
+            className="flex items-center gap-1.5 rounded-full bg-white/10 px-3 py-1 text-[13px] font-medium text-white/80 transition-colors hover:bg-white/20"
+          >
+            <RotateCcw className="h-3.5 w-3.5" aria-hidden />
+            Retry
+          </button>
+        ) : null}
       </div>
     </motion.div>
   );
@@ -1525,6 +1563,32 @@ export function ContinuousChatOverlay({
     [send],
   );
 
+  // Retry a failed/interrupted assistant turn by re-sending its preceding user
+  // turn — the SAME send() path the edit-resend action uses. (The ShellController
+  // exposes no handleChatRetry, so the overlay owns the walk-back locally; a
+  // truncating in-place retry would require a controller method we don't have.)
+  // Reads the live message list through a ref so the callback keeps a stable
+  // identity and the memoized ThreadLine isn't re-rendered on every tick.
+  const messagesRef = React.useRef(messages);
+  messagesRef.current = messages;
+  const handleRetry = React.useCallback(
+    (assistantId: string) => {
+      const list = messagesRef.current;
+      const assistantIdx = list.findIndex(
+        (m) => m.id === assistantId && m.role === "assistant",
+      );
+      if (assistantIdx < 0) return;
+      for (let i = assistantIdx - 1; i >= 0; i -= 1) {
+        if (list[i].role === "user") {
+          const retryText = list[i].content.trim();
+          if (retryText) send(retryText);
+          return;
+        }
+      }
+    },
+    [send],
+  );
+
   const slash = slashProp ?? EMPTY_SLASH_CONTROLLER;
 
   // Honor the OS "reduce motion" setting: every overlay animation collapses to
@@ -1532,6 +1596,27 @@ export function ContinuousChatOverlay({
   const reduce = useReducedMotion() ?? false;
 
   const [draft, setDraft] = React.useState("");
+  // Per-conversation composer draft persistence — the SAME localStorage-backed
+  // store the desktop ChatView surface uses (readChatDraft/writeChatDraft via
+  // useChatComposerDraftPersistence), keyed by the active conversation id. This
+  // closes the platform gap where only ChatView restored a draft: on the ambient
+  // overlay (mobile/web/default-desktop) a draft typed here now survives a reload
+  // / navigation and follows the conversation across surfaces. Restore fires on
+  // mount and on a conversation-id change; the persist is debounced. It coexists
+  // with the prefill (CHAT_PREFILL / assistant-launch) and dictation paths: those
+  // setDraft() edits are persisted like any keystroke, and restore only fires on a
+  // conversation-id change — so a just-prefilled composer is never clobbered. The
+  // successful-send path clears it (below).
+  const activeConversationId = conversationNav.activeId;
+  useChatComposerDraftPersistence({
+    activeConversationId,
+    chatInput: draft,
+    setChatInput: setDraft,
+  });
+  // Live handle to the active conversation id for the send path's draft clear,
+  // so submitText / pickSuggestion keep their stable identities.
+  const activeConversationIdRef = React.useRef(activeConversationId);
+  activeConversationIdRef.current = activeConversationId;
   // The active view can take over the composer: override the placeholder and
   // receive the live draft (e.g. Help uses the chat as its search box).
   const viewChatBinding = useViewChatBinding();
@@ -1817,6 +1902,7 @@ export function ContinuousChatOverlay({
           onCopy={handleCopyMessage}
           onSpeak={handleSpeakMessage}
           onEdit={handleEditResend}
+          onRetry={handleRetry}
           speaking={speaking && playingMessageId === m.id}
           onOpenSettings={openSettings}
           turnStatus={isInFlight ? turnStatus : undefined}
@@ -1830,6 +1916,7 @@ export function ContinuousChatOverlay({
       handleCopyMessage,
       handleSpeakMessage,
       handleEditResend,
+      handleRetry,
       speaking,
       playingMessageId,
       openSettings,
@@ -1966,6 +2053,10 @@ export function ContinuousChatOverlay({
       // reaches the server. The composer controls are disabled too — this
       // guards the event-driven entry points (prefill, dictation, slash).
       if (firstRunOpen) return;
+      // Successful submit: drop the persisted draft for this conversation NOW
+      // (not just via the debounced persist of the now-empty draft) so a reload
+      // in the debounce window can't restore an already-sent draft.
+      clearChatDraft(activeConversationIdRef.current);
       // A bound view (e.g. the coding cockpit when a session is focused) can
       // claim the send to drive its OWN target instead of the host agent. If it
       // consumes the text, clear the composer and stop — do not fall through to
@@ -2017,6 +2108,7 @@ export function ContinuousChatOverlay({
     (text: string) => {
       if (!canSend) return;
       setDraft("");
+      clearChatDraft(activeConversationIdRef.current);
       send(text);
       // Open to HALF (conversation above the keyboard), not a full-screen jump.
       setFreeH(null);

--- a/packages/ui/src/components/shell/shell-state.test.ts
+++ b/packages/ui/src/components/shell/shell-state.test.ts
@@ -160,6 +160,20 @@ describe("selectVisibleShellMessages (#9141 gap 4 windowing)", () => {
     ).toEqual(["u1", "a1"]);
   });
 
+  it("keeps a content-less FAILED assistant turn (its retry / gate UI must render)", () => {
+    const failed: ShellMessage = {
+      ...msg("a1", "assistant", ""),
+      failureKind: "rate_limited",
+    };
+    // Kept in every phase — a rate-limit/provider stall fails before any token
+    // streams, so a content check alone would hide the failure + its retry.
+    expect(
+      selectVisibleShellMessages([msg("u1", "user", "hi"), failed], "idle").map(
+        (m) => m.id,
+      ),
+    ).toEqual(["u1", "a1"]);
+  });
+
   it("still drops turns with an EMPTY attachments array", () => {
     const emptyAtt: ShellMessage = {
       ...msg("a1", "assistant", ""),

--- a/packages/ui/src/components/shell/shell-state.ts
+++ b/packages/ui/src/components/shell/shell-state.ts
@@ -53,12 +53,15 @@ export const MAX_RENDERED_SHELL_MESSAGES = 80;
  * Pure transcript-windowing decision (#9141 gap 4 seam). Drops empty turns —
  * EXCEPT turns that carry non-text content (attachments or a pending secret
  * request: an image-only send is a valid user turn and an assistant reply can
- * be a bare generated image) and EXCEPT the in-flight assistant turn while a
- * reply is streaming (phase === "responding"), so its bubble can show the
- * breathing dots anchored where the text will fill in — then keeps only the
- * most recent `max` turns to bound DOM nodes. Pure + DOM-free so the cap +
- * exceptions are unit-testable and any future virtualizer can reuse the same
- * predicate.
+ * be a bare generated image), a FAILED assistant turn (failureKind carries the
+ * retry / no-provider / insufficient-credits UI, which is often content-less —
+ * a rate-limit or provider stall fails before any token streams, so dropping
+ * it would hide the failure AND its retry affordance entirely), and the
+ * in-flight assistant turn while a reply is streaming (phase === "responding"),
+ * so its bubble can show the breathing dots anchored where the text will fill
+ * in — then keeps only the most recent `max` turns to bound DOM nodes. Pure +
+ * DOM-free so the cap + exceptions are unit-testable and any future virtualizer
+ * can reuse the same predicate.
  */
 export function selectVisibleShellMessages(
   messages: readonly ShellMessage[],
@@ -70,6 +73,7 @@ export function selectVisibleShellMessages(
       m.content.trim() ||
       (m.attachments?.length ?? 0) > 0 ||
       m.secretRequest !== undefined ||
+      m.failureKind !== undefined ||
       (m.role === "assistant" && phase === "responding"),
   );
   return max > 0 && kept.length > max ? kept.slice(-max) : [...kept];


### PR DESCRIPTION
## Summary

Closes the last cross-platform parity gaps between the desktop ChatView and the ambient overlay (mobile/web/default-desktop), plus a compound window-filter bug found while testing.

- **Composer draft persistence on the overlay:** only ChatView restored a per-conversation draft — the overlay lost the typed draft on reload/navigation. Wired `useChatComposerDraftPersistence` (the SAME store ChatView uses) keyed by the active conversation id; restore on mount/conversation-change, debounced persist, clear on successful send. Coexists with prefill + dictation (restore only fires on a conversation-id change, so a just-prefilled composer is never clobbered).
- **Retry on a failed turn in the overlay:** a recoverable failure (`rate_limited`/`provider_issue`) had no retry in the shipped overlay — only the unmounted ChatView renderer did, so a stalled turn was a dead end. Added a Retry control re-sending the preceding user turn via the same `send()` path edit-resend uses (`no_provider` keeps its Settings gate; `insufficient_credits` excluded).
- **Compound bug found while testing:** `selectVisibleShellMessages` dropped a **content-less failed turn**, so the retry (and the `no_provider` gate) never rendered for exactly the rate-limit/provider-stall case that fails before any token streams. `failureKind` is now a keep condition.
- **De-larped the flagship STOP test:** it asserted the retained partial with a `?? fallback` that passed even if the bubble was deleted. Now positively requires the partial bubble to exist, carry the interrupted marker, and hold the partial text (the pre-fix regression fails).

## Evidence
144 unit (overlay 123 / shell-state 14 / stop-test 2 / ChatComposerContext) + chat-sheet & conversation-swipe e2e green. The draft hook + window predicate keep their own unit suites.

Refs the #10722 sweep. Two remaining de-larp follow-ups (mobile-lifecycle, launcher-interaction synthetic swipe) noted in the sweep summary — an agent stalled on infra before reaching them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)