### PR TITLE
feat(orchestrator): model-backed sub-agent interruption decision (#11028)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/interruption-decider.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/interruption-decider.test.ts
@@ -1,7 +1,18 @@
-import { describe, expect, it } from "vitest";
-import { decideInterruption } from "../../src/services/interruption-decider.js";
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  decideInterruption,
+  decideInterruptionWithModel,
+} from "../../src/services/interruption-decider.js";
 
 const base = { agentType: "claude", agentLabel: "Ada" } as const;
+
+/** Minimal runtime exposing only `useModel`, which is all the classifier uses. */
+function runtimeWithModel(
+  useModel: (type: unknown, params: unknown) => Promise<unknown>,
+): IAgentRuntime {
+  return { useModel: vi.fn(useModel) } as unknown as IAgentRuntime;
+}
 
 describe("decideInterruption", () => {
   it("ignores empty text", () => {
@@ -176,5 +187,84 @@ describe("decideInterruption", () => {
     expect(
       decideInterruption({ ...base, text: "stop", sessionBusy: true }).action,
     ).toBe("interrupt");
+  });
+});
+
+describe("decideInterruptionWithModel", () => {
+  it("skips the model for empty text (ignore)", async () => {
+    const useModel = vi.fn(async () => "{}");
+    const decision = await decideInterruptionWithModel(
+      runtimeWithModel(useModel),
+      { ...base, text: "   ", sessionBusy: true },
+    );
+    expect(decision.action).toBe("ignore");
+    expect(useModel).not.toHaveBeenCalled();
+  });
+
+  it("skips the model for an idle agent in a solo room (deliver via regex)", async () => {
+    const useModel = vi.fn(async () => "{}");
+    const decision = await decideInterruptionWithModel(
+      runtimeWithModel(useModel),
+      { ...base, text: "add a dark mode toggle", sessionBusy: false },
+    );
+    expect(decision.action).toBe("deliver");
+    expect(useModel).not.toHaveBeenCalled();
+  });
+
+  it("consults the model mid-turn and uses its verdict", async () => {
+    const useModel = vi.fn(async () =>
+      JSON.stringify({ action: "queue", reason: "additive test request" }),
+    );
+    const decision = await decideInterruptionWithModel(
+      runtimeWithModel(useModel),
+      { ...base, text: "also add unit tests for the parser", sessionBusy: true },
+    );
+    expect(useModel).toHaveBeenCalledTimes(1);
+    expect(decision.action).toBe("queue");
+    expect(decision.reason).toMatch(/^model:/);
+  });
+
+  it("lets the model interrupt for a semantic redirect the regex would only queue", async () => {
+    // "let's rework this to use Postgres" has no STOP/REDIRECT regex token, so
+    // the pure decider queues it; the model recognizes a direction-invalidating
+    // redirect and interrupts.
+    const regex = decideInterruption({
+      ...base,
+      text: "let's rework this to use Postgres",
+      sessionBusy: true,
+    });
+    expect(regex.action).toBe("queue");
+    const useModel = vi.fn(async () =>
+      JSON.stringify({ action: "interrupt", reason: "invalidating redirect" }),
+    );
+    const decision = await decideInterruptionWithModel(
+      runtimeWithModel(useModel),
+      { ...base, text: "let's rework this to use Postgres", sessionBusy: true },
+    );
+    expect(decision.action).toBe("interrupt");
+  });
+
+  it("falls back to the regex decision when the model throws", async () => {
+    const useModel = vi.fn(async () => {
+      throw new Error("model unavailable");
+    });
+    const decision = await decideInterruptionWithModel(
+      runtimeWithModel(useModel),
+      { ...base, text: "stop", sessionBusy: true },
+    );
+    // Regex still interrupts on a bare "stop".
+    expect(decision.action).toBe("interrupt");
+  });
+
+  it("falls back to the regex decision on an unparseable / invalid verdict", async () => {
+    const useModel = vi.fn(async () =>
+      JSON.stringify({ action: "banana", reason: "nonsense" }),
+    );
+    const decision = await decideInterruptionWithModel(
+      runtimeWithModel(useModel),
+      { ...base, text: "also add tests", sessionBusy: true },
+    );
+    // Invalid action → regex fallback (mid-turn relevant → queue).
+    expect(decision.action).toBe("queue");
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/active-session-forward.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/active-session-forward.ts
@@ -10,7 +10,7 @@
  */
 import type { IAgentRuntime, Memory } from "@elizaos/core";
 import { AcpService } from "./acp-service.js";
-import { decideInterruption } from "./interruption-decider.js";
+import { decideInterruptionWithModel } from "./interruption-decider.js";
 import type { SubAgentInbox } from "./sub-agent-inbox.js";
 import { requireTaskAgentAccess } from "./task-policy.js";
 import { type SessionInfo, TERMINAL_SESSION_STATUSES } from "./types.js";
@@ -109,12 +109,22 @@ export function createActiveSessionForwardHandler(
       // "Crowded room": more than one live sub-agent bound to this room.
       const multiParty = sessions.filter(boundToRoom).length > 1;
       const busy = isSessionBusy(active.status);
-      const decision = decideInterruption({
+      // What the sub-agent is working on, for the model classifier's relevance
+      // judgement — best-effort from session metadata (all optional).
+      const meta = (active.metadata ?? {}) as Record<string, unknown>;
+      const taskContext = [
+        meta.originalTask,
+        meta.task,
+        meta.goal,
+        meta.taskTitle,
+      ].find((v): v is string => typeof v === "string" && v.trim().length > 0);
+      const decision = await decideInterruptionWithModel(runtime, {
         text,
         agentType: active.agentType,
         sessionBusy: busy,
         multiParty,
         ...(label ? { agentLabel: label } : {}),
+        ...(taskContext ? { taskContext } : {}),
       });
       runtime.logger?.debug?.(
         {

--- a/plugins/plugin-agent-orchestrator/src/services/interruption-decider.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/interruption-decider.ts
@@ -17,6 +17,9 @@
  * stop/redirect; otherwise relevant messages QUEUE and ambient ones are IGNORE.
  */
 
+import { type IAgentRuntime, ModelType } from "@elizaos/core";
+import { parseJsonObjectResponse } from "./json-model-output.js";
+
 export type InterruptionAction = "deliver" | "queue" | "interrupt" | "ignore";
 
 export interface InterruptionDecision {
@@ -37,6 +40,9 @@ export interface InterruptionInput {
   shouldRespond?: "RESPOND" | "IGNORE" | "STOP";
   /** True when the room has participants beyond the user + this sub-agent. */
   multiParty?: boolean;
+  /** What the sub-agent is working on (task/goal), for the model classifier's
+   *  relevance judgement. Ignored by the pure-regex {@link decideInterruption}. */
+  taskContext?: string;
 }
 
 // Explicit "stop what you're doing" intent.
@@ -134,4 +140,105 @@ export function decideInterruption(
     return { action: "ignore", reason: "ambient chatter during turn" };
   }
   return { action: "queue", reason: "relevant; deliver after current turn" };
+}
+
+// ── Model-backed classifier ─────────────────────────────────────────────────
+//
+// The regex decider above is a fast, deterministic pre-filter, but it reasons
+// only over English surface patterns: it cannot tell an intent-level halt
+// ("wait, this is all wrong") from an additive aside, nor a direction-changing
+// redirect ("actually target Postgres") from a code-content instruction ("stop
+// using axios"), and it is English-only. For the decision-critical cases — a
+// sub-agent mid-turn, or a crowded room where directedness matters — we ask a
+// small model to classify the message's intent toward the running agent with
+// full task context. It returns the 4-way action directly (a superset of the
+// core RESPOND/IGNORE/STOP verdict, which cannot express "interrupt to
+// redirect"). The regex decision remains the fallback whenever the model is
+// unavailable or returns an unparseable verdict, so behavior only ever improves.
+
+function buildInterruptionClassifierPrompt(input: InterruptionInput): string {
+  const label = input.agentLabel?.trim() || input.agentType;
+  const work = input.taskContext?.trim()
+    ? input.taskContext.trim().slice(0, 500)
+    : "a coding task";
+  const state = input.sessionBusy
+    ? "MID-TURN (actively generating or running a tool right now)"
+    : "IDLE (between turns)";
+  const room = input.multiParty
+    ? "multiple participants — a message may be directed at someone else, not this agent"
+    : "just the user and this agent";
+  return [
+    "You are the interruption controller for an autonomous coding sub-agent in a shared chat room.",
+    "A human just posted a message. Decide what to do with it relative to the sub-agent's IN-PROGRESS work.",
+    "",
+    `Sub-agent: ${label} (${input.agentType}), working on: ${work}`,
+    `State: ${state}`,
+    `Room: ${room}`,
+    "",
+    `Incoming message: """${input.text.trim().slice(0, 800)}"""`,
+    "",
+    "Choose EXACTLY one action:",
+    '- "interrupt": stop or change direction RIGHT NOW — an explicit halt ("stop", "cancel", "wait"), or a redirect that invalidates the work in progress ("no, use Postgres not MySQL", "scrap that, start over"). Reserve for genuine halts/redirects worth cancelling live work for.',
+    '- "queue": a RELEVANT instruction or addition that should reach the agent AFTER the current turn — including code-content instructions like "stop using axios", "don\'t import lodash", "also add tests", "make the header sticky too". These change what the code does; they are NOT a command to halt the agent.',
+    '- "deliver": the agent is idle and this message is for it — send it now.',
+    '- "ignore": chatter not meant for this agent — acknowledgements ("nice", "thanks", "lgtm"), or (in a crowded room) messages addressed to someone else or unrelated to the task.',
+    "",
+    'Bias: a working sub-agent keeps working. Prefer "queue" over "interrupt" unless the message is a genuine halt or a direction-invalidating redirect. Never choose "interrupt" merely because the text contains the word "stop" — judge intent.',
+    '',
+    'Respond with ONLY a JSON object: {"action":"interrupt|queue|deliver|ignore","reason":"<short>"}',
+  ].join("\n");
+}
+
+function parseInterruptionVerdict(raw: string): InterruptionDecision | null {
+  const obj = parseJsonObjectResponse<{ action?: unknown; reason?: unknown }>(
+    raw,
+  );
+  if (!obj) return null;
+  const action =
+    typeof obj.action === "string" ? obj.action.trim().toLowerCase() : "";
+  if (
+    action !== "interrupt" &&
+    action !== "queue" &&
+    action !== "deliver" &&
+    action !== "ignore"
+  ) {
+    return null;
+  }
+  const detail =
+    typeof obj.reason === "string" && obj.reason.trim()
+      ? obj.reason.trim().slice(0, 160)
+      : "verdict";
+  return { action, reason: `model: ${detail}` };
+}
+
+/**
+ * Model-backed interruption decision. Uses the pure regex {@link
+ * decideInterruption} as a cheap pre-filter for the unambiguous cases (empty
+ * text → ignore; an idle agent in a solo room → deliver), and for the
+ * decision-critical cases (mid-turn, or a crowded room) asks a small model to
+ * classify intent with full task context. Falls back to the regex decision on
+ * any model error or unparseable verdict — so it never regresses the pure path.
+ */
+export async function decideInterruptionWithModel(
+  runtime: IAgentRuntime,
+  input: InterruptionInput,
+): Promise<InterruptionDecision> {
+  const baseline = decideInterruption(input);
+  if (!input.text.trim()) return baseline;
+  // Only a mid-turn agent (interrupt-vs-queue matters) or a crowded room
+  // (directed-vs-ambient matters) warrants a model call. An idle agent in a
+  // solo room simply receives the message.
+  if (!input.sessionBusy && !input.multiParty) return baseline;
+  try {
+    const raw = await runtime.useModel(ModelType.TEXT_SMALL, {
+      prompt: buildInterruptionClassifierPrompt(input),
+      stopSequences: [],
+    });
+    const verdict = parseInterruptionVerdict(
+      typeof raw === "string" ? raw : String(raw),
+    );
+    return verdict ?? baseline;
+  } catch {
+    return baseline;
+  }
 }


### PR DESCRIPTION
Addresses the interruption residual from **#11028**: the mid-task interrupt/queue/deliver/ignore decision was 100% regex.

## Why

`decideInterruption` already accepts an optional `shouldRespond` verdict, but `active-session-forward.ts` never supplied one — so every routing call reasoned only over English surface patterns. That cannot:
- separate an intent-level halt ("wait, this is all wrong") from an additive aside,
- tell a direction-changing **redirect** ("actually, let's target Postgres" — no STOP/REDIRECT token) from a code-content instruction ("stop using axios"),
- work in any non-English language.

The 3-way `shouldRespond` (RESPOND/IGNORE/STOP) also can't express "**interrupt to redirect**" (a redirect isn't a halt), so even threading it wouldn't fully solve it.

## What

`decideInterruptionWithModel(runtime, input)`:
- **Regex pre-filter (cheap, deterministic)** handles the unambiguous cases with no model call — empty text → ignore; an idle agent in a solo room → deliver.
- **Model classifier (TEXT_SMALL)** handles the decision-critical cases — a sub-agent mid-turn (interrupt-vs-queue matters) or a crowded room (directed-vs-ambient matters). It sees the task context + agent role + room shape and returns the **4-way action directly**, with a prompt that encodes the bias ("a working sub-agent keeps working; prefer queue over interrupt; never interrupt merely because the text says 'stop' — judge intent").
- **Regex is the fallback** on any model error or unparseable/invalid verdict, so it never regresses the pure path and adds no live-turn cancellation on failure.

Follows the plugin's existing `runtime.useModel(TEXT_SMALL)` + `parseJsonObjectResponse` pattern (goal-llm-verifier). `active-session-forward` now threads task context from session metadata and awaits the decider.

## Evidence

```
$ bunx vitest run __tests__/unit/interruption-decider.test.ts   → 16 passed (16)
$ bunx vitest run __tests__/unit/active-session-forward.test.ts → 13 passed (13)
```

+6 new cases: skips the model for empty/idle-solo; uses the model's verdict mid-turn; **interrupts for a semantic redirect the regex only queues**; falls back to regex on a model throw and on an invalid verdict.

Refs #11028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)