### PR TITLE
test(cloud): cover direct-wallet native underpayment retry regression

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-payments.integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-payments.integration.test.ts
@@ -357,7 +357,7 @@ beforeAll(async () => {
     // eslint-disable-next-line no-console
     console.warn("[direct-wallet-payments test] PGlite unavailable, skipping:", error);
   }
-}, 120_000);
+}, 240_000);
 
 afterAll(async () => {
   if (closeDb) await closeDb();
@@ -769,6 +769,46 @@ d.skipIf(!process.env.DATABASE_URL || !pgliteAvailable)(
       expect(stats.failed).toBe(1);
       const row2 = await dbWrite.query.cryptoPayments.findFirst();
       expect(row2?.status).toBe("failed_chain");
+    });
+
+    test("#11154 processBroadcastBatch fails native slippage-floor errors on the first attempt", async () => {
+      await resetTable();
+      const { payment } = await service.createPayment(env, {
+        organizationId: ORG_ID,
+        userId: USER_ID,
+        accountWalletAddress: null,
+        payerAddress: PAYER_EVM,
+        amountUsd: 60,
+        network: "bsc",
+        tokenSymbol: "BNB",
+      });
+      const meta = payment.metadata as Record<string, unknown>;
+      const expectedUnits = BigInt(meta.expected_token_units as string);
+      const receive = env.CRYPTO_DIRECT_BSC_RECEIVE_ADDRESS;
+      const hash = `0x${"c".repeat(64)}`;
+      await trustPayerProof(payment);
+      await service.attachTransaction(env, {
+        paymentId: payment.id,
+        txHash: hash,
+        userId: USER_ID,
+      });
+      chainTxs.set(hash, {
+        from: PAYER_EVM,
+        to: receive,
+        value: (expectedUnits * 90n) / 100n,
+        status: "success",
+        receiveAddress: receive,
+      });
+
+      const stats = await service.processBroadcastBatch(env);
+
+      expect(stats.failed).toBe(1);
+      const row = await dbWrite.query.cryptoPayments.findFirst();
+      expect(row?.status).toBe("failed_chain");
+      expect((row?.metadata as Record<string, unknown>).failure_reason).toMatch(
+        /below the expected floor/,
+      );
+      expect(Number((row?.metadata as Record<string, unknown>).verify_attempts ?? 0)).toBe(0);
     });
 
     test("Solana confirmPayment rejects when receiving ATA owner mismatches treasury", async () => {


### PR DESCRIPTION
Follow-up to #11154 / #11189.

This adds one regression test for the BSC native-token path through `processBroadcastBatch`: an attached BNB tx below the locked slippage floor must fail closed on the first cron pass, without bumping `verify_attempts` and retrying like an RPC/transient error.

It also widens this integration file's PGlite `beforeAll` budget from 120s to 240s. On this Windows checkout the suite setup can legitimately exceed 120s after Vite transform/import, and the narrower timeout failed before the selected tests ran.

Validation on Windows:
- `git diff --check origin/develop...HEAD`
- `bunx @biomejs/biome@2.5.1 check packages/cloud/shared/src/lib/services/__tests__/direct-wallet-payments.integration.test.ts`
- `bun run --cwd packages/cloud/shared test:vitest -- -t processBroadcastBatch` -> 1 file passed; 10 passed, 29 skipped

Known warning: Vitest reports existing nested `vi.mock` hoisting warnings in this file; this PR does not introduce that pattern.
