### PR TITLE
fix(core): count canonical MESSAGE memories so session summarization fires

### DIFF
--- a/packages/core/src/features/advanced-memory/evaluators/memory-items.test.ts
+++ b/packages/core/src/features/advanced-memory/evaluators/memory-items.test.ts
@@ -119,3 +119,77 @@ describe("summaryEvaluator storeSummary processor — first-store offset (regres
 		expect(stored[0].messageCount).toBe(2);
 	});
 });
+
+describe("summaryEvaluator.shouldRun — dialogue count matches canonical MESSAGE memories (#11250)", () => {
+	function messageMemory(id: string, metadataType: string): Memory {
+		return {
+			id,
+			entityId: "user-1",
+			roomId: "room-1",
+			content: { text: `line ${id}`, type: "text" },
+			metadata: { type: metadataType },
+			createdAt: 1,
+		} as unknown as Memory;
+	}
+
+	function runtimeWithMessages(metadataType: string, count: number) {
+		const memories = Array.from({ length: count }, (_v, i) =>
+			messageMemory(`m-${i}`, metadataType),
+		);
+		const memoryService = {
+			getConfig: () => ({
+				shortTermSummarizationThreshold: 16,
+				shortTermSummarizationInterval: 8,
+			}),
+			getCurrentSessionSummary: async () => null,
+		};
+		return createMockRuntime({
+			agentId: "agent-1",
+			character: { name: "Agent" },
+			getService: (name: string) =>
+				name === "memory" ? (memoryService as never) : null,
+			getMemories: async () => memories,
+		} as never);
+	}
+
+	const trigger = {
+		id: "trigger",
+		roomId: "room-1",
+		content: { text: "hello", type: "text" },
+		metadata: { type: "message" },
+		createdAt: 2,
+	} as unknown as Memory;
+
+	it("fires at threshold for canonical MemoryType.MESSAGE ('message') memories", async () => {
+		const rt = runtimeWithMessages("message", 16);
+		const run = await summaryEvaluator.shouldRun?.({
+			runtime: rt,
+			message: trigger,
+			state: {} as State,
+			options: {} as EvaluatorRunOptions,
+		});
+		expect(run).toBe(true);
+	});
+
+	it("still counts the legacy metadata types (back-compat)", async () => {
+		const rt = runtimeWithMessages("user_message", 16);
+		const run = await summaryEvaluator.shouldRun?.({
+			runtime: rt,
+			message: trigger,
+			state: {} as State,
+			options: {} as EvaluatorRunOptions,
+		});
+		expect(run).toBe(true);
+	});
+
+	it("does not fire below threshold", async () => {
+		const rt = runtimeWithMessages("message", 4);
+		const run = await summaryEvaluator.shouldRun?.({
+			runtime: rt,
+			message: trigger,
+			state: {} as State,
+			options: {} as EvaluatorRunOptions,
+		});
+		expect(run).toBe(false);
+	});
+});

--- a/packages/core/src/features/advanced-memory/evaluators/memory-items.ts
+++ b/packages/core/src/features/advanced-memory/evaluators/memory-items.ts
@@ -8,6 +8,7 @@ import type {
 	RegisteredEvaluator,
 	UUID,
 } from "../../../types/index.ts";
+import { MemoryType } from "../../../types/memory.ts";
 import { isSyntheticConversationArtifactMemory } from "../../../utils/synthetic-conversation-artifact.ts";
 import { isObjectRecord as isRecord } from "../../../utils/type-guards.ts";
 import type { MemoryService } from "../services/memory-service.ts";
@@ -86,14 +87,20 @@ function toStringArray(value: unknown): string[] {
 }
 
 function isDialogueMessage(msg: Memory): boolean {
+	const metadataType = msg.metadata?.type as string | undefined;
 	return (
 		!isSyntheticConversationArtifactMemory(msg) &&
 		!(
-			msg.content.type === "action_result" &&
-			(msg.metadata?.type as string) === "action_result"
+			msg.content.type === "action_result" && metadataType === "action_result"
 		) &&
-		((msg.metadata?.type as string) === "agent_response_message" ||
-			(msg.metadata?.type as string) === "user_message")
+		// The canonical current format: createMessageMemory stamps
+		// MemoryType.MESSAGE ("message") — matching this is what actually makes
+		// summarization fire. The two legacy strings are kept for back-compat but
+		// nothing in the repo writes them anymore, so without MESSAGE the dialogue
+		// count was permanently 0 and short-term summarization never ran (silently).
+		(metadataType === MemoryType.MESSAGE ||
+			metadataType === "agent_response_message" ||
+			metadataType === "user_message")
 	);
 }
 


### PR DESCRIPTION
Fixes #11253. Found by the Fable-5 lane hunt.

**Symptom:** Advanced-memory short-term session summarization (the `SUMMARIZED_CONTEXT` provider) **never runs** — the summary context is always empty, silently. On by default (`advancedMemory` defaults true).

**Root cause:** `isDialogueMessage` (`memory-items.ts:88`) only accepted `metadata.type === "agent_response_message" | "user_message"` — legacy strings **nothing in the repo writes**. `createMessageMemory` stamps `MemoryType.MESSAGE` (`"message"`); `services/message.ts` stamps `type:"message"`. So `getDialogueMessageCount` was permanently 0 → `shouldSummarize` never crossed threshold (16) → `summaryEvaluator.shouldRun` always false → `getCurrentSessionSummary` null → provider renders empty.

**Fix:** accept `MemoryType.MESSAGE` alongside the two legacy strings, keeping the synthetic-artifact and `action_result` exclusions.

### Evidence
- **`shouldRun` regression test** (public evaluator seam): 16 `MessageType.MESSAGE`-typed memories → `shouldRun` true; below threshold → false; legacy `user_message` still counted (back-compat). **Mutation-checked** — dropping the `MESSAGE` match reds the canonical test.
- `tsgo --noEmit` clean; multi-target core build (node+browser+edge) clean; biome clean.

### N/A rows
- Live-LLM trajectory: N/A — the fix is the gating predicate that decides whether the summary model call happens; the test drives the gate deterministically. The downstream summary generation itself is unchanged.
- Screenshots: N/A — backend memory subsystem.