### PR TITLE
fix(orchestrator): don't suppress coding tasks phrased as a to-do (#11028)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/create-task.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/create-task.test.ts
@@ -61,6 +61,30 @@ describe("TASKS:create", () => {
     ).toBe(false);
   });
 
+  it("keeps a coding request phrased as a to-do eligible for TASKS (#11028)", async () => {
+    // "add a task to build ..." tripped the personal-lifeops keyword gate and
+    // suppressed the coding orchestrator even for an unambiguous build request.
+    // The gate now defers to the structural task classifier for build/deploy/view
+    // signals, so a landing-page build phrased as a to-do stays eligible.
+    expect(
+      await createTaskAction.validate(
+        runtimeWith(serviceMock()),
+        memory({ text: "add a task to build me a landing page" }),
+        state,
+      ),
+    ).toBe(true);
+  });
+
+  it("still routes a bare personal to-do off TASKS (no regression)", async () => {
+    expect(
+      await createTaskAction.validate(
+        runtimeWith(serviceMock()),
+        memory({ text: "add a task to buy milk" }),
+        state,
+      ),
+    ).toBe(false);
+  });
+
   it("supports nyx options.parameters and returns data.agents[].sessionId plus id", async () => {
     const svc = serviceMock();
     // Must be a real directory: resolveSpawnWorkdir drops an explicit workdir

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -39,6 +39,10 @@ import type {
 } from "@elizaos/core";
 import { ChannelType, logger as coreLogger, stringToUuid } from "@elizaos/core";
 import type { IssueInfo, PullRequestInfo } from "git-workspace-service";
+import {
+  type OrchestratorTaskType,
+  detectTaskType,
+} from "../services/acceptance-criteria.js";
 import { augmentTaskWithDeployGuidance } from "../services/app-deploy-guidance.js";
 import { OrchestratorTaskService } from "../services/orchestrator-task-service.js";
 import { normalizeRepositoryInput } from "../services/repo-input.js";
@@ -515,10 +519,27 @@ function taskWithResolvedRoute(
   return sections.join("\n");
 }
 
+// Specialized (non-default) task types detectTaskType only returns for
+// unambiguous build/deploy/view signals — a bare personal to-do never trips them.
+const SPECIALIZED_CODING_TASK_TYPES: ReadonlySet<OrchestratorTaskType> = new Set(
+  ["view-create", "app-build", "deploy"],
+);
+
 function looksLikePersonalLifeOpsTask(text: string): boolean {
-  return /\b(?:add|create|make|open|save|set)\s+(?:an?\s+)?(?:to-?do|task|reminder|note)\b/i.test(
-    text,
-  );
+  if (
+    !/\b(?:add|create|make|open|save|set)\s+(?:an?\s+)?(?:to-?do|task|reminder|note)\b/i.test(
+      text,
+    )
+  ) {
+    return false;
+  }
+  // A conversational "add a task to build/deploy a landing page/app/site/view" is
+  // a coding request phrased as a to-do, not a personal-lifeops item. Reuse the
+  // structural task classifier: it flags those unambiguous build/deploy/view
+  // signals, so don't suppress the coding orchestrator for them. A generic
+  // "add a task to buy milk" carries no such signal (detectTaskType → "coding"
+  // default) and stays a suppressed lifeops item.
+  return !SPECIALIZED_CODING_TASK_TYPES.has(detectTaskType(text));
 }
 
 // Durable variant of runPromptAndClose: drives the spawned session through the


### PR DESCRIPTION
From the 2026-07 orchestrator audit follow-ups (**#11028**).

## Bug

`looksLikePersonalLifeOpsTask` gated the TASKS action's `validate()` purely on the phrase `add|create|make|open|save|set … (a) to-do/task/reminder/note`. So a coding request phrased conversationally — **"add a task to build me a landing page"** — matched the personal-lifeops gate and suppressed the coding orchestrator entirely (validate → `false`).

That directly contradicts the gate's own comment a few lines up: *"WHETHER the coding parent actually surfaces to the planner is decided structurally … not by keyword-matching the request text here."*

## Fix

Defer to the existing structural classifier instead of a raw phrase match: `detectTaskType` (from `acceptance-criteria.ts`) returns a specialized type (`app-build` / `deploy` / `view-create`) only for unambiguous build/deploy/view signals — generic text defaults to `"coding"`. The gate now skips suppression when a specialized signal is present, so:

- "add a task to build me a landing page" → `app-build` → **eligible** (fixed)
- "add a task to buy milk" → no signal → still routed off TASKS to LifeOps (unchanged)

No new keyword list — it reuses the classifier the acceptance-criteria path already owns.

## Evidence

```
$ bunx vitest run __tests__/unit/create-task.test.ts
Test Files  1 passed (1)
     Tests  8 passed (8)
```

+2 cases: a to-do-phrased landing-page build stays eligible; a bare "buy milk" to-do stays routed off TASKS (no regression).

Refs #11028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)