### PR TITLE
fix(ui): resolve #11144 — ShellBackButton occludes the first filter chip of the spatial views

### DIFF
--- a/packages/app/test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/apps-personal-assistant-decomposed-interactions.spec.ts
@@ -10,6 +10,7 @@
 // interaction owner that closes INTERACTION_DEBT in
 // view-interaction-coverage.test.ts.
 
+import type { Locator } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 import {
   installDefaultAppRoutes,
@@ -21,6 +22,40 @@ test.beforeEach(async ({ page }) => {
   await seedAppStorage(page);
   await installDefaultAppRoutes(page);
 });
+
+// Regression guard for #11144: the shell's fixed "Go back" button (z-[60],
+// top-left) used to sit on top of the FIRST filter chip of the decomposed
+// spatial views, so `document.elementFromPoint` at the chip centre returned the
+// back button and the chip was untappable on both the desktop and Pixel-7
+// lanes. The shell now reserves the back-button column (SHELL_BACK_INSET_CLASS
+// in packages/ui/src/App.tsx), so the chip centre must hit-test to the chip
+// itself (or a descendant). Assert that before driving the chip so a shell
+// regression fails here loudly instead of silently making the chip dead again.
+async function expectChipIsTopHit(chip: Locator): Promise<void> {
+  await expect(chip).toBeVisible({ timeout: 15_000 });
+  await chip.scrollIntoViewIfNeeded();
+  const hit = await chip.evaluate((el) => {
+    const r = el.getBoundingClientRect();
+    const top = document.elementFromPoint(
+      r.left + r.width / 2,
+      r.top + r.height / 2,
+    );
+    return {
+      isSelf: top === el || el.contains(top),
+      topLabel: top?.getAttribute("aria-label") ?? null,
+      topTestId: top?.getAttribute("data-testid") ?? null,
+    };
+  });
+  // The chip centre must resolve to the chip, NOT the shell back button
+  // (data-testid="shell-back-button", aria-label="Go back"). #11144.
+  expect(
+    hit.isSelf,
+    `first filter chip must be the top hit-test target at its centre, not ` +
+      `occluded by the shell back button (#11144). elementFromPoint resolved ` +
+      `to testId=${hit.topTestId} label=${hit.topLabel}`,
+  ).toBe(true);
+  expect(hit.topTestId).not.toBe("shell-back-button");
+}
 
 test("calendar decomposed view: day/week/month view-mode control switches", async ({
   page,
@@ -76,23 +111,24 @@ test("inbox decomposed view: channel filters toggle", async ({ page }) => {
     page.getByText("gm everyone — standup in 10").first(),
   ).toBeVisible({ timeout: 15_000 });
 
-  // Activating a channel chip narrows the server query (?channels=<channel>)
-  // and the rendered list: the active chip is renamed "* <Channel>", its
-  // thread stays, and the other channel's thread disappears.
-  //
-  // KNOWN BUG (documented, not accepted): the first chip in the row ("Email")
-  // sits under the shell's floating "Go back" button (fixed, z-60, top-left),
-  // which intercepts pointer events on BOTH the desktop and Pixel-7 lanes, so
-  // the Email chip is untappable. Drive the same filter semantics through the
-  // "Discord" chip (clear of the overlay) until the shell occlusion is fixed.
-  await page.getByRole("button", { name: "Discord", exact: true }).click();
-  await expect(
-    page.getByRole("button", { name: "* Discord", exact: true }),
-  ).toBeVisible({ timeout: 15_000 });
-  await expect(
-    page.getByText("gm everyone — standup in 10").first(),
-  ).toBeVisible({ timeout: 15_000 });
-  await expect(page.getByText("Invoice #42 overdue")).toHaveCount(0, {
+  // #11144 regression guard: the FIRST chip in the row ("Email") used to be
+  // occluded by the shell's fixed "Go back" button (z-[60], top-left) and was
+  // untappable on both the desktop and Pixel-7 lanes. The shell now reserves
+  // the back-button column (SHELL_BACK_INSET_CLASS), so the Email chip centre
+  // must hit-test to the chip itself, and clicking it must drive the real
+  // channel-filter semantics: the active chip is renamed "* Email", the gmail
+  // thread stays, and the Discord thread disappears.
+  const email = page.getByRole("button", { name: "Email", exact: true });
+  await expectChipIsTopHit(email);
+  await email.click();
+  // Selecting Email narrows the server query to the gmail channel: the gmail
+  // thread stays and the Discord thread disappears. (The active chip renders a
+  // "* Email" affordance like the other channels' "* <Channel>", but the
+  // list-narrowing outcome is the label-independent proof the tap landed.)
+  await expect(page.getByText("Invoice #42 overdue").first()).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(page.getByText("gm everyone — standup in 10")).toHaveCount(0, {
     timeout: 15_000,
   });
 });
@@ -239,15 +275,15 @@ test("relationships decomposed view: renders the graph and toggles a kind filter
     timeout: 15_000,
   });
 
-  // Clicking the active kind chip again deselects it (back to every kind).
-  // KNOWN BUG (documented, not accepted): the dedicated "All" chip is the
-  // first chip in the row and sits under the shell's floating "Go back"
-  // button (fixed, z-60, top-left) on both lanes, so it is untappable — same
-  // occlusion as the inbox "Email" chip. The toggle-off path exercises the
-  // same restore semantics.
-  await page
-    .getByRole("button", { name: "Organizations", exact: true })
-    .click();
+  // #11144 regression guard: the dedicated "All" chip is the FIRST chip in the
+  // row and used to sit under the shell's fixed "Go back" button (z-[60],
+  // top-left) on both lanes, so it was untappable — the same occlusion as the
+  // inbox "Email" chip. The shell now reserves the back-button column, so the
+  // "All" chip centre must hit-test to the chip, and tapping it restores every
+  // kind (Graph (3)).
+  const all = page.getByRole("button", { name: "All", exact: true });
+  await expectChipIsTopHit(all);
+  await all.click();
   await expect(page.getByText("Graph (3)").first()).toBeVisible({
     timeout: 15_000,
   });

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -112,6 +112,18 @@ import { VoiceWorkbenchShell } from "./voice/voice-selftest/VoiceWorkbenchShell"
 
 const MOBILE_NAV_PADDING_CLASS =
   "pb-[calc(var(--eliza-mobile-nav-offset,0px)+var(--safe-area-bottom,0px)+var(--eliza-continuous-chat-clearance,5.25rem))]";
+
+// Reserve the ShellBackButton footprint on the LEFT of routed content so the
+// top-left of a view (e.g. the first filter chip of the decomposed spatial
+// views) is never under the fixed `z-[60]` back button and stays tappable.
+// The button is `left: calc(safe-area-left + 0.75rem)` and `h-9 w-9` (2.25rem),
+// so its right edge is at `safe-area-left + 3rem`; we add a 0.5rem gap → a
+// 3.5rem + safe-area reserved column. Applied to the routed shell, which always
+// renders ShellBackButton — so there is no width-dependent layout jump (the
+// button is present on both the desktop and mobile lanes). Full-bleed pages own
+// their edge-to-edge surface and position their own content, so they are left
+// untouched. See issue #11144.
+const SHELL_BACK_INSET_CLASS = "pl-[calc(var(--safe-area-left,0px)+3.5rem)]";
 type ExtractComponent<TValue> =
   TValue extends ComponentType<infer Props> ? ComponentType<Props> : never;
 
@@ -1471,13 +1483,17 @@ function routedShellMainClass(tab: string): string {
   // One tight page gutter for every routed view: minimal top so headers sit
   // right under the chrome, a small side gutter, modest bottom. Views that own
   // their full surface (browser/apps/views/background) still get zero padding.
-  const pagePadding =
+  // The LEFT gutter reserves the ShellBackButton footprint (#11144) so the
+  // top-left of a view — e.g. the first filter chip of the decomposed spatial
+  // views — never sits under the fixed `z-[60]` back button and stays tappable.
+  const fullSurface =
     tab === "browser" ||
     tab === "apps" ||
     tab === "views" ||
-    tab === "background"
-      ? ""
-      : "px-2 sm:px-3 pt-2 pb-4";
+    tab === "background";
+  const pagePadding = fullSurface
+    ? ""
+    : `pr-2 sm:pr-3 pt-2 pb-4 ${SHELL_BACK_INSET_CLASS}`;
   const mobilePadding = tab === "browser" ? "" : MOBILE_NAV_PADDING_CLASS;
   return `flex flex-1 min-h-0 min-w-0 overflow-hidden ${pagePadding} ${mobilePadding}`;
 }


### PR DESCRIPTION
## What

Resolves #11144. The fixed `ShellBackButton` (`left-3 top-3 z-[60]`, `h-9 w-9`) sat on top of the **first filter chip** (`Email` / `All`) of the decomposed personal-assistant spatial views. `document.elementFromPoint` at the chip centres resolved to the back button on **both** desktop and the Pixel-7 viewport, so those chips were untappable.

## Fix approach

**Inset the chip row, don't move the button.** The back button's top-left placement is a shell-wide convention (rendered by both `RoutedShellContent` and `FullBleedShellContent`), so per the issue guidance I reserve the button's column rather than repositioning it.

- New `SHELL_BACK_INSET_CLASS = "pl-[calc(var(--safe-area-left,0px)+3.5rem)]"` in `packages/ui/src/App.tsx`.
- `routedShellMainClass` now applies it to the routed `<main>` (replacing the symmetric `px-*` with `pr-*` + the left inset).
- Footprint math: button is `left: calc(safe-area-left + 0.75rem)` and `2.25rem` wide → right edge at `safe-area-left + 3rem`; `+0.5rem` gap → a `3.5rem + safe-area` reserved column.

### Responsive-safe / no layout jump
- Uses a `calc(var(--safe-area-left,0px) + …)` arbitrary value — same pattern as the existing `MOBILE_NAV_PADDING_CLASS`, so it works identically on the desktop (`chromium`) and mobile (`Pixel-7` / `mobile-chromium`) lanes.
- **No width-dependent jump:** the back button is *always* present in the routed shell, so the inset is constant across viewports.
- **Gated:** the full-surface tabs (`browser`/`apps`/`views`/`background`) keep their existing zero-padding behaviour untouched, and `FullBleedShellContent` (edge-to-edge pages that own their surface, e.g. the orchestrator) is deliberately left alone.
- Chips remain horizontally scrollable/tappable — only the row's left origin shifts clear of the button.

## Test change

Removed the two `KNOWN BUG (documented, not accepted)` workarounds in `apps-personal-assistant-decomposed-interactions.spec.ts` (the inbox `Email` chip and the relationships `All` chip, which drove the filter through a *non-first* chip to dodge the overlay) and replaced them with a real regression guard:

```
expectChipIsTopHit(chip):
  document.elementFromPoint(chipCenter) must resolve to the chip (or a
  descendant), NOT data-testid="shell-back-button" / aria-label="Go back". (#11144)
```

Both tests now drive the real filter through the **first** chip (`Email`, `All`) after asserting it is the top hit-test target — so a shell regression fails loudly here instead of silently making the chip dead again.

## Evidence / caveats

- **App.tsx typechecks clean** (`tsgo --noEmit` on `packages/ui` — zero errors in `App.tsx`; unrelated `cloud/shared` drizzle-orm resolution noise is environmental to the worktree, not from this change).
- **biome check passes** on both edited files.
- **ui-smoke harness not run headless here:** this environment has no Playwright browsers installed and the ui-smoke harness needs a built app + served backend stub, so I could not execute the spec end-to-end. The fix rests on the `elementFromPoint` assertion logic (which is exactly the failing condition described in the issue) plus the static footprint math above. The assertion will exercise the real occlusion on both configured lanes in CI.
- **codex review not run (usage-limited).**

Co-authored-by: wakesync <shadow@shad0w.xyz>
