### PR TITLE
fix(homepage): mirror hover contrast on focus

### DIFF
--- a/packages/homepage/src/index.css
+++ b/packages/homepage/src/index.css
@@ -11,6 +11,8 @@
   --font-sans: "Poppins";
   --font-mono: "Poppins";
   --radius-xs: 3px;
+  /* Dark enough for AA contrast on white while staying in the orange brand family. */
+  --brand-orange-hover: #9c3600;
 }
 
 body {
@@ -760,8 +762,10 @@ article {
 }
 
 .app-release-link:hover,
-.app-checksum-row a:hover {
-  color: #9c3600;
+.app-release-link:focus-visible,
+.app-checksum-row a:hover,
+.app-checksum-row a:focus-visible {
+  color: var(--brand-orange-hover);
   text-decoration: underline;
 }
 
@@ -809,7 +813,9 @@ article {
   box-shadow: 0 20px 60px rgba(8, 9, 12, 0.06);
 }
 
-.app-download-card:hover {
+.app-download-card:hover,
+.app-download-card:focus-visible,
+.app-download-card:focus-within {
   background: var(--brand-black);
   color: var(--brand-white);
   transform: translateY(-1px);
@@ -866,7 +872,9 @@ article {
   color: rgba(8, 9, 12, 0.45);
 }
 
-.app-download-card:hover .app-card-icon {
+.app-download-card:hover .app-card-icon,
+.app-download-card:focus-visible .app-card-icon,
+.app-download-card:focus-within .app-card-icon {
   background: rgba(255, 255, 255, 0.12);
   color: var(--brand-white);
 }
@@ -874,7 +882,15 @@ article {
 .app-download-card:hover .app-download-card-copy span,
 .app-download-card:hover .app-download-card-copy small,
 .app-download-card:hover .app-download-card-meta,
-.app-download-card:hover .app-card-arrow {
+.app-download-card:hover .app-card-arrow,
+.app-download-card:focus-visible .app-download-card-copy span,
+.app-download-card:focus-visible .app-download-card-copy small,
+.app-download-card:focus-visible .app-download-card-meta,
+.app-download-card:focus-visible .app-card-arrow,
+.app-download-card:focus-within .app-download-card-copy span,
+.app-download-card:focus-within .app-download-card-copy small,
+.app-download-card:focus-within .app-download-card-meta,
+.app-download-card:focus-within .app-card-arrow {
   color: rgba(255, 255, 255, 0.78);
 }
 
@@ -1151,7 +1167,9 @@ article {
   }
 }
 
-/* Reduced motion */
+/* Reduced motion: this standalone homepage owns animated wordmarks, pulse loops,
+   reveal transitions, and smooth scrolling, so the global override intentionally
+   wins over component-level animation declarations for accessibility. */
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,


### PR DESCRIPTION
## Summary

- add a `--brand-orange-hover` token for the darker homepage link hover/focus color instead of hard-coding the hex at each use site
- mirror the download-card hover contrast treatment for `:focus-visible` / `:focus-within` so keyboard users get the same readable state
- expand the reduced-motion WHY comment so the global `!important` override remains intentionally documented

## Why

This closes the remaining review feedback from #10300 without changing the visual design: the darker orange remains the approved high-contrast orange, but it is now centrally named, and keyboard focus gets parity with mouse hover on the interactive download cards and release/checksum links.

## Verification

- `ELIZA_SKIP_ARTIFACT_SYNC=1 bun install --frozen-lockfile`
- `bun run --cwd packages/homepage lint:check`
- `bun run --cwd packages/homepage test`
- `bun run --cwd packages/homepage typecheck`
- `bun run --cwd packages/homepage build`
- Rendered built homepage via `bun --bun vite preview --port 4455 --host 127.0.0.1`
- Captured before/after screenshots for desktop + mobile:
  - download card hover
  - download card keyboard focus
  - release link hover
  - release link keyboard focus
- Computed-style assertion on patched build:
  - release link focus color: `rgb(156, 54, 0)`
  - download card focus background/color: `rgb(0, 0, 0)` / `rgb(255, 255, 255)`
  - download card metadata focus color: `rgba(255, 255, 255, 0.78)`

Note: install used `ELIZA_SKIP_ARTIFACT_SYNC=1` because this homepage CSS change does not need the 971 MiB native artifact bundle; the artifact script itself reports progress and was intentionally skipped for this verification lane.
