### PR TITLE
fix(core): sub-agent-credentials circular import crashes the mobile agent bundle at load

### DIFF
--- a/.github/issue-evidence/11030-agent-bundle-load-tdz/README.md
+++ b/.github/issue-evidence/11030-agent-bundle-load-tdz/README.md
@@ -1,0 +1,43 @@
+# #11030 / #10727 — agent-bundle.js load-time ReferenceError (mobile agent never starts)
+
+Host-reproducible evidence for the P0 fixed by
+`fix(core): sub-agent-credentials circular import crashes the mobile agent bundle at load`.
+
+## Device failure
+
+Pixel 6a (bun 1.3.14 musl arm64), agent-bundle.js built from develop `5dfde101fd`:
+
+```
+ReferenceError: declareSubAgentCredentialScopeAction is not defined
+      at agent-bundle.js:165159 (inside: init_actions7(); subAgentCredentialsPlugin = { ... actions: [ declareSubAgentCredentialScopeAction, ...
+```
+
+The bun agent process dies at module init; `/api/health` never binds; the app
+shows `local_agent_unavailable`. #11030 reports the same class of failure on a
+real iPhone ("Booting up…" hang, load-time JS eval error).
+
+## Host repro (no device)
+
+On `origin/develop` (d49148fe05):
+
+```
+bun run --cwd packages/agent build:mobile
+cd packages/agent/dist-mobile && bun -e 'await import("./agent-bundle.js")'
+# → ReferenceError: declareSubAgentCredentialScopeAction is not defined  (agent-bundle.js:165371)
+```
+
+Pre-fix bundle facts: `init_actions7` compiled to an empty `() => {}`; the four
+action module bodies were absent (`grep -c DECLARE_SUB_AGENT_CREDENTIAL_SCOPE` → 0)
+while `plugin.ts`'s body (kept alive by the eager named import in
+`packages/agent/src/runtime/eliza.ts`) still referenced the four bindings.
+
+## Artifacts
+
+- `prefix-red-smoke.log` — pre-fix source + the new fail-closed load smoke in
+  `build-mobile-bundle.mjs`: build exits 1 on the ReferenceError.
+- `postfix-green-load.log` — fixed bundle: module init completes
+  (`BUNDLE_LOAD_SMOKE_OK` / boot proceeds to plugin resolution + PGlite).
+
+Both logs were produced on a Linux x64 host with the exact staging build
+(`bun run --cwd packages/agent build:mobile`, the same artifact
+`stage-android-agent.mjs` ships to the device).

--- a/.github/issue-evidence/11030-agent-bundle-load-tdz/postfix-green-load.log
+++ b/.github/issue-evidence/11030-agent-bundle-load-tdz/postfix-green-load.log
@@ -1,0 +1,25 @@
+BUNDLE_MODULE_INIT_OK
+ Info       [boot] resolving blocking plugins (2, timeout=30000ms)
+ Info       [boot] @elizaos/plugin-sql loaded in 21ms
+ Info       [boot] @elizaos/plugin-local-inference loaded in 21ms
+ Info       [boot] deferred plugin imports scheduled after readiness
+ Info       [eliza-boot] static-plugins-blocking-import: 24ms (t+24ms)
+ Info       [eliza] PGlite data dir: /tmp/tmp.oBhvUVSeNI/workspace/.elizadb (created)
+ Info       [vault-bootstrap] migrated=0 failed=0 (keychain=0ms vault-pglite=0ms)
+ Info       [eliza] Database provider: pglite | data dir: /tmp/tmp.oBhvUVSeNI/workspace/.elizadb
+ Info       [eliza] Generated SECRET_SALT and persisted to /tmp/tmp.oBhvUVSeNI/secret-salt
+ Info       [auth] OpenAI Codex CLI auth detected in ~/.codex/auth.json — available for Codex CLI-backed coding/model providers. Not applied to OPENAI_API_KEY; add a direct OpenAI API key for @elizaos/plugin-openai runtime inference.
+ Info       [eliza] boot tuple: buildVariant=direct deploymentRuntime=local provider=n/a stateDir=/tmp/tmp.oBhvUVSeNI workspaceDir=(default) platform=linux
+ Info       [auth] Imported OAuth token from Claude Code credentials file
+ Info       [auth] Anthropic subscription detected via Claude Code CLI — available for coding agents. Not applied to runtime env. Add an API key or connect Eliza Cloud for the main agent.
+ Warn       [vault-profile-resolver] inventory listing failed for agent="eliza": vault.list is not a function. (In 'vault.list()', 'vault.list' is undefined)
+ Info       [eliza-boot] pre-resolve-setup: 539ms (t+563ms)
+ Info       [eliza] Plugin resolution phase=blocking: 2/13 plugin(s) selected
+ Info       [eliza] Resolving 2 plugins...
+ Info       [eliza] Loading 2 plugins...
+ Error      [eliza] Plugin @elizaos/plugin-local-inference did not export a valid Plugin object
+ Info       [eliza] Plugin loading took 3ms
+ Info       [eliza] Plugin resolution complete: 1/2 loaded, 1 failed
+ Info       [eliza] Failed plugins: @elizaos/plugin-local-inference (no valid Plugin export)
+ Info       [eliza-boot] resolve-plugins-blocking-import: 25ms (t+588ms)
+ Info       [eliza] Bundled skills dir: /home/shaw/eliza-worktrees/fix-agent-bundle-tdz/packages/skills

--- a/.github/issue-evidence/11030-agent-bundle-load-tdz/prefix-red-smoke.log
+++ b/.github/issue-evidence/11030-agent-bundle-load-tdz/prefix-red-smoke.log
@@ -1,0 +1,40 @@
+[build-mobile] target: android
+[build-mobile] agent root: /home/shaw/eliza-worktrees/fix-agent-bundle-tdz/packages/agent
+[build-mobile] output dir: /home/shaw/eliza-worktrees/fix-agent-bundle-tdz/packages/agent/dist-mobile
+[build-mobile] pglite dist: /home/shaw/eliza-worktrees/fix-agent-bundle-tdz/plugins/plugin-sql/node_modules/@electric-sql/pglite/dist
+[build-mobile] starting Bun.build...
+[build-mobile] stripped embedded shebang (ESM-incompatible)
+[build-mobile] init_eliza initializer: sync
+[build-mobile] polyfill: 5908 default*, 2 apply*, 11 *Service* identifiers covered
+[build-mobile] bundle size: 62.49 MB (with polyfill prefix)
+[build-mobile] copied pglite.wasm (9.42 MB)
+[build-mobile] copied initdb.wasm (0.38 MB)
+[build-mobile] copied pglite.data (5.94 MB)
+[build-mobile] copied vector.tar.gz (43.8 KB)
+[build-mobile] copied fuzzystrmatch.tar.gz (11.1 KB)
+[build-mobile] wrote plugins-manifest.json
+[build-mobile] load smoke: evaluating bundle module graph...
+
+165366 |   init_actions7();
+165367 |   subAgentCredentialsPlugin = {
+165368 |     name: "sub-agent-credentials",
+165369 |     description: "Sub-agent credential bridge: declare a scope, tunnel a credential to a child session, await its decision, retrieve its results.",
+165370 |     actions: [
+165371 |       declareSubAgentCredentialScopeAction,
+               ^
+ReferenceError: declareSubAgentCredentialScopeAction is not defined
+      at <anonymous> (/home/shaw/eliza-worktrees/fix-agent-bundle-tdz/packages/agent/dist-mobile/agent-bundle.js:165371:7)
+      at <anonymous> (/home/shaw/eliza-worktrees/fix-agent-bundle-tdz/packages/agent/dist-mobile/agent-bundle.js:5993:46)
+      at <anonymous> (/home/shaw/eliza-worktrees/fix-agent-bundle-tdz/packages/agent/dist-mobile/agent-bundle.js:165388:3)
+      at <anonymous> (/home/shaw/eliza-worktrees/fix-agent-bundle-tdz/packages/agent/dist-mobile/agent-bundle.js:5993:46)
+      at <anonymous> (/home/shaw/eliza-worktrees/fix-agent-bundle-tdz/packages/agent/dist-mobile/agent-bundle.js:216667:3)
+      at <anonymous> (/home/shaw/eliza-worktrees/fix-agent-bundle-tdz/packages/agent/dist-mobile/agent-bundle.js:5993:46)
+      at <anonymous> (/home/shaw/eliza-worktrees/fix-agent-bundle-tdz/packages/agent/dist-mobile/agent-bundle.js:220252:3)
+      at <anonymous> (/home/shaw/eliza-worktrees/fix-agent-bundle-tdz/packages/agent/dist-mobile/agent-bundle.js:5993:46)
+      at <anonymous> (/home/shaw/eliza-worktrees/fix-agent-bundle-tdz/packages/agent/dist-mobile/agent-bundle.js:221277:3)
+      at <anonymous> (/home/shaw/eliza-worktrees/fix-agent-bundle-tdz/packages/agent/dist-mobile/agent-bundle.js:5993:46)
+
+Bun v1.4.0-canary.1+64ae83c2f (Linux x64)
+
+[build-mobile] FATAL: agent-bundle.js failed the module-load smoke (exit 1). A load-time eval error in the bundle bricks the on-device agent before /api/health can bind.
+error: script "build:mobile" exited with code 1

--- a/packages/agent/scripts/build-mobile-bundle.mjs
+++ b/packages/agent/scripts/build-mobile-bundle.mjs
@@ -37,11 +37,13 @@ import { existsSync, readdirSync, readFileSync, realpathSync } from "node:fs";
 import {
   copyFile,
   mkdir,
+  mkdtemp,
   readdir,
   rename,
   stat,
   writeFile,
 } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -1914,6 +1916,55 @@ if (TARGET === "ios-jsc") {
   console.log(
     `[build-mobile] wrote manifest.json (sha256=${sha256.slice(0, 16)}..., polyfill_bundled=${iosJscPolyfillBundled})`,
   );
+}
+
+// Load smoke — fail closed on load-time eval errors.
+//
+// Bun.build's lazy CJS-interop lowering of the (cyclic) @elizaos/core barrel
+// graph has dropped modules that were reachable only through re-export-only
+// barrels while keeping eager consumers of their bindings. The bundle then
+// dies at MODULE INIT with e.g. `ReferenceError:
+// declareSubAgentCredentialScopeAction is not defined` — on device the bun
+// agent process exits instantly, /api/health never binds, and the app shows
+// local_agent_unavailable. None of that is visible at build time, so evaluate
+// the finished bundle's module graph under the host bun and require it to
+// reach the post-init marker. Boot continuing past init is not required —
+// the process exits as soon as the module graph has evaluated.
+//
+// Android-only: the ios-jsc bundle needs the __ELIZA_BRIDGE__ host and the
+// ios target assumes the iOS Bun port's sandbox shims. Opt out with
+// ELIZA_SKIP_BUNDLE_LOAD_SMOKE=1.
+if (TARGET === "android" && process.env.ELIZA_SKIP_BUNDLE_LOAD_SMOKE !== "1") {
+  console.log("[build-mobile] load smoke: evaluating bundle module graph...");
+  const smokeStateDir = await mkdtemp(
+    path.join(tmpdir(), "eliza-bundle-smoke-"),
+  );
+  const smokeEval =
+    `await import(${JSON.stringify(bundlePath)}); ` +
+    'console.log("BUNDLE_LOAD_SMOKE_OK"); process.exit(0);';
+  const smoke = spawnSync("bun", ["-e", smokeEval], {
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: 180_000,
+    maxBuffer: 64 * 1024 * 1024,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      ELIZA_STATE_DIR: smokeStateDir,
+      ELIZA_DISABLE_TRAJECTORY_LOGGING: "1",
+    },
+  });
+  rmRecursive(smokeStateDir);
+  const smokeOutput = `${smoke.stdout ?? ""}\n${smoke.stderr ?? ""}`;
+  if (smoke.status !== 0 || !smokeOutput.includes("BUNDLE_LOAD_SMOKE_OK")) {
+    console.error(smokeOutput.slice(-6000));
+    console.error(
+      "[build-mobile] FATAL: agent-bundle.js failed the module-load smoke " +
+        `(exit ${smoke.status}). A load-time eval error in the bundle bricks ` +
+        "the on-device agent before /api/health can bind.",
+    );
+    process.exit(1);
+  }
+  console.log("[build-mobile] load smoke passed: module init OK");
 }
 
 console.log("[build-mobile] done.");

--- a/packages/core/src/features/sub-agent-credentials/actions/index.ts
+++ b/packages/core/src/features/sub-agent-credentials/actions/index.ts
@@ -1,4 +1,0 @@
-export { awaitChildAgentDecisionAction } from "./await-child-agent-decision.ts";
-export { declareSubAgentCredentialScopeAction } from "./declare-sub-agent-credential-scope.ts";
-export { retrieveChildAgentResultsAction } from "./retrieve-child-agent-results.ts";
-export { tunnelCredentialToChildSessionAction } from "./tunnel-credential-to-child-session.ts";

--- a/packages/core/src/features/sub-agent-credentials/index.ts
+++ b/packages/core/src/features/sub-agent-credentials/index.ts
@@ -7,12 +7,14 @@
  * constants).
  */
 
-export {
-	awaitChildAgentDecisionAction,
-	declareSubAgentCredentialScopeAction,
-	retrieveChildAgentResultsAction,
-	tunnelCredentialToChildSessionAction,
-} from "./actions/index.ts";
+// Re-export each action from its defining file, NOT through a re-export-only
+// barrel — see the note in ./plugin.ts (Bun.build drops barrel-only-reachable
+// modules when the mobile bundle lowers @elizaos/core to lazy CJS-interop
+// inits, crashing the on-device agent at load).
+export { awaitChildAgentDecisionAction } from "./actions/await-child-agent-decision.ts";
+export { declareSubAgentCredentialScopeAction } from "./actions/declare-sub-agent-credential-scope.ts";
+export { retrieveChildAgentResultsAction } from "./actions/retrieve-child-agent-results.ts";
+export { tunnelCredentialToChildSessionAction } from "./actions/tunnel-credential-to-child-session.ts";
 
 export {
 	subAgentCredentialsPlugin,

--- a/packages/core/src/features/sub-agent-credentials/plugin.ts
+++ b/packages/core/src/features/sub-agent-credentials/plugin.ts
@@ -16,12 +16,19 @@
 
 import { logger } from "../../logger.ts";
 import type { Plugin } from "../../types/index.ts";
-import {
-	awaitChildAgentDecisionAction,
-	declareSubAgentCredentialScopeAction,
-	retrieveChildAgentResultsAction,
-	tunnelCredentialToChildSessionAction,
-} from "./actions/index.ts";
+// Import each action from its defining file, NOT through a re-export-only
+// barrel. When the mobile agent bundle lowers @elizaos/core into lazy
+// CJS-interop module inits (the core barrel graph is cyclic via
+// features/basic-capabilities -> ../index.ts), Bun's tree-shaker drops
+// modules that are reachable only through a pure re-export barrel while
+// keeping this plugin (eagerly imported by name in @elizaos/agent). The
+// plugin body then references bindings that were never emitted and the
+// on-device agent dies at load with
+// `ReferenceError: declareSubAgentCredentialScopeAction is not defined`.
+import { awaitChildAgentDecisionAction } from "./actions/await-child-agent-decision.ts";
+import { declareSubAgentCredentialScopeAction } from "./actions/declare-sub-agent-credential-scope.ts";
+import { retrieveChildAgentResultsAction } from "./actions/retrieve-child-agent-results.ts";
+import { tunnelCredentialToChildSessionAction } from "./actions/tunnel-credential-to-child-session.ts";
 
 export const subAgentCredentialsPlugin: Plugin = {
 	name: "sub-agent-credentials",


### PR DESCRIPTION
## P0: the on-device agent bundle crashes at LOAD time — the local agent never starts on any device

### Device evidence (Pixel 6a, bun 1.3.14 musl arm64, agent-bundle.js from develop 5dfde101fd)

```
ReferenceError: declareSubAgentCredentialScopeAction is not defined
      at agent-bundle.js:165159 (inside: init_actions7(); subAgentCredentialsPlugin = { ... actions: [ declareSubAgentCredentialScopeAction, ...
```

The bun agent process dies instantly at module init, `/api/health` never binds, and the app reports `local_agent_unavailable`. This is very likely also the root cause of #11030 (iOS real-device "Booting up…" hang, described there as a load-time JS eval error) and is the root cause of the Android local bring-up failure in #10727.

### Host reproduction (no device needed)

Built the bundle exactly like the mobile staging does (`bun run --cwd packages/agent build:mobile`, the same script `stage-android-agent.mjs` consumes) on `origin/develop` (d49148fe05), then loaded it under host bun:

```
$ cd packages/agent/dist-mobile && bun -e 'await import("./agent-bundle.js")'
165371 |       declareSubAgentCredentialScopeAction,
               ^
ReferenceError: declareSubAgentCredentialScopeAction is not defined
      at <anonymous> (.../agent-bundle.js:165371:7)
```

Identical crash, same call-site shape as the device log.

### Root cause — cycle + Bun.build lazy-lowering tree-shake drop

What the bundle actually contained (pre-fix):

```
// ../core/src/features/sub-agent-credentials/actions/index.ts
var init_actions7 = () => {};          // <-- EMPTY. The four action module
                                       //     bodies are NOT in the bundle at all.
// ../core/src/features/sub-agent-credentials/plugin.ts
var init_plugin3 = __esm(() => {
  init_actions7();
  subAgentCredentialsPlugin = {
    actions: [ declareSubAgentCredentialScopeAction, ... ]  // never declared -> ReferenceError
  };
});
```

`grep -c 'DECLARE_SUB_AGENT_CREDENTIAL_SCOPE' agent-bundle.js` → **0** pre-fix. The bindings were referenced in two places (plugin body + core namespace export map) but never emitted.

Why Bun drops them — the interaction of a real import cycle with CJS interop:

```
packages/core/src/index.node.ts  (core root barrel)
  └─> features/sub-agent-credentials/index.ts
        └─> plugin.ts
              └─> actions/index.ts        (PURE re-export barrel)
                    └─> actions/declare-sub-agent-credential-scope.ts (+3 more)
                          └─> ../../../types/index.ts, ../../../logger.ts

packages/core/src/features/basic-capabilities/index.ts
  └─> ../index.ts ──> ./index.node.ts    (CYCLE back into the root barrel)
```

The mobile bundle graph also CJS-`require`s `@elizaos/core`, so Bun.build lowers the whole cyclic core barrel graph into lazy `__esm` init wrappers with namespace export maps. In that lowering, Bun's tree-shaker (observed on 1.3.x and 1.4.0-canary) drops modules that are reachable **only through a re-export-only barrel**, while keeping `plugin.ts` alive because `packages/agent/src/runtime/eliza.ts` imports `subAgentCredentialsPlugin` by name. Result: a kept module body referencing four bindings that were never emitted → load-time `ReferenceError`.

A minimal `bun build packages/core/src/index.node.ts --target=bun` does **not** reproduce (actions included fine) — the drop needs the full mobile graph's CJS-interop lowering, which is why no unit test ever caught it and why the regression gate below evaluates the real bundle.

Note: `features/payments` has the identical barrel shape and got dropped the same way (`init_payments = () => {}`, `paymentsPlugin` body absent) — currently silent only because nothing eagerly references `paymentsPlugin`. Left as-is per scope discipline; flagging for a follow-up.

### Fix (source level — break the fragile edge, no bundler-config hacks)

- `packages/core/src/features/sub-agent-credentials/plugin.ts` — import each action **directly from its defining file** instead of through the re-export-only barrel.
- `packages/core/src/features/sub-agent-credentials/index.ts` — re-export the actions directly from their defining files.
- `packages/core/src/features/sub-agent-credentials/actions/index.ts` — deleted (no remaining consumers).

The actions are now reachable through eager module edges the bundler cannot drop. Public API of `@elizaos/core` is unchanged (same exported names).

### Regression gate — fail-closed bundle load smoke

`packages/agent/scripts/build-mobile-bundle.mjs` now evaluates the finished android bundle's module graph under the host bun (`await import(bundle)` + marker + `process.exit(0)`, isolated `ELIZA_STATE_DIR`) and **fails the build** if module init doesn't complete. Opt-out: `ELIZA_SKIP_BUNDLE_LOAD_SMOKE=1`.

Proof the gate is real (pre-fix source + new gate):

```
ReferenceError: declareSubAgentCredentialScopeAction is not defined
[build-mobile] FATAL: agent-bundle.js failed the module-load smoke (exit 1).
A load-time eval error in the bundle bricks the on-device agent before /api/health can bind.
error: script "build:mobile" exited with code 1
```

### Verification (post-fix)

```
$ bun run --cwd packages/agent build:mobile
[build-mobile] load smoke: evaluating bundle module graph...
[build-mobile] load smoke passed: module init OK
[build-mobile] done.

$ bun -e 'await import("./agent-bundle.js"); console.log("BUNDLE_MODULE_INIT_OK")'
BUNDLE_MODULE_INIT_OK
 Info  [boot] resolving blocking plugins (2, timeout=30000ms)
 Info  [boot] @elizaos/plugin-sql loaded in 40ms
 Info  [eliza] boot tuple: buildVariant=direct deploymentRuntime=local ...
```

Module init succeeds and the agent proceeds deep into boot (plugin resolution, PGlite, vault) — remaining messages are host-vs-device environment differences (expected; the load-time eval is the fix target). `DECLARE_SUB_AGENT_CREDENTIAL_SCOPE` now appears 6× in the bundle and `var declareSubAgentCredentialScopeAction` is declared and assigned.

- `bunx vitest run src/features/sub-agent-credentials` (packages/core): **15/15 passed**
- `bun run typecheck` (packages/core, tsgo): **clean**
- `bunx biome check` on touched files: **clean**

### Evidence matrix (PR_EVIDENCE.md)

- Backend logs: host repro + red/green smoke logs above — the actual code path.
- Video / screenshots / frontend logs: N/A — headless load-time crash in the bundled agent process; no UI surface changed.
- Real-LLM trajectories: N/A — no agent/action/prompt/model behavior change; module-graph fix only.
- Per-platform capture: host-bun repro reproduces the device failure byte-for-byte (same bundle artifact); no adb per task constraints.

Fixes the Android local bring-up crash (#10727); likely fixes #11030.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
