### PR TITLE
fix(orchestrator): wire task archive/reopen/pause to the durable service (#11028)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/archive-reopen-lifecycle.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/archive-reopen-lifecycle.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  archiveCodingTaskAction,
+  reopenCodingTaskAction,
+} from "../../src/actions/tasks.js";
+import {
+  callback,
+  memory,
+  runtimeWith,
+  state,
+} from "../../src/test-utils/action-test-utils.js";
+
+// A minimal OrchestratorTaskService double exposing only the durable lifecycle
+// methods the action wiring calls. `runtimeWith` returns it for every
+// getService() lookup, which is all these paths need.
+function taskServiceMock() {
+  return {
+    listSessions: () => [],
+    archiveTask: vi.fn(async (id: string) =>
+      id === "t1" ? { task: { id, archived: true }, sessions: [] } : null,
+    ),
+    reopenTask: vi.fn(async (id: string) =>
+      id === "t1" ? { task: { id, archived: false }, sessions: [] } : null,
+    ),
+    pauseTask: vi.fn(async (id: string) =>
+      id === "t1" ? { task: { id, paused: true }, sessions: [] } : null,
+    ),
+  };
+}
+
+const opts = (parameters: Record<string, unknown>) => ({ parameters });
+
+describe("TASKS archive/reopen lifecycle (#11028)", () => {
+  it("archives a task through the durable service (was UNSUPPORTED_OPERATION)", async () => {
+    const svc = taskServiceMock();
+    const result = await archiveCodingTaskAction.handler(
+      runtimeWith(svc),
+      memory({}),
+      state,
+      opts({ action: "archive", taskId: "t1" }),
+      callback(),
+    );
+    expect(svc.archiveTask).toHaveBeenCalledWith("t1");
+    expect(result?.success).toBe(true);
+  });
+
+  it("reopens a task through the durable service", async () => {
+    const svc = taskServiceMock();
+    const result = await reopenCodingTaskAction.handler(
+      runtimeWith(svc),
+      memory({}),
+      state,
+      opts({ action: "reopen", taskId: "t1" }),
+      callback(),
+    );
+    expect(svc.reopenTask).toHaveBeenCalledWith("t1");
+    expect(result?.success).toBe(true);
+  });
+
+  it("pauses a task via the control action (archive/reopen/pause all route to the service)", async () => {
+    const svc = taskServiceMock();
+    const result = await archiveCodingTaskAction.handler(
+      runtimeWith(svc),
+      memory({}),
+      state,
+      opts({ action: "control", controlAction: "pause", taskId: "t1" }),
+      callback(),
+    );
+    expect(svc.pauseTask).toHaveBeenCalledWith("t1");
+    expect(result?.success).toBe(true);
+  });
+
+  it("reports TASK_NOT_FOUND for an unknown task", async () => {
+    const svc = taskServiceMock();
+    const result = await archiveCodingTaskAction.handler(
+      runtimeWith(svc),
+      memory({}),
+      state,
+      opts({ action: "archive", taskId: "ghost" }),
+      callback(),
+    );
+    expect(result?.success).toBe(false);
+    expect(result?.error).toBe("TASK_NOT_FOUND");
+  });
+
+  it("requires a taskId", async () => {
+    const svc = taskServiceMock();
+    const result = await archiveCodingTaskAction.handler(
+      runtimeWith(svc),
+      memory({}),
+      state,
+      opts({ action: "archive" }),
+      callback(),
+    );
+    expect(result?.error).toBe("MISSING_TASK_ID");
+  });
+
+  it("still reports UNSUPPORTED_OPERATION in true ACP-only mode (no task service)", async () => {
+    const result = await archiveCodingTaskAction.handler(
+      runtimeWith(undefined),
+      memory({}),
+      state,
+      opts({ action: "archive", taskId: "t1" }),
+      callback(),
+    );
+    expect(result?.error).toBe("UNSUPPORTED_OPERATION");
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -1933,14 +1933,12 @@ async function runControl(
     });
   }
 
+  // Archive / reopen / pause are durable task-lifecycle operations, not ACP
+  // session controls — route them to the durable task service (see
+  // runTaskLifecycleControl). Previously this branch hard-failed with
+  // UNSUPPORTED_OPERATION even though the service supports all three.
   if (action === "archive" || action === "reopen" || action === "pause") {
-    const msg =
-      "Task thread archive/pause controls are unavailable in ACP-only mode. Use ACP session stop, send, or spawn operations.";
-    if (callback) await callback({ text: msg });
-    return failureResult("TASKS:control", "UNSUPPORTED_OPERATION", msg, {
-      reason: "acp_only",
-      action,
-    });
+    return runTaskLifecycleControl(runtime, params, content, callback, action);
   }
 
   const instruction =
@@ -2711,72 +2709,103 @@ async function runManageIssues(
 
 // ── action: archive / reopen (ARCHIVE_CODING_TASK / REOPEN_CODING_TASK) ────
 
-async function runArchive(
-  _runtime: IAgentRuntime,
-  _message: Memory,
-  _state: State | undefined,
+type TaskLifecycleOp = "archive" | "reopen" | "pause";
+
+/**
+ * Archive / reopen / pause a durable task via OrchestratorTaskService. These are
+ * first-class operations on the durable task store — the
+ * `/api/orchestrator/tasks/:id/{archive,reopen}` routes already expose them, and
+ * `archiveTask`/`reopenTask`/`pauseTask` all exist. The old action paths returned
+ * `UNSUPPORTED_OPERATION` ("ACP-only mode") from before the task service existed,
+ * which then failed the very calls the archive/reopen similes train the planner
+ * to make. Only a genuinely ACP-only runtime (no task service registered) still
+ * reports the operation as unavailable.
+ */
+async function runTaskLifecycleControl(
+  runtime: IAgentRuntime,
   params: Record<string, unknown>,
   content: Record<string, unknown>,
   callback: HandlerCallback | undefined,
+  op: TaskLifecycleOp,
 ): Promise<ActionResult> {
+  const actionName = `TASKS:${op}`;
   const taskId =
     pickString(params, content, "taskId") ??
     pickString(params, content, "threadId");
   if (!taskId) {
     const msg = "taskId is required.";
     await callbackText(callback, msg);
-    return {
-      success: false,
-      text: msg,
-      values: { error: "MISSING_TASK_ID" },
-    };
+    return failureResult(actionName, "MISSING_TASK_ID", msg, {
+      reason: "missing_task_id",
+    });
   }
-
-  try {
-    const msg = "Task thread archives are unavailable in ACP-only mode.";
+  const taskService = runtime.getService?.(
+    OrchestratorTaskService.serviceType,
+  ) as OrchestratorTaskService | null | undefined;
+  if (!taskService) {
+    const msg = `Task ${op} is unavailable without the orchestrator task service.`;
     await callbackText(callback, msg);
-    return { success: false, text: msg, error: "UNSUPPORTED_OPERATION" };
+    return failureResult(actionName, "UNSUPPORTED_OPERATION", msg, {
+      reason: "acp_only",
+      action: op,
+    });
+  }
+  try {
+    const result =
+      op === "archive"
+        ? await taskService.archiveTask(taskId)
+        : op === "reopen"
+          ? await taskService.reopenTask(taskId)
+          : await taskService.pauseTask(taskId);
+    if (!result) {
+      const msg = `Task ${taskId} not found.`;
+      await callbackText(callback, msg);
+      return failureResult(actionName, "TASK_NOT_FOUND", msg, {
+        reason: "task_not_found",
+        taskId,
+      });
+    }
+    const verb =
+      op === "archive" ? "Archived" : op === "reopen" ? "Reopened" : "Paused";
+    const out = `${verb} coding task ${taskId}.`;
+    await callbackText(callback, out);
+    return {
+      success: true,
+      text: out,
+      data: { actionName, taskId, task: result },
+    };
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);
-    coreLogger.warn(`[TASKS:archive] failed: ${errMsg}`);
-    const out = `Failed to archive coding task ${taskId}: ${errMsg}`;
+    coreLogger.warn(`[${actionName}] failed: ${errMsg}`);
+    const out = `Failed to ${op} coding task ${taskId}: ${errMsg}`;
     await callbackText(callback, out);
-    return { success: false, text: out, error: errMsg };
+    return failureResult(actionName, "LIFECYCLE_FAILED", out, {
+      reason: "lifecycle_failed",
+      taskId,
+    });
   }
 }
 
-async function runReopen(
-  _runtime: IAgentRuntime,
+async function runArchive(
+  runtime: IAgentRuntime,
   _message: Memory,
   _state: State | undefined,
   params: Record<string, unknown>,
   content: Record<string, unknown>,
   callback: HandlerCallback | undefined,
 ): Promise<ActionResult> {
-  const taskId =
-    pickString(params, content, "taskId") ??
-    pickString(params, content, "threadId");
-  if (!taskId) {
-    const msg = "taskId is required.";
-    await callbackText(callback, msg);
-    return {
-      success: false,
-      text: msg,
-      values: { error: "MISSING_TASK_ID" },
-    };
-  }
+  return runTaskLifecycleControl(runtime, params, content, callback, "archive");
+}
 
-  try {
-    const msg = "Task thread reopen is unavailable in ACP-only mode.";
-    await callbackText(callback, msg);
-    return { success: false, text: msg, error: "UNSUPPORTED_OPERATION" };
-  } catch (err) {
-    const errMsg = err instanceof Error ? err.message : String(err);
-    coreLogger.warn(`[TASKS:reopen] failed: ${errMsg}`);
-    const out = `Failed to reopen coding task ${taskId}: ${errMsg}`;
-    await callbackText(callback, out);
-    return { success: false, text: out, error: errMsg };
-  }
+async function runReopen(
+  runtime: IAgentRuntime,
+  _message: Memory,
+  _state: State | undefined,
+  params: Record<string, unknown>,
+  content: Record<string, unknown>,
+  callback: HandlerCallback | undefined,
+): Promise<ActionResult> {
+  return runTaskLifecycleControl(runtime, params, content, callback, "reopen");
 }
 
 // ── parent action ──────────────────────────────────────────────────────


### PR DESCRIPTION
From the **#11028** audit follow-ups.

## Bug (larp)

`runArchive`, `runReopen`, and `runControl`'s `archive`/`reopen`/`pause` branch all hard-failed with `UNSUPPORTED_OPERATION` ("unavailable in ACP-only mode") — a stale message from before `OrchestratorTaskService` existed. But the service now fully supports `archiveTask` / `reopenTask` / `pauseTask`, and the `/api/orchestrator/tasks/:id/{archive,reopen}` HTTP routes already call them. The TASKS action even ships `ARCHIVE_CODING_TASK` / `REOPEN_CODING_TASK` similes that train the planner to call exactly these paths — which then always failed. The capability exists and is advertised, but the action refused it.

## Fix

Route all three lifecycle ops through one shared `runTaskLifecycleControl` helper that resolves `OrchestratorTaskService` and calls the matching method, reporting faithfully:
- success (with the updated task DTO),
- `TASK_NOT_FOUND` for an unknown id,
- `MISSING_TASK_ID` when no id is supplied,
- `UNSUPPORTED_OPERATION` **only** in a genuinely ACP-only runtime (no task service registered).

The dedicated `archive`/`reopen` sub-actions and the `control` action now share one correct path (previously three separate stubs all returning the same false failure).

## Evidence

```
$ bunx vitest run __tests__/unit/archive-reopen-lifecycle.test.ts   → 6 passed (6)
$ bunx vitest run cancel-task create-task orchestrator-task-service → 72 passed (72)
```

+6 cases: archive/reopen succeed via the service; the control action's pause routes through; `TASK_NOT_FOUND` / `MISSING_TASK_ID`; ACP-only still `UNSUPPORTED_OPERATION`. No regressions in the related suites.

Refs #11028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)