### PR TITLE
fix(core): fail closed when pinned SSRF transport cannot load + real socket-level pinning tests

### DIFF
--- a/packages/core/src/network/fetch-guard.fail-closed.test.ts
+++ b/packages/core/src/network/fetch-guard.fail-closed.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import { fetchWithSsrfGuard } from "./fetch-guard.ts";
+
+// Simulate a packaging/import failure of the pinned transport module. On a
+// Node-like runtime the guard must fail CLOSED (reject the guarded fetch)
+// instead of silently reverting to the racy unpinned path.
+vi.mock("./node-pinned-fetch.js", () => {
+	throw new Error("simulated packaging failure");
+});
+
+describe("fetchWithSsrfGuard when the pinned transport cannot load (Node runtime)", () => {
+	it("fails closed instead of falling back to unpinned fetch", async () => {
+		await expect(
+			fetchWithSsrfGuard({ url: "https://example.com/resource" }),
+		).rejects.toThrow(/pinned DNS transport .* failed to load/i);
+	});
+
+	it("keeps failing closed on subsequent guarded fetches (no poisoned success)", async () => {
+		await expect(
+			fetchWithSsrfGuard({ url: "https://example.org/other" }),
+		).rejects.toThrow(/Refusing to fall back to unpinned fetch/i);
+	});
+
+	it("still honors an explicitly provided fetchImpl (caller opted out of node defaults)", async () => {
+		const fetchImpl = vi.fn(async () => new Response("ok", { status: 200 }));
+		const { response, release } = await fetchWithSsrfGuard({
+			url: "https://example.com/page",
+			fetchImpl,
+		});
+		expect(response.status).toBe(200);
+		expect(fetchImpl).toHaveBeenCalledTimes(1);
+		await release();
+	});
+});

--- a/packages/core/src/network/fetch-guard.ts
+++ b/packages/core/src/network/fetch-guard.ts
@@ -5,6 +5,7 @@
  * SSRF attacks and DNS rebinding.
  */
 
+import { logger } from "../logger.js";
 import {
 	isBlockedHostname,
 	isPrivateIpAddress,
@@ -74,13 +75,31 @@ async function loadNodePinnedFetchDefaults(): Promise<NodePinnedFetchDefaults | 
 	if (!isNodeLikeRuntime()) {
 		return null;
 	}
-	nodePinnedFetchDefaults ??= import("./node-pinned-fetch.js")
-		.then(({ nodeLookupFn, nodePinnedFetch }) => ({
+	// On Node-like runtimes the pinned transport is the DNS-rebinding defense.
+	// If it fails to load, fail CLOSED: guarded fetches must error rather than
+	// silently fall back to the racy unpinned path.
+	nodePinnedFetchDefaults ??= import("./node-pinned-fetch.js").then(
+		({ nodeLookupFn, nodePinnedFetch }) => ({
 			lookupFn: nodeLookupFn,
 			pinnedFetchImpl: nodePinnedFetch,
-		}))
-		.catch(() => null);
-	return nodePinnedFetchDefaults;
+		}),
+	);
+	try {
+		return await nodePinnedFetchDefaults;
+	} catch (error) {
+		// Do not memoize the failure as a permanent null — allow a retry on the
+		// next guarded fetch in case the failure was transient.
+		nodePinnedFetchDefaults = undefined;
+		logger.error(
+			{ error },
+			"[FetchGuard] Failed to load the pinned DNS transport on a Node-like runtime; failing closed",
+		);
+		throw new Error(
+			"SSRF guard: pinned DNS transport (node-pinned-fetch) failed to load on a Node-like runtime. " +
+				"Refusing to fall back to unpinned fetch (DNS rebinding risk). " +
+				`Underlying error: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
 }
 
 function isRedirectStatus(status: number): boolean {

--- a/packages/core/src/network/pinned-fetch.integration.test.ts
+++ b/packages/core/src/network/pinned-fetch.integration.test.ts
@@ -1,0 +1,142 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { fetchWithSsrfGuard } from "./fetch-guard.ts";
+import { nodePinnedFetch } from "./node-pinned-fetch.ts";
+import { type LookupFn, SsrfBlockedError } from "./ssrf.ts";
+
+/**
+ * Socket-level integration tests for the pinned SSRF transport.
+ *
+ * These use a REAL local HTTP server and the REAL node:http pinned transport
+ * (`nodePinnedFetch`) — no mocked plumbing. The fake `.test` hostnames do not
+ * exist in any resolver, so a successful request proves the connection was
+ * routed through the pinned lookup to 127.0.0.1 at the socket level.
+ */
+describe("pinned fetch through a real local HTTP server", () => {
+	let server: Server;
+	let port: number;
+	const seenRequests: Array<{ host: string | undefined; url: string }> = [];
+
+	beforeAll(async () => {
+		server = createServer((req, res) => {
+			seenRequests.push({ host: req.headers.host, url: req.url ?? "" });
+			if (req.url === "/redirect-to-rebound") {
+				res.statusCode = 302;
+				res.setHeader("location", `http://rebound.example.test:${port}/steal`);
+				res.end();
+				return;
+			}
+			res.statusCode = 200;
+			res.setHeader("content-type", "text/plain");
+			res.end(`hello from ${req.url}`);
+		});
+		await new Promise<void>((resolve) =>
+			server.listen(0, "127.0.0.1", resolve),
+		);
+		port = (server.address() as AddressInfo).port;
+	});
+
+	afterAll(async () => {
+		await new Promise<void>((resolve, reject) =>
+			server.close((err) => (err ? reject(err) : resolve())),
+		);
+	});
+
+	it("connects to 127.0.0.1 via the pinned lookup for a fake hostname (real socket)", async () => {
+		let lookupCalls = 0;
+		const lookupFn: LookupFn = async (hostname) => {
+			lookupCalls += 1;
+			expect(hostname).toBe("pinned.example.test");
+			return [{ address: "127.0.0.1", family: 4 }];
+		};
+
+		const { response, finalUrl, release } = await fetchWithSsrfGuard({
+			url: `http://pinned.example.test:${port}/hello`,
+			lookupFn,
+			pinnedFetchImpl: nodePinnedFetch,
+			// 127.0.0.1 is private: the resolved-address check must be explicitly
+			// allowlisted for this hostname, mirroring a real internal allowlist.
+			policy: { allowedHostnames: ["pinned.example.test"] },
+			timeoutMs: 5000,
+		});
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe("hello from /hello");
+		expect(finalUrl).toBe(`http://pinned.example.test:${port}/hello`);
+		// Exactly one resolution — the transport reused the pinned addresses.
+		expect(lookupCalls).toBe(1);
+		// The server saw the original Host header, proving the request targeted
+		// the fake hostname while the socket went to the pinned 127.0.0.1.
+		const request = seenRequests.find((entry) => entry.url === "/hello");
+		expect(request?.host).toBe(`pinned.example.test:${port}`);
+		await release();
+	});
+
+	it("blocks a rebinding flip: second resolution of the same hostname returns a private IP", async () => {
+		const requestsBefore = seenRequests.length;
+		let resolutions = 0;
+		const lookupFn: LookupFn = async () => {
+			resolutions += 1;
+			// First resolution: a public address (what the attacker's DNS serves
+			// while the URL is being vetted). Second resolution: flipped to a
+			// private target — the classic rebinding move.
+			return resolutions === 1
+				? [{ address: "203.0.113.10", family: 4 }]
+				: [{ address: "169.254.169.254", family: 4 }];
+		};
+
+		// First guarded fetch pins 203.0.113.10 (TEST-NET, unroutable) — abort it
+		// fast; the point is the resolution was accepted and pinned.
+		await expect(
+			fetchWithSsrfGuard({
+				url: `http://rebind.example.test:${port}/first`,
+				lookupFn,
+				pinnedFetchImpl: nodePinnedFetch,
+				timeoutMs: 250,
+			}),
+		).rejects.toThrow();
+		expect(resolutions).toBe(1);
+
+		// Second guarded fetch re-resolves; DNS now serves the private metadata
+		// IP. The guard must block BEFORE any socket is opened.
+		await expect(
+			fetchWithSsrfGuard({
+				url: `http://rebind.example.test:${port}/second`,
+				lookupFn,
+				pinnedFetchImpl: nodePinnedFetch,
+				timeoutMs: 5000,
+			}),
+		).rejects.toBeInstanceOf(SsrfBlockedError);
+		expect(resolutions).toBe(2);
+		// No request ever reached the local server for either attempt.
+		expect(seenRequests.length).toBe(requestsBefore);
+	});
+
+	it("blocks a redirect hop whose hostname resolves to a private IP (through the real transport)", async () => {
+		const lookupFn: LookupFn = async (hostname) => {
+			if (hostname === "pinned.example.test") {
+				return [{ address: "127.0.0.1", family: 4 }];
+			}
+			// The redirect target "rebound.example.test" resolves to a private IP.
+			return [{ address: "10.0.0.1", family: 4 }];
+		};
+
+		await expect(
+			fetchWithSsrfGuard({
+				url: `http://pinned.example.test:${port}/redirect-to-rebound`,
+				lookupFn,
+				pinnedFetchImpl: nodePinnedFetch,
+				policy: { allowedHostnames: ["pinned.example.test"] },
+				timeoutMs: 5000,
+			}),
+		).rejects.toBeInstanceOf(SsrfBlockedError);
+
+		// The first hop really hit the server; the rebound hop never did.
+		const firstHop = seenRequests.filter(
+			(entry) => entry.url === "/redirect-to-rebound",
+		);
+		expect(firstHop.length).toBe(1);
+		expect(seenRequests.some((entry) => entry.url === "/steal")).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

Follow-up hardening to #11178 (DNS pinning in the SSRF guard; see also #11147).

1. **Fail closed on pinned-transport load failure.** `loadNodePinnedFetchDefaults()` previously did `.catch(() => null)` and memoized the null — an import/packaging failure silently reverted the DNS-rebinding defense to the racy unpinned path for the life of the process. Now, on a Node-like runtime, a load failure logs via the structured logger (`[FetchGuard]`) and **throws a clear error on guarded fetches**; the failed promise is not memoized, so a transient failure can recover. Callers that explicitly pass `fetchImpl`/`pinnedFetchImpl` are unaffected.

2. **Real socket-level integration tests** (`pinned-fetch.integration.test.ts`) — no mocked plumbing: a real `node:http` server on 127.0.0.1 reached through the actual `nodePinnedFetch` transport with a fake `.test` hostname pinned to 127.0.0.1 (success proves the socket used the pinned lookup — the hostname resolves nowhere else); a rebinding simulation where the second resolution flips to 169.254.169.254 and is blocked before any socket opens; and a redirect hop whose target resolves private, blocked mid-chain. Plus `fetch-guard.fail-closed.test.ts` simulating the transport import failure.

## Verification

- `bun run --cwd packages/core test -- src/network/` — 33 passed (4 files)
- `bun run --cwd packages/core typecheck` — clean
- biome check on touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)