### PR TITLE
fix(android-native): drop i8mm from the arm64 CPU floor — SIGILL on every Tensor G1/G2 device (#10727)

### DIFF
--- a/packages/app-core/scripts/aosp/compile-libllama.mjs
+++ b/packages/app-core/scripts/aosp/compile-libllama.mjs
@@ -1353,7 +1353,7 @@ export function ensureZigDrivers({
       : null;
 
   // arm64: the ggml-cpu CMakeLists emits the GCC-style ISA string
-  // `-march=armv8.2-a+dotprod+fp16+i8mm` (from GGML_CPU_ARM_ARCH). Zig 0.13's
+  // `-march=armv8.2-a+dotprod+fp16` (from GGML_CPU_ARM_ARCH). Zig 0.13's
   // bundled LLVM rejects that for the aarch64 target — it tries to translate
   // `armv8.2-a` to a `-mcpu=` value and dies with "unknown CPU: 'armv8.2'"
   // (the same class of breakage the riscv64 filter handles). Zig instead
@@ -1513,7 +1513,7 @@ export function buildLibllamaForAbi({
 
   // arm64-v8a: GGML_NATIVE=OFF leaves the cross-build at the bare armv8-a
   // baseline, which keeps ggml's dotprod/i8mm/fp16 NEON kernels AND the eliza
-  // QJL NEON-dotprod kernel dead. Pin the armv8.2-a+dotprod+fp16+i8mm floor and
+  // QJL NEON-dotprod kernel dead. Pin the armv8.2-a+dotprod+fp16 floor (no i8mm — see arm64-simd.mjs) and
   // flip the QJL dispatch define so the Pixel-class Tensor G4 actually runs the
   // accelerated paths. See build-helpers/arm64-simd.mjs for the full rationale.
   const arm64BuildFlags = androidArm64SimdCmakeFlags(abi);

--- a/packages/app-core/scripts/build-helpers/arm64-simd.mjs
+++ b/packages/app-core/scripts/build-helpers/arm64-simd.mjs
@@ -32,31 +32,31 @@
 //
 // Floor rationale:
 //   armv8.2-a is the floor that introduced dotprod + fp16 vector arithmetic.
-//   i8mm is NOT in the floor. It was originally included on the assumption
-//   that the __ARM_FEATURE_* self-guards are runtime checks — they are not:
-//   they are compile-time macros that `-march=...+i8mm` defines
-//   unconditionally, so the compiler emits smmla into the quantized matmul
-//   kernels with no hardware gate. On any core older than ARMv8.6 that is a
-//   hard SIGILL: device-verified on a Pixel 6a (Tensor G1, Cortex-X1/A76/A55,
-//   /proc/cpuinfo Features has asimddp but no i8mm) — pure-CPU decode and the
-//   clip/mmproj encoder both die with "Illegal instruction" (exit 132), which
-//   breaks every Tensor G1/G2 device (Pixel 6/6a/6 Pro/7 series) on the CPU
-//   path (#10727). The Pixel 9a / Tensor G4 has i8mm, which is why earlier
-//   9a-only verification never caught it.
-//   To get i8mm speed back on v8.6+ cores without dropping v8.2 devices,
-//   switch to the GGML_CPU_ALL_VARIANTS=ON + GGML_BACKEND_DL=ON
-//   runtime-dispatch route (as the riscv64 build already does) — never
-//   re-add +i8mm to this fixed floor.
+//   i8mm arrived at armv8.6-a and is NOT in the default floor. The
+//   __ARM_FEATURE_* kernel self-guards are compile-time macros, not runtime
+//   checks — `-march=...+i8mm` defines __ARM_FEATURE_MATMUL_INT8
+//   unconditionally, so smmla lands ungated in the quantized matmul kernels.
+//   Device-proven SIGILL (exit 132) on a physical Pixel 6a (Tensor G1 —
+//   /proc/cpuinfo has asimddp, no i8mm): pure-CPU decode, the ASR q4_K matmul
+//   path, and the clip/mmproj encoder all crash, i.e. every Tensor G1/G2
+//   phone (Pixel 6/6a/6 Pro/7). The Pixel 9a (Tensor G4, has i8mm) is why
+//   9a-only verification never caught it. Keep i8mm as an explicit opt-in
+//   (ELIZA_ANDROID_ARM64_I8MM=1) for controlled perf runs on devices known to
+//   support it. Devices below armv8.2-a (pre-2017 SoCs) are not a target; if
+//   that changes, switch to the GGML_CPU_ALL_VARIANTS=ON + GGML_BACKEND_DL=ON
+//   runtime-dispatch route (as the riscv64 build already does) instead of
+//   lowering this floor.
 
 /**
  * The fixed Android arm64-v8a SIMD architecture string passed to
  * `-DGGML_CPU_ARM_ARCH=`. Exported for tests / logging.
  */
 export const ANDROID_ARM64_CPU_ARCH = "armv8.2-a+dotprod+fp16";
+export const ANDROID_ARM64_CPU_ARCH_I8MM = "armv8.2-a+dotprod+fp16+i8mm";
 
 /**
  * CMake `-D` flags that raise an Android arm64-v8a fork build from the bare
- * armv8-a baseline to the armv8.2-a+dotprod+fp16 floor AND turn on the
+ * armv8-a baseline to the armv8.2-a+dotprod+fp16+i8mm floor AND turn on the
  * QJL NEON-dotprod dispatch define.
  *
  * Returns an empty array for any non-arm64 ABI so callers can splat it
@@ -68,8 +68,12 @@ export const ANDROID_ARM64_CPU_ARCH = "armv8.2-a+dotprod+fp16";
  */
 export function androidArm64SimdCmakeFlags(abi) {
   if (abi !== "arm64-v8a") return [];
+  const arch =
+    process.env.ELIZA_ANDROID_ARM64_I8MM?.trim() === "1"
+      ? ANDROID_ARM64_CPU_ARCH_I8MM
+      : ANDROID_ARM64_CPU_ARCH;
   return [
-    `-DGGML_CPU_ARM_ARCH=${ANDROID_ARM64_CPU_ARCH}`,
+    `-DGGML_CPU_ARM_ARCH=${arch}`,
     // Flip the QJL_HAVE_NEON_DOTPROD dispatch define (ggml-cpu/CMakeLists.txt
     // ~L161). Without this the live dotprod kernel body compiles but the QJL
     // dispatcher never routes to it.

--- a/packages/app-core/scripts/build-helpers/arm64-simd.mjs
+++ b/packages/app-core/scripts/build-helpers/arm64-simd.mjs
@@ -31,26 +31,32 @@
 //   __ARM_FEATURE_DOTPROD, so this never produces an undefined symbol.
 //
 // Floor rationale:
-//   armv8.2-a is the floor that introduced dotprod + fp16 vector arithmetic;
-//   i8mm arrived at armv8.6-a but is back-portable as a `+i8mm` feature
-//   suffix on an armv8.2-a base (the toolchain emits the i8mm instructions;
-//   the runtime only executes them on hardware that has them, and the QJL/ggml
-//   kernels self-guard on the corresponding __ARM_FEATURE_* macros). The
-//   Pixel 9a / Tensor G4 reports asimddp + i8mm + asimdhp/fphp, so this floor
-//   is safe for the only Android arm64 device we ship to today. Devices below
-//   armv8.2-a (pre-2017 SoCs) are not a target; if that changes, switch to the
-//   GGML_CPU_ALL_VARIANTS=ON + GGML_BACKEND_DL=ON runtime-dispatch route (as
-//   the riscv64 build already does) instead of lowering this floor.
+//   armv8.2-a is the floor that introduced dotprod + fp16 vector arithmetic.
+//   i8mm is NOT in the floor. It was originally included on the assumption
+//   that the __ARM_FEATURE_* self-guards are runtime checks — they are not:
+//   they are compile-time macros that `-march=...+i8mm` defines
+//   unconditionally, so the compiler emits smmla into the quantized matmul
+//   kernels with no hardware gate. On any core older than ARMv8.6 that is a
+//   hard SIGILL: device-verified on a Pixel 6a (Tensor G1, Cortex-X1/A76/A55,
+//   /proc/cpuinfo Features has asimddp but no i8mm) — pure-CPU decode and the
+//   clip/mmproj encoder both die with "Illegal instruction" (exit 132), which
+//   breaks every Tensor G1/G2 device (Pixel 6/6a/6 Pro/7 series) on the CPU
+//   path (#10727). The Pixel 9a / Tensor G4 has i8mm, which is why earlier
+//   9a-only verification never caught it.
+//   To get i8mm speed back on v8.6+ cores without dropping v8.2 devices,
+//   switch to the GGML_CPU_ALL_VARIANTS=ON + GGML_BACKEND_DL=ON
+//   runtime-dispatch route (as the riscv64 build already does) — never
+//   re-add +i8mm to this fixed floor.
 
 /**
  * The fixed Android arm64-v8a SIMD architecture string passed to
  * `-DGGML_CPU_ARM_ARCH=`. Exported for tests / logging.
  */
-export const ANDROID_ARM64_CPU_ARCH = "armv8.2-a+dotprod+fp16+i8mm";
+export const ANDROID_ARM64_CPU_ARCH = "armv8.2-a+dotprod+fp16";
 
 /**
  * CMake `-D` flags that raise an Android arm64-v8a fork build from the bare
- * armv8-a baseline to the armv8.2-a+dotprod+fp16+i8mm floor AND turn on the
+ * armv8-a baseline to the armv8.2-a+dotprod+fp16 floor AND turn on the
  * QJL NEON-dotprod dispatch define.
  *
  * Returns an empty array for any non-arm64 ABI so callers can splat it

--- a/packages/app-core/scripts/build-helpers/arm64-simd.test.mjs
+++ b/packages/app-core/scripts/build-helpers/arm64-simd.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import {
+  ANDROID_ARM64_CPU_ARCH,
+  ANDROID_ARM64_CPU_ARCH_I8MM,
+  androidArm64SimdCmakeFlags,
+} from "./arm64-simd.mjs";
+
+const ORIGINAL_I8MM = process.env.ELIZA_ANDROID_ARM64_I8MM;
+
+afterEach(() => {
+  if (ORIGINAL_I8MM === undefined) {
+    delete process.env.ELIZA_ANDROID_ARM64_I8MM;
+  } else {
+    process.env.ELIZA_ANDROID_ARM64_I8MM = ORIGINAL_I8MM;
+  }
+});
+
+test("uses the Pixel-safe arm64 floor by default", () => {
+  delete process.env.ELIZA_ANDROID_ARM64_I8MM;
+
+  assert.deepEqual(androidArm64SimdCmakeFlags("arm64-v8a"), [
+    `-DGGML_CPU_ARM_ARCH=${ANDROID_ARM64_CPU_ARCH}`,
+    "-DGGML_USE_DOTPROD=ON",
+  ]);
+});
+
+test("can opt in to i8mm for known-compatible Android arm64 devices", () => {
+  process.env.ELIZA_ANDROID_ARM64_I8MM = "1";
+
+  assert.deepEqual(androidArm64SimdCmakeFlags("arm64-v8a"), [
+    `-DGGML_CPU_ARM_ARCH=${ANDROID_ARM64_CPU_ARCH_I8MM}`,
+    "-DGGML_USE_DOTPROD=ON",
+  ]);
+});
+
+test("does not add arm64 flags to other Android ABIs", () => {
+  process.env.ELIZA_ANDROID_ARM64_I8MM = "1";
+
+  assert.deepEqual(androidArm64SimdCmakeFlags("x86_64"), []);
+});

--- a/packages/app-core/scripts/stage-elizavoice-lib.mjs
+++ b/packages/app-core/scripts/stage-elizavoice-lib.mjs
@@ -203,7 +203,7 @@ mkdirSync(buildDir, { recursive: true });
 // arm64 SIMD floor: GGML_NATIVE=OFF cross-builds to bare armv8-a, which leaves
 // the LLM + ASR matmul/dot kernels (ggml dotprod/i8mm/fp16) AND the eliza QJL
 // NEON-dotprod K-cache kernel dead — this fused .so would carry the full
-// LLM+ASR+voice stack but run it scalar. Pin armv8.2-a+dotprod+fp16+i8mm and
+// LLM+ASR+voice stack but run it scalar. Pin armv8.2-a+dotprod+fp16 (no i8mm — SIGILLs pre-v8.6 cores, see arm64-simd.mjs) and
 // flip the QJL dispatch define (build-helpers/arm64-simd.mjs). The voice
 // classifier forward graphs are tiny scalar C and unaffected; this lights up
 // the heavy LLM/ASR paths the same lib carries.


### PR DESCRIPTION
## What

Part of #10727 (device-optimized inference / no broken paths). The Android arm64 CPU SIMD floor `armv8.2-a+dotprod+fp16+i8mm` (from #9584-era `arm64-simd.mjs`) crashes the CPU inference path on every **Tensor G1/G2** device (Pixel 6 / 6a / 6 Pro / 7 series).

**Root cause:** the floor's own doc block assumed the `__ARM_FEATURE_*` kernel self-guards are runtime checks. They are **compile-time** macros — `-march=…+i8mm` defines `__ARM_FEATURE_MATMUL_INT8` unconditionally, so `smmla` is emitted ungated into the quantized matmul kernels. Cores older than ARMv8.6 take a hard SIGILL.

**Device proof (Pixel 6a, Tensor G1 — `/proc/cpuinfo` Features has `asimddp`, no `i8mm`):**
- pure-CPU decode: `llama-completion -dev none` → `EXIT=132` (SIGILL)
- clip/mmproj vision encode on CPU: `Illegal instruction`
- same binaries, GPU path (`-ngl 99`, Mali-G78 Vulkan): 12/12 clean — the crash is CPU-only, exactly the class of silent device breakage #10727 exists to catch.
- The Pixel 9a (Tensor G4, **has** i8mm) is why earlier 9a-only verification never caught this.

**Fix:** floor drops to `armv8.2-a+dotprod+fp16` (dotprod + fp16 NEON kernels + QJL NEON-dotprod dispatch all stay live). i8mm speed on v8.6+ cores should return via the `GGML_CPU_ALL_VARIANTS=ON + GGML_BACKEND_DL=ON` runtime-dispatch route (the riscv64 build's pattern) — documented in the helper; never by re-raising the fixed floor.

## Evidence

- Post-fix rebuild + on-device re-verify (Pixel 6a): CPU decode exit 0 + Mali Vulkan still 12/12 — being captured now, will comment results on this PR before merge.
- Screenshots / video / trajectories / audio: N/A — build-flags change, no UI/agent surface.

Refs #10727, #9508 (same device campaign).

🤖 Generated with [Claude Code](https://claude.com/claude-code)