### PR TITLE
fix(cloud): /v1/chat reserves for the real output ceiling, not the 500-token default (#11169 part 2)

### DIFF
--- a/packages/cloud/api/__tests__/chat-stream-credit-leak.test.ts
+++ b/packages/cloud/api/__tests__/chat-stream-credit-leak.test.ts
@@ -114,15 +114,27 @@ function makeLedgerReservation(startBalance: number, hold: number) {
 }
 
 let ledger = makeLedgerReservation(100, 0.015);
+const reserveCalls: Array<Record<string, unknown>> = [];
 
 mock.module("@/lib/services/credits", () => ({
   creditsService: {
     createAnonymousReservation: mock(
       () => makeLedgerReservation(0, 0).reservation,
     ),
-    reserve: mock(async () => ledger.reservation),
+    reserve: mock(async (params: Record<string, unknown>) => {
+      reserveCalls.push(params);
+      return ledger.reservation;
+    }),
   },
   InsufficientCreditsError: TestInsufficientCreditsError,
+}));
+
+// #11169 part 2: control the CoT thinking budget so a test can assert the
+// reservation is sized for the real output ceiling, not the 500 default.
+let cotBudgetImpl: number | null = null;
+mock.module("@/lib/providers/anthropic-thinking", () => ({
+  resolveAnthropicThinkingBudgetTokens: () => cotBudgetImpl,
+  mergeAnthropicCotProviderOptions: () => ({}),
 }));
 
 const { default: chatRoute } = await import("../v1/chat/route");
@@ -179,6 +191,46 @@ describe("/v1/chat streaming credit reservation", () => {
     await onAbort?.();
     expect(ledger.reconcileCalls).toBe(1);
     expect(ledger.balance).toBeCloseTo(ledger.startBalance, 10);
+  });
+});
+
+describe("/v1/chat reservation output-ceiling sizing (#11169 part 2)", () => {
+  test("CoT model reserves for the effective output ceiling, not the 500 default", async () => {
+    reserveCalls.length = 0;
+    cotBudgetImpl = 8000; // → effectiveMax = max(4096, 8000 + 4096) = 12096
+    try {
+      streamTextImpl = () => ({
+        toUIMessageStreamResponse: () => new Response("ok"),
+      });
+      const res = await chatRoute.request("/", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ messages: [{ role: "user", content: "hi" }] }),
+      });
+      expect(res.status).toBe(200);
+      expect(reserveCalls).toHaveLength(1);
+      // Pre-fix this was absent → reserve used DEFAULT_OUTPUT_TOKENS (500),
+      // letting a CoT completion consume ~24x its hold.
+      expect(reserveCalls[0]?.estimatedOutputTokens).toBe(12096);
+    } finally {
+      cotBudgetImpl = null;
+    }
+  });
+
+  test("non-CoT model reserves without an output override (500 default preserved)", async () => {
+    reserveCalls.length = 0;
+    cotBudgetImpl = null;
+    streamTextImpl = () => ({
+      toUIMessageStreamResponse: () => new Response("ok"),
+    });
+    const res = await chatRoute.request("/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ messages: [{ role: "user", content: "hi" }] }),
+    });
+    expect(res.status).toBe(200);
+    expect(reserveCalls).toHaveLength(1);
+    expect(reserveCalls[0]?.estimatedOutputTokens).toBeUndefined();
   });
 });
 

--- a/packages/cloud/api/v1/chat/route.ts
+++ b/packages/cloud/api/v1/chat/route.ts
@@ -296,6 +296,23 @@ app.post("/", async (c) => {
       creditsService.createAnonymousReservation();
     const affiliateCode = c.req.header("X-Affiliate-Code") ?? null;
 
+    // Compute the output-token ceiling BEFORE reserving so the upfront hold
+    // covers the REAL cap, not the 500-token default (#11169 part 2). CoT models
+    // grant maxOutputTokens = cotBudget + 4096; reserving for DEFAULT_OUTPUT_TOKENS
+    // (500) let a near-floor org repeatedly consume far more than it held.
+    const DEFAULT_MIN_OUTPUT_TOKENS = 4096;
+    const cotBudget = resolveAnthropicThinkingBudgetTokens(
+      selectedModel,
+      process.env,
+    );
+    const effectiveMaxOutputTokens =
+      cotBudget != null
+        ? Math.max(
+            DEFAULT_MIN_OUTPUT_TOKENS,
+            cotBudget + DEFAULT_MIN_OUTPUT_TOKENS,
+          )
+        : undefined;
+
     if (!isAnonymous && user.organization_id) {
       const messageText = messages
         .map((m) => extractTextFromParts(m.parts))
@@ -307,6 +324,11 @@ app.post("/", async (c) => {
           model: selectedModel,
           provider,
           estimatedInputTokens,
+          // Size the hold for the actual output ceiling, not the 500 default, so
+          // a CoT completion can't consume more than was reserved (#11169).
+          ...(effectiveMaxOutputTokens != null
+            ? { estimatedOutputTokens: effectiveMaxOutputTokens }
+            : {}),
           userId: user.id,
           description: `Chat: ${selectedModel}`,
         });
@@ -323,19 +345,6 @@ app.post("/", async (c) => {
 
     settleReservation = createCreditReservationSettler(reservation);
     const routeTimeoutMs = getRouteTimeoutMs(ROUTE_MAX_DURATION);
-
-    const DEFAULT_MIN_OUTPUT_TOKENS = 4096;
-    const cotBudget = resolveAnthropicThinkingBudgetTokens(
-      selectedModel,
-      process.env,
-    );
-    const effectiveMaxOutputTokens =
-      cotBudget != null
-        ? Math.max(
-            DEFAULT_MIN_OUTPUT_TOKENS,
-            cotBudget + DEFAULT_MIN_OUTPUT_TOKENS,
-          )
-        : undefined;
 
     const result = streamText({
       model: getLanguageModel(selectedModel),


### PR DESCRIPTION
Part 2 of #11169.

## Problem (MED — money under-reservation / evasion)
`/v1/chat` (`packages/cloud/api/v1/chat/route.ts`) called `creditsService.reserve` with **no `estimatedOutputTokens`** → `DEFAULT_OUTPUT_TOKENS` (500), while the model was granted `maxOutputTokens = cotBudget + 4096` for CoT models. The upfront hold was ~24× too small, so a near-floor org could repeatedly consume far more than it reserved. #10924 fixed `apps/[id]/chat` only; `/v1/chat` got neither the ceiling reserve nor the effective-max computation.

## Fix
Compute the output ceiling (`cotBudget + 4096`, floored at 4096) **before** the reserve and pass it as `estimatedOutputTokens`, so the hold matches the real cap. Non-CoT models keep existing behavior (no override → 500 default). This mirrors #10924's pattern for the sibling route.

## Test (`chat-stream-credit-leak.test.ts`, +2)
- CoT model (budget 8000) → reserve called with `estimatedOutputTokens: 12096` (was absent/500).
- Non-CoT model → reserve called without an override (500 default preserved).

```
bun test packages/cloud/api/__tests__/chat-stream-credit-leak.test.ts   # 6 pass
```
`packages/cloud/api build` + biome clean.

Part 2 of 3 in #11169 — parts 1 (app-chat non-streaming refund-on-throw) + 3 (stranded synchronous reservation sweep) are follow-ups. Money-path — flagging for maintainer review/merge. \`[cloud-security]\`