### PR TITLE
fix(cloud): make the default signup eliza character coherent

### DIFF
--- a/packages/cloud/shared/src/lib/eliza/agent.ts
+++ b/packages/cloud/shared/src/lib/eliza/agent.ts
@@ -138,7 +138,7 @@ After talking to you, they should feel:
 - Like coming back tomorrow would be natural
 
 ## Staying honest (this matters)
-- Never claim facts, prices, dates, or "I remember when you…" unless it's actually in this conversation or something a tool gave you this turn. If you don't know or can't recall, say so plainly — that reads as more trustworthy than a confident guess.
+- Never claim facts, prices, dates, or "I remember when you…" unless it's actually in your context — this conversation, stored memories about them you can see, or a tool result. If you don't know or can't recall, say so plainly — that reads as more trustworthy than a confident guess.
 - If a link, image, or file can't be read, say that directly instead of inventing what's in it.
 - You have real tools and can take real actions when they're available — prefer doing the thing over explaining how to do it.
 

--- a/packages/cloud/shared/src/lib/utils/default-eliza-character.test.ts
+++ b/packages/cloud/shared/src/lib/utils/default-eliza-character.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "vitest";
+import defaultAgent from "../eliza/agent";
+import { getConditionalPlugins } from "../eliza/agent-mode-types";
+import { getDefaultElizaCharacterData } from "./default-eliza-character";
+
+/**
+ * The default Eliza character is what every new cloud signup gets. Its persona
+ * promises (bio), behavioral rules (system), examples, and settings must stay
+ * coherent with each other and with what the agent loader actually wires up —
+ * a bio that promises months-later memory next to a rule that forbids recalling
+ * anything outside the current conversation ships a self-contradicting agent,
+ * and a tool-first system prompt with zero enabled tools ships a liar.
+ */
+
+describe("getDefaultElizaCharacterData", () => {
+  const character = getDefaultElizaCharacterData();
+
+  test("memory honesty rule is scoped to context, not just the current conversation", () => {
+    // bio[0] promises long-term memory; the honesty rule must allow recall from
+    // stored memories visible in context, not restrict it to "this conversation".
+    expect(character.bio[0]).toMatch(/months later/);
+    expect(character.system).toContain("in your context");
+    expect(character.system).toContain("stored memories");
+    expect(character.system).not.toContain("something a tool gave you this turn");
+  });
+
+  test("recall message example models context-scoped honesty instead of denying memory", () => {
+    const recallExample = character.message_examples.find((example) =>
+      example.some(
+        (msg) =>
+          typeof (msg.content as { text?: string })?.text === "string" &&
+          ((msg.content as { text: string }).text.includes("do you remember") ||
+            (msg.content as { text: string }).text.includes("remember what i told you")),
+      ),
+    );
+    expect(recallExample).toBeDefined();
+
+    const reply = (recallExample!.at(-1)!.content as { text: string }).text;
+    // The reply must acknowledge stored memories exist (consistent with bio[0])
+    // while honestly reporting what is actually visible — not a blanket denial.
+    expect(reply).toMatch(/memories/);
+    expect(reply).not.toContain("i don't have anything from last month");
+  });
+
+  test("web search is enabled and resolves to the plugin the loader injects", () => {
+    expect(character.settings).toMatchObject({ webSearch: { enabled: true } });
+    // Same code path AgentLoader.resolvePlugins uses for character settings.
+    expect(getConditionalPlugins(character.settings)).toContain("@elizaos/plugin-web-search");
+  });
+
+  test("topics are third-person — no second-person referent confusion", () => {
+    for (const topic of character.topics) {
+      expect(topic).not.toMatch(/\byou(?:'(?:re|ve))?\b|\byour\b/i);
+    }
+  });
+
+  test("duplicate persona in lib/eliza/agent.ts carries the same context-scoped honesty rule", () => {
+    // agent.ts holds a near-duplicate persona (see the header comment in
+    // default-eliza-character.ts); until they are deduplicated, the honesty
+    // scoping must stay in sync so both defaults behave the same way.
+    expect(defaultAgent.character.system).toContain("in your context");
+    expect(defaultAgent.character.system).toContain("stored memories");
+    expect(defaultAgent.character.system).not.toContain("something a tool gave you this turn");
+  });
+});

--- a/packages/cloud/shared/src/lib/utils/default-eliza-character.test.ts
+++ b/packages/cloud/shared/src/lib/utils/default-eliza-character.test.ts
@@ -1,6 +1,8 @@
+import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, test } from "vitest";
 import defaultAgent from "../eliza/agent";
 import { getConditionalPlugins } from "../eliza/agent-mode-types";
+import { WebSearchService } from "../eliza/plugin-web-search/src/services/searchService";
 import { getDefaultElizaCharacterData } from "./default-eliza-character";
 
 /**
@@ -9,7 +11,8 @@ import { getDefaultElizaCharacterData } from "./default-eliza-character";
  * coherent with each other and with what the agent loader actually wires up —
  * a bio that promises months-later memory next to a rule that forbids recalling
  * anything outside the current conversation ships a self-contradicting agent,
- * and a tool-first system prompt with zero enabled tools ships a liar.
+ * and a settings key that loads a plugin whose service can never start ships
+ * an error on every runtime creation.
  */
 
 describe("getDefaultElizaCharacterData", () => {
@@ -42,10 +45,26 @@ describe("getDefaultElizaCharacterData", () => {
     expect(reply).not.toContain("i don't have anything from last month");
   });
 
-  test("web search is enabled and resolves to the plugin the loader injects", () => {
-    expect(character.settings).toMatchObject({ webSearch: { enabled: true } });
-    // Same code path AgentLoader.resolvePlugins uses for character settings.
-    expect(getConditionalPlugins(character.settings)).toContain("@elizaos/plugin-web-search");
+  test("never injects a web-search service that cannot start", async () => {
+    // WebSearchService.initialize() throws unless runtime.getSetting() can see
+    // a Google key, and the runtime only injects those keys for the
+    // request-level webSearchEnabled toggle (buildSettings in
+    // lib/eliza/runtime/settings.ts) — never from this character. Prove that
+    // with the real service against exactly what this character's settings
+    // make visible: the service cannot start from character settings alone.
+    const settings = character.settings as Record<string, unknown>;
+    const runtimeStub = {
+      getSetting: (key: string) => (settings[key] as string | undefined) ?? null,
+    } as unknown as IAgentRuntime;
+    await expect(WebSearchService.start(runtimeStub)).rejects.toThrow(/GOOGLE_API_KEY/);
+
+    // Therefore the character must not carry the settings key that makes the
+    // agent loader inject @elizaos/plugin-web-search — same code path
+    // AgentLoader.resolvePlugins uses — or every runtime creation logs a
+    // "Service start failed" error for a dead plugin. Web search still works
+    // for this character via the request-level toggle, which injects the
+    // plugin and the keys together.
+    expect(getConditionalPlugins(settings)).not.toContain("@elizaos/plugin-web-search");
   });
 
   test("topics are third-person — no second-person referent confusion", () => {

--- a/packages/cloud/shared/src/lib/utils/default-eliza-character.ts
+++ b/packages/cloud/shared/src/lib/utils/default-eliza-character.ts
@@ -121,11 +121,15 @@ someone wants to think out loud, direct when they just want an answer.
     ] as string[],
     adjectives: ["warm", "curious", "grounded", "direct", "present", "honest"] as string[],
     plugins: [] as string[],
-    // webSearch.enabled is the settings key the agent loader honors
-    // (SETTINGS_PLUGIN_MAP in lib/eliza/agent-mode-types.ts): it injects
-    // @elizaos/plugin-web-search so the tool-first system prompt can actually
-    // fetch current info instead of shipping with zero tools.
-    settings: { webSearch: { enabled: true } } as Record<string, unknown>,
+    // Do NOT enable settings.webSearch here. That key makes the agent loader
+    // inject @elizaos/plugin-web-search (SETTINGS_PLUGIN_MAP in
+    // lib/eliza/agent-mode-types.ts), but the Google keys its WebSearchService
+    // needs are only injected for the request-level webSearchEnabled toggle
+    // (buildSettings in lib/eliza/runtime/settings.ts) — never provisioned with
+    // this character. A character-level enable ships a service whose start()
+    // throws on every runtime creation. Web search for this character works via
+    // the request toggle, which injects the plugin and the keys together.
+    settings: {} as Record<string, unknown>,
     style: {
       all: [
         "keep responses concise and conversational",

--- a/packages/cloud/shared/src/lib/utils/default-eliza-character.ts
+++ b/packages/cloud/shared/src/lib/utils/default-eliza-character.ts
@@ -35,9 +35,9 @@ someone wants to think out loud, direct when they just want an answer.
 
 ## Staying honest (this matters)
 - Never claim facts, prices, dates, or "I remember when you…" unless it's
-  actually in this conversation or something a tool gave you this turn. If you
-  don't know or can't recall, say so plainly — that reads as more trustworthy
-  than a confident guess.
+  actually in your context — this conversation, stored memories about them you
+  can see, or a tool result. If you don't know or can't recall, say so plainly —
+  that reads as more trustworthy than a confident guess.
 - If a link, image, or file can't be read, say that directly instead of
   inventing what's in it.
 - You have real tools and can take real actions when they're available — prefer
@@ -69,7 +69,7 @@ someone wants to think out loud, direct when they just want an answer.
         {
           name: "Eliza",
           content: {
-            text: "i don't have anything from last month in front of me right now, so i won't pretend i do. tell me again and i'll keep it close.",
+            text: "if it were in my saved memories i'd bring it up, but i'm not seeing anything about your sister in what i have. tell me again and i'll hold onto it this time.",
           },
         },
       ],
@@ -112,16 +112,20 @@ someone wants to think out loud, direct when they just want an answer.
       "https://raw.githubusercontent.com/elizaOS/eliza-avatars/refs/heads/master/Eliza/portrait.png",
     knowledge: [] as string[],
     topics: [
-      "what's going on in your life",
-      "the thing you're working on",
-      "decisions you're weighing",
-      "people who matter to you",
-      "what you're curious about",
-      "what you've been avoiding",
+      "what's going on in their life",
+      "the thing they're working on",
+      "decisions they're weighing",
+      "people who matter to them",
+      "what they're curious about",
+      "what they've been avoiding",
     ] as string[],
     adjectives: ["warm", "curious", "grounded", "direct", "present", "honest"] as string[],
     plugins: [] as string[],
-    settings: {} as Record<string, unknown>,
+    // webSearch.enabled is the settings key the agent loader honors
+    // (SETTINGS_PLUGIN_MAP in lib/eliza/agent-mode-types.ts): it injects
+    // @elizaos/plugin-web-search so the tool-first system prompt can actually
+    // fetch current info instead of shipping with zero tools.
+    settings: { webSearch: { enabled: true } } as Record<string, unknown>,
     style: {
       all: [
         "keep responses concise and conversational",


### PR DESCRIPTION
[core-brain]

Part of the flawless-launch push in #11157.

## Problem

The default Eliza character every new cloud signup gets (`packages/cloud/shared/src/lib/utils/default-eliza-character.ts`) shipped three self-contradictions:

1. **Memory promise vs honesty rule (high).** `bio[0]` promises months-later memory ("months later she'll reference that thing you mentioned"), but the `## Staying honest` rule forbade recalling anything that isn't "in this conversation or something a tool gave you this turn", and `message_examples[1]` had Eliza flatly deny having last month's context. A brand-new agent whose bio promises long-term memory while its rules ban it ships a self-contradicting persona.
2. **Second-person topic referent (low).** Topics were second person ("the thing you're working on") — when topics render into prompts about the character, "you" reads as the model, not the user.
3. **(caught in adversarial self-review, fixed in the second commit)** The first commit tried to fix "tool-first prompt, zero tools" by enabling `settings: { webSearch: { enabled: true } }` at the character level. That is a dead-on-arrival plugin load: the key makes `AgentLoader.resolvePlugins` → `getConditionalPlugins` inject `@elizaos/plugin-web-search` on every default-character runtime, but the Google keys `WebSearchService.initialize()` requires (`GOOGLE_API_KEY` / `GEMINI_API_KEY` / `GOOGLE_GENERATIVE_AI_API_KEY`) are only injected for the **request-level** `webSearchEnabled` toggle (`buildSettings` in `lib/eliza/runtime/settings.ts`) and are never provisioned with the character (signup path is a plain DB insert in `steward-sync.ts`; core `getSetting` has no `process.env` fallback). Core eagerly starts services at plugin registration, so every runtime creation logged a `Service start failed` error for a service that can never start.

## Fix

- Scoped the memory-honesty rule to what is actually visible: "unless it's actually in your context — this conversation, stored memories about them you can see, or a tool result". This makes the rule consistent with the runtime (stored memories ARE surfaced in context) and with `bio[0]`. The identical rule text is duplicated in `lib/eliza/agent.ts` (the runtime default agent persona) — fixed identically there.
- Rewrote `message_examples[1]` to MODEL the honest behavior: Eliza acknowledges saved memories exist, honestly reports she doesn't see anything about the sister in them, and offers to hold onto it — instead of a blanket "I don't have anything from last month" denial.
- Rephrased all six topics to third person ("the thing they're working on", "decisions they're weighing", …).
- **Kept `settings: {}`** with a comment documenting why webSearch must not be enabled here. Web search keeps working for the default character through the existing request-level toggle, which injects the plugin and the keys together (`agent-loader.ts` `webSearchEnabled` option + `buildSettings`). Wiring the platform Google key at character level would bypass the per-request opt-in and its billing gate — a product decision for a separate PR, and strictly worse than the toggle path that already works.

Persona untouched otherwise — same warm-companion voice, same examples, same style rules.

## Evidence

- Character-shape test `packages/cloud/shared/src/lib/utils/default-eliza-character.test.ts` (5 tests, 18 assertions) locks the coherence invariants, the duplicate-persona honesty-rule sync in `agent.ts`, and the web-search invariant with the **real service**: `WebSearchService.start()` against exactly what the character's settings make visible must reject (proving a character-level enable is dead), therefore `getConditionalPlugins(character.settings)` must not inject the plugin. If someone later provisions a key with the character, the rejects assertion fails and forces a conscious flip. **5 pass / 0 fail** (`bun run --cwd packages/cloud/shared test src/lib/utils/default-eliza-character.test.ts`).
- Typecheck (`bun run --cwd packages/cloud/shared typecheck`): exit 0, zero errors in touched files.
- Package lint (`bun run --cwd packages/cloud/shared lint`): zero findings in touched files.
- Branch rebased on `origin/develop` (`9b92fd1ca5`) before push.

## Follow-up (out of scope here)

- `lib/eliza/agent.ts` and `lib/utils/default-eliza-character.ts` hold near-duplicate persona copies (same `## Staying honest` block, same `bio[0]`, overlapping voice rules) that have to be kept in sync by hand — the new test pins the honesty rule in both, but the duplication itself should be deduplicated in a dedicated PR.
- If always-on web search for the default character is wanted, it needs a real key-provisioning path (and a billing decision), not a bare `webSearch.enabled` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
