### PR TITLE
fix(orchestrator): dedupe TERMINAL_SESSION_STATUSES to the canonical set (#11028)

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/actions/common.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/common.ts
@@ -17,6 +17,7 @@ import type {
   SpawnOptions,
   SpawnResult,
 } from "../services/types.js";
+import { TERMINAL_SESSION_STATUSES } from "../services/types.js";
 
 export interface AcpActionService {
   defaultApprovalPreset?: ApprovalPreset;
@@ -306,19 +307,6 @@ export async function listSessionsWithin(
     ),
   ]);
 }
-
-// Terminal session statuses — a session in one of these is done and no
-// longer occupying a provider slot. Defined as the terminal set (not the
-// active set) so any non-terminal status — including transient ones like
-// `starting` that aren't in the documented `SessionStatus` union — counts
-// as active and the gate fails closed. Mirrors the terminal filter in
-// AcpService.enforceSessionLimit.
-const TERMINAL_SESSION_STATUSES = new Set([
-  "completed",
-  "stopped",
-  "errored",
-  "cancelled",
-]);
 
 /**
  * Block until the number of in-flight sub-agent sessions drops below the

--- a/plugins/plugin-agent-orchestrator/src/api/parent-context-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/parent-context-routes.ts
@@ -12,7 +12,10 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import type { IAgentRuntime, Memory } from "@elizaos/core";
 import { ModelType } from "@elizaos/core";
 import { activeWorkspaceContextProvider } from "../providers/active-workspace-context.js";
-import type { SessionInfo } from "../services/types.js";
+import {
+  TERMINAL_SESSION_STATUSES,
+  type SessionInfo,
+} from "../services/types.js";
 import type { RouteContext } from "./route-utils.js";
 import { sendJson } from "./route-utils.js";
 
@@ -40,7 +43,6 @@ const BRIDGE_TIMEOUT_MS = 5_000;
 const DEFAULT_MEMORY_LIMIT = 10;
 const MAX_MEMORY_LIMIT = 50;
 const MEMORY_TABLES = ["facts", "messages", "documents"] as const;
-const TERMINAL_SESSION_STATUSES = new Set(["stopped", "error", "exited"]);
 
 class BridgeRouteError extends Error {
   constructor(

--- a/plugins/plugin-agent-orchestrator/src/providers/available-agents.ts
+++ b/plugins/plugin-agent-orchestrator/src/providers/available-agents.ts
@@ -6,15 +6,12 @@ import {
   shortId,
 } from "../actions/common.js";
 import { getTaskAgentFrameworkState } from "../services/task-agent-frameworks.js";
-import type { SessionInfo } from "../services/types.js";
+import {
+  TERMINAL_SESSION_STATUSES,
+  type SessionInfo,
+} from "../services/types.js";
 
 const MAX_RENDERED_ACTIVE_SESSIONS = 8;
-const TERMINAL_SESSION_STATUSES = new Set([
-  "completed",
-  "stopped",
-  "errored",
-  "cancelled",
-]);
 
 function sessionSortTime(session: SessionInfo): number {
   return new Date(session.lastActivityAt).getTime();


### PR DESCRIPTION
From the **#11028** audit follow-ups — a "duplicate constant" finding that had already turned into real drift.

## Bug

Three modules kept their own copies of the terminal-session-status set, and they had **already drifted** from the canonical `TERMINAL_SESSION_STATUSES` in `services/types.ts` (`{stopped, completed, error, errored, cancelled}`):

| File | Its copy | Drift |
|---|---|---|
| `providers/available-agents.ts` | `{completed, stopped, errored, cancelled}` | missing `error` |
| `actions/common.ts` | `{completed, stopped, errored, cancelled}` | missing `error` |
| `api/parent-context-routes.ts` | `{stopped, error, exited}` | missing `completed`/`errored`/`cancelled`; phantom `exited` (not in the `SessionStatus` union → never matches) |

Consequences: an `errored` session was treated as still-active in available-agents (shown as available) and in the concurrent-spawn slot gate (`common.ts`); and `parent-context-routes` treated essentially no real terminal state as terminal.

## Fix

Replace all three local copies with the canonical import so the terminal set has a single source of truth and cannot drift again. Behavior converges on the correct set.

## Evidence

```
$ bunx vitest run available-agents bridge-routes multi-account-spawn → 27 passed (27)
```

Refs #11028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)