### PR TITLE
fix(orchestrator): task-store delete/write race — tombstone + dirty tracking inside the queued op (#11028)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts
@@ -699,8 +699,12 @@ describe("orchestrator-task-store audit follow-ups (#11028)", () => {
     const path = await tempFile();
     const a = new FileTaskStore(path);
     const b = new FileTaskStore(path);
-    // Both instances load the empty file; each inserts a distinct task. Before
-    // the read-merge-write fix, b's whole-document write clobbered a's task.
+    // Hydrate BOTH instances from the empty file BEFORE either writes, so b
+    // cannot pick up a's task at lazy-load time — only the read-merge-write in
+    // afterWrite can preserve it. (Without the explicit hydration this test
+    // also passed on the pre-merge clobbering code, i.e. it proved nothing.)
+    await a.listTasks();
+    await b.listTasks();
     const ta = await a.createTask(createInput({ title: "from A" }));
     const tb = await b.createTask(createInput({ title: "from B" }));
     const reader = new FileTaskStore(path);
@@ -724,5 +728,58 @@ describe("orchestrator-task-store audit follow-ups (#11028)", () => {
     const ids = (await reader.listTasks()).map((t) => t.id);
     expect(ids).not.toContain(seed.task.id);
     expect(ids).toContain(x.task.id);
+  });
+
+  it("FileTaskStore delete that races an in-flight write in the same process stays deleted", async () => {
+    const path = await tempFile();
+    const a = new FileTaskStore(path);
+    const x = await a.createTask(createInput({ title: "X" }));
+    // Enqueue a write and a delete back-to-back without awaiting in between.
+    // With the tombstone recorded outside the queued op, the earlier write's
+    // afterWrite consumed and cleared it while X was still in memory, and the
+    // delete's own persist then re-seeded X from disk — deleteTask returned
+    // true but X survived on disk AND in memory.
+    const [, deleted] = await Promise.all([
+      a.createTask(createInput({ title: "Y" })),
+      a.deleteTask(x.task.id),
+    ]);
+    expect(deleted).toBe(true);
+    expect(await a.getTask(x.task.id)).toBeNull();
+    const reader = new FileTaskStore(path);
+    const ids = (await reader.listTasks()).map((t) => t.id);
+    expect(ids).not.toContain(x.task.id);
+    expect(ids).toHaveLength(1);
+  });
+
+  it("FileTaskStore failed delete does not phantom-delete another process's task later", async () => {
+    const path = await tempFile();
+    const a = new FileTaskStore(path);
+    await a.listTasks(); // hydrate `a` from the empty file
+    const b = new FileTaskStore(path);
+    const x = await b.createTask(createInput({ title: "X" }));
+    // `a` never saw X, so its delete is a no-op and must say so.
+    expect(await a.deleteTask(x.task.id)).toBe(false);
+    // The failed delete must not leave a lingering tombstone that a later
+    // unrelated write applies, silently destroying the other process's task.
+    await a.createTask(createInput({ title: "Y" }));
+    const reader = new FileTaskStore(path);
+    const ids = (await reader.listTasks()).map((t) => t.id);
+    expect(ids).toContain(x.task.id);
+  });
+
+  it("FileTaskStore write does not revert another process's update to a task it did not touch", async () => {
+    const path = await tempFile();
+    const a = new FileTaskStore(path);
+    const t = await a.createTask(createInput({ title: "shared" }));
+    const b = new FileTaskStore(path);
+    await b.listTasks(); // b hydrates {t} at its pre-update version
+    await a.updateTask(t.task.id, { status: "done" });
+    // b, still holding the stale copy of t, persists an unrelated insert. The
+    // merge must overlay only b's dirty docs, keeping the newer on-disk t
+    // instead of reverting it to b's stale in-memory copy.
+    await b.createTask(createInput({ title: "unrelated" }));
+    const reader = new FileTaskStore(path);
+    const after = await reader.getTask(t.task.id);
+    expect(after?.task.status).toBe("done");
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
@@ -350,6 +350,7 @@ export class InMemoryTaskStore {
     return this.enqueue(async () => {
       const doc = newTaskDocument(input);
       this.docs.set(doc.task.id, doc);
+      this.noteMutated(doc.task.id);
       await this.afterWrite();
       return cloneDocument(doc);
     });
@@ -390,6 +391,7 @@ export class InMemoryTaskStore {
         updatedAt: nowIso(),
         lastActivityAt: nextPatch.lastActivityAt ?? Date.now(),
       };
+      this.noteMutated(id);
       await this.afterWrite();
       return structuredClone(doc.task);
     });
@@ -398,8 +400,17 @@ export class InMemoryTaskStore {
   async deleteTask(id: string): Promise<boolean> {
     return this.enqueue(async () => {
       const existed = this.docs.delete(id);
-      if (existed) await this.afterWrite();
-      return existed;
+      if (!existed) return false;
+      // Record the delete inside the queued op, immediately before its own
+      // afterWrite(). Recording it earlier (outside the queue) let an
+      // already-queued write's afterWrite consume and clear the tombstone while
+      // the doc was still present, after which the delete's own persist
+      // re-seeded the doc from disk — resurrecting a task whose deleteTask had
+      // returned true. It also left a lingering tombstone when the delete
+      // turned out to be a no-op.
+      this.noteDeleted(id);
+      await this.afterWrite();
+      return true;
     });
   }
 
@@ -414,6 +425,7 @@ export class InMemoryTaskStore {
       else doc.sessions.push(session);
       doc.task.lastActivityAt = Date.now();
       doc.task.updatedAt = nowIso();
+      this.noteMutated(session.taskId);
       await this.afterWrite();
     });
   }
@@ -433,6 +445,7 @@ export class InMemoryTaskStore {
         });
         doc.task.lastActivityAt = Date.now();
         doc.task.updatedAt = nowIso();
+        this.noteMutated(doc.task.id);
         await this.afterWrite();
         return;
       }
@@ -504,6 +517,7 @@ export class InMemoryTaskStore {
       mutate(doc);
       doc.task.lastActivityAt = Date.now();
       doc.task.updatedAt = nowIso();
+      this.noteMutated(taskId);
       await this.afterWrite();
     });
   }
@@ -511,6 +525,17 @@ export class InMemoryTaskStore {
   protected async afterWrite(): Promise<void> {
     // Durable subclasses persist here.
   }
+
+  /** Called inside the queued op for every doc this store mutated, right
+   * before afterWrite(). The file backend tracks these ids so its persist
+   * only overlays docs this process actually changed. No-op here. */
+  protected noteMutated(_id: string): void {}
+
+  /** Called inside the queued op when a doc was actually removed, right
+   * before afterWrite(). The file backend records a tombstone so its persist
+   * does not resurrect the doc from a concurrent process's on-disk copy.
+   * No-op here. */
+  protected noteDeleted(_id: string): void {}
 
   /** Replace the in-memory doc set from a durable source. Public so the SQL
    * backend can seed this store as a single-document mutation engine. */
@@ -531,11 +556,17 @@ function defaultStateFile(runtime?: TaskStoreRuntime): string {
 export class FileTaskStore extends InMemoryTaskStore {
   private readonly lockFile: string;
   private loaded = false;
-  // Ids deleted by this process since the last persist. afterWrite() re-reads the
-  // on-disk document set under the lock and merges it with this process's
-  // in-memory docs; tombstones ensure a task this process deleted is not
-  // resurrected from a concurrent process's copy of the file.
+  // Ids this process deleted but has not yet durably persisted. afterWrite()
+  // re-reads the on-disk document set under the lock; tombstones ensure a task
+  // this process deleted is not resurrected from a concurrent process's copy
+  // of the file. Populated via the noteDeleted() hook inside the queued delete
+  // op so an earlier-queued write can never consume a tombstone prematurely.
   private readonly tombstones = new Set<string>();
+  // Ids this process mutated but has not yet durably persisted. afterWrite()
+  // overlays ONLY these docs onto the on-disk set, so tasks this process never
+  // touched keep a concurrent process's (possibly newer) on-disk version
+  // instead of being reverted to this process's stale in-memory copy.
+  private readonly dirty = new Set<string>();
 
   constructor(
     private readonly filePath: string,
@@ -597,9 +628,6 @@ export class FileTaskStore extends InMemoryTaskStore {
   }
   override async deleteTask(id: string) {
     await this.ensureLoaded();
-    // Record the tombstone BEFORE the write so afterWrite()'s disk merge removes
-    // it even if a concurrent process's on-disk copy still carries the task.
-    this.tombstones.add(id);
     return super.deleteTask(id);
   }
   override async addSession(session: OrchestratorTaskSession) {
@@ -642,19 +670,26 @@ export class FileTaskStore extends InMemoryTaskStore {
     return super.addPlanRevision(revision);
   }
 
+  protected override noteMutated(id: string): void {
+    this.dirty.add(id);
+  }
+
+  protected override noteDeleted(id: string): void {
+    this.tombstones.add(id);
+  }
+
   protected override async afterWrite(): Promise<void> {
     await this.withLock(async () => {
       await mkdir(dirname(this.filePath), { recursive: true });
-      // Read-merge-write under the lock so a concurrent process's inserts/updates
-      // to OTHER tasks survive this process's whole-document write. Merge order:
-      //   1. seed from the current on-disk set (picks up concurrent inserts),
-      //   2. drop this process's deletes (tombstones),
-      //   3. overlay this process's in-memory docs (its inserts/updates win; a
-      //      re-created id is present in this.docs so it is restored after the
-      //      tombstone delete).
-      // Residual: two processes updating DIFFERENT fields of the SAME task still
-      // resolves last-writer-wins at the document level (matching the SQL
-      // backend's single-row semantics); cross-task lost updates are eliminated.
+      // Read-merge-write under the lock so a concurrent process's writes to
+      // OTHER tasks survive this process's write. Merge order:
+      //   1. seed from the current on-disk set (concurrent inserts/updates),
+      //   2. drop the ids this process deleted (tombstones),
+      //   3. overlay only the docs this process actually mutated (dirty ids) —
+      //      untouched tasks keep their on-disk versions.
+      // Residual: two processes mutating the SAME task still resolve
+      // last-writer-wins at the document level, matching the SQL backend's
+      // single-row upsert semantics.
       const merged = new Map<string, OrchestratorTaskDocument>();
       try {
         const contents = await readFile(this.filePath, "utf8");
@@ -671,16 +706,22 @@ export class FileTaskStore extends InMemoryTaskStore {
         if (code !== "ENOENT") throw error;
       }
       for (const id of this.tombstones) merged.delete(id);
-      for (const [id, doc] of this.docs) merged.set(id, doc);
-      // Adopt the merged view so subsequent reads in this process observe the
-      // concurrent inserts too, then clear the applied tombstones.
+      for (const id of this.dirty) {
+        const doc = this.docs.get(id);
+        if (doc) merged.set(id, doc);
+      }
+      // Adopt the merged view so subsequent reads in this process observe
+      // concurrent inserts/updates/deletes too.
       this.docs.clear();
       for (const [id, doc] of merged) this.docs.set(id, doc);
-      this.tombstones.clear();
       const tempPath = `${this.filePath}.${process.pid}.${Date.now()}.tmp`;
       const payload = JSON.stringify([...merged.values()], null, 2);
       await writeFile(tempPath, `${payload}\n`, "utf8");
       await rename(tempPath, this.filePath);
+      // Forget applied tombstones/dirty ids only after the rename lands; a
+      // failed write leaves them pending so the next persist applies them.
+      this.tombstones.clear();
+      this.dirty.clear();
     });
   }
 


### PR DESCRIPTION
Follow-up to #11197 (refs #11028), from post-merge review of the task-store concurrency fix. Two defects in the `FileTaskStore` read-merge-write as merged, both reproduced by regression tests that **fail on current develop**:

## 1. Deleted-task resurrection race (in-process)

`deleteTask` recorded its tombstone **before** the delete was enqueued. Interleaving:

1. `createTask(Y)` is enqueued (op1), `deleteTask(X)` adds tombstone X and enqueues (op2).
2. op1's `afterWrite` consumes tombstone X — but the whole-doc overlay re-adds X (still in memory) — then `tombstones.clear()`.
3. op2 deletes X from memory, but its `afterWrite` has no tombstone left and re-seeds X from disk.

Result: `deleteTask` returned `true`, X survived on disk **and** in memory. A failed delete (unknown id) also left a lingering tombstone that a later unrelated write applied — phantom-deleting another process's task after the delete had reported `false`.

**Fix:** `noteDeleted()` hook invoked inside the queued op, immediately before that op's own `afterWrite`, and only when the doc actually existed. Queue serialization guarantees each tombstone is applied exactly once, by the right persist.

## 2. Cross-process update revert

`afterWrite` overlaid this process's **entire** in-memory doc set, so any write reverted a concurrent process's on-disk updates to tasks this process never touched. #11197's "cross-task lost updates are eliminated" only held for inserts/deletes. **Fix:** `noteMutated()` hook tracks dirty ids; the merge overlays only docs this process actually mutated. Untouched tasks keep their on-disk versions, and the adopted merged view now also propagates concurrent deletes into this process's memory.

Also: tombstone/dirty sets clear only **after** the temp-file rename lands (a failed write leaves them pending for the next persist), and the concurrent-insert merge test now hydrates both stores before either writes — as previously written it also passed on the pre-#11197 clobbering code, i.e. it proved nothing.

## Evidence

Regression proof — new tests against **develop's** store code (fix reverted, tests kept):

```
Tests  3 failed | 32 passed (35)
  × FileTaskStore delete that races an in-flight write in the same process stays deleted
  × FileTaskStore failed delete does not phantom-delete another process's task later
  × FileTaskStore write does not revert another process's update to a task it did not touch
```

With the fix:

```
$ bunx vitest run __tests__/unit/orchestrator-task-store.test.ts
Tests  35 passed (35)

$ bun run test   # full plugin suite
Test Files  132 passed | 4 skipped (136)
     Tests  1367 passed | 8 skipped (1375)
```

Plugin `typecheck` (tsgo) clean; biome clean on both touched files.

Frontend evidence: N/A — storage-layer concurrency fix, no UI surface; behavior is covered by the deterministic unit regressions above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)