### PR TITLE
fix(cockpit): keep the desktop w-80 inspector rail in the session pane

### DIFF
--- a/plugins/plugin-task-coordinator/src/CockpitSessionPane.tsx
+++ b/plugins/plugin-task-coordinator/src/CockpitSessionPane.tsx
@@ -387,7 +387,7 @@ export function CockpitSessionPane({
         {detail ? (
           <TaskInspector
             detail={detail}
-            className="flex"
+            className={isMobile ? "flex" : undefined}
             style={
               isMobile
                 ? inspectorOpen


### PR DESCRIPTION
## What

Follow-up to #11159. That PR's stated intent was "Desktop is unchanged", but the `TaskInspector` mount in `CockpitSessionPane.tsx` passed `className="flex"` unconditionally, overriding the component's default `"flex w-80"` and silently removing the fixed 320px rail width on desktop.

This passes `className={isMobile ? "flex" : undefined}` so the mobile drawer keeps its full-width flex layout and desktop falls back to the default `flex w-80` rail (verified in `OrchestratorWorkbench.tsx`: `${className ?? "flex w-80"}`).

## Testing

- `bunx biome check` on the touched file: clean.
- `bun run --cwd plugins/plugin-task-coordinator test`: 182 tests pass (incl. `CockpitSessionPane.test.tsx` and the inspector tests; 2 suites needed the fresh-worktree i18n generation step to run at all).
- Plugin typecheck: no new errors from this change (one pre-existing `OrchestratorWorkbench.tsx` ref-type error exists on develop tip with or without this diff).

Evidence: N/A screenshots — one-line class fix restoring the pre-#11159 desktop rail; behavior covered by the existing CockpitSessionPane inspector tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)