### PR TITLE
fix(ui/chat): resolve #11112 — composer focus-open regression + WebKit slash-menu/reload (lane 3/9 → 9/9)

### DIFF
--- a/packages/app/playwright.ui-smoke.config.ts
+++ b/packages/app/playwright.ui-smoke.config.ts
@@ -167,7 +167,20 @@ export default defineConfig({
           {
             name: "webkit",
             testMatch: WEBKIT_POINTER_FOCUS_SPEC,
-            use: { ...devices["Desktop Safari"] },
+            use: {
+              ...devices["Desktop Safari"],
+              // Same parity as the desktop-webkit lane below: the PROD renderer
+              // registers /sw.js (skipWaiting + clients.claim), and WebKit —
+              // unlike Chromium — does NOT bypass a controlling service worker
+              // when page.route interception is active. Once the SW claims the
+              // page, every /api/* fetch silently goes AROUND the per-spec
+              // route fixtures to the real stub server (verified via an
+              // in-page probe: a route-fulfilled /api/conversations returned
+              // the stub server's conversations instead of the fixture's), so
+              // e.g. the conversation-persistence reload rehydrated a foreign
+              // thread and timed out (#11112 finding 2).
+              serviceWorkers: "block" as const,
+            },
           },
         ]
       : []),

--- a/packages/app/test/ui-smoke/chat-overlay-controls-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/chat-overlay-controls-interactions.spec.ts
@@ -183,7 +183,16 @@ test("chat overlay: transcript text is selectable and the old transcribe toggle 
 
   const selectable = page.locator('[data-chat-selectable="true"]').first();
   await expect(selectable).toBeVisible();
-  await expect(selectable).toHaveCSS("user-select", "text");
+  // WebKit's getComputedStyle reports only the prefixed `-webkit-user-select`
+  // and returns "" for the unprefixed `user-select`, so probe both (the app's
+  // `select-text` / base.css emits both). Same cross-engine fix #11103 applied
+  // to the sibling selectable assertion; this one was missed. The behavioral
+  // range-selection assert below is the real proof either way.
+  const userSelect = await selectable.evaluate((node) => {
+    const s = getComputedStyle(node);
+    return s.getPropertyValue("-webkit-user-select") || s.userSelect;
+  });
+  expect(userSelect).toBe("text");
 
   const selectedText = await selectable.evaluate((node) => {
     const range = document.createRange();

--- a/packages/ui/src/chat/useSlashCommandController.catalog.test.ts
+++ b/packages/ui/src/chat/useSlashCommandController.catalog.test.ts
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+
+/**
+ * Catalog-load contract for useSlashCommandController (#11112).
+ *
+ * The slash menu only mounts when the controller's merged `commands` are
+ * non-empty, so this pins the engine-agnostic contract behind it: whenever the
+ * catalog fetch resolves with commands, `commands` resolve — with the default
+ * (trusted dashboard) auth context keeping requiresAuth / requiresElevated
+ * commands visible — and a FAILED fetch degrades to an empty catalog while
+ * surfacing the error instead of silently swallowing it (a swallowed error is
+ * indistinguishable from a genuinely empty catalog).
+ */
+
+import type { CustomActionDef } from "@elizaos/shared";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  CommandSurface,
+  SlashCommandCatalogItem,
+} from "../api/client-types-commands";
+
+const { listCommands, listCustomActions } = vi.hoisted(() => ({
+  listCommands:
+    vi.fn<(surface?: string) => Promise<SlashCommandCatalogItem[]>>(),
+  listCustomActions: vi.fn<() => Promise<CustomActionDef[]>>(),
+}));
+
+vi.mock("../api", () => ({
+  client: {
+    listCommands: (surface?: string) => listCommands(surface),
+    listCustomActions: () => listCustomActions(),
+  },
+}));
+vi.mock("../config/boot-config-react.hooks", () => ({
+  useBootConfig: (): { shortcutFlags?: { naturalLanguage?: boolean } } => ({}),
+}));
+vi.mock("../hooks/useAvailableViews", () => ({
+  useAvailableViews: (): { views: never[] } => ({ views: [] }),
+}));
+vi.mock("../state", () => ({
+  useAppSelectorShallow: <T>(
+    selector: (state: {
+      setTab: (tab: string) => void;
+      handleChatClear: () => Promise<void>;
+    }) => T,
+  ): T =>
+    selector({
+      setTab: () => {},
+      handleChatClear: async () => {},
+    }),
+}));
+
+import { useSlashCommandController } from "./useSlashCommandController";
+
+function cmd(
+  partial: Partial<SlashCommandCatalogItem> & { key: string },
+): SlashCommandCatalogItem {
+  return {
+    nativeName: partial.key,
+    description: "",
+    textAliases: [`/${partial.key}`],
+    scope: "both",
+    acceptsArgs: false,
+    args: [],
+    requiresAuth: false,
+    requiresElevated: false,
+    target: { kind: "agent" },
+    ...partial,
+  };
+}
+
+const GUI: CommandSurface = "gui";
+
+beforeEach(() => {
+  listCommands.mockReset();
+  listCustomActions.mockReset();
+  listCustomActions.mockResolvedValue([]);
+  window.localStorage.clear();
+});
+
+describe("useSlashCommandController — catalog load (#11112)", () => {
+  it("resolves commands whenever the catalog fetch resolves, keeping auth-gated commands under the trusted-dashboard defaults", async () => {
+    listCommands.mockResolvedValue([
+      cmd({
+        key: "settings",
+        target: { kind: "navigate", tab: "settings", path: "/settings" },
+      }),
+      cmd({ key: "clear", requiresAuth: true }),
+      cmd({ key: "admin", requiresElevated: true }),
+    ]);
+
+    const { result } = renderHook(() => useSlashCommandController());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(listCommands).toHaveBeenCalledWith(GUI);
+    expect(result.current.commands.map((c) => c.key)).toEqual([
+      "settings",
+      "clear",
+      "admin",
+    ]);
+  });
+
+  it("still hides auth-gated commands for an unauthorized sender", async () => {
+    listCommands.mockResolvedValue([
+      cmd({ key: "open", requiresAuth: false }),
+      cmd({ key: "clear", requiresAuth: true }),
+      cmd({ key: "admin", requiresElevated: true }),
+    ]);
+
+    const { result } = renderHook(() =>
+      useSlashCommandController({ isAuthorized: false, isElevated: false }),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.commands.map((c) => c.key)).toEqual(["open"]);
+  });
+
+  it("an empty catalog resolves to no commands without any error (the menu simply never mounts)", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    listCommands.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useSlashCommandController());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.commands).toEqual([]);
+    expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  it("a failed catalog fetch degrades to an empty catalog AND surfaces the error", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const failure = new Error("catalog fetch failed");
+    listCommands.mockRejectedValue(failure);
+
+    const { result } = renderHook(() => useSlashCommandController());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.commands).toEqual([]);
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining("[useSlashCommandController]"),
+      failure,
+    );
+    consoleError.mockRestore();
+  });
+
+  it("a failed custom-actions fetch surfaces the error but keeps the server catalog", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    listCommands.mockResolvedValue([cmd({ key: "settings" })]);
+    const failure = new Error("custom actions fetch failed");
+    listCustomActions.mockRejectedValue(failure);
+
+    const { result } = renderHook(() => useSlashCommandController());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.commands.map((c) => c.key)).toEqual(["settings"]);
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining("[useSlashCommandController]"),
+      failure,
+    );
+    consoleError.mockRestore();
+  });
+});

--- a/packages/ui/src/chat/useSlashCommandController.ts
+++ b/packages/ui/src/chat/useSlashCommandController.ts
@@ -203,12 +203,28 @@ export function useSlashCommandController(
     let cancelled = false;
     setLoading(true);
     void (async () => {
+      // Degrade to an empty catalog so the composer keeps working, but SURFACE
+      // the failure: a silently-swallowed fetch error is indistinguishable
+      // from a genuinely empty catalog (the menu just never mounts), which
+      // made #11112 needlessly hard to diagnose.
       const catalog: SlashCommandCatalogItem[] = await client
         .listCommands("gui")
-        .catch(() => []);
+        .catch((error: unknown) => {
+          console.error(
+            "[useSlashCommandController] Failed to load the slash-command catalog; slash menu will be empty",
+            error,
+          );
+          return [];
+        });
       const customActions: CustomActionDef[] = await client
         .listCustomActions()
-        .catch(() => []);
+        .catch((error: unknown) => {
+          console.error(
+            "[useSlashCommandController] Failed to load custom actions; omitting them from the slash menu",
+            error,
+          );
+          return [];
+        });
       if (cancelled) return;
       setServerCommands(catalog);
       const saved = loadSavedCustomCommands().map((c) =>

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -251,6 +251,51 @@ describe("ContinuousChatOverlay", () => {
     expect(sheet.getAttribute("data-variant")).toBe("open");
   });
 
+  it("flips the overlay to data-open when the composer textarea is focused (the ui-smoke contract)", () => {
+    render(<ContinuousChatOverlay controller={makeController()} />);
+    const overlay = screen.getByTestId("continuous-chat-overlay");
+    expect(overlay.getAttribute("data-open")).toBeNull();
+    fireEvent.focus(screen.getByTestId("chat-composer-textarea"));
+    expect(overlay.getAttribute("data-open")).toBe("true");
+  });
+
+  it("opens the sheet when the thread lands AFTER the composer was focused (focus wins the boot race, #11112)", () => {
+    // Boot: the overlay renders (and can be focused) before the restored
+    // conversation's messages arrive. The focus→expand used to be a one-shot
+    // no-op with nothing revealable, so data-open never flipped.
+    const { rerender } = render(
+      <ContinuousChatOverlay controller={makeController({ messages: [] })} />,
+    );
+    const overlay = screen.getByTestId("continuous-chat-overlay");
+    const composer = screen.getByTestId("chat-composer-textarea");
+    act(() => {
+      composer.focus();
+    });
+    // Nothing to reveal yet — focusing the bare input must not open an empty sheet.
+    expect(overlay.getAttribute("data-open")).toBeNull();
+
+    // The restored conversation's messages land while the composer is still
+    // focused: the parked focus-open intent completes the open.
+    rerender(<ContinuousChatOverlay controller={makeController()} />);
+    expect(overlay.getAttribute("data-open")).toBe("true");
+  });
+
+  it("drops the parked focus-open intent if the composer blurred before the thread arrived", () => {
+    const { rerender } = render(
+      <ContinuousChatOverlay controller={makeController({ messages: [] })} />,
+    );
+    const overlay = screen.getByTestId("continuous-chat-overlay");
+    const composer = screen.getByTestId("chat-composer-textarea");
+    act(() => {
+      composer.focus();
+      composer.blur();
+    });
+
+    // The thread arriving later must NOT pop the sheet open — the user left.
+    rerender(<ContinuousChatOverlay controller={makeController()} />);
+    expect(overlay.getAttribute("data-open")).toBeNull();
+  });
+
   it("does not move the overlay bottom padding just because the composer is focused", () => {
     render(<ContinuousChatOverlay controller={makeController()} />);
     const overlay = screen.getByTestId("continuous-chat-overlay");

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -1811,6 +1811,14 @@ export function ContinuousChatOverlay({
   // that the normal "tap the visible composer" path relies on (which would
   // fling a history thread open to half instead of resting on the input bar).
   const suppressExpandOnFocusRef = React.useRef(false);
+  // A focus→expand that found nothing revealable yet (the boot race: composer
+  // focused while the restored conversation's messages are still in flight)
+  // parks its intent here. The reveal-edge effect below honors it — but only
+  // while the composer is STILL focused — so focusing the composer opens the
+  // chat even when the focus wins the race against the thread load. Consumed
+  // on every reveal edge so a stale intent can never fling the sheet open long
+  // after the user has moved on.
+  const pendingExpandOnRevealRef = React.useRef(false);
   const focusThreadRef = React.useRef(false);
   // Recomputed only when the thread or phase changes — NOT on every drag/draft
   // re-render. Pure windowing (empty-turn filter + most-recent cap, with the
@@ -2864,12 +2872,40 @@ export function ContinuousChatOverlay({
   // handle) can return to that prior resting state. Clears any free-rest so the
   // height matches the detent (no stale freeH pinning it below half).
   const expand = React.useCallback(() => {
-    if (!hasRevealableThread) return;
+    if (!hasRevealableThread) {
+      // Nothing to reveal YET — don't open an empty sheet, but remember the
+      // intent: on boot the composer can gain focus while the restored
+      // conversation's messages are still in flight, and dropping the expand
+      // here made focus-to-open silently do nothing (#11112). The reveal-edge
+      // effect below completes the open once the thread arrives, if the
+      // composer is still focused.
+      pendingExpandOnRevealRef.current = true;
+      return;
+    }
+    pendingExpandOnRevealRef.current = false;
     preFocusCollapsedRef.current = !sheetOpen;
     setFreeH(null);
     // Open to at least HALF; if already at half/full, keep the taller mode.
     setMode((m) => (m === "half" || m === "full" ? m : "half"));
   }, [hasRevealableThread, sheetOpen]);
+
+  // Reveal edge: the thread just became showable. If a focus→expand was parked
+  // while there was nothing to reveal (see expand above), honor it now — but
+  // only while the composer is STILL focused, so a long-abandoned focus can't
+  // pop the sheet open. The intent is consumed either way (one-shot). A
+  // pill-open keyboard-raise never parks an intent (its focus is suppressed
+  // before expand runs), so the suppressExpandOnFocusRef contract holds.
+  React.useEffect(() => {
+    if (!hasRevealableThread || !pendingExpandOnRevealRef.current) return;
+    pendingExpandOnRevealRef.current = false;
+    if (
+      typeof document === "undefined" ||
+      document.activeElement !== inputRef.current
+    ) {
+      return;
+    }
+    expand();
+  }, [hasRevealableThread, expand]);
 
   // Interactive tour control: the tutorial drives the chat into a clean, known
   // state at the start of each frame (so the spotlight always lands on the right


### PR DESCRIPTION
## Summary

Fixes all of #11112 (the WebKit cross-engine pointer/focus lane that was never actually run). Full lane goes **3/9 → 9/9** on WebKit, Chromium unaffected.

- **[keystone, live regression on develop, both engines] Focusing the composer no longer opened the overlay.** `expand()` early-returns when there's no revealable thread; on `/chat` the composer gains focus BEFORE the restored conversation's messages arrive, so the one-shot focus→expand no-op'd and the sheet never opened even after the thread loaded. Reproduced on real Chromium (the "long transcript scrolls" spec: 16.5s timeout → 2.5s pass). Fix parks the open-intent and completes it on the reveal edge, only if the composer is still focused (suppress-ref contract untouched). +3 jsdom regression tests.
- **[WebKit findings 1 & 2] Slash menu never mounted + conversation reload rehydrated a foreign thread.** One root cause: the PROD renderer registers `/sw.js`, and WebKit (unlike Chromium) doesn't bypass a controlling service worker for `page.route` interception, so `/api/*` fetches went around the per-spec fixtures to the real stub. Fixed with `serviceWorkers: 'block'` on the webkit lane (parity with the existing desktop-webkit lane). Both specs stay pristine.
- **Diagnosis hardening:** the slash controller swallowed catalog-fetch failures with `.catch(() => [])`, making a failed fetch indistinguishable from an empty catalog (what made this hard to find). Now surfaces the error before degrading; +5 engine-agnostic controller tests.
- **Sibling WebKit assertion:** a second `toHaveCSS('user-select','text')` #11103 missed — WebKit reports only the prefixed property; probe both.

Once merged, the CI lane's `continue-on-error` can be flipped to blocking (the whole remaining ask on #11112).

## Evidence
Full WebKit pointer/focus lane **9/9** + Chromium parity (chat-overlay-controls 4/4, slash 4/4, conversation 3/3); overlay jsdom 126/126, fuzz 119/119, slash controller 36/36; run-chat-sheet-e2e PASSED; 5/5 gesture-e2e baseline held.

Closes #11112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)