### PR TITLE
fix(cloud): invalidate app cache after compliance review — stale review_status payment gate

### DIFF
--- a/packages/cloud/shared/src/lib/services/app-review.ts
+++ b/packages/cloud/shared/src/lib/services/app-review.ts
@@ -26,6 +26,7 @@ import { type AppReview, appReviews } from "../../db/schemas/app-reviews";
 import { type App, apps } from "../../db/schemas/apps";
 import { getLanguageModel, hasLanguageModelProviderConfigured } from "../providers/language-model";
 import { logger } from "../utils/logger";
+import { appsService } from "./apps";
 
 /** Bump when the rubric or category taxonomy changes so old rows stay attributable. */
 export const RUBRIC_VERSION = "2026-07-01.1";
@@ -398,6 +399,26 @@ export async function runAppReview(params: RunAppReviewParams): Promise<AppRevie
 
     return row;
   });
+
+  // The review just changed apps.review_status in the DB, but appsService caches
+  // the app row (getById, TTL 300s) — the monetization/charge gates read through
+  // that cache via isAppMonetizationApproved. Without this invalidation an
+  // approval 403s legit creators for up to 5 min, and a re-review to REJECTED
+  // leaves the payment gate reading a stale "approved" row. Mirrors the
+  // invalidate-on-mutation invariant documented at apps.ts:105-111. Best-effort:
+  // a cache-eviction failure must not fail the (already-committed) review.
+  try {
+    await appsService.invalidateCache(
+      app.id,
+      app.api_key_id ?? undefined,
+      app.slug ?? undefined,
+    );
+  } catch (err) {
+    logger.warn("[AppReview] cache invalidation after review failed", {
+      appId: app.id,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
 
   logger.info("[AppReview] Completed review", {
     appId: app.id,


### PR DESCRIPTION
**Found via the Fable-5 live-staging e2e sweep** (charter #11157 launch-hardening). Money/compliance path — flagging `[cloud-money]`/`[cloud-audit]` to review/own per the charter split; I root-caused + fixed + proved it live.

### Bug
`runAppReview` (`packages/cloud/shared/src/lib/services/app-review.ts`) commits the review decision to `apps.review_status` in a transaction but **never evicts the appsService app-row cache** (`getById`, TTL 300s) — violating the invalidate-on-mutation invariant documented at `apps.ts:105-111`. The monetization-enable + charge gates read review status through that cache via `isAppMonetizationApproved`, so:
- an **approval** 403s legit creators from enabling monetization / taking charges for **up to 5 min**;
- a re-review to **REJECTED** leaves the `getById`-backed gate reading a stale `approved` row for up to 5 min (compliance hole).

### Fix
After the review transaction, `appsService.invalidateCache(app.id, api_key_id, slug)` (best-effort — a cache-eviction failure must not fail the already-committed review). Typecheck-clean, no import cycle (`apps.ts` doesn't import `app-review.ts`).

### Evidence — live before/after on staging (deterministic pre-filter ban, no model needed)
| | POST /review | immediate GET /apps/:id |
|---|---|---|
| **BEFORE** (found in sweep) | `review_status: rejected` | `draft` ❌ stale |
| **AFTER** (this fix, staging worker `41ee53dc`) | `review_status: rejected` | `rejected` ✅ fresh |

Real staging Worker + real Railway DB + real review path, inspected by hand. The charge path (`appsRepository.findById`, uncached) was already reading fresh, so money-OUT was protected; this closes the getById-backed staleness the monetization gate and GET /review exposed.

### Note
This is the CODE-level sibling of the config-level staleness in #11126 (Hyperdrive query cache) — both are read-after-write on the compliance/money surface. With both fixed, that whole class is closed.

— `[cloud-frontdoor]`