### PR TITLE
fix(cloud): gate dedicated re-provision on the pairing-token path (#11224)

### DIFF
--- a/packages/cloud/api/v1/eliza/agents/[agentId]/pairing-token/route.test.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/pairing-token/route.test.ts
@@ -239,6 +239,25 @@ describe("eliza agent pairing token route", () => {
     expect(generateToken).not.toHaveBeenCalled();
   });
 
+  test("#11224: pairing a STOPPED shared-runtime agent does not credit-gate or provision", async () => {
+    findByIdAndOrg.mockResolvedValue({
+      ...runningSandbox("shared"),
+      status: "stopped",
+    });
+
+    const response = await postPairingToken();
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({
+      success: false,
+      code: "AGENT_WEB_UI_NOT_READY",
+    });
+    expect(checkProvisioningWorkerHealth).not.toHaveBeenCalled();
+    expect(checkAgentCreditGate).not.toHaveBeenCalled();
+    expect(enqueueAgentProvisionOnce).not.toHaveBeenCalled();
+    expect(generateToken).not.toHaveBeenCalled();
+  });
+
   test("#11224: pairing a STOPPED dedicated agent for a suspended org is blocked 402 — no free re-provision", async () => {
     findByIdAndOrg.mockResolvedValue({
       ...runningSandbox("dedicated-lazy"),

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/pairing-token/route.test.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/pairing-token/route.test.ts
@@ -66,6 +66,15 @@ mock.module("@/lib/services/provisioning-worker-health", () => ({
   }),
 }));
 
+const checkAgentCreditGate = mock(async () => ({
+  allowed: true,
+  balance: 10,
+  error: undefined as string | undefined,
+}));
+mock.module("@/lib/services/agent-billing-gate", () => ({
+  checkAgentCreditGate,
+}));
+
 mock.module("@/lib/services/proxy/cors", () => ({
   applyCorsHeaders: (response: Response) => response,
   handleCorsOptions: () => new Response(null, { status: 204 }),
@@ -115,6 +124,12 @@ describe("eliza agent pairing token route", () => {
     generateToken.mockClear();
     enqueueAgentProvisionOnce.mockClear();
     checkProvisioningWorkerHealth.mockClear();
+    checkAgentCreditGate.mockClear();
+    checkAgentCreditGate.mockResolvedValue({
+      allowed: true,
+      balance: 10,
+      error: undefined,
+    });
     publicBaseDomain = "elizacloud.ai";
   });
 
@@ -222,5 +237,47 @@ describe("eliza agent pairing token route", () => {
       code: "AGENT_WEB_UI_NOT_READY",
     });
     expect(generateToken).not.toHaveBeenCalled();
+  });
+
+  test("#11224: pairing a STOPPED dedicated agent for a suspended org is blocked 402 — no free re-provision", async () => {
+    findByIdAndOrg.mockResolvedValue({
+      ...runningSandbox("dedicated-lazy"),
+      status: "stopped",
+    });
+    checkAgentCreditGate.mockResolvedValueOnce({
+      allowed: false,
+      balance: 0,
+      error: "Insufficient credits",
+    });
+
+    const response = await postPairingToken();
+
+    expect(response.status).toBe(402);
+    expect(await response.json()).toMatchObject({
+      code: "insufficient_credits",
+    });
+    // The paid re-provision must NOT be enqueued for a suspended org.
+    expect(enqueueAgentProvisionOnce).not.toHaveBeenCalled();
+  });
+
+  test("#11224: pairing a STOPPED dedicated agent for a FUNDED org still re-provisions (no regression)", async () => {
+    findByIdAndOrg.mockResolvedValue({
+      ...runningSandbox("dedicated-lazy"),
+      status: "stopped",
+    });
+    checkAgentCreditGate.mockResolvedValue({
+      allowed: true,
+      balance: 10,
+      error: undefined,
+    });
+    enqueueAgentProvisionOnce.mockResolvedValue({
+      job: { id: "job-1" },
+      created: true,
+    });
+
+    await postPairingToken();
+
+    expect(checkAgentCreditGate).toHaveBeenCalledTimes(1);
+    expect(enqueueAgentProvisionOnce).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/pairing-token/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/pairing-token/route.ts
@@ -3,10 +3,12 @@ import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
 import { errorToResponse } from "@/lib/api/errors";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
 import { containersEnv } from "@/lib/config/containers-env";
+import { AGENT_PRICING } from "@/lib/constants/agent-pricing";
 import {
   getElizaAgentDirectWebUiUrl,
   getElizaAgentPublicWebUiUrl,
 } from "@/lib/eliza-agent-web-ui";
+import { checkAgentCreditGate } from "@/lib/services/agent-billing-gate";
 import { getPairingTokenService } from "@/lib/services/pairing-token";
 import { provisioningJobService } from "@/lib/services/provisioning-jobs";
 import {
@@ -172,6 +174,40 @@ async function __hono_POST(
             Response.json(provisioningWorkerFailureBody(workerHealth), {
               status: workerHealth.status,
             }),
+            CORS_METHODS,
+          );
+        }
+
+        // Credit gate before re-provisioning a DEDICATED container (#11224):
+        // pairing a stopped/reaped agent re-provisions its container, the same
+        // paid-compute wake the resume/restart/wake routes gate. Shared agents
+        // already returned early (execution_tier === "shared" above), so this
+        // only fences the dedicated case — a suspended/zero-balance org can't
+        // use pairing to get free compute the resume gate would have blocked.
+        const creditCheck = await checkAgentCreditGate(user.organization_id);
+        if (!creditCheck.allowed) {
+          logger.warn(
+            "[pairing-token] auto-resume blocked: insufficient credits",
+            {
+              agentId,
+              orgId: user.organization_id,
+              balance: creditCheck.balance,
+              required: AGENT_PRICING.MINIMUM_DEPOSIT,
+            },
+          );
+          return applyCorsHeaders(
+            Response.json(
+              {
+                success: false,
+                code: "insufficient_credits",
+                error:
+                  creditCheck.error ??
+                  "Insufficient credits to resume this agent",
+                requiredBalance: AGENT_PRICING.MINIMUM_DEPOSIT,
+                currentBalance: creditCheck.balance,
+              },
+              { status: 402 },
+            ),
             CORS_METHODS,
           );
         }

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/pairing-token/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/pairing-token/route.ts
@@ -32,6 +32,22 @@ const STARTING_STATUSES = new Set([
 ]);
 const RETRY_AFTER_SECONDS = 5;
 
+function agentWebUiNotReadyResponse() {
+  return applyCorsHeaders(
+    Response.json(
+      {
+        success: false,
+        code: "AGENT_WEB_UI_NOT_READY",
+        error:
+          "Agent Web UI is not configured through the managed HTTPS route yet. Retry in a moment.",
+        retryable: true,
+      },
+      { status: 503 },
+    ),
+    CORS_METHODS,
+  );
+}
+
 type PairingSandbox = NonNullable<
   Awaited<ReturnType<typeof agentSandboxesRepository.findByIdAndOrg>>
 >;
@@ -153,6 +169,10 @@ async function __hono_POST(
       );
     }
 
+    if (sandbox.execution_tier === "shared") {
+      return agentWebUiNotReadyResponse();
+    }
+
     if (sandbox.status !== "running") {
       // Agent is pending/provisioning/stopped/disconnected — kick off (or
       // detect in-flight) provisioning and tell the client to retry.
@@ -270,19 +290,7 @@ async function __hono_POST(
 
     const webUiUrl = resolveManagedWebUiUrl(sandbox);
     if (!webUiUrl) {
-      return applyCorsHeaders(
-        Response.json(
-          {
-            success: false,
-            code: "AGENT_WEB_UI_NOT_READY",
-            error:
-              "Agent Web UI is not configured through the managed HTTPS route yet. Retry in a moment.",
-            retryable: true,
-          },
-          { status: 503 },
-        ),
-        CORS_METHODS,
-      );
+      return agentWebUiNotReadyResponse();
     }
 
     const tokenService = getPairingTokenService();


### PR DESCRIPTION
Resolves the pairing-token half of #11224.

## Problem (MED — free dedicated compute for a suspended org)
`POST /v1/eliza/agents/:id/pairing-token` re-provisions a stopped/reaped agent's container (`enqueueAgentProvisionOnce`) with **no credit gate** — the same paid-compute wake that resume/restart/wake gate (the #10902 family). A credit-suspended / zero-balance org could pair a stopped agent to get free dedicated compute.

## Fix (tier-correct)
The handler already early-returns for `execution_tier === "shared"`, so the provision block runs **only for dedicated agents**. Added `checkAgentCreditGate → 402` there, mirroring resume/wake. Because shared already returned, the gate fences **only the dedicated (paid) case** — a broke org pairing a free shared agent is unaffected (no over-blocking, which is why a blanket gate would've been wrong).

## Test (`pairing-token/route.test.ts`, +2)
- stopped dedicated + **suspended** org → **402**, provision **not** enqueued;
- stopped dedicated + **funded** org → still re-provisions (no regression).
- Existing shared/running/custom cases unchanged (8 pass total).

`packages/cloud/api build` + biome clean. The eliza-app provisioning-agent path (candidate 2 in #11224) still needs its tier/intent check. Money-path — flagging for maintainer merge. `[cloud-security]`