### PR TITLE
feat(plugin-cli-inference): rotate chat-brain accounts on subscription limit before tier-failover

### DIFF
--- a/plugins/plugin-cli-inference/AGENTS.md
+++ b/plugins/plugin-cli-inference/AGENTS.md
@@ -179,7 +179,7 @@ bun run --cwd plugins/plugin-cli-inference build
 - **Isolated cwd per call.** Created with `mkdtemp` under `tmpdir()`, validated by `resolveSafeCwd`, removed in a `finally`. Keeps the CLI out of real projects (suppresses Claude Code repo-context identity).
 - **`/dev/null` stdin is REQUIRED** — without it the CLI waits ~3s for stdin.
 - **sandbox.ts is a copy.** Keep in sync with `packages/plugin-remote-manifest/src/sub-agent-claude-code/sandbox.ts` if `SENSITIVE_ENV_RE` / `SAFE_ENV_KEYS` change upstream.
-- **Multi-account/AccountPool failover is OUT of v1** — the CLI owns one on-disk cred set. Single-token chat-inference is a documented gap.
+- **Multi-account rotation (SDK backends).** On a subscription-limit throw the warm `claude-sdk` / `codex-sdk` sessions rotate to the next healthy AccountPool account (read off the `eliza.account-pool.coding-agent.v1` globalThis bridge — see `src/chat-account-rotation.ts`), swap the subprocess `CLAUDE_CODE_OAUTH_TOKEN` / `CODEX_HOME`, and retry once; tier-failover only fires when the pool is exhausted. The token flows into the SDK subprocess env only, never `process.env`. The cold `claude`/`codex` CLI backends still use the single on-disk cred set.
 - See the root `AGENTS.md` for repo-wide architecture rules, logger conventions, and ESM requirements.
 
 <!-- BEGIN: evidence-and-e2e-mandate (managed; canonical standard = repo-root PR_EVIDENCE.md) -->

--- a/plugins/plugin-cli-inference/CLAUDE.md
+++ b/plugins/plugin-cli-inference/CLAUDE.md
@@ -179,7 +179,7 @@ bun run --cwd plugins/plugin-cli-inference build
 - **Isolated cwd per call.** Created with `mkdtemp` under `tmpdir()`, validated by `resolveSafeCwd`, removed in a `finally`. Keeps the CLI out of real projects (suppresses Claude Code repo-context identity).
 - **`/dev/null` stdin is REQUIRED** — without it the CLI waits ~3s for stdin.
 - **sandbox.ts is a copy.** Keep in sync with `packages/plugin-remote-manifest/src/sub-agent-claude-code/sandbox.ts` if `SENSITIVE_ENV_RE` / `SAFE_ENV_KEYS` change upstream.
-- **Multi-account/AccountPool failover is OUT of v1** — the CLI owns one on-disk cred set. Single-token chat-inference is a documented gap.
+- **Multi-account rotation (SDK backends).** On a subscription-limit throw the warm `claude-sdk` / `codex-sdk` sessions rotate to the next healthy AccountPool account (read off the `eliza.account-pool.coding-agent.v1` globalThis bridge — see `src/chat-account-rotation.ts`), swap the subprocess `CLAUDE_CODE_OAUTH_TOKEN` / `CODEX_HOME`, and retry once; tier-failover only fires when the pool is exhausted. The token flows into the SDK subprocess env only, never `process.env`. The cold `claude`/`codex` CLI backends still use the single on-disk cred set.
 - See the root `AGENTS.md` for repo-wide architecture rules, logger conventions, and ESM requirements.
 
 <!-- BEGIN: evidence-and-e2e-mandate (managed; canonical standard = repo-root PR_EVIDENCE.md) -->

--- a/plugins/plugin-cli-inference/__tests__/chat-account-rotation.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/chat-account-rotation.test.ts
@@ -1,0 +1,554 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  ACCOUNT_LIMIT_COOLOFF_MS,
+  buildRotatedSubprocessEnv,
+  type ChatAccountRotator,
+  type ChatAccountSelection,
+  createChatAccountRotator,
+  isAccountLimitError,
+  parseLimitResetMs,
+} from "../src/chat-account-rotation";
+import { ClaudeSdkSession, type SdkModule } from "../src/claude-sdk-session";
+import { type CodexModule, CodexSdkSession } from "../src/codex-sdk-session";
+
+/**
+ * Gap A of elizaOS/eliza#11180: on a subscription-limit throw the warm SDK
+ * sessions must rotate to the next healthy AccountPool account (via a mocked
+ * multi-account bridge/rotator) BEFORE the throw reaches tier-failover — and
+ * the subscription token must only ever flow into the SDK subprocess env,
+ * never into the runtime's own process.env.
+ */
+
+const BRIDGE_SYMBOL = Symbol.for("eliza.account-pool.coding-agent.v1");
+
+const LIMIT_TEXT = "You've hit your session limit · resets 9:30pm (UTC)";
+
+function account(id: string, envPatch: Record<string, string>): ChatAccountSelection {
+  return { providerId: "anthropic-subscription", accountId: id, label: id, envPatch };
+}
+
+/** Sequential mock rotator: hands out `accounts` in order, recording calls. */
+function makeRotator(accounts: ChatAccountSelection[]) {
+  const selectCalls: Array<string[] | undefined> = [];
+  const limitedCalls: Array<{ accountId: string; detail: string }> = [];
+  let i = 0;
+  const rotator: ChatAccountRotator = {
+    async select(exclude?: string[]) {
+      selectCalls.push(exclude);
+      const next = accounts[i] ?? null;
+      if (next) i += 1;
+      return next;
+    },
+    async markLimited(sel, detail) {
+      limitedCalls.push({ accountId: sel.accountId, detail });
+    },
+  };
+  return { rotator, selectCalls, limitedCalls };
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+describe("isAccountLimitError", () => {
+  it("matches the session's own limit-classed throws and raw provider forms", () => {
+    expect(
+      isAccountLimitError(
+        new Error(`[cli-inference:sdk] subscription rate limit reached: ${LIMIT_TEXT}`)
+      )
+    ).toBe(true);
+    expect(isAccountLimitError(new Error(LIMIT_TEXT))).toBe(true);
+    expect(isAccountLimitError(new Error("Claude AI usage limit reached|1893456000"))).toBe(true);
+    expect(isAccountLimitError(new Error("API Error: 429 too many requests"))).toBe(true);
+    expect(isAccountLimitError(new Error("You've hit your usage limit."))).toBe(true);
+  });
+
+  it("does NOT match ordinary session failures (no false-positive eviction)", () => {
+    expect(isAccountLimitError(new Error("[cli-inference:sdk] empty completion (subtype=?)"))).toBe(
+      false
+    );
+    expect(isAccountLimitError(new Error("[cli-inference:sdk] turn timed out after 90000ms"))).toBe(
+      false
+    );
+    expect(
+      isAccountLimitError(
+        new Error("[cli-inference:sdk] route: model emitted no decision (subtype=?)")
+      )
+    ).toBe(false);
+    expect(
+      isAccountLimitError(
+        new Error("API Error: 400 messages: text content blocks must be non-empty")
+      )
+    ).toBe(false);
+    expect(isAccountLimitError(new Error("boom"))).toBe(false);
+  });
+});
+
+describe("parseLimitResetMs", () => {
+  const now = 1_700_000_000_000;
+
+  it("parses the classic CLI epoch form (seconds and ms)", () => {
+    expect(parseLimitResetMs("Claude AI usage limit reached|1893456000", now)).toBe(
+      1_893_456_000_000
+    );
+    expect(parseLimitResetMs("Claude AI usage limit reached|1893456000000", now)).toBe(
+      1_893_456_000_000
+    );
+  });
+
+  it("falls back to the default cool-off for past epochs and unparseable text", () => {
+    expect(parseLimitResetMs("Claude AI usage limit reached|1000000000", now)).toBe(
+      now + ACCOUNT_LIMIT_COOLOFF_MS
+    );
+    expect(parseLimitResetMs(LIMIT_TEXT, now)).toBe(now + ACCOUNT_LIMIT_COOLOFF_MS);
+  });
+});
+
+describe("buildRotatedSubprocessEnv", () => {
+  const saved: Record<string, string | undefined> = {};
+  const keys = ["CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY", "CODEX_HOME", "OPENAI_API_KEY"];
+  beforeEach(() => {
+    for (const k of keys) {
+      saved[k] = process.env[k];
+      process.env[k] = `ambient-${k}`;
+    }
+  });
+  afterEach(() => {
+    for (const k of keys) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it("spreads process.env, drops competing ambient auth vars, patch wins — and never mutates process.env", () => {
+    const env = buildRotatedSubprocessEnv("claude", { CLAUDE_CODE_OAUTH_TOKEN: "token-1" });
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe("token-1");
+    expect(env).not.toHaveProperty("ANTHROPIC_API_KEY");
+    expect(env.PATH).toBe(process.env.PATH); // inherited vars survive
+    expect(env.CODEX_HOME).toBe("ambient-CODEX_HOME"); // other agent's vars untouched
+    // TOS invariant: the merge is pure.
+    expect(process.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("ambient-CLAUDE_CODE_OAUTH_TOKEN");
+    expect(process.env.ANTHROPIC_API_KEY).toBe("ambient-ANTHROPIC_API_KEY");
+
+    const codexEnv = buildRotatedSubprocessEnv("codex", { CODEX_HOME: "/fake/home" });
+    expect(codexEnv.CODEX_HOME).toBe("/fake/home");
+    expect(codexEnv).not.toHaveProperty("OPENAI_API_KEY");
+    expect(codexEnv.CLAUDE_CODE_OAUTH_TOKEN).toBe("ambient-CLAUDE_CODE_OAUTH_TOKEN");
+    expect(process.env.CODEX_HOME).toBe("ambient-CODEX_HOME");
+  });
+});
+
+describe("createChatAccountRotator (globalThis bridge reader)", () => {
+  afterEach(() => {
+    delete (globalThis as Record<symbol, unknown>)[BRIDGE_SYMBOL];
+  });
+
+  it("no-ops (null) when no bridge is installed", async () => {
+    const rotator = createChatAccountRotator("claude", "key-1");
+    expect(await rotator.select()).toBeNull();
+    await rotator.markLimited(account("a", {}), "detail"); // must not throw
+  });
+
+  it("forwards agentType/sessionKey/exclude to bridge.select and untilMs to markRateLimited", async () => {
+    const selectArgs: unknown[] = [];
+    const limitArgs: unknown[] = [];
+    (globalThis as Record<symbol, unknown>)[BRIDGE_SYMBOL] = {
+      select: async (agentType: string, opts: unknown) => {
+        selectArgs.push([agentType, opts]);
+        return account("acc-1", { CLAUDE_CODE_OAUTH_TOKEN: "t1" });
+      },
+      markRateLimited: async (...args: unknown[]) => {
+        limitArgs.push(args);
+      },
+    };
+    const rotator = createChatAccountRotator("claude", "key-1");
+    const picked = await rotator.select(["dead-account"]);
+    expect(picked?.accountId).toBe("acc-1");
+    expect(selectArgs[0]).toEqual(["claude", { sessionKey: "key-1", exclude: ["dead-account"] }]);
+
+    await rotator.markLimited(
+      picked as ChatAccountSelection,
+      "Claude AI usage limit reached|1893456000"
+    );
+    const [providerId, accountId, untilMs, detail] = limitArgs[0] as [
+      string,
+      string,
+      number,
+      string,
+    ];
+    expect(providerId).toBe("anthropic-subscription");
+    expect(accountId).toBe("acc-1");
+    expect(untilMs).toBe(1_893_456_000_000);
+    expect(detail).toContain("usage limit reached");
+  });
+
+  it("returns null on a throwing or empty-envPatch bridge (never throws into the inference path)", async () => {
+    (globalThis as Record<symbol, unknown>)[BRIDGE_SYMBOL] = {
+      select: async () => {
+        throw new Error("pool exploded");
+      },
+      markRateLimited: async () => {
+        throw new Error("pool exploded");
+      },
+    };
+    const rotator = createChatAccountRotator("codex", "key-2");
+    expect(await rotator.select()).toBeNull();
+    await rotator.markLimited(account("a", {}), "detail"); // swallowed
+
+    (globalThis as Record<symbol, unknown>)[BRIDGE_SYMBOL] = {
+      select: async () => account("acc-empty", {}),
+      markRateLimited: async () => {},
+    };
+    expect(await createChatAccountRotator("claude", "key-3").select()).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ClaudeSdkSession rotation (fake SDK + mock rotator)
+// ---------------------------------------------------------------------------
+
+interface TurnScript {
+  toolCall?: { action: unknown; params?: unknown };
+  text?: string;
+  subtype?: string;
+  noResult?: boolean;
+}
+
+type ToolHandler = (args: {
+  action?: unknown;
+  params?: unknown;
+}) => Promise<{ content: Array<{ type: string; text: string }> }>;
+
+/** Fake SdkModule replaying `scripts` turn-by-turn, capturing options per start. */
+function makeFakeSdk(scripts: TurnScript[]): {
+  sdk: SdkModule;
+  starts: () => number;
+  optionsPerStart: Array<Record<string, unknown>>;
+} {
+  let startCount = 0;
+  let turn = 0;
+  const optionsPerStart: Array<Record<string, unknown>> = [];
+  const sdk: SdkModule = {
+    tool: (_name, _desc, _schema, handler) => ({ handler }) as unknown,
+    createSdkMcpServer: (opts) => ({ tools: opts.tools }) as unknown,
+    query: ({ options }) => {
+      startCount += 1;
+      optionsPerStart.push(options);
+      const servers = options.mcpServers as
+        | { eliza?: { tools?: Array<{ handler: ToolHandler }> } }
+        | undefined;
+      const handler = servers?.eliza?.tools?.[0]?.handler;
+      async function* gen() {
+        while (turn < scripts.length) {
+          const s = scripts[turn++];
+          if (s.toolCall && handler) {
+            await handler({ action: s.toolCall.action, params: s.toolCall.params });
+          }
+          if (s.text !== undefined) {
+            yield {
+              type: "assistant",
+              message: { content: [{ type: "text", text: s.text }] },
+            };
+          }
+          if (!s.noResult) {
+            yield { type: "result", subtype: s.subtype ?? "success", result: undefined };
+          }
+        }
+      }
+      const iter = gen();
+      return {
+        [Symbol.asyncIterator]: () => iter,
+        interrupt: async () => {},
+      } as unknown as ReturnType<SdkModule["query"]>;
+    },
+  };
+  return { sdk, starts: () => startCount, optionsPerStart };
+}
+
+const fakeZod = { z: { string: () => ({}), any: () => ({}), record: () => ({}) } };
+
+function makeClaudeSession(
+  scripts: TurnScript[],
+  rotator: ChatAccountRotator | null,
+  opts: { router?: boolean; restartAfterTurns?: number } = {}
+) {
+  const fake = makeFakeSdk(scripts);
+  const session = new ClaudeSdkSession({
+    model: "test-model",
+    systemPrompt: "test system",
+    router: opts.router ?? false,
+    restartAfterTurns: opts.restartAfterTurns,
+    sdkModule: fake.sdk,
+    zodModule: fakeZod,
+    accountRotator: rotator,
+  });
+  return { session, ...fake };
+}
+
+describe("ClaudeSdkSession — rotate-on-limit (Gap A #11180)", () => {
+  const savedToken = process.env.CLAUDE_CODE_OAUTH_TOKEN;
+  const savedKey = process.env.ANTHROPIC_API_KEY;
+  beforeEach(() => {
+    delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+    delete process.env.ANTHROPIC_API_KEY;
+  });
+  afterEach(() => {
+    if (savedToken === undefined) delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+    else process.env.CLAUDE_CODE_OAUTH_TOKEN = savedToken;
+    if (savedKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+    else process.env.ANTHROPIC_API_KEY = savedKey;
+  });
+
+  it("marks the limited account, rotates to the next healthy one, and retries ONCE — token stays out of process.env", async () => {
+    const { rotator, selectCalls, limitedCalls } = makeRotator([
+      account("acc-1", { CLAUDE_CODE_OAUTH_TOKEN: "token-1" }),
+      account("acc-2", { CLAUDE_CODE_OAUTH_TOKEN: "token-2" }),
+    ]);
+    const { session, starts, optionsPerStart } = makeClaudeSession(
+      [
+        { text: LIMIT_TEXT, subtype: "success" }, // acc-1's turn hits the limit
+        { text: "recovered", subtype: "success" }, // acc-2's retry succeeds
+      ],
+      rotator
+    );
+
+    expect(await session.generate("hi")).toBe("recovered");
+    expect(starts()).toBe(2);
+    // Initial selection + the exclude-the-limited-account re-pick. No third pick.
+    expect(selectCalls).toEqual([undefined, ["acc-1"]]);
+    expect(limitedCalls).toHaveLength(1);
+    expect(limitedCalls[0]?.accountId).toBe("acc-1");
+    expect(limitedCalls[0]?.detail).toMatch(/rate limit/i);
+    // Each warm process authenticated AS its account, in the SUBPROCESS env only.
+    const env1 = optionsPerStart[0]?.env as Record<string, string | undefined>;
+    const env2 = optionsPerStart[1]?.env as Record<string, string | undefined>;
+    expect(env1?.CLAUDE_CODE_OAUTH_TOKEN).toBe("token-1");
+    expect(env2?.CLAUDE_CODE_OAUTH_TOKEN).toBe("token-2");
+    expect(env1?.PATH).toBe(process.env.PATH);
+    // TOS invariant: the runtime's own env never saw either token.
+    expect(process.env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+    expect(process.env.ANTHROPIC_API_KEY).toBeUndefined();
+    await session.dispose();
+  });
+
+  it("falls to tier-failover ONLY when the pool has no other healthy account", async () => {
+    const { rotator, selectCalls, limitedCalls } = makeRotator([
+      account("acc-1", { CLAUDE_CODE_OAUTH_TOKEN: "token-1" }),
+      // no second account: the exclude re-pick returns null (all limited)
+    ]);
+    const { session, starts } = makeClaudeSession(
+      [{ text: LIMIT_TEXT, subtype: "success" }],
+      rotator
+    );
+
+    await expect(session.generate("hi")).rejects.toThrow(/subscription rate limit reached/);
+    expect(starts()).toBe(1); // no retry without a replacement account
+    expect(selectCalls).toEqual([undefined, ["acc-1"]]);
+    expect(limitedCalls.map((c) => c.accountId)).toEqual(["acc-1"]); // limit recorded before failover
+    await session.dispose();
+  });
+
+  it("records the replacement account's limit too when the single retry also limits (no rotation loop)", async () => {
+    const { rotator, selectCalls, limitedCalls } = makeRotator([
+      account("acc-1", { CLAUDE_CODE_OAUTH_TOKEN: "token-1" }),
+      account("acc-2", { CLAUDE_CODE_OAUTH_TOKEN: "token-2" }),
+      account("acc-3", { CLAUDE_CODE_OAUTH_TOKEN: "token-3" }), // must never be reached
+    ]);
+    const { session, starts } = makeClaudeSession(
+      [
+        { text: LIMIT_TEXT, subtype: "success" },
+        { text: LIMIT_TEXT, subtype: "success" },
+      ],
+      rotator
+    );
+
+    await expect(session.generate("hi")).rejects.toThrow(/subscription rate limit reached/);
+    expect(starts()).toBe(2); // exactly one rotation retry
+    expect(selectCalls).toHaveLength(2); // acc-3 never selected
+    expect(limitedCalls.map((c) => c.accountId)).toEqual(["acc-1", "acc-2"]);
+    await session.dispose();
+  });
+
+  it("does NOT rotate on a non-limit failure", async () => {
+    const { rotator, selectCalls, limitedCalls } = makeRotator([
+      account("acc-1", { CLAUDE_CODE_OAUTH_TOKEN: "token-1" }),
+      account("acc-2", { CLAUDE_CODE_OAUTH_TOKEN: "token-2" }),
+    ]);
+    const { session } = makeClaudeSession([{ text: "partial", noResult: true }], rotator);
+
+    await expect(session.generate("hi")).rejects.toThrow(/session-ended|empty completion/);
+    expect(selectCalls).toEqual([undefined]); // only the start-time selection
+    expect(limitedCalls).toHaveLength(0);
+    await session.dispose();
+  });
+
+  it("keeps the pre-pool behavior when rotation is disabled (no env injection, straight throw)", async () => {
+    const { session, optionsPerStart } = makeClaudeSession(
+      [{ text: LIMIT_TEXT, subtype: "success" }],
+      null
+    );
+    await expect(session.generate("hi")).rejects.toThrow(/subscription rate limit reached/);
+    expect(optionsPerStart[0]?.env).toBeUndefined(); // ambient ~/.claude creds
+    await session.dispose();
+  });
+
+  it("re-selects on every scheduled restart so a fresh token is injected", async () => {
+    const { rotator, selectCalls } = makeRotator([
+      account("acc-1", { CLAUDE_CODE_OAUTH_TOKEN: "token-a" }),
+      account("acc-1", { CLAUDE_CODE_OAUTH_TOKEN: "token-b" }), // same account, fresh token
+    ]);
+    const { session, optionsPerStart } = makeClaudeSession(
+      [
+        { text: "one", subtype: "success" },
+        { text: "two", subtype: "success" },
+      ],
+      rotator,
+      { restartAfterTurns: 1 }
+    );
+    expect(await session.generate("1")).toBe("one");
+    expect(await session.generate("2")).toBe("two");
+    expect(selectCalls).toEqual([undefined, undefined]);
+    expect((optionsPerStart[1]?.env as Record<string, string>)?.CLAUDE_CODE_OAUTH_TOKEN).toBe(
+      "token-b"
+    );
+    await session.dispose();
+  });
+
+  it("rotates in ROUTE mode too and the retried turn's decision is returned", async () => {
+    const { rotator, limitedCalls } = makeRotator([
+      account("acc-1", { CLAUDE_CODE_OAUTH_TOKEN: "token-1" }),
+      account("acc-2", { CLAUDE_CODE_OAUTH_TOKEN: "token-2" }),
+    ]);
+    const { session } = makeClaudeSession(
+      [
+        { text: LIMIT_TEXT, subtype: "error_max_turns" }, // no decision + limit envelope
+        { toolCall: { action: "WEB_FETCH", params: { url: "u" } }, subtype: "error_max_turns" },
+      ],
+      rotator,
+      { router: true }
+    );
+    const out = JSON.parse(await session.route("price?"));
+    expect(out).toEqual({ action: "WEB_FETCH", params: { url: "u" } });
+    expect(limitedCalls.map((c) => c.accountId)).toEqual(["acc-1"]);
+    await session.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CodexSdkSession rotation (fake Codex + mock rotator)
+// ---------------------------------------------------------------------------
+
+interface CodexTurnScript {
+  finalResponse?: string;
+  throws?: string;
+}
+
+function makeFakeCodex(scripts: CodexTurnScript[]): {
+  codexModule: CodexModule;
+  starts: () => number;
+  ctorOptions: Array<Record<string, unknown>>;
+} {
+  let startCount = 0;
+  let turn = 0;
+  const ctorOptions: Array<Record<string, unknown>> = [];
+  const codexModule = {
+    Codex: class {
+      constructor(options?: Record<string, unknown>) {
+        ctorOptions.push(options ?? {});
+      }
+      startThread() {
+        startCount += 1;
+        return {
+          run: async () => {
+            const s = scripts[turn++] ?? {};
+            if (s.throws) throw new Error(s.throws);
+            return { items: [], finalResponse: s.finalResponse, usage: null };
+          },
+        };
+      }
+    },
+  } as unknown as CodexModule;
+  return { codexModule, starts: () => startCount, ctorOptions };
+}
+
+function makeCodexSession(scripts: CodexTurnScript[], rotator: ChatAccountRotator | null) {
+  const fake = makeFakeCodex(scripts);
+  const session = new CodexSdkSession({
+    model: "gpt-test",
+    codexModule: fake.codexModule,
+    accountRotator: rotator,
+  });
+  return { session, ...fake };
+}
+
+function codexAccount(id: string, home: string): ChatAccountSelection {
+  return { providerId: "openai-codex", accountId: id, label: id, envPatch: { CODEX_HOME: home } };
+}
+
+describe("CodexSdkSession — rotate-on-limit (Gap A #11180)", () => {
+  const savedHome = process.env.CODEX_HOME;
+  beforeEach(() => {
+    delete process.env.CODEX_HOME;
+  });
+  afterEach(() => {
+    if (savedHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = savedHome;
+  });
+
+  it("swaps the per-account CODEX_HOME and retries once — CODEX_HOME stays out of process.env", async () => {
+    const { rotator, selectCalls, limitedCalls } = makeRotator([
+      codexAccount("acc-1", "/fake/codex-home/acc-1"),
+      codexAccount("acc-2", "/fake/codex-home/acc-2"),
+    ]);
+    const { session, starts, ctorOptions } = makeCodexSession(
+      [{ throws: "You've hit your usage limit. Try again later." }, { finalResponse: "recovered" }],
+      rotator
+    );
+
+    expect(await session.generate("hi")).toBe("recovered");
+    expect(starts()).toBe(2);
+    expect(selectCalls).toEqual([undefined, ["acc-1"]]);
+    expect(limitedCalls.map((c) => c.accountId)).toEqual(["acc-1"]);
+    const env1 = ctorOptions[0]?.env as Record<string, string | undefined>;
+    const env2 = ctorOptions[1]?.env as Record<string, string | undefined>;
+    expect(env1?.CODEX_HOME).toBe("/fake/codex-home/acc-1");
+    expect(env2?.CODEX_HOME).toBe("/fake/codex-home/acc-2");
+    expect(env1?.PATH).toBe(process.env.PATH); // codex env REPLACES; PATH must survive
+    expect(process.env.CODEX_HOME).toBeUndefined(); // TOS invariant
+    session.dispose();
+  });
+
+  it("falls to tier-failover only when the pool is exhausted, recording the limit first", async () => {
+    const { rotator, selectCalls, limitedCalls } = makeRotator([codexAccount("acc-1", "/fake/a")]);
+    const { session, starts } = makeCodexSession(
+      [{ throws: "quota exceeded for this billing cycle" }],
+      rotator
+    );
+
+    await expect(session.generate("hi")).rejects.toThrow(/quota exceeded/);
+    expect(starts()).toBe(1);
+    expect(selectCalls).toEqual([undefined, ["acc-1"]]);
+    expect(limitedCalls.map((c) => c.accountId)).toEqual(["acc-1"]);
+    session.dispose();
+  });
+
+  it("does NOT rotate on a non-limit failure", async () => {
+    const { rotator, selectCalls, limitedCalls } = makeRotator([
+      codexAccount("acc-1", "/fake/a"),
+      codexAccount("acc-2", "/fake/b"),
+    ]);
+    const { session } = makeCodexSession([{ throws: "boom" }], rotator);
+
+    await expect(session.generate("hi")).rejects.toThrow(/boom/);
+    expect(selectCalls).toEqual([undefined]);
+    expect(limitedCalls).toHaveLength(0);
+    session.dispose();
+  });
+
+  it("keeps the pre-pool behavior when rotation is disabled (no env option at all)", async () => {
+    const { session, ctorOptions } = makeCodexSession([{ finalResponse: "ok" }], null);
+    expect(await session.generate("hi")).toBe("ok");
+    expect(ctorOptions[0]?.env).toBeUndefined(); // ambient ~/.codex creds
+    session.dispose();
+  });
+});

--- a/plugins/plugin-cli-inference/src/chat-account-rotation.ts
+++ b/plugins/plugin-cli-inference/src/chat-account-rotation.ts
@@ -1,0 +1,198 @@
+/**
+ * Chat-brain account rotation — the Gap A half of elizaOS/eliza#11180.
+ *
+ * The warm SDK sessions ({@link ClaudeSdkSession} / CodexSdkSession) authenticate
+ * from ambient credentials (`~/.claude` / `CLAUDE_CODE_OAUTH_TOKEN` / `~/.codex`).
+ * When that one account hits its subscription limit the session throws and
+ * `useModel` fails over to the next model TIER — a user with N linked
+ * Claude/Codex accounts still stalls the brain when account #1 limits, because
+ * nothing ever consults the AccountPool.
+ *
+ * This module lets the sessions consume the pool WITHOUT importing
+ * `@elizaos/app-core` (this plugin depends only on `@elizaos/core`): exactly like
+ * the orchestrator's `coding-account-selection.ts`, it reads the account-selector
+ * bridge that `getDefaultAccountPool()` installs on a `globalThis` symbol. The
+ * bridge materializes per-account subprocess env (claude → `CLAUDE_CODE_OAUTH_TOKEN`,
+ * codex → a per-account `CODEX_HOME`) and records limits + resets back into pool
+ * health, so the account panel / keep-alive sweep see chat-brain limits too.
+ *
+ * ⚠ TOS invariant (mirrors `coding-account-bridge.ts`): the subscription token
+ * flows ONLY into the SDK subprocess env (`query options.env` / `new Codex({env})`)
+ * — NEVER into the runtime's own `process.env`.
+ *
+ * When no bridge / no pooled accounts exist every helper here no-ops and the
+ * single-account behavior (ambient creds, throw-to-tier-failover) is untouched.
+ *
+ * @module plugin-cli-inference/chat-account-rotation
+ */
+
+import { logger } from "@elizaos/core";
+
+/**
+ * Same symbol the coding-agent path uses (`coding-account-bridge.ts` publishes,
+ * the orchestrator's `coding-account-selection.ts` consumes). The richer
+ * `select()` contract is required here — the bare `subscription-selector.v1`
+ * bridge only returns an account id, which cannot materialize the subprocess
+ * env or record health.
+ */
+const ACCOUNT_SELECTOR_BRIDGE_SYMBOL: unique symbol = Symbol.for(
+  "eliza.account-pool.coding-agent.v1"
+);
+
+/** Agent types whose subscription auth the chat brain shares. */
+export type ChatAgentType = "claude" | "codex";
+
+/** A pool-selected account plus the env vars its subprocess needs. */
+export interface ChatAccountSelection {
+  providerId: string;
+  accountId: string;
+  label: string;
+  /** Secrets — injected into the SDK subprocess env only, never process.env. */
+  envPatch: Record<string, string>;
+}
+
+/** Narrow structural view of the app-core bridge (never imported). */
+interface AccountSelectorBridge {
+  select(
+    agentType: string,
+    opts?: { sessionKey?: string; exclude?: string[] }
+  ): Promise<ChatAccountSelection | null>;
+  markRateLimited(
+    providerId: string,
+    accountId: string,
+    untilMs: number,
+    detail?: string
+  ): Promise<void>;
+}
+
+function getBridge(): AccountSelectorBridge | null {
+  if (typeof globalThis === "undefined") return null;
+  const bridge = (globalThis as Record<symbol, unknown>)[ACCOUNT_SELECTOR_BRIDGE_SYMBOL];
+  if (!bridge || typeof bridge !== "object") return null;
+  const b = bridge as Partial<AccountSelectorBridge>;
+  return typeof b.select === "function" && typeof b.markRateLimited === "function"
+    ? (b as AccountSelectorBridge)
+    : null;
+}
+
+/**
+ * Conservative limit classifier — the same bar as the orchestrator's
+ * `classifyAccountFailure` RATE_LIMIT_RE: require an UNAMBIGUOUS quota/limit
+ * signal before evicting an account from rotation. Matches both this plugin's
+ * own limit-classed throws ("subscription rate limit reached: …") and raw
+ * provider forms (429s, "usage limit reached", "You've hit your session limit").
+ */
+const ACCOUNT_LIMIT_RE =
+  /\b429\b|rate[\s-]?limit(?:ed|ing)?|too many requests|quota (?:exceeded|exhausted)|usage limit reached|hit your\b[^.]*\blimit\b/i;
+
+/** True when a thrown session error is account-limit-classed (→ rotate). */
+export function isAccountLimitError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return ACCOUNT_LIMIT_RE.test(msg);
+}
+
+/**
+ * Cool-off recorded when the limit text carries no parseable reset — matching
+ * the orchestrator's RATE_LIMIT_COOLOFF_MS. The pool prefers the provider's own
+ * `usage.resetsAt` when its usage probe has one, so this is only the floor.
+ */
+export const ACCOUNT_LIMIT_COOLOFF_MS = 15 * 60_000;
+
+/**
+ * Parse the limit's reset time (epoch ms) out of the error text. The classic
+ * Claude CLI envelope carries a unix epoch ("Claude AI usage limit reached|<epoch>");
+ * the SDK UI string ("· resets 9:30pm (UTC)") does not — fall back to the
+ * default cool-off and let the pool's authoritative `usage.resetsAt` win.
+ */
+export function parseLimitResetMs(detail: string, nowMs = Date.now()): number {
+  const epoch = detail.match(/\|\s*(\d{10,13})\b/);
+  if (epoch?.[1]) {
+    const n = Number(epoch[1]);
+    const ms = epoch[1].length >= 13 ? n : n * 1000;
+    if (ms > nowMs) return ms;
+  }
+  return nowMs + ACCOUNT_LIMIT_COOLOFF_MS;
+}
+
+/**
+ * Ambient auth vars that would compete with a rotated account's env patch.
+ * Both SDKs REPLACE the subprocess environment when `env` is provided, so the
+ * merge spreads `process.env` (PATH/HOME must survive) but drops these first —
+ * otherwise an operator's own `CLAUDE_CODE_OAUTH_TOKEN` / `CODEX_HOME` /
+ * API key could out-rank the account the pool just selected.
+ */
+const COMPETING_AUTH_VARS: Readonly<Record<ChatAgentType, readonly string[]>> = {
+  claude: ["CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY"],
+  codex: ["CODEX_HOME", "OPENAI_API_KEY"],
+};
+
+/**
+ * Build the SDK subprocess env for a rotated account: `process.env` minus the
+ * competing ambient auth vars, plus the account's env patch. Pure — never
+ * mutates `process.env` (the TOS invariant lives here).
+ */
+export function buildRotatedSubprocessEnv(
+  agentType: ChatAgentType,
+  envPatch: Record<string, string>
+): Record<string, string | undefined> {
+  const env: Record<string, string | undefined> = { ...process.env };
+  for (const key of COMPETING_AUTH_VARS[agentType]) delete env[key];
+  return { ...env, ...envPatch };
+}
+
+/** Rotation hooks a warm SDK session consumes. Implementations never throw. */
+export interface ChatAccountRotator {
+  /** Pick an account (null = no bridge / no healthy account → ambient creds). */
+  select(exclude?: string[]): Promise<ChatAccountSelection | null>;
+  /** Record a limit + its parsed reset into pool health (best-effort). */
+  markLimited(selection: ChatAccountSelection, detail: string): Promise<void>;
+}
+
+/**
+ * Default rotator: resolves the bridge lazily on every call (the pool installs
+ * it after plugin construction), scopes selection to one `sessionKey` so pool
+ * affinity keeps a warm session on a stable account across restarts, and
+ * swallows bridge faults (a degraded pool must not break the inference path —
+ * the caller just stays on ambient creds / tier failover).
+ */
+export function createChatAccountRotator(
+  agentType: ChatAgentType,
+  sessionKey: string
+): ChatAccountRotator {
+  return {
+    async select(exclude?: string[]): Promise<ChatAccountSelection | null> {
+      const bridge = getBridge();
+      if (!bridge) return null;
+      try {
+        const selection = await bridge.select(agentType, {
+          sessionKey,
+          ...(exclude && exclude.length > 0 ? { exclude } : {}),
+        });
+        if (!selection || Object.keys(selection.envPatch ?? {}).length === 0) {
+          return null;
+        }
+        return selection;
+      } catch (err) {
+        logger.warn(`[cli-inference] account select failed for ${agentType}: ${String(err)}`);
+        return null;
+      }
+    },
+    async markLimited(selection: ChatAccountSelection, detail: string): Promise<void> {
+      const bridge = getBridge();
+      if (!bridge) return;
+      try {
+        await bridge.markRateLimited(
+          selection.providerId,
+          selection.accountId,
+          parseLimitResetMs(detail),
+          detail
+        );
+      } catch (err) {
+        // Pool feedback is best-effort — never break the failover path.
+        logger.warn(
+          `[cli-inference] could not record limit for ${selection.providerId}/${selection.accountId}: ${String(err)}`
+        );
+      }
+    },
+  };
+}

--- a/plugins/plugin-cli-inference/src/claude-sdk-session.ts
+++ b/plugins/plugin-cli-inference/src/claude-sdk-session.ts
@@ -43,6 +43,13 @@
  */
 
 import { logger } from "@elizaos/core";
+import {
+  buildRotatedSubprocessEnv,
+  type ChatAccountRotator,
+  type ChatAccountSelection,
+  createChatAccountRotator,
+  isAccountLimitError,
+} from "./chat-account-rotation";
 import { ProviderApiError, parseProviderApiErrorText } from "./provider-errors";
 
 const DEFAULT_MODEL = "claude-opus-4-7";
@@ -170,6 +177,11 @@ export interface ClaudeSdkSessionConfig {
   /** Injected for tests; defaults to the real SDK + zod. */
   sdkModule?: SdkModule;
   zodModule?: ZodModule;
+  /**
+   * Multi-account rotation hooks (Gap A, elizaOS/eliza#11180). Defaults to the
+   * AccountPool bridge rotator; pass `null` to disable rotation entirely.
+   */
+  accountRotator?: ChatAccountRotator | null;
 }
 
 // Resolved at runtime from the hoisted workspace node_modules (the Agent SDK
@@ -231,10 +243,13 @@ export class ClaudeSdkSession {
   private readonly turnTimeoutMs: number;
   private readonly sdkOverride?: SdkModule;
   private readonly zodOverride?: ZodModule;
+  private readonly rotator: ChatAccountRotator | null;
 
   private query: SdkQuery | null = null;
   private feed: ((msg: SdkUserMessage) => void) | null = null;
   private iterator: AsyncIterator<SdkMessage> | null = null;
+  // The pool account serving this warm process (null = ambient ~/.claude creds).
+  private account: ChatAccountSelection | null = null;
   private turns = 0;
   private chain: Promise<unknown> = Promise.resolve();
   // ROUTE mode: the MCP tool handler writes the current turn's decision here.
@@ -258,6 +273,13 @@ export class ClaudeSdkSession {
         : DEFAULT_TURN_TIMEOUT_MS;
     this.sdkOverride = config.sdkModule;
     this.zodOverride = config.zodModule;
+    this.rotator =
+      config.accountRotator !== undefined
+        ? config.accountRotator
+        : createChatAccountRotator(
+            "claude",
+            `cli-inference:claude:${this.model}:${this.router ? "route" : "text"}`
+          );
   }
 
   /** TEXT mode: generate one completion's text. Serialized. */
@@ -300,11 +322,68 @@ export class ClaudeSdkSession {
     } catch (err) {
       // Self-heal: a dead/erroring session must not poison the next turn.
       await this.dispose();
+      // Gap A (#11180): a limit-classed failure rotates to the next healthy
+      // pool account and retries ONCE, BEFORE the throw reaches tier-failover.
+      const rotated = await this.rotateOnLimit(err);
+      if (rotated) {
+        try {
+          await this.start(rotated);
+          this.turns += 1;
+          return await this.sendAndRead(body, mode);
+        } catch (retryErr) {
+          await this.dispose();
+          // The replacement limited too — record it, then fall to the next tier.
+          if (this.rotator && isAccountLimitError(retryErr)) {
+            await this.rotator.markLimited(
+              rotated,
+              retryErr instanceof Error ? retryErr.message : String(retryErr)
+            );
+          }
+          throw retryErr instanceof Error
+            ? retryErr
+            : new Error(`[cli-inference:sdk] ${String(retryErr)}`);
+        }
+      }
       throw err instanceof Error ? err : new Error(`[cli-inference:sdk] ${String(err)}`);
     }
   }
 
-  private async start(): Promise<void> {
+  /**
+   * On a limit-classed failure: record the limit (+ parsed reset) against the
+   * serving account and pick the next healthy one (breaking pool session
+   * affinity via `exclude`). Returns the replacement selection, or null when
+   * rotation is impossible — no rotator, non-limit error, or the pool has no
+   * other healthy account — in which case the caller throws so `useModel`
+   * falls to the next model TIER (the pre-existing behavior).
+   */
+  private async rotateOnLimit(err: unknown): Promise<ChatAccountSelection | null> {
+    if (!this.rotator || !isAccountLimitError(err)) return null;
+    const limited = this.account;
+    const detail = err instanceof Error ? err.message : String(err);
+    if (limited) await this.rotator.markLimited(limited, detail);
+    const next = await this.rotator.select(limited ? [limited.accountId] : undefined);
+    if (!next) {
+      if (limited) {
+        logger.warn(
+          `[cli-inference:sdk] account "${limited.label}" hit its limit and no other healthy account is available — failing over to the next model tier`
+        );
+      }
+      return null;
+    }
+    logger.info(
+      `[cli-inference:sdk] rotating chat brain from ${limited ? `account "${limited.label}"` : "ambient credentials"} to account "${next.label}" after a subscription limit`
+    );
+    return next;
+  }
+
+  private async start(account?: ChatAccountSelection | null): Promise<void> {
+    // Pin a pool account for this warm process. Re-selected on every (re)start
+    // so a restarted session gets a FRESH access token (the injected token
+    // cannot refresh itself mid-run); pool session-affinity keeps the account
+    // stable across restarts. When no pool/bridge exists this resolves null and
+    // the subprocess inherits the ambient creds (~/.claude /
+    // CLAUDE_CODE_OAUTH_TOKEN) exactly as before.
+    this.account = account !== undefined ? account : ((await this.rotator?.select()) ?? null);
     const sdk = this.sdkOverride ?? (await loadSdk());
     // A pull-based async generator the SDK drains; we push the next user message
     // into it via `this.feed`.
@@ -342,6 +421,14 @@ export class ClaudeSdkSession {
       // "I'll fetch it…" preamble-then-act pattern that leaks when maxTurns>1.
       maxTurns: this.router ? 1 : this.textMaxTurns,
     };
+    if (this.account) {
+      // Authenticate the SDK subprocess AS the selected pool account. The token
+      // flows ONLY into this subprocess env — never into the runtime's own
+      // process.env (TOS invariant, mirroring coding-account-bridge). `env`
+      // REPLACES the subprocess environment, so the helper spreads process.env
+      // (PATH/HOME survive) and drops competing ambient auth vars first.
+      options.env = buildRotatedSubprocessEnv("claude", this.account.envPatch);
+    }
     if (this.systemPrompt) options.systemPrompt = this.systemPrompt;
     if (this.claudeExecutablePath) {
       options.pathToClaudeCodeExecutable = this.claudeExecutablePath;

--- a/plugins/plugin-cli-inference/src/codex-sdk-session.ts
+++ b/plugins/plugin-cli-inference/src/codex-sdk-session.ts
@@ -37,6 +37,13 @@
  */
 
 import { logger } from "@elizaos/core";
+import {
+  buildRotatedSubprocessEnv,
+  type ChatAccountRotator,
+  type ChatAccountSelection,
+  createChatAccountRotator,
+  isAccountLimitError,
+} from "./chat-account-rotation";
 
 const DEFAULT_MODEL = "gpt-5.5";
 const DEFAULT_RESTART_AFTER_TURNS = 20;
@@ -99,6 +106,11 @@ export interface CodexSdkSessionConfig {
   restartAfterTurns?: number;
   /** Injected for tests; defaults to the real SDK. */
   codexModule?: CodexModule;
+  /**
+   * Multi-account rotation hooks (Gap A, elizaOS/eliza#11180). Defaults to the
+   * AccountPool bridge rotator; pass `null` to disable rotation entirely.
+   */
+  accountRotator?: ChatAccountRotator | null;
 }
 
 const SDK_PACKAGE = "@openai/codex-sdk";
@@ -145,8 +157,11 @@ export class CodexSdkSession {
   private readonly codexBinPath: string | null;
   private readonly restartAfterTurns: number;
   private readonly codexOverride?: CodexModule;
+  private readonly rotator: ChatAccountRotator | null;
 
   private thread: CodexThread | null = null;
+  // The pool account serving this warm thread (null = ambient ~/.codex creds).
+  private account: ChatAccountSelection | null = null;
   private turns = 0;
   private chain: Promise<unknown> = Promise.resolve();
 
@@ -160,6 +175,13 @@ export class CodexSdkSession {
         ? config.restartAfterTurns
         : DEFAULT_RESTART_AFTER_TURNS;
     this.codexOverride = config.codexModule;
+    this.rotator =
+      config.accountRotator !== undefined
+        ? config.accountRotator
+        : createChatAccountRotator(
+            "codex",
+            `cli-inference:codex:${this.model}:${this.router ? "route" : "text"}`
+          );
   }
 
   /** TEXT mode: generate one completion's text. Serialized. */
@@ -189,32 +211,92 @@ export class CodexSdkSession {
     if (this.thread && this.turns >= this.restartAfterTurns) {
       this.dispose();
     }
-    if (!this.thread) {
-      await this.start();
-    }
-    this.turns += 1;
     try {
-      const thread = this.thread;
-      if (!thread) throw new Error("[cli-inference:codex-sdk] thread not started");
-      // ROUTE: constrain output to {action, params:json-string} via the codex
-      // native output schema (reliable shape; needs the system codex binary).
-      const turn = await thread.run(
-        body,
-        mode === "route" ? { outputSchema: ROUTE_OUTPUT_SCHEMA } : undefined
-      );
-      const text = turnToText(turn);
-      if (mode === "route") {
-        return this.normalizeRoute(text);
-      }
-      if (!text) {
-        throw new Error("[cli-inference:codex-sdk] empty completion");
-      }
-      return text;
+      return await this.runTurn(body, mode);
     } catch (err) {
       // Self-heal: a dead/erroring thread must not poison the next turn.
       this.dispose();
+      // Gap A (#11180): a limit-classed failure rotates to the next healthy
+      // pool account and retries ONCE, BEFORE the throw reaches tier-failover.
+      const rotated = await this.rotateOnLimit(err);
+      if (rotated) {
+        try {
+          return await this.runTurn(body, mode, rotated);
+        } catch (retryErr) {
+          this.dispose();
+          // The replacement limited too — record it, then fall to the next tier.
+          if (this.rotator && isAccountLimitError(retryErr)) {
+            await this.rotator.markLimited(
+              rotated,
+              retryErr instanceof Error ? retryErr.message : String(retryErr)
+            );
+          }
+          throw retryErr instanceof Error
+            ? retryErr
+            : new Error(`[cli-inference:codex-sdk] ${String(retryErr)}`);
+        }
+      }
       throw err instanceof Error ? err : new Error(`[cli-inference:codex-sdk] ${String(err)}`);
     }
+  }
+
+  /**
+   * Run one turn, starting the warm thread if needed — optionally pinned to a
+   * pre-selected account (the rotate-on-limit retry).
+   */
+  private async runTurn(
+    body: string,
+    mode: "text" | "route",
+    account?: ChatAccountSelection | null
+  ): Promise<string> {
+    if (!this.thread) {
+      await this.start(account);
+    }
+    this.turns += 1;
+    const thread = this.thread;
+    if (!thread) throw new Error("[cli-inference:codex-sdk] thread not started");
+    // ROUTE: constrain output to {action, params:json-string} via the codex
+    // native output schema (reliable shape; needs the system codex binary).
+    const turn = await thread.run(
+      body,
+      mode === "route" ? { outputSchema: ROUTE_OUTPUT_SCHEMA } : undefined
+    );
+    const text = turnToText(turn);
+    if (mode === "route") {
+      return this.normalizeRoute(text);
+    }
+    if (!text) {
+      throw new Error("[cli-inference:codex-sdk] empty completion");
+    }
+    return text;
+  }
+
+  /**
+   * On a limit-classed failure: record the limit (+ parsed reset) against the
+   * serving account and pick the next healthy one (breaking pool session
+   * affinity via `exclude`). Returns the replacement selection, or null when
+   * rotation is impossible — no rotator, non-limit error, or the pool has no
+   * other healthy account — in which case the caller throws so `useModel`
+   * falls to the next model TIER (the pre-existing behavior).
+   */
+  private async rotateOnLimit(err: unknown): Promise<ChatAccountSelection | null> {
+    if (!this.rotator || !isAccountLimitError(err)) return null;
+    const limited = this.account;
+    const detail = err instanceof Error ? err.message : String(err);
+    if (limited) await this.rotator.markLimited(limited, detail);
+    const next = await this.rotator.select(limited ? [limited.accountId] : undefined);
+    if (!next) {
+      if (limited) {
+        logger.warn(
+          `[cli-inference:codex-sdk] account "${limited.label}" hit its limit and no other healthy account is available — failing over to the next model tier`
+        );
+      }
+      return null;
+    }
+    logger.info(
+      `[cli-inference:codex-sdk] rotating chat brain from ${limited ? `account "${limited.label}"` : "ambient credentials"} to account "${next.label}" after a subscription limit`
+    );
+    return next;
   }
 
   /** Coerce the structured-output JSON into a bare {action, params} string. */
@@ -257,11 +339,28 @@ export class CodexSdkSession {
     });
   }
 
-  private async start(): Promise<void> {
+  private async start(account?: ChatAccountSelection | null): Promise<void> {
+    // Pin a pool account for this warm thread. Re-selected on every (re)start
+    // so a restarted thread gets fresh account credentials; pool
+    // session-affinity keeps the account stable across restarts. When no
+    // pool/bridge exists this resolves null and the subprocess inherits the
+    // ambient creds (~/.codex) exactly as before.
+    this.account = account !== undefined ? account : ((await this.rotator?.select()) ?? null);
     const { Codex } = this.codexOverride ?? (await loadCodex());
     // Drive the system codex binary (not the SDK's bundled-and-often-stale one)
     // when a path is configured, so current models work.
-    const codex = new Codex(this.codexBinPath ? { codexPathOverride: this.codexBinPath } : {});
+    const codexOptions: Record<string, unknown> = {};
+    if (this.codexBinPath) codexOptions.codexPathOverride = this.codexBinPath;
+    if (this.account) {
+      // Authenticate the codex subprocess AS the selected pool account (its
+      // per-account CODEX_HOME). The credential flows ONLY into this subprocess
+      // env — never into the runtime's own process.env (TOS invariant,
+      // mirroring coding-account-bridge). `env` REPLACES the subprocess
+      // environment, so the helper spreads process.env (PATH/HOME survive) and
+      // drops competing ambient auth vars first.
+      codexOptions.env = buildRotatedSubprocessEnv("codex", this.account.envPatch);
+    }
+    const codex = new Codex(codexOptions);
     // Pure inference: read-only, no network, no approvals, no git-repo coupling —
     // a warm completion engine, not a coding agent.
     const options: Record<string, unknown> = {


### PR DESCRIPTION
[core-brain]

Closes the **Gap A half of #11180** (chat brain never rotates accounts). Part of the FLAWLESS drive (#11157).

## Problem

The AccountPool publishes selector bridges (`account-pool.ts` / `coding-account-bridge.ts`), but the **chat brain had zero consumers**: the warm `claude-sdk` / `codex-sdk` sessions in `plugin-cli-inference` authenticate from ambient credentials (`~/.claude` / `CLAUDE_CODE_OAUTH_TOKEN` / `~/.codex`), and on a subscription-limit throw (`isClaudeSubscriptionLimitMessage`) the session fails straight to the next model **tier** — never to the next **account**. A user with N linked Claude/Codex accounts still stalls the brain the moment account #1 limits. Coding agents already rotate (via `coding-account-bridge`); chat did not.

## Fix

New `src/chat-account-rotation.ts` + rotation hooks in both warm SDK sessions:

- **Bridge consumption stays core-only.** The plugin reads the account-selector bridge off the `globalThis` symbol `eliza.account-pool.coding-agent.v1` — the same pattern (and the same bridge family) the orchestrator's `coding-account-selection.ts` uses — never importing app-core. The bare `subscription-selector.v1` bridge (`pickAccountId` only) cannot materialize subprocess env or record health, so the sessions consume the richer selector that `getDefaultAccountPool()` installs alongside it.
- **Select at session start.** Every warm (re)start pins a pool account and injects its env into the **SDK subprocess only**: claude → `CLAUDE_CODE_OAUTH_TOKEN` via `query options.env`, codex → per-account `CODEX_HOME` via `new Codex({env})`. Re-selecting on every restart keeps injected tokens fresh (they cannot refresh themselves mid-run); pool session-affinity keeps the account stable.
- **Rotate on the limit-classed throw, BEFORE tier-failover.** On a limit-classed error (conservative classifier, same bar as the orchestrator's `classifyAccountFailure`): record the limit + parsed reset into pool health (`markRateLimited`, epoch parsed from the classic `…|<epoch>` envelope, 15-min cool-off floor otherwise; the pool's authoritative `usage.resetsAt` wins when present), pick the next healthy account **excluding the limited one** (this breaks session affinity so it re-picks), restart the warm session on the new credentials, and retry **exactly once**. If the retry also limits, that account is recorded too and the error propagates.
- **Tier-failover only when the pool returns null** (all accounts limited / no pool) — the pre-existing behavior is byte-identical when no bridge or no pooled accounts exist.
- **TOS invariant mirrored from `coding-account-bridge.ts`:** the subscription token flows ONLY into the SDK subprocess env. `buildRotatedSubprocessEnv` is pure — it spreads `process.env` (both SDKs REPLACE the subprocess env when `env` is set, so PATH/HOME must survive), drops competing ambient auth vars (`CLAUDE_CODE_OAUTH_TOKEN`/`ANTHROPIC_API_KEY`, `CODEX_HOME`/`OPENAI_API_KEY`) so the selected account always wins, and never touches the runtime's own `process.env`.

## Evidence

- **89/89 tests pass** (`bun run --cwd plugins/plugin-cli-inference test`): 70 pre-existing + **19 new** against a mocked multi-account bridge/rotator:
  - rotate-on-limit picks the next healthy account and retries once (claude TEXT + ROUTE modes, codex);
  - the limited account is recorded (`markRateLimited` with parsed reset) **before** any failover;
  - tier-failover fires **only** when the pool is exhausted (select-with-exclude returns null);
  - the single-retry bound holds when the replacement also limits (no rotation loop; third account never touched);
  - non-limit failures (mid-turn death, timeouts, 400s) never rotate or evict;
  - no pool/bridge → byte-identical pre-existing behavior (no `env` option at all);
  - **token never leaks into `process.env`** (asserted after the full rotation flow, both backends).
- **Typecheck clean** (`tsgo --noEmit`), **Biome clean on all touched files** (the one formatter diff in `subscription-limit.test.ts` is pre-existing on develop and left untouched).
- Real-LLM trajectory for the rotation moment: **N/A for now** — live verification needs a second linked subscription account, which this environment doesn't have yet (noted in #11180); the rotation contract is fully proven with the mocked bridge, and single-account live behavior is unchanged (default rotator no-ops without a pool). Live multi-account verification is pending a 2nd account.

## Notes for reviewers

- `plugins/plugin-cli-inference/src/chat-account-rotation.ts` is the whole new surface; the session diffs are the select-at-start env injection + the rotate-retry arm in `sendOnce`.
- The cold `claude` / `codex` CLI backends (per-call spawn) still use the single on-disk cred set — that half is Gap B in #11180 (the CLI-external rotation shim), tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)