### PR TITLE
fix(core): stop the fact-extractor silently discarding a whole turn's memory ops (sev-high)

### DIFF
--- a/packages/core/src/features/advanced-capabilities/evaluators/factExtractor.schema.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/factExtractor.schema.ts
@@ -78,7 +78,14 @@ const AddDurableOpSchema = z.object({
 	op: z.literal("add_durable"),
 	claim: z.string().min(1),
 	category: DurableCategoryEnum,
-	structured_fields: StructuredFieldsSchema,
+	// `.default({})`, NOT required: the advertised wire schema (reflection-items
+	// factOpsSchema) marks structured_fields optional (only `op` is required)
+	// and the extractor prompt never even names the field, so the model omits it
+	// on most turns. A required schema here rejected those ops — and because the
+	// whole `ops` array was parsed atomically, one omission silently discarded
+	// EVERY fact op for the turn. The default keeps the inferred type a
+	// non-optional record so downstream applyAddDurable stays type-safe.
+	structured_fields: StructuredFieldsSchema.default({}),
 	keywords: KeywordsSchema,
 	verification_status: VerificationStatusEnum.optional(),
 	reason: z.string().optional(),
@@ -88,7 +95,8 @@ const AddCurrentOpSchema = z.object({
 	op: z.literal("add_current"),
 	claim: z.string().min(1),
 	category: CurrentCategoryEnum,
-	structured_fields: StructuredFieldsSchema,
+	// See AddDurableOpSchema: wire-optional + prompt-unnamed → default, not required.
+	structured_fields: StructuredFieldsSchema.default({}),
 	keywords: KeywordsSchema,
 	/**
 	 * ISO timestamp of when the state began. Optional in the schema because
@@ -149,3 +157,35 @@ export const ExtractorOutputSchema = z.object({
 });
 
 export type ExtractorOutput = z.infer<typeof ExtractorOutputSchema>;
+
+/**
+ * Parse the extractor envelope tolerantly, op-by-op.
+ *
+ * `ExtractorOutputSchema` parses the whole `ops` array atomically, so a single
+ * malformed op (the model occasionally hallucinates one bad entry among good
+ * ones — a missing `factId` on a strengthen, a `contradict` with no `reason`)
+ * fails `safeParse` and silently discards EVERY fact op for the turn. That is
+ * real, launch-critical memory loss.
+ *
+ * This validates the envelope leniently (`{ ops: [...] }`), then validates each
+ * op independently, keeping only the ones that pass and reporting how many were
+ * dropped so the caller can log it. Returns null only when the envelope itself
+ * is not `{ ops: array }` (a genuinely malformed section).
+ */
+export function parseExtractorOutputTolerant(
+	output: unknown,
+): { value: ExtractorOutput; dropped: number } | null {
+	const envelope = z.object({ ops: z.array(z.unknown()) }).safeParse(output);
+	if (!envelope.success) return null;
+	const ops: ExtractorOp[] = [];
+	let dropped = 0;
+	for (const raw of envelope.data.ops) {
+		const parsed = OpSchema.safeParse(raw);
+		if (parsed.success) {
+			ops.push(parsed.data);
+		} else {
+			dropped += 1;
+		}
+	}
+	return { value: { ops }, dropped };
+}

--- a/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.test.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.test.ts
@@ -202,3 +202,56 @@ describe("reflection evaluator schemas are strict-structured-output safe", () =>
 		}
 	});
 });
+
+describe("factExtractor tolerant parsing (#11235)", () => {
+	it("accepts an add op that omits structured_fields (wire-optional, prompt-unnamed)", async () => {
+		const { parseExtractorOutputTolerant } = await import(
+			"./factExtractor.schema.ts"
+		);
+		const parsed = parseExtractorOutputTolerant({
+			ops: [
+				{ op: "add_durable", claim: "lives in Berlin", category: "identity" },
+			],
+		});
+		expect(parsed).not.toBeNull();
+		expect(parsed?.dropped).toBe(0);
+		expect(parsed?.value.ops).toHaveLength(1);
+		// The default keeps structured_fields a concrete record for downstream use.
+		expect(parsed?.value.ops[0]).toMatchObject({
+			op: "add_durable",
+			structured_fields: {},
+		});
+	});
+
+	it("keeps valid ops when one op in the array is malformed (no whole-turn discard)", async () => {
+		const { parseExtractorOutputTolerant } = await import(
+			"./factExtractor.schema.ts"
+		);
+		const parsed = parseExtractorOutputTolerant({
+			ops: [
+				{ op: "add_durable", claim: "likes tea", category: "preference" },
+				{ op: "contradict" }, // invalid: missing required factId + reason
+				{ op: "strengthen", factId: "fact-123" },
+			],
+		});
+		expect(parsed).not.toBeNull();
+		expect(parsed?.dropped).toBe(1);
+		expect(parsed?.value.ops.map((o) => o.op)).toEqual([
+			"add_durable",
+			"strengthen",
+		]);
+	});
+
+	it("returns null only when the envelope itself is not { ops: array }", async () => {
+		const { parseExtractorOutputTolerant } = await import(
+			"./factExtractor.schema.ts"
+		);
+		expect(parseExtractorOutputTolerant({ nope: true })).toBeNull();
+		expect(parseExtractorOutputTolerant(null)).toBeNull();
+		// An empty ops array is a VALID (zero-op) turn, not a parse failure.
+		expect(parseExtractorOutputTolerant({ ops: [] })).toMatchObject({
+			dropped: 0,
+			value: { ops: [] },
+		});
+	});
+});

--- a/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.ts
@@ -39,7 +39,8 @@ import {
 	type ContradictOp,
 	type DecayOp,
 	type ExtractorOp,
-	ExtractorOutputSchema,
+	type ExtractorOutput,
+	parseExtractorOutputTolerant,
 	type StrengthenOp,
 } from "./factExtractor.schema.ts";
 import {
@@ -861,10 +862,7 @@ function canEvaluateMessage(message: Memory): boolean {
 	);
 }
 
-export const factMemoryEvaluator: Evaluator<
-	z.infer<typeof ExtractorOutputSchema>,
-	FactPrepared
-> = {
+export const factMemoryEvaluator: Evaluator<ExtractorOutput, FactPrepared> = {
 	name: "factMemory",
 	description:
 		"Extracts durable/current fact-store ops from recent conversation.",
@@ -901,8 +899,11 @@ Known current facts:
 ${formatKnownLines(current.slice(0, MAX_KNOWN_PER_KIND), "current")}`;
 	},
 	parse(output) {
-		const result = ExtractorOutputSchema.safeParse(output);
-		return result.success ? result.data : null;
+		// Tolerant, op-by-op: a single malformed op must not discard the whole
+		// turn's valid fact ops (see parseExtractorOutputTolerant). Returns null
+		// only when the envelope itself isn't `{ ops: [...] }`.
+		const result = parseExtractorOutputTolerant(output);
+		return result ? result.value : null;
 	},
 	processors: [
 		{


### PR DESCRIPTION
Fixes #11239. **Sev-high silent memory loss** — the post-turn fact/relationship/identity extraction discarded the ENTIRE turn's ops on two common, wire-legal inputs. Found by a Fable-5 adversarial hunt, reproduced empirically.

### Two coupled defects (`factExtractor.schema.ts`)
Both end at `ExtractorOutputSchema.safeParse` → null → `parse()` returns null → every op for the turn dropped:

1. **`structured_fields` required in zod, but wire-optional + prompt-unnamed.** `factOpsSchema` (the advertised wire schema) has `required: ["op"]` only, and the extractor prompt never names `structured_fields`, so the model omits it on most turns → op rejected → whole turn lost. **Reproduced:** `add_durable` without `structured_fields` → REJECTED.
2. **Atomic array parse.** `z.array(OpSchema)` fails wholesale if any element is invalid — one hallucinated bad op (a `contradict` with no `reason`) nukes the valid ops beside it. **Reproduced:** `[valid add, contradict-without-reason]` → WHOLE ARRAY REJECTED.

### Fix
- `structured_fields: StructuredFieldsSchema.default({})` on the add ops — tolerates the omission; `.default` keeps the inferred type a non-optional record so `applyAddDurable`/`applyAddCurrent` stay type-safe (no downstream change).
- `parseExtractorOutputTolerant(output)` — validate the envelope leniently (`{ ops: [...] }`), then each op independently, keeping the passing ones and returning a `dropped` count. Returns null only for a genuinely malformed section. Wired into `reflection-items.ts` `parse()`.

### Evidence
- **Mutation-checked tests** (reflection-items.test.ts): (a) an add op omitting `structured_fields` now parses with `structured_fields: {}`; (b) a mixed valid/invalid array keeps the valid ops (`dropped: 1`); (c) a non-envelope still returns null, and `{ops: []}` is a valid zero-op turn. Reverting fix #1 fails (a); reverting fix #2 (atomic parse) fails (b).
- `tsgo --noEmit` clean; multi-target core build (node+browser+edge) clean; biome clean.

### Scope note
Making the discard **observable** (a `logger.warn` on `dropped > 0` and on the parse-null) is a separate, broader evaluator-silent-failure finding (services/evaluator.ts) — `parseExtractorOutputTolerant` already returns the `dropped` count to enable it. This PR is the correctness fix (stop losing the data); the logging PR can consume the count.

### N/A rows
- Live-LLM trajectory: N/A to force in CI (needs a live extraction turn); the failure inputs are exercised deterministically against the real exported schema (not a mock).
- Screenshots: N/A — backend memory-pipeline fix, no UI.