### PR TITLE
fix(orchestrator): disk-verify completion artifacts + surface requested-vs-actual agent type

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/completion-envelope.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/completion-envelope.test.ts
@@ -42,6 +42,54 @@ describe("parseCompletionEnvelope (#8895)", () => {
     }
   });
 
+  it("carries the real workdir and disk-verified changed files", () => {
+    const res = parseCompletionEnvelope(
+      fenced({
+        ...validEnvelope(),
+        realWorkdir: "/workspace/task-real",
+        verifiedChangedFiles: [
+          {
+            path: "src/a.ts",
+            exists: true,
+            absolutePath: "/workspace/task-real/src/a.ts",
+            sizeBytes: 12,
+          },
+        ],
+        artifactsVerified: true,
+        missingArtifacts: [],
+      }),
+    );
+    expect(res.present).toBe(true);
+    expect(res.ok).toBe(true);
+    if (res.present && res.ok) {
+      expect(res.envelope.realWorkdir).toBe("/workspace/task-real");
+      expect(res.envelope.verifiedChangedFiles?.[0]).toMatchObject({
+        path: "src/a.ts",
+        exists: true,
+      });
+      expect(res.envelope.artifactsVerified).toBe(true);
+    }
+  });
+
+  it("marks missing artifacts as unverified", () => {
+    const res = parseCompletionEnvelope(
+      fenced({
+        ...validEnvelope(),
+        realWorkdir: "/workspace/task-real",
+        verifiedChangedFiles: [{ path: "index.html", exists: false }],
+        artifactsVerified: false,
+        missingArtifacts: ["index.html"],
+      }),
+    );
+    expect(res.present).toBe(true);
+    expect(res.ok).toBe(true);
+    if (res.present && res.ok) {
+      expect(res.envelope.artifactsVerified).toBe(false);
+      expect(res.envelope.missingArtifacts).toEqual(["index.html"]);
+      expect(summarizeEnvelope(res.envelope)).toContain("UNVERIFIED missing");
+    }
+  });
+
   it("flags a present-but-incomplete envelope (missing testResults)", () => {
     const { testResults, ...partial } = validEnvelope();
     void testResults;

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/workspace-diff.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/workspace-diff.test.ts
@@ -9,6 +9,7 @@ import {
   captureBaselineSha,
   captureChangeSet,
   summarizeChangeSet,
+  verifyChangedFilesOnDisk,
 } from "../../src/services/workspace-diff.ts";
 
 function git(cwd: string, args: string[]): void {
@@ -214,5 +215,34 @@ describe("workspace-diff — real git capture", () => {
       capturedAt: 0,
     });
     expect(text).toBe("Changed 2 files: index.html, style.css");
+  });
+
+  it("verifies changed files against the real workdir on disk", () => {
+    writeFileSync(join(dir, "verified.txt"), "present\n");
+    const verification = verifyChangedFilesOnDisk(dir, [
+      "verified.txt",
+      "missing.txt",
+    ]);
+    expect(verification.workdir).toBe(dir);
+    expect(verification.verified).toBe(false);
+    expect(verification.files).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: "verified.txt", exists: true }),
+        expect.objectContaining({ path: "missing.txt", exists: false }),
+      ]),
+    );
+    expect(verification.missingFiles).toEqual(["missing.txt"]);
+    expect(
+      summarizeChangeSet(
+        {
+          changedFiles: ["verified.txt", "missing.txt"],
+          diffStat: "2 file(s) changed",
+          diff: "",
+          truncated: false,
+          capturedAt: 0,
+        },
+        verification,
+      ),
+    ).toContain("UNVERIFIED: missing missing.txt");
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/completion-envelope.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/completion-envelope.ts
@@ -28,6 +28,18 @@ export interface EnvelopeCriterionStatus {
 export interface CompletionEnvelope {
   diffSummary: string;
   filesChanged: string[];
+  /** Real workdir path observed by the orchestrator/verifier, never a requested path guess. */
+  realWorkdir?: string;
+  /** Disk-verified changed files, populated by truthful completion routing/verifiers. */
+  verifiedChangedFiles?: Array<{
+    path: string;
+    exists: boolean;
+    absolutePath?: string;
+    sizeBytes?: number;
+  }>;
+  /** False when any claimed changed file/artifact was missing at completion. */
+  artifactsVerified?: boolean;
+  missingArtifacts?: string[];
   testResults: EnvelopeTestResult[];
   screenshotPaths: string[];
   trajectoryPath?: string;
@@ -48,6 +60,19 @@ export const COMPLETION_ENVELOPE_INSTRUCTION = [
     {
       diffSummary: "string — one-line summary of what changed",
       filesChanged: ["string — repo-relative paths"],
+      realWorkdir:
+        "string — optional; the actual working directory used, not the requested path",
+      verifiedChangedFiles: [
+        {
+          path: "string — repo/workdir-relative path",
+          exists: true,
+          absolutePath: "string — optional absolute path verified on disk",
+          sizeBytes: 123,
+        },
+      ],
+      artifactsVerified:
+        "boolean — optional; false if any changed file/artifact is missing",
+      missingArtifacts: ["string — optional missing claimed files/artifacts"],
       testResults: [
         {
           command: "string",
@@ -130,10 +155,46 @@ export function parseCompletionEnvelope(text: string): CompletionEnvelopeParse {
     errors.push("filesChanged must be a string[]");
   if (!isStringArray(o.residualRisks))
     errors.push("residualRisks must be a string[]");
+  if (o.realWorkdir !== undefined && typeof o.realWorkdir !== "string")
+    errors.push("realWorkdir must be a string");
+  if (
+    o.artifactsVerified !== undefined &&
+    typeof o.artifactsVerified !== "boolean"
+  ) {
+    errors.push("artifactsVerified must be a boolean");
+  }
+  if (o.missingArtifacts !== undefined && !isStringArray(o.missingArtifacts)) {
+    errors.push("missingArtifacts must be a string[]");
+  }
   if (!Array.isArray(o.screenshotPaths)) {
     // optional-ish but must be an array when present; default to [] if missing
     if (o.screenshotPaths !== undefined)
       errors.push("screenshotPaths must be a string[]");
+  }
+
+  const verifiedChangedFiles: CompletionEnvelope["verifiedChangedFiles"] = [];
+  if (o.verifiedChangedFiles !== undefined) {
+    if (!Array.isArray(o.verifiedChangedFiles)) {
+      errors.push("verifiedChangedFiles must be an array");
+    } else {
+      for (const [i, f] of o.verifiedChangedFiles.entries()) {
+        const file = f as Record<string, unknown>;
+        if (!file || typeof file.path !== "string" || typeof file.exists !== "boolean") {
+          errors.push(`verifiedChangedFiles[${i}] must be {path, exists}`);
+        } else {
+          verifiedChangedFiles.push({
+            path: file.path,
+            exists: file.exists,
+            ...(typeof file.absolutePath === "string"
+              ? { absolutePath: file.absolutePath }
+              : {}),
+            ...(typeof file.sizeBytes === "number"
+              ? { sizeBytes: file.sizeBytes }
+              : {}),
+          });
+        }
+      }
+    }
   }
 
   const testResults: EnvelopeTestResult[] = [];
@@ -192,6 +253,14 @@ export function parseCompletionEnvelope(text: string): CompletionEnvelopeParse {
     envelope: {
       diffSummary: o.diffSummary as string,
       filesChanged: o.filesChanged as string[],
+      ...(typeof o.realWorkdir === "string" ? { realWorkdir: o.realWorkdir } : {}),
+      ...(verifiedChangedFiles.length > 0 ? { verifiedChangedFiles } : {}),
+      ...(typeof o.artifactsVerified === "boolean"
+        ? { artifactsVerified: o.artifactsVerified }
+        : {}),
+      ...(isStringArray(o.missingArtifacts)
+        ? { missingArtifacts: o.missingArtifacts }
+        : {}),
       testResults,
       screenshotPaths: isStringArray(o.screenshotPaths)
         ? o.screenshotPaths
@@ -214,7 +283,14 @@ export function summarizeEnvelope(env: CompletionEnvelope): string {
     .map((c) => c.criterion);
   return [
     `diff: ${env.diffSummary}`,
+    env.realWorkdir ? `workdir: ${env.realWorkdir}` : "",
     `files: ${env.filesChanged.length}`,
+    env.verifiedChangedFiles
+      ? `verifiedFiles: ${env.verifiedChangedFiles.filter((f) => f.exists).length}/${env.verifiedChangedFiles.length}`
+      : "",
+    env.artifactsVerified === false && env.missingArtifacts?.length
+      ? `UNVERIFIED missing: ${env.missingArtifacts.join(", ")}`
+      : "",
     tests ? `tests: ${tests}` : "tests: none",
     `criteria: ${env.acceptanceCriteriaStatus.filter((c) => c.met).length}/${env.acceptanceCriteriaStatus.length} met`,
     unmet.length > 0 ? `unmet: ${unmet.join("; ")}` : "",

--- a/plugins/plugin-agent-orchestrator/src/services/independent-verifier.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/independent-verifier.ts
@@ -85,15 +85,20 @@ export function verdictFromEnvelope(
   const failedCommands = env.testResults
     .filter((t) => t.exitCode !== 0)
     .map((t) => t.command);
+  const missingArtifacts =
+    env.artifactsVerified === false ? (env.missingArtifacts ?? []) : [];
   // No criteria reported is itself inconclusive — a real verifier confirms each.
-  const inconclusive = env.acceptanceCriteriaStatus.length === 0;
+  const inconclusive =
+    env.acceptanceCriteriaStatus.length === 0 || missingArtifacts.length > 0;
   const passed =
     !inconclusive && unmet.length === 0 && failedCommands.length === 0;
   const summary = passed
     ? `Independent verification passed: ${env.acceptanceCriteriaStatus.length} criteria met, ${env.testResults.length} command(s) green.`
-    : inconclusive
-      ? "Independent verifier reported no per-criterion status — unverified."
-      : `Independent verification failed: ${unmet.length} unmet criteria, ${failedCommands.length} failing command(s).`;
+    : missingArtifacts.length > 0
+      ? `Independent verifier found missing artifacts: ${missingArtifacts.join(", ")}.`
+      : inconclusive
+        ? "Independent verifier reported no per-criterion status — unverified."
+        : `Independent verification failed: ${unmet.length} unmet criteria, ${failedCommands.length} failing command(s).`;
   return { passed, unmet, failedCommands, summary, inconclusive };
 }
 

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -1784,6 +1784,18 @@ export class OrchestratorTaskService extends Service {
             completionEnvelope: {
               diffSummary: parse.envelope.diffSummary,
               filesChanged: parse.envelope.filesChanged,
+              ...(parse.envelope.realWorkdir
+                ? { realWorkdir: parse.envelope.realWorkdir }
+                : {}),
+              ...(parse.envelope.verifiedChangedFiles
+                ? { verifiedChangedFiles: parse.envelope.verifiedChangedFiles }
+                : {}),
+              ...(typeof parse.envelope.artifactsVerified === "boolean"
+                ? { artifactsVerified: parse.envelope.artifactsVerified }
+                : {}),
+              ...(parse.envelope.missingArtifacts
+                ? { missingArtifacts: parse.envelope.missingArtifacts }
+                : {}),
               testResults: parse.envelope.testResults,
               acceptanceCriteriaStatus: parse.envelope.acceptanceCriteriaStatus,
               residualRisks: parse.envelope.residualRisks,

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -36,6 +36,8 @@ import type { SessionEventName, SessionInfo } from "./types.js";
 import {
   captureChangeSet,
   summarizeChangeSet,
+  verifyChangedFilesOnDisk,
+  type WorkspaceArtifactVerification,
   type WorkspaceChangeSet,
 } from "./workspace-diff.js";
 
@@ -952,6 +954,7 @@ export class SubAgentRouter extends Service {
     // is persisted so "what did you change / show me the diff" can be
     // answered from the actual change set instead of a confabulated edit.
     let changeSet: WorkspaceChangeSet | undefined;
+    let artifactVerification: WorkspaceArtifactVerification | undefined;
     if (event === "task_complete" && this.acp) {
       try {
         const meta = session.metadata as Record<string, unknown> | undefined;
@@ -969,8 +972,13 @@ export class SubAgentRouter extends Service {
         // so the provider — which selects the most-recently-completed session
         // and reads ITS change set — can't bleed an older task's diff.
         if (changeSet) {
+          artifactVerification = verifyChangedFilesOnDisk(
+            session.workdir,
+            changeSet.changedFiles,
+          );
           await this.acp.updateSessionMetadata(sessionId, {
             lastChangeSet: changeSet,
+            lastArtifactVerification: artifactVerification,
           });
         }
       } catch (err) {
@@ -992,7 +1000,14 @@ export class SubAgentRouter extends Service {
           ? `[sub-agent: ${origin.label} (${session.agentType}) — unrecoverable]\nThis task lost its working session ${stateLostRespawnCount} times and could not be recovered after ${this.loopState.stateLostRespawnCap} automatic restarts. Decide whether to retry the task from scratch, escalate to the user, or drop it.`
           : capExceeded
             ? `[sub-agent: ${origin.label} (${session.agentType}) — round-trip cap exceeded]\nThis session reached ${nextCount} round-trips (cap=${this.loopState.roundTripCap}) and was force-stopped to prevent a runaway loop. Decide whether to spawn a fresh session, escalate to the user, or drop the task.`
-            : composeNarration(event, origin.label, session, data, changeSet),
+            : composeNarration(
+                event,
+                origin.label,
+                session,
+                data,
+                changeSet,
+                artifactVerification,
+              ),
     );
     // Fact-check any URLs the sub-agent claimed. Weak coding models
     // routinely report "the app is live at <url>" without writing the
@@ -1132,7 +1147,13 @@ export class SubAgentRouter extends Service {
           deliverable,
         });
       }
-      const preview = (deliverable ?? text).trim().slice(0, 200);
+      // Strip the planner-only `[sub-agent: …]` header before previewing so
+      // the notification body shows the actual result (e.g. "PR opened"),
+      // not the relay/do-not-respawn directive. The header can now be long
+      // (it carries the actual-workdir + requested-vs-actual-agent note), so a
+      // naive slice(0,200) of the raw text would capture only the directive.
+      const previewSource = (deliverable ?? stripSubAgentHeaderLine(text)).trim();
+      const preview = previewSource.slice(0, 200);
       void getNotifier(this.runtime)
         ?.notify({
           title: `${origin.label || "Agent task"} finished`,
@@ -1239,6 +1260,21 @@ export class SubAgentRouter extends Service {
                 ? "stopped"
                 : session.status,
             subAgentAgentType: session.agentType,
+            subAgentActualAgentType: session.agentType,
+            ...(pickPlainString(sessionMeta?.requestedType)
+              ? {
+                  subAgentRequestedType: pickPlainString(
+                    sessionMeta?.requestedType,
+                  ),
+                }
+              : {}),
+            subAgentWorkdir: session.workdir,
+            ...(artifactVerification
+              ? {
+                  subAgentArtifactVerification:
+                    artifactVerificationMetadata(artifactVerification),
+                }
+              : {}),
             subAgentRoundTrip: nextCount,
             subAgentRoundTripCap: this.loopState.roundTripCap,
             subAgentRoutingKind: routingKind,
@@ -2378,6 +2414,7 @@ function composeNarration(
   session: SessionInfo,
   data: unknown,
   changeSet?: WorkspaceChangeSet,
+  artifactVerification?: WorkspaceArtifactVerification,
 ): string {
   // For task_complete the LABEL is the original (often imperative) task text —
   // e.g. "Use the webfetch tool on this exact URL: …". A literal planner reads
@@ -2387,9 +2424,17 @@ function composeNarration(
   // that each sub-agent had already returned). The directive below is INSIDE
   // the bracketed header, so every `[sub-agent:`-prefix stripper (user-facing
   // reply, deliverable extraction) still removes it — only the planner sees it.
+  const meta = session.metadata as Record<string, unknown> | undefined;
+  const requestedType = pickPlainString(meta?.requestedType);
+  const agentTypeNote =
+    event === "task_complete" &&
+    requestedType &&
+    requestedType !== session.agentType
+      ? ` Requested agent type was ${requestedType}; actual agent type was ${session.agentType}.`
+      : "";
   const header =
     event === "task_complete"
-      ? `[sub-agent: ${label} (${session.agentType}) — task_complete — this delegated task is DONE; the result is below, relay it to the user as the answer, do NOT start another sub-agent for it]`
+      ? `[sub-agent: ${label} (${session.agentType}) — task_complete — this delegated task is DONE; the result is below, relay it to the user as the answer, state the actual workdir (${session.workdir}), do NOT substitute or repeat a requested path unless it matches the actual workdir, and do NOT start another sub-agent for it.${agentTypeNote}]`
       : `[sub-agent: ${label} (${session.agentType}) — ${event}]`;
   if (event === QUESTION_FOR_TASK_CREATOR) {
     const message =
@@ -2436,15 +2481,32 @@ function composeNarration(
     // transcript, so the leak/respawn problems the diff-summary path solved
     // stay solved.
     const capturedDeliverable = extractShortToolDeliverable(data);
+    // Only surface a disk-verification LINE when it carries a real signal —
+    // i.e. a claimed changed file was MISSING at completion. A clean, verified
+    // change set stays silent here: `summarizeChangeSet(..., verification)`
+    // already appends a `(verified on disk)` suffix, and adding a separate
+    // "verified" body line would pollute the completion body that downstream
+    // consumers (notification preview, verified-URL fallback, the completion
+    // evaluator's reply) read from, regressing existing narration tests. The
+    // authoritative workdir + requested-vs-actual-agent note lives in the
+    // planner-only header (stripped by every `[sub-agent:`-prefix reader), so
+    // it never leaks into the user-facing body.
+    const missing = artifactVerification?.missingFiles ?? [];
+    const unverifiedLine =
+      artifactVerification && !artifactVerification.verified && missing.length > 0
+        ? `Artifact verification: UNVERIFIED at completion; missing ${missing.join(", ")}.`
+        : undefined;
     const lines = [
       ...(capturedDeliverable ? [capturedDeliverable] : []),
-      summarizeChangeSet(changeSet),
+      summarizeChangeSet(changeSet, artifactVerification),
+      unverifiedLine,
       changeSet.diffStat,
       ...urls,
     ].filter((line) => typeof line === "string" && line.trim().length > 0);
     return `${header}\n${lines.join("\n")}`;
   }
-  // Genuinely no captured output — keep the explicit note.
+  // Genuinely no captured output — keep the explicit note. The workdir lives
+  // in the planner-only header, not the body.
   if (response === undefined) {
     return `${header}\nsub-agent reports task complete (no captured output).`;
   }
@@ -2477,6 +2539,40 @@ function stripRoutingKindBanner(text: string): string {
       "",
     )
     .trimStart();
+}
+
+// Flatten a disk-verification result into a JSON-safe metadata shape so it
+// satisfies the Content metadata index signature (a plain object of
+// JsonValue-compatible fields, no optional-undefined members).
+function artifactVerificationMetadata(
+  verification: WorkspaceArtifactVerification,
+): Record<string, unknown> {
+  return {
+    workdir: verification.workdir,
+    verified: verification.verified,
+    missingFiles: [...verification.missingFiles],
+    files: verification.files.map((file) => ({
+      path: file.path,
+      absolutePath: file.absolutePath,
+      exists: file.exists,
+      ...(typeof file.sizeBytes === "number"
+        ? { sizeBytes: file.sizeBytes }
+        : {}),
+      ...(file.kind ? { kind: file.kind } : {}),
+      ...(file.error ? { error: file.error } : {}),
+    })),
+  };
+}
+
+// Drop the leading planner-only `[sub-agent: …]` directive line so a preview or
+// body reader sees the actual result, not the relay/do-not-respawn header.
+// Mirrors the evaluator's `stripRouterAnnotations` header handling; kept local
+// so the router has no cross-module import for a one-line string op.
+function stripSubAgentHeaderLine(text: string): string {
+  const lines = text.replace(/\r\n/g, "\n").split("\n");
+  return (lines[0]?.startsWith("[sub-agent:") ? lines.slice(1) : lines)
+    .join("\n")
+    .trim();
 }
 
 function routingKindFromPayloadBanner(data: unknown): string | undefined {

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-diff.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-diff.ts
@@ -37,6 +37,24 @@ export interface WorkspaceChangeSet {
   capturedAt: number;
 }
 
+/** Disk-level verification for one path the sub-agent claims changed. */
+export interface WorkspaceChangedFileVerification {
+  path: string;
+  absolutePath: string;
+  exists: boolean;
+  sizeBytes?: number;
+  kind?: "file" | "directory" | "other";
+  error?: string;
+}
+
+/** Completion-time artifact verification rooted in the real session workdir. */
+export interface WorkspaceArtifactVerification {
+  workdir: string;
+  verified: boolean;
+  files: WorkspaceChangedFileVerification[];
+  missingFiles: string[];
+}
+
 async function git(
   workdir: string,
   args: string[],
@@ -296,11 +314,57 @@ function captureToolPathOnlyChangeSet(
   };
 }
 
+export function verifyChangedFilesOnDisk(
+  workdir: string,
+  changedFiles: readonly string[],
+): WorkspaceArtifactVerification {
+  const files = changedFiles.map((file) => {
+    const rel = toWorkdirRelative(workdir, file) || file;
+    const absolutePath = resolve(workdir, rel);
+    try {
+      const stat = statSync(absolutePath);
+      return {
+        path: rel,
+        absolutePath,
+        exists: true,
+        sizeBytes: stat.size,
+        kind: stat.isFile()
+          ? ("file" as const)
+          : stat.isDirectory()
+            ? ("directory" as const)
+            : ("other" as const),
+      };
+    } catch (err) {
+      return {
+        path: rel,
+        absolutePath,
+        exists: false,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  });
+  const missingFiles = files.filter((file) => !file.exists).map((file) => file.path);
+  return {
+    workdir,
+    verified: missingFiles.length === 0,
+    files,
+    missingFiles,
+  };
+}
+
 /** One-line, human-facing summary of a change set for a completion banner. */
-export function summarizeChangeSet(changeSet: WorkspaceChangeSet): string {
+export function summarizeChangeSet(
+  changeSet: WorkspaceChangeSet,
+  verification?: WorkspaceArtifactVerification,
+): string {
   const count = changeSet.changedFiles.length;
   const noun = count === 1 ? "file" : "files";
   const shown = changeSet.changedFiles.slice(0, 6).join(", ");
   const more = count > 6 ? ` (+${count - 6} more)` : "";
-  return `Changed ${count} ${noun}: ${shown}${more}`;
+  const verifiedSuffix = verification
+    ? verification.verified
+      ? " (verified on disk)"
+      : ` (UNVERIFIED: missing ${verification.missingFiles.join(", ")})`
+    : "";
+  return `Changed ${count} ${noun}: ${shown}${more}${verifiedSuffix}`;
 }


### PR DESCRIPTION
## What
Makes coding-agent completion reports **disk-verified** and surfaces **requested→actual agent-type mismatch**, so a completion can no longer silently larp success (claim files that were never written, or claim it ran claude when codex actually ran).

## Why
A sub-agent that reports `task_complete` was trusted on its word. Weak coding models routinely claim files/artifacts that never hit disk, and the billing proxy never told the user when the *requested* agent type differed from the one that actually ran. Both are truthfulness gaps in the completion envelope.

## Changes
- **completion-envelope.ts**: new optional envelope fields — `realWorkdir`, `verifiedChangedFiles[]`, `artifactsVerified`, `missingArtifacts[]` — parsed, validated, and summarized. `summarizeEnvelope` surfaces an `UNVERIFIED missing: …` line when artifacts are absent.
- **workspace-diff.ts**: `verifyChangedFilesOnDisk(workdir, files)` stats each claimed changed file against the **real** session workdir; `summarizeChangeSet` appends `(verified on disk)` / `(UNVERIFIED: missing …)`.
- **sub-agent-router.ts**: on `task_complete`, verifies the captured change set on disk, persists it on session metadata (`lastArtifactVerification`, `subAgentArtifactVerification`), and threads `requestedType → actualAgentType` + the real workdir into the **planner-only** `[sub-agent: …]` header. The header is stripped by every `[sub-agent:`-prefix reader, so it steers the planner **without** polluting the user-facing body or the notification preview. Notification preview now strips the header line before slicing so a long directive no longer truncates the actual result.
- **independent-verifier.ts**: missing artifacts ⇒ `inconclusive`, never `passed`.
- **orchestrator-task-service.ts**: threads the new envelope fields through the stored completion envelope.

## Evidence
```
vitest run (5 files): 129 passed (129)
  - completion-envelope.test.ts    12 passed
  - workspace-diff.test.ts         17 passed
  - sub-agent-router.test.ts       (green)
  - sub-agent-router-notification.test.ts  7 passed
  - orchestrator-correctness.test.ts  (green)
tsc --noEmit: clean on all 5 touched service files
```

**Design note:** the disk-verification body line is emitted *only* when it carries a real signal (a claimed file was missing). A clean/verified change set stays silent in the body — `summarizeChangeSet` already appends `(verified on disk)`, and adding a separate "verified" body line regressed 4 existing narration tests (notification preview, verified-URL fallback, completion-evaluator reply). Keeping the authoritative workdir/agent-type in the planner-only header is the fix.

**Collision check:** scanned recent develop commits + open/all PRs matching "completion" and orchestrator service history. No overlap — #11205 (task-store race) and #11202/#11197 (task-store concurrency/coding-todo) are lalalune`s, different concern. Rebased onto current origin/develop (fast-forward, no conflicts).

codex review not run (account usage-limited).

— [sol-orch]
