### PR TITLE
fix(cloud): gate eliza-app provisioning-agent first-provision on credits (#11224 candidate 2)

### DIFF
--- a/packages/cloud/api/__tests__/provisioning-agent-default-image.test.ts
+++ b/packages/cloud/api/__tests__/provisioning-agent-default-image.test.ts
@@ -73,6 +73,15 @@ mock.module("@/lib/utils/logger", () => ({
   },
 }));
 
+const mockCheckAgentCreditGate = mock(async () => ({
+  allowed: true as boolean,
+  balance: 10,
+  error: undefined as string | undefined,
+}));
+mock.module("@/lib/services/agent-billing-gate", () => ({
+  checkAgentCreditGate: mockCheckAgentCreditGate,
+}));
+
 // Import after all mocks are in place.
 const { default: app } = await import("../eliza-app/provisioning-agent/route");
 
@@ -166,5 +175,28 @@ describe("provisioning-agent DEFAULT_DOCKER_IMAGE", () => {
     const call = firstCreateAgentCall();
     expect(call).toBeDefined();
     expect(call!.dockerImage).toMatch(/^ghcr\.io\//);
+  });
+
+  test("#11224: a credit-suspended org is blocked 402 — no dedicated agent created or provisioned", async () => {
+    mockListByOrganization.mockResolvedValue([]); // no existing sandbox → provision path
+    mockCreateAgent.mockClear();
+    mockEnqueueAgentProvision.mockClear();
+    mockCheckAgentCreditGate.mockResolvedValueOnce({
+      allowed: false,
+      balance: 0,
+      error: "Insufficient credits",
+    });
+
+    const req = new Request("http://localhost/", {
+      method: "POST",
+      headers: { Authorization: "Bearer valid-session-token" },
+    });
+    const res = await app.fetch(req);
+
+    expect(res.status).toBe(402);
+    expect(await res.json()).toMatchObject({ code: "insufficient_credits" });
+    // The gate fires BEFORE any dedicated agent is minted/provisioned.
+    expect(mockCreateAgent).not.toHaveBeenCalled();
+    expect(mockEnqueueAgentProvision).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/eliza-app/provisioning-agent/route.ts
+++ b/packages/cloud/api/eliza-app/provisioning-agent/route.ts
@@ -13,6 +13,8 @@ import type { Context } from "hono";
 import { Hono } from "hono";
 import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
 import { containersEnv } from "@/lib/config/containers-env";
+import { AGENT_PRICING } from "@/lib/constants/agent-pricing";
+import { checkAgentCreditGate } from "@/lib/services/agent-billing-gate";
 import { elizaAppSessionService } from "@/lib/services/eliza-app";
 import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
 import { provisioningJobService } from "@/lib/services/provisioning-jobs";
@@ -91,6 +93,36 @@ app.post("/", async (c) => {
 
     if (existing) {
       return c.json({ success: true, data: sandboxPayload(existing) });
+    }
+
+    // Credit gate before provisioning a NEW dedicated agent (#11224): this
+    // creates a custom-image (DEFAULT_DOCKER_IMAGE → dedicated) sandbox and
+    // eagerly enqueues its container, the same paid compute the main
+    // create/resume/wake paths gate. Without it a credit-suspended / zero-balance
+    // org gets a free dedicated container. New orgs clear this via the signup
+    // grant; only genuinely suspended orgs are blocked. (Existing sandboxes
+    // returned above are unaffected — this only fences the first provision.)
+    const creditCheck = await checkAgentCreditGate(session.organizationId);
+    if (!creditCheck.allowed) {
+      logger.warn(
+        "[eliza-app provisioning-agent] provision blocked: insufficient credits",
+        {
+          orgId: session.organizationId,
+          balance: creditCheck.balance,
+          required: AGENT_PRICING.MINIMUM_DEPOSIT,
+        },
+      );
+      return c.json(
+        {
+          success: false,
+          code: "insufficient_credits",
+          error:
+            creditCheck.error ?? "Insufficient credits to provision an agent",
+          requiredBalance: AGENT_PRICING.MINIMUM_DEPOSIT,
+          currentBalance: creditCheck.balance,
+        },
+        402,
+      );
     }
 
     // No sandbox yet — create one and enqueue provisioning.


### PR DESCRIPTION
Resolves the eliza-app half of #11224 (pairing-token half = #11227).

## Problem (MED — free dedicated compute for a suspended org)
`POST /api/eliza-app/provisioning-agent` creates a **dedicated** agent (`dockerImage = DEFAULT_DOCKER_IMAGE` → custom tier = paid container) and eagerly enqueues its container when the org has no sandbox, with **no credit gate**. Any valid session — including a credit-suspended / zero-balance org — could get a free dedicated container.

## Fix (verified tier-correct)
Confirmed this path is **always dedicated** (never shared — it always passes `dockerImage`), so unlike the general worry in #11224, a gate here can't wrongly block a free shared agent. Added `checkAgentCreditGate → 402` before the first-provision `createAgent`, mirroring the main create/resume/wake paths. New orgs clear it via the $5 signup grant; only genuinely suspended orgs are blocked. Existing-sandbox calls (returned earlier) are unaffected — only the first provision is fenced.

## Test (`provisioning-agent-default-image.test.ts`, +1)
- suspended org (gate denied) → **402**, `createAgent` + `enqueueAgentProvision` **not** called.
- Existing image-canonicalization tests unchanged (**4 pass**).

`packages/cloud/api build` + biome clean. Money-path — flagging for maintainer merge. `[cloud-security]`