### PR TITLE
fix(orchestrator): detach coding-agent turns from chat timeout

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/initial-task-timeout.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/initial-task-timeout.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { resolveInitialTaskPromptTimeoutMs } from "../services/acp-service.ts";
+
+describe("background initial task prompt timeout", () => {
+  it("detaches spawned initial tasks from the service/chat-turn timeout when no explicit timeout is set", () => {
+    expect(resolveInitialTaskPromptTimeoutMs(undefined)).toBe(0);
+  });
+
+  it("preserves explicit caller timeouts", () => {
+    expect(resolveInitialTaskPromptTimeoutMs(120_000)).toBe(120_000);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/__tests__/sub-agent-discord-routing.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/sub-agent-discord-routing.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { readOrigin } from "../services/sub-agent-router.ts";
+import type { SessionInfo } from "../services/types.ts";
+
+const ORIGIN_ROOM = "11111111-1111-4111-8111-111111111111";
+const TASK_ROOM = "22222222-2222-4222-8222-222222222222";
+const MSG = "33333333-3333-4333-8333-333333333333";
+
+function session(metadata: Record<string, unknown>): SessionInfo {
+  return {
+    id: "sess-1",
+    agentType: "codex",
+    workdir: "/tmp/work",
+    status: "ready",
+    createdAt: new Date(0),
+    lastActivityAt: new Date(0),
+    metadata,
+  } as unknown as SessionInfo;
+}
+
+describe("sub-agent Discord reply routing", () => {
+  it("keeps origin.roomId pointed at the user-facing Discord room, not the internal task room", () => {
+    const origin = readOrigin(
+      session({
+        originRoomId: ORIGIN_ROOM,
+        taskRoomId: TASK_ROOM,
+        roomId: TASK_ROOM,
+        messageId: MSG,
+        source: "discord",
+        label: "build game",
+      }),
+    );
+
+    expect(origin?.roomId).toBe(ORIGIN_ROOM);
+    expect(origin?.taskRoomId).toBe(TASK_ROOM);
+  });
+
+  it("falls back to legacy roomId when no distinct origin room was persisted", () => {
+    const origin = readOrigin(
+      session({
+        roomId: ORIGIN_ROOM,
+        messageId: MSG,
+        source: "discord",
+      }),
+    );
+
+    expect(origin?.roomId).toBe(ORIGIN_ROOM);
+    expect(origin?.taskRoomId).toBe(ORIGIN_ROOM);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -147,6 +147,16 @@ const ORPHAN_RESUME_STATUSES: ReadonlySet<string> = new Set([
 ]);
 const ORPHAN_RESUME_PROMPT =
   "[System] Your previous turn was interrupted by a runtime restart. Continue where you left off on the original task and report results as usual.";
+// Background sub-agent initial tasks are fire-and-forget from the originating
+// chat turn. When no action-level timeout is explicit, do not bind the
+// session/prompt request to the ACP service default (often configured to the
+// connector message budget, e.g. 120s). User cancel / shutdown still flow
+// through cancelSession()/stopSession(), and explicit timeouts remain honored.
+export function resolveInitialTaskPromptTimeoutMs(
+  explicitTimeoutMs: number | undefined,
+): number | undefined {
+  return explicitTimeoutMs ?? 0;
+}
 const DEFAULT_AGENTS: AgentType[] = ["elizaos", "codex", "claude", "opencode"];
 // Path segment the app-core coding-account bridge uses for per-account Codex
 // homes (`<stateDir>/auth/_codex-home/<accountId>`). buildEnv keys off this
@@ -674,7 +684,7 @@ export class AcpService extends Service {
           (opts.metadata as Record<string, unknown> | undefined)
             ?.keepAliveAfterComplete === true;
         void this.sendPrompt(id, initialTask ?? "", {
-          timeoutMs: opts.timeoutMs,
+          timeoutMs: resolveInitialTaskPromptTimeoutMs(opts.timeoutMs),
           model: opts.model,
         })
           .catch((err: unknown) => {
@@ -747,7 +757,7 @@ export class AcpService extends Service {
         (opts.metadata as Record<string, unknown> | undefined)
           ?.keepAliveAfterComplete === true;
       void this.sendPrompt(id, initialTask ?? "", {
-        timeoutMs: opts.timeoutMs,
+        timeoutMs: resolveInitialTaskPromptTimeoutMs(opts.timeoutMs),
         model: opts.model,
       })
         .catch((err: unknown) => {

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -1365,14 +1365,15 @@ export class SubAgentRouter extends Service {
       const delivered = await sendToTarget(
         {
           source,
-          roomId: target.roomId,
+          roomId: origin.roomId,
         },
         threadedResponse,
       ).catch((err) => {
         this.log("warn", "sub-agent reply delivery failed", {
           sessionId,
           source,
-          roomId: target.roomId,
+          roomId: origin.roomId,
+          targetRoomId: target.roomId,
           error: err instanceof Error ? err.message : String(err),
         });
         return undefined;
@@ -1825,7 +1826,9 @@ function publicPreferredUrls(urls: string[]): string[] {
 }
 
 interface OriginInfo {
+  /** Original user-facing room, e.g. the Discord channel-backed room. */
   roomId: UUID;
+  /** Internal task/swarm room minted for sub-agent coordination. */
   taskRoomId: UUID;
   worktreeRoomId?: UUID;
   swarmRooms: SwarmRoomTarget[];
@@ -1878,11 +1881,12 @@ export function spawnRootIdFromMeta(
   );
 }
 
-function readOrigin(session: SessionInfo): OriginInfo | null {
+export function readOrigin(session: SessionInfo): OriginInfo | null {
   const meta = session.metadata as Record<string, unknown> | undefined;
   if (!meta) return null;
   const taskRoomId = pickUuid(meta.taskRoomId) ?? pickUuid(meta.roomId);
-  const roomId = taskRoomId ?? pickUuid(meta.roomId);
+  const roomId =
+    pickUuid(meta.originRoomId) ?? pickUuid(meta.sourceRoomId) ?? taskRoomId;
   if (!roomId || !taskRoomId) return null;
   const worktreeRoomId = pickUuid(meta.worktreeRoomId);
   const swarmRooms = normalizeSwarmRooms(


### PR DESCRIPTION
## Summary
- detach spawned coding-agent initial prompts from the ACP/default prompt timeout when no explicit action timeout is supplied
- keep explicit per-action timeouts honored
- route sub-agent synthetic reply callbacks back to the original user-facing room, not the internal task room
- read `originRoomId` from spawn metadata so Discord room->channel resolution uses the channel-backed room

## Root cause
- Bug 1: `AcpService.spawnSession()` launches `initialTask` via fire-and-forget `sendPrompt()`, but passed `opts.timeoutMs` through as-is. When no explicit timeout is provided, `sendPrompt()` falls back to `sessionTimeoutMs` / native transport default request timeout (`acp-service.ts` send path, `acp-native-transport.ts` request timer), binding background coding work to a host/chat-sized request budget. The timeout path cancels the ACP prompt, then the router sees repeated state-loss/error recovery and eventually hits the state-lost cap.
- Bug 2: `readOrigin()` ignored persisted `originRoomId` and set `origin.roomId` to `taskRoomId`; `buildReplyCallback()` then delivered to `target.roomId` (often the minted task room). Discord `handleSendMessage()` resolves by `runtime.getRoom(roomId).channelId`, so internal task rooms without a Discord `channelId` fail with `Could not resolve Discord channel ID for room <uuid>`.

## Tests
- `bunx vitest run --config vitest.config.ts src/__tests__/initial-task-timeout.test.ts src/__tests__/sub-agent-discord-routing.test.ts` ✅
- `bunx @biomejs/biome check ... --no-errors-on-unmatched` ✅
- `bun run typecheck` attempted, baseline dependency failures in this worktree: unresolved `drizzle-orm`, `git-workspace-service`, `coding-agent-adapters`, generated validation keyword data, etc.

## Notes
- User cancel / shutdown still use `cancelSession()` / `stopSession()`.
- Explicit action timeout values are preserved.
