### PR TITLE
fix(orchestrator): refresh stale enrichment metadata when a session resumes (post-#11093)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/swarm-coordinator-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/swarm-coordinator-service.test.ts
@@ -575,7 +575,7 @@ describe("SwarmCoordinatorService", () => {
     }
   });
 
-  it("cancels the pending eviction when the session resumes within the grace window", async () => {
+  it("cancels the pending eviction and refreshes metadata when the session resumes within the grace window", async () => {
     vi.useFakeTimers();
     try {
       const acp = makeAcpStub({
@@ -586,19 +586,36 @@ describe("SwarmCoordinatorService", () => {
       const runtime = makeRuntime({ [AcpService.serviceType]: acp });
       const coordinator = await SwarmCoordinatorService.start(runtime);
 
+      const received: SwarmEvent[] = [];
+      coordinator.subscribe((e) => received.push(e));
+
       // Turn 1 completes and schedules the 60s eviction. task_complete fires at
-      // the end of every prompt turn — it is NOT the end of the session.
+      // the end of every prompt turn; it is NOT the end of the session.
       acp.emit("sess-resume", "task_complete", { response: "turn 1 done" });
       await vi.advanceTimersByTimeAsync(0);
       expect(coordinator.tasks.has("sess-resume")).toBe(true);
+      expect(received.at(-1)?.data).toMatchObject({ label: "build-site" });
+      expect(acp.getSession).toHaveBeenCalledTimes(1);
 
-      // A follow-up turn reuses the same session WITHIN the grace window: a
-      // non-terminal event must cancel the pending eviction.
+      // A follow-up turn reuses the same session WITHIN the grace window. Its
+      // persisted metadata may have changed since the first turn, so canceling
+      // the eviction must also drop the old enrichment snapshot.
+      acp.setSession({
+        agentType: "codex",
+        workdir: "/tmp/wd",
+        metadata: { label: "build-site-turn-2", initialTask: "build it again" },
+      });
       await vi.advanceTimersByTimeAsync(30_000);
       acp.emit("sess-resume", "tool_running", { toolCall: { title: "Bash" } });
       await vi.advanceTimersByTimeAsync(0);
 
-      // Past the original 60s deadline the live task state must survive — without
+      expect(received.at(-1)?.data).toMatchObject({
+        label: "build-site-turn-2",
+        initialTask: "build it again",
+      });
+      expect(acp.getSession).toHaveBeenCalledTimes(2);
+
+      // Past the original 60s deadline the live task state must survive. Without
       // the cancel it is evicted mid-turn, blinding Discord suppression + routing.
       await vi.advanceTimersByTimeAsync(60_000);
       expect(coordinator.tasks.has("sess-resume")).toBe(true);

--- a/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
@@ -391,6 +391,17 @@ export class SwarmCoordinatorService extends Service {
     event: string,
     data: unknown,
   ): Promise<void> {
+    // A non-terminal event means the session resumed: a follow-up prompt turn
+    // reuses the same session (task_complete fires at the end of every turn, then
+    // the session returns to a non-terminal status and accepts more input). Cancel
+    // any pending post-terminal eviction so the still-live task state is not
+    // deleted mid-turn. Also refresh cached enrichment metadata: session metadata
+    // can be patched between turns, and a resumed turn must not reuse the prior
+    // turn's stale snapshot — so this must run BEFORE enrichment below.
+    if (!this.isTerminalEvent(event)) {
+      this.cancelLegacyTaskEviction(sessionId);
+    }
+
     const enrichedData = this.shouldEnrichEvent(event)
       ? await this.enrichEventData(sessionId, data)
       : data;
@@ -407,24 +418,6 @@ export class SwarmCoordinatorService extends Service {
       await this.runCustomValidatorAndDispatch(sessionId, enrichedData);
       this.scheduleLegacyTaskEviction(sessionId);
       return;
-    }
-
-    // A non-terminal event means the session resumed: a follow-up prompt turn
-    // reuses the same session (task_complete fires at the end of every turn, then
-    // the session returns to a non-terminal status and accepts more input). Cancel
-    // any pending post-terminal eviction so the still-live task state and its
-    // enrichment cache are not deleted mid-turn — an eviction inside the grace
-    // window blinds Discord timeout suppression and task routing until the next
-    // ACP event happens to recreate the entry.
-    // A non-terminal event means the session resumed: a follow-up prompt turn
-    // reuses the same session (task_complete fires at the end of every turn, then
-    // the session returns to a non-terminal status and accepts more input). Cancel
-    // any pending post-terminal eviction so the still-live task state and its
-    // enrichment cache are not deleted mid-turn — an eviction inside the grace
-    // window blinds Discord timeout suppression and task routing until the next
-    // ACP event happens to recreate the entry.
-    if (!this.isTerminalEvent(event)) {
-      this.cancelLegacyTaskEviction(sessionId);
     }
 
     const swarmEvent: SwarmEvent = {
@@ -626,6 +619,7 @@ export class SwarmCoordinatorService extends Service {
     if (!existing) return;
     clearTimeout(existing);
     this.legacyTaskEvictionTimers.delete(sessionId);
+    this.enrichmentMetadataCache.delete(sessionId);
   }
 
   private dispatchSwarmEvent(swarmEvent: SwarmEvent): void {


### PR DESCRIPTION
## What

Follow-up to #11086 / #11093 (SwarmCoordinatorService enrichment cache + resume-window eviction cancel), found during interaction-level verification of develop HEAD after the merge storm.

When a completed session resumes within the 60s legacy-task eviction grace window, `cancelLegacyTaskEviction()` kept the **cached enrichment metadata snapshot from the previous turn**. Session metadata can be patched between turns (label, initialTask, origin routing ids), so every event of the resumed turn was enriched with the prior turn's stale snapshot and fanned out to subscribers + the WS dashboard bridge, until the entry happened to be evicted and recreated.

## Fix

- `cancelLegacyTaskEviction()` now also drops the `enrichmentMetadataCache` entry, so the next enrichable event re-reads the session from `AcpService`.
- The resume check moved **before** event enrichment in `handleAcpEvent`. Ordering matters: with the old enrich-then-cancel order, the very event that signals the resume was still enriched from the stale snapshot (proven by the failing test below before the reorder).
- Deduplicated an accidentally doubled comment block introduced in #11093.

## Not the boot-readiness symptom

The live "coordinator not available after 90s (boot), supervisionLevel unavailable" symptom is **not** explained by this change: the boot path (`scheduleAcpBindRetry`, 500ms x 120 = 60s bind patience) is untouched here and looks correct in isolation. This PR fixes a correctness bug in the resume/eviction path only. The 90s boot symptom needs a separate lane.

## Evidence

- Targeted test extended: patches session metadata between turns, asserts the resumed event carries the new `label` + `initialTask` and `getSession` is re-hit exactly once. Fails on develop HEAD, passes with the fix.
- `bunx vitest run __tests__/unit/swarm-coordinator-service.test.ts`: **21/21 pass**
- Full plugin unit suite `__tests__/unit`: **105 files, 1105/1105 pass**
- `bun run typecheck` (tsgo): clean (after building `packages/core` + `packages/agent`)
- Rebased onto current `origin/develop` (4a8a6d32b4), tests re-run green post-rebase.
- Collision check: no overlapping open PRs; #11205 (task-store tombstone race) touches different files.

Note: codex review not run (account usage-limited).

— [sol-orch]
