### PR TITLE
fix(ci): pin cloud-cf-deploy bun off canary — unblock stranded prod deploys (#10839)

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -204,7 +204,12 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
-          bun-version: "canary"
+          # Pinned off `canary`: canary's link phase hangs on the self-hosted
+          # runners (bun install resolves+extracts in ~2min then stalls past the
+          # 900s cap, ×3 retries), stranding prod deploys — observed on runs
+          # 28552075615 and 28569068598 (the money-integrity wave). A released
+          # bun does not exhibit the hang. See elizaOS/eliza#10839.
+          bun-version: "latest"
 
       - name: Install dependencies
         working-directory: ${{ env.CHECKOUT_DIR }}
@@ -507,7 +512,12 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
-          bun-version: "canary"
+          # Pinned off `canary`: canary's link phase hangs on the self-hosted
+          # runners (bun install resolves+extracts in ~2min then stalls past the
+          # 900s cap, ×3 retries), stranding prod deploys — observed on runs
+          # 28552075615 and 28569068598 (the money-integrity wave). A released
+          # bun does not exhibit the hang. See elizaOS/eliza#10839.
+          bun-version: "latest"
 
       - name: Install dependencies
         working-directory: ${{ env.CHECKOUT_DIR }}
@@ -841,7 +851,12 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
-          bun-version: "canary"
+          # Pinned off `canary`: canary's link phase hangs on the self-hosted
+          # runners (bun install resolves+extracts in ~2min then stalls past the
+          # 900s cap, ×3 retries), stranding prod deploys — observed on runs
+          # 28552075615 and 28569068598 (the money-integrity wave). A released
+          # bun does not exhibit the hang. See elizaOS/eliza#10839.
+          bun-version: "latest"
 
       - name: Install dependencies
         working-directory: ${{ env.CHECKOUT_DIR }}


### PR DESCRIPTION
All 3 cloud-cf-deploy jobs pinned bun to \`canary\`, whose link phase hangs on the self-hosted runners (install resolves in ~2min, then stalls past the 900s cap x3 → deploy fails). This stranded prod deploys — including the in-flight **money-integrity wave** deploy \`28569068598\` (payout gate #11190, cron #11189, escrow, gate #11163), so those merged fixes are NOT live for real users. Pin to \`latest\` (release); a released bun does not hang. @lalalune can pin a specific version if preferred. Refs #10839. `[cloud-audit]`