### PR TITLE
fix(cockpit): hide the placebo tier toggle + surface silent mutation errors

### DIFF
--- a/plugins/plugin-task-coordinator/src/CockpitSessionPane.test.tsx
+++ b/plugins/plugin-task-coordinator/src/CockpitSessionPane.test.tsx
@@ -374,7 +374,12 @@ describe("CockpitSessionPane — drill-in (client mocked at the boundary)", () =
     expect(screen.queryByTestId("cockpit-session-transcript")).toBeNull();
   });
 
-  it("Eliza Cloud: flipping the tier persists policy + RESTARTS (stops old worker, no agent accumulation)", async () => {
+  it("Eliza Cloud: tier toggle is HIDDEN while the Fast/Smart tiers map to the same model (no destructive placebo)", async () => {
+    // #11235: both ELIZA_CLOUD_TIER_MODEL tiers currently resolve to the same
+    // model (gemma-4-31b), so a rendered toggle would be a permanent "Fast"
+    // whose every tap fired a DESTRUCTIVE restart (stopActive kills live workers
+    // mid-turn) that swapped the model to an identical value. It must not render
+    // until the tiers genuinely diverge.
     calls.getCodingAgentTaskThread.mockResolvedValue({
       ...detailFixture,
       providerPolicy: {
@@ -384,26 +389,28 @@ describe("CockpitSessionPane — drill-in (client mocked at the boundary)", () =
       },
     });
     renderPane();
-    const smart = await screen.findByTestId("cockpit-tier-large");
-    fireEvent.click(smart);
-    // 1. persist the new tier's model on the task policy
+    // The pane loads (a stable non-tier element is present)…
+    await screen.findByTestId("cockpit-session-pane");
+    // …but neither tier control is offered, so no destructive restart is
+    // reachable from the cockpit while the tiers are indistinct.
+    expect(screen.queryByTestId("cockpit-tier-large")).toBeNull();
+    expect(screen.queryByTestId("cockpit-tier-small")).toBeNull();
+    expect(calls.restartOrchestratorTask).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a failed TaskInspector mutation (actionError) instead of failing silently", async () => {
+    // #11235: runMutation catches every write error, sets actionError, and never
+    // rethrows — so all 13 inspector mutations (pause/resume/archive/…) used to
+    // fail 100% silently. The pane now renders actionError in the alert banner.
+    calls.pauseOrchestratorTask.mockRejectedValue(new Error("task is gone"));
+    renderPane();
+    const pause = await screen.findByTestId("orchestrator-inspector-pause");
+    fireEvent.click(pause);
     await waitFor(() =>
-      expect(calls.updateOrchestratorTask).toHaveBeenCalledWith(
-        "task-1",
-        expect.objectContaining({
-          providerPolicy: expect.objectContaining({ model: "gemma-4-31b" }),
-        }),
+      expect(screen.getByTestId("cockpit-session-error").textContent).toMatch(
+        /task is gone/i,
       ),
     );
-    // 2. RESTART with stopActive (replaces the worker) — NOT addOrchestratorAgent
-    // (which would accumulate live agents on repeated flips — Shaw's review).
-    await waitFor(() =>
-      expect(calls.restartOrchestratorTask).toHaveBeenCalledWith(
-        "task-1",
-        expect.objectContaining({ stopActive: true }),
-      ),
-    );
-    expect(calls.addOrchestratorAgent).not.toHaveBeenCalled();
   });
 
   it("surfaces an error when a composer-driven message fails to deliver", async () => {
@@ -457,7 +464,10 @@ describe("CockpitSessionPane — inspector layout per surface (#11159 audit)", (
       const inspector = await screen.findByTestId("orchestrator-inspector");
       expect(inspector.className).not.toContain("w-80");
       // Drawer geometry comes from the inline style (closed => hidden).
-      expect(inspector.style.display === "none" || inspector.style.position === "absolute").toBe(true);
+      expect(
+        inspector.style.display === "none" ||
+          inspector.style.position === "absolute",
+      ).toBe(true);
     } finally {
       vi.unstubAllGlobals();
     }

--- a/plugins/plugin-task-coordinator/src/CockpitSessionPane.tsx
+++ b/plugins/plugin-task-coordinator/src/CockpitSessionPane.tsx
@@ -75,7 +75,7 @@ export function CockpitSessionPane({
   t = fallbackTranslate,
   locale,
 }: CockpitSessionPaneProps) {
-  const { detail, messages, events, mutating, runMutation } =
+  const { detail, messages, events, mutating, runMutation, actionError } =
     useOrchestratorData({
       selectedId: taskId,
       showArchived: false,
@@ -160,15 +160,26 @@ export function CockpitSessionPane({
   const isElizaCloud =
     detail?.providerPolicy?.preferredFramework === "elizaos" &&
     detail?.providerPolicy?.providerSource === "eliza-cloud";
-  const currentTier: ElizaCloudTier =
-    ELIZA_CLOUD_TIER_MODEL.small === ELIZA_CLOUD_TIER_MODEL.large
-      ? "small"
-      : detail?.providerPolicy?.model === ELIZA_CLOUD_TIER_MODEL.large
-        ? "large"
-        : "small";
+  // The Fast/Smart tiers are only distinct when their models differ. Today both
+  // map to DEFAULT_CEREBRAS_TEXT_MODEL (ELIZA_CLOUD_TIER_MODEL), so the toggle
+  // would render a permanent "Fast" whose every tap still fired a DESTRUCTIVE
+  // restart (stopActive kills the task's live workers mid-turn) that swapped the
+  // model to an identical value. Only show the toggle when the tiers genuinely
+  // diverge; the onTierChange no-op guard below is the belt-and-braces backstop.
+  const tiersAreDistinct =
+    ELIZA_CLOUD_TIER_MODEL.small !== ELIZA_CLOUD_TIER_MODEL.large;
+  const currentTier: ElizaCloudTier = !tiersAreDistinct
+    ? "small"
+    : detail?.providerPolicy?.model === ELIZA_CLOUD_TIER_MODEL.large
+      ? "large"
+      : "small";
   const onTierChange = useCallback(
     (tier: ElizaCloudTier) => {
       const model = ELIZA_CLOUD_TIER_MODEL[tier];
+      // No-op guard: never fire the destructive restart when the target model
+      // already matches the task's current model (identical-tier tap, or tiers
+      // that don't diverge).
+      if (model === detail?.providerPolicy?.model) return;
       void runMutation(async () => {
         await client.updateOrchestratorTask(taskId, {
           providerPolicy: {
@@ -184,7 +195,7 @@ export function CockpitSessionPane({
         await client.restartOrchestratorTask(taskId, { stopActive: true });
       });
     },
-    [taskId, runMutation],
+    [taskId, runMutation, detail?.providerPolicy?.model],
   );
 
   // Sub-agents render their per-session label; derive the lookup exactly as the
@@ -275,7 +286,7 @@ export function CockpitSessionPane({
           {detail?.title ??
             t("cockpit.session.loading", { defaultValue: "Loading room…" })}
         </h2>
-        {isElizaCloud ? (
+        {isElizaCloud && tiersAreDistinct ? (
           <CockpitTierToggle
             value={currentTier}
             onChange={onTierChange}
@@ -340,13 +351,18 @@ export function CockpitSessionPane({
         ) : null}
       </header>
 
-      {composerError ? (
+      {(composerError ?? actionError) ? (
         <div
           role="alert"
           data-testid="cockpit-session-error"
           className="shrink-0 border-destructive/40 border-b bg-destructive/10 px-3 py-2 text-xs text-destructive"
         >
-          {composerError}
+          {/* Surfaces BOTH the composer send error and actionError from
+              useOrchestratorData — the latter covers all 13 TaskInspector
+              mutations (pause/resume/archive/delete/restart/…) + the tier swap,
+              which previously failed 100% silently (runMutation catches, sets
+              actionError, and never rethrows). */}
+          {composerError ?? actionError}
         </div>
       ) : null}
 


### PR DESCRIPTION
Fixes #11244. Two coupled cockpit sev-meds from the Fable-5 lane hunt, both in `CockpitSessionPane.tsx`.

### 1. Destructive tier-toggle placebo
`ELIZA_CLOUD_TIER_MODEL.small` and `.large` both resolve to `DEFAULT_CEREBRAS_TEXT_MODEL` (`gemma-4-31b`) today, so the toggle showed a permanent "Fast" — but `CockpitTierToggle`'s only guard is `next !== value`, so tapping "Smart" still fired `onTierChange` → persisted an **identical** providerPolicy → `restartOrchestratorTask({stopActive:true})`, which **stops the task's live workers mid-turn** and respawns. A destructive restart to change nothing, no confirm.

**Fix:** render the toggle only when the tiers genuinely diverge (`.small !== .large`); `onTierChange` early-returns when the target model already equals the task's current model.

### 2. All 13 inspector mutations failed silently
`useOrchestratorData.runMutation` catches every error → sets `actionError` → never rethrows, but the pane never rendered `actionError`. So pause/resume/archive/reopen/delete/fork/restart/validate/priority/add-agent/stop-agent + the tier swap showed **nothing** on failure.

**Fix:** surface `actionError` in the existing `role="alert"` banner (`composerError ?? actionError`).

### Evidence
- Tests: replaced the test that asserted the *buggy* destructive flip with one asserting the toggle is **hidden** (no reachable restart) while tiers are indistinct; added a test that a rejected inspector mutation surfaces in the alert banner. **10/10.**
- `tsgo --noEmit` + view bundle build + biome all clean.

### N/A rows
- Screenshots: partial N/A — the fix is "a control disappears" + "an error banner appears"; both are asserted in jsdom tests. A phone-viewport capture belongs with the broader cockpit device pass.
- Live-LLM trajectory: N/A — UI/state fix, no model behavior.