### PR TITLE
fix(openai): surface provider errors on the live-streaming chat path (sev-high)

### DIFF
--- a/plugins/plugin-openai/__tests__/native-plumbing.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/native-plumbing.shape.test.ts
@@ -301,6 +301,73 @@ describe("OpenAI native text plumbing", () => {
     expect(onStreamChunk).toHaveBeenNthCalledWith(2, "lo");
   });
 
+  it("re-throws a provider error routed to onError during live streaming (no silent empty reply)", async () => {
+    // The AI SDK routes a request failure to onError and ends textStream empty
+    // rather than throwing. The live-streaming branch must capture that error
+    // and re-throw it when the stream ends, so the runtime's `for await`
+    // consumer throws and multi-provider failover engages (instead of treating
+    // the empty stream as a successful empty reply).
+    const providerError = new Error("provider 429 after retries");
+    aiMocks.streamText.mockImplementation(
+      (params: { onError?: (e: { error: unknown }) => void }) => {
+        // Simulate the SDK invoking onError, then closing the stream empty.
+        params.onError?.({ error: providerError });
+        // Companion promises resolve empty (the SDK leaves them unresolved/
+        // rejected on a failed stream, but they are not what this test asserts
+        // — the fix surfaces the error via the captured onError + textStream
+        // re-throw, not the companions). Resolving avoids spurious unhandled
+        // rejections from companions the prompt-only path never consumes.
+        return {
+          textStream: (async function* emptyStream() {
+            // no chunks — the request failed before any text
+          })(),
+          text: Promise.resolve(""),
+          toolCalls: Promise.resolve([]),
+          finishReason: Promise.resolve(undefined),
+          usage: Promise.resolve(undefined),
+        };
+      }
+    );
+
+    const { handleTextSmall } = await import("../models/text");
+    const stream = (await handleTextSmall(createRuntime(), {
+      prompt: "stream",
+      stream: true,
+    } as never)) as { textStream: AsyncIterable<string> };
+
+    await expect(
+      (async () => {
+        for await (const _chunk of stream.textStream) {
+          // drain
+        }
+      })()
+    ).rejects.toThrow("provider 429 after retries");
+  });
+
+  it("does not throw when a live stream ends empty with no provider error", async () => {
+    // Control for the fix above: a genuinely empty (but successful) stream must
+    // still complete normally — the re-throw is gated on a captured error only.
+    aiMocks.streamText.mockResolvedValue({
+      textStream: (async function* emptyStream() {})(),
+      text: Promise.resolve(""),
+      toolCalls: Promise.resolve([]),
+      finishReason: Promise.resolve("stop"),
+      usage: Promise.resolve({ inputTokens: 1, outputTokens: 0 }),
+    });
+
+    const { handleTextSmall } = await import("../models/text");
+    const stream = (await handleTextSmall(createRuntime(), {
+      prompt: "stream",
+      stream: true,
+    } as never)) as { textStream: AsyncIterable<string> };
+
+    const chunks: string[] = [];
+    for await (const chunk of stream.textStream) {
+      chunks.push(chunk);
+    }
+    expect(chunks).toEqual([]);
+  });
+
   it("maps string responseFormat json_object into the AI SDK responseFormat", async () => {
     aiMocks.generateText.mockResolvedValue({
       text: "{}",

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -1333,13 +1333,35 @@ async function generateTextByModelType(
       generateParams
     );
     details.response = "";
-    const result = await recordLlmCall(runtime, details, () => streamText(generateParams));
+    // The AI SDK does NOT throw on a request failure during live streaming — it
+    // routes the error to `onError` and ends `textStream` empty (see the same
+    // hazard documented for the buffered path above). Without capturing it, an
+    // empty stream reads as a SUCCESSFUL empty reply upstream: the user sees a
+    // blank bubble, the runtime's multi-provider failover never engages (it only
+    // advances on a thrown error), and the only trace is the SDK's default
+    // console.error. Capture the error and re-throw it at the end of the
+    // generator so the runtime's `for await` consumer throws and failover works.
+    let streamError: unknown;
+    const result = await recordLlmCall(runtime, details, () =>
+      streamText({
+        ...generateParams,
+        onError: ({ error }: { error: unknown }) => {
+          streamError = error;
+        },
+      })
+    );
 
     return {
       textStream: (async function* textStreamWithCallback() {
         for await (const chunk of result.textStream) {
           params.onStreamChunk?.(chunk);
           yield chunk;
+        }
+        // The SDK ended the stream; if it ended because of a provider error,
+        // surface it now (a mid-stream disconnect after partial chunks also
+        // throws here instead of yielding a silently truncated reply).
+        if (streamError !== undefined) {
+          throw streamError;
         }
       })(),
       text: handledPromise(result.text),


### PR DESCRIPTION
Fixes #11233. **Sev-high launch-blocker** — found by a Fable-5 adversarial hunt of the streaming path, verified end-to-end.

### The bug
The live-streaming branch of `generateTextByModelType` (`plugins/plugin-openai/models/text.ts`) called `streamText(generateParams)` with **no `onError`**. The AI SDK doesn't throw on a request failure during streaming — it routes the error to `onError` and ends `textStream` empty (confirmed in `ai@6.0.174`: default `onError = ({error}) => console.error(error)`; `textStream` drops error parts). So the runtime's `for await` consumer gets **zero chunks and returns `""` as a SUCCESSFUL reply**:
- the user sees a blank bubble,
- multi-provider **failover never engages** (it only advances on a thrown error),
- the transient-retry helper never runs (it's gated to the coding sub-agent's `ELIZA_PLANNER_FULL_ACTION_SURFACE`),
- the only trace is a raw `console.error` outside the structured logger.

Every streamed chat turn during a provider hiccup (expired key 401, model-not-found 404, context-length 400, 429/5xx after SDK retries, mid-stream disconnect) was a **silent failure**. The default chat path is streaming, so this is the phone/SSE user's normal path.

The codebase already documents this exact hazard (text.ts:1139-1143) and fixed it **only** in the buffered coding path. This closes the gap for regular chat.

### The fix
Attach `onError` to capture the error; re-throw it when the generator's stream ends. The runtime's consumer then throws → lands in the `useModel` catch → failover/retry works, exactly as the buffered path already does. A mid-stream disconnect after partial chunks also surfaces instead of yielding a silently truncated reply.

### Evidence
- **Test** (`native-plumbing.shape.test.ts`): a provider error routed to `onError` now **rejects** the consumed `textStream`; a genuinely-empty *successful* stream still completes normally (control). **Mutation-checked** — neutralizing the re-throw turns the error test red.
- `tsgo --noEmit` clean; biome clean. `onError` on `streamText` is already used by the buffered path (same file), confirming the SDK API.

### N/A rows
- Live-LLM trajectory: N/A to force in CI (needs a real provider outage); the failure mode is exercised deterministically via the SDK-contract mock (`onError` invoked + empty stream), which is exactly what the SDK does on a real failure.
- Screenshots: N/A — backend model-handler error-propagation fix, no UI change (the *effect* is the user stops getting silent blank replies).