### PR TITLE
feat(cli-inference): rotate to next pooled account on subscription limit before failover (#11180 Gap A)

### DIFF
--- a/plugins/plugin-cli-inference/AGENTS.md
+++ b/plugins/plugin-cli-inference/AGENTS.md
@@ -179,7 +179,7 @@ bun run --cwd plugins/plugin-cli-inference build
 - **Isolated cwd per call.** Created with `mkdtemp` under `tmpdir()`, validated by `resolveSafeCwd`, removed in a `finally`. Keeps the CLI out of real projects (suppresses Claude Code repo-context identity).
 - **`/dev/null` stdin is REQUIRED** — without it the CLI waits ~3s for stdin.
 - **sandbox.ts is a copy.** Keep in sync with `packages/plugin-remote-manifest/src/sub-agent-claude-code/sandbox.ts` if `SENSITIVE_ENV_RE` / `SAFE_ENV_KEYS` change upstream.
-- **Multi-account/AccountPool failover is OUT of v1** — the CLI owns one on-disk cred set. Single-token chat-inference is a documented gap.
+- **Multi-account rotation (SDK backends only).** On a subscription-limit throw the `claude-sdk` / `codex-sdk` chat brain rotates to the next healthy pooled account (via the `eliza.account-pool.coding-agent.v1` bridge, in `src/account-rotation.ts`) before falling to provider failover — see issue #11180. Rotation applies the pool's env patch (`CLAUDE_CODE_OAUTH_TOKEN` / per-account `CODEX_HOME`) to `process.env`, evicts the warm session so it re-auths as the new account, and retries transparently. Only rate-limit-class errors rotate; non-limit errors rethrow straight to failover. Default ON when a pool is present; opt out with `ELIZA_CLI_INFERENCE_ACCOUNT_ROTATION=0`. The COLD `claude --print` / `codex exec` CLIs still own one on-disk cred set (rotation is SDK-only; the bare-CLI shim is issue #11180 Gap B).
 - See the root `AGENTS.md` for repo-wide architecture rules, logger conventions, and ESM requirements.
 
 <!-- BEGIN: evidence-and-e2e-mandate (managed; canonical standard = repo-root PR_EVIDENCE.md) -->

--- a/plugins/plugin-cli-inference/CLAUDE.md
+++ b/plugins/plugin-cli-inference/CLAUDE.md
@@ -179,7 +179,7 @@ bun run --cwd plugins/plugin-cli-inference build
 - **Isolated cwd per call.** Created with `mkdtemp` under `tmpdir()`, validated by `resolveSafeCwd`, removed in a `finally`. Keeps the CLI out of real projects (suppresses Claude Code repo-context identity).
 - **`/dev/null` stdin is REQUIRED** — without it the CLI waits ~3s for stdin.
 - **sandbox.ts is a copy.** Keep in sync with `packages/plugin-remote-manifest/src/sub-agent-claude-code/sandbox.ts` if `SENSITIVE_ENV_RE` / `SAFE_ENV_KEYS` change upstream.
-- **Multi-account/AccountPool failover is OUT of v1** — the CLI owns one on-disk cred set. Single-token chat-inference is a documented gap.
+- **Multi-account rotation (SDK backends only).** On a subscription-limit throw the `claude-sdk` / `codex-sdk` chat brain rotates to the next healthy pooled account (via the `eliza.account-pool.coding-agent.v1` bridge, in `src/account-rotation.ts`) before falling to provider failover — see issue #11180. Rotation applies the pool's env patch (`CLAUDE_CODE_OAUTH_TOKEN` / per-account `CODEX_HOME`) to `process.env`, evicts the warm session so it re-auths as the new account, and retries transparently. Only rate-limit-class errors rotate; non-limit errors rethrow straight to failover. Default ON when a pool is present; opt out with `ELIZA_CLI_INFERENCE_ACCOUNT_ROTATION=0`. The COLD `claude --print` / `codex exec` CLIs still own one on-disk cred set (rotation is SDK-only; the bare-CLI shim is issue #11180 Gap B).
 - See the root `AGENTS.md` for repo-wide architecture rules, logger conventions, and ESM requirements.
 
 <!-- BEGIN: evidence-and-e2e-mandate (managed; canonical standard = repo-root PR_EVIDENCE.md) -->

--- a/plugins/plugin-cli-inference/__tests__/account-rotation.test.ts
+++ b/plugins/plugin-cli-inference/__tests__/account-rotation.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  isSubscriptionLimitError,
+  type RotationAccountSelection,
+  rotationAgentTypeForBackend,
+  rotationEnabled,
+  withAccountRotation,
+} from "../src/account-rotation";
+import { ProviderApiError } from "../src/provider-errors";
+
+/**
+ * Issue #11180 Gap A: the chat brain must rotate to the next healthy pooled
+ * account on a subscription limit, and ONLY on a subscription limit — a non-limit
+ * error must fall straight through to the caller's provider-failover chain.
+ *
+ * These drive the pure rotation logic with a FAKE coding-agent selector bridge
+ * installed on the `globalThis` symbol (the real bridge lives in app-core; the
+ * plugin only reads the contract off the symbol). No real pool, no real SDK, no
+ * second live account needed to prove the logic — exactly as the issue's test
+ * plan requires.
+ */
+
+const BRIDGE_SYMBOL = Symbol.for("eliza.account-pool.coding-agent.v1");
+
+interface FakeBridge {
+  select: ReturnType<typeof vi.fn>;
+  markRateLimited: ReturnType<typeof vi.fn>;
+  recordUsage: ReturnType<typeof vi.fn>;
+}
+
+function installFakeBridge(selections: Array<RotationAccountSelection | null>): FakeBridge {
+  let i = 0;
+  const bridge: FakeBridge = {
+    select: vi.fn(async () => {
+      const next = i < selections.length ? selections[i] : null;
+      i += 1;
+      return next;
+    }),
+    markRateLimited: vi.fn(async () => undefined),
+    recordUsage: vi.fn(async () => undefined),
+  };
+  (globalThis as Record<symbol, unknown>)[BRIDGE_SYMBOL] = bridge;
+  return bridge;
+}
+
+function uninstallBridge(): void {
+  delete (globalThis as Record<symbol, unknown>)[BRIDGE_SYMBOL];
+}
+
+function account(id: string): RotationAccountSelection {
+  return {
+    providerId: "anthropic-subscription",
+    accountId: id,
+    label: id,
+    source: "oauth",
+    strategy: "least-used",
+    envPatch: { CLAUDE_CODE_OAUTH_TOKEN: `tok-${id}` },
+  };
+}
+
+const enabledGetter = () => undefined;
+
+afterEach(() => {
+  uninstallBridge();
+  vi.restoreAllMocks();
+});
+
+describe("isSubscriptionLimitError", () => {
+  it("classifies the session handler's own limit throw", () => {
+    expect(
+      isSubscriptionLimitError(
+        new Error(
+          "[cli-inference:sdk] subscription rate limit reached: You've hit your session limit"
+        )
+      )
+    ).toBe(true);
+  });
+
+  it("classifies 429 / 529 status envelopes", () => {
+    expect(
+      isSubscriptionLimitError(new ProviderApiError("upstream API Error: 429", { statusCode: 429 }))
+    ).toBe(true);
+    expect(
+      isSubscriptionLimitError(new ProviderApiError("upstream API Error: 529", { statusCode: 529 }))
+    ).toBe(true);
+    expect(isSubscriptionLimitError(new Error("API Error: 429 rate limited"))).toBe(true);
+  });
+
+  it("classifies provider quota / rate-limit vocabulary", () => {
+    expect(isSubscriptionLimitError(new Error("usage limit reached"))).toBe(true);
+    expect(isSubscriptionLimitError(new Error("quota exhausted for this key"))).toBe(true);
+    expect(isSubscriptionLimitError(new Error("too many requests"))).toBe(true);
+  });
+
+  it("does NOT classify non-limit errors (would burn a healthy account)", () => {
+    expect(
+      isSubscriptionLimitError(new Error("[cli-inference:sdk] empty completion (subtype=success)"))
+    ).toBe(false);
+    expect(
+      isSubscriptionLimitError(
+        new ProviderApiError("API Error: 400 messages: text content blocks must be non-empty", {
+          statusCode: 400,
+        })
+      )
+    ).toBe(false);
+    expect(isSubscriptionLimitError(new Error("401 unauthorized"))).toBe(false);
+    expect(isSubscriptionLimitError(new Error("route: model emitted no decision"))).toBe(false);
+  });
+});
+
+describe("rotationAgentTypeForBackend", () => {
+  it("maps only the SDK backends to a rotation agent type", () => {
+    expect(rotationAgentTypeForBackend("claude-sdk")).toBe("claude");
+    expect(rotationAgentTypeForBackend("codex-sdk")).toBe("codex");
+    // Cold CLIs read the single on-disk login — out of scope (Gap B / CLI shim).
+    expect(rotationAgentTypeForBackend("claude")).toBeNull();
+    expect(rotationAgentTypeForBackend("codex")).toBeNull();
+  });
+});
+
+describe("rotationEnabled", () => {
+  it("defaults ON and honors the opt-out flag", () => {
+    expect(rotationEnabled(() => undefined)).toBe(true);
+    expect(rotationEnabled(() => "1")).toBe(true);
+    for (const off of ["0", "false", "no", "off", "OFF", " Off "]) {
+      expect(rotationEnabled(() => off)).toBe(false);
+    }
+  });
+});
+
+describe("withAccountRotation", () => {
+  const ctx = (overrides: Record<string, unknown> = {}) => ({
+    backend: "claude-sdk",
+    getValue: enabledGetter,
+    onRotate: vi.fn(),
+    ...overrides,
+  });
+
+  it("passes success straight through with no rotation", async () => {
+    const bridge = installFakeBridge([account("b")]);
+    const attempt = vi.fn(async () => "hello");
+    const c = ctx();
+    await expect(withAccountRotation(attempt, c as never)).resolves.toBe("hello");
+    expect(attempt).toHaveBeenCalledTimes(1);
+    expect(bridge.select).not.toHaveBeenCalled();
+    expect(c.onRotate).not.toHaveBeenCalled();
+  });
+
+  it("rotates on a subscription-limit error then succeeds on the next account", async () => {
+    const bridge = installFakeBridge([account("b")]);
+    let calls = 0;
+    const attempt = vi.fn(async () => {
+      calls += 1;
+      if (calls === 1) throw new Error("subscription rate limit reached: session limit");
+      return "answer-on-account-b";
+    });
+    const c = ctx();
+    await expect(withAccountRotation(attempt, c as never)).resolves.toBe("answer-on-account-b");
+    expect(attempt).toHaveBeenCalledTimes(2);
+    expect(bridge.select).toHaveBeenCalledTimes(1);
+    // Selected account b's token was applied so the fresh session re-auths as it.
+    expect(process.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("tok-b");
+    // The warm session bound to the limited account was torn down before retry.
+    expect(c.onRotate).toHaveBeenCalledTimes(1);
+    // Usage recorded against the account we rotated INTO on success.
+    expect(bridge.recordUsage).toHaveBeenCalledWith("anthropic-subscription", "b", { ok: true });
+  });
+
+  it("does NOT rotate on a non-limit error — rethrows immediately to failover", async () => {
+    const bridge = installFakeBridge([account("b")]);
+    const attempt = vi.fn(async () => {
+      throw new Error("[cli-inference:sdk] empty completion (subtype=success)");
+    });
+    const c = ctx();
+    await expect(withAccountRotation(attempt, c as never)).rejects.toThrow("empty completion");
+    expect(attempt).toHaveBeenCalledTimes(1);
+    expect(bridge.select).not.toHaveBeenCalled();
+    expect(c.onRotate).not.toHaveBeenCalled();
+  });
+
+  it("excludes already-tried accounts and rotates through several before succeeding", async () => {
+    const bridge = installFakeBridge([account("b"), account("c")]);
+    let calls = 0;
+    const attempt = vi.fn(async () => {
+      calls += 1;
+      if (calls <= 2) throw new Error("429 too many requests");
+      return "answer-on-account-c";
+    });
+    await expect(withAccountRotation(attempt, ctx() as never)).resolves.toBe("answer-on-account-c");
+    expect(attempt).toHaveBeenCalledTimes(3);
+    expect(bridge.select).toHaveBeenCalledTimes(2);
+    // Second select excludes the first rotated-into account (b).
+    expect(bridge.select.mock.calls[1][1].exclude).toContain("b");
+  });
+
+  it("falls through to provider failover (rethrows) when the pool is exhausted", async () => {
+    const bridge = installFakeBridge([account("b"), null]);
+    const attempt = vi.fn(async () => {
+      throw new Error("subscription rate limit reached: session limit");
+    });
+    // First limit → rotate to b; b limits too → select returns null → rethrow.
+    await expect(withAccountRotation(attempt, ctx() as never)).rejects.toThrow(
+      "subscription rate limit reached"
+    );
+    expect(bridge.select).toHaveBeenCalledTimes(2);
+    // The rotated-into account b was marked rate-limited when it also limited.
+    expect(bridge.markRateLimited).toHaveBeenCalledWith(
+      "anthropic-subscription",
+      "b",
+      expect.any(Number),
+      expect.any(String)
+    );
+  });
+
+  it("single-account no-op: no bridge installed → single un-wrapped attempt, throw to failover", async () => {
+    uninstallBridge();
+    const attempt = vi.fn(async () => {
+      throw new Error("subscription rate limit reached: session limit");
+    });
+    const c = ctx();
+    await expect(withAccountRotation(attempt, c as never)).rejects.toThrow(
+      "subscription rate limit reached"
+    );
+    expect(attempt).toHaveBeenCalledTimes(1);
+    expect(c.onRotate).not.toHaveBeenCalled();
+  });
+
+  it("does not rotate when disabled via the opt-out flag", async () => {
+    const bridge = installFakeBridge([account("b")]);
+    const attempt = vi.fn(async () => {
+      throw new Error("subscription rate limit reached: session limit");
+    });
+    const c = ctx({ getValue: () => "0" });
+    await expect(withAccountRotation(attempt, c as never)).rejects.toThrow(
+      "subscription rate limit reached"
+    );
+    expect(attempt).toHaveBeenCalledTimes(1);
+    expect(bridge.select).not.toHaveBeenCalled();
+  });
+
+  it("non-rotatable backend (cold CLI) is a pass-through no-op", async () => {
+    const bridge = installFakeBridge([account("b")]);
+    const attempt = vi.fn(async () => {
+      throw new Error("subscription rate limit reached: session limit");
+    });
+    const c = ctx({ backend: "claude" });
+    await expect(withAccountRotation(attempt, c as never)).rejects.toThrow(
+      "subscription rate limit reached"
+    );
+    expect(attempt).toHaveBeenCalledTimes(1);
+    expect(bridge.select).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-cli-inference/index.ts
+++ b/plugins/plugin-cli-inference/index.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import type { GenerateTextParams, IAgentRuntime, Plugin } from "@elizaos/core";
 import { logger, ModelType } from "@elizaos/core";
+import { rotationEnabled, withAccountRotation } from "./src/account-rotation";
 import { ClaudeCli } from "./src/claude-cli";
 import { ClaudeSdkSession } from "./src/claude-sdk-session";
 import {
@@ -137,13 +138,30 @@ function shortHash(value: string): string {
  * `router=true` builds a native `route_action` MCP-tool session (the planner);
  * `router=false` builds a plain text-generation session (reply/large tiers).
  */
+function claudeSessionKey(model: string, systemPrompt: string, router: boolean): string {
+  return `${model}\u001f${router ? "route" : "text"}\u001f${shortHash(systemPrompt)}`;
+}
+
+/**
+ * Evict + dispose a warm Claude SDK session by its cache key so the NEXT
+ * `getSdkSession` for that key spins up a fresh process — which re-reads the
+ * (rotated) `CLAUDE_CODE_OAUTH_TOKEN` / `~/.claude` credential. Used by account
+ * rotation after a subscription limit. Best-effort: dispose is fire-and-forget.
+ */
+function evictSdkSession(key: string): void {
+  const existing = sdkSessions.get(key);
+  if (!existing) return;
+  sdkSessions.delete(key);
+  void existing.dispose();
+}
+
 function getSdkSession(
   runtime: IAgentRuntime,
   model: string,
   systemPrompt: string,
   router: boolean
 ): ClaudeSdkSession {
-  const key = `${model}\u001f${router ? "route" : "text"}\u001f${shortHash(systemPrompt)}`;
+  const key = claudeSessionKey(model, systemPrompt, router);
   const existing = sdkSessions.get(key);
   if (existing) {
     // Mark most-recently-used: delete + re-insert moves it to the Map's tail.
@@ -198,13 +216,29 @@ function resolveCodexModel(runtime: IAgentRuntime, modelType: string): string {
   return ((isSmallTier ? small : large) || large || "gpt-5.5").trim();
 }
 
+function codexSessionKey(model: string, router: boolean): string {
+  return `${model}\u001f${router ? "route" : "text"}`;
+}
+
+/**
+ * Evict + dispose a warm Codex SDK thread by its cache key so the next
+ * `getCodexSdkSession` re-starts it — re-reading the (rotated) per-account
+ * `CODEX_HOME`. Used by account rotation after a subscription limit.
+ */
+function evictCodexSdkSession(key: string): void {
+  const existing = codexSdkSessions.get(key);
+  if (!existing) return;
+  codexSdkSessions.delete(key);
+  existing.dispose();
+}
+
 /** Lazily create + cache a warm Codex SDK thread for a (model, mode). */
 function getCodexSdkSession(
   runtime: IAgentRuntime,
   model: string,
   router: boolean
 ): CodexSdkSession {
-  const key = `${model}\u001f${router ? "route" : "text"}`;
+  const key = codexSessionKey(model, router);
   let session = codexSdkSessions.get(key);
   if (!session) {
     session = new CodexSdkSession({
@@ -274,7 +308,19 @@ async function generateViaCli(
     // 2/4). Keying by the framed system keeps one warm process per tier.
     const framedSystem = frameTextSystemPrompt(system);
     const framedBody = appendTextDirective(body);
-    return getSdkSession(runtime, model, framedSystem, false).generate(framedBody);
+    const key = claudeSessionKey(model, framedSystem, false);
+    // On a subscription limit, rotate to the next healthy pooled Claude account
+    // (evicting the warm session so it re-auths as the new account), then retry;
+    // fall through to provider failover only when the pool is exhausted.
+    return withAccountRotation(
+      () => getSdkSession(runtime, model, framedSystem, false).generate(framedBody),
+      {
+        backend,
+        getValue: (k) => getSetting(runtime, k),
+        sessionKey: `cli-inference:${key}`,
+        onRotate: () => evictSdkSession(key),
+      }
+    );
   }
   if (backend === "codex-sdk") {
     // Warm Codex SDK thread. codex-sdk folds the system into the body, so frame
@@ -282,7 +328,16 @@ async function generateViaCli(
     const model = resolveCodexModel(runtime, modelType);
     const { system, body } = flattenPrompt(generateParams);
     const framedBody = appendTextDirective(`${frameTextSystemPrompt(system)}\n\n${body}`);
-    return getCodexSdkSession(runtime, model, false).generate(framedBody);
+    const key = codexSessionKey(model, false);
+    return withAccountRotation(
+      () => getCodexSdkSession(runtime, model, false).generate(framedBody),
+      {
+        backend,
+        getValue: (k) => getSetting(runtime, k),
+        sessionKey: `cli-inference:${key}`,
+        onRotate: () => evictCodexSdkSession(key),
+      }
+    );
   }
   const cli = backend === "claude" ? buildClaude(runtime) : buildCodex(runtime);
   return cli.generate(generateParams);
@@ -315,8 +370,17 @@ async function planViaCli(runtime: IAgentRuntime, params: GenerateTextParams): P
   });
   if (backend === "claude-sdk") {
     const model = resolveSdkModel(runtime, ModelType.ACTION_PLANNER);
-    const session = getSdkSession(runtime, model, ROUTER_SYSTEM_PROMPT, true);
-    return session.route(buildRouterBody(params));
+    const routerBody = buildRouterBody(params);
+    const key = claudeSessionKey(model, ROUTER_SYSTEM_PROMPT, true);
+    return withAccountRotation(
+      () => getSdkSession(runtime, model, ROUTER_SYSTEM_PROMPT, true).route(routerBody),
+      {
+        backend,
+        getValue: (k) => getSetting(runtime, k),
+        sessionKey: `cli-inference:${key}`,
+        onRotate: () => evictSdkSession(key),
+      }
+    );
   }
   if (backend === "codex-sdk") {
     // codex routes via NATIVE structured output (outputSchema) for a reliable
@@ -324,9 +388,15 @@ async function planViaCli(runtime: IAgentRuntime, params: GenerateTextParams): P
     // persona) is folded into the body (codex-sdk has no thread-level system
     // prompt); the session applies the schema + parses the result.
     const model = resolveCodexModel(runtime, ModelType.ACTION_PLANNER);
-    const session = getCodexSdkSession(runtime, model, true);
     const clean = buildCleanRoutingParams(params);
-    return session.route(`${clean.system ?? ""}\n\n${clean.prompt ?? ""}`);
+    const routeBody = `${clean.system ?? ""}\n\n${clean.prompt ?? ""}`;
+    const key = codexSessionKey(model, true);
+    return withAccountRotation(() => getCodexSdkSession(runtime, model, true).route(routeBody), {
+      backend,
+      getValue: (k) => getSetting(runtime, k),
+      sessionKey: `cli-inference:${key}`,
+      onRotate: () => evictCodexSdkSession(key),
+    });
   }
   return generateViaCli(runtime, buildCleanRoutingParams(params), ModelType.ACTION_PLANNER);
 }
@@ -373,6 +443,7 @@ export const cliInferencePlugin: Plugin = {
     ELIZA_CLI_SDK_TURN_TIMEOUT_MS: readEnv("ELIZA_CLI_SDK_TURN_TIMEOUT_MS") ?? null,
     ELIZA_CLI_CODEX_MODEL: readEnv("ELIZA_CLI_CODEX_MODEL") ?? null,
     ELIZA_CLI_TIMEOUT_MS: readEnv("ELIZA_CLI_TIMEOUT_MS") ?? null,
+    ELIZA_CLI_INFERENCE_ACCOUNT_ROTATION: readEnv("ELIZA_CLI_INFERENCE_ACCOUNT_ROTATION") ?? null,
   },
   async init(): Promise<void> {
     const backend = resolveCliBackend({ ELIZA_CHAT_VIA_CLI: readEnv("ELIZA_CHAT_VIA_CLI") });
@@ -402,6 +473,11 @@ export const cliInferencePlugin: Plugin = {
         "[cli-inference] text-planner mode (ELIZA_PLANNER_NATIVE_TOOLS=0) — ACTION_PLANNER also served via this route (standalone SAFE stack)"
       );
     }
+    if ((backend === "claude-sdk" || backend === "codex-sdk") && rotationEnabled(readEnv)) {
+      logger.info(
+        "[cli-inference] multi-account rotation ON — a subscription limit rotates to the next healthy pooled account before provider failover (opt out: ELIZA_CLI_INFERENCE_ACCOUNT_ROTATION=0)"
+      );
+    }
   },
   async dispose(): Promise<void> {
     await disposeSdkSessions();
@@ -409,6 +485,12 @@ export const cliInferencePlugin: Plugin = {
   models: buildModels(),
 };
 
+export {
+  isSubscriptionLimitError,
+  rotationAgentTypeForBackend,
+  rotationEnabled,
+  withAccountRotation,
+} from "./src/account-rotation";
 export { ClaudeCli } from "./src/claude-cli";
 export { ClaudeSdkSession } from "./src/claude-sdk-session";
 export {

--- a/plugins/plugin-cli-inference/src/account-rotation.ts
+++ b/plugins/plugin-cli-inference/src/account-rotation.ts
@@ -1,0 +1,318 @@
+/**
+ * Chat-brain multi-account rotation for the SAFE/CLI inference route (issue
+ * #11180 Gap A).
+ *
+ * The problem: `plugin-cli-inference` authenticates the warm claude-sdk / codex-sdk
+ * session from the machine's single ambient credential (`~/.claude` /
+ * `CLAUDE_CODE_OAUTH_TOKEN`, or `~/.codex` / `CODEX_HOME`). When THAT account hits
+ * its hourly/monthly subscription limit, the SDK ends the turn by streaming the
+ * limit envelope, the session handlers throw (per the throw-to-failover contract),
+ * and `useModel` skips straight to the next provider TIER (cloud / API key) — it
+ * never asks the pool for the next healthy *account* of the SAME provider first. A
+ * user with two Claude Max accounts still stalls the brain when account #1 limits,
+ * exactly like a solo account.
+ *
+ * The fix (this module): on a subscription-limit-classed throw, consume the
+ * `eliza.account-pool.coding-agent.v1` bridge (the SAME bridge coding sub-agents
+ * rotate through — it maps backend → provider, pool-selects the next healthy
+ * account, and MATERIALIZES the exact env the subprocess needs:
+ * `CLAUDE_CODE_OAUTH_TOKEN` for claude, a per-account `CODEX_HOME` for codex).
+ * We apply that env patch to `process.env` (the SDK reads its creds from there /
+ * from the materialized `CODEX_HOME`), dispose the warm session so it re-auths as
+ * the new account on its next start, and retry the turn transparently. Only when
+ * the pool returns null (all accounts limited / no pool / single account) do we
+ * rethrow so the caller's existing provider-failover chain runs. Rotation
+ * (account A → account B, same provider) therefore composes with — and runs
+ * BEFORE — failover (claude → cloud → api).
+ *
+ * Design notes:
+ *  - **Bridge over `globalThis`, not an app-core import.** The pool + credential
+ *    store live in `@elizaos/app-core`; this plugin depends only on
+ *    `@elizaos/core`. Like `plugin-agent-orchestrator/coding-account-selection.ts`
+ *    we read the narrow contract off a `Symbol.for(...)` key. When no pool is
+ *    configured the bridge is absent and this module is a pass-through no-op
+ *    (single-account behavior is byte-for-byte unchanged).
+ *  - **TOS invariant preserved.** The subscription token materialized by the
+ *    bridge only ever lands in `process.env` (which the first-party claude/codex
+ *    SDK subprocess reads for its own auth) — the same place the ambient
+ *    credential already lives for the claude-sdk path — never logged, never
+ *    forwarded to a third-party API. `CODEX_HOME` is a directory path, not a
+ *    secret.
+ *  - **Rotation is opt-out-able**, gated like the rest of the plugin's env
+ *    conventions: `ELIZA_CLI_INFERENCE_ACCOUNT_ROTATION` (default ON when a pool
+ *    is present; set `0`/`false`/`off` to disable and go straight to failover).
+ *  - **Only rate-limit-class errors rotate.** A non-limit failure (timeout parsed
+ *    as retryable is still a limit-shaped signal; a 400/empty-completion/auth
+ *    error is NOT) rethrows immediately so we never burn the pool on a bug.
+ *
+ * @module plugin-cli-inference/account-rotation
+ */
+
+import { logger } from "@elizaos/core";
+
+/** Symbol the app-core coding-agent selector bridge is published under. */
+const CODING_AGENT_SELECTOR_BRIDGE_SYMBOL: unique symbol = Symbol.for(
+  "eliza.account-pool.coding-agent.v1"
+);
+
+/** A selected account plus the env the first-party subprocess needs to auth as it. */
+export interface RotationAccountSelection {
+  providerId: string;
+  accountId: string;
+  label: string;
+  source: "oauth" | "api-key";
+  strategy: string;
+  /** Secrets / paths injected into the process env, never persisted or logged. */
+  envPatch: Record<string, string>;
+}
+
+/** The narrow slice of the coding-agent bridge this module consumes. */
+interface CodingAgentSelectorBridge {
+  select(
+    agentType: string,
+    opts?: { sessionKey?: string; strategy?: string; exclude?: string[] }
+  ): Promise<RotationAccountSelection | null>;
+  markRateLimited(
+    providerId: string,
+    accountId: string,
+    untilMs: number,
+    detail?: string
+  ): Promise<void>;
+  recordUsage(
+    providerId: string,
+    accountId: string,
+    result: { tokens?: number; ok: boolean; model?: string; latencyMs?: number }
+  ): Promise<void>;
+}
+
+/** Read the installed bridge, or null when no pool has been constructed. */
+export function getCodingAccountBridge(): CodingAgentSelectorBridge | null {
+  if (typeof globalThis === "undefined") return null;
+  const bridge = (globalThis as Record<symbol, unknown>)[CODING_AGENT_SELECTOR_BRIDGE_SYMBOL];
+  return (bridge as CodingAgentSelectorBridge | undefined) ?? null;
+}
+
+/**
+ * The backends whose warm SDK sessions authenticate per pooled account. The
+ * cold `claude --print` / `codex exec` CLIs read the machine's single on-disk
+ * login and are out of scope for in-runtime rotation (they'd need the CLI shim,
+ * issue #11180 Gap B), so ONLY the SDK backends map to a rotation agent type.
+ */
+const BACKEND_TO_AGENT_TYPE: Readonly<Record<string, string>> = {
+  "claude-sdk": "claude",
+  "codex-sdk": "codex",
+};
+
+/** Map an inference backend to the coding-agent pool type, or null when unrotatable. */
+export function rotationAgentTypeForBackend(backend: string): string | null {
+  return BACKEND_TO_AGENT_TYPE[backend] ?? null;
+}
+
+/** Default cool-off applied to an account that hit a subscription limit (15 min). */
+export const ROTATION_RATE_LIMIT_COOLOFF_MS = 15 * 60_000;
+
+/**
+ * True when this error is the subscription-limit / rate-limit class that should
+ * trigger account rotation. Deliberately CONSERVATIVE: the session handlers
+ * already narrow their throws (they only surface the limit envelope as a
+ * "subscription rate limit reached: …" message, or a `ProviderApiError` whose
+ * message carries the upstream status), so we anchor on those same signals plus
+ * a 429/529/quota vocabulary. A false positive burns a healthy account out of
+ * the pool for 15 min, so anything ambiguous (400, empty completion, plain auth
+ * failure, generic timeout) does NOT rotate — it rethrows to failover.
+ */
+export function isSubscriptionLimitError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err ?? "");
+  const statusCode = (err as { statusCode?: unknown })?.statusCode;
+  if (typeof statusCode === "number" && (statusCode === 429 || statusCode === 529)) {
+    return true;
+  }
+  const t = message.toLowerCase();
+  return (
+    // The claude-sdk session's own limit throw ("subscription rate limit reached: …").
+    t.includes("subscription rate limit reached") ||
+    // Explicit status the SDK envelope carries.
+    /\b(429|529)\b/.test(t) ||
+    // Provider limit / quota vocabulary. Kept tight: "rate limit" + "usage limit
+    // reached" + "quota exceeded/exhausted" + "too many requests" are the
+    // unambiguous provider signals (matches the orchestrator's classifier).
+    /rate[\s-]?limit(?:ed|ing)?/.test(t) ||
+    t.includes("usage limit reached") ||
+    /quota (?:exceeded|exhausted)/.test(t) ||
+    t.includes("too many requests")
+  );
+}
+
+/** Resolve whether rotation is enabled (default ON; opt-out via env/setting). */
+export function rotationEnabled(getValue: (key: string) => string | undefined): boolean {
+  const raw = getValue("ELIZA_CLI_INFERENCE_ACCOUNT_ROTATION")?.trim().toLowerCase();
+  if (raw === "0" || raw === "false" || raw === "no" || raw === "off") return false;
+  return true;
+}
+
+/** Apply an env patch to `process.env` (secrets/paths the SDK subprocess reads). */
+function applyEnvPatch(envPatch: Record<string, string>): void {
+  if (typeof process === "undefined") return;
+  for (const [key, value] of Object.entries(envPatch)) {
+    process.env[key] = value;
+  }
+}
+
+/** A description safe to log about a selection (label + provider, NEVER the token). */
+function safeAccountLabel(sel: RotationAccountSelection): string {
+  return `${sel.providerId}/${sel.label}`;
+}
+
+export interface RotationContext {
+  /** The configured inference backend (claude-sdk / codex-sdk / claude / codex). */
+  backend: string;
+  /** Read a runtime setting/env value (rotation gate). */
+  getValue: (key: string) => string | undefined;
+  /** Stable key so pool session-affinity ties a conversation to one account. */
+  sessionKey?: string;
+  /**
+   * Called after a successful rotation, BEFORE the retry, so the caller can tear
+   * down the warm SDK session bound to the old account's credential — the fresh
+   * session then re-auths as the newly-selected account on its next start.
+   */
+  onRotate: () => void | Promise<void>;
+  /** Selection strategy override (else the pool's default). */
+  strategy?: string;
+}
+
+/**
+ * Run `attempt` with transparent account rotation on subscription-limit errors.
+ *
+ * Flow:
+ *  1. Try `attempt()`. On success, return it (and best-effort record usage on the
+ *     currently-selected account if we rotated into it).
+ *  2. If it throws and the error is NOT a subscription-limit (or rotation is
+ *     disabled / no bridge / backend not rotatable), rethrow immediately →
+ *     the caller's existing provider-failover chain handles it.
+ *  3. On a limit error: mark the current account rate-limited, select the next
+ *     healthy account from the pool (excluding every account already tried),
+ *     apply its env patch, dispose the warm session (`onRotate`), and retry.
+ *     Repeat until an attempt succeeds or the pool is exhausted; when the pool
+ *     returns null, rethrow the LAST limit error so failover runs.
+ *
+ * A single structured `warn` is emitted per rotation (no credential/envelope
+ * leakage). At most `maxRotations` swaps are attempted to bound the loop even if
+ * the pool mis-reports health.
+ */
+export async function withAccountRotation(
+  attempt: () => Promise<string>,
+  ctx: RotationContext,
+  maxRotations = 8
+): Promise<string> {
+  const agentType = rotationAgentTypeForBackend(ctx.backend);
+  const bridge = agentType ? getCodingAccountBridge() : null;
+  // No rotation possible/desired → single, un-wrapped attempt (behavior
+  // identical to pre-rotation: any throw goes straight to the caller's failover).
+  if (!bridge || !agentType || !rotationEnabled(ctx.getValue)) {
+    return attempt();
+  }
+
+  const tried: string[] = [];
+  // The account we rotated INTO (null while still on the ambient credential).
+  // We only touch pool health/usage for accounts WE selected — the ambient
+  // credential may not be a pooled account at all, so guessing its provider id
+  // could mis-mark a stranger's account.
+  let current: RotationAccountSelection | null = null;
+  let lastError: unknown;
+
+  for (let rotations = 0; rotations <= maxRotations; rotations += 1) {
+    try {
+      const result = await attempt();
+      // Record a successful call against the account we rotated INTO so
+      // quota-aware selection reflects real usage (best-effort; never throws).
+      if (current) {
+        void bridge
+          .recordUsage(current.providerId, current.accountId, { ok: true })
+          .catch(() => undefined);
+      }
+      return result;
+    } catch (err) {
+      lastError = err;
+      if (!isSubscriptionLimitError(err)) {
+        // Not a limit — a genuine failure. Do NOT rotate (would burn a healthy
+        // account); rethrow so the caller's provider-failover chain runs.
+        throw err;
+      }
+      // The active account just limited. Mark it (with its reset window) so
+      // quota-aware selection routes around it, then pick the next healthy one.
+      // Only for an account WE selected (the ambient credential is untracked).
+      if (current) {
+        void bridge
+          .markRateLimited(
+            current.providerId,
+            current.accountId,
+            Date.now() + ROTATION_RATE_LIMIT_COOLOFF_MS,
+            "cli-inference subscription limit"
+          )
+          .catch(() => undefined);
+      }
+
+      let selection: RotationAccountSelection | null = null;
+      try {
+        selection = await bridge.select(agentType, {
+          ...(ctx.sessionKey ? { sessionKey: ctx.sessionKey } : {}),
+          ...(ctx.strategy ? { strategy: ctx.strategy } : {}),
+          exclude: tried,
+        });
+      } catch (selectErr) {
+        // Pool selection itself failed — treat as pool-exhausted and fail over.
+        logger.warn(
+          {
+            src: "cli-inference:rotation",
+            backend: ctx.backend,
+            reason: "select-failed",
+          },
+          `[cli-inference] account rotation select failed (${String(selectErr)}) — falling through to provider failover`
+        );
+        throw err;
+      }
+
+      if (!selection) {
+        // Pool exhausted: every healthy account tried, or none configured.
+        // Rethrow the limit error so the caller's failover chain (cloud / API)
+        // runs — rotation composes with, and yields to, failover.
+        logger.warn(
+          {
+            src: "cli-inference:rotation",
+            backend: ctx.backend,
+            tried: tried.length,
+            reason: "pool-exhausted",
+          },
+          `[cli-inference] all pooled ${agentType} accounts rate-limited (${tried.length} tried) — failing over to next provider tier`
+        );
+        throw err;
+      }
+
+      tried.push(selection.accountId);
+      current = selection;
+      applyEnvPatch(selection.envPatch);
+      // Tear down the warm session so it re-auths as the newly-selected account.
+      try {
+        await ctx.onRotate();
+      } catch {
+        // Session teardown is best-effort; the fresh start will re-init anyway.
+      }
+      logger.warn(
+        {
+          src: "cli-inference:rotation",
+          backend: ctx.backend,
+          account: safeAccountLabel(selection),
+          strategy: selection.strategy,
+          attempt: rotations + 1,
+        },
+        `[cli-inference] rotated to next ${agentType} account after subscription limit`
+      );
+      // loop retries the turn on the new account
+    }
+  }
+
+  // Exhausted maxRotations without success — fail over with the last error.
+  throw lastError instanceof Error
+    ? lastError
+    : new Error(`[cli-inference] account rotation exhausted: ${String(lastError)}`);
+}


### PR DESCRIPTION
Closes #11180 Gap A (chat-brain account rotation — the keystone). Does NOT touch Gap B (the bare-CLI shim) or the shared-selection-core extract; one concern per PR.

## Problem
`plugin-cli-inference`'s chat brain (`claude-sdk` / `codex-sdk`) authenticates from the machine's single ambient credential (`~/.claude` / `CLAUDE_CODE_OAUTH_TOKEN`, or `~/.codex` / `CODEX_HOME`). On a subscription-limit throw the session handlers correctly throw (per the throw-to-failover contract), and `useModel` skips straight to the next provider **TIER** (cloud / API key) — it never asks the pool for the next healthy **account** of the same provider first. A user with two Claude Max accounts still stalled the brain when account #1 limited, exactly like a solo account. The `subscription-selector.v1` bridge had **zero consumers** on the chat path (as the issue notes).

## Fix
- **New `src/account-rotation.ts`** consumes the `eliza.account-pool.coding-agent.v1` bridge — the **same** bridge coding sub-agents rotate through, which maps backend → provider, pool-selects the next healthy account, and materializes the exact env the subprocess needs (`CLAUDE_CODE_OAUTH_TOKEN` / per-account `CODEX_HOME`). Read off a `globalThis` symbol (no `@elizaos/app-core` import), mirroring `plugin-agent-orchestrator/src/services/coding-account-selection.ts`. When no pool is configured the bridge is absent and the module is a **byte-for-byte pass-through no-op** (single-account behavior unchanged).
- **`withAccountRotation(attempt, ctx)`** wraps the SDK call in `index.ts` (`generateViaCli` + `planViaCli`, both `claude-sdk` and `codex-sdk`): on a limit throw it marks the current account rate-limited (with its reset window), selects the next healthy account (excluding every account already tried), applies its env patch to `process.env`, **evicts the warm SDK session** so it re-auths as the new account on next start, and retries the turn transparently.
- **Rotation composes with — and runs BEFORE — failover.** Pool exhausted (`select → null`) or a select failure → rethrow the limit error so the caller's existing provider-failover chain (claude → cloud → api) runs. Rotation-within-provider first, failover-across-providers second.
- **Only rate-limit-class errors rotate.** `isSubscriptionLimitError` keys off the SAME narrowed signals the session handlers already throw ("subscription rate limit reached", `ProviderApiError` with a 429/529 status) plus quota/too-many-requests vocabulary. A 400 / empty-completion / plain-auth / generic error rethrows immediately — never burns a healthy account (a false positive would evict a good account for 15 min).
- **TOS invariant preserved.** The subscription token only ever lands in `process.env` (which the first-party claude/codex SDK subprocess reads for its own auth — the same place the ambient credential already lives for the `claude-sdk` path), never logged/forwarded. Single structured `warn` per rotation, no credential/envelope leakage. `CODEX_HOME` is a directory path, not a secret.
- **Opt-out-able** like the plugin's other env conventions: `ELIZA_CLI_INFERENCE_ACCOUNT_ROTATION=0` (default ON when a pool is present, gated the same way the plugin gates its other flags).

## How rotation composes with failover
`useModel` tier order is unchanged. Within the `cli-inference` handler for a tier, a subscription limit now first walks the pooled accounts of the same provider (A → B → …); only when the pool returns null does the original limit error propagate up, letting `useModel` fall to the next tier exactly as before. So a 2-account host that used to stall now rotates; a 1-account host (or `ELIZA_CLI_INFERENCE_ACCOUNT_ROTATION=0`) behaves identically to today.

## Reconciled with develop
Reused the existing subscription-limit detection contract from the session handlers (recently hardened in #10944 / #10975 / #11080 / #11109) rather than re-classifying SDK envelopes — `isSubscriptionLimitError` anchors on those thrown signals.

## Tests / evidence
14 new unit tests in `__tests__/account-rotation.test.ts`, driven by a FAKE `coding-agent.v1` bridge on the `globalThis` symbol (no real pool / SDK / second live account — provable with mocks + one account, as the issue's test plan requires):
- limit-error classification (session throw, 429/529 status, quota vocab) vs non-limit non-classification (400, empty-completion, 401, route-no-decision)
- rotate-on-limit → succeed on next account (applies token, evicts session, records usage)
- **non-trigger**: non-limit error rethrows immediately, no rotation
- tried-account exclusion across multiple rotations (2nd `select` excludes the 1st)
- **pool exhaustion → failover handoff** (select → null rethrows; rotated-into account marked rate-limited)
- single-account no-op (no bridge), disabled-flag no-op, non-rotatable cold backend no-op
- `rotationEnabled` default-ON + opt-out, `rotationAgentTypeForBackend` (SDK-only mapping)

```
Test Files  6 passed (6)
     Tests  84 passed (84)   # 14 new + 70 existing
```
`tsgo --noEmit` clean · `biome check` clean · `bun run build.ts` green.

**codex review not run (usage-limited).**

Caveat: the subscription-limit-message phrasing the SDK streams is inferred from the shipping envelopes already covered by the merged detectors; `isSubscriptionLimitError` deliberately errs toward NOT rotating on ambiguous errors, so at worst an un-recognized limit phrasing degrades to today's straight-to-failover behavior (no regression), never a false rotation.

— `[sol-orch]`
