### PR TITLE
fix(orchestrator): coordinator no longer goes silently inert when ACP binds late (bind-race)

### DIFF
--- a/packages/agent/src/api/coordinator-wiring.ts
+++ b/packages/agent/src/api/coordinator-wiring.ts
@@ -41,6 +41,31 @@ function discoverCoordinator(runtime: AgentRuntime): unknown | null {
 }
 
 /**
+ * Read the coordinator's self-reported ACP bind state, if it exposes one.
+ * `bound` means the ACP session-event stream is live and supervision works;
+ * `unbound` / `pending` carry an actionable reason. The service object can
+ * exist while the stream is dead (bind race on a heavy boot), so "the service
+ * is present" is NOT sufficient to conclude coding-agent features work — we
+ * probe this to report WHY when they don't.
+ */
+function readBindState(
+  coordinator: unknown,
+): { status: string; reason: string | null } | null {
+  if (!coordinator || typeof coordinator !== "object") return null;
+  const bindState = (coordinator as { acpBindState?: unknown }).acpBindState;
+  if (!bindState || typeof bindState !== "object") return null;
+  const { status, reason } = bindState as {
+    status?: unknown;
+    reason?: unknown;
+  };
+  if (typeof status !== "string") return null;
+  return {
+    status,
+    reason: typeof reason === "string" ? reason : null,
+  };
+}
+
+/**
  * Wire coordinator bridges using polling-based service discovery.
  *
  * 1. Attempts immediate wiring (coordinator may already be available).
@@ -111,12 +136,43 @@ export async function wireCoordinatorBridgesWhenReady<S extends WirableState>(
     }
 
     if (!serviceFound) {
-      // Service never appeared — log at debug level only. This is normal
-      // if the orchestrator plugin is disabled or not configured.
-      logger.debug?.(
-        `[eliza-api] coordinator not available after ${POLL_TIMEOUT_MS / 1000}s (${context}) — coding agent features disabled`,
-      );
+      // Service never appeared. Distinguish the two very different causes so
+      // this isn't a generic "disabled" that hides a real degradation:
+      //   (a) The orchestrator plugin isn't installed/enabled at all — normal
+      //       for non-coding deployments → debug.
+      //   (b) The plugin IS installed but the coordinator never registered or
+      //       never bound its ACP stream (the bind race) → warn, with the
+      //       coordinator's own actionable reason if it exposes one.
+      const pluginPresent = runtime.hasService?.("SWARM_COORDINATOR") ?? false;
+      if (pluginPresent) {
+        logger.warn(
+          `[eliza-api] coordinator service registered but never became ` +
+            `discoverable after ${POLL_TIMEOUT_MS / 1000}s (${context}) — ` +
+            `coding-agent supervision DEGRADED. This usually means the ` +
+            `orchestrator's SWARM_COORDINATOR service failed to start; ` +
+            `check the service-start logs above.`,
+        );
+      } else {
+        logger.debug?.(
+          `[eliza-api] coordinator not available after ${POLL_TIMEOUT_MS / 1000}s (${context}) — coding agent features disabled`,
+        );
+      }
       return result;
+    }
+
+    // Service appeared. But existence alone doesn't mean supervision works: if
+    // its ACP session-event stream never bound, callbacks wire but no events
+    // ever fire. Surface that explicitly rather than reporting silent success.
+    const bindState = readBindState(discoverCoordinator(runtime));
+    if (bindState && bindState.status !== "bound") {
+      logger.warn(
+        `[eliza-api] coordinator present but ACP stream not bound ` +
+          `(status=${bindState.status}${
+            bindState.reason ? `, reason=${bindState.reason}` : ""
+          }) (${context}) — coding-agent supervision DEGRADED. ` +
+          `Bridges will wire but events will not flow until the bind ` +
+          `completes; the coordinator retries indefinitely.`,
+      );
     }
 
     // 3. Service loaded — retry failed bridges

--- a/plugins/plugin-agent-orchestrator/src/__tests__/swarm-coordinator-acp-bind.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/swarm-coordinator-acp-bind.test.ts
@@ -1,0 +1,223 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AcpService } from "../services/acp-service.js";
+import { SwarmCoordinatorService } from "../services/swarm-coordinator-service.js";
+
+/**
+ * Regression coverage for the coordinator "silent bind give-up" bug.
+ *
+ * BEFORE the fix, `SwarmCoordinatorService` polled `getService(ACP)` at
+ * 500ms x 120 = 60s and then gave up SILENTLY, setting `acpBindTimer = null`
+ * and never re-arming. On a heavy boot where AcpService registered later than
+ * 60s (big character, many plugins, embedding warmup), the coordinator went
+ * permanently inert while its service object still existed — so the 90s wiring
+ * probe "succeeded" and set its callbacks, but no ACP events ever reached them.
+ *
+ * These tests drive that exact race with fake timers:
+ *   - late-registration (ACP appears at ~70s) must still bind (was: dead).
+ *   - normal boot (ACP present immediately) binds without retries.
+ *   - ACP load-promise rejection marks the coordinator UNBOUND loudly.
+ *   - never-registers keeps retrying (unbounded) instead of going silent.
+ */
+
+/** Minimal fake ACP service exposing just the `onSessionEvent` surface. */
+function makeFakeAcp(): {
+  acp: Pick<AcpService, "onSessionEvent">;
+  emit: (sessionId: string, event: string, data: unknown) => void;
+  subscriberCount: () => number;
+} {
+  const handlers: Array<
+    (sessionId: string, event: string, data: unknown) => void
+  > = [];
+  return {
+    acp: {
+      onSessionEvent(handler) {
+        handlers.push(handler as (s: string, e: string, d: unknown) => void);
+        return () => {
+          const i = handlers.indexOf(
+            handler as (s: string, e: string, d: unknown) => void,
+          );
+          if (i >= 0) handlers.splice(i, 1);
+        };
+      },
+    } as Pick<AcpService, "onSessionEvent">,
+    emit: (sessionId, event, data) => {
+      for (const h of [...handlers]) h(sessionId, event, data);
+    },
+    subscriberCount: () => handlers.length,
+  };
+}
+
+interface FakeRuntimeControls {
+  runtime: IAgentRuntime;
+  /** Make the ACP service discoverable via getService + resolve its load-promise. */
+  registerAcp: (acp: unknown) => void;
+  /** Reject the ACP load-promise (ACP failed to start). */
+  failAcpStart: (err: Error) => void;
+}
+
+/**
+ * A runtime that models the two discovery surfaces the coordinator uses:
+ *   - `getService(ACP)` — sync lookup, null until `registerAcp`.
+ *   - `getServiceLoadPromise(ACP)` — event-driven, resolves on `registerAcp`
+ *     or rejects on `failAcpStart`.
+ * `driveLoadPromise` toggles whether the load-promise surface exists, so we can
+ * exercise both the event-driven path and the polling fallback in isolation.
+ */
+function makeRuntime(
+  opts: { driveLoadPromise: boolean } = { driveLoadPromise: true },
+): FakeRuntimeControls {
+  let acpInstance: unknown = null;
+  let resolveLoad: ((svc: unknown) => void) | null = null;
+  let rejectLoad: ((err: Error) => void) | null = null;
+  const loadPromise = new Promise<unknown>((resolve, reject) => {
+    resolveLoad = resolve;
+    rejectLoad = reject;
+  });
+  // Prevent unhandled-rejection noise before anyone awaits.
+  loadPromise.catch(() => {});
+
+  const runtime = {
+    getService: (serviceType: string) =>
+      serviceType === AcpService.serviceType ? acpInstance : null,
+    getServiceLoadPromise: opts.driveLoadPromise
+      ? (serviceType: string) =>
+          serviceType === AcpService.serviceType
+            ? loadPromise
+            : Promise.reject(new Error("no such service"))
+      : undefined,
+  } as unknown as IAgentRuntime;
+
+  return {
+    runtime,
+    registerAcp: (acp: unknown) => {
+      acpInstance = acp;
+      resolveLoad?.(acp);
+    },
+    failAcpStart: (err: Error) => {
+      rejectLoad?.(err);
+    },
+  };
+}
+
+describe("SwarmCoordinatorService ACP bind race (coordinator silent give-up)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("binds when ACP registers LATE (~70s > old 60s give-up window) — the regression", async () => {
+    // Polling-fallback ONLY: this is the path that previously gave up at 60s.
+    const { runtime, registerAcp } = makeRuntime({ driveLoadPromise: false });
+    const { acp, emit, subscriberCount } = makeFakeAcp();
+
+    const service = new SwarmCoordinatorService(runtime);
+    // start() calls bindToAcp(); construct-and-bind manually to mirror it.
+    (service as unknown as { bindToAcp: () => void }).bindToAcp();
+
+    expect(service.acpBindState.status).toBe("pending");
+
+    // Advance PAST the old 60s give-up point. On develop HEAD the poll loop
+    // has stopped by now (acpBindTimer = null) and never re-arms.
+    await vi.advanceTimersByTimeAsync(65_000);
+    expect(service.acpBindState.status).toBe("pending"); // still trying
+
+    // ACP finally starts at ~70s.
+    registerAcp(acp);
+    await vi.advanceTimersByTimeAsync(6_000);
+
+    expect(service.acpBindState.status).toBe("bound");
+    expect(subscriberCount()).toBe(1);
+
+    // And the event stream is actually live.
+    const seen: string[] = [];
+    service.subscribe((e) => seen.push(e.type));
+    emit("s1", "task_complete", {});
+    // handleAcpEvent is async (enrichment + dispatch happen after awaits); let
+    // the microtask queue drain before asserting the listener fired.
+    await vi.advanceTimersByTimeAsync(10);
+    await Promise.resolve();
+    expect(seen).toContain("task_complete");
+
+    await service.stop();
+  });
+
+  it("binds via the event-driven load-promise when ACP starts late", async () => {
+    const { runtime, registerAcp } = makeRuntime({ driveLoadPromise: true });
+    const { acp, subscriberCount } = makeFakeAcp();
+
+    const service = new SwarmCoordinatorService(runtime);
+    (service as unknown as { bindToAcp: () => void }).bindToAcp();
+    expect(service.acpBindState.status).toBe("pending");
+
+    // Simulate a very slow boot: 70s, still nothing.
+    await vi.advanceTimersByTimeAsync(70_000);
+    expect(service.acpBindState.status).toBe("pending");
+
+    // ACP start resolves the load-promise; bind should complete promptly.
+    registerAcp(acp);
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(service.acpBindState.status).toBe("bound");
+    expect(subscriberCount()).toBe(1);
+    await service.stop();
+  });
+
+  it("normal boot: binds immediately with zero retries", async () => {
+    const { runtime, registerAcp } = makeRuntime();
+    const { acp, subscriberCount } = makeFakeAcp();
+    registerAcp(acp); // ACP already up before the coordinator starts
+
+    const service = new SwarmCoordinatorService(runtime);
+    (service as unknown as { bindToAcp: () => void }).bindToAcp();
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(service.acpBindState.status).toBe("bound");
+    expect(service.acpBindState.attempts).toBe(0);
+    expect(subscriberCount()).toBe(1);
+    await service.stop();
+  });
+
+  it("marks UNBOUND loudly when ACP fails to start (load-promise rejects)", async () => {
+    const errorSpy = vi.fn();
+    const { runtime, failAcpStart } = makeRuntime({ driveLoadPromise: true });
+    const { subscriberCount } = makeFakeAcp();
+
+    const service = new SwarmCoordinatorService(runtime);
+    (service as unknown as { bindToAcp: () => void }).bindToAcp();
+
+    failAcpStart(new Error("acp subprocess crashed"));
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(service.acpBindState.status).toBe("unbound");
+    expect(service.acpBindState.reason).toContain("acp subprocess crashed");
+    expect(subscriberCount()).toBe(0);
+    await service.stop();
+  });
+
+  it("never-registers: keeps retrying indefinitely (does not go silent)", async () => {
+    // Polling fallback with no load-promise and ACP that never appears.
+    const { runtime } = makeRuntime({ driveLoadPromise: false });
+    const service = new SwarmCoordinatorService(runtime);
+    (service as unknown as { bindToAcp: () => void }).bindToAcp();
+
+    // Push far past every old give-up point.
+    await vi.advanceTimersByTimeAsync(300_000);
+
+    // Still pending (retrying), NOT silently abandoned.
+    expect(service.acpBindState.status).toBe("pending");
+    expect(service.acpBindState.attempts).toBeGreaterThan(120);
+
+    // Proves the retry timer is still armed: registering now still binds.
+    const { acp } = makeFakeAcp();
+    (runtime.getService as unknown) = (t: string) =>
+      t === AcpService.serviceType ? acp : null;
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(service.acpBindState.status).toBe("bound");
+
+    await service.stop();
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/swarm-coordinator-service.ts
@@ -193,12 +193,48 @@ export class SwarmCoordinatorService extends Service {
   private stopped = false;
 
   /**
+   * Observable bind state so the readiness probe (coordinator-wiring.ts) and
+   * status route can report WHY supervision is degraded — a bound coordinator
+   * whose ACP stream never connected looks identical, from the outside, to a
+   * healthy one (the service object exists either way). Consumers read
+   * {@link acpBindState} instead of inferring liveness from `getService()`.
+   *
+   *  - `pending`   : bind in flight (event-driven wait + polling fallback).
+   *  - `bound`     : subscribed to the ACP session-event stream; events flow.
+   *  - `unbound`   : ACP service failed to start / rejected; stream inactive.
+   */
+  private acpBindStatus: "pending" | "bound" | "unbound" = "pending";
+  /** Last actionable reason the bind is not `bound` (for the readiness probe). */
+  private acpBindReason: string | null = null;
+  /** Set once the event-driven load-promise wait has been armed (arm-once). */
+  private acpLoadWaitArmed = false;
+
+  /**
    * The room id that out-of-band synthesis routing falls back to. Declared on
    * the interface the bridges read; the orchestrator routes per-task room ids
    * through the completion payload instead, so this stays null and the bridges
    * use their own per-task fallback. Kept for interface compatibility.
    */
   sourceRoomId: string | null = null;
+
+  /**
+   * Readiness view for third-party probes. `bound` means the ACP session-event
+   * stream is live and supervision works; anything else carries an actionable
+   * `reason`. Coordinator-wiring reads this so the 90s probe can distinguish
+   * "plugin missing" from "bind timed out" instead of reporting a generic
+   * "coordinator not available".
+   */
+  get acpBindState(): {
+    status: "pending" | "bound" | "unbound";
+    reason: string | null;
+    attempts: number;
+  } {
+    return {
+      status: this.acpBindStatus,
+      reason: this.acpBindReason,
+      attempts: this.acpBindAttempts,
+    };
+  }
 
   static async start(runtime: IAgentRuntime): Promise<SwarmCoordinatorService> {
     const service = new SwarmCoordinatorService(runtime);
@@ -238,6 +274,14 @@ export class SwarmCoordinatorService extends Service {
     }
     this.legacyTaskEvictionTimers.clear();
     this.tasks.clear();
+    // The event-driven load-promise wait can't be cancelled, but `stopped`
+    // guards its continuation; reset the arm flag so a restarted instance
+    // re-arms cleanly.
+    this.acpLoadWaitArmed = false;
+    if (this.acpBindStatus === "pending") {
+      this.acpBindStatus = "unbound";
+      this.acpBindReason = "service stopped before ACP bind completed";
+    }
   }
 
   // ── subscribe() — the surface verification-room-bridge depends on ──────────
@@ -333,17 +377,89 @@ export class SwarmCoordinatorService extends Service {
   }
 
   /**
-   * Subscribe to the AcpService session-event stream. Service start order at
-   * boot is not deterministic, so if ACP isn't registered yet we retry on a
-   * short interval (bounded) until it appears.
+   * Subscribe to the AcpService session-event stream.
+   *
+   * Service start order at boot is not deterministic and ACP startup can take
+   * well over a minute on a heavy boot (big character, many plugins, embedding
+   * warmup). Binding therefore uses two complementary mechanisms:
+   *
+   *   1. **Event-driven** — `runtime.getServiceLoadPromise(ACP)` resolves the
+   *      instant ACP finishes starting, however long that takes. This is the
+   *      primary path: no fixed deadline, so it can't "give up" before a slow
+   *      boot finishes. It resolves/rejects exactly once.
+   *   2. **Polling fallback** — a short interval re-checks `getService(ACP)` in
+   *      case the load-promise is unavailable or the service was registered by
+   *      a path that doesn't drive it. Unlike the old bounded 60s loop, this
+   *      fallback is UNBOUNDED but backs off and ESCALATES log severity, so a
+   *      genuinely stuck bind is loud (error) instead of silent.
+   *
+   * The prior implementation polled for a fixed 60s then gave up with a single
+   * warn, leaving `acpBindTimer=null` and never re-arming. On a boot where ACP
+   * registered at, say, 70s, the coordinator went permanently inert while the
+   * service object still existed — so the 90s wiring probe "succeeded" and set
+   * its callbacks, but no ACP events ever reached them (supervision degraded,
+   * silently). This fix closes that race.
    */
   private bindToAcp(): void {
     if (this.stopped || this.unsubscribeAcp) return;
+
+    // Arm the event-driven wait exactly once. This is the real fix: it can't
+    // time out before ACP starts, however slow the boot.
+    this.armAcpLoadWait();
+
     const acp = this.acp();
     if (!acp) {
+      // ACP not registered yet — keep the polling fallback ticking. The
+      // load-promise above will normally win the race, but the poll survives
+      // the case where it isn't wired.
       this.scheduleAcpBindRetry();
       return;
     }
+    this.completeBind(acp);
+  }
+
+  /**
+   * Event-driven bind: await the ACP service load-promise, which resolves as
+   * soon as ACP finishes starting (no fixed deadline). Armed once; the polling
+   * fallback races it and whichever wins calls {@link completeBind} (guarded by
+   * `unsubscribeAcp` so the second is a no-op).
+   */
+  private armAcpLoadWait(): void {
+    if (this.acpLoadWaitArmed || this.stopped) return;
+    const loadPromise = this.runtime.getServiceLoadPromise?.(
+      AcpService.serviceType,
+    );
+    if (!loadPromise || typeof loadPromise.then !== "function") {
+      // Runtime doesn't expose the load-promise — rely on the polling fallback.
+      return;
+    }
+    this.acpLoadWaitArmed = true;
+    void loadPromise.then(
+      (svc) => {
+        if (this.stopped || this.unsubscribeAcp) return;
+        const acp =
+          (svc as AcpService | undefined) &&
+          typeof (svc as AcpService).onSessionEvent === "function"
+            ? (svc as AcpService)
+            : this.acp();
+        if (acp) this.completeBind(acp);
+      },
+      (err: unknown) => {
+        // ACP failed to start. This is terminal: the polling fallback would
+        // spin forever, so mark unbound LOUDLY with the actionable reason.
+        if (this.stopped || this.unsubscribeAcp) return;
+        this.markUnbound(
+          `AcpService failed to start: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      },
+    );
+  }
+
+  /** Subscribe to the resolved ACP instance. Idempotent via `unsubscribeAcp`. */
+  private completeBind(acp: AcpService): void {
+    if (this.stopped || this.unsubscribeAcp) return;
     if (this.acpBindTimer) {
       clearTimeout(this.acpBindTimer);
       this.acpBindTimer = null;
@@ -351,6 +467,8 @@ export class SwarmCoordinatorService extends Service {
     this.unsubscribeAcp = acp.onSessionEvent((sessionId, event, data) => {
       void this.handleAcpEvent(sessionId, String(event), data);
     });
+    this.acpBindStatus = "bound";
+    this.acpBindReason = null;
     logger.info(
       `[SwarmCoordinator] subscribed to ACP session-event stream${
         this.acpBindAttempts > 0
@@ -362,23 +480,67 @@ export class SwarmCoordinatorService extends Service {
     );
   }
 
-  private scheduleAcpBindRetry(): void {
-    // 500ms × 120 = 60s of patience — covers slow plugin-load cold boots while
-    // bounding the dangling-timer window after stop() to 0.5s.
-    const MAX_ATTEMPTS = 120;
-    const INTERVAL_MS = 500;
-    if (this.stopped) return;
-    if (this.acpBindAttempts >= MAX_ATTEMPTS) {
-      logger.warn(
-        "[SwarmCoordinator] AcpService never became available; swarm event stream inactive.",
-      );
-      return;
+  /** Record a terminal bind failure and log at error level (LOUD). */
+  private markUnbound(reason: string): void {
+    if (this.acpBindTimer) {
+      clearTimeout(this.acpBindTimer);
+      this.acpBindTimer = null;
     }
+    this.acpBindStatus = "unbound";
+    this.acpBindReason = reason;
+    logger.error(
+      `[SwarmCoordinator] ACP bind failed — swarm event stream inactive, ` +
+        `coding-agent supervision DEGRADED. Reason: ${reason}. ` +
+        `Verify the AcpService started (check for its start log / ` +
+        `ACP_SUBPROCESS_SERVICE errors above).`,
+    );
+  }
+
+  /**
+   * Polling fallback: re-check for the ACP service on a short interval. Unlike
+   * the old bounded loop this never gives up, but it backs off and escalates
+   * log severity so a stuck bind is impossible to miss. The event-driven
+   * load-promise normally binds first (making this loop a no-op via the
+   * `unsubscribeAcp` guard); the poll exists for runtimes that don't drive the
+   * load-promise.
+   */
+  private scheduleAcpBindRetry(): void {
+    if (this.stopped || this.unsubscribeAcp) return;
+    // Attempt count at which the bind is "clearly wrong, not just slow". At
+    // 500ms base this is ~60s — the old give-up point, now the START of loud
+    // logging rather than the end of trying.
+    const ESCALATE_AT = 120;
+    const BASE_INTERVAL_MS = 500;
+    const MAX_INTERVAL_MS = 5_000;
     this.acpBindAttempts += 1;
+
+    // Backoff: hold the base cadence until the escalation point (so a normal
+    // slow boot binds promptly), then grow to a coarse steady-state so an
+    // indefinite wait doesn't burn a tight timer.
+    const interval =
+      this.acpBindAttempts < ESCALATE_AT
+        ? BASE_INTERVAL_MS
+        : Math.min(
+            MAX_INTERVAL_MS,
+            BASE_INTERVAL_MS * 2 ** (this.acpBindAttempts - ESCALATE_AT),
+          );
+
+    // Escalate severity once we cross the "this is taking too long" threshold.
+    // First crossing is a warn; keep it grep-able but not spammy afterward.
+    if (this.acpBindAttempts === ESCALATE_AT) {
+      this.acpBindReason = `AcpService still unavailable after ${this.acpBindAttempts} attempts (~${Math.round(
+        (BASE_INTERVAL_MS * this.acpBindAttempts) / 1000,
+      )}s); still retrying`;
+      logger.warn(
+        `[SwarmCoordinator] ${this.acpBindReason}. If this persists, ` +
+          `coding-agent supervision is degraded — check AcpService startup.`,
+      );
+    }
+
     this.acpBindTimer = setTimeout(() => {
       this.acpBindTimer = null;
       this.bindToAcp();
-    }, INTERVAL_MS);
+    }, interval);
   }
 
   /**

--- a/plugins/plugin-app-control/src/services/verification-room-bridge.ts
+++ b/plugins/plugin-app-control/src/services/verification-room-bridge.ts
@@ -63,7 +63,12 @@ const VERDICT_DEDUPE_TTL_MS = 10 * 60 * 1000;
  * dangling-timer window after `stop()` to 0.5s.
  */
 const ATTACH_RETRY_INTERVAL_MS = 500;
+// Attempt count at which a still-unbound bridge stops being "plausibly slow"
+// and starts logging loudly + backing off. Not a give-up point: the bridge
+// retries indefinitely (a heavy boot can register the coordinator well past
+// the old 30s window), it just gets coarser and louder past here.
 const ATTACH_MAX_RETRIES = 60;
+const ATTACH_MAX_RETRY_INTERVAL_MS = 5_000;
 
 /**
  * Minimal shape of the SwarmCoordinator service surface this bridge
@@ -353,21 +358,36 @@ export class VerificationRoomBridgeService extends Service {
 	}
 
 	private scheduleAttachRetry(): void {
-		if (this.attachRetryAttempts >= ATTACH_MAX_RETRIES) {
-			// Final attempt exhausted — log once at debug level so this is
-			// silent in deployments that genuinely don't have the
-			// orchestrator plugin enabled (the common case for non-create
-			// agent deployments) while still being grep-able.
-			logger.debug(
-				`[VerificationRoomBridge] SWARM_COORDINATOR service still has no subscribe() after ${ATTACH_MAX_RETRIES} retries; bridge inactive. Verification verdicts will not be posted back to chat.`,
-			);
-			return;
-		}
 		this.attachRetryAttempts += 1;
+		// The orchestrator's SWARM_COORDINATOR can take well over the old
+		// bounded window to register + bind on a heavy boot. Giving up at a
+		// fixed retry count left this bridge permanently inactive (verdicts
+		// never posted back) even though the coordinator DID eventually appear.
+		// Retry indefinitely with backoff + escalating severity instead: quiet
+		// while it's plausibly just slow, loud once it's clearly wrong. If the
+		// orchestrator plugin genuinely isn't installed this loop is harmless
+		// (coarse steady-state poll), and stop() clears the timer.
+		const interval =
+			this.attachRetryAttempts < ATTACH_MAX_RETRIES
+				? ATTACH_RETRY_INTERVAL_MS
+				: Math.min(
+						ATTACH_MAX_RETRY_INTERVAL_MS,
+						ATTACH_RETRY_INTERVAL_MS *
+							2 ** (this.attachRetryAttempts - ATTACH_MAX_RETRIES),
+					);
+		if (this.attachRetryAttempts === ATTACH_MAX_RETRIES) {
+			// First crossing of the "taking too long" threshold — warn once so a
+			// stuck bridge is grep-able without spamming a non-orchestrator boot.
+			logger.warn(
+				`[VerificationRoomBridge] SWARM_COORDINATOR service still has no subscribe() after ${ATTACH_MAX_RETRIES} attempts (~${Math.round(
+					(ATTACH_RETRY_INTERVAL_MS * ATTACH_MAX_RETRIES) / 1000,
+				)}s); still retrying. If this persists, verification verdicts will not be posted back to chat — check the orchestrator's SwarmCoordinator startup.`,
+			);
+		}
 		this.attachRetryTimer = setTimeout(() => {
 			this.attachRetryTimer = null;
 			this.attach();
-		}, ATTACH_RETRY_INTERVAL_MS);
+		}, interval);
 	}
 
 	private async handleEvent(event: SwarmEventLike): Promise<void> {


### PR DESCRIPTION
## The bug (observed live)

On our self-hosted node the runtime reports **`coordinator not available after 90s (boot) — coding agent features disabled`** with `supervisionLevel: "unavailable"`. Spawns still work, but supervision is silently degraded. The `task-coordinator` plugin loads fine (~7ms); the readiness probe still fails.

## Root cause (confirmed)

A **60s inner bind window racing a 90s outer readiness probe**, with a silent give-up in the inner window:

1. `SwarmCoordinatorService.bindToAcp()` (plugin-agent-orchestrator) subscribes to the `AcpService` session-event stream. It polled `getService(ACP)` at **500ms × 120 = 60s**, then gave up **silently** — one `warn`, `acpBindTimer` set to `null`, **never re-armed**.
2. `wireCoordinatorBridgesWhenReady` (`packages/agent/src/api/coordinator-wiring.ts`) polls `getService("SWARM_COORDINATOR")` for **90s**. It only checked the service *exists* — never whether its ACP stream was bound.

So on a heavy boot (big character, many plugins, embedding warmup) where `AcpService.start()` finished **past 60s**, the coordinator's bind window expired. The service object still existed, so the 90s wiring probe "succeeded" and set the chat/ws/synthesis callbacks — but **no ACP events ever reached them**. A dead-but-present coordinator was indistinguishable from a healthy one. That's the exact symptom.

Same silent-give-up class also lived in `plugin-app-control`'s verification-room bridge (30s bounded → gave up at debug; verdicts silently never posted back).

## Fix

- **Event-driven bind (primary):** `await runtime.getServiceLoadPromise(ACP)` — resolves the instant ACP finishes starting, no fixed deadline, so it can't give up before a slow boot completes. Resolves/rejects exactly once.
- **Polling fallback (secondary):** unbounded retry with backoff (500ms until ~60s, then exponential to a 5s steady-state) + escalating log severity. No more silent give-up. Exists for runtimes that don't drive the load-promise.
- **Loud failure:** if ACP fails to start (load-promise rejects), the coordinator is marked **UNBOUND at error level** with an actionable reason.
- **Observability:** new `acpBindState` getter (`status` + `reason` + `attempts`). The readiness probe reads it and now reports **WHY** supervision is degraded — distinguishing *plugin missing* (debug) from *registered but never bound* / *present but ACP stream not bound* (warn, with reason).

## Repro / evidence

New `plugins/plugin-agent-orchestrator/src/__tests__/swarm-coordinator-acp-bind.test.ts` drives the exact race with fake timers. **All 5 tests FAIL on develop HEAD** (the late-register case never binds; `seen` stays empty; the new `acpBindState` surface doesn't exist) and **PASS with the fix**:

- late ACP registration ~70s (> old 60s window) — the regression
- event-driven bind on a slow boot
- normal boot binds immediately, 0 retries
- ACP start failure → UNBOUND loudly with reason
- never-registers → keeps retrying (unbounded), does not go silent

```
Test Files  1 passed (1)
     Tests  5 passed (5)
```

Full plugin unit suite green:
```
Test Files  133 passed | 4 skipped (137)
     Tests  1380 passed | 8 skipped (1388)
```

`tsgo` clean on all touched files. (The one pre-existing `@elizaos/agent/utils/atomic-json` error is in `packages/app-core/src/services/coding-account-bridge.ts`, unmodified by this diff — it needs the `@elizaos/agent` package built and is not from this change.)

## Notes

- One concern per PR: only the coordinator ACP-bind race + its readiness reporting.
- Adjacent but different concern: #11205 (task-store delete/write race) and #11214 (stale enrichment metadata) — untouched.
- No forbidden files touched (verified `vite.config.ts` / `index.html` / `client-base.ts` untouched); no binary files.
- **codex review not run (usage-limited).**

— [sol-orch]
