### PR TITLE
fix(app): make Retry work on the post-startup backend-unavailable screen

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2293,7 +2293,17 @@ export function App() {
               detail:
                 "The auth probe could not reach /api/auth/me. If this is local development, start the local agent API with `bun run dev` or `bun run dev:desktop`, then retry.",
             }}
-            onRetry={retryStartup}
+            onRetry={() => {
+              // This screen is triggered by the AUTH probe failing
+              // (useAuthStatus publishes `server_unavailable` after its 10×1s
+              // retry budget), so `retryStartup()` alone is a no-op here —
+              // the startup coordinator is already in a ready/hydrating phase
+              // whose reducer has no RETRY arm. Re-probe auth so a transient
+              // outage (agent restart, phone network blip) actually recovers,
+              // and still kick the startup retry for the mixed case.
+              refetchAuth();
+              retryStartup();
+            }}
           />
           <BugReportModal />
         </BugReportProvider>


### PR DESCRIPTION
Fixes #11246. Found by the Fable-5 lane hunt.

**Symptom:** After startup, if the auth probe (`/api/auth/me`) can't reach the backend for >~11s (agent restart, phone network blip), the whole app is replaced by `StartupFailureView` and its **Retry button does nothing** — the user is stranded until a full reload.

**Root cause:** the branch is triggered by the **auth** probe (`useAuthStatus` → `server_unavailable`), but `onRetry` was `retryStartup` alone. `retryStartup()` dispatches `{type:"RETRY"}` to the startup coordinator, whose reducer only handles RETRY in `pairing-required`/`first-run-required`; here the coordinator is already `starting-runtime`/`hydrating`/`ready`, so RETRY hits the default and nothing re-probes auth.

**Fix (one call site):** `onRetry={() => { refetchAuth(); retryStartup(); }}`. `refetchAuth` is already in scope from `useAuthStatus` (line 1802) and re-probes with its own 10×1s budget, so a transient outage recovers; `retryStartup()` stays for the mixed case.

### Evidence
- `tsgo --noEmit` clean on `App.tsx` (the sole pre-existing repo error is an unrelated missing `iwer` XR test dep in `src/spatial/__e2e__/immersive-fixture.ts`, present on clean develop); biome clean.

### N/A rows
- Unit test: **N/A this commit** — the change is a callback-wiring fix inside a large render branch gated on a live post-startup auth-outage phase; there's no seam to exercise it in jsdom without standing up the full startup-coordinator + auth-probe machinery. The fix is a direct, reviewer-verifiable wiring of an already-in-scope `refetchAuth` (whose re-probe behavior is itself covered by `useAuthStatus` tests). Happy to add an integration test if the reviewer wants one.
- Screenshots: N/A — the visible change is "the existing Retry button now recovers instead of doing nothing."
- Live-LLM trajectory: N/A — startup/auth wiring, no model behavior.