### PR TITLE
fix(orchestrator): corrupt task-state file no longer bricks every subsequent write (post-#11197/#11205 audit)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-store.test.ts
@@ -767,6 +767,35 @@ describe("orchestrator-task-store audit follow-ups (#11028)", () => {
     expect(ids).toContain(x.task.id);
   });
 
+  it("FileTaskStore keeps mutating after the state file is corrupted externally", async () => {
+    const path = await tempFile();
+    const warnings: string[] = [];
+    const store = new FileTaskStore(path, {
+      warn: (message) => warnings.push(message),
+    });
+    const a = await store.createTask(createInput({ title: "A" }));
+    const b = await store.createTask(createInput({ title: "B" }));
+    // Corrupt the file behind the store's back. JSON.parse throws a
+    // SyntaxError with no .code, which the persist path used to rethrow —
+    // bricking EVERY subsequent mutation while ensureLoaded warned-and-continued
+    // for the same condition.
+    await writeFile(path, "{not json[[", "utf8");
+
+    const updated = await store.updateTask(a.task.id, { status: "done" });
+    expect(updated?.status).toBe("done");
+    expect(warnings.some((m) => m.includes("task file unreadable"))).toBe(true);
+    // The recovery must not drop non-dirty in-memory tasks: B was untouched by
+    // the update, and both memory and the rewritten file must still carry it.
+    expect((await store.getTask(b.task.id))?.task.title).toBe("B");
+    const c = await store.createTask(createInput({ title: "C" }));
+
+    const reader = new FileTaskStore(path);
+    const titles = (await reader.listTasks()).map((t) => t.title).sort();
+    expect(titles).toEqual(["A", "B", "C"]);
+    expect((await reader.getTask(a.task.id))?.task.status).toBe("done");
+    expect((await reader.getTask(c.task.id))?.task.title).toBe("C");
+  });
+
   it("FileTaskStore write does not revert another process's update to a task it did not touch", async () => {
     const path = await tempFile();
     const a = new FileTaskStore(path);

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
@@ -703,7 +703,20 @@ export class FileTaskStore extends InMemoryTaskStore {
       } catch (error) {
         const code =
           isRecord(error) && typeof error.code === "string" ? error.code : "";
-        if (code !== "ENOENT") throw error;
+        if (code !== "ENOENT") {
+          // A corrupt state file (e.g. a JSON.parse SyntaxError, which carries
+          // no .code) must not brick every subsequent mutation — ensureLoaded
+          // warns and continues for the same condition. The file is unreadable,
+          // so the only surviving state is this process's in-memory doc set:
+          // seed the merge from it (an empty seed would drop every non-dirty
+          // task from memory AND the rewrite below). The atomic write then
+          // replaces the corrupt file with a readable one.
+          this.logger?.warn?.(
+            "[OrchestratorTaskStore] task file unreadable during persist; rewriting from in-memory state",
+            error,
+          );
+          for (const doc of this.docs.values()) merged.set(doc.task.id, doc);
+        }
       }
       for (const id of this.tombstones) merged.delete(id);
       for (const id of this.dirty) {


### PR DESCRIPTION
Last residual from the adversarial audit of #11197 (findings 1/2/3/5 — the tombstone-consumption delete race, lingering-tombstone destruction, whole-doc overlay clobber, and the vacuous concurrent-insert test — were already fixed on develop by #11205, whose tests map 1:1 to the audit's executable repros; independently verified green).

**Finding 4:** `FileTaskStore.afterWrite`'s re-read rethrew any non-ENOENT error — a corrupt state file (a `JSON.parse` SyntaxError carries no `.code`) made **every subsequent mutation reject forever**, while `ensureLoaded` deliberately warns-and-continues for the same condition — contradictory read/write postures and a persistence brick requiring manual file deletion.

**Fix:** warn (matching `ensureLoaded`) and continue — with one deliberate deviation from the audit's 'empty merged seed' suggestion: the merge is seeded from the **in-memory doc set**, because under #11205's dirty-only overlay an empty seed would silently drop every non-dirty task from memory AND the rewritten file (corrupt file + one small write = mass data destruction). The atomic rename then replaces the corrupt file with a readable one.

**Evidence (fail-without-fix, independently re-verified):** new test `FileTaskStore keeps mutating after the state file is corrupted externally` — corrupts the file behind a live store, asserts the next update succeeds + warns, untouched tasks survive in memory and on disk, and a fresh reader sees the repaired file. Revert the production hunk → exactly that test red (1/36); restored → **36/36**. Full plugin unit lane: 105 files / 1128 tests green. `tsgo --noEmit`: 0 errors. Biome clean.

Refs #11197 #11205 #11028

🤖 Generated with [Claude Code](https://claude.com/claude-code)